### PR TITLE
fix: support Windows launcher import paths

### DIFF
--- a/bin/import-specifier.mjs
+++ b/bin/import-specifier.mjs
@@ -1,0 +1,7 @@
+import { join } from 'path'
+import { pathToFileURL } from 'url'
+
+export function getDistImportSpecifier(baseDir) {
+  const distPath = join(baseDir, '..', 'dist', 'cli.mjs')
+  return pathToFileURL(distPath).href
+}

--- a/bin/import-specifier.test.mjs
+++ b/bin/import-specifier.test.mjs
@@ -1,0 +1,13 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { getDistImportSpecifier } from './import-specifier.mjs'
+
+test('builds a file URL import specifier for dist/cli.mjs', () => {
+  const specifier = getDistImportSpecifier('C:\\repo\\bin')
+
+  assert.equal(
+    specifier,
+    'file:///C:/repo/dist/cli.mjs',
+  )
+})

--- a/bin/openclaude
+++ b/bin/openclaude
@@ -10,12 +10,13 @@
 import { existsSync } from 'fs'
 import { join, dirname } from 'path'
 import { fileURLToPath } from 'url'
+import { getDistImportSpecifier } from './import-specifier.mjs'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 const distPath = join(__dirname, '..', 'dist', 'cli.mjs')
 
 if (existsSync(distPath)) {
-  await import(distPath)
+  await import(getDistImportSpecifier(__dirname))
 } else {
   console.error(`
   openclaude: dist/cli.mjs not found.


### PR DESCRIPTION
## What changed
- fix the Windows launcher to import dist/cli.mjs via a valid ile:// URL
- add a focused regression test for the generated import specifier

## Root cause
in/openclaude used wait import(distPath) with a raw Windows absolute path like C:\...\dist\cli.mjs.
Node's ESM loader on Windows requires a ile:// URL for absolute path imports, which caused:
ERR_UNSUPPORTED_ESM_URL_SCHEME

## Validation
- 
ode --test bin/import-specifier.test.mjs

## Issue
- fixes #8