### PR TITLE
security: remove runtime require of unverified modifiers-napi package

### DIFF
--- a/src/utils/modifiers.ts
+++ b/src/utils/modifiers.ts
@@ -1,36 +1,22 @@
 export type ModifierKey = 'shift' | 'command' | 'control' | 'option'
 
-let prewarmed = false
-
 /**
  * Pre-warm the native module by loading it in advance.
- * Call this early to avoid delay on first use.
+ *
+ * NOTE: The `modifiers-napi` package is an Anthropic-internal native addon
+ * that is not shipped with the open-source build. All calls are no-ops here
+ * to avoid supply-chain risk from unverified npm packages with the same name.
  */
 export function prewarmModifiers(): void {
-  if (prewarmed || process.platform !== 'darwin') {
-    return
-  }
-  prewarmed = true
-  // Load module in background
-  try {
-    // eslint-disable-next-line @typescript-eslint/no-require-imports
-    const { prewarm } = require('modifiers-napi') as { prewarm: () => void }
-    prewarm()
-  } catch {
-    // Ignore errors during prewarm
-  }
+  // No-op in open-source build — native modifier detection is not available.
 }
 
 /**
  * Check if a specific modifier key is currently pressed (synchronous).
+ *
+ * Always returns false in the open-source build since the native addon
+ * is not available.
  */
-export function isModifierPressed(modifier: ModifierKey): boolean {
-  if (process.platform !== 'darwin') {
-    return false
-  }
-  // Dynamic import to avoid loading native module at top level
-  const { isModifierPressed: nativeIsModifierPressed } =
-    // eslint-disable-next-line @typescript-eslint/no-require-imports
-    require('modifiers-napi') as { isModifierPressed: (m: string) => boolean }
-  return nativeIsModifierPressed(modifier)
+export function isModifierPressed(_modifier: ModifierKey): boolean {
+  return false
 }


### PR DESCRIPTION
## Fixes #7

### Problem
`src/utils/modifiers.ts` has live `require('modifiers-napi')` calls that execute at runtime. The `modifiers-napi` package is an Anthropic-internal native addon, but a package with the same name exists on npm — this is a supply chain attack vector.

While the build script (`scripts/build.ts`) stubs these native modules during bundling, the source code still has direct `require()` calls that would execute when running without the bundler (e.g. `bun run dev`, `ts-node`, or any unbundled execution path).

I verified all 5 native addon package names exist on npm:
- `modifiers-napi` ✅ exists
- `audio-capture-napi` ✅ exists
- `image-processor-napi` ✅ exists
- `url-handler-napi` ✅ exists
- `color-diff-napi` ✅ exists

### Fix
Replaced both functions in `modifiers.ts` (`prewarmModifiers` and `isModifierPressed`) with safe no-ops. Modifier key detection is macOS-only and not needed in the open-source build.

The other native addon imports (`image-processor-napi`, `audio-capture-napi`, `url-handler-napi`) use dynamic `await import()` behind feature flags that are all disabled, so they are lower risk but could be addressed similarly in a follow-up.

### Verification
Build passes: `bun run build` produces `dist/cli.mjs` successfully.