### PR TITLE
Fix Windows ESM import by using file URL

### DIFF
--- a/bin/openclaude
+++ b/bin/openclaude
@@ -9,14 +9,13 @@
 
 import { existsSync } from 'fs'
 import { join, dirname } from 'path'
-import { fileURLToPath } from 'url'
-import { getDistImportSpecifier } from './import-specifier.mjs'
+import { fileURLToPath, pathToFileURL } from 'url'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 const distPath = join(__dirname, '..', 'dist', 'cli.mjs')
 
 if (existsSync(distPath)) {
-  await import(getDistImportSpecifier(__dirname))
+  await import(pathToFileURL(distPath).href)
 } else {
   console.error(`
   openclaude: dist/cli.mjs not found.


### PR DESCRIPTION
On Windows, Node’s default ESM loader can’t import() a raw absolute path like C:\... because it gets interpreted as a URL scheme (c:), triggering ERR_UNSUPPORTED_ESM_URL_SCHEME. This change converts the built CLI path to a proper file:// URL via pathToFileURL() before importing, so openclaude runs correctly on Windows.