### PR TITLE
fix: correct double-slash in import path (structuredIO.ts)

### DIFF
--- a/src/cli/structuredIO.ts
+++ b/src/cli/structuredIO.ts
@@ -4,7 +4,7 @@ import type {
   JSONRPCMessage,
 } from '@modelcontextprotocol/sdk/types.js'
 import { randomUUID } from 'crypto'
-import type { AssistantMessage } from 'src//types/message.js'
+import type { AssistantMessage } from 'src/types/message.js'
 import type {
   HookInput,
   HookJSONOutput,


### PR DESCRIPTION
## Summary

- Fixes double-slash in import path `src//types/message.js` → `src/types/message.js` in `src/cli/structuredIO.ts`
- The double slash may cause unpredictable module resolution depending on OS and bundler behavior

## Changes

One character removed. Zero risk.

## Relates to

#29