### PR TITLE
fix: map tool_choice 'none' in OpenAI shim

### DIFF
--- a/src/services/api/openaiShim.ts
+++ b/src/services/api/openaiShim.ts
@@ -630,6 +630,8 @@ class OpenAIShimMessages {
             }
           } else if (tc.type === 'any') {
             body.tool_choice = 'required'
+          } else if (tc.type === 'none') {
+            body.tool_choice = 'none'
           }
         }
       }


### PR DESCRIPTION
## Summary

- Adds missing `tool_choice: 'none'` mapping in the Anthropic → OpenAI translation
- Previously, `{ type: 'none' }` was silently ignored, causing the request to default to `auto` — the exact opposite of disabling tool use

## Changes

2 lines added in `src/services/api/openaiShim.ts`.

## Relates to

#30