### PR TITLE
fix: restrict .openclaude-profile.json to owner-only permissions (0600)

### DIFF
--- a/scripts/provider-bootstrap.ts
+++ b/scripts/provider-bootstrap.ts
@@ -123,7 +123,7 @@ async function main(): Promise<void> {
   }
 
   const outputPath = resolve(process.cwd(), '.openclaude-profile.json')
-  writeFileSync(outputPath, JSON.stringify(profile, null, 2), 'utf8')
+  writeFileSync(outputPath, JSON.stringify(profile, null, 2), { encoding: 'utf8', mode: 0o600 })
 
   console.log(`Saved profile: ${selected}`)
   console.log(`Path: ${outputPath}`)


### PR DESCRIPTION
## Summary

- Sets file permissions to `0600` (owner read/write only) when writing `.openclaude-profile.json`
- The profile file may contain API keys in plain text. Without explicit permissions, `writeFileSync` defaults to the process umask — on systems with permissive umask (`0022`), the file is world-readable (`644`), exposing credentials to other local users

## Changes

1 line changed in `scripts/provider-bootstrap.ts`.

## Relates to

#24