### PR TITLE
fix: define MACRO.PACKAGE_URL in build script to fix auto-update

### DIFF
--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -60,6 +60,8 @@ const result = await Bun.build({
     'MACRO.BUILD_TIME': JSON.stringify(new Date().toISOString()),
     'MACRO.ISSUES_EXPLAINER':
       JSON.stringify('report the issue at https://github.com/anthropics/claude-code/issues'),
+    'MACRO.PACKAGE_URL': JSON.stringify('@gitlawb/openclaude'),
+    'MACRO.NATIVE_PACKAGE_URL': 'undefined',
   },
   plugins: [
     {


### PR DESCRIPTION
## Summary

- Adds missing `MACRO.PACKAGE_URL` and `MACRO.NATIVE_PACKAGE_URL` to the build `define` block
- Without these, the macros resolve to `undefined` at runtime, causing `npm install undefined` and `npm view undefined` in the auto-update and installer flows (~10 files affected)

## Changes

2 lines added in `scripts/build.ts`:
- `MACRO.PACKAGE_URL` → `'@gitlawb/openclaude'` (the published npm package name)
- `MACRO.NATIVE_PACKAGE_URL` → `undefined` (no native binary distribution for OpenClaude)

## Relates to

#29