### PR TITLE
fix: release SSE stream reader on exception to prevent memory leak

### DIFF
--- a/src/services/api/codexShim.ts
+++ b/src/services/api/codexShim.ts
@@ -566,6 +566,7 @@ async function* readSseEvents(response: Response): AsyncGenerator<CodexSseEvent>
   const decoder = new TextDecoder()
   let buffer = ''
 
+  try {
   while (true) {
     const { done, value } = await reader.read()
     if (done) break
@@ -600,6 +601,9 @@ async function* readSseEvents(response: Response): AsyncGenerator<CodexSseEvent>
 
       yield { event, data }
     }
+  }
+  } finally {
+    reader.releaseLock()
   }
 }
 

--- a/src/services/api/openaiShim.ts
+++ b/src/services/api/openaiShim.ts
@@ -374,6 +374,7 @@ async function* openaiStreamToAnthropic(
   const decoder = new TextDecoder()
   let buffer = ''
 
+  try {
   while (true) {
     const { done, value } = await reader.read()
     if (done) break
@@ -528,6 +529,9 @@ async function* openaiStreamToAnthropic(
         hasEmittedFinalUsage = true
       }
     }
+  }
+  } finally {
+    reader.releaseLock()
   }
 
   yield { type: 'message_stop' }


### PR DESCRIPTION
## Summary

- Wraps SSE stream reading loops in `try/finally` with `reader.releaseLock()` in both `openaiShim.ts` and `codexShim.ts`
- Without this, if the caller throws (AbortError, parse failure, user cancellation), the `ReadableStreamDefaultReader` stays locked and the response body is never garbage collected

## Changes

- `src/services/api/openaiShim.ts` — wrap `openaiStreamToAnthropic` reader loop in try/finally
- `src/services/api/codexShim.ts` — wrap `readSseEvents` reader loop in try/finally

Behavioral change: none on happy path. On exception, the reader is now properly released.

## Relates to

#25