### PR TITLE
test: cover DeepSeek max token limits

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "test:provider-recommendation": "node --test --experimental-strip-types src/utils/providerRecommendation.test.ts src/utils/providerProfile.test.ts",
     "typecheck": "tsc --noEmit",
     "smoke": "bun run build && node dist/cli.mjs --version",
-    "test:provider": "bun test src/services/api/*.test.ts",
+    "test:provider": "bun test src/services/api/*.test.ts src/utils/context.test.ts",
     "doctor:runtime": "bun run scripts/system-check.ts",
     "doctor:runtime:json": "bun run scripts/system-check.ts --json",
     "doctor:report": "bun run scripts/system-check.ts --out reports/doctor-runtime.json",

--- a/src/utils/context.test.ts
+++ b/src/utils/context.test.ts
@@ -1,0 +1,37 @@
+import { afterEach, expect, test } from 'bun:test'
+
+import { getMaxOutputTokensForModel } from '../services/api/claude.ts'
+import {
+  getContextWindowForModel,
+  getModelMaxOutputTokens,
+} from './context.ts'
+
+const originalEnv = {
+  CLAUDE_CODE_USE_OPENAI: process.env.CLAUDE_CODE_USE_OPENAI,
+  CLAUDE_CODE_MAX_OUTPUT_TOKENS: process.env.CLAUDE_CODE_MAX_OUTPUT_TOKENS,
+}
+
+afterEach(() => {
+  process.env.CLAUDE_CODE_USE_OPENAI = originalEnv.CLAUDE_CODE_USE_OPENAI
+  process.env.CLAUDE_CODE_MAX_OUTPUT_TOKENS =
+    originalEnv.CLAUDE_CODE_MAX_OUTPUT_TOKENS
+})
+
+test('deepseek-chat uses provider-specific context and output caps', () => {
+  process.env.CLAUDE_CODE_USE_OPENAI = '1'
+  delete process.env.CLAUDE_CODE_MAX_OUTPUT_TOKENS
+
+  expect(getContextWindowForModel('deepseek-chat')).toBe(64_000)
+  expect(getModelMaxOutputTokens('deepseek-chat')).toEqual({
+    default: 8_192,
+    upperLimit: 8_192,
+  })
+  expect(getMaxOutputTokensForModel('deepseek-chat')).toBe(8_192)
+})
+
+test('deepseek-chat clamps oversized max output overrides to the provider limit', () => {
+  process.env.CLAUDE_CODE_USE_OPENAI = '1'
+  process.env.CLAUDE_CODE_MAX_OUTPUT_TOKENS = '32000'
+
+  expect(getMaxOutputTokensForModel('deepseek-chat')).toBe(8_192)
+})


### PR DESCRIPTION
﻿## What changed
- add regression coverage for OpenAI-compatible provider token caps
- specifically cover `deepseek-chat` context window and max output token limits
- verify oversized `CLAUDE_CODE_MAX_OUTPUT_TOKENS` values still clamp to DeepSeek's native `8192` limit

## Why
Issue #35 reported `deepseek-chat` failing with `Invalid max_tokens` on the DeepSeek OpenAI-compatible endpoint.

The runtime cap logic is already present on `main`, but it was easy for this behavior to look unresolved without focused coverage. This PR locks the behavior down so provider-specific limits for DeepSeek stay protected against future regressions.

## Impact
- helps prevent regressions on DeepSeek and other OpenAI-compatible provider cap handling
- gives maintainers a focused test path for the reported failure mode
- makes issue triage clearer because the expected DeepSeek limit is now encoded in tests

## Validation
- `bun test src/utils/context.test.ts`
- `bun run test:provider`
