### PR TITLE
fix: skip Anthropic credential check in CI for 3P providers

### DIFF
--- a/src/utils/auth.ts
+++ b/src/utils/auth.ts
@@ -274,6 +274,7 @@ export function getAnthropicApiKeyWithSource(
     }
 
     if (
+      !isUsing3PServices() &&
       !apiKeyEnv &&
       !process.env.CLAUDE_CODE_OAUTH_TOKEN &&
       !process.env.CLAUDE_CODE_OAUTH_TOKEN_FILE_DESCRIPTOR
@@ -1729,13 +1730,14 @@ export function getSubscriptionName(): string {
   }
 }
 
-/** Check if using third-party services (Bedrock or Vertex or Foundry or OpenAI-compatible) */
+/** Check if using third-party services (Bedrock or Vertex or Foundry or OpenAI-compatible or Gemini) */
 export function isUsing3PServices(): boolean {
   return !!(
     isEnvTruthy(process.env.CLAUDE_CODE_USE_BEDROCK) ||
     isEnvTruthy(process.env.CLAUDE_CODE_USE_VERTEX) ||
     isEnvTruthy(process.env.CLAUDE_CODE_USE_FOUNDRY) ||
-    isEnvTruthy(process.env.CLAUDE_CODE_USE_OPENAI)
+    isEnvTruthy(process.env.CLAUDE_CODE_USE_OPENAI) ||
+    isEnvTruthy(process.env.CLAUDE_CODE_USE_GEMINI)
   )
 }
 


### PR DESCRIPTION
## Problem

In CI mode (`CI=1`), `auth.ts` throws immediately if `ANTHROPIC_API_KEY` or `CLAUDE_CODE_OAUTH_TOKEN` are missing — even when `CLAUDE_CODE_USE_OPENAI=1` or `CLAUDE_CODE_USE_GEMINI=1` is set. This crashes any OpenAI/Gemini/Ollama CI pipeline before it can do anything.

Related to #40.

## Root Cause

`getAnthropicApiKeyWithSource()` has this guard in the CI path:

```ts
if (
  !apiKeyEnv &&
  !process.env.CLAUDE_CODE_OAUTH_TOKEN &&
  !process.env.CLAUDE_CODE_OAUTH_TOKEN_FILE_DESCRIPTOR
) {
  throw new Error('ANTHROPIC_API_KEY or CLAUDE_CODE_OAUTH_TOKEN env var is required')
}
```

No check for whether the user is running a 3P provider that doesn't need Anthropic credentials at all.

## Fix

Two changes in `src/utils/auth.ts`:

1. **Guard the throw** with `!isUsing3PServices()` — 3P provider users skip the check entirely
2. **Add `CLAUDE_CODE_USE_GEMINI`** to `isUsing3PServices()` — it was missing, so Gemini users were not detected as 3P

## Test

```bash
# Before fix — crashes immediately in CI with OpenAI provider
CI=1 CLAUDE_CODE_USE_OPENAI=1 OPENAI_API_KEY=sk-test OPENAI_MODEL=gpt-4o node dist/cli.mjs --version
# Error: ANTHROPIC_API_KEY or CLAUDE_CODE_OAUTH_TOKEN env var is required

# After fix — works correctly
CI=1 CLAUDE_CODE_USE_OPENAI=1 OPENAI_API_KEY=sk-test OPENAI_MODEL=gpt-4o node dist/cli.mjs --version
# 0.1.4 (Open Claude)

CI=1 CLAUDE_CODE_USE_GEMINI=1 GEMINI_API_KEY=test node dist/cli.mjs --version
# 0.1.4 (Open Claude)
```