### PR TITLE
docs: note minimum Bun version for Windows builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ npm install -g @gitlawb/openclaude
 
 ### Option B: From source (requires Bun)
 
+Use Bun `1.3.11` or newer for source builds on Windows. Older Bun versions such as `1.3.4` can fail with a large batch of unresolved module errors during `bun run build`.
+
 ```bash
 # Clone from gitlawb
 git clone https://node.gitlawb.com/z6MkqDnb7Siv3Cwj7pGJq4T5EsUisECqR8KpnDLwcaZq5TPr/openclaude.git


### PR DESCRIPTION
## What changed
- add a README note that Windows source builds should use Bun `1.3.11` or newer
- call out that older Bun versions such as `1.3.4` can fail with unresolved module errors during `bun run build`

## Why
Issue #23 turned out to be caused by an outdated Bun version on Windows rather than an open build bug in current `main`.

This docs update makes that requirement visible in the install flow so other users do not waste time chasing hundreds of missing-module errors on older Bun releases.

Refs #23