### PR TITLE
fix: normalize tool schemas so required ⊇ properties for OpenAI/Codex

### DIFF
--- a/src/services/api/openaiShim.ts
+++ b/src/services/api/openaiShim.ts
@@ -217,6 +217,21 @@ function convertMessages(
   return result
 }
 
+/**
+ * OpenAI requires every key in `properties` to also appear in `required`.
+ * Anthropic schemas often mark fields as optional (omitted from `required`),
+ * which causes 400 errors on OpenAI/Codex endpoints. This normalizes the
+ * schema by ensuring `required` is a superset of `properties` keys.
+ */
+function normalizeSchemaForOpenAI(schema: Record<string, unknown>): Record<string, unknown> {
+  if (schema.type !== 'object' || !schema.properties) return schema
+  const properties = schema.properties as Record<string, unknown>
+  const existingRequired = Array.isArray(schema.required) ? schema.required as string[] : []
+  const allKeys = Object.keys(properties)
+  const required = Array.from(new Set([...existingRequired, ...allKeys]))
+  return { ...schema, required }
+}
+
 function convertTools(
   tools: Array<{ name: string; description?: string; input_schema?: Record<string, unknown> }>,
 ): OpenAITool[] {
@@ -227,7 +242,7 @@ function convertTools(
       function: {
         name: t.name,
         description: t.description ?? '',
-        parameters: t.input_schema ?? { type: 'object', properties: {} },
+        parameters: normalizeSchemaForOpenAI(t.input_schema ?? { type: 'object', properties: {} }),
       },
     }))
 }


### PR DESCRIPTION
## Problem

OpenAI and Codex enforce strict JSON Schema validation — every key in `properties` must also appear in `required`. Anthropic schemas often mark fields as optional (omitted from `required`), which causes 400 errors immediately on any OpenAI/Codex endpoint.

Reported in #46. Example error:

```
API Error: Codex API error 400: {
  "error": {
    "message": "Invalid schema for function 'Agent': In context=(), 'required' is required to be supplied and to be an array including every key in properties. Missing 'subagent_type'.",
    "type": "invalid_request_error",
    "param": "tools[0].parameters",
    "code": "invalid_function_parameters"
  }
}
```

The `Agent` tool has `subagent_type` in `properties` but not in `required` — valid for Anthropic, rejected by OpenAI.

## Fix

Added `normalizeSchemaForOpenAI()` in `convertTools()` in `openaiShim.ts`. Before sending any tool schema to the API, it ensures `required` is a superset of all `properties` keys:

- Existing `required` entries are preserved
- Missing keys are appended
- Schemas without `properties` (e.g. `type: 'string'`) pass through unchanged

This fixes the issue for the `Agent` tool and any other tool with optional properties, without touching individual tool definitions.

## Test

Tested locally with `CLAUDE_CODE_USE_OPENAI=1` and GPT-4o:

```
spawn an agent to list files in current directory
```

**Before fix:** immediate 400 error on tool schema validation  
**After fix:** `Agent(List files in current directory) → Done (1 tool use · 8.9k tokens · 8s)`

Closes #46.