### PR TITLE
fix: handle empty string delta.content in OpenAI streaming

### DIFF
--- a/src/services/api/openaiShim.ts
+++ b/src/services/api/openaiShim.ts
@@ -345,8 +345,9 @@ async function* openaiStreamToAnthropic(
       for (const choice of chunk.choices ?? []) {
         const delta = choice.delta
 
-        // Text content
-        if (delta.content) {
+        // Text content — use != null to distinguish absent field from empty string,
+        // some providers send "" as first delta to signal streaming start
+        if (delta.content != null) {
           if (!hasEmittedContentStart) {
             yield {
               type: 'content_block_start',


### PR DESCRIPTION
## Summary

- Fixes a protocol violation where some providers send `""` as the first delta to signal streaming start
- The falsy check `if (delta.content)` treated empty string as absent, skipping `content_block_start` — the next delta with actual text was emitted without it, breaking the Anthropic event sequence

## Changes

1 line changed in `src/services/api/openaiShim.ts` — `if (delta.content)` → `if (delta.content != null)`.

## Relates to

#42