### PR TITLE
fix: use correct default port for wss:// in NO_PROXY matching

### DIFF
--- a/src/utils/proxy.ts
+++ b/src/utils/proxy.ts
@@ -97,7 +97,9 @@ export function shouldBypassProxy(
   try {
     const url = new URL(urlString)
     const hostname = url.hostname.toLowerCase()
-    const port = url.port || (url.protocol === 'https:' ? '443' : '80')
+    const port = url.port || (
+      url.protocol === 'https:' || url.protocol === 'wss:' ? '443' : '80'
+    )
     const hostWithPort = `${hostname}:${port}`
 
     // Split by comma or space and trim each entry


### PR DESCRIPTION
## Summary

- Fixes `NO_PROXY` matching for `wss://` URLs — the default port was incorrectly resolved to `80` instead of `443`
- A `NO_PROXY` entry like `example.com:443` would not match `wss://example.com` because the port comparison failed

## Changes

1 line changed in `src/utils/proxy.ts` — added `wss:` to the `443` port branch.

## Relates to

#40