### PR TITLE
fix: add CLAUDE_CODE_USE_GEMINI to is3P check to prevent login screen

### DIFF
--- a/src/utils/auth.ts
+++ b/src/utils/auth.ts
@@ -116,7 +116,8 @@ export function isAnthropicAuthEnabled(): boolean {
     isEnvTruthy(process.env.CLAUDE_CODE_USE_BEDROCK) ||
     isEnvTruthy(process.env.CLAUDE_CODE_USE_VERTEX) ||
     isEnvTruthy(process.env.CLAUDE_CODE_USE_FOUNDRY) ||
-    isEnvTruthy(process.env.CLAUDE_CODE_USE_OPENAI)
+    isEnvTruthy(process.env.CLAUDE_CODE_USE_OPENAI) ||
+    isEnvTruthy(process.env.CLAUDE_CODE_USE_GEMINI)
 
   // Check if user has configured an external API key source
   // This allows externally-provided API keys to work (without requiring proxy configuration)


### PR DESCRIPTION
## Problem

Gemini users see the Anthropic/gcloud login screen at startup even when `CLAUDE_CODE_USE_GEMINI=1` and `GEMINI_API_KEY` are correctly set. Reported in #43.

## Root Cause

`isAnthropicAuthEnabled()` in `src/utils/auth.ts` uses an `is3P` check to decide whether to skip Anthropic auth. `CLAUDE_CODE_USE_OPENAI` was included but `CLAUDE_CODE_USE_GEMINI` was missing:

```ts
const is3P =
  isEnvTruthy(process.env.CLAUDE_CODE_USE_BEDROCK) ||
  isEnvTruthy(process.env.CLAUDE_CODE_USE_VERTEX) ||
  isEnvTruthy(process.env.CLAUDE_CODE_USE_FOUNDRY) ||
  isEnvTruthy(process.env.CLAUDE_CODE_USE_OPENAI)
  // CLAUDE_CODE_USE_GEMINI missing ← bug
```

With `is3P = false`, `shouldDisableAuth = false`, so `isAnthropicAuthEnabled()` returns `true` → login screen appears.

## Fix

One line — add `CLAUDE_CODE_USE_GEMINI` to the `is3P` check, consistent with `CLAUDE_CODE_USE_OPENAI`.

## Test

```bash
CLAUDE_CODE_USE_GEMINI=1 GEMINI_API_KEY=your-key openclaude
# Before: Anthropic/gcloud login screen appears
# After: starts directly, no login prompt
```

Closes #43.