### PR TITLE
test: cover OpenAI max token caps for gpt-4o and GPT-5.4

### DIFF
--- a/src/utils/context.test.ts
+++ b/src/utils/context.test.ts
@@ -54,3 +54,35 @@ test('gpt-4o clamps oversized max output overrides to the provider limit', () =>
 
   expect(getMaxOutputTokensForModel('gpt-4o')).toBe(16_384)
 })
+
+test('gpt-5.4 family uses provider-specific context and output caps', () => {
+  process.env.CLAUDE_CODE_USE_OPENAI = '1'
+  delete process.env.CLAUDE_CODE_MAX_OUTPUT_TOKENS
+
+  expect(getContextWindowForModel('gpt-5.4')).toBe(1_050_000)
+  expect(getModelMaxOutputTokens('gpt-5.4')).toEqual({
+    default: 128_000,
+    upperLimit: 128_000,
+  })
+
+  expect(getContextWindowForModel('gpt-5.4-mini')).toBe(400_000)
+  expect(getModelMaxOutputTokens('gpt-5.4-mini')).toEqual({
+    default: 128_000,
+    upperLimit: 128_000,
+  })
+
+  expect(getContextWindowForModel('gpt-5.4-nano')).toBe(400_000)
+  expect(getModelMaxOutputTokens('gpt-5.4-nano')).toEqual({
+    default: 128_000,
+    upperLimit: 128_000,
+  })
+})
+
+test('gpt-5.4 family keeps large max output overrides within provider limits', () => {
+  process.env.CLAUDE_CODE_USE_OPENAI = '1'
+  process.env.CLAUDE_CODE_MAX_OUTPUT_TOKENS = '200000'
+
+  expect(getMaxOutputTokensForModel('gpt-5.4')).toBe(128_000)
+  expect(getMaxOutputTokensForModel('gpt-5.4-mini')).toBe(128_000)
+  expect(getMaxOutputTokensForModel('gpt-5.4-nano')).toBe(128_000)
+})

--- a/src/utils/model/openaiContextWindows.ts
+++ b/src/utils/model/openaiContextWindows.ts
@@ -13,6 +13,9 @@
 
 const OPENAI_CONTEXT_WINDOWS: Record<string, number> = {
   // OpenAI
+  'gpt-5.4':               1_050_000,
+  'gpt-5.4-mini':            400_000,
+  'gpt-5.4-nano':            400_000,
   'gpt-4o':                   128_000,
   'gpt-4o-mini':              128_000,
   'gpt-4.1':                  1_047_576,
@@ -62,6 +65,9 @@ const OPENAI_CONTEXT_WINDOWS: Record<string, number> = {
  */
 const OPENAI_MAX_OUTPUT_TOKENS: Record<string, number> = {
   // OpenAI
+  'gpt-5.4':                 128_000,
+  'gpt-5.4-mini':            128_000,
+  'gpt-5.4-nano':            128_000,
   'gpt-4o':                   16_384,
   'gpt-4o-mini':              16_384,
   'gpt-4.1':                  32_768,


### PR DESCRIPTION
## What changed
- add regression coverage for the reported OpenAI-compatible `gpt-4o` output token limit
- add GPT-5.4 family entries to the OpenAI-compatible context/output cap table
- verify `gpt-4o` defaults to `16384` max output tokens and clamps oversized overrides
- verify `gpt-5.4`, `gpt-5.4-mini`, and `gpt-5.4-nano` resolve to the documented provider-specific context and output caps

## Why
Issue #58 specifically reported `gpt-4o` failing with:

`max_tokens is too large: 32000 ... this model supports at most 16384 completion tokens`

The runtime cap logic for `gpt-4o` is already present on `main`, but this PR locks that reported behavior down with focused tests so it does not regress.

While touching the same OpenAI-compatible cap table, this PR also refreshes the newer GPT-5.4 chat-completions family so OpenClaude has current provider-specific limits there too.

Refs #58

## Validation
- `bun test src/utils/context.test.ts`
- `bun run test:provider`