### PR TITLE
fix: sort skills menu by namespace

### DIFF
--- a/src/components/skills/SkillsMenu.tsx
+++ b/src/components/skills/SkillsMenu.tsx
@@ -233,7 +233,7 @@ function _temp3(skill_0) {
   return <Box key={`${skill_0.name}-${skill_0.source}`}><Text>{getSkillListLabel(skill_0)}</Text><Text dimColor={true}>{pluginName ? ` · ${pluginName}` : ""} · {tokenDisplay} description tokens</Text></Box>;
 }
 function _temp2(a, b) {
-  return getCommandName(a).localeCompare(getCommandName(b));
+  return a.name.localeCompare(b.name);
 }
 function _temp(cmd) {
   return cmd.type === "prompt" && (cmd.loadedFrom === "skills" || cmd.loadedFrom === "commands_DEPRECATED" || cmd.loadedFrom === "plugin" || cmd.loadedFrom === "mcp");


### PR DESCRIPTION
## Summary
- sort Skills dialog entries by the full namespaced skill name instead of the display skill name
- keep nested skills ordered consistently with the namespaced labels added in #65