### PR TITLE
test: align Codex strict schema expectation

### DIFF
--- a/src/services/api/codexShim.test.ts
+++ b/src/services/api/codexShim.test.ts
@@ -72,7 +72,7 @@ describe('Codex provider config', () => {
 })
 
 describe('Codex request translation', () => {
-  test('disables strict mode for tools with optional parameters', () => {
+  test('normalizes optional parameters into strict Responses schemas', () => {
     const tools = convertToolsToResponsesTools([
       {
         name: 'Agent',
@@ -102,9 +102,10 @@ describe('Codex request translation', () => {
             prompt: { type: 'string' },
             subagent_type: { type: 'string' },
           },
-          required: ['description', 'prompt'],
+          required: ['description', 'prompt', 'subagent_type'],
           additionalProperties: false,
         },
+        strict: true,
       },
     ])
   })


### PR DESCRIPTION
## Summary
- update the Codex shim test to match the current strict-schema normalization behavior
- keep the new PR checks green on the latest `main`

## Why
The new `PR Checks` workflow exposed an existing stale expectation in `codexShim.test.ts` after #71 merged. The Codex tool-schema normalizer now promotes all properties into `required` and marks the resulting tool schema as `strict`, but the test was still expecting the older non-strict shape.

## Validation
- `bun test src/services/api/codexShim.test.ts`
- `bun run smoke`
- `bun run test:provider`
- `npm run test:provider-recommendation`