### PR TITLE
fix: use max_completion_tokens instead of max_tokens for OpenAI-compatible APIs

### DIFF
--- a/src/services/api/openaiShim.ts
+++ b/src/services/api/openaiShim.ts
@@ -636,8 +636,12 @@ class OpenAIShimMessages {
     const body: Record<string, unknown> = {
       model: request.resolvedModel,
       messages: openaiMessages,
-      max_tokens: params.max_tokens,
       stream: params.stream ?? false,
+    }
+    if (params.max_tokens !== undefined) {
+      body.max_completion_tokens = params.max_tokens
+    } else if ((params as Record<string, unknown>).max_completion_tokens !== undefined) {
+      body.max_completion_tokens = (params as Record<string, unknown>).max_completion_tokens
     }
 
     if (params.stream) {


### PR DESCRIPTION
## Problem

Azure OpenAI and newer OpenAI models (o1, o3, o4...) return a 400 error when `max_tokens` is used:

```
API Error: OpenAI API error 400: {
  "error": {
    "message": "Unsupported parameter: 'max_tokens' is not supported with this model. Use 'max_completion_tokens' instead.",
    "type": "invalid_request_error",
    "param": "max_tokens",
    "code": "unsupported_parameter"
  }
}
```

## Fix

Map `params.max_tokens` to `max_completion_tokens` in the request body. This is now the standard parameter name across OpenAI-compatible APIs and is supported by all current providers (Azure OpenAI, OpenAI, OpenRouter, etc.).