### PR TITLE
fix: show correct version in startup screen

### DIFF
--- a/src/components/StartupScreen.ts
+++ b/src/components/StartupScreen.ts
@@ -174,7 +174,7 @@ export function printStartupScreen(): void {
   out.push(boxRow(sRow, W, sLen))
 
   out.push(`${rgb(...BORDER)}\u255a${'\u2550'.repeat(W - 2)}\u255d${RESET}`)
-  out.push(`  ${DIM}${rgb(...DIMCOL)}openclaude v${MACRO.DISPLAY_VERSION ?? MACRO.VERSION}${RESET}`)
+  out.push(`  ${DIM}${rgb(...DIMCOL)}openclaude ${RESET}${rgb(...ACCENT)}v${MACRO.DISPLAY_VERSION ?? MACRO.VERSION}${RESET}`)
   out.push('')
 
   process.stdout.write(out.join('\n') + '\n')


### PR DESCRIPTION
## Problem

The startup screen always shows `openclaude v0.1.4` regardless of the actual installed version (reported in #95).

## Root Cause

`StartupScreen.ts` was reading the version using:
```ts
(globalThis as Record<string, unknown>)['MACRO_DISPLAY_VERSION'] ?? '0.1.4'
```

The Bun bundler inlines build-time constants using **dot notation** (`MACRO.DISPLAY_VERSION`), not as a `globalThis` key. So `globalThis['MACRO_DISPLAY_VERSION']` is always `undefined` and the hardcoded fallback `'0.1.4'` is shown every time.

Every other file in the codebase reads it correctly:
```ts
MACRO.DISPLAY_VERSION ?? MACRO.VERSION  // cli.tsx, main.tsx, logoV2Utils.ts
```

## Fix

Replace the broken `globalThis` access with the standard `MACRO.DISPLAY_VERSION ?? MACRO.VERSION` pattern and add the required `declare const MACRO` for TypeScript.

Fixes #95