### PR TITLE
docs: replace stale OpenRouter Gemini example

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,8 +118,12 @@ export OPENAI_MODEL=deepseek-chat
 export CLAUDE_CODE_USE_OPENAI=1
 export OPENAI_API_KEY=sk-or-...
 export OPENAI_BASE_URL=https://openrouter.ai/api/v1
-export OPENAI_MODEL=google/gemini-2.0-flash
+export OPENAI_MODEL=google/gemini-2.0-flash-001
 ```
+
+OpenRouter model availability changes over time. If a model stops working,
+pick another currently available OpenRouter model before assuming the
+OpenAI-compatible setup is broken.
 
 ### Ollama (local, free)
 


### PR DESCRIPTION
## Summary
- replace the stale OpenRouter Gemini README example with `google/gemini-2.0-flash-001`
- add a short note that OpenRouter model availability can change over time
- document the model ID that was verified locally after reproducing `google/gemini-2.0-flash` failing with `400 invalid model ID`

## Test Plan
- [x] `npm run smoke`
- [x] manual local repro: `google/gemini-2.0-flash` fails on OpenRouter with `400 invalid model ID`
- [x] manual local verification: `google/gemini-2.0-flash-001` works with the same OpenRouter setup

X: https://x.com/0x_art

Fixes #103