### PR TITLE
Restore public type definitions used by the open build

### DIFF
--- a/src/entrypoints/sdk/runtimeTypes.ts
+++ b/src/entrypoints/sdk/runtimeTypes.ts
@@ -1,2 +1,1 @@
-// Stub — SDK runtime types not included in source snapshot
-export type {}
+export type EffortLevel = 'low' | 'medium' | 'high' | 'max'

--- a/src/types/connectorText.ts
+++ b/src/types/connectorText.ts
@@ -1,18 +1,22 @@
-// Stub — original type not included in source snapshot
-export interface ConnectorTextBlock {
+export type ConnectorTextBlock = {
   type: 'connector_text'
-  text: string
+  connector_text: string
+  connector?: string
 }
 
-export interface ConnectorTextDelta {
+export type ConnectorTextDelta = {
   type: 'connector_text_delta'
-  text: string
+  connector_text: string
+  connector?: string
 }
 
-export function isConnectorTextBlock(block: unknown): block is ConnectorTextBlock {
+export function isConnectorTextBlock(
+  value: unknown,
+): value is ConnectorTextBlock {
   return (
-    typeof block === 'object' &&
-    block !== null &&
-    (block as Record<string, unknown>).type === 'connector_text'
+    typeof value === 'object' &&
+    value !== null &&
+    'connector_text' in value &&
+    typeof (value as { connector_text?: unknown }).connector_text === 'string'
   )
 }

--- a/src/utils/filePersistence/types.ts
+++ b/src/utils/filePersistence/types.ts
@@ -1,10 +1,18 @@
-// Stub — types not included in source snapshot
-export const OUTPUTS_SUBDIR = 'tool-results'
+export const OUTPUTS_SUBDIR = 'outputs'
 
-export interface PersistedFile {
-  path: string
-  content: string
-  size: number
+export type PersistedFile = {
+  filename: string
+  file_id?: string
+}
+
+export type FailedPersistence = {
+  filename: string
+  error: string
+}
+
+export type FilesPersistedEventData = {
+  files: PersistedFile[]
+  failed: FailedPersistence[]
 }
 
 export type TurnStartTime = number


### PR DESCRIPTION
This replaces a few placeholder public types with definitions that match how the open build is already using them.

- `src/types/connectorText.ts` now matches the `connector_text` block shape consumed in message rendering and API logging.
- `src/utils/filePersistence/types.ts` now matches the payload that `filePersistence.ts` already produces for BYOC uploads, including the `outputs` directory name and the `files` / `failed` result shape.
- `src/entrypoints/sdk/runtimeTypes.ts` now defines `EffortLevel`, including `max`, which is referenced by the effort and model-selection UI.

I kept this PR intentionally small. It does not add new behavior; it fixes type shims that had drifted from current usage in the open build.

Validation:
- `npm run smoke`

I did not use `npm run typecheck` as a validation signal because the repository currently has broader snapshot/type gaps unrelated to this diff.