### PR TITLE
fix: handle tool_choice 'none' and is_error in codexShim

### DIFF
--- a/src/services/api/codexShim.ts
+++ b/src/services/api/codexShim.ts
@@ -231,10 +231,11 @@ export function convertAnthropicMessagesToResponsesInput(
 
         for (const toolResult of toolResults) {
           const { callId } = normalizeToolUseId(toolResult.tool_use_id)
+          const output = convertToolResultToText(toolResult.content)
           items.push({
             type: 'function_call_output',
             call_id: callId,
-            output: convertToolResultToText(toolResult.content),
+            output: toolResult.is_error ? `Error: ${output}` : output,
           })
         }
 
@@ -453,6 +454,7 @@ function convertToolChoice(toolChoice: unknown): unknown {
   if (!choice?.type) return undefined
   if (choice.type === 'auto') return 'auto'
   if (choice.type === 'any') return 'required'
+  if (choice.type === 'none') return 'none'
   if (choice.type === 'tool' && choice.name) {
     return {
       type: 'function',


### PR DESCRIPTION
## Summary

- Adds missing `tool_choice: 'none'` mapping in `convertToolChoice()` — without this, disabling tools was silently ignored and the model could call tools freely
- Forwards `is_error` flag from `tool_result` blocks by prefixing with `Error:` (matching `openaiShim` behavior)

## Problem

**tool_choice none:** When Claude Code sends `tool_choice: { type: 'none' }` through the Codex transport, `convertToolChoice()` returned `undefined` (no match), so `tool_choice` was omitted from the request body. The Codex endpoint defaulted to `auto`, which is the exact opposite of the intended behavior.

**is_error:** `openaiShim.ts:163` correctly prefixes error tool results with `Error:`, but `codexShim.ts` never inspected `is_error`. A tool that returns an error result looked identical to a success result from Codex's perspective.

## Test plan

- [x] `bun test src/services/api/codexShim.test.ts` — 7 pass
- [ ] Verify tool_choice none prevents tool calls with Codex transport