### PR TITLE
fix: skip Anthropic model migration for third-party providers

### DIFF
--- a/src/migrations/migrateSonnet1mToSonnet45.ts
+++ b/src/migrations/migrateSonnet1mToSonnet45.ts
@@ -3,6 +3,7 @@ import {
   setMainLoopModelOverride,
 } from '../bootstrap/state.js'
 import { getGlobalConfig, saveGlobalConfig } from '../utils/config.js'
+import { getAPIProvider } from '../utils/model/providers.js'
 import {
   getSettingsForSource,
   updateSettingsForSource,
@@ -23,6 +24,10 @@ import {
  * tracked by a completion flag in global config.
  */
 export function migrateSonnet1mToSonnet45(): void {
+  if (getAPIProvider() !== 'firstParty') {
+    return
+  }
+
   const config = getGlobalConfig()
   if (config.sonnet1m45MigrationComplete) {
     return


### PR DESCRIPTION
## Summary

- Adds `getAPIProvider() !== 'firstParty'` guard to `migrateSonnet1mToSonnet45()`
- Prevents the migration from rewriting a 3P user's model setting to an Anthropic-specific alias

## Problem

The migration unconditionally rewrites `model: 'sonnet[1m]'` to `'sonnet-4-5-20250929[1m]'`. If a third-party (OpenAI/Gemini/Ollama) user happened to have this setting (e.g. from a previous 1P setup), their model would be silently corrupted to an alias that doesn't exist on their provider.

This follows the same pattern used by `migrateFennecToOpus` (which guards on `USER_TYPE !== 'ant'`) and the fix suggested in #41.

## Test plan

- [ ] Verify migration is skipped when `CLAUDE_CODE_USE_OPENAI=1`
- [ ] Verify migration still runs correctly for firstParty users