### PR TITLE
security: pin GitHub Actions to immutable SHA digests

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -12,15 +12,15 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 22
 
       - name: Set up Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@4bc047ad259df6fc24a6c9b0f9a0cb08cf17fbe5 # v2.0.1
         with:
           bun-version: 1.3.11
 


### PR DESCRIPTION
## Summary

- Pins all GitHub Actions in `pr-checks.yml` to immutable commit SHA digests instead of mutable version tags

## Changes

| Action | Before | After |
|--------|--------|-------|
| `actions/checkout` | `@v4` | `@11bd71901bbe5b1630ceea73d27597364c9af683` (v4.2.2) |
| `actions/setup-node` | `@v4` | `@49933ea5288caeca8642d1e84afbd3f7d6820020` (v4.4.0) |
| `oven-sh/setup-bun` | `@v2` | `@4bc047ad259df6fc24a6c9b0f9a0cb08cf17fbe5` (v2.0.1) |

## Why

Mutable version tags (`@v4`, `@v2`) can be repointed to arbitrary code by the action maintainer or an attacker who compromises their repository. `oven-sh/setup-bun` is a third-party action with higher risk. Pinning to SHA ensures the exact code that was audited is what runs in CI.

Relates to #115

## Test plan

- [ ] Verify CI pipeline still runs successfully with pinned SHAs