### PR TITLE
fix: skip assertMinVersion for third-party providers

### DIFF
--- a/src/utils/autoUpdater.ts
+++ b/src/utils/autoUpdater.ts
@@ -9,6 +9,7 @@ import {
   logEvent,
 } from 'src/services/analytics/index.js'
 import { type ReleaseChannel, saveGlobalConfig } from './config.js'
+import { getAPIProvider } from './model/providers.js'
 import { logForDebugging } from './debug.js'
 import { env } from './env.js'
 import { getClaudeConfigHomeDir } from './envUtils.js'
@@ -69,6 +70,12 @@ export type MaxVersionConfig = {
  */
 export async function assertMinVersion(): Promise<void> {
   if (process.env.NODE_ENV === 'test') {
+    return
+  }
+
+  // Skip version check for third-party providers — the min version
+  // kill-switch is Anthropic-specific and should not block 3P users
+  if (getAPIProvider() !== 'firstParty') {
     return
   }
 


### PR DESCRIPTION
## Summary

- Adds `getAPIProvider() !== 'firstParty'` guard to `assertMinVersion()` in `autoUpdater.ts`

## Problem

`assertMinVersion()` calls Anthropic's GrowthBook endpoint to enforce a minimum version. This is currently safe for 3P (OpenAI/Gemini/Ollama) users only because `isAnalyticsDisabled()` returns `true`, which disables GrowthBook. But this safety depends on a single stub function — if an upstream merge ever changes it, 3P users would be subject to Anthropic's version kill-switch.

Adding an explicit provider guard makes the safety independent of the analytics stub.

Relates to #115

## Test plan

- [ ] Verify `assertMinVersion()` exits early when `CLAUDE_CODE_USE_OPENAI=1`
- [ ] Verify it still works normally for firstParty users