### PR TITLE
fix: expose real HTTP response in withResponse instead of empty mock

### DIFF
--- a/src/services/api/openaiShim.ts
+++ b/src/services/api/openaiShim.ts
@@ -564,9 +564,13 @@ class OpenAIShimMessages {
   ) {
     const self = this
 
+    // Capture the real HTTP response for header inspection (quota, rate-limit)
+    let httpResponse: Response | undefined
+
     const promise = (async () => {
       const request = resolveProviderRequest({ model: params.model })
       const response = await self._doRequest(request, params, options)
+      httpResponse = response
 
       if (params.stream) {
         return new OpenAIShimStream(
@@ -593,8 +597,9 @@ class OpenAIShimMessages {
           const data = await promise
           return {
             data,
-            response: new Response(),
-            request_id: makeMessageId(),
+            response: httpResponse ?? new Response(),
+            request_id:
+              httpResponse?.headers.get('x-request-id') ?? makeMessageId(),
           }
         }
 


### PR DESCRIPTION
## Summary

- Captures the real HTTP `Response` from `fetch()` and exposes it via `withResponse()`
- Uses the server-assigned `x-request-id` header instead of generating a random local ID

## Problem

`withResponse()` returned `new Response()` (empty body, no headers) and a random `request_id`. The caller in `claude.ts` reads `response.headers` to extract quota status, rate-limit info, and request IDs for error correlation. All of this was silently lost.

Relates to #114

## Test plan

- [x] `bun test src/services/api/openaiShim.test.ts` — 3 pass
- [ ] Verify response headers are accessible after streaming completes