### PR TITLE
fix: skip stream_options for local providers (Ollama compatibility)

### DIFF
--- a/src/services/api/openaiShim.ts
+++ b/src/services/api/openaiShim.ts
@@ -26,6 +26,7 @@ import {
   type ShimCreateParams,
 } from './codexShim.js'
 import {
+  isLocalProviderUrl,
   resolveCodexApiCredentials,
   resolveProviderRequest,
 } from './providerConfig.js'
@@ -672,7 +673,9 @@ class OpenAIShimMessages {
       body.max_completion_tokens = maxCompletionTokensValue
     }
 
-    if (params.stream) {
+    // stream_options is an OpenAI extension not supported by all providers
+    // (Ollama < 0.5 returns 400, some proxies strip unknown fields)
+    if (params.stream && !isLocalProviderUrl(request.baseUrl)) {
       body.stream_options = { include_usage: true }
     }
 


### PR DESCRIPTION
## Summary

- Only sends `stream_options: { include_usage: true }` for remote providers
- Local providers (Ollama, LM Studio) detected via `isLocalProviderUrl()`

## Problem

`stream_options` is an OpenAI extension not supported by all providers. Older Ollama versions (< 0.5) return 400 when receiving unknown fields in the request body. Local providers typically don't report usage in streaming anyway.

Relates to #113

## Test plan

- [x] `bun test src/services/api/openaiShim.test.ts` — 3 pass
- [ ] Verify Ollama streaming works without 400 errors
- [ ] Verify OpenAI still reports usage in streaming chunks