### PR TITLE
fix: use provider-neutral label in CostThresholdDialog

### DIFF
--- a/src/components/CostThresholdDialog.tsx
+++ b/src/components/CostThresholdDialog.tsx
@@ -38,7 +38,7 @@ export function CostThresholdDialog(t0) {
   }
   let t4;
   if ($[4] !== onDone || $[5] !== t3) {
-    t4 = <Dialog title="You've spent $5 on the Anthropic API this session." onCancel={onDone}>{t1}{t3}</Dialog>;
+    t4 = <Dialog title="You've spent $5 on API calls this session." onCancel={onDone}>{t1}{t3}</Dialog>;
     $[4] = onDone;
     $[5] = t3;
     $[6] = t4;


### PR DESCRIPTION
## Summary

- Changes the hardcoded "Anthropic API" string to "API calls" in the cost threshold dialog title

## Problem

The `CostThresholdDialog` shows _"You've spent $5 on the Anthropic API this session."_ regardless of the active provider. For users on OpenAI, Gemini, Ollama, or other providers, this is misleading.

Relates to #39 (finding 3)

## Test plan

- [ ] Verify the dialog shows the updated text when the cost threshold is reached