### PR TITLE
fix: throw APIError instead of plain Error so retry logic works for all providers

### DIFF
--- a/src/services/api/codexShim.ts
+++ b/src/services/api/codexShim.ts
@@ -1,3 +1,4 @@
+import { APIError } from '@anthropic-ai/sdk'
 import type {
   ResolvedCodexCredentials,
   ResolvedProviderRequest,
@@ -553,7 +554,14 @@ export async function performCodexRequest(options: {
 
   if (!response.ok) {
     const errorBody = await response.text().catch(() => 'unknown error')
-    throw new Error(`Codex API error ${response.status}: ${errorBody}`)
+    let errorResponse: object | undefined
+    try { errorResponse = JSON.parse(errorBody) } catch { /* raw text */ }
+    throw APIError.generate(
+      response.status,
+      errorResponse,
+      `Codex API error ${response.status}: ${errorBody}`,
+      response.headers as unknown as Record<string, string>,
+    )
   }
 
   return response
@@ -633,10 +641,11 @@ export async function collectCodexCompletedResponse(
 
   for await (const event of readSseEvents(response)) {
     if (event.event === 'response.failed') {
-      throw new Error(
-        event.data?.response?.error?.message ??
-          event.data?.error?.message ??
-          'Codex response failed',
+      const msg = event.data?.response?.error?.message ??
+        event.data?.error?.message ??
+        'Codex response failed'
+      throw APIError.generate(
+        500, undefined, msg, {} as Record<string, string>,
       )
     }
 
@@ -650,7 +659,10 @@ export async function collectCodexCompletedResponse(
   }
 
   if (!completedResponse) {
-    throw new Error('Codex response ended without a completed payload')
+    throw APIError.generate(
+      500, undefined, 'Codex response ended without a completed payload',
+      {} as Record<string, string>,
+    )
   }
 
   return completedResponse
@@ -806,10 +818,11 @@ export async function* codexStreamToAnthropic(
     }
 
     if (event.event === 'response.failed') {
-      throw new Error(
-        payload?.response?.error?.message ??
-          payload?.error?.message ??
-          'Codex response failed',
+      const msg = payload?.response?.error?.message ??
+        payload?.error?.message ??
+        'Codex response failed'
+      throw APIError.generate(
+        500, undefined, msg, {} as Record<string, string>,
       )
     }
   }

--- a/src/services/api/openaiShim.ts
+++ b/src/services/api/openaiShim.ts
@@ -16,6 +16,7 @@
  *   CODEX_API_KEY / ~/.codex/auth.json — Codex auth for codexplan/codexspark
  */
 
+import { APIError } from '@anthropic-ai/sdk'
 import {
   codexStreamToAnthropic,
   collectCodexCompletedResponse,
@@ -756,7 +757,14 @@ class OpenAIShimMessages {
 
     if (!response.ok) {
       const errorBody = await response.text().catch(() => 'unknown error')
-      throw new Error(`OpenAI API error ${response.status}: ${errorBody}`)
+      let errorResponse: object | undefined
+      try { errorResponse = JSON.parse(errorBody) } catch { /* raw text */ }
+      throw APIError.generate(
+        response.status,
+        errorResponse,
+        `OpenAI API error ${response.status}: ${errorBody}`,
+        response.headers as unknown as Record<string, string>,
+      )
     }
 
     return response


### PR DESCRIPTION
## Summary

The retry logic in `withRetry.ts` **never fired** for any OpenAI-compatible provider. This PR fixes it by throwing properly typed `APIError` instances from the shim layer.

## Root Cause

The shim threw plain `Error` objects:
```ts
throw new Error(`OpenAI API error ${response.status}: ${errorBody}`)
```

But `withRetry.ts` checks `instanceof APIError` (from `@anthropic-ai/sdk`) at 8 decision points. Plain `Error` fails all of them, so every transient error (429 rate limit, 503 server error, network timeout) was treated as fatal and never retried.

## Fix

Uses `APIError.generate()` — the SDK's own public factory — at all throw sites in both `openaiShim.ts` and `codexShim.ts`. This produces properly typed errors that carry:
- `status` — enables status-based retry decisions (429, 500, 502, 503)
- `headers` — enables `Retry-After` header parsing and `x-should-retry` detection
- Correct `instanceof APIError` identity — passes the retry gate

No changes to `withRetry.ts` needed. The retry layer already handles the correct abstraction; it just needed correctly typed errors at the origin.

## Changes

- `openaiShim.ts` — HTTP error path now throws `APIError.generate(status, errorResponse, message, headers)`
- `codexShim.ts` — HTTP error path + 3 streaming error paths (`response.failed`, `response ended without completed payload`) all throw `APIError.generate()`

## Impact

**All users** on OpenAI, Gemini, DeepSeek, Ollama, Azure OpenAI, Groq, Mistral, and any OpenAI-compatible provider now get proper retry behavior:
- 429 → retry with `Retry-After` header delay
- 500/502/503 → retry with exponential backoff
- 401 → OAuth token refresh
- Network failures → stale connection detection

Fixes #129

## Test plan

- [x] `bun test src/services/api/openaiShim.test.ts` — 3 pass
- [x] `bun test src/services/api/codexShim.test.ts` — 7 pass
- [ ] Verify 429 from OpenAI triggers retry with backoff
- [ ] Verify 503 from Ollama triggers retry
- [ ] Verify non-retryable errors (400, 401 without OAuth) still fail immediately