### PR TITLE
fix: prevent ANTHROPIC_API_KEY from interfering with Gemini provider auth

### DIFF
--- a/src/services/api/errors.ts
+++ b/src/services/api/errors.ts
@@ -812,7 +812,8 @@ export function getAssistantMessageFromError(
 
   if (
     error instanceof Error &&
-    error.message.toLowerCase().includes('x-api-key')
+    error.message.toLowerCase().includes('x-api-key') &&
+    getAPIProvider() === 'firstParty'
   ) {
     // In CCR mode, auth is via JWTs - this is likely a transient network issue
     if (isCCRMode()) {

--- a/src/utils/auth.ts
+++ b/src/utils/auth.ts
@@ -286,7 +286,7 @@ export function getAnthropicApiKeyWithSource(
       )
     }
 
-    if (apiKeyEnv) {
+    if (apiKeyEnv && !isUsing3PServices()) {
       return {
         key: apiKeyEnv,
         source: 'ANTHROPIC_API_KEY',
@@ -294,6 +294,7 @@ export function getAnthropicApiKeyWithSource(
     }
 
     // OAuth token is present but this function returns API keys only
+    // Also reached when 3P provider is active — ANTHROPIC_API_KEY is ignored
     return {
       key: null,
       source: 'none',


### PR DESCRIPTION
## Summary

Three independent fixes that resolve the "Invalid API key" error when using `CLAUDE_CODE_USE_GEMINI=1` with `ANTHROPIC_API_KEY` set to any value (including `dummy`).

## Root Cause

Three code paths lacked provider-awareness:

### 1. `src/utils/auth.ts` — CI branch leaks `ANTHROPIC_API_KEY` to Gemini sessions

In the CI branch of `getAnthropicApiKeyWithSource()`, the `ANTHROPIC_API_KEY` value was returned directly without checking `isUsing3PServices()`. When a Gemini user sets `ANTHROPIC_API_KEY=dummy` (following CI workaround patterns), the dummy key leaks into the Anthropic key resolution pipeline and is later used in accidental Anthropic SDK calls that return 401.

**Fix:** Guard with `isUsing3PServices()` — symmetric with the existing `throw` guard 10 lines above.

### 2. `src/services/api/errors.ts` — "Invalid API key" shown for non-Anthropic errors

The `x-api-key` error handler surfaced "Invalid API key" for **any** provider when the error message contained `x-api-key`. A Gemini user hitting a network error saw a misleading Anthropic auth message instead of the real error.

**Fix:** Add `getAPIProvider() === 'firstParty'` guard (already imported).

### 3. `src/entrypoints/cli.tsx` — No Gemini credential validation at startup

`validateProviderEnvOrExit()` had branches for GitHub and OpenAI but none for Gemini. A user with `CLAUDE_CODE_USE_GEMINI=1` but no `GEMINI_API_KEY` got no early diagnostic and hit a cryptic error deep in the session.

**Fix:** Add Gemini branch that validates `GEMINI_API_KEY` or `GOOGLE_API_KEY` at startup.

## Why `ANTHROPIC_API_KEY=dummy` specifically

In non-CI interactive sessions, `getAnthropicApiKeyWithSource()` hits the approved-key-list check first — `"dummy"` is not approved, so it falls through to `source: 'none'`. In CI mode (`CI=1`), the function bypasses the approved-list check entirely and returns whatever is in `ANTHROPIC_API_KEY`. This is the precise environmental condition that triggers the bug.

Fixes #133

## Test plan

- [x] `bun test` — 16 pass across 3 test files
- [ ] Verify `CLAUDE_CODE_USE_GEMINI=1` + `GEMINI_API_KEY=valid` + `ANTHROPIC_API_KEY=dummy` no longer shows "Invalid API key"
- [ ] Verify `CLAUDE_CODE_USE_GEMINI=1` without `GEMINI_API_KEY` shows clear startup error
- [ ] Verify firstParty users still see "Invalid API key" correctly on auth failure