### PR TITLE
fix: report cached tokens from OpenAI prompt_tokens_details

### DIFF
--- a/src/services/api/openaiShim.ts
+++ b/src/services/api/openaiShim.ts
@@ -376,6 +376,9 @@ interface OpenAIStreamChunk {
     prompt_tokens?: number
     completion_tokens?: number
     total_tokens?: number
+    prompt_tokens_details?: {
+      cached_tokens?: number
+    }
   }
 }
 
@@ -392,7 +395,7 @@ function convertChunkUsage(
     input_tokens: usage.prompt_tokens ?? 0,
     output_tokens: usage.completion_tokens ?? 0,
     cache_creation_input_tokens: 0,
-    cache_read_input_tokens: 0,
+    cache_read_input_tokens: usage.prompt_tokens_details?.cached_tokens ?? 0,
   }
 }
 
@@ -920,6 +923,9 @@ class OpenAIShimMessages {
       usage?: {
         prompt_tokens?: number
         completion_tokens?: number
+        prompt_tokens_details?: {
+          cached_tokens?: number
+        }
       }
     },
     model: string,
@@ -985,7 +991,7 @@ class OpenAIShimMessages {
         input_tokens: data.usage?.prompt_tokens ?? 0,
         output_tokens: data.usage?.completion_tokens ?? 0,
         cache_creation_input_tokens: 0,
-        cache_read_input_tokens: 0,
+        cache_read_input_tokens: data.usage?.prompt_tokens_details?.cached_tokens ?? 0,
       },
     }
   }


### PR DESCRIPTION
## Summary

Maps OpenAI's `usage.prompt_tokens_details.cached_tokens` to `cache_read_input_tokens` in the Anthropic usage format, making prompt caching visible in the session summary and cost tracker.

## Root Cause

OpenAI has automatic prompt caching (no explicit markers needed) that reduces costs for repeated prefixes. The caching **works server-side** — but the shim hardcoded `cache_read_input_tokens: 0`, making it invisible to the user and cost tracker.

OpenAI returns cached token counts in:
```json
{
  "usage": {
    "prompt_tokens": 1200,
    "prompt_tokens_details": {
      "cached_tokens": 800
    }
  }
}
```

The shim's `OpenAIStreamChunk` interface didn't declare `prompt_tokens_details`, and `convertChunkUsage()` never read it.

## Changes

- Extended `OpenAIStreamChunk.usage` and `_convertNonStreamingResponse` data type with `prompt_tokens_details.cached_tokens`
- `convertChunkUsage()` now maps `cached_tokens` → `cache_read_input_tokens`
- Same fix in `_convertNonStreamingResponse()` for the non-streaming path
- `cache_creation_input_tokens` stays 0 — OpenAI's auto-caching has no creation cost

## What this does NOT change

- No change to how cache markers are handled (Anthropic's `cache_control` is correctly stripped since OpenAI doesn't use it)
- No change to the Codex path (different API format)
- The actual caching behavior is unchanged — this is purely a **reporting** fix

Fixes #152

## Test plan

- [x] `bun test src/services/api/openaiShim.test.ts` — 3 pass
- [x] `bun test src/services/api/codexShim.test.ts` — 7 pass
- [ ] Verify cached token counts appear in session summary with OpenAI provider
- [ ] Verify cost tracker reflects cache savings