### PR TITLE
fix: deterministic prefix matching and correct Llama 3.x context windows

### DIFF
--- a/src/utils/model/openaiContextWindows.ts
+++ b/src/utils/model/openaiContextWindows.ts
@@ -50,9 +50,11 @@ const OPENAI_CONTEXT_WINDOWS: Record<string, number> = {
   'gemini-2.5-flash':       1_048_576,
 
   // Ollama local models
-  'llama3.3:70b':               8_192,
-  'llama3.1:8b':                8_192,
-  'llama3.2:3b':                8_192,
+  // Llama 3.1+ models support 128k context natively (Meta official specs).
+  // Ollama defaults to num_ctx=8192 but users can configure higher values.
+  'llama3.3:70b':             128_000,
+  'llama3.1:8b':              128_000,
+  'llama3.2:3b':              128_000,
   'qwen2.5-coder:32b':        32_768,
   'qwen2.5-coder:7b':         32_768,
   'deepseek-coder-v2:16b':    163_840,
@@ -122,7 +124,11 @@ const OPENAI_MAX_OUTPUT_TOKENS: Record<string, number> = {
 
 function lookupByModel<T>(table: Record<string, T>, model: string): T | undefined {
   if (table[model] !== undefined) return table[model]
-  for (const key of Object.keys(table)) {
+  // Sort keys by length descending so the most specific prefix wins.
+  // Without this, 'gpt-4-turbo-preview' could match 'gpt-4' (8k) instead
+  // of 'gpt-4-turbo' (128k) depending on V8's key iteration order.
+  const sortedKeys = Object.keys(table).sort((a, b) => b.length - a.length)
+  for (const key of sortedKeys) {
     if (model.startsWith(key)) return table[key]
   }
   return undefined


### PR DESCRIPTION
## Summary

Two fixes in `openaiContextWindows.ts` addressing findings 1 and 2 from issue #132.

## Changes

### 1. Deterministic prefix matching in `lookupByModel()`

The prefix search iterated `Object.keys(table)` without ordering. If both `gpt-4` and `gpt-4-turbo` exist as keys, `gpt-4-turbo-preview` could match either depending on V8's key iteration order.

Now sorts keys by length descending before iterating, so the most specific prefix always wins.

### 2. Llama 3.x context windows updated from 8k to 128k

`llama3.3:70b`, `llama3.1:8b`, `llama3.2:3b` were set to 8,192 — but this is Ollama's default `num_ctx`, not the model's actual capability. Per [Meta's official specs](https://ai.meta.com/blog/meta-llama-3-1/):

- Llama 3.1 (8B, 70B, 405B): **128K** context
- Llama 3.2 (1B, 3B): **128K** context
- Llama 3.3 (70B): **128K** context

The old 8k value caused premature auto-compact warnings for users who configured `OLLAMA_NUM_CTX` to higher values.

Relates to #132

## Test plan

- [x] `bun test src/utils/context.test.ts` — 6 pass
- [ ] Verify `gpt-4-turbo-preview` resolves to `gpt-4-turbo` (128k) not `gpt-4` (8k)
- [ ] Verify Llama models show correct 128k context window in status