### PR TITLE
fix: crypto.randomUUID for IDs, Azure Foundry detection, safety filter visibility

### DIFF
--- a/src/services/api/codexShim.ts
+++ b/src/services/api/codexShim.ts
@@ -85,7 +85,7 @@ function makeUsage(usage?: {
 }
 
 function makeMessageId(): string {
-  return `msg_${Math.random().toString(36).slice(2)}${Date.now().toString(36)}`
+  return `msg_${crypto.randomUUID().replace(/-/g, '')}`
 }
 
 function normalizeToolUseId(toolUseId: string | undefined): {

--- a/src/services/api/openaiShim.ts
+++ b/src/services/api/openaiShim.ts
@@ -231,7 +231,7 @@ function convertMessages(
               input?: unknown
               extra_content?: Record<string, unknown>
             }) => ({
-              id: tu.id ?? `call_${Math.random().toString(36).slice(2)}`,
+              id: tu.id ?? `call_${crypto.randomUUID().replace(/-/g, '')}`,
               type: 'function' as const,
               function: {
                 name: tu.name ?? 'unknown',
@@ -389,7 +389,7 @@ interface OpenAIStreamChunk {
 }
 
 function makeMessageId(): string {
-  return `msg_${Math.random().toString(36).slice(2)}${Date.now().toString(36)}`
+  return `msg_${crypto.randomUUID().replace(/-/g, '')}`
 }
 
 function convertChunkUsage(
@@ -610,6 +610,23 @@ async function* openaiStreamToAnthropic(
               : choice.finish_reason === 'length'
                 ? 'max_tokens'
                 : 'end_turn'
+          if (choice.finish_reason === 'content_filter' || choice.finish_reason === 'safety') {
+            // Gemini/Azure content safety filter blocked the response.
+            // Emit a visible text block so the user knows why output was truncated.
+            if (!hasEmittedContentStart) {
+              yield {
+                type: 'content_block_start',
+                index: contentBlockIndex,
+                content_block: { type: 'text', text: '' },
+              }
+              hasEmittedContentStart = true
+            }
+            yield {
+              type: 'content_block_delta',
+              index: contentBlockIndex,
+              delta: { type: 'text_delta', text: '\n\n[Content blocked by provider safety filter]' },
+            }
+          }
           lastStopReason = stopReason
 
           yield {
@@ -841,7 +858,14 @@ class OpenAIShimMessages {
     }
 
     const apiKey = process.env.OPENAI_API_KEY ?? ''
-    const isAzure = /cognitiveservices\.azure\.com|openai\.azure\.com/.test(request.baseUrl)
+    // Detect Azure endpoints by hostname (not raw URL) to prevent bypass via
+    // path segments like https://evil.com/cognitiveservices.azure.com/
+    let isAzure = false
+    try {
+      const { hostname } = new URL(request.baseUrl)
+      isAzure = hostname.endsWith('.azure.com') &&
+        (hostname.includes('cognitiveservices') || hostname.includes('openai') || hostname.includes('services.ai'))
+    } catch { /* malformed URL — not Azure */ }
 
     if (apiKey) {
       if (isAzure) {
@@ -1002,6 +1026,13 @@ class OpenAIShimMessages {
         : choice?.finish_reason === 'length'
           ? 'max_tokens'
           : 'end_turn'
+
+    if (choice?.finish_reason === 'content_filter' || choice?.finish_reason === 'safety') {
+      content.push({
+        type: 'text',
+        text: '\n\n[Content blocked by provider safety filter]',
+      })
+    }
 
     return {
       id: data.id ?? makeMessageId(),


### PR DESCRIPTION
## Summary

Three targeted fixes addressing findings from issues #113 and #114.

## Changes

### 1. `crypto.randomUUID()` replaces `Math.random()` for ID generation

**Files:** `openaiShim.ts`, `codexShim.ts`

`makeMessageId()` and the tool call ID fallback used `Math.random()` which is not cryptographically secure and predictable in seeded environments (some test runners). Now uses the globally available `crypto.randomUUID()`.

### 2. Azure endpoint detection anchored to parsed hostname

**File:** `openaiShim.ts`

The regex `/cognitiveservices\.azure\.com|openai\.azure\.com/` tested the raw URL string, which could be bypassed via path segments (e.g., `https://evil.com/cognitiveservices.azure.com/`). Now parses the URL and checks `hostname.endsWith('.azure.com')` with specific subdomain matching.

Also adds support for **Azure AI Foundry** endpoints (`*.services.ai.azure.com`) which were not detected, causing the `api-key` header to not be set and the deployment URL to not be constructed.

### 3. Content safety filter blocks surfaced to user

**File:** `openaiShim.ts` (streaming + non-streaming)

When Gemini or Azure returns `finish_reason: 'content_filter'` or `'safety'`, the response was silently returned as an empty/truncated message with `stop_reason: 'end_turn'`. Now emits a visible text block `[Content blocked by provider safety filter]` so the user understands why the output was cut short.

Relates to #113, #114

## Test plan

- [x] `bun test src/services/api/openaiShim.test.ts` — pass
- [x] `bun test src/services/api/codexShim.test.ts` — pass
- [ ] Verify Azure AI Foundry endpoints (`*.services.ai.azure.com`) correctly use `api-key` header
- [ ] Verify safety-filtered Gemini responses show the blocked message
- [ ] Verify message IDs are UUID format