### PR TITLE
fix: block update command for 3P providers, align thinking block handling

### DIFF
--- a/src/cli/update.ts
+++ b/src/cli/update.ts
@@ -1,4 +1,5 @@
 import chalk from 'chalk'
+import { getAPIProvider } from 'src/utils/model/providers.js'
 import { logEvent } from 'src/services/analytics/index.js'
 import {
   getLatestVersion,
@@ -28,6 +29,19 @@ import { gte } from 'src/utils/semver.js'
 import { getInitialSettings } from 'src/utils/settings/settings.js'
 
 export async function update() {
+  // Block updates for third-party providers. The update mechanism downloads
+  // from Anthropic's distribution bucket, which would silently replace the
+  // OpenClaude build (with the OpenAI shim) with the upstream Claude Code
+  // binary (without it).
+  if (getAPIProvider() !== 'firstParty') {
+    writeToStdout(
+      chalk.yellow('Auto-update is not available for third-party provider builds.\n') +
+      'To update, pull the latest source from the repository and rebuild:\n' +
+      '  git pull && bun install && bun run build\n',
+    )
+    return
+  }
+
   logEvent('tengu_update_check', {})
   writeToStdout(`Current version: ${MACRO.VERSION}\n`)
 

--- a/src/services/api/codexShim.ts
+++ b/src/services/api/codexShim.ts
@@ -264,7 +264,8 @@ export function convertAnthropicMessagesToResponsesInput(
 
     if (role === 'assistant') {
       const textBlocks = Array.isArray(content)
-        ? content.filter((block: { type?: string }) => block.type !== 'tool_use')
+        ? content.filter((block: { type?: string }) =>
+            block.type !== 'tool_use' && block.type !== 'thinking')
         : content
       const parts = convertContentBlocksToResponsesParts(textBlocks, 'assistant')
       if (parts.length > 0) {


### PR DESCRIPTION
## Summary

Two fixes for 3P user safety (issue #115).

## Changes

### 1. Block `update` command for third-party providers

**File:** `src/cli/update.ts`

The update mechanism downloads binaries from Anthropic's GCS distribution bucket. A 3P user running `claude update` (or `/update`) would silently replace their OpenClaude install (with the OpenAI shim) with the upstream Claude Code binary (without it), breaking their setup.

Now detects the active provider and shows an actionable message:
```
Auto-update is not available for third-party provider builds.
To update, pull the latest source from the repository and rebuild:
  git pull && bun install && bun run build
```

### 2. Align thinking block handling between shims

**File:** `src/services/api/codexShim.ts`

`openaiShim.ts` filters out `thinking` blocks from assistant history content. `codexShim.ts` did not — thinking blocks were included as plain text in assistant messages for the Codex transport. This caused inconsistent conversation history when switching providers.

Now both shims filter `type !== 'tool_use' && type !== 'thinking'` from assistant content.

Relates to #115

## Test plan

- [x] `bun test src/services/api/codexShim.test.ts` — 9 pass
- [ ] Verify `/update` shows the redirect message with `CLAUDE_CODE_USE_OPENAI=1`
- [ ] Verify firstParty users can still update normally