### PR TITLE
fix: provider-aware error messages and skip Anthropic key approval for 3P

### DIFF
--- a/src/components/Onboarding.tsx
+++ b/src/components/Onboarding.tsx
@@ -99,7 +99,7 @@ export function Onboarding({
     // Add API key step if needed
     // On homespace, ANTHROPIC_API_KEY is preserved in process.env for child
     // processes but ignored by Claude Code itself (see auth.ts).
-    if (!process.env.ANTHROPIC_API_KEY || isRunningOnHomespace()) {
+    if (!process.env.ANTHROPIC_API_KEY || isRunningOnHomespace() || !isAnthropicAuthEnabled()) {
       return '';
     }
     const customApiKeyTruncated = normalizeApiKeyForConfig(process.env.ANTHROPIC_API_KEY);

--- a/src/services/api/errors.ts
+++ b/src/services/api/errors.ts
@@ -164,6 +164,12 @@ export const TOKEN_REVOKED_ERROR_MESSAGE =
 export const CCR_AUTH_ERROR_MESSAGE =
   'Authentication error · This may be a temporary network issue, please try again'
 export const REPEATED_529_ERROR_MESSAGE = 'Repeated 529 Overloaded errors'
+export function getCustomOffSwitchMessage(): string {
+  return getAPIProvider() === 'firstParty'
+    ? 'Opus is experiencing high load, please use /model to switch to Sonnet'
+    : 'The API is experiencing high load, please try again shortly or use /model to switch models'
+}
+// Backward-compatible constant for string matching in error handlers
 export const CUSTOM_OFF_SWITCH_MESSAGE =
   'Opus is experiencing high load, please use /model to switch to Sonnet'
 export const API_TIMEOUT_ERROR_MESSAGE = 'Request timed out'
@@ -457,7 +463,7 @@ export function getAssistantMessageFromError(
     error.message.includes(CUSTOM_OFF_SWITCH_MESSAGE)
   ) {
     return createAssistantAPIErrorMessage({
-      content: CUSTOM_OFF_SWITCH_MESSAGE,
+      content: getCustomOffSwitchMessage(),
       error: 'rate_limit',
     })
   }


### PR DESCRIPTION
## Summary

Two fixes for misleading Anthropic-specific UI/messages shown to third-party provider users.

## Changes

### 1. Provider-aware 529 overload message

**File:** `src/services/api/errors.ts`

The hardcoded message _"Opus is experiencing high load, please use /model to switch to Sonnet"_ is shown to ALL users on 529 errors, including those on OpenAI, Gemini, or Ollama who have never used Opus. Added `getCustomOffSwitchMessage()` that returns a provider-neutral message for 3P users:

> _"The API is experiencing high load, please try again shortly or use /model to switch models"_

The original constant `CUSTOM_OFF_SWITCH_MESSAGE` is preserved for backward-compatible string matching in error classification code.

### 2. Skip Anthropic API key approval for 3P providers

**File:** `src/components/Onboarding.tsx`

When a user has `ANTHROPIC_API_KEY` set in their environment (e.g., from a previous Anthropic setup) but is running with `CLAUDE_CODE_USE_OPENAI=1` or `CLAUDE_CODE_USE_GEMINI=1`, the onboarding showed an irrelevant "approve API key" step. Now checks `isAnthropicAuthEnabled()` (already imported) to skip this step for 3P providers.

Relates to #28 (finding 3), #115 (finding 6)

## Test plan

- [x] `bun test` — 13 pass
- [ ] Verify 529 error shows provider-neutral message with OpenAI
- [ ] Verify onboarding skips API key approval with `CLAUDE_CODE_USE_GEMINI=1` + `ANTHROPIC_API_KEY` set