### PR TITLE
feat: add .env.example with all provider configurations

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,107 @@
+# =============================================================================
+# OpenClaude Environment Configuration
+# =============================================================================
+# Copy this file to .env and fill in your values:
+#   cp .env.example .env
+#
+# Only set the variables for the provider you want to use.
+# All other sections can be left commented out.
+# =============================================================================
+
+
+# =============================================================================
+# PROVIDER SELECTION — uncomment ONE block below
+# =============================================================================
+
+# -----------------------------------------------------------------------------
+# Option 1: Anthropic (default — no provider flag needed)
+# -----------------------------------------------------------------------------
+ANTHROPIC_API_KEY=sk-ant-your-key-here
+
+# Override the default model (optional)
+# ANTHROPIC_MODEL=claude-sonnet-4-5
+
+# Use a custom Anthropic-compatible endpoint (optional)
+# ANTHROPIC_BASE_URL=https://api.anthropic.com
+
+
+# -----------------------------------------------------------------------------
+# Option 2: OpenAI
+# -----------------------------------------------------------------------------
+# CLAUDE_CODE_USE_OPENAI=1
+# OPENAI_API_KEY=sk-your-key-here
+# OPENAI_MODEL=gpt-4o
+
+# Use a custom OpenAI-compatible endpoint (optional — defaults to api.openai.com)
+# OPENAI_BASE_URL=https://api.openai.com/v1
+
+
+# -----------------------------------------------------------------------------
+# Option 3: Google Gemini
+# -----------------------------------------------------------------------------
+# CLAUDE_CODE_USE_GEMINI=1
+# GEMINI_API_KEY=your-gemini-key-here
+# GEMINI_MODEL=gemini-2.0-flash
+
+# Use a custom Gemini endpoint (optional)
+# GEMINI_BASE_URL=https://generativelanguage.googleapis.com
+
+
+# -----------------------------------------------------------------------------
+# Option 4: GitHub Models
+# -----------------------------------------------------------------------------
+# CLAUDE_CODE_USE_GITHUB=1
+# GITHUB_TOKEN=ghp_your-token-here
+
+
+# -----------------------------------------------------------------------------
+# Option 5: Ollama (local models)
+# -----------------------------------------------------------------------------
+# CLAUDE_CODE_USE_OPENAI=1
+# OPENAI_BASE_URL=http://localhost:11434/v1
+# OPENAI_API_KEY=ollama
+# OPENAI_MODEL=llama3.2
+
+
+# -----------------------------------------------------------------------------
+# Option 6: AWS Bedrock
+# -----------------------------------------------------------------------------
+# CLAUDE_CODE_USE_BEDROCK=1
+# AWS_REGION=us-east-1
+# AWS_DEFAULT_REGION=us-east-1
+# AWS_BEARER_TOKEN_BEDROCK=your-bearer-token-here
+# ANTHROPIC_BEDROCK_BASE_URL=https://bedrock-runtime.us-east-1.amazonaws.com
+
+
+# -----------------------------------------------------------------------------
+# Option 7: Google Vertex AI
+# -----------------------------------------------------------------------------
+# CLAUDE_CODE_USE_VERTEX=1
+# ANTHROPIC_VERTEX_PROJECT_ID=your-gcp-project-id
+# CLOUD_ML_REGION=us-east5
+# GOOGLE_CLOUD_PROJECT=your-gcp-project-id
+
+
+# =============================================================================
+# OPTIONAL TUNING
+# =============================================================================
+
+# Max number of API retries on failure (default: 10)
+# CLAUDE_CODE_MAX_RETRIES=10
+
+# Enable persistent retry mode for unattended/CI sessions
+# Retries 429/529 indefinitely with smart backoff
+# CLAUDE_CODE_UNATTENDED_RETRY=1
+
+# Enable extended key reporting (Kitty keyboard protocol)
+# Useful for iTerm2, WezTerm, Ghostty if modifier keys feel off
+# OPENCLAUDE_ENABLE_EXTENDED_KEYS=1
+
+# Disable "Co-authored-by" line in git commits made by OpenClaude
+# OPENCLAUDE_DISABLE_CO_AUTHORED_BY=1
+
+# Custom timeout for API requests in milliseconds (default: varies)
+# API_TIMEOUT_MS=60000
+
+# Enable debug logging
+# CLAUDE_DEBUG=1

--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,6 @@ dist/
 *.tsbuildinfo
 .env
 .env.*
+!.env.example
 .openclaude-profile.json
 reports/


### PR DESCRIPTION
## Summary

Closes #175

New contributors had no single reference for required environment variables — they had to hunt through the README and source files. This adds `.env.example` at the repo root covering all supported providers with placeholder values, inline comments, and copy-paste-ready blocks.

### What's included

- **7 provider configurations** — Anthropic, OpenAI, Gemini, GitHub Models, Ollama, AWS Bedrock, Google Vertex AI
- **Optional tuning vars** — `CLAUDE_CODE_MAX_RETRIES`, `CLAUDE_CODE_UNATTENDED_RETRY`, `OPENCLAUDE_ENABLE_EXTENDED_KEYS`, `OPENCLAUDE_DISABLE_CO_AUTHORED_BY`, `API_TIMEOUT_MS`, `CLAUDE_DEBUG`
- **`.gitignore` fix** — added `!.env.example` exception so the template isn't suppressed by the existing `.env.*` ignore rule

### Usage

```bash
cp .env.example .env
# fill in your values, then:
openclaude
```

---

X: [@0x_art](https://x.com/0x_art)