### PR TITLE
fix: route CLAUDE_CODE_USE_GEMINI through OpenAI-compatible shim

### DIFF
--- a/src/services/api/client.test.ts
+++ b/src/services/api/client.test.ts
@@ -1,0 +1,121 @@
+import { afterEach, beforeEach, expect, test } from 'bun:test'
+import { getAnthropicClient } from './client.js'
+
+type FetchType = typeof globalThis.fetch
+
+type ShimClient = {
+  beta: {
+    messages: {
+      create: (params: Record<string, unknown>) => Promise<unknown>
+    }
+  }
+}
+
+const originalFetch = globalThis.fetch
+const originalMacro = (globalThis as Record<string, unknown>).MACRO
+const originalEnv = {
+  CLAUDE_CODE_USE_GEMINI: process.env.CLAUDE_CODE_USE_GEMINI,
+  GEMINI_API_KEY: process.env.GEMINI_API_KEY,
+  GEMINI_MODEL: process.env.GEMINI_MODEL,
+  GEMINI_BASE_URL: process.env.GEMINI_BASE_URL,
+  GOOGLE_API_KEY: process.env.GOOGLE_API_KEY,
+  OPENAI_API_KEY: process.env.OPENAI_API_KEY,
+  OPENAI_BASE_URL: process.env.OPENAI_BASE_URL,
+  OPENAI_MODEL: process.env.OPENAI_MODEL,
+  ANTHROPIC_API_KEY: process.env.ANTHROPIC_API_KEY,
+  ANTHROPIC_AUTH_TOKEN: process.env.ANTHROPIC_AUTH_TOKEN,
+}
+
+beforeEach(() => {
+  ;(globalThis as Record<string, unknown>).MACRO = { VERSION: 'test-version' }
+  process.env.CLAUDE_CODE_USE_GEMINI = '1'
+  process.env.GEMINI_API_KEY = 'gemini-test-key'
+  process.env.GEMINI_MODEL = 'gemini-2.0-flash'
+  process.env.GEMINI_BASE_URL = 'https://gemini.example/v1beta/openai'
+
+  delete process.env.GOOGLE_API_KEY
+  delete process.env.OPENAI_API_KEY
+  delete process.env.OPENAI_BASE_URL
+  delete process.env.OPENAI_MODEL
+  delete process.env.ANTHROPIC_API_KEY
+  delete process.env.ANTHROPIC_AUTH_TOKEN
+})
+
+afterEach(() => {
+  ;(globalThis as Record<string, unknown>).MACRO = originalMacro
+  process.env.CLAUDE_CODE_USE_GEMINI = originalEnv.CLAUDE_CODE_USE_GEMINI
+  process.env.GEMINI_API_KEY = originalEnv.GEMINI_API_KEY
+  process.env.GEMINI_MODEL = originalEnv.GEMINI_MODEL
+  process.env.GEMINI_BASE_URL = originalEnv.GEMINI_BASE_URL
+  process.env.GOOGLE_API_KEY = originalEnv.GOOGLE_API_KEY
+  process.env.OPENAI_API_KEY = originalEnv.OPENAI_API_KEY
+  process.env.OPENAI_BASE_URL = originalEnv.OPENAI_BASE_URL
+  process.env.OPENAI_MODEL = originalEnv.OPENAI_MODEL
+  process.env.ANTHROPIC_API_KEY = originalEnv.ANTHROPIC_API_KEY
+  process.env.ANTHROPIC_AUTH_TOKEN = originalEnv.ANTHROPIC_AUTH_TOKEN
+  globalThis.fetch = originalFetch
+})
+
+test('routes Gemini provider requests through the OpenAI-compatible shim', async () => {
+  let capturedUrl: string | undefined
+  let capturedHeaders: Headers | undefined
+  let capturedBody: Record<string, unknown> | undefined
+
+  globalThis.fetch = (async (input, init) => {
+    capturedUrl =
+      typeof input === 'string'
+        ? input
+        : input instanceof URL
+          ? input.toString()
+          : input.url
+    capturedHeaders = new Headers(init?.headers)
+    capturedBody = JSON.parse(String(init?.body)) as Record<string, unknown>
+
+    return new Response(
+      JSON.stringify({
+        id: 'chatcmpl-gemini',
+        model: 'gemini-2.0-flash',
+        choices: [
+          {
+            message: {
+              role: 'assistant',
+              content: 'gemini ok',
+            },
+            finish_reason: 'stop',
+          },
+        ],
+        usage: {
+          prompt_tokens: 8,
+          completion_tokens: 3,
+          total_tokens: 11,
+        },
+      }),
+      {
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      },
+    )
+  }) as FetchType
+
+  const client = (await getAnthropicClient({
+    maxRetries: 0,
+    model: 'gemini-2.0-flash',
+  })) as unknown as ShimClient
+
+  const response = await client.beta.messages.create({
+    model: 'gemini-2.0-flash',
+    system: 'test system',
+    messages: [{ role: 'user', content: 'hello' }],
+    max_tokens: 64,
+    stream: false,
+  })
+
+  expect(capturedUrl).toBe('https://gemini.example/v1beta/openai/chat/completions')
+  expect(capturedHeaders?.get('authorization')).toBe('Bearer gemini-test-key')
+  expect(capturedBody?.model).toBe('gemini-2.0-flash')
+  expect(response).toMatchObject({
+    role: 'assistant',
+    model: 'gemini-2.0-flash',
+  })
+})

--- a/src/services/api/client.ts
+++ b/src/services/api/client.ts
@@ -156,7 +156,8 @@ export async function getAnthropicClient({
   }
   if (
     isEnvTruthy(process.env.CLAUDE_CODE_USE_OPENAI) ||
-    isEnvTruthy(process.env.CLAUDE_CODE_USE_GITHUB)
+    isEnvTruthy(process.env.CLAUDE_CODE_USE_GITHUB) ||
+    isEnvTruthy(process.env.CLAUDE_CODE_USE_GEMINI)
   ) {
     const { createOpenAIShimClient } = await import('./openaiShim.js')
     return createOpenAIShimClient({


### PR DESCRIPTION
## Summary

Fixes #176

### Root Cause

`CLAUDE_CODE_USE_GEMINI` was missing from the OpenAI shim routing condition in `src/services/api/client.ts`:

```ts
// Before — Gemini never reached the shim
if (
  isEnvTruthy(process.env.CLAUDE_CODE_USE_OPENAI) ||
  isEnvTruthy(process.env.CLAUDE_CODE_USE_GITHUB)
) {

// After — Gemini correctly routes to the shim
if (
  isEnvTruthy(process.env.CLAUDE_CODE_USE_OPENAI) ||
  isEnvTruthy(process.env.CLAUDE_CODE_USE_GITHUB) ||
  isEnvTruthy(process.env.CLAUDE_CODE_USE_GEMINI)
) {
```

Gemini uses Google's OpenAI-compatible endpoint (`generativelanguage.googleapis.com/v1beta/openai`). The `openaiShim.ts` already had correct code to map `GEMINI_API_KEY → OPENAI_API_KEY` and set `OPENAI_BASE_URL` — but that code lived inside `createOpenAIShimClient()`, which was **never called** for Gemini because the routing condition didn't include it.

Every Gemini request fell through to the Anthropic client path. With no `ANTHROPIC_API_KEY` set, the SDK threw:
> *Could not resolve authentication method. Expected either apiKey or authToken to be set.*

### Fix

One line added to `client.ts` routing condition. No logic changes to the shim itself.

### Verified

- Test was already written and failing with the exact same error — now passes ✓
- Build clean: `✓ Built openclaude v0.1.7 → dist/cli.mjs`
- Manual run confirmed: startup screen shows `Provider: Google Gemini` with correct endpoint, no auth error

---

X: [@0x_art](https://x.com/0x_art)