### PR TITLE
feat: (Extension of #175) added cross-platform system-wide environment variable setup guide for all providers

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -112,13 +112,9 @@
 #     [System.Environment]::SetEnvironmentVariable('VAR_NAME', $null, 'User')
 #
 # LOAD ORDER:
-#   1. System environment variables (from shell profile) — highest priority
-#   2. .env file in the project directory — fills in anything not already set
-#
-#   This means you can set a default provider system-wide and override it
-#   for a specific project by placing a .env file in that project's root
-#   with different values.
-#
+#   Shell and system environment variables are inherited by the process.
+#   Project .env files are only used if your launcher or shell loads them
+#   before starting OpenClaude.
 # COMPATIBILITY:
 #   System-wide variables work regardless of how you run OpenClaude:
 #   npx, global npm install, bun run, or node directly. Any process
@@ -162,7 +158,7 @@ ANTHROPIC_API_KEY=sk-ant-your-key-here
 # GEMINI_MODEL=gemini-2.0-flash
 
 # Use a custom Gemini endpoint (optional)
-# GEMINI_BASE_URL=https://generativelanguage.googleapis.com
+# GEMINI_BASE_URL=https://generativelanguage.googleapis.com/v1beta/openai
 
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
I extended the .env.example from the previous branch to add to a comprehensive system-wide setup instructions to .env.example so that contributors and users can configure OpenClaude once and use it from any
directory on their machine, without needing a .env file in every project.

What I added:
- Step-by-step instructions for setting environment variables on macOS (zsh),
  Linux (bash), Windows PowerShell, Windows CMD, and Windows GUI
- Quick-reference variable list covering all 8 provider options (Anthropic,
  OpenAI, Gemini, GitHub Models, Ollama, LM Studio, AWS Bedrock, Vertex AI)
- Instructions for switching between providers by unsetting variables
- Load order explanation (system env vars vs project .env files)
- Compatibility note confirming it works with npx, npm global, bun, and node
- AWS Bedrock note about potential AWS CLI credential requirements
- LM Studio clarification that OPENAI_API_KEY is optional for local servers

Extends #175

X: [@solomo63655](https://x.com/solomo63655)