### PR TITLE
security: pin @mendable/firecrawl-js to exact version

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -13,7 +13,7 @@
         "@anthropic-ai/vertex-sdk": "0.14.4",
         "@commander-js/extra-typings": "12.1.0",
         "@growthbook/growthbook": "1.6.5",
-        "@mendable/firecrawl-js": "^4.18.1",
+        "@mendable/firecrawl-js": "4.18.1",
         "@modelcontextprotocol/sdk": "1.29.0",
         "@opentelemetry/api": "1.9.1",
         "@opentelemetry/api-logs": "0.214.0",

--- a/package.json
+++ b/package.json
@@ -113,7 +113,7 @@
     "xss": "1.0.15",
     "yaml": "2.8.3",
     "zod": "3.25.76",
-    "@mendable/firecrawl-js": "^4.18.1"
+    "@mendable/firecrawl-js": "4.18.1"
   },
   "devDependencies": {
     "@types/bun": "1.3.11",


### PR DESCRIPTION
Pins @mendable/firecrawl-js from ^4.18.1 to 4.18.1 in both package.json and bun.lock. This dependency was added in #168 with a caret range, inconsistent with the exact-version pinning policy from #102.

The package itself is clean — no postinstall scripts, no known CVEs in the client SDK, 0 npm audit findings — but the caret range should be locked down for consistency.