### PR TITLE
fix: prevent keyboard freeze when MCP notification effects fire

### DIFF
--- a/src/context/notifications.tsx
+++ b/src/context/notifications.tsx
@@ -1,6 +1,7 @@
 import type * as React from 'react';
 import { useCallback, useEffect } from 'react';
 import { useAppStateStore, useSetAppState } from 'src/state/AppState.js';
+import { logError } from '../utils/log.js';
 import type { Theme } from '../utils/theme.js';
 type Priority = 'low' | 'medium' | 'high' | 'immediate';
 type BaseNotification = {
@@ -44,6 +45,7 @@ export function useNotifications(): {
 
   // Process queue when current notification finishes or queue changes
   const processQueue = useCallback(() => {
+    try {
     setAppState(prev => {
       const next = getNext(prev.notifications.queue);
       if (prev.notifications.current !== null || !next) {
@@ -74,8 +76,12 @@ export function useNotifications(): {
         }
       };
     });
+    } catch (error) {
+      logError(error);
+    }
   }, [setAppState]);
   const addNotification = useCallback<AddNotificationFn>((notif: Notification) => {
+    try {
     // Handle immediate priority notifications
     if (notif.priority === 'immediate') {
       // Clear any existing timeout since we're showing a new immediate notification
@@ -189,8 +195,12 @@ export function useNotifications(): {
 
     // Process queue after adding the notification
     processQueue();
+    } catch (error) {
+      logError(error);
+    }
   }, [setAppState, processQueue]);
   const removeNotification = useCallback<RemoveNotificationFn>((key: string) => {
+    try {
     setAppState(prev => {
       const isCurrent = prev.notifications.current?.key === key;
       const inQueue = prev.notifications.queue.some(n => n.key === key);
@@ -210,6 +220,9 @@ export function useNotifications(): {
       };
     });
     processQueue();
+    } catch (error) {
+      logError(error);
+    }
   }, [setAppState, processQueue]);
 
   // Process queue on mount if there are notifications in the initial state.

--- a/src/hooks/notifs/useMcpConnectivityStatus.tsx
+++ b/src/hooks/notifs/useMcpConnectivityStatus.tsx
@@ -1,5 +1,6 @@
 import { c as _c } from "react-compiler-runtime";
 import * as React from 'react';
+import { logError } from '../../utils/log.js';
 import { useEffect } from 'react';
 import { useNotifications } from 'src/context/notifications.js';
 import { getIsRemoteMode } from '../../bootstrap/state.js';
@@ -23,43 +24,47 @@ export function useMcpConnectivityStatus(t0) {
   let t3;
   if ($[0] !== addNotification || $[1] !== mcpClients) {
     t2 = () => {
-      if (getIsRemoteMode()) {
-        return;
-      }
-      const failedLocalClients = mcpClients.filter(_temp);
-      const failedClaudeAiClients = mcpClients.filter(_temp2);
-      const needsAuthLocalServers = mcpClients.filter(_temp3);
-      const needsAuthClaudeAiServers = mcpClients.filter(_temp4);
-      if (failedLocalClients.length === 0 && failedClaudeAiClients.length === 0 && needsAuthLocalServers.length === 0 && needsAuthClaudeAiServers.length === 0) {
-        return;
-      }
-      if (failedLocalClients.length > 0) {
-        addNotification({
-          key: "mcp-failed",
-          jsx: <><Text color="error">{failedLocalClients.length} MCP{" "}{failedLocalClients.length === 1 ? "server" : "servers"} failed</Text><Text dimColor={true}> · /mcp</Text></>,
-          priority: "medium"
-        });
-      }
-      if (failedClaudeAiClients.length > 0) {
-        addNotification({
-          key: "mcp-claudeai-failed",
-          jsx: <><Text color="error">{failedClaudeAiClients.length} claude.ai{" "}{failedClaudeAiClients.length === 1 ? "connector" : "connectors"}{" "}unavailable</Text><Text dimColor={true}> · /mcp</Text></>,
-          priority: "medium"
-        });
-      }
-      if (needsAuthLocalServers.length > 0) {
-        addNotification({
-          key: "mcp-needs-auth",
-          jsx: <><Text color="warning">{needsAuthLocalServers.length} MCP{" "}{needsAuthLocalServers.length === 1 ? "server needs" : "servers need"}{" "}auth</Text><Text dimColor={true}> · /mcp</Text></>,
-          priority: "medium"
-        });
-      }
-      if (needsAuthClaudeAiServers.length > 0) {
-        addNotification({
-          key: "mcp-claudeai-needs-auth",
-          jsx: <><Text color="warning">{needsAuthClaudeAiServers.length} claude.ai{" "}{needsAuthClaudeAiServers.length === 1 ? "connector needs" : "connectors need"}{" "}auth</Text><Text dimColor={true}> · /mcp</Text></>,
-          priority: "medium"
-        });
+      try {
+        if (getIsRemoteMode()) {
+          return;
+        }
+        const failedLocalClients = mcpClients.filter(_temp);
+        const failedClaudeAiClients = mcpClients.filter(_temp2);
+        const needsAuthLocalServers = mcpClients.filter(_temp3);
+        const needsAuthClaudeAiServers = mcpClients.filter(_temp4);
+        if (failedLocalClients.length === 0 && failedClaudeAiClients.length === 0 && needsAuthLocalServers.length === 0 && needsAuthClaudeAiServers.length === 0) {
+          return;
+        }
+        if (failedLocalClients.length > 0) {
+          addNotification({
+            key: "mcp-failed",
+            jsx: <><Text color="error">{failedLocalClients.length} MCP{" "}{failedLocalClients.length === 1 ? "server" : "servers"} failed</Text><Text dimColor={true}> · /mcp</Text></>,
+            priority: "medium"
+          });
+        }
+        if (failedClaudeAiClients.length > 0) {
+          addNotification({
+            key: "mcp-claudeai-failed",
+            jsx: <><Text color="error">{failedClaudeAiClients.length} claude.ai{" "}{failedClaudeAiClients.length === 1 ? "connector" : "connectors"}{" "}unavailable</Text><Text dimColor={true}> · /mcp</Text></>,
+            priority: "medium"
+          });
+        }
+        if (needsAuthLocalServers.length > 0) {
+          addNotification({
+            key: "mcp-needs-auth",
+            jsx: <><Text color="warning">{needsAuthLocalServers.length} MCP{" "}{needsAuthLocalServers.length === 1 ? "server needs" : "servers need"}{" "}auth</Text><Text dimColor={true}> · /mcp</Text></>,
+            priority: "medium"
+          });
+        }
+        if (needsAuthClaudeAiServers.length > 0) {
+          addNotification({
+            key: "mcp-claudeai-needs-auth",
+            jsx: <><Text color="warning">{needsAuthClaudeAiServers.length} claude.ai{" "}{needsAuthClaudeAiServers.length === 1 ? "connector needs" : "connectors need"}{" "}auth</Text><Text dimColor={true}> · /mcp</Text></>,
+            priority: "medium"
+          });
+        }
+      } catch (error) {
+        logError(error);
       }
     };
     t3 = [addNotification, mcpClients];

--- a/src/ink/reconciler.ts
+++ b/src/ink/reconciler.ts
@@ -433,6 +433,8 @@ const reconciler = createReconciler<
   scheduleTimeout: setTimeout,
   cancelTimeout: clearTimeout,
   noTimeout: -1,
+  supportsMicrotasks: true,
+  scheduleMicrotask: queueMicrotask,
   getCurrentUpdatePriority: () => dispatcher.currentUpdatePriority,
   beforeActiveInstanceBlur() {},
   afterActiveInstanceBlur() {},

--- a/src/utils/context.test.ts
+++ b/src/utils/context.test.ts
@@ -12,9 +12,17 @@ const originalEnv = {
 }
 
 afterEach(() => {
-  process.env.CLAUDE_CODE_USE_OPENAI = originalEnv.CLAUDE_CODE_USE_OPENAI
-  process.env.CLAUDE_CODE_MAX_OUTPUT_TOKENS =
-    originalEnv.CLAUDE_CODE_MAX_OUTPUT_TOKENS
+  if (originalEnv.CLAUDE_CODE_USE_OPENAI === undefined) {
+    delete process.env.CLAUDE_CODE_USE_OPENAI
+  } else {
+    process.env.CLAUDE_CODE_USE_OPENAI = originalEnv.CLAUDE_CODE_USE_OPENAI
+  }
+  if (originalEnv.CLAUDE_CODE_MAX_OUTPUT_TOKENS === undefined) {
+    delete process.env.CLAUDE_CODE_MAX_OUTPUT_TOKENS
+  } else {
+    process.env.CLAUDE_CODE_MAX_OUTPUT_TOKENS =
+      originalEnv.CLAUDE_CODE_MAX_OUTPUT_TOKENS
+  }
 })
 
 test('deepseek-chat uses provider-specific context and output caps', () => {


### PR DESCRIPTION
## Problem

Keyboard input freezes completely after the **"N MCP server(s) need auth"** notification appears. Users report that once this notification fires, the CLI becomes completely unresponsive to keypresses — they cannot type, use arrow keys, or exit with Ctrl+C without killing the terminal.

Reported in: #169, #205, #77

## Root Cause

Three related issues, all in the same code path:

**1. Missing `supportsMicrotasks` in the reconciler (primary cause)**

React 19's reconciler checks for `supportsMicrotasks` in the host config to decide how to schedule passive effect flushes. Without it, state updates dispatched from inside `useEffect` callbacks (like the MCP auth notification) are not flushed via microtask — they get silently dropped. This corrupts React's internal `executionContext`, causing it to permanently skip all future state updates, including the ones that drive keyboard input handling.

**2. No error boundary in `useMcpConnectivityStatus`**

If anything throws inside the MCP connectivity effect, the exception propagates up into `flushPassiveEffects`. React does not catch this — it leaves `executionContext` in a permanently dirty state, which has the same freeze effect.

**3. No error boundary in `notifications.tsx`**

`addNotification`, `removeNotification`, and `processQueue` are called from 12+ notification hooks inside passive effects. Any uncaught throw from any of them triggers the same `executionContext` corruption.

## Fix

| File | Change |
|------|--------|
| `src/ink/reconciler.ts` | Add `supportsMicrotasks: true` + `scheduleMicrotask: queueMicrotask` to the reconciler host config |
| `src/hooks/notifs/useMcpConnectivityStatus.tsx` | Wrap MCP auth notification effect body in `try/catch` with `logError` |
| `src/context/notifications.tsx` | Wrap `addNotification`, `removeNotification`, `processQueue` in `try/catch` with `logError` |
| `src/utils/context.test.ts` | Fix pre-existing test isolation bug: assigning `undefined` to `process.env` created the string `"undefined"`, polluting env for subsequent test files |

## Why This Approach

This is a two-layer fix:

- **Layer 1 (`supportsMicrotasks`)** fixes the root cause — React 19 now correctly schedules passive effect flushes so state updates are never silently dropped.
- **Layer 2 (try/catch)** is a defensive guard — even if an unexpected error occurs inside a notification effect in the future, React's internal state stays clean and the CLI remains responsive.

Both layers together make the notification path robust against the freeze.

## Testing

- Build: `bun run build` → ✓ `dist/cli.mjs`
- Tests: `bun test` → 139/139 pass

**Manual test:** Configure a failing MCP server in settings (command: `nonexistent-binary`), start the CLI, wait for the "1 MCP server(s) need auth" notification, then verify keyboard input still works normally.

## Related

Complementary to #210 (which adds the try/catch layer). This PR adds the `supportsMicrotasks` fix which addresses the primary cause.