### PR TITLE
Polish TUI and fix Codex tool call streaming

### DIFF
--- a/scripts/launch-codex.sh
+++ b/scripts/launch-codex.sh
@@ -1,0 +1,30 @@
+#!/bin/zsh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+cd "$REPO_DIR"
+
+export CLAUDE_CODE_USE_OPENAI=1
+export OPENAI_MODEL="${OPENAI_MODEL:-codexplan}"
+
+if ! command -v openclaude >/dev/null 2>&1; then
+  if [ ! -f "$REPO_DIR/dist/cli.mjs" ]; then
+    echo "Local build not found at $REPO_DIR/dist/cli.mjs"
+    echo "Run: npx bun run build"
+    exit 1
+  fi
+fi
+
+echo "Launching OpenClaude from: $REPO_DIR"
+echo "Using Codex OAuth from: $HOME/.codex/auth.json"
+echo "Model: $OPENAI_MODEL"
+echo
+
+if [ -f "$REPO_DIR/dist/cli.mjs" ]; then
+  exec node "$REPO_DIR/dist/cli.mjs" "$@"
+fi
+
+exec openclaude "$@"

--- a/scripts/stop-openclaude.sh
+++ b/scripts/stop-openclaude.sh
@@ -1,0 +1,42 @@
+#!/bin/zsh
+
+set -euo pipefail
+
+patterns=(
+  'openclaude'
+  'dist/cli.mjs'
+  'bin/openclaude'
+)
+
+pids=()
+
+for pattern in "${patterns[@]}"; do
+  while IFS= read -r pid; do
+    [[ -n "${pid:-}" ]] && pids+=("$pid")
+  done < <(pgrep -f "$pattern" 2>/dev/null || true)
+done
+
+if [[ ${#pids[@]} -eq 0 ]]; then
+  echo "No OpenClaude processes found."
+  exit 0
+fi
+
+unique_pids=($(printf "%s\n" "${pids[@]}" | sort -u))
+
+echo "Stopping OpenClaude processes: ${unique_pids[*]}"
+kill "${unique_pids[@]}" 2>/dev/null || true
+sleep 1
+
+remaining=()
+for pid in "${unique_pids[@]}"; do
+  if kill -0 "$pid" 2>/dev/null; then
+    remaining+=("$pid")
+  fi
+done
+
+if [[ ${#remaining[@]} -gt 0 ]]; then
+  echo "Force stopping remaining processes: ${remaining[*]}"
+  kill -9 "${remaining[@]}" 2>/dev/null || true
+fi
+
+echo "OpenClaude stop command finished."

--- a/src/components/LogoV2/CondensedLogo.tsx
+++ b/src/components/LogoV2/CondensedLogo.tsx
@@ -101,7 +101,7 @@ export function CondensedLogo() {
   } else {
     t6 = $[10];
   }
-  const t6a = 'Open terminal for any LLM';
+  const t6a = 'Codex-ready terminal for any LLM';
   let t7;
   if ($[11] !== shouldSplit || $[12] !== truncatedBilling || $[13] !== truncatedModel) {
     t7 = shouldSplit ? <><Text><Text color="inactive">Model</Text><Text dimColor={true}>  {truncatedModel}</Text></Text><Text><Text color="inactive">Mode</Text><Text dimColor={true}>   {truncatedBilling}</Text></Text></> : <Text><Text color="inactive">Model</Text><Text dimColor={true}>  {truncatedModel} · {truncatedBilling}</Text></Text>;
@@ -141,7 +141,7 @@ export function CondensedLogo() {
   }
   let t12;
   if ($[23] !== t10 || $[24] !== t11 || $[25] !== t6 || $[26] !== t7 || $[27] !== t9) {
-    t12 = <OffscreenFreeze><Box borderStyle="round" borderColor="inactive" paddingX={2} paddingY={0} flexDirection="row" gap={2} alignItems="center"><Box flexDirection="column" alignItems="center"><Text color="inactive">•</Text>{t4}<Text color="inactive">•</Text></Box><Box flexDirection="column"><Text bold={true}>OPEN CLAUDE</Text><Text dimColor={true}>{t6a}</Text><Box marginTop={1}>{t6}</Box>{t7}{t9}{t10}{t11}</Box></Box></OffscreenFreeze>;
+    t12 = <OffscreenFreeze><Box borderStyle="round" borderColor="promptBorder" paddingX={2} paddingY={1} flexDirection="row" gap={2} alignItems="center"><Box flexDirection="column" alignItems="center"><Text color="inactive">·</Text>{t4}<Text color="inactive">·</Text></Box><Box flexDirection="column"><Text bold={true}>OPEN CLAUDE</Text><Text color="inactive">{t6a}</Text><Box marginTop={1}>{t6}</Box>{t7}{t9}{t10}{t11}</Box></Box></OffscreenFreeze>;
     $[23] = t10;
     $[24] = t11;
     $[25] = t6;

--- a/src/components/MessageResponse.tsx
+++ b/src/components/MessageResponse.tsx
@@ -19,7 +19,7 @@ export function MessageResponse(t0) {
   }
   let t1;
   if ($[0] === Symbol.for("react.memo_cache_sentinel")) {
-    t1 = <NoSelect fromLeftEdge={true} flexShrink={0}><Text dimColor={true}>{"  "}⎿  </Text></NoSelect>;
+    t1 = <NoSelect fromLeftEdge={true} flexShrink={0}><Text color="inactive">{"  "}│  </Text></NoSelect>;
     $[0] = t1;
   } else {
     t1 = $[0];

--- a/src/components/PromptInput/PromptInput.tsx
+++ b/src/components/PromptInput/PromptInput.tsx
@@ -2326,13 +2326,18 @@ function getInitialPasteId(messages: Message[]): number {
   return maxId + 1;
 }
 function buildBorderText(showFastIcon: boolean, showFastIconHint: boolean, fastModeCooldown: boolean): BorderTextOptions | undefined {
-  if (!showFastIcon) return undefined;
+  if (!showFastIcon) return {
+    content: ` ${chalk.dim('prompt')} `,
+    position: 'top',
+    align: 'start',
+    offset: 1
+  };
   const fastSeg = showFastIconHint ? `${getFastIconString(true, fastModeCooldown)} ${chalk.dim('/fast')}` : getFastIconString(true, fastModeCooldown);
   return {
-    content: ` ${fastSeg} `,
+    content: ` ${chalk.dim('prompt')}  ${fastSeg} `,
     position: 'top',
-    align: 'end',
-    offset: 0
+    align: 'start',
+    offset: 1
   };
 }
 export default React.memo(PromptInput);

--- a/src/components/PromptInput/PromptInputFooter.tsx
+++ b/src/components/PromptInput/PromptInputFooter.tsx
@@ -136,7 +136,8 @@ function PromptInputFooter({
     return <PromptInputHelpMenu dimColor={true} fixedWidth={true} paddingX={2} />;
   }
   return <>
-      <Box flexDirection={isNarrow ? 'column' : 'row'} justifyContent={isNarrow ? 'flex-start' : 'space-between'} paddingX={2} gap={isNarrow ? 0 : 1}>
+      <Box borderStyle="single" borderTop={true} borderBottom={false} borderLeft={false} borderRight={false} borderColor="promptBorder" paddingX={1}>
+        <Box flexDirection={isNarrow ? 'column' : 'row'} justifyContent={isNarrow ? 'flex-start' : 'space-between'} paddingX={1} gap={isNarrow ? 0 : 1}>
         <Box flexDirection="column" flexShrink={isNarrow ? 0 : 1}>
           {mode === 'prompt' && !isShort && !exitMessage.show && !isPasting && statusLineShouldDisplay(settings) && <StatusLine messagesRef={messagesRef} lastAssistantMessageId={lastAssistantMessageId} vimMode={vimMode} />}
           <PromptInputFooterLeftSide exitMessage={exitMessage} vimMode={vimMode} mode={mode} toolPermissionContext={toolPermissionContext} suppressHint={suppressHint} isLoading={isLoading} tasksSelected={pillSelected} teamsSelected={teamsSelected} teammateFooterIndex={teammateFooterIndex} tmuxSelected={tmuxSelected} isPasting={isPasting} isSearching={isSearching} historyQuery={historyQuery} setHistoryQuery={setHistoryQuery} historyFailedMatch={historyFailedMatch} onOpenTasksDialog={onOpenTasksDialog} />
@@ -145,6 +146,7 @@ function PromptInputFooter({
           {isFullscreen ? null : <Notifications apiKeyStatus={apiKeyStatus} autoUpdaterResult={autoUpdaterResult} debug={debug} isAutoUpdating={isAutoUpdating} verbose={verbose} messages={messages} onAutoUpdaterResult={onAutoUpdaterResult} onChangeIsUpdating={onChangeIsUpdating} ideSelection={ideSelection} mcpClients={mcpClients} isInputWrapped={isInputWrapped} isNarrow={isNarrow} />}
           {"external" === 'ant' && isUndercover() && <Text dimColor>undercover</Text>}
           <BridgeStatusIndicator bridgeSelected={bridgeSelected} />
+        </Box>
         </Box>
       </Box>
       {"external" === 'ant' && <CoordinatorTaskPanel />}

--- a/src/components/StartupScreen.ts
+++ b/src/components/StartupScreen.ts
@@ -1,5 +1,5 @@
 /**
- * OpenClaude startup screen — filled-block text logo with sunset gradient.
+ * OpenClaude startup screen with a restrained gradient logo and compact runtime info.
  * Called once at CLI startup before the Ink UI renders.
  *
  * Addresses: https://github.com/Gitlawb/openclaude/issues/55
@@ -177,7 +177,7 @@ export function printStartupScreen(): void {
   out.push('')
 
   // Tagline
-  out.push(`  ${rgb(...ACCENT)}\u2726${RESET} ${rgb(...CREAM)}Any model. Every tool. Zero limits.${RESET} ${rgb(...ACCENT)}\u2726${RESET}`)
+  out.push(`  ${rgb(...ACCENT)}\u2726${RESET} ${rgb(...CREAM)}Any model. Native tools. Codex-ready.${RESET} ${rgb(...ACCENT)}\u2726${RESET}`)
   out.push('')
 
   // Provider info box
@@ -201,8 +201,8 @@ export function printStartupScreen(): void {
 
   const sC: RGB = p.isLocal ? [130, 175, 130] : ACCENT
   const sL = p.isLocal ? 'local' : 'cloud'
-  const sRow = ` ${rgb(...sC)}\u25cf${RESET} ${DIM}${rgb(...DIMCOL)}${sL}${RESET}    ${DIM}${rgb(...DIMCOL)}Ready \u2014 type ${RESET}${rgb(...ACCENT)}/help${RESET}${DIM}${rgb(...DIMCOL)} to begin${RESET}`
-  const sLen = ` \u25cf ${sL}    Ready \u2014 type /help to begin`.length
+  const sRow = ` ${rgb(...sC)}\u25cf${RESET} ${DIM}${rgb(...DIMCOL)}${sL}${RESET}    ${DIM}${rgb(...DIMCOL)}Ready. Type ${RESET}${rgb(...ACCENT)}/help${RESET}${DIM}${rgb(...DIMCOL)} to begin.${RESET}`
+  const sLen = ` \u25cf ${sL}    Ready. Type /help to begin.`.length
   out.push(boxRow(sRow, W, sLen))
 
   out.push(`${rgb(...BORDER)}\u255a${'\u2550'.repeat(W - 2)}\u255d${RESET}`)

--- a/src/components/StatusLine.tsx
+++ b/src/components/StatusLine.tsx
@@ -311,9 +311,13 @@ function StatusLineInner({
   // a row from ScrollBox and shifts content. Reserve the row while loading
   // (same trick as PromptInputFooterLeftSide).
   return <Box paddingX={paddingX} gap={2}>
-      {statusLineText ? <Text dimColor wrap="truncate">
-          <Ansi>{statusLineText}</Ansi>
-        </Text> : isFullscreenEnvEnabled() ? <Text> </Text> : null}
+      {statusLineText ? <Box borderStyle="round" borderColor="inactive" paddingX={1} flexDirection="row">
+          <Text color="inactive">status</Text>
+          <Text color="inactive">  </Text>
+          <Text wrap="truncate">
+            <Ansi>{statusLineText}</Ansi>
+          </Text>
+        </Box> : isFullscreenEnvEnabled() ? <Text> </Text> : null}
     </Box>;
 }
 

--- a/src/components/messages/AssistantToolUseMessage.tsx
+++ b/src/components/messages/AssistantToolUseMessage.tsx
@@ -207,7 +207,7 @@ export function AssistantToolUseMessage(t0) {
   }
   let t10;
   if ($[42] !== renderedToolUseMessage) {
-    t10 = renderedToolUseMessage !== "" && <Box flexWrap="nowrap"><Text>({renderedToolUseMessage})</Text></Box>;
+    t10 = renderedToolUseMessage !== "" && <Box flexWrap="nowrap"><Text color="inactive">({renderedToolUseMessage})</Text></Box>;
     $[42] = renderedToolUseMessage;
     $[43] = t10;
   } else {
@@ -225,7 +225,7 @@ export function AssistantToolUseMessage(t0) {
   }
   let t12;
   if ($[48] !== t10 || $[49] !== t11 || $[50] !== t6 || $[51] !== t7 || $[52] !== t9) {
-    t12 = <Box flexDirection="row" flexWrap="nowrap" minWidth={t6}>{t7}{t9}{t10}{t11}</Box>;
+    t12 = <Box flexDirection="row" flexWrap="nowrap" minWidth={t6} gap={1}>{t7}{t9}{t10}{t11}</Box>;
     $[48] = t10;
     $[49] = t11;
     $[50] = t6;
@@ -272,7 +272,7 @@ export function AssistantToolUseMessage(t0) {
   }
   let t15;
   if ($[73] !== t12 || $[74] !== t13 || $[75] !== t14) {
-    t15 = <Box flexDirection="column">{t12}{t13}{t14}</Box>;
+    t15 = <Box flexDirection="column" borderStyle="round" borderColor="promptBorder" paddingX={1}>{t12}{t13}{t14}</Box>;
     $[73] = t12;
     $[74] = t13;
     $[75] = t14;

--- a/src/components/messages/SystemAPIErrorMessage.tsx
+++ b/src/components/messages/SystemAPIErrorMessage.tsx
@@ -114,7 +114,10 @@ export function SystemAPIErrorMessage(t0) {
   }
   let t11;
   if ($[24] !== T1 || $[25] !== t10 || $[26] !== t6 || $[27] !== t7 || $[28] !== t8) {
-    t11 = <T1 flexDirection={t6}>{t7}{t8}{t10}</T1>;
+    t11 = <T1 flexDirection="column" borderStyle="round" borderColor="error" paddingX={1}>
+        <Text color="error" bold={true}>API request failed</Text>
+        <T1 flexDirection={t6}>{t7}{t8}{t10}</T1>
+      </T1>;
     $[24] = T1;
     $[25] = t10;
     $[26] = t6;

--- a/src/services/api/codexShim.test.ts
+++ b/src/services/api/codexShim.test.ts
@@ -45,6 +45,23 @@ async function collectStreamEventTypes(responseText: string): Promise<string[]> 
   return events
 }
 
+async function collectStreamEvents(
+  responseText: string,
+): Promise<AnthropicStreamEvent[]> {
+  const stream = new ReadableStream({
+    start(controller) {
+      controller.enqueue(new TextEncoder().encode(responseText))
+      controller.close()
+    },
+  })
+
+  const events: AnthropicStreamEvent[] = []
+  for await (const event of codexStreamToAnthropic(new Response(stream), 'gpt-5.4')) {
+    events.push(event)
+  }
+  return events
+}
+
 describe('Codex provider config', () => {
   test('resolves codexplan alias to Codex transport with reasoning', () => {
     const resolved = resolveProviderRequest({ model: 'codexplan' })
@@ -318,5 +335,30 @@ describe('Codex request translation', () => {
       'message_delta',
       'message_stop',
     ])
+  })
+
+  test('flushes final function-call arguments from output_item.done', async () => {
+    const responseText = [
+      'event: response.output_item.added',
+      'data: {"type":"response.output_item.added","item":{"id":"fc_1","type":"function_call","status":"in_progress","call_id":"call_1","name":"Bash","arguments":""},"output_index":0,"sequence_number":0}',
+      '',
+      'event: response.output_item.done',
+      'data: {"type":"response.output_item.done","item":{"id":"fc_1","type":"function_call","status":"completed","call_id":"call_1","name":"Bash","arguments":"{\\"command\\":\\"ls -la\\"}"},"output_index":0,"sequence_number":1}',
+      '',
+      'event: response.completed',
+      'data: {"type":"response.completed","response":{"id":"resp_1","status":"completed","model":"gpt-5.4","output":[{"type":"function_call","call_id":"call_1","name":"Bash","arguments":"{\\"command\\":\\"ls -la\\"}"}],"usage":{"input_tokens":2,"output_tokens":1}},"sequence_number":2}',
+      '',
+    ].join('\n')
+
+    const events = await collectStreamEvents(responseText)
+    const partialJson = events
+      .filter(
+        event =>
+          event.type === 'content_block_delta' &&
+          event.delta?.type === 'input_json_delta',
+      )
+      .map(event => event.delta?.partial_json)
+
+    expect(partialJson).toEqual(['{"command":"ls -la"}'])
   })
 })

--- a/src/services/api/codexShim.ts
+++ b/src/services/api/codexShim.ts
@@ -675,7 +675,7 @@ export async function* codexStreamToAnthropic(
   const messageId = makeMessageId()
   const toolBlocksByItemId = new Map<
     string,
-    { index: number; toolUseId: string }
+    { index: number; toolUseId: string; jsonBuffer: string }
   >()
   let activeTextBlockIndex: number | null = null
   let nextContentBlockIndex = 0
@@ -727,6 +727,7 @@ export async function* codexStreamToAnthropic(
         toolBlocksByItemId.set(String(item.id ?? toolUseId), {
           index: blockIndex,
           toolUseId,
+          jsonBuffer: '',
         })
         sawToolUse = true
 
@@ -742,6 +743,10 @@ export async function* codexStreamToAnthropic(
         }
 
         if (item.arguments) {
+          const toolBlock = toolBlocksByItemId.get(String(item.id ?? toolUseId))
+          if (toolBlock) {
+            toolBlock.jsonBuffer += item.arguments
+          }
           yield {
             type: 'content_block_delta',
             index: blockIndex,
@@ -780,6 +785,7 @@ export async function* codexStreamToAnthropic(
     if (event.event === 'response.function_call_arguments.delta') {
       const toolBlock = toolBlocksByItemId.get(String(payload.item_id ?? ''))
       if (toolBlock) {
+        toolBlock.jsonBuffer += payload.delta ?? ''
         yield {
           type: 'content_block_delta',
           index: toolBlock.index,
@@ -797,6 +803,22 @@ export async function* codexStreamToAnthropic(
       if (item?.type === 'function_call') {
         const toolBlock = toolBlocksByItemId.get(String(item.id ?? ''))
         if (toolBlock) {
+          const finalArgs =
+            typeof item.arguments === 'string' ? item.arguments : ''
+          if (finalArgs.length > toolBlock.jsonBuffer.length) {
+            const remainder = finalArgs.slice(toolBlock.jsonBuffer.length)
+            toolBlock.jsonBuffer = finalArgs
+            if (remainder) {
+              yield {
+                type: 'content_block_delta',
+                index: toolBlock.index,
+                delta: {
+                  type: 'input_json_delta',
+                  partial_json: remainder,
+                },
+              }
+            }
+          }
           yield {
             type: 'content_block_stop',
             index: toolBlock.index,


### PR DESCRIPTION
## Summary
- fix Codex/OpenAI tool-call streaming so final arguments from output item completion events are preserved
- polish the TUI shell with cleaner prompt, status, error, tool, and startup presentation
- add local launch and stop scripts for the patched Codex OAuth workflow

## Testing
- npx bun run build
- npx bun test src/services/api/codexShim.test.ts
- CLAUDE_CODE_USE_OPENAI=1 OPENAI_MODEL=codexplan node dist/cli.mjs -p --bare --permission-mode bypassPermissions "Reply with exactly: facelift smoke ok"
- CLAUDE_CODE_USE_OPENAI=1 OPENAI_MODEL=codexplan node dist/cli.mjs -p --bare --permission-mode bypassPermissions --verbose --output-format stream-json "Use Bash to print the current directory name only."