### PR TITLE
fix: correct model-facing identity prompts

### DIFF
--- a/src/constants/promptIdentity.test.ts
+++ b/src/constants/promptIdentity.test.ts
@@ -1,0 +1,48 @@
+import { afterEach, expect, test } from 'bun:test'
+
+import { getSystemPrompt, DEFAULT_AGENT_PROMPT } from './prompts.js'
+import { CLI_SYSPROMPT_PREFIXES, getCLISyspromptPrefix } from './system.js'
+import { GENERAL_PURPOSE_AGENT } from '../tools/AgentTool/built-in/generalPurposeAgent.js'
+import { EXPLORE_AGENT } from '../tools/AgentTool/built-in/exploreAgent.js'
+
+const originalSimpleEnv = process.env.CLAUDE_CODE_SIMPLE
+
+afterEach(() => {
+  process.env.CLAUDE_CODE_SIMPLE = originalSimpleEnv
+})
+
+test('CLI identity prefixes describe OpenClaude instead of Claude Code', () => {
+  expect(getCLISyspromptPrefix()).toContain('OpenClaude')
+  expect(getCLISyspromptPrefix()).not.toContain("Anthropic's official CLI for Claude")
+
+  for (const prefix of CLI_SYSPROMPT_PREFIXES) {
+    expect(prefix).toContain('OpenClaude')
+    expect(prefix).not.toContain("Anthropic's official CLI for Claude")
+  }
+})
+
+test('simple mode identity describes OpenClaude instead of Claude Code', async () => {
+  process.env.CLAUDE_CODE_SIMPLE = '1'
+
+  const prompt = await getSystemPrompt([], 'gpt-4o')
+
+  expect(prompt[0]).toContain('OpenClaude')
+  expect(prompt[0]).not.toContain("Anthropic's official CLI for Claude")
+})
+
+test('built-in agent prompts describe OpenClaude instead of Claude Code', () => {
+  expect(DEFAULT_AGENT_PROMPT).toContain('OpenClaude')
+  expect(DEFAULT_AGENT_PROMPT).not.toContain("Anthropic's official CLI for Claude")
+
+  const generalPrompt = GENERAL_PURPOSE_AGENT.getSystemPrompt({
+    toolUseContext: { options: {} as never },
+  })
+  expect(generalPrompt).toContain('OpenClaude')
+  expect(generalPrompt).not.toContain("Anthropic's official CLI for Claude")
+
+  const explorePrompt = EXPLORE_AGENT.getSystemPrompt({
+    toolUseContext: { options: {} as never },
+  })
+  expect(explorePrompt).toContain('OpenClaude')
+  expect(explorePrompt).not.toContain("Anthropic's official CLI for Claude")
+})

--- a/src/constants/prompts.ts
+++ b/src/constants/prompts.ts
@@ -449,7 +449,7 @@ export async function getSystemPrompt(
 ): Promise<string[]> {
   if (isEnvTruthy(process.env.CLAUDE_CODE_SIMPLE)) {
     return [
-      `You are Claude Code, Anthropic's official CLI for Claude.\n\nCWD: ${getCwd()}\nDate: ${getSessionStartDate()}`,
+      `You are OpenClaude, an open-source fork of Claude Code.\n\nCWD: ${getCwd()}\nDate: ${getSessionStartDate()}`,
     ]
   }
 
@@ -755,7 +755,7 @@ export function getUnameSR(): string {
   return `${osType()} ${osRelease()}`
 }
 
-export const DEFAULT_AGENT_PROMPT = `You are an agent for Claude Code, Anthropic's official CLI for Claude. Given the user's message, you should use the tools available to complete the task. Complete the task fully—don't gold-plate, but don't leave it half-done. When you complete the task, respond with a concise report covering what was done and any key findings — the caller will relay this to the user, so it only needs the essentials.`
+export const DEFAULT_AGENT_PROMPT = `You are an agent for OpenClaude, an open-source fork of Claude Code. Given the user's message, you should use the tools available to complete the task. Complete the task fully—don't gold-plate, but don't leave it half-done. When you complete the task, respond with a concise report covering what was done and any key findings — the caller will relay this to the user, so it only needs the essentials.`
 
 export async function enhanceSystemPromptWithEnvDetails(
   existingSystemPrompt: string[],

--- a/src/constants/system.ts
+++ b/src/constants/system.ts
@@ -7,9 +7,12 @@ import { isEnvDefinedFalsy } from '../utils/envUtils.js'
 import { getAPIProvider } from '../utils/model/providers.js'
 import { getWorkload } from '../utils/workloadContext.js'
 
-const DEFAULT_PREFIX = `You are Claude Code, Anthropic's official CLI for Claude.`
-const AGENT_SDK_CLAUDE_CODE_PRESET_PREFIX = `You are Claude Code, Anthropic's official CLI for Claude, running within the Claude Agent SDK.`
-const AGENT_SDK_PREFIX = `You are a Claude agent, built on Anthropic's Claude Agent SDK.`
+const DEFAULT_PREFIX =
+  `You are OpenClaude, an open-source fork of Claude Code.`
+const AGENT_SDK_CLAUDE_CODE_PRESET_PREFIX =
+  `You are OpenClaude, an open-source fork of Claude Code, running within the Claude Agent SDK.`
+const AGENT_SDK_PREFIX =
+  `You are a Claude agent running in OpenClaude, built on the Claude Agent SDK.`
 
 const CLI_SYSPROMPT_PREFIX_VALUES = [
   DEFAULT_PREFIX,

--- a/src/tools/AgentTool/built-in/exploreAgent.ts
+++ b/src/tools/AgentTool/built-in/exploreAgent.ts
@@ -21,7 +21,7 @@ function getExploreSystemPrompt(): string {
     ? `- Use \`grep\` via ${BASH_TOOL_NAME} for searching file contents with regex`
     : `- Use ${GREP_TOOL_NAME} for searching file contents with regex`
 
-  return `You are a file search specialist for Claude Code, Anthropic's official CLI for Claude. You excel at thoroughly navigating and exploring codebases.
+  return `You are a file search specialist for OpenClaude, an open-source fork of Claude Code. You excel at thoroughly navigating and exploring codebases.
 
 === CRITICAL: READ-ONLY MODE - NO FILE MODIFICATIONS ===
 This is a READ-ONLY exploration task. You are STRICTLY PROHIBITED from:

--- a/src/tools/AgentTool/built-in/generalPurposeAgent.ts
+++ b/src/tools/AgentTool/built-in/generalPurposeAgent.ts
@@ -1,6 +1,6 @@
 import type { BuiltInAgentDefinition } from '../loadAgentsDir.js'
 
-const SHARED_PREFIX = `You are an agent for Claude Code, Anthropic's official CLI for Claude. Given the user's message, you should use the tools available to complete the task. Complete the task fully—don't gold-plate, but don't leave it half-done.`
+const SHARED_PREFIX = `You are an agent for OpenClaude, an open-source fork of Claude Code. Given the user's message, you should use the tools available to complete the task. Complete the task fully—don't gold-plate, but don't leave it half-done.`
 
 const SHARED_GUIDELINES = `Your strengths:
 - Searching for code, configurations, and patterns across large codebases


### PR DESCRIPTION
## Summary
- fix model-facing identity strings that still describe the runtime as `Claude Code`
- update the main CLI/system prompt prefix, simple mode identity, and built-in agent identity prompts
- add focused regression coverage for the prompt identity surface

## Why
Issue #219 is a narrow runtime prompt-branding bug: OpenClaude still tells the model that it is `Claude Code`, so `who are you?` responses can reflect that old identity.

This PR intentionally stays scoped to model-facing identity strings only. It does **not** attempt a broad repo-wide rename.

## Testing
- `bun test src/constants/promptIdentity.test.ts`
- `bun -e "import { getCLISyspromptPrefix } from './src/constants/system.ts'; console.log(getCLISyspromptPrefix({ isNonInteractive: false, hasAppendSystemPrompt: false }));"`

## Notes
- `bun run smoke` is currently blocked on this checkout by an unrelated unresolved `@mendable/firecrawl-js` dependency during build, so I did not use it as a gate for this PR.

## Contributor
X handle: @crypt0beast