### PR TITLE
chore: patch dependabot vulnerabilities

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -36,7 +36,7 @@
         "cli-highlight": "2.1.11",
         "code-excerpt": "4.0.0",
         "commander": "12.1.0",
-        "diff": "7.0.0",
+        "diff": "8.0.3",
         "emoji-regex": "10.6.0",
         "env-paths": "3.0.0",
         "execa": "9.6.1",
@@ -49,7 +49,7 @@
         "ignore": "7.0.5",
         "indent-string": "5.0.0",
         "jsonc-parser": "3.3.1",
-        "lodash-es": "4.17.23",
+        "lodash-es": "4.18.0",
         "lru-cache": "11.2.7",
         "marked": "15.0.12",
         "p-map": "7.0.4",
@@ -436,7 +436,7 @@
 
     "depd": ["depd@2.0.0", "", {}, "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="],
 
-    "diff": ["diff@7.0.0", "", {}, "sha512-PJWHUb1RFevKCwaFA9RlG5tCd+FO5iRh9A8HEtkmBH2Li03iJriB6m6JIN4rGz3K3JLawI7/veA1xzRKP6ISBw=="],
+    "diff": ["diff@8.0.3", "", {}, "sha512-qejHi7bcSD4hQAZE0tNAawRK1ZtafHDmMTMkrrIGgSLl7hTnQHmKCeB45xAcbfTqK2zowkM3j3bHt/4b/ARbYQ=="],
 
     "dijkstrajs": ["dijkstrajs@1.0.3", "", {}, "sha512-qiSlmBq9+BCdCA/L46dw8Uy93mloxsPSbwnm5yrKn2vMPiy8KyAskTF6zuV/j5BMsmOGZDPs7KjU+mjb670kfA=="],
 
@@ -596,7 +596,7 @@
 
     "locate-path": ["locate-path@5.0.0", "", { "dependencies": { "p-locate": "^4.1.0" } }, "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g=="],
 
-    "lodash-es": ["lodash-es@4.17.23", "", {}, "sha512-kVI48u3PZr38HdYz98UmfPnXl2DXrpdctLrFLCd3kOx1xUkOmpFPx7gCWWM5MPkL/fD8zb+Ph0QzjGFs4+hHWg=="],
+    "lodash-es": ["lodash-es@4.18.0", "", {}, "sha512-koAgswPPA+UTaPN64Etp+PGP+WT6oqOS2NMi5yDkMaiGw9qY4VxQbQF0mtKMyr4BlTznWyzePV5UpECTJQmSUA=="],
 
     "lodash.camelcase": ["lodash.camelcase@4.3.0", "", {}, "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA=="],
 
@@ -823,6 +823,8 @@
     "zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
     "zod-to-json-schema": ["zod-to-json-schema@3.25.2", "", { "peerDependencies": { "zod": "^3.25.28 || ^4" } }, "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA=="],
+
+    "@anthropic-ai/sandbox-runtime/lodash-es": ["lodash-es@4.17.23", "", {}, "sha512-kVI48u3PZr38HdYz98UmfPnXl2DXrpdctLrFLCd3kOx1xUkOmpFPx7gCWWM5MPkL/fD8zb+Ph0QzjGFs4+hHWg=="],
 
     "@aws-crypto/crc32/@aws-crypto/util": ["@aws-crypto/util@5.2.0", "", { "dependencies": { "@aws-sdk/types": "^3.222.0", "@smithy/util-utf8": "^2.0.0", "tslib": "^2.6.2" } }, "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ=="],
 

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "@anthropic-ai/vertex-sdk": "0.14.4",
     "@commander-js/extra-typings": "12.1.0",
     "@growthbook/growthbook": "1.6.5",
+    "@mendable/firecrawl-js": "4.18.1",
     "@modelcontextprotocol/sdk": "1.29.0",
     "@opentelemetry/api": "1.9.1",
     "@opentelemetry/api-logs": "0.214.0",
@@ -73,7 +74,7 @@
     "cli-highlight": "2.1.11",
     "code-excerpt": "4.0.0",
     "commander": "12.1.0",
-    "diff": "7.0.0",
+    "diff": "8.0.3",
     "emoji-regex": "10.6.0",
     "env-paths": "3.0.0",
     "execa": "9.6.1",
@@ -86,7 +87,7 @@
     "ignore": "7.0.5",
     "indent-string": "5.0.0",
     "jsonc-parser": "3.3.1",
-    "lodash-es": "4.17.23",
+    "lodash-es": "4.18.0",
     "lru-cache": "11.2.7",
     "marked": "15.0.12",
     "p-map": "7.0.4",
@@ -112,8 +113,7 @@
     "ws": "8.20.0",
     "xss": "1.0.15",
     "yaml": "2.8.3",
-    "zod": "3.25.76",
-    "@mendable/firecrawl-js": "4.18.1"
+    "zod": "3.25.76"
   },
   "devDependencies": {
     "@types/bun": "1.3.11",


### PR DESCRIPTION
## Summary
- bump `lodash-es` from `4.17.23` to `4.18.0`
- bump `diff` from `7.0.0` to `8.0.3`
- refresh `bun.lock` for the patched runtime dependency set

This is a focused security/dependency PR to address the 3 open Dependabot alerts currently shown on the repo security tab.

## Dependabot Alerts Addressed
- `lodash-es` high severity: `GHSA-r5fr-rjxr-66jc` / `CVE-2026-4800`
- `lodash-es` moderate severity: `GHSA-f23m-r3pf-42rh` / `CVE-2026-2950`
- `diff` low severity: `GHSA-73rr-hh4g-fpgx` / `CVE-2026-24001`

## Notes
- the alerts are on direct `package.json` dependencies, so these bumps target the exact open findings
- Bun also normalized the existing `@mendable/firecrawl-js` entry position in `package.json`; no version change was made there

## Validation
- `bun run build`
- `bun run smoke`

X: @crypt0beast
