### PR TITLE
Added LM Studio provider setup guide

### DIFF
--- a/docs/quick-start-mac-linux.md
+++ b/docs/quick-start-mac-linux.md
@@ -75,8 +75,8 @@ Install LM Studio first from:
 Then in LM Studio:
 
 1. Download a model (e.g., Llama 3.1 8B, Mistral 7B)
-2. Go to the "Local Server" tab
-3. Select your model and click "Start Server"
+2. Go to the "Developer" tab
+3. Select your model and enable the server via the toggle
 
 Then run:
 
@@ -84,13 +84,14 @@ Then run:
 export CLAUDE_CODE_USE_OPENAI=1
 export OPENAI_BASE_URL=http://localhost:1234/v1
 export OPENAI_MODEL=your-model-name
+# export OPENAI_API_KEY=lmstudio  # optional: some users need a dummy key
 
 openclaude
 ```
 
 Replace `your-model-name` with the model name shown in LM Studio.
 
-No API key is needed for LM Studio local models.
+No API key is needed for LM Studio local models (but uncomment the `OPENAI_API_KEY` line if you hit auth errors).
 
 ## 4. If `openclaude` Is Not Found
 
@@ -119,7 +120,7 @@ Check the basics:
 
 - make sure LM Studio is installed
 - make sure LM Studio is running
-- make sure the Local Server is started (click "Start Server" in the Local Server tab)
+- make sure the server is enabled (toggle on in the "Developer" tab)
 - make sure a model is loaded in LM Studio
 - make sure the model name matches what you set in `OPENAI_MODEL`
 

--- a/docs/quick-start-windows.md
+++ b/docs/quick-start-windows.md
@@ -75,8 +75,8 @@ Install LM Studio first from:
 Then in LM Studio:
 
 1. Download a model (e.g., Llama 3.1 8B, Mistral 7B)
-2. Go to the "Local Server" tab
-3. Select your model and click "Start Server"
+2. Go to the "Developer" tab
+3. Select your model and enable the server via the toggle
 
 Then run:
 
@@ -84,13 +84,14 @@ Then run:
 $env:CLAUDE_CODE_USE_OPENAI="1"
 $env:OPENAI_BASE_URL="http://localhost:1234/v1"
 $env:OPENAI_MODEL="your-model-name"
+# $env:OPENAI_API_KEY="lmstudio"  # optional: some users need a dummy key
 
 openclaude
 ```
 
 Replace `your-model-name` with the model name shown in LM Studio.
 
-No API key is needed for LM Studio local models.
+No API key is needed for LM Studio local models (but uncomment the `OPENAI_API_KEY` line if you hit auth errors).
 
 ## 4. If `openclaude` Is Not Found
 
@@ -119,7 +120,7 @@ Check the basics:
 
 - make sure LM Studio is installed
 - make sure LM Studio is running
-- make sure the Local Server is started (click "Start Server" in the Local Server tab)
+- make sure the server is enabled (toggle on in the "Developer" tab)
 - make sure a model is loaded in LM Studio
 - make sure the model name matches what you set in `OPENAI_MODEL`
 


### PR DESCRIPTION
Add LM Studio as Option D in quick-start documentation for both Mac/Linux and Windows.

**Changes:**
- Added LM Studio installation and setup instructions
- Included environment variable configuration for OpenAI-compatible API
- Added troubleshooting section for LM Studio

**Files Modified:**
- `docs/quick-start-mac-linux.md`
- `docs/quick-start-windows.md`