### PR TITLE
fix: forward reasoning content, Ollama max_tokens fallback, tool result images

### DIFF
--- a/src/services/api/openaiShim.test.ts
+++ b/src/services/api/openaiShim.test.ts
@@ -386,3 +386,195 @@ test('sanitizes malformed MCP tool schemas before sending them to OpenAI', async
   expect(properties?.priority?.enum).toEqual([0, 1, 2, 3])
   expect(properties?.priority).not.toHaveProperty('default')
 })
+
+// ---------------------------------------------------------------------------
+// Regression tests requested by reviewer on PR #237
+// ---------------------------------------------------------------------------
+
+test('streams reasoning_content as thinking blocks then closes before tool_calls', async () => {
+  // Simulates DeepSeek R1 pattern: reasoning → tool_call (no text in between)
+  globalThis.fetch = (async () => {
+    const chunks = makeStreamChunks([
+      {
+        id: 'chatcmpl-r1',
+        object: 'chat.completion.chunk',
+        model: 'deepseek-reasoner',
+        choices: [{ index: 0, delta: { reasoning_content: 'Let me think...' }, finish_reason: null }],
+      },
+      {
+        id: 'chatcmpl-r1',
+        object: 'chat.completion.chunk',
+        model: 'deepseek-reasoner',
+        choices: [{ index: 0, delta: { reasoning_content: ' about this.' }, finish_reason: null }],
+      },
+      {
+        id: 'chatcmpl-r1',
+        object: 'chat.completion.chunk',
+        model: 'deepseek-reasoner',
+        choices: [{
+          index: 0,
+          delta: { tool_calls: [{ index: 0, id: 'call_1', type: 'function', function: { name: 'Bash', arguments: '{"command":"ls"}' } }] },
+          finish_reason: null,
+        }],
+      },
+      {
+        id: 'chatcmpl-r1',
+        object: 'chat.completion.chunk',
+        model: 'deepseek-reasoner',
+        choices: [{ index: 0, delta: {}, finish_reason: 'tool_calls' }],
+        usage: { prompt_tokens: 10, completion_tokens: 5, total_tokens: 15 },
+      },
+    ])
+    return makeSseResponse(chunks)
+  }) as FetchType
+
+  const client = createOpenAIShimClient({}) as OpenAIShimClient
+  const result = client.beta.messages.create({
+    model: 'deepseek-reasoner',
+    system: 'sys',
+    messages: [{ role: 'user', content: 'think and act' }],
+    max_tokens: 1024,
+    stream: true,
+  })
+
+  const { data: stream } = await (result as unknown as { withResponse: () => Promise<{ data: AsyncIterable<Record<string, unknown>> }> }).withResponse()
+
+  const events: Array<{ type: string; [k: string]: unknown }> = []
+  for await (const event of stream) {
+    events.push(event as { type: string })
+  }
+
+  const types = events.map(e => e.type)
+
+  // Verify thinking block is opened and closed before tool_use
+  expect(types).toContain('content_block_start')
+
+  // Find the thinking start and tool_use start
+  const thinkingStart = events.find(
+    e => e.type === 'content_block_start' && (e.content_block as Record<string, string>)?.type === 'thinking',
+  )
+  const toolUseStart = events.find(
+    e => e.type === 'content_block_start' && (e.content_block as Record<string, string>)?.type === 'tool_use',
+  )
+
+  expect(thinkingStart).toBeDefined()
+  expect(toolUseStart).toBeDefined()
+
+  // Thinking block index should be lower than tool_use index
+  const thinkingIdx = (thinkingStart as Record<string, number>).index
+  const toolIdx = (toolUseStart as Record<string, number>).index
+  expect(thinkingIdx).toBeLessThan(toolIdx)
+
+  // Verify thinking block is stopped before tool_use starts
+  const thinkingStop = events.find(
+    e => e.type === 'content_block_stop' && (e as Record<string, number>).index === thinkingIdx,
+  )
+  expect(thinkingStop).toBeDefined()
+  const thinkingStopPos = events.indexOf(thinkingStop!)
+  const toolStartPos = events.indexOf(toolUseStart!)
+  expect(thinkingStopPos).toBeLessThan(toolStartPos)
+
+  // Verify thinking deltas contain the reasoning text
+  const thinkingDeltas = events.filter(
+    e => e.type === 'content_block_delta' && (e.delta as Record<string, string>)?.type === 'thinking_delta',
+  )
+  expect(thinkingDeltas.length).toBeGreaterThan(0)
+  const fullThinking = thinkingDeltas.map(e => (e.delta as Record<string, string>).thinking).join('')
+  expect(fullThinking).toContain('Let me think...')
+  expect(fullThinking).toContain('about this.')
+})
+
+test('forwards tool_result images as image_url content parts', async () => {
+  let sentBody: Record<string, unknown> | undefined
+
+  globalThis.fetch = (async (_input: unknown, init: RequestInit | undefined) => {
+    sentBody = JSON.parse(String(init?.body))
+    return new Response(
+      JSON.stringify({
+        id: 'chatcmpl-img',
+        model: 'gpt-4o',
+        choices: [{ message: { role: 'assistant', content: 'I see the image.' }, finish_reason: 'stop' }],
+        usage: { prompt_tokens: 100, completion_tokens: 5, total_tokens: 105 },
+      }),
+      { headers: { 'Content-Type': 'application/json' } },
+    )
+  }) as FetchType
+
+  const client = createOpenAIShimClient({}) as OpenAIShimClient
+
+  await client.beta.messages.create({
+    model: 'gpt-4o',
+    system: 'sys',
+    messages: [
+      { role: 'user', content: 'take screenshot' },
+      {
+        role: 'assistant',
+        content: [{ type: 'tool_use', id: 'call_ss', name: 'Screenshot', input: {} }],
+      },
+      {
+        role: 'user',
+        content: [{
+          type: 'tool_result',
+          tool_use_id: 'call_ss',
+          content: [
+            { type: 'text', text: 'Screenshot captured' },
+            { type: 'image', source: { type: 'base64', media_type: 'image/png', data: 'iVBORw0KGgo=' } },
+          ],
+        }],
+      },
+    ],
+    max_tokens: 64,
+    stream: false,
+  })
+
+  const messages = sentBody?.messages as Array<{ role: string; content: unknown }>
+  const toolMsg = messages.find(m => m.role === 'tool')
+  expect(toolMsg).toBeDefined()
+
+  // Content should be an array with text + image_url parts (not a flat string)
+  const content = toolMsg!.content as Array<{ type: string; text?: string; image_url?: { url: string } }>
+  expect(Array.isArray(content)).toBe(true)
+
+  const textPart = content.find(p => p.type === 'text')
+  expect(textPart?.text).toContain('Screenshot captured')
+
+  const imagePart = content.find(p => p.type === 'image_url')
+  expect(imagePart).toBeDefined()
+  expect(imagePart!.image_url!.url).toContain('data:image/png;base64,')
+})
+
+test('sends max_tokens instead of max_completion_tokens for local providers', async () => {
+  // Override to local URL (Ollama pattern)
+  process.env.OPENAI_BASE_URL = 'http://localhost:11434/v1'
+  let sentBody: Record<string, unknown> | undefined
+
+  globalThis.fetch = (async (_input: unknown, init: RequestInit | undefined) => {
+    sentBody = JSON.parse(String(init?.body))
+    return new Response(
+      JSON.stringify({
+        id: 'chatcmpl-local',
+        model: 'llama3.1:8b',
+        choices: [{ message: { role: 'assistant', content: 'hello' }, finish_reason: 'stop' }],
+        usage: { prompt_tokens: 5, completion_tokens: 1, total_tokens: 6 },
+      }),
+      { headers: { 'Content-Type': 'application/json' } },
+    )
+  }) as FetchType
+
+  const client = createOpenAIShimClient({}) as OpenAIShimClient
+
+  await client.beta.messages.create({
+    model: 'llama3.1:8b',
+    system: 'sys',
+    messages: [{ role: 'user', content: 'hi' }],
+    max_tokens: 512,
+    stream: false,
+  })
+
+  // Local provider should use max_tokens, not max_completion_tokens
+  expect(sentBody?.max_tokens).toBe(512)
+  expect(sentBody?.max_completion_tokens).toBeUndefined()
+
+  // Also verify stream_options is NOT sent for local providers
+  expect(sentBody?.stream_options).toBeUndefined()
+})

--- a/src/services/api/openaiShim.ts
+++ b/src/services/api/openaiShim.ts
@@ -561,7 +561,11 @@ async function* openaiStreamToAnthropic(
         if (delta.tool_calls) {
           for (const tc of delta.tool_calls) {
             if (tc.id && tc.function?.name) {
-              // New tool call starting
+              // New tool call starting — close any open blocks first
+              if (hasEmittedThinkingStart) {
+                yield { type: 'content_block_stop', index: thinkingBlockIndex }
+                hasEmittedThinkingStart = false
+              }
               if (hasEmittedContentStart) {
                 yield {
                   type: 'content_block_stop',

--- a/src/services/api/openaiShim.ts
+++ b/src/services/api/openaiShim.ts
@@ -156,6 +156,49 @@ function convertContentBlocks(
   return parts
 }
 
+/**
+ * Build tool result content, preserving images as image_url parts.
+ * OpenAI accepts multipart content arrays on tool role messages.
+ */
+function buildToolResultContent(
+  content: unknown,
+  isError?: boolean,
+): string | Array<{ type: string; text?: string; image_url?: { url: string } }> {
+  if (typeof content === 'string') {
+    return isError ? `Error: ${content}` : content
+  }
+  if (!Array.isArray(content)) {
+    const text = JSON.stringify(content ?? '')
+    return isError ? `Error: ${text}` : text
+  }
+
+  const parts: Array<{ type: string; text?: string; image_url?: { url: string } }> = []
+  for (const block of content as Array<Record<string, unknown>>) {
+    if (block.type === 'text') {
+      parts.push({ type: 'text', text: (block.text as string) ?? '' })
+    } else if (block.type === 'image') {
+      const src = block.source as { type?: string; media_type?: string; data?: string; url?: string } | undefined
+      if (src?.type === 'base64' && src.data && src.media_type) {
+        parts.push({ type: 'image_url', image_url: { url: `data:${src.media_type};base64,${src.data}` } })
+      } else if (src?.type === 'url' && src.url) {
+        parts.push({ type: 'image_url', image_url: { url: src.url } })
+      }
+    }
+  }
+
+  if (parts.length === 0) return ''
+  if (parts.length === 1 && parts[0].type === 'text') {
+    const text = parts[0].text ?? ''
+    return isError ? `Error: ${text}` : text
+  }
+  if (isError && parts[0]?.type === 'text') {
+    parts[0] = { ...parts[0], text: `Error: ${parts[0].text ?? ''}` }
+  } else if (isError) {
+    parts.unshift({ type: 'text', text: 'Error:' })
+  }
+  return parts
+}
+
 function convertMessages(
   messages: Array<{ role: string; message?: { role?: string; content?: unknown }; content?: unknown }>,
   system: unknown,
@@ -182,15 +225,10 @@ function convertMessages(
 
         // Emit tool results as tool messages
         for (const tr of toolResults) {
-          const trContent = Array.isArray(tr.content)
-            ? tr.content.map((c: { text?: string }) => c.text ?? '').join('\n')
-            : typeof tr.content === 'string'
-              ? tr.content
-              : JSON.stringify(tr.content ?? '')
           result.push({
             role: 'tool',
             tool_call_id: tr.tool_use_id ?? 'unknown',
-            content: tr.is_error ? `Error: ${trContent}` : trContent,
+            content: buildToolResultContent(tr.content, tr.is_error),
           })
         }
 
@@ -368,6 +406,8 @@ interface OpenAIStreamChunk {
     delta: {
       role?: string
       content?: string | null
+      reasoning_content?: string | null
+      reasoning?: string | null
       tool_calls?: Array<{
         index: number
         id?: string
@@ -417,6 +457,8 @@ async function* openaiStreamToAnthropic(
   let contentBlockIndex = 0
   const activeToolCalls = new Map<number, { id: string; name: string; index: number; jsonBuffer: string }>()
   let hasEmittedContentStart = false
+  let hasEmittedThinkingStart = false
+  let thinkingBlockIndex = -1
   let lastStopReason: 'tool_use' | 'max_tokens' | 'end_turn' | null = null
   let hasEmittedFinalUsage = false
   let hasProcessedFinishReason = false
@@ -473,9 +515,33 @@ async function* openaiStreamToAnthropic(
       for (const choice of chunk.choices ?? []) {
         const delta = choice.delta
 
-        // Text content — use != null to distinguish absent field from empty string,
-        // some providers send "" as first delta to signal streaming start
+        // Reasoning content from thinking models (DeepSeek R1, etc.)
+        const reasoningText = delta.reasoning_content ?? delta.reasoning
+        if (reasoningText != null && reasoningText !== '') {
+          if (!hasEmittedThinkingStart) {
+            thinkingBlockIndex = contentBlockIndex
+            yield {
+              type: 'content_block_start',
+              index: thinkingBlockIndex,
+              content_block: { type: 'thinking', thinking: '' },
+            }
+            contentBlockIndex++
+            hasEmittedThinkingStart = true
+          }
+          yield {
+            type: 'content_block_delta',
+            index: thinkingBlockIndex,
+            delta: { type: 'thinking_delta', thinking: reasoningText },
+          }
+        }
+
+        // Text content — use != null to distinguish absent field from empty string
         if (delta.content != null) {
+          // Close thinking block before opening text block
+          if (hasEmittedThinkingStart && !hasEmittedContentStart) {
+            yield { type: 'content_block_stop', index: thinkingBlockIndex }
+            hasEmittedThinkingStart = false
+          }
           if (!hasEmittedContentStart) {
             yield {
               type: 'content_block_start',
@@ -562,6 +628,11 @@ async function* openaiStreamToAnthropic(
         if (choice.finish_reason && !hasProcessedFinishReason) {
           hasProcessedFinishReason = true
 
+          // Close thinking block if still open (reasoning-only models)
+          if (hasEmittedThinkingStart) {
+            yield { type: 'content_block_stop', index: thinkingBlockIndex }
+            hasEmittedThinkingStart = false
+          }
           // Close any open content blocks
           if (hasEmittedContentStart) {
             yield {
@@ -815,7 +886,10 @@ class OpenAIShimMessages {
     }
 
     const isGithub = isGithubModelsMode()
-    if (isGithub && body.max_completion_tokens !== undefined) {
+    const isLocal = isLocalProviderUrl(request.baseUrl)
+    // GitHub Models and local providers (Ollama, LM Studio) accept max_tokens only.
+    // OpenAI cloud and Azure require max_completion_tokens.
+    if ((isGithub || isLocal) && body.max_completion_tokens !== undefined) {
       body.max_tokens = body.max_completion_tokens
       delete body.max_completion_tokens
     }
@@ -960,6 +1034,8 @@ class OpenAIShimMessages {
             | string
             | null
             | Array<{ type?: string; text?: string }>
+          reasoning_content?: string | null
+          reasoning?: string | null
           tool_calls?: Array<{
             id: string
             function: { name: string; arguments: string }
@@ -980,6 +1056,12 @@ class OpenAIShimMessages {
   ) {
     const choice = data.choices?.[0]
     const content: Array<Record<string, unknown>> = []
+
+    // Prepend thinking block for reasoning models (DeepSeek R1, etc.)
+    const rawReasoning = choice?.message?.reasoning_content ?? choice?.message?.reasoning
+    if (rawReasoning) {
+      content.push({ type: 'thinking', thinking: rawReasoning, signature: '' })
+    }
 
     const rawContent = choice?.message?.content
     if (typeof rawContent === 'string' && rawContent) {


### PR DESCRIPTION
## Summary

Three significant fixes in the OpenAI shim addressing long-standing gaps in provider compatibility, reasoning model support, and tool result fidelity.

## Changes

### 1. Forward `reasoning_content` from thinking models as Anthropic thinking blocks

**Impact:** Users of DeepSeek R1, o3, and other reasoning models can now see chain-of-thought output.

Previously, `delta.reasoning_content` was silently ignored — reasoning models appeared to "just think silently" with no visible output until the final answer.

**Streaming path:**
- Detects `delta.reasoning_content` (or `delta.reasoning` alias)
- Emits `content_block_start` with `type: 'thinking'`
- Streams `thinking_delta` events with the reasoning text
- Closes the thinking block when `delta.content` begins (model switches from reasoning to answering)
- Handles edge case: reasoning-only responses without text content

**Non-streaming path:**
- Detects `message.reasoning_content` (or `reasoning` alias)
- Prepends a `{ type: 'thinking', thinking: text, signature: '' }` block before text content

### 2. Use `max_tokens` for local providers (Ollama/LM Studio compatibility)

**Impact:** Ollama < 0.5 users get their token budget respected.

Older Ollama versions silently ignore `max_completion_tokens` and use their internal default. Now mirrors the existing GitHub Models fallback: for local providers (detected via `isLocalProviderUrl`), `max_completion_tokens` is swapped to `max_tokens`.

### 3. Preserve images in `tool_result` blocks

**Impact:** Screenshot tools, browser tools, and any tool returning images now work with OpenAI providers.

Previously, image blocks in tool results were mapped to empty strings via `c.text ?? ''`. New `buildToolResultContent()` helper emits proper `image_url` content parts:
- Base64 images → `data:` URI
- URL images → direct URL passthrough
- Text + images → multipart content array (supported by OpenAI on `tool` role messages)

Relates to #30, #113, #114

## Test plan

- [x] `bun test src/services/api/openaiShim.test.ts` — pass
- [x] `bun test src/services/api/codexShim.test.ts` — pass
- [ ] Verify DeepSeek R1 shows chain-of-thought in streaming
- [ ] Verify Ollama respects max_tokens with older versions
- [ ] Verify screenshot tool results include images for OpenAI providers