### PR TITLE
security: force lodash-es 4.18.0 for transitive dependencies

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -49,7 +49,7 @@
         "ignore": "7.0.5",
         "indent-string": "5.0.0",
         "jsonc-parser": "3.3.1",
-        "lodash-es": "4.18.0",
+        "lodash-es": "4.18.1",
         "lru-cache": "11.2.7",
         "marked": "15.0.12",
         "p-map": "7.0.4",
@@ -86,7 +86,7 @@
     },
   },
   "overrides": {
-    "lodash-es": "4.18.0",
+    "lodash-es": "4.18.1",
   },
   "packages": {
     "@alcalzone/ansi-tokenize": ["@alcalzone/ansi-tokenize@0.3.0", "", { "dependencies": { "ansi-styles": "^6.2.1", "is-fullwidth-code-point": "^5.0.0" } }, "sha512-p+CMKJ93HFmLkjXKlXiVGlMQEuRb6H0MokBSwUsX+S6BRX8eV5naFZpQJFfJHjRZY0Hmnqy1/r6UWl3x+19zYA=="],
@@ -599,7 +599,7 @@
 
     "locate-path": ["locate-path@5.0.0", "", { "dependencies": { "p-locate": "^4.1.0" } }, "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g=="],
 
-    "lodash-es": ["lodash-es@4.18.0", "", {}, "sha512-koAgswPPA+UTaPN64Etp+PGP+WT6oqOS2NMi5yDkMaiGw9qY4VxQbQF0mtKMyr4BlTznWyzePV5UpECTJQmSUA=="],
+    "lodash-es": ["lodash-es@4.18.1", "", {}, "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A=="],
 
     "lodash.camelcase": ["lodash.camelcase@4.3.0", "", {}, "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA=="],
 

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "ignore": "7.0.5",
     "indent-string": "5.0.0",
     "jsonc-parser": "3.3.1",
-    "lodash-es": "4.18.0",
+    "lodash-es": "4.18.1",
     "lru-cache": "11.2.7",
     "marked": "15.0.12",
     "p-map": "7.0.4",
@@ -143,6 +143,6 @@
     "access": "public"
   },
   "overrides": {
-    "lodash-es": "4.18.0"
+    "lodash-es": "4.18.1"
   }
 }


### PR DESCRIPTION
## Summary

Forces all copies of `lodash-es` (including transitive) to `4.18.0` via the `overrides` field in `package.json`, resolving the remaining HIGH severity vulnerability.

## Problem

PR #225 bumped the direct `lodash-es` dependency to `4.18.0`, but `@anthropic-ai/sandbox-runtime@0.0.46` declares `"lodash-es": "^4.17.23"` — Bun resolved this to a **separate copy** at `4.17.23` in the lockfile. The vulnerable transitive copy remained:

```
@anthropic-ai/sandbox-runtime/lodash-es → lodash-es@4.17.23  ← VULNERABLE
```

**Vulnerabilities:**
- **HIGH**: Code Injection via `_.template` imports key names ([GHSA-r5fr-rjxr-66jc](https://github.com/advisories/GHSA-r5fr-rjxr-66jc))
- **MODERATE**: Prototype Pollution via `_.unset`/`_.omit` ([GHSA-f23m-r3pf-42rh](https://github.com/advisories/GHSA-f23m-r3pf-42rh))

## Fix

```json
"overrides": {
  "lodash-es": "4.18.0"
}
```

This forces Bun to resolve ALL `lodash-es` ranges (including `^4.17.23` from sandbox-runtime) to `4.18.0`.

## Verification

```
$ bun audit
No vulnerabilities found
```

## Test plan

- [x] `bun audit` — zero vulnerabilities
- [x] `bun test` — 13 pass
- [x] `bun install` — clean install with override applied