### PR TITLE
fix: prevent cross-provider model env var leaks and sync Codex detection

### DIFF
--- a/src/services/api/providerConfig.ts
+++ b/src/services/api/providerConfig.ts
@@ -201,7 +201,7 @@ function parseModelDescriptor(model: string): ModelDescriptor {
   }
 }
 
-function isCodexAlias(model: string): boolean {
+export function isCodexAlias(model: string): boolean {
   const normalized = model.trim().toLowerCase()
   const base = normalized.split('?', 1)[0] ?? normalized
   return base in CODEX_ALIAS_MODELS

--- a/src/utils/model/model.ts
+++ b/src/utils/model/model.ts
@@ -75,7 +75,15 @@ export function getUserSpecifiedModelSetting(): ModelSetting | undefined {
     specifiedModel = modelOverride
   } else {
     const settings = getSettings_DEPRECATED() || {}
-    specifiedModel = process.env.ANTHROPIC_MODEL || process.env.GEMINI_MODEL || process.env.OPENAI_MODEL || settings.model || undefined
+    // Read the model env var that matches the active provider to prevent
+    // cross-provider leaks (e.g. ANTHROPIC_MODEL sent to the OpenAI API).
+    const provider = getAPIProvider()
+    specifiedModel =
+      (provider === 'gemini' ? process.env.GEMINI_MODEL : undefined) ||
+      (provider === 'openai' || provider === 'gemini' ? process.env.OPENAI_MODEL : undefined) ||
+      (provider === 'firstParty' ? process.env.ANTHROPIC_MODEL : undefined) ||
+      settings.model ||
+      undefined
   }
 
   // Ignore the user-specified model if it's not in the availableModels allowlist.

--- a/src/utils/model/providers.ts
+++ b/src/utils/model/providers.ts
@@ -1,4 +1,5 @@
 import type { AnalyticsMetadata_I_VERIFIED_THIS_IS_NOT_CODE_OR_FILEPATHS } from '../../services/analytics/index.js'
+import { isCodexAlias } from '../../services/api/providerConfig.js'
 import { isEnvTruthy } from '../envUtils.js'
 
 export type APIProvider =
@@ -33,17 +34,11 @@ export function usesAnthropicAccountFlow(): boolean {
   return getAPIProvider() === 'firstParty'
 }
 function isCodexModel(): boolean {
-  const model = (process.env.OPENAI_MODEL || '').toLowerCase()
-  return (
-    model === 'codexplan' ||
-    model === 'codexspark' ||
-    model === 'gpt-5.4' ||
-    model === 'gpt-5.3-codex' ||
-    model === 'gpt-5.3-codex-spark' ||
-    model === 'gpt-5.2-codex' ||
-    model === 'gpt-5.1-codex-max' ||
-    model === 'gpt-5.1-codex-mini'
-  )
+  const model = (process.env.OPENAI_MODEL || '').trim()
+  if (!model) return false
+  // Delegate to the canonical alias table in providerConfig to keep
+  // the two Codex detection systems (provider type + transport) in sync.
+  return isCodexAlias(model)
 }
 
 export function getAPIProviderForStatsig(): AnalyticsMetadata_I_VERIFIED_THIS_IS_NOT_CODE_OR_FILEPATHS {


### PR DESCRIPTION
## Summary

Two provider routing bugs that cause silent wrong-model failures for 3P users.

## Bug 1 — `ANTHROPIC_MODEL` overrides `OPENAI_MODEL` for 3P providers

**File:** `src/utils/model/model.ts:78`

`getUserSpecifiedModelSetting()` read env vars with a flat OR chain:
```ts
process.env.ANTHROPIC_MODEL || process.env.GEMINI_MODEL || process.env.OPENAI_MODEL
```

A user switching from Anthropic to OpenAI with `ANTHROPIC_MODEL` still in their environment would silently send the Anthropic model name (e.g. `claude-opus-4-6`) to the OpenAI API. The OpenAI endpoint returns a 404/model-not-found with no hint that the wrong env var was used.

**Fix:** Gate each env var behind `getAPIProvider()`:
- `firstParty` → reads `ANTHROPIC_MODEL`
- `gemini` → reads `GEMINI_MODEL`, then `OPENAI_MODEL`
- `openai` → reads `OPENAI_MODEL`

## Bug 2 — `isCodexModel()` desynchronized from `CODEX_ALIAS_MODELS`

**Files:** `src/utils/model/providers.ts:35-47`, `src/services/api/providerConfig.ts:204`

Two parallel, manually-maintained lists for Codex model detection:
- `CODEX_ALIAS_MODELS` in `providerConfig.ts` — 11 entries (canonical, used for transport selection)
- `isCodexModel()` in `providers.ts` — 8 entries (used for `getAPIProvider()`)

Missing from `isCodexModel()`: `gpt-5.4-mini` and `gpt-5.2`. Users with these models got a **split-brain**: `getAPIProvider()` returned `'openai'` while `resolveProviderRequest()` selected `codex_responses` transport, causing auth failures and incorrect model display.

**Fix:** Export `isCodexAlias()` from `providerConfig.ts` and delegate `isCodexModel()` to it. Single source of truth, zero maintenance burden.

## Test plan

- [x] `bun test` — 27 pass across 4 test files
- [ ] Verify `ANTHROPIC_MODEL=claude-opus-4-6 CLAUDE_CODE_USE_OPENAI=1 OPENAI_MODEL=gpt-4o` uses gpt-4o (not claude-opus-4-6)
- [ ] Verify `OPENAI_MODEL=gpt-5.4-mini` correctly detects as Codex model