### PR TITLE
fix: run dangerous path check before auto-allowing rm/rmdir in acceptEdits mode

### DIFF
--- a/src/tools/BashTool/modeValidation.ts
+++ b/src/tools/BashTool/modeValidation.ts
@@ -1,8 +1,10 @@
 import type { z } from 'zod/v4'
 import type { ToolPermissionContext } from '../../Tool.js'
 import { splitCommand_DEPRECATED } from '../../utils/bash/commands.js'
+import { getCwd } from '../../utils/cwd.js'
 import type { PermissionResult } from '../../utils/permissions/PermissionResult.js'
 import type { BashTool } from './BashTool.js'
+import { checkDangerousRemovalPaths } from './pathValidation.js'
 
 const ACCEPT_EDITS_ALLOWED_COMMANDS = [
   'mkdir',
@@ -39,6 +41,17 @@ function validateCommandForMode(
     toolPermissionContext.mode === 'acceptEdits' &&
     isFilesystemCommand(baseCmd)
   ) {
+    // Guard: always run dangerous path check for rm/rmdir before auto-allowing.
+    // This prevents rm -rf ~ / rm -rf / from bypassing checkDangerousRemovalPaths
+    // which is otherwise skipped when acceptEdits returns allow early.
+    if (baseCmd === 'rm' || baseCmd === 'rmdir') {
+      const args = trimmedCmd.split(/\s+/).slice(1)
+      const dangerousResult = checkDangerousRemovalPaths(baseCmd, args, getCwd())
+      if (dangerousResult.behavior !== 'passthrough') {
+        return dangerousResult
+      }
+    }
+
     return {
       behavior: 'allow',
       updatedInput: { command: cmd },

--- a/src/tools/BashTool/pathValidation.ts
+++ b/src/tools/BashTool/pathValidation.ts
@@ -67,7 +67,7 @@ export type PathCommand =
  * require explicit user approval, even if allowlist rules exist.
  * This prevents catastrophic data loss from commands like `rm -rf /`.
  */
-function checkDangerousRemovalPaths(
+export function checkDangerousRemovalPaths(
   command: 'rm' | 'rmdir',
   args: string[],
   cwd: string,


### PR DESCRIPTION
## Summary

Fixes finding 3 from issue #244 — \ mode bypasses \ for \ and \.

## Root Cause

In \, filesystem commands in \ mode returned \ immediately without running \. This meant \ and \ bypassed the dangerous path guard entirely — the check in \ never ran.

\
## Fix

Export \ from \ and call it for \/\ in \ before returning \:

\
## Behaviour After Fix

| Command | Before | After |
|---------|--------|-------|
| \ in acceptEdits | auto-allowed ❌ | prompts user ✅ |
| \ in acceptEdits | auto-allowed ❌ | prompts user ✅ |
| \ in acceptEdits | auto-allowed ✅ | auto-allowed ✅ |
| \, \, \, \, \ | auto-allowed ✅ | auto-allowed ✅ |

## Why This Matters for 3P Models

First-party Claude models refuse dangerous commands on their own. But 3P models (local Ollama, DeepSeek, Devstral etc.) lack that training and can blindly emit destructive commands. This fix ensures the code-level guard fires regardless of which model is running.

## Test Plan

- [x] \ — 200/200 pass
- [x] \error TS5025: Unknown compiler option '--noEmit\'. Did you mean 'noEmit'? — no new errors in changed files
- [x] Manual: \ in acceptEdits mode prompts for approval
- [x] Manual: \ in acceptEdits mode auto-allows

Addresses finding 3 from #244. Findings 1 and 2 (classifier warning, sandbox gate) are separate concerns and need follow-up PRs.