### PR TITLE
fix: consume --bare flag in launch scripts and widen Gemini reachability check

### DIFF
--- a/scripts/provider-launch.ts
+++ b/scripts/provider-launch.ts
@@ -39,7 +39,7 @@ function parseLaunchOptions(argv: string[]): LaunchOptions {
   for (let i = 0; i < argv.length; i++) {
     const arg = argv[i]!
     const lower = arg.toLowerCase()
-    if (lower === '--fast') {
+    if (lower === '--fast' || lower === '--bare') {
       fast = true
       continue
     }

--- a/scripts/system-check.ts
+++ b/scripts/system-check.ts
@@ -311,11 +311,14 @@ async function checkBaseUrlReachability(): Promise<CheckResult> {
       signal: controller.signal,
     })
 
-    if (response.status === 200 || response.status === 401 || response.status === 403) {
+    // Accept any response that proves the endpoint is reachable.
+    // Google's Gemini OpenAI-compat endpoint returns 404 for bare /models
+    // GET without a model ID. 429 means rate-limited but reachable.
+    if (response.status < 500) {
       return pass('Provider reachability', `Reached ${endpoint} (status ${response.status}).`)
     }
 
-    return fail('Provider reachability', `Unexpected status ${response.status} from ${endpoint}.`)
+    return fail('Provider reachability', `Server error ${response.status} from ${endpoint}.`)
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error)
     return fail('Provider reachability', `Failed to reach ${endpoint}: ${message}`)


### PR DESCRIPTION
## Summary

Two fixes for the provider launch system that prevent `dev:gemini` and `dev:*:fast` from crashing.

## Bug 1 — `--bare` crashes `dev:profile:fast` and `dev:ollama:fast`

**File:** `scripts/provider-launch.ts:39-69`

The `--bare` flag was not recognized by `parseLaunchOptions()` and fell through to `passthroughArgs`, getting forwarded to `node dist/cli.mjs --bare`. The CLI doesn't accept `--bare` and crashes.

**Affected scripts:** `dev:profile:fast`, `dev:ollama:fast` (both pass `--fast --bare`)

**Fix:** Consume `--bare` as an alias for `--fast` — it was always used alongside `--fast` in the npm scripts and has no independent behavior.

## Bug 2 — `dev:gemini` fails reachability check with Google API 404

**File:** `scripts/system-check.ts:314-318`

The reachability probe only accepted HTTP 200, 401, 403. Google's Gemini OpenAI-compat endpoint (`/v1beta/openai/models`) returns **404** for a bare GET, and **429** for rate-limited requests. Both prove reachability but were treated as failures, blocking the launch.

**Fix:** Accept any HTTP status < 500 as proof of reachability. Only 5xx server errors indicate the endpoint is down.

Relates to #196

## Test plan

- [x] `bun test` — 13 pass
- [ ] Verify `bun run dev:ollama:fast` no longer crashes
- [ ] Verify `bun run dev:gemini` passes reachability check with 404 from Google