### PR TITLE
fix: add missing o1-series and Ollama models to context window table

### DIFF
--- a/src/utils/model/openaiContextWindows.ts
+++ b/src/utils/model/openaiContextWindows.ts
@@ -23,9 +23,13 @@ const OPENAI_CONTEXT_WINDOWS: Record<string, number> = {
   'gpt-4.1-nano':             1_047_576,
   'gpt-4-turbo':              128_000,
   'gpt-4':                     8_192,
+  'o1':                       200_000,
+  'o1-mini':                  128_000,
+  'o1-preview':               128_000,
+  'o1-pro':                   200_000,
+  'o3':                       200_000,
   'o3-mini':                  200_000,
   'o4-mini':                  200_000,
-  'o3':                       200_000,
 
   // DeepSeek (V3: 128k context per official docs)
   'deepseek-chat':            128_000,
@@ -63,6 +67,9 @@ const OPENAI_CONTEXT_WINDOWS: Record<string, number> = {
   'phi4:14b':                  16_384,
   'gemma2:27b':                 8_192,
   'codellama:13b':              16_384,
+  'llama3.2:1b':              128_000,
+  'qwen3:8b':                 128_000,
+  'codestral':                 32_768,
 }
 
 /**
@@ -82,9 +89,13 @@ const OPENAI_MAX_OUTPUT_TOKENS: Record<string, number> = {
   'gpt-4.1-nano':             32_768,
   'gpt-4-turbo':               4_096,
   'gpt-4':                     4_096,
+  'o1':                       100_000,
+  'o1-mini':                   65_536,
+  'o1-preview':                32_768,
+  'o1-pro':                   100_000,
+  'o3':                       100_000,
   'o3-mini':                  100_000,
   'o4-mini':                  100_000,
-  'o3':                       100_000,
 
   // DeepSeek
   'deepseek-chat':              8_192,
@@ -120,6 +131,9 @@ const OPENAI_MAX_OUTPUT_TOKENS: Record<string, number> = {
   'phi4:14b':                   4_096,
   'gemma2:27b':                 4_096,
   'codellama:13b':              4_096,
+  'llama3.2:1b':                4_096,
+  'qwen3:8b':                   8_192,
+  'codestral':                   8_192,
 }
 
 function lookupByModel<T>(table: Record<string, T>, model: string): T | undefined {


### PR DESCRIPTION
## Summary

Adds missing models to the context window and max output token lookup tables. Without these entries, the models fall through to the 200k default context window, causing auto-compact to never trigger and users to hit hard `context_window_exceeded` errors.

## Models added

| Model | Context Window | Max Output |
|-------|---------------|------------|
| `o1` | 200,000 | 100,000 |
| `o1-mini` | 128,000 | 65,536 |
| `o1-preview` | 128,000 | 32,768 |
| `o1-pro` | 200,000 | 100,000 |
| `llama3.2:1b` | 128,000 | 4,096 |
| `qwen3:8b` | 128,000 | 8,192 |
| `codestral` | 32,768 | 8,192 |

Relates to #248

## Test plan

- [x] `bun test src/utils/context.test.ts` — 6 pass