### PR TITLE
docs: add GitHub community standard files

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,41 @@
+---
+name: Bug report
+about: Report a reproducible problem in OpenClaude
+title: ""
+labels: ""
+assignees: ""
+---
+
+## Summary
+
+What is broken?
+
+## Steps to Reproduce
+
+1.
+2.
+3.
+
+## Expected Behavior
+
+What should have happened?
+
+## Actual Behavior
+
+What happened instead?
+
+## Environment
+
+- OpenClaude version:
+- OS:
+- Terminal:
+- Provider:
+- Model:
+
+## Logs / Screenshots
+
+Paste the exact error output or attach screenshots if useful.
+
+## Additional Context
+
+Anything else maintainers should know?

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: OpenClaude Discussions
+    url: https://github.com/Gitlawb/openclaude/discussions
+    about: Use Discussions for setup help, questions, ideas, and community conversation.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,27 @@
+---
+name: Feature request
+about: Suggest an improvement or new capability for OpenClaude
+title: ""
+labels: ""
+assignees: ""
+---
+
+## Summary
+
+What would you like OpenClaude to do?
+
+## Problem
+
+What problem does this solve for you?
+
+## Proposed Direction
+
+Describe the smallest useful version of the feature if possible.
+
+## Alternatives Considered
+
+What are you doing today instead?
+
+## Additional Context
+
+Examples, screenshots, related projects, or prior art.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,21 @@
+## Summary
+
+- what changed
+- why it changed
+
+## Impact
+
+- user-facing impact:
+- developer/maintainer impact:
+
+## Testing
+
+- [ ] `bun run build`
+- [ ] `bun run smoke`
+- [ ] focused tests:
+
+## Notes
+
+- provider/model path tested:
+- screenshots attached (if UI changed):
+- follow-up work or known limitations:

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,126 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and maintainers pledge to make participation in
+our community a harassment-free experience for everyone, regardless of age,
+body size, visible or invisible disability, ethnicity, sex characteristics,
+gender identity and expression, level of experience, education, socio-economic
+status, nationality, personal appearance, race, religion, or sexual identity
+and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+- Focusing on what is best not just for us as individuals, but for the
+  overall community
+
+Examples of unacceptable behavior include:
+
+- The use of sexualized language or imagery, and sexual attention or
+  advances of any kind
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or email
+  address, without their explicit permission
+- Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for
+moderation decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official email address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the project maintainers through the repository maintainers or
+security/community contact paths available in the repository.
+
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series
+of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within
+the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org/),
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html](https://www.contributor-covenant.org/version/2/1/code_of_conduct.html).
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder](https://github.com/mozilla/diversity).
+
+For answers to common questions about this code of conduct, see the FAQ at
+[https://www.contributor-covenant.org/faq](https://www.contributor-covenant.org/faq).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,119 @@
+# Contributing to OpenClaude
+
+Thanks for contributing.
+
+OpenClaude is a fast-moving open-source coding-agent CLI with support for multiple providers, local backends, MCP, and a terminal-first workflow. The best contributions here are focused, well-tested, and easy to review.
+
+## Before You Start
+
+- Search existing [issues](https://github.com/Gitlawb/openclaude/issues) and [discussions](https://github.com/Gitlawb/openclaude/discussions) before opening a new thread.
+- Use issues for confirmed bugs and actionable feature work.
+- Use discussions for setup help, ideas, and general community conversation.
+- For larger changes, open an issue first so the scope is clear before implementation.
+- For security reports, follow [SECURITY.md](SECURITY.md).
+
+## Local Setup
+
+Install dependencies:
+
+```bash
+bun install
+```
+
+Build the CLI:
+
+```bash
+bun run build
+```
+
+Smoke test:
+
+```bash
+bun run smoke
+```
+
+Run the app locally:
+
+```bash
+bun run dev
+```
+
+If you are working on provider setup or saved profiles, useful commands include:
+
+```bash
+bun run profile:init
+bun run dev:profile
+```
+
+## Development Workflow
+
+- Keep PRs focused on one problem or feature.
+- Avoid mixing unrelated cleanup into the same change.
+- Preserve existing repo patterns unless the change is intentionally refactoring them.
+- Add or update tests when the change affects behavior.
+- Update docs when setup, commands, or user-facing behavior changes.
+
+## Validation
+
+At minimum, run the most relevant checks for your change.
+
+Common checks:
+
+```bash
+bun run build
+bun run smoke
+```
+
+Focused tests:
+
+```bash
+bun test ./path/to/test-file.test.ts
+```
+
+When working on provider/runtime setup, this can also help:
+
+```bash
+bun run doctor:runtime
+```
+
+## Pull Requests
+
+Good PRs usually include:
+
+- a short explanation of what changed
+- why it changed
+- the user or developer impact
+- the exact checks you ran
+
+If the PR touches UI, terminal presentation, or the VS Code extension, include screenshots when useful.
+
+If the PR changes provider behavior, mention which provider path was tested.
+
+## Code Style
+
+- Follow the existing code style in the touched files.
+- Prefer small, readable changes over broad rewrites.
+- Do not reformat unrelated files just because they are nearby.
+- Keep comments useful and concise.
+
+## Provider Changes
+
+OpenClaude supports multiple provider paths. If you change provider logic:
+
+- be explicit about which providers are affected
+- avoid breaking third-party providers while fixing first-party behavior
+- test the exact provider/model path you changed when possible
+- call out any limitations or follow-up work in the PR description
+
+## Community
+
+Please be respectful and constructive with other contributors.
+
+Maintainers may ask for:
+
+- narrower scope
+- focused follow-up PRs
+- stronger validation
+- docs updates for behavior changes
+
+That is normal and helps keep the project reviewable as it grows.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 OpenClaude contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
## Summary

This PR adds the missing repository community-standard files so the GitHub community profile is much more complete and contributor onboarding is clearer.

Added:
- `LICENSE` (MIT)
- `CONTRIBUTING.md`
- `CODE_OF_CONDUCT.md`
- `.github/pull_request_template.md`
- issue templates for bug reports and feature requests
- `.github/ISSUE_TEMPLATE/config.yml` with a Discussions redirect for questions/ideas

## Why

The repo was missing several of GitHub's recommended community-standard files:
- license
- contributing guide
- code of conduct
- issue templates
- pull request template

This PR fills those gaps without changing runtime behavior.

## Impact

- clearer contributor guidance
- cleaner issue intake
- better PR structure
- stronger GitHub community profile / repository hygiene

## Testing

No runtime tests were needed.

This PR only adds repository metadata, templates, and contributor/community documentation.