### PR TITLE
fix: disable cache_control injection for third-party providers

### DIFF
--- a/src/services/api/claude.ts
+++ b/src/services/api/claude.ts
@@ -331,6 +331,14 @@ export function getExtraBodyParams(betaHeaders?: string[]): JsonObject {
 }
 
 export function getPromptCachingEnabled(model: string): boolean {
+  // Prompt caching is an Anthropic-specific feature. Third-party providers
+  // do not understand cache_control blocks and strict backends (e.g. Azure
+  // Foundry) reject or flag requests that contain them.
+  const provider = getAPIProvider()
+  if (provider !== 'firstParty' && provider !== 'bedrock' && provider !== 'vertex') {
+    return false
+  }
+
   // Global disable takes precedence
   if (isEnvTruthy(process.env.DISABLE_PROMPT_CACHING)) return false
 


### PR DESCRIPTION
## Summary

- Gated `getPromptCachingEnabled()` to return `false` for all non-Anthropic providers
- Only `firstParty`, `bedrock`, and `vertex` now receive `cache_control` blocks

## Impact

- **User-facing**: Azure Foundry users can now use openclaude without hitting content filter 400 errors. Fixes #273.
- **All 3P providers** (foundry, openai, gemini, github, codex): requests are now clean of Anthropic-specific cache metadata. Relates to #267 Finding 1.

## Root Cause

`getPromptCachingEnabled()` had no provider awareness — it returned `true` for every provider unless explicitly disabled via env vars. This caused `addCacheBreakpoints()` to inject `cache_control: { type: "ephemeral" }` blocks into all requests, including those sent to Azure Foundry.

Azure's Responsible AI content filter treats unexpected Anthropic-specific fields as a jailbreak signal and rejects the request with a 400 — even for a trivial prompt like "hi":

```json
"jailbreak": { "filtered": true, "detected": true }
```

## Fix

One provider check at the top of `getPromptCachingEnabled()`:

```ts
const provider = getAPIProvider()
if (provider !== 'firstParty' && provider !== 'bedrock' && provider !== 'vertex') {
  return false
}
```

`getAPIProvider` was already imported in `claude.ts`. No new imports needed.

## Testing

- [x] `bun run build`
- [x] `bun run smoke`
- [x] `bun test` — 200/200 pass
- [x] Provider tested: Azure Foundry (fix targets `foundry` provider path)

## Notes

- No behaviour change for `firstParty`, `bedrock`, or `vertex` — prompt caching works exactly as before for Anthropic-native providers
- `foundry` is the affected provider for #273 but the fix applies to all 3P providers for correctness