### PR TITLE
fix: change default config dir from ~/.claude to ~/.openclaude

### DIFF
--- a/src/utils/envUtils.ts
+++ b/src/utils/envUtils.ts
@@ -1,4 +1,5 @@
 import memoize from 'lodash-es/memoize.js'
+import { existsSync } from 'fs'
 import { homedir } from 'os'
 import { join } from 'path'
 
@@ -6,9 +7,18 @@ import { join } from 'path'
 // tests that change the env var get a fresh value without explicit cache.clear.
 export const getClaudeConfigHomeDir = memoize(
   (): string => {
-    return (
-      process.env.CLAUDE_CONFIG_DIR ?? join(homedir(), '.claude')
-    ).normalize('NFC')
+    if (process.env.CLAUDE_CONFIG_DIR) {
+      return process.env.CLAUDE_CONFIG_DIR.normalize('NFC')
+    }
+    const newDefault = join(homedir(), '.openclaude')
+    // Migration compatibility: if ~/.openclaude doesn't exist yet but ~/.claude
+    // does, keep using ~/.claude so existing users don't lose their data on
+    // upgrade. New installs (neither dir exists) go straight to ~/.openclaude.
+    const legacyPath = join(homedir(), '.claude')
+    if (!existsSync(newDefault) && existsSync(legacyPath)) {
+      return legacyPath.normalize('NFC')
+    }
+    return newDefault.normalize('NFC')
   },
   () => process.env.CLAUDE_CONFIG_DIR,
 )


### PR DESCRIPTION
## Summary

- Changes the default config directory from `~/.claude` to `~/.openclaude`
- Adds a **migration compatibility fallback** for existing users
- No unrelated changes — `src/utils/envUtils.ts` only

## Root Cause

`getClaudeConfigHomeDir()` fell back to `~/.claude`, the same directory used by Anthropic's official Claude Code CLI. Any user with Claude Code already installed would have openclaude silently share their existing config, API keys, and project data.

## Fix

**New default:** `~/.openclaude`

**Migration fallback:** If `~/.openclaude` does not exist yet but `~/.claude` does, the legacy path is kept automatically. This means:
- Existing openclaude users → continue using `~/.claude`, no data loss
- New installs → go straight to `~/.openclaude`
- Users who want explicit control → set `CLAUDE_CONFIG_DIR`

## Migration path for existing users

To move to the new isolated directory:
```bash
cp -r ~/.claude ~/.openclaude
# Then on next launch ~/.openclaude exists so legacy fallback won't trigger
```

## Test Plan

- [ ] `bun run build` passes
- [ ] Fresh install (no `~/.claude`, no `~/.openclaude`) → creates `~/.openclaude`
- [ ] Existing user (`~/.claude` exists, no `~/.openclaude`) → continues using `~/.claude`
- [ ] Migrated user (both dirs exist) → uses `~/.openclaude`
- [ ] `CLAUDE_CONFIG_DIR` set → always wins

Fixes #184
Replaces #279