### PR TITLE
fix: resolve keyboard input freeze on Windows and Mac at startup

### DIFF
--- a/src/components/LogoV2/AnimatedAsterisk.tsx
+++ b/src/components/LogoV2/AnimatedAsterisk.tsx
@@ -20,7 +20,9 @@ export function AnimatedAsterisk({
   // Read prefersReducedMotion once at mount — no useSettings() subscription,
   // since that would re-render whenever settings change.
   const [reducedMotion] = useState(() => getInitialSettings().prefersReducedMotion ?? false);
-  const [done, setDone] = useState(reducedMotion);
+  // Skip animation on Windows — 60 re-renders in 3s competes with stdin processing
+  // and causes keyboard freeze on CMD/PowerShell (issues #228, #205).
+  const [done, setDone] = useState(reducedMotion || process.platform === 'win32');
   // useAnimationFrame's clock is shared — capture our start offset so the
   // sweep always begins at hue 0 regardless of when we mount.
   const startTimeRef = useRef<number | null>(null);

--- a/src/entrypoints/cli.tsx
+++ b/src/entrypoints/cli.tsx
@@ -416,7 +416,7 @@ async function main(): Promise<void> {
   }
 
   // No special flags detected, load and run the full CLI
-  if (process.env.OPENCLAUDE_ENABLE_EARLY_INPUT === '1') {
+  if (process.env.OPENCLAUDE_DISABLE_EARLY_INPUT !== '1') {
     const {
       startCapturingEarlyInput
     } = await import('../utils/earlyInput.js');

--- a/src/ink/components/App.tsx
+++ b/src/ink/components/App.tsx
@@ -229,12 +229,12 @@ export default class App extends PureComponent<Props, State> {
         stopCapturingEarlyInput();
         stdin.ref();
         stdin.setRawMode(true);
-        stdin.resume();
         if (this.stdinMode === 'data') {
           stdin.addListener('data', this.handleDataChunk);
         } else {
           stdin.addListener('readable', this.handleReadable);
         }
+        stdin.resume();
         // Enable bracketed paste mode
         this.props.stdout.write(EBP);
         // Enable terminal focus reporting (DECSET 1004)


### PR DESCRIPTION
## Problem

Three separate issues introduced during the rebrand commit caused keyboard input to freeze or silently drop characters at startup, particularly on Windows CMD/PowerShell and Mac terminals (reported in #228, #220, #205).

## Root Causes & Fixes

### 1. Early input capture disabled by default (`cli.tsx`)

The rebrand commit gated `startCapturingEarlyInput()` behind an opt-in env flag (`OPENCLAUDE_ENABLE_EARLY_INPUT=1`). Characters typed before React finished mounting were silently dropped — users who type immediately after launch see an empty input box with no feedback.

**Fix:** Flipped to an opt-out flag (`OPENCLAUDE_DISABLE_EARLY_INPUT=1`). Early input capture is now on by default, matching the original upstream behaviour.

### 2. `stdin.resume()` called before listener was attached (`App.tsx`)

`stdin.resume()` put the stream into flowing mode before the `data`/`readable` listener was registered. Input arriving in that window was queued and delivered in a burst when the listener connected, flooding React's scheduler and stalling input processing.

**Fix:** Moved `stdin.resume()` to after the listener is attached so the stream only flows once the handler is ready.

### 3. `AnimatedAsterisk` fires ~60 React re-renders in 3 seconds (`AnimatedAsterisk.tsx`)

The startup screen colour sweep animation runs at 50ms intervals for 3000ms. Each tick triggers a re-render of the startup screen subtree, competing with stdin event processing in React's microtask queue. On Windows, where the event loop scheduler is slower, this caused typing to lag or freeze for the first few seconds after launch.

**Fix:** Animation is skipped on Windows (`process.platform === 'win32'`), showing the icon in settled state immediately. Mac and Linux are unaffected.

## Files Changed

| File | Change |
|------|--------|
| `src/entrypoints/cli.tsx` | Re-enable early input capture by default |
| `src/ink/components/App.tsx` | Move `stdin.resume()` after listener registration |
| `src/components/LogoV2/AnimatedAsterisk.tsx` | Skip colour animation on Windows |

## Testing

- Build: `bun run build` — clean, no errors
- Tests: 196/200 pass (4 pre-existing failures unrelated to this change, confirmed by testing before and after)
- Manual: verified on Windows — startup typing, mid-session typing, and Ctrl+C exit all work correctly

Relates to #228, #220, #205