### PR TITLE
fix(openai-shim): ensure tool results are followed by assistant msg

### DIFF
--- a/src/services/api/openaiShim.ts
+++ b/src/services/api/openaiShim.ts
@@ -265,6 +265,16 @@ function convertMessages(
     }
   }
 
+  // Final validation for strict providers (like Mistral):
+  // A 'tool' message MUST be followed by an 'assistant' message.
+  // If the last message is a tool result, add a dummy assistant continuation.
+  if (result.length > 0 && result[result.length - 1].role === 'tool') {
+    result.push({
+      role: 'assistant',
+      content: 'Thinking...',
+    })
+  }
+
   return result
 }
 


### PR DESCRIPTION
  Summary

   - What changed: Modified src/services/api/openaiShim.ts to ensure that any message sequence ending with a
     tool role message is automatically followed by a dummy assistant message ("Thinking...").
   - Why it changed: Certain OpenAI-compatible providers, specifically Mistral and Devstral models, enforce
     strict message ordering. They reject requests where a tool message is followed directly by a user
     message. This scenario occurs frequently when a user interrupts a tool execution (via ESC) and
     immediately submits a new prompt.

  Impact

   - User-facing impact: Fixes the "Unexpected role 'user' after role 'tool'" error for users utilizing
     Mistral-based models or providers with strict validation schemas.
   - Developer/maintainer impact: Increases the robustness of the OpenAI shim by handling provider-specific
     ordering constraints transparently.

  Testing

   - [x] bun run build (Verified via Docker build process)
   - [ ] bun run smoke
   - [x] Focused tests: Verified message sequence construction in convertMessages to confirm the trailing
     assistant message is correctly appended when needed.

  Notes

   - Provider/model path tested: devstral-small-2 via OpenAI-compatible endpoint.
   - Screenshots attached: N/A (Backend logic change).
   - Follow-up work or known limitations: The current fix uses a static string "Thinking...". While sufficient
     for validation, future iterations could potentially merge this logic into a more comprehensive state
     recovery system.