### PR TITLE
fix: make initial model selection respect active provider env

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "smoke": "bun run build && node dist/cli.mjs --version",
     "verify:privacy": "bun run scripts/verify-no-phone-home.ts",
     "build:verified": "bun run build && bun run verify:privacy",
-    "test:provider": "bun test src/services/api/*.test.ts src/utils/context.test.ts",
+    "test:provider": "bun test src/services/api/*.test.ts src/utils/context.test.ts src/utils/model/*.test.ts",
     "doctor:runtime": "bun run scripts/system-check.ts",
     "doctor:runtime:json": "bun run scripts/system-check.ts --json",
     "doctor:report": "bun run scripts/system-check.ts --out reports/doctor-runtime.json",

--- a/src/utils/model/model.ts
+++ b/src/utils/model/model.ts
@@ -68,7 +68,7 @@ export function isNonCustomOpusModel(model: ModelName): boolean {
  * Priority order within this function:
  * 1. Model override during session (from /model command) - highest priority
  * 2. Model override at startup (from --model flag)
- * 3. ANTHROPIC_MODEL environment variable
+ * 3. Active-provider model environment variable
  * 4. Settings (from user's saved settings)
  */
 export function getUserSpecifiedModelSetting(): ModelSetting | undefined {
@@ -84,10 +84,10 @@ export function getUserSpecifiedModelSetting(): ModelSetting | undefined {
     const provider = getAPIProvider()
     specifiedModel =
       (provider === 'gemini' ? process.env.GEMINI_MODEL : undefined) ||
-      (provider === 'openai' || provider === 'gemini' || provider === 'github'
+      (provider === 'openai' || provider === 'codex' || provider === 'github'
         ? process.env.OPENAI_MODEL
         : undefined) ||
-      (provider === 'firstParty' ? process.env.ANTHROPIC_MODEL : undefined) ||
+      process.env.ANTHROPIC_MODEL ||
       settings.model ||
       undefined
   }

--- a/src/utils/model/modelSelection.test.ts
+++ b/src/utils/model/modelSelection.test.ts
@@ -1,0 +1,70 @@
+import { afterEach, expect, test } from 'bun:test'
+
+import { setMainLoopModelOverride } from '../../bootstrap/state.js'
+import { getUserSpecifiedModelSetting } from './model.js'
+
+const originalEnv = {
+  ANTHROPIC_MODEL: process.env.ANTHROPIC_MODEL,
+  GEMINI_MODEL: process.env.GEMINI_MODEL,
+  OPENAI_MODEL: process.env.OPENAI_MODEL,
+  CLAUDE_CODE_USE_GEMINI: process.env.CLAUDE_CODE_USE_GEMINI,
+  CLAUDE_CODE_USE_GITHUB: process.env.CLAUDE_CODE_USE_GITHUB,
+  CLAUDE_CODE_USE_OPENAI: process.env.CLAUDE_CODE_USE_OPENAI,
+}
+
+function restoreEnv(
+  key: keyof typeof originalEnv,
+  value: string | undefined,
+): void {
+  if (value === undefined) {
+    delete process.env[key]
+  } else {
+    process.env[key] = value
+  }
+}
+
+function clearProviderAndModelEnv(): void {
+  delete process.env.ANTHROPIC_MODEL
+  delete process.env.GEMINI_MODEL
+  delete process.env.OPENAI_MODEL
+  delete process.env.CLAUDE_CODE_USE_GEMINI
+  delete process.env.CLAUDE_CODE_USE_GITHUB
+  delete process.env.CLAUDE_CODE_USE_OPENAI
+}
+
+afterEach(() => {
+  setMainLoopModelOverride(undefined)
+  restoreEnv('ANTHROPIC_MODEL', originalEnv.ANTHROPIC_MODEL)
+  restoreEnv('GEMINI_MODEL', originalEnv.GEMINI_MODEL)
+  restoreEnv('OPENAI_MODEL', originalEnv.OPENAI_MODEL)
+  restoreEnv('CLAUDE_CODE_USE_GEMINI', originalEnv.CLAUDE_CODE_USE_GEMINI)
+  restoreEnv('CLAUDE_CODE_USE_GITHUB', originalEnv.CLAUDE_CODE_USE_GITHUB)
+  restoreEnv('CLAUDE_CODE_USE_OPENAI', originalEnv.CLAUDE_CODE_USE_OPENAI)
+})
+
+test('openai provider ignores stale gemini model env when choosing the main loop model', () => {
+  clearProviderAndModelEnv()
+  process.env.CLAUDE_CODE_USE_OPENAI = '1'
+  process.env.OPENAI_MODEL = 'llama-3.3-70b-versatile'
+  process.env.GEMINI_MODEL = 'gemini-2.0-flash-exp'
+
+  expect(getUserSpecifiedModelSetting()).toBe('llama-3.3-70b-versatile')
+})
+
+test('gemini provider ignores stale openai model env when choosing the main loop model', () => {
+  clearProviderAndModelEnv()
+  process.env.CLAUDE_CODE_USE_GEMINI = '1'
+  process.env.GEMINI_MODEL = 'gemini-2.5-flash'
+  process.env.OPENAI_MODEL = 'gpt-4o'
+
+  expect(getUserSpecifiedModelSetting()).toBe('gemini-2.5-flash')
+})
+
+test('first-party provider ignores third-party model env vars', () => {
+  clearProviderAndModelEnv()
+  process.env.ANTHROPIC_MODEL = 'claude-sonnet-4-6'
+  process.env.GEMINI_MODEL = 'gemini-2.0-flash-exp'
+  process.env.OPENAI_MODEL = 'gpt-4o'
+
+  expect(getUserSpecifiedModelSetting()).toBe('claude-sonnet-4-6')
+})

--- a/src/utils/model/modelSelection.test.ts
+++ b/src/utils/model/modelSelection.test.ts
@@ -4,19 +4,28 @@ import { setMainLoopModelOverride } from '../../bootstrap/state.js'
 import { getUserSpecifiedModelSetting } from './model.js'
 
 const originalEnv = {
-  ANTHROPIC_MODEL: process.env.ANTHROPIC_MODEL,
-  GEMINI_MODEL: process.env.GEMINI_MODEL,
-  OPENAI_MODEL: process.env.OPENAI_MODEL,
-  CLAUDE_CODE_USE_BEDROCK: process.env.CLAUDE_CODE_USE_BEDROCK,
-  CLAUDE_CODE_USE_FOUNDRY: process.env.CLAUDE_CODE_USE_FOUNDRY,
-  CLAUDE_CODE_USE_GEMINI: process.env.CLAUDE_CODE_USE_GEMINI,
-  CLAUDE_CODE_USE_GITHUB: process.env.CLAUDE_CODE_USE_GITHUB,
-  CLAUDE_CODE_USE_OPENAI: process.env.CLAUDE_CODE_USE_OPENAI,
-  CLAUDE_CODE_USE_VERTEX: process.env.CLAUDE_CODE_USE_VERTEX,
+  anthropicModel: process.env.ANTHROPIC_MODEL,
+  geminiModel: process.env.GEMINI_MODEL,
+  openaiModel: process.env.OPENAI_MODEL,
+  useBedrock: process.env.CLAUDE_CODE_USE_BEDROCK,
+  useFoundry: process.env.CLAUDE_CODE_USE_FOUNDRY,
+  useGemini: process.env.CLAUDE_CODE_USE_GEMINI,
+  useGithub: process.env.CLAUDE_CODE_USE_GITHUB,
+  useOpenai: process.env.CLAUDE_CODE_USE_OPENAI,
+  useVertex: process.env.CLAUDE_CODE_USE_VERTEX,
 }
 
 function restoreEnv(
-  key: keyof typeof originalEnv,
+  key:
+    | 'ANTHROPIC_MODEL'
+    | 'GEMINI_MODEL'
+    | 'OPENAI_MODEL'
+    | 'CLAUDE_CODE_USE_BEDROCK'
+    | 'CLAUDE_CODE_USE_FOUNDRY'
+    | 'CLAUDE_CODE_USE_GEMINI'
+    | 'CLAUDE_CODE_USE_GITHUB'
+    | 'CLAUDE_CODE_USE_OPENAI'
+    | 'CLAUDE_CODE_USE_VERTEX',
   value: string | undefined,
 ): void {
   if (value === undefined) {
@@ -40,15 +49,15 @@ function clearProviderAndModelEnv(): void {
 
 afterEach(() => {
   setMainLoopModelOverride(undefined)
-  restoreEnv('ANTHROPIC_MODEL', originalEnv.ANTHROPIC_MODEL)
-  restoreEnv('GEMINI_MODEL', originalEnv.GEMINI_MODEL)
-  restoreEnv('OPENAI_MODEL', originalEnv.OPENAI_MODEL)
-  restoreEnv('CLAUDE_CODE_USE_BEDROCK', originalEnv.CLAUDE_CODE_USE_BEDROCK)
-  restoreEnv('CLAUDE_CODE_USE_FOUNDRY', originalEnv.CLAUDE_CODE_USE_FOUNDRY)
-  restoreEnv('CLAUDE_CODE_USE_GEMINI', originalEnv.CLAUDE_CODE_USE_GEMINI)
-  restoreEnv('CLAUDE_CODE_USE_GITHUB', originalEnv.CLAUDE_CODE_USE_GITHUB)
-  restoreEnv('CLAUDE_CODE_USE_OPENAI', originalEnv.CLAUDE_CODE_USE_OPENAI)
-  restoreEnv('CLAUDE_CODE_USE_VERTEX', originalEnv.CLAUDE_CODE_USE_VERTEX)
+  restoreEnv('ANTHROPIC_MODEL', originalEnv.anthropicModel)
+  restoreEnv('GEMINI_MODEL', originalEnv.geminiModel)
+  restoreEnv('OPENAI_MODEL', originalEnv.openaiModel)
+  restoreEnv('CLAUDE_CODE_USE_BEDROCK', originalEnv.useBedrock)
+  restoreEnv('CLAUDE_CODE_USE_FOUNDRY', originalEnv.useFoundry)
+  restoreEnv('CLAUDE_CODE_USE_GEMINI', originalEnv.useGemini)
+  restoreEnv('CLAUDE_CODE_USE_GITHUB', originalEnv.useGithub)
+  restoreEnv('CLAUDE_CODE_USE_OPENAI', originalEnv.useOpenai)
+  restoreEnv('CLAUDE_CODE_USE_VERTEX', originalEnv.useVertex)
 })
 
 test('getUserSpecifiedModelSetting prefers OPENAI_MODEL for openai provider over stale GEMINI_MODEL', () => {

--- a/src/utils/model/modelSelection.test.ts
+++ b/src/utils/model/modelSelection.test.ts
@@ -7,9 +7,12 @@ const originalEnv = {
   ANTHROPIC_MODEL: process.env.ANTHROPIC_MODEL,
   GEMINI_MODEL: process.env.GEMINI_MODEL,
   OPENAI_MODEL: process.env.OPENAI_MODEL,
+  CLAUDE_CODE_USE_BEDROCK: process.env.CLAUDE_CODE_USE_BEDROCK,
+  CLAUDE_CODE_USE_FOUNDRY: process.env.CLAUDE_CODE_USE_FOUNDRY,
   CLAUDE_CODE_USE_GEMINI: process.env.CLAUDE_CODE_USE_GEMINI,
   CLAUDE_CODE_USE_GITHUB: process.env.CLAUDE_CODE_USE_GITHUB,
   CLAUDE_CODE_USE_OPENAI: process.env.CLAUDE_CODE_USE_OPENAI,
+  CLAUDE_CODE_USE_VERTEX: process.env.CLAUDE_CODE_USE_VERTEX,
 }
 
 function restoreEnv(
@@ -27,9 +30,12 @@ function clearProviderAndModelEnv(): void {
   delete process.env.ANTHROPIC_MODEL
   delete process.env.GEMINI_MODEL
   delete process.env.OPENAI_MODEL
+  delete process.env.CLAUDE_CODE_USE_BEDROCK
+  delete process.env.CLAUDE_CODE_USE_FOUNDRY
   delete process.env.CLAUDE_CODE_USE_GEMINI
   delete process.env.CLAUDE_CODE_USE_GITHUB
   delete process.env.CLAUDE_CODE_USE_OPENAI
+  delete process.env.CLAUDE_CODE_USE_VERTEX
 }
 
 afterEach(() => {
@@ -37,12 +43,15 @@ afterEach(() => {
   restoreEnv('ANTHROPIC_MODEL', originalEnv.ANTHROPIC_MODEL)
   restoreEnv('GEMINI_MODEL', originalEnv.GEMINI_MODEL)
   restoreEnv('OPENAI_MODEL', originalEnv.OPENAI_MODEL)
+  restoreEnv('CLAUDE_CODE_USE_BEDROCK', originalEnv.CLAUDE_CODE_USE_BEDROCK)
+  restoreEnv('CLAUDE_CODE_USE_FOUNDRY', originalEnv.CLAUDE_CODE_USE_FOUNDRY)
   restoreEnv('CLAUDE_CODE_USE_GEMINI', originalEnv.CLAUDE_CODE_USE_GEMINI)
   restoreEnv('CLAUDE_CODE_USE_GITHUB', originalEnv.CLAUDE_CODE_USE_GITHUB)
   restoreEnv('CLAUDE_CODE_USE_OPENAI', originalEnv.CLAUDE_CODE_USE_OPENAI)
+  restoreEnv('CLAUDE_CODE_USE_VERTEX', originalEnv.CLAUDE_CODE_USE_VERTEX)
 })
 
-test('openai provider ignores stale gemini model env when choosing the main loop model', () => {
+test('getUserSpecifiedModelSetting prefers OPENAI_MODEL for openai provider over stale GEMINI_MODEL', () => {
   clearProviderAndModelEnv()
   process.env.CLAUDE_CODE_USE_OPENAI = '1'
   process.env.OPENAI_MODEL = 'llama-3.3-70b-versatile'
@@ -51,7 +60,7 @@ test('openai provider ignores stale gemini model env when choosing the main loop
   expect(getUserSpecifiedModelSetting()).toBe('llama-3.3-70b-versatile')
 })
 
-test('gemini provider ignores stale openai model env when choosing the main loop model', () => {
+test('getUserSpecifiedModelSetting prefers GEMINI_MODEL for gemini provider over stale OPENAI_MODEL', () => {
   clearProviderAndModelEnv()
   process.env.CLAUDE_CODE_USE_GEMINI = '1'
   process.env.GEMINI_MODEL = 'gemini-2.5-flash'
@@ -60,7 +69,7 @@ test('gemini provider ignores stale openai model env when choosing the main loop
   expect(getUserSpecifiedModelSetting()).toBe('gemini-2.5-flash')
 })
 
-test('first-party provider ignores third-party model env vars', () => {
+test('getUserSpecifiedModelSetting prefers ANTHROPIC_MODEL for first-party provider over third-party model env vars', () => {
   clearProviderAndModelEnv()
   process.env.ANTHROPIC_MODEL = 'claude-sonnet-4-6'
   process.env.GEMINI_MODEL = 'gemini-2.0-flash-exp'


### PR DESCRIPTION
## Summary

- make `getUserSpecifiedModelSetting()` choose the model env var for the active provider instead of checking unrelated provider env vars first
- add regression tests for stale `GEMINI_MODEL` / `OPENAI_MODEL` cross-provider leakage
- include those model-selection tests in the existing provider test suite

## Impact

- user-facing impact: OpenAI-compatible sessions no longer pick a stale Gemini model when both `OPENAI_MODEL` and `GEMINI_MODEL` are present in the environment
- developer/maintainer impact: provider env precedence is now covered by the normal provider test path, reducing the chance of future regressions

## Root Cause

`getUserSpecifiedModelSetting()` in `src/utils/model/model.ts` previously resolved model env vars in a fixed order:

- `ANTHROPIC_MODEL`
- `GEMINI_MODEL`
- `OPENAI_MODEL`

That ignored the active provider and allowed stale env vars from a different provider to win.

A concrete failure case was:

- `CLAUDE_CODE_USE_OPENAI=1`
- `OPENAI_MODEL=llama-3.3-70b-versatile`
- stale `GEMINI_MODEL=gemini-2.0-flash-exp`

In that state, the runtime could still resolve `gemini-2.0-flash-exp` even though the UI/provider path was OpenAI-compatible.

## Fix

Make model selection provider-aware:

- Gemini provider reads `GEMINI_MODEL`
- OpenAI/Codex/GitHub providers read `OPENAI_MODEL`
- first-party Anthropic reads `ANTHROPIC_MODEL`

This keeps model resolution aligned with the active provider instead of unrelated leftover env vars.

## Testing

- [x] `bun test src/utils/model/modelSelection.test.ts`
- [x] `env -u USER_TYPE bun run test:provider`
- [x] `env -u USER_TYPE bun run smoke`
- [x] `env -u USER_TYPE npm run test:provider-recommendation`

## Notes

- provider/model path tested: OpenAI-compatible, Gemini, and first-party env precedence through the model-selection regression tests
- screenshots attached: n/a
- follow-up work or known limitations: there is a separate interactive startup issue where the splash screen can appear without the REPL prompt in some directories; that is intentionally not included in this PR to keep scope focused

Relates to #300
