### PR TITLE
fix: skip Anthropic MCP registry fetch for third-party providers

### DIFF
--- a/src/services/mcp/officialRegistry.test.ts
+++ b/src/services/mcp/officialRegistry.test.ts
@@ -1,0 +1,61 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test'
+import axios from 'axios'
+
+const originalEnv = { ...process.env }
+
+async function importFreshModule() {
+  return import(`./officialRegistry.ts?ts=${Date.now()}-${Math.random()}`)
+}
+
+beforeEach(() => {
+  process.env = { ...originalEnv }
+})
+
+afterEach(() => {
+  process.env = { ...originalEnv }
+})
+
+describe('prefetchOfficialMcpUrls', () => {
+  test('does not fetch registry when using OpenAI mode', async () => {
+    process.env.CLAUDE_CODE_USE_OPENAI = '1'
+    const getSpy = mock(() => Promise.resolve({ data: { servers: [] } }))
+    axios.get = getSpy as typeof axios.get
+
+    const { prefetchOfficialMcpUrls } = await importFreshModule()
+    await prefetchOfficialMcpUrls()
+
+    expect(getSpy).not.toHaveBeenCalled()
+  })
+
+  test('does not fetch registry when using Gemini mode', async () => {
+    process.env.CLAUDE_CODE_USE_GEMINI = '1'
+    const getSpy = mock(() => Promise.resolve({ data: { servers: [] } }))
+    axios.get = getSpy as typeof axios.get
+
+    const { prefetchOfficialMcpUrls } = await importFreshModule()
+    await prefetchOfficialMcpUrls()
+
+    expect(getSpy).not.toHaveBeenCalled()
+  })
+
+  test('fetches registry in first-party mode', async () => {
+    delete process.env.CLAUDE_CODE_USE_OPENAI
+    delete process.env.CLAUDE_CODE_USE_GEMINI
+    delete process.env.CLAUDE_CODE_USE_GITHUB
+
+    const getSpy = mock(() =>
+      Promise.resolve({
+        data: {
+          servers: [{ server: { remotes: [{ url: 'https://example.com/mcp' }] } }],
+        },
+      }),
+    )
+    axios.get = getSpy as typeof axios.get
+
+    const { prefetchOfficialMcpUrls, isOfficialMcpUrl } = await importFreshModule()
+    await prefetchOfficialMcpUrls()
+
+    expect(getSpy).toHaveBeenCalledTimes(1)
+    expect(isOfficialMcpUrl('https://example.com/mcp')).toBe(true)
+  })
+})

--- a/src/services/mcp/officialRegistry.ts
+++ b/src/services/mcp/officialRegistry.ts
@@ -1,6 +1,7 @@
 import axios from 'axios'
 import { logForDebugging } from '../../utils/debug.js'
 import { errorMessage } from '../../utils/errors.js'
+import { getAPIProvider } from '../../utils/model/providers.js'
 
 type RegistryServer = {
   server: {
@@ -32,6 +33,11 @@ function normalizeUrl(url: string): string | undefined {
  */
 export async function prefetchOfficialMcpUrls(): Promise<void> {
   if (process.env.CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC) {
+    return
+  }
+
+  // Anthropic's official MCP registry is only relevant for first-party mode.
+  if (getAPIProvider() !== 'firstParty') {
     return
   }
 


### PR DESCRIPTION
## Summary
- skip official MCP registry prefetch when the active provider is not first-party
- keep existing Anthropic MCP registry behavior unchanged for first-party mode
- add focused coverage for OpenAI, Gemini, and first-party registry fetch paths

## Validation
- bun test ./src/services/mcp/officialRegistry.test.ts
- bun run build
- bun run smoke
- manual local check: OpenAI mode leaves axiosCalled=false for prefetchOfficialMcpUrls()