### PR TITLE
Start the unused-code cleanup with a narrow components pass

### DIFF
--- a/src/components/AgentProgressLine.tsx
+++ b/src/components/AgentProgressLine.tsx
@@ -1,5 +1,4 @@
 import { c as _c } from "react-compiler-runtime";
-import * as React from 'react';
 import { Box, Text } from '../ink.js';
 import { formatNumber } from '../utils/format.js';
 import type { Theme } from '../utils/theme.js';
@@ -20,7 +19,7 @@ type Props = {
   lastToolInfo?: string | null;
   hideType?: boolean;
 };
-export function AgentProgressLine(t0) {
+export function AgentProgressLine(t0: Props) {
   const $ = _c(32);
   const {
     agentType,

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -1,5 +1,5 @@
 import { c as _c } from "react-compiler-runtime";
-import React from 'react';
+import type { ReactNode } from 'react';
 import { FpsMetricsProvider } from '../context/fpsMetrics.js';
 import { StatsProvider, type StatsStore } from '../context/stats.js';
 import { type AppState, AppStateProvider } from '../state/AppState.js';
@@ -9,14 +9,14 @@ type Props = {
   getFpsMetrics: () => FpsMetrics | undefined;
   stats?: StatsStore;
   initialState: AppState;
-  children: React.ReactNode;
+  children: ReactNode;
 };
 
 /**
  * Top-level wrapper for interactive sessions.
  * Provides FPS metrics, stats context, and app state to the component tree.
  */
-export function App(t0) {
+export function App(t0: Props) {
   const $ = _c(9);
   const {
     getFpsMetrics,

--- a/src/components/ApproveApiKey.tsx
+++ b/src/components/ApproveApiKey.tsx
@@ -1,5 +1,4 @@
 import { c as _c } from "react-compiler-runtime";
-import React from 'react';
 import { Text } from '../ink.js';
 import { saveGlobalConfig } from '../utils/config.js';
 import { Select } from './CustomSelect/index.js';
@@ -8,7 +7,7 @@ type Props = {
   customApiKeyTruncated: string;
   onDone(approved: boolean): void;
 };
-export function ApproveApiKey(t0) {
+export function ApproveApiKey(t0: Props) {
   const $ = _c(17);
   const {
     customApiKeyTruncated,
@@ -16,7 +15,7 @@ export function ApproveApiKey(t0) {
   } = t0;
   let t1;
   if ($[0] !== customApiKeyTruncated || $[1] !== onDone) {
-    t1 = function onChange(value) {
+    t1 = function onChange(value: 'yes' | 'no') {
       bb2: switch (value) {
         case "yes":
           {
@@ -102,7 +101,7 @@ export function ApproveApiKey(t0) {
   }
   let t8;
   if ($[11] !== onChange) {
-    t8 = <Select defaultValue="no" defaultFocusValue="no" options={t7} onChange={value_0 => onChange(value_0 as 'yes' | 'no')} onCancel={() => onChange("no")} />;
+    t8 = <Select defaultValue="no" defaultFocusValue="no" options={t7} onChange={(value_0: string) => onChange(value_0 as 'yes' | 'no')} onCancel={() => onChange("no")} />;
     $[11] = onChange;
     $[12] = t8;
   } else {

--- a/src/components/EffortPicker.tsx
+++ b/src/components/EffortPicker.tsx
@@ -1,18 +1,15 @@
-import React, { useState } from 'react'
+import type { ReactNode } from 'react'
 import { Box, Text } from '../ink.js'
 import { useMainLoopModel } from '../hooks/useMainLoopModel.js'
 import { useAppState, useSetAppState } from '../state/AppState.js'
-import type { EffortLevel, OpenAIEffortLevel } from '../utils/effort.js'
+import type { EffortLevel } from '../utils/effort.js'
 import {
   getAvailableEffortLevels,
   getDisplayedEffortLevel,
   getEffortLevelDescription,
   getEffortLevelLabel,
-  getEffortValueDescription,
   modelSupportsEffort,
   modelUsesOpenAIEffort,
-  standardEffortToOpenAI,
-  isOpenAIEffortLevel,
 } from '../utils/effort.js'
 import { getAPIProvider } from '../utils/model/providers.js'
 import { getReasoningEffortForModel } from '../services/api/providerConfig.js'
@@ -22,7 +19,7 @@ import { KeyboardShortcutHint } from './design-system/KeyboardShortcutHint.js'
 import { Byline } from './design-system/Byline.js'
 
 type EffortOption = {
-  label: React.ReactNode
+  label: ReactNode
   value: string
   description: string
   isAvailable: boolean
@@ -44,8 +41,6 @@ export function EffortPicker({ onSelect, onCancel }: Props) {
 
   // For OpenAI/Codex, get the model's default reasoning effort
   const modelReasoningEffort = usesOpenAIEffort ? getReasoningEffortForModel(model) : undefined
-  const defaultEffortForModel = modelReasoningEffort || currentDisplayedLevel
-
   const options: EffortOption[] = [
     {
       label: <EffortOptionLabel level="auto" text="Auto" isCurrent={false} />,

--- a/src/components/PromptInput/IssueFlagBanner.tsx
+++ b/src/components/PromptInput/IssueFlagBanner.tsx
@@ -1,7 +1,3 @@
-import * as React from 'react';
-import { FLAG_ICON } from '../../constants/figures.js';
-import { Box, Text } from '../../ink.js';
-
 /**
  * ANT-ONLY: Banner shown in the transcript that prompts users to report
  * issues via /issue. Appears when friction is detected in the conversation.


### PR DESCRIPTION
## Summary

- remove clearly unused imports from a small first-pass set of components
- remove one dead local in `src/components/EffortPicker.tsx`
- reconnect a few existing `Props` aliases to their component signatures so they stop surfacing as avoidable noise
- keep the scope intentionally narrow to a low-risk components-only batch

Part of #314.

## Why this changed

Issue #314 tracks a broader unused-code cleanup effort, but the safest way to tackle it is in narrow batches.

This PR starts with a small set of low-risk component cleanups where the evidence is direct:
- imports were present but never referenced
- one local was computed but never used
- several files already had `Props` aliases defined, but the component signatures were no longer typed against them, leaving avoidable unused-type and implicit-`any` noise

Keeping this pass small makes review easier and avoids mixing straightforward cleanup with higher-risk signature or compatibility-placeholder changes.

## Impact

- user-facing impact:
  - no intended runtime or CLI behavior changes
- developer/maintainer impact:
  - reduces unused-symbol noise in a core component slice
  - makes future no-unused sweeps easier to read
  - establishes the pattern for follow-up cleanup PRs from #314

## Changed files

- `src/components/AgentProgressLine.tsx`
- `src/components/App.tsx`
- `src/components/ApproveApiKey.tsx`
- `src/components/EffortPicker.tsx`
- `src/components/PromptInput/IssueFlagBanner.tsx`

## Testing

- [x] `bun run build`
- [x] `bun run smoke`
- [x] focused tests:
  - `timeout 90s bash -lc "bun x tsc --noEmit --noUnusedLocals --noUnusedParameters --pretty false 2>&1 | rg 'src/components/(AgentProgressLine|App|ApproveApiKey|EffortPicker|PromptInput/IssueFlagBanner)\\.tsx'"`

## Notes

- provider/model path tested:
  - none (cleanup-only PR)
- screenshots attached (if UI changed):
  - not applicable
- follow-up work or known limitations:
  - full repo typecheck still has broader baseline noise outside this narrow pass
  - higher-risk unused-parameter / compatibility-placeholder cleanup remains tracked in #314
