### PR TITLE
Continue the unused-code cleanup with a dialog-focused pass

### DIFF
--- a/src/components/AutoModeOptInDialog.tsx
+++ b/src/components/AutoModeOptInDialog.tsx
@@ -14,14 +14,14 @@ type Props = {
   // Startup gate: decline exits the process, so relabel accordingly.
   declineExits?: boolean;
 };
-export function AutoModeOptInDialog(t0) {
+export function AutoModeOptInDialog(t0: Props) {
   const $ = _c(18);
   const {
     onAccept,
     onDecline,
     declineExits
   } = t0;
-  let t1;
+  let t1: [];
   if ($[0] === Symbol.for("react.memo_cache_sentinel")) {
     t1 = [];
     $[0] = t1;
@@ -31,7 +31,7 @@ export function AutoModeOptInDialog(t0) {
   React.useEffect(_temp, t1);
   let t2;
   if ($[1] !== onAccept || $[2] !== onDecline) {
-    t2 = function onChange(value) {
+    t2 = function onChange(value: 'accept' | 'accept-default' | 'decline') {
       bb3: switch (value) {
         case "accept":
           {
@@ -109,7 +109,7 @@ export function AutoModeOptInDialog(t0) {
   }
   let t8;
   if ($[9] !== onChange) {
-    t8 = value_0 => onChange(value_0 as 'accept' | 'accept-default' | 'decline');
+    t8 = (value_0: string) => onChange(value_0 as 'accept' | 'accept-default' | 'decline');
     $[9] = onChange;
     $[10] = t8;
   } else {

--- a/src/components/BypassPermissionsModeDialog.tsx
+++ b/src/components/BypassPermissionsModeDialog.tsx
@@ -1,5 +1,5 @@
 import { c as _c } from "react-compiler-runtime";
-import React, { useCallback } from 'react';
+import React from 'react';
 import { logEvent } from 'src/services/analytics/index.js';
 import { Box, Link, Newline, Text } from '../ink.js';
 import { gracefulShutdownSync } from '../utils/gracefulShutdown.js';
@@ -9,12 +9,12 @@ import { Dialog } from './design-system/Dialog.js';
 type Props = {
   onAccept(): void;
 };
-export function BypassPermissionsModeDialog(t0) {
+export function BypassPermissionsModeDialog(t0: Props) {
   const $ = _c(7);
   const {
     onAccept
   } = t0;
-  let t1;
+  let t1: [];
   if ($[0] === Symbol.for("react.memo_cache_sentinel")) {
     t1 = [];
     $[0] = t1;
@@ -24,7 +24,7 @@ export function BypassPermissionsModeDialog(t0) {
   React.useEffect(_temp, t1);
   let t2;
   if ($[1] !== onAccept) {
-    t2 = function onChange(value) {
+    t2 = function onChange(value: 'accept' | 'decline') {
       bb3: switch (value) {
         case "accept":
           {
@@ -70,7 +70,7 @@ export function BypassPermissionsModeDialog(t0) {
   }
   let t5;
   if ($[5] !== onChange) {
-    t5 = <Dialog title="WARNING: Claude Code running in Bypass Permissions mode" color="error" onCancel={handleEscape}>{t3}<Select options={t4} onChange={value_0 => onChange(value_0 as 'accept' | 'decline')} /></Dialog>;
+    t5 = <Dialog title="WARNING: Claude Code running in Bypass Permissions mode" color="error" onCancel={handleEscape}>{t3}<Select options={t4} onChange={(value_0: string) => onChange(value_0 as 'accept' | 'decline')} /></Dialog>;
     $[5] = onChange;
     $[6] = t5;
   } else {

--- a/src/components/ClaudeMdExternalIncludesDialog.tsx
+++ b/src/components/ClaudeMdExternalIncludesDialog.tsx
@@ -1,5 +1,5 @@
 import { c as _c } from "react-compiler-runtime";
-import React, { useCallback } from 'react';
+import React from 'react';
 import { logEvent } from 'src/services/analytics/index.js';
 import { Box, Link, Text } from '../ink.js';
 import type { ExternalClaudeMdInclude } from '../utils/claudemd.js';
@@ -11,14 +11,14 @@ type Props = {
   isStandaloneDialog?: boolean;
   externalIncludes?: ExternalClaudeMdInclude[];
 };
-export function ClaudeMdExternalIncludesDialog(t0) {
+export function ClaudeMdExternalIncludesDialog(t0: Props) {
   const $ = _c(18);
   const {
     onDone,
     isStandaloneDialog,
     externalIncludes
   } = t0;
-  let t1;
+  let t1: [];
   if ($[0] === Symbol.for("react.memo_cache_sentinel")) {
     t1 = [];
     $[0] = t1;
@@ -28,7 +28,7 @@ export function ClaudeMdExternalIncludesDialog(t0) {
   React.useEffect(_temp, t1);
   let t2;
   if ($[1] !== onDone) {
-    t2 = value => {
+    t2 = (value: 'yes' | 'no') => {
       if (value === "no") {
         logEvent("tengu_claude_md_external_includes_dialog_declined", {});
         saveCurrentProjectConfig(_temp2);
@@ -94,7 +94,7 @@ export function ClaudeMdExternalIncludesDialog(t0) {
   }
   let t10;
   if ($[10] !== handleSelection) {
-    t10 = <Select options={t9} onChange={value_0 => handleSelection(value_0 as 'yes' | 'no')} />;
+    t10 = <Select options={t9} onChange={(value_0: string) => handleSelection(value_0 as 'yes' | 'no')} />;
     $[10] = handleSelection;
     $[11] = t10;
   } else {
@@ -114,17 +114,17 @@ export function ClaudeMdExternalIncludesDialog(t0) {
   }
   return t11;
 }
-function _temp4(include, i) {
+function _temp4(include: ExternalClaudeMdInclude, i: number) {
   return <Text key={i} dimColor={true}>{"  "}{include.path}</Text>;
 }
-function _temp3(current_0) {
+function _temp3(current_0: any) {
   return {
     ...current_0,
     hasClaudeMdExternalIncludesApproved: true,
     hasClaudeMdExternalIncludesWarningShown: true
   };
 }
-function _temp2(current) {
+function _temp2(current: any) {
   return {
     ...current,
     hasClaudeMdExternalIncludesApproved: false,

--- a/src/components/DevChannelsDialog.tsx
+++ b/src/components/DevChannelsDialog.tsx
@@ -1,5 +1,4 @@
 import { c as _c } from "react-compiler-runtime";
-import React, { useCallback } from 'react';
 import type { ChannelEntry } from '../bootstrap/state.js';
 import { Box, Text } from '../ink.js';
 import { gracefulShutdownSync } from '../utils/gracefulShutdown.js';
@@ -9,7 +8,7 @@ type Props = {
   channels: ChannelEntry[];
   onAccept(): void;
 };
-export function DevChannelsDialog(t0) {
+export function DevChannelsDialog(t0: Props) {
   const $ = _c(14);
   const {
     channels,
@@ -17,7 +16,7 @@ export function DevChannelsDialog(t0) {
   } = t0;
   let t1;
   if ($[0] !== onAccept) {
-    t1 = function onChange(value) {
+    t1 = function onChange(value: 'accept' | 'exit') {
       bb2: switch (value) {
         case "accept":
           {
@@ -79,7 +78,7 @@ export function DevChannelsDialog(t0) {
   }
   let t7;
   if ($[9] !== onChange) {
-    t7 = <Select options={t6} onChange={value_0 => onChange(value_0 as 'accept' | 'exit')} />;
+    t7 = <Select options={t6} onChange={(value_0: string) => onChange(value_0 as 'accept' | 'exit')} />;
     $[9] = onChange;
     $[10] = t7;
   } else {
@@ -96,7 +95,7 @@ export function DevChannelsDialog(t0) {
   }
   return t8;
 }
-function _temp2(c) {
+function _temp2(c: ChannelEntry) {
   return c.kind === "plugin" ? `plugin:${c.name}@${c.marketplace}` : `server:${c.name}`;
 }
 function _temp() {


### PR DESCRIPTION
## Summary

- continue the unused-code cleanup from #314 with a second narrow dialog-focused pass
- remove avoidable unused imports in dialog components
- reconnect existing `Props` aliases to component signatures
- add explicit callback/parameter typing where the files were surfacing no-unused / implicit-`any` noise

Part of #314.

## Why this changed

PR #316 handled the first small component batch. This follow-up keeps the same strategy: take a homogeneous, low-risk slice instead of widening the existing PR.

These four dialog components shared the same straightforward cleanup shape:
- dormant `Props` aliases
- unused `useCallback` imports
- untyped callback parameters that only existed as compiler noise

Fixing them together keeps the review focused and continues reducing the unused-symbol backlog without drifting into broader refactors.

## Impact

- user-facing impact:
  - no intended runtime or CLI behavior changes
- developer/maintainer impact:
  - further reduces no-unused noise in `src/components/**`
  - keeps the cleanup series incremental and reviewable
  - leaves wider/higher-risk cleanup for later passes

## Changed files

- `src/components/AutoModeOptInDialog.tsx`
- `src/components/BypassPermissionsModeDialog.tsx`
- `src/components/ClaudeMdExternalIncludesDialog.tsx`
- `src/components/DevChannelsDialog.tsx`

## Testing

- [x] `bun run build`
- [x] `bun run smoke`
- [x] focused tests:
  - `timeout 90s bash -lc "bun x tsc --noEmit --noUnusedLocals --noUnusedParameters --pretty false 2>&1 | rg 'src/components/(AutoModeOptInDialog|BypassPermissionsModeDialog|ClaudeMdExternalIncludesDialog|DevChannelsDialog)\\.tsx'"`

## Notes

- provider/model path tested:
  - none (cleanup-only PR)
- screenshots attached (if UI changed):
  - not applicable
- follow-up work or known limitations:
  - broader component cleanup remains, including files like `EffortCallout`, but was intentionally left out to keep this pass uniform
  - full repo typecheck still has unrelated baseline noise outside this scope
