### PR TITLE
Remove another tiny batch of unused React imports

### DIFF
--- a/src/components/FallbackToolUseRejectedMessage.tsx
+++ b/src/components/FallbackToolUseRejectedMessage.tsx
@@ -1,5 +1,4 @@
 import { c as _c } from "react-compiler-runtime";
-import * as React from 'react';
 import { InterruptedByUser } from './InterruptedByUser.js';
 import { MessageResponse } from './MessageResponse.js';
 export function FallbackToolUseRejectedMessage() {

--- a/src/components/HelpV2/General.tsx
+++ b/src/components/HelpV2/General.tsx
@@ -1,5 +1,4 @@
 import { c as _c } from "react-compiler-runtime";
-import * as React from 'react';
 import { Box, Text } from '../../ink.js';
 import { PromptInputHelpMenu } from '../PromptInput/PromptInputHelpMenu.js';
 export function General() {

--- a/src/components/InterruptedByUser.tsx
+++ b/src/components/InterruptedByUser.tsx
@@ -1,5 +1,4 @@
 import { c as _c } from "react-compiler-runtime";
-import * as React from 'react';
 import { Text } from '../ink.js';
 export function InterruptedByUser() {
   const $ = _c(1);

--- a/src/components/LogoV2/AnimatedClawd.tsx
+++ b/src/components/LogoV2/AnimatedClawd.tsx
@@ -1,5 +1,4 @@
 import { c as _c } from "react-compiler-runtime";
-import * as React from 'react';
 import { useEffect, useRef, useState } from 'react';
 import { Box } from '../../ink.js';
 import { getInitialSettings } from '../../utils/settings/settings.js';

--- a/src/components/MCPServerDialogCopy.tsx
+++ b/src/components/MCPServerDialogCopy.tsx
@@ -1,5 +1,4 @@
 import { c as _c } from "react-compiler-runtime";
-import React from 'react';
 import { Link, Text } from '../ink.js';
 export function MCPServerDialogCopy() {
   const $ = _c(1);

--- a/src/components/PressEnterToContinue.tsx
+++ b/src/components/PressEnterToContinue.tsx
@@ -1,5 +1,4 @@
 import { c as _c } from "react-compiler-runtime";
-import * as React from 'react';
 import { Text } from '../ink.js';
 export function PressEnterToContinue() {
   const $ = _c(1);


### PR DESCRIPTION
## Summary

- continue the unused-code cleanup from #314 with an ultra-small fourth pass
- remove unused `React` imports from six files that each had the same single-warning pattern

Part of #314.

## Why this changed

The compiler output exposed a clean mini-batch of files that each had just one straightforward warning: an unused `React` import.

This is the cheapest kind of cleanup to review and merge, so it makes sense to peel it off separately instead of folding it into larger passes.

## Impact

- user-facing impact:
  - no intended runtime or CLI behavior changes
- developer/maintainer impact:
  - reduces no-unused noise with an extremely low-risk diff
  - keeps the cleanup series moving with almost no review overhead

## Changed files

- `src/components/FallbackToolUseRejectedMessage.tsx`
- `src/components/HelpV2/General.tsx`
- `src/components/InterruptedByUser.tsx`
- `src/components/LogoV2/AnimatedClawd.tsx`
- `src/components/MCPServerDialogCopy.tsx`
- `src/components/PressEnterToContinue.tsx`

## Testing

- [x] `bun run build`
- [x] `bun run smoke`
- [x] focused tests:
  - `timeout 90s bash -lc "bun x tsc --noEmit --noUnusedLocals --noUnusedParameters --pretty false 2>&1 | rg 'src/components/(FallbackToolUseRejectedMessage|InterruptedByUser|PressEnterToContinue|MCPServerDialogCopy|HelpV2/General|LogoV2/AnimatedClawd)\\.tsx'"`

## Notes

- provider/model path tested:
  - none (cleanup-only PR)
- screenshots attached (if UI changed):
  - not applicable
- follow-up work or known limitations:
  - broader component cleanup remains in #314, but this pass intentionally stays single-purpose
  - full repo typecheck still has broader noise outside this scope
