### PR TITLE
Trim another small LogoV2 batch of unused React imports

### DIFF
--- a/src/components/LogoV2/GuestPassesUpsell.tsx
+++ b/src/components/LogoV2/GuestPassesUpsell.tsx
@@ -1,5 +1,4 @@
 import { c as _c } from "react-compiler-runtime";
-import * as React from 'react';
 import { useState } from 'react';
 import { Text } from '../../ink.js';
 import { logEvent } from '../../services/analytics/index.js';

--- a/src/components/LogoV2/Opus1mMergeNotice.tsx
+++ b/src/components/LogoV2/Opus1mMergeNotice.tsx
@@ -1,5 +1,4 @@
 import { c as _c } from "react-compiler-runtime";
-import * as React from 'react';
 import { useEffect, useState } from 'react';
 import { UP_ARROW } from '../../constants/figures.js';
 import { Box, Text } from '../../ink.js';

--- a/src/components/LogoV2/VoiceModeNotice.tsx
+++ b/src/components/LogoV2/VoiceModeNotice.tsx
@@ -1,6 +1,5 @@
 import { c as _c } from "react-compiler-runtime";
 import { feature } from 'bun:bundle';
-import * as React from 'react';
 import { useEffect, useState } from 'react';
 import { Box, Text } from '../../ink.js';
 import { getGlobalConfig, saveGlobalConfig } from '../../utils/config.js';


### PR DESCRIPTION
## Summary

- continue the unused-code cleanup from #314 with a fifth narrow pass
- remove unused `React` imports from three `LogoV2` notice/upsell components that shared the same single-warning pattern

Part of #314.

## Why this changed

The compiler output exposed another small, uniform batch: three `LogoV2` components where the only targeted warning was an unused `React` import.

That makes them a good candidate for another micro-pass: easy to review, behavior-neutral, and consistent with the cleanup strategy used in the earlier PRs.

## Impact

- user-facing impact:
  - no intended runtime or CLI behavior changes
- developer/maintainer impact:
  - further reduces no-unused noise in `src/components/LogoV2/**`
  - keeps the cleanup series incremental and low risk

## Changed files

- `src/components/LogoV2/GuestPassesUpsell.tsx`
- `src/components/LogoV2/Opus1mMergeNotice.tsx`
- `src/components/LogoV2/VoiceModeNotice.tsx`

## Testing

- [x] `bun run build`
- [x] `bun run smoke`
- [x] focused tests:
  - `timeout 90s bash -lc "bun x tsc --noEmit --noUnusedLocals --noUnusedParameters --pretty false 2>&1 | rg 'src/components/LogoV2/(GuestPassesUpsell|Opus1mMergeNotice|VoiceModeNotice)\\.tsx'"`

## Notes

- provider/model path tested:
  - none (cleanup-only PR)
- screenshots attached (if UI changed):
  - not applicable
- follow-up work or known limitations:
  - broader component cleanup remains in #314, but this pass intentionally stays single-pattern
  - full repo typecheck still has broader noise outside this scope
