### PR TITLE
Remove another tiny message-component batch of unused React imports

### DIFF
--- a/src/components/messages/CompactBoundaryMessage.tsx
+++ b/src/components/messages/CompactBoundaryMessage.tsx
@@ -1,5 +1,4 @@
 import { c as _c } from "react-compiler-runtime";
-import * as React from 'react';
 import { Box, Text } from '../../ink.js';
 import { useShortcutDisplay } from '../../keybindings/useShortcutDisplay.js';
 export function CompactBoundaryMessage() {

--- a/src/components/messages/UserToolResultMessage/RejectedToolUseMessage.tsx
+++ b/src/components/messages/UserToolResultMessage/RejectedToolUseMessage.tsx
@@ -1,5 +1,4 @@
 import { c as _c } from "react-compiler-runtime";
-import * as React from 'react';
 import { Text } from '../../../ink.js';
 import { MessageResponse } from '../../MessageResponse.js';
 export function RejectedToolUseMessage() {

--- a/src/components/messages/UserToolResultMessage/UserToolCanceledMessage.tsx
+++ b/src/components/messages/UserToolResultMessage/UserToolCanceledMessage.tsx
@@ -1,5 +1,4 @@
 import { c as _c } from "react-compiler-runtime";
-import * as React from 'react';
 import { InterruptedByUser } from 'src/components/InterruptedByUser.js';
 import { MessageResponse } from 'src/components/MessageResponse.js';
 export function UserToolCanceledMessage() {


### PR DESCRIPTION
## Summary

- continue the unused-code cleanup from #314 with a sixth tiny pass
- remove unused `React` imports from three message-related components that shared the same single-warning pattern

Part of #314.

## Why this changed

The compiler output exposed another clean micro-batch in `src/components/messages/**`: three files with the same one-line warning for an unused `React` import.

This is exactly the kind of low-risk cleanup that fits the current strategy: tiny diff, easy review, and no behavior change.

## Impact

- user-facing impact:
  - no intended runtime or CLI behavior changes
- developer/maintainer impact:
  - further reduces no-unused noise in `src/components/messages/**`
  - keeps the cleanup series incremental and easy to merge

## Changed files

- `src/components/messages/CompactBoundaryMessage.tsx`
- `src/components/messages/UserToolResultMessage/RejectedToolUseMessage.tsx`
- `src/components/messages/UserToolResultMessage/UserToolCanceledMessage.tsx`

## Testing

- [x] `bun run build`
- [x] `bun run smoke`
- [x] focused tests:
  - `timeout 90s bash -lc "bun x tsc --noEmit --noUnusedLocals --noUnusedParameters --pretty false 2>&1 | rg 'src/components/messages/(CompactBoundaryMessage|UserToolResultMessage/RejectedToolUseMessage|UserToolResultMessage/UserToolCanceledMessage)\\.tsx'"`

## Notes

- provider/model path tested:
  - none (cleanup-only PR)
- screenshots attached (if UI changed):
  - not applicable
- follow-up work or known limitations:
  - broader cleanup remains in #314, but this pass intentionally stays one-line and message-scoped
  - full repo typecheck still has broader noise outside this scope
