### PR TITLE
Remove a tiny PromptInput pair of unused React imports

### DIFF
--- a/src/components/PromptInput/PromptInputFooterSuggestions.test.tsx
+++ b/src/components/PromptInput/PromptInputFooterSuggestions.test.tsx
@@ -1,5 +1,4 @@
 import figures from 'figures'
-import React from 'react'
 import { describe, expect, it } from 'bun:test'
 import { renderToString } from '../../utils/staticRender.js'
 import {

--- a/src/components/PromptInput/PromptInputFooterSuggestions.tsx
+++ b/src/components/PromptInput/PromptInputFooterSuggestions.tsx
@@ -1,5 +1,4 @@
 import figures from 'figures'
-import * as React from 'react'
 import { memo, type ReactNode } from 'react'
 import { useTerminalSize } from '../../hooks/useTerminalSize.js'
 import { stringWidth } from '../../ink/stringWidth.js'


### PR DESCRIPTION
## Summary

- continue the unused-code cleanup from #314 with a seventh tiny pass
- remove unused `React` imports from a two-file `PromptInputFooterSuggestions` pair

Part of #314.

## Why this changed

The compiler output exposed a neat pair of files in `src/components/PromptInput/**` — the component and its test — that both had the same single warning for an unused `React` import.

That makes them a good fit for another micro-pass: tightly scoped, behavior-neutral, and easy to review as a single unit.

## Impact

- user-facing impact:
  - no intended runtime or CLI behavior changes
- developer/maintainer impact:
  - further reduces no-unused noise in `src/components/PromptInput/**`
  - keeps the cleanup series incremental and low-risk

## Changed files

- `src/components/PromptInput/PromptInputFooterSuggestions.tsx`
- `src/components/PromptInput/PromptInputFooterSuggestions.test.tsx`

## Testing

- [x] `bun run build`
- [x] `bun run smoke`
- [x] focused tests:
  - `timeout 90s bash -lc "bun x tsc --noEmit --noUnusedLocals --noUnusedParameters --pretty false 2>&1 | rg 'src/components/PromptInput/PromptInputFooterSuggestions(\\.test)?\\.tsx'"`

## Notes

- provider/model path tested:
  - none (cleanup-only PR)
- screenshots attached (if UI changed):
  - not applicable
- follow-up work or known limitations:
  - broader cleanup remains in #314, but this pass intentionally stays single-pattern and path-local
  - full repo typecheck still has broader noise outside this scope
