### PR TITLE
fix: guard rawBaseUrl against literal "undefined" string from env vars (issue #336)

### DIFF
--- a/src/services/api/codexShim.test.ts
+++ b/src/services/api/codexShim.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, test } from 'bun:test'
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
 import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
 import { join } from 'node:path'
 import { tmpdir } from 'node:os'
@@ -46,11 +46,47 @@ async function collectStreamEventTypes(responseText: string): Promise<string[]> 
 }
 
 describe('Codex provider config', () => {
+  const originalOpenaiBaseUrl = process.env.OPENAI_BASE_URL
+  const originalOpenaiApiBase = process.env.OPENAI_API_BASE
+
+  beforeEach(() => {
+    delete process.env.OPENAI_BASE_URL
+    delete process.env.OPENAI_API_BASE
+  })
+
+  afterEach(() => {
+    if (originalOpenaiBaseUrl === undefined) delete process.env.OPENAI_BASE_URL
+    else process.env.OPENAI_BASE_URL = originalOpenaiBaseUrl
+    if (originalOpenaiApiBase === undefined) delete process.env.OPENAI_API_BASE
+    else process.env.OPENAI_API_BASE = originalOpenaiApiBase
+  })
+
   test('resolves codexplan alias to Codex transport with reasoning', () => {
     const resolved = resolveProviderRequest({ model: 'codexplan' })
     expect(resolved.transport).toBe('codex_responses')
     expect(resolved.resolvedModel).toBe('gpt-5.4')
     expect(resolved.reasoning).toEqual({ effort: 'high' })
+  })
+
+  test('resolves codexplan to Codex transport even when OPENAI_BASE_URL is the string "undefined"', () => {
+    // On Windows, env vars can leak as the literal string "undefined" instead of
+    // the JS value undefined when not properly unset (issue #336).
+    process.env.OPENAI_BASE_URL = 'undefined'
+    const resolved = resolveProviderRequest({ model: 'codexplan' })
+    expect(resolved.transport).toBe('codex_responses')
+  })
+
+  test('resolves codexplan to Codex transport even when OPENAI_BASE_URL is an empty string', () => {
+    process.env.OPENAI_BASE_URL = ''
+    const resolved = resolveProviderRequest({ model: 'codexplan' })
+    expect(resolved.transport).toBe('codex_responses')
+  })
+
+  test('prefers explicit baseUrl option over env var', () => {
+    process.env.OPENAI_BASE_URL = 'https://example.com/v1'
+    const resolved = resolveProviderRequest({ model: 'codexplan', baseUrl: 'https://chatgpt.com/backend-api/codex' })
+    expect(resolved.transport).toBe('codex_responses')
+    expect(resolved.baseUrl).toBe('https://chatgpt.com/backend-api/codex')
   })
 
   test('loads Codex credentials from auth.json fallback', () => {

--- a/src/services/api/providerConfig.ts
+++ b/src/services/api/providerConfig.ts
@@ -112,7 +112,19 @@ function isPrivateIpv6Address(hostname: string): boolean {
 }
 
 function asTrimmedString(value: unknown): string | undefined {
-  return typeof value === 'string' && value.trim() ? value.trim() : undefined
+  if (typeof value !== 'string') return undefined
+  const trimmed = value.trim()
+  return trimmed ? trimmed : undefined
+}
+
+// Reads an env-var-style string intended as a URL or path, rejecting both
+// empty strings and the literal string "undefined" that Windows shells can
+// write when a variable is unset-then-referenced without quotes (issue #336).
+function asEnvUrl(value: string | undefined): string | undefined {
+  if (!value) return undefined
+  const trimmed = value.trim()
+  if (!trimmed || trimmed === 'undefined') return undefined
+  return trimmed
 }
 
 function readNestedString(
@@ -287,10 +299,9 @@ export function resolveProviderRequest(options?: {
     (isGithubMode ? 'github:copilot' : 'gpt-4o')
   const descriptor = parseModelDescriptor(requestedModel)
   const rawBaseUrl =
-    options?.baseUrl ??
-    process.env.OPENAI_BASE_URL ??
-    process.env.OPENAI_API_BASE ??
-    undefined
+    asEnvUrl(options?.baseUrl) ??
+    asEnvUrl(process.env.OPENAI_BASE_URL) ??
+    asEnvUrl(process.env.OPENAI_API_BASE)
   // Use Codex transport only when:
   // - the base URL is explicitly the Codex endpoint, OR
   // - the model is a Codex alias AND no custom base URL has been set


### PR DESCRIPTION
## Summary

Fixes the test failure reported in #336 where `resolveProviderRequest({ model: 'codexplan' })` returns `transport: 'chat_completions'` instead of `'codex_responses'` when run on Windows.

## Root cause

On Windows, shells can write the literal string `"undefined"` into `OPENAI_BASE_URL` (or `OPENAI_API_BASE`) when the variable is referenced while unset, without quotes. The nullish-coalescing operator (`??`) does not filter this because `"undefined"` is a truthy string. As a result:

```
rawBaseUrl = "undefined"   // truthy — not null/undefined
!rawBaseUrl = false
(!rawBaseUrl && isCodexAlias('codexplan')) = false
→ transport = 'chat_completions'  // wrong
```

## Fix

Introduce a small private helper `asEnvUrl()` that trims the value and rejects both empty strings and the sentinel string `"undefined"`. Apply it to all three `rawBaseUrl` sources (`options.baseUrl`, `OPENAI_BASE_URL`, `OPENAI_API_BASE`).

```ts
function asEnvUrl(value: string | undefined): string | undefined {
  if (!value) return undefined
  const trimmed = value.trim()
  if (!trimmed || trimmed === 'undefined') return undefined
  return trimmed
}
```

## Tests added

Three new test cases in the `'Codex provider config'` describe block in `codexShim.test.ts`:

- `OPENAI_BASE_URL = 'undefined'` → transport stays `codex_responses`
- `OPENAI_BASE_URL = ''` → transport stays `codex_responses`  
- explicit `baseUrl` option wins over `OPENAI_BASE_URL`

Also added `beforeEach`/`afterEach` guards so individual tests cannot contaminate each other via env var state.

## Affected files

- `src/services/api/providerConfig.ts` — new `asEnvUrl()` helper, applied to `rawBaseUrl`
- `src/services/api/codexShim.test.ts` — three new test cases + env isolation guards

Closes #336