### PR TITLE
Reduce internal-only labeling noise in source comments

### DIFF
--- a/src/bootstrap/state.ts
+++ b/src/bootstrap/state.ts
@@ -112,7 +112,7 @@ type State = {
   agentColorIndex: number
   // Last API request for bug reports
   lastAPIRequest: Omit<BetaMessageStreamParams, 'messages'> | null
-  // Messages from the last API request (ant-only; reference, not clone).
+  // Messages from the last API request (internal-only; reference, not clone).
   // Captures the exact post-compaction, CLAUDE.md-injected message set sent
   // to the API so /share's serialized_conversation.json reflects reality.
   lastAPIRequestMessages: BetaMessageStreamParams['messages'] | null
@@ -185,7 +185,7 @@ type State = {
       agentId: string | null
     }
   >
-  // Track slow operations for dev bar display (ant-only)
+  // Track slow operations for dev bar display (internal-only)
   slowOperations: Array<{
     operation: string
     durationMs: number

--- a/src/bridge/bridgeConfig.ts
+++ b/src/bridge/bridgeConfig.ts
@@ -1,11 +1,11 @@
 /**
- * Shared bridge auth/URL resolution. Consolidates the ant-only
+ * Shared bridge auth/URL resolution. Consolidates the internal-only
  * CLAUDE_BRIDGE_* dev overrides that were previously copy-pasted across
  * a dozen files — inboundAttachments, BriefTool/upload, bridgeMain,
  * initReplBridge, remoteBridgeCore, daemon workers, /rename,
  * /remote-control.
  *
- * Two layers: *Override() returns the ant-only env var (or undefined);
+ * Two layers: *Override() returns the internal-only env var (or undefined);
  * the non-Override versions fall through to the real OAuth store/config.
  * Callers that compose with a different auth source (e.g. daemon workers
  * using IPC auth) use the Override getters directly.

--- a/src/bridge/bridgeEnabled.ts
+++ b/src/bridge/bridgeEnabled.ts
@@ -174,7 +174,7 @@ export function checkBridgeMinVersion(): string | null {
 
 /**
  * Default for remoteControlAtStartup when the user hasn't explicitly set it.
- * When the CCR_AUTO_CONNECT build flag is present (ant-only) and the
+ * When the CCR_AUTO_CONNECT build flag is present (internal-only) and the
  * tengu_cobalt_harbor GrowthBook gate is on, all sessions connect to CCR by
  * default — the user can still opt out by setting remoteControlAtStartup=false
  * in config (explicit settings always win over this default).

--- a/src/bridge/bridgeMain.ts
+++ b/src/bridge/bridgeMain.ts
@@ -1520,7 +1520,7 @@ export async function runBridgeLoop(
   // Skip when the loop exited fatally (env expired, auth failed, give-up) —
   // resume is impossible in those cases and the message would contradict the
   // error already printed.
-  // feature('KAIROS') gate: --session-id is ant-only; without the gate,
+  // feature('KAIROS') gate: --session-id is internal-only; without the gate,
   // revert to the pre-PR behavior (archive + deregister on every shutdown).
   if (
     feature('KAIROS') &&
@@ -1888,7 +1888,7 @@ export function parseArgs(args: string[]): ParsedArgs {
 
 async function printHelp(): Promise<void> {
   // Use EXTERNAL_PERMISSION_MODES for help text — internal modes (bubble)
-  // are ant-only and auto is feature-gated; they're still accepted by validation.
+  // are internal-only and auto is feature-gated; they're still accepted by validation.
   const { EXTERNAL_PERMISSION_MODES } = await import('../types/permissions.js')
   const modes = EXTERNAL_PERMISSION_MODES.join(', ')
   const showServer = await isMultiSessionSpawnEnabled()
@@ -2356,7 +2356,7 @@ export async function bridgeMain(args: string[]): Promise<void> {
   // environment_id and reuse that for registration (idempotent on the
   // backend). Left undefined otherwise — the backend rejects
   // client-generated UUIDs and will allocate a fresh environment.
-  // feature('KAIROS') gate: --session-id is ant-only; parseArgs already
+  // feature('KAIROS') gate: --session-id is internal-only; parseArgs already
   // rejects the flag when the gate is off, so resumeSessionId is always
   // undefined here in external builds — this guard is for tree-shaking.
   let reuseEnvironmentId: string | undefined

--- a/src/bridge/initReplBridge.ts
+++ b/src/bridge/initReplBridge.ts
@@ -161,7 +161,7 @@ export async function initReplBridge(
     return null
   }
 
-  // When CLAUDE_BRIDGE_OAUTH_TOKEN is set (ant-only local dev), the bridge
+  // When CLAUDE_BRIDGE_OAUTH_TOKEN is set (internal-only local dev), the bridge
   // uses that token directly via getBridgeAccessToken() — keychain state is
   // irrelevant. Skip 2b/2c to preserve that decoupling: an expired keychain
   // token shouldn't block a bridge connection that doesn't use it.

--- a/src/bridge/remoteBridgeCore.ts
+++ b/src/bridge/remoteBridgeCore.ts
@@ -1,4 +1,4 @@
-// biome-ignore-all assist/source/organizeImports: ANT-ONLY import markers must not be reordered
+// biome-ignore-all assist/source/organizeImports: internal-only import markers must not be reordered
 /**
  * Env-less Remote Control bridge core.
  *

--- a/src/bridge/replBridge.ts
+++ b/src/bridge/replBridge.ts
@@ -1,4 +1,4 @@
-// biome-ignore-all assist/source/organizeImports: ANT-ONLY import markers must not be reordered
+// biome-ignore-all assist/source/organizeImports: internal-only import markers must not be reordered
 import { randomUUID } from 'crypto'
 import {
   createBridgeApiClient,

--- a/src/cli/print.ts
+++ b/src/cli/print.ts
@@ -1,4 +1,4 @@
-// biome-ignore-all assist/source/organizeImports: ANT-ONLY import markers must not be reordered
+// biome-ignore-all assist/source/organizeImports: internal-only import markers must not be reordered
 import { feature } from 'bun:bundle'
 import { readFile, stat } from 'fs/promises'
 import { dirname } from 'path'
@@ -2829,7 +2829,7 @@ function runHeadlessStreaming(
 
       if (message.type === 'control_request') {
         if (message.request.subtype === 'interrupt') {
-          // Track escapes for attribution (ant-only feature)
+          // Track escapes for attribution (internal-only feature)
           if (feature('COMMIT_ATTRIBUTION')) {
             setAppState(prev => ({
               ...prev,
@@ -3765,7 +3765,7 @@ function runHeadlessStreaming(
             ...getSettingsWithSources(),
             applied: {
               model,
-              // Numeric effort (ant-only) → null; SDK schema is string-level only.
+              // Numeric effort (internal-only) → null; SDK schema is string-level only.
               effort: typeof effort === 'string' ? effort : null,
             },
           })
@@ -5025,7 +5025,7 @@ async function loadInitialMessages(
   }
 
   // Handle resume in print mode (accepts session ID or URL)
-  // URLs are [ANT-ONLY]
+  // URLs are [internal-only]
   if (options.resume) {
     try {
       logEvent('tengu_resume_print', {})

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -1,4 +1,4 @@
-// biome-ignore-all assist/source/organizeImports: ANT-ONLY import markers must not be reordered
+// biome-ignore-all assist/source/organizeImports: internal-only import markers must not be reordered
 import addDir from './commands/add-dir/index.js'
 import autofixPr from './commands/autofix-pr/index.js'
 import backfillSessions from './commands/backfill-sessions/index.js'

--- a/src/commands/context/context-noninteractive.ts
+++ b/src/commands/context/context-noninteractive.ts
@@ -199,7 +199,7 @@ function formatContextAsMarkdownTable(data: ContextData): string {
     output += `\n`
   }
 
-  // System tools (ant-only)
+  // System tools (internal-only)
   if (
     systemTools &&
     systemTools.length > 0 &&
@@ -214,7 +214,7 @@ function formatContextAsMarkdownTable(data: ContextData): string {
     output += `\n`
   }
 
-  // System prompt sections (ant-only)
+  // System prompt sections (internal-only)
   if (
     systemPromptSections &&
     systemPromptSections.length > 0 &&
@@ -288,7 +288,7 @@ function formatContextAsMarkdownTable(data: ContextData): string {
     output += `\n`
   }
 
-  // Message breakdown (ant-only)
+  // Message breakdown (internal-only)
   if (messageBreakdown && process.env.USER_TYPE === 'ant') {
     output += `### [ANT-ONLY] Message Breakdown\n\n`
     output += `| Category | Tokens |\n`

--- a/src/commands/insights.ts
+++ b/src/commands/insights.ts
@@ -2187,7 +2187,7 @@ function generateHtmlReport(
     `
       : ''
 
-  // Build Team Feedback section (collapsible, ant-only)
+  // Build Team Feedback section (collapsible, internal-only)
   const ccImprovements =
     process.env.USER_TYPE === 'ant'
       ? insights.cc_team_improvements?.improvements || []
@@ -2804,7 +2804,7 @@ export async function generateUsageReport(options?: {
 }> {
   let remoteStats: { hosts: RemoteHostInfo[]; totalCopied: number } | undefined
 
-  // Optionally collect data from remote hosts first (ant-only)
+  // Optionally collect data from remote hosts first (internal-only)
   if (process.env.USER_TYPE === 'ant' && options?.collectRemote) {
     const destDir = join(getClaudeConfigHomeDir(), 'projects')
     const { hosts, totalCopied } = await collectAllRemoteHostData(destDir)
@@ -3085,7 +3085,7 @@ const usageReport: Command = {
       `${data.git_commits} commits`,
     ].join(' · ')
 
-    // Build remote host info (ant-only)
+    // Build remote host info (internal-only)
     let remoteInfo = ''
     if (process.env.USER_TYPE === 'ant') {
       if (remoteStats && remoteStats.totalCopied > 0) {

--- a/src/commands/terminalSetup/terminalSetup.tsx
+++ b/src/commands/terminalSetup/terminalSetup.tsx
@@ -118,7 +118,7 @@ export async function setupTerminal(theme: ThemeName): Promise<string> {
   });
   maybeMarkProjectOnboardingComplete();
 
-  // Install shell completions (ant-only, since the completion command is ant-only)
+  // Install shell completions (internal-only, since the completion command is internal-only)
   if ("external" === 'ant') {
     result += await setupShellCompletion(theme);
   }

--- a/src/commands/ultraplan.tsx
+++ b/src/commands/ultraplan.tsx
@@ -52,7 +52,7 @@ const DEFAULT_INSTRUCTIONS: string = (typeof _rawPrompt === 'string' ? _rawPromp
 // so the override path is DCE'd from external builds).
 // Shell-set env only, so top-level process.env read is fine
 // — settings.env never injects this.
-/* eslint-disable custom-rules/no-process-env-top-level, custom-rules/no-sync-fs -- ant-only dev override; eager top-level read is the point (crash at startup, not silently inside the slash-command try/catch) */
+/* eslint-disable custom-rules/no-process-env-top-level, custom-rules/no-sync-fs -- internal-only dev override; eager top-level read is the point (crash at startup, not silently inside the slash-command try/catch) */
 const ULTRAPLAN_INSTRUCTIONS: string = "external" === 'ant' && process.env.ULTRAPLAN_PROMPT_FILE ? readFileSync(process.env.ULTRAPLAN_PROMPT_FILE, 'utf8').trimEnd() : DEFAULT_INSTRUCTIONS;
 /* eslint-enable custom-rules/no-process-env-top-level, custom-rules/no-sync-fs */
 

--- a/src/components/LogoV2/LogoV2.tsx
+++ b/src/components/LogoV2/LogoV2.tsx
@@ -1,5 +1,5 @@
 import { c as _c } from "react-compiler-runtime";
-// biome-ignore-all assist/source/organizeImports: ANT-ONLY import markers must not be reordered
+// biome-ignore-all assist/source/organizeImports: internal-only import markers must not be reordered
 import * as React from 'react';
 import { Box, Text, color } from '../../ink.js';
 import { useTerminalSize } from '../../hooks/useTerminalSize.js';

--- a/src/components/PromptInput/IssueFlagBanner.tsx
+++ b/src/components/PromptInput/IssueFlagBanner.tsx
@@ -1,5 +1,5 @@
 /**
- * ANT-ONLY: Banner shown in the transcript that prompts users to report
+ * internal-only: Banner shown in the transcript that prompts users to report
  * issues via /issue. Appears when friction is detected in the conversation.
  */
 export function IssueFlagBanner() {

--- a/src/components/PromptInput/PromptInput.tsx
+++ b/src/components/PromptInput/PromptInput.tsx
@@ -293,7 +293,7 @@ function PromptInput({
   // the pill returns null for implicit-and-not-reconnecting, so nav must too,
   // otherwise bridge becomes an invisible selection stop.
   const bridgeFooterVisible = replBridgeConnected && (replBridgeExplicit || replBridgeReconnecting);
-  // Tmux pill (ant-only) — visible when there's an active tungsten session
+  // Tmux pill (internal-only) — visible when there's an active tungsten session
   const hasTungstenSession = useAppState(s => "external" === 'ant' && s.tungstenActiveSession !== undefined);
   const tmuxFooterVisible = "external" === 'ant' && hasTungstenSession;
   // WebBrowser pill — visible when a browser is open
@@ -2153,7 +2153,7 @@ function PromptInput({
     }} onCancel={() => setShowHistoryPicker(false)} />;
   }
 
-  // Show loop mode menu when requested (ant-only, eliminated from external builds)
+  // Show loop mode menu when requested (internal-only, eliminated from external builds)
   if (modelPickerElement) {
     return modelPickerElement;
   }

--- a/src/components/PromptInput/PromptInputFooterLeftSide.tsx
+++ b/src/components/PromptInput/PromptInputFooterLeftSide.tsx
@@ -1,5 +1,5 @@
 import { c as _c } from "react-compiler-runtime";
-// biome-ignore-all assist/source/organizeImports: ANT-ONLY import markers must not be reordered
+// biome-ignore-all assist/source/organizeImports: internal-only import markers must not be reordered
 import { feature } from 'bun:bundle';
 // Dead code elimination: conditional import for COORDINATOR_MODE
 /* eslint-disable @typescript-eslint/no-require-imports */
@@ -364,7 +364,7 @@ function ModeIndicator({
   // BackgroundTaskStatus is NOT in parts — it renders as a Box sibling so
   // its click-target Box isn't nested inside the <Text wrap="truncate">
   // wrapper (reconciler throws on Box-in-Text).
-  // Tmux pill (ant-only) — appears right after tasks in nav order
+  // Tmux pill (internal-only) — appears right after tasks in nav order
   ...("external" === 'ant' && hasTmuxSession ? [<TungstenPill key="tmux" selected={tmuxSelected} />] : []), ...(isAgentSwarmsEnabled() && hasTeams ? [<TeamStatus key="teams" teamsSelected={teamsSelected} showHint={showHint && !hasBackgroundTasks} />] : []), ...(shouldShowPrStatus ? [<PrBadge key="pr-status" number={prStatus.number!} url={prStatus.url!} reviewState={prStatus.reviewState!} />] : [])];
 
   // Check if any in-process teammates exist (for hint text cycling)

--- a/src/components/Settings/Config.tsx
+++ b/src/components/Settings/Config.tsx
@@ -1,5 +1,5 @@
 import { c as _c } from "react-compiler-runtime";
-// biome-ignore-all assist/source/organizeImports: ANT-ONLY import markers must not be reordered
+// biome-ignore-all assist/source/organizeImports: internal-only import markers must not be reordered
 import { feature } from 'bun:bundle';
 import { Box, Text, useTheme, useThemeSetting, useTerminalFocus } from '../../ink.js';
 import type { KeyboardEvent } from '../../ink/events/keyboard-event.js';
@@ -342,7 +342,7 @@ export function Config({
       });
     }
   },
-  // Fast mode toggle (ant-only, eliminated from external builds)
+  // Fast mode toggle (internal-only, eliminated from external builds)
   ...(isFastModeEnabled() && isFastModeAvailable() ? [{
     id: 'fastMode',
     label: `Fast mode (${FAST_MODE_MODEL_DISPLAY} only)`,
@@ -391,7 +391,7 @@ export function Config({
       });
     }
   }] : []),
-  // Speculation toggle (ant-only)
+  // Speculation toggle (internal-only)
   ...("external" === 'ant' ? [{
     id: 'speculationEnabled',
     label: 'Speculative execution',

--- a/src/components/Settings/Settings.tsx
+++ b/src/components/Settings/Settings.tsx
@@ -1,5 +1,5 @@
 import { c as _c } from "react-compiler-runtime";
-// biome-ignore-all assist/source/organizeImports: ANT-ONLY import markers must not be reordered
+// biome-ignore-all assist/source/organizeImports: internal-only import markers must not be reordered
 import * as React from 'react';
 import { Suspense, useState } from 'react';
 import { useKeybinding } from '../../keybindings/useKeybinding.js';

--- a/src/components/Spinner.tsx
+++ b/src/components/Spinner.tsx
@@ -1,5 +1,5 @@
 import { c as _c } from "react-compiler-runtime";
-// biome-ignore-all assist/source/organizeImports: ANT-ONLY import markers must not be reordered
+// biome-ignore-all assist/source/organizeImports: internal-only import markers must not be reordered
 import { Box, Text } from '../ink.js';
 import * as React from 'react';
 import { useEffect, useMemo, useRef, useState } from 'react';
@@ -258,7 +258,7 @@ function SpinnerWithVerbInner({
   const showBtwTip = tipsEnabled && elapsedSnapshot > 30_000 && !getGlobalConfig().btwUseCount;
   const effectiveTip = contextTipsActive ? undefined : showClearTip && !nextTask ? 'Use /clear to start fresh when switching topics and free up context' : showBtwTip && !nextTask ? "Use /btw to ask a quick side question without interrupting Claude's current work" : spinnerTip;
 
-  // Budget text (ant-only) — shown above the tip line
+  // Budget text (internal-only) — shown above the tip line
   let budgetText: string | null = null;
   if (feature('TOKEN_BUDGET')) {
     const budget = getCurrentTurnTokenBudget();

--- a/src/components/Stats.tsx
+++ b/src/components/Stats.tsx
@@ -379,7 +379,7 @@ function OverviewTab({
   // Calculate range days based on selected date range
   const rangeDays = dateRange === '7d' ? 7 : dateRange === '30d' ? 30 : stats.totalDays;
 
-  // Compute shot stats data (ant-only, gated by feature flag)
+  // Compute shot stats data (internal-only, gated by feature flag)
   let shotStatsData: {
     avgShots: string;
     buckets: {
@@ -511,7 +511,7 @@ function OverviewTab({
         </Box>
       </Box>
 
-      {/* Speculation time saved (ant-only) */}
+      {/* Speculation time saved (internal-only) */}
       {"external" === 'ant' && stats.totalSpeculationTimeSavedMs > 0 && <Box flexDirection="row" gap={4}>
             <Box flexDirection="column" width={28}>
               <Text wrap="truncate">
@@ -523,7 +523,7 @@ function OverviewTab({
             </Box>
           </Box>}
 
-      {/* Shot stats (ant-only) */}
+      {/* Shot stats (internal-only) */}
       {shotStatsData && <>
           <Box marginTop={1}>
             <Text>Shot distribution</Text>
@@ -1150,13 +1150,13 @@ function renderOverviewToAnsi(stats: ClaudeCodeStats): string[] {
   const peakHourVal = stats.peakActivityHour !== null ? `${stats.peakActivityHour}:00-${stats.peakActivityHour + 1}:00` : 'N/A';
   lines.push(row('Active days', activeDaysVal, 'Peak hour', peakHourVal));
 
-  // Speculation time saved (ant-only)
+  // Speculation time saved (internal-only)
   if ("external" === 'ant' && stats.totalSpeculationTimeSavedMs > 0) {
     const label = 'Speculation saved:'.padEnd(COL1_LABEL_WIDTH);
     lines.push(label + h(formatDuration(stats.totalSpeculationTimeSavedMs)));
   }
 
-  // Shot stats (ant-only)
+  // Shot stats (internal-only)
   if (feature('SHOT_STATS') && stats.shotDistribution) {
     const dist = stats.shotDistribution;
     const totalWithShots = Object.values(dist).reduce((s, n) => s + n, 0);

--- a/src/components/messages/AttachmentMessage.tsx
+++ b/src/components/messages/AttachmentMessage.tsx
@@ -1,5 +1,5 @@
 import { c as _c } from "react-compiler-runtime";
-// biome-ignore-all assist/source/organizeImports: ANT-ONLY import markers must not be reordered
+// biome-ignore-all assist/source/organizeImports: internal-only import markers must not be reordered
 import React, { useMemo } from 'react';
 import { Ansi, Box, Text } from '../../ink.js';
 import type { Attachment } from 'src/utils/attachments.js';

--- a/src/components/messages/SystemTextMessage.tsx
+++ b/src/components/messages/SystemTextMessage.tsx
@@ -1,5 +1,5 @@
 import { c as _c } from "react-compiler-runtime";
-// biome-ignore-all assist/source/organizeImports: ANT-ONLY import markers must not be reordered
+// biome-ignore-all assist/source/organizeImports: internal-only import markers must not be reordered
 import { Box, Text, type TextProps } from '../../ink.js';
 import { feature } from 'bun:bundle';
 import * as React from 'react';

--- a/src/components/permissions/BashPermissionRequest/BashPermissionRequest.tsx
+++ b/src/components/permissions/BashPermissionRequest/BashPermissionRequest.tsx
@@ -211,7 +211,7 @@ function BashPermissionRequestInner({
   // Editable prefix — initialize synchronously with the best prefix we can
   // extract without tree-sitter, then refine via tree-sitter for compound
   // commands. The sync path matters because TREE_SITTER_BASH is gated
-  // ant-only: in external builds the async refinement below always resolves
+  // internal-only: in external builds the async refinement below always resolves
   // to [] and this initial value is what the user sees.
   //
   // Lazy initializer: this runs regex + split on every render if left in

--- a/src/components/permissions/PowerShellPermissionRequest/powershellToolUseOptions.tsx
+++ b/src/components/permissions/PowerShellPermissionRequest/powershellToolUseOptions.tsx
@@ -39,7 +39,7 @@ export function powershellToolUseOptions({
   }
 
   // Note: No sandbox toggle for PowerShell - sandbox is not supported on Windows
-  // Note: No classifier-reviewed option for PowerShell (ANT-ONLY feature for Bash)
+  // Note: No classifier-reviewed option for PowerShell (internal-only feature for Bash)
 
   // Only show "always allow" options when not restricted by allowManagedPermissionRulesOnly.
   // Prefer the editable prefix input (static extractor + user edits) over the

--- a/src/components/permissions/hooks.ts
+++ b/src/components/permissions/hooks.ts
@@ -164,7 +164,7 @@ export function usePermissionRequestLogging(
       }
     }
 
-    // [ANT-ONLY] Log bash tool calls, so we can categorize
+    // [internal-only] Log bash tool calls, so we can categorize
     // & burn down calls that should have been allowed
     if (process.env.USER_TYPE === 'ant') {
       const parsedInput = BashTool.inputSchema.safeParse(toolUseConfirm.input)

--- a/src/components/tasks/BackgroundTasksDialog.tsx
+++ b/src/components/tasks/BackgroundTasksDialog.tsx
@@ -103,7 +103,7 @@ type ListItem = {
   status: 'running';
 };
 
-// WORKFLOW_SCRIPTS is ant-only (build_flags.yaml). Static imports would leak
+// WORKFLOW_SCRIPTS is internal-only (build_flags.yaml). Static imports would leak
 // ~1.3K lines into external builds. Gate with feature() + require so the
 // bundler can dead-code-eliminate the branch.
 /* eslint-disable @typescript-eslint/no-require-imports */

--- a/src/constants/common.ts
+++ b/src/constants/common.ts
@@ -2,7 +2,7 @@ import memoize from 'lodash-es/memoize.js'
 
 // This ensures you get the LOCAL date in ISO format
 export function getLocalISODate(): string {
-  // Check for ant-only date override
+  // Check for internal-only date override
   if (process.env.CLAUDE_CODE_OVERRIDE_DATE) {
     return process.env.CLAUDE_CODE_OVERRIDE_DATE
   }

--- a/src/constants/prompts.ts
+++ b/src/constants/prompts.ts
@@ -1,4 +1,4 @@
-// biome-ignore-all assist/source/organizeImports: ANT-ONLY import markers must not be reordered
+// biome-ignore-all assist/source/organizeImports: internal-only import markers must not be reordered
 import { type as osType, version as osVersion, release as osRelease } from 'os'
 import { env } from '../utils/env.js'
 import { getIsGit } from '../utils/git.js'
@@ -389,7 +389,7 @@ function getSessionSpecificGuidanceSection(
       : null,
     hasAgentTool &&
     feature('VERIFICATION_AGENT') &&
-    // 3P default: false — verification agent is ant-only A/B
+    // 3P default: false — verification agent is internal-only A/B
     getFeatureValue_CACHED_MAY_BE_STALE('tengu_hive_evidence', false)
       ? `The contract: when non-trivial implementation happens on your turn, independent adversarial verification must happen before you report completion \u2014 regardless of who did the implementing (you directly, a fork you spawned, or a subagent). You are the one reporting to the user; you own the gate. Non-trivial means: 3+ file edits, backend/API changes, or infrastructure changes. Spawn the ${AGENT_TOOL_NAME} tool with subagent_type="${VERIFICATION_AGENT_TYPE}". Your own checks, caveats, and a fork's self-checks do NOT substitute \u2014 only the verifier assigns a verdict; you cannot self-assign PARTIAL. Pass the original user request, all files changed (by anyone), the approach, and the plan file path if applicable. Flag concerns if you have them but do NOT share test results or claim things work. On FAIL: fix, resume the verifier with its findings plus your fix, repeat until PASS. On PASS: spot-check it \u2014 re-run 2-3 commands from its report, confirm every PASS has a Command run block with output that matches your re-run. If any PASS lacks a command block or diverges, resume the verifier with the specifics. On PARTIAL (from the verifier): report what passed and what could not be verified.`
       : null,

--- a/src/constants/tools.ts
+++ b/src/constants/tools.ts
@@ -1,4 +1,4 @@
-// biome-ignore-all assist/source/organizeImports: ANT-ONLY import markers must not be reordered
+// biome-ignore-all assist/source/organizeImports: internal-only import markers must not be reordered
 import { feature } from 'bun:bundle'
 import { TASK_OUTPUT_TOOL_NAME } from '../tools/TaskOutputTool/constants.js'
 import { EXIT_PLAN_MODE_V2_TOOL_NAME } from '../tools/ExitPlanModeTool/constants.js'

--- a/src/context.ts
+++ b/src/context.ts
@@ -19,7 +19,7 @@ import { logError } from './utils/log.js'
 
 const MAX_STATUS_CHARS = 2000
 
-// System prompt injection for cache breaking (ant-only, ephemeral debugging state)
+// System prompt injection for cache breaking (internal-only, ephemeral debugging state)
 let systemPromptInjection: string | null = null
 
 export function getSystemPromptInjection(): string | null {
@@ -127,7 +127,7 @@ export const getSystemContext = memoize(
         ? null
         : await getGitStatus()
 
-    // Include system prompt injection if set (for cache breaking, ant-only)
+    // Include system prompt injection if set (for cache breaking, internal-only)
     const injection = feature('BREAK_CACHE_COMMAND')
       ? getSystemPromptInjection()
       : null

--- a/src/entrypoints/sdk/controlSchemas.ts
+++ b/src/entrypoints/sdk/controlSchemas.ts
@@ -505,7 +505,7 @@ export const SDKControlGetSettingsResponseSchema = lazySchema(() =>
       applied: z
         .object({
           model: z.string(),
-          // String levels only — numeric effort is ant-only and the
+          // String levels only — numeric effort is internal-only and the
           // Zod→proto generator can't emit enum∪number unions.
           effort: z.enum(['low', 'medium', 'high', 'max']).nullable(),
         })

--- a/src/hooks/useMergedTools.ts
+++ b/src/hooks/useMergedTools.ts
@@ -1,4 +1,4 @@
-// biome-ignore-all assist/source/organizeImports: ANT-ONLY import markers must not be reordered
+// biome-ignore-all assist/source/organizeImports: internal-only import markers must not be reordered
 import { useMemo } from 'react'
 import type { Tools, ToolPermissionContext } from '../Tool.js'
 import { assembleToolPool } from '../tools.js'

--- a/src/keybindings/defaultBindings.ts
+++ b/src/keybindings/defaultBindings.ts
@@ -306,7 +306,7 @@ export const DEFAULT_BINDINGS: KeybindingBlock[] = [
       // Note: diff:back is handled by left arrow in detail mode
     },
   },
-  // Model picker effort cycling (ant-only)
+  // Model picker effort cycling (internal-only)
   {
     context: 'ModelPicker',
     bindings: {

--- a/src/keybindings/schema.ts
+++ b/src/keybindings/schema.ts
@@ -150,7 +150,7 @@ export const KEYBINDING_ACTIONS = [
   'diff:viewDetails',
   'diff:previousFile',
   'diff:nextFile',
-  // Model picker actions (ant-only)
+  // Model picker actions (internal-only)
   'modelPicker:decreaseEffort',
   'modelPicker:increaseEffort',
   // Select component actions (distinct from confirm: to avoid collisions)

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1127,7 +1127,7 @@ async function run(): Promise<CommanderCommand> {
     // Extract disable slash commands flag
     const disableSlashCommands = options.disableSlashCommands || false;
 
-    // Extract tasks mode options (ant-only)
+    // Extract tasks mode options (internal-only)
     const tasksOption = "external" === 'ant' && (options as {
       tasks?: boolean | string;
     }).tasks;
@@ -2213,7 +2213,7 @@ async function run(): Promise<CommanderCommand> {
       const ctx = getRenderContext(false);
       getFpsMetrics = ctx.getFpsMetrics;
       stats = ctx.stats;
-      // Install asciicast recorder before Ink mounts (ant-only, opt-in via CLAUDE_CODE_TERMINAL_RECORDING=1)
+      // Install asciicast recorder before Ink mounts (internal-only, opt-in via CLAUDE_CODE_TERMINAL_RECORDING=1)
       if ("external" === 'ant') {
         installAsciicastRecorder();
       }
@@ -2246,7 +2246,7 @@ async function run(): Promise<CommanderCommand> {
         }
       }
 
-      // Check for pending agent memory snapshot updates (only for --agent mode, ant-only)
+      // Check for pending agent memory snapshot updates (only for --agent mode, internal-only)
       if (feature('AGENT_MEMORY_SNAPSHOT') && mainThreadAgentDefinition && isCustomAgent(mainThreadAgentDefinition) && mainThreadAgentDefinition.memory && mainThreadAgentDefinition.pendingSnapshotUpdate) {
         const agentDef = mainThreadAgentDefinition;
         const choice = await launchSnapshotUpdateDialog(root, {
@@ -3041,7 +3041,7 @@ async function run(): Promise<CommanderCommand> {
       logSessionTelemetry();
     });
 
-    // Set up per-turn session environment data uploader (ant-only build).
+    // Set up per-turn session environment data uploader (internal-only build).
     // Default-enabled for all ant users when working in an Anthropic-owned
     // repo. Captures git/filesystem state (NOT transcripts) at each turn so
     // environments can be recreated at any user message index. Gating:
@@ -3341,7 +3341,7 @@ async function run(): Promise<CommanderCommand> {
       }, renderAndRun);
       return;
     } else if (options.resume || options.fromPr || teleport || remote !== null) {
-      // Handle resume flow - from file (ant-only), session ID, or interactive selector
+      // Handle resume flow - from file (internal-only), session ID, or interactive selector
 
       // Clear stale caches before resuming to ensure fresh file/skill discovery
       const {
@@ -4246,7 +4246,7 @@ async function run(): Promise<CommanderCommand> {
     } = await import('./cli/handlers/plugins.js');
     await pluginUpdateHandler(plugin, options);
   });
-  // END ANT-ONLY
+  // END internal-only
 
   // Setup token command
   program.command('setup-token').description('Set up a long-lived authentication token (requires Claude subscription)').action(async () => {
@@ -4361,7 +4361,7 @@ async function run(): Promise<CommanderCommand> {
     });
   }
 
-  // claude rollback (ant-only)
+  // claude rollback (internal-only)
   // Rolls back to previous releases
   if ("external" === 'ant') {
     program.command('rollback [target]').description('[ANT-ONLY] Roll back to a previous release\n\nExamples:\n  claude rollback                                    Go 1 version back from current\n  claude rollback 3                                  Go 3 versions back from current\n  claude rollback 2.0.73-dev.20251217.t190658        Roll back to a specific version').option('-l, --list', 'List recent published versions with ages').option('--dry-run', 'Show what would be installed without installing').option('--safe', 'Roll back to the server-pinned safe version (set by oncall during incidents)').action(async (target?: string, options?: {
@@ -4386,7 +4386,7 @@ async function run(): Promise<CommanderCommand> {
     await installHandler(target, options);
   });
 
-  // ant-only commands
+  // internal-only commands
   if ("external" === 'ant') {
     const validateLogId = (value: string) => {
       const maybeSessionId = validateUuid(value);

--- a/src/query.ts
+++ b/src/query.ts
@@ -1,4 +1,4 @@
-// biome-ignore-all assist/source/organizeImports: ANT-ONLY import markers must not be reordered
+// biome-ignore-all assist/source/organizeImports: internal-only import markers must not be reordered
 import type {
   ToolResultBlockParam,
   ToolUseBlock,

--- a/src/screens/REPL.tsx
+++ b/src/screens/REPL.tsx
@@ -1,5 +1,5 @@
 import { c as _c } from "react-compiler-runtime";
-// biome-ignore-all assist/source/organizeImports: ANT-ONLY import markers must not be reordered
+// biome-ignore-all assist/source/organizeImports: internal-only import markers must not be reordered
 import { feature } from 'bun:bundle';
 import { spawnSync } from 'child_process';
 import { snapshotOutputTokensForTurn, getCurrentTurnTokenBudget, getTurnOutputTokens, getBudgetContinuationCount, getTotalInputTokens } from '../bootstrap/state.js';
@@ -101,7 +101,7 @@ const useVoiceIntegration: typeof import('../hooks/useVoiceIntegration.js').useV
   resetAnchor: () => { }
 });
 const VoiceKeybindingHandler: typeof import('../hooks/useVoiceIntegration.js').VoiceKeybindingHandler = feature('VOICE_MODE') ? require('../hooks/useVoiceIntegration.js').VoiceKeybindingHandler : () => null;
-// Frustration detection is ant-only (dogfooding). Conditional require so external
+// Frustration detection is internal-only (dogfooding). Conditional require so external
 // builds eliminate the module entirely (including its two O(n) useMemos that run
 // on every messages change, plus the GrowthBook fetch).
 const useFrustrationDetection: typeof import('../components/FeedbackSurvey/useFrustrationDetection.js').useFrustrationDetection = "external" === 'ant' ? require('../components/FeedbackSurvey/useFrustrationDetection.js').useFrustrationDetection : () => ({
@@ -726,7 +726,7 @@ export function REPL({
   const [ideToInstallExtension, setIDEToInstallExtension] = useState<IdeType | null>(null);
   const [ideInstallationStatus, setIDEInstallationStatus] = useState<IDEExtensionInstallationStatus | null>(null);
   const [showIdeOnboarding, setShowIdeOnboarding] = useState(false);
-  // Dead code elimination: model switch callout state (ant-only)
+  // Dead code elimination: model switch callout state (internal-only)
   const [showModelSwitchCallout, setShowModelSwitchCallout] = useState(() => {
     if ("external" === 'ant') {
       return shouldShowAntModelSwitch();
@@ -1161,7 +1161,7 @@ export function REPL({
     }
   }, [sessionStatus, waitingFor]);
 
-  // 3P default: off — OSC 21337 is ant-only while the spec stabilizes.
+  // 3P default: off — OSC 21337 is internal-only while the spec stabilizes.
   // Gated so we can roll back if the sidebar indicator conflicts with
   // the title spinner in terminals that render both. When the flag is
   // on, the user-facing config setting controls whether it's active.
@@ -1428,7 +1428,7 @@ export function REPL({
   // Ref instead of state to avoid triggering React re-renders on every
   // streaming text_delta. The spinner reads this via its animation timer.
   const responseLengthRef = useRef(0);
-  // API performance metrics ref for ant-only spinner display (TTFT/OTPS).
+  // API performance metrics ref for internal-only spinner display (TTFT/OTPS).
   // Accumulates metrics from all API requests in a turn for P50 aggregation.
   const apiMetricsRef = useRef<Array<{
     ttftMs: number;
@@ -2044,10 +2044,10 @@ export function REPL({
     // Onboarding dialogs (special conditions)
     if (allowDialogsWithAnimation && showIdeOnboarding) return 'ide-onboarding';
 
-    // Model switch callout (ant-only, eliminated from external builds)
+    // Model switch callout (internal-only, eliminated from external builds)
     if ("external" === 'ant' && allowDialogsWithAnimation && showModelSwitchCallout) return 'model-switch';
 
-    // Undercover auto-enable explainer (ant-only, eliminated from external builds)
+    // Undercover auto-enable explainer (internal-only, eliminated from external builds)
     if ("external" === 'ant' && allowDialogsWithAnimation && showUndercoverCallout) return 'undercover-callout';
 
     // Effort callout (shown once for Opus 4.6 users when effort is enabled)
@@ -2814,7 +2814,7 @@ export function REPL({
     }
     queryCheckpoint('query_end');
 
-    // Capture ant-only API metrics before resetLoadingState clears the ref.
+    // Capture internal-only API metrics before resetLoadingState clears the ref.
     // For multi-request turns (tool use loops), compute P50 across all requests.
     if ("external" === 'ant' && apiMetricsRef.current.length > 0) {
       const entries = apiMetricsRef.current;
@@ -2938,7 +2938,7 @@ export function REPL({
         // can stop the spark animation and show post-turn UI.
         sendBridgeResultRef.current();
 
-        // Auto-hide tungsten panel content at turn end (ant-only), but keep
+        // Auto-hide tungsten panel content at turn end (internal-only), but keep
         // tungstenActiveSession set so the pill stays in the footer and the user
         // can reopen the panel. Background tmux tasks (e.g. /hunter) run for
         // minutes — wiping the session made the pill disappear entirely, forcing
@@ -2955,7 +2955,7 @@ export function REPL({
           });
         }
 
-        // Capture budget info before clearing (ant-only)
+        // Capture budget info before clearing (internal-only)
         let budgetInfo: {
           tokens: number;
           limit: number;
@@ -4901,7 +4901,7 @@ export function REPL({
             {postCompactSurvey.state !== 'closed' ? <FeedbackSurvey state={postCompactSurvey.state} lastResponse={postCompactSurvey.lastResponse} handleSelect={postCompactSurvey.handleSelect} inputValue={inputValue} setInputValue={setInputValue} onRequestFeedback={handleSurveyRequestFeedback} /> : memorySurvey.state !== 'closed' ? <FeedbackSurvey state={memorySurvey.state} lastResponse={memorySurvey.lastResponse} handleSelect={memorySurvey.handleSelect} handleTranscriptSelect={memorySurvey.handleTranscriptSelect} inputValue={inputValue} setInputValue={setInputValue} onRequestFeedback={handleSurveyRequestFeedback} message="How well did Claude use its memory? (optional)" /> : <FeedbackSurvey state={feedbackSurvey.state} lastResponse={feedbackSurvey.lastResponse} handleSelect={feedbackSurvey.handleSelect} handleTranscriptSelect={feedbackSurvey.handleTranscriptSelect} inputValue={inputValue} setInputValue={setInputValue} onRequestFeedback={didAutoRunIssueRef.current ? undefined : handleSurveyRequestFeedback} />}
             {/* Frustration-triggered transcript sharing prompt */}
             {frustrationDetection.state !== 'closed' && <FeedbackSurvey state={frustrationDetection.state} lastResponse={null} handleSelect={() => { }} handleTranscriptSelect={frustrationDetection.handleTranscriptSelect} inputValue={inputValue} setInputValue={setInputValue} />}
-            {/* Skill improvement survey - appears when improvements detected (ant-only) */}
+            {/* Skill improvement survey - appears when improvements detected (internal-only) */}
             {"external" === 'ant' && skillImprovementSurvey.suggestion && <SkillImprovementSurvey isOpen={skillImprovementSurvey.isOpen} skillName={skillImprovementSurvey.suggestion.skillName} updates={skillImprovementSurvey.suggestion.updates} handleSelect={skillImprovementSurvey.handleSelect} inputValue={inputValue} setInputValue={setInputValue} />}
             {showIssueFlagBanner && <IssueFlagBanner />}
             { }

--- a/src/services/SessionMemory/sessionMemory.ts
+++ b/src/services/SessionMemory/sessionMemory.ts
@@ -282,7 +282,7 @@ const extractSessionMemory = sequential(async function (
 
   // Check gate lazily when hook runs (cached, non-blocking)
   if (!isSessionMemoryGateEnabled()) {
-    // Log gate failure once per session (ant-only)
+    // Log gate failure once per session (internal-only)
     if (process.env.USER_TYPE === 'ant' && !hasLoggedGateFailure) {
       hasLoggedGateFailure = true
       logEvent('tengu_session_memory_gate_disabled', {})
@@ -359,7 +359,7 @@ export function initSessionMemory(): void {
   // Session memory is used for compaction, so respect auto-compact settings
   const autoCompactEnabled = isAutoCompactEnabled()
 
-  // Log initialization state (ant-only to avoid noise in external logs)
+  // Log initialization state (internal-only to avoid noise in external logs)
   if (process.env.USER_TYPE === 'ant') {
     logEvent('tengu_session_memory_init', {
       auto_compact_enabled: autoCompactEnabled,

--- a/src/services/analytics/firstPartyEventLoggingExporter.ts
+++ b/src/services/analytics/firstPartyEventLoggingExporter.ts
@@ -711,7 +711,7 @@ export class FirstPartyEventLoggingExporter implements LogRecordExporter {
         eventMetadata,
       )
 
-      // _PROTO_* keys are PII-tagged values meant only for privileged BQ
+      // _PROTO_* keys are PII-tagged values meinternal only for privileged BQ
       // columns. Hoist known keys to proto fields, then defensively strip any
       // remaining _PROTO_* so an unrecognized future key can't silently land
       // in the general-access additional_metadata blob. sink.ts applies the

--- a/src/services/analytics/growthbook.ts
+++ b/src/services/analytics/growthbook.ts
@@ -202,7 +202,7 @@ export function hasGrowthBookEnvOverride(feature: string): boolean {
 }
 
 /**
- * Local config overrides set via /config Gates tab (ant-only). Checked after
+ * Local config overrides set via /config Gates tab (internal-only). Checked after
  * env-var overrides — env wins so eval harnesses remain deterministic. Unlike
  * getEnvOverrides this is not memoized: the user can change overrides at
  * runtime, and getGlobalConfig() is already memory-cached (pointer-chase)

--- a/src/services/analytics/metadata.ts
+++ b/src/services/analytics/metadata.ts
@@ -1,4 +1,4 @@
-// biome-ignore-all assist/source/organizeImports: ANT-ONLY import markers must not be reordered
+// biome-ignore-all assist/source/organizeImports: internal-only import markers must not be reordered
 /**
  * Shared event metadata enrichment for analytics systems
  *
@@ -490,9 +490,9 @@ export type EventMetadata = {
   teamName?: string // Team name for swarm agents (from env var or AsyncLocalStorage)
   subscriptionType?: string // OAuth subscription tier (max, pro, enterprise, team)
   rh?: string // Hashed repo remote URL (first 16 chars of SHA256), for joining with server-side data
-  kairosActive?: true // KAIROS assistant mode active (ant-only; set in main.tsx after gate check)
-  skillMode?: 'discovery' | 'coach' | 'discovery_and_coach' // Which skill surfacing mechanism(s) are gated on (ant-only; for BQ session segmentation)
-  observerMode?: 'backseat' | 'skillcoach' | 'both' // Which observer classifiers are gated on (ant-only; for BQ cohort splits on tengu_backseat_* events)
+  kairosActive?: true // KAIROS assistant mode active (internal-only; set in main.tsx after gate check)
+  skillMode?: 'discovery' | 'coach' | 'discovery_and_coach' // Which skill surfacing mechanism(s) are gated on (internal-only; for BQ session segmentation)
+  observerMode?: 'backseat' | 'skillcoach' | 'both' // Which observer classifiers are gated on (internal-only; for BQ cohort splits on tengu_backseat_* events)
 }
 
 /**

--- a/src/services/analytics/sink.ts
+++ b/src/services/analytics/sink.ts
@@ -62,7 +62,7 @@ function logEventImpl(eventName: string, metadata: LogEventMetadata): void {
 
   if (shouldTrackDatadog()) {
     // Datadog is a general-access backend — strip _PROTO_* keys
-    // (unredacted PII-tagged values meant only for the 1P privileged column).
+    // (unredacted PII-tagged values meinternal only for the 1P privileged column).
     void trackDatadogEvent(eventName, stripProtoFields(metadataWithSampleRate))
   }
 

--- a/src/services/api/claude.ts
+++ b/src/services/api/claude.ts
@@ -463,7 +463,7 @@ function configureEffortParams(
     outputConfig.effort = effortValue
     betas.push(EFFORT_BETA_HEADER)
   } else if (process.env.USER_TYPE === 'ant') {
-    // Numeric effort override - ant-only (uses anthropic_internal)
+    // Numeric effort override - internal-only (uses anthropic_internal)
     const existingInternal =
       (extraBodyParams.anthropic_internal as Record<string, unknown>) || {}
     extraBodyParams.anthropic_internal = {
@@ -1195,7 +1195,7 @@ async function* queryModel(
   // Determine if cached microcompact is enabled for this model.
   // Computed once here (in async context) and captured by paramsFromContext.
   // The beta header is also captured here to avoid a top-level import of the
-  // ant-only CACHE_EDITING_BETA_HEADER constant.
+  // internal-only CACHE_EDITING_BETA_HEADER constant.
   let cachedMCEnabled = false
   let cacheEditingBetaHeader = ''
   if (feature('CACHED_MICROCOMPACT')) {

--- a/src/services/api/withRetry.ts
+++ b/src/services/api/withRetry.ts
@@ -75,7 +75,7 @@ const FOREGROUND_529_RETRY_SOURCES = new Set<QuerySource>([
   'side_question',
   // Security classifiers — must complete for auto-mode correctness.
   // yoloClassifier.ts uses 'auto_mode' (not 'yolo_classifier' — that's
-  // type-only). bash_classifier is ant-only; feature-gate so the string
+  // type-only). bash_classifier is internal-only; feature-gate so the string
   // tree-shakes out of external builds (excluded-strings.txt).
   'auto_mode',
   ...(feature('BASH_CLASSIFIER') ? (['bash_classifier'] as const) : []),
@@ -88,7 +88,7 @@ function shouldRetry529(querySource: QuerySource | undefined): boolean {
   )
 }
 
-// CLAUDE_CODE_UNATTENDED_RETRY: for unattended sessions (ant-only). Retries 429/529
+// CLAUDE_CODE_UNATTENDED_RETRY: for unattended sessions (internal-only). Retries 429/529
 // indefinitely with higher backoff and periodic keep-alive yields so the host
 // environment does not mark the session idle mid-wait.
 // TODO(ANT-344): the keep-alive via SystemAPIErrorMessage yields is a stopgap

--- a/src/services/autoDream/autoDream.ts
+++ b/src/services/autoDream/autoDream.ts
@@ -1,4 +1,4 @@
-// biome-ignore-all assist/source/organizeImports: ANT-ONLY import markers must not be reordered
+// biome-ignore-all assist/source/organizeImports: internal-only import markers must not be reordered
 // Background memory consolidation. Fires the /dream prompt as a forked
 // subagent when time-gate passes AND enough sessions have accumulated.
 //

--- a/src/services/compact/apiMicrocompact.ts
+++ b/src/services/compact/apiMicrocompact.ts
@@ -86,7 +86,7 @@ export function getAPIContextManagement(options?: {
     })
   }
 
-  // Tool clearing strategies are ant-only
+  // Tool clearing strategies are internal-only
   if (process.env.USER_TYPE !== 'ant') {
     return strategies.length > 0 ? { edits: strategies } : undefined
   }

--- a/src/services/compact/autoCompact.ts
+++ b/src/services/compact/autoCompact.ts
@@ -188,7 +188,7 @@ export async function shouldAutoCompact(
 
   // Reactive-only mode: suppress proactive autocompact, let reactive compact
   // catch the API's prompt-too-long. feature() wrapper keeps the flag string
-  // out of external builds (REACTIVE_COMPACT is ant-only).
+  // out of external builds (REACTIVE_COMPACT is internal-only).
   // Note: returning false here also means autoCompactIfNeeded never reaches
   // trySessionMemoryCompaction in the query loop — the /compact call site
   // still tries session memory first. Revisit if reactive-only graduates.

--- a/src/services/compact/microCompact.ts
+++ b/src/services/compact/microCompact.ts
@@ -49,7 +49,7 @@ const COMPACTABLE_TOOLS = new Set<string>([
   FILE_WRITE_TOOL_NAME,
 ])
 
-// --- Cached microcompact state (ant-only, gated by feature('CACHED_MICROCOMPACT')) ---
+// --- Cached microcompact state (internal-only, gated by feature('CACHED_MICROCOMPACT')) ---
 
 // Lazy-initialized cached MC module and state to avoid importing in external builds.
 // The imports and state live inside feature() checks for dead code elimination.

--- a/src/services/compact/sessionMemoryCompact.ts
+++ b/src/services/compact/sessionMemoryCompact.ts
@@ -419,7 +419,7 @@ export function shouldUseSessionMemoryCompaction(): boolean {
   )
   const shouldUse = sessionMemoryFlag && smCompactFlag
 
-  // Log flag states for debugging (ant-only to avoid noise in external logs)
+  // Log flag states for debugging (internal-only to avoid noise in external logs)
   if (process.env.USER_TYPE === 'ant') {
     logEvent('tengu_sm_compact_flag_check', {
       tengu_session_memory: sessionMemoryFlag,

--- a/src/services/mockRateLimits.ts
+++ b/src/services/mockRateLimits.ts
@@ -1,4 +1,4 @@
-// Mock rate limits for testing [ANT-ONLY]
+// Mock rate limits for testing [internal-only]
 // This allows testing various rate limit scenarios without hitting actual limits
 //
 // ⚠️  WARNING: This is for internal testing/demo purposes only!

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -341,7 +341,7 @@ export async function setup(
       setImmediate(() => {
         void import('./utils/attributionHooks.js').then(
           ({ registerAttributionHooks }) => {
-            registerAttributionHooks() // Register attribution tracking hooks (ant-only feature)
+            registerAttributionHooks() // Register attribution tracking hooks (internal-only feature)
           },
         )
       })

--- a/src/state/AppState.tsx
+++ b/src/state/AppState.tsx
@@ -10,7 +10,7 @@ import { applySettingsChange } from '../utils/settings/applySettingsChange.js';
 import type { SettingSource } from '../utils/settings/constants.js';
 import { createStore } from './store.js';
 
-// DCE: voice context is ant-only. External builds get a passthrough.
+// DCE: voice context is internal-only. External builds get a passthrough.
 /* eslint-disable @typescript-eslint/no-require-imports */
 const VoiceProvider: (props: {
   children: React.ReactNode;

--- a/src/state/onChangeAppState.ts
+++ b/src/state/onChangeAppState.ts
@@ -140,7 +140,7 @@ export function onChangeAppState({
     }))
   }
 
-  // tungstenPanelVisible (ant-only tmux panel sticky toggle)
+  // tungstenPanelVisible (internal-only tmux panel sticky toggle)
   if (isAntEmployee()) {
     if (
       newState.tungstenPanelVisible !== oldState.tungstenPanelVisible &&

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -1,4 +1,4 @@
-// biome-ignore-all assist/source/organizeImports: ANT-ONLY import markers must not be reordered
+// biome-ignore-all assist/source/organizeImports: internal-only import markers must not be reordered
 import { toolMatchesName, type Tool, type Tools } from './Tool.js'
 import { AgentTool } from './tools/AgentTool/AgentTool.js'
 import { SkillTool } from './tools/SkillTool/SkillTool.js'
@@ -11,7 +11,7 @@ import { NotebookEditTool } from './tools/NotebookEditTool/NotebookEditTool.js'
 import { WebFetchTool } from './tools/WebFetchTool/WebFetchTool.js'
 import { TaskStopTool } from './tools/TaskStopTool/TaskStopTool.js'
 import { BriefTool } from './tools/BriefTool/BriefTool.js'
-// Dead code elimination: conditional import for ant-only tools
+// Dead code elimination: conditional import for internal-only tools
 /* eslint-disable custom-rules/no-process-env-top-level, @typescript-eslint/no-require-imports */
 const REPLTool =
   process.env.USER_TYPE === 'ant'

--- a/src/tools/AgentTool/AgentTool.tsx
+++ b/src/tools/AgentTool/AgentTool.tsx
@@ -430,7 +430,7 @@ export const AgentTool = buildTool({
     // Resolve effective isolation mode (explicit param overrides agent def)
     const effectiveIsolation = isolation ?? selectedAgent.isolation;
 
-    // Remote isolation: delegate to CCR. Gated ant-only — the guard enables
+    // Remote isolation: delegate to CCR. Gated internal-only — the guard enables
     // dead code elimination of the entire block for external builds.
     if ("external" === 'ant' && effectiveIsolation === 'remote') {
       const eligibility = await checkRemoteAgentEligibility();

--- a/src/tools/AgentTool/UI.tsx
+++ b/src/tools/AgentTool/UI.tsx
@@ -323,7 +323,7 @@ export function renderToolResultMessage(data: Output, progressMessagesForMessage
   theme: ThemeName;
   isTranscriptMode?: boolean;
 }): React.ReactNode {
-  // Remote-launched agents (ant-only) use a private output type not in the
+  // Remote-launched agents (internal-only) use a private output type not in the
   // public schema. Narrow via the internal discriminant.
   const internal = data as Output | RemoteLaunchedOutput;
   if (internal.status === 'remote_launched') {

--- a/src/tools/AgentTool/loadAgentsDir.ts
+++ b/src/tools/AgentTool/loadAgentsDir.ts
@@ -123,7 +123,7 @@ export type BaseAgentDefinition = {
   background?: boolean // Always run as background task when spawned
   initialPrompt?: string // Prepended to the first user turn (slash commands work)
   memory?: AgentMemoryScope // Persistent memory scope
-  isolation?: 'worktree' | 'remote' // Run in an isolated git worktree, or remotely in CCR (ant-only)
+  isolation?: 'worktree' | 'remote' // Run in an isolated git worktree, or remotely in CCR (internal-only)
   pendingSnapshotUpdate?: { snapshotTimestamp: string }
   /** Omit CLAUDE.md hierarchy from the agent's userContext. Read-only agents
    * (Explore, Plan) don't need commit/PR/lint guidelines — the main agent has
@@ -604,7 +604,7 @@ export function parseAgentFromMarkdown(
       }
     }
 
-    // Parse isolation mode. 'remote' is ant-only; external builds reject it at parse time.
+    // Parse isolation mode. 'remote' is internal-only; external builds reject it at parse time.
     type IsolationMode = 'worktree' | 'remote'
     const VALID_ISOLATION_MODES: readonly IsolationMode[] =
       process.env.USER_TYPE === 'ant' ? ['worktree', 'remote'] : ['worktree']

--- a/src/tools/AgentTool/runAgent.ts
+++ b/src/tools/AgentTool/runAgent.ts
@@ -371,7 +371,7 @@ export async function* runAgent({
     registerPerfettoAgent(agentId, agentDefinition.agentType, parentId)
   }
 
-  // Log API calls path for subagents (ant-only)
+  // Log API calls path for subagents (internal-only)
   if (process.env.USER_TYPE === 'ant') {
     logForDebugging(
       `[Subagent ${agentDefinition.agentType}] API calls: ${getDisplayPath(getDumpPromptsPath(agentId))}`,

--- a/src/tools/BashTool/readOnlyValidation.ts
+++ b/src/tools/BashTool/readOnlyValidation.ts
@@ -1136,7 +1136,7 @@ const COMMAND_ALLOWLIST: Record<string, CommandConfig> = {
   ...DOCKER_READ_ONLY_COMMANDS,
 }
 
-// gh commands are ant-only since they make network requests, which goes against
+// gh commands are internal-only since they make network requests, which goes against
 // the read-only validation principle of no network access
 const ANT_ONLY_COMMAND_ALLOWLIST: Record<string, CommandConfig> = {
   // All gh read-only commands from shared validation map

--- a/src/tools/SkillTool/SkillTool.ts
+++ b/src/tools/SkillTool/SkillTool.ts
@@ -371,7 +371,7 @@ export const SkillTool: Tool<InputSchema, Output, Progress> = buildTool({
       ? trimmed.substring(1)
       : trimmed
 
-    // Remote canonical skill handling (ant-only experimental). Intercept
+    // Remote canonical skill handling (internal-only experimental). Intercept
     // `_canonical_<slug>` names before local command lookup since remote
     // skills are not in the local command registry.
     if (
@@ -485,7 +485,7 @@ export const SkillTool: Tool<InputSchema, Output, Progress> = buildTool({
       }
     }
 
-    // Remote canonical skills are ant-only experimental — auto-grant.
+    // Remote canonical skills are internal-only experimental — auto-grant.
     // Placed AFTER the deny loop so a user-configured Skill(_canonical_:*)
     // deny rule is honored (same pattern as safe-properties auto-allow below).
     // The skill content itself is canonical/curated, not user-authored.
@@ -597,7 +597,7 @@ export const SkillTool: Tool<InputSchema, Output, Progress> = buildTool({
     // Remove leading slash if present (for compatibility)
     const commandName = trimmed.startsWith('/') ? trimmed.substring(1) : trimmed
 
-    // Remote canonical skill execution (ant-only experimental). Intercepts
+    // Remote canonical skill execution (internal-only experimental). Intercepts
     // `_canonical_<slug>` before local command lookup — loads SKILL.md from
     // AKI/GCS (with local cache), injects content directly as a user message.
     // Remote skills are declarative markdown so no slash-command expansion

--- a/src/types/hooks.ts
+++ b/src/types/hooks.ts
@@ -1,4 +1,4 @@
-// biome-ignore-all assist/source/organizeImports: ANT-ONLY import markers must not be reordered
+// biome-ignore-all assist/source/organizeImports: internal-only import markers must not be reordered
 import { z } from 'zod/v4'
 import { lazySchema } from '../utils/lazySchema.js'
 import {

--- a/src/utils/analyzeContext.ts
+++ b/src/utils/analyzeContext.ts
@@ -408,7 +408,7 @@ async function countBuiltInToolTokens(
         )
       : 0
 
-  // Build per-tool breakdown for always-loaded tools (ant-only, proportional
+  // Build per-tool breakdown for always-loaded tools (internal-only, proportional
   // split of the bulk count based on rough schema size estimation). Excludes
   // SkillTool since its tokens are shown in the separate Skills category.
   let systemToolDetails: SystemToolDetail[] = []

--- a/src/utils/attachments.ts
+++ b/src/utils/attachments.ts
@@ -1,4 +1,4 @@
-// biome-ignore-all assist/source/organizeImports: ANT-ONLY import markers must not be reordered
+// biome-ignore-all assist/source/organizeImports: internal-only import markers must not be reordered
 import {
   logEvent,
   type AnalyticsMetadata_I_VERIFIED_THIS_IS_NOT_CODE_OR_FILEPATHS,

--- a/src/utils/autoRunIssue.tsx
+++ b/src/utils/autoRunIssue.tsx
@@ -96,7 +96,7 @@ export function shouldAutoRunIssue(reason: AutoRunIssueReason): boolean {
 
 /**
  * Returns the appropriate command to auto-run based on the reason
- * ANT-ONLY: good-claude command only exists in ant builds
+ * internal-only: good-claude command only exists in ant builds
  */
 export function getAutoRunCommand(reason: AutoRunIssueReason): string {
   // Only ant builds have the /good-claude command

--- a/src/utils/autoUpdater.ts
+++ b/src/utils/autoUpdater.ts
@@ -417,7 +417,7 @@ export async function getGcsDistTags(): Promise<NpmDistTags> {
 }
 
 /**
- * Get version history from npm registry (ant-only feature)
+ * Get version history from npm registry (internal-only feature)
  * Returns versions sorted newest-first, limited to the specified count
  *
  * Uses NATIVE_PACKAGE_URL when available because:

--- a/src/utils/bash/parser.ts
+++ b/src/utils/bash/parser.ts
@@ -58,7 +58,7 @@ export async function parseCommand(
 ): Promise<ParsedCommandData | null> {
   if (!command || command.length > MAX_COMMAND_LENGTH) return null
 
-  // Gate: ant-only until pentest. External builds fall back to legacy
+  // Gate: internal-only until pentest. External builds fall back to legacy
   // regex/shell-quote path. Guarding the whole body inside the positive
   // branch lets Bun DCE the NAPI import AND keeps telemetry honest — we
   // only fire tengu_tree_sitter_load when a load was genuinely attempted.

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -232,9 +232,9 @@ export type GlobalConfig = {
   }
   primaryApiKey?: string // Primary API key for the user when no environment variable is set, set via oauth (TODO: rename)
   hasAcknowledgedCostThreshold?: boolean
-  hasSeenUndercoverAutoNotice?: boolean // ant-only: whether the one-time auto-undercover explainer has been shown
-  hasSeenUltraplanTerms?: boolean // ant-only: whether the one-time CCR terms notice has been shown in the ultraplan launch dialog
-  hasResetAutoModeOptInForDefaultOffer?: boolean // ant-only: one-shot migration guard, re-prompts churned auto-mode users
+  hasSeenUndercoverAutoNotice?: boolean // internal-only: whether the one-time auto-undercover explainer has been shown
+  hasSeenUltraplanTerms?: boolean // internal-only: whether the one-time CCR terms notice has been shown in the ultraplan launch dialog
+  hasResetAutoModeOptInForDefaultOffer?: boolean // internal-only: one-shot migration guard, re-prompts churned auto-mode users
   oauthAccount?: AccountInfo
   iterm2KeyBindingInstalled?: boolean // Legacy - keeping for backward compatibility
   editorMode?: EditorMode
@@ -405,7 +405,7 @@ export type GlobalConfig = {
   // Claude Code usage tracking
   claudeCodeFirstTokenDate?: string // ISO timestamp of the user's first Claude Code OAuth token
 
-  // Model switch callout tracking (ant-only)
+  // Model switch callout tracking (internal-only)
   modelSwitchCalloutDismissed?: boolean // Whether user chose "Don't show again"
   modelSwitchCalloutLastShown?: number // Timestamp of last shown (don't show for 24h)
   modelSwitchCalloutVersion?: string
@@ -457,7 +457,7 @@ export type GlobalConfig = {
   // Cached GrowthBook feature values
   cachedGrowthBookFeatures?: { [featureName: string]: unknown }
 
-  // Local GrowthBook overrides (ant-only, set via /config Gates tab).
+  // Local GrowthBook overrides (internal-only, set via /config Gates tab).
   // Checked after env-var overrides but before the real resolved value.
   growthBookOverrides?: { [featureName: string]: unknown }
 
@@ -545,7 +545,7 @@ export type GlobalConfig = {
   // PR status footer configuration (feature-flagged via GrowthBook)
   prStatusFooterEnabled?: boolean // Show PR review status in footer (default: true)
 
-  // Tmux live panel visibility (ant-only, toggled via Enter on tmux pill)
+  // Tmux live panel visibility (internal-only, toggled via Enter on tmux pill)
   tungstenPanelVisible?: boolean
 
   // Cached org-level fast mode status from the API.
@@ -564,10 +564,10 @@ export type GlobalConfig = {
   // undefined = no cache, null = extra usage enabled, string = disabled reason.
   cachedExtraUsageDisabledReason?: string | null
 
-  // Auto permissions notification tracking (ant-only)
+  // Auto permissions notification tracking (internal-only)
   autoPermissionsNotificationCount?: number // Number of times the auto permissions notification has been shown
 
-  // Speculation configuration (ant-only)
+  // Speculation configuration (internal-only)
   speculationEnabled?: boolean // Whether speculation is enabled (default: true)
 
 
@@ -913,7 +913,7 @@ let lastReadFileStats: { mtime: number; size: number } | null = null
 let configCacheHits = 0
 let configCacheMisses = 0
 // Session-total count of actual disk writes to the global config file.
-// Exposed for ant-only dev diagnostics (see inc-4552) so anomalous write
+// Exposed for internal-only dev diagnostics (see inc-4552) so anomalous write
 // rates surface in the UI before they corrupt ~/.claude.json.
 let globalConfigWriteCount = 0
 
@@ -1125,7 +1125,7 @@ export function getGlobalConfig(): GlobalConfig {
 /**
  * Returns the effective value of remoteControlAtStartup. Precedence:
  *   1. User's explicit config value (always wins — honors opt-out)
- *   2. CCR auto-connect default (ant-only build, GrowthBook-gated)
+ *   2. CCR auto-connect default (internal-only build, GrowthBook-gated)
  *   3. false (Remote Control must be explicitly opted into)
  */
 export function getRemoteControlAtStartup(): boolean {

--- a/src/utils/context.ts
+++ b/src/utils/context.ts
@@ -1,4 +1,4 @@
-// biome-ignore-all assist/source/organizeImports: ANT-ONLY import markers must not be reordered
+// biome-ignore-all assist/source/organizeImports: internal-only import markers must not be reordered
 import { CONTEXT_1M_BETA_HEADER } from '../constants/betas.js'
 import { getGlobalConfig } from './config.js'
 import { isEnvTruthy } from './envUtils.js'
@@ -53,7 +53,7 @@ export function getContextWindowForModel(
   model: string,
   betas?: string[],
 ): number {
-  // Allow override via environment variable (ant-only)
+  // Allow override via environment variable (internal-only)
   // This takes precedence over all other context window resolution, including 1M detection,
   // so users can cap the effective context window for local decisions (auto-compact, etc.)
   // while still using a 1M-capable endpoint.

--- a/src/utils/conversationRecovery.ts
+++ b/src/utils/conversationRecovery.ts
@@ -50,7 +50,7 @@ import {
 import { jsonStringify } from './slowOperations.js'
 import type { ContentReplacementRecord } from './toolResultStorage.js'
 
-// Dead code elimination: ant-only tool names are conditionally required so
+// Dead code elimination: internal-only tool names are conditionally required so
 // their strings don't leak into external builds. Static imports always bundle.
 /* eslint-disable @typescript-eslint/no-require-imports */
 const BRIEF_TOOL_NAME: string | null =

--- a/src/utils/debugFilter.ts
+++ b/src/utils/debugFilter.ts
@@ -58,7 +58,7 @@ export const parseDebugFilter = memoize(
  * - "category: message" -> ["category"]
  * - "[CATEGORY] message" -> ["category"]
  * - "MCP server \"name\": message" -> ["mcp", "name"]
- * - "[ANT-ONLY] 1P event: tengu_timer" -> ["ant-only", "1p"]
+ * - "[internal-only] 1P event: tengu_timer" -> ["internal-only", "1p"]
  *
  * Returns lowercase categories for case-insensitive matching
  */
@@ -85,7 +85,7 @@ export function extractDebugCategories(message: string): string[] {
   }
 
   // Pattern 4: Check for additional categories in the message
-  // e.g., "[ANT-ONLY] 1P event: tengu_timer" should match both "ant-only" and "1p"
+  // e.g., "[internal-only] 1P event: tengu_timer" should match both "internal-only" and "1p"
   if (message.toLowerCase().includes('1p event:')) {
     categories.push('1p')
   }

--- a/src/utils/effort.ts
+++ b/src/utils/effort.ts
@@ -1,4 +1,4 @@
-// biome-ignore-all assist/source/organizeImports: ANT-ONLY import markers must not be reordered
+// biome-ignore-all assist/source/organizeImports: internal-only import markers must not be reordered
 import { isUltrathinkEnabled } from './thinking.js'
 import { getInitialSettings } from './settings/settings.js'
 import { isProSubscriber, isMaxSubscriber, isTeamSubscriber } from './auth.js'

--- a/src/utils/fullscreen.ts
+++ b/src/utils/fullscreen.ts
@@ -107,7 +107,7 @@ export function _resetTmuxControlModeProbeForTesting(): void {
 
 /**
  * Whether fullscreen (flicker-free) mode is enabled. Env var takes highest
- * precedence, then the `flickerFreeMode` config setting, then the ant-only
+ * precedence, then the `flickerFreeMode` config setting, then the internal-only
  * default. External users can enable via `/config` instead of setting the env.
  *
  * Priority order:

--- a/src/utils/hooks.ts
+++ b/src/utils/hooks.ts
@@ -1,4 +1,4 @@
-// biome-ignore-all assist/source/organizeImports: ANT-ONLY import markers must not be reordered
+// biome-ignore-all assist/source/organizeImports: internal-only import markers must not be reordered
 /**
  * Hooks are user-defined shell commands that can be executed at various points
  * in Claude Code's lifecycle.

--- a/src/utils/messages/systemInit.ts
+++ b/src/utils/messages/systemInit.ts
@@ -84,7 +84,7 @@ export function buildSystemInitMessage(inputs: SystemInitInputs): SDKMessage {
     })),
     uuid: randomUUID(),
   }
-  // Hidden from public SDK types — ant-only UDS messaging socket path
+  // Hidden from public SDK types — internal-only UDS messaging socket path
   if (feature('UDS_INBOX')) {
     /* eslint-disable @typescript-eslint/no-require-imports */
     ;(initMessage as Record<string, unknown>).messaging_socket_path =

--- a/src/utils/model/antModels.ts
+++ b/src/utils/model/antModels.ts
@@ -29,7 +29,7 @@ export type AntModelOverrideConfig = {
   switchCallout?: AntModelSwitchCalloutConfig
 }
 
-// @[MODEL LAUNCH]: Update tengu_ant_model_override with new ant-only models
+// @[MODEL LAUNCH]: Update tengu_ant_model_override with new internal-only models
 // @[MODEL LAUNCH]: Add the codename to scripts/excluded-strings.txt to prevent it from leaking to external builds.
 export function getAntModelOverrideConfig(): AntModelOverrideConfig | null {
   if (process.env.USER_TYPE !== 'ant') {

--- a/src/utils/model/model.ts
+++ b/src/utils/model/model.ts
@@ -1,4 +1,4 @@
-// biome-ignore-all assist/source/organizeImports: ANT-ONLY import markers must not be reordered
+// biome-ignore-all assist/source/organizeImports: internal-only import markers must not be reordered
 /**
  * Ensure that any model codenames introduced here are also added to
  * scripts/excluded-strings.txt to avoid leaking them. Wrap any codename string

--- a/src/utils/model/modelOptions.ts
+++ b/src/utils/model/modelOptions.ts
@@ -1,4 +1,4 @@
-// biome-ignore-all assist/source/organizeImports: ANT-ONLY import markers must not be reordered
+// biome-ignore-all assist/source/organizeImports: internal-only import markers must not be reordered
 import { getInitialMainLoopModel } from '../../bootstrap/state.js'
 import {
   isClaudeAISubscriber,

--- a/src/utils/model/validateModel.ts
+++ b/src/utils/model/validateModel.ts
@@ -1,4 +1,4 @@
-// biome-ignore-all assist/source/organizeImports: ANT-ONLY import markers must not be reordered
+// biome-ignore-all assist/source/organizeImports: internal-only import markers must not be reordered
 import { MODEL_ALIASES } from './aliases.js'
 import { isModelAllowed } from './modelAllowlist.js'
 import { getAPIProvider } from './providers.js'

--- a/src/utils/permissions/PermissionMode.ts
+++ b/src/utils/permissions/PermissionMode.ts
@@ -92,7 +92,7 @@ const PERMISSION_MODE_CONFIG: Partial<
 
 /**
  * Type guard to check if a PermissionMode is an ExternalPermissionMode.
- * auto is ant-only and excluded from external modes.
+ * auto is internal-only and excluded from external modes.
  */
 export function isExternalPermissionMode(
   mode: PermissionMode,

--- a/src/utils/permissions/bashClassifier.ts
+++ b/src/utils/permissions/bashClassifier.ts
@@ -1,4 +1,4 @@
-// Stub for external builds - classifier permissions feature is ANT-ONLY
+// Stub for external builds - classifier permissions feature is internal-only
 
 export const PROMPT_PREFIX = 'prompt:'
 

--- a/src/utils/permissions/dangerousPatterns.ts
+++ b/src/utils/permissions/dangerousPatterns.ts
@@ -50,9 +50,9 @@ export const DANGEROUS_BASH_PATTERNS: readonly string[] = [
   'env',
   'xargs',
   'sudo',
-  // Anthropic internal: ant-only tools plus general tools that ant sandbox
+  // Anthropic internal: internal-only tools plus general tools that ant sandbox
   // dotfile data shows are commonly over-allowlisted as broad prefixes.
-  // These stay ant-only — external users don't have coo, and the rest are
+  // These stay internal-only — external users don't have coo, and the rest are
   // an empirical-risk call grounded in ant sandbox data, not a universal
   // "this tool is unsafe" judgment. PS may want these once it has usage data.
   ...(process.env.USER_TYPE === 'ant'

--- a/src/utils/permissions/permissionRuleParser.ts
+++ b/src/utils/permissions/permissionRuleParser.ts
@@ -4,7 +4,7 @@ import { TASK_OUTPUT_TOOL_NAME } from '../../tools/TaskOutputTool/constants.js'
 import { TASK_STOP_TOOL_NAME } from '../../tools/TaskStopTool/prompt.js'
 import type { PermissionRuleValue } from './PermissionRule.js'
 
-// Dead code elimination: ant-only tool names are conditionally required so
+// Dead code elimination: internal-only tool names are conditionally required so
 // their strings don't leak into external builds. Static imports always bundle.
 /* eslint-disable @typescript-eslint/no-require-imports */
 const BRIEF_TOOL_NAME: string | null =

--- a/src/utils/permissions/permissions.ts
+++ b/src/utils/permissions/permissions.ts
@@ -558,7 +558,7 @@ export const hasPermissionsToUseTool: CanUseToolFn = async (
         createDenialTrackingState()
 
       // PowerShell requires explicit user permission in auto mode unless
-      // POWERSHELL_AUTO_MODE (ant-only build flag) is on. When disabled, this
+      // POWERSHELL_AUTO_MODE (internal-only build flag) is on. When disabled, this
       // guard keeps PS out of the classifier and skips the acceptEdits
       // fast-path below. When enabled, PS flows through to the classifier like
       // Bash — the classifier prompt gets POWERSHELL_DENY_GUIDANCE appended so

--- a/src/utils/permissions/yoloClassifier.ts
+++ b/src/utils/permissions/yoloClassifier.ts
@@ -1455,7 +1455,7 @@ function getClassifierModel(): string {
 }
 
 /**
- * Resolve the XML classifier setting: ant-only env var takes precedence,
+ * Resolve the XML classifier setting: internal-only env var takes precedence,
  * then GrowthBook. Returns undefined when unset (caller decides default).
  */
 function resolveTwoStageClassifier():

--- a/src/utils/sessionRestore.ts
+++ b/src/utils/sessionRestore.ts
@@ -107,7 +107,7 @@ export function restoreSessionStateFromLog(
     })
   }
 
-  // Restore attribution state (ant-only feature)
+  // Restore attribution state (internal-only feature)
   if (
     feature('COMMIT_ATTRIBUTION') &&
     result.attributionSnapshots &&

--- a/src/utils/sessionStorage.ts
+++ b/src/utils/sessionStorage.ts
@@ -2233,7 +2233,7 @@ function forEachParsedJSONLBufferEntry<T>(
 function applySnipRemovals(messages: Map<UUID, TranscriptMessage>): void {
   // Structural check — snipMetadata only exists on the boundary subtype.
   // Avoids the subtype literal which is in excluded-strings.txt
-  // (HISTORY_SNIP is ant-only; the literal must not leak into external builds).
+  // (HISTORY_SNIP is internal-only; the literal must not leak into external builds).
   type WithSnipMeta = { snipMetadata?: { removedUuids?: UUID[] } }
   const toDelete = new Set<UUID>()
   for (const entry of messages.values()) {

--- a/src/utils/settings/mdm/constants.ts
+++ b/src/utils/settings/mdm/constants.ts
@@ -39,7 +39,7 @@ export const MDM_SUBPROCESS_TIMEOUT_MS = 5000
 
 /**
  * Build the list of macOS plist paths in priority order (highest first).
- * Evaluates `process.env.USER_TYPE` at call time so ant-only paths are
+ * Evaluates `process.env.USER_TYPE` at call time so internal-only paths are
  * included only when appropriate.
  */
 export function getMacOSPlistPaths(): Array<{ path: string; label: string }> {

--- a/src/utils/shell/readOnlyCommandValidation.ts
+++ b/src/utils/shell/readOnlyCommandValidation.ts
@@ -3,7 +3,7 @@
  *
  * Exports complete command configuration maps that any shell tool can import:
  * - GIT_READ_ONLY_COMMANDS: all git subcommands with safe flags and callbacks
- * - GH_READ_ONLY_COMMANDS: ant-only gh CLI commands (network-dependent)
+ * - GH_READ_ONLY_COMMANDS: internal-only gh CLI commands (network-dependent)
  * - EXTERNAL_READONLY_COMMANDS: cross-shell commands that work in both bash and PowerShell
  * - containsVulnerableUncPath: UNC path detection for credential leak prevention
  * - outputLimits are in outputLimits.ts
@@ -602,7 +602,7 @@ export const GIT_READ_ONLY_COMMANDS: Record<string, ExternalCommandConfig> = {
       '-s': 'none', // Print size of object
       '-p': 'none', // Pretty-print object contents
       '-e': 'none', // Exit with zero if object exists, non-zero otherwise
-      // Batch mode — read-only check variant only
+      // Batch mode — read-only check variinternal only
       '--batch-check': 'none', // For each object on stdin, print type and size (no content)
       // Output control
       '--allow-undetermined-type': 'none',
@@ -923,7 +923,7 @@ export const GIT_READ_ONLY_COMMANDS: Record<string, ExternalCommandConfig> = {
 }
 
 // ---------------------------------------------------------------------------
-// GH_READ_ONLY_COMMANDS — ant-only gh CLI commands (network-dependent)
+// GH_READ_ONLY_COMMANDS — internal-only gh CLI commands (network-dependent)
 // ---------------------------------------------------------------------------
 
 // SECURITY: Shared callback for all gh commands to prevent network exfil.

--- a/src/utils/stats.ts
+++ b/src/utils/stats.ts
@@ -81,7 +81,7 @@ export type ClaudeCodeStats = {
   // Speculation time saved
   totalSpeculationTimeSavedMs: number
 
-  // Shot stats (ant-only, gated by SHOT_STATS feature flag)
+  // Shot stats (internal-only, gated by SHOT_STATS feature flag)
   shotDistribution?: { [shotCount: number]: number }
   oneShotRate?: number
 }
@@ -208,7 +208,7 @@ async function processSessionFiles(
       // their token usage counted, but not as separate sessions.
       const isSubagentFile = sessionFile.includes(`${sep}subagents${sep}`)
 
-      // Extract shot count from PR attribution in gh pr create calls (ant-only)
+      // Extract shot count from PR attribution in gh pr create calls (internal-only)
       // This must run before the sidechain filter since subagent transcripts
       // mark all messages as sidechain
       if (feature('SHOT_STATS') && shotDistributionMap) {

--- a/src/utils/statsCache.ts
+++ b/src/utils/statsCache.ts
@@ -70,7 +70,7 @@ export type PersistedStatsCache = {
   hourCounts: { [hour: number]: number }
   // Speculation time saved across all sessions
   totalSpeculationTimeSavedMs: number
-  // Shot distribution: map of shot count → number of sessions (ant-only)
+  // Shot distribution: map of shot count → number of sessions (internal-only)
   shotDistribution?: { [shotCount: number]: number }
 }
 

--- a/src/utils/statusNoticeDefinitions.tsx
+++ b/src/utils/statusNoticeDefinitions.tsx
@@ -1,4 +1,4 @@
-// biome-ignore-all assist/source/organizeImports: ANT-ONLY import markers must not be reordered
+// biome-ignore-all assist/source/organizeImports: internal-only import markers must not be reordered
 import { Box, Text } from '../ink.js';
 import * as React from 'react';
 import { getLargeMemoryFiles, MAX_MEMORY_CHARACTER_COUNT, type MemoryFileInfo } from './claudemd.js';

--- a/src/utils/tasks.ts
+++ b/src/utils/tasks.ts
@@ -316,7 +316,7 @@ export async function getTask(
     const content = await readFile(path, 'utf-8')
     const data = jsonParse(content) as { status?: string }
 
-    // TEMPORARY: Migrate old status names for existing sessions (ant-only)
+    // TEMPORARY: Migrate old status names for existing sessions (internal-only)
     if (process.env.USER_TYPE === 'ant') {
       if (data.status === 'open') data.status = 'pending'
       else if (data.status === 'resolved') data.status = 'completed'

--- a/src/utils/telemetry/betaSessionTracing.ts
+++ b/src/utils/telemetry/betaSessionTracing.ts
@@ -426,7 +426,7 @@ export function addBetaLLMResponseAttributes(
     }
   }
 
-  // Add thinking_output - ant-only
+  // Add thinking_output - internal-only
   if (
     process.env.USER_TYPE === 'ant' &&
     metadata.thinkingOutput !== undefined

--- a/src/utils/telemetry/perfettoTracing.ts
+++ b/src/utils/telemetry/perfettoTracing.ts
@@ -4,7 +4,7 @@
  * This module generates traces in the Chrome Trace Event format that can be
  * viewed in ui.perfetto.dev or Chrome's chrome://tracing.
  *
- * NOTE: This feature is ant-only and eliminated from external builds.
+ * NOTE: This feature is internal-only and eliminated from external builds.
  *
  * The trace file includes:
  * - Agent hierarchy (parent-child relationships in a swarm)

--- a/src/utils/thinking.ts
+++ b/src/utils/thinking.ts
@@ -1,4 +1,4 @@
-// biome-ignore-all assist/source/organizeImports: ANT-ONLY import markers must not be reordered
+// biome-ignore-all assist/source/organizeImports: internal-only import markers must not be reordered
 import type { Theme } from './theme.js'
 import { feature } from 'bun:bundle'
 import { getFeatureValue_CACHED_MAY_BE_STALE } from '../services/analytics/growthbook.js'


### PR DESCRIPTION
## Summary
- rewrite comment-only `ANT-ONLY` / `ant-only` markers to neutral `internal-only` wording across the source tree
- keep the pass strictly comment/prose-only without changing runtime strings, command descriptions, flags, or protocol identifiers
- preserve the current green build/privacy/provider-test state while reducing obvious internal prose leakage

## Test plan
- [x] `bun run build`
- [x] `bun run smoke`
- [x] `bun run verify:privacy`
- [x] `bun run test:provider`
- [x] `bun run test:provider-recommendation`
- [ ] `bunx tsc --noEmit` *(still noisy on this upstream snapshot; this PR does not change runtime signatures or add new type surfaces)*

## Notes
This is Phase B of the staged cleanup plan and intentionally avoids runtime/user-facing string rewrites. Remaining `[ANT-ONLY]` hits are mostly live labels and command descriptions, which are deferred to later scoped passes.