### PR TITLE
Neutralize internal Anthropic prose in comments

### DIFF
--- a/src/bridge/trustedDevice.ts
+++ b/src/bridge/trustedDevice.ts
@@ -17,7 +17,7 @@ import { jsonStringify } from '../utils/slowOperations.js'
  *
  * Bridge sessions have SecurityTier=ELEVATED on the server (CCR v2).
  * The server gates ConnectBridgeWorker on its own flag
- * (sessions_elevated_auth_enforcement in Anthropic Main); this CLI-side
+ * (sessions_elevated_auth_enforcement in the server-side main deployment); this CLI-side
  * flag controls whether the CLI sends X-Trusted-Device-Token at all.
  * Two flags so rollout can be staged: flip CLI-side first (headers
  * start flowing, server still no-ops), then flip server-side.

--- a/src/cli/update.ts
+++ b/src/cli/update.ts
@@ -30,7 +30,7 @@ import { getInitialSettings } from 'src/utils/settings/settings.js'
 
 export async function update() {
   // Block updates for third-party providers. The update mechanism downloads
-  // from Anthropic's distribution bucket, which would silently replace the
+  // from the first-party distribution bucket, which would silently replace the
   // OpenClaude build (with the OpenAI shim) with the upstream Claude Code
   // binary (without it).
   if (getAPIProvider() !== 'firstParty') {

--- a/src/keybindings/loadUserBindings.ts
+++ b/src/keybindings/loadUserBindings.ts
@@ -5,7 +5,7 @@
  * for changes to reload them automatically.
  *
  * NOTE: User keybinding customization is currently only available for
- * Anthropic employees (USER_TYPE === 'ant'). External users always
+ * internal users (USER_TYPE === 'ant'). External users always
  * use the default bindings.
  */
 
@@ -128,7 +128,7 @@ function getDefaultParsedBindings(): ParsedBinding[] {
  * Returns merged default + user bindings along with validation warnings.
  *
  * For external users, always returns default bindings only.
- * User customization is currently gated to Anthropic employees.
+ * User customization is currently gated to internal users.
  */
 export async function loadKeybindings(): Promise<KeybindingsLoadResult> {
   const defaultBindings = getDefaultParsedBindings()
@@ -254,7 +254,7 @@ export function loadKeybindingsSync(): ParsedBinding[] {
  * Uses cached values if available.
  *
  * For external users, always returns default bindings only.
- * User customization is currently gated to Anthropic employees.
+ * User customization is currently gated to internal users.
  */
 export function loadKeybindingsSyncWithWarnings(): KeybindingsLoadResult {
   if (cachedBindings) {

--- a/src/services/mcp/officialRegistry.ts
+++ b/src/services/mcp/officialRegistry.ts
@@ -36,7 +36,7 @@ export async function prefetchOfficialMcpUrls(): Promise<void> {
     return
   }
 
-  // Anthropic's official MCP registry is only relevant for first-party mode.
+  // The official first-party MCP registry is only relevant for first-party mode.
   if (getAPIProvider() !== 'firstParty') {
     return
   }

--- a/src/tools/BashTool/bashPermissions.ts
+++ b/src/tools/BashTool/bashPermissions.ts
@@ -431,7 +431,7 @@ const ANT_ONLY_SAFE_ENV_VARS = new Set([
   'CLOUDSDK_CORE_PROJECT', // GCP project ID
   'CLUSTER', // generic cluster name
 
-  // Anthropic internal cluster selection (just names/identifiers)
+  // Internal cluster selection (just names/identifiers)
   'COO_CLUSTER', // coo cluster name
   'COO_CLUSTER_NAME', // coo cluster name (alternate)
   'COO_NAMESPACE', // coo namespace

--- a/src/tools/BashTool/readOnlyValidation.ts
+++ b/src/tools/BashTool/readOnlyValidation.ts
@@ -1141,7 +1141,7 @@ const COMMAND_ALLOWLIST: Record<string, CommandConfig> = {
 const ANT_ONLY_COMMAND_ALLOWLIST: Record<string, CommandConfig> = {
   // All gh read-only commands from shared validation map
   ...GH_READ_ONLY_COMMANDS,
-  // aki — Anthropic internal knowledge-base search CLI.
+  // aki — internal knowledge-base search CLI.
   // Network read-only (same policy as gh). --audit-csv omitted: writes to disk.
   aki: {
     safeFlags: {

--- a/src/tools/WebFetchTool/utils.ts
+++ b/src/tools/WebFetchTool/utils.ts
@@ -177,7 +177,7 @@ type DomainCheckResult =
 export async function checkDomainBlocklist(
   domain: string,
 ): Promise<DomainCheckResult> {
-  // Third-party providers should not consult Anthropic's domain policy.
+  // Third-party providers should not consult the first-party domain policy.
   if (getAPIProvider() !== 'firstParty') {
     return { status: 'allowed' }
   }

--- a/src/utils/attachments.ts
+++ b/src/utils/attachments.ts
@@ -2641,7 +2641,7 @@ let suppressNext = false
 const FILTERED_LISTING_MAX = 30
 
 /**
- * Filter skills to bundled (Anthropic-curated) + MCP (user-connected) only.
+ * Filter skills to bundled + MCP (user-connected) only.
  * Used when skill-search is enabled to resolve the turn-0 gap for subagents:
  * these sources are small, intent-signaled, and won't hit the truncation budget.
  * User/project/plugin skills (the long tail — 200+) go through discovery instead.

--- a/src/utils/autoUpdater.ts
+++ b/src/utils/autoUpdater.ts
@@ -74,7 +74,7 @@ export async function assertMinVersion(): Promise<void> {
   }
 
   // Skip version check for third-party providers — the min version
-  // kill-switch is Anthropic-specific and should not block 3P users
+  // kill-switch is first-party-specific and should not block 3P users
   if (getAPIProvider() !== 'firstParty') {
     return
   }

--- a/src/utils/buildConfig.ts
+++ b/src/utils/buildConfig.ts
@@ -1,7 +1,7 @@
 /**
  * OpenClaude build-time constants.
  *
- * These replace process.env checks that were only meaningful in Anthropic's
+ * These replace process.env checks that were only meaningful in the upstream
  * internal build. In OpenClaude all such gates are permanently disabled so
  * external users cannot activate internal code paths by setting env vars.
  */
@@ -9,7 +9,7 @@
 /**
  * Always false in OpenClaude.
  * Replaces all `process.env.USER_TYPE === 'ant'` checks so that no external
- * user can activate Anthropic-internal features (commit attribution hooks,
+ * user can activate internal-only features (commit attribution hooks,
  * system-prompt section clearing, dangerously-skip-permissions bypass, etc.)
  * by setting USER_TYPE in their shell environment.
  */

--- a/src/utils/http.ts
+++ b/src/utils/http.ts
@@ -51,7 +51,7 @@ export function getMCPUserAgent(): string {
 }
 
 // User-Agent for WebFetch requests to arbitrary sites. `Claude-User` is
-// Anthropic's publicly documented agent for user-initiated fetches (what site
+// The first-party provider's publicly documented agent for user-initiated fetches (what site
 // operators match in robots.txt); the claude-code suffix lets them distinguish
 // local CLI traffic from claude.ai server-side fetches.
 export function getWebFetchUserAgent(): string {

--- a/src/utils/modifiers.ts
+++ b/src/utils/modifiers.ts
@@ -3,7 +3,7 @@ export type ModifierKey = 'shift' | 'command' | 'control' | 'option'
 /**
  * Pre-warm the native module by loading it in advance.
  *
- * NOTE: The `modifiers-napi` package is an Anthropic-internal native addon
+ * NOTE: The `modifiers-napi` package is an internal-only native addon
  * that is not shipped with the open-source build. All calls are no-ops here
  * to avoid supply-chain risk from unverified npm packages with the same name.
  */

--- a/src/utils/permissions/dangerousPatterns.ts
+++ b/src/utils/permissions/dangerousPatterns.ts
@@ -50,7 +50,7 @@ export const DANGEROUS_BASH_PATTERNS: readonly string[] = [
   'env',
   'xargs',
   'sudo',
-  // Anthropic internal: internal-only tools plus general tools that ant sandbox
+  // Internal-only: internal-only tools plus general tools that ant sandbox
   // dotfile data shows are commonly over-allowlisted as broad prefixes.
   // These stay internal-only — external users don't have coo, and the rest are
   // an empirical-risk call grounded in ant sandbox data, not a universal

--- a/src/utils/permissions/yoloClassifier.ts
+++ b/src/utils/permissions/yoloClassifier.ts
@@ -98,7 +98,7 @@ export type AutoModeRules = {
  * captured tag contents ARE the defaults. Bullet items are single-line in the
  * template; each line starting with `- ` becomes one array entry.
  * Used by `claude auto-mode defaults`. Always returns external defaults,
- * never the Anthropic-internal template.
+ * never the internal-only template.
  */
 export function getDefaultExternalAutoModeRules(): AutoModeRules {
   return {


### PR DESCRIPTION
## Summary
- rewrite a small set of clearly internal or explanatory `Anthropic` comments to neutral wording
- keep the pass strictly prose-only without changing runtime strings, command labels, flags, URLs, or protocol identifiers
- preserve the current green build/privacy/provider-test state while reducing obvious internal explanatory references

## Test plan
- [x] `bun run build`
- [x] `bun run smoke`
- [x] `bun run verify:privacy`
- [x] `bun run test:provider`
- [x] `bun run test:provider-recommendation`
- [ ] `bunx tsc --noEmit` *(still noisy on this upstream snapshot; this PR does not change runtime signatures or add new type surfaces)*

## Notes
This is a narrow follow-up to the earlier comment-only cleanup. Functional Anthropic references — SDK/API behavior, provider labels, URLs, and protocol docs — are intentionally left alone for separate reviewed passes.