### PR TITLE
Finish neutralizing internal-only ANT-ONLY labels

### DIFF
--- a/src/commands/cost/cost.ts
+++ b/src/commands/cost/cost.ts
@@ -16,7 +16,7 @@ export const call: LocalCommandCall = async () => {
     }
 
     if (process.env.USER_TYPE === 'ant') {
-      value += `\n\n[ANT-ONLY] Showing cost anyway:\n ${formatTotalCost()}`
+      value += `\n\n[internal-only] Showing cost anyway:\n ${formatTotalCost()}`
     }
     return { type: 'text', value }
   }

--- a/src/components/HelpV2/HelpV2.tsx
+++ b/src/components/HelpV2/HelpV2.tsx
@@ -114,7 +114,7 @@ export function HelpV2(t0) {
     if (false && antOnlyCommands.length > 0) {
       let t7;
       if ($[26] !== antOnlyCommands || $[27] !== close || $[28] !== columns || $[29] !== maxHeight) {
-        t7 = <Tab key="ant-only" title="[internal-only]"><Commands commands={antOnlyCommands} maxHeight={maxHeight} columns={columns} title="Browse internal-only commands:" onCancel={close} /></Tab>;
+        t7 = <Tab key="internal-only" title="[internal-only]"><Commands commands={antOnlyCommands} maxHeight={maxHeight} columns={columns} title="Browse internal-only commands:" onCancel={close} /></Tab>;
         $[26] = antOnlyCommands;
         $[27] = close;
         $[28] = columns;

--- a/src/components/LogoV2/feedConfigs.tsx
+++ b/src/components/LogoV2/feedConfigs.tsx
@@ -41,7 +41,7 @@ export function createWhatsNewFeed(releaseNotes: string[]): FeedConfig {
   });
   const emptyMessage = "external" === 'ant' ? 'Unable to fetch latest claude-cli-internal commits' : 'Check /release-notes for recent updates';
   return {
-    title: "external" === 'ant' ? "Open Claude Updates [ANT-ONLY: Latest CC commits]" : "Open Claude Updates",
+    title: "external" === 'ant' ? "Open Claude Updates [internal-only: Latest CC commits]" : "Open Claude Updates",
     lines,
     footer: lines.length > 0 ? '/release-notes for more' : undefined,
     emptyMessage

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3798,17 +3798,17 @@ async function run(): Promise<CommanderCommand> {
     program.addOption(new Option('--advisor <model>', 'Enable the server-side advisor tool with the specified model (alias or full ID).').hideHelp());
   }
   if ("external" === 'ant') {
-    program.addOption(new Option('--delegate-permissions', '[ANT-ONLY] Alias for --permission-mode auto.').implies({
+    program.addOption(new Option('--delegate-permissions', '[internal-only] Alias for --permission-mode auto.').implies({
       permissionMode: 'auto'
     }));
-    program.addOption(new Option('--dangerously-skip-permissions-with-classifiers', '[ANT-ONLY] Deprecated alias for --permission-mode auto.').hideHelp().implies({
+    program.addOption(new Option('--dangerously-skip-permissions-with-classifiers', '[internal-only] Deprecated alias for --permission-mode auto.').hideHelp().implies({
       permissionMode: 'auto'
     }));
-    program.addOption(new Option('--afk', '[ANT-ONLY] Deprecated alias for --permission-mode auto.').hideHelp().implies({
+    program.addOption(new Option('--afk', '[internal-only] Deprecated alias for --permission-mode auto.').hideHelp().implies({
       permissionMode: 'auto'
     }));
-    program.addOption(new Option('--tasks [id]', '[ANT-ONLY] Tasks mode: watch for tasks and auto-process them. Optional id is used as both the task list ID and agent ID (defaults to "tasklist").').argParser(String).hideHelp());
-    program.option('--agent-teams', '[ANT-ONLY] Force Claude to use multi-agent mode for solving problems', () => true);
+    program.addOption(new Option('--tasks [id]', '[internal-only] Tasks mode: watch for tasks and auto-process them. Optional id is used as both the task list ID and agent ID (defaults to "tasklist").').argParser(String).hideHelp());
+    program.option('--agent-teams', '[internal-only] Force Claude to use multi-agent mode for solving problems', () => true);
   }
   if (feature('TRANSCRIPT_CLASSIFIER')) {
     program.addOption(new Option('--enable-auto-mode', 'Opt in to auto mode').hideHelp());
@@ -4353,7 +4353,7 @@ async function run(): Promise<CommanderCommand> {
 
   // claude up — run the project's CLAUDE.md "# claude up" setup instructions.
   if ("external" === 'ant') {
-    program.command('up').description('[ANT-ONLY] Initialize or upgrade the local dev environment using the "# claude up" section of the nearest CLAUDE.md').action(async () => {
+    program.command('up').description('[internal-only] Initialize or upgrade the local dev environment using the "# claude up" section of the nearest CLAUDE.md').action(async () => {
       const {
         up
       } = await import('src/cli/up.js');
@@ -4364,7 +4364,7 @@ async function run(): Promise<CommanderCommand> {
   // claude rollback (internal-only)
   // Rolls back to previous releases
   if ("external" === 'ant') {
-    program.command('rollback [target]').description('[ANT-ONLY] Roll back to a previous release\n\nExamples:\n  claude rollback                                    Go 1 version back from current\n  claude rollback 3                                  Go 3 versions back from current\n  claude rollback 2.0.73-dev.20251217.t190658        Roll back to a specific version').option('-l, --list', 'List recent published versions with ages').option('--dry-run', 'Show what would be installed without installing').option('--safe', 'Roll back to the server-pinned safe version (set by oncall during incidents)').action(async (target?: string, options?: {
+    program.command('rollback [target]').description('[internal-only] Roll back to a previous release\n\nExamples:\n  claude rollback                                    Go 1 version back from current\n  claude rollback 3                                  Go 3 versions back from current\n  claude rollback 2.0.73-dev.20251217.t190658        Roll back to a specific version').option('-l, --list', 'List recent published versions with ages').option('--dry-run', 'Show what would be installed without installing').option('--safe', 'Roll back to the server-pinned safe version (set by oncall during incidents)').action(async (target?: string, options?: {
       list?: boolean;
       dryRun?: boolean;
       safe?: boolean;
@@ -4394,7 +4394,7 @@ async function run(): Promise<CommanderCommand> {
       return Number(value);
     };
     // claude log
-    program.command('log').description('[ANT-ONLY] Manage conversation logs.').argument('[number|sessionId]', 'A number (0, 1, 2, etc.) to display a specific log, or the sesssion ID (uuid) of a log', validateLogId).action(async (logId: string | number | undefined) => {
+    program.command('log').description('[internal-only] Manage conversation logs.').argument('[number|sessionId]', 'A number (0, 1, 2, etc.) to display a specific log, or the sesssion ID (uuid) of a log', validateLogId).action(async (logId: string | number | undefined) => {
       const {
         logHandler
       } = await import('./cli/handlers/ant.js');
@@ -4402,7 +4402,7 @@ async function run(): Promise<CommanderCommand> {
     });
 
     // claude error
-    program.command('error').description('[ANT-ONLY] View error logs. Optionally provide a number (0, -1, -2, etc.) to display a specific log.').argument('[number]', 'A number (0, 1, 2, etc.) to display a specific log', parseInt).action(async (number: number | undefined) => {
+    program.command('error').description('[internal-only] View error logs. Optionally provide a number (0, -1, -2, etc.) to display a specific log.').argument('[number]', 'A number (0, 1, 2, etc.) to display a specific log', parseInt).action(async (number: number | undefined) => {
       const {
         errorHandler
       } = await import('./cli/handlers/ant.js');
@@ -4410,7 +4410,7 @@ async function run(): Promise<CommanderCommand> {
     });
 
     // claude export
-    program.command('export').description('[ANT-ONLY] Export a conversation to a text file.').usage('<source> <outputFile>').argument('<source>', 'Session ID, log index (0, 1, 2...), or path to a .json/.jsonl log file').argument('<outputFile>', 'Output file path for the exported text').addHelpText('after', `
+    program.command('export').description('[internal-only] Export a conversation to a text file.').usage('<source> <outputFile>').argument('<source>', 'Session ID, log index (0, 1, 2...), or path to a .json/.jsonl log file').argument('<outputFile>', 'Output file path for the exported text').addHelpText('after', `
 Examples:
   $ claude export 0 conversation.txt                Export conversation at log index 0
   $ claude export <uuid> conversation.txt           Export conversation by session ID
@@ -4422,7 +4422,7 @@ Examples:
       await exportHandler(source, outputFile);
     });
     if ("external" === 'ant') {
-      const taskCmd = program.command('task').description('[ANT-ONLY] Manage task list tasks');
+      const taskCmd = program.command('task').description('[internal-only] Manage task list tasks');
       taskCmd.command('create <subject>').description('Create a new task').option('-d, --description <text>', 'Task description').option('-l, --list <id>', 'Task list ID (defaults to "tasklist")').action(async (subject: string, opts: {
         description?: string;
         list?: string;

--- a/src/services/PromptSuggestion/speculation.ts
+++ b/src/services/PromptSuggestion/speculation.ts
@@ -302,7 +302,7 @@ function createSpeculationFeedbackMessage(
       : ''
 
   return createSystemMessage(
-    `[ANT-ONLY] ${parts.join(' · ')} · ${savedText}${sessionSuffix}`,
+    `[internal-only] ${parts.join(' · ')} · ${savedText}${sessionSuffix}`,
     'warning',
   )
 }

--- a/src/services/analytics/firstPartyEventLogger.ts
+++ b/src/services/analytics/firstPartyEventLogger.ts
@@ -186,7 +186,7 @@ async function logEventTo1PAsync(
     // Debug logging when debug mode is enabled
     if (process.env.USER_TYPE === 'ant') {
       logForDebugging(
-        `[ANT-ONLY] 1P event: ${eventName} ${jsonStringify(metadata, null, 0)}`,
+        `[internal-only] 1P event: ${eventName} ${jsonStringify(metadata, null, 0)}`,
       )
     }
 
@@ -287,7 +287,7 @@ export function logGrowthBookExperimentTo1P(
 
   if (process.env.USER_TYPE === 'ant') {
     logForDebugging(
-      `[ANT-ONLY] 1P GrowthBook experiment: ${data.experimentId} variation=${data.variationId}`,
+      `[internal-only] 1P GrowthBook experiment: ${data.experimentId} variation=${data.variationId}`,
     )
   }
 

--- a/src/utils/effort.ts
+++ b/src/utils/effort.ts
@@ -292,7 +292,7 @@ export function getEffortLevelDescription(level: EffortLevel | OpenAIEffortLevel
  */
 export function getEffortValueDescription(value: EffortValue): string {
   if (process.env.USER_TYPE === 'ant' && typeof value === 'number') {
-    return `[ANT-ONLY] Numeric effort value of ${value}`
+    return `[internal-only] Numeric effort value of ${value}`
   }
 
   if (typeof value === 'string') {

--- a/src/utils/hooks/hooksConfigManager.ts
+++ b/src/utils/hooks/hooksConfigManager.ts
@@ -350,7 +350,7 @@ export function groupHooksByEventAndMatcher(
               event: hookEvent,
               config: {
                 type: 'command',
-                command: '[ANT-ONLY] Built-in Hook',
+                command: '[internal-only] Built-in Hook',
               },
               matcher: matcher.matcher,
               source: 'builtinHook',


### PR DESCRIPTION
## Summary
- replace the remaining `[ANT-ONLY]` / `ant-only` labels in gated/internal command descriptions, debug output, and headings with neutral internal wording
- keep the pass strictly label-only without changing logic or command behavior
- reduce remaining source hits for `ANT-ONLY|ant-only` to zero

## Test plan
- [x] `bun run build`
- [x] `bun run smoke`
- [x] `bun run verify:privacy`
- [x] `bun run test:provider`
- [x] `bun run test:provider-recommendation`
- [ ] `bunx tsc --noEmit` *(still noisy on this upstream snapshot; this PR does not change runtime signatures or add new type surfaces)*

## Notes
This continues the narrow internal-label cleanup lane. The next phase should move off label cleanup and onto a separately scoped logic or rebrand pass.