### PR TITLE
fix(ci): add typecheck to CI and fix env leak in withRetry test

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -30,6 +30,15 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
+      # Temporarily allow failures while we fix pre-existing type errors (~4208).
+      # Remove continue-on-error once the count is reduced to zero.
+      - name: Type check
+        run: bun run typecheck
+        continue-on-error: true
+
+      - name: Build
+        run: bun run build
+
       - name: Smoke check
         run: bun run smoke
 

--- a/src/services/api/withRetry.test.ts
+++ b/src/services/api/withRetry.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test, afterEach } from 'bun:test'
+import { describe, expect, test, afterEach, beforeEach } from 'bun:test'
 import { getRateLimitResetDelayMs, parseOpenAIDuration } from './withRetry.js'
 import { APIError } from '@anthropic-ai/sdk'
 
@@ -14,8 +14,25 @@ function makeError(headers: Record<string, string>): APIError {
   } as unknown as APIError
 }
 
-// Save/restore env vars between tests
+// Save original env vars before any mutation
 const originalEnv = { ...process.env }
+
+// Clear provider env before EACH test so the first test in every
+// describe block also runs with a clean slate (not just between tests).
+beforeEach(() => {
+  for (const key of [
+    'CLAUDE_CODE_USE_OPENAI',
+    'CLAUDE_CODE_USE_GEMINI',
+    'CLAUDE_CODE_USE_GITHUB',
+    'CLAUDE_CODE_USE_BEDROCK',
+    'CLAUDE_CODE_USE_VERTEX',
+    'CLAUDE_CODE_USE_FOUNDRY',
+  ]) {
+    delete process.env[key]
+  }
+})
+
+// Restore original env after each test
 afterEach(() => {
   for (const key of [
     'CLAUDE_CODE_USE_OPENAI',


### PR DESCRIPTION
## Summary

- Add `tsc --noEmit` and `bun run build` to the PR checks workflow (typecheck gated with `continue-on-error` while pre-existing type errors are resolved incrementally)
- Fix `withRetry.test.ts`: provider env vars leaked into the first test of each describe block, causing the firstParty test to incorrectly resolve to the 'openai' provider when `CLAUDE_CODE_USE_OPENAI` is set in the environment

## Impact

- user-facing impact: none (CI-only change)
- developer/maintainer impact: PR validation now also runs typecheck and build before smoke/tests, catching broken types and failed builds at PR time

## Testing

- [x] `bun run build`
- [x] `bun run smoke`
- [x] `bun run test:provider` (74/74 pass)
- [x] `bun run test:provider-recommendation` (45/45 pass)

## Notes

- The typecheck step uses `continue-on-error` because the repo currently has ~4200 pre-existing type errors (mostly from removed internal Anthropic modules). ~700 of those are legitimately fixable without access to internal code.
- provider/model path tested: all providers (OpenAI, firstParty, bedrock, vertex, github)
- The test fix was found by running the CI pipeline locally in an environment where `CLAUDE_CODE_USE_OPENAI=1` was set.