### PR TITLE
Migrate config and profile defaults to openlawb

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ Advanced and source-build guides:
 - **Streaming responses**: Real-time token output and tool progress
 - **Tool calling**: Multi-step tool loops with model calls, tool execution, and follow-up responses
 - **Images**: URL and base64 image inputs for providers that support vision
-- **Provider profiles**: Guided setup plus saved `.openclaude-profile.json` support
+- **Provider profiles**: Guided setup plus saved `.openlawb-profile.json` support (legacy `.openclaude-profile.json` still loads)
 - **Local and remote model backends**: Cloud APIs, local servers, and Apple Silicon local inference
 
 ## Provider Notes

--- a/scripts/provider-bootstrap.ts
+++ b/scripts/provider-bootstrap.ts
@@ -59,7 +59,9 @@ async function main(): Promise<void> {
   const argBaseUrl = parseArg('--base-url')
   const argApiKey = parseArg('--api-key')
   const goal = normalizeRecommendationGoal(
-    parseArg('--goal') || process.env.OPENCLAUDE_PROFILE_GOAL,
+    parseArg('--goal') ||
+      process.env.OPENLAWB_PROFILE_GOAL ||
+      process.env.OPENCLAUDE_PROFILE_GOAL,
   )
 
   let selected: ProviderProfile

--- a/scripts/provider-launch.ts
+++ b/scripts/provider-launch.ts
@@ -34,7 +34,10 @@ function parseLaunchOptions(argv: string[]): LaunchOptions {
   let requestedProfile: ProviderProfile | 'auto' | null = 'auto'
   const passthroughArgs: string[] = []
   let fast = false
-  let goal = normalizeRecommendationGoal(process.env.OPENCLAUDE_PROFILE_GOAL)
+  let goal = normalizeRecommendationGoal(
+    process.env.OPENLAWB_PROFILE_GOAL ??
+      process.env.OPENCLAUDE_PROFILE_GOAL,
+  )
 
   for (let i = 0; i < argv.length; i++) {
     const arg = argv[i]!

--- a/scripts/provider-recommend.ts
+++ b/scripts/provider-recommend.ts
@@ -39,7 +39,10 @@ function parseOptions(argv: string[]): CliOptions {
   const options: CliOptions = {
     apply: false,
     benchmark: false,
-    goal: normalizeRecommendationGoal(process.env.OPENCLAUDE_PROFILE_GOAL),
+    goal: normalizeRecommendationGoal(
+      process.env.OPENLAWB_PROFILE_GOAL ??
+        process.env.OPENCLAUDE_PROFILE_GOAL,
+    ),
     json: false,
     provider: 'auto',
     baseUrl: null,
@@ -113,7 +116,9 @@ function printHumanSummary(payload: {
   }
 
   if (payload.applied) {
-    console.log('\nSaved .openclaude-profile.json with the recommended profile.')
+    console.log(
+      '\nSaved .openlawb-profile.json with the recommended profile (legacy .openclaude-profile.json is still supported).',
+    )
     console.log('Next: bun run dev:profile')
   } else {
     console.log(

--- a/src/commands/provider/provider.test.tsx
+++ b/src/commands/provider/provider.test.tsx
@@ -187,7 +187,7 @@ test('buildProfileSaveMessage maps provider fields without echoing secrets', () 
       OPENAI_MODEL: 'gpt-4o',
       OPENAI_BASE_URL: 'https://api.openai.com/v1',
     },
-    'D:/codings/Opensource/openclaude/.openclaude-profile.json',
+    'D:/codings/Opensource/openclaude/.openlawb-profile.json',
   )
 
   expect(message).toContain('Saved OpenAI-compatible profile.')
@@ -205,7 +205,7 @@ test('buildProfileSaveMessage describes Gemini access token / ADC mode clearly',
       GEMINI_MODEL: 'gemini-2.5-flash',
       GEMINI_BASE_URL: 'https://generativelanguage.googleapis.com/v1beta/openai',
     },
-    'D:/codings/Opensource/openclaude/.openclaude-profile.json',
+    'D:/codings/Opensource/openclaude/.openlawb-profile.json',
   )
 
   expect(message).toContain('Saved Google Gemini profile.')

--- a/src/commands/provider/provider.tsx
+++ b/src/commands/provider/provider.tsx
@@ -459,7 +459,8 @@ function ProviderChooser({
     options.push({
       label: 'Clear saved profile',
       value: 'clear',
-      description: 'Remove .openclaude-profile.json and return to normal startup',
+      description:
+        'Remove .openlawb-profile.json (and legacy .openclaude-profile.json) and return to normal startup',
     })
   }
 

--- a/src/utils/envUtils.ts
+++ b/src/utils/envUtils.ts
@@ -10,13 +10,19 @@ export const getClaudeConfigHomeDir = memoize(
     if (process.env.CLAUDE_CONFIG_DIR) {
       return process.env.CLAUDE_CONFIG_DIR.normalize('NFC')
     }
-    const newDefault = join(homedir(), '.openclaude')
-    // Migration compatibility: if ~/.openclaude doesn't exist yet but ~/.claude
-    // does, keep using ~/.claude so existing users don't lose their data on
-    // upgrade. New installs (neither dir exists) go straight to ~/.openclaude.
-    const legacyPath = join(homedir(), '.claude')
-    if (!existsSync(newDefault) && existsSync(legacyPath)) {
-      return legacyPath.normalize('NFC')
+    const newDefault = join(homedir(), '.openlawb')
+    const legacyOpenClaudePath = join(homedir(), '.openclaude')
+    // Migration compatibility: prefer the new default when it exists, then the
+    // previous OpenClaude location, then the oldest ~/.claude location.
+    const legacyClaudePath = join(homedir(), '.claude')
+    if (existsSync(newDefault)) {
+      return newDefault.normalize('NFC')
+    }
+    if (existsSync(legacyOpenClaudePath)) {
+      return legacyOpenClaudePath.normalize('NFC')
+    }
+    if (existsSync(legacyClaudePath)) {
+      return legacyClaudePath.normalize('NFC')
     }
     return newDefault.normalize('NFC')
   },

--- a/src/utils/providerProfile.test.ts
+++ b/src/utils/providerProfile.test.ts
@@ -13,6 +13,7 @@ import {
   buildOllamaProfileEnv,
   buildOpenAIProfileEnv,
   createProfileFile,
+  LEGACY_PROFILE_FILE_NAME,
   maskSecretForDisplay,
   loadProfileFile,
   PROFILE_FILE_NAME,
@@ -411,6 +412,24 @@ test('saveProfileFile writes a profile that loadProfileFile can read back', () =
       JSON.parse(readFileSync(filePath, 'utf8')).profile,
       'openai',
     )
+    assert.deepEqual(loadProfileFile({ cwd }), persisted)
+  } finally {
+    rmSync(cwd, { recursive: true, force: true })
+  }
+})
+
+test('loadProfileFile falls back to the legacy profile filename', () => {
+  const cwd = mkdtempSync(join(tmpdir(), 'openclaude-profile-file-legacy-'))
+
+  try {
+    const persisted = createProfileFile('openai', {
+      OPENAI_API_KEY: 'sk-test',
+      OPENAI_MODEL: 'gpt-4o',
+    })
+
+    const legacyPath = join(cwd, LEGACY_PROFILE_FILE_NAME)
+    writeFileSync(legacyPath, JSON.stringify(persisted, null, 2), 'utf8')
+
     assert.deepEqual(loadProfileFile({ cwd }), persisted)
   } finally {
     rmSync(cwd, { recursive: true, force: true })

--- a/src/utils/providerProfile.ts
+++ b/src/utils/providerProfile.ts
@@ -15,7 +15,8 @@ import {
 import { readGeminiAccessToken } from './geminiCredentials.ts'
 import { getOllamaChatBaseUrl } from './providerDiscovery.ts'
 
-export const PROFILE_FILE_NAME = '.openclaude-profile.json'
+export const PROFILE_FILE_NAME = '.openlawb-profile.json'
+export const LEGACY_PROFILE_FILE_NAME = '.openclaude-profile.json'
 export const DEFAULT_GEMINI_BASE_URL =
   'https://generativelanguage.googleapis.com/v1beta/openai'
 export const DEFAULT_GEMINI_MODEL = 'gemini-2.0-flash'
@@ -86,6 +87,20 @@ function resolveProfileFilePath(options?: ProfileFileLocation): string {
   }
 
   return resolve(options?.cwd ?? process.cwd(), PROFILE_FILE_NAME)
+}
+
+function getCandidateProfileFilePaths(
+  options?: ProfileFileLocation,
+): string[] {
+  if (options?.filePath) {
+    return [options.filePath]
+  }
+
+  const cwd = options?.cwd ?? process.cwd()
+  return [
+    resolve(cwd, PROFILE_FILE_NAME),
+    resolve(cwd, LEGACY_PROFILE_FILE_NAME),
+  ]
 }
 
 export function isProviderProfile(value: unknown): value is ProviderProfile {
@@ -362,28 +377,30 @@ export function createProfileFile(
 }
 
 export function loadProfileFile(options?: ProfileFileLocation): ProfileFile | null {
-  const filePath = resolveProfileFilePath(options)
-  if (!existsSync(filePath)) {
-    return null
-  }
+  for (const filePath of getCandidateProfileFilePaths(options)) {
+    if (!existsSync(filePath)) {
+      continue
+    }
 
-  try {
-    const parsed = JSON.parse(readFileSync(filePath, 'utf8')) as Partial<ProfileFile>
-    if (!isProviderProfile(parsed.profile) || !parsed.env || typeof parsed.env !== 'object') {
+    try {
+      const parsed = JSON.parse(readFileSync(filePath, 'utf8')) as Partial<ProfileFile>
+      if (!isProviderProfile(parsed.profile) || !parsed.env || typeof parsed.env !== 'object') {
+        return null
+      }
+
+      return {
+        profile: parsed.profile,
+        env: parsed.env,
+        createdAt:
+          typeof parsed.createdAt === 'string'
+            ? parsed.createdAt
+            : new Date().toISOString(),
+      }
+    } catch {
       return null
     }
-
-    return {
-      profile: parsed.profile,
-      env: parsed.env,
-      createdAt:
-        typeof parsed.createdAt === 'string'
-          ? parsed.createdAt
-          : new Date().toISOString(),
-    }
-  } catch {
-    return null
   }
+  return null
 }
 
 export function saveProfileFile(
@@ -399,9 +416,15 @@ export function saveProfileFile(
 }
 
 export function deleteProfileFile(options?: ProfileFileLocation): string {
-  const filePath = resolveProfileFilePath(options)
-  rmSync(filePath, { force: true })
-  return filePath
+  const candidates = getCandidateProfileFilePaths(options)
+  let removedPath: string | null = null
+  for (const filePath of candidates) {
+    if (existsSync(filePath) && !removedPath) {
+      removedPath = filePath
+    }
+    rmSync(filePath, { force: true })
+  }
+  return removedPath ?? resolveProfileFilePath(options)
 }
 
 export function hasExplicitProviderSelection(
@@ -676,7 +699,10 @@ export async function buildStartupEnvFromProfile(options?: {
     persisted,
     goal:
       options?.goal ??
-      normalizeRecommendationGoal(processEnv.OPENCLAUDE_PROFILE_GOAL),
+      normalizeRecommendationGoal(
+        processEnv.OPENLAWB_PROFILE_GOAL ??
+          processEnv.OPENCLAUDE_PROFILE_GOAL,
+      ),
     processEnv,
     getOllamaChatBaseUrl:
       options?.getOllamaChatBaseUrl ?? getOllamaChatBaseUrl,

--- a/vscode-extension/openclaude-vscode/README.md
+++ b/vscode-extension/openclaude-vscode/README.md
@@ -10,7 +10,7 @@ A practical VS Code companion for OpenClaude with a project-aware **Control Cent
   - whether the launch shim injects `CLAUDE_CODE_USE_OPENAI=1`
   - the current workspace folder
   - the launch cwd that will be used for terminal sessions
-  - whether `.openclaude-profile.json` exists in the current workspace root
+  - whether `.openlawb-profile.json` exists in the current workspace root (legacy `.openclaude-profile.json` still works)
   - a conservative provider summary derived from the workspace profile or known environment flags
 - **Project-aware launch behavior**:
   - `Launch OpenClaude` launches from the active editor's workspace when possible
@@ -49,7 +49,7 @@ A practical VS Code companion for OpenClaude with a project-aware **Control Cent
 
 ## Notes on Status Detection
 
-- Provider status prefers the real workspace `.openclaude-profile.json` file when present.
+- Provider status prefers the real workspace `.openlawb-profile.json` file when present (with fallback to legacy `.openclaude-profile.json`).
 - If no saved profile exists, the extension falls back to known environment flags available to the VS Code extension host.
 - If the source of truth is unclear, the extension shows `unknown` instead of guessing.
 
@@ -67,4 +67,3 @@ To package (optional):
 ```bash
 npm run package
 ```
-

--- a/vscode-extension/openclaude-vscode/src/extension.js
+++ b/vscode-extension/openclaude-vscode/src/extension.js
@@ -15,7 +15,8 @@ const { buildControlCenterViewModel } = require('./presentation');
 
 const OPENCLAUDE_REPO_URL = 'https://github.com/Gitlawb/openclaude';
 const OPENCLAUDE_SETUP_URL = 'https://github.com/Gitlawb/openclaude/blob/main/README.md#quick-start';
-const PROFILE_FILE_NAME = '.openclaude-profile.json';
+const PROFILE_FILE_NAME = '.openlawb-profile.json';
+const LEGACY_PROFILE_FILE_NAME = '.openclaude-profile.json';
 
 function escapeHtml(value) {
   return String(value)
@@ -200,6 +201,26 @@ function readWorkspaceProfile(profilePath) {
   }
 }
 
+function getWorkspaceProfileCandidates(workspaceFolder) {
+  if (!workspaceFolder) {
+    return [];
+  }
+
+  return [
+    path.join(workspaceFolder, PROFILE_FILE_NAME),
+    path.join(workspaceFolder, LEGACY_PROFILE_FILE_NAME),
+  ];
+}
+
+function resolveWorkspaceProfilePath(workspaceFolder) {
+  for (const candidate of getWorkspaceProfileCandidates(workspaceFolder)) {
+    if (fs.existsSync(candidate)) {
+      return candidate;
+    }
+  }
+  return workspaceFolder ? path.join(workspaceFolder, PROFILE_FILE_NAME) : null;
+}
+
 async function collectControlCenterState() {
   const configured = vscode.workspace.getConfiguration('openclaude');
   const launchCommand = configured.get('launchCommand', 'openclaude');
@@ -216,9 +237,7 @@ async function collectControlCenterState() {
     executable,
   });
   const installed = await isCommandAvailable(executable, launchTargets.projectAwareCwd);
-  const profilePath = workspaceFolder
-    ? path.join(workspaceFolder, PROFILE_FILE_NAME)
-    : null;
+  const profilePath = resolveWorkspaceProfilePath(workspaceFolder);
 
   const profileState = workspaceFolder
     ? readWorkspaceProfile(profilePath)
@@ -1084,7 +1103,7 @@ function activate(context) {
     provider,
   );
 
-  const profileWatcher = vscode.workspace.createFileSystemWatcher(`**/${PROFILE_FILE_NAME}`);
+  const profileWatcher = vscode.workspace.createFileSystemWatcher(`**/{${PROFILE_FILE_NAME},${LEGACY_PROFILE_FILE_NAME}}`);
 
   context.subscriptions.push(
     startCommand,

--- a/vscode-extension/openclaude-vscode/src/extension.test.js
+++ b/vscode-extension/openclaude-vscode/src/extension.test.js
@@ -15,8 +15,8 @@ function createStatus(overrides = {}) {
     launchCwdLabel: '/workspace/openclaude/very/long/path/example-project',
     canLaunchInWorkspaceRoot: true,
     profileStatusLabel: 'Found',
-    profileStatusHint: '/workspace/openclaude/very/long/path/example-project/.openclaude-profile.json',
-    workspaceProfilePath: '/workspace/openclaude/very/long/path/example-project/.openclaude-profile.json',
+    profileStatusHint: '/workspace/openclaude/very/long/path/example-project/.openlawb-profile.json',
+    workspaceProfilePath: '/workspace/openclaude/very/long/path/example-project/.openlawb-profile.json',
     providerState: {
       label: 'Codex',
       detail: 'gpt-5.4',

--- a/vscode-extension/openclaude-vscode/src/presentation.test.js
+++ b/vscode-extension/openclaude-vscode/src/presentation.test.js
@@ -9,8 +9,8 @@ test('truncateMiddle keeps the profile filename visible', () => {
   const { truncateMiddle } = loadPresentation();
 
   assert.equal(
-    truncateMiddle('/Users/example/projects/openclaude/workspace/.openclaude-profile.json', 30),
-    '.../.openclaude-profile.json',
+    truncateMiddle('/Users/example/projects/openclaude/workspace/.openlawb-profile.json', 30),
+    '.../.openlawb-profile.json',
   );
 });
 
@@ -18,8 +18,8 @@ test('truncateMiddle keeps the filename visible for Windows-style paths', () => 
   const { truncateMiddle } = loadPresentation();
 
   assert.equal(
-    truncateMiddle('C:\\Users\\example\\openclaude\\workspace\\.openclaude-profile.json', 30),
-    '...\\.openclaude-profile.json',
+    truncateMiddle('C:\\Users\\example\\openclaude\\workspace\\.openlawb-profile.json', 30),
+    '...\\.openlawb-profile.json',
   );
 });
 
@@ -63,13 +63,13 @@ test('buildActionModel includes workspace-profile action when a profile exists',
 
   const model = buildActionModel({
     canLaunchInWorkspaceRoot: true,
-    workspaceProfilePath: 'C:\\Users\\example\\openclaude\\workspace\\.openclaude-profile.json',
+    workspaceProfilePath: 'C:\\Users\\example\\openclaude\\workspace\\.openlawb-profile.json',
   });
 
   assert.deepEqual(model.openProfile, {
     id: 'openProfile',
     label: 'Open Workspace Profile',
-    detail: 'Inspect ...\\.openclaude-profile.json',
+    detail: 'Inspect ...\\.openlawb-profile.json',
     tone: 'neutral',
     disabled: false,
   });
@@ -88,8 +88,8 @@ function createStatus(overrides = {}) {
     launchCwdLabel: '/workspace/openclaude',
     canLaunchInWorkspaceRoot: true,
     profileStatusLabel: 'Found',
-    profileStatusHint: '/workspace/openclaude/.openclaude-profile.json',
-    workspaceProfilePath: '/workspace/openclaude/.openclaude-profile.json',
+    profileStatusHint: '/workspace/openclaude/.openlawb-profile.json',
+    workspaceProfilePath: '/workspace/openclaude/.openlawb-profile.json',
     providerState: {
       label: 'Codex',
       detail: 'gpt-5.4',
@@ -173,7 +173,7 @@ test('buildControlCenterViewModel uses a concise project summary before full pat
           key: 'profileStatus',
           label: 'Workspace profile',
           summary: 'Found',
-          detail: '/workspace/openclaude/.openclaude-profile.json',
+          detail: '/workspace/openclaude/.openlawb-profile.json',
           tone: 'neutral',
         },
       ],


### PR DESCRIPTION
## Summary
- change the default config home from `~/.openclaude` to `~/.openlawb` with fallback to legacy `~/.openclaude` and `~/.claude`
- change the default provider profile file to `.openlawb-profile.json` with fallback support for legacy `.openclaude-profile.json`
- update provider scripts, provider UX text, README notes, and the VS Code extension to prefer the new profile filename while keeping legacy compatibility

## Test plan
- [x] `bun run build`
- [x] `bun run smoke`
- [x] `bun run verify:privacy`
- [x] `bun test src/utils/providerProfile.test.ts src/commands/provider/provider.test.tsx vscode-extension/openclaude-vscode/src/extension.test.js vscode-extension/openclaude-vscode/src/presentation.test.js`
- [ ] `bunx tsc --noEmit` *(still noisy on this upstream snapshot; this PR is validated with focused tests instead)*

## Notes
This is the first rebrand migration slice only. It intentionally does **not** rename package names, binaries, global command names, or the broader `OpenClaude`/`Claude Code` user-facing product text yet.