### PR TITLE
fix: preserve unicode in Windows clipboard fallback

### DIFF
--- a/src/ink/termio/osc.test.ts
+++ b/src/ink/termio/osc.test.ts
@@ -1,0 +1,110 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test'
+
+const originalEnv = { ...process.env }
+const originalPlatform = process.platform
+
+const execFileNoThrowMock = mock(
+  async () => ({ code: 0, stdout: '', stderr: '' }),
+)
+
+mock.module('../../utils/execFileNoThrow.js', () => ({
+  execFileNoThrow: execFileNoThrowMock,
+}))
+
+async function importFreshOscModule() {
+  return import(`./osc.ts?ts=${Date.now()}-${Math.random()}`)
+}
+
+describe('Windows clipboard fallback', () => {
+  beforeEach(() => {
+    execFileNoThrowMock.mockClear()
+    process.env = { ...originalEnv }
+    delete process.env['SSH_CONNECTION']
+    delete process.env['TMUX']
+    Object.defineProperty(process, 'platform', { value: 'win32' })
+  })
+
+  afterEach(() => {
+    mock.restore()
+    process.env = { ...originalEnv }
+    Object.defineProperty(process, 'platform', { value: originalPlatform })
+  })
+
+  test('uses PowerShell instead of clip.exe for local Windows copy', async () => {
+    const { setClipboard } = await importFreshOscModule()
+
+    await setClipboard('Привет мир')
+
+    expect(execFileNoThrowMock.mock.calls.some(([cmd]) => cmd === 'clip')).toBe(
+      false,
+    )
+    expect(
+      execFileNoThrowMock.mock.calls.some(([cmd]) => cmd === 'powershell'),
+    ).toBe(true)
+  })
+
+  test('passes the original Unicode text to the Windows copy command', async () => {
+    const { setClipboard } = await importFreshOscModule()
+
+    await setClipboard('Привет мир')
+
+    const windowsCall = execFileNoThrowMock.mock.calls.find(
+      ([cmd]) => cmd === 'powershell',
+    )
+
+    expect(windowsCall?.[2]).toMatchObject({ input: 'Привет мир' })
+  })
+})
+
+describe('clipboard path behavior remains stable', () => {
+  beforeEach(() => {
+    execFileNoThrowMock.mockClear()
+    process.env = { ...originalEnv }
+    delete process.env['SSH_CONNECTION']
+    delete process.env['TMUX']
+  })
+
+  afterEach(() => {
+    mock.restore()
+    process.env = { ...originalEnv }
+    Object.defineProperty(process, 'platform', { value: originalPlatform })
+  })
+
+  test('getClipboardPath stays native on local macOS', async () => {
+    Object.defineProperty(process, 'platform', { value: 'darwin' })
+    const { getClipboardPath } = await importFreshOscModule()
+
+    expect(getClipboardPath()).toBe('native')
+  })
+
+  test('getClipboardPath stays tmux-buffer when TMUX is set', async () => {
+    Object.defineProperty(process, 'platform', { value: 'linux' })
+    process.env['TMUX'] = '/tmp/tmux-1000/default,123,0'
+    const { getClipboardPath } = await importFreshOscModule()
+
+    expect(getClipboardPath()).toBe('tmux-buffer')
+  })
+
+  test('Windows clipboard fallback is skipped over SSH', async () => {
+    Object.defineProperty(process, 'platform', { value: 'win32' })
+    process.env['SSH_CONNECTION'] = '1 2 3 4'
+    const { setClipboard } = await importFreshOscModule()
+
+    await setClipboard('Привет мир')
+
+    expect(execFileNoThrowMock.mock.calls.some(([cmd]) => cmd === 'powershell')).toBe(
+      false,
+    )
+  })
+
+  test('local macOS clipboard fallback still uses pbcopy', async () => {
+    Object.defineProperty(process, 'platform', { value: 'darwin' })
+    const { setClipboard } = await importFreshOscModule()
+
+    await setClipboard('hello')
+
+    expect(execFileNoThrowMock.mock.calls.some(([cmd]) => cmd === 'pbcopy')).toBe(
+      true,
+    )
+  })
+})

--- a/src/ink/termio/osc.test.ts
+++ b/src/ink/termio/osc.test.ts
@@ -3,6 +3,8 @@ import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test'
 const originalEnv = { ...process.env }
 const originalPlatform = process.platform
 
+const generateTempFilePathMock = mock(() => '/tmp/openclaude-clipboard.txt')
+
 const execFileNoThrowMock = mock(
   async () => ({ code: 0, stdout: '', stderr: '' }),
 )
@@ -11,13 +13,22 @@ mock.module('../../utils/execFileNoThrow.js', () => ({
   execFileNoThrow: execFileNoThrowMock,
 }))
 
+mock.module('../../utils/tempfile.js', () => ({
+  generateTempFilePath: generateTempFilePathMock,
+}))
+
 async function importFreshOscModule() {
   return import(`./osc.ts?ts=${Date.now()}-${Math.random()}`)
+}
+
+async function flushClipboardCopy(): Promise<void> {
+  await new Promise(resolve => setTimeout(resolve, 0))
 }
 
 describe('Windows clipboard fallback', () => {
   beforeEach(() => {
     execFileNoThrowMock.mockClear()
+    generateTempFilePathMock.mockClear()
     process.env = { ...originalEnv }
     delete process.env['SSH_CONNECTION']
     delete process.env['TMUX']
@@ -34,6 +45,7 @@ describe('Windows clipboard fallback', () => {
     const { setClipboard } = await importFreshOscModule()
 
     await setClipboard('Привет мир')
+    await flushClipboardCopy()
 
     expect(execFileNoThrowMock.mock.calls.some(([cmd]) => cmd === 'clip')).toBe(
       false,
@@ -43,16 +55,28 @@ describe('Windows clipboard fallback', () => {
     ).toBe(true)
   })
 
-  test('passes the original Unicode text to the Windows copy command', async () => {
+  test('passes Windows clipboard text through a UTF-8 temp file instead of stdin', async () => {
     const { setClipboard } = await importFreshOscModule()
 
     await setClipboard('Привет мир')
+    await flushClipboardCopy()
 
     const windowsCall = execFileNoThrowMock.mock.calls.find(
       ([cmd]) => cmd === 'powershell',
     )
 
-    expect(windowsCall?.[2]).toMatchObject({ input: 'Привет мир' })
+    expect(windowsCall?.[2]).toMatchObject({
+      stdin: 'ignore',
+    })
+    expect(windowsCall?.[2]).not.toMatchObject({ input: 'Привет мир' })
+    expect(windowsCall?.[2]).not.toMatchObject({
+      env: expect.objectContaining({
+        OPENCLAUDE_CLIPBOARD_TEXT_B64: expect.any(String),
+      }),
+    })
+    expect(windowsCall?.[1]).toContain(
+      "$text = [System.IO.File]::ReadAllText('/tmp/openclaude-clipboard.txt', [System.Text.Encoding]::UTF8); Set-Clipboard -Value $text",
+    )
   })
 })
 

--- a/src/ink/termio/osc.test.ts
+++ b/src/ink/termio/osc.test.ts
@@ -1,9 +1,11 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test'
+import { join } from 'node:path'
 
 const originalEnv = { ...process.env }
 const originalPlatform = process.platform
+const mockedClipboardPath = join(process.cwd(), 'openclaude-clipboard.txt')
 
-const generateTempFilePathMock = mock(() => '/tmp/openclaude-clipboard.txt')
+const generateTempFilePathMock = mock(() => mockedClipboardPath)
 
 const execFileNoThrowMock = mock(
   async () => ({ code: 0, stdout: '', stderr: '' }),
@@ -36,7 +38,6 @@ describe('Windows clipboard fallback', () => {
   })
 
   afterEach(() => {
-    mock.restore()
     process.env = { ...originalEnv }
     Object.defineProperty(process, 'platform', { value: originalPlatform })
   })
@@ -75,7 +76,7 @@ describe('Windows clipboard fallback', () => {
       }),
     })
     expect(windowsCall?.[1]).toContain(
-      "$text = [System.IO.File]::ReadAllText('/tmp/openclaude-clipboard.txt', [System.Text.Encoding]::UTF8); Set-Clipboard -Value $text",
+      `$text = [System.IO.File]::ReadAllText('${mockedClipboardPath.replace(/'/g, "''")}', [System.Text.Encoding]::UTF8); Set-Clipboard -Value $text`,
     )
   })
 })
@@ -89,7 +90,6 @@ describe('clipboard path behavior remains stable', () => {
   })
 
   afterEach(() => {
-    mock.restore()
     process.env = { ...originalEnv }
     Object.defineProperty(process, 'platform', { value: originalPlatform })
   })

--- a/src/ink/termio/osc.ts
+++ b/src/ink/termio/osc.ts
@@ -129,7 +129,7 @@ export async function tmuxLoadBuffer(text: string): Promise<boolean> {
  * Local (no SSH_CONNECTION): also shell out to a native clipboard utility.
  * OSC 52 and tmux -w both depend on terminal settings — iTerm2 disables
  * OSC 52 by default, VS Code shows a permission prompt on first use. Native
- * utilities (pbcopy/wl-copy/xclip/xsel/clip.exe) always work locally. Over
+ * utilities (pbcopy/wl-copy/xclip/xsel/PowerShell Set-Clipboard) always work locally. Over
  * SSH these would write to the remote clipboard — OSC 52 is the right path there.
  *
  * Returns the sequence for the caller to write to stdout (raw OSC 52
@@ -211,9 +211,18 @@ function copyNative(text: string): void {
       return
     }
     case 'win32':
-      // clip.exe is always available on Windows. Unicode handling is
-      // imperfect (system locale encoding) but good enough for a fallback.
-      void execFileNoThrow('clip', [], opts)
+      // PowerShell's Set-Clipboard preserves Unicode text more reliably than
+      // clip.exe, which can mangle non-ASCII text under some Windows locales.
+      void execFileNoThrow(
+        'powershell',
+        [
+          '-NoProfile',
+          '-NonInteractive',
+          '-Command',
+          '$text = [Console]::In.ReadToEnd(); Set-Clipboard -Value $text',
+        ],
+        opts,
+      )
       return
   }
 }

--- a/src/ink/termio/osc.ts
+++ b/src/ink/termio/osc.ts
@@ -3,8 +3,10 @@
  */
 
 import { Buffer } from 'buffer'
+import { unlink, writeFile } from 'node:fs/promises'
 import { env } from '../../utils/env.js'
 import { execFileNoThrow } from '../../utils/execFileNoThrow.js'
+import { generateTempFilePath } from '../../utils/tempfile.js'
 import { BEL, ESC, ESC_TYPE, SEP } from './ansi.js'
 import type { Action, Color, TabStatusAction } from './types.js'
 
@@ -211,18 +213,32 @@ function copyNative(text: string): void {
       return
     }
     case 'win32':
-      // PowerShell's Set-Clipboard preserves Unicode text more reliably than
-      // clip.exe, which can mangle non-ASCII text under some Windows locales.
-      void execFileNoThrow(
-        'powershell',
-        [
-          '-NoProfile',
-          '-NonInteractive',
-          '-Command',
-          '$text = [Console]::In.ReadToEnd(); Set-Clipboard -Value $text',
-        ],
-        opts,
-      )
+      // Avoid piping non-ASCII text through the Windows stdin/codepage
+      // boundary. Write UTF-8 text to a temp file and let PowerShell read it
+      // directly as UTF-8 before calling Set-Clipboard.
+      void (async () => {
+        const tempPath = generateTempFilePath('openclaude-clipboard', '.txt')
+        const escapedTempPath = tempPath.replace(/'/g, "''")
+        try {
+          await writeFile(tempPath, text, { encoding: 'utf8' })
+          await execFileNoThrow(
+            'powershell',
+            [
+              '-NoProfile',
+              '-NonInteractive',
+              '-Command',
+              `$text = [System.IO.File]::ReadAllText('${escapedTempPath}', [System.Text.Encoding]::UTF8); Set-Clipboard -Value $text`,
+            ],
+            {
+              useCwd: false,
+              timeout: opts.timeout,
+              stdin: 'ignore',
+            },
+          )
+        } finally {
+          await unlink(tempPath).catch(() => {})
+        }
+      })().catch(() => {})
       return
   }
 }


### PR DESCRIPTION
## Summary
- replace the Windows local clipboard fallback in `src/ink/termio/osc.ts` with PowerShell `Set-Clipboard` so fullscreen selection copy preserves non-ASCII text
- add focused regression coverage for the Windows clipboard path and guardrail tests for unchanged macOS, tmux, and SSH behavior
- keep the existing clipboard flow intact outside the Windows native fallback branch

## Testing
- `\"/home/gnanasekaran/.bun/bin/bun\" test src/ink/termio/osc.test.ts`
- `\"/home/gnanasekaran/.bun/bin/bun\" test src/ink/parse-keypress.test.ts`
- `\"/home/gnanasekaran/.bun/bin/bun\" run scripts/build.ts`

## Manual Verification
- verified on Windows that fullscreen selection copy preserves Russian text during paste round-trip

Fixes #386