### PR TITLE
feat(provider): add ChatGPT Codex provider flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ Advanced and source-build guides:
 | OpenAI-compatible | `/provider` or env vars | Works with OpenAI, OpenRouter, DeepSeek, Groq, Mistral, LM Studio, and other compatible `/v1` servers |
 | Gemini | `/provider` or env vars | Supports API key, access token, or local ADC workflow on current `main` |
 | GitHub Models | `/onboard-github` | Interactive onboarding with saved credentials |
-| Codex | `/provider` | Uses existing Codex credentials when available |
+| Codex | `/provider` | Can reuse an existing local Codex login and offers built-in Codex model choices |
 | Ollama | `/provider` or env vars | Local inference with no API key |
 | Atomic Chat | advanced setup | Local Apple Silicon backend |
 | Bedrock / Vertex / Foundry | env vars | Additional provider integrations for supported environments |

--- a/docs/advanced-setup.md
+++ b/docs/advanced-setup.md
@@ -50,6 +50,8 @@ export OPENAI_MODEL=gpt-4o
 
 If you already use the Codex CLI, OpenClaude reads `~/.codex/auth.json` automatically. You can also point it elsewhere with `CODEX_AUTH_JSON_PATH` or override the token directly with `CODEX_API_KEY`.
 
+You can now also use `/provider` to add a `ChatGPT / Codex` profile, reuse a detected local Codex login, and pick from built-in Codex model options instead of typing a model name manually.
+
 ```bash
 export CLAUDE_CODE_USE_OPENAI=1
 export OPENAI_MODEL=codexplan

--- a/docs/non-technical-setup.md
+++ b/docs/non-technical-setup.md
@@ -59,6 +59,7 @@ Choose this if:
 
 - you already use the Codex CLI
 - you already have Codex or ChatGPT auth configured
+- you want OpenClaude to reuse your local Codex login from `/provider`
 
 ## What Success Looks Like
 

--- a/src/components/ProviderManager.tsx
+++ b/src/components/ProviderManager.tsx
@@ -1,8 +1,10 @@
 import figures from 'figures'
 import * as React from 'react'
+import { resolveCodexApiCredentials } from '../services/api/providerConfig.js'
 import { Box, Text } from '../ink.js'
 import { useKeybinding } from '../keybindings/useKeybinding.js'
 import type { ProviderProfile } from '../utils/config.js'
+import { getCodexModelOptions } from '../utils/model/modelOptions.js'
 import {
   addProviderProfile,
   deleteProviderProfile,
@@ -36,8 +38,14 @@ type Screen =
   | 'select-active'
   | 'select-edit'
   | 'select-delete'
+  | 'codex-auth'
+  | 'codex-model'
 
 type DraftField = 'name' | 'baseUrl' | 'model' | 'apiKey'
+
+type CodexAuthStatus =
+  | { available: true; sourceDescription: string }
+  | { available: false; sourceDescription: string }
 
 type ProviderDraft = Record<DraftField, string>
 
@@ -94,11 +102,37 @@ function presetToDraft(preset: ProviderPreset): ProviderDraft {
   }
 }
 
+function getCodexAuthStatus(): CodexAuthStatus {
+  const credentials = resolveCodexApiCredentials(process.env)
+  if (credentials.apiKey && credentials.accountId) {
+    return {
+      available: true,
+      sourceDescription:
+        credentials.source === 'env'
+          ? 'Detected credentials in the current environment.'
+          : credentials.authPath
+            ? `Detected local Codex login at ${credentials.authPath}.`
+            : 'Detected local Codex credentials.',
+    }
+  }
+
+  return {
+    available: false,
+    sourceDescription: credentials.authPath
+      ? `No usable local Codex login found. Expected auth file: ${credentials.authPath}.`
+      : 'No usable local Codex login found.',
+  }
+}
+
 function profileSummary(profile: ProviderProfile, isActive: boolean): string {
   const activeSuffix = isActive ? ' (active)' : ''
   const keyInfo = profile.apiKey ? 'key set' : 'no key'
   const providerKind =
-    profile.provider === 'anthropic' ? 'anthropic' : 'openai-compatible'
+    profile.provider === 'anthropic'
+      ? 'anthropic'
+      : profile.provider === 'codex'
+        ? 'codex'
+        : 'openai-compatible'
   return `${providerKind} · ${profile.baseUrl} · ${profile.model} · ${keyInfo}${activeSuffix}`
 }
 
@@ -121,6 +155,7 @@ export function ProviderManager({ mode, onDone }: Props): React.ReactNode {
   const [cursorOffset, setCursorOffset] = React.useState(0)
   const [statusMessage, setStatusMessage] = React.useState<string | undefined>()
   const [errorMessage, setErrorMessage] = React.useState<string | undefined>()
+  const codexAuthStatus = React.useMemo(() => getCodexAuthStatus(), [])
 
   const currentStep = FORM_STEPS[formStepIndex] ?? FORM_STEPS[0]
   const currentStepKey = currentStep.key
@@ -150,7 +185,7 @@ export function ProviderManager({ mode, onDone }: Props): React.ReactNode {
     setFormStepIndex(0)
     setCursorOffset(nextDraft.name.length)
     setErrorMessage(undefined)
-    setScreen('form')
+    setScreen(defaults.provider === 'codex' ? 'codex-auth' : 'form')
   }
 
   function startEditProfile(profileId: string): void {
@@ -175,7 +210,7 @@ export function ProviderManager({ mode, onDone }: Props): React.ReactNode {
       name: draft.name,
       baseUrl: draft.baseUrl,
       model: draft.model,
-      apiKey: draft.apiKey,
+      apiKey: draftProvider === 'codex' ? draft.apiKey || undefined : draft.apiKey,
     }
 
     const saved = editingProfileId
@@ -247,6 +282,16 @@ export function ProviderManager({ mode, onDone }: Props): React.ReactNode {
       return
     }
 
+    if (screen === 'codex-model') {
+      setScreen('codex-auth')
+      return
+    }
+
+    if (screen === 'codex-auth') {
+      setScreen('select-preset')
+      return
+    }
+
     if (mode === 'first-run') {
       setScreen('select-preset')
       return
@@ -276,6 +321,11 @@ export function ProviderManager({ mode, onDone }: Props): React.ReactNode {
         value: 'openai',
         label: 'OpenAI',
         description: 'OpenAI API with API key',
+      },
+      {
+        value: 'codex',
+        label: 'ChatGPT / Codex',
+        description: 'Use ChatGPT Codex-compatible credentials',
       },
       {
         value: 'moonshotai',
@@ -379,7 +429,9 @@ export function ProviderManager({ mode, onDone }: Props): React.ReactNode {
           Provider type:{' '}
           {draftProvider === 'anthropic'
             ? 'Anthropic native API'
-            : 'OpenAI-compatible API'}
+            : draftProvider === 'codex'
+              ? 'ChatGPT Codex-compatible API'
+              : 'OpenAI-compatible API'}
         </Text>
         <Text dimColor>
           Step {formStepIndex + 1} of {FORM_STEPS.length}: {currentStep.label}
@@ -407,6 +459,91 @@ export function ProviderManager({ mode, onDone }: Props): React.ReactNode {
         <Text dimColor>
           Press Enter to continue. Press Esc to go back.
         </Text>
+      </Box>
+    )
+  }
+
+  function renderCodexAuth(): React.ReactNode {
+    const options = [
+      {
+        value: 'use-local',
+        label: 'Use detected login',
+        description: codexAuthStatus.available
+          ? codexAuthStatus.sourceDescription
+          : 'Unavailable until a local Codex login is detected',
+        disabled: !codexAuthStatus.available,
+      },
+      {
+        value: 'manual',
+        label: 'Enter token manually',
+        description: 'Store a CODEX_API_KEY in this provider profile',
+      },
+    ]
+
+    return (
+      <Box flexDirection="column" gap={1}>
+        <Text color="remember" bold>
+          {editingProfileId ? 'Edit Codex provider' : 'Create Codex provider'}
+        </Text>
+        <Text dimColor>
+          Use an existing local Codex login when available, or fall back to a manual token.
+        </Text>
+        <Text dimColor>{codexAuthStatus.sourceDescription}</Text>
+        <Text dimColor>Default model: {draft.model}</Text>
+        <Select
+          options={options}
+          onChange={value => {
+            setErrorMessage(undefined)
+            if (value === 'use-local') {
+              setDraft(prev => ({ ...prev, apiKey: '' }))
+              setCursorOffset(draft.model.length)
+              setScreen('codex-model')
+              return
+            }
+
+            setFormStepIndex(3)
+            setCursorOffset(draft.apiKey.length)
+            setScreen('form')
+          }}
+          onCancel={handleBackFromForm}
+          visibleOptionCount={options.length}
+        />
+      </Box>
+    )
+  }
+
+  function renderCodexModelSelection(): React.ReactNode {
+    const options = getCodexModelOptions()
+
+    return (
+      <Box flexDirection="column" gap={1}>
+        <Text color="remember" bold>
+          Choose Codex model
+        </Text>
+        <Text dimColor>
+          Pick a default Codex model. This list is pre-filled from the models already known in the codebase.
+        </Text>
+        <Text dimColor>
+          If you already logged in with Codex locally, your credentials will be reused automatically.
+        </Text>
+        <Select
+          options={options.map(option => ({
+            value: option.value,
+            label: option.label,
+            description: option.description,
+          }))}
+          defaultValue={draft.model}
+          defaultFocusValue={draft.model}
+          inlineDescriptions
+          visibleOptionCount={Math.min(8, options.length)}
+          onChange={value => {
+            setDraft(prev => ({ ...prev, model: String(value) }))
+            setFormStepIndex(0)
+            setCursorOffset(draft.name.length)
+            setScreen('form')
+          }}
+          onCancel={() => setScreen('codex-auth')}
+        />
       </Box>
     )
   }
@@ -534,7 +671,7 @@ export function ProviderManager({ mode, onDone }: Props): React.ReactNode {
         profile.id === activeProfileId
           ? `${profile.name} (active)`
           : profile.name,
-      description: `${profile.provider === 'anthropic' ? 'anthropic' : 'openai-compatible'} · ${profile.baseUrl} · ${profile.model}`,
+      description: `${profile.provider === 'anthropic' ? 'anthropic' : profile.provider === 'codex' ? 'codex' : 'openai-compatible'} · ${profile.baseUrl} · ${profile.model}`,
     }))
 
     return (
@@ -560,6 +697,12 @@ export function ProviderManager({ mode, onDone }: Props): React.ReactNode {
       break
     case 'form':
       content = renderForm()
+      break
+    case 'codex-auth':
+      content = renderCodexAuth()
+      break
+    case 'codex-model':
+      content = renderCodexModelSelection()
       break
     case 'select-active':
       content = renderProfileSelection(

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -183,7 +183,7 @@ export type OutputStyle = string
 export type ProviderProfile = {
   id: string
   name: string
-  provider: 'openai' | 'anthropic'
+  provider: 'openai' | 'anthropic' | 'codex'
   baseUrl: string
   model: string
   apiKey?: string

--- a/src/utils/model/modelOptions.ts
+++ b/src/utils/model/modelOptions.ts
@@ -284,7 +284,7 @@ function getCodexSparkOption(): ModelOption {
   }
 }
 
-function getCodexModelOptions(): ModelOption[] {
+export function getCodexModelOptions(): ModelOption[] {
   return [
     {
       value: 'gpt-5.4',

--- a/src/utils/providerProfiles.test.ts
+++ b/src/utils/providerProfiles.test.ts
@@ -23,6 +23,7 @@ const RESTORED_KEYS = [
   'OPENAI_API_BASE',
   'OPENAI_MODEL',
   'OPENAI_API_KEY',
+  'CODEX_API_KEY',
   'ANTHROPIC_BASE_URL',
   'ANTHROPIC_MODEL',
   'ANTHROPIC_API_KEY',
@@ -86,6 +87,25 @@ describe('applyProviderProfileToProcessEnv', () => {
     expect(process.env.CLAUDE_CODE_USE_GITHUB).toBeUndefined()
     expect(process.env.CLAUDE_CODE_USE_OPENAI).toBeUndefined()
     expect(getAPIProvider()).toBe('firstParty')
+  })
+
+  test('codex profile uses CODEX_API_KEY instead of OPENAI_API_KEY', () => {
+    process.env.OPENAI_API_KEY = 'sk-openai'
+
+    applyProviderProfileToProcessEnv(
+      buildProfile({
+        provider: 'codex',
+        baseUrl: 'https://chatgpt.com/backend-api/codex',
+        model: 'codexplan',
+        apiKey: 'codex-token',
+      }),
+    )
+
+    expect(process.env.CLAUDE_CODE_USE_OPENAI).toBe('1')
+    expect(process.env.OPENAI_BASE_URL).toBe('https://chatgpt.com/backend-api/codex')
+    expect(process.env.OPENAI_MODEL).toBe('codexplan')
+    expect(process.env.CODEX_API_KEY).toBe('codex-token')
+    expect(process.env.OPENAI_API_KEY).toBeUndefined()
   })
 })
 
@@ -172,6 +192,15 @@ describe('getProviderPresetDefaults', () => {
     expect(defaults.baseUrl).toBe('http://localhost:11434/v1')
     expect(defaults.model).toBe('llama3.1:8b')
   })
+
+  test('codex preset defaults to the ChatGPT Codex endpoint', () => {
+    const defaults = getProviderPresetDefaults('codex')
+
+    expect(defaults.provider).toBe('codex')
+    expect(defaults.baseUrl).toBe('https://chatgpt.com/backend-api/codex')
+    expect(defaults.model).toBe('codexplan')
+    expect(defaults.requiresApiKey).toBe(false)
+  })
 })
 
 describe('deleteProviderProfile', () => {
@@ -209,6 +238,7 @@ describe('deleteProviderProfile', () => {
     expect(process.env.OPENAI_API_BASE).toBeUndefined()
     expect(process.env.OPENAI_MODEL).toBeUndefined()
     expect(process.env.OPENAI_API_KEY).toBeUndefined()
+    expect(process.env.CODEX_API_KEY).toBeUndefined()
 
     expect(process.env.ANTHROPIC_BASE_URL).toBeUndefined()
     expect(process.env.ANTHROPIC_MODEL).toBeUndefined()
@@ -235,5 +265,35 @@ describe('deleteProviderProfile', () => {
     expect(process.env.CLAUDE_CODE_USE_OPENAI).toBe('1')
     expect(process.env.OPENAI_BASE_URL).toBe('http://localhost:11434/v1')
     expect(process.env.OPENAI_MODEL).toBe('qwen2.5:3b')
+  })
+
+  test('deleting final codex profile clears CODEX_API_KEY when profile applied it', () => {
+    applyProviderProfileToProcessEnv(
+      buildProfile({
+        id: 'only_codex',
+        provider: 'codex',
+        baseUrl: 'https://chatgpt.com/backend-api/codex',
+        model: 'codexplan',
+        apiKey: 'codex-token',
+      }),
+    )
+
+    saveGlobalConfig(current => ({
+      ...current,
+      providerProfiles: [
+        buildProfile({
+          id: 'only_codex',
+          provider: 'codex',
+          baseUrl: 'https://chatgpt.com/backend-api/codex',
+          model: 'codexplan',
+        }),
+      ],
+      activeProviderProfileId: 'only_codex',
+    }))
+
+    const result = deleteProviderProfile('only_codex')
+
+    expect(result.removed).toBe(true)
+    expect(process.env.CODEX_API_KEY).toBeUndefined()
   })
 })

--- a/src/utils/providerProfiles.ts
+++ b/src/utils/providerProfiles.ts
@@ -10,6 +10,7 @@ export type ProviderPreset =
   | 'anthropic'
   | 'ollama'
   | 'openai'
+  | 'codex'
   | 'moonshotai'
   | 'deepseek'
   | 'gemini'
@@ -54,7 +55,12 @@ function normalizeBaseUrl(value: string): string {
 function sanitizeProfile(profile: ProviderProfile): ProviderProfile | null {
   const id = trimValue(profile.id)
   const name = trimValue(profile.name)
-  const provider = profile.provider === 'anthropic' ? 'anthropic' : 'openai'
+  const provider =
+    profile.provider === 'anthropic'
+      ? 'anthropic'
+      : profile.provider === 'codex'
+        ? 'codex'
+        : 'openai'
   const baseUrl = normalizeBaseUrl(profile.baseUrl)
   const model = trimValue(profile.model)
 
@@ -134,6 +140,15 @@ export function getProviderPresetDefaults(
         model: 'gpt-5.3-codex',
         apiKey: '',
         requiresApiKey: true,
+      }
+    case 'codex':
+      return {
+        provider: 'codex',
+        name: 'ChatGPT / Codex',
+        baseUrl: 'https://chatgpt.com/backend-api/codex',
+        model: 'codexplan',
+        apiKey: '',
+        requiresApiKey: false,
       }
     case 'moonshotai':
       return {
@@ -294,6 +309,21 @@ function isProcessEnvAlignedWithProfile(
     )
   }
 
+  if (profile.provider === 'codex') {
+    return (
+      processEnv.CLAUDE_CODE_USE_OPENAI !== undefined &&
+      processEnv.CLAUDE_CODE_USE_GEMINI === undefined &&
+      processEnv.CLAUDE_CODE_USE_GITHUB === undefined &&
+      processEnv.CLAUDE_CODE_USE_BEDROCK === undefined &&
+      processEnv.CLAUDE_CODE_USE_VERTEX === undefined &&
+      processEnv.CLAUDE_CODE_USE_FOUNDRY === undefined &&
+      sameOptionalEnvValue(processEnv.OPENAI_BASE_URL, profile.baseUrl) &&
+      sameOptionalEnvValue(processEnv.OPENAI_MODEL, profile.model) &&
+      (!includeApiKey ||
+        sameOptionalEnvValue(processEnv.CODEX_API_KEY, profile.apiKey))
+    )
+  }
+
   return (
     processEnv.CLAUDE_CODE_USE_OPENAI !== undefined &&
     processEnv.CLAUDE_CODE_USE_GEMINI === undefined &&
@@ -334,6 +364,7 @@ export function clearProviderProfileEnvFromProcessEnv(
   delete processEnv.OPENAI_API_BASE
   delete processEnv.OPENAI_MODEL
   delete processEnv.OPENAI_API_KEY
+  delete processEnv.CODEX_API_KEY
 
   delete processEnv.ANTHROPIC_BASE_URL
   delete processEnv.ANTHROPIC_MODEL
@@ -366,6 +397,17 @@ export function applyProviderProfileToProcessEnv(profile: ProviderProfile): void
   process.env.OPENAI_BASE_URL = profile.baseUrl
   process.env.OPENAI_MODEL = profile.model
 
+  if (profile.provider === 'codex') {
+    delete process.env.OPENAI_API_KEY
+    if (profile.apiKey) {
+      process.env.CODEX_API_KEY = profile.apiKey
+    } else {
+      delete process.env.CODEX_API_KEY
+    }
+    return
+  }
+
+  delete process.env.CODEX_API_KEY
   if (profile.apiKey) {
     process.env.OPENAI_API_KEY = profile.apiKey
   } else {


### PR DESCRIPTION
Add Codex as a first-class provider in the provider manager, including reuse of detected local Codex login, built-in Codex model choices, and updated docs for the new setup path.                            
                                                                                                                                           
  ## Summary                             
                                                                                                                                                                             
  - Added `codex` as a first-class provider type in the provider manager and provider profile config.                                                                        
  - Exposed a dedicated `ChatGPT / Codex` preset in the modern provider manager UI.                                                                                          
  - Added detection of existing local Codex credentials so users can reuse a detected local Codex login instead of always entering a token manually.                         
  - Added a built-in Codex model selection step so users can choose known Codex model options without typing model IDs by hand.
  - Updated provider environment application logic so Codex profiles use `CODEX_API_KEY` instead of `OPENAI_API_KEY`.                                                        
  - Updated docs to explain the new Codex provider flow and local-login reuse path.
                                                                                                                                                                             
  - This changed because Codex support already existed in the runtime/backend, but it was not exposed cleanly in the modern provider-manager flow.                           
  - This makes the Codex path discoverable, easier to configure, and more aligned with how users actually authenticate when they already use the Codex CLI locally.          
                                                                                                                                                                             
  ## Impact                                                                                                                                                                  
  - user-facing impact:                                                                                                                                                      
    - Users can now select `ChatGPT / Codex` directly in the provider manager.                                                                                               
    - Users can reuse an existing local Codex login when available.                                                                                                          
    - Users can choose from built-in Codex model options instead of manually entering a model name.                                                                          
    - Docs now describe the Codex setup path more clearly.                                                                                                                   
                                         
  - developer/maintainer impact:                                                                                                                                             
    - Introduces `codex` as an explicit provider profile type in the provider manager flow.                                                                                  
    - Keeps Codex-specific environment handling isolated from generic OpenAI-compatible provider handling.                                                                   
    - Adds focused tests covering Codex preset defaults and env application behavior.                                                                                        
                                                                                                                                                                             
  ## Testing                                                                                                                                                                                                                                                                                                          
  - [x] `bun run build`                                                                                                                                                      
  - [x] `bun run smoke` 
  - [x] `bun run dev`                                                                                                                                                     
  - [x] focused tests:                                                                                                                                                       
    - [x] `bun test src/utils/providerProfiles.test.ts`                                                                                                                      
    - [x] `bun test src/commands/provider/provider.test.tsx`                                                                                                                 
    - [x] `bun test src/utils/providerProfile.test.ts`
                                                                                                                                                                    
  ## Notes                                                                                                                                                                                                                                                                                                                     
  - provider/model path tested:                                                                                                                                              
    - Codex via `https://chatgpt.com/backend-api/codex`                                                                                                                      
    - default model path: `codexplan`                                                                                                                                        
                                                                                                                                                                             
  - screenshots attached (if UI changed):                                                                                                                                    
<img width="1919" height="876" alt="image" src="https://github.com/user-attachments/assets/85cbb0da-3389-49ed-8590-065f4d0ddf19" />         

<img width="1919" height="876" alt="image" src="https://github.com/user-attachments/assets/bdee8aa4-ceb0-4ca7-9e62-c6d1fbdb205f" />

<img width="1919" height="876" alt="image" src="https://github.com/user-attachments/assets/d03c5c7b-e049-4dee-a024-2fdcc5cbc9db" />
            
                                                                                                                                                                             
  - follow-up work or known limitations:                                                                                                                                   
    - This PR improves provider-manager UX and local credential reuse, but does not add a browser-based ChatGPT/Codex login flow inside OpenClaude itself.                   
    - Model choices are built from known Codex options in the codebase, not from live discovery against the backend.                                                         
                                                                                                                          