### PR TITLE
feat: Add Gemini support with thought_signature fix 

### DIFF
--- a/src/utils/messages.ts
+++ b/src/utils/messages.ts
@@ -2223,10 +2223,12 @@ export function normalizeMessagesForAPI(
 
                   // When tool search is enabled, preserve all fields including 'caller'
                   if (toolSearchEnabled) {
+                    const { extra_content, ...restBlock } = block as any
                     return {
-                      ...block,
+                      ...restBlock,
                       name: canonicalName,
                       input: normalizedInput,
+                      ...(getAPIProvider() === 'gemini' && extra_content ? { extra_content } : {})
                     }
                   }
 


### PR DESCRIPTION

## Key Changes
1. **Gemini `thought_signature` Fix**
   - **Problem:** When sending previous Assistant tool blocks (e.g., `Bash`) back to Gemini in the conversation context, the API rejected the payload with a `400 Bad Request` because it strictly requires the `google: { thought_signature }` tag from the original response to be maintained. 
   - **Solution:** While `@anthropic-ai/sdk` successfully parsed these non-standard fields as `extra_content`, the sanitizer in [normalizeMessagesForAPI](cci:1://file:///home/babu/Projects/openclaude/src/utils/messages.ts:1988:0-2370:1) ([messages.ts](cci:7://file:///home/babu/Projects/openclaude/src/utils/messages.ts:0:0-0:0)) was forcefully rebuilding the objects and dropping the opaque blocks. I've updated [normalizeMessagesForAPI](cci:1://file:///home/babu/Projects/openclaude/src/utils/messages.ts:1988:0-2370:1) to safely carry over any existing `extra_content` blocks.
