### PR TITLE
docs: add LiteLLM proxy setup guide

### DIFF
--- a/docs/litellm-setup.md
+++ b/docs/litellm-setup.md
@@ -134,7 +134,7 @@ openclaude
 | 404 or Model Not Found | Model alias doesn't exist in LiteLLM config | Verify the `model_name` in `litellm_config.yaml` matches `OPENAI_MODEL` |
 | Connection Refused | LiteLLM proxy isn't running | Start the proxy with `litellm --config litellm_config.yaml --port 4000` |
 | Auth Failed | Missing or wrong `master_key` | Set the correct key in `OPENAI_API_KEY` |
-| Upstream provider error | The backend provider key is missing or invalid | Ensure the upstream API key (e.g., `OPENAI_API_KEY`) is set in your LiteLLM environment |
+| Upstream provider error | The backend provider key is missing or invalid | Ensure the upstream API key (e.g., `OPENAI_API_KEY`) is set in your LiteLLM proxy process environment |
 | Tools fail but chat works | The selected model has weak function/tool calling support | Switch to a model with strong tool support (e.g., GPT-4o, Claude Sonnet) |
 
 ## 6. Resources


### PR DESCRIPTION
## Summary

Adds a LiteLLM proxy setup guide for OpenClaude using the existing OpenAI-compatible provider path.

## What Changed

- Added `docs/litellm-setup.md` — a comprehensive setup guide covering:
  - LiteLLM proxy installation and configuration
  - Multi-provider routing examples with `litellm_config.yaml`
  - How to point OpenClaude to the LiteLLM proxy via env vars and `/provider`
  - Example configs for multi-provider routing with spend tracking
  - Troubleshooting table for common issues
  - Links to official LiteLLM documentation

## Why It Changed

OpenClaude already supports OpenAI-compatible `/v1` servers (OpenAI, DeepSeek, Groq, Mistral, LM Studio, Ollama, etc.). LiteLLM provides an OpenAI-compatible proxy that can route to 100+ providers. This PR makes that workflow explicit so users can route OpenClaude through LiteLLM without guessing env vars, model alias format, or base URL setup.

## Impact

- **User-facing**: Users can now easily configure OpenClaude to use LiteLLM as a gateway to multiple LLM providers
- **Developer/maintainer**: No code changes required — this is a docs-only PR

## Validation

- [x] `bun run build` — no code changes
- [x] `bun run smoke` — no code changes
- [x] Markdown renders correctly in GitHub preview
- [x] Consistent with existing provider doc style (matches LM Studio, Ollama, DeepSeek docs)

## Notes

- This is a **docs-only** contribution. No source code was modified.
- Follows the same structure and style as `docs/advanced-setup.md` provider examples.
- Matches the LiteLLM documentation pattern for OpenAI-compatible endpoints.