### PR TITLE
Fixed gemini error Function call is missing a thought_signature in functionCall parts

### DIFF
--- a/src/services/api/openaiShim.ts
+++ b/src/services/api/openaiShim.ts
@@ -298,7 +298,9 @@ function convertMessages(
               // Handle Gemini thought_signature
               if (isGeminiMode()) {
                 // If the model provided a signature in the tool_use block itself (e.g. from a previous Turn/Step)
-                const signature = tu.signature ?? (index === 0 ? (thinkingBlock as any)?.signature : undefined)
+                // Use thinkingBlock.signature for ALL tool calls in the same assistant turn if available.
+                // The API requires the same signature on every replayed function call part in a parallel set.
+                const signature = tu.signature ?? (thinkingBlock as any)?.signature
 
                 // Merge into existing google-specific metadata if present
                 const existingGoogle = (toolCall.extra_content?.google as Record<string, unknown>) ?? {}


### PR DESCRIPTION
## Summary
                                                                            
  - What changed: Added support for Google Gemini's "Thought Signatures" in the OpenAI-compatible API shim.
   Updated convertMessages, openaiStreamToAnthropic (streaming), and _convertNonStreamingResponse          
  (non-streaming) to extract, preserve, and round-trip the thought_signature within the                    
  extra_content.google field.                                                                              
  - Why it changed: Gemini 3 models (1.5 Flash/Pro) strictly require these encrypted signatures to be      
  passed back in the conversation history during multi-turn tool interactions. Without them, the API       
  returns a 400 "Function call is missing a thought_signature" error, which completely broke tool-using
  workflows for Gemini users.                                                                              
                                                            
  Impact

  - User-facing impact: Fixes a critical bug that prevented Google Gemini users from using any tools (Bash,
   Read, Edit, etc.). Users can now successfully run multi-step agentic tasks using Gemini models.
  - Developer/maintainer impact: Improves the robustness of the openaiShim by correctly handling           
  provider-specific metadata. Introduces a isGeminiMode helper to centralize Gemini-specific logic without 
  polluting the general OpenAI path.
                                                                                                           
  Testing                                                   

  - bun run build                                                                                          
  - bun run smoke
  - focused tests: Verified that tool calls now include extra_content.google.thought_signature when        
  isGeminiMode is true.                                                                                    
   
  Notes                                                                                                    
                                                            
  - Provider/model path tested: Google Gemini (via                                                         
  https://generativelanguage.googleapis.com/v1beta/openai).
  - Screenshots attached: N/A (Backend fix).                                                               
  - Follow-up work or known limitations: Includes a fallback signature ("skip_thought_signature_validator")
   to prevent 400 errors if a signature is missing from history, though native signatures are preferred for
   model reasoning quality.
