### PR TITLE
fix: defer startup plugin checks until prompt idle

### DIFF
--- a/src/screens/REPL.tsx
+++ b/src/screens/REPL.tsx
@@ -787,41 +787,6 @@ export function REPL({
 
   // Start background plugin installations
 
-  // SECURITY: This code is guaranteed to run ONLY after the "trust this folder" dialog
-  // has been confirmed by the user. The trust dialog is shown in cli.tsx (line ~387)
-  // before the REPL component is rendered. The dialog blocks execution until the user
-  // accepts, and only then is the REPL component mounted and this effect runs.
-  // This ensures that plugin installations from repository and user settings only
-  // happen after explicit user consent to trust the current working directory.
-  useEffect(() => {
-    if (
-      !shouldRunStartupChecks(
-        isRemoteSession,
-        startupChecksStartedRef.current,
-        promptTypingSuppressionActive,
-      )
-    ) {
-      return;
-    }
-
-    const timeout = setTimeout(() => {
-      if (
-        !shouldRunStartupChecks(
-          isRemoteSession,
-          startupChecksStartedRef.current,
-          promptTypingSuppressionActive,
-        )
-      ) {
-        return;
-      }
-
-      startupChecksStartedRef.current = true;
-      void performStartupChecks(setAppState);
-    }, 1500);
-
-    return () => clearTimeout(timeout);
-  }, [setAppState, isRemoteSession, promptTypingSuppressionActive]);
-
   // Allow Claude in Chrome MCP to send prompts through MCP notifications
   // and sync permission mode changes to the Chrome extension
   usePromptsFromClaudeInChrome(isRemoteSession ? EMPTY_MCP_CLIENTS : mcpClients, toolPermissionContext.mode);
@@ -1364,6 +1329,42 @@ export function REPL({
   inputValueRef.current = inputValue;
   const promptTypingSuppressionActive = isPromptTypingSuppressionActive(isPromptInputActive, inputValue);
   const startupChecksStartedRef = useRef(false);
+
+  // SECURITY: This code is guaranteed to run ONLY after the "trust this folder" dialog
+  // has been confirmed by the user. The trust dialog is shown in cli.tsx (line ~387)
+  // before the REPL component is rendered. The dialog blocks execution until the user
+  // accepts, and only then is the REPL component mounted and this effect runs.
+  // This ensures that plugin installations from repository and user settings only
+  // happen after explicit user consent to trust the current working directory.
+  useEffect(() => {
+    if (
+      !shouldRunStartupChecks(
+        isRemoteSession,
+        startupChecksStartedRef.current,
+        promptTypingSuppressionActive,
+      )
+    ) {
+      return;
+    }
+
+    const timeout = setTimeout(() => {
+      if (
+        !shouldRunStartupChecks(
+          isRemoteSession,
+          startupChecksStartedRef.current,
+          promptTypingSuppressionActive,
+        )
+      ) {
+        return;
+      }
+
+      startupChecksStartedRef.current = true;
+      void performStartupChecks(setAppState);
+    }, PROMPT_SUPPRESSION_MS);
+
+    return () => clearTimeout(timeout);
+  }, [setAppState, isRemoteSession, promptTypingSuppressionActive]);
+
   const insertTextRef = useRef<{
     insert: (text: string) => void;
     setInputWithCursor: (value: string, cursor: number) => void;

--- a/src/screens/REPL.tsx
+++ b/src/screens/REPL.tsx
@@ -1341,7 +1341,7 @@ export function REPL({
       !shouldRunStartupChecks(
         isRemoteSession,
         startupChecksStartedRef.current,
-        promptTypingSuppressionActive,
+        isPromptInputActive,
       )
     ) {
       return;
@@ -1352,7 +1352,7 @@ export function REPL({
         !shouldRunStartupChecks(
           isRemoteSession,
           startupChecksStartedRef.current,
-          promptTypingSuppressionActive,
+          isPromptInputActive,
         )
       ) {
         return;
@@ -1363,7 +1363,7 @@ export function REPL({
     }, PROMPT_SUPPRESSION_MS);
 
     return () => clearTimeout(timeout);
-  }, [setAppState, isRemoteSession, promptTypingSuppressionActive]);
+  }, [setAppState, isRemoteSession, isPromptInputActive]);
 
   const insertTextRef = useRef<{
     insert: (text: string) => void;

--- a/src/screens/REPL.tsx
+++ b/src/screens/REPL.tsx
@@ -237,6 +237,7 @@ import { useOfficialMarketplaceNotification } from 'src/hooks/useOfficialMarketp
 import { usePromptsFromClaudeInChrome } from 'src/hooks/usePromptsFromClaudeInChrome.js';
 import { getTipToShowOnSpinner, recordShownTip } from 'src/services/tips/tipScheduler.js';
 import type { Theme } from 'src/utils/theme.js';
+import { shouldRunStartupChecks } from './replStartupGates.js';
 import { isPromptTypingSuppressionActive } from './replInputSuppression.js';
 import { checkAndDisableBypassPermissionsIfNeeded, checkAndDisableAutoModeIfNeeded, useKickOffCheckAndDisableBypassPermissionsIfNeeded, useKickOffCheckAndDisableAutoModeIfNeeded } from 'src/utils/permissions/bypassPermissionsKillswitch.js';
 import { SandboxManager } from 'src/utils/sandbox/sandbox-adapter.js';
@@ -793,9 +794,33 @@ export function REPL({
   // This ensures that plugin installations from repository and user settings only
   // happen after explicit user consent to trust the current working directory.
   useEffect(() => {
-    if (isRemoteSession) return;
-    void performStartupChecks(setAppState);
-  }, [setAppState, isRemoteSession]);
+    if (
+      !shouldRunStartupChecks(
+        isRemoteSession,
+        startupChecksStartedRef.current,
+        promptTypingSuppressionActive,
+      )
+    ) {
+      return;
+    }
+
+    const timeout = setTimeout(() => {
+      if (
+        !shouldRunStartupChecks(
+          isRemoteSession,
+          startupChecksStartedRef.current,
+          promptTypingSuppressionActive,
+        )
+      ) {
+        return;
+      }
+
+      startupChecksStartedRef.current = true;
+      void performStartupChecks(setAppState);
+    }, 1500);
+
+    return () => clearTimeout(timeout);
+  }, [setAppState, isRemoteSession, promptTypingSuppressionActive]);
 
   // Allow Claude in Chrome MCP to send prompts through MCP notifications
   // and sync permission mode changes to the Chrome extension
@@ -1338,6 +1363,7 @@ export function REPL({
   const inputValueRef = useRef(inputValue);
   inputValueRef.current = inputValue;
   const promptTypingSuppressionActive = isPromptTypingSuppressionActive(isPromptInputActive, inputValue);
+  const startupChecksStartedRef = useRef(false);
   const insertTextRef = useRef<{
     insert: (text: string) => void;
     setInputWithCursor: (value: string, cursor: number) => void;

--- a/src/screens/replStartupGates.test.ts
+++ b/src/screens/replStartupGates.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from 'bun:test'
 import { shouldRunStartupChecks } from './replStartupGates.js'
 
 describe('shouldRunStartupChecks', () => {
-  it('blocks startup checks while the prompt is actively typing or seeded', () => {
+  it('blocks startup checks while the user is actively typing', () => {
     expect(shouldRunStartupChecks(false, false, true)).toBe(false)
   })
 

--- a/src/screens/replStartupGates.test.ts
+++ b/src/screens/replStartupGates.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'bun:test'
+
+import { shouldRunStartupChecks } from './replStartupGates.js'
+
+describe('shouldRunStartupChecks', () => {
+  it('blocks startup checks while the prompt is actively typing or seeded', () => {
+    expect(shouldRunStartupChecks(false, false, true)).toBe(false)
+  })
+
+  it('blocks startup checks after they already ran', () => {
+    expect(shouldRunStartupChecks(false, true, false)).toBe(false)
+  })
+
+  it('blocks startup checks for remote sessions', () => {
+    expect(shouldRunStartupChecks(true, false, false)).toBe(false)
+  })
+
+  it('allows startup checks once the session is local, idle, and not started', () => {
+    expect(shouldRunStartupChecks(false, false, false)).toBe(true)
+  })
+})

--- a/src/screens/replStartupGates.ts
+++ b/src/screens/replStartupGates.ts
@@ -1,7 +1,7 @@
 export function shouldRunStartupChecks(
   isRemoteSession: boolean,
   hasStarted: boolean,
-  promptTypingSuppressionActive: boolean,
+  isPromptInputActive: boolean,
 ): boolean {
-  return !isRemoteSession && !hasStarted && !promptTypingSuppressionActive
+  return !isRemoteSession && !hasStarted && !isPromptInputActive
 }

--- a/src/screens/replStartupGates.ts
+++ b/src/screens/replStartupGates.ts
@@ -1,0 +1,7 @@
+export function shouldRunStartupChecks(
+  isRemoteSession: boolean,
+  hasStarted: boolean,
+  promptTypingSuppressionActive: boolean,
+): boolean {
+  return !isRemoteSession && !hasStarted && !promptTypingSuppressionActive
+}


### PR DESCRIPTION
## Summary
- defer `performStartupChecks()` until the REPL is locally idle instead of firing it immediately on mount
- keep startup plugin checks enabled by default, but move them out of the initial typing window
- add a small gate helper test for the new startup-check condition

## Why
Current builds already include the earlier keyboard-freeze fixes (#266, #285) and the startup dialog suppression fix (#423), but there are still reports in #363 where:
- normal startup accepts a few characters and then becomes unusable
- `--bare` works
- a minimal settings file with plugins/hooks disabled also works

The strongest remaining code path is immediate plugin startup work from `performStartupChecks(setAppState)` landing during initial prompt interaction.

## Test Plan
- `bun test src/screens/replStartupGates.test.ts`
- `bun run build`
- `bun run smoke`

## Note
Generated with Codex from a local reproduction, and the resulting fix did work for the reporter locally before opening this PR.

Closes #435
