### PR TITLE
fix: avoid Groq token-limit 413 for small prompts

### DIFF
--- a/src/services/api/errors.ts
+++ b/src/services/api/errors.ts
@@ -781,6 +781,25 @@ export function getAssistantMessageFromError(
   // Check for request too large errors (413 status)
   // This typically happens when a large PDF + conversation context exceeds the 32MB API limit
   if (error instanceof APIError && error.status === 413) {
+    // Groq's 413 almost always means token-per-minute (TPM) rate-limit exhaustion,
+    // not raw upload size. Surface a more actionable message so users don't chase
+    // the wrong fix. (See #337, #449.)
+    const lowerMsg = error.message.toLowerCase()
+    const looksLikeGroqTpm =
+      lowerMsg.includes('groq.com') ||
+      lowerMsg.includes('tokens per minute') ||
+      lowerMsg.includes('"code":"rate_limit_exceeded"') ||
+      lowerMsg.includes('"type":"tokens"')
+    if (looksLikeGroqTpm) {
+      const innerMatch = error.message.match(/"message"\s*:\s*"([^"]+)"/)
+      const detail = innerMatch?.[1]
+      return createAssistantAPIErrorMessage({
+        content: `${API_ERROR_MESSAGE_PREFIX}: Groq token-per-minute limit exceeded${detail ? ` — ${detail}` : ''}. Try /compact, reduce enabled tools, or switch to a model with a higher TPM (e.g. llama-3.3-70b-versatile on a paid tier).`,
+        error: 'rate_limit',
+        errorDetails: error.message,
+      })
+    }
+
     return createAssistantAPIErrorMessage({
       content: getRequestTooLargeErrorMessage(),
       error: 'invalid_request',

--- a/src/services/api/openaiShim.test.ts
+++ b/src/services/api/openaiShim.test.ts
@@ -1,5 +1,10 @@
 import { afterEach, beforeEach, expect, test } from 'bun:test'
-import { createOpenAIShimClient } from './openaiShim.ts'
+import {
+  applyGroqPayloadAdjustments,
+  clampGroqMaxTokens,
+  compactPayloadForGroq,
+  createOpenAIShimClient,
+} from './openaiShim.ts'
 
 type FetchType = typeof globalThis.fetch
 
@@ -2855,4 +2860,141 @@ test('classifies chat-completions endpoint 404 failures with endpoint_not_found 
       stream: false,
     }),
   ).rejects.toThrow('openai_category=endpoint_not_found')
+})
+
+// ---------------------------------------------------------------------------
+// Groq token-budget compaction (#449)
+// ---------------------------------------------------------------------------
+
+function makeLargeText(approxChars: number): string {
+  return 'x'.repeat(approxChars)
+}
+
+test('Groq compaction is a no-op for small payloads', () => {
+  const body: Record<string, unknown> = {
+    model: 'llama-3.1-8b-instant',
+    messages: [
+      { role: 'system', content: 'you are helpful' },
+      { role: 'user', content: 'oi' },
+    ],
+  }
+  const report = compactPayloadForGroq(body, 'llama-3.1-8b-instant')
+  expect(report.strippedToolDescriptions).toBe(false)
+  expect(report.droppedMessages).toBe(0)
+  expect(report.removedTools).toBe(false)
+  expect(report.keptOnlyLastUser).toBe(false)
+})
+
+test('Groq compaction strips top-level tool descriptions but keeps nested schema descriptions', () => {
+  const body: Record<string, unknown> = {
+    model: 'llama-3.1-8b-instant',
+    messages: [{ role: 'user', content: 'small user prompt' }],
+    tools: [
+      {
+        type: 'function',
+        function: {
+          name: 'search',
+          description: makeLargeText(30_000),
+          parameters: {
+            type: 'object',
+            properties: {
+              query: { type: 'string', description: 'The search query' },
+            },
+          },
+        },
+      },
+    ],
+  }
+  compactPayloadForGroq(body, 'llama-3.1-8b-instant')
+  const tool = (body.tools as Array<{ function: { description?: string; parameters: { properties: { query: { description?: string } } } } }>)[0]
+  expect(tool.function.description).toBeUndefined()
+  expect(tool.function.parameters.properties.query.description).toBe('The search query')
+})
+
+test('Groq compaction preserves assistant tool_calls ↔ tool message pairing', () => {
+  const body: Record<string, unknown> = {
+    model: 'llama-3.1-8b-instant',
+    messages: [
+      { role: 'system', content: 'sys' },
+      { role: 'user', content: makeLargeText(10_000) },
+      {
+        role: 'assistant',
+        content: null,
+        tool_calls: [{ id: 'call_1', type: 'function', function: { name: 'f', arguments: '{}' } }],
+      },
+      { role: 'tool', tool_call_id: 'call_1', content: makeLargeText(10_000) },
+      { role: 'user', content: makeLargeText(10_000) },
+      {
+        role: 'assistant',
+        content: null,
+        tool_calls: [{ id: 'call_2', type: 'function', function: { name: 'f', arguments: '{}' } }],
+      },
+      { role: 'tool', tool_call_id: 'call_2', content: 'recent' },
+      { role: 'user', content: 'final question' },
+    ],
+  }
+
+  compactPayloadForGroq(body, 'llama-3.1-8b-instant')
+  const remaining = body.messages as Array<Record<string, unknown>>
+
+  const callIds = new Set<string>()
+  for (const m of remaining) {
+    if (m.role === 'assistant' && Array.isArray(m.tool_calls)) {
+      for (const tc of m.tool_calls as Array<{ id?: string }>) {
+        if (tc.id) callIds.add(tc.id)
+      }
+    }
+  }
+  for (const m of remaining) {
+    if (m.role === 'tool') {
+      expect(callIds.has(m.tool_call_id as string)).toBe(true)
+    }
+  }
+  expect(remaining[remaining.length - 1]).toEqual({ role: 'user', content: 'final question' })
+})
+
+test('Groq max_tokens is clamped based on estimated prompt size and model TPM', () => {
+  const body: Record<string, unknown> = {
+    model: 'llama-3.1-8b-instant',
+    messages: [{ role: 'user', content: makeLargeText(8_000) }],
+    max_tokens: 100_000,
+  }
+  clampGroqMaxTokens(body, 'llama-3.1-8b-instant')
+  expect(typeof body.max_tokens).toBe('number')
+  expect(body.max_tokens as number).toBeGreaterThan(0)
+  expect(body.max_tokens as number).toBeLessThan(100_000)
+  expect(body.max_completion_tokens).toBeUndefined()
+})
+
+test('Groq model-aware TPM: 70b model allows larger prompt budget than 8b', () => {
+  const bigPrompt = makeLargeText(40_000)
+  const body70b: Record<string, unknown> = {
+    model: 'llama-3.3-70b-versatile',
+    messages: [{ role: 'user', content: bigPrompt }],
+    tools: [{ type: 'function', function: { name: 't', description: 'desc', parameters: {} } }],
+  }
+  const body8b: Record<string, unknown> = {
+    model: 'llama-3.1-8b-instant',
+    messages: [{ role: 'user', content: bigPrompt }],
+    tools: [{ type: 'function', function: { name: 't', description: 'desc', parameters: {} } }],
+  }
+
+  const r70 = compactPayloadForGroq(body70b, 'llama-3.3-70b-versatile')
+  const r8 = compactPayloadForGroq(body8b, 'llama-3.1-8b-instant')
+  // 8b (6k TPM) should compact more aggressively than 70b (32k TPM).
+  const score70 = Number(r70.strippedToolDescriptions) + Number(r70.removedTools) + Number(r70.keptOnlyLastUser)
+  const score8 = Number(r8.strippedToolDescriptions) + Number(r8.removedTools) + Number(r8.keptOnlyLastUser)
+  expect(score8).toBeGreaterThanOrEqual(score70)
+})
+
+test('applyGroqPayloadAdjustments performs compaction + clamp and is idempotent on small payloads', () => {
+  const body: Record<string, unknown> = {
+    model: 'llama-3.1-8b-instant',
+    messages: [{ role: 'user', content: 'oi' }],
+    max_completion_tokens: 4000,
+  }
+  applyGroqPayloadAdjustments(body, 'llama-3.1-8b-instant')
+  expect(body.max_completion_tokens).toBeUndefined()
+  expect(typeof body.max_tokens).toBe('number')
+  expect((body.messages as unknown[]).length).toBe(1)
 })

--- a/src/services/api/openaiShim.ts
+++ b/src/services/api/openaiShim.ts
@@ -91,18 +91,27 @@ const GEMINI_API_HOST = 'generativelanguage.googleapis.com'
 // model is not listed we fall back to GROQ_DEFAULT_MAX_REQUEST_TOKENS.
 const GROQ_DEFAULT_MAX_REQUEST_TOKENS = 6_000
 const GROQ_COMPLETION_TOKEN_SAFETY_MARGIN = 500
-const GROQ_TARGET_PROMPT_RATIO = 0.75
+// Target prompt ≤ 60% of TPM budget, reserving 40% for completion + retries
+// within the same minute. Lower ratio = more aggressive trimming but fewer
+// unsolicited 413s on bursty conversations (e.g. Claude Code loops).
+const GROQ_TARGET_PROMPT_RATIO = 0.6
 // Approx chars-per-token for mixed English prose + code. OpenAI's tokenizer
 // averages ~4 chars/token for English and ~3 for code; we pick 4 as a
 // conservative blend so we slightly UNDER-estimate rather than over-trim.
 const GROQ_CHARS_PER_TOKEN = 4
 
+// Free-tier TPM limits per https://console.groq.com/docs/rate-limits (2026-04).
+// Paid tiers are higher, but we're conservative because we can't detect tier.
 const GROQ_MODEL_TPM_LIMITS: Array<{ pattern: RegExp; tpm: number }> = [
-  { pattern: /llama-3\.3-70b/i, tpm: 32_000 },
-  { pattern: /llama-3\.1-70b/i, tpm: 20_000 },
+  { pattern: /llama-3\.3-70b/i, tpm: 12_000 },
+  { pattern: /llama-3\.1-70b/i, tpm: 12_000 },
   { pattern: /llama-3\.1-8b/i, tpm: 6_000 },
+  { pattern: /llama-3-70b/i, tpm: 6_000 },
+  { pattern: /llama-3-8b/i, tpm: 6_000 },
   { pattern: /mixtral-8x7b/i, tpm: 5_000 },
   { pattern: /gemma2?-/i, tpm: 15_000 },
+  { pattern: /qwen/i, tpm: 6_000 },
+  { pattern: /deepseek/i, tpm: 6_000 },
 ]
 
 const SHARED_TEXT_ENCODER = new TextEncoder()

--- a/src/services/api/openaiShim.ts
+++ b/src/services/api/openaiShim.ts
@@ -81,6 +81,32 @@ const GITHUB_429_BASE_DELAY_SEC = 1
 const GITHUB_429_MAX_DELAY_SEC = 32
 const GEMINI_API_HOST = 'generativelanguage.googleapis.com'
 
+// Groq token-per-minute (TPM) limits cause HTTP 413 even for short prompts
+// when tool schemas bloat the outgoing request. We conservatively cap the
+// effective prompt budget and shrink payloads before sending.
+//
+// NOTE: these are conservative defaults based on Groq's free-tier TPM rate
+// limits as documented at https://console.groq.com/docs/rate-limits (as of
+// 2026-04). Per-model overrides come from GROQ_MODEL_TPM_LIMITS below; if a
+// model is not listed we fall back to GROQ_DEFAULT_MAX_REQUEST_TOKENS.
+const GROQ_DEFAULT_MAX_REQUEST_TOKENS = 6_000
+const GROQ_COMPLETION_TOKEN_SAFETY_MARGIN = 500
+const GROQ_TARGET_PROMPT_RATIO = 0.75
+// Approx chars-per-token for mixed English prose + code. OpenAI's tokenizer
+// averages ~4 chars/token for English and ~3 for code; we pick 4 as a
+// conservative blend so we slightly UNDER-estimate rather than over-trim.
+const GROQ_CHARS_PER_TOKEN = 4
+
+const GROQ_MODEL_TPM_LIMITS: Array<{ pattern: RegExp; tpm: number }> = [
+  { pattern: /llama-3\.3-70b/i, tpm: 32_000 },
+  { pattern: /llama-3\.1-70b/i, tpm: 20_000 },
+  { pattern: /llama-3\.1-8b/i, tpm: 6_000 },
+  { pattern: /mixtral-8x7b/i, tpm: 5_000 },
+  { pattern: /gemma2?-/i, tpm: 15_000 },
+]
+
+const SHARED_TEXT_ENCODER = new TextEncoder()
+
 const COPILOT_HEADERS: Record<string, string> = {
   'User-Agent': 'GitHubCopilotChat/0.26.7',
   'Editor-Version': 'vscode/1.99.3',
@@ -148,6 +174,249 @@ function hasGeminiApiHost(baseUrl: string | undefined): boolean {
 function formatRetryAfterHint(response: Response): string {
   const ra = response.headers.get('retry-after')
   return ra ? ` (Retry-After: ${ra})` : ''
+}
+
+function isGroqBaseUrl(baseUrl: string | undefined): boolean {
+  if (!baseUrl) return false
+  try {
+    const hostname = new URL(baseUrl).hostname.toLowerCase()
+    return hostname === 'groq.com' || hostname.endsWith('.groq.com')
+  } catch {
+    return baseUrl.toLowerCase().includes('groq.com')
+  }
+}
+
+function getGroqMaxRequestTokens(model: string | undefined): number {
+  if (!model) return GROQ_DEFAULT_MAX_REQUEST_TOKENS
+  for (const entry of GROQ_MODEL_TPM_LIMITS) {
+    if (entry.pattern.test(model)) return entry.tpm
+  }
+  return GROQ_DEFAULT_MAX_REQUEST_TOKENS
+}
+
+// Estimate prompt tokens from a serialized payload. Uses chars-per-token
+// ratio to approximate tokenization without loading a tokenizer. Reuses a
+// module-scoped TextEncoder to avoid re-allocation on hot paths.
+function estimateGroqPromptTokens(value: unknown): number {
+  const serialized = JSON.stringify(value) ?? ''
+  // byteLength approximates character count for ASCII; for mixed content this
+  // slightly over-estimates (in our favor — more conservative compaction).
+  const bytes = SHARED_TEXT_ENCODER.encode(serialized).length
+  return Math.ceil(bytes / GROQ_CHARS_PER_TOKEN)
+}
+
+// Strip top-level tool descriptions only. We intentionally KEEP nested JSON
+// Schema property descriptions because those materially help the model
+// understand parameter semantics; removing them degrades tool-calling quality.
+function stripToolTopLevelDescriptions(
+  tools: Array<Record<string, unknown>>,
+): Array<Record<string, unknown>> {
+  return tools.map(tool => {
+    if (!tool || typeof tool !== 'object') return tool
+    const next: Record<string, unknown> = { ...tool }
+    if (next.function && typeof next.function === 'object') {
+      const fn = { ...(next.function as Record<string, unknown>) }
+      delete fn.description
+      next.function = fn
+    } else {
+      delete next.description
+    }
+    return next
+  })
+}
+
+// Find the lowest message count from the front we can drop while preserving
+// assistant(tool_calls) ↔ tool(tool_call_id) adjacency. Returns a new message
+// array trimmed to fit the target byte budget, or null if no safe trim point.
+function trimGroqMessagesForBudget(
+  messages: Array<Record<string, unknown>>,
+  targetTokens: number,
+  otherTokens: number,
+): { messages: Array<Record<string, unknown>>; removed: number } {
+  // Precompute per-message token estimates
+  const perMessageTokens = messages.map(m => estimateGroqPromptTokens(m))
+  const total = perMessageTokens.reduce((a, b) => a + b, 0)
+
+  let budget = Math.max(0, targetTokens - otherTokens)
+  if (total <= budget) return { messages, removed: 0 }
+
+  // Always keep: leading system messages and the final message (the active user turn).
+  const systemCount = messages.findIndex(m => m.role !== 'system')
+  const systemEnd = systemCount === -1 ? messages.length : systemCount
+  const lastIndex = messages.length - 1
+
+  // Build "keep" flags. Start by keeping system + last, fill forward from the
+  // end (recent context) until we exceed the budget.
+  const keep = new Array(messages.length).fill(false)
+  for (let i = 0; i < systemEnd; i++) keep[i] = true
+  if (lastIndex >= 0) keep[lastIndex] = true
+
+  let used = 0
+  for (let i = 0; i < messages.length; i++) if (keep[i]) used += perMessageTokens[i]
+
+  for (let i = lastIndex - 1; i >= systemEnd; i--) {
+    if (keep[i]) continue
+    if (used + perMessageTokens[i] > budget) break
+    keep[i] = true
+    used += perMessageTokens[i]
+  }
+
+  // Preserve tool_call ↔ tool_result pairing. A message with role === 'tool'
+  // and a tool_call_id must be preceded by an assistant message whose
+  // tool_calls includes that id; drop orphans.
+  const toolCallIdsInScope = new Set<string>()
+  for (let i = 0; i < messages.length; i++) {
+    if (!keep[i]) continue
+    const m = messages[i]
+    if (m.role === 'assistant' && Array.isArray(m.tool_calls)) {
+      for (const tc of m.tool_calls as Array<Record<string, unknown>>) {
+        if (typeof tc?.id === 'string') toolCallIdsInScope.add(tc.id)
+      }
+    }
+  }
+  for (let i = 0; i < messages.length; i++) {
+    if (!keep[i]) continue
+    const m = messages[i]
+    if (m.role === 'tool') {
+      const id = typeof m.tool_call_id === 'string' ? m.tool_call_id : undefined
+      if (!id || !toolCallIdsInScope.has(id)) keep[i] = false
+    }
+  }
+
+  const trimmed = messages.filter((_, i) => keep[i])
+  return { messages: trimmed, removed: messages.length - trimmed.length }
+}
+
+export type GroqCompactionReport = {
+  strippedToolDescriptions: boolean
+  droppedMessages: number
+  removedTools: boolean
+  keptOnlyLastUser: boolean
+}
+
+// Compacts a Groq-bound OpenAI-compatible chat.completions payload to fit
+// within the conservative token budget for the resolved model. Returns a
+// report describing what was changed so callers can surface user-visible
+// warnings (see #449 review feedback).
+export function compactPayloadForGroq(
+  body: Record<string, unknown>,
+  model: string | undefined,
+): GroqCompactionReport {
+  const maxTokens = getGroqMaxRequestTokens(model)
+  const target = Math.floor(maxTokens * GROQ_TARGET_PROMPT_RATIO)
+  const report: GroqCompactionReport = {
+    strippedToolDescriptions: false,
+    droppedMessages: 0,
+    removedTools: false,
+    keptOnlyLastUser: false,
+  }
+
+  let promptTokens = estimateGroqPromptTokens(body)
+  if (promptTokens <= target) return report
+
+  if (Array.isArray(body.tools) && body.tools.length > 0) {
+    body.tools = stripToolTopLevelDescriptions(
+      body.tools as Array<Record<string, unknown>>,
+    )
+    report.strippedToolDescriptions = true
+    promptTokens = estimateGroqPromptTokens(body)
+  }
+  if (promptTokens <= target) return report
+
+  if (Array.isArray(body.messages) && body.messages.length > 1) {
+    const messages = body.messages as Array<Record<string, unknown>>
+    // Estimate non-message overhead (tools, system prompt fields, etc.) once.
+    const bodyWithoutMessages = { ...body, messages: [] as unknown[] }
+    const otherTokens = estimateGroqPromptTokens(bodyWithoutMessages)
+
+    const { messages: trimmed, removed } = trimGroqMessagesForBudget(
+      messages,
+      target,
+      otherTokens,
+    )
+    if (removed > 0) {
+      body.messages = trimmed
+      report.droppedMessages = removed
+      promptTokens = estimateGroqPromptTokens(body)
+    }
+  }
+  if (promptTokens <= target) return report
+
+  if (body.tools) {
+    delete body.tools
+    body.tool_choice = 'none'
+    report.removedTools = true
+    promptTokens = estimateGroqPromptTokens(body)
+  }
+  if (promptTokens <= target) return report
+
+  if (Array.isArray(body.messages) && body.messages.length > 1) {
+    const messages = body.messages as Array<Record<string, unknown>>
+    const lastUserMessage = [...messages]
+      .reverse()
+      .find(message => message.role === 'user')
+    const lastMessage = lastUserMessage ?? messages[messages.length - 1]
+    body.messages = lastMessage ? [lastMessage] : []
+    report.keptOnlyLastUser = true
+  }
+
+  return report
+}
+
+// Cap max_tokens so prompt + completion fits inside the model's TPM budget.
+export function clampGroqMaxTokens(
+  body: Record<string, unknown>,
+  model: string | undefined,
+): void {
+  const maxRequestTokens = getGroqMaxRequestTokens(model)
+  const currentMaxTokens =
+    typeof body.max_tokens === 'number'
+      ? body.max_tokens
+      : typeof body.max_completion_tokens === 'number'
+        ? body.max_completion_tokens
+        : 4000
+
+  const estimatedPromptTokens = estimateGroqPromptTokens(body)
+  const availableCompletionTokens =
+    maxRequestTokens -
+    estimatedPromptTokens -
+    GROQ_COMPLETION_TOKEN_SAFETY_MARGIN
+
+  body.max_tokens = Math.min(
+    currentMaxTokens,
+    Math.max(1, availableCompletionTokens),
+  )
+  delete body.max_completion_tokens
+}
+
+function describeGroqCompaction(report: GroqCompactionReport): string | null {
+  const parts: string[] = []
+  if (report.strippedToolDescriptions) parts.push('stripped tool descriptions')
+  if (report.droppedMessages > 0)
+    parts.push(`dropped ${report.droppedMessages} earlier message(s)`)
+  if (report.removedTools) parts.push('disabled tools')
+  if (report.keptOnlyLastUser) parts.push('kept only last user message')
+  if (parts.length === 0) return null
+  return parts.join('; ')
+}
+
+// Apply Groq-specific compaction + max_tokens clamp. Surfaces a warning to
+// the user (via logForDebugging) whenever the payload had to be shrunk so the
+// degraded output isn't silently worse than expected (#449 review feedback).
+export function applyGroqPayloadAdjustments(
+  body: Record<string, unknown>,
+  model: string | undefined,
+): void {
+  const report = compactPayloadForGroq(body, model)
+  clampGroqMaxTokens(body, model)
+
+  const summary = describeGroqCompaction(report)
+  if (summary) {
+    logForDebugging(
+      `[OpenAIShim][Groq] Prompt compacted to fit TPM budget (${summary}). Some tools/context were omitted; consider /compact, fewer tools, or a higher-limit model.`,
+      { level: 'warn' },
+    )
+  }
 }
 
 function shouldRedactUrlQueryParam(name: string): boolean {
@@ -1399,6 +1668,13 @@ class OpenAIShimMessages {
           }
         }
       }
+    }
+
+    if (isGroqBaseUrl(request.baseUrl)) {
+      // Groq rejects stream_options on some endpoints; and has strict TPM
+      // limits that require pre-flight payload shrinking (see #449).
+      delete body.stream_options
+      applyGroqPayloadAdjustments(body, request.resolvedModel)
     }
 
     const headers: Record<string, string> = {


### PR DESCRIPTION
## Summary
- Fixes Groq requests that failed with HTTP 413 due to token budget overflow (TPM), even for short prompts.
- Adds Groq-specific payload compaction by estimated prompt tokens.
- Caps `max_tokens` dynamically for Groq based on estimated prompt size.
- Improves 413 error mapping: when provider response indicates token/rate-limit overflow, show a rate-limit guidance message instead of generic "Request too large".

## Why
A short prompt like `oi` could still fail with 413 on Groq because the outgoing request (tools + context + completion budget) exceeded token limits, not necessarily byte-size upload limits.

## Validation
- `bun test src/services/api/openaiShim.test.ts`
- `bun run build`
- `bun run start --print "oi"` (reproduced previously failing path; now succeeds)

Closes #337
