### PR TITLE
fix: align Agent handling across OpenAI and Codex

### DIFF
--- a/src/services/api/codexShim.test.ts
+++ b/src/services/api/codexShim.test.ts
@@ -376,4 +376,78 @@ describe('Codex request translation', () => {
       'message_stop',
     ])
   })
+
+  test('keeps malformed plain-string Agent arguments invalid in completed Codex responses', () => {
+    const message = convertCodexResponseToAnthropicMessage(
+      {
+        id: 'resp_agent_1',
+        model: 'gpt-5.4',
+        output: [
+          {
+            type: 'function_call',
+            id: 'fc_agent_1',
+            call_id: 'call_agent_1',
+            name: 'Agent',
+            arguments: 'delegate this task',
+          },
+        ],
+        usage: { input_tokens: 12, output_tokens: 4 },
+      },
+      'gpt-5.4',
+    )
+
+    expect(message.stop_reason).toBe('tool_use')
+    expect(message.content).toEqual([
+      {
+        type: 'tool_use',
+        id: 'call_agent_1',
+        name: 'Agent',
+        input: {},
+      },
+    ])
+  })
+
+  test('preserves truncated Codex Agent arguments as raw streamed deltas', async () => {
+    const responseText = [
+      'event: response.output_item.added',
+      'data: {"type":"response.output_item.added","item":{"id":"fc_agent_1","type":"function_call","call_id":"call_agent_1","name":"Agent","arguments":"delegate this task"},"output_index":0,"sequence_number":0}',
+      '',
+      'event: response.output_item.done',
+      'data: {"type":"response.output_item.done","item":{"id":"fc_agent_1","type":"function_call","call_id":"call_agent_1","name":"Agent","arguments":"delegate this task"},"output_index":0,"sequence_number":1}',
+      '',
+      'event: response.incomplete',
+      'data: {"type":"response.incomplete","response":{"id":"resp_agent_2","status":"incomplete","model":"gpt-5.4","output":[{"id":"fc_agent_1","type":"function_call","call_id":"call_agent_1","name":"Agent","arguments":"delegate this task"}],"incomplete_details":{"reason":"max_output_tokens"},"usage":{"input_tokens":2,"output_tokens":1}},"sequence_number":2}',
+      '',
+    ].join('\n')
+
+    const stream = new ReadableStream({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode(responseText))
+        controller.close()
+      },
+    })
+
+    const events: Array<Record<string, unknown>> = []
+    for await (const event of codexStreamToAnthropic(new Response(stream), 'gpt-5.4')) {
+      events.push(event as Record<string, unknown>)
+    }
+
+    const streamedInput = events
+      .filter(
+        event =>
+          event.type === 'content_block_delta' &&
+          typeof event.delta === 'object' &&
+          event.delta !== null &&
+          (event.delta as Record<string, unknown>).type === 'input_json_delta',
+      )
+      .map(event => (event.delta as Record<string, unknown>).partial_json)
+      .join('')
+
+    const messageDelta = events.find(event => event.type === 'message_delta') as
+      | { delta?: { stop_reason?: string } }
+      | undefined
+
+    expect(streamedInput).toBe('delegate this task')
+    expect(messageDelta?.delta?.stop_reason).toBe('tool_use')
+  })
 })

--- a/src/services/api/codexShim.ts
+++ b/src/services/api/codexShim.ts
@@ -4,6 +4,7 @@ import type {
   ResolvedProviderRequest,
 } from './providerConfig.js'
 import { sanitizeSchemaForOpenAICompat } from './openaiSchemaSanitizer.js'
+import { normalizeToolArguments } from './toolArgumentNormalization.js'
 
 export interface AnthropicUsage {
   input_tokens: number
@@ -871,7 +872,7 @@ export function convertCodexResponseToAnthropicMessage(
       try {
         input = JSON.parse(item.arguments ?? '{}')
       } catch {
-        input = { raw: item.arguments ?? '' }
+        input = normalizeToolArguments(item.name ?? 'tool', item.arguments)
       }
 
       content.push({

--- a/src/services/api/openaiShim.test.ts
+++ b/src/services/api/openaiShim.test.ts
@@ -343,6 +343,164 @@ test('preserves image tool results as placeholders in follow-up requests', async
   expect(toolMessage?.content).toContain('[image:image/png]')
 })
 
+test('keeps Agent tool required fields aligned with the current schema in Gemini mode', async () => {
+  let requestBody: Record<string, unknown> | undefined
+
+  process.env.CLAUDE_CODE_USE_GEMINI = '1'
+  process.env.GEMINI_AUTH_MODE = 'access-token'
+  process.env.GEMINI_ACCESS_TOKEN = 'gemini-access-token'
+  process.env.GOOGLE_CLOUD_PROJECT = 'gemini-project'
+  process.env.GEMINI_BASE_URL =
+    'https://generativelanguage.googleapis.com/v1beta/openai'
+  process.env.GEMINI_MODEL = 'gemini-2.0-flash'
+  delete process.env.OPENAI_BASE_URL
+  delete process.env.OPENAI_API_KEY
+  delete process.env.GEMINI_API_KEY
+  delete process.env.GOOGLE_API_KEY
+
+  globalThis.fetch = (async (_input, init) => {
+    requestBody = JSON.parse(String(init?.body))
+
+    return new Response(
+      JSON.stringify({
+        id: 'chatcmpl-agent-schema',
+        model: 'gemini-2.0-flash',
+        choices: [
+          {
+            message: {
+              role: 'assistant',
+              content: 'ok',
+            },
+            finish_reason: 'stop',
+          },
+        ],
+        usage: {
+          prompt_tokens: 3,
+          completion_tokens: 1,
+          total_tokens: 4,
+        },
+      }),
+      {
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      },
+    )
+  }) as FetchType
+
+  const client = createOpenAIShimClient({}) as OpenAIShimClient
+
+  await client.beta.messages.create({
+    model: 'gemini-2.0-flash',
+    system: 'test system',
+    messages: [{ role: 'user', content: 'Spawn an agent' }],
+    tools: [
+      {
+        name: 'Agent',
+        description: 'Launch a new agent',
+        input_schema: {
+          type: 'object',
+          properties: {
+            description: { type: 'string' },
+            prompt: { type: 'string' },
+            subagent_type: { type: 'string' },
+          },
+          required: ['description', 'prompt'],
+          additionalProperties: false,
+        },
+      },
+    ],
+    max_tokens: 32,
+    stream: false,
+  })
+
+  const tools = requestBody?.tools as Array<Record<string, unknown>> | undefined
+  const agentTool = tools?.find(tool => (tool.function as Record<string, unknown>)?.name === 'Agent') as
+    | { function?: { parameters?: { required?: string[] } } }
+    | undefined
+
+  expect(agentTool?.function?.parameters?.required).toEqual(['description', 'prompt'])
+})
+
+test('does not reintroduce legacy Agent message field into Gemini required list', async () => {
+  let requestBody: Record<string, unknown> | undefined
+
+  process.env.CLAUDE_CODE_USE_GEMINI = '1'
+  process.env.GEMINI_AUTH_MODE = 'access-token'
+  process.env.GEMINI_ACCESS_TOKEN = 'gemini-access-token'
+  process.env.GOOGLE_CLOUD_PROJECT = 'gemini-project'
+  process.env.GEMINI_BASE_URL =
+    'https://generativelanguage.googleapis.com/v1beta/openai'
+  process.env.GEMINI_MODEL = 'gemini-2.0-flash'
+  delete process.env.OPENAI_BASE_URL
+  delete process.env.OPENAI_API_KEY
+  delete process.env.GEMINI_API_KEY
+  delete process.env.GOOGLE_API_KEY
+
+  globalThis.fetch = (async (_input, init) => {
+    requestBody = JSON.parse(String(init?.body))
+
+    return new Response(
+      JSON.stringify({
+        id: 'chatcmpl-agent-schema-legacy',
+        model: 'gemini-2.0-flash',
+        choices: [
+          {
+            message: {
+              role: 'assistant',
+              content: 'ok',
+            },
+            finish_reason: 'stop',
+          },
+        ],
+        usage: {
+          prompt_tokens: 3,
+          completion_tokens: 1,
+          total_tokens: 4,
+        },
+      }),
+      {
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      },
+    )
+  }) as FetchType
+
+  const client = createOpenAIShimClient({}) as OpenAIShimClient
+
+  await client.beta.messages.create({
+    model: 'gemini-2.0-flash',
+    system: 'test system',
+    messages: [{ role: 'user', content: 'Spawn an agent' }],
+    tools: [
+      {
+        name: 'Agent',
+        description: 'Launch a new agent',
+        input_schema: {
+          type: 'object',
+          properties: {
+            description: { type: 'string' },
+            prompt: { type: 'string' },
+          },
+          required: ['description', 'prompt'],
+          additionalProperties: false,
+        },
+      },
+    ],
+    max_tokens: 32,
+    stream: false,
+  })
+
+  const tools = requestBody?.tools as Array<Record<string, unknown>> | undefined
+  const agentTool = tools?.find(tool => (tool.function as Record<string, unknown>)?.name === 'Agent') as
+    | { function?: { parameters?: { required?: string[] } } }
+    | undefined
+
+  expect(agentTool?.function?.parameters?.required).not.toContain('message')
+  expect(agentTool?.function?.parameters?.required).not.toContain('subagent_type')
+})
+
 test('uses GEMINI_ACCESS_TOKEN for Gemini OpenAI-compatible requests', async () => {
   let capturedAuthorization: string | null = null
   let capturedProject: string | null = null
@@ -1421,6 +1579,142 @@ test('does not normalize incomplete streamed Bash commands when finish_reason is
     .join('')
 
   expect(streamedInput).toBe('rg --fi')
+})
+
+test('keeps malformed plain-string Agent arguments invalid in non-streaming responses', async () => {
+  globalThis.fetch = (async (_input, _init) => {
+    return new Response(
+      JSON.stringify({
+        id: 'chatcmpl-agent-1',
+        model: 'google/gemini-3.1-pro-preview',
+        choices: [
+          {
+            message: {
+              role: 'assistant',
+              tool_calls: [
+                {
+                  id: 'function-call-agent-1',
+                  type: 'function',
+                  function: {
+                    name: 'Agent',
+                    arguments: 'delegate this task',
+                  },
+                },
+              ],
+            },
+            finish_reason: 'tool_calls',
+          },
+        ],
+        usage: {
+          prompt_tokens: 12,
+          completion_tokens: 4,
+          total_tokens: 16,
+        },
+      }),
+      {
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      },
+    )
+  }) as FetchType
+
+  const client = createOpenAIShimClient({}) as OpenAIShimClient
+
+  const message = await client.beta.messages.create({
+    model: 'google/gemini-3.1-pro-preview',
+    system: 'test system',
+    messages: [{ role: 'user', content: 'Use Agent' }],
+    max_tokens: 64,
+    stream: false,
+  }) as {
+    content?: Array<Record<string, unknown>>
+  }
+
+  expect(message.content).toEqual([
+    {
+      type: 'tool_use',
+      id: 'function-call-agent-1',
+      name: 'Agent',
+      input: {},
+    },
+  ])
+})
+
+test('keeps malformed plain-string Agent arguments invalid in streaming responses', async () => {
+  globalThis.fetch = (async (_input, _init) => {
+    const chunks = makeStreamChunks([
+      {
+        id: 'chatcmpl-agent-1',
+        object: 'chat.completion.chunk',
+        model: 'google/gemini-3.1-pro-preview',
+        choices: [
+          {
+            index: 0,
+            delta: {
+              role: 'assistant',
+              tool_calls: [
+                {
+                  index: 0,
+                  id: 'function-call-agent-1',
+                  type: 'function',
+                  function: {
+                    name: 'Agent',
+                    arguments: 'delegate this task',
+                  },
+                },
+              ],
+            },
+            finish_reason: null,
+          },
+        ],
+      },
+      {
+        id: 'chatcmpl-agent-1',
+        object: 'chat.completion.chunk',
+        model: 'google/gemini-3.1-pro-preview',
+        choices: [
+          {
+            index: 0,
+            delta: {},
+            finish_reason: 'tool_calls',
+          },
+        ],
+      },
+    ])
+
+    return makeSseResponse(chunks)
+  }) as FetchType
+
+  const client = createOpenAIShimClient({}) as OpenAIShimClient
+
+  const result = await client.beta.messages
+    .create({
+      model: 'google/gemini-3.1-pro-preview',
+      system: 'test system',
+      messages: [{ role: 'user', content: 'Use Agent' }],
+      max_tokens: 64,
+      stream: true,
+    })
+    .withResponse()
+
+  const events: Array<Record<string, unknown>> = []
+  for await (const event of result.data) {
+    events.push(event)
+  }
+
+  const normalizedInput = events
+    .filter(
+      event =>
+        event.type === 'content_block_delta' &&
+        typeof event.delta === 'object' &&
+        event.delta !== null &&
+        (event.delta as Record<string, unknown>).type === 'input_json_delta',
+    )
+    .map(event => (event.delta as Record<string, unknown>).partial_json)
+    .join('')
+
+  expect(normalizedInput).toBe('{}')
 })
 
 test('repairs truncated JSON objects even without command field', async () => {

--- a/src/services/api/openaiShim.ts
+++ b/src/services/api/openaiShim.ts
@@ -44,7 +44,7 @@ import { sanitizeSchemaForOpenAICompat } from '../../utils/schemaSanitizer.js'
 import { redactSecretValueForDisplay } from '../../utils/providerProfile.js'
 import {
   normalizeToolArguments,
-  hasToolFieldMapping,
+  shouldNormalizeToolArgumentsAtStop,
 } from './toolArgumentNormalization.js'
 
 type SecretValueSource = Partial<{
@@ -445,13 +445,15 @@ function convertTools(
     .map(t => {
       const schema = { ...(t.input_schema ?? { type: 'object', properties: {} }) } as Record<string, unknown>
 
-      // For Codex/OpenAI: promote known Agent sub-fields into required[] only if
-      // they actually exist in properties (Gemini rejects required keys absent from properties).
+      // Keep the Agent tool schema aligned with the current tool contract.
+      // The live schema requires description + prompt, while subagent_type is optional.
+      // When Gemini compatibility disables strict mode, preserve only the current
+      // required fields and avoid forcing legacy or optional fields into required[].
       if (t.name === 'Agent' && schema.properties) {
         const props = schema.properties as Record<string, unknown>
         if (!Array.isArray(schema.required)) schema.required = []
         const req = schema.required as string[]
-        for (const key of ['message', 'subagent_type']) {
+        for (const key of ['description', 'prompt']) {
           if (key in props && !req.includes(key)) req.push(key)
         }
       }
@@ -559,7 +561,6 @@ async function* openaiStreamToAnthropic(
       name: string
       index: number
       jsonBuffer: string
-      normalizeAtStop: boolean
     }
   >()
   let hasEmittedContentStart = false
@@ -685,13 +686,12 @@ async function* openaiStreamToAnthropic(
 
               const toolBlockIndex = contentBlockIndex
               const initialArguments = tc.function.arguments ?? ''
-              const normalizeAtStop = hasToolFieldMapping(tc.function.name)
+              const normalizeAtStop = shouldNormalizeToolArgumentsAtStop(tc.function.name)
               activeToolCalls.set(tc.index, {
                 id: tc.id,
                 name: tc.function.name,
                 index: toolBlockIndex,
                 jsonBuffer: initialArguments,
-                normalizeAtStop,
               })
 
               yield {
@@ -733,7 +733,7 @@ async function* openaiStreamToAnthropic(
                   active.jsonBuffer += tc.function.arguments
                 }
 
-                if (active.normalizeAtStop) {
+                if (shouldNormalizeToolArgumentsAtStop(active.name)) {
                   continue
                 }
 
@@ -770,7 +770,7 @@ async function* openaiStreamToAnthropic(
           }
           // Close active tool calls
           for (const [, tc] of activeToolCalls) {
-            if (tc.normalizeAtStop) {
+            if (shouldNormalizeToolArgumentsAtStop(tc.name)) {
               let partialJson: string
               if (choice.finish_reason === 'length') {
                 // Truncated by max tokens — preserve raw buffer to avoid

--- a/src/services/api/toolArgumentNormalization.test.ts
+++ b/src/services/api/toolArgumentNormalization.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, test } from 'bun:test'
-import { normalizeToolArguments } from './toolArgumentNormalization'
+import {
+  normalizeToolArguments,
+  shouldNormalizeToolArgumentsAtStop,
+} from './toolArgumentNormalization'
 
 describe('normalizeToolArguments', () => {
   describe('Bash tool', () => {
@@ -151,6 +154,21 @@ describe('normalizeToolArguments', () => {
       expect(
         normalizeToolArguments('Grep', '{"pattern":"fixme","path":"/src"}'),
       ).toEqual({ pattern: 'fixme', path: '/src' })
+    })
+  })
+
+  describe('shouldNormalizeToolArgumentsAtStop', () => {
+    test('returns true for Agent', () => {
+      expect(shouldNormalizeToolArgumentsAtStop('Agent')).toBe(true)
+    })
+
+    test('returns true for mapped tools', () => {
+      expect(shouldNormalizeToolArgumentsAtStop('Bash')).toBe(true)
+      expect(shouldNormalizeToolArgumentsAtStop('Read')).toBe(true)
+    })
+
+    test('returns false for unrelated tools', () => {
+      expect(shouldNormalizeToolArgumentsAtStop('UnknownTool')).toBe(false)
     })
   })
 

--- a/src/services/api/toolArgumentNormalization.ts
+++ b/src/services/api/toolArgumentNormalization.ts
@@ -30,6 +30,10 @@ export function hasToolFieldMapping(toolName: string): boolean {
   return toolName in STRING_ARGUMENT_TOOL_FIELDS
 }
 
+export function shouldNormalizeToolArgumentsAtStop(toolName: string): boolean {
+  return hasToolFieldMapping(toolName) || toolName === 'Agent'
+}
+
 function wrapPlainStringToolArguments(
   toolName: string,
   value: string,

--- a/src/tools/AgentTool/AgentTool.test.ts
+++ b/src/tools/AgentTool/AgentTool.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, test } from 'bun:test'
+
+import { resolveEffectiveRunInBackground } from './AgentTool.js'
+
+describe('resolveEffectiveRunInBackground', () => {
+  test('keeps run_in_background when schema can advertise it', () => {
+    expect(
+      resolveEffectiveRunInBackground(true, {
+        backgroundTasksDisabled: false,
+        forkSubagentEnabled: false,
+      }),
+    ).toBe(true)
+
+    expect(
+      resolveEffectiveRunInBackground(false, {
+        backgroundTasksDisabled: false,
+        forkSubagentEnabled: false,
+      }),
+    ).toBe(false)
+  })
+
+  test('ignores run_in_background when background tasks are disabled', () => {
+    expect(
+      resolveEffectiveRunInBackground(true, {
+        backgroundTasksDisabled: true,
+        forkSubagentEnabled: false,
+      }),
+    ).toBeUndefined()
+  })
+
+  test('ignores run_in_background when fork subagent mode is enabled', () => {
+    expect(
+      resolveEffectiveRunInBackground(true, {
+        backgroundTasksDisabled: false,
+        forkSubagentEnabled: true,
+      }),
+    ).toBeUndefined()
+  })
+})

--- a/src/tools/AgentTool/AgentTool.tsx
+++ b/src/tools/AgentTool/AgentTool.tsx
@@ -439,7 +439,7 @@ export const AgentTool = buildTool({
       color: selectedAgent.color as AnalyticsMetadata_I_VERIFIED_THIS_IS_NOT_CODE_OR_FILEPATHS,
       is_built_in_agent: isBuiltInAgent(selectedAgent),
       is_resume: false,
-      is_async: (run_in_background === true || selectedAgent.background === true) && !isBackgroundTasksDisabled,
+      is_async: (effectiveRunInBackground === true || selectedAgent.background === true) && !isBackgroundTasksDisabled,
       is_fork: isForkPath
     });
 

--- a/src/tools/AgentTool/AgentTool.tsx
+++ b/src/tools/AgentTool/AgentTool.tsx
@@ -76,6 +76,18 @@ function getAutoBackgroundMs(): number {
   return 0;
 }
 
+export function resolveEffectiveRunInBackground(
+  runInBackground: boolean | undefined,
+  options: {
+    backgroundTasksDisabled: boolean;
+    forkSubagentEnabled: boolean;
+  },
+): boolean | undefined {
+  return options.backgroundTasksDisabled || options.forkSubagentEnabled
+    ? undefined
+    : runInBackground;
+}
+
 // Multi-agent type constants are defined inline inside gated blocks to enable dead code elimination
 
 // Base input schema without multi-agent parameters
@@ -250,6 +262,10 @@ export const AgentTool = buildTool({
   }: AgentToolInput, toolUseContext, canUseTool, assistantMessage, onProgress?) {
     const startTime = Date.now();
     const model = isCoordinatorMode() ? undefined : modelParam;
+    const effectiveRunInBackground = resolveEffectiveRunInBackground(run_in_background, {
+      backgroundTasksDisabled: isBackgroundTasksDisabled,
+      forkSubagentEnabled: isForkSubagentEnabled()
+    });
 
     // Get app state for permission mode and agent filtering
     const appState = toolUseContext.getAppState();
@@ -275,7 +291,7 @@ export const AgentTool = buildTool({
     // In-process teammates cannot spawn background agents (their lifecycle is
     // tied to the leader's process). Tmux teammates are separate processes and
     // can manage their own background agents.
-    if (isInProcessTeammate() && teamName && run_in_background === true) {
+    if (isInProcessTeammate() && teamName && effectiveRunInBackground === true) {
       throw new Error('In-process teammates cannot spawn background agents. Use run_in_background=false for synchronous subagents.');
     }
 
@@ -545,7 +561,7 @@ export const AgentTool = buildTool({
       isBuiltInAgent: isBuiltInAgent(selectedAgent),
       startTime,
       agentType: selectedAgent.agentType,
-      isAsync: (run_in_background === true || selectedAgent.background === true) && !isBackgroundTasksDisabled
+      isAsync: (effectiveRunInBackground === true || selectedAgent.background === true) && !isBackgroundTasksDisabled
     };
 
     // Use inline env check instead of coordinatorModule to avoid circular
@@ -564,7 +580,7 @@ export const AgentTool = buildTool({
     // <task-notification> re-entry there is handled by the else branch
     // below (registerAsyncAgentTask + notifyOnCompletion).
     const assistantForceAsync = feature('KAIROS') ? appState.kairosEnabled : false;
-    const shouldRunAsync = (run_in_background === true || selectedAgent.background === true || isCoordinator || forceAsync || assistantForceAsync || (proactiveModule?.isProactiveActive() ?? false)) && !isBackgroundTasksDisabled;
+    const shouldRunAsync = (effectiveRunInBackground === true || selectedAgent.background === true || isCoordinator || forceAsync || assistantForceAsync || (proactiveModule?.isProactiveActive() ?? false)) && !isBackgroundTasksDisabled;
     // Assemble the worker's tool pool independently of the parent's.
     // Workers always get their tools from assembleToolPool with their own
     // permission mode, so they aren't affected by the parent's tool


### PR DESCRIPTION
  Align the Agent tool schema with the current runtime contract and make malformed Agent payload handling consistent across OpenAI and Codex paths. Also ignore hidden `run_in_background` inputs at runtime so     
  Agent behavior matches the advertised schema.                                                                                                                                                                     
                                                                                                                                                                                                                    
  ## Summary                                                                                                                                                                                                        
                                                                                                                                                                                                                    
  - align OpenAI/Gemini Agent schema handling with the current runtime contract (`description` + `prompt`)                                                                                                          
  - normalize malformed non-truncated Agent payloads consistently across OpenAI and Codex completed paths                                                                                                           
  - preserve truncated streamed Agent payloads as raw data instead of guessing valid input                                                                                                                          
  - ignore hidden `run_in_background` inputs at runtime when that field is omitted from the advertised Agent schema                                                                                                 
  - add focused regression coverage for Agent schema shaping, malformed payload handling, and AgentTool background gating                                                                                           
                                                                                                                                                                                                                    
  ## Impact                                                                                                                                                                                                         
                                                                                                                                                                                                                    
  - improves consistency for Agent tool calls on OpenAI-compatible and Codex paths                                                                                                                                  
  - avoids provider-facing schema drift for Agent                                                                                                                                                                   
  - makes malformed Agent payload handling safer and more predictable                                                                                                                                               
  - keeps runtime behavior aligned with the advertised Agent schema                                                                                                                                                 
                                                                                                                                                                                                                    
  ## Testing                                                                                                                                                                                                        
                                                                                                                                                                                                                    
  - [x] `bun run build`                                                                                                                                                                                             
  - [x] `node dist/cli.mjs --version`                                                                                                                                                                               
  - [x] `bun test src/tools/AgentTool/AgentTool.test.ts src/services/api/openaiShim.test.ts src/services/api/codexShim.test.ts src/services/api/toolArgumentNormalization.test.ts`                                  
                                                                                                                                                                                                                    
  ## Notes                                                                                                                                                                                                          
                                                                                                                                                                                                                    
  - manually validated local Agent behavior for:                                                                                                                                                                    
    - normal Agent launch                                                                                                                                                                                           
    - background Agent launch                                                                                                                                                                                       
    - small parallel Agent runs                                                                                                                                                                                     
  - separate exploratory testing surfaced a likely `Grep`/`Glob` argument-handling issue, but that appears to be independent of this patch and is not included in this PR