### PR TITLE
fix: strip Anthropic params from 3P resume paths

### DIFF
--- a/src/services/api/openaiShim.ts
+++ b/src/services/api/openaiShim.ts
@@ -195,10 +195,12 @@ function convertContentBlocks(
         // handled separately
         break
       case 'thinking':
-        // Append thinking as text with a marker for models that support reasoning
-        if (block.thinking) {
-          parts.push({ type: 'text', text: `<thinking>${block.thinking}</thinking>` })
-        }
+      case 'redacted_thinking':
+        // Strip thinking blocks for OpenAI-compatible providers.
+        // These are Anthropic-specific content types that 3P providers
+        // don't understand. Serializing them as <thinking> text corrupts
+        // multi-turn context: the model sees the tags as part of its
+        // previous reply and may mimic or misattribute them.
         break
       default:
         if (block.text) {

--- a/src/utils/context.ts
+++ b/src/utils/context.ts
@@ -72,16 +72,23 @@ export function getContextWindowForModel(
     return 1_000_000
   }
 
-  // OpenAI-compatible provider — use known context windows for the model
-  if (
+  // OpenAI-compatible provider — use known context windows for the model.
+  // Unknown models get a conservative 8k default so auto-compact triggers
+  // before hitting a hard context_window_exceeded error (issue #248 finding 3).
+  const isOpenAIProvider =
     isEnvTruthy(process.env.CLAUDE_CODE_USE_OPENAI) ||
     isEnvTruthy(process.env.CLAUDE_CODE_USE_GEMINI) ||
     isEnvTruthy(process.env.CLAUDE_CODE_USE_GITHUB)
-  ) {
+  if (isOpenAIProvider) {
     const openaiWindow = getOpenAIContextWindow(model)
     if (openaiWindow !== undefined) {
       return openaiWindow
     }
+    console.error(
+      `[context] Warning: model "${model}" not in context window table — using conservative 8k default. ` +
+      'Add it to src/utils/model/openaiContextWindows.ts for accurate compaction.',
+    )
+    return 8_000
   }
 
   const cap = getModelCapability(model)

--- a/src/utils/conversationRecovery.hooks.test.ts
+++ b/src/utils/conversationRecovery.hooks.test.ts
@@ -69,3 +69,93 @@ test('loadConversationForResume rejects oversized transcripts before resume hook
   )
   expect(hookSpy).not.toHaveBeenCalled()
 })
+
+test('deserializeMessagesWithInterruptDetection strips thinking blocks only for OpenAI-compatible providers', async () => {
+  const serializedMessages = [
+    user(id(10), 'hello'),
+    {
+      type: 'assistant',
+      uuid: id(11),
+      parentUuid: id(10),
+      timestamp: ts,
+      cwd: '/tmp',
+      sessionId,
+      version: 'test',
+      message: {
+        role: 'assistant',
+        content: [
+          { type: 'thinking', thinking: 'secret reasoning' },
+          { type: 'text', text: 'visible reply' },
+        ],
+      },
+    },
+    {
+      type: 'assistant',
+      uuid: id(12),
+      parentUuid: id(11),
+      timestamp: ts,
+      cwd: '/tmp',
+      sessionId,
+      version: 'test',
+      message: {
+        role: 'assistant',
+        content: [{ type: 'thinking', thinking: 'only hidden reasoning' }],
+      },
+    },
+    user(id(13), 'follow up'),
+  ]
+
+  mock.module('./model/providers.js', () => ({
+    getAPIProvider: () => 'openai',
+    isOpenAICompatibleProvider: (provider: string) =>
+      provider === 'openai' ||
+      provider === 'gemini' ||
+      provider === 'github' ||
+      provider === 'codex',
+  }))
+
+  const openaiModule = await import(`./conversationRecovery.ts?provider=openai-${Date.now()}`)
+  const thirdParty = openaiModule.deserializeMessagesWithInterruptDetection(serializedMessages as never[])
+  const thirdPartyAssistantMessages = thirdParty.messages.filter(
+    message => message.type === 'assistant',
+  )
+
+  expect(thirdPartyAssistantMessages).toHaveLength(2)
+  expect(thirdPartyAssistantMessages[0]?.message?.content).toEqual([
+    { type: 'text', text: 'visible reply' },
+  ])
+  expect(
+    JSON.stringify(thirdPartyAssistantMessages.map(message => message.message?.content)),
+  ).not.toContain('secret reasoning')
+  expect(
+    JSON.stringify(thirdPartyAssistantMessages.map(message => message.message?.content)),
+  ).not.toContain('only hidden reasoning')
+
+  mock.restore()
+  mock.module('./model/providers.js', () => ({
+    getAPIProvider: () => 'bedrock',
+    isOpenAICompatibleProvider: (provider: string) =>
+      provider === 'openai' ||
+      provider === 'gemini' ||
+      provider === 'github' ||
+      provider === 'codex',
+  }))
+
+  const bedrockModule = await import(`./conversationRecovery.ts?provider=bedrock-${Date.now()}`)
+  const anthropicCompatible = bedrockModule.deserializeMessagesWithInterruptDetection(serializedMessages as never[])
+  const anthropicAssistantMessages = anthropicCompatible.messages.filter(
+    message => message.type === 'assistant',
+  )
+
+  expect(anthropicAssistantMessages).toHaveLength(2)
+  expect(anthropicAssistantMessages[0]?.message?.content).toEqual([
+    { type: 'thinking', thinking: 'secret reasoning' },
+    { type: 'text', text: 'visible reply' },
+  ])
+  expect(
+    JSON.stringify(anthropicAssistantMessages.map(message => message.message?.content)),
+  ).toContain('secret reasoning')
+  expect(
+    JSON.stringify(anthropicAssistantMessages.map(message => message.message?.content)),
+  ).not.toContain('only hidden reasoning')
+})

--- a/src/utils/conversationRecovery.test.ts
+++ b/src/utils/conversationRecovery.test.ts
@@ -4,48 +4,14 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
 import {
-  deserializeMessagesWithInterruptDetection,
   loadConversationForResume,
   ResumeTranscriptTooLargeError,
 } from './conversationRecovery.ts'
 
 const tempDirs: string[] = []
 const originalSimple = process.env.CLAUDE_CODE_SIMPLE
-const originalProviderEnv = {
-  CLAUDE_CODE_USE_OPENAI: process.env.CLAUDE_CODE_USE_OPENAI,
-  CLAUDE_CODE_USE_GEMINI: process.env.CLAUDE_CODE_USE_GEMINI,
-  CLAUDE_CODE_USE_GITHUB: process.env.CLAUDE_CODE_USE_GITHUB,
-  CLAUDE_CODE_USE_BEDROCK: process.env.CLAUDE_CODE_USE_BEDROCK,
-  CLAUDE_CODE_USE_VERTEX: process.env.CLAUDE_CODE_USE_VERTEX,
-  CLAUDE_CODE_USE_FOUNDRY: process.env.CLAUDE_CODE_USE_FOUNDRY,
-}
 const sessionId = '00000000-0000-4000-8000-000000001999'
 const ts = '2026-04-02T00:00:00.000Z'
-
-function restoreProviderEnv() {
-  for (const [key, value] of Object.entries(originalProviderEnv)) {
-    if (value === undefined) {
-      delete process.env[key]
-    } else {
-      process.env[key] = value
-    }
-  }
-}
-
-function clearProviderEnv() {
-  delete process.env.CLAUDE_CODE_USE_OPENAI
-  delete process.env.CLAUDE_CODE_USE_GEMINI
-  delete process.env.CLAUDE_CODE_USE_GITHUB
-  delete process.env.CLAUDE_CODE_USE_BEDROCK
-  delete process.env.CLAUDE_CODE_USE_VERTEX
-  delete process.env.CLAUDE_CODE_USE_FOUNDRY
-}
-
-function setProviderEnv(provider: 'openai' | 'bedrock') {
-  clearProviderEnv()
-  if (provider === 'openai') process.env.CLAUDE_CODE_USE_OPENAI = '1'
-  if (provider === 'bedrock') process.env.CLAUDE_CODE_USE_BEDROCK = '1'
-}
 
 
 function id(n: number): string {
@@ -81,7 +47,6 @@ async function writeJsonl(entry: unknown): Promise<string> {
 
 afterEach(async () => {
   process.env.CLAUDE_CODE_SIMPLE = originalSimple
-  restoreProviderEnv()
   await Promise.all(tempDirs.splice(0).map(dir => rm(dir, { recursive: true, force: true })))
 })
 
@@ -113,74 +78,4 @@ test('loadConversationForResume rejects oversized reconstructed transcripts', as
   )
 })
 
-test('deserializeMessagesWithInterruptDetection strips thinking blocks only for OpenAI-compatible providers', () => {
-  const serializedMessages = [
-    user(id(10), 'hello'),
-    {
-      type: 'assistant',
-      uuid: id(11),
-      parentUuid: id(10),
-      timestamp: ts,
-      cwd: '/tmp',
-      sessionId,
-      version: 'test',
-      message: {
-        role: 'assistant',
-        content: [
-          { type: 'thinking', thinking: 'secret reasoning' },
-          { type: 'text', text: 'visible reply' },
-        ],
-      },
-    },
-    {
-      type: 'assistant',
-      uuid: id(12),
-      parentUuid: id(11),
-      timestamp: ts,
-      cwd: '/tmp',
-      sessionId,
-      version: 'test',
-      message: {
-        role: 'assistant',
-        content: [{ type: 'thinking', thinking: 'only hidden reasoning' }],
-      },
-    },
-    user(id(13), 'follow up'),
-  ]
-
-  setProviderEnv('openai')
-  const thirdParty = deserializeMessagesWithInterruptDetection(serializedMessages as never[])
-  const thirdPartyAssistantMessages = thirdParty.messages.filter(
-    message => message.type === 'assistant',
-  )
-
-  expect(thirdPartyAssistantMessages).toHaveLength(2)
-  expect(thirdPartyAssistantMessages[0]?.message?.content).toEqual([
-    { type: 'text', text: 'visible reply' },
-  ])
-  expect(
-    JSON.stringify(thirdPartyAssistantMessages.map(message => message.message?.content)),
-  ).not.toContain('secret reasoning')
-  expect(
-    JSON.stringify(thirdPartyAssistantMessages.map(message => message.message?.content)),
-  ).not.toContain('only hidden reasoning')
-
-  setProviderEnv('bedrock')
-  const anthropicCompatible = deserializeMessagesWithInterruptDetection(serializedMessages as never[])
-  const anthropicAssistantMessages = anthropicCompatible.messages.filter(
-    message => message.type === 'assistant',
-  )
-
-  expect(anthropicAssistantMessages).toHaveLength(2)
-  expect(anthropicAssistantMessages[0]?.message?.content).toEqual([
-    { type: 'thinking', thinking: 'secret reasoning' },
-    { type: 'text', text: 'visible reply' },
-  ])
-  expect(
-    JSON.stringify(anthropicAssistantMessages.map(message => message.message?.content)),
-  ).toContain('secret reasoning')
-  expect(
-    JSON.stringify(anthropicAssistantMessages.map(message => message.message?.content)),
-  ).not.toContain('only hidden reasoning')
-})
 

--- a/src/utils/conversationRecovery.test.ts
+++ b/src/utils/conversationRecovery.test.ts
@@ -77,5 +77,3 @@ test('loadConversationForResume rejects oversized reconstructed transcripts', as
     'Reconstructed transcript is too large to resume safely',
   )
 })
-
-

--- a/src/utils/conversationRecovery.test.ts
+++ b/src/utils/conversationRecovery.test.ts
@@ -11,8 +11,42 @@ import {
 
 const tempDirs: string[] = []
 const originalSimple = process.env.CLAUDE_CODE_SIMPLE
+const originalProviderEnv = {
+  CLAUDE_CODE_USE_OPENAI: process.env.CLAUDE_CODE_USE_OPENAI,
+  CLAUDE_CODE_USE_GEMINI: process.env.CLAUDE_CODE_USE_GEMINI,
+  CLAUDE_CODE_USE_GITHUB: process.env.CLAUDE_CODE_USE_GITHUB,
+  CLAUDE_CODE_USE_BEDROCK: process.env.CLAUDE_CODE_USE_BEDROCK,
+  CLAUDE_CODE_USE_VERTEX: process.env.CLAUDE_CODE_USE_VERTEX,
+  CLAUDE_CODE_USE_FOUNDRY: process.env.CLAUDE_CODE_USE_FOUNDRY,
+}
 const sessionId = '00000000-0000-4000-8000-000000001999'
 const ts = '2026-04-02T00:00:00.000Z'
+
+function restoreProviderEnv() {
+  for (const [key, value] of Object.entries(originalProviderEnv)) {
+    if (value === undefined) {
+      delete process.env[key]
+    } else {
+      process.env[key] = value
+    }
+  }
+}
+
+function clearProviderEnv() {
+  delete process.env.CLAUDE_CODE_USE_OPENAI
+  delete process.env.CLAUDE_CODE_USE_GEMINI
+  delete process.env.CLAUDE_CODE_USE_GITHUB
+  delete process.env.CLAUDE_CODE_USE_BEDROCK
+  delete process.env.CLAUDE_CODE_USE_VERTEX
+  delete process.env.CLAUDE_CODE_USE_FOUNDRY
+}
+
+function setProviderEnv(provider: 'openai' | 'bedrock') {
+  clearProviderEnv()
+  if (provider === 'openai') process.env.CLAUDE_CODE_USE_OPENAI = '1'
+  if (provider === 'bedrock') process.env.CLAUDE_CODE_USE_BEDROCK = '1'
+}
+
 
 function id(n: number): string {
   return `00000000-0000-4000-8000-${String(n).padStart(12, '0')}`
@@ -47,12 +81,7 @@ async function writeJsonl(entry: unknown): Promise<string> {
 
 afterEach(async () => {
   process.env.CLAUDE_CODE_SIMPLE = originalSimple
-  delete process.env.CLAUDE_CODE_USE_OPENAI
-  delete process.env.CLAUDE_CODE_USE_GEMINI
-  delete process.env.CLAUDE_CODE_USE_GITHUB
-  delete process.env.CLAUDE_CODE_USE_BEDROCK
-  delete process.env.CLAUDE_CODE_USE_VERTEX
-  delete process.env.CLAUDE_CODE_USE_FOUNDRY
+  restoreProviderEnv()
   await Promise.all(tempDirs.splice(0).map(dir => rm(dir, { recursive: true, force: true })))
 })
 
@@ -119,7 +148,7 @@ test('deserializeMessagesWithInterruptDetection strips thinking blocks only for 
     user(id(13), 'follow up'),
   ]
 
-  process.env.CLAUDE_CODE_USE_OPENAI = '1'
+  setProviderEnv('openai')
   const thirdParty = deserializeMessagesWithInterruptDetection(serializedMessages as never[])
   const thirdPartyAssistantMessages = thirdParty.messages.filter(
     message => message.type === 'assistant',
@@ -136,8 +165,7 @@ test('deserializeMessagesWithInterruptDetection strips thinking blocks only for 
     JSON.stringify(thirdPartyAssistantMessages.map(message => message.message?.content)),
   ).not.toContain('only hidden reasoning')
 
-  delete process.env.CLAUDE_CODE_USE_OPENAI
-  process.env.CLAUDE_CODE_USE_BEDROCK = '1'
+  setProviderEnv('bedrock')
   const anthropicCompatible = deserializeMessagesWithInterruptDetection(serializedMessages as never[])
   const anthropicAssistantMessages = anthropicCompatible.messages.filter(
     message => message.type === 'assistant',

--- a/src/utils/conversationRecovery.test.ts
+++ b/src/utils/conversationRecovery.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
 import {
+  deserializeMessagesWithInterruptDetection,
   loadConversationForResume,
   ResumeTranscriptTooLargeError,
 } from './conversationRecovery.ts'
@@ -46,6 +47,12 @@ async function writeJsonl(entry: unknown): Promise<string> {
 
 afterEach(async () => {
   process.env.CLAUDE_CODE_SIMPLE = originalSimple
+  delete process.env.CLAUDE_CODE_USE_OPENAI
+  delete process.env.CLAUDE_CODE_USE_GEMINI
+  delete process.env.CLAUDE_CODE_USE_GITHUB
+  delete process.env.CLAUDE_CODE_USE_BEDROCK
+  delete process.env.CLAUDE_CODE_USE_VERTEX
+  delete process.env.CLAUDE_CODE_USE_FOUNDRY
   await Promise.all(tempDirs.splice(0).map(dir => rm(dir, { recursive: true, force: true })))
 })
 
@@ -75,5 +82,77 @@ test('loadConversationForResume rejects oversized reconstructed transcripts', as
   expect((caught as Error).message).toContain(
     'Reconstructed transcript is too large to resume safely',
   )
+})
+
+test('deserializeMessagesWithInterruptDetection strips thinking blocks only for OpenAI-compatible providers', () => {
+  const serializedMessages = [
+    user(id(10), 'hello'),
+    {
+      type: 'assistant',
+      uuid: id(11),
+      parentUuid: id(10),
+      timestamp: ts,
+      cwd: '/tmp',
+      sessionId,
+      version: 'test',
+      message: {
+        role: 'assistant',
+        content: [
+          { type: 'thinking', thinking: 'secret reasoning' },
+          { type: 'text', text: 'visible reply' },
+        ],
+      },
+    },
+    {
+      type: 'assistant',
+      uuid: id(12),
+      parentUuid: id(11),
+      timestamp: ts,
+      cwd: '/tmp',
+      sessionId,
+      version: 'test',
+      message: {
+        role: 'assistant',
+        content: [{ type: 'thinking', thinking: 'only hidden reasoning' }],
+      },
+    },
+    user(id(13), 'follow up'),
+  ]
+
+  process.env.CLAUDE_CODE_USE_OPENAI = '1'
+  const thirdParty = deserializeMessagesWithInterruptDetection(serializedMessages as never[])
+  const thirdPartyAssistantMessages = thirdParty.messages.filter(
+    message => message.type === 'assistant',
+  )
+
+  expect(thirdPartyAssistantMessages).toHaveLength(2)
+  expect(thirdPartyAssistantMessages[0]?.message?.content).toEqual([
+    { type: 'text', text: 'visible reply' },
+  ])
+  expect(
+    JSON.stringify(thirdPartyAssistantMessages.map(message => message.message?.content)),
+  ).not.toContain('secret reasoning')
+  expect(
+    JSON.stringify(thirdPartyAssistantMessages.map(message => message.message?.content)),
+  ).not.toContain('only hidden reasoning')
+
+  delete process.env.CLAUDE_CODE_USE_OPENAI
+  process.env.CLAUDE_CODE_USE_BEDROCK = '1'
+  const anthropicCompatible = deserializeMessagesWithInterruptDetection(serializedMessages as never[])
+  const anthropicAssistantMessages = anthropicCompatible.messages.filter(
+    message => message.type === 'assistant',
+  )
+
+  expect(anthropicAssistantMessages).toHaveLength(2)
+  expect(anthropicAssistantMessages[0]?.message?.content).toEqual([
+    { type: 'thinking', thinking: 'secret reasoning' },
+    { type: 'text', text: 'visible reply' },
+  ])
+  expect(
+    JSON.stringify(anthropicAssistantMessages.map(message => message.message?.content)),
+  ).toContain('secret reasoning')
+  expect(
+    JSON.stringify(anthropicAssistantMessages.map(message => message.message?.content)),
+  ).not.toContain('only hidden reasoning')
 })
 

--- a/src/utils/conversationRecovery.ts
+++ b/src/utils/conversationRecovery.ts
@@ -24,6 +24,7 @@ import {
   type FileHistorySnapshot,
 } from './fileHistory.js'
 import { logError } from './log.js'
+import { getAPIProvider } from './model/providers.js'
 import {
   createAssistantMessage,
   createUserMessage,
@@ -178,6 +179,25 @@ export type DeserializeResult = {
 }
 
 /**
+ * Remove thinking/redacted_thinking content blocks from assistant messages.
+ * Messages that become empty after stripping are removed entirely.
+ */
+function stripThinkingBlocks(messages: NormalizedMessage[]): NormalizedMessage[] {
+  return messages.reduce<NormalizedMessage[]>((acc, msg) => {
+    if (msg.type !== 'assistant' || !Array.isArray(msg.message?.content)) {
+      acc.push(msg)
+      return acc
+    }
+    const filtered = msg.message.content.filter(
+      (block: { type?: string }) => block.type !== 'thinking' && block.type !== 'redacted_thinking',
+    )
+    if (filtered.length === 0) return acc
+    acc.push({ ...msg, message: { ...msg.message, content: filtered } })
+    return acc
+  }, [])
+}
+
+/**
  * Deserializes messages from a log file into the format expected by the REPL.
  * Filters unresolved tool uses, orphaned thinking messages, and appends a
  * synthetic assistant sentinel when the last message is from the user.
@@ -227,10 +247,19 @@ export function deserializeMessagesWithInterruptDetection(
       filteredToolUses,
     ) as NormalizedMessage[]
 
+    // Strip thinking/redacted_thinking content blocks from assistant messages
+    // when resuming against a 3P provider. These Anthropic-specific blocks cause
+    // 400 errors or context corruption on OpenAI-compatible providers (issue #248 finding 5).
+    const provider = getAPIProvider()
+    const isThirdPartyProvider = provider !== 'firstParty' && provider !== 'bedrock' && provider !== 'vertex' && provider !== 'foundry'
+    const thinkingStripped = isThirdPartyProvider
+      ? stripThinkingBlocks(filteredThinking)
+      : filteredThinking
+
     // Filter out assistant messages with only whitespace text content.
     // This can happen when model outputs "\n\n" before thinking, user cancels mid-stream.
     const filteredMessages = filterWhitespaceOnlyAssistantMessages(
-      filteredThinking,
+      thinkingStripped,
     ) as NormalizedMessage[]
 
     const internalState = detectTurnInterruption(filteredMessages)


### PR DESCRIPTION
## Summary
- strip Anthropic-specific thinking payloads before replaying deserialized assistant messages through OpenAI-compatible provider paths
- use a conservative context-window fallback for unknown third-party models so auto-compaction still triggers instead of silently assuming a 200k window
- move provider-sensitive resume coverage behind focused mocks and isolate provider env handling in the regression tests

## Test plan
- [x] `bun test src/utils/conversationRecovery.test.ts src/utils/conversationRecovery.hooks.test.ts src/services/api/openaiShim.test.ts src/utils/context.test.ts`
- [x] `bun run test:provider`
- [x] `bun run smoke`

🤖 Generated with [OpenClaude](https://github.com/Gitlawb/openclaude)