### PR TITLE
Improve custom provider setup and provider validation flow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,3 @@ GEMINI.md
 package-lock.json
 /.claude
 coverage/
-.claude-index/
-.idea/
-CLAUDE.md
-*.tgz

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,7 @@ GEMINI.md
 package-lock.json
 /.claude
 coverage/
+.claude-index/
+.idea/
+CLAUDE.md
+*.tgz

--- a/src/components/ProviderManager.tsx
+++ b/src/components/ProviderManager.tsx
@@ -216,6 +216,7 @@ export function ProviderManager({ mode, onDone }: Props): React.ReactNode {
   const [formStepIndex, setFormStepIndex] = React.useState(0)
   const [cursorOffset, setCursorOffset] = React.useState(0)
   const [isTestingConnection, setIsTestingConnection] = React.useState(false)
+  const testEpochRef = React.useRef(0)
   const [statusMessage, setStatusMessage] = React.useState<string | undefined>()
   const [errorMessage, setErrorMessage] = React.useState<string | undefined>()
 
@@ -463,6 +464,7 @@ export function ProviderManager({ mode, onDone }: Props): React.ReactNode {
   }
 
   async function testAndPersistDraft(): Promise<void> {
+    const epoch = ++testEpochRef.current
     setIsTestingConnection(true)
     setErrorMessage(undefined)
 
@@ -475,6 +477,10 @@ export function ProviderManager({ mode, onDone }: Props): React.ReactNode {
     }
 
     const result = await testProviderProfileConnection(payload)
+
+    // Discard the result if the user navigated away or started a new test.
+    if (epoch !== testEpochRef.current) return
+
     setIsTestingConnection(false)
 
     if (!result.ok) {
@@ -517,7 +523,9 @@ export function ProviderManager({ mode, onDone }: Props): React.ReactNode {
 
     if (screen === 'confirm-save') {
       if (isTestingConnection) {
-        return
+        // Invalidate the in-flight test so its result is discarded.
+        ++testEpochRef.current
+        setIsTestingConnection(false)
       }
       setScreen('form')
       return

--- a/src/components/ProviderManager.tsx
+++ b/src/components/ProviderManager.tsx
@@ -217,6 +217,7 @@ export function ProviderManager({ mode, onDone }: Props): React.ReactNode {
   const [cursorOffset, setCursorOffset] = React.useState(0)
   const [isTestingConnection, setIsTestingConnection] = React.useState(false)
   const testEpochRef = React.useRef(0)
+  const testAbortRef = React.useRef<AbortController | null>(null)
   const [statusMessage, setStatusMessage] = React.useState<string | undefined>()
   const [errorMessage, setErrorMessage] = React.useState<string | undefined>()
 
@@ -465,6 +466,8 @@ export function ProviderManager({ mode, onDone }: Props): React.ReactNode {
 
   async function testAndPersistDraft(): Promise<void> {
     const epoch = ++testEpochRef.current
+    const abort = new AbortController()
+    testAbortRef.current = abort
     setIsTestingConnection(true)
     setErrorMessage(undefined)
 
@@ -476,7 +479,9 @@ export function ProviderManager({ mode, onDone }: Props): React.ReactNode {
       apiKey: draft.apiKey,
     }
 
-    const result = await testProviderProfileConnection(payload)
+    const result = await testProviderProfileConnection(payload, {
+      signal: abort.signal,
+    })
 
     // Discard the result if the user navigated away or started a new test.
     if (epoch !== testEpochRef.current) return
@@ -523,7 +528,8 @@ export function ProviderManager({ mode, onDone }: Props): React.ReactNode {
 
     if (screen === 'confirm-save') {
       if (isTestingConnection) {
-        // Invalidate the in-flight test so its result is discarded.
+        // Abort the in-flight request and invalidate its result.
+        testAbortRef.current?.abort()
         ++testEpochRef.current
         setIsTestingConnection(false)
       }

--- a/src/components/ProviderManager.tsx
+++ b/src/components/ProviderManager.tsx
@@ -516,6 +516,9 @@ export function ProviderManager({ mode, onDone }: Props): React.ReactNode {
     setErrorMessage(undefined)
 
     if (screen === 'confirm-save') {
+      if (isTestingConnection) {
+        return
+      }
       setScreen('form')
       return
     }

--- a/src/components/ProviderManager.tsx
+++ b/src/components/ProviderManager.tsx
@@ -15,6 +15,7 @@ import {
   type ProviderProfileInput,
   updateProviderProfile,
 } from '../utils/providerProfiles.js'
+import { testProviderProfileConnection } from '../utils/providerProfileConnection.js'
 import {
   clearGithubModelsToken,
   GITHUB_MODELS_HYDRATED_ENV_MARKER,
@@ -42,7 +43,9 @@ type Props = {
 type Screen =
   | 'menu'
   | 'select-preset'
+  | 'select-custom-provider-mode'
   | 'form'
+  | 'confirm-save'
   | 'select-active'
   | 'select-edit'
   | 'select-delete'
@@ -109,6 +112,10 @@ function presetToDraft(preset: ProviderPreset): ProviderDraft {
     model: defaults.model,
     apiKey: defaults.apiKey ?? '',
   }
+}
+
+function providerModeLabel(provider: ProviderProfile['provider']): string {
+  return provider === 'anthropic' ? 'Anthropic' : 'OpenAI-compatible'
 }
 
 function profileSummary(profile: ProviderProfile, isActive: boolean): string {
@@ -208,6 +215,7 @@ export function ProviderManager({ mode, onDone }: Props): React.ReactNode {
   )
   const [formStepIndex, setFormStepIndex] = React.useState(0)
   const [cursorOffset, setCursorOffset] = React.useState(0)
+  const [isTestingConnection, setIsTestingConnection] = React.useState(false)
   const [statusMessage, setStatusMessage] = React.useState<string | undefined>()
   const [errorMessage, setErrorMessage] = React.useState<string | undefined>()
 
@@ -364,8 +372,13 @@ export function ProviderManager({ mode, onDone }: Props): React.ReactNode {
     return null
   }
 
-  function startCreateFromPreset(preset: ProviderPreset): void {
-    const defaults = getProviderPresetDefaults(preset)
+  function startCreateFromPreset(
+    preset: ProviderPreset,
+    options?: {
+      provider?: ProviderProfile['provider']
+    },
+  ): void {
+    const defaults = getProviderPresetDefaults(preset, options)
     const nextDraft = {
       name: defaults.name,
       baseUrl: defaults.baseUrl,
@@ -377,6 +390,7 @@ export function ProviderManager({ mode, onDone }: Props): React.ReactNode {
     setDraft(nextDraft)
     setFormStepIndex(0)
     setCursorOffset(nextDraft.name.length)
+    setIsTestingConnection(false)
     setErrorMessage(undefined)
     setScreen('form')
   }
@@ -393,6 +407,7 @@ export function ProviderManager({ mode, onDone }: Props): React.ReactNode {
     setDraft(nextDraft)
     setFormStepIndex(0)
     setCursorOffset(nextDraft.name.length)
+    setIsTestingConnection(false)
     setErrorMessage(undefined)
     setScreen('form')
   }
@@ -442,8 +457,32 @@ export function ProviderManager({ mode, onDone }: Props): React.ReactNode {
 
     setEditingProfileId(null)
     setFormStepIndex(0)
+    setIsTestingConnection(false)
     setErrorMessage(undefined)
     setScreen('menu')
+  }
+
+  async function testAndPersistDraft(): Promise<void> {
+    setIsTestingConnection(true)
+    setErrorMessage(undefined)
+
+    const payload: ProviderProfileInput = {
+      provider: draftProvider,
+      name: draft.name,
+      baseUrl: draft.baseUrl,
+      model: draft.model,
+      apiKey: draft.apiKey,
+    }
+
+    const result = await testProviderProfileConnection(payload)
+    setIsTestingConnection(false)
+
+    if (!result.ok) {
+      setErrorMessage(result.message)
+      return
+    }
+
+    persistDraft()
   }
 
   function handleFormSubmit(value: string): void {
@@ -470,11 +509,16 @@ export function ProviderManager({ mode, onDone }: Props): React.ReactNode {
       return
     }
 
-    persistDraft()
+    setScreen('confirm-save')
   }
 
   function handleBackFromForm(): void {
     setErrorMessage(undefined)
+
+    if (screen === 'confirm-save') {
+      setScreen('form')
+      return
+    }
 
     if (formStepIndex > 0) {
       const nextIndex = formStepIndex - 1
@@ -494,7 +538,7 @@ export function ProviderManager({ mode, onDone }: Props): React.ReactNode {
 
   useKeybinding('confirm:no', handleBackFromForm, {
     context: 'Settings',
-    isActive: screen === 'form',
+    isActive: screen === 'form' || screen === 'confirm-save',
   })
 
   function renderPresetSelection(): React.ReactNode {
@@ -562,7 +606,7 @@ export function ProviderManager({ mode, onDone }: Props): React.ReactNode {
       {
         value: 'custom',
         label: 'Custom',
-        description: 'Any OpenAI-compatible provider',
+        description: 'Custom Anthropic or OpenAI-compatible provider',
       },
       ...(mode === 'first-run'
         ? [
@@ -590,6 +634,10 @@ export function ProviderManager({ mode, onDone }: Props): React.ReactNode {
               closeWithCancelled('Provider setup skipped')
               return
             }
+            if (value === 'custom') {
+              setScreen('select-custom-provider-mode')
+              return
+            }
             startCreateFromPreset(value as ProviderPreset)
           }}
           onCancel={() => {
@@ -605,6 +653,41 @@ export function ProviderManager({ mode, onDone }: Props): React.ReactNode {
     )
   }
 
+  function renderCustomProviderModeSelection(): React.ReactNode {
+    return (
+      <Box flexDirection="column" gap={1}>
+        <Text color="remember" bold>
+          Choose API mode
+        </Text>
+        <Text dimColor>
+          Custom providers can use Anthropic native API mode or OpenAI-compatible
+          API mode.
+        </Text>
+        <Select
+          options={[
+            {
+              value: 'anthropic',
+              label: 'Anthropic',
+              description: 'Native Anthropic API with x-api-key auth',
+            },
+            {
+              value: 'openai',
+              label: 'OpenAI-compatible',
+              description: 'Chat/completions style APIs such as OpenAI, OpenRouter, or local gateways',
+            },
+          ]}
+          onChange={value =>
+            startCreateFromPreset('custom', {
+              provider: value as ProviderProfile['provider'],
+            })
+          }
+          onCancel={() => setScreen('select-preset')}
+          visibleOptionCount={2}
+        />
+      </Box>
+    )
+  }
+
   function renderForm(): React.ReactNode {
     return (
       <Box flexDirection="column" gap={1}>
@@ -613,10 +696,7 @@ export function ProviderManager({ mode, onDone }: Props): React.ReactNode {
         </Text>
         <Text dimColor>{currentStep.helpText}</Text>
         <Text dimColor>
-          Provider type:{' '}
-          {draftProvider === 'anthropic'
-            ? 'Anthropic native API'
-            : 'OpenAI-compatible API'}
+          API mode: {providerModeLabel(draftProvider)}
         </Text>
         <Text dimColor>
           Step {formStepIndex + 1} of {FORM_STEPS.length}: {currentStep.label}
@@ -644,6 +724,76 @@ export function ProviderManager({ mode, onDone }: Props): React.ReactNode {
         <Text dimColor>
           Press Enter to continue. Press Esc to go back.
         </Text>
+      </Box>
+    )
+  }
+
+  function renderConfirmSave(): React.ReactNode {
+    const summaryKey =
+      draft.apiKey.trim().length > 0 ? 'API key configured' : 'No API key'
+
+    if (isTestingConnection) {
+      return (
+        <Box flexDirection="column" gap={1}>
+          <Text color="remember" bold>
+            Testing provider connection
+          </Text>
+          <Text dimColor>
+            Running a minimal validation request against {draft.model}.
+          </Text>
+        </Box>
+      )
+    }
+
+    return (
+      <Box flexDirection="column" gap={1}>
+        <Text color="remember" bold>
+          Confirm provider profile
+        </Text>
+        <Text dimColor>
+          Review the profile, then either test it before saving or save
+          directly.
+        </Text>
+        <Box flexDirection="column">
+          <Text dimColor>Name: {draft.name}</Text>
+          <Text dimColor>API mode: {providerModeLabel(draftProvider)}</Text>
+          <Text dimColor>Base URL: {draft.baseUrl}</Text>
+          <Text dimColor>Model: {draft.model}</Text>
+          <Text dimColor>{summaryKey}</Text>
+        </Box>
+        {errorMessage ? <Text color="error">{errorMessage}</Text> : null}
+        <Select
+          options={[
+            {
+              value: 'test-save',
+              label: 'Test and save',
+              description: 'Run a live validation request first; save only if it succeeds',
+            },
+            {
+              value: 'save',
+              label: 'Save without testing',
+              description: 'Write the profile immediately',
+            },
+            {
+              value: 'back',
+              label: 'Back',
+              description: 'Return to the form',
+            },
+          ]}
+          onChange={value => {
+            if (value === 'test-save') {
+              void testAndPersistDraft()
+              return
+            }
+            if (value === 'save') {
+              persistDraft()
+              return
+            }
+            setScreen('form')
+          }}
+          onCancel={handleBackFromForm}
+          visibleOptionCount={3}
+        />
       </Box>
     )
   }
@@ -823,8 +973,14 @@ export function ProviderManager({ mode, onDone }: Props): React.ReactNode {
     case 'select-preset':
       content = renderPresetSelection()
       break
+    case 'select-custom-provider-mode':
+      content = renderCustomProviderModeSelection()
+      break
     case 'form':
       content = renderForm()
+      break
+    case 'confirm-save':
+      content = renderConfirmSave()
       break
     case 'select-active':
       content = renderProfileSelection(

--- a/src/services/api/client.ts
+++ b/src/services/api/client.ts
@@ -108,9 +108,11 @@ export async function getAnthropicClient({
   const remoteSessionId = process.env.CLAUDE_CODE_REMOTE_SESSION_ID
   const clientApp = process.env.CLAUDE_AGENT_SDK_CLIENT_APP
   const customHeaders = getCustomHeaders()
+  const anthropicBaseUrl =
+    providerOverride?.baseURL ?? process.env.ANTHROPIC_BASE_URL
   const defaultHeaders: { [key: string]: string } = {
     'x-app': 'cli',
-    'User-Agent': getUserAgent(),
+    'User-Agent': getUserAgent(anthropicBaseUrl),
     'X-Claude-Code-Session-Id': getSessionId(),
     ...customHeaders,
     ...(containerId ? { 'x-claude-remote-container-id': containerId } : {}),

--- a/src/utils/http.test.ts
+++ b/src/utils/http.test.ts
@@ -33,4 +33,20 @@ describe('getUserAgent', () => {
 
     expect(userAgent).toStartWith('claude-cli/')
   })
+
+  test('uses claude-cli user agent when no baseUrl provided', async () => {
+    const { getUserAgent } = await importFreshHttpModule()
+
+    const userAgent = getUserAgent()
+
+    expect(userAgent).toStartWith('claude-cli/')
+  })
+
+  test('uses claude-cli user agent for malformed URLs', async () => {
+    const { getUserAgent } = await importFreshHttpModule()
+
+    const userAgent = getUserAgent('not-a-url')
+
+    expect(userAgent).toStartWith('claude-cli/')
+  })
 })

--- a/src/utils/http.test.ts
+++ b/src/utils/http.test.ts
@@ -1,4 +1,11 @@
-import { afterEach, describe, expect, test } from 'bun:test'
+import { afterEach, beforeAll, describe, expect, test } from 'bun:test'
+
+// MACRO.* are build-time constants injected by the bundler (see scripts/build.ts).
+// Provide a minimal stub so tests can import http.ts without a full build.
+beforeAll(() => {
+  // @ts-expect-error — build-time macro stub
+  globalThis.MACRO ??= { VERSION: '0.0.0-test' }
+})
 
 const originalEnv = { ...process.env }
 

--- a/src/utils/http.test.ts
+++ b/src/utils/http.test.ts
@@ -1,0 +1,29 @@
+import { afterEach, describe, expect, test } from 'bun:test'
+
+const originalEnv = { ...process.env }
+
+afterEach(() => {
+  process.env = { ...originalEnv }
+})
+
+async function importFreshHttpModule() {
+  return import(`./http.js?ts=${Date.now()}-${Math.random()}`)
+}
+
+describe('getUserAgent', () => {
+  test('uses claude-code user agent for kimi coding anthropic endpoint', async () => {
+    const { getUserAgent } = await importFreshHttpModule()
+
+    const userAgent = getUserAgent('https://api.kimi.com/coding')
+
+    expect(userAgent).toStartWith('claude-code/')
+  })
+
+  test('keeps claude-cli user agent for other endpoints', async () => {
+    const { getUserAgent } = await importFreshHttpModule()
+
+    const userAgent = getUserAgent('https://api.anthropic.com')
+
+    expect(userAgent).toStartWith('claude-cli/')
+  })
+})

--- a/src/utils/http.ts
+++ b/src/utils/http.ts
@@ -16,7 +16,7 @@ import { getWorkload } from './workloadContext.js'
 
 // WARNING: We rely on `claude-cli` in the user agent for log filtering.
 // Please do NOT change this without making sure that logging also gets updated!
-export function shouldUseClaudeCodeUserAgent(
+function shouldUseClaudeCodeUserAgent(
   baseUrl: string | undefined,
 ): boolean {
   if (!baseUrl) {

--- a/src/utils/http.ts
+++ b/src/utils/http.ts
@@ -16,6 +16,18 @@ import { getWorkload } from './workloadContext.js'
 
 // WARNING: We rely on `claude-cli` in the user agent for log filtering.
 // Please do NOT change this without making sure that logging also gets updated!
+//
+// Providers listed here receive a `claude-code/` user-agent instead of the
+// default `claude-cli/` prefix.  These are third-party Anthropic-compatible
+// coding endpoints that do NOT flow through Anthropic's log infrastructure,
+// so the prefix swap has no impact on 1P log filtering.
+//
+// To add a new provider, append a { hostname, pathPrefix } entry.
+const CLAUDE_CODE_UA_HOSTS: ReadonlyArray<{
+  hostname: string
+  pathPrefix: RegExp
+}> = [{ hostname: 'api.kimi.com', pathPrefix: /^\/coding(?:\/|$)/i }]
+
 function shouldUseClaudeCodeUserAgent(
   baseUrl: string | undefined,
 ): boolean {
@@ -25,9 +37,9 @@ function shouldUseClaudeCodeUserAgent(
 
   try {
     const url = new URL(baseUrl)
-    return (
-      url.hostname.toLowerCase() === 'api.kimi.com' &&
-      /^\/coding(?:\/|$)/i.test(url.pathname)
+    const host = url.hostname.toLowerCase()
+    return CLAUDE_CODE_UA_HOSTS.some(
+      (h) => h.hostname === host && h.pathPrefix.test(url.pathname),
     )
   } catch {
     return false

--- a/src/utils/http.ts
+++ b/src/utils/http.ts
@@ -16,7 +16,29 @@ import { getWorkload } from './workloadContext.js'
 
 // WARNING: We rely on `claude-cli` in the user agent for log filtering.
 // Please do NOT change this without making sure that logging also gets updated!
-export function getUserAgent(): string {
+export function shouldUseClaudeCodeUserAgent(
+  baseUrl: string | undefined,
+): boolean {
+  if (!baseUrl) {
+    return false
+  }
+
+  try {
+    const url = new URL(baseUrl)
+    return (
+      url.hostname.toLowerCase() === 'api.kimi.com' &&
+      /^\/coding(?:\/|$)/i.test(url.pathname)
+    )
+  } catch {
+    return false
+  }
+}
+
+export function getUserAgent(baseUrl?: string): string {
+  if (shouldUseClaudeCodeUserAgent(baseUrl)) {
+    return getClaudeCodeUserAgent()
+  }
+
   const agentSdkVersion = process.env.CLAUDE_AGENT_SDK_VERSION
     ? `, agent-sdk/${process.env.CLAUDE_AGENT_SDK_VERSION}`
     : ''

--- a/src/utils/model/validateModel.ts
+++ b/src/utils/model/validateModel.ts
@@ -26,9 +26,12 @@ export function clearValidModelCache(): void {
 
 /**
  * Validates a model by attempting an actual API call.
+ * An optional AbortSignal can be passed to cancel the request early
+ * (e.g. when the user presses Esc during a connection test).
  */
 export async function validateModel(
   model: string,
+  options?: { signal?: AbortSignal },
 ): Promise<{ valid: boolean; error?: string }> {
   const normalizedModel = model.trim()
 
@@ -87,6 +90,7 @@ export async function validateModel(
       model: normalizedModel,
       max_tokens: 1,
       maxRetries: 0,
+      signal: options?.signal,
       querySource: 'model_validation',
       messages: [
         {

--- a/src/utils/model/validateModel.ts
+++ b/src/utils/model/validateModel.ts
@@ -16,6 +16,15 @@ import { getCachedOllamaModelOptions, isOllamaProvider } from './ollamaModels.js
 const validModelCache = new Map<string, boolean>()
 
 /**
+ * Clear the validation cache so the next validateModel() call makes a real
+ * API request.  Used by connection-test flows where the same model name may
+ * need to be validated against different providers / credentials.
+ */
+export function clearValidModelCache(): void {
+  validModelCache.clear()
+}
+
+/**
  * Validates a model by attempting an actual API call.
  */
 export async function validateModel(

--- a/src/utils/providerProfileConnection.test.ts
+++ b/src/utils/providerProfileConnection.test.ts
@@ -114,6 +114,27 @@ describe('testProviderProfileConnection', () => {
     expect(process.env.CLAUDE_CODE_OAUTH_TOKEN_FILE_DESCRIPTOR).toBe('3')
   })
 
+  test('returns error message when validateModel throws', async () => {
+    const { testProviderProfileConnection } = await importFreshModule()
+
+    const validateModel = mock(async () => {
+      throw new Error('Network timeout')
+    })
+
+    const result = await testProviderProfileConnection(
+      {
+        provider: 'openai',
+        name: 'Throwing provider',
+        baseUrl: 'https://api.example.com/v1',
+        model: 'some-model',
+        apiKey: 'key',
+      },
+      { validateModel },
+    )
+
+    expect(result).toEqual({ ok: false, message: 'Network timeout' })
+  })
+
   test('requires model and base url before testing', async () => {
     const { testProviderProfileConnection } = await importFreshModule()
 

--- a/src/utils/providerProfileConnection.test.ts
+++ b/src/utils/providerProfileConnection.test.ts
@@ -24,6 +24,7 @@ describe('testProviderProfileConnection', () => {
     process.env.OPENAI_BASE_URL = 'https://api.example.com/v1'
     process.env.OPENAI_MODEL = 'old-model'
     process.env.OPENAI_API_KEY = 'old-key'
+    process.env.OPENAI_ORG = 'old-org'
 
     const validateModel = mock(async (model: string) => {
       expect(model).toBe('claude-sonnet-4-6')
@@ -31,6 +32,7 @@ describe('testProviderProfileConnection', () => {
       expect(process.env.ANTHROPIC_BASE_URL).toBe('https://api.anthropic.com')
       expect(process.env.ANTHROPIC_MODEL).toBe('claude-sonnet-4-6')
       expect(process.env.ANTHROPIC_API_KEY).toBe('anthropic-key')
+      expect(process.env.OPENAI_ORG).toBeUndefined()
       return { valid: true }
     })
 
@@ -50,6 +52,7 @@ describe('testProviderProfileConnection', () => {
     expect(process.env.OPENAI_BASE_URL).toBe('https://api.example.com/v1')
     expect(process.env.OPENAI_MODEL).toBe('old-model')
     expect(process.env.OPENAI_API_KEY).toBe('old-key')
+    expect(process.env.OPENAI_ORG).toBe('old-org')
     expect(process.env.ANTHROPIC_BASE_URL).toBeUndefined()
   })
 

--- a/src/utils/providerProfileConnection.test.ts
+++ b/src/utils/providerProfileConnection.test.ts
@@ -86,21 +86,23 @@ describe('testProviderProfileConnection', () => {
     expect(process.env.OPENAI_API_KEY).toBeUndefined()
   })
 
-  test('suppresses OAuth tokens during validation so API key is exercised', async () => {
+  test('suppresses auth tokens during validation so API key is exercised', async () => {
     const { testProviderProfileConnection } = await importFreshModule()
     process.env.CLAUDE_CODE_OAUTH_TOKEN = 'oauth-token-value'
     process.env.CLAUDE_CODE_OAUTH_TOKEN_FILE_DESCRIPTOR = '3'
+    process.env.ANTHROPIC_AUTH_TOKEN = 'bearer-token-value'
 
     const validateModel = mock(async () => {
       expect(process.env.CLAUDE_CODE_OAUTH_TOKEN).toBeUndefined()
       expect(process.env.CLAUDE_CODE_OAUTH_TOKEN_FILE_DESCRIPTOR).toBeUndefined()
+      expect(process.env.ANTHROPIC_AUTH_TOKEN).toBeUndefined()
       return { valid: true }
     })
 
     const result = await testProviderProfileConnection(
       {
         provider: 'anthropic',
-        name: 'Test OAuth Bypass',
+        name: 'Test Auth Bypass',
         baseUrl: 'https://api.anthropic.com',
         model: 'claude-sonnet-4-6',
         apiKey: 'my-api-key',
@@ -109,9 +111,33 @@ describe('testProviderProfileConnection', () => {
     )
 
     expect(result).toEqual({ ok: true })
-    // OAuth env vars should be restored after the test
+    // Auth env vars should be restored after the test
     expect(process.env.CLAUDE_CODE_OAUTH_TOKEN).toBe('oauth-token-value')
     expect(process.env.CLAUDE_CODE_OAUTH_TOKEN_FILE_DESCRIPTOR).toBe('3')
+    expect(process.env.ANTHROPIC_AUTH_TOKEN).toBe('bearer-token-value')
+  })
+
+  test('forwards abort signal to validateModel', async () => {
+    const { testProviderProfileConnection } = await importFreshModule()
+    const controller = new AbortController()
+
+    const validateModel = mock(async (_model: string, opts?: { signal?: AbortSignal }) => {
+      expect(opts?.signal).toBe(controller.signal)
+      return { valid: true }
+    })
+
+    const result = await testProviderProfileConnection(
+      {
+        provider: 'openai',
+        name: 'Signal test',
+        baseUrl: 'https://api.example.com/v1',
+        model: 'test-model',
+        apiKey: 'key',
+      },
+      { validateModel, signal: controller.signal },
+    )
+
+    expect(result).toEqual({ ok: true })
   })
 
   test('returns error message when validateModel throws', async () => {

--- a/src/utils/providerProfileConnection.test.ts
+++ b/src/utils/providerProfileConnection.test.ts
@@ -1,0 +1,102 @@
+import { afterEach, describe, expect, mock, test } from 'bun:test'
+
+import type { ProviderProfileInput } from './providerProfiles.js'
+
+const originalEnv = { ...process.env }
+
+function restoreEnv(): void {
+  process.env = { ...originalEnv }
+}
+
+async function importFreshModule() {
+  return import(`./providerProfileConnection.ts?ts=${Date.now()}-${Math.random()}`)
+}
+
+describe('testProviderProfileConnection', () => {
+  afterEach(() => {
+    restoreEnv()
+    mock.restore()
+  })
+
+  test('uses anthropic env for anthropic profiles and restores previous env', async () => {
+    const { testProviderProfileConnection } = await importFreshModule()
+    process.env.CLAUDE_CODE_USE_OPENAI = '1'
+    process.env.OPENAI_BASE_URL = 'https://api.example.com/v1'
+    process.env.OPENAI_MODEL = 'old-model'
+    process.env.OPENAI_API_KEY = 'old-key'
+
+    const validateModel = mock(async (model: string) => {
+      expect(model).toBe('claude-sonnet-4-6')
+      expect(process.env.CLAUDE_CODE_USE_OPENAI).toBeUndefined()
+      expect(process.env.ANTHROPIC_BASE_URL).toBe('https://api.anthropic.com')
+      expect(process.env.ANTHROPIC_MODEL).toBe('claude-sonnet-4-6')
+      expect(process.env.ANTHROPIC_API_KEY).toBe('anthropic-key')
+      return { valid: true }
+    })
+
+    const result = await testProviderProfileConnection(
+      {
+        provider: 'anthropic',
+        name: 'Anthropic Custom',
+        baseUrl: 'https://api.anthropic.com',
+        model: 'claude-sonnet-4-6',
+        apiKey: 'anthropic-key',
+      },
+      { validateModel },
+    )
+
+    expect(result).toEqual({ ok: true })
+    expect(process.env.CLAUDE_CODE_USE_OPENAI).toBe('1')
+    expect(process.env.OPENAI_BASE_URL).toBe('https://api.example.com/v1')
+    expect(process.env.OPENAI_MODEL).toBe('old-model')
+    expect(process.env.OPENAI_API_KEY).toBe('old-key')
+    expect(process.env.ANTHROPIC_BASE_URL).toBeUndefined()
+  })
+
+  test('uses openai env for openai-compatible profiles and returns validation errors', async () => {
+    const { testProviderProfileConnection } = await importFreshModule()
+    delete process.env.CLAUDE_CODE_USE_OPENAI
+
+    const validateModel = mock(async () => {
+      expect(process.env.CLAUDE_CODE_USE_OPENAI).toBe('1')
+      expect(process.env.OPENAI_BASE_URL).toBe('https://api.openai.com/v1')
+      expect(process.env.OPENAI_MODEL).toBe('gpt-4o-mini')
+      expect(process.env.OPENAI_API_KEY).toBe('openai-key')
+      return { valid: false, error: 'Authentication failed.' }
+    })
+
+    const result = await testProviderProfileConnection(
+      {
+        provider: 'openai',
+        name: 'Custom OpenAI',
+        baseUrl: 'https://api.openai.com/v1',
+        model: 'gpt-4o-mini',
+        apiKey: 'openai-key',
+      },
+      { validateModel },
+    )
+
+    expect(result).toEqual({ ok: false, message: 'Authentication failed.' })
+    expect(process.env.CLAUDE_CODE_USE_OPENAI).toBeUndefined()
+    expect(process.env.OPENAI_BASE_URL).toBeUndefined()
+    expect(process.env.OPENAI_MODEL).toBeUndefined()
+    expect(process.env.OPENAI_API_KEY).toBeUndefined()
+  })
+
+  test('requires model and base url before testing', async () => {
+    const { testProviderProfileConnection } = await importFreshModule()
+
+    const result = await testProviderProfileConnection({
+      provider: 'openai',
+      name: 'Incomplete',
+      baseUrl: '',
+      model: '',
+      apiKey: '',
+    } as ProviderProfileInput)
+
+    expect(result).toEqual({
+      ok: false,
+      message: 'Base URL and model are required before testing the provider.',
+    })
+  })
+})

--- a/src/utils/providerProfileConnection.test.ts
+++ b/src/utils/providerProfileConnection.test.ts
@@ -86,6 +86,34 @@ describe('testProviderProfileConnection', () => {
     expect(process.env.OPENAI_API_KEY).toBeUndefined()
   })
 
+  test('suppresses OAuth tokens during validation so API key is exercised', async () => {
+    const { testProviderProfileConnection } = await importFreshModule()
+    process.env.CLAUDE_CODE_OAUTH_TOKEN = 'oauth-token-value'
+    process.env.CLAUDE_CODE_OAUTH_TOKEN_FILE_DESCRIPTOR = '3'
+
+    const validateModel = mock(async () => {
+      expect(process.env.CLAUDE_CODE_OAUTH_TOKEN).toBeUndefined()
+      expect(process.env.CLAUDE_CODE_OAUTH_TOKEN_FILE_DESCRIPTOR).toBeUndefined()
+      return { valid: true }
+    })
+
+    const result = await testProviderProfileConnection(
+      {
+        provider: 'anthropic',
+        name: 'Test OAuth Bypass',
+        baseUrl: 'https://api.anthropic.com',
+        model: 'claude-sonnet-4-6',
+        apiKey: 'my-api-key',
+      },
+      { validateModel },
+    )
+
+    expect(result).toEqual({ ok: true })
+    // OAuth env vars should be restored after the test
+    expect(process.env.CLAUDE_CODE_OAUTH_TOKEN).toBe('oauth-token-value')
+    expect(process.env.CLAUDE_CODE_OAUTH_TOKEN_FILE_DESCRIPTOR).toBe('3')
+  })
+
   test('requires model and base url before testing', async () => {
     const { testProviderProfileConnection } = await importFreshModule()
 

--- a/src/utils/providerProfileConnection.test.ts
+++ b/src/utils/providerProfileConnection.test.ts
@@ -9,7 +9,7 @@ function restoreEnv(): void {
 }
 
 async function importFreshModule() {
-  return import(`./providerProfileConnection.ts?ts=${Date.now()}-${Math.random()}`)
+  return import(`./providerProfileConnection.js?ts=${Date.now()}-${Math.random()}`)
 }
 
 describe('testProviderProfileConnection', () => {

--- a/src/utils/providerProfileConnection.ts
+++ b/src/utils/providerProfileConnection.ts
@@ -28,19 +28,48 @@ function setOptionalEnvValue(key: string, value: string | undefined): void {
   }
 }
 
+function deleteEnvKeys(keys: string[]): void {
+  for (const key of keys) {
+    delete process.env[key]
+  }
+}
+
+function restoreProcessEnv(snapshot: NodeJS.ProcessEnv): void {
+  for (const key of Object.keys(process.env)) {
+    if (!(key in snapshot)) {
+      delete process.env[key]
+    }
+  }
+
+  for (const [key, value] of Object.entries(snapshot)) {
+    if (value === undefined) {
+      delete process.env[key]
+    } else {
+      process.env[key] = value
+    }
+  }
+}
+
 function applyProfileToProcessEnv(input: ProviderProfileInput): void {
-  delete process.env.CLAUDE_CODE_USE_GEMINI
-  delete process.env.CLAUDE_CODE_USE_GITHUB
-  delete process.env.CLAUDE_CODE_USE_BEDROCK
-  delete process.env.CLAUDE_CODE_USE_VERTEX
-  delete process.env.CLAUDE_CODE_USE_FOUNDRY
+  deleteEnvKeys([
+    'CLAUDE_CODE_USE_GEMINI',
+    'CLAUDE_CODE_USE_GITHUB',
+    'CLAUDE_CODE_USE_BEDROCK',
+    'CLAUDE_CODE_USE_VERTEX',
+    'CLAUDE_CODE_USE_FOUNDRY',
+    'OPENAI_ORG',
+    'OPENAI_PROJECT',
+    'OPENAI_ORGANIZATION',
+  ])
 
   if (input.provider === 'anthropic') {
-    delete process.env.CLAUDE_CODE_USE_OPENAI
-    delete process.env.OPENAI_BASE_URL
-    delete process.env.OPENAI_API_BASE
-    delete process.env.OPENAI_MODEL
-    delete process.env.OPENAI_API_KEY
+    deleteEnvKeys([
+      'CLAUDE_CODE_USE_OPENAI',
+      'OPENAI_BASE_URL',
+      'OPENAI_API_BASE',
+      'OPENAI_MODEL',
+      'OPENAI_API_KEY',
+    ])
 
     process.env.ANTHROPIC_BASE_URL = trimValue(input.baseUrl)
     process.env.ANTHROPIC_MODEL = trimValue(input.model)
@@ -99,6 +128,6 @@ export async function testProviderProfileConnection(
       message: error instanceof Error ? error.message : String(error),
     }
   } finally {
-    process.env = previousEnv
+    restoreProcessEnv(previousEnv)
   }
 }

--- a/src/utils/providerProfileConnection.ts
+++ b/src/utils/providerProfileConnection.ts
@@ -35,16 +35,23 @@ function setOptionalEnvValue(key: string, value: string | undefined): void {
   }
 }
 
-// OAuth-related env vars that must be suppressed during connection tests
+// Auth-related env vars that must be suppressed during connection tests
 // so that the entered API key is actually validated instead of being
-// bypassed by an active Claude.ai subscriber session.
+// bypassed by an active Claude.ai subscriber session or a pre-existing
+// bearer token.
 //
 // These correspond to the token sources checked in auth.ts
-// (getAuthTokenSource / getClaudeAIOAuthTokens).  If a new OAuth env var
+// (getAuthTokenSource / getClaudeAIOAuthTokens) and the bearer-token
+// fallback in client.ts (configureApiKeyHeaders).  If a new auth env var
 // is added there, it should be added here as well.
-const OAUTH_ENV_KEYS = [
+//
+// LIMITATION: If the user authenticated via keychain/secure-storage OAuth
+// (not env vars), the memoized token from getClaudeAIOAuthTokens() will
+// still be used.  The env var suppression only covers env-var-based auth.
+const AUTH_ENV_KEYS_TO_SUPPRESS = [
   'CLAUDE_CODE_OAUTH_TOKEN',
   'CLAUDE_CODE_OAUTH_TOKEN_FILE_DESCRIPTOR',
+  'ANTHROPIC_AUTH_TOKEN',
 ]
 
 function deleteEnvKeys(keys: string[]): void {
@@ -136,7 +143,7 @@ export async function testProviderProfileConnection(
   try {
     // Suppress OAuth tokens so getAnthropicClient() falls through to
     // API-key auth, ensuring the entered key is actually exercised.
-    deleteEnvKeys(OAUTH_ENV_KEYS)
+    deleteEnvKeys(AUTH_ENV_KEYS_TO_SUPPRESS)
 
     applyProfileToProcessEnv({
       ...input,

--- a/src/utils/providerProfileConnection.ts
+++ b/src/utils/providerProfileConnection.ts
@@ -11,7 +11,12 @@ type ValidateModelFn = (
 async function defaultValidateModel(
   model: string,
 ): Promise<{ valid: boolean; error?: string }> {
-  const { validateModel } = await import('./model/validateModel.js')
+  const { clearValidModelCache, validateModel } = await import(
+    './model/validateModel.js'
+  )
+  // Clear the cache so the request actually hits the new provider endpoint
+  // instead of returning a stale success from a previous provider.
+  clearValidModelCache()
   return validateModel(model)
 }
 
@@ -27,6 +32,14 @@ function setOptionalEnvValue(key: string, value: string | undefined): void {
     delete process.env[key]
   }
 }
+
+// OAuth-related env vars that must be suppressed during connection tests
+// so that the entered API key is actually validated instead of being
+// bypassed by an active Claude.ai subscriber session.
+const OAUTH_ENV_KEYS = [
+  'CLAUDE_CODE_OAUTH_TOKEN',
+  'CLAUDE_CODE_OAUTH_TOKEN_FILE_DESCRIPTOR',
+]
 
 function deleteEnvKeys(keys: string[]): void {
   for (const key of keys) {
@@ -106,6 +119,10 @@ export async function testProviderProfileConnection(
   const previousEnv = { ...process.env }
 
   try {
+    // Suppress OAuth tokens so getAnthropicClient() falls through to
+    // API-key auth, ensuring the entered key is actually exercised.
+    deleteEnvKeys(OAUTH_ENV_KEYS)
+
     applyProfileToProcessEnv({
       ...input,
       baseUrl,

--- a/src/utils/providerProfileConnection.ts
+++ b/src/utils/providerProfileConnection.ts
@@ -1,0 +1,104 @@
+import type { ProviderProfileInput } from './providerProfiles.js'
+
+type ConnectionTestResult =
+  | { ok: true }
+  | { ok: false; message: string }
+
+type ValidateModelFn = (
+  model: string,
+) => Promise<{ valid: boolean; error?: string }>
+
+async function defaultValidateModel(
+  model: string,
+): Promise<{ valid: boolean; error?: string }> {
+  const { validateModel } = await import('./model/validateModel.js')
+  return validateModel(model)
+}
+
+function trimValue(value: string | undefined): string {
+  return value?.trim() ?? ''
+}
+
+function setOptionalEnvValue(key: string, value: string | undefined): void {
+  const trimmed = trimValue(value)
+  if (trimmed) {
+    process.env[key] = trimmed
+  } else {
+    delete process.env[key]
+  }
+}
+
+function applyProfileToProcessEnv(input: ProviderProfileInput): void {
+  delete process.env.CLAUDE_CODE_USE_GEMINI
+  delete process.env.CLAUDE_CODE_USE_GITHUB
+  delete process.env.CLAUDE_CODE_USE_BEDROCK
+  delete process.env.CLAUDE_CODE_USE_VERTEX
+  delete process.env.CLAUDE_CODE_USE_FOUNDRY
+
+  if (input.provider === 'anthropic') {
+    delete process.env.CLAUDE_CODE_USE_OPENAI
+    delete process.env.OPENAI_BASE_URL
+    delete process.env.OPENAI_API_BASE
+    delete process.env.OPENAI_MODEL
+    delete process.env.OPENAI_API_KEY
+
+    process.env.ANTHROPIC_BASE_URL = trimValue(input.baseUrl)
+    process.env.ANTHROPIC_MODEL = trimValue(input.model)
+    setOptionalEnvValue('ANTHROPIC_API_KEY', input.apiKey)
+    return
+  }
+
+  process.env.CLAUDE_CODE_USE_OPENAI = '1'
+  process.env.OPENAI_BASE_URL = trimValue(input.baseUrl)
+  process.env.OPENAI_MODEL = trimValue(input.model)
+  setOptionalEnvValue('OPENAI_API_KEY', input.apiKey)
+
+  delete process.env.ANTHROPIC_BASE_URL
+  delete process.env.ANTHROPIC_MODEL
+  delete process.env.ANTHROPIC_API_KEY
+}
+
+export async function testProviderProfileConnection(
+  input: ProviderProfileInput,
+  options?: {
+    validateModel?: ValidateModelFn
+  },
+): Promise<ConnectionTestResult> {
+  const baseUrl = trimValue(input.baseUrl)
+  const model = trimValue(input.model)
+
+  if (!baseUrl || !model) {
+    return {
+      ok: false,
+      message: 'Base URL and model are required before testing the provider.',
+    }
+  }
+
+  const previousEnv = { ...process.env }
+
+  try {
+    applyProfileToProcessEnv({
+      ...input,
+      baseUrl,
+      model,
+      apiKey: trimValue(input.apiKey),
+    })
+
+    const result = await (options?.validateModel ?? defaultValidateModel)(model)
+    if (!result.valid) {
+      return {
+        ok: false,
+        message: result.error ?? 'Provider test failed.',
+      }
+    }
+
+    return { ok: true }
+  } catch (error) {
+    return {
+      ok: false,
+      message: error instanceof Error ? error.message : String(error),
+    }
+  } finally {
+    process.env = previousEnv
+  }
+}

--- a/src/utils/providerProfileConnection.ts
+++ b/src/utils/providerProfileConnection.ts
@@ -6,10 +6,12 @@ type ConnectionTestResult =
 
 type ValidateModelFn = (
   model: string,
+  options?: { signal?: AbortSignal },
 ) => Promise<{ valid: boolean; error?: string }>
 
 async function defaultValidateModel(
   model: string,
+  options?: { signal?: AbortSignal },
 ): Promise<{ valid: boolean; error?: string }> {
   const { clearValidModelCache, validateModel } = await import(
     './model/validateModel.js'
@@ -17,7 +19,7 @@ async function defaultValidateModel(
   // Clear the cache so the request actually hits the new provider endpoint
   // instead of returning a stale success from a previous provider.
   clearValidModelCache()
-  return validateModel(model)
+  return validateModel(model, options)
 }
 
 function trimValue(value: string | undefined): string {
@@ -36,6 +38,10 @@ function setOptionalEnvValue(key: string, value: string | undefined): void {
 // OAuth-related env vars that must be suppressed during connection tests
 // so that the entered API key is actually validated instead of being
 // bypassed by an active Claude.ai subscriber session.
+//
+// These correspond to the token sources checked in auth.ts
+// (getAuthTokenSource / getClaudeAIOAuthTokens).  If a new OAuth env var
+// is added there, it should be added here as well.
 const OAUTH_ENV_KEYS = [
   'CLAUDE_CODE_OAUTH_TOKEN',
   'CLAUDE_CODE_OAUTH_TOKEN_FILE_DESCRIPTOR',
@@ -100,10 +106,19 @@ function applyProfileToProcessEnv(input: ProviderProfileInput): void {
   delete process.env.ANTHROPIC_API_KEY
 }
 
+/**
+ * Test a provider profile by temporarily applying its env vars and running
+ * a minimal API validation request.
+ *
+ * **Not safe for concurrent use** — mutates `process.env` for the duration
+ * of the test and restores it in a `finally` block.  Only one connection
+ * test should be in-flight at a time (enforced by the UI via testEpochRef).
+ */
 export async function testProviderProfileConnection(
   input: ProviderProfileInput,
   options?: {
     validateModel?: ValidateModelFn
+    signal?: AbortSignal
   },
 ): Promise<ConnectionTestResult> {
   const baseUrl = trimValue(input.baseUrl)
@@ -130,7 +145,8 @@ export async function testProviderProfileConnection(
       apiKey: trimValue(input.apiKey),
     })
 
-    const result = await (options?.validateModel ?? defaultValidateModel)(model)
+    const validate = options?.validateModel ?? defaultValidateModel
+    const result = await validate(model, { signal: options?.signal })
     if (!result.valid) {
       return {
         ok: false,

--- a/src/utils/providerProfiles.test.ts
+++ b/src/utils/providerProfiles.test.ts
@@ -359,6 +359,9 @@ describe('getProviderPresetDefaults', () => {
   })
 
   test('custom preset can default to anthropic mode', async () => {
+    delete process.env.ANTHROPIC_BASE_URL
+    delete process.env.ANTHROPIC_MODEL
+    delete process.env.ANTHROPIC_API_KEY
     const { getProviderPresetDefaults } = await importFreshProviderProfileModules()
 
     const defaults = getProviderPresetDefaults('custom', {

--- a/src/utils/providerProfiles.test.ts
+++ b/src/utils/providerProfiles.test.ts
@@ -3,7 +3,7 @@ import { afterEach, describe, expect, mock, test } from 'bun:test'
 import type { ProviderProfile } from './config.js'
 
 async function importFreshProvidersModule() {
-  return import(`./model/providers.ts?ts=${Date.now()}-${Math.random()}`)
+  return import(`./model/providers.js?ts=${Date.now()}-${Math.random()}`)
 }
 
 const originalEnv = { ...process.env }
@@ -356,6 +356,20 @@ describe('getProviderPresetDefaults', () => {
 
     expect(defaults.baseUrl).toBe('http://localhost:11434/v1')
     expect(defaults.model).toBe('llama3.1:8b')
+  })
+
+  test('custom preset can default to anthropic mode', async () => {
+    const { getProviderPresetDefaults } = await importFreshProviderProfileModules()
+
+    const defaults = getProviderPresetDefaults('custom', {
+      provider: 'anthropic',
+    })
+
+    expect(defaults.provider).toBe('anthropic')
+    expect(defaults.name).toBe('Custom Anthropic')
+    expect(defaults.baseUrl).toBe('https://api.anthropic.com')
+    expect(defaults.model).toBe('claude-sonnet-4-6')
+    expect(defaults.requiresApiKey).toBe(true)
   })
 })
 

--- a/src/utils/providerProfiles.ts
+++ b/src/utils/providerProfiles.ts
@@ -116,6 +116,9 @@ function getModelCacheByProfile(
 
 export function getProviderPresetDefaults(
   preset: ProviderPreset,
+  options?: {
+    provider?: ProviderProfile['provider']
+  },
 ): ProviderPresetDefaults {
   switch (preset) {
     case 'anthropic':
@@ -218,6 +221,17 @@ export function getProviderPresetDefaults(
         requiresApiKey: false,
       }
     case 'custom':
+      if (options?.provider === 'anthropic') {
+        return {
+          provider: 'anthropic',
+          name: 'Custom Anthropic',
+          baseUrl:
+            process.env.ANTHROPIC_BASE_URL ?? 'https://api.anthropic.com',
+          model: process.env.ANTHROPIC_MODEL ?? 'claude-sonnet-4-6',
+          apiKey: process.env.ANTHROPIC_API_KEY ?? '',
+          requiresApiKey: true,
+        }
+      }
       return {
         provider: 'openai',
         name: 'Custom OpenAI-compatible',


### PR DESCRIPTION
 ---
  Summary

  This PR improves the custom provider setup experience in /provider with two main additions:

  1. API Mode Selection for Custom Providers

  Previously, selecting "Custom" in the provider preset list always defaulted to OpenAI-compatible mode. Now users are
  presented with an intermediate screen to choose between:
  - Anthropic — Native Anthropic API with x-api-key auth
  - OpenAI-compatible — Chat/completions style APIs (OpenAI, OpenRouter, local gateways, etc.)

  getProviderPresetDefaults('custom') now accepts an optional { provider } parameter to return Anthropic-native defaults
  (base URL, model, API key fields) when provider: 'anthropic' is passed.

  2. Test-Before-Save Flow

  After completing the provider form, users land on a new Confirm screen that displays a profile summary and offers three
   options:
  - Test and save — Runs a live validateModel request against the configured endpoint; saves only if validation succeeds
  - Save without testing — Writes the profile immediately (previous behavior)
  - Back — Returns to the form for further editing

  The validation logic lives in a new providerProfileConnection.ts helper which:
  - Snapshots process.env before applying provider-specific env vars
  - Calls validateModel (injected for testability)
  - Restores the original process.env in a finally block, ensuring no env leakage regardless of success or failure
  - Blocks Esc navigation while a connection test is in-flight to prevent persistDraft() from firing after the user has
  navigated away

  3. User-Agent Handling for Compatible Coding Endpoints

  getUserAgent() now accepts an optional baseUrl parameter. When the base URL matches the Kimi coding endpoint
  (api.kimi.com/coding), it returns a claude-code/ user agent instead of the default claude-cli/ agent.
  getAnthropicClient in client.ts passes the resolved baseURL through to getUserAgent().

  

  Test Plan

  - bun test src/utils/http.test.ts — user agent selection for kimi coding vs other endpoints
  - bun test src/utils/providerProfileConnection.test.ts — env isolation, restore after success/failure, missing fields
  validation
  - bun test src/utils/providerProfiles.test.ts — custom preset Anthropic defaults with env var independence

  ---