### PR TITLE
feat: add MiniMax provider support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -40,6 +40,12 @@
 #     CLAUDE_CODE_USE_GITHUB=1
 #     GITHUB_TOKEN=ghp_your-token-here
 #
+#   Option 4b — MiniMax:
+#     CLAUDE_CODE_USE_MINIMAX=1
+#     MINIMAX_API_KEY=your-minimax-key-here
+#     OPENAI_MODEL=MiniMax-M2.7              (optional — MiniMax-M2.7 is the default)
+#     OPENAI_BASE_URL=https://api.minimax.io/v1  (optional — this is the default)
+#
 #   Option 5 — Ollama (local):
 #     CLAUDE_CODE_USE_OPENAI=1
 #     OPENAI_BASE_URL=http://localhost:11434/v1
@@ -223,6 +229,15 @@ ANTHROPIC_API_KEY=sk-ant-your-key-here
 # ANTHROPIC_VERTEX_PROJECT_ID=your-gcp-project-id
 # CLOUD_ML_REGION=us-east5
 # GOOGLE_CLOUD_PROJECT=your-gcp-project-id
+
+
+# -----------------------------------------------------------------------------
+# Option 9: MiniMax
+# -----------------------------------------------------------------------------
+# CLAUDE_CODE_USE_MINIMAX=1
+# MINIMAX_API_KEY=your-minimax-key-here
+# OPENAI_MODEL=MiniMax-M2.7           (optional — MiniMax-M2.7 is the default)
+# OPENAI_BASE_URL=https://api.minimax.io/v1  (optional — this is the default)
 
 
 # =============================================================================

--- a/src/services/api/client.ts
+++ b/src/services/api/client.ts
@@ -177,7 +177,8 @@ export async function getAnthropicClient({
   if (
     isEnvTruthy(process.env.CLAUDE_CODE_USE_OPENAI) ||
     isEnvTruthy(process.env.CLAUDE_CODE_USE_GITHUB) ||
-    isEnvTruthy(process.env.CLAUDE_CODE_USE_GEMINI)
+    isEnvTruthy(process.env.CLAUDE_CODE_USE_GEMINI) ||
+    isEnvTruthy(process.env.CLAUDE_CODE_USE_MINIMAX)
   ) {
     const { createOpenAIShimClient } = await import('./openaiShim.js')
     return createOpenAIShimClient({

--- a/src/services/api/openaiShim.ts
+++ b/src/services/api/openaiShim.ts
@@ -53,6 +53,7 @@ type SecretValueSource = Partial<{
   GEMINI_API_KEY: string
   GOOGLE_API_KEY: string
   GEMINI_ACCESS_TOKEN: string
+  MINIMAX_API_KEY: string
 }>
 
 const GITHUB_MODELS_DEFAULT_BASE = 'https://models.github.ai/inference'
@@ -219,6 +220,10 @@ function isGeminiMode(): boolean {
     isEnvTruthy(process.env.CLAUDE_CODE_USE_GEMINI) ||
     hasGeminiApiHost(process.env.OPENAI_BASE_URL)
   )
+}
+
+function isMiniMaxMode(): boolean {
+  return isEnvTruthy(process.env.CLAUDE_CODE_USE_MINIMAX)
 }
 
 function convertMessages(
@@ -1099,8 +1104,12 @@ class OpenAIShimMessages {
     }
 
     const isGemini = isGeminiMode()
+    const isMiniMax = isMiniMaxMode()
     const apiKey =
-      this.providerOverride?.apiKey ?? process.env.OPENAI_API_KEY ?? ''
+      this.providerOverride?.apiKey ??
+      (isMiniMax ? process.env.MINIMAX_API_KEY : undefined) ??
+      process.env.OPENAI_API_KEY ??
+      ''
     // Detect Azure endpoints by hostname (not raw URL) to prevent bypass via
     // path segments like https://evil.com/cognitiveservices.azure.com/
     let isAzure = false

--- a/src/services/api/providerConfig.minimax.test.ts
+++ b/src/services/api/providerConfig.minimax.test.ts
@@ -1,0 +1,70 @@
+import { afterEach, beforeEach, expect, test } from 'bun:test'
+
+import {
+  DEFAULT_MINIMAX_BASE_URL,
+  DEFAULT_MINIMAX_MODEL,
+  resolveProviderRequest,
+} from './providerConfig.js'
+
+const originalEnv = {
+  CLAUDE_CODE_USE_MINIMAX: process.env.CLAUDE_CODE_USE_MINIMAX,
+  OPENAI_BASE_URL: process.env.OPENAI_BASE_URL,
+  OPENAI_MODEL: process.env.OPENAI_MODEL,
+}
+
+beforeEach(() => {
+  delete process.env.CLAUDE_CODE_USE_MINIMAX
+  delete process.env.OPENAI_BASE_URL
+  delete process.env.OPENAI_MODEL
+})
+
+afterEach(() => {
+  process.env.CLAUDE_CODE_USE_MINIMAX = originalEnv.CLAUDE_CODE_USE_MINIMAX
+  process.env.OPENAI_BASE_URL = originalEnv.OPENAI_BASE_URL
+  process.env.OPENAI_MODEL = originalEnv.OPENAI_MODEL
+})
+
+test('uses MiniMax base URL by default when CLAUDE_CODE_USE_MINIMAX is set', () => {
+  process.env.CLAUDE_CODE_USE_MINIMAX = '1'
+
+  const result = resolveProviderRequest()
+
+  expect(result.baseUrl).toBe(DEFAULT_MINIMAX_BASE_URL)
+  expect(result.transport).toBe('chat_completions')
+})
+
+test('uses MiniMax-M2.7 as default model when CLAUDE_CODE_USE_MINIMAX is set', () => {
+  process.env.CLAUDE_CODE_USE_MINIMAX = '1'
+
+  const result = resolveProviderRequest()
+
+  expect(result.resolvedModel).toBe(DEFAULT_MINIMAX_MODEL)
+  expect(result.requestedModel).toBe(DEFAULT_MINIMAX_MODEL)
+})
+
+test('respects OPENAI_MODEL override when CLAUDE_CODE_USE_MINIMAX is set', () => {
+  process.env.CLAUDE_CODE_USE_MINIMAX = '1'
+  process.env.OPENAI_MODEL = 'MiniMax-M2.7-highspeed'
+
+  const result = resolveProviderRequest()
+
+  expect(result.resolvedModel).toBe('MiniMax-M2.7-highspeed')
+  expect(result.requestedModel).toBe('MiniMax-M2.7-highspeed')
+})
+
+test('respects OPENAI_BASE_URL override when CLAUDE_CODE_USE_MINIMAX is set', () => {
+  process.env.CLAUDE_CODE_USE_MINIMAX = '1'
+  process.env.OPENAI_BASE_URL = 'https://custom.minimax.example.com/v1'
+
+  const result = resolveProviderRequest()
+
+  expect(result.baseUrl).toBe('https://custom.minimax.example.com/v1')
+})
+
+test('DEFAULT_MINIMAX_BASE_URL points to api.minimax.io', () => {
+  expect(DEFAULT_MINIMAX_BASE_URL).toBe('https://api.minimax.io/v1')
+})
+
+test('DEFAULT_MINIMAX_MODEL is MiniMax-M2.7', () => {
+  expect(DEFAULT_MINIMAX_MODEL).toBe('MiniMax-M2.7')
+})

--- a/src/services/api/providerConfig.ts
+++ b/src/services/api/providerConfig.ts
@@ -9,6 +9,8 @@ export const DEFAULT_OPENAI_BASE_URL = 'https://api.openai.com/v1'
 export const DEFAULT_CODEX_BASE_URL = 'https://chatgpt.com/backend-api/codex'
 /** Default GitHub Models API model when user selects copilot / github:copilot */
 export const DEFAULT_GITHUB_MODELS_API_MODEL = 'openai/gpt-4.1'
+export const DEFAULT_MINIMAX_BASE_URL = 'https://api.minimax.io/v1'
+export const DEFAULT_MINIMAX_MODEL = 'MiniMax-M2.7'
 
 const CODEX_ALIAS_MODELS: Record<
   string,
@@ -300,11 +302,12 @@ export function resolveProviderRequest(options?: {
   reasoningEffortOverride?: ReasoningEffort
 }): ResolvedProviderRequest {
   const isGithubMode = isEnvTruthy(process.env.CLAUDE_CODE_USE_GITHUB)
+  const isMiniMaxMode = isEnvTruthy(process.env.CLAUDE_CODE_USE_MINIMAX)
   const requestedModel =
     options?.model?.trim() ||
     process.env.OPENAI_MODEL?.trim() ||
     options?.fallbackModel?.trim() ||
-    (isGithubMode ? 'github:copilot' : 'gpt-4o')
+    (isGithubMode ? 'github:copilot' : isMiniMaxMode ? DEFAULT_MINIMAX_MODEL : 'gpt-4o')
   const descriptor = parseModelDescriptor(requestedModel)
   const rawBaseUrl =
     asEnvUrl(options?.baseUrl) ??
@@ -334,7 +337,9 @@ export function resolveProviderRequest(options?: {
       (rawBaseUrl ??
         (transport === 'codex_responses'
           ? DEFAULT_CODEX_BASE_URL
-          : DEFAULT_OPENAI_BASE_URL)
+          : isMiniMaxMode
+            ? DEFAULT_MINIMAX_BASE_URL
+            : DEFAULT_OPENAI_BASE_URL)
       ).replace(/\/+$/, ''),
     reasoning,
   }
@@ -346,7 +351,8 @@ export function getAdditionalModelOptionsCacheScope(): string | null {
         !isEnvTruthy(process.env.CLAUDE_CODE_USE_GITHUB) &&
         !isEnvTruthy(process.env.CLAUDE_CODE_USE_BEDROCK) &&
         !isEnvTruthy(process.env.CLAUDE_CODE_USE_VERTEX) &&
-        !isEnvTruthy(process.env.CLAUDE_CODE_USE_FOUNDRY)) {
+        !isEnvTruthy(process.env.CLAUDE_CODE_USE_FOUNDRY) &&
+        !isEnvTruthy(process.env.CLAUDE_CODE_USE_MINIMAX)) {
       return 'firstParty'
     }
     return null

--- a/src/utils/model/providers.ts
+++ b/src/utils/model/providers.ts
@@ -11,23 +11,26 @@ export type APIProvider =
   | 'gemini'
   | 'github'
   | 'codex'
+  | 'minimax'
 
 export function getAPIProvider(): APIProvider {
   return isEnvTruthy(process.env.CLAUDE_CODE_USE_GEMINI)
     ? 'gemini'
     : isEnvTruthy(process.env.CLAUDE_CODE_USE_GITHUB)
       ? 'github'
-      : isEnvTruthy(process.env.CLAUDE_CODE_USE_OPENAI)
-        ? isCodexModel()
-          ? 'codex'
-          : 'openai'
-        : isEnvTruthy(process.env.CLAUDE_CODE_USE_BEDROCK)
-          ? 'bedrock'
-          : isEnvTruthy(process.env.CLAUDE_CODE_USE_VERTEX)
-            ? 'vertex'
-            : isEnvTruthy(process.env.CLAUDE_CODE_USE_FOUNDRY)
-              ? 'foundry'
-              : 'firstParty'
+      : isEnvTruthy(process.env.CLAUDE_CODE_USE_MINIMAX)
+        ? 'minimax'
+        : isEnvTruthy(process.env.CLAUDE_CODE_USE_OPENAI)
+          ? isCodexModel()
+            ? 'codex'
+            : 'openai'
+          : isEnvTruthy(process.env.CLAUDE_CODE_USE_BEDROCK)
+            ? 'bedrock'
+            : isEnvTruthy(process.env.CLAUDE_CODE_USE_VERTEX)
+              ? 'vertex'
+              : isEnvTruthy(process.env.CLAUDE_CODE_USE_FOUNDRY)
+                ? 'foundry'
+                : 'firstParty'
 }
 
 export function usesAnthropicAccountFlow(): boolean {


### PR DESCRIPTION
## Summary

Add MiniMax as a first-class provider for OpenClaude by introducing a dedicated `CLAUDE_CODE_USE_MINIMAX` flag that routes through the existing OpenAI-compatible shim.

- Add `minimax` to `APIProvider` union type and `getAPIProvider()` detection logic
- Route `CLAUDE_CODE_USE_MINIMAX=1` through the existing OpenAI-compatible shim (no new shim needed)
- Default base URL: `https://api.minimax.io/v1`, default model: `MiniMax-M2.7`
- Support `MINIMAX_API_KEY` for authentication (falls back to `OPENAI_API_KEY`)
- Add 6 unit tests in `providerConfig.minimax.test.ts`
- Document provider in `.env.example`

## Usage

```sh
CLAUDE_CODE_USE_MINIMAX=1 \
MINIMAX_API_KEY=sk-... \
openclaude
```

## Test plan

- [x] 6 new unit tests pass
- [x] 68 total tests pass (no regressions)
- [x] Build succeeds: `bun run build`
- [x] Smoke test passes: `bun run smoke`

## API Reference

Chat (OpenAI Compatible): https://platform.minimax.io/docs/api-reference/text-openai-api