### PR TITLE
security: never store API keys in profile file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ GEMINI.md
 package-lock.json
 /.claude
 coverage/
+.cursor/

--- a/bin/oc
+++ b/bin/oc
@@ -1,0 +1,39 @@
+#!/bin/bash
+# OpenClaude wrapper that loads .env before execution
+# Usage: ./bin/oc [args...]
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
+ENV_FILE="$PROJECT_DIR/.env"
+
+# Load .env if it exists
+if [ -f "$ENV_FILE" ]; then
+  set -a
+  while IFS='=' read -r key value || [ -n "$key" ]; do
+    # Skip comments and empty lines
+    [[ "$key" =~ ^[[:space:]]*# ]] && continue
+    [[ -z "$key" ]] && continue
+    
+    # Trim whitespace
+    key=$(echo "$key" | xargs)
+    value=$(echo "$value" | xargs)
+    
+    # Skip if no value
+    [[ -z "$value" ]] && continue
+    
+    # Remove surrounding quotes if present
+    value="${value%\"}"
+    value="${value#\"}"
+    value="${value%\'}"
+    value="${value#\'}"
+    
+    # Export only if not already set (shell takes precedence)
+    if [ -z "${!key+x}" ]; then
+      export "$key=$value"
+    fi
+  done < "$ENV_FILE"
+  set +a
+fi
+
+# Run openclaude with all passed arguments
+exec openclaude "$@"

--- a/bin/oc
+++ b/bin/oc
@@ -2,9 +2,9 @@
 # OpenClaude wrapper that loads .env before execution
 # Usage: ./bin/oc [args...]
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
-ENV_FILE="$PROJECT_DIR/.env"
+# Load .env from the CURRENT WORKING DIRECTORY, not the wrapper location
+# This ensures each project can have its own .env configuration
+ENV_FILE="${PWD}/.env"
 
 # Load .env if it exists
 if [ -f "$ENV_FILE" ]; then

--- a/scripts/provider-bootstrap.ts
+++ b/scripts/provider-bootstrap.ts
@@ -156,15 +156,17 @@ async function main(): Promise<void> {
     if (!builtEnv) {
       const credentials = resolveCodexApiCredentials(process.env)
       const authHint = credentials.authPath
-        ? ` or make sure ${credentials.authPath} exists`
+        ? `make sure ${credentials.authPath} exists`
         : ''
       if (!credentials.apiKey) {
         console.error('Codex profile requires an API key.')
         console.error('')
         console.error('Set CODEX_API_KEY in your .env file:')
         console.error('  CODEX_API_KEY=your-key-here')
-        console.error('')
-        console.error(`Alternative: ${authHint}`)
+        if (authHint) {
+          console.error('')
+          console.error(`Alternative: ${authHint}`)
+        }
       } else {
         console.error('Codex profile requires CHATGPT_ACCOUNT_ID or an auth.json that includes it.')
       }

--- a/scripts/provider-bootstrap.ts
+++ b/scripts/provider-bootstrap.ts
@@ -1,32 +1,33 @@
 // @ts-nocheck
 import {
-  resolveCodexApiCredentials,
+    resolveCodexApiCredentials,
 } from '../src/services/api/providerConfig.js'
 import {
-  getGoalDefaultOpenAIModel,
-  normalizeRecommendationGoal,
-  recommendOllamaModel,
-} from '../src/utils/providerRecommendation.ts'
-import {
-  buildAtomicChatProfileEnv,
-  buildCodexProfileEnv,
-  buildGeminiProfileEnv,
-  buildOllamaProfileEnv,
-  buildOpenAIProfileEnv,
-  createProfileFile,
-  saveProfileFile,
-  selectAutoProfile,
-  type ProfileFile,
-  type ProviderProfile,
+    buildAtomicChatProfileEnv,
+    buildCodexProfileEnv,
+    buildGeminiProfileEnv,
+    buildOllamaProfileEnv,
+    buildOpenAIProfileEnv,
+    createProfileFile,
+    saveProfileFile,
+    selectAutoProfile,
+    type ProfileFile,
+    type ProviderProfile,
 } from '../src/utils/providerProfile.ts'
 import {
-  getAtomicChatChatBaseUrl,
-  getOllamaChatBaseUrl,
-  hasLocalAtomicChat,
-  hasLocalOllama,
-  listAtomicChatModels,
-  listOllamaModels,
+    getGoalDefaultOpenAIModel,
+    normalizeRecommendationGoal,
+    recommendOllamaModel,
+} from '../src/utils/providerRecommendation.ts'
+import {
+    getAtomicChatChatBaseUrl,
+    getOllamaChatBaseUrl,
+    hasLocalAtomicChat,
+    hasLocalOllama,
+    listAtomicChatModels,
+    listOllamaModels,
 } from './provider-discovery.ts'
+import { loadDotEnvFile } from '../src/utils/dotenv.ts'
 
 function parseArg(name: string): string | null {
   const args = process.argv.slice(2)
@@ -53,14 +54,34 @@ async function resolveOllamaModel(
   return recommended?.name ?? null
 }
 
+function printSecurityNote(): void {
+  console.log('')
+  console.log('SECURITY NOTE:')
+  console.log('  API keys are NOT stored in the profile file.')
+  console.log('  Set your API key in the .env file:')
+  console.log('    GEMINI_API_KEY=your-key-here')
+  console.log('    OPENAI_API_KEY=your-key-here')
+  console.log('    CODEX_API_KEY=your-key-here')
+  console.log('')
+}
+
 async function main(): Promise<void> {
+  // Load .env file so API keys are available for validation
+  loadDotEnvFile()
+
   const provider = parseProviderArg()
   const argModel = parseArg('--model')
   const argBaseUrl = parseArg('--base-url')
-  const argApiKey = parseArg('--api-key')
   const goal = normalizeRecommendationGoal(
     parseArg('--goal') || process.env.OPENCLAUDE_PROFILE_GOAL,
   )
+
+  // Warn if deprecated --api-key is used
+  if (parseArg('--api-key')) {
+    console.warn('WARNING: --api-key is deprecated for security reasons.')
+    console.warn('         API keys should be set in the .env file instead.')
+    console.warn('')
+  }
 
   let selected: ProviderProfile
   let resolvedOllamaModel: string | null = null
@@ -80,12 +101,16 @@ async function main(): Promise<void> {
     const builtEnv = buildGeminiProfileEnv({
       model: argModel || null,
       baseUrl: argBaseUrl || null,
-      apiKey: argApiKey || null,
+      apiKey: null, // Keys come from .env, not args
       processEnv: process.env,
     })
 
     if (!builtEnv) {
-      console.error('Gemini profile requires an API key. Use --api-key or set GEMINI_API_KEY.')
+      console.error('Gemini profile requires an API key.')
+      console.error('')
+      console.error('Set GEMINI_API_KEY in your .env file:')
+      console.error('  GEMINI_API_KEY=your-key-here')
+      console.error('')
       console.error('Get a free key at: https://aistudio.google.com/apikey')
       process.exit(1)
     }
@@ -124,21 +149,22 @@ async function main(): Promise<void> {
     const builtEnv = buildCodexProfileEnv({
       model: argModel,
       baseUrl: argBaseUrl,
-      apiKey: argApiKey || process.env.CODEX_API_KEY || null,
+      apiKey: null, // Keys come from .env, not args
       processEnv: process.env,
     })
 
     if (!builtEnv) {
-      const credentials = resolveCodexApiCredentials(
-        argApiKey
-          ? { ...process.env, CODEX_API_KEY: argApiKey }
-          : process.env,
-      )
+      const credentials = resolveCodexApiCredentials(process.env)
       const authHint = credentials.authPath
         ? ` or make sure ${credentials.authPath} exists`
         : ''
       if (!credentials.apiKey) {
-        console.error(`Codex profile requires CODEX_API_KEY${authHint}.`)
+        console.error('Codex profile requires an API key.')
+        console.error('')
+        console.error('Set CODEX_API_KEY in your .env file:')
+        console.error('  CODEX_API_KEY=your-key-here')
+        console.error('')
+        console.error(`Alternative: ${authHint}`)
       } else {
         console.error('Codex profile requires CHATGPT_ACCOUNT_ID or an auth.json that includes it.')
       }
@@ -151,12 +177,15 @@ async function main(): Promise<void> {
       goal,
       model: argModel || null,
       baseUrl: argBaseUrl || null,
-      apiKey: argApiKey || process.env.OPENAI_API_KEY || null,
+      apiKey: null, // Keys come from .env, not args
       processEnv: process.env,
     })
 
     if (!builtEnv) {
-      console.error('OpenAI profile requires a real API key. Use --api-key or set OPENAI_API_KEY.')
+      console.error('OpenAI profile requires an API key.')
+      console.error('')
+      console.error('Set OPENAI_API_KEY in your .env file:')
+      console.error('  OPENAI_API_KEY=your-key-here')
       process.exit(1)
     }
 
@@ -171,9 +200,12 @@ async function main(): Promise<void> {
   console.log(`Goal: ${goal}`)
   console.log(`Model: ${profile.env.GEMINI_MODEL || profile.env.OPENAI_MODEL || getGoalDefaultOpenAIModel(goal)}`)
   console.log(`Path: ${outputPath}`)
+  
+  printSecurityNote()
+  
   console.log('Next: bun run dev:profile')
 }
 
 await main()
 
-export {}
+export { }

--- a/src/entrypoints/cli.tsx
+++ b/src/entrypoints/cli.tsx
@@ -96,6 +96,13 @@ async function main(): Promise<void> {
     }
   }
 
+  // Load .env file early so API keys are available for provider setup
+  // Shell environment variables take precedence over .env values
+  {
+    const { loadDotEnvFile } = await import('../utils/dotenv.js')
+    loadDotEnvFile()
+  }
+
   // Enable configs first so we can read settings
   {
     const { enableConfigs } = await import('../utils/config.js')

--- a/src/utils/dotenv.test.ts
+++ b/src/utils/dotenv.test.ts
@@ -128,6 +128,40 @@ test('loadDotEnvFile handles escaped quotes in double-quoted values', () => {
   }
 })
 
+test('loadDotEnvFile preserves literal backslashes in Windows paths', () => {
+  const tempDir = createTempDir()
+  const envContent = `CODEX_AUTH_JSON_PATH="C:\\\\new\\\\auth.json"`
+  writeFileSync(join(tempDir, '.env'), envContent)
+  
+  const originalPath = process.env.CODEX_AUTH_JSON_PATH
+  delete process.env.CODEX_AUTH_JSON_PATH
+  
+  try {
+    loadDotEnvFile(tempDir)
+    assert.equal(process.env.CODEX_AUTH_JSON_PATH, 'C:\\new\\auth.json')
+  } finally {
+    process.env.CODEX_AUTH_JSON_PATH = originalPath
+    cleanup(tempDir)
+  }
+})
+
+test('loadDotEnvFile handles mixed escapes correctly', () => {
+  const tempDir = createTempDir()
+  const envContent = `MIXED="line1\\nC:\\\\path\\\\file.txt"`
+  writeFileSync(join(tempDir, '.env'), envContent)
+  
+  const originalMixed = process.env.MIXED
+  delete process.env.MIXED
+  
+  try {
+    loadDotEnvFile(tempDir)
+    assert.equal(process.env.MIXED, 'line1\nC:\\path\\file.txt')
+  } finally {
+    process.env.MIXED = originalMixed
+    cleanup(tempDir)
+  }
+})
+
 test('loadDotEnvFile does not override existing env vars', () => {
   const tempDir = createTempDir()
   const envContent = `FOO=from-file`

--- a/src/utils/dotenv.test.ts
+++ b/src/utils/dotenv.test.ts
@@ -1,0 +1,201 @@
+import assert from 'node:assert/strict'
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import test from 'node:test'
+
+import { loadDotEnvFile, hasDotEnvFile } from './dotenv.ts'
+
+function createTempDir(): string {
+  return mkdtempSync(join(tmpdir(), 'dotenv-test-'))
+}
+
+function cleanup(dir: string): void {
+  rmSync(dir, { recursive: true, force: true })
+}
+
+test('loadDotEnvFile loads simple key-value pairs', () => {
+  const tempDir = createTempDir()
+  const envContent = `
+FOO=bar
+BAZ=qux
+`
+  writeFileSync(join(tempDir, '.env'), envContent)
+  
+  const originalFoo = process.env.FOO
+  const originalBaz = process.env.BAZ
+  delete process.env.FOO
+  delete process.env.BAZ
+  
+  try {
+    loadDotEnvFile(tempDir)
+    assert.equal(process.env.FOO, 'bar')
+    assert.equal(process.env.BAZ, 'qux')
+  } finally {
+    process.env.FOO = originalFoo
+    process.env.BAZ = originalBaz
+    cleanup(tempDir)
+  }
+})
+
+test('loadDotEnvFile ignores comments', () => {
+  const tempDir = createTempDir()
+  const envContent = `
+# This is a comment
+FOO=bar
+# Another comment
+BAZ=qux
+`
+  writeFileSync(join(tempDir, '.env'), envContent)
+  
+  const originalFoo = process.env.FOO
+  delete process.env.FOO
+  
+  try {
+    loadDotEnvFile(tempDir)
+    assert.equal(process.env.FOO, 'bar')
+  } finally {
+    process.env.FOO = originalFoo
+    cleanup(tempDir)
+  }
+})
+
+test('loadDotEnvFile handles double-quoted values', () => {
+  const tempDir = createTempDir()
+  const envContent = `FOO="hello world"`
+  writeFileSync(join(tempDir, '.env'), envContent)
+  
+  const originalFoo = process.env.FOO
+  delete process.env.FOO
+  
+  try {
+    loadDotEnvFile(tempDir)
+    assert.equal(process.env.FOO, 'hello world')
+  } finally {
+    process.env.FOO = originalFoo
+    cleanup(tempDir)
+  }
+})
+
+test('loadDotEnvFile handles single-quoted values', () => {
+  const tempDir = createTempDir()
+  const envContent = `FOO='hello world'`
+  writeFileSync(join(tempDir, '.env'), envContent)
+  
+  const originalFoo = process.env.FOO
+  delete process.env.FOO
+  
+  try {
+    loadDotEnvFile(tempDir)
+    assert.equal(process.env.FOO, 'hello world')
+  } finally {
+    process.env.FOO = originalFoo
+    cleanup(tempDir)
+  }
+})
+
+test('loadDotEnvFile handles escape sequences in double-quoted values', () => {
+  const tempDir = createTempDir()
+  const envContent = `FOO="line1\\nline2"`
+  writeFileSync(join(tempDir, '.env'), envContent)
+  
+  const originalFoo = process.env.FOO
+  delete process.env.FOO
+  
+  try {
+    loadDotEnvFile(tempDir)
+    assert.equal(process.env.FOO, 'line1\nline2')
+  } finally {
+    process.env.FOO = originalFoo
+    cleanup(tempDir)
+  }
+})
+
+test('loadDotEnvFile handles escaped quotes in double-quoted values', () => {
+  const tempDir = createTempDir()
+  const envContent = `KEY="a\\"b"`
+  writeFileSync(join(tempDir, '.env'), envContent)
+  
+  const originalKey = process.env.KEY
+  delete process.env.KEY
+  
+  try {
+    loadDotEnvFile(tempDir)
+    assert.equal(process.env.KEY, 'a"b')
+  } finally {
+    process.env.KEY = originalKey
+    cleanup(tempDir)
+  }
+})
+
+test('loadDotEnvFile does not override existing env vars', () => {
+  const tempDir = createTempDir()
+  const envContent = `FOO=from-file`
+  writeFileSync(join(tempDir, '.env'), envContent)
+  
+  const originalFoo = process.env.FOO
+  process.env.FOO = 'from-shell'
+  
+  try {
+    loadDotEnvFile(tempDir)
+    assert.equal(process.env.FOO, 'from-shell')
+  } finally {
+    process.env.FOO = originalFoo
+    cleanup(tempDir)
+  }
+})
+
+test('loadDotEnvFile removes inline comments from unquoted values', () => {
+  const tempDir = createTempDir()
+  const envContent = `FOO=bar # this is a comment`
+  writeFileSync(join(tempDir, '.env'), envContent)
+  
+  const originalFoo = process.env.FOO
+  delete process.env.FOO
+  
+  try {
+    loadDotEnvFile(tempDir)
+    assert.equal(process.env.FOO, 'bar')
+  } finally {
+    process.env.FOO = originalFoo
+    cleanup(tempDir)
+  }
+})
+
+test('loadDotEnvFile handles empty file gracefully', () => {
+  const tempDir = createTempDir()
+  writeFileSync(join(tempDir, '.env'), '')
+  
+  try {
+    loadDotEnvFile(tempDir)
+  } finally {
+    cleanup(tempDir)
+  }
+})
+
+test('loadDotEnvFile handles non-existent file gracefully', () => {
+  const tempDir = createTempDir()
+  loadDotEnvFile(tempDir)
+  cleanup(tempDir)
+})
+
+test('hasDotEnvFile returns true when .env exists', () => {
+  const tempDir = createTempDir()
+  writeFileSync(join(tempDir, '.env'), 'FOO=bar')
+  
+  try {
+    assert.equal(hasDotEnvFile(tempDir), true)
+  } finally {
+    cleanup(tempDir)
+  }
+})
+
+test('hasDotEnvFile returns false when .env does not exist', () => {
+  const tempDir = createTempDir()
+  
+  try {
+    assert.equal(hasDotEnvFile(tempDir), false)
+  } finally {
+    cleanup(tempDir)
+  }
+})

--- a/src/utils/dotenv.ts
+++ b/src/utils/dotenv.ts
@@ -16,7 +16,14 @@ export function loadDotEnvFile(cwd?: string): void {
   const envPath = resolve(cwd ?? process.cwd(), '.env')
   if (!existsSync(envPath)) return
 
-  const content = readFileSync(envPath, 'utf8')
+  let content: string
+  try {
+    content = readFileSync(envPath, 'utf8')
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    console.warn(`Warning: Failed to read .env file at ${envPath}: ${message}`)
+    return
+  }
   
   for (const line of content.split('\n')) {
     const trimmed = line.trim()
@@ -34,8 +41,14 @@ export function loadDotEnvFile(cwd?: string): void {
     // Handle quoted values
     const trimmedValue = value.trim()
     if (trimmedValue.startsWith('"')) {
-      // Double-quoted: find closing quote
-      const endQuote = trimmedValue.indexOf('"', 1)
+      // Double-quoted: find unescaped closing quote
+      let endQuote = -1
+      for (let i = 1; i < trimmedValue.length; i++) {
+        if (trimmedValue[i] === '"' && trimmedValue[i - 1] !== '\\') {
+          endQuote = i
+          break
+        }
+      }
       if (endQuote !== -1) {
         value = trimmedValue.slice(1, endQuote)
         // Handle escape sequences in double-quoted strings

--- a/src/utils/dotenv.ts
+++ b/src/utils/dotenv.ts
@@ -52,12 +52,16 @@ export function loadDotEnvFile(cwd?: string): void {
       if (endQuote !== -1) {
         value = trimmedValue.slice(1, endQuote)
         // Handle escape sequences in double-quoted strings
+        // IMPORTANT: Process \\ FIRST using a placeholder to preserve literal backslashes
+        // This ensures "C:\\new\\path" stays as "C:\new\path" not "C:\n..."
+        const BACKSLASH_PLACEHOLDER = '\x00BACKSLASH\x00'
         value = value
+          .replace(/\\\\/g, BACKSLASH_PLACEHOLDER)
           .replace(/\\n/g, '\n')
           .replace(/\\r/g, '\r')
           .replace(/\\t/g, '\t')
           .replace(/\\"/g, '"')
-          .replace(/\\\\/g, '\\')
+          .replace(new RegExp(BACKSLASH_PLACEHOLDER, 'g'), '\\')
       } else {
         value = trimmedValue.slice(1)
       }

--- a/src/utils/dotenv.ts
+++ b/src/utils/dotenv.ts
@@ -1,0 +1,86 @@
+import { existsSync, readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+/**
+ * Load environment variables from a .env file into process.env.
+ * 
+ * Features:
+ * - Ignores comments (lines starting with #)
+ * - Handles quoted values (single and double quotes)
+ * - Does NOT override existing environment variables (shell takes precedence)
+ * - Supports inline comments after values
+ * 
+ * @param cwd - Working directory to look for .env file (defaults to process.cwd())
+ */
+export function loadDotEnvFile(cwd?: string): void {
+  const envPath = resolve(cwd ?? process.cwd(), '.env')
+  if (!existsSync(envPath)) return
+
+  const content = readFileSync(envPath, 'utf8')
+  
+  for (const line of content.split('\n')) {
+    const trimmed = line.trim()
+    
+    if (!trimmed || trimmed.startsWith('#')) continue
+
+    const eqIndex = trimmed.indexOf('=')
+    if (eqIndex === -1) continue
+
+    const key = trimmed.slice(0, eqIndex).trim()
+    if (!key) continue
+
+    let value = trimmed.slice(eqIndex + 1)
+    
+    // Handle quoted values
+    const trimmedValue = value.trim()
+    if (trimmedValue.startsWith('"')) {
+      // Double-quoted: find closing quote
+      const endQuote = trimmedValue.indexOf('"', 1)
+      if (endQuote !== -1) {
+        value = trimmedValue.slice(1, endQuote)
+        // Handle escape sequences in double-quoted strings
+        value = value
+          .replace(/\\n/g, '\n')
+          .replace(/\\r/g, '\r')
+          .replace(/\\t/g, '\t')
+          .replace(/\\"/g, '"')
+          .replace(/\\\\/g, '\\')
+      } else {
+        value = trimmedValue.slice(1)
+      }
+    } else if (trimmedValue.startsWith("'")) {
+      // Single-quoted: find closing quote (no escape processing)
+      const endQuote = trimmedValue.indexOf("'", 1)
+      if (endQuote !== -1) {
+        value = trimmedValue.slice(1, endQuote)
+      } else {
+        value = trimmedValue.slice(1)
+      }
+    } else {
+      // Unquoted: trim and remove inline comments
+      value = trimmedValue
+      const commentIndex = value.indexOf(' #')
+      if (commentIndex !== -1) {
+        value = value.slice(0, commentIndex)
+      }
+      value = value.trim()
+    }
+
+    // Do NOT override existing environment variables
+    // Shell environment takes precedence over .env file
+    if (process.env[key] === undefined) {
+      process.env[key] = value
+    }
+  }
+}
+
+/**
+ * Check if a .env file exists in the given directory.
+ * 
+ * @param cwd - Working directory to check (defaults to process.cwd())
+ * @returns true if .env file exists
+ */
+export function hasDotEnvFile(cwd?: string): boolean {
+  const envPath = resolve(cwd ?? process.cwd(), '.env')
+  return existsSync(envPath)
+}

--- a/src/utils/providerProfile.test.ts
+++ b/src/utils/providerProfile.test.ts
@@ -119,12 +119,12 @@ test('openai launch ignores codex shell transport hints', async () => {
 })
 
 test('openai launch ignores codex persisted transport hints', async () => {
+  // SECURITY: Profile should not contain API keys - they come from processEnv
   const env = await buildLaunchEnv({
     profile: 'openai',
     persisted: profile('openai', {
       OPENAI_BASE_URL: 'https://chatgpt.com/backend-api/codex',
       OPENAI_MODEL: 'codexplan',
-      OPENAI_API_KEY: 'sk-persisted',
     }),
     goal: 'balanced',
     processEnv: {
@@ -138,21 +138,23 @@ test('openai launch ignores codex persisted transport hints', async () => {
 })
 
 test('matching persisted gemini env is reused for gemini launch', async () => {
+  // SECURITY: API key comes from processEnv (.env), not from persisted profile
   const env = await buildLaunchEnv({
     profile: 'gemini',
     persisted: profile('gemini', {
       GEMINI_MODEL: 'gemini-2.5-flash',
-      GEMINI_API_KEY: 'gem-persisted',
       GEMINI_BASE_URL: 'https://example.test/v1beta/openai',
     }),
     goal: 'balanced',
-    processEnv: {},
+    processEnv: {
+      GEMINI_API_KEY: 'gem-from-env',
+    },
   })
 
   assert.equal(env.CLAUDE_CODE_USE_GEMINI, '1')
   assert.equal(env.CLAUDE_CODE_USE_OPENAI, undefined)
   assert.equal(env.GEMINI_MODEL, 'gemini-2.5-flash')
-  assert.equal(env.GEMINI_API_KEY, 'gem-persisted')
+  assert.equal(env.GEMINI_API_KEY, 'gem-from-env')
   assert.equal(env.GEMINI_BASE_URL, 'https://example.test/v1beta/openai')
 })
 
@@ -192,23 +194,24 @@ test('gemini launch ignores mismatched persisted openai env and strips other pro
 })
 
 test('matching persisted codex env is reused for codex launch', async () => {
+  // SECURITY: API key comes from processEnv (.env), not from persisted profile
   const env = await buildLaunchEnv({
     profile: 'codex',
     persisted: profile('codex', {
       OPENAI_BASE_URL: 'https://chatgpt.com/backend-api/codex',
       OPENAI_MODEL: 'codexspark',
-      CODEX_API_KEY: 'codex-persisted',
       CHATGPT_ACCOUNT_ID: 'acct_persisted',
     }),
     goal: 'balanced',
     processEnv: {
+      CODEX_API_KEY: 'codex-from-env',
       CODEX_AUTH_JSON_PATH: missingCodexAuthPath,
     },
   })
 
   assert.equal(env.OPENAI_BASE_URL, 'https://chatgpt.com/backend-api/codex')
   assert.equal(env.OPENAI_MODEL, 'codexspark')
-  assert.equal(env.CODEX_API_KEY, 'codex-persisted')
+  assert.equal(env.CODEX_API_KEY, 'codex-from-env')
   assert.equal(env.CHATGPT_ACCOUNT_ID, 'acct_persisted')
 })
 
@@ -256,12 +259,13 @@ test('codex launch ignores mismatched persisted openai env', async () => {
 })
 
 test('codex launch ignores placeholder codex env keys', async () => {
+  // SECURITY: Profile should not contain API keys
+  // When processEnv has a placeholder, the key should be undefined
   const env = await buildLaunchEnv({
     profile: 'codex',
     persisted: profile('codex', {
       OPENAI_BASE_URL: 'https://chatgpt.com/backend-api/codex',
       OPENAI_MODEL: 'codexspark',
-      CODEX_API_KEY: 'codex-persisted',
       CHATGPT_ACCOUNT_ID: 'acct_persisted',
     }),
     goal: 'balanced',
@@ -271,7 +275,8 @@ test('codex launch ignores placeholder codex env keys', async () => {
     },
   })
 
-  assert.equal(env.CODEX_API_KEY, 'codex-persisted')
+  // Placeholder 'SUA_CHAVE' is sanitized to undefined
+  assert.equal(env.CODEX_API_KEY, undefined)
   assert.equal(env.CHATGPT_ACCOUNT_ID, 'acct_persisted')
 })
 
@@ -347,17 +352,17 @@ test('codex profiles require a chatgpt account id', () => {
   assert.equal(env, null)
 })
 
-test('gemini profiles accept google api key fallback', () => {
+test('gemini profiles accept google api key fallback but do not store it', () => {
   const env = buildGeminiProfileEnv({
     processEnv: {
       GOOGLE_API_KEY: 'gem-live',
     },
   })
 
+  // SECURITY: API keys are NOT stored in profile - they come from .env at runtime
   assert.deepEqual(env, {
     GEMINI_AUTH_MODE: 'api-key',
     GEMINI_MODEL: 'gemini-2.0-flash',
-    GEMINI_API_KEY: 'gem-live',
   })
 })
 
@@ -399,9 +404,10 @@ test('saveProfileFile writes a profile that loadProfileFile can read back', () =
   const cwd = mkdtempSync(join(tmpdir(), 'openclaude-profile-file-'))
 
   try {
+    // SECURITY: Profile file should NOT contain API keys
     const persisted = createProfileFile('openai', {
-      OPENAI_API_KEY: 'sk-test',
       OPENAI_MODEL: 'gpt-4o',
+      OPENAI_BASE_URL: 'https://api.openai.com/v1',
     })
 
     const filePath = saveProfileFile(persisted, { cwd })
@@ -418,17 +424,19 @@ test('saveProfileFile writes a profile that loadProfileFile can read back', () =
 })
 
 test('buildStartupEnvFromProfile applies persisted gemini settings when no provider is explicitly selected', async () => {
+  // SECURITY: API key comes from processEnv (.env), not from persisted profile
   const env = await buildStartupEnvFromProfile({
     persisted: profile('gemini', {
-      GEMINI_API_KEY: 'gem-test',
       GEMINI_MODEL: 'gemini-2.5-flash',
     }),
-    processEnv: {},
+    processEnv: {
+      GEMINI_API_KEY: 'gem-from-env',
+    },
   })
 
   assert.equal(env.CLAUDE_CODE_USE_GEMINI, '1')
   assert.equal(env.CLAUDE_CODE_USE_OPENAI, undefined)
-  assert.equal(env.GEMINI_API_KEY, 'gem-test')
+  assert.equal(env.GEMINI_API_KEY, 'gem-from-env')
   assert.equal(env.GEMINI_MODEL, 'gemini-2.5-flash')
 })
 
@@ -510,9 +518,9 @@ test('buildStartupEnvFromProfile treats explicit falsey provider flags as user i
     CLAUDE_CODE_USE_OPENAI: '0',
   }
 
+  // SECURITY: Profile should not contain API keys
   const env = await buildStartupEnvFromProfile({
     persisted: profile('gemini', {
-      GEMINI_API_KEY: 'gem-persisted',
       GEMINI_MODEL: 'gemini-2.5-flash',
     }),
     processEnv,
@@ -565,10 +573,10 @@ test('openai profiles ignore codex shell transport hints', () => {
     },
   })
 
+  // SECURITY: API keys are NOT stored in profile
   assert.deepEqual(env, {
     OPENAI_BASE_URL: 'https://api.openai.com/v1',
     OPENAI_MODEL: 'gpt-4o',
-    OPENAI_API_KEY: 'sk-live',
   })
 })
 
@@ -583,25 +591,27 @@ test('openai profiles ignore poisoned shell model and base url values', () => {
     },
   })
 
+  // SECURITY: API keys are NOT stored in profile
   assert.deepEqual(env, {
     OPENAI_BASE_URL: 'https://api.openai.com/v1',
     OPENAI_MODEL: 'gpt-4o',
-    OPENAI_API_KEY: 'sk-live',
   })
 })
 
 test('startup env ignores poisoned persisted openai model and base url', async () => {
+  // SECURITY: API key comes from processEnv (.env), not from persisted profile
   const env = await buildStartupEnvFromProfile({
     persisted: profile('openai', {
-      OPENAI_API_KEY: 'sk-live',
       OPENAI_MODEL: 'sk-live',
       OPENAI_BASE_URL: 'sk-live',
     }),
-    processEnv: {},
+    processEnv: {
+      OPENAI_API_KEY: 'sk-from-env',
+    },
   })
 
   assert.equal(env.CLAUDE_CODE_USE_OPENAI, '1')
-  assert.equal(env.OPENAI_API_KEY, 'sk-live')
+  assert.equal(env.OPENAI_API_KEY, 'sk-from-env')
   assert.equal(env.OPENAI_MODEL, 'gpt-4o')
   assert.equal(env.OPENAI_BASE_URL, 'https://api.openai.com/v1')
 })

--- a/src/utils/providerProfile.ts
+++ b/src/utils/providerProfile.ts
@@ -649,7 +649,10 @@ export async function buildLaunchEnv(options: {
     (usePersistedOpenAIConfig ? persistedOpenAIModel : undefined) ||
     defaultOpenAIModel
   // SECURITY: Use only shell/env key, never persisted
-  env.OPENAI_API_KEY = processEnv.OPENAI_API_KEY
+  // Only set if defined to avoid propagating undefined via Object.assign
+  if (processEnv.OPENAI_API_KEY) {
+    env.OPENAI_API_KEY = processEnv.OPENAI_API_KEY
+  }
   delete env.CODEX_API_KEY
   delete env.CHATGPT_ACCOUNT_ID
   delete env.CODEX_ACCOUNT_ID

--- a/src/utils/providerProfile.ts
+++ b/src/utils/providerProfile.ts
@@ -7,13 +7,13 @@ import {
   resolveCodexApiCredentials,
   resolveProviderRequest,
 } from '../services/api/providerConfig.ts'
+import { readGeminiAccessToken } from './geminiCredentials.ts'
+import { getOllamaChatBaseUrl } from './providerDiscovery.ts'
 import {
   getGoalDefaultOpenAIModel,
   normalizeRecommendationGoal,
   type RecommendationGoal,
 } from './providerRecommendation.ts'
-import { readGeminiAccessToken } from './geminiCredentials.ts'
-import { getOllamaChatBaseUrl } from './providerDiscovery.ts'
 
 export const PROFILE_FILE_NAME = '.openclaude-profile.json'
 export const DEFAULT_GEMINI_BASE_URL =
@@ -250,9 +250,8 @@ export function buildGeminiProfileEnv(options: {
       DEFAULT_GEMINI_MODEL,
   }
 
-  if (authMode === 'api-key' && key) {
-    env.GEMINI_API_KEY = key
-  }
+  // SECURITY: Do NOT store API keys in profile file
+  // Keys will be read from .env or shell environment at runtime
 
   const baseUrl =
     sanitizeProviderConfigValue(options.baseUrl, { GEMINI_API_KEY: key }, processEnv) ||
@@ -299,6 +298,8 @@ export function buildOpenAIProfileEnv(options: {
   })
   const useShellOpenAIConfig = shellOpenAIRequest.transport === 'chat_completions'
 
+  // SECURITY: Do NOT store API keys in profile file
+  // Keys will be read from .env or shell environment at runtime
   return {
     OPENAI_BASE_URL:
       sanitizeProviderConfigValue(
@@ -316,7 +317,6 @@ export function buildOpenAIProfileEnv(options: {
       ) ||
       (useShellOpenAIConfig ? shellOpenAIModel : undefined) ||
       defaultModel,
-    OPENAI_API_KEY: key,
   }
 }
 
@@ -336,16 +336,13 @@ export function buildCodexProfileEnv(options: {
     return null
   }
 
+  // SECURITY: Do NOT store API keys in profile file
+  // Keys will be read from .env or shell environment at runtime
   const env: ProfileEnv = {
     OPENAI_BASE_URL: options.baseUrl || DEFAULT_CODEX_BASE_URL,
     OPENAI_MODEL: options.model || 'codexplan',
+    CHATGPT_ACCOUNT_ID: credentials.accountId,
   }
-
-  if (key) {
-    env.CODEX_API_KEY = key
-  }
-
-  env.CHATGPT_ACCOUNT_ID = credentials.accountId
 
   return env
 }
@@ -481,10 +478,11 @@ export async function buildLaunchEnv(options: {
   const storedGeminiAccessToken =
     options.readGeminiAccessToken?.() ?? readGeminiAccessToken()
 
+  // SECURITY: API keys are read ONLY from processEnv (shell or .env file)
+  // Never from persisted profile file
   const shellGeminiKey = sanitizeApiKey(
     processEnv.GEMINI_API_KEY ?? processEnv.GOOGLE_API_KEY,
   )
-  const persistedGeminiKey = sanitizeApiKey(persistedEnv.GEMINI_API_KEY)
   const persistedGeminiAuthMode = persistedEnv.GEMINI_AUTH_MODE
 
   if (options.profile === 'gemini') {
@@ -510,9 +508,9 @@ export async function buildLaunchEnv(options: {
       persistedGeminiAuthMode === 'adc'
         ? persistedGeminiAuthMode
         : 'api-key'
-    const geminiKey = shellGeminiKey || persistedGeminiKey
-    if (geminiAuthMode === 'api-key' && geminiKey) {
-      env.GEMINI_API_KEY = geminiKey
+    // SECURITY: Use only shell/env key, never persisted
+    if (geminiAuthMode === 'api-key' && shellGeminiKey) {
+      env.GEMINI_API_KEY = shellGeminiKey
     } else {
       delete env.GEMINI_API_KEY
     }
@@ -601,9 +599,8 @@ export async function buildLaunchEnv(options: {
     env.OPENAI_MODEL = persistedOpenAIModel || 'codexplan'
     delete env.OPENAI_API_KEY
 
-    const codexKey =
-      sanitizeApiKey(processEnv.CODEX_API_KEY) ||
-      sanitizeApiKey(persistedEnv.CODEX_API_KEY)
+    // SECURITY: Use only shell/env key, never persisted
+    const codexKey = sanitizeApiKey(processEnv.CODEX_API_KEY)
     const liveCodexCredentials = resolveCodexApiCredentials(processEnv)
     const codexAccountId =
       processEnv.CHATGPT_ACCOUNT_ID ||
@@ -651,7 +648,8 @@ export async function buildLaunchEnv(options: {
     (useShellOpenAIConfig ? shellOpenAIModel : undefined) ||
     (usePersistedOpenAIConfig ? persistedOpenAIModel : undefined) ||
     defaultOpenAIModel
-  env.OPENAI_API_KEY = processEnv.OPENAI_API_KEY || persistedEnv.OPENAI_API_KEY
+  // SECURITY: Use only shell/env key, never persisted
+  env.OPENAI_API_KEY = processEnv.OPENAI_API_KEY
   delete env.CODEX_API_KEY
   delete env.CHATGPT_ACCOUNT_ID
   delete env.CODEX_ACCOUNT_ID


### PR DESCRIPTION
BREAKING CHANGE: API keys are no longer saved in .openclaude-profile.json

## Problem

The `.openclaude-profile.json` file was storing API keys in plain text, which is a security risk even with .gitignore protection:
- Keys persist on disk without encryption
- Can be accidentally copied/shared
- Remain in system backups

## Solution

Refactored the profile system to follow security best practices:

1. **Created `src/utils/dotenv.ts`**
   - Lightweight .env parser with no external dependencies
   - Loads environment variables from .env file at startup
   - Shell environment variables take precedence over .env

2. **Modified profile builders** (`providerProfile.ts`)
   - `buildGeminiProfileEnv` no longer includes GEMINI_API_KEY
   - `buildOpenAIProfileEnv` no longer includes OPENAI_API_KEY
   - `buildCodexProfileEnv` no longer includes CODEX_API_KEY
   - `buildLaunchEnv` reads keys only from processEnv (shell/.env)

3. **Integrated .env loading** (`cli.tsx`)
   - Added loadDotEnvFile() call before profile loading
   - Ensures API keys from .env are available for provider setup

4. **Updated bootstrap script** (`provider-bootstrap.ts`)
   - Deprecated --api-key argument with warning
   - Added security note about using .env for API keys
   - Loads .env automatically for validation

5. **Created wrapper script** (`bin/oc`)
   - Loads .env before running global openclaude
   - Useful until changes are published to npm

## Priority Order (after change)

1. Shell environment (highest priority)
2. .env file (loaded at startup)
3. Profile file (model, base_url, auth_mode only - NO keys)

## Migration

Users must move their API keys from .openclaude-profile.json to .env:

```bash
# .env
GEMINI_API_KEY=your-key-here
OPENAI_API_KEY=your-key-here
```

Files modified:
- src/utils/dotenv.ts (new)
- src/utils/providerProfile.ts
- src/utils/providerProfile.test.ts
- src/entrypoints/cli.tsx
- scripts/provider-bootstrap.ts
- bin/oc (new)
- .gitignore

Made-with: Cursor

## Summary

- what changed
- why it changed

## Impact

- user-facing impact:
- developer/maintainer impact:

## Testing

- [ ] `bun run build`
- [ ] `bun run smoke`
- [ ] focused tests:

## Notes

- provider/model path tested:
- screenshots attached (if UI changed):
- follow-up work or known limitations:
