### PR TITLE
fix: rebrand prompt identity to openclaude

### DIFF
--- a/src/constants/promptIdentity.test.ts
+++ b/src/constants/promptIdentity.test.ts
@@ -2,8 +2,11 @@ import { afterEach, expect, test } from 'bun:test'
 
 import { getSystemPrompt, DEFAULT_AGENT_PROMPT } from './prompts.js'
 import { CLI_SYSPROMPT_PREFIXES, getCLISyspromptPrefix } from './system.js'
+import { CLAUDE_CODE_GUIDE_AGENT } from '../tools/AgentTool/built-in/claudeCodeGuideAgent.js'
 import { GENERAL_PURPOSE_AGENT } from '../tools/AgentTool/built-in/generalPurposeAgent.js'
 import { EXPLORE_AGENT } from '../tools/AgentTool/built-in/exploreAgent.js'
+import { PLAN_AGENT } from '../tools/AgentTool/built-in/planAgent.js'
+import { STATUSLINE_SETUP_AGENT } from '../tools/AgentTool/built-in/statuslineSetup.js'
 
 const originalSimpleEnv = process.env.CLAUDE_CODE_SIMPLE
 
@@ -13,10 +16,12 @@ afterEach(() => {
 
 test('CLI identity prefixes describe OpenClaude instead of Claude Code', () => {
   expect(getCLISyspromptPrefix()).toContain('OpenClaude')
+  expect(getCLISyspromptPrefix()).not.toContain('Claude Code')
   expect(getCLISyspromptPrefix()).not.toContain("Anthropic's official CLI for Claude")
 
   for (const prefix of CLI_SYSPROMPT_PREFIXES) {
     expect(prefix).toContain('OpenClaude')
+    expect(prefix).not.toContain('Claude Code')
     expect(prefix).not.toContain("Anthropic's official CLI for Claude")
   }
 })
@@ -27,22 +32,50 @@ test('simple mode identity describes OpenClaude instead of Claude Code', async (
   const prompt = await getSystemPrompt([], 'gpt-4o')
 
   expect(prompt[0]).toContain('OpenClaude')
+  expect(prompt[0]).not.toContain('Claude Code')
   expect(prompt[0]).not.toContain("Anthropic's official CLI for Claude")
 })
 
 test('built-in agent prompts describe OpenClaude instead of Claude Code', () => {
   expect(DEFAULT_AGENT_PROMPT).toContain('OpenClaude')
+  expect(DEFAULT_AGENT_PROMPT).not.toContain('Claude Code')
   expect(DEFAULT_AGENT_PROMPT).not.toContain("Anthropic's official CLI for Claude")
 
   const generalPrompt = GENERAL_PURPOSE_AGENT.getSystemPrompt({
     toolUseContext: { options: {} as never },
   })
   expect(generalPrompt).toContain('OpenClaude')
+  expect(generalPrompt).not.toContain('Claude Code')
   expect(generalPrompt).not.toContain("Anthropic's official CLI for Claude")
 
   const explorePrompt = EXPLORE_AGENT.getSystemPrompt({
     toolUseContext: { options: {} as never },
   })
   expect(explorePrompt).toContain('OpenClaude')
+  expect(explorePrompt).not.toContain('Claude Code')
   expect(explorePrompt).not.toContain("Anthropic's official CLI for Claude")
+
+  const planPrompt = PLAN_AGENT.getSystemPrompt({
+    toolUseContext: { options: {} as never },
+  })
+  expect(planPrompt).toContain('OpenClaude')
+  expect(planPrompt).not.toContain('Claude Code')
+
+  const statuslinePrompt = STATUSLINE_SETUP_AGENT.getSystemPrompt({
+    toolUseContext: { options: {} as never },
+  })
+  expect(statuslinePrompt).toContain('OpenClaude')
+  expect(statuslinePrompt).not.toContain('Claude Code')
+
+  const guidePrompt = CLAUDE_CODE_GUIDE_AGENT.getSystemPrompt({
+    toolUseContext: {
+      options: {
+        commands: [],
+        agentDefinitions: { activeAgents: [] },
+        mcpClients: [],
+      } as never,
+    },
+  })
+  expect(guidePrompt).toContain('OpenClaude')
+  expect(guidePrompt).not.toContain('Claude Code')
 })

--- a/src/constants/promptIdentity.test.ts
+++ b/src/constants/promptIdentity.test.ts
@@ -77,5 +77,8 @@ test('built-in agent prompts describe OpenClaude instead of Claude Code', () => 
     },
   })
   expect(guidePrompt).toContain('OpenClaude')
-  expect(guidePrompt).not.toContain('Claude Code')
+  expect(guidePrompt).toContain('You are the OpenClaude guide agent.')
+  expect(guidePrompt).toContain('**OpenClaude** (the CLI tool)')
+  expect(guidePrompt).not.toContain('You are the Claude guide agent.')
+  expect(guidePrompt).not.toContain('**Claude Code** (the CLI tool)')
 })

--- a/src/constants/prompts.ts
+++ b/src/constants/prompts.ts
@@ -214,7 +214,7 @@ function getSimpleDoingTasksSection(): string {
   ]
 
   const userHelpSubitems = [
-    `/help: Get help with using Claude Code`,
+    `/help: Get help with using OpenClaude`,
     `To give feedback, users should ${MACRO.ISSUES_EXPLAINER}`,
   ]
 
@@ -242,7 +242,7 @@ function getSimpleDoingTasksSection(): string {
       : []),
     ...(process.env.USER_TYPE === 'ant'
       ? [
-          `If the user reports a bug, slowness, or unexpected behavior with Claude Code itself (as opposed to asking you to fix their own code), recommend the appropriate slash command: /issue for model-related problems (odd outputs, wrong tool choices, hallucinations, refusals), or /share to upload the full session transcript for product bugs, crashes, slowness, or general issues. Only recommend these when the user is describing a problem with Claude Code.`,
+          `If the user reports a bug, slowness, or unexpected behavior with OpenClaude itself (as opposed to asking you to fix their own code), recommend the appropriate slash command: /issue for model-related problems (odd outputs, wrong tool choices, hallucinations, refusals), or /share to upload the full session transcript for product bugs, crashes, slowness, or general issues. Only recommend these when the user is describing a problem with OpenClaude.`,
         ]
       : []),
     `If the user asks for help or wants to give feedback inform them of the following:`,
@@ -449,7 +449,7 @@ export async function getSystemPrompt(
 ): Promise<string[]> {
   if (isEnvTruthy(process.env.CLAUDE_CODE_SIMPLE)) {
     return [
-      `You are OpenClaude, an open-source fork of Claude Code.\n\nCWD: ${getCwd()}\nDate: ${getSessionStartDate()}`,
+      `You are OpenClaude, an open-source coding agent and CLI.\n\nCWD: ${getCwd()}\nDate: ${getSessionStartDate()}`,
     ]
   }
 
@@ -696,10 +696,10 @@ export async function computeSimpleEnvInfo(
       : `The most recent Claude model family is Claude 4.5/4.6. Model IDs — Opus 4.6: '${CLAUDE_4_5_OR_4_6_MODEL_IDS.opus}', Sonnet 4.6: '${CLAUDE_4_5_OR_4_6_MODEL_IDS.sonnet}', Haiku 4.5: '${CLAUDE_4_5_OR_4_6_MODEL_IDS.haiku}'. When building AI applications, default to the latest and most capable Claude models.`,
     process.env.USER_TYPE === 'ant' && isUndercover()
       ? null
-      : `Claude Code is available as a CLI in the terminal, desktop app (Mac/Windows), web app (claude.ai/code), and IDE extensions (VS Code, JetBrains).`,
+      : `OpenClaude is available as a CLI in the terminal and can be used across local development environments and IDE workflows.`,
     process.env.USER_TYPE === 'ant' && isUndercover()
       ? null
-      : `Fast mode for Claude Code uses the same ${FRONTIER_MODEL_NAME} model with faster output. It does NOT switch to a different model. It can be toggled with /fast.`,
+      : `Fast mode for OpenClaude uses the same ${FRONTIER_MODEL_NAME} model with faster output. It does NOT switch to a different model. It can be toggled with /fast.`,
   ].filter(item => item !== null)
 
   return [
@@ -755,7 +755,7 @@ export function getUnameSR(): string {
   return `${osType()} ${osRelease()}`
 }
 
-export const DEFAULT_AGENT_PROMPT = `You are an agent for OpenClaude, an open-source fork of Claude Code. Given the user's message, you should use the tools available to complete the task. Complete the task fully—don't gold-plate, but don't leave it half-done. When you complete the task, respond with a concise report covering what was done and any key findings — the caller will relay this to the user, so it only needs the essentials.`
+export const DEFAULT_AGENT_PROMPT = `You are an agent for OpenClaude, an open-source coding agent and CLI. Given the user's message, you should use the tools available to complete the task. Complete the task fully—don't gold-plate, but don't leave it half-done. When you complete the task, respond with a concise report covering what was done and any key findings — the caller will relay this to the user, so it only needs the essentials.`
 
 export async function enhanceSystemPromptWithEnvDetails(
   existingSystemPrompt: string[],

--- a/src/constants/system.ts
+++ b/src/constants/system.ts
@@ -8,11 +8,11 @@ import { getAPIProvider } from '../utils/model/providers.js'
 import { getWorkload } from '../utils/workloadContext.js'
 
 const DEFAULT_PREFIX =
-  `You are OpenClaude, an open-source fork of Claude Code.`
+  `You are OpenClaude, an open-source coding agent and CLI.`
 const AGENT_SDK_CLAUDE_CODE_PRESET_PREFIX =
-  `You are OpenClaude, an open-source fork of Claude Code, running within the Claude Agent SDK.`
+  `You are OpenClaude, an open-source coding agent and CLI running within the Claude Agent SDK.`
 const AGENT_SDK_PREFIX =
-  `You are a Claude agent running in OpenClaude, built on the Claude Agent SDK.`
+  `You are OpenClaude, built on the Claude Agent SDK.`
 
 const CLI_SYSPROMPT_PREFIX_VALUES = [
   DEFAULT_PREFIX,

--- a/src/tools/AgentTool/built-in/claudeCodeGuideAgent.ts
+++ b/src/tools/AgentTool/built-in/claudeCodeGuideAgent.ts
@@ -39,7 +39,7 @@ function getClaudeCodeGuideBasePrompt(): string {
 
 **Documentation sources:**
 
-- **OpenClaude docs** (${CLAUDE_CODE_DOCS_MAP_URL}): Fetch this for questions about the OpenClaude CLI tool, including:
+- **Claude Code docs** (${CLAUDE_CODE_DOCS_MAP_URL}): Use these as the compatibility reference for questions about the OpenClaude CLI tool, including:
   - Installation, setup, and getting started
   - Hooks (pre/post command execution)
   - Custom skills
@@ -74,7 +74,7 @@ function getClaudeCodeGuideBasePrompt(): string {
 4. Fetch the specific documentation pages
 5. Provide clear, actionable guidance based on official documentation
 6. Use ${WEB_SEARCH_TOOL_NAME} if docs don't cover the topic
-7. Reference local project files (CLAUDE.md, .openclaude/ directory) when relevant using ${localSearchHint}
+7. Reference local project files (CLAUDE.md, .claude/ directory) when relevant using ${localSearchHint}
 
 **Guidelines:**
 - Always prioritize official documentation over assumptions

--- a/src/tools/AgentTool/built-in/claudeCodeGuideAgent.ts
+++ b/src/tools/AgentTool/built-in/claudeCodeGuideAgent.ts
@@ -27,19 +27,19 @@ function getClaudeCodeGuideBasePrompt(): string {
     ? `${FILE_READ_TOOL_NAME}, \`find\`, and \`grep\``
     : `${FILE_READ_TOOL_NAME}, ${GLOB_TOOL_NAME}, and ${GREP_TOOL_NAME}`
 
-  return `You are the Claude guide agent. Your primary responsibility is helping users understand and use Claude Code, the Claude Agent SDK, and the Claude API (formerly the Anthropic API) effectively.
+  return `You are the OpenClaude guide agent. Your primary responsibility is helping users understand and use OpenClaude, the Claude Agent SDK, and the Claude API (formerly the Anthropic API) effectively.
 
 **Your expertise spans three domains:**
 
-1. **Claude Code** (the CLI tool): Installation, configuration, hooks, skills, MCP servers, keyboard shortcuts, IDE integrations, settings, and workflows.
+1. **OpenClaude** (the CLI tool): Installation, configuration, hooks, skills, MCP servers, keyboard shortcuts, IDE integrations, settings, and workflows.
 
-2. **Claude Agent SDK**: A framework for building custom AI agents based on Claude Code technology. Available for Node.js/TypeScript and Python.
+2. **Claude Agent SDK**: A framework for building custom AI agents. Available for Node.js/TypeScript and Python.
 
 3. **Claude API**: The Claude API (formerly known as the Anthropic API) for direct model interaction, tool use, and integrations.
 
 **Documentation sources:**
 
-- **Claude Code docs** (${CLAUDE_CODE_DOCS_MAP_URL}): Fetch this for questions about the Claude Code CLI tool, including:
+- **OpenClaude docs** (${CLAUDE_CODE_DOCS_MAP_URL}): Fetch this for questions about the OpenClaude CLI tool, including:
   - Installation, setup, and getting started
   - Hooks (pre/post command execution)
   - Custom skills
@@ -74,7 +74,7 @@ function getClaudeCodeGuideBasePrompt(): string {
 4. Fetch the specific documentation pages
 5. Provide clear, actionable guidance based on official documentation
 6. Use ${WEB_SEARCH_TOOL_NAME} if docs don't cover the topic
-7. Reference local project files (CLAUDE.md, .claude/ directory) when relevant using ${localSearchHint}
+7. Reference local project files (CLAUDE.md, .openclaude/ directory) when relevant using ${localSearchHint}
 
 **Guidelines:**
 - Always prioritize official documentation over assumptions
@@ -97,7 +97,7 @@ function getFeedbackGuideline(): string {
 
 export const CLAUDE_CODE_GUIDE_AGENT: BuiltInAgentDefinition = {
   agentType: CLAUDE_CODE_GUIDE_AGENT_TYPE,
-  whenToUse: `Use this agent when the user asks questions ("Can Claude...", "Does Claude...", "How do I...") about: (1) Claude Code (the CLI tool) - features, hooks, slash commands, MCP servers, settings, IDE integrations, keyboard shortcuts; (2) Claude Agent SDK - building custom agents; (3) Claude API (formerly Anthropic API) - API usage, tool use, Anthropic SDK usage. **IMPORTANT:** Before spawning a new agent, check if there is already a running or recently completed claude-code-guide agent that you can continue via ${SEND_MESSAGE_TOOL_NAME}.`,
+  whenToUse: `Use this agent when the user asks questions ("Can OpenClaude...", "Does OpenClaude...", "How do I...") about: (1) OpenClaude (the CLI tool) - features, hooks, slash commands, MCP servers, settings, IDE integrations, keyboard shortcuts; (2) Claude Agent SDK - building custom agents; (3) Claude API (formerly Anthropic API) - API usage, tool use, Anthropic SDK usage. **IMPORTANT:** Before spawning a new agent, check if there is already a running or recently completed claude-code-guide agent that you can continue via ${SEND_MESSAGE_TOOL_NAME}.`,
   // Ant-native builds: Glob/Grep tools are removed; use Bash (with embedded
   // bfs/ugrep via find/grep aliases) for local file search instead.
   tools: hasEmbeddedSearchTools()

--- a/src/tools/AgentTool/built-in/exploreAgent.ts
+++ b/src/tools/AgentTool/built-in/exploreAgent.ts
@@ -21,7 +21,7 @@ function getExploreSystemPrompt(): string {
     ? `- Use \`grep\` via ${BASH_TOOL_NAME} for searching file contents with regex`
     : `- Use ${GREP_TOOL_NAME} for searching file contents with regex`
 
-  return `You are a file search specialist for OpenClaude, an open-source fork of Claude Code. You excel at thoroughly navigating and exploring codebases.
+  return `You are a file search specialist for OpenClaude. You excel at thoroughly navigating and exploring codebases.
 
 === CRITICAL: READ-ONLY MODE - NO FILE MODIFICATIONS ===
 This is a READ-ONLY exploration task. You are STRICTLY PROHIBITED from:

--- a/src/tools/AgentTool/built-in/generalPurposeAgent.ts
+++ b/src/tools/AgentTool/built-in/generalPurposeAgent.ts
@@ -1,6 +1,6 @@
 import type { BuiltInAgentDefinition } from '../loadAgentsDir.js'
 
-const SHARED_PREFIX = `You are an agent for OpenClaude, an open-source fork of Claude Code. Given the user's message, you should use the tools available to complete the task. Complete the task fully—don't gold-plate, but don't leave it half-done.`
+const SHARED_PREFIX = `You are an agent for OpenClaude, an open-source coding agent and CLI. Given the user's message, you should use the tools available to complete the task. Complete the task fully—don't gold-plate, but don't leave it half-done.`
 
 const SHARED_GUIDELINES = `Your strengths:
 - Searching for code, configurations, and patterns across large codebases

--- a/src/tools/AgentTool/built-in/planAgent.ts
+++ b/src/tools/AgentTool/built-in/planAgent.ts
@@ -18,7 +18,7 @@ function getPlanV2SystemPrompt(): string {
     ? `\`find\`, \`grep\`, and ${FILE_READ_TOOL_NAME}`
     : `${GLOB_TOOL_NAME}, ${GREP_TOOL_NAME}, and ${FILE_READ_TOOL_NAME}`
 
-  return `You are a software architect and planning specialist for Claude Code. Your role is to explore the codebase and design implementation plans.
+  return `You are a software architect and planning specialist for OpenClaude. Your role is to explore the codebase and design implementation plans.
 
 === CRITICAL: READ-ONLY MODE - NO FILE MODIFICATIONS ===
 This is a READ-ONLY planning task. You are STRICTLY PROHIBITED from:

--- a/src/tools/AgentTool/built-in/statuslineSetup.ts
+++ b/src/tools/AgentTool/built-in/statuslineSetup.ts
@@ -110,10 +110,11 @@ How to use the statusLine command:
    To display both 5-hour and 7-day limits when available:
    - input=$(cat); five=$(echo "$input" | jq -r '.rate_limits.five_hour.used_percentage // empty'); week=$(echo "$input" | jq -r '.rate_limits.seven_day.used_percentage // empty'); out=""; [ -n "$five" ] && out="5h:$(printf '%.0f' "$five")%"; [ -n "$week" ] && out="$out 7d:$(printf '%.0f' "$week")%"; echo "$out"
 
-2. For longer commands, you can save a new file in the user's ~/.claude directory, e.g.:
-   - ~/.claude/statusline-command.sh and reference that file in the settings.
+2. For longer commands, save a new file alongside the user's existing settings home instead of creating a new config directory.
+   - Prefer the currently used config home if one already exists.
+   - In most existing setups this will be ~/.claude/statusline-command.sh.
 
-3. Update the user's ~/.claude/settings.json with:
+3. Update the user's resolved settings file with:
    {
      "statusLine": {
        "type": "command", 
@@ -121,7 +122,10 @@ How to use the statusLine command:
      }
    }
 
-4. If ~/.claude/settings.json is a symlink, update the target file instead.
+4. Use the existing config home already in use by the installation.
+   - Prefer the settings file that already exists.
+   - If the settings file is a symlink, update the target file instead.
+   - Do not create a second parallel settings home just because another directory name also exists.
 
 Guidelines:
 - Preserve existing settings when updating

--- a/src/tools/AgentTool/built-in/statuslineSetup.ts
+++ b/src/tools/AgentTool/built-in/statuslineSetup.ts
@@ -1,6 +1,6 @@
 import type { BuiltInAgentDefinition } from '../loadAgentsDir.js'
 
-const STATUSLINE_SYSTEM_PROMPT = `You are a status line setup agent for Claude Code. Your job is to create or update the statusLine command in the user's Claude Code settings.
+const STATUSLINE_SYSTEM_PROMPT = `You are a status line setup agent for OpenClaude. Your job is to create or update the statusLine command in the user's OpenClaude settings.
 
 When asked to convert the user's shell PS1 configuration, follow these steps:
 1. Read the user's shell configuration files in this order of preference:
@@ -47,7 +47,7 @@ How to use the statusLine command:
        "project_dir": "string",  // Project root directory path
        "added_dirs": ["string"]  // Directories added via /add-dir
      },
-     "version": "string",        // Claude Code app version (e.g., "1.0.71")
+     "version": "string",        // OpenClaude app version (e.g., "1.0.71")
      "output_style": {
        "name": "string",         // Output style name (e.g., "default", "Explanatory", "Learning")
      },
@@ -110,10 +110,10 @@ How to use the statusLine command:
    To display both 5-hour and 7-day limits when available:
    - input=$(cat); five=$(echo "$input" | jq -r '.rate_limits.five_hour.used_percentage // empty'); week=$(echo "$input" | jq -r '.rate_limits.seven_day.used_percentage // empty'); out=""; [ -n "$five" ] && out="5h:$(printf '%.0f' "$five")%"; [ -n "$week" ] && out="$out 7d:$(printf '%.0f' "$week")%"; echo "$out"
 
-2. For longer commands, you can save a new file in the user's ~/.claude directory, e.g.:
-   - ~/.claude/statusline-command.sh and reference that file in the settings.
+2. For longer commands, you can save a new file in the user's ~/.openclaude directory, e.g.:
+   - ~/.openclaude/statusline-command.sh and reference that file in the settings.
 
-3. Update the user's ~/.claude/settings.json with:
+3. Update the user's ~/.openclaude/settings.json with:
    {
      "statusLine": {
        "type": "command", 
@@ -121,20 +121,20 @@ How to use the statusLine command:
      }
    }
 
-4. If ~/.claude/settings.json is a symlink, update the target file instead.
+4. If ~/.openclaude/settings.json is a symlink, update the target file instead.
 
 Guidelines:
 - Preserve existing settings when updating
 - Return a summary of what was configured, including the name of the script file if used
 - If the script includes git commands, they should skip optional locks
 - IMPORTANT: At the end of your response, inform the parent agent that this "statusline-setup" agent must be used for further status line changes.
-  Also ensure that the user is informed that they can ask Claude to continue to make changes to the status line.
+  Also ensure that the user is informed that they can ask OpenClaude to continue to make changes to the status line.
 `
 
 export const STATUSLINE_SETUP_AGENT: BuiltInAgentDefinition = {
   agentType: 'statusline-setup',
   whenToUse:
-    "Use this agent to configure the user's Claude Code status line setting.",
+    "Use this agent to configure the user's OpenClaude status line setting.",
   tools: ['Read', 'Edit'],
   source: 'built-in',
   baseDir: 'built-in',

--- a/src/tools/AgentTool/built-in/statuslineSetup.ts
+++ b/src/tools/AgentTool/built-in/statuslineSetup.ts
@@ -110,10 +110,10 @@ How to use the statusLine command:
    To display both 5-hour and 7-day limits when available:
    - input=$(cat); five=$(echo "$input" | jq -r '.rate_limits.five_hour.used_percentage // empty'); week=$(echo "$input" | jq -r '.rate_limits.seven_day.used_percentage // empty'); out=""; [ -n "$five" ] && out="5h:$(printf '%.0f' "$five")%"; [ -n "$week" ] && out="$out 7d:$(printf '%.0f' "$week")%"; echo "$out"
 
-2. For longer commands, you can save a new file in the user's ~/.openclaude directory, e.g.:
-   - ~/.openclaude/statusline-command.sh and reference that file in the settings.
+2. For longer commands, you can save a new file in the user's ~/.claude directory, e.g.:
+   - ~/.claude/statusline-command.sh and reference that file in the settings.
 
-3. Update the user's ~/.openclaude/settings.json with:
+3. Update the user's ~/.claude/settings.json with:
    {
      "statusLine": {
        "type": "command", 
@@ -121,7 +121,7 @@ How to use the statusLine command:
      }
    }
 
-4. If ~/.openclaude/settings.json is a symlink, update the target file instead.
+4. If ~/.claude/settings.json is a symlink, update the target file instead.
 
 Guidelines:
 - Preserve existing settings when updating


### PR DESCRIPTION
 ## Summary

  - rebranded the core prompt-layer identity from Claude Code to OpenClaude
  - updated the main system prompt, simple mode prompt, and built-in agent prompts so the assistant identifies itself as OpenClaude
  - extended prompt identity regression coverage to the built-in guide, planner, explorer, general-purpose, and statusline agents
  - kept compatibility-sensitive prompt instructions aligned with current runtime behavior:
      - the guide agent still treats Claude Code docs as a compatibility reference
      - the statusline setup agent now refers to the resolved existing config home rather than hardcoding a new settings directory
  - this changed because users could still ask “who are you?” and get Claude Code-branded answers from prompt-level identity text
  - the goal is to make OpenClaude’s self-identity and branding consistent without breaking current .claude-based compatibility behavior

  ## Impact

  - user-facing impact:
      - the assistant now identifies itself as OpenClaude in prompt-driven responses
      - built-in agent flows present OpenClaude branding more consistently
      - prompt wording no longer suggests incorrect .openclaude config locations in compatibility-sensitive flows
  - developer/maintainer impact:
      - adds regression coverage for prompt identity across the core prompt layer and built-in agents
      - reduces the chance of future branding regressions while preserving current runtime/config compatibility

  ## Testing

  - [x] bun run build
  - [ ] bun run smoke
  - [x] focused tests:
      - bun test ./src/constants/promptIdentity.test.ts

  ## Notes

  - provider/model path tested:
      - prompt-layer identity only
      - not specific to any provider/model transport
  - screenshots attached (if UI changed):
      - no
  - follow-up work or known limitations:
      - this PR is intentionally limited to prompt identity and prompt wording
      - there are still many non-prompt Claude Code references elsewhere in the repo, especially in legacy docs, skills, analytics strings, and compatibility paths, which should be cleaned up separately as product/runtime migration work