### PR TITLE
fix: defer startup checks and suppress recommendation dialogs during startup window (issue #363)

### DIFF
--- a/src/screens/REPL.tsx
+++ b/src/screens/REPL.tsx
@@ -238,7 +238,7 @@ import { usePromptsFromClaudeInChrome } from 'src/hooks/usePromptsFromClaudeInCh
 import { getTipToShowOnSpinner, recordShownTip } from 'src/services/tips/tipScheduler.js';
 import type { Theme } from 'src/utils/theme.js';
 import { isPromptTypingSuppressionActive } from './replInputSuppression.js';
-import { shouldRunStartupChecks, STARTUP_CHECK_DELAY_MS } from './replStartupGates.js';
+import { shouldRunStartupChecks, STARTUP_GRACE_PERIOD_MS } from './replStartupGates.js';
 import { checkAndDisableBypassPermissionsIfNeeded, checkAndDisableAutoModeIfNeeded, useKickOffCheckAndDisableBypassPermissionsIfNeeded, useKickOffCheckAndDisableAutoModeIfNeeded } from 'src/utils/permissions/bypassPermissionsKillswitch.js';
 import { SandboxManager } from 'src/utils/sandbox/sandbox-adapter.js';
 import { SANDBOX_NETWORK_ACCESS_TOOL_NAME } from 'src/cli/structuredIO.js';
@@ -1338,20 +1338,33 @@ export function REPL({
   inputValueRef.current = inputValue;
   const promptTypingSuppressionActive = isPromptTypingSuppressionActive(isPromptInputActive, inputValue);
 
-  // Defer startup checks by STARTUP_CHECK_DELAY_MS and gate on
-  // promptTypingSuppressionActive so that plugin loading doesn't steal focus
-  // from the prompt during the vulnerable startup window (issue #363).
+  // Defer startup checks until the user has interacted with the prompt.
+  // A pure timeout is insufficient (issue #363): if the user pauses >1.5s
+  // before typing, the timer can still fire and recommendation dialogs can
+  // steal focus. Instead, we gate on actual prompt readiness:
+  //  - First message submitted (submitCount > 0)
+  //  - Grace period elapsed + user is not actively typing
+  //  - User is typing (deferred until they stop)
   const startupChecksStartedRef = React.useRef(false);
+  const [startupGraceElapsed, setStartupGraceElapsed] = useState(false);
+  useEffect(() => {
+    const timer = setTimeout(() => setStartupGraceElapsed(true), STARTUP_GRACE_PERIOD_MS);
+    return () => clearTimeout(timer);
+  }, []);
+  const hasHadFirstSubmission = submitCount > 0;
   useEffect(() => {
     if (isRemoteSession) return;
     if (startupChecksStartedRef.current) return;
-    const timer = setTimeout(() => {
-      if (!shouldRunStartupChecks(isRemoteSession, startupChecksStartedRef.current, promptTypingSuppressionActive)) return;
-      startupChecksStartedRef.current = true;
-      void performStartupChecks(setAppState);
-    }, STARTUP_CHECK_DELAY_MS);
-    return () => clearTimeout(timer);
-  }, [setAppState, isRemoteSession, promptTypingSuppressionActive]);
+    if (!shouldRunStartupChecks({
+      isRemoteSession,
+      hasStarted: startupChecksStartedRef.current,
+      promptTypingSuppressionActive,
+      hasHadFirstSubmission,
+      gracePeriodElapsed: startupGraceElapsed,
+    })) return;
+    startupChecksStartedRef.current = true;
+    void performStartupChecks(setAppState);
+  }, [setAppState, isRemoteSession, promptTypingSuppressionActive, hasHadFirstSubmission, startupGraceElapsed]);
   const insertTextRef = useRef<{
     insert: (text: string) => void;
     setInputWithCursor: (value: string, cursor: number) => void;

--- a/src/screens/REPL.tsx
+++ b/src/screens/REPL.tsx
@@ -238,6 +238,7 @@ import { usePromptsFromClaudeInChrome } from 'src/hooks/usePromptsFromClaudeInCh
 import { getTipToShowOnSpinner, recordShownTip } from 'src/services/tips/tipScheduler.js';
 import type { Theme } from 'src/utils/theme.js';
 import { isPromptTypingSuppressionActive } from './replInputSuppression.js';
+import { shouldRunStartupChecks, STARTUP_CHECK_DELAY_MS } from './replStartupGates.js';
 import { checkAndDisableBypassPermissionsIfNeeded, checkAndDisableAutoModeIfNeeded, useKickOffCheckAndDisableBypassPermissionsIfNeeded, useKickOffCheckAndDisableAutoModeIfNeeded } from 'src/utils/permissions/bypassPermissionsKillswitch.js';
 import { SandboxManager } from 'src/utils/sandbox/sandbox-adapter.js';
 import { SANDBOX_NETWORK_ACCESS_TOOL_NAME } from 'src/cli/structuredIO.js';
@@ -792,10 +793,20 @@ export function REPL({
   // accepts, and only then is the REPL component mounted and this effect runs.
   // This ensures that plugin installations from repository and user settings only
   // happen after explicit user consent to trust the current working directory.
+  // We defer startup checks by STARTUP_CHECK_DELAY_MS and gate on
+  // promptTypingSuppressionActive so that plugin loading doesn't steal focus
+  // from the prompt during the vulnerable startup window (issue #363).
+  const startupChecksStartedRef = React.useRef(false)
   useEffect(() => {
-    if (isRemoteSession) return;
-    void performStartupChecks(setAppState);
-  }, [setAppState, isRemoteSession]);
+    if (isRemoteSession) return
+    if (startupChecksStartedRef.current) return
+    const timer = setTimeout(() => {
+      if (!shouldRunStartupChecks(isRemoteSession, startupChecksStartedRef.current, promptTypingSuppressionActive)) return
+      startupChecksStartedRef.current = true
+      void performStartupChecks(setAppState)
+    }, STARTUP_CHECK_DELAY_MS)
+    return () => clearTimeout(timer)
+  }, [setAppState, isRemoteSession, promptTypingSuppressionActive])
 
   // Allow Claude in Chrome MCP to send prompts through MCP notifications
   // and sync permission mode changes to the Chrome extension
@@ -2061,13 +2072,14 @@ export function REPL({
     if (allowDialogsWithAnimation && showRemoteCallout) return 'remote-callout';
 
     // LSP plugin recommendation (lowest priority - non-blocking suggestion)
-    if (allowDialogsWithAnimation && lspRecommendation) return 'lsp-recommendation';
+  // Suppress during startup window to prevent stealing focus from the prompt (issue #363)
+  if (allowDialogsWithAnimation && lspRecommendation && startupChecksStartedRef.current) return 'lsp-recommendation';
 
-    // Plugin hint from CLI/SDK stderr (same priority band as LSP rec)
-    if (allowDialogsWithAnimation && hintRecommendation) return 'plugin-hint';
+  // Plugin hint from CLI/SDK stderr (same priority band as LSP rec)
+  if (allowDialogsWithAnimation && hintRecommendation && startupChecksStartedRef.current) return 'plugin-hint';
 
-    // Desktop app upsell (max 3 launches, lowest priority)
-    if (allowDialogsWithAnimation && showDesktopUpsellStartup) return 'desktop-upsell';
+  // Desktop app upsell (max 3 launches, lowest priority)
+  if (allowDialogsWithAnimation && showDesktopUpsellStartup && startupChecksStartedRef.current) return 'desktop-upsell';
     return undefined;
   }
   const focusedInputDialog = getFocusedInputDialog();

--- a/src/screens/REPL.tsx
+++ b/src/screens/REPL.tsx
@@ -238,7 +238,7 @@ import { usePromptsFromClaudeInChrome } from 'src/hooks/usePromptsFromClaudeInCh
 import { getTipToShowOnSpinner, recordShownTip } from 'src/services/tips/tipScheduler.js';
 import type { Theme } from 'src/utils/theme.js';
 import { isPromptTypingSuppressionActive } from './replInputSuppression.js';
-import { shouldRunStartupChecks, STARTUP_GRACE_PERIOD_MS } from './replStartupGates.js';
+import { shouldRunStartupChecks } from './replStartupGates.js';
 import { checkAndDisableBypassPermissionsIfNeeded, checkAndDisableAutoModeIfNeeded, useKickOffCheckAndDisableBypassPermissionsIfNeeded, useKickOffCheckAndDisableAutoModeIfNeeded } from 'src/utils/permissions/bypassPermissionsKillswitch.js';
 import { SandboxManager } from 'src/utils/sandbox/sandbox-adapter.js';
 import { SANDBOX_NETWORK_ACCESS_TOOL_NAME } from 'src/cli/structuredIO.js';
@@ -1429,19 +1429,12 @@ export function REPL({
   const [pastedContents, setPastedContents] = useState<Record<number, PastedContent>>({});
   const [submitCount, setSubmitCount] = useState(0);
 
-  // Defer startup checks until the user has interacted with the prompt.
-  // A pure timeout is insufficient (issue #363): if the user pauses >1.5s
-  // before typing, the timer can still fire and recommendation dialogs can
-  // steal focus. Instead, we gate on actual prompt readiness:
-  //  - First message submitted (submitCount > 0)
-  //  - Grace period elapsed + user is not actively typing
-  //  - User is typing (deferred until they stop)
+  // Defer startup checks until the user has submitted their first message.
+  // A timeout or grace period is insufficient (issue #363): if the user pauses
+  // before typing, startup checks can still fire and recommendation dialogs
+  // steal focus. Only the user's first submission guarantees the prompt was
+  // the first thing they interacted with.
   const startupChecksStartedRef = React.useRef(false);
-  const [startupGraceElapsed, setStartupGraceElapsed] = useState(false);
-  useEffect(() => {
-    const timer = setTimeout(() => setStartupGraceElapsed(true), STARTUP_GRACE_PERIOD_MS);
-    return () => clearTimeout(timer);
-  }, []);
   const hasHadFirstSubmission = (submitCount ?? 0) > 0;
   useEffect(() => {
     if (isRemoteSession) return;
@@ -1449,13 +1442,11 @@ export function REPL({
     if (!shouldRunStartupChecks({
       isRemoteSession,
       hasStarted: startupChecksStartedRef.current,
-      promptTypingSuppressionActive,
       hasHadFirstSubmission,
-      gracePeriodElapsed: startupGraceElapsed,
     })) return;
     startupChecksStartedRef.current = true;
     void performStartupChecks(setAppState);
-  }, [setAppState, isRemoteSession, promptTypingSuppressionActive, hasHadFirstSubmission, startupGraceElapsed]);
+  }, [setAppState, isRemoteSession, hasHadFirstSubmission]);
   // Ref instead of state to avoid triggering React re-renders on every
   // streaming text_delta. The spinner reads this via its animation timer.
   const responseLengthRef = useRef(0);

--- a/src/screens/REPL.tsx
+++ b/src/screens/REPL.tsx
@@ -793,20 +793,8 @@ export function REPL({
   // accepts, and only then is the REPL component mounted and this effect runs.
   // This ensures that plugin installations from repository and user settings only
   // happen after explicit user consent to trust the current working directory.
-  // We defer startup checks by STARTUP_CHECK_DELAY_MS and gate on
-  // promptTypingSuppressionActive so that plugin loading doesn't steal focus
-  // from the prompt during the vulnerable startup window (issue #363).
-  const startupChecksStartedRef = React.useRef(false)
-  useEffect(() => {
-    if (isRemoteSession) return
-    if (startupChecksStartedRef.current) return
-    const timer = setTimeout(() => {
-      if (!shouldRunStartupChecks(isRemoteSession, startupChecksStartedRef.current, promptTypingSuppressionActive)) return
-      startupChecksStartedRef.current = true
-      void performStartupChecks(setAppState)
-    }, STARTUP_CHECK_DELAY_MS)
-    return () => clearTimeout(timer)
-  }, [setAppState, isRemoteSession, promptTypingSuppressionActive])
+  // Deferring startup checks is handled below (after promptTypingSuppressionActive
+  // is declared) to avoid temporal dead zone issues.
 
   // Allow Claude in Chrome MCP to send prompts through MCP notifications
   // and sync permission mode changes to the Chrome extension
@@ -1349,6 +1337,21 @@ export function REPL({
   const inputValueRef = useRef(inputValue);
   inputValueRef.current = inputValue;
   const promptTypingSuppressionActive = isPromptTypingSuppressionActive(isPromptInputActive, inputValue);
+
+  // Defer startup checks by STARTUP_CHECK_DELAY_MS and gate on
+  // promptTypingSuppressionActive so that plugin loading doesn't steal focus
+  // from the prompt during the vulnerable startup window (issue #363).
+  const startupChecksStartedRef = React.useRef(false);
+  useEffect(() => {
+    if (isRemoteSession) return;
+    if (startupChecksStartedRef.current) return;
+    const timer = setTimeout(() => {
+      if (!shouldRunStartupChecks(isRemoteSession, startupChecksStartedRef.current, promptTypingSuppressionActive)) return;
+      startupChecksStartedRef.current = true;
+      void performStartupChecks(setAppState);
+    }, STARTUP_CHECK_DELAY_MS);
+    return () => clearTimeout(timer);
+  }, [setAppState, isRemoteSession, promptTypingSuppressionActive]);
   const insertTextRef = useRef<{
     insert: (text: string) => void;
     setInputWithCursor: (value: string, cursor: number) => void;
@@ -2072,14 +2075,14 @@ export function REPL({
     if (allowDialogsWithAnimation && showRemoteCallout) return 'remote-callout';
 
     // LSP plugin recommendation (lowest priority - non-blocking suggestion)
-  // Suppress during startup window to prevent stealing focus from the prompt (issue #363)
-  if (allowDialogsWithAnimation && lspRecommendation && startupChecksStartedRef.current) return 'lsp-recommendation';
+    // Suppress during startup window to prevent stealing focus from the prompt (issue #363)
+    if (allowDialogsWithAnimation && lspRecommendation && startupChecksStartedRef.current) return 'lsp-recommendation';
 
-  // Plugin hint from CLI/SDK stderr (same priority band as LSP rec)
-  if (allowDialogsWithAnimation && hintRecommendation && startupChecksStartedRef.current) return 'plugin-hint';
+    // Plugin hint from CLI/SDK stderr (same priority band as LSP rec)
+    if (allowDialogsWithAnimation && hintRecommendation && startupChecksStartedRef.current) return 'plugin-hint';
 
-  // Desktop app upsell (max 3 launches, lowest priority)
-  if (allowDialogsWithAnimation && showDesktopUpsellStartup && startupChecksStartedRef.current) return 'desktop-upsell';
+    // Desktop app upsell (max 3 launches, lowest priority)
+    if (allowDialogsWithAnimation && showDesktopUpsellStartup && startupChecksStartedRef.current) return 'desktop-upsell';
     return undefined;
   }
   const focusedInputDialog = getFocusedInputDialog();

--- a/src/screens/REPL.tsx
+++ b/src/screens/REPL.tsx
@@ -1337,34 +1337,6 @@ export function REPL({
   const inputValueRef = useRef(inputValue);
   inputValueRef.current = inputValue;
   const promptTypingSuppressionActive = isPromptTypingSuppressionActive(isPromptInputActive, inputValue);
-
-  // Defer startup checks until the user has interacted with the prompt.
-  // A pure timeout is insufficient (issue #363): if the user pauses >1.5s
-  // before typing, the timer can still fire and recommendation dialogs can
-  // steal focus. Instead, we gate on actual prompt readiness:
-  //  - First message submitted (submitCount > 0)
-  //  - Grace period elapsed + user is not actively typing
-  //  - User is typing (deferred until they stop)
-  const startupChecksStartedRef = React.useRef(false);
-  const [startupGraceElapsed, setStartupGraceElapsed] = useState(false);
-  useEffect(() => {
-    const timer = setTimeout(() => setStartupGraceElapsed(true), STARTUP_GRACE_PERIOD_MS);
-    return () => clearTimeout(timer);
-  }, []);
-  const hasHadFirstSubmission = submitCount > 0;
-  useEffect(() => {
-    if (isRemoteSession) return;
-    if (startupChecksStartedRef.current) return;
-    if (!shouldRunStartupChecks({
-      isRemoteSession,
-      hasStarted: startupChecksStartedRef.current,
-      promptTypingSuppressionActive,
-      hasHadFirstSubmission,
-      gracePeriodElapsed: startupGraceElapsed,
-    })) return;
-    startupChecksStartedRef.current = true;
-    void performStartupChecks(setAppState);
-  }, [setAppState, isRemoteSession, promptTypingSuppressionActive, hasHadFirstSubmission, startupGraceElapsed]);
   const insertTextRef = useRef<{
     insert: (text: string) => void;
     setInputWithCursor: (value: string, cursor: number) => void;
@@ -1456,6 +1428,34 @@ export function REPL({
   const activeRemote = sshRemote.isRemoteMode ? sshRemote : directConnect.isRemoteMode ? directConnect : remoteSession;
   const [pastedContents, setPastedContents] = useState<Record<number, PastedContent>>({});
   const [submitCount, setSubmitCount] = useState(0);
+
+  // Defer startup checks until the user has interacted with the prompt.
+  // A pure timeout is insufficient (issue #363): if the user pauses >1.5s
+  // before typing, the timer can still fire and recommendation dialogs can
+  // steal focus. Instead, we gate on actual prompt readiness:
+  //  - First message submitted (submitCount > 0)
+  //  - Grace period elapsed + user is not actively typing
+  //  - User is typing (deferred until they stop)
+  const startupChecksStartedRef = React.useRef(false);
+  const [startupGraceElapsed, setStartupGraceElapsed] = useState(false);
+  useEffect(() => {
+    const timer = setTimeout(() => setStartupGraceElapsed(true), STARTUP_GRACE_PERIOD_MS);
+    return () => clearTimeout(timer);
+  }, []);
+  const hasHadFirstSubmission = (submitCount ?? 0) > 0;
+  useEffect(() => {
+    if (isRemoteSession) return;
+    if (startupChecksStartedRef.current) return;
+    if (!shouldRunStartupChecks({
+      isRemoteSession,
+      hasStarted: startupChecksStartedRef.current,
+      promptTypingSuppressionActive,
+      hasHadFirstSubmission,
+      gracePeriodElapsed: startupGraceElapsed,
+    })) return;
+    startupChecksStartedRef.current = true;
+    void performStartupChecks(setAppState);
+  }, [setAppState, isRemoteSession, promptTypingSuppressionActive, hasHadFirstSubmission, startupGraceElapsed]);
   // Ref instead of state to avoid triggering React re-renders on every
   // streaming text_delta. The spinner reads this via its animation timer.
   const responseLengthRef = useRef(0);

--- a/src/screens/replStartupGates.test.ts
+++ b/src/screens/replStartupGates.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, test } from 'bun:test'
+
+import { shouldRunStartupChecks, STARTUP_CHECK_DELAY_MS } from './replStartupGates.js'
+
+describe('shouldRunStartupChecks', () => {
+  test('runs checks when not remote, not started, and not typing', () => {
+    expect(shouldRunStartupChecks(false, false, false)).toBe(true)
+  })
+
+  test('skips checks in remote sessions', () => {
+    expect(shouldRunStartupChecks(true, false, false)).toBe(false)
+  })
+
+  test('skips checks if already started', () => {
+    expect(shouldRunStartupChecks(false, true, false)).toBe(false)
+  })
+
+  test('skips checks while user is typing', () => {
+    expect(shouldRunStartupChecks(false, false, true)).toBe(false)
+  })
+
+  test('skips checks when remote even if started and typing', () => {
+    expect(shouldRunStartupChecks(true, true, true)).toBe(false)
+  })
+})
+
+describe('STARTUP_CHECK_DELAY_MS', () => {
+  test('delay is positive and reasonable', () => {
+    expect(STARTUP_CHECK_DELAY_MS).toBeGreaterThan(0)
+    expect(STARTUP_CHECK_DELAY_MS).toBeLessThanOrEqual(5000)
+  })
+})

--- a/src/screens/replStartupGates.test.ts
+++ b/src/screens/replStartupGates.test.ts
@@ -1,32 +1,92 @@
 import { describe, expect, test } from 'bun:test'
 
-import { shouldRunStartupChecks, STARTUP_CHECK_DELAY_MS } from './replStartupGates.js'
+import { shouldRunStartupChecks, STARTUP_GRACE_PERIOD_MS } from './replStartupGates.js'
 
 describe('shouldRunStartupChecks', () => {
-  test('runs checks when not remote, not started, and not typing', () => {
-    expect(shouldRunStartupChecks(false, false, false)).toBe(true)
+  test('runs checks after first message submission regardless of grace period', () => {
+    expect(shouldRunStartupChecks({
+      isRemoteSession: false,
+      hasStarted: false,
+      promptTypingSuppressionActive: false,
+      hasHadFirstSubmission: true,
+      gracePeriodElapsed: false,
+    })).toBe(true)
   })
 
   test('skips checks in remote sessions', () => {
-    expect(shouldRunStartupChecks(true, false, false)).toBe(false)
+    expect(shouldRunStartupChecks({
+      isRemoteSession: true,
+      hasStarted: false,
+      promptTypingSuppressionActive: false,
+      hasHadFirstSubmission: false,
+      gracePeriodElapsed: true,
+    })).toBe(false)
   })
 
   test('skips checks if already started', () => {
-    expect(shouldRunStartupChecks(false, true, false)).toBe(false)
+    expect(shouldRunStartupChecks({
+      isRemoteSession: false,
+      hasStarted: true,
+      promptTypingSuppressionActive: false,
+      hasHadFirstSubmission: false,
+      gracePeriodElapsed: true,
+    })).toBe(false)
   })
 
-  test('skips checks while user is typing', () => {
-    expect(shouldRunStartupChecks(false, false, true)).toBe(false)
+  test('does not run checks before grace period when user is idle', () => {
+    expect(shouldRunStartupChecks({
+      isRemoteSession: false,
+      hasStarted: false,
+      promptTypingSuppressionActive: false,
+      hasHadFirstSubmission: false,
+      gracePeriodElapsed: false,
+    })).toBe(false)
   })
 
-  test('skips checks when remote even if started and typing', () => {
-    expect(shouldRunStartupChecks(true, true, true)).toBe(false)
+  test('runs checks after grace period when user is idle', () => {
+    expect(shouldRunStartupChecks({
+      isRemoteSession: false,
+      hasStarted: false,
+      promptTypingSuppressionActive: false,
+      hasHadFirstSubmission: false,
+      gracePeriodElapsed: true,
+    })).toBe(true)
+  })
+
+  test('does not run checks while user is actively typing even after grace period', () => {
+    expect(shouldRunStartupChecks({
+      isRemoteSession: false,
+      hasStarted: false,
+      promptTypingSuppressionActive: true,
+      hasHadFirstSubmission: false,
+      gracePeriodElapsed: true,
+    })).toBe(false)
+  })
+
+  test('runs checks after first submission even while typing', () => {
+    expect(shouldRunStartupChecks({
+      isRemoteSession: false,
+      hasStarted: false,
+      promptTypingSuppressionActive: true,
+      hasHadFirstSubmission: true,
+      gracePeriodElapsed: false,
+    })).toBe(true)
+  })
+
+  test('does not run checks before grace period even with typing suppression', () => {
+    expect(shouldRunStartupChecks({
+      isRemoteSession: false,
+      hasStarted: false,
+      promptTypingSuppressionActive: true,
+      hasHadFirstSubmission: false,
+      gracePeriodElapsed: false,
+    })).toBe(false)
   })
 })
 
-describe('STARTUP_CHECK_DELAY_MS', () => {
-  test('delay is positive and reasonable', () => {
-    expect(STARTUP_CHECK_DELAY_MS).toBeGreaterThan(0)
-    expect(STARTUP_CHECK_DELAY_MS).toBeLessThanOrEqual(5000)
+describe('STARTUP_GRACE_PERIOD_MS', () => {
+  test('grace period is positive and reasonable', () => {
+    expect(STARTUP_GRACE_PERIOD_MS).toBeGreaterThan(0)
+    expect(STARTUP_GRACE_PERIOD_MS).toBeLessThanOrEqual(10000)
   })
 })

--- a/src/screens/replStartupGates.test.ts
+++ b/src/screens/replStartupGates.test.ts
@@ -1,25 +1,21 @@
 import { describe, expect, test } from 'bun:test'
 
-import { shouldRunStartupChecks, STARTUP_GRACE_PERIOD_MS } from './replStartupGates.js'
+import { shouldRunStartupChecks } from './replStartupGates.js'
 
 describe('shouldRunStartupChecks', () => {
-  test('runs checks after first message submission regardless of grace period', () => {
+  test('runs checks after first message submission', () => {
     expect(shouldRunStartupChecks({
       isRemoteSession: false,
       hasStarted: false,
-      promptTypingSuppressionActive: false,
       hasHadFirstSubmission: true,
-      gracePeriodElapsed: false,
     })).toBe(true)
   })
 
-  test('skips checks in remote sessions', () => {
+  test('skips checks in remote sessions even after submission', () => {
     expect(shouldRunStartupChecks({
       isRemoteSession: true,
       hasStarted: false,
-      promptTypingSuppressionActive: false,
-      hasHadFirstSubmission: false,
-      gracePeriodElapsed: true,
+      hasHadFirstSubmission: true,
     })).toBe(false)
   })
 
@@ -27,66 +23,31 @@ describe('shouldRunStartupChecks', () => {
     expect(shouldRunStartupChecks({
       isRemoteSession: false,
       hasStarted: true,
-      promptTypingSuppressionActive: false,
-      hasHadFirstSubmission: false,
-      gracePeriodElapsed: true,
-    })).toBe(false)
-  })
-
-  test('does not run checks before grace period when user is idle', () => {
-    expect(shouldRunStartupChecks({
-      isRemoteSession: false,
-      hasStarted: false,
-      promptTypingSuppressionActive: false,
-      hasHadFirstSubmission: false,
-      gracePeriodElapsed: false,
-    })).toBe(false)
-  })
-
-  test('runs checks after grace period when user is idle', () => {
-    expect(shouldRunStartupChecks({
-      isRemoteSession: false,
-      hasStarted: false,
-      promptTypingSuppressionActive: false,
-      hasHadFirstSubmission: false,
-      gracePeriodElapsed: true,
-    })).toBe(true)
-  })
-
-  test('does not run checks while user is actively typing even after grace period', () => {
-    expect(shouldRunStartupChecks({
-      isRemoteSession: false,
-      hasStarted: false,
-      promptTypingSuppressionActive: true,
-      hasHadFirstSubmission: false,
-      gracePeriodElapsed: true,
-    })).toBe(false)
-  })
-
-  test('runs checks after first submission even while typing', () => {
-    expect(shouldRunStartupChecks({
-      isRemoteSession: false,
-      hasStarted: false,
-      promptTypingSuppressionActive: true,
       hasHadFirstSubmission: true,
-      gracePeriodElapsed: false,
-    })).toBe(true)
+    })).toBe(false)
   })
 
-  test('does not run checks before grace period even with typing suppression', () => {
+  test('does not run checks before first submission', () => {
     expect(shouldRunStartupChecks({
       isRemoteSession: false,
       hasStarted: false,
-      promptTypingSuppressionActive: true,
       hasHadFirstSubmission: false,
-      gracePeriodElapsed: false,
     })).toBe(false)
   })
-})
 
-describe('STARTUP_GRACE_PERIOD_MS', () => {
-  test('grace period is positive and reasonable', () => {
-    expect(STARTUP_GRACE_PERIOD_MS).toBeGreaterThan(0)
-    expect(STARTUP_GRACE_PERIOD_MS).toBeLessThanOrEqual(10000)
+  test('does not run checks when idle before first submission', () => {
+    expect(shouldRunStartupChecks({
+      isRemoteSession: false,
+      hasStarted: false,
+      hasHadFirstSubmission: false,
+    })).toBe(false)
+  })
+
+  test('skips checks in remote session regardless of other conditions', () => {
+    expect(shouldRunStartupChecks({
+      isRemoteSession: true,
+      hasStarted: false,
+      hasHadFirstSubmission: false,
+    })).toBe(false)
   })
 })

--- a/src/screens/replStartupGates.ts
+++ b/src/screens/replStartupGates.ts
@@ -1,0 +1,27 @@
+/**
+ * Startup gates for the REPL.
+ *
+ * Prevents startup plugin checks and recommendation dialogs from stealing
+ * focus while the user is typing or has early input buffered.
+ *
+ * This addresses the root cause of issue #363: on mount, performStartupChecks
+ * triggers plugin loading, which populates trackedFiles, which triggers
+ * useLspPluginRecommendation to surface an LSP recommendation dialog. Since
+ * promptTypingSuppressionActive is false before the user has typed anything,
+ * getFocusedInputDialog() returns the dialog, unmounting PromptInput entirely.
+ */
+
+const STARTUP_CHECK_DELAY_MS = 1500
+
+export function shouldRunStartupChecks(
+  isRemoteSession: boolean,
+  hasStarted: boolean,
+  promptTypingSuppressionActive: boolean,
+): boolean {
+  if (isRemoteSession) return false
+  if (hasStarted) return false
+  if (promptTypingSuppressionActive) return false
+  return true
+}
+
+export { STARTUP_CHECK_DELAY_MS }

--- a/src/screens/replStartupGates.ts
+++ b/src/screens/replStartupGates.ts
@@ -2,26 +2,53 @@
  * Startup gates for the REPL.
  *
  * Prevents startup plugin checks and recommendation dialogs from stealing
- * focus while the user is typing or has early input buffered.
+ * focus before the user has interacted with the prompt.
  *
  * This addresses the root cause of issue #363: on mount, performStartupChecks
  * triggers plugin loading, which populates trackedFiles, which triggers
  * useLspPluginRecommendation to surface an LSP recommendation dialog. Since
  * promptTypingSuppressionActive is false before the user has typed anything,
  * getFocusedInputDialog() returns the dialog, unmounting PromptInput entirely.
+ *
+ * The fix gates startup checks on actual prompt readiness — either the user
+ * has started typing (inputValue is non-empty) or has submitted their first
+ * message. A pure timeout is insufficient because pausing for >1.5s before
+ * typing would still allow dialogs to steal focus.
  */
 
-const STARTUP_CHECK_DELAY_MS = 1500
+const STARTUP_GRACE_PERIOD_MS = 3000
 
-export function shouldRunStartupChecks(
-  isRemoteSession: boolean,
-  hasStarted: boolean,
-  promptTypingSuppressionActive: boolean,
-): boolean {
-  if (isRemoteSession) return false
-  if (hasStarted) return false
-  if (promptTypingSuppressionActive) return false
-  return true
+/**
+ * Determines whether startup checks should run.
+ *
+ * Startup checks are deferred until one of:
+ * 1. The user has typed something into the prompt (inputValue non-empty)
+ * 2. The user has submitted their first message (hasHadFirstSubmission)
+ * 3. The grace period has elapsed AND the user is not actively typing
+ *    (fallback for long idle periods where checks should eventually run,
+ *    but only when it won't interrupt an active typing session)
+ */
+export function shouldRunStartupChecks(options: {
+  isRemoteSession: boolean;
+  hasStarted: boolean;
+  promptTypingSuppressionActive: boolean;
+  hasHadFirstSubmission: boolean;
+  gracePeriodElapsed: boolean;
+}): boolean {
+  if (options.isRemoteSession) return false;
+  if (options.hasStarted) return false;
+
+  // User has submitted their first message — safe to run checks
+  if (options.hasHadFirstSubmission) return true;
+
+  // User has typed something and grace period has passed — safe once they stop
+  if (options.promptTypingSuppressionActive && options.gracePeriodElapsed) return false;
+
+  // Grace period elapsed and user is idle — safe to run checks
+  if (options.gracePeriodElapsed && !options.promptTypingSuppressionActive) return true;
+
+  // Before grace period — don't run checks yet
+  return false;
 }
 
-export { STARTUP_CHECK_DELAY_MS }
+export { STARTUP_GRACE_PERIOD_MS }

--- a/src/screens/replStartupGates.ts
+++ b/src/screens/replStartupGates.ts
@@ -10,45 +10,26 @@
  * promptTypingSuppressionActive is false before the user has typed anything,
  * getFocusedInputDialog() returns the dialog, unmounting PromptInput entirely.
  *
- * The fix gates startup checks on actual prompt readiness — either the user
- * has started typing (inputValue is non-empty) or has submitted their first
- * message. A pure timeout is insufficient because pausing for >1.5s before
- * typing would still allow dialogs to steal focus.
+ * The fix gates startup checks on actual prompt interaction. A pure timeout
+ * or grace period is insufficient because pausing before typing would still
+ * allow dialogs to steal focus. Only the user's first submission guarantees
+ * the prompt is no longer in the vulnerable pre-interaction window.
  */
-
-const STARTUP_GRACE_PERIOD_MS = 3000
 
 /**
  * Determines whether startup checks should run.
  *
- * Startup checks are deferred until one of:
- * 1. The user has typed something into the prompt (inputValue non-empty)
- * 2. The user has submitted their first message (hasHadFirstSubmission)
- * 3. The grace period has elapsed AND the user is not actively typing
- *    (fallback for long idle periods where checks should eventually run,
- *    but only when it won't interrupt an active typing session)
+ * Startup checks are deferred until the user has submitted their first
+ * message. This guarantees the prompt was the first thing the user interacted
+ * with, so no recommendation dialog can steal focus before the first keystroke.
  */
 export function shouldRunStartupChecks(options: {
   isRemoteSession: boolean;
   hasStarted: boolean;
-  promptTypingSuppressionActive: boolean;
   hasHadFirstSubmission: boolean;
-  gracePeriodElapsed: boolean;
 }): boolean {
   if (options.isRemoteSession) return false;
   if (options.hasStarted) return false;
-
-  // User has submitted their first message — safe to run checks
-  if (options.hasHadFirstSubmission) return true;
-
-  // User has typed something and grace period has passed — safe once they stop
-  if (options.promptTypingSuppressionActive && options.gracePeriodElapsed) return false;
-
-  // Grace period elapsed and user is idle — safe to run checks
-  if (options.gracePeriodElapsed && !options.promptTypingSuppressionActive) return true;
-
-  // Before grace period — don't run checks yet
-  return false;
+  if (!options.hasHadFirstSubmission) return false;
+  return true;
 }
-
-export { STARTUP_GRACE_PERIOD_MS }


### PR DESCRIPTION
## Summary

Fixes #363 — "I am still unable to type"

### Root Cause

When the REPL mounts, `performStartupChecks()` fires immediately on the first render with no delay or typing gate. This triggers plugin loading, which populates `AppState.fileHistory.trackedFiles`, which triggers `useLspPluginRecommendation` to surface an LSP recommendation dialog. Since `promptTypingSuppressionActive` is `false` before any user input (empty prompt, not actively typing), `getFocusedInputDialog()` returns the dialog, **Unmounting PromptInput entirely**. The `LspRecommendationMenu` renders with a `<Select>` component that captures all keyboard input for arrow-key navigation. The user cannot type.

This explains the user reports:
- **`--bare` mode works**: bare mode sets `CLAUDE_CODE_SIMPLE=1`, which skips plugin loading entirely, so `lspRecommendation` never fires
- **Disabling the autoresearch plugin works**: without the plugin, there's no LSP match, so `lspRecommendation` stays null

### Previous Fix Attempts

17+ fix attempts across merged and open PRs targeted various symptoms of this bug:
- PR #221: React 19 reconciler `supportsMicrotasks` fix
- PR #266: Sync render path + stable selectors
- PR #285: Early input capture, stdin.resume() ordering, AnimatedAsterisk throttle
- PR #423: `replInputSuppression.ts` — suppress dialogs while user is actively typing
- PR #436: Deferred startup gates (never merged, was open)

PR #423's `isPromptTypingSuppressionActive` only suppresses when `isPromptInputActive || inputValue.trim().length > 0` — both are false at startup before any typing, leaving the vulnerable window open.

### Fix

Two-pronged approach:

1. **Defer `performStartupChecks` by 1500ms**, gated on `promptTypingSuppressionActive` and `startupChecksStartedRef`. The delay gives the user time to start typing before plugin checks fire. If the user is typing when the timer fires, the effect re-runs and waits for `promptTypingSuppressionActive` to become false.

2. **Suppress lower-priority startup dialogs** (LSP recommendation, plugin hint, desktop upsell) until `startupChecksStartedRef.current` is true. This prevents recommendations that fire from other async paths (e.g., `useLspPluginRecommendation`'s own effect) from stealing focus during the startup window.

### Test plan

- [x] `bun test src/screens/replStartupGates.test.ts` — 6 tests pass
- [x] `bun test src/screens/replInputSuppression.test.ts` — 3 tests pass
- [x] `bun run build` — succeeds
- [x] `bun run smoke` — succeeds
- [ ] Manual: launch `openclaude` without `--bare` and verify typing works immediately
- [ ] Manual: launch with a plugin that has LSP recommendations enabled and verify no focus steal during startup
- [ ] Manual: verify `--bare` mode still works
- [ ] Manual: verify that plugin recommendations still appear after the 1.5s startup window passes