### PR TITLE
fix: Select cursor highlight broken when moving over options (#472)

### DIFF
--- a/src/components/CustomSelect/use-multi-select-state.ts
+++ b/src/components/CustomSelect/use-multi-select-state.ts
@@ -1,5 +1,4 @@
 import { useCallback, useState } from 'react'
-import { isDeepStrictEqual } from 'util'
 import { useRegisterOverlay } from '../../context/overlayContext.js'
 import type { InputEvent } from '../../ink/events/input-event.js'
 // eslint-disable-next-line custom-rules/prefer-use-keybindings -- raw space/arrow multiselect input
@@ -9,6 +8,7 @@ import {
   normalizeFullWidthSpace,
 } from '../../utils/stringUtils.js'
 import type { OptionWithDescription } from './select.js'
+import { optionsNavigateEqual } from './use-select-navigation.js'
 import { useSelectNavigation } from './use-select-navigation.js'
 
 export type UseMultiSelectStateProps<T> = {
@@ -174,7 +174,7 @@ export function useMultiSelectState<T>({
   // and the deleted ui/useMultiSelectState.ts — without this, MCPServerDesktopImportDialog
   // keeps colliding servers checked after getAllMcpConfigs() resolves.
   const [lastOptions, setLastOptions] = useState(options)
-  if (options !== lastOptions && !isDeepStrictEqual(options, lastOptions)) {
+  if (options !== lastOptions && !optionsNavigateEqual(options, lastOptions)) {
     setSelectedValues(defaultValue)
     setLastOptions(options)
   }

--- a/src/components/CustomSelect/use-select-navigation.ts
+++ b/src/components/CustomSelect/use-select-navigation.ts
@@ -6,9 +6,33 @@ import {
   useRef,
   useState,
 } from 'react'
-import { isDeepStrictEqual } from 'util'
 import OptionMap from './option-map.js'
 import type { OptionWithDescription } from './select.js'
+
+/**
+ * Compare two option arrays for structural equality on properties that
+ * affect navigation behavior. ReactNode `label` and function `onChange`
+ * are intentionally excluded — they are identity-unstable (new reference
+ * each render) but don't change navigation semantics.
+ */
+export function optionsNavigateEqual<T>(
+  a: OptionWithDescription<T>[],
+  b: OptionWithDescription<T>[],
+): boolean {
+  if (a.length !== b.length) return false
+  for (let i = 0; i < a.length; i++) {
+    const ao = a[i]!
+    const bo = b[i]!
+    if (
+      ao.value !== bo.value ||
+      ao.disabled !== bo.disabled ||
+      ao.type !== bo.type
+    ) {
+      return false
+    }
+  }
+  return true
+}
 
 type State<T> = {
   /**
@@ -524,7 +548,7 @@ export function useSelectNavigation<T>({
 
   const [lastOptions, setLastOptions] = useState(options)
 
-  if (options !== lastOptions && !isDeepStrictEqual(options, lastOptions)) {
+  if (options !== lastOptions && !optionsNavigateEqual(options, lastOptions)) {
     dispatch({
       type: 'reset',
       state: createDefaultState({


### PR DESCRIPTION
Fixes #472

## Summary

Cursor highlight was broken when moving over options in Select menus. Only the first option remained highlighted regardless of arrow key navigation.

## Root Cause

isDeepStrictEqual in use-select-navigation.ts and use-multi-select-state.ts compared the entire options array deeply, including label (ReactNode/JSX elements), onChange (function callbacks), and disabled (computed booleans). These properties are identity-unstable - they get new references on every render, causing deep comparison to fail even when the options are semantically identical.

When deep comparison fails, the reset logic fires on every render, dispatching a reset action that sets focusedValue back to the first option - overriding any focus-next-option / focus-previous-option dispatches.

## Fix

Replace isDeepStrictEqual with optionsNavigateEqual, which only compares navigation-relevant properties: value, disabled, and type. ReactNode labels and function callbacks are excluded as they don't affect navigation semantics.

## Files Changed

- src/components/CustomSelect/use-select-navigation.ts - added optionsNavigateEqual, replaced isDeepStrictEqual
- src/components/CustomSelect/use-multi-select-state.ts - replaced isDeepStrictEqual with optionsNavigateEqual