### PR TITLE
fix: let saved provider profiles win on restart

### DIFF
--- a/src/utils/providerProfile.test.ts
+++ b/src/utils/providerProfile.test.ts
@@ -485,24 +485,31 @@ test('buildStartupEnvFromProfile leaves explicit provider selections untouched',
   assert.equal(env.OPENAI_API_KEY, undefined)
 })
 
-test('buildStartupEnvFromProfile leaves profile-managed env untouched', async () => {
+test('buildStartupEnvFromProfile lets saved startup profile override profile-managed env', async () => {
   const processEnv = {
     CLAUDE_CODE_PROVIDER_PROFILE_ENV_APPLIED: '1',
-    ANTHROPIC_BASE_URL: 'https://api.anthropic.com',
-    ANTHROPIC_MODEL: 'claude-sonnet-4-6',
+    CLAUDE_CODE_PROVIDER_PROFILE_ENV_APPLIED_ID: 'saved_ollama',
+    CLAUDE_CODE_USE_OPENAI: '1',
+    OPENAI_BASE_URL: 'http://localhost:11434/v1',
+    OPENAI_MODEL: 'llama3.1:8b',
   }
 
   const env = await buildStartupEnvFromProfile({
     persisted: profile('openai', {
       OPENAI_API_KEY: 'sk-persisted',
-      OPENAI_MODEL: 'gpt-4o',
+      OPENAI_MODEL: 'Meta-Llama-3.1-70B-Instruct',
+      OPENAI_BASE_URL: 'https://api.sambanova.ai/v1',
     }),
     processEnv,
   })
 
-  assert.equal(env, processEnv)
-  assert.equal(env.ANTHROPIC_MODEL, 'claude-sonnet-4-6')
-  assert.equal(env.OPENAI_MODEL, undefined)
+  assert.notEqual(env, processEnv)
+  assert.equal(env.CLAUDE_CODE_USE_OPENAI, '1')
+  assert.equal(env.OPENAI_API_KEY, 'sk-persisted')
+  assert.equal(env.OPENAI_MODEL, 'Meta-Llama-3.1-70B-Instruct')
+  assert.equal(env.OPENAI_BASE_URL, 'https://api.sambanova.ai/v1')
+  assert.equal(env.CLAUDE_CODE_PROVIDER_PROFILE_ENV_APPLIED, undefined)
+  assert.equal(env.CLAUDE_CODE_PROVIDER_PROFILE_ENV_APPLIED_ID, undefined)
 })
 
 test('buildStartupEnvFromProfile treats explicit falsey provider flags as user intent', async () => {

--- a/src/utils/providerProfile.ts
+++ b/src/utils/providerProfile.ts
@@ -667,14 +667,31 @@ export async function buildStartupEnvFromProfile(options?: {
   readGeminiAccessToken?: () => string | undefined
 }): Promise<NodeJS.ProcessEnv> {
   const processEnv = options?.processEnv ?? process.env
-  if (hasExplicitProviderSelection(processEnv)) {
+  const persisted = options?.persisted ?? loadProfileFile()
+
+  // Saved /provider profiles should still win over provider-manager env that was
+  // auto-applied during startup. Only explicit shell/flag provider selection
+  // should bypass the persisted startup profile.
+  const profileManagedEnv = processEnv.CLAUDE_CODE_PROVIDER_PROFILE_ENV_APPLIED === '1'
+  if (hasExplicitProviderSelection(processEnv) && !profileManagedEnv) {
     return processEnv
   }
 
-  const persisted = options?.persisted ?? loadProfileFile()
   if (!persisted) {
     return processEnv
   }
+
+  const launchProcessEnv = profileManagedEnv
+    ? (() => {
+        const cleanedEnv = { ...processEnv }
+        for (const key of PROFILE_ENV_KEYS) {
+          delete cleanedEnv[key]
+        }
+        delete cleanedEnv.CLAUDE_CODE_PROVIDER_PROFILE_ENV_APPLIED
+        delete cleanedEnv.CLAUDE_CODE_PROVIDER_PROFILE_ENV_APPLIED_ID
+        return cleanedEnv
+      })()
+    : processEnv
 
   return buildLaunchEnv({
     profile: persisted.profile,
@@ -682,7 +699,7 @@ export async function buildStartupEnvFromProfile(options?: {
     goal:
       options?.goal ??
       normalizeRecommendationGoal(processEnv.OPENCLAUDE_PROFILE_GOAL),
-    processEnv,
+    processEnv: launchProcessEnv,
     getOllamaChatBaseUrl:
       options?.getOllamaChatBaseUrl ?? getOllamaChatBaseUrl,
     resolveOllamaDefaultModel: options?.resolveOllamaDefaultModel,


### PR DESCRIPTION
## Summary
- treat profile-managed env as restart state instead of explicit user intent in `buildStartupEnvFromProfile()`
- clear stale provider-managed env keys before rebuilding startup env from the saved profile
- add a regression test covering a saved OpenAI-compatible profile replacing stale Ollama values on restart

## Test plan
- [x] `bun test src/utils/providerProfile.test.ts`
- [x] `bun run build`
- [ ] Optional manual check: save an OpenAI-compatible provider in `/provider`, restart, and confirm it no longer falls back to the previous Ollama profile

Fixes #392

🤖 Generated with [OpenClaude](https://github.com/Gitlawb/openclaude)