### PR TITLE
Error: Fix of an image in the conversation exceeds the dimension limit for many-image requests (2000px)

### DIFF
--- a/src/constants/apiLimits.ts
+++ b/src/constants/apiLimits.ts
@@ -33,14 +33,14 @@ export const IMAGE_TARGET_RAW_SIZE = (API_IMAGE_MAX_BASE64_SIZE * 3) / 4 // 3.75
  *
  * Note: The API internally resizes images larger than 1568px (source:
  * encoding/full_encoding.py), but this is handled server-side and doesn't
- * cause errors. These client-side limits (2000px) are slightly larger to
+ * cause errors. These client-side limits (1568px) are slightly larger to
  * preserve quality when beneficial.
  *
  * The API_IMAGE_MAX_BASE64_SIZE (5MB) is the actual hard limit that causes
  * API errors if exceeded.
  */
-export const IMAGE_MAX_WIDTH = 2000
-export const IMAGE_MAX_HEIGHT = 2000
+export const IMAGE_MAX_WIDTH = 1568
+export const IMAGE_MAX_HEIGHT = 1568
 
 // =============================================================================
 // PDF LIMITS


### PR DESCRIPTION
## Summary

- what changed

Changed both constants from 2000 to 1568 in src/constants/apiLimits.ts:42-43. This is the resolution the API internally downscales to anyway (documented in the API's encoding/full_encoding.py), so there is zero effective quality loss. All images are now safely below the many-image threshold.

export const IMAGE_MAX_WIDTH = 1568
export const IMAGE_MAX_HEIGHT = 1568

- why it changed

Due to the error: "Fix of an image in the conversation exceeds the dimension limit for many-image requests (2000px)"

Root cause: IMAGE_MAX_WIDTH and IMAGE_MAX_HEIGHT were set to 2000 — exactly the APIs many-image dimension limit. Images resized to exactly 2000px would get rejected when the conversation accumulated enough images to trigger the API's many-image mode.

## Impact

- user-facing impact: No
- developer/maintainer impact: The single constant change propagates everywhere — imageResizer.ts uses IMAGE_MAX_WIDTH/IMAGE_MAX_HEIGHT for all resize decisions, and the error messages reference these constants dynamically. No other files need changes.

## Testing

- [X] `bun run build`
- [X] `bun run smoke`
- [X] focused tests: Test many-image mode behavior/images greater than 2000px / fixed.

## Notes

- provider/model path tested: Executed many prints from my screen and requested to OpenClaude using Opus 4.6/Sonnet 4.6 to analyze all images; all images greater than 2000px, Opus 4.6/Sonnet 4.6 was able to analyze them.
- screenshots attached (if UI changed):
- follow-up work or known limitations: No