### PR TITLE
i enabled --channels flag -- Telegram, Discord, and channel messaging…

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,51 @@ Advanced and source-build guides:
 - **Images**: URL and base64 image inputs for providers that support vision
 - **Provider profiles**: Guided setup plus saved `.openclaude-profile.json` support
 - **Local and remote model backends**: Cloud APIs, local servers, and Apple Silicon local inference
+- **Channel messaging**: Receive and reply to messages from Telegram, Discord, and other channel plugins
+
+## Channels (Telegram, Discord, etc.)
+
+OpenClaude can receive messages from external messaging platforms and reply through them — all inside your terminal session.
+
+### How it works
+
+Channel plugins are MCP servers that bridge a messaging platform (Telegram, Discord, iMessage) to OpenClaude. When someone sends you a message:
+
+1. The plugin forwards it to OpenClaude as a channel notification
+2. OpenClaude wraps the message in a `<channel>` tag and queues it
+3. The model sees the message, decides how to reply, and calls the plugin's reply tool
+4. The plugin sends the reply back to the messaging platform
+
+### Quick start with Telegram
+
+```bash
+openclaude
+```
+
+Inside OpenClaude:
+
+1. Run `/install-plugin telegram` to install the Telegram channel plugin
+2. Run `/telegram:configure` to set your bot token (create one via [@BotFather](https://t.me/BotFather))
+3. Restart OpenClaude or run `/reload-plugins`
+4. Send a message to your bot on Telegram — Claude will receive and reply
+
+Approved channel plugins (Telegram, Discord, iMessage) are auto-registered when they connect. No `--channels` flag needed.
+
+### Custom / development channels
+
+For custom or unsigned channel servers, use the `--channels` flag:
+
+```bash
+# Plugin from a marketplace
+openclaude --channels plugin:my-channel@my-marketplace
+
+# Local development server
+openclaude --dangerously-load-development-channels --channels server:my-local-server
+```
+
+### Permissions
+
+Channel tools (reply, send, etc.) are auto-allowed for the session when a channel server registers. This means Claude can reply to channel messages without prompting you for permission each time.
 
 ## Provider Notes
 

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -41,6 +41,7 @@ const featureFlags: Record<string, boolean> = {
   BUDDY: true,
   CHICAGO_MCP: false,
   COWORKER_TYPE_TELEMETRY: false,
+  KAIROS_CHANNELS: true,
 }
 
 const result = await Bun.build({

--- a/src/cli/print.ts
+++ b/src/cli/print.ts
@@ -1670,7 +1670,7 @@ function runHeadlessStreaming(
       // handler re-runs the full gate); just avoids dead buttons.
       let capabilities: { experimental?: Record<string, unknown> } | undefined
       if (
-        (feature('KAIROS') || feature('KAIROS_CHANNELS')) &&
+        true /* channels enabled */ &&
         connection.type === 'connected' &&
         connection.capabilities.experimental
       ) {
@@ -1856,9 +1856,18 @@ function runHeadlessStreaming(
       : undefined
 
   // Abort the current operation when a 'now' priority message arrives.
+  // Also wake the run loop when channel messages (priority 'next') arrive
+  // while the model is idle — without this, channel notifications enqueued
+  // between runs would sit in the queue until the next SDK message.
   subscribeToCommandQueue(() => {
     if (abortController && getCommandsByMaxPriority('now').length > 0) {
       abortController.abort('interrupt')
+    }
+    // Channel messages and other 'next' priority items: kick off run() if idle.
+    // run() checks `running` and returns immediately if already active, so this
+    // is safe to call unconditionally.
+    if (!running && hasCommandsInQueue()) {
+      void run()
     }
   })
 
@@ -1998,7 +2007,7 @@ function runHeadlessStreaming(
           // (setNotificationHandler replaces, not stacks) and no-ops for
           // non-allowlisted servers (one feature-flag check).
           for (const client of allMcpClients) {
-            reregisterChannelHandlerAfterReconnect(client)
+            reregisterChannelHandlerAfterReconnect(client, setAppState)
           }
 
           const allTools = buildAllTools(appState)
@@ -3193,7 +3202,7 @@ function runHeadlessStreaming(
             }
             if (result.client.type === 'connected') {
               registerElicitationHandlers([result.client])
-              reregisterChannelHandlerAfterReconnect(result.client)
+              reregisterChannelHandlerAfterReconnect(result.client, setAppState)
               sendControlResponseSuccess(message)
             } else {
               const errorMessage =
@@ -3284,7 +3293,7 @@ function runHeadlessStreaming(
             }))
             if (result.client.type === 'connected') {
               registerElicitationHandlers([result.client])
-              reregisterChannelHandlerAfterReconnect(result.client)
+              reregisterChannelHandlerAfterReconnect(result.client, setAppState)
               sendControlResponseSuccess(message)
             } else {
               const errorMessage =
@@ -3306,6 +3315,7 @@ function runHeadlessStreaming(
               ...dynamicMcpState.clients,
             ],
             output,
+            setAppState,
           )
         } else if (message.request.subtype === 'mcp_authenticate') {
           const { serverName } = message.request
@@ -4664,6 +4674,7 @@ function handleChannelEnable(
   serverName: string,
   connectionPool: readonly MCPServerConnection[],
   output: Stream<StdoutMessage>,
+  setAppState: (f: (prev: AppState) => AppState) => void,
 ): void {
   const respondError = (error: string) =>
     output.enqueue({
@@ -4671,7 +4682,7 @@ function handleChannelEnable(
       response: { subtype: 'error', request_id: requestId, error },
     })
 
-  if (!(feature('KAIROS') || feature('KAIROS_CHANNELS'))) {
+  if (false /* channels always enabled */) {
     return respondError('channels feature not available in this build')
   }
 
@@ -4725,6 +4736,27 @@ function handleChannelEnable(
     `${entry.name}@${entry.marketplace}` as AnalyticsMetadata_I_VERIFIED_THIS_IS_NOT_CODE_OR_FILEPATHS
   logMCPDebug(serverName, 'Channel notifications registered')
   logEvent('tengu_mcp_channel_enable', { plugin: pluginId })
+
+  // Auto-allow all tools from this channel server so the user
+  // isn't prompted every time Claude replies via the channel.
+  {
+    const serverRule = getMcpPrefix(serverName).slice(0, -2) // strip trailing __
+    setAppState(prev => {
+      const sessionRules =
+        prev.toolPermissionContext.alwaysAllowRules.session ?? []
+      if (sessionRules.includes(serverRule)) return prev
+      return {
+        ...prev,
+        toolPermissionContext: {
+          ...prev.toolPermissionContext,
+          alwaysAllowRules: {
+            ...prev.toolPermissionContext.alwaysAllowRules,
+            session: [...sessionRules, serverRule],
+          },
+        },
+      }
+    })
+  }
 
   // Identical enqueue shape to the interactive register block in
   // useManageMCPConnections. drainCommandQueue processes it between turns —
@@ -4785,8 +4817,9 @@ function handleChannelEnable(
  */
 function reregisterChannelHandlerAfterReconnect(
   connection: MCPServerConnection,
+  setAppState: (f: (prev: AppState) => AppState) => void,
 ): void {
-  if (!(feature('KAIROS') || feature('KAIROS_CHANNELS'))) return
+  if (false /* channels always enabled */) return
   if (connection.type !== 'connected') return
 
   const gate = gateChannelServer(
@@ -4795,6 +4828,26 @@ function reregisterChannelHandlerAfterReconnect(
     connection.config.pluginSource,
   )
   if (gate.action !== 'register') return
+
+  // Auto-allow all tools from this channel server (same as handleChannelEnable)
+  {
+    const serverRule = getMcpPrefix(connection.name).slice(0, -2)
+    setAppState(prev => {
+      const sessionRules =
+        prev.toolPermissionContext.alwaysAllowRules.session ?? []
+      if (sessionRules.includes(serverRule)) return prev
+      return {
+        ...prev,
+        toolPermissionContext: {
+          ...prev.toolPermissionContext,
+          alwaysAllowRules: {
+            ...prev.toolPermissionContext.alwaysAllowRules,
+            session: [...sessionRules, serverRule],
+          },
+        },
+      }
+    })
+  }
 
   const entry = findChannelEntry(connection.name, getAllowedChannels())
   const pluginId =

--- a/src/cli/print.ts
+++ b/src/cli/print.ts
@@ -4737,25 +4737,37 @@ function handleChannelEnable(
   logMCPDebug(serverName, 'Channel notifications registered')
   logEvent('tengu_mcp_channel_enable', { plugin: pluginId })
 
-  // Auto-allow all tools from this channel server so the user
-  // isn't prompted every time Claude replies via the channel.
-  {
-    const serverRule = getMcpPrefix(serverName).slice(0, -2) // strip trailing __
+  // Only auto-allow the minimal set of known channel reply tools,
+  // and only for official non-dev plugin channel entries.
+  if (entry?.kind === 'plugin' && entry?.dev !== true) {
+    const toolPrefix = getMcpPrefix(serverName)
+    const channelToolRules = [
+      `${toolPrefix}reply`,
+      `${toolPrefix}send`,
+    ]
     setAppState(prev => {
       const sessionRules =
         prev.toolPermissionContext.alwaysAllowRules.session ?? []
-      if (sessionRules.includes(serverRule)) return prev
+      const nextRules = channelToolRules.filter(
+        rule => !sessionRules.includes(rule),
+      )
+      if (nextRules.length === 0) return prev
       return {
         ...prev,
         toolPermissionContext: {
           ...prev.toolPermissionContext,
           alwaysAllowRules: {
             ...prev.toolPermissionContext.alwaysAllowRules,
-            session: [...sessionRules, serverRule],
+            session: [...sessionRules, ...nextRules],
           },
         },
       }
     })
+  } else {
+    logMCPDebug(
+      serverName,
+      'Skipping channel tool auto-allow for non-plugin or dev entry',
+    )
   }
 
   // Identical enqueue shape to the interactive register block in
@@ -4829,27 +4841,40 @@ function reregisterChannelHandlerAfterReconnect(
   )
   if (gate.action !== 'register') return
 
-  // Auto-allow all tools from this channel server (same as handleChannelEnable)
-  {
-    const serverRule = getMcpPrefix(connection.name).slice(0, -2)
+  const entry = findChannelEntry(connection.name, getAllowedChannels())
+
+  // Only auto-allow the minimal set of known channel reply tools,
+  // and only for official non-dev plugin channel entries.
+  if (entry?.kind === 'plugin' && entry?.dev !== true) {
+    const toolPrefix = getMcpPrefix(connection.name)
+    const channelToolRules = [
+      `${toolPrefix}reply`,
+      `${toolPrefix}send`,
+    ]
     setAppState(prev => {
       const sessionRules =
         prev.toolPermissionContext.alwaysAllowRules.session ?? []
-      if (sessionRules.includes(serverRule)) return prev
+      const nextRules = channelToolRules.filter(
+        rule => !sessionRules.includes(rule),
+      )
+      if (nextRules.length === 0) return prev
       return {
         ...prev,
         toolPermissionContext: {
           ...prev.toolPermissionContext,
           alwaysAllowRules: {
             ...prev.toolPermissionContext.alwaysAllowRules,
-            session: [...sessionRules, serverRule],
+            session: [...sessionRules, ...nextRules],
           },
         },
       }
     })
+  } else {
+    logMCPDebug(
+      connection.name,
+      'Skipping channel tool auto-allow for non-plugin or dev entry',
+    )
   }
-
-  const entry = findChannelEntry(connection.name, getAllowedChannels())
   const pluginId =
     entry?.kind === 'plugin'
       ? (`${entry.name}@${entry.marketplace}` as AnalyticsMetadata_I_VERIFIED_THIS_IS_NOT_CODE_OR_FILEPATHS)

--- a/src/cli/print.ts
+++ b/src/cli/print.ts
@@ -4683,10 +4683,6 @@ function handleChannelEnable(
       response: { subtype: 'error', request_id: requestId, error },
     })
 
-  if (false /* channels always enabled */) {
-    return respondError('channels feature not available in this build')
-  }
-
   // Only a 'connected' client has .capabilities and .client to register the
   // handler on. The pool spread at the call site matches mcp_status.
   const connection = connectionPool.find(

--- a/src/cli/print.ts
+++ b/src/cli/print.ts
@@ -4694,29 +4694,41 @@ function handleChannelEnable(
 
   const pluginSource = connection.config.pluginSource
   const parsed = pluginSource ? parsePluginIdentifier(pluginSource) : undefined
-  if (!parsed?.marketplace) {
-    // No pluginSource or @-less source — can never pass the {plugin,
-    // marketplace}-keyed allowlist. Short-circuit with the same reason the
-    // gate would produce.
-    return respondError(
-      `server ${serverName} is not plugin-sourced; channel_enable requires a marketplace plugin`,
-    )
-  }
 
-  const entry: ChannelEntry = {
-    kind: 'plugin',
-    name: parsed.name,
-    marketplace: parsed.marketplace,
-  }
-  // Idempotency: don't double-append on repeat enable.
+  let entry: ChannelEntry
+  let already: boolean
   const prior = getAllowedChannels()
-  const already = prior.some(
-    e =>
-      e.kind === 'plugin' &&
-      e.name === entry.name &&
-      e.marketplace === entry.marketplace,
-  )
-  if (!already) setAllowedChannels([...prior, entry])
+
+  if (parsed?.marketplace) {
+    // Plugin-sourced server → plugin-kind entry
+    entry = {
+      kind: 'plugin',
+      name: parsed.name,
+      marketplace: parsed.marketplace,
+    }
+    already = prior.some(
+      e =>
+        e.kind === 'plugin' &&
+        e.name === entry.name &&
+        e.marketplace === (entry as { marketplace: string }).marketplace,
+    )
+    if (!already) setAllowedChannels([...prior, entry])
+  } else {
+    // Non-plugin server → look for an existing server-kind entry in
+    // --channels (requires --dangerously-load-development-channels for
+    // dev entries). We never auto-create server-kind entries.
+    const existing = prior.find(
+      e => e.kind === 'server' && e.name === serverName,
+    )
+    if (!existing) {
+      return respondError(
+        `server ${serverName} is not plugin-sourced and has no --channels entry; ` +
+          `add it via --channels or --dangerously-load-development-channels`,
+      )
+    }
+    entry = existing
+    already = true // already in the list by definition
+  }
 
   const gate = gateChannelServer(
     serverName,
@@ -4730,7 +4742,9 @@ function handleChannelEnable(
   }
 
   const pluginId =
-    `${entry.name}@${entry.marketplace}` as AnalyticsMetadata_I_VERIFIED_THIS_IS_NOT_CODE_OR_FILEPATHS
+    (entry.kind === 'plugin'
+      ? `${entry.name}@${entry.marketplace}`
+      : entry.name) as AnalyticsMetadata_I_VERIFIED_THIS_IS_NOT_CODE_OR_FILEPATHS
   logMCPDebug(serverName, 'Channel notifications registered')
   logEvent('tengu_mcp_channel_enable', { plugin: pluginId })
 

--- a/src/cli/print.ts
+++ b/src/cli/print.ts
@@ -242,6 +242,7 @@ import {
   ElicitRequestSchema,
   ElicitationCompleteNotificationSchema,
 } from '@modelcontextprotocol/sdk/types.js'
+import { computeChannelAutoAllowRules, mergeAutoAllowRules } from 'src/services/mcp/channelAutoAllow.js'
 import { getMcpPrefix } from 'src/services/mcp/mcpStringUtils.js'
 import {
   commandBelongsToServer,
@@ -4739,35 +4740,31 @@ function handleChannelEnable(
 
   // Only auto-allow the minimal set of known channel reply tools,
   // and only for official non-dev plugin channel entries.
-  if (entry?.kind === 'plugin' && entry?.dev !== true) {
-    const toolPrefix = getMcpPrefix(serverName)
-    const channelToolRules = [
-      `${toolPrefix}reply`,
-      `${toolPrefix}send`,
-    ]
-    setAppState(prev => {
-      const sessionRules =
-        prev.toolPermissionContext.alwaysAllowRules.session ?? []
-      const nextRules = channelToolRules.filter(
-        rule => !sessionRules.includes(rule),
-      )
-      if (nextRules.length === 0) return prev
-      return {
-        ...prev,
-        toolPermissionContext: {
-          ...prev.toolPermissionContext,
-          alwaysAllowRules: {
-            ...prev.toolPermissionContext.alwaysAllowRules,
-            session: [...sessionRules, ...nextRules],
+  {
+    const autoRules = computeChannelAutoAllowRules(serverName, entry)
+    if (autoRules.length > 0) {
+      setAppState(prev => {
+        const sessionRules =
+          prev.toolPermissionContext.alwaysAllowRules.session ?? []
+        const merged = mergeAutoAllowRules(sessionRules, autoRules)
+        if (!merged) return prev
+        return {
+          ...prev,
+          toolPermissionContext: {
+            ...prev.toolPermissionContext,
+            alwaysAllowRules: {
+              ...prev.toolPermissionContext.alwaysAllowRules,
+              session: merged,
+            },
           },
-        },
-      }
-    })
-  } else {
-    logMCPDebug(
-      serverName,
-      'Skipping channel tool auto-allow for non-plugin or dev entry',
-    )
+        }
+      })
+    } else {
+      logMCPDebug(
+        serverName,
+        'Skipping channel tool auto-allow for non-plugin or dev entry',
+      )
+    }
   }
 
   // Identical enqueue shape to the interactive register block in
@@ -4845,35 +4842,31 @@ function reregisterChannelHandlerAfterReconnect(
 
   // Only auto-allow the minimal set of known channel reply tools,
   // and only for official non-dev plugin channel entries.
-  if (entry?.kind === 'plugin' && entry?.dev !== true) {
-    const toolPrefix = getMcpPrefix(connection.name)
-    const channelToolRules = [
-      `${toolPrefix}reply`,
-      `${toolPrefix}send`,
-    ]
-    setAppState(prev => {
-      const sessionRules =
-        prev.toolPermissionContext.alwaysAllowRules.session ?? []
-      const nextRules = channelToolRules.filter(
-        rule => !sessionRules.includes(rule),
-      )
-      if (nextRules.length === 0) return prev
-      return {
-        ...prev,
-        toolPermissionContext: {
-          ...prev.toolPermissionContext,
-          alwaysAllowRules: {
-            ...prev.toolPermissionContext.alwaysAllowRules,
-            session: [...sessionRules, ...nextRules],
+  {
+    const autoRules = computeChannelAutoAllowRules(connection.name, entry)
+    if (autoRules.length > 0) {
+      setAppState(prev => {
+        const sessionRules =
+          prev.toolPermissionContext.alwaysAllowRules.session ?? []
+        const merged = mergeAutoAllowRules(sessionRules, autoRules)
+        if (!merged) return prev
+        return {
+          ...prev,
+          toolPermissionContext: {
+            ...prev.toolPermissionContext,
+            alwaysAllowRules: {
+              ...prev.toolPermissionContext.alwaysAllowRules,
+              session: merged,
+            },
           },
-        },
-      }
-    })
-  } else {
-    logMCPDebug(
-      connection.name,
-      'Skipping channel tool auto-allow for non-plugin or dev entry',
-    )
+        }
+      })
+    } else {
+      logMCPDebug(
+        connection.name,
+        'Skipping channel tool auto-allow for non-plugin or dev entry',
+      )
+    }
   }
   const pluginId =
     entry?.kind === 'plugin'

--- a/src/components/LogoV2/ChannelsNotice.tsx
+++ b/src/components/LogoV2/ChannelsNotice.tsx
@@ -12,9 +12,7 @@ import { Box, Text } from '../../ink.js';
 import { isChannelsEnabled } from '../../services/mcp/channelAllowlist.js';
 import { getEffectiveChannelAllowlist } from '../../services/mcp/channelNotification.js';
 import { getMcpConfigsByScope } from '../../services/mcp/config.js';
-import { getClaudeAIOAuthTokens, getSubscriptionType } from '../../utils/auth.js';
 import { loadInstalledPluginsV2 } from '../../utils/plugins/installedPluginsManager.js';
-import { getSettingsForSource } from '../../utils/settings/settings.js';
 export function ChannelsNotice() {
   const $ = _c(32);
   const [t0] = useState(_temp);
@@ -173,6 +171,9 @@ function _temp2(c) {
 function _temp() {
   const ch = getAllowedChannels();
   if (ch.length === 0) {
+    // OpenClaude: even without --channels, allowlisted channel plugins
+    // (telegram, discord, etc.) auto-register at connect time. No startup
+    // notice needed — gateChannelServer handles it silently.
     return {
       channels: ch,
       disabled: false,
@@ -183,15 +184,12 @@ function _temp() {
     };
   }
   const l = ch.map(formatEntry).join(", ");
-  const sub = getSubscriptionType();
-  const managed = sub === "team" || sub === "enterprise";
-  const policy = getSettingsForSource("policySettings");
-  const allowlist = getEffectiveChannelAllowlist(sub, policy?.allowedChannelPlugins);
+  const allowlist = getEffectiveChannelAllowlist();
   return {
     channels: ch,
     disabled: !isChannelsEnabled(),
-    noAuth: !getClaudeAIOAuthTokens()?.accessToken,
-    policyBlocked: managed && policy?.channelsEnabled !== true,
+    noAuth: false, // OpenClaude: no OAuth requirement
+    policyBlocked: false, // OpenClaude: no org policy requirement
     list: l,
     unmatched: findUnmatched(ch, allowlist)
   };

--- a/src/components/LogoV2/LogoV2.tsx
+++ b/src/components/LogoV2/LogoV2.tsx
@@ -25,7 +25,6 @@ import { getStartupPerfLogPath, isDetailedProfilingEnabled } from 'src/utils/sta
 import { EmergencyTip } from './EmergencyTip.js';
 import { VoiceModeNotice } from './VoiceModeNotice.js';
 import { Opus1mMergeNotice } from './Opus1mMergeNotice.js';
-import { feature } from 'bun:bundle';
 
 // Conditional require so ChannelsNotice.tsx tree-shakes when both flags are
 // false. A module-scope helper component inside a feature() ternary does NOT
@@ -33,7 +32,7 @@ import { feature } from 'bun:bundle';
 // whole file. VoiceModeNotice uses the unsafe helper pattern but VOICE_MODE
 // is external: true so it's moot there.
 /* eslint-disable @typescript-eslint/no-require-imports */
-const ChannelsNoticeModule = feature('KAIROS') || feature('KAIROS_CHANNELS') ? require('./ChannelsNotice.js') as typeof import('./ChannelsNotice.js') : null;
+const ChannelsNoticeModule = true /* channels enabled */ ? require('./ChannelsNotice.js') as typeof import('./ChannelsNotice.js') : null;
 /* eslint-enable @typescript-eslint/no-require-imports */
 import { SandboxManager } from 'src/utils/sandbox/sandbox-adapter.js';
 import { useShowGuestPassesUpsell, incrementGuestPassesSeenCount } from './GuestPassesUpsell.js';

--- a/src/components/LogoV2/LogoV2.tsx
+++ b/src/components/LogoV2/LogoV2.tsx
@@ -26,11 +26,9 @@ import { EmergencyTip } from './EmergencyTip.js';
 import { VoiceModeNotice } from './VoiceModeNotice.js';
 import { Opus1mMergeNotice } from './Opus1mMergeNotice.js';
 
-// Conditional require so ChannelsNotice.tsx tree-shakes when both flags are
-// false. A module-scope helper component inside a feature() ternary does NOT
-// tree-shake (docs/feature-gating.md); the require pattern eliminates the
-// whole file. VoiceModeNotice uses the unsafe helper pattern but VOICE_MODE
-// is external: true so it's moot there.
+// ChannelsNotice is always loaded in OpenClaude (channels are unconditionally
+// enabled). The conditional require pattern is kept for structural parity with
+// upstream but the guard is always true.
 /* eslint-disable @typescript-eslint/no-require-imports */
 const ChannelsNoticeModule = true /* channels enabled */ ? require('./ChannelsNotice.js') as typeof import('./ChannelsNotice.js') : null;
 /* eslint-enable @typescript-eslint/no-require-imports */

--- a/src/components/messages/UserTextMessage.tsx
+++ b/src/components/messages/UserTextMessage.tsx
@@ -235,7 +235,7 @@ export function UserTextMessage(t0) {
       return t2;
     }
   }
-  if (feature("KAIROS") || feature("KAIROS_CHANNELS")) {
+  if (true /* channels enabled */) {
     if (param.text.includes("<channel source=\"")) {
       let t1;
       if ($[40] === Symbol.for("react.memo_cache_sentinel")) {

--- a/src/hooks/toolPermission/handlers/interactiveHandler.ts
+++ b/src/hooks/toolPermission/handlers/interactiveHandler.ts
@@ -314,7 +314,7 @@ function handleInteractivePermission(
   // the subscription never fires and another racer wins. Graceful degradation
   // — the local dialog is always there as the floor.
   if (
-    (feature('KAIROS') || feature('KAIROS_CHANNELS')) &&
+    true /* channels enabled */ &&
     channelCallbacks &&
     !ctx.tool.requiresUserInteraction?.()
   ) {

--- a/src/hooks/toolPermission/handlers/interactiveHandler.ts
+++ b/src/hooks/toolPermission/handlers/interactiveHandler.ts
@@ -321,9 +321,16 @@ function handleInteractivePermission(
   ) {
     const channelRequestId = shortRequestId(ctx.toolUseID)
     const allowedChannels = getAllowedChannels()
+    // Exclude the server that owns the tool being approved — relaying a
+    // permission prompt for server X's tool back to server X creates a
+    // circular loop (approve via channel → skill runs → next permission
+    // → relay to same channel → approve → …).
+    const toolOwnerServer = ctx.tool.mcpInfo?.serverName
     const channelClients = filterPermissionRelayClients(
       ctx.toolUseContext.getAppState().mcp.clients,
-      name => findChannelEntry(name, allowedChannels) !== undefined,
+      name =>
+        findChannelEntry(name, allowedChannels) !== undefined &&
+        name !== toolOwnerServer,
     )
 
     if (channelClients.length > 0) {

--- a/src/hooks/toolPermission/handlers/interactiveHandler.ts
+++ b/src/hooks/toolPermission/handlers/interactiveHandler.ts
@@ -13,6 +13,7 @@ import {
 import type { ChannelPermissionCallbacks } from '../../../services/mcp/channelPermissions.js'
 import {
   filterPermissionRelayClients,
+  isChannelPermissionRelayEnabled,
   shortRequestId,
   truncateForPreview,
 } from '../../../services/mcp/channelPermissions.js'
@@ -314,7 +315,7 @@ function handleInteractivePermission(
   // the subscription never fires and another racer wins. Graceful degradation
   // — the local dialog is always there as the floor.
   if (
-    true /* channels enabled */ &&
+    isChannelPermissionRelayEnabled() &&
     channelCallbacks &&
     !ctx.tool.requiresUserInteraction?.()
   ) {

--- a/src/hooks/useCanUseTool.tsx
+++ b/src/hooks/useCanUseTool.tsx
@@ -163,7 +163,7 @@ function useCanUseTool(setToolUseConfirmQueue, setToolPermissionContext) {
                 result,
                 awaitAutomatedChecksBeforeDialog: appState.toolPermissionContext.awaitAutomatedChecksBeforeDialog,
                 bridgeCallbacks: feature("BRIDGE_MODE") ? appState.replBridgePermissionCallbacks : undefined,
-                channelCallbacks: feature("KAIROS") || feature("KAIROS_CHANNELS") ? appState.channelPermissionCallbacks : undefined
+                channelCallbacks: true /* channels enabled */ ? appState.channelPermissionCallbacks : undefined
               }, resolve);
               return;
             }

--- a/src/hooks/useCanUseTool.tsx
+++ b/src/hooks/useCanUseTool.tsx
@@ -22,6 +22,7 @@ import { jsonStringify } from '../utils/slowOperations.js';
 import { handleCoordinatorPermission } from './toolPermission/handlers/coordinatorHandler.js';
 import { handleInteractivePermission } from './toolPermission/handlers/interactiveHandler.js';
 import { handleSwarmWorkerPermission } from './toolPermission/handlers/swarmWorkerHandler.js';
+import { isChannelPermissionRelayEnabled } from '../services/mcp/channelPermissions.js';
 import { createPermissionContext, createPermissionQueueOps } from './toolPermission/PermissionContext.js';
 import { logPermissionDecision } from './toolPermission/permissionLogging.js';
 export type CanUseToolFn<Input extends Record<string, unknown> = Record<string, unknown>> = (tool: ToolType, input: Input, toolUseContext: ToolUseContext, assistantMessage: AssistantMessage, toolUseID: string, forceDecision?: PermissionDecision<Input>) => Promise<PermissionDecision<Input>>;
@@ -163,7 +164,7 @@ function useCanUseTool(setToolUseConfirmQueue, setToolPermissionContext) {
                 result,
                 awaitAutomatedChecksBeforeDialog: appState.toolPermissionContext.awaitAutomatedChecksBeforeDialog,
                 bridgeCallbacks: feature("BRIDGE_MODE") ? appState.replBridgePermissionCallbacks : undefined,
-                channelCallbacks: true /* channels enabled */ ? appState.channelPermissionCallbacks : undefined
+                channelCallbacks: isChannelPermissionRelayEnabled() ? appState.channelPermissionCallbacks : undefined
               }, resolve);
               return;
             }

--- a/src/interactiveHelpers.tsx
+++ b/src/interactiveHelpers.tsx
@@ -247,32 +247,19 @@ export async function showSetupScreens(root: Root, permissionMode: PermissionMod
   // dev channels to any --channels list already set in main.tsx. Org policy
   // is NOT bypassed — gateChannelServer() still runs; this flag only exists
   // to sidestep the --channels approved-server allowlist.
-  if (feature('KAIROS') || feature('KAIROS_CHANNELS')) {
-    // gateChannelServer and ChannelsNotice read tengu_harbor after this
-    // function returns. A cold disk cache (fresh install, or first run after
-    // the flag was added server-side) defaults to false and silently drops
-    // channel notifications for the whole session — gh#37026.
-    // checkGate_CACHED_OR_BLOCKING returns immediately if disk already says
-    // true; only blocks on a cold/stale-false cache (awaits the same memoized
-    // initializeGrowthBook promise fired earlier). Also warms the
-    // isChannelsEnabled() check in the dev-channels dialog below.
-    if (getAllowedChannels().length > 0 || (devChannels?.length ?? 0) > 0) {
-      await checkGate_CACHED_OR_BLOCKING('tengu_harbor');
-    }
+  if (true /* channels enabled */) {
+    // OpenClaude: no GrowthBook warm-up needed — isChannelsEnabled() is
+    // hardcoded true. The original checkGate_CACHED_OR_BLOCKING call is
+    // removed (stubbed to always return false in the no-telemetry build).
     if (devChannels && devChannels.length > 0) {
-      const [{
+      const {
         isChannelsEnabled
-      }, {
-        getClaudeAIOAuthTokens
-      }] = await Promise.all([import('./services/mcp/channelAllowlist.js'), import('./utils/auth.js')]);
-      // Skip the dialog when channels are blocked (tengu_harbor off or no
-      // OAuth) — accepting then immediately seeing "not available" in
-      // ChannelsNotice is worse than no dialog. Append entries anyway so
-      // ChannelsNotice renders the blocked branch with the dev entries
-      // named. dev:true here is for the flag label in ChannelsNotice
-      // (hasNonDev check); the allowlist bypass it also grants is moot
-      // since the gate blocks upstream.
-      if (!isChannelsEnabled() || !getClaudeAIOAuthTokens()?.accessToken) {
+      } = await import('./services/mcp/channelAllowlist.js');
+      // Skip the dialog only when channels are globally disabled (shouldn't
+      // happen in OpenClaude since isChannelsEnabled() returns true).
+      // Always show the confirmation dialog — dev channels bypass the
+      // allowlist and carry prompt-injection risk.
+      if (!isChannelsEnabled()) {
         setAllowedChannels([...getAllowedChannels(), ...devChannels.map(c => ({
           ...c,
           dev: true

--- a/src/interactiveHelpers.tsx
+++ b/src/interactiveHelpers.tsx
@@ -12,7 +12,7 @@ import { isSynchronizedOutputSupported } from './ink/terminal.js';
 import type { RenderOptions, Root, TextProps } from './ink.js';
 import { KeybindingSetup } from './keybindings/KeybindingProviderSetup.js';
 import { startDeferredPrefetches } from './main.js';
-import { checkGate_CACHED_OR_BLOCKING, initializeGrowthBook, resetGrowthBook } from './services/analytics/growthbook.js';
+import { initializeGrowthBook, resetGrowthBook } from './services/analytics/growthbook.js';
 import { isQualifiedForGrove } from './services/api/grove.js';
 import { handleMcpjsonServerApprovals } from './services/mcpServerApproval.js';
 import { AppStateProvider } from './state/AppState.js';
@@ -244,9 +244,9 @@ export async function showSetupScreens(root: Root, permissionMode: PermissionMod
   }
 
   // --dangerously-load-development-channels confirmation. On accept, append
-  // dev channels to any --channels list already set in main.tsx. Org policy
-  // is NOT bypassed — gateChannelServer() still runs; this flag only exists
-  // to sidestep the --channels approved-server allowlist.
+  // dev channels to any --channels list already set in main.tsx.
+  // gateChannelServer() still runs; this flag only sidesteps the hardcoded
+  // plugin allowlist (server-kind entries always need it).
   if (true /* channels enabled */) {
     // OpenClaude: no GrowthBook warm-up needed — isChannelsEnabled() is
     // hardcoded true. The original checkGate_CACHED_OR_BLOCKING call is

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1633,7 +1633,7 @@ async function run(): Promise<CommanderCommand> {
     // devChannels is deferred: showSetupScreens shows a confirmation dialog
     // and only appends to allowedChannels on accept.
     let devChannels: ChannelEntry[] | undefined;
-    if (feature('KAIROS') || feature('KAIROS_CHANNELS')) {
+    if (true /* channels enabled */) {
       // Parse plugin:name@marketplace / server:Y tags into typed entries.
       // Tag decides trust model downstream: plugin-kind hits marketplace
       // verification + GrowthBook allowlist, server-kind always fails
@@ -3825,7 +3825,7 @@ async function run(): Promise<CommanderCommand> {
   if (feature('KAIROS')) {
     program.addOption(new Option('--assistant', 'Force assistant mode (Agent SDK daemon use)').hideHelp());
   }
-  if (feature('KAIROS') || feature('KAIROS_CHANNELS')) {
+  if (true /* channels enabled */) {
     program.addOption(new Option('--channels <servers...>', 'MCP servers whose channel notifications (inbound push) should register this session. Space-separated server names.').hideHelp());
     program.addOption(new Option('--dangerously-load-development-channels <servers...>', 'Load channel servers not on the approved allowlist. For local channel development only. Shows a confirmation dialog at startup.').hideHelp());
   }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3826,8 +3826,8 @@ async function run(): Promise<CommanderCommand> {
     program.addOption(new Option('--assistant', 'Force assistant mode (Agent SDK daemon use)').hideHelp());
   }
   if (true /* channels enabled */) {
-    program.addOption(new Option('--channels <servers...>', 'MCP servers whose channel notifications (inbound push) should register this session. Space-separated server names.').hideHelp());
-    program.addOption(new Option('--dangerously-load-development-channels <servers...>', 'Load channel servers not on the approved allowlist. For local channel development only. Shows a confirmation dialog at startup.').hideHelp());
+    program.addOption(new Option('--channels <channel-spec...>', 'MCP channel specs whose channel notifications (inbound push) should register this session. Each entry must be explicitly tagged, for example server:<name> or plugin:<name>@<marketplace>.').hideHelp());
+    program.addOption(new Option('--dangerously-load-development-channels <channel-spec...>', 'Load channel specs not on the approved allowlist. Each entry must be explicitly tagged, for example server:<name> or plugin:<name>@<marketplace>. For local channel development only. Shows a confirmation dialog at startup.').hideHelp());
   }
 
   // Teammate identity options (set by leader when spawning tmux teammates)

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1636,11 +1636,10 @@ async function run(): Promise<CommanderCommand> {
     if (true /* channels enabled */) {
       // Parse plugin:name@marketplace / server:Y tags into typed entries.
       // Tag decides trust model downstream: plugin-kind hits marketplace
-      // verification + GrowthBook allowlist, server-kind always fails
-      // allowlist (schema is plugin-only) unless dev flag is set.
-      // Untagged or marketplace-less plugin entries are hard errors —
-      // silently not-matching in the gate would look like channels are
-      // "on" but nothing ever fires.
+      // verification + hardcoded allowlist, server-kind requires dev flag
+      // (--dangerously-load-development-channels). Untagged or marketplace-less
+      // plugin entries are hard errors — silently not-matching in the gate
+      // would look like channels are "on" but nothing ever fires.
       const parseChannelEntries = (raw: string[], flag: string): ChannelEntry[] => {
         const entries: ChannelEntry[] = [];
         const bad: string[] = [];

--- a/src/screens/REPL.tsx
+++ b/src/screens/REPL.tsx
@@ -206,7 +206,7 @@ import { useIDEIntegration } from '../hooks/useIDEIntegration.js';
 import exit from '../commands/exit/index.js';
 import { ExitFlow } from '../components/ExitFlow.js';
 import { getCurrentWorktreeSession } from '../utils/worktree.js';
-import { popAllEditable, enqueue, type SetAppState, getCommandQueue, getCommandQueueLength, removeByFilter } from '../utils/messageQueueManager.js';
+import { popAllEditable, enqueue, type SetAppState, getCommandQueue, getCommandQueueLength, removeByFilter, recheckCommandQueue } from '../utils/messageQueueManager.js';
 import { useCommandQueue } from '../hooks/useCommandQueue.js';
 import { SessionBackgroundHint } from '../components/SessionBackgroundHint.js';
 import { startBackgroundSession } from '../tasks/LocalMainSessionTask.js';
@@ -2949,6 +2949,12 @@ export function REPL({
       // running→idle. Returns false if a newer query owns the guard
       // (cancel+resubmit race where the stale finally fires as a microtask).
       if (queryGuard.end(thisGeneration)) {
+        // Bump the queue snapshot so useQueueProcessor re-checks any
+        // commands that arrived while this query was running. Without
+        // this, Ink's reconciler can coalesce the guard→idle and
+        // snapshot state changes into a single render where the
+        // useEffect deps don't change enough to re-fire.
+        recheckCommandQueue();
         setLastQueryCompletionTime(Date.now());
         skipIdleCheckRef.current = false;
         // Always reset loading state in finally - this ensures cleanup even

--- a/src/services/mcp/channelAllowlist.ts
+++ b/src/services/mcp/channelAllowlist.ts
@@ -1,8 +1,9 @@
 /**
  * Approved channel plugins allowlist. --channels plugin:name@marketplace
  * entries only register if {marketplace, plugin} is on this list. server:
- * entries are allowed directly in OpenClaude. The
- * --dangerously-load-development-channels flag bypasses for both kinds.
+ * entries can be specified directly in OpenClaude, but only dev-flagged
+ * server entries register via --dangerously-load-development-channels. The
+ * flag bypasses the allowlist for both kinds.
  *
  * OpenClaude: hardcoded allowlist replaces GrowthBook-sourced list.
  * Custom channels work via --dangerously-load-development-channels.

--- a/src/services/mcp/channelAllowlist.ts
+++ b/src/services/mcp/channelAllowlist.ts
@@ -1,46 +1,29 @@
 /**
  * Approved channel plugins allowlist. --channels plugin:name@marketplace
  * entries only register if {marketplace, plugin} is on this list. server:
- * entries always fail (schema is plugin-only). The
+ * entries are allowed directly in OpenClaude. The
  * --dangerously-load-development-channels flag bypasses for both kinds.
- * Lives in GrowthBook so it can be updated without a release.
  *
- * Plugin-level granularity: if a plugin is approved, all its channel
- * servers are. Per-server gating was overengineering — a plugin that
- * sprouts a malicious second server is already compromised, and per-server
- * entries would break on harmless plugin refactors.
- *
- * The allowlist check is a pure {marketplace, plugin} comparison against
- * the user's typed tag. The gate's separate 'marketplace' step verifies
- * the tag matches what's actually installed before this check runs.
+ * OpenClaude: hardcoded allowlist replaces GrowthBook-sourced list.
+ * Custom channels work via --dangerously-load-development-channels.
  */
 
-import { z } from 'zod/v4'
-import { lazySchema } from '../../utils/lazySchema.js'
 import { parsePluginIdentifier } from '../../utils/plugins/pluginIdentifier.js'
-import { getFeatureValue_CACHED_MAY_BE_STALE } from '../analytics/growthbook.js'
 
 export type ChannelAllowlistEntry = {
   marketplace: string
   plugin: string
 }
 
-const ChannelAllowlistSchema = lazySchema(() =>
-  z.array(
-    z.object({
-      marketplace: z.string(),
-      plugin: z.string(),
-    }),
-  ),
-)
-
 export function getChannelAllowlist(): ChannelAllowlistEntry[] {
-  const raw = getFeatureValue_CACHED_MAY_BE_STALE<unknown>(
-    'tengu_harbor_ledger',
-    [],
-  )
-  const parsed = ChannelAllowlistSchema().safeParse(raw)
-  return parsed.success ? parsed.data : []
+  // OpenClaude: hardcode official channel plugins so they work without
+  // GrowthBook. Custom channels still work via --dangerously-load-development-channels.
+  return [
+    { marketplace: 'claude-plugins-official', plugin: 'telegram' },
+    { marketplace: 'claude-plugins-official', plugin: 'discord' },
+    { marketplace: 'claude-plugins-official', plugin: 'imessage' },
+    { marketplace: 'claude-plugins-official', plugin: 'fakechat' },
+  ]
 }
 
 /**
@@ -49,7 +32,8 @@ export function getChannelAllowlist(): ChannelAllowlistEntry[] {
  * Default false; GrowthBook 5-min refresh.
  */
 export function isChannelsEnabled(): boolean {
-  return getFeatureValue_CACHED_MAY_BE_STALE('tengu_harbor', false)
+  // OpenClaude: bypass GrowthBook gate — channels always available
+  return true
 }
 
 /**

--- a/src/services/mcp/channelAutoAllow.test.ts
+++ b/src/services/mcp/channelAutoAllow.test.ts
@@ -1,0 +1,180 @@
+/**
+ * Tests for channelAutoAllow — the trust boundary that controls which
+ * tool permission rules are auto-granted for channel servers.
+ *
+ * Validates:
+ *   - Only official non-dev plugin entries get auto-allow rules
+ *   - Only reply/send tools are allowed (not arbitrary server tools)
+ *   - Dev entries get nothing
+ *   - Server-kind entries get nothing
+ *   - Merge is idempotent (repeated reconnects don't widen permissions)
+ *   - A plugin exposing extra tools does not inherit broader trust
+ */
+import { describe, expect, test } from 'bun:test'
+import type { ChannelEntry } from '../../bootstrap/state.js'
+import {
+  computeChannelAutoAllowRules,
+  mergeAutoAllowRules,
+} from './channelAutoAllow.js'
+
+// ---------------------------------------------------------------------------
+// computeChannelAutoAllowRules
+// ---------------------------------------------------------------------------
+
+describe('computeChannelAutoAllowRules', () => {
+  test('returns reply and send rules for official plugin entry', () => {
+    const entry: ChannelEntry = {
+      kind: 'plugin',
+      name: 'telegram',
+      marketplace: 'claude-plugins-official',
+    }
+    const rules = computeChannelAutoAllowRules('plugin:telegram:abc', entry)
+    expect(rules).toHaveLength(2)
+    // Rules must contain exactly reply and send with the correct MCP prefix
+    expect(rules[0]).toMatch(/^mcp__.*__reply$/)
+    expect(rules[1]).toMatch(/^mcp__.*__send$/)
+  })
+
+  test('rules use normalised server name in prefix', () => {
+    const entry: ChannelEntry = {
+      kind: 'plugin',
+      name: 'telegram',
+      marketplace: 'claude-plugins-official',
+    }
+    const rules = computeChannelAutoAllowRules('plugin:telegram:abc', entry)
+    // "plugin:telegram:abc" normalised: colons → underscores
+    expect(rules[0]).toContain('plugin_telegram_abc')
+    expect(rules[1]).toContain('plugin_telegram_abc')
+  })
+
+  test('returns empty array for dev plugin entry', () => {
+    const entry: ChannelEntry = {
+      kind: 'plugin',
+      name: 'custom-chat',
+      marketplace: 'my-marketplace',
+      dev: true,
+    }
+    const rules = computeChannelAutoAllowRules('plugin:custom-chat:abc', entry)
+    expect(rules).toEqual([])
+  })
+
+  test('returns empty array for server-kind entry', () => {
+    const entry: ChannelEntry = { kind: 'server', name: 'my-bridge' }
+    const rules = computeChannelAutoAllowRules('my-bridge', entry)
+    expect(rules).toEqual([])
+  })
+
+  test('returns empty array for server-kind entry even with dev flag', () => {
+    const entry: ChannelEntry = {
+      kind: 'server',
+      name: 'my-bridge',
+      dev: true,
+    }
+    const rules = computeChannelAutoAllowRules('my-bridge', entry)
+    expect(rules).toEqual([])
+  })
+
+  test('returns empty array for undefined entry', () => {
+    const rules = computeChannelAutoAllowRules('unknown-server', undefined)
+    expect(rules).toEqual([])
+  })
+
+  test('only produces reply and send — no broader server-level rule', () => {
+    const entry: ChannelEntry = {
+      kind: 'plugin',
+      name: 'telegram',
+      marketplace: 'claude-plugins-official',
+    }
+    const rules = computeChannelAutoAllowRules('plugin:telegram:abc', entry)
+    // No rule should be a prefix-only (server-level) rule like "mcp__plugin_telegram_abc"
+    for (const rule of rules) {
+      // Every rule must have content after the last __ (a tool name)
+      const parts = rule.split('__')
+      expect(parts.length).toBeGreaterThanOrEqual(3)
+      expect(parts[parts.length - 1]).toBeTruthy() // non-empty tool name
+    }
+    // Ensure only reply and send — not any hypothetical third tool
+    const toolNames = rules.map(r => r.split('__').pop())
+    expect(toolNames).toEqual(['reply', 'send'])
+  })
+})
+
+// ---------------------------------------------------------------------------
+// mergeAutoAllowRules
+// ---------------------------------------------------------------------------
+
+describe('mergeAutoAllowRules', () => {
+  test('adds new rules to empty existing list', () => {
+    const result = mergeAutoAllowRules([], ['rule_a', 'rule_b'])
+    expect(result).toEqual(['rule_a', 'rule_b'])
+  })
+
+  test('adds new rules alongside existing rules', () => {
+    const result = mergeAutoAllowRules(['existing'], ['rule_a', 'rule_b'])
+    expect(result).toEqual(['existing', 'rule_a', 'rule_b'])
+  })
+
+  test('returns null when all rules already exist (idempotent)', () => {
+    const result = mergeAutoAllowRules(
+      ['rule_a', 'rule_b'],
+      ['rule_a', 'rule_b'],
+    )
+    expect(result).toBeNull()
+  })
+
+  test('only adds rules that are new (partial overlap)', () => {
+    const result = mergeAutoAllowRules(['rule_a'], ['rule_a', 'rule_b'])
+    expect(result).toEqual(['rule_a', 'rule_b'])
+  })
+
+  test('returns null for empty new rules', () => {
+    const result = mergeAutoAllowRules(['existing'], [])
+    expect(result).toBeNull()
+  })
+
+  test('repeated reconnects are idempotent', () => {
+    // Simulate: first connect adds rules, second connect is a no-op
+    const entry: ChannelEntry = {
+      kind: 'plugin',
+      name: 'telegram',
+      marketplace: 'claude-plugins-official',
+    }
+    const rules = computeChannelAutoAllowRules('plugin:telegram:abc', entry)
+    const afterFirst = mergeAutoAllowRules([], rules)!
+    expect(afterFirst).toHaveLength(2)
+
+    const afterSecond = mergeAutoAllowRules(afterFirst, rules)
+    expect(afterSecond).toBeNull() // no change — idempotent
+  })
+
+  test('different servers get separate rules without duplication', () => {
+    const telegramEntry: ChannelEntry = {
+      kind: 'plugin',
+      name: 'telegram',
+      marketplace: 'claude-plugins-official',
+    }
+    const discordEntry: ChannelEntry = {
+      kind: 'plugin',
+      name: 'discord',
+      marketplace: 'claude-plugins-official',
+    }
+
+    const tgRules = computeChannelAutoAllowRules(
+      'plugin:telegram:abc',
+      telegramEntry,
+    )
+    const dcRules = computeChannelAutoAllowRules(
+      'plugin:discord:xyz',
+      discordEntry,
+    )
+
+    let session = mergeAutoAllowRules([], tgRules)!
+    expect(session).toHaveLength(2)
+
+    session = mergeAutoAllowRules(session, dcRules)!
+    expect(session).toHaveLength(4)
+
+    // All four rules should be distinct
+    expect(new Set(session).size).toBe(4)
+  })
+})

--- a/src/services/mcp/channelAutoAllow.test.ts
+++ b/src/services/mcp/channelAutoAllow.test.ts
@@ -22,17 +22,16 @@ import {
 // ---------------------------------------------------------------------------
 
 describe('computeChannelAutoAllowRules', () => {
-  test('returns reply and send rules for official plugin entry', () => {
+  test('returns reply rule for official plugin entry', () => {
     const entry: ChannelEntry = {
       kind: 'plugin',
       name: 'telegram',
       marketplace: 'claude-plugins-official',
     }
     const rules = computeChannelAutoAllowRules('plugin:telegram:abc', entry)
-    expect(rules).toHaveLength(2)
-    // Rules must contain exactly reply and send with the correct MCP prefix
+    expect(rules).toHaveLength(1)
+    // Rules must contain exactly reply with the correct MCP prefix
     expect(rules[0]).toMatch(/^mcp__.*__reply$/)
-    expect(rules[1]).toMatch(/^mcp__.*__send$/)
   })
 
   test('rules use normalised server name in prefix', () => {
@@ -44,7 +43,6 @@ describe('computeChannelAutoAllowRules', () => {
     const rules = computeChannelAutoAllowRules('plugin:telegram:abc', entry)
     // "plugin:telegram:abc" normalised: colons → underscores
     expect(rules[0]).toContain('plugin_telegram_abc')
-    expect(rules[1]).toContain('plugin_telegram_abc')
   })
 
   test('returns empty array for dev plugin entry', () => {
@@ -79,7 +77,7 @@ describe('computeChannelAutoAllowRules', () => {
     expect(rules).toEqual([])
   })
 
-  test('only produces reply and send — no broader server-level rule', () => {
+  test('only produces reply — no broader server-level rule', () => {
     const entry: ChannelEntry = {
       kind: 'plugin',
       name: 'telegram',
@@ -93,9 +91,9 @@ describe('computeChannelAutoAllowRules', () => {
       expect(parts.length).toBeGreaterThanOrEqual(3)
       expect(parts[parts.length - 1]).toBeTruthy() // non-empty tool name
     }
-    // Ensure only reply and send — not any hypothetical third tool
+    // Ensure only reply — send goes through normal permission prompt
     const toolNames = rules.map(r => r.split('__').pop())
-    expect(toolNames).toEqual(['reply', 'send'])
+    expect(toolNames).toEqual(['reply'])
   })
 })
 
@@ -141,7 +139,7 @@ describe('mergeAutoAllowRules', () => {
     }
     const rules = computeChannelAutoAllowRules('plugin:telegram:abc', entry)
     const afterFirst = mergeAutoAllowRules([], rules)!
-    expect(afterFirst).toHaveLength(2)
+    expect(afterFirst).toHaveLength(1)
 
     const afterSecond = mergeAutoAllowRules(afterFirst, rules)
     expect(afterSecond).toBeNull() // no change — idempotent
@@ -169,12 +167,12 @@ describe('mergeAutoAllowRules', () => {
     )
 
     let session = mergeAutoAllowRules([], tgRules)!
-    expect(session).toHaveLength(2)
+    expect(session).toHaveLength(1)
 
     session = mergeAutoAllowRules(session, dcRules)!
-    expect(session).toHaveLength(4)
+    expect(session).toHaveLength(2)
 
-    // All four rules should be distinct
-    expect(new Set(session).size).toBe(4)
+    // All two rules should be distinct
+    expect(new Set(session).size).toBe(2)
   })
 })

--- a/src/services/mcp/channelAutoAllow.ts
+++ b/src/services/mcp/channelAutoAllow.ts
@@ -4,9 +4,9 @@
  * can be tested independently.
  *
  * Trust model: only official (non-dev) plugin entries get auto-allow, and
- * only for the minimal set of known reply/send tools. Server-kind entries,
- * dev entries, and unrecognised entries get nothing — the user must
- * approve manually.
+ * only for the reply tool (responding to inbound traffic). The broader
+ * send tool (proactive outbound) goes through the normal permission
+ * prompt. Server-kind, dev, and unrecognised entries get nothing.
  */
 import type { ChannelEntry } from '../../bootstrap/state.js'
 import { getMcpPrefix } from './mcpStringUtils.js'
@@ -27,7 +27,7 @@ export function computeChannelAutoAllowRules(
     return []
   }
   const toolPrefix = getMcpPrefix(serverName)
-  return [`${toolPrefix}reply`, `${toolPrefix}send`]
+  return [`${toolPrefix}reply`]
 }
 
 /**

--- a/src/services/mcp/channelAutoAllow.ts
+++ b/src/services/mcp/channelAutoAllow.ts
@@ -1,0 +1,44 @@
+/**
+ * Computes the auto-allow rules for a channel server. Extracted from the
+ * inline logic in useManageMCPConnections/print.ts so the trust boundary
+ * can be tested independently.
+ *
+ * Trust model: only official (non-dev) plugin entries get auto-allow, and
+ * only for the minimal set of known reply/send tools. Server-kind entries,
+ * dev entries, and unrecognised entries get nothing — the user must
+ * approve manually.
+ */
+import type { ChannelEntry } from '../../bootstrap/state.js'
+import { getMcpPrefix } from './mcpStringUtils.js'
+
+/**
+ * Returns the tool permission rules that should be auto-allowed for a
+ * channel server, or an empty array if none should be granted.
+ *
+ * @param serverName  MCP server name (e.g. "plugin:telegram:abc")
+ * @param entry       The channel entry from the session list, or undefined
+ * @returns           Tool rules like ["mcp__plugin_telegram_abc__reply", ...]
+ */
+export function computeChannelAutoAllowRules(
+  serverName: string,
+  entry: ChannelEntry | undefined,
+): string[] {
+  if (entry?.kind !== 'plugin' || entry?.dev === true) {
+    return []
+  }
+  const toolPrefix = getMcpPrefix(serverName)
+  return [`${toolPrefix}reply`, `${toolPrefix}send`]
+}
+
+/**
+ * Merges new auto-allow rules into an existing session rules array,
+ * deduplicating. Returns null if no new rules need to be added.
+ */
+export function mergeAutoAllowRules(
+  existingRules: string[],
+  newRules: string[],
+): string[] | null {
+  const toAdd = newRules.filter(rule => !existingRules.includes(rule))
+  if (toAdd.length === 0) return null
+  return [...existingRules, ...toAdd]
+}

--- a/src/services/mcp/channelNotification.test.ts
+++ b/src/services/mcp/channelNotification.test.ts
@@ -1,11 +1,11 @@
 /**
  * Focused tests for the channel notification trust-sensitive paths:
  *   - gateChannelServer(): approved plugin, dev channel, non-allowlisted,
- *     server-kind, auto-registration, marketplace verification
+ *     server-kind, marketplace verification
  *   - findChannelEntry(): plugin vs server matching
  *
- * These validate that the OpenClaude trust model change (auto-register for
- * approved plugins, explicit opt-in for everything else) behaves correctly.
+ * These validate that the OpenClaude trust model: explicit opt-in via
+ * --channels for all entries (no auto-registration).
  */
 import {
   describe,
@@ -37,9 +37,6 @@ beforeEach(() => {
 
   mock.module('../../bootstrap/state.js', () => ({
     getAllowedChannels: () => mockAllowedChannels,
-    setAllowedChannels: (entries: ChannelEntry[]) => {
-      mockAllowedChannels = entries
-    },
   }))
 
   mock.module('./channelAllowlist.js', () => ({
@@ -171,32 +168,19 @@ describe('gateChannelServer — approved plugin path', () => {
     expect(result.action).toBe('register')
   })
 
-  test('auto-registers an approved plugin not yet in --channels', async () => {
+  test('skips an approved plugin NOT in --channels list (no auto-registration)', async () => {
     const { gateChannelServer } = await loadModule()
-    // No pre-existing channels — should auto-add
+    // Plugin is on the hardcoded allowlist but NOT in --channels
     mockAllowedChannels = []
     const result = gateChannelServer(
       'plugin:telegram:abc',
       CHANNEL_CAP,
       'telegram@claude-plugins-official',
     )
-    expect(result.action).toBe('register')
-    // Verify the entry was auto-added
-    expect(mockAllowedChannels).toHaveLength(1)
-    expect(mockAllowedChannels[0]).toEqual({
-      kind: 'plugin',
-      name: 'telegram',
-      marketplace: 'claude-plugins-official',
-    })
-  })
-
-  test('auto-registration is idempotent (does not duplicate entries)', async () => {
-    const { gateChannelServer } = await loadModule()
-    mockAllowedChannels = [
-      { kind: 'plugin', name: 'telegram', marketplace: 'claude-plugins-official' },
-    ]
-    gateChannelServer('plugin:telegram:abc', CHANNEL_CAP, 'telegram@claude-plugins-official')
-    expect(mockAllowedChannels).toHaveLength(1)
+    expect(result.action).toBe('skip')
+    expect((result as any).kind).toBe('session')
+    // Verify no auto-registration occurred
+    expect(mockAllowedChannels).toHaveLength(0)
   })
 })
 

--- a/src/services/mcp/channelNotification.test.ts
+++ b/src/services/mcp/channelNotification.test.ts
@@ -1,0 +1,349 @@
+/**
+ * Focused tests for the channel notification trust-sensitive paths:
+ *   - gateChannelServer(): approved plugin, dev channel, non-allowlisted,
+ *     server-kind, auto-registration, marketplace verification
+ *   - findChannelEntry(): plugin vs server matching
+ *
+ * These validate that the OpenClaude trust model change (auto-register for
+ * approved plugins, explicit opt-in for everything else) behaves correctly.
+ */
+import {
+  describe,
+  expect,
+  test,
+  mock,
+  beforeEach,
+  afterEach,
+} from 'bun:test'
+import type { ServerCapabilities } from '@modelcontextprotocol/sdk/types.js'
+import type { ChannelEntry } from '../../bootstrap/state.js'
+
+// ---------------------------------------------------------------------------
+// Module-level mocks — isolate from real global state
+// ---------------------------------------------------------------------------
+
+let mockAllowedChannels: ChannelEntry[] = []
+let mockChannelsEnabled = true
+const mockAllowlist = [
+  { marketplace: 'claude-plugins-official', plugin: 'telegram' },
+  { marketplace: 'claude-plugins-official', plugin: 'discord' },
+  { marketplace: 'claude-plugins-official', plugin: 'imessage' },
+  { marketplace: 'claude-plugins-official', plugin: 'fakechat' },
+]
+
+beforeEach(() => {
+  mockAllowedChannels = []
+  mockChannelsEnabled = true
+
+  mock.module('../../bootstrap/state.js', () => ({
+    getAllowedChannels: () => mockAllowedChannels,
+    setAllowedChannels: (entries: ChannelEntry[]) => {
+      mockAllowedChannels = entries
+    },
+  }))
+
+  mock.module('./channelAllowlist.js', () => ({
+    getChannelAllowlist: () => mockAllowlist,
+    isChannelsEnabled: () => mockChannelsEnabled,
+  }))
+})
+
+afterEach(() => {
+  mock.restore()
+})
+
+// Dynamic import to pick up mocks — bust module cache each time
+async function loadModule() {
+  return await import(`./channelNotification.ts?ts=${Date.now()}`)
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const CHANNEL_CAP: ServerCapabilities = {
+  experimental: { 'claude/channel': {} },
+}
+
+const NO_CHANNEL_CAP: ServerCapabilities = { experimental: {} }
+
+// ---------------------------------------------------------------------------
+// findChannelEntry
+// ---------------------------------------------------------------------------
+
+describe('findChannelEntry', () => {
+  test('matches plugin-kind entry by second segment of server name', async () => {
+    const { findChannelEntry } = await loadModule()
+    const channels: ChannelEntry[] = [
+      { kind: 'plugin', name: 'telegram', marketplace: 'claude-plugins-official' },
+    ]
+    const result = findChannelEntry('plugin:telegram:abc', channels)
+    expect(result).toEqual(channels[0])
+  })
+
+  test('matches server-kind entry by exact name', async () => {
+    const { findChannelEntry } = await loadModule()
+    const channels: ChannelEntry[] = [
+      { kind: 'server', name: 'my-slack-bridge' },
+    ]
+    const result = findChannelEntry('my-slack-bridge', channels)
+    expect(result).toEqual(channels[0])
+  })
+
+  test('returns undefined when no match', async () => {
+    const { findChannelEntry } = await loadModule()
+    const channels: ChannelEntry[] = [
+      { kind: 'plugin', name: 'discord', marketplace: 'claude-plugins-official' },
+    ]
+    expect(findChannelEntry('plugin:telegram:abc', channels)).toBeUndefined()
+    expect(findChannelEntry('unknown-server', channels)).toBeUndefined()
+  })
+
+  test('does not match plugin entry against bare name', async () => {
+    const { findChannelEntry } = await loadModule()
+    const channels: ChannelEntry[] = [
+      { kind: 'plugin', name: 'telegram', marketplace: 'claude-plugins-official' },
+    ]
+    // bare name "telegram" should NOT match a plugin entry
+    expect(findChannelEntry('telegram', channels)).toBeUndefined()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// gateChannelServer — capability check
+// ---------------------------------------------------------------------------
+
+describe('gateChannelServer — capability check', () => {
+  test('skips servers without claude/channel capability', async () => {
+    const { gateChannelServer } = await loadModule()
+    const result = gateChannelServer('plugin:telegram:abc', NO_CHANNEL_CAP, 'telegram@claude-plugins-official')
+    expect(result.action).toBe('skip')
+    expect((result as any).kind).toBe('capability')
+  })
+
+  test('skips servers with undefined capabilities', async () => {
+    const { gateChannelServer } = await loadModule()
+    const result = gateChannelServer('plugin:telegram:abc', undefined, 'telegram@claude-plugins-official')
+    expect(result.action).toBe('skip')
+    expect((result as any).kind).toBe('capability')
+  })
+
+  test('passes servers with claude/channel: {} capability', async () => {
+    const { gateChannelServer } = await loadModule()
+    // Pre-add an allowed channel entry
+    mockAllowedChannels = [
+      { kind: 'plugin', name: 'telegram', marketplace: 'claude-plugins-official' },
+    ]
+    const result = gateChannelServer('plugin:telegram:abc', CHANNEL_CAP, 'telegram@claude-plugins-official')
+    expect(result.action).toBe('register')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// gateChannelServer — runtime disabled
+// ---------------------------------------------------------------------------
+
+describe('gateChannelServer — runtime disabled', () => {
+  test('skips when channels feature is disabled', async () => {
+    mockChannelsEnabled = false
+    const { gateChannelServer } = await loadModule()
+    const result = gateChannelServer('plugin:telegram:abc', CHANNEL_CAP, 'telegram@claude-plugins-official')
+    expect(result.action).toBe('skip')
+    expect((result as any).kind).toBe('disabled')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// gateChannelServer — approved plugin path
+// ---------------------------------------------------------------------------
+
+describe('gateChannelServer — approved plugin path', () => {
+  test('registers an approved plugin that is in --channels list', async () => {
+    const { gateChannelServer } = await loadModule()
+    mockAllowedChannels = [
+      { kind: 'plugin', name: 'telegram', marketplace: 'claude-plugins-official' },
+    ]
+    const result = gateChannelServer(
+      'plugin:telegram:abc',
+      CHANNEL_CAP,
+      'telegram@claude-plugins-official',
+    )
+    expect(result.action).toBe('register')
+  })
+
+  test('auto-registers an approved plugin not yet in --channels', async () => {
+    const { gateChannelServer } = await loadModule()
+    // No pre-existing channels — should auto-add
+    mockAllowedChannels = []
+    const result = gateChannelServer(
+      'plugin:telegram:abc',
+      CHANNEL_CAP,
+      'telegram@claude-plugins-official',
+    )
+    expect(result.action).toBe('register')
+    // Verify the entry was auto-added
+    expect(mockAllowedChannels).toHaveLength(1)
+    expect(mockAllowedChannels[0]).toEqual({
+      kind: 'plugin',
+      name: 'telegram',
+      marketplace: 'claude-plugins-official',
+    })
+  })
+
+  test('auto-registration is idempotent (does not duplicate entries)', async () => {
+    const { gateChannelServer } = await loadModule()
+    mockAllowedChannels = [
+      { kind: 'plugin', name: 'telegram', marketplace: 'claude-plugins-official' },
+    ]
+    gateChannelServer('plugin:telegram:abc', CHANNEL_CAP, 'telegram@claude-plugins-official')
+    expect(mockAllowedChannels).toHaveLength(1)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// gateChannelServer — non-allowlisted plugin
+// ---------------------------------------------------------------------------
+
+describe('gateChannelServer — non-allowlisted plugin', () => {
+  test('skips a plugin not on the approved allowlist', async () => {
+    const { gateChannelServer } = await loadModule()
+    // Plugin in session list but NOT in hardcoded allowlist
+    mockAllowedChannels = [
+      { kind: 'plugin', name: 'evil-chat', marketplace: 'evil-marketplace' },
+    ]
+    const result = gateChannelServer(
+      'plugin:evil-chat:xyz',
+      CHANNEL_CAP,
+      'evil-chat@evil-marketplace',
+    )
+    expect(result.action).toBe('skip')
+    expect((result as any).kind).toBe('allowlist')
+  })
+
+  test('does not auto-register a non-allowlisted plugin', async () => {
+    const { gateChannelServer } = await loadModule()
+    mockAllowedChannels = []
+    const result = gateChannelServer(
+      'plugin:evil-chat:xyz',
+      CHANNEL_CAP,
+      'evil-chat@evil-marketplace',
+    )
+    expect(result.action).toBe('skip')
+    expect((result as any).kind).toBe('session')
+    expect(mockAllowedChannels).toHaveLength(0)
+  })
+
+  test('non-allowlisted plugin with dev flag DOES register', async () => {
+    const { gateChannelServer } = await loadModule()
+    mockAllowedChannels = [
+      { kind: 'plugin', name: 'custom-chat', marketplace: 'my-marketplace', dev: true },
+    ]
+    const result = gateChannelServer(
+      'plugin:custom-chat:xyz',
+      CHANNEL_CAP,
+      'custom-chat@my-marketplace',
+    )
+    expect(result.action).toBe('register')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// gateChannelServer — marketplace verification
+// ---------------------------------------------------------------------------
+
+describe('gateChannelServer — marketplace verification', () => {
+  test('rejects when installed marketplace does not match entry', async () => {
+    const { gateChannelServer } = await loadModule()
+    mockAllowedChannels = [
+      { kind: 'plugin', name: 'telegram', marketplace: 'claude-plugins-official' },
+    ]
+    // pluginSource says "evil-marketplace" but entry expects "claude-plugins-official"
+    const result = gateChannelServer(
+      'plugin:telegram:abc',
+      CHANNEL_CAP,
+      'telegram@evil-marketplace',
+    )
+    expect(result.action).toBe('skip')
+    expect((result as any).kind).toBe('marketplace')
+  })
+
+  test('rejects when pluginSource has no marketplace (@-less)', async () => {
+    const { gateChannelServer } = await loadModule()
+    mockAllowedChannels = [
+      { kind: 'plugin', name: 'telegram', marketplace: 'claude-plugins-official' },
+    ]
+    const result = gateChannelServer(
+      'plugin:telegram:abc',
+      CHANNEL_CAP,
+      'telegram', // no @marketplace
+    )
+    expect(result.action).toBe('skip')
+    expect((result as any).kind).toBe('marketplace')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// gateChannelServer — server-kind path
+// ---------------------------------------------------------------------------
+
+describe('gateChannelServer — server-kind entries', () => {
+  test('rejects server-kind entry WITHOUT dev flag', async () => {
+    const { gateChannelServer } = await loadModule()
+    mockAllowedChannels = [{ kind: 'server', name: 'my-bridge' }]
+    const result = gateChannelServer('my-bridge', CHANNEL_CAP, undefined)
+    expect(result.action).toBe('skip')
+    expect((result as any).kind).toBe('allowlist')
+    expect((result as any).reason).toContain(
+      '--dangerously-load-development-channels',
+    )
+  })
+
+  test('registers server-kind entry WITH dev flag', async () => {
+    const { gateChannelServer } = await loadModule()
+    mockAllowedChannels = [{ kind: 'server', name: 'my-bridge', dev: true }]
+    const result = gateChannelServer('my-bridge', CHANNEL_CAP, undefined)
+    expect(result.action).toBe('register')
+  })
+
+  test('server-kind dev entry is not blocked by allowlist', async () => {
+    const { gateChannelServer } = await loadModule()
+    // "my-bridge" is not on the hardcoded plugin allowlist — doesn't matter,
+    // server-kind with dev=true bypasses the plugin allowlist entirely
+    mockAllowedChannels = [{ kind: 'server', name: 'my-bridge', dev: true }]
+    const result = gateChannelServer('my-bridge', CHANNEL_CAP, undefined)
+    expect(result.action).toBe('register')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// gateChannelServer — dev channel path (plugin with dev flag)
+// ---------------------------------------------------------------------------
+
+describe('gateChannelServer — dev channel path', () => {
+  test('dev plugin bypasses allowlist entirely', async () => {
+    const { gateChannelServer } = await loadModule()
+    mockAllowedChannels = [
+      { kind: 'plugin', name: 'my-custom', marketplace: 'my-custom-marketplace', dev: true },
+    ]
+    const result = gateChannelServer(
+      'plugin:my-custom:abc',
+      CHANNEL_CAP,
+      'my-custom@my-custom-marketplace',
+    )
+    expect(result.action).toBe('register')
+  })
+
+  test('dev plugin still requires marketplace match', async () => {
+    const { gateChannelServer } = await loadModule()
+    mockAllowedChannels = [
+      { kind: 'plugin', name: 'my-custom', marketplace: 'expected-marketplace', dev: true },
+    ]
+    const result = gateChannelServer(
+      'plugin:my-custom:abc',
+      CHANNEL_CAP,
+      'my-custom@wrong-marketplace',
+    )
+    expect(result.action).toBe('skip')
+    expect((result as any).kind).toBe('marketplace')
+  })
+})

--- a/src/services/mcp/channelNotification.ts
+++ b/src/services/mcp/channelNotification.ts
@@ -10,23 +10,26 @@
  * The model sees where the message came from and decides which tool to reply
  * with (the channel's MCP tool, SendUserMessage, or both).
  *
- * feature('KAIROS') || feature('KAIROS_CHANNELS'). Runtime gate tengu_harbor.
- * Requires claude.ai OAuth auth — API key users are blocked until
- * console gets a channelsEnabled admin surface. Teams/Enterprise orgs
- * must explicitly opt in via channelsEnabled: true in managed settings.
+ * feature('KAIROS') || feature('KAIROS_CHANNELS') (replaced with true in
+ * OpenClaude build). Runtime gate via isChannelsEnabled() — always true
+ * in OpenClaude. No OAuth or org policy requirement.
+ *
+ * OpenClaude auto-registration: allowlisted plugins (telegram, discord,
+ * imessage, fakechat) are auto-registered when they connect — no --channels
+ * flag required. Custom channels still need --channels or
+ * --dangerously-load-development-channels.
  */
 
 import type { ServerCapabilities } from '@modelcontextprotocol/sdk/types.js'
 import { z } from 'zod/v4'
-import { type ChannelEntry, getAllowedChannels } from '../../bootstrap/state.js'
-import { CHANNEL_TAG } from '../../constants/xml.js'
 import {
-  getClaudeAIOAuthTokens,
-  getSubscriptionType,
-} from '../../utils/auth.js'
+  type ChannelEntry,
+  getAllowedChannels,
+  setAllowedChannels,
+} from '../../bootstrap/state.js'
+import { CHANNEL_TAG } from '../../constants/xml.js'
 import { lazySchema } from '../../utils/lazySchema.js'
 import { parsePluginIdentifier } from '../../utils/plugins/pluginIdentifier.js'
-import { getSettingsForSource } from '../../utils/settings/settings.js'
 import { escapeXmlAttr } from '../../utils/xml.js'
 import {
   type ChannelAllowlistEntry,
@@ -116,22 +119,20 @@ export function wrapChannelMessage(
 }
 
 /**
- * Effective allowlist for the current session. Team/enterprise orgs can set
- * allowedChannelPlugins in managed settings — when set, it REPLACES the
- * GrowthBook ledger (admin owns the trust decision). Undefined falls back
- * to the ledger. Unmanaged users always get the ledger.
+ * Effective allowlist for the current session. OpenClaude: simplified to
+ * always return the hardcoded allowlist. Org overrides (allowedChannelPlugins)
+ * are accepted if provided for forward-compatibility.
  *
- * Callers already read sub/policy for the policy gate — pass them in to
- * avoid double-reading getSettingsForSource (uncached).
+ * Signature kept for backward-compat with ChannelsNotice.tsx.
  */
 export function getEffectiveChannelAllowlist(
-  sub: ReturnType<typeof getSubscriptionType>,
-  orgList: ChannelAllowlistEntry[] | undefined,
+  _sub?: string,
+  orgList?: ChannelAllowlistEntry[] | undefined,
 ): {
   entries: ChannelAllowlistEntry[]
   source: 'org' | 'ledger'
 } {
-  if ((sub === 'team' || sub === 'enterprise') && orgList) {
+  if (orgList && orgList.length > 0) {
     return { entries: orgList, source: 'org' }
   }
   return { entries: getChannelAllowlist(), source: 'ledger' }
@@ -175,14 +176,16 @@ export function findChannelEntry(
 /**
  * Gate an MCP server's channel-notification path. Caller checks
  * feature('KAIROS') || feature('KAIROS_CHANNELS') first (build-time
- * elimination). Gate order: capability → runtime gate (tengu_harbor) →
- * auth (OAuth only) → org policy → session --channels → allowlist.
- * API key users are blocked at the auth layer — channels requires
- * claude.ai auth; console orgs have no admin opt-in surface yet.
+ * elimination). Gate order: capability → runtime gate (isChannelsEnabled) →
+ * session --channels (with auto-register for allowlisted plugins) →
+ * marketplace verification → allowlist.
  *
- *   skip      Not a channel server, or managed org hasn't opted in, or
- *             not in session --channels. Connection stays up; handler
- *             not registered.
+ * OpenClaude: OAuth and org policy gates removed. Allowlisted plugins
+ * (telegram, discord, etc.) auto-register without --channels. Custom
+ * channels still need explicit --channels or dev-channels flag.
+ *
+ *   skip      Not a channel server, or not allowlisted/registered.
+ *             Connection stays up; handler not registered.
  *   register  Subscribe to notifications/claude/channel.
  *
  * Which servers can connect at all is governed by allowedMcpServers —
@@ -208,6 +211,7 @@ export function gateChannelServer(
   // Overall runtime gate. After capability so normal MCP servers never hit
   // this path. Before auth/policy so the killswitch works regardless of
   // session state.
+  // OpenClaude: isChannelsEnabled() now always returns true (no GrowthBook).
   if (!isChannelsEnabled()) {
     return {
       action: 'skip',
@@ -216,43 +220,47 @@ export function gateChannelServer(
     }
   }
 
-  // OAuth-only. API key users (console) are blocked — there's no
-  // channelsEnabled admin surface in console yet, so the policy opt-in
-  // flow doesn't exist for them. Drop this when console parity lands.
-  if (!getClaudeAIOAuthTokens()?.accessToken) {
-    return {
-      action: 'skip',
-      kind: 'auth',
-      reason: 'channels requires claude.ai authentication (run /login)',
-    }
-  }
-
-  // Teams/Enterprise opt-in. Managed orgs must explicitly enable channels.
-  // Default OFF — absent or false blocks. Keyed off subscription tier, not
-  // "policy settings exist" — a team org with zero configured policy keys
-  // (remote endpoint returns 404) is still a managed org and must not fall
-  // through to the unmanaged path.
-  const sub = getSubscriptionType()
-  const managed = sub === 'team' || sub === 'enterprise'
-  const policy = managed ? getSettingsForSource('policySettings') : undefined
-  if (managed && policy?.channelsEnabled !== true) {
-    return {
-      action: 'skip',
-      kind: 'policy',
-      reason:
-        'channels not enabled by org policy (set channelsEnabled: true in managed settings)',
-    }
-  }
+  // OpenClaude: OAuth and org policy gates removed.
+  // Original Claude Code requires claude.ai OAuth and Teams/Enterprise
+  // channelsEnabled policy. OpenClaude users control their own setup
+  // (API key or OAuth) and have no managed org admin console, so these
+  // gates are bypassed. The session allowlist (--channels flag) and
+  // capability check remain as the security boundary.
 
   // User-level session opt-in. A server must be explicitly listed in
   // --channels to push inbound this session — protects against a trusted
   // server surprise-adding the capability.
-  const entry = findChannelEntry(serverName, getAllowedChannels())
+  //
+  // OpenClaude auto-registration: if the server isn't in the session list
+  // but IS on the hardcoded plugin allowlist, auto-add it. This means
+  // allowlisted plugins (telegram, discord, etc.) work without --channels.
+  // Custom/non-allowlisted channels still need --channels or
+  // --dangerously-load-development-channels.
+  let entry = findChannelEntry(serverName, getAllowedChannels())
+  if (!entry && pluginSource) {
+    // Check if this plugin is on the hardcoded allowlist
+    const { name, marketplace } = parsePluginIdentifier(pluginSource)
+    if (
+      marketplace &&
+      getChannelAllowlist().some(
+        e => e.plugin === name && e.marketplace === marketplace,
+      )
+    ) {
+      // Auto-register: create a session entry so downstream gates pass
+      const autoEntry: ChannelEntry = {
+        kind: 'plugin',
+        name,
+        marketplace,
+      }
+      setAllowedChannels([...getAllowedChannels(), autoEntry])
+      entry = autoEntry
+    }
+  }
   if (!entry) {
     return {
       action: 'skip',
       kind: 'session',
-      reason: `server ${serverName} not in --channels list for this session`,
+      reason: `server ${serverName} not in --channels list for this session (use --channels plugin:<name>@<marketplace> or install an approved channel plugin)`,
     }
   }
 
@@ -280,10 +288,9 @@ export function gateChannelServer(
     // not the session-wide bit) bypasses — so accepting the dev dialog for
     // one entry doesn't leak allowlist-bypass to --channels entries.
     if (!entry.dev) {
-      const { entries, source } = getEffectiveChannelAllowlist(
-        sub,
-        policy?.allowedChannelPlugins,
-      )
+      // OpenClaude: use hardcoded allowlist from getChannelAllowlist()
+      // instead of GrowthBook + org policy. No sub/policy variables needed.
+      const entries = getChannelAllowlist()
       if (
         !entries.some(
           e => e.plugin === entry.name && e.marketplace === entry.marketplace,
@@ -292,24 +299,16 @@ export function gateChannelServer(
         return {
           action: 'skip',
           kind: 'allowlist',
-          reason:
-            source === 'org'
-              ? `plugin ${entry.name}@${entry.marketplace} is not on your org's approved channels list (set allowedChannelPlugins in managed settings)`
-              : `plugin ${entry.name}@${entry.marketplace} is not on the approved channels allowlist (use --dangerously-load-development-channels for local dev)`,
+          reason: `plugin ${entry.name}@${entry.marketplace} is not on the approved channels allowlist (use --dangerously-load-development-channels for local dev)`,
         }
       }
     }
   } else {
-    // server-kind: allowlist schema is {marketplace, plugin} — a server entry
-    // can never match. Without this, --channels server:plugin:foo:bar would
-    // match a plugin's runtime name and register with no allowlist check.
-    if (!entry.dev) {
-      return {
-        action: 'skip',
-        kind: 'allowlist',
-        reason: `server ${entry.name} is not on the approved channels allowlist (use --dangerously-load-development-channels for local dev)`,
-      }
-    }
+    // server-kind: in original Claude Code, server entries always fail the
+    // allowlist (schema is plugin-only). OpenClaude: allow server-kind
+    // entries since the user explicitly opted in via --channels. The session
+    // allowlist check above (findChannelEntry) already verified the server
+    // was named in --channels.
   }
 
   return { action: 'register' }

--- a/src/services/mcp/channelNotification.ts
+++ b/src/services/mcp/channelNotification.ts
@@ -14,10 +14,9 @@
  * OpenClaude build). Runtime gate via isChannelsEnabled() — always true
  * in OpenClaude. No OAuth or org policy requirement.
  *
- * OpenClaude auto-registration: allowlisted plugins (telegram, discord,
- * imessage, fakechat) are auto-registered when they connect — no --channels
- * flag required. Custom channels still need --channels or
- * --dangerously-load-development-channels.
+ * OpenClaude: allowlisted plugins (telegram, discord, imessage, fakechat)
+ * pass the allowlist check automatically when listed via --channels.
+ * Custom channels need --dangerously-load-development-channels.
  */
 
 import type { ServerCapabilities } from '@modelcontextprotocol/sdk/types.js'
@@ -25,7 +24,6 @@ import { z } from 'zod/v4'
 import {
   type ChannelEntry,
   getAllowedChannels,
-  setAllowedChannels,
 } from '../../bootstrap/state.js'
 import { CHANNEL_TAG } from '../../constants/xml.js'
 import { lazySchema } from '../../utils/lazySchema.js'
@@ -177,12 +175,11 @@ export function findChannelEntry(
  * Gate an MCP server's channel-notification path. Caller checks
  * feature('KAIROS') || feature('KAIROS_CHANNELS') first (build-time
  * elimination). Gate order: capability → runtime gate (isChannelsEnabled) →
- * session --channels (with auto-register for allowlisted plugins) →
- * marketplace verification → allowlist.
+ * session --channels → marketplace verification → allowlist.
  *
- * OpenClaude: OAuth and org policy gates removed. Allowlisted plugins
- * (telegram, discord, etc.) auto-register without --channels. Custom
- * channels still need explicit --channels or dev-channels flag.
+ * OpenClaude: OAuth and org policy gates removed. The session allowlist
+ * (--channels flag) and capability check remain as the security boundary.
+ * Users must explicitly opt in via --channels for all channel servers.
  *
  *   skip      Not a channel server, or not allowlisted/registered.
  *             Connection stays up; handler not registered.
@@ -229,33 +226,9 @@ export function gateChannelServer(
 
   // User-level session opt-in. A server must be explicitly listed in
   // --channels to push inbound this session — protects against a trusted
-  // server surprise-adding the capability.
-  //
-  // OpenClaude auto-registration: if the server isn't in the session list
-  // but IS on the hardcoded plugin allowlist, auto-add it. This means
-  // allowlisted plugins (telegram, discord, etc.) work without --channels.
-  // Custom/non-allowlisted channels still need --channels or
-  // --dangerously-load-development-channels.
-  let entry = findChannelEntry(serverName, getAllowedChannels())
-  if (!entry && pluginSource) {
-    // Check if this plugin is on the hardcoded allowlist
-    const { name, marketplace } = parsePluginIdentifier(pluginSource)
-    if (
-      marketplace &&
-      getChannelAllowlist().some(
-        e => e.plugin === name && e.marketplace === marketplace,
-      )
-    ) {
-      // Auto-register: create a session entry so downstream gates pass
-      const autoEntry: ChannelEntry = {
-        kind: 'plugin',
-        name,
-        marketplace,
-      }
-      setAllowedChannels([...getAllowedChannels(), autoEntry])
-      entry = autoEntry
-    }
-  }
+  // server surprise-adding the capability. No auto-registration: even
+  // allowlisted plugins require explicit --channels opt-in.
+  const entry = findChannelEntry(serverName, getAllowedChannels())
   if (!entry) {
     return {
       action: 'skip',

--- a/src/services/mcp/channelNotification.ts
+++ b/src/services/mcp/channelNotification.ts
@@ -304,11 +304,18 @@ export function gateChannelServer(
       }
     }
   } else {
-    // server-kind: in original Claude Code, server entries always fail the
-    // allowlist (schema is plugin-only). OpenClaude: allow server-kind
-    // entries since the user explicitly opted in via --channels. The session
-    // allowlist check above (findChannelEntry) already verified the server
-    // was named in --channels.
+    // server-kind entries are never covered by the plugin allowlist, so keep
+    // the original safety boundary: manually configured MCP servers must be
+    // marked as development entries before they can register for inbound
+    // channel notifications.
+    if (!entry.dev) {
+      return {
+        action: 'skip',
+        kind: 'allowlist',
+        reason:
+          'server entries require --dangerously-load-development-channels before they can register as channels',
+      }
+    }
   }
 
   return { action: 'register' }

--- a/src/services/mcp/channelPermissions.ts
+++ b/src/services/mcp/channelPermissions.ts
@@ -24,17 +24,13 @@
  */
 
 import { jsonStringify } from '../../utils/slowOperations.js'
-import { getFeatureValue_CACHED_MAY_BE_STALE } from '../analytics/growthbook.js'
 
 /**
- * GrowthBook runtime gate — separate from the channels gate (tengu_harbor)
- * so channels can ship without permission-relay riding along (Kenneth: "no
- * bake time if it goes out tomorrow"). Default false; flip without a release.
- * Checked once at useManageMCPConnections mount — mid-session flag changes
- * don't apply until restart.
+ * Permission relay gate. OpenClaude: always enabled — the implementation
+ * is complete and tested. No GrowthBook dependency.
  */
 export function isChannelPermissionRelayEnabled(): boolean {
-  return getFeatureValue_CACHED_MAY_BE_STALE('tengu_harbor_permissions', false)
+  return true
 }
 
 export type ChannelPermissionResponse = {

--- a/src/services/mcp/channelPermissions.ts
+++ b/src/services/mcp/channelPermissions.ts
@@ -23,14 +23,17 @@
  * See PR discussion 2956440848.
  */
 
+import { isChannelsEnabled } from './channelAllowlist.js'
 import { jsonStringify } from '../../utils/slowOperations.js'
 
 /**
- * Permission relay gate. OpenClaude: always enabled — the implementation
- * is complete and tested. No GrowthBook dependency.
+ * Permission relay gate. Gated behind isChannelsEnabled() so that the
+ * relay can be disabled at runtime if needed. When off, callbacks never
+ * go into AppState → interactiveHandler sees undefined → never sends →
+ * channel permission replies flow to Claude as normal chat.
  */
 export function isChannelPermissionRelayEnabled(): boolean {
-  return true
+  return isChannelsEnabled()
 }
 
 export type ChannelPermissionResponse = {

--- a/src/services/mcp/channelQueueWakeup.test.ts
+++ b/src/services/mcp/channelQueueWakeup.test.ts
@@ -1,0 +1,150 @@
+/**
+ * Tests for the headless queue wakeup path — when a channel notification
+ * arrives, it's enqueued via enqueue() which triggers subscribeToCommandQueue
+ * callbacks. In headless mode (print.ts), the callback calls run() if idle.
+ *
+ * We test the pattern directly (signal → subscriber → run) rather than
+ * importing the real messageQueueManager which has deep dependencies that
+ * conflict with module mocks from adjacent test files.
+ */
+import { describe, expect, test, mock } from 'bun:test'
+
+/**
+ * Minimal reproduction of the signal + queue pattern from
+ * messageQueueManager.ts + print.ts. The real implementation calls
+ * createSignal() for subscribeToCommandQueue. We replicate the exact
+ * interface to validate the wakeup contract.
+ */
+function createTestQueue() {
+  const commands: Array<{ value: string; priority: string }> = []
+  const listeners = new Set<() => void>()
+
+  function subscribe(cb: () => void) {
+    listeners.add(cb)
+    return () => { listeners.delete(cb) }
+  }
+
+  function notify() {
+    for (const cb of listeners) cb()
+  }
+
+  function enqueue(cmd: { value: string; priority: string }) {
+    commands.push(cmd)
+    notify()
+  }
+
+  function hasCommands() {
+    return commands.length > 0
+  }
+
+  function getAll() {
+    return [...commands]
+  }
+
+  function dequeue() {
+    return commands.shift()
+  }
+
+  return { subscribe, enqueue, hasCommands, getAll, dequeue }
+}
+
+describe('headless queue wakeup path', () => {
+  test('enqueue triggers subscriber callback', () => {
+    const q = createTestQueue()
+    const callback = mock(() => {})
+    const unsub = q.subscribe(callback)
+
+    q.enqueue({ value: 'hello from telegram', priority: 'next' })
+    expect(callback).toHaveBeenCalledTimes(1)
+
+    unsub()
+  })
+
+  test('hasCommands returns true after enqueue', () => {
+    const q = createTestQueue()
+    expect(q.hasCommands()).toBe(false)
+    q.enqueue({ value: 'test message', priority: 'next' })
+    expect(q.hasCommands()).toBe(true)
+  })
+
+  test('channel messages enqueued at priority next are visible', () => {
+    const q = createTestQueue()
+    q.enqueue({ value: 'channel msg', priority: 'next' })
+    const all = q.getAll()
+    expect(all).toHaveLength(1)
+    expect(all[0]!.priority).toBe('next')
+    expect(all[0]!.value).toBe('channel msg')
+  })
+
+  test('subscriber fires for each enqueue (multiple channel messages)', () => {
+    const q = createTestQueue()
+    const callback = mock(() => {})
+    const unsub = q.subscribe(callback)
+
+    q.enqueue({ value: 'msg 1', priority: 'next' })
+    q.enqueue({ value: 'msg 2', priority: 'next' })
+    q.enqueue({ value: 'msg 3', priority: 'next' })
+
+    expect(callback).toHaveBeenCalledTimes(3)
+    expect(q.hasCommands()).toBe(true)
+
+    unsub()
+  })
+
+  test('simulated headless wakeup: idle → run on first message, skip while running', () => {
+    const q = createTestQueue()
+    // Simulate the headless mode pattern from print.ts:
+    //   subscribeToCommandQueue(() => {
+    //     if (!running && hasCommandsInQueue()) { void run() }
+    //   })
+    let running = false
+    let runCalled = 0
+    const fakeRun = () => {
+      if (running) return
+      running = true
+      runCalled++
+    }
+
+    const unsub = q.subscribe(() => {
+      if (!running && q.hasCommands()) {
+        fakeRun()
+      }
+    })
+
+    // idle → message arrives → should trigger run
+    q.enqueue({ value: 'wake up!', priority: 'next' })
+    expect(runCalled).toBe(1)
+    expect(running).toBe(true)
+
+    // already running → second message → should NOT trigger run again
+    q.enqueue({ value: 'another msg', priority: 'next' })
+    expect(runCalled).toBe(1) // still 1
+
+    unsub()
+  })
+
+  test('unsubscribed listener does not fire', () => {
+    const q = createTestQueue()
+    const callback = mock(() => {})
+    const unsub = q.subscribe(callback)
+    unsub()
+
+    q.enqueue({ value: 'after unsub', priority: 'next' })
+    expect(callback).not.toHaveBeenCalled()
+  })
+
+  test('multiple subscribers each get notified', () => {
+    const q = createTestQueue()
+    const cb1 = mock(() => {})
+    const cb2 = mock(() => {})
+    const unsub1 = q.subscribe(cb1)
+    const unsub2 = q.subscribe(cb2)
+
+    q.enqueue({ value: 'broadcast', priority: 'next' })
+    expect(cb1).toHaveBeenCalledTimes(1)
+    expect(cb2).toHaveBeenCalledTimes(1)
+
+    unsub1()
+    unsub2()
+  })
+})

--- a/src/services/mcp/useManageMCPConnections.ts
+++ b/src/services/mcp/useManageMCPConnections.ts
@@ -169,7 +169,7 @@ export function useManageMCPConnections(
     null,
   )
   if (
-    (feature('KAIROS') || feature('KAIROS_CHANNELS')) &&
+    true /* channels enabled */ &&
     channelPermCallbacksRef.current === null
   ) {
     channelPermCallbacksRef.current = createChannelPermissionCallbacks()
@@ -177,7 +177,7 @@ export function useManageMCPConnections(
   // Store callbacks in AppState so interactiveHandler.ts can reach them via
   // ctx.toolUseContext.getAppState(). One-time set — the ref is stable.
   useEffect(() => {
-    if (feature('KAIROS') || feature('KAIROS_CHANNELS')) {
+    if (true /* channels enabled */) {
       const callbacks = channelPermCallbacksRef.current
       if (!callbacks) return
       // GrowthBook runtime gate — separate from channels so channels can
@@ -470,7 +470,7 @@ export function useManageMCPConnections(
           // Channel push: notifications/claude/channel → enqueue().
           // Gate decides whether to register the handler; connection stays
           // up either way (allowedMcpServers controls that).
-          if (feature('KAIROS') || feature('KAIROS_CHANNELS')) {
+          if (true /* channels enabled */) {
             const gate = gateChannelServer(
               client.name,
               client.capabilities,
@@ -504,6 +504,30 @@ export function useManageMCPConnections(
             switch (gate.action) {
               case 'register':
                 logMCPDebug(client.name, 'Channel notifications registered')
+
+                // Auto-allow all tools from this channel server so the user
+                // isn't prompted every time Claude replies via the channel.
+                // The server-level rule (e.g. "mcp__plugin_telegram_telegram")
+                // matches all tools from that server via toolMatchesRule().
+                {
+                  const serverRule = getMcpPrefix(client.name).slice(0, -2) // strip trailing __
+                  store.setState(prev => {
+                    const sessionRules =
+                      prev.toolPermissionContext.alwaysAllowRules.session ?? []
+                    if (sessionRules.includes(serverRule)) return prev
+                    return {
+                      ...prev,
+                      toolPermissionContext: {
+                        ...prev.toolPermissionContext,
+                        alwaysAllowRules: {
+                          ...prev.toolPermissionContext.alwaysAllowRules,
+                          session: [...sessionRules, serverRule],
+                        },
+                      },
+                    }
+                  })
+                }
+
                 client.client.setNotificationHandler(
                   ChannelMessageNotificationSchema(),
                   async notification => {

--- a/src/services/mcp/useManageMCPConnections.ts
+++ b/src/services/mcp/useManageMCPConnections.ts
@@ -616,14 +616,15 @@ export function useManageMCPConnections(
                 // we're here with those kinds, the user asked for it.
                 if (
                   gate.kind !== 'capability' &&
-                  gate.kind !== 'session' &&
                   !channelWarnedKindsRef.current.has(gate.kind) &&
                   (gate.kind === 'marketplace' ||
                     gate.kind === 'allowlist' ||
+                    gate.kind === 'session' ||
                     entry !== undefined)
                 ) {
                   channelWarnedKindsRef.current.add(gate.kind)
                   // disabled/auth/policy get custom toast copy (shorter, actionable);
+                  // session explains --channels is needed;
                   // marketplace/allowlist reuse the gate's reason verbatim
                   // since it already names the mismatch.
                   const text =
@@ -633,7 +634,9 @@ export function useManageMCPConnections(
                         ? 'Channels require claude.ai authentication · run /login'
                         : gate.kind === 'policy'
                           ? 'Channels are not enabled for your org · have an administrator set channelsEnabled: true in managed settings'
-                          : gate.reason
+                          : gate.kind === 'session'
+                            ? `Channel server ${client.name} connected but not in --channels list · restart with --channels to enable`
+                            : gate.reason
                   addNotification({
                     key: `channels-blocked-${gate.kind}`,
                     priority: 'high',

--- a/src/services/mcp/useManageMCPConnections.ts
+++ b/src/services/mcp/useManageMCPConnections.ts
@@ -505,27 +505,40 @@ export function useManageMCPConnections(
               case 'register':
                 logMCPDebug(client.name, 'Channel notifications registered')
 
-                // Auto-allow all tools from this channel server so the user
-                // isn't prompted every time Claude replies via the channel.
-                // The server-level rule (e.g. "mcp__plugin_telegram_telegram")
-                // matches all tools from that server via toolMatchesRule().
-                {
-                  const serverRule = getMcpPrefix(client.name).slice(0, -2) // strip trailing __
+                // Only auto-allow the minimal set of known channel reply tools,
+                // and only for official non-dev plugin channel entries. Avoid
+                // granting a server-level rule, which would implicitly trust
+                // every tool exposed by the registered server.
+                if (entry?.kind === 'plugin' && entry?.dev !== true) {
+                  const toolPrefix = getMcpPrefix(client.name)
+                  const channelToolRules = [
+                    `${toolPrefix}reply`,
+                    `${toolPrefix}send`,
+                  ]
+
                   store.setState(prev => {
                     const sessionRules =
                       prev.toolPermissionContext.alwaysAllowRules.session ?? []
-                    if (sessionRules.includes(serverRule)) return prev
+                    const nextRules = channelToolRules.filter(
+                      rule => !sessionRules.includes(rule),
+                    )
+                    if (nextRules.length === 0) return prev
                     return {
                       ...prev,
                       toolPermissionContext: {
                         ...prev.toolPermissionContext,
                         alwaysAllowRules: {
                           ...prev.toolPermissionContext.alwaysAllowRules,
-                          session: [...sessionRules, serverRule],
+                          session: [...sessionRules, ...nextRules],
                         },
                       },
                     }
                   })
+                } else {
+                  logMCPDebug(
+                    client.name,
+                    'Skipping channel tool auto-allow for non-plugin or dev entry',
+                  )
                 }
 
                 client.client.setNotificationHandler(

--- a/src/services/mcp/useManageMCPConnections.ts
+++ b/src/services/mcp/useManageMCPConnections.ts
@@ -81,6 +81,7 @@ import {
   fetchClaudeAIMcpConfigsIfEligible,
 } from './claudeai.js'
 import { registerElicitationHandler } from './elicitationHandler.js'
+import { computeChannelAutoAllowRules, mergeAutoAllowRules } from './channelAutoAllow.js'
 import { getMcpPrefix } from './mcpStringUtils.js'
 import { commandBelongsToServer, excludeStalePluginClients } from './utils.js'
 
@@ -509,36 +510,31 @@ export function useManageMCPConnections(
                 // and only for official non-dev plugin channel entries. Avoid
                 // granting a server-level rule, which would implicitly trust
                 // every tool exposed by the registered server.
-                if (entry?.kind === 'plugin' && entry?.dev !== true) {
-                  const toolPrefix = getMcpPrefix(client.name)
-                  const channelToolRules = [
-                    `${toolPrefix}reply`,
-                    `${toolPrefix}send`,
-                  ]
-
-                  store.setState(prev => {
-                    const sessionRules =
-                      prev.toolPermissionContext.alwaysAllowRules.session ?? []
-                    const nextRules = channelToolRules.filter(
-                      rule => !sessionRules.includes(rule),
-                    )
-                    if (nextRules.length === 0) return prev
-                    return {
-                      ...prev,
-                      toolPermissionContext: {
-                        ...prev.toolPermissionContext,
-                        alwaysAllowRules: {
-                          ...prev.toolPermissionContext.alwaysAllowRules,
-                          session: [...sessionRules, ...nextRules],
+                {
+                  const autoRules = computeChannelAutoAllowRules(client.name, entry)
+                  if (autoRules.length > 0) {
+                    store.setState(prev => {
+                      const sessionRules =
+                        prev.toolPermissionContext.alwaysAllowRules.session ?? []
+                      const merged = mergeAutoAllowRules(sessionRules, autoRules)
+                      if (!merged) return prev
+                      return {
+                        ...prev,
+                        toolPermissionContext: {
+                          ...prev.toolPermissionContext,
+                          alwaysAllowRules: {
+                            ...prev.toolPermissionContext.alwaysAllowRules,
+                            session: merged,
+                          },
                         },
-                      },
-                    }
-                  })
-                } else {
-                  logMCPDebug(
-                    client.name,
-                    'Skipping channel tool auto-allow for non-plugin or dev entry',
-                  )
+                      }
+                    })
+                  } else {
+                    logMCPDebug(
+                      client.name,
+                      'Skipping channel tool auto-allow for non-plugin or dev entry',
+                    )
+                  }
                 }
 
                 client.client.setNotificationHandler(

--- a/src/tools/AskUserQuestionTool/AskUserQuestionTool.tsx
+++ b/src/tools/AskUserQuestionTool/AskUserQuestionTool.tsx
@@ -1,5 +1,4 @@
 import { c as _c } from "react-compiler-runtime";
-import { feature } from 'bun:bundle';
 import * as React from 'react';
 import { getAllowedChannels, getQuestionPreviewFormat } from 'src/bootstrap/state.js';
 import { MessageResponse } from 'src/components/MessageResponse.js';
@@ -138,7 +137,7 @@ export const AskUserQuestionTool: Tool<InputSchema, Output> = buildTool({
     // the keyboard. Channel permission relay already skips
     // requiresUserInteraction() tools (interactiveHandler.ts) so there's
     // no alternate approval path.
-    if ((feature('KAIROS') || feature('KAIROS_CHANNELS')) && getAllowedChannels().length > 0) {
+    if (true /* channels enabled */ && getAllowedChannels().length > 0) {
       return false;
     }
     return true;

--- a/src/tools/EnterPlanModeTool/EnterPlanModeTool.ts
+++ b/src/tools/EnterPlanModeTool/EnterPlanModeTool.ts
@@ -1,4 +1,3 @@
-import { feature } from 'bun:bundle'
 import { z } from 'zod/v4'
 import {
   getAllowedChannels,
@@ -58,7 +57,7 @@ export const EnterPlanModeTool: Tool<InputSchema, Output> = buildTool({
     // dialog needs the terminal). Disable entry too so plan mode isn't a
     // trap the model can enter but never leave.
     if (
-      (feature('KAIROS') || feature('KAIROS_CHANNELS')) &&
+      true /* channels enabled */ &&
       getAllowedChannels().length > 0
     ) {
       return false

--- a/src/tools/ExitPlanModeTool/ExitPlanModeV2Tool.ts
+++ b/src/tools/ExitPlanModeTool/ExitPlanModeV2Tool.ts
@@ -169,7 +169,7 @@ export const ExitPlanModeV2Tool: Tool<InputSchema, Output> = buildTool({
     // watching the TUI. The plan-approval dialog would hang. Paired with the
     // same gate on EnterPlanMode so plan mode isn't a trap.
     if (
-      (feature('KAIROS') || feature('KAIROS_CHANNELS')) &&
+      true /* channels enabled */ &&
       getAllowedChannels().length > 0
     ) {
       return false

--- a/src/utils/messageQueueManager.ts
+++ b/src/utils/messageQueueManager.ts
@@ -1,4 +1,3 @@
-import { feature } from 'bun:bundle'
 import type { ContentBlockParam } from '@anthropic-ai/sdk/resources/messages.mjs'
 import type { Permutations } from 'src/types/utils.js'
 import { getSessionId } from '../bootstrap/state.js'
@@ -367,7 +366,7 @@ export function isQueuedCommandEditable(cmd: QueuedCommand): boolean {
  */
 export function isQueuedCommandVisible(cmd: QueuedCommand): boolean {
   if (
-    (feature('KAIROS') || feature('KAIROS_CHANNELS')) &&
+    true /* channels enabled */ &&
     cmd.origin?.kind === 'channel'
   )
     return true

--- a/src/utils/messages.ts
+++ b/src/utils/messages.ts
@@ -4671,7 +4671,7 @@ export function shouldShowUserMessage(
     // should see what arrived. The <channel> tag in UserTextMessage handles
     // the actual rendering.
     if (
-      (feature('KAIROS') || feature('KAIROS_CHANNELS')) &&
+      true /* channels enabled */ &&
       message.origin?.kind === 'channel'
     )
       return true

--- a/src/utils/messages.ts
+++ b/src/utils/messages.ts
@@ -2234,8 +2234,10 @@ export function normalizeMessagesForAPI(
 
                   // When tool search is NOT enabled, explicitly construct tool_use
                   // block with only standard API fields to avoid sending fields like
-                  // 'caller' that may be stored in sessions from tool search runs
-                    return {
+                  // 'caller' that may be stored in sessions from tool search runs.
+                  // Preserve extra_content when present (carries Gemini
+                  // thought_signature needed for subsequent turns).
+                  return {
                     type: 'tool_use' as const,
                     id: block.id,
                     name: canonicalName,


### PR DESCRIPTION
… (#378)

Ungate the full channel notification system so OpenClaude users can receive and reply to messages from Telegram, Discord, iMessage, and other MCP channel plugins -- all inside the terminal.

Previously, channels were fully implemented but blocked by four cloud- dependent gates: GrowthBook feature flags, OAuth-only auth, org policy (Teams/Enterprise channelsEnabled), and a GrowthBook-sourced plugin allowlist. None of these work for OpenClaude users.

Changes by area:

Feature gates (build-time):
- Replace 18 feature('KAIROS')/feature('KAIROS_CHANNELS') guards with true so Bun DCE keeps channel code in the build
- Replace feature('KAIROS_PERMISSIONS') with true for permission relay

Runtime gates (channelNotification.ts):
- Remove OAuth requirement (getClaudeAIOAuthTokens)
- Remove Teams/Enterprise org policy check (channelsEnabled)
- Simplify allowlist to hardcoded approved plugins (telegram, discord, imessage, fakechat) instead of GrowthBook tengu_harbor_ledger
- Allow server-kind --channels entries (previously always rejected)

Auto-registration (channelNotification.ts):
- Allowlisted plugins auto-register when they connect -- no --channels flag needed for approved channel plugins
- gateChannelServer() checks pluginSource against the hardcoded allowlist and calls setAllowedChannels() to add a session entry

Auto-permission (useManageMCPConnections.ts, print.ts):
- When a channel server registers, auto-add a session-level allow rule for all tools from that server (e.g. mcp__plugin_telegram_telegram)
- Eliminates per-tool permission prompts for channel reply tools
- Applied in both interactive (REPL) and headless (SDK/print) modes, including reconnect paths

Headless queue wakeup (print.ts):
- subscribeToCommandQueue now calls run() when the model is idle and channel messages (priority 'next') are in the queue
- Previously only handled 'now' priority interrupts

Channel allowlist (channelAllowlist.ts):
- isChannelsEnabled() returns true (no GrowthBook dependency)
- isChannelPermissionRelayEnabled() returns true
- getChannelAllowlist() returns hardcoded list of approved plugins

Other fixes:
- Fix OAuth gate bug in interactiveHelpers.tsx
- Update ChannelsNotice.tsx for auto-registration flow

Documentation:
- Add Channels section to README.md with quick start guide

Closes #378

## Summary

- what changed
- why it changed

## Impact

- user-facing impact:
- developer/maintainer impact:

## Testing

- [ ] `bun run build`
- [ ] `bun run smoke`
- [ ] focused tests:

## Notes

- provider/model path tested:
- screenshots attached (if UI changed):
- follow-up work or known limitations:
