### PR TITLE
feat: auto install latest versions #533

### DIFF
--- a/src/cli/update.ts
+++ b/src/cli/update.ts
@@ -33,7 +33,7 @@ export async function update() {
   // from the first-party distribution bucket, which would silently replace the
   // OpenClaude build (with the OpenAI shim) with the upstream Claude Code
   // binary (without it).
-  if (getAPIProvider() !== 'firstParty') {
+  if (getAPIProvider() !== 'firstParty' && MACRO.PACKAGE_URL !== '@gitlawb/openclaude') {
     writeToStdout(
       chalk.yellow('Auto-update is not available for third-party provider builds.\n') +
       'To update, pull the latest source from the repository and rebuild:\n' +
@@ -43,7 +43,8 @@ export async function update() {
   }
 
   logEvent('tengu_update_check', {})
-  writeToStdout(`Current version: ${MACRO.VERSION}\n`)
+  const currentVersion = typeof MACRO !== 'undefined' ? (MACRO.DISPLAY_VERSION ?? MACRO.VERSION) : '0.0.0';
+  writeToStdout(`Current version: ${currentVersion}\n`)
 
   const channel = getInitialSettings()?.autoUpdatesChannel ?? 'latest'
   writeToStdout(`Checking for updates to ${channel} version...\n`)
@@ -136,8 +137,8 @@ export async function update() {
     if (packageManager === 'homebrew') {
       writeToStdout('Claude is managed by Homebrew.\n')
       const latest = await getLatestVersion(channel)
-      if (latest && !gte(MACRO.VERSION, latest)) {
-        writeToStdout(`Update available: ${MACRO.VERSION} → ${latest}\n`)
+      if (latest && !gte(currentVersion, latest)) {
+        writeToStdout(`Update available: ${currentVersion} → ${latest}\n`)
         writeToStdout('\n')
         writeToStdout('To update, run:\n')
         writeToStdout(chalk.bold('  brew upgrade claude-code') + '\n')
@@ -147,8 +148,8 @@ export async function update() {
     } else if (packageManager === 'winget') {
       writeToStdout('Claude is managed by winget.\n')
       const latest = await getLatestVersion(channel)
-      if (latest && !gte(MACRO.VERSION, latest)) {
-        writeToStdout(`Update available: ${MACRO.VERSION} → ${latest}\n`)
+      if (latest && !gte(currentVersion, latest)) {
+        writeToStdout(`Update available: ${currentVersion} → ${latest}\n`)
         writeToStdout('\n')
         writeToStdout('To update, run:\n')
         writeToStdout(
@@ -160,8 +161,8 @@ export async function update() {
     } else if (packageManager === 'apk') {
       writeToStdout('Claude is managed by apk.\n')
       const latest = await getLatestVersion(channel)
-      if (latest && !gte(MACRO.VERSION, latest)) {
-        writeToStdout(`Update available: ${MACRO.VERSION} → ${latest}\n`)
+      if (latest && !gte(currentVersion, latest)) {
+        writeToStdout(`Update available: ${currentVersion} → ${latest}\n`)
         writeToStdout('\n')
         writeToStdout('To update, run:\n')
         writeToStdout(chalk.bold('  apk upgrade claude-code') + '\n')
@@ -250,14 +251,14 @@ export async function update() {
         await gracefulShutdown(1)
       }
 
-      if (result.latestVersion === MACRO.VERSION) {
+      if (result.latestVersion === currentVersion) {
         writeToStdout(
-          chalk.green(`Claude Code is up to date (${MACRO.VERSION})`) + '\n',
+          chalk.green(`Claude Code is up to date (${currentVersion})`) + '\n',
         )
       } else {
         writeToStdout(
           chalk.green(
-            `Successfully updated from ${MACRO.VERSION} to version ${result.latestVersion}`,
+            `Successfully updated from ${currentVersion} to version ${result.latestVersion}`,
           ) + '\n',
         )
         await regenerateCompletionCache()
@@ -320,15 +321,15 @@ export async function update() {
   }
 
   // Check if versions match exactly, including any build metadata (like SHA)
-  if (latestVersion === MACRO.VERSION) {
+  if (latestVersion === currentVersion) {
     writeToStdout(
-      chalk.green(`Claude Code is up to date (${MACRO.VERSION})`) + '\n',
+      chalk.green(`Claude Code is up to date (${currentVersion})`) + '\n',
     )
     await gracefulShutdown(0)
   }
 
   writeToStdout(
-    `New version available: ${latestVersion} (current: ${MACRO.VERSION})\n`,
+    `New version available: ${latestVersion} (current: ${currentVersion})\n`,
   )
   writeToStdout('Installing update...\n')
 
@@ -388,7 +389,7 @@ export async function update() {
     case 'success':
       writeToStdout(
         chalk.green(
-          `Successfully updated from ${MACRO.VERSION} to version ${latestVersion}`,
+          `Successfully updated from ${currentVersion} to version ${latestVersion}`,
         ) + '\n',
       )
       await regenerateCompletionCache()

--- a/src/components/AutoUpdater.tsx
+++ b/src/components/AutoUpdater.tsx
@@ -53,7 +53,7 @@ export function AutoUpdater({
       logForDebugging('AutoUpdater: Skipping update check in test/dev environment');
       return;
     }
-    const currentVersion = MACRO.VERSION;
+    const currentVersion = typeof MACRO !== 'undefined' ? (MACRO.DISPLAY_VERSION ?? MACRO.VERSION) : '0.0.0';
     const channel = getInitialSettings()?.autoUpdatesChannel ?? 'latest';
     let latestVersion = await getLatestVersion(channel);
     const isDisabled = isAutoUpdaterDisabled();

--- a/src/components/LogoV2/LogoV2.tsx
+++ b/src/components/LogoV2/LogoV2.tsx
@@ -94,7 +94,7 @@ export function LogoV2() {
   if ($[2] === Symbol.for("react.memo_cache_sentinel")) {
     t2 = () => {
       const currentConfig = getGlobalConfig();
-      if (currentConfig.lastReleaseNotesSeen === MACRO.VERSION) {
+      if (currentConfig.lastReleaseNotesSeen === (typeof MACRO !== 'undefined' ? (MACRO.DISPLAY_VERSION ?? MACRO.VERSION) : '0.0.0')) {
         return;
       }
       saveGlobalConfig(_temp3);
@@ -528,12 +528,12 @@ export function LogoV2() {
   return t41;
 }
 function _temp3(current) {
-  if (current.lastReleaseNotesSeen === MACRO.VERSION) {
+  if (current.lastReleaseNotesSeen === (typeof MACRO !== 'undefined' ? (MACRO.DISPLAY_VERSION ?? MACRO.VERSION) : '0.0.0')) {
     return current;
   }
   return {
     ...current,
-    lastReleaseNotesSeen: MACRO.VERSION
+    lastReleaseNotesSeen: (typeof MACRO !== 'undefined' ? (MACRO.DISPLAY_VERSION ?? MACRO.VERSION) : '0.0.0')
   };
 }
 function _temp2(s_0) {

--- a/src/components/NativeAutoUpdater.tsx
+++ b/src/components/NativeAutoUpdater.tsx
@@ -87,14 +87,14 @@ export function NativeAutoUpdater({
     // Log the start of an auto-update check for funnel analysis
     logEvent('tengu_native_auto_updater_start', {});
     try {
+      const currentVersion = typeof MACRO !== 'undefined' ? (MACRO.DISPLAY_VERSION ?? MACRO.VERSION) : '0.0.0';
       // Check if current version is above the max allowed version
       const maxVersion = await getMaxVersion();
-      if (maxVersion && gt(MACRO.VERSION, maxVersion)) {
+      if (maxVersion && gt(currentVersion, maxVersion)) {
         const msg = await getMaxVersionMessage();
         setMaxVersionIssue(msg ?? 'affects your version');
       }
       const result = await installLatest(channel);
-      const currentVersion = MACRO.VERSION;
       const latencyMs = Date.now() - startTime;
 
       // Handle lock contention gracefully - just return without treating as error

--- a/src/components/PackageManagerAutoUpdater.tsx
+++ b/src/components/PackageManagerAutoUpdater.tsx
@@ -31,23 +31,24 @@ export function PackageManagerAutoUpdater(t0) {
       if (isAutoUpdaterDisabled()) {
         return;
       }
+      const currentVersion = typeof MACRO !== 'undefined' ? (MACRO.DISPLAY_VERSION ?? MACRO.VERSION) : '0.0.0';
       const [channel, pm] = await Promise.all([Promise.resolve(getInitialSettings()?.autoUpdatesChannel ?? "latest"), getPackageManager()]);
       setPackageManager(pm);
       let latest = await getLatestVersionFromGcs(channel);
       const maxVersion = await getMaxVersion();
       if (maxVersion && latest && gt(latest, maxVersion)) {
         logForDebugging(`PackageManagerAutoUpdater: maxVersion ${maxVersion} is set, capping update from ${latest} to ${maxVersion}`);
-        if (gte(MACRO.VERSION, maxVersion)) {
-          logForDebugging(`PackageManagerAutoUpdater: current version ${MACRO.VERSION} is already at or above maxVersion ${maxVersion}, skipping update`);
+        if (gte(currentVersion, maxVersion)) {
+          logForDebugging(`PackageManagerAutoUpdater: current version ${currentVersion} is already at or above maxVersion ${maxVersion}, skipping update`);
           setUpdateAvailable(false);
           return;
         }
         latest = maxVersion;
       }
-      const hasUpdate = latest && !gte(MACRO.VERSION, latest) && !shouldSkipVersion(latest);
+      const hasUpdate = latest && !gte(currentVersion, latest) && !shouldSkipVersion(latest);
       setUpdateAvailable(!!hasUpdate);
       if (hasUpdate) {
-        logForDebugging(`PackageManagerAutoUpdater: Update available ${MACRO.VERSION} -> ${latest}`);
+        logForDebugging(`PackageManagerAutoUpdater: Update available ${currentVersion} -> ${latest}`);
       }
     };
     $[0] = t1;
@@ -76,7 +77,7 @@ export function PackageManagerAutoUpdater(t0) {
   const updateCommand = packageManager === "homebrew" ? "brew upgrade claude-code" : packageManager === "winget" ? "winget upgrade Anthropic.ClaudeCode" : packageManager === "apk" ? "apk upgrade claude-code" : "your package manager update command";
   let t4;
   if ($[3] !== verbose) {
-    t4 = verbose && <Text dimColor={true} wrap="truncate">currentVersion: {MACRO.VERSION}</Text>;
+    t4 = verbose && <Text dimColor={true} wrap="truncate">currentVersion: {typeof MACRO !== 'undefined' ? (MACRO.DISPLAY_VERSION ?? MACRO.VERSION) : '0.0.0'}</Text>;
     $[3] = verbose;
     $[4] = t4;
   } else {

--- a/src/components/Settings/Config.tsx
+++ b/src/components/Settings/Config.tsx
@@ -1642,7 +1642,7 @@ export function Config({
           channel: channel as AnalyticsMetadata_I_VERIFIED_THIS_IS_NOT_CODE_OR_FILEPATHS
         });
       }} />}
-        </Dialog> : showSubmenu === 'ChannelDowngrade' ? <ChannelDowngradeDialog currentVersion={MACRO.VERSION} onChoice={(choice: ChannelDowngradeChoice) => {
+        </Dialog> : showSubmenu === 'ChannelDowngrade' ? <ChannelDowngradeDialog currentVersion={(typeof MACRO !== 'undefined' ? (MACRO.DISPLAY_VERSION ?? MACRO.VERSION) : '0.0.0')} onChoice={(choice: ChannelDowngradeChoice) => {
       setShowSubmenu(null);
       setTabsHidden(false);
       if (choice === 'cancel') {
@@ -1659,7 +1659,7 @@ export function Config({
       };
       if (choice === 'stay') {
         // User wants to stay on current version until stable catches up
-        newSettings.minimumVersion = MACRO.VERSION;
+        newSettings.minimumVersion = (typeof MACRO !== 'undefined' ? (MACRO.DISPLAY_VERSION ?? MACRO.VERSION) : '0.0.0');
       }
       updateSettingsForSource('userSettings', newSettings);
       setSettingsData(prev_27 => ({

--- a/src/hooks/useUpdateNotification.ts
+++ b/src/hooks/useUpdateNotification.ts
@@ -15,7 +15,7 @@ export function shouldShowUpdateNotification(
 
 export function useUpdateNotification(
   updatedVersion: string | null | undefined,
-  initialVersion: string = MACRO.VERSION,
+  initialVersion: string = typeof MACRO !== 'undefined' ? (MACRO.DISPLAY_VERSION ?? MACRO.VERSION) : '0.0.0',
 ): string | null {
   const [lastNotifiedSemver, setLastNotifiedSemver] = useState<string | null>(
     () => getSemverPart(initialVersion),

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -102,6 +102,7 @@ import { getActiveAgentsFromList, getAgentDefinitionsWithOverrides, isBuiltInAge
 import type { LogOption } from './types/logs.js';
 import type { Message as MessageType } from './types/message.js';
 import { assertMinVersion } from './utils/autoUpdater.js';
+import { notifyUpdates } from './utils/updateNotifier.js';
 import { CLAUDE_IN_CHROME_SKILL_HINT, CLAUDE_IN_CHROME_SKILL_HINT_WITH_WEBBROWSER } from './utils/claudeInChrome/prompt.js';
 import { setupClaudeInChrome, shouldAutoEnableClaudeInChrome, shouldEnableClaudeInChrome } from './utils/claudeInChrome/setup.js';
 import { getContextWindowForModel } from './utils/context.js';
@@ -1770,6 +1771,7 @@ async function run(): Promise<CommanderCommand> {
       console.error(warning);
     });
     void assertMinVersion();
+    void notifyUpdates();
 
     // claude.ai config fetch: -p mode only (interactive uses useManageMCPConnections
     // two-phase loading). Kicked off here to overlap with setup(); awaited

--- a/src/utils/autoUpdater.ts
+++ b/src/utils/autoUpdater.ts
@@ -105,6 +105,7 @@ This will ensure you have access to the latest features and improvements.
   }
 }
 
+
 /**
  * Returns the maximum allowed version for the current user type.
  * For ants, returns the `ant` field (dev version format).

--- a/src/utils/nativeInstaller/installer.ts
+++ b/src/utils/nativeInstaller/installer.ts
@@ -507,6 +507,7 @@ async function updateLatest(
 
   logForDebugging(`Checking for native installer update to version ${version}`)
 
+  const currentVersion = typeof MACRO !== 'undefined' ? (MACRO.DISPLAY_VERSION ?? MACRO.VERSION) : '0.0.0';
   // Check if max version is set (server-side kill switch for auto-updates)
   if (!forceReinstall) {
     const maxVersion = await getMaxVersion()
@@ -515,9 +516,9 @@ async function updateLatest(
         `Native installer: maxVersion ${maxVersion} is set, capping update from ${version} to ${maxVersion}`,
       )
       // If we're already at or above maxVersion, skip the update entirely
-      if (gte(MACRO.VERSION, maxVersion)) {
+      if (gte(currentVersion, maxVersion)) {
         logForDebugging(
-          `Native installer: current version ${MACRO.VERSION} is already at or above maxVersion ${maxVersion}, skipping update`,
+          `Native installer: current version ${currentVersion} is already at or above maxVersion ${maxVersion}, skipping update`,
         )
         logEvent('tengu_native_update_skipped_max_version', {
           latency_ms: Date.now() - startTime,
@@ -537,7 +538,7 @@ async function updateLatest(
   // is invalid (e.g., empty/corrupted from a failed install), or we're running via npx.
   if (
     !forceReinstall &&
-    version === MACRO.VERSION &&
+    version === currentVersion &&
     (await versionIsAvailable(version)) &&
     (await isPossibleClaudeBinary(executablePath))
   ) {

--- a/src/utils/updateNotifier.ts
+++ b/src/utils/updateNotifier.ts
@@ -30,13 +30,13 @@ export async function notifyUpdates(): Promise<void> {
       // biome-ignore lint/suspicious/noConsole:: intentional console output
       console.log(
         chalk.green(`
-A new version of Open Claude is available: \${latestVersion} (current: \${currentVersion})
+A new version of Open Claude is available: ${latestVersion} (current: ${currentVersion})
 To update, please run:
-    npm install -g \${MACRO.PACKAGE_URL}
+    npm install -g ${MACRO.PACKAGE_URL}
 `),
       )
     }
   } catch (error) {
-    logForDebugging(`notifyUpdates failed: \${error}`)
+    logForDebugging(`notifyUpdates failed: ${error}`)
   }
 }

--- a/src/utils/updateNotifier.ts
+++ b/src/utils/updateNotifier.ts
@@ -1,0 +1,42 @@
+import chalk from 'chalk'
+import { getLatestVersion } from './autoUpdater.js'
+import { logForDebugging } from './debug.js'
+import { lt } from './semver.js'
+import { getInitialSettings } from './settings/settings.js'
+
+/**
+ * Checks for a newer version on npm and suggests the user to update.
+ * Does not block startup.
+ */
+export async function notifyUpdates(): Promise<void> {
+  if (
+    process.env.NODE_ENV === 'test' ||
+    process.env.NODE_ENV === 'development' ||
+    process.env.OPENCLAUDE_SKIP_UPDATE_CHECK === 'true'
+  ) {
+    return
+  }
+
+  try {
+    const channel = getInitialSettings()?.autoUpdatesChannel ?? 'latest'
+    const latestVersion = await getLatestVersion(channel)
+
+    const currentVersion =
+      typeof MACRO !== 'undefined'
+        ? (MACRO.DISPLAY_VERSION ?? MACRO.VERSION)
+        : '0.0.0'
+
+    if (latestVersion && lt(currentVersion, latestVersion)) {
+      // biome-ignore lint/suspicious/noConsole:: intentional console output
+      console.log(
+        chalk.green(`
+A new version of Open Claude is available: \${latestVersion} (current: \${currentVersion})
+To update, please run:
+    npm install -g \${MACRO.PACKAGE_URL}
+`),
+      )
+    }
+  } catch (error) {
+    logForDebugging(`notifyUpdates failed: \${error}`)
+  }
+}


### PR DESCRIPTION
## Summary

- **What changed:**
  - Implemented a non-blocking startup check (`notifyUpdates`) in a new utility `src/utils/updateNotifier.ts` that queries npm for the latest `@gitlawb/openclaude` version and suggests an update if available.
  - Fixed version comparison logic in `src/cli/update.ts`, `AutoUpdater.tsx`, `NativeAutoUpdater.tsx`, and `PackageManagerAutoUpdater.tsx` to use `MACRO.DISPLAY_VERSION` (the actual version) instead of the build-time mock `MACRO.VERSION` (`99.0.0`).
  - Modified the `claude update` CLI to allow updates for the Open Claude package even when running with third-party providers.
  - Updated `LogoV2.tsx`, `Config.tsx`, and `useUpdateNotification.ts` to sync release notes tracking and version-based settings with the actual display version.

- **Why it changed:**
  - In Open Claude, `MACRO.VERSION` is set to `99.0.0` to prevent upstream Anthropic kill-switches from disabling the tool. However, this caused Open Claude's own update mechanisms to fail as they always perceived the local version as "newer" than the latest release on npm.
  - Users were missing important updates because the CLI didn't suggest installing newer versions of the fork.

## Impact

- **User-facing impact:**
  - Users will now receive a green notification in the terminal on startup when a newer version of Open Claude is available.
  - The `claude update` command now correctly identifies and installs newer versions for fork users.
  - Release notes and version-specific settings (like channel downgrades) now reflect the true version number.

- **Developer/maintainer impact:**
  - Improved update reliability for fork users while maintaining the "99.0.0" bypass for upstream compatibility.
  - Standardized version checking across the codebase by prioritizing `DISPLAY_VERSION`.

## Testing

- [x] `bun run build` - Successfully bundled the CLI.
- [x] `bun run smoke` - Verified `--version` output is correct (`0.1.8 (Open Claude)`).
- [x] `bun test` - All 616 tests passed.
- [x] Manual verification: Confirmed that mocking a lower `DISPLAY_VERSION` triggers the update suggestion, while matching the latest version suppresses it.

## Notes

- **Provider/model path tested:** OpenAI and Gemini (verified that the update command is no longer blocked for these providers).
- **Screenshots attached (if UI changed):** N/A (CLI console output).
- **Follow-up work or known limitations:** The update suggestion respects `NODE_ENV=development` and can be disabled via `OPENCLAUDE_SKIP_UPDATE_CHECK=true`.
