### PR TITLE
feat: improve GitHub auth UX and device flow reliability

### DIFF
--- a/src/commands/onboard-github/onboard-github.tsx
+++ b/src/commands/onboard-github/onboard-github.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react'
-import { useCallback, useState } from 'react'
+import { useCallback, useRef, useState } from 'react'
 import { Select } from '../../components/CustomSelect/select.js'
 import { Spinner } from '../../components/Spinner.js'
-import { Box, Text } from '../../ink.js'
+import { Box, Text, useInput } from '../../ink.js'
 import {
   exchangeForCopilotToken,
   openVerificationUri,
@@ -27,7 +27,7 @@ const FORCE_RELOGIN_ARGS = new Set([
   '--reauth',
 ])
 
-type Step = 'menu' | 'device-busy' | 'error'
+type Step = 'menu' | 'device-busy' | 'device-waiting' | 'device-polling' | 'exchanging-token' | 'error'
 
 const PROVIDER_SPECIFIC_KEYS = new Set([
   'CLAUDE_CODE_USE_OPENAI',
@@ -35,6 +35,7 @@ const PROVIDER_SPECIFIC_KEYS = new Set([
   'CLAUDE_CODE_USE_BEDROCK',
   'CLAUDE_CODE_USE_VERTEX',
   'CLAUDE_CODE_USE_FOUNDRY',
+  'CLAUDE_CODE_GITHUB_ANTHROPIC_API',
   'OPENAI_BASE_URL',
   'OPENAI_API_BASE',
   'OPENAI_API_KEY',
@@ -226,28 +227,77 @@ function OnboardGithub(props: {
     [onChangeAPIKey, onDone],
   )
 
+  // Ref to hold device code info between the request and polling phases.
+  const deviceRef = useRef<{ device_code: string; interval: number; expires_in: number } | null>(null)
+  const abortRef = useRef<AbortController | null>(null)
+
   const runDeviceFlow = useCallback(async () => {
     setStep('device-busy')
     setErrorMsg(null)
     setDeviceHint(null)
     try {
       const device = await requestDeviceCode()
+      deviceRef.current = device
       setDeviceHint({
         user_code: device.user_code,
         verification_uri: device.verification_uri,
       })
       await openVerificationUri(device.verification_uri)
+      // Show the code and wait for the user to press Enter before polling.
+      setStep('device-waiting')
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e)
+      setErrorMsg(msg)
+      setStep('error')
+    }
+  }, [])
+
+  const startPolling = useCallback(async () => {
+    const device = deviceRef.current
+    if (!device) return
+    setStep('device-polling')
+    const abortController = new AbortController()
+    abortRef.current = abortController
+    const onSigint = () => abortController.abort()
+    process.once('SIGINT', onSigint)
+    try {
       const oauthToken = await pollAccessToken(device.device_code, {
         initialInterval: device.interval,
         timeoutSeconds: device.expires_in,
+        signal: abortController.signal,
       })
-      const copilotToken = await exchangeForCopilotToken(oauthToken)
-      await finalize(copilotToken.token, DEFAULT_MODEL, oauthToken)
+      // OAuth token obtained — now try to exchange for a Copilot API token.
+      setStep('exchanging-token')
+      // This requires an active GitHub Copilot subscription. If it fails
+      // (no subscription, timeout, network error), fall back to the OAuth
+      // token itself — this still works for GitHub Models endpoints.
+      try {
+        const copilotToken = await exchangeForCopilotToken(oauthToken)
+        await finalize(copilotToken.token, DEFAULT_MODEL, oauthToken)
+      } catch {
+        // Copilot token exchange failed — save OAuth token directly.
+        await finalize(oauthToken, DEFAULT_MODEL)
+      }
     } catch (e) {
-      setErrorMsg(e instanceof Error ? e.message : String(e))
+      const msg = e instanceof Error ? e.message : String(e)
+      if (msg === 'Cancelled') {
+        onDone('GitHub onboard cancelled', { display: 'system' })
+        return
+      }
+      setErrorMsg(msg)
       setStep('error')
+    } finally {
+      process.off('SIGINT', onSigint)
+      abortRef.current = null
     }
-  }, [finalize])
+  }, [finalize, onDone])
+
+  // Wait for Enter in the device-waiting step, then start polling.
+  useInput((_input, key) => {
+    if (step === 'device-waiting' && key.return) {
+      startPolling()
+    }
+  })
 
   if (step === 'error' && errorMsg) {
     const options = [
@@ -278,23 +328,46 @@ function OnboardGithub(props: {
     )
   }
 
+  if (step === 'exchanging-token') {
+    return (
+      <Box flexDirection="column" gap={1}>
+        <Text>GitHub Copilot sign-in</Text>
+        <Text dimColor>Authorization confirmed. Retrieving API token...</Text>
+        <Spinner />
+      </Box>
+    )
+  }
+
   if (step === 'device-busy') {
     return (
       <Box flexDirection="column" gap={1}>
         <Text>GitHub Copilot sign-in</Text>
-        {deviceHint ? (
-          <>
-            <Text>
-              Enter code <Text bold>{deviceHint.user_code}</Text> at{' '}
-              {deviceHint.verification_uri}
-            </Text>
-            <Text dimColor>
-              A browser window may have opened. Waiting for authorization...
-            </Text>
-          </>
-        ) : (
-          <Text dimColor>Requesting device code from GitHub...</Text>
-        )}
+        <Text dimColor>Requesting device code from GitHub...</Text>
+        <Spinner />
+      </Box>
+    )
+  }
+
+  if (step === 'device-waiting' && deviceHint) {
+    return (
+      <Box flexDirection="column" gap={1}>
+        <Text>GitHub Copilot sign-in</Text>
+        <Text>
+          Enter code <Text bold>{deviceHint.user_code}</Text> at{' '}
+          {deviceHint.verification_uri}
+        </Text>
+        <Text dimColor>
+          A browser window may have opened. Press Enter after you have authorized.
+        </Text>
+      </Box>
+    )
+  }
+
+  if (step === 'device-polling') {
+    return (
+      <Box flexDirection="column" gap={1}>
+        <Text>GitHub Copilot sign-in</Text>
+        <Text dimColor>Waiting for authorization...</Text>
         <Spinner />
       </Box>
     )

--- a/src/entrypoints/cli.tsx
+++ b/src/entrypoints/cli.tsx
@@ -84,6 +84,14 @@ async function main(): Promise<void> {
     return;
   }
 
+  // --help/-h must bypass provider validation so users can always see usage
+  // without needing to be authenticated first.
+  if (args.some(a => a === '--help' || a === '-h')) {
+    const { main: cliMain } = await import('../main.js')
+    await cliMain()
+    return
+  }
+
   // --provider: set provider env vars early so saved-profile resolution,
   // validation, and the startup banner all see the intended provider/model.
   if (args.includes('--provider')) {

--- a/src/services/github/deviceFlow.ts
+++ b/src/services/github/deviceFlow.ts
@@ -5,6 +5,10 @@
 
 import { execFileNoThrow } from '../../utils/execFileNoThrow.js'
 
+// VS Code GitHub Copilot Chat extension OAuth app — required for the
+// copilot_internal/v2/token exchange that produces a valid Copilot API token.
+// Other client IDs (e.g. the gh CLI's) produce OAuth tokens that the Copilot
+// API rejects with 403 "not licensed to use Copilot".
 export const DEFAULT_GITHUB_DEVICE_FLOW_CLIENT_ID = 'Iv1.b507a08c87ecfe98'
 
 export const GITHUB_DEVICE_CODE_URL = 'https://github.com/login/device/code'
@@ -55,8 +59,18 @@ export function getGithubDeviceFlowClientId(): string {
   )
 }
 
-function sleep(ms: number): Promise<void> {
-  return new Promise(resolve => setTimeout(resolve, ms))
+function sleep(ms: number, signal?: AbortSignal): Promise<void> {
+  return new Promise((resolve, reject) => {
+    if (signal?.aborted) {
+      reject(new GitHubDeviceFlowError('Cancelled'))
+      return
+    }
+    const timer = setTimeout(resolve, ms)
+    signal?.addEventListener('abort', () => {
+      clearTimeout(timer)
+      reject(new GitHubDeviceFlowError('Cancelled'))
+    }, { once: true })
+  })
 }
 
 export async function requestDeviceCode(options?: {
@@ -133,6 +147,8 @@ export type PollOptions = {
   initialInterval?: number
   timeoutSeconds?: number
   fetchImpl?: FetchLike
+  onStatusChange?: (status: 'polling' | 'exchanging') => void
+  signal?: AbortSignal
 }
 
 export async function pollAccessToken(
@@ -146,9 +162,15 @@ export async function pollAccessToken(
   let interval = Math.max(1, options?.initialInterval ?? 5)
   const timeoutSeconds = options?.timeoutSeconds ?? 900
   const fetchFn = options?.fetchImpl ?? fetch
+  const signal = options?.signal
   const start = Date.now()
 
+  // GitHub enforces strictly MORE than `interval` seconds between polls;
+  // polling at exactly `interval` triggers slow_down. We add 1s buffer to
+  // every sleep to stay safely above the boundary.
+
   while ((Date.now() - start) / 1000 < timeoutSeconds) {
+    if (signal?.aborted) throw new GitHubDeviceFlowError('Cancelled')
     const res = await fetchFn(GITHUB_DEVICE_ACCESS_TOKEN_URL, {
       method: 'POST',
       headers: { Accept: 'application/json' },
@@ -157,6 +179,9 @@ export async function pollAccessToken(
         device_code: deviceCode,
         grant_type: 'urn:ietf:params:oauth:grant-type:device_code',
       }),
+      signal: signal
+        ? AbortSignal.any([signal, AbortSignal.timeout(15_000)])
+        : AbortSignal.timeout(15_000),
     })
     if (!res.ok) {
       const text = await res.text().catch(() => '')
@@ -174,13 +199,13 @@ export async function pollAccessToken(
       throw new GitHubDeviceFlowError('No access_token in response')
     }
     if (err === 'authorization_pending') {
-      await sleep(interval * 1000)
+      await sleep((interval + 1) * 1000, signal)
       continue
     }
     if (err === 'slow_down') {
-      interval =
-        typeof data.interval === 'number' ? data.interval : interval + 5
-      await sleep(interval * 1000)
+      const suggested = typeof data.interval === 'number' ? data.interval : interval + 5
+      interval = Math.min(suggested, 30)
+      await sleep((interval + 1) * 1000, signal)
       continue
     }
     if (err === 'expired_token') {
@@ -216,6 +241,8 @@ export async function openVerificationUri(uri: string): Promise<void> {
   }
 }
 
+const COPILOT_TOKEN_EXCHANGE_TIMEOUT_MS = 15_000
+
 /**
  * Exchange an OAuth access token for a Copilot API token.
  * The OAuth token alone cannot be used with the Copilot API endpoint.
@@ -232,6 +259,7 @@ export async function exchangeForCopilotToken(
       Authorization: `Bearer ${oauthToken}`,
       ...COPILOT_HEADERS,
     },
+    signal: AbortSignal.timeout(COPILOT_TOKEN_EXCHANGE_TIMEOUT_MS),
   })
   if (!res.ok) {
     const text = await res.text().catch(() => '')

--- a/src/utils/providerValidation.ts
+++ b/src/utils/providerValidation.ts
@@ -160,14 +160,54 @@ export async function getProviderValidationError(
   return null
 }
 
+/**
+ * Returns true when the user appears to be starting an interactive REPL session
+ * (i.e. `openclaude` with no arguments or only flag-style arguments that don't
+ * select a non-interactive sub-command).  In this mode we allow GitHub auth
+ * errors through as warnings so the user can run /onboard-github from inside
+ * the CLI rather than being locked out entirely.
+ */
+function isInteractiveReplMode(argv: string[] = process.argv.slice(2)): boolean {
+  if (argv.length === 0) return true
+  // Non-interactive sub-commands that should still hard-fail on missing auth
+  const nonInteractiveSubcommands = new Set([
+    'print', '-p', '--print',
+    'run',
+    'export',
+    'config',
+    'doctor',
+  ])
+  // If the first positional-looking argument is a known non-interactive
+  // sub-command, don't allow the bypass.
+  const firstArg = argv[0]
+  if (firstArg && !firstArg.startsWith('-') && nonInteractiveSubcommands.has(firstArg)) {
+    return false
+  }
+  return true
+}
+
 export async function validateProviderEnvOrExit(
   env: NodeJS.ProcessEnv = process.env,
 ): Promise<void> {
   const error = await getProviderValidationError(env)
-  if (error) {
-    console.error(error)
-    process.exit(1)
+  if (!error) return
+
+  // For GitHub auth errors in interactive REPL mode, warn instead of exiting
+  // so the user can run /onboard-github from within the CLI.
+  const isGithubAuthError =
+    isEnvTruthy(env.CLAUDE_CODE_USE_GITHUB) &&
+    !isEnvTruthy(env.CLAUDE_CODE_USE_OPENAI) &&
+    (error.includes('authentication required') ||
+      error.includes('token has expired') ||
+      error.includes('token is invalid'))
+
+  if (isGithubAuthError && isInteractiveReplMode()) {
+    console.error(`Warning: ${error}\n`)
+    return
   }
+
+  console.error(error)
+  process.exit(1)
 }
 
 export function shouldExitForStartupProviderValidationError(options: {

--- a/src/utils/providerValidation.ts
+++ b/src/utils/providerValidation.ts
@@ -76,6 +76,40 @@ function getOpenAIMissingKeyMessage(): string {
   ].join('\n')
 }
 
+type GithubEndpointType = 'copilot' | 'models' | 'custom'
+
+function githubAuthError(
+  endpointType: GithubEndpointType,
+  kind: 'missing' | 'expired' | 'invalid',
+): string {
+  if (endpointType === 'copilot') {
+    switch (kind) {
+      case 'missing':
+        return 'GitHub Copilot authentication required.\n' +
+          'Run /onboard-github in the CLI to sign in with your GitHub account.\n' +
+          'This will store your OAuth token securely and enable Copilot models.'
+      case 'expired':
+        return 'GitHub Copilot token has expired.\n' +
+          'Run /onboard-github to sign in again and get a fresh token.'
+      case 'invalid':
+        return 'GitHub Copilot token is invalid or corrupted.\n' +
+          'Run /onboard-github to sign in again with your GitHub account.'
+    }
+  }
+  // GitHub Models, custom, or future endpoint types
+  switch (kind) {
+    case 'missing':
+      return 'GITHUB_TOKEN or GH_TOKEN is required for your GitHub endpoint.\n' +
+        'Set one of these environment variables to a valid token.'
+    case 'expired':
+      return 'GitHub token has expired.\n' +
+        'Set a fresh GITHUB_TOKEN or GH_TOKEN.'
+    case 'invalid':
+      return 'GitHub token is invalid or corrupted.\n' +
+        'Check your GITHUB_TOKEN or GH_TOKEN.'
+  }
+}
+
 export async function getProviderValidationError(
   env: NodeJS.ProcessEnv = process.env,
   options?: {
@@ -100,20 +134,16 @@ export async function getProviderValidationError(
 
   if (useGithub && !useOpenAI) {
     const token = (env.GITHUB_TOKEN?.trim() || env.GH_TOKEN?.trim()) ?? ''
-    if (!token) {
-      return 'GitHub Copilot authentication required.\n' +
-        'Run /onboard-github in the CLI to sign in with your GitHub account.\n' +
-        'This will store your OAuth token securely and enable Copilot models.'
-    }
     const endpointType = getGithubEndpointType(env.OPENAI_BASE_URL)
+    if (!token) {
+      return githubAuthError(endpointType, 'missing')
+    }
     const status = checkGithubTokenStatus(token, endpointType)
     if (status === 'expired') {
-      return 'GitHub Copilot token has expired.\n' +
-        'Run /onboard-github to sign in again and get a fresh token.'
+      return githubAuthError(endpointType, 'expired')
     }
     if (status === 'invalid_format') {
-      return 'GitHub Copilot token is invalid or corrupted.\n' +
-        'Run /onboard-github to sign in again with your GitHub account.'
+      return githubAuthError(endpointType, 'invalid')
     }
     return null
   }
@@ -192,16 +222,19 @@ export async function validateProviderEnvOrExit(
   const error = await getProviderValidationError(env)
   if (!error) return
 
-  // For GitHub auth errors in interactive REPL mode, warn instead of exiting
-  // so the user can run /onboard-github from within the CLI.
-  const isGithubAuthError =
+  // For GitHub Copilot auth errors in interactive REPL mode, warn instead of
+  // exiting so the user can run /onboard-github from within the CLI.
+  // Only applies to the Copilot endpoint — GitHub Models and custom endpoints
+  // have no in-CLI recovery path, so they should still hard-exit.
+  const isGithubCopilotAuthError =
     isEnvTruthy(env.CLAUDE_CODE_USE_GITHUB) &&
     !isEnvTruthy(env.CLAUDE_CODE_USE_OPENAI) &&
+    getGithubEndpointType(env.OPENAI_BASE_URL) === 'copilot' &&
     (error.includes('authentication required') ||
       error.includes('token has expired') ||
       error.includes('token is invalid'))
 
-  if (isGithubAuthError && isInteractiveReplMode()) {
+  if (isGithubCopilotAuthError && isInteractiveReplMode()) {
     console.error(`Warning: ${error}\n`)
     return
   }


### PR DESCRIPTION
## Summary

- `--help`/`-h` bypasses provider validation so usage is always accessible without auth
- GitHub auth errors in interactive REPL mode become warnings instead of hard exits, allowing users to run `/onboard-github` from within the CLI
- Device flow: AbortSignal support for cancellation, fetch timeouts (15s), +1s poll buffer to avoid GitHub `slow_down` responses, interval capped at 30s
- Onboarding: user presses Enter after browser authorization before polling starts, SIGINT cancellation support, new `exchanging-token` spinner step, graceful fallback when Copilot token exchange fails (saves OAuth token directly)

## Test plan

- [ ] Run `openclaude --help` without any auth configured — should show usage instead of erroring
- [ ] Run `openclaude` without GitHub auth — should show warning and enter REPL
- [ ] Run `/onboard-github` — verify device flow shows code, waits for Enter, then polls
- [ ] Press Ctrl+C during device flow — should cancel cleanly
- [ ] Complete device flow with valid Copilot subscription — should succeed
- [ ] Complete device flow without Copilot subscription — should fall back to OAuth token