### PR TITLE
feat: native Anthropic API mode for GitHub Copilot + prompt caching

### DIFF
--- a/src/services/api/claude.ts
+++ b/src/services/api/claude.ts
@@ -23,6 +23,7 @@ import { randomUUID } from 'crypto'
 import {
   getAPIProvider,
   isFirstPartyAnthropicBaseUrl,
+  isGithubNativeAnthropicMode,
 } from 'src/utils/model/providers.js'
 import {
   getAttributionHeader,
@@ -334,8 +335,13 @@ export function getPromptCachingEnabled(model: string): boolean {
   // Prompt caching is an Anthropic-specific feature. Third-party providers
   // do not understand cache_control blocks and strict backends (e.g. Azure
   // Foundry) reject or flag requests that contain them.
+  //
+  // Exception: when the GitHub provider is configured in native Anthropic API
+  // mode (CLAUDE_CODE_GITHUB_ANTHROPIC_API=1), requests are sent in Anthropic
+  // format, so cache_control blocks are supported.
   const provider = getAPIProvider()
-  if (provider !== 'firstParty' && provider !== 'bedrock' && provider !== 'vertex') {
+  const isNativeGithub = isGithubNativeAnthropicMode(model)
+  if (provider !== 'firstParty' && provider !== 'bedrock' && provider !== 'vertex' && !isNativeGithub) {
     return false
   }
 

--- a/src/services/api/client.ts
+++ b/src/services/api/client.ts
@@ -14,6 +14,7 @@ import { getSmallFastModel } from 'src/utils/model/model.js'
 import {
   getAPIProvider,
   isFirstPartyAnthropicBaseUrl,
+  isGithubNativeAnthropicMode,
 } from 'src/utils/model/providers.js'
 import { getProxyFetchOptions } from 'src/utils/proxy.js'
 import {
@@ -173,6 +174,25 @@ export async function getAnthropicClient({
       timeout: parseInt(process.env.API_TIMEOUT_MS || String(600 * 1000), 10),
       providerOverride,
     }) as unknown as Anthropic
+  }
+  // GitHub provider in native Anthropic API mode: send requests in Anthropic
+  // format so cache_control blocks are honoured and prompt caching works.
+  // Requires the GitHub endpoint (OPENAI_BASE_URL) to support Anthropic's
+  // messages API — set CLAUDE_CODE_GITHUB_ANTHROPIC_API=1 to opt in.
+  if (isGithubNativeAnthropicMode(model)) {
+    const githubBaseUrl =
+      process.env.OPENAI_BASE_URL?.replace(/\/$/, '') ??
+      'https://api.githubcopilot.com'
+    const githubToken =
+      process.env.GITHUB_TOKEN ?? process.env.GH_TOKEN ?? ''
+    const nativeArgs: ConstructorParameters<typeof Anthropic>[0] = {
+      ...ARGS,
+      baseURL: githubBaseUrl,
+      authToken: githubToken,
+      // No apiKey — we authenticate via Bearer token (authToken)
+      apiKey: null,
+    }
+    return new Anthropic(nativeArgs)
   }
   if (
     isEnvTruthy(process.env.CLAUDE_CODE_USE_OPENAI) ||

--- a/src/utils/model/openaiContextWindows.ts
+++ b/src/utils/model/openaiContextWindows.ts
@@ -12,6 +12,44 @@
  */
 
 const OPENAI_CONTEXT_WINDOWS: Record<string, number> = {
+  // GitHub Copilot — values from https://api.githubcopilot.com/models (2026-04-09)
+  // Namespaced so they don't collide with bare model names from other providers.
+  'github:copilot':                           128_000,
+  // Claude
+  'github:copilot:claude-sonnet-4':           216_000,
+  'github:copilot:claude-haiku-4':            200_000,
+  'github:copilot:claude-sonnet-4.5':         200_000,
+  'github:copilot:claude-sonnet-4.6':         200_000,
+  'github:copilot:claude-opus-4':             200_000,
+  'github:copilot:claude-opus-4.6':           200_000,
+  // GPT
+  'github:copilot:gpt-3.5-turbo':             16_384,
+  'github:copilot:gpt-4':                     32_768,
+  'github:copilot:gpt-4-0125-preview':       128_000,
+  'github:copilot:gpt-4-o-preview':          128_000,
+  'github:copilot:gpt-4.1':                  128_000,
+  'github:copilot:gpt-4o':                   128_000,
+  'github:copilot:gpt-4o-2024-08-06':        128_000,
+  'github:copilot:gpt-4o-2024-11-20':        128_000,
+  'github:copilot:gpt-4o-mini':              128_000,
+  'github:copilot:gpt-5-mini':               264_000,
+  'github:copilot:gpt-5.1':                  264_000,
+  'github:copilot:gpt-5.2':                  400_000,
+  'github:copilot:gpt-5.2-codex':            400_000,
+  'github:copilot:gpt-5.3-codex':            400_000,
+  'github:copilot:gpt-5.4':                  400_000,
+  'github:copilot:gpt-5.4-mini':             400_000,
+  // Gemini
+  'github:copilot:gemini-2.5-pro':           128_000,
+  'github:copilot:gemini-3-flash-preview':   128_000,
+  'github:copilot:gemini-3.1-pro-preview':   200_000,
+  // Grok
+  'github:copilot:grok-code-fast-1':         256_000,
+
+  // NOTE: bare Claude model names (e.g. 'claude-sonnet-4') are intentionally
+  // omitted. Different OpenAI-compatible providers may impose different context
+  // limits for the same model name, so we cannot safely hardcode values here.
+
   // OpenAI
   'gpt-5.4':               1_050_000,
   'gpt-5.4-mini':            400_000,
@@ -82,6 +120,41 @@ const OPENAI_CONTEXT_WINDOWS: Record<string, number> = {
  * Fixes: 400 error "max_tokens is too large" when default 32k exceeds model limit.
  */
 const OPENAI_MAX_OUTPUT_TOKENS: Record<string, number> = {
+  // GitHub Copilot — values from https://api.githubcopilot.com/models (2026-04-09)
+  'github:copilot':                            16_384,
+  // Claude
+  'github:copilot:claude-sonnet-4':            16_000,
+  'github:copilot:claude-haiku-4':             64_000,
+  'github:copilot:claude-sonnet-4.5':          32_000,
+  'github:copilot:claude-sonnet-4.6':          32_000,
+  'github:copilot:claude-opus-4':              32_000,
+  'github:copilot:claude-opus-4.6':            32_000,
+  // GPT
+  'github:copilot:gpt-3.5-turbo':              4_096,
+  'github:copilot:gpt-4':                      4_096,
+  'github:copilot:gpt-4-0125-preview':         4_096,
+  'github:copilot:gpt-4-o-preview':            4_096,
+  'github:copilot:gpt-4.1':                   16_384,
+  'github:copilot:gpt-4o':                     4_096,
+  'github:copilot:gpt-4o-2024-08-06':         16_384,
+  'github:copilot:gpt-4o-2024-11-20':         16_384,
+  'github:copilot:gpt-4o-mini':                4_096,
+  'github:copilot:gpt-5-mini':                64_000,
+  'github:copilot:gpt-5.1':                   64_000,
+  'github:copilot:gpt-5.2':                  128_000,
+  'github:copilot:gpt-5.2-codex':            128_000,
+  'github:copilot:gpt-5.3-codex':            128_000,
+  'github:copilot:gpt-5.4':                  128_000,
+  'github:copilot:gpt-5.4-mini':             128_000,
+  // Gemini
+  'github:copilot:gemini-2.5-pro':            64_000,
+  'github:copilot:gemini-3-flash-preview':    64_000,
+  'github:copilot:gemini-3.1-pro-preview':    64_000,
+  // Grok
+  'github:copilot:grok-code-fast-1':          64_000,
+
+  // NOTE: bare Claude model names omitted — see context windows comment above.
+
   // OpenAI
   'gpt-5.4':                 128_000,
   'gpt-5.4-mini':            128_000,
@@ -145,6 +218,19 @@ const OPENAI_MAX_OUTPUT_TOKENS: Record<string, number> = {
 }
 
 function lookupByModel<T>(table: Record<string, T>, model: string): T | undefined {
+  // Try provider-qualified key first: "{OPENAI_MODEL}:{model}" so that
+  // e.g. "github:copilot:claude-haiku-4.5" can have different limits than
+  // a bare "claude-haiku-4.5" served by another provider.
+  const providerModel = process.env.OPENAI_MODEL?.trim()
+  if (providerModel && providerModel !== model) {
+    const qualified = `${providerModel}:${model}`
+    const qualifiedResult = lookupByKey(table, qualified)
+    if (qualifiedResult !== undefined) return qualifiedResult
+  }
+  return lookupByKey(table, model)
+}
+
+function lookupByKey<T>(table: Record<string, T>, model: string): T | undefined {
   if (table[model] !== undefined) return table[model]
   // Sort keys by length descending so the most specific prefix wins.
   // Without this, 'gpt-4-turbo-preview' could match 'gpt-4' (8k) instead

--- a/src/utils/model/providers.ts
+++ b/src/utils/model/providers.ts
@@ -33,6 +33,28 @@ export function getAPIProvider(): APIProvider {
 export function usesAnthropicAccountFlow(): boolean {
   return getAPIProvider() === 'firstParty'
 }
+
+/**
+ * Returns true when the GitHub provider should use Anthropic's native API
+ * format instead of the OpenAI-compatible shim.
+ *
+ * Enabled automatically when CLAUDE_CODE_USE_GITHUB=1 and the selected model
+ * is a Claude model (OPENAI_MODEL starts with "claude-"). Can also be forced
+ * on with CLAUDE_CODE_GITHUB_ANTHROPIC_API=1 for any model.
+ *
+ * api.githubcopilot.com supports Anthropic native format for Claude models,
+ * enabling prompt caching via cache_control blocks which significantly reduces
+ * per-turn token costs by caching the system prompt and tool definitions.
+ */
+export function isGithubNativeAnthropicMode(resolvedModel?: string): boolean {
+  if (!isEnvTruthy(process.env.CLAUDE_CODE_USE_GITHUB)) return false
+  if (isEnvTruthy(process.env.CLAUDE_CODE_GITHUB_ANTHROPIC_API)) return true
+  // Auto-enable for Claude models — they support native format + caching.
+  // Prefer the resolved model name (e.g. "claude-haiku-4.5") over OPENAI_MODEL
+  // which may be a generic alias like "github:copilot".
+  const model = resolvedModel?.trim() || process.env.OPENAI_MODEL?.trim() || ''
+  return model.toLowerCase().startsWith('claude-')
+}
 function isCodexModel(): boolean {
   return shouldUseCodexTransport(
     process.env.OPENAI_MODEL || '',


### PR DESCRIPTION
## Summary

Fixes #515 — each turn previously sent ~25k tokens of system prompt as fresh input because prompt caching was unconditionally disabled for the GitHub provider.

**Root cause:** `getPromptCachingEnabled()` only allowed caching for `firstParty`/`bedrock`/`vertex` providers. GitHub Copilot (`provider='github'`) was excluded, and all requests went through the OpenAI-compatible shim which strips `cache_control` blocks.

**Changes:**
- Add `isGithubNativeAnthropicMode(resolvedModel)` that auto-enables when Copilot routes to a Claude model, creating a native Anthropic client instead of the OpenAI shim
- Enable prompt caching for native GitHub mode so `cache_control` blocks are sent and honoured
- Add namespaced Copilot model context windows (`github:copilot:*`) with values from the Copilot `/models` API, plus composite key lookup (`{OPENAI_MODEL}:{resolvedModel}`) so different providers can define different limits for the same model name
- `CLAUDE_CODE_GITHUB_ANTHROPIC_API=1` env var to force native mode for any model

## Test plan

- [ ] Use GitHub Copilot with a Claude model — verify native Anthropic client is created (check debug logs)
- [ ] Run `/cost` after a few turns — `cache_write` should be non-zero on turn 1, `cache_read` should grow on subsequent turns
- [ ] Verify cost per turn drops significantly after turn 1
- [ ] Use GitHub Copilot with a non-Claude model (e.g. `gpt-4o`) — should still use OpenAI shim
- [ ] Set `CLAUDE_CODE_GITHUB_ANTHROPIC_API=1` — should force native mode regardless of model
- [ ] Verify context window lookup resolves correctly for `github:copilot:claude-haiku-4.5` etc.