### PR TITLE
fix: add store:false to Chat Completions and /responses fallback

### DIFF
--- a/src/services/api/openaiShim.ts
+++ b/src/services/api/openaiShim.ts
@@ -1158,6 +1158,7 @@ class OpenAIShimMessages {
       model: request.resolvedModel,
       messages: openaiMessages,
       stream: params.stream ?? false,
+      store: false,
     }
     // Convert max_tokens to max_completion_tokens for OpenAI API compatibility.
     // Azure OpenAI requires max_completion_tokens and does not accept max_tokens.
@@ -1332,6 +1333,7 @@ class OpenAIShimMessages {
               }>,
             ),
             stream: params.stream ?? false,
+            store: false,
           }
 
           if (!Array.isArray(responsesBody.input) || responsesBody.input.length === 0) {


### PR DESCRIPTION
## Summary

Add `store: false` to the Chat Completions and `/responses` fallback request bodies in `openaiShim.ts`.

## Problem

The Responses API primary path (`codexShim.ts`) already sets `store: false`, but the Chat Completions path and the `/responses` fallback in `openaiShim.ts` do not. This creates an inconsistency where some API paths opt out of server-side data storage and others do not.

## Changes

- Add `store: false` to the Chat Completions request body (line ~1161)
- Add `store: false` to the `/responses` fallback request body (line ~1336)

## Context

`store: false` tells the API provider not to persist conversation data for model training, logging, or other non-operational purposes. This is a privacy measure that does not affect caching or functionality.

Whether third-party proxies (e.g. GitHub Copilot) honour this parameter is provider-dependent, but setting it is a reasonable default for user privacy and consistency with the codexShim path.