### PR TITLE
feat: native Anthropic API mode for Claude models on GitHub Copilot

### DIFF
--- a/src/services/api/claude.ts
+++ b/src/services/api/claude.ts
@@ -23,6 +23,7 @@ import { randomUUID } from 'crypto'
 import {
   getAPIProvider,
   isFirstPartyAnthropicBaseUrl,
+  isGithubNativeAnthropicMode,
 } from 'src/utils/model/providers.js'
 import {
   getAttributionHeader,
@@ -334,8 +335,13 @@ export function getPromptCachingEnabled(model: string): boolean {
   // Prompt caching is an Anthropic-specific feature. Third-party providers
   // do not understand cache_control blocks and strict backends (e.g. Azure
   // Foundry) reject or flag requests that contain them.
+  //
+  // Exception: when the GitHub provider is configured in native Anthropic API
+  // mode (CLAUDE_CODE_GITHUB_ANTHROPIC_API=1), requests are sent in Anthropic
+  // format, so cache_control blocks are supported.
   const provider = getAPIProvider()
-  if (provider !== 'firstParty' && provider !== 'bedrock' && provider !== 'vertex') {
+  const isNativeGithub = isGithubNativeAnthropicMode(model)
+  if (provider !== 'firstParty' && provider !== 'bedrock' && provider !== 'vertex' && !isNativeGithub) {
     return false
   }
 

--- a/src/services/api/client.ts
+++ b/src/services/api/client.ts
@@ -14,6 +14,7 @@ import { getSmallFastModel } from 'src/utils/model/model.js'
 import {
   getAPIProvider,
   isFirstPartyAnthropicBaseUrl,
+  isGithubNativeAnthropicMode,
 } from 'src/utils/model/providers.js'
 import { getProxyFetchOptions } from 'src/utils/proxy.js'
 import {
@@ -173,6 +174,25 @@ export async function getAnthropicClient({
       timeout: parseInt(process.env.API_TIMEOUT_MS || String(600 * 1000), 10),
       providerOverride,
     }) as unknown as Anthropic
+  }
+  // GitHub provider in native Anthropic API mode: send requests in Anthropic
+  // format so cache_control blocks are honoured and prompt caching works.
+  // Requires the GitHub endpoint (OPENAI_BASE_URL) to support Anthropic's
+  // messages API — set CLAUDE_CODE_GITHUB_ANTHROPIC_API=1 to opt in.
+  if (isGithubNativeAnthropicMode(model)) {
+    const githubBaseUrl =
+      process.env.OPENAI_BASE_URL?.replace(/\/$/, '') ??
+      'https://api.githubcopilot.com'
+    const githubToken =
+      process.env.GITHUB_TOKEN ?? process.env.GH_TOKEN ?? ''
+    const nativeArgs: ConstructorParameters<typeof Anthropic>[0] = {
+      ...ARGS,
+      baseURL: githubBaseUrl,
+      authToken: githubToken,
+      // No apiKey — we authenticate via Bearer token (authToken)
+      apiKey: null,
+    }
+    return new Anthropic(nativeArgs)
   }
   if (
     isEnvTruthy(process.env.CLAUDE_CODE_USE_OPENAI) ||

--- a/src/utils/model/providers.ts
+++ b/src/utils/model/providers.ts
@@ -33,6 +33,28 @@ export function getAPIProvider(): APIProvider {
 export function usesAnthropicAccountFlow(): boolean {
   return getAPIProvider() === 'firstParty'
 }
+
+/**
+ * Returns true when the GitHub provider should use Anthropic's native API
+ * format instead of the OpenAI-compatible shim.
+ *
+ * Enabled automatically when CLAUDE_CODE_USE_GITHUB=1 and the selected model
+ * is a Claude model (OPENAI_MODEL starts with "claude-"). Can also be forced
+ * on with CLAUDE_CODE_GITHUB_ANTHROPIC_API=1 for any model.
+ *
+ * api.githubcopilot.com supports Anthropic native format for Claude models,
+ * enabling prompt caching via cache_control blocks which significantly reduces
+ * per-turn token costs by caching the system prompt and tool definitions.
+ */
+export function isGithubNativeAnthropicMode(resolvedModel?: string): boolean {
+  if (!isEnvTruthy(process.env.CLAUDE_CODE_USE_GITHUB)) return false
+  if (isEnvTruthy(process.env.CLAUDE_CODE_GITHUB_ANTHROPIC_API)) return true
+  // Auto-enable for Claude models — they support native format + caching.
+  // Prefer the resolved model name (e.g. "claude-haiku-4.5") over OPENAI_MODEL
+  // which may be a generic alias like "github:copilot".
+  const model = resolvedModel?.trim() || process.env.OPENAI_MODEL?.trim() || ''
+  return model.toLowerCase().startsWith('claude-')
+}
 function isCodexModel(): boolean {
   return shouldUseCodexTransport(
     process.env.OPENAI_MODEL || '',


### PR DESCRIPTION
## Summary

Automatically switch to Anthropic's native messages API when using Claude models through GitHub Copilot, instead of going through the OpenAI-compatible shim.

## Background

The Copilot proxy (`api.githubcopilot.com`) supports Anthropic's native API format for Claude models. Currently, all requests go through the OpenAI shim which translates Anthropic→OpenAI→Anthropic, losing `cache_control` blocks in the process.

While Copilot does perform server-side auto-caching (see #515 investigation), using the native format gives us:
- **Explicit `cache_control` blocks** for fine-grained caching control
- **No lossy translation** — messages stay in Anthropic format end-to-end
- **Potentially better Claude behaviour** with native message format

## Changes

**`src/utils/model/providers.ts`**
- Add `isGithubNativeAnthropicMode(resolvedModel?)` — returns `true` when the GitHub provider is active and the resolved model starts with `claude-`
- Can be forced with `CLAUDE_CODE_GITHUB_ANTHROPIC_API=1`

**`src/services/api/client.ts`**
- Create a native `Anthropic` client when `isGithubNativeAnthropicMode()` is true
- Uses the GitHub base URL (`OPENAI_BASE_URL` or `https://api.githubcopilot.com`)
- Authenticates via Bearer token (`GITHUB_TOKEN` / `GH_TOKEN`)

**`src/services/api/claude.ts`**
- Enable prompt caching for native GitHub mode in `getPromptCachingEnabled()`
- Previously only allowed for `firstParty`, `bedrock`, and `vertex` providers

## Usage

Automatic when using a Claude model on Copilot:
```bash
CLAUDE_CODE_USE_GITHUB=1 OPENAI_MODEL=github:copilot openclaude
# /model → Claude Sonnet 4 → native Anthropic mode auto-enabled
```

Force for any model:
```bash
CLAUDE_CODE_GITHUB_ANTHROPIC_API=1
```

Related: #515