### PR TITLE
fix(ink): resolve stale TUI state via separate Box and Text fixes

### DIFF
--- a/src/components/InteractiveMenuRegression.test.tsx
+++ b/src/components/InteractiveMenuRegression.test.tsx
@@ -1,0 +1,152 @@
+import { PassThrough } from 'node:stream'
+
+import { expect, test } from 'bun:test'
+import React from 'react'
+import stripAnsi from 'strip-ansi'
+
+import { createRoot } from '../ink.js'
+import type { ResolvedAgent } from '../tools/AgentTool/agentDisplay.js'
+import { AgentsList } from './agents/AgentsList.js'
+
+const SYNC_START = '\x1B[?2026h'
+const SYNC_END = '\x1B[?2026l'
+
+function extractLastFrame(output: string): string {
+  let lastFrame: string | null = null
+  let cursor = 0
+
+  while (cursor < output.length) {
+    const start = output.indexOf(SYNC_START, cursor)
+    if (start === -1) break
+
+    const contentStart = start + SYNC_START.length
+    const end = output.indexOf(SYNC_END, contentStart)
+    if (end === -1) break
+
+    const frame = output.slice(contentStart, end)
+    if (frame.trim().length > 0) {
+      lastFrame = frame
+    }
+    cursor = end + SYNC_END.length
+  }
+
+  return lastFrame ?? output
+}
+
+function normalizeFrame(output: string): string {
+  return stripAnsi(output).replace(/\s+/g, ' ').trim()
+}
+
+async function waitForNormalizedFrame(
+  getOutput: () => string,
+  predicate: (frame: string) => boolean,
+  options?: { timeoutMs?: number; intervalMs?: number },
+): Promise<string> {
+  const timeoutMs = options?.timeoutMs ?? 2000
+  const intervalMs = options?.intervalMs ?? 10
+  const startedAt = Date.now()
+
+  while (Date.now() - startedAt < timeoutMs) {
+    const frame = normalizeFrame(extractLastFrame(getOutput()))
+    if (predicate(frame)) {
+      return frame
+    }
+    await Bun.sleep(intervalMs)
+  }
+
+  const lastFrame = normalizeFrame(extractLastFrame(getOutput()))
+  throw new Error(`Timed out waiting for frame. Last frame:\n${lastFrame}`)
+}
+
+function createTestStreams(): {
+  stdout: PassThrough
+  stdin: PassThrough & {
+    isTTY: boolean
+    setRawMode: (mode: boolean) => void
+    ref: () => void
+    unref: () => void
+  }
+  getOutput: () => string
+} {
+  let output = ''
+  const stdout = new PassThrough()
+  const stdin = new PassThrough() as PassThrough & {
+    isTTY: boolean
+    setRawMode: (mode: boolean) => void
+    ref: () => void
+    unref: () => void
+  }
+
+  stdin.isTTY = true
+  stdin.setRawMode = () => {}
+  stdin.ref = () => {}
+  stdin.unref = () => {}
+  ;(stdout as unknown as { columns: number }).columns = 120
+  stdout.on('data', chunk => {
+    output += chunk.toString()
+  })
+
+  return {
+    stdout,
+    stdin,
+    getOutput: () => output,
+  }
+}
+
+function createPluginAgent(agentType: string): ResolvedAgent {
+  return {
+    agentType,
+    whenToUse: 'Used for regression testing',
+    source: 'plugin',
+    plugin: 'codex',
+    getSystemPrompt: () => '',
+    baseDir: 'plugin/codex',
+    model: 'inherit',
+  } as ResolvedAgent
+}
+
+test('AgentsList keeps keyboard navigation working after the first move', async () => {
+  const { stdout, stdin, getOutput } = createTestStreams()
+  const root = await createRoot({
+    stdout: stdout as unknown as NodeJS.WriteStream,
+    stdin: stdin as unknown as NodeJS.ReadStream,
+    patchConsole: false,
+  })
+
+  try {
+    root.render(
+      <AgentsList
+        source="all"
+        agents={[createPluginAgent('codex:codex-rescue')]}
+        onBack={() => {}}
+        onSelect={() => {}}
+        onCreateNew={() => {}}
+      />,
+    )
+
+    const initialFrame = await waitForNormalizedFrame(getOutput, frame =>
+      frame.includes('❯ Create new agent'),
+    )
+    expect(initialFrame).toContain('❯ Create new agent')
+
+    stdin.write('\x1b[B')
+    const downFrame = await waitForNormalizedFrame(getOutput, frame =>
+      frame.includes('❯ codex:codex-rescue'),
+    )
+    expect(downFrame).toContain('❯ codex:codex-rescue')
+
+    stdin.write('\x1b[A')
+    const finalFrame = await waitForNormalizedFrame(getOutput, frame =>
+      frame.includes('❯ Create new agent') &&
+      !frame.includes('❯ codex:codex-rescue'),
+    )
+
+    expect(finalFrame).toContain('❯ Create new agent')
+    expect(finalFrame).not.toContain('❯ codex:codex-rescue')
+  } finally {
+    root.unmount()
+    stdin.end()
+    stdout.end()
+    await Bun.sleep(25)
+  }
+})

--- a/src/ink/components/Box.tsx
+++ b/src/ink/components/Box.tsx
@@ -8,6 +8,19 @@ import type { FocusEvent } from '../events/focus-event.js';
 import type { KeyboardEvent } from '../events/keyboard-event.js';
 import type { Styles } from '../styles.js';
 import * as warn from '../warn.js';
+
+const handlerIdentityKeys = new WeakMap<Function, number>();
+let nextHandlerIdentityKey = 1;
+
+function getHandlerIdentityKey(handler: Function): number {
+  const existing = handlerIdentityKeys.get(handler);
+  if (existing !== undefined) {
+    return existing;
+  }
+  const next = nextHandlerIdentityKey++;
+  handlerIdentityKeys.set(handler, next);
+  return next;
+}
 export type Props = Except<Styles, 'textWrap'> & {
   /**
    * Tab order index. Nodes with `tabIndex >= 0` participate in
@@ -48,7 +61,7 @@ export type Props = Except<Styles, 'textWrap'> & {
  * `<Box>` is an essential Ink component to build your layout. It's like `<div style="display: flex">` in the browser.
  */
 function BoxInner(t0, ref: React.ForwardedRef<DOMElement>) {
-  const $ = _c(42);
+  const $ = _c(43);
   let autoFocus;
   let children;
   let flexDirection;
@@ -159,6 +172,8 @@ function BoxInner(t0, ref: React.ForwardedRef<DOMElement>) {
   }
   const t1 = style.overflowX ?? style.overflow ?? "visible";
   const t2 = style.overflowY ?? style.overflow ?? "visible";
+  const shouldRemountInteractiveHost = autoFocus === true && typeof tabIndex === 'number' && tabIndex >= 0 && onKeyDown !== undefined;
+  const hostKey = shouldRemountInteractiveHost ? getHandlerIdentityKey(onKeyDown) : undefined;
   let t3;
   if ($[19] !== flexDirection || $[20] !== flexGrow || $[21] !== flexShrink || $[22] !== flexWrap || $[23] !== style || $[24] !== t1 || $[25] !== t2) {
     t3 = {
@@ -182,25 +197,26 @@ function BoxInner(t0, ref: React.ForwardedRef<DOMElement>) {
     t3 = $[26];
   }
   let t4;
-  if ($[27] !== autoFocus || $[28] !== children || $[29] !== onBlur || $[30] !== onBlurCapture || $[31] !== onClick || $[32] !== onFocus || $[33] !== onFocusCapture || $[34] !== onKeyDown || $[35] !== onKeyDownCapture || $[36] !== onMouseEnter || $[37] !== onMouseLeave || $[38] !== ref || $[39] !== t3 || $[40] !== tabIndex) {
-    t4 = <ink-box ref={ref} tabIndex={tabIndex} autoFocus={autoFocus} onClick={onClick} onFocus={onFocus} onFocusCapture={onFocusCapture} onBlur={onBlur} onBlurCapture={onBlurCapture} onMouseEnter={onMouseEnter} onMouseLeave={onMouseLeave} onKeyDown={onKeyDown} onKeyDownCapture={onKeyDownCapture} style={t3}>{children}</ink-box>;
+  if ($[27] !== autoFocus || $[28] !== children || $[29] !== hostKey || $[30] !== onBlur || $[31] !== onBlurCapture || $[32] !== onClick || $[33] !== onFocus || $[34] !== onFocusCapture || $[35] !== onKeyDown || $[36] !== onKeyDownCapture || $[37] !== onMouseEnter || $[38] !== onMouseLeave || $[39] !== ref || $[40] !== t3 || $[41] !== tabIndex) {
+    t4 = <ink-box key={hostKey} ref={ref} tabIndex={tabIndex} autoFocus={autoFocus} onClick={onClick} onFocus={onFocus} onFocusCapture={onFocusCapture} onBlur={onBlur} onBlurCapture={onBlurCapture} onMouseEnter={onMouseEnter} onMouseLeave={onMouseLeave} onKeyDown={onKeyDown} onKeyDownCapture={onKeyDownCapture} style={t3}>{children}</ink-box>;
     $[27] = autoFocus;
     $[28] = children;
-    $[29] = onBlur;
-    $[30] = onBlurCapture;
-    $[31] = onClick;
-    $[32] = onFocus;
-    $[33] = onFocusCapture;
-    $[34] = onKeyDown;
-    $[35] = onKeyDownCapture;
-    $[36] = onMouseEnter;
-    $[37] = onMouseLeave;
-    $[38] = ref;
-    $[39] = t3;
-    $[40] = tabIndex;
-    $[41] = t4;
+    $[29] = hostKey;
+    $[30] = onBlur;
+    $[31] = onBlurCapture;
+    $[32] = onClick;
+    $[33] = onFocus;
+    $[34] = onFocusCapture;
+    $[35] = onKeyDown;
+    $[36] = onKeyDownCapture;
+    $[37] = onMouseEnter;
+    $[38] = onMouseLeave;
+    $[39] = ref;
+    $[40] = t3;
+    $[41] = tabIndex;
+    $[42] = t4;
   } else {
-    t4 = $[41];
+    t4 = $[42];
   }
   return t4;
 }

--- a/src/ink/components/Box.tsx
+++ b/src/ink/components/Box.tsx
@@ -8,19 +8,6 @@ import type { FocusEvent } from '../events/focus-event.js';
 import type { KeyboardEvent } from '../events/keyboard-event.js';
 import type { Styles } from '../styles.js';
 import * as warn from '../warn.js';
-
-const handlerIdentityKeys = new WeakMap<Function, number>();
-let nextHandlerIdentityKey = 1;
-
-function getHandlerIdentityKey(handler: Function): number {
-  const existing = handlerIdentityKeys.get(handler);
-  if (existing !== undefined) {
-    return existing;
-  }
-  const next = nextHandlerIdentityKey++;
-  handlerIdentityKeys.set(handler, next);
-  return next;
-}
 export type Props = Except<Styles, 'textWrap'> & {
   /**
    * Tab order index. Nodes with `tabIndex >= 0` participate in
@@ -172,8 +159,18 @@ function BoxInner(t0, ref: React.ForwardedRef<DOMElement>) {
   }
   const t1 = style.overflowX ?? style.overflow ?? "visible";
   const t2 = style.overflowY ?? style.overflow ?? "visible";
-  const shouldRemountInteractiveHost = autoFocus === true && typeof tabIndex === 'number' && tabIndex >= 0 && onKeyDown !== undefined;
-  const hostKey = shouldRemountInteractiveHost ? getHandlerIdentityKey(onKeyDown) : undefined;
+  const onKeyDownRef = React.useRef(onKeyDown);
+  onKeyDownRef.current = onKeyDown;
+  const onKeyDownCaptureRef = React.useRef(onKeyDownCapture);
+  onKeyDownCaptureRef.current = onKeyDownCapture;
+  const stableOnKeyDown = React.useCallback((event: KeyboardEvent) => {
+    onKeyDownRef.current?.(event);
+  }, []);
+  const stableOnKeyDownCapture = React.useCallback((event: KeyboardEvent) => {
+    onKeyDownCaptureRef.current?.(event);
+  }, []);
+  const hostOnKeyDown = onKeyDown === undefined ? undefined : stableOnKeyDown;
+  const hostOnKeyDownCapture = onKeyDownCapture === undefined ? undefined : stableOnKeyDownCapture;
   let t3;
   if ($[19] !== flexDirection || $[20] !== flexGrow || $[21] !== flexShrink || $[22] !== flexWrap || $[23] !== style || $[24] !== t1 || $[25] !== t2) {
     t3 = {
@@ -197,26 +194,25 @@ function BoxInner(t0, ref: React.ForwardedRef<DOMElement>) {
     t3 = $[26];
   }
   let t4;
-  if ($[27] !== autoFocus || $[28] !== children || $[29] !== hostKey || $[30] !== onBlur || $[31] !== onBlurCapture || $[32] !== onClick || $[33] !== onFocus || $[34] !== onFocusCapture || $[35] !== onKeyDown || $[36] !== onKeyDownCapture || $[37] !== onMouseEnter || $[38] !== onMouseLeave || $[39] !== ref || $[40] !== t3 || $[41] !== tabIndex) {
-    t4 = <ink-box key={hostKey} ref={ref} tabIndex={tabIndex} autoFocus={autoFocus} onClick={onClick} onFocus={onFocus} onFocusCapture={onFocusCapture} onBlur={onBlur} onBlurCapture={onBlurCapture} onMouseEnter={onMouseEnter} onMouseLeave={onMouseLeave} onKeyDown={onKeyDown} onKeyDownCapture={onKeyDownCapture} style={t3}>{children}</ink-box>;
+  if ($[27] !== autoFocus || $[28] !== children || $[29] !== onBlur || $[30] !== onBlurCapture || $[31] !== onClick || $[32] !== onFocus || $[33] !== onFocusCapture || $[34] !== hostOnKeyDown || $[35] !== hostOnKeyDownCapture || $[36] !== onMouseEnter || $[37] !== onMouseLeave || $[38] !== ref || $[39] !== t3 || $[40] !== tabIndex) {
+    t4 = <ink-box ref={ref} tabIndex={tabIndex} autoFocus={autoFocus} onClick={onClick} onFocus={onFocus} onFocusCapture={onFocusCapture} onBlur={onBlur} onBlurCapture={onBlurCapture} onMouseEnter={onMouseEnter} onMouseLeave={onMouseLeave} onKeyDown={hostOnKeyDown} onKeyDownCapture={hostOnKeyDownCapture} style={t3}>{children}</ink-box>;
     $[27] = autoFocus;
     $[28] = children;
-    $[29] = hostKey;
-    $[30] = onBlur;
-    $[31] = onBlurCapture;
-    $[32] = onClick;
-    $[33] = onFocus;
-    $[34] = onFocusCapture;
-    $[35] = onKeyDown;
-    $[36] = onKeyDownCapture;
-    $[37] = onMouseEnter;
-    $[38] = onMouseLeave;
-    $[39] = ref;
-    $[40] = t3;
-    $[41] = tabIndex;
-    $[42] = t4;
+    $[29] = onBlur;
+    $[30] = onBlurCapture;
+    $[31] = onClick;
+    $[32] = onFocus;
+    $[33] = onFocusCapture;
+    $[34] = hostOnKeyDown;
+    $[35] = hostOnKeyDownCapture;
+    $[36] = onMouseEnter;
+    $[37] = onMouseLeave;
+    $[38] = ref;
+    $[39] = t3;
+    $[40] = tabIndex;
+    $[41] = t4;
   } else {
-    t4 = $[42];
+    t4 = $[41];
   }
   return t4;
 }

--- a/src/ink/components/Text.tsx
+++ b/src/ink/components/Text.tsx
@@ -112,7 +112,7 @@ const memoizedStylesForWrap: Record<NonNullable<Styles['textWrap']>, Styles> = {
  * This component can display text, and change its style to make it colorful, bold, underline, italic or strikethrough.
  */
 export default function Text(t0) {
-  const $ = _c(29);
+  const $ = _c(30);
   const {
     color,
     backgroundColor,
@@ -238,16 +238,18 @@ export default function Text(t0) {
     t14 = $[24];
   }
   const textStyles = t14;
+  const textStyleKey = JSON.stringify(textStyles);
   const t15 = memoizedStylesForWrap[wrap];
   let t16;
-  if ($[25] !== children || $[26] !== t15 || $[27] !== textStyles) {
-    t16 = <ink-text style={t15} textStyles={textStyles}>{children}</ink-text>;
+  if ($[25] !== children || $[26] !== t15 || $[27] !== textStyleKey || $[28] !== textStyles) {
+    t16 = <ink-text key={textStyleKey} style={t15} textStyles={textStyles}>{children}</ink-text>;
     $[25] = children;
     $[26] = t15;
-    $[27] = textStyles;
-    $[28] = t16;
+    $[27] = textStyleKey;
+    $[28] = textStyles;
+    $[29] = t16;
   } else {
-    t16 = $[28];
+    t16 = $[29];
   }
   return t16;
 }


### PR DESCRIPTION
This PR resolves two distinct but overlapping shared issues that caused stale state in interactive menus such as `/config` and `/agents`.

## Summary

A previous workaround in `Box` remounted the entire interactive subtree and happened to mask two separate defects at once. This change removes that coarse remount behavior and replaces it with:

- a principled shared fix for stale retained `onKeyDown` handlers in `Box`
- a narrower shared repaint workaround for stale style-only updates in `Text`

## What we found

We investigated narrower shared layers such as `useSelectNavigation` and list/highlight rendering, but the failing paths did not go through them consistently.

Tracing showed that in affected screens like `/agents`:

- component state did change after the first arrow key press
- the component-level `handleKeyDown` callback identity also changed
- but the retained `ink-box` host kept invoking the original `onKeyDown` handler

That means the main “moves one step then gets stuck” bug was not caused by `useSelectNavigation`, but by a stale retained host handler.

Separately, style-only updates on retained `<ink-text>` nodes could leave stale visual highlighting behind even after state was already correct.

## Implementation

### 1. Shared handler fix (`src/ink/components/Box.tsx`)

`Box` now passes stable `onKeyDown` / `onKeyDownCapture` wrapper callbacks to the host element. Those wrappers read the latest handler from a ref.

This avoids stale retained host handlers without forcing subtree remounts and without relying on handler identity changes.

### 2. Shared text repaint workaround (`src/ink/components/Text.tsx`)

`Text` now derives a React key from serialized `textStyles` and remounts `<ink-text>` when style-only text changes occur.

This is an intentional shared workaround for stale retained text repainting. It fixes the visual focus/highlight lag without reintroducing the coarse subtree remount behavior from the earlier `Box` workaround.

## Why this approach

- addresses the stale handler problem at the shared host boundary
- keeps the text repaint fix narrowly scoped to style-only text updates
- avoids scattering per-screen remount/focus hacks across the codebase

## Notes

- the `Box` change is the principled fix for the stale keydown-handler issue
- the `Text` change is still a shared workaround for retained text repainting, not a claimed final renderer root-cause fix

## Testing

- [x] `bun run build`
- [x] `bun run smoke`
- [x] focused tests:
  - verified `/agents` no longer gets stuck after the first arrow-key move
  - verified `/config` updates both keyboard behavior and visual highlight correctly
  - verified the old Box subtree-remount workaround is no longer needed
  
 before:
<img width="1113" height="627" alt="_260410031839" src="https://github.com/user-attachments/assets/d5235e65-48cc-49c7-bd20-1b3875e5bc24" />

after:

https://github.com/user-attachments/assets/f4d5e4ae-32f4-4ea7-9688-b00ed6e1185e









