### PR TITLE
fix: report cache reads in streaming and correct cost calculation

### DIFF
--- a/src/cost-tracker.ts
+++ b/src/cost-tracker.ts
@@ -181,7 +181,7 @@ function formatCost(cost: number, maxDecimalPlaces: number = 4): string {
 function formatModelUsage(): string {
   const modelUsageMap = getModelUsage()
   if (Object.keys(modelUsageMap).length === 0) {
-    return 'Usage:                 0 input, 0 output, 0 cache read, 0 cache write'
+    return 'Usage:                 0 input, 0 output'
   }
 
   // Accumulate usage by short name
@@ -211,15 +211,19 @@ function formatModelUsage(): string {
 
   let result = 'Usage by model:'
   for (const [shortName, usage] of Object.entries(usageByShortName)) {
-    const usageString =
+    let usageString =
       `  ${formatNumber(usage.inputTokens)} input, ` +
-      `${formatNumber(usage.outputTokens)} output, ` +
-      `${formatNumber(usage.cacheReadInputTokens)} cache read, ` +
-      `${formatNumber(usage.cacheCreationInputTokens)} cache write` +
-      (usage.webSearchRequests > 0
-        ? `, ${formatNumber(usage.webSearchRequests)} web search`
-        : '') +
-      ` (${formatCost(usage.costUSD)})`
+      `${formatNumber(usage.outputTokens)} output`
+    if (usage.cacheReadInputTokens > 0) {
+      usageString += `, ${formatNumber(usage.cacheReadInputTokens)} cache read`
+    }
+    if (usage.cacheCreationInputTokens > 0) {
+      usageString += `, ${formatNumber(usage.cacheCreationInputTokens)} cache write`
+    }
+    if (usage.webSearchRequests > 0) {
+      usageString += `, ${formatNumber(usage.webSearchRequests)} web search`
+    }
+    usageString += ` (${formatCost(usage.costUSD)})`
     result += `\n` + `${shortName}:`.padStart(21) + usageString
   }
   return result

--- a/src/services/api/codexShim.ts
+++ b/src/services/api/codexShim.ts
@@ -80,12 +80,17 @@ type CodexSseEvent = {
 function makeUsage(usage?: {
   input_tokens?: number
   output_tokens?: number
+  input_tokens_details?: { cached_tokens?: number }
+  prompt_tokens_details?: { cached_tokens?: number }
 }): AnthropicUsage {
   return {
     input_tokens: usage?.input_tokens ?? 0,
     output_tokens: usage?.output_tokens ?? 0,
     cache_creation_input_tokens: 0,
-    cache_read_input_tokens: 0,
+    cache_read_input_tokens:
+      usage?.input_tokens_details?.cached_tokens ??
+      usage?.prompt_tokens_details?.cached_tokens ??
+      0,
   }
 }
 
@@ -890,8 +895,16 @@ export async function* codexStreamToAnthropic(
       stop_sequence: null,
     },
     usage: {
-      input_tokens: finalResponse?.usage?.input_tokens ?? 0,
+      // Subtract cached tokens: OpenAI includes them in input_tokens,
+      // but Anthropic convention treats input_tokens as non-cached only.
+      input_tokens: (finalResponse?.usage?.input_tokens ?? 0) -
+        (finalResponse?.usage?.input_tokens_details?.cached_tokens ??
+         finalResponse?.usage?.prompt_tokens_details?.cached_tokens ?? 0),
       output_tokens: finalResponse?.usage?.output_tokens ?? 0,
+      cache_read_input_tokens:
+        finalResponse?.usage?.input_tokens_details?.cached_tokens ??
+        finalResponse?.usage?.prompt_tokens_details?.cached_tokens ??
+        0,
     },
   }
   yield { type: 'message_stop' }

--- a/src/services/api/openaiShim.ts
+++ b/src/services/api/openaiShim.ts
@@ -538,11 +538,14 @@ function convertChunkUsage(
 ): Partial<AnthropicUsage> | undefined {
   if (!usage) return undefined
 
+  const cached = usage.prompt_tokens_details?.cached_tokens ?? 0
   return {
-    input_tokens: usage.prompt_tokens ?? 0,
+    // Subtract cached tokens: OpenAI includes them in prompt_tokens,
+    // but Anthropic convention treats input_tokens as non-cached only.
+    input_tokens: (usage.prompt_tokens ?? 0) - cached,
     output_tokens: usage.completion_tokens ?? 0,
     cache_creation_input_tokens: 0,
-    cache_read_input_tokens: usage.prompt_tokens_details?.cached_tokens ?? 0,
+    cache_read_input_tokens: cached,
   }
 }
 


### PR DESCRIPTION
## Summary

Fix bugs that cause `/cost` to show incorrect cache stats and inflated costs when using OpenAI-compatible providers (GitHub Copilot, OpenAI direct).

## Problem

### Bug 1: Streaming cache reads always 0 (codexShim)

`codexStreamToAnthropic()` builds the final `message_delta` usage object inline — it never calls `makeUsage()`. The inline object only included `input_tokens` and `output_tokens`, so `cache_read_input_tokens` was hardcoded to 0.

This means `/cost` **never showed cache reads** for any model going through the Responses API (GPT-5+, Codex models).

Also, `makeUsage()` itself did not read `input_tokens_details.cached_tokens`, so even the non-streaming path was broken.

### Bug 2: Cost inflated ~2x from convention mismatch (both shims)

OpenAI convention: `prompt_tokens` **includes** cached tokens (`prompt_tokens = uncached + cached`).
Anthropic convention: `input_tokens` is **non-cached only** (`input_tokens = uncached`).

The shim translated `prompt_tokens → input_tokens` without adjusting, then the cost formula double-counted cached tokens (once at full input rate, once at cache rate).

From issue #515:
```
claude-haiku: 24.4k input, 22.8k cache read → $0.135/turn (WRONG)
                                             → $0.02/turn  (CORRECT)
```

### Bug 3: Misleading "0 cache write" display

`/cost` always showed `0 cache write` for every model, even when caching is working. Providers like GitHub Copilot manage their own cache server-side and never report `cache_creation_input_tokens`. Showing `0 cache write` implies caching is broken when it is not.

## Changes

**codexShim.ts:**
- `makeUsage()`: read `input_tokens_details.cached_tokens` and `prompt_tokens_details.cached_tokens`
- Streaming `message_delta`: add `cache_read_input_tokens` from usage details
- Subtract cached from `input_tokens` for correct Anthropic convention

**openaiShim.ts:**
- `convertChunkUsage()`: subtract `cached_tokens` from `prompt_tokens` before mapping to `input_tokens`

**cost-tracker.ts:**
- Only show `cache read` and `cache write` in `/cost` when value > 0

## Before/After

Before:
```
claude-haiku:  2.6k input, 151 output, 0 cache read, 0 cache write ($0.27)
```

After:
```
claude-haiku:  2.6k input, 151 output, 39.8k cache read ($0.04)
```

Fixes #515