### PR TITLE
feat: native Anthropic API mode for Claude models on GitHub Copilot

### DIFF
--- a/src/services/api/claude.ts
+++ b/src/services/api/claude.ts
@@ -23,6 +23,7 @@ import { randomUUID } from 'crypto'
 import {
   getAPIProvider,
   isFirstPartyAnthropicBaseUrl,
+  isGithubNativeAnthropicMode,
 } from 'src/utils/model/providers.js'
 import {
   getAttributionHeader,
@@ -334,8 +335,13 @@ export function getPromptCachingEnabled(model: string): boolean {
   // Prompt caching is an Anthropic-specific feature. Third-party providers
   // do not understand cache_control blocks and strict backends (e.g. Azure
   // Foundry) reject or flag requests that contain them.
+  //
+  // Exception: when the GitHub provider is configured in native Anthropic API
+  // mode (CLAUDE_CODE_GITHUB_ANTHROPIC_API=1), requests are sent in Anthropic
+  // format, so cache_control blocks are supported.
   const provider = getAPIProvider()
-  if (provider !== 'firstParty' && provider !== 'bedrock' && provider !== 'vertex') {
+  const isNativeGithub = isGithubNativeAnthropicMode(model)
+  if (provider !== 'firstParty' && provider !== 'bedrock' && provider !== 'vertex' && !isNativeGithub) {
     return false
   }
 

--- a/src/services/api/client.ts
+++ b/src/services/api/client.ts
@@ -14,6 +14,7 @@ import { getSmallFastModel } from 'src/utils/model/model.js'
 import {
   getAPIProvider,
   isFirstPartyAnthropicBaseUrl,
+  isGithubNativeAnthropicMode,
 } from 'src/utils/model/providers.js'
 import { getProxyFetchOptions } from 'src/utils/proxy.js'
 import {
@@ -173,6 +174,25 @@ export async function getAnthropicClient({
       timeout: parseInt(process.env.API_TIMEOUT_MS || String(600 * 1000), 10),
       providerOverride,
     }) as unknown as Anthropic
+  }
+  // GitHub provider in native Anthropic API mode: send requests in Anthropic
+  // format so cache_control blocks are honoured and prompt caching works.
+  // Requires the GitHub endpoint (OPENAI_BASE_URL) to support Anthropic's
+  // messages API — set CLAUDE_CODE_GITHUB_ANTHROPIC_API=1 to opt in.
+  if (isGithubNativeAnthropicMode(model)) {
+    const githubBaseUrl =
+      process.env.OPENAI_BASE_URL?.replace(/\/$/, '') ??
+      'https://api.githubcopilot.com'
+    const githubToken =
+      process.env.GITHUB_TOKEN ?? process.env.GH_TOKEN ?? ''
+    const nativeArgs: ConstructorParameters<typeof Anthropic>[0] = {
+      ...ARGS,
+      baseURL: githubBaseUrl,
+      authToken: githubToken,
+      // No apiKey — we authenticate via Bearer token (authToken)
+      apiKey: null,
+    }
+    return new Anthropic(nativeArgs)
   }
   if (
     isEnvTruthy(process.env.CLAUDE_CODE_USE_OPENAI) ||

--- a/src/utils/model/providers.test.ts
+++ b/src/utils/model/providers.test.ts
@@ -7,6 +7,7 @@ const originalEnv = {
   CLAUDE_CODE_USE_BEDROCK: process.env.CLAUDE_CODE_USE_BEDROCK,
   CLAUDE_CODE_USE_VERTEX: process.env.CLAUDE_CODE_USE_VERTEX,
   CLAUDE_CODE_USE_FOUNDRY: process.env.CLAUDE_CODE_USE_FOUNDRY,
+  CLAUDE_CODE_GITHUB_ANTHROPIC_API: process.env.CLAUDE_CODE_GITHUB_ANTHROPIC_API,
   OPENAI_BASE_URL: process.env.OPENAI_BASE_URL,
   OPENAI_API_BASE: process.env.OPENAI_API_BASE,
   OPENAI_MODEL: process.env.OPENAI_MODEL,
@@ -19,6 +20,7 @@ afterEach(() => {
   process.env.CLAUDE_CODE_USE_BEDROCK = originalEnv.CLAUDE_CODE_USE_BEDROCK
   process.env.CLAUDE_CODE_USE_VERTEX = originalEnv.CLAUDE_CODE_USE_VERTEX
   process.env.CLAUDE_CODE_USE_FOUNDRY = originalEnv.CLAUDE_CODE_USE_FOUNDRY
+  process.env.CLAUDE_CODE_GITHUB_ANTHROPIC_API = originalEnv.CLAUDE_CODE_GITHUB_ANTHROPIC_API
   process.env.OPENAI_BASE_URL = originalEnv.OPENAI_BASE_URL
   process.env.OPENAI_API_BASE = originalEnv.OPENAI_API_BASE
   process.env.OPENAI_MODEL = originalEnv.OPENAI_MODEL
@@ -35,6 +37,7 @@ function clearProviderEnv(): void {
   delete process.env.CLAUDE_CODE_USE_BEDROCK
   delete process.env.CLAUDE_CODE_USE_VERTEX
   delete process.env.CLAUDE_CODE_USE_FOUNDRY
+  delete process.env.CLAUDE_CODE_GITHUB_ANTHROPIC_API
   delete process.env.OPENAI_BASE_URL
   delete process.env.OPENAI_API_BASE
   delete process.env.OPENAI_MODEL
@@ -106,4 +109,63 @@ test('official OpenAI base URLs now keep provider detection on openai for aliase
 
   const { getAPIProvider } = await importFreshProvidersModule()
   expect(getAPIProvider()).toBe('openai')
+})
+
+// isGithubNativeAnthropicMode
+
+test('isGithubNativeAnthropicMode: false when CLAUDE_CODE_USE_GITHUB is not set', async () => {
+  clearProviderEnv()
+  process.env.OPENAI_MODEL = 'claude-sonnet-4-5'
+  const { isGithubNativeAnthropicMode } = await importFreshProvidersModule()
+  expect(isGithubNativeAnthropicMode()).toBe(false)
+})
+
+test('isGithubNativeAnthropicMode: true for claude- model via OPENAI_MODEL', async () => {
+  clearProviderEnv()
+  process.env.CLAUDE_CODE_USE_GITHUB = '1'
+  process.env.OPENAI_MODEL = 'claude-sonnet-4-5'
+  const { isGithubNativeAnthropicMode } = await importFreshProvidersModule()
+  expect(isGithubNativeAnthropicMode()).toBe(true)
+})
+
+test('isGithubNativeAnthropicMode: true when resolvedModel overrides non-claude OPENAI_MODEL', async () => {
+  clearProviderEnv()
+  process.env.CLAUDE_CODE_USE_GITHUB = '1'
+  process.env.OPENAI_MODEL = 'github:copilot'
+  const { isGithubNativeAnthropicMode } = await importFreshProvidersModule()
+  expect(isGithubNativeAnthropicMode('claude-haiku-4-5')).toBe(true)
+})
+
+test('isGithubNativeAnthropicMode: false for non-Claude model', async () => {
+  clearProviderEnv()
+  process.env.CLAUDE_CODE_USE_GITHUB = '1'
+  process.env.OPENAI_MODEL = 'gpt-4o'
+  const { isGithubNativeAnthropicMode } = await importFreshProvidersModule()
+  expect(isGithubNativeAnthropicMode()).toBe(false)
+})
+
+test('isGithubNativeAnthropicMode: force flag returns false for non-Claude model', async () => {
+  clearProviderEnv()
+  process.env.CLAUDE_CODE_USE_GITHUB = '1'
+  process.env.CLAUDE_CODE_GITHUB_ANTHROPIC_API = '1'
+  process.env.OPENAI_MODEL = 'gpt-4o'
+  const { isGithubNativeAnthropicMode } = await importFreshProvidersModule()
+  expect(isGithubNativeAnthropicMode()).toBe(false)
+})
+
+test('isGithubNativeAnthropicMode: force flag returns true for claude- model', async () => {
+  clearProviderEnv()
+  process.env.CLAUDE_CODE_USE_GITHUB = '1'
+  process.env.CLAUDE_CODE_GITHUB_ANTHROPIC_API = '1'
+  process.env.OPENAI_MODEL = 'claude-sonnet-4-5'
+  const { isGithubNativeAnthropicMode } = await importFreshProvidersModule()
+  expect(isGithubNativeAnthropicMode()).toBe(true)
+})
+
+test('isGithubNativeAnthropicMode: force flag with no model returns true', async () => {
+  clearProviderEnv()
+  process.env.CLAUDE_CODE_USE_GITHUB = '1'
+  process.env.CLAUDE_CODE_GITHUB_ANTHROPIC_API = '1'
+  const { isGithubNativeAnthropicMode } = await importFreshProvidersModule()
+  expect(isGithubNativeAnthropicMode()).toBe(true)
 })

--- a/src/utils/model/providers.test.ts
+++ b/src/utils/model/providers.test.ts
@@ -7,7 +7,6 @@ const originalEnv = {
   CLAUDE_CODE_USE_BEDROCK: process.env.CLAUDE_CODE_USE_BEDROCK,
   CLAUDE_CODE_USE_VERTEX: process.env.CLAUDE_CODE_USE_VERTEX,
   CLAUDE_CODE_USE_FOUNDRY: process.env.CLAUDE_CODE_USE_FOUNDRY,
-  CLAUDE_CODE_GITHUB_ANTHROPIC_API: process.env.CLAUDE_CODE_GITHUB_ANTHROPIC_API,
   OPENAI_BASE_URL: process.env.OPENAI_BASE_URL,
   OPENAI_API_BASE: process.env.OPENAI_API_BASE,
   OPENAI_MODEL: process.env.OPENAI_MODEL,
@@ -20,7 +19,6 @@ afterEach(() => {
   process.env.CLAUDE_CODE_USE_BEDROCK = originalEnv.CLAUDE_CODE_USE_BEDROCK
   process.env.CLAUDE_CODE_USE_VERTEX = originalEnv.CLAUDE_CODE_USE_VERTEX
   process.env.CLAUDE_CODE_USE_FOUNDRY = originalEnv.CLAUDE_CODE_USE_FOUNDRY
-  process.env.CLAUDE_CODE_GITHUB_ANTHROPIC_API = originalEnv.CLAUDE_CODE_GITHUB_ANTHROPIC_API
   process.env.OPENAI_BASE_URL = originalEnv.OPENAI_BASE_URL
   process.env.OPENAI_API_BASE = originalEnv.OPENAI_API_BASE
   process.env.OPENAI_MODEL = originalEnv.OPENAI_MODEL
@@ -37,7 +35,6 @@ function clearProviderEnv(): void {
   delete process.env.CLAUDE_CODE_USE_BEDROCK
   delete process.env.CLAUDE_CODE_USE_VERTEX
   delete process.env.CLAUDE_CODE_USE_FOUNDRY
-  delete process.env.CLAUDE_CODE_GITHUB_ANTHROPIC_API
   delete process.env.OPENAI_BASE_URL
   delete process.env.OPENAI_API_BASE
   delete process.env.OPENAI_MODEL
@@ -120,7 +117,7 @@ test('isGithubNativeAnthropicMode: false when CLAUDE_CODE_USE_GITHUB is not set'
   expect(isGithubNativeAnthropicMode()).toBe(false)
 })
 
-test('isGithubNativeAnthropicMode: true for claude- model via OPENAI_MODEL', async () => {
+test('isGithubNativeAnthropicMode: true for bare claude- model via OPENAI_MODEL', async () => {
   clearProviderEnv()
   process.env.CLAUDE_CODE_USE_GITHUB = '1'
   process.env.OPENAI_MODEL = 'claude-sonnet-4-5'
@@ -128,12 +125,28 @@ test('isGithubNativeAnthropicMode: true for claude- model via OPENAI_MODEL', asy
   expect(isGithubNativeAnthropicMode()).toBe(true)
 })
 
-test('isGithubNativeAnthropicMode: true when resolvedModel overrides non-claude OPENAI_MODEL', async () => {
+test('isGithubNativeAnthropicMode: true for github:copilot:claude- compound format', async () => {
+  clearProviderEnv()
+  process.env.CLAUDE_CODE_USE_GITHUB = '1'
+  process.env.OPENAI_MODEL = 'github:copilot:claude-sonnet-4'
+  const { isGithubNativeAnthropicMode } = await importFreshProvidersModule()
+  expect(isGithubNativeAnthropicMode()).toBe(true)
+})
+
+test('isGithubNativeAnthropicMode: true when resolvedModel is a claude- model', async () => {
   clearProviderEnv()
   process.env.CLAUDE_CODE_USE_GITHUB = '1'
   process.env.OPENAI_MODEL = 'github:copilot'
   const { isGithubNativeAnthropicMode } = await importFreshProvidersModule()
   expect(isGithubNativeAnthropicMode('claude-haiku-4-5')).toBe(true)
+})
+
+test('isGithubNativeAnthropicMode: false for generic github:copilot alias', async () => {
+  clearProviderEnv()
+  process.env.CLAUDE_CODE_USE_GITHUB = '1'
+  process.env.OPENAI_MODEL = 'github:copilot'
+  const { isGithubNativeAnthropicMode } = await importFreshProvidersModule()
+  expect(isGithubNativeAnthropicMode()).toBe(false)
 })
 
 test('isGithubNativeAnthropicMode: false for non-Claude model', async () => {
@@ -144,28 +157,10 @@ test('isGithubNativeAnthropicMode: false for non-Claude model', async () => {
   expect(isGithubNativeAnthropicMode()).toBe(false)
 })
 
-test('isGithubNativeAnthropicMode: force flag returns false for non-Claude model', async () => {
+test('isGithubNativeAnthropicMode: false for github:copilot:gpt- model', async () => {
   clearProviderEnv()
   process.env.CLAUDE_CODE_USE_GITHUB = '1'
-  process.env.CLAUDE_CODE_GITHUB_ANTHROPIC_API = '1'
-  process.env.OPENAI_MODEL = 'gpt-4o'
+  process.env.OPENAI_MODEL = 'github:copilot:gpt-4o'
   const { isGithubNativeAnthropicMode } = await importFreshProvidersModule()
   expect(isGithubNativeAnthropicMode()).toBe(false)
-})
-
-test('isGithubNativeAnthropicMode: force flag returns true for claude- model', async () => {
-  clearProviderEnv()
-  process.env.CLAUDE_CODE_USE_GITHUB = '1'
-  process.env.CLAUDE_CODE_GITHUB_ANTHROPIC_API = '1'
-  process.env.OPENAI_MODEL = 'claude-sonnet-4-5'
-  const { isGithubNativeAnthropicMode } = await importFreshProvidersModule()
-  expect(isGithubNativeAnthropicMode()).toBe(true)
-})
-
-test('isGithubNativeAnthropicMode: force flag with no model returns true', async () => {
-  clearProviderEnv()
-  process.env.CLAUDE_CODE_USE_GITHUB = '1'
-  process.env.CLAUDE_CODE_GITHUB_ANTHROPIC_API = '1'
-  const { isGithubNativeAnthropicMode } = await importFreshProvidersModule()
-  expect(isGithubNativeAnthropicMode()).toBe(true)
 })

--- a/src/utils/model/providers.ts
+++ b/src/utils/model/providers.ts
@@ -45,6 +45,28 @@ export function getAPIProvider(): APIProvider {
 export function usesAnthropicAccountFlow(): boolean {
   return getAPIProvider() === 'firstParty'
 }
+
+/**
+ * Returns true when the GitHub provider should use Anthropic's native API
+ * format instead of the OpenAI-compatible shim.
+ *
+ * Enabled automatically when CLAUDE_CODE_USE_GITHUB=1 and the selected model
+ * is a Claude model (OPENAI_MODEL starts with "claude-"). Can also be forced
+ * on with CLAUDE_CODE_GITHUB_ANTHROPIC_API=1 for any model.
+ *
+ * api.githubcopilot.com supports Anthropic native format for Claude models,
+ * enabling prompt caching via cache_control blocks which significantly reduces
+ * per-turn token costs by caching the system prompt and tool definitions.
+ */
+export function isGithubNativeAnthropicMode(resolvedModel?: string): boolean {
+  if (!isEnvTruthy(process.env.CLAUDE_CODE_USE_GITHUB)) return false
+  if (isEnvTruthy(process.env.CLAUDE_CODE_GITHUB_ANTHROPIC_API)) return true
+  // Auto-enable for Claude models — they support native format + caching.
+  // Prefer the resolved model name (e.g. "claude-haiku-4.5") over OPENAI_MODEL
+  // which may be a generic alias like "github:copilot".
+  const model = resolvedModel?.trim() || process.env.OPENAI_MODEL?.trim() || ''
+  return model.toLowerCase().startsWith('claude-')
+}
 function isCodexModel(): boolean {
   return shouldUseCodexTransport(
     process.env.OPENAI_MODEL || '',

--- a/src/utils/model/providers.ts
+++ b/src/utils/model/providers.ts
@@ -52,7 +52,8 @@ export function usesAnthropicAccountFlow(): boolean {
  *
  * Enabled automatically when CLAUDE_CODE_USE_GITHUB=1 and the selected model
  * is a Claude model (OPENAI_MODEL starts with "claude-"). Can also be forced
- * on with CLAUDE_CODE_GITHUB_ANTHROPIC_API=1 for any model.
+ * on with CLAUDE_CODE_GITHUB_ANTHROPIC_API=1 for Claude models that use an
+ * alias (e.g. "github:copilot") that would not be detected automatically.
  *
  * api.githubcopilot.com supports Anthropic native format for Claude models,
  * enabling prompt caching via cache_control blocks which significantly reduces
@@ -60,12 +61,18 @@ export function usesAnthropicAccountFlow(): boolean {
  */
 export function isGithubNativeAnthropicMode(resolvedModel?: string): boolean {
   if (!isEnvTruthy(process.env.CLAUDE_CODE_USE_GITHUB)) return false
-  if (isEnvTruthy(process.env.CLAUDE_CODE_GITHUB_ANTHROPIC_API)) return true
-  // Auto-enable for Claude models — they support native format + caching.
   // Prefer the resolved model name (e.g. "claude-haiku-4.5") over OPENAI_MODEL
   // which may be a generic alias like "github:copilot".
   const model = resolvedModel?.trim() || process.env.OPENAI_MODEL?.trim() || ''
-  return model.toLowerCase().startsWith('claude-')
+  const isClaudeModel = model.toLowerCase().startsWith('claude-')
+  // Force flag: opt in explicitly when using a Claude model under a non-standard
+  // alias (e.g. OPENAI_MODEL=github:copilot). This flag is only intended for
+  // endpoints known to serve a Claude model; native Anthropic format is only
+  // validated for Claude models on Copilot.
+  if (isEnvTruthy(process.env.CLAUDE_CODE_GITHUB_ANTHROPIC_API)) {
+    return isClaudeModel || !model
+  }
+  return isClaudeModel
 }
 function isCodexModel(): boolean {
   return shouldUseCodexTransport(

--- a/src/utils/model/providers.ts
+++ b/src/utils/model/providers.ts
@@ -51,9 +51,8 @@ export function usesAnthropicAccountFlow(): boolean {
  * format instead of the OpenAI-compatible shim.
  *
  * Enabled automatically when CLAUDE_CODE_USE_GITHUB=1 and the selected model
- * is a Claude model (OPENAI_MODEL starts with "claude-"). Can also be forced
- * on with CLAUDE_CODE_GITHUB_ANTHROPIC_API=1 for Claude models that use an
- * alias (e.g. "github:copilot") that would not be detected automatically.
+ * is a Claude model. Handles both bare model names ("claude-sonnet-4") and the
+ * standard GitHub Copilot format ("github:copilot:claude-sonnet-4").
  *
  * api.githubcopilot.com supports Anthropic native format for Claude models,
  * enabling prompt caching via cache_control blocks which significantly reduces
@@ -61,18 +60,14 @@ export function usesAnthropicAccountFlow(): boolean {
  */
 export function isGithubNativeAnthropicMode(resolvedModel?: string): boolean {
   if (!isEnvTruthy(process.env.CLAUDE_CODE_USE_GITHUB)) return false
-  // Prefer the resolved model name (e.g. "claude-haiku-4.5") over OPENAI_MODEL
-  // which may be a generic alias like "github:copilot".
   const model = resolvedModel?.trim() || process.env.OPENAI_MODEL?.trim() || ''
-  const isClaudeModel = model.toLowerCase().startsWith('claude-')
-  // Force flag: opt in explicitly when using a Claude model under a non-standard
-  // alias (e.g. OPENAI_MODEL=github:copilot). This flag is only intended for
-  // endpoints known to serve a Claude model; native Anthropic format is only
-  // validated for Claude models on Copilot.
-  if (isEnvTruthy(process.env.CLAUDE_CODE_GITHUB_ANTHROPIC_API)) {
-    return isClaudeModel || !model
-  }
-  return isClaudeModel
+  const normalized = model.toLowerCase()
+  // Match bare model names ("claude-sonnet-4") and the standard GitHub Copilot
+  // compound format ("github:copilot:claude-sonnet-4").
+  return (
+    normalized.startsWith('claude-') ||
+    normalized.startsWith('github:copilot:claude-')
+  )
 }
 function isCodexModel(): boolean {
   return shouldUseCodexTransport(

--- a/src/utils/model/providers.ts
+++ b/src/utils/model/providers.ts
@@ -50,9 +50,9 @@ export function usesAnthropicAccountFlow(): boolean {
  * Returns true when the GitHub provider should use Anthropic's native API
  * format instead of the OpenAI-compatible shim.
  *
- * Enabled automatically when CLAUDE_CODE_USE_GITHUB=1 and the selected model
- * is a Claude model. Handles both bare model names ("claude-sonnet-4") and the
- * standard GitHub Copilot format ("github:copilot:claude-sonnet-4").
+ * Enabled when CLAUDE_CODE_USE_GITHUB=1 and the model string contains "claude-"
+ * anywhere (handles bare names like "claude-sonnet-4" and compound formats like
+ * "github:copilot:claude-sonnet-4" or any future provider-prefixed variants).
  *
  * api.githubcopilot.com supports Anthropic native format for Claude models,
  * enabling prompt caching via cache_control blocks which significantly reduces
@@ -61,13 +61,7 @@ export function usesAnthropicAccountFlow(): boolean {
 export function isGithubNativeAnthropicMode(resolvedModel?: string): boolean {
   if (!isEnvTruthy(process.env.CLAUDE_CODE_USE_GITHUB)) return false
   const model = resolvedModel?.trim() || process.env.OPENAI_MODEL?.trim() || ''
-  const normalized = model.toLowerCase()
-  // Match bare model names ("claude-sonnet-4") and the standard GitHub Copilot
-  // compound format ("github:copilot:claude-sonnet-4").
-  return (
-    normalized.startsWith('claude-') ||
-    normalized.startsWith('github:copilot:claude-')
-  )
+  return model.toLowerCase().includes('claude-')
 }
 function isCodexModel(): boolean {
   return shouldUseCodexTransport(


### PR DESCRIPTION
## Summary

Automatically switch to Anthropic's native messages API when using Claude models through GitHub Copilot, instead of going through the OpenAI-compatible shim.

## Background

The Copilot proxy (`api.githubcopilot.com`) supports Anthropic's native API format for Claude models. Currently, all requests go through the OpenAI shim which translates Anthropic→OpenAI→Anthropic, losing `cache_control` blocks in the process.

While Copilot does perform server-side auto-caching (see #515 investigation), using the native format gives us:
- **Explicit `cache_control` blocks** for fine-grained caching control
- **No lossy translation** — messages stay in Anthropic format end-to-end
- **Potentially better Claude behaviour** with native message format

## Changes

**`src/utils/model/providers.ts`**
- Add `isGithubNativeAnthropicMode(resolvedModel?)` — returns `true` when the GitHub provider is active and the resolved model starts with `claude-`
- Can be forced with `CLAUDE_CODE_GITHUB_ANTHROPIC_API=1`

**`src/services/api/client.ts`**
- Create a native `Anthropic` client when `isGithubNativeAnthropicMode()` is true
- Uses the GitHub base URL (`OPENAI_BASE_URL` or `https://api.githubcopilot.com`)
- Authenticates via Bearer token (`GITHUB_TOKEN` / `GH_TOKEN`)

**`src/services/api/claude.ts`**
- Enable prompt caching for native GitHub mode in `getPromptCachingEnabled()`
- Previously only allowed for `firstParty`, `bedrock`, and `vertex` providers

## Usage

Automatic when using a Claude model on Copilot:
```bash
CLAUDE_CODE_USE_GITHUB=1 OPENAI_MODEL=github:copilot openclaude
# /model → Claude Sonnet 4 → native Anthropic mode auto-enabled
```

Force for any model:
```bash
CLAUDE_CODE_GITHUB_ANTHROPIC_API=1
```

Related: #515