### PR TITLE
fix: rename .claude.json to .openclaude.json with legacy fallback

### DIFF
--- a/src/commands/onboard-github/onboard-github.tsx
+++ b/src/commands/onboard-github/onboard-github.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react'
-import { useCallback, useState } from 'react'
+import { useCallback, useRef, useState } from 'react'
 import { Select } from '../../components/CustomSelect/select.js'
 import { Spinner } from '../../components/Spinner.js'
-import { Box, Text } from '../../ink.js'
+import { Box, Text, useInput } from '../../ink.js'
 import {
   exchangeForCopilotToken,
   openVerificationUri,
@@ -27,7 +27,7 @@ const FORCE_RELOGIN_ARGS = new Set([
   '--reauth',
 ])
 
-type Step = 'menu' | 'device-busy' | 'error'
+type Step = 'menu' | 'device-busy' | 'device-waiting' | 'device-polling' | 'exchanging-token' | 'error'
 
 const PROVIDER_SPECIFIC_KEYS = new Set([
   'CLAUDE_CODE_USE_OPENAI',
@@ -35,6 +35,7 @@ const PROVIDER_SPECIFIC_KEYS = new Set([
   'CLAUDE_CODE_USE_BEDROCK',
   'CLAUDE_CODE_USE_VERTEX',
   'CLAUDE_CODE_USE_FOUNDRY',
+  'CLAUDE_CODE_GITHUB_ANTHROPIC_API',
   'OPENAI_BASE_URL',
   'OPENAI_API_BASE',
   'OPENAI_API_KEY',
@@ -226,28 +227,77 @@ function OnboardGithub(props: {
     [onChangeAPIKey, onDone],
   )
 
+  // Ref to hold device code info between the request and polling phases.
+  const deviceRef = useRef<{ device_code: string; interval: number; expires_in: number } | null>(null)
+  const abortRef = useRef<AbortController | null>(null)
+
   const runDeviceFlow = useCallback(async () => {
     setStep('device-busy')
     setErrorMsg(null)
     setDeviceHint(null)
     try {
       const device = await requestDeviceCode()
+      deviceRef.current = device
       setDeviceHint({
         user_code: device.user_code,
         verification_uri: device.verification_uri,
       })
       await openVerificationUri(device.verification_uri)
+      // Show the code and wait for the user to press Enter before polling.
+      setStep('device-waiting')
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e)
+      setErrorMsg(msg)
+      setStep('error')
+    }
+  }, [])
+
+  const startPolling = useCallback(async () => {
+    const device = deviceRef.current
+    if (!device) return
+    setStep('device-polling')
+    const abortController = new AbortController()
+    abortRef.current = abortController
+    const onSigint = () => abortController.abort()
+    process.once('SIGINT', onSigint)
+    try {
       const oauthToken = await pollAccessToken(device.device_code, {
         initialInterval: device.interval,
         timeoutSeconds: device.expires_in,
+        signal: abortController.signal,
       })
-      const copilotToken = await exchangeForCopilotToken(oauthToken)
-      await finalize(copilotToken.token, DEFAULT_MODEL, oauthToken)
+      // OAuth token obtained — now try to exchange for a Copilot API token.
+      setStep('exchanging-token')
+      // This requires an active GitHub Copilot subscription. If it fails
+      // (no subscription, timeout, network error), fall back to the OAuth
+      // token itself — this still works for GitHub Models endpoints.
+      try {
+        const copilotToken = await exchangeForCopilotToken(oauthToken)
+        await finalize(copilotToken.token, DEFAULT_MODEL, oauthToken)
+      } catch {
+        // Copilot token exchange failed — save OAuth token directly.
+        await finalize(oauthToken, DEFAULT_MODEL)
+      }
     } catch (e) {
-      setErrorMsg(e instanceof Error ? e.message : String(e))
+      const msg = e instanceof Error ? e.message : String(e)
+      if (msg === 'Cancelled') {
+        onDone('GitHub onboard cancelled', { display: 'system' })
+        return
+      }
+      setErrorMsg(msg)
       setStep('error')
+    } finally {
+      process.off('SIGINT', onSigint)
+      abortRef.current = null
     }
-  }, [finalize])
+  }, [finalize, onDone])
+
+  // Wait for Enter in the device-waiting step, then start polling.
+  useInput((_input, key) => {
+    if (step === 'device-waiting' && key.return) {
+      startPolling()
+    }
+  })
 
   if (step === 'error' && errorMsg) {
     const options = [
@@ -278,23 +328,46 @@ function OnboardGithub(props: {
     )
   }
 
+  if (step === 'exchanging-token') {
+    return (
+      <Box flexDirection="column" gap={1}>
+        <Text>GitHub Copilot sign-in</Text>
+        <Text dimColor>Authorization confirmed. Retrieving API token...</Text>
+        <Spinner />
+      </Box>
+    )
+  }
+
   if (step === 'device-busy') {
     return (
       <Box flexDirection="column" gap={1}>
         <Text>GitHub Copilot sign-in</Text>
-        {deviceHint ? (
-          <>
-            <Text>
-              Enter code <Text bold>{deviceHint.user_code}</Text> at{' '}
-              {deviceHint.verification_uri}
-            </Text>
-            <Text dimColor>
-              A browser window may have opened. Waiting for authorization...
-            </Text>
-          </>
-        ) : (
-          <Text dimColor>Requesting device code from GitHub...</Text>
-        )}
+        <Text dimColor>Requesting device code from GitHub...</Text>
+        <Spinner />
+      </Box>
+    )
+  }
+
+  if (step === 'device-waiting' && deviceHint) {
+    return (
+      <Box flexDirection="column" gap={1}>
+        <Text>GitHub Copilot sign-in</Text>
+        <Text>
+          Enter code <Text bold>{deviceHint.user_code}</Text> at{' '}
+          {deviceHint.verification_uri}
+        </Text>
+        <Text dimColor>
+          A browser window may have opened. Press Enter after you have authorized.
+        </Text>
+      </Box>
+    )
+  }
+
+  if (step === 'device-polling') {
+    return (
+      <Box flexDirection="column" gap={1}>
+        <Text>GitHub Copilot sign-in</Text>
+        <Text dimColor>Waiting for authorization...</Text>
         <Spinner />
       </Box>
     )

--- a/src/cost-tracker.ts
+++ b/src/cost-tracker.ts
@@ -181,7 +181,7 @@ function formatCost(cost: number, maxDecimalPlaces: number = 4): string {
 function formatModelUsage(): string {
   const modelUsageMap = getModelUsage()
   if (Object.keys(modelUsageMap).length === 0) {
-    return 'Usage:                 0 input, 0 output, 0 cache read, 0 cache write'
+    return 'Usage:                 0 input, 0 output'
   }
 
   // Accumulate usage by short name
@@ -211,15 +211,19 @@ function formatModelUsage(): string {
 
   let result = 'Usage by model:'
   for (const [shortName, usage] of Object.entries(usageByShortName)) {
-    const usageString =
+    let usageString =
       `  ${formatNumber(usage.inputTokens)} input, ` +
-      `${formatNumber(usage.outputTokens)} output, ` +
-      `${formatNumber(usage.cacheReadInputTokens)} cache read, ` +
-      `${formatNumber(usage.cacheCreationInputTokens)} cache write` +
-      (usage.webSearchRequests > 0
-        ? `, ${formatNumber(usage.webSearchRequests)} web search`
-        : '') +
-      ` (${formatCost(usage.costUSD)})`
+      `${formatNumber(usage.outputTokens)} output`
+    if (usage.cacheReadInputTokens > 0) {
+      usageString += `, ${formatNumber(usage.cacheReadInputTokens)} cache read`
+    }
+    if (usage.cacheCreationInputTokens > 0) {
+      usageString += `, ${formatNumber(usage.cacheCreationInputTokens)} cache write`
+    }
+    if (usage.webSearchRequests > 0) {
+      usageString += `, ${formatNumber(usage.webSearchRequests)} web search`
+    }
+    usageString += ` (${formatCost(usage.costUSD)})`
     result += `\n` + `${shortName}:`.padStart(21) + usageString
   }
   return result

--- a/src/entrypoints/cli.tsx
+++ b/src/entrypoints/cli.tsx
@@ -84,6 +84,14 @@ async function main(): Promise<void> {
     return;
   }
 
+  // --help/-h must bypass provider validation so users can always see usage
+  // without needing to be authenticated first.
+  if (args.some(a => a === '--help' || a === '-h')) {
+    const { main: cliMain } = await import('../main.js')
+    await cliMain()
+    return
+  }
+
   // --provider: set provider env vars early so saved-profile resolution,
   // validation, and the startup banner all see the intended provider/model.
   if (args.includes('--provider')) {

--- a/src/hooks/useOfficialMarketplaceNotification.tsx
+++ b/src/hooks/useOfficialMarketplaceNotification.tsx
@@ -19,7 +19,7 @@ async function _temp() {
     logForDebugging("Showing marketplace config save failure notification");
     notifs.push({
       key: "marketplace-config-save-failed",
-      jsx: <Text color="error">Failed to save marketplace retry info · Check ~/.claude.json permissions</Text>,
+      jsx: <Text color="error">Failed to save marketplace retry info · Check ~/.openclaude.json permissions</Text>,
       priority: "immediate",
       timeoutMs: 10000
     });

--- a/src/migrations/resetAutoModeOptInForDefaultOffer.ts
+++ b/src/migrations/resetAutoModeOptInForDefaultOffer.ts
@@ -12,7 +12,7 @@ import {
  * One-shot migration: clear skipAutoPermissionPrompt for users who accepted
  * the old 2-option AutoModeOptInDialog but don't have auto as their default.
  * Re-surfaces the dialog so they see the new "make it my default mode" option.
- * Guard lives in GlobalConfig (~/.claude.json), not settings.json, so it
+ * Guard lives in GlobalConfig (~/.openclaude.json), not settings.json, so it
  * survives settings resets and doesn't re-arm itself.
  *
  * Only runs when tengu_auto_mode_config.enabled === 'enabled'. For 'opt-in'

--- a/src/screens/REPL.tsx
+++ b/src/screens/REPL.tsx
@@ -3873,7 +3873,7 @@ export function REPL({
   // empty to non-empty, not on every length change -- otherwise a render loop
   // (concurrent onQuery thrashing, etc.) spams saveGlobalConfig, which hits
   // ELOCKED under concurrent sessions and falls back to unlocked writes.
-  // That write storm is the primary trigger for ~/.claude.json corruption
+  // That write storm is the primary trigger for ~/.openclaude.json corruption
   // (GH #3117).
   const hasCountedQueueUseRef = useRef(false);
   useEffect(() => {

--- a/src/services/analytics/growthbook.ts
+++ b/src/services/analytics/growthbook.ts
@@ -334,7 +334,7 @@ async function processRemoteEvalPayload(
   // Empty object is truthy — without the length check, `{features: {}}`
   // (transient server bug, truncated response) would pass, clear the maps
   // below, return true, and syncRemoteEvalToDisk would wholesale-write `{}`
-  // to disk: total flag blackout for every process sharing ~/.claude.json.
+  // to disk: total flag blackout for every process sharing ~/.openclaude.json.
   if (!payload?.features || Object.keys(payload.features).length === 0) {
     return false
   }

--- a/src/services/api/codexShim.ts
+++ b/src/services/api/codexShim.ts
@@ -80,12 +80,17 @@ type CodexSseEvent = {
 function makeUsage(usage?: {
   input_tokens?: number
   output_tokens?: number
+  input_tokens_details?: { cached_tokens?: number }
+  prompt_tokens_details?: { cached_tokens?: number }
 }): AnthropicUsage {
   return {
     input_tokens: usage?.input_tokens ?? 0,
     output_tokens: usage?.output_tokens ?? 0,
     cache_creation_input_tokens: 0,
-    cache_read_input_tokens: 0,
+    cache_read_input_tokens:
+      usage?.input_tokens_details?.cached_tokens ??
+      usage?.prompt_tokens_details?.cached_tokens ??
+      0,
   }
 }
 
@@ -890,8 +895,16 @@ export async function* codexStreamToAnthropic(
       stop_sequence: null,
     },
     usage: {
-      input_tokens: finalResponse?.usage?.input_tokens ?? 0,
+      // Subtract cached tokens: OpenAI includes them in input_tokens,
+      // but Anthropic convention treats input_tokens as non-cached only.
+      input_tokens: (finalResponse?.usage?.input_tokens ?? 0) -
+        (finalResponse?.usage?.input_tokens_details?.cached_tokens ??
+         finalResponse?.usage?.prompt_tokens_details?.cached_tokens ?? 0),
       output_tokens: finalResponse?.usage?.output_tokens ?? 0,
+      cache_read_input_tokens:
+        finalResponse?.usage?.input_tokens_details?.cached_tokens ??
+        finalResponse?.usage?.prompt_tokens_details?.cached_tokens ??
+        0,
     },
   }
   yield { type: 'message_stop' }

--- a/src/services/api/openaiShim.ts
+++ b/src/services/api/openaiShim.ts
@@ -538,11 +538,14 @@ function convertChunkUsage(
 ): Partial<AnthropicUsage> | undefined {
   if (!usage) return undefined
 
+  const cached = usage.prompt_tokens_details?.cached_tokens ?? 0
   return {
-    input_tokens: usage.prompt_tokens ?? 0,
+    // Subtract cached tokens: OpenAI includes them in prompt_tokens,
+    // but Anthropic convention treats input_tokens as non-cached only.
+    input_tokens: (usage.prompt_tokens ?? 0) - cached,
     output_tokens: usage.completion_tokens ?? 0,
     cache_creation_input_tokens: 0,
-    cache_read_input_tokens: usage.prompt_tokens_details?.cached_tokens ?? 0,
+    cache_read_input_tokens: cached,
   }
 }
 

--- a/src/services/api/openaiShim.ts
+++ b/src/services/api/openaiShim.ts
@@ -1158,6 +1158,7 @@ class OpenAIShimMessages {
       model: request.resolvedModel,
       messages: openaiMessages,
       stream: params.stream ?? false,
+      store: false,
     }
     // Convert max_tokens to max_completion_tokens for OpenAI API compatibility.
     // Azure OpenAI requires max_completion_tokens and does not accept max_tokens.
@@ -1332,6 +1333,7 @@ class OpenAIShimMessages {
               }>,
             ),
             stream: params.stream ?? false,
+            store: false,
           }
 
           if (!Array.isArray(responsesBody.input) || responsesBody.input.length === 0) {

--- a/src/services/github/deviceFlow.ts
+++ b/src/services/github/deviceFlow.ts
@@ -5,6 +5,10 @@
 
 import { execFileNoThrow } from '../../utils/execFileNoThrow.js'
 
+// VS Code GitHub Copilot Chat extension OAuth app — required for the
+// copilot_internal/v2/token exchange that produces a valid Copilot API token.
+// Other client IDs (e.g. the gh CLI's) produce OAuth tokens that the Copilot
+// API rejects with 403 "not licensed to use Copilot".
 export const DEFAULT_GITHUB_DEVICE_FLOW_CLIENT_ID = 'Iv1.b507a08c87ecfe98'
 
 export const GITHUB_DEVICE_CODE_URL = 'https://github.com/login/device/code'
@@ -55,8 +59,18 @@ export function getGithubDeviceFlowClientId(): string {
   )
 }
 
-function sleep(ms: number): Promise<void> {
-  return new Promise(resolve => setTimeout(resolve, ms))
+function sleep(ms: number, signal?: AbortSignal): Promise<void> {
+  return new Promise((resolve, reject) => {
+    if (signal?.aborted) {
+      reject(new GitHubDeviceFlowError('Cancelled'))
+      return
+    }
+    const timer = setTimeout(resolve, ms)
+    signal?.addEventListener('abort', () => {
+      clearTimeout(timer)
+      reject(new GitHubDeviceFlowError('Cancelled'))
+    }, { once: true })
+  })
 }
 
 export async function requestDeviceCode(options?: {
@@ -133,6 +147,8 @@ export type PollOptions = {
   initialInterval?: number
   timeoutSeconds?: number
   fetchImpl?: FetchLike
+  onStatusChange?: (status: 'polling' | 'exchanging') => void
+  signal?: AbortSignal
 }
 
 export async function pollAccessToken(
@@ -146,9 +162,15 @@ export async function pollAccessToken(
   let interval = Math.max(1, options?.initialInterval ?? 5)
   const timeoutSeconds = options?.timeoutSeconds ?? 900
   const fetchFn = options?.fetchImpl ?? fetch
+  const signal = options?.signal
   const start = Date.now()
 
+  // GitHub enforces strictly MORE than `interval` seconds between polls;
+  // polling at exactly `interval` triggers slow_down. We add 1s buffer to
+  // every sleep to stay safely above the boundary.
+
   while ((Date.now() - start) / 1000 < timeoutSeconds) {
+    if (signal?.aborted) throw new GitHubDeviceFlowError('Cancelled')
     const res = await fetchFn(GITHUB_DEVICE_ACCESS_TOKEN_URL, {
       method: 'POST',
       headers: { Accept: 'application/json' },
@@ -157,6 +179,9 @@ export async function pollAccessToken(
         device_code: deviceCode,
         grant_type: 'urn:ietf:params:oauth:grant-type:device_code',
       }),
+      signal: signal
+        ? AbortSignal.any([signal, AbortSignal.timeout(15_000)])
+        : AbortSignal.timeout(15_000),
     })
     if (!res.ok) {
       const text = await res.text().catch(() => '')
@@ -174,13 +199,13 @@ export async function pollAccessToken(
       throw new GitHubDeviceFlowError('No access_token in response')
     }
     if (err === 'authorization_pending') {
-      await sleep(interval * 1000)
+      await sleep((interval + 1) * 1000, signal)
       continue
     }
     if (err === 'slow_down') {
-      interval =
-        typeof data.interval === 'number' ? data.interval : interval + 5
-      await sleep(interval * 1000)
+      const suggested = typeof data.interval === 'number' ? data.interval : interval + 5
+      interval = Math.min(suggested, 30)
+      await sleep((interval + 1) * 1000, signal)
       continue
     }
     if (err === 'expired_token') {
@@ -216,6 +241,8 @@ export async function openVerificationUri(uri: string): Promise<void> {
   }
 }
 
+const COPILOT_TOKEN_EXCHANGE_TIMEOUT_MS = 15_000
+
 /**
  * Exchange an OAuth access token for a Copilot API token.
  * The OAuth token alone cannot be used with the Copilot API endpoint.
@@ -232,6 +259,7 @@ export async function exchangeForCopilotToken(
       Authorization: `Bearer ${oauthToken}`,
       ...COPILOT_HEADERS,
     },
+    signal: AbortSignal.timeout(COPILOT_TOKEN_EXCHANGE_TIMEOUT_MS),
   })
   if (!res.ok) {
     const text = await res.text().catch(() => '')

--- a/src/tools/ConfigTool/prompt.ts
+++ b/src/tools/ConfigTool/prompt.ts
@@ -59,7 +59,7 @@ export function generatePrompt(): string {
 ## Configurable settings list
 The following settings are available for you to change:
 
-### Global Settings (stored in ~/.claude.json)
+### Global Settings (stored in ~/.openclaude.json)
 ${globalSettings.join('\n')}
 
 ### Project Settings (stored in settings.json)

--- a/src/utils/auth.ts
+++ b/src/utils/auth.ts
@@ -692,7 +692,7 @@ export function refreshAwsAuth(awsAuthRefresh: string): Promise<boolean> {
               'AWS auth refresh timed out after 3 minutes. Run your auth command manually in a separate terminal.',
             )
           : chalk.red(
-              'Error running awsAuthRefresh (in settings or ~/.claude.json):',
+              'Error running awsAuthRefresh (in settings or ~/.openclaude.json):',
             )
         // biome-ignore lint/suspicious/noConsole:: intentional console output
         console.error(message)
@@ -770,7 +770,7 @@ async function getAwsCredsFromCredentialExport(): Promise<{
       }
     } catch (e) {
       const message = chalk.red(
-        'Error getting AWS credentials from awsCredentialExport (in settings or ~/.claude.json):',
+        'Error getting AWS credentials from awsCredentialExport (in settings or ~/.openclaude.json):',
       )
       if (e instanceof Error) {
         // biome-ignore lint/suspicious/noConsole:: intentional console output
@@ -960,7 +960,7 @@ export function refreshGcpAuth(gcpAuthRefresh: string): Promise<boolean> {
               'GCP auth refresh timed out after 3 minutes. Run your auth command manually in a separate terminal.',
             )
           : chalk.red(
-              'Error running gcpAuthRefresh (in settings or ~/.claude.json):',
+              'Error running gcpAuthRefresh (in settings or ~/.openclaude.json):',
             )
         // biome-ignore lint/suspicious/noConsole:: intentional console output
         console.error(message)
@@ -1957,7 +1957,7 @@ export async function validateForceLoginOrg(): Promise<OrgValidationResult> {
 
   // Always fetch the authoritative org UUID from the profile endpoint.
   // Even keychain-sourced tokens verify server-side: the cached org UUID
-  // in ~/.claude.json is user-writable and cannot be trusted.
+  // in ~/.openclaude.json is user-writable and cannot be trusted.
   const { source } = getAuthTokenSource()
   const isEnvVarToken =
     source === 'CLAUDE_CODE_OAUTH_TOKEN' ||

--- a/src/utils/caCertsConfig.ts
+++ b/src/utils/caCertsConfig.ts
@@ -28,7 +28,7 @@ import { getSettingsForSource } from './settings/settings.js'
  * is lazy-initialized) and ensure Node.js compatibility.
  *
  * This is safe to call before the trust dialog because we only read from
- * user-controlled files (~/.claude/settings.json and ~/.claude.json),
+ * user-controlled files (~/.claude/settings.json and ~/.openclaude.json),
  * not from project-level settings.
  */
 export function applyExtraCACertsFromConfig(): void {
@@ -52,7 +52,7 @@ export function applyExtraCACertsFromConfig(): void {
  * after the trust dialog. But we need the CA cert early to establish the TLS
  * connection to an HTTPS proxy during init().
  *
- * We read from global config (~/.claude.json) and user settings
+ * We read from global config (~/.openclaude.json) and user settings
  * (~/.claude/settings.json). These are user-controlled files that don't
  * require trust approval.
  */

--- a/src/utils/claudeInChrome/setup.ts
+++ b/src/utils/claudeInChrome/setup.ts
@@ -355,7 +355,7 @@ exec ${command}
  *
  * Only positive detections are persisted. A negative result from the
  * filesystem scan is not cached, because it may come from a machine that
- * shares ~/.claude.json but has no local Chrome (e.g. a remote dev
+ * shares ~/.openclaude.json but has no local Chrome (e.g. a remote dev
  * environment using the bridge), and caching it would permanently poison
  * auto-enable for every session on every machine that reads that config.
  */

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -915,7 +915,7 @@ let configCacheHits = 0
 let configCacheMisses = 0
 // Session-total count of actual disk writes to the global config file.
 // Exposed for internal-only dev diagnostics (see inc-4552) so anomalous write
-// rates surface in the UI before they corrupt ~/.claude.json.
+// rates surface in the UI before they corrupt ~/.openclaude.json.
 let globalConfigWriteCount = 0
 
 export function getGlobalConfigWriteCount(): number {
@@ -1254,7 +1254,7 @@ function saveConfigWithLock<A extends object>(
     const currentConfig = getConfig(file, createDefault)
     if (file === getGlobalClaudeFile() && wouldLoseAuthState(currentConfig)) {
       logForDebugging(
-        'saveConfigWithLock: re-read config is missing auth that cache has; refusing to write to avoid wiping ~/.claude.json. See GH #3117.',
+        'saveConfigWithLock: re-read config is missing auth that cache has; refusing to write to avoid wiping ~/.openclaude.json. See GH #3117.',
         { level: 'error' },
       )
       logEvent('tengu_config_auth_loss_prevented', {})

--- a/src/utils/deepLink/registerProtocol.ts
+++ b/src/utils/deepLink/registerProtocol.ts
@@ -253,7 +253,7 @@ async function resolveClaudePath(): Promise<string> {
  * Check whether the OS-level protocol handler is already registered AND
  * points at the expected `claude` binary. Reads the registration artifact
  * directly (symlink target, .desktop Exec line, registry value) rather than
- * a cached flag in ~/.claude.json, so:
+ * a cached flag in ~/.openclaude.json, so:
  *   - the check is per-machine (config can sync across machines; OS state can't)
  *   - stale paths self-heal (install-method change → re-register next session)
  *   - deleted artifacts self-heal
@@ -311,7 +311,7 @@ export async function ensureDeepLinkProtocolRegistered(): Promise<void> {
   // EACCES/ENOSPC are deterministic — retrying next session won't help.
   // Throttle to once per 24h so a read-only ~/.local/share/applications
   // doesn't generate a failure event on every startup. Marker lives in
-  // ~/.claude (per-machine, not synced) rather than ~/.claude.json (can sync).
+  // ~/.claude (per-machine, not synced) rather than ~/.openclaude.json (can sync).
   const failureMarkerPath = path.join(
     getClaudeConfigHomeDir(),
     '.deep-link-register-failed',

--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -21,8 +21,20 @@ export const getGlobalClaudeFile = memoize((): string => {
     return join(getClaudeConfigHomeDir(), '.config.json')
   }
 
-  const filename = `.claude${fileSuffixForOauthConfig()}.json`
-  return join(process.env.CLAUDE_CONFIG_DIR || homedir(), filename)
+  const oauthSuffix = fileSuffixForOauthConfig()
+  const configDir = process.env.CLAUDE_CONFIG_DIR || homedir()
+
+  // Prefer .openclaude.json; fall back to .claude.json if it already exists
+  // (same migration strategy as resolveClaudeConfigHomeDir).
+  const newFilename = `.openclaude${oauthSuffix}.json`
+  const legacyFilename = `.claude${oauthSuffix}.json`
+  if (
+    !getFsImplementation().existsSync(join(configDir, newFilename)) &&
+    getFsImplementation().existsSync(join(configDir, legacyFilename))
+  ) {
+    return join(configDir, legacyFilename)
+  }
+  return join(configDir, newFilename)
 })
 
 const hasInternetAccess = memoize(async (): Promise<boolean> => {

--- a/src/utils/json.ts
+++ b/src/utils/json.ts
@@ -24,7 +24,7 @@ type CachedParse = { ok: true; value: unknown } | { ok: false }
 // lodash memoize default resolver = first arg only).
 // Skip caching above this size — the LRU stores the full string as the key,
 // so a 200KB config file would pin ~10MB in #keyList across 50 slots. Large
-// inputs like ~/.claude.json also change between reads (numStartups bumps on
+// inputs like ~/.openclaude.json also change between reads (numStartups bumps on
 // every CC startup), so the cache never hits anyway.
 const PARSE_CACHE_MAX_KEY_BYTES = 8 * 1024
 

--- a/src/utils/managedEnv.ts
+++ b/src/utils/managedEnv.ts
@@ -131,7 +131,7 @@ export function applySafeConfigEnvironmentVariables(): void {
         : null
   }
 
-  // Global config (~/.claude.json) is user-controlled. In CCD mode,
+  // Global config (~/.openclaude.json) is user-controlled. In CCD mode,
   // filterSettingsEnv strips keys that were in the spawn env snapshot so
   // the desktop host's operational vars (OTEL, etc.) are not overridden.
   Object.assign(process.env, filterSettingsEnv(getGlobalConfig().env))

--- a/src/utils/model/openaiContextWindows.ts
+++ b/src/utils/model/openaiContextWindows.ts
@@ -12,6 +12,44 @@
  */
 
 const OPENAI_CONTEXT_WINDOWS: Record<string, number> = {
+  // GitHub Copilot — values from https://api.githubcopilot.com/models (2026-04-09)
+  // Namespaced so they don't collide with bare model names from other providers.
+  'github:copilot':                           128_000,
+  // Claude
+  'github:copilot:claude-sonnet-4':           216_000,
+  'github:copilot:claude-haiku-4':            200_000,
+  'github:copilot:claude-sonnet-4.5':         200_000,
+  'github:copilot:claude-sonnet-4.6':         200_000,
+  'github:copilot:claude-opus-4':             200_000,
+  'github:copilot:claude-opus-4.6':           200_000,
+  // GPT
+  'github:copilot:gpt-3.5-turbo':             16_384,
+  'github:copilot:gpt-4':                     32_768,
+  'github:copilot:gpt-4-0125-preview':       128_000,
+  'github:copilot:gpt-4-o-preview':          128_000,
+  'github:copilot:gpt-4.1':                  128_000,
+  'github:copilot:gpt-4o':                   128_000,
+  'github:copilot:gpt-4o-2024-08-06':        128_000,
+  'github:copilot:gpt-4o-2024-11-20':        128_000,
+  'github:copilot:gpt-4o-mini':              128_000,
+  'github:copilot:gpt-5-mini':               264_000,
+  'github:copilot:gpt-5.1':                  264_000,
+  'github:copilot:gpt-5.2':                  400_000,
+  'github:copilot:gpt-5.2-codex':            400_000,
+  'github:copilot:gpt-5.3-codex':            400_000,
+  'github:copilot:gpt-5.4':                  400_000,
+  'github:copilot:gpt-5.4-mini':             400_000,
+  // Gemini
+  'github:copilot:gemini-2.5-pro':           128_000,
+  'github:copilot:gemini-3-flash-preview':   128_000,
+  'github:copilot:gemini-3.1-pro-preview':   200_000,
+  // Grok
+  'github:copilot:grok-code-fast-1':         256_000,
+
+  // NOTE: bare Claude model names (e.g. 'claude-sonnet-4') are intentionally
+  // omitted. Different OpenAI-compatible providers may impose different context
+  // limits for the same model name, so we cannot safely hardcode values here.
+
   // OpenAI
   'gpt-5.4':               1_050_000,
   'gpt-5.4-mini':            400_000,
@@ -82,6 +120,41 @@ const OPENAI_CONTEXT_WINDOWS: Record<string, number> = {
  * Fixes: 400 error "max_tokens is too large" when default 32k exceeds model limit.
  */
 const OPENAI_MAX_OUTPUT_TOKENS: Record<string, number> = {
+  // GitHub Copilot — values from https://api.githubcopilot.com/models (2026-04-09)
+  'github:copilot':                            16_384,
+  // Claude
+  'github:copilot:claude-sonnet-4':            16_000,
+  'github:copilot:claude-haiku-4':             64_000,
+  'github:copilot:claude-sonnet-4.5':          32_000,
+  'github:copilot:claude-sonnet-4.6':          32_000,
+  'github:copilot:claude-opus-4':              32_000,
+  'github:copilot:claude-opus-4.6':            32_000,
+  // GPT
+  'github:copilot:gpt-3.5-turbo':              4_096,
+  'github:copilot:gpt-4':                      4_096,
+  'github:copilot:gpt-4-0125-preview':         4_096,
+  'github:copilot:gpt-4-o-preview':            4_096,
+  'github:copilot:gpt-4.1':                   16_384,
+  'github:copilot:gpt-4o':                     4_096,
+  'github:copilot:gpt-4o-2024-08-06':         16_384,
+  'github:copilot:gpt-4o-2024-11-20':         16_384,
+  'github:copilot:gpt-4o-mini':                4_096,
+  'github:copilot:gpt-5-mini':                64_000,
+  'github:copilot:gpt-5.1':                   64_000,
+  'github:copilot:gpt-5.2':                  128_000,
+  'github:copilot:gpt-5.2-codex':            128_000,
+  'github:copilot:gpt-5.3-codex':            128_000,
+  'github:copilot:gpt-5.4':                  128_000,
+  'github:copilot:gpt-5.4-mini':             128_000,
+  // Gemini
+  'github:copilot:gemini-2.5-pro':            64_000,
+  'github:copilot:gemini-3-flash-preview':    64_000,
+  'github:copilot:gemini-3.1-pro-preview':    64_000,
+  // Grok
+  'github:copilot:grok-code-fast-1':          64_000,
+
+  // NOTE: bare Claude model names omitted — see context windows comment above.
+
   // OpenAI
   'gpt-5.4':                 128_000,
   'gpt-5.4-mini':            128_000,
@@ -145,6 +218,19 @@ const OPENAI_MAX_OUTPUT_TOKENS: Record<string, number> = {
 }
 
 function lookupByModel<T>(table: Record<string, T>, model: string): T | undefined {
+  // Try provider-qualified key first: "{OPENAI_MODEL}:{model}" so that
+  // e.g. "github:copilot:claude-haiku-4.5" can have different limits than
+  // a bare "claude-haiku-4.5" served by another provider.
+  const providerModel = process.env.OPENAI_MODEL?.trim()
+  if (providerModel && providerModel !== model) {
+    const qualified = `${providerModel}:${model}`
+    const qualifiedResult = lookupByKey(table, qualified)
+    if (qualifiedResult !== undefined) return qualifiedResult
+  }
+  return lookupByKey(table, model)
+}
+
+function lookupByKey<T>(table: Record<string, T>, model: string): T | undefined {
   if (table[model] !== undefined) return table[model]
   // Sort keys by length descending so the most specific prefix wins.
   // Without this, 'gpt-4-turbo-preview' could match 'gpt-4' (8k) instead

--- a/src/utils/permissions/filesystem.ts
+++ b/src/utils/permissions/filesystem.ts
@@ -64,6 +64,7 @@ export const DANGEROUS_FILES = [
   '.profile',
   '.ripgreprc',
   '.mcp.json',
+  '.openclaude.json',
   '.claude.json',
 ] as const
 

--- a/src/utils/providerValidation.ts
+++ b/src/utils/providerValidation.ts
@@ -143,12 +143,52 @@ export async function getProviderValidationError(
   return null
 }
 
+/**
+ * Returns true when the user appears to be starting an interactive REPL session
+ * (i.e. `openclaude` with no arguments or only flag-style arguments that don't
+ * select a non-interactive sub-command).  In this mode we allow GitHub auth
+ * errors through as warnings so the user can run /onboard-github from inside
+ * the CLI rather than being locked out entirely.
+ */
+function isInteractiveReplMode(argv: string[] = process.argv.slice(2)): boolean {
+  if (argv.length === 0) return true
+  // Non-interactive sub-commands that should still hard-fail on missing auth
+  const nonInteractiveSubcommands = new Set([
+    'print', '-p', '--print',
+    'run',
+    'export',
+    'config',
+    'doctor',
+  ])
+  // If the first positional-looking argument is a known non-interactive
+  // sub-command, don't allow the bypass.
+  const firstArg = argv[0]
+  if (firstArg && !firstArg.startsWith('-') && nonInteractiveSubcommands.has(firstArg)) {
+    return false
+  }
+  return true
+}
+
 export async function validateProviderEnvOrExit(
   env: NodeJS.ProcessEnv = process.env,
 ): Promise<void> {
   const error = await getProviderValidationError(env)
-  if (error) {
-    console.error(error)
-    process.exit(1)
+  if (!error) return
+
+  // For GitHub auth errors in interactive REPL mode, warn instead of exiting
+  // so the user can run /onboard-github from within the CLI.
+  const isGithubAuthError =
+    isEnvTruthy(env.CLAUDE_CODE_USE_GITHUB) &&
+    !isEnvTruthy(env.CLAUDE_CODE_USE_OPENAI) &&
+    (error.includes('authentication required') ||
+      error.includes('token has expired') ||
+      error.includes('token is invalid'))
+
+  if (isGithubAuthError && isInteractiveReplMode()) {
+    console.error(`Warning: ${error}\n`)
+    return
   }
+
+  console.error(error)
+  process.exit(1)
 }

--- a/src/utils/providerValidation.ts
+++ b/src/utils/providerValidation.ts
@@ -61,6 +61,40 @@ function checkGithubTokenStatus(
   return 'valid'
 }
 
+type GithubEndpointType = 'copilot' | 'models' | 'custom'
+
+function githubAuthError(
+  endpointType: GithubEndpointType,
+  kind: 'missing' | 'expired' | 'invalid',
+): string {
+  if (endpointType === 'copilot') {
+    switch (kind) {
+      case 'missing':
+        return 'GitHub Copilot authentication required.\n' +
+          'Run /onboard-github in the CLI to sign in with your GitHub account.\n' +
+          'This will store your OAuth token securely and enable Copilot models.'
+      case 'expired':
+        return 'GitHub Copilot token has expired.\n' +
+          'Run /onboard-github to sign in again and get a fresh token.'
+      case 'invalid':
+        return 'GitHub Copilot token is invalid or corrupted.\n' +
+          'Run /onboard-github to sign in again with your GitHub account.'
+    }
+  }
+  // GitHub Models, custom, or future endpoint types
+  switch (kind) {
+    case 'missing':
+      return 'GITHUB_TOKEN or GH_TOKEN is required for your GitHub endpoint.\n' +
+        'Set one of these environment variables to a valid token.'
+    case 'expired':
+      return 'GitHub token has expired.\n' +
+        'Set a fresh GITHUB_TOKEN or GH_TOKEN.'
+    case 'invalid':
+      return 'GitHub token is invalid or corrupted.\n' +
+        'Check your GITHUB_TOKEN or GH_TOKEN.'
+  }
+}
+
 export async function getProviderValidationError(
   env: NodeJS.ProcessEnv = process.env,
   options?: {
@@ -84,20 +118,16 @@ export async function getProviderValidationError(
 
   if (useGithub && !useOpenAI) {
     const token = (env.GITHUB_TOKEN?.trim() || env.GH_TOKEN?.trim()) ?? ''
-    if (!token) {
-      return 'GitHub Copilot authentication required.\n' +
-        'Run /onboard-github in the CLI to sign in with your GitHub account.\n' +
-        'This will store your OAuth token securely and enable Copilot models.'
-    }
     const endpointType = getGithubEndpointType(env.OPENAI_BASE_URL)
+    if (!token) {
+      return githubAuthError(endpointType, 'missing')
+    }
     const status = checkGithubTokenStatus(token, endpointType)
     if (status === 'expired') {
-      return 'GitHub Copilot token has expired.\n' +
-        'Run /onboard-github to sign in again and get a fresh token.'
+      return githubAuthError(endpointType, 'expired')
     }
     if (status === 'invalid_format') {
-      return 'GitHub Copilot token is invalid or corrupted.\n' +
-        'Run /onboard-github to sign in again with your GitHub account.'
+      return githubAuthError(endpointType, 'invalid')
     }
     return null
   }
@@ -175,16 +205,19 @@ export async function validateProviderEnvOrExit(
   const error = await getProviderValidationError(env)
   if (!error) return
 
-  // For GitHub auth errors in interactive REPL mode, warn instead of exiting
-  // so the user can run /onboard-github from within the CLI.
-  const isGithubAuthError =
+  // For GitHub Copilot auth errors in interactive REPL mode, warn instead of
+  // exiting so the user can run /onboard-github from within the CLI.
+  // Only applies to the Copilot endpoint — GitHub Models and custom endpoints
+  // have no in-CLI recovery path, so they should still hard-exit.
+  const isGithubCopilotAuthError =
     isEnvTruthy(env.CLAUDE_CODE_USE_GITHUB) &&
     !isEnvTruthy(env.CLAUDE_CODE_USE_OPENAI) &&
+    getGithubEndpointType(env.OPENAI_BASE_URL) === 'copilot' &&
     (error.includes('authentication required') ||
       error.includes('token has expired') ||
       error.includes('token is invalid'))
 
-  if (isGithubAuthError && isInteractiveReplMode()) {
+  if (isGithubCopilotAuthError && isInteractiveReplMode()) {
     console.error(`Warning: ${error}\n`)
     return
   }


### PR DESCRIPTION
## Summary

Rename the global config file from `~/.claude.json` to `~/.openclaude.json`, following the same migration pattern already used for the config directory (`~/.claude` → `~/.openclaude`).

## Problem

The config directory was renamed from `~/.claude` to `~/.openclaude` (with legacy fallback), but the global config file `~/.claude.json` was missed. This creates an inconsistency: new installs get `~/.openclaude/` but still write to `~/.claude.json`.

## Changes

**`src/utils/env.ts`** — Core logic change:
- `getGlobalClaudeFile()` now prefers `.openclaude{suffix}.json`
- Falls back to `.claude{suffix}.json` only if the legacy file exists and the new one does not
- Handles all OAuth suffix variants (`.openclaude.json`, `.openclaude-custom-oauth.json`, etc.)

**`src/utils/permissions/filesystem.ts`**:
- Add `.openclaude.json` to the filesystem permissions allowlist
- Keep `.claude.json` for legacy file protection

**12 files** — Comment/string reference updates:
- All `~/.claude.json` references in comments, error messages, and prompt text updated to `~/.openclaude.json`

## Migration strategy

Same as `resolveClaudeConfigHomeDir`:
- **New installs**: get `~/.openclaude.json` from the start
- **Existing users**: continue using `~/.claude.json` until they rename it (no data loss, no breakage)