### PR TITLE
fix: display selected model in startup screen instead of hardcoded sonnet 4.6

### DIFF
--- a/src/components/StartupScreen.ts
+++ b/src/components/StartupScreen.ts
@@ -7,6 +7,8 @@
 
 import { isLocalProviderUrl } from '../services/api/providerConfig.js'
 import { getLocalOpenAICompatibleProviderLabel } from '../utils/providerDiscovery.js'
+import { getSettings_DEPRECATED } from '../utils/settings/settings.js'
+import { parseUserSpecifiedModel } from '../utils/model/model.js'
 
 declare const MACRO: { VERSION: string; DISPLAY_VERSION?: string }
 
@@ -139,9 +141,11 @@ function detectProvider(): { name: string; model: string; baseUrl: string; isLoc
     return { name, model: displayModel, baseUrl, isLocal }
   }
 
-  // Default: Anthropic
-  const model = process.env.ANTHROPIC_MODEL || process.env.CLAUDE_MODEL || 'claude-sonnet-4-6'
-  return { name: 'Anthropic', model, baseUrl: 'https://api.anthropic.com', isLocal: false }
+  // Default: Anthropic - check settings.model first, then env vars
+  const settings = getSettings_DEPRECATED() || {}
+  const modelSetting = settings.model || process.env.ANTHROPIC_MODEL || process.env.CLAUDE_MODEL || 'claude-sonnet-4-6'
+  const resolvedModel = parseUserSpecifiedModel(modelSetting)
+  return { name: 'Anthropic', model: resolvedModel, baseUrl: 'https://api.anthropic.com', isLocal: false }
 }
 
 // ─── Box drawing ──────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Fix startup screen to display the actual selected model instead of hardcoded sonnet-4-6
- Now reads model from `settings.model` first, then falls back to `ANTHROPIC_MODEL`/`CLAUDE_MODEL` env vars
- Uses `parseUserSpecifiedModel` to resolve model aliases (e.g., `opus` → `claude-opus-4-6`)

## History note
User reported that the startup screen always showed "sonnet-4-6" even after selecting "Opus 4.6" via `/model` command. The root cause was that `detectProvider()` only checked env vars, ignoring the persisted settings model. Additionally, model aliases like "opus" were not resolved to their canonical form (e.g., `claude-opus-4-6`).

## Test commands
```bash
bun run build && node dist/cli.mjs
```
1. Set model to opus via `/model` command
2. Restart CLI — startup screen should show `claude-opus-4-6` (not `sonnet-4-6` or bare `opus`)
```