### PR TITLE
fix(ink): restore host prop updates in React 19 reconciler

### DIFF
--- a/src/ink/reconciler.test.ts
+++ b/src/ink/reconciler.test.ts
@@ -1,0 +1,369 @@
+import { PassThrough } from 'node:stream'
+
+import { expect, test } from 'bun:test'
+import React from 'react'
+
+import type { DOMElement, ElementNames } from './dom.ts'
+import instances from './instances.ts'
+import { LayoutEdge } from './layout/node.ts'
+import type { ParsedKey } from './parse-keypress.ts'
+import { createRoot } from './root.ts'
+
+type TestStdin = PassThrough & {
+  isTTY: boolean
+  setRawMode: (mode: boolean) => void
+  ref: () => void
+  unref: () => void
+}
+
+const RAW_TEXT_STYLE = {
+  flexDirection: 'row',
+  flexGrow: 0,
+  flexShrink: 1,
+  textWrap: 'wrap',
+} as const
+
+function createTestStreams(): {
+  stdout: PassThrough
+  stdin: TestStdin
+} {
+  const stdout = new PassThrough()
+  const stdin = new PassThrough() as TestStdin
+
+  stdin.isTTY = true
+  stdin.setRawMode = () => {}
+  stdin.ref = () => {}
+  stdin.unref = () => {}
+
+  ;(stdout as unknown as { columns: number }).columns = 120
+  ;(stdout as unknown as { rows: number }).rows = 24
+  ;(stdout as unknown as { isTTY: boolean }).isTTY = true
+
+  return { stdout, stdin }
+}
+
+async function waitForCondition(
+  predicate: () => boolean,
+  errorMessage: string,
+  timeoutMs = 2000,
+): Promise<void> {
+  const startedAt = Date.now()
+
+  while (Date.now() - startedAt < timeoutMs) {
+    if (predicate()) {
+      return
+    }
+
+    await Bun.sleep(10)
+  }
+
+  throw new Error(errorMessage)
+}
+
+function getRootNode(stdout: PassThrough): DOMElement {
+  const instance = getInkInstance(stdout)
+
+  if (!instance.rootNode) {
+    throw new Error('Ink instance root node not found')
+  }
+
+  return instance.rootNode
+}
+
+function getInkInstance(stdout: PassThrough): {
+  rootNode?: DOMElement
+  dispatchKeyboardEvent: (parsedKey: ParsedKey) => void
+} {
+  const instance = instances.get(
+    stdout as unknown as NodeJS.WriteStream,
+  ) as
+    | {
+        rootNode?: DOMElement
+        dispatchKeyboardEvent: (parsedKey: ParsedKey) => void
+      }
+    | undefined
+
+  if (!instance) {
+    throw new Error('Ink instance not found')
+  }
+
+  return instance
+}
+
+function findElement(
+  node: DOMElement,
+  nodeName: ElementNames,
+): DOMElement | undefined {
+  if (node.nodeName === nodeName) {
+    return node
+  }
+
+  for (const child of node.childNodes) {
+    if (child.nodeName === '#text') {
+      continue
+    }
+
+    const found = findElement(child, nodeName)
+    if (found) {
+      return found
+    }
+  }
+
+  return undefined
+}
+
+function requireElement(stdout: PassThrough, nodeName: ElementNames): DOMElement {
+  const found = findElement(getRootNode(stdout), nodeName)
+
+  if (!found) {
+    throw new Error(`Expected to find ${nodeName} in Ink root tree`)
+  }
+
+  return found
+}
+
+async function createHarness(): Promise<{
+  stdout: PassThrough
+  stdin: TestStdin
+  root: Awaited<ReturnType<typeof createRoot>>
+  dispose: () => Promise<void>
+}> {
+  const { stdout, stdin } = createTestStreams()
+  const root = await createRoot({
+    stdout: stdout as unknown as NodeJS.WriteStream,
+    stdin: stdin as unknown as NodeJS.ReadStream,
+    patchConsole: false,
+  })
+
+  return {
+    stdout,
+    stdin,
+    root,
+    dispose: async () => {
+      root.unmount()
+      stdin.end()
+      stdout.end()
+      await Bun.sleep(25)
+    },
+  }
+}
+
+test('raw ink-box updates keyboard handlers and attributes in place across rerenders', async () => {
+  const calls: string[] = []
+  const firstHandler = () => calls.push('first')
+  const secondHandler = () => calls.push('second')
+  const harness = await createHarness()
+
+  try {
+    harness.root.render(
+      React.createElement(
+        'ink-box',
+        {
+          autoFocus: true,
+          onKeyDown: firstHandler,
+          tabIndex: 0,
+        },
+        'first render',
+      ),
+    )
+
+    await Bun.sleep(25)
+
+    const firstBox = requireElement(harness.stdout, 'ink-box')
+    expect(firstBox.attributes.tabIndex).toBe(0)
+    expect(firstBox._eventHandlers?.onKeyDown).toBe(firstHandler)
+
+    harness.root.render(
+      React.createElement(
+        'ink-box',
+        {
+          autoFocus: true,
+          onKeyDown: secondHandler,
+          tabIndex: 1,
+        },
+        'second render',
+      ),
+    )
+
+    await Bun.sleep(25)
+
+    const secondBox = requireElement(harness.stdout, 'ink-box')
+    expect(secondBox).toBe(firstBox)
+    expect(secondBox.attributes.tabIndex).toBe(1)
+    expect(secondBox._eventHandlers?.onKeyDown).toBe(secondHandler)
+
+    getInkInstance(harness.stdout).dispatchKeyboardEvent({
+      kind: 'key',
+      name: 'a',
+      fn: false,
+      ctrl: false,
+      meta: false,
+      shift: false,
+      option: false,
+      super: false,
+      sequence: 'a',
+      raw: 'a',
+      isPasted: false,
+    })
+
+    await waitForCondition(
+      () => calls.length === 1,
+      'Timed out waiting for rerendered onKeyDown handler to fire',
+    )
+
+    expect(calls).toEqual(['second'])
+  } finally {
+    await harness.dispose()
+  }
+})
+
+test('raw ink-text updates textStyles in place across rerenders', async () => {
+  const harness = await createHarness()
+
+  try {
+    harness.root.render(
+      React.createElement(
+        'ink-text',
+        {
+          style: RAW_TEXT_STYLE,
+          textStyles: { color: 'ansi:red' },
+        },
+        'host text',
+      ),
+    )
+
+    await Bun.sleep(25)
+
+    const firstText = requireElement(harness.stdout, 'ink-text')
+    expect(firstText.textStyles).toEqual({ color: 'ansi:red' })
+
+    harness.root.render(
+      React.createElement(
+        'ink-text',
+        {
+          style: RAW_TEXT_STYLE,
+          textStyles: { color: 'ansi:blue' },
+        },
+        'host text',
+      ),
+    )
+
+    await Bun.sleep(25)
+
+    const secondText = requireElement(harness.stdout, 'ink-text')
+    expect(secondText).toBe(firstText)
+    expect(secondText.textStyles).toEqual({ color: 'ansi:blue' })
+  } finally {
+    await harness.dispose()
+  }
+})
+
+test('raw ink-box removes event handler when set to undefined', async () => {
+  const calls: string[] = []
+  const handler = () => calls.push('fired')
+  const harness = await createHarness()
+
+  try {
+    harness.root.render(
+      React.createElement(
+        'ink-box',
+        {
+          autoFocus: true,
+          onKeyDown: handler,
+          tabIndex: 0,
+        },
+        'with handler',
+      ),
+    )
+
+    await Bun.sleep(25)
+
+    const box = requireElement(harness.stdout, 'ink-box')
+    expect(box._eventHandlers?.onKeyDown).toBe(handler)
+
+    // Remove the handler
+    harness.root.render(
+      React.createElement(
+        'ink-box',
+        {
+          autoFocus: true,
+          tabIndex: 0,
+        },
+        'without handler',
+      ),
+    )
+
+    await Bun.sleep(25)
+
+    const sameBox = requireElement(harness.stdout, 'ink-box')
+    expect(sameBox).toBe(box)
+    expect(sameBox._eventHandlers?.onKeyDown).toBeUndefined()
+
+    // Dispatch a key event and verify the removed handler is NOT called
+    getInkInstance(harness.stdout).dispatchKeyboardEvent({
+      kind: 'key',
+      name: 'a',
+      fn: false,
+      ctrl: false,
+      meta: false,
+      shift: false,
+      option: false,
+      super: false,
+      sequence: 'a',
+      raw: 'a',
+      isPasted: false,
+    })
+
+    await Bun.sleep(50)
+    expect(calls).toEqual([])
+  } finally {
+    await harness.dispose()
+  }
+})
+
+test('raw ink-box updates layout style in place across rerenders', async () => {
+  const harness = await createHarness()
+
+  try {
+    harness.root.render(
+      React.createElement(
+        'ink-box',
+        {
+          style: { flexDirection: 'row', paddingLeft: 1 },
+        },
+        'styled box',
+      ),
+    )
+
+    await Bun.sleep(25)
+
+    const box = requireElement(harness.stdout, 'ink-box')
+    expect(box.style.flexDirection).toBe('row')
+    expect(box.style.paddingLeft).toBe(1)
+
+    harness.root.render(
+      React.createElement(
+        'ink-box',
+        {
+          style: { flexDirection: 'column', paddingLeft: 2 },
+        },
+        'styled box',
+      ),
+    )
+
+    await Bun.sleep(25)
+
+    const sameBox = requireElement(harness.stdout, 'ink-box')
+    expect(sameBox).toBe(box)
+    expect(sameBox.style.flexDirection).toBe('column')
+    expect(sameBox.style.paddingLeft).toBe(2)
+
+    // Verify the update reached the layout engine, not just the style object
+    const yogaNode = sameBox.yogaNode!
+    expect(yogaNode).toBeDefined()
+    yogaNode.calculateLayout(120)
+    expect(yogaNode.getComputedPadding(LayoutEdge.Left)).toBe(2)
+  } finally {
+    await harness.dispose()
+  }
+})

--- a/src/ink/reconciler.ts
+++ b/src/ink/reconciler.ts
@@ -449,16 +449,24 @@ const reconciler = createReconciler<
   },
   commitUpdate(
     node: DOMElement,
-    updatePayload: UpdatePayload | null,
     _type: ElementNames,
-    _oldProps: Props,
-    _newProps: Props,
+    oldProps: Props,
+    newProps: Props,
   ): void {
-    if (!updatePayload) {
+    // React 19 mutation mode calls commitUpdate as
+    // (instance, type, oldProps, newProps, fiber) and does not pass the
+    // prepareUpdate() payload here. This renderer used to treat the second
+    // argument as updatePayload, which left mounted ink-* nodes with stale
+    // attributes, event handlers, and textStyles until something forced a
+    // remount. Recompute the prop/style diff here so host nodes update
+    // correctly in place on rerender.
+    const props = diff(oldProps, newProps)
+    const style = diff(oldProps['style'] as Styles, newProps['style'] as Styles)
+    const nextStyle = newProps['style'] as Styles | undefined
+
+    if (!props && !style) {
       return
     }
-
-    const { props, style, nextStyle } = updatePayload
 
     if (props) {
       for (const [key, value] of Object.entries(props)) {


### PR DESCRIPTION
It seems we finally found the real root cause. Problem wasn't in Box or Text, but in src/ink/reconciler.ts: after migrating to React 19 / react-reconciler@0.33 our commitUpdate was broken, so mounted ink-* nodes didn't update onKeyDown, tabIndex and textStyles in-place. That's why the previous fixes acted as workarounds via remounting/avoiding stale handlers. This is now fixed in the reconciler, low-level regression tests have been added, and the bug reproducibly disappears without those workarounds 

## Summary

- Fix the real root cause of stale TUI menu handlers/highlights in the Ink reconciler.
- Restore in-place host prop updates for `ink-*` nodes under React 19 / `react-reconciler@0.33`.
- Add a regression test that fails when `ink-box` handlers/attributes or `ink-text` styles stop updating on rerender.

## What we found

The menu bugs in `/agents`, `/config`, and related screens looked like focus or repaint issues, but the shared failure mode was deeper: already-mounted `ink-*` host nodes were not receiving updated props reliably.

Minimal raw host-node probes showed that before the fix:

- `ink-box` kept stale `onKeyDown` handlers across rerenders
- `ink-box` could retain stale `tabIndex`
- `ink-text` could retain stale `textStyles`

The root cause was in `src/ink/reconciler.ts`: our `commitUpdate` implementation still expected the older `prepareUpdate`/`updatePayload` shape, while `react-reconciler@0.33.0` mutation mode calls `commitUpdate(instance, type, oldProps, newProps, fiber)`.

That mismatch broke in-place host prop updates and made remount-based workarounds in `Box.tsx` and `Text.tsx` appear necessary.

## Implementation

- Update `src/ink/reconciler.ts` so `commitUpdate` diffs `oldProps` and `newProps` directly in the React 19 mutation path instead of expecting an `updatePayload`.
- Keep applying changed attributes, event handlers, `textStyles`, and layout styles through the normal host update path.
- Add `src/ink/reconciler.test.ts` with low-level regression coverage for:
  - `ink-box` updating `tabIndex` and `onKeyDown` in place on rerender
  - `ink-text` updating `textStyles` in place on rerender

## Notes

- Earlier fixes in `Box.tsx` and `Text.tsx` were valid workarounds, but not the root fix 
- The reconciler change is the key behavioral fix; the new test is intended to prevent this exact API mismatch from slipping back in

## Testing

- [x]  `bun test src/ink/reconciler.test.ts`
- [x]  `bun test src/components/InteractiveMenuRegression.test.tsx src/components/ThemePicker.test.tsx`
- [x]  `bun run build`

before:
<img width="1113" height="627" alt="image" src="https://github.com/user-attachments/assets/a3d6a0b9-23ee-4c35-8f78-7c7d5c4a3931" />

after: 

https://github.com/user-attachments/assets/efa5719a-6f3f-439b-96fb-936fca6a7a9a

