### PR TITLE
feat(vscode): add full chat interface to OpenClaude extension

### DIFF
--- a/vscode-extension/openclaude-vscode/package.json
+++ b/vscode-extension/openclaude-vscode/package.json
@@ -2,7 +2,7 @@
   "name": "openclaude-vscode",
   "displayName": "OpenClaude",
   "description": "Practical VS Code companion for OpenClaude with project-aware launch behavior and a real Control Center.",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "publisher": "devnull-bootloader",
   "engines": {
     "vscode": "^1.95.0"
@@ -19,7 +19,12 @@
     "onCommand:openclaude.openSetupDocs",
     "onCommand:openclaude.openWorkspaceProfile",
     "onCommand:openclaude.openControlCenter",
-    "onView:openclaude.controlCenter"
+    "onCommand:openclaude.newChat",
+    "onCommand:openclaude.openChat",
+    "onCommand:openclaude.resumeSession",
+    "onCommand:openclaude.abortChat",
+    "onView:openclaude.controlCenter",
+    "onView:openclaude.chat"
   ],
   "main": "./src/extension.js",
   "files": [
@@ -28,6 +33,7 @@
     "src/extension.js",
     "src/presentation.js",
     "src/state.js",
+    "src/chat/**",
     "themes/**"
   ],
   "contributes": {
@@ -61,6 +67,26 @@
         "command": "openclaude.openControlCenter",
         "title": "OpenClaude: Open Control Center",
         "category": "OpenClaude"
+      },
+      {
+        "command": "openclaude.newChat",
+        "title": "OpenClaude: New Chat",
+        "category": "OpenClaude"
+      },
+      {
+        "command": "openclaude.openChat",
+        "title": "OpenClaude: Open Chat Panel",
+        "category": "OpenClaude"
+      },
+      {
+        "command": "openclaude.resumeSession",
+        "title": "OpenClaude: Resume Session",
+        "category": "OpenClaude"
+      },
+      {
+        "command": "openclaude.abortChat",
+        "title": "OpenClaude: Abort Generation",
+        "category": "OpenClaude"
       }
     ],
     "viewsContainers": {
@@ -75,12 +101,24 @@
     "views": {
       "openclaude": [
         {
+          "id": "openclaude.chat",
+          "name": "Chat",
+          "type": "webview"
+        },
+        {
           "id": "openclaude.controlCenter",
           "name": "Control Center",
           "type": "webview"
         }
       ]
     },
+    "keybindings": [
+      {
+        "command": "openclaude.openChat",
+        "key": "ctrl+shift+l",
+        "mac": "cmd+shift+l"
+      }
+    ],
     "configuration": {
       "title": "OpenClaude",
       "properties": {
@@ -98,6 +136,18 @@
           "type": "boolean",
           "default": false,
           "description": "Optionally set CLAUDE_CODE_USE_OPENAI=1 in launched OpenClaude terminals."
+        },
+        "openclaude.permissionMode": {
+          "type": "string",
+          "default": "acceptEdits",
+          "enum": ["default", "acceptEdits", "bypassPermissions", "plan"],
+          "enumDescriptions": [
+            "Prompt for permission on each tool use (requires manual approval)",
+            "Auto-approve file edits, prompt for other operations (recommended)",
+            "Auto-approve all operations without prompting",
+            "Read-only mode — no file modifications allowed"
+          ],
+          "description": "Permission mode for chat sessions. Controls which tool operations are auto-approved."
         }
       }
     },
@@ -111,7 +161,7 @@
   },
   "scripts": {
     "test": "node --test ./src/*.test.js",
-    "lint": "node -e \"for (const file of require('node:fs').readdirSync('./src')) { if (file.endsWith('.js')) { require('node:child_process').execFileSync(process.execPath, ['--check', require('node:path').join('src', file)], { stdio: 'inherit' }); } }\"",
+    "lint": "node scripts/lint.js",
     "package": "npx @vscode/vsce package --no-dependencies"
   },
   "keywords": [

--- a/vscode-extension/openclaude-vscode/scripts/lint.js
+++ b/vscode-extension/openclaude-vscode/scripts/lint.js
@@ -1,0 +1,17 @@
+const { readdirSync } = require('node:fs');
+const { execFileSync } = require('node:child_process');
+const { join } = require('node:path');
+
+function check(dir) {
+  for (const f of readdirSync(dir, { withFileTypes: true })) {
+    if (f.isDirectory()) {
+      check(join(dir, f.name));
+    } else if (f.name.endsWith('.js') && !f.name.endsWith('.test.js')) {
+      execFileSync(process.execPath, ['--check', join(dir, f.name)], {
+        stdio: 'inherit',
+      });
+    }
+  }
+}
+
+check('./src');

--- a/vscode-extension/openclaude-vscode/src/chat/chatProvider.js
+++ b/vscode-extension/openclaude-vscode/src/chat/chatProvider.js
@@ -1,0 +1,676 @@
+/**
+ * chatProvider — WebviewViewProvider (sidebar) and WebviewPanel manager
+ * (editor tab) that wire ProcessManager events to the chat UI.
+ */
+
+const vscode = require('vscode');
+const crypto = require('crypto');
+const { ProcessManager } = require('./processManager');
+const { toViewModel } = require('./messageParser');
+const { renderChatHtml } = require('./chatRenderer');
+const { isAssistantMessage, isPartialMessage, isStreamEvent,
+        isContentBlockDelta, isContentBlockStart, isMessageStart,
+        isResultMessage, isControlRequest, isToolProgressMessage,
+        isStatusMessage, isRateLimitEvent, getTextContent,
+        getToolUseBlocks } = require('./protocol');
+
+async function openFileInEditor(filePath) {
+  try {
+    const uri = vscode.Uri.file(filePath);
+    const doc = await vscode.workspace.openTextDocument(uri);
+    await vscode.window.showTextDocument(doc, { preview: false });
+  } catch {
+    vscode.window.showWarningMessage(`Could not open file: ${filePath}`);
+  }
+}
+
+function getLaunchConfig() {
+  const cfg = vscode.workspace.getConfiguration('openclaude');
+  const command = cfg.get('launchCommand', 'openclaude');
+  const shimEnabled = cfg.get('useOpenAIShim', false);
+  const permissionMode = cfg.get('permissionMode', 'acceptEdits');
+  const env = {};
+  if (shimEnabled) env.CLAUDE_CODE_USE_OPENAI = '1';
+  const folders = vscode.workspace.workspaceFolders;
+  const cwd = folders && folders.length > 0 ? folders[0].uri.fsPath : undefined;
+  return { command, cwd, env, permissionMode };
+}
+
+class ChatController {
+  constructor(sessionManager) {
+    this._sessionManager = sessionManager;
+    this._process = null;
+    this._webviews = new Set();
+    this._accumulatedText = '';
+    this._toolUses = [];
+    this._messages = [];
+    this._currentSessionId = null;
+    this._streaming = false;
+    this._lastResult = null;
+    this._thinkingTokens = 0;
+    this._thinkingStartTime = null;
+    this._currentBlockType = null;
+
+    this._onDidChangeState = new vscode.EventEmitter();
+    this.onDidChangeState = this._onDidChangeState.event;
+  }
+
+  get sessionId() { return this._currentSessionId; }
+  get isStreaming() { return this._process && this._process.running; }
+  get sessionManager() { return this._sessionManager; }
+
+  registerWebview(webview) {
+    this._webviews.add(webview);
+    return { dispose: () => this._webviews.delete(webview) };
+  }
+
+  broadcast(msg) {
+    for (const wv of this._webviews) {
+      try { wv.postMessage(msg); } catch { /* webview might be disposed */ }
+    }
+  }
+
+  _broadcast(msg) {
+    this.broadcast(msg);
+  }
+
+  async startSession(opts = {}) {
+    this.stopSession();
+    this._accumulatedText = '';
+    this._toolUses = [];
+    // Only clear messages if this is a brand new session (not continuing)
+    if (!opts.continueSession && !opts.sessionId) {
+      this._messages = [];
+    }
+    this._currentSessionId = opts.sessionId || this._currentSessionId || null;
+
+    const { command, cwd, env, permissionMode } = getLaunchConfig();
+
+    this._process = new ProcessManager({
+      command,
+      cwd,
+      env,
+      sessionId: opts.sessionId,
+      continueSession: opts.continueSession || false,
+      model: opts.model,
+      permissionMode,
+      extraArgs: opts.extraArgs || [],
+    });
+
+    this._readyResolve = null;
+    this._readyPromise = new Promise(resolve => { this._readyResolve = resolve; });
+
+    this._process.onMessage((msg) => {
+      if (msg.type === 'system' && this._readyResolve) {
+        this._readyResolve();
+        this._readyResolve = null;
+      }
+      this._handleMessage(msg);
+    });
+    this._process.onError((err) => {
+      this._broadcast({ type: 'error', message: err.message || String(err) });
+    });
+    this._process.onExit(({ code }) => {
+      // Flush any remaining streamed text
+      if (this._streaming && this._accumulatedText) {
+        this._broadcast({ type: 'stream_end', text: this._accumulatedText, usage: null, final: true });
+      } else if (this._streaming) {
+        this._broadcast({ type: 'stream_end', text: '', usage: (this._lastResult || {}).usage || null, final: true });
+      }
+      this._streaming = false;
+      this._accumulatedText = '';
+      this._toolUses = [];
+      this._lastResult = null;
+      this._broadcast({
+        type: 'connected',
+        message: code === 0 ? 'Ready' : `Process exited (code ${code})`,
+      });
+      this._onDidChangeState.fire('idle');
+    });
+
+    try {
+      this._process.start();
+      this._broadcast({ type: 'connected', message: 'Connected' });
+      this._onDidChangeState.fire('connected');
+    } catch (err) {
+      this._broadcast({ type: 'error', message: `Failed to start: ${err.message}` });
+    }
+  }
+
+  stopSession() {
+    if (this._process) {
+      this._process.dispose();
+      this._process = null;
+    }
+  }
+
+  async sendMessage(text) {
+    // Keep the process alive for multi-turn — just send directly.
+    // The CLI maintains full session state (tools, history) across turns.
+    // Only start a new process if none exists or it died.
+    if (!this._process || !this._process.running) {
+      await this.startSession({
+        sessionId: this._currentSessionId || undefined,
+      });
+    }
+    await this._doSend(text);
+  }
+
+  async _doSend(text) {
+    if (!this._process) return;
+    // On first message after process start, wait for CLI to be ready.
+    // On subsequent messages, the process is already running and accepting input.
+    if (this._readyPromise) {
+      const grace = new Promise(resolve => setTimeout(resolve, 8000));
+      await Promise.race([this._readyPromise, grace]);
+      this._readyPromise = null;
+    }
+    this._accumulatedText = '';
+    this._toolUses = [];
+    try {
+      this._process.sendUserMessage(text);
+      this._messages.push({ role: 'user', text });
+    } catch (err) {
+      this._broadcast({ type: 'error', message: err.message });
+    }
+  }
+
+  abort() {
+    if (this._process) {
+      this._process.abort();
+      this._broadcast({ type: 'stream_end', text: this._accumulatedText, usage: null });
+      this._onDidChangeState.fire('idle');
+    }
+  }
+
+  sendPermissionResponse(requestId, action, toolUseId) {
+    if (!this._process) return;
+    if (action === 'deny') {
+      try {
+        this._process.write({
+          type: 'control_response',
+          response: {
+            subtype: 'error',
+            request_id: requestId,
+            error: 'User denied permission',
+          },
+        });
+      } catch (err) {
+        this._broadcast({ type: 'error', message: err.message });
+      }
+      return;
+    }
+    try {
+      this._process.sendControlResponse(requestId, {
+        toolUseID: toolUseId || undefined,
+        ...(action === 'allow-session' ? { remember: true } : {}),
+      });
+    } catch (err) {
+      this._broadcast({ type: 'error', message: err.message });
+    }
+  }
+
+  getMessages() { return this._messages; }
+
+  _handleMessage(msg) {
+    if (msg.session_id && !this._currentSessionId) {
+      this._currentSessionId = msg.session_id;
+    }
+
+    // System message — extract model and session info
+    if (msg.type === 'system') {
+      this._broadcast({
+        type: 'system_info',
+        model: msg.model || null,
+        sessionId: msg.session_id || msg.sessionId || null,
+      });
+      return;
+    }
+
+    // Control request (permission prompt) — check EARLY before other handlers
+    if (msg.type === 'control_request' || isControlRequest(msg)) {
+      const req = msg.request || {};
+      const { toolDisplayName, parseToolInput } = require('./messageParser');
+      this._broadcast({
+        type: 'permission_request',
+        requestId: msg.request_id,
+        toolName: req.tool_name || 'Unknown',
+        displayName: req.display_name || req.title || toolDisplayName(req.tool_name),
+        description: req.description || '',
+        inputPreview: parseToolInput(req.input),
+        toolUseId: req.tool_use_id || null,
+      });
+      return;
+    }
+
+    // Control cancel request
+    if (msg.type === 'control_cancel_request') {
+      return;
+    }
+
+    // Handle Anthropic raw stream events (the primary streaming mechanism)
+    if (isStreamEvent(msg)) {
+      this._handleStreamEvent(msg);
+      return;
+    }
+
+    // Assistant message — always mid-turn; true completion comes from 'result'
+    if (isAssistantMessage(msg)) {
+      const inner = msg.message || msg;
+      const text = getTextContent(inner);
+      const toolBlocks = getToolUseBlocks(inner);
+      const { toolDisplayName, toolIcon } = require('./messageParser');
+      const toolUseVms = toolBlocks.map(tu => ({
+        id: tu.id,
+        name: tu.name,
+        displayName: toolDisplayName(tu.name),
+        icon: toolIcon(tu.name),
+        inputPreview: typeof tu.input === 'string' ? tu.input : JSON.stringify(tu.input || ''),
+        input: tu.input,
+        status: 'running',
+      }));
+      this._messages.push({ role: 'assistant', text, toolUses: toolUseVms });
+      const usage = inner.usage || msg.usage || null;
+
+      // Finalize current text bubble but stay streaming — true completion
+      // is signaled by the 'result' message, not by the assistant message.
+      this._broadcast({ type: 'stream_end', text, usage, final: false });
+      this._accumulatedText = '';
+
+      if (toolBlocks.length > 0) {
+        for (const tu of toolBlocks) {
+          this._broadcast({
+            type: 'tool_input_ready',
+            toolUseId: tu.id,
+            input: tu.input,
+            name: tu.name,
+          });
+        }
+        this._broadcast({ type: 'status', content: 'Using tools...' });
+      }
+      return;
+    }
+
+    // User message with tool_use_result — this is the tool output
+    if (msg.type === 'user' && msg.message) {
+      const content = msg.message.content;
+      if (Array.isArray(content)) {
+        for (const block of content) {
+          if (block.type === 'tool_result' && block.tool_use_id) {
+            const resultText = typeof block.content === 'string'
+              ? block.content
+              : Array.isArray(block.content)
+                ? block.content.map(b => b.text || '').join('')
+                : '';
+            this._broadcast({
+              type: 'tool_result',
+              toolUseId: block.tool_use_id,
+              content: resultText.slice(0, 2000) || '(done)',
+              isError: block.is_error || false,
+            });
+          }
+        }
+      }
+      this._broadcast({ type: 'status', content: 'Thinking...' });
+      return;
+    }
+
+    // Session result — turn is complete. Go idle. The process stays alive
+    // in stream-json mode for multi-turn conversation.
+    if (msg.type === 'result' && msg.subtype) {
+      this._lastResult = msg;
+      // Only use result text if nothing was shown via streaming yet
+      const text = this._accumulatedText || '';
+      this._broadcast({ type: 'stream_end', text, usage: msg.usage || null, final: true });
+      // Show turn info: if the model stopped without using tools (num_turns=1),
+      // the user knows the model chose not to edit
+      if (msg.num_turns !== undefined) {
+        const reason = msg.stop_reason || 'done';
+        this._broadcast({
+          type: 'status',
+          content: msg.num_turns > 1
+            ? 'Completed (' + msg.num_turns + ' turns)'
+            : 'Ready',
+        });
+      }
+      this._accumulatedText = '';
+      this._toolUses = [];
+      this._streaming = false;
+      this._onDidChangeState.fire('idle');
+      return;
+    }
+
+    if (isToolProgressMessage(msg)) {
+      const vm = toViewModel(msg)[0];
+      this._broadcast({
+        type: 'tool_progress',
+        toolUseId: vm.toolUseId,
+        content: vm.content,
+      });
+      return;
+    }
+
+    if (isStatusMessage(msg)) {
+      const vm = toViewModel(msg)[0];
+      this._broadcast({ type: 'status', content: vm.content });
+      return;
+    }
+
+    if (isRateLimitEvent(msg)) {
+      const vm = toViewModel(msg)[0];
+      this._broadcast({ type: 'rate_limit', message: vm.message });
+      return;
+    }
+
+    // Log unhandled message types for debugging
+    if (msg.type && msg.type !== 'stream_event') {
+      this._broadcast({ type: 'status', content: '[debug] unhandled: ' + msg.type });
+    }
+  }
+
+  _handleStreamEvent(msg) {
+    const event = msg.event;
+    if (!event) return;
+
+    switch (event.type) {
+      case 'message_start':
+        this._accumulatedText = '';
+        this._thinkingTokens = 0;
+        this._currentBlockType = null;
+        if (!this._streaming) {
+          this._streaming = true;
+          this._toolUses = [];
+          this._onDidChangeState.fire('streaming');
+        }
+        this._broadcast({ type: 'stream_start' });
+        break;
+
+      case 'content_block_start':
+        if (event.content_block) {
+          this._currentBlockType = event.content_block.type;
+          if (event.content_block.type === 'tool_use') {
+            const tu = event.content_block;
+            this._toolUses.push({ id: tu.id, name: tu.name, input: '' });
+            const { toolDisplayName, toolIcon } = require('./messageParser');
+            this._broadcast({
+              type: 'tool_use',
+              toolUse: {
+                id: tu.id,
+                name: tu.name,
+                displayName: toolDisplayName(tu.name),
+                icon: toolIcon(tu.name),
+                inputPreview: '',
+                input: tu.input || null,
+                status: 'running',
+              },
+            });
+          } else if (event.content_block.type === 'thinking') {
+            this._thinkingTokens = 0;
+            this._thinkingStartTime = Date.now();
+            this._broadcast({ type: 'thinking_start' });
+          }
+        }
+        break;
+
+      case 'content_block_delta':
+        if (event.delta) {
+          if (event.delta.type === 'text_delta' && event.delta.text) {
+            this._accumulatedText += event.delta.text;
+            this._broadcast({ type: 'stream_delta', text: this._accumulatedText });
+          } else if (event.delta.type === 'thinking_delta') {
+            this._thinkingTokens += (event.delta.thinking || '').length;
+            const elapsed = Math.round((Date.now() - (this._thinkingStartTime || Date.now())) / 1000);
+            this._broadcast({
+              type: 'thinking_delta',
+              tokens: this._thinkingTokens,
+              elapsed,
+            });
+          } else if (event.delta.type === 'input_json_delta' && event.delta.partial_json) {
+            const lastTool = this._toolUses[this._toolUses.length - 1];
+            if (lastTool) {
+              lastTool.input = (lastTool.input || '') + event.delta.partial_json;
+            }
+          }
+        }
+        break;
+
+      case 'content_block_stop':
+        if (this._currentBlockType === 'thinking') {
+          this._broadcast({ type: 'thinking_end' });
+        }
+        this._currentBlockType = null;
+        break;
+
+      case 'message_delta':
+        break;
+
+      case 'message_stop':
+        break;
+
+      default:
+        break;
+    }
+  }
+
+  dispose() {
+    this.stopSession();
+    this._onDidChangeState.dispose();
+  }
+}
+
+class OpenClaudeChatViewProvider {
+  constructor(chatController) {
+    this._chatController = chatController;
+    this._webviewView = null;
+  }
+
+  resolveWebviewView(webviewView, _context, _token) {
+    this._webviewView = webviewView;
+    const webview = webviewView.webview;
+    webview.options = { enableScripts: true };
+
+    const registration = this._chatController.registerWebview(webview);
+    webviewView.onDidDispose(() => {
+      registration.dispose();
+      if (this._webviewView === webviewView) this._webviewView = null;
+    });
+
+    webview.html = this._getHtml(webview);
+    this._attachMessageHandler(webview);
+  }
+
+  _getHtml() {
+    const nonce = crypto.randomBytes(16).toString('hex');
+    return renderChatHtml({ nonce, platform: process.platform });
+  }
+
+  _attachMessageHandler(webview) {
+    webview.onDidReceiveMessage(async (msg) => {
+      switch (msg.type) {
+        case 'send_message':
+          this._chatController.sendMessage(msg.text);
+          break;
+        case 'abort':
+          this._chatController.abort();
+          break;
+        case 'new_session':
+          this._chatController.stopSession();
+          webview.postMessage({ type: 'session_cleared' });
+          break;
+        case 'resume_session':
+          this._chatController.stopSession();
+          webview.postMessage({ type: 'session_cleared' });
+          await this._loadAndDisplaySession(webview, msg.sessionId);
+          await this._chatController.startSession({ sessionId: msg.sessionId });
+          break;
+        case 'permission_response':
+          this._chatController.sendPermissionResponse(msg.requestId, msg.action, msg.toolUseId);
+          break;
+        case 'copy_code':
+          if (msg.text) await vscode.env.clipboard.writeText(msg.text);
+          break;
+        case 'open_file':
+          if (msg.path) await openFileInEditor(msg.path);
+          break;
+        case 'request_sessions':
+          await this._sendSessionList(webview);
+          break;
+        case 'restore_request':
+          this._restoreMessages(webview);
+          break;
+        case 'webview_ready':
+          break;
+      }
+    });
+  }
+
+  async _sendSessionList(webview) {
+    if (!this._chatController.sessionManager) return;
+    try {
+      const sessions = await this._chatController.sessionManager.listSessions();
+      webview.postMessage({ type: 'session_list', sessions });
+    } catch {
+      webview.postMessage({ type: 'session_list', sessions: [] });
+    }
+  }
+
+  _restoreMessages(webview) {
+    const messages = this._chatController.getMessages();
+    if (messages.length > 0) {
+      webview.postMessage({ type: 'restore_messages', messages });
+    }
+  }
+
+  async _loadAndDisplaySession(webview, sessionId) {
+    if (!this._chatController.sessionManager) return;
+    try {
+      const messages = await this._chatController.sessionManager.loadSession(sessionId);
+      if (messages && messages.length > 0) {
+        this._chatController._messages = messages;
+        webview.postMessage({ type: 'restore_messages', messages });
+      }
+    } catch { /* session may not be loadable */ }
+  }
+}
+
+class OpenClaudeChatPanelManager {
+  constructor(chatController) {
+    this._chatController = chatController;
+    this._panel = null;
+  }
+
+  openPanel() {
+    if (this._panel) {
+      this._panel.reveal();
+      return;
+    }
+
+    this._panel = vscode.window.createWebviewPanel(
+      'openclaude.chatPanel',
+      'OpenClaude Chat',
+      vscode.ViewColumn.Beside,
+      {
+        enableScripts: true,
+        retainContextWhenHidden: true,
+      },
+    );
+
+    const webview = this._panel.webview;
+    const registration = this._chatController.registerWebview(webview);
+
+    this._panel.onDidDispose(() => {
+      registration.dispose();
+      this._panel = null;
+    });
+
+    const nonce = crypto.randomBytes(16).toString('hex');
+    webview.html = renderChatHtml({ nonce, platform: process.platform });
+    this._attachMessageHandler(webview);
+
+    const messages = this._chatController.getMessages();
+    if (messages.length > 0) {
+      webview.postMessage({ type: 'restore_messages', messages });
+    }
+  }
+
+  _attachMessageHandler(webview) {
+    webview.onDidReceiveMessage(async (msg) => {
+      switch (msg.type) {
+        case 'send_message':
+          this._chatController.sendMessage(msg.text);
+          break;
+        case 'abort':
+          this._chatController.abort();
+          break;
+        case 'new_session':
+          this._chatController.stopSession();
+          webview.postMessage({ type: 'session_cleared' });
+          break;
+        case 'resume_session':
+          this._chatController.stopSession();
+          webview.postMessage({ type: 'session_cleared' });
+          await this._loadAndDisplaySession(webview, msg.sessionId);
+          await this._chatController.startSession({ sessionId: msg.sessionId });
+          break;
+        case 'permission_response':
+          this._chatController.sendPermissionResponse(msg.requestId, msg.action, msg.toolUseId);
+          break;
+        case 'copy_code':
+          if (msg.text) await vscode.env.clipboard.writeText(msg.text);
+          break;
+        case 'open_file':
+          if (msg.path) await openFileInEditor(msg.path);
+          break;
+        case 'request_sessions':
+          await this._sendSessionList(webview);
+          break;
+        case 'restore_request':
+          this._restoreMessages(webview);
+          break;
+        case 'webview_ready':
+          break;
+      }
+    });
+  }
+
+  async _sendSessionList(webview) {
+    if (!this._chatController.sessionManager) return;
+    try {
+      const sessions = await this._chatController.sessionManager.listSessions();
+      webview.postMessage({ type: 'session_list', sessions });
+    } catch {
+      webview.postMessage({ type: 'session_list', sessions: [] });
+    }
+  }
+
+  _restoreMessages(webview) {
+    const messages = this._chatController.getMessages();
+    if (messages.length > 0) {
+      webview.postMessage({ type: 'restore_messages', messages });
+    }
+  }
+
+  async _loadAndDisplaySession(webview, sessionId) {
+    if (!this._chatController.sessionManager) return;
+    try {
+      const messages = await this._chatController.sessionManager.loadSession(sessionId);
+      if (messages && messages.length > 0) {
+        this._chatController._messages = messages;
+        webview.postMessage({ type: 'restore_messages', messages });
+      }
+    } catch { /* session may not be loadable */ }
+  }
+
+  dispose() {
+    if (this._panel) {
+      this._panel.dispose();
+      this._panel = null;
+    }
+  }
+}
+
+module.exports = {
+  ChatController,
+  OpenClaudeChatViewProvider,
+  OpenClaudeChatPanelManager,
+};

--- a/vscode-extension/openclaude-vscode/src/chat/chatRenderer.js
+++ b/vscode-extension/openclaude-vscode/src/chat/chatRenderer.js
@@ -1,0 +1,1354 @@
+/**
+ * chatRenderer — produces the full self-contained HTML document for the chat
+ * webview.  All CSS and JS are inlined (no external bundles).
+ *
+ * The webview JS communicates with the extension host via postMessage.
+ * Incoming messages update the DOM incrementally so streaming feels fluid.
+ */
+
+function escapeHtml(value) {
+  return String(value)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+function renderChatHtml({ nonce, platform }) {
+  const modKey = platform === 'darwin' ? 'Cmd' : 'Ctrl';
+
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta http-equiv="Content-Security-Policy"
+        content="default-src 'none'; style-src 'unsafe-inline'; script-src 'nonce-${nonce}';" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <style>
+    :root {
+      --oc-bg: #0a0908;
+      --oc-panel: #110d0c;
+      --oc-panel-strong: #17110f;
+      --oc-panel-soft: #1d1512;
+      --oc-border: #645041;
+      --oc-border-soft: rgba(220,195,170,0.14);
+      --oc-text: #f7efe5;
+      --oc-text-dim: #dcc3aa;
+      --oc-text-soft: #aa9078;
+      --oc-accent: #d77757;
+      --oc-accent-bright: #f09464;
+      --oc-accent-soft: rgba(240,148,100,0.18);
+      --oc-positive: #e8b86b;
+      --oc-warning: #f3c969;
+      --oc-critical: #ff8a6c;
+      --oc-focus: #ffd3a1;
+      --oc-user-bg: rgba(240,148,100,0.12);
+      --oc-user-border: rgba(240,148,100,0.28);
+      --oc-assistant-bg: rgba(255,255,255,0.03);
+      --oc-assistant-border: rgba(220,195,170,0.10);
+      --oc-code-bg: #1a1310;
+      --oc-code-border: rgba(220,195,170,0.12);
+      --oc-tool-bg: rgba(232,184,107,0.06);
+      --oc-tool-border: rgba(232,184,107,0.22);
+      --oc-perm-bg: rgba(255,138,108,0.08);
+      --oc-perm-border: rgba(255,138,108,0.35);
+    }
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    html, body { height: 100%; overflow: hidden; }
+    body {
+      font-family: var(--vscode-font-family, "Segoe UI", system-ui, sans-serif);
+      font-size: 13px;
+      color: var(--oc-text);
+      background: var(--oc-bg);
+      display: flex;
+      flex-direction: column;
+      position: relative;
+    }
+
+    /* ── Header ── */
+    .chat-header {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      padding: 8px 12px;
+      border-bottom: 1px solid var(--oc-border-soft);
+      background: var(--oc-panel);
+      flex-shrink: 0;
+    }
+    .chat-header .brand {
+      font-weight: 700;
+      font-size: 14px;
+      color: var(--oc-text);
+      flex: 1;
+      min-width: 0;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+    .chat-header .brand-accent { color: var(--oc-accent-bright); }
+    .header-btn {
+      border: 1px solid var(--oc-border-soft);
+      border-radius: 6px;
+      background: rgba(255,255,255,0.04);
+      color: var(--oc-text-dim);
+      padding: 4px 8px;
+      font-size: 12px;
+      cursor: pointer;
+      white-space: nowrap;
+    }
+    .header-btn:hover { border-color: var(--oc-accent); color: var(--oc-text); }
+    .header-btn.danger { border-color: var(--oc-critical); color: var(--oc-critical); }
+    .header-btn.danger:hover { background: rgba(255,138,108,0.12); }
+    #abortBtn { display: none; }
+
+    /* ── Status bar ── */
+    .status-bar {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      padding: 4px 12px;
+      font-size: 11px;
+      color: var(--oc-text-soft);
+      border-bottom: 1px solid var(--oc-border-soft);
+      background: var(--oc-panel);
+      flex-shrink: 0;
+    }
+    .status-bar .status-dot {
+      width: 6px; height: 6px;
+      border-radius: 50%;
+      background: var(--oc-text-soft);
+      flex-shrink: 0;
+    }
+    .status-bar .status-dot.connected { background: var(--oc-positive); }
+    .status-bar .status-dot.streaming { background: var(--oc-accent-bright); animation: pulse 1s infinite; }
+    .status-bar .status-dot.error { background: var(--oc-critical); }
+    @keyframes pulse { 0%,100% { opacity: 1; } 50% { opacity: 0.4; } }
+    .status-text { flex: 1; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+    .status-usage { color: var(--oc-text-soft); }
+
+    /* ── Message list ── */
+    .messages {
+      flex: 1;
+      overflow-y: auto;
+      padding: 12px;
+      display: flex;
+      flex-direction: column;
+      gap: 12px;
+    }
+    .messages::-webkit-scrollbar { width: 6px; }
+    .messages::-webkit-scrollbar-track { background: transparent; }
+    .messages::-webkit-scrollbar-thumb { background: rgba(220,195,170,0.18); border-radius: 3px; }
+
+    /* ── Welcome screen ── */
+    .welcome {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      flex: 1;
+      text-align: center;
+      padding: 32px 16px;
+      gap: 16px;
+    }
+    .welcome-title { font-size: 20px; font-weight: 700; color: var(--oc-text); }
+    .welcome-title .accent { color: var(--oc-accent-bright); }
+    .welcome-sub { font-size: 13px; color: var(--oc-text-dim); max-width: 36ch; }
+    .welcome-hint { font-size: 11px; color: var(--oc-text-soft); }
+    .welcome-hint kbd {
+      padding: 2px 6px;
+      border-radius: 4px;
+      border: 1px solid var(--oc-border-soft);
+      background: rgba(255,255,255,0.04);
+      font-family: inherit;
+      font-size: 11px;
+    }
+
+    /* ── User message ── */
+    .msg-user {
+      align-self: flex-end;
+      max-width: 85%;
+      padding: 10px 14px;
+      border-radius: 14px 14px 4px 14px;
+      background: var(--oc-user-bg);
+      border: 1px solid var(--oc-user-border);
+      word-break: break-word;
+      white-space: pre-wrap;
+    }
+
+    /* ── Assistant message ── */
+    .msg-assistant {
+      align-self: flex-start;
+      max-width: 95%;
+      padding: 10px 14px;
+      border-radius: 4px 14px 14px 14px;
+      background: var(--oc-assistant-bg);
+      border: 1px solid var(--oc-assistant-border);
+      word-break: break-word;
+    }
+    .msg-assistant .md-content { line-height: 1.55; }
+    .msg-assistant .md-content:empty { display: none; }
+    .msg-assistant .md-content p { margin-bottom: 8px; }
+    .msg-assistant .md-content p:last-child { margin-bottom: 0; }
+    .msg-assistant .md-content ul,
+    .msg-assistant .md-content ol { padding-left: 20px; margin-bottom: 8px; }
+    .msg-assistant .md-content li { margin-bottom: 4px; }
+    .msg-assistant .md-content h1,
+    .msg-assistant .md-content h2,
+    .msg-assistant .md-content h3 {
+      color: var(--oc-text);
+      margin: 12px 0 6px;
+      font-size: 14px;
+      font-weight: 700;
+    }
+    .msg-assistant .md-content h1 { font-size: 16px; }
+    .msg-assistant .md-content a { color: var(--oc-accent-bright); text-decoration: underline; }
+    .msg-assistant .md-content strong { color: var(--oc-text); font-weight: 700; }
+    .msg-assistant .md-content em { font-style: italic; color: var(--oc-text-dim); }
+    .msg-assistant .md-content blockquote {
+      border-left: 3px solid var(--oc-accent);
+      padding: 4px 12px;
+      margin: 8px 0;
+      color: var(--oc-text-dim);
+    }
+    .msg-assistant .md-content hr {
+      border: none;
+      border-top: 1px solid var(--oc-border-soft);
+      margin: 12px 0;
+    }
+
+    /* inline code */
+    .md-content code:not(.code-block code) {
+      padding: 1px 5px;
+      border-radius: 4px;
+      background: var(--oc-code-bg);
+      border: 1px solid var(--oc-code-border);
+      font-family: var(--vscode-editor-font-family, Consolas, monospace);
+      font-size: 12px;
+      color: var(--oc-accent-bright);
+    }
+
+    /* fenced code */
+    .code-wrapper {
+      position: relative;
+      margin: 8px 0;
+      border-radius: 8px;
+      border: 1px solid var(--oc-code-border);
+      background: var(--oc-code-bg);
+      overflow: hidden;
+    }
+    .code-header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      padding: 4px 10px;
+      font-size: 11px;
+      color: var(--oc-text-soft);
+      border-bottom: 1px solid var(--oc-code-border);
+      background: rgba(255,255,255,0.02);
+    }
+    .code-copy-btn {
+      border: none;
+      background: transparent;
+      color: var(--oc-text-soft);
+      cursor: pointer;
+      font-size: 11px;
+      padding: 2px 6px;
+      border-radius: 4px;
+    }
+    .code-copy-btn:hover { background: rgba(255,255,255,0.08); color: var(--oc-text); }
+    .code-block {
+      display: block;
+      padding: 10px 12px;
+      overflow-x: auto;
+      font-family: var(--vscode-editor-font-family, Consolas, monospace);
+      font-size: 12px;
+      line-height: 1.5;
+      white-space: pre;
+      color: var(--oc-text-dim);
+    }
+    .code-block::-webkit-scrollbar { height: 4px; }
+    .code-block::-webkit-scrollbar-thumb { background: rgba(220,195,170,0.2); border-radius: 2px; }
+
+    /* keyword highlighting */
+    .hl-keyword { color: #c586c0; }
+    .hl-string { color: #ce9178; }
+    .hl-comment { color: #6a9955; font-style: italic; }
+    .hl-number { color: #b5cea8; }
+    .hl-func { color: #dcdcaa; }
+    .hl-type { color: #4ec9b0; }
+
+    /* ── Tool use card ── */
+    .tool-card {
+      margin: 8px 0;
+      border-radius: 8px;
+      border: 1px solid var(--oc-tool-border);
+      background: var(--oc-tool-bg);
+      overflow: hidden;
+    }
+    .tool-header {
+      display: flex;
+      align-items: center;
+      gap: 6px;
+      padding: 8px 10px;
+      cursor: pointer;
+      user-select: none;
+    }
+    .tool-icon { font-size: 14px; flex-shrink: 0; }
+    .tool-name { font-weight: 600; font-size: 12px; color: var(--oc-text); flex: 1; }
+    .tool-status { font-size: 11px; color: var(--oc-text-soft); }
+    .tool-status.running { color: var(--oc-accent-bright); }
+    .tool-status.error { color: var(--oc-critical); }
+    .tool-status.complete { color: var(--oc-positive); }
+    .tool-chevron {
+      font-size: 10px;
+      color: var(--oc-text-soft);
+      transition: transform 150ms;
+    }
+    .tool-card.expanded .tool-chevron { transform: rotate(90deg); }
+    .tool-body {
+      display: none;
+      padding: 0 10px 10px;
+      font-size: 12px;
+      border-top: 1px solid var(--oc-tool-border);
+    }
+    .tool-card.expanded .tool-body { display: block; }
+    .tool-input-label,
+    .tool-output-label {
+      font-size: 10px;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      color: var(--oc-text-soft);
+      margin: 8px 0 4px;
+    }
+    .tool-input-content,
+    .tool-output-content {
+      padding: 6px 8px;
+      border-radius: 6px;
+      background: rgba(0,0,0,0.2);
+      font-family: var(--vscode-editor-font-family, Consolas, monospace);
+      font-size: 11px;
+      color: var(--oc-text-dim);
+      white-space: pre-wrap;
+      word-break: break-all;
+      max-height: 200px;
+      overflow-y: auto;
+    }
+    .tool-output-content.error { color: var(--oc-critical); }
+    .tool-path {
+      font-weight: 400;
+      color: var(--oc-text-soft);
+      font-size: 11px;
+      margin-left: 4px;
+    }
+    .file-link {
+      color: var(--oc-accent-bright);
+      cursor: pointer;
+      text-decoration: none;
+      border-bottom: 1px dotted var(--oc-accent);
+      transition: color 120ms, border-color 120ms;
+    }
+    .file-link:hover {
+      color: var(--oc-focus);
+      border-bottom-color: var(--oc-focus);
+    }
+    .tool-input-content.tool-diff-old {
+      border-left: 3px solid var(--oc-critical);
+      padding-left: 10px;
+      color: #ff9e8a;
+      text-decoration: line-through;
+      opacity: 0.7;
+    }
+    .tool-input-content.tool-diff-new {
+      border-left: 3px solid var(--oc-positive);
+      padding-left: 10px;
+      color: #c8e6a0;
+    }
+    .tool-diff-btn {
+      margin-top: 6px;
+      border: 1px solid var(--oc-accent);
+      border-radius: 6px;
+      background: rgba(240,148,100,0.08);
+      color: var(--oc-accent-bright);
+      padding: 4px 10px;
+      font-size: 11px;
+      cursor: pointer;
+    }
+    .tool-diff-btn:hover { background: rgba(240,148,100,0.16); }
+
+    /* ── Permission card ── */
+    .perm-card {
+      margin: 8px 0;
+      padding: 10px 12px;
+      border-radius: 8px;
+      border: 1px solid var(--oc-perm-border);
+      background: var(--oc-perm-bg);
+    }
+    .perm-title { font-weight: 700; font-size: 12px; color: var(--oc-critical); margin-bottom: 6px; }
+    .perm-desc { font-size: 12px; color: var(--oc-text-dim); margin-bottom: 8px; }
+    .perm-input {
+      padding: 6px 8px;
+      margin-bottom: 8px;
+      border-radius: 6px;
+      background: rgba(0,0,0,0.2);
+      font-family: var(--vscode-editor-font-family, Consolas, monospace);
+      font-size: 11px;
+      color: var(--oc-text-dim);
+      white-space: pre-wrap;
+      max-height: 120px;
+      overflow-y: auto;
+    }
+    .perm-actions { display: flex; gap: 6px; }
+    .perm-btn {
+      padding: 5px 12px;
+      border-radius: 6px;
+      font-size: 12px;
+      font-weight: 600;
+      cursor: pointer;
+      border: 1px solid;
+    }
+    .perm-btn.allow {
+      background: rgba(232,184,107,0.14);
+      border-color: var(--oc-positive);
+      color: var(--oc-positive);
+    }
+    .perm-btn.deny {
+      background: rgba(255,138,108,0.1);
+      border-color: var(--oc-critical);
+      color: var(--oc-critical);
+    }
+    .perm-btn.allow-session {
+      background: rgba(232,184,107,0.08);
+      border-color: rgba(232,184,107,0.4);
+      color: var(--oc-text-dim);
+    }
+    .perm-btn:hover { filter: brightness(1.15); }
+
+    /* ── Status pill ── */
+    .msg-status {
+      align-self: center;
+      font-size: 11px;
+      color: var(--oc-text-soft);
+      padding: 4px 12px;
+      border-radius: 999px;
+      border: 1px solid var(--oc-border-soft);
+      background: rgba(255,255,255,0.02);
+    }
+
+    /* ── Rate limit ── */
+    .msg-rate-limit {
+      align-self: center;
+      font-size: 11px;
+      color: var(--oc-warning);
+      padding: 6px 14px;
+      border-radius: 8px;
+      border: 1px solid rgba(243,201,105,0.3);
+      background: rgba(243,201,105,0.06);
+    }
+
+    /* ── Thinking block ── */
+    .thinking-block {
+      display: none;
+      align-self: flex-start;
+      padding: 10px 14px;
+      border-radius: 10px;
+      border: 1px solid rgba(200,160,255,0.25);
+      background: rgba(160,120,220,0.08);
+      margin: 4px 0;
+      gap: 6px;
+      flex-direction: column;
+    }
+    .thinking-block.visible { display: flex; }
+    .thinking-header {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      font-size: 12px;
+      color: #c4a0ff;
+      font-weight: 600;
+    }
+    .thinking-spinner {
+      width: 12px; height: 12px;
+      border: 2px solid rgba(200,160,255,0.3);
+      border-top-color: #c4a0ff;
+      border-radius: 50%;
+      animation: spin 0.8s linear infinite;
+    }
+    @keyframes spin { to { transform: rotate(360deg); } }
+    .thinking-meta {
+      font-size: 11px;
+      color: var(--oc-text-soft);
+    }
+
+    /* ── Typing indicator ── */
+    .typing-indicator {
+      display: none;
+      align-self: flex-start;
+      padding: 10px 14px;
+      gap: 4px;
+    }
+    .typing-indicator.visible { display: flex; }
+    .typing-dot {
+      width: 6px; height: 6px;
+      border-radius: 50%;
+      background: var(--oc-accent);
+      animation: typingBounce 1.2s infinite;
+    }
+    .typing-dot:nth-child(2) { animation-delay: 0.2s; }
+    .typing-dot:nth-child(3) { animation-delay: 0.4s; }
+    @keyframes typingBounce {
+      0%, 60%, 100% { transform: translateY(0); opacity: 0.4; }
+      30% { transform: translateY(-4px); opacity: 1; }
+    }
+
+    /* ── Input area ── */
+    .input-area {
+      display: flex;
+      gap: 8px;
+      padding: 10px 12px;
+      border-top: 1px solid var(--oc-border-soft);
+      background: var(--oc-panel);
+      flex-shrink: 0;
+      align-items: flex-end;
+    }
+    .input-area textarea {
+      flex: 1;
+      min-height: 36px;
+      max-height: 160px;
+      padding: 8px 12px;
+      border: 1px solid var(--oc-border-soft);
+      border-radius: 10px;
+      background: rgba(255,255,255,0.04);
+      color: var(--oc-text);
+      font-family: inherit;
+      font-size: 13px;
+      resize: none;
+      outline: none;
+      line-height: 1.4;
+    }
+    .input-area textarea::placeholder { color: var(--oc-text-soft); }
+    .input-area textarea:focus { border-color: var(--oc-accent); }
+    .send-btn {
+      width: 36px;
+      height: 36px;
+      border-radius: 10px;
+      border: 1px solid var(--oc-accent);
+      background: linear-gradient(135deg, rgba(240,148,100,0.2), rgba(215,119,87,0.12));
+      color: var(--oc-accent-bright);
+      cursor: pointer;
+      font-size: 16px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      flex-shrink: 0;
+    }
+    .send-btn:hover { background: rgba(240,148,100,0.25); }
+    .send-btn:disabled { opacity: 0.4; cursor: not-allowed; }
+
+    /* ── Session list overlay ── */
+    .session-overlay {
+      display: none;
+      position: absolute;
+      inset: 0;
+      z-index: 100;
+      background: rgba(5,5,5,0.92);
+      flex-direction: column;
+    }
+    .session-overlay.visible { display: flex; }
+    .session-overlay-header {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      padding: 10px 12px;
+      border-bottom: 1px solid var(--oc-border-soft);
+    }
+    .session-overlay-header h2 { font-size: 14px; font-weight: 700; flex: 1; }
+    .session-search {
+      margin: 8px 12px;
+      padding: 8px 10px;
+      border: 1px solid var(--oc-border-soft);
+      border-radius: 8px;
+      background: rgba(255,255,255,0.04);
+      color: var(--oc-text);
+      font-size: 13px;
+      outline: none;
+    }
+    .session-search:focus { border-color: var(--oc-accent); }
+    .session-list {
+      flex: 1;
+      overflow-y: auto;
+      padding: 8px 12px;
+    }
+    .session-group-label {
+      font-size: 10px;
+      text-transform: uppercase;
+      letter-spacing: 0.1em;
+      color: var(--oc-text-soft);
+      padding: 8px 0 4px;
+    }
+    .session-item {
+      padding: 10px;
+      border-radius: 8px;
+      border: 1px solid transparent;
+      cursor: pointer;
+      margin-bottom: 4px;
+    }
+    .session-item:hover { background: rgba(255,255,255,0.04); border-color: var(--oc-border-soft); }
+    .session-item-title { font-weight: 600; font-size: 13px; color: var(--oc-text); margin-bottom: 2px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+    .session-item-preview { font-size: 11px; color: var(--oc-text-dim); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+    .session-item-time { font-size: 10px; color: var(--oc-text-soft); margin-top: 2px; }
+    .session-empty { text-align: center; padding: 32px; color: var(--oc-text-soft); }
+  </style>
+</head>
+<body>
+  <div class="chat-header">
+    <div class="brand">Open<span class="brand-accent">Claude</span></div>
+    <button class="header-btn" id="historyBtn" title="Session history">History</button>
+    <button class="header-btn" id="newChatBtn" title="New chat">+ New</button>
+    <button class="header-btn danger" id="abortBtn" title="Abort generation">Stop</button>
+  </div>
+  <div class="status-bar">
+    <span class="status-dot" id="statusDot"></span>
+    <span class="status-text" id="statusText">Ready</span>
+    <span class="status-usage" id="statusUsage"></span>
+  </div>
+
+  <div class="messages" id="messages">
+    <div class="welcome" id="welcomeScreen">
+      <div class="welcome-title">Open<span class="accent">Claude</span></div>
+      <div class="welcome-sub">Ask a question, request a code change, or start a new task.</div>
+      <div class="welcome-hint">Press <kbd>${escapeHtml(modKey)}+L</kbd> to focus input</div>
+    </div>
+  </div>
+
+  <div class="thinking-block" id="thinkingBlock">
+    <div class="thinking-header">
+      <div class="thinking-spinner"></div>
+      <span id="thinkingLabel">Thinking...</span>
+    </div>
+    <div class="thinking-meta" id="thinkingMeta"></div>
+  </div>
+
+  <div class="typing-indicator" id="typingIndicator">
+    <div class="typing-dot"></div>
+    <div class="typing-dot"></div>
+    <div class="typing-dot"></div>
+  </div>
+
+  <div class="input-area">
+    <textarea id="chatInput" placeholder="Message OpenClaude..." rows="1"></textarea>
+    <button class="send-btn" id="sendBtn" title="Send message">&#x27A4;</button>
+  </div>
+
+  <!-- Session list overlay -->
+  <div class="session-overlay" id="sessionOverlay">
+    <div class="session-overlay-header">
+      <h2>Session History</h2>
+      <button class="header-btn" id="closeSessionsBtn">Close</button>
+    </div>
+    <input class="session-search" id="sessionSearch" type="text" placeholder="Search sessions..." />
+    <div class="session-list" id="sessionList">
+      <div class="session-empty">No sessions found</div>
+    </div>
+  </div>
+
+<script nonce="${nonce}">
+(function() {
+  const vscode = acquireVsCodeApi();
+
+  const messagesEl = document.getElementById('messages');
+  const welcomeEl = document.getElementById('welcomeScreen');
+  const inputEl = document.getElementById('chatInput');
+  const sendBtn = document.getElementById('sendBtn');
+  const abortBtn = document.getElementById('abortBtn');
+  const newChatBtn = document.getElementById('newChatBtn');
+  const historyBtn = document.getElementById('historyBtn');
+  const statusDot = document.getElementById('statusDot');
+  const statusText = document.getElementById('statusText');
+  const statusUsage = document.getElementById('statusUsage');
+  const typingIndicator = document.getElementById('typingIndicator');
+  const sessionOverlay = document.getElementById('sessionOverlay');
+  const closeSessionsBtn = document.getElementById('closeSessionsBtn');
+  const sessionSearch = document.getElementById('sessionSearch');
+  const sessionList = document.getElementById('sessionList');
+
+  let isStreaming = false;
+  let currentAssistantEl = null;
+  let currentTextEl = null;
+  const toolResultMap = {};
+
+  /* ── Markdown renderer ── */
+  function renderMarkdown(text) {
+    if (!text) return '';
+    let html = escapeForMd(text);
+
+    // fenced code blocks
+    html = html.replace(/\`\`\`(\\w*?)\\n([\\s\\S]*?)\`\`\`/g, (_, lang, code) => {
+      const langLabel = lang || 'text';
+      const highlighted = highlightCode(code, langLabel);
+      const id = 'cb-' + Math.random().toString(36).slice(2, 8);
+      return '<div class="code-wrapper"><div class="code-header">' +
+        '<span>' + langLabel + '</span>' +
+        '<button class="code-copy-btn" data-copy-id="' + id + '">Copy</button></div>' +
+        '<code class="code-block" id="' + id + '">' + highlighted + '</code></div>';
+    });
+
+    // inline code
+    html = html.replace(/\`([^\`]+?)\`/g, '<code>$1</code>');
+
+    // headings
+    html = html.replace(/^### (.+)$/gm, '<h3>$1</h3>');
+    html = html.replace(/^## (.+)$/gm, '<h2>$1</h2>');
+    html = html.replace(/^# (.+)$/gm, '<h1>$1</h1>');
+
+    // blockquotes
+    html = html.replace(/^&gt; (.+)$/gm, '<blockquote>$1</blockquote>');
+
+    // hr
+    html = html.replace(/^---$/gm, '<hr/>');
+
+    // bold / italic
+    html = html.replace(/\\*\\*(.+?)\\*\\*/g, '<strong>$1</strong>');
+    html = html.replace(/\\*(.+?)\\*/g, '<em>$1</em>');
+
+    // links
+    html = html.replace(/\\[([^\\]]+)\\]\\(([^)]+)\\)/g, '<a href="$2" title="$2">$1</a>');
+
+    // unordered lists (simple)
+    html = html.replace(/^[\\-\\*] (.+)$/gm, '<li>$1</li>');
+    html = html.replace(/((?:<li>.*<\\/li>\\n?)+)/g, '<ul>$1</ul>');
+
+    // ordered lists
+    html = html.replace(/^\\d+\\. (.+)$/gm, '<li>$1</li>');
+
+    // paragraphs (double newline)
+    html = html.replace(/\\n\\n/g, '</p><p>');
+    html = '<p>' + html + '</p>';
+    html = html.replace(/<p><\\/p>/g, '');
+    html = html.replace(/<p>(<h[123]>)/g, '$1');
+    html = html.replace(/(<\\/h[123]>)<\\/p>/g, '$1');
+    html = html.replace(/<p>(<ul>)/g, '$1');
+    html = html.replace(/(<\\/ul>)<\\/p>/g, '$1');
+    html = html.replace(/<p>(<blockquote>)/g, '$1');
+    html = html.replace(/(<\\/blockquote>)<\\/p>/g, '$1');
+    html = html.replace(/<p>(<hr\\/>)/g, '$1');
+    html = html.replace(/(<hr\\/>)<\\/p>/g, '$1');
+    html = html.replace(/<p>(<div class="code-wrapper">)/g, '$1');
+    html = html.replace(/(<\\/div>)<\\/p>/g, '$1');
+
+    return html;
+  }
+
+  function escapeForMd(text) {
+    return text
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;');
+  }
+
+  function highlightCode(code, lang) {
+    let result = code;
+    const kwPattern = /\\b(const|let|var|function|return|if|else|for|while|class|import|export|from|async|await|try|catch|throw|new|typeof|instanceof|switch|case|break|default|continue|do|in|of|yield|void|delete|true|false|null|undefined|this|super|extends|implements|interface|type|enum|public|private|protected|static|readonly|abstract|def|print|self|elif|except|finally|with|as|lambda|pass|raise|None|True|False)\\b/g;
+    const strPattern = /(&quot;[^&]*?&quot;|&#39;[^&]*?&#39;|'[^']*?'|"[^"]*?")/g;
+    const commentPattern = /(\\/{2}.*$|#.*$)/gm;
+    const numPattern = /\\b(\\d+\\.?\\d*)\\b/g;
+
+    result = result.replace(commentPattern, '<span class="hl-comment">$1</span>');
+    result = result.replace(strPattern, '<span class="hl-string">$1</span>');
+    result = result.replace(kwPattern, '<span class="hl-keyword">$1</span>');
+    result = result.replace(numPattern, '<span class="hl-number">$1</span>');
+
+    return result;
+  }
+
+  /* ── DOM helpers ── */
+  function scrollToBottom() {
+    requestAnimationFrame(() => {
+      messagesEl.scrollTop = messagesEl.scrollHeight;
+    });
+  }
+
+  function hideWelcome() {
+    if (welcomeEl) welcomeEl.style.display = 'none';
+  }
+
+  function showWelcome() {
+    if (welcomeEl) welcomeEl.style.display = 'flex';
+  }
+
+  function setStreaming(val, label) {
+    isStreaming = val;
+    abortBtn.style.display = val ? 'block' : 'none';
+    sendBtn.disabled = val;
+    typingIndicator.classList.toggle('visible', val);
+    statusDot.className = 'status-dot ' + (val ? 'streaming' : 'connected');
+    statusText.textContent = label || (val ? 'Generating...' : 'Ready');
+  }
+
+  function setStatusLabel(label) {
+    statusText.textContent = label;
+  }
+
+  function appendUserMessage(text) {
+    hideWelcome();
+    const el = document.createElement('div');
+    el.className = 'msg-user';
+    el.textContent = text;
+    messagesEl.appendChild(el);
+    scrollToBottom();
+  }
+
+  function getOrCreateAssistantEl() {
+    if (!currentAssistantEl) {
+      hideWelcome();
+      currentAssistantEl = document.createElement('div');
+      currentAssistantEl.className = 'msg-assistant';
+      currentTextEl = document.createElement('div');
+      currentTextEl.className = 'md-content';
+      currentAssistantEl.appendChild(currentTextEl);
+      messagesEl.appendChild(currentAssistantEl);
+    }
+    return { container: currentAssistantEl, textEl: currentTextEl };
+  }
+
+  function finalizeAssistant() {
+    // Hide the text div if it's empty (model went straight to tool use)
+    if (currentTextEl && !currentTextEl.textContent.trim()) {
+      currentTextEl.style.display = 'none';
+    }
+    // Remove the entire bubble if it has no visible content at all
+    if (currentAssistantEl) {
+      const hasText = currentTextEl && currentTextEl.textContent.trim();
+      const hasToolCards = currentAssistantEl.querySelector('.tool-card');
+      if (!hasText && !hasToolCards) {
+        currentAssistantEl.remove();
+      }
+    }
+    currentAssistantEl = null;
+    currentTextEl = null;
+  }
+
+  function appendToolCard(toolUse) {
+    const { container } = getOrCreateAssistantEl();
+    const card = document.createElement('div');
+    card.className = 'tool-card expanded';
+    card.dataset.toolId = toolUse.id || '';
+    const statusClass = toolUse.status || 'running';
+    const statusLabel = statusClass === 'running' ? 'Running...'
+      : statusClass === 'error' ? 'Error' : 'Done';
+
+    var inputSummary = '';
+    if (toolUse.input && typeof toolUse.input === 'object') {
+      if (toolUse.input.file_path || toolUse.input.path) {
+        inputSummary = (toolUse.input.file_path || toolUse.input.path);
+      }
+      if (toolUse.input.command) {
+        inputSummary = toolUse.input.command;
+      }
+    }
+    if (!inputSummary) inputSummary = toolUse.inputPreview || '';
+
+    var inputDetail = '';
+    if (toolUse.input && typeof toolUse.input === 'object') {
+      if (toolUse.input.new_string || toolUse.input.content) {
+        var content = toolUse.input.new_string || toolUse.input.content || '';
+        if (content.length > 500) content = content.slice(0, 500) + '... (truncated)';
+        inputDetail = '<div class="tool-input-label">Changes</div>' +
+          '<div class="tool-input-content">' + escapeForMd(content) + '</div>';
+      }
+      if (toolUse.input.old_string && toolUse.input.new_string) {
+        var oldStr = toolUse.input.old_string;
+        var newStr = toolUse.input.new_string;
+        if (oldStr.length > 300) oldStr = oldStr.slice(0, 300) + '...';
+        if (newStr.length > 300) newStr = newStr.slice(0, 300) + '...';
+        inputDetail = '<div class="tool-input-label">Replace</div>' +
+          '<div class="tool-input-content tool-diff-old">' + escapeForMd(oldStr) + '</div>' +
+          '<div class="tool-input-label">With</div>' +
+          '<div class="tool-input-content tool-diff-new">' + escapeForMd(newStr) + '</div>';
+      }
+    }
+
+    var isFileTool = inputSummary && !toolUse.input?.command;
+    var fileLink = isFileTool
+      ? '<a class="file-link" data-filepath="' + escapeForMd(inputSummary) + '" title="Open in editor">' + escapeForMd(inputSummary.split(/[\\/]/).pop() || inputSummary) + '</a>'
+      : (inputSummary ? escapeForMd(inputSummary.split(/[\\/]/).pop() || inputSummary) : '');
+    var pathDisplay = isFileTool
+      ? '<div class="tool-input-label">Path</div><div class="tool-input-content"><a class="file-link" data-filepath="' + escapeForMd(inputSummary) + '" title="Open in editor">' + escapeForMd(inputSummary) + '</a></div>'
+      : (inputSummary ? '<div class="tool-input-label">' + (toolUse.input?.command ? 'Command' : 'Path') + '</div><div class="tool-input-content">' + escapeForMd(inputSummary) + '</div>' : '');
+
+    card.innerHTML =
+      '<div class="tool-header">' +
+        '<span class="tool-icon">' + (toolUse.icon || '') + '</span>' +
+        '<span class="tool-name">' + escapeForMd(toolUse.displayName || toolUse.name || 'Tool') +
+          (fileLink ? ' <span class="tool-path">' + fileLink + '</span>' : '') +
+        '</span>' +
+        '<span class="tool-status ' + statusClass + '">' + statusLabel + '</span>' +
+        '<span class="tool-chevron">&#9654;</span>' +
+      '</div>' +
+      '<div class="tool-body">' +
+        pathDisplay +
+        inputDetail +
+        '<div class="tool-output-label">Output</div>' +
+        '<div class="tool-output-content" data-tool-output="' + (toolUse.id || '') + '">Running...</div>' +
+      '</div>';
+    card.querySelector('.tool-header').addEventListener('click', () => {
+      card.classList.toggle('expanded');
+    });
+    container.appendChild(card);
+    scrollToBottom();
+    return card;
+  }
+
+  function updateToolResult(toolUseId, content, isError) {
+    const outputEl = document.querySelector('[data-tool-output="' + toolUseId + '"]');
+    if (outputEl) {
+      outputEl.textContent = content || '(done)';
+      if (isError) outputEl.classList.add('error');
+    }
+    const card = document.querySelector('[data-tool-id="' + toolUseId + '"]');
+    if (card) {
+      const statusEl = card.querySelector('.tool-status');
+      if (statusEl) {
+        statusEl.className = 'tool-status ' + (isError ? 'error' : 'complete');
+        statusEl.textContent = isError ? 'Error' : 'Done';
+      }
+    }
+  }
+
+  function updateToolProgress(toolUseId, content) {
+    const outputEl = document.querySelector('[data-tool-output="' + toolUseId + '"]');
+    if (outputEl && (outputEl.textContent === 'Waiting...' || outputEl.textContent === 'Running...')) {
+      outputEl.textContent = content || '';
+    }
+  }
+
+  function updateToolInput(toolUseId, input, toolName) {
+    const card = document.querySelector('[data-tool-id="' + toolUseId + '"]');
+    if (!card) return;
+    const body = card.querySelector('.tool-body');
+    if (!body) return;
+
+    if (!input || typeof input !== 'object') return;
+
+    // Update the header with clickable file path
+    const nameEl = card.querySelector('.tool-name');
+    if (nameEl && (input.file_path || input.path)) {
+      const fp = input.file_path || input.path;
+      const shortName = fp.split(/[\\/]/).pop() || fp;
+      if (!nameEl.querySelector('.tool-path')) {
+        nameEl.insertAdjacentHTML('beforeend', ' <span class="tool-path"><a class="file-link" data-filepath="' + escapeForMd(fp) + '" title="Open in editor">' + escapeForMd(shortName) + '</a></span>');
+      }
+    }
+
+    // Update path display
+    var pathHtml = '';
+    if (input.file_path || input.path) {
+      var fp = input.file_path || input.path;
+      pathHtml = '<div class="tool-input-label">Path</div><div class="tool-input-content">' +
+        '<a class="file-link" data-filepath="' + escapeForMd(fp) + '" title="Open in editor">' + escapeForMd(fp) + '</a></div>';
+    }
+    if (input.command) {
+      pathHtml = '<div class="tool-input-label">Command</div><div class="tool-input-content">' +
+        escapeForMd(input.command) + '</div>';
+    }
+
+    // Build diff display for edit operations
+    var diffHtml = '';
+    if (input.old_string && input.new_string) {
+      var oldStr = input.old_string;
+      var newStr = input.new_string;
+      if (oldStr.length > 500) oldStr = oldStr.slice(0, 500) + '... (truncated)';
+      if (newStr.length > 500) newStr = newStr.slice(0, 500) + '... (truncated)';
+      diffHtml = '<div class="tool-input-label">Replace</div>' +
+        '<div class="tool-input-content tool-diff-old">' + escapeForMd(oldStr) + '</div>' +
+        '<div class="tool-input-label">With</div>' +
+        '<div class="tool-input-content tool-diff-new">' + escapeForMd(newStr) + '</div>';
+    } else if (input.content || input.new_string) {
+      var content = input.content || input.new_string || '';
+      if (content.length > 800) content = content.slice(0, 800) + '... (truncated)';
+      diffHtml = '<div class="tool-input-label">Content</div>' +
+        '<div class="tool-input-content tool-diff-new">' + escapeForMd(content) + '</div>';
+    }
+
+    // Keep the output element
+    const outputEl = body.querySelector('[data-tool-output]');
+    const outputHtml = outputEl ? outputEl.outerHTML : '';
+    const outputLabel = '<div class="tool-output-label">Output</div>';
+
+    body.innerHTML = pathHtml + diffHtml + outputLabel + outputHtml;
+    card.classList.add('expanded');
+    scrollToBottom();
+  }
+
+  function appendPermissionCard(perm) {
+    hideWelcome();
+    const el = document.createElement('div');
+    el.className = 'perm-card';
+    el.dataset.requestId = perm.requestId || '';
+    el.innerHTML =
+      '<div class="perm-title">Permission Required: ' + escapeForMd(perm.displayName || perm.toolName || 'Tool') + '</div>' +
+      (perm.description ? '<div class="perm-desc">' + escapeForMd(perm.description) + '</div>' : '') +
+      (perm.inputPreview ? '<div class="perm-input">' + escapeForMd(perm.inputPreview) + '</div>' : '') +
+      '<div class="perm-actions">' +
+        '<button class="perm-btn allow" data-action="allow">Allow</button>' +
+        '<button class="perm-btn deny" data-action="deny">Deny</button>' +
+        '<button class="perm-btn allow-session" data-action="allow-session">Allow for session</button>' +
+      '</div>';
+    el.querySelectorAll('.perm-btn').forEach(btn => {
+      btn.addEventListener('click', () => {
+        const action = btn.dataset.action;
+        vscode.postMessage({
+          type: 'permission_response',
+          requestId: perm.requestId,
+          toolUseId: perm.toolUseId || null,
+          action: action,
+        });
+        el.querySelectorAll('.perm-btn').forEach(b => { b.disabled = true; b.style.opacity = '0.4'; });
+        btn.style.opacity = '1';
+      });
+    });
+    messagesEl.appendChild(el);
+    scrollToBottom();
+  }
+
+  function appendStatusMessage(text) {
+    const el = document.createElement('div');
+    el.className = 'msg-status';
+    el.textContent = text;
+    messagesEl.appendChild(el);
+    scrollToBottom();
+  }
+
+  function appendRateLimitMessage(text) {
+    const el = document.createElement('div');
+    el.className = 'msg-rate-limit';
+    el.textContent = text;
+    messagesEl.appendChild(el);
+    scrollToBottom();
+  }
+
+  /* ── Thinking block ── */
+  const thinkingBlock = document.getElementById('thinkingBlock');
+  const thinkingLabel = document.getElementById('thinkingLabel');
+  const thinkingMeta = document.getElementById('thinkingMeta');
+
+  function showThinkingBlock() {
+    thinkingBlock.classList.add('visible');
+    thinkingLabel.textContent = 'Thinking...';
+    thinkingMeta.textContent = '';
+    setStatusLabel('Thinking...');
+    scrollToBottom();
+  }
+
+  function updateThinkingBlock(tokens, elapsed) {
+    const elapsedStr = elapsed >= 60
+      ? Math.floor(elapsed / 60) + 'm ' + (elapsed % 60) + 's'
+      : elapsed + 's';
+    thinkingLabel.textContent = 'Thinking...';
+    thinkingMeta.textContent = elapsedStr + ' · ~' + tokens + ' tokens';
+    setStatusLabel('Thinking... (' + elapsedStr + ')');
+  }
+
+  function hideThinkingBlock() {
+    thinkingBlock.classList.remove('visible');
+    setStatusLabel('Generating...');
+  }
+
+  /* ── Session list ── */
+  function renderSessionList(sessions) {
+    if (!sessions || sessions.length === 0) {
+      sessionList.innerHTML = '<div class="session-empty">No sessions found</div>';
+      return;
+    }
+    const groups = groupByDate(sessions);
+    let html = '';
+    for (const [label, items] of groups) {
+      html += '<div class="session-group-label">' + escapeForMd(label) + '</div>';
+      for (const s of items) {
+        html += '<div class="session-item" data-session-id="' + (s.id || '') + '">' +
+          '<div class="session-item-title">' + escapeForMd(s.title || s.id || 'Untitled') + '</div>' +
+          '<div class="session-item-preview">' + escapeForMd(s.preview || '') + '</div>' +
+          '<div class="session-item-time">' + escapeForMd(s.timeLabel || '') + '</div>' +
+        '</div>';
+      }
+    }
+    sessionList.innerHTML = html;
+    sessionList.querySelectorAll('.session-item').forEach(el => {
+      el.addEventListener('click', () => {
+        vscode.postMessage({ type: 'resume_session', sessionId: el.dataset.sessionId });
+        sessionOverlay.classList.remove('visible');
+      });
+    });
+  }
+
+  function groupByDate(sessions) {
+    const now = new Date();
+    const today = new Date(now.getFullYear(), now.getMonth(), now.getDate()).getTime();
+    const yesterday = today - 86400000;
+    const weekAgo = today - 604800000;
+    const groups = new Map();
+    for (const s of sessions) {
+      const t = s.timestamp || 0;
+      let label;
+      if (t >= today) label = 'Today';
+      else if (t >= yesterday) label = 'Yesterday';
+      else if (t >= weekAgo) label = 'This Week';
+      else label = 'Older';
+      if (!groups.has(label)) groups.set(label, []);
+      groups.get(label).push(s);
+    }
+    return groups;
+  }
+
+  /* ── Input handling ── */
+  function sendMessage() {
+    const text = inputEl.value.trim();
+    if (!text || isStreaming) return;
+    appendUserMessage(text);
+    vscode.postMessage({ type: 'send_message', text });
+    inputEl.value = '';
+    autoResizeInput();
+    setStreaming(true);
+  }
+
+  function autoResizeInput() {
+    inputEl.style.height = 'auto';
+    inputEl.style.height = Math.min(inputEl.scrollHeight, 160) + 'px';
+  }
+
+  inputEl.addEventListener('input', autoResizeInput);
+  inputEl.addEventListener('keydown', (e) => {
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault();
+      sendMessage();
+    }
+  });
+  sendBtn.addEventListener('click', sendMessage);
+  abortBtn.addEventListener('click', () => vscode.postMessage({ type: 'abort' }));
+  newChatBtn.addEventListener('click', () => vscode.postMessage({ type: 'new_session' }));
+  historyBtn.addEventListener('click', () => {
+    sessionOverlay.classList.toggle('visible');
+    if (sessionOverlay.classList.contains('visible')) {
+      vscode.postMessage({ type: 'request_sessions' });
+      sessionSearch.focus();
+    }
+  });
+  closeSessionsBtn.addEventListener('click', () => sessionOverlay.classList.remove('visible'));
+  sessionSearch.addEventListener('input', () => {
+    const q = sessionSearch.value.toLowerCase();
+    sessionList.querySelectorAll('.session-item').forEach(el => {
+      const text = el.textContent.toLowerCase();
+      el.style.display = text.includes(q) ? '' : 'none';
+    });
+  });
+
+  // Copy code handler (event delegation)
+  document.addEventListener('click', (e) => {
+    const copyBtn = e.target.closest('.code-copy-btn');
+    if (copyBtn) {
+      const id = copyBtn.dataset.copyId;
+      const codeEl = document.getElementById(id);
+      if (codeEl) {
+        const text = codeEl.textContent;
+        vscode.postMessage({ type: 'copy_code', text });
+        copyBtn.textContent = 'Copied!';
+        setTimeout(() => { copyBtn.textContent = 'Copy'; }, 1500);
+      }
+      return;
+    }
+
+    const fileLink = e.target.closest('.file-link');
+    if (fileLink) {
+      e.preventDefault();
+      e.stopPropagation();
+      const filepath = fileLink.dataset.filepath;
+      if (filepath) {
+        vscode.postMessage({ type: 'open_file', path: filepath });
+      }
+      return;
+    }
+  });
+
+  /* ── Message handling from extension ── */
+  window.addEventListener('message', (event) => {
+    const msg = event.data;
+    if (!msg) return;
+
+    switch (msg.type) {
+      case 'stream_start':
+        setStreaming(true, 'Generating...');
+        getOrCreateAssistantEl();
+        break;
+
+      case 'stream_delta': {
+        setStatusLabel('Generating...');
+        const { textEl } = getOrCreateAssistantEl();
+        textEl.innerHTML = renderMarkdown(msg.text || '');
+        scrollToBottom();
+        break;
+      }
+
+      case 'stream_end':
+        if (msg.text) {
+          const { textEl } = getOrCreateAssistantEl();
+          textEl.innerHTML = renderMarkdown(msg.text);
+        }
+        finalizeAssistant();
+        if (msg.usage) {
+          const u = msg.usage;
+          statusUsage.textContent = (u.input_tokens || 0) + ' in / ' + (u.output_tokens || 0) + ' out';
+        }
+        if (msg.final) {
+          setStreaming(false);
+        }
+        scrollToBottom();
+        break;
+
+      case 'tool_use':
+        appendToolCard(msg.toolUse);
+        setStatusLabel('Running: ' + (msg.toolUse.displayName || msg.toolUse.name || 'tool') + '...');
+        break;
+
+      case 'tool_result':
+        updateToolResult(msg.toolUseId, msg.content, msg.isError);
+        break;
+
+      case 'tool_input_ready':
+        updateToolInput(msg.toolUseId, msg.input, msg.name);
+        break;
+
+      case 'tool_progress':
+        updateToolProgress(msg.toolUseId, msg.content);
+        break;
+
+      case 'permission_request':
+        appendPermissionCard(msg);
+        break;
+
+      case 'status':
+        setStatusLabel(msg.content || 'Working...');
+        break;
+
+      case 'rate_limit':
+        appendRateLimitMessage(msg.message || 'Rate limited');
+        break;
+
+      case 'thinking_start':
+        showThinkingBlock();
+        break;
+
+      case 'thinking_delta':
+        updateThinkingBlock(msg.tokens || 0, msg.elapsed || 0);
+        break;
+
+      case 'thinking_end':
+        hideThinkingBlock();
+        break;
+
+      case 'system_info':
+        if (msg.model) {
+          statusUsage.textContent = msg.model;
+        }
+        break;
+
+      case 'error':
+        setStreaming(false);
+        finalizeAssistant();
+        statusDot.className = 'status-dot error';
+        statusText.textContent = 'Error: ' + (msg.message || 'Unknown error');
+        break;
+
+      case 'session_list':
+        renderSessionList(msg.sessions);
+        break;
+
+      case 'session_cleared':
+        messagesEl.innerHTML = '';
+        if (welcomeEl) {
+          messagesEl.appendChild(welcomeEl);
+          showWelcome();
+        }
+        currentAssistantEl = null;
+        currentTextEl = null;
+        statusUsage.textContent = '';
+        statusDot.className = 'status-dot connected';
+        statusText.textContent = 'Ready';
+        break;
+
+      case 'restore_messages':
+        hideWelcome();
+        if (msg.messages) {
+          for (const m of msg.messages) {
+            if (m.role === 'user') {
+              appendUserMessage(m.text || '');
+            } else if (m.role === 'assistant') {
+              const { textEl } = getOrCreateAssistantEl();
+              textEl.innerHTML = renderMarkdown(m.text || '');
+              if (m.toolUses && m.toolUses.length > 0) {
+                for (const tu of m.toolUses) {
+                  var displayName = tu.name || 'Tool';
+                  var icon = '';
+                  var inputPreview = '';
+                  if (tu.input && typeof tu.input === 'object') {
+                    inputPreview = tu.input.file_path || tu.input.path || tu.input.command || '';
+                  }
+                  var card = appendToolCard({
+                    id: tu.id,
+                    name: tu.name,
+                    displayName: displayName,
+                    icon: icon,
+                    inputPreview: inputPreview,
+                    input: tu.input,
+                    status: tu.status || 'complete',
+                  });
+                  if (tu.input) {
+                    updateToolInput(String(tu.id), tu.input, tu.name);
+                  }
+                  if (tu.result !== undefined && tu.result !== null) {
+                    updateToolResult(String(tu.id), tu.result, tu.isError || false);
+                  } else {
+                    updateToolResult(String(tu.id), '(done)', false);
+                  }
+                }
+              }
+              finalizeAssistant();
+            }
+          }
+        }
+        scrollToBottom();
+        break;
+
+      case 'connected':
+        setStreaming(false);
+        statusDot.className = 'status-dot connected';
+        statusText.textContent = msg.message || 'Connected';
+        break;
+
+      default:
+        break;
+    }
+  });
+
+  // Focus input on Ctrl/Cmd+L
+  document.addEventListener('keydown', (e) => {
+    if ((e.ctrlKey || e.metaKey) && e.key === 'l') {
+      e.preventDefault();
+      inputEl.focus();
+    }
+  });
+
+  // Restore state
+  const prevState = vscode.getState();
+  if (prevState && prevState.hasMessages) {
+    vscode.postMessage({ type: 'restore_request' });
+  }
+
+  // Notify ready
+  vscode.postMessage({ type: 'webview_ready' });
+})();
+</script>
+</body>
+</html>`;
+}
+
+module.exports = { renderChatHtml };

--- a/vscode-extension/openclaude-vscode/src/chat/diffController.js
+++ b/vscode-extension/openclaude-vscode/src/chat/diffController.js
@@ -1,0 +1,90 @@
+/**
+ * diffController — provides a TextDocumentContentProvider for virtual
+ * diff documents and helpers to open VS Code's native diff editor when
+ * tool use involves file edits.
+ */
+
+const vscode = require('vscode');
+
+const SCHEME = 'openclaude-diff';
+let contentStore = new Map();
+
+class DiffContentProvider {
+  constructor() {
+    this._onDidChange = new vscode.EventEmitter();
+    this.onDidChange = this._onDidChange.event;
+  }
+
+  provideTextDocumentContent(uri) {
+    return contentStore.get(uri.toString()) || '';
+  }
+
+  update(uri) {
+    this._onDidChange.fire(uri);
+  }
+
+  dispose() {
+    this._onDidChange.dispose();
+  }
+}
+
+function storeContent(id, content) {
+  const uri = vscode.Uri.parse(`${SCHEME}:/${id}`);
+  contentStore.set(uri.toString(), content);
+  return uri;
+}
+
+function clearContent(id) {
+  const uri = vscode.Uri.parse(`${SCHEME}:/${id}`);
+  contentStore.delete(uri.toString());
+}
+
+function clearAll() {
+  contentStore.clear();
+}
+
+/**
+ * Opens a diff view between original and modified content.
+ * @param {object} opts
+ * @param {string} opts.filePath - Display path (for the title)
+ * @param {string} opts.original - Original file content
+ * @param {string} opts.modified - Modified file content
+ * @param {string} [opts.toolUseId] - Unique ID for this diff
+ */
+async function openDiff({ filePath, original, modified, toolUseId }) {
+  const id = toolUseId || Math.random().toString(36).slice(2, 10);
+  const originalUri = storeContent(`original-${id}`, original || '');
+  const modifiedUri = storeContent(`modified-${id}`, modified || '');
+  const shortName = filePath ? filePath.split(/[\\/]/).pop() : 'file';
+  const title = `${shortName} (OpenClaude Diff)`;
+
+  await vscode.commands.executeCommand('vscode.diff', originalUri, modifiedUri, title);
+}
+
+/**
+ * Opens a diff between a real file on disk and modified content from
+ * a tool use result.
+ * @param {object} opts
+ * @param {string} opts.filePath - Absolute path to the real file
+ * @param {string} opts.modified - Modified content
+ * @param {string} [opts.toolUseId]
+ */
+async function openFileDiff({ filePath, modified, toolUseId }) {
+  const id = toolUseId || Math.random().toString(36).slice(2, 10);
+  const fileUri = vscode.Uri.file(filePath);
+  const modifiedUri = storeContent(`modified-${id}`, modified || '');
+  const shortName = filePath.split(/[\\/]/).pop() || 'file';
+  const title = `${shortName} (OpenClaude Edit)`;
+
+  await vscode.commands.executeCommand('vscode.diff', fileUri, modifiedUri, title);
+}
+
+module.exports = {
+  DiffContentProvider,
+  SCHEME,
+  openDiff,
+  openFileDiff,
+  storeContent,
+  clearContent,
+  clearAll,
+};

--- a/vscode-extension/openclaude-vscode/src/chat/messageParser.js
+++ b/vscode-extension/openclaude-vscode/src/chat/messageParser.js
@@ -1,0 +1,177 @@
+/**
+ * messageParser — transforms raw SDK messages from the CLI into view-model
+ * objects that the chat renderer can display.
+ */
+
+const {
+  isAssistantMessage,
+  isPartialMessage,
+  isResultMessage,
+  isControlRequest,
+  isStatusMessage,
+  isToolProgressMessage,
+  isSessionStateChanged,
+  isRateLimitEvent,
+  getTextContent,
+  getToolUseBlocks,
+} = require('./protocol');
+
+function parseToolInput(input) {
+  if (!input || typeof input !== 'object') return String(input ?? '');
+  if (input.command) return input.command;
+  if (input.file_path || input.path) return input.file_path || input.path;
+  if (input.query) return input.query;
+  try { return JSON.stringify(input, null, 2); } catch { return String(input); }
+}
+
+function toolDisplayName(name) {
+  const map = {
+    Bash: 'Terminal',
+    Read: 'Read File',
+    Write: 'Write File',
+    Edit: 'Edit File',
+    MultiEdit: 'Multi Edit',
+    Glob: 'Find Files',
+    Grep: 'Search',
+    LS: 'List Directory',
+    WebFetch: 'Web Fetch',
+    WebSearch: 'Web Search',
+    TodoRead: 'Read Todos',
+    TodoWrite: 'Write Todos',
+    Task: 'Sub-agent',
+  };
+  return map[name] || name || 'Tool';
+}
+
+function toolIcon(name) {
+  const map = {
+    Bash: '\u{1F4BB}',
+    Read: '\u{1F4C4}',
+    Write: '\u{270F}\uFE0F',
+    Edit: '\u{270F}\uFE0F',
+    MultiEdit: '\u{270F}\uFE0F',
+    Glob: '\u{1F50D}',
+    Grep: '\u{1F50E}',
+    LS: '\u{1F4C2}',
+    WebFetch: '\u{1F310}',
+    WebSearch: '\u{1F310}',
+    Task: '\u{1F916}',
+  };
+  return map[name] || '\u{1F527}';
+}
+
+/**
+ * Converts an SDK message into one or more view-model entries for the chat UI.
+ * Returns an array so partial messages can update in-place while final messages
+ * produce a finalized entry.
+ */
+function toViewModel(msg) {
+  if (isAssistantMessage(msg)) {
+    return [{
+      kind: 'assistant',
+      id: msg.id || msg.message?.id || null,
+      text: getTextContent(msg.message || msg),
+      toolUses: getToolUseBlocks(msg.message || msg).map(tu => ({
+        id: tu.id,
+        name: tu.name,
+        displayName: toolDisplayName(tu.name),
+        icon: toolIcon(tu.name),
+        inputPreview: parseToolInput(tu.input),
+        input: tu.input,
+        status: 'complete',
+      })),
+      model: msg.model || null,
+      stopReason: msg.stop_reason || null,
+      usage: msg.usage || null,
+      final: true,
+    }];
+  }
+
+  if (isPartialMessage(msg)) {
+    const inner = msg.message || msg;
+    return [{
+      kind: 'assistant_partial',
+      id: inner.id || null,
+      text: getTextContent(inner),
+      toolUses: getToolUseBlocks(inner).map(tu => ({
+        id: tu.id,
+        name: tu.name,
+        displayName: toolDisplayName(tu.name),
+        icon: toolIcon(tu.name),
+        inputPreview: parseToolInput(tu.input),
+        input: tu.input,
+        status: 'running',
+      })),
+      final: false,
+    }];
+  }
+
+  if (isResultMessage(msg)) {
+    return [{
+      kind: 'tool_result',
+      toolUseId: msg.tool_use_id,
+      content: typeof msg.content === 'string'
+        ? msg.content
+        : Array.isArray(msg.content)
+          ? msg.content.map(b => b.text || '').join('')
+          : '',
+      isError: msg.is_error || false,
+    }];
+  }
+
+  if (isControlRequest(msg)) {
+    return [{
+      kind: 'permission_request',
+      requestId: msg.request_id || msg.id,
+      toolName: msg.tool_name || msg.tool?.name || 'Unknown',
+      displayName: toolDisplayName(msg.tool_name || msg.tool?.name),
+      description: msg.description || msg.tool?.description || '',
+      input: msg.tool_input || msg.input || null,
+      inputPreview: parseToolInput(msg.tool_input || msg.input),
+    }];
+  }
+
+  if (isToolProgressMessage(msg)) {
+    return [{
+      kind: 'tool_progress',
+      toolUseId: msg.tool_use_id,
+      content: msg.content || msg.progress || '',
+    }];
+  }
+
+  if (isStatusMessage(msg)) {
+    return [{
+      kind: 'status',
+      content: msg.content || msg.message || '',
+    }];
+  }
+
+  if (isSessionStateChanged(msg)) {
+    return [{
+      kind: 'session_state',
+      sessionId: msg.session_id || null,
+      state: msg.state || null,
+    }];
+  }
+
+  if (isRateLimitEvent(msg)) {
+    return [{
+      kind: 'rate_limit',
+      retryAfter: msg.retry_after || null,
+      message: msg.message || 'Rate limited',
+    }];
+  }
+
+  return [{
+    kind: 'unknown',
+    type: msg.type,
+    raw: msg,
+  }];
+}
+
+module.exports = {
+  toViewModel,
+  toolDisplayName,
+  toolIcon,
+  parseToolInput,
+};

--- a/vscode-extension/openclaude-vscode/src/chat/processManager.js
+++ b/vscode-extension/openclaude-vscode/src/chat/processManager.js
@@ -1,0 +1,194 @@
+/**
+ * ProcessManager — spawns OpenClaude in print/SDK mode and manages the
+ * NDJSON stdin/stdout lifecycle.
+ *
+ * Usage:
+ *   const pm = new ProcessManager({ command, cwd, env });
+ *   pm.onMessage(msg => { ... });
+ *   pm.onError(err => { ... });
+ *   pm.onExit(code => { ... });
+ *   await pm.start();
+ *   pm.sendUserMessage('Hello');
+ *   pm.abort();          // SIGINT (graceful)
+ *   pm.kill();           // SIGTERM (hard)
+ *   pm.dispose();
+ */
+
+const { spawn } = require('child_process');
+const vscode = require('vscode');
+const { parseStdoutLine, serializeStdinMessage, buildUserMessage, buildControlResponse } = require('./protocol');
+
+class ProcessManager {
+  /**
+   * @param {object} opts
+   * @param {string} opts.command - The openclaude binary (e.g. 'openclaude')
+   * @param {string} [opts.cwd] - Working directory
+   * @param {Record<string,string>} [opts.env] - Extra env vars
+   * @param {string} [opts.sessionId] - Session to resume
+   * @param {boolean} [opts.continueSession] - Use --continue instead of --resume
+   * @param {string} [opts.model] - Model override
+   * @param {string[]} [opts.extraArgs] - Additional CLI flags
+   */
+  constructor(opts) {
+    this._command = opts.command || 'openclaude';
+    this._cwd = opts.cwd || undefined;
+    this._env = opts.env || {};
+    this._sessionId = opts.sessionId || null;
+    this._continueSession = opts.continueSession || false;
+    this._model = opts.model || null;
+    this._permissionMode = opts.permissionMode || 'acceptEdits';
+    this._extraArgs = opts.extraArgs || [];
+    this._process = null;
+    this._buffer = '';
+    this._disposed = false;
+
+    this._onMessageEmitter = new vscode.EventEmitter();
+    this._onErrorEmitter = new vscode.EventEmitter();
+    this._onExitEmitter = new vscode.EventEmitter();
+    this.onMessage = this._onMessageEmitter.event;
+    this.onError = this._onErrorEmitter.event;
+    this.onExit = this._onExitEmitter.event;
+  }
+
+  get running() {
+    return this._process !== null && !this._process.killed;
+  }
+
+  get sessionId() {
+    return this._sessionId;
+  }
+
+  start() {
+    if (this._disposed) throw new Error('ProcessManager is disposed');
+    if (this._process) throw new Error('Process already started');
+
+    const args = [
+      '--print',
+      '--verbose',
+      '--input-format=stream-json',
+      '--output-format=stream-json',
+      '--include-partial-messages',
+      '--permission-mode', this._permissionMode || 'acceptEdits',
+    ];
+
+    if (this._sessionId) {
+      args.push('--resume', this._sessionId);
+    } else if (this._continueSession) {
+      args.push('--continue');
+    }
+
+    if (this._model) {
+      args.push('--model', this._model);
+    }
+
+    args.push(...this._extraArgs);
+
+    const spawnEnv = { ...process.env, ...this._env };
+    const isWin = process.platform === 'win32';
+
+    if (isWin) {
+      // On Windows, npm global installs create .cmd shims that spawn()
+      // cannot find without a shell.  Build one command string so the
+      // deprecation warning about unsanitised args does not fire.
+      const cmdLine = [this._command, ...args].join(' ');
+      this._process = spawn(cmdLine, [], {
+        cwd: this._cwd,
+        env: spawnEnv,
+        stdio: ['pipe', 'pipe', 'pipe'],
+        shell: true,
+        windowsHide: true,
+      });
+    } else {
+      this._process = spawn(this._command, args, {
+        cwd: this._cwd,
+        env: spawnEnv,
+        stdio: ['pipe', 'pipe', 'pipe'],
+        windowsHide: true,
+      });
+    }
+
+    this._process.stdout.setEncoding('utf8');
+    this._process.stderr.setEncoding('utf8');
+
+    this._process.stdout.on('data', (chunk) => this._onData(chunk));
+    this._process.stderr.on('data', (chunk) => this._onStderr(chunk));
+    this._process.on('error', (err) => this._onErrorEmitter.fire(err));
+    this._process.on('close', (code, signal) => {
+      this._process = null;
+      this._onExitEmitter.fire({ code, signal });
+    });
+  }
+
+  _onData(chunk) {
+    this._buffer += chunk;
+    const lines = this._buffer.split('\n');
+    this._buffer = lines.pop() || '';
+
+    for (const line of lines) {
+      const msg = parseStdoutLine(line);
+      if (msg) {
+        this._extractSessionId(msg);
+        this._onMessageEmitter.fire(msg);
+      }
+    }
+  }
+
+  _extractSessionId(msg) {
+    if (msg.session_id && !this._sessionId) {
+      this._sessionId = msg.session_id;
+    }
+  }
+
+  _onStderr(chunk) {
+    const trimmed = chunk.trim();
+    if (!trimmed) return;
+    // Suppress common non-error noise from the CLI (deprecation warnings, etc.)
+    if (/^\(node:\d+\)|^DeprecationWarning|^ExperimentalWarning/i.test(trimmed)) return;
+    this._onErrorEmitter.fire(new Error(trimmed));
+  }
+
+  sendUserMessage(text) {
+    this._write(buildUserMessage(text));
+  }
+
+  sendControlResponse(requestId, result) {
+    this._write(buildControlResponse(requestId, result));
+  }
+
+  write(msg) {
+    if (!this._process || !this._process.stdin.writable) {
+      throw new Error('Process is not running');
+    }
+    this._process.stdin.write(serializeStdinMessage(msg));
+  }
+
+  _write(msg) {
+    this.write(msg);
+  }
+
+  abort() {
+    if (this._process && !this._process.killed) {
+      if (process.platform === 'win32') {
+        this._process.kill('SIGINT');
+      } else {
+        this._process.kill('SIGINT');
+      }
+    }
+  }
+
+  kill() {
+    if (this._process && !this._process.killed) {
+      this._process.kill('SIGTERM');
+    }
+  }
+
+  dispose() {
+    this._disposed = true;
+    this.kill();
+    this._onMessageEmitter.dispose();
+    this._onErrorEmitter.dispose();
+    this._onExitEmitter.dispose();
+  }
+}
+
+module.exports = { ProcessManager };

--- a/vscode-extension/openclaude-vscode/src/chat/protocol.js
+++ b/vscode-extension/openclaude-vscode/src/chat/protocol.js
@@ -1,0 +1,186 @@
+/**
+ * NDJSON protocol helpers and message type constants for the OpenClaude
+ * stream-json SDK wire format.
+ *
+ * The extension spawns `openclaude --print --input-format=stream-json
+ * --output-format=stream-json` and speaks NDJSON over stdin/stdout.
+ * This module provides lightweight parsing, serialization, and type guards
+ * so the rest of the extension never touches raw JSON strings.
+ */
+
+const MESSAGE_TYPES = {
+  ASSISTANT: 'assistant',
+  USER: 'user',
+  USER_REPLAY: 'user_replay',
+  RESULT: 'result',
+  SYSTEM: 'system',
+  STREAM_EVENT: 'stream_event',
+  PARTIAL: 'partial',
+  COMPACT_BOUNDARY: 'compact_boundary',
+  STATUS: 'status',
+  API_RETRY: 'api_retry',
+  LOCAL_COMMAND_OUTPUT: 'local_command_output',
+  HOOK_STARTED: 'hook_started',
+  HOOK_PROGRESS: 'hook_progress',
+  HOOK_RESPONSE: 'hook_response',
+  TOOL_PROGRESS: 'tool_progress',
+  AUTH_STATUS: 'auth_status',
+  TASK_NOTIFICATION: 'task_notification',
+  TASK_STARTED: 'task_started',
+  TASK_PROGRESS: 'task_progress',
+  SESSION_STATE_CHANGED: 'session_state_changed',
+  FILES_PERSISTED: 'files_persisted',
+  TOOL_USE_SUMMARY: 'tool_use_summary',
+  RATE_LIMIT: 'rate_limit',
+  ELICITATION_COMPLETE: 'elicitation_complete',
+  PROMPT_SUGGESTION: 'prompt_suggestion',
+  STREAMLINED_TEXT: 'streamlined_text',
+  STREAMLINED_TOOL_USE_SUMMARY: 'streamlined_tool_use_summary',
+  POST_TURN_SUMMARY: 'post_turn_summary',
+  CONTROL_RESPONSE: 'control_response',
+  CONTROL_REQUEST: 'control_request',
+};
+
+function parseStdoutLine(line) {
+  const trimmed = (line || '').trim();
+  if (!trimmed) return null;
+  try {
+    return JSON.parse(trimmed);
+  } catch {
+    return null;
+  }
+}
+
+function serializeStdinMessage(msg) {
+  return JSON.stringify(msg) + '\n';
+}
+
+function buildUserMessage(text) {
+  return {
+    type: 'user',
+    message: {
+      role: 'user',
+      content: text,
+    },
+    parent_tool_use_id: null,
+  };
+}
+
+function buildControlResponse(requestId, result) {
+  return {
+    type: 'control_response',
+    response: {
+      subtype: 'success',
+      request_id: requestId,
+      response: result || {},
+    },
+  };
+}
+
+function isAssistantMessage(msg) {
+  return msg && msg.type === MESSAGE_TYPES.ASSISTANT;
+}
+
+function isPartialMessage(msg) {
+  return msg && msg.type === MESSAGE_TYPES.PARTIAL;
+}
+
+function isStreamEvent(msg) {
+  return msg && msg.type === MESSAGE_TYPES.STREAM_EVENT && msg.event;
+}
+
+function isContentBlockDelta(msg) {
+  return isStreamEvent(msg) && msg.event.type === 'content_block_delta';
+}
+
+function isContentBlockStart(msg) {
+  return isStreamEvent(msg) && msg.event.type === 'content_block_start';
+}
+
+function isMessageStart(msg) {
+  return isStreamEvent(msg) && msg.event.type === 'message_start';
+}
+
+function isMessageStop(msg) {
+  return isStreamEvent(msg) && msg.event.type === 'message_stop';
+}
+
+function isMessageDelta(msg) {
+  return isStreamEvent(msg) && msg.event.type === 'message_delta';
+}
+
+function isResultMessage(msg) {
+  return msg && msg.type === MESSAGE_TYPES.RESULT;
+}
+
+function isToolUse(block) {
+  return block && block.type === 'tool_use';
+}
+
+function isTextBlock(block) {
+  return block && block.type === 'text';
+}
+
+function isThinkingBlock(block) {
+  return block && block.type === 'thinking';
+}
+
+function isControlRequest(msg) {
+  return msg && msg.type === MESSAGE_TYPES.CONTROL_REQUEST;
+}
+
+function isStatusMessage(msg) {
+  return msg && msg.type === MESSAGE_TYPES.STATUS;
+}
+
+function isToolProgressMessage(msg) {
+  return msg && msg.type === MESSAGE_TYPES.TOOL_PROGRESS;
+}
+
+function isSessionStateChanged(msg) {
+  return msg && msg.type === MESSAGE_TYPES.SESSION_STATE_CHANGED;
+}
+
+function isRateLimitEvent(msg) {
+  return msg && msg.type === MESSAGE_TYPES.RATE_LIMIT;
+}
+
+function getTextContent(message) {
+  if (!message || !Array.isArray(message.content)) return '';
+  return message.content
+    .filter(b => b.type === 'text')
+    .map(b => b.text || '')
+    .join('');
+}
+
+function getToolUseBlocks(message) {
+  if (!message || !Array.isArray(message.content)) return [];
+  return message.content.filter(b => b.type === 'tool_use');
+}
+
+module.exports = {
+  MESSAGE_TYPES,
+  parseStdoutLine,
+  serializeStdinMessage,
+  buildUserMessage,
+  buildControlResponse,
+  isAssistantMessage,
+  isPartialMessage,
+  isStreamEvent,
+  isContentBlockDelta,
+  isContentBlockStart,
+  isMessageStart,
+  isMessageStop,
+  isMessageDelta,
+  isResultMessage,
+  isToolUse,
+  isTextBlock,
+  isThinkingBlock,
+  isControlRequest,
+  isStatusMessage,
+  isToolProgressMessage,
+  isSessionStateChanged,
+  isRateLimitEvent,
+  getTextContent,
+  getToolUseBlocks,
+};

--- a/vscode-extension/openclaude-vscode/src/chat/sessionManager.js
+++ b/vscode-extension/openclaude-vscode/src/chat/sessionManager.js
@@ -1,0 +1,282 @@
+/**
+ * sessionManager — reads JSONL session history from disk, lists sessions,
+ * and provides metadata for the session list UI.
+ *
+ * Session files live under:
+ *   ~/.openclaude/projects/<sanitized-cwd>/<sessionId>.jsonl
+ *
+ * Falls back to ~/.claude/projects/ for legacy installs.
+ */
+
+const fs = require('fs');
+const fsp = require('fs/promises');
+const path = require('path');
+const os = require('os');
+const crypto = require('crypto');
+
+const MAX_SANITIZED_LENGTH = 80;
+
+function sanitizePath(name) {
+  const sanitized = name.replace(/[^a-zA-Z0-9]/g, '-');
+  if (sanitized.length <= MAX_SANITIZED_LENGTH) return sanitized;
+  const hash = simpleHash(name);
+  return sanitized.slice(0, MAX_SANITIZED_LENGTH) + '-' + hash;
+}
+
+function simpleHash(str) {
+  let h = 0;
+  for (let i = 0; i < str.length; i++) {
+    h = ((h << 5) - h + str.charCodeAt(i)) | 0;
+  }
+  return Math.abs(h).toString(36);
+}
+
+function resolveConfigDir() {
+  const envDir = process.env.CLAUDE_CONFIG_DIR;
+  if (envDir) return envDir;
+  const home = os.homedir();
+  const openClaudeDir = path.join(home, '.openclaude');
+  const legacyDir = path.join(home, '.claude');
+  if (!fs.existsSync(openClaudeDir) && fs.existsSync(legacyDir)) {
+    return legacyDir;
+  }
+  return openClaudeDir;
+}
+
+function getProjectsDir() {
+  return path.join(resolveConfigDir(), 'projects');
+}
+
+function getProjectDir(cwd) {
+  return path.join(getProjectsDir(), sanitizePath(cwd));
+}
+
+class SessionManager {
+  constructor() {
+    this._cwd = null;
+  }
+
+  setCwd(cwd) {
+    this._cwd = cwd;
+  }
+
+  async listSessions() {
+    const projectDir = this._cwd
+      ? getProjectDir(this._cwd)
+      : null;
+
+    const dirs = projectDir
+      ? [projectDir]
+      : await this._allProjectDirs();
+
+    const sessions = [];
+    for (const dir of dirs) {
+      const items = await this._readSessionDir(dir);
+      sessions.push(...items);
+    }
+
+    sessions.sort((a, b) => b.timestamp - a.timestamp);
+    return sessions;
+  }
+
+  async _allProjectDirs() {
+    const base = getProjectsDir();
+    if (!fs.existsSync(base)) return [];
+    try {
+      const entries = await fsp.readdir(base, { withFileTypes: true });
+      return entries
+        .filter(e => e.isDirectory())
+        .map(e => path.join(base, e.name));
+    } catch {
+      return [];
+    }
+  }
+
+  async _readSessionDir(dir) {
+    if (!fs.existsSync(dir)) return [];
+    try {
+      const files = await fsp.readdir(dir);
+      const jsonlFiles = files.filter(f => f.endsWith('.jsonl'));
+      const results = [];
+
+      for (const file of jsonlFiles) {
+        const filePath = path.join(dir, file);
+        try {
+          const meta = await this._extractSessionMeta(filePath);
+          if (meta) results.push(meta);
+        } catch { /* skip unreadable */ }
+      }
+
+      return results;
+    } catch {
+      return [];
+    }
+  }
+
+  async _extractSessionMeta(filePath) {
+    const sessionId = path.basename(filePath, '.jsonl');
+    const stat = await fsp.stat(filePath);
+    // Read a larger head because JSONL files often start with system/snapshot
+    // entries before the first user message.
+    const head = await this._readHead(filePath, 65536);
+    const lines = head.split('\n').filter(Boolean);
+
+    let title = null;
+    let preview = '';
+    let timestamp = stat.mtimeMs;
+    let firstTimestamp = null;
+
+    for (const line of lines) {
+      try {
+        const entry = JSON.parse(line);
+
+        if (!preview && entry.type === 'user' && entry.message) {
+          const content = entry.message.content;
+          if (typeof content === 'string') {
+            preview = content.slice(0, 120);
+          } else if (Array.isArray(content)) {
+            const textBlock = content.find(b => b.type === 'text');
+            preview = textBlock ? (textBlock.text || '').slice(0, 120) : '';
+          }
+        }
+
+        if (entry.type === 'custom-title' || entry.type === 'session-title') {
+          title = entry.title || entry.name || null;
+        }
+
+        if (entry.type === 'summary' && entry.summary && !title) {
+          title = entry.summary;
+        }
+
+        if (entry.timestamp && !firstTimestamp) {
+          const t = typeof entry.timestamp === 'number'
+            ? entry.timestamp
+            : new Date(entry.timestamp).getTime();
+          if (t && !isNaN(t)) firstTimestamp = t;
+        }
+      } catch { /* skip bad line */ }
+    }
+
+    if (firstTimestamp) timestamp = firstTimestamp;
+    const timeLabel = formatRelativeTime(timestamp);
+
+    return {
+      id: sessionId,
+      title: title || preview.slice(0, 60) || 'Untitled session',
+      preview: preview || '',
+      timestamp,
+      timeLabel,
+      filePath,
+    };
+  }
+
+  async loadSession(sessionId) {
+    const projectDir = this._cwd ? getProjectDir(this._cwd) : null;
+    const dirs = projectDir ? [projectDir] : await this._allProjectDirs();
+
+    for (const dir of dirs) {
+      const filePath = path.join(dir, `${sessionId}.jsonl`);
+      if (fs.existsSync(filePath)) {
+        return this._parseSessionFile(filePath);
+      }
+    }
+    return null;
+  }
+
+  async _parseSessionFile(filePath) {
+    const content = await fsp.readFile(filePath, 'utf8');
+    const lines = content.split('\n').filter(Boolean);
+    const messages = [];
+    const toolResults = new Map();
+
+    // First pass: collect tool results from user messages
+    for (const line of lines) {
+      try {
+        const entry = JSON.parse(line);
+        if (entry.type === 'user' && entry.message && Array.isArray(entry.message.content)) {
+          for (const block of entry.message.content) {
+            if (block.type === 'tool_result' && block.tool_use_id) {
+              const resultText = typeof block.content === 'string'
+                ? block.content
+                : Array.isArray(block.content)
+                  ? block.content.map(b => b.text || '').join('')
+                  : '';
+              toolResults.set(String(block.tool_use_id), {
+                content: resultText.slice(0, 2000),
+                isError: block.is_error || false,
+              });
+            }
+          }
+        }
+      } catch { /* skip */ }
+    }
+
+    // Second pass: build messages with tool use details
+    for (const line of lines) {
+      try {
+        const entry = JSON.parse(line);
+        if (entry.type === 'user' && entry.message) {
+          const c = entry.message.content;
+          // Skip tool result messages (they're user messages with tool_result blocks)
+          if (Array.isArray(c) && c.length > 0 && c[0].type === 'tool_result') continue;
+          const text = typeof c === 'string'
+            ? c
+            : Array.isArray(c)
+              ? c.filter(b => b.type === 'text').map(b => b.text).join('')
+              : '';
+          if (text) messages.push({ role: 'user', text });
+        } else if (entry.type === 'assistant' && entry.message) {
+          const c = entry.message.content;
+          const text = typeof c === 'string'
+            ? c
+            : Array.isArray(c)
+              ? c.filter(b => b.type === 'text').map(b => b.text).join('')
+              : '';
+          const toolUses = Array.isArray(c)
+            ? c.filter(b => b.type === 'tool_use').map(tu => {
+                const result = toolResults.get(String(tu.id));
+                return {
+                  id: tu.id,
+                  name: tu.name,
+                  input: tu.input || null,
+                  status: result ? (result.isError ? 'error' : 'complete') : 'complete',
+                  result: result ? result.content : null,
+                  isError: result ? result.isError : false,
+                };
+              })
+            : [];
+          messages.push({ role: 'assistant', text, toolUses });
+        }
+      } catch { /* skip */ }
+    }
+
+    return messages;
+  }
+
+  async _readHead(filePath, bytes) {
+    const fd = await fsp.open(filePath, 'r');
+    try {
+      const buf = Buffer.alloc(bytes);
+      const { bytesRead } = await fd.read(buf, 0, bytes, 0);
+      return buf.slice(0, bytesRead).toString('utf8');
+    } finally {
+      await fd.close();
+    }
+  }
+}
+
+function formatRelativeTime(ts) {
+  const now = Date.now();
+  const diff = now - ts;
+  const mins = Math.floor(diff / 60000);
+  if (mins < 1) return 'Just now';
+  if (mins < 60) return `${mins}m ago`;
+  const hours = Math.floor(mins / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  if (days < 7) return `${days}d ago`;
+  const date = new Date(ts);
+  return date.toLocaleDateString();
+}
+
+module.exports = { SessionManager };

--- a/vscode-extension/openclaude-vscode/src/extension.js
+++ b/vscode-extension/openclaude-vscode/src/extension.js
@@ -12,6 +12,9 @@ const {
   resolveCommandCheckPath,
 } = require('./state');
 const { buildControlCenterViewModel } = require('./presentation');
+const { ChatController, OpenClaudeChatViewProvider, OpenClaudeChatPanelManager } = require('./chat/chatProvider');
+const { SessionManager } = require('./chat/sessionManager');
+const { DiffContentProvider, SCHEME: DIFF_SCHEME } = require('./chat/diffController');
 
 const OPENCLAUDE_REPO_URL = 'https://github.com/Gitlawb/openclaude';
 const OPENCLAUDE_SETUP_URL = 'https://github.com/Gitlawb/openclaude/blob/main/README.md#quick-start';
@@ -1041,11 +1044,58 @@ class OpenClaudeControlCenterProvider {
  * @param {vscode.ExtensionContext} context
  */
 function activate(context) {
+  // ── Control Center (existing) ──
   const provider = new OpenClaudeControlCenterProvider();
   const refreshProvider = () => {
     void provider.refresh();
   };
 
+  // ── Chat system ──
+  const sessionManager = new SessionManager();
+  const folders = vscode.workspace.workspaceFolders;
+  if (folders && folders.length > 0) {
+    sessionManager.setCwd(folders[0].uri.fsPath);
+  }
+
+  const chatController = new ChatController(sessionManager);
+  const chatViewProvider = new OpenClaudeChatViewProvider(chatController);
+  const chatPanelManager = new OpenClaudeChatPanelManager(chatController);
+
+  // ── Diff content provider ──
+  const diffProvider = new DiffContentProvider();
+  const diffProviderReg = vscode.workspace.registerTextDocumentContentProvider(
+    DIFF_SCHEME,
+    diffProvider,
+  );
+
+  // ── Status bar ──
+  const statusBarItem = vscode.window.createStatusBarItem(
+    vscode.StatusBarAlignment.Right,
+    100,
+  );
+  statusBarItem.text = '$(comment-discussion) OpenClaude';
+  statusBarItem.tooltip = 'Open OpenClaude Chat';
+  statusBarItem.command = 'openclaude.openChat';
+  statusBarItem.show();
+
+  chatController.onDidChangeState((state) => {
+    switch (state) {
+      case 'streaming':
+        statusBarItem.text = '$(sync~spin) OpenClaude';
+        statusBarItem.tooltip = 'OpenClaude is generating...';
+        break;
+      case 'connected':
+        statusBarItem.text = '$(comment-discussion) OpenClaude';
+        statusBarItem.tooltip = 'OpenClaude connected';
+        break;
+      default:
+        statusBarItem.text = '$(comment-discussion) OpenClaude';
+        statusBarItem.tooltip = 'Open OpenClaude Chat';
+        break;
+    }
+  });
+
+  // ── Existing commands ──
   const startCommand = vscode.commands.registerCommand('openclaude.start', async () => {
     await launchOpenClaude();
   });
@@ -1079,32 +1129,95 @@ function activate(context) {
     await vscode.commands.executeCommand('workbench.view.extension.openclaude');
   });
 
-  const providerDisposable = vscode.window.registerWebviewViewProvider(
+  // ── New chat commands ──
+  const newChatCommand = vscode.commands.registerCommand('openclaude.newChat', () => {
+    chatController.stopSession();
+    chatController.broadcast({ type: 'session_cleared' });
+  });
+
+  const openChatCommand = vscode.commands.registerCommand('openclaude.openChat', () => {
+    chatPanelManager.openPanel();
+  });
+
+  const resumeSessionCommand = vscode.commands.registerCommand('openclaude.resumeSession', async () => {
+    const sessions = await sessionManager.listSessions();
+    if (sessions.length === 0) {
+      await vscode.window.showInformationMessage('No sessions found to resume.');
+      return;
+    }
+    const items = sessions.slice(0, 30).map(s => ({
+      label: s.title || s.id,
+      description: s.timeLabel,
+      detail: s.preview,
+      sessionId: s.id,
+    }));
+    const picked = await vscode.window.showQuickPick(items, {
+      placeHolder: 'Select a session to resume',
+    });
+    if (picked) {
+      chatController.stopSession();
+      chatController.broadcast({ type: 'session_cleared' });
+      await chatController.startSession({ sessionId: picked.sessionId });
+    }
+  });
+
+  const abortChatCommand = vscode.commands.registerCommand('openclaude.abortChat', () => {
+    chatController.abort();
+  });
+
+  // ── Register providers ──
+  const controlCenterProviderReg = vscode.window.registerWebviewViewProvider(
     'openclaude.controlCenter',
     provider,
+  );
+
+  const chatViewProviderReg = vscode.window.registerWebviewViewProvider(
+    'openclaude.chat',
+    chatViewProvider,
+    { webviewOptions: { retainContextWhenHidden: true } },
   );
 
   const profileWatcher = vscode.workspace.createFileSystemWatcher(`**/${PROFILE_FILE_NAME}`);
 
   context.subscriptions.push(
+    // existing
     startCommand,
     startInWorkspaceRootCommand,
     openDocsCommand,
     openSetupDocsCommand,
     openWorkspaceProfileCommand,
     openUiCommand,
-    providerDisposable,
+    controlCenterProviderReg,
+    // new chat
+    newChatCommand,
+    openChatCommand,
+    resumeSessionCommand,
+    abortChatCommand,
+    chatViewProviderReg,
+    diffProviderReg,
+    statusBarItem,
+    // watchers
     profileWatcher,
     vscode.workspace.onDidChangeConfiguration(event => {
       if (event.affectsConfiguration('openclaude')) {
         refreshProvider();
       }
     }),
-    vscode.workspace.onDidChangeWorkspaceFolders(refreshProvider),
+    vscode.workspace.onDidChangeWorkspaceFolders((e) => {
+      refreshProvider();
+      const folders = vscode.workspace.workspaceFolders;
+      if (folders && folders.length > 0) {
+        sessionManager.setCwd(folders[0].uri.fsPath);
+      }
+    }),
     vscode.window.onDidChangeActiveTextEditor(refreshProvider),
     profileWatcher.onDidCreate(refreshProvider),
     profileWatcher.onDidChange(refreshProvider),
     profileWatcher.onDidDelete(refreshProvider),
+    // disposables
+    { dispose: () => chatController.dispose() },
+    { dispose: () => chatPanelManager.dispose() },
+    { dispose: () => diffProvider.dispose() },
   );
 }
 
@@ -1116,4 +1229,7 @@ module.exports = {
   OpenClaudeControlCenterProvider,
   renderControlCenterHtml,
   resolveLaunchTargets,
+  ChatController,
+  OpenClaudeChatViewProvider,
+  OpenClaudeChatPanelManager,
 };


### PR DESCRIPTION
## Summary

Adds a Claude Code-like chat experience to the existing VS Code extension, turning it from a launcher/control panel into a full interactive chat interface.

![OpenClaude Chat Extension - showing tool use diffs, streaming responses, and inline file editing](https://github.com/user-attachments/assets/85584754-551d-4cce-a592-1883d31f2df6)



- **Streaming chat panel** (sidebar + editor tab) communicating with the CLI via `--print --input-format=stream-json --output-format=stream-json`
- **Tool use visualization** with inline diffs showing old/new content for file edits, clickable file paths that open in the editor
- **Session history** browser that reads JSONL transcripts from disk, with search and date grouping
- **Thinking block indicator** showing elapsed time and approximate token count
- **Permission mode setting** (`acceptEdits` default) for auto-approving file operations
- **Status bar** with live activity indicators (Thinking, Generating, Running: Tool, Ready)
- **Keybinding**: `Ctrl+Shift+L` / `Cmd+Shift+L` to open chat panel

### New files (under `vscode-extension/openclaude-vscode/src/chat/`)

| File | Purpose |
|------|---------|
| `protocol.js` | NDJSON wire format helpers and message type constants |
| `processManager.js` | Spawns CLI process, manages stdin/stdout lifecycle |
| `messageParser.js` | Transforms SDK messages into renderable view models |
| `chatRenderer.js` | Full self-contained HTML/CSS/JS chat UI |
| `chatProvider.js` | WebviewViewProvider (sidebar) + WebviewPanel (editor) |
| `sessionManager.js` | Reads JSONL session files, lists/loads sessions |
| `diffController.js` | TextDocumentContentProvider for virtual diff documents |

## Status

**Draft** - Core functionality works (streaming, tool use, history, multi-turn), but still iterating on:
- Multi-turn tool use reliability (model sometimes responds text-only on follow-up turns)
- Extended thinking block display refinement
- Edge cases in session restore

## Test plan

- [ ] Start a new chat and send a message - verify streaming response
- [ ] Ask the model to read/edit a file - verify tool card with diff display
- [ ] Click file path in tool card - verify it opens in editor
- [ ] Click History - verify past sessions load with tool details
- [ ] Send multiple messages in a row - verify multi-turn works
- [ ] Press Ctrl+Shift+L - verify chat panel opens in editor