### PR TITLE
fix(web-search): stop leaking abort listeners in custom provider retry

### DIFF
--- a/src/tools/WebSearchTool/providers/custom.ts
+++ b/src/tools/WebSearchTool/providers/custom.ts
@@ -406,20 +406,18 @@ async function fetchWithRetry(url: string, init: RequestInit, signal?: AbortSign
   let lastStatus: number | undefined
 
   for (let attempt = 0; attempt < 2; attempt++) {
-    // Create a timeout that races with the external signal
-    const controller = new AbortController()
-    const timer = setTimeout(() => controller.abort(), timeoutMs)
+    // Compose timeout with caller signal via AbortSignal.any so each attempt
+    // has a fresh timeout and we don't leak an abort listener on `signal`
+    // (the previous implementation added one per attempt and never removed
+    // it, and the listener kept a reference to a stale AbortController).
+    const timeoutSignal = AbortSignal.timeout(timeoutMs)
+    const combined = signal
+      ? AbortSignal.any([signal, timeoutSignal])
+      : timeoutSignal
 
-    // If the external signal is already aborted, forward it
-    if (signal?.aborted) {
-      controller.abort()
-    } else {
-      signal?.addEventListener('abort', () => controller.abort(), { once: true })
-    }
-
+    lastStatus = undefined
     try {
-      const res = await fetch(url, { ...init, signal: controller.signal })
-      clearTimeout(timer)
+      const res = await fetch(url, { ...init, signal: combined })
 
       if (!res.ok) {
         lastStatus = res.status
@@ -427,26 +425,20 @@ async function fetchWithRetry(url: string, init: RequestInit, signal?: AbortSign
       }
       return await res.json()
     } catch (err) {
-      clearTimeout(timer)
       lastErr = err instanceof Error ? err : new Error(String(err))
 
-      // AbortError from timeout
-      if (lastErr.name === 'AbortError' && !signal?.aborted) {
+      // Caller-initiated abort wins — propagate without retry or rewrite.
+      if (signal?.aborted) throw lastErr
+
+      // Timeout (TimeoutError on Bun/Node, or AbortError with timeoutSignal aborted).
+      if (timeoutSignal.aborted) {
         throw new Error(`Custom search timed out after ${timeoutSec}s`)
       }
 
-      // Retry on 5xx or network errors only
-      if (attempt === 0) {
-        if (lastStatus !== undefined && lastStatus >= 500) {
-          await new Promise(r => setTimeout(r, 500))
-          continue
-        }
-        if (lastStatus === undefined) {
-          // Network error — retry
-          await new Promise(r => setTimeout(r, 500))
-          continue
-        }
-        // 4xx — don't retry
+      // Retry once on 5xx or network errors; do not retry 4xx.
+      if (attempt === 0 && (lastStatus === undefined || lastStatus >= 500)) {
+        await new Promise(r => setTimeout(r, 500))
+        continue
       }
       throw lastErr
     }


### PR DESCRIPTION
## Summary

`fetchWithRetry` in `src/tools/WebSearchTool/providers/custom.ts` attached a fresh abort listener to the caller's `AbortSignal` on every retry attempt and never removed it:

```js
signal?.addEventListener('abort', () => controller.abort(), { once: true })
```

`{ once: true }` only cleans up if the event fires. On non-aborted signals the listener stays attached indefinitely, holding a closure over an already-dead `AbortController`. For long-lived caller signals (e.g. a session-wide signal shared across many searches) this leaks one listener per request, and two per request that triggers a retry.

## What changed

Replaced the manual `AbortController` + `setTimeout` + `addEventListener` dance with `AbortSignal.any([signal, AbortSignal.timeout(ms)])`. The runtime handles listener cleanup; no user-code listener to leak. This pattern is already used elsewhere in the codebase — see `src/services/mcp/xaa.ts`.

Side wins from the rewrite:

- Caller-initiated abort vs timeout is now cleanly distinguished via `signal.aborted` vs `timeoutSignal.aborted`, instead of inferring from `AbortError.name`.
- `lastStatus` is reset per attempt so a 5xx on attempt 0 can't leak into attempt 1's retry decision.
- Two redundant retry branches (`lastStatus >= 500` and `lastStatus === undefined`) collapse into one condition.

## Notes

- Retry semantics are preserved (one retry on 5xx or network error, no retry on 4xx).
- Timeout error message is unchanged: `Custom search timed out after Ns`.
- `engines.node >= 20.0.0`. `AbortSignal.any` lands in Node 20.3. Already used in-repo, so matching the project's effective floor.

## Test plan

- [x] `bun test src/tools/WebSearchTool/providers/custom.test.ts` — 17 pass, no regressions
- [x] `bun run typecheck` — no new errors in `custom.ts`

🤖 Generated with [OpenClaude](https://github.com/Gitlawb/openclaude)