### PR TITLE
fix(read/edit): avoid tab-prefix ambiguity in compact read output

### DIFF
--- a/src/tools/FileEditTool/prompt.ts
+++ b/src/tools/FileEditTool/prompt.ts
@@ -11,7 +11,7 @@ export function getEditToolDescription(): string {
 
 function getDefaultEditDescription(): string {
   const prefixFormat = isCompactLinePrefixEnabled()
-    ? 'line number + tab'
+    ? 'line number + arrow'
     : 'spaces + line number + arrow'
   const minimalUniquenessHint =
     process.env.USER_TYPE === 'ant'

--- a/src/utils/file.test.ts
+++ b/src/utils/file.test.ts
@@ -1,0 +1,51 @@
+import { afterEach, describe, expect, mock, test } from 'bun:test'
+
+async function importFileModuleWithKillswitchEnabled(
+  killswitchEnabled: boolean,
+) {
+  mock.module('../services/analytics/growthbook.js', () => ({
+    getFeatureValue_CACHED_MAY_BE_STALE: () => killswitchEnabled,
+  }))
+
+  return import(`./file.js?ts=${Date.now()}-${Math.random()}`)
+}
+
+afterEach(() => {
+  mock.restore()
+})
+
+describe('addLineNumbers', () => {
+  test('uses unambiguous arrow compact prefix and preserves leading tabs', async () => {
+    const { addLineNumbers } = await importFileModuleWithKillswitchEnabled(false)
+
+    const result = addLineNumbers({
+      content: '\tfirst\n\t\tsecond',
+      startLine: 41,
+    })
+
+    expect(result).toBe('41→\tfirst\n42→\t\tsecond')
+  })
+
+  test('keeps padded arrow format when compact mode is disabled', async () => {
+    const { addLineNumbers } = await importFileModuleWithKillswitchEnabled(true)
+
+    const result = addLineNumbers({
+      content: 'alpha\nbeta',
+      startLine: 1,
+    })
+
+    expect(result).toBe('     1→alpha\n     2→beta')
+  })
+})
+
+describe('stripLineNumberPrefix', () => {
+  test('strips compact arrow, padded arrow, and legacy tab prefixes', async () => {
+    const { stripLineNumberPrefix } = await importFileModuleWithKillswitchEnabled(
+      false,
+    )
+
+    expect(stripLineNumberPrefix('41→\tfirst')).toBe('\tfirst')
+    expect(stripLineNumberPrefix('     2→beta')).toBe('beta')
+    expect(stripLineNumberPrefix('7\t\tlegacy-tab')).toBe('\tlegacy-tab')
+  })
+})

--- a/src/utils/file.ts
+++ b/src/utils/file.ts
@@ -267,7 +267,7 @@ export async function suggestPathUnderCwd(
 }
 
 /**
- * Whether to use the compact line-number prefix format (`N\t` instead of
+ * Whether to use the compact line-number prefix format (`N→` instead of
  * `     N→`). The padded-arrow format costs 9 bytes/line overhead; at
  * 1.35B Read calls × 132 lines avg this is 2.18% of fleet uncached input
  * (bq-queries/read_line_prefix_overhead_verify.sql).
@@ -303,7 +303,7 @@ export function addLineNumbers({
 
   if (isCompactLinePrefixEnabled()) {
     return lines
-      .map((line, index) => `${index + startLine}\t${line}`)
+      .map((line, index) => `${index + startLine}→${line}`)
       .join('\n')
   }
 


### PR DESCRIPTION
## Summary
- switch compact Read line prefixes from N+tab to N→ so file indentation tabs remain unambiguous in model-facing output
- keep legacy N+tab stripping support for backward compatibility while preserving existing padded-arrow mode behavior
- update Edit tool guidance text to reflect compact line number + arrow format
- add regression tests covering compact arrow formatting, padded fallback formatting, and legacy tab-prefix stripping

Fixes #596

## Validation
- bun test src/utils/file.test.ts
- bun run build