### PR TITLE
ci: publish npm in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,9 +4,6 @@ on:
   push:
     branches:
       - main
-  release:
-    types:
-      - published
 
 concurrency:
   group: auto-release-${{ github.ref }}
@@ -15,7 +12,6 @@ concurrency:
 jobs:
   release-please:
     name: Release Please
-    if: ${{ github.event_name == 'push' }}
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -34,7 +30,8 @@ jobs:
 
   publish-npm:
     name: Publish to npm
-    if: ${{ github.event_name == 'release' }}
+    needs: release-please
+    if: ${{ needs.release-please.outputs.release_created == 'true' }}
     runs-on: ubuntu-latest
     environment: release
     permissions:
@@ -44,7 +41,7 @@ jobs:
       - name: Checkout release tag
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
-          ref: ${{ github.event.release.tag_name }}
+          ref: ${{ needs.release-please.outputs.tag_name }}
           fetch-depth: 0
 
       - name: Set up Node.js
@@ -84,8 +81,8 @@ jobs:
       - name: Release summary
         run: |
           {
-            echo "## Released ${{ github.event.release.tag_name }}"
+            echo "## Released ${{ needs.release-please.outputs.tag_name }}"
             echo
             echo "- npm: https://www.npmjs.com/package/@gitlawb/openclaude"
-            echo "- GitHub: https://github.com/Gitlawb/openclaude/releases/tag/${{ github.event.release.tag_name }}"
+            echo "- GitHub: https://github.com/Gitlawb/openclaude/releases/tag/${{ needs.release-please.outputs.tag_name }}"
           } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Summary

  - changed the npm publish job in .github/workflows/release.yml to run in the same workflow as release-please
  - removed the separate GitHub release event publish path
  - restored publish gating to:
      - needs.release-please.outputs.release_created == 'true'
  - restored tag checkout to the exact release tag produced by release-please
  - kept the Trusted Publishing fixes already in place:
      - Node 24
      - NODE_AUTH_TOKEN cleared before npm publish --provenance
  - this changed because the release event design broke the intended UX
  - when the release PR was merged, publish no longer reliably followed in the same release flow, and GitHub release events created via GITHUB_TOKEN are a poor foundation for chaining a second workflow
  - the correct behavior is for the same release workflow run to publish the exact tag that release-please just created

  ## Impact

  - user-facing impact:
      - future release PR merges should publish to npm automatically as part of the same release workflow
      - removes the need for a second manual release/publish step after merging a release PR
  - developer/maintainer impact:
      - release automation is simpler and more predictable
      - publish now depends directly on release-please outputs instead of a second GitHub event
      - keeps the existing OIDC/trusted-publishing hardening in place

  ## Testing

  - [ ] bun run build
  - [ ] bun run smoke
  - [x] focused tests:
      - workflow logic reviewed against current upstream release state
      - verified publish-npm now depends on release_created and checks out needs.release-please.outputs.tag_name

  ## Notes

  - provider/model path tested:
      - not applicable, this is CI/release automation only
  - screenshots attached (if UI changed):
      - no
  - follow-up work or known limitations:
      - this fixes future releases such as 0.2.2
      - 0.2.1 was already cut under the old workflow shape, so this PR is about making the next release path correct rather than retroactively changing that run