### PR TITLE
feat: activate message actions in open build

### DIFF
--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -37,7 +37,7 @@ const featureFlags: Record<string, boolean> = {
   AWAY_SUMMARY: false,
   TRANSCRIPT_CLASSIFIER: false,
   WEB_BROWSER_TOOL: false,
-  MESSAGE_ACTIONS: false,
+  MESSAGE_ACTIONS: true,
   BUDDY: true,
   CHICAGO_MCP: false,
   COWORKER_TYPE_TELEMETRY: false,


### PR DESCRIPTION
## Summary
- Enable the `MESSAGE_ACTIONS` feature flag (`scripts/build.ts`) so open-build users get the `shift+up` keybinding for the message actions panel.
- Follows the activation pattern established in #346 (buddy system).

**Gate sites (5 total):**
- `src/keybindings/defaultBindings.ts:88,268`
- `src/screens/REPL.tsx:611,4595,4938`

Pure UI/keybinding feature — zero external dependencies, zero breakage risk.

## Test plan
- [x] `bun run build` — compiles successfully
- [x] `bun run smoke` — smoke tests pass
- [ ] Launch openclaude, verify `shift+up` opens the message actions panel
- [ ] Verify no regression on existing keybindings