### PR TITLE
feat: activate agent triggers (cron scheduling) in open build

### DIFF
--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -23,7 +23,7 @@ const featureFlags: Record<string, boolean> = {
   KAIROS: false,
   BRIDGE_MODE: false,
   DAEMON: false,
-  AGENT_TRIGGERS: false,
+  AGENT_TRIGGERS: true,
   MONITOR_TOOL: false,
   ABLATION_BASELINE: false,
   DUMP_SYSTEM_PROMPT: false,


### PR DESCRIPTION
## Summary
- Enable the `AGENT_TRIGGERS` feature flag (`scripts/build.ts`) to unlock `CronCreate`, `CronDelete`, and `CronList` tools for all open-build users.
- Follows the activation pattern established in #346 (buddy system).

The cron scheduling implementation is **complete and production-ready** (600+ lines):
- `src/tools/ScheduleCronTool/CronCreateTool.ts` — create recurring/one-shot tasks
- `src/tools/ScheduleCronTool/CronDeleteTool.ts` — delete scheduled tasks
- `src/tools/ScheduleCronTool/CronListTool.ts` — list active tasks
- `src/utils/cronTasks.ts` — persistence via `.claude/scheduled_tasks.json`
- `src/utils/cronScheduler.ts` — local event loop with missed-task detection
- `src/utils/cronTasksLock.ts` — multi-session lock coordination

The GrowthBook runtime gate (`tengu_kairos_cron`) defaults to `true` via the no-telemetry stub, so this works out of the box. Kill-switch: `CLAUDE_CODE_DISABLE_CRON=1`.

## Test plan
- [x] `bun run build` — compiles successfully
- [x] `bun run smoke` — smoke tests pass
- [ ] Ask the agent to schedule a recurring task, verify `.claude/scheduled_tasks.json` is created
- [ ] Verify CronList shows the scheduled task
- [ ] Verify CronDelete removes it
- [ ] Verify `CLAUDE_CODE_DISABLE_CRON=1` disables the feature