### PR TITLE
cleanup: remove dead USER_TYPE branches from non-stubbed modules

### DIFF
--- a/src/bootstrap/state.ts
+++ b/src/bootstrap/state.ts
@@ -388,11 +388,6 @@ function getInitialState(): State {
     mainThreadAgentType: undefined,
     // Remote mode
     isRemoteMode: false,
-    ...(process.env.USER_TYPE === 'ant'
-      ? {
-          replBridgeActive: false,
-        }
-      : {}),
     // Direct connect server URL
     directConnectServerUrl: undefined,
     // System prompt section cache state
@@ -1566,24 +1561,11 @@ export function clearInvokedSkillsForAgent(agentId: string): void {
 const MAX_SLOW_OPERATIONS = 10
 const SLOW_OPERATION_TTL_MS = 10000
 
-export function addSlowOperation(operation: string, durationMs: number): void {
-  if (process.env.USER_TYPE !== 'ant') return
-  // Skip tracking for editor sessions (user editing a prompt file in $EDITOR)
-  // These are intentionally slow since the user is drafting text
-  if (operation.includes('exec') && operation.includes('claude-prompt-')) {
-    return
-  }
-  const now = Date.now()
-  // Remove stale operations
-  STATE.slowOperations = STATE.slowOperations.filter(
-    op => now - op.timestamp < SLOW_OPERATION_TTL_MS,
-  )
-  // Add new operation
-  STATE.slowOperations.push({ operation, durationMs, timestamp: now })
-  // Keep only the most recent operations
-  if (STATE.slowOperations.length > MAX_SLOW_OPERATIONS) {
-    STATE.slowOperations = STATE.slowOperations.slice(-MAX_SLOW_OPERATIONS)
-  }
+export function addSlowOperation(
+  _operation: string,
+  _durationMs: number,
+): void {
+  // Internal slow-operation tracking removed (was ant-only)
 }
 
 const EMPTY_SLOW_OPERATIONS: ReadonlyArray<{

--- a/src/bridge/bridgeConfig.ts
+++ b/src/bridge/bridgeConfig.ts
@@ -1,11 +1,10 @@
 /**
- * Shared bridge auth/URL resolution. Consolidates the internal-only
- * CLAUDE_BRIDGE_* dev overrides that were previously copy-pasted across
- * a dozen files — inboundAttachments, BriefTool/upload, bridgeMain,
- * initReplBridge, remoteBridgeCore, daemon workers, /rename,
- * /remote-control.
+ * Shared bridge auth/URL resolution. Consolidates the CLAUDE_BRIDGE_*
+ * dev overrides that were previously copy-pasted across a dozen files —
+ * inboundAttachments, BriefTool/upload, bridgeMain, initReplBridge,
+ * remoteBridgeCore, daemon workers, /rename, /remote-control.
  *
- * Two layers: *Override() returns the internal-only env var (or undefined);
+ * Two layers: *Override() returns the dev env var (or undefined);
  * the non-Override versions fall through to the real OAuth store/config.
  * Callers that compose with a different auth source (e.g. daemon workers
  * using IPC auth) use the Override getters directly.
@@ -14,14 +13,14 @@
 import { getOauthConfig } from '../constants/oauth.js'
 import { getClaudeAIOAuthTokens } from '../utils/auth.js'
 
-/** Dev override for bridge OAuth token (removed: was ant-only). */
+/** Dev override: CLAUDE_BRIDGE_OAUTH_TOKEN, else undefined. */
 export function getBridgeTokenOverride(): string | undefined {
-  return undefined
+  return process.env.CLAUDE_BRIDGE_OAUTH_TOKEN || undefined
 }
 
-/** Dev override for bridge base URL (removed: was ant-only). */
+/** Dev override: CLAUDE_BRIDGE_BASE_URL, else undefined. */
 export function getBridgeBaseUrlOverride(): string | undefined {
-  return undefined
+  return process.env.CLAUDE_BRIDGE_BASE_URL || undefined
 }
 
 /**

--- a/src/bridge/bridgeConfig.ts
+++ b/src/bridge/bridgeConfig.ts
@@ -14,21 +14,14 @@
 import { getOauthConfig } from '../constants/oauth.js'
 import { getClaudeAIOAuthTokens } from '../utils/auth.js'
 
-/** Ant-only dev override: CLAUDE_BRIDGE_OAUTH_TOKEN, else undefined. */
+/** Dev override for bridge OAuth token (removed: was ant-only). */
 export function getBridgeTokenOverride(): string | undefined {
-  return (
-    (process.env.USER_TYPE === 'ant' &&
-      process.env.CLAUDE_BRIDGE_OAUTH_TOKEN) ||
-    undefined
-  )
+  return undefined
 }
 
-/** Ant-only dev override: CLAUDE_BRIDGE_BASE_URL, else undefined. */
+/** Dev override for bridge base URL (removed: was ant-only). */
 export function getBridgeBaseUrlOverride(): string | undefined {
-  return (
-    (process.env.USER_TYPE === 'ant' && process.env.CLAUDE_BRIDGE_BASE_URL) ||
-    undefined
-  )
+  return undefined
 }
 
 /**

--- a/src/bridge/bridgeMain.ts
+++ b/src/bridge/bridgeMain.ts
@@ -338,22 +338,6 @@ export async function runBridgeLoop(
     spawn_mode: config.spawnMode,
   })
 
-  // For ant users, show where session debug logs will land so they can tail them.
-  // sessionRunner.ts uses the same base path. File appears once a session spawns.
-  if (process.env.USER_TYPE === 'ant') {
-    let debugGlob: string
-    if (config.debugFile) {
-      const ext = config.debugFile.lastIndexOf('.')
-      debugGlob =
-        ext > 0
-          ? `${config.debugFile.slice(0, ext)}-*${config.debugFile.slice(ext)}`
-          : `${config.debugFile}-*`
-    } else {
-      debugGlob = join(tmpdir(), 'claude', 'bridge-session-*.log')
-    }
-    logger.setDebugLogPath(debugGlob)
-  }
-
   logger.printBanner(config, environmentId)
 
   // Seed the logger's session count + spawn mode before any render. Without
@@ -1132,7 +1116,7 @@ export async function runBridgeLoop(
             } else {
               sessionDebugFile = `${config.debugFile}-${safeId}`
             }
-          } else if (config.verbose || process.env.USER_TYPE === 'ant') {
+          } else if (config.verbose) {
             sessionDebugFile = join(
               tmpdir(),
               'claude',
@@ -2192,16 +2176,7 @@ export async function bridgeMain(args: string[]): Promise<void> {
     process.exit(1)
   }
 
-  // Session ingress URL for WebSocket connections. In production this is the
-  // same as baseUrl (Envoy routes /v1/session_ingress/* to session-ingress).
-  // Locally, session-ingress runs on a different port (9413) than the
-  // contain-provide-api (8211), so CLAUDE_BRIDGE_SESSION_INGRESS_URL must be
-  // set explicitly. Ant-only, matching CLAUDE_BRIDGE_BASE_URL.
-  const sessionIngressUrl =
-    process.env.USER_TYPE === 'ant' &&
-    process.env.CLAUDE_BRIDGE_SESSION_INGRESS_URL
-      ? process.env.CLAUDE_BRIDGE_SESSION_INGRESS_URL
-      : baseUrl
+  const sessionIngressUrl = baseUrl
 
   const { getBranch, getRemoteUrl, findGitRoot } = await import(
     '../utils/git.js'
@@ -2850,11 +2825,7 @@ export async function runBridgeHeadless(
       'Remote Control base URL uses HTTP. Only HTTPS or localhost HTTP is allowed.',
     )
   }
-  const sessionIngressUrl =
-    process.env.USER_TYPE === 'ant' &&
-    process.env.CLAUDE_BRIDGE_SESSION_INGRESS_URL
-      ? process.env.CLAUDE_BRIDGE_SESSION_INGRESS_URL
-      : baseUrl
+  const sessionIngressUrl = baseUrl
 
   const { getBranch, getRemoteUrl, findGitRoot } = await import(
     '../utils/git.js'

--- a/src/bridge/bridgeUI.ts
+++ b/src/bridge/bridgeUI.ts
@@ -221,11 +221,6 @@ export function createBridgeLogger(options: {
       suffix += chalk.dim(' \u00b7 ') + chalk.dim(branch)
     }
 
-    if (process.env.USER_TYPE === 'ant' && debugLogPath) {
-      writeStatus(
-        `${chalk.yellow('[internal] Logs:')} ${chalk.dim(debugLogPath)}\n`,
-      )
-    }
     writeStatus(`${indicatorColor(indicator)} ${stateText}${suffix}\n`)
 
     // Session count and per-session list (multi-session mode only)

--- a/src/bridge/initReplBridge.ts
+++ b/src/bridge/initReplBridge.ts
@@ -464,11 +464,7 @@ export async function initReplBridge(
   // Everything from here down is passed explicitly to bridgeCore.
   const branch = await getBranch()
   const gitRepoUrl = await getRemoteUrl()
-  const sessionIngressUrl =
-    process.env.USER_TYPE === 'ant' &&
-    process.env.CLAUDE_BRIDGE_SESSION_INGRESS_URL
-      ? process.env.CLAUDE_BRIDGE_SESSION_INGRESS_URL
-      : baseUrl
+  const sessionIngressUrl = baseUrl
 
   // Assistant-mode sessions advertise a distinct worker_type so the web UI
   // can filter them into a dedicated picker. KAIROS guard keeps the

--- a/src/bridge/replBridge.ts
+++ b/src/bridge/replBridge.ts
@@ -60,12 +60,6 @@ import {
 } from './pollConfigDefaults.js'
 import { errorMessage } from '../utils/errors.js'
 import { sleep } from '../utils/sleep.js'
-import {
-  wrapApiForFaultInjection,
-  registerBridgeDebugHandle,
-  clearBridgeDebugHandle,
-  injectBridgeFault,
-} from './bridgeDebug.js'
 
 export type ReplBridgeHandle = {
   bridgeSessionId: string
@@ -324,10 +318,7 @@ export async function initBridgeCore(
     onAuth401,
     getTrustedDeviceToken,
   })
-  // Ant-only: interpose so /bridge-kick can inject poll/register/heartbeat
-  // failures. Zero cost in external builds (rawApi passes through unchanged).
-  const api =
-    process.env.USER_TYPE === 'ant' ? wrapApiForFaultInjection(rawApi) : rawApi
+  const api = rawApi
 
   const bridgeConfig: BridgeConfig = {
     dir,
@@ -965,45 +956,6 @@ export async function initBridgeCore(
     })
   }
 
-  // Ant-only: SIGUSR2 → force doReconnect() for manual testing. Skips the
-  // ~30s poll wait — fire-and-observe in the debug log immediately.
-  // Windows has no USR signals; `process.on` would throw there.
-  let sigusr2Handler: (() => void) | undefined
-  if (process.env.USER_TYPE === 'ant' && process.platform !== 'win32') {
-    sigusr2Handler = () => {
-      logForDebugging(
-        '[bridge:repl] SIGUSR2 received — forcing doReconnect() for testing',
-      )
-      void reconnectEnvironmentWithSession()
-    }
-    process.on('SIGUSR2', sigusr2Handler)
-  }
-
-  // Ant-only: /bridge-kick fault injection. handleTransportPermanentClose
-  // is defined below and assigned into this slot so the slash command can
-  // invoke it directly — the real setOnClose callback is buried inside
-  // wireTransport which is itself inside onWorkReceived.
-  let debugFireClose: ((code: number) => void) | null = null
-  if (process.env.USER_TYPE === 'ant') {
-    registerBridgeDebugHandle({
-      fireClose: code => {
-        if (!debugFireClose) {
-          logForDebugging('[bridge:debug] fireClose: no transport wired yet')
-          return
-        }
-        logForDebugging(`[bridge:debug] fireClose(${code}) — injecting`)
-        debugFireClose(code)
-      },
-      forceReconnect: () => {
-        logForDebugging('[bridge:debug] forceReconnect — injecting')
-        void reconnectEnvironmentWithSession()
-      },
-      injectFault: injectBridgeFault,
-      wakePollLoop,
-      describe: () =>
-        `env=${environmentId} session=${currentSessionId} transport=${transport?.getStateLabel() ?? 'null'} workId=${currentWorkId ?? 'null'}`,
-    })
-  }
 
   const pollOpts = {
     api,
@@ -1568,13 +1520,6 @@ export async function initBridgeCore(
     }
     if (keepAliveTimer !== null) {
       clearInterval(keepAliveTimer)
-    }
-    if (sigusr2Handler) {
-      process.off('SIGUSR2', sigusr2Handler)
-    }
-    if (process.env.USER_TYPE === 'ant') {
-      clearBridgeDebugHandle()
-      debugFireClose = null
     }
     pollController.abort()
     logForDebugging('[bridge:repl] Teardown: poll loop aborted')

--- a/src/bridge/sessionRunner.ts
+++ b/src/bridge/sessionRunner.ts
@@ -324,7 +324,7 @@ export function createSessionSpawner(deps: SessionSpawnerDeps): SessionSpawner {
         } else {
           debugFile = `${deps.debugFile}-${safeId}`
         }
-      } else if (deps.verbose || process.env.USER_TYPE === 'ant') {
+      } else if (deps.verbose) {
         debugFile = join(tmpdir(), 'claude', `bridge-session-${safeId}.log`)
       }
 

--- a/src/cli/print.ts
+++ b/src/cli/print.ts
@@ -491,17 +491,6 @@ export async function runHeadless(
     setSDKStatus?: (status: SDKStatus) => void
   },
 ): Promise<void> {
-  if (
-    process.env.USER_TYPE === 'ant' &&
-    isEnvTruthy(process.env.CLAUDE_CODE_EXIT_AFTER_FIRST_RENDER)
-  ) {
-    process.stderr.write(
-      `\nStartup time: ${Math.round(process.uptime() * 1000)}ms\n`,
-    )
-    // eslint-disable-next-line custom-rules/no-process-exit
-    process.exit(0)
-  }
-
   // Fire user settings download now so it overlaps with the MCP/tool setup
   // below. Managed settings already started in main.tsx preAction; this gives
   // user settings a similar head start. The cached promise is joined in

--- a/src/cli/update.ts
+++ b/src/cli/update.ts
@@ -307,10 +307,7 @@ export async function update() {
     process.stderr.write('  • Check your internet connection\n')
     process.stderr.write('  • Run with --debug flag for more details\n')
     const packageName =
-      MACRO.PACKAGE_URL ||
-      (process.env.USER_TYPE === 'ant'
-        ? '@anthropic-ai/claude-cli'
-        : '@anthropic-ai/claude-code')
+      MACRO.PACKAGE_URL || '@anthropic-ai/claude-code'
     process.stderr.write(
       `  • Manually check: npm view ${packageName} version\n`,
     )

--- a/src/commands/bridge-kick.ts
+++ b/src/commands/bridge-kick.ts
@@ -192,7 +192,7 @@ const bridgeKick = {
   type: 'local',
   name: 'bridge-kick',
   description: 'Inject bridge failure states for manual recovery testing',
-  isEnabled: () => process.env.USER_TYPE === 'ant',
+  isEnabled: () => false,
   supportsNonInteractive: false,
   load: () => Promise.resolve({ call }),
 } satisfies Command

--- a/src/commands/clear/caches.ts
+++ b/src/commands/clear/caches.ts
@@ -91,15 +91,6 @@ export function clearSessionCaches(
   // Clear swarm permission pending callbacks
   if (!hasPreserved) clearAllPendingCallbacks()
 
-  // Clear tungsten session usage tracking
-  if (process.env.USER_TYPE === 'ant') {
-    void import('../../tools/TungstenTool/TungstenTool.js').then(
-      ({ clearSessionsWithTungstenUsage, resetInitializationState }) => {
-        clearSessionsWithTungstenUsage()
-        resetInitializationState()
-      },
-    )
-  }
   // Clear attribution caches (file content cache, pending bash states)
   // Dynamic import to preserve dead code elimination for COMMIT_ATTRIBUTION feature flag
   if (feature('COMMIT_ATTRIBUTION')) {

--- a/src/commands/clear/conversation.ts
+++ b/src/commands/clear/conversation.ts
@@ -7,7 +7,6 @@ import { randomUUID, type UUID } from 'crypto'
 import {
   getLastMainRequestId,
   getOriginalCwd,
-  getSessionId,
   regenerateSessionId,
 } from '../../bootstrap/state.js'
 import {
@@ -201,10 +200,6 @@ export async function clearConversation({
   // Generate new session ID to provide fresh state
   // Set the old session as parent for analytics lineage tracking
   regenerateSessionId({ setCurrentAsParent: true })
-  // Update the environment variable so subprocesses use the new session ID
-  if (process.env.USER_TYPE === 'ant' && process.env.CLAUDE_CODE_SESSION_ID) {
-    process.env.CLAUDE_CODE_SESSION_ID = getSessionId()
-  }
   await resetSessionFilePointer()
 
   // Preserved local_agent tasks had their TaskOutput symlink baked against the

--- a/src/commands/commit-push-pr.ts
+++ b/src/commands/commit-push-pr.ts
@@ -5,7 +5,6 @@ import {
 } from '../utils/attribution.js'
 import { getDefaultBranch } from '../utils/git.js'
 import { executeShellCommandsInPrompt } from '../utils/promptShellExecution.js'
-import { getUndercoverInstructions, isUndercover } from '../utils/undercover.js'
 
 const ALLOWED_TOOLS = [
   'Bash(git checkout --branch:*)',
@@ -34,27 +33,19 @@ function getPromptContent(
   const safeUser = process.env.SAFEUSER || ''
   const username = process.env.USER || ''
 
-  let prefix = ''
-  let reviewerArg = ' and `--reviewer anthropics/claude-code`'
-  let addReviewerArg = ' (and add `--add-reviewer anthropics/claude-code`)'
-  let changelogSection = `
+  const reviewerArg = ' and `--reviewer anthropics/claude-code`'
+  const addReviewerArg = ' (and add `--add-reviewer anthropics/claude-code`)'
+  const changelogSection = `
 
 ## Changelog
 <!-- CHANGELOG:START -->
 [If this PR contains user-facing changes, add a changelog entry here. Otherwise, remove this section.]
 <!-- CHANGELOG:END -->`
-  let slackStep = `
+  const slackStep = `
 
 5. After creating/updating the PR, check if the user's AGENTS.md or CLAUDE.md mentions posting to Slack channels. If it does, use ToolSearch to search for "slack send message" tools. If ToolSearch finds a Slack tool, ask the user if they'd like you to post the PR URL to the relevant Slack channel. Only post if the user confirms. If ToolSearch returns no results or errors, skip this step silently—do not mention the failure, do not attempt workarounds, and do not try alternative approaches.`
-  if (process.env.USER_TYPE === 'ant' && isUndercover()) {
-    prefix = getUndercoverInstructions() + '\n'
-    reviewerArg = ''
-    addReviewerArg = ''
-    changelogSection = ''
-    slackStep = ''
-  }
 
-  return `${prefix}## Context
+  return `## Context
 
 - \`SAFEUSER\`: ${safeUser}
 - \`whoami\`: ${username}

--- a/src/commands/commit.ts
+++ b/src/commands/commit.ts
@@ -1,7 +1,6 @@
 import type { Command } from '../commands.js'
 import { getAttributionTexts } from '../utils/attribution.js'
 import { executeShellCommandsInPrompt } from '../utils/promptShellExecution.js'
-import { getUndercoverInstructions, isUndercover } from '../utils/undercover.js'
 
 const ALLOWED_TOOLS = [
   'Bash(git add:*)',
@@ -12,12 +11,7 @@ const ALLOWED_TOOLS = [
 function getPromptContent(): string {
   const { commit: commitAttribution } = getAttributionTexts()
 
-  let prefix = ''
-  if (process.env.USER_TYPE === 'ant' && isUndercover()) {
-    prefix = getUndercoverInstructions() + '\n'
-  }
-
-  return `${prefix}## Context
+  return `## Context
 
 - Current git status: !\`git status\`
 - Current git diff (staged and unstaged changes): !\`git diff HEAD\`

--- a/src/commands/context/context-noninteractive.ts
+++ b/src/commands/context/context-noninteractive.ts
@@ -199,36 +199,6 @@ function formatContextAsMarkdownTable(data: ContextData): string {
     output += `\n`
   }
 
-  // System tools (internal-only)
-  if (
-    systemTools &&
-    systemTools.length > 0 &&
-    process.env.USER_TYPE === 'ant'
-  ) {
-    output += `### [internal] System Tools\n\n`
-    output += `| Tool | Tokens |\n`
-    output += `|------|--------|\n`
-    for (const tool of systemTools) {
-      output += `| ${tool.name} | ${formatTokens(tool.tokens)} |\n`
-    }
-    output += `\n`
-  }
-
-  // System prompt sections (internal-only)
-  if (
-    systemPromptSections &&
-    systemPromptSections.length > 0 &&
-    process.env.USER_TYPE === 'ant'
-  ) {
-    output += `### [internal] System Prompt Sections\n\n`
-    output += `| Section | Tokens |\n`
-    output += `|---------|--------|\n`
-    for (const section of systemPromptSections) {
-      output += `| ${section.name} | ${formatTokens(section.tokens)} |\n`
-    }
-    output += `\n`
-  }
-
   // Custom agents
   if (agents.length > 0) {
     output += `### Custom Agents\n\n`
@@ -286,39 +256,6 @@ function formatContextAsMarkdownTable(data: ContextData): string {
       output += `| ${skill.name} | ${getSourceDisplayName(skill.source)} | ${formatTokens(skill.tokens)} |\n`
     }
     output += `\n`
-  }
-
-  // Message breakdown (internal-only)
-  if (messageBreakdown && process.env.USER_TYPE === 'ant') {
-    output += `### [internal] Message Breakdown\n\n`
-    output += `| Category | Tokens |\n`
-    output += `|----------|--------|\n`
-    output += `| Tool calls | ${formatTokens(messageBreakdown.toolCallTokens)} |\n`
-    output += `| Tool results | ${formatTokens(messageBreakdown.toolResultTokens)} |\n`
-    output += `| Attachments | ${formatTokens(messageBreakdown.attachmentTokens)} |\n`
-    output += `| Assistant messages (non-tool) | ${formatTokens(messageBreakdown.assistantMessageTokens)} |\n`
-    output += `| User messages (non-tool-result) | ${formatTokens(messageBreakdown.userMessageTokens)} |\n`
-    output += `\n`
-
-    if (messageBreakdown.toolCallsByType.length > 0) {
-      output += `#### Top Tools\n\n`
-      output += `| Tool | Call Tokens | Result Tokens |\n`
-      output += `|------|-------------|---------------|\n`
-      for (const tool of messageBreakdown.toolCallsByType) {
-        output += `| ${tool.name} | ${formatTokens(tool.callTokens)} | ${formatTokens(tool.resultTokens)} |\n`
-      }
-      output += `\n`
-    }
-
-    if (messageBreakdown.attachmentsByType.length > 0) {
-      output += `#### Top Attachments\n\n`
-      output += `| Attachment | Tokens |\n`
-      output += `|------------|--------|\n`
-      for (const attachment of messageBreakdown.attachmentsByType) {
-        output += `| ${attachment.name} | ${formatTokens(attachment.tokens)} |\n`
-      }
-      output += `\n`
-    }
   }
 
   return output

--- a/src/commands/cost/cost.ts
+++ b/src/commands/cost/cost.ts
@@ -15,9 +15,6 @@ export const call: LocalCommandCall = async () => {
         'You are currently using your subscription to power your Claude Code usage'
     }
 
-    if (process.env.USER_TYPE === 'ant') {
-      value += `\n\n[internal-only] Showing cost anyway:\n ${formatTotalCost()}`
-    }
     return { type: 'text', value }
   }
   return { type: 'text', value: formatTotalCost() }

--- a/src/commands/cost/index.ts
+++ b/src/commands/cost/index.ts
@@ -10,10 +10,6 @@ const cost = {
   name: 'cost',
   description: 'Show the total cost and duration of the current session',
   get isHidden() {
-    // Keep visible for Ants even if they're subscribers (they see cost breakdowns)
-    if (process.env.USER_TYPE === 'ant') {
-      return false
-    }
     return isClaudeAISubscriber()
   },
   supportsNonInteractive: true,

--- a/src/commands/createMovedToPluginCommand.ts
+++ b/src/commands/createMovedToPluginCommand.ts
@@ -41,24 +41,6 @@ export function createMovedToPluginCommand({
       args: string,
       context: ToolUseContext,
     ): Promise<ContentBlockParam[]> {
-      if (process.env.USER_TYPE === 'ant') {
-        return [
-          {
-            type: 'text',
-            text: `This command has been moved to a plugin. Tell the user:
-
-1. To install the plugin, run:
-   claude plugin install ${pluginName}@claude-code-marketplace
-
-2. After installation, use /${pluginName}:${pluginCommand} to run this command
-
-3. For more information, see: https://github.com/anthropics/claude-code-marketplace/blob/main/${pluginName}/README.md
-
-Do not attempt to run the command. Simply inform the user about the plugin installation.`,
-          },
-        ]
-      }
-
       return getPromptWhileMarketplaceIsPrivate(args, context)
     },
   }

--- a/src/commands/feedback/index.ts
+++ b/src/commands/feedback/index.ts
@@ -17,7 +17,6 @@ const feedback = {
       isEnvTruthy(process.env.DISABLE_FEEDBACK_COMMAND) ||
       isEnvTruthy(process.env.DISABLE_BUG_COMMAND) ||
       isEssentialTrafficOnly() ||
-      process.env.USER_TYPE === 'ant' ||
       !isPolicyAllowed('allow_product_feedback')
     ),
   load: () => import('./feedback.js'),

--- a/src/commands/files/index.ts
+++ b/src/commands/files/index.ts
@@ -4,7 +4,7 @@ const files = {
   type: 'local',
   name: 'files',
   description: 'List all files currently in context',
-  isEnabled: () => process.env.USER_TYPE === 'ant',
+  isEnabled: () => false,
   supportsNonInteractive: true,
   load: () => import('./files.js'),
 } satisfies Command

--- a/src/commands/initMode.ts
+++ b/src/commands/initMode.ts
@@ -3,10 +3,7 @@ import { isEnvTruthy } from '../utils/envUtils.js'
 
 export function isNewInitEnabled(): boolean {
   if (feature('NEW_INIT')) {
-    return (
-      process.env.USER_TYPE === 'ant' ||
-      isEnvTruthy(process.env.CLAUDE_CODE_NEW_INIT)
-    )
+    return isEnvTruthy(process.env.CLAUDE_CODE_NEW_INIT)
   }
 
   return false

--- a/src/commands/insights.ts
+++ b/src/commands/insights.ts
@@ -1,17 +1,12 @@
 import { execFileSync } from 'child_process'
 import { diffLines } from 'diff'
-import { constants as fsConstants } from 'fs'
 import {
-  copyFile,
   mkdir,
-  mkdtemp,
   readdir,
   readFile,
-  rm,
   unlink,
   writeFile,
 } from 'fs/promises'
-import { tmpdir } from 'os'
 import { extname, join } from 'path'
 import type { Command } from '../commands.js'
 import { queryWithModel } from '../services/api/claude.js'
@@ -22,7 +17,6 @@ import {
 import type { LogOption } from '../types/logs.js'
 import { getClaudeConfigHomeDir } from '../utils/envUtils.js'
 import { toError } from '../utils/errors.js'
-import { execFileNoThrow } from '../utils/execFileNoThrow.js'
 import { logError } from '../utils/log.js'
 import { extractTextContent } from '../utils/messages.js'
 import { getDefaultOpusModel } from '../utils/model/model.js'
@@ -57,168 +51,22 @@ type RemoteHostInfo = {
 }
 
 /* eslint-disable custom-rules/no-process-env-top-level */
-const getRunningRemoteHosts: () => Promise<string[]> =
-  process.env.USER_TYPE === 'ant'
-    ? async () => {
-        const { stdout, code } = await execFileNoThrow(
-          'coder',
-          ['list', '-o', 'json'],
-          { timeout: 30000 },
-        )
-        if (code !== 0) return []
-        try {
-          const workspaces = jsonParse(stdout) as Array<{
-            name: string
-            latest_build?: { status?: string }
-          }>
-          return workspaces
-            .filter(w => w.latest_build?.status === 'running')
-            .map(w => w.name)
-        } catch {
-          return []
-        }
-      }
-    : async () => []
+const getRunningRemoteHosts: () => Promise<string[]> = async () => []
 
 const getRemoteHostSessionCount: (hs: string) => Promise<number> =
-  process.env.USER_TYPE === 'ant'
-    ? async (homespace: string) => {
-        const { stdout, code } = await execFileNoThrow(
-          'ssh',
-          [
-            `${homespace}.coder`,
-            'find /root/.claude/projects -name "*.jsonl" 2>/dev/null | wc -l',
-          ],
-          { timeout: 30000 },
-        )
-        if (code !== 0) return 0
-        return parseInt(stdout.trim(), 10) || 0
-      }
-    : async () => 0
+  async () => 0
 
 const collectFromRemoteHost: (
   hs: string,
   destDir: string,
 ) => Promise<{ copied: number; skipped: number }> =
-  process.env.USER_TYPE === 'ant'
-    ? async (homespace: string, destDir: string) => {
-        const result = { copied: 0, skipped: 0 }
-
-        // Create temp directory
-        const tempDir = await mkdtemp(join(tmpdir(), 'claude-hs-'))
-
-        try {
-          // SCP the projects folder
-          const scpResult = await execFileNoThrow(
-            'scp',
-            ['-rq', `${homespace}.coder:/root/.claude/projects/`, tempDir],
-            { timeout: 300000 },
-          )
-          if (scpResult.code !== 0) {
-            // SCP failed
-            return result
-          }
-
-          const projectsDir = join(tempDir, 'projects')
-          let projectDirents: Awaited<ReturnType<typeof readdir>>
-          try {
-            projectDirents = await readdir(projectsDir, { withFileTypes: true })
-          } catch {
-            return result
-          }
-
-          // Merge into destination (parallel per project directory)
-          await Promise.all(
-            projectDirents.map(async dirent => {
-              const projectName = dirent.name
-              const projectPath = join(projectsDir, projectName)
-
-              // Skip if not a directory
-              if (!dirent.isDirectory()) return
-
-              const destProjectName = `${projectName}__${homespace}`
-              const destProjectPath = join(destDir, destProjectName)
-
-              try {
-                await mkdir(destProjectPath, { recursive: true })
-              } catch {
-                // Directory may already exist
-              }
-
-              // Copy session files (skip existing)
-              let files: Awaited<ReturnType<typeof readdir>>
-              try {
-                files = await readdir(projectPath, { withFileTypes: true })
-              } catch {
-                return
-              }
-              await Promise.all(
-                files.map(async fileDirent => {
-                  const fileName = fileDirent.name
-                  if (!fileName.endsWith('.jsonl')) return
-
-                  const srcFile = join(projectPath, fileName)
-                  const destFile = join(destProjectPath, fileName)
-
-                  try {
-                    await copyFile(srcFile, destFile, fsConstants.COPYFILE_EXCL)
-                    result.copied++
-                  } catch {
-                    // EEXIST from COPYFILE_EXCL means dest already exists
-                    result.skipped++
-                  }
-                }),
-              )
-            }),
-          )
-        } finally {
-          try {
-            await rm(tempDir, { recursive: true, force: true })
-          } catch {
-            // Ignore cleanup errors
-          }
-        }
-
-        return result
-      }
-    : async () => ({ copied: 0, skipped: 0 })
+  async () => ({ copied: 0, skipped: 0 })
 
 const collectAllRemoteHostData: (destDir: string) => Promise<{
   hosts: RemoteHostInfo[]
   totalCopied: number
   totalSkipped: number
-}> =
-  process.env.USER_TYPE === 'ant'
-    ? async (destDir: string) => {
-        const rHosts = await getRunningRemoteHosts()
-        const result: RemoteHostInfo[] = []
-        let totalCopied = 0
-        let totalSkipped = 0
-
-        // Collect from all hosts in parallel (SCP per host can take seconds)
-        const hostResults = await Promise.all(
-          rHosts.map(async hs => {
-            const sessionCount = await getRemoteHostSessionCount(hs)
-            if (sessionCount > 0) {
-              const { copied, skipped } = await collectFromRemoteHost(
-                hs,
-                destDir,
-              )
-              return { name: hs, sessionCount, copied, skipped }
-            }
-            return { name: hs, sessionCount, copied: 0, skipped: 0 }
-          }),
-        )
-
-        for (const hr of hostResults) {
-          result.push({ name: hr.name, sessionCount: hr.sessionCount })
-          totalCopied += hr.copied
-          totalSkipped += hr.skipped
-        }
-
-        return { hosts: result, totalCopied, totalSkipped }
-      }
-    : async () => ({ hosts: [], totalCopied: 0, totalSkipped: 0 })
+}> = async () => ({ hosts: [], totalCopied: 0, totalSkipped: 0 })
 /* eslint-enable custom-rules/no-process-env-top-level */
 
 // ============================================================================
@@ -1447,38 +1295,6 @@ RESPOND WITH ONLY A VALID JSON OBJECT:
 Include 3 opportunities. Think BIG - autonomous workflows, parallel agents, iterating against tests.`,
     maxTokens: 8192,
   },
-  ...(process.env.USER_TYPE === 'ant'
-    ? [
-        {
-          name: 'cc_team_improvements',
-          prompt: `Analyze this Claude Code usage data and suggest product improvements for the CC team.
-
-RESPOND WITH ONLY A VALID JSON OBJECT:
-{
-  "improvements": [
-    {"title": "Product/tooling improvement", "detail": "3-4 sentences describing the improvement", "evidence": "3-4 sentences with specific session examples"}
-  ]
-}
-
-Include 2-3 improvements based on friction patterns observed.`,
-          maxTokens: 8192,
-        },
-        {
-          name: 'model_behavior_improvements',
-          prompt: `Analyze this Claude Code usage data and suggest model behavior improvements.
-
-RESPOND WITH ONLY A VALID JSON OBJECT:
-{
-  "improvements": [
-    {"title": "Model behavior change", "detail": "3-4 sentences describing what the model should do differently", "evidence": "3-4 sentences with specific examples"}
-  ]
-}
-
-Include 2-3 improvements based on friction patterns observed.`,
-          maxTokens: 8192,
-        },
-      ]
-    : []),
   {
     name: 'fun_ending',
     prompt: `Analyze this Claude Code usage data and find a memorable moment.
@@ -2187,76 +2003,7 @@ function generateHtmlReport(
     `
       : ''
 
-  // Build Team Feedback section (collapsible, internal-only)
-  const ccImprovements =
-    process.env.USER_TYPE === 'ant'
-      ? insights.cc_team_improvements?.improvements || []
-      : []
-  const modelImprovements =
-    process.env.USER_TYPE === 'ant'
-      ? insights.model_behavior_improvements?.improvements || []
-      : []
-  const teamFeedbackHtml =
-    ccImprovements.length > 0 || modelImprovements.length > 0
-      ? `
-    <h2 id="section-feedback" class="feedback-header">Closing the Loop: Feedback for Other Teams</h2>
-    <p class="feedback-intro">Suggestions for the CC product and model teams based on your usage patterns. Click to expand.</p>
-    ${
-      ccImprovements.length > 0
-        ? `
-    <div class="collapsible-section">
-      <div class="collapsible-header" onclick="toggleCollapsible(this)">
-        <span class="collapsible-arrow">▶</span>
-        <h3>Product Improvements for CC Team</h3>
-      </div>
-      <div class="collapsible-content">
-        <div class="suggestions-section">
-          ${ccImprovements
-            .map(
-              imp => `
-            <div class="feedback-card team-card">
-              <div class="feedback-title">${escapeHtml(imp.title || '')}</div>
-              <div class="feedback-detail">${escapeHtml(imp.detail || '')}</div>
-              ${imp.evidence ? `<div class="feedback-evidence"><em>Evidence:</em> ${escapeHtml(imp.evidence)}</div>` : ''}
-            </div>
-          `,
-            )
-            .join('')}
-        </div>
-      </div>
-    </div>
-    `
-        : ''
-    }
-    ${
-      modelImprovements.length > 0
-        ? `
-    <div class="collapsible-section">
-      <div class="collapsible-header" onclick="toggleCollapsible(this)">
-        <span class="collapsible-arrow">▶</span>
-        <h3>Model Behavior Improvements</h3>
-      </div>
-      <div class="collapsible-content">
-        <div class="suggestions-section">
-          ${modelImprovements
-            .map(
-              imp => `
-            <div class="feedback-card model-card">
-              <div class="feedback-title">${escapeHtml(imp.title || '')}</div>
-              <div class="feedback-detail">${escapeHtml(imp.detail || '')}</div>
-              ${imp.evidence ? `<div class="feedback-evidence"><em>Evidence:</em> ${escapeHtml(imp.evidence)}</div>` : ''}
-            </div>
-          `,
-            )
-            .join('')}
-        </div>
-      </div>
-    </div>
-    `
-        : ''
-    }
-    `
-      : ''
+  const teamFeedbackHtml = ''
 
   // Build Fun Ending section
   const funEnding = insights.fun_ending
@@ -2802,14 +2549,7 @@ export async function generateUsageReport(options?: {
   remoteStats?: { hosts: RemoteHostInfo[]; totalCopied: number }
   facets: Map<string, SessionFacets>
 }> {
-  let remoteStats: { hosts: RemoteHostInfo[]; totalCopied: number } | undefined
-
-  // Optionally collect data from remote hosts first (internal-only)
-  if (process.env.USER_TYPE === 'ant' && options?.collectRemote) {
-    const destDir = join(getClaudeConfigHomeDir(), 'projects')
-    const { hosts, totalCopied } = await collectAllRemoteHostData(destDir)
-    remoteStats = { hosts, totalCopied }
-  }
+  const remoteStats: { hosts: RemoteHostInfo[]; totalCopied: number } | undefined = undefined
 
   // Phase 1: Lite scan — filesystem metadata only (no JSONL parsing)
   const allScannedSessions = await scanAllSessions()
@@ -3044,30 +2784,7 @@ const usageReport: Command = {
   progressMessage: 'analyzing your sessions',
   source: 'builtin',
   async getPromptForCommand(args) {
-    let collectRemote = false
-    let remoteHosts: string[] = []
-    let hasRemoteHosts = false
-
-    if (process.env.USER_TYPE === 'ant') {
-      // Parse --homespaces flag
-      collectRemote = args?.includes('--homespaces') ?? false
-
-      // Check for available remote hosts
-      remoteHosts = await getRunningRemoteHosts()
-      hasRemoteHosts = remoteHosts.length > 0
-
-      // Show collection message if collecting
-      if (collectRemote && hasRemoteHosts) {
-        // biome-ignore lint/suspicious/noConsole: intentional
-        console.error(
-          `Collecting sessions from ${remoteHosts.length} homespace(s): ${remoteHosts.join(', ')}...`,
-        )
-      }
-    }
-
-    const { insights, htmlPath, data, remoteStats } = await generateUsageReport(
-      { collectRemote },
-    )
+    const { insights, htmlPath, data, remoteStats } = await generateUsageReport()
 
     let reportUrl = `file://${htmlPath}`
     let uploadHint = ''
@@ -3085,20 +2802,7 @@ const usageReport: Command = {
       `${data.git_commits} commits`,
     ].join(' · ')
 
-    // Build remote host info (internal-only)
-    let remoteInfo = ''
-    if (process.env.USER_TYPE === 'ant') {
-      if (remoteStats && remoteStats.totalCopied > 0) {
-        const hsNames = remoteStats.hosts
-          .filter(h => h.sessionCount > 0)
-          .map(h => h.name)
-          .join(', ')
-        remoteInfo = `\n_Collected ${remoteStats.totalCopied} new sessions from: ${hsNames}_\n`
-      } else if (!collectRemote && hasRemoteHosts) {
-        // Suggest using --homespaces if they have remote hosts but didn't use the flag
-        remoteInfo = `\n_Tip: Run \`/insights --homespaces\` to include sessions from your ${remoteHosts.length} running homespace(s)_\n`
-      }
-    }
+    const remoteInfo = ''
 
     // Build markdown summary from insights
     const atAGlance = insights.at_a_glance

--- a/src/commands/insights.ts
+++ b/src/commands/insights.ts
@@ -41,33 +41,6 @@ function getInsightsModel(): string {
   return getDefaultOpusModel()
 }
 
-// ============================================================================
-// Homespace Data Collection
-// ============================================================================
-
-type RemoteHostInfo = {
-  name: string
-  sessionCount: number
-}
-
-/* eslint-disable custom-rules/no-process-env-top-level */
-const getRunningRemoteHosts: () => Promise<string[]> = async () => []
-
-const getRemoteHostSessionCount: (hs: string) => Promise<number> =
-  async () => 0
-
-const collectFromRemoteHost: (
-  hs: string,
-  destDir: string,
-) => Promise<{ copied: number; skipped: number }> =
-  async () => ({ copied: 0, skipped: 0 })
-
-const collectAllRemoteHostData: (destDir: string) => Promise<{
-  hosts: RemoteHostInfo[]
-  totalCopied: number
-  totalSkipped: number
-}> = async () => ({ hosts: [], totalCopied: 0, totalSkipped: 0 })
-/* eslint-enable custom-rules/no-process-env-top-level */
 
 // ============================================================================
 // Types
@@ -2406,7 +2379,6 @@ export type InsightsExport = {
     claude_code_version: string
     date_range: { start: string; end: string }
     session_count: number
-    remote_hosts_collected?: string[]
   }
   aggregated_data: AggregatedData
   insights: InsightResults
@@ -2427,13 +2399,8 @@ export function buildExportData(
   data: AggregatedData,
   insights: InsightResults,
   facets: Map<string, SessionFacets>,
-  remoteStats?: { hosts: RemoteHostInfo[]; totalCopied: number },
 ): InsightsExport {
   const version = typeof MACRO !== 'undefined' ? MACRO.VERSION : 'unknown'
-
-  const remote_hosts_collected = remoteStats?.hosts
-    .filter(h => h.sessionCount > 0)
-    .map(h => h.name)
 
   const facets_summary = {
     total: facets.size,
@@ -2472,10 +2439,6 @@ export function buildExportData(
       claude_code_version: version,
       date_range: data.date_range,
       session_count: data.total_sessions,
-      ...(remote_hosts_collected &&
-        remote_hosts_collected.length > 0 && {
-          remote_hosts_collected,
-        }),
     },
     aggregated_data: data,
     insights,
@@ -2540,17 +2503,12 @@ async function scanAllSessions(): Promise<LiteSessionInfo[]> {
 // Main Function
 // ============================================================================
 
-export async function generateUsageReport(options?: {
-  collectRemote?: boolean
-}): Promise<{
+export async function generateUsageReport(): Promise<{
   insights: InsightResults
   htmlPath: string
   data: AggregatedData
-  remoteStats?: { hosts: RemoteHostInfo[]; totalCopied: number }
   facets: Map<string, SessionFacets>
 }> {
-  const remoteStats: { hosts: RemoteHostInfo[]; totalCopied: number } | undefined = undefined
-
   // Phase 1: Lite scan — filesystem metadata only (no JSONL parsing)
   const allScannedSessions = await scanAllSessions()
   const totalSessionsScanned = allScannedSessions.length
@@ -2757,7 +2715,6 @@ export async function generateUsageReport(options?: {
     insights,
     htmlPath,
     data: aggregated,
-    remoteStats,
     facets: substantiveFacets,
   }
 }
@@ -2784,7 +2741,7 @@ const usageReport: Command = {
   progressMessage: 'analyzing your sessions',
   source: 'builtin',
   async getPromptForCommand(args) {
-    const { insights, htmlPath, data, remoteStats } = await generateUsageReport()
+    const { insights, htmlPath, data } = await generateUsageReport()
 
     let reportUrl = `file://${htmlPath}`
     let uploadHint = ''

--- a/src/commands/tag/index.ts
+++ b/src/commands/tag/index.ts
@@ -4,7 +4,7 @@ const tag = {
   type: 'local-jsx',
   name: 'tag',
   description: 'Toggle a searchable tag on the current session',
-  isEnabled: () => process.env.USER_TYPE === 'ant',
+  isEnabled: () => false,
   argumentHint: '<tag-name>',
   load: () => import('./tag.js'),
 } satisfies Command

--- a/src/commands/thinkback-play/thinkback-play.ts
+++ b/src/commands/thinkback-play/thinkback-play.ts
@@ -4,15 +4,10 @@ import { loadInstalledPluginsV2 } from '../../utils/plugins/installedPluginsMana
 import { OFFICIAL_MARKETPLACE_NAME } from '../../utils/plugins/officialMarketplace.js'
 import { playAnimation } from '../thinkback/thinkback.js'
 
-const INTERNAL_MARKETPLACE_NAME = 'claude-code-marketplace'
 const SKILL_NAME = 'thinkback'
 
 function getPluginId(): string {
-  const marketplaceName =
-    process.env.USER_TYPE === 'ant'
-      ? INTERNAL_MARKETPLACE_NAME
-      : OFFICIAL_MARKETPLACE_NAME
-  return `thinkback@${marketplaceName}`
+  return `thinkback@${OFFICIAL_MARKETPLACE_NAME}`
 }
 
 export async function call(): Promise<LocalCommandResult> {

--- a/src/commands/version.ts
+++ b/src/commands/version.ts
@@ -14,7 +14,7 @@ const version = {
   name: 'version',
   description:
     'Print the version this session is running (not what autoupdate downloaded)',
-  isEnabled: () => process.env.USER_TYPE === 'ant',
+  isEnabled: () => false,
   supportsNonInteractive: true,
   load: () => Promise.resolve({ call }),
 } satisfies Command

--- a/src/ink/termio/osc.ts
+++ b/src/ink/termio/osc.ts
@@ -490,7 +490,7 @@ export const CLEAR_TAB_STATUS = osc(
  * DCS-passthrough carries the sequence to the outer terminal.
  */
 export function supportsTabStatus(): boolean {
-  return process.env.USER_TYPE === 'ant'
+  return false
 }
 
 /**

--- a/src/ink/termio/osc.ts
+++ b/src/ink/termio/osc.ts
@@ -4,6 +4,7 @@
 
 import { Buffer } from 'buffer'
 import { unlink, writeFile } from 'node:fs/promises'
+import { getFeatureValue_CACHED_MAY_BE_STALE } from '../../services/analytics/growthbook.js'
 import { env } from '../../utils/env.js'
 import { execFileNoThrow } from '../../utils/execFileNoThrow.js'
 import { generateTempFilePath } from '../../utils/tempfile.js'
@@ -490,7 +491,7 @@ export const CLEAR_TAB_STATUS = osc(
  * DCS-passthrough carries the sequence to the outer terminal.
  */
 export function supportsTabStatus(): boolean {
-  return false
+  return getFeatureValue_CACHED_MAY_BE_STALE('tengu_terminal_sidebar', false)
 }
 
 /**

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -50,7 +50,6 @@ import { TodoWriteTool } from './tools/TodoWriteTool/TodoWriteTool.js'
 import { ExitPlanModeV2Tool } from './tools/ExitPlanModeTool/ExitPlanModeV2Tool.js'
 import { TestingPermissionTool } from './tools/testing/TestingPermissionTool.js'
 import { GrepTool } from './tools/GrepTool/GrepTool.js'
-import { TungstenTool } from './tools/TungstenTool/TungstenTool.js'
 // Lazy require to break circular dependency: tools.ts -> TeamCreateTool/TeamDeleteTool -> ... -> tools.ts
 /* eslint-disable @typescript-eslint/no-require-imports */
 const getTeamCreateTool = () =>
@@ -71,7 +70,6 @@ import { ToolSearchTool } from './tools/ToolSearchTool/ToolSearchTool.js'
 import { EnterPlanModeTool } from './tools/EnterPlanModeTool/EnterPlanModeTool.js'
 import { EnterWorktreeTool } from './tools/EnterWorktreeTool/EnterWorktreeTool.js'
 import { ExitWorktreeTool } from './tools/ExitWorktreeTool/ExitWorktreeTool.js'
-import { ConfigTool } from './tools/ConfigTool/ConfigTool.js'
 import { TaskCreateTool } from './tools/TaskCreateTool/TaskCreateTool.js'
 import { TaskGetTool } from './tools/TaskGetTool/TaskGetTool.js'
 import { TaskUpdateTool } from './tools/TaskUpdateTool/TaskUpdateTool.js'

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -13,15 +13,8 @@ import { TaskStopTool } from './tools/TaskStopTool/TaskStopTool.js'
 import { BriefTool } from './tools/BriefTool/BriefTool.js'
 // Dead code elimination: conditional import for internal-only tools
 /* eslint-disable custom-rules/no-process-env-top-level, @typescript-eslint/no-require-imports */
-const REPLTool =
-  process.env.USER_TYPE === 'ant'
-    ? require('./tools/REPLTool/REPLTool.js').REPLTool
-    : null
-const SuggestBackgroundPRTool =
-  process.env.USER_TYPE === 'ant'
-    ? require('./tools/SuggestBackgroundPRTool/SuggestBackgroundPRTool.js')
-        .SuggestBackgroundPRTool
-    : null
+const REPLTool = null
+const SuggestBackgroundPRTool = null
 const SleepTool =
   feature('PROACTIVE') || feature('KAIROS')
     ? require('./tools/SleepTool/SleepTool.js').SleepTool
@@ -211,8 +204,6 @@ export function getAllBaseTools(): Tools {
     AskUserQuestionTool,
     SkillTool,
     EnterPlanModeTool,
-    ...(process.env.USER_TYPE === 'ant' ? [ConfigTool] : []),
-    ...(process.env.USER_TYPE === 'ant' ? [TungstenTool] : []),
     ...(SuggestBackgroundPRTool ? [SuggestBackgroundPRTool] : []),
     ...(WebBrowserTool ? [WebBrowserTool] : []),
     ...(isTodoV2Enabled()
@@ -229,7 +220,6 @@ export function getAllBaseTools(): Tools {
       ? [getTeamCreateTool(), getTeamDeleteTool()]
       : []),
     ...(VerifyPlanExecutionTool ? [VerifyPlanExecutionTool] : []),
-    ...(process.env.USER_TYPE === 'ant' && REPLTool ? [REPLTool] : []),
     ...(WorkflowTool ? [WorkflowTool] : []),
     ...(SleepTool ? [SleepTool] : []),
     ...cronTools,

--- a/src/tools/BashTool/readOnlyValidation.ts
+++ b/src/tools/BashTool/readOnlyValidation.ts
@@ -1208,9 +1208,6 @@ function getCommandAllowlist(): Record<string, CommandConfig> {
     const { xargs: _, ...rest } = allowlist
     allowlist = rest
   }
-  if (process.env.USER_TYPE === 'ant') {
-    return { ...allowlist, ...ANT_ONLY_COMMAND_ALLOWLIST }
-  }
   return allowlist
 }
 

--- a/src/tools/BashTool/readOnlyValidation.ts
+++ b/src/tools/BashTool/readOnlyValidation.ts
@@ -1136,67 +1136,6 @@ const COMMAND_ALLOWLIST: Record<string, CommandConfig> = {
   ...DOCKER_READ_ONLY_COMMANDS,
 }
 
-// gh commands are internal-only since they make network requests, which goes against
-// the read-only validation principle of no network access
-const ANT_ONLY_COMMAND_ALLOWLIST: Record<string, CommandConfig> = {
-  // All gh read-only commands from shared validation map
-  ...GH_READ_ONLY_COMMANDS,
-  // aki — internal knowledge-base search CLI.
-  // Network read-only (same policy as gh). --audit-csv omitted: writes to disk.
-  aki: {
-    safeFlags: {
-      '-h': 'none',
-      '--help': 'none',
-      '-k': 'none',
-      '--keyword': 'none',
-      '-s': 'none',
-      '--semantic': 'none',
-      '--no-adaptive': 'none',
-      '-n': 'number',
-      '--limit': 'number',
-      '-o': 'number',
-      '--offset': 'number',
-      '--source': 'string',
-      '--exclude-source': 'string',
-      '-a': 'string',
-      '--after': 'string',
-      '-b': 'string',
-      '--before': 'string',
-      '--collection': 'string',
-      '--drive': 'string',
-      '--folder': 'string',
-      '--descendants': 'none',
-      '-m': 'string',
-      '--meta': 'string',
-      '-t': 'string',
-      '--threshold': 'string',
-      '--kw-weight': 'string',
-      '--sem-weight': 'string',
-      '-j': 'none',
-      '--json': 'none',
-      '-c': 'none',
-      '--chunk': 'none',
-      '--preview': 'none',
-      '-d': 'none',
-      '--full-doc': 'none',
-      '-v': 'none',
-      '--verbose': 'none',
-      '--stats': 'none',
-      '-S': 'number',
-      '--summarize': 'number',
-      '--explain': 'none',
-      '--examine': 'string',
-      '--url': 'string',
-      '--multi-turn': 'number',
-      '--multi-turn-model': 'string',
-      '--multi-turn-context': 'string',
-      '--no-rerank': 'none',
-      '--audit': 'none',
-      '--local': 'none',
-      '--staging': 'none',
-    },
-  },
-}
 
 function getCommandAllowlist(): Record<string, CommandConfig> {
   let allowlist: Record<string, CommandConfig> = COMMAND_ALLOWLIST


### PR DESCRIPTION
## Summary

- Remove ~45 `process.env.USER_TYPE === 'ant'` checks that gate purely internal/dead code across 28 source files
- Continues the cleanup started in #315 by gnanam1990
- Categories removed: undercover guards, internal CLI commands (`/bridge-kick`, `/tag`, `/files`, `/version`), bridge debug infrastructure (fault injection, SIGUSR2 handler, debug handles), internal tool stubs (`REPLTool`, `TungstenTool`, `ConfigTool`, `SuggestBackgroundPRTool`), internal performance/analytics instrumentation, and internal insights remote host collection

**Does NOT touch** USER_TYPE gates that protect useful features (agent nesting in `constants/tools.ts`, effort overrides, sandbox config, computer use).

### Files changed (28 files, -607 lines)

| Category | Files |
|----------|-------|
| Undercover guards | `commit.ts`, `commit-push-pr.ts` |
| Internal CLI commands | `bridge-kick.ts`, `tag/index.ts`, `files/index.ts`, `version.ts` |
| Bridge debug infra | `replBridge.ts`, `bridgeMain.ts`, `bridgeUI.ts`, `bridgeConfig.ts`, `initReplBridge.ts`, `sessionRunner.ts` |
| Internal tools | `tools.ts` |
| Internal state/perf | `state.ts`, `print.ts` |
| Internal insights | `insights.ts`, `context-noninteractive.ts` |
| Misc internal code | `update.ts`, `osc.ts`, `caches.ts`, `conversation.ts`, `cost/index.ts`, `cost/cost.ts`, `initMode.ts`, `feedback/index.ts`, `createMovedToPluginCommand.ts`, `thinkback-play.ts`, `readOnlyValidation.ts` |

## Test plan

- [x] `bun run build` compiles successfully
- [x] `bun run smoke` passes
- [ ] Verify no regressions in external user workflows (commit, PR, feedback, insights commands)
- [ ] Verify bridge/remote-control mode still works for non-ant users