### PR TITLE
fix: extend provider guard to protect anthropic profiles from cross-t…

### DIFF
--- a/src/utils/providerProfiles.test.ts
+++ b/src/utils/providerProfiles.test.ts
@@ -259,6 +259,8 @@ describe('applyActiveProviderProfileFromConfig', () => {
     delete process.env.CLAUDE_CODE_USE_BEDROCK
     delete process.env.CLAUDE_CODE_USE_VERTEX
     delete process.env.CLAUDE_CODE_USE_FOUNDRY
+    delete process.env.CLAUDE_CODE_PROVIDER_PROFILE_ENV_APPLIED
+    delete process.env.CLAUDE_CODE_PROVIDER_PROFILE_ENV_APPLIED_ID
 
     process.env.OPENAI_BASE_URL = 'http://localhost:11434/v1'
     process.env.OPENAI_MODEL = 'qwen2.5:3b'

--- a/src/utils/providerProfiles.ts
+++ b/src/utils/providerProfiles.ts
@@ -417,7 +417,7 @@ export function applyActiveProviderProfileFromConfig(
     processEnv[PROFILE_ENV_APPLIED_FLAG] === '1' &&
     trimOrUndefined(processEnv[PROFILE_ENV_APPLIED_ID]) === activeProfile.id
 
-  if (!options?.force && hasProviderSelectionFlags(processEnv)) {
+  if (!options?.force && (hasProviderSelectionFlags(processEnv) || processEnv[PROFILE_ENV_APPLIED_FLAG] === '1')) {
     // Respect explicit startup provider intent. Auto-heal only when this
     // exact active profile previously applied the current env.
     if (!isCurrentEnvProfileManaged) {


### PR DESCRIPTION
---

## Summary

Fixes a bug where two terminals sharing `~/.claude.json` could overwrite each other's active provider profile when using different provider types (e.g., one terminal on Anthropic, another on a custom OpenAI-compatible provider).

---

## Impact

**Before:**  
The provider activation guard in `applyActiveProviderProfileFromConfig()` only checked `CLAUDE_CODE_USE_*` environment flags (like `CLAUDE_CODE_USE_OPENAI`), which are never set for the default Anthropic provider.

This caused cross-terminal interference:

- Terminal A: Uses Anthropic provider (no `USE_*` flags set)
- Terminal B: Uses custom OpenAI-compatible provider (`CLAUDE_CODE_USE_OPENAI=1`)
- When Terminal B activates its profile → Terminal A's Anthropic guard sees no flags and allows the override → Terminal A's session gets corrupted

**After:**  
The guard now also checks `CLAUDE_CODE_PROVIDER_PROFILE_APPLIED`, which is set by all provider profiles including Anthropic. This prevents cross-terminal interference regardless of provider type.

---

## Testing

**Reproduce bug (before fix):**

```bash
# Terminal 1
  openclaude --provider my-anthropic-custom
  
# Terminal 2
  openclaude --provider my-openai-custom

# Result: Terminal 1's provider gets overwritten

## Verify fix (after fix):

# Same setup — both terminals maintain their selected providers

Unit test updated to clean up the new env flag in teardown.

## Notes
Minimal change: single condition added to existing guard logic
No breaking changes — only prevents unintended behavior
Related to multi-terminal provider isolation work