### PR TITLE
fix: improve fetch diagnostics for bootstrap and session requests

### DIFF
--- a/src/bridge/createSession.ts
+++ b/src/bridge/createSession.ts
@@ -217,13 +217,14 @@ export async function getBridgeSession(
   }
 
   const url = `${opts?.baseUrl ?? getOauthConfig().BASE_API_URL}/v1/sessions/${sessionId}`
+  const timeoutMs = 10_000
   logForDebugging(`[bridge] Fetching session ${sessionId}`)
 
   let response
   try {
     response = await axios.get<{ environment_id?: string; title?: string }>(
       url,
-      { headers, timeout: 10_000, validateStatus: s => s < 500 },
+      { headers, timeout: timeoutMs, validateStatus: s => s < 500 },
     )
   } catch (err: unknown) {
     if (axios.isAxiosError(err)) {
@@ -232,13 +233,14 @@ export async function getBridgeSession(
       const requestUrl = err.config?.url ?? url
       const method = err.config?.method?.toUpperCase() ?? 'GET'
       const message = err.message ?? errorMessage(err)
+      const timeout = err.config?.timeout ?? timeoutMs
 
       logForDebugging(
-        `[bridge] Session fetch request failed: status=${status} code=${code} method=${method} url=${requestUrl} timeout=10000 message=${message}`,
+        `[bridge] Session fetch request failed: status=${status} code=${code} method=${method} url=${requestUrl} timeout=${timeout} message=${message}`,
       )
     } else {
       logForDebugging(
-        `[bridge] Session fetch request failed: url=${url} timeout=10000 message=${errorMessage(err)}`,
+        `[bridge] Session fetch request failed: url=${url} timeout=${timeoutMs} message=${errorMessage(err)}`,
       )
     }
     return null

--- a/src/bridge/createSession.ts
+++ b/src/bridge/createSession.ts
@@ -226,16 +226,28 @@ export async function getBridgeSession(
       { headers, timeout: 10_000, validateStatus: s => s < 500 },
     )
   } catch (err: unknown) {
-    logForDebugging(
-      `[bridge] Session fetch request failed: ${errorMessage(err)}`,
-    )
+    if (axios.isAxiosError(err)) {
+      const status = err.response?.status ?? 'no-response'
+      const code = err.code ?? 'unknown-code'
+      const requestUrl = err.config?.url ?? url
+      const method = err.config?.method?.toUpperCase() ?? 'GET'
+      const message = err.message ?? errorMessage(err)
+
+      logForDebugging(
+        `[bridge] Session fetch request failed: status=${status} code=${code} method=${method} url=${requestUrl} timeout=10000 message=${message}`,
+      )
+    } else {
+      logForDebugging(
+        `[bridge] Session fetch request failed: url=${url} timeout=10000 message=${errorMessage(err)}`,
+      )
+    }
     return null
   }
 
   if (response.status !== 200) {
     const detail = extractErrorDetail(response.data)
     logForDebugging(
-      `[bridge] Session fetch failed with status ${response.status}${detail ? `: ${detail}` : ''}`,
+      `[bridge] Session fetch failed with status ${response.status} url=${url}${detail ? `: ${detail}` : ''}`,
     )
     return null
   }

--- a/src/services/api/bootstrap.ts
+++ b/src/services/api/bootstrap.ts
@@ -116,9 +116,21 @@ async function fetchBootstrapAPI(): Promise<BootstrapResponse | null> {
       return parsed.data
     })
   } catch (error) {
-    logForDebugging(
-      `[Bootstrap] Fetch failed: ${axios.isAxiosError(error) ? (error.response?.status ?? error.code) : 'unknown'}`,
-    )
+    if (axios.isAxiosError(error)) {
+      const status = error.response?.status ?? 'no-response'
+      const code = error.code ?? 'unknown-code'
+      const method = error.config?.method?.toUpperCase() ?? 'UNKNOWN'
+      const requestUrl = error.config?.url ?? 'unknown-url'
+      const message = error.message ?? 'unknown axios error'
+
+      logForDebugging(
+        `[Bootstrap] Fetch failed: status=${status} code=${code} method=${method} url=${requestUrl} message=${message}`,
+      )
+    } else {
+      const message = error instanceof Error ? error.message : String(error)
+      logForDebugging(`[Bootstrap] Fetch failed: ${message}`)
+    }
+
     throw error
   }
 }


### PR DESCRIPTION
## Summary

This PR improves diagnostics for fetch failures in the bootstrap and session request paths.

## Changes

- In `src/services/api/bootstrap.ts`, log richer Axios error context on fetch failure:
  - HTTP status (or `no-response`)
  - Axios error code
  - HTTP method
  - request URL
  - error message

- In `src/bridge/createSession.ts`:
  - log detailed Axios context when the session fetch throws (status, code, method, URL, timeout, message)
  - log the request URL when the session returns a non-200 status

## Why

Users in #490 and related issues are seeing only a generic `fetch failed` message when using Ollama/OpenAI-compatible providers on Windows, even when the Ollama HTTP API itself is healthy.

This PR does not change behavior, but makes failures much more actionable by surfacing which request path/status/code is failing, which should make it easier to debug provider/runtime issues such as the ones reported in #490.

Related to: #490