### PR TITLE
feat: activate coordinator mode in open build

### DIFF
--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -29,6 +29,7 @@ const featureFlags: Record<string, boolean> = {
   DUMP_SYSTEM_PROMPT: false,
   CACHED_MICROCOMPACT: false,
   COORDINATOR_MODE: true,
+  BUILTIN_EXPLORE_PLAN_AGENTS: true,
   CONTEXT_COLLAPSE: false,
   COMMIT_ATTRIBUTION: false,
   TEAMMEM: false,

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -28,7 +28,7 @@ const featureFlags: Record<string, boolean> = {
   ABLATION_BASELINE: false,
   DUMP_SYSTEM_PROMPT: false,
   CACHED_MICROCOMPACT: false,
-  COORDINATOR_MODE: false,
+  COORDINATOR_MODE: true,
   CONTEXT_COLLAPSE: false,
   COMMIT_ATTRIBUTION: false,
   TEAMMEM: false,

--- a/src/coordinator/workerAgent.ts
+++ b/src/coordinator/workerAgent.ts
@@ -1,8 +1,18 @@
-import type { AgentDefinition } from '../tools/AgentTool/loadAgentsDir.js'
+import type { BuiltInAgentDefinition } from '../tools/AgentTool/loadAgentsDir.js'
 import { EXPLORE_AGENT } from '../tools/AgentTool/built-in/exploreAgent.js'
 import { GENERAL_PURPOSE_AGENT } from '../tools/AgentTool/built-in/generalPurposeAgent.js'
 import { PLAN_AGENT } from '../tools/AgentTool/built-in/planAgent.js'
 
-export function getCoordinatorAgents(): AgentDefinition[] {
-  return [GENERAL_PURPOSE_AGENT, EXPLORE_AGENT, PLAN_AGENT]
+// The coordinator system prompt instructs the model to spawn workers with
+// subagent_type: "worker". This agent definition matches that type so
+// AgentTool.tsx can resolve it. It reuses GENERAL_PURPOSE_AGENT's capabilities.
+const WORKER_AGENT: BuiltInAgentDefinition = {
+  ...GENERAL_PURPOSE_AGENT,
+  agentType: 'worker',
+  whenToUse:
+    'Worker agent for coordinator mode. Executes tasks autonomously — research, implementation, or verification.',
+}
+
+export function getCoordinatorAgents(): BuiltInAgentDefinition[] {
+  return [WORKER_AGENT, GENERAL_PURPOSE_AGENT, EXPLORE_AGENT, PLAN_AGENT]
 }

--- a/src/coordinator/workerAgent.ts
+++ b/src/coordinator/workerAgent.ts
@@ -1,0 +1,8 @@
+import type { AgentDefinition } from '../tools/AgentTool/loadAgentsDir.js'
+import { EXPLORE_AGENT } from '../tools/AgentTool/built-in/exploreAgent.js'
+import { GENERAL_PURPOSE_AGENT } from '../tools/AgentTool/built-in/generalPurposeAgent.js'
+import { PLAN_AGENT } from '../tools/AgentTool/built-in/planAgent.js'
+
+export function getCoordinatorAgents(): AgentDefinition[] {
+  return [GENERAL_PURPOSE_AGENT, EXPLORE_AGENT, PLAN_AGENT]
+}


### PR DESCRIPTION
## Summary

Activate the full multi-agent system in the open build: coordinator mode, worker agents, and built-in Explore/Plan agents.

### Highlight: agent nesting unlocked

The most impactful change is a single line removed in `src/constants/tools.ts:41` (PR #644):
```typescript
...(process.env.USER_TYPE === 'ant' ? [] : [AGENT_TOOL_NAME]),
```
This line added `AGENT_TOOL_NAME` to the disallowed tools list for sub-agents, preventing non-ant users from using recursive agent workflows. Removing it unlocks **recursive agent spawning**: a sub-agent can now spawn its own sub-agents. This enables complex coordination patterns (agent teams, hierarchical delegation) that were previously reserved for Anthropic employees.

### Changes (3 commits)

**1. Coordinator mode activated** (`scripts/build.ts`, `src/coordinator/workerAgent.ts`)
- Enable `COORDINATOR_MODE: true` build flag
- Create `workerAgent.ts` — the only missing module from the source snapshot
- Includes `WORKER_AGENT` with `agentType: 'worker'` to match the coordinator system prompt's `subagent_type: "worker"` instructions

**2. Explore and Plan agents activated** (`scripts/build.ts`)
- Enable `BUILTIN_EXPLORE_PLAN_AGENTS: true` build flag
- Makes Explore (fast, haiku, read-only) and Plan (architect, read-only) agents available in both normal and coordinator modes
- Resolves the inconsistency where coordinator workers had these agents but normal sessions did not

### What is coordinator mode?

A multi-agent orchestration system:
- A **coordinator** receives the user's task and decomposes it into sub-tasks
- It spawns **workers** via `AgentTool` that execute in parallel
- Workers communicate back via `SendMessageTool`, coordinator can stop them with `TaskStopTool`
- A 252-line system prompt guides the coordinator's orchestration strategy
- Session mode persists across restarts

### Runtime activation

Coordinator mode is **opt-in at runtime**:
```bash
export CLAUDE_CODE_COORDINATOR_MODE=1
```

Explore and Plan agents are **always available** (no env var needed).

Optional scratchpad for cross-worker knowledge sharing:
```json
// ~/.claude/feature-flags.json (requires #639)
{ "tengu_scratch": true }
```

### Relationship to other PRs
- **#644** (agent nesting) — compatible: coordinator has its own `COORDINATOR_MODE_ALLOWED_TOOLS`
- **#639** (local feature flags) — enables `tengu_scratch` scratchpad and `tengu_amber_stoat` control
- **#637** (dead code) — no overlap with coordinator files

## Test plan
- [x] `bun run build` — compiles successfully
- [x] `bun run smoke` — smoke tests pass
- [ ] Set `CLAUDE_CODE_COORDINATOR_MODE=1`, verify coordinator system prompt loads
- [ ] Spawn a worker agent with `subagent_type: "worker"`, verify it resolves
- [ ] Verify Explore and Plan agents appear in `/agent` list
- [ ] Test session resume preserves coordinator mode
- [ ] Verify coordinator mode is inactive by default (no env var = normal mode)