### PR TITLE
feat: add Qwen OAuth integration and provider support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ GEMINI.md
 package-lock.json
 /.claude
 coverage/
+.openclaude/settings.local.json

--- a/src/QueryEngine.ts
+++ b/src/QueryEngine.ts
@@ -486,7 +486,9 @@ export class QueryEngine {
       },
     }))
 
-    const mainLoopModel = modelFromUserInput ?? initialMainLoopModel
+    const mainLoopModel = modelFromUserInput ?? (userSpecifiedModel
+      ? parseUserSpecifiedModel(userSpecifiedModel)
+      : getMainLoopModel())
 
     // Recreate after processing the prompt to pick up updated messages and
     // model (from slash commands).

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -21,6 +21,7 @@ import dream from './commands/dream/index.js'
 import ctx_viz from './commands/ctx_viz/index.js'
 import doctor from './commands/doctor/index.js'
 import onboardGithub from './commands/onboard-github/index.js'
+import onboardQwen from './commands/onboard-qwen/index.js'
 import memory from './commands/memory/index.js'
 import help from './commands/help/index.js'
 import ide from './commands/ide/index.js'
@@ -299,6 +300,7 @@ const COMMANDS = memoize((): Command[] => [
   mobile,
   model,
   onboardGithub,
+  onboardQwen,
   outputStyle,
   remoteEnv,
   plugin,

--- a/src/commands/onboard-qwen/index.ts
+++ b/src/commands/onboard-qwen/index.ts
@@ -1,0 +1,12 @@
+import type { Command } from '../../commands.js'
+
+const onboardQwen: Command = {
+  name: 'onboard-qwen',
+  aliases: ['qwen-login', 'onboardqwen', 'qwenlogin'],
+  description:
+    'Interactive setup for Qwen (free OAuth): device-flow sign-in, credentials stored at ~/.qwen/oauth_creds.json',
+  type: 'local-jsx',
+  load: () => import('./onboard-qwen.js'),
+}
+
+export default onboardQwen

--- a/src/commands/onboard-qwen/onboard-qwen.tsx
+++ b/src/commands/onboard-qwen/onboard-qwen.tsx
@@ -1,0 +1,248 @@
+import * as React from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { Select } from '../../components/CustomSelect/select.js'
+import { Spinner } from '../../components/Spinner.js'
+import { Box, Text } from '../../ink.js'
+import {
+  openQwenVerificationUri,
+  pollQwenDeviceToken,
+  requestQwenDeviceCode,
+} from '../../services/qwen/deviceFlow.js'
+import type { LocalJSXCommandCall } from '../../types/command.js'
+import {
+  fromTokenResponse,
+  hydrateQwenCredentialsFromDisk,
+  loadQwenCredentials,
+  saveQwenCredentials,
+} from '../../utils/qwenCredentials.js'
+import { resolveQwenBaseUrl } from '../../services/qwen/deviceFlow.js'
+import {
+  getSettingsForSource,
+  updateSettingsForSource,
+} from '../../utils/settings/settings.js'
+
+const DEFAULT_MODEL = 'qwen3-coder-plus'
+
+const FORCE_RELOGIN_ARGS = new Set([
+  'force',
+  '--force',
+  'relogin',
+  '--relogin',
+  'reauth',
+  '--reauth',
+])
+
+const PROVIDER_SPECIFIC_KEYS = new Set([
+  'CLAUDE_CODE_USE_OPENAI',
+  'CLAUDE_CODE_USE_GEMINI',
+  'CLAUDE_CODE_USE_GITHUB',
+  'CLAUDE_CODE_USE_MISTRAL',
+  'CLAUDE_CODE_USE_BEDROCK',
+  'CLAUDE_CODE_USE_VERTEX',
+  'CLAUDE_CODE_USE_FOUNDRY',
+  'OPENAI_BASE_URL',
+  'OPENAI_API_BASE',
+  'OPENAI_API_KEY',
+  'OPENAI_MODEL',
+])
+
+type Step = 'menu' | 'device-busy' | 'error'
+
+export function shouldForceQwenRelogin(args?: string): boolean {
+  const normalized = (args ?? '').trim().toLowerCase()
+  if (!normalized) return false
+  return normalized.split(/\s+/).some(arg => FORCE_RELOGIN_ARGS.has(arg))
+}
+
+export function hasExistingQwenLogin(): boolean {
+  const creds = loadQwenCredentials()
+  if (!creds) return false
+  // Even if expired, the refresh token lets us recover silently — treat as present.
+  return Boolean(creds.refresh_token)
+}
+
+function applyQwenProcessEnv(
+  model: string,
+  baseUrl: string,
+  accessToken: string,
+  env: NodeJS.ProcessEnv = process.env,
+): void {
+  for (const key of PROVIDER_SPECIFIC_KEYS) {
+    delete env[key]
+  }
+  env.CLAUDE_CODE_USE_QWEN = '1'
+  env.OPENAI_BASE_URL = baseUrl
+  env.OPENAI_MODEL = model
+  env.OPENAI_API_KEY = accessToken
+  delete env.CLAUDE_CODE_PROVIDER_PROFILE_ENV_APPLIED
+  delete env.CLAUDE_CODE_PROVIDER_PROFILE_ENV_APPLIED_ID
+}
+
+function mergeUserSettingsEnv(
+  model: string,
+  baseUrl: string,
+): { ok: boolean; detail?: string } {
+  const current = getSettingsForSource('userSettings')
+  const currentEnv = current?.env ?? {}
+
+  const nextEnv: Record<string, string> = {}
+  for (const [key, value] of Object.entries(currentEnv)) {
+    if (!PROVIDER_SPECIFIC_KEYS.has(key)) {
+      nextEnv[key] = value
+    }
+  }
+
+  nextEnv.CLAUDE_CODE_USE_QWEN = '1'
+  nextEnv.OPENAI_MODEL = model
+  nextEnv.OPENAI_BASE_URL = baseUrl
+
+  const { error } = updateSettingsForSource('userSettings', { env: nextEnv })
+  if (error) {
+    return { ok: false, detail: error.message }
+  }
+  return { ok: true }
+}
+
+function OnboardQwen(props: {
+  onDone: Parameters<LocalJSXCommandCall>[0]
+  onChangeAPIKey: () => void
+}): React.ReactNode {
+  const { onDone, onChangeAPIKey } = props
+  const [step, setStep] = useState<Step>('menu')
+  const [errorMsg, setErrorMsg] = useState<string | null>(null)
+  const [deviceHint, setDeviceHint] = useState<{
+    user_code: string
+    verification_uri: string
+    verification_uri_complete: string
+  } | null>(null)
+  const startedRef = useRef(false)
+
+  const runDeviceFlow = useCallback(async () => {
+    setStep('device-busy')
+    setErrorMsg(null)
+    setDeviceHint(null)
+    try {
+      const device = await requestQwenDeviceCode()
+      setDeviceHint({
+        user_code: device.user_code,
+        verification_uri: device.verification_uri,
+        verification_uri_complete: device.verification_uri_complete,
+      })
+      await openQwenVerificationUri(device.verification_uri_complete)
+      const token = await pollQwenDeviceToken(
+        device.device_code,
+        device.code_verifier,
+        {
+          initialInterval: device.interval,
+          timeoutSeconds: device.expires_in,
+        },
+      )
+      const creds = fromTokenResponse(token)
+      const saved = saveQwenCredentials(creds)
+      if (!saved.success) {
+        setErrorMsg(saved.warning ?? 'Could not save Qwen credentials to disk.')
+        setStep('error')
+        return
+      }
+      const baseUrl = resolveQwenBaseUrl(creds.resource_url)
+      const merged = mergeUserSettingsEnv(DEFAULT_MODEL, baseUrl)
+      if (!merged.ok) {
+        setErrorMsg(
+          `Credentials saved, but user settings update failed: ${merged.detail ?? 'unknown error'}. ` +
+            'Add CLAUDE_CODE_USE_QWEN=1 and OPENAI_MODEL=qwen3-coder-plus to ~/.claude/settings.json manually.',
+        )
+        setStep('error')
+        return
+      }
+      applyQwenProcessEnv(DEFAULT_MODEL, baseUrl, creds.access_token)
+      hydrateQwenCredentialsFromDisk()
+      onChangeAPIKey()
+      onDone(
+        `Qwen OAuth complete. Credentials saved to ~/.qwen/oauth_creds.json; model ${DEFAULT_MODEL} activated. Restart if the model does not switch.`,
+        { display: 'user' },
+      )
+    } catch (e) {
+      setErrorMsg(e instanceof Error ? e.message : String(e))
+      setStep('error')
+    }
+  }, [onChangeAPIKey, onDone])
+
+  // Auto-start the flow: this command has no useful pre-flow choice.
+  useEffect(() => {
+    if (startedRef.current) return
+    startedRef.current = true
+    void runDeviceFlow()
+  }, [runDeviceFlow])
+
+  if (step === 'error' && errorMsg) {
+    const options = [
+      { label: 'Retry', value: 'retry' as const },
+      { label: 'Cancel', value: 'cancel' as const },
+    ]
+    return (
+      <Box flexDirection="column" gap={1}>
+        <Text color="red">{errorMsg}</Text>
+        <Select
+          options={options}
+          onChange={(v: string) => {
+            if (v === 'retry') {
+              void runDeviceFlow()
+            } else {
+              onDone('Qwen onboard cancelled', { display: 'system' })
+            }
+          }}
+        />
+      </Box>
+    )
+  }
+
+  return (
+    <Box flexDirection="column" gap={1}>
+      <Text bold>Qwen OAuth sign-in</Text>
+      {deviceHint ? (
+        <>
+          <Text>
+            Enter code <Text bold>{deviceHint.user_code}</Text> at{' '}
+            {deviceHint.verification_uri}
+          </Text>
+          <Text dimColor>
+            A browser window may have opened at{' '}
+            {deviceHint.verification_uri_complete}. Waiting for authorization...
+          </Text>
+        </>
+      ) : (
+        <Text dimColor>Requesting device code from chat.qwen.ai...</Text>
+      )}
+      <Spinner />
+    </Box>
+  )
+}
+
+export const call: LocalJSXCommandCall = async (onDone, context, args) => {
+  const forceRelogin = shouldForceQwenRelogin(args)
+  if (hasExistingQwenLogin() && !forceRelogin) {
+    hydrateQwenCredentialsFromDisk()
+    const merged = mergeUserSettingsEnv(
+      DEFAULT_MODEL,
+      process.env.OPENAI_BASE_URL ?? 'https://portal.qwen.ai/v1',
+    )
+    if (!merged.ok) {
+      onDone(
+        `Qwen credentials detected, but user settings activation failed: ${merged.detail ?? 'unknown error'}. ` +
+          'Set CLAUDE_CODE_USE_QWEN=1 and OPENAI_MODEL=qwen3-coder-plus in user settings manually.',
+        { display: 'system' },
+      )
+      return null
+    }
+    context.onChangeAPIKey()
+    onDone(
+      'Qwen already authorized. Activated Qwen mode using existing credentials. Use /onboard-qwen --force to re-authenticate.',
+      { display: 'user' },
+    )
+    return null
+  }
+
+  return (
+    <OnboardQwen onDone={onDone} onChangeAPIKey={context.onChangeAPIKey} />
+  )
+}

--- a/src/commands/provider/provider.tsx
+++ b/src/commands/provider/provider.tsx
@@ -25,11 +25,14 @@ import {
   buildMistralProfileEnv,
   buildOllamaProfileEnv,
   buildOpenAIProfileEnv,
+  buildQwenProfileEnv,
   createProfileFile,
   DEFAULT_GEMINI_BASE_URL,
   DEFAULT_GEMINI_MODEL,
   DEFAULT_MISTRAL_BASE_URL,
   DEFAULT_MISTRAL_MODEL,
+  DEFAULT_QWEN_BASE_URL,
+  DEFAULT_QWEN_MODEL,
   deleteProfileFile,
   loadProfileFile,
   maskSecretForDisplay,
@@ -41,6 +44,7 @@ import {
   type ProfileFile,
   type ProviderProfile,
 } from '../../utils/providerProfile.js'
+import { loadQwenCredentials } from '../../utils/qwenCredentials.js'
 import {
   getGeminiProjectIdHint,
   mayHaveGeminiAdcCredentials,
@@ -94,6 +98,7 @@ type Step =
       authMode: 'api-key' | 'access-token' | 'adc'
     }
   | { name: 'codex-check' }
+  | { name: 'qwen-check' }
 
 type CurrentProviderSummary = {
   providerLabel: string
@@ -193,6 +198,21 @@ export function buildCurrentProviderSummary(options?: {
       ),
       endpointLabel: getSafeDisplayValue(
         processEnv.GEMINI_BASE_URL ?? DEFAULT_GEMINI_BASE_URL,
+        processEnv,
+      ),
+      savedProfileLabel,
+    }
+  }
+
+  if (isEnvTruthy(processEnv.CLAUDE_CODE_USE_QWEN)) {
+    return {
+      providerLabel: 'Qwen (OAuth)',
+      modelLabel: getSafeDisplayValue(
+        processEnv.OPENAI_MODEL ?? DEFAULT_QWEN_MODEL,
+        processEnv,
+      ),
+      endpointLabel: getSafeDisplayValue(
+        processEnv.OPENAI_BASE_URL ?? DEFAULT_QWEN_BASE_URL,
         processEnv,
       ),
       savedProfileLabel,
@@ -330,6 +350,23 @@ function buildSavedProfileSummary(
           maskSecretForDisplay(env.CODEX_API_KEY) !== undefined
             ? 'configured'
             : undefined,
+      }
+    case 'qwen-oauth':
+      return {
+        providerLabel: 'Qwen (OAuth)',
+        modelLabel: getSafeDisplayValue(
+          env.OPENAI_MODEL ?? DEFAULT_QWEN_MODEL,
+          process.env,
+          env,
+        ),
+        endpointLabel: getSafeDisplayValue(
+          env.OPENAI_BASE_URL ?? DEFAULT_QWEN_BASE_URL,
+          process.env,
+          env,
+        ),
+        credentialLabel: loadQwenCredentials()
+          ? 'stored in ~/.qwen/oauth_creds.json'
+          : 'not configured — run /onboard-qwen',
       }
     case 'ollama':
       return {
@@ -536,6 +573,11 @@ function ProviderChooser({
       label: 'Codex',
       value: 'codex',
       description: 'Use existing ChatGPT Codex CLI auth or env credentials',
+    },
+    {
+      label: 'Qwen (OAuth, free)',
+      value: 'qwen-oauth',
+      description: 'Use Qwen chat.qwen.ai OAuth via ~/.qwen/oauth_creds.json',
     },
   ]
 
@@ -974,6 +1016,68 @@ function CodexCredentialStep({
   )
 }
 
+function QwenCredentialStep({
+  onSave,
+  onBack,
+  onCancel,
+}: {
+  onSave: (profile: ProviderProfile, env: ProfileEnv) => void
+  onBack: () => void
+  onCancel: () => void
+}): React.ReactNode {
+  const creds = loadQwenCredentials()
+
+  if (!creds) {
+    return (
+      <Dialog title="Qwen (OAuth) setup" onCancel={onCancel} color="warning">
+        <Box flexDirection="column" gap={1}>
+          <Text>
+            No Qwen credentials found at ~/.qwen/oauth_creds.json. Run
+            /onboard-qwen to complete the device-flow login, then come back to
+            /provider to save the profile.
+          </Text>
+          <Select
+            options={[
+              { label: 'Back', value: 'back' },
+              { label: 'Cancel', value: 'cancel' },
+            ]}
+            onChange={value => (value === 'back' ? onBack() : onCancel())}
+            onCancel={onCancel}
+          />
+        </Box>
+      </Dialog>
+    )
+  }
+
+  return (
+    <Dialog title="Save Qwen (OAuth) profile?" onCancel={onBack}>
+      <Box flexDirection="column" gap={1}>
+        <Text>
+          Credentials detected at ~/.qwen/oauth_creds.json. Save a profile
+          using {DEFAULT_QWEN_MODEL} on {DEFAULT_QWEN_BASE_URL}?
+        </Text>
+        <Select
+          options={[
+            { label: 'Save Qwen (OAuth) profile', value: 'save' },
+            { label: 'Back', value: 'back' },
+            { label: 'Cancel', value: 'cancel' },
+          ]}
+          onChange={value => {
+            if (value === 'save') {
+              onSave('qwen-oauth', buildQwenProfileEnv({}))
+            } else if (value === 'back') {
+              onBack()
+            } else {
+              onCancel()
+            }
+          }}
+          onCancel={onBack}
+        />
+      </Box>
+    </Dialog>
+  )
+}
+
 function resolveCodexCredentials(processEnv: NodeJS.ProcessEnv):
   | { ok: true; sourceDescription: string }
   | { ok: false; message: string } {
@@ -1035,6 +1139,8 @@ export function ProviderWizard({
                 name: 'mistral-key',
                 defaultModel: defaults.mistralModel,
               })
+            } else if (value === 'qwen-oauth') {
+              setStep({ name: 'qwen-check' })
             } else if (value === 'clear') {
               const filePath = deleteProfileFile()
               onDone(`Removed saved provider profile at ${filePath}. Restart OpenClaude to go back to normal startup.`, {
@@ -1465,6 +1571,15 @@ export function ProviderWizard({
     case 'codex-check':
       return (
         <CodexCredentialStep
+          onSave={(profile, env) => finishProfileSave(onDone, profile, env)}
+          onBack={() => setStep({ name: 'choose' })}
+          onCancel={() => onDone()}
+        />
+      )
+
+    case 'qwen-check':
+      return (
+        <QwenCredentialStep
           onSave={(profile, env) => finishProfileSave(onDone, profile, env)}
           onBack={() => setStep({ name: 'choose' })}
           onCancel={() => onDone()}

--- a/src/components/ProviderManager.tsx
+++ b/src/components/ProviderManager.tsx
@@ -29,6 +29,12 @@ import {
 } from '../utils/githubModelsCredentials.js'
 import { isEnvTruthy } from '../utils/envUtils.js'
 import { updateSettingsForSource } from '../utils/settings/settings.js'
+import {
+  buildQwenProfileEnv,
+  createProfileFile,
+  saveProfileFile,
+} from '../utils/providerProfile.js'
+import { loadQwenCredentials } from '../utils/qwenCredentials.js'
 import { type OptionWithDescription, Select } from './CustomSelect/index.js'
 import { Pane } from './design-system/Pane.js'
 import TextInput from './TextInput.js'
@@ -716,6 +722,11 @@ export function ProviderManager({ mode, onDone }: Props): React.ReactNode {
         description: 'Local LM Studio endpoint',
       },
       {
+        value: 'qwen-oauth',
+        label: 'Qwen (OAuth, free)',
+        description: 'Use Qwen chat.qwen.ai OAuth (run /onboard-qwen first)',
+      },
+      {
         value: 'custom',
         label: 'Custom',
         description: 'Any OpenAI-compatible provider',
@@ -744,6 +755,30 @@ export function ProviderManager({ mode, onDone }: Props): React.ReactNode {
           onChange={value => {
             if (value === 'skip') {
               closeWithCancelled('Provider setup skipped')
+              return
+            }
+            if (value === 'qwen-oauth') {
+              if (!loadQwenCredentials()) {
+                setErrorMessage(
+                  'No Qwen credentials found. Run /onboard-qwen to log in first, then reopen /provider.',
+                )
+                setScreen('menu')
+                return
+              }
+              try {
+                const filePath = saveProfileFile(
+                  createProfileFile('qwen-oauth', buildQwenProfileEnv({})),
+                )
+                onDone({
+                  action: 'saved',
+                  message: `Saved Qwen (OAuth) profile at ${filePath}. Restart OpenClaude to use it.`,
+                })
+              } catch (error) {
+                setErrorMessage(
+                  `Could not save Qwen profile: ${error instanceof Error ? error.message : String(error)}`,
+                )
+                setScreen('menu')
+              }
               return
             }
             startCreateFromPreset(value as ProviderPreset)

--- a/src/components/StartupScreen.ts
+++ b/src/components/StartupScreen.ts
@@ -88,6 +88,7 @@ function detectProvider(): { name: string; model: string; baseUrl: string; isLoc
   const useGithub = process.env.CLAUDE_CODE_USE_GITHUB === '1' || process.env.CLAUDE_CODE_USE_GITHUB === 'true'
   const useOpenAI = process.env.CLAUDE_CODE_USE_OPENAI === '1' || process.env.CLAUDE_CODE_USE_OPENAI === 'true'
   const useMistral = process.env.CLAUDE_CODE_USE_MISTRAL === '1' || process.env.CLAUDE_CODE_USE_MISTRAL === 'true'
+  const useQwen = process.env.CLAUDE_CODE_USE_QWEN === '1' || process.env.CLAUDE_CODE_USE_QWEN === 'true'
 
   if (useGemini) {
     const model = process.env.GEMINI_MODEL || 'gemini-2.0-flash'
@@ -106,6 +107,12 @@ function detectProvider(): { name: string; model: string; baseUrl: string; isLoc
     const baseUrl =
       process.env.OPENAI_BASE_URL || 'https://api.githubcopilot.com'
     return { name: 'GitHub Copilot', model, baseUrl, isLocal: false }
+  }
+
+  if (useQwen) {
+    const model = process.env.OPENAI_MODEL || 'qwen3-coder-plus'
+    const baseUrl = process.env.OPENAI_BASE_URL || 'https://portal.qwen.ai/v1'
+    return { name: 'Qwen', model, baseUrl, isLocal: false }
   }
 
   if (useOpenAI) {

--- a/src/services/api/client.ts
+++ b/src/services/api/client.ts
@@ -178,7 +178,8 @@ export async function getAnthropicClient({
     isEnvTruthy(process.env.CLAUDE_CODE_USE_OPENAI) ||
     isEnvTruthy(process.env.CLAUDE_CODE_USE_GITHUB) ||
     isEnvTruthy(process.env.CLAUDE_CODE_USE_GEMINI) ||
-    isEnvTruthy(process.env.CLAUDE_CODE_USE_MISTRAL)
+    isEnvTruthy(process.env.CLAUDE_CODE_USE_MISTRAL) ||
+    isEnvTruthy(process.env.CLAUDE_CODE_USE_QWEN)
   ) {
     const { createOpenAIShimClient } = await import('./openaiShim.js')
     return createOpenAIShimClient({

--- a/src/services/api/openaiShim.ts
+++ b/src/services/api/openaiShim.ts
@@ -25,6 +25,10 @@ import { APIError } from '@anthropic-ai/sdk'
 import { isEnvTruthy } from '../../utils/envUtils.js'
 import { resolveGeminiCredential } from '../../utils/geminiAuth.js'
 import { hydrateGeminiAccessTokenFromSecureStorage } from '../../utils/geminiCredentials.js'
+import {
+  hydrateQwenCredentialsFromDisk,
+  resolveQwenCredential,
+} from '../../utils/qwenCredentials.js'
 import { hydrateGithubModelsTokenFromSecureStorage } from '../../utils/githubModelsCredentials.js'
 import {
   looksLikeLeakedReasoningPrefix,
@@ -1216,19 +1220,21 @@ class OpenAIShimMessages {
 
     const isGithub = isGithubModelsMode()
     const isMistral = isMistralMode()
+    const isQwen = isEnvTruthy(process.env.CLAUDE_CODE_USE_QWEN)
 
     const githubEndpointType = getGithubEndpointType(request.baseUrl)
     const isGithubCopilot = isGithub && githubEndpointType === 'copilot'
     const isGithubModels = isGithub && (githubEndpointType === 'models' || githubEndpointType === 'custom')
 
-    if ((isGithub || isMistral) && body.max_completion_tokens !== undefined) {
+    if ((isGithub || isMistral || isQwen) && body.max_completion_tokens !== undefined) {
       body.max_tokens = body.max_completion_tokens
       delete body.max_completion_tokens
     }
 
-    // mistral also doesn't recognize body.store
-    if (isMistral) {
+    // mistral and qwen don't recognize body.store or stream_options
+    if (isMistral || isQwen) {
       delete body.store
+      delete body.stream_options
     }
 
     if (params.temperature !== undefined) body.temperature = params.temperature
@@ -1269,7 +1275,29 @@ class OpenAIShimMessages {
     }
 
     const isGemini = isEnvTruthy(process.env.CLAUDE_CODE_USE_GEMINI)
-    const apiKey = this.providerOverride?.apiKey ?? process.env.OPENAI_API_KEY ?? ''
+    // For Qwen, always resolve from disk so a stale env-hydrated token gets
+    // refreshed mid-session without requiring a CLI restart.
+    let qwenAccessToken: string | undefined
+    if (isQwen && !this.providerOverride?.apiKey) {
+      const resolved = await resolveQwenCredential(process.env)
+      if (resolved.kind === 'token') {
+        qwenAccessToken = resolved.accessToken
+        process.env.OPENAI_API_KEY = resolved.accessToken
+      }
+      // If Qwen credential resolution failed (refresh token expired), don't
+      // fall back to a stale env var — throw immediately with a clear message.
+      const finalKey = this.providerOverride?.apiKey ?? qwenAccessToken
+      if (!finalKey) {
+        throw new Error(
+          'Qwen access token expired. Run /onboard-qwen to re-authenticate.',
+        )
+      }
+    }
+    const apiKey =
+      this.providerOverride?.apiKey ??
+      qwenAccessToken ??
+      process.env.OPENAI_API_KEY ??
+      ''
     // Detect Azure endpoints by hostname (not raw URL) to prevent bypass via
     // path segments like https://evil.com/cognitiveservices.azure.com/
     let isAzure = false
@@ -1301,6 +1329,12 @@ class OpenAIShimMessages {
     } else if (isGithubModels) {
       headers['Accept'] = 'application/vnd.github+json'
       headers['X-GitHub-Api-Version'] = '2022-11-28'
+    } else if (isQwen) {
+      const qwenUa = `QwenCode/0.14.3 (${process.platform}; ${process.arch})`
+      headers['User-Agent'] = qwenUa
+      headers['X-DashScope-UserAgent'] = qwenUa
+      headers['X-DashScope-AuthType'] = 'qwen-oauth'
+      headers['X-DashScope-CacheControl'] = 'enable'
     }
 
     // Build the chat completions URL
@@ -1586,6 +1620,7 @@ export function createOpenAIShimClient(options: {
 }): unknown {
   hydrateGeminiAccessTokenFromSecureStorage()
   hydrateGithubModelsTokenFromSecureStorage()
+  hydrateQwenCredentialsFromDisk()
 
   // When Gemini provider is active, map Gemini env vars to OpenAI-compatible ones
   // so the existing providerConfig.ts infrastructure picks them up correctly.

--- a/src/services/api/providerConfig.ts
+++ b/src/services/api/providerConfig.ts
@@ -359,13 +359,14 @@ export function resolveProviderRequest(options?: {
 }): ResolvedProviderRequest {
   const isGithubMode = isEnvTruthy(process.env.CLAUDE_CODE_USE_GITHUB)
   const isMistralMode = isEnvTruthy(process.env.CLAUDE_CODE_USE_MISTRAL)
+  const isQwenMode = isEnvTruthy(process.env.CLAUDE_CODE_USE_QWEN)
   const requestedModel =
     options?.model?.trim() ||
     (isMistralMode
       ? process.env.MISTRAL_MODEL?.trim()
       : process.env.OPENAI_MODEL?.trim()) ||
     options?.fallbackModel?.trim() ||
-    (isGithubMode ? 'github:copilot' : 'gpt-4o')
+    (isGithubMode ? 'github:copilot' : isQwenMode ? 'qwen3-coder-plus' : 'gpt-4o')
   const descriptor = parseModelDescriptor(requestedModel)
   const rawBaseUrl =
     asEnvUrl(options?.baseUrl) ??
@@ -428,7 +429,8 @@ export function getAdditionalModelOptionsCacheScope(): string | null {
         !isEnvTruthy(process.env.CLAUDE_CODE_USE_GITHUB) &&
         !isEnvTruthy(process.env.CLAUDE_CODE_USE_BEDROCK) &&
         !isEnvTruthy(process.env.CLAUDE_CODE_USE_VERTEX) &&
-        !isEnvTruthy(process.env.CLAUDE_CODE_USE_FOUNDRY)) {
+        !isEnvTruthy(process.env.CLAUDE_CODE_USE_FOUNDRY) &&
+        !isEnvTruthy(process.env.CLAUDE_CODE_USE_QWEN)) {
       return 'firstParty'
     }
     return null

--- a/src/services/api/withRetry.ts
+++ b/src/services/api/withRetry.ts
@@ -33,6 +33,7 @@ import {
 } from '../../utils/fastMode.js'
 import { isNonCustomOpusModel } from '../../utils/model/model.js'
 import { disableKeepAlive } from '../../utils/proxy.js'
+import { resolveQwenCredential } from '../../utils/qwenCredentials.js'
 import { sleep } from '../../utils/sleep.js'
 import type { ThinkingConfig } from '../../utils/thinking.js'
 import { getFeatureValue_CACHED_MAY_BE_STALE } from '../analytics/growthbook.js'
@@ -254,6 +255,13 @@ export async function* withRetry<T>(
           const failedAccessToken = getClaudeAIOAuthTokens()?.accessToken
           if (failedAccessToken) {
             await handleOAuth401Error(failedAccessToken)
+          }
+          // For Qwen, re-resolve credentials from disk to pick up a refreshed token
+          if (getAPIProvider() === 'qwen') {
+            const resolved = await resolveQwenCredential(process.env)
+            if (resolved.kind === 'token') {
+              process.env.OPENAI_API_KEY = resolved.accessToken
+            }
           }
         }
         client = await getClient()

--- a/src/services/qwen/deviceFlow.ts
+++ b/src/services/qwen/deviceFlow.ts
@@ -1,0 +1,267 @@
+/**
+ * Qwen OAuth 2.0 Device Authorization Grant with PKCE.
+ *
+ * Uses the same public endpoints and client_id as the qwen-code CLI, so
+ * credentials written by either tool are interchangeable (both live at
+ * ~/.qwen/oauth_creds.json).
+ *
+ * Device code:  POST https://chat.qwen.ai/api/v1/oauth2/device/code
+ * Token:        POST https://chat.qwen.ai/api/v1/oauth2/token
+ * Scope:        openid profile email model.completion
+ */
+
+import { createHash, randomBytes } from 'node:crypto'
+
+import { execFileNoThrow } from '../../utils/execFileNoThrow.js'
+
+export const QWEN_OAUTH_CLIENT_ID = 'f0304373b74a44d2b584a3fb70ca9e56'
+export const QWEN_DEVICE_CODE_URL =
+  'https://chat.qwen.ai/api/v1/oauth2/device/code'
+export const QWEN_TOKEN_URL = 'https://chat.qwen.ai/api/v1/oauth2/token'
+export const QWEN_OAUTH_SCOPE = 'openid profile email model.completion'
+export const QWEN_DEFAULT_RESOURCE_URL = 'https://portal.qwen.ai/v1'
+
+export class QwenDeviceFlowError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'QwenDeviceFlowError'
+  }
+}
+
+type FetchLike = (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>
+
+export type QwenDeviceCodeResult = {
+  device_code: string
+  user_code: string
+  verification_uri: string
+  verification_uri_complete: string
+  expires_in: number
+  interval: number
+  code_verifier: string
+}
+
+export type QwenTokenResponse = {
+  access_token: string
+  refresh_token: string
+  token_type: string
+  expires_in: number
+  /** Domain (no scheme) the caller should use as the chat base host. */
+  resource_url?: string
+}
+
+function base64UrlEncode(buffer: Buffer): string {
+  return buffer
+    .toString('base64')
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=+$/, '')
+}
+
+function createPkcePair(): { verifier: string; challenge: string } {
+  const verifier = base64UrlEncode(randomBytes(32))
+  const challenge = base64UrlEncode(
+    createHash('sha256').update(verifier).digest(),
+  )
+  return { verifier, challenge }
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms))
+}
+
+export async function requestQwenDeviceCode(options?: {
+  fetchImpl?: FetchLike
+}): Promise<QwenDeviceCodeResult> {
+  const fetchFn = options?.fetchImpl ?? fetch
+  const { verifier, challenge } = createPkcePair()
+
+  const res = await fetchFn(QWEN_DEVICE_CODE_URL, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/x-www-form-urlencoded',
+      Accept: 'application/json',
+    },
+    body: new URLSearchParams({
+      client_id: QWEN_OAUTH_CLIENT_ID,
+      scope: QWEN_OAUTH_SCOPE,
+      code_challenge: challenge,
+      code_challenge_method: 'S256',
+    }),
+  })
+
+  if (!res.ok) {
+    const text = await res.text().catch(() => '')
+    throw new QwenDeviceFlowError(
+      `Device code request failed: ${res.status} ${text}`,
+    )
+  }
+
+  const data = (await res.json()) as Record<string, unknown>
+  const device_code = data.device_code
+  const user_code = data.user_code
+  const verification_uri = data.verification_uri
+  const verification_uri_complete = data.verification_uri_complete
+  if (
+    typeof device_code !== 'string' ||
+    typeof user_code !== 'string' ||
+    typeof verification_uri !== 'string'
+  ) {
+    throw new QwenDeviceFlowError('Malformed device code response from Qwen')
+  }
+
+  return {
+    device_code,
+    user_code,
+    verification_uri,
+    verification_uri_complete:
+      typeof verification_uri_complete === 'string'
+        ? verification_uri_complete
+        : verification_uri,
+    expires_in: typeof data.expires_in === 'number' ? data.expires_in : 1800,
+    interval: typeof data.interval === 'number' ? data.interval : 5,
+    code_verifier: verifier,
+  }
+}
+
+export type PollQwenOptions = {
+  initialInterval?: number
+  timeoutSeconds?: number
+  fetchImpl?: FetchLike
+}
+
+export async function pollQwenDeviceToken(
+  deviceCode: string,
+  codeVerifier: string,
+  options?: PollQwenOptions,
+): Promise<QwenTokenResponse> {
+  let interval = Math.max(1, options?.initialInterval ?? 5)
+  const timeoutSeconds = options?.timeoutSeconds ?? 1800
+  const fetchFn = options?.fetchImpl ?? fetch
+  const start = Date.now()
+
+  while ((Date.now() - start) / 1000 < timeoutSeconds) {
+    const res = await fetchFn(QWEN_TOKEN_URL, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded',
+        Accept: 'application/json',
+      },
+      body: new URLSearchParams({
+        grant_type: 'urn:ietf:params:oauth:grant-type:device_code',
+        client_id: QWEN_OAUTH_CLIENT_ID,
+        device_code: deviceCode,
+        code_verifier: codeVerifier,
+      }),
+    })
+
+    const data = (await res.json().catch(() => ({}))) as Record<string, unknown>
+
+    if (res.ok && typeof data.access_token === 'string') {
+      return normalizeTokenResponse(data)
+    }
+
+    const err = typeof data.error === 'string' ? data.error : undefined
+    if (err === 'authorization_pending') {
+      await sleep(interval * 1000)
+      continue
+    }
+    if (err === 'slow_down') {
+      interval = typeof data.interval === 'number' ? data.interval : interval + 5
+      await sleep(interval * 1000)
+      continue
+    }
+    if (err === 'expired_token') {
+      throw new QwenDeviceFlowError(
+        'Device code expired. Start the login flow again.',
+      )
+    }
+    if (err === 'access_denied') {
+      throw new QwenDeviceFlowError('Authorization was denied or cancelled.')
+    }
+    const detail = err ?? `HTTP ${res.status}`
+    throw new QwenDeviceFlowError(`Qwen OAuth error: ${detail}`)
+  }
+
+  throw new QwenDeviceFlowError('Timed out waiting for authorization.')
+}
+
+export async function refreshQwenToken(
+  refreshToken: string,
+  fetchImpl?: FetchLike,
+): Promise<QwenTokenResponse> {
+  const fetchFn = fetchImpl ?? fetch
+  const res = await fetchFn(QWEN_TOKEN_URL, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/x-www-form-urlencoded',
+      Accept: 'application/json',
+    },
+    body: new URLSearchParams({
+      grant_type: 'refresh_token',
+      client_id: QWEN_OAUTH_CLIENT_ID,
+      refresh_token: refreshToken,
+    }),
+  })
+
+  const data = (await res.json().catch(() => ({}))) as Record<string, unknown>
+  if (!res.ok || typeof data.access_token !== 'string') {
+    const err = typeof data.error === 'string' ? data.error : `HTTP ${res.status}`
+    throw new QwenDeviceFlowError(`Token refresh failed: ${err}`)
+  }
+  return normalizeTokenResponse(data, refreshToken)
+}
+
+function normalizeTokenResponse(
+  data: Record<string, unknown>,
+  fallbackRefreshToken?: string,
+): QwenTokenResponse {
+  const access_token = data.access_token
+  const refresh_token =
+    typeof data.refresh_token === 'string' ? data.refresh_token : fallbackRefreshToken
+  const expires_in = typeof data.expires_in === 'number' ? data.expires_in : 3600
+  const token_type = typeof data.token_type === 'string' ? data.token_type : 'Bearer'
+  const resource_url =
+    typeof data.resource_url === 'string' ? data.resource_url : undefined
+
+  if (typeof access_token !== 'string' || !refresh_token) {
+    throw new QwenDeviceFlowError('Malformed Qwen token response')
+  }
+  return {
+    access_token,
+    refresh_token,
+    expires_in,
+    token_type,
+    resource_url,
+  }
+}
+
+/**
+ * Normalize a `resource_url` (which Qwen returns as a bare host, sometimes
+ * already including a path) into a fully-qualified chat completions base URL.
+ */
+export function resolveQwenBaseUrl(resourceUrl: string | undefined): string {
+  const trimmed = resourceUrl?.trim()
+  if (!trimmed) return QWEN_DEFAULT_RESOURCE_URL
+  const withScheme = /^https?:\/\//i.test(trimmed) ? trimmed : `https://${trimmed}`
+  const cleaned = withScheme.replace(/\/+$/, '')
+  if (/\/v\d+(?:beta)?$/i.test(cleaned)) return cleaned
+  return `${cleaned}/v1`
+}
+
+/** Best-effort browser launch for the verification URL. */
+export async function openQwenVerificationUri(uri: string): Promise<void> {
+  try {
+    if (process.platform === 'darwin') {
+      await execFileNoThrow('open', [uri], { useCwd: false, timeout: 5000 })
+    } else if (process.platform === 'win32') {
+      await execFileNoThrow('cmd', ['/c', 'start', '', uri], {
+        useCwd: false,
+        timeout: 5000,
+      })
+    } else {
+      await execFileNoThrow('xdg-open', [uri], { useCwd: false, timeout: 5000 })
+    }
+  } catch {
+    // User can open it manually.
+  }
+}

--- a/src/utils/attribution.ts
+++ b/src/utils/attribution.ts
@@ -70,19 +70,27 @@ export function getAttributionTexts(): AttributionTexts {
   // fall back to "Claude Opus 4.6" for unrecognized models to avoid leaking codenames.
   const model = getMainLoopModel()
   const isKnownPublicModel = getPublicModelDisplayName(model) !== null
+  const publicModelDisplayName = getPublicModelDisplayName(model)
   const modelName =
     isInternalModelRepoCached() || isKnownPublicModel
-      ? getPublicModelName(model)
-      : 'Claude Opus 4.6'
+      ? (getAPIProvider() === 'qwen' ? publicModelDisplayName! : getPublicModelName(model))
+      : model.toString().toLowerCase().includes('qwen')
+        ? 'Qwen-Coder' // Special handling for Qwen models that aren't recognized as public models
+        : 'Claude Opus 4.6'
   const defaultAttribution =
     '🤖 Generated with [OpenClaude](https://github.com/Gitlawb/openclaude)'
-  const coAuthorDomain =
-    getAPIProvider() === 'firstParty' ? 'anthropic.com' : 'openclaude.dev'
+  const apiProvider = getAPIProvider()
+  const modelContainsQwen = model.toString().toLowerCase().includes('qwen')
+  const isQwen = apiProvider === 'qwen' || modelContainsQwen
+  const coAuthorEmail =
+    apiProvider === 'firstParty' ? 'noreply@anthropic.com' :
+    isQwen ? 'qwen-coder@alibabacloud.com' :
+    'noreply@openclaude.dev'
   const defaultCommit = isEnvTruthy(
     process.env.OPENCLAUDE_DISABLE_CO_AUTHORED_BY,
   )
     ? ''
-    : `Co-Authored-By: ${modelName} <noreply@${coAuthorDomain}>`
+    : `Co-Authored-By: ${modelName} <${coAuthorEmail}>`
 
   const settings = getInitialSettings()
 

--- a/src/utils/context.ts
+++ b/src/utils/context.ts
@@ -85,7 +85,8 @@ export function getContextWindowForModel(
     isEnvTruthy(process.env.CLAUDE_CODE_USE_OPENAI) ||
     isEnvTruthy(process.env.CLAUDE_CODE_USE_GEMINI) ||
     isEnvTruthy(process.env.CLAUDE_CODE_USE_GITHUB) ||
-    isEnvTruthy(process.env.CLAUDE_CODE_USE_MISTRAL)
+    isEnvTruthy(process.env.CLAUDE_CODE_USE_MISTRAL) ||
+    isEnvTruthy(process.env.CLAUDE_CODE_USE_QWEN)
   if (isOpenAIProvider) {
     const openaiWindow = getOpenAIContextWindow(model)
     if (openaiWindow !== undefined) {
@@ -194,7 +195,8 @@ export function getModelMaxOutputTokens(model: string): {
     isEnvTruthy(process.env.CLAUDE_CODE_USE_OPENAI) ||
     isEnvTruthy(process.env.CLAUDE_CODE_USE_GEMINI) ||
     isEnvTruthy(process.env.CLAUDE_CODE_USE_GITHUB) ||
-    isEnvTruthy(process.env.CLAUDE_CODE_USE_MISTRAL)
+    isEnvTruthy(process.env.CLAUDE_CODE_USE_MISTRAL) ||
+    isEnvTruthy(process.env.CLAUDE_CODE_USE_QWEN)
   ) {
     const openaiMax = getOpenAIMaxOutputTokens(model)
     if (openaiMax !== undefined) {

--- a/src/utils/model/configs.ts
+++ b/src/utils/model/configs.ts
@@ -1,7 +1,8 @@
 import type { ModelName } from './model.js'
 import type { APIProvider } from './providers.js'
 
-export type ModelConfig = Record<APIProvider, ModelName>
+export type ModelConfig = Partial<Record<APIProvider, ModelName>> &
+  Record<Exclude<APIProvider, 'mistral' | 'qwen'>, ModelName>
 
 // ---------------------------------------------------------------------------
 // OpenAI-compatible model mappings

--- a/src/utils/model/model.ts
+++ b/src/utils/model/model.ts
@@ -88,7 +88,7 @@ export function getUserSpecifiedModelSetting(): ModelSetting | undefined {
     specifiedModel =
       (provider === 'gemini' ? process.env.GEMINI_MODEL : undefined) ||
       (provider === 'mistral' ? process.env.MISTRAL_MODEL : undefined) ||
-      (provider === 'openai' || provider === 'gemini' || provider === 'mistral' || provider === 'github' ? process.env.OPENAI_MODEL : undefined) ||
+      (provider === 'openai' || provider === 'gemini' || provider === 'mistral' || provider === 'github' || provider === 'qwen' ? process.env.OPENAI_MODEL : undefined) ||
       (provider === 'firstParty' ? process.env.ANTHROPIC_MODEL : undefined) ||
       settings.model ||
       undefined
@@ -272,6 +272,10 @@ export function getDefaultMainLoopModelSetting(): ModelName | ModelAlias {
   }
   if (getAPIProvider() === 'mistral') {
     return process.env.MISTRAL_MODEL || 'devstral-latest'
+  }
+  // Qwen provider: always use the configured Qwen model
+  if (getAPIProvider() === 'qwen') {
+    return process.env.OPENAI_MODEL || 'qwen3-coder-plus'
   }
   // OpenAI provider: always use the configured OpenAI model
   if (getAPIProvider() === 'openai') {
@@ -460,8 +464,8 @@ export function renderModelSetting(setting: ModelName | ModelAlias): string {
  * if the model is not recognized as a public model.
  */
 export function getPublicModelDisplayName(model: ModelName): string | null {
-  // For OpenAI/Gemini/Codex/GitHub providers, show the actual model name not a Claude alias
-  if (getAPIProvider() === 'openai' || getAPIProvider() === 'gemini' || getAPIProvider() === 'codex' || getAPIProvider() === 'github') {
+  // For OpenAI/Gemini/Codex/GitHub/Qwen providers, show the actual model name not a Claude alias
+  if (getAPIProvider() === 'openai' || getAPIProvider() === 'gemini' || getAPIProvider() === 'codex' || getAPIProvider() === 'github' || getAPIProvider() === 'qwen') {
     // Return display names for known GitHub Copilot models
     const copilotModelNames: Record<string, string> = {
       'gpt-5.4': 'GPT-5.4',
@@ -487,6 +491,17 @@ export function getPublicModelDisplayName(model: ModelName): string | null {
     if (copilotModelNames[model]) {
       return copilotModelNames[model]
     }
+
+    // Return display names for known Qwen models - format to match GitHub profile display name
+    if (model.startsWith('qwen')) {
+      // Convert to match GitHub profile display name (e.g., 'qwen3-coder-plus' -> 'Qwen-Coder')
+      if (model.includes('coder')) {
+        return 'Qwen-Coder'
+      }
+      // For other qwen models, capitalize first letter (e.g., 'qwen3' -> 'Qwen3')
+      return model.charAt(0).toUpperCase() + model.slice(1)
+    }
+
     return null
   }
   switch (model) {

--- a/src/utils/model/modelStrings.ts
+++ b/src/utils/model/modelStrings.ts
@@ -25,7 +25,13 @@ const MODEL_KEYS = Object.keys(ALL_MODEL_CONFIGS) as ModelKey[]
 function getBuiltinModelStrings(provider: APIProvider): ModelStrings {
   // Codex piggybacks on the OpenAI provider transport for Anthropic tier aliases.
   // Reuse OpenAI mappings so model string lookups never return undefined.
-  const providerKey = provider === 'codex' || provider === 'github' ? 'openai' : provider
+  const providerKey =
+    provider === 'codex' ||
+    provider === 'github' ||
+    provider === 'mistral' ||
+    provider === 'qwen'
+      ? 'openai'
+      : provider
   const out = {} as ModelStrings
   for (const key of MODEL_KEYS) {
     out[key] = ALL_MODEL_CONFIGS[key][providerKey]

--- a/src/utils/model/providers.ts
+++ b/src/utils/model/providers.ts
@@ -12,9 +12,12 @@ export type APIProvider =
   | 'github'
   | 'codex'
   | 'mistral'
+  | 'qwen'
 
 export function getAPIProvider(): APIProvider {
-  return isEnvTruthy(process.env.CLAUDE_CODE_USE_GEMINI)
+  return isEnvTruthy(process.env.CLAUDE_CODE_USE_QWEN)
+    ? 'qwen'
+    : isEnvTruthy(process.env.CLAUDE_CODE_USE_GEMINI)
     ? 'gemini'
     :
     isEnvTruthy(process.env.CLAUDE_CODE_USE_MISTRAL)

--- a/src/utils/providerProfile.ts
+++ b/src/utils/providerProfile.ts
@@ -26,6 +26,7 @@ const PROFILE_ENV_KEYS = [
   'CLAUDE_CODE_USE_OPENAI',
   'CLAUDE_CODE_USE_GEMINI',
   'CLAUDE_CODE_USE_MISTRAL',
+  'CLAUDE_CODE_USE_QWEN',
   'CLAUDE_CODE_USE_BEDROCK',
   'CLAUDE_CODE_USE_VERTEX',
   'CLAUDE_CODE_USE_FOUNDRY',
@@ -54,7 +55,14 @@ const SECRET_ENV_KEYS = [
   'MISTRAL_API_KEY',
 ] as const
 
-export type ProviderProfile = 'openai' | 'ollama' | 'codex' | 'gemini' | 'atomic-chat' | 'mistral'
+export type ProviderProfile =
+  | 'openai'
+  | 'ollama'
+  | 'codex'
+  | 'gemini'
+  | 'atomic-chat'
+  | 'mistral'
+  | 'qwen-oauth'
 
 export type ProfileEnv = {
   OPENAI_BASE_URL?: string
@@ -105,7 +113,8 @@ export function isProviderProfile(value: unknown): value is ProviderProfile {
     value === 'codex' ||
     value === 'gemini' ||
     value === 'atomic-chat' ||
-    value === 'mistral'
+    value === 'mistral' ||
+    value === 'qwen-oauth'
   )
 }
 
@@ -399,6 +408,21 @@ export function buildMistralProfileEnv(options: {
   return env
 }
 
+export const DEFAULT_QWEN_MODEL = 'qwen3-coder-plus'
+export const DEFAULT_QWEN_BASE_URL = 'https://portal.qwen.ai/v1'
+
+export function buildQwenProfileEnv(options: {
+  model?: string | null
+  baseUrl?: string | null
+}): ProfileEnv {
+  // OPENAI_API_KEY intentionally omitted — resolved at runtime from
+  // ~/.qwen/oauth_creds.json via resolveQwenCredential().
+  return {
+    OPENAI_BASE_URL: options.baseUrl?.trim() || DEFAULT_QWEN_BASE_URL,
+    OPENAI_MODEL: options.model?.trim() || DEFAULT_QWEN_MODEL,
+  }
+}
+
 export function createProfileFile(
   profile: ProviderProfile,
   env: ProfileEnv,
@@ -468,7 +492,8 @@ export function hasExplicitProviderSelection(
     processEnv.CLAUDE_CODE_USE_MISTRAL !== undefined ||
     processEnv.CLAUDE_CODE_USE_BEDROCK !== undefined ||
     processEnv.CLAUDE_CODE_USE_VERTEX !== undefined ||
-    processEnv.CLAUDE_CODE_USE_FOUNDRY !== undefined
+    processEnv.CLAUDE_CODE_USE_FOUNDRY !== undefined ||
+    processEnv.CLAUDE_CODE_USE_QWEN !== undefined
   )
 }
 
@@ -657,12 +682,53 @@ export async function buildLaunchEnv(options: {
     return env
   }
 
+  if (options.profile === 'qwen-oauth') {
+    const env: NodeJS.ProcessEnv = {
+      ...processEnv,
+      CLAUDE_CODE_USE_QWEN: '1',
+    }
+
+    delete env.CLAUDE_CODE_USE_OPENAI
+    delete env.CLAUDE_CODE_USE_GITHUB
+    delete env.CLAUDE_CODE_USE_GEMINI
+    delete env.CLAUDE_CODE_USE_MISTRAL
+    delete env.CLAUDE_CODE_USE_BEDROCK
+    delete env.CLAUDE_CODE_USE_VERTEX
+    delete env.CLAUDE_CODE_USE_FOUNDRY
+
+    env.OPENAI_MODEL =
+      sanitizeProviderConfigValue(persistedEnv.OPENAI_MODEL, persistedEnv) ||
+      DEFAULT_QWEN_MODEL
+    env.OPENAI_BASE_URL =
+      sanitizeProviderConfigValue(persistedEnv.OPENAI_BASE_URL, persistedEnv) ||
+      DEFAULT_QWEN_BASE_URL
+
+    // Access token is hydrated from disk by hydrateQwenCredentialsFromDisk()
+    // when the shim initializes. Avoid baking a stale value into the profile.
+    delete env.OPENAI_API_KEY
+    delete env.GEMINI_API_KEY
+    delete env.GEMINI_AUTH_MODE
+    delete env.GEMINI_ACCESS_TOKEN
+    delete env.GEMINI_MODEL
+    delete env.GEMINI_BASE_URL
+    delete env.GOOGLE_API_KEY
+    delete env.MISTRAL_API_KEY
+    delete env.MISTRAL_MODEL
+    delete env.MISTRAL_BASE_URL
+    delete env.CODEX_API_KEY
+    delete env.CHATGPT_ACCOUNT_ID
+    delete env.CODEX_ACCOUNT_ID
+
+    return env
+  }
+
   const env: NodeJS.ProcessEnv = {
     ...processEnv,
     CLAUDE_CODE_USE_OPENAI: '1',
   }
 
   delete env.CLAUDE_CODE_USE_MISTRAL
+  delete env.CLAUDE_CODE_USE_QWEN
   delete env.CLAUDE_CODE_USE_BEDROCK
   delete env.CLAUDE_CODE_USE_VERTEX
   delete env.CLAUDE_CODE_USE_FOUNDRY

--- a/src/utils/providerProfiles.ts
+++ b/src/utils/providerProfiles.ts
@@ -262,7 +262,8 @@ function hasProviderSelectionFlags(
     processEnv.CLAUDE_CODE_USE_GITHUB !== undefined ||
     processEnv.CLAUDE_CODE_USE_BEDROCK !== undefined ||
     processEnv.CLAUDE_CODE_USE_VERTEX !== undefined ||
-    processEnv.CLAUDE_CODE_USE_FOUNDRY !== undefined
+    processEnv.CLAUDE_CODE_USE_FOUNDRY !== undefined ||
+    processEnv.CLAUDE_CODE_USE_QWEN !== undefined
   )
 }
 
@@ -279,7 +280,8 @@ function hasConflictingProviderFlagsForProfile(
     processEnv.CLAUDE_CODE_USE_GITHUB !== undefined ||
     processEnv.CLAUDE_CODE_USE_BEDROCK !== undefined ||
     processEnv.CLAUDE_CODE_USE_VERTEX !== undefined ||
-    processEnv.CLAUDE_CODE_USE_FOUNDRY !== undefined
+    processEnv.CLAUDE_CODE_USE_FOUNDRY !== undefined ||
+    processEnv.CLAUDE_CODE_USE_QWEN !== undefined
   )
 }
 
@@ -354,6 +356,7 @@ export function clearProviderProfileEnvFromProcessEnv(
   delete processEnv.CLAUDE_CODE_USE_BEDROCK
   delete processEnv.CLAUDE_CODE_USE_VERTEX
   delete processEnv.CLAUDE_CODE_USE_FOUNDRY
+  delete processEnv.CLAUDE_CODE_USE_QWEN
 
   delete processEnv.OPENAI_BASE_URL
   delete processEnv.OPENAI_API_BASE

--- a/src/utils/qwenCredentials.ts
+++ b/src/utils/qwenCredentials.ts
@@ -1,0 +1,180 @@
+/**
+ * Persistent credentials for the Qwen OAuth provider.
+ *
+ * Stored at ~/.qwen/oauth_creds.json for compatibility with the qwen-code CLI
+ * — either tool can refresh tokens written by the other.
+ *
+ *   { access_token, refresh_token, token_type, resource_url, expires_at }
+ *
+ * `expires_at` is milliseconds since the Unix epoch (the qwen-code CLI's
+ * convention). We refresh 30s before that boundary.
+ */
+
+import { mkdirSync, readFileSync, writeFileSync } from 'node:fs'
+import { homedir } from 'node:os'
+import { dirname, join } from 'node:path'
+
+import { isBareMode, isEnvTruthy } from './envUtils.js'
+import {
+  refreshQwenToken,
+  resolveQwenBaseUrl,
+  QWEN_DEFAULT_RESOURCE_URL,
+  QwenDeviceFlowError,
+  type QwenTokenResponse,
+} from '../services/qwen/deviceFlow.js'
+
+const REFRESH_LEEWAY_MS = 30_000
+
+export type QwenCredentials = {
+  access_token: string
+  refresh_token: string
+  token_type: string
+  resource_url?: string
+  /** Milliseconds since epoch. */
+  expires_at: number
+}
+
+export function getQwenCredentialsPath(
+  env: NodeJS.ProcessEnv = process.env,
+): string {
+  const override = env.QWEN_OAUTH_CREDS_PATH?.trim()
+  if (override) return override
+  const qwenHome = env.QWEN_HOME?.trim() || join(homedir(), '.qwen')
+  return join(qwenHome, 'oauth_creds.json')
+}
+
+export function loadQwenCredentials(
+  path = getQwenCredentialsPath(),
+): QwenCredentials | undefined {
+  try {
+    const raw = readFileSync(path, 'utf8')
+    const parsed = JSON.parse(raw) as Partial<QwenCredentials> | undefined
+    if (
+      !parsed ||
+      typeof parsed.access_token !== 'string' ||
+      typeof parsed.refresh_token !== 'string' ||
+      typeof parsed.expires_at !== 'number'
+    ) {
+      return undefined
+    }
+    return {
+      access_token: parsed.access_token,
+      refresh_token: parsed.refresh_token,
+      token_type:
+        typeof parsed.token_type === 'string' ? parsed.token_type : 'Bearer',
+      resource_url:
+        typeof parsed.resource_url === 'string' ? parsed.resource_url : undefined,
+      expires_at: parsed.expires_at,
+    }
+  } catch {
+    return undefined
+  }
+}
+
+export function saveQwenCredentials(
+  creds: QwenCredentials,
+  path = getQwenCredentialsPath(),
+): { success: boolean; warning?: string } {
+  try {
+    mkdirSync(dirname(path), { recursive: true })
+    writeFileSync(path, JSON.stringify(creds, null, 2), { mode: 0o600 })
+    return { success: true }
+  } catch (err) {
+    return {
+      success: false,
+      warning: err instanceof Error ? err.message : String(err),
+    }
+  }
+}
+
+export function fromTokenResponse(
+  response: QwenTokenResponse,
+  now: number = Date.now(),
+): QwenCredentials {
+  return {
+    access_token: response.access_token,
+    refresh_token: response.refresh_token,
+    token_type: response.token_type || 'Bearer',
+    resource_url: response.resource_url,
+    expires_at: now + response.expires_in * 1000,
+  }
+}
+
+export type ResolvedQwenCredential =
+  | { kind: 'none' }
+  | { kind: 'token'; accessToken: string; baseUrl: string }
+
+/**
+ * Returns a usable access token, refreshing on-the-fly if within the leeway
+ * window. Persists refreshed credentials back to disk.
+ */
+export async function resolveQwenCredential(
+  env: NodeJS.ProcessEnv = process.env,
+): Promise<ResolvedQwenCredential> {
+  const path = getQwenCredentialsPath(env)
+  const current = loadQwenCredentials(path)
+  if (!current) return { kind: 'none' }
+
+  if (Date.now() < current.expires_at - REFRESH_LEEWAY_MS) {
+    return {
+      kind: 'token',
+      accessToken: current.access_token,
+      baseUrl: resolveQwenBaseUrl(current.resource_url),
+    }
+  }
+
+  try {
+    const refreshed = await refreshQwenToken(current.refresh_token)
+    const next: QwenCredentials = {
+      access_token: refreshed.access_token,
+      refresh_token: refreshed.refresh_token,
+      token_type: refreshed.token_type || current.token_type,
+      resource_url: refreshed.resource_url ?? current.resource_url,
+      expires_at: Date.now() + refreshed.expires_in * 1000,
+    }
+    saveQwenCredentials(next, path)
+    return {
+      kind: 'token',
+      accessToken: next.access_token,
+      baseUrl: resolveQwenBaseUrl(next.resource_url),
+    }
+  } catch (err) {
+    if (err instanceof QwenDeviceFlowError) {
+      return { kind: 'none' }
+    }
+    throw err
+  }
+}
+
+/** Synchronous, non-refreshing lookup — used by early env hydration. */
+export function readQwenAccessTokenSync(
+  env: NodeJS.ProcessEnv = process.env,
+): { accessToken: string; baseUrl: string } | undefined {
+  const current = loadQwenCredentials(getQwenCredentialsPath(env))
+  if (!current) return undefined
+  if (Date.now() >= current.expires_at) return undefined
+  return {
+    accessToken: current.access_token,
+    baseUrl: resolveQwenBaseUrl(current.resource_url),
+  }
+}
+
+/**
+ * If Qwen mode is on, copy the stored access token into OPENAI_* env vars so
+ * downstream OpenAI-shim code picks it up. Mirrors
+ * `hydrateGeminiAccessTokenFromSecureStorage` in `geminiCredentials.ts`.
+ */
+export function hydrateQwenCredentialsFromDisk(
+  env: NodeJS.ProcessEnv = process.env,
+): void {
+  if (!isEnvTruthy(env.CLAUDE_CODE_USE_QWEN)) return
+  if (isBareMode()) return
+  const creds = readQwenAccessTokenSync(env)
+  if (!creds) return
+  // Always overwrite: tokens are short-lived, the disk copy is authoritative.
+  env.OPENAI_API_KEY = creds.accessToken
+  env.OPENAI_BASE_URL ??= creds.baseUrl
+  env.OPENAI_MODEL ??= 'qwen3-coder-plus'
+}
+
+export const QWEN_DEFAULT_BASE_URL = QWEN_DEFAULT_RESOURCE_URL

--- a/src/utils/status.tsx
+++ b/src/utils/status.tsx
@@ -252,6 +252,7 @@ export function buildAPIProviderProperties(): Property[] {
       gemini: 'Google Gemini',
       github: 'GitHub Models',
       mistral: 'Mistral',
+      qwen: 'Qwen (OAuth)',
     }[apiProvider];
     properties.push({
       label: 'API provider',


### PR DESCRIPTION
## Summary

- Add Qwen OAuth authentication support via `/onboard-qwen` command
- Implement Qwen provider configuration in provider manager UI
- Add Qwen-specific API client handling with proper headers and token refresh
- Include Qwen in model configuration and provider detection logic
- Add Qwen credentials management and storage at `~/.qwen/oauth_creds.json`
- Support Qwen model (`qwen3-coder-plus`) with portal.qwen.ai endpoint

## Test plan

- [ ] Verify `/onboard-qwen` command works for OAuth flow
- [ ] Test Qwen provider selection in UI
- [ ] Confirm API requests work with Qwen endpoint
- [ ] Validate token refresh functionality
- [ ] Ensure credentials are properly stored and retrieved

🤖 Generated with [OpenClaude](https://github.com/Gitlawb/openclaude)