### PR TITLE
fix: replace broken bun:bundle shim with source pre-processing

### DIFF
--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -8,7 +8,8 @@
  * - src/ path aliases
  */
 
-import { readFileSync } from 'fs'
+import { readFileSync, readdirSync, writeFileSync } from 'fs'
+import { join } from 'path'
 import { noTelemetryPlugin } from './no-telemetry-plugin'
 
 const pkg = JSON.parse(readFileSync('./package.json', 'utf-8'))
@@ -42,6 +43,56 @@ const featureFlags: Record<string, boolean> = {
   CHICAGO_MCP: false,
   COWORKER_TYPE_TELEMETRY: false,
 }
+
+// ── Pre-process: replace feature() calls with boolean literals ──────
+// Bun v1.3.9+ resolves `import { feature } from 'bun:bundle'` natively
+// before plugins can intercept it via onResolve. The bun: namespace is
+// handled by Bun's C++ resolver which runs before the JS plugin phase,
+// so the previous onResolve/onLoad shim was silently ineffective — ALL
+// feature() calls evaluated to false regardless of the featureFlags map.
+//
+// Fix: pre-process source files to strip the bun:bundle import and
+// replace feature('FLAG') calls with their boolean literal. Files are
+// modified in-place before Bun.build() and restored in a finally block.
+
+// Match feature('FLAG') calls, including multi-line: feature(\n  'FLAG',\n)
+const featureCallRe = /\bfeature\(\s*['"](\w+)['"][,\s]*\)/gs
+const featureImportRe = /import\s*\{[^}]*\bfeature\b[^}]*\}\s*from\s*['"]bun:bundle['"];?\s*\n?/g
+const modifiedFiles = new Map<string, string>() // path → original content
+
+function preProcessFeatureFlags(dir: string) {
+  for (const ent of readdirSync(dir, { withFileTypes: true })) {
+    const full = join(dir, ent.name)
+    if (ent.isDirectory()) { preProcessFeatureFlags(full); continue }
+    if (!/\.(ts|tsx)$/.test(ent.name)) continue
+
+    const raw = readFileSync(full, 'utf-8')
+    if (!raw.includes('feature(')) continue
+
+    let contents = raw
+    contents = contents.replace(featureImportRe, '')
+    contents = contents.replace(featureCallRe, (_match, name) =>
+      String((featureFlags as Record<string, boolean>)[name] ?? false),
+    )
+
+    if (contents !== raw) {
+      modifiedFiles.set(full, raw)
+      writeFileSync(full, contents)
+    }
+  }
+}
+
+function restoreModifiedFiles() {
+  for (const [path, original] of modifiedFiles) {
+    writeFileSync(path, original)
+  }
+  modifiedFiles.clear()
+}
+
+preProcessFeatureFlags(join(import.meta.dir, '..', 'src'))
+const numModified = modifiedFiles.size
+
+try {
 
 const result = await Bun.build({
   entrypoints: ['./src/entrypoints/cli.tsx'],
@@ -103,18 +154,11 @@ export async function handleBgFlag() { throw new Error("Background sessions are 
           ],
         ] as const)
 
-        // Resolve `import { feature } from 'bun:bundle'` to a shim
-        build.onResolve({ filter: /^bun:bundle$/ }, () => ({
-          path: 'bun:bundle',
-          namespace: 'bun-bundle-shim',
-        }))
-        build.onLoad(
-          { filter: /.*/, namespace: 'bun-bundle-shim' },
-          () => ({
-            contents: `const featureFlags = ${JSON.stringify(featureFlags)};\nexport function feature(name) { return featureFlags[name] ?? false; }`,
-            loader: 'js',
-          }),
-        )
+        // bun:bundle feature() replacement is handled by the source
+        // pre-processing step above (see preProcessFeatureFlags).
+        // The previous onResolve/onLoad shim was ineffective in Bun
+        // v1.3.9+ because the bun: namespace is resolved natively
+        // before the JS plugin phase runs.
 
         build.onResolve(
           { filter: /^\.\.\/(daemon\/workerRegistry|daemon\/main|cli\/bg|cli\/handlers\/templateJobs|environment-runner\/main|self-hosted-runner\/main)\.js$/ },
@@ -274,16 +318,7 @@ export const SeverityNumber = {};
 
         // Scan source to find imports that can't resolve
         function scanForMissingImports() {
-          function walk(dir: string) {
-            for (const ent of fs.readdirSync(dir, { withFileTypes: true })) {
-              const full = pathMod.join(dir, ent.name)
-              if (ent.isDirectory()) { walk(full); continue }
-              if (!/\.(ts|tsx)$/.test(ent.name)) continue
-              const code: string = fs.readFileSync(full, 'utf-8')
-              // Collect all imports
-              for (const m of code.matchAll(/import\s+(?:\{([^}]*)\}|(\w+))?\s*(?:,\s*\{([^}]*)\})?\s*from\s+['"](.*?)['"]/g)) {
-                const specifier = m[4]
-                const namedPart = m[1] || m[3] || ''
+          function checkAndRegister(specifier: string, fileDir: string, namedPart: string) {
                 const names = namedPart.split(',')
                   .map((s: string) => s.trim().replace(/^type\s+/, ''))
                   .filter((s: string) => s && !s.startsWith('type '))
@@ -303,8 +338,7 @@ export const SeverityNumber = {};
                 }
                 // Check relative .js imports
                 else if (specifier.endsWith('.js') && (specifier.startsWith('./') || specifier.startsWith('../'))) {
-                  const dir2 = pathMod.dirname(full)
-                  const resolved = pathMod.resolve(dir2, specifier)
+                  const resolved = pathMod.resolve(fileDir, specifier)
                   const tsVariant = resolved.replace(/\.js$/, '.ts')
                   const tsxVariant = resolved.replace(/\.js$/, '.tsx')
                   if (!fs.existsSync(resolved) && !fs.existsSync(tsVariant) && !fs.existsSync(tsxVariant)) {
@@ -317,6 +351,30 @@ export const SeverityNumber = {};
                   if (!missingModuleExports.has(specifier)) missingModuleExports.set(specifier, new Set())
                   for (const n of names) missingModuleExports.get(specifier)!.add(n)
                 }
+          }
+
+          function walk(dir: string) {
+            for (const ent of fs.readdirSync(dir, { withFileTypes: true })) {
+              const full = pathMod.join(dir, ent.name)
+              if (ent.isDirectory()) { walk(full); continue }
+              if (!/\.(ts|tsx)$/.test(ent.name)) continue
+              const code: string = fs.readFileSync(full, 'utf-8')
+              const fileDir = pathMod.dirname(full)
+
+              // Collect static imports: import { X } from '...'
+              for (const m of code.matchAll(/import\s+(?:\{([^}]*)\}|(\w+))?\s*(?:,\s*\{([^}]*)\})?\s*from\s+['"](.*?)['"]/g)) {
+                checkAndRegister(m[4], fileDir, m[1] || m[3] || '')
+              }
+
+              // Collect dynamic requires: require('...') — these are used
+              // behind feature() gates and become live when flags are enabled.
+              for (const m of code.matchAll(/require\(\s*['"](\.\.?\/[^'"]+)['"]\s*\)/g)) {
+                checkAndRegister(m[1], fileDir, '')
+              }
+
+              // Collect dynamic imports: import('...')
+              for (const m of code.matchAll(/import\(\s*['"](\.\.?\/[^'"]+)['"]\s*\)/g)) {
+                checkAndRegister(m[1], fileDir, '')
               }
             }
           }
@@ -393,3 +451,9 @@ if (!result.success) {
 }
 
 console.log(`✓ Built openclaude v${version} → dist/cli.mjs`)
+
+} finally {
+  // Always restore source files, even if Bun.build() throws
+  restoreModifiedFiles()
+  console.log(`  🔄 feature-flags: pre-processed ${numModified} files (restored)`)
+}

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -92,6 +92,14 @@ function restoreModifiedFiles() {
 preProcessFeatureFlags(join(import.meta.dir, '..', 'src'))
 const numModified = modifiedFiles.size
 
+// Restore source files on abrupt termination (Ctrl+C, kill, etc.)
+for (const signal of ['SIGINT', 'SIGTERM'] as const) {
+  process.on(signal, () => {
+    restoreModifiedFiles()
+    process.exit(signal === 'SIGINT' ? 130 : 143)
+  })
+}
+
 try {
 
 const result = await Bun.build({
@@ -447,10 +455,10 @@ if (!result.success) {
   for (const log of result.logs) {
     console.error(log)
   }
-  process.exit(1)
+  process.exitCode = 1
+} else {
+  console.log(`✓ Built openclaude v${version} → dist/cli.mjs`)
 }
-
-console.log(`✓ Built openclaude v${version} → dist/cli.mjs`)
 
 } finally {
   // Always restore source files, even if Bun.build() throws


### PR DESCRIPTION
## Summary

The `onResolve`/`onLoad` plugin shim for `import { feature } from 'bun:bundle'` was **silently ineffective** in Bun v1.3.9+. The `bun:` namespace is resolved by Bun's native C++ resolver before the JS plugin phase runs, so the `onResolve` callback was never called. This meant **ALL** `feature()` flags evaluated to `false` regardless of the `featureFlags` map — including `MONITOR_TOOL: true` which was already enabled.

### Root cause

Bun handles `bun:bundle` as a compile-time macro via its internal resolver, not as a regular module. Plugins cannot intercept `bun:` namespace resolution.

### Fix — source pre-processing

Replace the broken shim with a build-time source transformation:

1. **Before `Bun.build()`**: walk `src/`, strip `import { feature } from 'bun:bundle'`, replace `feature('FLAG')` calls with boolean literals from the `featureFlags` map
2. **After `Bun.build()`**: restore original source files in a `finally` block (safe even if the build throws)
3. **Extended scanner**: detect `require()` and dynamic `import()` calls (not just static `import ... from`) since modules behind feature() gates become resolvable when flags are enabled

### Impact

- **No feature flags changed** — this PR only fixes the mechanism. Existing flags (`MONITOR_TOOL: true`, `BUDDY: true`) now actually take effect.
- Foundation for all feature activation PRs (#632, #633, #647, #648) which depend on `feature()` working correctly.
- 0 `feature()` calls remain in the compiled bundle (all constant-folded).

### Before/After

| | Before (broken shim) | After (pre-processing) |
|---|---|---|
| `feature('MONITOR_TOOL')` with `MONITOR_TOOL: true` | `false` at runtime | `true` (constant-folded) |
| `feature()` calls in bundle | 2+ (runtime function) | 0 (all replaced) |
| Source files after build | Unchanged | Restored in `finally` |

## Test plan
- [x] `bun run build` — compiles successfully (206 files pre-processed, all restored)
- [x] `bun run smoke` — smoke tests pass
- [x] 0 `feature()` calls in compiled bundle
- [x] Source files verified intact after build (`bun:bundle` imports present)
- [ ] Enable a flag (e.g. `COORDINATOR_MODE: true`), verify the feature code is included in the bundle