### PR TITLE
feat: add allowBypassPermissionsMode setting

### DIFF
--- a/src/cli/print.ts
+++ b/src/cli/print.ts
@@ -4592,7 +4592,7 @@ function handleSetPermissionMode(
           subtype: 'error',
           request_id: requestId,
           error:
-            'Cannot set permission mode to bypassPermissions because the session was not launched with --dangerously-skip-permissions',
+            'Cannot set permission mode to bypassPermissions. Enable it with --allow-dangerously-skip-permissions or set permissions.allowBypassPermissionsMode in settings.json',
         },
       })
       return toolPermissionContext

--- a/src/hooks/useReplBridge.tsx
+++ b/src/hooks/useReplBridge.tsx
@@ -434,7 +434,7 @@ export function useReplBridge(messages: Message[], setMessages: (action: React.S
                 if (!store.getState().toolPermissionContext.isBypassPermissionsModeAvailable) {
                   return {
                     ok: false,
-                    error: 'Cannot set permission mode to bypassPermissions because the session was not launched with --dangerously-skip-permissions'
+                    error: 'Cannot set permission mode to bypassPermissions. Enable it with --allow-dangerously-skip-permissions or set permissions.allowBypassPermissionsMode in settings.json'
                   };
                 }
               }

--- a/src/utils/permissions/permissionSetup.ts
+++ b/src/utils/permissions/permissionSetup.ts
@@ -936,9 +936,12 @@ export async function initializeToolPermissionContext({
   const settings = getSettings_DEPRECATED() || {}
   const settingsDisableBypassPermissionsMode =
     settings.permissions?.disableBypassPermissionsMode === 'disable'
+  const settingsAllowBypassPermissionsMode =
+    settings.permissions?.allowBypassPermissionsMode === true
   const isBypassPermissionsModeAvailable =
     (permissionMode === 'bypassPermissions' ||
-      allowDangerouslySkipPermissions) &&
+      allowDangerouslySkipPermissions ||
+      settingsAllowBypassPermissionsMode) &&
     !growthBookDisableBypassPermissionsMode &&
     !settingsDisableBypassPermissionsMode
 

--- a/src/utils/permissions/permissionSetup.ts
+++ b/src/utils/permissions/permissionSetup.ts
@@ -19,6 +19,7 @@ import {
   getSettings_DEPRECATED,
   getSettingsFilePathForSource,
   getUseAutoModeDuringPlan,
+  hasAllowBypassPermissionsMode,
   hasAutoModeOptIn,
 } from '../settings/settings.js'
 import {
@@ -936,8 +937,7 @@ export async function initializeToolPermissionContext({
   const settings = getSettings_DEPRECATED() || {}
   const settingsDisableBypassPermissionsMode =
     settings.permissions?.disableBypassPermissionsMode === 'disable'
-  const settingsAllowBypassPermissionsMode =
-    settings.permissions?.allowBypassPermissionsMode === true
+  const settingsAllowBypassPermissionsMode = hasAllowBypassPermissionsMode()
   const isBypassPermissionsModeAvailable =
     (permissionMode === 'bypassPermissions' ||
       allowDangerouslySkipPermissions ||

--- a/src/utils/settings/allowBypassPermissionsMode.test.ts
+++ b/src/utils/settings/allowBypassPermissionsMode.test.ts
@@ -1,0 +1,27 @@
+import { describe, test, expect } from 'bun:test'
+
+describe('SettingsSchema allowBypassPermissionsMode', () => {
+  test('accepts allowBypassPermissionsMode: true', async () => {
+    const { SettingsSchema } = await import('./types.js')
+    const result = SettingsSchema().safeParse({
+      permissions: { allowBypassPermissionsMode: true },
+    })
+    expect(result.success).toBe(true)
+  })
+
+  test('accepts allowBypassPermissionsMode: false', async () => {
+    const { SettingsSchema } = await import('./types.js')
+    const result = SettingsSchema().safeParse({
+      permissions: { allowBypassPermissionsMode: false },
+    })
+    expect(result.success).toBe(true)
+  })
+
+  test('rejects non-boolean allowBypassPermissionsMode', async () => {
+    const { SettingsSchema } = await import('./types.js')
+    const result = SettingsSchema().safeParse({
+      permissions: { allowBypassPermissionsMode: 'yes' },
+    })
+    expect(result.success).toBe(false)
+  })
+})

--- a/src/utils/settings/settings.ts
+++ b/src/utils/settings/settings.ts
@@ -890,6 +890,24 @@ export function hasSkipDangerousModePermissionPrompt(): boolean {
 }
 
 /**
+ * Returns true if any trusted settings source has enabled bypass permissions
+ * mode availability. projectSettings is intentionally excluded — a malicious
+ * project could otherwise enable bypass mode (security risk).
+ */
+export function hasAllowBypassPermissionsMode(): boolean {
+  return !!(
+    getSettingsForSource('userSettings')?.permissions
+      ?.allowBypassPermissionsMode ||
+    getSettingsForSource('localSettings')?.permissions
+      ?.allowBypassPermissionsMode ||
+    getSettingsForSource('flagSettings')?.permissions
+      ?.allowBypassPermissionsMode ||
+    getSettingsForSource('policySettings')?.permissions
+      ?.allowBypassPermissionsMode
+  )
+}
+
+/**
  * Returns true if any trusted settings source has accepted the auto
  * mode opt-in dialog. projectSettings is intentionally excluded —
  * a malicious project could otherwise auto-bypass the dialog (RCE risk).

--- a/src/utils/settings/settings.ts
+++ b/src/utils/settings/settings.ts
@@ -574,6 +574,7 @@ export function getManagedSettingsKeysForLogging(
       'ask',
       'defaultMode',
       'disableBypassPermissionsMode',
+      'allowBypassPermissionsMode',
       ...(feature('TRANSCRIPT_CLASSIFIER') ? ['disableAutoMode'] : []),
       'additionalDirectories',
     ]),

--- a/src/utils/settings/types.ts
+++ b/src/utils/settings/types.ts
@@ -69,6 +69,12 @@ export const PermissionsSchema = lazySchema(() =>
         .enum(['disable'])
         .optional()
         .describe('Disable the ability to bypass permission prompts'),
+      allowBypassPermissionsMode: z
+        .boolean()
+        .optional()
+        .describe(
+          'Allow bypass permissions mode to appear in the mode list without requiring the CLI flag',
+        ),
       ...(feature('TRANSCRIPT_CLASSIFIER')
         ? {
             disableAutoMode: z


### PR DESCRIPTION
## Summary

- Adds a new `permissions.allowBypassPermissionsMode` boolean setting in `settings.json`
- When set to `true`, bypass permissions mode appears in the mode carousel (Shift+Tab) and plan mode exit options — without requiring the `--allow-dangerously-skip-permissions` CLI flag
- The `disableBypassPermissionsMode` setting (admin/policy) retains priority and can still block bypass mode

## Usage

```json
{
  "permissions": {
    "allowBypassPermissionsMode": true
  }
}
```

## Files changed

- `src/utils/settings/types.ts` — Zod schema: new optional boolean field
- `src/utils/settings/settings.ts` — `validNestedKeys` whitelist: register the new field for settings expansion
- `src/utils/permissions/permissionSetup.ts` — `isBypassPermissionsModeAvailable` condition: OR with the new setting

## Test plan

- [ ] Build passes (`npm run build`)
- [ ] Add `"permissions": { "allowBypassPermissionsMode": true }` to `~/.claude/settings.json`
- [ ] Launch `claude` without any CLI flag → Shift+Tab cycles through modes including "Bypass Permissions"
- [ ] Default mode remains "Default"
- [ ] Adding `"disableBypassPermissionsMode": "disable"` alongside it → bypass mode is hidden (disable wins)