### PR TITLE
fix: preserve reasoning content on tool call replays

### DIFF
--- a/src/services/api/openaiShim.test.ts
+++ b/src/services/api/openaiShim.test.ts
@@ -584,6 +584,62 @@ test('preserves Gemini tool call extra_content in follow-up requests', async () 
   })
 })
 
+test('preserves reasoning_content on assistant tool calls in follow-up requests (issue #522)', async () => {
+  let requestBody: Record<string, unknown> | undefined
+
+  globalThis.fetch = (async (_input, init) => {
+    requestBody = JSON.parse(String(init?.body))
+
+    return makeNonStreamResponse()
+  }) as FetchType
+
+  const client = createOpenAIShimClient({}) as OpenAIShimClient
+
+  await client.beta.messages.create({
+    model: 'kimi-k2.5',
+    system: 'test system',
+    messages: [
+      { role: 'user', content: 'Use Bash' },
+      {
+        role: 'assistant',
+        content: [
+          { type: 'thinking', thinking: 'I should inspect the current directory first.' },
+          {
+            type: 'tool_use',
+            id: 'call_1',
+            name: 'Bash',
+            input: { command: 'pwd' },
+          },
+        ],
+      },
+      {
+        role: 'user',
+        content: [
+          {
+            type: 'tool_result',
+            tool_use_id: 'call_1',
+            content: '/tmp/openclaude',
+          },
+        ],
+      },
+    ],
+    max_tokens: 64,
+    stream: false,
+  })
+
+  const assistantWithToolCall = (requestBody?.messages as Array<Record<string, unknown>>).find(
+    message => Array.isArray(message.tool_calls),
+  ) as { reasoning_content?: string; tool_calls?: Array<Record<string, unknown>> } | undefined
+
+  expect(assistantWithToolCall?.reasoning_content).toBe(
+    'I should inspect the current directory first.',
+  )
+  expect(assistantWithToolCall?.tool_calls?.[0]).toMatchObject({
+    id: 'call_1',
+    type: 'function',
+  })
+})
+
 test('preserves Grep tool pattern field in OpenAI-compatible schemas', async () => {
   let requestBody: Record<string, unknown> | undefined
 
@@ -2374,6 +2430,61 @@ test('coalesces consecutive assistant messages preserving tool_calls (issue #202
 
   const assistantMsgs = sentMessages?.filter(m => m.role === 'assistant')
   expect(assistantMsgs?.length).toBe(1)
+  expect(assistantMsgs?.[0]?.tool_calls?.length).toBeGreaterThan(0)
+})
+
+test('coalesces consecutive assistant messages preserving reasoning_content (issue #522)', async () => {
+  let sentMessages:
+    | Array<{
+        role: string
+        content: unknown
+        reasoning_content?: string
+        tool_calls?: unknown[]
+      }>
+    | undefined
+
+  globalThis.fetch = (async (_input: unknown, init: RequestInit | undefined) => {
+    sentMessages = JSON.parse(String(init?.body)).messages
+    return makeNonStreamResponse()
+  }) as FetchType
+
+  const client = createOpenAIShimClient({}) as OpenAIShimClient
+
+  await client.beta.messages.create({
+    model: 'kimi-k2.5',
+    system: 'sys',
+    messages: [
+      { role: 'user', content: 'go' },
+      {
+        role: 'assistant',
+        content: [
+          {
+            type: 'thinking',
+            thinking: 'I should inspect the current directory first.',
+          },
+          {
+            type: 'tool_use',
+            id: 'call_1',
+            name: 'Bash',
+            input: { command: 'pwd' },
+          },
+        ],
+      },
+      {
+        role: 'assistant',
+        content: 'Continuing after the tool call.',
+      },
+      { role: 'user', content: [{ type: 'tool_result', tool_use_id: 'call_1', content: '/tmp' }] },
+    ],
+    max_tokens: 64,
+    stream: false,
+  })
+
+  const assistantMsgs = sentMessages?.filter(m => m.role === 'assistant')
+  expect(assistantMsgs?.length).toBe(1)
+  expect(assistantMsgs?.[0]?.reasoning_content).toBe(
+    'I should inspect the current directory first.',
+  )
   expect(assistantMsgs?.[0]?.tool_calls?.length).toBeGreaterThan(0)
 })
 

--- a/src/services/api/openaiShim.ts
+++ b/src/services/api/openaiShim.ts
@@ -141,6 +141,7 @@ function sleepMs(ms: number): Promise<void> {
 interface OpenAIMessage {
   role: 'system' | 'user' | 'assistant' | 'tool'
   content?: string | Array<{ type: string; text?: string; image_url?: { url: string } }>
+  reasoning_content?: string
   tool_calls?: Array<{
     id: string
     type: 'function'
@@ -342,6 +343,13 @@ function convertMessages(
       // Check for tool_use blocks
       if (Array.isArray(content)) {
         const toolUses = content.filter((b: { type?: string }) => b.type === 'tool_use')
+        const reasoningContent = content
+          .filter(
+            (b: { type?: string; thinking?: string }) =>
+              b.type === 'thinking' && typeof b.thinking === 'string' && b.thinking !== '',
+          )
+          .map((b: { thinking?: string }) => b.thinking ?? '')
+          .join('\n\n')
         const thinkingBlock = content.find((b: { type?: string }) => b.type === 'thinking')
         const textContent = content.filter(
           (b: { type?: string }) => b.type !== 'tool_use' && b.type !== 'thinking',
@@ -353,6 +361,9 @@ function convertMessages(
             const c = convertContentBlocks(textContent)
             return typeof c === 'string' ? c : Array.isArray(c) ? c.map((p: { text?: string }) => p.text ?? '').join('') : ''
           })(),
+        }
+        if (reasoningContent) {
+          assistantMsg.reasoning_content = reasoningContent
         }
 
         if (toolUses.length > 0) {
@@ -442,6 +453,12 @@ function convertMessages(
           return c
         }
         prev.content = [...toArray(prevContent), ...toArray(curContent)]
+      }
+
+      if (msg.reasoning_content) {
+        prev.reasoning_content = [prev.reasoning_content, msg.reasoning_content]
+          .filter((value): value is string => Boolean(value))
+          .join('\n\n')
       }
 
       if (msg.tool_calls?.length) {


### PR DESCRIPTION
## Problem
Reasoning-capable OpenAI-compatible providers such as Kimi require assistant tool-call messages in the replayed history to include `reasoning_content`. OpenClaude currently strips Anthropic `thinking` blocks when converting assistant messages for the OpenAI shim, so follow-up requests can contain `tool_calls` without the required reasoning payload and fail with a 400 error.

## Root Cause
`convertMessages()` removes `thinking` blocks from assistant history to avoid leaking Anthropic-only content types into OpenAI-compatible providers, but it does not preserve that reasoning anywhere when the same assistant turn also contains `tool_use` blocks.

## Fix
Preserve assistant thinking text as `reasoning_content` on replayed OpenAI-compatible assistant messages, including after assistant-message coalescing, while continuing to omit Anthropic-only block types from `content`.

## Validation
- `~/.bun/bin/bun install`
- `~/.bun/bin/bun test ./src/services/api/openaiShim.test.ts`

Closes #522
