### PR TITLE
docs: add GitLawb mirror to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,9 @@ Use OpenAI-compatible APIs, Gemini, GitHub Models, Codex OAuth, Codex, Ollama, A
 [![Security Policy](https://img.shields.io/badge/security-policy-0f766e)](SECURITY.md)
 [![License](https://img.shields.io/badge/license-MIT-2563eb)](LICENSE)
 
+OpenClaude is also mirrored to GitLawb:
+[gitlawb.com/node/repos/z6MkqDnb/openclaude](https://gitlawb.com/node/repos/z6MkqDnb/openclaude)
+
 [Quick Start](#quick-start) | [Setup Guides](#setup-guides) | [Providers](#supported-providers) | [Source Build](#source-build-and-local-development) | [VS Code Extension](#vs-code-extension) | [Community](#community)
 
 ## Why OpenClaude


### PR DESCRIPTION
 ## Summary

  - added a short note near the top of the README that OpenClaude is mirrored to GitLawb
  - linked directly to the mirror:
      - https://gitlawb.com/node/repos/z6MkqDnb/openclaude
  - this changed because users should be able to discover the GitLawb mirror directly from the main project README

  ## Impact

  - user-facing impact:
      - makes the GitLawb mirror visible from the main landing page
  - developer/maintainer impact:
      - no code or workflow changes
      - documentation-only update