### PR TITLE
feat: add local openclaude-for-chrome-mcp package

### DIFF
--- a/packages/openclaude-for-chrome-mcp/index.ts
+++ b/packages/openclaude-for-chrome-mcp/index.ts
@@ -1,0 +1,13 @@
+/**
+ * OpenClaude for Chrome MCP
+ *
+ * Local implementation of the Chrome browser automation MCP server
+ * for OpenClaude.
+ *
+ * This package bridges OpenClaude's MCP tool system to the Chrome extension
+ * (ID: fcoeoabgfenejglbffodgkkbkcdhcgfn) via the native messaging host socket.
+ */
+
+export { BROWSER_TOOLS } from './tools.js'
+export { createClaudeForChromeMcpServer } from './server.js'
+export type { ClaudeForChromeContext, Logger, PermissionMode } from './types.js'

--- a/packages/openclaude-for-chrome-mcp/protocol.ts
+++ b/packages/openclaude-for-chrome-mcp/protocol.ts
@@ -1,0 +1,42 @@
+/**
+ * OpenClaude for Chrome MCP — Socket protocol types
+ *
+ * Defines the message format used over the Unix domain socket between
+ * this MCP server (client side) and the Chrome native host (server side).
+ *
+ * Protocol: 4-byte little-endian length prefix followed by a UTF-8 JSON payload.
+ * See chromeNativeHost.ts:374-409 for the server-side implementation.
+ */
+
+/** Sent from MCP server to native host over the socket. */
+export interface ToolRequest {
+  method: string
+  params?: unknown
+}
+
+/**
+ * Received from native host over the socket.
+ * The native host strips the `type` field from Chrome's `tool_response`
+ * before forwarding (chromeNativeHost.ts:299-301).
+ */
+export interface ToolResponse {
+  /** Tool-specific result payload */
+  result?: unknown
+  /** Error from the Chrome extension — may be a string or structured object */
+  error?: string | Record<string, unknown>
+  /** Base64-encoded screenshot PNG, returned by computer/read_page tools */
+  screenshot?: string
+  [key: string]: unknown
+}
+
+/**
+ * Notification forwarded from Chrome via the native host.
+ * The native host strips the `type` field before forwarding.
+ * Used for device pairing, connection state, etc.
+ */
+export interface Notification {
+  notificationType?: string
+  deviceId?: string
+  deviceName?: string
+  [key: string]: unknown
+}

--- a/packages/openclaude-for-chrome-mcp/server.ts
+++ b/packages/openclaude-for-chrome-mcp/server.ts
@@ -1,0 +1,160 @@
+/**
+ * OpenClaude for Chrome MCP — Server factory
+ *
+ * Creates an MCP server that exposes browser automation tools.
+ * Tool calls are forwarded to the Chrome extension via the native host socket.
+ */
+
+import { Server } from '@modelcontextprotocol/sdk/server/index.js'
+import {
+  CallToolRequestSchema,
+  ListToolsRequestSchema,
+} from '@modelcontextprotocol/sdk/types.js'
+import { BROWSER_TOOLS } from './tools.js'
+import { SocketClient } from './socketClient.js'
+import type { ClaudeForChromeContext } from './types.js'
+
+/**
+ * Create an MCP server wired to the Chrome extension via native host socket.
+ * The returned server exposes the 17 browser tools and forwards calls to Chrome.
+ *
+ * Usage (subprocess mode — mcpServer.ts):
+ *   const server = createClaudeForChromeMcpServer(context)
+ *   await server.connect(new StdioServerTransport())
+ *
+ * Usage (in-process mode — mcp/client.ts):
+ *   const server = createClaudeForChromeMcpServer(context)
+ *   const [clientTransport, serverTransport] = createLinkedTransportPair()
+ *   await server.connect(serverTransport)
+ */
+export function createClaudeForChromeMcpServer(
+  context: ClaudeForChromeContext,
+): Server {
+  const server = new Server(
+    { name: context.serverName, version: '1.0.0' },
+    { capabilities: { tools: {} } },
+  )
+
+  const client = new SocketClient(context)
+
+  // Clean up socket on server shutdown
+  server.onclose = () => {
+    client.disconnect()
+  }
+
+  // ── ListTools ──────────────────────────────────────────────────────
+  server.setRequestHandler(ListToolsRequestSchema, async () => ({
+    tools: BROWSER_TOOLS,
+  }))
+
+  // ── CallTool ───────────────────────────────────────────────────────
+  server.setRequestHandler(CallToolRequestSchema, async (request) => {
+    const { name: toolName, arguments: toolArgs } = request.params
+
+    // Lazy connect on first tool call
+    if (!client.isConnected()) {
+      try {
+        await client.connect()
+      } catch (e) {
+        context.logger.warn(
+          `[OpenClaude Chrome] Failed to connect: ${e}`,
+        )
+      }
+    }
+
+    // If still not connected after attempt, return a user-friendly error
+    if (!client.isConnected()) {
+      const msg = context.onToolCallDisconnected()
+      return {
+        content: [{ type: 'text' as const, text: msg }],
+        isError: true,
+      }
+    }
+
+    try {
+      context.trackEvent('chrome_tool_call', {
+        tool_name: toolName,
+      })
+
+      const response = await client.sendToolRequest(toolName, toolArgs)
+
+      // Handle error responses from the extension
+      if (response.error) {
+        context.trackEvent('chrome_tool_error', {
+          tool_name: toolName,
+          error_type: typeof response.error === 'string' ? response.error.slice(0, 100) : 'unknown',
+        })
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text:
+                typeof response.error === 'string'
+                  ? response.error
+                  : JSON.stringify(response.error),
+            },
+          ],
+          isError: true,
+        }
+      }
+
+      // Handle screenshot responses (base64 PNG from computer/read_page tools)
+      if (response.screenshot && typeof response.screenshot === 'string') {
+        const content: Array<
+          | { type: 'image'; data: string; mimeType: string }
+          | { type: 'text'; text: string }
+        > = [
+          {
+            type: 'image' as const,
+            data: response.screenshot,
+            mimeType: 'image/png',
+          },
+        ]
+
+        // Include any accompanying text result
+        const textResult = response.result ?? response.text
+        if (textResult !== undefined) {
+          content.push({
+            type: 'text' as const,
+            text:
+              typeof textResult === 'string'
+                ? textResult
+                : JSON.stringify(textResult),
+          })
+        }
+
+        return { content }
+      }
+
+      // Standard text response — use result field if present, otherwise
+      // strip known meta-keys and serialize the remaining payload
+      const { error: _e, screenshot: _s, ...rest } = response
+      const result = rest.result !== undefined ? rest.result : rest
+      const text =
+        typeof result === 'string' ? result : JSON.stringify(result)
+
+      return {
+        content: [{ type: 'text' as const, text }],
+      }
+    } catch (error) {
+      context.trackEvent('chrome_tool_error', {
+        tool_name: toolName,
+        error_type: 'exception',
+      })
+      context.logger.error(
+        `[OpenClaude Chrome] Tool call failed: ${toolName} — ${error}`,
+      )
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text: `OpenClaude Chrome tool error: ${error instanceof Error ? error.message : String(error)}`,
+          },
+        ],
+        isError: true,
+      }
+    }
+  })
+
+  return server
+}

--- a/packages/openclaude-for-chrome-mcp/socketClient.ts
+++ b/packages/openclaude-for-chrome-mcp/socketClient.ts
@@ -1,0 +1,286 @@
+/**
+ * OpenClaude for Chrome MCP — Unix socket client
+ *
+ * Connects to the Chrome native host's Unix domain socket and provides
+ * a request/response API for tool calls. The native host
+ * (chromeNativeHost.ts) acts as a bridge between this socket client
+ * and the Chrome extension via native messaging.
+ *
+ * Protocol: 4-byte little-endian length prefix + UTF-8 JSON payload.
+ */
+
+import { createConnection, type Socket } from 'net'
+import type { ClaudeForChromeContext } from './types.js'
+import type { ToolRequest, ToolResponse } from './protocol.js'
+
+const CONNECTION_TIMEOUT_MS = 5_000
+const TOOL_CALL_TIMEOUT_MS = 120_000
+const MAX_MESSAGE_SIZE = 1024 * 1024 // 1 MB, matches chromeNativeHost.ts
+
+type PendingRequest = {
+  resolve: (value: ToolResponse) => void
+  reject: (error: Error) => void
+  timer: ReturnType<typeof setTimeout>
+}
+
+export class SocketClient {
+  private socket: Socket | null = null
+  private buffer: Buffer = Buffer.alloc(0)
+  private pendingQueue: PendingRequest[] = []
+  private connected = false
+  private connectPromise: Promise<void> | null = null
+  private context: ClaudeForChromeContext
+
+  constructor(context: ClaudeForChromeContext) {
+    this.context = context
+  }
+
+  isConnected(): boolean {
+    return this.connected
+  }
+
+  /**
+   * Attempt to connect to the native host socket.
+   * Tries the primary socketPath first, then scans getSocketPaths().
+   * Concurrent callers share the same in-flight promise.
+   */
+  async connect(): Promise<void> {
+    if (this.connected) return
+    if (this.connectPromise) return this.connectPromise
+    this.connectPromise = this.doConnect().finally(() => {
+      this.connectPromise = null
+    })
+    return this.connectPromise
+  }
+
+  private async doConnect(): Promise<void> {
+    const candidates = [
+      this.context.socketPath,
+      ...this.context.getSocketPaths().filter(p => p !== this.context.socketPath),
+    ]
+
+    for (const socketPath of candidates) {
+      try {
+        await this.tryConnect(socketPath)
+        this.context.logger.info(
+          `[OpenClaude Chrome] Connected to native host socket: ${socketPath}`,
+        )
+        this.context.trackEvent('chrome_socket_connected')
+        return
+      } catch {
+        // Socket not available, try next candidate
+      }
+    }
+
+    // Throw so concurrent awaiters of connectPromise all get the same rejection
+    // and a fresh connect() can be attempted on the next tool call.
+    throw new Error(
+      'Could not connect to any native host socket',
+    )
+  }
+
+  private tryConnect(socketPath: string): Promise<void> {
+    return new Promise<void>((resolve, reject) => {
+      let settled = false
+      const settle = (fn: () => void) => {
+        if (settled) return
+        settled = true
+        clearTimeout(timer)
+        fn()
+      }
+
+      const timer = setTimeout(() => {
+        settle(() => {
+          socket.destroy()
+          reject(new Error(`Connection timeout: ${socketPath}`))
+        })
+      }, CONNECTION_TIMEOUT_MS)
+
+      const socket = createConnection(socketPath, () => {
+        settle(() => {
+          // Remove connect-time listeners before installing persistent ones
+          socket.removeAllListeners('error')
+          socket.removeAllListeners('close')
+
+          this.socket = socket
+          this.connected = true
+          this.buffer = Buffer.alloc(0)
+
+          // Persistent handlers — only active after successful connection
+          socket.on('data', (data: Buffer) => this.onData(data))
+          socket.on('error', (err: Error) => {
+            this.context.logger.debug(
+              `[OpenClaude Chrome] Socket error: ${err.message}`,
+            )
+            this.handleDisconnect()
+          })
+          socket.on('close', () => {
+            this.handleDisconnect()
+          })
+
+          resolve()
+        })
+      })
+
+      // Connect-time listeners — only reject, never touch instance state
+      socket.on('error', (err: Error) => {
+        settle(() => reject(err))
+      })
+      socket.on('close', () => {
+        settle(() => reject(new Error(`Socket closed during connect: ${socketPath}`)))
+      })
+    })
+  }
+
+  /**
+   * Send a tool request and wait for the response.
+   * Tool calls are sequential (one at a time from the LLM), so a simple
+   * FIFO queue handles request/response correlation.
+   */
+  async sendToolRequest(
+    method: string,
+    params?: unknown,
+  ): Promise<ToolResponse> {
+    const socket = this.socket
+    if (!socket || !this.connected) {
+      throw new Error('Not connected to native host')
+    }
+
+    const request: ToolRequest = { method, params }
+    const payload = Buffer.from(JSON.stringify(request), 'utf-8')
+
+    if (payload.length > MAX_MESSAGE_SIZE) {
+      throw new Error(
+        `Tool request too large: ${payload.length} bytes (max ${MAX_MESSAGE_SIZE})`,
+      )
+    }
+
+    const lengthBuf = Buffer.alloc(4)
+    lengthBuf.writeUInt32LE(payload.length, 0)
+    const frame = Buffer.concat([lengthBuf, payload])
+
+    return new Promise<ToolResponse>((resolve, reject) => {
+      const timer = setTimeout(() => {
+        const idx = this.pendingQueue.findIndex(p => p.resolve === resolve)
+        if (idx !== -1) this.pendingQueue.splice(idx, 1)
+        reject(new Error(`Tool call timeout: ${method}`))
+      }, TOOL_CALL_TIMEOUT_MS)
+
+      this.pendingQueue.push({ resolve, reject, timer })
+
+      // Single atomic write; use callback to surface write errors
+      socket.write(frame, (err) => {
+        if (err) {
+          const idx = this.pendingQueue.findIndex(p => p.resolve === resolve)
+          if (idx !== -1) {
+            this.pendingQueue.splice(idx, 1)
+            clearTimeout(timer)
+            reject(err)
+          }
+        }
+      })
+    })
+  }
+
+  disconnect(): void {
+    this.handleDisconnect()
+  }
+
+  // ── Private ────────────────────────────────────────────────────────
+
+  private onData(data: Buffer): void {
+    this.buffer = Buffer.concat([this.buffer, data])
+
+    while (this.buffer.length >= 4) {
+      const length = this.buffer.readUInt32LE(0)
+
+      if (length === 0 || length > MAX_MESSAGE_SIZE) {
+        this.context.logger.error(
+          `[OpenClaude Chrome] Invalid message length: ${length}`,
+        )
+        this.handleDisconnect()
+        return
+      }
+
+      if (this.buffer.length < 4 + length) {
+        break
+      }
+
+      const messageBytes = this.buffer.subarray(4, 4 + length)
+      this.buffer = this.buffer.subarray(4 + length)
+
+      try {
+        const message = JSON.parse(messageBytes.toString('utf-8')) as Record<
+          string,
+          unknown
+        >
+        this.handleMessage(message)
+      } catch (e) {
+        this.context.logger.error(
+          `[OpenClaude Chrome] Failed to parse message: ${e}`,
+        )
+      }
+    }
+  }
+
+  private handleMessage(message: Record<string, unknown>): void {
+    // Notifications carry a notificationType field (protocol-reliable discriminant)
+    // or deviceId+deviceName (fallback for device_paired events). Always route
+    // these to handleNotification regardless of pending queue state — a pairing
+    // notification can arrive during a tool call and must not be consumed as a
+    // tool response.
+    if (
+      message.notificationType !== undefined ||
+      (message.deviceId !== undefined && message.deviceName !== undefined)
+    ) {
+      this.handleNotification(message)
+      return
+    }
+
+    const pending = this.pendingQueue.shift()
+    if (pending) {
+      clearTimeout(pending.timer)
+      pending.resolve(message as ToolResponse)
+    } else {
+      this.context.logger.debug(
+        '[OpenClaude Chrome] Received message with no pending request',
+      )
+    }
+  }
+
+  private handleNotification(message: Record<string, unknown>): void {
+    const type = message.notificationType as string | undefined
+
+    if (type === 'device_paired' || (message.deviceId && message.deviceName)) {
+      const deviceId = message.deviceId as string
+      const deviceName = message.deviceName as string
+      this.context.onExtensionPaired(deviceId, deviceName)
+    }
+
+    this.context.logger.debug(
+      `[OpenClaude Chrome] Notification: ${type ?? 'unknown'}`,
+    )
+  }
+
+  /**
+   * Idempotent teardown — safe to call from error, close, or explicit disconnect.
+   * Guards against double-fire (error + close events on the same socket).
+   */
+  private handleDisconnect(): void {
+    if (!this.connected && this.socket === null) return
+
+    this.connected = false
+    const s = this.socket
+    this.socket = null
+    s?.destroy()
+    this.rejectAllPending('Native host disconnected')
+  }
+
+  private rejectAllPending(reason: string): void {
+    for (const pending of this.pendingQueue) {
+      clearTimeout(pending.timer)
+      pending.reject(new Error(reason))
+    }
+    this.pendingQueue = []
+  }
+}

--- a/packages/openclaude-for-chrome-mcp/tools.ts
+++ b/packages/openclaude-for-chrome-mcp/tools.ts
@@ -1,0 +1,476 @@
+/**
+ * OpenClaude for Chrome MCP — Browser tool definitions
+ *
+ * Each tool has a name, description, and JSON Schema inputSchema conforming
+ * to the MCP Tool type from @modelcontextprotocol/sdk/types.js.
+ *
+ * Tool names must match the ChromeToolName union in
+ * src/utils/claudeInChrome/toolRendering.tsx exactly.
+ */
+
+import type { Tool } from '@modelcontextprotocol/sdk/types.js'
+
+export const BROWSER_TOOLS: Tool[] = [
+  {
+    name: 'tabs_context_mcp',
+    description:
+      'Get information about the current browser tabs. Call this at the start of a browser automation session to understand what tabs are available.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        createIfEmpty: {
+          type: 'boolean',
+          description:
+            'If true and no tabs are open, create a new blank tab automatically.',
+        },
+      },
+    },
+  },
+  {
+    name: 'tabs_create_mcp',
+    description: 'Create a new browser tab.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        url: {
+          type: 'string',
+          description: 'Optional URL to navigate to in the new tab.',
+        },
+      },
+    },
+  },
+  {
+    name: 'navigate',
+    description: 'Navigate to a URL in a browser tab.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        url: {
+          type: 'string',
+          description: 'The URL to navigate to.',
+        },
+        tabId: {
+          type: 'number',
+          description: 'The ID of the tab to navigate.',
+        },
+      },
+      required: ['url', 'tabId'],
+    },
+  },
+  {
+    name: 'read_page',
+    description:
+      'Read the content or accessibility tree of a web page. Returns structural information about the page elements.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        tabId: {
+          type: 'number',
+          description: 'The ID of the tab to read.',
+        },
+        depth: {
+          type: 'number',
+          description:
+            'Maximum depth of the accessibility tree to return. Defaults to full depth.',
+        },
+        filter: {
+          type: 'string',
+          description: 'Filter expression to narrow results.',
+        },
+        max_chars: {
+          type: 'number',
+          description: 'Maximum number of characters to return.',
+        },
+        ref_id: {
+          type: 'string',
+          description:
+            'Reference ID of a specific element to read instead of the full page.',
+        },
+      },
+      required: ['tabId'],
+    },
+  },
+  {
+    name: 'get_page_text',
+    description:
+      'Get the full text content of a page as plain text. Useful for reading long-form content without structural overhead.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        tabId: {
+          type: 'number',
+          description: 'The ID of the tab to read.',
+        },
+      },
+      required: ['tabId'],
+    },
+  },
+  {
+    name: 'find',
+    description:
+      'Search for elements on the page matching a query. Returns matching elements with their reference IDs for interaction.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        query: {
+          type: 'string',
+          description: 'The search query or CSS selector to find elements.',
+        },
+        tabId: {
+          type: 'number',
+          description: 'The ID of the tab to search in.',
+        },
+      },
+      required: ['query', 'tabId'],
+    },
+  },
+  {
+    name: 'form_input',
+    description:
+      'Fill in a form field identified by a reference ID with a given value.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        ref: {
+          type: 'string',
+          description: 'The reference ID of the form element to fill.',
+        },
+        value: {
+          type: 'string',
+          description: 'The value to set on the form element.',
+        },
+        tabId: {
+          type: 'number',
+          description: 'The ID of the tab containing the form.',
+        },
+      },
+      required: ['ref', 'value', 'tabId'],
+    },
+  },
+  {
+    name: 'computer',
+    description:
+      'Perform low-level computer interactions: mouse clicks, keyboard input, scrolling, screenshots, drag, and wait. This is the primary tool for interacting with page elements.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        action: {
+          type: 'string',
+          enum: [
+            'left_click',
+            'right_click',
+            'double_click',
+            'middle_click',
+            'type',
+            'key',
+            'scroll',
+            'screenshot',
+            'wait',
+            'left_click_drag',
+            'zoom',
+          ],
+          description: 'The action to perform.',
+        },
+        tabId: {
+          type: 'number',
+          description: 'The ID of the tab to act on.',
+        },
+        coordinate: {
+          type: 'array',
+          items: { type: 'number' },
+          description:
+            '[x, y] coordinate for click/drag actions. Alternative to ref.',
+        },
+        ref: {
+          type: 'string',
+          description:
+            'Reference ID of the element to interact with. Alternative to coordinate.',
+        },
+        text: {
+          type: 'string',
+          description:
+            'Text to type (for "type" action) or key combo (for "key" action, e.g. "Enter", "Control+c").',
+        },
+        scroll_direction: {
+          type: 'string',
+          enum: ['up', 'down', 'left', 'right'],
+          description: 'Direction to scroll (for "scroll" action).',
+        },
+        scroll_amount: {
+          type: 'number',
+          description:
+            'Number of scroll increments (for "scroll" action). Defaults to 3.',
+        },
+        duration: {
+          type: 'number',
+          description: 'Duration in seconds (for "wait" action).',
+        },
+        start_coordinate: {
+          type: 'array',
+          items: { type: 'number' },
+          description:
+            '[x, y] starting coordinate for drag actions.',
+        },
+        modifiers: {
+          type: 'array',
+          items: {
+            type: 'string',
+            enum: ['Alt', 'Control', 'Meta', 'Shift'],
+          },
+          description: 'Modifier keys to hold during the action.',
+        },
+        region: {
+          type: 'object',
+          properties: {
+            x: { type: 'number' },
+            y: { type: 'number' },
+            width: { type: 'number' },
+            height: { type: 'number' },
+          },
+          description:
+            'Region to capture for screenshot action. If omitted, captures the full viewport.',
+        },
+        repeat: {
+          type: 'number',
+          description: 'Number of times to repeat the action.',
+        },
+      },
+      required: ['action', 'tabId'],
+    },
+  },
+  {
+    name: 'javascript_tool',
+    description:
+      'Execute JavaScript code in a browser tab and return the result. Use console.log for debugging and check results with read_console_messages.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        action: {
+          type: 'string',
+          enum: ['execute'],
+          description: 'The action to perform. Currently only "execute" is supported.',
+        },
+        text: {
+          type: 'string',
+          description: 'The JavaScript code to execute.',
+        },
+        tabId: {
+          type: 'number',
+          description: 'The ID of the tab to execute in.',
+        },
+      },
+      required: ['action', 'text', 'tabId'],
+    },
+  },
+  {
+    name: 'resize_window',
+    description:
+      'Resize the browser window to specific dimensions. Useful for testing responsive layouts.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        width: {
+          type: 'number',
+          description: 'The target width in pixels.',
+        },
+        height: {
+          type: 'number',
+          description: 'The target height in pixels.',
+        },
+        tabId: {
+          type: 'number',
+          description: 'The ID of the tab whose window to resize.',
+        },
+      },
+      required: ['width', 'height', 'tabId'],
+    },
+  },
+  {
+    name: 'gif_creator',
+    description:
+      'Record browser interactions as GIF animations. Start recording, capture frames during actions, then save the GIF.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        action: {
+          type: 'string',
+          enum: ['start', 'capture', 'save', 'cancel'],
+          description:
+            'The GIF recording action: "start" to begin, "capture" to add a frame, "save" to finalize, "cancel" to discard.',
+        },
+        tabId: {
+          type: 'number',
+          description: 'The ID of the tab to record.',
+        },
+        filename: {
+          type: 'string',
+          description:
+            'File name for the saved GIF (for "save" action). Should be descriptive.',
+        },
+        download: {
+          type: 'boolean',
+          description:
+            'If true, download the GIF to the user\'s downloads folder.',
+        },
+        options: {
+          type: 'object',
+          properties: {
+            quality: { type: 'number' },
+            fps: { type: 'number' },
+          },
+          description: 'Recording quality options.',
+        },
+      },
+      required: ['action', 'tabId'],
+    },
+  },
+  {
+    name: 'upload_image',
+    description:
+      'Upload an image to a file input element on the page.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        imageId: {
+          type: 'string',
+          description: 'The ID of the image to upload (from a previous screenshot or capture).',
+        },
+        tabId: {
+          type: 'number',
+          description: 'The ID of the tab containing the file input.',
+        },
+        coordinate: {
+          type: 'array',
+          items: { type: 'number' },
+          description: '[x, y] coordinate of the file input element.',
+        },
+        ref: {
+          type: 'string',
+          description: 'Reference ID of the file input element.',
+        },
+        filename: {
+          type: 'string',
+          description: 'Optional filename for the uploaded image.',
+        },
+      },
+      required: ['imageId', 'tabId'],
+    },
+  },
+  {
+    name: 'update_plan',
+    description:
+      'Update the automation plan with new domains or approach information.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        domains: {
+          type: 'array',
+          items: { type: 'string' },
+          description: 'List of domains involved in the automation.',
+        },
+        approach: {
+          type: 'string',
+          description: 'Description of the automation approach.',
+        },
+      },
+      required: ['domains', 'approach'],
+    },
+  },
+  {
+    name: 'read_console_messages',
+    description:
+      'Read browser console messages (logs, warnings, errors). Use the pattern parameter to filter for specific entries.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        tabId: {
+          type: 'number',
+          description: 'The ID of the tab to read console messages from.',
+        },
+        pattern: {
+          type: 'string',
+          description:
+            'Regex-compatible pattern to filter console messages. Filters server-side for efficiency.',
+        },
+        onlyErrors: {
+          type: 'boolean',
+          description: 'If true, only return error-level messages.',
+        },
+        limit: {
+          type: 'number',
+          description: 'Maximum number of messages to return.',
+        },
+        clear: {
+          type: 'boolean',
+          description: 'If true, clear the console buffer after reading.',
+        },
+      },
+      required: ['tabId'],
+    },
+  },
+  {
+    name: 'read_network_requests',
+    description:
+      'Read captured network requests. Useful for debugging API calls and monitoring traffic.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        tabId: {
+          type: 'number',
+          description: 'The ID of the tab to read network requests from.',
+        },
+        urlPattern: {
+          type: 'string',
+          description: 'Pattern to filter requests by URL.',
+        },
+        limit: {
+          type: 'number',
+          description: 'Maximum number of requests to return.',
+        },
+        clear: {
+          type: 'boolean',
+          description: 'If true, clear the request buffer after reading.',
+        },
+      },
+      required: ['tabId'],
+    },
+  },
+  {
+    name: 'shortcuts_list',
+    description:
+      'List available keyboard shortcuts for the current page or extension.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        tabId: {
+          type: 'number',
+          description: 'The ID of the tab to list shortcuts for.',
+        },
+      },
+      required: ['tabId'],
+    },
+  },
+  {
+    name: 'shortcuts_execute',
+    description:
+      'Execute a named keyboard shortcut on the page.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        tabId: {
+          type: 'number',
+          description: 'The ID of the tab to execute the shortcut in.',
+        },
+        shortcutId: {
+          type: 'string',
+          description: 'The ID of the shortcut to execute (from shortcuts_list).',
+        },
+        command: {
+          type: 'string',
+          description: 'Alternative: a command string to execute.',
+        },
+      },
+      required: ['tabId', 'shortcutId'],
+    },
+  },
+]

--- a/packages/openclaude-for-chrome-mcp/types.ts
+++ b/packages/openclaude-for-chrome-mcp/types.ts
@@ -1,0 +1,59 @@
+/**
+ * OpenClaude for Chrome MCP — Type definitions
+ *
+ * These types match the interface expected by the existing consumers
+ * in src/utils/claudeInChrome/mcpServer.ts and src/services/mcp/client.ts.
+ */
+
+export interface Logger {
+  silly(message: string, ...args: unknown[]): void
+  debug(message: string, ...args: unknown[]): void
+  info(message: string, ...args: unknown[]): void
+  warn(message: string, ...args: unknown[]): void
+  error(message: string, ...args: unknown[]): void
+}
+
+export type PermissionMode =
+  | 'ask'
+  | 'skip_all_permission_checks'
+  | 'follow_a_plan'
+
+export interface ClaudeForChromeContext {
+  serverName: string
+  logger: Logger
+  socketPath: string
+  getSocketPaths: () => string[]
+  clientTypeId: string
+
+  onAuthenticationError: () => void
+  onToolCallDisconnected: () => string
+  onExtensionPaired: (deviceId: string, name: string) => void
+  getPersistedDeviceId: () => string | undefined
+
+  bridgeConfig?: {
+    url: string
+    getUserId: () => Promise<string | undefined>
+    getOAuthToken: () => Promise<string>
+    devUserId?: string
+  }
+
+  initialPermissionMode?: PermissionMode
+
+  callAnthropicMessages?: (req: {
+    model: string
+    max_tokens: number
+    system: string
+    messages: Array<{ role: string; content: unknown }>
+    stop_sequences?: string[]
+    signal?: AbortSignal
+  }) => Promise<{
+    content: Array<{ type: 'text'; text: string }>
+    stop_reason: string | null
+    usage?: { input_tokens: number; output_tokens: number }
+  }>
+
+  trackEvent: (
+    eventName: string,
+    metadata?: Record<string, boolean | number | string | undefined>,
+  ) => void
+}

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -204,6 +204,11 @@ export async function handleBgFlag() { throw new Error("Background sessions are 
 
         // NOTE: @opentelemetry/* kept as external deps (too many named exports to stub)
 
+        // Resolve openclaude-for-chrome-mcp to the local package
+        build.onResolve({ filter: /^openclaude-for-chrome-mcp$/ }, () => ({
+          path: join(import.meta.dir, '..', 'packages', 'openclaude-for-chrome-mcp', 'index.ts'),
+        }))
+
         // Resolve native addon and missing snapshot imports to stubs
         for (const mod of [
           'audio-capture-napi',
@@ -213,7 +218,6 @@ export async function handleBgFlag() { throw new Error("Background sessions are 
           'url-handler-napi',
           'color-diff-napi',
           '@anthropic-ai/mcpb',
-          '@ant/claude-for-chrome-mcp',
           '@anthropic-ai/sandbox-runtime',
           'asciichart',
           'plist',
@@ -251,13 +255,11 @@ export const __stub = true;
 export const SandboxViolationStore = null;
 export const SandboxManager = new Proxy({}, { get: () => noop });
 export const SandboxRuntimeConfigSchema = { parse: () => ({}) };
-export const BROWSER_TOOLS = [];
 export const getMcpConfigForManifest = noop;
 export const ColorDiff = null;
 export const ColorFile = null;
 export const getSyntaxTheme = noop;
 export const plot = noop;
-export const createClaudeForChromeMcpServer = noop;
 // OpenTelemetry exports
 export const ExportResultCode = { SUCCESS: 0, FAILED: 1 };
 export const resourceFromAttributes = noop;

--- a/src/services/mcp/client.ts
+++ b/src/services/mcp/client.ts
@@ -925,7 +925,7 @@ export const connectToServer = memoize(
           '../../utils/claudeInChrome/mcpServer.js'
         )
         const { createClaudeForChromeMcpServer } = await import(
-          '@ant/claude-for-chrome-mcp'
+          'openclaude-for-chrome-mcp'
         )
         const { createLinkedTransportPair } = await import(
           './InProcessTransport.js'

--- a/src/skills/bundled/claudeInChrome.ts
+++ b/src/skills/bundled/claudeInChrome.ts
@@ -1,4 +1,4 @@
-import { BROWSER_TOOLS } from '@ant/claude-for-chrome-mcp'
+import { BROWSER_TOOLS } from 'openclaude-for-chrome-mcp'
 import { BASE_CHROME_PROMPT } from '../../utils/claudeInChrome/prompt.js'
 import { shouldAutoEnableClaudeInChrome } from '../../utils/claudeInChrome/setup.js'
 import { registerBundledSkill } from '../bundledSkills.js'

--- a/src/utils/claudeInChrome/common.ts
+++ b/src/utils/claudeInChrome/common.ts
@@ -500,7 +500,7 @@ export function getAllSocketPaths(): string[] {
 
   // Scan for *.sock files in the socket directory
   try {
-    // eslint-disable-next-line custom-rules/no-sync-fs -- ClaudeForChromeContext.getSocketPaths (external @ant/claude-for-chrome-mcp) requires a sync () => string[] callback
+    // eslint-disable-next-line custom-rules/no-sync-fs -- ClaudeForChromeContext.getSocketPaths (openclaude-for-chrome-mcp) requires a sync () => string[] callback
     const files = readdirSync(socketDir)
     for (const file of files) {
       if (file.endsWith('.sock')) {

--- a/src/utils/claudeInChrome/mcpServer.ts
+++ b/src/utils/claudeInChrome/mcpServer.ts
@@ -3,7 +3,7 @@ import {
   createClaudeForChromeMcpServer,
   type Logger,
   type PermissionMode,
-} from '@ant/claude-for-chrome-mcp'
+} from 'openclaude-for-chrome-mcp'
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js'
 import { format } from 'util'
 import { shutdownDatadog } from '../../services/analytics/datadog.js'
@@ -160,13 +160,8 @@ export function createChromeContext(
     // ListTools also filters browser_task + lightning_turn out, so external
     // users never see the tools advertised. Three independent gates.
     //
-    // Types inlined: AnthropicMessagesRequest/Response live in
-    // @ant/claude-for-chrome-mcp@0.4.0 which isn't published yet. CI installs
-    // 0.3.0. The callAnthropicMessages field is also 0.4.0-only, but spreading
-    // an extra property into ClaudeForChromeContext is fine against either
-    // version — 0.3.0 sees an unknown field (allowed in spread), 0.4.0 sees a
-    // structurally-matching one. Once 0.4.0 is published, this can switch to
-    // the package's exported types and the dep can be bumped.
+    // The callAnthropicMessages field is defined in
+    // openclaude-for-chrome-mcp/types.ts as part of ClaudeForChromeContext.
     ...(process.env.USER_TYPE === 'ant' && {
       callAnthropicMessages: async (req: {
         model: string

--- a/src/utils/claudeInChrome/setup.ts
+++ b/src/utils/claudeInChrome/setup.ts
@@ -1,4 +1,4 @@
-import { BROWSER_TOOLS } from '@ant/claude-for-chrome-mcp'
+import { BROWSER_TOOLS } from 'openclaude-for-chrome-mcp'
 import { chmod, mkdir, readFile, writeFile } from 'fs/promises'
 import { homedir } from 'os'
 import { join } from 'path'

--- a/src/utils/claudeInChrome/toolRendering.tsx
+++ b/src/utils/claudeInChrome/toolRendering.tsx
@@ -9,7 +9,7 @@ import { trackClaudeInChromeTabId } from './common.js';
 export type { Tool } from '@modelcontextprotocol/sdk/types.js';
 
 /**
- * All tool names from BROWSER_TOOLS in @ant/claude-for-chrome-mcp.
+ * All tool names from BROWSER_TOOLS in openclaude-for-chrome-mcp.
  * Keep in sync with the package's BROWSER_TOOLS array.
  */
 export type ChromeToolName = 'javascript_tool' | 'read_page' | 'find' | 'form_input' | 'computer' | 'navigate' | 'resize_window' | 'gif_creator' | 'upload_image' | 'get_page_text' | 'tabs_context_mcp' | 'tabs_create_mcp' | 'update_plan' | 'read_console_messages' | 'read_network_requests' | 'shortcuts_list' | 'shortcuts_execute';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,12 +11,13 @@
     "resolveJsonModule": true,
     "declaration": false,
     "outDir": "./dist",
-    "rootDir": "./src",
+    "rootDir": ".",
     "baseUrl": ".",
     "paths": {
-      "src/*": ["./src/*"]
+      "src/*": ["./src/*"],
+      "openclaude-for-chrome-mcp": ["./packages/openclaude-for-chrome-mcp/index.ts"]
     }
   },
-  "include": ["src/**/*"],
+  "include": ["src/**/*", "packages/**/*"],
   "exclude": ["node_modules", "dist"]
 }


### PR DESCRIPTION
## Summary

- Add `packages/openclaude-for-chrome-mcp/` — a local MCP server package that replaces the previously stubbed `@ant/claude-for-chrome-mcp`, enabling Chrome browser automation via the extension (ID `fcoeoabgfenejglbffodgkkbkcdhcgfn`)
- Redirect build resolution from the proprietary stub to the local package via `onResolve` in `scripts/build.ts`
- Rename all imports from `@ant/claude-for-chrome-mcp` to `openclaude-for-chrome-mcp` across 4 consumer files

### Package contents (6 files)
| File | Purpose |
|------|---------|
| `types.ts` | `Logger`, `PermissionMode`, `ClaudeForChromeContext` types |
| `protocol.ts` | Socket protocol types (4-byte LE + JSON, matching `chromeNativeHost.ts`) |
| `tools.ts` | 17 browser tool definitions with full MCP schemas (typed as SDK `Tool[]`) |
| `socketClient.ts` | Unix socket client with lazy connection, backpressure-safe writes, idempotent teardown |
| `server.ts` | MCP server factory using `@modelcontextprotocol/sdk` with `ListTools`/`CallTool` handlers |
| `index.ts` | Barrel export |

### Modified files (8 files)
- `scripts/build.ts` — `onResolve` for local package; removed from native-stub list; dead stubs cleaned
- `tsconfig.json` — `paths` mapping, `rootDir: "."`, `packages/**/*` in include
- `src/utils/claudeInChrome/mcpServer.ts` — import + obsolete version comment cleaned
- `src/utils/claudeInChrome/setup.ts` — import renamed
- `src/utils/claudeInChrome/common.ts` — comment updated
- `src/utils/claudeInChrome/toolRendering.tsx` — comment updated
- `src/skills/bundled/claudeInChrome.ts` — import renamed
- `src/services/mcp/client.ts` — dynamic import renamed

## Test plan

- [x] `bun run build` succeeds
- [x] `bun run typecheck` — no new errors from the package
- [x] `BROWSER_TOOLS` in bundle contains 17 tool definitions (not `[]`)
- [x] 0 references to `@ant/claude-for-chrome-mcp` remain in source
- [x] 4 rounds of code review with fixes applied
- [ ] End-to-end: `openclaude --chrome` with extension installed → `tabs_context_mcp` returns results