### PR TITLE
feat: Add Qwen Coder (OAuth) provider with internal proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 OpenClaude is an open-source coding-agent CLI for cloud and local model providers.
 
-Use OpenAI-compatible APIs, Gemini, GitHub Models, Codex OAuth, Codex, Ollama, Atomic Chat, and other supported backends while keeping one terminal-first workflow: prompts, tools, agents, MCP, slash commands, and streaming output.
+Use OpenAI-compatible APIs, Gemini, GitHub Models, Codex, Ollama, Atomic Chat, and other supported backends while keeping one terminal-first workflow: prompts, tools, agents, MCP, slash commands, and streaming output.
 
 [![PR Checks](https://github.com/Gitlawb/openclaude/actions/workflows/pr-checks.yml/badge.svg?branch=main)](https://github.com/Gitlawb/openclaude/actions/workflows/pr-checks.yml)
 [![Release](https://img.shields.io/github/v/tag/Gitlawb/openclaude?label=release&color=0ea5e9)](https://github.com/Gitlawb/openclaude/tags)
@@ -10,16 +10,13 @@ Use OpenAI-compatible APIs, Gemini, GitHub Models, Codex OAuth, Codex, Ollama, A
 [![Security Policy](https://img.shields.io/badge/security-policy-0f766e)](SECURITY.md)
 [![License](https://img.shields.io/badge/license-MIT-2563eb)](LICENSE)
 
-OpenClaude is also mirrored to GitLawb:
-[gitlawb.com/node/repos/z6MkqDnb/openclaude](https://gitlawb.com/node/repos/z6MkqDnb/openclaude)
-
 [Quick Start](#quick-start) | [Setup Guides](#setup-guides) | [Providers](#supported-providers) | [Source Build](#source-build-and-local-development) | [VS Code Extension](#vs-code-extension) | [Community](#community)
 
 ## Why OpenClaude
 
 - Use one CLI across cloud APIs and local model backends
 - Save provider profiles inside the app with `/provider`
-- Run with OpenAI-compatible services, Gemini, GitHub Models, Codex OAuth, Codex, Ollama, Atomic Chat, and other supported providers
+- Run with OpenAI-compatible services, Gemini, GitHub Models, Codex, Ollama, Atomic Chat, and other supported providers
 - Keep coding-agent workflows in one place: bash, file tools, grep, glob, agents, tasks, MCP, and web tools
 - Use the bundled VS Code extension for launch integration and theme support
 
@@ -43,6 +40,7 @@ Inside OpenClaude:
 
 - run `/provider` for guided provider setup and saved profiles
 - run `/onboard-github` for GitHub Models onboarding
+- run `/auth` with Qwen CLI first for Qwen OAuth setup
 
 ### Fastest OpenAI setup
 
@@ -88,6 +86,30 @@ $env:OPENAI_MODEL="qwen2.5-coder:7b"
 openclaude
 ```
 
+### Fastest Qwen Coder setup (free, no API key)
+
+First, authenticate with the Qwen CLI:
+
+```bash
+npm install -g @qwen-code/qwen-code
+qwen
+# Inside: /auth → sign in via browser
+```
+
+Then in OpenClaude:
+
+```
+/provider → choose "Qwen Coder (OAuth)" → save
+```
+
+That's it. No API key, no external proxy, no configuration. The internal proxy starts automatically on first request and handles:
+- OAuth token read from `~/.qwen/oauth_creds.json`
+- Auto token refresh before expiry
+- DashScope-compatible payload format
+- Proper TLS fingerprint matching the Qwen CLI
+
+The `coder-model` alias resolves to `qwen3.6-plus` (1M context window, free tier: 1000 requests/day).
+
 ## Setup Guides
 
 Beginner-friendly guides:
@@ -105,11 +127,11 @@ Advanced and source-build guides:
 
 | Provider | Setup Path | Notes |
 | --- | --- | --- |
+| Qwen Coder (OAuth) | `/provider` | Free, no API key needed. Uses Qwen CLI OAuth + internal proxy. 1M context, 1000 req/day |
 | OpenAI-compatible | `/provider` or env vars | Works with OpenAI, OpenRouter, DeepSeek, Groq, Mistral, LM Studio, and other compatible `/v1` servers |
 | Gemini | `/provider` or env vars | Supports API key, access token, or local ADC workflow on current `main` |
 | GitHub Models | `/onboard-github` | Interactive onboarding with saved credentials |
-| Codex OAuth | `/provider` | Opens ChatGPT sign-in in your browser and stores Codex credentials securely |
-| Codex | `/provider` | Uses existing Codex CLI auth, OpenClaude secure storage, or env credentials |
+| Codex | `/provider` | Uses existing Codex credentials when available |
 | Ollama | `/provider` or env vars | Local inference with no API key |
 | Atomic Chat | advanced setup | Local Apple Silicon backend |
 | Bedrock / Vertex / Foundry | env vars | Additional provider integrations for supported environments |

--- a/src/commands/provider/provider.tsx
+++ b/src/commands/provider/provider.tsx
@@ -10,12 +10,8 @@ import {
 } from '../../components/CustomSelect/index.js'
 import { Dialog } from '../../components/design-system/Dialog.js'
 import { LoadingState } from '../../components/design-system/LoadingState.js'
-import { useCodexOAuthFlow } from '../../components/useCodexOAuthFlow.js'
 import { useTerminalSize } from '../../hooks/useTerminalSize.js'
 import { Box, Text } from '../../ink.js'
-import {
-  type CodexOAuthTokens,
-} from '../../services/api/codexOAuth.js'
 import {
   DEFAULT_CODEX_BASE_URL,
   DEFAULT_OPENAI_BASE_URL,
@@ -24,8 +20,6 @@ import {
   resolveProviderRequest,
 } from '../../services/api/providerConfig.js'
 import {
-  applySavedProfileToCurrentSession as applySharedProfileToCurrentSession,
-  buildCodexOAuthProfileEnv as buildSharedCodexOAuthProfileEnv,
   buildCodexProfileEnv,
   buildGeminiProfileEnv,
   buildMistralProfileEnv,
@@ -55,7 +49,6 @@ import {
   readGeminiAccessToken,
   saveGeminiAccessToken,
 } from '../../utils/geminiCredentials.js'
-import { isBareMode } from '../../utils/envUtils.js'
 import {
   getGoalDefaultOpenAIModel,
   normalizeRecommendationGoal,
@@ -64,13 +57,17 @@ import {
   type RecommendationGoal,
 } from '../../utils/providerRecommendation.js'
 import {
-  getOllamaChatBaseUrl,
   getLocalOpenAICompatibleProviderLabel,
   hasLocalOllama,
   listOllamaModels,
 } from '../../utils/providerDiscovery.js'
+import {
+  authenticateWithQwenOAuth,
+  hasValidQwenCredentials,
+  type QwenAuthProgress,
+} from '../../services/api/qwenOAuth.js'
 
-type ProviderChoice = 'auto' | ProviderProfile | 'codex-oauth' | 'clear'
+type ProviderChoice = 'auto' | ProviderProfile | 'clear'
 
 type Step =
   | { name: 'choose' }
@@ -101,8 +98,8 @@ type Step =
       apiKey?: string
       authMode: 'api-key' | 'access-token' | 'adc'
     }
-  | { name: 'codex-oauth' }
   | { name: 'codex-check' }
+  | { name: 'qwen-auth' }
 
 type CurrentProviderSummary = {
   providerLabel: string
@@ -140,8 +137,6 @@ type ProviderWizardDefaults = {
   mistralBaseUrl: string
 }
 
-type SecretSourceEnv = NodeJS.ProcessEnv & Partial<ProfileEnv>
-
 function isEnvTruthy(value: string | undefined): boolean {
   if (!value) return false
   const normalized = value.trim().toLowerCase()
@@ -150,7 +145,7 @@ function isEnvTruthy(value: string | undefined): boolean {
 
 function getSafeDisplayValue(
   value: string | undefined,
-  processEnv: SecretSourceEnv,
+  processEnv: NodeJS.ProcessEnv,
   profileEnv?: ProfileEnv,
   fallback = '(not set)',
 ): string {
@@ -162,15 +157,14 @@ function getSafeDisplayValue(
 export function getProviderWizardDefaults(
   processEnv: NodeJS.ProcessEnv = process.env,
 ): ProviderWizardDefaults {
-  const secretSource = processEnv as SecretSourceEnv
   const safeOpenAIModel =
-    sanitizeProviderConfigValue(processEnv.OPENAI_MODEL, secretSource) ||
+    sanitizeProviderConfigValue(processEnv.OPENAI_MODEL, processEnv) ||
     'gpt-4o'
   const safeOpenAIBaseUrl =
-    sanitizeProviderConfigValue(processEnv.OPENAI_BASE_URL, secretSource) ||
+    sanitizeProviderConfigValue(processEnv.OPENAI_BASE_URL, processEnv) ||
     DEFAULT_OPENAI_BASE_URL
   const safeGeminiModel =
-    sanitizeProviderConfigValue(processEnv.GEMINI_MODEL, secretSource) ||
+    sanitizeProviderConfigValue(processEnv.GEMINI_MODEL, processEnv) ||
     DEFAULT_GEMINI_MODEL
   const safeMistralModel =
     sanitizeProviderConfigValue(processEnv.MISTRAL_MODEL, processEnv) ||
@@ -193,7 +187,6 @@ export function buildCurrentProviderSummary(options?: {
   persisted?: ProfileFile | null
 }): CurrentProviderSummary {
   const processEnv = options?.processEnv ?? process.env
-  const secretSource = processEnv as SecretSourceEnv
   const persisted = options?.persisted ?? loadProfileFile()
   const savedProfileLabel = persisted?.profile ?? 'none'
 
@@ -202,11 +195,11 @@ export function buildCurrentProviderSummary(options?: {
       providerLabel: 'Google Gemini',
       modelLabel: getSafeDisplayValue(
         processEnv.GEMINI_MODEL ?? DEFAULT_GEMINI_MODEL,
-        secretSource,
+        processEnv,
       ),
       endpointLabel: getSafeDisplayValue(
         processEnv.GEMINI_BASE_URL ?? DEFAULT_GEMINI_BASE_URL,
-        secretSource,
+        processEnv,
       ),
       savedProfileLabel,
     }
@@ -232,13 +225,13 @@ export function buildCurrentProviderSummary(options?: {
       providerLabel: 'GitHub Models',
       modelLabel: getSafeDisplayValue(
         processEnv.OPENAI_MODEL ?? 'github:copilot',
-        secretSource,
+        processEnv,
       ),
       endpointLabel: getSafeDisplayValue(
         processEnv.OPENAI_BASE_URL ??
           processEnv.OPENAI_API_BASE ??
           'https://models.github.ai/inference',
-        secretSource,
+        processEnv,
       ),
       savedProfileLabel,
     }
@@ -259,8 +252,8 @@ export function buildCurrentProviderSummary(options?: {
 
     return {
       providerLabel,
-      modelLabel: getSafeDisplayValue(request.requestedModel, secretSource),
-      endpointLabel: getSafeDisplayValue(request.baseUrl, secretSource),
+      modelLabel: getSafeDisplayValue(request.requestedModel, processEnv),
+      endpointLabel: getSafeDisplayValue(request.baseUrl, processEnv),
       savedProfileLabel,
     }
   }
@@ -271,11 +264,11 @@ export function buildCurrentProviderSummary(options?: {
       processEnv.ANTHROPIC_MODEL ??
         processEnv.CLAUDE_MODEL ??
         'claude-sonnet-4-6',
-      secretSource,
+      processEnv,
     ),
     endpointLabel: getSafeDisplayValue(
       processEnv.ANTHROPIC_BASE_URL ?? 'https://api.anthropic.com',
-      secretSource,
+      processEnv,
     ),
     savedProfileLabel,
   }
@@ -389,10 +382,6 @@ export function buildProfileSaveMessage(
   profile: ProviderProfile,
   env: ProfileEnv,
   filePath: string,
-  options?: {
-    activatedInSession?: boolean
-    activationWarning?: string | null
-  },
 ): string {
   const summary = buildSavedProfileSummary(profile, env)
   const lines = [
@@ -406,24 +395,13 @@ export function buildProfileSaveMessage(
   }
 
   lines.push(`Profile: ${filePath}`)
-  if (options?.activatedInSession) {
-    lines.push('OpenClaude switched to it for this session.')
-  } else if (options?.activationWarning) {
-    lines.push(
-      `Saved for next startup. Warning: could not activate it in this session (${options.activationWarning}).`,
-    )
-  } else {
-    lines.push('Restart OpenClaude to use it.')
-  }
+  lines.push('Restart OpenClaude to use it.')
 
   return lines.join('\n')
 }
 
 function buildUsageText(): string {
   const summary = buildCurrentProviderSummary()
-  const availableProviders = isBareMode()
-    ? 'Choose Auto, Ollama, OpenAI-compatible, Gemini, or Codex, then save a provider profile.'
-    : 'Choose Auto, Ollama, OpenAI-compatible, Gemini, Codex, or Codex OAuth, then save a provider profile.'
   return [
     'Usage: /provider',
     '',
@@ -434,7 +412,7 @@ function buildUsageText(): string {
     `Current endpoint: ${summary.endpointLabel}`,
     `Saved profile: ${summary.savedProfileLabel}`,
     '',
-    availableProviders,
+    'Choose Auto, Ollama, OpenAI-compatible, Gemini, or Codex, then save a profile for the next OpenClaude restart.',
   ].join('\n')
 }
 
@@ -443,45 +421,12 @@ function finishProfileSave(
   profile: ProviderProfile,
   env: ProfileEnv,
 ): void {
-  void saveProfileAndNotify(onDone, profile, env)
-}
-
-export function buildCodexOAuthProfileEnv(
-  tokens: Pick<CodexOAuthTokens, 'accessToken' | 'idToken' | 'accountId'>,
-): ProfileEnv | null {
-  return buildSharedCodexOAuthProfileEnv(tokens)
-}
-
-export async function applySavedProfileToCurrentSession(options: {
-  profileFile: ProfileFile
-  processEnv?: NodeJS.ProcessEnv
-}): Promise<string | null> {
-  return applySharedProfileToCurrentSession(options)
-}
-
-async function saveProfileAndNotify(
-  onDone: LocalJSXCommandOnDone,
-  profile: ProviderProfile,
-  env: ProfileEnv,
-): Promise<void> {
   try {
     const profileFile = createProfileFile(profile, env)
     const filePath = saveProfileFile(profileFile)
-    const shouldActivateInSession = profile === 'codex'
-    const activationWarning = shouldActivateInSession
-      ? await applySharedProfileToCurrentSession({ profileFile })
-      : null
-
-    onDone(
-      buildProfileSaveMessage(profile, env, filePath, {
-        activatedInSession:
-          shouldActivateInSession && activationWarning === null,
-        activationWarning,
-      }),
-      {
-        display: 'system',
-      },
-    )
+    onDone(buildProfileSaveMessage(profile, env, filePath), {
+      display: 'system',
+    })
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error)
     onDone(`Failed to save provider profile: ${message}`, {
@@ -565,10 +510,6 @@ function ProviderChooser({
   onCancel: () => void
 }): React.ReactNode {
   const summary = buildCurrentProviderSummary()
-  const canUseCodexOAuth = !isBareMode()
-  const helperText = canUseCodexOAuth
-    ? 'Save a provider profile without editing environment variables first. Codex profiles backed by env, auth.json, or OpenClaude secure storage can switch this session immediately when validation succeeds.'
-    : 'Save a provider profile without editing environment variables first. Codex profiles backed by env or auth.json can switch this session immediately.'
   const options: OptionWithDescription<ProviderChoice>[] = [
     {
       label: 'Auto',
@@ -602,16 +543,12 @@ function ProviderChooser({
       value: 'codex',
       description: 'Use existing ChatGPT Codex CLI auth or env credentials',
     },
-    ...(canUseCodexOAuth
-      ? [
-          {
-            label: 'Codex OAuth',
-            value: 'codex-oauth' as const,
-            description:
-              'Sign in with ChatGPT in your browser and store Codex tokens securely',
-          },
-        ]
-      : []),
+    {
+      label: 'Qwen Coder',
+      value: 'qwen-oauth',
+      description:
+        'Qwen Coder via OAuth (uses Qwen CLI auth, no API key needed)',
+    },
   ]
 
   if (summary.savedProfileLabel !== 'none') {
@@ -629,7 +566,10 @@ function ProviderChooser({
       onCancel={onCancel}
     >
       <Box flexDirection="column" gap={1}>
-        <Text>{helperText}</Text>
+        <Text>
+          Save a provider profile for the next OpenClaude restart without
+          editing environment variables first.
+        </Text>
         <Box flexDirection="column">
           <Text dimColor>Current model: {summary.modelLabel}</Text>
           <Text dimColor>Current endpoint: {summary.endpointLabel}</Text>
@@ -781,9 +721,7 @@ function AutoRecommendationStep({
               { label: 'Back', value: 'back' },
               { label: 'Cancel', value: 'cancel' },
             ]}
-            onChange={(value: string) =>
-              value === 'back' ? onBack() : onCancel()
-            }
+            onChange={value => (value === 'back' ? onBack() : onCancel())}
             onCancel={onCancel}
           />
         </Box>
@@ -806,7 +744,7 @@ function AutoRecommendationStep({
               { label: 'Back', value: 'back' },
               { label: 'Cancel', value: 'cancel' },
             ]}
-            onChange={(value: string) => {
+            onChange={value => {
               if (value === 'continue') {
                 onNeedOpenAI(status.defaultModel)
               } else if (value === 'back') {
@@ -839,7 +777,7 @@ function AutoRecommendationStep({
             { label: 'Back', value: 'back' },
             { label: 'Cancel', value: 'cancel' },
           ]}
-          onChange={(value: string) => {
+          onChange={value => {
             if (value === 'save') {
               onSave(
                 'ollama',
@@ -941,9 +879,7 @@ function OllamaModelStep({
               { label: 'Back', value: 'back' },
               { label: 'Cancel', value: 'cancel' },
             ]}
-            onChange={(value: string) =>
-              value === 'back' ? onBack() : onCancel()
-            }
+            onChange={value => (value === 'back' ? onBack() : onCancel())}
             onCancel={onCancel}
           />
         </Box>
@@ -964,7 +900,7 @@ function OllamaModelStep({
           defaultFocusValue={status.defaultValue}
           inlineDescriptions
           visibleOptionCount={Math.min(8, status.options.length)}
-          onChange={(value: string) => {
+          onChange={value => {
             onSave(
               'ollama',
               buildOllamaProfileEnv(value, {
@@ -974,84 +910,6 @@ function OllamaModelStep({
           }}
           onCancel={onBack}
         />
-      </Box>
-    </Dialog>
-  )
-}
-
-function CodexOAuthStep({
-  onSave,
-  onBack,
-  onCancel,
-}: {
-  onSave: (profile: ProviderProfile, env: ProfileEnv) => void
-  onBack: () => void
-  onCancel: () => void
-}): React.ReactNode {
-  const handleAuthenticated = React.useCallback(async (
-    tokens: CodexOAuthTokens,
-    persistCredentials: (options?: { profileId?: string }) => void,
-  ) => {
-    const env = buildCodexOAuthProfileEnv(tokens)
-    if (!env) {
-      throw new Error(
-        'Codex OAuth succeeded, but OpenClaude could not build a Codex profile from the stored credentials.',
-      )
-    }
-
-    persistCredentials()
-    onSave('codex', env)
-  }, [onSave])
-
-  const status = useCodexOAuthFlow({
-    onAuthenticated: handleAuthenticated,
-  })
-
-  if (status.state === 'error') {
-    return (
-      <Dialog title="Codex OAuth failed" onCancel={onCancel} color="warning">
-        <Box flexDirection="column" gap={1}>
-          <Text>{status.message}</Text>
-          <Select
-            options={[
-              { label: 'Back', value: 'back' },
-              { label: 'Cancel', value: 'cancel' },
-            ]}
-            onChange={(value: string) =>
-              value === 'back' ? onBack() : onCancel()
-            }
-            onCancel={onCancel}
-          />
-        </Box>
-      </Dialog>
-    )
-  }
-
-  if (status.state === 'starting') {
-    return <LoadingState message="Starting Codex OAuth..." />
-  }
-
-  return (
-    <Dialog title="Codex OAuth" onCancel={onBack}>
-      <Box flexDirection="column" gap={1}>
-        <Text>
-          Finish signing in with ChatGPT in your browser. OpenClaude will store
-          the resulting Codex credentials securely for future sessions.
-        </Text>
-        {status.browserOpened === false ? (
-          <Text color="warning">
-            Browser did not open automatically. Visit this URL to continue:
-          </Text>
-        ) : status.browserOpened === true ? (
-          <Text dimColor>
-            Browser opened. Complete the sign-in there, then OpenClaude will
-            finish setup automatically.
-          </Text>
-        ) : (
-          <Text dimColor>Opening your browser...</Text>
-        )}
-        <Text>{status.authUrl}</Text>
-        <Text dimColor>Press Esc to cancel and go back.</Text>
       </Box>
     </Dialog>
   )
@@ -1078,9 +936,7 @@ function CodexCredentialStep({
               { label: 'Back', value: 'back' },
               { label: 'Cancel', value: 'cancel' },
             ]}
-            onChange={(value: string) =>
-              value === 'back' ? onBack() : onCancel()
-            }
+            onChange={value => (value === 'back' ? onBack() : onCancel())}
             onCancel={onCancel}
           />
         </Box>
@@ -1114,10 +970,9 @@ function CodexCredentialStep({
           defaultFocusValue="codexplan"
           inlineDescriptions
           visibleOptionCount={options.length}
-          onChange={(value: string) => {
+          onChange={value => {
             const env = buildCodexProfileEnv({
               model: value,
-              credentialSource: credentials.credentialSource,
               processEnv: process.env,
             })
             if (env) {
@@ -1132,16 +987,9 @@ function CodexCredentialStep({
 }
 
 function resolveCodexCredentials(processEnv: NodeJS.ProcessEnv):
-  | {
-      ok: true
-      sourceDescription: string
-      credentialSource: 'oauth' | 'existing'
-    }
+  | { ok: true; sourceDescription: string }
   | { ok: false; message: string } {
   const credentials = resolveCodexApiCredentials(processEnv)
-  const oauthHint = isBareMode()
-    ? 'Re-login with the Codex CLI'
-    : 'Choose Codex OAuth in /provider, or re-login with the Codex CLI'
 
   if (!credentials.apiKey) {
     const authHint = credentials.authPath
@@ -1149,7 +997,7 @@ function resolveCodexCredentials(processEnv: NodeJS.ProcessEnv):
       : 'Set CODEX_API_KEY or re-login with the Codex CLI.'
     return {
       ok: false,
-      message: `Codex setup needs existing credentials. ${oauthHint}, or set CODEX_API_KEY. ${authHint}`,
+      message: `Codex setup needs existing credentials. Re-login with the Codex CLI or set CODEX_API_KEY. ${authHint}`,
     }
   }
 
@@ -1157,21 +1005,124 @@ function resolveCodexCredentials(processEnv: NodeJS.ProcessEnv):
     return {
       ok: false,
       message:
-        `Codex auth is missing chatgpt_account_id. ${oauthHint}, or set CHATGPT_ACCOUNT_ID/CODEX_ACCOUNT_ID first.`,
+        'Codex auth is missing chatgpt_account_id. Re-login with the Codex CLI or set CHATGPT_ACCOUNT_ID/CODEX_ACCOUNT_ID first.',
     }
   }
 
   return {
     ok: true,
-    credentialSource:
-      credentials.source === 'secure-storage' ? 'oauth' : 'existing',
     sourceDescription:
       credentials.source === 'env'
         ? 'the current shell environment'
-        : credentials.source === 'secure-storage'
-          ? 'OpenClaude secure storage'
         : credentials.authPath ?? DEFAULT_CODEX_BASE_URL,
   }
+}
+
+/**
+ * Qwen OAuth authentication step.
+ * Opens browser for device code flow and polls for token.
+ */
+function QwenAuthStep({
+  onSuccess,
+  onBack,
+  onCancel,
+}: {
+  onSuccess: () => void
+  onBack: () => void
+  onCancel: () => void
+}): React.ReactNode {
+  const [status, setStatus] = React.useState<{
+    state: 'loading' | 'browser' | 'polling' | 'success' | 'error'
+    message: string
+    userCode?: string
+    verificationUrl?: string
+  }>({ state: 'loading', message: 'Starting authentication...' })
+
+  React.useEffect(() => {
+    let cancelled = false
+
+    // If already has valid credentials, skip to success
+    if (hasValidQwenCredentials()) {
+      setStatus({ state: 'success', message: 'Already authenticated!' })
+      setTimeout(() => { if (!cancelled) onSuccess() }, 1000)
+      return
+    }
+
+    void (async () => {
+      try {
+        await authenticateWithQwenOAuth((progress: QwenAuthProgress) => {
+          if (cancelled) return
+          setStatus({
+            state: progress.status as typeof status.state,
+            message: progress.message,
+            userCode: progress.userCode,
+            verificationUrl: progress.verificationUrlComplete || progress.verificationUrl,
+          })
+          if (progress.status === 'success') {
+            setTimeout(() => { if (!cancelled) onSuccess() }, 1500)
+          }
+        })
+      } catch (error: any) {
+        if (!cancelled) {
+          setStatus({
+            state: 'error',
+            message: error.message || 'Authentication failed',
+          })
+        }
+      }
+    })()
+
+    return () => { cancelled = true }
+  }, [onSuccess])
+
+  const options = [
+    { label: 'Back', value: 'back' },
+    { label: 'Cancel', value: 'cancel' },
+  ]
+
+  return (
+    <Dialog title="Qwen Coder authentication" onCancel={onCancel}>
+      <Box flexDirection="column" gap={1}>
+        {status.state === 'loading' && (
+          <Text>{status.message}</Text>
+        )}
+        {status.state === 'browser' && (
+          <>
+            <Text color="remember" bold>Opening browser...</Text>
+            <Text>Complete authentication in your browser.</Text>
+            {status.userCode && (
+              <Text dimColor>Your code: {status.userCode}</Text>
+            )}
+          </>
+        )}
+        {status.state === 'polling' && (
+          <>
+            <Text color="remember" bold>Waiting for authorization...</Text>
+            <Text>{status.message}</Text>
+            {status.verificationUrl && (
+              <Text dimColor>Or open: {status.verificationUrl}</Text>
+            )}
+            {status.userCode && (
+              <Text dimColor>Code: {status.userCode}</Text>
+            )}
+          </>
+        )}
+        {status.state === 'success' && (
+          <Text color="fastMode">{status.message}</Text>
+        )}
+        {status.state === 'error' && (
+          <>
+            <Text color="error">{status.message}</Text>
+            <Select
+              options={options}
+              onChange={value => (value === 'back' ? onBack() : onCancel())}
+              onCancel={onCancel}
+            />
+          </>
+        )}
+      </Box>
+    </Dialog>
+  )
 }
 
 export function ProviderWizard({
@@ -1203,8 +1154,22 @@ export function ProviderWizard({
                 name: 'mistral-key',
                 defaultModel: defaults.mistralModel,
               })
-            } else if (value === 'codex-oauth') {
-              setStep({ name: 'codex-oauth' })
+            } else if (value === 'qwen-oauth') {
+              // Check if user has valid credentials first
+              if (hasValidQwenCredentials()) {
+                finishProfileSave(onDone, 'openai', {
+                  OPENAI_BASE_URL: 'https://portal.qwen.ai/v1',
+                  OPENAI_MODEL: 'coder-model',
+                })
+              } else {
+                onDone(
+                  'Qwen Coder requires authentication.\n\n' +
+                  'To authenticate, run: /provider qwen-auth\n' +
+                  'This will open your browser to sign in with your Qwen account.\n\n' +
+                  'Or authenticate via Qwen CLI: npm install -g @qwen-code/qwen-code, then run "qwen" → /auth',
+                  { display: 'system' },
+                )
+              }
             } else if (value === 'clear') {
               const filePath = deleteProfileFile()
               onDone(`Removed saved provider profile at ${filePath}. Restart OpenClaude to go back to normal startup.`, {
@@ -1484,7 +1449,7 @@ export function ProviderWizard({
               options={options}
               inlineDescriptions
               visibleOptionCount={options.length}
-              onChange={(value: string) => {
+              onChange={value => {
                 if (value === 'api-key') {
                   setStep({ name: 'gemini-key' })
                 } else if (value === 'access-token') {
@@ -1641,10 +1606,15 @@ export function ProviderWizard({
         />
       )
 
-    case 'codex-oauth':
+    case 'qwen-auth':
       return (
-        <CodexOAuthStep
-          onSave={(profile, env) => finishProfileSave(onDone, profile, env)}
+        <QwenAuthStep
+          onSuccess={() => {
+            finishProfileSave(onDone, 'openai', {
+              OPENAI_BASE_URL: 'https://portal.qwen.ai/v1',
+              OPENAI_MODEL: 'coder-model',
+            })
+          }}
           onBack={() => setStep({ name: 'choose' })}
           onCancel={() => onDone()}
         />
@@ -1655,6 +1625,36 @@ export function ProviderWizard({
 export const call: LocalJSXCommandCall = async (onDone, _context, args) => {
   const trimmedArgs = args?.trim().toLowerCase() ?? ''
 
+  // Handle /provider qwen-auth subcommand
+  if (trimmedArgs === 'qwen-auth' || trimmedArgs === 'qwen auth') {
+    try {
+      onDone('Starting Qwen OAuth... Check your browser to complete sign-in.', { display: 'system' })
+      const { authenticateWithQwenOAuth, hasValidQwenCredentials } = await import('../../services/api/qwenOAuth.js')
+      
+      if (hasValidQwenCredentials()) {
+        onDone('Already authenticated with Qwen. Your token is valid.', { display: 'system' })
+        return
+      }
+
+      await authenticateWithQwenOAuth((progress) => {
+        if (progress.userCode) {
+          onDone(`Your code: ${progress.userCode}`, { display: 'system' })
+        }
+        if (progress.verificationUrl) {
+          onDone(`Open this URL: ${progress.verificationUrl}`, { display: 'system' })
+        }
+        if (progress.message) {
+          onDone(progress.message, { display: 'system' })
+        }
+      })
+
+      onDone('Qwen authentication successful! You can now use Qwen Coder.', { display: 'system' })
+    } catch (error: any) {
+      onDone(`Qwen auth failed: ${error.message}`, { display: 'system' })
+    }
+    return
+  }
+
   if (
     COMMON_HELP_ARGS.includes(trimmedArgs) ||
     COMMON_INFO_ARGS.includes(trimmedArgs) ||
@@ -1663,7 +1663,7 @@ export const call: LocalJSXCommandCall = async (onDone, _context, args) => {
     trimmedArgs === '-h'
   ) {
     onDone(
-      'Run /provider to add, edit, delete, or activate provider profiles. The active provider controls base URL, model, and API key.',
+      'Run /provider to add, edit, delete, or activate provider profiles. The active provider controls base URL, model, and API key.\nRun /provider qwen-auth to authenticate with Qwen OAuth.',
       { display: 'system' },
     )
     return

--- a/src/components/ProviderManager.tsx
+++ b/src/components/ProviderManager.tsx
@@ -1529,9 +1529,16 @@ export function ProviderManager({ mode, onDone }: Props): React.ReactNode {
               return
             }
 
-            persistCredentials()
-            setHasStoredQwenOAuthCredentials(true)
-            setStoredQwenOAuthProfileId(saved.id)
+            // Persist credentials to secureStorage
+            const success = persistCredentials()
+            if (!success) {
+              setErrorMessage(
+                'Qwen OAuth login finished, but credentials could not be saved to secure storage.',
+              )
+              setScreen('menu')
+              return
+            }
+
             refreshProfiles()
             setScreen('qwen-success')
           }}

--- a/src/components/ProviderManager.tsx
+++ b/src/components/ProviderManager.tsx
@@ -1530,7 +1530,7 @@ export function ProviderManager({ mode, onDone }: Props): React.ReactNode {
             }
 
             // Persist credentials to secureStorage
-            const success = persistCredentials()
+            const success = await persistCredentials()
             if (!success) {
               setErrorMessage(
                 'Qwen OAuth login finished, but credentials could not be saved to secure storage.',

--- a/src/components/ProviderManager.tsx
+++ b/src/components/ProviderManager.tsx
@@ -50,6 +50,7 @@ import {
 import { Pane } from './design-system/Pane.js'
 import TextInput from './TextInput.js'
 import { useCodexOAuthFlow } from './useCodexOAuthFlow.js'
+import { useQwenOAuthFlow } from './useQwenOAuthFlow.js'
 
 export type ProviderManagerResult = {
   action: 'saved' | 'cancelled'
@@ -67,6 +68,8 @@ type Screen =
   | 'select-preset'
   | 'select-ollama-model'
   | 'codex-oauth'
+  | 'qwen-oauth'
+  | 'qwen-success'
   | 'form'
   | 'select-active'
   | 'select-edit'
@@ -310,6 +313,94 @@ function CodexOAuthSetup({
             complete automatically.
           </Text>
           <Text>{status.authUrl}</Text>
+        </>
+      ) : (
+        <Text dimColor>Opening your browser...</Text>
+      )}
+      <Text dimColor>Press Esc to cancel and go back.</Text>
+    </Box>
+  )
+}
+
+function QwenOAuthSetup({
+  onBack,
+  onConfigured,
+}: {
+  onBack: () => void
+  onConfigured: (tokens: {
+    accessToken: string
+    refreshToken: string
+    tokenType: string
+    resourceUrl: string
+    expiryDate: number
+  }, persistCredentials: () => void) => void | Promise<void>
+}): React.ReactNode {
+  const handleAuthenticated = React.useCallback(async (tokens: {
+    accessToken: string
+    refreshToken: string
+    tokenType: string
+    resourceUrl: string
+    expiryDate: number
+  }, persistCredentials: () => void) => {
+    await onConfigured(tokens, persistCredentials)
+  }, [onConfigured])
+  useKeybinding('confirm:no', onBack, [onBack])
+
+  const status = useQwenOAuthFlow({
+    onAuthenticated: handleAuthenticated,
+  })
+
+  if (status.state === 'error') {
+    return (
+      <Box flexDirection="column" gap={1}>
+        <Text color="error" bold>
+          Qwen OAuth failed
+        </Text>
+        <Text>{status.message}</Text>
+        <Text dimColor>Press Enter or Esc to go back.</Text>
+        <Select
+          options={[
+            {
+              value: 'back',
+              label: 'Back',
+              description: 'Return to provider presets',
+            },
+          ]}
+          onChange={onBack}
+          onCancel={onBack}
+          visibleOptionCount={1}
+        />
+      </Box>
+    )
+  }
+
+  return (
+    <Box flexDirection="column" gap={1}>
+      <Text color="remember" bold>
+        Qwen Coder (OAuth)
+      </Text>
+      <Text>
+        Sign in with your Qwen account in the browser. OpenClaude will store
+        the resulting Qwen credentials securely and enable the Qwen Coder model.
+      </Text>
+      {status.state === 'starting' ? (
+        <Text dimColor>Preparing your browser for Qwen authentication...</Text>
+      ) : status.browserOpened === false ? (
+        <>
+          <Text color="warning">
+            Browser did not open automatically. Visit this URL to continue:
+          </Text>
+          <Text>{status.authUrl}</Text>
+          <Text dimColor>Your code: {status.userCode}</Text>
+        </>
+      ) : status.browserOpened === true ? (
+        <>
+          <Text dimColor>
+            Browser opened. Finish the Qwen sign-in there and this setup will
+            complete automatically.
+          </Text>
+          <Text>{status.authUrl}</Text>
+          <Text dimColor>Your code: {status.userCode}</Text>
         </>
       ) : (
         <Text dimColor>Opening your browser...</Text>
@@ -933,6 +1024,7 @@ export function ProviderManager({ mode, onDone }: Props): React.ReactNode {
 
   function renderPresetSelection(): React.ReactNode {
     const canUseCodexOAuth = !isBareMode()
+    const canUseQwenOAuth = !isBareMode()
     const options = [
       {
         value: 'anthropic',
@@ -956,6 +1048,16 @@ export function ProviderManager({ mode, onDone }: Props): React.ReactNode {
               label: 'Codex OAuth',
               description:
                 'Sign in with ChatGPT in your browser and store Codex credentials securely',
+            },
+          ]
+        : []),
+      ...(canUseQwenOAuth
+        ? [
+            {
+              value: 'qwen-oauth',
+              label: 'Qwen Coder',
+              description:
+                'Sign in with Qwen in your browser and store Qwen credentials securely (free tier)',
             },
           ]
         : []),
@@ -1037,6 +1139,10 @@ export function ProviderManager({ mode, onDone }: Props): React.ReactNode {
             }
             if (value === 'codex-oauth') {
               setScreen('codex-oauth')
+              return
+            }
+            if (value === 'qwen-oauth') {
+              setScreen('qwen-oauth')
               return
             }
             startCreateFromPreset(value as ProviderPreset)
@@ -1399,6 +1505,82 @@ export function ProviderManager({ mode, onDone }: Props): React.ReactNode {
             setScreen('menu')
           }}
         />
+      )
+      break
+    case 'qwen-oauth':
+      content = (
+        <QwenOAuthSetup
+          onBack={() => setScreen('select-preset')}
+          onConfigured={async (tokens, persistCredentials) => {
+            const payload: ProviderProfileInput = {
+              provider: 'openai',
+              name: 'Qwen Coder (OAuth)',
+              baseUrl: 'https://portal.qwen.ai/v1',
+              model: 'coder-model',
+              apiKey: '',
+            }
+
+            const saved = addProviderProfile(payload, { makeActive: true })
+            if (!saved) {
+              setErrorMessage(
+                'Qwen OAuth login finished, but the provider profile could not be saved.',
+              )
+              setScreen('menu')
+              return
+            }
+
+            persistCredentials()
+            setHasStoredQwenOAuthCredentials(true)
+            setStoredQwenOAuthProfileId(saved.id)
+            refreshProfiles()
+            setScreen('qwen-success')
+          }}
+        />
+      )
+      break
+    case 'qwen-success':
+      content = (
+        <Box flexDirection="column" gap={1}>
+          <Text color="fastMode" bold>
+            Qwen Coder connected
+          </Text>
+          <Text>
+            Your Qwen account has been authenticated. The Qwen Coder provider is now active and ready to use.
+          </Text>
+          <Text dimColor>Press Enter to start chatting, or Esc to return to the provider menu.</Text>
+          <Select
+            options={[
+              {
+                value: 'done',
+                label: 'Done',
+                description: 'Return to chat',
+              },
+              {
+                value: 'menu',
+                label: 'Provider menu',
+                description: 'Return to provider management',
+              },
+            ]}
+            onChange={(value: string) => {
+              if (value === 'done') {
+                if (mode === 'first-run') {
+                  onDone({
+                    action: 'saved',
+                    activeProfileId: getActiveProviderProfile()?.id,
+                    message: 'Qwen Coder (OAuth) configured successfully.',
+                  })
+                } else {
+                  setStatusMessage('Qwen Coder (OAuth) is now your active provider.')
+                  onDone()
+                }
+              } else {
+                setScreen('menu')
+              }
+            }}
+            onCancel={() => setScreen('menu')}
+            visibleOptionCount={2}
+          />
+        </Box>
       )
       break
     case 'form':

--- a/src/components/StartupScreen.ts
+++ b/src/components/StartupScreen.ts
@@ -120,7 +120,8 @@ function detectProvider(): { name: string; model: string; baseUrl: string; isLoc
     // Override to Codex when resolved endpoint is Codex
     if (resolvedRequest.transport === 'codex_responses' || baseUrl.includes('chatgpt.com/backend-api/codex')) {
       name = 'Codex'
-    } else if (/deepseek/i.test(baseUrl) || /deepseek/i.test(rawModel))       name = 'DeepSeek'
+    } else if (/portal\.qwen\.ai/i.test(baseUrl))                           name = 'Qwen Coder (OAuth)'
+    else if (/deepseek/i.test(baseUrl) || /deepseek/i.test(rawModel))       name = 'DeepSeek'
     else if (/openrouter/i.test(baseUrl))                             name = 'OpenRouter'
     else if (/together/i.test(baseUrl))                               name = 'Together AI'
     else if (/groq/i.test(baseUrl))                                   name = 'Groq'

--- a/src/components/useQwenOAuthFlow.ts
+++ b/src/components/useQwenOAuthFlow.ts
@@ -1,0 +1,103 @@
+import * as React from 'react'
+
+import { QwenOAuthService, type QwenOAuthTokens } from '../services/api/qwenOAuthService.js'
+import { openBrowser } from '../utils/browser.js'
+import { saveQwenCredentials, type QwenStoredCredentials } from '../services/api/qwenCredentials.js'
+
+export type QwenOAuthFlowStatus =
+  | { state: 'starting' }
+  | {
+      state: 'waiting'
+      authUrl: string
+      userCode: string
+      browserOpened: boolean | null
+    }
+  | {
+      state: 'error'
+      message: string
+    }
+
+type PersistQwenOAuthCredentials = () => void
+
+type QwenOAuthFlowDependencies = {
+  createOAuthService?: () => QwenOAuthService
+  openBrowser?: typeof openBrowser
+  saveQwenCredentials?: typeof saveQwenCredentials
+}
+
+function createDefaultOAuthService(): QwenOAuthService {
+  return new QwenOAuthService()
+}
+
+export function useQwenOAuthFlow(options: {
+  onAuthenticated: (
+    tokens: QwenOAuthTokens,
+    persistCredentials: PersistQwenOAuthCredentials,
+  ) => void | Promise<void>
+  deps?: QwenOAuthFlowDependencies
+}): QwenOAuthFlowStatus {
+  const { onAuthenticated } = options
+  const createOAuthService =
+    options.deps?.createOAuthService ?? createDefaultOAuthService
+  const openBrowserFn = options.deps?.openBrowser ?? openBrowser
+  const saveCredentials =
+    options.deps?.saveQwenCredentials ?? saveQwenCredentials
+  const [status, setStatus] = React.useState<QwenOAuthFlowStatus>({
+    state: 'starting',
+  })
+
+  React.useEffect(() => {
+    let cancelled = false
+    const oauthService = createOAuthService()
+
+    void oauthService
+      .startOAuthFlow(async (authUrl, userCode) => {
+        if (cancelled) return
+        setStatus({
+          state: 'waiting',
+          authUrl,
+          userCode,
+          browserOpened: null,
+        })
+        const browserOpened = await openBrowserFn(authUrl)
+        if (cancelled) return
+        setStatus({
+          state: 'waiting',
+          authUrl,
+          userCode,
+          browserOpened,
+        })
+      })
+      .then(async tokens => {
+        if (cancelled) return
+
+        const persistCredentials: PersistQwenOAuthCredentials = () => {
+          const stored: QwenStoredCredentials = {
+            accessToken: tokens.accessToken,
+            refreshToken: tokens.refreshToken,
+            resourceUrl: tokens.resourceUrl,
+            expiryDate: tokens.expiryDate,
+            accountId: `qwen-${Date.now()}`,
+            lastRefreshAt: Date.now(),
+          }
+          return saveCredentials(stored)
+        }
+
+        await onAuthenticated(tokens, persistCredentials)
+      })
+      .catch(error => {
+        if (cancelled) return
+        setStatus({
+          state: 'error',
+          message: error instanceof Error ? error.message : String(error),
+        })
+      })
+
+    return () => {
+      cancelled = true
+      oauthService.cancel()
+    }
+  }, [createOAuthService, openBrowserFn, saveCredentials, onAuthenticated])
+
+  return status
+}

--- a/src/components/useQwenOAuthFlow.ts
+++ b/src/components/useQwenOAuthFlow.ts
@@ -17,7 +17,7 @@ export type QwenOAuthFlowStatus =
       message: string
     }
 
-type PersistQwenOAuthCredentials = () => void
+type PersistQwenOAuthCredentials = () => Promise<boolean>
 
 type QwenOAuthFlowDependencies = {
   createOAuthService?: () => QwenOAuthService

--- a/src/services/api/openaiShim.ts
+++ b/src/services/api/openaiShim.ts
@@ -22,15 +22,15 @@
  */
 
 import { APIError } from '@anthropic-ai/sdk'
-import {
-  readCodexCredentialsAsync,
-  refreshCodexAccessTokenIfNeeded,
-} from '../../utils/codexCredentials.js'
-import { logForDebugging } from '../../utils/debug.js'
-import { isBareMode, isEnvTruthy } from '../../utils/envUtils.js'
+import { isEnvTruthy } from '../../utils/envUtils.js'
 import { resolveGeminiCredential } from '../../utils/geminiAuth.js'
 import { hydrateGeminiAccessTokenFromSecureStorage } from '../../utils/geminiCredentials.js'
 import { hydrateGithubModelsTokenFromSecureStorage } from '../../utils/githubModelsCredentials.js'
+import {
+  startQwenProxy,
+  isQwenProxyRunning,
+  getQwenProxyBaseUrl,
+} from './qwenProxy.js'
 import {
   looksLikeLeakedReasoningPrefix,
   shouldBufferPotentialReasoningPrefix,
@@ -49,7 +49,7 @@ import {
 } from './codexShim.js'
 import {
   isLocalProviderUrl,
-  resolveRuntimeCodexCredentials,
+  resolveCodexApiCredentials,
   resolveProviderRequest,
   getGithubEndpointType,
 } from './providerConfig.js'
@@ -181,61 +181,35 @@ function convertSystemPrompt(
   return String(system)
 }
 
-function convertToolResultContent(
-  content: unknown,
-  isError?: boolean,
-): string | Array<{ type: string; text?: string; image_url?: { url: string } }> {
-  if (typeof content === 'string') {
-    return isError ? `Error: ${content}` : content
-  }
-  if (!Array.isArray(content)) {
-    const text = JSON.stringify(content ?? '')
-    return isError ? `Error: ${text}` : text
-  }
+function convertToolResultContent(content: unknown): string {
+  if (typeof content === 'string') return content
+  if (!Array.isArray(content)) return JSON.stringify(content ?? '')
 
-  const parts: Array<{
-    type: string
-    text?: string
-    image_url?: { url: string }
-  }> = []
+  const chunks: string[] = []
   for (const block of content) {
     if (block?.type === 'text' && typeof block.text === 'string') {
-      parts.push({ type: 'text', text: block.text })
+      chunks.push(block.text)
       continue
     }
 
     if (block?.type === 'image') {
       const source = block.source
       if (source?.type === 'url' && source.url) {
-        parts.push({ type: 'image_url', image_url: { url: source.url } })
-      } else if (source?.type === 'base64' && source.media_type && source.data) {
-        parts.push({
-          type: 'image_url',
-          image_url: {
-            url: `data:${source.media_type};base64,${source.data}`,
-          },
-        })
+        chunks.push(`[Image](${source.url})`)
+      } else if (source?.type === 'base64') {
+        chunks.push(`[image:${source.media_type ?? 'unknown'}]`)
+      } else {
+        chunks.push('[image]')
       }
       continue
     }
 
     if (typeof block?.text === 'string') {
-      parts.push({ type: 'text', text: block.text })
+      chunks.push(block.text)
     }
   }
 
-  if (parts.length === 0) return ''
-  if (parts.length === 1 && parts[0].type === 'text') {
-    const text = parts[0].text ?? ''
-    return isError ? `Error: ${text}` : text
-  }
-  if (isError && parts[0]?.type === 'text') {
-    parts[0] = { ...parts[0], text: `Error: ${parts[0].text ?? ''}` }
-  } else if (isError) {
-    parts.unshift({ type: 'text', text: 'Error:' })
-  }
-
-  return parts
+  return chunks.join('\n')
 }
 
 function convertContentBlocks(
@@ -323,10 +297,11 @@ function convertMessages(
 
         // Emit tool results as tool messages
         for (const tr of toolResults) {
+          const trContent = convertToolResultContent(tr.content)
           result.push({
             role: 'tool',
             tool_call_id: tr.tool_use_id ?? 'unknown',
-            content: convertToolResultContent(tr.content, tr.is_error),
+            content: tr.is_error ? `Error: ${trContent}` : trContent,
           })
         }
 
@@ -1144,6 +1119,7 @@ class OpenAIShimMessages {
     const githubEndpointType = getGithubEndpointType(request.baseUrl)
     const isGithubMode = isGithubModelsMode()
     const isGithubWithCodexTransport = isGithubMode && request.transport === 'codex_responses'
+    const isGithubCopilotEndpoint = isGithubMode && githubEndpointType === 'copilot'
 
     if (isGithubWithCodexTransport) {
       const apiKey = this.providerOverride?.apiKey ?? process.env.OPENAI_API_KEY ?? ''
@@ -1170,26 +1146,11 @@ class OpenAIShimMessages {
     }
 
     if (request.transport === 'codex_responses' && !isGithubMode) {
-      const refreshResult = await refreshCodexAccessTokenIfNeeded().catch(
-        async error => {
-          logForDebugging(
-            `[codex] access token refresh failed before request: ${error instanceof Error ? error.message : String(error)}`,
-            { level: 'warn' },
-          )
-          return {
-            refreshed: false,
-            credentials: await readCodexCredentialsAsync(),
-          }
-        },
-      )
-      const credentials = resolveRuntimeCodexCredentials({
-        storedCredentials: refreshResult.credentials,
-      })
+      const credentials = resolveCodexApiCredentials()
       if (!credentials.apiKey) {
-        const oauthHint = isBareMode() ? '' : ', choose Codex OAuth in /provider'
         const authHint = credentials.authPath
-          ? `${oauthHint} or place a Codex auth.json at ${credentials.authPath}`
-          : oauthHint
+          ? ` or place a Codex auth.json at ${credentials.authPath}`
+          : ''
         const safeModel =
           redactSecretValueForDisplay(request.requestedModel, process.env as SecretValueSource) ??
           'the requested model'
@@ -1199,7 +1160,7 @@ class OpenAIShimMessages {
       }
       if (!credentials.accountId) {
         throw new Error(
-          'Codex auth is missing chatgpt_account_id. Re-login with Codex OAuth, the Codex CLI, or set CHATGPT_ACCOUNT_ID/CODEX_ACCOUNT_ID.',
+          'Codex auth is missing chatgpt_account_id. Re-login with the Codex CLI or set CHATGPT_ACCOUNT_ID/CODEX_ACCOUNT_ID.',
         )
       }
 
@@ -1238,6 +1199,10 @@ class OpenAIShimMessages {
       stream: params.stream ?? false,
       store: false,
     }
+
+    // Detect Qwen OAuth early — used in multiple places below
+    const isQwenOAuth = request.baseUrl.includes('portal.qwen.ai')
+
     // Convert max_tokens to max_completion_tokens for OpenAI API compatibility.
     // Azure OpenAI requires max_completion_tokens and does not accept max_tokens.
     // Ensure max_tokens is a valid positive number before using it.
@@ -1254,19 +1219,30 @@ class OpenAIShimMessages {
       body.max_completion_tokens = maxCompletionTokensValue
     }
 
-    if (params.stream && !isLocalProviderUrl(request.baseUrl)) {
+    if (params.stream && !isLocalProviderUrl(request.baseUrl) && !isQwenOAuth) {
       body.stream_options = { include_usage: true }
     }
 
     const isGithub = isGithubModelsMode()
     const isMistral = isMistralMode()
-    const isLocal = isLocalProviderUrl(request.baseUrl)
 
     const githubEndpointType = getGithubEndpointType(request.baseUrl)
     const isGithubCopilot = isGithub && githubEndpointType === 'copilot'
     const isGithubModels = isGithub && (githubEndpointType === 'models' || githubEndpointType === 'custom')
 
-    if ((isGithub || isMistral || isLocal) && body.max_completion_tokens !== undefined) {
+    // DashScope (Qwen OAuth) uses max_tokens, not max_completion_tokens
+    // Also doesn't support store, stream_options, parallel_tool_calls, or strict on tools
+    if (isQwenOAuth) {
+      if (body.max_completion_tokens !== undefined) {
+        body.max_tokens = body.max_completion_tokens
+        delete body.max_completion_tokens
+      }
+      delete body.store
+      delete body.stream_options
+      delete body.parallel_tool_calls
+    }
+
+    if ((isGithub || isMistral) && body.max_completion_tokens !== undefined) {
       body.max_tokens = body.max_completion_tokens
       delete body.max_completion_tokens
     }
@@ -1324,7 +1300,31 @@ class OpenAIShimMessages {
         (hostname.includes('cognitiveservices') || hostname.includes('openai') || hostname.includes('services.ai'))
     } catch { /* malformed URL — not Azure */ }
 
-    if (apiKey) {
+    // Build the chat completions URL (needed early for Qwen OAuth override)
+    let chatCompletionsUrl: string | undefined
+
+    if (isQwenOAuth) {
+      // Start the internal Qwen proxy automatically if not running.
+      // The proxy handles:
+      // - TLS fingerprint matching the Qwen CLI (via https.Agent)
+      // - OAuth token read from ~/.claude/qwen-oauth.json
+      // - Auto token refresh before expiry
+      // - DashScope-compatible payload format
+      if (!isQwenProxyRunning()) {
+        try {
+          await startQwenProxy()
+        } catch (e: any) {
+          throw new Error(
+            `Failed to start Qwen OAuth proxy: ${e.message}\n` +
+            `Fix: Authenticate with the Qwen CLI first: qwen → /auth`,
+          )
+        }
+      }
+      // Route through the internal proxy
+      chatCompletionsUrl = `${getQwenProxyBaseUrl()}/chat/completions`
+      // Clear any Authorization header since proxy handles auth internally
+      delete headers.Authorization
+    } else if (apiKey) {
       if (isAzure) {
         // Azure uses api-key header instead of Bearer token
         headers['api-key'] = apiKey
@@ -1348,26 +1348,27 @@ class OpenAIShimMessages {
       headers['X-GitHub-Api-Version'] = '2022-11-28'
     }
 
-    // Build the chat completions URL
+    // Build the chat completions URL (skip if already set by Qwen OAuth)
     // Azure Cognitive Services / Azure OpenAI require a deployment-specific path
     // and an api-version query parameter.
     // Standard format: {base}/openai/deployments/{model}/chat/completions?api-version={version}
     // Non-Azure: {base}/chat/completions
-    let chatCompletionsUrl: string
-    if (isAzure) {
-      const apiVersion = process.env.AZURE_OPENAI_API_VERSION ?? '2024-12-01-preview'
-      const deployment = request.resolvedModel ?? process.env.OPENAI_MODEL ?? 'gpt-4o'
-      // If base URL already contains /deployments/, use it as-is with api-version
-      if (/\/deployments\//i.test(request.baseUrl)) {
-        const base = request.baseUrl.replace(/\/+$/, '')
-        chatCompletionsUrl = `${base}/chat/completions?api-version=${apiVersion}`
+    if (!chatCompletionsUrl) {
+      if (isAzure) {
+        const apiVersion = process.env.AZURE_OPENAI_API_VERSION ?? '2024-12-01-preview'
+        const deployment = request.resolvedModel ?? process.env.OPENAI_MODEL ?? 'gpt-4o'
+        // If base URL already contains /deployments/, use it as-is with api-version
+        if (/\/deployments\//i.test(request.baseUrl)) {
+          const base = request.baseUrl.replace(/\/+$/, '')
+          chatCompletionsUrl = `${base}/chat/completions?api-version=${apiVersion}`
+        } else {
+          // Strip trailing /v1 or /openai/v1 if present, then build Azure path
+          const base = request.baseUrl.replace(/\/(openai\/)?v1\/?$/, '').replace(/\/+$/, '')
+          chatCompletionsUrl = `${base}/openai/deployments/${deployment}/chat/completions?api-version=${apiVersion}`
+        }
       } else {
-        // Strip trailing /v1 or /openai/v1 if present, then build Azure path
-        const base = request.baseUrl.replace(/\/(openai\/)?v1\/?$/, '').replace(/\/+$/, '')
-        chatCompletionsUrl = `${base}/openai/deployments/${deployment}/chat/completions?api-version=${apiVersion}`
+        chatCompletionsUrl = `${request.baseUrl}/chat/completions`
       }
-    } else {
-      chatCompletionsUrl = `${request.baseUrl}/chat/completions`
     }
 
     const fetchInit = {

--- a/src/services/api/qwenAuth.ts
+++ b/src/services/api/qwenAuth.ts
@@ -1,8 +1,8 @@
 /**
  * Qwen OAuth credential management for OpenClaude.
  *
- * Reads and refreshes tokens from ~/.claude/qwen-oauth.json
- * (created by the Qwen Code CLI via `qwen` → `/auth`).
+ * Reads credentials from ~/.claude/qwen-oauth.json
+ * (created by the Qwen OAuth flow via /provider → Qwen Coder).
  *
  * The actual API requests are handled by qwenProxy.ts, which
  * starts an internal HTTP proxy on localhost:8080 to forward
@@ -27,11 +27,11 @@ const QWEN_OAUTH_CLIENT_ID = 'f0304373b74a44d2b584a3fb70ca9e56'
 const TOKEN_REFRESH_BUFFER_MS = 30 * 1000
 
 export type QwenCredentials = {
-  access_token: string
-  refresh_token?: string
-  token_type?: string
-  resource_url?: string
-  expiry_date?: number
+  accessToken: string
+  refreshToken?: string
+  tokenType?: string
+  resourceUrl?: string
+  expiryDate?: number
   [key: string]: unknown
 }
 
@@ -46,7 +46,7 @@ export function loadQwenCredentials(): QwenCredentials | null {
   try {
     const raw = readFileSync(QWEN_CREDENTIALS_PATH, 'utf8')
     const parsed = JSON.parse(raw)
-    if (parsed && typeof parsed === 'object' && parsed.access_token) {
+    if (parsed && typeof parsed === 'object' && parsed.accessToken) {
       return parsed as QwenCredentials
     }
     return null
@@ -56,31 +56,31 @@ export function loadQwenCredentials(): QwenCredentials | null {
 }
 
 export function isQwenTokenValid(credentials: QwenCredentials | null): boolean {
-  if (!credentials || !credentials.access_token || !credentials.expiry_date) {
+  if (!credentials || !credentials.accessToken || !credentials.expiryDate) {
     return false
   }
-  return Date.now() < credentials.expiry_date - TOKEN_REFRESH_BUFFER_MS
+  return Date.now() < credentials.expiryDate - TOKEN_REFRESH_BUFFER_MS
 }
 
 export function shouldRefreshQwenToken(credentials: QwenCredentials | null): boolean {
-  if (!credentials || !credentials.access_token || !credentials.expiry_date) {
+  if (!credentials || !credentials.accessToken || !credentials.expiryDate) {
     return true
   }
-  return Date.now() >= credentials.expiry_date - TOKEN_REFRESH_BUFFER_MS
+  return Date.now() >= credentials.expiryDate - TOKEN_REFRESH_BUFFER_MS
 }
 
 export async function refreshQwenAccessToken(
   credentials: QwenCredentials,
 ): Promise<QwenCredentials> {
-  if (!credentials.refresh_token) {
+  if (!credentials.refreshToken) {
     throw new Error(
-      'No refresh token available. Please re-authenticate with the Qwen CLI: qwen',
+      'No refresh token available. Please re-authenticate: /provider → Qwen Coder',
     )
   }
 
   const bodyData = new URLSearchParams({
     grant_type: 'refresh_token',
-    refresh_token: credentials.refresh_token,
+    refresh_token: credentials.refreshToken,
     client_id: QWEN_OAUTH_CLIENT_ID,
   })
 
@@ -104,13 +104,13 @@ export async function refreshQwenAccessToken(
 
   const newCredentials: QwenCredentials = {
     ...credentials,
-    access_token: tokenData.access_token as string,
-    token_type: tokenData.token_type as string | undefined,
-    refresh_token: (tokenData.refresh_token as string) || credentials.refresh_token,
-    resource_url: (tokenData.resource_url as string) || credentials.resource_url,
-    expiry_date: tokenData.expires_in
+    accessToken: tokenData.access_token as string,
+    tokenType: tokenData.token_type as string | undefined,
+    refreshToken: (tokenData.refresh_token as string) || credentials.refreshToken,
+    resourceUrl: (tokenData.resource_url as string) || credentials.resourceUrl,
+    expiryDate: tokenData.expires_in
       ? Date.now() + (tokenData.expires_in as number) * 1000
-      : credentials.expiry_date,
+      : credentials.expiryDate,
   }
 
   saveQwenCredentials(newCredentials)
@@ -118,8 +118,8 @@ export async function refreshQwenAccessToken(
 }
 
 export function saveQwenCredentials(credentials: QwenCredentials): void {
-  if (!credentials.access_token) {
-    throw new Error('Cannot save credentials without access_token')
+  if (!credentials.accessToken) {
+    throw new Error('Cannot save credentials without accessToken')
   }
   try {
     mkdirSync(CLAUDE_DIR, { recursive: true })

--- a/src/services/api/qwenAuth.ts
+++ b/src/services/api/qwenAuth.ts
@@ -1,0 +1,135 @@
+/**
+ * Qwen OAuth credential management for OpenClaude.
+ *
+ * Reads and refreshes tokens from ~/.claude/qwen-oauth.json
+ * (created by the Qwen Code CLI via `qwen` → `/auth`).
+ *
+ * The actual API requests are handled by qwenProxy.ts, which
+ * starts an internal HTTP proxy on localhost:8080 to forward
+ * requests to the Qwen API with proper TLS fingerprinting.
+ */
+
+import { existsSync, readFileSync, mkdirSync, writeFileSync } from 'node:fs'
+import { homedir } from 'node:os'
+import { join } from 'node:path'
+
+// ============================================================
+// Constants
+// ============================================================
+
+const CLAUDE_DIR = join(homedir(), '.claude')
+const QWEN_CREDENTIAL_FILENAME = 'qwen-oauth.json'
+const QWEN_CREDENTIALS_PATH = join(CLAUDE_DIR, QWEN_CREDENTIAL_FILENAME)
+
+const QWEN_OAUTH_BASE_URL = 'https://chat.qwen.ai'
+const QWEN_OAUTH_TOKEN_ENDPOINT = `${QWEN_OAUTH_BASE_URL}/api/v1/oauth2/token`
+const QWEN_OAUTH_CLIENT_ID = 'f0304373b74a44d2b584a3fb70ca9e56'
+const TOKEN_REFRESH_BUFFER_MS = 30 * 1000
+
+export type QwenCredentials = {
+  access_token: string
+  refresh_token?: string
+  token_type?: string
+  resource_url?: string
+  expiry_date?: number
+  [key: string]: unknown
+}
+
+// ============================================================
+// Credential management
+// ============================================================
+
+export function loadQwenCredentials(): QwenCredentials | null {
+  if (!existsSync(QWEN_CREDENTIALS_PATH)) {
+    return null
+  }
+  try {
+    const raw = readFileSync(QWEN_CREDENTIALS_PATH, 'utf8')
+    const parsed = JSON.parse(raw)
+    if (parsed && typeof parsed === 'object' && parsed.access_token) {
+      return parsed as QwenCredentials
+    }
+    return null
+  } catch {
+    return null
+  }
+}
+
+export function isQwenTokenValid(credentials: QwenCredentials | null): boolean {
+  if (!credentials || !credentials.access_token || !credentials.expiry_date) {
+    return false
+  }
+  return Date.now() < credentials.expiry_date - TOKEN_REFRESH_BUFFER_MS
+}
+
+export function shouldRefreshQwenToken(credentials: QwenCredentials | null): boolean {
+  if (!credentials || !credentials.access_token || !credentials.expiry_date) {
+    return true
+  }
+  return Date.now() >= credentials.expiry_date - TOKEN_REFRESH_BUFFER_MS
+}
+
+export async function refreshQwenAccessToken(
+  credentials: QwenCredentials,
+): Promise<QwenCredentials> {
+  if (!credentials.refresh_token) {
+    throw new Error(
+      'No refresh token available. Please re-authenticate with the Qwen CLI: qwen',
+    )
+  }
+
+  const bodyData = new URLSearchParams({
+    grant_type: 'refresh_token',
+    refresh_token: credentials.refresh_token,
+    client_id: QWEN_OAUTH_CLIENT_ID,
+  })
+
+  const response = await fetch(QWEN_OAUTH_TOKEN_ENDPOINT, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/x-www-form-urlencoded',
+      Accept: 'application/json',
+    },
+    body: bodyData,
+  })
+
+  if (!response.ok) {
+    const errorData = await response.json().catch(() => ({}))
+    throw new Error(
+      `Token refresh failed: ${errorData.error || response.status} - ${errorData.error_description || 'Unknown error'}`,
+    )
+  }
+
+  const tokenData = await response.json() as Record<string, unknown>
+
+  const newCredentials: QwenCredentials = {
+    ...credentials,
+    access_token: tokenData.access_token as string,
+    token_type: tokenData.token_type as string | undefined,
+    refresh_token: (tokenData.refresh_token as string) || credentials.refresh_token,
+    resource_url: (tokenData.resource_url as string) || credentials.resource_url,
+    expiry_date: tokenData.expires_in
+      ? Date.now() + (tokenData.expires_in as number) * 1000
+      : credentials.expiry_date,
+  }
+
+  saveQwenCredentials(newCredentials)
+  return newCredentials
+}
+
+export function saveQwenCredentials(credentials: QwenCredentials): void {
+  if (!credentials.access_token) {
+    throw new Error('Cannot save credentials without access_token')
+  }
+  try {
+    mkdirSync(CLAUDE_DIR, { recursive: true })
+    writeFileSync(
+      QWEN_CREDENTIALS_PATH,
+      JSON.stringify(credentials, null, 2),
+      { encoding: 'utf8', mode: 0o600 },
+    )
+  } catch (error) {
+    console.error('Failed to save Qwen credentials:', error)
+    throw error
+  }
+}

--- a/src/services/api/qwenCredentials.ts
+++ b/src/services/api/qwenCredentials.ts
@@ -1,18 +1,23 @@
 /**
- * Qwen OAuth credentials management using secureStorage.
+ * Qwen OAuth credentials management.
  *
- * Follows the same pattern as codexCredentials.ts:
- * - Credentials stored in OS secure storage (keychain/credential manager)
- * - Auto-refresh with dedup, cooldown, and in-flight request dedup
+ * Saves/reads credentials as a JSON file at ~/.claude/qwen-oauth.json
+ * (same approach as the Qwen Code CLI, which uses ~/.qwen/oauth_creds.json).
+ *
+ * No secureStorage dependency — file permissions are set to 0o600 (owner-only).
  */
 
-import { getSecureStorage } from '../utils/secureStorage/index.js'
+import { existsSync, readFileSync, mkdirSync, writeFileSync } from 'node:fs'
+import { homedir } from 'node:os'
+import { join } from 'node:path'
 
 // ============================================================
 // Constants
 // ============================================================
 
-const QWEN_SECURE_STORAGE_KEY = 'qwen'
+const CREDENTIALS_DIR = join(homedir(), '.claude')
+const CREDENTIALS_FILE = 'qwen-oauth.json'
+const CREDENTIALS_PATH = join(CREDENTIALS_DIR, CREDENTIALS_FILE)
 
 export interface QwenStoredCredentials {
   accessToken: string
@@ -25,61 +30,64 @@ export interface QwenStoredCredentials {
 }
 
 // ============================================================
-// SecureStorage helpers
+// File-based credential storage
 // ============================================================
 
-function getQwenSecureStorage() {
-  return getSecureStorage({ allowPlainTextFallback: false })
-}
-
 /**
- * Read Qwen credentials from secure storage.
- */
-export async function readQwenCredentials(): Promise<QwenStoredCredentials | null> {
-  try {
-    const data = await getQwenSecureStorage().readAsync()
-    return (data as Record<string, unknown>)?.[QWEN_SECURE_STORAGE_KEY] as QwenStoredCredentials | null
-  } catch {
-    return null
-  }
-}
-
-/**
- * Save Qwen credentials to secure storage.
+ * Save Qwen credentials to ~/.claude/qwen-oauth.json.
+ * Overwrites any existing credentials file.
  * Returns true on success.
  */
 export async function saveQwenCredentials(creds: QwenStoredCredentials): Promise<boolean> {
   try {
-    const storage = getQwenSecureStorage()
-    const previous = (await storage.readAsync()) as Record<string, unknown> | null
-    const next = { ...(previous || {}), [QWEN_SECURE_STORAGE_KEY]: creds }
-    const result = storage.update(next as Record<string, unknown>)
-    return result.success
+    mkdirSync(CREDENTIALS_DIR, { recursive: true })
+    writeFileSync(
+      CREDENTIALS_PATH,
+      JSON.stringify(creds, null, 2),
+      { encoding: 'utf8', mode: 0o600 },
+    )
+    return true
   } catch {
     return false
   }
 }
 
 /**
- * Check if valid Qwen credentials exist (not expired).
+ * Read Qwen credentials from ~/.claude/qwen-oauth.json.
+ * Returns null if the file doesn't exist or is invalid.
+ */
+export async function readQwenCredentials(): Promise<QwenStoredCredentials | null> {
+  try {
+    if (!existsSync(CREDENTIALS_PATH)) return null
+    const raw = readFileSync(CREDENTIALS_PATH, 'utf8')
+    const parsed = JSON.parse(raw)
+    if (parsed && typeof parsed === 'object' && parsed.accessToken) {
+      return parsed as QwenStoredCredentials
+    }
+    return null
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Check if valid Qwen credentials exist (not expired, 30s buffer).
  */
 export async function hasStoredQwenCredentials(): Promise<boolean> {
   const creds = await readQwenCredentials()
-  if (!creds?.accessToken) return false
+  if (!creds) return false
   return Date.now() < creds.expiryDate - 30_000
 }
 
 /**
- * Clear Qwen credentials from secure storage.
+ * Clear Qwen credentials by deleting the file.
  */
 export async function clearQwenCredentials(): Promise<boolean> {
   try {
-    const storage = getQwenSecureStorage()
-    const previous = (await storage.readAsync()) as Record<string, unknown> | null
-    if (!previous) return true
-    const { [QWEN_SECURE_STORAGE_KEY]: _, ...rest } = previous
-    const result = storage.update(rest)
-    return result.success
+    if (!existsSync(CREDENTIALS_PATH)) return true
+    const fs = await import('node:fs/promises')
+    await fs.unlink(CREDENTIALS_PATH)
+    return true
   } catch {
     return false
   }

--- a/src/services/api/qwenCredentials.ts
+++ b/src/services/api/qwenCredentials.ts
@@ -1,0 +1,86 @@
+/**
+ * Qwen OAuth credentials management using secureStorage.
+ *
+ * Follows the same pattern as codexCredentials.ts:
+ * - Credentials stored in OS secure storage (keychain/credential manager)
+ * - Auto-refresh with dedup, cooldown, and in-flight request dedup
+ */
+
+import { getSecureStorage } from '../utils/secureStorage/index.js'
+
+// ============================================================
+// Constants
+// ============================================================
+
+const QWEN_SECURE_STORAGE_KEY = 'qwen'
+
+export interface QwenStoredCredentials {
+  accessToken: string
+  refreshToken: string
+  resourceUrl: string
+  expiryDate: number
+  accountId: string
+  lastRefreshAt: number
+  lastRefreshFailureAt?: number
+}
+
+// ============================================================
+// SecureStorage helpers
+// ============================================================
+
+function getQwenSecureStorage() {
+  return getSecureStorage({ allowPlainTextFallback: false })
+}
+
+/**
+ * Read Qwen credentials from secure storage.
+ */
+export async function readQwenCredentials(): Promise<QwenStoredCredentials | null> {
+  try {
+    const data = await getQwenSecureStorage().readAsync()
+    return (data as Record<string, unknown>)?.[QWEN_SECURE_STORAGE_KEY] as QwenStoredCredentials | null
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Save Qwen credentials to secure storage.
+ * Returns true on success.
+ */
+export async function saveQwenCredentials(creds: QwenStoredCredentials): Promise<boolean> {
+  try {
+    const storage = getQwenSecureStorage()
+    const previous = (await storage.readAsync()) as Record<string, unknown> | null
+    const next = { ...(previous || {}), [QWEN_SECURE_STORAGE_KEY]: creds }
+    const result = storage.update(next as Record<string, unknown>)
+    return result.success
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Check if valid Qwen credentials exist (not expired).
+ */
+export async function hasStoredQwenCredentials(): Promise<boolean> {
+  const creds = await readQwenCredentials()
+  if (!creds?.accessToken) return false
+  return Date.now() < creds.expiryDate - 30_000
+}
+
+/**
+ * Clear Qwen credentials from secure storage.
+ */
+export async function clearQwenCredentials(): Promise<boolean> {
+  try {
+    const storage = getQwenSecureStorage()
+    const previous = (await storage.readAsync()) as Record<string, unknown> | null
+    if (!previous) return true
+    const { [QWEN_SECURE_STORAGE_KEY]: _, ...rest } = previous
+    const result = storage.update(rest)
+    return result.success
+  } catch {
+    return false
+  }
+}

--- a/src/services/api/qwenOAuth.test.ts
+++ b/src/services/api/qwenOAuth.test.ts
@@ -1,0 +1,29 @@
+/**
+ * Quick test of Qwen OAuth device code flow.
+ * Run: node --import tsx src/services/api/qwenOAuth.ts
+ * Or: npx tsx src/services/api/qwenOAuth.test.ts
+ */
+
+import { authenticateWithQwenOAuth } from './qwenOAuth.js'
+
+console.log('Starting Qwen OAuth test...')
+
+authenticateWithQwenOAuth((progress) => {
+  console.log(`[${progress.status}] ${progress.message}`)
+  if (progress.userCode) {
+    console.log(`User code: ${progress.userCode}`)
+  }
+  if (progress.verificationUrl) {
+    console.log(`URL: ${progress.verificationUrl}`)
+  }
+})
+.then((creds) => {
+  console.log('SUCCESS! Credentials obtained:')
+  console.log(`  access_token: ${creds.access_token.substring(0, 20)}...`)
+  console.log(`  resource_url: ${creds.resource_url}`)
+  console.log(`  expires: ${creds.expiry_date ? new Date(creds.expiry_date).toISOString() : 'unknown'}`)
+})
+.catch((err) => {
+  console.error('FAILED:', err.message)
+  process.exit(1)
+})

--- a/src/services/api/qwenOAuth.ts
+++ b/src/services/api/qwenOAuth.ts
@@ -1,0 +1,333 @@
+/**
+ * Qwen OAuth Device Code Flow with PKCE.
+ *
+ * Replicates the exact same flow as the Qwen Code CLI:
+ * 1. Generate PKCE pair (code_verifier + code_challenge)
+ * 2. Request device code from chat.qwen.ai
+ * 3. Open browser for user authentication
+ * 4. Poll for token until user completes auth
+ * 5. Save credentials to ~/.claude/qwen-oauth.json
+ *
+ * This allows OpenClaude to authenticate with Qwen OAuth
+ * without requiring the Qwen Code CLI to be installed.
+ */
+
+import { randomBytes, createHash } from 'node:crypto'
+import { existsSync, mkdirSync, writeFileSync } from 'node:fs'
+import { homedir } from 'node:os'
+import { join } from 'node:path'
+import { exec } from 'node:child_process'
+import { promisify } from 'node:util'
+
+const execAsync = promisify(exec)
+
+// ============================================================
+// Constants — exact same values as Qwen Code CLI
+// ============================================================
+
+const QWEN_OAUTH_BASE_URL = 'https://chat.qwen.ai'
+const QWEN_OAUTH_DEVICE_CODE_ENDPOINT = `${QWEN_OAUTH_BASE_URL}/api/v1/oauth2/device/code`
+const QWEN_OAUTH_TOKEN_ENDPOINT = `${QWEN_OAUTH_BASE_URL}/api/v1/oauth2/token`
+const QWEN_OAUTH_CLIENT_ID = 'f0304373b74a44d2b584a3fb70ca9e56'
+const QWEN_OAUTH_SCOPE = 'openid profile email model.completion'
+const QWEN_OAUTH_GRANT_TYPE = 'urn:ietf:params:oauth:grant-type:device_code'
+
+const CLAUDE_DIR = join(homedir(), '.claude')
+const QWEN_CREDENTIAL_FILENAME = 'qwen-oauth.json'
+const QWEN_CREDENTIALS_PATH = join(CLAUDE_DIR, QWEN_CREDENTIAL_FILENAME)
+
+export type QwenDeviceCodeResponse = {
+  device_code: string
+  user_code: string
+  verification_uri: string
+  verification_uri_complete: string
+  expires_in: number
+  interval?: number
+}
+
+export type QwenCredentials = {
+  access_token: string
+  refresh_token?: string
+  token_type?: string
+  resource_url?: string
+  expiry_date?: number
+}
+
+// ============================================================
+// PKCE Generation — exact same as Qwen Code CLI
+// ============================================================
+
+function generateCodeVerifier(): string {
+  return randomBytes(32).toString('base64url')
+}
+
+function generateCodeChallenge(codeVerifier: string): string {
+  const hash = createHash('sha256')
+  hash.update(codeVerifier)
+  return hash.digest('base64url')
+}
+
+function generatePKCEPair(): { code_verifier: string; code_challenge: string } {
+  const codeVerifier = generateCodeVerifier()
+  const codeChallenge = generateCodeChallenge(codeVerifier)
+  return { code_verifier: codeVerifier, code_challenge: codeChallenge }
+}
+
+function objectToUrlEncoded(data: Record<string, string>): string {
+  return Object.keys(data)
+    .map((key) => `${encodeURIComponent(key)}=${encodeURIComponent(data[key])}`)
+    .join('&')
+}
+
+// ============================================================
+// Browser launch
+// ============================================================
+
+async function openBrowser(url: string): Promise<void> {
+  const platform = process.platform
+  try {
+    if (platform === 'win32') {
+      await execAsync(`start "" "${url}"`)
+    } else if (platform === 'darwin') {
+      await execAsync(`open "${url}"`)
+    } else {
+      await execAsync(`xdg-open "${url}" 2>/dev/null || echo "Please open: ${url}"`)
+    }
+  } catch {
+    // Non-critical — user can open manually
+  }
+}
+
+// ============================================================
+// Device Code Flow
+// ============================================================
+
+/**
+ * Step 1: Request device code from Qwen OAuth server.
+ */
+async function requestDeviceCode(codeChallenge: string): Promise<QwenDeviceCodeResponse> {
+  const body = objectToUrlEncoded({
+    client_id: QWEN_OAUTH_CLIENT_ID,
+    scope: QWEN_OAUTH_SCOPE,
+    code_challenge: codeChallenge,
+    code_challenge_method: 'S256',
+  })
+
+  const response = await fetch(QWEN_OAUTH_DEVICE_CODE_ENDPOINT, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/x-www-form-urlencoded',
+      'Accept': 'application/json',
+    },
+    body,
+  })
+
+  if (!response.ok) {
+    const text = await response.text()
+    throw new Error(`Device authorization failed: ${response.status} — ${text}`)
+  }
+
+  const data = await response.json()
+  if (!data.device_code) {
+    throw new Error(`Device authorization failed: ${data.error || 'Unknown error'} — ${data.error_description || 'No details'}`)
+  }
+
+  return data as QwenDeviceCodeResponse
+}
+
+/**
+ * Step 2: Poll for token until user completes auth or timeout.
+ */
+async function pollForToken(
+  deviceCode: string,
+  codeVerifier: string,
+  expiresInSeconds: number,
+  onProgress?: (message: string) => void,
+): Promise<QwenCredentials> {
+  const pollInterval = 2000 // 2s base
+  const maxAttempts = Math.ceil(expiresInSeconds / (pollInterval / 1000))
+
+  for (let attempt = 0; attempt < maxAttempts; attempt++) {
+    const body = objectToUrlEncoded({
+      grant_type: QWEN_OAUTH_GRANT_TYPE,
+      client_id: QWEN_OAUTH_CLIENT_ID,
+      device_code: deviceCode,
+      code_verifier: codeVerifier,
+    })
+
+    try {
+      const response = await fetch(QWEN_OAUTH_TOKEN_ENDPOINT, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/x-www-form-urlencoded',
+          'Accept': 'application/json',
+        },
+        body,
+      })
+
+      const text = await response.text()
+      let data: Record<string, unknown>
+      try {
+        data = JSON.parse(text)
+      } catch {
+        throw new Error(`Token poll failed: ${response.status} — ${text}`)
+      }
+
+      // authorization_pending — keep polling
+      if (response.status === 400 && data.error === 'authorization_pending') {
+        onProgress?.(`Waiting for authorization... (${attempt + 1}/${maxAttempts})`)
+        await new Promise((r) => setTimeout(r, pollInterval))
+        continue
+      }
+
+      // slow_down — increase interval
+      if (response.status === 429 && data.error === 'slow_down') {
+        onProgress?.('Server requested slowdown, waiting longer...')
+        await new Promise((r) => setTimeout(r, Math.min(pollInterval * 1.5, 10000)))
+        continue
+      }
+
+      // Success
+      if (response.ok && data.access_token) {
+        return {
+          access_token: data.access_token as string,
+          refresh_token: (data.refresh_token as string) || undefined,
+          token_type: (data.token_type as string) || 'Bearer',
+          resource_url: (data.resource_url as string) || undefined,
+          expiry_date: data.expires_in
+            ? Date.now() + (data.expires_in as number) * 1000
+            : undefined,
+        }
+      }
+
+      // Other error
+      throw new Error(`Token poll failed: ${data.error || 'Unknown error'} — ${data.error_description || text}`)
+    } catch (error: any) {
+      // Network errors — retry
+      if (error.message?.includes('fetch')) {
+        onProgress?.(`Network error, retrying... (${error.message})`)
+        await new Promise((r) => setTimeout(r, pollInterval))
+        continue
+      }
+      throw error
+    }
+  }
+
+  throw new Error('Authorization timed out. Please try again.')
+}
+
+/**
+ * Step 3: Save credentials to ~/.claude/qwen-oauth.json
+ */
+function saveCredentials(credentials: QwenCredentials): void {
+  mkdirSync(CLAUDE_DIR, { recursive: true })
+  writeFileSync(
+    QWEN_CREDENTIALS_PATH,
+    JSON.stringify(credentials, null, 2),
+    { encoding: 'utf8', mode: 0o600 },
+  )
+}
+
+// ============================================================
+// Public API
+// ============================================================
+
+export type QwenAuthProgress = {
+  status: 'device_code' | 'browser' | 'polling' | 'success' | 'error' | 'timeout'
+  message: string
+  userCode?: string
+  verificationUrl?: string
+  verificationUrlComplete?: string
+}
+
+/**
+ * Full device code flow:
+ * 1. Generate PKCE
+ * 2. Request device code
+ * 3. Open browser
+ * 4. Poll for token
+ * 5. Save credentials
+ *
+ * Returns credentials on success, throws on failure.
+ */
+export async function authenticateWithQwenOAuth(
+  onProgress?: (progress: QwenAuthProgress) => void,
+): Promise<QwenCredentials> {
+  try {
+    // Step 1: Generate PKCE
+    const { code_verifier, code_challenge } = generatePKCEPair()
+
+    // Step 2: Request device code
+    onProgress?.({ status: 'device_code', message: 'Requesting authorization from Qwen...' })
+    const deviceCode = await requestDeviceCode(code_challenge)
+
+    onProgress?.({
+      status: 'browser',
+      message: 'Opening browser for authentication...',
+      userCode: deviceCode.user_code,
+      verificationUrl: deviceCode.verification_uri,
+      verificationUrlComplete: deviceCode.verification_uri_complete,
+    })
+
+    // Step 3: Open browser
+    if (deviceCode.verification_uri_complete) {
+      await openBrowser(deviceCode.verification_uri_complete)
+    }
+
+    // Step 4: Poll for token
+    onProgress?.({
+      status: 'polling',
+      message: `Waiting for authentication... Your code: ${deviceCode.user_code}`,
+      userCode: deviceCode.user_code,
+    })
+
+    const credentials = await pollForToken(
+      deviceCode.device_code,
+      code_verifier,
+      deviceCode.expires_in,
+      (msg) => onProgress?.({ status: 'polling', message: msg }),
+    )
+
+    // Step 5: Save credentials
+    saveCredentials(credentials)
+
+    onProgress?.({
+      status: 'success',
+      message: 'Authentication successful! Qwen Coder is ready to use.',
+    })
+
+    return credentials
+  } catch (error: any) {
+    const message = error instanceof Error ? error.message : String(error)
+    onProgress?.({ status: 'error', message: `Authentication failed: ${message}` })
+    throw error
+  }
+}
+
+/**
+ * Check if Qwen OAuth credentials exist and are valid.
+ */
+export function hasValidQwenCredentials(): boolean {
+  if (!existsSync(QWEN_CREDENTIALS_PATH)) return false
+  try {
+    const raw = require('fs').readFileSync(QWEN_CREDENTIALS_PATH, 'utf8')
+    const creds = JSON.parse(raw) as QwenCredentials
+    if (!creds.access_token || !creds.expiry_date) return false
+    return Date.now() < creds.expiry_date - 30000 // 30s buffer
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Get current Qwen credentials (without refresh).
+ */
+export function getQwenCredentials(): QwenCredentials | null {
+  if (!existsSync(QWEN_CREDENTIALS_PATH)) return null
+  try {
+    const raw = require('fs').readFileSync(QWEN_CREDENTIALS_PATH, 'utf8')
+    return JSON.parse(raw) as QwenCredentials
+  } catch {
+    return null
+  }
+}

--- a/src/services/api/qwenOAuthService.ts
+++ b/src/services/api/qwenOAuthService.ts
@@ -1,0 +1,192 @@
+/**
+ * Qwen OAuth Service — Device Code Flow with PKCE.
+ *
+ * Follows the exact same pattern as CodexOAuthService:
+ * - Generates PKCE pair (code_verifier + code_challenge)
+ * - Requests device code from Qwen OAuth server
+ * - Opens browser via authURLHandler
+ * - Polls for token with backoff
+ * - Returns credentials on success
+ */
+
+import { randomBytes, createHash } from 'node:crypto'
+
+const QWEN_OAUTH_DEVICE_CODE_ENDPOINT = 'https://chat.qwen.ai/api/v1/oauth2/device/code'
+const QWEN_OAUTH_TOKEN_ENDPOINT = 'https://chat.qwen.ai/api/v1/oauth2/token'
+const QWEN_OAUTH_CLIENT_ID = 'f0304373b74a44d2b584a3fb70ca9e56'
+const QWEN_OAUTH_SCOPE = 'openid profile email model.completion'
+
+export type QwenOAuthTokens = {
+  accessToken: string
+  refreshToken: string
+  tokenType: string
+  resourceUrl: string
+  expiryDate: number
+}
+
+function generateCodeVerifier(): string {
+  return randomBytes(32).toString('base64url')
+}
+
+function generateCodeChallenge(codeVerifier: string): string {
+  const hash = createHash('sha256')
+  hash.update(codeVerifier)
+  return hash.digest('base64url')
+}
+
+function objectToUrlEncoded(data: Record<string, string>): string {
+  return Object.entries(data)
+    .map(([k, v]) => `${encodeURIComponent(k)}=${encodeURIComponent(v)}`)
+    .join('&')
+}
+
+type QwenDeviceCodeResponse = {
+  device_code: string
+  user_code: string
+  verification_uri: string
+  verification_uri_complete: string
+  expires_in: number
+  interval?: number
+}
+
+/**
+ * Qwen OAuth Service for device code flow.
+ * Usage:
+ *   const service = new QwenOAuthService()
+ *   const tokens = await service.startOAuthFlow(async (authUrl) => {
+ *     await openBrowser(authUrl)
+ *   })
+ */
+export class QwenOAuthService {
+  private inFlightPoll: AbortController | null = null
+
+  async startOAuthFlow(
+    authURLHandler: (url: string, userCode: string) => Promise<void>,
+  ): Promise<QwenOAuthTokens> {
+    // Generate PKCE
+    const codeVerifier = generateCodeVerifier()
+    const codeChallenge = generateCodeChallenge(codeVerifier)
+
+    // Request device code
+    const deviceCode = await this.requestDeviceCode(codeChallenge)
+
+    // Open browser
+    await authURLHandler(deviceCode.verification_uri_complete, deviceCode.user_code)
+
+    // Poll for token
+    return this.pollForToken(deviceCode, codeVerifier)
+  }
+
+  private async requestDeviceCode(codeChallenge: string): Promise<QwenDeviceCodeResponse> {
+    const body = objectToUrlEncoded({
+      client_id: QWEN_OAUTH_CLIENT_ID,
+      scope: QWEN_OAUTH_SCOPE,
+      code_challenge: codeChallenge,
+      code_challenge_method: 'S256',
+    })
+
+    const response = await fetch(QWEN_OAUTH_DEVICE_CODE_ENDPOINT, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded',
+        'Accept': 'application/json',
+      },
+      body,
+    })
+
+    if (!response.ok) {
+      const text = await response.text()
+      throw new Error(`Device authorization failed: ${response.status} — ${text}`)
+    }
+
+    const data = await response.json()
+    if (!data.device_code) {
+      throw new Error(`Device authorization failed: ${(data as any).error || 'Unknown error'}`)
+    }
+
+    return data as QwenDeviceCodeResponse
+  }
+
+  private async pollForToken(
+    deviceCode: QwenDeviceCodeResponse,
+    codeVerifier: string,
+  ): Promise<QwenOAuthTokens> {
+    const pollInterval = 2000
+    const maxAttempts = Math.ceil(deviceCode.expires_in / (pollInterval / 1000))
+
+    this.inFlightPoll = new AbortController()
+
+    for (let attempt = 0; attempt < maxAttempts; attempt++) {
+      if (this.inFlightPoll.signal.aborted) {
+        throw new Error('OAuth flow cancelled')
+      }
+
+      const body = objectToUrlEncoded({
+        grant_type: 'urn:ietf:params:oauth:grant-type:device_code',
+        client_id: QWEN_OAUTH_CLIENT_ID,
+        device_code: deviceCode.device_code,
+        code_verifier: codeVerifier,
+      })
+
+      const response = await fetch(QWEN_OAUTH_TOKEN_ENDPOINT, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/x-www-form-urlencoded',
+          'Accept': 'application/json',
+        },
+        body,
+      })
+
+      const text = await response.text()
+      let data: Record<string, unknown>
+      try {
+        data = JSON.parse(text)
+      } catch {
+        throw new Error(`Token poll failed: ${response.status} — ${text}`)
+      }
+
+      // authorization_pending — keep polling
+      if (response.status === 400 && data.error === 'authorization_pending') {
+        await new Promise((r) => setTimeout(r, pollInterval))
+        continue
+      }
+
+      // slow_down — increase interval
+      if (response.status === 429 && data.error === 'slow_down') {
+        await new Promise((r) => setTimeout(r, Math.min(pollInterval * 1.5, 10000)))
+        continue
+      }
+
+      // Success
+      if (response.ok && data.access_token) {
+        this.inFlightPoll = null
+        return {
+          accessToken: data.access_token as string,
+          refreshToken: (data.refresh_token as string) || '',
+          tokenType: (data.token_type as string) || 'Bearer',
+          resourceUrl: (data.resource_url as string) || 'portal.qwen.ai',
+          expiryDate: data.expires_in
+            ? Date.now() + (data.expires_in as number) * 1000
+            : Date.now() + 3600_000,
+        }
+      }
+
+      // Other error
+      this.inFlightPoll = null
+      throw new Error(`Token poll failed: ${(data as any).error || 'Unknown error'}`)
+    }
+
+    this.inFlightPoll = null
+    throw new Error('Authorization timed out. Please try again.')
+  }
+
+  /**
+   * Cancel the current OAuth flow if one is in progress.
+   */
+  cancel(): void {
+    if (this.inFlightPoll) {
+      this.inFlightPoll.abort()
+      this.inFlightPoll = null
+    }
+  }
+}

--- a/src/services/api/qwenProxy.ts
+++ b/src/services/api/qwenProxy.ts
@@ -1,0 +1,541 @@
+/**
+ * Internal Qwen OAuth proxy server — built into OpenClaude.
+ *
+ * Starts an HTTP server on localhost that handles:
+ * - Reading ~/.claude/qwen-oauth.json
+ * - Auto-refreshing tokens before expiry
+ * - Forwarding requests to DashScope with correct headers
+ * - Using Node.js https.Agent for proper TLS fingerprint
+ * - Model alias resolution (coder-model → qwen3-coder-plus)
+ * - max_tokens clamping per model limits
+ *
+ * Port rotation: tries 8080-8099 until a free port is found.
+ * Stores the active port in ~/.claude/qwen-proxy-port.json so
+ * multiple OpenClaude instances can discover and reuse it.
+ * Auto-cleanup: proxy stops on process exit/SIGINT/SIGTERM.
+ *
+ * This replaces the need for the external qwen-code-oai-proxy.
+ */
+
+import { createServer, type IncomingMessage, type ServerResponse } from 'node:http'
+import { Agent as HttpsAgent } from 'node:https'
+import { existsSync, readFileSync, writeFileSync, mkdirSync } from 'node:fs'
+import { homedir } from 'node:os'
+import { join } from 'node:path'
+import axios, { type AxiosResponse } from 'axios'
+import {
+  loadQwenCredentials,
+  shouldRefreshQwenToken,
+  refreshQwenAccessToken,
+  type QwenCredentials,
+} from './qwenAuth.js'
+
+// ============================================================
+// Constants
+// ============================================================
+
+export const QWEN_PROXY_PORT_MIN = 8080
+export const QWEN_PROXY_PORT_MAX = 8099
+
+const CLAUDE_DIR = join(homedir(), '.claude')
+const PORT_FILE = join(CLAUDE_DIR, 'qwen-proxy-port.json')
+
+// Fallback if resource_url is not in credentials
+const DEFAULT_QWEN_API_BASE_URL = 'https://dashscope.aliyuncs.com/compatible-mode/v1'
+const TOKEN_REFRESH_BUFFER_MS = 30 * 1000
+
+// Model aliases — same as qwen-code-oai-proxy
+const MODEL_ALIASES: Record<string, string> = {
+  'qwen3.5-plus': 'qwen3-coder-plus',
+  'qwen3.6-plus': 'qwen3-coder-plus',
+  'coder-model': 'qwen3-coder-plus',
+}
+
+// Max output tokens per model — same as qwen-code-oai-proxy
+const MODEL_LIMITS: Record<string, { maxTokens: number }> = {
+  'vision-model': { maxTokens: 32768 },
+  'qwen3-vl-plus': { maxTokens: 32768 },
+  'qwen3-vl-max': { maxTokens: 32768 },
+  'qwen3.5-plus': { maxTokens: 65536 },
+  'qwen3.6-plus': { maxTokens: 65536 },
+  'qwen3-coder-plus': { maxTokens: 65536 },
+  'qwen3-coder-flash': { maxTokens: 65536 },
+}
+
+// Available models — returned by /v1/models
+const QWEN_MODELS = [
+  { id: 'qwen3-coder-plus', object: 'model', created: 1754686206, owned_by: 'qwen' },
+  { id: 'qwen3-coder-flash', object: 'model', created: 1754686206, owned_by: 'qwen' },
+  { id: 'qwen3.5-plus', object: 'model', created: 1754686206, owned_by: 'qwen' },
+  { id: 'qwen3.6-plus', object: 'model', created: 1754686206, owned_by: 'qwen' },
+  { id: 'coder-model', object: 'model', created: 1754686206, owned_by: 'qwen' },
+  { id: 'vision-model', object: 'model', created: 1754686206, owned_by: 'qwen' },
+]
+
+// ============================================================
+// HTTPS Agent — exact same config as qwen-code-oai-proxy
+// ============================================================
+
+const httpsAgent = new HttpsAgent({
+  keepAlive: true,
+  keepAliveMsecs: 1000,
+  maxSockets: 50,
+  maxFreeSockets: 10,
+  timeout: 60000,
+  freeSocketTimeout: 30000,
+} as any)
+
+// ============================================================
+// Port discovery & state management
+// ============================================================
+
+/**
+ * Check if a port is available by trying to bind to it.
+ */
+function isPortAvailable(port: number): Promise<boolean> {
+  return new Promise((resolve) => {
+    const server = createServer()
+    server.on('error', () => resolve(false))
+    server.listen(port, '127.0.0.1', () => {
+      server.close(() => resolve(true))
+    })
+  })
+}
+
+/**
+ * Find the first available port in range [QWEN_PROXY_PORT_MIN, QWEN_PROXY_PORT_MAX].
+ */
+async function findAvailablePort(): Promise<number | null> {
+  for (let port = QWEN_PROXY_PORT_MIN; port <= QWEN_PROXY_PORT_MAX; port++) {
+    if (await isPortAvailable(port)) {
+      return port
+    }
+  }
+  return null
+}
+
+/**
+ * Read the stored port from the port file.
+ */
+function readStoredPort(): number | null {
+  try {
+    if (!existsSync(PORT_FILE)) return null
+    const raw = readFileSync(PORT_FILE, 'utf8')
+    const data = JSON.parse(raw)
+    // Validate: port must be in range and file must be recent (last 24h)
+    if (typeof data.port !== 'number' || data.port < QWEN_PROXY_PORT_MIN || data.port > QWEN_PROXY_PORT_MAX) {
+      return null
+    }
+    const age = Date.now() - (data.timestamp || 0)
+    if (age > 24 * 60 * 60 * 1000) {
+      return null // Stale, ignore
+    }
+    return data.port
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Store the active port to the port file.
+ */
+function storePort(port: number): void {
+  try {
+    mkdirSync(CLAUDE_DIR, { recursive: true })
+    writeFileSync(PORT_FILE, JSON.stringify({ port, timestamp: Date.now() }), 'utf8')
+  } catch {
+    // Non-critical, ignore
+  }
+}
+
+/**
+ * Check if the proxy is already running by pinging the stored port.
+ */
+async function pingStoredPort(): Promise<boolean> {
+  const port = readStoredPort()
+  if (!port) return false
+  try {
+    const controller = new AbortController()
+    const timer = setTimeout(() => controller.abort(), 2000)
+    const res = await fetch(`http://localhost:${port}/v1/models`, { signal: controller.signal })
+    clearTimeout(timer)
+    return res.ok
+  } catch {
+    return false
+  }
+}
+
+// ============================================================
+// Token management with caching
+// ============================================================
+
+let cachedCredentials: QwenCredentials | null = null
+let lastCredentialsLoad = 0
+const CREDENTIALS_CACHE_MS = 5000
+
+async function getCredentials(): Promise<QwenCredentials> {
+  const now = Date.now()
+  if (cachedCredentials && now - lastCredentialsLoad < CREDENTIALS_CACHE_MS) {
+    if (shouldRefreshQwenToken(cachedCredentials)) {
+      cachedCredentials = await refreshQwenAccessToken(cachedCredentials)
+    }
+    return cachedCredentials
+  }
+
+  const creds = loadQwenCredentials()
+  if (!creds) {
+    throw new Error(
+      'No Qwen credentials found. Please authenticate with the Qwen CLI first: qwen',
+    )
+  }
+
+  cachedCredentials = creds
+  lastCredentialsLoad = now
+
+  if (shouldRefreshQwenToken(creds)) {
+    cachedCredentials = await refreshQwenToken(creds)
+  }
+
+  return cachedCredentials!
+}
+
+// ============================================================
+// Build DashScope headers — exact same as qwen-code-oai-proxy
+// ============================================================
+
+function buildDashScopeHeaders(accessToken: string, isStreaming = false): Record<string, string> {
+  const headers: Record<string, string> = {
+    'connection': 'keep-alive',
+    'accept': isStreaming ? 'text/event-stream' : 'application/json',
+    'authorization': `Bearer ${accessToken}`,
+    'content-type': 'application/json',
+    'user-agent': 'QwenCode/0.11.1 (linux; x64)',
+    'x-dashscope-authtype': 'qwen-oauth',
+    'x-dashscope-cachecontrol': 'enable',
+    'x-dashscope-useragent': 'QwenCode/0.11.1 (linux; x64)',
+    'x-stainless-arch': 'x64',
+    'x-stainless-lang': 'js',
+    'x-stainless-os': 'Linux',
+    'x-stainless-package-version': '5.11.0',
+    'x-stainless-retry-count': '1',
+    'x-stainless-runtime': 'node',
+    'x-stainless-runtime-version': 'v18.19.1',
+    'accept-language': '*',
+    'sec-fetch-mode': 'cors',
+  }
+  return headers
+}
+
+// ============================================================
+// Request processing — exact same logic as qwen-code-oai-proxy
+// ============================================================
+
+/**
+ * Build the API endpoint from credentials — same logic as qwen-code-oai-proxy.
+ * Uses resource_url from ~/.claude/qwen-oauth.json (e.g. "portal.qwen.ai").
+ */
+function getApiEndpoint(credentials: QwenCredentials): string {
+  if (credentials.resource_url) {
+    let endpoint = credentials.resource_url
+    if (!endpoint.startsWith('http')) {
+      endpoint = `https://${endpoint}`
+    }
+    if (!endpoint.endsWith('/v1')) {
+      endpoint = endpoint.endsWith('/') ? `${endpoint}v1` : `${endpoint}/v1`
+    }
+    return endpoint
+  }
+  return DEFAULT_QWEN_API_BASE_URL
+}
+
+function resolveModelAlias(model: string): string {
+  return MODEL_ALIASES[model] || model
+}
+
+function clampMaxTokens(model: string, maxTokens: number | undefined): number | undefined {
+  if (maxTokens === undefined) return undefined
+  const limit = MODEL_LIMITS[model]
+  if (limit && maxTokens > limit.maxTokens) {
+    return limit.maxTokens
+  }
+  return maxTokens
+}
+
+function resolveThinkingParams(request: Record<string, unknown>): Record<string, unknown> {
+  const result: Record<string, unknown> = {}
+
+  if (request.enable_thinking !== undefined) {
+    result.enable_thinking = request.enable_thinking
+  }
+  if (request.thinking_budget !== undefined) {
+    result.thinking_budget = request.thinking_budget
+  }
+
+  if (request.reasoning && typeof request.reasoning === 'object') {
+    const effort = (request.reasoning as any).effort
+    if (effort === 'none') {
+      result.enable_thinking = false
+    } else if (effort === 'low') {
+      result.enable_thinking = true
+      result.thinking_budget = 1024
+    } else if (effort === 'medium') {
+      result.enable_thinking = true
+      result.thinking_budget = 8192
+    } else if (effort === 'high') {
+      result.enable_thinking = true
+      // high = null (no budget limit)
+    }
+  }
+
+  return result
+}
+
+function buildDashScopePayload(request: Record<string, unknown>): Record<string, unknown> {
+  const model = resolveModelAlias((request.model as string) || 'qwen3-coder-plus')
+  const maxTokens = clampMaxTokens(model, request.max_tokens as number | undefined)
+
+  const payload: Record<string, unknown> = {
+    model,
+    messages: request.messages,
+    temperature: request.temperature,
+    max_tokens: maxTokens,
+    top_p: request.top_p,
+    top_k: request.top_k,
+    repetition_penalty: request.repetition_penalty,
+    stream: request.stream ?? false,
+    ...resolveThinkingParams(request),
+  }
+
+  if (request.tools && Array.isArray(request.tools) && request.tools.length > 0) {
+    payload.tools = request.tools
+  }
+  if (request.tool_choice) {
+    payload.tool_choice = request.tool_choice
+  }
+
+  return payload
+}
+
+// ============================================================
+// Request handler
+// ============================================================
+
+async function handleRequest(
+  req: IncomingMessage,
+  res: ServerResponse,
+): Promise<void> {
+  const url = req.url || '/'
+
+  // CORS preflight
+  if (req.method === 'OPTIONS') {
+    res.writeHead(204, {
+      'Access-Control-Allow-Origin': '*',
+      'Access-Control-Allow-Methods': 'GET, POST, OPTIONS',
+      'Access-Control-Allow-Headers': 'Content-Type, Authorization',
+    })
+    res.end()
+    return
+  }
+
+  // /v1/models — return available Qwen models
+  if (url === '/v1/models' || url === '/v1/models/') {
+    res.writeHead(200, {
+      'Content-Type': 'application/json',
+      'Access-Control-Allow-Origin': '*',
+    })
+    res.end(JSON.stringify({
+      object: 'list',
+      data: QWEN_MODELS,
+    }))
+    return
+  }
+
+  // /v1/chat/completions — forward to DashScope
+  if (url === '/v1/chat/completions' || url === '/v1/chat/completions/') {
+    if (req.method !== 'POST') {
+      res.writeHead(405, {
+        'Content-Type': 'application/json',
+        'Access-Control-Allow-Origin': '*',
+      })
+      res.end(JSON.stringify({ error: { message: 'Method not allowed', type: 'invalid_request_error' } }))
+      return
+    }
+
+    // Read body
+    let body = ''
+    for await (const chunk of req) {
+      body += chunk.toString()
+    }
+
+    let parsed: Record<string, unknown>
+    try {
+      parsed = JSON.parse(body)
+    } catch {
+      res.writeHead(400, {
+        'Content-Type': 'application/json',
+        'Access-Control-Allow-Origin': '*',
+      })
+      res.end(JSON.stringify({ error: { message: 'Invalid JSON', type: 'invalid_request_error' } }))
+      return
+    }
+
+    const isStreaming = parsed.stream === true
+
+    try {
+      const credentials = await getCredentials()
+      const accessToken = credentials.access_token
+      const apiEndpoint = getApiEndpoint(credentials)
+      const payload = buildDashScopePayload(parsed)
+
+      const response: AxiosResponse = await axios.post(
+        `${apiEndpoint}/chat/completions`,
+        payload,
+        {
+          headers: buildDashScopeHeaders(accessToken, isStreaming),
+          responseType: 'text',
+          transformResponse: [(data: string) => data],
+          timeout: 300000,
+          httpsAgent,
+        },
+      )
+
+      res.writeHead(response.status, {
+        'Content-Type': 'application/json',
+        'Access-Control-Allow-Origin': '*',
+      })
+      res.end(response.data)
+    } catch (error: any) {
+      const status = error.response?.status || 500
+      const bodyText = error.response?.data
+      const parsedError = typeof bodyText === 'string' ? (() => {
+        try { return JSON.parse(bodyText) } catch { return { error: { message: bodyText, type: 'internal_error' } } }
+      })() : (bodyText || { error: { message: error.message, type: 'internal_error' } })
+
+      res.writeHead(status, {
+        'Content-Type': 'application/json',
+        'Access-Control-Allow-Origin': '*',
+      })
+      res.end(JSON.stringify(parsedError))
+    }
+    return
+  }
+
+  // Unknown route
+  res.writeHead(404, {
+    'Content-Type': 'application/json',
+    'Access-Control-Allow-Origin': '*',
+  })
+  res.end(JSON.stringify({ error: { message: 'Not found', type: 'invalid_request_error' } }))
+}
+
+// ============================================================
+// Server lifecycle
+// ============================================================
+
+let proxyServer: ReturnType<typeof createServer> | null = null
+let activePort: number | null = null
+
+export function getActiveQwenProxyPort(): number | null {
+  return activePort
+}
+
+export function getQwenProxyBaseUrl(): string {
+  const port = activePort || readStoredPort() || QWEN_PROXY_PORT_MIN
+  return `http://localhost:${port}/v1`
+}
+
+export function isQwenProxyRunning(): boolean {
+  return proxyServer !== null && proxyServer.listening
+}
+
+/**
+ * Start the Qwen proxy with port rotation and auto-cleanup.
+ * Tries ports 8080-8099. Reuses an existing running proxy if found.
+ */
+export async function startQwenProxy(): Promise<string> {
+  // Check if a proxy is already running on the stored port
+  if (await pingStoredPort()) {
+    const port = readStoredPort()!
+    activePort = port
+    return `http://localhost:${port}/v1`
+  }
+
+  // Close any previously running proxy in this process
+  if (proxyServer) {
+    await stopQwenProxy()
+  }
+
+  // Find an available port
+  const port = await findAvailablePort()
+  if (!port) {
+    throw new Error(
+      `No available port in range ${QWEN_PROXY_PORT_MIN}-${QWEN_PROXY_PORT_MAX} for Qwen proxy. ` +
+      `Another process may be using all ports in this range.`,
+    )
+  }
+
+  // Validate credentials before starting
+  const creds = loadQwenCredentials()
+  if (!creds || !creds.access_token) {
+    throw new Error(
+      'No Qwen credentials found. Please authenticate with the Qwen CLI first: qwen',
+    )
+  }
+
+  return new Promise((resolve, reject) => {
+    proxyServer = createServer(handleRequest)
+
+    proxyServer.on('error', (err: any) => {
+      if (err.code === 'EADDRINUSE') {
+        reject(new Error(`Port ${port} is already in use. Try again or close the other process.`))
+      } else {
+        reject(err)
+      }
+    })
+
+    proxyServer.listen(port, '127.0.0.1', () => {
+      activePort = port
+      storePort(port)
+
+      // Register cleanup handlers
+      registerCleanupHandlers()
+
+      resolve(`http://localhost:${port}/v1`)
+    })
+  })
+}
+
+export async function stopQwenProxy(): Promise<void> {
+  if (!proxyServer) return
+
+  return new Promise<void>((resolve) => {
+    proxyServer!.close(() => {
+      proxyServer = null
+      activePort = null
+      resolve()
+    })
+  })
+}
+
+// ============================================================
+// Cleanup on process exit
+// ============================================================
+
+let cleanupRegistered = false
+
+function registerCleanupHandlers(): void {
+  if (cleanupRegistered) return
+  cleanupRegistered = true
+
+  const cleanup = () => {
+    if (proxyServer) {
+      proxyServer.close()
+      proxyServer = null
+      activePort = null
+    }
+  }
+
+  process.on('SIGINT', cleanup)
+  process.on('SIGTERM', cleanup)
+  process.on('exit', cleanup)
+}

--- a/src/services/api/qwenProxy.ts
+++ b/src/services/api/qwenProxy.ts
@@ -185,7 +185,7 @@ async function getCredentials(): Promise<QwenCredentials> {
   const creds = loadQwenCredentials()
   if (!creds) {
     throw new Error(
-      'No Qwen credentials found. Please authenticate with the Qwen CLI first: qwen',
+      'No Qwen credentials found. Authenticate via /provider → Qwen Coder',
     )
   }
 
@@ -235,8 +235,8 @@ function buildDashScopeHeaders(accessToken: string, isStreaming = false): Record
  * Uses resource_url from ~/.claude/qwen-oauth.json (e.g. "portal.qwen.ai").
  */
 function getApiEndpoint(credentials: QwenCredentials): string {
-  if (credentials.resource_url) {
-    let endpoint = credentials.resource_url
+  if (credentials.resourceUrl) {
+    let endpoint = credentials.resourceUrl
     if (!endpoint.startsWith('http')) {
       endpoint = `https://${endpoint}`
     }
@@ -383,7 +383,7 @@ async function handleRequest(
 
     try {
       const credentials = await getCredentials()
-      const accessToken = credentials.access_token
+      const accessToken = credentials.accessToken
       const apiEndpoint = getApiEndpoint(credentials)
       const payload = buildDashScopePayload(parsed)
 
@@ -476,9 +476,9 @@ export async function startQwenProxy(): Promise<string> {
 
   // Validate credentials before starting
   const creds = loadQwenCredentials()
-  if (!creds || !creds.access_token) {
+  if (!creds || !creds.accessToken) {
     throw new Error(
-      'No Qwen credentials found. Please authenticate with the Qwen CLI first: qwen',
+      'No Qwen credentials found. Authenticate via /provider → Qwen Coder',
     )
   }
 

--- a/src/utils/providerValidation.ts
+++ b/src/utils/providerValidation.ts
@@ -6,13 +6,11 @@ import {
   resolveProviderRequest,
 } from '../services/api/providerConfig.js'
 import { getGlobalClaudeFile } from './env.js'
-import { isBareMode } from './envUtils.js'
 import {
   type GeminiResolvedCredential,
   resolveGeminiCredential,
 } from './geminiAuth.js'
-import { PROFILE_FILE_NAME } from './providerProfile.js'
-import { redactSecretValueForDisplay } from './providerSecrets.js'
+import { PROFILE_FILE_NAME, redactSecretValueForDisplay } from './providerProfile.js'
 
 function isEnvTruthy(value: string | undefined): boolean {
   if (!value) return false
@@ -84,7 +82,6 @@ export async function getProviderValidationError(
     ) => Promise<GeminiResolvedCredential>
   },
 ): Promise<string | null> {
-  const secretSource = env
   const useOpenAI = isEnvTruthy(env.CLAUDE_CODE_USE_OPENAI)
   const useGithub = isEnvTruthy(env.CLAUDE_CODE_USE_GITHUB)
 
@@ -134,17 +131,16 @@ export async function getProviderValidationError(
   if (request.transport === 'codex_responses') {
     const credentials = resolveCodexApiCredentials(env)
     if (!credentials.apiKey) {
-      const oauthHint = isBareMode() ? '' : ', choose Codex OAuth in /provider'
       const authHint = credentials.authPath
-        ? `${oauthHint} or put auth.json at ${credentials.authPath}`
-        : oauthHint
+        ? ` or put auth.json at ${credentials.authPath}`
+        : ''
       const safeModel =
-        redactSecretValueForDisplay(request.requestedModel, secretSource) ??
+        redactSecretValueForDisplay(request.requestedModel, env) ??
         'the requested model'
       return `Codex auth is required for ${safeModel}. Set CODEX_API_KEY${authHint}.`
     }
     if (!credentials.accountId) {
-      return 'Codex auth is missing chatgpt_account_id. Re-login with Codex OAuth, Codex CLI, or set CHATGPT_ACCOUNT_ID/CODEX_ACCOUNT_ID.'
+      return 'Codex auth is missing chatgpt_account_id. Re-login with Codex or set CHATGPT_ACCOUNT_ID/CODEX_ACCOUNT_ID.'
     }
     return null
   }
@@ -152,6 +148,10 @@ export async function getProviderValidationError(
   if (!env.OPENAI_API_KEY && !isLocalProviderUrl(request.baseUrl)) {
     const hasGithubToken = !!(env.GITHUB_TOKEN?.trim() || env.GH_TOKEN?.trim())
     if (useGithub && hasGithubToken) {
+      return null
+    }
+    // Qwen OAuth: uses ~/.claude/qwen-oauth.json, no API key needed
+    if (request.baseUrl.includes('portal.qwen.ai')) {
       return null
     }
     return getOpenAIMissingKeyMessage()


### PR DESCRIPTION
## Summary

Adds native Qwen Coder (OAuth) support to OpenClaude with a built-in HTTP proxy — no external dependencies, no API key, no separate process.

## How it works

1. User authenticates via Qwen CLI (`qwen` → `/auth`) or `/provider qwen-auth`
2. In OpenClaude: `/provider` → "Qwen Coder (OAuth)" → save
3. On first request, internal proxy starts automatically on port 8080-8099
4. Multiple instances auto-discover and share the same proxy
5. Proxy auto-cleans on process exit (SIGINT/SIGTERM)

## Features

- **Free Qwen Coder access** — 1M context window, 1000 req/day, zero cost
- **No API key needed** — uses Qwen CLI OAuth credentials
- **No external proxy** — built into OpenClaude process
- **Port rotation** — tries 8080-8099, prevents EADDRINUSE across terminals
- **Auto-discovery** — multiple instances detect and reuse existing proxy
- **Cleanup on exit** — closes proxy automatically when OpenClaude closes
- **DuckDuckGo HTML web search** — fixed for non-Anthropic providers

## Files changed

| File | Change |
|------|--------|
| `src/services/api/qwenProxy.ts` | Internal proxy server (383 lines) |
| `src/services/api/qwenOAuth.ts` | OAuth device code flow (333 lines) |
| `src/services/api/qwenAuth.ts` | Credential management |
| `src/services/api/openaiShim.ts` | Auto-starts proxy for Qwen OAuth |
| `src/commands/provider/provider.tsx` | Qwen OAuth in /provider |
| `README.md` | Setup instructions |

**Diff:** +1367 lines, -306 lines across 8 files