### PR TITLE
docs: add Star History chart to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,10 @@ OpenClaude is also mirrored to GitLawb:
 
 [Quick Start](#quick-start) | [Setup Guides](#setup-guides) | [Providers](#supported-providers) | [Source Build](#source-build-and-local-development) | [VS Code Extension](#vs-code-extension) | [Community](#community)
 
+## Star History
+
+[![Star History Chart](https://api.star-history.com/chart?repos=gitlawb/openclaude&type=date&legend=top-left)](https://www.star-history.com/?repos=gitlawb%2Fopenclaude&type=date&legend=top-left)
+
 ## Why OpenClaude
 
 - Use one CLI across cloud APIs and local model backends


### PR DESCRIPTION
 ## Summary

  - **What changed**: Added a "## Star History" section with an embedded growth chart to `README.md` (placed after the badges for high visibility).
  - **Why it changed**: To visually demonstrate the project's adoption and momentum, which has become a popular convention in open source READMEs.

  ## Impact

  - **user-facing impact**: Purely cosmetic — visitors to the GitHub repo will now see a nice star history chart.
  - **developer/maintainer impact**: None.

  ## Testing

  - [x] `bun run build`
  - [x] `bun run smoke`
  - [ ] focused tests: (not applicable — docs only)

  ## Notes

  - provider/model path tested: N/A
  - screenshots attached (if UI changed): N/A
  - follow-up work or known limitations: None

  Want me to use this to create the PR now?