### PR TITLE
feat: add ripgrep to Dockerfile for faster file searching

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,8 +36,8 @@ COPY --from=build /app/node_modules/ node_modules/
 COPY --from=build /app/package.json package.json
 COPY README.md ./
 
-# Install git — many CLI tool operations depend on it
-RUN apt-get update && apt-get install -y --no-install-recommends git \
+# Install git and ripgrep — many CLI tool operations depend on them
+RUN apt-get update && apt-get install -y --no-install-recommends git ripgrep \
     && rm -rf /var/lib/apt/lists/*
 
 # Run as non-root user


### PR DESCRIPTION
  Summary

   - What changed: Added the ripgrep package to the runtime stage of the
     Dockerfile.
   - Why it changed: Many OpenClaude CLI operations and agent tools rely on fast
     file searching. Since the base image is node:22-slim, ripgrep was missing,
     which could cause certain "search" or "grep" related tools to fail or
     perform suboptimally within the container.

  Impact

   - User-facing impact: Improved performance and reliability for file-searching
     tools when running OpenClaude via Docker.
   - Developer/Maintainer impact: Ensures the Docker environment has the
     necessary system dependencies to match the expected capabilities of the
     CLI.

  Testing

   - [x] bun run build (Verified during the multi-stage Docker build process)
   - [ ] bun run smoke
   - [x] Focused tests: Manually verified the image build with docker build -t
     openclaude:mac . and confirmed the binary is available in the final layer.

  Notes

   - Provider/model path tested: N/A (System dependency change).
   - Screenshots attached: N/A.
   - Follow-up work: None. The ripgrep binary is now correctly available for the
     node user in the container.
