### PR TITLE
ci: skip release-please on fork repositories

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,7 @@ concurrency:
 
 jobs:
   release-please:
+    if: ${{ github.repository == 'Gitlawb/openclaude' }}
     name: Release Please
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
This PR isolates the release workflow fork guard into its own change. It prevents release-please from running on forked repositories where `GITHUB_TOKEN` may not be available.