### PR TITLE
feat(web): add browser UI with modular server and session persistence

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,6 +228,37 @@ npm run dev:grpc:cli
 
 ---
 
+## Web Interface
+
+OpenClaude includes a browser-based web interface that provides a chat UI with real-time streaming, tool call visualization, and permission dialogs. It uses the same `QueryEngine` as the CLI and gRPC server.
+
+### Start the Web Server
+
+```bash
+npm run dev:web
+```
+
+Then open `http://localhost:3000` in your browser.
+
+### Configuration
+
+| Variable | Default | Description |
+| -------- | ------- | ----------- |
+| `WEB_PORT` | `3000` | HTTP server port |
+| `WEB_HOST` | `localhost` | Bind address |
+
+### Features
+
+- Real-time streaming responses via WebSocket
+- Markdown rendering with syntax highlighting
+- Collapsible tool call cards showing arguments and output
+- Permission prompts for sensitive tool operations
+- Multi-turn conversation support with session persistence
+- Responsive layout for desktop and mobile
+- Automatic WebSocket reconnection
+
+---
+
 ## Source Build And Local Development
 
 ```bash

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "dev:code": "bun run profile:code && bun run dev:profile",
     "dev:grpc": "bun run scripts/start-grpc.ts",
     "dev:grpc:cli": "bun run scripts/grpc-cli.ts",
+    "dev:web": "bun run scripts/start-web.ts",
     "start": "node dist/cli.mjs",
     "test": "bun test",
     "test:coverage": "bun test --coverage --coverage-reporter=lcov --coverage-dir=coverage --max-concurrency=1 && bun run scripts/render-coverage-heatmap.ts",

--- a/scripts/start-web.ts
+++ b/scripts/start-web.ts
@@ -1,0 +1,61 @@
+import { WebServer } from '../src/web/server.ts'
+import { init } from '../src/entrypoints/init.ts'
+
+Object.assign(globalThis, {
+  MACRO: {
+    VERSION: '0.3.0',
+    DISPLAY_VERSION: '0.3.0',
+    PACKAGE_URL: '@gitlawb/openclaude',
+  }
+})
+
+// Global cache scope and other experimental betas require internal API support
+// not available to external accounts. Disable by default for the web server.
+if (!process.env.CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS) {
+  process.env.CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS = '1'
+}
+
+async function main() {
+  console.log('Starting OpenClaude Web Server...')
+  await init()
+
+  const { enableConfigs } = await import('../src/utils/config.js')
+  enableConfigs()
+  const { applySafeConfigEnvironmentVariables } = await import('../src/utils/managedEnv.js')
+  applySafeConfigEnvironmentVariables()
+  const { hydrateGeminiAccessTokenFromSecureStorage } = await import('../src/utils/geminiCredentials.js')
+  hydrateGeminiAccessTokenFromSecureStorage()
+  const { hydrateGithubModelsTokenFromSecureStorage } = await import('../src/utils/githubModelsCredentials.js')
+  hydrateGithubModelsTokenFromSecureStorage()
+
+  const { buildStartupEnvFromProfile, applyProfileEnvToProcessEnv } = await import('../src/utils/providerProfile.js')
+  const { getProviderValidationError, validateProviderEnvOrExit } = await import('../src/utils/providerValidation.js')
+  const startupEnv = await buildStartupEnvFromProfile({ processEnv: process.env })
+  if (startupEnv !== process.env) {
+    const startupProfileError = await getProviderValidationError(startupEnv)
+    if (startupProfileError) {
+      console.warn(`Warning: ignoring saved provider profile. ${startupProfileError}`)
+    } else {
+      applyProfileEnvToProcessEnv(process.env, startupEnv)
+    }
+  }
+  // Force registered provider profile to take priority over .env keys.
+  // Bun loads .env into process.env before any code runs, which causes
+  // applyActiveProviderProfileFromConfig to skip (it sees existing flags).
+  // Forcing here ensures the OpenClaude-registered profile wins.
+  const { applyActiveProviderProfileFromConfig } = await import('../src/utils/providerProfiles.js')
+  applyActiveProviderProfileFromConfig(undefined, { force: true })
+
+  await validateProviderEnvOrExit()
+
+  const port = process.env.WEB_PORT ? parseInt(process.env.WEB_PORT, 10) : 3000
+  const host = process.env.WEB_HOST || 'localhost'
+  const server = new WebServer()
+
+  server.start(port, host)
+}
+
+main().catch((err) => {
+  console.error('Fatal error starting web server:', err)
+  process.exit(1)
+})

--- a/scripts/start-web.ts
+++ b/scripts/start-web.ts
@@ -1,11 +1,15 @@
+import { createRequire } from 'node:module'
 import { WebServer } from '../src/web/server.ts'
 import { init } from '../src/entrypoints/init.ts'
 
+const require = createRequire(import.meta.url)
+const pkg = require('../package.json') as { version: string; name: string }
+
 Object.assign(globalThis, {
   MACRO: {
-    VERSION: '0.3.0',
-    DISPLAY_VERSION: '0.3.0',
-    PACKAGE_URL: '@gitlawb/openclaude',
+    VERSION: pkg.version,
+    DISPLAY_VERSION: pkg.version,
+    PACKAGE_URL: pkg.name,
   }
 })
 

--- a/src/web/client/app.html
+++ b/src/web/client/app.html
@@ -1,0 +1,98 @@
+<div id="app">
+  <div class="sidebar">
+    <div class="sidebar-header">
+      <div class="logo">
+        <div class="logo-mark"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="white" stroke-width="2.5" stroke-linecap="round"><polyline points="4 17 10 11 4 5"/><line x1="12" y1="19" x2="20" y2="19"/></svg></div>
+        <div class="logo-wordmark"><em>Open</em>Claude<small>AI Coding Agent</small></div>
+      </div>
+      <button class="new-chat-btn" id="new-chat-btn">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg>
+        New conversation
+      </button>
+    </div>
+    <div class="sidebar-sessions" id="session-list"></div>
+    <div class="sidebar-footer">
+      <span id="token-display" class="token-count">0 tokens</span>
+      <span>v0.3.0</span>
+    </div>
+  </div>
+
+  <div class="main">
+    <div class="topbar">
+      <span class="topbar-title" id="topbar-title">New conversation</span>
+      <span class="provider-badge" id="provider-badge" style="display:none"></span>
+      <div class="model-select-wrap">
+        <select class="model-select" id="model-select" title="Select model">
+          <option value="">Default model</option>
+        </select>
+        <svg class="model-arrow" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="6 9 12 15 18 9"/></svg>
+      </div>
+      <div class="conn-badge">
+        <div class="conn-dot" id="conn-dot"></div>
+        <span id="conn-label">Connecting</span>
+      </div>
+    </div>
+
+    <div id="messages">
+      <div class="welcome" id="welcome">
+        <div class="welcome-logo"><svg width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="white" stroke-width="2.5" stroke-linecap="round"><polyline points="4 17 10 11 4 5"/><line x1="12" y1="19" x2="20" y2="19"/></svg></div>
+        <h2>Welcome to <em>OpenClaude</em></h2>
+        <p>Your AI coding agent, now in the browser. Ask questions, generate code, debug issues, or explore your codebase.</p>
+        <div class="suggestions">
+          <button class="suggest-btn" data-prompt="Explain the project structure and architecture">
+            <span class="suggest-title">Project overview</span>
+            <span class="suggest-desc">Understand the codebase architecture</span>
+          </button>
+          <button class="suggest-btn" data-prompt="Find potential bugs and suggest fixes">
+            <span class="suggest-title">Find bugs</span>
+            <span class="suggest-desc">Scan for issues and vulnerabilities</span>
+          </button>
+          <button class="suggest-btn" data-prompt="Write comprehensive tests for the main modules">
+            <span class="suggest-title">Write tests</span>
+            <span class="suggest-desc">Generate test suites for your code</span>
+          </button>
+          <button class="suggest-btn" data-prompt="Suggest performance improvements and refactoring">
+            <span class="suggest-title">Optimize code</span>
+            <span class="suggest-desc">Improve performance and readability</span>
+          </button>
+        </div>
+      </div>
+    </div>
+
+    <div id="typing">
+      <div class="typing-inner">
+        <div class="msg-avatar bot-av" style="width:28px;height:28px;border-radius:8px"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="white" stroke-width="2.5" stroke-linecap="round"><polyline points="4 17 10 11 4 5"/><line x1="12" y1="19" x2="20" y2="19"/></svg></div>
+        <div class="typing-dots"><span></span><span></span><span></span></div>
+      </div>
+    </div>
+
+    <div id="input-area">
+      <div class="input-container">
+        <div class="cwd-bar">
+          <span class="cwd-label"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z"/></svg> Directory</span>
+          <input type="text" class="cwd-value" id="cwd-input" spellcheck="false">
+        </div>
+        <div class="img-preview-bar" id="img-preview" style="display:none"></div>
+        <div class="input-box">
+          <textarea id="user-input" rows="1" placeholder="Ask anything about your code..." autofocus></textarea>
+          <input type="file" id="file-input" accept="image/*" multiple style="display:none">
+          <div class="input-actions">
+            <button class="input-btn" id="attach-btn" title="Attach image">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><path d="M21.44 11.05l-9.19 9.19a6 6 0 0 1-8.49-8.49l9.19-9.19a4 4 0 0 1 5.66 5.66l-9.2 9.19a2 2 0 0 1-2.83-2.83l8.49-8.48"/></svg>
+            </button>
+            <button class="input-btn" id="send-btn" title="Send (Enter)">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><line x1="22" y1="2" x2="11" y2="13"/><polygon points="22 2 15 22 11 13 2 9 22 2"/></svg>
+            </button>
+            <button class="input-btn" id="cancel-btn" title="Stop generating">
+              <svg viewBox="0 0 24 24" fill="currentColor"><rect x="6" y="6" width="12" height="12" rx="2"/></svg>
+            </button>
+          </div>
+        </div>
+        <div class="input-footer">
+          <span>Shift + Enter for new line</span>
+          <span id="token-info"></span>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/src/web/client/app.html
+++ b/src/web/client/app.html
@@ -13,7 +13,7 @@
     <div class="sidebar-sessions" id="session-list"></div>
     <div class="sidebar-footer">
       <span id="token-display" class="token-count">0 tokens</span>
-      <span>v0.3.0</span>
+      <span id="version-label">v0.0.0</span>
     </div>
   </div>
 

--- a/src/web/client/app.js
+++ b/src/web/client/app.js
@@ -137,9 +137,15 @@
     var proto = location.protocol === 'https:' ? 'wss:' : 'ws:';
     ws = new WebSocket(proto + '//' + location.host);
     ws.onopen = function() { connDot.classList.add('ok'); connLabel.textContent = 'Connected' };
-    ws.onclose = function() {
-      connDot.classList.remove('ok'); connLabel.textContent = 'Reconnecting...';
-      streaming = false; updateUI(); setTimeout(connect, 2000);
+    ws.onclose = function(ev) {
+      connDot.classList.remove('ok');
+      streaming = false; updateUI();
+      if (ev.code === 4401) {
+        connLabel.textContent = 'Unauthorized';
+        return;
+      }
+      connLabel.textContent = 'Reconnecting...';
+      setTimeout(connect, 2000);
     };
     ws.onerror = function() { ws.close() };
     ws.onmessage = function(ev) { try { handleMsg(JSON.parse(ev.data)) } catch(e) { console.error(e) } };
@@ -225,14 +231,14 @@
 
   function renderMd(el, text) {
     try {
-      el.innerHTML = marked.parse(text);
+      el.innerHTML = DOMPurify.sanitize(marked.parse(text));
       el.querySelectorAll('pre').forEach(function(pre) {
         if (pre.querySelector('.code-header')) return;
         var codeEl = pre.querySelector('code');
         var lang = '';
         if (codeEl) {
           var cls = codeEl.className || '';
-          var m = cls.match(/language-(\\w+)/);
+          var m = cls.match(/language-(\w+)/);
           if (m) lang = m[1];
           hljs.highlightElement(codeEl);
         }
@@ -288,7 +294,7 @@
       var sep = document.createElement('div'); sep.className = 'tool-output-sep';
       e.body.appendChild(sep);
       var pre = document.createElement('pre');
-      pre.textContent = output.length > 2000 ? output.slice(0, 2000) + '\\n... (truncated)' : output;
+      pre.textContent = output.length > 2000 ? output.slice(0, 2000) + '\n... (truncated)' : output;
       e.body.appendChild(pre);
     }
   }
@@ -296,17 +302,24 @@
   function showPerm(pid, question, toolName) {
     var ov = document.createElement('div'); ov.className = 'perm-overlay';
     var card = document.createElement('div'); card.className = 'perm-card';
-    card.innerHTML = '<div class="perm-icon">&#9888;&#65039;</div>' +
-      '<h3>Permission Required</h3>' +
-      '<p>' + esc(question) + '</p>' +
-      '<div class="perm-actions">' +
-      '<button class="btn-deny" id="pd">Deny</button>' +
-      '<button class="btn-allow" id="po" style="background:var(--blue);color:#fff">Allow once</button>' +
-      '<button class="btn-allow" id="ps">Allow for session</button></div>';
+
+    var icon = document.createElement('div'); icon.className = 'perm-icon'; icon.textContent = '\u26A0\uFE0F';
+    var h3 = document.createElement('h3'); h3.textContent = 'Permission Required';
+    var p = document.createElement('p'); p.textContent = question;
+    var actions = document.createElement('div'); actions.className = 'perm-actions';
+
+    var denyBtn = document.createElement('button'); denyBtn.className = 'btn-deny'; denyBtn.textContent = 'Deny';
+    var onceBtn = document.createElement('button'); onceBtn.className = 'btn-allow'; onceBtn.textContent = 'Allow once';
+    onceBtn.style.cssText = 'background:var(--blue);color:#fff';
+    var sessBtn = document.createElement('button'); sessBtn.className = 'btn-allow'; sessBtn.textContent = 'Allow for session';
+
+    actions.appendChild(denyBtn); actions.appendChild(onceBtn); actions.appendChild(sessBtn);
+    card.appendChild(icon); card.appendChild(h3); card.appendChild(p); card.appendChild(actions);
     ov.appendChild(card); document.body.appendChild(ov);
-    card.querySelector('#ps').onclick = function() { wsReply(pid,'session'); ov.remove() };
-    card.querySelector('#po').onclick = function() { wsReply(pid,'yes'); ov.remove() };
-    card.querySelector('#pd').onclick = function() { wsReply(pid,'no'); ov.remove() };
+
+    sessBtn.onclick = function() { wsReply(pid,'session'); ov.remove() };
+    onceBtn.onclick = function() { wsReply(pid,'yes'); ov.remove() };
+    denyBtn.onclick = function() { wsReply(pid,'no'); ov.remove() };
     ov.onclick = function(e) { if (e.target === ov) { wsReply(pid,'no'); ov.remove() } };
   }
 
@@ -398,7 +411,7 @@
     if (streaming) return;
     var existing = sessions.find(function(s) { return s.id === savedEntry.id });
     if (existing) { switchSession(existing.id); return }
-    fetch('/api/sessions/' + index).then(function(r) { return r.json() }).then(function(data) {
+    fetch('/api/sessions/' + encodeURIComponent(savedEntry.id)).then(function(r) { return r.json() }).then(function(data) {
       if (!data || !data.messages) return;
       var s = { id: data.id || savedEntry.id, title: savedEntry.title || data.title || 'Untitled', messages: data.messages, ts: Date.now(), savedIndex: index };
       sessions.push(s);

--- a/src/web/client/app.js
+++ b/src/web/client/app.js
@@ -1,0 +1,590 @@
+(function() {
+  var $ = function(s) { return document.getElementById(s) };
+  var messagesEl = $('messages');
+  var inputEl = $('user-input');
+  var sendBtn = $('send-btn');
+  var cancelBtn = $('cancel-btn');
+  var typingEl = $('typing');
+  var connDot = $('conn-dot');
+  var connLabel = $('conn-label');
+  var tokenInfo = $('token-info');
+  var tokenDisplay = $('token-display');
+  var welcomeEl = $('welcome');
+  var topbarTitle = $('topbar-title');
+  var sessionListEl = $('session-list');
+  var providerBadge = $('provider-badge');
+  var cwdInput = $('cwd-input');
+  var modelSelect = $('model-select');
+  var attachBtn = $('attach-btn');
+  var fileInput = $('file-input');
+  var imgPreview = $('img-preview');
+  var currentCwd = '';
+  var savedSessions = [];
+  var pendingImages = [];
+  var noProvider = false;
+  var logoSvg = '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="white" stroke-width="2.5" stroke-linecap="round"><polyline points="4 17 10 11 4 5"/><line x1="12" y1="19" x2="20" y2="19"/></svg>';
+
+  marked.setOptions({
+    highlight: function(code, lang) {
+      if (lang && hljs.getLanguage(lang)) return hljs.highlight(code, { language: lang }).value;
+      return hljs.highlightAuto(code).value;
+    },
+    breaks: true, gfm: true
+  });
+
+  var ws = null, streaming = false, currentBubble = null, currentText = '';
+  var totalIn = 0, totalOut = 0;
+  var toolCards = new Map(), sessions = [], activeSession = null;
+  var STORAGE_KEY = 'openclaude_sessions';
+  /** Session ids removed from the sidebar; History comes from the server and would reappear without this. */
+  var HIDDEN_IDS_KEY = 'openclaude_hidden_session_ids';
+
+  function loadHiddenSessionIds() {
+    try {
+      var raw = localStorage.getItem(HIDDEN_IDS_KEY);
+      if (!raw) return new Set();
+      var arr = JSON.parse(raw);
+      if (!Array.isArray(arr)) return new Set();
+      return new Set(arr.map(function(x) { return String(x) }));
+    } catch (e) {
+      return new Set();
+    }
+  }
+
+  var hiddenSessionIds = loadHiddenSessionIds();
+
+  function persistHiddenSessionIds() {
+    try {
+      localStorage.setItem(HIDDEN_IDS_KEY, JSON.stringify(Array.from(hiddenSessionIds)));
+    } catch (e) {}
+  }
+
+  function saveSessions() {
+    try {
+      var data = sessions.map(function(s) {
+        return { id: s.id, title: s.title, messages: s.messages, ts: s.ts, model: s.model || '' };
+      });
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(data));
+    } catch(e) {}
+  }
+
+  function loadSessionsFromStorage() {
+    try {
+      var raw = localStorage.getItem(STORAGE_KEY);
+      if (!raw) return;
+      var data = JSON.parse(raw);
+      if (!Array.isArray(data)) return;
+      sessions = data.filter(function(s) { return s && s.id && Array.isArray(s.messages) });
+      if (sessions.length > 0) {
+        activeSession = sessions[0];
+      }
+    } catch(e) {}
+  }
+
+  function newSession() {
+    var s = { id: crypto.randomUUID(), title: 'New conversation', messages: [], ts: Date.now(), model: modelSelect.value || '' };
+    sessions.unshift(s);
+    activeSession = s;
+    saveSessions();
+    renderSessions();
+    return s;
+  }
+
+  function renderSessions() {
+    sessionListEl.innerHTML = '';
+    sessions.forEach(function(s) {
+      var el = document.createElement('div');
+      el.className = 'session-item' + (activeSession && s.id === activeSession.id ? ' active' : '');
+      el.textContent = s.title;
+      el.addEventListener('click', function() { switchSession(s.id) });
+      sessionListEl.appendChild(el);
+    });
+  }
+
+  function switchSession(id) {
+    var s = sessions.find(function(x) { return x.id === id });
+    if (!s || streaming) return;
+    activeSession = s;
+    topbarTitle.textContent = s.title;
+    modelSelect.value = s.model || '';
+    messagesEl.innerHTML = '';
+    if (s.messages.length === 0) {
+      messagesEl.appendChild(welcomeEl); welcomeEl.style.display = 'flex';
+    } else {
+      welcomeEl.style.display = 'none';
+      s.messages.forEach(function(m) { addMessageEl(m.role, m.content, true) });
+    }
+    renderSessions();
+  }
+
+  $('new-chat-btn').addEventListener('click', function() {
+    if (streaming) return;
+    activeSession = newSession();
+    topbarTitle.textContent = 'New conversation';
+    messagesEl.innerHTML = '';
+    messagesEl.appendChild(welcomeEl); welcomeEl.style.display = 'flex';
+    renderSessions();
+  });
+
+  document.querySelectorAll('.suggest-btn').forEach(function(btn) {
+    btn.addEventListener('click', function() {
+      inputEl.value = btn.getAttribute('data-prompt');
+      sendMessage();
+    });
+  });
+
+  function connect() {
+    var proto = location.protocol === 'https:' ? 'wss:' : 'ws:';
+    ws = new WebSocket(proto + '//' + location.host);
+    ws.onopen = function() { connDot.classList.add('ok'); connLabel.textContent = 'Connected' };
+    ws.onclose = function() {
+      connDot.classList.remove('ok'); connLabel.textContent = 'Reconnecting...';
+      streaming = false; updateUI(); setTimeout(connect, 2000);
+    };
+    ws.onerror = function() { ws.close() };
+    ws.onmessage = function(ev) { try { handleMsg(JSON.parse(ev.data)) } catch(e) { console.error(e) } };
+  }
+
+  function handleMsg(msg) {
+    switch(msg.type) {
+      case 'config':
+        if (msg.cwd) { currentCwd = msg.cwd; cwdInput.value = msg.cwd }
+        if (msg.provider && msg.provider !== 'unknown') {
+          providerBadge.textContent = msg.model || msg.provider;
+          providerBadge.style.display = 'inline-flex';
+        }
+        if (msg.noProvider) {
+          noProvider = true;
+          $('input-area').classList.add('input-disabled');
+          var w = $('welcome');
+          if (w) {
+            var sug = w.querySelector('.suggestions');
+            if (sug) sug.innerHTML = '<div class="no-provider-msg"><h3>No API Key Configured</h3><p>Run <code>openclaude</code> in your terminal to set up a provider, or add an API key to your <code>.env</code> file.</p></div>';
+          }
+        }
+        break;
+      case 'text_chunk':
+        if (!currentBubble) { currentBubble = addMessageEl('assistant', ''); currentText = '' }
+        currentText += msg.text;
+        renderMd(currentBubble, currentText);
+        scrollEnd();
+        break;
+      case 'tool_start': mkToolCard(msg.toolUseId, msg.toolName, msg.args); scrollEnd(); break;
+      case 'tool_result': finishToolCard(msg.toolUseId, msg.output, msg.isError); scrollEnd(); break;
+      case 'action_required': showPerm(msg.promptId, msg.question, msg.toolName); break;
+      case 'done':
+        if (currentText) {
+          activeSession.messages.push({ role:'assistant', content:currentText });
+          if (activeSession.messages.length === 2) {
+            activeSession.title = activeSession.messages[0].content.slice(0, 48);
+            topbarTitle.textContent = activeSession.title;
+            renderSessions();
+          }
+        }
+        if (currentBubble && msg.model) {
+          var modelTag = document.createElement('div');
+          modelTag.style.cssText = 'margin-top:10px;font-size:11px;color:var(--text-muted);font-family:JetBrains Mono,monospace;display:flex;align-items:center;gap:5px';
+          modelTag.innerHTML = '<svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><path d="M12 6v6l4 2"/></svg> ' + esc(msg.model);
+          currentBubble.appendChild(modelTag);
+        }
+        streaming = false; currentBubble = null; currentText = '';
+        totalIn += msg.promptTokens || 0; totalOut += msg.completionTokens || 0;
+        saveSessions();
+        updTokens(); updateUI();
+        break;
+      case 'error':
+        streaming = false; currentBubble = null; currentText = '';
+        var errEl = addMessageEl('assistant', '');
+        errEl.innerHTML = '<div style="color:var(--red);padding:12px 16px;background:var(--red-dim);border-radius:var(--radius-md);border:1px solid rgba(248,113,113,0.15);font-size:13px;line-height:1.5"><strong>Error:</strong> ' + esc(msg.message) + '</div>';
+        updateUI();
+        break;
+    }
+  }
+
+  function addMessageEl(role, content, replay) {
+    if (welcomeEl.style.display !== 'none' && !replay) welcomeEl.style.display = 'none';
+    var row = document.createElement('div'); row.className = 'msg-row';
+    var inner = document.createElement('div'); inner.className = 'msg-inner';
+    var av = document.createElement('div');
+    av.className = 'msg-avatar ' + (role === 'user' ? 'user-av' : 'bot-av');
+    if (role === 'user') av.textContent = 'U';
+    else av.innerHTML = logoSvg;
+    var body = document.createElement('div'); body.className = 'msg-body';
+    var meta = document.createElement('div'); meta.className = 'msg-meta';
+    meta.textContent = role === 'user' ? 'You' : 'OpenClaude';
+    var bubble = document.createElement('div');
+    bubble.className = 'msg-content' + (role === 'user' ? ' user-text' : '');
+    if (role === 'user') bubble.textContent = content;
+    else if (replay) renderMd(bubble, content);
+    body.appendChild(meta); body.appendChild(bubble);
+    inner.appendChild(av); inner.appendChild(body);
+    row.appendChild(inner); messagesEl.appendChild(row);
+    scrollEnd();
+    return bubble;
+  }
+
+  function renderMd(el, text) {
+    try {
+      el.innerHTML = marked.parse(text);
+      el.querySelectorAll('pre').forEach(function(pre) {
+        if (pre.querySelector('.code-header')) return;
+        var codeEl = pre.querySelector('code');
+        var lang = '';
+        if (codeEl) {
+          var cls = codeEl.className || '';
+          var m = cls.match(/language-(\\w+)/);
+          if (m) lang = m[1];
+          hljs.highlightElement(codeEl);
+        }
+        var hdr = document.createElement('div'); hdr.className = 'code-header';
+        var langSpan = document.createElement('span'); langSpan.textContent = lang || 'code';
+        var cpBtn = document.createElement('button'); cpBtn.className = 'copy-btn';
+        cpBtn.innerHTML = '<svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg> Copy';
+        cpBtn.addEventListener('click', function() {
+          navigator.clipboard.writeText(codeEl ? codeEl.textContent : pre.textContent);
+          cpBtn.innerHTML = '<svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="20 6 9 17 4 12"/></svg> Copied!';
+          cpBtn.classList.add('copied');
+          setTimeout(function() {
+            cpBtn.innerHTML = '<svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg> Copy';
+            cpBtn.classList.remove('copied');
+          }, 2000);
+        });
+        hdr.appendChild(langSpan); hdr.appendChild(cpBtn);
+        pre.insertBefore(hdr, pre.firstChild);
+      });
+    } catch(e) { el.textContent = text }
+  }
+
+  function mkToolCard(id, name, args) {
+    var card = document.createElement('div'); card.className = 'tool-card';
+    var hdr = document.createElement('div'); hdr.className = 'tool-header';
+    var chev = document.createElement('div'); chev.className = 'tool-chevron';
+    chev.innerHTML = '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><polyline points="9 18 15 12 9 6"/></svg>';
+    var iconW = document.createElement('div'); iconW.className = 'tool-icon-wrap';
+    iconW.innerHTML = '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M14.7 6.3a1 1 0 0 0 0 1.4l1.6 1.6a1 1 0 0 0 1.4 0l3.77-3.77a6 6 0 0 1-7.94 7.94l-6.91 6.91a2.12 2.12 0 0 1-3-3l6.91-6.91a6 6 0 0 1 7.94-7.94l-3.76 3.76z"/></svg>';
+    var nm = document.createElement('span'); nm.className = 'tool-name'; nm.textContent = name;
+    var badge = document.createElement('span'); badge.className = 'tool-badge running'; badge.textContent = 'running';
+    hdr.appendChild(chev); hdr.appendChild(iconW); hdr.appendChild(nm); hdr.appendChild(badge);
+    var body = document.createElement('div'); body.className = 'tool-body';
+    var pre = document.createElement('pre');
+    try { pre.textContent = JSON.stringify(JSON.parse(args), null, 2) } catch(e) { pre.textContent = args }
+    body.appendChild(pre);
+    hdr.addEventListener('click', function() { chev.classList.toggle('open'); body.classList.toggle('open') });
+    card.appendChild(hdr); card.appendChild(body);
+    var row = document.createElement('div'); row.className = 'msg-row';
+    var inner = document.createElement('div'); inner.className = 'msg-inner';
+    var sp = document.createElement('div'); sp.style.cssText = 'width:32px;flex-shrink:0';
+    var wrap = document.createElement('div'); wrap.style.cssText = 'flex:1;min-width:0';
+    wrap.appendChild(card); inner.appendChild(sp); inner.appendChild(wrap);
+    row.appendChild(inner); messagesEl.appendChild(row);
+    toolCards.set(id, { badge:badge, body:body });
+  }
+
+  function finishToolCard(id, output, isErr) {
+    var e = toolCards.get(id); if (!e) return;
+    e.badge.className = 'tool-badge ' + (isErr ? 'error' : 'done');
+    e.badge.textContent = isErr ? 'error' : 'done';
+    if (output) {
+      var sep = document.createElement('div'); sep.className = 'tool-output-sep';
+      e.body.appendChild(sep);
+      var pre = document.createElement('pre');
+      pre.textContent = output.length > 2000 ? output.slice(0, 2000) + '\\n... (truncated)' : output;
+      e.body.appendChild(pre);
+    }
+  }
+
+  function showPerm(pid, question, toolName) {
+    var ov = document.createElement('div'); ov.className = 'perm-overlay';
+    var card = document.createElement('div'); card.className = 'perm-card';
+    card.innerHTML = '<div class="perm-icon">&#9888;&#65039;</div>' +
+      '<h3>Permission Required</h3>' +
+      '<p>' + esc(question) + '</p>' +
+      '<div class="perm-actions">' +
+      '<button class="btn-deny" id="pd">Deny</button>' +
+      '<button class="btn-allow" id="po" style="background:var(--blue);color:#fff">Allow once</button>' +
+      '<button class="btn-allow" id="ps">Allow for session</button></div>';
+    ov.appendChild(card); document.body.appendChild(ov);
+    card.querySelector('#ps').onclick = function() { wsReply(pid,'session'); ov.remove() };
+    card.querySelector('#po').onclick = function() { wsReply(pid,'yes'); ov.remove() };
+    card.querySelector('#pd').onclick = function() { wsReply(pid,'no'); ov.remove() };
+    ov.onclick = function(e) { if (e.target === ov) { wsReply(pid,'no'); ov.remove() } };
+  }
+
+  function wsReply(pid, text) { if (ws && ws.readyState === 1) ws.send(JSON.stringify({ type:'input', promptId:pid, reply:text })) }
+
+  function sendMessage() {
+    var text = inputEl.value.trim();
+    if ((!text && pendingImages.length === 0) || streaming || noProvider) return;
+    if (!text) text = 'Describe this image.';
+    var bubble = addMessageEl('user', text);
+    if (pendingImages.length > 0) {
+      pendingImages.forEach(function(img) {
+        var imgEl = document.createElement('img');
+        imgEl.src = 'data:' + img.mediaType + ';base64,' + img.data;
+        imgEl.className = 'user-image';
+        bubble.appendChild(imgEl);
+      });
+    }
+    activeSession.messages.push({ role:'user', content:text });
+    inputEl.value = ''; inputEl.style.height = 'auto';
+    streaming = true; toolCards.clear(); updateUI();
+    var reqCwd = cwdInput.value.trim() || currentCwd;
+    var reqModel = modelSelect.value || undefined;
+    var payload = { type:'request', message:text, sessionId:activeSession.id, cwd:reqCwd };
+    if (reqModel) payload.model = reqModel;
+    if (pendingImages.length > 0) payload.images = pendingImages;
+    if (ws && ws.readyState === 1) ws.send(JSON.stringify(payload));
+    pendingImages = [];
+    imgPreview.innerHTML = '';
+    imgPreview.style.display = 'none';
+  }
+
+  function cancelReq() {
+    if (ws && ws.readyState === 1) ws.send(JSON.stringify({ type:'cancel' }));
+    streaming = false; currentBubble = null; currentText = ''; updateUI();
+  }
+
+  function updateUI() {
+    sendBtn.style.display = streaming ? 'none' : 'flex';
+    cancelBtn.style.display = streaming ? 'flex' : 'none';
+    sendBtn.disabled = streaming;
+    typingEl.classList.toggle('on', streaming);
+    if (!streaming) inputEl.focus();
+  }
+
+  function updTokens() {
+    tokenInfo.textContent = totalIn.toLocaleString() + ' in / ' + totalOut.toLocaleString() + ' out';
+    tokenDisplay.textContent = (totalIn + totalOut).toLocaleString() + ' tokens';
+  }
+
+  function scrollEnd() { messagesEl.scrollTop = messagesEl.scrollHeight }
+  function esc(s) { var d = document.createElement('div'); d.textContent = s; return d.innerHTML }
+
+  inputEl.addEventListener('keydown', function(e) { if (e.key === 'Enter' && !e.shiftKey) { e.preventDefault(); sendMessage() } });
+  inputEl.addEventListener('input', function() { this.style.height = 'auto'; this.style.height = Math.min(this.scrollHeight, 200) + 'px' });
+  sendBtn.addEventListener('click', sendMessage);
+  cancelBtn.addEventListener('click', cancelReq);
+  modelSelect.addEventListener('change', function() {
+    if (activeSession) activeSession.model = modelSelect.value;
+  });
+
+  function loadModels() {
+    fetch('/api/models').then(function(r) { return r.json() }).then(function(models) {
+      if (!Array.isArray(models)) return;
+      var current = modelSelect.value;
+      modelSelect.innerHTML = '<option value="">Default model</option>';
+      models.forEach(function(m) {
+        var opt = document.createElement('option');
+        opt.value = m.value || '';
+        opt.textContent = m.label || m.value;
+        if (m.description) opt.title = m.description;
+        modelSelect.appendChild(opt);
+      });
+      if (current) modelSelect.value = current;
+    }).catch(function() {});
+  }
+
+  function loadSavedSessions() {
+    fetch('/api/sessions').then(function(r) { return r.json() }).then(function(list) {
+      if (!Array.isArray(list)) return;
+      savedSessions = list.filter(function(s) {
+        return s && s.id && !hiddenSessionIds.has(String(s.id));
+      });
+      renderSessions();
+    }).catch(function() {});
+  }
+
+  function loadSavedSession(index, savedEntry) {
+    if (streaming) return;
+    var existing = sessions.find(function(s) { return s.id === savedEntry.id });
+    if (existing) { switchSession(existing.id); return }
+    fetch('/api/sessions/' + index).then(function(r) { return r.json() }).then(function(data) {
+      if (!data || !data.messages) return;
+      var s = { id: data.id || savedEntry.id, title: savedEntry.title || data.title || 'Untitled', messages: data.messages, ts: Date.now(), savedIndex: index };
+      sessions.push(s);
+      activeSession = s;
+      topbarTitle.textContent = s.title;
+      messagesEl.innerHTML = '';
+      welcomeEl.style.display = 'none';
+      s.messages.forEach(function(m) { addMessageEl(m.role, m.content, true) });
+      renderSessions();
+      scrollEnd();
+    }).catch(function(e) { console.error('Failed to load session', e) });
+  }
+
+  function deleteSession(id) {
+    hiddenSessionIds.add(String(id));
+    persistHiddenSessionIds();
+    sessions = sessions.filter(function(s) { return s.id !== id });
+    savedSessions = savedSessions.filter(function(s) { return s.id !== id });
+    if (activeSession && activeSession.id === id) {
+      if (sessions.length > 0) {
+        switchSession(sessions[0].id);
+      } else {
+        activeSession = newSession();
+        topbarTitle.textContent = 'New conversation';
+        messagesEl.innerHTML = '';
+        messagesEl.appendChild(welcomeEl); welcomeEl.style.display = 'flex';
+      }
+    }
+    saveSessions();
+    renderSessions();
+  }
+
+  function renameSession(id, newTitle) {
+    var s = sessions.find(function(x) { return x.id === id });
+    if (s) { s.title = newTitle }
+    var sv = savedSessions.find(function(x) { return x.id === id });
+    if (sv) { sv.title = newTitle }
+    if (activeSession && activeSession.id === id) { topbarTitle.textContent = newTitle }
+    saveSessions();
+    renderSessions();
+  }
+
+  function buildSessionEl(s, clickFn) {
+    var el = document.createElement('div');
+    el.className = 'session-item' + (activeSession && s.id === activeSession.id ? ' active' : '');
+
+    var titleSpan = document.createElement('span');
+    titleSpan.className = 'session-title';
+    var t = s.title || 'Untitled';
+    titleSpan.textContent = t.length > 40 ? t.slice(0, 40) + '...' : t;
+    titleSpan.addEventListener('click', clickFn);
+
+    var actions = document.createElement('div');
+    actions.className = 'session-actions';
+
+    var editBtn = document.createElement('button');
+    editBtn.className = 'session-act-btn';
+    editBtn.title = 'Rename';
+    editBtn.innerHTML = '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"/><path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z"/></svg>';
+    editBtn.addEventListener('click', function(e) {
+      e.stopPropagation();
+      titleSpan.style.display = 'none'; actions.style.display = 'none';
+      var inp = document.createElement('input');
+      inp.className = 'rename-input';
+      inp.value = s.title || '';
+      el.insertBefore(inp, actions);
+      inp.focus(); inp.select();
+      function finish() { renameSession(s.id, inp.value.trim() || s.title) }
+      inp.addEventListener('keydown', function(ev) { if (ev.key === 'Enter') finish(); if (ev.key === 'Escape') renderSessions() });
+      inp.addEventListener('blur', finish);
+    });
+
+    var delBtn = document.createElement('button');
+    delBtn.className = 'session-act-btn del';
+    delBtn.title = 'Delete';
+    delBtn.innerHTML = '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="3 6 5 6 21 6"/><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"/></svg>';
+    delBtn.addEventListener('click', function(e) { e.stopPropagation(); deleteSession(s.id) });
+
+    actions.appendChild(editBtn);
+    actions.appendChild(delBtn);
+    el.appendChild(titleSpan);
+    el.appendChild(actions);
+    return el;
+  }
+
+  renderSessions = function() {
+    sessionListEl.innerHTML = '';
+    sessions.forEach(function(s) {
+      sessionListEl.appendChild(buildSessionEl(s, function() { switchSession(s.id) }));
+    });
+    if (savedSessions.length > 0) {
+      var hasVisible = false;
+      savedSessions.forEach(function(sv) {
+        if (sessions.find(function(m) { return m.id === sv.id })) return;
+        if (!hasVisible) {
+          var div = document.createElement('div');
+          div.className = 'saved-divider';
+          div.textContent = 'History';
+          sessionListEl.appendChild(div);
+          hasVisible = true;
+        }
+        var idx = savedSessions.indexOf(sv);
+        sessionListEl.appendChild(buildSessionEl(
+          { id: sv.id, title: sv.title || 'Untitled' },
+          function() { loadSavedSession(idx, sv) }
+        ));
+      });
+    }
+  };
+
+  function addImageFromFile(file) {
+    if (!file || !file.type.startsWith('image/')) return;
+    var reader = new FileReader();
+    reader.onload = function() {
+      var result = reader.result;
+      var base64 = result.split(',')[1];
+      var mediaType = file.type || 'image/png';
+      pendingImages.push({ data: base64, mediaType: mediaType });
+      renderImagePreviews();
+    };
+    reader.readAsDataURL(file);
+  }
+
+  function renderImagePreviews() {
+    imgPreview.innerHTML = '';
+    if (pendingImages.length === 0) { imgPreview.style.display = 'none'; return }
+    imgPreview.style.display = 'flex';
+    pendingImages.forEach(function(img, i) {
+      var thumb = document.createElement('div');
+      thumb.className = 'img-thumb';
+      var imgEl = document.createElement('img');
+      imgEl.src = 'data:' + img.mediaType + ';base64,' + img.data;
+      var removeBtn = document.createElement('button');
+      removeBtn.className = 'img-thumb-remove';
+      removeBtn.textContent = 'x';
+      removeBtn.addEventListener('click', function() {
+        pendingImages.splice(i, 1);
+        renderImagePreviews();
+      });
+      thumb.appendChild(imgEl);
+      thumb.appendChild(removeBtn);
+      imgPreview.appendChild(thumb);
+    });
+  }
+
+  attachBtn.addEventListener('click', function() { fileInput.click() });
+  fileInput.addEventListener('change', function() {
+    Array.from(fileInput.files || []).forEach(addImageFromFile);
+    fileInput.value = '';
+  });
+
+  inputEl.addEventListener('paste', function(e) {
+    var items = e.clipboardData && e.clipboardData.items;
+    if (!items) return;
+    for (var i = 0; i < items.length; i++) {
+      if (items[i].type.startsWith('image/')) {
+        e.preventDefault();
+        addImageFromFile(items[i].getAsFile());
+        return;
+      }
+    }
+  });
+
+  var inputBox = inputEl.closest('.input-box');
+  inputBox.addEventListener('dragover', function(e) { e.preventDefault(); inputBox.style.borderColor = 'var(--accent)' });
+  inputBox.addEventListener('dragleave', function() { inputBox.style.borderColor = '' });
+  inputBox.addEventListener('drop', function(e) {
+    e.preventDefault(); inputBox.style.borderColor = '';
+    var files = e.dataTransfer && e.dataTransfer.files;
+    if (files) Array.from(files).forEach(addImageFromFile);
+  });
+
+  loadSessionsFromStorage();
+  if (sessions.length === 0) {
+    newSession();
+  } else {
+    activeSession = sessions[0];
+    topbarTitle.textContent = activeSession.title;
+    if (activeSession.model) modelSelect.value = activeSession.model;
+    if (activeSession.messages.length > 0) {
+      welcomeEl.style.display = 'none';
+      activeSession.messages.forEach(function(m) { addMessageEl(m.role, m.content, true) });
+    }
+  }
+  renderSessions();
+  loadModels();
+  loadSavedSessions();
+  connect();
+})();

--- a/src/web/client/styles.css
+++ b/src/web/client/styles.css
@@ -1,0 +1,428 @@
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap');
+
+*,*::before,*::after{box-sizing:border-box;margin:0;padding:0}
+
+:root {
+  --bg-base: #0a0a0f;
+  --bg-primary: #0e0e14;
+  --bg-secondary: #141420;
+  --bg-tertiary: #1c1c2e;
+  --bg-elevated: #20203a;
+  --bg-hover: #262645;
+  --bg-glass: rgba(20,20,32,0.75);
+  --border: rgba(255,255,255,0.06);
+  --border-active: rgba(139,92,246,0.4);
+  --text-primary: #ececf1;
+  --text-secondary: #9898b0;
+  --text-tertiary: #6b6b84;
+  --text-muted: #4a4a60;
+  --accent: #8b5cf6;
+  --accent-light: #a78bfa;
+  --accent-soft: #c4b5fd;
+  --accent-dim: rgba(139,92,246,0.1);
+  --accent-glow: rgba(139,92,246,0.2);
+  --gradient-accent: linear-gradient(135deg, #8b5cf6, #6d28d9, #4c1d95);
+  --gradient-surface: linear-gradient(180deg, rgba(139,92,246,0.04) 0%, transparent 100%);
+  --green: #34d399;
+  --green-dim: rgba(52,211,153,0.1);
+  --red: #f87171;
+  --red-dim: rgba(248,113,113,0.1);
+  --yellow: #fbbf24;
+  --yellow-dim: rgba(251,191,36,0.1);
+  --blue: #60a5fa;
+  --blue-dim: rgba(96,165,250,0.1);
+  --radius: 14px;
+  --radius-md: 10px;
+  --radius-sm: 8px;
+  --shadow-sm: 0 1px 2px rgba(0,0,0,0.3);
+  --shadow: 0 2px 8px rgba(0,0,0,0.3);
+  --shadow-lg: 0 8px 32px rgba(0,0,0,0.5);
+  --shadow-glow: 0 0 20px rgba(139,92,246,0.15);
+}
+
+html, body {
+  height:100%; background:var(--bg-base); color:var(--text-primary);
+  font-family:'Inter',system-ui,-apple-system,sans-serif; font-size:14px;
+  overflow:hidden; -webkit-font-smoothing:antialiased; -moz-osx-font-smoothing:grayscale;
+}
+a { color:var(--accent-light); text-decoration:none }
+a:hover { text-decoration:underline }
+::selection { background:var(--accent-glow); color:#fff }
+
+#app { display:flex; height:100vh; position:relative }
+
+/* ===== SIDEBAR ===== */
+.sidebar {
+  width:272px; background:var(--bg-primary); border-right:1px solid var(--border);
+  display:flex; flex-direction:column; flex-shrink:0; position:relative; z-index:10;
+}
+.sidebar::after {
+  content:''; position:absolute; top:0; right:0; bottom:0; width:1px;
+  background:linear-gradient(180deg, rgba(139,92,246,0.15), transparent 40%, transparent 60%, rgba(139,92,246,0.1));
+  pointer-events:none;
+}
+.sidebar-header { padding:20px 18px; border-bottom:1px solid var(--border) }
+.logo { display:flex; align-items:center; gap:11px; margin-bottom:16px }
+.logo-mark {
+  width:34px; height:34px; background:var(--gradient-accent); border-radius:10px;
+  display:flex; align-items:center; justify-content:center;
+  font-size:14px; font-weight:700; color:white; letter-spacing:-0.5px;
+  box-shadow:0 2px 12px rgba(139,92,246,0.3);
+}
+.logo-wordmark { font-size:15px; font-weight:600; letter-spacing:-0.4px }
+.logo-wordmark em { font-style:normal; color:var(--accent-soft); font-weight:700 }
+.logo-wordmark small { display:block; font-size:10.5px; font-weight:400; color:var(--text-muted); letter-spacing:0.3px; margin-top:1px }
+.new-chat-btn {
+  width:100%; padding:10px 14px; background:var(--bg-tertiary); border:1px solid var(--border);
+  border-radius:var(--radius-md); color:var(--text-secondary); font-size:13px; font-weight:500;
+  font-family:inherit; cursor:pointer; transition:all .2s; display:flex; align-items:center; gap:9px;
+}
+.new-chat-btn:hover { background:var(--bg-elevated); color:var(--text-primary); border-color:var(--border-active); box-shadow:var(--shadow-glow) }
+.new-chat-btn svg { width:15px; height:15px; opacity:.5 }
+.sidebar-sessions { flex:1; overflow-y:auto; padding:10px 8px; scrollbar-width:thin; scrollbar-color:var(--bg-elevated) transparent }
+.sidebar-sessions::-webkit-scrollbar { width:3px }
+.sidebar-sessions::-webkit-scrollbar-thumb { background:var(--bg-elevated); border-radius:3px }
+.session-item {
+  padding:8px 12px; border-radius:var(--radius-sm); font-size:13px; color:var(--text-tertiary);
+  cursor:pointer; transition:all .15s; margin-bottom:1px; font-weight:400;
+  border:1px solid transparent; display:flex; align-items:center; gap:6px; position:relative;
+}
+.session-item:hover { background:var(--bg-tertiary); color:var(--text-secondary) }
+.session-item.active { background:var(--accent-dim); color:var(--accent-light); border-color:rgba(139,92,246,0.12); font-weight:500 }
+.session-title { flex:1; overflow:hidden; text-overflow:ellipsis; white-space:nowrap }
+.session-actions { display:none; gap:2px; flex-shrink:0 }
+.session-item:hover .session-actions { display:flex }
+.session-act-btn {
+  width:22px; height:22px; border:none; background:transparent; color:var(--text-muted);
+  cursor:pointer; border-radius:4px; display:flex; align-items:center; justify-content:center;
+  transition:all .1s; padding:0;
+}
+.session-act-btn:hover { background:var(--bg-hover); color:var(--text-primary) }
+.session-act-btn.del:hover { color:var(--red) }
+.session-act-btn svg { width:12px; height:12px }
+.rename-input {
+  flex:1; background:var(--bg-primary); border:1px solid var(--border-active); border-radius:4px;
+  padding:2px 6px; color:var(--text-primary); font-family:inherit; font-size:12px; outline:none;
+  min-width:0;
+}
+.sidebar-footer {
+  padding:14px 18px; border-top:1px solid var(--border); font-size:11px; color:var(--text-muted);
+  display:flex; justify-content:space-between; align-items:center;
+}
+.sidebar-footer .token-count { font-family:'JetBrains Mono',monospace; font-size:10.5px; color:var(--text-tertiary) }
+
+/* ===== MAIN ===== */
+.main { flex:1; display:flex; flex-direction:column; min-width:0; background:var(--bg-base) }
+.topbar {
+  height:54px; border-bottom:1px solid var(--border); display:flex; align-items:center;
+  padding:0 24px; gap:12px; flex-shrink:0; background:var(--bg-primary);
+  backdrop-filter:blur(12px);
+}
+.topbar-title { font-size:13px; font-weight:500; color:var(--text-tertiary); letter-spacing:-0.1px }
+.conn-badge {
+  margin-left:auto; display:inline-flex; align-items:center; gap:7px; font-size:11px;
+  color:var(--text-muted); padding:5px 12px; background:var(--bg-secondary);
+  border-radius:20px; border:1px solid var(--border); font-weight:500;
+}
+.conn-dot {
+  width:7px; height:7px; border-radius:50%; background:var(--red);
+  transition:all .3s; box-shadow:0 0 6px rgba(248,113,113,0.4);
+}
+.conn-dot.ok { background:var(--green); box-shadow:0 0 6px rgba(52,211,153,0.5) }
+
+/* ===== MESSAGES ===== */
+#messages {
+  flex:1; overflow-y:auto; padding:28px 0; scrollbar-width:thin;
+  scrollbar-color:rgba(255,255,255,0.05) transparent;
+}
+#messages::-webkit-scrollbar { width:5px }
+#messages::-webkit-scrollbar-track { background:transparent }
+#messages::-webkit-scrollbar-thumb { background:rgba(255,255,255,0.06); border-radius:4px }
+#messages::-webkit-scrollbar-thumb:hover { background:rgba(255,255,255,0.1) }
+
+.msg-row { padding:6px 0; animation:msgSlide .3s cubic-bezier(.16,1,.3,1) }
+@keyframes msgSlide { from { opacity:0; transform:translateY(12px) } to { opacity:1; transform:none } }
+
+.msg-inner { max-width:820px; margin:0 auto; padding:0 28px; display:flex; gap:16px }
+
+.msg-avatar {
+  width:32px; height:32px; border-radius:10px; flex-shrink:0;
+  display:flex; align-items:center; justify-content:center;
+  font-size:12px; font-weight:600; margin-top:3px;
+}
+.msg-avatar.user-av { background:linear-gradient(135deg, #2563eb, #1d4ed8); color:rgba(255,255,255,.9) }
+.msg-avatar.bot-av { background:var(--gradient-accent); color:rgba(255,255,255,.9); box-shadow:0 2px 8px rgba(139,92,246,0.25) }
+
+.msg-body { flex:1; min-width:0 }
+.msg-meta { font-size:11px; color:var(--text-muted); margin-bottom:6px; font-weight:500; display:flex; align-items:center; gap:8px }
+.msg-content { line-height:1.75; color:var(--text-primary); font-size:14px }
+.msg-content.user-text { color:var(--text-secondary) }
+
+/* --- Markdown --- */
+.msg-content p { margin:0 0 12px }
+.msg-content p:last-child { margin-bottom:0 }
+.msg-content code {
+  font-family:'JetBrains Mono',monospace; font-size:12.5px; background:var(--bg-tertiary);
+  padding:2px 7px; border-radius:5px; border:1px solid var(--border); color:var(--accent-soft);
+}
+.msg-content pre {
+  position:relative; margin:14px 0; border-radius:var(--radius-md); overflow:hidden;
+  background:var(--bg-secondary) !important; border:1px solid var(--border);
+  box-shadow:var(--shadow-sm);
+}
+.msg-content pre code {
+  display:block; padding:18px; background:transparent !important; border:none;
+  font-size:12.5px; line-height:1.65; overflow-x:auto; white-space:pre; color:var(--text-primary);
+}
+.code-header {
+  display:flex; align-items:center; justify-content:space-between; padding:8px 14px;
+  background:var(--bg-tertiary); border-bottom:1px solid var(--border);
+  font-size:11px; color:var(--text-muted); font-family:'JetBrains Mono',monospace;
+}
+.copy-btn {
+  padding:4px 10px; background:var(--bg-secondary); border:1px solid var(--border);
+  border-radius:var(--radius-sm); color:var(--text-muted); font-size:11px;
+  font-family:inherit; cursor:pointer; transition:all .15s; display:flex; align-items:center; gap:5px;
+}
+.copy-btn:hover { background:var(--bg-hover); color:var(--text-primary); border-color:var(--border-active) }
+.copy-btn.copied { color:var(--green); border-color:rgba(52,211,153,0.3) }
+.msg-content ul, .msg-content ol { margin:8px 0 14px 22px }
+.msg-content li { margin-bottom:5px; line-height:1.7 }
+.msg-content blockquote {
+  border-left:3px solid var(--accent); padding:4px 0 4px 16px; margin:12px 0;
+  color:var(--text-secondary); font-style:italic;
+}
+.msg-content table { border-collapse:collapse; margin:12px 0; width:100%; font-size:13px }
+.msg-content th, .msg-content td { border:1px solid var(--border); padding:10px 14px; text-align:left }
+.msg-content th { background:var(--bg-tertiary); font-weight:600; color:var(--text-secondary); font-size:12px; text-transform:uppercase; letter-spacing:0.5px }
+.msg-content h1,.msg-content h2,.msg-content h3,.msg-content h4 { margin:20px 0 10px; font-weight:600; letter-spacing:-0.3px }
+.msg-content h1 { font-size:22px } .msg-content h2 { font-size:18px } .msg-content h3 { font-size:15px }
+.msg-content hr { border:none; border-top:1px solid var(--border); margin:20px 0 }
+.msg-content strong { font-weight:600; color:var(--text-primary) }
+
+/* ===== TOOL CARDS ===== */
+.tool-card {
+  margin:12px 0; border:1px solid var(--border); border-radius:var(--radius-md);
+  overflow:hidden; font-size:13px; background:var(--bg-secondary);
+  transition:border-color .2s;
+}
+.tool-card:hover { border-color:rgba(255,255,255,0.08) }
+.tool-header {
+  display:flex; align-items:center; gap:10px; padding:11px 16px;
+  cursor:pointer; user-select:none; transition:background .15s;
+}
+.tool-header:hover { background:rgba(255,255,255,0.02) }
+.tool-chevron {
+  width:16px; height:16px; color:var(--text-muted); transition:transform .25s cubic-bezier(.16,1,.3,1);
+  display:flex; align-items:center; justify-content:center;
+}
+.tool-chevron.open { transform:rotate(90deg) }
+.tool-icon-wrap {
+  width:24px; height:24px; border-radius:6px; display:flex; align-items:center; justify-content:center;
+  background:var(--blue-dim); flex-shrink:0;
+}
+.tool-icon-wrap svg { width:12px; height:12px; color:var(--blue) }
+.tool-name { font-family:'JetBrains Mono',monospace; font-weight:500; color:var(--text-primary); font-size:12.5px }
+.tool-badge {
+  margin-left:auto; font-size:10.5px; padding:3px 10px; border-radius:20px; font-weight:600;
+  letter-spacing:0.3px; text-transform:uppercase;
+}
+.tool-badge.running { background:var(--yellow-dim); color:var(--yellow) }
+.tool-badge.done { background:var(--green-dim); color:var(--green) }
+.tool-badge.error { background:var(--red-dim); color:var(--red) }
+.tool-body {
+  display:none; padding:14px 16px; background:var(--bg-primary); border-top:1px solid var(--border);
+  max-height:320px; overflow:auto;
+}
+.tool-body.open { display:block }
+.tool-body pre {
+  margin:0; white-space:pre-wrap; font-family:'JetBrains Mono',monospace;
+  font-size:12px; color:var(--text-secondary); line-height:1.65;
+}
+.tool-output-sep { border-top:1px dashed rgba(255,255,255,0.06); margin:12px 0; }
+
+/* ===== PERMISSION MODAL ===== */
+.perm-overlay {
+  position:fixed; inset:0; background:rgba(0,0,0,.7); backdrop-filter:blur(8px);
+  display:flex; align-items:center; justify-content:center; z-index:100;
+  animation:fadeIn .2s ease;
+}
+@keyframes fadeIn { from { opacity:0 } to { opacity:1 } }
+.perm-card {
+  background:var(--bg-secondary); border:1px solid var(--border); border-radius:20px;
+  padding:32px; max-width:480px; width:92%;
+  box-shadow:var(--shadow-lg), 0 0 40px rgba(139,92,246,0.08);
+  animation:modalIn .25s cubic-bezier(.16,1,.3,1);
+}
+@keyframes modalIn { from { opacity:0; transform:scale(.92) translateY(8px) } to { opacity:1; transform:none } }
+.perm-icon {
+  width:44px; height:44px; border-radius:12px; background:var(--yellow-dim);
+  display:flex; align-items:center; justify-content:center; font-size:20px; margin-bottom:16px;
+}
+.perm-card h3 { font-size:17px; font-weight:600; margin-bottom:8px; letter-spacing:-0.2px }
+.perm-card p { color:var(--text-secondary); margin-bottom:24px; font-size:13.5px; line-height:1.65 }
+.perm-actions { display:flex; gap:10px; justify-content:flex-end }
+.perm-actions button {
+  padding:10px 24px; border-radius:var(--radius-md); border:none; font-size:13px;
+  font-weight:600; font-family:inherit; cursor:pointer; transition:all .2s;
+}
+.btn-allow { background:var(--green); color:#000; font-weight:700 }
+.btn-allow:hover { filter:brightness(1.1); box-shadow:0 0 16px rgba(52,211,153,.3); transform:translateY(-1px) }
+.btn-deny { background:var(--bg-tertiary); color:var(--text-secondary); border:1px solid var(--border) }
+.btn-deny:hover { background:var(--bg-hover); color:var(--text-primary) }
+
+/* ===== TYPING ===== */
+#typing { display:none; padding:6px 0 }
+#typing.on { display:block }
+.typing-inner { max-width:820px; margin:0 auto; padding:0 28px; display:flex; gap:16px; align-items:center }
+.typing-dots { display:flex; gap:5px; align-items:center; padding:10px 0 }
+.typing-dots span {
+  width:6px; height:6px; background:var(--accent); border-radius:50%;
+  animation:typePulse 1.2s infinite ease-in-out;
+}
+.typing-dots span:nth-child(2) { animation-delay:.2s }
+.typing-dots span:nth-child(3) { animation-delay:.4s }
+@keyframes typePulse { 0%,80%,100% { transform:scale(.6); opacity:.3 } 40% { transform:scale(1); opacity:1 } }
+
+/* ===== WELCOME ===== */
+.welcome {
+  display:flex; flex-direction:column; align-items:center; justify-content:center;
+  flex:1; padding:48px 24px; text-align:center; position:relative;
+}
+.welcome::before {
+  content:''; position:absolute; width:300px; height:300px; border-radius:50%;
+  background:radial-gradient(circle, rgba(139,92,246,0.06) 0%, transparent 70%);
+  pointer-events:none; top:50%; left:50%; transform:translate(-50%,-60%);
+}
+.welcome-logo {
+  width:64px; height:64px; background:var(--gradient-accent); border-radius:18px;
+  display:flex; align-items:center; justify-content:center;
+  font-size:22px; font-weight:700; color:white; margin-bottom:24px;
+  box-shadow:0 4px 24px rgba(139,92,246,0.3), 0 0 48px rgba(139,92,246,0.1);
+  position:relative;
+}
+.welcome h2 { font-size:26px; font-weight:700; margin-bottom:8px; letter-spacing:-0.5px }
+.welcome h2 em { font-style:normal; color:var(--accent-light) }
+.welcome p { color:var(--text-tertiary); font-size:15px; max-width:420px; line-height:1.65; margin-bottom:32px }
+.suggestions { display:grid; grid-template-columns:1fr 1fr; gap:10px; max-width:480px; width:100% }
+.suggest-btn {
+  padding:14px 18px; background:var(--bg-secondary); border:1px solid var(--border);
+  border-radius:var(--radius-md); color:var(--text-secondary); font-size:13px;
+  font-family:inherit; cursor:pointer; transition:all .2s; text-align:left;
+  display:flex; flex-direction:column; gap:4px;
+}
+.suggest-btn:hover { border-color:var(--border-active); color:var(--text-primary); background:var(--bg-tertiary); box-shadow:var(--shadow-glow); transform:translateY(-1px) }
+.suggest-btn .suggest-title { font-weight:600; font-size:13px; color:var(--text-primary) }
+.suggest-btn .suggest-desc { font-size:11.5px; color:var(--text-muted); line-height:1.4 }
+
+/* ===== INPUT ===== */
+#input-area { padding:0 28px 24px; flex-shrink:0 }
+.input-container { max-width:820px; margin:0 auto }
+.input-box {
+  position:relative; background:var(--bg-secondary); border:1px solid var(--border);
+  border-radius:16px; transition:all .2s;
+  box-shadow:0 -8px 32px rgba(10,10,15,0.5);
+}
+.input-box:focus-within { border-color:var(--border-active); box-shadow:0 0 0 3px var(--accent-dim), 0 -8px 32px rgba(10,10,15,0.5) }
+#user-input {
+  width:100%; resize:none; background:transparent; border:none; padding:16px 56px 16px 20px;
+  color:var(--text-primary); font-family:'Inter',system-ui,sans-serif; font-size:14px;
+  line-height:1.6; max-height:200px; min-height:24px; outline:none;
+}
+#user-input::placeholder { color:var(--text-muted) }
+.input-actions { position:absolute; right:10px; bottom:10px; display:flex; gap:4px }
+.input-btn {
+  width:36px; height:36px; border-radius:10px; border:none; cursor:pointer;
+  display:flex; align-items:center; justify-content:center; transition:all .2s;
+}
+.input-btn svg { width:16px; height:16px }
+#send-btn { background:var(--accent); color:white }
+#send-btn:hover:not(:disabled) { background:var(--accent-light); box-shadow:0 2px 12px rgba(139,92,246,0.35); transform:translateY(-1px) }
+#send-btn:disabled { opacity:.25; cursor:not-allowed }
+#cancel-btn { display:none; background:transparent; border:1px solid var(--red); color:var(--red) }
+#cancel-btn:hover { background:var(--red); color:white }
+.input-footer { padding:8px 4px 0; font-size:11px; color:var(--text-muted); display:flex; justify-content:space-between }
+.input-footer span { font-family:'JetBrains Mono',monospace; font-size:10.5px }
+
+/* ===== MODEL SELECT ===== */
+.model-select-wrap { position:relative; margin-left:auto }
+.model-select {
+  appearance:none; background:var(--bg-tertiary); border:1px solid var(--border);
+  border-radius:var(--radius-sm); padding:5px 28px 5px 10px; color:var(--text-secondary);
+  font-family:'JetBrains Mono',monospace; font-size:11px; cursor:pointer;
+  outline:none; transition:all .15s; max-width:320px;
+}
+.model-select:hover { border-color:var(--border-active); color:var(--text-primary) }
+.model-select:focus { border-color:var(--accent); box-shadow:0 0 0 2px var(--accent-dim) }
+.model-select option { background:var(--bg-secondary); color:var(--text-primary) }
+.model-arrow {
+  position:absolute; right:8px; top:50%; transform:translateY(-50%);
+  pointer-events:none; color:var(--text-muted); width:12px; height:12px;
+}
+.saved-divider {
+  padding:8px 12px 4px; font-size:10.5px; font-weight:600; color:var(--text-muted);
+  text-transform:uppercase; letter-spacing:0.5px;
+}
+
+/* ===== CWD BAR ===== */
+.cwd-bar {
+  max-width:820px; margin:0 auto 8px; display:flex; align-items:center; gap:8px;
+  padding:0 4px; font-size:12px;
+}
+.cwd-label { color:var(--text-muted); font-weight:500; white-space:nowrap; display:flex; align-items:center; gap:5px }
+.cwd-label svg { width:13px; height:13px; color:var(--text-tertiary) }
+.cwd-value {
+  flex:1; background:transparent; border:1px solid transparent; border-radius:var(--radius-sm);
+  padding:5px 10px; color:var(--text-secondary); font-family:'JetBrains Mono',monospace; font-size:11.5px;
+  outline:none; transition:all .15s; min-width:0;
+}
+.cwd-value:hover { background:var(--bg-secondary); border-color:var(--border) }
+.cwd-value:focus { background:var(--bg-secondary); border-color:var(--border-active); color:var(--text-primary); box-shadow:0 0 0 2px var(--accent-dim) }
+.provider-badge {
+  display:inline-flex; align-items:center; gap:5px; font-size:11px; font-weight:600;
+  padding:4px 10px; border-radius:20px; background:var(--accent-dim); color:var(--accent-light);
+  border:1px solid rgba(139,92,246,0.15); text-transform:capitalize; white-space:nowrap;
+  font-family:'JetBrains Mono',monospace; letter-spacing:0.3px;
+}
+
+/* ===== IMAGE ATTACHMENTS ===== */
+.img-preview-bar {
+  display:flex; gap:8px; padding:8px 12px 0; flex-wrap:wrap; max-width:820px; margin:0 auto;
+}
+.img-thumb {
+  position:relative; width:64px; height:64px; border-radius:var(--radius-sm); overflow:hidden;
+  border:1px solid var(--border); background:var(--bg-tertiary); flex-shrink:0;
+}
+.img-thumb img { width:100%; height:100%; object-fit:cover }
+.img-thumb-remove {
+  position:absolute; top:-4px; right:-4px; width:18px; height:18px; border-radius:50%;
+  background:var(--red); color:#fff; border:2px solid var(--bg-secondary);
+  font-size:10px; cursor:pointer; display:flex; align-items:center; justify-content:center;
+  line-height:1; transition:transform .1s;
+}
+.img-thumb-remove:hover { transform:scale(1.15) }
+#attach-btn { background:transparent; border:1px solid var(--border); color:var(--text-muted) }
+#attach-btn:hover { border-color:var(--border-active); color:var(--accent-light) }
+.msg-content .user-image { max-width:200px; border-radius:var(--radius-sm); margin:8px 0; border:1px solid var(--border) }
+
+/* ===== NO PROVIDER ===== */
+.no-provider-msg {
+  padding:24px; background:var(--yellow-dim); border:1px solid rgba(251,191,36,0.2);
+  border-radius:var(--radius-md); text-align:center; max-width:480px; margin:0 auto;
+}
+.no-provider-msg h3 { color:var(--yellow); font-size:15px; margin-bottom:8px }
+.no-provider-msg p { color:var(--text-secondary); font-size:13px; line-height:1.6 }
+.no-provider-msg code {
+  background:var(--bg-tertiary); padding:2px 8px; border-radius:4px;
+  font-family:'JetBrains Mono',monospace; font-size:12px; color:var(--accent-light);
+}
+.input-disabled { opacity:.4; pointer-events:none }
+
+/* ===== RESPONSIVE ===== */
+@media(max-width:768px) {
+  .sidebar { display:none }
+  .msg-inner, .typing-inner { padding:0 16px }
+  #input-area { padding:0 16px 16px }
+  .msg-avatar { width:28px; height:28px; font-size:11px; border-radius:8px }
+  .suggestions { grid-template-columns:1fr }
+}

--- a/src/web/provider.ts
+++ b/src/web/provider.ts
@@ -1,0 +1,18 @@
+import http from 'node:http'
+
+export function detectProvider(): { provider: string; model: string } {
+  const env = process.env
+  if (env.CLAUDE_CODE_USE_GEMINI) return { provider: 'gemini', model: env.GEMINI_MODEL || env.OPENAI_MODEL || 'gemini' }
+  if (env.CLAUDE_CODE_USE_GITHUB) return { provider: 'github', model: env.OPENAI_MODEL || 'github-models' }
+  if (env.CLAUDE_CODE_USE_OPENAI) return { provider: 'openai', model: env.OPENAI_MODEL || 'openai' }
+  if (env.CLAUDE_CODE_USE_BEDROCK) return { provider: 'bedrock', model: env.ANTHROPIC_MODEL || 'bedrock' }
+  if (env.CLAUDE_CODE_USE_VERTEX) return { provider: 'vertex', model: env.ANTHROPIC_MODEL || 'vertex' }
+  if (env.ANTHROPIC_API_KEY) return { provider: 'anthropic', model: env.ANTHROPIC_MODEL || 'claude' }
+  if (env.OPENAI_API_KEY) return { provider: 'openai', model: env.OPENAI_MODEL || 'openai' }
+  return { provider: 'unknown', model: 'none' }
+}
+
+export function jsonResponse(res: http.ServerResponse, data: unknown, status = 200) {
+  res.writeHead(status, { 'Content-Type': 'application/json' })
+  res.end(JSON.stringify(data))
+}

--- a/src/web/provider.ts
+++ b/src/web/provider.ts
@@ -1,12 +1,23 @@
 import http from 'node:http'
+import { getActiveProviderProfile } from '../utils/providerProfiles.js'
 
+/**
+ * Detect the active provider using the canonical profile system, falling back
+ * to raw environment variables for provider modes (Gemini, GitHub, Bedrock,
+ * Vertex) that the profile system doesn't model directly.
+ */
 export function detectProvider(): { provider: string; model: string } {
+  const profile = getActiveProviderProfile()
+  if (profile) {
+    return { provider: profile.provider, model: profile.model || profile.provider }
+  }
+
   const env = process.env
   if (env.CLAUDE_CODE_USE_GEMINI) return { provider: 'gemini', model: env.GEMINI_MODEL || env.OPENAI_MODEL || 'gemini' }
   if (env.CLAUDE_CODE_USE_GITHUB) return { provider: 'github', model: env.OPENAI_MODEL || 'github-models' }
-  if (env.CLAUDE_CODE_USE_OPENAI) return { provider: 'openai', model: env.OPENAI_MODEL || 'openai' }
   if (env.CLAUDE_CODE_USE_BEDROCK) return { provider: 'bedrock', model: env.ANTHROPIC_MODEL || 'bedrock' }
   if (env.CLAUDE_CODE_USE_VERTEX) return { provider: 'vertex', model: env.ANTHROPIC_MODEL || 'vertex' }
+  if (env.CLAUDE_CODE_USE_OPENAI) return { provider: 'openai', model: env.OPENAI_MODEL || 'openai' }
   if (env.ANTHROPIC_API_KEY) return { provider: 'anthropic', model: env.ANTHROPIC_MODEL || 'claude' }
   if (env.OPENAI_API_KEY) return { provider: 'openai', model: env.OPENAI_MODEL || 'openai' }
   return { provider: 'unknown', model: 'none' }

--- a/src/web/routes.ts
+++ b/src/web/routes.ts
@@ -8,35 +8,37 @@ export async function handleHttpRequest(
   res: http.ServerResponse,
   html: string,
 ): Promise<boolean> {
-  if (req.method === 'GET' && (req.url === '/' || req.url === '')) {
+  const pathname = (req.url || '/').split('?')[0]
+
+  if (req.method === 'GET' && (pathname === '/' || pathname === '')) {
     res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' })
     res.end(html)
     return true
   }
 
-  if (req.method === 'GET' && req.url === '/api/health') {
+  if (req.method === 'GET' && pathname === '/api/health') {
     jsonResponse(res, { status: 'ok' })
     return true
   }
 
-  if (req.method === 'GET' && req.url === '/api/provider') {
+  if (req.method === 'GET' && pathname === '/api/provider') {
     jsonResponse(res, detectProvider())
     return true
   }
 
-  if (req.method === 'GET' && req.url === '/api/cwd') {
+  if (req.method === 'GET' && pathname === '/api/cwd') {
     jsonResponse(res, { cwd: process.cwd() })
     return true
   }
 
-  if (req.method === 'GET' && req.url === '/api/models') {
+  if (req.method === 'GET' && pathname === '/api/models') {
     try {
       const options = getModelOptions()
       const seen = new Set<string>()
       const models = options
-        .filter((o: any) => o.value !== null && o.value !== undefined)
-        .map((o: any) => ({ value: o.value, label: o.label, description: o.description }))
-        .filter((m: any) => {
+        .filter((o: Record<string, unknown>) => o.value !== null && o.value !== undefined)
+        .map((o: Record<string, unknown>) => ({ value: o.value as string, label: o.label as string, description: o.description as string }))
+        .filter((m) => {
           if (seen.has(m.value)) return false
           seen.add(m.value)
           return true
@@ -49,15 +51,14 @@ export async function handleHttpRequest(
     return true
   }
 
-  if (req.method === 'GET' && req.url === '/api/sessions') {
+  if (req.method === 'GET' && pathname === '/api/sessions') {
     try {
       const logs = await loadMessageLogs(30)
-      const sessions = logs.map((log: any) => ({
-        id: log.sessionId || String(log.value),
-        title: log.firstPrompt || 'Untitled',
-        date: log.modified?.toISOString() || log.date,
-        messageCount: log.messageCount || 0,
-        fullPath: log.fullPath || '',
+      const sessions = logs.map((log: Record<string, unknown>) => ({
+        id: (log.sessionId as string) || String(log.value),
+        title: (log.firstPrompt as string) || 'Untitled',
+        date: (log.modified instanceof Date ? log.modified.toISOString() : log.date) as string,
+        messageCount: (log.messageCount as number) || 0,
       }))
       jsonResponse(res, sessions)
     } catch {
@@ -66,28 +67,34 @@ export async function handleHttpRequest(
     return true
   }
 
-  const sessionMatch = req.url?.match(/^\/api\/sessions\/(\d+)$/)
+  const sessionMatch = pathname.match(/^\/api\/sessions\/([^/?]+)/)
   if (req.method === 'GET' && sessionMatch) {
     try {
-      const idx = parseInt(sessionMatch[1], 10)
+      const requestedId = decodeURIComponent(sessionMatch[1])
       const logs = await loadMessageLogs(30)
-      if (idx < 0 || idx >= logs.length) {
+      const logEntry = logs.find(
+        (log: Record<string, unknown>) =>
+          (log.sessionId && String(log.sessionId) === requestedId) ||
+          String(log.value) === requestedId,
+      )
+      if (!logEntry) {
         jsonResponse(res, { error: 'Session not found' }, 404)
         return true
       }
-      const fullLog = await loadFullLog(logs[idx])
-      const messages = (fullLog.messages || []).map((m: any) => {
+      const fullLog = await loadFullLog(logEntry)
+      interface MessageLike { role?: string; content?: string | { type?: string; text?: string }[] }
+      const messages = ((fullLog.messages || []) as MessageLike[]).map((m) => {
         let text = ''
         if (typeof m.content === 'string') {
           text = m.content
         } else if (Array.isArray(m.content)) {
           text = m.content
-            .filter((b: any) => b.type === 'text')
-            .map((b: any) => b.text || '')
+            .filter((b) => b.type === 'text')
+            .map((b) => b.text || '')
             .join('\n')
         }
         return { role: m.role, content: text }
-      }).filter((m: any) => m.content && (m.role === 'user' || m.role === 'assistant'))
+      }).filter((m) => m.content && (m.role === 'user' || m.role === 'assistant'))
       jsonResponse(res, {
         id: fullLog.sessionId || String(fullLog.value),
         title: fullLog.firstPrompt || 'Untitled',

--- a/src/web/routes.ts
+++ b/src/web/routes.ts
@@ -1,0 +1,104 @@
+import http from 'node:http'
+import { getModelOptions } from '../utils/model/modelOptions.js'
+import { loadMessageLogs, loadFullLog } from '../utils/sessionStorage.js'
+import { detectProvider, jsonResponse } from './provider.js'
+
+export async function handleHttpRequest(
+  req: http.IncomingMessage,
+  res: http.ServerResponse,
+  html: string,
+): Promise<boolean> {
+  if (req.method === 'GET' && (req.url === '/' || req.url === '')) {
+    res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' })
+    res.end(html)
+    return true
+  }
+
+  if (req.method === 'GET' && req.url === '/api/health') {
+    jsonResponse(res, { status: 'ok' })
+    return true
+  }
+
+  if (req.method === 'GET' && req.url === '/api/provider') {
+    jsonResponse(res, detectProvider())
+    return true
+  }
+
+  if (req.method === 'GET' && req.url === '/api/cwd') {
+    jsonResponse(res, { cwd: process.cwd() })
+    return true
+  }
+
+  if (req.method === 'GET' && req.url === '/api/models') {
+    try {
+      const options = getModelOptions()
+      const seen = new Set<string>()
+      const models = options
+        .filter((o: any) => o.value !== null && o.value !== undefined)
+        .map((o: any) => ({ value: o.value, label: o.label, description: o.description }))
+        .filter((m: any) => {
+          if (seen.has(m.value)) return false
+          seen.add(m.value)
+          return true
+        })
+      jsonResponse(res, models)
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : String(err)
+      jsonResponse(res, { error: message }, 500)
+    }
+    return true
+  }
+
+  if (req.method === 'GET' && req.url === '/api/sessions') {
+    try {
+      const logs = await loadMessageLogs(30)
+      const sessions = logs.map((log: any) => ({
+        id: log.sessionId || String(log.value),
+        title: log.firstPrompt || 'Untitled',
+        date: log.modified?.toISOString() || log.date,
+        messageCount: log.messageCount || 0,
+        fullPath: log.fullPath || '',
+      }))
+      jsonResponse(res, sessions)
+    } catch {
+      jsonResponse(res, [])
+    }
+    return true
+  }
+
+  const sessionMatch = req.url?.match(/^\/api\/sessions\/(\d+)$/)
+  if (req.method === 'GET' && sessionMatch) {
+    try {
+      const idx = parseInt(sessionMatch[1], 10)
+      const logs = await loadMessageLogs(30)
+      if (idx < 0 || idx >= logs.length) {
+        jsonResponse(res, { error: 'Session not found' }, 404)
+        return true
+      }
+      const fullLog = await loadFullLog(logs[idx])
+      const messages = (fullLog.messages || []).map((m: any) => {
+        let text = ''
+        if (typeof m.content === 'string') {
+          text = m.content
+        } else if (Array.isArray(m.content)) {
+          text = m.content
+            .filter((b: any) => b.type === 'text')
+            .map((b: any) => b.text || '')
+            .join('\n')
+        }
+        return { role: m.role, content: text }
+      }).filter((m: any) => m.content && (m.role === 'user' || m.role === 'assistant'))
+      jsonResponse(res, {
+        id: fullLog.sessionId || String(fullLog.value),
+        title: fullLog.firstPrompt || 'Untitled',
+        messages,
+      })
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : String(err)
+      jsonResponse(res, { error: message || 'Failed to load session' }, 500)
+    }
+    return true
+  }
+
+  return false
+}

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -1,0 +1,31 @@
+import http from 'node:http'
+import { WebSocketServer } from 'ws'
+import { getWebUI } from './ui.js'
+import { handleHttpRequest } from './routes.js'
+import { handleWebSocketConnection } from './wsHandler.js'
+
+export class WebServer {
+  private httpServer: http.Server
+  private wss: WebSocketServer
+  private sessions: Map<string, any[]> = new Map()
+
+  constructor() {
+    const html = getWebUI()
+
+    this.httpServer = http.createServer(async (req, res) => {
+      const handled = await handleHttpRequest(req, res, html)
+      if (handled) return
+      res.writeHead(404, { 'Content-Type': 'text/plain' })
+      res.end('Not Found')
+    })
+
+    this.wss = new WebSocketServer({ server: this.httpServer })
+    this.wss.on('connection', (ws: any) => handleWebSocketConnection(ws, this.sessions))
+  }
+
+  start(port: number = 3000, host: string = 'localhost') {
+    this.httpServer.listen(port, host, () => {
+      console.log(`OpenClaude Web running at http://${host}:${port}`)
+    })
+  }
+}

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -1,18 +1,45 @@
 import http from 'node:http'
+import { randomBytes } from 'node:crypto'
 import { WebSocketServer } from 'ws'
 import { getWebUI } from './ui.js'
 import { handleHttpRequest } from './routes.js'
 import { handleWebSocketConnection } from './wsHandler.js'
+import { SessionStore } from './sessionStore.js'
+
+const COOKIE_NAME = 'openclaude_session'
 
 export class WebServer {
   private httpServer: http.Server
   private wss: WebSocketServer
-  private sessions: Map<string, any[]> = new Map()
+  private sessionStore = new SessionStore()
+  private authToken: string
+  private validCookies = new Set<string>()
 
   constructor() {
+    this.authToken = process.env.OPENCLAUDE_AUTH_TOKEN || randomBytes(24).toString('hex')
     const html = getWebUI()
 
     this.httpServer = http.createServer(async (req, res) => {
+      const url = new URL(req.url || '/', `http://${req.headers.host || 'localhost'}`)
+      const pathname = url.pathname
+
+      if (req.method === 'GET' && (pathname === '/' || pathname === '') && url.searchParams.get('token') === this.authToken) {
+        const sessionId = randomBytes(24).toString('hex')
+        this.validCookies.add(sessionId)
+        res.writeHead(302, {
+          'Set-Cookie': `${COOKIE_NAME}=${sessionId}; HttpOnly; SameSite=Strict; Path=/`,
+          Location: '/',
+        })
+        res.end()
+        return
+      }
+
+      if (!this.authenticate(req)) {
+        res.writeHead(401, { 'Content-Type': 'application/json' })
+        res.end(JSON.stringify({ error: 'Unauthorized' }))
+        return
+      }
+
       const handled = await handleHttpRequest(req, res, html)
       if (handled) return
       res.writeHead(404, { 'Content-Type': 'text/plain' })
@@ -20,12 +47,38 @@ export class WebServer {
     })
 
     this.wss = new WebSocketServer({ server: this.httpServer })
-    this.wss.on('connection', (ws: any) => handleWebSocketConnection(ws, this.sessions))
+    this.wss.on('connection', (ws, req) => {
+      if (!this.authenticate(req)) {
+        ws.close(4401, 'Unauthorized')
+        return
+      }
+      handleWebSocketConnection(ws, this.sessionStore)
+    })
+  }
+
+  private authenticate(req: http.IncomingMessage): boolean {
+    const cookie = this.parseCookie(req.headers.cookie)
+    if (cookie && this.validCookies.has(cookie)) return true
+
+    const authHeader = req.headers.authorization
+    if (authHeader?.startsWith('Bearer ') && authHeader.slice(7) === this.authToken) return true
+
+    return false
+  }
+
+  private parseCookie(header: string | undefined): string | null {
+    if (!header) return null
+    for (const part of header.split(';')) {
+      const [name, ...rest] = part.trim().split('=')
+      if (name === COOKIE_NAME) return rest.join('=')
+    }
+    return null
   }
 
   start(port: number = 3000, host: string = 'localhost') {
     this.httpServer.listen(port, host, () => {
-      console.log(`OpenClaude Web running at http://${host}:${port}`)
+      console.log(`OpenClaude Web running at http://${host}:${port}?token=${this.authToken}`)
+      console.log(`Auth token: ${this.authToken}`)
     })
   }
 }

--- a/src/web/sessionStore.ts
+++ b/src/web/sessionStore.ts
@@ -1,0 +1,71 @@
+interface SessionEntry {
+  messages: unknown[]
+  lastAccess: number
+}
+
+const MAX_SESSIONS = 1000
+const SESSION_TTL_MS = 4 * 60 * 60 * 1000 // 4 hours
+
+export class SessionStore {
+  private store = new Map<string, SessionEntry>()
+  private cleanupTimer: ReturnType<typeof setInterval>
+
+  constructor() {
+    this.cleanupTimer = setInterval(() => this.evictExpired(), 60_000)
+    if (typeof this.cleanupTimer === 'object' && 'unref' in this.cleanupTimer) {
+      this.cleanupTimer.unref()
+    }
+  }
+
+  get(sessionId: string): unknown[] | undefined {
+    const entry = this.store.get(sessionId)
+    if (!entry) return undefined
+    if (Date.now() - entry.lastAccess > SESSION_TTL_MS) {
+      this.store.delete(sessionId)
+      return undefined
+    }
+    entry.lastAccess = Date.now()
+    return entry.messages
+  }
+
+  set(sessionId: string, messages: unknown[]): void {
+    if (this.store.size >= MAX_SESSIONS && !this.store.has(sessionId)) {
+      this.evictOldest()
+    }
+    this.store.set(sessionId, { messages, lastAccess: Date.now() })
+  }
+
+  has(sessionId: string): boolean {
+    return this.get(sessionId) !== undefined
+  }
+
+  get size(): number {
+    return this.store.size
+  }
+
+  private evictExpired(): void {
+    const now = Date.now()
+    for (const [id, entry] of this.store) {
+      if (now - entry.lastAccess > SESSION_TTL_MS) {
+        this.store.delete(id)
+      }
+    }
+  }
+
+  private evictOldest(): void {
+    let oldestId: string | null = null
+    let oldestTime = Infinity
+    for (const [id, entry] of this.store) {
+      if (entry.lastAccess < oldestTime) {
+        oldestTime = entry.lastAccess
+        oldestId = id
+      }
+    }
+    if (oldestId) this.store.delete(oldestId)
+  }
+
+  destroy(): void {
+    clearInterval(this.cleanupTimer)
+    this.store.clear()
+  }
+}

--- a/src/web/ui.ts
+++ b/src/web/ui.ts
@@ -1,0 +1,32 @@
+import { readFileSync } from 'node:fs'
+import { join, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+
+export function getWebUI(): string {
+  const css = readFileSync(join(__dirname, 'client/styles.css'), 'utf8')
+  const body = readFileSync(join(__dirname, 'client/app.html'), 'utf8')
+  const js = readFileSync(join(__dirname, 'client/app.js'), 'utf8')
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>OpenClaude</title>
+<link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='%238b5cf6' stroke-width='2.5' stroke-linecap='round'><polyline points='4 17 10 11 4 5'/><line x1='12' y1='19' x2='20' y2='19'/></svg>">
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.11.1/styles/github-dark-dimmed.min.css">
+<script src="https://cdnjs.cloudflare.com/ajax/libs/marked/15.0.7/marked.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.11.1/highlight.min.js"></script>
+<style>
+${css}
+</style>
+</head>
+<body>
+${body}
+<script>
+${js}
+</script>
+</body>
+</html>`
+}

--- a/src/web/ui.ts
+++ b/src/web/ui.ts
@@ -8,6 +8,9 @@ export function getWebUI(): string {
   const css = readFileSync(join(__dirname, 'client/styles.css'), 'utf8')
   const body = readFileSync(join(__dirname, 'client/app.html'), 'utf8')
   const js = readFileSync(join(__dirname, 'client/app.js'), 'utf8')
+  const version = (globalThis as Record<string, unknown>).MACRO
+    ? ((globalThis as Record<string, unknown>).MACRO as Record<string, string>).VERSION || '0.0.0'
+    : '0.0.0'
   return `<!DOCTYPE html>
 <html lang="en">
 <head>
@@ -18,6 +21,7 @@ export function getWebUI(): string {
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.11.1/styles/github-dark-dimmed.min.css">
 <script src="https://cdnjs.cloudflare.com/ajax/libs/marked/15.0.7/marked.min.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.11.1/highlight.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/dompurify/3.2.4/purify.min.js"></script>
 <style>
 ${css}
 </style>
@@ -25,6 +29,8 @@ ${css}
 <body>
 ${body}
 <script>
+var __APP_VERSION__ = ${JSON.stringify('v' + version)};
+(function() { var el = document.getElementById('version-label'); if (el) el.textContent = __APP_VERSION__; })();
 ${js}
 </script>
 </body>

--- a/src/web/ws.d.ts
+++ b/src/web/ws.d.ts
@@ -1,0 +1,15 @@
+declare module 'ws' {
+  import type { Server } from 'node:http'
+
+  export class WebSocketServer {
+    constructor(options: { server: Server })
+    on(event: string, listener: (...args: unknown[]) => void): this
+  }
+
+  export class WebSocket {
+    static readonly OPEN: number
+    readyState: number
+    send(data: string): void
+    on(event: string, listener: (...args: unknown[]) => void): this
+  }
+}

--- a/src/web/ws.d.ts
+++ b/src/web/ws.d.ts
@@ -1,8 +1,9 @@
 declare module 'ws' {
-  import type { Server } from 'node:http'
+  import type { Server, IncomingMessage } from 'node:http'
 
   export class WebSocketServer {
     constructor(options: { server: Server })
+    on(event: 'connection', listener: (socket: WebSocket, request: IncomingMessage) => void): this
     on(event: string, listener: (...args: unknown[]) => void): this
   }
 
@@ -10,6 +11,7 @@ declare module 'ws' {
     static readonly OPEN: number
     readyState: number
     send(data: string): void
+    close(code?: number, reason?: string): void
     on(event: string, listener: (...args: unknown[]) => void): this
   }
 }

--- a/src/web/wsHandler.ts
+++ b/src/web/wsHandler.ts
@@ -1,15 +1,15 @@
 import { randomUUID } from 'crypto'
+import type { ContentBlockParam } from '@anthropic-ai/sdk/resources/messages.mjs'
 import { WebSocket } from 'ws'
 import { QueryEngine } from '../QueryEngine.js'
 import { getTools } from '../tools.js'
 import { getDefaultAppState } from '../state/AppStateStore.js'
 import type { AppState } from '../state/AppState.js'
 import { FileStateCache, READ_FILE_STATE_CACHE_SIZE } from '../utils/fileStateCache.js'
-import { getAgentDefinitionsWithOverrides } from '../tools/AgentTool/loadAgentsDir.js'
+import { getAgentDefinitionsWithOverrides, type AgentDefinition } from '../tools/AgentTool/loadAgentsDir.js'
 import { recordTranscript, flushSessionStorage } from '../utils/sessionStorage.js'
 import { detectProvider } from './provider.js'
-
-const MAX_SESSIONS = 1000
+import type { SessionStore } from './sessionStore.js'
 
 interface ImageAttachment {
   data: string
@@ -46,11 +46,16 @@ function isValidClientMessage(data: unknown): data is ClientMessage {
   return false
 }
 
+interface ContentBlock {
+  type: string
+  text?: string
+}
+
 function extractTextFromContent(content: unknown): string {
   if (typeof content === 'string') return content
   if (!Array.isArray(content)) return ''
-  return content
-    .map((block: any) => {
+  return (content as ContentBlock[])
+    .map((block) => {
       if (block.type === 'text') return block.text ?? ''
       return ''
     })
@@ -58,16 +63,31 @@ function extractTextFromContent(content: unknown): string {
     .join('')
 }
 
-export function handleWebSocketConnection(ws: WebSocket, sessions: Map<string, any[]>) {
+const RATE_LIMIT_WINDOW_MS = 60_000
+const RATE_LIMIT_MAX_REQUESTS = 30
+
+export function handleWebSocketConnection(ws: WebSocket, sessions: SessionStore) {
   let engine: QueryEngine | null = null
   let appState: AppState = getDefaultAppState()
   const fileCache = new FileStateCache(READ_FILE_STATE_CACHE_SIZE, 25 * 1024 * 1024)
   const pendingRequests = new Map<string, (reply: string) => void>()
   const sessionAllowedTools = new Set<string>()
-  let previousMessages: any[] = []
+  let previousMessages: unknown[] = []
   let sessionId = ''
   let interrupted = false
   let activeCwd = process.cwd()
+
+  const rateLimitWindow: number[] = []
+
+  function isRateLimited(): boolean {
+    const now = Date.now()
+    while (rateLimitWindow.length > 0 && now - rateLimitWindow[0] > RATE_LIMIT_WINDOW_MS) {
+      rateLimitWindow.shift()
+    }
+    if (rateLimitWindow.length >= RATE_LIMIT_MAX_REQUESTS) return true
+    rateLimitWindow.push(now)
+    return false
+  }
 
   const send = (data: Record<string, unknown>) => {
     if (ws.readyState === WebSocket.OPEN) {
@@ -92,6 +112,11 @@ export function handleWebSocketConnection(ws: WebSocket, sessions: Map<string, a
       return
     }
 
+    if (parsed.type === 'request' && isRateLimited()) {
+      send({ type: 'error', message: 'Rate limit exceeded — try again shortly', code: 'RATE_LIMITED' })
+      return
+    }
+
     try {
       if (parsed.type === 'request') {
         if (engine) {
@@ -107,13 +132,14 @@ export function handleWebSocketConnection(ws: WebSocket, sessions: Map<string, a
         }
 
         previousMessages = []
-        if (sessionId && sessions.has(sessionId)) {
-          previousMessages = [...sessions.get(sessionId)!]
+        if (sessionId) {
+          const stored = sessions.get(sessionId)
+          if (stored) previousMessages = [...stored]
         }
 
         const toolNameById = new Map<string, string>()
 
-        let agentDefs: any[] = []
+        let agentDefs: AgentDefinition[] = []
         try {
           const result = await getAgentDefinitionsWithOverrides(activeCwd)
           agentDefs = result.activeAgents
@@ -185,15 +211,15 @@ export function handleWebSocketConnection(ws: WebSocket, sessions: Map<string, a
         let completionTokens = 0
         let actualModel = parsed.model || ''
 
-        let messageInput: string | any[] = parsed.message
+        let messageInput: string | ContentBlockParam[] = parsed.message
         if (parsed.images && parsed.images.length > 0) {
-          const contentBlocks: any[] = [{ type: 'text', text: parsed.message }]
+          const contentBlocks: ContentBlockParam[] = [{ type: 'text', text: parsed.message }]
           for (const img of parsed.images) {
             contentBlocks.push({
               type: 'image',
               source: {
                 type: 'base64',
-                media_type: img.mediaType || 'image/png',
+                media_type: (img.mediaType || 'image/png') as 'image/jpeg' | 'image/png' | 'image/gif' | 'image/webp',
                 data: img.data,
               },
             })
@@ -224,19 +250,19 @@ export function handleWebSocketConnection(ws: WebSocket, sessions: Map<string, a
           } else if (msg.type === 'user') {
             const content = msg.message.content
             if (Array.isArray(content)) {
-              for (const block of content) {
+              for (const block of content as Record<string, unknown>[]) {
                 if (block.type === 'tool_result') {
                   let outputStr = ''
                   if (typeof block.content === 'string') {
                     outputStr = block.content
                   } else if (Array.isArray(block.content)) {
-                    outputStr = block.content
-                      .map((c: any) => (c.type === 'text' ? c.text : ''))
+                    outputStr = (block.content as ContentBlock[])
+                      .map((c) => (c.type === 'text' ? c.text ?? '' : ''))
                       .join('\n')
                   }
                   send({
                     type: 'tool_result',
-                    toolName: toolNameById.get(block.tool_use_id) ?? block.tool_use_id,
+                    toolName: toolNameById.get(block.tool_use_id as string) ?? block.tool_use_id,
                     toolUseId: block.tool_use_id,
                     output: outputStr,
                     isError: block.is_error || false,
@@ -263,9 +289,6 @@ export function handleWebSocketConnection(ws: WebSocket, sessions: Map<string, a
           previousMessages = [...engine.getMessages()]
 
           if (sessionId) {
-            if (!sessions.has(sessionId) && sessions.size >= MAX_SESSIONS) {
-              sessions.delete(sessions.keys().next().value!)
-            }
             sessions.set(sessionId, previousMessages)
           }
 

--- a/src/web/wsHandler.ts
+++ b/src/web/wsHandler.ts
@@ -1,0 +1,329 @@
+import { randomUUID } from 'crypto'
+import { WebSocket } from 'ws'
+import { QueryEngine } from '../QueryEngine.js'
+import { getTools } from '../tools.js'
+import { getDefaultAppState } from '../state/AppStateStore.js'
+import type { AppState } from '../state/AppState.js'
+import { FileStateCache, READ_FILE_STATE_CACHE_SIZE } from '../utils/fileStateCache.js'
+import { getAgentDefinitionsWithOverrides } from '../tools/AgentTool/loadAgentsDir.js'
+import { recordTranscript, flushSessionStorage } from '../utils/sessionStorage.js'
+import { detectProvider } from './provider.js'
+
+const MAX_SESSIONS = 1000
+
+interface ImageAttachment {
+  data: string
+  mediaType: string
+}
+
+interface ClientRequest {
+  type: 'request'
+  message: string
+  sessionId?: string
+  cwd?: string
+  model?: string
+  images?: ImageAttachment[]
+}
+
+interface ClientInput {
+  type: 'input'
+  promptId: string
+  reply: string
+}
+
+interface ClientCancel {
+  type: 'cancel'
+}
+
+type ClientMessage = ClientRequest | ClientInput | ClientCancel
+
+function isValidClientMessage(data: unknown): data is ClientMessage {
+  if (typeof data !== 'object' || data === null) return false
+  const msg = data as Record<string, unknown>
+  if (msg.type === 'request') return typeof msg.message === 'string'
+  if (msg.type === 'input') return typeof msg.promptId === 'string' && typeof msg.reply === 'string'
+  if (msg.type === 'cancel') return true
+  return false
+}
+
+function extractTextFromContent(content: unknown): string {
+  if (typeof content === 'string') return content
+  if (!Array.isArray(content)) return ''
+  return content
+    .map((block: any) => {
+      if (block.type === 'text') return block.text ?? ''
+      return ''
+    })
+    .filter(Boolean)
+    .join('')
+}
+
+export function handleWebSocketConnection(ws: WebSocket, sessions: Map<string, any[]>) {
+  let engine: QueryEngine | null = null
+  let appState: AppState = getDefaultAppState()
+  const fileCache = new FileStateCache(READ_FILE_STATE_CACHE_SIZE, 25 * 1024 * 1024)
+  const pendingRequests = new Map<string, (reply: string) => void>()
+  const sessionAllowedTools = new Set<string>()
+  let previousMessages: any[] = []
+  let sessionId = ''
+  let interrupted = false
+  let activeCwd = process.cwd()
+
+  const send = (data: Record<string, unknown>) => {
+    if (ws.readyState === WebSocket.OPEN) {
+      ws.send(JSON.stringify(data))
+    }
+  }
+
+  const providerInfo = detectProvider()
+  send({ type: 'config', cwd: activeCwd, ...providerInfo, noProvider: providerInfo.provider === 'unknown' })
+
+  ws.on('message', async (raw: any) => {
+    let parsed: unknown
+    try {
+      parsed = JSON.parse(String(raw))
+    } catch {
+      send({ type: 'error', message: 'Invalid JSON', code: 'INVALID_JSON' })
+      return
+    }
+
+    if (!isValidClientMessage(parsed)) {
+      send({ type: 'error', message: 'Invalid message format', code: 'INVALID_FORMAT' })
+      return
+    }
+
+    try {
+      if (parsed.type === 'request') {
+        if (engine) {
+          send({ type: 'error', message: 'A request is already in progress', code: 'ALREADY_EXISTS' })
+          return
+        }
+
+        interrupted = false
+        sessionId = parsed.sessionId || ''
+
+        if (parsed.cwd) {
+          activeCwd = parsed.cwd
+        }
+
+        previousMessages = []
+        if (sessionId && sessions.has(sessionId)) {
+          previousMessages = [...sessions.get(sessionId)!]
+        }
+
+        const toolNameById = new Map<string, string>()
+
+        let agentDefs: any[] = []
+        try {
+          const result = await getAgentDefinitionsWithOverrides(activeCwd)
+          agentDefs = result.activeAgents
+        } catch {
+          // Fall back to empty agents if loading fails
+        }
+
+        engine = new QueryEngine({
+          cwd: activeCwd,
+          tools: getTools(appState.toolPermissionContext),
+          commands: [],
+          mcpClients: [],
+          agents: agentDefs,
+          ...(previousMessages.length > 0 ? { initialMessages: previousMessages } : {}),
+          ...(parsed.model ? { userSpecifiedModel: parsed.model } : {}),
+          includePartialMessages: true,
+          canUseTool: async (tool, input, _context, _assistantMsg, toolUseID) => {
+            if (toolUseID) {
+              toolNameById.set(toolUseID, tool.name)
+            }
+
+            send({
+              type: 'tool_start',
+              toolName: tool.name,
+              args: JSON.stringify(input),
+              toolUseId: toolUseID,
+            })
+
+            if (sessionAllowedTools.has(tool.name)) {
+              return { behavior: 'allow' }
+            }
+
+            const promptId = randomUUID()
+            send({
+              type: 'action_required',
+              promptId,
+              question: `Allow ${tool.name}?`,
+              toolName: tool.name,
+              actionType: 'CONFIRM_COMMAND',
+            })
+
+            return new Promise((resolve) => {
+              pendingRequests.set(promptId, (reply) => {
+                const lower = reply.toLowerCase()
+                if (lower === 'session') {
+                  sessionAllowedTools.add(tool.name)
+                  resolve({ behavior: 'allow' })
+                } else if (lower === 'yes' || lower === 'y') {
+                  resolve({ behavior: 'allow' })
+                } else {
+                  resolve({
+                    behavior: 'deny',
+                    message: 'User denied via web UI',
+                    decisionReason: { type: 'other', reason: 'User denied via web UI' },
+                  })
+                }
+              })
+            })
+          },
+          getAppState: () => appState,
+          setAppState: (updater) => {
+            appState = updater(appState)
+          },
+          readFileCache: fileCache,
+        })
+
+        let fullText = ''
+        let promptTokens = 0
+        let completionTokens = 0
+        let actualModel = parsed.model || ''
+
+        let messageInput: string | any[] = parsed.message
+        if (parsed.images && parsed.images.length > 0) {
+          const contentBlocks: any[] = [{ type: 'text', text: parsed.message }]
+          for (const img of parsed.images) {
+            contentBlocks.push({
+              type: 'image',
+              source: {
+                type: 'base64',
+                media_type: img.mediaType || 'image/png',
+                data: img.data,
+              },
+            })
+          }
+          messageInput = contentBlocks
+        }
+
+        const generator = engine.submitMessage(messageInput)
+
+        for await (const msg of generator) {
+          if (interrupted) break
+
+          if (msg.type === 'stream_event') {
+            if (msg.event.type === 'message_start' && msg.event.message?.model) {
+              actualModel = msg.event.message.model
+            }
+            if (msg.event.type === 'content_block_delta' && msg.event.delta.type === 'text_delta') {
+              send({ type: 'text_chunk', text: msg.event.delta.text })
+              fullText += msg.event.delta.text
+            }
+          } else if (msg.type === 'assistant') {
+            if (msg.message?.model) actualModel = msg.message.model
+            const text = extractTextFromContent(msg.message?.content)
+            if (text) {
+              send({ type: 'text_chunk', text })
+              fullText += text
+            }
+          } else if (msg.type === 'user') {
+            const content = msg.message.content
+            if (Array.isArray(content)) {
+              for (const block of content) {
+                if (block.type === 'tool_result') {
+                  let outputStr = ''
+                  if (typeof block.content === 'string') {
+                    outputStr = block.content
+                  } else if (Array.isArray(block.content)) {
+                    outputStr = block.content
+                      .map((c: any) => (c.type === 'text' ? c.text : ''))
+                      .join('\n')
+                  }
+                  send({
+                    type: 'tool_result',
+                    toolName: toolNameById.get(block.tool_use_id) ?? block.tool_use_id,
+                    toolUseId: block.tool_use_id,
+                    output: outputStr,
+                    isError: block.is_error || false,
+                  })
+                }
+              }
+            }
+          } else if (msg.type === 'result') {
+            if (msg.subtype === 'success') {
+              if (msg.result && !fullText) {
+                fullText = msg.result
+                send({ type: 'text_chunk', text: fullText })
+              }
+              promptTokens = msg.usage?.input_tokens ?? 0
+              completionTokens = msg.usage?.output_tokens ?? 0
+            } else {
+              const errMsg = msg.subtype?.replace('error_', '').replace(/_/g, ' ') || 'unknown error'
+              send({ type: 'error', message: errMsg, code: msg.subtype || 'ERROR' })
+            }
+          }
+        }
+
+        if (!interrupted) {
+          previousMessages = [...engine.getMessages()]
+
+          if (sessionId) {
+            if (!sessions.has(sessionId) && sessions.size >= MAX_SESSIONS) {
+              sessions.delete(sessions.keys().next().value!)
+            }
+            sessions.set(sessionId, previousMessages)
+          }
+
+          try {
+            await recordTranscript(previousMessages)
+          } catch {
+            // Non-fatal: session still works even if persistence fails
+          }
+
+          send({
+            type: 'done',
+            fullText,
+            promptTokens,
+            completionTokens,
+            model: actualModel || parsed.model || detectProvider().model,
+          })
+        }
+
+        engine = null
+      } else if (parsed.type === 'input') {
+        const resolver = pendingRequests.get(parsed.promptId)
+        if (resolver) {
+          resolver(parsed.reply)
+          pendingRequests.delete(parsed.promptId)
+        }
+      } else if (parsed.type === 'cancel') {
+        interrupted = true
+        if (engine) {
+          engine.interrupt()
+        }
+      }
+    } catch (err: unknown) {
+      console.error('Error processing WebSocket message:', err)
+      const message = err instanceof Error ? err.message : String(err)
+      send({
+        type: 'error',
+        message: message || 'Internal server error',
+        code: 'INTERNAL',
+      })
+      engine = null
+    }
+  })
+
+  ws.on('close', async () => {
+    interrupted = true
+    for (const resolve of pendingRequests.values()) {
+      resolve('no')
+    }
+    if (engine) {
+      engine.interrupt()
+    }
+    engine = null
+    pendingRequests.clear()
+
+    try {
+      await flushSessionStorage()
+    } catch {
+      // Best-effort flush on disconnect
+    }
+  })
+}


### PR DESCRIPTION
## Summary
Adds a web interface that runs OpenClaude in the browser over HTTP/WebSocket, aligned with CLI behavior (provider profile, models, cwd, tool permissions, transcripts).

<img width="3437" height="1306" alt="image" src="https://github.com/user-attachments/assets/e0e29958-184b-4b27-afa2-0e51e6e2fa2d" />


## Changes
- `scripts/start-web.ts` and `npm run dev:web` / `bun run dev:web`
- Modular server: `src/web/server.ts`, `routes.ts`, `wsHandler.ts`, `provider.ts`, `ui.ts`
- Client split into `src/web/client/` (HTML, CSS, JS)
- README section for the web interface
- Sidebar: local chats + History from transcripts, deletes persist (including hiding server History entries after refresh)

## How to test
1. Configure provider as for the CLI.
2. Run `bun run dev:web` (or `npm run dev:web`).
3. Open the printed URL, send messages, try model/cwd, delete chats and refresh.