### PR TITLE
fix: focus "Done" option after completing provider manager actions

### DIFF
--- a/src/components/ProviderManager.tsx
+++ b/src/components/ProviderManager.tsx
@@ -361,6 +361,7 @@ export function ProviderManager({ mode, onDone }: Props): React.ReactNode {
   const [cursorOffset, setCursorOffset] = React.useState(0)
   const [statusMessage, setStatusMessage] = React.useState<string | undefined>()
   const [errorMessage, setErrorMessage] = React.useState<string | undefined>()
+  const [menuFocusValue, setMenuFocusValue] = React.useState<string | undefined>()
   const [hasStoredCodexOAuthCredentials, setHasStoredCodexOAuthCredentials] =
     React.useState(false)
   const [storedCodexOAuthProfileId, setStoredCodexOAuthProfileId] =
@@ -576,7 +577,7 @@ export function ProviderManager({ mode, onDone }: Props): React.ReactNode {
         const githubError = activateGithubProvider()
         if (githubError) {
           setErrorMessage(`Could not activate GitHub provider: ${githubError}`)
-          setScreen('menu')
+          returnToMenu()
           return
         }
 
@@ -586,14 +587,14 @@ export function ProviderManager({ mode, onDone }: Props): React.ReactNode {
           mainLoopModel: GITHUB_PROVIDER_DEFAULT_MODEL,
         }))
         setStatusMessage(`Active provider: ${GITHUB_PROVIDER_LABEL}`)
-        setScreen('menu')
+        returnToMenu()
         return
       }
 
       const active = setActiveProviderProfile(profileId)
       if (!active) {
         setErrorMessage('Could not change active provider.')
-        setScreen('menu')
+        returnToMenu()
         return
       }
 
@@ -635,14 +636,19 @@ export function ProviderManager({ mode, onDone }: Props): React.ReactNode {
             ? `Active provider: ${active.name}. Warning: could not clear startup provider override (${settingsOverrideError}).`
             : `Active provider: ${active.name}`,
       )
-      setScreen('menu')
+      returnToMenu()
     } catch (error) {
       refreshProfiles()
       setStatusMessage(undefined)
       const detail = error instanceof Error ? error.message : String(error)
       setErrorMessage(`Could not finish activating ${providerLabel}: ${detail}`)
-      setScreen('menu')
+      returnToMenu()
     }
+  }
+
+  function returnToMenu(): void {
+    setMenuFocusValue('done')
+    setScreen('menu')
   }
 
   function closeWithCancelled(message: string): void {
@@ -822,7 +828,7 @@ export function ProviderManager({ mode, onDone }: Props): React.ReactNode {
     setEditingProfileId(null)
     setFormStepIndex(0)
     setErrorMessage(undefined)
-    setScreen('menu')
+    returnToMenu()
   }
 
   function renderOllamaSelection(): React.ReactNode {
@@ -945,7 +951,7 @@ export function ProviderManager({ mode, onDone }: Props): React.ReactNode {
       return
     }
 
-    setScreen('menu')
+    returnToMenu()
   }
 
   useKeybinding('confirm:no', handleBackFromForm, {
@@ -1078,7 +1084,7 @@ export function ProviderManager({ mode, onDone }: Props): React.ReactNode {
               closeWithCancelled('Provider setup skipped')
               return
             }
-            setScreen('menu')
+            returnToMenu()
           }}
           visibleOptionCount={Math.min(13, options.length)}
         />
@@ -1278,6 +1284,7 @@ export function ProviderManager({ mode, onDone }: Props): React.ReactNode {
             }
           }}
           onCancel={() => closeWithCancelled('Provider manager closed')}
+          defaultFocusValue={menuFocusValue}
           visibleOptionCount={options.length}
         />
       </Box>
@@ -1325,8 +1332,8 @@ export function ProviderManager({ mode, onDone }: Props): React.ReactNode {
                 description: 'Return to provider manager',
               },
             ]}
-            onChange={() => setScreen('menu')}
-            onCancel={() => setScreen('menu')}
+            onChange={() => returnToMenu()}
+            onCancel={() => returnToMenu()}
             visibleOptionCount={1}
           />
         </Box>
@@ -1341,7 +1348,7 @@ export function ProviderManager({ mode, onDone }: Props): React.ReactNode {
         <Select
           options={selectOptions}
           onChange={onSelect}
-          onCancel={() => setScreen('menu')}
+          onCancel={() => returnToMenu()}
           visibleOptionCount={Math.min(10, Math.max(2, selectOptions.length))}
         />
       </Box>
@@ -1382,7 +1389,7 @@ export function ProviderManager({ mode, onDone }: Props): React.ReactNode {
               setErrorMessage(
                 'Codex OAuth login finished, but the provider profile could not be saved.',
               )
-              setScreen('menu')
+              returnToMenu()
               return
             }
 
@@ -1394,7 +1401,7 @@ export function ProviderManager({ mode, onDone }: Props): React.ReactNode {
               setErrorMessage(
                 'Codex OAuth login finished, but the provider could not be set as the startup provider.',
               )
-              setScreen('menu')
+              returnToMenu()
               return
             }
 
@@ -1428,7 +1435,7 @@ export function ProviderManager({ mode, onDone }: Props): React.ReactNode {
 
             setStatusMessage(message)
             setErrorMessage(undefined)
-            setScreen('menu')
+            returnToMenu()
           }}
         />
       )
@@ -1468,7 +1475,7 @@ export function ProviderManager({ mode, onDone }: Props): React.ReactNode {
               refreshProfiles()
               setStatusMessage('GitHub provider deleted')
             }
-            setScreen('menu')
+            returnToMenu()
             return
           }
 
@@ -1503,7 +1510,7 @@ export function ProviderManager({ mode, onDone }: Props): React.ReactNode {
                 : 'Provider deleted',
             )
           }
-          setScreen('menu')
+          returnToMenu()
         },
         { includeGithub: true },
       )


### PR DESCRIPTION
When returning to the provider manager menu after completing an action (add, edit, delete, set active, etc.), the cursor now lands on "Done" instead of the first option ("Add provider"). This prevents accidental re-entry into the same action if the user presses Enter quickly.

On initial /provider invocation, the cursor still starts on the first option ("Add provider") as expected.

## Summary

- **What changed:** The provider manager menu (`/provider`) now focuses the "Done" option after completing any action (add, edit, delete, set active, logout). Previously, the cursor always reset to the first option ("Add provider") on every return to the menu.
- **Why it changed:** A `menuFocusValue` state was added (initially `undefined`) that controls the `defaultFocusValue` prop on the main menu `<Select>`. A `returnToMenu()` helper sets this state to `"done"` before navigating back. All 17 `setScreen('menu')` calls were replaced with `returnToMenu()`. On fresh mount the value is `undefined`, so the first option is focused as before.

## Impact

- **User-facing impact:** After completing a provider action, pressing Enter once closes the menu instead of accidentally starting another "Add provider" flow. First-time `/provider` invocation is unchanged — cursor still starts on "Add provider".
- **Developer/maintainer impact:** No API or structural changes. Single-file change in `ProviderManager.tsx` (23 insertions, 16 deletions). All sub-screens returning to the menu now go through `returnToMenu()` instead of direct `setScreen('menu')`.

## Testing

- [x] `bun run build` — passes
- [x] `bun run smoke`
- [x] focused tests: `bun test src/components/ProviderManager.test.tsx` — 9/9 pass

## Notes

- **Provider/model path tested:** All menu actions (add provider, set active, edit, delete, Codex OAuth logout)
- **Screenshots attached:** N/A (terminal TUI change)
- **Follow-up work or known limitations:** None. The `menuFocusValue` state resets on component unmount, so multiple `/provider` invocations in the same session each start fresh on the first option.