### PR TITLE
feat persist provider-scoped model and effort selections

### DIFF
--- a/src/hooks/useMainLoopModel.ts
+++ b/src/hooks/useMainLoopModel.ts
@@ -13,6 +13,7 @@ import {
 export function useMainLoopModel(): ModelName {
   const mainLoopModel = useAppState(s => s.mainLoopModel)
   const mainLoopModelForSession = useAppState(s => s.mainLoopModelForSession)
+  useAppState(s => s.providerSelectionTargetKey)
 
   // parseUserSpecifiedModel reads tengu_ant_model_override via
   // _CACHED_MAY_BE_STALE (in resolveAntModel). Until GB init completes,

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -118,6 +118,7 @@ import { logError } from './utils/log.js';
 import { getModelDeprecationWarning } from './utils/model/deprecation.js';
 import { getDefaultMainLoopModel, getUserSpecifiedModelSetting, normalizeModelStringForAPI, parseUserSpecifiedModel } from './utils/model/model.js';
 import { ensureModelStringsInitialized } from './utils/model/modelStrings.js';
+import { getCurrentProviderSelectionTarget } from './utils/model/providerTargets.js';
 import { PERMISSION_MODES } from './utils/permissions/PermissionMode.js';
 import { checkAndDisableBypassPermissions, getAutoModeEnabledStateIfCached, initializeToolPermissionContext, initialPermissionModeFromCLI, isDefaultPermissionModeAuto, parseToolListFromCLI, removeDangerousPermissions, stripDangerousPermissionsForAutoMode, verifyAutoModeGateAccess } from './utils/permissions/permissionSetup.js';
 import { cleanupOrphanedPluginVersionsInBackground } from './utils/plugins/cacheUtils.js';
@@ -2610,6 +2611,8 @@ async function run(): Promise<CommanderCommand> {
       // If disableSlashCommands is true, return empty array
       const commandsHeadless = disableSlashCommands ? [] : commands.filter(command => command.type === 'prompt' && !command.disableNonInteractive || command.type === 'local' && command.supportsNonInteractive);
       const defaultState = getDefaultAppState();
+      const initialProviderSelectionTargetKey =
+        getCurrentProviderSelectionTarget().targetKey;
       const headlessInitialState: AppState = {
         ...defaultState,
         mcp: {
@@ -2619,6 +2622,7 @@ async function run(): Promise<CommanderCommand> {
           tools: mcpTools
         },
         toolPermissionContext,
+        providerSelectionTargetKey: initialProviderSelectionTargetKey,
         effortValue: parseEffortValue(options.effort) ?? getInitialEffortSetting(),
         ...(isFastModeEnabled() && {
           fastMode: getInitialFastModeSetting(effectiveModel ?? null)
@@ -2913,6 +2917,7 @@ async function run(): Promise<CommanderCommand> {
       ccrMirrorEnabled = isCcrMirrorEnabled();
     }
     const initialState: AppState = {
+      providerSelectionTargetKey: getCurrentProviderSelectionTarget().targetKey,
       settings: getInitialSettings(),
       tasks: {},
       agentNameRegistry: new Map(),

--- a/src/services/api/providerConfig.ts
+++ b/src/services/api/providerConfig.ts
@@ -426,19 +426,16 @@ export function resolveProviderRequest(options?: {
   const reasoning = options?.reasoningEffortOverride
     ? { effort: options.reasoningEffortOverride }
     : descriptor.reasoning
+  const defaultBaseUrl =
+    transport === 'codex_responses'
+      ? (isGithubMode ? GITHUB_COPILOT_BASE_URL : DEFAULT_CODEX_BASE_URL)
+      : (isGithubMode ? GITHUB_COPILOT_BASE_URL : DEFAULT_OPENAI_BASE_URL)
 
   return {
     transport,
     requestedModel,
     resolvedModel,
-    baseUrl:
-      (finalBaseUrl ??
-        (isGithubCopilot && transport === 'codex_responses'
-          ? GITHUB_COPILOT_BASE_URL
-          : (isGithubMode
-            ? GITHUB_COPILOT_BASE_URL
-            : DEFAULT_OPENAI_BASE_URL))
-      ).replace(/\/+$/, ''),
+    baseUrl: (rawBaseUrl ?? defaultBaseUrl).replace(/\/+$/, ''),
     reasoning,
   }
 }

--- a/src/state/AppStateStore.ts
+++ b/src/state/AppStateStore.ts
@@ -31,6 +31,7 @@ import type { FileHistoryState } from '../utils/fileHistory.js'
 import type { REPLHookContext } from '../utils/hooks/postSamplingHooks.js'
 import type { SessionHooksState } from '../utils/hooks/sessionHooks.js'
 import type { ModelSetting } from '../utils/model/model.js'
+import { resolveProviderSelectionTarget } from '../utils/model/providerModelSettings.js'
 import type { DenialTrackingState } from '../utils/permissions/denialTracking.js'
 import type { PermissionMode } from '../utils/permissions/PermissionMode.js'
 import { getInitialSettings } from '../utils/settings/settings.js'
@@ -229,6 +230,7 @@ export type AppState = DeepImmutable<{
   thinkingEnabled: boolean | undefined
   promptSuggestionEnabled: boolean
   sessionHooks: SessionHooksState
+  providerSelectionTargetKey: string
   tungstenActiveSession?: {
     sessionName: string
     socketName: string
@@ -465,6 +467,9 @@ export function getDefaultAppState(): AppState {
       ? 'plan'
       : 'default'
 
+  const initialProviderSelectionTargetKey =
+    resolveProviderSelectionTarget().targetKey
+
   return {
     settings: getInitialSettings(),
     tasks: {},
@@ -539,6 +544,7 @@ export function getDefaultAppState(): AppState {
     thinkingEnabled: shouldEnableThinkingByDefault(),
     promptSuggestionEnabled: shouldEnablePromptSuggestion(),
     sessionHooks: new Map(),
+    providerSelectionTargetKey: initialProviderSelectionTargetKey,
     inbox: {
       messages: [],
     },

--- a/src/state/onChangeAppState.ts
+++ b/src/state/onChangeAppState.ts
@@ -10,6 +10,7 @@ import { toError } from '../utils/errors.js'
 import { logError } from '../utils/log.js'
 import { applyConfigEnvironmentVariables } from '../utils/managedEnv.js'
 import { persistActiveProviderProfileModel } from '../utils/providerProfiles.js'
+import { buildProviderModelSettingsUpdate } from '../utils/model/providerModelSettings.js'
 import {
   permissionModeFromString,
   toExternalPermissionMode,
@@ -19,7 +20,10 @@ import {
   notifySessionMetadataChanged,
   type SessionExternalMetadata,
 } from '../utils/sessionState.js'
-import { updateSettingsForSource } from '../utils/settings/settings.js'
+import {
+  getSettingsForSource,
+  updateSettingsForSource,
+} from '../utils/settings/settings.js'
 import type { AppState } from './AppStateStore.js'
 
 // Inverse of the push below — restore on worker restart.
@@ -98,8 +102,14 @@ export function onChangeAppState({
     newState.mainLoopModel !== oldState.mainLoopModel &&
     newState.mainLoopModel === null
   ) {
-    // Remove from settings
-    updateSettingsForSource('userSettings', { model: undefined })
+    const userSettings = getSettingsForSource('userSettings') || {}
+    updateSettingsForSource(
+      'userSettings',
+      buildProviderModelSettingsUpdate({
+        settings: userSettings,
+        model: undefined,
+      }),
+    )
     setMainLoopModelOverride(null)
   }
 
@@ -108,8 +118,14 @@ export function onChangeAppState({
     newState.mainLoopModel !== oldState.mainLoopModel &&
     newState.mainLoopModel !== null
   ) {
-    // Save to settings
-    updateSettingsForSource('userSettings', { model: newState.mainLoopModel })
+    const userSettings = getSettingsForSource('userSettings') || {}
+    updateSettingsForSource(
+      'userSettings',
+      buildProviderModelSettingsUpdate({
+        settings: userSettings,
+        model: newState.mainLoopModel,
+      }),
+    )
     setMainLoopModelOverride(newState.mainLoopModel)
 
     // Keep active provider profiles in sync with /model choices so restarts

--- a/src/state/onChangeAppState.ts
+++ b/src/state/onChangeAppState.ts
@@ -11,6 +11,8 @@ import { logError } from '../utils/log.js'
 import { applyConfigEnvironmentVariables } from '../utils/managedEnv.js'
 import { persistActiveProviderProfileModel } from '../utils/providerProfiles.js'
 import { buildProviderModelSettingsUpdate } from '../utils/model/providerModelSettings.js'
+import { toPersistableEffort } from '../utils/effort.js'
+import { getCurrentProviderSelectionTarget } from '../utils/model/providerTargets.js'
 import {
   permissionModeFromString,
   toExternalPermissionMode,
@@ -97,42 +99,66 @@ export function onChangeAppState({
     notifyPermissionModeChanged(newMode)
   }
 
-  // mainLoopModel: remove it from settings?
+  const mainLoopModelChanged = newState.mainLoopModel !== oldState.mainLoopModel
+  const effortValueChanged = newState.effortValue !== oldState.effortValue
+  const providerSelectionTargetChanged =
+    newState.providerSelectionTargetKey !== oldState.providerSelectionTargetKey
   if (
-    newState.mainLoopModel !== oldState.mainLoopModel &&
-    newState.mainLoopModel === null
+    mainLoopModelChanged ||
+    effortValueChanged ||
+    providerSelectionTargetChanged
   ) {
     const userSettings = getSettingsForSource('userSettings') || {}
     updateSettingsForSource(
       'userSettings',
-      buildProviderModelSettingsUpdate({
-        settings: userSettings,
-        model: undefined,
-      }),
+      {
+        ...buildProviderModelSettingsUpdate({
+          settings: userSettings,
+          targetKey: newState.providerSelectionTargetKey,
+          ...(mainLoopModelChanged
+            ? { model: newState.mainLoopModel }
+            : {}),
+          ...(effortValueChanged
+            ? { effortLevel: toPersistableEffort(newState.effortValue) }
+            : {}),
+        }),
+        ...(providerSelectionTargetChanged
+          ? { activeProviderTarget: newState.providerSelectionTargetKey }
+          : {}),
+      },
     )
-    setMainLoopModelOverride(null)
   }
 
-  // mainLoopModel: add it to settings?
-  if (
-    newState.mainLoopModel !== oldState.mainLoopModel &&
-    newState.mainLoopModel !== null
-  ) {
-    const userSettings = getSettingsForSource('userSettings') || {}
-    updateSettingsForSource(
-      'userSettings',
-      buildProviderModelSettingsUpdate({
-        settings: userSettings,
-        model: newState.mainLoopModel,
-      }),
-    )
+  if (providerSelectionTargetChanged) {
+    try {
+      clearApiKeyHelperCache()
+      clearAwsCredentialsCache()
+      clearGcpCredentialsCache()
+      applyConfigEnvironmentVariables()
+    } catch (error) {
+      logError(toError(error))
+    }
+  }
+
+  if (mainLoopModelChanged) {
     setMainLoopModelOverride(newState.mainLoopModel)
 
     // Keep active provider profiles in sync with /model choices so restarts
     // keep using the last selected model instead of the profile's old default.
-    if (process.env.CLAUDE_CODE_PROVIDER_PROFILE_ENV_APPLIED === '1') {
+    if (
+      newState.mainLoopModel !== null &&
+      process.env.CLAUDE_CODE_PROVIDER_PROFILE_ENV_APPLIED === '1'
+    ) {
       persistActiveProviderProfileModel(newState.mainLoopModel)
     }
+  }
+
+  if (
+    providerSelectionTargetChanged &&
+    newState.mainLoopModel !== null &&
+    getCurrentProviderSelectionTarget().targetKey.startsWith('profile:')
+  ) {
+    persistActiveProviderProfileModel(newState.mainLoopModel)
   }
 
   // expandedView → persist as showExpandedTodos + showSpinnerTree for backwards compat

--- a/src/state/onChangeAppState.ts
+++ b/src/state/onChangeAppState.ts
@@ -134,7 +134,9 @@ export function onChangeAppState({
       clearApiKeyHelperCache()
       clearAwsCredentialsCache()
       clearGcpCredentialsCache()
-      applyConfigEnvironmentVariables()
+      applyConfigEnvironmentVariables({
+        forcePersistedProviderSelectionTarget: true,
+      })
     } catch (error) {
       logError(toError(error))
     }

--- a/src/utils/effort.provider.test.ts
+++ b/src/utils/effort.provider.test.ts
@@ -1,0 +1,66 @@
+import { afterEach, beforeEach, expect, mock, test } from 'bun:test'
+
+import { getReasoningEffortForModel } from '../services/api/providerConfig.js'
+
+const originalEnv = {
+  CLAUDE_CODE_USE_OPENAI: process.env.CLAUDE_CODE_USE_OPENAI,
+  CLAUDE_CODE_EFFORT_LEVEL: process.env.CLAUDE_CODE_EFFORT_LEVEL,
+}
+
+async function importFreshEffortModule(
+  provider: 'firstParty' | 'openai' | 'codex',
+) {
+  mock.restore()
+  mock.module('./model/providers.js', () => ({
+    getAPIProvider: () => provider,
+  }))
+  const nonce = `${Date.now()}-${Math.random()}`
+  return import(`./effort.js?ts=${nonce}`)
+}
+
+beforeEach(() => {
+  mock.restore()
+  delete process.env.CLAUDE_CODE_USE_OPENAI
+  delete process.env.CLAUDE_CODE_EFFORT_LEVEL
+})
+
+afterEach(() => {
+  process.env.CLAUDE_CODE_USE_OPENAI = originalEnv.CLAUDE_CODE_USE_OPENAI
+  process.env.CLAUDE_CODE_EFFORT_LEVEL = originalEnv.CLAUDE_CODE_EFFORT_LEVEL
+  mock.restore()
+})
+
+test.each(['openai', 'codex'] as const)(
+  'OpenAI/Codex models expose xhigh effort for %s',
+  async provider => {
+    const {
+      getAvailableEffortLevels,
+      modelUsesOpenAIEffort,
+      resolveAppliedEffort,
+    } = await importFreshEffortModule(provider)
+
+    expect(modelUsesOpenAIEffort('gpt-5.4')).toBe(true)
+    expect(getAvailableEffortLevels('gpt-5.4')).toEqual([
+      'low',
+      'medium',
+      'high',
+      'xhigh',
+    ])
+    expect(resolveAppliedEffort('gpt-5.4', 'xhigh')).toBe('xhigh')
+    expect(getReasoningEffortForModel('gpt-5.4')).toBe('high')
+    expect(getReasoningEffortForModel('gpt-5.4-mini')).toBe('medium')
+  },
+)
+
+test('Claude models still advertise max effort instead of xhigh', async () => {
+  const { getAvailableEffortLevels, modelUsesOpenAIEffort } =
+    await importFreshEffortModule('firstParty')
+
+  expect(modelUsesOpenAIEffort('claude-opus-4-6')).toBe(false)
+  expect(getAvailableEffortLevels('claude-opus-4-6')).toEqual([
+    'low',
+    'medium',
+    'high',
+    'max',
+  ])
+})

--- a/src/utils/effort.ts
+++ b/src/utils/effort.ts
@@ -7,6 +7,7 @@ import { getAPIProvider } from './model/providers.js'
 import { get3PModelCapabilityOverride } from './model/modelSupportOverrides.js'
 import { supportsCodexReasoningEffort } from '../services/api/providerConfig.js'
 import { isEnvTruthy } from './envUtils.js'
+import { getPersistedEffortSettingForProvider } from './model/providerModelSettings.js'
 import type { EffortLevel } from 'src/entrypoints/sdk/runtimeTypes.js'
 
 export type { EffortLevel }
@@ -26,7 +27,7 @@ export const OPENAI_EFFORT_LEVELS = [
 ] as const
 
 export type OpenAIEffortLevel = typeof OPENAI_EFFORT_LEVELS[number]
-export type EffortValue = EffortLevel | number
+export type EffortValue = EffortLevel | OpenAIEffortLevel | number
 
 // @[MODEL LAUNCH]: Add the new model to the allowlist if it supports the effort parameter.
 export function modelSupportsEffort(model: string): boolean {
@@ -149,20 +150,26 @@ export function parseEffortValue(value: unknown): EffortValue | undefined {
  */
 export function toPersistableEffort(
   value: EffortValue | undefined,
-): EffortLevel | undefined {
+): EffortLevel | OpenAIEffortLevel | undefined {
   if (value === 'low' || value === 'medium' || value === 'high') {
     return value
   }
-  if (value === 'max') {
+  if (value === 'xhigh') {
+    return value
+  }
+  if (value === 'max' && process.env.USER_TYPE === 'ant') {
     return value
   }
   return undefined
 }
 
-export function getInitialEffortSetting(): EffortLevel | undefined {
-  // toPersistableEffort validates 'max' on read, so a manually
-  // edited settings.json with an invalid level doesn't leak into a fresh session.
-  return toPersistableEffort(getInitialSettings().effortLevel)
+export function getInitialEffortSetting():
+  | EffortLevel
+  | OpenAIEffortLevel
+  | undefined {
+  return getPersistedEffortSettingForProvider({
+    settings: getInitialSettings(),
+  })
 }
 
 /**
@@ -256,6 +263,9 @@ export function isValidNumericEffort(value: number): boolean {
 
 export function convertEffortValueToLevel(value: EffortValue): EffortLevel {
   if (typeof value === 'string') {
+    if (value === 'xhigh') {
+      return 'max'
+    }
     // Runtime guard: value may come from remote config (GrowthBook) where
     // TypeScript types can't help us. Coerce unknown strings to 'high'
     // rather than passing them through unchecked.

--- a/src/utils/managedEnv.ts
+++ b/src/utils/managedEnv.ts
@@ -191,7 +191,9 @@ export function applySafeConfigEnvironmentVariables(): void {
  * should only be called after trust is established. This applies potentially
  * dangerous environment variables such as LD_PRELOAD, PATH, etc.
  */
-export function applyConfigEnvironmentVariables(): void {
+export function applyConfigEnvironmentVariables(options?: {
+  forcePersistedProviderSelectionTarget?: boolean
+}): void {
   Object.assign(process.env, filterSettingsEnv(getGlobalConfig().env))
 
   Object.assign(process.env, filterSettingsEnv(getSettings_DEPRECATED()?.env))
@@ -199,7 +201,9 @@ export function applyConfigEnvironmentVariables(): void {
   // Keep runtime provider/model env aligned with the active profile, except
   // when an explicit provider selection is already present in process.env.
   applyActiveProviderProfileFromConfig()
-  applyPersistedProviderSelectionTarget()
+  applyPersistedProviderSelectionTarget(undefined, {
+    force: options?.forcePersistedProviderSelectionTarget,
+  })
 
   // Clear caches so agents are rebuilt with the new env vars
   clearCACertsCache()

--- a/src/utils/managedEnv.ts
+++ b/src/utils/managedEnv.ts
@@ -9,6 +9,7 @@ import {
 import { clearMTLSCache } from './mtls.js'
 import { clearProxyCache, configureGlobalAgents } from './proxy.js'
 import { applyActiveProviderProfileFromConfig } from './providerProfiles.js'
+import { applyPersistedProviderSelectionTarget } from './model/providerTargets.js'
 import { isSettingSourceEnabled } from './settings/constants.js'
 import {
   getSettings_DEPRECATED,
@@ -180,6 +181,7 @@ export function applySafeConfigEnvironmentVariables(): void {
   // Apply active provider profile only when startup did not explicitly
   // select a provider via flags/env. Explicit startup intent should win.
   applyActiveProviderProfileFromConfig()
+  applyPersistedProviderSelectionTarget()
 }
 
 /**
@@ -197,6 +199,7 @@ export function applyConfigEnvironmentVariables(): void {
   // Keep runtime provider/model env aligned with the active profile, except
   // when an explicit provider selection is already present in process.env.
   applyActiveProviderProfileFromConfig()
+  applyPersistedProviderSelectionTarget()
 
   // Clear caches so agents are rebuilt with the new env vars
   clearCACertsCache()

--- a/src/utils/model/model.provider.test.ts
+++ b/src/utils/model/model.provider.test.ts
@@ -1,0 +1,61 @@
+import { afterEach, beforeEach, expect, mock, test } from 'bun:test'
+
+import { resetModelStringsForTestingOnly } from '../../bootstrap/state.js'
+
+const originalEnv = {
+  OPENAI_MODEL: process.env.OPENAI_MODEL,
+  ANTHROPIC_DEFAULT_SONNET_MODEL: process.env.ANTHROPIC_DEFAULT_SONNET_MODEL,
+  CLAUDE_CODE_USE_OPENAI: process.env.CLAUDE_CODE_USE_OPENAI,
+}
+
+async function importFreshModelModule(provider: 'openai' | 'codex') {
+  mock.restore()
+  mock.module('./providers.js', () => ({
+    getAPIProvider: () => provider,
+  }))
+  const nonce = `${Date.now()}-${Math.random()}`
+  return import(`./model.js?ts=${nonce}`)
+}
+
+beforeEach(() => {
+  mock.restore()
+  delete process.env.OPENAI_MODEL
+  delete process.env.ANTHROPIC_DEFAULT_SONNET_MODEL
+  delete process.env.CLAUDE_CODE_USE_OPENAI
+  resetModelStringsForTestingOnly()
+})
+
+afterEach(() => {
+  process.env.OPENAI_MODEL = originalEnv.OPENAI_MODEL
+  process.env.ANTHROPIC_DEFAULT_SONNET_MODEL =
+    originalEnv.ANTHROPIC_DEFAULT_SONNET_MODEL
+  process.env.CLAUDE_CODE_USE_OPENAI = originalEnv.CLAUDE_CODE_USE_OPENAI
+  resetModelStringsForTestingOnly()
+  mock.restore()
+})
+
+test.each([
+  ['openai', 'gpt-4o', 'GPT-4o'],
+  ['codex', 'gpt-5.4', 'GPT-5.4'],
+] as const)(
+  'Sonnet resolves to a provider-specific model under %s',
+  async (provider, expectedModel, expectedDisplay) => {
+    const { getDefaultSonnetModel, parseUserSpecifiedModel, renderDefaultModelSetting } =
+      await importFreshModelModule(provider)
+
+    expect(getDefaultSonnetModel()).toBe(expectedModel)
+    expect(parseUserSpecifiedModel('sonnet')).toBe(expectedModel)
+    expect(renderDefaultModelSetting('sonnet')).toBe(expectedDisplay)
+  },
+)
+
+test('provider switching does not retain a previous provider\'s sonnet mapping', async () => {
+  const openaiModule = await importFreshModelModule('openai')
+  const openaiResolved = openaiModule.parseUserSpecifiedModel('sonnet')
+
+  const codexModule = await importFreshModelModule('codex')
+  const codexResolved = codexModule.parseUserSpecifiedModel('sonnet')
+
+  expect(openaiResolved).not.toBe(codexResolved)
+  expect(codexModule.parseUserSpecifiedModel('sonnet')).toBe('gpt-5.4')
+})

--- a/src/utils/model/model.ts
+++ b/src/utils/model/model.ts
@@ -24,6 +24,7 @@ import { formatModelPricing, getOpus46CostTier } from '../modelCost.js'
 import { getSettings_DEPRECATED } from '../settings/settings.js'
 import type { PermissionMode } from '../permissions/PermissionMode.js'
 import { getAPIProvider } from './providers.js'
+import { getPersistedModelSettingForProvider, resolveSettingsModelProvider } from './providerModelSettings.js'
 import { LIGHTNING_BOLT } from '../../constants/figures.js'
 import { isModelAllowed } from './modelAllowlist.js'
 import { type ModelAlias, isModelAlias } from './aliases.js'
@@ -63,16 +64,17 @@ export function isNonCustomOpusModel(model: ModelName): boolean {
 }
 
 /**
- * Helper to get the model from /model (including via /config), the --model flag, environment variable,
- * or the saved settings. The returned value can be a model alias if that's what the user specified.
+ * Helper to get the model from /model (including via /config), the --model flag, provider-specific
+ * saved settings, environment variables, or the legacy global settings.model field. The returned
+ * value can be a model alias if that's what the user specified.
  * Undefined if the user didn't configure anything, in which case we fall back to
  * the default (null).
  *
  * Priority order within this function:
  * 1. Model override during session (from /model command) - highest priority
- * 2. Model override at startup (from --model flag)
- * 3. ANTHROPIC_MODEL environment variable
- * 4. Settings (from user's saved settings)
+ * 2. Model override at startup (from --model flag, stored in mainLoopModelOverride)
+ * 3. Provider-specific saved settings (providerModels, then compatible legacy settings.model)
+ * 4. Provider environment variable
  */
 export function getUserSpecifiedModelSetting(): ModelSetting | undefined {
   let specifiedModel: ModelSetting | undefined
@@ -82,16 +84,25 @@ export function getUserSpecifiedModelSetting(): ModelSetting | undefined {
     specifiedModel = modelOverride
   } else {
     const settings = getSettings_DEPRECATED() || {}
-    // Read the model env var that matches the active provider to prevent
-    // cross-provider leaks (e.g. ANTHROPIC_MODEL sent to the OpenAI API).
-    const provider = getAPIProvider()
-    specifiedModel =
+    const provider = resolveSettingsModelProvider()
+    const envModel =
       (provider === 'gemini' ? process.env.GEMINI_MODEL : undefined) ||
       (provider === 'mistral' ? process.env.MISTRAL_MODEL : undefined) ||
-      (provider === 'openai' || provider === 'gemini' || provider === 'mistral' || provider === 'github' ? process.env.OPENAI_MODEL : undefined) ||
-      (provider === 'firstParty' ? process.env.ANTHROPIC_MODEL : undefined) ||
-      settings.model ||
-      undefined
+      (provider === 'openai' ||
+      provider === 'codex' ||
+      provider === 'gemini' ||
+      provider === 'mistral' ||
+      provider === 'github'
+        ? process.env.OPENAI_MODEL
+        : undefined) ||
+      (provider === 'firstParty' ||
+      provider === 'bedrock' ||
+      provider === 'vertex' ||
+      provider === 'foundry'
+        ? process.env.ANTHROPIC_MODEL
+        : undefined)
+    specifiedModel =
+      getPersistedModelSettingForProvider({ settings, provider }) || envModel
   }
 
   // Ignore the user-specified model if it's not in the availableModels allowlist.
@@ -108,8 +119,8 @@ export function getUserSpecifiedModelSetting(): ModelSetting | undefined {
  * Model Selection Priority Order:
  * 1. Model override during session (from /model command) - highest priority
  * 2. Model override at startup (from --model flag)
- * 3. ANTHROPIC_MODEL environment variable
- * 4. Settings (from user's saved settings)
+ * 3. Provider-specific saved settings
+ * 4. Provider environment variable
  * 5. Built-in default
  *
  * @returns The resolved model name to use

--- a/src/utils/model/providerModelSettings.test.ts
+++ b/src/utils/model/providerModelSettings.test.ts
@@ -1,68 +1,119 @@
 import { expect, test } from 'bun:test'
 
+import type { SettingsJson } from '../settings/types.js'
 import {
   buildProviderModelSettingsUpdate,
+  getPersistedEffortSettingForProvider,
   getPersistedModelSettingForProvider,
+  resolveProviderSelectionTarget,
 } from './providerModelSettings.js'
 
-test('provider-specific model wins over legacy model', () => {
-  const settings = {
+test('provider target keys can be profile-scoped', () => {
+  expect(
+    resolveProviderSelectionTarget({
+      provider: 'openai',
+      profileId: 'provider_123',
+    }),
+  ).toEqual({
+    provider: 'openai',
+    targetKey: 'profile:provider_123',
+  })
+})
+
+test('provider-target selections take precedence over provider and legacy model settings', () => {
+  const settings: SettingsJson = {
     model: 'claude-sonnet-4-6',
     providerModels: {
-      codex: 'gpt-5.4?reasoning=xhigh',
+      openai: 'gpt-4o',
+    },
+    providerTargetSelections: {
+      openai: {
+        model: 'gpt-5.4',
+      },
     },
   }
 
   expect(
     getPersistedModelSettingForProvider({
       settings,
-      provider: 'codex',
+      provider: 'openai',
     }),
-  ).toBe('gpt-5.4?reasoning=xhigh')
+  ).toBe('gpt-5.4')
 })
 
-test('legacy first-party model does not leak into codex provider', () => {
-  expect(
-    getPersistedModelSettingForProvider({
-      settings: { model: 'claude-sonnet-4-6' },
-      provider: 'codex',
-    }),
-  ).toBeUndefined()
-})
-
-test('legacy aliases still work across providers', () => {
-  expect(
-    getPersistedModelSettingForProvider({
-      settings: { model: 'sonnet' },
-      provider: 'codex',
-    }),
-  ).toBe('sonnet')
-})
-
-test('update writes provider-specific model and keeps legacy model for compatibility', () => {
-  expect(
-    buildProviderModelSettingsUpdate({
-      provider: 'codex',
-      model: 'gpt-5.4?reasoning=xhigh',
-    }),
-  ).toEqual({
-    model: 'gpt-5.4?reasoning=xhigh',
+test('provider-target selections fall back to provider model and legacy model compatibility', () => {
+  const settings: SettingsJson = {
+    model: 'gpt-4o',
     providerModels: {
-      codex: 'gpt-5.4?reasoning=xhigh',
+      openai: 'gpt-5.4',
     },
-  })
+  }
+
+  expect(
+    getPersistedModelSettingForProvider({
+      settings,
+      provider: 'openai',
+    }),
+  ).toBe('gpt-5.4')
 })
 
-test('clearing current provider only removes matching legacy model', () => {
+test('provider-target effort settings override the legacy global effort level', () => {
+  const settings: SettingsJson = {
+    effortLevel: 'low',
+    providerTargetSelections: {
+      openai: {
+        effortLevel: 'high',
+      },
+    },
+  }
+
   expect(
-    buildProviderModelSettingsUpdate({
-      provider: 'codex',
-      model: undefined,
-      settings: { model: 'claude-sonnet-4-6' },
+    getPersistedEffortSettingForProvider({
+      settings,
+      provider: 'openai',
     }),
-  ).toEqual({
+  ).toBe('high')
+
+  expect(
+    getPersistedEffortSettingForProvider({
+      settings,
+      provider: 'gemini',
+    }),
+  ).toBe('low')
+})
+
+test('buildProviderModelSettingsUpdate writes provider-target scoped model and effort patches', () => {
+  const settings: SettingsJson = {
+    model: 'gpt-4o',
     providerModels: {
-      codex: undefined,
+      openai: 'gpt-4o',
+    },
+    providerTargetSelections: {
+      openai: {
+        model: 'gpt-4o',
+        effortLevel: 'low',
+      },
+    },
+    effortLevel: 'low',
+  }
+
+  const update = buildProviderModelSettingsUpdate({
+    settings,
+    provider: 'openai',
+    targetKey: 'profile:provider_123',
+    model: 'gpt-5.4',
+    effortLevel: 'high',
+  })
+
+  expect(update.model).toBe('gpt-5.4')
+  expect(update.effortLevel).toBe('high')
+  expect(update.providerModels).toEqual({
+    openai: 'gpt-5.4',
+  })
+  expect(update.providerTargetSelections).toEqual({
+    'profile:provider_123': {
+      model: 'gpt-5.4',
+      effortLevel: 'high',
     },
   })
 })

--- a/src/utils/model/providerModelSettings.test.ts
+++ b/src/utils/model/providerModelSettings.test.ts
@@ -1,0 +1,68 @@
+import { expect, test } from 'bun:test'
+
+import {
+  buildProviderModelSettingsUpdate,
+  getPersistedModelSettingForProvider,
+} from './providerModelSettings.js'
+
+test('provider-specific model wins over legacy model', () => {
+  const settings = {
+    model: 'claude-sonnet-4-6',
+    providerModels: {
+      codex: 'gpt-5.4?reasoning=xhigh',
+    },
+  }
+
+  expect(
+    getPersistedModelSettingForProvider({
+      settings,
+      provider: 'codex',
+    }),
+  ).toBe('gpt-5.4?reasoning=xhigh')
+})
+
+test('legacy first-party model does not leak into codex provider', () => {
+  expect(
+    getPersistedModelSettingForProvider({
+      settings: { model: 'claude-sonnet-4-6' },
+      provider: 'codex',
+    }),
+  ).toBeUndefined()
+})
+
+test('legacy aliases still work across providers', () => {
+  expect(
+    getPersistedModelSettingForProvider({
+      settings: { model: 'sonnet' },
+      provider: 'codex',
+    }),
+  ).toBe('sonnet')
+})
+
+test('update writes provider-specific model and keeps legacy model for compatibility', () => {
+  expect(
+    buildProviderModelSettingsUpdate({
+      provider: 'codex',
+      model: 'gpt-5.4?reasoning=xhigh',
+    }),
+  ).toEqual({
+    model: 'gpt-5.4?reasoning=xhigh',
+    providerModels: {
+      codex: 'gpt-5.4?reasoning=xhigh',
+    },
+  })
+})
+
+test('clearing current provider only removes matching legacy model', () => {
+  expect(
+    buildProviderModelSettingsUpdate({
+      provider: 'codex',
+      model: undefined,
+      settings: { model: 'claude-sonnet-4-6' },
+    }),
+  ).toEqual({
+    providerModels: {
+      codex: undefined,
+    },
+  })
+})

--- a/src/utils/model/providerModelSettings.ts
+++ b/src/utils/model/providerModelSettings.ts
@@ -1,9 +1,27 @@
 import { resolveProviderRequest } from '../../services/api/providerConfig.js'
+import type { EffortLevel, OpenAIEffortLevel } from '../effort.js'
 import type { SettingsJson } from '../settings/types.js'
 import { isModelAlias } from './aliases.js'
 import { getAPIProvider, type APIProvider } from './providers.js'
+import { getActiveProviderProfileSelectionTargetKey } from '../providerProfiles.js'
 
 export type ProviderModelSettings = Partial<Record<APIProvider, string>>
+export type PersistedEffortLevel = EffortLevel | OpenAIEffortLevel
+
+export type ProviderTargetSelection = {
+  model?: string
+  effortLevel?: PersistedEffortLevel
+}
+
+export type ProviderTargetSelections = Record<
+  string,
+  ProviderTargetSelection | undefined
+>
+
+export type ProviderSelectionTarget = {
+  provider: APIProvider
+  targetKey: string
+}
 
 function asTrimmedModel(value: unknown): string | undefined {
   if (typeof value !== 'string') return undefined
@@ -43,6 +61,17 @@ function isLegacyModelCompatibleWithProvider(
       )
     case 'gemini':
       return base.startsWith('gemini')
+    case 'mistral':
+      return (
+        base.startsWith('mistral') ||
+        base.startsWith('ministral') ||
+        base.startsWith('devstral') ||
+        base.startsWith('codestral') ||
+        base.startsWith('pixtral') ||
+        base.startsWith('magistral') ||
+        base.startsWith('open-mistral') ||
+        base.startsWith('open-mixtral')
+      )
     case 'github':
       return base.startsWith('github:') || base === 'copilot'
     case 'codex':
@@ -60,6 +89,44 @@ function isLegacyModelCompatibleWithProvider(
         base.includes('.claude-')
       )
   }
+}
+
+function getProviderModelSettings(
+  settings: SettingsJson | undefined,
+): ProviderModelSettings | undefined {
+  const providerModels = settings?.providerModels
+  if (!providerModels || typeof providerModels !== 'object') {
+    return undefined
+  }
+  return providerModels as ProviderModelSettings
+}
+
+function getProviderTargetSelections(
+  settings: SettingsJson | undefined,
+): ProviderTargetSelections | undefined {
+  const providerTargetSelections = settings?.providerTargetSelections
+  if (
+    !providerTargetSelections ||
+    typeof providerTargetSelections !== 'object'
+  ) {
+    return undefined
+  }
+  return providerTargetSelections as ProviderTargetSelections
+}
+
+function getPersistedEffortLevel(
+  value: unknown,
+): PersistedEffortLevel | undefined {
+  if (value === 'low' || value === 'medium' || value === 'high') {
+    return value
+  }
+  if (value === 'xhigh') {
+    return value
+  }
+  if (value === 'max' && process.env.USER_TYPE === 'ant') {
+    return value
+  }
+  return undefined
 }
 
 export function resolveSettingsModelProvider(options?: {
@@ -83,14 +150,88 @@ export function resolveSettingsModelProvider(options?: {
   return request.transport === 'codex_responses' ? 'codex' : 'openai'
 }
 
-function getProviderModelSettings(
+export function resolveProviderSelectionTarget(options?: {
+  provider?: APIProvider
+  model?: string
+  baseUrl?: string
+  targetKey?: string
+  profileId?: string
+}): ProviderSelectionTarget {
+  const provider = resolveSettingsModelProvider({
+    provider: options?.provider,
+    model: options?.model,
+    baseUrl: options?.baseUrl,
+  })
+
+  const explicitTargetKey = asTrimmedModel(options?.targetKey)
+  if (explicitTargetKey) {
+    return {
+      provider,
+      targetKey: explicitTargetKey,
+    }
+  }
+
+  const explicitProfileKey = asTrimmedModel(options?.profileId)
+  if (explicitProfileKey) {
+    return {
+      provider,
+      targetKey: `profile:${explicitProfileKey}`,
+    }
+  }
+
+  const activeProfileTargetKey = getActiveProviderProfileSelectionTargetKey()
+  return {
+    provider,
+    targetKey: activeProfileTargetKey ?? provider,
+  }
+}
+
+function getProviderTargetSelection(
   settings: SettingsJson | undefined,
-): ProviderModelSettings | undefined {
-  const providerModels = settings?.providerModels
-  if (!providerModels || typeof providerModels !== 'object') {
+  targetKey: string,
+): ProviderTargetSelection | undefined {
+  const selection = getProviderTargetSelections(settings)?.[targetKey]
+  if (!selection || typeof selection !== 'object') {
     return undefined
   }
-  return providerModels as ProviderModelSettings
+  return selection
+}
+
+function buildProviderTargetSelectionPatch(options: {
+  settings?: SettingsJson
+  targetKey: string
+  model?: string | null
+  effortLevel?: PersistedEffortLevel | null
+}): ProviderTargetSelection | undefined {
+  const current = getProviderTargetSelection(options.settings, options.targetKey)
+  const next: ProviderTargetSelection = current ? { ...current } : {}
+  let touched = false
+
+  if (Object.prototype.hasOwnProperty.call(options, 'model')) {
+    touched = true
+    const model = asTrimmedModel(options.model)
+    if (model) {
+      next.model = model
+    } else {
+      delete next.model
+    }
+  }
+
+  if (Object.prototype.hasOwnProperty.call(options, 'effortLevel')) {
+    touched = true
+    const effortLevel = getPersistedEffortLevel(options.effortLevel)
+    if (effortLevel) {
+      next.effortLevel = effortLevel
+    } else {
+      delete next.effortLevel
+    }
+  }
+
+  if (!touched) {
+    return undefined
+  }
+
+  return Object.keys(next).length > 0 ? next : undefined
 }
 
 export function getPersistedModelSettingForProvider(options?: {
@@ -98,56 +239,127 @@ export function getPersistedModelSettingForProvider(options?: {
   provider?: APIProvider
   model?: string
   baseUrl?: string
+  targetKey?: string
+  profileId?: string
 }): string | undefined {
   const settings = options?.settings
-  const provider = resolveSettingsModelProvider({
+  const target = resolveProviderSelectionTarget({
     provider: options?.provider,
     model: options?.model,
     baseUrl: options?.baseUrl,
+    targetKey: options?.targetKey,
+    profileId: options?.profileId,
   })
 
-  const providerModel = asTrimmedModel(
-    getProviderModelSettings(settings)?.[provider],
+  const providerTargetModel = asTrimmedModel(
+    getProviderTargetSelection(settings, target.targetKey)?.model,
   )
+  if (providerTargetModel) {
+    return providerTargetModel
+  }
+
+  const providerModel = asTrimmedModel(getProviderModelSettings(settings)?.[target.provider])
   if (providerModel) {
     return providerModel
   }
 
   const legacyModel = asTrimmedModel(settings?.model)
-  if (legacyModel && isLegacyModelCompatibleWithProvider(legacyModel, provider)) {
+  if (legacyModel && isLegacyModelCompatibleWithProvider(legacyModel, target.provider)) {
     return legacyModel
   }
 
   return undefined
 }
 
+export function getPersistedEffortSettingForProvider(options?: {
+  settings?: SettingsJson
+  provider?: APIProvider
+  model?: string
+  baseUrl?: string
+  targetKey?: string
+  profileId?: string
+}): PersistedEffortLevel | undefined {
+  const settings = options?.settings
+  const target = resolveProviderSelectionTarget({
+    provider: options?.provider,
+    model: options?.model,
+    baseUrl: options?.baseUrl,
+    targetKey: options?.targetKey,
+    profileId: options?.profileId,
+  })
+
+  const providerTargetEffort = getPersistedEffortLevel(
+    getProviderTargetSelection(settings, target.targetKey)?.effortLevel,
+  )
+  if (providerTargetEffort) {
+    return providerTargetEffort
+  }
+
+  return getPersistedEffortLevel(settings?.effortLevel)
+}
+
 export function buildProviderModelSettingsUpdate(options: {
   settings?: SettingsJson
   provider?: APIProvider
   model?: string | null
+  effortLevel?: PersistedEffortLevel | null
   baseUrl?: string
-}): Pick<SettingsJson, 'model' | 'providerModels'> {
-  const provider = resolveSettingsModelProvider({
+  targetKey?: string
+  profileId?: string
+}): Partial<SettingsJson> {
+  const target = resolveProviderSelectionTarget({
     provider: options.provider,
     model: options.model ?? undefined,
     baseUrl: options.baseUrl,
+    targetKey: options.targetKey,
+    profileId: options.profileId,
   })
   const normalizedModel = asTrimmedModel(options.model)
+  const normalizedEffort = getPersistedEffortLevel(options.effortLevel)
   const legacyModel = asTrimmedModel(options.settings?.model)
+  const nextTargetSelection = buildProviderTargetSelectionPatch({
+    settings: options.settings,
+    targetKey: target.targetKey,
+    ...(Object.prototype.hasOwnProperty.call(options, 'model')
+      ? { model: options.model }
+      : {}),
+    ...(Object.prototype.hasOwnProperty.call(options, 'effortLevel')
+      ? { effortLevel: options.effortLevel }
+      : {}),
+  })
 
-  const update: Pick<SettingsJson, 'model' | 'providerModels'> = {
-    providerModels: {
-      [provider]: normalizedModel,
-    } as SettingsJson['providerModels'],
+  const update: Partial<SettingsJson> = {}
+
+  if (Object.prototype.hasOwnProperty.call(options, 'model')) {
+    update.providerModels = {
+      [target.provider]: normalizedModel,
+    } as SettingsJson['providerModels']
+
+    if (normalizedModel) {
+      update.model = normalizedModel
+    } else if (
+      legacyModel &&
+      isLegacyModelCompatibleWithProvider(legacyModel, target.provider)
+    ) {
+      update.model = undefined
+    }
   }
 
-  if (normalizedModel) {
-    update.model = normalizedModel
+  if (Object.prototype.hasOwnProperty.call(options, 'effortLevel')) {
+    update.effortLevel = normalizedEffort
+  }
+
+  if (nextTargetSelection !== undefined) {
+    update.providerTargetSelections = {
+      [target.targetKey]: nextTargetSelection,
+    } as SettingsJson['providerTargetSelections']
   } else if (
-    legacyModel &&
-    isLegacyModelCompatibleWithProvider(legacyModel, provider)
+    Object.prototype.hasOwnProperty.call(options, 'model') ||
+    Object.prototype.hasOwnProperty.call(options, 'effortLevel')
   ) {
-    update.model = undefined
+    update.providerTargetSelections = {
+      [target.targetKey]: undefined,
+    } as SettingsJson['providerTargetSelections']
   }
 
   return update

--- a/src/utils/model/providerModelSettings.ts
+++ b/src/utils/model/providerModelSettings.ts
@@ -1,0 +1,154 @@
+import { resolveProviderRequest } from '../../services/api/providerConfig.js'
+import type { SettingsJson } from '../settings/types.js'
+import { isModelAlias } from './aliases.js'
+import { getAPIProvider, type APIProvider } from './providers.js'
+
+export type ProviderModelSettings = Partial<Record<APIProvider, string>>
+
+function asTrimmedModel(value: unknown): string | undefined {
+  if (typeof value !== 'string') return undefined
+  const trimmed = value.trim()
+  return trimmed ? trimmed : undefined
+}
+
+function isAliasLikeModel(model: string): boolean {
+  const normalized = model.toLowerCase().replace(/\[1m\]$/i, '').trim()
+  return isModelAlias(normalized)
+}
+
+function isLegacyModelCompatibleWithProvider(
+  model: string,
+  provider: APIProvider,
+): boolean {
+  const normalized = model.trim().toLowerCase()
+  if (!normalized) return false
+
+  const base = (normalized.split('?', 1)[0] ?? normalized).trim()
+  if (isAliasLikeModel(base)) {
+    return true
+  }
+
+  switch (provider) {
+    case 'firstParty':
+    case 'bedrock':
+    case 'vertex':
+    case 'foundry':
+      return (
+        base.startsWith('claude') ||
+        base.includes('.claude-') ||
+        base.startsWith('arn:aws:bedrock') ||
+        base.startsWith('anthropic.claude') ||
+        base.startsWith('us.anthropic.claude') ||
+        base.startsWith('eu.anthropic.claude')
+      )
+    case 'gemini':
+      return base.startsWith('gemini')
+    case 'github':
+      return base.startsWith('github:') || base === 'copilot'
+    case 'codex':
+      return (
+        base === 'codexplan' ||
+        base === 'codexspark' ||
+        base.startsWith('gpt-5')
+      )
+    case 'openai':
+      return !(
+        base.startsWith('claude') ||
+        base.startsWith('gemini') ||
+        base.startsWith('github:') ||
+        base.startsWith('arn:aws:bedrock') ||
+        base.includes('.claude-')
+      )
+  }
+}
+
+export function resolveSettingsModelProvider(options?: {
+  provider?: APIProvider
+  model?: string
+  baseUrl?: string
+}): APIProvider {
+  const provider = options?.provider ?? getAPIProvider()
+  if (options?.provider !== undefined) {
+    return provider
+  }
+
+  if (provider !== 'openai' && provider !== 'codex') {
+    return provider
+  }
+
+  const request = resolveProviderRequest({
+    model: options?.model,
+    baseUrl: options?.baseUrl,
+  })
+  return request.transport === 'codex_responses' ? 'codex' : 'openai'
+}
+
+function getProviderModelSettings(
+  settings: SettingsJson | undefined,
+): ProviderModelSettings | undefined {
+  const providerModels = settings?.providerModels
+  if (!providerModels || typeof providerModels !== 'object') {
+    return undefined
+  }
+  return providerModels as ProviderModelSettings
+}
+
+export function getPersistedModelSettingForProvider(options?: {
+  settings?: SettingsJson
+  provider?: APIProvider
+  model?: string
+  baseUrl?: string
+}): string | undefined {
+  const settings = options?.settings
+  const provider = resolveSettingsModelProvider({
+    provider: options?.provider,
+    model: options?.model,
+    baseUrl: options?.baseUrl,
+  })
+
+  const providerModel = asTrimmedModel(
+    getProviderModelSettings(settings)?.[provider],
+  )
+  if (providerModel) {
+    return providerModel
+  }
+
+  const legacyModel = asTrimmedModel(settings?.model)
+  if (legacyModel && isLegacyModelCompatibleWithProvider(legacyModel, provider)) {
+    return legacyModel
+  }
+
+  return undefined
+}
+
+export function buildProviderModelSettingsUpdate(options: {
+  settings?: SettingsJson
+  provider?: APIProvider
+  model?: string | null
+  baseUrl?: string
+}): Pick<SettingsJson, 'model' | 'providerModels'> {
+  const provider = resolveSettingsModelProvider({
+    provider: options.provider,
+    model: options.model ?? undefined,
+    baseUrl: options.baseUrl,
+  })
+  const normalizedModel = asTrimmedModel(options.model)
+  const legacyModel = asTrimmedModel(options.settings?.model)
+
+  const update: Pick<SettingsJson, 'model' | 'providerModels'> = {
+    providerModels: {
+      [provider]: normalizedModel,
+    } as SettingsJson['providerModels'],
+  }
+
+  if (normalizedModel) {
+    update.model = normalizedModel
+  } else if (
+    legacyModel &&
+    isLegacyModelCompatibleWithProvider(legacyModel, provider)
+  ) {
+    update.model = undefined
+  }
+
+  return update
+}

--- a/src/utils/model/providerTargets.test.ts
+++ b/src/utils/model/providerTargets.test.ts
@@ -5,7 +5,6 @@ import type { SettingsJson } from '../settings/types.js'
 import {
   applyPersistedProviderSelectionTarget,
   applyProviderSelectionTarget,
-  getCurrentProviderSelectionTarget,
 } from './providerTargets.js'
 
 const ORIGINAL_ENV = { ...process.env }
@@ -59,8 +58,46 @@ test('applyPersistedProviderSelectionTarget overrides launcher defaults with fir
   expect(target?.targetKey).toBe('firstParty')
   expect(process.env.CLAUDE_CODE_USE_OPENAI).toBeUndefined()
   expect(process.env.OPENAI_MODEL).toBeUndefined()
-  expect(getCurrentProviderSelectionTarget()).toEqual({
-    provider: 'firstParty',
-    targetKey: 'firstParty',
+  expect(process.env.ANTHROPIC_MODEL).toBe('claude-sonnet-4-6')
+  expect(process.env.CLAUDE_CODE_USE_GITHUB).toBeUndefined()
+})
+
+test('applyPersistedProviderSelectionTarget skips restore when provider routing is host-managed', () => {
+  process.env.CLAUDE_CODE_PROVIDER_MANAGED_BY_HOST = '1'
+  process.env.CLAUDE_CODE_USE_OPENAI = '1'
+  process.env.OPENAI_MODEL = 'gpt-5.4'
+
+  const target = applyPersistedProviderSelectionTarget({
+    activeProviderTarget: 'firstParty',
+    providerTargetSelections: {
+      firstParty: {
+        model: 'claude-sonnet-4-6',
+      },
+    },
   })
+
+  expect(target).toBeUndefined()
+  expect(process.env.CLAUDE_CODE_USE_OPENAI).toBe('1')
+  expect(process.env.OPENAI_MODEL).toBe('gpt-5.4')
+})
+
+test('applyPersistedProviderSelectionTarget can force restore in host-managed sessions', () => {
+  process.env.CLAUDE_CODE_PROVIDER_MANAGED_BY_HOST = '1'
+
+  const target = applyPersistedProviderSelectionTarget(
+    {
+      activeProviderTarget: 'codex',
+      providerTargetSelections: {
+        codex: {
+          model: 'gpt-5.4',
+          effortLevel: 'xhigh',
+        },
+      },
+    },
+    { force: true },
+  )
+
+  expect(target?.targetKey).toBe('codex')
+  expect(process.env.CLAUDE_CODE_USE_OPENAI).toBe('1')
+  expect(process.env.OPENAI_MODEL).toBe('gpt-5.4')
 })

--- a/src/utils/model/providerTargets.test.ts
+++ b/src/utils/model/providerTargets.test.ts
@@ -1,0 +1,66 @@
+import { afterEach, beforeEach, expect, test } from 'bun:test'
+
+import { enableConfigs } from '../config.js'
+import type { SettingsJson } from '../settings/types.js'
+import {
+  applyPersistedProviderSelectionTarget,
+  applyProviderSelectionTarget,
+  getCurrentProviderSelectionTarget,
+} from './providerTargets.js'
+
+const ORIGINAL_ENV = { ...process.env }
+
+beforeEach(() => {
+  for (const key of Object.keys(process.env)) {
+    delete process.env[key]
+  }
+  process.env.NODE_ENV = 'test'
+  enableConfigs()
+})
+
+afterEach(() => {
+  for (const key of Object.keys(process.env)) {
+    delete process.env[key]
+  }
+  Object.assign(process.env, ORIGINAL_ENV)
+})
+
+test('applyProviderSelectionTarget restores Codex routing from persisted target state', () => {
+  const settings: SettingsJson = {
+    activeProviderTarget: 'codex',
+    providerTargetSelections: {
+      codex: {
+        model: 'gpt-5.4',
+        effortLevel: 'xhigh',
+      },
+    },
+  }
+
+  const target = applyProviderSelectionTarget('codex', settings)
+
+  expect(target?.targetKey).toBe('codex')
+  expect(process.env.CLAUDE_CODE_USE_OPENAI).toBe('1')
+  expect(process.env.OPENAI_MODEL).toBe('gpt-5.4')
+})
+
+test('applyPersistedProviderSelectionTarget overrides launcher defaults with first-party selection', () => {
+  process.env.CLAUDE_CODE_USE_OPENAI = '1'
+  process.env.OPENAI_MODEL = 'gpt-5.4'
+
+  const target = applyPersistedProviderSelectionTarget({
+    activeProviderTarget: 'firstParty',
+    providerTargetSelections: {
+      firstParty: {
+        model: 'claude-sonnet-4-6',
+      },
+    },
+  })
+
+  expect(target?.targetKey).toBe('firstParty')
+  expect(process.env.CLAUDE_CODE_USE_OPENAI).toBeUndefined()
+  expect(process.env.OPENAI_MODEL).toBeUndefined()
+  expect(getCurrentProviderSelectionTarget()).toEqual({
+    provider: 'firstParty',
+    targetKey: 'firstParty',
+  })
+})

--- a/src/utils/model/providerTargets.ts
+++ b/src/utils/model/providerTargets.ts
@@ -1,0 +1,476 @@
+import {
+  getGlobalConfig,
+  saveGlobalConfig,
+  type ProviderProfile as ConfigProviderProfile,
+} from '../config.js'
+import { hydrateGithubModelsTokenFromSecureStorage } from '../githubModelsCredentials.js'
+import { DEFAULT_GEMINI_MODEL, DEFAULT_MISTRAL_MODEL } from '../providerProfile.js'
+import {
+  applyProviderProfileToProcessEnv,
+  clearProviderProfileEnvFromProcessEnv,
+  getProviderProfileSelectionTargetKey,
+  getProviderProfiles,
+} from '../providerProfiles.js'
+import { getSettings_DEPRECATED } from '../settings/settings.js'
+import type { SettingsJson } from '../settings/types.js'
+import {
+  getPersistedModelSettingForProvider,
+  resolveProviderSelectionTarget,
+  resolveSettingsModelProvider,
+  type ProviderSelectionTarget,
+} from './providerModelSettings.js'
+import type { APIProvider } from './providers.js'
+import { isTeamPremiumSubscriber, isMaxSubscriber } from '../auth.js'
+import { getModelStrings } from './modelStrings.js'
+
+export type ProviderSelectionTargetOption = ProviderSelectionTarget & {
+  kind: 'builtin' | 'profile'
+  label: string
+  description: string
+  profileId?: string
+  profile?: ConfigProviderProfile
+}
+
+const BUILTIN_TARGET_KEYS = [
+  'firstParty',
+  'codex',
+  'openai',
+  'github',
+  'gemini',
+  'mistral',
+] as const satisfies readonly APIProvider[]
+
+function trimString(value: unknown): string | undefined {
+  if (typeof value !== 'string') return undefined
+  const trimmed = value.trim()
+  return trimmed.length > 0 ? trimmed : undefined
+}
+
+function isBuiltinTargetKey(value: string): value is APIProvider {
+  return (BUILTIN_TARGET_KEYS as readonly string[]).includes(value)
+}
+
+function getBuiltinTargetLabel(provider: APIProvider): string {
+  switch (provider) {
+    case 'firstParty':
+      return 'Anthropic'
+    case 'codex':
+      return 'Codex'
+    case 'openai':
+      return 'OpenAI-compatible'
+    case 'github':
+      return 'GitHub Models'
+    case 'gemini':
+      return 'Gemini'
+    case 'mistral':
+      return 'Mistral'
+    case 'bedrock':
+      return 'Bedrock'
+    case 'vertex':
+      return 'Vertex'
+    case 'foundry':
+      return 'Foundry'
+  }
+}
+
+function getBuiltinTargetDescription(provider: APIProvider): string {
+  switch (provider) {
+    case 'firstParty':
+      return 'Claude models via Anthropic auth'
+    case 'codex':
+      return 'GPT-5.x models on the Codex backend'
+    case 'openai':
+      return 'Generic OpenAI-compatible endpoint'
+    case 'github':
+      return 'GitHub Models with stored GitHub token'
+    case 'gemini':
+      return 'Gemini OpenAI-compatible endpoint'
+    case 'mistral':
+      return 'Mistral OpenAI-compatible endpoint'
+    case 'bedrock':
+      return 'Anthropic-compatible Bedrock endpoint'
+    case 'vertex':
+      return 'Anthropic-compatible Vertex endpoint'
+    case 'foundry':
+      return 'Anthropic-compatible Foundry endpoint'
+  }
+}
+
+function getFirstPartyDefaultResolvedModel(): string {
+  return isMaxSubscriber() || isTeamPremiumSubscriber()
+    ? getModelStrings().opus46
+    : getModelStrings().sonnet46
+}
+
+function getFallbackModelForBuiltinTarget(provider: APIProvider): string | undefined {
+  switch (provider) {
+    case 'codex':
+      return 'gpt-5.4'
+    case 'openai':
+      return 'gpt-4o'
+    case 'github':
+      return 'github:copilot'
+    case 'gemini':
+      return DEFAULT_GEMINI_MODEL
+    case 'mistral':
+      return DEFAULT_MISTRAL_MODEL
+    case 'firstParty':
+    case 'bedrock':
+    case 'vertex':
+    case 'foundry':
+      return undefined
+  }
+}
+
+function resolveProfileTargetOption(
+  profile: ConfigProviderProfile,
+): ProviderSelectionTargetOption {
+  const targetKey = getProviderProfileSelectionTargetKey(profile.id) ?? profile.id
+  const provider =
+    profile.provider === 'anthropic'
+      ? 'firstParty'
+      : resolveSettingsModelProvider({
+          model: profile.model,
+          baseUrl: profile.baseUrl,
+        })
+
+  return {
+    kind: 'profile',
+    provider,
+    targetKey,
+    profileId: profile.id,
+    profile,
+    label: profile.name,
+    description: `${getBuiltinTargetLabel(provider)} profile · ${profile.model}`,
+  }
+}
+
+function resolveBuiltinTargetOption(provider: APIProvider): ProviderSelectionTargetOption {
+  return {
+    kind: 'builtin',
+    provider,
+    targetKey: provider,
+    label: getBuiltinTargetLabel(provider),
+    description: getBuiltinTargetDescription(provider),
+  }
+}
+
+export function getPersistedActiveProviderTarget(
+  settings: SettingsJson | undefined = getSettings_DEPRECATED(),
+): string | undefined {
+  return trimString(settings?.activeProviderTarget)
+}
+
+export function getCurrentProviderSelectionTarget(): ProviderSelectionTarget {
+  return resolveProviderSelectionTarget()
+}
+
+export function resolveProviderSelectionTargetOption(
+  targetKey: string,
+): ProviderSelectionTargetOption | undefined {
+  const trimmed = trimString(targetKey)
+  if (!trimmed) {
+    return undefined
+  }
+
+  if (trimmed.startsWith('profile:')) {
+    const profileId = trimmed.slice('profile:'.length)
+    const profile = getProviderProfiles().find(item => item.id === profileId)
+    return profile ? resolveProfileTargetOption(profile) : undefined
+  }
+
+  if (isBuiltinTargetKey(trimmed)) {
+    return resolveBuiltinTargetOption(trimmed)
+  }
+
+  return undefined
+}
+
+export function getProviderSelectionTargetOptions(
+  settings: SettingsJson | undefined = getSettings_DEPRECATED(),
+): ProviderSelectionTargetOption[] {
+  const current = getCurrentProviderSelectionTarget()
+  const persistedTargetKey = getPersistedActiveProviderTarget(settings)
+  const options: ProviderSelectionTargetOption[] = []
+  const seen = new Set<string>()
+
+  const push = (option: ProviderSelectionTargetOption | undefined): void => {
+    if (!option || seen.has(option.targetKey)) {
+      return
+    }
+    seen.add(option.targetKey)
+    options.push(option)
+  }
+
+  push(resolveProviderSelectionTargetOption(current.targetKey))
+  push(resolveProviderSelectionTargetOption(persistedTargetKey ?? ''))
+  push(resolveBuiltinTargetOption('firstParty'))
+  push(resolveBuiltinTargetOption('codex'))
+
+  if (
+    current.targetKey === current.provider &&
+    current.provider !== 'firstParty' &&
+    current.provider !== 'codex'
+  ) {
+    push(resolveBuiltinTargetOption(current.provider))
+  }
+
+  for (const profile of getProviderProfiles()) {
+    push(resolveProfileTargetOption(profile))
+  }
+
+  return options
+}
+
+function getPersistedModelForTarget(
+  target: ProviderSelectionTargetOption,
+  settings: SettingsJson | undefined,
+): string | undefined {
+  const persisted = getPersistedModelSettingForProvider({
+    settings,
+    provider: target.provider,
+    targetKey: target.targetKey,
+  })
+
+  if (!persisted) {
+    return undefined
+  }
+
+  if (
+    target.provider === 'codex' &&
+    resolveSettingsModelProvider({
+      provider: 'codex',
+      model: persisted,
+    }) !== 'codex'
+  ) {
+    return undefined
+  }
+
+  if (
+    target.provider === 'openai' &&
+    resolveSettingsModelProvider({
+      provider: 'openai',
+      model: persisted,
+    }) === 'codex'
+  ) {
+    return undefined
+  }
+
+  return persisted
+}
+
+export function getDefaultModelSettingForTarget(
+  target: ProviderSelectionTargetOption,
+  settings: SettingsJson | undefined = getSettings_DEPRECATED(),
+): string | null {
+  const persisted = getPersistedModelForTarget(target, settings)
+  if (persisted) {
+    return persisted
+  }
+
+  if (target.kind === 'profile') {
+    return target.profile?.model ?? null
+  }
+
+  return getFallbackModelForBuiltinTarget(target.provider) ?? null
+}
+
+function resolveAliasForFirstPartyTarget(modelSetting: string | null): string {
+  const normalized = modelSetting?.trim().toLowerCase() ?? ''
+  const has1mTag = normalized.endsWith('[1m]')
+  const base = has1mTag
+    ? normalized.replace(/\[1m\]$/i, '').trim()
+    : normalized
+
+  let resolved: string
+  switch (base) {
+    case '':
+      resolved = getFirstPartyDefaultResolvedModel()
+      break
+    case 'sonnet':
+      resolved = getModelStrings().sonnet46
+      break
+    case 'opus':
+      resolved = getModelStrings().opus46
+      break
+    case 'haiku':
+      resolved = getModelStrings().haiku45
+      break
+    case 'opusplan':
+      resolved = getModelStrings().sonnet46
+      break
+    default:
+      resolved = modelSetting ?? getFirstPartyDefaultResolvedModel()
+      break
+  }
+
+  return has1mTag ? `${resolved}[1m]` : resolved
+}
+
+export function resolveModelSettingForTarget(
+  target: ProviderSelectionTargetOption,
+  modelSetting: string | null | undefined,
+  settings: SettingsJson | undefined = getSettings_DEPRECATED(),
+): string {
+  const selectedModel = modelSetting ?? getDefaultModelSettingForTarget(target, settings)
+
+  if (target.provider === 'firstParty') {
+    return resolveAliasForFirstPartyTarget(selectedModel)
+  }
+
+  if (
+    selectedModel === null ||
+    selectedModel === undefined ||
+    selectedModel.trim() === '' ||
+    selectedModel === 'sonnet' ||
+    selectedModel === 'opus' ||
+    selectedModel === 'haiku'
+  ) {
+    return (
+      getDefaultModelSettingForTarget(target, settings) ??
+      getFallbackModelForBuiltinTarget(target.provider) ??
+      getFirstPartyDefaultResolvedModel()
+    )
+  }
+
+  return selectedModel
+}
+
+function clearGeminiEnv(): void {
+  delete process.env.GEMINI_API_KEY
+  delete process.env.GEMINI_AUTH_MODE
+  delete process.env.GEMINI_ACCESS_TOKEN
+  delete process.env.GEMINI_MODEL
+  delete process.env.GEMINI_BASE_URL
+  delete process.env.GOOGLE_API_KEY
+}
+
+function clearMistralEnv(): void {
+  delete process.env.MISTRAL_API_KEY
+  delete process.env.MISTRAL_MODEL
+  delete process.env.MISTRAL_BASE_URL
+}
+
+function clearAnthropicSelectionEnv(): void {
+  delete process.env.ANTHROPIC_MODEL
+  delete process.env.ANTHROPIC_BASE_URL
+  delete process.env.ANTHROPIC_API_KEY
+}
+
+function setOpenAIProviderEnv(model: string): void {
+  clearProviderProfileEnvFromProcessEnv()
+  clearGeminiEnv()
+  clearMistralEnv()
+  clearAnthropicSelectionEnv()
+
+  process.env.CLAUDE_CODE_USE_OPENAI = '1'
+  process.env.OPENAI_MODEL = model
+  delete process.env.CLAUDE_CODE_USE_GITHUB
+}
+
+function setFirstPartyProviderEnv(model: string | undefined): void {
+  clearProviderProfileEnvFromProcessEnv()
+  clearGeminiEnv()
+  clearMistralEnv()
+  delete process.env.CLAUDE_CODE_USE_GITHUB
+
+  if (model) {
+    process.env.ANTHROPIC_MODEL = model
+  } else {
+    delete process.env.ANTHROPIC_MODEL
+  }
+}
+
+function setGithubProviderEnv(model: string): void {
+  clearProviderProfileEnvFromProcessEnv()
+  clearGeminiEnv()
+  clearMistralEnv()
+  clearAnthropicSelectionEnv()
+
+  process.env.CLAUDE_CODE_USE_GITHUB = '1'
+  process.env.OPENAI_MODEL = model
+  hydrateGithubModelsTokenFromSecureStorage()
+}
+
+function setGeminiProviderEnv(model: string): void {
+  clearProviderProfileEnvFromProcessEnv()
+  clearMistralEnv()
+  clearAnthropicSelectionEnv()
+
+  process.env.CLAUDE_CODE_USE_GEMINI = '1'
+  process.env.GEMINI_MODEL = model
+}
+
+function setMistralProviderEnv(model: string): void {
+  clearProviderProfileEnvFromProcessEnv()
+  clearGeminiEnv()
+  clearAnthropicSelectionEnv()
+
+  process.env.CLAUDE_CODE_USE_MISTRAL = '1'
+  process.env.MISTRAL_MODEL = model
+}
+
+export function applyProviderSelectionTarget(
+  targetKey: string,
+  settings: SettingsJson | undefined = getSettings_DEPRECATED(),
+): ProviderSelectionTargetOption | undefined {
+  const target = resolveProviderSelectionTargetOption(targetKey)
+  if (!target) {
+    return undefined
+  }
+
+  if (target.kind === 'profile' && target.profile) {
+    const current = getGlobalConfig()
+    if (current.activeProviderProfileId !== target.profile.id) {
+      saveGlobalConfig(config => ({
+        ...config,
+        activeProviderProfileId: target.profile!.id,
+      }))
+    }
+    applyProviderProfileToProcessEnv(target.profile)
+    return target
+  }
+
+  const model = getPersistedModelForTarget(target, settings)
+  const resolvedModel = resolveModelSettingForTarget(target, model, settings)
+
+  switch (target.provider) {
+    case 'firstParty':
+      setFirstPartyProviderEnv(model ? resolvedModel : undefined)
+      return target
+    case 'codex':
+      setOpenAIProviderEnv(resolvedModel)
+      return target
+    case 'openai':
+      setOpenAIProviderEnv(resolvedModel)
+      return target
+    case 'github':
+      setGithubProviderEnv(resolvedModel)
+      return target
+    case 'gemini':
+      setGeminiProviderEnv(resolvedModel)
+      return target
+    case 'mistral':
+      setMistralProviderEnv(resolvedModel)
+      return target
+    case 'bedrock':
+    case 'vertex':
+    case 'foundry':
+      return target
+  }
+}
+
+export function applyPersistedProviderSelectionTarget(
+  settings: SettingsJson | undefined = getSettings_DEPRECATED(),
+): ProviderSelectionTargetOption | undefined {
+  if (process.env.CLAUDE_CODE_PROVIDER_CLI_OVERRIDE === '1') {
+    return undefined
+  }
+
+  const targetKey = getPersistedActiveProviderTarget(settings)
+  if (!targetKey) {
+    return undefined
+  }
+
+  return applyProviderSelectionTarget(targetKey, settings)
+}

--- a/src/utils/model/providerTargets.ts
+++ b/src/utils/model/providerTargets.ts
@@ -5,6 +5,7 @@ import {
 } from '../config.js'
 import { hydrateGithubModelsTokenFromSecureStorage } from '../githubModelsCredentials.js'
 import { DEFAULT_GEMINI_MODEL, DEFAULT_MISTRAL_MODEL } from '../providerProfile.js'
+import { isEnvTruthy } from '../envUtils.js'
 import {
   applyProviderProfileToProcessEnv,
   clearProviderProfileEnvFromProcessEnv,
@@ -462,8 +463,18 @@ export function applyProviderSelectionTarget(
 
 export function applyPersistedProviderSelectionTarget(
   settings: SettingsJson | undefined = getSettings_DEPRECATED(),
+  options?: {
+    force?: boolean
+  },
 ): ProviderSelectionTargetOption | undefined {
-  if (process.env.CLAUDE_CODE_PROVIDER_CLI_OVERRIDE === '1') {
+  if (!options?.force && process.env.CLAUDE_CODE_PROVIDER_CLI_OVERRIDE === '1') {
+    return undefined
+  }
+
+  if (
+    !options?.force &&
+    isEnvTruthy(process.env.CLAUDE_CODE_PROVIDER_MANAGED_BY_HOST)
+  ) {
     return undefined
   }
 

--- a/src/utils/providerFlag.ts
+++ b/src/utils/providerFlag.ts
@@ -87,6 +87,7 @@ export function applyProviderFlag(
   delete process.env.CLAUDE_CODE_USE_VERTEX
 
   const model = parseModelFlag(args)
+  process.env.CLAUDE_CODE_PROVIDER_CLI_OVERRIDE = '1'
 
   switch (provider as ProviderFlagName) {
     case 'anthropic':

--- a/src/utils/providerProfiles.ts
+++ b/src/utils/providerProfiles.ts
@@ -344,6 +344,32 @@ export function getActiveProviderProfile(
   return profiles.find(profile => profile.id === activeId) ?? profiles[0]
 }
 
+export function getProviderProfileSelectionTargetKey(
+  profileId: string,
+): string | undefined {
+  const trimmed = trimOrUndefined(profileId)
+  return trimmed ? `profile:${trimmed}` : undefined
+}
+
+export function getActiveProviderProfileSelectionTargetKey(
+  config = getGlobalConfig(),
+): string | undefined {
+  const activeProfile = getActiveProviderProfile(config)
+  if (!activeProfile) {
+    return undefined
+  }
+
+  if (process.env[PROFILE_ENV_APPLIED_FLAG] !== '1') {
+    return undefined
+  }
+
+  if (trimOrUndefined(process.env[PROFILE_ENV_APPLIED_ID]) !== activeProfile.id) {
+    return undefined
+  }
+
+  return getProviderProfileSelectionTargetKey(activeProfile.id)
+}
+
 export function clearProviderProfileEnvFromProcessEnv(
   processEnv: NodeJS.ProcessEnv = process.env,
 ): void {

--- a/src/utils/settings/applySettingsChange.ts
+++ b/src/utils/settings/applySettingsChange.ts
@@ -1,6 +1,8 @@
 import type { AppState } from '../../state/AppState.js'
 import { logForDebugging } from '../debug.js'
 import { updateHooksConfigSnapshot } from '../hooks/hooksConfigSnapshot.js'
+import { getPersistedEffortSettingForProvider } from '../model/providerModelSettings.js'
+import { getPersistedActiveProviderTarget } from '../model/providerTargets.js'
 import {
   createDisabledBypassPermissionsContext,
   findOverlyBroadBashPermissions,
@@ -71,8 +73,14 @@ export function applySettingsChange(
     // (e.g. via applyFlagSettings from IDE). Only propagate if the setting
     // itself changed — otherwise unrelated settings churn (e.g. tips dismissal
     // on startup) would clobber a --effort CLI flag value held in AppState.
-    const prevEffort = prev.settings.effortLevel
-    const newEffort = newSettings.effortLevel
+    const prevEffort = getPersistedEffortSettingForProvider({
+      settings: prev.settings,
+      targetKey: getPersistedActiveProviderTarget(prev.settings),
+    })
+    const newEffort = getPersistedEffortSettingForProvider({
+      settings: newSettings,
+      targetKey: getPersistedActiveProviderTarget(newSettings),
+    })
     const effortChanged = prevEffort !== newEffort
 
     return {

--- a/src/utils/settings/types.ts
+++ b/src/utils/settings/types.ts
@@ -383,6 +383,21 @@ export const SettingsSchema = lazySchema(() =>
         .string()
         .optional()
         .describe('Override the default model used by Claude Code'),
+      providerModels: z
+        .object({
+          firstParty: z.string().optional(),
+          bedrock: z.string().optional(),
+          vertex: z.string().optional(),
+          foundry: z.string().optional(),
+          openai: z.string().optional(),
+          gemini: z.string().optional(),
+          github: z.string().optional(),
+          codex: z.string().optional(),
+        })
+        .optional()
+        .describe(
+          'Provider-specific persisted model selections used by /model. These override built-in provider defaults without leaking between providers.',
+        ),
       // Enterprise allowlist of models
       availableModels: z
         .array(z.string())

--- a/src/utils/settings/types.ts
+++ b/src/utils/settings/types.ts
@@ -259,6 +259,11 @@ export const CUSTOMIZATION_SURFACES = [
   'mcp',
 ] as const
 
+const PERSISTED_EFFORT_LEVELS =
+  process.env.USER_TYPE === 'ant'
+    ? (['low', 'medium', 'high', 'max', 'xhigh'] as const)
+    : (['low', 'medium', 'high', 'xhigh'] as const)
+
 export const SettingsSchema = lazySchema(() =>
   z
     .object({
@@ -391,12 +396,31 @@ export const SettingsSchema = lazySchema(() =>
           foundry: z.string().optional(),
           openai: z.string().optional(),
           gemini: z.string().optional(),
+          mistral: z.string().optional(),
           github: z.string().optional(),
           codex: z.string().optional(),
         })
         .optional()
         .describe(
           'Provider-specific persisted model selections used by /model. These override built-in provider defaults without leaking between providers.',
+        ),
+      providerTargetSelections: z
+        .record(
+          z.string(),
+          z.object({
+            model: z.string().optional(),
+            effortLevel: z.enum(PERSISTED_EFFORT_LEVELS).optional(),
+          }),
+        )
+        .optional()
+        .describe(
+          'Provider-target scoped model and effort selections. Keys may be provider families or future profile-scoped targets. This is the canonical persisted state for /model and /effort.',
+        ),
+      activeProviderTarget: z
+        .string()
+        .optional()
+        .describe(
+          'Persisted provider target selected by /model. This can reference a builtin provider family (for example "firstParty" or "codex") or a profile-scoped target key such as "profile:<id>".',
         ),
       // Enterprise allowlist of models
       availableModels: z
@@ -729,7 +753,7 @@ export const SettingsSchema = lazySchema(() =>
             'enabled automatically for supported models.',
         ),
       effortLevel: z
-        .enum(['low', 'medium', 'high', 'max'])
+        .enum(PERSISTED_EFFORT_LEVELS)
         .optional()
         .catch(undefined)
         .describe('Persisted effort level for supported models.'),


### PR DESCRIPTION
## Summary
- make persisted `/model` and `/effort` settings provider-target scoped instead of globally leaking between providers
- restore persisted provider selections on startup and preserve explicit CLI overrides
- add tests for provider-specific model resolution, effort persistence, and provider target restoration

## Testing
- `env -i PATH=/Users/jguan/.bun/bin:/usr/bin:/bin HOME=$HOME TMPDIR=${TMPDIR:-/tmp} bun test ./src/utils/model/providerModelSettings.test.ts ./src/utils/model/providerTargets.test.ts ./src/utils/model/model.provider.test.ts ./src/utils/effort.provider.test.ts ./src/services/api/codexShim.test.ts`
- `env -i PATH=/Users/jguan/.bun/bin:/usr/bin:/bin HOME=$HOME TMPDIR=${TMPDIR:-/tmp} bun run build`
