### PR TITLE
Set active Agent, some minor fixes in arrow keys

### DIFF
--- a/src/components/agents/AgentsMenu.tsx
+++ b/src/components/agents/AgentsMenu.tsx
@@ -7,12 +7,14 @@ import type { CommandResultDisplay } from '../../commands.js';
 import { useExitOnCtrlCDWithKeybindings } from '../../hooks/useExitOnCtrlCDWithKeybindings.js';
 import { useMergedTools } from '../../hooks/useMergedTools.js';
 import { Box, Text } from '../../ink.js';
+import { setMainThreadAgentType } from '../../bootstrap/state.js';
 import { useAppState, useSetAppState } from '../../state/AppState.js';
 import type { Tools } from '../../Tool.js';
 import { type ResolvedAgent, resolveAgentOverrides } from '../../tools/AgentTool/agentDisplay.js';
 import { type AgentDefinition, getActiveAgentsFromList } from '../../tools/AgentTool/loadAgentsDir.js';
 import { toError } from '../../utils/errors.js';
 import { logError } from '../../utils/log.js';
+import { saveAgentSetting } from '../../utils/sessionStorage.js';
 import { Select } from '../CustomSelect/select.js';
 import { Dialog } from '../design-system/Dialog.js';
 import { AgentDetail } from './AgentDetail.js';
@@ -48,6 +50,7 @@ export function AgentsMenu(t0) {
   const agentDefinitions = useAppState(_temp);
   const mcpTools = useAppState(_temp2);
   const toolPermissionContext = useAppState(_temp3);
+  const activeSessionAgentType = useAppState(_temp10);
   const setAppState = useSetAppState();
   const {
     allAgents,
@@ -369,50 +372,67 @@ export function AgentsMenu(t0) {
           t17 = $[65];
         }
         const menuItems = t17;
-        let t18;
-        if ($[66] !== agentToUse || $[67] !== modeState) {
-          t18 = value_0 => {
-            bb129: switch (value_0) {
-              case "view":
-                {
-                  setModeState({
-                    mode: "view-agent",
-                    agent: agentToUse,
-                    previousMode: modeState.previousMode
-                  });
-                  break bb129;
-                }
-              case "edit":
-                {
-                  setModeState({
-                    mode: "edit-agent",
-                    agent: agentToUse,
-                    previousMode: modeState
-                  });
-                  break bb129;
-                }
-              case "delete":
-                {
-                  setModeState({
-                    mode: "delete-confirm",
-                    agent: agentToUse,
-                    previousMode: modeState
-                  });
-                  break bb129;
-                }
-              case "back":
-                {
-                  setModeState(modeState.previousMode);
-                }
-            }
-          };
-          $[66] = agentToUse;
-          $[67] = modeState;
-          $[68] = t18;
-        } else {
-          t18 = $[68];
-        }
-        const handleMenuSelect = t18;
+        const isAlreadyActive = activeSessionAgentType === agentToUse.agentType;
+        const sessionMenuItem = isAlreadyActive ? {
+          label: "Active in this session",
+          value: "active-noop"
+        } : {
+          label: "Set as active for this session",
+          value: "activate"
+        };
+        const menuItemsWithSessionOption = [...menuItems.slice(0, -1), sessionMenuItem, menuItems[menuItems.length - 1]];
+        const handleMenuSelect = value_0 => {
+          bb129: switch (value_0) {
+            case "view":
+              {
+                setModeState({
+                  mode: "view-agent",
+                  agent: agentToUse,
+                  previousMode: modeState.previousMode
+                });
+                break bb129;
+              }
+            case "edit":
+              {
+                setModeState({
+                  mode: "edit-agent",
+                  agent: agentToUse,
+                  previousMode: modeState
+                });
+                break bb129;
+              }
+            case "delete":
+              {
+                setModeState({
+                  mode: "delete-confirm",
+                  agent: agentToUse,
+                  previousMode: modeState
+                });
+                break bb129;
+              }
+            case "activate":
+              {
+                setMainThreadAgentType(agentToUse.agentType);
+                saveAgentSetting(agentToUse.agentType);
+                setAppState(prev => ({
+                  ...prev,
+                  agent: agentToUse.agentType
+                }));
+                setChanges(prev_0 => [...prev_0, `Active agent for this session: ${chalk.bold(agentToUse.agentType)}`]);
+                setModeState(modeState.previousMode);
+                break bb129;
+              }
+            case "active-noop":
+              {
+                setModeState(modeState.previousMode);
+                break bb129;
+              }
+            case "back":
+              {
+                setModeState(modeState.previousMode);
+              }
+          }
+        };
         let t19;
         if ($[69] !== modeState.previousMode) {
           t19 = () => setModeState(modeState.previousMode);
@@ -430,10 +450,10 @@ export function AgentsMenu(t0) {
           t20 = $[72];
         }
         let t21;
-        if ($[73] !== handleMenuSelect || $[74] !== menuItems || $[75] !== t20) {
-          t21 = <Select options={menuItems} onChange={handleMenuSelect} onCancel={t20} />;
+        if ($[73] !== handleMenuSelect || $[74] !== menuItemsWithSessionOption || $[75] !== t20) {
+          t21 = <Select options={menuItemsWithSessionOption} onChange={handleMenuSelect} onCancel={t20} />;
           $[73] = handleMenuSelect;
-          $[74] = menuItems;
+          $[74] = menuItemsWithSessionOption;
           $[75] = t20;
           $[76] = t21;
         } else {
@@ -796,4 +816,7 @@ function _temp2(s_0) {
 }
 function _temp(s) {
   return s.agentDefinitions;
+}
+function _temp10(s_2) {
+  return s_2.agent;
 }

--- a/src/screens/REPL.tsx
+++ b/src/screens/REPL.tsx
@@ -196,7 +196,7 @@ const PROACTIVE_NO_OP_SUBSCRIBE = (_cb: () => void) => () => { };
 const PROACTIVE_FALSE = () => false;
 const SUGGEST_BG_PR_NOOP = (_p: string, _n: string): boolean => false;
 const useProactive = feature('PROACTIVE') || feature('KAIROS') ? require('../proactive/useProactive.js').useProactive : null;
-const useScheduledTasks = require('../hooks/useScheduledTasks.js').useScheduledTasks;
+const useScheduledTasks = feature('AGENT_TRIGGERS') ? require('../hooks/useScheduledTasks.js').useScheduledTasks : null;
 /* eslint-enable @typescript-eslint/no-require-imports */
 import { isAgentSwarmsEnabled } from '../utils/agentSwarmsEnabled.js';
 import { useTaskListWatcher } from '../hooks/useTaskListWatcher.js';
@@ -615,6 +615,7 @@ export function REPL({
   // Agent definition is state so /resume can update it mid-session
   const [mainThreadAgentDefinition, setMainThreadAgentDefinition] = useState(initialMainThreadAgentDefinition);
   const toolPermissionContext = useAppState(s => s.toolPermissionContext);
+  const activeSessionAgentType = useAppState(s => s.agent);
   const verbose = useAppState(s => s.verbose);
   const mcp = useAppState(s => s.mcp);
   const agentDefinitions = useAppState(s => s.agentDefinitions);
@@ -677,6 +678,18 @@ export function REPL({
 
   // Local state for commands (hot-reloadable when skill files change)
   const [localCommands, setLocalCommands] = useState(initialCommands);
+
+  // Keep the main-thread agent definition in sync with AppState.agent so
+  // selecting an active agent from /agents takes effect immediately.
+  useEffect(() => {
+    const resolved = activeSessionAgentType ? agentDefinitions.activeAgents.find(a => a.agentType === activeSessionAgentType) : undefined;
+    setMainThreadAgentDefinition(prev => {
+      if (prev?.agentType === resolved?.agentType && prev?.source === resolved?.source) {
+        return prev;
+      }
+      return resolved;
+    });
+  }, [activeSessionAgentType, agentDefinitions.activeAgents]);
 
   // Watch for skill file changes and reload all commands
   useSkillsChange(isRemoteSession ? undefined : getProjectRoot(), setLocalCommands);
@@ -827,14 +840,8 @@ export function REPL({
   // Merge commands from local state, plugins, and MCP
   const commandsWithPlugins = useMergedCommands(localCommands, pluginCommands as Command[]);
   const mergedCommands = useMergedCommands(commandsWithPlugins, mcp.commands as Command[]);
-  // Keep plugin commands out of render-time command props. Feeding the full
-  // execution set into PromptInput/Messages reintroduced the startup repaint
-  // freeze, while transcript rendering still round-trips plugin skills via the
-  // SkillTool's `skill` payload without needing plugin command objects here.
-  const renderMergedCommands = useMergedCommands(localCommands, mcp.commands as Command[]);
   // Filter out all commands if disableSlashCommands is true
   const commands = useMemo(() => disableSlashCommands ? [] : mergedCommands, [disableSlashCommands, mergedCommands]);
-  const renderCommands = useMemo(() => disableSlashCommands ? [] : renderMergedCommands, [disableSlashCommands, renderMergedCommands]);
   useIdeLogging(isRemoteSession ? EMPTY_MCP_CLIENTS : mcp.clients);
   useIdeSelection(isRemoteSession ? EMPTY_MCP_CLIENTS : mcp.clients, setIDESelection);
   const [streamMode, setStreamMode] = useState<SpinnerMode>('responding');
@@ -4076,13 +4083,21 @@ export function REPL({
   });
 
   // Scheduled tasks from .claude/scheduled_tasks.json (CronCreate/Delete/List)
-  // and session-only /loop runs.
-  const assistantMode = store.getState().kairosEnabled;
-  useScheduledTasks({
-    isLoading,
-    assistantMode,
-    setMessages
-  });
+  if (feature('AGENT_TRIGGERS')) {
+    // Assistant mode bypasses the isLoading gate (the proactive tick →
+    // Sleep → tick loop would otherwise starve the scheduler).
+    // kairosEnabled is set once in initialState (main.tsx) and never mutated — no
+    // subscription needed. The tengu_kairos_cron runtime gate is checked inside
+    // useScheduledTasks's effect (not here) since wrapping a hook call in a dynamic
+    // condition would break rules-of-hooks.
+    const assistantMode = store.getState().kairosEnabled;
+    // biome-ignore lint/correctness/useHookAtTopLevel: feature() is a compile-time constant
+    useScheduledTasks!({
+      isLoading,
+      assistantMode,
+      setMessages
+    });
+  }
 
   // Note: Permission polling is now handled by useInboxPoller
   // - Workers receive permission responses via mailbox messages
@@ -4424,7 +4439,7 @@ export function REPL({
     // and transcript-mode are mutually exclusive (this early return), so
     // only one ScrollBox is ever mounted at a time.
     const transcriptScrollRef = isFullscreenEnvEnabled() && !disableVirtualScroll && !dumpMode ? scrollRef : undefined;
-    const transcriptMessagesElement = <Messages messages={transcriptMessages} tools={tools} commands={renderCommands} verbose={true} toolJSX={null} toolUseConfirmQueue={[]} inProgressToolUseIDs={inProgressToolUseIDs} isMessageSelectorVisible={false} conversationId={conversationId} screen={screen} agentDefinitions={agentDefinitions} streamingToolUses={transcriptStreamingToolUses} showAllInTranscript={showAllInTranscript} onOpenRateLimitOptions={handleOpenRateLimitOptions} isLoading={isLoading} hidePastThinking={true} streamingThinking={streamingThinking} scrollRef={transcriptScrollRef} jumpRef={jumpRef} onSearchMatchesChange={onSearchMatchesChange} scanElement={scanElement} setPositions={setPositions} disableRenderCap={dumpMode} />;
+    const transcriptMessagesElement = <Messages messages={transcriptMessages} tools={tools} commands={commands} verbose={true} toolJSX={null} toolUseConfirmQueue={[]} inProgressToolUseIDs={inProgressToolUseIDs} isMessageSelectorVisible={false} conversationId={conversationId} screen={screen} agentDefinitions={agentDefinitions} streamingToolUses={transcriptStreamingToolUses} showAllInTranscript={showAllInTranscript} onOpenRateLimitOptions={handleOpenRateLimitOptions} isLoading={isLoading} hidePastThinking={true} streamingThinking={streamingThinking} scrollRef={transcriptScrollRef} jumpRef={jumpRef} onSearchMatchesChange={onSearchMatchesChange} scanElement={scanElement} setPositions={setPositions} disableRenderCap={dumpMode} />;
     const transcriptToolJSX = toolJSX && <Box flexDirection="column" width="100%">
       {toolJSX.jsx}
     </Box>;
@@ -4592,7 +4607,7 @@ export function REPL({
         jumpToNew(scrollRef.current);
       }} scrollable={<>
         <TeammateViewHeader />
-        <Messages messages={displayedMessages} tools={tools} commands={renderCommands} verbose={verbose} toolJSX={toolJSX} toolUseConfirmQueue={toolUseConfirmQueue} inProgressToolUseIDs={viewedTeammateTask ? viewedTeammateTask.inProgressToolUseIDs ?? new Set() : inProgressToolUseIDs} isMessageSelectorVisible={isMessageSelectorVisible} conversationId={conversationId} screen={screen} streamingToolUses={streamingToolUses} showAllInTranscript={showAllInTranscript} agentDefinitions={agentDefinitions} onOpenRateLimitOptions={handleOpenRateLimitOptions} isLoading={isLoading} streamingText={isLoading && !viewedAgentTask ? visibleStreamingText : null} isBriefOnly={viewedAgentTask ? false : isBriefOnly} unseenDivider={viewedAgentTask ? undefined : unseenDivider} scrollRef={isFullscreenEnvEnabled() ? scrollRef : undefined} trackStickyPrompt={isFullscreenEnvEnabled() ? true : undefined} cursor={cursor} setCursor={setCursor} cursorNavRef={cursorNavRef} />
+        <Messages messages={displayedMessages} tools={tools} commands={commands} verbose={verbose} toolJSX={toolJSX} toolUseConfirmQueue={toolUseConfirmQueue} inProgressToolUseIDs={viewedTeammateTask ? viewedTeammateTask.inProgressToolUseIDs ?? new Set() : inProgressToolUseIDs} isMessageSelectorVisible={isMessageSelectorVisible} conversationId={conversationId} screen={screen} streamingToolUses={streamingToolUses} showAllInTranscript={showAllInTranscript} agentDefinitions={agentDefinitions} onOpenRateLimitOptions={handleOpenRateLimitOptions} isLoading={isLoading} streamingText={isLoading && !viewedAgentTask ? visibleStreamingText : null} isBriefOnly={viewedAgentTask ? false : isBriefOnly} unseenDivider={viewedAgentTask ? undefined : unseenDivider} scrollRef={isFullscreenEnvEnabled() ? scrollRef : undefined} trackStickyPrompt={isFullscreenEnvEnabled() ? true : undefined} cursor={cursor} setCursor={setCursor} cursorNavRef={cursorNavRef} />
         <AwsAuthStatusBox />
         {/* Hide the processing placeholder while a modal is showing —
                   it would sit at the last visible transcript row right above
@@ -4925,7 +4940,7 @@ export function REPL({
             {"external" === 'ant' && skillImprovementSurvey.suggestion && <SkillImprovementSurvey isOpen={skillImprovementSurvey.isOpen} skillName={skillImprovementSurvey.suggestion.skillName} updates={skillImprovementSurvey.suggestion.updates} handleSelect={skillImprovementSurvey.handleSelect} inputValue={inputValue} setInputValue={setInputValue} />}
             {showIssueFlagBanner && <IssueFlagBanner />}
             { }
-            <PromptInput debug={debug} ideSelection={ideSelection} hasSuppressedDialogs={!!hasSuppressedDialogs} isLocalJSXCommandActive={isShowingLocalJSXCommand} getToolUseContext={getToolUseContext} toolPermissionContext={toolPermissionContext} setToolPermissionContext={setToolPermissionContext} apiKeyStatus={apiKeyStatus} commands={renderCommands} agents={agentDefinitions.activeAgents} isLoading={isLoading} onExit={handleExit} verbose={verbose} messages={messages} onAutoUpdaterResult={setAutoUpdaterResult} autoUpdaterResult={autoUpdaterResult} input={inputValue} onInputChange={setInputValue} mode={inputMode} onModeChange={setInputMode} stashedPrompt={stashedPrompt} setStashedPrompt={setStashedPrompt} submitCount={submitCount} onShowMessageSelector={handleShowMessageSelector} onMessageActionsEnter={
+            <PromptInput debug={debug} ideSelection={ideSelection} hasSuppressedDialogs={!!hasSuppressedDialogs} isLocalJSXCommandActive={isShowingLocalJSXCommand} getToolUseContext={getToolUseContext} toolPermissionContext={toolPermissionContext} setToolPermissionContext={setToolPermissionContext} apiKeyStatus={apiKeyStatus} commands={commands} agents={agentDefinitions.activeAgents} isLoading={isLoading} onExit={handleExit} verbose={verbose} messages={messages} onAutoUpdaterResult={setAutoUpdaterResult} autoUpdaterResult={autoUpdaterResult} input={inputValue} onInputChange={setInputValue} mode={inputMode} onModeChange={setInputMode} stashedPrompt={stashedPrompt} setStashedPrompt={setStashedPrompt} submitCount={submitCount} onShowMessageSelector={handleShowMessageSelector} onMessageActionsEnter={
               // Works during isLoading — edit cancels first; uuid selection survives appends.
               feature('MESSAGE_ACTIONS') && isFullscreenEnvEnabled() && !disableMessageActions ? enterMessageActions : undefined} mcpClients={mcpClients} pastedContents={pastedContents} setPastedContents={setPastedContents} vimMode={vimMode} setVimMode={setVimMode} showBashesDialog={showBashesDialog} setShowBashesDialog={setShowBashesDialog} onSubmit={onSubmit} onAgentSubmit={onAgentSubmit} isSearchingHistory={isSearchingHistory} setIsSearchingHistory={setIsSearchingHistory} helpOpen={isHelpOpen} setHelpOpen={setIsHelpOpen} insertTextRef={feature('VOICE_MODE') ? insertTextRef : undefined} voiceInterimRange={voice.interimRange} />
             <SessionBackgroundHint onBackgroundSession={handleBackgroundSession} isLoading={isLoading} />

--- a/src/tools/AgentTool/loadAgentsDir.ts
+++ b/src/tools/AgentTool/loadAgentsDir.ts
@@ -1,4 +1,5 @@
 import { feature } from 'bun:bundle'
+import type { Dirent } from 'node:fs'
 import { readdir, readFile } from 'fs/promises'
 import memoize from 'lodash-es/memoize.js'
 import { basename, join } from 'path'
@@ -322,7 +323,7 @@ async function loadLegacyProjectRootAgentFiles(
 
   const allParsedFiles = await Promise.all(
     claudeDirs.map(async claudeDir => {
-      let entries
+      let entries: Dirent[] = []
       try {
         entries = await readdir(claudeDir, { withFileTypes: true })
       } catch (e: unknown) {
@@ -363,7 +364,7 @@ async function loadLegacyProjectRootAgentFiles(
         }),
       )
 
-      return parsedFiles.filter(file => file !== null)
+      return parsedFiles.filter((file): file is NonNullable<typeof file> => file !== null)
     }),
   )
 

--- a/src/tools/AgentTool/loadAgentsDir.ts
+++ b/src/tools/AgentTool/loadAgentsDir.ts
@@ -1,6 +1,7 @@
 import { feature } from 'bun:bundle'
+import { readdir, readFile } from 'fs/promises'
 import memoize from 'lodash-es/memoize.js'
-import { basename } from 'path'
+import { basename, join } from 'path'
 import type { SettingSource } from 'src/utils/settings/constants.js'
 import { z } from 'zod/v4'
 import { isAutoMemoryEnabled } from '../../memdir/paths.js'
@@ -21,6 +22,8 @@ import {
 } from '../../utils/effort.js'
 import { isEnvTruthy } from '../../utils/envUtils.js'
 import { parsePositiveIntFromFrontmatter } from '../../utils/frontmatterParser.js'
+import { parseFrontmatter } from '../../utils/frontmatterParser.js'
+import { findGitRoot } from '../../utils/git.js'
 import { lazySchema } from '../../utils/lazySchema.js'
 import { logError } from '../../utils/log.js'
 import {
@@ -28,6 +31,7 @@ import {
   parseAgentToolsFromFrontmatter,
   parseSlashCommandToolsFromFrontmatter,
 } from '../../utils/markdownConfigLoader.js'
+import { isFsInaccessible } from '../../utils/errors.js'
 import {
   PERMISSION_MODES,
   type PermissionMode,
@@ -293,6 +297,79 @@ async function initializeAgentMemorySnapshots(
   )
 }
 
+/**
+ * Backward-compatible fallback for project agents placed directly under
+ * .claude/*.md instead of the canonical .claude/agents/*.md.
+ *
+ * These files are loaded with lower precedence than canonical project agents.
+ */
+async function loadLegacyProjectRootAgentFiles(
+  cwd: string,
+): Promise<
+  Array<{
+    filePath: string
+    baseDir: string
+    frontmatter: Record<string, unknown>
+    content: string
+    source: SettingSource
+  }>
+> {
+  const gitRoot = findGitRoot(cwd)
+  const claudeDirs = [join(cwd, '.claude')]
+  if (gitRoot && gitRoot !== cwd) {
+    claudeDirs.push(join(gitRoot, '.claude'))
+  }
+
+  const allParsedFiles = await Promise.all(
+    claudeDirs.map(async claudeDir => {
+      let entries
+      try {
+        entries = await readdir(claudeDir, { withFileTypes: true })
+      } catch (e: unknown) {
+        if (isFsInaccessible(e)) {
+          return []
+        }
+        throw e
+      }
+
+      const markdownEntries = entries.filter(
+        entry => entry.isFile() && entry.name.endsWith('.md'),
+      )
+
+      const parsedFiles = await Promise.all(
+        markdownEntries.map(async entry => {
+          const filePath = join(claudeDir, entry.name)
+          try {
+            const rawContent = await readFile(filePath, { encoding: 'utf-8' })
+            const { frontmatter, content } = parseFrontmatter(
+              rawContent,
+              filePath,
+            )
+            return {
+              filePath,
+              baseDir: claudeDir,
+              frontmatter,
+              content,
+              source: 'projectSettings' as const,
+            }
+          } catch (error) {
+            const errorMessage =
+              error instanceof Error ? error.message : String(error)
+            logForDebugging(
+              `Skipping invalid legacy root agent file ${filePath}: ${errorMessage}`,
+            )
+            return null
+          }
+        }),
+      )
+
+      return parsedFiles.filter(file => file !== null)
+    }),
+  )
+
+  return allParsedFiles.flat()
+}
+
 export const getAgentDefinitionsWithOverrides = memoize(
   async (cwd: string): Promise<AgentDefinitionsResult> => {
     // Simple mode: skip custom agents, only return built-ins
@@ -305,10 +382,17 @@ export const getAgentDefinitionsWithOverrides = memoize(
     }
 
     try {
-      const markdownFiles = await loadMarkdownFilesForSubdir('agents', cwd)
+      const [markdownFiles, legacyRootMarkdownFiles] = await Promise.all([
+        loadMarkdownFilesForSubdir('agents', cwd),
+        loadLegacyProjectRootAgentFiles(cwd),
+      ])
+
+      // Legacy root files are lower-priority fallback; canonical
+      // .claude/agents/*.md entries should win on conflicts.
+      const allMarkdownFiles = [...legacyRootMarkdownFiles, ...markdownFiles]
 
       const failedFiles: Array<{ path: string; error: string }> = []
-      const customAgents = markdownFiles
+      const customAgents = allMarkdownFiles
         .map(({ filePath, baseDir, frontmatter, content, source }) => {
           const agent = parseAgentFromMarkdown(
             filePath,

--- a/src/utils/markdownConfigLoader.ts
+++ b/src/utils/markdownConfigLoader.ts
@@ -17,7 +17,7 @@ import type { FrontmatterData } from './frontmatterParser.js'
 import { parseFrontmatter } from './frontmatterParser.js'
 import { findCanonicalGitRoot, findGitRoot } from './git.js'
 import { parseToolListFromCLI } from './permissions/permissionSetup.js'
-import { ripGrep } from './ripgrep.js'
+import { ripGrep, RipgrepUnavailableError } from './ripgrep.js'
 import {
   isSettingSourceEnabled,
   type SettingSource,
@@ -567,11 +567,26 @@ async function loadMarkdownFiles(dir: string): Promise<
           signal,
         )
   } catch (e: unknown) {
+    // Auto-fallback when ripgrep is unavailable on the host.
+    // This keeps markdown-based customizations (agents/skills/commands)
+    // working in environments without rg.
+    if (!useNative && e instanceof RipgrepUnavailableError) {
+      logForDebugging(
+        `ripgrep unavailable for ${dir}; falling back to native markdown search`,
+      )
+      try {
+        files = await findMarkdownFilesNative(dir, AbortSignal.timeout(3000))
+      } catch (nativeErr: unknown) {
+        if (isFsInaccessible(nativeErr)) return []
+        throw nativeErr
+      }
+    } else {
     // Handle missing/inaccessible dir directly instead of pre-checking
     // existence (TOCTOU). findMarkdownFilesNative already catches internally;
     // ripGrep rejects on inaccessible target paths.
-    if (isFsInaccessible(e)) return []
-    throw e
+      if (isFsInaccessible(e)) return []
+      throw e
+    }
   }
 
   const results = await Promise.all(


### PR DESCRIPTION
## Summary

- Added **"Set as active for this session"** option in the `/agents` context menu, allowing users to switch the active agent mid-session without restarting
- `REPL.tsx` now syncs `mainThreadAgentDefinition` with `AppState.agent` via `useEffect`, so the agent change takes effect immediately
- Fixed `useScheduledTasks` to only be invoked when the `AGENT_TRIGGERS` feature flag is active (prevents rules-of-hooks violation)
- Cleaned up `renderCommands` / `pluginCommands` split — now uses a single `commands` variable and reads `plugins.commands` directly from AppState
- Added `loadLegacyProjectRootAgentFiles()` to support backward-compatible `.claude/*.md` agent files (in addition to the canonical `.claude/agents/*.md` path)

## Impact

- **user-facing impact:** Users can now select and activate a custom agent from the `/agents` menu and it takes effect immediately in the current session, without needing to restart. The menu shows "Active in this session" when the agent is already selected.
- **developer/maintainer impact:** `renderCommands` and the `pluginCommands` workaround have been removed, simplifying the command pipeline in `REPL.tsx`. The `useScheduledTasks` hook is now gated behind the `AGENT_TRIGGERS` feature flag.

## Testing

- [x] `bun run build`
- [x] `bun run smoke`
- [x] focused tests: agent activation via `/agents` menu, verified agent switches immediately; legacy `.claude/*.md` agent files load correctly

## Notes

- provider/model path tested: default claude provider
- screenshots attached (if UI changed): N/A (menu text change only)
- follow-up work or known limitations: The `loadLegacyProjectRootAgentFiles` function is a fallback for backward compatibility — files in `.claude/agents/` still take precedence

- https://github.com/Gitlawb/openclaude/issues/526
- https://github.com/Gitlawb/openclaude/issues/452
- https://github.com/Gitlawb/openclaude/issues/710