### PR TITLE
fix: prevent crash in commands tab when description is undefined

### DIFF
--- a/src/utils/truncate.ts
+++ b/src/utils/truncate.ts
@@ -131,11 +131,15 @@ export function truncateToWidthNoEllipsis(
  * @param singleLine If true, also truncates at the first newline
  * @returns The truncated string with ellipsis if needed
  */
+
 export function truncate(
   str: string,
   maxWidth: number,
   singleLine: boolean = false,
 ): string {
+  // Undefined or null protection
+  if (!str) return ''
+
   let result = str
 
   // If singleLine is true, truncate at first newline


### PR DESCRIPTION
This commit fixes a crash in the CLI that occurs when navigating to the /help commands tab. The issue happens because the truncate function receives an undefined value for the str parameter if a command lacks a description, causing the .indexOf() method to throw an exception. To resolve this, an early return check was added at the beginning of the function to gracefully handle empty values and prevent the UI from crashing.

## Summary

- **what changed**: Added an early return check (`if (!str) return ''`) to the `truncate` utility function.
- **why it changed**: To prevent a `Cannot read properties of undefined (reading 'indexOf')` error when rendering the `/help` -> `commands` UI table for commands that do not have a description.

## Impact

- **user-facing impact**: Users can now safely navigate to the commands tab in the help menu without the CLI suddenly crashing.
- **developer/maintainer impact**: Makes the text truncation utility more robust by safely handling falsy inputs.

## Testing

- [x] `bun run build`
- [x] `bun run smoke`
- **focused tests**: Launched the CLI locally, typed `/help`, navigated to the `commands` tab, and visually verified that the UI renders correctly without throwing the `indexOf` exception.