### PR TITLE
feat: opt-out env var OPENCLAUDE_DISABLE_STRICT_TOOLS for MCP tools with complex optional params

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -264,8 +264,10 @@ ANTHROPIC_API_KEY=sk-ant-your-key-here
 # Useful for iTerm2, WezTerm, Ghostty if modifier keys feel off
 # OPENCLAUDE_ENABLE_EXTENDED_KEYS=1
 
-# Disable "Co-authored-by" line in git commits made by OpenClaude
-# OPENCLAUDE_DISABLE_CO_AUTHORED_BY=1
+# Disable strict tool schema normalization for non-Gemini providers
+# Use if MCP tools with complex optional params (e.g. list[dict]) fail with                   
+# "Extra required key ... supplied" errors from OpenAI-compatible endpoints
+# OPENCLAUDE_DISABLE_STRICT_TOOLS=1 
 
 # Custom timeout for API requests in milliseconds (default: varies)
 # API_TIMEOUT_MS=60000

--- a/src/services/api/openaiShim.ts
+++ b/src/services/api/openaiShim.ts
@@ -597,7 +597,10 @@ function convertTools(
         function: {
           name: t.name,
           description: t.description ?? '',
-          parameters: normalizeSchemaForOpenAI(schema, !isGemini),
+          parameters: normalizeSchemaForOpenAI(
+              schema,                                                                           
+              !isGemini && !isEnvTruthy(process.env.OPENCLAUDE_DISABLE_STRICT_TOOLS),
+            ),
         },
       }
     })


### PR DESCRIPTION
## Summary
Adds an opt-out env var `OPENCLAUDE_DISABLE_STRICT_TOOLS=1` to bypass strict schema normalization at `src/services/api/openaiShim.ts:600`.

Default behavior is unchanged (backward compatible). The flag follows the same pattern as other `OPENCLAUDE_*` toggles and is read via `isEnvTruthy`, which is already imported in the file.

## Motivation

Valid MCP tools with optional parameters of complex types (e.g. `list[dict[str, Any]]` in postgres-mcp's `explain_query`) fail on strict-enforcing OpenAI-compatible providers with:

> Invalid schema for function 'X': 'required' is required to be supplied and to be an array including every key in properties. Extra required key 'Y' supplied.

The upstream MCP schemas are valid JSON Schema Draft-07; the failure is introduced during strict transformation. Until the transformer handles complex optional types robustly, users need a way to opt out.

## Changes

- `src/services/api/openaiShim.ts` — `convertTools` now respects `OPENCLAUDE_DISABLE_STRICT_TOOLS`.
- `.env.example` — documents the new flag in the `OPTIONAL TUNING` section.

## Test plan

- [x] Default (flag unset) → strict still enabled for non-Gemini (no behavior change).
- [x] `OPENCLAUDE_DISABLE_STRICT_TOOLS=1` → strict disabled; postgres-mcp `explain_query` loads without the 400 error.
- [x] Gemini path unaffected in both cases.

Closes #737
Refs #525