### PR TITLE
fix(mcp): sync required array with properties in tool schemas

### DIFF
--- a/src/utils/api.test.ts
+++ b/src/utils/api.test.ts
@@ -78,3 +78,28 @@ test('toolToAPISchema keeps skill required for SkillTool', async () => {
     required: ['skill'],
   })
 })
+
+test('toolToAPISchema removes extra required keys not in properties (MCP schema sanitization)', async () => {
+  const schema = await toolToAPISchema(
+    {
+      name: 'mcp__test__create_object',
+      inputSchema: z.strictObject({}),
+      inputJSONSchema: {
+        type: 'object',
+        properties: {
+          name: { type: 'string' },
+        },
+        required: ['name', 'attributes'],
+      },
+      prompt: async () => 'Create an object',
+    } as unknown as Tool,
+    {
+      getToolPermissionContext: async () => getEmptyToolPermissionContext(),
+      tools: [] as unknown as Tools,
+      agents: [],
+    },
+  )
+
+  const inputSchema = (schema as { input_schema: { required?: string[] } }).input_schema
+  expect(inputSchema.required).toEqual(['name'])
+})

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -111,9 +111,58 @@ function filterSwarmFieldsFromSchema(
       delete filteredProps[field]
     }
     filtered.properties = filteredProps
+
+    // Keep `required` in sync after removing properties
+    if (Array.isArray(filtered.required)) {
+      filtered.required = filtered.required.filter(
+        (key: string) => key in filteredProps,
+      )
+    }
   }
 
   return filtered
+}
+
+/**
+ * Ensure `required` only lists keys present in `properties`.
+ * MCP servers may emit schemas where these are out of sync, causing
+ * API 400 errors ("Extra required key supplied").
+ * Recurses into nested object schemas.
+ */
+function sanitizeSchemaRequired(
+  schema: Anthropic.Tool.InputSchema,
+): Anthropic.Tool.InputSchema {
+  if (!schema || typeof schema !== 'object') {
+    return schema
+  }
+
+  const result = { ...schema }
+  const props = result.properties as Record<string, unknown> | undefined
+
+  if (props && Array.isArray(result.required)) {
+    result.required = result.required.filter(
+      (key: string) => key in props,
+    )
+  }
+
+  // Recurse into nested object properties
+  if (props) {
+    const sanitizedProps = { ...props }
+    for (const [key, value] of Object.entries(sanitizedProps)) {
+      if (
+        value &&
+        typeof value === 'object' &&
+        (value as Record<string, unknown>).type === 'object'
+      ) {
+        sanitizedProps[key] = sanitizeSchemaRequired(
+          value as Anthropic.Tool.InputSchema,
+        )
+      }
+    }
+    result.properties = sanitizedProps
+  }
+
+  return result
 }
 
 export async function toolToAPISchema(
@@ -156,7 +205,7 @@ export async function toolToAPISchema(
     // Use tool's JSON schema directly if provided, otherwise convert Zod schema
     let input_schema = (
       'inputJSONSchema' in tool && tool.inputJSONSchema
-        ? tool.inputJSONSchema
+        ? sanitizeSchemaRequired(tool.inputJSONSchema as Anthropic.Tool.InputSchema)
         : zodToJsonSchema(tool.inputSchema)
     ) as Anthropic.Tool.InputSchema
 


### PR DESCRIPTION
## Summary

MCP servers can emit tool schemas where the `required` array contains keys not present in `properties`. The Claude API strictly validates this and rejects the request with a 400 error:

> Invalid schema for function '…': Extra required key 'attributes' supplied.

## Changes

1. **Added `sanitizeSchemaRequired()`** — filters `required` arrays to only include keys present in `properties`, recursing into nested object schemas. Applied when processing MCP tool `inputJSONSchema`.

2. **Fixed `filterSwarmFieldsFromSchema()`** — already removed properties but didn't update `required`, which could cause the same class of error when swarm fields are filtered.

3. **Added test** — verifies that extra `required` keys are removed from MCP tool schemas.

## Verification

- Reviewed the schema flow from MCP client → `toolToAPISchema` → API call
- Added unit test for the sanitization path
- `sanitizeSchemaRequired` is only applied to `inputJSONSchema` (MCP tools), not to Zod-generated schemas which are already well-formed

Closes #525