### PR TITLE
fix: allow provider recovery during startup

### DIFF
--- a/src/entrypoints/cli.tsx
+++ b/src/entrypoints/cli.tsx
@@ -5,7 +5,7 @@ import {
 } from '../utils/providerProfile.js'
 import {
   getProviderValidationError,
-  validateProviderEnvOrExit,
+  validateProviderEnvForStartupOrExit,
 } from '../utils/providerValidation.js'
 
 // OpenClaude: polyfill globalThis.File for Node < 20.
@@ -132,7 +132,7 @@ async function main(): Promise<void> {
     hydrateGithubModelsTokenFromSecureStorage()
   }
 
-  await validateProviderEnvOrExit()
+  await validateProviderEnvForStartupOrExit()
 
   // Print the gradient startup screen before the Ink UI loads
   const { printStartupScreen } = await import('../components/StartupScreen.js')

--- a/src/utils/providerValidation.test.ts
+++ b/src/utils/providerValidation.test.ts
@@ -1,6 +1,9 @@
 import { afterEach, expect, test } from 'bun:test'
 
-import { getProviderValidationError } from './providerValidation.ts'
+import {
+  getProviderValidationError,
+  shouldExitForStartupProviderValidationError,
+} from './providerValidation.ts'
 
 const originalEnv = {
   CLAUDE_CODE_USE_OPENAI: process.env.CLAUDE_CODE_USE_OPENAI,
@@ -92,4 +95,46 @@ test('openai missing key error includes recovery guidance and config locations',
   )
   expect(message).toContain('Saved startup settings can come from')
   expect(message).toContain('.openclaude-profile.json')
+})
+
+test('startup provider validation allows interactive recovery', () => {
+  expect(
+    shouldExitForStartupProviderValidationError({
+      args: [],
+      stdoutIsTTY: true,
+    }),
+  ).toBe(false)
+})
+
+test('startup provider validation stays strict for non-interactive launches', () => {
+  expect(
+    shouldExitForStartupProviderValidationError({
+      args: ['-p', 'hello'],
+      stdoutIsTTY: true,
+    }),
+  ).toBe(true)
+  expect(
+    shouldExitForStartupProviderValidationError({
+      args: ['--print', 'hello'],
+      stdoutIsTTY: true,
+    }),
+  ).toBe(true)
+  expect(
+    shouldExitForStartupProviderValidationError({
+      args: [],
+      stdoutIsTTY: false,
+    }),
+  ).toBe(true)
+  expect(
+    shouldExitForStartupProviderValidationError({
+      args: ['--sdk-url', 'ws://127.0.0.1:3000'],
+      stdoutIsTTY: true,
+    }),
+  ).toBe(true)
+  expect(
+    shouldExitForStartupProviderValidationError({
+      args: ['--sdk-url=ws://127.0.0.1:3000'],
+      stdoutIsTTY: true,
+    }),
+  ).toBe(true)
 })

--- a/src/utils/providerValidation.ts
+++ b/src/utils/providerValidation.ts
@@ -169,3 +169,44 @@ export async function validateProviderEnvOrExit(
     process.exit(1)
   }
 }
+
+export function shouldExitForStartupProviderValidationError(options: {
+  args?: string[]
+  stdoutIsTTY?: boolean
+} = {}): boolean {
+  const args = options.args ?? process.argv.slice(2)
+  const stdoutIsTTY = options.stdoutIsTTY ?? process.stdout.isTTY
+
+  if (!stdoutIsTTY) {
+    return true
+  }
+
+  return (
+    args.includes('-p') ||
+    args.includes('--print') ||
+    args.includes('--init-only') ||
+    args.some(arg => arg.startsWith('--sdk-url'))
+  )
+}
+
+export async function validateProviderEnvForStartupOrExit(
+  env: NodeJS.ProcessEnv = process.env,
+  options?: {
+    args?: string[]
+    stdoutIsTTY?: boolean
+  },
+): Promise<void> {
+  const error = await getProviderValidationError(env)
+  if (!error) {
+    return
+  }
+
+  if (shouldExitForStartupProviderValidationError(options)) {
+    console.error(error)
+    process.exit(1)
+  }
+
+  console.error(
+    `Warning: provider configuration is incomplete.\n${error}\nOpenClaude will continue starting so you can run /provider and repair the saved provider settings.`,
+  )
+}


### PR DESCRIPTION
## Summary

  - Changed startup provider validation so interactive TTY launches warn and continue when provider config is incomplete.
  - Kept strict provider validation for non-interactive paths like `-p`, `--print`, `--init-only`, `--sdk-url`, and piped/non-TTY runs.
  - Added focused tests for the startup validation decision logic.

  ## Impact

  - user-facing impact: users with unfinished OpenAI-compatible setup are no longer blocked before OpenClaude starts; they can launch the app and run `/provider` to repair saved provider settings.
  - developer/maintainer impact: strict validation remains available through `validateProviderEnvOrExit`, while CLI startup now uses a separate recovery-aware validator.

  ## Testing

  - [x] `bun run build`
  - [x] `bun run smoke`
  - [x] focused tests: `bun test src/utils/providerValidation.test.ts`

  ## Notes

  - provider/model path tested: interactive startup with `CLAUDE_CODE_USE_OPENAI=1`, remote `OPENAI_BASE_URL`, and no `OPENAI_API_KEY`; non-interactive decision paths covered by unit tests.
  - screenshots attached (if UI changed): no UI layout change.
  - follow-up work or known limitations: `bun run typecheck` still fails on existing repo-wide type issues unrelated to this change.