### PR TITLE
feat: add `OPENCLAUDE_DISABLE_STRICT_TOOLS` env var to opt out of strict MCP tool schema normalization

### DIFF
--- a/src/services/api/openaiShim.ts
+++ b/src/services/api/openaiShim.ts
@@ -607,7 +607,10 @@ function convertTools(
         function: {
           name: t.name,
           description: t.description ?? '',
-          parameters: normalizeSchemaForOpenAI(schema, !isGemini),
+          parameters: normalizeSchemaForOpenAI(
+            schema,
+            !isGemini && !isEnvTruthy(process.env.OPENCLAUDE_DISABLE_STRICT_TOOLS),
+          ),
         },
       }
     })
@@ -1657,7 +1660,7 @@ class OpenAIShimMessages {
           } catch (error) {
             throwClassifiedTransportError(error, responsesUrl)
           }
-          
+
           if (responsesResponse.ok) {
             return responsesResponse
           }


### PR DESCRIPTION
### Summary

Introduces an opt-in environment variable that lets users bypass strict schema normalization for MCP tools when their OpenAI-compatible endpoint rejects valid tools with complex optional parameters.

Strict mode remains the default for non-Gemini providers. The new flag only relaxes that default when explicitly set — no behavior change for existing users.

### Problem

Some MCP tools expose parameters like `list[dict]` or deeply-nested optional objects (e.g. postgres-mcp's `explain_query`). After strict normalization these schemas can be rejected by OpenAI-compatible providers with errors such as:

```
Extra required key "..." supplied
```

Today the only workaround is to disable the tool entirely or switch provider. This PR adds a per-deployment escape hatch.

### Changes

- **`src/services/api/openaiShim.ts`** — `convertTools` now passes `!isGemini && !isEnvTruthy(process.env.OPENCLAUDE_DISABLE_STRICT_TOOLS)` as the `strict` argument to `normalizeSchemaForOpenAI`.
- **`.env.example`** — document the new flag.

### Usage

```bash
# .env
OPENCLAUDE_DISABLE_STRICT_TOOLS=1
```

Unset or `=0` keeps the current strict behavior.

### Review feedback addressed

- [x] Fixed the syntax error in `convertTools` (missing `},` closing the `function` object) that was breaking the smoke/test CI job.
- [x] Rebased on latest `main` so the branch picks up `#745` (orphan tool_result handling) and `#754` (schema required sync).
- [x] Restored `OPENCLAUDE_DISABLE_CO_AUTHORED_BY` documentation in `.env.example`.
- [x] Fixed indentation of the `normalizeSchemaForOpenAI(...)` multi-line call to match surrounding 2-space style.
- [x] Removed trailing whitespace.

### Test plan

- [x] `bun run smoke` passes locally.
- [x] `bun test --max-concurrency=1` passes locally.
- [x] With the flag unset, strict mode still rejects malformed tool schemas (no regression).
- [x] With `OPENCLAUDE_DISABLE_STRICT_TOOLS=1`, postgres-mcp's `explain_query` is accepted and invokable end-to-end on an OpenAI-compatible provider.
- [ ] Reviewer to confirm on their setup.

### Backward compatibility

Default behavior unchanged. Flag is additive and opt-in.