### PR TITLE
fix: enforce Bash path constraints after sandbox allow

### DIFF
--- a/src/tools/BashTool/bashPermissions.test.ts
+++ b/src/tools/BashTool/bashPermissions.test.ts
@@ -1,0 +1,59 @@
+import { afterEach, expect, test } from 'bun:test'
+
+import { getEmptyToolPermissionContext } from '../../Tool.js'
+import { SandboxManager } from '../../utils/sandbox/sandbox-adapter.js'
+import { bashToolHasPermission } from './bashPermissions.js'
+
+const originalSandboxMethods = {
+  isSandboxingEnabled: SandboxManager.isSandboxingEnabled,
+  isAutoAllowBashIfSandboxedEnabled:
+    SandboxManager.isAutoAllowBashIfSandboxedEnabled,
+  areUnsandboxedCommandsAllowed: SandboxManager.areUnsandboxedCommandsAllowed,
+  getExcludedCommands: SandboxManager.getExcludedCommands,
+}
+
+afterEach(() => {
+  SandboxManager.isSandboxingEnabled =
+    originalSandboxMethods.isSandboxingEnabled
+  SandboxManager.isAutoAllowBashIfSandboxedEnabled =
+    originalSandboxMethods.isAutoAllowBashIfSandboxedEnabled
+  SandboxManager.areUnsandboxedCommandsAllowed =
+    originalSandboxMethods.areUnsandboxedCommandsAllowed
+  SandboxManager.getExcludedCommands = originalSandboxMethods.getExcludedCommands
+})
+
+function makeToolUseContext() {
+  const toolPermissionContext = getEmptyToolPermissionContext()
+
+  return {
+    abortController: new AbortController(),
+    options: {
+      isNonInteractiveSession: false,
+    },
+    getAppState() {
+      return {
+        toolPermissionContext,
+      }
+    },
+  } as never
+}
+
+test('sandbox auto-allow still enforces Bash path constraints', async () => {
+  ;(globalThis as unknown as { MACRO: { VERSION: string } }).MACRO = {
+    VERSION: 'test',
+  }
+
+  SandboxManager.isSandboxingEnabled = () => true
+  SandboxManager.isAutoAllowBashIfSandboxedEnabled = () => true
+  SandboxManager.areUnsandboxedCommandsAllowed = () => true
+  SandboxManager.getExcludedCommands = () => []
+
+  const result = await bashToolHasPermission(
+    { command: 'cat ../../../../../etc/passwd' },
+    makeToolUseContext(),
+  )
+
+  expect(result.behavior).toBe('ask')
+  expect(result.message).toContain('was blocked')
+  expect(result.message).toContain('/etc/passwd')
+})

--- a/src/tools/BashTool/bashPermissions.ts
+++ b/src/tools/BashTool/bashPermissions.ts
@@ -1814,7 +1814,10 @@ export async function bashToolHasPermission(
       input,
       appState.toolPermissionContext,
     )
-    if (sandboxAutoAllowResult.behavior !== 'passthrough') {
+    if (
+      sandboxAutoAllowResult.behavior === 'deny' ||
+      sandboxAutoAllowResult.behavior === 'ask'
+    ) {
       return sandboxAutoAllowResult
     }
   }


### PR DESCRIPTION
## Summary

  - Prevent sandbox auto-allow from short-circuiting the Bash permission pipeline on allow decisions.
  - Preserve early returns for explicit deny/ask rules in sandbox auto-allow mode.
  - Add a regression test proving path traversal still reaches Bash path constraints when sandbox auto-allow is enabled.

  ## Impact

  - user-facing impact: sandboxed Bash sessions can no longer auto-allow path traversal commands before directory restrictions run.
  - developer/maintainer impact: sandbox auto-allow now suppresses prompts only after critical path constraints have a chance to run; deny/ask behavior remains unchanged.

  ## Testing

  - [x] `bun run build`
  - [x] `bun run smoke`
  - [x] focused tests: `bun test src/tools/BashTool/bashPermissions.test.ts`, `bun test src/tools/BashTool/modeValidation.test.ts src/tools/BashTool/sedEditParser.test.ts`

  ## Notes

  - provider/model path tested: Bash permission flow with sandbox auto-allow enabled and path traversal input.
  - screenshots attached (if UI changed): no UI change.
  - follow-up work or known limitations: none known.