### PR TITLE
feat(api): credential pool with rotation on auth / rate-limit failures

### DIFF
--- a/src/services/api/credentialPool.test.ts
+++ b/src/services/api/credentialPool.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, test } from 'bun:test'
+
+import {
+  createCredentialPool,
+  parseKeyList,
+} from './credentialPool.ts'
+
+describe('parseKeyList', () => {
+  test('returns empty for nullish input', () => {
+    expect(parseKeyList(undefined)).toEqual([])
+    expect(parseKeyList(null)).toEqual([])
+    expect(parseKeyList('')).toEqual([])
+  })
+
+  test('splits on commas and trims whitespace', () => {
+    expect(parseKeyList('sk-1, sk-2 ,sk-3')).toEqual(['sk-1', 'sk-2', 'sk-3'])
+  })
+
+  test('drops empty entries', () => {
+    expect(parseKeyList('sk-1,,sk-2, ,sk-3')).toEqual(['sk-1', 'sk-2', 'sk-3'])
+  })
+
+  test('dedupes while preserving order', () => {
+    expect(parseKeyList('sk-1,sk-2,sk-1,sk-3,sk-2')).toEqual([
+      'sk-1',
+      'sk-2',
+      'sk-3',
+    ])
+  })
+
+  test('handles a single key with no commas', () => {
+    expect(parseKeyList('sk-only')).toEqual(['sk-only'])
+  })
+})
+
+describe('createCredentialPool', () => {
+  test('round-robins through healthy keys', () => {
+    const pool = createCredentialPool(['a', 'b', 'c'])
+    expect(pool.next()?.token).toBe('a')
+    expect(pool.next()?.token).toBe('b')
+    expect(pool.next()?.token).toBe('c')
+    expect(pool.next()?.token).toBe('a')
+  })
+
+  test('reports size and healthy count', () => {
+    const pool = createCredentialPool(['a', 'b', 'c'])
+    expect(pool.size).toBe(3)
+    expect(pool.healthyCount()).toBe(3)
+  })
+
+  test('empty pool returns null from next()', () => {
+    const pool = createCredentialPool([])
+    expect(pool.next()).toBeNull()
+    expect(pool.size).toBe(0)
+    expect(pool.healthyCount()).toBe(0)
+  })
+
+  test('single-key pool repeats that key', () => {
+    const pool = createCredentialPool(['only'])
+    expect(pool.next()?.token).toBe('only')
+    expect(pool.next()?.token).toBe('only')
+  })
+
+  test('attempt includes the original index', () => {
+    const pool = createCredentialPool(['a', 'b', 'c'])
+    expect(pool.next()).toEqual({ token: 'a', index: 0 })
+    expect(pool.next()).toEqual({ token: 'b', index: 1 })
+    expect(pool.next()).toEqual({ token: 'c', index: 2 })
+  })
+
+  test('auth failure evicts a key permanently', () => {
+    const pool = createCredentialPool(['a', 'b', 'c'])
+    pool.markFailed('b', 'auth')
+    expect(pool.healthyCount()).toBe(2)
+
+    const seen = new Set<string>()
+    for (let i = 0; i < 6; i++) {
+      const attempt = pool.next()
+      if (attempt) seen.add(attempt.token)
+    }
+    expect(seen.has('a')).toBe(true)
+    expect(seen.has('c')).toBe(true)
+    // 'b' may return only as a degraded last-resort; with other keys healthy, never.
+    expect(seen.has('b')).toBe(false)
+  })
+
+  test('rate-limit failure puts a key in cooldown', () => {
+    const pool = createCredentialPool(['a', 'b'])
+    pool.markFailed('a', 'rate_limit')
+    expect(pool.healthyCount()).toBe(1)
+    // 'a' is cooling; next() should return 'b' repeatedly while 'a' is cold.
+    expect(pool.next()?.token).toBe('b')
+    expect(pool.next()?.token).toBe('b')
+  })
+
+  test('markSuccess clears cooldown', () => {
+    const pool = createCredentialPool(['a', 'b'])
+    pool.markFailed('a', 'rate_limit')
+    expect(pool.healthyCount()).toBe(1)
+    pool.markSuccess('a')
+    expect(pool.healthyCount()).toBe(2)
+  })
+
+  test('markFailed on unknown token is a no-op', () => {
+    const pool = createCredentialPool(['a', 'b'])
+    pool.markFailed('does-not-exist', 'auth')
+    expect(pool.healthyCount()).toBe(2)
+  })
+
+  test('all-evicted pool still returns a degraded attempt', () => {
+    const pool = createCredentialPool(['a', 'b'])
+    pool.markFailed('a', 'auth')
+    pool.markFailed('b', 'auth')
+    expect(pool.healthyCount()).toBe(0)
+    // Degrades to least-recently-failed key so caller still has an attempt
+    // to make (which will fail and surface a real error to the user).
+    const attempt = pool.next()
+    expect(attempt).not.toBeNull()
+    expect(['a', 'b']).toContain(attempt?.token)
+  })
+
+  test('all-cooling pool returns least-recently-failed key', () => {
+    const pool = createCredentialPool(['a', 'b'])
+    pool.markFailed('a', 'rate_limit')
+    // Small delay to ensure 'a' is older than 'b'
+    const then = Date.now()
+    while (Date.now() === then) {
+      // spin for at least 1ms so lastFailureAtMs differs
+    }
+    pool.markFailed('b', 'rate_limit')
+    expect(pool.healthyCount()).toBe(0)
+    // Degraded pick = least-recently-failed = 'a'
+    expect(pool.next()?.token).toBe('a')
+  })
+})

--- a/src/services/api/credentialPool.ts
+++ b/src/services/api/credentialPool.ts
@@ -1,0 +1,156 @@
+/**
+ * Credential pool with rotation for OpenAI-compatible providers.
+ *
+ * Lets users configure multiple API keys (comma-separated) and rotate through
+ * them transparently when individual keys hit auth failures or rate limits.
+ * Addresses heavy-use pain points: OpenRouter / Groq / Together free tiers,
+ * personal + team key mixing, key-exhaustion on long runs.
+ *
+ * Usage pattern:
+ *   const pool = createCredentialPool(keys)
+ *   const attempt = pool.next()            // get current key + token
+ *   // ... make request ...
+ *   pool.markFailed(attempt.token, 'auth') // on 401: evict permanently
+ *   pool.markFailed(attempt.token, 'rate_limit') // on 429: cooldown 30s
+ *   pool.markSuccess(attempt.token)         // clear any prior cooldown
+ *
+ * Degradation: if every key is evicted or cooling down, `next()` still returns
+ * the least-recently-failed key rather than nothing — caller's own error
+ * handling takes over. Never hard-fails on pool exhaustion.
+ */
+
+type FailureKind = 'auth' | 'rate_limit'
+
+export type CredentialAttempt = {
+  token: string
+  /** 0-based position in the original key list. Useful for logs. */
+  index: number
+}
+
+export interface CredentialPool {
+  /** Returns the next healthy key, or the best-degraded option if none are healthy. */
+  next(): CredentialAttempt | null
+  /** Records a failure. Auth → permanent evict. Rate limit → 30s cooldown. */
+  markFailed(token: string, kind: FailureKind): void
+  /** Clears any cooldown on a key that just succeeded. */
+  markSuccess(token: string): void
+  /** Total keys in the pool (including evicted). */
+  readonly size: number
+  /** Keys currently usable (not evicted, not cooling down). */
+  healthyCount(): number
+}
+
+type KeyState = {
+  token: string
+  index: number
+  evicted: boolean
+  cooldownUntilMs: number
+  lastFailureAtMs: number
+}
+
+const RATE_LIMIT_COOLDOWN_MS = 30_000
+
+function nowMs(): number {
+  return Date.now()
+}
+
+/**
+ * Parse `OPENAI_API_KEYS` (plural, comma-separated) or `OPENAI_API_KEY` (single,
+ * which may itself be a comma-separated list for convenience). Whitespace-trimmed,
+ * empty entries dropped, duplicates collapsed.
+ */
+export function parseKeyList(
+  raw: string | undefined | null,
+): string[] {
+  if (!raw) return []
+  const seen = new Set<string>()
+  const out: string[] = []
+  for (const part of raw.split(',')) {
+    const trimmed = part.trim()
+    if (!trimmed) continue
+    if (seen.has(trimmed)) continue
+    seen.add(trimmed)
+    out.push(trimmed)
+  }
+  return out
+}
+
+export function createCredentialPool(
+  keys: readonly string[],
+): CredentialPool {
+  const states: KeyState[] = keys.map((token, index) => ({
+    token,
+    index,
+    evicted: false,
+    cooldownUntilMs: 0,
+    lastFailureAtMs: 0,
+  }))
+
+  let cursor = 0
+
+  function findByToken(token: string): KeyState | undefined {
+    return states.find(s => s.token === token)
+  }
+
+  function isHealthy(state: KeyState, at: number): boolean {
+    return !state.evicted && state.cooldownUntilMs <= at
+  }
+
+  function healthyCount(): number {
+    const at = nowMs()
+    return states.filter(s => isHealthy(s, at)).length
+  }
+
+  function next(): CredentialAttempt | null {
+    if (states.length === 0) return null
+    const at = nowMs()
+
+    // Scan from cursor for a healthy key.
+    for (let i = 0; i < states.length; i++) {
+      const idx = (cursor + i) % states.length
+      const state = states[idx]
+      if (isHealthy(state, at)) {
+        cursor = (idx + 1) % states.length
+        return { token: state.token, index: state.index }
+      }
+    }
+
+    // No healthy key. Pick the least-recently-failed non-evicted key as a
+    // degraded attempt; if every key is evicted, return the least-recently-
+    // failed evicted key so the caller still gets an error path rather than
+    // a silent null.
+    const nonEvicted = states.filter(s => !s.evicted)
+    const pickFrom = nonEvicted.length > 0 ? nonEvicted : states
+    const degraded = pickFrom.reduce((best, s) =>
+      s.lastFailureAtMs < best.lastFailureAtMs ? s : best,
+    )
+    return { token: degraded.token, index: degraded.index }
+  }
+
+  function markFailed(token: string, kind: FailureKind): void {
+    const state = findByToken(token)
+    if (!state) return
+    state.lastFailureAtMs = nowMs()
+    if (kind === 'auth') {
+      state.evicted = true
+      return
+    }
+    state.cooldownUntilMs = nowMs() + RATE_LIMIT_COOLDOWN_MS
+  }
+
+  function markSuccess(token: string): void {
+    const state = findByToken(token)
+    if (!state) return
+    state.cooldownUntilMs = 0
+  }
+
+  return {
+    next,
+    markFailed,
+    markSuccess,
+    get size() {
+      return states.length
+    },
+    healthyCount,
+  }
+}

--- a/src/services/api/openaiShim.test.ts
+++ b/src/services/api/openaiShim.test.ts
@@ -6,6 +6,7 @@ type FetchType = typeof globalThis.fetch
 const originalEnv = {
   OPENAI_BASE_URL: process.env.OPENAI_BASE_URL,
   OPENAI_API_KEY: process.env.OPENAI_API_KEY,
+  OPENAI_API_KEYS: process.env.OPENAI_API_KEYS,
   OPENAI_MODEL: process.env.OPENAI_MODEL,
   CLAUDE_CODE_USE_GITHUB: process.env.CLAUDE_CODE_USE_GITHUB,
   GITHUB_TOKEN: process.env.GITHUB_TOKEN,
@@ -74,6 +75,7 @@ function makeStreamChunks(chunks: unknown[]): string[] {
 beforeEach(() => {
   process.env.OPENAI_BASE_URL = 'http://example.test/v1'
   process.env.OPENAI_API_KEY = 'test-key'
+  delete process.env.OPENAI_API_KEYS
   delete process.env.OPENAI_MODEL
   delete process.env.CLAUDE_CODE_USE_GITHUB
   delete process.env.GITHUB_TOKEN
@@ -93,6 +95,7 @@ beforeEach(() => {
 afterEach(() => {
   restoreEnv('OPENAI_BASE_URL', originalEnv.OPENAI_BASE_URL)
   restoreEnv('OPENAI_API_KEY', originalEnv.OPENAI_API_KEY)
+  restoreEnv('OPENAI_API_KEYS', originalEnv.OPENAI_API_KEYS)
   restoreEnv('OPENAI_MODEL', originalEnv.OPENAI_MODEL)
   restoreEnv('CLAUDE_CODE_USE_GITHUB', originalEnv.CLAUDE_CODE_USE_GITHUB)
   restoreEnv('GITHUB_TOKEN', originalEnv.GITHUB_TOKEN)
@@ -2943,4 +2946,155 @@ test('preserves valid tool_result and drops orphan tool_result', async () => {
   
   const orphanMessage = toolMessages.find(m => m.tool_call_id === 'orphan_call_2')
   expect(orphanMessage).toBeUndefined()
+})
+
+test('credential pool: rotates to next key on 429', async () => {
+  delete process.env.OPENAI_API_KEY
+  process.env.OPENAI_API_KEYS = 'sk-one,sk-two'
+
+  const attemptedKeys: string[] = []
+  globalThis.fetch = (async (_input, init) => {
+    const auth = (init?.headers as Record<string, string> | undefined)?.Authorization
+    attemptedKeys.push(auth?.replace(/^Bearer /, '') ?? '')
+
+    // First key rate-limited, second key succeeds.
+    if (attemptedKeys.length === 1) {
+      return new Response('{"error":"rate limited"}', {
+        status: 429,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    }
+    return new Response(
+      JSON.stringify({
+        id: 'chatcmpl-ok',
+        model: 'gpt-4o',
+        choices: [
+          { message: { role: 'assistant', content: 'ok' }, finish_reason: 'stop' },
+        ],
+        usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+      }),
+      { headers: { 'Content-Type': 'application/json' } },
+    )
+  }) as FetchType
+
+  const client = createOpenAIShimClient({}) as OpenAIShimClient
+  const result = (await client.beta.messages.create({
+    model: 'gpt-4o',
+    system: 'test',
+    messages: [{ role: 'user', content: 'hi' }],
+    max_tokens: 8,
+    stream: false,
+  })) as { content: Array<Record<string, unknown>> }
+
+  expect(attemptedKeys).toEqual(['sk-one', 'sk-two'])
+  expect(result.content[0]?.text).toBe('ok')
+})
+
+test('credential pool: rotates to next key on 401', async () => {
+  delete process.env.OPENAI_API_KEY
+  process.env.OPENAI_API_KEYS = 'sk-bad,sk-good'
+
+  const attemptedKeys: string[] = []
+  globalThis.fetch = (async (_input, init) => {
+    const auth = (init?.headers as Record<string, string> | undefined)?.Authorization
+    attemptedKeys.push(auth?.replace(/^Bearer /, '') ?? '')
+
+    if (attemptedKeys.length === 1) {
+      return new Response('{"error":"invalid api key"}', {
+        status: 401,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    }
+    return new Response(
+      JSON.stringify({
+        id: 'chatcmpl-ok',
+        model: 'gpt-4o',
+        choices: [
+          { message: { role: 'assistant', content: 'ok' }, finish_reason: 'stop' },
+        ],
+        usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+      }),
+      { headers: { 'Content-Type': 'application/json' } },
+    )
+  }) as FetchType
+
+  const client = createOpenAIShimClient({}) as OpenAIShimClient
+  const result = (await client.beta.messages.create({
+    model: 'gpt-4o',
+    system: 'test',
+    messages: [{ role: 'user', content: 'hi' }],
+    max_tokens: 8,
+    stream: false,
+  })) as { content: Array<Record<string, unknown>> }
+
+  expect(attemptedKeys).toEqual(['sk-bad', 'sk-good'])
+  expect(result.content[0]?.text).toBe('ok')
+})
+
+test('credential pool: comma-separated OPENAI_API_KEY is treated as multi-key', async () => {
+  process.env.OPENAI_API_KEY = 'sk-a, sk-b'
+  delete process.env.OPENAI_API_KEYS
+
+  const attemptedKeys: string[] = []
+  globalThis.fetch = (async (_input, init) => {
+    const auth = (init?.headers as Record<string, string> | undefined)?.Authorization
+    attemptedKeys.push(auth?.replace(/^Bearer /, '') ?? '')
+
+    if (attemptedKeys.length === 1) {
+      return new Response('{"error":"rate limited"}', {
+        status: 429,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    }
+    return new Response(
+      JSON.stringify({
+        id: 'chatcmpl-ok',
+        model: 'gpt-4o',
+        choices: [
+          { message: { role: 'assistant', content: 'ok' }, finish_reason: 'stop' },
+        ],
+        usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+      }),
+      { headers: { 'Content-Type': 'application/json' } },
+    )
+  }) as FetchType
+
+  const client = createOpenAIShimClient({}) as OpenAIShimClient
+  await client.beta.messages.create({
+    model: 'gpt-4o',
+    system: 'test',
+    messages: [{ role: 'user', content: 'hi' }],
+    max_tokens: 8,
+    stream: false,
+  })
+
+  expect(attemptedKeys).toEqual(['sk-a', 'sk-b'])
+})
+
+test('credential pool: single key → no rotation retries on 429', async () => {
+  // Verifies backward compatibility: 1-key pool preserves prior one-shot behavior.
+  process.env.OPENAI_API_KEY = 'sk-only'
+  delete process.env.OPENAI_API_KEYS
+
+  let callCount = 0
+  globalThis.fetch = (async () => {
+    callCount++
+    return new Response('{"error":"rate limited"}', {
+      status: 429,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  }) as FetchType
+
+  const client = createOpenAIShimClient({}) as OpenAIShimClient
+  await expect(
+    client.beta.messages.create({
+      model: 'gpt-4o',
+      system: 'test',
+      messages: [{ role: 'user', content: 'hi' }],
+      max_tokens: 8,
+      stream: false,
+    }),
+  ).rejects.toThrow()
+
+  expect(callCount).toBe(1)
 })

--- a/src/services/api/openaiShim.ts
+++ b/src/services/api/openaiShim.ts
@@ -47,6 +47,11 @@ import {
   type AnthropicUsage,
   type ShimCreateParams,
 } from './codexShim.js'
+import {
+  createCredentialPool,
+  parseKeyList,
+  type CredentialPool,
+} from './credentialPool.js'
 import { fetchWithProxyRetry } from './fetchWithProxyRetry.js'
 import {
   isLocalProviderUrl,
@@ -1422,10 +1427,18 @@ class OpenAIShimMessages {
 
     const isGemini = isGeminiMode()
     const isMiniMax = !!process.env.MINIMAX_API_KEY
-    const apiKey =
+    // OPENAI_API_KEYS (plural, comma-separated) takes precedence for multi-key
+    // rotation. Single OPENAI_API_KEY may itself contain commas for convenience.
+    // providerOverride always wins (explicit per-profile key) and produces a
+    // single-key pool.
+    const keyListRaw =
       this.providerOverride?.apiKey ??
+      process.env.OPENAI_API_KEYS ??
       process.env.OPENAI_API_KEY ??
-      (isMiniMax ? process.env.MINIMAX_API_KEY : '')
+      (isMiniMax ? process.env.MINIMAX_API_KEY ?? '' : '')
+    const credentialPool: CredentialPool = createCredentialPool(
+      parseKeyList(keyListRaw),
+    )
     // Detect Azure endpoints by hostname (not raw URL) to prevent bypass via
     // path segments like https://evil.com/cognitiveservices.azure.com/
     let isAzure = false
@@ -1435,19 +1448,42 @@ class OpenAIShimMessages {
         (hostname.includes('cognitiveservices') || hostname.includes('openai') || hostname.includes('services.ai'))
     } catch { /* malformed URL — not Azure */ }
 
-    if (apiKey) {
-      if (isAzure) {
-        // Azure uses api-key header instead of Bearer token
-        headers['api-key'] = apiKey
-      } else {
-        headers.Authorization = `Bearer ${apiKey}`
-      }
-    } else if (isGemini) {
+    // Resolve Gemini credential once (not rotatable — tied to the ambient auth).
+    let geminiAuthHeader: string | undefined
+    let geminiProjectId: string | undefined
+    if (credentialPool.size === 0 && isGemini) {
       const geminiCredential = await resolveGeminiCredential(process.env)
       if (geminiCredential.kind !== 'none') {
-        headers.Authorization = `Bearer ${geminiCredential.credential}`
-        if (geminiCredential.kind !== 'api-key' && 'projectId' in geminiCredential && geminiCredential.projectId) {
-          headers['x-goog-user-project'] = geminiCredential.projectId
+        geminiAuthHeader = `Bearer ${geminiCredential.credential}`
+        if (
+          geminiCredential.kind !== 'api-key' &&
+          'projectId' in geminiCredential &&
+          geminiCredential.projectId
+        ) {
+          geminiProjectId = geminiCredential.projectId
+        }
+      }
+    }
+
+    const applyAuthHeaders = (
+      targetHeaders: Record<string, string>,
+      apiKey: string | undefined,
+    ): void => {
+      delete targetHeaders.Authorization
+      delete targetHeaders['api-key']
+      delete targetHeaders['x-goog-user-project']
+      if (apiKey) {
+        if (isAzure) {
+          targetHeaders['api-key'] = apiKey
+        } else {
+          targetHeaders.Authorization = `Bearer ${apiKey}`
+        }
+        return
+      }
+      if (geminiAuthHeader) {
+        targetHeaders.Authorization = geminiAuthHeader
+        if (geminiProjectId) {
+          targetHeaders['x-goog-user-project'] = geminiProjectId
         }
       }
     }
@@ -1488,7 +1524,11 @@ class OpenAIShimMessages {
       signal: options?.signal,
     }
 
-    const maxAttempts = isGithub ? GITHUB_429_MAX_RETRIES : 1
+    // Base attempts from existing policy (GitHub 429 retry); extend to cover
+    // pool rotation if multiple keys are configured. Single-key pools preserve
+    // the prior one-shot behaviour.
+    const baseAttempts = isGithub ? GITHUB_429_MAX_RETRIES : 1
+    const maxAttempts = Math.max(baseAttempts, credentialPool.size || 1)
 
     const throwClassifiedTransportError = (
       error: unknown,
@@ -1555,7 +1595,14 @@ class OpenAIShimMessages {
     }
 
     let response: Response | undefined
+    let lastAttemptedKey: string | undefined
     for (let attempt = 0; attempt < maxAttempts; attempt++) {
+      // Pick a key for this attempt. Empty-pool falls through to Gemini ADC
+      // or keyless local provider handling inside applyAuthHeaders.
+      const keyAttempt = credentialPool.next()
+      applyAuthHeaders(headers, keyAttempt?.token)
+      lastAttemptedKey = keyAttempt?.token
+
       try {
         response = await fetchWithProxyRetry(chatCompletionsUrl, fetchInit)
       } catch (error) {
@@ -1577,7 +1624,24 @@ class OpenAIShimMessages {
       }
 
       if (response.ok) {
+        if (lastAttemptedKey) credentialPool.markSuccess(lastAttemptedKey)
         return response
+      }
+
+      // Credential-pool rotation: on auth / rate-limit failures with more
+      // healthy keys available, mark the current key and retry with the next.
+      if (
+        credentialPool.size > 1 &&
+        lastAttemptedKey &&
+        (response.status === 401 || response.status === 403 || response.status === 429) &&
+        attempt < maxAttempts - 1
+      ) {
+        const kind = response.status === 429 ? 'rate_limit' : 'auth'
+        credentialPool.markFailed(lastAttemptedKey, kind)
+        if (credentialPool.healthyCount() > 0) {
+          await response.text().catch(() => {})
+          continue
+        }
       }
 
       if (


### PR DESCRIPTION
Heavy users of OpenAI-compatible providers (OpenRouter, Groq, Together, self-hosted, personal-plus-team key mixes) frequently hit quota or auth failures on individual keys, which today surfaces as a hard error to the user. Adds transparent multi-key rotation.

New env var: OPENAI_API_KEYS (plural, comma-separated) takes precedence over OPENAI_API_KEY. For convenience, OPENAI_API_KEY itself is now also treated as a comma-separated list — no config migration needed for users who want rotation without adopting the new var.

Behavior:
- Round-robin across healthy keys; single-key pools preserve prior behavior.
- On 401/403: permanently evict the offending key from the pool for this request lifetime.
- On 429: 30s cooldown on the offending key; rotate to next healthy key.
- On success: clears any cooldown on the used key.
- All keys exhausted: falls back to least-recently-failed key so the caller still gets a meaningful error rather than silent failure.

Max attempts per request = max(existing policy, pool.size), so rotation doesn't starve existing GitHub 429 retry behavior and single-key pools continue one-shot.

Auth header rebuilt per attempt via applyAuthHeaders() helper; Gemini ADC and keyless-local paths remain untouched (pool size 0 → same headers as before).