### PR TITLE
feat(context): auto-discover context window for unknown 3P models

### DIFF
--- a/src/utils/context.ts
+++ b/src/utils/context.ts
@@ -4,6 +4,11 @@ import { getGlobalConfig } from './config.js'
 import { isEnvTruthy } from './envUtils.js'
 import { getCanonicalName } from './model/model.js'
 import { getModelCapability } from './model/modelCapabilities.js'
+import {
+  discoverContextWindow,
+  getCachedContextWindow,
+  rememberContextWindow,
+} from './model/modelContextDiscovery.js'
 import { getOpenAIContextWindow, getOpenAIMaxOutputTokens } from './model/openaiContextWindows.js'
 
 // Model context window size (200k tokens for all models right now)
@@ -91,10 +96,22 @@ export function getContextWindowForModel(
     if (openaiWindow !== undefined) {
       return openaiWindow
     }
+    const baseUrl = (
+      process.env.OPENAI_BASE_URL ??
+      process.env.OPENAI_API_BASE ??
+      'https://api.openai.com/v1'
+    ).replace(/\/+$/, '')
+    const cached = getCachedContextWindow(baseUrl, model)
+    if (cached !== undefined) {
+      return cached
+    }
+    // Fall back to conservative default but trigger a one-shot background
+    // probe so the NEXT call for this model returns an accurate value.
     console.error(
       `[context] Warning: model "${model}" not in context window table — using conservative 128k default. ` +
-      'Add it to src/utils/model/openaiContextWindows.ts for accurate compaction.',
+      'Probing the provider to auto-detect (result cached in ~/.openclaude/model-metadata.json).',
     )
+    triggerBackgroundContextProbe(baseUrl, model)
     return OPENAI_FALLBACK_CONTEXT_WINDOW
   }
 
@@ -122,6 +139,37 @@ export function getContextWindowForModel(
     }
   }
   return MODEL_CONTEXT_WINDOW_DEFAULT
+}
+
+// Track in-flight / completed probes so a single session triggers at most one
+// discovery per (baseUrl, model) pair, regardless of how many compaction calls
+// re-enter getContextWindowForModel().
+const probedThisSession = new Set<string>()
+
+function triggerBackgroundContextProbe(baseUrl: string, model: string): void {
+  const key = `${baseUrl}::${model}`
+  if (probedThisSession.has(key)) return
+  probedThisSession.add(key)
+
+  const headers: Record<string, string> = {}
+  const apiKey = process.env.OPENAI_API_KEY?.trim()
+  if (apiKey) headers.Authorization = `Bearer ${apiKey}`
+
+  // Fire-and-forget; no callers wait on this.
+  void discoverContextWindow(baseUrl, model, headers)
+    .then(result => {
+      if (result) {
+        rememberContextWindow(
+          baseUrl,
+          model,
+          result.contextWindow,
+          result.source,
+        )
+      }
+    })
+    .catch(() => {
+      // Swallow — we already returned the fallback value; next session will retry.
+    })
 }
 
 export function getSonnet1mExpTreatmentEnabled(model: string): boolean {

--- a/src/utils/model/modelContextDiscovery.test.ts
+++ b/src/utils/model/modelContextDiscovery.test.ts
@@ -178,6 +178,32 @@ describe('discoverContextWindow — /v1/models/{id}', () => {
     const result = await discoverContextWindow('https://example/v1', 'm')
     expect(result?.contextWindow).toBe(64_000)
   })
+
+  test('does NOT treat max_tokens as the context window (it is output cap)', async () => {
+    // Regression: max_tokens in the OpenAI schema is the output-completion
+    // cap, not the context window. Caching 4096 here for a 128k-context
+    // model would trigger aggressive premature auto-compaction. The
+    // discoverer must ignore max_tokens entirely.
+    globalThis.fetch = (async () =>
+      new Response(
+        JSON.stringify({ id: 'm', max_tokens: 4096 }),
+        { headers: { 'Content-Type': 'application/json' } },
+      )) as typeof fetch
+
+    const result = await discoverContextWindow('https://example/v1', 'm')
+    expect(result).toBeUndefined()
+  })
+
+  test('prefers context_length when both max_tokens and context_length present', async () => {
+    globalThis.fetch = (async () =>
+      new Response(
+        JSON.stringify({ id: 'm', max_tokens: 4096, context_length: 128_000 }),
+        { headers: { 'Content-Type': 'application/json' } },
+      )) as typeof fetch
+
+    const result = await discoverContextWindow('https://example/v1', 'm')
+    expect(result?.contextWindow).toBe(128_000)
+  })
 })
 
 describe('discoverContextWindow — fallback strategies', () => {

--- a/src/utils/model/modelContextDiscovery.test.ts
+++ b/src/utils/model/modelContextDiscovery.test.ts
@@ -1,0 +1,287 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+
+import {
+  __resetContextCacheForTests,
+  __setConfigDirForTests,
+  discoverContextWindow,
+  getCachedContextWindow,
+  rememberContextWindow,
+  warmContextWindowCache,
+} from './modelContextDiscovery.ts'
+
+const originalFetch = globalThis.fetch
+
+let tempHome: string
+
+beforeEach(() => {
+  tempHome = mkdtempSync(join(tmpdir(), 'openclaude-mctest-'))
+  // Inject path directly — env-var isolation is racy under bun's parallel file
+  // execution because process.env is process-global.
+  __setConfigDirForTests(tempHome)
+})
+
+afterEach(() => {
+  __setConfigDirForTests(null)
+  rmSync(tempHome, { recursive: true, force: true })
+  globalThis.fetch = originalFetch
+  __resetContextCacheForTests()
+})
+
+const CACHE_PATH = (home: string): string => join(home, 'model-metadata.json')
+
+describe('cache read/write', () => {
+  test('returns undefined when no cache file exists', () => {
+    expect(getCachedContextWindow('https://openrouter.ai/api/v1', 'model-x'))
+      .toBeUndefined()
+  })
+
+  test('rememberContextWindow persists to disk and is readable in-memory', () => {
+    rememberContextWindow(
+      'https://openrouter.ai/api/v1',
+      'anthropic/claude-3.5-sonnet',
+      200_000,
+      'test',
+    )
+
+    expect(
+      getCachedContextWindow(
+        'https://openrouter.ai/api/v1',
+        'anthropic/claude-3.5-sonnet',
+      ),
+    ).toBe(200_000)
+
+    expect(existsSync(CACHE_PATH(tempHome))).toBe(true)
+    const raw = readFileSync(CACHE_PATH(tempHome), 'utf8')
+    const parsed = JSON.parse(raw)
+    expect(parsed.version).toBe(1)
+    expect(
+      parsed.entries['https://openrouter.ai/api/v1::anthropic/claude-3.5-sonnet']
+        ?.contextWindow,
+    ).toBe(200_000)
+  })
+
+  test('trailing slashes in baseUrl are normalized', () => {
+    rememberContextWindow(
+      'https://openrouter.ai/api/v1/',
+      'm',
+      100,
+      'test',
+    )
+    expect(getCachedContextWindow('https://openrouter.ai/api/v1', 'm')).toBe(100)
+  })
+
+  test('entries older than 30 days are ignored on load', () => {
+    const stale = {
+      version: 1,
+      entries: {
+        'https://example/v1::old-model': {
+          contextWindow: 9999,
+          discoveredAt: Date.now() - 40 * 24 * 60 * 60 * 1000,
+          source: 'stale',
+        },
+        'https://example/v1::fresh-model': {
+          contextWindow: 128_000,
+          discoveredAt: Date.now() - 1000,
+          source: 'fresh',
+        },
+      },
+    }
+    writeFileSync(CACHE_PATH(tempHome), JSON.stringify(stale), 'utf8')
+    __resetContextCacheForTests()
+
+    expect(getCachedContextWindow('https://example/v1', 'old-model')).toBeUndefined()
+    expect(getCachedContextWindow('https://example/v1', 'fresh-model')).toBe(128_000)
+  })
+
+  test('version mismatch discards cache entries', () => {
+    const v99 = {
+      version: 99,
+      entries: {
+        'https://example/v1::m': {
+          contextWindow: 42,
+          discoveredAt: Date.now(),
+          source: 'v99',
+        },
+      },
+    }
+    writeFileSync(CACHE_PATH(tempHome), JSON.stringify(v99), 'utf8')
+    __resetContextCacheForTests()
+
+    expect(getCachedContextWindow('https://example/v1', 'm')).toBeUndefined()
+  })
+
+  test('malformed cache file is handled gracefully', () => {
+    writeFileSync(CACHE_PATH(tempHome), 'not json{{{', 'utf8')
+    __resetContextCacheForTests()
+    expect(getCachedContextWindow('https://example/v1', 'm')).toBeUndefined()
+  })
+})
+
+describe('discoverContextWindow — /v1/models/{id}', () => {
+  test('parses OpenRouter-style context_length', async () => {
+    globalThis.fetch = (async (input: URL | RequestInfo) => {
+      const url = typeof input === 'string' ? input : (input as URL).toString()
+      expect(url).toBe(
+        'https://openrouter.ai/api/v1/models/anthropic%2Fclaude-3.5-sonnet',
+      )
+      return new Response(
+        JSON.stringify({
+          id: 'anthropic/claude-3.5-sonnet',
+          context_length: 200_000,
+        }),
+        { headers: { 'Content-Type': 'application/json' } },
+      )
+    }) as typeof fetch
+
+    const result = await discoverContextWindow(
+      'https://openrouter.ai/api/v1',
+      'anthropic/claude-3.5-sonnet',
+    )
+    expect(result?.contextWindow).toBe(200_000)
+  })
+
+  test('parses Together-style context_window', async () => {
+    globalThis.fetch = (async () =>
+      new Response(
+        JSON.stringify({ id: 'm', context_window: 131_072 }),
+        { headers: { 'Content-Type': 'application/json' } },
+      )) as typeof fetch
+
+    const result = await discoverContextWindow(
+      'https://api.together.xyz/v1',
+      'm',
+    )
+    expect(result?.contextWindow).toBe(131_072)
+  })
+
+  test('parses vLLM max_model_len', async () => {
+    globalThis.fetch = (async () =>
+      new Response(
+        JSON.stringify({ id: 'm', max_model_len: 32_768 }),
+        { headers: { 'Content-Type': 'application/json' } },
+      )) as typeof fetch
+
+    const result = await discoverContextWindow('http://localhost:8000/v1', 'm')
+    expect(result?.contextWindow).toBe(32_768)
+  })
+
+  test('parses nested data field', async () => {
+    globalThis.fetch = (async () =>
+      new Response(
+        JSON.stringify({ data: { id: 'm', context_length: 64_000 } }),
+        { headers: { 'Content-Type': 'application/json' } },
+      )) as typeof fetch
+
+    const result = await discoverContextWindow('https://example/v1', 'm')
+    expect(result?.contextWindow).toBe(64_000)
+  })
+})
+
+describe('discoverContextWindow — fallback strategies', () => {
+  test('falls back to /models list when /models/{id} is 404', async () => {
+    let calls = 0
+    globalThis.fetch = (async (input: URL | RequestInfo) => {
+      calls++
+      const url = typeof input === 'string' ? input : (input as URL).toString()
+      if (url.includes('/models/m')) {
+        return new Response('not found', { status: 404 })
+      }
+      if (url.endsWith('/models')) {
+        return new Response(
+          JSON.stringify({
+            data: [
+              { id: 'other', context_length: 8_000 },
+              { id: 'm', context_length: 48_000 },
+            ],
+          }),
+          { headers: { 'Content-Type': 'application/json' } },
+        )
+      }
+      return new Response('', { status: 404 })
+    }) as typeof fetch
+
+    const result = await discoverContextWindow('https://example/v1', 'm')
+    expect(result?.contextWindow).toBe(48_000)
+    expect(calls).toBeGreaterThanOrEqual(2)
+  })
+
+  test('falls back to Ollama /api/show when /v1 endpoints fail', async () => {
+    globalThis.fetch = (async (input: URL | RequestInfo) => {
+      const url = typeof input === 'string' ? input : (input as URL).toString()
+      if (url.includes('/api/show')) {
+        return new Response(
+          JSON.stringify({
+            model_info: {
+              'llama.context_length': 8_192,
+              'general.architecture': 'llama',
+            },
+          }),
+          { headers: { 'Content-Type': 'application/json' } },
+        )
+      }
+      return new Response('', { status: 404 })
+    }) as typeof fetch
+
+    const result = await discoverContextWindow(
+      'http://localhost:11434/v1',
+      'llama3',
+    )
+    expect(result?.contextWindow).toBe(8_192)
+  })
+
+  test('returns undefined when all strategies fail', async () => {
+    globalThis.fetch = (async () => new Response('', { status: 500 })) as typeof fetch
+    const result = await discoverContextWindow('https://example/v1', 'm')
+    expect(result).toBeUndefined()
+  })
+
+  test('network errors do not throw', async () => {
+    globalThis.fetch = (async () => {
+      throw new Error('ECONNREFUSED')
+    }) as typeof fetch
+    const result = await discoverContextWindow('https://example/v1', 'm')
+    expect(result).toBeUndefined()
+  })
+})
+
+describe('warmContextWindowCache', () => {
+  test('skips probe when a fresh entry already exists', async () => {
+    rememberContextWindow('https://example/v1', 'm', 100, 'seeded')
+
+    let probed = false
+    globalThis.fetch = (async () => {
+      probed = true
+      return new Response('', { status: 200 })
+    }) as typeof fetch
+
+    await warmContextWindowCache('https://example/v1', 'm')
+    expect(probed).toBe(false)
+    expect(getCachedContextWindow('https://example/v1', 'm')).toBe(100)
+  })
+
+  test('probes and caches when no entry exists', async () => {
+    globalThis.fetch = (async () =>
+      new Response(
+        JSON.stringify({ id: 'm', context_length: 4096 }),
+        { headers: { 'Content-Type': 'application/json' } },
+      )) as typeof fetch
+
+    await warmContextWindowCache('https://example/v1', 'm')
+    expect(getCachedContextWindow('https://example/v1', 'm')).toBe(4096)
+  })
+
+  test('no-ops on empty baseUrl or model', async () => {
+    let probed = false
+    globalThis.fetch = (async () => {
+      probed = true
+      return new Response('{}')
+    }) as typeof fetch
+
+    await warmContextWindowCache('', 'm')
+    await warmContextWindowCache('https://example/v1', '')
+    expect(probed).toBe(false)
+  })
+})

--- a/src/utils/model/modelContextDiscovery.ts
+++ b/src/utils/model/modelContextDiscovery.ts
@@ -1,0 +1,349 @@
+/**
+ * Runtime context-window discovery for OpenAI-compatible providers.
+ *
+ * Addresses the "unknown 3P model → conservative 128k fallback → silent
+ * truncation" bug class. Probes the provider for the actual context window
+ * and caches the result on disk so future runs skip the probe.
+ *
+ * Discovery strategies (first hit wins):
+ *   1. GET {baseUrl}/models/{modelId} — OpenRouter, Together, Fireworks return
+ *      `context_length` / `context_window` / `max_model_len`.
+ *   2. GET {baseUrl}/models — some providers put context info in the list entries.
+ *   3. POST {baseUrl}/../api/show  {"name": "<model>"} — Ollama native endpoint.
+ *
+ * Cache file: $CLAUDE_CONFIG_DIR/model-metadata.json (30-day TTL).
+ * In-memory mirror loaded sync at first access so getContextWindowForModel()
+ * stays synchronous.
+ */
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'fs'
+import { join } from 'path'
+import { logForDebugging } from '../debug.js'
+import { getClaudeConfigHomeDir } from '../envUtils.js'
+
+const CACHE_FILE_NAME = 'model-metadata.json'
+const CACHE_SCHEMA_VERSION = 1
+const CACHE_TTL_MS = 30 * 24 * 60 * 60 * 1000 // 30 days
+const DISCOVERY_TIMEOUT_MS = 5000
+
+type CacheEntry = {
+  contextWindow: number
+  discoveredAt: number
+  source: string
+}
+
+type CacheFile = {
+  version: number
+  entries: Record<string, CacheEntry>
+}
+
+type InMemoryCache = Map<string, CacheEntry>
+
+let memCache: InMemoryCache | null = null
+let configDirOverride: string | null = null
+
+function resolveConfigDir(): string {
+  return configDirOverride ?? getClaudeConfigHomeDir()
+}
+
+function cacheFilePath(): string {
+  return join(resolveConfigDir(), CACHE_FILE_NAME)
+}
+
+/**
+ * Test hook: inject a specific config directory instead of reading the
+ * process-global env var. Avoids cross-test races under `bun test`'s parallel
+ * file execution. Pass null to revert to env-based resolution.
+ */
+export function __setConfigDirForTests(dir: string | null): void {
+  configDirOverride = dir
+  memCache = null
+}
+
+function cacheKey(baseUrl: string, model: string): string {
+  return `${baseUrl.replace(/\/+$/, '')}::${model}`
+}
+
+function loadFromDisk(): InMemoryCache {
+  const cache: InMemoryCache = new Map()
+  const path = cacheFilePath()
+  if (!existsSync(path)) return cache
+
+  try {
+    const raw = readFileSync(path, 'utf8')
+    const parsed = JSON.parse(raw) as CacheFile
+    if (parsed.version !== CACHE_SCHEMA_VERSION) return cache
+    if (!parsed.entries || typeof parsed.entries !== 'object') return cache
+
+    const now = Date.now()
+    for (const [key, entry] of Object.entries(parsed.entries)) {
+      if (
+        !entry ||
+        typeof entry.contextWindow !== 'number' ||
+        typeof entry.discoveredAt !== 'number'
+      ) {
+        continue
+      }
+      if (now - entry.discoveredAt > CACHE_TTL_MS) continue
+      cache.set(key, entry)
+    }
+  } catch (err) {
+    logForDebugging(
+      `[modelContextDiscovery] failed to read cache: ${String(err)}`,
+      { level: 'warn' },
+    )
+  }
+  return cache
+}
+
+function ensureLoaded(): InMemoryCache {
+  if (memCache === null) {
+    memCache = loadFromDisk()
+  }
+  return memCache
+}
+
+function persist(cache: InMemoryCache): void {
+  try {
+    const dir = resolveConfigDir()
+    if (!existsSync(dir)) {
+      mkdirSync(dir, { recursive: true })
+    }
+    const file: CacheFile = {
+      version: CACHE_SCHEMA_VERSION,
+      entries: Object.fromEntries(cache.entries()),
+    }
+    writeFileSync(cacheFilePath(), JSON.stringify(file, null, 2), 'utf8')
+  } catch (err) {
+    logForDebugging(
+      `[modelContextDiscovery] failed to write cache: ${String(err)}`,
+      { level: 'warn' },
+    )
+  }
+}
+
+/**
+ * Synchronous cache lookup. Safe to call from sync code paths like
+ * getContextWindowForModel(). Returns undefined if the model has never been
+ * discovered or its entry expired.
+ */
+export function getCachedContextWindow(
+  baseUrl: string | undefined,
+  model: string,
+): number | undefined {
+  if (!baseUrl || !model) return undefined
+  const cache = ensureLoaded()
+  const entry = cache.get(cacheKey(baseUrl, model))
+  return entry?.contextWindow
+}
+
+/**
+ * Test/reset hook. Clears the in-memory cache so the next call re-reads from disk.
+ */
+export function __resetContextCacheForTests(): void {
+  memCache = null
+}
+
+function extractContextFromModelEntry(
+  entry: Record<string, unknown> | null | undefined,
+): number | undefined {
+  if (!entry || typeof entry !== 'object') return undefined
+  // Known field names across providers:
+  //   context_length — OpenRouter, Together
+  //   context_window — Anthropic-style, some Groq models
+  //   max_model_len  — vLLM / some OSS servers
+  //   max_input_tokens — Cohere, some others
+  const candidates = [
+    'context_length',
+    'context_window',
+    'max_model_len',
+    'max_input_tokens',
+    'max_context_length',
+    'max_tokens',
+  ]
+  for (const key of candidates) {
+    const value = (entry as Record<string, unknown>)[key]
+    if (typeof value === 'number' && value > 0) {
+      return value
+    }
+  }
+  return undefined
+}
+
+async function fetchJson(
+  url: string,
+  init: RequestInit,
+  timeoutMs: number,
+): Promise<unknown> {
+  const ctrl = new AbortController()
+  const timer = setTimeout(() => ctrl.abort(), timeoutMs)
+  try {
+    const res = await fetch(url, { ...init, signal: ctrl.signal })
+    if (!res.ok) return undefined
+    const contentType = res.headers.get('content-type') ?? ''
+    if (!contentType.includes('json')) return undefined
+    return await res.json()
+  } catch {
+    return undefined
+  } finally {
+    clearTimeout(timer)
+  }
+}
+
+async function probeModelEndpoint(
+  baseUrl: string,
+  model: string,
+  headers: Record<string, string>,
+): Promise<{ contextWindow: number; source: string } | undefined> {
+  const trimmed = baseUrl.replace(/\/+$/, '')
+  const encoded = encodeURIComponent(model)
+  const url = `${trimmed}/models/${encoded}`
+  const data = (await fetchJson(
+    url,
+    { method: 'GET', headers },
+    DISCOVERY_TIMEOUT_MS,
+  )) as Record<string, unknown> | undefined
+  if (!data) return undefined
+  const direct = extractContextFromModelEntry(data)
+  if (direct) return { contextWindow: direct, source: `GET ${url}` }
+  // Some providers wrap metadata: { data: {...} } or { model: {...} }
+  for (const nestKey of ['data', 'model', 'object']) {
+    const nested = (data as Record<string, unknown>)[nestKey]
+    const nestedWindow = extractContextFromModelEntry(
+      nested as Record<string, unknown>,
+    )
+    if (nestedWindow) {
+      return { contextWindow: nestedWindow, source: `GET ${url} (${nestKey})` }
+    }
+  }
+  return undefined
+}
+
+async function probeModelList(
+  baseUrl: string,
+  model: string,
+  headers: Record<string, string>,
+): Promise<{ contextWindow: number; source: string } | undefined> {
+  const trimmed = baseUrl.replace(/\/+$/, '')
+  const url = `${trimmed}/models`
+  const data = (await fetchJson(
+    url,
+    { method: 'GET', headers },
+    DISCOVERY_TIMEOUT_MS,
+  )) as { data?: Array<Record<string, unknown>> } | undefined
+  const list = data?.data
+  if (!Array.isArray(list)) return undefined
+  const entry = list.find(e => (e as { id?: string }).id === model)
+  if (!entry) return undefined
+  const window = extractContextFromModelEntry(entry)
+  if (window) return { contextWindow: window, source: `GET ${url} (list)` }
+  return undefined
+}
+
+async function probeOllamaShow(
+  baseUrl: string,
+  model: string,
+  headers: Record<string, string>,
+): Promise<{ contextWindow: number; source: string } | undefined> {
+  // Ollama's native endpoint lives at /api/show, outside /v1.
+  let originAndPrefix: string
+  try {
+    const parsed = new URL(baseUrl)
+    const normalized = parsed.pathname.replace(/\/+$/, '')
+    const prefix = normalized.endsWith('/v1') ? normalized.slice(0, -3) : normalized
+    originAndPrefix = `${parsed.origin}${prefix}`.replace(/\/+$/, '')
+  } catch {
+    return undefined
+  }
+  const url = `${originAndPrefix}/api/show`
+  const data = (await fetchJson(
+    url,
+    {
+      method: 'POST',
+      headers: { ...headers, 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: model }),
+    },
+    DISCOVERY_TIMEOUT_MS,
+  )) as Record<string, unknown> | undefined
+  if (!data) return undefined
+
+  // Ollama reports context via model_info["<arch>.context_length"] or parameters.
+  const modelInfo = data.model_info as Record<string, unknown> | undefined
+  if (modelInfo) {
+    for (const [key, value] of Object.entries(modelInfo)) {
+      if (key.endsWith('.context_length') && typeof value === 'number' && value > 0) {
+        return { contextWindow: value, source: `POST ${url} (model_info.${key})` }
+      }
+    }
+  }
+  const parameters = data.parameters
+  if (typeof parameters === 'string') {
+    const match = parameters.match(/num_ctx\s+(\d+)/i)
+    if (match) {
+      const n = parseInt(match[1], 10)
+      if (n > 0) return { contextWindow: n, source: `POST ${url} (parameters)` }
+    }
+  }
+  return undefined
+}
+
+/**
+ * Probe the provider for the context window of a specific model. Tries
+ * /models/{id}, then /models list, then Ollama /api/show. Returns undefined
+ * when no strategy succeeds.
+ */
+export async function discoverContextWindow(
+  baseUrl: string,
+  model: string,
+  headers: Record<string, string> = {},
+): Promise<{ contextWindow: number; source: string } | undefined> {
+  const strategies = [probeModelEndpoint, probeModelList, probeOllamaShow]
+  for (const strategy of strategies) {
+    const result = await strategy(baseUrl, model, headers)
+    if (result) return result
+  }
+  return undefined
+}
+
+/**
+ * Record a discovered context window to the cache (memory + disk). Subsequent
+ * synchronous reads via getCachedContextWindow() will see it immediately.
+ */
+export function rememberContextWindow(
+  baseUrl: string,
+  model: string,
+  contextWindow: number,
+  source: string,
+): void {
+  if (!baseUrl || !model || !contextWindow) return
+  const cache = ensureLoaded()
+  cache.set(cacheKey(baseUrl, model), {
+    contextWindow,
+    discoveredAt: Date.now(),
+    source,
+  })
+  persist(cache)
+}
+
+/**
+ * One-shot probe-and-cache. Does nothing if a fresh cache entry already exists.
+ * Intended to be called at startup (fire-and-forget) for the active model.
+ */
+export async function warmContextWindowCache(
+  baseUrl: string,
+  model: string,
+  headers: Record<string, string> = {},
+): Promise<void> {
+  if (!baseUrl || !model) return
+  const existing = getCachedContextWindow(baseUrl, model)
+  if (existing !== undefined) return
+  const discovered = await discoverContextWindow(baseUrl, model, headers)
+  if (discovered) {
+    rememberContextWindow(
+      baseUrl,
+      model,
+      discovered.contextWindow,
+      discovered.source,
+    )
+  }
+}

--- a/src/utils/model/modelContextDiscovery.ts
+++ b/src/utils/model/modelContextDiscovery.ts
@@ -148,18 +148,26 @@ function extractContextFromModelEntry(
   entry: Record<string, unknown> | null | undefined,
 ): number | undefined {
   if (!entry || typeof entry !== 'object') return undefined
-  // Known field names across providers:
-  //   context_length — OpenRouter, Together
-  //   context_window — Anthropic-style, some Groq models
-  //   max_model_len  — vLLM / some OSS servers
-  //   max_input_tokens — Cohere, some others
+  // Known context-window field names across providers. Each one unambiguously
+  // refers to the *input* / total-window size.
+  //   context_length     — OpenRouter, Together, Fireworks
+  //   context_window     — Anthropic-style, some Groq models
+  //   max_model_len      — vLLM / some OSS servers
+  //   max_input_tokens   — Cohere, some others
+  //   max_context_length — less common fallback seen on a few providers
+  //
+  // NOTE: `max_tokens` is DELIBERATELY omitted. In the OpenAI API schema
+  // (and vLLM's OpenAI-compatible endpoint) `max_tokens` is the output
+  // completion cap, not the context window. A 128k-context model with a
+  // 4096 output cap would be cached as a 4096-window — triggering aggressive
+  // premature auto-compaction on every turn. Only use fields whose semantics
+  // are unambiguous.
   const candidates = [
     'context_length',
     'context_window',
     'max_model_len',
     'max_input_tokens',
     'max_context_length',
-    'max_tokens',
   ]
   for (const key of candidates) {
     const value = (entry as Record<string, unknown>)[key]


### PR DESCRIPTION
Unknown OpenAI-compatible models today silently fall back to a conservative 128k default with a "add this model to openaiContextWindows.ts" warning. That static table is impossible to keep current across the long tail of providers / fine-tunes / self-hosted setups, and the undetected mismatch causes silent truncation or premature auto-compaction.

Adds runtime discovery that probes the provider on first use and caches the result so future sessions skip the probe.

New module: src/utils/model/modelContextDiscovery.ts
- discoverContextWindow() tries three strategies in order:
  1. GET {baseUrl}/models/{id} — OpenRouter, Together, Fireworks, vLLM (fields: context_length / context_window / max_model_len / etc.)
  2. GET {baseUrl}/models — providers that expose context in the list entry
  3. POST {origin}/api/show — Ollama native endpoint, parses model_info and parameters.num_ctx
- Cache file: $CLAUDE_CONFIG_DIR/model-metadata.json, 30-day TTL, schema- versioned, malformed-safe.
- Synchronous getCachedContextWindow() keeps getContextWindowForModel() non-async — no ripple through call sites.

Integration: after the static-table miss in getContextWindowForModel(), consult the cache. On miss, still return the conservative fallback but fire a fire-and-forget background probe (deduped per session) so the next turn / next session has an accurate value.

Test isolation note: uses __setConfigDirForTests() instead of CLAUDE_CONFIG_DIR env var, since bun runs test files in parallel and process.env is process-global.
