### PR TITLE
fix(api): consolidate 3P provider compatibility fixes

### DIFF
--- a/src/__tests__/bugfixes.test.ts
+++ b/src/__tests__/bugfixes.test.ts
@@ -21,11 +21,11 @@ describe('Gemini store field fix', () => {
   test('isGeminiMode is imported and used in openaiShim', async () => {
     const content = await file('services/api/openaiShim.ts').text()
 
-    // Verify the fix: store deletion should check for Gemini mode
+    // Verify the fix: store deletion should check for Gemini mode and local providers
     expect(content).toContain('isGeminiMode()')
-    expect(content).toContain("mistral and gemini don't recognize body.store")
-    // Ensure the delete body.store is guarded for both Mistral and Gemini
-    expect(content).toMatch(/isMistral\s*\|\|\s*isGeminiMode\(\)/)
+    expect(content).toContain("Strip store for providers that don't recognize it")
+    // Ensure the delete body.store is guarded for Mistral, Gemini, and local providers
+    expect(content).toMatch(/isMistral\s*\|\|\s*isGeminiMode\(\)\s*\|\|\s*isLocal/)
   })
 
   test('store: false is still set by default (OpenAI needs it)', async () => {

--- a/src/services/api/openaiShim.test.ts
+++ b/src/services/api/openaiShim.test.ts
@@ -3019,3 +3019,123 @@ test('preserves valid tool_result and drops orphan tool_result', async () => {
   const orphanMessage = toolMessages.find(m => m.tool_call_id === 'orphan_call_2')
   expect(orphanMessage).toBeUndefined()
 })
+
+test('request body does not contain store field for local providers', async () => {
+  process.env.CLAUDE_CODE_USE_OPENAI = '1'
+  process.env.OPENAI_BASE_URL = 'http://localhost:11434/v1'
+  let requestBody: Record<string, unknown> | undefined
+
+  globalThis.fetch = (async (_input, init) => {
+    requestBody = JSON.parse(String(init?.body))
+    return new Response(
+      JSON.stringify({
+        id: 'chatcmpl-1',
+        object: 'chat.completion',
+        model: 'test-model',
+        choices: [{ index: 0, message: { role: 'assistant', content: 'ok' }, finish_reason: 'stop' }],
+        usage: { prompt_tokens: 10, completion_tokens: 2, total_tokens: 12 },
+      }),
+      { headers: { 'Content-Type': 'application/json' } },
+    )
+  }) as FetchType
+
+  const client = createOpenAIShimClient({ defaultHeaders: {} }) as unknown as OpenAIShimClient
+  await client.beta.messages.create({
+    model: 'some-model',
+    messages: [{ role: 'user', content: [{ type: 'text', text: 'hi' }] }],
+    max_tokens: 64,
+    stream: false,
+  })
+
+  expect(requestBody).toBeDefined()
+  expect('store' in requestBody!).toBe(false)
+})
+
+test('preserves reasoning_content on assistant messages with tool_calls during replay', async () => {
+  process.env.CLAUDE_CODE_USE_OPENAI = '1'
+  let requestBody: Record<string, unknown> | undefined
+
+  globalThis.fetch = (async (_input, init) => {
+    requestBody = JSON.parse(String(init?.body))
+    return new Response(
+      JSON.stringify({
+        id: 'chatcmpl-1',
+        object: 'chat.completion',
+        model: 'test-model',
+        choices: [{ index: 0, message: { role: 'assistant', content: 'done' }, finish_reason: 'stop' }],
+        usage: { prompt_tokens: 10, completion_tokens: 2, total_tokens: 12 },
+      }),
+      { headers: { 'Content-Type': 'application/json' } },
+    )
+  }) as FetchType
+
+  const client = createOpenAIShimClient({ defaultHeaders: {} }) as unknown as OpenAIShimClient
+  await client.beta.messages.create({
+    model: 'kimi-k2.5',
+    messages: [
+      { role: 'user', content: [{ type: 'text', text: 'read file' }] },
+      {
+        role: 'assistant',
+        content: [
+          { type: 'thinking', thinking: 'I should use the read tool' },
+          { type: 'tool_use', id: 'call_1', name: 'Read', input: { file_path: 'test.ts' } },
+        ],
+      },
+      {
+        role: 'user',
+        content: [
+          { type: 'tool_result', tool_use_id: 'call_1', content: 'file contents here' },
+        ],
+      },
+    ],
+    max_tokens: 64,
+    stream: false,
+  })
+
+  const messages = requestBody?.messages as Array<Record<string, unknown>>
+  const assistantMsg = messages.find(m => m.role === 'assistant' && m.tool_calls)
+  expect(assistantMsg).toBeDefined()
+  expect(assistantMsg!.reasoning_content).toBe('I should use the read tool')
+})
+
+test('does not add reasoning_content on assistant messages without tool_calls', async () => {
+  process.env.CLAUDE_CODE_USE_OPENAI = '1'
+  let requestBody: Record<string, unknown> | undefined
+
+  globalThis.fetch = (async (_input, init) => {
+    requestBody = JSON.parse(String(init?.body))
+    return new Response(
+      JSON.stringify({
+        id: 'chatcmpl-1',
+        object: 'chat.completion',
+        model: 'test-model',
+        choices: [{ index: 0, message: { role: 'assistant', content: 'ok' }, finish_reason: 'stop' }],
+        usage: { prompt_tokens: 10, completion_tokens: 2, total_tokens: 12 },
+      }),
+      { headers: { 'Content-Type': 'application/json' } },
+    )
+  }) as FetchType
+
+  const client = createOpenAIShimClient({ defaultHeaders: {} }) as unknown as OpenAIShimClient
+  await client.beta.messages.create({
+    model: 'deepseek-reasoner',
+    messages: [
+      { role: 'user', content: [{ type: 'text', text: 'explain' }] },
+      {
+        role: 'assistant',
+        content: [
+          { type: 'thinking', thinking: 'Let me think about this' },
+          { type: 'text', text: 'Here is the explanation' },
+        ],
+      },
+      { role: 'user', content: [{ type: 'text', text: 'thanks' }] },
+    ],
+    max_tokens: 64,
+    stream: false,
+  })
+
+  const messages = requestBody?.messages as Array<Record<string, unknown>>
+  const assistantMsg = messages.find(m => m.role === 'assistant' && !m.tool_calls)
+  expect(assistantMsg).toBeDefined()
+  expect(assistantMsg!.reasoning_content).toBeUndefined()
+})

--- a/src/services/api/openaiShim.ts
+++ b/src/services/api/openaiShim.ts
@@ -192,6 +192,7 @@ function sleepMs(ms: number): Promise<void> {
 interface OpenAIMessage {
   role: 'system' | 'user' | 'assistant' | 'tool'
   content?: string | Array<{ type: string; text?: string; image_url?: { url: string } }>
+  reasoning_content?: string
   tool_calls?: Array<{
     id: string
     type: 'function'
@@ -416,6 +417,16 @@ function convertMessages(
         }
 
         if (toolUses.length > 0) {
+          // Preserve thinking text as reasoning_content for providers that
+          // require it on replayed assistant tool-call messages (e.g. Kimi,
+          // DeepSeek). Without this, follow-up requests fail with 400:
+          // "reasoning_content is missing in assistant tool call message".
+          // Note: only the first thinking block per turn is captured (.find);
+          // Anthropic's API typically produces one thinking block per turn.
+          if (thinkingBlock) {
+            assistantMsg.reasoning_content = (thinkingBlock as { thinking?: string }).thinking ?? ''
+          }
+
           assistantMsg.tool_calls = toolUses.map(
             (tu: {
               id?: string
@@ -1345,9 +1356,10 @@ class OpenAIShimMessages {
       delete body.max_completion_tokens
     }
 
-    // mistral and gemini don't recognize body.store — Gemini returns 400
-    // "Invalid JSON payload received. Unknown name 'store': Cannot find field."
-    if (isMistral || isGeminiMode()) {
+    // Strip store for providers that don't recognize it. Only OpenAI's own
+    // API supports this field — Gemini returns 400, local servers (vLLM,
+    // Ollama) reject unknown fields, and other providers silently ignore it.
+    if (isMistral || isGeminiMode() || isLocal) {
       delete body.store
     }
 

--- a/src/utils/context.ts
+++ b/src/utils/context.ts
@@ -190,16 +190,20 @@ export function getModelMaxOutputTokens(model: string): {
   }
 
   // OpenAI-compatible provider — use known output limits to avoid 400 errors
-  if (
+  const isOpenAICompatProvider =
     isEnvTruthy(process.env.CLAUDE_CODE_USE_OPENAI) ||
     isEnvTruthy(process.env.CLAUDE_CODE_USE_GEMINI) ||
     isEnvTruthy(process.env.CLAUDE_CODE_USE_GITHUB) ||
     isEnvTruthy(process.env.CLAUDE_CODE_USE_MISTRAL)
-  ) {
+  if (isOpenAICompatProvider) {
     const openaiMax = getOpenAIMaxOutputTokens(model)
     if (openaiMax !== undefined) {
       return { default: openaiMax, upperLimit: openaiMax }
     }
+    // Unknown 3P model — use conservative default to avoid vLLM/Ollama 400
+    // errors when the default 32k exceeds the model's max_model_len.
+    // Users can override with CLAUDE_CODE_MAX_OUTPUT_TOKENS.
+    return { default: 4_096, upperLimit: 16_384 }
   }
 
   const m = getCanonicalName(model)

--- a/src/utils/model/openaiContextWindows.ts
+++ b/src/utils/model/openaiContextWindows.ts
@@ -177,15 +177,19 @@ const OPENAI_CONTEXT_WINDOWS: Record<string, number> = {
   'MiniMax-M2':               204_800,
 
   // Google (via OpenRouter)
-  'google/gemini-2.0-flash':1_048_576,
-  'google/gemini-2.5-pro':  1_048_576,
+  'google/gemini-2.0-flash':          1_048_576,
+  'google/gemini-2.5-pro':            1_048_576,
+  'google/gemini-3-flash-preview':    1_048_576,
+  'google/gemini-3.1-pro-preview':    1_048_576,
 
   // Google (native via CLAUDE_CODE_USE_GEMINI)
-  'gemini-2.0-flash':              1_048_576,
-  'gemini-2.5-pro':                1_048_576,
-  'gemini-2.5-flash':              1_048_576,
-  'gemini-3.1-pro':                1_048_576,
-  'gemini-3.1-flash-lite-preview': 1_048_576,
+  'gemini-2.0-flash':                 1_048_576,
+  'gemini-2.5-pro':                   1_048_576,
+  'gemini-2.5-flash':                 1_048_576,
+  'gemini-3-flash-preview':           1_048_576,
+  'gemini-3.1-pro':                   1_048_576,
+  'gemini-3.1-pro-preview':           1_048_576,
+  'gemini-3.1-flash-lite-preview':    1_048_576,
 
   // Ollama local models
   // Llama 3.1+ models support 128k context natively (Meta official specs).
@@ -329,15 +333,19 @@ const OPENAI_MAX_OUTPUT_TOKENS: Record<string, number> = {
   'MiniMax-Vision-01-Fast':    16_384,
 
   // Google (via OpenRouter)
-  'google/gemini-2.0-flash':   8_192,
-  'google/gemini-2.5-pro':    65_536,
+  'google/gemini-2.0-flash':          8_192,
+  'google/gemini-2.5-pro':           65_536,
+  'google/gemini-3-flash-preview':   65_536,
+  'google/gemini-3.1-pro-preview':   65_536,
 
   // Google (native via CLAUDE_CODE_USE_GEMINI)
-  'gemini-2.0-flash':              8_192,
-  'gemini-2.5-pro':                65_536,
-  'gemini-2.5-flash':              65_536,
-  'gemini-3.1-pro':                65_536,
-  'gemini-3.1-flash-lite-preview': 65_536,
+  'gemini-2.0-flash':                 8_192,
+  'gemini-2.5-pro':                  65_536,
+  'gemini-2.5-flash':                65_536,
+  'gemini-3-flash-preview':          65_536,
+  'gemini-3.1-pro':                  65_536,
+  'gemini-3.1-pro-preview':          65_536,
+  'gemini-3.1-flash-lite-preview':   65_536,
 
   // Ollama local models (conservative safe defaults)
   'llama3.3:70b':               4_096,


### PR DESCRIPTION
## Summary

Consolidates six open PRs (#258, #268, #237, #643, #666, #677) into a single coherent changeset addressing 3P provider compatibility gaps in the OpenAI-compatible shim.

### What changed

**1. Strip `store` field for local providers** (`openaiShim.ts`)
- Extend the existing Mistral/Gemini `store` guard to also cover local providers (Ollama, vLLM, LM Studio)
- Local servers apply strict JSON validation and reject the OpenAI-specific `store: false` field with 400 errors

**2. Add Gemini 3.x model context windows** (`openaiContextWindows.ts`)
- Add `gemini-3-flash-preview` (1M context, 65k output) and `gemini-3.1-pro-preview` (1M context, 65k output)
- Add `google/` prefixed variants for OpenRouter compatibility
- Without these entries, new Gemini models fall back to the conservative 8k default, triggering an infinite auto-compact loop at session start

**3. Conservative max_output_tokens for unknown 3P models** (`context.ts`)
- Unknown models on OpenAI-compatible providers now return `{ default: 4096, upperLimit: 16384 }` instead of falling through to the Anthropic path (32k default)
- Prevents vLLM 400 errors where `max_model_len` (typically 32768) is exceeded by prompt + completion budget
- Users can override with `CLAUDE_CODE_MAX_OUTPUT_TOKENS`

**4. Preserve `reasoning_content` on tool call replays** (`openaiShim.ts`)
- When replaying assistant messages that contain both thinking blocks and tool_use blocks, extract the thinking text and set it as `reasoning_content` on the converted OpenAI message
- Providers like Kimi k2.5 and DeepSeek reasoner require this field on assistant tool-call messages — without it, follow-up requests fail with 400: "reasoning_content is missing in assistant tool call message"
- Field is set even when thinking text is empty (DeepSeek requires field presence)

### What was already fixed on main (not included)

These issues from the original PRs were already resolved upstream:
- `getPromptCachingEnabled()` is already provider-aware (only firstParty/bedrock/vertex)
- `reasoning_content` streaming is already implemented
- Tool result image handling (base64 + URL) is already implemented
- Thinking blocks are already stripped in `convertContentBlocks()`
- `stripThinkingBlocks` ordering in `conversationRecovery.ts` is already correct
- Context window fallback for unknown 3P models is already 8k

## Impact

- **user-facing:** Gemini 3.x users no longer hit 400 errors or infinite compaction loops. Ollama/vLLM users no longer get `store` field rejections. Kimi/DeepSeek reasoning model users can use tool calls without 400 errors. Unknown models on 3P providers get safe defaults instead of oversized token budgets.
- **developer/maintainer:** Minimal changes (5 files, +167/-23). All fixes are additive with clear inline comments.

## Testing

- [x] `bun run build` — v0.5.2 ✓
- [x] `bun run smoke` — 0.5.2 (Open Claude) ✓
- [x] `bun test` — 984/985 pass (1 pre-existing failure in QueryEngine.test.ts, unrelated)
- [x] 3 new tests:
  - `store` field absent for local provider URLs
  - `reasoning_content` preserved on assistant messages with tool_calls
  - `reasoning_content` absent on assistant messages without tool_calls

## PRs consolidated

| PR | Author | Finding | Status in this PR |
|----|--------|---------|-------------------|
| #258 | @auriti | Strip Anthropic params from 3P | Partially — thinking strip + 8k default already on main; reasoning_content replay added |
| #268 | @auriti | Prevent Anthropic field leaks | Partially — cache_control + headers already fixed; store guard extended |
| #237 | @auriti | Forward reasoning_content, Ollama max_tokens, tool images | Partially — streaming + images already on main; replay preservation added |
| #643 | @Gustavo-Falci | Gemini 400 + 2M context | Store already absent from shim; Gemini 3.x context windows added |
| #666 | @lttlin | Preserve reasoning_content on replays | Fully addressed |
| #677 | @Durannd | Store for local/Gemini + max_tokens default | Store guard extended; conservative output token fallback added |

## Notes

- The `store: false` field was already present in the shim body construction but only stripped for Mistral and Gemini. This PR extends the guard to local providers.
- `reasoning_content` is only set when the assistant message has both thinking blocks AND tool_use blocks. Text-only messages with thinking do not get the field.
- The 4096/16384 output token fallback is intentionally conservative. Users with models that support higher limits should add entries to `openaiContextWindows.ts` or set `CLAUDE_CODE_MAX_OUTPUT_TOKENS`.