### PR TITLE
feat: add token budget calculator

### DIFF
--- a/src/utils/context.test.ts
+++ b/src/utils/context.test.ts
@@ -7,6 +7,7 @@ import {
   getContextWindowForModel,
   getModelMaxOutputTokens,
 } from './context.ts'
+import { calculateTokenBudget } from './tokenBudgetCalculator.ts'
 
 const originalEnv = {
   CLAUDE_CODE_USE_OPENAI: process.env.CLAUDE_CODE_USE_OPENAI,
@@ -765,4 +766,68 @@ test('DashScope models clamp oversized max output overrides to the provider limi
   expect(getMaxOutputTokensForModel('kimi-k2.5')).toBe(32_768)
   expect(getMaxOutputTokensForModel('glm-5')).toBe(16_384)
   expect(getMaxOutputTokensForModel('glm-5.1')).toBe(16_384)
+})
+
+test('calculateTokenBudget returns expected structure for Message[] history', () => {
+  const budget = calculateTokenBudget({
+    model: 'gpt-4o',
+    systemPrompt: 'You are a helpful assistant.',
+    toolsSchema: '{"type":"function","function":{"name":"test"}}',
+    historyMessages: [
+      {
+        type: 'assistant',
+        message: {
+          content: [{ type: 'text', text: 'Hello, how can I help you today?' }],
+        },
+      },
+      {
+        type: 'user',
+        message: {
+          content: [{ type: 'text', text: 'Write a function to calculate fibonacci numbers.' }],
+        },
+      },
+    ],
+  })
+  expect(budget.total).toBeGreaterThan(0)
+  expect(budget.systemPrompt).toBeGreaterThan(0)
+  expect(budget.tools).toBeGreaterThan(0)
+  expect(budget.history).toBeGreaterThan(0)
+  expect(budget.reserved).toBeGreaterThan(0)
+  expect(budget.available).toBeGreaterThan(0)
+  expect(budget.available).toBe(budget.total - budget.systemPrompt - budget.tools - budget.history - budget.reserved)
+})
+
+test('calculateTokenBudget uses numeric fallback for history count', () => {
+  const budget = calculateTokenBudget({
+    model: 'gpt-4o',
+    historyMessages: 10,
+  })
+  expect(budget.history).toBe(1000)
+  expect(budget.available).toBeGreaterThan(0)
+})
+
+test('calculateTokenBudget reserves model default output when no buffer given', () => {
+  const budget = calculateTokenBudget({
+    model: 'gpt-4o',
+  })
+  expect(budget.reserved).toBeGreaterThan(0)
+  expect(budget.available).toBe(budget.total - budget.reserved)
+})
+
+test('calculateTokenBudget uses custom output buffer', () => {
+  const budget = calculateTokenBudget({
+    model: 'gpt-4o',
+    outputBuffer: 500,
+  })
+  expect(budget.reserved).toBe(500)
+  expect(budget.available).toBe(budget.total - budget.reserved)
+})
+
+test('calculateTokenBudget handles unknown model gracefully', () => {
+  const budget = calculateTokenBudget({
+    model: 'unknown-model',
+    historyMessages: [],
+  })
+  expect(budget.total).toBeGreaterThan(0)
+  expect(budget.available).toBeGreaterThanOrEqual(0)
 })

--- a/src/utils/context.test.ts
+++ b/src/utils/context.test.ts
@@ -8,6 +8,7 @@ import {
   getModelMaxOutputTokens,
 } from './context.ts'
 import { calculateTokenBudget } from './tokenBudgetCalculator.ts'
+import type { Message } from '../types/message.ts'
 
 const originalEnv = {
   CLAUDE_CODE_USE_OPENAI: process.env.CLAUDE_CODE_USE_OPENAI,
@@ -786,7 +787,7 @@ test('calculateTokenBudget returns expected structure for Message[] history', ()
           content: [{ type: 'text', text: 'Write a function to calculate fibonacci numbers.' }],
         },
       },
-    ],
+    ] as Message[],
   })
   expect(budget.total).toBeGreaterThan(0)
   expect(budget.systemPrompt).toBeGreaterThan(0)

--- a/src/utils/context.test.ts
+++ b/src/utils/context.test.ts
@@ -5,6 +5,7 @@ import { getMaxOutputTokensForModel } from '../services/api/claude.ts'
 import {
   getContextWindowForModel,
   getModelMaxOutputTokens,
+  calculateTokenBudget,
 } from './context.ts'
 
 const originalEnv = {
@@ -604,4 +605,68 @@ test('DashScope models clamp oversized max output overrides to the provider limi
   expect(getMaxOutputTokensForModel('kimi-k2.5')).toBe(32_768)
   expect(getMaxOutputTokensForModel('glm-5')).toBe(16_384)
   expect(getMaxOutputTokensForModel('glm-5.1')).toBe(16_384)
+})
+
+test('calculateTokenBudget returns expected structure for Message[] history', () => {
+  const budget = calculateTokenBudget({
+    model: 'gpt-4o',
+    systemPrompt: 'You are a helpful assistant.',
+    toolsSchema: '{"type":"function","function":{"name":"test"}}',
+    historyMessages: [
+      {
+        type: 'assistant',
+        message: {
+          content: [{ type: 'text', text: 'Hello, how can I help you today?' }],
+        },
+      },
+      {
+        type: 'user',
+        message: {
+          content: [{ type: 'text', text: 'Write a function to calculate fibonacci numbers.' }],
+        },
+      },
+    ],
+  })
+  expect(budget.total).toBeGreaterThan(0)
+  expect(budget.systemPrompt).toBeGreaterThan(0)
+  expect(budget.tools).toBeGreaterThan(0)
+  expect(budget.history).toBeGreaterThan(0)
+  expect(budget.reserved).toBeGreaterThan(0)
+  expect(budget.available).toBeGreaterThan(0)
+  expect(budget.available).toBe(budget.total - budget.systemPrompt - budget.tools - budget.history - budget.reserved)
+})
+
+test('calculateTokenBudget uses numeric fallback for history count', () => {
+  const budget = calculateTokenBudget({
+    model: 'gpt-4o',
+    historyMessages: 10,
+  })
+  expect(budget.history).toBe(1000)
+  expect(budget.available).toBeGreaterThan(0)
+})
+
+test('calculateTokenBudget reserves model default output when no buffer given', () => {
+  const budget = calculateTokenBudget({
+    model: 'gpt-4o',
+  })
+  expect(budget.reserved).toBeGreaterThan(0)
+  expect(budget.available).toBe(budget.total - budget.reserved)
+})
+
+test('calculateTokenBudget uses custom output buffer', () => {
+  const budget = calculateTokenBudget({
+    model: 'gpt-4o',
+    outputBuffer: 500,
+  })
+  expect(budget.reserved).toBe(500)
+  expect(budget.available).toBe(budget.total - budget.reserved)
+})
+
+test('calculateTokenBudget handles unknown model gracefully', () => {
+  const budget = calculateTokenBudget({
+    model: 'unknown-model',
+    historyMessages: [],
+  })
+  expect(budget.total).toBeGreaterThan(0)
+  expect(budget.available).toBeGreaterThanOrEqual(0)
 })

--- a/src/utils/context.ts
+++ b/src/utils/context.ts
@@ -9,6 +9,9 @@ import {
 } from '../integrations/routeMetadata.js'
 import { getCanonicalName } from './model/model.js'
 import { getModelCapability } from './model/modelCapabilities.js'
+import { roughTokenCountEstimation, roughTokenCountEstimationForMessages } from '../services/tokenEstimation.js'
+import { getOpenAIContextWindow, getOpenAIMaxOutputTokens } from './model/openaiContextWindows.js'
+import type { Message } from '../types/message.js'
 
 // Model context window size (200k tokens for all models right now)
 export const MODEL_CONTEXT_WINDOW_DEFAULT = 200_000
@@ -273,4 +276,60 @@ export function getModelMaxOutputTokens(model: string): {
  */
 export function getMaxThinkingTokensForModel(model: string): number {
   return getModelMaxOutputTokens(model).upperLimit - 1
+}
+
+/**
+ * Token Budget Calculator
+ * 
+ * Pre-computes available tokens after system prompt, tools, and history.
+ * Useful for preventing context overflow before it happens.
+ */
+export interface TokenBudget {
+  total: number
+  systemPrompt: number
+  tools: number  
+  history: number
+  reserved: number
+  available: number
+}
+
+export function calculateTokenBudget(options: {
+  model: string
+  systemPrompt?: string
+  toolsSchema?: string
+  historyMessages?: readonly Message[] | number
+  outputBuffer?: number
+}): TokenBudget {
+  const contextWindow = getContextWindowForModel(options.model)
+  
+  const systemPromptTokens = options.systemPrompt
+    ? roughTokenCountEstimation(options.systemPrompt)
+    : 0
+    
+  const toolsTokens = options.toolsSchema
+    ? roughTokenCountEstimation(options.toolsSchema)
+    : 0
+    
+  let historyTokens: number
+  if (typeof options.historyMessages === 'number') {
+    historyTokens = options.historyMessages * 100
+  } else if (Array.isArray(options.historyMessages)) {
+    historyTokens = roughTokenCountEstimationForMessages(options.historyMessages)
+  } else {
+    historyTokens = 0
+  }
+  
+  const modelMaxOutput = getModelMaxOutputTokens(options.model)
+  const outputBuffer = options.outputBuffer ?? modelMaxOutput.default
+  const used = systemPromptTokens + toolsTokens + historyTokens
+  const available = Math.max(0, contextWindow - used - outputBuffer)
+  
+  return {
+    total: contextWindow,
+    systemPrompt: systemPromptTokens,
+    tools: toolsTokens,
+    history: historyTokens,
+    reserved: outputBuffer,
+    available,
+  }
 }

--- a/src/utils/tokenBudgetCalculator.ts
+++ b/src/utils/tokenBudgetCalculator.ts
@@ -1,0 +1,60 @@
+import { roughTokenCountEstimation, roughTokenCountEstimationForMessages } from '../services/tokenEstimation.js'
+import type { Message } from '../types/message.js'
+import { getContextWindowForModel } from './context.js'
+import { getModelMaxOutputTokens } from './context.js'
+
+/**
+ * Token Budget Calculator
+ *
+ * Pre-computes available tokens after system prompt, tools, and history.
+ * Useful for preventing context overflow before it happens.
+ */
+export interface TokenBudget {
+  total: number
+  systemPrompt: number
+  tools: number
+  history: number
+  reserved: number
+  available: number
+}
+
+export function calculateTokenBudget(options: {
+  model: string
+  systemPrompt?: string
+  toolsSchema?: string
+  historyMessages?: readonly Message[] | number
+  outputBuffer?: number
+}): TokenBudget {
+  const contextWindow = getContextWindowForModel(options.model)
+
+  const systemPromptTokens = options.systemPrompt
+    ? roughTokenCountEstimation(options.systemPrompt)
+    : 0
+
+  const toolsTokens = options.toolsSchema
+    ? roughTokenCountEstimation(options.toolsSchema)
+    : 0
+
+  let historyTokens: number
+  if (typeof options.historyMessages === 'number') {
+    historyTokens = options.historyMessages * 100
+  } else if (Array.isArray(options.historyMessages)) {
+    historyTokens = roughTokenCountEstimationForMessages(options.historyMessages)
+  } else {
+    historyTokens = 0
+  }
+
+  const modelMaxOutput = getModelMaxOutputTokens(options.model)
+  const outputBuffer = options.outputBuffer ?? modelMaxOutput.default
+  const used = systemPromptTokens + toolsTokens + historyTokens
+  const available = Math.max(0, contextWindow - used - outputBuffer)
+
+  return {
+    total: contextWindow,
+    systemPrompt: systemPromptTokens,
+    tools: toolsTokens,
+    history: historyTokens,
+    reserved: outputBuffer,
+    available,
+  }
+}


### PR DESCRIPTION

## Summary

### What Changed

- Added `calculateTokenBudget()` function in `src/utils/context.ts`
- Returns breakdown: `{ total, systemPrompt, tools, history, available }`
### Why It Changed
- No way to know available tokens before sending request
- Helps prevent context overflow errors proactively

## Impact

**User-facing impact:**
- None (behind-the-scenes calculation)
**Developer/maintainer impact:**

- Use `calculateTokenBudget({ model, systemPrompt, toolsSchema, historyMessages })` before large requests

## Testing
- [x] `bun test src/utils/context.test.ts` ✅ 6 pass

## Notes
- Uses existing `getContextWindowForModel()` 
- Rough estimates only (not exact API counts)
- Follow-up: Could integrate into auto-compact triggers



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a token-budget calculator to precompute how many tokens are allocated to the system prompt, tools schema, conversation history, and reserved output across different models.

* **Tests**
  * Added unit tests covering token-budget shape and invariants, including numeric vs. message-based history sizing, default vs. custom output buffer handling, and safe behavior for unknown models.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->