### PR TITLE
fix: replace discontinued Gemini preview default with stable 2.5 Pro

### DIFF
--- a/src/utils/model/configs.ts
+++ b/src/utils/model/configs.ts
@@ -20,7 +20,7 @@ export const OPENAI_MODEL_DEFAULTS = {
 // Override with GEMINI_MODEL env var.
 // ---------------------------------------------------------------------------
 export const GEMINI_MODEL_DEFAULTS = {
-  opus: 'gemini-2.5-pro-preview-03-25',   // most capable
+  opus: 'gemini-2.5-pro',   // most capable
   sonnet: 'gemini-2.0-flash',              // balanced
   haiku: 'gemini-2.0-flash-lite',          // fast & cheap
 } as const
@@ -112,7 +112,7 @@ export const CLAUDE_OPUS_4_CONFIG = {
   vertex: 'claude-opus-4@20250514',
   foundry: 'claude-opus-4',
   openai: 'gpt-4o',
-  gemini: 'gemini-2.5-pro-preview-03-25',
+  gemini: 'gemini-2.5-pro',
   github: 'github:copilot',
   codex: 'gpt-5.4',
   'nvidia-nim': 'nvidia/llama-3.1-nemotron-70b-instruct',
@@ -125,7 +125,7 @@ export const CLAUDE_OPUS_4_1_CONFIG = {
   vertex: 'claude-opus-4-1@20250805',
   foundry: 'claude-opus-4-1',
   openai: 'gpt-4o',
-  gemini: 'gemini-2.5-pro-preview-03-25',
+  gemini: 'gemini-2.5-pro',
   github: 'github:copilot',
   codex: 'gpt-5.4',
   'nvidia-nim': 'nvidia/llama-3.1-nemotron-70b-instruct',
@@ -138,7 +138,7 @@ export const CLAUDE_OPUS_4_5_CONFIG = {
   vertex: 'claude-opus-4-5@20251101',
   foundry: 'claude-opus-4-5',
   openai: 'gpt-4o',
-  gemini: 'gemini-2.5-pro-preview-03-25',
+  gemini: 'gemini-2.5-pro',
   github: 'github:copilot',
   codex: 'gpt-5.4',
   'nvidia-nim': 'nvidia/llama-3.1-nemotron-70b-instruct',
@@ -151,7 +151,7 @@ export const CLAUDE_OPUS_4_6_CONFIG = {
   vertex: 'claude-opus-4-6',
   foundry: 'claude-opus-4-6',
   openai: 'gpt-4o',
-  gemini: 'gemini-2.5-pro-preview-03-25',
+  gemini: 'gemini-2.5-pro',
   github: 'github:copilot',
   codex: 'gpt-5.4',
   'nvidia-nim': 'nvidia/llama-3.1-nemotron-70b-instruct',

--- a/src/utils/model/model.ts
+++ b/src/utils/model/model.ts
@@ -140,7 +140,7 @@ export function getDefaultOpusModel(): ModelName {
   }
   // Gemini provider
   if (getAPIProvider() === 'gemini') {
-    return process.env.GEMINI_MODEL || 'gemini-2.5-pro-preview-03-25'
+    return process.env.GEMINI_MODEL || 'gemini-2.5-pro'
   }
   // Mistral provider
   if (getAPIProvider() === 'mistral') {


### PR DESCRIPTION
## Summary

Replace the discontinued `gemini-2.5-pro-preview-03-25` default with the stable `gemini-2.5-pro` in both the model config mappings and the runtime fallback path.

Supersedes #511 and #399 — this PR addresses the feedback from @gnanam1990 and @Vasanthdev2004 by fixing **both** locations:

- `src/utils/model/configs.ts`: all 5 Gemini opus/config mappings
- `src/utils/model/model.ts:143`: `getDefaultOpusModel()` runtime fallback

After this change, zero occurrences of `gemini-2.5-pro-preview-03-25` remain in the codebase.

Fixes #398

## Testing

- [x] `grep -rn "gemini-2.5-pro-preview" src/` returns no results
- [ ] `bun run build`
- [ ] Manual: run Gemini mode without `GEMINI_MODEL` set, confirm default resolves to `gemini-2.5-pro`