### PR TITLE
feat(provider): expose Atomic Chat in /provider picker with autodetect

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ Advanced and source-build guides:
 | Codex OAuth | `/provider` | Opens ChatGPT sign-in in your browser and stores Codex credentials securely |
 | Codex | `/provider` | Uses existing Codex CLI auth, OpenClaude secure storage, or env credentials |
 | Ollama | `/provider`, env vars, or `ollama launch` | Local inference with no API key |
-| Atomic Chat | advanced setup | Local Apple Silicon backend |
+| Atomic Chat | `/provider`, env vars, or `bun run dev:atomic-chat` | Local Model Provider; auto-detects loaded models |
 | Bedrock / Vertex / Foundry | env vars | Additional provider integrations for supported environments |
 
 ## What Works

--- a/src/components/ProviderManager.test.tsx
+++ b/src/components/ProviderManager.test.tsx
@@ -108,6 +108,7 @@ const PRESET_ORDER = [
   'Alibaba Coding Plan',
   'Alibaba Coding Plan (China)',
   'Anthropic',
+  'Atomic Chat',
   'Azure OpenAI',
   'Codex OAuth',
   'DeepSeek',

--- a/src/components/ProviderManager.tsx
+++ b/src/components/ProviderManager.tsx
@@ -37,7 +37,9 @@ import {
   readGithubModelsTokenAsync,
 } from '../utils/githubModelsCredentials.js'
 import {
+  probeAtomicChatReadiness,
   probeOllamaGenerationReadiness,
+  type AtomicChatReadiness,
   type OllamaGenerationReadiness,
 } from '../utils/providerDiscovery.js'
 import {
@@ -69,6 +71,7 @@ type Screen =
   | 'menu'
   | 'select-preset'
   | 'select-ollama-model'
+  | 'select-atomic-chat-model'
   | 'codex-oauth'
   | 'form'
   | 'select-active'
@@ -80,6 +83,16 @@ type DraftField = 'name' | 'baseUrl' | 'model' | 'apiKey'
 type ProviderDraft = Record<DraftField, string>
 
 type OllamaSelectionState =
+  | { state: 'idle' }
+  | { state: 'loading' }
+  | {
+      state: 'ready'
+      options: OptionWithDescription<string>[]
+      defaultValue?: string
+    }
+  | { state: 'unavailable'; message: string }
+
+type AtomicChatSelectionState =
   | { state: 'idle' }
   | { state: 'loading' }
   | {
@@ -220,6 +233,21 @@ function getGithubProviderSummary(
         : 'no token found'
   const activeSuffix = isActive ? ' (active)' : ''
   return `github-models · ${GITHUB_PROVIDER_DEFAULT_BASE_URL} · ${getGithubProviderModel(processEnv)} · ${credentialSummary}${activeSuffix}`
+}
+
+function describeAtomicChatSelectionIssue(
+  readiness: AtomicChatReadiness,
+  baseUrl: string,
+): string {
+  if (readiness.state === 'unreachable') {
+    return `Could not reach Atomic Chat at ${redactUrlForDisplay(baseUrl)}. Start the Atomic Chat app first, or enter the endpoint manually.`
+  }
+
+  if (readiness.state === 'no_models') {
+    return 'Atomic Chat is running, but no models are loaded. Download and load a model inside the Atomic Chat app first, or enter details manually.'
+  }
+
+  return ''
 }
 
 function describeOllamaSelectionIssue(
@@ -395,6 +423,8 @@ export function ProviderManager({ mode, onDone }: Props): React.ReactNode {
   const [ollamaSelection, setOllamaSelection] = React.useState<OllamaSelectionState>({
     state: 'idle',
   })
+  const [atomicChatSelection, setAtomicChatSelection] =
+    React.useState<AtomicChatSelectionState>({ state: 'idle' })
   // Deferred initialization: useState initializers run synchronously during
   // render, so getProviderProfiles() and getActiveProviderProfile() would block
   // the UI (sync file I/O). Defer to queueMicrotask after first render.
@@ -573,6 +603,45 @@ export function ProviderManager({ mode, onDone }: Props): React.ReactNode {
             label: model.name,
             value: model.name,
             description: model.summary,
+          })),
+        })
+      }
+    })()
+
+    return () => {
+      cancelled = true
+    }
+  }, [draft.baseUrl, screen])
+
+  React.useEffect(() => {
+    if (screen !== 'select-atomic-chat-model') {
+      return
+    }
+
+    let cancelled = false
+    setAtomicChatSelection({ state: 'loading' })
+
+    void (async () => {
+      const readiness = await probeAtomicChatReadiness({
+        baseUrl: draft.baseUrl,
+      })
+      if (readiness.state !== 'ready') {
+        if (!cancelled) {
+          setAtomicChatSelection({
+            state: 'unavailable',
+            message: describeAtomicChatSelectionIssue(readiness, draft.baseUrl),
+          })
+        }
+        return
+      }
+
+      if (!cancelled) {
+        setAtomicChatSelection({
+          state: 'ready',
+          defaultValue: readiness.models[0],
+          options: readiness.models.map(model => ({
+            label: model,
+            value: model,
           })),
         })
       }
@@ -889,6 +958,12 @@ export function ProviderManager({ mode, onDone }: Props): React.ReactNode {
       return
     }
 
+    if (preset === 'atomic-chat') {
+      setAtomicChatSelection({ state: 'loading' })
+      setScreen('select-atomic-chat-model')
+      return
+    }
+
     setScreen('form')
   }
 
@@ -962,6 +1037,86 @@ export function ProviderManager({ mode, onDone }: Props): React.ReactNode {
     setFormStepIndex(0)
     setErrorMessage(undefined)
     returnToMenu()
+  }
+
+  function renderAtomicChatSelection(): React.ReactNode {
+    if (
+      atomicChatSelection.state === 'loading' ||
+      atomicChatSelection.state === 'idle'
+    ) {
+      return (
+        <Box flexDirection="column" gap={1}>
+          <Text color="remember" bold>
+            Checking Atomic Chat
+          </Text>
+          <Text dimColor>Looking for loaded Atomic Chat models...</Text>
+        </Box>
+      )
+    }
+
+    if (atomicChatSelection.state === 'unavailable') {
+      return (
+        <Box flexDirection="column" gap={1}>
+          <Text color="remember" bold>
+            Atomic Chat setup
+          </Text>
+          <Text dimColor>{atomicChatSelection.message}</Text>
+          <Select
+            options={[
+              {
+                value: 'manual',
+                label: 'Enter manually',
+                description: 'Fill in the base URL and model yourself',
+              },
+              {
+                value: 'back',
+                label: 'Back',
+                description: 'Choose another provider preset',
+              },
+            ]}
+            onChange={(value: string) => {
+              if (value === 'manual') {
+                setFormStepIndex(0)
+                setCursorOffset(draft.name.length)
+                setScreen('form')
+                return
+              }
+              setScreen('select-preset')
+            }}
+            onCancel={() => setScreen('select-preset')}
+            visibleOptionCount={2}
+          />
+        </Box>
+      )
+    }
+
+    return (
+      <Box flexDirection="column" gap={1}>
+        <Text color="remember" bold>
+          Choose an Atomic Chat model
+        </Text>
+        <Text dimColor>
+          Pick one of the models loaded in Atomic Chat to save into a local
+          provider profile.
+        </Text>
+        <Select
+          options={atomicChatSelection.options}
+          defaultValue={atomicChatSelection.defaultValue}
+          defaultFocusValue={atomicChatSelection.defaultValue}
+          inlineDescriptions
+          visibleOptionCount={Math.min(8, atomicChatSelection.options.length)}
+          onChange={(value: string) => {
+            const nextDraft = {
+              ...draft,
+              model: value,
+            }
+            setDraft(nextDraft)
+            persistDraft(nextDraft)
+          }}
+          onCancel={() => setScreen('select-preset')}
+        />
+      </Box>
+    )
   }
 
   function renderOllamaSelection(): React.ReactNode {
@@ -1113,6 +1268,11 @@ export function ProviderManager({ mode, onDone }: Props): React.ReactNode {
         value: 'anthropic',
         label: 'Anthropic',
         description: 'Native Claude API (x-api-key auth)',
+      },
+      {
+        value: 'atomic-chat',
+        label: 'Atomic Chat',
+        description: 'Local Model Provider',
       },
       {
         value: 'azure-openai',
@@ -1472,6 +1632,9 @@ export function ProviderManager({ mode, onDone }: Props): React.ReactNode {
       break
     case 'select-ollama-model':
       content = renderOllamaSelection()
+      break
+    case 'select-atomic-chat-model':
+      content = renderAtomicChatSelection()
       break
     case 'codex-oauth':
       content = (

--- a/src/utils/providerDiscovery.test.ts
+++ b/src/utils/providerDiscovery.test.ts
@@ -299,3 +299,65 @@ test('ollama generation readiness reports ready when chat probe succeeds', async
     probeModel: 'llama3.1:8b',
   })
 })
+
+test('atomic chat readiness reports unreachable when /v1/models is down', async () => {
+  const { probeAtomicChatReadiness } = await loadProviderDiscoveryModule()
+
+  const calledUrls: string[] = []
+  globalThis.fetch = mock(input => {
+    const url = typeof input === 'string' ? input : input.url
+    calledUrls.push(url)
+    return Promise.resolve(new Response('unavailable', { status: 503 }))
+  }) as typeof globalThis.fetch
+
+  await expect(
+    probeAtomicChatReadiness({ baseUrl: 'http://127.0.0.1:1337' }),
+  ).resolves.toEqual({ state: 'unreachable' })
+
+  expect(calledUrls[0]).toBe('http://127.0.0.1:1337/v1/models')
+})
+
+test('atomic chat readiness reports no_models when server is reachable but empty', async () => {
+  const { probeAtomicChatReadiness } = await loadProviderDiscoveryModule()
+
+  globalThis.fetch = mock(() =>
+    Promise.resolve(
+      new Response(JSON.stringify({ data: [] }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    ),
+  ) as typeof globalThis.fetch
+
+  await expect(
+    probeAtomicChatReadiness({ baseUrl: 'http://127.0.0.1:1337' }),
+  ).resolves.toEqual({ state: 'no_models' })
+})
+
+test('atomic chat readiness returns loaded model ids when ready', async () => {
+  const { probeAtomicChatReadiness } = await loadProviderDiscoveryModule()
+
+  globalThis.fetch = mock(() =>
+    Promise.resolve(
+      new Response(
+        JSON.stringify({
+          data: [
+            { id: 'Qwen3_5-4B_Q4_K_M' },
+            { id: 'llama-3.1-8b-instruct' },
+          ],
+        }),
+        {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        },
+      ),
+    ),
+  ) as typeof globalThis.fetch
+
+  await expect(
+    probeAtomicChatReadiness({ baseUrl: 'http://127.0.0.1:1337' }),
+  ).resolves.toEqual({
+    state: 'ready',
+    models: ['Qwen3_5-4B_Q4_K_M', 'llama-3.1-8b-instruct'],
+  })
+})

--- a/src/utils/providerDiscovery.ts
+++ b/src/utils/providerDiscovery.ts
@@ -302,6 +302,24 @@ export async function listAtomicChatModels(
   }
 }
 
+export type AtomicChatReadiness =
+  | { state: 'unreachable' }
+  | { state: 'no_models' }
+  | { state: 'ready'; models: string[] }
+
+export async function probeAtomicChatReadiness(options?: {
+  baseUrl?: string
+}): Promise<AtomicChatReadiness> {
+  if (!(await hasLocalAtomicChat(options?.baseUrl))) {
+    return { state: 'unreachable' }
+  }
+  const models = await listAtomicChatModels(options?.baseUrl)
+  if (models.length === 0) {
+    return { state: 'no_models' }
+  }
+  return { state: 'ready', models }
+}
+
 export async function benchmarkOllamaModel(
   modelName: string,
   baseUrl?: string,

--- a/src/utils/providerProfiles.test.ts
+++ b/src/utils/providerProfiles.test.ts
@@ -527,6 +527,18 @@ describe('getProviderPresetDefaults', () => {
     expect(defaults.baseUrl).toBe('http://localhost:11434/v1')
     expect(defaults.model).toBe('llama3.1:8b')
   })
+
+  test('atomic-chat preset defaults to a local Atomic Chat endpoint', async () => {
+    const { getProviderPresetDefaults } = await importFreshProviderProfileModules()
+    delete process.env.OPENAI_MODEL
+
+    const defaults = getProviderPresetDefaults('atomic-chat')
+
+    expect(defaults.provider).toBe('openai')
+    expect(defaults.name).toBe('Atomic Chat')
+    expect(defaults.baseUrl).toBe('http://127.0.0.1:1337/v1')
+    expect(defaults.requiresApiKey).toBe(false)
+  })
 })
 
 describe('setActiveProviderProfile', () => {

--- a/src/utils/providerProfiles.ts
+++ b/src/utils/providerProfiles.ts
@@ -33,6 +33,7 @@ export type ProviderPreset =
   | 'custom'
   | 'nvidia-nim'
   | 'minimax'
+  | 'atomic-chat'
 
 export type ProviderProfileInput = {
   provider?: ProviderProfile['provider']
@@ -284,6 +285,15 @@ export function getProviderPresetDefaults(
         model: 'MiniMax-M2.5',
         apiKey: process.env.MINIMAX_API_KEY ?? '',
         requiresApiKey: true,
+      }
+    case 'atomic-chat':
+      return {
+        provider: 'openai',
+        name: 'Atomic Chat',
+        baseUrl: 'http://127.0.0.1:1337/v1',
+        model: process.env.OPENAI_MODEL ?? 'local-model',
+        apiKey: '',
+        requiresApiKey: false,
       }
     case 'ollama':
     default:


### PR DESCRIPTION
## Summary

Adds **Atomic Chat** as a first-class preset inside the in-session `/provider` slash command, mirroring the existing Ollama auto-detect flow. The underlying Atomic Chat launch profile from #74 stays unchanged — this PR only wires it into the interactive picker.

## What's new

- Picking `Atomic Chat` in `/provider` → probes `127.0.0.1:1337/v1/models`, lists loaded models for direct selection, and saves the profile in one step.
- Three-branch detection identical to Ollama:
  - **ready** → pick a loaded model from the list
  - **unreachable** → `Enter manually` / `Back`
  - **no_models** → `Enter manually` / `Back`
- Atomic Chat appears between `Anthropic` and `Azure OpenAI` in the preset list (alphabetical).
- README row updated from `advanced setup` to `/provider`, env vars, or `bun run dev:atomic-chat`.

## Files touched

- `src/utils/providerDiscovery.ts` — new `probeAtomicChatReadiness()` and `AtomicChatReadiness` type.
- `src/utils/providerProfiles.ts` — `atomic-chat` added to `ProviderPreset` union and `getProviderPresetDefaults()`.
- `src/components/ProviderManager.tsx` — new `select-atomic-chat-model` screen, state, effect, and render mirroring the Ollama flow.
- `src/components/ProviderManager.test.tsx` — `PRESET_ORDER` updated so `navigateToPreset('Ollama')` still lands on the right row.
- `src/utils/providerProfiles.test.ts` — preset-defaults test for \`atomic-chat\`.
- `src/utils/providerDiscovery.test.ts` — three tests for `probeAtomicChatReadiness` (unreachable / no_models / ready).
- `README.md` — Supported Providers table entry updated.

## Out of scope

No changes to `scripts/provider-launch.ts`, `scripts/provider-bootstrap.ts`, Python modules, or `smart_router.py` — those shipped in #74 and remain unchanged.

## Test plan

- [x] `bun test src/utils/providerDiscovery.test.ts` → 15 pass / 0 fail
- [x] `bun test src/utils/providerProfiles.test.ts` → 29 pass / 0 fail
- [x] `bun test src/components/ProviderManager.test.tsx` → 9 pass / 0 fail
- [x] Linter clean on all touched files
- [x] No new typecheck regressions beyond the pre-existing fetch-mock cast pattern in `providerDiscovery.test.ts`
- [x] Manual: `openclaude` → `/provider` → `Add provider` → confirmed Atomic Chat appears between Anthropic and Azure OpenAI, picks up loaded models from `127.0.0.1:1337`, and falls back to `Enter manually` when Atomic Chat is not running.

Made with [Cursor](https://cursor.com)