### PR TITLE
fix(model): codex/nvidia-nim/minimax now read OPENAI_MODEL env

### DIFF
--- a/src/utils/model/model.openai-shim-providers.test.ts
+++ b/src/utils/model/model.openai-shim-providers.test.ts
@@ -1,0 +1,115 @@
+import { afterEach, beforeEach, expect, test } from 'bun:test'
+
+import { saveGlobalConfig } from '../config.js'
+import { getUserSpecifiedModelSetting } from './model.js'
+
+const SAVED_ENV = {
+  CLAUDE_CODE_USE_OPENAI: process.env.CLAUDE_CODE_USE_OPENAI,
+  CLAUDE_CODE_USE_GEMINI: process.env.CLAUDE_CODE_USE_GEMINI,
+  CLAUDE_CODE_USE_GITHUB: process.env.CLAUDE_CODE_USE_GITHUB,
+  CLAUDE_CODE_USE_MISTRAL: process.env.CLAUDE_CODE_USE_MISTRAL,
+  CLAUDE_CODE_USE_BEDROCK: process.env.CLAUDE_CODE_USE_BEDROCK,
+  CLAUDE_CODE_USE_VERTEX: process.env.CLAUDE_CODE_USE_VERTEX,
+  CLAUDE_CODE_USE_FOUNDRY: process.env.CLAUDE_CODE_USE_FOUNDRY,
+  NVIDIA_NIM: process.env.NVIDIA_NIM,
+  MINIMAX_API_KEY: process.env.MINIMAX_API_KEY,
+  OPENAI_MODEL: process.env.OPENAI_MODEL,
+  OPENAI_BASE_URL: process.env.OPENAI_BASE_URL,
+  CODEX_API_KEY: process.env.CODEX_API_KEY,
+  CHATGPT_ACCOUNT_ID: process.env.CHATGPT_ACCOUNT_ID,
+}
+
+function restoreEnv(key: keyof typeof SAVED_ENV): void {
+  if (SAVED_ENV[key] === undefined) {
+    delete process.env[key]
+  } else {
+    process.env[key] = SAVED_ENV[key]
+  }
+}
+
+beforeEach(() => {
+  delete process.env.CLAUDE_CODE_USE_OPENAI
+  delete process.env.CLAUDE_CODE_USE_GEMINI
+  delete process.env.CLAUDE_CODE_USE_GITHUB
+  delete process.env.CLAUDE_CODE_USE_MISTRAL
+  delete process.env.CLAUDE_CODE_USE_BEDROCK
+  delete process.env.CLAUDE_CODE_USE_VERTEX
+  delete process.env.CLAUDE_CODE_USE_FOUNDRY
+  delete process.env.NVIDIA_NIM
+  delete process.env.MINIMAX_API_KEY
+  delete process.env.OPENAI_MODEL
+  delete process.env.OPENAI_BASE_URL
+  delete process.env.CODEX_API_KEY
+  delete process.env.CHATGPT_ACCOUNT_ID
+  saveGlobalConfig(current => ({
+    ...current,
+    model: undefined,
+  }))
+})
+
+afterEach(() => {
+  for (const key of Object.keys(SAVED_ENV) as Array<keyof typeof SAVED_ENV>) {
+    restoreEnv(key)
+  }
+  saveGlobalConfig(current => ({
+    ...current,
+    model: undefined,
+  }))
+})
+
+test('codex provider reads OPENAI_MODEL, not stale settings.model', () => {
+  // Regression: switching from Moonshot (settings.model='kimi-k2.6' persisted
+  // from that session) to the Codex profile. Codex profile correctly sets
+  // OPENAI_MODEL=codexplan + base URL to chatgpt.com/backend-api/codex.
+  // getUserSpecifiedModelSetting previously ignored env for 'codex' provider
+  // and returned settings.model='kimi-k2.6', causing Codex's API to reject
+  // the request: "The 'kimi-k2.6' model is not supported when using Codex".
+  saveGlobalConfig(current => ({ ...current, model: 'kimi-k2.6' }))
+  process.env.CLAUDE_CODE_USE_OPENAI = '1'
+  process.env.OPENAI_BASE_URL = 'https://chatgpt.com/backend-api/codex'
+  process.env.OPENAI_MODEL = 'codexplan'
+  process.env.CODEX_API_KEY = 'codex-test'
+  process.env.CHATGPT_ACCOUNT_ID = 'acct_test'
+
+  const model = getUserSpecifiedModelSetting()
+  expect(model).toBe('codexplan')
+})
+
+test('nvidia-nim provider reads OPENAI_MODEL, not stale settings.model', () => {
+  saveGlobalConfig(current => ({ ...current, model: 'kimi-k2.6' }))
+  process.env.NVIDIA_NIM = '1'
+  process.env.CLAUDE_CODE_USE_OPENAI = '1'
+  process.env.OPENAI_MODEL = 'nvidia/llama-3.1-nemotron-70b-instruct'
+
+  const model = getUserSpecifiedModelSetting()
+  expect(model).toBe('nvidia/llama-3.1-nemotron-70b-instruct')
+})
+
+test('minimax provider reads OPENAI_MODEL, not stale settings.model', () => {
+  saveGlobalConfig(current => ({ ...current, model: 'kimi-k2.6' }))
+  process.env.MINIMAX_API_KEY = 'minimax-test'
+  process.env.CLAUDE_CODE_USE_OPENAI = '1'
+  process.env.OPENAI_MODEL = 'MiniMax-M2.5'
+
+  const model = getUserSpecifiedModelSetting()
+  expect(model).toBe('MiniMax-M2.5')
+})
+
+test('openai provider still reads OPENAI_MODEL (regression guard)', () => {
+  saveGlobalConfig(current => ({ ...current, model: 'stale-default' }))
+  process.env.CLAUDE_CODE_USE_OPENAI = '1'
+  process.env.OPENAI_MODEL = 'gpt-4o'
+
+  const model = getUserSpecifiedModelSetting()
+  expect(model).toBe('gpt-4o')
+})
+
+test('github provider still reads OPENAI_MODEL (regression guard)', () => {
+  saveGlobalConfig(current => ({ ...current, model: 'stale-default' }))
+  process.env.CLAUDE_CODE_USE_GITHUB = '1'
+  process.env.OPENAI_MODEL = 'github:copilot'
+
+  const model = getUserSpecifiedModelSetting()
+  expect(model).toBe('github:copilot')
+})
+

--- a/src/utils/model/model.ts
+++ b/src/utils/model/model.ts
@@ -91,11 +91,24 @@ export function getUserSpecifiedModelSetting(): ModelSetting | undefined {
     const setting = normalizeModelSetting(settings.model)
     // Read the model env var that matches the active provider to prevent
     // cross-provider leaks (e.g. ANTHROPIC_MODEL sent to the OpenAI API).
+    //
+    // All OpenAI-shim providers (openai, codex, github, nvidia-nim, minimax)
+    // set CLAUDE_CODE_USE_OPENAI=1 + OPENAI_MODEL via
+    // applyProviderProfileToProcessEnv. Earlier this check only included
+    // openai/github — codex/nvidia-nim/minimax fell through to the stale
+    // settings.model, so switching from (say) Moonshot to Codex kept firing
+    // `kimi-k2.6` at the Codex endpoint and getting 400s.
     const provider = getAPIProvider()
+    const isOpenAIShimProvider =
+      provider === 'openai' ||
+      provider === 'codex' ||
+      provider === 'github' ||
+      provider === 'nvidia-nim' ||
+      provider === 'minimax'
     specifiedModel =
       (provider === 'gemini' ? process.env.GEMINI_MODEL : undefined) ||
       (provider === 'mistral' ? process.env.MISTRAL_MODEL : undefined) ||
-      (provider === 'openai' || provider === 'gemini' || provider === 'mistral' || provider === 'github' ? process.env.OPENAI_MODEL : undefined) ||
+      (isOpenAIShimProvider ? process.env.OPENAI_MODEL : undefined) ||
       (provider === 'firstParty' ? process.env.ANTHROPIC_MODEL : undefined) ||
       setting ||
       undefined


### PR DESCRIPTION
## Summary

  - what changed: `getUserSpecifiedModelSetting()` now treats `codex`, `nvidia-nim`, and `minimax` as OpenAI-shim providers that should consult `process.env.OPENAI_MODEL` — previously only `openai` and `github`
  were in that list, so the other three silently fell through to the stale `settings.model` value.
  - why it changed: Switching from one OpenAI-shim profile (e.g. Moonshot) to another (e.g. Codex) correctly updated the banner (reads env directly) but the query path (reads through `getUserSpecifiedModelSetting`)
   kept firing the persisted `settings.model` — e.g. `kimi-k2.6` — at the new endpoint, causing `API Error 400: "The 'kimi-k2.6' model is not supported when using Codex with a ChatGPT account."`

  ## Impact

  - user-facing impact: Users who switch between OpenAI-shim providers via `/provider` (Codex ↔ Moonshot, NVIDIA NIM, MiniMax, OpenRouter, Groq, etc.) no longer hit cross-provider model errors. The saved active
  profile's model is actually used for requests, not the stale `settings.model` from a prior session.
  - developer/maintainer impact: One extracted `isOpenAIShimProvider` flag replaces the divergent per-provider check. Adding another OpenAI-shim provider becomes a single-line addition. Gemini and Mistral branches
  are untouched — they correctly use `GEMINI_MODEL` / `MISTRAL_MODEL`.

  ## Testing

  - [x] `bun run build`
  - [x] `bun run smoke`
  - [x] focused tests:
    - `bun test src/utils/model/model.openai-shim-providers.test.ts` — 5 new regression tests (codex / nvidia-nim / minimax read OPENAI_MODEL; openai + github regression guards)
    - `bun test` — full suite **1148/1148 pass, 0 fail**

  ## Notes

  - provider/model path tested: Reproduced the original failure with Codex profile active and `settings.model=kimi-k2.6` persisted. Before: request body carried `model: "kimi-k2.6"` → 400 from Codex. After: request
   body carries `model: "codexplan"` → request succeeds. Also verified openai and github paths still read `OPENAI_MODEL` correctly.
  - screenshots attached (if UI changed): None — request-body-level fix; no UI changes.
  - follow-up work or known limitations:
    - A future cleanup could invert the logic and list the NON-shim providers instead (firstParty/bedrock/vertex/foundry/gemini/mistral), making new shim additions zero-touch. Kept this PR minimal to avoid behavior
   drift.
    - The settings.model fallback path (when env is unset) wasn't tested because `getSettings_DEPRECATED()` reads from on-disk settings; a separate follow-up could add a settings-mocking helper.