### PR TITLE
feat(minimax): update default model to MiniMax-M2.7

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -246,7 +246,7 @@ ANTHROPIC_API_KEY=sk-ant-your-key-here
 # CLAUDE_CODE_USE_OPENAI=1
 # MINIMAX_API_KEY=your-minimax-key-here
 # OPENAI_BASE_URL=https://api.minimax.io/v1
-# OPENAI_MODEL=MiniMax-M2.5
+# OPENAI_MODEL=MiniMax-M2.7
 
 
 # =============================================================================

--- a/src/utils/model/configs.ts
+++ b/src/utils/model/configs.ts
@@ -38,7 +38,7 @@ export const CLAUDE_3_7_SONNET_CONFIG = {
   github: 'github:copilot',
   codex: 'gpt-5.4',
   'nvidia-nim': 'nvidia/llama-3.1-nemotron-70b-instruct',
-  minimax: 'MiniMax-M2.5',
+  minimax: 'MiniMax-M2.7',
 } as const satisfies ModelConfig
 
 export const CLAUDE_3_5_V2_SONNET_CONFIG = {
@@ -51,7 +51,7 @@ export const CLAUDE_3_5_V2_SONNET_CONFIG = {
   github: 'github:copilot',
   codex: 'gpt-5.4',
   'nvidia-nim': 'nvidia/llama-3.1-nemotron-70b-instruct',
-  minimax: 'MiniMax-M2.5',
+  minimax: 'MiniMax-M2.7',
 } as const satisfies ModelConfig
 
 export const CLAUDE_3_5_HAIKU_CONFIG = {
@@ -64,7 +64,7 @@ export const CLAUDE_3_5_HAIKU_CONFIG = {
   github: 'github:copilot',
   codex: 'gpt-5.4',
   'nvidia-nim': 'nvidia/llama-3.1-nemotron-70b-instruct',
-  minimax: 'MiniMax-M2.5',
+  minimax: 'MiniMax-M2.7',
 } as const satisfies ModelConfig
 
 export const CLAUDE_HAIKU_4_5_CONFIG = {
@@ -77,7 +77,7 @@ export const CLAUDE_HAIKU_4_5_CONFIG = {
   github: 'github:copilot',
   codex: 'gpt-5.4',
   'nvidia-nim': 'nvidia/llama-3.1-nemotron-70b-instruct',
-  minimax: 'MiniMax-M2.5',
+  minimax: 'MiniMax-M2.7',
 } as const satisfies ModelConfig
 
 export const CLAUDE_SONNET_4_CONFIG = {
@@ -90,7 +90,7 @@ export const CLAUDE_SONNET_4_CONFIG = {
   github: 'github:copilot',
   codex: 'gpt-5.4',
   'nvidia-nim': 'nvidia/llama-3.1-nemotron-70b-instruct',
-  minimax: 'MiniMax-M2.5',
+  minimax: 'MiniMax-M2.7',
 } as const satisfies ModelConfig
 
 export const CLAUDE_SONNET_4_5_CONFIG = {
@@ -103,7 +103,7 @@ export const CLAUDE_SONNET_4_5_CONFIG = {
   github: 'github:copilot',
   codex: 'gpt-5.4',
   'nvidia-nim': 'nvidia/llama-3.1-nemotron-70b-instruct',
-  minimax: 'MiniMax-M2.5',
+  minimax: 'MiniMax-M2.7',
 } as const satisfies ModelConfig
 
 export const CLAUDE_OPUS_4_CONFIG = {
@@ -116,7 +116,7 @@ export const CLAUDE_OPUS_4_CONFIG = {
   github: 'github:copilot',
   codex: 'gpt-5.4',
   'nvidia-nim': 'nvidia/llama-3.1-nemotron-70b-instruct',
-  minimax: 'MiniMax-M2.5',
+  minimax: 'MiniMax-M2.7',
 } as const satisfies ModelConfig
 
 export const CLAUDE_OPUS_4_1_CONFIG = {
@@ -129,7 +129,7 @@ export const CLAUDE_OPUS_4_1_CONFIG = {
   github: 'github:copilot',
   codex: 'gpt-5.4',
   'nvidia-nim': 'nvidia/llama-3.1-nemotron-70b-instruct',
-  minimax: 'MiniMax-M2.5',
+  minimax: 'MiniMax-M2.7',
 } as const satisfies ModelConfig
 
 export const CLAUDE_OPUS_4_5_CONFIG = {
@@ -142,7 +142,7 @@ export const CLAUDE_OPUS_4_5_CONFIG = {
   github: 'github:copilot',
   codex: 'gpt-5.4',
   'nvidia-nim': 'nvidia/llama-3.1-nemotron-70b-instruct',
-  minimax: 'MiniMax-M2.5',
+  minimax: 'MiniMax-M2.7',
 } as const satisfies ModelConfig
 
 export const CLAUDE_OPUS_4_6_CONFIG = {
@@ -155,7 +155,7 @@ export const CLAUDE_OPUS_4_6_CONFIG = {
   github: 'github:copilot',
   codex: 'gpt-5.4',
   'nvidia-nim': 'nvidia/llama-3.1-nemotron-70b-instruct',
-  minimax: 'MiniMax-M2.5',
+  minimax: 'MiniMax-M2.7',
 } as const satisfies ModelConfig
 
 export const CLAUDE_SONNET_4_6_CONFIG = {
@@ -168,7 +168,7 @@ export const CLAUDE_SONNET_4_6_CONFIG = {
   github: 'github:copilot',
   codex: 'gpt-5.4',
   'nvidia-nim': 'nvidia/llama-3.1-nemotron-70b-instruct',
-  minimax: 'MiniMax-M2.5',
+  minimax: 'MiniMax-M2.7',
 } as const satisfies ModelConfig
 
 // @[MODEL LAUNCH]: Register the new config here.

--- a/src/utils/providerProfile.ts
+++ b/src/utils/providerProfile.ts
@@ -219,7 +219,7 @@ export function buildMiniMaxProfileEnv(options: {
   }
 
   const defaultBaseUrl = 'https://api.minimax.io/v1'
-  const defaultModel = 'MiniMax-M2.5'
+  const defaultModel = 'MiniMax-M2.7'
   const secretSource: SecretValueSource = { OPENAI_API_KEY: key }
 
   return {


### PR DESCRIPTION
## Summary

- Update buildMiniMaxProfileEnv default model from MiniMax-M2.5 to MiniMax-M2.7 in src/utils/providerProfile.ts
- Update all Claude model tier mappings (minimax key) in src/utils/model/configs.ts (covers haiku35 through opus46)
- Update .env.example to reference MiniMax-M2.7 as the recommended model

## Motivation

MiniMax-M2.7 is the latest generation MiniMax model with improved capabilities over M2.5. The context window definitions for MiniMax-M2.7 are already present in openaiContextWindows.ts (204,800 tokens context, 131,072 max output), and thinkTagSanitizer.ts already lists MiniMax-M2.7 as a reasoning model -- so this PR aligns the default model selection with the latest available model.

## Test plan

- [x] All existing MiniMax-related tests pass (context.test.ts, model.openai-shim-providers.test.ts, providerProfile.test.ts, ProviderManager.test.tsx, tokenModelCompression.test.ts)
- [x] No new test failures introduced
- [x] TypeScript types satisfied (satisfies ModelConfig constraint)