### PR TITLE
 docs(env): document OPENCLAUDE_DISABLE_STRICT_TOOLS in .env.example 

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -267,6 +267,11 @@ ANTHROPIC_API_KEY=sk-ant-your-key-here
 # Disable "Co-authored-by" line in git commits made by OpenClaude
 # OPENCLAUDE_DISABLE_CO_AUTHORED_BY=1
 
+# Disable strict tool schema normalization for non-Gemini providers
+# Useful when MCP tools with complex optional params (e.g. list[dict])
+# trigger "Extra required key ... supplied" errors from OpenAI-compatible endpoints
+# OPENCLAUDE_DISABLE_STRICT_TOOLS=1
+
 # Custom timeout for API requests in milliseconds (default: varies)
 # API_TIMEOUT_MS=60000
 


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                                                                  
                                                                                                                                                                                                                                                                              
  - Add `OPENCLAUDE_DISABLE_STRICT_TOOLS` entry to `.env.example` so the flag is discoverable                                                                                                                                                                                 
  - Code landed in #770 but the `.env.example` documentation step from issue #737 was missed                                                                                                                                                                                
                                                                                                                                                                                                                                                                              
  Closes #737                                                                                                                                                                                                                                                                 
                                                                                                                                                                                                                                                                              
  ## Impact                                                                                                                                                                                                                                                                   
                                                                                                                                                                                                                                                                              
  - user-facing impact: users who hit `"Extra required key ... supplied"` errors from OpenAI-compatible providers on MCP tools with complex optional params (e.g. `list[dict]`) can now find the opt-out flag by reading `.env.example`                                     
  - developer/maintainer impact: none — docs-only change, no code paths touched                                                                                                                                                                                               
                                         
  ## Testing                                                                                                                                                                                                                                                                  
                                                                                                                                                                                                                                                                            
  - [x] `bun run build` — not needed (docs only), ran anyway to confirm no break                                                                                                                                                                                              
  - [x] `bun run smoke` — passes (`0.6.0 (Open Claude)`)                                                                                                                                                                                                                    
  - [ ] focused tests: not applicable (no code changed)
                                                                                                                                                                                                                                                                              
  ## Notes                
                                                                                                                                                                                                                                                                              
  - provider/model path tested: not applicable (docs only)                                                                                                                                                                                                                  
  - screenshots attached (if UI changed): n/a                                                                                                                                                                                                                                 
  - follow-up work or known limitations: README intentionally not modified — it does not document individual `OPENCLAUDE_*` tuning flags, so `.env.example` is the right home. Happy to add a README note if maintainers prefer.