### PR TITLE
Fix provider persistence by clearing stale Mistral overrides

### DIFF
--- a/src/commands/onboard-github/onboard-github.test.ts
+++ b/src/commands/onboard-github/onboard-github.test.ts
@@ -55,6 +55,7 @@ describe('onboarding auth precedence cleanup', () => {
   test('clears preexisting OpenAI auth when switching to GitHub', () => {
     const env: NodeJS.ProcessEnv = {
       CLAUDE_CODE_USE_OPENAI: '1',
+      CLAUDE_CODE_USE_MISTRAL: '1',
       OPENAI_MODEL: 'gpt-4o',
       OPENAI_API_KEY: 'sk-stale-openai-key',
       OPENAI_ORG: 'org-old',
@@ -62,6 +63,9 @@ describe('onboarding auth precedence cleanup', () => {
       OPENAI_ORGANIZATION: 'org-legacy',
       OPENAI_BASE_URL: 'https://api.openai.com/v1',
       OPENAI_API_BASE: 'https://api.openai.com/v1',
+      MISTRAL_API_KEY: 'mistral-key',
+      MISTRAL_BASE_URL: 'https://api.mistral.ai/v1',
+      MISTRAL_MODEL: 'mistral-medium-latest',
       CLAUDE_CODE_PROVIDER_PROFILE_ENV_APPLIED: '1',
       CLAUDE_CODE_PROVIDER_PROFILE_ENV_APPLIED_ID: 'profile_old',
     }
@@ -79,6 +83,10 @@ describe('onboarding auth precedence cleanup', () => {
     expect(env.OPENAI_API_BASE).toBeUndefined()
 
     expect(env.CLAUDE_CODE_USE_OPENAI).toBeUndefined()
+    expect(env.CLAUDE_CODE_USE_MISTRAL).toBeUndefined()
+    expect(env.MISTRAL_API_KEY).toBeUndefined()
+    expect(env.MISTRAL_BASE_URL).toBeUndefined()
+    expect(env.MISTRAL_MODEL).toBeUndefined()
     expect(env.CLAUDE_CODE_PROVIDER_PROFILE_ENV_APPLIED).toBeUndefined()
     expect(env.CLAUDE_CODE_PROVIDER_PROFILE_ENV_APPLIED_ID).toBeUndefined()
 
@@ -89,6 +97,7 @@ describe('onboarding auth precedence cleanup', () => {
     expect(settingsEnv.OPENAI_ORG).toBeUndefined()
     expect(settingsEnv.OPENAI_PROJECT).toBeUndefined()
     expect(settingsEnv.OPENAI_ORGANIZATION).toBeUndefined()
+    expect(settingsEnv.CLAUDE_CODE_USE_MISTRAL).toBeUndefined()
   })
 })
 

--- a/src/commands/onboard-github/onboard-github.tsx
+++ b/src/commands/onboard-github/onboard-github.tsx
@@ -32,6 +32,7 @@ type Step = 'menu' | 'device-busy' | 'error'
 const PROVIDER_SPECIFIC_KEYS = new Set([
   'CLAUDE_CODE_USE_OPENAI',
   'CLAUDE_CODE_USE_GEMINI',
+  'CLAUDE_CODE_USE_MISTRAL',
   'CLAUDE_CODE_USE_BEDROCK',
   'CLAUDE_CODE_USE_VERTEX',
   'CLAUDE_CODE_USE_FOUNDRY',
@@ -45,6 +46,9 @@ const PROVIDER_SPECIFIC_KEYS = new Set([
   'GEMINI_MODEL',
   'GEMINI_ACCESS_TOKEN',
   'GEMINI_AUTH_MODE',
+  'MISTRAL_API_KEY',
+  'MISTRAL_BASE_URL',
+  'MISTRAL_MODEL',
 ])
 
 export function shouldForceGithubRelogin(args?: string): boolean {
@@ -95,6 +99,7 @@ export function buildGithubOnboardingSettingsEnv(
     OPENAI_API_BASE: undefined,
     CLAUDE_CODE_USE_OPENAI: undefined,
     CLAUDE_CODE_USE_GEMINI: undefined,
+    CLAUDE_CODE_USE_MISTRAL: undefined,
     CLAUDE_CODE_USE_BEDROCK: undefined,
     CLAUDE_CODE_USE_VERTEX: undefined,
     CLAUDE_CODE_USE_FOUNDRY: undefined,
@@ -117,6 +122,10 @@ export function applyGithubOnboardingProcessEnv(
 
   delete env.CLAUDE_CODE_USE_OPENAI
   delete env.CLAUDE_CODE_USE_GEMINI
+  delete env.CLAUDE_CODE_USE_MISTRAL
+  delete env.MISTRAL_API_KEY
+  delete env.MISTRAL_BASE_URL
+  delete env.MISTRAL_MODEL
   delete env.CLAUDE_CODE_USE_BEDROCK
   delete env.CLAUDE_CODE_USE_VERTEX
   delete env.CLAUDE_CODE_USE_FOUNDRY

--- a/src/components/ProviderManager.test.tsx
+++ b/src/components/ProviderManager.test.tsx
@@ -14,6 +14,7 @@ const SYNC_END = '\x1B[?2026l'
 const ORIGINAL_ENV = {
   CLAUDE_CODE_SIMPLE: process.env.CLAUDE_CODE_SIMPLE,
   CLAUDE_CODE_USE_GITHUB: process.env.CLAUDE_CODE_USE_GITHUB,
+  CLAUDE_CODE_USE_MISTRAL: process.env.CLAUDE_CODE_USE_MISTRAL,
   GITHUB_TOKEN: process.env.GITHUB_TOKEN,
   GH_TOKEN: process.env.GH_TOKEN,
 }
@@ -209,6 +210,7 @@ function mockProviderManagerDependencies(
     codexAsyncRead?: () => Promise<unknown>
     updateProviderProfile?: (...args: unknown[]) => unknown
     setActiveProviderProfile?: (...args: unknown[]) => unknown
+    updateSettingsForSource?: (...args: unknown[]) => unknown
     useCodexOAuthFlow?: (options: {
       onAuthenticated: (tokens: {
         accessToken: string
@@ -293,7 +295,8 @@ function mockProviderManagerDependencies(
   }))
 
   mock.module('../utils/settings/settings.js', () => ({
-    updateSettingsForSource: () => ({ error: null }),
+    updateSettingsForSource:
+      options?.updateSettingsForSource ?? (() => ({ error: null })),
   }))
 
   mock.module('./useCodexOAuthFlow.js', () => ({
@@ -903,6 +906,127 @@ test('ProviderManager keeps Codex OAuth as next-startup only when activating the
   expect(applySavedProfileToCurrentSession).toHaveBeenCalled()
   expect(setActiveProviderProfile).toHaveBeenCalledWith('provider_codex_oauth')
 
+  await mounted.dispose()
+})
+
+test('ProviderManager clears stale Mistral startup override when activating a saved profile', async () => {
+  delete process.env.CLAUDE_CODE_SIMPLE
+  delete process.env.CLAUDE_CODE_USE_GITHUB
+  delete process.env.GITHUB_TOKEN
+  delete process.env.GH_TOKEN
+
+  const profile = {
+    id: 'provider_openai',
+    provider: 'openai',
+    name: 'OpenAI Work',
+    baseUrl: 'https://api.openai.com/v1',
+    model: 'gpt-4o',
+    apiKey: '',
+  }
+  const setActiveProviderProfile = mock(() => profile)
+  const updateSettingsForSource = mock(() => ({ error: null }))
+
+  mockProviderManagerDependencies(
+    () => undefined,
+    async () => undefined,
+    {
+      getProviderProfiles: () => [profile],
+      setActiveProviderProfile,
+      updateSettingsForSource,
+    },
+  )
+
+  const nonce = `${Date.now()}-${Math.random()}`
+  const { ProviderManager } = await import(`./ProviderManager.js?ts=${nonce}`)
+  const mounted = await mountProviderManager(ProviderManager)
+
+  await waitForFrameOutput(
+    mounted.getOutput,
+    frame => frame.includes('Provider manager') && frame.includes('OpenAI Work'),
+  )
+
+  mounted.stdin.write('j')
+  await Bun.sleep(25)
+  mounted.stdin.write('\r')
+
+  await waitForFrameOutput(
+    mounted.getOutput,
+    frame => frame.includes('Set active provider') && frame.includes('OpenAI Work'),
+  )
+
+  await Bun.sleep(25)
+  mounted.stdin.write('\r')
+
+  await waitForCondition(() => setActiveProviderProfile.mock.calls.length > 0)
+
+  const clearedMistralOverride = updateSettingsForSource.mock.calls.some(
+    call => {
+      const args = call as any[]
+      return (
+        args[0] === 'userSettings' &&
+        args[1]?.env?.CLAUDE_CODE_USE_MISTRAL === undefined &&
+        args[1]?.env?.CLAUDE_CODE_USE_OPENAI === undefined &&
+        args[1]?.env?.CLAUDE_CODE_USE_GITHUB === undefined
+      )
+    },
+  )
+
+  expect(clearedMistralOverride).toBe(true)
+  await mounted.dispose()
+})
+
+test('ProviderManager GitHub activation clears stale Mistral startup override', async () => {
+  delete process.env.CLAUDE_CODE_SIMPLE
+  delete process.env.CLAUDE_CODE_USE_GITHUB
+  delete process.env.GITHUB_TOKEN
+  delete process.env.GH_TOKEN
+
+  const updateSettingsForSource = mock(() => ({ error: null }))
+
+  mockProviderManagerDependencies(
+    () => undefined,
+    async () => 'stored-github-token',
+    {
+      getProviderProfiles: () => [],
+      updateSettingsForSource,
+    },
+  )
+
+  const nonce = `${Date.now()}-${Math.random()}`
+  const { ProviderManager } = await import(`./ProviderManager.js?ts=${nonce}`)
+  const mounted = await mountProviderManager(ProviderManager)
+
+  await waitForFrameOutput(
+    mounted.getOutput,
+    frame => frame.includes('Provider manager') && frame.includes('GitHub Models'),
+  )
+
+  mounted.stdin.write('j')
+  await Bun.sleep(25)
+  mounted.stdin.write('\r')
+
+  await waitForFrameOutput(
+    mounted.getOutput,
+    frame => frame.includes('Set active provider') && frame.includes('GitHub Models'),
+  )
+
+  await Bun.sleep(25)
+  mounted.stdin.write('\r')
+
+  await waitForCondition(() => updateSettingsForSource.mock.calls.length > 0)
+
+  const githubActivationClearedMistral = updateSettingsForSource.mock.calls.some(
+    call => {
+      const args = call as any[]
+      return (
+        args[0] === 'userSettings' &&
+        args[1]?.env?.CLAUDE_CODE_USE_GITHUB === '1' &&
+        args[1]?.env?.CLAUDE_CODE_USE_MISTRAL === undefined
+      )
+    },
+  )
+
+  expect(githubActivationClearedMistral).toBe(true)
   await mounted.dispose()
 })
 

--- a/src/components/ProviderManager.tsx
+++ b/src/components/ProviderManager.tsx
@@ -675,6 +675,7 @@ export function ProviderManager({ mode, onDone }: Props): React.ReactNode {
       env: {
         CLAUDE_CODE_USE_OPENAI: undefined as any,
         CLAUDE_CODE_USE_GEMINI: undefined as any,
+        CLAUDE_CODE_USE_MISTRAL: undefined as any,
         CLAUDE_CODE_USE_GITHUB: undefined as any,
         CLAUDE_CODE_USE_BEDROCK: undefined as any,
         CLAUDE_CODE_USE_VERTEX: undefined as any,
@@ -863,6 +864,7 @@ export function ProviderManager({ mode, onDone }: Props): React.ReactNode {
         OPENAI_API_BASE: undefined as any,
         CLAUDE_CODE_USE_OPENAI: undefined as any,
         CLAUDE_CODE_USE_GEMINI: undefined as any,
+        CLAUDE_CODE_USE_MISTRAL: undefined as any,
         CLAUDE_CODE_USE_BEDROCK: undefined as any,
         CLAUDE_CODE_USE_VERTEX: undefined as any,
         CLAUDE_CODE_USE_FOUNDRY: undefined as any,
@@ -882,6 +884,7 @@ export function ProviderManager({ mode, onDone }: Props): React.ReactNode {
     delete process.env.OPENAI_API_BASE
     delete process.env.CLAUDE_CODE_USE_OPENAI
     delete process.env.CLAUDE_CODE_USE_GEMINI
+    delete process.env.CLAUDE_CODE_USE_MISTRAL
     delete process.env.CLAUDE_CODE_USE_BEDROCK
     delete process.env.CLAUDE_CODE_USE_VERTEX
     delete process.env.CLAUDE_CODE_USE_FOUNDRY


### PR DESCRIPTION
## Summary
- fix provider switching persistence regression where stale `CLAUDE_CODE_USE_MISTRAL` overrides could cause startup to ignore the saved active provider
- clear Mistral startup override flags in `ProviderManager` activation paths (standard profile activation and GitHub virtual provider activation)
- align GitHub onboarding cleanup with the same override behavior by clearing Mistral provider flags/env values
- add regression coverage in `ProviderManager` and onboarding tests

## Root cause
Provider-override cleanup logic cleared OpenAI/Gemini/GitHub flags but missed Mistral. If Mistral override state remained in user settings or process env, startup provider resolution could prioritize that stale override instead of the selected saved profile.

## Test plan
- `~/.bun/bin/bun test src/components/ProviderManager.test.tsx src/commands/onboard-github/onboard-github.test.ts`
- result: 26 passed, 0 failed
