### PR TITLE
fix(web-search): surface actionable error when DDG is rate-limited

### DIFF
--- a/src/tools/WebSearchTool/providers/duckduckgo.ts
+++ b/src/tools/WebSearchTool/providers/duckduckgo.ts
@@ -1,6 +1,23 @@
 import type { SearchInput, SearchProvider } from './types.js'
 import { applyDomainFilters, type ProviderOutput } from './types.js'
 
+// DuckDuckGo's HTML scraper aggressively blocks datacenter / repeat IPs with
+// an "anomaly in the request" response. When that happens we surface an
+// actionable error instead of the opaque scraper message so users know how
+// to configure a working backend.
+const DDG_ANOMALY_HINT =
+  'DuckDuckGo scraping is rate-limited from this network. ' +
+  'Configure a search backend with one of: ' +
+  'FIRECRAWL_API_KEY, TAVILY_API_KEY, EXA_API_KEY, YOU_API_KEY, ' +
+  'JINA_API_KEY, BING_API_KEY, MOJEEK_API_KEY, LINKUP_API_KEY — ' +
+  'or use an Anthropic / Vertex / Foundry provider for native web search.'
+
+function isAnomalyError(message: string): boolean {
+  return /anomaly in the request|likely making requests too quickly/i.test(
+    message,
+  )
+}
+
 export const duckduckgoProvider: SearchProvider = {
   name: 'duckduckgo',
 
@@ -20,7 +37,16 @@ export const duckduckgoProvider: SearchProvider = {
     }
     if (signal?.aborted) throw new DOMException('Aborted', 'AbortError')
     // TODO: duck-duck-scrape doesn't accept AbortSignal — can't cancel in-flight searches
-    const response = await search(input.query, { safeSearch: SafeSearchType.STRICT })
+    let response: Awaited<ReturnType<typeof search>>
+    try {
+      response = await search(input.query, { safeSearch: SafeSearchType.STRICT })
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err)
+      if (isAnomalyError(msg)) {
+        throw new Error(DDG_ANOMALY_HINT)
+      }
+      throw err
+    }
 
     const hits = applyDomainFilters(
       response.results.map(r => ({


### PR DESCRIPTION
## Summary

- Users on non-Anthropic / non-codex providers (minimax, kimi, generic OpenAI-compatible endpoints) with no paid search API key configured fall through to the DuckDuckGo adapter. DDG's HTML scraper is blocked on most IPs with an opaque `"anomaly in the request, you are likely making requests too quickly"` response, making `web_search` look like a silent failure with no hint at how to fix it.
- The DDG provider now intercepts that response and rethrows with a clear, actionable message listing every env var that would unblock the tool (`FIRECRAWL_API_KEY`, `TAVILY_API_KEY`, `EXA_API_KEY`, `YOU_API_KEY`, `JINA_API_KEY`, `BING_API_KEY`, `MOJEEK_API_KEY`, `LINKUP_API_KEY`) plus the native-search option (Anthropic / Vertex / Foundry).
- Behavior for configured backends is unchanged — this only improves the error surface when DDG is the last fallback and hits the scraper block.

## Why this fix, not a different default backend

Every reliable free alternative either requires an API key (Brave, Mojeek, Bing) or is equally scrape-hostile. Shipping a default key isn't acceptable. Clear error text is the smallest honest fix — it converts a mysterious failure into a one-line setup step.

## Test plan

- [x] Unit-level repro: call the DDG provider directly from a clean IP and confirm the old opaque error is now replaced with the actionable hint.
  ```
  bun -e "import('./src/tools/WebSearchTool/providers/duckduckgo.ts').then(async m => { try { await m.duckduckgoProvider.search({ query: 'test' }); } catch(e) { console.log(e.message); } });"
  ```
  Output:
  ```
  DuckDuckGo scraping is rate-limited from this network. Configure a search backend with one of: FIRECRAWL_API_KEY, TAVILY_API_KEY, EXA_API_KEY, YOU_API_KEY, JINA_API_KEY, BING_API_KEY, MOJEEK_API_KEY, LINKUP_API_KEY — or use an Anthropic / Vertex / Foundry provider for native web search.
  ```
- [ ] End-to-end: run `openclaude` against an OpenAI-compatible endpoint (e.g. kimi) without any search API keys, trigger a `web_search` tool call, and confirm the tool_result contains the new actionable error rather than the raw scraper message.
- [ ] Happy path: set one of the listed env vars (e.g. `FIRECRAWL_API_KEY`) and confirm `web_search` returns real results — no regression.
- [x] `tsc --noEmit` clean on the modified file.

## Out of scope

The separate report that codex transport's `web_search` tool "fails" with minimax/kimi is a different path — the Responses API tool schema is sent correctly, so the likely cause is the codex-transport server not honoring the tool. Needs a live endpoint to diagnose; not addressed here.