### PR TITLE
feat: add OPENCLAUDE_DISABLE_TOOL_REMINDERS env var to suppress hidden tool-output reminders

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -272,6 +272,11 @@ ANTHROPIC_API_KEY=sk-ant-your-key-here
 # trigger "Extra required key ... supplied" errors from OpenAI-compatible endpoints
 # OPENCLAUDE_DISABLE_STRICT_TOOLS=1
 
+# Disable hidden <system-reminder> messages injected into tool output
+# Suppresses the file-read cyber-risk reminder and the todo/task tool nudges
+# Useful for users who want full transparency over what the model sees
+# OPENCLAUDE_DISABLE_TOOL_REMINDERS=1
+
 # Custom timeout for API requests in milliseconds (default: varies)
 # API_TIMEOUT_MS=60000
 

--- a/src/tools/FileReadTool/FileReadTool.ts
+++ b/src/tools/FileReadTool/FileReadTool.ts
@@ -733,6 +733,9 @@ export const CYBER_RISK_MITIGATION_REMINDER =
 const MITIGATION_EXEMPT_MODELS = new Set(['claude-opus-4-6'])
 
 function shouldIncludeFileReadMitigation(): boolean {
+  if (isEnvTruthy(process.env.OPENCLAUDE_DISABLE_TOOL_REMINDERS)) {
+    return false
+  }
   const shortName = getCanonicalName(getMainLoopModel())
   return !MITIGATION_EXEMPT_MODELS.has(shortName)
 }

--- a/src/utils/messages.ts
+++ b/src/utils/messages.ts
@@ -75,6 +75,7 @@ import type {
 import { isAdvisorBlock } from './advisor.js'
 import { isAgentSwarmsEnabled } from './agentSwarmsEnabled.js'
 import { count } from './array.js'
+import { isEnvTruthy } from './envUtils.js'
 import {
   type Attachment,
   type HookAttachment,
@@ -3666,6 +3667,9 @@ Read the team config to discover your teammates' names. Check the task list peri
       ])
     }
     case 'todo_reminder': {
+      if (isEnvTruthy(process.env.OPENCLAUDE_DISABLE_TOOL_REMINDERS)) {
+        return []
+      }
       const todoItems = attachment.content
         .map((todo, index) => `${index + 1}. [${todo.status}] ${todo.content}`)
         .join('\n')
@@ -3684,6 +3688,9 @@ Read the team config to discover your teammates' names. Check the task list peri
     }
     case 'task_reminder': {
       if (!isTodoV2Enabled()) {
+        return []
+      }
+      if (isEnvTruthy(process.env.OPENCLAUDE_DISABLE_TOOL_REMINDERS)) {
         return []
       }
       const taskItems = attachment.content


### PR DESCRIPTION
## Summary                                                                                                                                                                                                    
                                                                                                                                                                                                                
  - Add `OPENCLAUDE_DISABLE_TOOL_REMINDERS` env var that suppresses the hidden `<system-reminder>` messages injected into tool output                                                                           
  - Gates three injection sites: FileReadTool cyber-risk mitigation reminder, `todo_reminder` for TodoWrite, and `task_reminder` for TaskCreate/TaskUpdate                                                      
  - Default behavior unchanged when the flag is unset                                                                                                                                                           
                                                                                                                                                                                                                
  Closes #809                                                                                                                                                                                                   
                                                                                                                                                                                                                
  ## Impact                                                                                                                                                                                                     
                                                                                                                                                                                                                
  - user-facing impact: users can opt into full transparency over what the model receives. When set, file-read results and task/todo attachments ship without the appended model-only reminders. No change for  
  anyone who does not set the flag.                                                                                                                                                                             
  - developer/maintainer impact: minimal — three new early-return guards, one new import in `src/utils/messages.ts`, one documentation entry in `.env.example`.                                                 
                                                                                                                                                                                                                
  ## Testing                                                                                                                                                                                                    
            
  - [x] `bun run build`                                                                                                                                                                                         
  - [x] `bun run smoke` (passes: `0.6.0 (Open Claude)`)                                                                                                                                                         
  - [ ] focused tests: no existing tests for the three reminder paths; the change is a narrow env-gate so I relied on build + manual verification. Happy to add tests if maintainers prefer.
                                                                                                                                                                                                                
  ## Notes                                                                                                                                                                                                      
                                                                                                                                                                                                                
  - provider/model path tested: not provider-specific (reminders are attached in the message layer, independent of provider)                                                                                    
  - screenshots attached (if UI changed): n/a (no UI)                                                                                                                                                           
  - follow-up work or known limitations: this PR only implements suggestion 1 from the issue (opt-out flag). Other suggestions (widen `MITIGATION_EXEMPT_MODELS`, drop the "NEVER mention this reminder to the
  user" phrase, show reminders in the transcript) are intentionally out of scope. 