### PR TITLE
fix(test): add missing teammate exports to hookChains integration mock

### DIFF
--- a/src/utils/hookChains.integration.test.ts
+++ b/src/utils/hookChains.integration.test.ts
@@ -75,6 +75,13 @@ async function importHookChainsHarness(
     getAgentName: () => senderName,
     getTeamName: () => teamName,
     getTeammateColor: () => 'blue',
+    // Keep parity with the real module's surface so later tests that
+    // run after this file (mock.module is process-global and mock.restore
+    // does not undo module mocks in Bun) do not see undefined members.
+    isTeammate: () => false,
+    isPlanModeRequired: () => false,
+    getAgentId: () => undefined,
+    getParentSessionId: () => undefined,
   }))
 
   mock.module('../bridge/replBridgeHandle.js', () => ({


### PR DESCRIPTION
## Summary

- Expand the `mock.module('./teammate.js', ...)` stub in `src/utils/hookChains.integration.test.ts` so it covers `isTeammate`, `isPlanModeRequired`, `getAgentId`, and `getParentSessionId` in addition to the three it already declared.
- Bun keeps module mocks process-global and `mock.restore()` does not undo them. That means whenever another test file ran after `hookChains.integration.test.ts` in the same `bun test` invocation and reached the real teammate module, it received `undefined` for the missing members.
- The visible symptom was intermittent CI failures in `src/commands/provider/provider.test.tsx` (e.g. `TextEntryDialog resets its input state when initialValue changes`, `wizard step remount prevents a typed API key from leaking into the next field`, `ProviderWizard hides Codex OAuth while running in bare mode`), because `getDefaultAppState` in `AppStateStore.ts` calls `teammateUtils.isTeammate()`.

Closes #839

## Impact

- user-facing impact: none (test-only change)
- developer/maintainer impact: CI becomes stable for any PR whose test-file order places `hookChains.integration.test.ts` before a file that eventually reaches the real teammate module. No production code path is affected.

## Testing

- [x] `bun test src/utils/hookChains.integration.test.ts src/commands/provider/provider.test.tsx` — previously failed with `teammateUtils.isTeammate is not a function`; now both files run cleanly.
- [x] `bun test` — full suite: `1195 pass, 0 fail` on my machine with this patch.
- [ ] focused tests: n/a beyond the two files above (this is a test-isolation fix).

## Notes

- provider/model path tested: not provider-specific (test infrastructure only).
- screenshots attached (if UI changed): n/a.
- follow-up work or known limitations: the same leak pattern could affect other `mock.module(...)` calls in this file (`analytics/index.js`, `telemetry/events.js`, etc.) if their real exports grow and downstream consumers rely on them. Happy to tackle those in a follow-up if maintainers prefer. The structural fix would be isolating this integration test in its own `bun test` run so its module mocks cannot leak at all.