### PR TITLE
fix(effort): persist xhigh and send reasoning_effort on chat_completions

### DIFF
--- a/src/commands/effort/effort.tsx
+++ b/src/commands/effort/effort.tsx
@@ -4,7 +4,7 @@ import { useMainLoopModel } from '../../hooks/useMainLoopModel.js';
 import { type AnalyticsMetadata_I_VERIFIED_THIS_IS_NOT_CODE_OR_FILEPATHS, logEvent } from '../../services/analytics/index.js';
 import { useAppState, useSetAppState } from '../../state/AppState.js';
 import type { LocalJSXCommandOnDone } from '../../types/command.js';
-import { type EffortValue, getDisplayedEffortLevel, getEffortEnvOverride, getEffortValueDescription, isEffortLevel, isOpenAIEffortLevel, modelUsesOpenAIEffort, toPersistableEffort } from '../../utils/effort.js';
+import { type EffortValue, getDisplayedEffortLevel, getEffortEnvOverride, getEffortValueDescription, isEffortLevel, isOpenAIEffortLevel, modelUsesOpenAIEffort, openAIEffortToStandard, toPersistableEffort } from '../../utils/effort.js';
 import { EffortPicker } from '../../components/EffortPicker.js';
 import { updateSettingsForSource } from '../../utils/settings/settings.js';
 const COMMON_HELP_ARGS = ['help', '-h', '--help'];
@@ -114,7 +114,8 @@ export function executeEffort(args: string): EffortCommandResult {
     return setEffortValue(normalized);
   }
   if (isOpenAIEffortLevel(normalized)) {
-    return setEffortValue(normalized);
+    // Normalize OpenAI-shaped 'xhigh' → standard 'max' so it persists.
+    return setEffortValue(openAIEffortToStandard(normalized));
   }
   return {
     message: `Invalid argument: ${args}. Valid options are: low, medium, high, max, xhigh, auto`
@@ -175,7 +176,7 @@ function ApplyEffortAndClose(t0) {
 export async function call(onDone: LocalJSXCommandOnDone, _context: unknown, args?: string): Promise<React.ReactNode> {
   args = args?.trim() || '';
   if (COMMON_HELP_ARGS.includes(args)) {
-    onDone('Usage: /effort [low|medium|high|max|auto]\n\nEffort levels:\n- low: Quick, straightforward implementation\n- medium: Balanced approach with standard testing\n- high: Comprehensive implementation with extensive testing\n- max: Maximum capability with deepest reasoning (Opus 4.6 only)\n- auto: Use the default effort level for your model');
+    onDone('Usage: /effort [low|medium|high|max|xhigh|auto]\n\nEffort levels:\n- low: Quick, straightforward implementation\n- medium: Balanced approach with standard testing\n- high: Comprehensive implementation with extensive testing\n- max: Maximum capability with deepest reasoning (Opus 4.6 only)\n- xhigh: Extra-high reasoning for OpenAI/Codex models (alias for max)\n- auto: Use the default effort level for your model');
     return;
   }
   if (args === 'current' || args === 'status') {

--- a/src/components/EffortPicker.tsx
+++ b/src/components/EffortPicker.tsx
@@ -8,8 +8,10 @@ import {
   getDisplayedEffortLevel,
   getEffortLevelDescription,
   getEffortLevelLabel,
+  isOpenAIEffortLevel,
   modelSupportsEffort,
   modelUsesOpenAIEffort,
+  openAIEffortToStandard,
 } from '../utils/effort.js'
 import { getAPIProvider } from '../utils/model/providers.js'
 import { getReasoningEffortForModel } from '../services/api/providerConfig.js'
@@ -76,7 +78,12 @@ export function EffortPicker({ onSelect, onCancel }: Props) {
       }))
       onSelect(undefined)
     } else {
-      const effortLevel = value as EffortLevel
+      // Normalize OpenAI-shaped 'xhigh' to the standard EffortLevel ('max')
+      // so AppState + settings.json always hold a persistable value. The shim
+      // converts back to 'xhigh' at the request boundary.
+      const effortLevel = isOpenAIEffortLevel(value)
+        ? openAIEffortToStandard(value)
+        : (value as EffortLevel)
       setAppState(prev => ({
         ...prev,
         effortValue: effortLevel,
@@ -90,10 +97,15 @@ export function EffortPicker({ onSelect, onCancel }: Props) {
   }
 
   const supportsEffort = modelSupportsEffort(model)
-  // For OpenAI/Codex, use the model's default reasoning effort as initial focus
-  // For Claude, use the displayed effort level or 'auto'
+  // For OpenAI/Codex: prefer the user's current selection (max → xhigh for
+  // option matching), otherwise the model's alias default, otherwise auto.
+  // For Claude: user's current selection or auto.
   const initialFocus = usesOpenAIEffort
-    ? (modelReasoningEffort || 'auto')
+    ? (appStateEffort === 'max'
+        ? 'xhigh'
+        : appStateEffort
+          ? String(appStateEffort)
+          : (modelReasoningEffort || 'auto'))
     : (appStateEffort ? String(appStateEffort) : 'auto')
 
   return (

--- a/src/services/api/claude.ts
+++ b/src/services/api/claude.ts
@@ -836,6 +836,7 @@ export async function* executeNonStreamingRequest(
     fetchOverride?: Options['fetchOverride']
     source: string
     providerOverride?: Options['providerOverride']
+    effortValue?: EffortValue
   },
   retryOptions: {
     model: string
@@ -864,6 +865,7 @@ export async function* executeNonStreamingRequest(
         fetchOverride: clientOptions.fetchOverride,
         source: clientOptions.source,
         providerOverride: clientOptions.providerOverride,
+        effortValue: clientOptions.effortValue,
       }),
     async (anthropic, attempt, context) => {
       const start = Date.now()
@@ -1823,6 +1825,7 @@ async function* queryModel(
           fetchOverride: options.fetchOverride,
           source: options.querySource,
           providerOverride: options.providerOverride,
+          effortValue: effort,
         }),
       async (anthropic, attempt, context) => {
         attemptNumber = attempt
@@ -2590,7 +2593,7 @@ async function* queryModel(
           : 'other') as AnalyticsMetadata_I_VERIFIED_THIS_IS_NOT_CODE_OR_FILEPATHS,
       })
       const result = yield* executeNonStreamingRequest(
-        { model: options.model, source: options.querySource, providerOverride: options.providerOverride },
+        { model: options.model, source: options.querySource, providerOverride: options.providerOverride, effortValue: effort },
         {
           model: options.model,
           fallbackModel: options.fallbackModel,
@@ -2689,7 +2692,7 @@ async function* queryModel(
       try {
         // Fall back to non-streaming mode
         const result = yield* executeNonStreamingRequest(
-          { model: options.model, source: options.querySource },
+          { model: options.model, source: options.querySource, effortValue: effort },
           {
             model: options.model,
             fallbackModel: options.fallbackModel,

--- a/src/services/api/client.ts
+++ b/src/services/api/client.ts
@@ -9,6 +9,12 @@ import {
   refreshAndGetAwsCredentials,
   refreshGcpCredentialsIfNeeded,
 } from 'src/utils/auth.js'
+import {
+  convertEffortValueToLevel,
+  type EffortValue,
+  standardEffortToOpenAI,
+  type OpenAIEffortLevel,
+} from 'src/utils/effort.js'
 import { getUserAgent } from 'src/utils/http.js'
 import { getSmallFastModel } from 'src/utils/model/model.js'
 import {
@@ -164,6 +170,7 @@ export async function getAnthropicClient({
   fetchOverride,
   source,
   providerOverride,
+  effortValue,
 }: {
   apiKey?: string
   maxRetries: number
@@ -171,7 +178,14 @@ export async function getAnthropicClient({
   fetchOverride?: ClientOptions['fetch']
   source?: string
   providerOverride?: ProviderOverride
+  effortValue?: EffortValue
 }): Promise<Anthropic> {
+  // Convert the runtime effort value to the OpenAI-shaped enum the shim
+  // expects. Undefined → shim falls back to descriptor/alias defaults.
+  const shimReasoningEffort: OpenAIEffortLevel | undefined =
+    effortValue !== undefined
+      ? standardEffortToOpenAI(convertEffortValueToLevel(effortValue))
+      : undefined
   const containerId = process.env.CLAUDE_CODE_CONTAINER_ID
   const remoteSessionId = process.env.CLAUDE_CODE_REMOTE_SESSION_ID
   const clientApp = process.env.CLAUDE_AGENT_SDK_CLIENT_APP
@@ -248,6 +262,7 @@ export async function getAnthropicClient({
       maxRetries,
       timeout: parseInt(process.env.API_TIMEOUT_MS || String(600 * 1000), 10),
       providerOverride,
+      reasoningEffort: shimReasoningEffort,
     }) as unknown as Anthropic
   }
   // GitHub provider in native Anthropic API mode: send requests in Anthropic
@@ -292,6 +307,7 @@ export async function getAnthropicClient({
       defaultHeaders,
       maxRetries,
       timeout: parseInt(process.env.API_TIMEOUT_MS || String(600 * 1000), 10),
+      reasoningEffort: shimReasoningEffort,
     }) as unknown as Anthropic
   }
   if (isEnvTruthy(process.env.CLAUDE_CODE_USE_BEDROCK)) {

--- a/src/services/api/openaiShim.test.ts
+++ b/src/services/api/openaiShim.test.ts
@@ -5019,3 +5019,113 @@ test('strips Anthropic attribution header block from responses-API instructions 
   expect(instructions).not.toContain('cc_version=')
   expect(instructions).toContain('You are Claude Code.')
 })
+
+test('emits reasoning_effort on chat_completions when reasoningEffort is passed', async () => {
+  process.env.OPENAI_BASE_URL = 'https://api.openai.com/v1'
+  process.env.OPENAI_API_KEY = 'test-key'
+
+  let requestBody: Record<string, unknown> | undefined
+
+  globalThis.fetch = (async (_input, init) => {
+    requestBody = JSON.parse(String(init?.body))
+    return new Response(
+      JSON.stringify({
+        id: 'chatcmpl-1',
+        model: 'gpt-5.4',
+        choices: [
+          {
+            message: { role: 'assistant', content: 'ok' },
+            finish_reason: 'stop',
+          },
+        ],
+        usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+      }),
+      { headers: { 'Content-Type': 'application/json' } },
+    )
+  }) as FetchType
+
+  const client = createOpenAIShimClient({
+    reasoningEffort: 'xhigh',
+  }) as OpenAIShimClient
+
+  await client.beta.messages.create({
+    model: 'gpt-5.4',
+    messages: [{ role: 'user', content: 'hi' }],
+    max_tokens: 16,
+    stream: false,
+  })
+
+  expect(requestBody?.reasoning_effort).toBe('xhigh')
+})
+
+test('omits reasoning_effort on chat_completions when no override and model has no alias default', async () => {
+  process.env.OPENAI_BASE_URL = 'https://api.openai.com/v1'
+  process.env.OPENAI_API_KEY = 'test-key'
+
+  let requestBody: Record<string, unknown> | undefined
+
+  globalThis.fetch = (async (_input, init) => {
+    requestBody = JSON.parse(String(init?.body))
+    return new Response(
+      JSON.stringify({
+        id: 'chatcmpl-1',
+        model: 'gpt-4o',
+        choices: [
+          {
+            message: { role: 'assistant', content: 'ok' },
+            finish_reason: 'stop',
+          },
+        ],
+        usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+      }),
+      { headers: { 'Content-Type': 'application/json' } },
+    )
+  }) as FetchType
+
+  const client = createOpenAIShimClient({}) as OpenAIShimClient
+
+  await client.beta.messages.create({
+    model: 'gpt-4o',
+    messages: [{ role: 'user', content: 'hi' }],
+    max_tokens: 16,
+    stream: false,
+  })
+
+  expect(requestBody && 'reasoning_effort' in requestBody).toBe(false)
+})
+
+test('emits reasoning_effort from codex alias default when no override is passed', async () => {
+  process.env.OPENAI_BASE_URL = 'https://api.openai.com/v1'
+  process.env.OPENAI_API_KEY = 'test-key'
+
+  let requestBody: Record<string, unknown> | undefined
+
+  globalThis.fetch = (async (_input, init) => {
+    requestBody = JSON.parse(String(init?.body))
+    return new Response(
+      JSON.stringify({
+        id: 'chatcmpl-1',
+        model: 'gpt-5.4',
+        choices: [
+          {
+            message: { role: 'assistant', content: 'ok' },
+            finish_reason: 'stop',
+          },
+        ],
+        usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+      }),
+      { headers: { 'Content-Type': 'application/json' } },
+    )
+  }) as FetchType
+
+  const client = createOpenAIShimClient({}) as OpenAIShimClient
+
+  await client.beta.messages.create({
+    model: 'gpt-5.4',
+    messages: [{ role: 'user', content: 'hi' }],
+    max_tokens: 16,
+    stream: false,
+  })
+
+  expect(requestBody?.reasoning_effort).toBe('high')
+})

--- a/src/services/api/openaiShim.ts
+++ b/src/services/api/openaiShim.ts
@@ -1565,6 +1565,13 @@ class OpenAIShimMessages {
       stream: params.stream ?? false,
       store: false,
     }
+    // Emit reasoning_effort for chat_completions when the resolved provider
+     // request carries a reasoning effort (set via /effort, model alias default,
+     // or `?reasoning=<level>` query on the model string). OpenAI, Codex, and
+     // most OpenAI-compatible endpoints read it from this top-level field.
+    if (request.reasoning) {
+      body.reasoning_effort = request.reasoning.effort
+    }
     // Convert max_tokens to max_completion_tokens for OpenAI API compatibility.
     // Azure OpenAI requires max_completion_tokens and does not accept max_tokens.
     // Ensure max_tokens is a valid positive number before using it.

--- a/src/utils/effort.codex.test.ts
+++ b/src/utils/effort.codex.test.ts
@@ -1,4 +1,16 @@
 import { afterEach, expect, mock, test } from 'bun:test'
+// Import the real auth.js and providerConfig.js up front so we can spread
+// their export surfaces into mock factories. `mock.module()` is process-global
+// in bun:test and `mock.restore()` does not undo it (see user.test.ts), so
+// any module we mock here needs to keep the full original export shape — or
+// downstream tests that load it via openaiShim/client/codexShim crash with
+// "Export named 'X' not found in module".
+import * as actualAuth from './auth.js'
+import * as actualProviderConfig from '../services/api/providerConfig.js'
+import * as actualThinking from './thinking.js'
+import * as actualGrowthbook from 'src/services/analytics/growthbook.js'
+import * as actualProviders from './model/providers.js'
+import * as actualModelSupportOverrides from './model/modelSupportOverrides.js'
 
 afterEach(() => {
   mock.restore()
@@ -9,23 +21,29 @@ async function importFreshEffortModule(options: {
   supportsCodexReasoningEffort: boolean
 }) {
   mock.module('./model/providers.js', () => ({
+    ...actualProviders,
     getAPIProvider: () => options.provider,
   }))
   mock.module('./model/modelSupportOverrides.js', () => ({
+    ...actualModelSupportOverrides,
     get3PModelCapabilityOverride: () => undefined,
   }))
   mock.module('../services/api/providerConfig.js', () => ({
+    ...actualProviderConfig,
     supportsCodexReasoningEffort: () => options.supportsCodexReasoningEffort,
   }))
   mock.module('./auth.js', () => ({
+    ...actualAuth,
     isProSubscriber: () => false,
     isMaxSubscriber: () => false,
     isTeamSubscriber: () => false,
   }))
   mock.module('./thinking.js', () => ({
+    ...actualThinking,
     isUltrathinkEnabled: () => false,
   }))
   mock.module('src/services/analytics/growthbook.js', () => ({
+    ...actualGrowthbook,
     getFeatureValue_CACHED_MAY_BE_STALE: (_key: string, fallback: unknown) =>
       fallback,
   }))

--- a/src/utils/effort.codex.test.ts
+++ b/src/utils/effort.codex.test.ts
@@ -17,6 +17,18 @@ async function importFreshEffortModule(options: {
   mock.module('../services/api/providerConfig.js', () => ({
     supportsCodexReasoningEffort: () => options.supportsCodexReasoningEffort,
   }))
+  mock.module('./auth.js', () => ({
+    isProSubscriber: () => false,
+    isMaxSubscriber: () => false,
+    isTeamSubscriber: () => false,
+  }))
+  mock.module('./thinking.js', () => ({
+    isUltrathinkEnabled: () => false,
+  }))
+  mock.module('src/services/analytics/growthbook.js', () => ({
+    getFeatureValue_CACHED_MAY_BE_STALE: (_key: string, fallback: unknown) =>
+      fallback,
+  }))
 
   return import(`./effort.js?ts=${Date.now()}-${Math.random()}`)
 }
@@ -89,4 +101,37 @@ test('standardEffortToOpenAI maps max to xhigh for shim payload', async () => {
   expect(standardEffortToOpenAI('high')).toBe('high')
   expect(openAIEffortToStandard('xhigh')).toBe('max')
   expect(openAIEffortToStandard('high')).toBe('high')
+})
+
+test('e2e: xhigh → persisted max → resolveAppliedEffort → wire xhigh on OpenAI/Codex (no high clamp)', async () => {
+  const {
+    toPersistableEffort,
+    resolveAppliedEffort,
+    standardEffortToOpenAI,
+  } = await importFreshEffortModule({
+    provider: 'openai',
+    supportsCodexReasoningEffort: true,
+  })
+
+  // Picker writes the OpenAI-shaped value; toPersistableEffort normalizes.
+  const persisted = toPersistableEffort('xhigh')
+  expect(persisted).toBe('max')
+
+  // App state holds 'max'. Non-Opus 'max' must NOT be downgraded to 'high'
+  // when the model uses the OpenAI effort scheme — the shim converts back
+  // to 'xhigh' on the wire.
+  const applied = resolveAppliedEffort('gpt-5.4', persisted)
+  expect(applied).toBe('max')
+
+  // Final wire value the client shim emits.
+  expect(standardEffortToOpenAI(applied as 'max')).toBe('xhigh')
+})
+
+test('e2e: max on non-Opus Anthropic model still clamps to high', async () => {
+  const { resolveAppliedEffort } = await importFreshEffortModule({
+    provider: 'firstParty' as unknown as 'openai',
+    supportsCodexReasoningEffort: false,
+  })
+
+  expect(resolveAppliedEffort('claude-sonnet-4-6', 'max')).toBe('high')
 })

--- a/src/utils/effort.codex.test.ts
+++ b/src/utils/effort.codex.test.ts
@@ -63,3 +63,30 @@ test('gpt-5.3-codex-spark stays without effort controls', async () => {
   expect(modelSupportsEffort('gpt-5.3-codex-spark')).toBe(false)
   expect(getAvailableEffortLevels('gpt-5.3-codex-spark')).toEqual([])
 })
+
+test('toPersistableEffort normalizes xhigh to max so it survives settings write', async () => {
+  const { toPersistableEffort } = await importFreshEffortModule({
+    provider: 'openai',
+    supportsCodexReasoningEffort: true,
+  })
+
+  expect(toPersistableEffort('xhigh')).toBe('max')
+  expect(toPersistableEffort('max')).toBe('max')
+  expect(toPersistableEffort('high')).toBe('high')
+  expect(toPersistableEffort('medium')).toBe('medium')
+  expect(toPersistableEffort('low')).toBe('low')
+  expect(toPersistableEffort(undefined)).toBeUndefined()
+})
+
+test('standardEffortToOpenAI maps max to xhigh for shim payload', async () => {
+  const { standardEffortToOpenAI, openAIEffortToStandard } =
+    await importFreshEffortModule({
+      provider: 'openai',
+      supportsCodexReasoningEffort: true,
+    })
+
+  expect(standardEffortToOpenAI('max')).toBe('xhigh')
+  expect(standardEffortToOpenAI('high')).toBe('high')
+  expect(openAIEffortToStandard('xhigh')).toBe('max')
+  expect(openAIEffortToStandard('high')).toBe('high')
+})

--- a/src/utils/effort.ts
+++ b/src/utils/effort.ts
@@ -219,8 +219,14 @@ export function resolveAppliedEffort(
   }
   const resolved =
     envOverride ?? appStateEffortValue ?? getDefaultEffortForModel(model)
-  // API rejects 'max' on non-Opus-4.6 models — downgrade to 'high'.
-  if (resolved === 'max' && !modelSupportsMaxEffort(model)) {
+  // API rejects 'max' on non-Opus-4.6 Anthropic models — downgrade to 'high'.
+  // OpenAI/Codex models use 'max' as the standard form of 'xhigh'; the client
+  // shim converts it back to 'xhigh' on the wire, so don't clamp it here.
+  if (
+    resolved === 'max' &&
+    !modelSupportsMaxEffort(model) &&
+    !modelUsesOpenAIEffort(model)
+  ) {
     return 'high'
   }
   return resolved

--- a/src/utils/effort.ts
+++ b/src/utils/effort.ts
@@ -144,6 +144,8 @@ export function parseEffortValue(value: unknown): EffortValue | undefined {
 /**
  * Numeric values are model-default only and not persisted.
  * 'max' can now be persisted by all users.
+ * OpenAI-shaped 'xhigh' is normalized to its EffortLevel equivalent ('max')
+ * so any code path that leaks the OpenAI label still persists correctly.
  * Write sites call this before saving to settings so the Zod schema
  * (which only accepts string levels) never rejects a write.
  */
@@ -155,6 +157,9 @@ export function toPersistableEffort(
   }
   if (value === 'max') {
     return value
+  }
+  if (value === 'xhigh') {
+    return 'max'
   }
   return undefined
 }


### PR DESCRIPTION
## Summary

Fixes #853 — `xhigh` reasoning effort now persists and is actually sent to Codex/OpenAI providers (including Custom API).

### Persistence
- `EffortPicker.handleSelect` normalizes the OpenAI-shaped `xhigh` to the standard `max` before writing AppState/settings. Previously the `xhigh` value fell through `toPersistableEffort` as `undefined`, so the setting silently reverted on reload.
- `/effort xhigh` takes the same normalization path.
- `toPersistableEffort` maps `xhigh → max` as a defensive backstop.
- `EffortPicker` initialFocus now reflects the user's stored selection (`max` shown as `xhigh` on the OpenAI/Codex picker) instead of always snapping back to the alias default.

### API payload
- `openaiShim` chat_completions body now emits `reasoning_effort` from `request.reasoning.effort`. Previously only the `codex_responses` transport forwarded it, so Custom API users on chat_completions received no effort at all.
- `getAnthropicClient` accepts `effortValue` and forwards it as `reasoningEffort` to `createOpenAIShimClient` on both the `providerOverride` (Custom API) and direct-OpenAI/Gemini/Mistral/GitHub paths. Conversion from internal `max` → wire-level `xhigh` happens at the OpenAI boundary via `standardEffortToOpenAI`.
- `claude.ts` threads the resolved effort through main streaming and both non-streaming fallback call sites.

## Test plan
- [x] `bun test src/utils/effort.codex.test.ts` — persistence normalization + conversion
- [x] `bun test src/services/api/openaiShim.test.ts` — new tests verify `reasoning_effort` is present when override is passed, omitted when no override/alias default, and falls back to codex alias default
- [x] `bun test src/services/api/openaiShim.compression.test.ts src/services/api/codexShim.test.ts` — no regressions
- [ ] Manual: set a Custom API provider (e.g. OpenRouter/DeepInfra), `/effort xhigh`, confirm `reasoning_effort: "xhigh"` in network tab, reopen `/effort` — shows `xhigh` as current.
