### PR TITLE
fix: make OpenAI fallback context window configurable + support external model lookup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -149,6 +149,23 @@ ANTHROPIC_API_KEY=sk-ant-your-key-here
 # Use a custom OpenAI-compatible endpoint (optional — defaults to api.openai.com)
 # OPENAI_BASE_URL=https://api.openai.com/v1
 
+# Fallback context window size (tokens) when the model is not found in the
+# built-in table (default: 128000). Increase this for models with larger
+# context windows (e.g. 200000 for Claude-sized contexts).
+# CLAUDE_CODE_OPENAI_FALLBACK_CONTEXT_WINDOW=128000
+
+# Per-model context window overrides as a JSON object.
+# Takes precedence over the built-in table, so you can register new or
+# custom models without patching source.
+# Example: CLAUDE_CODE_OPENAI_CONTEXT_WINDOWS={"my-corp/llm-v3":262144,"gpt-4o-mini":128000}
+# CLAUDE_CODE_OPENAI_CONTEXT_WINDOWS=
+
+# Per-model maximum output token overrides as a JSON object.
+# Use this alongside CLAUDE_CODE_OPENAI_CONTEXT_WINDOWS when your model
+# supports a different output limit than what the built-in table specifies.
+# Example: CLAUDE_CODE_OPENAI_MAX_OUTPUT_TOKENS={"my-corp/llm-v3":8192}
+# CLAUDE_CODE_OPENAI_MAX_OUTPUT_TOKENS=
+
 
 # -----------------------------------------------------------------------------
 # Option 3: Google Gemini

--- a/src/utils/context.ts
+++ b/src/utils/context.ts
@@ -12,7 +12,12 @@ export const MODEL_CONTEXT_WINDOW_DEFAULT = 200_000
 // Fallback context window for unknown 3P models. Must be large enough that
 // the effective context (this minus output token reservation) stays positive,
 // otherwise auto-compact fires on every message (issue #635).
-export const OPENAI_FALLBACK_CONTEXT_WINDOW = 128_000
+// Override via CLAUDE_CODE_OPENAI_FALLBACK_CONTEXT_WINDOW env var to avoid
+// hardcoding when deploying models not yet in openaiContextWindows.ts.
+export const OPENAI_FALLBACK_CONTEXT_WINDOW = (() => {
+  const v = parseInt(process.env.CLAUDE_CODE_OPENAI_FALLBACK_CONTEXT_WINDOW ?? '', 10)
+  return !isNaN(v) && v > 0 ? v : 128_000
+})()
 
 // Maximum output tokens for compact operations
 export const COMPACT_MAX_OUTPUT_TOKENS = 20_000

--- a/src/utils/model/openaiContextWindows.ts
+++ b/src/utils/model/openaiContextWindows.ts
@@ -413,16 +413,51 @@ const OPENAI_MAX_OUTPUT_TOKENS: Record<string, number> = {
   'moonshot-v1-128k':          32_768,
 }
 
-function lookupByModel<T>(table: Record<string, T>, model: string): T | undefined {
+// External context-window overrides loaded once at startup.
+// Set CLAUDE_CODE_OPENAI_CONTEXT_WINDOWS to a JSON object mapping model name
+// → context-window token count to add or override entries without editing
+// this file.  Example:
+//   CLAUDE_CODE_OPENAI_CONTEXT_WINDOWS='{"my-corp/llm-v2":200000}'
+const OPENAI_EXTERNAL_CONTEXT_WINDOWS: Record<string, number> = (() => {
+  try {
+    const raw = process.env.CLAUDE_CODE_OPENAI_CONTEXT_WINDOWS
+    if (raw) {
+      const parsed = JSON.parse(raw)
+      if (typeof parsed === 'object' && parsed !== null) return parsed as Record<string, number>
+    }
+  } catch { /* ignore malformed JSON */ }
+  return {}
+})()
+
+// External max-output-token overrides.
+// Set CLAUDE_CODE_OPENAI_MAX_OUTPUT_TOKENS to a JSON object mapping model name
+// → max output token count.
+const OPENAI_EXTERNAL_MAX_OUTPUT_TOKENS: Record<string, number> = (() => {
+  try {
+    const raw = process.env.CLAUDE_CODE_OPENAI_MAX_OUTPUT_TOKENS
+    if (raw) {
+      const parsed = JSON.parse(raw)
+      if (typeof parsed === 'object' && parsed !== null) return parsed as Record<string, number>
+    }
+  } catch { /* ignore malformed JSON */ }
+  return {}
+})()
+
+function lookupByModel<T>(table: Record<string, T>, externalTable: Record<string, T>, model: string): T | undefined {
   // Try provider-qualified key first: "{OPENAI_MODEL}:{model}" so that
   // e.g. "github:copilot:claude-haiku-4.5" can have different limits than
   // a bare "claude-haiku-4.5" served by another provider.
   const providerModel = process.env.OPENAI_MODEL?.trim()
   if (providerModel && providerModel !== model) {
     const qualified = `${providerModel}:${model}`
+    // External table takes precedence over the built-in table.
+    const externalQualified = lookupByKey(externalTable, qualified)
+    if (externalQualified !== undefined) return externalQualified
     const qualifiedResult = lookupByKey(table, qualified)
     if (qualifiedResult !== undefined) return qualifiedResult
   }
+  const externalResult = lookupByKey(externalTable, model)
+  if (externalResult !== undefined) return externalResult
   return lookupByKey(table, model)
 }
 
@@ -446,7 +481,7 @@ function lookupByKey<T>(table: Record<string, T>, model: string): T | undefined 
  * "gpt-4o-2024-11-20" resolve to the base "gpt-4o" entry.
  */
 export function getOpenAIContextWindow(model: string): number | undefined {
-  return lookupByModel(OPENAI_CONTEXT_WINDOWS, model)
+  return lookupByModel(OPENAI_CONTEXT_WINDOWS, OPENAI_EXTERNAL_CONTEXT_WINDOWS, model)
 }
 
 /**
@@ -454,5 +489,5 @@ export function getOpenAIContextWindow(model: string): number | undefined {
  * Returns undefined if the model is not in the table.
  */
 export function getOpenAIMaxOutputTokens(model: string): number | undefined {
-  return lookupByModel(OPENAI_MAX_OUTPUT_TOKENS, model)
+  return lookupByModel(OPENAI_MAX_OUTPUT_TOKENS, OPENAI_EXTERNAL_MAX_OUTPUT_TOKENS, model)
 }


### PR DESCRIPTION
## What changed

- `OPENAI_FALLBACK_CONTEXT_WINDOW` in `context.ts` is no longer a bare constant — it reads from `CLAUDE_CODE_OPENAI_FALLBACK_CONTEXT_WINDOW` (env var, integer) and falls back to `128_000` when unset.
- `openaiContextWindows.ts` loads two optional external tables at startup:
  - `CLAUDE_CODE_OPENAI_CONTEXT_WINDOWS` — JSON object mapping model name → context-window token count
  - `CLAUDE_CODE_OPENAI_MAX_OUTPUT_TOKENS` — JSON object mapping model name → max output token count
- Both external tables are checked **before** the built-in tables; provider-qualified and prefix-matching lookup logic is preserved.

## Why

The built-in lookup table in `openaiContextWindows.ts` must be updated manually every time a new OpenAI-compatible model is deployed. When a model is missing from the table the code silently falls back to `128_000`, which is frequently **lower** than the model's actual context window. This causes `auto-compact` to fire prematurely even when there is plenty of context budget remaining (follow-up to #635).

With this change, operators deploying private or newly-released models can supply accurate context limits without patching source code on every model release.

## Usage

```sh
# Override the fallback for all unknown models
export CLAUDE_CODE_OPENAI_FALLBACK_CONTEXT_WINDOW=200000

# Or supply exact per-model overrides (take precedence over built-in table)
export CLAUDE_CODE_OPENAI_CONTEXT_WINDOWS='{"my-corp/llm-v3":262144,"my-corp/llm-v3-mini":131072}'
export CLAUDE_CODE_OPENAI_MAX_OUTPUT_TOKENS='{"my-corp/llm-v3":16384}'
```

The built-in lookup table is **unchanged**; this is a pure additive change with no impact on existing configurations.

## Checks run

```
bun run build
bun run smoke
```

Provider path tested: `CLAUDE_CODE_USE_OPENAI=1` with a model name absent from the built-in table — confirmed that the fallback env var and external JSON override are both respected.