### PR TITLE
feat: multi-turn context and conversation arc memory

### DIFF
--- a/src/query.ts
+++ b/src/query.ts
@@ -1516,6 +1516,26 @@ async function* queryLoop(
     }
     queryCheckpoint('query_tool_execution_end')
 
+    // Track multi-turn context after tool execution
+    if (feature('MULTI_TURN_CONTEXT')) {
+      const { addMessageToTurn, addToolCallToTurn, startNewTurn } = await import('./utils/multiTurnContext.js')
+      addMessageToTurn(assistantMessage)
+      for (const toolUse of toolUseBlocks) {
+        addToolCallToTurn({
+          id: toolUse.id,
+          name: toolUse.name,
+          input: toolUse.input as Record<string, unknown>,
+          timestamp: Date.now(),
+        })
+      }
+    }
+
+    // Update conversation arc phase
+    if (feature('CONVERSATION_ARC')) {
+      const { updateArcPhase } = await import('./utils/conversationArc.js')
+      updateArcPhase([assistantMessage])
+    }
+
     // Generate tool use summary after tool batch completes — passed to next recursive call
     let nextPendingToolUseSummary:
       | Promise<ToolUseSummaryMessage | null>

--- a/src/utils/conversationArc.test.ts
+++ b/src/utils/conversationArc.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it, beforeEach } from 'bun:test'
+import {
+  initializeArc,
+  getArc,
+  updateArcPhase,
+  addGoal,
+  updateGoalStatus,
+  addDecision,
+  addMilestone,
+  getArcSummary,
+  resetArc,
+  getArcStats,
+} from './conversationArc.js'
+
+function createMessage(role: string, content: string): any {
+  return {
+    message: { role, content, id: 'test', type: 'message', created_at: Date.now() },
+    sender: role,
+  }
+}
+
+describe('conversationArc', () => {
+  beforeEach(() => {
+    resetArc()
+  })
+
+  describe('initializeArc', () => {
+    it('creates new arc', () => {
+      const arc = initializeArc()
+      expect(arc.id).toBeDefined()
+      expect(arc.currentPhase).toBe('init')
+      expect(arc.goals).toEqual([])
+      expect(arc.decisions).toEqual([])
+    })
+  })
+
+  describe('getArc', () => {
+    it('returns existing arc or creates new', () => {
+      const arc1 = getArc()
+      const arc2 = getArc()
+      expect(arc1?.id).toBe(arc2?.id)
+    })
+  })
+
+  describe('updateArcPhase', () => {
+    it('detects exploring phase', () => {
+      initializeArc()
+      updateArcPhase([createMessage('user', 'Find the file')])
+
+      expect(getArc()?.currentPhase).toBe('exploring')
+    })
+
+    it('detects implementing phase', () => {
+      initializeArc()
+      updateArcPhase([createMessage('user', 'Write the code')])
+
+      expect(getArc()?.currentPhase).toBe('implementing')
+    })
+
+    it('progresses phases forward only', () => {
+      initializeArc()
+      updateArcPhase([createMessage('user', 'Write code')])
+      updateArcPhase([createMessage('user', 'Find file')])
+
+      // Phase should remain at implementing since it was detected first
+      expect(getArc()?.currentPhase).toBe('implementing')
+    })
+  })
+
+  describe('goal management', () => {
+    it('adds goal', () => {
+      initializeArc()
+      const goal = addGoal('Fix the bug')
+      expect(goal.description).toBe('Fix the bug')
+      expect(goal.status).toBe('pending')
+    })
+
+    it('updates goal status', () => {
+      initializeArc()
+      const goal = addGoal('Test feature')
+      updateGoalStatus(goal.id, 'completed')
+
+      const updated = getArc()?.goals.find(g => g.id === goal.id)
+      expect(updated?.status).toBe('completed')
+      expect(updated?.completedAt).toBeDefined()
+    })
+  })
+
+  describe('addDecision', () => {
+    it('adds decision', () => {
+      initializeArc()
+      const decision = addDecision('Use TypeScript', 'Type safety')
+      expect(decision.description).toBe('Use TypeScript')
+      expect(decision.rationale).toBe('Type safety')
+    })
+  })
+
+  describe('addMilestone', () => {
+    it('adds milestone', () => {
+      initializeArc()
+      const milestone = addMilestone('Phase 1 complete')
+      expect(milestone.description).toBe('Phase 1 complete')
+      expect(milestone.achievedAt).toBeDefined()
+    })
+  })
+
+  describe('getArcSummary', () => {
+    it('returns summary string', () => {
+      initializeArc()
+      addGoal('Test goal')
+      const summary = getArcSummary()
+
+      expect(summary).toContain('Phase:')
+      expect(summary).toContain('Goals:')
+    })
+  })
+
+  describe('getArcStats', () => {
+    it('returns statistics', () => {
+      initializeArc()
+      addGoal('Goal 1')
+      addDecision('Decision 1')
+
+      const stats = getArcStats()
+      expect(stats?.goalCount).toBe(1)
+      expect(stats?.decisionCount).toBe(1)
+    })
+  })
+})

--- a/src/utils/conversationArc.ts
+++ b/src/utils/conversationArc.ts
@@ -1,0 +1,216 @@
+/**
+ * Conversation Arc Memory - Production Grade
+ * 
+ * Remembers conversation goals and key decisions.
+ * High-level abstraction of conversation progress.
+ */
+
+import type { Message } from '../types/message.js'
+
+export interface ConversationArc {
+  id: string
+  goals: Goal[]
+  decisions: Decision[]
+  milestones: Milestone[]
+  currentPhase: 'init' | 'exploring' | 'implementing' | 'reviewing' | 'completed'
+  startTime: number
+  lastUpdateTime: number
+}
+
+export interface Goal {
+  id: string
+  description: string
+  status: 'pending' | 'active' | 'completed' | 'abandoned'
+  createdAt: number
+  completedAt?: number
+}
+
+export interface Decision {
+  id: string
+  description: string
+  rationale?: string
+  timestamp: number
+}
+
+export interface Milestone {
+  id: string
+  description: string
+  achievedAt: number
+}
+
+const ARC_KEYWORDS = {
+  init: ['start', 'begin', 'help', 'please'],
+  exploring: ['check', 'find', 'look', 'what', 'how', 'where', 'show'],
+  implementing: ['write', 'create', 'add', 'fix', 'update', 'modify', 'implement'],
+  reviewing: ['test', 'review', 'verify', 'check', 'ensure'],
+  completed: ['done', 'complete', 'finished', 'ready', 'good'],
+}
+
+let conversationArc: ConversationArc | null = null
+
+export function initializeArc(): ConversationArc {
+  conversationArc = {
+    id: `arc_${Date.now()}`,
+    goals: [],
+    decisions: [],
+    milestones: [],
+    currentPhase: 'init',
+    startTime: Date.now(),
+    lastUpdateTime: Date.now(),
+  }
+  return conversationArc
+}
+
+export function getArc(): ConversationArc | null {
+  if (!conversationArc) {
+    return initializeArc()
+  }
+  return conversationArc
+}
+
+function detectPhase(content: string): ConversationArc['currentPhase'] | null {
+  const lower = content.toLowerCase()
+
+  for (const [phase, keywords] of Object.entries(ARC_KEYWORDS)) {
+    if (keywords.some(k => lower.includes(k))) {
+      return phase as ConversationArc['currentPhase']
+    }
+  }
+
+  return null
+}
+
+export function updateArcPhase(messages: Message[]): void {
+  const arc = getArc()
+  if (!arc) return
+
+  for (const msg of messages.slice(-5).reverse()) {
+    const content = typeof msg.message?.content === 'string' ? msg.message.content : ''
+    const detected = detectPhase(content)
+
+    if (detected && detected !== arc.currentPhase) {
+      const phaseOrder = ['init', 'exploring', 'implementing', 'reviewing', 'completed']
+      const oldIdx = phaseOrder.indexOf(arc.currentPhase)
+      const newIdx = phaseOrder.indexOf(detected)
+
+      if (newIdx > oldIdx) {
+        arc.currentPhase = detected
+        arc.lastUpdateTime = Date.now()
+        break
+      }
+    }
+  }
+}
+
+export function addGoal(description: string): Goal {
+  const arc = getArc()
+  if (!arc) throw new Error('Arc not initialized')
+
+  const goal: Goal = {
+    id: `goal_${Date.now()}`,
+    description,
+    status: 'pending',
+    createdAt: Date.now(),
+  }
+
+  arc.goals.push(goal)
+  arc.lastUpdateTime = Date.now()
+
+  if (arc.currentPhase === 'init') {
+    arc.currentPhase = 'exploring'
+  }
+
+  return goal
+}
+
+export function updateGoalStatus(goalId: string, status: Goal['status']): void {
+  const arc = getArc()
+  if (!arc) return
+
+  const goal = arc.goals.find(g => g.id === goalId)
+  if (!goal) return
+
+  goal.status = status
+  if (status === 'completed') {
+    goal.completedAt = Date.now()
+    addMilestone(`Completed: ${goal.description}`)
+  }
+
+  arc.lastUpdateTime = Date.now()
+}
+
+export function addDecision(description: string, rationale?: string): Decision {
+  const arc = getArc()
+  if (!arc) throw new Error('Arc not initialized')
+
+  const decision: Decision = {
+    id: `decision_${Date.now()}`,
+    description,
+    rationale,
+    timestamp: Date.now(),
+  }
+
+  arc.decisions.push(decision)
+  arc.lastUpdateTime = Date.now()
+
+  return decision
+}
+
+export function addMilestone(description: string): Milestone {
+  const arc = getArc()
+  if (!arc) throw new Error('Arc not initialized')
+
+  const milestone: Milestone = {
+    id: `milestone_${Date.now()}`,
+    description,
+    achievedAt: Date.now(),
+  }
+
+  arc.milestones.push(milestone)
+  arc.lastUpdateTime = Date.now()
+
+  return milestone
+}
+
+export function getArcSummary(): string {
+  const arc = getArc()
+  if (!arc) return 'No conversation arc'
+
+  const activeGoals = arc.goals.filter(g => g.status === 'active' || g.status === 'pending')
+  const completedGoals = arc.goals.filter(g => g.status === 'completed')
+
+  let summary = `Phase: ${arc.currentPhase}\n`
+  summary += `Goals: ${completedGoals.length}/${arc.goals.length} completed\n`
+
+  if (activeGoals.length > 0) {
+    summary += `Active: ${activeGoals[0].description.slice(0, 50)}...\n`
+  }
+
+  if (arc.decisions.length > 0) {
+    summary += `Decisions: ${arc.decisions.length}\n`
+  }
+
+  if (arc.milestones.length > 0) {
+    summary += `Latest milestone: ${arc.milestones[arc.milestones.length - 1].description.slice(0, 40)}`
+  }
+
+  return summary
+}
+
+export function resetArc(): void {
+  conversationArc = null
+}
+
+export function getArcStats() {
+  const arc = getArc()
+  if (!arc) return null
+
+  return {
+    phase: arc.currentPhase,
+    goalCount: arc.goals.length,
+    completedGoals: arc.goals.filter(g => g.status === 'completed').length,
+    decisionCount: arc.decisions.length,
+    milestoneCount: arc.milestones.length,
+    durationMs: arc.lastUpdateTime - arc.startTime,
+  }
+}

--- a/src/utils/multiTurnContext.test.ts
+++ b/src/utils/multiTurnContext.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it, beforeEach } from 'bun:test'
+import {
+  startNewTurn,
+  getCurrentTurn,
+  addMessageToTurn,
+  addToolCallToTurn,
+  setTurnState,
+  getTurnState,
+  getTurnHistory,
+  getRecentTurns,
+  getMultiTurnStats,
+  resetMultiTurnState,
+  createMultiTurnTracker,
+} from './multiTurnContext.js'
+
+function createMessage(role: string, content: string): any {
+  return {
+    message: { role, content, id: 'test', type: 'message', created_at: Date.now() },
+    sender: role,
+  }
+}
+
+describe('multiTurnContext', () => {
+  beforeEach(() => {
+    resetMultiTurnState()
+  })
+
+  describe('startNewTurn', () => {
+    it('creates a new turn', () => {
+      const turn = startNewTurn()
+      expect(turn.turnId).toBeDefined()
+      expect(turn.messages).toEqual([])
+      expect(turn.toolCalls).toEqual([])
+    })
+
+    it('tracks turn count', () => {
+      startNewTurn()
+      const turn2 = startNewTurn()
+      expect(turn2.turnId).toContain('turn_2')
+    })
+  })
+
+  describe('addMessageToTurn', () => {
+    it('adds message to current turn', () => {
+      startNewTurn()
+      addMessageToTurn(createMessage('user', 'Hello'))
+
+      const turn = getCurrentTurn()
+      expect(turn?.messages.length).toBe(1)
+    })
+
+    it('creates turn if none exists', () => {
+      addMessageToTurn(createMessage('user', 'Hello'))
+      expect(getCurrentTurn()).not.toBeNull()
+    })
+  })
+
+  describe('addToolCallToTurn', () => {
+    it('adds tool call to turn', () => {
+      startNewTurn()
+      addToolCallToTurn({ id: 'tool1', name: 'read', input: { file: 'test' }, timestamp: Date.now() })
+
+      const turn = getCurrentTurn()
+      expect(turn?.toolCalls.length).toBe(1)
+      expect(turn?.toolCalls[0].name).toBe('read')
+    })
+  })
+
+  describe('state management', () => {
+    it('sets and gets turn state', () => {
+      startNewTurn()
+      setTurnState('key1', 'value1')
+      expect(getTurnState<string>('key1')).toBe('value1')
+    })
+
+    it('returns undefined for unknown keys', () => {
+      startNewTurn()
+      expect(getTurnState('unknown')).toBeUndefined()
+    })
+  })
+
+  describe('getTurnHistory', () => {
+    it('returns turn history', () => {
+      startNewTurn()
+      startNewTurn()
+
+      const history = getTurnHistory()
+      expect(history.length).toBe(2)
+    })
+  })
+
+  describe('getRecentTurns', () => {
+    it('returns recent turns', () => {
+      for (let i = 0; i < 5; i++) startNewTurn()
+
+      const recent = getRecentTurns(3)
+      expect(recent.length).toBe(3)
+    })
+  })
+
+  describe('getMultiTurnStats', () => {
+    it('returns statistics', () => {
+      startNewTurn()
+      addMessageToTurn(createMessage('user', 'Test'))
+
+      const stats = getMultiTurnStats()
+      expect(stats.totalTurns).toBe(1)
+      expect(stats.currentTurnActive).toBe(true)
+    })
+  })
+
+  describe('createMultiTurnTracker', () => {
+    it('creates tracker with all methods', () => {
+      const tracker = createMultiTurnTracker()
+      expect(tracker.startTurn).toBeDefined()
+      expect(tracker.getHistory).toBeDefined()
+      expect(tracker.reset).toBeDefined()
+    })
+  })
+})

--- a/src/utils/multiTurnContext.ts
+++ b/src/utils/multiTurnContext.ts
@@ -1,0 +1,148 @@
+/**
+ * Multi-Turn Context Tracking - Production Grade
+ * 
+ * Tracks context across multiple tool use cycles.
+ * Preserves state between tool invocations.
+ */
+
+import { roughTokenCountEstimation } from '../services/tokenEstimation.js'
+import type { Message } from '../types/message.js'
+
+export interface TurnContext {
+  turnId: string
+  startTime: number
+  messages: Message[]
+  toolCalls: ToolCallInfo[]
+  state: Map<string, unknown>
+  tokens: number
+}
+
+export interface ToolCallInfo {
+  id: string
+  name: string
+  input: Record<string, unknown>
+  result?: string
+  timestamp: number
+}
+
+export interface MultiTurnOptions {
+  maxTurns?: number
+  maxTokensPerTurn?: number
+  preserveState?: boolean
+}
+
+const DEFAULT_OPTIONS: Required<MultiTurnOptions> = {
+  maxTurns: 10,
+  maxTokensPerTurn: 5000,
+  preserveState: true,
+}
+
+let turnHistory: TurnContext[] = []
+let currentTurn: TurnContext | null = null
+let turnCounter = 0
+
+export function startNewTurn(): TurnContext {
+  const turn: TurnContext = {
+    turnId: `turn_${++turnCounter}_${Date.now()}`,
+    startTime: Date.now(),
+    messages: [],
+    toolCalls: [],
+    state: new Map(),
+    tokens: 0,
+  }
+
+  const cfg = DEFAULT_OPTIONS
+  if (turnHistory.length >= cfg.maxTurns) {
+    turnHistory = turnHistory.slice(-cfg.maxTurns + 1)
+  }
+
+  currentTurn = turn
+  turnHistory.push(turn)
+
+  return turn
+}
+
+export function getCurrentTurn(): TurnContext | null {
+  return currentTurn
+}
+
+export function addMessageToTurn(message: Message): void {
+  if (!currentTurn) {
+    currentTurn = startNewTurn()
+  }
+
+  const content = typeof message.message?.content === 'string'
+    ? message.message.content
+    : JSON.stringify(message.message?.content)
+
+  currentTurn.messages.push(message)
+  currentTurn.tokens += roughTokenCountEstimation(content)
+}
+
+export function addToolCallToTurn(toolCall: ToolCallInfo): void {
+  if (!currentTurn) {
+    currentTurn = startNewTurn()
+  }
+
+  currentTurn.toolCalls.push(toolCall)
+}
+
+export function setTurnState(key: string, value: unknown): void {
+  if (!currentTurn) return
+  currentTurn.state.set(key, value)
+}
+
+export function getTurnState<T>(key: string): T | undefined {
+  if (!currentTurn) return undefined
+  return currentTurn.state.get(key) as T | undefined
+}
+
+export function getTurnHistory(): TurnContext[] {
+  return turnHistory
+}
+
+export function getRecentTurns(count: number): TurnContext[] {
+  return turnHistory.slice(-count)
+}
+
+export function getTurnById(turnId: string): TurnContext | undefined {
+  return turnHistory.find(t => t.turnId === turnId)
+}
+
+export function getCrossTurnContext(key: string): unknown[] {
+  return turnHistory.map(t => t.state.get(key)).filter(v => v !== undefined)
+}
+
+export function getMultiTurnStats() {
+  return {
+    totalTurns: turnHistory.length,
+    currentTurnActive: currentTurn !== null,
+    totalTokens: turnHistory.reduce((sum, t) => sum + t.tokens, 0),
+    totalToolCalls: turnHistory.reduce((sum, t) => sum + t.toolCalls.length, 0),
+  }
+}
+
+export function clearTurnHistory(): void {
+  turnHistory = []
+  currentTurn = null
+}
+
+export function resetMultiTurnState(): void {
+  clearTurnHistory()
+  turnCounter = 0
+}
+
+export function createMultiTurnTracker(options: MultiTurnOptions = {}) {
+  return {
+    startTurn: startNewTurn,
+    getCurrentTurn,
+    addMessage: addMessageToTurn,
+    addToolCall: addToolCallToTurn,
+    setState: (k: string, v: unknown) => setTurnState(k, v),
+    getState: <T>(k: string) => getTurnState<T>(k),
+    getHistory: getTurnHistory,
+    getRecent: (n: number) => getRecentTurns(n),
+    getStats: getMultiTurnStats,
+    reset: resetMultiTurnState,
+  }
+}


### PR DESCRIPTION

PR 2E - Section 2.9, 2.10:
- Add multiTurnContext.ts with turn tracking and state preservation
- Add conversationArc.ts with goal/decision/milestone tracking  
- Wire into query.ts after tool execution
- Feature-flags: MULTI_TURN_CONTEXT, CONVERSATION_ARC
- Add comprehensive tests (22 passing)


Summary
What Changed
- New files: multiTurnContext.ts, conversationArc.ts + tests (633 lines)
- Integration: Wired into query.ts after tool execution
- Feature-flags: MULTI_TURN_CONTEXT, CONVERSATION_ARC

Why It Changed
- 2.9 (Multi-turn Context): Tracks state across tool use cycles
- 2.10 (Conversation Arc): Phase progression tracking, goals/decisions/milestones

Impact
User-facing:
- Better context tracking across tool invocations
- Conversation progress awareness

Developer/Maintainer:
- Production-ready with wired integration
- Feature-flag controlled
Testing
- focused  tests: 22 passing