### PR TITLE
fix(update): show real package version and give actionable guidance

### DIFF
--- a/src/cli/update.ts
+++ b/src/cli/update.ts
@@ -35,15 +35,20 @@ export async function update() {
   // binary (without it).
   if (getAPIProvider() !== 'firstParty') {
     writeToStdout(
-      chalk.yellow('Auto-update is not available for third-party provider builds.\n') +
-      'To update, pull the latest source from the repository and rebuild:\n' +
-      '  git pull && bun install && bun run build\n',
+      chalk.yellow(
+        `Auto-update is not available for third-party provider builds.\n`,
+      ) +
+        `Current version: ${MACRO.DISPLAY_VERSION}\n\n` +
+        `To update, reinstall from npm:\n` +
+        chalk.bold(`  npm install -g ${MACRO.PACKAGE_URL}@latest`) + '\n\n' +
+        `Or, if you built from source, pull and rebuild:\n` +
+        chalk.bold('  git pull && bun install && bun run build') + '\n',
     )
-    return
+    await gracefulShutdown(0)
   }
 
   logEvent('tengu_update_check', {})
-  writeToStdout(`Current version: ${MACRO.VERSION}\n`)
+  writeToStdout(`Current version: ${MACRO.DISPLAY_VERSION}\n`)
 
   const channel = getInitialSettings()?.autoUpdatesChannel ?? 'latest'
   writeToStdout(`Checking for updates to ${channel} version...\n`)
@@ -123,9 +128,14 @@ export async function update() {
   if (diagnostic.installationType === 'development') {
     writeToStdout('\n')
     writeToStdout(
-      chalk.yellow('Warning: Cannot update development build') + '\n',
+      chalk.yellow('You are running a development build — auto-update is unavailable.') + '\n',
     )
-    await gracefulShutdown(1)
+    writeToStdout('To update, pull the latest source and rebuild:\n')
+    writeToStdout(chalk.bold('  git pull && bun install && bun run build') + '\n')
+    writeToStdout('\n')
+    writeToStdout('Or reinstall from npm:\n')
+    writeToStdout(chalk.bold(`  npm install -g ${MACRO.PACKAGE_URL}@latest`) + '\n')
+    await gracefulShutdown(0)
   }
 
   // Check if running from a package manager
@@ -136,8 +146,8 @@ export async function update() {
     if (packageManager === 'homebrew') {
       writeToStdout('Claude is managed by Homebrew.\n')
       const latest = await getLatestVersion(channel)
-      if (latest && !gte(MACRO.VERSION, latest)) {
-        writeToStdout(`Update available: ${MACRO.VERSION} → ${latest}\n`)
+      if (latest && !gte(MACRO.DISPLAY_VERSION, latest)) {
+        writeToStdout(`Update available: ${MACRO.DISPLAY_VERSION} → ${latest}\n`)
         writeToStdout('\n')
         writeToStdout('To update, run:\n')
         writeToStdout(chalk.bold('  brew upgrade claude-code') + '\n')
@@ -147,8 +157,8 @@ export async function update() {
     } else if (packageManager === 'winget') {
       writeToStdout('Claude is managed by winget.\n')
       const latest = await getLatestVersion(channel)
-      if (latest && !gte(MACRO.VERSION, latest)) {
-        writeToStdout(`Update available: ${MACRO.VERSION} → ${latest}\n`)
+      if (latest && !gte(MACRO.DISPLAY_VERSION, latest)) {
+        writeToStdout(`Update available: ${MACRO.DISPLAY_VERSION} → ${latest}\n`)
         writeToStdout('\n')
         writeToStdout('To update, run:\n')
         writeToStdout(
@@ -160,8 +170,8 @@ export async function update() {
     } else if (packageManager === 'apk') {
       writeToStdout('Claude is managed by apk.\n')
       const latest = await getLatestVersion(channel)
-      if (latest && !gte(MACRO.VERSION, latest)) {
-        writeToStdout(`Update available: ${MACRO.VERSION} → ${latest}\n`)
+      if (latest && !gte(MACRO.DISPLAY_VERSION, latest)) {
+        writeToStdout(`Update available: ${MACRO.DISPLAY_VERSION} → ${latest}\n`)
         writeToStdout('\n')
         writeToStdout('To update, run:\n')
         writeToStdout(chalk.bold('  apk upgrade claude-code') + '\n')
@@ -250,14 +260,14 @@ export async function update() {
         await gracefulShutdown(1)
       }
 
-      if (result.latestVersion === MACRO.VERSION) {
+      if (result.latestVersion === MACRO.DISPLAY_VERSION) {
         writeToStdout(
-          chalk.green(`Claude Code is up to date (${MACRO.VERSION})`) + '\n',
+          chalk.green(`OpenClaude is up to date (${MACRO.DISPLAY_VERSION})`) + '\n',
         )
       } else {
         writeToStdout(
           chalk.green(
-            `Successfully updated from ${MACRO.VERSION} to version ${result.latestVersion}`,
+            `Successfully updated from ${MACRO.DISPLAY_VERSION} to version ${result.latestVersion}`,
           ) + '\n',
         )
         await regenerateCompletionCache()
@@ -320,15 +330,15 @@ export async function update() {
   }
 
   // Check if versions match exactly, including any build metadata (like SHA)
-  if (latestVersion === MACRO.VERSION) {
+  if (latestVersion === MACRO.DISPLAY_VERSION) {
     writeToStdout(
-      chalk.green(`Claude Code is up to date (${MACRO.VERSION})`) + '\n',
+      chalk.green(`OpenClaude is up to date (${MACRO.DISPLAY_VERSION})`) + '\n',
     )
     await gracefulShutdown(0)
   }
 
   writeToStdout(
-    `New version available: ${latestVersion} (current: ${MACRO.VERSION})\n`,
+    `New version available: ${latestVersion} (current: ${MACRO.DISPLAY_VERSION})\n`,
   )
   writeToStdout('Installing update...\n')
 
@@ -388,7 +398,7 @@ export async function update() {
     case 'success':
       writeToStdout(
         chalk.green(
-          `Successfully updated from ${MACRO.VERSION} to version ${latestVersion}`,
+          `Successfully updated from ${MACRO.DISPLAY_VERSION} to version ${latestVersion}`,
         ) + '\n',
       )
       await regenerateCompletionCache()


### PR DESCRIPTION
## Summary

Fixes #852. The `openclaude update` / `openclaude upgrade` command printed `Current version: 99.0.0` and, in the development-build branch, exited with only `Warning: Cannot update development build` — leaving users unable to see their real version or update.

## Root cause

`MACRO.VERSION` is hardcoded to `'99.0.0'` in `scripts/build.ts` as an internal-compat sentinel so OpenClaude passes upstream minimum-version guards. The real package version is exposed separately as `MACRO.DISPLAY_VERSION`. `src/cli/update.ts` used `MACRO.VERSION` for both the displayed version and every `latestVersion` comparison, so:

- Every user saw `Current version: 99.0.0`.
- `99.0.0 >= <any real npm version>`, so the "up to date" / "update available" checks were permanently wrong.

## Changes

All scoped to `src/cli/update.ts`:

- Display `MACRO.DISPLAY_VERSION` (the real package version, e.g. `0.6.0`) in all user-facing output.
- Use `MACRO.DISPLAY_VERSION` for all version comparisons (`gte`, equality checks, update-available prompts).
- Replace the dead-end `Warning: Cannot update development build` (exit 1, no guidance) with concrete instructions for both source builds (`git pull && bun install && bun run build`) and npm installs.
- Extend the existing third-party-provider branch to also show the current version and the npm reinstall command, so users who installed via npm aren't told only to rebuild from source.

## Before vs. after

**Before:**
```
Current version: 99.0.0
Checking for updates to latest version...
Warning: Cannot update development build
```

**After (third-party provider):**
```
Auto-update is not available for third-party provider builds.
Current version: 0.6.0

To update, reinstall from npm:
  npm install -g @gitlawb/openclaude@latest

Or, if you built from source, pull and rebuild:
  git pull && bun install && bun run build
```

## Test plan

- [x] `bun run build` succeeds
- [x] `bun run typecheck` — no new errors introduced on `update.ts` (the `Cannot find name 'MACRO'` errors are pre-existing on every `MACRO.*` reference in the codebase; build-time constants are not typed)
- [x] `bun test` — 1187 pass / 8 fail, identical to main; no regressions
- [x] `node dist/cli.mjs update` — real version displayed, concrete install instructions shown
- [ ] Manual smoke on a first-party install (requires Anthropic auth — not reachable locally; change is a mechanical `MACRO.VERSION` → `MACRO.DISPLAY_VERSION` swap)