### PR TITLE
fix(shell): recover when CWD path was replaced by a non-directory

### DIFF
--- a/src/utils/Shell.ts
+++ b/src/utils/Shell.ts
@@ -1,6 +1,6 @@
 import { execFileSync, spawn } from 'child_process'
 import { constants as fsConstants, readFileSync, unlinkSync } from 'fs'
-import { type FileHandle, mkdir, open, realpath, stat } from 'fs/promises'
+import { type FileHandle, mkdir, open, stat } from 'fs/promises'
 import memoize from 'lodash-es/memoize.js'
 import { isAbsolute, resolve } from 'path'
 import { join as posixJoin } from 'path/posix'

--- a/src/utils/Shell.ts
+++ b/src/utils/Shell.ts
@@ -1,6 +1,6 @@
 import { execFileSync, spawn } from 'child_process'
 import { constants as fsConstants, readFileSync, unlinkSync } from 'fs'
-import { type FileHandle, mkdir, open, realpath } from 'fs/promises'
+import { type FileHandle, mkdir, open, realpath, stat } from 'fs/promises'
 import memoize from 'lodash-es/memoize.js'
 import { isAbsolute, resolve } from 'path'
 import { join as posixJoin } from 'path/posix'
@@ -217,22 +217,34 @@ export async function exec(
 
   let cwd = pwd()
 
-  // Recover if the current working directory no longer exists on disk.
-  // This can happen when a command deletes its own CWD (e.g., temp dir cleanup).
+  // Recover if the current working directory no longer exists on disk,
+  // or was replaced by a non-directory (e.g., the path was renamed and a file
+  // was created in its place). realpath() succeeds on any existing path
+  // regardless of type, so we must also verify it's a directory — otherwise
+  // spawn would fail later with ENOTDIR / exit 126.
+  let cwdIsValidDir = false
   try {
-    await realpath(cwd)
+    cwdIsValidDir = (await stat(cwd)).isDirectory()
   } catch {
+    cwdIsValidDir = false
+  }
+  if (!cwdIsValidDir) {
     const fallback = getOriginalCwd()
     logForDebugging(
-      `Shell CWD "${cwd}" no longer exists, recovering to "${fallback}"`,
+      `Shell CWD "${cwd}" is not a valid directory, recovering to "${fallback}"`,
     )
+    let fallbackIsValidDir = false
     try {
-      await realpath(fallback)
+      fallbackIsValidDir = (await stat(fallback)).isDirectory()
+    } catch {
+      fallbackIsValidDir = false
+    }
+    if (fallbackIsValidDir) {
       setCwdState(fallback)
       cwd = fallback
-    } catch {
+    } else {
       return createFailedCommand(
-        `Working directory "${cwd}" no longer exists. Please restart Claude from an existing directory.`,
+        `Working directory "${cwd}" is no longer a valid directory. Please restart Claude from an existing directory.`,
       )
     }
   }


### PR DESCRIPTION
## Summary

Fixes #844. When the session's cached working directory is renamed out from under OpenClaude and a file is subsequently created at the old path (`mv orig renamed && touch orig`), every Bash tool invocation fails with `ENOTDIR: not a directory, posix_spawn '/usr/bin/zsh'` (exit 126), and `!`-prefixed commands silently fail. No recovery is possible without restarting the session.

## Root cause

The pre-spawn guard in `src/utils/Shell.ts:exec()` used `realpath(cwd)` to detect a missing CWD:

```ts
try {
  await realpath(cwd)
} catch {
  // recover to originalCwd
}
```

`realpath()` succeeds on any existing path — file **or** directory — so a path that was replaced with a regular file slipped past the check. `spawn()` was then called with `cwd` pointing at a non-directory and failed with ENOTDIR.

## Fix

Replace `realpath()` with `stat().isDirectory()` for both the primary CWD check and the `getOriginalCwd()` fallback. When the cached CWD is no longer a valid directory, fall back to the original CWD (existing behaviour) and update state so subsequent tools recover transparently.

Scoped to a single file (`src/utils/Shell.ts`, +20/-8).

## Repro & verification

```bash
mkdir -p /tmp/x/orig && mv /tmp/x/orig /tmp/x/renamed && touch /tmp/x/orig
```

Then invoke `Shell.exec()` with the stale `cwd=/tmp/x/orig`:

| | exit code | stderr |
|---|---|---|
| Before | 126 | `ENOTDIR: not a directory, posix_spawn '/usr/bin/zsh'` |
| After  | 0   | _(empty — cwd transparently recovered to originalCwd)_ |

## Test plan

- [x] `bun run build` succeeds
- [x] Direct repro of the reported failure (`ENOTDIR … exit 126`) confirmed against `main`; confirmed fixed by this change
- [x] `bun test` — same pass/fail counts with and without this change (the pre-existing model/provider test failures on `main` are unrelated)
- [x] Scoped Shell/BashTool tests: 13 pass, 0 fail