### PR TITLE
fix(mcp): disable MCP_SKILLS feature flag — source not mirrored

### DIFF
--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -34,6 +34,7 @@ const featureFlags: Record<string, boolean> = {
   WEB_BROWSER_TOOL: false,        // Built-in browser automation (source not mirrored)
   CHICAGO_MCP: false,             // Computer-use MCP (native Swift modules stubbed)
   COWORKER_TYPE_TELEMETRY: false, // Telemetry for agent/coworker type classification
+  MCP_SKILLS: false,              // Dynamic MCP skill discovery (src/skills/mcpSkills.ts not mirrored; enabling this causes "fetchMcpSkillsForClient is not a function" when MCP servers with resources connect — see #856)
 
   // ── Enabled: upstream defaults ──────────────────────────────────────
   COORDINATOR_MODE: true,             // Multi-agent coordinator with worker delegation
@@ -56,7 +57,6 @@ const featureFlags: Record<string, boolean> = {
   EXTRACT_MEMORIES: true,             // Auto-extract durable memories from conversations
   FORK_SUBAGENT: true,                // Implicit context-forking when omitting subagent_type
   VERIFICATION_AGENT: true,           // Built-in read-only agent for test/verification
-  MCP_SKILLS: true,                   // Discover skills dynamically from MCP server resources
   PROMPT_CACHE_BREAK_DETECTION: true, // Detect & log unexpected prompt cache invalidations
   HOOK_PROMPTS: true,                 // Allow tools to request interactive user prompts
 }

--- a/scripts/feature-flags-source-guard.test.ts
+++ b/scripts/feature-flags-source-guard.test.ts
@@ -1,0 +1,47 @@
+import { existsSync, readFileSync } from 'fs'
+import { join } from 'path'
+import { expect, test } from 'bun:test'
+
+// Regression guard for #856. Several build feature flags require source files
+// that are not mirrored into the open build. When such a flag is set to `true`
+// without the source present, the bundler falls back to a missing-module stub
+// that only exports `default`, which causes runtime errors like
+// `fetchMcpSkillsForClient is not a function` when downstream code reaches
+// through the `require()` to a named export.
+//
+// This test fails fast at test-time if someone re-enables one of these flags
+// without first mirroring the corresponding source file.
+
+const BUILD_SCRIPT = join(import.meta.dir, 'build.ts')
+const REPO_ROOT = join(import.meta.dir, '..')
+
+type FlagGuard = {
+  flag: string
+  source: string // path relative to repo root
+}
+
+const FLAG_REQUIRES_SOURCE: FlagGuard[] = [
+  { flag: 'MCP_SKILLS', source: 'src/skills/mcpSkills.ts' },
+]
+
+test('build feature flags are not enabled without their source files', () => {
+  const buildScript = readFileSync(BUILD_SCRIPT, 'utf-8')
+
+  for (const { flag, source } of FLAG_REQUIRES_SOURCE) {
+    const enabledRe = new RegExp(`^\\s*${flag}\\s*:\\s*true\\b`, 'm')
+    const isEnabled = enabledRe.test(buildScript)
+    const sourceExists = existsSync(join(REPO_ROOT, source))
+
+    if (isEnabled && !sourceExists) {
+      throw new Error(
+        `Feature flag ${flag} is enabled in scripts/build.ts, but its required source file "${source}" does not exist. ` +
+          `Enabling this flag without the source will cause runtime errors (missing named exports from the missing-module stub). ` +
+          `Either mirror the source file or set ${flag}: false.`,
+      )
+    }
+
+    // When the source IS present, the flag can be either true or false; either
+    // is fine. We only care about the "enabled but missing" combination.
+    expect(true).toBe(true)
+  }
+})


### PR DESCRIPTION
## Summary

Fixes #856. Disable the `MCP_SKILLS` build feature flag so MCP servers with resources (RepoPrompt, and any other server that exposes `resources.listChanged`) load their tools correctly in headless and interactive sessions.

Credit: diagnosis was basically done by the reporter (@wuxianliang) in the issue — they pointed straight at `../../skills/mcpSkills.js` being stubbed while the named export was still being called. cc @kevincodex1 who picked this one up on triage.

## Problem

MCP servers that report `resources` capabilities failed during post-connect tool loading:

```
MCP server "RepoPrompt": Successfully connected (transport: stdio)
MCP server "RepoPrompt": Connection established with capabilities: {"hasTools":true,"hasPrompts":true,"hasResources":true,...}
MCP server "RepoPrompt": Error fetching tools/commands/resources: fetchMcpSkillsForClient is not a function
```

`openclaude mcp doctor <server>` still reported the server as healthy, because the doctor command does not exercise the skills-fetch path — only connection + handshake.

## Root Cause

1. `scripts/build.ts` had `MCP_SKILLS: true` in the feature-flag map.
2. The feature-flag pre-processor inlines each `feature('MCP_SKILLS')` call site with the literal `true`, so the guards stayed live:
   ```ts
   const fetchMcpSkillsForClient = feature('MCP_SKILLS')
     ? (require('../../skills/mcpSkills.js') as typeof import('../../skills/mcpSkills.js'))
         .fetchMcpSkillsForClient
     : null
   ```
3. The source file `src/skills/mcpSkills.ts` is **not** mirrored into the open build tree. The bundler falls back to its generic missing-module-stub handler, which for `require()`-style imports only emits a `default` export:
   ```js
   // missing-module-stub:../../skills/mcpSkills.js
   var noop = () => null, mcpSkills_default = noop;
   ```
4. The downstream destructure `.fetchMcpSkillsForClient` resolves to `undefined`. Every call site then invoked `fetchMcpSkillsForClient!(client)` (or `.cache.delete(...)`) → `TypeError: is not a function`.

Every call site was already defensively guarded with `if (feature('MCP_SKILLS'))` / `feature('MCP_SKILLS') ? ... : Promise.resolve([])`, so the fix is simply to flip the flag.

## Fix

- `scripts/build.ts`: set `MCP_SKILLS: false` and move the entry into the existing "Disabled: require Anthropic infrastructure or missing source" group, so the intent matches the neighbors.
- No changes to runtime code. All call sites remain defensively guarded; with `feature('MCP_SKILLS')` now inlined as `false`, the entire `require()` path becomes dead code and the `Promise.resolve([])` / skip branches take over.

## Files Changed

- `scripts/build.ts` — flip `MCP_SKILLS` to `false`, move to disabled-missing-source group, explain in-line.
- `scripts/feature-flags-source-guard.test.ts` _(new)_ — regression test that fails if any feature flag in the "requires mirrored source" list is re-enabled without the source file present. Keeps future flag flips honest.

## Verification

**Automated**
- [x] New regression test `build feature flags are not enabled without their source files` — fails on `main`, passes with this fix
- [x] Full test suite: 1222 pass / 12 fail (same 12 pre-existing failures as `main`; the +1 pass is the new test)
- [x] Build passes
- [x] Bundled `dist/cli.mjs` no longer contains `missing-module-stub:../../skills/mcpSkills.js` — the dead-code branch is eliminated entirely

**Manual**
- Reproduction of the runtime error requires an MCP server that advertises `resources` capabilities (RepoPrompt in the reporter's case). I don't have RepoPrompt set up locally; asking @wuxianliang to verify on their setup before merge.

## Risk / Side Effects

None expected. Dynamic skill discovery from MCP resources was already non-functional in every release of the open build (the require path has always returned a stub without the named export). Turning the flag off just causes the code to skip the path cleanly instead of throwing. Any user who relied on MCP skills being populated via this path was already seeing 0 skills.

If `src/skills/mcpSkills.ts` is ever mirrored into the open tree in a follow-up, re-enabling the flag is a one-line change and the new regression test will automatically allow it.

## How to Test This PR Locally

```bash
gh pr checkout <this PR number>
bun install
bun run build

# Test 1 — regression test
bun test scripts/feature-flags-source-guard.test.ts

# Test 2 — reporter's original repro
openclaude mcp doctor RepoPrompt   # still reports healthy
openclaude --debug-file /tmp/openclaude-headless.log -p --output-format stream-json \
  --verbose --max-turns 1 "say ok in one word"
# Confirm RepoPrompt init event marks it connected, tools are listed, and the
# debug log no longer contains "fetchMcpSkillsForClient is not a function".
```

## Screenshots / Logs

Before, in the reporter's debug log:
```
MCP server "RepoPrompt": Error fetching tools/commands/resources: fetchMcpSkillsForClient is not a function
```

After (expected, pending reporter verification): connection + capabilities logged, no such error line.

## Checklist

- [x] Linked the issue (#856)
- [x] Wrote a regression test
- [x] Verified locally (build + bundle + test suite)
- [ ] Reporter verification on affected setup — requested
- [x] No new dependencies
- [x] No Anthropic fingerprints / network leaks introduced
- [x] Self-reviewed the diff