### PR TITLE
Add sponsors section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,25 @@ Use OpenAI-compatible APIs, Gemini, GitHub Models, Codex OAuth, Codex, Ollama, A
 OpenClaude is also mirrored to GitLawb:
 [gitlawb.com/node/repos/z6MkqDnb/openclaude](https://gitlawb.com/node/repos/z6MkqDnb/openclaude)
 
-[Quick Start](#quick-start) | [Setup Guides](#setup-guides) | [Providers](#supported-providers) | [Source Build](#source-build-and-local-development) | [VS Code Extension](#vs-code-extension) | [Community](#community)
+[Quick Start](#quick-start) | [Setup Guides](#setup-guides) | [Providers](#supported-providers) | [Source Build](#source-build-and-local-development) | [VS Code Extension](#vs-code-extension) | [Sponsors](#sponsors) | [Community](#community)
+
+## Sponsors
+
+<p align="center">
+  <a href="https://gitlawb.com">
+    <img src="https://gitlawb.com/logo.png" alt="GitLawb logo" width="96">
+  </a>
+  &nbsp;&nbsp;&nbsp;&nbsp;
+  <a href="https://bankr.bot">
+    <img src="https://bankr.bot/favicon.svg" alt="Bankr.bot logo" width="96">
+  </a>
+</p>
+
+<p align="center">
+  <a href="https://gitlawb.com"><strong>GitLawb</strong></a>
+  &nbsp;&nbsp;&nbsp;&nbsp;
+  <a href="https://bankr.bot"><strong>Bankr.bot</strong></a>
+</p>
 
 ## Star History
 


### PR DESCRIPTION
## Summary

  - Added a Sponsors section to the README with linked GitLawb and Bankr.bot logos.
  - Added the Sponsors anchor to the README top navigation so the section is easy to find.

  ## Impact

  - user-facing impact: README visitors can see and click through to the project sponsors.
  - developer/maintainer impact: Documentation-only change; no runtime or build behavior changes.

  ## Testing

  - [ ] `bun run build`
  - [ ] `bun run smoke`
  - [x] focused tests: verified the README diff and confirmed the sponsor logo URLs resolve.

  ## Notes

  - provider/model path tested: not applicable.
  - screenshots attached (if UI changed): not applicable; README-only change.
  - follow-up work or known limitations: uses externally hosted sponsor logo URLs.