### PR TITLE
Add DeepSeek V4 flash/pro support and DeepSeek thinking compatibility

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -145,6 +145,11 @@ ANTHROPIC_API_KEY=sk-ant-your-key-here
 # CLAUDE_CODE_USE_OPENAI=1
 # OPENAI_API_KEY=sk-your-key-here
 # OPENAI_MODEL=gpt-4o
+# For DeepSeek, set:
+# OPENAI_BASE_URL=https://api.deepseek.com/v1
+# OPENAI_MODEL=deepseek-v4-flash
+# Optional: OPENAI_MODEL=deepseek-v4-pro
+# Legacy aliases also work: deepseek-chat and deepseek-reasoner
 
 # Use a custom OpenAI-compatible endpoint (optional — defaults to api.openai.com)
 # OPENAI_BASE_URL=https://api.openai.com/v1

--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ Add to `~/.claude/settings.json`:
 ```json
 {
   "agentModels": {
-    "deepseek-chat": {
+    "deepseek-v4-flash": {
       "base_url": "https://api.deepseek.com/v1",
       "api_key": "sk-your-key"
     },
@@ -167,10 +167,10 @@ Add to `~/.claude/settings.json`:
     }
   },
   "agentRouting": {
-    "Explore": "deepseek-chat",
+    "Explore": "deepseek-v4-flash",
     "Plan": "gpt-4o",
     "general-purpose": "gpt-4o",
-    "frontend-dev": "deepseek-chat",
+    "frontend-dev": "deepseek-v4-flash",
     "default": "gpt-4o"
   }
 }

--- a/docs/advanced-setup.md
+++ b/docs/advanced-setup.md
@@ -68,8 +68,10 @@ openclaude
 export CLAUDE_CODE_USE_OPENAI=1
 export OPENAI_API_KEY=sk-...
 export OPENAI_BASE_URL=https://api.deepseek.com/v1
-export OPENAI_MODEL=deepseek-chat
+export OPENAI_MODEL=deepseek-v4-flash
 ```
+
+Use `deepseek-v4-pro` when you want the stronger model. `deepseek-chat` and `deepseek-reasoner` remain available as DeepSeek's legacy API aliases.
 
 ### Google Gemini via OpenRouter
 
@@ -169,7 +171,7 @@ export OPENAI_MODEL=gpt-4o
 |----------|----------|-------------|
 | `CLAUDE_CODE_USE_OPENAI` | Yes | Set to `1` to enable the OpenAI provider |
 | `OPENAI_API_KEY` | Yes* | Your API key (`*` not needed for local models like Ollama or Atomic Chat) |
-| `OPENAI_MODEL` | Yes | Model name such as `gpt-4o`, `deepseek-chat`, or `llama3.3:70b` |
+| `OPENAI_MODEL` | Yes | Model name such as `gpt-4o`, `deepseek-v4-flash`, or `llama3.3:70b` |
 | `OPENAI_BASE_URL` | No | API endpoint, defaulting to `https://api.openai.com/v1` |
 | `CODEX_API_KEY` | Codex only | Codex or ChatGPT access token override |
 | `CODEX_AUTH_JSON_PATH` | Codex only | Path to a Codex CLI `auth.json` file |

--- a/docs/quick-start-mac-linux.md
+++ b/docs/quick-start-mac-linux.md
@@ -41,10 +41,12 @@ openclaude
 export CLAUDE_CODE_USE_OPENAI=1
 export OPENAI_API_KEY=sk-your-key-here
 export OPENAI_BASE_URL=https://api.deepseek.com/v1
-export OPENAI_MODEL=deepseek-chat
+export OPENAI_MODEL=deepseek-v4-flash
 
 openclaude
 ```
+
+Use `deepseek-v4-pro` when you want the stronger model. `deepseek-chat` and `deepseek-reasoner` still work as DeepSeek's legacy API aliases.
 
 ### Option C: Ollama
 

--- a/docs/quick-start-windows.md
+++ b/docs/quick-start-windows.md
@@ -41,10 +41,12 @@ openclaude
 $env:CLAUDE_CODE_USE_OPENAI="1"
 $env:OPENAI_API_KEY="sk-your-key-here"
 $env:OPENAI_BASE_URL="https://api.deepseek.com/v1"
-$env:OPENAI_MODEL="deepseek-chat"
+$env:OPENAI_MODEL="deepseek-v4-flash"
 
 openclaude
 ```
+
+Use `deepseek-v4-pro` when you want the stronger model. `deepseek-chat` and `deepseek-reasoner` still work as DeepSeek's legacy API aliases.
 
 ### Option C: Ollama
 

--- a/src/components/ProviderManager.test.tsx
+++ b/src/components/ProviderManager.test.tsx
@@ -151,6 +151,7 @@ function createDeferred<T>(): {
 
 function mockProviderProfilesModule(options?: {
   addProviderProfile?: (...args: unknown[]) => unknown
+  getActiveProviderProfile?: () => unknown
   getProviderProfiles?: () => unknown[]
   updateProviderProfile?: (...args: unknown[]) => unknown
   setActiveProviderProfile?: (...args: unknown[]) => unknown
@@ -159,7 +160,7 @@ function mockProviderProfilesModule(options?: {
     addProviderProfile: options?.addProviderProfile ?? (() => null),
     applyActiveProviderProfileFromConfig: () => {},
     deleteProviderProfile: () => ({ removed: false, activeProfileId: null }),
-    getActiveProviderProfile: () => null,
+    getActiveProviderProfile: options?.getActiveProviderProfile ?? (() => null),
     getProviderPresetDefaults: (preset: string) =>
       preset === 'ollama'
         ? {
@@ -189,6 +190,7 @@ function mockProviderManagerDependencies(
     addProviderProfile?: (...args: unknown[]) => unknown
     applySavedProfileToCurrentSession?: (...args: unknown[]) => Promise<string | null>
     clearCodexCredentials?: () => { success: boolean; warning?: string }
+    getActiveProviderProfile?: () => unknown
     getProviderProfiles?: () => unknown[]
     probeOllamaGenerationReadiness?: () => Promise<{
       state: 'ready' | 'unreachable' | 'no_models' | 'generation_failed'
@@ -228,6 +230,7 @@ function mockProviderManagerDependencies(
 ): void {
   mockProviderProfilesModule({
     addProviderProfile: options?.addProviderProfile,
+    getActiveProviderProfile: options?.getActiveProviderProfile,
     getProviderProfiles: options?.getProviderProfiles,
     updateProviderProfile: options?.updateProviderProfile,
     setActiveProviderProfile: options?.setActiveProviderProfile,
@@ -330,6 +333,10 @@ async function mountProviderManager(
   options?: {
     mode?: 'first-run' | 'manage'
     onDone?: (result?: unknown) => void
+    onChangeAppState?: (args: {
+      newState: unknown
+      oldState: unknown
+    }) => void
   },
 ): Promise<{
   stdin: PassThrough
@@ -344,7 +351,7 @@ async function mountProviderManager(
   })
 
   root.render(
-    <AppStateProvider>
+    <AppStateProvider onChangeAppState={options?.onChangeAppState}>
       <KeybindingSetup>
         <ProviderManager
           mode={options?.mode ?? 'manage'}
@@ -902,6 +909,205 @@ test('ProviderManager keeps Codex OAuth as next-startup only when activating the
   )
   expect(applySavedProfileToCurrentSession).toHaveBeenCalled()
   expect(setActiveProviderProfile).toHaveBeenCalledWith('provider_codex_oauth')
+
+  await mounted.dispose()
+})
+
+test('ProviderManager activating a multi-model provider sets the session model to the primary model', async () => {
+  delete process.env.CLAUDE_CODE_SIMPLE
+  delete process.env.CLAUDE_CODE_USE_GITHUB
+  delete process.env.GITHUB_TOKEN
+  delete process.env.GH_TOKEN
+
+  const multiModelProfile = {
+    id: 'provider_multi_model',
+    provider: 'openai',
+    name: 'Multi Model Provider',
+    baseUrl: 'https://api.openai.com/v1',
+    model: 'gpt-5.4; gpt-5.4-mini',
+    apiKey: 'sk-test',
+  }
+
+  const setActiveProviderProfile = mock(() => multiModelProfile)
+  const appStateChanges: Array<{ newState: any; oldState: any }> = []
+
+  mockProviderManagerDependencies(
+    () => undefined,
+    async () => undefined,
+    {
+      getProviderProfiles: () => [multiModelProfile],
+      setActiveProviderProfile,
+    },
+  )
+
+  const nonce = `${Date.now()}-${Math.random()}`
+  const { ProviderManager } = await import(`./ProviderManager.js?ts=${nonce}`)
+  const mounted = await mountProviderManager(ProviderManager, {
+    onChangeAppState: args => {
+      appStateChanges.push(args as { newState: any; oldState: any })
+    },
+  })
+
+  await waitForFrameOutput(
+    mounted.getOutput,
+    frame =>
+      frame.includes('Provider manager') &&
+      frame.includes('Set active provider'),
+  )
+
+  mounted.stdin.write('j')
+  await Bun.sleep(25)
+  mounted.stdin.write('\r')
+
+  await waitForFrameOutput(
+    mounted.getOutput,
+    frame =>
+      frame.includes('Set active provider') &&
+      frame.includes('Multi Model Provider'),
+  )
+
+  await Bun.sleep(25)
+  mounted.stdin.write('\r')
+
+  await waitForCondition(() => setActiveProviderProfile.mock.calls.length > 0)
+  await waitForCondition(() =>
+    appStateChanges.some(
+      ({ newState, oldState }) =>
+        newState.mainLoopModel === 'gpt-5.4' &&
+        oldState.mainLoopModel !== newState.mainLoopModel,
+    ),
+  )
+
+  expect(setActiveProviderProfile).toHaveBeenCalledWith('provider_multi_model')
+  expect(
+    appStateChanges.some(
+      ({ newState }) =>
+        newState.mainLoopModel === 'gpt-5.4' &&
+        newState.mainLoopModelForSession === null,
+    ),
+  ).toBe(true)
+  expect(
+    appStateChanges.some(
+      ({ newState }) => newState.mainLoopModel === 'gpt-5.4; gpt-5.4-mini',
+    ),
+  ).toBe(false)
+
+  await mounted.dispose()
+})
+
+test('ProviderManager editing an active multi-model provider keeps app state on the primary model', async () => {
+  delete process.env.CLAUDE_CODE_SIMPLE
+  delete process.env.CLAUDE_CODE_USE_GITHUB
+  delete process.env.GITHUB_TOKEN
+  delete process.env.GH_TOKEN
+
+  const multiModelProfile = {
+    id: 'provider_multi_model',
+    provider: 'openai',
+    name: 'Multi Model Provider',
+    baseUrl: 'https://api.openai.com/v1',
+    model: 'gpt-5.4; gpt-5.4-mini',
+    apiKey: 'sk-test',
+  }
+
+  const updateProviderProfile = mock(() => multiModelProfile)
+  const appStateChanges: Array<{ newState: any; oldState: any }> = []
+
+  mockProviderManagerDependencies(
+    () => undefined,
+    async () => undefined,
+    {
+      getActiveProviderProfile: () => multiModelProfile,
+      getProviderProfiles: () => [multiModelProfile],
+      updateProviderProfile,
+    },
+  )
+
+  const nonce = `${Date.now()}-${Math.random()}`
+  const { ProviderManager } = await import(`./ProviderManager.js?ts=${nonce}`)
+  const mounted = await mountProviderManager(ProviderManager, {
+    onChangeAppState: args => {
+      appStateChanges.push(args as { newState: any; oldState: any })
+    },
+  })
+
+  await waitForFrameOutput(
+    mounted.getOutput,
+    frame =>
+      frame.includes('Provider manager') &&
+      frame.includes('Edit provider'),
+  )
+
+  mounted.stdin.write('j')
+  await Bun.sleep(25)
+  mounted.stdin.write('j')
+  await Bun.sleep(25)
+  mounted.stdin.write('\r')
+
+  await waitForFrameOutput(
+    mounted.getOutput,
+    frame =>
+      frame.includes('Edit provider') &&
+      frame.includes('Multi Model Provider'),
+  )
+
+  await Bun.sleep(25)
+  mounted.stdin.write('\r')
+
+  await waitForFrameOutput(
+    mounted.getOutput,
+    frame =>
+      frame.includes('Edit provider profile') &&
+      frame.includes('Step 1 of 4'),
+  )
+
+  mounted.stdin.write('\r')
+  await waitForFrameOutput(
+    mounted.getOutput,
+    frame => frame.includes('Step 2 of 4'),
+  )
+
+  mounted.stdin.write('\r')
+  await waitForFrameOutput(
+    mounted.getOutput,
+    frame => frame.includes('Step 3 of 4'),
+  )
+
+  mounted.stdin.write('\r')
+  await waitForFrameOutput(
+    mounted.getOutput,
+    frame => frame.includes('Step 4 of 4'),
+  )
+
+  mounted.stdin.write('\r')
+
+  await waitForCondition(() => updateProviderProfile.mock.calls.length > 0)
+  await waitForCondition(() =>
+    appStateChanges.some(
+      ({ newState, oldState }) =>
+        newState.mainLoopModel === 'gpt-5.4' &&
+        oldState.mainLoopModel !== newState.mainLoopModel,
+    ),
+  )
+
+  expect(updateProviderProfile).toHaveBeenCalledWith(
+    'provider_multi_model',
+    expect.objectContaining({
+      model: 'gpt-5.4; gpt-5.4-mini',
+    }),
+  )
+  expect(
+    appStateChanges.some(
+      ({ newState }) =>
+        newState.mainLoopModel === 'gpt-5.4' &&
+        newState.mainLoopModelForSession === null,
+    ),
+  ).toBe(true)
+  expect(
+    appStateChanges.some(
+      ({ newState }) => newState.mainLoopModel === 'gpt-5.4; gpt-5.4-mini',
+    ),
+  ).toBe(false)
 
   await mounted.dispose()
 })

--- a/src/components/ProviderManager.tsx
+++ b/src/components/ProviderManager.tsx
@@ -125,8 +125,8 @@ const FORM_STEPS: Array<{
   {
     key: 'model',
     label: 'Default model',
-    placeholder: 'e.g. llama3.1:8b or glm-4.7, glm-4.7-flash',
-    helpText: 'Model name(s) to use. Separate multiple with commas; first is default.',
+    placeholder: 'e.g. llama3.1:8b or glm-4.7; glm-4.7-flash',
+    helpText: 'Model name(s) to use. Separate multiple with ";" or ","; first is default.',
   },
   {
     key: 'apiKey',
@@ -780,19 +780,14 @@ export function ProviderManager({ mode, onDone }: Props): React.ReactNode {
       // Update the session model to the new provider's first model.
       // persistActiveProviderProfileModel (called by onChangeAppState) will
       // not overwrite the multi-model list because it checks if the model
-      // is already in the profile's comma-separated model list.
+      // is already in the provider's configured model list.
       const newModel = getPrimaryModel(active.model)
       setAppState(prev => ({
         ...prev,
         mainLoopModel: newModel,
-      }))
-
-      providerLabel = active.name
-      setAppState(prev => ({
-        ...prev,
-        mainLoopModel: active.model,
         mainLoopModelForSession: null,
       }))
+      providerLabel = active.name
       const settingsOverrideError =
         clearStartupProviderOverrideFromUserSettings()
       const isActiveCodexOAuth = isCodexOAuthProfile(
@@ -996,7 +991,7 @@ export function ProviderManager({ mode, onDone }: Props): React.ReactNode {
     if (isActiveSavedProfile) {
       setAppState(prev => ({
         ...prev,
-        mainLoopModel: saved.model,
+        mainLoopModel: getPrimaryModel(saved.model),
         mainLoopModelForSession: null,
       }))
     }

--- a/src/services/api/openaiShim.test.ts
+++ b/src/services/api/openaiShim.test.ts
@@ -3415,10 +3415,7 @@ test('Moonshot: echoes reasoning_content on assistant tool-call messages', async
   )
 })
 
-test('non-Moonshot providers do NOT receive reasoning_content on assistant messages', async () => {
-  // Guard: only Moonshot opts in. DeepSeek/OpenRouter/etc. receive the
-  // outgoing assistant message without reasoning_content to avoid
-  // unknown-field rejections from strict servers.
+test('DeepSeek echoes reasoning_content on assistant tool-call messages', async () => {
   process.env.OPENAI_BASE_URL = 'https://api.deepseek.com/v1'
   process.env.OPENAI_API_KEY = 'sk-deepseek'
 
@@ -3428,7 +3425,7 @@ test('non-Moonshot providers do NOT receive reasoning_content on assistant messa
     return new Response(
       JSON.stringify({
         id: 'chatcmpl-1',
-        model: 'deepseek-chat',
+        model: 'deepseek-v4-flash',
         choices: [
           { message: { role: 'assistant', content: 'ok' }, finish_reason: 'stop' },
         ],
@@ -3440,7 +3437,7 @@ test('non-Moonshot providers do NOT receive reasoning_content on assistant messa
 
   const client = createOpenAIShimClient({}) as OpenAIShimClient
   await client.beta.messages.create({
-    model: 'deepseek-chat',
+    model: 'deepseek-v4-flash',
     system: 'test',
     messages: [
       { role: 'user', content: 'hi' },
@@ -3473,7 +3470,7 @@ test('non-Moonshot providers do NOT receive reasoning_content on assistant messa
     m => m.role === 'assistant' && Array.isArray(m.tool_calls),
   )
   expect(assistantWithToolCall).toBeDefined()
-  expect(assistantWithToolCall?.reasoning_content).toBeUndefined()
+  expect(assistantWithToolCall?.reasoning_content).toBe('thought')
 })
 
 test('Moonshot: cn host is also detected', async () => {
@@ -3506,6 +3503,112 @@ test('Moonshot: cn host is also detected', async () => {
   })
 
   expect(requestBody?.store).toBeUndefined()
+})
+
+test('DeepSeek sends thinking toggle and normalized reasoning effort', async () => {
+  process.env.OPENAI_BASE_URL = 'https://api.deepseek.com/v1'
+  process.env.OPENAI_API_KEY = 'sk-deepseek'
+
+  let requestBody: Record<string, unknown> | undefined
+  globalThis.fetch = (async (_input, init) => {
+    requestBody = JSON.parse(String(init?.body))
+    return new Response(
+      JSON.stringify({
+        id: 'chatcmpl-1',
+        model: 'deepseek-v4-pro',
+        choices: [
+          { message: { role: 'assistant', content: 'ok' }, finish_reason: 'stop' },
+        ],
+        usage: { prompt_tokens: 3, completion_tokens: 1, total_tokens: 4 },
+      }),
+      { headers: { 'Content-Type': 'application/json' } },
+    )
+  }) as FetchType
+
+  const client = createOpenAIShimClient({
+    reasoningEffort: 'xhigh',
+  }) as OpenAIShimClient
+  await client.beta.messages.create({
+    model: 'deepseek-v4-pro',
+    system: 'test',
+    messages: [{ role: 'user', content: 'hi' }],
+    max_tokens: 64,
+    stream: false,
+    thinking: { type: 'enabled' },
+  })
+
+  expect(requestBody?.thinking).toEqual({ type: 'enabled' })
+  expect(requestBody?.reasoning_effort).toBe('max')
+  expect(requestBody?.max_tokens).toBe(64)
+  expect(requestBody?.max_completion_tokens).toBeUndefined()
+  expect(requestBody?.store).toBeUndefined()
+})
+
+test('DeepSeek omits thinking controls when the Anthropic-side request does not set them', async () => {
+  process.env.OPENAI_BASE_URL = 'https://api.deepseek.com/v1'
+  process.env.OPENAI_API_KEY = 'sk-deepseek'
+
+  let requestBody: Record<string, unknown> | undefined
+  globalThis.fetch = (async (_input, init) => {
+    requestBody = JSON.parse(String(init?.body))
+    return new Response(
+      JSON.stringify({
+        id: 'chatcmpl-1',
+        model: 'deepseek-v4-flash',
+        choices: [
+          { message: { role: 'assistant', content: 'ok' }, finish_reason: 'stop' },
+        ],
+        usage: { prompt_tokens: 3, completion_tokens: 1, total_tokens: 4 },
+      }),
+      { headers: { 'Content-Type': 'application/json' } },
+    )
+  }) as FetchType
+
+  const client = createOpenAIShimClient({}) as OpenAIShimClient
+  await client.beta.messages.create({
+    model: 'deepseek-v4-flash',
+    system: 'test',
+    messages: [{ role: 'user', content: 'hi' }],
+    max_tokens: 32,
+    stream: false,
+  })
+
+  expect(requestBody?.thinking).toBeUndefined()
+  expect(requestBody?.reasoning_effort).toBeUndefined()
+})
+
+test('DeepSeek forwards an explicit thinking disable toggle for V4 models', async () => {
+  process.env.OPENAI_BASE_URL = 'https://api.deepseek.com/v1'
+  process.env.OPENAI_API_KEY = 'sk-deepseek'
+
+  let requestBody: Record<string, unknown> | undefined
+  globalThis.fetch = (async (_input, init) => {
+    requestBody = JSON.parse(String(init?.body))
+    return new Response(
+      JSON.stringify({
+        id: 'chatcmpl-1',
+        model: 'deepseek-v4-flash',
+        choices: [
+          { message: { role: 'assistant', content: 'ok' }, finish_reason: 'stop' },
+        ],
+        usage: { prompt_tokens: 3, completion_tokens: 1, total_tokens: 4 },
+      }),
+      { headers: { 'Content-Type': 'application/json' } },
+    )
+  }) as FetchType
+
+  const client = createOpenAIShimClient({}) as OpenAIShimClient
+  await client.beta.messages.create({
+    model: 'deepseek-v4-flash',
+    system: 'test',
+    messages: [{ role: 'user', content: 'hi' }],
+    max_tokens: 32,
+    stream: false,
+    thinking: { type: 'disabled' },
+  })
+
+  expect(requestBody?.thinking).toEqual({ type: 'disabled' })
+  expect(requestBody?.reasoning_effort).toBeUndefined()
 })
 
 

--- a/src/services/api/openaiShim.test.ts
+++ b/src/services/api/openaiShim.test.ts
@@ -3473,6 +3473,64 @@ test('DeepSeek echoes reasoning_content on assistant tool-call messages', async 
   expect(assistantWithToolCall?.reasoning_content).toBe('thought')
 })
 
+test('generic OpenAI-compatible providers do not echo reasoning_content on assistant tool-call messages', async () => {
+  process.env.OPENAI_BASE_URL = 'https://api.openai.com/v1'
+  process.env.OPENAI_API_KEY = 'sk-openai-test'
+
+  let requestBody: Record<string, unknown> | undefined
+  globalThis.fetch = (async (_input, init) => {
+    requestBody = JSON.parse(String(init?.body))
+    return new Response(
+      JSON.stringify({
+        id: 'chatcmpl-1',
+        model: 'gpt-4o',
+        choices: [
+          { message: { role: 'assistant', content: 'ok' }, finish_reason: 'stop' },
+        ],
+        usage: { prompt_tokens: 3, completion_tokens: 1, total_tokens: 4 },
+      }),
+      { headers: { 'Content-Type': 'application/json' } },
+    )
+  }) as FetchType
+
+  const client = createOpenAIShimClient({}) as OpenAIShimClient
+  await client.beta.messages.create({
+    model: 'gpt-4o',
+    system: 'test',
+    messages: [
+      { role: 'user', content: 'hi' },
+      {
+        role: 'assistant',
+        content: [
+          { type: 'thinking', thinking: 'thought' },
+          { type: 'text', text: 'hello' },
+          {
+            type: 'tool_use',
+            id: 'call_1',
+            name: 'Bash',
+            input: { command: 'ls' },
+          },
+        ],
+      },
+      {
+        role: 'user',
+        content: [
+          { type: 'tool_result', tool_use_id: 'call_1', content: 'files' },
+        ],
+      },
+    ],
+    max_tokens: 32,
+    stream: false,
+  })
+
+  const messages = requestBody?.messages as Array<Record<string, unknown>>
+  const assistantWithToolCall = messages.find(
+    m => m.role === 'assistant' && Array.isArray(m.tool_calls),
+  )
+  expect(assistantWithToolCall).toBeDefined()
+  expect(assistantWithToolCall?.reasoning_content).toBeUndefined()
+})
+
 test('Moonshot: cn host is also detected', async () => {
   process.env.OPENAI_BASE_URL = 'https://api.moonshot.cn/v1'
   process.env.OPENAI_API_KEY = 'sk-moonshot-test'

--- a/src/services/api/openaiShim.ts
+++ b/src/services/api/openaiShim.ts
@@ -88,6 +88,9 @@ const MOONSHOT_API_HOSTS = new Set([
   'api.moonshot.ai',
   'api.moonshot.cn',
 ])
+const DEEPSEEK_API_HOSTS = new Set([
+  'api.deepseek.com',
+])
 
 const COPILOT_HEADERS: Record<string, string> = {
   'User-Agent': 'GitHubCopilotChat/0.26.7',
@@ -160,6 +163,21 @@ function isMoonshotBaseUrl(baseUrl: string | undefined): boolean {
   } catch {
     return false
   }
+}
+
+function isDeepSeekBaseUrl(baseUrl: string | undefined): boolean {
+  if (!baseUrl) return false
+  try {
+    return DEEPSEEK_API_HOSTS.has(new URL(baseUrl).hostname.toLowerCase())
+  } catch {
+    return false
+  }
+}
+
+function normalizeDeepSeekReasoningEffort(
+  effort: 'low' | 'medium' | 'high' | 'xhigh',
+): 'high' | 'max' {
+  return effort === 'xhigh' ? 'max' : 'high'
 }
 
 function formatRetryAfterHint(response: Response): string {
@@ -1487,9 +1505,11 @@ class OpenAIShimMessages {
     )
     const openaiMessages = convertMessages(compressedMessages, params.system, {
       // Moonshot requires every assistant tool-call message to carry
-      // reasoning_content when its thinking feature is active. Echo it back
-      // from the thinking block we captured on the inbound response.
-      preserveReasoningContent: isMoonshotBaseUrl(request.baseUrl),
+      // reasoning_content when its thinking feature is active. DeepSeek does
+      // the same for tool-call turns in thinking mode. Echo it back from the
+      // thinking block we captured on the inbound response.
+      preserveReasoningContent:
+        isMoonshotBaseUrl(request.baseUrl) || isDeepSeekBaseUrl(request.baseUrl),
     })
 
     const body: Record<string, unknown> = {
@@ -1527,8 +1547,9 @@ class OpenAIShimMessages {
     const isGithubModels = isGithub && (githubEndpointType === 'models' || githubEndpointType === 'custom')
 
     const isMoonshot = isMoonshotBaseUrl(request.baseUrl)
+    const isDeepSeek = isDeepSeekBaseUrl(request.baseUrl)
 
-    if ((isGithub || isMistral || isLocal || isMoonshot) && body.max_completion_tokens !== undefined) {
+    if ((isGithub || isMistral || isLocal || isMoonshot || isDeepSeek) && body.max_completion_tokens !== undefined) {
       body.max_tokens = body.max_completion_tokens
       delete body.max_completion_tokens
     }
@@ -1538,12 +1559,33 @@ class OpenAIShimMessages {
     // Moonshot (api.moonshot.ai/.cn) has not published support for the
     // parameter either; strip it preemptively to avoid the same class of
     // error on strict-parse providers.
-    if (isMistral || isGeminiMode() || isMoonshot) {
+    if (isMistral || isGeminiMode() || isMoonshot || isDeepSeek) {
       delete body.store
     }
 
     if (params.temperature !== undefined) body.temperature = params.temperature
     if (params.top_p !== undefined) body.top_p = params.top_p
+
+    if (isDeepSeek) {
+      const requestedThinkingType = (params.thinking as { type?: string } | undefined)?.type
+      const deepSeekThinkingType =
+        requestedThinkingType === 'disabled'
+          ? 'disabled'
+          : requestedThinkingType === 'enabled' || requestedThinkingType === 'adaptive'
+            ? 'enabled'
+            : undefined
+
+      if (deepSeekThinkingType) {
+        body.thinking = { type: deepSeekThinkingType }
+      }
+
+      if (deepSeekThinkingType === 'enabled') {
+        const effort = request.reasoning?.effort
+        if (effort) {
+          body.reasoning_effort = normalizeDeepSeekReasoningEffort(effort)
+        }
+      }
+    }
 
     if (params.tools && params.tools.length > 0) {
       const converted = convertTools(

--- a/src/utils/context.test.ts
+++ b/src/utils/context.test.ts
@@ -31,25 +31,36 @@ afterEach(() => {
   }
 })
 
-test('deepseek-chat uses provider-specific context and output caps', () => {
+test('deepseek-v4-flash uses provider-specific context and output caps', () => {
+  process.env.CLAUDE_CODE_USE_OPENAI = '1'
+  delete process.env.CLAUDE_CODE_MAX_OUTPUT_TOKENS
+  delete process.env.OPENAI_MODEL
+
+  expect(getContextWindowForModel('deepseek-v4-flash')).toBe(1_048_576)
+  expect(getModelMaxOutputTokens('deepseek-v4-flash')).toEqual({
+    default: 262_144,
+    upperLimit: 262_144,
+  })
+  expect(getMaxOutputTokensForModel('deepseek-v4-flash')).toBe(262_144)
+})
+
+test('deepseek legacy aliases keep their documented provider caps', () => {
   process.env.CLAUDE_CODE_USE_OPENAI = '1'
   delete process.env.CLAUDE_CODE_MAX_OUTPUT_TOKENS
   delete process.env.OPENAI_MODEL
 
   expect(getContextWindowForModel('deepseek-chat')).toBe(128_000)
-  expect(getModelMaxOutputTokens('deepseek-chat')).toEqual({
-    default: 8_192,
-    upperLimit: 8_192,
-  })
+  expect(getContextWindowForModel('deepseek-reasoner')).toBe(128_000)
   expect(getMaxOutputTokensForModel('deepseek-chat')).toBe(8_192)
+  expect(getMaxOutputTokensForModel('deepseek-reasoner')).toBe(65_536)
 })
 
-test('deepseek-chat clamps oversized max output overrides to the provider limit', () => {
+test('deepseek-v4-flash clamps oversized max output overrides to the provider limit', () => {
   process.env.CLAUDE_CODE_USE_OPENAI = '1'
-  process.env.CLAUDE_CODE_MAX_OUTPUT_TOKENS = '32000'
+  process.env.CLAUDE_CODE_MAX_OUTPUT_TOKENS = '500000'
   delete process.env.OPENAI_MODEL
 
-  expect(getMaxOutputTokensForModel('deepseek-chat')).toBe(8_192)
+  expect(getMaxOutputTokensForModel('deepseek-v4-flash')).toBe(262_144)
 })
 
 test('gpt-4o uses provider-specific context and output caps', () => {

--- a/src/utils/model/openaiContextWindows.ts
+++ b/src/utils/model/openaiContextWindows.ts
@@ -89,7 +89,13 @@ const OPENAI_CONTEXT_WINDOWS: Record<string, number> = {
   'o3-mini':                  200_000,
   'o4-mini':                  200_000,
 
-  // DeepSeek (V3: 128k context per official docs)
+  // DeepSeek V4 coding-agent models. DeepSeek's official coding-agent guide
+  // publishes V4 Pro at 1,048,576 context / 262,144 output; Flash is treated
+  // as the same family for local budgeting until a dedicated public model card
+  // lands.
+  'deepseek-v4-flash':      1_048_576,
+  'deepseek-v4-pro':        1_048_576,
+  // Legacy DeepSeek API aliases documented in the public pricing/model pages.
   'deepseek-chat':            128_000,
   'deepseek-reasoner':        128_000,
 
@@ -306,9 +312,12 @@ const OPENAI_MAX_OUTPUT_TOKENS: Record<string, number> = {
   'o3-mini':                  100_000,
   'o4-mini':                  100_000,
 
-  // DeepSeek
+  // DeepSeek V4 coding-agent models. See context-window note above.
+  'deepseek-v4-flash':        262_144,
+  'deepseek-v4-pro':          262_144,
+  // Legacy DeepSeek API aliases documented in the public pricing/model pages.
   'deepseek-chat':              8_192,
-  'deepseek-reasoner':         32_768,
+  'deepseek-reasoner':         65_536,
 
   // Groq
   'llama-3.3-70b-versatile':  32_768,

--- a/src/utils/providerModels.test.ts
+++ b/src/utils/providerModels.test.ts
@@ -16,6 +16,21 @@ describe('parseModelList', () => {
     ])
   })
 
+  test('splits semicolon-separated models', () => {
+    expect(parseModelList('glm-4.7; glm-4.7-flash')).toEqual([
+      'glm-4.7',
+      'glm-4.7-flash',
+    ])
+  })
+
+  test('splits mixed comma- and semicolon-separated models', () => {
+    expect(parseModelList('gpt-5.4; gpt-5.4-mini, o3')).toEqual([
+      'gpt-5.4',
+      'gpt-5.4-mini',
+      'o3',
+    ])
+  })
+
   test('returns single model in an array', () => {
     expect(parseModelList('llama3.1:8b')).toEqual(['llama3.1:8b'])
   })
@@ -62,6 +77,10 @@ describe('getPrimaryModel', () => {
     expect(getPrimaryModel('glm-4.7, glm-4.7-flash')).toBe('glm-4.7')
   })
 
+  test('returns first model from semicolon-separated list', () => {
+    expect(getPrimaryModel('glm-4.7; glm-4.7-flash')).toBe('glm-4.7')
+  })
+
   test('returns the only model when single model is provided', () => {
     expect(getPrimaryModel('llama3.1:8b')).toBe('llama3.1:8b')
   })
@@ -84,6 +103,10 @@ describe('getPrimaryModel', () => {
 describe('hasMultipleModels', () => {
   test('returns true when multiple models are present', () => {
     expect(hasMultipleModels('glm-4.7, glm-4.7-flash')).toBe(true)
+  })
+
+  test('returns true for semicolon-separated models', () => {
+    expect(hasMultipleModels('glm-4.7; glm-4.7-flash')).toBe(true)
   })
 
   test('returns false for a single model', () => {

--- a/src/utils/providerModels.ts
+++ b/src/utils/providerModels.ts
@@ -1,28 +1,30 @@
 /**
- * Utility functions for parsing comma-separated model names in provider profiles.
+ * Utility functions for parsing provider-profile model lists.
  *
- * Example: "glm-4.7, glm-4.7-flash" -> ["glm-4.7", "glm-4.7-flash"]
- * Single model: "llama3.1:8b" -> ["llama3.1:8b"]
+ * Examples:
+ * - "glm-4.7, glm-4.7-flash" -> ["glm-4.7", "glm-4.7-flash"]
+ * - "glm-4.7; glm-4.7-flash" -> ["glm-4.7", "glm-4.7-flash"]
+ * - "llama3.1:8b" -> ["llama3.1:8b"]
  */
 
 /**
- * Splits a comma-separated model field into an array of trimmed model names,
- * filtering out any empty entries.
+ * Splits a comma- or semicolon-separated model field into an array of trimmed
+ * model names, filtering out any empty entries.
  */
 export function parseModelList(modelField: string): string[] {
   return modelField
-    .split(',')
+    .split(/[;,]/)
     .map((part) => part.trim())
     .filter((part) => part.length > 0)
 }
 
 /**
- * Returns the first (primary) model from a comma-separated model field.
- * Falls back to the original string if parsing yields no results.
+ * Returns the first (primary) model from a model-list field.
+ * Falls back to the trimmed original string if parsing yields no results.
  */
 export function getPrimaryModel(modelField: string): string {
   const models = parseModelList(modelField)
-  return models.length > 0 ? models[0] : modelField
+  return models.length > 0 ? models[0] : modelField.trim()
 }
 
 /**

--- a/src/utils/providerProfile.test.ts
+++ b/src/utils/providerProfile.test.ts
@@ -784,6 +784,22 @@ test('openai profiles ignore poisoned shell model and base url values', () => {
   })
 })
 
+test('openai profiles normalize multi-model profile values to the primary model', () => {
+  const env = buildOpenAIProfileEnv({
+    goal: 'balanced',
+    apiKey: 'sk-live',
+    model: 'deepseek-v4-flash, deepseek-v4-pro, deepseek-chat',
+    baseUrl: 'https://api.deepseek.com/v1',
+    processEnv: {},
+  })
+
+  assert.deepEqual(env, {
+    OPENAI_BASE_URL: 'https://api.deepseek.com/v1',
+    OPENAI_MODEL: 'deepseek-v4-flash',
+    OPENAI_API_KEY: 'sk-live',
+  })
+})
+
 test('startup env ignores poisoned persisted openai model and base url', async () => {
   const env = await buildStartupEnvFromProfile({
     persisted: profile('openai', {

--- a/src/utils/providerProfile.test.ts
+++ b/src/utils/providerProfile.test.ts
@@ -391,6 +391,21 @@ test('gemini profiles accept google api key fallback', () => {
   })
 })
 
+test('gemini profiles use the first model from a semicolon-separated list', () => {
+  const env = buildGeminiProfileEnv({
+    authMode: 'api-key',
+    apiKey: 'gem-live',
+    model: 'gemini-2.5-pro; gemini-2.5-flash',
+    processEnv: {},
+  })
+
+  assert.deepEqual(env, {
+    GEMINI_AUTH_MODE: 'api-key',
+    GEMINI_MODEL: 'gemini-2.5-pro',
+    GEMINI_API_KEY: 'gem-live',
+  })
+})
+
 test('gemini profiles support access-token auth mode without persisting a key', () => {
   const env = buildGeminiProfileEnv({
     authMode: 'access-token',
@@ -766,6 +781,21 @@ test('openai profiles ignore codex shell transport hints', () => {
   })
 })
 
+test('openai profiles use the first model from a semicolon-separated list', () => {
+  const env = buildOpenAIProfileEnv({
+    goal: 'balanced',
+    apiKey: 'sk-live',
+    model: 'gpt-5.4; gpt-5.4-mini',
+    processEnv: {},
+  })
+
+  assert.deepEqual(env, {
+    OPENAI_BASE_URL: 'https://api.openai.com/v1',
+    OPENAI_MODEL: 'gpt-5.4',
+    OPENAI_API_KEY: 'sk-live',
+  })
+})
+
 test('openai profiles ignore poisoned shell model and base url values', () => {
   const env = buildOpenAIProfileEnv({
     goal: 'balanced',
@@ -813,6 +843,22 @@ test('startup env ignores poisoned persisted openai model and base url', async (
   assert.equal(env.CLAUDE_CODE_USE_OPENAI, '1')
   assert.equal(env.OPENAI_API_KEY, 'sk-live')
   assert.equal(env.OPENAI_MODEL, 'gpt-4o')
+  assert.equal(env.OPENAI_BASE_URL, 'https://api.openai.com/v1')
+})
+
+test('startup env normalizes a semicolon-separated persisted openai model list', async () => {
+  const env = await buildStartupEnvFromProfile({
+    persisted: profile('openai', {
+      OPENAI_API_KEY: 'sk-live',
+      OPENAI_MODEL: 'gpt-5.4; gpt-5.4-mini',
+      OPENAI_BASE_URL: 'https://api.openai.com/v1',
+    }),
+    processEnv: {},
+  })
+
+  assert.equal(env.CLAUDE_CODE_USE_OPENAI, '1')
+  assert.equal(env.OPENAI_API_KEY, 'sk-live')
+  assert.equal(env.OPENAI_MODEL, 'gpt-5.4')
   assert.equal(env.OPENAI_BASE_URL, 'https://api.openai.com/v1')
 })
 

--- a/src/utils/providerProfile.ts
+++ b/src/utils/providerProfile.ts
@@ -15,6 +15,7 @@ import {
 } from './providerRecommendation.js'
 import { readGeminiAccessToken } from './geminiCredentials.js'
 import { getOllamaChatBaseUrl } from './providerDiscovery.js'
+import { getPrimaryModel } from './providerModels.js'
 import { getProviderValidationError } from './providerValidation.js'
 import {
   maskSecretForDisplay,
@@ -296,6 +297,7 @@ export function buildOpenAIProfileEnv(options: {
 
   const defaultModel = getGoalDefaultOpenAIModel(options.goal)
   const secretSource: SecretValueSource = { OPENAI_API_KEY: key }
+  const requestedModel = sanitizeProviderConfigValue(options.model, secretSource)
   const shellOpenAIModel = sanitizeProviderConfigValue(
     processEnv.OPENAI_MODEL,
     secretSource,
@@ -317,7 +319,7 @@ export function buildOpenAIProfileEnv(options: {
       (useShellOpenAIConfig ? shellOpenAIBaseUrl : undefined) ||
       DEFAULT_OPENAI_BASE_URL,
     OPENAI_MODEL:
-      sanitizeProviderConfigValue(options.model, secretSource) ||
+      (requestedModel ? getPrimaryModel(requestedModel) : undefined) ||
       (useShellOpenAIConfig ? shellOpenAIModel : undefined) ||
       defaultModel,
     OPENAI_API_KEY: key,

--- a/src/utils/providerProfile.ts
+++ b/src/utils/providerProfile.ts
@@ -140,6 +140,18 @@ function resolveProfileFilePath(options?: ProfileFileLocation): string {
   return resolve(options?.cwd ?? process.cwd(), PROFILE_FILE_NAME)
 }
 
+function normalizeProfileModel(
+  value: string | undefined | null,
+): string | undefined {
+  const trimmed = value?.trim()
+  if (!trimmed) {
+    return undefined
+  }
+
+  const primary = getPrimaryModel(trimmed)
+  return primary.length > 0 ? primary : undefined
+}
+
 export function isProviderProfile(value: unknown): value is ProviderProfile {
   return (
     value === 'openai' ||
@@ -200,8 +212,12 @@ export function buildNvidiaNimProfileEnv(options: {
       sanitizeProviderConfigValue(processEnv.OPENAI_BASE_URL, secretSource) ||
       defaultBaseUrl,
     OPENAI_MODEL:
-      sanitizeProviderConfigValue(options.model, secretSource) ||
-      sanitizeProviderConfigValue(processEnv.OPENAI_MODEL, secretSource) ||
+      normalizeProfileModel(
+        sanitizeProviderConfigValue(options.model, secretSource),
+      ) ||
+      normalizeProfileModel(
+        sanitizeProviderConfigValue(processEnv.OPENAI_MODEL, secretSource),
+      ) ||
       'nvidia/llama-3.1-nemotron-70b-instruct',
     OPENAI_API_KEY: key,
     NVIDIA_NIM: '1',
@@ -230,8 +246,12 @@ export function buildMiniMaxProfileEnv(options: {
       sanitizeProviderConfigValue(processEnv.OPENAI_BASE_URL, secretSource) ||
       defaultBaseUrl,
     OPENAI_MODEL:
-      sanitizeProviderConfigValue(options.model, secretSource) ||
-      sanitizeProviderConfigValue(processEnv.OPENAI_MODEL, secretSource) ||
+      normalizeProfileModel(
+        sanitizeProviderConfigValue(options.model, secretSource),
+      ) ||
+      normalizeProfileModel(
+        sanitizeProviderConfigValue(processEnv.OPENAI_MODEL, secretSource),
+      ) ||
       defaultModel,
     OPENAI_API_KEY: key,
     MINIMAX_API_KEY: key,
@@ -263,8 +283,12 @@ export function buildGeminiProfileEnv(options: {
   const env: ProfileEnv = {
     GEMINI_AUTH_MODE: authMode,
     GEMINI_MODEL:
-      sanitizeProviderConfigValue(options.model, secretSource) ||
-      sanitizeProviderConfigValue(processEnv.GEMINI_MODEL, secretSource) ||
+      normalizeProfileModel(
+        sanitizeProviderConfigValue(options.model, secretSource),
+      ) ||
+      normalizeProfileModel(
+        sanitizeProviderConfigValue(processEnv.GEMINI_MODEL, secretSource),
+      ) ||
       DEFAULT_GEMINI_MODEL,
   }
 
@@ -297,10 +321,11 @@ export function buildOpenAIProfileEnv(options: {
 
   const defaultModel = getGoalDefaultOpenAIModel(options.goal)
   const secretSource: SecretValueSource = { OPENAI_API_KEY: key }
-  const requestedModel = sanitizeProviderConfigValue(options.model, secretSource)
-  const shellOpenAIModel = sanitizeProviderConfigValue(
-    processEnv.OPENAI_MODEL,
-    secretSource,
+  const shellOpenAIModel = normalizeProfileModel(
+    sanitizeProviderConfigValue(
+      processEnv.OPENAI_MODEL,
+      secretSource,
+    ),
   )
   const shellOpenAIBaseUrl = sanitizeProviderConfigValue(
     processEnv.OPENAI_BASE_URL,
@@ -319,7 +344,9 @@ export function buildOpenAIProfileEnv(options: {
       (useShellOpenAIConfig ? shellOpenAIBaseUrl : undefined) ||
       DEFAULT_OPENAI_BASE_URL,
     OPENAI_MODEL:
-      (requestedModel ? getPrimaryModel(requestedModel) : undefined) ||
+      normalizeProfileModel(
+        sanitizeProviderConfigValue(options.model, secretSource),
+      ) ||
       (useShellOpenAIConfig ? shellOpenAIModel : undefined) ||
       defaultModel,
     OPENAI_API_KEY: key,
@@ -376,10 +403,14 @@ export function buildMistralProfileEnv(options: {
   const env: ProfileEnv = {
     MISTRAL_API_KEY: key,
     MISTRAL_MODEL:
-      sanitizeProviderConfigValue(options.model, { MISTRAL_API_KEY: key }) ||
-      sanitizeProviderConfigValue(
-        processEnv.MISTRAL_MODEL,
-        { MISTRAL_API_KEY: key },
+      normalizeProfileModel(
+        sanitizeProviderConfigValue(options.model, { MISTRAL_API_KEY: key }),
+      ) ||
+      normalizeProfileModel(
+        sanitizeProviderConfigValue(
+          processEnv.MISTRAL_MODEL,
+          { MISTRAL_API_KEY: key },
+        ),
       ) ||
       DEFAULT_MISTRAL_MODEL,
   }
@@ -536,33 +567,41 @@ export async function buildLaunchEnv(options: {
     options.persisted?.profile === options.profile
       ? options.persisted.env ?? {}
       : {}
-  const persistedOpenAIModel = sanitizeProviderConfigValue(
-    persistedEnv.OPENAI_MODEL,
-    persistedEnv,
+  const persistedOpenAIModel = normalizeProfileModel(
+    sanitizeProviderConfigValue(
+      persistedEnv.OPENAI_MODEL,
+      persistedEnv,
+    ),
   )
   const persistedOpenAIBaseUrl = sanitizeProviderConfigValue(
     persistedEnv.OPENAI_BASE_URL,
     persistedEnv,
   )
-  const shellOpenAIModel = sanitizeProviderConfigValue(
-    processEnv.OPENAI_MODEL,
-    processEnv as SecretValueSource,
+  const shellOpenAIModel = normalizeProfileModel(
+    sanitizeProviderConfigValue(
+      processEnv.OPENAI_MODEL,
+      processEnv as SecretValueSource,
+    ),
   )
   const shellOpenAIBaseUrl = sanitizeProviderConfigValue(
     processEnv.OPENAI_BASE_URL,
     processEnv as SecretValueSource,
   )
-  const persistedGeminiModel = sanitizeProviderConfigValue(
-    persistedEnv.GEMINI_MODEL,
-    persistedEnv,
+  const persistedGeminiModel = normalizeProfileModel(
+    sanitizeProviderConfigValue(
+      persistedEnv.GEMINI_MODEL,
+      persistedEnv,
+    ),
   )
   const persistedGeminiBaseUrl = sanitizeProviderConfigValue(
     persistedEnv.GEMINI_BASE_URL,
     persistedEnv,
   )
-  const shellGeminiModel = sanitizeProviderConfigValue(
-    processEnv.GEMINI_MODEL,
-    processEnv as SecretValueSource,
+  const shellGeminiModel = normalizeProfileModel(
+    sanitizeProviderConfigValue(
+      processEnv.GEMINI_MODEL,
+      processEnv as SecretValueSource,
+    ),
   )
   const shellGeminiBaseUrl = sanitizeProviderConfigValue(
     processEnv.GEMINI_BASE_URL,
@@ -660,11 +699,15 @@ export async function buildLaunchEnv(options: {
     delete env.CLAUDE_CODE_USE_VERTEX
     delete env.CLAUDE_CODE_USE_FOUNDRY
 
-    const shellMistralModel = sanitizeProviderConfigValue(
-      processEnv.MISTRAL_MODEL,
+    const shellMistralModel = normalizeProfileModel(
+      sanitizeProviderConfigValue(
+        processEnv.MISTRAL_MODEL,
+      ),
     )
-    const persistedMistralModel = sanitizeProviderConfigValue(
-      persistedEnv.MISTRAL_MODEL,
+    const persistedMistralModel = normalizeProfileModel(
+      sanitizeProviderConfigValue(
+        persistedEnv.MISTRAL_MODEL,
+      ),
     )
     const shellMistralBaseUrl = sanitizeProviderConfigValue(
       processEnv.MISTRAL_BASE_URL,

--- a/src/utils/providerProfiles.test.ts
+++ b/src/utils/providerProfiles.test.ts
@@ -628,6 +628,45 @@ describe('setActiveProviderProfile', () => {
     }
   })
 
+  test('persists primary model for keyed openai-compatible multi-model profiles', async () => {
+    const tempDir = mkdtempSync(join(tmpdir(), 'openclaude-provider-'))
+    process.chdir(tempDir)
+
+    try {
+      const { setActiveProviderProfile } =
+        await importFreshProviderProfileModules()
+      const deepSeekProfile = buildProfile({
+        id: 'deepseek_prof',
+        name: 'DeepSeek',
+        provider: 'openai',
+        baseUrl: 'https://api.deepseek.com/v1',
+        model: 'deepseek-v4-flash, deepseek-v4-pro, deepseek-chat',
+        apiKey: 'sk-deepseek-live',
+      })
+
+      saveMockGlobalConfig(current => ({
+        ...current,
+        providerProfiles: [deepSeekProfile],
+      }))
+
+      const result = setActiveProviderProfile('deepseek_prof')
+      const persisted = JSON.parse(
+        readFileSync(join(tempDir, '.openclaude-profile.json'), 'utf8'),
+      )
+
+      expect(result?.id).toBe('deepseek_prof')
+      expect(persisted.profile).toBe('openai')
+      expect(persisted.env).toEqual({
+        OPENAI_BASE_URL: 'https://api.deepseek.com/v1',
+        OPENAI_MODEL: 'deepseek-v4-flash',
+        OPENAI_API_KEY: 'sk-deepseek-live',
+      })
+    } finally {
+      process.chdir(originalCwd)
+      rmSync(tempDir, { recursive: true, force: true })
+    }
+  })
+
   test('sets ANTHROPIC_MODEL env var when switching to an anthropic-type provider', async () => {
     const { setActiveProviderProfile } =
       await importFreshProviderProfileModules()

--- a/src/utils/providerProfiles.test.ts
+++ b/src/utils/providerProfiles.test.ts
@@ -539,6 +539,20 @@ describe('getProviderPresetDefaults', () => {
     expect(defaults.baseUrl).toBe('http://127.0.0.1:1337/v1')
     expect(defaults.requiresApiKey).toBe(false)
   })
+
+  test('deepseek preset defaults to DeepSeek V4 flash and exposes flash/pro aliases', async () => {
+    const { getProviderPresetDefaults } = await importFreshProviderProfileModules()
+
+    const defaults = getProviderPresetDefaults('deepseek')
+
+    expect(defaults.provider).toBe('openai')
+    expect(defaults.name).toBe('DeepSeek')
+    expect(defaults.baseUrl).toBe('https://api.deepseek.com/v1')
+    expect(defaults.model).toBe(
+      'deepseek-v4-flash, deepseek-v4-pro, deepseek-chat, deepseek-reasoner',
+    )
+    expect(defaults.requiresApiKey).toBe(true)
+  })
 })
 
 describe('setActiveProviderProfile', () => {

--- a/src/utils/providerProfiles.test.ts
+++ b/src/utils/providerProfiles.test.ts
@@ -221,6 +221,23 @@ describe('applyProviderProfileToProcessEnv', () => {
     expect(process.env.OPENAI_BASE_URL).toBe('https://api.openai.com/v1')
   })
 
+  test('openai profile with semicolon-separated multi-model string sets only first model in OPENAI_MODEL', async () => {
+    const { applyProviderProfileToProcessEnv } =
+      await importFreshProviderProfileModules()
+
+    applyProviderProfileToProcessEnv(
+      buildProfile({
+        provider: 'openai',
+        baseUrl: 'https://api.openai.com/v1',
+        model: 'glm-4.7; glm-4.7-flash; glm-4.7-plus',
+      }),
+    )
+
+    expect(process.env.OPENAI_MODEL).toBe('glm-4.7')
+    expect(String(process.env.CLAUDE_CODE_USE_OPENAI)).toBe('1')
+    expect(process.env.OPENAI_BASE_URL).toBe('https://api.openai.com/v1')
+  })
+
   test('anthropic profile with multi-model string sets only first model in ANTHROPIC_MODEL', async () => {
     const { applyProviderProfileToProcessEnv } =
       await importFreshProviderProfileModules()
@@ -235,6 +252,34 @@ describe('applyProviderProfileToProcessEnv', () => {
 
     expect(process.env.ANTHROPIC_MODEL).toBe('claude-sonnet-4-6')
     expect(process.env.ANTHROPIC_BASE_URL).toBe('https://api.anthropic.com')
+  })
+
+  test('gemini profile with semicolon-separated multi-model string sets only first model in GEMINI_MODEL', async () => {
+    const { applyProviderProfileToProcessEnv } =
+      await importFreshProviderProfileModules()
+
+    applyProviderProfileToProcessEnv(
+      buildGeminiProfile({
+        model: 'gemini-3-flash-preview; gemini-3-pro-preview',
+      }),
+    )
+
+    expect(process.env.GEMINI_MODEL).toBe('gemini-3-flash-preview')
+    expect(process.env.CLAUDE_CODE_USE_GEMINI).toBe('1')
+  })
+
+  test('mistral profile with semicolon-separated multi-model string sets only first model in MISTRAL_MODEL', async () => {
+    const { applyProviderProfileToProcessEnv } =
+      await importFreshProviderProfileModules()
+
+    applyProviderProfileToProcessEnv(
+      buildMistralProfile({
+        model: 'devstral-latest; mistral-medium-latest',
+      }),
+    )
+
+    expect(process.env.MISTRAL_MODEL).toBe('devstral-latest')
+    expect(process.env.CLAUDE_CODE_USE_MISTRAL).toBe('1')
   })
 })
 
@@ -880,6 +925,24 @@ describe('getProfileModelOptions', () => {
       buildProfile({
         name: 'Test Provider',
         model: 'glm-4.7, glm-4.7-flash, glm-4.7-plus',
+      }),
+    )
+
+    expect(options).toEqual([
+      { value: 'glm-4.7', label: 'glm-4.7', description: 'Provider: Test Provider' },
+      { value: 'glm-4.7-flash', label: 'glm-4.7-flash', description: 'Provider: Test Provider' },
+      { value: 'glm-4.7-plus', label: 'glm-4.7-plus', description: 'Provider: Test Provider' },
+    ])
+  })
+
+  test('generates options for semicolon-separated multi-model profile', async () => {
+    const { getProfileModelOptions } =
+      await importFreshProviderProfileModules()
+
+    const options = getProfileModelOptions(
+      buildProfile({
+        name: 'Test Provider',
+        model: 'glm-4.7; glm-4.7-flash; glm-4.7-plus',
       }),
     )
 

--- a/src/utils/providerProfiles.ts
+++ b/src/utils/providerProfiles.ts
@@ -171,7 +171,7 @@ export function getProviderPresetDefaults(
         provider: 'openai',
         name: 'DeepSeek',
         baseUrl: 'https://api.deepseek.com/v1',
-        model: 'deepseek-chat',
+        model: 'deepseek-v4-flash, deepseek-v4-pro, deepseek-chat, deepseek-reasoner',
         apiKey: '',
         requiresApiKey: true,
       }

--- a/src/utils/providerProfiles.ts
+++ b/src/utils/providerProfiles.ts
@@ -448,7 +448,7 @@ function isProcessEnvAlignedWithProfile(
       processEnv.CLAUDE_CODE_USE_VERTEX === undefined &&
       processEnv.CLAUDE_CODE_USE_FOUNDRY === undefined &&
       sameOptionalEnvValue(processEnv.MISTRAL_BASE_URL, profile.baseUrl) &&
-      sameOptionalEnvValue(processEnv.MISTRAL_MODEL, profile.model) &&
+      sameOptionalEnvValue(processEnv.MISTRAL_MODEL, getPrimaryModel(profile.model)) &&
       (!includeApiKey ||
         sameOptionalEnvValue(processEnv.MISTRAL_API_KEY, profile.apiKey))
     )
@@ -464,7 +464,7 @@ function isProcessEnvAlignedWithProfile(
       processEnv.CLAUDE_CODE_USE_VERTEX === undefined &&
       processEnv.CLAUDE_CODE_USE_FOUNDRY === undefined &&
       sameOptionalEnvValue(processEnv.GEMINI_BASE_URL, profile.baseUrl) &&
-      sameOptionalEnvValue(processEnv.GEMINI_MODEL, profile.model) &&
+      sameOptionalEnvValue(processEnv.GEMINI_MODEL, getPrimaryModel(profile.model)) &&
       (!includeApiKey ||
         sameOptionalEnvValue(processEnv.GEMINI_API_KEY, profile.apiKey))
     )
@@ -561,7 +561,7 @@ export function applyProviderProfileToProcessEnv(profile: ProviderProfile): void
   if (profile.provider === 'mistral') {
     process.env.CLAUDE_CODE_USE_MISTRAL = '1'
     process.env.MISTRAL_BASE_URL = profile.baseUrl
-    process.env.MISTRAL_MODEL = profile.model
+    process.env.MISTRAL_MODEL = getPrimaryModel(profile.model)
 
     if (profile.apiKey) {
       process.env.MISTRAL_API_KEY = profile.apiKey
@@ -578,7 +578,7 @@ export function applyProviderProfileToProcessEnv(profile: ProviderProfile): void
   if (profile.provider === 'gemini') {
     process.env.CLAUDE_CODE_USE_GEMINI = '1'
     process.env.GEMINI_BASE_URL = profile.baseUrl
-    process.env.GEMINI_MODEL = profile.model
+    process.env.GEMINI_MODEL = getPrimaryModel(profile.model)
 
     if (profile.apiKey) {
       process.env.GEMINI_API_KEY = profile.apiKey
@@ -819,7 +819,7 @@ export function persistActiveProviderProfileModel(
 
 /**
  * Generate model options from a provider profile's model field.
- * Each comma-separated model becomes a separate option in the picker.
+ * Each parsed model becomes a separate option in the picker.
  */
 export function getProfileModelOptions(profile: ProviderProfile): ModelOption[] {
   const models = parseModelList(profile.model)
@@ -907,7 +907,7 @@ export function setActiveProviderProfile(
       case 'gemini':
         return (
           buildGeminiProfileEnv({
-            model: activeProfile.model,
+            model: getPrimaryModel(activeProfile.model),
             baseUrl: activeProfile.baseUrl,
             apiKey: activeProfile.apiKey,
             authMode: 'api-key',
@@ -917,7 +917,7 @@ export function setActiveProviderProfile(
       case 'mistral':
         return (
           buildMistralProfileEnv({
-            model: activeProfile.model,
+            model: getPrimaryModel(activeProfile.model),
             baseUrl: activeProfile.baseUrl,
             apiKey: activeProfile.apiKey,
             processEnv: process.env,
@@ -928,7 +928,7 @@ export function setActiveProviderProfile(
           ? (
               buildOpenAIProfileEnv({
                 goal: 'balanced',
-                model: activeProfile.model,
+                model: getPrimaryModel(activeProfile.model),
                 baseUrl: activeProfile.baseUrl,
                 apiKey: activeProfile.apiKey,
                 processEnv: process.env,
@@ -945,7 +945,7 @@ export function setActiveProviderProfile(
             profile: 'openai' as ProviderProfileStartup,
             env: {
               OPENAI_BASE_URL: activeProfile.baseUrl,
-              OPENAI_MODEL: activeProfile.model,
+              OPENAI_MODEL: getPrimaryModel(activeProfile.model),
               OPENAI_API_KEY: activeProfile.apiKey,
             },
           } as const)

--- a/src/utils/thinking.ts
+++ b/src/utils/thinking.ts
@@ -105,6 +105,12 @@ export function modelSupportsThinking(model: string): boolean {
   if (provider === 'foundry' || provider === 'firstParty') {
     return !canonical.includes('claude-3-')
   }
+  if (
+    canonical.startsWith('deepseek-v4-') ||
+    canonical === 'deepseek-reasoner'
+  ) {
+    return true
+  }
   // 3P (Bedrock/Vertex): only Opus 4+ and Sonnet 4+
   return canonical.includes('sonnet-4') || canonical.includes('opus-4')
 }


### PR DESCRIPTION
## Summary

This PR updates OpenClaude's OpenAI-compatible DeepSeek integration for the current DeepSeek V4 model lineup and DeepSeek-specific thinking behavior.

Closes #876

## What Changed

- added `deepseek-v4-flash` and `deepseek-v4-pro` to the DeepSeek preset/default model list
- added provider-specific context window and output cap entries for the DeepSeek V4 models
- updated the OpenAI shim for DeepSeek API compatibility:
  - use `max_tokens` instead of `max_completion_tokens`
  - strip unsupported `store`
  - forward DeepSeek `thinking` controls
  - normalize reasoning effort for DeepSeek requests
  - preserve `reasoning_content` across assistant tool-call follow-up turns
- kept legacy aliases for `deepseek-chat` and `deepseek-reasoner`
- kept `deepseek-chat` non-thinking to stay aligned with documented legacy DeepSeek behavior
- updated setup/docs/examples to reflect the DeepSeek V4 options

## Why

DeepSeek’s current API documentation exposes V4 model IDs and provider-specific thinking controls. OpenClaude needed to support those newer model IDs and request semantics so the DeepSeek provider path continues to work cleanly.

## Impact

- DeepSeek users now get working V4 defaults in provider presets
- DeepSeek reasoning/thinking behavior is forwarded more accurately, including tool-call continuation turns
- docs and setup examples now match the currently supported DeepSeek models

## Provider Path Tested

- DeepSeek OpenAI-compatible request handling was validated through focused unit tests in the shim and provider profile/context coverage
- I did not run a live credentialed DeepSeek generation request in this environment

## Checks Run

- `bun run build`
- `bun run smoke`
- `bun test src/utils/context.test.ts src/utils/providerProfiles.test.ts`
- `bun test src/services/api/openaiShim.test.ts`
- `bun run doctor:runtime`
- `npm pack`