### PR TITLE
feat(api): extend reasoning_content preservation to DeepSeek for multi-turn tool calls

### DIFF
--- a/src/services/api/openaiShim.ts
+++ b/src/services/api/openaiShim.ts
@@ -89,6 +89,10 @@ const MOONSHOT_API_HOSTS = new Set([
   'api.moonshot.cn',
 ])
 
+const DEEPSEEK_API_HOSTS = new Set([
+  'api.deepseek.com',
+])
+
 const COPILOT_HEADERS: Record<string, string> = {
   'User-Agent': 'GitHubCopilotChat/0.26.7',
   'Editor-Version': 'vscode/1.99.3',
@@ -157,6 +161,15 @@ function isMoonshotBaseUrl(baseUrl: string | undefined): boolean {
   if (!baseUrl) return false
   try {
     return MOONSHOT_API_HOSTS.has(new URL(baseUrl).hostname.toLowerCase())
+  } catch {
+    return false
+  }
+}
+
+function isDeepseekBaseUrl(baseUrl: string | undefined): boolean {
+  if (!baseUrl) return false
+  try {
+    return DEEPSEEK_API_HOSTS.has(new URL(baseUrl).hostname.toLowerCase())
   } catch {
     return false
   }
@@ -670,6 +683,17 @@ function convertMessages(
           ...(lastAfterPossibleInjection.tool_calls ?? []),
           ...msg.tool_calls,
         ]
+      }
+
+      // Merge reasoning_content for DeepSeek multi-turn compatibility.
+      // DeepSeek requires reasoning_content to be passed back on every
+      // subsequent request. When the coalescing pass merges consecutive
+      // assistant messages, the reasoning payload must be merged as well
+      // so the model sees the full chain-of-thought history it expects.
+      if (msg.reasoning_content && lastAfterPossibleInjection.reasoning_content) {
+        lastAfterPossibleInjection.reasoning_content += '\n' + msg.reasoning_content
+      } else if (msg.reasoning_content) {
+        lastAfterPossibleInjection.reasoning_content = msg.reasoning_content
       }
     } else {
       coalesced.push(msg)
@@ -1489,7 +1513,11 @@ class OpenAIShimMessages {
       // Moonshot requires every assistant tool-call message to carry
       // reasoning_content when its thinking feature is active. Echo it back
       // from the thinking block we captured on the inbound response.
-      preserveReasoningContent: isMoonshotBaseUrl(request.baseUrl),
+      // DeepSeek likewise requires reasoning_content on every subsequent
+      // request of a multi-turn conversation when multi-turn tool calls are
+      // in use; omitting it and the API returns 400.
+      preserveReasoningContent:
+        isMoonshotBaseUrl(request.baseUrl) || isDeepseekBaseUrl(request.baseUrl),
     })
 
     const body: Record<string, unknown> = {


### PR DESCRIPTION
## Summary

DeepSeek requires `reasoning_content` to be passed back on every subsequent request of a multi-turn conversation that uses tool calls. Without it, the API returns a 400 error.

This change extends the existing Moonshot `reasoning_content` preservation infrastructure to also cover DeepSeek:

- **Added `isDeepseekBaseUrl`** detection for `api.deepseek.com`
- **Extended `preserveReasoningContent` gate** to trigger for DeepSeek in addition to Moonshot
- **Added `reasoning_content` merging** during the coalescing pass — when consecutive assistant messages are merged to satisfy OAI role alternation requirements, their `reasoning_content` payloads must also be merged so the model sees the full chain-of-thought history it expects

## Test plan

- [ ] Manual testing: multi-turn tool call conversation against DeepSeek API (`api.deepseek.com`) no longer fails with 400
- [ ] Existing Moonshot behavior is unchanged (same `preserveReasoningContent` path, just with an additional OR condition)
- [ ] Other providers (OpenAI, Mistral, Gemini) unaffected — the coalescing merge only applies when `reasoning_content` is present, which only happens when `preserveReasoningContent` is true for DeepSeek/Moonshot

🤖 Generated with [OpenClaude](https://github.com/Gitlawb/openclaude)