### PR TITLE
feat(api): DeepSeek V4 thinking mode support and model registration

### DIFF
--- a/src/services/api/openaiShim.test.ts
+++ b/src/services/api/openaiShim.test.ts
@@ -3449,18 +3449,92 @@ test('DeepSeek providers receive reasoning_content on assistant messages', async
         content: [
           { type: 'thinking', thinking: 'thought' },
           { type: 'text', text: 'hello' },
+          {
+            type: 'tool_use',
+            id: 'call_1',
+            name: 'Bash',
+            input: { command: 'ls' },
+          },
         ],
       },
-      { role: 'user', content: [{ type: 'tool_result', tool_use_id: 'call_1', content: 'lab' }] },
+      {
+        role: 'user',
+        content: [
+          { type: 'tool_result', tool_use_id: 'call_1', content: 'files' },
+        ],
+      },
     ],
     max_tokens: 32,
     stream: false,
   })
 
   const messages = requestBody?.messages as Array<Record<string, unknown>>
-  const assistantMsg = messages.find(m => m.role === 'assistant')
-  expect(assistantMsg).toBeDefined()
-  expect(assistantMsg?.reasoning_content).toBe('thought')
+  const assistantWithToolCall = messages.find(
+    m => m.role === 'assistant' && Array.isArray(m.tool_calls),
+  )
+  expect(assistantWithToolCall).toBeDefined()
+  expect(assistantWithToolCall?.reasoning_content).toBe('thought')
+})
+
+test('DeepSeek: tool call without thinking block still gets empty reasoning_content', async () => {
+  // DeepSeek V4 may emit a tool_call without a preceding non-empty
+  // reasoning_content delta on trivial follow-up tool calls. The
+  // reasoning_content field must still be present (even if empty) to
+  // satisfy the echo-back contract.
+  process.env.OPENAI_BASE_URL = 'https://api.deepseek.com/v1'
+  process.env.OPENAI_API_KEY = 'sk-deepseek'
+
+  let requestBody: Record<string, unknown> | undefined
+  globalThis.fetch = (async (_input, init) => {
+    requestBody = JSON.parse(String(init?.body))
+    return new Response(
+      JSON.stringify({
+        id: 'chatcmpl-2',
+        model: 'deepseek-chat',
+        choices: [
+          { message: { role: 'assistant', content: 'ok' }, finish_reason: 'stop' },
+        ],
+        usage: { prompt_tokens: 3, completion_tokens: 1, total_tokens: 4 },
+      }),
+      { headers: { 'Content-Type': 'application/json' } },
+    )
+  }) as FetchType
+
+  const client = createOpenAIShimClient({}) as OpenAIShimClient
+  await client.beta.messages.create({
+    model: 'deepseek-chat',
+    system: 'test',
+    messages: [
+      { role: 'user', content: 'check the file' },
+      {
+        role: 'assistant',
+        content: [
+          { type: 'text', text: '' },
+          {
+            type: 'tool_use',
+            id: 'call_2',
+            name: 'Read',
+            input: { file_path: '/tmp/f' },
+          },
+        ],
+      },
+      {
+        role: 'user',
+        content: [
+          { type: 'tool_result', tool_use_id: 'call_2', content: 'data' },
+        ],
+      },
+    ],
+    max_tokens: 32,
+    stream: false,
+  })
+
+  const messages = requestBody?.messages as Array<Record<string, unknown>>
+  const assistantWithToolCall = messages.find(
+    m => m.role === 'assistant' && Array.isArray(m.tool_calls),
+  )
+  expect(assistantWithToolCall).toBeDefined()
+  expect(assistantWithToolCall?.reasoning_content).toBe('')
 })
 
 test('Moonshot: cn host is also detected', async () => {

--- a/src/services/api/openaiShim.test.ts
+++ b/src/services/api/openaiShim.test.ts
@@ -3415,10 +3415,10 @@ test('Moonshot: echoes reasoning_content on assistant tool-call messages', async
   )
 })
 
-test('non-Moonshot providers do NOT receive reasoning_content on assistant messages', async () => {
-  // Guard: only Moonshot opts in. DeepSeek/OpenRouter/etc. receive the
-  // outgoing assistant message without reasoning_content to avoid
-  // unknown-field rejections from strict servers.
+test('DeepSeek providers receive reasoning_content on assistant messages', async () => {
+  // DeepSeek V4 requires reasoning_content to be echoed back on multi-turn
+  // tool calls. The same preservation path used for Moonshot now also covers
+  // DeepSeek API hosts.
   process.env.OPENAI_BASE_URL = 'https://api.deepseek.com/v1'
   process.env.OPENAI_API_KEY = 'sk-deepseek'
 
@@ -3449,31 +3449,18 @@ test('non-Moonshot providers do NOT receive reasoning_content on assistant messa
         content: [
           { type: 'thinking', thinking: 'thought' },
           { type: 'text', text: 'hello' },
-          {
-            type: 'tool_use',
-            id: 'call_1',
-            name: 'Bash',
-            input: { command: 'ls' },
-          },
         ],
       },
-      {
-        role: 'user',
-        content: [
-          { type: 'tool_result', tool_use_id: 'call_1', content: 'files' },
-        ],
-      },
+      { role: 'user', content: [{ type: 'tool_result', tool_use_id: 'call_1', content: 'lab' }] },
     ],
     max_tokens: 32,
     stream: false,
   })
 
   const messages = requestBody?.messages as Array<Record<string, unknown>>
-  const assistantWithToolCall = messages.find(
-    m => m.role === 'assistant' && Array.isArray(m.tool_calls),
-  )
-  expect(assistantWithToolCall).toBeDefined()
-  expect(assistantWithToolCall?.reasoning_content).toBeUndefined()
+  const assistantMsg = messages.find(m => m.role === 'assistant')
+  expect(assistantMsg).toBeDefined()
+  expect(assistantMsg?.reasoning_content).toBe('thought')
 })
 
 test('Moonshot: cn host is also detected', async () => {

--- a/src/services/api/openaiShim.ts
+++ b/src/services/api/openaiShim.ts
@@ -1555,6 +1555,7 @@ class OpenAIShimMessages {
     const isGithubModels = isGithub && (githubEndpointType === 'models' || githubEndpointType === 'custom')
 
     const isMoonshot = isMoonshotBaseUrl(request.baseUrl)
+    const isDeepseek = isDeepseekBaseUrl(request.baseUrl)
 
     if ((isGithub || isMistral || isLocal || isMoonshot) && body.max_completion_tokens !== undefined) {
       body.max_tokens = body.max_completion_tokens
@@ -1570,8 +1571,13 @@ class OpenAIShimMessages {
       delete body.store
     }
 
-    if (params.temperature !== undefined) body.temperature = params.temperature
-    if (params.top_p !== undefined) body.top_p = params.top_p
+    // DeepSeek V4+ models have thinking enabled by default and reject
+    // temperature/top_p when thinking is active (the API ignores them
+    // silently but the payload contract expects them stripped).
+    if (!isDeepseek) {
+      if (params.temperature !== undefined) body.temperature = params.temperature
+      if (params.top_p !== undefined) body.top_p = params.top_p
+    }
 
     if (params.tools && params.tools.length > 0) {
       const converted = convertTools(
@@ -1599,6 +1605,13 @@ class OpenAIShimMessages {
           }
         }
       }
+    }
+
+    // DeepSeek V4+ models require thinking mode to be explicitly enabled
+    // via extra_body. Without it, the V4 endpoint may hang or reject the
+    // request. Pass the thinking toggle for all DeepSeek API hosts.
+    if (isDeepseek) {
+      body.extra_body = { thinking: { type: 'enabled' } }
     }
 
     const headers: Record<string, string> = {

--- a/src/services/api/openaiShim.ts
+++ b/src/services/api/openaiShim.ts
@@ -519,11 +519,23 @@ function convertMessages(
         // `reasoning_content` field on the outgoing OpenAI-shaped message.
         // Gated per-provider because other endpoints either ignore the field
         // (harmless) or strict-reject unknown fields (harmful).
-        if (preserveReasoningContent) {
-          const thinkingText = (thinkingBlock as { thinking?: string } | undefined)?.thinking
-          if (typeof thinkingText === 'string' && thinkingText.trim().length > 0) {
-            assistantMsg.reasoning_content = thinkingText
-          }
+        //
+        // DeepSeek V4 likewise requires reasoning_content on every
+        // assistant tool-call message. The model may produce a tool_call
+        // without a preceding non-empty reasoning_content delta (e.g. on a
+        // trivial follow-up tool call), in which case no thinking block is
+        // emitted. For providers that require reasoning continuity, always
+        // set reasoning_content when tool_calls are present so the echo-back
+        // contract is satisfied even when the model produced no reasoning.
+        const thinkingText = (thinkingBlock as { thinking?: string } | undefined)?.thinking
+        if (
+          preserveReasoningContent &&
+          (typeof thinkingText === 'string' || toolUses.length > 0)
+        ) {
+          assistantMsg.reasoning_content =
+            typeof thinkingText === 'string' && thinkingText.trim().length > 0
+              ? thinkingText
+              : ''
         }
 
         if (toolUses.length > 0) {

--- a/src/services/api/openaiShim.ts
+++ b/src/services/api/openaiShim.ts
@@ -89,6 +89,10 @@ const MOONSHOT_API_HOSTS = new Set([
   'api.moonshot.cn',
 ])
 
+const DEEPSEEK_API_HOSTS = new Set([
+  'api.deepseek.com',
+])
+
 const COPILOT_HEADERS: Record<string, string> = {
   'User-Agent': 'GitHubCopilotChat/0.26.7',
   'Editor-Version': 'vscode/1.99.3',
@@ -157,6 +161,15 @@ function isMoonshotBaseUrl(baseUrl: string | undefined): boolean {
   if (!baseUrl) return false
   try {
     return MOONSHOT_API_HOSTS.has(new URL(baseUrl).hostname.toLowerCase())
+  } catch {
+    return false
+  }
+}
+
+function isDeepseekBaseUrl(baseUrl: string | undefined): boolean {
+  if (!baseUrl) return false
+  try {
+    return DEEPSEEK_API_HOSTS.has(new URL(baseUrl).hostname.toLowerCase())
   } catch {
     return false
   }
@@ -670,6 +683,17 @@ function convertMessages(
           ...(lastAfterPossibleInjection.tool_calls ?? []),
           ...msg.tool_calls,
         ]
+      }
+
+      // Merge reasoning_content for DeepSeek multi-turn compatibility.
+      // DeepSeek requires reasoning_content to be passed back on every
+      // subsequent request. When the coalescing pass merges consecutive
+      // assistant messages, the reasoning payload must be merged as well
+      // so the model sees the full chain-of-thought history it expects.
+      if (msg.reasoning_content && lastAfterPossibleInjection.reasoning_content) {
+        lastAfterPossibleInjection.reasoning_content += '\n' + msg.reasoning_content
+      } else if (msg.reasoning_content) {
+        lastAfterPossibleInjection.reasoning_content = msg.reasoning_content
       }
     } else {
       coalesced.push(msg)
@@ -1489,7 +1513,11 @@ class OpenAIShimMessages {
       // Moonshot requires every assistant tool-call message to carry
       // reasoning_content when its thinking feature is active. Echo it back
       // from the thinking block we captured on the inbound response.
-      preserveReasoningContent: isMoonshotBaseUrl(request.baseUrl),
+      // DeepSeek likewise requires reasoning_content on every subsequent
+      // request of a multi-turn conversation when multi-turn tool calls are
+      // in use; omitting it and the API returns 400.
+      preserveReasoningContent:
+        isMoonshotBaseUrl(request.baseUrl) || isDeepseekBaseUrl(request.baseUrl),
     })
 
     const body: Record<string, unknown> = {

--- a/src/utils/model/openaiContextWindows.ts
+++ b/src/utils/model/openaiContextWindows.ts
@@ -96,7 +96,14 @@ const OPENAI_CONTEXT_WINDOWS: Record<string, number> = {
   'o3-mini':                  200_000,
   'o4-mini':                  200_000,
 
-  // DeepSeek (V3: 128k context per official docs)
+  // DeepSeek
+  // V4 series (replaces deprecated V3 models — thinking enabled by default)
+  'deepseek-v4-pro':          128_000,
+  'deepseek-v4-flash':        128_000,
+  // User-facing display names
+  'DeepSeek-V4-Pro':          128_000,
+  'DeepSeek-V4-Flash':        128_000,
+  // Deprecated V3 models (kept for backward compatibility)
   'deepseek-chat':            128_000,
   'deepseek-reasoner':        128_000,
 
@@ -317,6 +324,12 @@ const OPENAI_MAX_OUTPUT_TOKENS: Record<string, number> = {
   'o4-mini':                  100_000,
 
   // DeepSeek
+  'deepseek-v4-pro':           32_768,
+  'deepseek-v4-flash':         32_768,
+  // User-facing display names
+  'DeepSeek-V4-Pro':           32_768,
+  'DeepSeek-V4-Flash':         32_768,
+  // Deprecated
   'deepseek-chat':              8_192,
   'deepseek-reasoner':         32_768,
 

--- a/src/utils/providerProfiles.ts
+++ b/src/utils/providerProfiles.ts
@@ -173,7 +173,7 @@ export function getProviderPresetDefaults(
         provider: 'openai',
         name: 'DeepSeek',
         baseUrl: 'https://api.deepseek.com/v1',
-        model: 'deepseek-chat',
+        model: 'deepseek-v4-pro',
         apiKey: '',
         requiresApiKey: true,
       }


### PR DESCRIPTION
## Summary

DeepSeek has deprecated their V3 endpoints (`deepseek-chat`, `deepseek-reasoner`) in favor of V4-series models (`deepseek-v4-pro`, `deepseek-v4-flash`) that require thinking mode to be explicitly enabled via `extra_body`. Without the thinking toggle, the V4 endpoint may hang or timeout rather than returning a clear error.

This PR extends the existing DeepSeek `reasoning_content` preservation (echoed back for multi-turn tool calls, same as the existing Moonshot path) and adds the V4-specific requirements.

## Changes

- **`src/services/api/openaiShim.ts`** — Inject `extra_body: { thinking: { type: "enabled" } }` for all DeepSeek API hosts. Skip `temperature` and `top_p` for DeepSeek (V4 thinking mode silently ignores these per [official docs](https://api-docs.deepseek.com/guides/thinking_mode)).
- **`src/utils/model/openaiContextWindows.ts`** — Register `deepseek-v4-pro` and `deepseek-v4-flash` (128k context, 32k output) with both lowercase and display-name casing for the `/provider` picker UI. Keep deprecated V3 entries for backwards compatibility.
- **`src/utils/providerProfiles.ts`** — Update default DeepSeek profile model from `deepseek-chat` to `deepseek-v4-pro`.

## Provider path tested

DeepSeek V4 API (`api.deepseek.com/v1`) — multi-turn conversation with tool calls confirmed working.

## Checks

```bash
bun test ./src/services/api/openaiShim.test.ts  # 59 pass, 0 fail
bun test ./src/utils/context.test.ts             # 19 pass, 0 fail
bun run scripts/build.ts                         # Built openclaude v0.6.0
```
