### PR TITLE
fix(query): restore system prompt structure and add missing config import

### DIFF
--- a/src/query.ts
+++ b/src/query.ts
@@ -99,6 +99,7 @@ import { applyToolResultBudget } from './utils/toolResultStorage.js'
 import { recordContentReplacement } from './utils/sessionStorage.js'
 import { handleStopHooks } from './query/stopHooks.js'
 import { buildQueryConfig } from './query/config.js'
+import { getGlobalConfig } from './utils/config.js'
 import { productionDeps, type QueryDeps } from './query/deps.js'
 import type { Terminal, Continue } from './query/transitions.js'
 import { feature } from 'bun:bundle'
@@ -476,14 +477,27 @@ async function* queryLoop(
       messagesForQuery = collapseResult.messages
     }
 
-    const lastMessage = messagesForQuery[messagesForQuery.length - 1]
-    const userQueryText = lastMessage?.type === 'user' ? (typeof lastMessage.message.content === 'string' ? lastMessage.message.content : '') : ''
-
-    const { getArcSummary } = await import('./utils/conversationArc.js')
-    const arcSummary = getArcSummary(userQueryText)
+    // arcSummary must be a separate array element; concatenating it into a
+    // template string makes [...systemPrompt] spread chars, shredding the prompt.
+    let promptWithArc: readonly string[] = systemPrompt
+    if (feature('CONVERSATION_ARC')) {
+      if (getGlobalConfig().knowledgeGraphEnabled) {
+        const lastMessage = messagesForQuery[messagesForQuery.length - 1]
+        const userQueryText =
+          lastMessage?.type === 'user' &&
+          typeof lastMessage.message.content === 'string'
+            ? lastMessage.message.content
+            : ''
+        const { getArcSummary } = await import('./utils/conversationArc.js')
+        const arcSummary = getArcSummary(userQueryText)
+        if (arcSummary) {
+          promptWithArc = [...systemPrompt, arcSummary]
+        }
+      }
+    }
 
     const fullSystemPrompt = asSystemPrompt(
-      appendSystemContext(`${systemPrompt}\n\n${arcSummary}`, systemContext),
+      appendSystemContext(asSystemPrompt(promptWithArc), systemContext),
     )
 
     queryCheckpoint('query_autocompact_start')
@@ -1878,9 +1892,11 @@ async function* queryLoop(
     }
 
     queryCheckpoint('query_recursive_call')
-    
-    // Persist conversation progress to global project memory
-    if (getGlobalConfig().knowledgeGraphEnabled) {
+
+    if (
+      feature('CONVERSATION_ARC') &&
+      getGlobalConfig().knowledgeGraphEnabled
+    ) {
       const { finalizeArcTurn } = await import('./utils/conversationArc.js')
       finalizeArcTurn()
     }


### PR DESCRIPTION
Summary

  - what changed: Three fixes in src/query.ts cleaning up regressions from the memory PRs (#894 / #899):
    a. Add the missing import { getGlobalConfig } from './utils/config.js' — six call sites referenced this symbol but no import existed.
    b. Stop coercing SystemPrompt (a readonly string[]) into a template-literal string before passing it to appendSystemContext. Append arcSummary as its own array element
  when the gate is on.
    c. Wrap the finalizeArcTurn() call near the recursive-call checkpoint in feature('CONVERSATION_ARC'), matching the gating used by every other arc/memory call site.
  - why it changed: Two distinct runtime bugs were chained together:
    - The unimported getGlobalConfig() was hidden by short-circuit evaluation at five sites (feature('CONVERSATION_ARC') && getGlobalConfig().…, where the build
  pre-processor replaces the missing flag with literal false). The sixth site had no feature() gate, so it ran on every recursive queryLoop iteration and threw
  ReferenceError: getGlobalConfig is not defined — visibly killing subagents (e.g. "Agent 'Analyze codebase architecture' failed: getGlobalConfig is not defined").
    - appendSystemContext(\${systemPrompt}\n\n${arcSummary}`, …) Array.toString()-coerced the prompt array to a comma-joined string, which [...stringValue]then spread
  **character-by-character** insideappendSystemContext`, rebuilding the system prompt as thousands of one-char blocks. Stronger models tolerated it; weaker open models
  (kimi) degraded into looping on read-only tools without ever committing edits — the "stuck" behavior reported in-session.

  Impact

  - user-facing impact: Subagent tool paths (Explore/Plan/general-purpose) no longer crash with getGlobalConfig is not defined. Mid-task hangs and read-only-tool loops on
  weaker provider models (kimi, etc.) caused by the shredded system prompt are eliminated. Prompt cache integrity is restored — section boundaries are no longer collapsed
  every turn.
  - developer/maintainer impact: feature('CONVERSATION_ARC') and feature('MULTI_TURN_CONTEXT') are still off by default (absent from scripts/build.ts's flag map → resolved
  to false), so the conversation-arc / KG path is dead-code-eliminated for everyone, exactly as before. getArcSummary() no longer runs unconditionally on every turn. No
  public API changes; arc behavior, when later enabled, is correct (separate prompt section, properly typed array).

  Testing

  - bun run build — clean (✓ Built openclaude v0.6.0 → dist/cli.mjs)
  - bun run smoke — node dist/cli.mjs --version → 0.6.0 (Open Claude)
  - focused tests: bun test — 1464 pass / 0 fail / 3152 expect() calls / 3.77s

  Notes

  - provider/model path tested: Verified against the OpenAI-shim path (kimi was the original repro). Anthropic-direct path unaffected (same code is reached through queryLoop
   regardless of provider).
  - screenshots attached: N/A — no UI changes.
  - follow-up work or known limitations:
    - tsc --noEmit is currently broken on main by pre-existing unrelated errors (MACRO globals, missing services/oauth/types.js, SecureStorageData.claudeAiOauth, etc.).
  That's why this regression slipped past CI in the first place. Worth a separate cleanup PR so future memory/agent PRs are guarded by typecheck again.
    - CONVERSATION_ARC and MULTI_TURN_CONTEXT are referenced in code but never declared in scripts/build.ts's featureFlags map. They currently resolve to false via the ??
  false fallback. If/when the memory feature is intentionally enabled in the open build, they should be added to that map explicitly so the gate is intentional rather than
  implicit.
