### PR TITLE
fix(openaiShim): unconditionally set reasoning_content for DeepSeek V…

### DIFF
--- a/src/services/api/openaiShim.ts
+++ b/src/services/api/openaiShim.ts
@@ -539,9 +539,11 @@ function convertMessages(
         // (harmless) or strict-reject unknown fields (harmful).
         if (preserveReasoningContent) {
           const thinkingText = (thinkingBlock as { thinking?: string } | undefined)?.thinking
-          if (typeof thinkingText === 'string' && thinkingText.trim().length > 0) {
-            assistantMsg.reasoning_content = thinkingText
-          }
+          // DeepSeek V4 (and similar reasoning providers) require reasoning_content
+          // to be present on every assistant message, even as empty string, when
+          // thinking mode is enabled. The field's presence satisfies the API contract;
+          // omitting it causes 400: "reasoning_content must be passed back to the API".
+          assistantMsg.reasoning_content = typeof thinkingText === 'string' ? thinkingText : ''
         }
 
         if (toolUses.length > 0) {
@@ -635,6 +637,12 @@ function convertMessages(
           })(),
         }
 
+        // Reasoning providers require reasoning_content on every assistant
+        // message when thinking mode is active (empty string is accepted).
+        if (preserveReasoningContent) {
+          assistantMsg.reasoning_content = ''
+        }
+
         if (assistantMsg.content) {
           result.push(assistantMsg)
         }
@@ -659,6 +667,7 @@ function convertMessages(
       coalesced.push({
         role: 'assistant',
         content: '[Tool execution interrupted by user]',
+        reasoning_content: '',
       })
     }
 


### PR DESCRIPTION
## Summary
- DeepSeek V4 (and similar reasoning providers) require `reasoning_content`
  present on every assistant message in the request history when thinking
  mode is active. The API accepts empty string — the field just needs to
  exist.
- Prior guard only set `reasoning_content` when `thinkingText.trim().length > 0`,
  so tool-call turns and edge cases (synthetic interrupts, non-array content)
  sent assistant messages without the field → 400.
- Fix: always set `reasoning_content` when `preserveReasoningContent` is true,
  falling back to `""` when thinking text is missing. Two additional sites
  (coalescing interrupt, string-content else branch) now also emit the field.
## Impact
- **user-facing**: fixes `API Error: 400 {"error":{"message":"The reasoning_content in the thinking mode must be passed back to the API."}}`
  for DeepSeek V4 models (`deepseek-v4-pro`, `deepseek-v4-flash`) against
  `api.deepseek.com`. Tool-call rounds and plain multi-turn now work.
- **developer/maintainer**: gated behind existing `preserveReasoningContent`
  flag. Non-DeepSeek providers (OpenAI, Gemini, Mistral, etc.) unaffected.
## Testing
- `bun run build`
- `bun run smoke`
- focused tests: `bun test src/services/api/openaiShim.test.ts`
- live verification: `deepseek-v4-pro` against `api.deepseek.com` —
  multi-turn tool-call round completed without 400
## Notes
- provider/model path tested: DeepSeek (`api.deepseek.com`) with
  `deepseek-v4-pro`
- follow-up work or known limitations: none