### PR TITLE
Fix commit attribution configuration

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -9,6 +9,7 @@ import feedback from './commands/feedback/index.js'
 import clear from './commands/clear/index.js'
 import color from './commands/color/index.js'
 import commit from './commands/commit.js'
+import commitMessage from './commands/commit-message/index.js'
 import copy from './commands/copy/index.js'
 import desktop from './commands/desktop/index.js'
 import commitPushPr from './commands/commit-push-pr.js'
@@ -277,6 +278,7 @@ const COMMANDS = memoize((): Command[] => [
   clear,
   color,
   compact,
+  commitMessage,
   config,
   copy,
   desktop,

--- a/src/commands/commit-message/commit-message.test.ts
+++ b/src/commands/commit-message/commit-message.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'bun:test'
+import { formatCoAuthorTrailer, parseCoAuthor } from './commit-message.js'
+
+describe('commit-message command helpers', () => {
+  it('parses quoted co-author names with a plain email', () => {
+    expect(parseCoAuthor('"GPT 5.5" noreply@openclaude.dev')).toEqual({
+      name: 'GPT 5.5',
+      email: 'noreply@openclaude.dev',
+    })
+  })
+
+  it('parses co-author trailers with angle-bracket emails', () => {
+    expect(parseCoAuthor('OpenClaude (gpt-5.5) <noreply@openclaude.dev>')).toEqual(
+      {
+        name: 'OpenClaude (gpt-5.5)',
+        email: 'noreply@openclaude.dev',
+      },
+    )
+  })
+
+  it('formats a sanitized co-author trailer', () => {
+    expect(
+      formatCoAuthorTrailer('OpenClaude <gpt>\n', '<noreply@openclaude.dev>'),
+    ).toBe('Co-Authored-By: OpenClaude gpt <noreply@openclaude.dev>')
+  })
+})

--- a/src/commands/commit-message/commit-message.test.ts
+++ b/src/commands/commit-message/commit-message.test.ts
@@ -28,11 +28,13 @@ describe('commit-message command helpers', () => {
     ).toBe('Co-Authored-By: OpenClaude gpt <noreply@openclaude.dev>')
   })
 
-  it('makes set-attribution scope explicit in usage text', () => {
+  it('makes set scope explicit with example text', () => {
     expect(USAGE).toContain(
       'Controls only the attribution text appended after /commit messages.',
     )
-    expect(USAGE).toContain('/commit-message set-attribution')
-    expect(USAGE).not.toContain('/commit-message set <')
+    expect(USAGE).toContain(
+      '/commit-message set "Generated with OpenClaude using GPT-5.5"',
+    )
+    expect(USAGE).not.toContain('/commit-message set-attribution')
   })
 })

--- a/src/commands/commit-message/commit-message.test.ts
+++ b/src/commands/commit-message/commit-message.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'bun:test'
 import {
   formatCoAuthorTrailer,
   parseCoAuthor,
+  stripMatchingQuotes,
   USAGE,
 } from './commit-message.js'
 
@@ -19,6 +20,23 @@ describe('commit-message command helpers', () => {
         name: 'OpenClaude (gpt-5.5)',
         email: 'noreply@openclaude.dev',
       },
+    )
+  })
+
+  it('rejects co-author trailers with empty sanitized names', () => {
+    expect(parseCoAuthor('"  " noreply@openclaude.dev')).toBeNull()
+    expect(parseCoAuthor('"  " <noreply@openclaude.dev>')).toBeNull()
+  })
+
+  it('strips one pair of matching quotes from custom attribution text', () => {
+    expect(stripMatchingQuotes('"Generated with OpenClaude"')).toBe(
+      'Generated with OpenClaude',
+    )
+    expect(stripMatchingQuotes("'Generated with OpenClaude'")).toBe(
+      'Generated with OpenClaude',
+    )
+    expect(stripMatchingQuotes('"Generated with OpenClaude')).toBe(
+      '"Generated with OpenClaude',
     )
   })
 

--- a/src/commands/commit-message/commit-message.test.ts
+++ b/src/commands/commit-message/commit-message.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'bun:test'
-import { formatCoAuthorTrailer, parseCoAuthor } from './commit-message.js'
+import {
+  formatCoAuthorTrailer,
+  parseCoAuthor,
+  USAGE,
+} from './commit-message.js'
 
 describe('commit-message command helpers', () => {
   it('parses quoted co-author names with a plain email', () => {
@@ -22,5 +26,13 @@ describe('commit-message command helpers', () => {
     expect(
       formatCoAuthorTrailer('OpenClaude <gpt>\n', '<noreply@openclaude.dev>'),
     ).toBe('Co-Authored-By: OpenClaude gpt <noreply@openclaude.dev>')
+  })
+
+  it('makes set-attribution scope explicit in usage text', () => {
+    expect(USAGE).toContain(
+      'Controls only the attribution text appended after /commit messages.',
+    )
+    expect(USAGE).toContain('/commit-message set-attribution')
+    expect(USAGE).not.toContain('/commit-message set <')
   })
 })

--- a/src/commands/commit-message/commit-message.ts
+++ b/src/commands/commit-message/commit-message.ts
@@ -11,14 +11,16 @@ type ParsedCoAuthor = {
   email: string
 }
 
-const USAGE = [
+export const USAGE = [
   'Commit message attribution',
+  'Controls only the attribution text appended after /commit messages.',
+  'It does not set the commit title or summary.',
   '',
   'Usage:',
   '  /commit-message status',
   '  /commit-message off',
   '  /commit-message default',
-  '  /commit-message set <custom attribution text>',
+  '  /commit-message set-attribution <custom text appended after the commit message>',
   '  /commit-message co-author "Name" name@example.com',
 ].join('\n')
 
@@ -122,6 +124,7 @@ export const call: LocalCommandCall = async args => {
       }
     }
 
+    case 'set-attribution':
     case 'set':
     case 'custom': {
       const value = commandArg
@@ -130,7 +133,7 @@ export const call: LocalCommandCall = async args => {
       if (error) return { type: 'text', value: error }
       return {
         type: 'text',
-        value: `Commit attribution set to:\n${value}`,
+        value: `Commit attribution text appended by /commit set to:\n${value}`,
       }
     }
 

--- a/src/commands/commit-message/commit-message.ts
+++ b/src/commands/commit-message/commit-message.ts
@@ -31,6 +31,17 @@ function sanitizeSingleLine(value: string): string {
     .trim()
 }
 
+export function stripMatchingQuotes(value: string): string {
+  const trimmed = value.trim()
+  if (trimmed.length < 2) return trimmed
+  const first = trimmed[0]
+  const last = trimmed[trimmed.length - 1]
+  if ((first === '"' && last === '"') || (first === "'" && last === "'")) {
+    return trimmed.slice(1, -1)
+  }
+  return trimmed
+}
+
 export function formatCoAuthorTrailer(name: string, email: string): string {
   const cleanName = sanitizeSingleLine(name).replace(/[<>]/g, '')
   const cleanEmail = sanitizeSingleLine(email).replace(/[<>]/g, '')
@@ -43,11 +54,14 @@ export function parseCoAuthor(value: string): ParsedCoAuthor | null {
     /^(?:"([^"]+)"|'([^']+)'|(.+?))\s*<([^<>\s]+@[^<>\s]+)>$/,
   )
   if (angleMatch) {
+    const name = sanitizeSingleLine(
+      angleMatch[1] ?? angleMatch[2] ?? angleMatch[3] ?? '',
+    )
+    const email = sanitizeSingleLine(angleMatch[4] ?? '')
+    if (!name || !email) return null
     return {
-      name: sanitizeSingleLine(
-        angleMatch[1] ?? angleMatch[2] ?? angleMatch[3] ?? '',
-      ),
-      email: sanitizeSingleLine(angleMatch[4] ?? ''),
+      name,
+      email,
     }
   }
 
@@ -56,11 +70,15 @@ export function parseCoAuthor(value: string): ParsedCoAuthor | null {
   )
   if (!plainMatch) return null
 
+  const name = sanitizeSingleLine(
+    plainMatch[1] ?? plainMatch[2] ?? plainMatch[3] ?? '',
+  )
+  const email = sanitizeSingleLine(plainMatch[4] ?? '')
+  if (!name || !email) return null
+
   return {
-    name: sanitizeSingleLine(
-      plainMatch[1] ?? plainMatch[2] ?? plainMatch[3] ?? '',
-    ),
-    email: sanitizeSingleLine(plainMatch[4] ?? ''),
+    name,
+    email,
   }
 }
 
@@ -127,7 +145,7 @@ export const call: LocalCommandCall = async args => {
     case 'set-attribution':
     case 'set':
     case 'custom': {
-      const value = commandArg
+      const value = stripMatchingQuotes(commandArg)
       if (!value) return { type: 'text', value: USAGE }
       const error = saveCommitAttribution(value)
       if (error) return { type: 'text', value: error }

--- a/src/commands/commit-message/commit-message.ts
+++ b/src/commands/commit-message/commit-message.ts
@@ -1,0 +1,153 @@
+import type { LocalCommandCall } from '../../types/command.js'
+import { getAttributionTexts } from '../../utils/attribution.js'
+import { settingsChangeDetector } from '../../utils/settings/changeDetector.js'
+import {
+  getInitialSettings,
+  updateSettingsForSource,
+} from '../../utils/settings/settings.js'
+
+type ParsedCoAuthor = {
+  name: string
+  email: string
+}
+
+const USAGE = [
+  'Commit message attribution',
+  '',
+  'Usage:',
+  '  /commit-message status',
+  '  /commit-message off',
+  '  /commit-message default',
+  '  /commit-message set <custom attribution text>',
+  '  /commit-message co-author "Name" name@example.com',
+  '  /commit-message co-author "Name" <name@example.com>',
+].join('\n')
+
+function sanitizeSingleLine(value: string): string {
+  return value
+    .replace(/[\r\n]/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim()
+}
+
+export function formatCoAuthorTrailer(name: string, email: string): string {
+  const cleanName = sanitizeSingleLine(name).replace(/[<>]/g, '')
+  const cleanEmail = sanitizeSingleLine(email).replace(/[<>]/g, '')
+  return `Co-Authored-By: ${cleanName} <${cleanEmail}>`
+}
+
+export function parseCoAuthor(value: string): ParsedCoAuthor | null {
+  const trimmed = value.trim()
+  const angleMatch = trimmed.match(
+    /^(?:"([^"]+)"|'([^']+)'|(.+?))\s*<([^<>\s]+@[^<>\s]+)>$/,
+  )
+  if (angleMatch) {
+    return {
+      name: sanitizeSingleLine(
+        angleMatch[1] ?? angleMatch[2] ?? angleMatch[3] ?? '',
+      ),
+      email: sanitizeSingleLine(angleMatch[4] ?? ''),
+    }
+  }
+
+  const plainMatch = trimmed.match(
+    /^(?:"([^"]+)"|'([^']+)'|(.+?))\s+([^<>\s]+@[^<>\s]+)$/,
+  )
+  if (!plainMatch) return null
+
+  return {
+    name: sanitizeSingleLine(
+      plainMatch[1] ?? plainMatch[2] ?? plainMatch[3] ?? '',
+    ),
+    email: sanitizeSingleLine(plainMatch[4] ?? ''),
+  }
+}
+
+function saveCommitAttribution(commit: string | undefined): string | null {
+  const result = updateSettingsForSource('userSettings', {
+    attribution: { commit },
+  })
+  if (result.error) {
+    return 'Failed to update user settings. Check your settings file for syntax errors.'
+  }
+  settingsChangeDetector.notifyChange('userSettings')
+  return null
+}
+
+function formatStatus(): string {
+  const effective = getAttributionTexts().commit
+  const configured = getInitialSettings().attribution?.commit
+  const configuredText =
+    configured === undefined
+      ? 'default'
+      : configured === ''
+        ? 'off'
+        : configured
+
+  return [
+    'Commit message attribution',
+    `Configured: ${configuredText}`,
+    `Effective: ${effective || 'off'}`,
+  ].join('\n')
+}
+
+export const call: LocalCommandCall = async args => {
+  const raw = args.trim()
+  if (!raw || raw === 'status') {
+    return { type: 'text', value: `${formatStatus()}\n\n${USAGE}` }
+  }
+
+  const [command = '', ...rest] = raw.split(/\s+/)
+  const commandArg = rest.join(' ').trim()
+
+  switch (command.toLowerCase()) {
+    case 'off':
+    case 'none':
+    case 'disable': {
+      const error = saveCommitAttribution('')
+      if (error) return { type: 'text', value: error }
+      return {
+        type: 'text',
+        value: 'Commit attribution disabled for future /commit messages.',
+      }
+    }
+
+    case 'default':
+    case 'reset':
+    case 'on': {
+      const error = saveCommitAttribution(undefined)
+      if (error) return { type: 'text', value: error }
+      return {
+        type: 'text',
+        value: 'Commit attribution reset to the OpenClaude default.',
+      }
+    }
+
+    case 'set':
+    case 'custom': {
+      const value = commandArg
+      if (!value) return { type: 'text', value: USAGE }
+      const error = saveCommitAttribution(value)
+      if (error) return { type: 'text', value: error }
+      return {
+        type: 'text',
+        value: `Commit attribution set to:\n${value}`,
+      }
+    }
+
+    case 'co-author':
+    case 'coauthor': {
+      const parsed = parseCoAuthor(commandArg)
+      if (!parsed) return { type: 'text', value: USAGE }
+      const trailer = formatCoAuthorTrailer(parsed.name, parsed.email)
+      const error = saveCommitAttribution(trailer)
+      if (error) return { type: 'text', value: error }
+      return {
+        type: 'text',
+        value: `Commit co-author set to:\n${trailer}`,
+      }
+    }
+  }
+
+  return { type: 'text', value: USAGE }
+}

--- a/src/commands/commit-message/commit-message.ts
+++ b/src/commands/commit-message/commit-message.ts
@@ -20,7 +20,7 @@ export const USAGE = [
   '  /commit-message status',
   '  /commit-message off',
   '  /commit-message default',
-  '  /commit-message set-attribution <custom text appended after the commit message>',
+  '  /commit-message set "Generated with OpenClaude using GPT-5.5"',
   '  /commit-message co-author "Name" name@example.com',
 ].join('\n')
 

--- a/src/commands/commit-message/commit-message.ts
+++ b/src/commands/commit-message/commit-message.ts
@@ -20,7 +20,6 @@ const USAGE = [
   '  /commit-message default',
   '  /commit-message set <custom attribution text>',
   '  /commit-message co-author "Name" name@example.com',
-  '  /commit-message co-author "Name" <name@example.com>',
 ].join('\n')
 
 function sanitizeSingleLine(value: string): string {

--- a/src/commands/commit-message/index.ts
+++ b/src/commands/commit-message/index.ts
@@ -4,7 +4,7 @@ const command = {
   type: 'local',
   name: 'commit-message',
   description: 'Configure commit attribution text',
-  argumentHint: '[status|off|default|set <text>|co-author <name> <email>]',
+  argumentHint: '[status|off|default|set-attribution <text>|co-author <name> <email>]',
   supportsNonInteractive: true,
   load: () => import('./commit-message.js'),
 } satisfies Command

--- a/src/commands/commit-message/index.ts
+++ b/src/commands/commit-message/index.ts
@@ -4,7 +4,7 @@ const command = {
   type: 'local',
   name: 'commit-message',
   description: 'Configure commit attribution text',
-  argumentHint: '[status|off|default|set-attribution <text>|co-author <name> <email>]',
+  argumentHint: '[status|off|default|set "text"|co-author <name> <email>]',
   supportsNonInteractive: true,
   load: () => import('./commit-message.js'),
 } satisfies Command

--- a/src/commands/commit-message/index.ts
+++ b/src/commands/commit-message/index.ts
@@ -1,0 +1,12 @@
+import type { Command } from '../../commands.js'
+
+const command = {
+  type: 'local',
+  name: 'commit-message',
+  description: 'Configure commit attribution text',
+  argumentHint: '[status|off|default|set <text>|co-author <name> <email>]',
+  supportsNonInteractive: true,
+  load: () => import('./commit-message.js'),
+} satisfies Command
+
+export default command

--- a/src/skills/bundled/updateConfig.ts
+++ b/src/skills/bundled/updateConfig.ts
@@ -73,6 +73,7 @@ Settings load in order: user → project → local (later overrides earlier).
 }
 \`\`\`
 Set \`commit\` or \`pr\` to empty string \`""\` to hide that attribution.
+You can also use \`/commit-message\` to configure commit attribution from the CLI.
 
 ### MCP Server Management
 \`\`\`json

--- a/src/utils/attribution.test.ts
+++ b/src/utils/attribution.test.ts
@@ -35,8 +35,11 @@ describe('getDefaultCommitCoAuthorName', () => {
     ).toBe('Claude Opus 4.6')
   })
 
-  it('uses the OpenClaude email for non-first-party commit attribution', () => {
+  it('uses the OpenClaude email for commit attribution across providers', () => {
     expect(getDefaultCommitCoAuthorEmail('openai')).toBe(
+      'openclaude@gitlawb.com',
+    )
+    expect(getDefaultCommitCoAuthorEmail('firstParty')).toBe(
       'openclaude@gitlawb.com',
     )
   })

--- a/src/utils/attribution.test.ts
+++ b/src/utils/attribution.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from 'bun:test'
-import { getDefaultCommitCoAuthorName } from './attribution.js'
+import {
+  getDefaultCommitCoAuthorEmail,
+  getDefaultCommitCoAuthorName,
+} from './attribution.js'
 
 describe('getDefaultCommitCoAuthorName', () => {
   it('does not label unknown non-Claude provider models as Opus', () => {
@@ -20,5 +23,11 @@ describe('getDefaultCommitCoAuthorName', () => {
         isInternalRepo: false,
       }),
     ).toBe('Claude Opus 4.6')
+  })
+
+  it('uses the OpenClaude email for non-first-party commit attribution', () => {
+    expect(getDefaultCommitCoAuthorEmail('openai')).toBe(
+      'openclaude@gitlawb.com',
+    )
   })
 })

--- a/src/utils/attribution.test.ts
+++ b/src/utils/attribution.test.ts
@@ -15,6 +15,16 @@ describe('getDefaultCommitCoAuthorName', () => {
     ).toBe('OpenClaude (gpt-5.5)')
   })
 
+  it('does not apply internal Claude formatting to non-Claude providers', () => {
+    expect(
+      getDefaultCommitCoAuthorName({
+        model: 'gpt-5.5',
+        apiProvider: 'openai',
+        isInternalRepo: true,
+      }),
+    ).toBe('OpenClaude (gpt-5.5)')
+  })
+
   it('keeps the codename-safe fallback for unknown first-party models', () => {
     expect(
       getDefaultCommitCoAuthorName({
@@ -23,6 +33,16 @@ describe('getDefaultCommitCoAuthorName', () => {
         isInternalRepo: false,
       }),
     ).toBe('Claude Opus 4.6')
+  })
+
+  it('sanitizes unknown internal Claude co-author names', () => {
+    expect(
+      getDefaultCommitCoAuthorName({
+        model: 'bad\nmodel<id>',
+        apiProvider: 'firstParty',
+        isInternalRepo: true,
+      }),
+    ).toBe('Claude (bad model id)')
   })
 
   it('does not duplicate the Claude prefix for Claude model names', () => {

--- a/src/utils/attribution.test.ts
+++ b/src/utils/attribution.test.ts
@@ -25,6 +25,16 @@ describe('getDefaultCommitCoAuthorName', () => {
     ).toBe('Claude Opus 4.6')
   })
 
+  it('does not duplicate the Claude prefix for Claude model names', () => {
+    expect(
+      getDefaultCommitCoAuthorName({
+        model: 'claude-opus-4-6',
+        apiProvider: 'firstParty',
+        isInternalRepo: false,
+      }),
+    ).toBe('Claude Opus 4.6')
+  })
+
   it('uses the OpenClaude email for non-first-party commit attribution', () => {
     expect(getDefaultCommitCoAuthorEmail('openai')).toBe(
       'openclaude@gitlawb.com',

--- a/src/utils/attribution.test.ts
+++ b/src/utils/attribution.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'bun:test'
+import { getDefaultCommitCoAuthorName } from './attribution.js'
+
+describe('getDefaultCommitCoAuthorName', () => {
+  it('does not label unknown non-Claude provider models as Opus', () => {
+    expect(
+      getDefaultCommitCoAuthorName({
+        model: 'gpt-5.5',
+        apiProvider: 'openai',
+        isInternalRepo: false,
+      }),
+    ).toBe('OpenClaude (gpt-5.5)')
+  })
+
+  it('keeps the codename-safe fallback for unknown first-party models', () => {
+    expect(
+      getDefaultCommitCoAuthorName({
+        model: 'unreleased-internal-model',
+        apiProvider: 'firstParty',
+        isInternalRepo: false,
+      }),
+    ).toBe('Claude Opus 4.6')
+  })
+})

--- a/src/utils/attribution.ts
+++ b/src/utils/attribution.ts
@@ -43,15 +43,20 @@ function sanitizeCoAuthorNamePart(value: string): string {
   return value
     .replace(/[\r\n<>]/g, ' ')
     .replace(/\s+/g, ' ')
+    .replace(/\(\s+/g, '(')
+    .replace(/\s+\)/g, ')')
     .trim()
 }
 
 function formatClaudeCoAuthorName(model: string): string {
   const publicName = getPublicModelDisplayName(model)
   if (!publicName) {
-    return getPublicModelName(model)
+    return sanitizeCoAuthorNamePart(getPublicModelName(model))
   }
-  return publicName.startsWith('Claude ') ? publicName : `Claude ${publicName}`
+  const coAuthorName = publicName.startsWith('Claude ')
+    ? publicName
+    : `Claude ${publicName}`
+  return sanitizeCoAuthorNamePart(coAuthorName)
 }
 
 export function getDefaultCommitCoAuthorName({
@@ -72,7 +77,7 @@ export function getDefaultCommitCoAuthorName({
     apiProvider === 'foundry' ||
     normalizedModel.includes('claude')
 
-  if (isInternalRepo || (isClaudeProvider && isKnownPublicModel)) {
+  if (isClaudeProvider && (isInternalRepo || isKnownPublicModel)) {
     return formatClaudeCoAuthorName(model)
   }
 
@@ -80,6 +85,7 @@ export function getDefaultCommitCoAuthorName({
   // historical public fallback. OpenAI-compatible providers should identify the
   // actual configured model instead of claiming Claude Opus.
   if (apiProvider === 'firstParty') {
+    // @[MODEL LAUNCH]: Update this fallback when the default public Claude model changes.
     return 'Claude Opus 4.6'
   }
 

--- a/src/utils/attribution.ts
+++ b/src/utils/attribution.ts
@@ -39,6 +39,46 @@ export type AttributionTexts = {
   pr: string
 }
 
+function sanitizeCoAuthorNamePart(value: string): string {
+  return value
+    .replace(/[\r\n<>]/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim()
+}
+
+export function getDefaultCommitCoAuthorName({
+  model,
+  apiProvider,
+  isInternalRepo,
+}: {
+  model: string
+  apiProvider: string
+  isInternalRepo: boolean
+}): string {
+  const isKnownPublicModel = getPublicModelDisplayName(model) !== null
+  const normalizedModel = model.toLowerCase()
+  const isClaudeProvider =
+    apiProvider === 'firstParty' ||
+    apiProvider === 'bedrock' ||
+    apiProvider === 'vertex' ||
+    apiProvider === 'foundry' ||
+    normalizedModel.includes('claude')
+
+  if (isInternalRepo || (isClaudeProvider && isKnownPublicModel)) {
+    return getPublicModelName(model)
+  }
+
+  // Unknown first-party models may be unreleased Claude codenames, so keep the
+  // historical public fallback. OpenAI-compatible providers should identify the
+  // actual configured model instead of claiming Claude Opus.
+  if (apiProvider === 'firstParty') {
+    return 'Claude Opus 4.6'
+  }
+
+  const sanitizedModel = sanitizeCoAuthorNamePart(model)
+  return sanitizedModel ? `OpenClaude (${sanitizedModel})` : 'OpenClaude'
+}
+
 /**
  * Returns attribution text for commits and PRs based on user settings.
  * Handles:
@@ -65,19 +105,19 @@ export function getAttributionTexts(): AttributionTexts {
     return { commit: '', pr: '' }
   }
 
-  // @[MODEL LAUNCH]: Update the hardcoded fallback model name below (guards against codename leaks).
-  // For internal repos, use the real model name. For external repos,
-  // fall back to "Claude Opus 4.6" for unrecognized models to avoid leaking codenames.
+  // First-party unknown models may be unreleased Claude codenames. Other
+  // providers can safely use the configured public model string.
   const model = getMainLoopModel()
-  const isKnownPublicModel = getPublicModelDisplayName(model) !== null
-  const modelName =
-    isInternalModelRepoCached() || isKnownPublicModel
-      ? getPublicModelName(model)
-      : 'Claude Opus 4.6'
+  const apiProvider = getAPIProvider()
+  const modelName = getDefaultCommitCoAuthorName({
+    model,
+    apiProvider,
+    isInternalRepo: isInternalModelRepoCached(),
+  })
   const defaultAttribution =
     '🤖 Generated with [OpenClaude](https://github.com/Gitlawb/openclaude)'
   const coAuthorDomain =
-    getAPIProvider() === 'firstParty' ? 'anthropic.com' : 'openclaude.dev'
+    apiProvider === 'firstParty' ? 'anthropic.com' : 'openclaude.dev'
   const defaultCommit = isEnvTruthy(
     process.env.OPENCLAUDE_DISABLE_CO_AUTHORED_BY,
   )

--- a/src/utils/attribution.ts
+++ b/src/utils/attribution.ts
@@ -87,10 +87,8 @@ export function getDefaultCommitCoAuthorName({
   return sanitizedModel ? `OpenClaude (${sanitizedModel})` : 'OpenClaude'
 }
 
-export function getDefaultCommitCoAuthorEmail(apiProvider: string): string {
-  return apiProvider === 'firstParty'
-    ? 'noreply@anthropic.com'
-    : 'openclaude@gitlawb.com'
+export function getDefaultCommitCoAuthorEmail(_apiProvider: string): string {
+  return 'openclaude@gitlawb.com'
 }
 
 /**

--- a/src/utils/attribution.ts
+++ b/src/utils/attribution.ts
@@ -46,6 +46,14 @@ function sanitizeCoAuthorNamePart(value: string): string {
     .trim()
 }
 
+function formatClaudeCoAuthorName(model: string): string {
+  const publicName = getPublicModelDisplayName(model)
+  if (!publicName) {
+    return getPublicModelName(model)
+  }
+  return publicName.startsWith('Claude ') ? publicName : `Claude ${publicName}`
+}
+
 export function getDefaultCommitCoAuthorName({
   model,
   apiProvider,
@@ -65,7 +73,7 @@ export function getDefaultCommitCoAuthorName({
     normalizedModel.includes('claude')
 
   if (isInternalRepo || (isClaudeProvider && isKnownPublicModel)) {
-    return getPublicModelName(model)
+    return formatClaudeCoAuthorName(model)
   }
 
   // Unknown first-party models may be unreleased Claude codenames, so keep the

--- a/src/utils/attribution.ts
+++ b/src/utils/attribution.ts
@@ -79,6 +79,12 @@ export function getDefaultCommitCoAuthorName({
   return sanitizedModel ? `OpenClaude (${sanitizedModel})` : 'OpenClaude'
 }
 
+export function getDefaultCommitCoAuthorEmail(apiProvider: string): string {
+  return apiProvider === 'firstParty'
+    ? 'noreply@anthropic.com'
+    : 'openclaude@gitlawb.com'
+}
+
 /**
  * Returns attribution text for commits and PRs based on user settings.
  * Handles:
@@ -116,13 +122,12 @@ export function getAttributionTexts(): AttributionTexts {
   })
   const defaultAttribution =
     '🤖 Generated with [OpenClaude](https://github.com/Gitlawb/openclaude)'
-  const coAuthorDomain =
-    apiProvider === 'firstParty' ? 'anthropic.com' : 'openclaude.dev'
+  const coAuthorEmail = getDefaultCommitCoAuthorEmail(apiProvider)
   const defaultCommit = isEnvTruthy(
     process.env.OPENCLAUDE_DISABLE_CO_AUTHORED_BY,
   )
     ? ''
-    : `Co-Authored-By: ${modelName} <noreply@${coAuthorDomain}>`
+    : `Co-Authored-By: ${modelName} <${coAuthorEmail}>`
 
   const settings = getInitialSettings()
 


### PR DESCRIPTION
## Summary
- add /commit-message to view, disable, reset, or customize commit attribution
- avoid labeling non-Claude provider commit co-authors as Claude Opus 4.6
- document the CLI command alongside the existing attribution setting

## Test plan
- [x] bun test src/commands/commit-message/commit-message.test.ts src/utils/attribution.test.ts
- [x] git diff --check

Fixes #919