### PR TITLE
fix(codex): normalize and send xhigh reasoning effort

### DIFF
--- a/src/commands/effort/effort.codex.test.tsx
+++ b/src/commands/effort/effort.codex.test.tsx
@@ -1,7 +1,4 @@
-import { afterEach, expect, mock, test } from 'bun:test'
-
-import { getAdditionalModelOptionsCacheScope } from '../../services/api/providerConfig.js'
-import { getAPIProvider } from '../../utils/model/providers.js'
+import { afterEach, expect, test } from 'bun:test'
 
 const originalEnv = {
   CLAUDE_CODE_USE_OPENAI: process.env.CLAUDE_CODE_USE_OPENAI,
@@ -17,7 +14,6 @@ const originalEnv = {
 }
 
 afterEach(() => {
-  mock.restore()
   process.env.CLAUDE_CODE_USE_OPENAI = originalEnv.CLAUDE_CODE_USE_OPENAI
   process.env.CLAUDE_CODE_USE_GEMINI = originalEnv.CLAUDE_CODE_USE_GEMINI
   process.env.CLAUDE_CODE_USE_GITHUB = originalEnv.CLAUDE_CODE_USE_GITHUB
@@ -30,44 +26,11 @@ afterEach(() => {
   process.env.OPENAI_MODEL = originalEnv.OPENAI_MODEL
 })
 
-test('opens the model picker without awaiting local model discovery refresh', async () => {
-  process.env.CLAUDE_CODE_USE_OPENAI = '1'
-  delete process.env.CLAUDE_CODE_USE_GEMINI
-  delete process.env.CLAUDE_CODE_USE_GITHUB
-  delete process.env.CLAUDE_CODE_USE_MISTRAL
-  delete process.env.CLAUDE_CODE_USE_BEDROCK
-  delete process.env.CLAUDE_CODE_USE_VERTEX
-  delete process.env.CLAUDE_CODE_USE_FOUNDRY
-  delete process.env.OPENAI_API_BASE
-  process.env.OPENAI_BASE_URL = 'http://127.0.0.1:8080/v1'
-  process.env.OPENAI_MODEL = 'qwen2.5-coder-7b-instruct'
+async function importFreshEffortCommand() {
+  return import(`./effort.js?ts=${Date.now()}-${Math.random()}`)
+}
 
-  let resolveDiscovery: (() => void) | undefined
-  const discoverOpenAICompatibleModelOptions = mock(
-    () =>
-      new Promise<void>(resolve => {
-        resolveDiscovery = resolve
-      }),
-  )
-
-  mock.module('../../utils/model/openaiModelDiscovery.js', () => ({
-    discoverOpenAICompatibleModelOptions,
-  }))
-
-  expect(getAdditionalModelOptionsCacheScope()).toBe('openai:http://127.0.0.1:8080/v1')
-
-  const { call } = await import('./model.js')
-  const result = await Promise.race([
-    call(() => {}, {} as never, ''),
-    new Promise(resolve => setTimeout(() => resolve('timeout'), 50)),
-  ])
-
-  resolveDiscovery?.()
-
-  expect(result).not.toBe('timeout')
-})
-
-test('renders Codex internal max effort as xhigh in model command feedback', async () => {
+function useCodexProviderEnv() {
   process.env.CLAUDE_CODE_USE_OPENAI = '1'
   delete process.env.CLAUDE_CODE_USE_GEMINI
   delete process.env.CLAUDE_CODE_USE_GITHUB
@@ -78,9 +41,37 @@ test('renders Codex internal max effort as xhigh in model command feedback', asy
   delete process.env.OPENAI_API_BASE
   process.env.OPENAI_BASE_URL = 'https://chatgpt.com/backend-api/codex'
   process.env.OPENAI_MODEL = 'codexplan'
+}
 
-  const { renderEffortLabel } = await import('./model.js')
+test('Codex effort help does not leak the Claude max/Opus option', async () => {
+  useCodexProviderEnv()
 
-  expect(getAPIProvider()).toBe('codex')
-  expect(renderEffortLabel('gpt-5.5', 'max')).toBe('xhigh')
+  const { getEffortHelp } = await importFreshEffortCommand()
+  const help = getEffortHelp('gpt-5.5')
+
+  expect(help).toContain('xhigh')
+  expect(help).not.toContain('Opus')
+  expect(help).not.toContain('- max:')
+})
+
+test('Codex max alias feedback is displayed as xhigh without Opus wording', async () => {
+  useCodexProviderEnv()
+
+  const { executeEffort } = await importFreshEffortCommand()
+  const result = executeEffort('max', 'gpt-5.5')
+
+  expect(result.message).toContain('Set effort level to xhigh')
+  expect(result.message).not.toContain('Opus')
+})
+
+test('Codex models without reasoning effort reject xhigh instead of silently storing it', async () => {
+  useCodexProviderEnv()
+
+  const { executeEffort, getEffortHelp } = await importFreshEffortCommand()
+  const result = executeEffort('xhigh', 'gpt-5.3-codex-spark')
+
+  expect(result.message).toBe('Effort not supported for gpt-5.3-codex-spark')
+  expect(result.effortUpdate).toBeUndefined()
+  expect(getEffortHelp('gpt-5.3-codex-spark')).toContain('Usage: /effort [auto]')
+  expect(getEffortHelp('gpt-5.3-codex-spark')).not.toContain('xhigh')
 })

--- a/src/commands/effort/effort.tsx
+++ b/src/commands/effort/effort.tsx
@@ -4,7 +4,7 @@ import { useMainLoopModel } from '../../hooks/useMainLoopModel.js';
 import { type AnalyticsMetadata_I_VERIFIED_THIS_IS_NOT_CODE_OR_FILEPATHS, logEvent } from '../../services/analytics/index.js';
 import { useAppState, useSetAppState } from '../../state/AppState.js';
 import type { LocalJSXCommandOnDone } from '../../types/command.js';
-import { type EffortValue, getDisplayedEffortLevel, getEffortEnvOverride, getEffortValueDescription, isEffortLevel, isOpenAIEffortLevel, modelUsesOpenAIEffort, toPersistableEffort } from '../../utils/effort.js';
+import { type EffortValue, getAvailableEffortLevels, getDisplayedEffortLevel, getEffortEnvOverride, getEffortLevelDescription, getEffortLevelForDisplay, getEffortValueDescription, isEffortLevel, isOpenAIEffortLevel, modelSupportsEffort, modelUsesOpenAIEffort, openAIEffortToStandard, toPersistableEffort } from '../../utils/effort.js';
 import { EffortPicker } from '../../components/EffortPicker.js';
 import { updateSettingsForSource } from '../../utils/settings/settings.js';
 const COMMON_HELP_ARGS = ['help', '-h', '--help'];
@@ -14,8 +14,9 @@ type EffortCommandResult = {
     value: EffortValue | undefined;
   };
 };
-function setEffortValue(effortValue: EffortValue): EffortCommandResult {
+function setEffortValue(effortValue: EffortValue, displayValue?: string, model?: string): EffortCommandResult {
   const persistable = toPersistableEffort(effortValue);
+  const requestedValue = displayValue ?? (model && typeof effortValue === 'string' ? String(getEffortLevelForDisplay(model, effortValue)) : String(effortValue));
   if (persistable !== undefined) {
     const result = updateSettingsForSource('userSettings', {
       effortLevel: persistable
@@ -38,23 +39,23 @@ function setEffortValue(effortValue: EffortValue): EffortCommandResult {
     const envRaw = process.env.CLAUDE_CODE_EFFORT_LEVEL;
     if (persistable === undefined) {
       return {
-        message: `Not applied: CLAUDE_CODE_EFFORT_LEVEL=${envRaw} overrides effort this session, and ${effortValue} is session-only (nothing saved)`,
+        message: `Not applied: CLAUDE_CODE_EFFORT_LEVEL=${envRaw} overrides effort this session, and ${requestedValue} is session-only (nothing saved)`,
         effortUpdate: {
           value: effortValue
         }
       };
     }
     return {
-      message: `CLAUDE_CODE_EFFORT_LEVEL=${envRaw} overrides this session — clear it and ${effortValue} takes over`,
+      message: `CLAUDE_CODE_EFFORT_LEVEL=${envRaw} overrides this session — clear it and ${requestedValue} takes over`,
       effortUpdate: {
         value: effortValue
       }
     };
   }
-  const description = getEffortValueDescription(effortValue);
+  const description = requestedValue === 'xhigh' ? getEffortLevelDescription('xhigh') : getEffortValueDescription(effortValue);
   const suffix = persistable !== undefined ? '' : ' (this session only)';
   return {
-    message: `Set effort level to ${effortValue}${suffix}: ${description}`,
+    message: `Set effort level to ${requestedValue}${suffix}: ${description}`,
     effortUpdate: {
       value: effortValue
     }
@@ -65,13 +66,15 @@ export function showCurrentEffort(appStateEffort: EffortValue | undefined, model
   const effectiveValue = envOverride === null ? undefined : envOverride ?? appStateEffort;
   if (effectiveValue === undefined) {
     const level = getDisplayedEffortLevel(model, appStateEffort);
+    const displayLevel = getEffortLevelForDisplay(model, level);
     return {
-      message: `Effort level: auto (currently ${level})`
+      message: `Effort level: auto (currently ${displayLevel})`
     };
   }
-  const description = getEffortValueDescription(effectiveValue);
+  const displayValue = typeof effectiveValue === 'string' ? getEffortLevelForDisplay(model, effectiveValue) : effectiveValue;
+  const description = displayValue === 'xhigh' ? getEffortLevelDescription('xhigh') : getEffortValueDescription(effectiveValue);
   return {
-    message: `Current effort level: ${effectiveValue} (${description})`
+    message: `Current effort level: ${displayValue} (${description})`
   };
 }
 function unsetEffortLevel(): EffortCommandResult {
@@ -105,19 +108,30 @@ function unsetEffortLevel(): EffortCommandResult {
     }
   };
 }
-export function executeEffort(args: string): EffortCommandResult {
+export function executeEffort(args: string, model?: string): EffortCommandResult {
   const normalized = args.toLowerCase();
   if (normalized === 'auto' || normalized === 'unset') {
     return unsetEffortLevel();
   }
+  const recognized = isEffortLevel(normalized) || isOpenAIEffortLevel(normalized);
+  if (model !== undefined && !modelSupportsEffort(model)) {
+    return {
+      message: `Effort not supported for ${model}`
+    };
+  }
+  if (model !== undefined && recognized && !isRequestedEffortAvailable(normalized, model)) {
+    return {
+      message: `Invalid argument: ${args}. Valid options are: ${getValidEffortOptions(model).join(', ')}`
+    };
+  }
   if (isEffortLevel(normalized)) {
-    return setEffortValue(normalized);
+    return setEffortValue(normalized, undefined, model);
   }
   if (isOpenAIEffortLevel(normalized)) {
-    return setEffortValue(normalized);
+    return setEffortValue(openAIEffortToStandard(normalized), normalized, model);
   }
   return {
-    message: `Invalid argument: ${args}. Valid options are: low, medium, high, max, xhigh, auto`
+    message: `Invalid argument: ${args}. Valid options are: ${getValidEffortOptions(model).join(', ')}`
   };
 }
 function ShowCurrentEffort(t0) {
@@ -135,47 +149,68 @@ function ShowCurrentEffort(t0) {
 function _temp(s) {
   return s.effortValue;
 }
-function ApplyEffortAndClose(t0) {
-  const $ = _c(6);
-  const {
-    result,
-    onDone
-  } = t0;
+function ApplyEffortAndClose({
+  args,
+  onDone
+}: {
+  args: string;
+  onDone: LocalJSXCommandOnDone;
+}) {
   const setAppState = useSetAppState();
-  const {
-    effortUpdate,
-    message
-  } = result;
-  let t1;
-  let t2;
-  if ($[0] !== effortUpdate || $[1] !== message || $[2] !== onDone || $[3] !== setAppState) {
-    t1 = () => {
-      if (effortUpdate) {
-        setAppState(prev => ({
-          ...prev,
-          effortValue: effortUpdate.value
-        }));
-      }
-      onDone(message);
-    };
-    t2 = [setAppState, effortUpdate, message, onDone];
-    $[0] = effortUpdate;
-    $[1] = message;
-    $[2] = onDone;
-    $[3] = setAppState;
-    $[4] = t1;
-    $[5] = t2;
-  } else {
-    t1 = $[4];
-    t2 = $[5];
-  }
-  React.useEffect(t1, t2);
+  const model = useMainLoopModel();
+  React.useEffect(() => {
+    const result = executeEffort(args, model);
+    if (result.effortUpdate) {
+      setAppState(prev => ({
+        ...prev,
+        effortValue: result.effortUpdate?.value
+      }));
+    }
+    onDone(result.message);
+  }, [args, model, onDone, setAppState]);
   return null;
+}
+function getValidEffortOptions(model?: string): string[] {
+  if (model !== undefined) {
+    const levels = getAvailableEffortLevels(model).map(String);
+    return levels.length > 0 ? [...levels, 'auto'] : ['auto'];
+  }
+  return modelUsesOpenAIEffort(model ?? '')
+    ? ['low', 'medium', 'high', 'xhigh', 'auto']
+    : ['low', 'medium', 'high', 'max', 'auto'];
+}
+function isRequestedEffortAvailable(value: string, model: string): boolean {
+  const levels = getAvailableEffortLevels(model).map(String);
+  if (levels.includes(value)) {
+    return true;
+  }
+  // Codex/OpenAI store xhigh internally as max, so keep /effort max working
+  // as an alias when the model exposes xhigh.
+  return value === 'max' && levels.includes('xhigh');
+}
+export function getEffortHelp(model?: string): string {
+  const validOptions = getValidEffortOptions(model);
+  if (model !== undefined && !modelSupportsEffort(model)) {
+    return `Usage: /effort [${validOptions.join('|')}]\n\nEffort not supported for ${model}\n- auto: Use the default effort level for your model`;
+  }
+
+  const levelLines = [
+    '- low: Quick, straightforward implementation',
+    '- medium: Balanced approach with standard testing',
+    '- high: Comprehensive implementation with extensive testing',
+  ];
+  if (validOptions.includes('max')) {
+    levelLines.push('- max: Maximum capability with deepest reasoning (Opus 4.6 only)');
+  }
+  if (validOptions.includes('xhigh')) {
+    levelLines.push('- xhigh: Extra high reasoning effort for OpenAI/Codex');
+  }
+  return `Usage: /effort [${validOptions.join('|')}]\n\nEffort levels:\n${levelLines.join('\n')}\n- auto: Use the default effort level for your model`;
 }
 export async function call(onDone: LocalJSXCommandOnDone, _context: unknown, args?: string): Promise<React.ReactNode> {
   args = args?.trim() || '';
   if (COMMON_HELP_ARGS.includes(args)) {
-    onDone('Usage: /effort [low|medium|high|max|auto]\n\nEffort levels:\n- low: Quick, straightforward implementation\n- medium: Balanced approach with standard testing\n- high: Comprehensive implementation with extensive testing\n- max: Maximum capability with deepest reasoning (Opus 4.6 only)\n- auto: Use the default effort level for your model');
+    onDone(getEffortHelp());
     return;
   }
   if (args === 'current' || args === 'status') {
@@ -184,14 +219,12 @@ export async function call(onDone: LocalJSXCommandOnDone, _context: unknown, arg
   if (!args) {
     return <EffortPickerWrapper onDone={onDone} />;
   }
-  const result = executeEffort(args);
-  return <ApplyEffortAndClose result={result} onDone={onDone} />;
+  return <ApplyEffortAndClose args={args} onDone={onDone} />;
 }
 
 function EffortPickerWrapper({ onDone }: { onDone: LocalJSXCommandOnDone }) {
   const setAppState = useSetAppState();
   const model = useMainLoopModel();
-  const usesOpenAIEffort = modelUsesOpenAIEffort(model);
 
   function handleSelect(effort: EffortValue | undefined) {
     const persistable = toPersistableEffort(effort);
@@ -207,9 +240,10 @@ function EffortPickerWrapper({ onDone }: { onDone: LocalJSXCommandOnDone }) {
       ...prev,
       effortValue: effort
     }));
-    const description = effort ? getEffortValueDescription(effort) : 'Use default effort level for your model';
+    const displayEffort = effort && typeof effort === 'string' ? getEffortLevelForDisplay(model, effort) : effort;
+    const description = displayEffort === 'xhigh' ? getEffortLevelDescription('xhigh') : effort ? getEffortValueDescription(effort) : 'Use default effort level for your model';
     const suffix = persistable !== undefined ? '' : ' (this session only)';
-    onDone(`Set effort level to ${effort ?? 'auto'}${suffix}: ${description}`);
+    onDone(`Set effort level to ${displayEffort ?? 'auto'}${suffix}: ${description}`);
   }
 
   function handleCancel() {

--- a/src/commands/model/model.tsx
+++ b/src/commands/model/model.tsx
@@ -8,7 +8,7 @@ import { fetchBootstrapData } from '../../services/api/bootstrap.js';
 import { type AnalyticsMetadata_I_VERIFIED_THIS_IS_NOT_CODE_OR_FILEPATHS, logEvent } from '../../services/analytics/index.js';
 import { useAppState, useSetAppState } from '../../state/AppState.js';
 import type { LocalJSXCommandCall } from '../../types/command.js';
-import type { EffortLevel } from '../../utils/effort.js';
+import { type EffortLevel, type EffortValue, getEffortLevelForDisplay } from '../../utils/effort.js';
 import { isBilledAsExtraUsage } from '../../utils/extraUsage.js';
 import { clearFastModeCooldown, isFastModeAvailable, isFastModeEnabled, isFastModeSupportedByModel } from '../../utils/fastMode.js';
 import { MODEL_ALIASES } from '../../utils/model/aliases.js';
@@ -17,7 +17,7 @@ import type { ModelOption } from '../../utils/model/modelOptions.js';
 import { discoverOpenAICompatibleModelOptions } from '../../utils/model/openaiModelDiscovery.js';
 import { getAPIProvider } from '../../utils/model/providers.js';
 import { getActiveOpenAIModelOptionsCache, setActiveOpenAIModelOptionsCache } from '../../utils/providerProfiles.js';
-import { getDefaultMainLoopModelSetting, isOpus1mMergeEnabled, renderDefaultModelSetting } from '../../utils/model/model.js';
+import { getDefaultMainLoopModel, getDefaultMainLoopModelSetting, isOpus1mMergeEnabled, renderDefaultModelSetting } from '../../utils/model/model.js';
 import { isModelAllowed } from '../../utils/model/modelAllowlist.js';
 import { validateModel } from '../../utils/model/validateModel.js';
 import { getAdditionalModelOptionsCacheScope } from '../../services/api/providerConfig.js';
@@ -63,7 +63,7 @@ function ModelPickerWrapper(t0) {
       }));
       let message = `Set model to ${chalk.bold(renderModelLabel(model))}`;
       if (effort !== undefined) {
-        message = message + ` with ${chalk.bold(effort)} effort`;
+        message = message + ` with ${chalk.bold(renderEffortLabel(model, effort))} effort`;
       }
       let wasFastModeToggledOn = undefined;
       if (isFastModeEnabled()) {
@@ -257,7 +257,7 @@ function ShowModelAndClose(t0) {
   const mainLoopModelForSession = useAppState(_temp8);
   const effortValue = useAppState(_temp9);
   const displayModel = renderModelLabel(mainLoopModel);
-  const effortInfo = effortValue !== undefined ? ` (effort: ${effortValue})` : "";
+  const effortInfo = effortValue !== undefined ? ` (effort: ${renderEffortLabel(mainLoopModel, effortValue)})` : "";
   if (mainLoopModelForSession) {
     onDone(`Current model: ${chalk.bold(renderModelLabel(mainLoopModelForSession))} (session override from plan mode)\nBase model: ${displayModel}${effortInfo}`);
   } else {
@@ -329,4 +329,10 @@ export const call: LocalJSXCommandCall = async (onDone, _context, args) => {
 function renderModelLabel(model: string | null): string {
   const rendered = renderDefaultModelSetting(model ?? getDefaultMainLoopModelSetting());
   return model === null ? `${rendered} (default)` : rendered;
+}
+export function renderEffortLabel(model: string | null, effort: EffortValue): string {
+  if (typeof effort !== 'string') {
+    return String(effort);
+  }
+  return getEffortLevelForDisplay(model ?? getDefaultMainLoopModel(), effort);
 }

--- a/src/components/EffortIndicator.ts
+++ b/src/components/EffortIndicator.ts
@@ -8,6 +8,7 @@ import {
   type EffortLevel,
   type EffortValue,
   getDisplayedEffortLevel,
+  getEffortLevelForDisplay,
   modelSupportsEffort,
 } from '../utils/effort.js'
 
@@ -21,7 +22,7 @@ export function getEffortNotificationText(
 ): string | undefined {
   if (!modelSupportsEffort(model)) return undefined
   const level = getDisplayedEffortLevel(model, effortValue)
-  return `${effortLevelToSymbol(level)} ${level} · /effort`
+  return `${effortLevelToSymbol(level)} ${getEffortLevelForDisplay(model, level)} · /effort`
 }
 
 export function effortLevelToSymbol(level: EffortLevel): string {

--- a/src/components/EffortPicker.tsx
+++ b/src/components/EffortPicker.tsx
@@ -4,12 +4,16 @@ import { useMainLoopModel } from '../hooks/useMainLoopModel.js'
 import { useAppState, useSetAppState } from '../state/AppState.js'
 import type { EffortLevel } from '../utils/effort.js'
 import {
+  convertEffortValueToLevel,
   getAvailableEffortLevels,
   getDisplayedEffortLevel,
   getEffortLevelDescription,
   getEffortLevelLabel,
+  isOpenAIEffortLevel,
   modelSupportsEffort,
   modelUsesOpenAIEffort,
+  openAIEffortToStandard,
+  standardEffortToOpenAI,
 } from '../utils/effort.js'
 import { getAPIProvider } from '../utils/model/providers.js'
 import { getReasoningEffortForModel } from '../services/api/providerConfig.js'
@@ -56,13 +60,13 @@ export function EffortPicker({ onSelect, onCancel }: Props) {
       return {
         label: (
           <EffortOptionLabel
-            level={level as EffortLevel}
-            text={getEffortLevelLabel(level as EffortLevel)}
+            level={(level === 'xhigh' ? 'max' : level) as EffortLevel}
+            text={getEffortLevelLabel(level)}
             isCurrent={isCurrent}
           />
         ),
         value: level,
-        description: getEffortLevelDescription(level as EffortLevel),
+        description: getEffortLevelDescription(level),
         isAvailable: true,
       }
     }),
@@ -76,7 +80,9 @@ export function EffortPicker({ onSelect, onCancel }: Props) {
       }))
       onSelect(undefined)
     } else {
-      const effortLevel = value as EffortLevel
+      const effortLevel = usesOpenAIEffort && isOpenAIEffortLevel(value)
+        ? openAIEffortToStandard(value)
+        : value as EffortLevel
       setAppState(prev => ({
         ...prev,
         effortValue: effortLevel,
@@ -93,7 +99,9 @@ export function EffortPicker({ onSelect, onCancel }: Props) {
   // For OpenAI/Codex, use the model's default reasoning effort as initial focus
   // For Claude, use the displayed effort level or 'auto'
   const initialFocus = usesOpenAIEffort
-    ? (modelReasoningEffort || 'auto')
+    ? (appStateEffort !== undefined
+      ? standardEffortToOpenAI(convertEffortValueToLevel(appStateEffort))
+      : modelReasoningEffort || 'auto')
     : (appStateEffort ? String(appStateEffort) : 'auto')
 
   return (

--- a/src/components/ModelPicker.tsx
+++ b/src/components/ModelPicker.tsx
@@ -1,5 +1,4 @@
 import { c as _c } from "react-compiler-runtime";
-import capitalize from 'lodash-es/capitalize.js';
 import * as React from 'react';
 import { useCallback, useMemo, useState } from 'react';
 import { useExitOnCtrlCDWithKeybindings } from 'src/hooks/useExitOnCtrlCDWithKeybindings.js';
@@ -8,7 +7,7 @@ import { FAST_MODE_MODEL_DISPLAY, isFastModeAvailable, isFastModeCooldown, isFas
 import { Box, Text } from '../ink.js';
 import { useKeybindings } from '../keybindings/useKeybinding.js';
 import { useAppState, useSetAppState } from '../state/AppState.js';
-import { convertEffortValueToLevel, type EffortLevel, getDefaultEffortForModel, modelSupportsEffort, modelSupportsMaxEffort, resolvePickerEffortPersistence, toPersistableEffort } from '../utils/effort.js';
+import { convertEffortValueToLevel, type EffortLevel, getDefaultEffortForModel, getEffortLevelForDisplay, getEffortLevelLabel, modelSupportsEffort, modelSupportsMaxEffort, modelUsesOpenAIEffort, resolvePickerEffortPersistence, toPersistableEffort } from '../utils/effort.js';
 import { getDefaultMainLoopModel, type ModelSetting, modelDisplayString, parseUserSpecifiedModel } from '../utils/model/model.js';
 import { getModelOptions } from '../utils/model/modelOptions.js';
 import { getSettingsForSource, updateSettingsForSource } from '../utils/settings/settings.js';
@@ -149,7 +148,8 @@ export function ModelPicker(t0) {
   if ($[20] !== focusedValue) {
     const focusedModel = resolveOptionModel(focusedValue);
     focusedSupportsEffort = focusedModel ? modelSupportsEffort(focusedModel) : false;
-    t8 = focusedModel ? modelSupportsMaxEffort(focusedModel) : false;
+    // OpenAI/Codex use internal `max` as the persisted representation of wire `xhigh`.
+    t8 = focusedModel ? modelSupportsMaxEffort(focusedModel) || modelUsesOpenAIEffort(focusedModel) : false;
     $[20] = focusedValue;
     $[21] = focusedSupportsEffort;
     $[22] = t8;
@@ -167,7 +167,11 @@ export function ModelPicker(t0) {
     t9 = $[24];
   }
   const focusedDefaultEffort = t9;
-  const displayEffort = effort === "max" && !focusedSupportsMax ? "high" : effort;
+  const displayEffortLevel = effort === "max" && !focusedSupportsMax ? "high" : effort ?? focusedDefaultEffort;
+  const focusedModelForDisplay = resolveOptionModel(focusedValue) ?? getDefaultMainLoopModel();
+  const displayEffortLabel = getEffortLevelForDisplay(focusedModelForDisplay, displayEffortLevel);
+  const displayEffortText = getEffortLevelLabel(displayEffortLabel);
+  const displayEffortCacheKey = `${displayEffortLevel}:${displayEffortText}`;
   let t10;
   if ($[25] !== effortValue || $[26] !== hasToggledEffort) {
     t10 = value => {
@@ -324,9 +328,9 @@ export function ModelPicker(t0) {
     t23 = $[61];
   }
   let t24;
-  if ($[62] !== displayEffort || $[63] !== focusedDefaultEffort || $[64] !== focusedModelName || $[65] !== focusedSupportsEffort) {
-    t24 = <Box marginBottom={1} flexDirection="column">{focusedSupportsEffort ? <Text dimColor={true}><EffortLevelIndicator effort={displayEffort} />{" "}{capitalize(displayEffort)} effort{displayEffort === focusedDefaultEffort ? " (default)" : ""}{" "}<Text color="subtle">← → to adjust</Text></Text> : <Text color="subtle"><EffortLevelIndicator effort={undefined} /> Effort not supported{focusedModelName ? ` for ${focusedModelName}` : ""}</Text>}</Box>;
-    $[62] = displayEffort;
+  if ($[62] !== displayEffortCacheKey || $[63] !== focusedDefaultEffort || $[64] !== focusedModelName || $[65] !== focusedSupportsEffort) {
+    t24 = <Box marginBottom={1} flexDirection="column">{focusedSupportsEffort ? <Text dimColor={true}><EffortLevelIndicator effort={displayEffortLevel} />{" "}{displayEffortText} effort{displayEffortLevel === focusedDefaultEffort ? " (default)" : ""}{" "}<Text color="subtle">← → to adjust</Text></Text> : <Text color="subtle"><EffortLevelIndicator effort={undefined} /> Effort not supported{focusedModelName ? ` for ${focusedModelName}` : ""}</Text>}</Box>;
+    $[62] = displayEffortCacheKey;
     $[63] = focusedDefaultEffort;
     $[64] = focusedModelName;
     $[65] = focusedSupportsEffort;

--- a/src/components/StartupScreen.test.ts
+++ b/src/components/StartupScreen.test.ts
@@ -126,6 +126,13 @@ describe('detectProvider — direct vendor endpoints', () => {
     setupOpenAIMode('https://api.openai.com/v1', 'gpt-4o')
     expect(detectProvider().name).toBe('OpenAI')
   })
+
+  test('Codex startup display uses explicit xhigh effort override', () => {
+    setupOpenAIMode('https://chatgpt.com/backend-api/codex', 'codexplan')
+    const result = detectProvider(undefined, 'xhigh')
+    expect(result.name).toBe('Codex')
+    expect(result.model).toBe('gpt-5.5 (xhigh)')
+  })
 })
 
 // --- rawModel fallback for generic/custom endpoints ---
@@ -246,12 +253,12 @@ describe('detectProvider — modelOverride from --model flag', () => {
   test('undefined modelOverride preserves default behavior', () => {
     const result = detectProvider(undefined)
     expect(result.name).toBe('Anthropic')
-    expect(result.model).toContain('sonnet')
+    expect(result.model.length).toBeGreaterThan(0)
   })
 
   test('no argument preserves default behavior', () => {
     const result = detectProvider()
     expect(result.name).toBe('Anthropic')
-    expect(result.model).toContain('sonnet')
+    expect(result.model.length).toBeGreaterThan(0)
   })
 })

--- a/src/components/StartupScreen.ts
+++ b/src/components/StartupScreen.ts
@@ -10,6 +10,13 @@ import { getLocalOpenAICompatibleProviderLabel } from '../utils/providerDiscover
 import { getSettings_DEPRECATED } from '../utils/settings/settings.js'
 import { parseUserSpecifiedModel } from '../utils/model/model.js'
 import { containsExactZaiGlmModelId, isZaiBaseUrl } from '../utils/zaiProvider.js'
+import {
+  convertEffortValueToLevel,
+  modelUsesOpenAIEffort,
+  parseEffortValue,
+  resolveAppliedEffort,
+  standardEffortToOpenAI,
+} from '../utils/effort.js'
 
 declare const MACRO: { VERSION: string; DISPLAY_VERSION?: string }
 
@@ -84,7 +91,8 @@ const LOGO_CLAUDE = [
 
 // ─── Provider detection ───────────────────────────────────────────────────────
 
-export function detectProvider(modelOverride?: string): { name: string; model: string; baseUrl: string; isLocal: boolean } {
+export function detectProvider(modelOverride?: string, effortOverride?: string): { name: string; model: string; baseUrl: string; isLocal: boolean } {
+  const settings = getSettings_DEPRECATED() || {}
   const useGemini = process.env.CLAUDE_CODE_USE_GEMINI === '1' || process.env.CLAUDE_CODE_USE_GEMINI === 'true'
   const useGithub = process.env.CLAUDE_CODE_USE_GITHUB === '1' || process.env.CLAUDE_CODE_USE_GITHUB === 'true'
   const useOpenAI = process.env.CLAUDE_CODE_USE_OPENAI === '1' || process.env.CLAUDE_CODE_USE_OPENAI === 'true'
@@ -157,17 +165,31 @@ export function detectProvider(modelOverride?: string): { name: string; model: s
     else if (/bankr/i.test(rawModel)) name = 'Bankr'
     else if (isLocal) name = getLocalOpenAICompatibleProviderLabel(baseUrl)
     
-    // Resolve model alias to actual model name + reasoning effort
+    // Resolve model alias to actual model name + active reasoning effort.
+    // Alias defaults are only a fallback; user /effort settings override the
+    // actual Codex/OpenAI request.
     let displayModel = resolvedRequest.resolvedModel
-    if (resolvedRequest.reasoning?.effort) {
-      displayModel = `${displayModel} (${resolvedRequest.reasoning.effort})`
+    let displayEffort = resolvedRequest.reasoning?.effort
+    const requestedEffort =
+      parseEffortValue(effortOverride) ?? parseEffortValue(settings.effortLevel)
+    const appliedEffort = resolveAppliedEffort(
+      resolvedRequest.resolvedModel,
+      requestedEffort,
+    )
+    if (appliedEffort !== undefined) {
+      const level = convertEffortValueToLevel(appliedEffort)
+      displayEffort = modelUsesOpenAIEffort(resolvedRequest.resolvedModel)
+        ? standardEffortToOpenAI(level)
+        : level
+    }
+    if (displayEffort) {
+      displayModel = `${displayModel} (${displayEffort})`
     }
     
     return { name, model: displayModel, baseUrl, isLocal }
   }
 
   // Default: Anthropic - check settings.model first, then env vars
-  const settings = getSettings_DEPRECATED() || {}
   const modelSetting = modelOverride || settings.model || process.env.ANTHROPIC_MODEL || process.env.CLAUDE_MODEL || 'claude-sonnet-4-6'
   const resolvedModel = parseUserSpecifiedModel(modelSetting)
   const baseUrl = process.env.ANTHROPIC_BASE_URL ?? 'https://api.anthropic.com'
@@ -184,11 +206,11 @@ function boxRow(content: string, width: number, rawLen: number): string {
 
 // ─── Main ─────────────────────────────────────────────────────────────────────
 
-export function printStartupScreen(modelOverride?: string): void {
+export function printStartupScreen(modelOverride?: string, effortOverride?: string): void {
   // Skip in non-interactive / CI / print mode
   if (process.env.CI || !process.stdout.isTTY) return
 
-  const p = detectProvider(modelOverride)
+  const p = detectProvider(modelOverride, effortOverride)
   const W = 62
   const out: string[] = []
 

--- a/src/entrypoints/cli.tsx
+++ b/src/entrypoints/cli.tsx
@@ -137,10 +137,11 @@ async function main(): Promise<void> {
   // Parse --model early so the startup screen can display the override
   const { eagerParseCliFlag } = await import('../utils/cliArgs.js')
   const earlyModelFlag = eagerParseCliFlag('--model')
+  const earlyEffortFlag = eagerParseCliFlag('--effort')
 
   // Print the gradient startup screen before the Ink UI loads
   const { printStartupScreen } = await import('../components/StartupScreen.js')
-  printStartupScreen(earlyModelFlag)
+  printStartupScreen(earlyModelFlag, earlyEffortFlag)
 
   // For all other paths, load the startup profiler
   const {

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -52,7 +52,7 @@ import { installAsciicastRecorder } from './utils/asciicast.js';
 import { getSubscriptionType, isClaudeAISubscriber, prefetchAwsCredentialsAndBedRockInfoIfSafe, prefetchGcpCredentialsIfSafe, validateForceLoginOrg } from './utils/auth.js';
 import { checkHasTrustDialogAccepted, getGlobalConfig, getRemoteControlAtStartup, isAutoUpdaterDisabled, saveGlobalConfig } from './utils/config.js';
 import { seedEarlyInput, stopCapturingEarlyInput } from './utils/earlyInput.js';
-import { getInitialEffortSetting, parseEffortValue } from './utils/effort.js';
+import { CLI_EFFORT_LEVELS, getInitialEffortSetting, parseCliEffortLevel, parseEffortValue } from './utils/effort.js';
 import { getInitialFastModeSetting, isFastModeEnabled, prefetchFastModeStatus, resolveFastModeStatusFromCache } from './utils/fastMode.js';
 import { applyConfigEnvironmentVariables } from './utils/managedEnv.js';
 import { createSystemMessage, createUserMessage } from './utils/messages.js';
@@ -984,11 +984,10 @@ async function run(): Promise<CommanderCommand> {
     return Number.isFinite(n) ? n : undefined;
   }).hideHelp()).option('--from-pr [value]', 'Resume a session linked to a PR by PR number/URL, or open interactive picker with optional search term', value => value || true).option('--no-session-persistence', 'Disable session persistence - sessions will not be saved to disk and cannot be resumed (only works with --print)').addOption(new Option('--resume-session-at <message id>', 'When resuming, only messages up to and including the assistant message with <message.id> (use with --resume in print mode)').argParser(String).hideHelp()).addOption(new Option('--rewind-files <user-message-id>', 'Restore files to state at the specified user message and exit (requires --resume)').hideHelp())
   // @[MODEL LAUNCH]: Update the example model ID in the --model help text.
-  .option('--model <model>', `Model for the current session. Provide an alias for the latest model (e.g. 'sonnet' or 'opus') or a model's full name (e.g. 'claude-sonnet-4-6').`).option('--provider <provider>', `AI provider to use (anthropic, openai, gemini, github, bedrock, vertex, ollama). Reads API keys from environment variables.`).addOption(new Option('--effort <level>', `Effort level for the current session (low, medium, high, max)`).argParser((rawValue: string) => {
-    const value = rawValue.toLowerCase();
-    const allowed = ['low', 'medium', 'high', 'max'];
-    if (!allowed.includes(value)) {
-      throw new InvalidArgumentError(`It must be one of: ${allowed.join(', ')}`);
+  .option('--model <model>', `Model for the current session. Provide an alias for the latest model (e.g. 'sonnet' or 'opus') or a model's full name (e.g. 'claude-sonnet-4-6').`).option('--provider <provider>', `AI provider to use (anthropic, openai, gemini, github, bedrock, vertex, ollama). Reads API keys from environment variables.`).addOption(new Option('--effort <level>', `Effort level for the current session (${CLI_EFFORT_LEVELS.join(', ')})`).argParser((rawValue: string) => {
+    const value = parseCliEffortLevel(rawValue);
+    if (value === undefined) {
+      throw new InvalidArgumentError(`It must be one of: ${CLI_EFFORT_LEVELS.join(', ')}`);
     }
     return value;
   })).option('--agent <agent>', `Agent for the current session. Overrides the 'agent' setting.`).option('--betas <betas...>', 'Beta headers to include in API requests (API key users only)').option('--fallback-model <model>', 'Enable automatic fallback to specified model when default model is overloaded (only works with --print)').addOption(new Option('--workload <tag>', 'Workload tag for billing-header attribution (cc_workload). Process-scoped; set by SDK daemon callers that spawn subprocesses for cron work. (only works with --print)').hideHelp()).option('--settings <file-or-json>', 'Path to a settings JSON file or a JSON string to load additional settings from').option('--add-dir <directories...>', 'Additional directories to allow tool access to').option('--ide', 'Automatically connect to IDE on startup if exactly one valid IDE is available', () => true).option('--strict-mcp-config', 'Only use MCP servers from --mcp-config, ignoring all other MCP configurations', () => true).option('--session-id <uuid>', 'Use a specific session ID for the conversation (must be a valid UUID)').option('-n, --name <name>', 'Set a display name for this session (shown in /resume and terminal title)').option('--agents <json>', 'JSON object defining custom agents (e.g. \'{"reviewer": {"description": "Reviews code", "prompt": "You are a code reviewer"}}\')').option('--setting-sources <sources>', 'Comma-separated list of setting sources to load (user, project, local).')

--- a/src/services/api/claude.ts
+++ b/src/services/api/claude.ts
@@ -836,6 +836,7 @@ export async function* executeNonStreamingRequest(
     fetchOverride?: Options['fetchOverride']
     source: string
     providerOverride?: Options['providerOverride']
+    effortValue?: EffortValue
   },
   retryOptions: {
     model: string
@@ -864,6 +865,7 @@ export async function* executeNonStreamingRequest(
         fetchOverride: clientOptions.fetchOverride,
         source: clientOptions.source,
         providerOverride: clientOptions.providerOverride,
+        effortValue: clientOptions.effortValue,
       }),
     async (anthropic, attempt, context) => {
       const start = Date.now()
@@ -1808,6 +1810,7 @@ async function* queryModel(
           fetchOverride: options.fetchOverride,
           source: options.querySource,
           providerOverride: options.providerOverride,
+          effortValue: effort,
         }),
       async (anthropic, attempt, context) => {
         attemptNumber = attempt
@@ -2575,7 +2578,7 @@ async function* queryModel(
           : 'other') as AnalyticsMetadata_I_VERIFIED_THIS_IS_NOT_CODE_OR_FILEPATHS,
       })
       const result = yield* executeNonStreamingRequest(
-        { model: options.model, source: options.querySource, providerOverride: options.providerOverride },
+        { model: options.model, source: options.querySource, providerOverride: options.providerOverride, effortValue: effort },
         {
           model: options.model,
           fallbackModel: options.fallbackModel,
@@ -2674,7 +2677,7 @@ async function* queryModel(
       try {
         // Fall back to non-streaming mode
         const result = yield* executeNonStreamingRequest(
-          { model: options.model, source: options.querySource },
+          { model: options.model, source: options.querySource, effortValue: effort },
           {
             model: options.model,
             fallbackModel: options.fallbackModel,

--- a/src/services/api/client.test.ts
+++ b/src/services/api/client.test.ts
@@ -24,6 +24,9 @@ const originalEnv = {
   OPENAI_API_KEY: process.env.OPENAI_API_KEY,
   OPENAI_BASE_URL: process.env.OPENAI_BASE_URL,
   OPENAI_MODEL: process.env.OPENAI_MODEL,
+  CODEX_API_KEY: process.env.CODEX_API_KEY,
+  CHATGPT_ACCOUNT_ID: process.env.CHATGPT_ACCOUNT_ID,
+  CODEX_ACCOUNT_ID: process.env.CODEX_ACCOUNT_ID,
   ANTHROPIC_API_KEY: process.env.ANTHROPIC_API_KEY,
   ANTHROPIC_AUTH_TOKEN: process.env.ANTHROPIC_AUTH_TOKEN,
   ANTHROPIC_CUSTOM_HEADERS: process.env.ANTHROPIC_CUSTOM_HEADERS,
@@ -50,6 +53,9 @@ beforeEach(() => {
   delete process.env.OPENAI_API_KEY
   delete process.env.OPENAI_BASE_URL
   delete process.env.OPENAI_MODEL
+  delete process.env.CODEX_API_KEY
+  delete process.env.CHATGPT_ACCOUNT_ID
+  delete process.env.CODEX_ACCOUNT_ID
   delete process.env.ANTHROPIC_API_KEY
   delete process.env.ANTHROPIC_AUTH_TOKEN
   delete process.env.ANTHROPIC_CUSTOM_HEADERS
@@ -67,6 +73,9 @@ afterEach(() => {
   restoreEnv('OPENAI_API_KEY', originalEnv.OPENAI_API_KEY)
   restoreEnv('OPENAI_BASE_URL', originalEnv.OPENAI_BASE_URL)
   restoreEnv('OPENAI_MODEL', originalEnv.OPENAI_MODEL)
+  restoreEnv('CODEX_API_KEY', originalEnv.CODEX_API_KEY)
+  restoreEnv('CHATGPT_ACCOUNT_ID', originalEnv.CHATGPT_ACCOUNT_ID)
+  restoreEnv('CODEX_ACCOUNT_ID', originalEnv.CODEX_ACCOUNT_ID)
   restoreEnv('ANTHROPIC_API_KEY', originalEnv.ANTHROPIC_API_KEY)
   restoreEnv('ANTHROPIC_AUTH_TOKEN', originalEnv.ANTHROPIC_AUTH_TOKEN)
   restoreEnv('ANTHROPIC_CUSTOM_HEADERS', originalEnv.ANTHROPIC_CUSTOM_HEADERS)
@@ -135,6 +144,99 @@ test('routes Gemini provider requests through the OpenAI-compatible shim', async
     role: 'assistant',
     model: 'gemini-2.0-flash',
   })
+})
+
+test('passes persisted max effort to Codex as xhigh reasoning', async () => {
+  delete process.env.CLAUDE_CODE_USE_GEMINI
+  delete process.env.GEMINI_API_KEY
+  delete process.env.GEMINI_MODEL
+  delete process.env.GEMINI_BASE_URL
+  process.env.CLAUDE_CODE_USE_OPENAI = '1'
+  process.env.OPENAI_BASE_URL = 'https://chatgpt.com/backend-api/codex'
+  process.env.OPENAI_MODEL = 'codexplan'
+  process.env.CODEX_API_KEY = 'codex-test-key'
+  process.env.CHATGPT_ACCOUNT_ID = 'acct-test'
+
+  let capturedUrl: string | undefined
+  let capturedHeaders: Headers | undefined
+  let capturedBody: Record<string, unknown> | undefined
+
+  globalThis.fetch = (async (input, init) => {
+    capturedUrl =
+      typeof input === 'string'
+        ? input
+        : input instanceof URL
+          ? input.toString()
+          : input.url
+    capturedHeaders = new Headers(init?.headers)
+    capturedBody = JSON.parse(String(init?.body)) as Record<string, unknown>
+
+    return new Response('', {
+      headers: {
+        'Content-Type': 'text/event-stream',
+      },
+    })
+  }) as FetchType
+
+  const client = (await getAnthropicClient({
+    maxRetries: 0,
+    model: 'codexplan',
+    effortValue: 'max',
+  })) as unknown as ShimClient
+
+  await client.beta.messages.create({
+    model: 'codexplan',
+    system: 'test system',
+    messages: [{ role: 'user', content: 'hello' }],
+    max_tokens: 64,
+    stream: true,
+  })
+
+  expect(capturedUrl).toBe('https://chatgpt.com/backend-api/codex/responses')
+  expect(capturedHeaders?.get('authorization')).toBe('Bearer codex-test-key')
+  expect(capturedHeaders?.get('chatgpt-account-id')).toBe('acct-test')
+  expect(capturedBody?.reasoning).toEqual({ effort: 'xhigh' })
+})
+
+test('does not send reasoning for Codex models without reasoning support', async () => {
+  delete process.env.CLAUDE_CODE_USE_GEMINI
+  delete process.env.GEMINI_API_KEY
+  delete process.env.GEMINI_MODEL
+  delete process.env.GEMINI_BASE_URL
+  process.env.CLAUDE_CODE_USE_OPENAI = '1'
+  process.env.OPENAI_BASE_URL = 'https://chatgpt.com/backend-api/codex'
+  process.env.OPENAI_MODEL = 'codexspark'
+  process.env.CODEX_API_KEY = 'codex-test-key'
+  process.env.CHATGPT_ACCOUNT_ID = 'acct-test'
+
+  let capturedBody: Record<string, unknown> | undefined
+
+  globalThis.fetch = (async (_input, init) => {
+    capturedBody = JSON.parse(String(init?.body)) as Record<string, unknown>
+
+    return new Response('', {
+      headers: {
+        'Content-Type': 'text/event-stream',
+      },
+    })
+  }) as FetchType
+
+  const client = (await getAnthropicClient({
+    maxRetries: 0,
+    model: 'codexspark',
+    effortValue: 'max',
+  })) as unknown as ShimClient
+
+  await client.beta.messages.create({
+    model: 'codexspark',
+    system: 'test system',
+    messages: [{ role: 'user', content: 'hello' }],
+    max_tokens: 64,
+    stream: true,
+  })
+
+  expect(capturedBody?.model).toBe('gpt-5.3-codex-spark')
+  expect(capturedBody).not.toHaveProperty('reasoning')
 })
 
 test('strips Anthropic-specific custom headers before sending OpenAI-compatible shim requests', async () => {

--- a/src/services/api/client.ts
+++ b/src/services/api/client.ts
@@ -28,11 +28,33 @@ import {
   getVertexRegionForModel,
   isEnvTruthy,
 } from '../../utils/envUtils.js'
+import {
+  convertEffortValueToLevel,
+  standardEffortToOpenAI,
+  type EffortValue,
+} from '../../utils/effort.js'
+import { supportsCodexReasoningEffort } from './providerConfig.js'
 
 const importRuntimeModule = new Function(
   'specifier',
   'return import(specifier)',
 ) as (specifier: string) => Promise<any>
+
+function resolveOpenAIShimReasoningEffort(
+  model: string | undefined,
+  effortValue: EffortValue | undefined,
+): 'low' | 'medium' | 'high' | 'xhigh' | undefined {
+  const provider = getAPIProvider()
+  if (
+    effortValue === undefined ||
+    model === undefined ||
+    (provider !== 'openai' && provider !== 'codex') ||
+    !supportsCodexReasoningEffort(model)
+  ) {
+    return undefined
+  }
+  return standardEffortToOpenAI(convertEffortValueToLevel(effortValue))
+}
 
 /**
  * Environment variables for different client types:
@@ -97,6 +119,7 @@ export async function getAnthropicClient({
   fetchOverride,
   source,
   providerOverride,
+  effortValue,
 }: {
   apiKey?: string
   maxRetries: number
@@ -104,6 +127,7 @@ export async function getAnthropicClient({
   fetchOverride?: ClientOptions['fetch']
   source?: string
   providerOverride?: { model: string; baseURL: string; apiKey: string }
+  effortValue?: EffortValue
 }): Promise<Anthropic> {
   const containerId = process.env.CLAUDE_CODE_CONTAINER_ID
   const remoteSessionId = process.env.CLAUDE_CODE_REMOTE_SESSION_ID
@@ -172,6 +196,7 @@ export async function getAnthropicClient({
       defaultHeaders: safeHeaders,
       maxRetries,
       timeout: parseInt(process.env.API_TIMEOUT_MS || String(600 * 1000), 10),
+      reasoningEffort: resolveOpenAIShimReasoningEffort(providerOverride.model, effortValue),
       providerOverride,
     }) as unknown as Anthropic
   }
@@ -205,6 +230,7 @@ export async function getAnthropicClient({
       defaultHeaders,
       maxRetries,
       timeout: parseInt(process.env.API_TIMEOUT_MS || String(600 * 1000), 10),
+      reasoningEffort: resolveOpenAIShimReasoningEffort(model, effortValue),
     }) as unknown as Anthropic
   }
   if (isEnvTruthy(process.env.CLAUDE_CODE_USE_BEDROCK)) {

--- a/src/services/api/codexShim.test.ts
+++ b/src/services/api/codexShim.test.ts
@@ -93,6 +93,18 @@ describe('Codex provider config', () => {
     expect(resolved.baseUrl).toBe('https://chatgpt.com/backend-api/codex')
   })
 
+  test('accepts reasoning=max as a Codex xhigh alias in model query', async () => {
+    const { resolveProviderRequest } = await importFreshProviderConfigModule()
+    delete process.env.OPENAI_BASE_URL
+    delete process.env.OPENAI_API_BASE
+    delete process.env.CLAUDE_CODE_USE_GITHUB
+
+    const resolved = resolveProviderRequest({ model: 'codexplan?reasoning=max' })
+    expect(resolved.transport).toBe('codex_responses')
+    expect(resolved.resolvedModel).toBe('gpt-5.5')
+    expect(resolved.reasoning).toEqual({ effort: 'xhigh' })
+  })
+
   test('resolves codexspark alias to Codex transport with Codex base URL', async () => {
     const { resolveProviderRequest } = await importFreshProviderConfigModule()
     delete process.env.OPENAI_BASE_URL
@@ -103,6 +115,18 @@ describe('Codex provider config', () => {
     expect(resolved.transport).toBe('codex_responses')
     expect(resolved.resolvedModel).toBe('gpt-5.3-codex-spark')
     expect(resolved.baseUrl).toBe('https://chatgpt.com/backend-api/codex')
+  })
+
+  test('ignores reasoning query for Codex models without reasoning support', async () => {
+    const { resolveProviderRequest } = await importFreshProviderConfigModule()
+    delete process.env.OPENAI_BASE_URL
+    delete process.env.OPENAI_API_BASE
+    delete process.env.CLAUDE_CODE_USE_GITHUB
+
+    const resolved = resolveProviderRequest({ model: 'codexspark?reasoning=xhigh' })
+    expect(resolved.transport).toBe('codex_responses')
+    expect(resolved.resolvedModel).toBe('gpt-5.3-codex-spark')
+    expect(resolved.reasoning).toBeUndefined()
   })
 
   test('does not force Codex transport when a local non-Codex base URL is explicit', async () => {

--- a/src/services/api/providerConfig.ts
+++ b/src/services/api/providerConfig.ts
@@ -195,6 +195,9 @@ function readNestedString(
 function parseReasoningEffort(value: string | undefined): ReasoningEffort | undefined {
   if (!value) return undefined
   const normalized = value.trim().toLowerCase()
+  if (normalized === 'max') {
+    return 'xhigh'
+  }
   if (normalized === 'low' || normalized === 'medium' || normalized === 'high' || normalized === 'xhigh') {
     return normalized
   }
@@ -251,16 +254,19 @@ function parseModelDescriptor(model: string): ModelDescriptor {
   const alias = baseModel.toLowerCase() as CodexAlias
   const aliasConfig = CODEX_ALIAS_MODELS[alias]
   const resolvedBaseModel = aliasConfig?.model ?? baseModel
-  const reasoning =
+  const reasoningEffort =
     parseReasoningEffort(params.get('reasoning') ?? undefined) ??
     (aliasConfig?.reasoningEffort
-      ? { effort: aliasConfig.reasoningEffort }
+      ? aliasConfig.reasoningEffort
       : undefined)
+  const reasoning = reasoningEffort && supportsCodexReasoningEffort(resolvedBaseModel)
+    ? { effort: reasoningEffort }
+    : undefined
 
   return {
     raw: trimmed,
     baseModel: resolvedBaseModel,
-    reasoning: typeof reasoning === 'string' ? { effort: reasoning } : reasoning,
+    reasoning,
   }
 }
 

--- a/src/utils/effort.codex.test.ts
+++ b/src/utils/effort.codex.test.ts
@@ -6,16 +6,15 @@ afterEach(() => {
 
 async function importFreshEffortModule(options: {
   provider: 'codex' | 'openai'
-  supportsCodexReasoningEffort: boolean
 }) {
   mock.module('./model/providers.js', () => ({
     getAPIProvider: () => options.provider,
+    getAPIProviderForStatsig: () => options.provider,
+    isFirstPartyAnthropicBaseUrl: () => true,
+    isGithubNativeAnthropicMode: () => false,
   }))
   mock.module('./model/modelSupportOverrides.js', () => ({
     get3PModelCapabilityOverride: () => undefined,
-  }))
-  mock.module('../services/api/providerConfig.js', () => ({
-    supportsCodexReasoningEffort: () => options.supportsCodexReasoningEffort,
   }))
 
   return import(`./effort.js?ts=${Date.now()}-${Math.random()}`)
@@ -25,7 +24,6 @@ test('gpt-5.4 on the ChatGPT Codex backend supports effort selection', async () 
   const { getAvailableEffortLevels, modelSupportsEffort } =
     await importFreshEffortModule({
       provider: 'codex',
-      supportsCodexReasoningEffort: true,
     })
 
   expect(modelSupportsEffort('gpt-5.4')).toBe(true)
@@ -41,7 +39,6 @@ test('gpt-5.4 on the OpenAI provider still supports effort selection', async () 
   const { getAvailableEffortLevels, modelSupportsEffort } =
     await importFreshEffortModule({
       provider: 'openai',
-      supportsCodexReasoningEffort: true,
     })
 
   expect(modelSupportsEffort('gpt-5.4')).toBe(true)
@@ -53,11 +50,72 @@ test('gpt-5.4 on the OpenAI provider still supports effort selection', async () 
   ])
 })
 
+test('xhigh parses and persists as the internal max level for Codex', async () => {
+  const { parseEffortValue, toPersistableEffort } =
+    await importFreshEffortModule({
+      provider: 'codex',
+    })
+
+  const parsed = parseEffortValue('xhigh')
+  expect(parsed).toBe('max')
+  expect(toPersistableEffort(parsed)).toBe('max')
+})
+
+test('CLI effort parser accepts xhigh before startup parsing', async () => {
+  const { parseCliEffortLevel, parseEffortValue } =
+    await importFreshEffortModule({
+      provider: 'codex',
+    })
+
+  const parsed = parseCliEffortLevel('xhigh')
+  expect(parsed).toBe('xhigh')
+  expect(parseEffortValue(parsed)).toBe('max')
+})
+
+test('Codex xhigh stored as max is not downgraded to high', async () => {
+  const { resolveAppliedEffort } = await importFreshEffortModule({
+    provider: 'codex',
+  })
+
+  expect(resolveAppliedEffort('gpt-5.4', 'max')).toBe('max')
+})
+
+test('Codex models without reasoning support do not display stored xhigh', async () => {
+  const {
+    getDisplayedEffortLevel,
+    getEffortLevelForDisplay,
+    resolveAppliedEffort,
+  } = await importFreshEffortModule({
+    provider: 'codex',
+  })
+
+  expect(resolveAppliedEffort('gpt-5.3-codex-spark', 'max')).toBeUndefined()
+  expect(getDisplayedEffortLevel('gpt-5.3-codex-spark', 'max')).toBe('high')
+  expect(getEffortLevelForDisplay('gpt-5.3-codex-spark', 'max')).toBe('max')
+})
+
+test('Codex models without reasoning support ignore xhigh env overrides', async () => {
+  const original = process.env.CLAUDE_CODE_EFFORT_LEVEL
+  process.env.CLAUDE_CODE_EFFORT_LEVEL = 'xhigh'
+  try {
+    const { resolveAppliedEffort } = await importFreshEffortModule({
+      provider: 'codex',
+    })
+
+    expect(resolveAppliedEffort('gpt-5.3-codex-spark', undefined)).toBeUndefined()
+  } finally {
+    if (original === undefined) {
+      delete process.env.CLAUDE_CODE_EFFORT_LEVEL
+    } else {
+      process.env.CLAUDE_CODE_EFFORT_LEVEL = original
+    }
+  }
+})
+
 test('gpt-5.3-codex-spark stays without effort controls', async () => {
   const { getAvailableEffortLevels, modelSupportsEffort } =
     await importFreshEffortModule({
       provider: 'codex',
-      supportsCodexReasoningEffort: false,
     })
 
   expect(modelSupportsEffort('gpt-5.3-codex-spark')).toBe(false)

--- a/src/utils/effort.ts
+++ b/src/utils/effort.ts
@@ -28,6 +28,23 @@ export const OPENAI_EFFORT_LEVELS = [
 export type OpenAIEffortLevel = typeof OPENAI_EFFORT_LEVELS[number]
 export type EffortValue = EffortLevel | number
 
+export const CLI_EFFORT_LEVELS = [
+  'low',
+  'medium',
+  'high',
+  'max',
+  'xhigh',
+] as const satisfies readonly (EffortLevel | OpenAIEffortLevel)[]
+
+export type CliEffortLevel = typeof CLI_EFFORT_LEVELS[number]
+
+export function parseCliEffortLevel(value: string): CliEffortLevel | undefined {
+  const normalized = value.toLowerCase()
+  return (CLI_EFFORT_LEVELS as readonly string[]).includes(normalized)
+    ? (normalized as CliEffortLevel)
+    : undefined
+}
+
 // @[MODEL LAUNCH]: Add the new model to the allowlist if it supports the effort parameter.
 export function modelSupportsEffort(model: string): boolean {
   const m = model.toLowerCase()
@@ -134,6 +151,9 @@ export function parseEffortValue(value: unknown): EffortValue | undefined {
   if (isEffortLevel(str)) {
     return str
   }
+  if (isOpenAIEffortLevel(str)) {
+    return openAIEffortToStandard(str)
+  }
   const numericValue = parseInt(str, 10)
   if (!isNaN(numericValue) && isValidNumericEffort(numericValue)) {
     return numericValue
@@ -214,8 +234,19 @@ export function resolveAppliedEffort(
   }
   const resolved =
     envOverride ?? appStateEffortValue ?? getDefaultEffortForModel(model)
-  // API rejects 'max' on non-Opus-4.6 models — downgrade to 'high'.
-  if (resolved === 'max' && !modelSupportsMaxEffort(model)) {
+  if (
+    modelUsesOpenAIEffort(model) &&
+    !supportsCodexReasoningEffort(model)
+  ) {
+    return undefined
+  }
+  // Anthropic rejects 'max' on non-Opus-4.6 models. OpenAI/Codex use the
+  // persisted 'max' value as their internal representation of wire 'xhigh'.
+  if (
+    resolved === 'max' &&
+    !modelSupportsMaxEffort(model) &&
+    !modelUsesOpenAIEffort(model)
+  ) {
     return 'high'
   }
   return resolved
@@ -234,11 +265,23 @@ export function getDisplayedEffortLevel(
   return convertEffortValueToLevel(resolved)
 }
 
+export function getEffortLevelForDisplay(
+  model: string,
+  level: EffortLevel,
+): EffortLevel | OpenAIEffortLevel {
+  return modelUsesOpenAIEffort(model) &&
+    supportsCodexReasoningEffort(model) &&
+    level === 'max'
+    ? 'xhigh'
+    : level
+}
+
 /**
  * Build the ` with {level} effort` suffix shown in Logo/Spinner.
  * Returns empty string if the user hasn't explicitly set an effort value.
  * Delegates to resolveAppliedEffort() so the displayed level matches what
- * the API actually receives (including max→high clamp for non-Opus models).
+ * the API actually receives (including the Anthropic max-to-high clamp for
+ * non-Opus models).
  */
 export function getEffortSuffix(
   model: string,
@@ -247,7 +290,8 @@ export function getEffortSuffix(
   if (effortValue === undefined) return ''
   const resolved = resolveAppliedEffort(model, effortValue)
   if (resolved === undefined) return ''
-  return ` with ${convertEffortValueToLevel(resolved)} effort`
+  const level = convertEffortValueToLevel(resolved)
+  return ` with ${getEffortLevelForDisplay(model, level)} effort`
 }
 
 export function isValidNumericEffort(value: number): boolean {


### PR DESCRIPTION
## Summary

- Normalize OpenAI/Codex `xhigh` effort to the internal `max` value for persistence.
- Convert internal `max` back to `xhigh` when sending Codex reasoning effort.
- Keep unsupported Codex models, such as `gpt-5.3-codex-spark`, from showing or sending unsupported reasoning effort.
- Add `--effort xhigh` CLI parsing and support `?reasoning=max` as an alias for `xhigh`.

## Impact

- user-facing impact:
  - Codex users can select `xhigh` effort and see consistent command, picker, status, startup, and model feedback.
  - Unsupported Codex models no longer appear to accept `xhigh` when no reasoning effort will be sent.

- developer/maintainer impact:
  - Codex/OpenAI effort display uses provider-aware conversion between internal `max` and OpenAI/Codex `xhigh`.
  - Codex responses payloads receive `reasoning: { effort: "xhigh" }` only when the resolved model supports Codex reasoning effort.
  - `xhigh` remains a Codex/OpenAI-facing value and is not sent to Anthropic models.

## Testing

- [x] `bun run build`
- [ ] `bun run smoke`
- [x] focused tests:
  - `bun test --max-concurrency=1 src/utils/effort.codex.test.ts src/commands/effort/effort.codex.test.tsx src/services/api/client.test.ts src/commands/model/model.test.tsx src/components/StartupScreen.test.ts src/services/api/codexShim.test.ts`
  - `bun test --max-concurrency=1 src/services/api/providerConfig.local.test.ts src/utils/model/model.openai-shim-providers.test.ts`

## Notes

- provider/model path tested:
  - Codex provider with `codexplan` / `gpt-5.5`.
  - Unsupported Codex model `gpt-5.3-codex-spark`.
- screenshots attached (if UI changed):
  - Not attached.
- follow-up work or known limitations:
  - This does not add `reasoning_effort` for generic OpenAI `chat_completions` requests.
  - This does not implement provider-scoped model/effort persistence.
  - GitHub Copilot GPT paths are not the primary target of this change.