### PR TITLE
fix(errors): show actual host in 404 message instead of Ollama hint (#926)

### DIFF
--- a/src/services/api/errors.openaiCompatibility.test.ts
+++ b/src/services/api/errors.openaiCompatibility.test.ts
@@ -28,6 +28,38 @@ test('maps endpoint_not_found category markers to actionable setup guidance', ()
   expect(text).toContain('/v1')
 })
 
+test('endpoint_not_found from a remote host shows the actual host, not Ollama (issue #926)', () => {
+  const error = APIError.generate(
+    404,
+    undefined,
+    'OpenAI API error 404: Not Found [openai_category=endpoint_not_found,host=integrate.api.nvidia.com] Hint: Endpoint at integrate.api.nvidia.com returned 404.',
+    new Headers(),
+  )
+
+  const message = getAssistantMessageFromError(error, 'moonshotai/kimi-k2.5-thinking')
+  const text = getFirstText(message)
+
+  expect(text).toContain('integrate.api.nvidia.com')
+  expect(text).toContain('moonshotai/kimi-k2.5-thinking')
+  expect(text).not.toContain('Ollama')
+  expect(text).not.toContain('11434')
+})
+
+test('endpoint_not_found without a host falls back to the Ollama-aware message', () => {
+  const error = APIError.generate(
+    404,
+    undefined,
+    'OpenAI API error 404: Not Found [openai_category=endpoint_not_found] Hint: Confirm OPENAI_BASE_URL includes /v1.',
+    new Headers(),
+  )
+
+  const message = getAssistantMessageFromError(error, 'qwen2.5-coder:7b')
+  const text = getFirstText(message)
+
+  expect(text).toContain('Provider endpoint was not found')
+  expect(text).toContain('Ollama')
+})
+
 test('maps tool_call_incompatible category markers to model/tool guidance', () => {
   const error = APIError.generate(
     400,

--- a/src/services/api/errors.ts
+++ b/src/services/api/errors.ts
@@ -51,7 +51,9 @@ import {
 import { shouldProcessRateLimits } from '../rateLimitMocking.js' // Used for /mock-limits command
 import { extractConnectionErrorDetails, formatAPIError } from './errorUtils.js'
 import {
+  extractOpenAICategoryHost,
   extractOpenAICategoryMarker,
+  isLocalhostLikeHost,
   type OpenAICompatibilityFailureCategory,
 } from './openaiErrorClassification.js'
 
@@ -68,25 +70,29 @@ function mapOpenAICompatibilityFailureToAssistantMessage(options: {
   category: OpenAICompatibilityFailureCategory
   model: string
   rawMessage: string
+  host?: string
 }): AssistantMessage {
   const switchCmd = getIsNonInteractiveSession() ? '--model' : '/model'
   const compactHint = getIsNonInteractiveSession()
     ? 'Reduce prompt size or start a new session.'
     : 'Run /compact or start a new session with /new.'
+  const isLocalhost = options.host === undefined || isLocalhostLikeHost(options.host)
 
   switch (options.category) {
     case 'localhost_resolution_failed':
     case 'connection_refused':
       return createAssistantAPIErrorMessage({
-        content:
-          'Could not connect to the local OpenAI-compatible provider. Ensure the local server is running, then use OPENAI_BASE_URL=http://127.0.0.1:11434/v1 for Ollama.',
+        content: isLocalhost
+          ? 'Could not connect to the local OpenAI-compatible provider. Ensure the local server is running, then use OPENAI_BASE_URL=http://127.0.0.1:11434/v1 for Ollama.'
+          : `Could not connect to the provider at ${options.host}. Verify OPENAI_BASE_URL is correct and that the host is reachable.`,
         error: 'unknown',
       })
 
     case 'endpoint_not_found':
       return createAssistantAPIErrorMessage({
-        content:
-          'Provider endpoint was not found. Confirm OPENAI_BASE_URL targets an OpenAI-compatible /v1 endpoint (for Ollama: http://127.0.0.1:11434/v1).',
+        content: isLocalhost
+          ? 'Provider endpoint was not found. Confirm OPENAI_BASE_URL targets an OpenAI-compatible /v1 endpoint (for Ollama: http://127.0.0.1:11434/v1).'
+          : `Provider endpoint at ${options.host} returned 404. Verify OPENAI_BASE_URL is correct and that the selected model (${options.model}) is supported by this provider.`,
         error: 'invalid_request',
       })
 
@@ -567,6 +573,7 @@ export function getAssistantMessageFromError(
         category: openaiCategory,
         model,
         rawMessage: error.message,
+        host: extractOpenAICategoryHost(error.message),
       })
     }
   }

--- a/src/services/api/openaiErrorClassification.test.ts
+++ b/src/services/api/openaiErrorClassification.test.ts
@@ -4,8 +4,10 @@ import {
   buildOpenAICompatibilityErrorMessage,
   classifyOpenAIHttpFailure,
   classifyOpenAINetworkFailure,
+  extractOpenAICategoryHost,
   extractOpenAICategoryMarker,
   formatOpenAICategoryMarker,
+  isLocalhostLikeHost,
 } from './openaiErrorClassification.js'
 
 test('classifies localhost ECONNREFUSED as connection_refused', () => {
@@ -94,4 +96,59 @@ test('embeds and extracts category markers in formatted messages', () => {
 test('ignores unknown category markers during extraction', () => {
   const malformed = 'OpenAI API error 500 [openai_category=totally_fake_category]'
   expect(extractOpenAICategoryMarker(malformed)).toBeUndefined()
+})
+
+test('endpoint_not_found 404 from a remote host gets a host-aware hint (issue #926)', () => {
+  const failure = classifyOpenAIHttpFailure({
+    status: 404,
+    body: 'Not Found',
+    url: 'https://integrate.api.nvidia.com/v1/chat/completions',
+  })
+
+  expect(failure.category).toBe('endpoint_not_found')
+  expect(failure.requestUrl).toBe('https://integrate.api.nvidia.com/v1/chat/completions')
+  expect(failure.hint).toContain('integrate.api.nvidia.com')
+  expect(failure.hint).not.toContain('local providers')
+})
+
+test('endpoint_not_found 404 from localhost keeps the Ollama-flavored hint', () => {
+  const failure = classifyOpenAIHttpFailure({
+    status: 404,
+    body: 'Not Found',
+    url: 'http://127.0.0.1:11434/v1/chat/completions',
+  })
+
+  expect(failure.category).toBe('endpoint_not_found')
+  expect(failure.hint).toContain('local providers')
+})
+
+test('marker round-trip preserves host segment', () => {
+  const formatted = buildOpenAICompatibilityErrorMessage(
+    'OpenAI API error 404: Not Found',
+    {
+      category: 'endpoint_not_found',
+      hint: 'Endpoint at integrate.api.nvidia.com returned 404.',
+      requestUrl: 'https://integrate.api.nvidia.com/v1/chat/completions',
+    },
+  )
+
+  expect(formatted).toContain('[openai_category=endpoint_not_found,host=integrate.api.nvidia.com]')
+  expect(extractOpenAICategoryMarker(formatted)).toBe('endpoint_not_found')
+  expect(extractOpenAICategoryHost(formatted)).toBe('integrate.api.nvidia.com')
+})
+
+test('marker without host stays backward-compatible', () => {
+  const marker = formatOpenAICategoryMarker('endpoint_not_found')
+  expect(marker).toBe('[openai_category=endpoint_not_found]')
+  expect(extractOpenAICategoryMarker(marker)).toBe('endpoint_not_found')
+  expect(extractOpenAICategoryHost(marker)).toBeUndefined()
+})
+
+test('isLocalhostLikeHost matches loopback variants', () => {
+  expect(isLocalhostLikeHost('localhost')).toBe(true)
+  expect(isLocalhostLikeHost('127.0.0.1')).toBe(true)
+  expect(isLocalhostLikeHost('127.0.0.5')).toBe(true)
+  expect(isLocalhostLikeHost('::1')).toBe(true)
+  expect(isLocalhostLikeHost('integrate.api.nvidia.com')).toBe(false)
+  expect(isLocalhostLikeHost(undefined)).toBe(false)
 })

--- a/src/services/api/openaiErrorClassification.ts
+++ b/src/services/api/openaiErrorClassification.ts
@@ -21,6 +21,7 @@ export type OpenAICompatibilityFailure = {
   hint?: string
   code?: string
   status?: number
+  requestUrl?: string
 }
 
 const OPENAI_CATEGORY_MARKER_PREFIX = '[openai_category='
@@ -96,6 +97,11 @@ function isLocalhostLikeHostname(hostname: string | null): boolean {
   return /^127\./.test(hostname)
 }
 
+export function isLocalhostLikeHost(host: string | null | undefined): boolean {
+  if (!host) return false
+  return isLocalhostLikeHostname(host.toLowerCase())
+}
+
 function isContextOverflowMessage(body: string): boolean {
   const lower = body.toLowerCase()
   return (
@@ -149,14 +155,18 @@ function isModelNotFoundMessage(body: string): boolean {
 
 export function formatOpenAICategoryMarker(
   category: OpenAICompatibilityFailureCategory,
+  host?: string,
 ): string {
+  if (host && /^[A-Za-z0-9.\-:]+$/.test(host)) {
+    return `${OPENAI_CATEGORY_MARKER_PREFIX}${category},host=${host}]`
+  }
   return `${OPENAI_CATEGORY_MARKER_PREFIX}${category}]`
 }
 
 export function extractOpenAICategoryMarker(
   message: string,
 ): OpenAICompatibilityFailureCategory | undefined {
-  const match = message.match(/\[openai_category=([a-z_]+)]/)
+  const match = message.match(/\[openai_category=([a-z_]+)(?:,host=[^\]]+)?]/)
   const category = match?.[1]
 
   if (!category || !isOpenAICompatibilityFailureCategory(category)) {
@@ -166,11 +176,17 @@ export function extractOpenAICategoryMarker(
   return category
 }
 
+export function extractOpenAICategoryHost(message: string): string | undefined {
+  const match = message.match(/\[openai_category=[a-z_]+,host=([A-Za-z0-9.\-:]+)]/)
+  return match?.[1]
+}
+
 export function buildOpenAICompatibilityErrorMessage(
   baseMessage: string,
-  failure: Pick<OpenAICompatibilityFailure, 'category' | 'hint'>,
+  failure: Pick<OpenAICompatibilityFailure, 'category' | 'hint' | 'requestUrl'>,
 ): string {
-  const marker = formatOpenAICategoryMarker(failure.category)
+  const host = failure.requestUrl ? getHostname(failure.requestUrl) ?? undefined : undefined
+  const marker = formatOpenAICategoryMarker(failure.category, host)
   const hint = failure.hint ? ` Hint: ${failure.hint}` : ''
   return `${baseMessage} ${marker}${hint}`
 }
@@ -247,8 +263,11 @@ export function classifyOpenAINetworkFailure(
 export function classifyOpenAIHttpFailure(options: {
   status: number
   body: string
+  url?: string
 }): OpenAICompatibilityFailure {
   const body = options.body ?? ''
+  const hostname = options.url ? getHostname(options.url) : null
+  const isLocalHost = isLocalhostLikeHostname(hostname)
 
   if (options.status === 401 || options.status === 403) {
     return {
@@ -284,13 +303,17 @@ export function classifyOpenAIHttpFailure(options: {
   }
 
   if (options.status === 404) {
+    const isRemote = hostname !== null && !isLocalHost
     return {
       source: 'http',
       category: 'endpoint_not_found',
       retryable: false,
       status: options.status,
       message: body,
-      hint: 'Endpoint was not found. Confirm OPENAI_BASE_URL includes /v1 for OpenAI-compatible local providers.',
+      requestUrl: options.url,
+      hint: isRemote
+        ? `Endpoint at ${hostname} returned 404. Verify OPENAI_BASE_URL is correct and the requested model is supported by this provider.`
+        : 'Endpoint was not found. Confirm OPENAI_BASE_URL includes /v1 for OpenAI-compatible local providers.',
     }
   }
 

--- a/src/services/api/openaiShim.ts
+++ b/src/services/api/openaiShim.ts
@@ -1935,7 +1935,9 @@ class OpenAIShimMessages {
         classifyOpenAIHttpFailure({
           status,
           body: errorBody,
+          url: requestUrl,
         })
+      const failureWithUrl = { ...failure, requestUrl: failure.requestUrl ?? requestUrl }
       const redactedUrl = redactUrlForDiagnostics(requestUrl)
 
       logForDebugging(
@@ -1948,7 +1950,7 @@ class OpenAIShimMessages {
         parsedBody,
         buildOpenAICompatibilityErrorMessage(
           `OpenAI API error ${status}: ${errorBody}${rateHint}`,
-          failure,
+          failureWithUrl,
         ),
         responseHeaders,
       )


### PR DESCRIPTION
## Summary

Closes #926.

When an OpenAI-compatible provider returns a 404, the user-facing error message hardcoded `for Ollama: http://127.0.0.1:11434/v1` as a hint regardless of the configured base URL. Users on remote providers (NVIDIA NIM, OpenRouter, etc.) read the Ollama localhost reference and concluded the app was ignoring their `OPENAI_BASE_URL`. The actual root cause is usually that the model name isn't in the provider's catalog, so the provider returns 404; the misleading hint just made it look like a routing bug.

## Before / After

**Before** (NVIDIA NIM with an unknown model):
> Provider endpoint was not found. Confirm OPENAI_BASE_URL targets an OpenAI-compatible /v1 endpoint (for Ollama: http://127.0.0.1:11434/v1).

**After** (same scenario):
> Provider endpoint at integrate.api.nvidia.com returned 404. Verify OPENAI_BASE_URL is correct and that the selected model (moonshotai/kimi-k2.5-thinking) is supported by this provider.

Localhost endpoints keep the existing Ollama-flavored guidance for backward compatibility.

## Changes

- `classifyOpenAIHttpFailure` now accepts an optional `url` and produces a host-aware hint for non-localhost 404s.
- The `[openai_category=...]` marker carries an optional `host=...` segment so the host can flow through the SDK error path to the user-facing mapper without changing call signatures elsewhere.
- `mapOpenAICompatibilityFailureToAssistantMessage` branches `endpoint_not_found` and `connection_refused` / `localhost_resolution_failed` messages on whether the host is localhost-like.
- `extractOpenAICategoryHost` and `isLocalhostLikeHost` exported as helpers.

## Tests

- Added 6 unit tests in `openaiErrorClassification.test.ts` covering: NVIDIA 404 (issue #926 repro), localhost 404, marker round-trip with and without host, `isLocalhostLikeHost`, backward-compat marker parse.
- Added 2 integration tests in `errors.openaiCompatibility.test.ts` asserting the user-facing text for remote 404 names the host and model and does not mention Ollama / 11434, and the unhosted marker still surfaces the original Ollama hint.

## Test plan

- [x] `bun run build` — passes (v0.7.0)
- [x] `bun test src/services/api/openaiErrorClassification.test.ts src/services/api/errors.openaiCompatibility.test.ts` — 17/17 pass
- [x] `bun test` — 1639 pass; the 4 remaining failures (`StartupScreen.test.ts`, `thinking.test.ts`) reproduce on `main` and are unrelated to this change.