### PR TITLE
fix(mcp): allow third-party providers to approve project-scope .mcp.json servers (#696)

### DIFF
--- a/src/__tests__/bugfixes.test.ts
+++ b/src/__tests__/bugfixes.test.ts
@@ -288,3 +288,30 @@ describe('Context overflow 500 fix', () => {
     expect(content).toContain('automatic compaction has failed')
   })
 })
+
+// ---------------------------------------------------------------------------
+// Fix N: Project-scope MCP servers from .mcp.json not detected for 3P providers (issue #696)
+// ---------------------------------------------------------------------------
+describe('Project-scope MCP approval — third-party providers (issue #696)', () => {
+  test('handleMcpjsonServerApprovals is NOT gated behind usesAnthropicSetup', async () => {
+    const content = await file('interactiveHelpers.tsx').text()
+
+    // The call site for handleMcpjsonServerApprovals must not sit inside an
+    // `if (usesAnthropicSetup) { ... }` block, or third-party providers will
+    // never get the dialog and project-scope .mcp.json servers will be silently
+    // dropped from /mcp listings (issue #696).
+    const approvalCallIdx = content.indexOf('await handleMcpjsonServerApprovals(root)')
+    expect(approvalCallIdx).toBeGreaterThan(-1)
+
+    // Look at the 800 chars BEFORE the call site for any `if (usesAnthropicSetup)`
+    // block that would still be open. Pick a window that's definitely inside the
+    // showSetupScreens function but not in earlier dialogs.
+    const before = content.slice(Math.max(0, approvalCallIdx - 800), approvalCallIdx)
+    expect(before).not.toMatch(/if\s*\(\s*usesAnthropicSetup\s*\)\s*{[^}]*$/)
+  })
+
+  test('issue #696 is referenced from the comment so future readers can find context', async () => {
+    const content = await file('interactiveHelpers.tsx').text()
+    expect(content).toContain('#696')
+  })
+})

--- a/src/interactiveHelpers.tsx
+++ b/src/interactiveHelpers.tsx
@@ -158,24 +158,25 @@ export async function showSetupScreens(root: Root, permissionMode: PermissionMod
     // Now that trust is established, prefetch system context if it wasn't already
     void getSystemContext();
 
-    // Skip MCP approval dialogs for third-party providers (no interactive auth prompts)
-    if (usesAnthropicSetup) {
-      // If settings are valid, check for any mcp.json servers that need approval
-      const {
-        errors: allErrors
-      } = getSettingsWithAllErrors();
-      if (allErrors.length === 0) {
-        await handleMcpjsonServerApprovals(root);
-      }
+    // MCP approval and external-includes warnings are about workspace
+    // trust, not about Anthropic auth. They must run for all providers
+    // — including third-party — otherwise project-scoped .mcp.json
+    // servers never get the approval that writes
+    // enableAllProjectMcpServers / enabledMcpjsonServers into
+    // settings.local.json, and the servers are silently dropped from
+    // /mcp and `mcp list` (issue #696).
+    const { errors: allErrors } = getSettingsWithAllErrors();
+    if (allErrors.length === 0) {
+      await handleMcpjsonServerApprovals(root);
+    }
 
-      // Check for claude.md includes that need approval
-      if (await shouldShowClaudeMdExternalIncludesWarning()) {
-        const externalIncludes = getExternalClaudeMdIncludes(await getMemoryFiles(true));
-        const {
-          ClaudeMdExternalIncludesDialog
-        } = await import('./components/ClaudeMdExternalIncludesDialog.js');
-        await showSetupDialog(root, done => <ClaudeMdExternalIncludesDialog onDone={done} isStandaloneDialog externalIncludes={externalIncludes} />);
-      }
+    // Check for claude.md includes that need approval
+    if (await shouldShowClaudeMdExternalIncludesWarning()) {
+      const externalIncludes = getExternalClaudeMdIncludes(await getMemoryFiles(true));
+      const {
+        ClaudeMdExternalIncludesDialog
+      } = await import('./components/ClaudeMdExternalIncludesDialog.js');
+      await showSetupDialog(root, done => <ClaudeMdExternalIncludesDialog onDone={done} isStandaloneDialog externalIncludes={externalIncludes} />);
     }
   }
 


### PR DESCRIPTION
## Summary

Closes #696.

When a user runs openclaude with a third-party provider, project-scope MCP servers added via \`openclaude mcp add -s project ...\` were silently dropped from \`/mcp\` and \`openclaude mcp list\`. Re-adding the same server printed \"MCP server already exists in .mcp.json\" but the server never actually loaded.

Reporter @gbmerrall did the diagnosis and pinpointed \`src/interactiveHelpers.tsx:162\` — \`handleMcpjsonServerApprovals\` was gated behind \`if (usesAnthropicSetup)\`, so 3P-provider users never saw the dialog that writes \`enableAllProjectMcpServers: true\` and \`enabledMcpjsonServers: [...]\` to \`settings.local.json\`.

## Why the original gate was wrong

\`handleMcpjsonServerApprovals\` is about workspace trust (do you want to load these MCP servers from this checkout's \`.mcp.json\`?) — it has zero dependency on Anthropic auth. Same for the \`CLAUDE.md\` external-includes warning. Gating both on \`usesAnthropicSetup\` conflated \"need Anthropic credentials\" with \"need to approve project content\".

## Changes

- **\`src/interactiveHelpers.tsx\`** — drop the \`if (usesAnthropicSetup) { ... }\` block around the MCP approval call and the external-includes warning. Inner logic is unchanged. Add a comment citing #696 so future readers find context.
- **\`src/__tests__/bugfixes.test.ts\`** — +2 regression tests: (1) source no longer has \`if (usesAnthropicSetup)\` immediately before the approval call, (2) the comment references #696.

## Why this is safe for everyone (including Anthropic-auth users)

\`handleMcpjsonServerApprovals\` early-returns when no servers are pending:

\`\`\`ts
const pendingServers = Object.keys(projectServers).filter(
  serverName => getProjectMcpServerStatus(serverName) === 'pending'
)
if (pendingServers.length === 0) {
  return
}
\`\`\`

So users **without** a project \`.mcp.json\` see zero behavior change. Only users in the bug's exact scenario — project \`.mcp.json\` exists, servers pending approval — now see the dialog they were missing.

## Test plan (Linux verified)

- [x] \`bun run build\` — passes (v0.7.0); built \`dist/cli.mjs\` shows \`handleMcpjsonServerApprovals(root2)\` running directly after \`setSessionTrustAccepted(true)\` with no auth gate around it
- [x] \`bun test src/__tests__/bugfixes.test.ts\` — 28/28 pass (2 new)
- [x] \`bun test\` (full) — 1634 pass; the 4 remaining failures (\`StartupScreen.test.ts\`, \`thinking.test.ts\`) reproduce on \`main\` and are unrelated
- [x] Behavioral check: \`handleMcpjsonServerApprovals\` early-returns on empty pending list, so users without project \`.mcp.json\` see no new dialog

## Notes

- This is a rebrand-aligned fix — \`usesAnthropicSetup\` gating that degrades the 3P-provider experience is exactly what the openclaude rebrand is trying to eliminate. No red-flag rule hits.
- @gbmerrall's diagnosis (in the issue thread) matches the fix exactly. Settings.local.json after approval ends up as:
  \`\`\`json
  {
    \"enableAllProjectMcpServers\": true,
    \"enabledMcpjsonServers\": [\"server-name\"],
    \"permissions\": { \"allow\": [\"mcp__server-name__tool\"] }
  }
  \`\`\`