### PR TITLE
fix(typecheck): make bun run typecheck actionable on main (#473)

### DIFF
--- a/src/constants/querySource.ts
+++ b/src/constants/querySource.ts
@@ -1,0 +1,7 @@
+/**
+ * Stub — query source enum not included in source snapshot. See
+ * src/types/message.ts for the same scoping caveat (issue #473).
+ */
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+export type QuerySource = any

--- a/src/entrypoints/agentSdkTypes.ts
+++ b/src/entrypoints/agentSdkTypes.ts
@@ -442,7 +442,84 @@ export async function connectRemoteControl(
   throw new Error('not implemented')
 }
 
-// add exit reason types for removing the error within gracefulShutdown file 
+// add exit reason types for removing the error within gracefulShutdown file
 export type ExitReason = {
-  
+
 }
+
+// ============================================================================
+// Stub re-exports — types not included in source snapshot.
+//
+// The upstream Anthropic SDK defines these in sub-files (sdk/coreTypes,
+// sdk/runtimeTypes, sdk/controlTypes, sdk/toolTypes) that are stubbed
+// in this open repo. Until the real definitions are restored, alias the
+// names to `any` so callers can resolve their imports and `tsc` becomes
+// actionable. See issue #473 for the typecheck-foundation effort.
+// ============================================================================
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+export type AnyZodRawShape = any
+export type ApiKeySource = any
+export type AsyncHookJSONOutput = any
+export type ConfigChangeHookInput = any
+export type CwdChangedHookInput = any
+export type ElicitationHookInput = any
+export type ElicitationResultHookInput = any
+export type FileChangedHookInput = any
+export type ForkSessionOptions = any
+export type ForkSessionResult = any
+export type GetSessionInfoOptions = any
+export type GetSessionMessagesOptions = any
+export type HookEvent = any
+export type HookInput = any
+export type HookJSONOutput = any
+export type InferShape<_T> = any
+export type InstructionsLoadedHookInput = any
+export type InternalOptions = any
+export type InternalQuery = any
+export type ListSessionsOptions = any
+export type McpSdkServerConfigWithInstance = any
+export type McpServerConfigForProcessTransport = any
+export type McpServerStatus = any
+export type ModelInfo = any
+export type ModelUsage = any
+export type NotificationHookInput = any
+export type Options = any
+export type PermissionDeniedHookInput = any
+export type PermissionMode = any
+export type PermissionRequestHookInput = any
+export type PermissionResult = any
+export type PermissionUpdate = any
+export type PostCompactHookInput = any
+export type PostToolUseFailureHookInput = any
+export type PostToolUseHookInput = any
+export type PreCompactHookInput = any
+export type PreToolUseHookInput = any
+export type Query = any
+export type RewindFilesResult = any
+export type SDKAssistantMessage = any
+export type SDKAssistantMessageError = any
+export type SDKCompactBoundaryMessage = any
+export type SdkMcpToolDefinition = any
+export type SDKPartialAssistantMessage = any
+export type SDKPermissionDenial = any
+export type SDKRateLimitInfo = any
+export type SDKStatus = any
+export type SDKStatusMessage = any
+export type SDKSystemMessage = any
+export type SDKToolProgressMessage = any
+export type SDKUserMessageReplay = any
+export type SessionEndHookInput = any
+export type SessionMessage = any
+export type SessionMutationOptions = any
+export type SessionStartHookInput = any
+export type SetupHookInput = any
+export type StopFailureHookInput = any
+export type StopHookInput = any
+export type SubagentStartHookInput = any
+export type SubagentStopHookInput = any
+export type SyncHookJSONOutput = any
+export type TaskCompletedHookInput = any
+export type TaskCreatedHookInput = any
+export type TeammateIdleHookInput = any
+export type UserPromptSubmitHookInput = any

--- a/src/entrypoints/sdk/controlTypes.ts
+++ b/src/entrypoints/sdk/controlTypes.ts
@@ -1,0 +1,10 @@
+/**
+ * Stub — control protocol types not included in source snapshot. See
+ * src/types/message.ts for the same scoping caveat (issue #473).
+ */
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+export type SDKControlRequest = any
+export type SDKControlResponse = any
+export type SDKControlPermissionRequest = any
+export type StdoutMessage = any

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -1,0 +1,16 @@
+/**
+ * Build-time globals replaced by the bundler at build time.
+ *
+ * `scripts/build.ts` substitutes these via Bun's `define` option, so at
+ * runtime the references are inlined as string literals. This declaration
+ * exists only to make `tsc --noEmit` aware of them — without it, every
+ * `MACRO.*` access fires TS2304 "Cannot find name 'MACRO'".
+ */
+declare const MACRO: {
+  VERSION: string
+  DISPLAY_VERSION: string
+  BUILD_TIME: string
+  ISSUES_EXPLAINER: string
+  PACKAGE_URL: string
+  NATIVE_PACKAGE_URL: string | undefined
+}

--- a/src/types/message.ts
+++ b/src/types/message.ts
@@ -1,0 +1,25 @@
+/**
+ * Stub — message type definitions not included in source snapshot.
+ *
+ * The upstream Anthropic source defines a rich Message discriminated union
+ * with structured Content blocks, role tags, tool_use payloads, and so on.
+ * That file is not mirrored to this open snapshot. This stub exists so
+ * `tsc --noEmit` can resolve `import { Message, ... } from 'src/types/message'`
+ * across the ~21 callers without fixing every transitive type the call
+ * sites use.
+ *
+ * Once the real definitions are restored upstream-side or reconstructed
+ * from runtime usage, replace these `any` aliases with proper types and
+ * delete this comment. See issue #473 for the typecheck-foundation effort.
+ */
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+export type Message = any
+export type AssistantMessage = any
+export type UserMessage = any
+export type SystemMessage = any
+export type SystemAPIErrorMessage = any
+export type AttachmentMessage = any
+export type ProgressMessage = any
+export type HookResultMessage = any
+export type NormalizedUserMessage = any

--- a/src/types/tools.ts
+++ b/src/types/tools.ts
@@ -1,0 +1,7 @@
+/**
+ * Stub — tool type definitions not included in source snapshot. See
+ * src/types/message.ts for the same scoping caveat (issue #473).
+ */
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+export type ShellProgress = any

--- a/src/types/utils.ts
+++ b/src/types/utils.ts
@@ -1,0 +1,15 @@
+/**
+ * Stub — utility type definitions not included in source snapshot. See
+ * src/types/message.ts for the same scoping caveat (issue #473).
+ */
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+export type DeepImmutable<T> = T extends any[]
+  ? readonly DeepImmutable<T[number]>[]
+  : T extends object
+    ? { readonly [K in keyof T]: DeepImmutable<T[K]> }
+    : T
+
+export type Permutations<T extends string, U extends string = T> = T extends T
+  ? T | `${T}${Permutations<Exclude<U, T>>}`
+  : never

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,10 +1,14 @@
 {
   "compilerOptions": {
-    "target": "ES2022",
+    "target": "ES2023",
+    "lib": ["ES2023", "DOM"],
     "module": "ESNext",
     "moduleResolution": "bundler",
     "jsx": "react-jsx",
     "strict": true,
+    "noImplicitAny": false,
+    "noEmit": true,
+    "allowImportingTsExtensions": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,


### PR DESCRIPTION
## Summary

Closes #473.

\`bun run typecheck\` was failing on main with ~4400 errors that were repo-foundation drift, not branch regressions — making the gate non-actionable for PR review. Per @kevincodex1's guidance on the issue (\"lets narrow the typecheck scope for now and then we expand step by step\") this PR addresses the four root causes from the bug report and brings the error count down 60%.

## Before / After (measured locally on Linux with stash-based before/after on the same Bun/TS versions)

\`\`\`
baseline (stashed main): 4434 errors
with PR applied:         1782 errors (60% reduction)
\`\`\`

Foundational root causes from the bug report:

| Root cause | Before | After |
|---|---|---|
| 3. TS lib baseline (TS2550 \`findLast\`/\`findLastIndex\`) | 41 | **0** |
| 4. \`MACRO\` global undeclared (TS2304) | 9 | **0** |
| .ts extension imports (TS5097) | 40 | **0** |
| 2. Missing modules (TS2307) | 587 | 325 (45% drop) |

## Changes

- **\`tsconfig.json\`** — bump \`target\` to \`ES2023\` and add \`lib: [\"ES2023\", \"DOM\"]\` so \`Array.findLast\`/\`findLastIndex\` resolve. Add \`noEmit: true\` for typecheck-only mode and \`allowImportingTsExtensions: true\`. Set \`noImplicitAny: false\` — cleaning up TSX-component implicit-any is explicitly out of scope per the issue (\"broad implicit any cleanup\" is on the non-scope list).

- **\`src/global.d.ts\`** *(new)* — ambient declaration for the build-time \`MACRO\` global injected by \`scripts/build.ts\` via Bun's \`define\` option.

- **\`src/types/{message,utils,tools}.ts\`** *(new stubs)* — highest-impact missing modules from the partial source snapshot. \`message\` alone unblocks 21 importers. Each stub carries a docstring referencing #473 so future readers know they're placeholders.

- **\`src/entrypoints/sdk/controlTypes.ts\`**, **\`src/constants/querySource.ts\`** *(new stubs)* — unblock 18 + 19 importers respectively.

- **\`src/entrypoints/agentSdkTypes.ts\`** — append \`any\`-typed aliases for ~70 SDK names that callers expect on the public surface but live in stubbed sub-files (\`PermissionMode\`, \`SDKCompactBoundaryMessage\`, \`HookEvent\`, \`ModelUsage\`, \`ModelInfo\`, \`McpServerConfigForProcessTransport\`, \`PermissionResult\`, etc. — exactly the list from auriti's bug-report enumeration).

## Test plan (Linux verified)

- [x] \`bunx tsc --noEmit --pretty false\` baseline (stashed): 4434 errors
- [x] \`bunx tsc --noEmit --pretty false\` with PR: **1782 errors** (60% reduction)
- [x] \`bun run build\`: passes (v0.7.0); built \`dist/cli.mjs\` works (\`node dist/cli.mjs --version\` → \`0.7.0 (OpenClaude)\`)
- [x] \`bun test\` (full suite): 1632 pass; the 4 remaining failures (\`StartupScreen.test.ts\`, \`thinking.test.ts\`) reproduce on \`main\` and are unrelated to this PR
- [x] Per-category histogram measured before/after via stash; foundational TS2550 / TS5097 / TS2304 (MACRO) all at zero

## Needs platform testers

This is a config + type-stub change — no runtime behavior changes. The TS error reduction should be platform-independent, but please pull this branch and confirm \`bun run typecheck\` and your IDE's TypeScript service report the expected ~1782 baseline on macOS and Windows:

\`\`\`
gh pr checkout <pr-number>
bun install
bun run typecheck   # expect ~1782 errors, not ~4400
bun run build
\`\`\`

Specifically worth confirming:
- **macOS** — VS Code TypeScript service picks up the new \`tsconfig.json\` cleanly
- **Windows** — same; also that the stub files don't have line-ending or path-resolution issues

## What's NOT in this PR (per the issue's explicit non-scope)

- Broad TS7006 implicit-any cleanup (covered by \`noImplicitAny: false\` for now; expand scope in follow-up PRs as the snapshot's type story is restored upstream-side)
- React/component typing cleanup
- Feature-specific refactors
- Optional/dead-code cleanup unrelated to restoring a valid typecheck baseline

The remaining ~1782 errors are localized to specific stubbed modules where contributors can grep their own files and address one snapshot gap at a time, matching @kevincodex1's \"narrow now, expand step by step\" directive.