### PR TITLE
fix(input): strip leading `!` when entering bash mode (#662)

### DIFF
--- a/src/components/PromptInput/PromptInput.tsx
+++ b/src/components/PromptInput/PromptInput.tsx
@@ -111,7 +111,7 @@ import { BackgroundTasksDialog } from '../tasks/BackgroundTasksDialog.js';
 import { shouldHideTasksFooter } from '../tasks/taskStatusUtils.js';
 import { TeamsDialog } from '../teams/TeamsDialog.js';
 import VimTextInput from '../VimTextInput.js';
-import { getModeFromInput, getValueFromInput } from './inputModes.js';
+import { detectModeEntry, getModeFromInput, getValueFromInput } from './inputModes.js';
 import { FOOTER_TEMPORARY_STATUS_TIMEOUT, Notifications } from './Notifications.js';
 import PromptInputFooter from './PromptInputFooter.js';
 import type { SuggestionItem } from './PromptInputFooterSuggestions.js';
@@ -878,24 +878,22 @@ function PromptInput({
     abortPromptSuggestion();
     abortSpeculation(setAppState);
 
-    // Check if this is a single character insertion at the start
-    const isSingleCharInsertion = value.length === input.length + 1;
-    const insertedAtStart = cursorOffset === 0;
-    const mode = getModeFromInput(value);
-    if (insertedAtStart && mode !== 'prompt') {
-      if (isSingleCharInsertion) {
-        onModeChange(mode);
-        return;
-      }
-      // Multi-char insertion into empty input (e.g. tab-accepting "! gcloud auth login")
-      if (input.length === 0) {
-        onModeChange(mode);
-        const valueWithoutMode = getValueFromInput(value).replaceAll('\t', '    ');
-        pushToBuffer(input, cursorOffset, pastedContents);
-        trackAndSetInput(valueWithoutMode);
-        setCursorOffset(valueWithoutMode.length);
-        return;
-      }
+    // Strip the mode character from the buffer when entering bash mode — the
+    // mode itself is shown via the prompt prefix in the UI. Without this,
+    // typing `!` into empty input would enter bash mode but leave the literal
+    // `!` in the buffer (issue #662).
+    const modeEntry = detectModeEntry({
+      value,
+      prevInputLength: input.length,
+      cursorOffset,
+    });
+    if (modeEntry) {
+      onModeChange(modeEntry.mode);
+      const cleaned = modeEntry.strippedValue.replaceAll('\t', '    ');
+      pushToBuffer(input, cursorOffset, pastedContents);
+      trackAndSetInput(cleaned);
+      setCursorOffset(cleaned.length);
+      return;
     }
     const processedValue = value.replaceAll('\t', '    ');
 

--- a/src/components/PromptInput/inputModes.test.ts
+++ b/src/components/PromptInput/inputModes.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from 'bun:test'
+import {
+  detectModeEntry,
+  getModeFromInput,
+  getValueFromInput,
+  isInputModeCharacter,
+  prependModeCharacterToInput,
+} from './inputModes.js'
+
+describe('inputModes', () => {
+  describe('getModeFromInput', () => {
+    it('returns bash mode for input starting with !', () => {
+      expect(getModeFromInput('!')).toBe('bash')
+      expect(getModeFromInput('!ls')).toBe('bash')
+    })
+
+    it('returns prompt mode for non-bash input', () => {
+      expect(getModeFromInput('')).toBe('prompt')
+      expect(getModeFromInput('hello')).toBe('prompt')
+      expect(getModeFromInput(' !')).toBe('prompt')
+    })
+  })
+
+  describe('getValueFromInput', () => {
+    it('strips the leading ! when entering bash mode', () => {
+      expect(getValueFromInput('!')).toBe('')
+      expect(getValueFromInput('!ls -la')).toBe('ls -la')
+    })
+
+    it('returns input unchanged in prompt mode', () => {
+      expect(getValueFromInput('')).toBe('')
+      expect(getValueFromInput('hello')).toBe('hello')
+    })
+  })
+
+  describe('isInputModeCharacter', () => {
+    it('returns true only for the bare ! character', () => {
+      expect(isInputModeCharacter('!')).toBe(true)
+      expect(isInputModeCharacter('!ls')).toBe(false)
+      expect(isInputModeCharacter('')).toBe(false)
+    })
+  })
+
+  describe('prependModeCharacterToInput', () => {
+    it('prepends ! when mode is bash', () => {
+      expect(prependModeCharacterToInput('ls', 'bash')).toBe('!ls')
+      expect(prependModeCharacterToInput('', 'bash')).toBe('!')
+    })
+
+    it('returns input unchanged in prompt mode', () => {
+      expect(prependModeCharacterToInput('hello', 'prompt')).toBe('hello')
+    })
+  })
+
+  describe('detectModeEntry', () => {
+    // Regression for #662 — typing `!` into empty input must switch to bash
+    // mode AND yield an empty stripped buffer. Before the fix the single-char
+    // path returned without stripping, leaving `!` visible in the buffer.
+    it('strips the mode character when typing ! into empty input', () => {
+      expect(
+        detectModeEntry({ value: '!', prevInputLength: 0, cursorOffset: 0 }),
+      ).toEqual({ mode: 'bash', strippedValue: '' })
+    })
+
+    it('strips the mode character when pasting !cmd into empty input', () => {
+      expect(
+        detectModeEntry({ value: '!ls -la', prevInputLength: 0, cursorOffset: 0 }),
+      ).toEqual({ mode: 'bash', strippedValue: 'ls -la' })
+    })
+
+    it('returns null when the cursor is not at the start', () => {
+      expect(
+        detectModeEntry({ value: '!', prevInputLength: 0, cursorOffset: 1 }),
+      ).toBeNull()
+    })
+
+    it('returns null when the value does not start with !', () => {
+      expect(
+        detectModeEntry({ value: 'hello', prevInputLength: 0, cursorOffset: 0 }),
+      ).toBeNull()
+    })
+
+    it('returns null when typing ! after existing text', () => {
+      // value="ab!" with prevInputLength=2 is a single-char insertion but does
+      // not start with ! — getModeFromInput returns 'prompt'.
+      expect(
+        detectModeEntry({ value: 'ab!', prevInputLength: 2, cursorOffset: 0 }),
+      ).toBeNull()
+    })
+
+    it('returns null when prepending ! to non-empty existing text', () => {
+      // Single-char insertion at start that produces "!ab" from "ab" — value
+      // length is 3, prevInputLength is 2, so isSingleCharInsertion is true
+      // and isMultiCharIntoEmpty is false. We accept the mode change here so
+      // that typing ! at the start of existing text still toggles mode.
+      const result = detectModeEntry({
+        value: '!ab',
+        prevInputLength: 2,
+        cursorOffset: 0,
+      })
+      expect(result).toEqual({ mode: 'bash', strippedValue: 'ab' })
+    })
+  })
+})

--- a/src/components/PromptInput/inputModes.ts
+++ b/src/components/PromptInput/inputModes.ts
@@ -31,3 +31,30 @@ export function getValueFromInput(input: string): string {
 export function isInputModeCharacter(input: string): boolean {
   return input === '!'
 }
+
+export type ModeEntryDecision = {
+  mode: HistoryMode
+  strippedValue: string
+}
+
+/**
+ * Decide whether an onChange `value` should switch the input mode (e.g.
+ * `prompt` → `bash`) and what the stripped buffer value should be.
+ *
+ * Returns null when no mode change applies. Returns a decision otherwise so
+ * callers run a single update path — no separate single-char vs multi-char
+ * branches that can drift apart.
+ */
+export function detectModeEntry(args: {
+  value: string
+  prevInputLength: number
+  cursorOffset: number
+}): ModeEntryDecision | null {
+  if (args.cursorOffset !== 0) return null
+  const mode = getModeFromInput(args.value)
+  if (mode === 'prompt') return null
+  const isSingleCharInsertion = args.value.length === args.prevInputLength + 1
+  const isMultiCharIntoEmpty = args.prevInputLength === 0
+  if (!isSingleCharInsertion && !isMultiCharIntoEmpty) return null
+  return { mode, strippedValue: getValueFromInput(args.value) }
+}


### PR DESCRIPTION
## Summary

Strip the leading `!` from the prompt buffer when typing a bare `!` enters bash mode, so the mode character does not stick around as visible text.

Closes #662

## Problem

When a user typed `!` into an empty prompt, OpenClaude entered bash mode (the prompt prefix turned into the bash indicator) but the literal `!` was still in the input buffer. Bash mode was already implied by the prefix, so the extra character was both visually wrong and meant the user had to backspace before typing a command.

## Root Cause

`src/components/PromptInput/PromptInput.tsx` had two separate branches in the onChange handler for entering bash mode:

1. **Single-char insertion** (typing `!` into empty input) — called `onModeChange('bash')` and `return`ed without updating the input buffer.
2. **Multi-char insertion into empty input** (e.g. tab-accepting `!gcloud auth login`) — called `getValueFromInput(value)` to strip the leading `!` and updated the buffer.

Only path #2 actually stripped the mode character, so the bare-`!` case left the `!` in place.

## Fix

Consolidated both paths through a new pure helper `detectModeEntry` in `inputModes.ts` that returns the new mode plus the stripped buffer value (or `null` when no mode change applies). The PromptInput onChange runs a single update path, so the mode character cannot leak into the buffer.

## Files Changed

- `src/components/PromptInput/inputModes.ts` — added `detectModeEntry` pure helper + `ModeEntryDecision` type.
- `src/components/PromptInput/PromptInput.tsx` — onChange uses the helper, replacing the two-branch single-char/multi-char logic.
- `src/components/PromptInput/inputModes.test.ts` — new test file with a regression case for bare-`!` into empty input.

## Verification

**Automated**
- New regression test added: `detectModeEntry > strips the mode character when typing ! into empty input`
- `bun test src/components/PromptInput/inputModes.test.ts` — 13 pass, 0 fail
- Full suite: same 4 pre-existing failures as `main`, no new regressions
- Typecheck: no new errors in the changed files

**Manual**
- Repro on `main`: launch openclaude → press `!` → bash mode prefix appears but `!` stays in the buffer.
- With this fix: press `!` → bash mode prefix appears and the buffer is empty.
- Multi-char paste path (`!ls -la`) still works: enters bash mode and buffer shows `ls -la`.

## Risk / Side Effects

Behavior change is limited to the input mode-entry path. The single-char-into-non-empty edge case (typing `!` at the start of existing text) now also strips the `!`, matching the multi-char branch and bash mode semantics. No provider routing, network, or fingerprint surfaces touched.

## How to Test This PR Locally

```bash
gh pr checkout <PR-number>
bun install
bun run build
bun start
# In the prompt, press `!` — bash mode should engage and the buffer should be empty.
```