### PR TITLE
feat: support self-hosted Firecrawl via FIRECRAWL_API_URL

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -367,6 +367,9 @@ ANTHROPIC_API_KEY=sk-ant-your-key-here
 # Firecrawl (premium, uses @mendable/firecrawl-js)
 # FIRECRAWL_API_KEY=fc-your-key-here
 
+# Self-hosted Firecrawl endpoint (optional — omit to use cloud API)
+# FIRECRAWL_API_URL=https://your-firecrawl-instance.com
+
 # ── Provider selection mode ─────────────────────────────────────────
 #
 # WEB_SEARCH_PROVIDER controls fallback behavior:

--- a/src/tools/WebFetchTool/WebFetchTool.ts
+++ b/src/tools/WebFetchTool/WebFetchTool.ts
@@ -28,7 +28,7 @@ function isFirecrawlEnabled(): boolean {
 async function scrapeWithFirecrawl(url: string): Promise<{ markdown: string; bytes: number }> {
   const { FirecrawlClient } = await import('@mendable/firecrawl-js')
   const app = new FirecrawlClient({
-    apiKey: process.env.FIRECRAWL_API_KEY!,
+    apiKey: process.env.FIRECRAWL_API_KEY,
     apiUrl: process.env.FIRECRAWL_API_URL,
   })
   const result = await app.scrape(url, { formats: ['markdown'] })

--- a/src/tools/WebFetchTool/WebFetchTool.ts
+++ b/src/tools/WebFetchTool/WebFetchTool.ts
@@ -22,12 +22,15 @@ import {
 } from './utils.js'
 
 function isFirecrawlEnabled(): boolean {
-  return Boolean(process.env.FIRECRAWL_API_KEY)
+  return Boolean(process.env.FIRECRAWL_API_KEY) || Boolean(process.env.FIRECRAWL_API_URL)
 }
 
 async function scrapeWithFirecrawl(url: string): Promise<{ markdown: string; bytes: number }> {
   const { FirecrawlClient } = await import('@mendable/firecrawl-js')
-  const app = new FirecrawlClient({ apiKey: process.env.FIRECRAWL_API_KEY! })
+  const app = new FirecrawlClient({
+    apiKey: process.env.FIRECRAWL_API_KEY!,
+    apiUrl: process.env.FIRECRAWL_API_URL,
+  })
   const result = await app.scrape(url, { formats: ['markdown'] })
   const markdown = (result as { markdown?: string }).markdown ?? ''
   return { markdown, bytes: Buffer.byteLength(markdown) }

--- a/src/tools/WebSearchTool/providers/firecrawl.test.ts
+++ b/src/tools/WebSearchTool/providers/firecrawl.test.ts
@@ -1,0 +1,47 @@
+import { afterEach, describe, expect, test } from 'bun:test'
+
+import { firecrawlProvider } from './firecrawl.ts'
+
+const originalEnv = {
+  FIRECRAWL_API_KEY: process.env.FIRECRAWL_API_KEY,
+  FIRECRAWL_API_URL: process.env.FIRECRAWL_API_URL,
+}
+
+function restoreEnv(key: string, value: string | undefined): void {
+  if (value === undefined) {
+    delete process.env[key]
+  } else {
+    process.env[key] = value
+  }
+}
+
+afterEach(() => {
+  restoreEnv('FIRECRAWL_API_KEY', originalEnv.FIRECRAWL_API_KEY)
+  restoreEnv('FIRECRAWL_API_URL', originalEnv.FIRECRAWL_API_URL)
+})
+
+describe('firecrawlProvider isConfigured', () => {
+  test('true when FIRECRAWL_API_KEY is set only', () => {
+    process.env.FIRECRAWL_API_KEY = 'fc-test-key'
+    delete process.env.FIRECRAWL_API_URL
+    expect(firecrawlProvider.isConfigured()).toBe(true)
+  })
+
+  test('true when FIRECRAWL_API_URL is set only', () => {
+    process.env.FIRECRAWL_API_KEY = undefined
+    process.env.FIRECRAWL_API_URL = 'https://self-hosted.firecrawl.dev'
+    expect(firecrawlProvider.isConfigured()).toBe(true)
+  })
+
+  test('true when both FIRECRAWL_API_KEY and FIRECRAWL_API_URL are set', () => {
+    process.env.FIRECRAWL_API_KEY = 'fc-test-key'
+    process.env.FIRECRAWL_API_URL = 'https://self-hosted.firecrawl.dev'
+    expect(firecrawlProvider.isConfigured()).toBe(true)
+  })
+
+  test('false when neither FIRECRAWL_API_KEY nor FIRECRAWL_API_URL is set', () => {
+    delete process.env.FIRECRAWL_API_KEY
+    delete process.env.FIRECRAWL_API_URL
+    expect(firecrawlProvider.isConfigured()).toBe(false)
+  })
+})

--- a/src/tools/WebSearchTool/providers/firecrawl.ts
+++ b/src/tools/WebSearchTool/providers/firecrawl.ts
@@ -5,7 +5,7 @@ export const firecrawlProvider: SearchProvider = {
   name: 'firecrawl',
 
   isConfigured() {
-    return Boolean(process.env.FIRECRAWL_API_KEY)
+    return Boolean(process.env.FIRECRAWL_API_KEY) || Boolean(process.env.FIRECRAWL_API_URL)
   },
 
   async search(input: SearchInput, signal?: AbortSignal): Promise<ProviderOutput> {
@@ -13,7 +13,10 @@ export const firecrawlProvider: SearchProvider = {
     if (signal?.aborted) throw new DOMException('Aborted', 'AbortError')
     // TODO: @mendable/firecrawl-js SDK doesn't accept AbortSignal — can't cancel in-flight searches
     const { FirecrawlClient } = await import('@mendable/firecrawl-js')
-    const app = new FirecrawlClient({ apiKey: process.env.FIRECRAWL_API_KEY! })
+    const app = new FirecrawlClient({
+      apiKey: process.env.FIRECRAWL_API_KEY,
+      apiUrl: process.env.FIRECRAWL_API_URL,
+    })
 
     let query = input.query
     if (input.blocked_domains?.length) {


### PR DESCRIPTION
Adds FIRECRAWL_API_URL env var to enable self-hosted Firecrawl instances. Both WebFetchTool and firecrawl search provider now check for either FIRECRAWL_API_KEY (cloud) or FIRECRAWL_API_URL (self-hosted). The FirecrawlClient accepts apiUrl for custom endpoints.

 ---
  Summary

  - Added FIRECRAWL_API_URL environment variable for self-hosted Firecrawl instances
  - Updated isFirecrawlEnabled() to check for either FIRECRAWL_API_KEY (cloud) or FIRECRAWL_API_URL (self-hosted)
  - Updated FirecrawlClient initialization in both WebFetchTool and firecrawl search provider to pass apiUrl            
   
  Files Changed                                                                                                         
                                                                                                                      
  - .env.example — Documented FIRECRAWL_API_URL env var                                                                 
  - src/tools/WebFetchTool/WebFetchTool.ts — Self-hosted Firecrawl support
  - src/tools/WebSearchTool/providers/firecrawl.ts — Self-hosted Firecrawl support                                      
                                                                                                                      
  Test plan

  - Set FIRECRAWL_API_URL=https://your-firecrawl-instance.com (no API key needed)                                       
  - Verify WebFetch uses the self-hosted instance
  - Verify firecrawl search provider uses the self-hosted instance                                                      
  - Existing FIRECRAWL_API_KEY flow still works (cloud Firecrawl)    
