### PR TITLE
feat(lsp): add first-class code intelligence setup

### DIFF
--- a/src/commands.test.ts
+++ b/src/commands.test.ts
@@ -1,4 +1,11 @@
-import { formatDescriptionWithSource } from './commands.js'
+import { describe, expect, test } from 'bun:test'
+import { builtInCommandNames, formatDescriptionWithSource } from './commands.js'
+
+describe('builtInCommandNames', () => {
+  test('includes the LSP command', () => {
+    expect(builtInCommandNames()).toContain('lsp')
+  })
+})
 
 describe('formatDescriptionWithSource', () => {
   test('returns empty text for prompt commands missing a description', () => {

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -28,6 +28,7 @@ import ide from './commands/ide/index.js'
 import init from './commands/init.js'
 import initVerifiers from './commands/init-verifiers.js'
 import keybindings from './commands/keybindings/index.js'
+import lsp from './commands/lsp/index.js'
 import login from './commands/login/index.js'
 import logout from './commands/logout/index.js'
 import installGitHubApp from './commands/install-github-app/index.js'
@@ -296,6 +297,7 @@ const COMMANDS = memoize((): Command[] => [
   init,
   keybindings,
   knowledge,
+  lsp,
   installGitHubApp,
   installSlackApp,
   mcp,

--- a/src/commands/lsp/index.ts
+++ b/src/commands/lsp/index.ts
@@ -1,0 +1,13 @@
+import type { Command } from '../../commands.js'
+
+const lsp = {
+  type: 'local',
+  name: 'lsp',
+  description: 'Inspect and set up Language Server Protocol code intelligence',
+  argumentHint:
+    'status | recommend [path] | install <plugin-id> | uninstall <plugin-id> | restart',
+  supportsNonInteractive: false,
+  load: () => import('./lsp.js'),
+} satisfies Command
+
+export default lsp

--- a/src/commands/lsp/lsp.test.ts
+++ b/src/commands/lsp/lsp.test.ts
@@ -21,6 +21,19 @@ type TestServerInstance = {
   config?: TestServerConfig
 }
 
+type OfficialMarketplaceCheckResult = {
+  installed: boolean
+  skipped: boolean
+  reason?:
+    | 'already_attempted'
+    | 'already_installed'
+    | 'policy_blocked'
+    | 'git_unavailable'
+    | 'gcs_unavailable'
+    | 'unknown'
+  configSaveFailed?: boolean
+}
+
 let initializationStatus: InitializationStatus = { status: 'not-started' }
 let configuredServers: Record<string, TestServerConfig> = {}
 let serverInstances = new Map<string, TestServerInstance>()
@@ -69,6 +82,13 @@ const uninstallPluginOp = mock(
 
 const reinitializeLspServerManager = mock(() => {})
 const waitForInitialization = mock(async () => {})
+const checkAndInstallOfficialMarketplace = mock(
+  async (): Promise<OfficialMarketplaceCheckResult> => ({
+    installed: false,
+    skipped: true,
+    reason: 'already_installed',
+  }),
+)
 const discoverWorkspaceExtensions = async (pathspec?: string) =>
   pathspec === 'src' || pathspec === '.'
     ? ['.ts', '.tsx']
@@ -96,6 +116,7 @@ const deps = {
     candidateCallOptions.push(options)
     return candidates
   },
+  checkAndInstallOfficialMarketplace,
   installPluginOp,
   uninstallPluginOp,
   refreshActivePlugins,
@@ -115,6 +136,12 @@ beforeEach(() => {
   refreshActivePlugins.mockClear()
   reinitializeLspServerManager.mockClear()
   waitForInitialization.mockClear()
+  checkAndInstallOfficialMarketplace.mockClear()
+  checkAndInstallOfficialMarketplace.mockImplementation(async () => ({
+    installed: false,
+    skipped: true,
+    reason: 'already_installed' as const,
+  }))
   deps.getInitializationStatus = () => initializationStatus
   deps.listLspPluginCandidates = async (options: unknown) => {
     candidateCallOptions.push(options)
@@ -358,6 +385,50 @@ describe('/lsp recommend', () => {
     }
   })
 
+  test('installs missing official marketplace and retries candidate lookup', async () => {
+    const typescriptCandidate = {
+      pluginId: 'typescript-lsp@claude-plugins-official',
+      pluginName: 'typescript-lsp',
+      marketplaceName: 'claude-plugins-official',
+      isOfficial: true,
+      extensions: ['.ts', '.tsx'],
+      command: 'typescript-language-server',
+      binaryInstalled: true,
+      installed: false,
+    }
+    let lookupCount = 0
+    deps.listLspPluginCandidates = async (options: unknown) => {
+      candidateCallOptions.push(options)
+      lookupCount += 1
+      return lookupCount === 1 ? [] : [typescriptCandidate]
+    }
+    checkAndInstallOfficialMarketplace.mockImplementationOnce(async () => ({
+      installed: true,
+      skipped: false,
+    }))
+
+    const output = await run('recommend src/main.ts')
+
+    expect(checkAndInstallOfficialMarketplace).toHaveBeenCalled()
+    expect(candidateCallOptions).toHaveLength(2)
+    expect(output).toContain(
+      'Anthropic marketplace installed for LSP recommendations',
+    )
+    expect(output).toContain('typescript-lsp@claude-plugins-official')
+  })
+
+  test('explains why marketplace repair could not provide candidates', async () => {
+    checkAndInstallOfficialMarketplace.mockImplementationOnce(async () => ({
+      installed: false,
+      skipped: true,
+      reason: 'policy_blocked',
+    }))
+
+    const output = await run('recommend src/main.ts')
+
+    expect(output).toContain('No LSP plugin candidates found for .ts')
+    expect(output).toContain('policy blocks it')
+  })
 })
 
 describe('/lsp install', () => {

--- a/src/commands/lsp/lsp.test.ts
+++ b/src/commands/lsp/lsp.test.ts
@@ -1,4 +1,7 @@
 import { beforeEach, describe, expect, mock, test } from 'bun:test'
+import { mkdir, mkdtemp, rm, writeFile } from 'fs/promises'
+import { tmpdir } from 'os'
+import { join } from 'path'
 
 type InitializationStatus =
   | { status: 'not-started' }
@@ -73,7 +76,8 @@ const discoverWorkspaceExtensions = async (pathspec?: string) =>
       ? []
       : ['.ts']
 
-const { runLspCommand } = await import('./lsp.js')
+const { discoverWorkspaceExtensions: discoverRealWorkspaceExtensions, runLspCommand } =
+  await import('./lsp.js')
 
 const EMPTY_CONTEXT = {
   setAppState: () => {},
@@ -305,6 +309,53 @@ describe('/lsp recommend', () => {
 
     expect(output).toContain('No file extensions found for ".".')
     expect(output).not.toContain('for ..')
+  })
+
+  test('filters noisy workspace extensions and reports matched candidate extensions', async () => {
+    deps.discoverWorkspaceExtensions = async () => [
+      '.ts',
+      '.png',
+      '.woff2',
+    ]
+    candidates = [
+      {
+        pluginId: 'typescript-lsp@claude-plugins-official',
+        pluginName: 'typescript-lsp',
+        marketplaceName: 'claude-plugins-official',
+        isOfficial: true,
+        extensions: ['.ts', '.tsx'],
+        command: 'typescript-language-server',
+        binaryInstalled: true,
+        installed: false,
+      },
+    ]
+
+    const output = await run('recommend')
+
+    expect(output).toContain('LSP recommendations for .ts')
+    expect(output).not.toContain('.png')
+    expect(output).not.toContain('.woff2')
+    expect(candidateCallOptions).toContainEqual(
+      expect.objectContaining({ extensions: ['.ts'] }),
+    )
+  })
+
+  test('falls back to filesystem scanning when git cannot enumerate workspace files', async () => {
+    const tempDir = await mkdtemp(join(tmpdir(), 'openclaude-lsp-'))
+    try {
+      await mkdir(join(tempDir, 'src'), { recursive: true })
+      await writeFile(join(tempDir, 'src', 'main.ts'), 'export const x = 1\n')
+      await writeFile(join(tempDir, 'src', 'style.css'), '.root {}\n')
+      await writeFile(join(tempDir, 'logo.png'), '')
+
+      const extensions = await discoverRealWorkspaceExtensions(undefined, tempDir)
+
+      expect(extensions).toContain('.ts')
+      expect(extensions).toContain('.css')
+      expect(extensions).not.toContain('.png')
+    } finally {
+      await rm(tempDir, { recursive: true, force: true })
+    }
   })
 
 })

--- a/src/commands/lsp/lsp.test.ts
+++ b/src/commands/lsp/lsp.test.ts
@@ -1,0 +1,553 @@
+import { beforeEach, describe, expect, mock, test } from 'bun:test'
+
+type InitializationStatus =
+  | { status: 'not-started' }
+  | { status: 'pending' }
+  | { status: 'success' }
+  | { status: 'failed'; error: Error }
+
+type TestServerConfig = {
+  command?: string
+  args?: string[]
+  extensionToLanguage?: Record<string, string>
+}
+
+type TestServerInstance = {
+  state?: string
+  lastError?: Error
+  config?: TestServerConfig
+}
+
+let initializationStatus: InitializationStatus = { status: 'not-started' }
+let configuredServers: Record<string, TestServerConfig> = {}
+let serverInstances = new Map<string, TestServerInstance>()
+let candidateCallOptions: unknown[] = []
+let candidates: Array<{
+  pluginId: string
+  pluginName: string
+  marketplaceName: string
+  description?: string
+  isOfficial: boolean
+  extensions: string[]
+  command: string
+  binaryInstalled: boolean
+  installed: boolean
+}> = []
+
+const installPluginOp = mock(
+  async (_plugin: string, _scope?: 'user' | 'local' | 'project') => ({
+    success: true,
+    message: 'Installed plugin',
+    pluginId: 'typescript-lsp@claude-plugins-official',
+    scope: 'user' as const,
+  }),
+)
+
+const refreshActivePlugins = mock(async () => ({
+  enabled_count: 1,
+  disabled_count: 0,
+  command_count: 0,
+  agent_count: 0,
+  hook_count: 0,
+  mcp_count: 0,
+  lsp_count: 1,
+  error_count: 0,
+  agentDefinitions: { activeAgents: [], allAgents: [] },
+  pluginCommands: [],
+}))
+
+const uninstallPluginOp = mock(
+  async (_plugin: string, _scope?: 'user' | 'local' | 'project') => ({
+    success: true,
+    message: 'Uninstalled plugin',
+    pluginId: 'typescript-lsp@claude-plugins-official',
+  }),
+)
+
+const reinitializeLspServerManager = mock(() => {})
+const waitForInitialization = mock(async () => {})
+const discoverWorkspaceExtensions = async (pathspec?: string) =>
+  pathspec === 'src' || pathspec === '.'
+    ? ['.ts', '.tsx']
+    : pathspec
+      ? []
+      : ['.ts']
+
+const { runLspCommand } = await import('./lsp.js')
+
+const EMPTY_CONTEXT = {
+  setAppState: () => {},
+} as Parameters<typeof runLspCommand>[1]
+
+const deps = {
+  getInitializationStatus: () => initializationStatus,
+  getLspServerManager: () =>
+    serverInstances.size > 0
+      ? {
+          getAllServers: () => serverInstances,
+        }
+      : undefined,
+  getAllLspServers: async () => ({ servers: configuredServers }),
+  listLspPluginCandidates: async (options: unknown) => {
+    candidateCallOptions.push(options)
+    return candidates
+  },
+  installPluginOp,
+  uninstallPluginOp,
+  refreshActivePlugins,
+  reinitializeLspServerManager,
+  waitForInitialization,
+  discoverWorkspaceExtensions,
+}
+
+beforeEach(() => {
+  initializationStatus = { status: 'not-started' }
+  configuredServers = {}
+  serverInstances = new Map()
+  candidateCallOptions = []
+  candidates = []
+  installPluginOp.mockClear()
+  uninstallPluginOp.mockClear()
+  refreshActivePlugins.mockClear()
+  reinitializeLspServerManager.mockClear()
+  waitForInitialization.mockClear()
+  deps.getInitializationStatus = () => initializationStatus
+  deps.listLspPluginCandidates = async (options: unknown) => {
+    candidateCallOptions.push(options)
+    return candidates
+  }
+  deps.discoverWorkspaceExtensions = discoverWorkspaceExtensions
+})
+
+async function run(args: string): Promise<string> {
+  const result = await runLspCommand(args, EMPTY_CONTEXT, deps)
+  expect(result.type).toBe('text')
+  return result.type === 'text' ? result.value : ''
+}
+
+describe('/lsp status', () => {
+  test('shows not-started status with no configured servers', async () => {
+    const output = await run('status')
+
+    expect(output).toContain('LSP status')
+    expect(output).toContain('Initialization: not-started')
+    expect(output).toContain('Configured plugin LSP servers: none')
+  })
+
+  test('shows success status with zero configured servers', async () => {
+    initializationStatus = { status: 'success' }
+
+    const output = await run('status')
+
+    expect(output).toContain('Initialization: success')
+    expect(output).toContain('Configured plugin LSP servers: none')
+  })
+
+  test('shows success status with configured servers', async () => {
+    initializationStatus = { status: 'success' }
+    configuredServers = {
+      'plugin:typescript-lsp:typescript': {
+        command: 'typescript-language-server',
+        args: ['--stdio'],
+        extensionToLanguage: { '.ts': 'typescript' },
+      },
+    }
+
+    const output = await run('status')
+
+    expect(output).toContain('Configured plugin LSP servers: 1')
+    expect(output).toContain('state: configured')
+    expect(output).toContain('typescript-language-server --stdio')
+    expect(output).toContain('extensions: .ts')
+  })
+
+  test('explains stopped servers as lazy-started rather than broken', async () => {
+    initializationStatus = { status: 'success' }
+    configuredServers = {
+      'plugin:typescript-lsp:typescript': {
+        command: 'typescript-language-server',
+        args: ['--stdio'],
+        extensionToLanguage: { '.ts': 'typescript' },
+      },
+    }
+    serverInstances = new Map([
+      [
+        'plugin:typescript-lsp:typescript',
+        {
+          state: 'stopped',
+          config: configuredServers['plugin:typescript-lsp:typescript'],
+        },
+      ],
+    ])
+
+    const output = await run('status')
+
+    expect(output).toContain(
+      'state: stopped (lazy start; starts on first LSP request)',
+    )
+  })
+
+  test('shows configured server state and initialization error', async () => {
+    initializationStatus = {
+      status: 'failed',
+      error: new Error('startup failed'),
+    }
+    configuredServers = {
+      'plugin:typescript-lsp:typescript': {
+        command: 'typescript-language-server',
+        extensionToLanguage: { '.ts': 'typescript', '.tsx': 'typescriptreact' },
+      },
+    }
+    serverInstances = new Map([
+      [
+        'plugin:typescript-lsp:typescript',
+        {
+          state: 'error',
+          lastError: new Error('server crashed'),
+          config: configuredServers['plugin:typescript-lsp:typescript'],
+        },
+      ],
+    ])
+
+    const output = await run('status')
+
+    expect(output).toContain('Initialization: failed')
+    expect(output).toContain('startup failed')
+    expect(output).toContain('plugin:typescript-lsp:typescript')
+    expect(output).toContain('state: error')
+    expect(output).toContain('typescript-language-server')
+    expect(output).toContain('.ts, .tsx')
+    expect(output).toContain('server crashed')
+  })
+})
+
+describe('/lsp recommend', () => {
+  test('lists candidates with binary state and next commands', async () => {
+    candidates = [
+      {
+        pluginId: 'typescript-lsp@claude-plugins-official',
+        pluginName: 'typescript-lsp',
+        marketplaceName: 'claude-plugins-official',
+        isOfficial: true,
+        extensions: ['.ts', '.tsx'],
+        command: 'typescript-language-server',
+        binaryInstalled: false,
+        installed: false,
+      },
+    ]
+
+    const output = await run('recommend src/main.ts')
+
+    expect(output).toContain('LSP recommendations for .ts')
+    expect(output).toContain('typescript-lsp@claude-plugins-official')
+    expect(output).toContain('binary: missing')
+    expect(output).toContain(
+      'npm install -g typescript typescript-language-server',
+    )
+    expect(output).toContain(
+      '/lsp install typescript-lsp@claude-plugins-official',
+    )
+  })
+
+  test('uses directory paths and bare extensions for recommendation scope', async () => {
+    candidates = [
+      {
+        pluginId: 'typescript-lsp@claude-plugins-official',
+        pluginName: 'typescript-lsp',
+        marketplaceName: 'claude-plugins-official',
+        isOfficial: true,
+        extensions: ['.ts', '.tsx'],
+        command: 'typescript-language-server',
+        binaryInstalled: true,
+        installed: false,
+      },
+    ]
+
+    expect(await run('recommend src')).toContain(
+      'LSP recommendations for .ts, .tsx',
+    )
+    expect(await run('recommend ts')).toContain('LSP recommendations for .ts')
+    expect(await run('recommend .')).toContain(
+      'LSP recommendations for .ts, .tsx',
+    )
+    expect(candidateCallOptions).toContainEqual(
+      expect.objectContaining({ extensions: ['.ts', '.tsx'] }),
+    )
+    expect(candidateCallOptions).toContainEqual(
+      expect.objectContaining({ extensions: ['.ts'] }),
+    )
+  })
+
+  test('does not list every marketplace candidate for a path without extensions', async () => {
+    candidates = [
+      {
+        pluginId: 'typescript-lsp@claude-plugins-official',
+        pluginName: 'typescript-lsp',
+        marketplaceName: 'claude-plugins-official',
+        isOfficial: true,
+        extensions: ['.ts', '.tsx'],
+        command: 'typescript-language-server',
+        binaryInstalled: true,
+        installed: false,
+      },
+    ]
+
+    const output = await run('recommend missing/path')
+
+    expect(output).toContain('No file extensions found for "missing/path".')
+    expect(candidateCallOptions).toEqual([])
+  })
+
+  test('quotes dot path when no extensions are found', async () => {
+    deps.discoverWorkspaceExtensions = async () => []
+
+    const output = await run('recommend .')
+
+    expect(output).toContain('No file extensions found for ".".')
+    expect(output).not.toContain('for ..')
+  })
+
+})
+
+describe('/lsp install', () => {
+  test('installs plugin and refreshes active plugins in-session', async () => {
+    const output = await run('install typescript-lsp@claude-plugins-official')
+
+    expect(installPluginOp).toHaveBeenCalledWith(
+      'typescript-lsp@claude-plugins-official',
+      'user',
+    )
+    expect(refreshActivePlugins).toHaveBeenCalledWith(EMPTY_CONTEXT.setAppState)
+    expect(output).toContain(
+      'Installed typescript-lsp@claude-plugins-official',
+    )
+    expect(output).toContain('Activated 1 plugin LSP server')
+  })
+
+  test('reports install operation exceptions', async () => {
+    installPluginOp.mockImplementationOnce(async () => {
+      throw new Error('install exploded')
+    })
+
+    const output = await run('install typescript-lsp@claude-plugins-official')
+
+    expect(output).toContain(
+      'Failed to install typescript-lsp@claude-plugins-official',
+    )
+    expect(output).toContain('install exploded')
+  })
+
+  test('reports partial success when refresh fails after install', async () => {
+    refreshActivePlugins.mockImplementationOnce(async () => {
+      throw new Error('refresh exploded')
+    })
+
+    const output = await run('install typescript-lsp@claude-plugins-official')
+
+    expect(output).toContain(
+      'Installed typescript-lsp@claude-plugins-official',
+    )
+    expect(output).toContain('plugin refresh failed')
+    expect(output).toContain('refresh exploded')
+  })
+})
+
+describe('/lsp uninstall', () => {
+  test('uninstalls plugin, refreshes plugins, and reports remaining servers', async () => {
+    configuredServers = {
+      'plugin:typescript-lsp:typescript': {
+        command: 'typescript-language-server',
+      },
+    }
+
+    const output = await run('uninstall typescript-lsp@claude-plugins-official')
+
+    expect(uninstallPluginOp).toHaveBeenCalledWith(
+      'typescript-lsp@claude-plugins-official',
+      'user',
+    )
+    expect(refreshActivePlugins).toHaveBeenCalledWith(EMPTY_CONTEXT.setAppState)
+    expect(reinitializeLspServerManager).not.toHaveBeenCalled()
+    expect(waitForInitialization).toHaveBeenCalled()
+    expect(output).toContain('Uninstalled typescript-lsp@claude-plugins-official')
+    expect(output).toContain('1 plugin LSP server still active')
+  })
+
+  test('reports usage when no plugin-id given', async () => {
+    const output = await run('uninstall')
+
+    expect(output).toContain('Usage: /lsp uninstall')
+    expect(uninstallPluginOp).not.toHaveBeenCalled()
+  })
+
+  test('reports uninstall failure', async () => {
+    uninstallPluginOp.mockImplementationOnce(async () => ({
+      success: false,
+      message: 'Plugin not found',
+      pluginId: 'nonexistent@marketplace',
+    }))
+
+    const output = await run('uninstall nonexistent@marketplace')
+
+    expect(output).toContain('Failed to uninstall')
+    expect(output).toContain('Plugin not found')
+  })
+
+  test('reports uninstall operation exceptions', async () => {
+    uninstallPluginOp.mockImplementationOnce(async () => {
+      throw new Error('uninstall exploded')
+    })
+
+    const output = await run('uninstall typescript-lsp@claude-plugins-official')
+
+    expect(output).toContain('Failed to uninstall')
+    expect(output).toContain('uninstall exploded')
+  })
+
+  test('reports partial success when refresh fails after uninstall', async () => {
+    refreshActivePlugins.mockImplementationOnce(async () => {
+      throw new Error('refresh exploded')
+    })
+
+    const output = await run('uninstall typescript-lsp@claude-plugins-official')
+
+    expect(output).toContain('Uninstalled typescript-lsp@claude-plugins-official')
+    expect(output).toContain('plugin refresh failed')
+    expect(output).toContain('refresh exploded')
+  })
+})
+
+describe('/lsp restart', () => {
+  test('reinitializes and reports server count', async () => {
+    initializationStatus = { status: 'success' }
+    configuredServers = {
+      'plugin:typescript-lsp:typescript': {
+        command: 'typescript-language-server',
+      },
+    }
+
+    const output = await run('restart')
+
+    expect(reinitializeLspServerManager).toHaveBeenCalled()
+    expect(waitForInitialization).toHaveBeenCalled()
+    expect(output).toContain('LSP restarted')
+    expect(output).toContain('1 server configured')
+  })
+
+  test('refuses to restart when LSP not initialized', async () => {
+    initializationStatus = { status: 'not-started' }
+
+    const output = await run('restart')
+
+    expect(reinitializeLspServerManager).not.toHaveBeenCalled()
+    expect(output).toContain('not been initialized')
+  })
+
+  test('reports restart failure', async () => {
+    initializationStatus = { status: 'success' }
+
+    // After restart, status becomes failed
+    const statuses: InitializationStatus[] = [
+      { status: 'success' },
+      { status: 'failed', error: new Error('server crash') },
+    ]
+    deps.getInitializationStatus = () => statuses.shift()!
+
+    const output = await run('restart')
+
+    expect(output).toContain('LSP restart failed')
+    expect(output).toContain('server crash')
+
+    // Restore original behavior
+    deps.getInitializationStatus = () => initializationStatus
+  })
+})
+
+describe('/lsp help', () => {
+  test('shows usage for all commands with examples', async () => {
+    const output = await run('help')
+
+    expect(output).toContain('/lsp status')
+    expect(output).toContain('/lsp recommend')
+    expect(output).toContain('/lsp install')
+    expect(output).toContain('/lsp uninstall')
+    expect(output).toContain('/lsp restart')
+    expect(output).toContain('Tip:')
+  })
+
+  test('shows help for unknown subcommands', async () => {
+    const output = await run('bogus')
+
+    expect(output).toContain('Unknown /lsp command "bogus"')
+    expect(output).toContain('/lsp status')
+    expect(output).toContain('/lsp restart')
+  })
+})
+
+describe('binary install hints', () => {
+  test('shows OS-specific install instructions for known binaries', async () => {
+    candidates = [
+      {
+        pluginId: 'clangd-lsp@claude-plugins-official',
+        pluginName: 'clangd-lsp',
+        marketplaceName: 'claude-plugins-official',
+        isOfficial: true,
+        extensions: ['.c', '.cpp'],
+        command: 'clangd',
+        binaryInstalled: false,
+        installed: false,
+      },
+    ]
+
+    const output = await run('recommend src/main.cpp')
+
+    expect(output).toContain('Binary missing: clangd')
+    expect(output).toContain('Arch/Manjaro:')
+    expect(output).toContain('sudo pacman -S clang')
+    expect(output).toContain('Debian/Ubuntu:')
+    expect(output).toContain('macOS:')
+    expect(output).toContain('Verify:')
+    expect(output).toContain('clangd --version')
+  })
+
+  test('shows generic fallback for unknown binaries', async () => {
+    candidates = [
+      {
+        pluginId: 'unknown-lsp@marketplace',
+        pluginName: 'unknown-lsp',
+        marketplaceName: 'marketplace',
+        isOfficial: false,
+        extensions: ['.xyz'],
+        command: 'some-unknown-binary',
+        binaryInstalled: false,
+        installed: false,
+      },
+    ]
+
+    const output = await run('recommend file.xyz')
+
+    expect(output).toContain('Binary missing: some-unknown-binary')
+    expect(output).toContain('Install some-unknown-binary and ensure it is on PATH')
+    expect(output).toContain('some-unknown-binary --version')
+  })
+
+  test('shows notes for binaries that have them', async () => {
+    candidates = [
+      {
+        pluginId: 'gopls-lsp@claude-plugins-official',
+        pluginName: 'gopls-lsp',
+        marketplaceName: 'claude-plugins-official',
+        isOfficial: true,
+        extensions: ['.go'],
+        command: 'gopls',
+        binaryInstalled: false,
+        installed: false,
+      },
+    ]
+
+    const output = await run('recommend main.go')
+
+    expect(output).toContain('Notes:')
+    expect(output).toContain('Ensure $(go env GOPATH)/bin is on PATH')
+  })
+})

--- a/src/commands/lsp/lsp.ts
+++ b/src/commands/lsp/lsp.ts
@@ -1,4 +1,5 @@
-import { extname } from 'path'
+import { readdir, stat } from 'fs/promises'
+import { extname, join, resolve } from 'path'
 import { getAllLspServers } from '../../services/lsp/config.js'
 import {
   getInitializationStatus,
@@ -72,6 +73,42 @@ const DEFAULT_DEPS: LspCommandDeps = {
   waitForInitialization,
   discoverWorkspaceExtensions,
 }
+
+const DISCOVERED_EXTENSION_IGNORE_SET = new Set([
+  '.eot',
+  '.gif',
+  '.ico',
+  '.jpeg',
+  '.jpg',
+  '.lock',
+  '.map',
+  '.otf',
+  '.png',
+  '.svg',
+  '.ttf',
+  '.webp',
+  '.woff',
+  '.woff2',
+])
+
+const DISCOVERY_DIRECTORY_IGNORE_SET = new Set([
+  '.cache',
+  '.git',
+  '.hg',
+  '.next',
+  '.openclaude',
+  '.svn',
+  'build',
+  'coverage',
+  'dist',
+  'node_modules',
+  'out',
+  'target',
+  'vendor',
+])
+
+const MAX_DISCOVERY_FILES = 5_000
+const MAX_DISCOVERY_DEPTH = 8
 
 type BinaryInstallHint = {
   install?: {
@@ -538,7 +575,9 @@ async function resolveRecommendationExtensions(
 ): Promise<string[]> {
   const trimmed = target.trim()
   if (!trimmed) {
-    return deps.discoverWorkspaceExtensions()
+    return filterDiscoveredRecommendationExtensions(
+      await deps.discoverWorkspaceExtensions(),
+    )
   }
 
   if (isExtensionLiteral(trimmed)) {
@@ -550,7 +589,7 @@ async function resolveRecommendationExtensions(
 
   const pathExtensions = await deps.discoverWorkspaceExtensions(trimmed)
   if (pathExtensions.length > 0) {
-    return pathExtensions
+    return filterDiscoveredRecommendationExtensions(pathExtensions)
   }
 
   if (/^[a-z0-9_+-]+$/i.test(trimmed)) {
@@ -584,15 +623,28 @@ function getCandidateMatchedExtensions(
   return Array.from(matched)
 }
 
-export async function discoverWorkspaceExtensions(pathspec?: string): Promise<string[]> {
+function filterDiscoveredRecommendationExtensions(
+  extensions: string[],
+): string[] {
+  return extensions.filter(ext => !DISCOVERED_EXTENSION_IGNORE_SET.has(ext))
+}
+
+export async function discoverWorkspaceExtensions(
+  pathspec?: string,
+  cwd = getCwd(),
+): Promise<string[]> {
   const args = pathspec ? ['ls-files', '--', pathspec] : ['ls-files']
   const result = await execFileNoThrowWithCwd(gitExe(), args, {
-    cwd: getCwd(),
+    cwd,
     timeout: 5_000,
     maxBuffer: 2 * 1024 * 1024,
   })
-  if (result.code !== 0) return []
-  return rankFileExtensions(result.stdout.split('\n'))
+  if (result.code === 0) {
+    const extensions = rankFileExtensions(result.stdout.split('\n'))
+    if (extensions.length > 0) return extensions
+  }
+
+  return discoverFilesystemExtensions(cwd, pathspec)
 }
 
 function rankFileExtensions(files: string[]): string[] {
@@ -600,6 +652,7 @@ function rankFileExtensions(files: string[]): string[] {
   for (const file of files) {
     const ext = extname(file.trim()).toLowerCase()
     if (!ext) continue
+    if (DISCOVERED_EXTENSION_IGNORE_SET.has(ext)) continue
     counts.set(ext, (counts.get(ext) ?? 0) + 1)
   }
 
@@ -607,4 +660,64 @@ function rankFileExtensions(files: string[]): string[] {
     .sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))
     .slice(0, 12)
     .map(([ext]) => ext)
+}
+
+async function discoverFilesystemExtensions(
+  cwd: string,
+  pathspec?: string,
+): Promise<string[]> {
+  const root = resolve(cwd, pathspec || '.')
+  let rootStat
+  try {
+    rootStat = await stat(root)
+  } catch {
+    return []
+  }
+
+  if (rootStat.isFile()) {
+    return rankFileExtensions([root])
+  }
+  if (!rootStat.isDirectory()) {
+    return []
+  }
+
+  const files: string[] = []
+  await collectFiles(root, files, 0)
+  return rankFileExtensions(files)
+}
+
+async function collectFiles(
+  directory: string,
+  files: string[],
+  depth: number,
+): Promise<void> {
+  if (files.length >= MAX_DISCOVERY_FILES || depth > MAX_DISCOVERY_DEPTH) {
+    return
+  }
+
+  let entries
+  try {
+    entries = await readdir(directory, { withFileTypes: true })
+  } catch {
+    return
+  }
+
+  entries.sort((a, b) => a.name.localeCompare(b.name))
+  for (const entry of entries) {
+    if (files.length >= MAX_DISCOVERY_FILES) {
+      return
+    }
+
+    const entryPath = join(directory, entry.name)
+    if (entry.isDirectory()) {
+      if (!DISCOVERY_DIRECTORY_IGNORE_SET.has(entry.name)) {
+        await collectFiles(entryPath, files, depth + 1)
+      }
+      continue
+    }
+
+    if (entry.isFile()) {
+      files.push(entryPath)
+    }
+  }
 }

--- a/src/commands/lsp/lsp.ts
+++ b/src/commands/lsp/lsp.ts
@@ -23,6 +23,10 @@ import {
   listLspPluginCandidates,
   type LspPluginCandidate,
 } from '../../utils/plugins/lspRecommendation.js'
+import {
+  checkAndInstallOfficialMarketplace,
+  type OfficialMarketplaceCheckResult,
+} from '../../utils/plugins/officialMarketplaceStartupCheck.js'
 import { refreshActivePlugins } from '../../utils/plugins/refresh.js'
 import { plural } from '../../utils/stringUtils.js'
 
@@ -53,6 +57,7 @@ export type LspCommandDeps = {
   getLspServerManager: () => LspServerManagerLike | undefined
   getAllLspServers: typeof getAllLspServers
   listLspPluginCandidates: typeof listLspPluginCandidates
+  checkAndInstallOfficialMarketplace: typeof checkAndInstallOfficialMarketplace
   installPluginOp: typeof installPluginOp
   uninstallPluginOp: typeof uninstallPluginOp
   refreshActivePlugins: typeof refreshActivePlugins
@@ -66,12 +71,25 @@ const DEFAULT_DEPS: LspCommandDeps = {
   getLspServerManager,
   getAllLspServers,
   listLspPluginCandidates,
+  checkAndInstallOfficialMarketplace,
   installPluginOp,
   uninstallPluginOp,
   refreshActivePlugins,
   reinitializeLspServerManager,
   waitForInitialization,
   discoverWorkspaceExtensions,
+}
+
+type BinaryInstallHint = {
+  install?: {
+    archManjaro?: string
+    debianUbuntu?: string
+    macos?: string
+    windows?: string
+    generic?: string
+  }
+  verify?: string
+  notes?: string[]
 }
 
 const DISCOVERED_EXTENSION_IGNORE_SET = new Set([
@@ -109,18 +127,6 @@ const DISCOVERY_DIRECTORY_IGNORE_SET = new Set([
 
 const MAX_DISCOVERY_FILES = 5_000
 const MAX_DISCOVERY_DEPTH = 8
-
-type BinaryInstallHint = {
-  install?: {
-    archManjaro?: string
-    debianUbuntu?: string
-    macos?: string
-    windows?: string
-    generic?: string
-  }
-  verify?: string
-  notes?: string[]
-}
 
 const BINARY_INSTALL_HINTS: Record<string, BinaryInstallHint> = {
   clangd: {
@@ -353,25 +359,110 @@ async function renderRecommendations(
       : 'No file extensions found in this workspace.'
   }
 
-  const candidates = await deps.listLspPluginCandidates({
-    extensions,
-    includeInstalled: true,
-    includeMissingBinaries: true,
-  })
+  const { candidates, marketplaceSetup, marketplaceSetupError } =
+    await listRecommendationCandidates(extensions, deps)
   const scope = formatExtensionScope(extensions)
 
   if (candidates.length === 0) {
-    return `No LSP plugin candidates found for ${scope}.`
+    const lines = [`No LSP plugin candidates found for ${scope}.`]
+    const setupMessage = renderMarketplaceSetupMessage(
+      marketplaceSetup,
+      marketplaceSetupError,
+      false,
+    )
+    if (setupMessage) lines.push(setupMessage)
+    return lines.join('\n')
   }
 
   const matchedScope = formatExtensionScope(
     getCandidateMatchedExtensions(extensions, candidates),
   )
   const lines = [`LSP recommendations for ${matchedScope || scope}`]
+  const setupMessage = renderMarketplaceSetupMessage(
+    marketplaceSetup,
+    marketplaceSetupError,
+    true,
+  )
+  if (setupMessage) lines.push(setupMessage)
   for (const candidate of candidates) {
     lines.push(...renderCandidate(candidate))
   }
   return lines.join('\n')
+}
+
+type RecommendationCandidateLookup = {
+  candidates: LspPluginCandidate[]
+  marketplaceSetup?: OfficialMarketplaceCheckResult
+  marketplaceSetupError?: string
+}
+
+async function listRecommendationCandidates(
+  extensions: string[],
+  deps: LspCommandDeps,
+): Promise<RecommendationCandidateLookup> {
+  const candidateOptions = {
+    extensions,
+    includeInstalled: true,
+    includeMissingBinaries: true,
+  }
+  let candidates = await deps.listLspPluginCandidates(candidateOptions)
+  if (candidates.length > 0) {
+    return { candidates }
+  }
+
+  let marketplaceSetup: OfficialMarketplaceCheckResult
+  try {
+    marketplaceSetup = await deps.checkAndInstallOfficialMarketplace()
+  } catch (error) {
+    return {
+      candidates,
+      marketplaceSetupError: errorMessage(error),
+    }
+  }
+
+  if (
+    marketplaceSetup.installed ||
+    marketplaceSetup.reason === 'already_installed'
+  ) {
+    candidates = await deps.listLspPluginCandidates(candidateOptions)
+  }
+
+  return { candidates, marketplaceSetup }
+}
+
+function renderMarketplaceSetupMessage(
+  result: OfficialMarketplaceCheckResult | undefined,
+  error: string | undefined,
+  foundCandidates: boolean,
+): string | undefined {
+  if (error) {
+    return `Anthropic marketplace setup failed: ${error}`
+  }
+  if (!result) {
+    return undefined
+  }
+  if (result.installed) {
+    return foundCandidates
+      ? 'Anthropic marketplace installed for LSP recommendations.'
+      : 'Anthropic marketplace was installed, but it has no matching LSP plugin candidates for this scope.'
+  }
+  if (!result.skipped || result.reason === 'already_installed') {
+    return undefined
+  }
+
+  switch (result.reason) {
+    case 'policy_blocked':
+      return 'Anthropic marketplace is unavailable because policy blocks it.'
+    case 'git_unavailable':
+      return 'Anthropic marketplace is unavailable because git is not available.'
+    case 'gcs_unavailable':
+      return 'Anthropic marketplace download is temporarily unavailable; it will retry later.'
+    case 'already_attempted':
+      return 'Anthropic marketplace setup was already attempted and is waiting before retrying.'
+    case 'unknown':
+    default:
+      return 'Anthropic marketplace setup failed; run /doctor for details.'
+  }
 }
 
 function renderCandidate(candidate: LspPluginCandidate): string[] {

--- a/src/commands/lsp/lsp.ts
+++ b/src/commands/lsp/lsp.ts
@@ -1,0 +1,610 @@
+import { extname } from 'path'
+import { getAllLspServers } from '../../services/lsp/config.js'
+import {
+  getInitializationStatus,
+  getLspServerManager,
+  reinitializeLspServerManager,
+  waitForInitialization,
+} from '../../services/lsp/manager.js'
+import {
+  installPluginOp,
+  uninstallPluginOp,
+} from '../../services/plugins/pluginOperations.js'
+import type {
+  LocalCommandCall,
+  LocalJSXCommandContext,
+} from '../../types/command.js'
+import { getCwd } from '../../utils/cwd.js'
+import { errorMessage } from '../../utils/errors.js'
+import { execFileNoThrowWithCwd } from '../../utils/execFileNoThrow.js'
+import { gitExe } from '../../utils/git.js'
+import {
+  listLspPluginCandidates,
+  type LspPluginCandidate,
+} from '../../utils/plugins/lspRecommendation.js'
+import { refreshActivePlugins } from '../../utils/plugins/refresh.js'
+import { plural } from '../../utils/stringUtils.js'
+
+type LspServerConfigLike = {
+  command?: string
+  args?: string[]
+  extensionToLanguage?: Record<string, string>
+}
+
+type LspServerInstanceLike = {
+  state?: string
+  lastError?: Error
+  config?: LspServerConfigLike
+}
+
+type LspServerManagerLike = {
+  getAllServers(): Map<string, LspServerInstanceLike>
+}
+
+type InstallPluginResult = Awaited<ReturnType<typeof installPluginOp>>
+type UninstallPluginResult = Awaited<ReturnType<typeof uninstallPluginOp>>
+type RefreshActivePluginsResult = Awaited<
+  ReturnType<typeof refreshActivePlugins>
+>
+
+export type LspCommandDeps = {
+  getInitializationStatus: typeof getInitializationStatus
+  getLspServerManager: () => LspServerManagerLike | undefined
+  getAllLspServers: typeof getAllLspServers
+  listLspPluginCandidates: typeof listLspPluginCandidates
+  installPluginOp: typeof installPluginOp
+  uninstallPluginOp: typeof uninstallPluginOp
+  refreshActivePlugins: typeof refreshActivePlugins
+  reinitializeLspServerManager: typeof reinitializeLspServerManager
+  waitForInitialization: typeof waitForInitialization
+  discoverWorkspaceExtensions: (pathspec?: string) => Promise<string[]>
+}
+
+const DEFAULT_DEPS: LspCommandDeps = {
+  getInitializationStatus,
+  getLspServerManager,
+  getAllLspServers,
+  listLspPluginCandidates,
+  installPluginOp,
+  uninstallPluginOp,
+  refreshActivePlugins,
+  reinitializeLspServerManager,
+  waitForInitialization,
+  discoverWorkspaceExtensions,
+}
+
+type BinaryInstallHint = {
+  install?: {
+    archManjaro?: string
+    debianUbuntu?: string
+    macos?: string
+    windows?: string
+    generic?: string
+  }
+  verify?: string
+  notes?: string[]
+}
+
+const BINARY_INSTALL_HINTS: Record<string, BinaryInstallHint> = {
+  clangd: {
+    install: {
+      archManjaro: 'sudo pacman -S clang',
+      debianUbuntu: 'sudo apt install clangd',
+      macos: 'brew install llvm',
+    },
+    verify: 'clangd --version',
+  },
+
+  vtsls: {
+    install: {
+      generic: 'npm install -g @vtsls/language-server typescript',
+    },
+    verify: 'vtsls --version',
+  },
+
+  'typescript-language-server': {
+    install: {
+      generic: 'npm install -g typescript typescript-language-server',
+    },
+    verify: 'typescript-language-server --version',
+  },
+
+  'pyright-langserver': {
+    install: {
+      generic: 'npm install -g pyright',
+    },
+    verify: 'pyright-langserver --help',
+  },
+
+  'rust-analyzer': {
+    install: {
+      generic: 'rustup component add rust-analyzer',
+    },
+    verify: 'rust-analyzer --version',
+  },
+
+  gopls: {
+    install: {
+      generic: 'go install golang.org/x/tools/gopls@latest',
+    },
+    verify: 'gopls version',
+    notes: ['Ensure $(go env GOPATH)/bin is on PATH.'],
+  },
+
+  'csharp-ls': {
+    install: {
+      generic: 'dotnet tool install --global csharp-ls',
+    },
+    verify: 'csharp-ls --version',
+    notes: ['Ensure ~/.dotnet/tools is on PATH.'],
+  },
+
+  jdtls: {
+    install: {
+      macos: 'brew install jdtls',
+      generic: 'Install Eclipse JDT LS/jdtls and ensure jdtls is on PATH',
+    },
+    verify: 'jdtls --version',
+  },
+
+  'kotlin-lsp': {
+    install: {
+      macos: 'brew install JetBrains/utils/kotlin-lsp',
+      generic:
+        'Install kotlin-lsp manually and ensure kotlin-lsp is on PATH',
+    },
+    verify: 'kotlin-lsp --version',
+    notes: ['Requires Java 17+.'],
+  },
+
+  'lua-language-server': {
+    install: {
+      macos: 'brew install lua-language-server',
+      generic:
+        'Install LuaLS/lua-language-server and ensure lua-language-server is on PATH',
+    },
+    verify: 'lua-language-server --version',
+  },
+
+  intelephense: {
+    install: {
+      generic: 'npm install -g intelephense',
+    },
+    verify: 'intelephense --version',
+  },
+
+  'ruby-lsp': {
+    install: {
+      generic: 'gem install ruby-lsp',
+    },
+    verify: 'ruby-lsp --version',
+  },
+
+  'sourcekit-lsp': {
+    install: {
+      macos: 'Install Xcode so sourcekit-lsp is available',
+      generic:
+        'Install the Swift toolchain and ensure sourcekit-lsp is on PATH',
+    },
+    verify: 'sourcekit-lsp --help',
+  },
+}
+
+export const call: LocalCommandCall = (args, context) =>
+  runLspCommand(args, context, DEFAULT_DEPS)
+
+export async function runLspCommand(
+  args: string,
+  context: Pick<LocalJSXCommandContext, 'setAppState'>,
+  deps: LspCommandDeps = DEFAULT_DEPS,
+) {
+  const { command, rest } = parseCommand(args)
+
+  switch (command) {
+    case '':
+    case 'help':
+      return text(helpText())
+    case 'status':
+      return text(await renderStatus(deps))
+    case 'recommend':
+      return text(await renderRecommendations(rest, deps))
+    case 'install':
+      return text(await installLspPlugin(rest, context, deps))
+    case 'uninstall':
+      return text(await uninstallLspPlugin(rest, context, deps))
+    case 'restart':
+      return text(await restartLsp(deps))
+    default:
+      return text(`Unknown /lsp command "${command}".\n\n${helpText()}`)
+  }
+}
+
+function text(value: string): { type: 'text'; value: string } {
+  return { type: 'text', value }
+}
+
+function parseCommand(args: string): { command: string; rest: string } {
+  const trimmed = args.trim()
+  if (!trimmed) return { command: '', rest: '' }
+  const match = /^(\S+)(?:\s+([\s\S]*))?$/.exec(trimmed)
+  return {
+    command: match?.[1]?.toLowerCase() ?? '',
+    rest: match?.[2]?.trim() ?? '',
+  }
+}
+
+function helpText(): string {
+  return [
+    'Usage:',
+    '  /lsp status',
+    '  /lsp recommend [path-or-extension]',
+    '  /lsp install <plugin-id>',
+    '  /lsp uninstall <plugin-id>',
+    '  /lsp restart',
+    '',
+    'Examples:',
+    '  /lsp status',
+    '  /lsp recommend .',
+    '  /lsp recommend src/main.ts',
+    '  /lsp recommend .ts',
+    '  /lsp install typescript-lsp@claude-plugins-official',
+    '  /lsp uninstall typescript-lsp@claude-plugins-official',
+    '  /lsp restart',
+    '',
+    'Tip:',
+    '  Run /lsp recommend first and copy the plugin id from the recommendation output.',
+  ].join('\n')
+}
+
+async function renderStatus(deps: LspCommandDeps): Promise<string> {
+  const status = deps.getInitializationStatus()
+  const { servers } = await deps.getAllLspServers()
+  const manager = deps.getLspServerManager()
+  const instances = manager?.getAllServers() ?? new Map()
+
+  const lines = ['LSP status', `Initialization: ${status.status}`]
+
+  if (status.status === 'failed') {
+    lines.push(`Initialization error: ${status.error.message}`)
+  }
+
+  const serverNames = Object.keys(servers).sort()
+  if (serverNames.length === 0) {
+    lines.push('Configured plugin LSP servers: none')
+    return lines.join('\n')
+  }
+
+  lines.push(`Configured plugin LSP servers: ${serverNames.length}`)
+  for (const name of serverNames) {
+    const instance = instances.get(name)
+    const config = (instance?.config ?? servers[name]) as LspServerConfigLike
+    const state = formatServerState(instance?.state ?? 'configured')
+    const command = [config.command, ...(config.args ?? [])]
+      .filter(Boolean)
+      .join(' ')
+    const extensions = Object.keys(config.extensionToLanguage ?? {}).sort()
+
+    lines.push(`- ${name} (state: ${state})`)
+    if (command) lines.push(`  command: ${command}`)
+    if (extensions.length > 0) {
+      lines.push(`  extensions: ${extensions.join(', ')}`)
+    }
+    if (instance?.lastError) {
+      lines.push(`  last error: ${instance.lastError.message}`)
+    }
+  }
+
+  return lines.join('\n')
+}
+
+function formatServerState(state: string): string {
+  if (state === 'stopped') {
+    return 'stopped (lazy start; starts on first LSP request)'
+  }
+  return state
+}
+
+async function renderRecommendations(
+  target: string,
+  deps: LspCommandDeps,
+): Promise<string> {
+  const trimmedTarget = target.trim()
+  const extensions = await resolveRecommendationExtensions(target, deps)
+  if (extensions.length === 0) {
+    return trimmedTarget
+      ? `No file extensions found for ${JSON.stringify(trimmedTarget)}.`
+      : 'No file extensions found in this workspace.'
+  }
+
+  const candidates = await deps.listLspPluginCandidates({
+    extensions,
+    includeInstalled: true,
+    includeMissingBinaries: true,
+  })
+  const scope = formatExtensionScope(extensions)
+
+  if (candidates.length === 0) {
+    return `No LSP plugin candidates found for ${scope}.`
+  }
+
+  const matchedScope = formatExtensionScope(
+    getCandidateMatchedExtensions(extensions, candidates),
+  )
+  const lines = [`LSP recommendations for ${matchedScope || scope}`]
+  for (const candidate of candidates) {
+    lines.push(...renderCandidate(candidate))
+  }
+  return lines.join('\n')
+}
+
+function renderCandidate(candidate: LspPluginCandidate): string[] {
+  const status = [
+    candidate.installed ? 'installed' : 'not installed',
+    candidate.binaryInstalled ? 'binary: found' : 'binary: missing',
+  ].join(', ')
+  const lines = [
+    `- ${candidate.pluginId} (${status})`,
+    `  command: ${candidate.command}`,
+    `  extensions: ${candidate.extensions.join(', ')}`,
+  ]
+
+  if (candidate.description) {
+    lines.push(`  description: ${candidate.description}`)
+  }
+  if (!candidate.binaryInstalled) {
+    lines.push('  next: install the language server binary')
+    for (const hintLine of binaryInstallHint(candidate.command).split('\n')) {
+      lines.push(hintLine ? `    ${hintLine}` : '    ')
+    }
+  }
+  if (!candidate.installed) {
+    lines.push(`  next: /lsp install ${candidate.pluginId}`)
+  }
+
+  return lines
+}
+
+function binaryInstallHint(command: string): string {
+  const hint = BINARY_INSTALL_HINTS[command]
+
+  if (!hint) {
+    return [
+      `Binary missing: ${command}`,
+      '',
+      'Install:',
+      `  Install ${command} and ensure it is on PATH`,
+      '',
+      'Verify:',
+      `  ${command} --version`,
+    ].join('\n')
+  }
+
+  const lines: string[] = [
+    `Binary missing: ${command}`,
+    '',
+    'Install:',
+  ]
+
+  if (hint.install?.archManjaro) {
+    lines.push(`  Arch/Manjaro: ${hint.install.archManjaro}`)
+  }
+
+  if (hint.install?.debianUbuntu) {
+    lines.push(`  Debian/Ubuntu: ${hint.install.debianUbuntu}`)
+  }
+
+  if (hint.install?.macos) {
+    lines.push(`  macOS: ${hint.install.macos}`)
+  }
+
+  if (hint.install?.windows) {
+    lines.push(`  Windows: ${hint.install.windows}`)
+  }
+
+  if (hint.install?.generic) {
+    lines.push(`  ${hint.install.generic}`)
+  }
+
+  if (hint.verify) {
+    lines.push('', 'Verify:', `  ${hint.verify}`)
+  }
+
+  if (hint.notes?.length) {
+    lines.push('', 'Notes:')
+    for (const note of hint.notes) {
+      lines.push(`  - ${note}`)
+    }
+  }
+
+  return lines.join('\n')
+}
+
+async function installLspPlugin(
+  pluginId: string,
+  context: Pick<LocalJSXCommandContext, 'setAppState'>,
+  deps: LspCommandDeps,
+): Promise<string> {
+  if (!pluginId) {
+    return 'Usage: /lsp install <plugin-id>'
+  }
+
+  let result: InstallPluginResult
+  try {
+    result = await deps.installPluginOp(pluginId, 'user')
+  } catch (error) {
+    return `Failed to install ${pluginId}: ${errorMessage(error)}`
+  }
+
+  if (!result.success) {
+    return `Failed to install ${pluginId}: ${result.message}`
+  }
+
+  const installedId = result.pluginId ?? pluginId
+  let refresh: RefreshActivePluginsResult
+  try {
+    refresh = await deps.refreshActivePlugins(context.setAppState)
+  } catch (error) {
+    return `Installed ${installedId}, but plugin refresh failed: ${errorMessage(
+      error,
+    )}. Run /reload-plugins after fixing the error.`
+  }
+
+  let message = `Installed ${installedId}. Activated ${refresh.lsp_count} ${plural(
+    refresh.lsp_count,
+    'plugin LSP server',
+  )}.`
+
+  if (refresh.error_count > 0) {
+    message += ` ${refresh.error_count} ${plural(
+      refresh.error_count,
+      'error',
+    )} during plugin refresh; run /doctor for details.`
+  }
+
+  return message
+}
+
+async function uninstallLspPlugin(
+  pluginId: string,
+  context: Pick<LocalJSXCommandContext, 'setAppState'>,
+  deps: LspCommandDeps,
+): Promise<string> {
+  if (!pluginId) {
+    return 'Usage: /lsp uninstall <plugin-id>'
+  }
+
+  let result: UninstallPluginResult
+  try {
+    result = await deps.uninstallPluginOp(pluginId, 'user')
+  } catch (error) {
+    return `Failed to uninstall ${pluginId}: ${errorMessage(error)}`
+  }
+
+  if (!result.success) {
+    return `Failed to uninstall ${pluginId}: ${result.message}`
+  }
+
+  const uninstalledId = result.pluginId ?? pluginId
+  let refresh: RefreshActivePluginsResult
+  try {
+    refresh = await deps.refreshActivePlugins(context.setAppState)
+  } catch (error) {
+    return `Uninstalled ${uninstalledId}, but plugin refresh failed: ${errorMessage(error)}. Run /reload-plugins after fixing the error.`
+  }
+
+  await deps.waitForInitialization()
+
+  let message = `Uninstalled ${uninstalledId}. ${refresh.lsp_count} ${plural(
+    refresh.lsp_count,
+    'plugin LSP server',
+  )} still active.`
+
+  if (refresh.error_count > 0) {
+    message += ` ${refresh.error_count} ${plural(
+      refresh.error_count,
+      'error',
+    )} during plugin refresh.`
+  }
+
+  return message
+}
+
+async function restartLsp(deps: LspCommandDeps): Promise<string> {
+  const statusBefore = deps.getInitializationStatus()
+  if (statusBefore.status === 'not-started') {
+    return 'LSP has not been initialized. Nothing to restart.'
+  }
+
+  deps.reinitializeLspServerManager()
+  await deps.waitForInitialization()
+
+  const statusAfter = deps.getInitializationStatus()
+  if (statusAfter.status === 'success') {
+    const servers = await deps.getAllLspServers()
+    const count = Object.keys(servers.servers).length
+    return `LSP restarted. ${count} ${plural(count, 'server')} configured.`
+  }
+
+  if (statusAfter.status === 'failed') {
+    return `LSP restart failed: ${statusAfter.error.message}`
+  }
+
+  return 'LSP restart in progress.'
+}
+
+async function resolveRecommendationExtensions(
+  target: string,
+  deps: Pick<LspCommandDeps, 'discoverWorkspaceExtensions'>,
+): Promise<string[]> {
+  const trimmed = target.trim()
+  if (!trimmed) {
+    return deps.discoverWorkspaceExtensions()
+  }
+
+  if (isExtensionLiteral(trimmed)) {
+    return [trimmed.toLowerCase()]
+  }
+
+  const ext = extname(trimmed).toLowerCase()
+  if (ext) return [ext]
+
+  const pathExtensions = await deps.discoverWorkspaceExtensions(trimmed)
+  if (pathExtensions.length > 0) {
+    return pathExtensions
+  }
+
+  if (/^[a-z0-9_+-]+$/i.test(trimmed)) {
+    return [`.${trimmed.toLowerCase()}`]
+  }
+
+  return []
+}
+
+function isExtensionLiteral(value: string): boolean {
+  return /^\.[A-Za-z0-9][A-Za-z0-9_+-]*$/.test(value)
+}
+
+function formatExtensionScope(extensions: string[]): string {
+  return [...extensions].sort().join(', ')
+}
+
+function getCandidateMatchedExtensions(
+  requestedExtensions: string[],
+  candidates: LspPluginCandidate[],
+): string[] {
+  const requested = new Set(requestedExtensions)
+  const matched = new Set<string>()
+  for (const candidate of candidates) {
+    for (const ext of candidate.extensions) {
+      if (requested.has(ext)) {
+        matched.add(ext)
+      }
+    }
+  }
+  return Array.from(matched)
+}
+
+export async function discoverWorkspaceExtensions(pathspec?: string): Promise<string[]> {
+  const args = pathspec ? ['ls-files', '--', pathspec] : ['ls-files']
+  const result = await execFileNoThrowWithCwd(gitExe(), args, {
+    cwd: getCwd(),
+    timeout: 5_000,
+    maxBuffer: 2 * 1024 * 1024,
+  })
+  if (result.code !== 0) return []
+  return rankFileExtensions(result.stdout.split('\n'))
+}
+
+function rankFileExtensions(files: string[]): string[] {
+  const counts = new Map<string, number>()
+  for (const file of files) {
+    const ext = extname(file.trim()).toLowerCase()
+    if (!ext) continue
+    counts.set(ext, (counts.get(ext) ?? 0) + 1)
+  }
+
+  return Array.from(counts.entries())
+    .sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))
+    .slice(0, 12)
+    .map(([ext]) => ext)
+}

--- a/src/hooks/notifs/useLspInitializationNotification.tsx
+++ b/src/hooks/notifs/useLspInitializationNotification.tsx
@@ -7,7 +7,6 @@ import { Text } from '../../ink.js';
 import { getInitializationStatus, getLspServerManager } from '../../services/lsp/manager.js';
 import { useSetAppState } from '../../state/AppState.js';
 import { logForDebugging } from '../../utils/debug.js';
-import { isEnvTruthy } from '../../utils/envUtils.js';
 const LSP_POLL_INTERVAL_MS = 5000;
 
 /**
@@ -17,7 +16,7 @@ const LSP_POLL_INTERVAL_MS = 5000;
  *
  * Also adds errors to appState.plugins.errors for /doctor display.
  *
- * Only active when ENABLE_LSP_TOOL is set.
+ * Active in normal REPL sessions. The manager itself no-ops in --bare mode.
  */
 export function useLspInitializationNotification() {
   const $ = _c(10);
@@ -138,5 +137,5 @@ function _temp2(e) {
   return `${e.type}:${e.source}`;
 }
 function _temp() {
-  return isEnvTruthy("true");
+  return true;
 }

--- a/src/tools.lsp.test.ts
+++ b/src/tools.lsp.test.ts
@@ -1,0 +1,32 @@
+import { beforeEach, expect, mock, test } from 'bun:test'
+import { getEmptyToolPermissionContext } from './Tool.js'
+
+let lspConnected = false
+
+mock.module('./services/lsp/manager.js', () => ({
+  getInitializationStatus: () => ({ status: 'success' }),
+  getLspServerManager: () => undefined,
+  isLspConnected: () => lspConnected,
+  reinitializeLspServerManager: () => {},
+  waitForInitialization: async () => {},
+}))
+
+const { getAllBaseTools, getTools } = await import('./tools.js')
+
+beforeEach(() => {
+  lspConnected = false
+})
+
+test('LSPTool is part of the base tool pool', () => {
+  expect(getAllBaseTools().map(tool => tool.name)).toContain('LSP')
+})
+
+test('LSPTool is filtered from usable tools until a server is connected', () => {
+  const permissionContext = getEmptyToolPermissionContext()
+
+  expect(getTools(permissionContext).map(tool => tool.name)).not.toContain('LSP')
+
+  lspConnected = true
+
+  expect(getTools(permissionContext).map(tool => tool.name)).toContain('LSP')
+})

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -208,7 +208,7 @@ export function getAllBaseTools(): Tools {
     ...(OverflowTestTool ? [OverflowTestTool] : []),
     ...(CtxInspectTool ? [CtxInspectTool] : []),
     ...(TerminalCaptureTool ? [TerminalCaptureTool] : []),
-    ...(isEnvTruthy(process.env.ENABLE_LSP_TOOL) ? [LSPTool] : []),
+    LSPTool,
     ...(isWorktreeModeEnabled() ? [EnterWorktreeTool, ExitWorktreeTool] : []),
     getSendMessageTool(),
     ...(ListPeersTool ? [ListPeersTool] : []),

--- a/src/utils/plugins/lspRecommendation.test.ts
+++ b/src/utils/plugins/lspRecommendation.test.ts
@@ -1,0 +1,185 @@
+import { beforeEach, describe, expect, mock, test } from 'bun:test'
+
+type MarketplaceEntry = {
+  name: string
+  description?: string
+  lspServers?: Record<
+    string,
+    {
+      command: string
+      args?: string[]
+      extensionToLanguage: Record<string, string>
+    }
+  >
+}
+
+let marketplaces: Record<string, MarketplaceEntry[]> = {}
+let installedPlugins = new Set<string>()
+let installedBinaries = new Set<string>()
+let config = {
+  lspRecommendationDisabled: false,
+  lspRecommendationNeverPlugins: [] as string[],
+  lspRecommendationIgnoredCount: 0,
+}
+let addMarketplaceSourceFn = mock(() => {})
+
+mock.module('./marketplaceManager.js', () => ({
+  loadKnownMarketplacesConfig: async () =>
+    Object.fromEntries(
+      Object.keys(marketplaces).map(name => [
+        name,
+        { installLocation: `/tmp/${name}` },
+      ]),
+    ),
+  getMarketplace: async (name: string) => ({
+    plugins: marketplaces[name] ?? [],
+  }),
+  addMarketplaceSource: addMarketplaceSourceFn,
+}))
+
+mock.module('../binaryCheck.js', () => ({
+  isBinaryInstalled: async (command: string) => installedBinaries.has(command),
+}))
+
+mock.module('./installedPluginsManager.js', () => ({
+  isPluginInstalled: (pluginId: string) => installedPlugins.has(pluginId),
+}))
+
+mock.module('../config.js', () => ({
+  getGlobalConfig: () => config,
+  saveGlobalConfig: mock((updater: (current: typeof config) => typeof config) => {
+    config = updater(config)
+  }),
+}))
+
+const {
+  getMatchingLspPlugins,
+  listLspPluginCandidates,
+} = await import('./lspRecommendation.js')
+
+function lspPlugin(
+  name: string,
+  command: string,
+  extensions: string[],
+  description = `${name} description`,
+): MarketplaceEntry {
+  return {
+    name,
+    description,
+    lspServers: {
+      [name]: {
+        command,
+        extensionToLanguage: Object.fromEntries(
+          extensions.map(ext => [ext, ext.slice(1)]),
+        ),
+      },
+    },
+  }
+}
+
+beforeEach(() => {
+  marketplaces = {
+    'claude-plugins-official': [
+      lspPlugin('typescript-lsp', 'typescript-language-server', [
+        '.ts',
+        '.tsx',
+        '.js',
+      ]),
+      lspPlugin('pyright-lsp', 'pyright-langserver', ['.py', '.pyi']),
+    ],
+    community: [lspPlugin('rust-analyzer-lsp', 'rust-analyzer', ['.rs'])],
+  }
+  installedPlugins = new Set()
+  installedBinaries = new Set(['typescript-language-server'])
+  config = {
+    lspRecommendationDisabled: false,
+    lspRecommendationNeverPlugins: [],
+    lspRecommendationIgnoredCount: 0,
+  }
+  addMarketplaceSourceFn.mockClear()
+})
+
+describe('listLspPluginCandidates', () => {
+  test('lists matching marketplace LSP plugins including missing binaries', async () => {
+    const candidates = await listLspPluginCandidates({
+      extensions: ['ts', '.py'],
+      includeInstalled: true,
+      includeMissingBinaries: true,
+    })
+
+    expect(candidates.map(candidate => candidate.pluginId)).toEqual([
+      'typescript-lsp@claude-plugins-official',
+      'pyright-lsp@claude-plugins-official',
+    ])
+    expect(candidates[0]).toMatchObject({
+      command: 'typescript-language-server',
+      binaryInstalled: true,
+      installed: false,
+      isOfficial: true,
+    })
+    expect(candidates[1]).toMatchObject({
+      command: 'pyright-langserver',
+      binaryInstalled: false,
+      installed: false,
+    })
+  })
+
+  test('filters installed and missing-binary candidates unless requested', async () => {
+    installedPlugins = new Set(['typescript-lsp@claude-plugins-official'])
+
+    const candidates = await listLspPluginCandidates({
+      extensions: ['.ts', '.py', '.rs'],
+    })
+
+    expect(candidates).toEqual([])
+  })
+
+  test('includes installed candidates when requested', async () => {
+    installedPlugins = new Set(['typescript-lsp@claude-plugins-official'])
+
+    const candidates = await listLspPluginCandidates({
+      extensions: ['.ts'],
+      includeInstalled: true,
+    })
+
+    expect(candidates).toHaveLength(1)
+    expect(candidates[0]).toMatchObject({
+      pluginId: 'typescript-lsp@claude-plugins-official',
+      installed: true,
+      binaryInstalled: true,
+    })
+  })
+})
+
+describe('getMatchingLspPlugins', () => {
+  test('keeps passive recommendations limited to installable non-installed plugins', async () => {
+    installedBinaries = new Set([
+      'typescript-language-server',
+      'rust-analyzer',
+    ])
+    installedPlugins = new Set(['typescript-lsp@claude-plugins-official'])
+
+    const matches = await getMatchingLspPlugins('src/main.rs')
+
+    expect(matches.map(match => match.pluginId)).toEqual([
+      'rust-analyzer-lsp@community',
+    ])
+    expect(matches[0]?.command).toBe('rust-analyzer')
+  })
+})
+
+describe('marketplace discovery side effects', () => {
+  test('does not mutate marketplace config when none are configured', async () => {
+    marketplaces = {}
+    installedBinaries = new Set(['typescript-language-server'])
+
+    const candidates = await listLspPluginCandidates({
+      extensions: ['.ts'],
+      includeInstalled: true,
+      includeMissingBinaries: true,
+    })
+
+    expect(addMarketplaceSourceFn).not.toHaveBeenCalled()
+    expect(candidates).toEqual([])
+  })
+})

--- a/src/utils/plugins/lspRecommendation.ts
+++ b/src/utils/plugins/lspRecommendation.ts
@@ -1,9 +1,11 @@
 /**
  * LSP Plugin Recommendation Utility
  *
- * Scans installed marketplaces for LSP plugins and recommends plugins
- * based on file extensions, but ONLY when the LSP binary is already
- * installed on the system.
+ * Scans installed marketplaces for LSP plugins.
+ *
+ * Passive recommendations only return plugins whose language-server binary is
+ * already installed. Explicit setup flows can request broader candidates,
+ * including installed plugins and missing-binary candidates.
  *
  * Limitation: Can only detect LSP plugins that declare their servers
  * inline in the marketplace entry. Plugins with separate .lsp.json files
@@ -35,6 +37,17 @@ export type LspPluginRecommendation = {
   isOfficial: boolean // From official marketplace?
   extensions: string[] // File extensions this plugin supports
   command: string // LSP server command (e.g., "typescript-language-server")
+}
+
+export type LspPluginCandidate = LspPluginRecommendation & {
+  binaryInstalled: boolean
+  installed: boolean
+}
+
+export type ListLspPluginCandidatesOptions = {
+  extensions?: string[]
+  includeInstalled?: boolean
+  includeMissingBinaries?: boolean
 }
 
 // Maximum number of times user can ignore recommendations before we stop showing
@@ -205,6 +218,75 @@ async function getLspPluginsFromMarketplaces(): Promise<
   return result
 }
 
+function normalizeExtension(ext: string): string {
+  const trimmed = ext.trim().toLowerCase()
+  if (!trimmed) return ''
+  return trimmed.startsWith('.') ? trimmed : `.${trimmed}`
+}
+
+function sortCandidates(
+  a: Pick<LspPluginCandidate, 'isOfficial'>,
+  b: Pick<LspPluginCandidate, 'isOfficial'>,
+): number {
+  if (a.isOfficial && !b.isOfficial) return -1
+  if (!a.isOfficial && b.isOfficial) return 1
+  return 0
+}
+
+/**
+ * List LSP plugin candidates from configured marketplaces.
+ *
+ * Unlike passive recommendations, this API is for explicit user-facing flows
+ * such as /lsp recommend. It can include installed plugins and plugins whose
+ * language-server binary is not yet present so the UI can explain next steps.
+ */
+export async function listLspPluginCandidates(
+  options: ListLspPluginCandidatesOptions = {},
+): Promise<LspPluginCandidate[]> {
+  const requestedExtensions =
+    options.extensions && options.extensions.length > 0
+      ? new Set(options.extensions.map(normalizeExtension).filter(Boolean))
+      : undefined
+  const includeInstalled = options.includeInstalled === true
+  const includeMissingBinaries = options.includeMissingBinaries === true
+
+  const allLspPlugins = await getLspPluginsFromMarketplaces()
+  const candidates: LspPluginCandidate[] = []
+
+  for (const [pluginId, info] of allLspPlugins) {
+    if (
+      requestedExtensions &&
+      !Array.from(requestedExtensions).some(ext => info.extensions.has(ext))
+    ) {
+      continue
+    }
+
+    const installed = isPluginInstalled(pluginId)
+    if (installed && !includeInstalled) {
+      continue
+    }
+
+    const binaryInstalled = await isBinaryInstalled(info.command)
+    if (!binaryInstalled && !includeMissingBinaries) {
+      continue
+    }
+
+    candidates.push({
+      pluginId,
+      pluginName: info.entry.name,
+      marketplaceName: info.marketplaceName,
+      description: info.entry.description,
+      isOfficial: info.isOfficial,
+      extensions: Array.from(info.extensions).sort(),
+      command: info.command,
+      binaryInstalled,
+      installed,
+    })
+  }
+
+  return candidates.sort(sortCandidates)
+}
+
 /**
  * Find matching LSP plugins for a file path.
  *
@@ -237,75 +319,31 @@ export async function getMatchingLspPlugins(
 
   logForDebugging(`[lspRecommendation] Looking for LSP plugins for ${ext}`)
 
-  // Get all LSP plugins from marketplaces
-  const allLspPlugins = await getLspPluginsFromMarketplaces()
-
   // Get config for filtering
   const config = getGlobalConfig()
   const neverPlugins = config.lspRecommendationNeverPlugins ?? []
+  const candidates = await listLspPluginCandidates({ extensions: [ext] })
 
-  // Filter to matching plugins
-  const matchingPlugins: Array<{ info: LspPluginInfo; pluginId: string }> = []
-
-  for (const [pluginId, info] of allLspPlugins) {
-    // Check extension match
-    if (!info.extensions.has(ext)) {
-      continue
-    }
-
-    // Filter: not in "never" list
-    if (neverPlugins.includes(pluginId)) {
+  return candidates
+    .filter(candidate => {
+      if (neverPlugins.includes(candidate.pluginId)) {
+        logForDebugging(
+          `[lspRecommendation] Skipping ${candidate.pluginId} (in never suggest list)`,
+        )
+        return false
+      }
       logForDebugging(
-        `[lspRecommendation] Skipping ${pluginId} (in never suggest list)`,
+        `[lspRecommendation] Binary '${candidate.command}' found for ${candidate.pluginId}`,
       )
-      continue
-    }
-
-    // Filter: not already installed
-    if (isPluginInstalled(pluginId)) {
-      logForDebugging(
-        `[lspRecommendation] Skipping ${pluginId} (already installed)`,
-      )
-      continue
-    }
-
-    matchingPlugins.push({ info, pluginId })
-  }
-
-  // Filter: binary must be installed (async check)
-  const pluginsWithBinary: Array<{ info: LspPluginInfo; pluginId: string }> = []
-
-  for (const { info, pluginId } of matchingPlugins) {
-    const binaryExists = await isBinaryInstalled(info.command)
-    if (binaryExists) {
-      pluginsWithBinary.push({ info, pluginId })
-      logForDebugging(
-        `[lspRecommendation] Binary '${info.command}' found for ${pluginId}`,
-      )
-    } else {
-      logForDebugging(
-        `[lspRecommendation] Skipping ${pluginId} (binary '${info.command}' not found)`,
-      )
-    }
-  }
-
-  // Sort: official marketplaces first
-  pluginsWithBinary.sort((a, b) => {
-    if (a.info.isOfficial && !b.info.isOfficial) return -1
-    if (!a.info.isOfficial && b.info.isOfficial) return 1
-    return 0
-  })
-
-  // Convert to recommendations
-  return pluginsWithBinary.map(({ info, pluginId }) => ({
-    pluginId,
-    pluginName: info.entry.name,
-    marketplaceName: info.marketplaceName,
-    description: info.entry.description,
-    isOfficial: info.isOfficial,
-    extensions: Array.from(info.extensions),
-    command: info.command,
-  }))
+      return true
+    })
+    .map(
+      ({
+        binaryInstalled: _binaryInstalled,
+        installed: _installed,
+        ...recommendation
+      }) => recommendation,
+    )
 }
 
 /**

--- a/src/utils/plugins/officialMarketplaceStartupCheck.test.ts
+++ b/src/utils/plugins/officialMarketplaceStartupCheck.test.ts
@@ -1,0 +1,125 @@
+import { beforeEach, describe, expect, mock, test } from 'bun:test'
+
+type TestGlobalConfig = {
+  officialMarketplaceAutoInstallAttempted?: boolean
+  officialMarketplaceAutoInstalled?: boolean
+  officialMarketplaceAutoInstallFailReason?:
+    | 'policy_blocked'
+    | 'git_unavailable'
+    | 'gcs_unavailable'
+    | 'unknown'
+  officialMarketplaceAutoInstallRetryCount?: number
+  officialMarketplaceAutoInstallLastAttemptTime?: number
+  officialMarketplaceAutoInstallNextRetryTime?: number
+}
+
+let config: TestGlobalConfig = {}
+let knownMarketplaces: Record<string, unknown> = {}
+const saveGlobalConfig = mock(
+  (updater: (current: TestGlobalConfig) => TestGlobalConfig) => {
+    config = updater(config)
+  },
+)
+const saveKnownMarketplacesConfig = mock(
+  async (next: Record<string, unknown>) => {
+    knownMarketplaces = next
+  },
+)
+const fetchOfficialMarketplaceFromGcs = mock(async () => 'sha')
+const addMarketplaceSource = mock(async () => ({
+  name: 'claude-plugins-official',
+  alreadyMaterialized: false,
+  resolvedSource: {},
+}))
+
+mock.module('../../services/analytics/growthbook.js', () => ({
+  getFeatureValue_CACHED_MAY_BE_STALE: () => true,
+}))
+
+mock.module('../../services/analytics/index.js', () => ({
+  logEvent: mock(() => {}),
+}))
+
+mock.module('../config.js', () => ({
+  getGlobalConfig: () => config,
+  saveGlobalConfig,
+}))
+
+mock.module('../debug.js', () => ({
+  logForDebugging: mock(() => {}),
+}))
+
+mock.module('../log.js', () => ({
+  logError: mock(() => {}),
+}))
+
+mock.module('./gitAvailability.js', () => ({
+  checkGitAvailable: async () => true,
+  markGitUnavailable: mock(() => {}),
+}))
+
+mock.module('./marketplaceHelpers.js', () => ({
+  isSourceAllowedByPolicy: () => true,
+}))
+
+mock.module('./marketplaceManager.js', () => ({
+  addMarketplaceSource,
+  getMarketplacesCacheDir: () => '/tmp/openclaude-marketplaces',
+  loadKnownMarketplacesConfig: async () => knownMarketplaces,
+  saveKnownMarketplacesConfig,
+}))
+
+mock.module('./officialMarketplaceGcs.js', () => ({
+  fetchOfficialMarketplaceFromGcs,
+}))
+
+const { checkAndInstallOfficialMarketplace } = await import(
+  './officialMarketplaceStartupCheck.js'
+)
+
+beforeEach(() => {
+  config = {}
+  knownMarketplaces = {}
+  saveGlobalConfig.mockClear()
+  saveKnownMarketplacesConfig.mockClear()
+  fetchOfficialMarketplaceFromGcs.mockClear()
+  fetchOfficialMarketplaceFromGcs.mockImplementation(async () => 'sha')
+  addMarketplaceSource.mockClear()
+})
+
+describe('checkAndInstallOfficialMarketplace', () => {
+  test('repairs missing known marketplace even when global config says installed', async () => {
+    config = {
+      officialMarketplaceAutoInstallAttempted: true,
+      officialMarketplaceAutoInstalled: true,
+    }
+
+    const result = await checkAndInstallOfficialMarketplace()
+
+    expect(result).toEqual({ installed: true, skipped: false })
+    expect(fetchOfficialMarketplaceFromGcs).toHaveBeenCalled()
+    expect(saveKnownMarketplacesConfig).toHaveBeenCalled()
+    expect(knownMarketplaces).toHaveProperty('claude-plugins-official')
+    expect(config.officialMarketplaceAutoInstalled).toBe(true)
+    expect(config.officialMarketplaceAutoInstallFailReason).toBeUndefined()
+  })
+
+  test('uses known marketplaces as the installed source of truth', async () => {
+    knownMarketplaces = {
+      'claude-plugins-official': {
+        installLocation: '/tmp/openclaude-marketplaces/claude-plugins-official',
+      },
+    }
+
+    const result = await checkAndInstallOfficialMarketplace()
+
+    expect(result).toEqual({
+      installed: false,
+      skipped: true,
+      reason: 'already_installed',
+    })
+    expect(fetchOfficialMarketplaceFromGcs).not.toHaveBeenCalled()
+    expect(config.officialMarketplaceAutoInstallAttempted).toBe(true)
+    expect(config.officialMarketplaceAutoInstalled).toBe(true)
+  })
+})

--- a/src/utils/plugins/officialMarketplaceStartupCheck.ts
+++ b/src/utils/plugins/officialMarketplaceStartupCheck.ts
@@ -81,11 +81,6 @@ function shouldRetryInstallation(
     return true
   }
 
-  // If already installed successfully, don't retry
-  if (config.officialMarketplaceAutoInstalled) {
-    return false
-  }
-
   const failReason = config.officialMarketplaceAutoInstallFailReason
   const retryCount = config.officialMarketplaceAutoInstallRetryCount || 0
   const nextRetryTime = config.officialMarketplaceAutoInstallNextRetryTime
@@ -147,19 +142,36 @@ export type OfficialMarketplaceCheckResult = {
 export async function checkAndInstallOfficialMarketplace(): Promise<OfficialMarketplaceCheckResult> {
   const config = getGlobalConfig()
 
-  // Check if we should retry installation
-  if (!shouldRetryInstallation(config)) {
-    const reason: OfficialMarketplaceSkipReason =
-      config.officialMarketplaceAutoInstallFailReason ?? 'already_attempted'
-    logForDebugging(`Official marketplace auto-install skipped: ${reason}`)
-    return {
-      installed: false,
-      skipped: true,
-      reason,
-    }
-  }
-
   try {
+    // Check if marketplace is already installed before consulting retry state.
+    // Retry state lives in global config; known_marketplaces.json is the actual
+    // source of truth for whether recommendation/setup code can read it.
+    const knownMarketplaces = await loadKnownMarketplacesConfig()
+    if (knownMarketplaces[OFFICIAL_MARKETPLACE_NAME]) {
+      logForDebugging(
+        `Official marketplace '${OFFICIAL_MARKETPLACE_NAME}' already installed, skipping`,
+      )
+      // Mark as attempted so we don't check again
+      saveGlobalConfig(current => ({
+        ...current,
+        officialMarketplaceAutoInstallAttempted: true,
+        officialMarketplaceAutoInstalled: true,
+      }))
+      return { installed: false, skipped: true, reason: 'already_installed' }
+    }
+
+    // Check if we should retry installation
+    if (!shouldRetryInstallation(config)) {
+      const reason: OfficialMarketplaceSkipReason =
+        config.officialMarketplaceAutoInstallFailReason ?? 'already_attempted'
+      logForDebugging(`Official marketplace auto-install skipped: ${reason}`)
+      return {
+        installed: false,
+        skipped: true,
+        reason,
+      }
+    }
+
     // Check if auto-install is disabled via env var
     if (isOfficialMarketplaceAutoInstallDisabled()) {
       logForDebugging(
@@ -177,21 +189,6 @@ export async function checkAndInstallOfficialMarketplace(): Promise<OfficialMark
         policy_blocked: true,
       })
       return { installed: false, skipped: true, reason: 'policy_blocked' }
-    }
-
-    // Check if marketplace is already installed
-    const knownMarketplaces = await loadKnownMarketplacesConfig()
-    if (knownMarketplaces[OFFICIAL_MARKETPLACE_NAME]) {
-      logForDebugging(
-        `Official marketplace '${OFFICIAL_MARKETPLACE_NAME}' already installed, skipping`,
-      )
-      // Mark as attempted so we don't check again
-      saveGlobalConfig(current => ({
-        ...current,
-        officialMarketplaceAutoInstallAttempted: true,
-        officialMarketplaceAutoInstalled: true,
-      }))
-      return { installed: false, skipped: true, reason: 'already_installed' }
     }
 
     // Check enterprise policy restrictions


### PR DESCRIPTION
## Summary

Adds first-class Language Server Protocol setup and discovery support to OpenClaude.

- Registers `LSPTool` in the normal base tool pool while preserving existing runtime safeguards: hidden until an LSP server is connected, still disabled in bare mode through the manager path, and lazy-started on first LSP request.
- Adds `/lsp status`, `/lsp recommend`, `/lsp install`, `/lsp uninstall`, and `/lsp restart` for inspecting and managing plugin-backed LSP servers.
- Extends LSP plugin recommendation utilities with a read-only candidate API that can include installed plugins and missing-binary candidates for explicit setup flows.
- Keeps passive recommendations read-only and installable-only, while `/lsp recommend` can repair missing official marketplace state and retry candidate discovery.
- Improves workspace extension discovery with a bounded filesystem fallback when `git ls-files` cannot enumerate files, and filters noisy binary/generated extensions.
- Clarifies `/lsp status` output so stopped servers are shown as lazy-started rather than broken.

## Why

The LSP stack already existed but was hidden behind an env-gated tool registration and had no user-facing setup flow. This exposes it conservatively: users only see the model tool when a plugin LSP server is actually available, while the slash command gives a concrete path from repo extensions to marketplace plugin, language-server binary, installation, refresh, and status.

The marketplace and extension-discovery changes address real setup failures seen during manual testing: missing/migrated official marketplace config, configured marketplaces without LSP candidates, and workspaces where `git ls-files` returned no usable extensions.

## Validation

- `bun test src/commands/lsp/lsp.test.ts src/utils/plugins/lspRecommendation.test.ts src/utils/plugins/officialMarketplaceStartupCheck.test.ts src/tools.lsp.test.ts src/commands.test.ts` - 41 pass, 0 fail.
- `git diff --check` - pass.
- `bun run typecheck --pretty false` currently reports pre-existing missing module errors in `src/commands.ts` for workflows, skillSearch, peers, fork, and WorkflowTool imports; no new LSP-specific typecheck errors were reported by the filtered check.
