### PR TITLE
fix(provider): allow remote Ollama without OPENAI_API_KEY (#369)

### DIFF
--- a/src/services/api/providerConfig.ts
+++ b/src/services/api/providerConfig.ts
@@ -459,7 +459,8 @@ function normalizePathWithV1(pathname: string): string {
   return `${trimmed}/v1`
 }
 
-function isLikelyOllamaEndpoint(baseUrl: string): boolean {
+export function isLikelyOllamaEndpoint(baseUrl: string | undefined): boolean {
+  if (!baseUrl) return false
   try {
     const parsed = new URL(baseUrl)
     const hostname = parsed.hostname.toLowerCase()

--- a/src/utils/providerValidation.test.ts
+++ b/src/utils/providerValidation.test.ts
@@ -288,6 +288,41 @@ test('github validation is skipped when openai mode is also active', async () =>
   )
 })
 
+test('remote Ollama by hostname does not require OPENAI_API_KEY (#369)', async () => {
+  process.env.CLAUDE_CODE_USE_OPENAI = '1'
+  process.env.OPENAI_BASE_URL = 'http://my-ollama-server.example.com:11434/v1'
+  delete process.env.OPENAI_API_KEY
+
+  await expect(getProviderValidationError(process.env)).resolves.toBeNull()
+})
+
+test('remote Ollama on default port without API key is allowed (#369)', async () => {
+  process.env.CLAUDE_CODE_USE_OPENAI = '1'
+  process.env.OPENAI_BASE_URL = 'http://203.0.113.5:11434/v1'
+  delete process.env.OPENAI_API_KEY
+
+  await expect(getProviderValidationError(process.env)).resolves.toBeNull()
+})
+
+test('remote Ollama identified by "ollama" in hostname is allowed without key (#369)', async () => {
+  process.env.CLAUDE_CODE_USE_OPENAI = '1'
+  process.env.OPENAI_BASE_URL = 'https://ollama.corp.example.com/v1'
+  delete process.env.OPENAI_API_KEY
+
+  await expect(getProviderValidationError(process.env)).resolves.toBeNull()
+})
+
+test('non-Ollama remote provider still requires OPENAI_API_KEY', async () => {
+  process.env.CLAUDE_CODE_USE_OPENAI = '1'
+  process.env.OPENAI_BASE_URL = 'https://api.openai.com/v1'
+  delete process.env.OPENAI_API_KEY
+
+  const message = await getProviderValidationError(process.env)
+  expect(message).toContain(
+    'OPENAI_API_KEY is required when CLAUDE_CODE_USE_OPENAI=1 and OPENAI_BASE_URL is not local.',
+  )
+})
+
 test('startup provider validation allows interactive recovery', () => {
   expect(
     shouldExitForStartupProviderValidationError({

--- a/src/utils/providerValidation.ts
+++ b/src/utils/providerValidation.ts
@@ -20,6 +20,7 @@ import {
 } from '../integrations/routeMetadata.js'
 import {
   getGithubEndpointType,
+  isLikelyOllamaEndpoint,
   isLocalProviderUrl,
   resolveCodexApiCredentials,
   resolveProviderRequest,
@@ -256,7 +257,8 @@ function getCredentialEnvValidationError(
   if (
     validation.allowLocalBaseUrlWithoutCredential &&
     request &&
-    isLocalProviderUrl(request.baseUrl)
+    (isLocalProviderUrl(request.baseUrl) ||
+      isLikelyOllamaEndpoint(request.baseUrl))
   ) {
     return null
   }
@@ -453,7 +455,8 @@ export async function getProviderValidationError(
           validationTarget.kind === 'vendor' &&
           validationTarget.descriptor.id === 'openai' &&
           !env.OPENAI_API_KEY &&
-          !isLocalProviderUrl(request.baseUrl)
+          !isLocalProviderUrl(request.baseUrl) &&
+          !isLikelyOllamaEndpoint(request.baseUrl)
         ) {
           return getOpenAIMissingKeyMessage()
         }
@@ -469,7 +472,11 @@ export async function getProviderValidationError(
     return genericRouteValidation.error
   }
 
-  if (!env.OPENAI_API_KEY && !isLocalProviderUrl(request.baseUrl)) {
+  if (
+    !env.OPENAI_API_KEY &&
+    !isLocalProviderUrl(request.baseUrl) &&
+    !isLikelyOllamaEndpoint(request.baseUrl)
+  ) {
     // If we have a validation target that explicitly says it doesn't require auth,
     // we should not require OPENAI_API_KEY.
     if (validationTarget?.descriptor.setup?.requiresAuth === false) {


### PR DESCRIPTION
## Summary

- Remote Ollama base URLs (a host outside the loopback / RFC1918 range, or a domain like `ollama.corp.example.com`) were being rejected at startup with `OPENAI_API_KEY is required when CLAUDE_CODE_USE_OPENAI=1 and OPENAI_BASE_URL is not local.`
- Ollama doesn't need an API key; the user had to invent a phantom value just to clear validation.
- Extended `getProviderValidationError` to bypass the API-key requirement when the base URL looks like Ollama (port `11434` on any host, or `ollama` substring in hostname/pathname). `isLikelyOllamaEndpoint` already encoded these heuristics for tool-call gating in `providerConfig.ts`; exported it and reused so the rules stay in one place.

## Impact

- user-facing impact: users can now point `OPENAI_BASE_URL` at a remote Ollama server (`http://ollama.corp.example.com/v1`, `http://203.0.113.5:11434/v1`, etc.) without setting `OPENAI_API_KEY`, matching the existing local-Ollama UX.
- developer/maintainer impact: `isLikelyOllamaEndpoint` is now exported. No call-site changes elsewhere.

## Testing

- [x] `bun run build`
- [x] `bun run smoke`
- [x] focused tests: `bun test src/utils/providerValidation.test.ts` — 10 pass, 4 new

## Notes

- provider/model path tested: `CLAUDE_CODE_USE_OPENAI=1` with non-local Ollama-shaped base URLs (`my-ollama-server.example.com:11434`, `203.0.113.5:11434`, `ollama.corp.example.com`) — all clear validation; non-Ollama remote (`api.openai.com`) still requires the key.
- screenshots attached: n/a (validation message change only)
- follow-up work / known limitations: same heuristic semantics as `isLikelyOllamaEndpoint` already used for tool-call gating; if the matching surface needs to be tighter (e.g. require both port AND host hint), the change would land in `providerConfig.ts` and benefit both call sites.

Fixes #369