### PR TITLE
fix(model): cap deepseek-v4-pro:cloud / :flash output at 65536 (#917)

### DIFF
--- a/src/utils/model/openaiContextWindows.test.ts
+++ b/src/utils/model/openaiContextWindows.test.ts
@@ -1,0 +1,32 @@
+import { expect, test } from 'bun:test'
+
+import {
+  getOpenAIContextWindow,
+  getOpenAIMaxOutputTokens,
+} from './openaiContextWindows.js'
+
+test('deepseek-v4-pro:cloud caps max output at 65536 (issue #917)', () => {
+  expect(getOpenAIMaxOutputTokens('deepseek-v4-pro:cloud')).toBe(65_536)
+})
+
+test('deepseek-v4-flash:cloud caps max output at 65536 (issue #917)', () => {
+  expect(getOpenAIMaxOutputTokens('deepseek-v4-flash:cloud')).toBe(65_536)
+})
+
+test('deepseek-v4-pro (non-cloud) keeps 262144 max output', () => {
+  expect(getOpenAIMaxOutputTokens('deepseek-v4-pro')).toBe(262_144)
+})
+
+test('deepseek-v4-flash (non-cloud) keeps 262144 max output', () => {
+  expect(getOpenAIMaxOutputTokens('deepseek-v4-flash')).toBe(262_144)
+})
+
+test('deepseek-v4 :cloud variants advertise 1M context window', () => {
+  expect(getOpenAIContextWindow('deepseek-v4-pro:cloud')).toBe(1_048_576)
+  expect(getOpenAIContextWindow('deepseek-v4-flash:cloud')).toBe(1_048_576)
+})
+
+test('prefix-match still resolves dated variants to base entry', () => {
+  // deepseek-v4-pro-2026-04 should fall back to base deepseek-v4-pro
+  expect(getOpenAIMaxOutputTokens('deepseek-v4-pro-2026-04')).toBe(262_144)
+})

--- a/src/utils/model/openaiContextWindows.ts
+++ b/src/utils/model/openaiContextWindows.ts
@@ -210,6 +210,10 @@ const OPENAI_CONTEXT_WINDOWS: Record<string, number> = {
   'qwen2.5-coder:7b':         32_768,
   'deepseek-coder-v2:16b':    163_840,
   'deepseek-r1:14b':           65_536,
+  // Ollama cloud variants of DeepSeek V4 (proxies to remote infra; same
+  // context as the OpenAI-shaped API entries above).
+  'deepseek-v4-flash:cloud': 1_048_576,
+  'deepseek-v4-pro:cloud':   1_048_576,
   'mistral:7b':                32_768,
   'phi4:14b':                  16_384,
   'gemma2:27b':                 8_192,
@@ -391,6 +395,13 @@ const OPENAI_MAX_OUTPUT_TOKENS: Record<string, number> = {
   'qwen2.5-coder:7b':          8_192,
   'deepseek-coder-v2:16b':     8_192,
   'deepseek-r1:14b':            8_192,
+  // Ollama cloud variants cap output at 65536 (verified against
+  // deepseek-v4-pro:cloud's "max_tokens (262144) exceeds model's maximum
+  // output tokens (65536)" 400 — issue #917). Without these explicit
+  // entries, prefix matching resolves to 'deepseek-v4-pro' (262144) and
+  // every request 400s.
+  'deepseek-v4-flash:cloud':  65_536,
+  'deepseek-v4-pro:cloud':    65_536,
   'mistral:7b':                 4_096,
   'phi4:14b':                   4_096,
   'gemma2:27b':                 4_096,


### PR DESCRIPTION
## Summary

- Ollama's `deepseek-v4-pro:cloud` and `deepseek-v4-flash:cloud` variants proxy to remote infra and cap `max_output_tokens` at 65536. Without explicit entries, `lookupByKey()`'s prefix-match resolves `deepseek-v4-pro:cloud` to the `deepseek-v4-pro` entry (262144), and every request 400s with `max_tokens (262144) exceeds model's maximum output tokens (65536) for model deepseek-v4-pro`.
- Added explicit `:cloud` entries to both `OPENAI_CONTEXT_WINDOWS` (1M, matching the upstream API entry) and `OPENAI_MAX_OUTPUT_TOKENS` (65536). Prefix-match still handles dated variants for the non-cloud entries.

## Impact

- user-facing impact: `/model deepseek-v4-pro:cloud` (and `:flash:cloud`) on an Ollama provider now sends a request the cloud variant accepts, instead of immediately 400-ing.
- developer/maintainer impact: two new entries in each lookup table; no logic change.

## Testing

- [x] `bun run build`
- [x] `bun run smoke`
- [x] focused tests: `bun test src/utils/model/openaiContextWindows.test.ts` — 6 pass (new file)

## Notes

- provider/model path tested: lookup-only change verified via the new tests; the test that the non-cloud `deepseek-v4-pro` and dated-suffix variants continue to resolve to the 262144 entry guards against regression in the prefix-match path.
- screenshots attached: n/a
- follow-up work / known limitations: if Ollama exposes additional `:cloud` tags for other DeepSeek variants in the future they'll need similar entries; same pattern.

Fixes #917