### PR TITLE
fix(worktree): surface git stderr in rev-parse failure message (#690)

### DIFF
--- a/src/utils/worktree.test.ts
+++ b/src/utils/worktree.test.ts
@@ -2,6 +2,7 @@ import { afterEach, expect, test } from 'bun:test'
 
 import {
   _resetGitWorktreeMutationLocksForTesting,
+  buildRevParseFailureMessage,
   withGitWorktreeMutationLock,
 } from './worktree.js'
 
@@ -66,4 +67,35 @@ test('withGitWorktreeMutationLock does not serialize different repos', async () 
 
   releaseFirst()
   await Promise.all([first, second])
+})
+
+test('buildRevParseFailureMessage surfaces git stderr for empty repos (#690)', () => {
+  const msg = buildRevParseFailureMessage(
+    'HEAD',
+    "fatal: ambiguous argument 'HEAD': unknown revision or path not in the working tree.\n",
+    128,
+  )
+  expect(msg).toContain('Failed to resolve base branch "HEAD"')
+  expect(msg).toContain('unknown revision or path')
+  expect(msg).toContain('HEAD has no resolvable commit')
+})
+
+test('buildRevParseFailureMessage falls back to exit code when stderr empty', () => {
+  const msg = buildRevParseFailureMessage('origin/main', '', 1)
+  expect(msg).toBe('Failed to resolve base branch "origin/main": exit code 1')
+})
+
+test('buildRevParseFailureMessage skips HEAD-specific hint for branch refs', () => {
+  const msg = buildRevParseFailureMessage(
+    'origin/main',
+    'fatal: ambiguous argument',
+    128,
+  )
+  expect(msg).not.toContain('HEAD has no resolvable commit')
+  expect(msg).toContain('fatal: ambiguous argument')
+})
+
+test('buildRevParseFailureMessage trims trailing whitespace from stderr', () => {
+  const msg = buildRevParseFailureMessage('HEAD', '  some error\n\n', 128)
+  expect(msg).toContain(': some error (HEAD')
 })

--- a/src/utils/worktree.ts
+++ b/src/utils/worktree.ts
@@ -252,6 +252,26 @@ export function worktreeBranchName(slug: string): string {
   return `worktree-${flattenSlug(slug)}`
 }
 
+/**
+ * Builds a human-readable message for `git rev-parse <baseBranch>` failures
+ * during worktree creation. Surfaces git's stderr so users can distinguish
+ * empty repos ("unknown revision or path"), detached HEADs pointing at
+ * missing objects, and a missing git binary — each previously surfaced as
+ * the same useless `git rev-parse failed`. See #690.
+ */
+export function buildRevParseFailureMessage(
+  baseBranch: string,
+  stderr: string,
+  exitCode: number,
+): string {
+  const detail = stderr.trim() || `exit code ${exitCode}`
+  const hint =
+    baseBranch === 'HEAD'
+      ? ' (HEAD has no resolvable commit — make at least one commit, or check whether git is installed and on PATH)'
+      : ''
+  return `Failed to resolve base branch "${baseBranch}": ${detail}${hint}`
+}
+
 function worktreePathFor(repoRoot: string, slug: string): string {
   return join(worktreesDir(repoRoot), flattenSlug(slug))
 }
@@ -346,14 +366,14 @@ async function getOrCreateWorktree(
     // For the fetch/PR-fetch paths we still need the SHA — the fs-only resolveRef
     // above only covers the "origin/<branch> already exists locally" case.
     if (!baseSha) {
-      const { stdout, code: shaCode } = await execFileNoThrowWithCwd(
+      const { stdout, stderr, code: shaCode } = await execFileNoThrowWithCwd(
         gitExe(),
         ['rev-parse', baseBranch],
         { cwd: repoRoot },
       )
       if (shaCode !== 0) {
         throw new Error(
-          `Failed to resolve base branch "${baseBranch}": git rev-parse failed`,
+          buildRevParseFailureMessage(baseBranch, stderr, shaCode),
         )
       }
       baseSha = stdout.trim()


### PR DESCRIPTION
## Summary

- When `/statusline` (or any AgentTool path that creates a worktree) hits `git rev-parse HEAD` failure during base-branch resolution in `src/utils/worktree.ts`, the previous error swallowed git's stderr and reported only `Failed to resolve base branch "HEAD": git rev-parse failed`. Users couldn't tell whether the cause was an empty repo (`unknown revision or path`), a detached HEAD pointing at a missing object, a missing git binary on PATH — every failure mode surfaced identically.
- Extracted the message construction into `buildRevParseFailureMessage()` and include git's stderr in the thrown `Error`. When the failing ref is literally `HEAD` (the fallback path when fetching `origin/<branch>` fails), the message also appends a short hint about the most common cause (no commits) and PATH check.

## Impact

- user-facing impact: actionable error text on `/statusline` failures (issue reporter on Windows 11 PowerShell hit the empty `git rev-parse failed` line and had no recourse).
- developer/maintainer impact: pure refactor of inline error build into a small exported helper; no behaviour change to the success path.

## Testing

- [x] `bun run build`
- [x] `bun run smoke`
- [x] focused tests: `bun test src/utils/worktree.test.ts` — 6 pass (4 new on `buildRevParseFailureMessage`)

## Notes

- provider/model path tested: error-message path; not provider-specific.
- screenshots attached: n/a (string change).
- follow-up work / known limitations: this surfaces git's own stderr; if a future Windows-specific git binary issue produces a non-actionable stderr we may need to special-case further. Out of scope for this PR.

Fixes #690