### PR TITLE
fix(oauth): skip refresh for third-party providers

### DIFF
--- a/src/services/api/authRouting.ts
+++ b/src/services/api/authRouting.ts
@@ -1,0 +1,29 @@
+import {
+  type APIProvider,
+  getAPIProvider,
+  isFirstPartyAnthropicBaseUrl,
+} from 'src/utils/model/providers.js'
+
+export type ProviderOverride = { model: string; baseURL: string; apiKey: string }
+
+export function shouldUseFirstPartyAnthropicAuthForProvider({
+  providerOverride,
+  apiProvider,
+  isFirstPartyBaseUrl,
+}: {
+  providerOverride?: ProviderOverride
+  apiProvider: APIProvider
+  isFirstPartyBaseUrl: boolean
+}): boolean {
+  return !providerOverride && apiProvider === 'firstParty' && isFirstPartyBaseUrl
+}
+
+export function shouldUseFirstPartyAnthropicAuth(
+  providerOverride?: ProviderOverride,
+): boolean {
+  return shouldUseFirstPartyAnthropicAuthForProvider({
+    providerOverride,
+    apiProvider: getAPIProvider(),
+    isFirstPartyBaseUrl: isFirstPartyAnthropicBaseUrl(),
+  })
+}

--- a/src/services/api/client.oauthRouting.test.ts
+++ b/src/services/api/client.oauthRouting.test.ts
@@ -1,188 +1,45 @@
-import { afterEach, expect, mock, test } from 'bun:test'
+import { expect, test } from 'bun:test'
+import { shouldUseFirstPartyAnthropicAuthForProvider } from './authRouting.js'
 
-const originalMacro = (globalThis as Record<string, unknown>).MACRO
-const originalEnv = {
-  CLAUDE_CODE_USE_GEMINI: process.env.CLAUDE_CODE_USE_GEMINI,
-  CLAUDE_CODE_USE_OPENAI: process.env.CLAUDE_CODE_USE_OPENAI,
-  CLAUDE_CODE_USE_GITHUB: process.env.CLAUDE_CODE_USE_GITHUB,
-  CLAUDE_CODE_USE_MISTRAL: process.env.CLAUDE_CODE_USE_MISTRAL,
-  CLAUDE_CODE_USE_BEDROCK: process.env.CLAUDE_CODE_USE_BEDROCK,
-  CLAUDE_CODE_USE_VERTEX: process.env.CLAUDE_CODE_USE_VERTEX,
-  CLAUDE_CODE_USE_FOUNDRY: process.env.CLAUDE_CODE_USE_FOUNDRY,
-  GEMINI_API_KEY: process.env.GEMINI_API_KEY,
-  GEMINI_MODEL: process.env.GEMINI_MODEL,
-  GEMINI_BASE_URL: process.env.GEMINI_BASE_URL,
-  GEMINI_AUTH_MODE: process.env.GEMINI_AUTH_MODE,
-  OPENAI_API_KEY: process.env.OPENAI_API_KEY,
-  OPENAI_BASE_URL: process.env.OPENAI_BASE_URL,
-  OPENAI_MODEL: process.env.OPENAI_MODEL,
-  ANTHROPIC_BASE_URL: process.env.ANTHROPIC_BASE_URL,
-  ANTHROPIC_API_KEY: process.env.ANTHROPIC_API_KEY,
-  ANTHROPIC_AUTH_TOKEN: process.env.ANTHROPIC_AUTH_TOKEN,
-  ANTHROPIC_CUSTOM_HEADERS: process.env.ANTHROPIC_CUSTOM_HEADERS,
+const providerOverride = {
+  model: 'gpt-4o',
+  baseURL: 'https://provider.example/v1',
+  apiKey: 'provider-test-key',
 }
 
-type AuthMockOptions = {
-  refreshSpy: ReturnType<typeof mock>
-  isClaudeAISubscriber?: boolean
-}
-
-function restoreEnv(key: keyof typeof originalEnv): void {
-  const value = originalEnv[key]
-  if (value === undefined) {
-    delete process.env[key]
-  } else {
-    process.env[key] = value
-  }
-}
-
-function clearProviderEnv(): void {
-  delete process.env.CLAUDE_CODE_USE_GEMINI
-  delete process.env.CLAUDE_CODE_USE_OPENAI
-  delete process.env.CLAUDE_CODE_USE_GITHUB
-  delete process.env.CLAUDE_CODE_USE_MISTRAL
-  delete process.env.CLAUDE_CODE_USE_BEDROCK
-  delete process.env.CLAUDE_CODE_USE_VERTEX
-  delete process.env.CLAUDE_CODE_USE_FOUNDRY
-  delete process.env.GEMINI_API_KEY
-  delete process.env.GEMINI_MODEL
-  delete process.env.GEMINI_BASE_URL
-  delete process.env.GEMINI_AUTH_MODE
-  delete process.env.OPENAI_API_KEY
-  delete process.env.OPENAI_BASE_URL
-  delete process.env.OPENAI_MODEL
-  delete process.env.ANTHROPIC_BASE_URL
-  delete process.env.ANTHROPIC_API_KEY
-  delete process.env.ANTHROPIC_AUTH_TOKEN
-  delete process.env.ANTHROPIC_CUSTOM_HEADERS
-}
-
-function installAuthMock({
-  refreshSpy,
-  isClaudeAISubscriber = true,
-}: AuthMockOptions): void {
-  mock.module('src/utils/auth.js', () => ({
-    checkAndRefreshOAuthTokenIfNeeded: refreshSpy,
-    clearApiKeyHelperCache: () => {},
-    clearAwsCredentialsCache: () => {},
-    clearGcpCredentialsCache: () => {},
-    clearOAuthTokenCache: () => {},
-    getAccountInformation: () => null,
-    getAnthropicApiKey: () => undefined,
-    getApiKeyFromApiKeyHelper: async () => undefined,
-    getApiKeyFromApiKeyHelperCached: () => null,
-    getApiKeyFromConfigOrMacOSKeychain: () => null,
-    getApiKeyHelperElapsedMs: () => 0,
-    getClaudeAIOAuthTokens: () => ({
-      accessToken: 'stored-claude-oauth-token',
-      refreshToken: 'stored-claude-refresh-token',
-      expiresAt: Date.now() + 60_000,
-      scopes: ['user:inference'],
-      subscriptionType: 'pro',
-      rateLimitTier: null,
+test('Gemini provider routing does not use first-party Anthropic auth', () => {
+  expect(
+    shouldUseFirstPartyAnthropicAuthForProvider({
+      apiProvider: 'gemini',
+      isFirstPartyBaseUrl: true,
     }),
-    getAuthTokenSource: () => ({ source: 'none', hasToken: false }),
-    getAnthropicApiKeyWithSource: () => ({ apiKey: undefined, source: 'none' }),
-    getOauthAccountInfo: () => null,
-    getRateLimitTier: () => null,
-    getSubscriptionName: () => 'Claude Pro',
-    getSubscriptionType: () => 'pro',
-    hasAnthropicApiKeyAuth: () => false,
-    hasOpusAccess: () => false,
-    hasProfileScope: () => false,
-    handleOAuth401Error: async () => false,
-    is1PApiCustomer: () => false,
-    isAnthropicAuthEnabled: () => true,
-    isClaudeAISubscriber: () => isClaudeAISubscriber,
-    isConsumerSubscriber: () => true,
-    isCustomApiKeyApproved: () => true,
-    isEnterpriseSubscriber: () => false,
-    isMaxSubscriber: () => false,
-    isOverageProvisioningAllowed: () => false,
-    isProSubscriber: () => true,
-    isTeamSubscriber: () => false,
-    isUsing3PServices: () => false,
-    isTeamPremiumSubscriber: () => false,
-    prefetchApiKeyFromApiKeyHelperIfSafe: () => {},
-    prefetchAwsCredentialsAndBedRockInfoIfSafe: () => {},
-    prefetchGcpCredentialsIfSafe: () => {},
-    refreshAndGetAwsCredentials: async () => null,
-    refreshGcpCredentialsIfNeeded: async () => {},
-    removeApiKey: async () => {},
-    saveApiKey: async () => {},
-    saveOAuthTokensIfNeeded: () => ({ success: true }),
-    validateForceLoginOrg: async () => ({ valid: true }),
-  }))
-}
-
-async function importFreshClientModule() {
-  return import(`./client.ts?ts=${Date.now()}-${Math.random()}`)
-}
-
-afterEach(() => {
-  ;(globalThis as Record<string, unknown>).MACRO = originalMacro
-  for (const key of Object.keys(originalEnv) as Array<keyof typeof originalEnv>) {
-    restoreEnv(key)
-  }
-  mock.restore()
+  ).toBe(false)
 })
 
-test('Gemini provider creation does not refresh stored Claude OAuth tokens', async () => {
-  ;(globalThis as Record<string, unknown>).MACRO = { VERSION: 'test-version' }
-  clearProviderEnv()
-  process.env.CLAUDE_CODE_USE_GEMINI = '1'
-  process.env.GEMINI_API_KEY = 'gemini-test-key'
-  process.env.GEMINI_MODEL = 'gemini-2.0-flash'
-  process.env.GEMINI_BASE_URL = 'https://gemini.example/v1beta/openai'
-  process.env.GEMINI_AUTH_MODE = 'api-key'
-
-  const refreshSpy = mock(async () => false)
-  installAuthMock({ refreshSpy })
-
-  const { getAnthropicClient } = await importFreshClientModule()
-
-  await getAnthropicClient({
-    maxRetries: 0,
-    model: 'gemini-2.0-flash',
-  })
-
-  expect(refreshSpy).toHaveBeenCalledTimes(0)
+test('providerOverride routing does not use first-party Anthropic auth', () => {
+  expect(
+    shouldUseFirstPartyAnthropicAuthForProvider({
+      providerOverride,
+      apiProvider: 'firstParty',
+      isFirstPartyBaseUrl: true,
+    }),
+  ).toBe(false)
 })
 
-test('providerOverride creation does not refresh stored Claude OAuth tokens', async () => {
-  ;(globalThis as Record<string, unknown>).MACRO = { VERSION: 'test-version' }
-  clearProviderEnv()
-
-  const refreshSpy = mock(async () => false)
-  installAuthMock({ refreshSpy })
-
-  const { getAnthropicClient } = await importFreshClientModule()
-
-  await getAnthropicClient({
-    maxRetries: 0,
-    providerOverride: {
-      model: 'gpt-4o',
-      baseURL: 'https://provider.example/v1',
-      apiKey: 'provider-test-key',
-    },
-  })
-
-  expect(refreshSpy).toHaveBeenCalledTimes(0)
+test('first-party Anthropic routing uses first-party Anthropic auth', () => {
+  expect(
+    shouldUseFirstPartyAnthropicAuthForProvider({
+      apiProvider: 'firstParty',
+      isFirstPartyBaseUrl: true,
+    }),
+  ).toBe(true)
 })
 
-test('first-party Anthropic client creation still refreshes stored Claude OAuth tokens', async () => {
-  ;(globalThis as Record<string, unknown>).MACRO = { VERSION: 'test-version' }
-  clearProviderEnv()
-
-  const refreshSpy = mock(async () => false)
-  installAuthMock({ refreshSpy })
-
-  const { getAnthropicClient } = await importFreshClientModule()
-
-  await getAnthropicClient({
-    maxRetries: 0,
-    model: 'claude-sonnet-4-5',
-  })
-
-  expect(refreshSpy).toHaveBeenCalledTimes(1)
+test('custom Anthropic base URLs do not use first-party Anthropic auth', () => {
+  expect(
+    shouldUseFirstPartyAnthropicAuthForProvider({
+      apiProvider: 'firstParty',
+      isFirstPartyBaseUrl: false,
+    }),
+  ).toBe(false)
 })

--- a/src/services/api/client.oauthRouting.test.ts
+++ b/src/services/api/client.oauthRouting.test.ts
@@ -1,0 +1,188 @@
+import { afterEach, expect, mock, test } from 'bun:test'
+
+const originalMacro = (globalThis as Record<string, unknown>).MACRO
+const originalEnv = {
+  CLAUDE_CODE_USE_GEMINI: process.env.CLAUDE_CODE_USE_GEMINI,
+  CLAUDE_CODE_USE_OPENAI: process.env.CLAUDE_CODE_USE_OPENAI,
+  CLAUDE_CODE_USE_GITHUB: process.env.CLAUDE_CODE_USE_GITHUB,
+  CLAUDE_CODE_USE_MISTRAL: process.env.CLAUDE_CODE_USE_MISTRAL,
+  CLAUDE_CODE_USE_BEDROCK: process.env.CLAUDE_CODE_USE_BEDROCK,
+  CLAUDE_CODE_USE_VERTEX: process.env.CLAUDE_CODE_USE_VERTEX,
+  CLAUDE_CODE_USE_FOUNDRY: process.env.CLAUDE_CODE_USE_FOUNDRY,
+  GEMINI_API_KEY: process.env.GEMINI_API_KEY,
+  GEMINI_MODEL: process.env.GEMINI_MODEL,
+  GEMINI_BASE_URL: process.env.GEMINI_BASE_URL,
+  GEMINI_AUTH_MODE: process.env.GEMINI_AUTH_MODE,
+  OPENAI_API_KEY: process.env.OPENAI_API_KEY,
+  OPENAI_BASE_URL: process.env.OPENAI_BASE_URL,
+  OPENAI_MODEL: process.env.OPENAI_MODEL,
+  ANTHROPIC_BASE_URL: process.env.ANTHROPIC_BASE_URL,
+  ANTHROPIC_API_KEY: process.env.ANTHROPIC_API_KEY,
+  ANTHROPIC_AUTH_TOKEN: process.env.ANTHROPIC_AUTH_TOKEN,
+  ANTHROPIC_CUSTOM_HEADERS: process.env.ANTHROPIC_CUSTOM_HEADERS,
+}
+
+type AuthMockOptions = {
+  refreshSpy: ReturnType<typeof mock>
+  isClaudeAISubscriber?: boolean
+}
+
+function restoreEnv(key: keyof typeof originalEnv): void {
+  const value = originalEnv[key]
+  if (value === undefined) {
+    delete process.env[key]
+  } else {
+    process.env[key] = value
+  }
+}
+
+function clearProviderEnv(): void {
+  delete process.env.CLAUDE_CODE_USE_GEMINI
+  delete process.env.CLAUDE_CODE_USE_OPENAI
+  delete process.env.CLAUDE_CODE_USE_GITHUB
+  delete process.env.CLAUDE_CODE_USE_MISTRAL
+  delete process.env.CLAUDE_CODE_USE_BEDROCK
+  delete process.env.CLAUDE_CODE_USE_VERTEX
+  delete process.env.CLAUDE_CODE_USE_FOUNDRY
+  delete process.env.GEMINI_API_KEY
+  delete process.env.GEMINI_MODEL
+  delete process.env.GEMINI_BASE_URL
+  delete process.env.GEMINI_AUTH_MODE
+  delete process.env.OPENAI_API_KEY
+  delete process.env.OPENAI_BASE_URL
+  delete process.env.OPENAI_MODEL
+  delete process.env.ANTHROPIC_BASE_URL
+  delete process.env.ANTHROPIC_API_KEY
+  delete process.env.ANTHROPIC_AUTH_TOKEN
+  delete process.env.ANTHROPIC_CUSTOM_HEADERS
+}
+
+function installAuthMock({
+  refreshSpy,
+  isClaudeAISubscriber = true,
+}: AuthMockOptions): void {
+  mock.module('src/utils/auth.js', () => ({
+    checkAndRefreshOAuthTokenIfNeeded: refreshSpy,
+    clearApiKeyHelperCache: () => {},
+    clearAwsCredentialsCache: () => {},
+    clearGcpCredentialsCache: () => {},
+    clearOAuthTokenCache: () => {},
+    getAccountInformation: () => null,
+    getAnthropicApiKey: () => undefined,
+    getApiKeyFromApiKeyHelper: async () => undefined,
+    getApiKeyFromApiKeyHelperCached: () => null,
+    getApiKeyFromConfigOrMacOSKeychain: () => null,
+    getApiKeyHelperElapsedMs: () => 0,
+    getClaudeAIOAuthTokens: () => ({
+      accessToken: 'stored-claude-oauth-token',
+      refreshToken: 'stored-claude-refresh-token',
+      expiresAt: Date.now() + 60_000,
+      scopes: ['user:inference'],
+      subscriptionType: 'pro',
+      rateLimitTier: null,
+    }),
+    getAuthTokenSource: () => ({ source: 'none', hasToken: false }),
+    getAnthropicApiKeyWithSource: () => ({ apiKey: undefined, source: 'none' }),
+    getOauthAccountInfo: () => null,
+    getRateLimitTier: () => null,
+    getSubscriptionName: () => 'Claude Pro',
+    getSubscriptionType: () => 'pro',
+    hasAnthropicApiKeyAuth: () => false,
+    hasOpusAccess: () => false,
+    hasProfileScope: () => false,
+    handleOAuth401Error: async () => false,
+    is1PApiCustomer: () => false,
+    isAnthropicAuthEnabled: () => true,
+    isClaudeAISubscriber: () => isClaudeAISubscriber,
+    isConsumerSubscriber: () => true,
+    isCustomApiKeyApproved: () => true,
+    isEnterpriseSubscriber: () => false,
+    isMaxSubscriber: () => false,
+    isOverageProvisioningAllowed: () => false,
+    isProSubscriber: () => true,
+    isTeamSubscriber: () => false,
+    isUsing3PServices: () => false,
+    isTeamPremiumSubscriber: () => false,
+    prefetchApiKeyFromApiKeyHelperIfSafe: () => {},
+    prefetchAwsCredentialsAndBedRockInfoIfSafe: () => {},
+    prefetchGcpCredentialsIfSafe: () => {},
+    refreshAndGetAwsCredentials: async () => null,
+    refreshGcpCredentialsIfNeeded: async () => {},
+    removeApiKey: async () => {},
+    saveApiKey: async () => {},
+    saveOAuthTokensIfNeeded: () => ({ success: true }),
+    validateForceLoginOrg: async () => ({ valid: true }),
+  }))
+}
+
+async function importFreshClientModule() {
+  return import(`./client.ts?ts=${Date.now()}-${Math.random()}`)
+}
+
+afterEach(() => {
+  ;(globalThis as Record<string, unknown>).MACRO = originalMacro
+  for (const key of Object.keys(originalEnv) as Array<keyof typeof originalEnv>) {
+    restoreEnv(key)
+  }
+  mock.restore()
+})
+
+test('Gemini provider creation does not refresh stored Claude OAuth tokens', async () => {
+  ;(globalThis as Record<string, unknown>).MACRO = { VERSION: 'test-version' }
+  clearProviderEnv()
+  process.env.CLAUDE_CODE_USE_GEMINI = '1'
+  process.env.GEMINI_API_KEY = 'gemini-test-key'
+  process.env.GEMINI_MODEL = 'gemini-2.0-flash'
+  process.env.GEMINI_BASE_URL = 'https://gemini.example/v1beta/openai'
+  process.env.GEMINI_AUTH_MODE = 'api-key'
+
+  const refreshSpy = mock(async () => false)
+  installAuthMock({ refreshSpy })
+
+  const { getAnthropicClient } = await importFreshClientModule()
+
+  await getAnthropicClient({
+    maxRetries: 0,
+    model: 'gemini-2.0-flash',
+  })
+
+  expect(refreshSpy).toHaveBeenCalledTimes(0)
+})
+
+test('providerOverride creation does not refresh stored Claude OAuth tokens', async () => {
+  ;(globalThis as Record<string, unknown>).MACRO = { VERSION: 'test-version' }
+  clearProviderEnv()
+
+  const refreshSpy = mock(async () => false)
+  installAuthMock({ refreshSpy })
+
+  const { getAnthropicClient } = await importFreshClientModule()
+
+  await getAnthropicClient({
+    maxRetries: 0,
+    providerOverride: {
+      model: 'gpt-4o',
+      baseURL: 'https://provider.example/v1',
+      apiKey: 'provider-test-key',
+    },
+  })
+
+  expect(refreshSpy).toHaveBeenCalledTimes(0)
+})
+
+test('first-party Anthropic client creation still refreshes stored Claude OAuth tokens', async () => {
+  ;(globalThis as Record<string, unknown>).MACRO = { VERSION: 'test-version' }
+  clearProviderEnv()
+
+  const refreshSpy = mock(async () => false)
+  installAuthMock({ refreshSpy })
+
+  const { getAnthropicClient } = await importFreshClientModule()
+
+  await getAnthropicClient({
+    maxRetries: 0,
+    model: 'claude-sonnet-4-5',
+  })
+
+  expect(refreshSpy).toHaveBeenCalledTimes(1)
+})

--- a/src/services/api/client.ts
+++ b/src/services/api/client.ts
@@ -13,7 +13,6 @@ import { getUserAgent } from 'src/utils/http.js'
 import { getSmallFastModel } from 'src/utils/model/model.js'
 import {
   getAPIProvider,
-  isFirstPartyAnthropicBaseUrl,
   isGithubNativeAnthropicMode,
 } from 'src/utils/model/providers.js'
 import { getProxyFetchOptions } from 'src/utils/proxy.js'
@@ -28,6 +27,10 @@ import {
   getVertexRegionForModel,
   isEnvTruthy,
 } from '../../utils/envUtils.js'
+import {
+  type ProviderOverride,
+  shouldUseFirstPartyAnthropicAuth,
+} from './authRouting.js'
 
 const importRuntimeModule = new Function(
   'specifier',
@@ -103,7 +106,7 @@ export async function getAnthropicClient({
   model?: string
   fetchOverride?: ClientOptions['fetch']
   source?: string
-  providerOverride?: { model: string; baseURL: string; apiKey: string }
+  providerOverride?: ProviderOverride
 }): Promise<Anthropic> {
   const containerId = process.env.CLAUDE_CODE_CONTAINER_ID
   const remoteSessionId = process.env.CLAUDE_CODE_REMOTE_SESSION_ID
@@ -135,21 +138,19 @@ export async function getAnthropicClient({
     defaultHeaders['x-anthropic-additional-protection'] = 'true'
   }
 
-  const shouldUseFirstPartyAnthropicAuth =
-    !providerOverride &&
-    getAPIProvider() === 'firstParty' &&
-    isFirstPartyAnthropicBaseUrl()
+  const shouldUseFirstPartyAuth =
+    shouldUseFirstPartyAnthropicAuth(providerOverride)
 
-  if (shouldUseFirstPartyAnthropicAuth) {
+  if (shouldUseFirstPartyAuth) {
     logForDebugging('[API:auth] OAuth token check starting')
     await checkAndRefreshOAuthTokenIfNeeded()
     logForDebugging('[API:auth] OAuth token check complete')
   }
 
   const isClaudeAiSubscriber =
-    shouldUseFirstPartyAnthropicAuth && isClaudeAISubscriber()
+    shouldUseFirstPartyAuth && isClaudeAISubscriber()
 
-  if (shouldUseFirstPartyAnthropicAuth && !isClaudeAiSubscriber) {
+  if (shouldUseFirstPartyAuth && !isClaudeAiSubscriber) {
     await configureApiKeyHeaders(defaultHeaders, getIsNonInteractiveSession())
   }
 

--- a/src/services/api/client.ts
+++ b/src/services/api/client.ts
@@ -135,11 +135,21 @@ export async function getAnthropicClient({
     defaultHeaders['x-anthropic-additional-protection'] = 'true'
   }
 
-  logForDebugging('[API:auth] OAuth token check starting')
-  await checkAndRefreshOAuthTokenIfNeeded()
-  logForDebugging('[API:auth] OAuth token check complete')
+  const shouldUseFirstPartyAnthropicAuth =
+    !providerOverride &&
+    getAPIProvider() === 'firstParty' &&
+    isFirstPartyAnthropicBaseUrl()
 
-  if (!isClaudeAISubscriber()) {
+  if (shouldUseFirstPartyAnthropicAuth) {
+    logForDebugging('[API:auth] OAuth token check starting')
+    await checkAndRefreshOAuthTokenIfNeeded()
+    logForDebugging('[API:auth] OAuth token check complete')
+  }
+
+  const isClaudeAiSubscriber =
+    shouldUseFirstPartyAnthropicAuth && isClaudeAISubscriber()
+
+  if (shouldUseFirstPartyAnthropicAuth && !isClaudeAiSubscriber) {
     await configureApiKeyHeaders(defaultHeaders, getIsNonInteractiveSession())
   }
 
@@ -362,8 +372,8 @@ export async function getAnthropicClient({
 
   // Determine authentication method based on available tokens
   const clientConfig: ConstructorParameters<typeof Anthropic>[0] = {
-    apiKey: isClaudeAISubscriber() ? null : apiKey || getAnthropicApiKey(),
-    authToken: isClaudeAISubscriber()
+    apiKey: isClaudeAiSubscriber ? null : apiKey || getAnthropicApiKey(),
+    authToken: isClaudeAiSubscriber
       ? getClaudeAIOAuthTokens()?.accessToken
       : undefined,
     // Set baseURL from OAuth config when using staging OAuth

--- a/src/services/oauth/client.populateAccountInfo.test.ts
+++ b/src/services/oauth/client.populateAccountInfo.test.ts
@@ -1,171 +1,42 @@
-import { afterEach, expect, mock, test } from 'bun:test'
-import { getGlobalConfig, saveGlobalConfig } from '../../utils/config.js'
+import { expect, test } from 'bun:test'
+import { shouldRefreshOAuthAccountInfo } from './client.js'
 
-const originalEnv = {
-  CLAUDE_CODE_ACCOUNT_UUID: process.env.CLAUDE_CODE_ACCOUNT_UUID,
-  CLAUDE_CODE_USER_EMAIL: process.env.CLAUDE_CODE_USER_EMAIL,
-  CLAUDE_CODE_ORGANIZATION_UUID: process.env.CLAUDE_CODE_ORGANIZATION_UUID,
-}
-
-function restoreEnv(key: keyof typeof originalEnv): void {
-  const value = originalEnv[key]
-  if (value === undefined) {
-    delete process.env[key]
-  } else {
-    process.env[key] = value
-  }
-}
-
-function installPopulateAccountInfoMocks({
-  isClaudeAISubscriber,
-  refreshSpy,
-  profileSpy,
-}: {
-  isClaudeAISubscriber: boolean
-  refreshSpy: ReturnType<typeof mock>
-  profileSpy: ReturnType<typeof mock>
-}): void {
-  mock.module('../../utils/auth.js', () => ({
-    checkAndRefreshOAuthTokenIfNeeded: refreshSpy,
-    clearApiKeyHelperCache: () => {},
-    clearAwsCredentialsCache: () => {},
-    clearGcpCredentialsCache: () => {},
-    clearOAuthTokenCache: () => {},
-    getAccountInformation: () => null,
-    getAnthropicApiKey: () => undefined,
-    getAnthropicApiKeyWithSource: () => ({
-      apiKey: undefined,
-      key: undefined,
-      source: 'none',
+test('OAuth account info population does not refresh when Claude.ai auth is inactive', () => {
+  expect(
+    shouldRefreshOAuthAccountInfo({
+      hasCompleteAccountInfo: false,
+      isClaudeAiSubscriber: false,
+      hasProfileScope: true,
     }),
-    getApiKeyFromApiKeyHelper: async () => undefined,
-    getApiKeyFromApiKeyHelperCached: () => null,
-    getApiKeyFromConfigOrMacOSKeychain: () => null,
-    getApiKeyHelperElapsedMs: () => 0,
-    getAuthTokenSource: () => ({ source: 'none', hasToken: false }),
-    getClaudeAIOAuthTokens: () => ({
-      accessToken: 'stored-claude-oauth-token',
-      refreshToken: 'stored-claude-refresh-token',
-      expiresAt: Date.now() + 60_000,
-      scopes: ['user:inference', 'user:profile'],
-      subscriptionType: 'pro',
-      rateLimitTier: null,
-    }),
-    getOauthAccountInfo: () => null,
-    getRateLimitTier: () => null,
-    getSubscriptionName: () => 'Claude Pro',
-    getSubscriptionType: () => 'pro',
-    handleOAuth401Error: async () => false,
-    hasAnthropicApiKeyAuth: () => false,
-    hasProfileScope: () => true,
-    hasOpusAccess: () => false,
-    is1PApiCustomer: () => false,
-    isAnthropicAuthEnabled: () => isClaudeAISubscriber,
-    isClaudeAISubscriber: () => isClaudeAISubscriber,
-    isConsumerSubscriber: () => true,
-    isCustomApiKeyApproved: () => true,
-    isEnterpriseSubscriber: () => false,
-    isMaxSubscriber: () => false,
-    isOverageProvisioningAllowed: () => false,
-    isProSubscriber: () => true,
-    isTeamPremiumSubscriber: () => false,
-    isTeamSubscriber: () => false,
-    isUsing3PServices: () => false,
-    prefetchApiKeyFromApiKeyHelperIfSafe: () => {},
-    prefetchAwsCredentialsAndBedRockInfoIfSafe: () => {},
-    prefetchGcpCredentialsIfSafe: () => {},
-    refreshAndGetAwsCredentials: async () => null,
-    refreshGcpCredentialsIfNeeded: async () => {},
-    removeApiKey: async () => {},
-    saveApiKey: async () => {},
-    saveOAuthTokensIfNeeded: () => ({ success: true }),
-    validateForceLoginOrg: async () => ({ valid: true }),
-  }))
-
-  mock.module('./getOauthProfile.js', () => ({
-    getOauthProfileFromOauthToken: profileSpy,
-  }))
-}
-
-async function importFreshOAuthClientModule() {
-  return import(`./client.ts?ts=${Date.now()}-${Math.random()}`)
-}
-
-afterEach(() => {
-  for (const key of Object.keys(originalEnv) as Array<keyof typeof originalEnv>) {
-    restoreEnv(key)
-  }
-  saveGlobalConfig(current => ({ ...current, oauthAccount: undefined }))
-  mock.restore()
+  ).toBe(false)
 })
 
-test('OAuth account info population does not refresh when Claude.ai auth is inactive', async () => {
-  delete process.env.CLAUDE_CODE_ACCOUNT_UUID
-  delete process.env.CLAUDE_CODE_USER_EMAIL
-  delete process.env.CLAUDE_CODE_ORGANIZATION_UUID
-  saveGlobalConfig(current => ({ ...current, oauthAccount: undefined }))
-
-  const refreshSpy = mock(async () => false)
-  const profileSpy = mock(async () => null)
-  installPopulateAccountInfoMocks({
-    isClaudeAISubscriber: false,
-    refreshSpy,
-    profileSpy,
-  })
-
-  const { populateOAuthAccountInfoIfNeeded } = await importFreshOAuthClientModule()
-  mock.restore()
-
-  const populated = await populateOAuthAccountInfoIfNeeded()
-
-  expect(populated).toBe(false)
-  expect(refreshSpy).toHaveBeenCalledTimes(0)
-  expect(profileSpy).toHaveBeenCalledTimes(0)
+test('OAuth account info population still refreshes active Claude.ai auth', () => {
+  expect(
+    shouldRefreshOAuthAccountInfo({
+      hasCompleteAccountInfo: false,
+      isClaudeAiSubscriber: true,
+      hasProfileScope: true,
+    }),
+  ).toBe(true)
 })
 
-test('OAuth account info population still refreshes active Claude.ai auth', async () => {
-  delete process.env.CLAUDE_CODE_ACCOUNT_UUID
-  delete process.env.CLAUDE_CODE_USER_EMAIL
-  delete process.env.CLAUDE_CODE_ORGANIZATION_UUID
-  saveGlobalConfig(current => ({ ...current, oauthAccount: undefined }))
+test('OAuth account info population skips refresh when profile scope is missing', () => {
+  expect(
+    shouldRefreshOAuthAccountInfo({
+      hasCompleteAccountInfo: false,
+      isClaudeAiSubscriber: true,
+      hasProfileScope: false,
+    }),
+  ).toBe(false)
+})
 
-  const refreshSpy = mock(async () => true)
-  const profileSpy = mock(async () => ({
-    account: {
-      uuid: 'account-uuid',
-      email: 'user@example.com',
-      display_name: 'Test User',
-      created_at: '2026-01-01T00:00:00.000Z',
-    },
-    organization: {
-      uuid: 'org-uuid',
-      has_extra_usage_enabled: true,
-      billing_type: 'claude_pro',
-      subscription_created_at: '2026-01-02T00:00:00.000Z',
-    },
-  }))
-  installPopulateAccountInfoMocks({
-    isClaudeAISubscriber: true,
-    refreshSpy,
-    profileSpy,
-  })
-
-  const { populateOAuthAccountInfoIfNeeded } = await importFreshOAuthClientModule()
-  mock.restore()
-
-  const populated = await populateOAuthAccountInfoIfNeeded()
-
-  expect(populated).toBe(true)
-  expect(refreshSpy).toHaveBeenCalledTimes(1)
-  expect(profileSpy).toHaveBeenCalledWith('stored-claude-oauth-token')
-  expect(getGlobalConfig().oauthAccount).toEqual({
-    accountUuid: 'account-uuid',
-    emailAddress: 'user@example.com',
-    organizationUuid: 'org-uuid',
-    displayName: 'Test User',
-    hasExtraUsageEnabled: true,
-    billingType: 'claude_pro',
-    accountCreatedAt: '2026-01-01T00:00:00.000Z',
-    subscriptionCreatedAt: '2026-01-02T00:00:00.000Z',
-  })
+test('OAuth account info population skips refresh when account info is complete', () => {
+  expect(
+    shouldRefreshOAuthAccountInfo({
+      hasCompleteAccountInfo: true,
+      isClaudeAiSubscriber: true,
+      hasProfileScope: true,
+    }),
+  ).toBe(false)
 })

--- a/src/services/oauth/client.populateAccountInfo.test.ts
+++ b/src/services/oauth/client.populateAccountInfo.test.ts
@@ -1,0 +1,171 @@
+import { afterEach, expect, mock, test } from 'bun:test'
+import { getGlobalConfig, saveGlobalConfig } from '../../utils/config.js'
+
+const originalEnv = {
+  CLAUDE_CODE_ACCOUNT_UUID: process.env.CLAUDE_CODE_ACCOUNT_UUID,
+  CLAUDE_CODE_USER_EMAIL: process.env.CLAUDE_CODE_USER_EMAIL,
+  CLAUDE_CODE_ORGANIZATION_UUID: process.env.CLAUDE_CODE_ORGANIZATION_UUID,
+}
+
+function restoreEnv(key: keyof typeof originalEnv): void {
+  const value = originalEnv[key]
+  if (value === undefined) {
+    delete process.env[key]
+  } else {
+    process.env[key] = value
+  }
+}
+
+function installPopulateAccountInfoMocks({
+  isClaudeAISubscriber,
+  refreshSpy,
+  profileSpy,
+}: {
+  isClaudeAISubscriber: boolean
+  refreshSpy: ReturnType<typeof mock>
+  profileSpy: ReturnType<typeof mock>
+}): void {
+  mock.module('../../utils/auth.js', () => ({
+    checkAndRefreshOAuthTokenIfNeeded: refreshSpy,
+    clearApiKeyHelperCache: () => {},
+    clearAwsCredentialsCache: () => {},
+    clearGcpCredentialsCache: () => {},
+    clearOAuthTokenCache: () => {},
+    getAccountInformation: () => null,
+    getAnthropicApiKey: () => undefined,
+    getAnthropicApiKeyWithSource: () => ({
+      apiKey: undefined,
+      key: undefined,
+      source: 'none',
+    }),
+    getApiKeyFromApiKeyHelper: async () => undefined,
+    getApiKeyFromApiKeyHelperCached: () => null,
+    getApiKeyFromConfigOrMacOSKeychain: () => null,
+    getApiKeyHelperElapsedMs: () => 0,
+    getAuthTokenSource: () => ({ source: 'none', hasToken: false }),
+    getClaudeAIOAuthTokens: () => ({
+      accessToken: 'stored-claude-oauth-token',
+      refreshToken: 'stored-claude-refresh-token',
+      expiresAt: Date.now() + 60_000,
+      scopes: ['user:inference', 'user:profile'],
+      subscriptionType: 'pro',
+      rateLimitTier: null,
+    }),
+    getOauthAccountInfo: () => null,
+    getRateLimitTier: () => null,
+    getSubscriptionName: () => 'Claude Pro',
+    getSubscriptionType: () => 'pro',
+    handleOAuth401Error: async () => false,
+    hasAnthropicApiKeyAuth: () => false,
+    hasProfileScope: () => true,
+    hasOpusAccess: () => false,
+    is1PApiCustomer: () => false,
+    isAnthropicAuthEnabled: () => isClaudeAISubscriber,
+    isClaudeAISubscriber: () => isClaudeAISubscriber,
+    isConsumerSubscriber: () => true,
+    isCustomApiKeyApproved: () => true,
+    isEnterpriseSubscriber: () => false,
+    isMaxSubscriber: () => false,
+    isOverageProvisioningAllowed: () => false,
+    isProSubscriber: () => true,
+    isTeamPremiumSubscriber: () => false,
+    isTeamSubscriber: () => false,
+    isUsing3PServices: () => false,
+    prefetchApiKeyFromApiKeyHelperIfSafe: () => {},
+    prefetchAwsCredentialsAndBedRockInfoIfSafe: () => {},
+    prefetchGcpCredentialsIfSafe: () => {},
+    refreshAndGetAwsCredentials: async () => null,
+    refreshGcpCredentialsIfNeeded: async () => {},
+    removeApiKey: async () => {},
+    saveApiKey: async () => {},
+    saveOAuthTokensIfNeeded: () => ({ success: true }),
+    validateForceLoginOrg: async () => ({ valid: true }),
+  }))
+
+  mock.module('./getOauthProfile.js', () => ({
+    getOauthProfileFromOauthToken: profileSpy,
+  }))
+}
+
+async function importFreshOAuthClientModule() {
+  return import(`./client.ts?ts=${Date.now()}-${Math.random()}`)
+}
+
+afterEach(() => {
+  for (const key of Object.keys(originalEnv) as Array<keyof typeof originalEnv>) {
+    restoreEnv(key)
+  }
+  saveGlobalConfig(current => ({ ...current, oauthAccount: undefined }))
+  mock.restore()
+})
+
+test('OAuth account info population does not refresh when Claude.ai auth is inactive', async () => {
+  delete process.env.CLAUDE_CODE_ACCOUNT_UUID
+  delete process.env.CLAUDE_CODE_USER_EMAIL
+  delete process.env.CLAUDE_CODE_ORGANIZATION_UUID
+  saveGlobalConfig(current => ({ ...current, oauthAccount: undefined }))
+
+  const refreshSpy = mock(async () => false)
+  const profileSpy = mock(async () => null)
+  installPopulateAccountInfoMocks({
+    isClaudeAISubscriber: false,
+    refreshSpy,
+    profileSpy,
+  })
+
+  const { populateOAuthAccountInfoIfNeeded } = await importFreshOAuthClientModule()
+  mock.restore()
+
+  const populated = await populateOAuthAccountInfoIfNeeded()
+
+  expect(populated).toBe(false)
+  expect(refreshSpy).toHaveBeenCalledTimes(0)
+  expect(profileSpy).toHaveBeenCalledTimes(0)
+})
+
+test('OAuth account info population still refreshes active Claude.ai auth', async () => {
+  delete process.env.CLAUDE_CODE_ACCOUNT_UUID
+  delete process.env.CLAUDE_CODE_USER_EMAIL
+  delete process.env.CLAUDE_CODE_ORGANIZATION_UUID
+  saveGlobalConfig(current => ({ ...current, oauthAccount: undefined }))
+
+  const refreshSpy = mock(async () => true)
+  const profileSpy = mock(async () => ({
+    account: {
+      uuid: 'account-uuid',
+      email: 'user@example.com',
+      display_name: 'Test User',
+      created_at: '2026-01-01T00:00:00.000Z',
+    },
+    organization: {
+      uuid: 'org-uuid',
+      has_extra_usage_enabled: true,
+      billing_type: 'claude_pro',
+      subscription_created_at: '2026-01-02T00:00:00.000Z',
+    },
+  }))
+  installPopulateAccountInfoMocks({
+    isClaudeAISubscriber: true,
+    refreshSpy,
+    profileSpy,
+  })
+
+  const { populateOAuthAccountInfoIfNeeded } = await importFreshOAuthClientModule()
+  mock.restore()
+
+  const populated = await populateOAuthAccountInfoIfNeeded()
+
+  expect(populated).toBe(true)
+  expect(refreshSpy).toHaveBeenCalledTimes(1)
+  expect(profileSpy).toHaveBeenCalledWith('stored-claude-oauth-token')
+  expect(getGlobalConfig().oauthAccount).toEqual({
+    accountUuid: 'account-uuid',
+    emailAddress: 'user@example.com',
+    organizationUuid: 'org-uuid',
+    displayName: 'Test User',
+    hasExtraUsageEnabled: true,
+    billingType: 'claude_pro',
+    accountCreatedAt: '2026-01-01T00:00:00.000Z',
+    subscriptionCreatedAt: '2026-01-02T00:00:00.000Z',
+  })
+})

--- a/src/services/oauth/client.ts
+++ b/src/services/oauth/client.ts
@@ -458,6 +458,18 @@ function hasCompleteOAuthAccountInfo(): boolean {
   )
 }
 
+export function shouldRefreshOAuthAccountInfo({
+  hasCompleteAccountInfo,
+  isClaudeAiSubscriber,
+  hasProfileScope,
+}: {
+  hasCompleteAccountInfo: boolean
+  isClaudeAiSubscriber: boolean
+  hasProfileScope: boolean
+}): boolean {
+  return !hasCompleteAccountInfo && isClaudeAiSubscriber && hasProfileScope
+}
+
 export async function populateOAuthAccountInfoIfNeeded(): Promise<boolean> {
   // Check env vars first (synchronous, no network call needed).
   // SDK callers like Cowork can provide account info directly, which also
@@ -481,9 +493,11 @@ export async function populateOAuthAccountInfoIfNeeded(): Promise<boolean> {
   }
 
   if (
-    hasCompleteOAuthAccountInfo() ||
-    !isClaudeAISubscriber() ||
-    !hasProfileScope()
+    !shouldRefreshOAuthAccountInfo({
+      hasCompleteAccountInfo: hasCompleteOAuthAccountInfo(),
+      isClaudeAiSubscriber: isClaudeAISubscriber(),
+      hasProfileScope: hasProfileScope(),
+    })
   ) {
     return false
   }

--- a/src/services/oauth/client.ts
+++ b/src/services/oauth/client.ts
@@ -448,6 +448,16 @@ export async function getOrganizationUUID(): Promise<string | null> {
  * Populate the OAuth account info if it has not already been cached in config.
  * @returns Whether or not the oauth account info was populated.
  */
+function hasCompleteOAuthAccountInfo(): boolean {
+  const oauthAccount = getGlobalConfig().oauthAccount
+  return Boolean(
+    oauthAccount &&
+      oauthAccount.billingType !== undefined &&
+      oauthAccount.accountCreatedAt !== undefined &&
+      oauthAccount.subscriptionCreatedAt !== undefined,
+  )
+}
+
 export async function populateOAuthAccountInfoIfNeeded(): Promise<boolean> {
   // Check env vars first (synchronous, no network call needed).
   // SDK callers like Cowork can provide account info directly, which also
@@ -470,19 +480,18 @@ export async function populateOAuthAccountInfoIfNeeded(): Promise<boolean> {
     }
   }
 
-  // Wait for any in-flight token refresh to complete first, since
-  // refreshOAuthToken already fetches and stores profile info
-  await checkAndRefreshOAuthTokenIfNeeded()
-
-  const config = getGlobalConfig()
   if (
-    (config.oauthAccount &&
-      config.oauthAccount.billingType !== undefined &&
-      config.oauthAccount.accountCreatedAt !== undefined &&
-      config.oauthAccount.subscriptionCreatedAt !== undefined) ||
+    hasCompleteOAuthAccountInfo() ||
     !isClaudeAISubscriber() ||
     !hasProfileScope()
   ) {
+    return false
+  }
+
+  // Wait for any in-flight token refresh to complete first, since
+  // refreshOAuthToken already fetches and stores profile info.
+  await checkAndRefreshOAuthTokenIfNeeded()
+  if (hasCompleteOAuthAccountInfo()) {
     return false
   }
 


### PR DESCRIPTION
## Summary
- Gate Claude.ai OAuth refresh during API client creation to first-party Anthropic routing only.
- Avoid startup OAuth account-info refresh when Claude.ai auth is inactive, while preserving refresh/profile population for active Claude.ai auth.
- Add focused, full-suite-stable regressions for third-party provider routing, provider overrides, and startup account-info guard behavior.

## Root Cause
Third-party providers could still trigger stored Claude.ai OAuth refreshes before provider-specific routing or account-info guards ran. A stale Claude.ai refresh token then produced 400s against `https://platform.claude.com/v1/oauth/token` even when the active model provider was Gemini/OpenAI-compatible.

## CI Follow-up
The first test implementation used Bun module mocks around shared auth/provider modules. Those tests passed in isolation but were order-dependent in the full `bun test --max-concurrency=1` suite. The follow-up commit moves the guard decisions into small pure predicates and tests those directly, while production still calls the same predicates from the client/account-info paths.

## Validation
- `bun test src/services/api/client.test.ts src/services/api/client.oauthRouting.test.ts src/services/oauth/client.populateAccountInfo.test.ts --max-concurrency=1`
- `env -u CLAUDE_CODE_USE_OPENAI -u OPENAI_BASE_URL -u OPENAI_MODEL -u OPENAI_API_KEY -u CLAUDE_CODE_MAX_RETRIES -u CLAUDE_CODE_UNATTENDED_RETRY bun test --max-concurrency=1`
- `bun run build`
- `bun run smoke`
- Fresh Gemini-mode debug launch had no `oauth/token`, `AxiosError`, `populateOAuthAccountInfoIfNeeded`, or `[API:auth]` matches.