### PR TITLE
fix(openai-shim): strip `store` when baseUrl points at Gemini

### DIFF
--- a/src/services/api/openaiShim.test.ts
+++ b/src/services/api/openaiShim.test.ts
@@ -285,6 +285,79 @@ test('strips store from strict OpenAI-compatible responses providers', async () 
   expect(capturedBody?.store).toBeUndefined()
 })
 
+test('strips store when providerOverride routes chat_completions to the Gemini host', async () => {
+  let capturedBody: Record<string, unknown> | undefined
+
+  globalThis.fetch = (async (_input, init) => {
+    capturedBody = JSON.parse(String(init?.body)) as Record<string, unknown>
+    return new Response(
+      JSON.stringify({
+        id: 'chatcmpl-gemini',
+        choices: [{ message: { role: 'assistant', content: 'ok' } }],
+      }),
+      { headers: { 'Content-Type': 'application/json' } },
+    )
+  }) as FetchType
+
+  const client = createOpenAIShimClient({
+    defaultHeaders: {},
+    providerOverride: {
+      model: 'gemini-3.1-pro',
+      baseURL: 'https://generativelanguage.googleapis.com/v1beta/openai',
+      apiKey: 'gemini-key',
+    },
+  }) as OpenAIShimClient
+
+  await client.beta.messages.create({
+    model: 'gemini-3.1-pro',
+    messages: [{ role: 'user', content: 'hello' }],
+    max_tokens: 64,
+    stream: false,
+  })
+
+  expect(capturedBody?.store).toBeUndefined()
+})
+
+test('strips store when providerOverride routes responses API to the Gemini host', async () => {
+  process.env.OPENAI_API_FORMAT = 'responses'
+  let capturedBody: Record<string, unknown> | undefined
+
+  globalThis.fetch = (async (_input, init) => {
+    capturedBody = JSON.parse(String(init?.body)) as Record<string, unknown>
+    return new Response(
+      JSON.stringify({
+        id: 'resp-gemini',
+        output: [
+          {
+            type: 'message',
+            role: 'assistant',
+            content: [{ type: 'output_text', text: 'ok' }],
+          },
+        ],
+      }),
+      { headers: { 'Content-Type': 'application/json' } },
+    )
+  }) as FetchType
+
+  const client = createOpenAIShimClient({
+    defaultHeaders: {},
+    providerOverride: {
+      model: 'gemini-3.1-pro',
+      baseURL: 'https://generativelanguage.googleapis.com/v1beta/openai',
+      apiKey: 'gemini-key',
+    },
+  }) as OpenAIShimClient
+
+  await client.beta.messages.create({
+    model: 'gemini-3.1-pro',
+    messages: [{ role: 'user', content: 'hello' }],
+    max_tokens: 64,
+    stream: false,
+  })
+
+  expect(capturedBody?.store).toBeUndefined()
+})
+
 test('uses custom OpenAI-compatible auth header value when configured', async () => {
   process.env.OPENAI_API_KEY = 'generic-key'
   process.env.OPENAI_AUTH_HEADER = 'api-key'

--- a/src/services/api/openaiShim.ts
+++ b/src/services/api/openaiShim.ts
@@ -1594,8 +1594,17 @@ class OpenAIShimMessages {
     // Moonshot direct API, Kimi Code's OpenAI-compatible coding endpoint,
     // DeepSeek, and Z.AI have not published support for the parameter either;
     // strip it preemptively to avoid the same class of error on strict-parse
-    // providers.
-    if (isMistral || isGeminiMode() || isMoonshot || isDeepSeek || isZai) {
+    // providers. Detect Gemini from request.baseUrl as well — providerOverride
+    // routes (e.g. ~/.claude.json primaryProvider: google) reach the Gemini
+    // host without setting OPENAI_BASE_URL / CLAUDE_CODE_USE_GEMINI.
+    if (
+      isMistral ||
+      isGeminiMode() ||
+      hasGeminiApiHost(request.baseUrl) ||
+      isMoonshot ||
+      isDeepSeek ||
+      isZai
+    ) {
       delete body.store
     }
 
@@ -1677,7 +1686,14 @@ class OpenAIShimMessages {
         store: false,
       }
 
-      if (isMistral || isGeminiMode() || isMoonshot || isDeepSeek || isZai) {
+      if (
+        isMistral ||
+        isGeminiMode() ||
+        hasGeminiApiHost(request.baseUrl) ||
+        isMoonshot ||
+        isDeepSeek ||
+        isZai
+      ) {
         delete responsesBody.store
       }
 


### PR DESCRIPTION
## Summary

- `isGeminiMode()` only consulted `CLAUDE_CODE_USE_GEMINI` and `process.env.OPENAI_BASE_URL`, so any flow that reaches `generativelanguage.googleapis.com` via `providerOverride` (e.g. `primaryProvider: google` in `~/.claude.json`) kept `store: false` on the payload and Gemini rejected it with `400 Invalid JSON payload received. Unknown name "store": Cannot find field.`
- Added `hasGeminiApiHost(request.baseUrl)` to the strip-`store` predicate for both `chat_completions` and the `responses` body so detection mirrors how Moonshot / DeepSeek / Z.AI / Mistral are already detected (by `request.baseUrl`, not just by env).

## Impact

- user-facing impact: Gemini users routed through `providerOverride` no longer hit the 400 regression on every request. Existing env-driven Gemini paths (`CLAUDE_CODE_USE_GEMINI=1`, `OPENAI_BASE_URL=https://generativelanguage.googleapis.com/...`) are unchanged.
- developer/maintainer impact: predicate is consistent with other strict-schema providers; new constant or helper not introduced.

## Testing

- [x] `bun run build`
- [x] `bun run smoke`
- [x] focused tests: `bun test src/services/api/openaiShim.test.ts` (75 pass; adds two regression tests covering the chat_completions and responses transports under `providerOverride`)

## Notes

- provider/model path tested: OpenAI shim chat_completions + responses against `generativelanguage.googleapis.com/v1beta/openai` via `providerOverride`. Mistral / DeepSeek / Z.AI / Moonshot strip behavior untouched.
- screenshots attached (if UI changed): n/a
- follow-up work or known limitations: `isGeminiMode()` itself is left alone — broadening it would change the Gemini auth/base-url resolution path, which is out of scope for this 400 fix.

Fixes #664