### PR TITLE
Hotfix: Store provider profiles outside working directories

### DIFF
--- a/PLAYBOOK.md
+++ b/PLAYBOOK.md
@@ -260,7 +260,7 @@ bun run profile:init -- --provider ollama --goal coding
 
 - Run `doctor:runtime` before debugging provider issues.
 - Prefer `dev:profile` over manual env edits.
-- Keep `.openclaude-profile.json` local (already gitignored).
+- Keep any legacy workspace `.openclaude-profile.json` local; new provider saves use the user config directory.
 - Use `doctor:report` before asking for help so you have a reproducible snapshot.
 
 ## 10. Quick Recovery Checklist

--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ Advanced and source-build guides:
 - **Streaming responses**: Real-time token output and tool progress
 - **Tool calling**: Multi-step tool loops with model calls, tool execution, and follow-up responses
 - **Images**: URL and base64 image inputs for providers that support vision
-- **Provider profiles**: Guided setup plus saved `.openclaude-profile.json` support
+- **Provider profiles**: Guided setup plus saved user-level provider profile support
 - **Local and remote model backends**: Cloud APIs, local servers, and Apple Silicon local inference
 
 ## Provider Notes

--- a/docs/advanced-setup.md
+++ b/docs/advanced-setup.md
@@ -275,7 +275,7 @@ bun run profile:init -- --provider atomic-chat
 # codex bootstrap with a fast model alias
 bun run profile:init -- --provider codex --model codexspark
 
-# launch using persisted profile (.openclaude-profile.json)
+# launch using persisted user-level provider profile
 bun run dev:profile
 
 # codex profile (uses CODEX_API_KEY or ~/.codex/auth.json)

--- a/src/utils/providerProfile.test.ts
+++ b/src/utils/providerProfile.test.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict'
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { existsSync, mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import test from 'node:test'
@@ -16,6 +16,8 @@ import {
   buildOpenAIProfileEnv,
   clearPersistedCodexOAuthProfile,
   createProfileFile,
+  deleteProfileFile,
+  getDefaultProfileFilePath,
   isPersistedCodexOAuthProfile,
   maskSecretForDisplay,
   loadProfileFile,
@@ -585,6 +587,150 @@ test('saveProfileFile writes a profile that loadProfileFile can read back', () =
   }
 })
 
+test('saveProfileFile defaults to user config instead of the working directory', () => {
+  const cwd = mkdtempSync(join(tmpdir(), 'openclaude-workspace-profile-'))
+  const configRoot = mkdtempSync(join(tmpdir(), 'openclaude-config-profile-'))
+  const configDir = join(configRoot, 'config')
+  const previousConfigDir = process.env.CLAUDE_CONFIG_DIR
+  const previousCwd = process.cwd()
+
+  try {
+    process.env.CLAUDE_CONFIG_DIR = configDir
+    process.chdir(cwd)
+
+    const persisted = createProfileFile('openai', {
+      OPENAI_API_KEY: 'sk-test',
+      OPENAI_MODEL: 'gpt-4o',
+    })
+
+    const filePath = saveProfileFile(persisted)
+
+    assert.equal(filePath, join(configDir, PROFILE_FILE_NAME))
+    assert.equal(getDefaultProfileFilePath(), join(configDir, PROFILE_FILE_NAME))
+    assert.equal(existsSync(join(cwd, PROFILE_FILE_NAME)), false)
+    assert.equal(statSync(configDir).mode & 0o777, 0o700)
+    assert.deepEqual(loadProfileFile(), persisted)
+  } finally {
+    process.chdir(previousCwd)
+    if (previousConfigDir === undefined) {
+      delete process.env.CLAUDE_CONFIG_DIR
+    } else {
+      process.env.CLAUDE_CONFIG_DIR = previousConfigDir
+    }
+    rmSync(cwd, { recursive: true, force: true })
+    rmSync(configRoot, { recursive: true, force: true })
+  }
+})
+
+test('loadProfileFile keeps project-local files as a legacy fallback', () => {
+  const cwd = mkdtempSync(join(tmpdir(), 'openclaude-legacy-profile-'))
+  const configDir = mkdtempSync(join(tmpdir(), 'openclaude-empty-config-profile-'))
+  const previousConfigDir = process.env.CLAUDE_CONFIG_DIR
+  const previousCwd = process.cwd()
+
+  try {
+    process.env.CLAUDE_CONFIG_DIR = configDir
+    process.chdir(cwd)
+
+    const legacyProfile = createProfileFile('gemini', {
+      GEMINI_API_KEY: 'gem-test',
+      GEMINI_MODEL: 'gemini-2.5-flash',
+    })
+    writeFileSync(
+      join(cwd, PROFILE_FILE_NAME),
+      JSON.stringify(legacyProfile, null, 2),
+      'utf8',
+    )
+
+    assert.deepEqual(loadProfileFile(), legacyProfile)
+  } finally {
+    process.chdir(previousCwd)
+    if (previousConfigDir === undefined) {
+      delete process.env.CLAUDE_CONFIG_DIR
+    } else {
+      process.env.CLAUDE_CONFIG_DIR = previousConfigDir
+    }
+    rmSync(cwd, { recursive: true, force: true })
+    rmSync(configDir, { recursive: true, force: true })
+  }
+})
+
+test('loadProfileFile does not fall back when user config profile is invalid', () => {
+  const cwd = mkdtempSync(join(tmpdir(), 'openclaude-invalid-profile-'))
+  const configDir = mkdtempSync(join(tmpdir(), 'openclaude-invalid-config-profile-'))
+  const previousConfigDir = process.env.CLAUDE_CONFIG_DIR
+  const previousCwd = process.cwd()
+
+  try {
+    process.env.CLAUDE_CONFIG_DIR = configDir
+    process.chdir(cwd)
+
+    const legacyProfile = createProfileFile('gemini', {
+      GEMINI_API_KEY: 'gem-test',
+      GEMINI_MODEL: 'gemini-2.5-flash',
+    })
+    writeFileSync(join(configDir, PROFILE_FILE_NAME), '{', 'utf8')
+    writeFileSync(
+      join(cwd, PROFILE_FILE_NAME),
+      JSON.stringify(legacyProfile, null, 2),
+      'utf8',
+    )
+
+    assert.equal(loadProfileFile(), null)
+  } finally {
+    process.chdir(previousCwd)
+    if (previousConfigDir === undefined) {
+      delete process.env.CLAUDE_CONFIG_DIR
+    } else {
+      process.env.CLAUDE_CONFIG_DIR = previousConfigDir
+    }
+    rmSync(cwd, { recursive: true, force: true })
+    rmSync(configDir, { recursive: true, force: true })
+  }
+})
+
+test('deleteProfileFile clears the default profile and legacy workspace fallback', () => {
+  const cwd = mkdtempSync(join(tmpdir(), 'openclaude-delete-profile-'))
+  const configDir = mkdtempSync(join(tmpdir(), 'openclaude-delete-config-profile-'))
+  const previousConfigDir = process.env.CLAUDE_CONFIG_DIR
+  const previousCwd = process.cwd()
+
+  try {
+    process.env.CLAUDE_CONFIG_DIR = configDir
+    process.chdir(cwd)
+
+    const configProfile = createProfileFile('openai', {
+      OPENAI_API_KEY: 'sk-test',
+    })
+    const legacyProfile = createProfileFile('ollama', {
+      OPENAI_BASE_URL: 'http://localhost:11434/v1',
+      OPENAI_MODEL: 'llama3.1:8b',
+    })
+
+    saveProfileFile(configProfile)
+    writeFileSync(
+      join(cwd, PROFILE_FILE_NAME),
+      JSON.stringify(legacyProfile, null, 2),
+      'utf8',
+    )
+
+    deleteProfileFile()
+
+    assert.equal(existsSync(join(configDir, PROFILE_FILE_NAME)), false)
+    assert.equal(existsSync(join(cwd, PROFILE_FILE_NAME)), false)
+    assert.equal(loadProfileFile(), null)
+  } finally {
+    process.chdir(previousCwd)
+    if (previousConfigDir === undefined) {
+      delete process.env.CLAUDE_CONFIG_DIR
+    } else {
+      process.env.CLAUDE_CONFIG_DIR = previousConfigDir
+    }
+    rmSync(cwd, { recursive: true, force: true })
+    rmSync(configDir, { recursive: true, force: true })
+  }
+})
+
 test('buildCodexProfileEnv tags OAuth-saved profiles so logout can remove them safely', () => {
   const env = buildCodexProfileEnv({
     model: 'codexplan',
@@ -653,6 +799,49 @@ test('clearPersistedCodexOAuthProfile removes only persisted Codex OAuth profile
     assert.deepEqual(loadProfileFile({ cwd }), existingCredentialProfile)
   } finally {
     rmSync(cwd, { recursive: true, force: true })
+  }
+})
+
+test('clearPersistedCodexOAuthProfile clears both default and legacy OAuth profiles', () => {
+  const cwd = mkdtempSync(join(tmpdir(), 'openclaude-clear-oauth-profile-'))
+  const configDir = mkdtempSync(join(tmpdir(), 'openclaude-clear-oauth-config-'))
+  const previousConfigDir = process.env.CLAUDE_CONFIG_DIR
+  const previousCwd = process.cwd()
+
+  try {
+    process.env.CLAUDE_CONFIG_DIR = configDir
+    process.chdir(cwd)
+
+    const oauthProfile = createProfileFile('codex', {
+      OPENAI_MODEL: 'codexplan',
+      OPENAI_BASE_URL: DEFAULT_CODEX_BASE_URL,
+      CHATGPT_ACCOUNT_ID: 'acct_oauth',
+      CODEX_CREDENTIAL_SOURCE: 'oauth',
+    })
+
+    saveProfileFile(oauthProfile)
+    writeFileSync(
+      join(cwd, PROFILE_FILE_NAME),
+      JSON.stringify(oauthProfile, null, 2),
+      'utf8',
+    )
+
+    assert.equal(
+      clearPersistedCodexOAuthProfile(),
+      join(configDir, PROFILE_FILE_NAME),
+    )
+    assert.equal(existsSync(join(configDir, PROFILE_FILE_NAME)), false)
+    assert.equal(existsSync(join(cwd, PROFILE_FILE_NAME)), false)
+    assert.equal(loadProfileFile(), null)
+  } finally {
+    process.chdir(previousCwd)
+    if (previousConfigDir === undefined) {
+      delete process.env.CLAUDE_CONFIG_DIR
+    } else {
+      process.env.CLAUDE_CONFIG_DIR = previousConfigDir
+    }
+    rmSync(cwd, { recursive: true, force: true })
+    rmSync(configDir, { recursive: true, force: true })
   }
 })
 

--- a/src/utils/providerProfile.ts
+++ b/src/utils/providerProfile.ts
@@ -1,5 +1,5 @@
-import { existsSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
-import { resolve } from 'node:path'
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
 import {
   DEFAULT_CODEX_BASE_URL,
   DEFAULT_OPENAI_BASE_URL,
@@ -18,6 +18,7 @@ import { readGeminiAccessToken } from './geminiCredentials.js'
 import { getOllamaChatBaseUrl } from './providerDiscovery.js'
 import { getPrimaryModel } from './providerModels.js'
 import { getProviderValidationError } from './providerValidation.js'
+import { getErrnoCode } from './errors.js'
 import {
   getRouteDefaultBaseUrl,
   getRouteDefaultModel,
@@ -35,7 +36,7 @@ export {
   sanitizeApiKey,
   sanitizeProviderConfigValue,
 } from './providerSecrets.js'
-import { isEnvTruthy } from './envUtils.js'
+import { getClaudeConfigHomeDir, isEnvTruthy } from './envUtils.js'
 
 export const PROFILE_FILE_NAME = '.openclaude-profile.json'
 export const DEFAULT_GEMINI_BASE_URL =
@@ -194,12 +195,82 @@ type ProfileFileLocation = {
   filePath?: string
 }
 
+export function getDefaultProfileFilePath(): string {
+  return join(getClaudeConfigHomeDir(), PROFILE_FILE_NAME)
+}
+
+function resolveLegacyProfileFilePath(cwd = process.cwd()): string {
+  return resolve(cwd, PROFILE_FILE_NAME)
+}
+
 function resolveProfileFilePath(options?: ProfileFileLocation): string {
   if (options?.filePath) {
     return options.filePath
   }
 
-  return resolve(options?.cwd ?? process.cwd(), PROFILE_FILE_NAME)
+  if (options?.cwd) {
+    return resolveLegacyProfileFilePath(options.cwd)
+  }
+
+  return getDefaultProfileFilePath()
+}
+
+function resolveProfileFileReadPaths(options?: ProfileFileLocation): string[] {
+  const primary = resolveProfileFilePath(options)
+  if (options?.filePath || options?.cwd) {
+    return [primary]
+  }
+
+  if (existsSync(primary)) {
+    return [primary]
+  }
+
+  const legacy = resolveLegacyProfileFilePath()
+  return legacy === primary ? [primary] : [primary, legacy]
+}
+
+function resolveProfileFileCleanupPaths(options?: ProfileFileLocation): string[] {
+  const primary = resolveProfileFilePath(options)
+  if (options?.filePath || options?.cwd) {
+    return [primary]
+  }
+
+  const legacy = resolveLegacyProfileFilePath()
+  return legacy === primary ? [primary] : [primary, legacy]
+}
+
+function ensureProfileDirectory(filePath: string): void {
+  try {
+    mkdirSync(dirname(filePath), { recursive: true, mode: 0o700 })
+  } catch (error) {
+    if (getErrnoCode(error) !== 'EEXIST') {
+      throw error
+    }
+  }
+}
+
+function readProfileFile(filePath: string): ProfileFile | null {
+  if (!existsSync(filePath)) {
+    return null
+  }
+
+  try {
+    const parsed = JSON.parse(readFileSync(filePath, 'utf8')) as Partial<ProfileFile>
+    if (!isProviderProfile(parsed.profile) || !parsed.env || typeof parsed.env !== 'object') {
+      return null
+    }
+
+    return {
+      profile: parsed.profile,
+      env: parsed.env,
+      createdAt:
+        typeof parsed.createdAt === 'string'
+          ? parsed.createdAt
+          : new Date().toISOString(),
+    }
+  } catch {
+    return null
+  }
 }
 
 function normalizeProfileModel(
@@ -743,37 +814,28 @@ export function isPersistedCodexOAuthProfile(
 export function clearPersistedCodexOAuthProfile(
   options?: ProfileFileLocation,
 ): string | null {
-  const persisted = loadProfileFile(options)
-  if (!isPersistedCodexOAuthProfile(persisted)) {
-    return null
+  let removedPath: string | null = null
+
+  for (const filePath of resolveProfileFileCleanupPaths(options)) {
+    const persisted = readProfileFile(filePath)
+    if (isPersistedCodexOAuthProfile(persisted)) {
+      rmSync(filePath, { force: true })
+      removedPath ??= filePath
+    }
   }
 
-  return deleteProfileFile(options)
+  return removedPath
 }
 
 export function loadProfileFile(options?: ProfileFileLocation): ProfileFile | null {
-  const filePath = resolveProfileFilePath(options)
-  if (!existsSync(filePath)) {
-    return null
+  for (const filePath of resolveProfileFileReadPaths(options)) {
+    const profile = readProfileFile(filePath)
+    if (profile) {
+      return profile
+    }
   }
 
-  try {
-    const parsed = JSON.parse(readFileSync(filePath, 'utf8')) as Partial<ProfileFile>
-    if (!isProviderProfile(parsed.profile) || !parsed.env || typeof parsed.env !== 'object') {
-      return null
-    }
-
-    return {
-      profile: parsed.profile,
-      env: parsed.env,
-      createdAt:
-        typeof parsed.createdAt === 'string'
-          ? parsed.createdAt
-          : new Date().toISOString(),
-    }
-  } catch {
-    return null
-  }
+  return null
 }
 
 export function saveProfileFile(
@@ -781,6 +843,7 @@ export function saveProfileFile(
   options?: ProfileFileLocation,
 ): string {
   const filePath = resolveProfileFilePath(options)
+  ensureProfileDirectory(filePath)
   writeFileSync(filePath, JSON.stringify(profileFile, null, 2), {
     encoding: 'utf8',
     mode: 0o600,
@@ -791,6 +854,12 @@ export function saveProfileFile(
 export function deleteProfileFile(options?: ProfileFileLocation): string {
   const filePath = resolveProfileFilePath(options)
   rmSync(filePath, { force: true })
+  if (!options?.filePath && !options?.cwd) {
+    const legacyPath = resolveLegacyProfileFilePath()
+    if (legacyPath !== filePath) {
+      rmSync(legacyPath, { force: true })
+    }
+  }
   return filePath
 }
 
@@ -1259,7 +1328,7 @@ export async function buildStartupEnvFromProfile(options?: {
 
   const profileManagedEnv = processEnv.CLAUDE_CODE_PROVIDER_PROFILE_ENV_APPLIED === '1'
 
-  // The legacy single-profile file (~/.openclaude-profile.json) is a
+  // The single-profile file in the user config directory is a
   // first-run / fallback mechanism. The newer plural provider-profile
   // system (`/provider` presets + activeProviderProfileId in config) is
   // applied earlier in the bootstrap via applyActiveProviderProfileFromConfig

--- a/src/utils/providerProfiles.test.ts
+++ b/src/utils/providerProfiles.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, readFileSync, rmSync } from 'node:fs'
+import { existsSync, mkdtempSync, readFileSync, rmSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
@@ -16,6 +16,7 @@ const originalCwd = process.cwd()
 const RESTORED_KEYS = [
   'CLAUDE_CODE_PROVIDER_PROFILE_ENV_APPLIED',
   'CLAUDE_CODE_PROVIDER_PROFILE_ENV_APPLIED_ID',
+  'CLAUDE_CONFIG_DIR',
   'CLAUDE_CODE_USE_OPENAI',
   'CLAUDE_CODE_USE_GEMINI',
   'CLAUDE_CODE_USE_MISTRAL',
@@ -1051,7 +1052,9 @@ describe('setActiveProviderProfile', () => {
 
   test('persists no-key openai-compatible profiles for restart fallback', async () => {
     const tempDir = mkdtempSync(join(tmpdir(), 'openclaude-provider-'))
+    const configDir = mkdtempSync(join(tmpdir(), 'openclaude-provider-config-'))
     process.chdir(tempDir)
+    process.env.CLAUDE_CONFIG_DIR = configDir
     process.env.OPENAI_API_KEY = 'sk-shell-should-not-persist'
 
     try {
@@ -1073,10 +1076,11 @@ describe('setActiveProviderProfile', () => {
 
       const result = setActiveProviderProfile('ollama_prof')
       const persisted = JSON.parse(
-        readFileSync(join(tempDir, '.openclaude-profile.json'), 'utf8'),
+        readFileSync(join(configDir, '.openclaude-profile.json'), 'utf8'),
       )
 
       expect(result?.id).toBe('ollama_prof')
+      expect(existsSync(join(tempDir, '.openclaude-profile.json'))).toBe(false)
       expect(persisted.profile).toBe('openai')
       expect(persisted.env).toEqual({
         OPENAI_BASE_URL: 'http://localhost:11434/v1',
@@ -1085,12 +1089,15 @@ describe('setActiveProviderProfile', () => {
     } finally {
       process.chdir(originalCwd)
       rmSync(tempDir, { recursive: true, force: true })
+      rmSync(configDir, { recursive: true, force: true })
     }
   })
 
   test('persists primary model for keyed openai-compatible multi-model profiles', async () => {
     const tempDir = mkdtempSync(join(tmpdir(), 'openclaude-provider-'))
+    const configDir = mkdtempSync(join(tmpdir(), 'openclaude-provider-config-'))
     process.chdir(tempDir)
+    process.env.CLAUDE_CONFIG_DIR = configDir
 
     try {
       const { setActiveProviderProfile } =
@@ -1112,10 +1119,11 @@ describe('setActiveProviderProfile', () => {
 
       const result = setActiveProviderProfile('deepseek_prof')
       const persisted = JSON.parse(
-        readFileSync(join(tempDir, '.openclaude-profile.json'), 'utf8'),
+        readFileSync(join(configDir, '.openclaude-profile.json'), 'utf8'),
       )
 
       expect(result?.id).toBe('deepseek_prof')
+      expect(existsSync(join(tempDir, '.openclaude-profile.json'))).toBe(false)
       expect(persisted.profile).toBe('openai')
       expect(persisted.env).toEqual({
         OPENAI_BASE_URL: 'https://api.deepseek.com/v1',
@@ -1125,12 +1133,15 @@ describe('setActiveProviderProfile', () => {
     } finally {
       process.chdir(originalCwd)
       rmSync(tempDir, { recursive: true, force: true })
+      rmSync(configDir, { recursive: true, force: true })
     }
   })
 
   test('persists descriptor-backed direct vendors using a legacy-compatible openai startup profile', async () => {
     const tempDir = mkdtempSync(join(tmpdir(), 'openclaude-provider-'))
+    const configDir = mkdtempSync(join(tmpdir(), 'openclaude-provider-config-'))
     process.chdir(tempDir)
+    process.env.CLAUDE_CONFIG_DIR = configDir
 
     try {
       const { setActiveProviderProfile } =
@@ -1151,10 +1162,11 @@ describe('setActiveProviderProfile', () => {
 
       const result = setActiveProviderProfile('deepseek_vendor_prof')
       const persisted = JSON.parse(
-        readFileSync(join(tempDir, '.openclaude-profile.json'), 'utf8'),
+        readFileSync(join(configDir, '.openclaude-profile.json'), 'utf8'),
       )
 
       expect(result?.id).toBe('deepseek_vendor_prof')
+      expect(existsSync(join(tempDir, '.openclaude-profile.json'))).toBe(false)
       expect(persisted.profile).toBe('openai')
       expect(persisted.env).toEqual({
         OPENAI_BASE_URL: 'https://api.deepseek.com/v1',
@@ -1164,12 +1176,15 @@ describe('setActiveProviderProfile', () => {
     } finally {
       process.chdir(originalCwd)
       rmSync(tempDir, { recursive: true, force: true })
+      rmSync(configDir, { recursive: true, force: true })
     }
   })
 
   test('persists bedrock profiles using a dedicated startup profile kind', async () => {
     const tempDir = mkdtempSync(join(tmpdir(), 'openclaude-provider-'))
+    const configDir = mkdtempSync(join(tmpdir(), 'openclaude-provider-config-'))
     process.chdir(tempDir)
+    process.env.CLAUDE_CONFIG_DIR = configDir
 
     try {
       const { setActiveProviderProfile } =
@@ -1189,10 +1204,11 @@ describe('setActiveProviderProfile', () => {
 
       const result = setActiveProviderProfile('bedrock_prof')
       const persisted = JSON.parse(
-        readFileSync(join(tempDir, '.openclaude-profile.json'), 'utf8'),
+        readFileSync(join(configDir, '.openclaude-profile.json'), 'utf8'),
       )
 
       expect(result?.id).toBe('bedrock_prof')
+      expect(existsSync(join(tempDir, '.openclaude-profile.json'))).toBe(false)
       expect(persisted.profile).toBe('bedrock')
       expect(persisted.env).toEqual({
         ANTHROPIC_MODEL: 'claude-sonnet-4-6',
@@ -1201,12 +1217,15 @@ describe('setActiveProviderProfile', () => {
     } finally {
       process.chdir(originalCwd)
       rmSync(tempDir, { recursive: true, force: true })
+      rmSync(configDir, { recursive: true, force: true })
     }
   })
 
   test('persists anthropic profiles using a dedicated anthropic startup profile', async () => {
     const tempDir = mkdtempSync(join(tmpdir(), 'openclaude-provider-'))
+    const configDir = mkdtempSync(join(tmpdir(), 'openclaude-provider-config-'))
     process.chdir(tempDir)
+    process.env.CLAUDE_CONFIG_DIR = configDir
 
     try {
       const { setActiveProviderProfile } =
@@ -1227,10 +1246,11 @@ describe('setActiveProviderProfile', () => {
 
       const result = setActiveProviderProfile('anthro_persisted_prof')
       const persisted = JSON.parse(
-        readFileSync(join(tempDir, '.openclaude-profile.json'), 'utf8'),
+        readFileSync(join(configDir, '.openclaude-profile.json'), 'utf8'),
       )
 
       expect(result?.id).toBe('anthro_persisted_prof')
+      expect(existsSync(join(tempDir, '.openclaude-profile.json'))).toBe(false)
       expect(persisted.profile).toBe('anthropic')
       expect(persisted.env).toEqual({
         ANTHROPIC_BASE_URL: 'https://api.anthropic.com',
@@ -1240,6 +1260,7 @@ describe('setActiveProviderProfile', () => {
     } finally {
       process.chdir(originalCwd)
       rmSync(tempDir, { recursive: true, force: true })
+      rmSync(configDir, { recursive: true, force: true })
     }
   })
 


### PR DESCRIPTION

## Summary

Fixes #968.

This PR moves persisted provider profile writes out of the current working directory and into the OpenClaude user config directory. Provider setup flows such as `/provider`, `bun run profile:init`, `bun run profile:auto`, and the convenience scripts all share `saveProfileFile()`, so changing the centralized writer prevents those flows from dropping `.openclaude-profile.json` into arbitrary project checkouts by default.

## Security impact

Previously, provider setup could create `.openclaude-profile.json` under `process.cwd()`. That file may include provider configuration and secret-bearing values such as API keys or auth-related tokens. In another repository, the file may not be ignored, which creates a realistic accidental disclosure path through commits, archives, support bundles, or uploaded workspaces.

The fix keeps default saves in the user config home, preserves `0600` permissions, and creates the parent directory as needed. Existing project-local `.openclaude-profile.json` files still load as a legacy fallback so existing users do not lose their current setup. Clearing the saved profile also removes both the user-level profile and any legacy workspace fallback so stale local state does not silently re-activate.

## Compatibility

- Explicit `filePath` and `cwd` options still work for callers/tests that intentionally need a specific location.
- Startup continues to read the user-level profile first, then falls back to a legacy workspace profile when no user-level profile exists.
- Docs now describe user-level persisted provider profiles instead of project-local profile files.

## Validation

- `git diff --check`
- `bun run test:provider-recommendation` - 62 passing tests

Note: `bun run typecheck` is still blocked by existing repo-wide TypeScript issues unrelated to this change, including missing generated SDK modules/types, `MACRO` globals, and test-runner globals.
