### PR TITLE
Fix user agent loading from OpenClaude config dirs

### DIFF
--- a/src/components/agents/agentFileUtils.ts
+++ b/src/components/agents/agentFileUtils.ts
@@ -1,5 +1,5 @@
 import { mkdir, open, unlink } from 'fs/promises'
-import { join } from 'path'
+import { join, relative } from 'path'
 import type { SettingSource } from 'src/utils/settings/constants.js'
 import { getManagedFilePath } from 'src/utils/settings/managedPath.js'
 import type { AgentMemoryScope } from '../../tools/AgentTool/agentMemory.js'
@@ -109,7 +109,7 @@ export function getActualAgentFilePath(agent: AgentDefinition): string {
     throw new Error('Cannot get file path for plugin agents')
   }
 
-  const dirPath = getAgentDirectoryPath(agent.source)
+  const dirPath = agent.baseDir || getAgentDirectoryPath(agent.source)
   const filename = agent.filename || agent.agentType
   return join(dirPath, `${filename}.md`)
 }
@@ -143,7 +143,11 @@ export function getActualRelativeAgentFilePath(agent: AgentDefinition): string {
     return 'CLI argument'
   }
 
-  const dirPath = getRelativeAgentDirectoryPath(agent.source)
+  const dirPath =
+    agent.baseDir &&
+    (agent.source === 'projectSettings' || agent.source === 'localSettings')
+      ? join('.', relative(getCwd(), agent.baseDir))
+      : getRelativeAgentDirectoryPath(agent.source)
   const filename = agent.filename || agent.agentType
   return join(dirPath, `${filename}.md`)
 }

--- a/src/components/agents/agentFileUtils.ts
+++ b/src/components/agents/agentFileUtils.ts
@@ -66,11 +66,7 @@ function getAgentDirectoryPath(location: SettingSource): string {
     case 'projectSettings':
       return join(getCwd(), AGENT_PATHS.FOLDER_NAME, AGENT_PATHS.AGENTS_DIR)
     case 'policySettings':
-      return join(
-        getManagedFilePath(),
-        AGENT_PATHS.FOLDER_NAME,
-        AGENT_PATHS.AGENTS_DIR,
-      )
+      return join(getManagedFilePath(), '.claude', AGENT_PATHS.AGENTS_DIR)
     case 'localSettings':
       return join(getCwd(), AGENT_PATHS.FOLDER_NAME, AGENT_PATHS.AGENTS_DIR)
   }
@@ -145,7 +141,9 @@ export function getActualRelativeAgentFilePath(agent: AgentDefinition): string {
 
   const dirPath =
     agent.baseDir &&
-    (agent.source === 'projectSettings' || agent.source === 'localSettings')
+    (agent.source === 'projectSettings' ||
+      agent.source === 'localSettings' ||
+      agent.source === 'policySettings')
       ? join('.', relative(getCwd(), agent.baseDir))
       : getRelativeAgentDirectoryPath(agent.source)
   const filename = agent.filename || agent.agentType

--- a/src/components/agents/new-agent-creation/wizard-steps/LocationStep.tsx
+++ b/src/components/agents/new-agent-creation/wizard-steps/LocationStep.tsx
@@ -1,6 +1,8 @@
 import { c as _c } from "react-compiler-runtime";
+import { join } from 'path';
 import React, { type ReactNode } from 'react';
 import { Box } from '../../../../ink.js';
+import { getClaudeConfigHomeDir } from '../../../../utils/envUtils.js';
 import type { SettingSource } from '../../../../utils/settings/constants.js';
 import { ConfigurableShortcutHint } from '../../../ConfigurableShortcutHint.js';
 import { Select } from '../../../CustomSelect/select.js';
@@ -26,17 +28,10 @@ export function LocationStep() {
   } else {
     t0 = $[0];
   }
-  let t1;
-  if ($[1] === Symbol.for("react.memo_cache_sentinel")) {
-    t1 = [t0, {
-      label: "Personal (~/.openclaude/agents/)",
-      value: "userSettings" as SettingSource
-    }];
-    $[1] = t1;
-  } else {
-    t1 = $[1];
-  }
-  const locationOptions = t1;
+  const locationOptions = [t0, {
+    label: `Personal (${join(getClaudeConfigHomeDir(), 'agents')})`,
+    value: "userSettings" as SettingSource
+  }];
   let t2;
   if ($[2] === Symbol.for("react.memo_cache_sentinel")) {
     t2 = <Byline><KeyboardShortcutHint shortcut={"\u2191\u2193"} action="navigate" /><KeyboardShortcutHint shortcut="Enter" action="select" /><ConfigurableShortcutHint action="confirm:no" context="Confirmation" fallback="Esc" description="cancel" /></Byline>;

--- a/src/components/agents/new-agent-creation/wizard-steps/LocationStep.tsx
+++ b/src/components/agents/new-agent-creation/wizard-steps/LocationStep.tsx
@@ -19,7 +19,7 @@ export function LocationStep() {
   let t0;
   if ($[0] === Symbol.for("react.memo_cache_sentinel")) {
     t0 = {
-      label: "Project (.claude/agents/)",
+      label: "Project (.openclaude/agents/)",
       value: "projectSettings" as SettingSource
     };
     $[0] = t0;
@@ -29,7 +29,7 @@ export function LocationStep() {
   let t1;
   if ($[1] === Symbol.for("react.memo_cache_sentinel")) {
     t1 = [t0, {
-      label: "Personal (~/.claude/agents/)",
+      label: "Personal (~/.openclaude/agents/)",
       value: "userSettings" as SettingSource
     }];
     $[1] = t1;

--- a/src/components/agents/types.ts
+++ b/src/components/agents/types.ts
@@ -2,7 +2,7 @@ import type { SettingSource } from 'src/utils/settings/constants.js'
 import type { AgentDefinition } from '../../tools/AgentTool/loadAgentsDir.js'
 
 export const AGENT_PATHS = {
-  FOLDER_NAME: '.claude',
+  FOLDER_NAME: '.openclaude',
   AGENTS_DIR: 'agents',
 } as const
 

--- a/src/tools/AgentTool/loadAgentsDir.test.ts
+++ b/src/tools/AgentTool/loadAgentsDir.test.ts
@@ -1,0 +1,115 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import { mkdtemp, mkdir, rm, writeFile } from 'fs/promises'
+import { tmpdir } from 'os'
+import { dirname, join } from 'path'
+import {
+  clearAgentDefinitionsCache,
+  getAgentDefinitionsWithOverrides,
+} from './loadAgentsDir.js'
+import { loadMarkdownFilesForSubdir } from '../../utils/markdownConfigLoader.js'
+
+const originalEnv = {
+  CLAUDE_CONFIG_DIR: process.env.CLAUDE_CONFIG_DIR,
+  CLAUDE_CODE_SIMPLE: process.env.CLAUDE_CODE_SIMPLE,
+  CLAUDE_CODE_USE_NATIVE_FILE_SEARCH:
+    process.env.CLAUDE_CODE_USE_NATIVE_FILE_SEARCH,
+}
+
+let tempDir: string
+
+beforeEach(async () => {
+  tempDir = await mkdtemp(join(tmpdir(), 'openclaude-agents-test-'))
+  process.env.CLAUDE_CONFIG_DIR = join(tempDir, '.openclaude')
+  process.env.CLAUDE_CODE_USE_NATIVE_FILE_SEARCH = '1'
+  delete process.env.CLAUDE_CODE_SIMPLE
+  clearAgentDefinitionsCache()
+  loadMarkdownFilesForSubdir.cache.clear?.()
+})
+
+afterEach(async () => {
+  await rm(tempDir, { recursive: true, force: true })
+  restoreEnv('CLAUDE_CONFIG_DIR')
+  restoreEnv('CLAUDE_CODE_SIMPLE')
+  restoreEnv('CLAUDE_CODE_USE_NATIVE_FILE_SEARCH')
+  clearAgentDefinitionsCache()
+  loadMarkdownFilesForSubdir.cache.clear?.()
+})
+
+function restoreEnv(key: keyof typeof originalEnv): void {
+  const originalValue = originalEnv[key]
+  if (originalValue === undefined) {
+    delete process.env[key]
+  } else {
+    process.env[key] = originalValue
+  }
+}
+
+async function writeAgent(
+  filePath: string,
+  name: string,
+  prompt = `You are ${name}.`,
+): Promise<void> {
+  await mkdir(dirname(filePath), { recursive: true })
+  await writeFile(
+    filePath,
+    `---
+name: ${name}
+description: "Use for regression coverage"
+---
+
+${prompt}
+`,
+  )
+}
+
+describe('agent definition loading', () => {
+  test('loads user agents from the OpenClaude config dir in simple mode', async () => {
+    await writeAgent(
+      join(process.env.CLAUDE_CONFIG_DIR!, 'agents', 'user-agent.md'),
+      'user-agent',
+    )
+
+    process.env.CLAUDE_CODE_SIMPLE = '1'
+    clearAgentDefinitionsCache()
+    loadMarkdownFilesForSubdir.cache.clear?.()
+
+    const { activeAgents } = await getAgentDefinitionsWithOverrides(tempDir)
+
+    expect(activeAgents.some(agent => agent.agentType === 'user-agent')).toBe(
+      true,
+    )
+  })
+
+  test('loads project agents from .openclaude/agents', async () => {
+    const projectDir = join(tempDir, 'project')
+    await writeAgent(
+      join(projectDir, '.openclaude', 'agents', 'project-agent.md'),
+      'project-agent',
+    )
+
+    const { activeAgents } = await getAgentDefinitionsWithOverrides(projectDir)
+
+    expect(
+      activeAgents.some(agent => agent.agentType === 'project-agent'),
+    ).toBe(true)
+  })
+
+  test('prefers .openclaude project agents over legacy .claude agents', async () => {
+    const projectDir = join(tempDir, 'project')
+    await writeAgent(
+      join(projectDir, '.claude', 'agents', 'shared-agent.md'),
+      'shared-agent',
+      'legacy prompt',
+    )
+    await writeAgent(
+      join(projectDir, '.openclaude', 'agents', 'shared-agent.md'),
+      'shared-agent',
+      'openclaude prompt',
+    )
+
+    const { activeAgents } = await getAgentDefinitionsWithOverrides(projectDir)
+    const agent = activeAgents.find(agent => agent.agentType === 'shared-agent')
+
+    expect(agent?.getSystemPrompt()).toBe('openclaude prompt')
+  })
+})

--- a/src/tools/AgentTool/loadAgentsDir.ts
+++ b/src/tools/AgentTool/loadAgentsDir.ts
@@ -19,7 +19,6 @@ import {
   type EffortValue,
   parseEffortValue,
 } from '../../utils/effort.js'
-import { isEnvTruthy } from '../../utils/envUtils.js'
 import { parsePositiveIntFromFrontmatter } from '../../utils/frontmatterParser.js'
 import { lazySchema } from '../../utils/lazySchema.js'
 import { logError } from '../../utils/log.js'
@@ -295,15 +294,6 @@ async function initializeAgentMemorySnapshots(
 
 export const getAgentDefinitionsWithOverrides = memoize(
   async (cwd: string): Promise<AgentDefinitionsResult> => {
-    // Simple mode: skip custom agents, only return built-ins
-    if (isEnvTruthy(process.env.CLAUDE_CODE_SIMPLE)) {
-      const builtInAgents = getBuiltInAgents()
-      return {
-        activeAgents: builtInAgents,
-        allAgents: builtInAgents,
-      }
-    }
-
     try {
       const markdownFiles = await loadMarkdownFilesForSubdir('agents', cwd)
 

--- a/src/utils/markdownConfigLoader.ts
+++ b/src/utils/markdownConfigLoader.ts
@@ -253,7 +253,7 @@ export function getProjectDirsUpToHome(
     }
 
     for (const configDirName of PROJECT_CONFIG_DIR_NAMES) {
-      const claudeSubdir = join(current, configDirName, subdir)
+      const configSubdir = join(current, configDirName, subdir)
       // Filter to existing dirs. This is a perf filter (avoids spawning
       // ripgrep on non-existent dirs downstream) and the worktree fallback
       // in loadMarkdownFilesForSubdir relies on it. statSync + explicit error
@@ -261,8 +261,8 @@ export function getProjectDirsUpToHome(
       // than silently swallowing them. Downstream loadMarkdownFiles handles
       // the TOCTOU window (dir disappearing before read) gracefully.
       try {
-        statSync(claudeSubdir)
-        dirs.push(claudeSubdir)
+        statSync(configSubdir)
+        dirs.push(configSubdir)
       } catch (e: unknown) {
         if (!isFsInaccessible(e)) throw e
       }
@@ -332,9 +332,9 @@ export const loadMarkdownFilesForSubdir = memoize(
       )
       if (!worktreeHasSubdir) {
         for (const configDirName of PROJECT_CONFIG_DIR_NAMES) {
-          const mainClaudeSubdir = join(canonicalRoot, configDirName, subdir)
-          if (!projectDirs.includes(mainClaudeSubdir)) {
-            projectDirs.push(mainClaudeSubdir)
+          const mainConfigSubdir = join(canonicalRoot, configDirName, subdir)
+          if (!projectDirs.includes(mainConfigSubdir)) {
+            projectDirs.push(mainConfigSubdir)
           }
         }
       }

--- a/src/utils/markdownConfigLoader.ts
+++ b/src/utils/markdownConfigLoader.ts
@@ -37,6 +37,8 @@ export const CLAUDE_CONFIG_DIRECTORIES = [
 
 export type ClaudeConfigDirectory = (typeof CLAUDE_CONFIG_DIRECTORIES)[number]
 
+const PROJECT_CONFIG_DIR_NAMES = ['.claude', '.openclaude'] as const
+
 export type MarkdownFile = {
   filePath: string
   baseDir: string
@@ -250,18 +252,20 @@ export function getProjectDirsUpToHome(
       break
     }
 
-    const claudeSubdir = join(current, '.claude', subdir)
-    // Filter to existing dirs. This is a perf filter (avoids spawning
-    // ripgrep on non-existent dirs downstream) and the worktree fallback
-    // in loadMarkdownFilesForSubdir relies on it. statSync + explicit error
-    // handling instead of existsSync — re-throws unexpected errors rather
-    // than silently swallowing them. Downstream loadMarkdownFiles handles
-    // the TOCTOU window (dir disappearing before read) gracefully.
-    try {
-      statSync(claudeSubdir)
-      dirs.push(claudeSubdir)
-    } catch (e: unknown) {
-      if (!isFsInaccessible(e)) throw e
+    for (const configDirName of PROJECT_CONFIG_DIR_NAMES) {
+      const claudeSubdir = join(current, configDirName, subdir)
+      // Filter to existing dirs. This is a perf filter (avoids spawning
+      // ripgrep on non-existent dirs downstream) and the worktree fallback
+      // in loadMarkdownFilesForSubdir relies on it. statSync + explicit error
+      // handling instead of existsSync — re-throws unexpected errors rather
+      // than silently swallowing them. Downstream loadMarkdownFiles handles
+      // the TOCTOU window (dir disappearing before read) gracefully.
+      try {
+        statSync(claudeSubdir)
+        dirs.push(claudeSubdir)
+      } catch (e: unknown) {
+        if (!isFsInaccessible(e)) throw e
+      }
     }
 
     // Stop after processing the git root directory - this prevents commands from parent
@@ -320,16 +324,18 @@ export const loadMarkdownFilesForSubdir = memoize(
     const gitRoot = findGitRoot(cwd)
     const canonicalRoot = findCanonicalGitRoot(cwd)
     if (gitRoot && canonicalRoot && canonicalRoot !== gitRoot) {
-      const worktreeSubdir = normalizePathForComparison(
-        join(gitRoot, '.claude', subdir),
+      const worktreeSubdirs = PROJECT_CONFIG_DIR_NAMES.map(configDirName =>
+        normalizePathForComparison(join(gitRoot, configDirName, subdir)),
       )
-      const worktreeHasSubdir = projectDirs.some(
-        dir => normalizePathForComparison(dir) === worktreeSubdir,
+      const worktreeHasSubdir = projectDirs.some(dir =>
+        worktreeSubdirs.includes(normalizePathForComparison(dir)),
       )
       if (!worktreeHasSubdir) {
-        const mainClaudeSubdir = join(canonicalRoot, '.claude', subdir)
-        if (!projectDirs.includes(mainClaudeSubdir)) {
-          projectDirs.push(mainClaudeSubdir)
+        for (const configDirName of PROJECT_CONFIG_DIR_NAMES) {
+          const mainClaudeSubdir = join(canonicalRoot, configDirName, subdir)
+          if (!projectDirs.includes(mainClaudeSubdir)) {
+            projectDirs.push(mainClaudeSubdir)
+          }
         }
       }
     }


### PR DESCRIPTION
Fixes #970.

## Summary
- load custom agent definitions even when simple/bare mode is active
- discover project agents from `.openclaude/agents` while retaining legacy `.claude/agents` support
- update agent creation/display file paths to use `.openclaude/agents` and preserve loaded `baseDir` for existing agents
- add regression coverage for user agents, project agents, and `.openclaude` precedence

## Root Cause
`CLAUDE_CODE_SIMPLE` caused the agent definition loader to return built-in agents only. Some OpenClaude agent UI/discovery paths also still targeted legacy `.claude/agents`, so files under `~/.openclaude/agents` or project `.openclaude/agents` could be invisible after restart.

## Validation
- `bun test src/tools/AgentTool/loadAgentsDir.test.ts`
- attempted `bun run typecheck`, but the repository currently has unrelated baseline TypeScript failures and missing generated/internal modules.