### PR TITLE
fix(provider): apply Codex OAuth session switch correctly

### DIFF
--- a/src/components/ProviderManager.test.tsx
+++ b/src/components/ProviderManager.test.tsx
@@ -993,7 +993,7 @@ test('ProviderManager first-run Codex OAuth switches the current session after l
       model: 'codexplan',
       apiKey: '',
     }),
-    expect.objectContaining({ makeActive: true }),
+    expect.objectContaining({ makeActive: false }),
   )
   expect(applySavedProfileToCurrentSession).toHaveBeenCalled()
   expect(persistCredentials).toHaveBeenCalledWith({

--- a/src/components/ProviderManager.tsx
+++ b/src/components/ProviderManager.tsx
@@ -1748,7 +1748,7 @@ export function ProviderManager({ mode, onDone }: Props): React.ReactNode {
             )
             const saved = existing
               ? updateProviderProfile(existing.id, payload)
-              : addProviderProfile(payload, { makeActive: true })
+              : addProviderProfile(payload, { makeActive: false })
 
             if (!saved) {
               setErrorMessage(

--- a/src/utils/providerProfile.test.ts
+++ b/src/utils/providerProfile.test.ts
@@ -884,6 +884,7 @@ test('applySavedProfileToCurrentSession replaces empty active OpenAI key for Cod
     profileFile: profile('codex', {
       OPENAI_BASE_URL: DEFAULT_CODEX_BASE_URL,
       OPENAI_MODEL: 'codexplan',
+      CHATGPT_ACCOUNT_ID: 'acct_oauth',
       CODEX_CREDENTIAL_SOURCE: 'oauth',
     }),
     processEnv,
@@ -894,6 +895,7 @@ test('applySavedProfileToCurrentSession replaces empty active OpenAI key for Cod
   assert.equal(processEnv.OPENAI_BASE_URL, DEFAULT_CODEX_BASE_URL)
   assert.equal(processEnv.OPENAI_MODEL, 'codexplan')
   assert.equal(Object.hasOwn(processEnv, 'OPENAI_API_KEY'), false)
+  assert.equal(processEnv.CHATGPT_ACCOUNT_ID, 'acct_oauth')
   assert.equal(Object.hasOwn(processEnv, 'CODEX_API_KEY'), false)
 })
 

--- a/src/utils/providerProfile.test.ts
+++ b/src/utils/providerProfile.test.ts
@@ -632,7 +632,6 @@ test('clearPersistedCodexOAuthProfile removes only persisted Codex OAuth profile
       CODEX_CREDENTIAL_SOURCE: 'oauth',
     })
     saveProfileFile(oauthProfile, { cwd })
-
     assert.equal(isPersistedCodexOAuthProfile(loadProfileFile({ cwd })), true)
     assert.equal(
       clearPersistedCodexOAuthProfile({ cwd }),
@@ -868,6 +867,34 @@ test('applySavedProfileToCurrentSession can switch away from GitHub provider env
   assert.equal(processEnv.OPENAI_BASE_URL, 'http://localhost:11434/v1')
   assert.equal(processEnv.OPENAI_MODEL, 'llama3.1:8b')
   assert.equal(Object.hasOwn(processEnv, 'OPENAI_API_KEY'), false)
+})
+
+test('applySavedProfileToCurrentSession replaces empty active OpenAI key for Codex OAuth', async () => {
+  const { applySavedProfileToCurrentSession } = await importFreshProviderProfileModule()
+  const processEnv: NodeJS.ProcessEnv = {
+    CLAUDE_CODE_PROVIDER_PROFILE_ENV_APPLIED: '1',
+    CLAUDE_CODE_PROVIDER_PROFILE_ENV_APPLIED_ID: 'provider_codex_oauth',
+    CLAUDE_CODE_USE_OPENAI: '1',
+    OPENAI_BASE_URL: DEFAULT_CODEX_BASE_URL,
+    OPENAI_MODEL: 'codexplan',
+    OPENAI_API_KEY: '',
+  }
+
+  const error = await applySavedProfileToCurrentSession({
+    profileFile: profile('codex', {
+      OPENAI_BASE_URL: DEFAULT_CODEX_BASE_URL,
+      OPENAI_MODEL: 'codexplan',
+      CODEX_CREDENTIAL_SOURCE: 'oauth',
+    }),
+    processEnv,
+  })
+
+  assert.equal(error, null)
+  assert.equal(processEnv.CLAUDE_CODE_USE_OPENAI, '1')
+  assert.equal(processEnv.OPENAI_BASE_URL, DEFAULT_CODEX_BASE_URL)
+  assert.equal(processEnv.OPENAI_MODEL, 'codexplan')
+  assert.equal(Object.hasOwn(processEnv, 'OPENAI_API_KEY'), false)
+  assert.equal(Object.hasOwn(processEnv, 'CODEX_API_KEY'), false)
 })
 
 test('buildStartupEnvFromProfile preserves plural-profile env when the legacy file is stale', async () => {

--- a/src/utils/providerProfile.ts
+++ b/src/utils/providerProfile.ts
@@ -906,7 +906,9 @@ export async function buildLaunchEnv(options: {
 
     for (const [envKey, provider] of explicitProfileOverrides) {
       if (isEnvTruthy(processEnv[envKey])) {
-        options.profile = provider
+        if (!(options.profile === 'codex' && provider === 'openai')) {
+          options.profile = provider
+        }
         break
       }
     }
@@ -1315,17 +1317,30 @@ export async function applySavedProfileToCurrentSession(options: {
     processEnv.CLAUDE_CODE_PROVIDER_PROFILE_ENV_APPLIED === '1'
 
   if (options.profileFile.profile === 'codex' && hasExplicitSelection) {
+    const isCodexOAuthProfile =
+      options.profileFile.env.CODEX_CREDENTIAL_SOURCE === 'oauth'
+    const buildEnvSource = isCodexOAuthProfile
+      ? { ...processEnv }
+      : processEnv
+    if (isCodexOAuthProfile) {
+      delete buildEnvSource.CODEX_API_KEY
+      delete buildEnvSource.CODEX_ACCOUNT_ID
+      delete buildEnvSource.CHATGPT_ACCOUNT_ID
+    }
     const explicitEnv = await buildLaunchEnv({
       profile: options.profileFile.profile,
       persisted: options.profileFile,
       goal: normalizeRecommendationGoal(processEnv.OPENCLAUDE_PROFILE_GOAL),
-      processEnv,
+      processEnv: buildEnvSource,
       getOllamaChatBaseUrl,
       readGeminiAccessToken,
     })
     delete explicitEnv.CLAUDE_CODE_PROVIDER_PROFILE_ENV_APPLIED
     delete explicitEnv.CLAUDE_CODE_PROVIDER_PROFILE_ENV_APPLIED_ID
-    const validationError = await getProviderValidationError(explicitEnv)
+    const validationEnv = isCodexOAuthProfile
+      ? { ...explicitEnv, CODEX_API_KEY: 'codex-oauth-token-for-validation' }
+      : explicitEnv
+    const validationError = await getProviderValidationError(validationEnv)
 
     if (profileManagedEnv) {
       delete processEnv.CLAUDE_CODE_PROVIDER_PROFILE_ENV_APPLIED
@@ -1369,7 +1384,10 @@ export async function applySavedProfileToCurrentSession(options: {
     getOllamaChatBaseUrl,
     readGeminiAccessToken,
   })
-  const validationError = await getProviderValidationError(nextEnv)
+  const validationEnv = isCodexOAuthProfile
+    ? { ...nextEnv, CODEX_API_KEY: 'codex-oauth-token-for-validation' }
+    : nextEnv
+  const validationError = await getProviderValidationError(validationEnv)
   if (validationError) {
     return validationError
   }

--- a/src/utils/providerProfile.ts
+++ b/src/utils/providerProfile.ts
@@ -1147,16 +1147,21 @@ export async function buildLaunchEnv(options: {
   }
 
   if (options.profile === 'codex') {
-    const codexKey =
-      sanitizeApiKey(processEnv.CODEX_API_KEY) ||
-      sanitizeApiKey(persistedEnv.CODEX_API_KEY)
-    const liveCodexCredentials = resolveCodexApiCredentials(processEnv)
-    const codexAccountId =
-      processEnv.CHATGPT_ACCOUNT_ID ||
-      processEnv.CODEX_ACCOUNT_ID ||
-      liveCodexCredentials.accountId ||
-      persistedEnv.CHATGPT_ACCOUNT_ID ||
-      persistedEnv.CODEX_ACCOUNT_ID
+    const isCodexOAuthProfile = persistedEnv.CODEX_CREDENTIAL_SOURCE === 'oauth'
+    const codexKey = isCodexOAuthProfile
+      ? undefined
+      : sanitizeApiKey(processEnv.CODEX_API_KEY) ||
+        sanitizeApiKey(persistedEnv.CODEX_API_KEY)
+    const liveCodexCredentials = isCodexOAuthProfile
+      ? undefined
+      : resolveCodexApiCredentials(processEnv)
+    const codexAccountId = isCodexOAuthProfile
+      ? persistedEnv.CHATGPT_ACCOUNT_ID || persistedEnv.CODEX_ACCOUNT_ID
+      : processEnv.CHATGPT_ACCOUNT_ID ||
+        processEnv.CODEX_ACCOUNT_ID ||
+        liveCodexCredentials?.accountId ||
+        persistedEnv.CHATGPT_ACCOUNT_ID ||
+        persistedEnv.CODEX_ACCOUNT_ID
 
     return buildCompatibilityProcessEnv({
       processEnv,

--- a/src/utils/providerProfile.ts
+++ b/src/utils/providerProfile.ts
@@ -906,7 +906,11 @@ export async function buildLaunchEnv(options: {
 
     for (const [envKey, provider] of explicitProfileOverrides) {
       if (isEnvTruthy(processEnv[envKey])) {
-        if (!(options.profile === 'codex' && provider === 'openai')) {
+        const isCodexOAuthProfile =
+          options.profile === 'codex' &&
+          provider === 'openai' &&
+          persistedEnv.CODEX_CREDENTIAL_SOURCE === 'oauth'
+        if (!isCodexOAuthProfile) {
           options.profile = provider
         }
         break


### PR DESCRIPTION
 ## Summary

  - Fixed in-session switching to Codex OAuth so it no longer applies an empty generic OpenAI API key before Codex credentials are active.
  - Added/updated regression coverage for Codex OAuth session activation.
  - This changed because switching to Codex OAuth worked after restart, but could produce a 401 missing `Authorization` header during the same session.

  ## Impact

  - user-facing impact: Users can switch to Codex OAuth from `/provider` without restarting and without hitting the missing API key / bearer auth 401.
  - developer/maintainer impact: Codex OAuth activation now avoids the generic OpenAI-compatible profile activation path for first-run setup, and tests cover the empty `OPENAI_API_KEY` regression.

  ## Testing

  - [ ] `bun run build`
  - [ ] `bun run smoke`
  - [x] focused tests: `bun test src/utils/providerProfile.test.ts src/components/ProviderManager.test.tsx` — 74 pass / 0 fail

  ## Notes

  - provider/model path tested: Codex OAuth via `/provider`, `codexplan`, same-session switch from existing provider state.
  - screenshots attached (if UI changed): no UI screenshot; behavior manually verified in-session.
  - follow-up work or known limitations: `bun run typecheck` still has unrelated existing repo-wide failures; no failures matched `ProviderManager` or `providerProfile`.