### PR TITLE
fix(openai-shim): don't label transport failures as HTTP 503 (#971)

### DIFF
--- a/src/services/api/openaiShim.test.ts
+++ b/src/services/api/openaiShim.test.ts
@@ -3566,6 +3566,44 @@ test('classifies localhost transport failures with actionable category marker', 
   ).rejects.toThrow('local server is running')
 })
 
+test('transport failures are not labeled with HTTP status 503', async () => {
+  // Issue #971: ENETDOWN (and other transport errors) are emitted before any
+  // HTTP response is received. Reporting them as "503" makes users believe the
+  // upstream server returned 503 Service Unavailable.
+  process.env.OPENAI_BASE_URL = 'https://intranet.example.test/v1'
+
+  const transportError = Object.assign(new TypeError('fetch failed'), {
+    code: 'ENETDOWN',
+  })
+
+  globalThis.fetch = (async () => {
+    throw transportError
+  }) as FetchType
+
+  const client = createOpenAIShimClient({}) as OpenAIShimClient
+
+  let caught: unknown
+  try {
+    await client.beta.messages.create({
+      model: 'gpt-4o-mini',
+      messages: [{ role: 'user', content: 'hello' }],
+      max_tokens: 64,
+      stream: false,
+    })
+  } catch (error) {
+    caught = error
+  }
+
+  expect(caught).toBeDefined()
+  const err = caught as { status?: number; message: string; constructor: { name: string } }
+  expect(err.constructor.name).toBe('APIConnectionError')
+  expect(err.status).toBeUndefined()
+  expect(err.message).not.toMatch(/^503\b/)
+  expect(err.message).toContain('OpenAI API transport error')
+  expect(err.message).toContain('code=ENETDOWN')
+  expect(err.message).toContain('openai_category=network_error')
+})
+
 test('propagates AbortError without wrapping it as transport failure', async () => {
   process.env.OPENAI_BASE_URL = 'http://localhost:11434/v1'
 

--- a/src/services/api/openaiShim.ts
+++ b/src/services/api/openaiShim.ts
@@ -1916,7 +1916,7 @@ class OpenAIShimMessages {
       )
 
       throw APIError.generate(
-        503,
+        0,
         undefined,
         buildOpenAICompatibilityErrorMessage(
           `OpenAI API transport error: ${safeMessage}${failure.code ? ` (code=${failure.code})` : ''}`,


### PR DESCRIPTION
## Summary
- Fix #971 by stopping `APIError.generate(503, ...)` for transport-layer failures, which made network errors render as `503 OpenAI API transport error: ...` and falsely implied the upstream server returned Service Unavailable.
- Use `APIError.generate(0, ...)` so the SDK constructs an `APIConnectionError` — semantically correct for "no HTTP response received" — with no spurious `503` prefix.
- Add a focused regression test that fails on `main` and passes with the fix.

## Root Cause
`src/services/api/openaiShim.ts:1918-1926` (`throwClassifiedTransportError`) wrapped every transport failure in `APIError.generate(503, ...)`. The OpenAI SDK formats `APIError.message` as `"${status} ${original}"`, so a local `ENETDOWN` (network interface down) was rendered as `503 OpenAI API transport error: fetch failed (code=ENETDOWN)`. The error category and hint were correct (`network_error` / "Network transport failed before a provider response was received") — only the synthesized 503 status was wrong.

The OpenAI SDK already provides the correct mapping: `APIError.generate(0, ...)` returns `APIConnectionError` (verified: `APIConnectionError extends APIError`, so existing `instanceof APIError` branches in `src/services/api/errors.ts` and `src/services/api/withRetry.ts` keep matching).

## What Changed
- `src/services/api/openaiShim.ts`: change the transport-error throw site from status `503` → `0`. Production diff is one character.
- `src/services/api/openaiShim.test.ts`: add `transport failures are not labeled with HTTP status 503` regression test that asserts the thrown error is `APIConnectionError`, has no `status`, and the message does not start with `503`.

## Verification
- Reproduced the misleading prefix on `main` with a small script:
  ```
  APIError.generate(503, undefined, msg).message
  // => "503 OpenAI API transport error: fetch failed (code=ENETDOWN)\n[openai_category=network_error] ..."
  ```
  After the fix:
  ```
  APIError.generate(0, undefined, msg).constructor.name === 'APIConnectionError'
  APIError.generate(0, undefined, msg).message
  // => "OpenAI API transport error: fetch failed (code=ENETDOWN)\n[openai_category=network_error] ..."
  ```
- New regression test **fails on `main`** (`Expected: "APIConnectionError" / Received: "InternalServerError"`) and **passes with the fix**.
- `bun test src/services/api/openaiShim.test.ts` → 83 pass / 0 fail (existing localhost-transport / Abort tests still green; they assert on message content, not status).
- `bun run build` → builds cleanly.
- Existing test failures in `openaiShim.diagnostics.test.ts` and typecheck errors in `ccrSession.ts` / `worktree.ts` reproduce on unmodified `main` and are unrelated to this change.

## Scope Note for the Reporter
@eminarcissus — to be transparent: the underlying cause of your error was `ENETDOWN`, which means your local machine could not reach the intranet host (the network interface itself was down — wifi off, VPN dropped, intranet unreachable). That's environmental and openclaude can't fix it from the client side. **What this PR fixes is only the misleading message** — instead of `503 OpenAI API transport error: ...` you'll now see `OpenAI API transport error: ... (code=ENETDOWN)` with the correct `openai_category=network_error` hint, which won't lead future users to think the server returned 503.

Could you pull this branch, reproduce your original setup, and confirm that:
1. The error message no longer starts with `503`.
2. The hint still correctly says "Network transport failed before a provider response was received."

I'll hold the merge until you confirm.