### PR TITLE
Another Pass On Branding Cleanup And Command Disablement

### DIFF
--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -137,7 +137,7 @@ const result = await Bun.build({
     'MACRO.DISPLAY_VERSION': JSON.stringify(version),
     'MACRO.BUILD_TIME': JSON.stringify(new Date().toISOString()),
     'MACRO.ISSUES_EXPLAINER':
-      JSON.stringify('report the issue at https://github.com/anthropics/claude-code/issues'),
+      JSON.stringify('report the issue at https://github.com/Gitlawb/openclaude/issues'),
     'MACRO.PACKAGE_URL': JSON.stringify('@gitlawb/openclaude'),
     'MACRO.NATIVE_PACKAGE_URL': 'undefined',
   },

--- a/src/commands/feedback/index.ts
+++ b/src/commands/feedback/index.ts
@@ -1,25 +1,11 @@
 import type { Command } from '../../commands.js'
-import { isPolicyAllowed } from '../../services/policyLimits/index.js'
-import { isEnvTruthy } from '../../utils/envUtils.js'
-import { isEssentialTrafficOnly } from '../../utils/privacyLevel.js'
-
 const feedback = {
   aliases: ['bug'],
   type: 'local-jsx',
   name: 'feedback',
   description: `Submit feedback about OpenClaude`,
   argumentHint: '[report]',
-  isEnabled: () =>
-    !(
-      isEnvTruthy(process.env.CLAUDE_CODE_USE_BEDROCK) ||
-      isEnvTruthy(process.env.CLAUDE_CODE_USE_VERTEX) ||
-      isEnvTruthy(process.env.CLAUDE_CODE_USE_FOUNDRY) ||
-      isEnvTruthy(process.env.DISABLE_FEEDBACK_COMMAND) ||
-      isEnvTruthy(process.env.DISABLE_BUG_COMMAND) ||
-      isEssentialTrafficOnly() ||
-      process.env.USER_TYPE === 'ant' ||
-      !isPolicyAllowed('allow_product_feedback')
-    ),
+  isEnabled: () => false,
   load: () => import('./feedback.js'),
 } satisfies Command
 

--- a/src/commands/mobile/index.ts
+++ b/src/commands/mobile/index.ts
@@ -5,6 +5,7 @@ const mobile = {
   name: 'mobile',
   aliases: ['ios', 'android'],
   description: 'Show QR code to download the Claude mobile app',
+  isEnabled: () => false,
   load: () => import('./mobile.js'),
 } satisfies Command
 

--- a/src/components/FeedbackSurvey/FeedbackSurvey.tsx
+++ b/src/components/FeedbackSurvey/FeedbackSurvey.tsx
@@ -152,7 +152,6 @@ function FeedbackSurveyThanks(t0) {
     t3 = $[7];
   }
   useDebouncedDigitInput(t3);
-  const feedbackCommand = false ? "/issue" : "/feedback";
   let t4;
   if ($[8] === Symbol.for("react.memo_cache_sentinel")) {
     t4 = <Text color="success">Thanks for the feedback!</Text>;
@@ -162,7 +161,7 @@ function FeedbackSurveyThanks(t0) {
   }
   let t5;
   if ($[9] !== lastResponse || $[10] !== showFollowUp) {
-    t5 = <Box marginTop={1} flexDirection="column">{t4}{showFollowUp ? <Text dimColor={true}>(Optional) Press [<Text color="ansi:cyan">1</Text>] to tell us what went well {" \xB7 "}{feedbackCommand}</Text> : lastResponse === "bad" ? <Text dimColor={true}>Use /issue to report model behavior issues.</Text> : <Text dimColor={true}>Use {feedbackCommand} to share detailed feedback anytime.</Text>}</Box>;
+    t5 = <Box marginTop={1} flexDirection="column">{t4}{showFollowUp ? <Text dimColor={true}>(Optional) Press [<Text color="ansi:cyan">1</Text>] to tell us what went well.</Text> : lastResponse === "bad" ? <Text dimColor={true}>Use the issue tracker to report model behavior issues.</Text> : null}</Box>;
     $[9] = lastResponse;
     $[10] = showFollowUp;
     $[11] = t5;

--- a/src/components/HelpV2/HelpV2.tsx
+++ b/src/components/HelpV2/HelpV2.tsx
@@ -7,6 +7,7 @@ import { useIsInsideModal } from '../../context/modalContext.js';
 import { useTerminalSize } from '../../hooks/useTerminalSize.js';
 import { Box, Link, Text } from '../../ink.js';
 import { useKeybinding } from '../../keybindings/useKeybinding.js';
+import { getPublicBuildVersion } from '../../utils/version.js';
 import { Pane } from '../design-system/Pane.js';
 import { Tab, Tabs } from '../design-system/Tabs.js';
 import { Commands } from './Commands.js';
@@ -136,48 +137,42 @@ export function HelpV2(t0) {
     tabs = $[15];
   }
   const t5 = insideModal ? undefined : maxHeight;
+  const publicBuildVersion = getPublicBuildVersion();
   let t6;
-  if ($[31] !== tabs) {
-    t6 = <Tabs title={false ? "/help" : `OpenClaude v${MACRO.VERSION}`} color="professionalBlue" defaultTab="general">{tabs}</Tabs>;
-    $[31] = tabs;
-    $[32] = t6;
+  if ($[31] !== publicBuildVersion || $[32] !== tabs) {
+    t6 = <Tabs title={false ? "/help" : `OpenClaude v${publicBuildVersion}`} color="professionalBlue" defaultTab="general">{tabs}</Tabs>;
+    $[31] = publicBuildVersion;
+    $[32] = tabs;
+    $[33] = t6;
   } else {
-    t6 = $[32];
+    t6 = $[33];
   }
   let t7;
-  if ($[33] === Symbol.for("react.memo_cache_sentinel")) {
+  if ($[34] === Symbol.for("react.memo_cache_sentinel")) {
     t7 = <Box marginTop={1}><Text>For more help:{" "}<Link url="https://github.com/Gitlawb/openclaude" /></Text></Box>;
-    $[33] = t7;
+    $[34] = t7;
   } else {
-    t7 = $[33];
+    t7 = $[34];
   }
   let t8;
-  if ($[34] !== dismissShortcut || $[35] !== exitState.keyName || $[36] !== exitState.pending) {
+  if ($[35] !== dismissShortcut || $[36] !== exitState.keyName || $[37] !== exitState.pending) {
     t8 = <Box marginTop={1}><Text dimColor={true}>{exitState.pending ? <>Press {exitState.keyName} again to exit</> : <Text italic={true}>{dismissShortcut} to cancel</Text>}</Text></Box>;
-    $[34] = dismissShortcut;
-    $[35] = exitState.keyName;
-    $[36] = exitState.pending;
-    $[37] = t8;
+    $[35] = dismissShortcut;
+    $[36] = exitState.keyName;
+    $[37] = exitState.pending;
+    $[38] = t8;
   } else {
-    t8 = $[37];
+    t8 = $[38];
   }
   let t9;
-  if ($[38] !== t6 || $[39] !== t8) {
+  if ($[39] !== t6 || $[40] !== t8) {
     t9 = <Pane color="professionalBlue">{t6}{t7}{t8}</Pane>;
-    $[38] = t6;
-    $[39] = t8;
-    $[40] = t9;
+    $[39] = t6;
+    $[40] = t8;
+    $[41] = t9;
   } else {
-    t9 = $[40];
+    t9 = $[41];
   }
-  let t10;
-  if ($[41] !== t5 || $[42] !== t9) {
-    t10 = <Box flexDirection="column" height={t5}>{t9}</Box>;
-    $[41] = t5;
-    $[42] = t9;
-    $[43] = t10;
-  } else {
-    t10 = $[43];
-  }
+  const t10 = <Box flexDirection="column" height={t5}>{t9}</Box>;
   return t10;
 }

--- a/src/components/messages/UserToolResultMessage/UserToolErrorMessage.tsx
+++ b/src/components/messages/UserToolResultMessage/UserToolErrorMessage.tsx
@@ -73,7 +73,7 @@ export function UserToolErrorMessage(t0) {
   if (feature("TRANSCRIPT_CLASSIFIER") && typeof param.content === "string" && isClassifierDenial(param.content)) {
     let t1;
     if ($[6] === Symbol.for("react.memo_cache_sentinel")) {
-      t1 = <MessageResponse height={1}><Text dimColor={true}>Denied by auto mode classifier {BULLET_OPERATOR} /feedback if incorrect</Text></MessageResponse>;
+      t1 = <MessageResponse height={1}><Text dimColor={true}>Denied by auto mode classifier {BULLET_OPERATOR} open an issue if incorrect</Text></MessageResponse>;
       $[6] = t1;
     } else {
       t1 = $[6];

--- a/src/components/permissions/EnterPlanModePermissionRequest/EnterPlanModePermissionRequest.tsx
+++ b/src/components/permissions/EnterPlanModePermissionRequest/EnterPlanModePermissionRequest.tsx
@@ -49,14 +49,14 @@ export function EnterPlanModePermissionRequest(t0) {
   const handleResponse = t1;
   let t2;
   if ($[5] === Symbol.for("react.memo_cache_sentinel")) {
-    t2 = <Text>Claude wants to enter plan mode to explore and design an implementation approach.</Text>;
+    t2 = <Text>OpenClaude wants to enter plan mode to explore and design an implementation approach.</Text>;
     $[5] = t2;
   } else {
     t2 = $[5];
   }
   let t3;
   if ($[6] === Symbol.for("react.memo_cache_sentinel")) {
-    t3 = <Box marginTop={1} flexDirection="column"><Text dimColor={true}>In plan mode, Claude will:</Text><Text dimColor={true}> · Explore the codebase thoroughly</Text><Text dimColor={true}> · Identify existing patterns</Text><Text dimColor={true}> · Design an implementation strategy</Text><Text dimColor={true}> · Present a plan for your approval</Text></Box>;
+    t3 = <Box marginTop={1} flexDirection="column"><Text dimColor={true}>In plan mode, OpenClaude will:</Text><Text dimColor={true}> · Explore the codebase thoroughly</Text><Text dimColor={true}> · Identify existing patterns</Text><Text dimColor={true}> · Design an implementation strategy</Text><Text dimColor={true}> · Present a plan for your approval</Text></Box>;
     $[6] = t3;
   } else {
     t3 = $[6];

--- a/src/components/permissions/ExitPlanModePermissionRequest/ExitPlanModePermissionRequest.tsx
+++ b/src/components/permissions/ExitPlanModePermissionRequest/ExitPlanModePermissionRequest.tsx
@@ -600,7 +600,7 @@ export function ExitPlanModePermissionRequest({
     }
     return <PermissionDialog color="planMode" title="Exit plan mode?" workerBadge={workerBadge}>
         <Box flexDirection="column" paddingX={1} marginTop={1}>
-          <Text>Claude wants to exit plan mode</Text>
+          <Text>OpenClaude wants to exit plan mode</Text>
           <Box marginTop={1}>
             <Select options={[{
             label: 'Yes',

--- a/src/components/permissions/FilePermissionDialog/permissionOptions.tsx
+++ b/src/components/permissions/FilePermissionDialog/permissionOptions.tsx
@@ -104,7 +104,7 @@ export function getFilePermissionOptions({
   // persisted permission rules.
   if ((inClaudeFolder || inGlobalClaudeFolder) && operationType !== 'read') {
     options.push({
-      label: 'Yes, and allow Claude to edit its own settings for this session',
+      label: 'Yes, and allow OpenClaude to edit its own settings for this session',
       value: 'yes-claude-folder',
       option: {
         type: 'accept-session',

--- a/src/components/permissions/PermissionPrompt.tsx
+++ b/src/components/permissions/PermissionPrompt.tsx
@@ -28,8 +28,8 @@ export type PermissionPromptProps<T extends string> = {
   toolAnalyticsContext?: ToolAnalyticsContext;
 };
 const DEFAULT_PLACEHOLDERS: Record<FeedbackType, string> = {
-  accept: 'tell Claude what to do next',
-  reject: 'tell Claude what to do differently'
+  accept: 'tell OpenClaude what to do next',
+  reject: 'tell OpenClaude what to do differently'
 };
 
 /**

--- a/src/constants/prompts.ts
+++ b/src/constants/prompts.ts
@@ -100,7 +100,7 @@ import type { OutputStyleConfig } from './outputStyles.js'
 import { CYBER_RISK_INSTRUCTION } from './cyberRiskInstruction.js'
 
 export const CLAUDE_CODE_DOCS_MAP_URL =
-  'https://code.claude.com/docs/en/claude_code_docs_map.md'
+  'https://github.com/Gitlawb/openclaude'
 
 /**
  * Boundary marker separating static (cross-org cacheable) content from dynamic content.
@@ -115,14 +115,7 @@ export const SYSTEM_PROMPT_DYNAMIC_BOUNDARY =
   '__SYSTEM_PROMPT_DYNAMIC_BOUNDARY__'
 
 // @[MODEL LAUNCH]: Update the latest frontier model.
-const FRONTIER_MODEL_NAME = 'Claude Opus 4.6'
-
-// @[MODEL LAUNCH]: Update the model family IDs below to the latest in each tier.
-const CLAUDE_4_5_OR_4_6_MODEL_IDS = {
-  opus: 'claude-opus-4-6',
-  sonnet: 'claude-sonnet-4-6',
-  haiku: 'claude-haiku-4-5-20251001',
-}
+const FRONTIER_MODEL_NAME = 'Claude Opus 4.7'
 
 function getHooksSection(): string {
   return `Users may configure 'hooks', shell commands that execute in response to events like tool calls, in settings. Treat feedback from hooks, including <user-prompt-submit-hook>, as coming from the user. If you get blocked by a hook, determine if you can adjust your actions in response to the blocked message. If not, ask the user to check their hooks configuration.`
@@ -691,9 +684,6 @@ export async function computeSimpleEnvInfo(
     `OS Version: ${unameSR}`,
     modelDescription,
     knowledgeCutoffMessage,
-    process.env.USER_TYPE === 'ant' && isUndercover()
-      ? null
-      : `The most recent Claude model family is Claude 4.5/4.6. Model IDs — Opus 4.6: '${CLAUDE_4_5_OR_4_6_MODEL_IDS.opus}', Sonnet 4.6: '${CLAUDE_4_5_OR_4_6_MODEL_IDS.sonnet}', Haiku 4.5: '${CLAUDE_4_5_OR_4_6_MODEL_IDS.haiku}'. When building AI applications, default to the latest and most capable Claude models.`,
     process.env.USER_TYPE === 'ant' && isUndercover()
       ? null
       : `OpenClaude is available as a CLI in the terminal and can be used across local development environments and IDE workflows.`,

--- a/src/screens/REPL.tsx
+++ b/src/screens/REPL.tsx
@@ -3668,18 +3668,6 @@ export function REPL({
     setAutoRunIssueReason(null);
   }, []);
 
-  // Handler for when user presses 1 on survey thanks screen to share details
-  const handleSurveyRequestFeedback = useCallback(() => {
-    const command = "external" === 'ant' ? '/issue' : '/feedback';
-    onSubmit(command, {
-      setCursorOffset: () => { },
-      clearBuffer: () => { },
-      resetHistory: () => { }
-    }).catch(err => {
-      logForDebugging(`Survey feedback request failed: ${err instanceof Error ? err.message : String(err)}`);
-    });
-  }, [onSubmit]);
-
   // onSubmit is unstable (deps include `messages` which changes every turn).
   // `handleOpenRateLimitOptions` is prop-drilled to every MessageRow, and each
   // MessageRow fiber pins the closure (and transitively the entire REPL render
@@ -4960,7 +4948,7 @@ export function REPL({
 
           {!toolJSX?.shouldHidePromptInput && !focusedInputDialog && !isExiting && !disabled && !cursor && !isShuttingDown() && <>
             {autoRunIssueReason && <AutoRunIssueNotification onRun={handleAutoRunIssue} onCancel={handleCancelAutoRunIssue} reason={getAutoRunIssueReasonText(autoRunIssueReason)} />}
-            {postCompactSurvey.state !== 'closed' ? <FeedbackSurvey state={postCompactSurvey.state} lastResponse={postCompactSurvey.lastResponse} handleSelect={postCompactSurvey.handleSelect} inputValue={inputValue} setInputValue={setInputValue} onRequestFeedback={handleSurveyRequestFeedback} /> : memorySurvey.state !== 'closed' ? <FeedbackSurvey state={memorySurvey.state} lastResponse={memorySurvey.lastResponse} handleSelect={memorySurvey.handleSelect} handleTranscriptSelect={memorySurvey.handleTranscriptSelect} inputValue={inputValue} setInputValue={setInputValue} onRequestFeedback={handleSurveyRequestFeedback} message="How well did Claude use its memory? (optional)" /> : <FeedbackSurvey state={feedbackSurvey.state} lastResponse={feedbackSurvey.lastResponse} handleSelect={feedbackSurvey.handleSelect} handleTranscriptSelect={feedbackSurvey.handleTranscriptSelect} inputValue={inputValue} setInputValue={setInputValue} onRequestFeedback={didAutoRunIssueRef.current ? undefined : handleSurveyRequestFeedback} />}
+            {postCompactSurvey.state !== 'closed' ? <FeedbackSurvey state={postCompactSurvey.state} lastResponse={postCompactSurvey.lastResponse} handleSelect={postCompactSurvey.handleSelect} inputValue={inputValue} setInputValue={setInputValue} /> : memorySurvey.state !== 'closed' ? <FeedbackSurvey state={memorySurvey.state} lastResponse={memorySurvey.lastResponse} handleSelect={memorySurvey.handleSelect} handleTranscriptSelect={memorySurvey.handleTranscriptSelect} inputValue={inputValue} setInputValue={setInputValue} message="How well did Claude use its memory? (optional)" /> : <FeedbackSurvey state={feedbackSurvey.state} lastResponse={feedbackSurvey.lastResponse} handleSelect={feedbackSurvey.handleSelect} handleTranscriptSelect={feedbackSurvey.handleTranscriptSelect} inputValue={inputValue} setInputValue={setInputValue} />}
             {/* Frustration-triggered transcript sharing prompt */}
             {frustrationDetection.state !== 'closed' && <FeedbackSurvey state={frustrationDetection.state} lastResponse={null} handleSelect={() => { }} handleTranscriptSelect={frustrationDetection.handleTranscriptSelect} inputValue={inputValue} setInputValue={setInputValue} />}
             {/* Skill improvement survey - appears when improvements detected (internal-only) */}

--- a/src/services/tips/tipRegistry.ts
+++ b/src/services/tips/tipRegistry.ts
@@ -461,13 +461,6 @@ const externalTips: Tip[] = [
     isRelevant: async () => true,
   },
   {
-    id: 'mobile-app',
-    content: async () =>
-      '/mobile to continue from your phone',
-    cooldownSessions: 15,
-    isRelevant: async () => true,
-  },
-  {
     id: 'opusplan-mode-reminder',
     content: async () =>
       `Your default model setting is Opus Plan Mode. Press ${getShortcutDisplay('chat:cycleMode', 'Chat', 'shift+tab')} twice to activate Plan Mode and plan with Opus.`,
@@ -617,7 +610,7 @@ const externalTips: Tip[] = [
   },
   {
     id: 'feedback-command',
-    content: async () => 'Use /feedback to help us improve!',
+    content: async () => 'Report bugs or feature requests in the issue tracker to help us improve.',
     cooldownSessions: 15,
     async isRelevant() {
       const config = getGlobalConfig()

--- a/src/tools/AgentTool/built-in/claudeCodeGuideAgent.ts
+++ b/src/tools/AgentTool/built-in/claudeCodeGuideAgent.ts
@@ -87,12 +87,7 @@ Complete the user's request by providing accurate, documentation-based guidance.
 }
 
 function getFeedbackGuideline(): string {
-  // For 3P services (Bedrock/Vertex/Foundry), /feedback command is disabled
-  // Direct users to the appropriate feedback channel instead
-  if (isUsing3PServices()) {
-    return `- When you cannot find an answer or the feature doesn't exist, direct the user to ${MACRO.ISSUES_EXPLAINER}`
-  }
-  return "- When you cannot find an answer or the feature doesn't exist, direct the user to use /feedback to report a feature request or bug"
+  return `- When you cannot find an answer or the feature doesn't exist, direct the user to ${MACRO.ISSUES_EXPLAINER}`
 }
 
 export const CLAUDE_CODE_GUIDE_AGENT: BuiltInAgentDefinition = {

--- a/src/utils/version.ts
+++ b/src/utils/version.ts
@@ -54,3 +54,7 @@ export const publicBuildVersion = normalizePublicVersion(
 export function getReleaseTagUrl(version: string = publicBuildVersion): string {
   return `${OPENCLAUDE_RELEASES_URL}/tag/v${normalizePublicVersion(version)}`
 }
+
+export function getPublicBuildVersion(): string {
+  return MACRO.DISPLAY_VERSION ?? MACRO.VERSION
+}


### PR DESCRIPTION
## Summary

This is another cleanup pass focused on OpenClaude branding consistency, a few related UX fixes, and disabling product surfaces we do not want exposed right now.

The main goals here were:

- continue replacing stale Claude/Anthropic-facing product references with OpenClaude-facing copy where appropriate
- tighten a few user-facing help and prompt strings so they point to the current OpenClaude project and issue flow
- disable `/feedback` and `/mobile` without deleting their implementation code
- fix the Help dialog version display path while cleaning up branding there

## What Changed

### Branding and copy cleanup

- updated issue-reporting guidance to point at the OpenClaude GitHub issues URL
- refreshed several user-facing strings to say `OpenClaude` instead of `Claude` where the product itself is being referenced
- removed the old injected prompt text describing Claude 4.5/4.6 model-family guidance
- updated the Help dialog title to use the public build version helper

### Disabled commands

- disabled `/feedback`
- disabled `/mobile`

These commands are now unavailable to users, but their code remains in place so we can re-enable or revisit the implementations later if needed.

### Follow-on cleanup from disabling commands

- removed or rewrote tips and survey follow-up text that still referenced `/feedback` or `/mobile`
- updated guide-agent fallback guidance so it sends users to the issue tracker instead of `/feedback`
- updated the classifier denial hint to tell users to open an issue instead of using `/feedback`

### Fixes included in this pass

- fixed the Help dialog title to use `getPublicBuildVersion()`
- fixed the Help dialog wrapper regression introduced during that update, so `/help` consistently preserves its outer layout container across re-renders

## Why

This PR is intentionally incremental. It is not a broad product rewrite; it is another pass at making the visible OpenClaude experience more coherent, while also turning off commands that we do not currently want users relying on.

## Verification

- built successfully with `bun run build`

## Notes

- this keeps the disabled command implementations in the tree for future reuse
- release-notes/changelog behavior was reviewed during this pass, but not changed in this PR
