### PR TITLE
Issue 982: fix(groq): strip unsupported store field from OpenAI-compatible requests

### DIFF
--- a/docs/advanced-setup.md
+++ b/docs/advanced-setup.md
@@ -159,10 +159,12 @@ export OPENAI_MODEL=meta-llama/Llama-3.3-70B-Instruct-Turbo
 
 ```bash
 export CLAUDE_CODE_USE_OPENAI=1
-export OPENAI_API_KEY=gsk_...
+export GROQ_API_KEY=gsk_...
 export OPENAI_BASE_URL=https://api.groq.com/openai/v1
 export OPENAI_MODEL=llama-3.3-70b-versatile
 ```
+
+`GROQ_API_KEY` matches the built-in Groq gateway preset. `OPENAI_API_KEY` also works as a fallback on the generic OpenAI-compatible path, but `GROQ_API_KEY` is the preferred variable for Groq-specific setup.
 
 ### Mistral
 

--- a/src/integrations/gateways/groq.ts
+++ b/src/integrations/gateways/groq.ts
@@ -16,6 +16,7 @@ export default defineGateway({
     kind: 'openai-compatible',
     openaiShim: {
       supportsAuthHeaders: true,
+      removeBodyFields: ['store'],
     },
   },
   preset: {

--- a/src/services/api/openaiShim.test.ts
+++ b/src/services/api/openaiShim.test.ts
@@ -4064,6 +4064,40 @@ test('Moonshot: uses max_tokens (not max_completion_tokens) and strips store', a
   expect(requestBody?.store).toBeUndefined()
 })
 
+test('Groq: keeps max_completion_tokens and strips unsupported store', async () => {
+  process.env.OPENAI_BASE_URL = 'https://api.groq.com/openai/v1'
+  process.env.OPENAI_API_KEY = 'gsk-test'
+
+  let requestBody: Record<string, unknown> | undefined
+  globalThis.fetch = (async (_input, init) => {
+    requestBody = JSON.parse(String(init?.body))
+    return new Response(
+      JSON.stringify({
+        id: 'chatcmpl-1',
+        model: 'llama-3.3-70b-versatile',
+        choices: [
+          { message: { role: 'assistant', content: 'ok' }, finish_reason: 'stop' },
+        ],
+        usage: { prompt_tokens: 3, completion_tokens: 1, total_tokens: 4 },
+      }),
+      { headers: { 'Content-Type': 'application/json' } },
+    )
+  }) as FetchType
+
+  const client = createOpenAIShimClient({}) as OpenAIShimClient
+  await client.beta.messages.create({
+    model: 'llama-3.3-70b-versatile',
+    system: 'you are groq',
+    messages: [{ role: 'user', content: 'hi' }],
+    max_tokens: 256,
+    stream: false,
+  })
+
+  expect(requestBody?.max_completion_tokens).toBe(256)
+  expect(requestBody?.max_tokens).toBeUndefined()
+  expect(requestBody?.store).toBeUndefined()
+})
+
 test('Moonshot: echoes reasoning_content on assistant tool-call messages', async () => {
   // Regression for: "API Error: 400 {"error":{"message":"thinking is enabled
   // but reasoning_content is missing in assistant tool call message at index


### PR DESCRIPTION
## Summary

This PR fixes #981 Groq requests failing immediately in OpenClaude v0.8.0 with:

> `Request too large (max 20MB). Double press esc to go back and try with a smaller file.`

for simple prompts such as `hola`.

## Issue

Users configuring Groq with:

- Base URL: `https://api.groq.com/openai/v1`
- Models such as `llama-3.3-70b-versatile` and `llama-3.1-8b-instant`

could hit an immediate failure before any meaningful response was returned, even with tiny text-only prompts.

The reported symptoms looked like a payload-size problem, but the actual request payload for a fresh turn is nowhere near Groq's documented size limits. The root cause was a compatibility mismatch in our OpenAI shim request body.

## Root Cause

Our Groq gateway was still sending `store: false` on chat completions requests.

Groq's current OpenAI-compatible API documentation marks `store` as unsupported for chat completions. That made Groq a poor fit for the default OpenAI-compatible body shape we were sending, and it could surface as a misleading generic client error instead of a clear provider-specific compatibility failure.

## Fix

- Configure the Groq gateway shim to remove the unsupported `store` field from request bodies
- Add a regression test proving Groq still uses `max_completion_tokens` while stripping `store`
- Update Groq setup docs to prefer `GROQ_API_KEY`, which matches the built-in Groq gateway preset

## Files Changed

- `src/integrations/gateways/groq.ts`
- `src/services/api/openaiShim.test.ts`
- `docs/advanced-setup.md`

## Validation

Tested with:

```bash
bun test src/services/api/openaiShim.test.ts --filter "Groq: keeps max_completion_tokens and strips unsupported store"
```

This regression test passes and confirms the Groq request body shape now matches the intended compatibility behavior.

## User Impact

After this change, Groq text requests should no longer fail immediately due to the unsupported `store` field, and OpenClaude should behave correctly for simple prompts against Groq's OpenAI-compatible endpoint.

## Notes

- This is a provider-compatibility fix, not a payload-size optimization change
- The docs update keeps `OPENAI_API_KEY` as a fallback note, but documents `GROQ_API_KEY` as the preferred Groq-specific env var
