### PR TITLE
Merge configured and discovered provider profile models

### DIFF
--- a/src/utils/providerProfiles.test.ts
+++ b/src/utils/providerProfiles.test.ts
@@ -1505,6 +1505,43 @@ describe('getProfileModelOptions', () => {
     ])
   })
 
+  test('appends discovered model cache entries for the same profile without duplicates', async () => {
+    const { getProfileModelOptions } =
+      await importFreshProviderProfileModules()
+
+    mockConfigState = {
+      ...createMockConfigState(),
+      openaiAdditionalModelOptionsCacheByProfile: {
+        provider_test: [
+          {
+            value: 'glm-4.7-flash',
+            label: 'glm-4.7-flash',
+            description: 'Discovered from API',
+          },
+          {
+            value: 'glm-4.7-plus',
+            label: 'glm-4.7-plus',
+            description: 'Discovered from API',
+          },
+        ],
+      },
+    }
+
+    const options = getProfileModelOptions(
+      buildProfile({
+        id: 'provider_test',
+        name: 'Test Provider',
+        model: 'glm-4.7, glm-4.7-flash',
+      }),
+    )
+
+    expect(options).toEqual([
+      { value: 'glm-4.7', label: 'glm-4.7', description: 'Provider: Test Provider' },
+      { value: 'glm-4.7-flash', label: 'glm-4.7-flash', description: 'Provider: Test Provider' },
+      { value: 'glm-4.7-plus', label: 'glm-4.7-plus', description: 'Discovered from API' },
+    ])
+  })
+
   test('returns empty array for empty model field', async () => {
     const { getProfileModelOptions } =
       await importFreshProviderProfileModules()
@@ -1546,5 +1583,141 @@ describe('setActiveProviderProfile model cache', () => {
     expect(cacheValues).toContain('glm-4.7')
     expect(cacheValues).toContain('glm-4.7-flash')
     expect(cacheValues).toContain('glm-4.7-plus')
+  })
+
+  test('merges configured profile models with discovered cache on activation', async () => {
+    const {
+      setActiveProviderProfile,
+      getActiveOpenAIModelOptionsCache,
+    } = await importFreshProviderProfileModules()
+
+    mockConfigState = {
+      ...createMockConfigState(),
+      providerProfiles: [
+        buildProfile({
+          id: 'multi_provider',
+          name: 'Multi Provider',
+          model: 'glm-4.7, glm-4.7-flash',
+          baseUrl: 'https://api.example.com/v1',
+        }),
+      ],
+      openaiAdditionalModelOptionsCacheByProfile: {
+        multi_provider: [
+          {
+            value: 'glm-4.7-plus',
+            label: 'glm-4.7-plus',
+            description: 'Discovered from API',
+          },
+          {
+            value: 'glm-4.7-flash',
+            label: 'glm-4.7-flash',
+            description: 'Discovered from API',
+          },
+        ],
+      },
+    }
+
+    setActiveProviderProfile('multi_provider')
+
+    expect(getActiveOpenAIModelOptionsCache()).toEqual([
+      {
+        value: 'glm-4.7',
+        label: 'glm-4.7',
+        description: 'Provider: Multi Provider',
+      },
+      {
+        value: 'glm-4.7-flash',
+        label: 'glm-4.7-flash',
+        description: 'Provider: Multi Provider',
+      },
+      {
+        value: 'glm-4.7-plus',
+        label: 'glm-4.7-plus',
+        description: 'Discovered from API',
+      },
+    ])
+  })
+
+  test('merges configured profile models with discovered cache during refresh writes', async () => {
+    const {
+      setActiveOpenAIModelOptionsCache,
+      getActiveOpenAIModelOptionsCache,
+    } = await importFreshProviderProfileModules()
+
+    mockConfigState = {
+      ...createMockConfigState(),
+      providerProfiles: [
+        buildProfile({
+          id: 'multi_provider',
+          name: 'Multi Provider',
+          model: 'glm-4.7, glm-4.7-flash',
+          baseUrl: 'https://api.example.com/v1',
+        }),
+      ],
+      activeProviderProfileId: 'multi_provider',
+    }
+
+    setActiveOpenAIModelOptionsCache([
+      {
+        value: 'glm-4.7-plus',
+        label: 'glm-4.7-plus',
+        description: 'Discovered from API',
+      },
+      {
+        value: 'glm-4.7-flash',
+        label: 'glm-4.7-flash',
+        description: 'Discovered from API',
+      },
+    ])
+
+    expect(getActiveOpenAIModelOptionsCache()).toEqual([
+      {
+        value: 'glm-4.7',
+        label: 'glm-4.7',
+        description: 'Provider: Multi Provider',
+      },
+      {
+        value: 'glm-4.7-flash',
+        label: 'glm-4.7-flash',
+        description: 'Provider: Multi Provider',
+      },
+      {
+        value: 'glm-4.7-plus',
+        label: 'glm-4.7-plus',
+        description: 'Discovered from API',
+      },
+    ])
+  })
+
+  test('falls back to configured profile models when no discovery cache exists yet', async () => {
+    const {
+      getActiveOpenAIModelOptionsCache,
+    } = await importFreshProviderProfileModules()
+
+    mockConfigState = {
+      ...createMockConfigState(),
+      providerProfiles: [
+        buildProfile({
+          id: 'multi_provider',
+          name: 'Multi Provider',
+          model: 'glm-4.7, glm-4.7-flash',
+          baseUrl: 'https://api.example.com/v1',
+        }),
+      ],
+      activeProviderProfileId: 'multi_provider',
+    }
+
+    expect(getActiveOpenAIModelOptionsCache()).toEqual([
+      {
+        value: 'glm-4.7',
+        label: 'glm-4.7',
+        description: 'Provider: Multi Provider',
+      },
+      {
+        value: 'glm-4.7-flash',
+        label: 'glm-4.7-flash',
+        description: 'Provider: Multi Provider',
+      },
+    ])
   })
 })

--- a/src/utils/providerProfiles.ts
+++ b/src/utils/providerProfiles.ts
@@ -254,6 +254,31 @@ function getModelCacheByProfile(
   return config.openaiAdditionalModelOptionsCacheByProfile?.[profileId] ?? []
 }
 
+function mergeModelOptionsByValue(
+  primaryOptions: ModelOption[],
+  additionalOptions: ModelOption[],
+): ModelOption[] {
+  const merged: ModelOption[] = []
+  const seen = new Set<string>()
+
+  for (const option of [...primaryOptions, ...additionalOptions]) {
+    if (typeof option.value !== 'string') {
+      continue
+    }
+    const value = option.value.trim()
+    if (!value || seen.has(value)) {
+      continue
+    }
+    seen.add(value)
+    merged.push({
+      ...option,
+      value,
+    })
+  }
+
+  return merged
+}
+
 export function getProviderPresetDefaults(
   preset: ProviderPreset,
 ): ProviderPresetDefaults {
@@ -842,19 +867,24 @@ export function persistActiveProviderProfileModel(
 
 /**
  * Generate model options from a provider profile's model field.
- * Each parsed model becomes a separate option in the picker.
+ * Each parsed model becomes a separate option in the picker, then any
+ * discovered OpenAI-compatible models cached for the same profile are
+ * appended without duplicates.
  */
-export function getProfileModelOptions(profile: ProviderProfile): ModelOption[] {
-  const models = parseModelList(profile.model)
-  if (models.length === 0) {
-    return []
-  }
-
-  return models.map(model => ({
+export function getProfileModelOptions(
+  profile: ProviderProfile,
+  config = getGlobalConfig(),
+): ModelOption[] {
+  const configuredOptions = parseModelList(profile.model).map(model => ({
     value: model,
     label: model,
     description: `Provider: ${profile.name}`,
   }))
+
+  return mergeModelOptionsByValue(
+    configuredOptions,
+    getModelCacheByProfile(profile.id, config),
+  )
 }
 
 function buildOpenAICompatibleStartupEnv(
@@ -1044,19 +1074,15 @@ export function setActiveProviderProfile(
     return null
   }
 
-  const profileModelOptions = getProfileModelOptions(activeProfile)
+  const profileModelOptions = getProfileModelOptions(activeProfile, current)
 
   saveGlobalConfig(config => ({
     ...config,
     activeProviderProfileId: profileId,
-    openaiAdditionalModelOptionsCache: profileModelOptions.length > 0
-      ? profileModelOptions
-      : getModelCacheByProfile(profileId, config),
+    openaiAdditionalModelOptionsCache: profileModelOptions,
     openaiAdditionalModelOptionsCacheByProfile: {
       ...(config.openaiAdditionalModelOptionsCacheByProfile ?? {}),
-      [profileId]: profileModelOptions.length > 0
-        ? profileModelOptions
-        : (config.openaiAdditionalModelOptionsCacheByProfile?.[profileId] ?? []),
+      [profileId]: profileModelOptions,
     },
   }))
 
@@ -1118,10 +1144,16 @@ export function deleteProviderProfile(profileId: string): {
       activeProviderProfileId: nextActiveId,
       openaiAdditionalModelOptionsCacheByProfile: cacheByProfile,
       openaiAdditionalModelOptionsCache: nextActiveId
-        ? getModelCacheByProfile(nextActiveId, {
-            ...current,
-            openaiAdditionalModelOptionsCacheByProfile: cacheByProfile,
-          })
+        ? (
+            nextActiveProfile
+              ? getProfileModelOptions(nextActiveProfile, {
+                  ...current,
+                  providerProfiles: nextProfiles,
+                  activeProviderProfileId: nextActiveId,
+                  openaiAdditionalModelOptionsCacheByProfile: cacheByProfile,
+                })
+              : []
+          )
         : [],
     }
   })
@@ -1159,6 +1191,11 @@ export function getActiveOpenAIModelOptionsCache(
     return cached
   }
 
+  const profileOptions = getProfileModelOptions(activeProfile, config)
+  if (profileOptions.length > 0) {
+    return profileOptions
+  }
+
   // Backward compatibility for users who have only the legacy single cache.
   if (
     Object.keys(config.openaiAdditionalModelOptionsCacheByProfile ?? {}).length ===
@@ -1181,12 +1218,21 @@ export function setActiveOpenAIModelOptionsCache(options: ModelOption[]): void {
     return
   }
 
+  const mergedOptions = mergeModelOptionsByValue(
+    parseModelList(activeProfile.model).map(model => ({
+      value: model,
+      label: model,
+      description: `Provider: ${activeProfile.name}`,
+    })),
+    options,
+  )
+
   saveGlobalConfig(current => ({
     ...current,
-    openaiAdditionalModelOptionsCache: options,
+    openaiAdditionalModelOptionsCache: mergedOptions,
     openaiAdditionalModelOptionsCacheByProfile: {
       ...(current.openaiAdditionalModelOptionsCacheByProfile ?? {}),
-      [activeProfile.id]: options,
+      [activeProfile.id]: mergedOptions,
     },
   }))
 }


### PR DESCRIPTION
## Summary

- Merge manually configured provider profile models with discovered OpenAI-compatible `/v1/models` results.
- Keep provider profile model caches consistent across activation, refresh writes, fallback reads, and profile deletion.
- Add focused regression coverage for the merged model-list behavior.

## Impact

- User-facing impact:
  Provider profiles now show both manually configured models and discovered OpenAI-compatible models together, instead of treating them as mutually exclusive.

- Developer/maintainer impact:
  Provider profile model option assembly is now centralized around a deduplicated merge, which makes activation and refresh behavior more predictable and easier to maintain.

## Testing

- [x] `bun run build`
- [x] `bun run smoke`
- [x] Focused tests:
  - `bun test src/utils/providerProfiles.test.ts`

## Notes

- Provider/model path tested:
  OpenAI-compatible provider profile flow with discovered `/v1/models` cache merging into configured profile models.

- Screenshots attached (if UI changed):
  Not applicable.

- Follow-up work or known limitations:
  This change focuses on merging configured and discovered provider models for the existing OpenAI-compatible discovery path. It does not expand discovery scope.
