### PR TITLE
fix: add TypeScript compilation stubs for closed-source modules

### DIFF
--- a/src/assistant/gate.ts
+++ b/src/assistant/gate.ts
@@ -1,0 +1,9 @@
+/**
+ * Stub — assistant gate module not included in source snapshot.
+ * Guarded by `feature('KAIROS')` at every call site — never invoked
+ * at runtime in the open-source build. See issue #473.
+ */
+
+export async function isKairosEnabled(): Promise<boolean> {
+  return false
+}

--- a/src/assistant/index.ts
+++ b/src/assistant/index.ts
@@ -1,0 +1,28 @@
+/**
+ * Stub — assistant module not included in source snapshot.
+ * All consumers guard access behind `feature('KAIROS')`, so these
+ * stubs are never invoked at runtime in the open-source build.
+ * See issue #473 for the typecheck-foundation effort.
+ */
+
+export function isAssistantMode(): boolean {
+  return false
+}
+
+export function isAssistantForced(): boolean {
+  return false
+}
+
+export function markAssistantForced(): void {}
+
+export async function initializeAssistantTeam(): Promise<undefined> {
+  return undefined
+}
+
+export function getAssistantSystemPromptAddendum(): string {
+  return ''
+}
+
+export function getAssistantActivationPath(): string | undefined {
+  return undefined
+}

--- a/src/assistant/sessionDiscovery.ts
+++ b/src/assistant/sessionDiscovery.ts
@@ -1,0 +1,5 @@
+/** Stub - not included in source snapshot. See issue #473. */
+export {}
+export type AssistantSession = any
+
+export function discoverAssistantSessions(..._args: any[]): any { return null }

--- a/src/bridge/peerSessions.ts
+++ b/src/bridge/peerSessions.ts
@@ -1,0 +1,4 @@
+/** Stub - not included in source snapshot. See issue #473. */
+export {}
+
+export function postInterClaudeMessage(..._args: any[]): any { return null }

--- a/src/bridge/webhookSanitizer.ts
+++ b/src/bridge/webhookSanitizer.ts
@@ -1,0 +1,4 @@
+/** Stub - not included in source snapshot. See issue #473. */
+export {}
+
+export function sanitizeInboundWebhookContent(..._args: any[]): any { return null }

--- a/src/cli/bg.ts
+++ b/src/cli/bg.ts
@@ -1,0 +1,12 @@
+/** Stub - not included in source snapshot. See issue #473. */
+export {}
+
+export function attachHandler(..._args: any[]): any { return null }
+
+export function handleBgFlag(..._args: any[]): any { return null }
+
+export function killHandler(..._args: any[]): any { return null }
+
+export function logsHandler(..._args: any[]): any { return null }
+
+export function psHandler(..._args: any[]): any { return null }

--- a/src/cli/handlers/ant.ts
+++ b/src/cli/handlers/ant.ts
@@ -1,0 +1,20 @@
+/** Stub - not included in source snapshot. See issue #473. */
+export {}
+
+export function completionHandler(..._args: any[]): any { return null }
+
+export function errorHandler(..._args: any[]): any { return null }
+
+export function exportHandler(..._args: any[]): any { return null }
+
+export function logHandler(..._args: any[]): any { return null }
+
+export function taskCreateHandler(..._args: any[]): any { return null }
+
+export function taskDirHandler(..._args: any[]): any { return null }
+
+export function taskGetHandler(..._args: any[]): any { return null }
+
+export function taskListHandler(..._args: any[]): any { return null }
+
+export function taskUpdateHandler(..._args: any[]): any { return null }

--- a/src/cli/handlers/templateJobs.ts
+++ b/src/cli/handlers/templateJobs.ts
@@ -1,0 +1,4 @@
+/** Stub - not included in source snapshot. See issue #473. */
+export {}
+
+export function templatesMain(..._args: any[]): any { return null }

--- a/src/cli/rollback.ts
+++ b/src/cli/rollback.ts
@@ -1,0 +1,4 @@
+/** Stub - not included in source snapshot. See issue #473. */
+export {}
+
+export function rollback(..._args: any[]): any { return null }

--- a/src/cli/transports/Transport.ts
+++ b/src/cli/transports/Transport.ts
@@ -1,0 +1,8 @@
+/**
+ * Stub — Transport type definitions not included in source snapshot.
+ * See src/types/message.ts for the same scoping caveat (issue #473).
+ */
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+export type Transport = any
+export type TransportMessage = any

--- a/src/cli/up.ts
+++ b/src/cli/up.ts
@@ -1,0 +1,4 @@
+/** Stub - not included in source snapshot. See issue #473. */
+export {}
+
+export function up(..._args: any[]): any { return null }

--- a/src/commands/fork/index.ts
+++ b/src/commands/fork/index.ts
@@ -1,0 +1,7 @@
+/**
+ * Stub — fork not included in source snapshot.
+ * See src/types/message.ts for the same scoping caveat (issue #473).
+ */
+export {}
+
+export default null as any

--- a/src/commands/install-github-app/types.ts
+++ b/src/commands/install-github-app/types.ts
@@ -1,0 +1,11 @@
+/**
+ * Stub — install-github-app types not included in source snapshot.
+ * See src/types/message.ts for the same scoping caveat (issue #473).
+ */
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+export type InstallGitHubAppState = any
+export type InstallGitHubAppStep = any
+export type State = any
+export type Warning = any
+export type Workflow = any

--- a/src/commands/peers/index.ts
+++ b/src/commands/peers/index.ts
@@ -1,0 +1,7 @@
+/**
+ * Stub — peers not included in source snapshot.
+ * See src/types/message.ts for the same scoping caveat (issue #473).
+ */
+export {}
+
+export default null as any

--- a/src/commands/plugin/types.ts
+++ b/src/commands/plugin/types.ts
@@ -1,0 +1,10 @@
+/**
+ * Stub — plugin types not included in source snapshot.
+ * See src/types/message.ts for the same scoping caveat (issue #473).
+ */
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+export type PluginEntry = any
+export type MarketplaceEntry = any
+export type PluginSettingsProps = any
+export type ViewState = any

--- a/src/commands/plugin/unifiedTypes.ts
+++ b/src/commands/plugin/unifiedTypes.ts
@@ -1,0 +1,8 @@
+/**
+ * Stub — unified plugin types not included in source snapshot.
+ * See src/types/message.ts for the same scoping caveat (issue #473).
+ */
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+export type UnifiedPluginEntry = any
+export type UnifiedInstalledItem = any

--- a/src/commands/workflows/index.ts
+++ b/src/commands/workflows/index.ts
@@ -1,0 +1,7 @@
+/**
+ * Stub — workflows not included in source snapshot.
+ * See src/types/message.ts for the same scoping caveat (issue #473).
+ */
+export {}
+
+export default null as any

--- a/src/components/FeedbackSurvey/useFrustrationDetection.ts
+++ b/src/components/FeedbackSurvey/useFrustrationDetection.ts
@@ -1,0 +1,2 @@
+/** Stub - not included in source snapshot. See issue #473. */
+export {}

--- a/src/components/FeedbackSurvey/utils.ts
+++ b/src/components/FeedbackSurvey/utils.ts
@@ -1,0 +1,9 @@
+/**
+ * Stub — FeedbackSurvey utils not included in source snapshot.
+ * See src/types/message.ts for the same scoping caveat (issue #473).
+ */
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+export function getSurveyType(): any { return null }
+export type FeedbackSurveyResponse = any
+export type FeedbackSurveyType = any

--- a/src/components/Spinner/types.ts
+++ b/src/components/Spinner/types.ts
@@ -1,0 +1,4 @@
+/** Stub - not included in source snapshot. See issue #473. */
+export {}
+export type RGBColor = any
+export type SpinnerMode = any

--- a/src/components/agents/SnapshotUpdateDialog.ts
+++ b/src/components/agents/SnapshotUpdateDialog.ts
@@ -1,0 +1,6 @@
+/** Stub - not included in source snapshot. See issue #473. */
+export {}
+
+export function buildMergePrompt(..._args: any[]): any { return null }
+
+export function SnapshotUpdateDialog(..._args: any[]): any { return null }

--- a/src/components/agents/new-agent-creation/types.ts
+++ b/src/components/agents/new-agent-creation/types.ts
@@ -1,0 +1,9 @@
+/**
+ * Stub — new-agent-creation types not included in source snapshot.
+ * See src/types/message.ts for the same scoping caveat (issue #473).
+ */
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+export type AgentCreationState = any
+export type AgentCreationStep = any
+export type AgentWizardData = any

--- a/src/components/mcp/types.ts
+++ b/src/components/mcp/types.ts
@@ -1,0 +1,14 @@
+/**
+ * Stub — mcp types not included in source snapshot.
+ * See src/types/message.ts for the same scoping caveat (issue #473).
+ */
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+export type McpPanelEntry = any
+export type AgentMcpServerInfo = any
+export type ClaudeAIServerInfo = any
+export type HTTPServerInfo = any
+export type MCPViewState = any
+export type SSEServerInfo = any
+export type ServerInfo = any
+export type StdioServerInfo = any

--- a/src/components/messages/SnipBoundaryMessage.ts
+++ b/src/components/messages/SnipBoundaryMessage.ts
@@ -1,0 +1,4 @@
+/** Stub - not included in source snapshot. See issue #473. */
+export {}
+
+export function SnipBoundaryMessage(..._args: any[]): any { return null }

--- a/src/components/messages/UserCrossSessionMessage.ts
+++ b/src/components/messages/UserCrossSessionMessage.ts
@@ -1,0 +1,4 @@
+/** Stub - not included in source snapshot. See issue #473. */
+export {}
+
+export function UserCrossSessionMessage(..._args: any[]): any { return null }

--- a/src/components/messages/UserForkBoilerplateMessage.ts
+++ b/src/components/messages/UserForkBoilerplateMessage.ts
@@ -1,0 +1,4 @@
+/** Stub - not included in source snapshot. See issue #473. */
+export {}
+
+export function UserForkBoilerplateMessage(..._args: any[]): any { return null }

--- a/src/components/messages/UserGitHubWebhookMessage.ts
+++ b/src/components/messages/UserGitHubWebhookMessage.ts
@@ -1,0 +1,4 @@
+/** Stub - not included in source snapshot. See issue #473. */
+export {}
+
+export function UserGitHubWebhookMessage(..._args: any[]): any { return null }

--- a/src/components/permissions/ReviewArtifactPermissionRequest/ReviewArtifactPermissionRequest.ts
+++ b/src/components/permissions/ReviewArtifactPermissionRequest/ReviewArtifactPermissionRequest.ts
@@ -1,0 +1,4 @@
+/** Stub - not included in source snapshot. See issue #473. */
+export {}
+
+export function ReviewArtifactPermissionRequest(..._args: any[]): any { return null }

--- a/src/components/tasks/MonitorMcpDetailDialog.ts
+++ b/src/components/tasks/MonitorMcpDetailDialog.ts
@@ -1,0 +1,4 @@
+/** Stub - not included in source snapshot. See issue #473. */
+export {}
+
+export function MonitorMcpDetailDialog(..._args: any[]): any { return null }

--- a/src/components/tasks/WorkflowDetailDialog.ts
+++ b/src/components/tasks/WorkflowDetailDialog.ts
@@ -1,0 +1,4 @@
+/** Stub - not included in source snapshot. See issue #473. */
+export {}
+
+export function WorkflowDetailDialog(..._args: any[]): any { return null }

--- a/src/components/ui/option.ts
+++ b/src/components/ui/option.ts
@@ -1,0 +1,3 @@
+/** Stub - not included in source snapshot. See issue #473. */
+export {}
+export type Option = any

--- a/src/components/wizard/types.ts
+++ b/src/components/wizard/types.ts
@@ -1,0 +1,11 @@
+/**
+ * Stub — wizard types not included in source snapshot.
+ * See src/types/message.ts for the same scoping caveat (issue #473).
+ */
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+export type WizardStep = any
+export type WizardState = any
+export type WizardContextValue<T = any> = any
+export type WizardProviderProps = any
+export type WizardStepComponent = any

--- a/src/daemon/main.ts
+++ b/src/daemon/main.ts
@@ -1,0 +1,4 @@
+/** Stub - not included in source snapshot. See issue #473. */
+export {}
+
+export function daemonMain(..._args: any[]): any { return null }

--- a/src/daemon/workerRegistry.ts
+++ b/src/daemon/workerRegistry.ts
@@ -1,0 +1,4 @@
+/** Stub - not included in source snapshot. See issue #473. */
+export {}
+
+export function runDaemonWorker(..._args: any[]): any { return null }

--- a/src/entrypoints/sdk/sdkUtilityTypes.ts
+++ b/src/entrypoints/sdk/sdkUtilityTypes.ts
@@ -1,0 +1,6 @@
+/**
+ * Stub — SDK utility types not included in source snapshot.
+ * See src/types/message.ts for the same scoping caveat (issue #473).
+ */
+export {}
+export type NonNullableUsage = any

--- a/src/entrypoints/sdk/settingsTypes.generated.ts
+++ b/src/entrypoints/sdk/settingsTypes.generated.ts
@@ -1,0 +1,7 @@
+/**
+ * Stub — generated settings types not included in source snapshot.
+ * See src/types/message.ts for the same scoping caveat (issue #473).
+ */
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+export type Settings = any

--- a/src/environment-runner/main.ts
+++ b/src/environment-runner/main.ts
@@ -1,0 +1,4 @@
+/** Stub - not included in source snapshot. See issue #473. */
+export {}
+
+export function environmentRunnerMain(..._args: any[]): any { return null }

--- a/src/hooks/notifs/useAntOrgWarningNotification.ts
+++ b/src/hooks/notifs/useAntOrgWarningNotification.ts
@@ -1,0 +1,2 @@
+/** Stub - not included in source snapshot. See issue #473. */
+export {}

--- a/src/ink/cursor.ts
+++ b/src/ink/cursor.ts
@@ -1,0 +1,3 @@
+/** Stub - not included in source snapshot. See issue #473. */
+export {}
+export type Cursor = any

--- a/src/ink/events/paste-event.ts
+++ b/src/ink/events/paste-event.ts
@@ -1,0 +1,3 @@
+/** Stub - not included in source snapshot. See issue #473. */
+export {}
+export type PasteEvent = any

--- a/src/ink/events/resize-event.ts
+++ b/src/ink/events/resize-event.ts
@@ -1,0 +1,3 @@
+/** Stub - not included in source snapshot. See issue #473. */
+export {}
+export type ResizeEvent = any

--- a/src/jobs/classifier.ts
+++ b/src/jobs/classifier.ts
@@ -1,0 +1,4 @@
+/** Stub - not included in source snapshot. See issue #473. */
+export {}
+
+export function classifyAndWriteState(..._args: any[]): any { return null }

--- a/src/memdir/memoryShapeTelemetry.ts
+++ b/src/memdir/memoryShapeTelemetry.ts
@@ -1,0 +1,6 @@
+/** Stub - not included in source snapshot. See issue #473. */
+export {}
+
+export function logMemoryRecallShape(..._args: any[]): any { return null }
+
+export function logMemoryWriteShape(..._args: any[]): any { return null }

--- a/src/proactive/index.ts
+++ b/src/proactive/index.ts
@@ -1,0 +1,11 @@
+/**
+ * Stub — proactive module not included in source snapshot.
+ * See src/types/message.ts for the same scoping caveat (issue #473).
+ */
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+export function isProactiveActive(): boolean { return false }
+export function isProactivePaused(): boolean { return false }
+export function activateProactive(_source?: string): void {}
+export function deactivateProactive(): void {}
+export const proactiveModule = null

--- a/src/query/transitions.ts
+++ b/src/query/transitions.ts
@@ -1,0 +1,4 @@
+/** Stub - not included in source snapshot. See issue #473. */
+export {}
+export type Continue = any
+export type Terminal = any

--- a/src/self-hosted-runner/main.ts
+++ b/src/self-hosted-runner/main.ts
@@ -1,0 +1,4 @@
+/** Stub - not included in source snapshot. See issue #473. */
+export {}
+
+export function selfHostedRunnerMain(..._args: any[]): any { return null }

--- a/src/server/backends/dangerousBackend.ts
+++ b/src/server/backends/dangerousBackend.ts
@@ -1,0 +1,4 @@
+/** Stub - not included in source snapshot. See issue #473. */
+export {}
+
+export function DangerousBackend(..._args: any[]): any { return null }

--- a/src/server/connectHeadless.ts
+++ b/src/server/connectHeadless.ts
@@ -1,0 +1,4 @@
+/** Stub - not included in source snapshot. See issue #473. */
+export {}
+
+export function runConnectHeadless(..._args: any[]): any { return null }

--- a/src/server/lockfile.ts
+++ b/src/server/lockfile.ts
@@ -1,0 +1,8 @@
+/** Stub - not included in source snapshot. See issue #473. */
+export {}
+
+export function probeRunningServer(..._args: any[]): any { return null }
+
+export function removeServerLock(..._args: any[]): any { return null }
+
+export function writeServerLock(..._args: any[]): any { return null }

--- a/src/server/parseConnectUrl.ts
+++ b/src/server/parseConnectUrl.ts
@@ -1,0 +1,4 @@
+/** Stub - not included in source snapshot. See issue #473. */
+export {}
+
+export function parseConnectUrl(..._args: any[]): any { return null }

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -1,0 +1,4 @@
+/** Stub - not included in source snapshot. See issue #473. */
+export {}
+
+export function startServer(..._args: any[]): any { return null }

--- a/src/server/serverBanner.ts
+++ b/src/server/serverBanner.ts
@@ -1,0 +1,4 @@
+/** Stub - not included in source snapshot. See issue #473. */
+export {}
+
+export function printBanner(..._args: any[]): any { return null }

--- a/src/server/serverLog.ts
+++ b/src/server/serverLog.ts
@@ -1,0 +1,4 @@
+/** Stub - not included in source snapshot. See issue #473. */
+export {}
+
+export function createServerLogger(..._args: any[]): any { return null }

--- a/src/server/sessionManager.ts
+++ b/src/server/sessionManager.ts
@@ -1,0 +1,4 @@
+/** Stub - not included in source snapshot. See issue #473. */
+export {}
+
+export function SessionManager(..._args: any[]): any { return null }

--- a/src/services/compact/cachedMCConfig.ts
+++ b/src/services/compact/cachedMCConfig.ts
@@ -1,0 +1,4 @@
+/** Stub - not included in source snapshot. See issue #473. */
+export {}
+
+export function getCachedMCConfig(..._args: any[]): any { return null }

--- a/src/services/compact/reactiveCompact.ts
+++ b/src/services/compact/reactiveCompact.ts
@@ -1,0 +1,17 @@
+/**
+ * Stub — reactiveCompact not included in source snapshot.
+ * See src/types/message.ts for the same scoping caveat (issue #473).
+ */
+export {}
+
+export function isReactiveCompactEnabled(..._args: any[]): any { return null }
+
+export function isReactiveOnlyMode(..._args: any[]): any { return null }
+
+export function isWithheldMediaSizeError(..._args: any[]): any { return null }
+
+export function isWithheldPromptTooLong(..._args: any[]): any { return null }
+
+export function reactiveCompactOnPromptTooLong(..._args: any[]): any { return null }
+
+export function tryReactiveCompact(..._args: any[]): any { return null }

--- a/src/services/compact/snipProjection.ts
+++ b/src/services/compact/snipProjection.ts
@@ -1,0 +1,6 @@
+/** Stub - not included in source snapshot. See issue #473. */
+export {}
+
+export function isSnipBoundaryMessage(..._args: any[]): any { return null }
+
+export function projectSnippedView(..._args: any[]): any { return null }

--- a/src/services/contextCollapse/operations.ts
+++ b/src/services/contextCollapse/operations.ts
@@ -1,0 +1,7 @@
+/**
+ * Stub — contextCollapse operations not included in source snapshot.
+ * See src/types/message.ts for the same scoping caveat (issue #473).
+ */
+export {}
+
+export function projectView(..._args: any[]): any { return null }

--- a/src/services/contextCollapse/persist.ts
+++ b/src/services/contextCollapse/persist.ts
@@ -1,0 +1,4 @@
+/** Stub - not included in source snapshot. See issue #473. */
+export {}
+
+export function restoreFromEntries(..._args: any[]): any { return null }

--- a/src/services/lsp/types.ts
+++ b/src/services/lsp/types.ts
@@ -1,0 +1,5 @@
+/** Stub - not included in source snapshot. See issue #473. */
+export {}
+export type LspServerConfig = any
+export type LspServerState = any
+export type ScopedLspServerConfig = any

--- a/src/services/oauth/types.ts
+++ b/src/services/oauth/types.ts
@@ -1,0 +1,17 @@
+/**
+ * Stub — OAuth type definitions not included in source snapshot.
+ * See src/types/message.ts for the same scoping caveat (issue #473).
+ */
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+export type OAuthTokens = any
+export type OAuthProfileResponse = any
+export type OAuthTokenExchangeResponse = any
+export type SubscriptionType = any
+export type BillingType = any
+export type RateLimitTier = any
+export type ReferralCampaign = any
+export type ReferralEligibilityResponse = any
+export type ReferralRedemptionsResponse = any
+export type ReferrerRewardInfo = any
+export type UserRolesResponse = any

--- a/src/services/sessionTranscript/sessionTranscript.ts
+++ b/src/services/sessionTranscript/sessionTranscript.ts
@@ -1,0 +1,6 @@
+/** Stub - not included in source snapshot. See issue #473. */
+export {}
+
+export function flushOnDateChange(..._args: any[]): any { return null }
+
+export function writeSessionTranscriptSegment(..._args: any[]): any { return null }

--- a/src/services/skillSearch/featureCheck.ts
+++ b/src/services/skillSearch/featureCheck.ts
@@ -1,0 +1,4 @@
+/** Stub - not included in source snapshot. See issue #473. */
+export {}
+
+export function isSkillSearchEnabled(..._args: any[]): any { return null }

--- a/src/services/skillSearch/localSearch.ts
+++ b/src/services/skillSearch/localSearch.ts
@@ -1,0 +1,7 @@
+/**
+ * Stub — skillSearch localSearch not included in source snapshot.
+ * See src/types/message.ts for the same scoping caveat (issue #473).
+ */
+export {}
+
+export function clearSkillIndexCache(..._args: any[]): any { return null }

--- a/src/services/skillSearch/prefetch.ts
+++ b/src/services/skillSearch/prefetch.ts
@@ -1,0 +1,8 @@
+/** Stub - not included in source snapshot. See issue #473. */
+export {}
+
+export function collectSkillDiscoveryPrefetch(..._args: any[]): any { return null }
+
+export function getTurnZeroSkillDiscovery(..._args: any[]): any { return null }
+
+export function startSkillDiscoveryPrefetch(..._args: any[]): any { return null }

--- a/src/services/skillSearch/remoteSkillLoader.ts
+++ b/src/services/skillSearch/remoteSkillLoader.ts
@@ -1,0 +1,2 @@
+/** Stub - not included in source snapshot. See issue #473. */
+export {}

--- a/src/services/skillSearch/remoteSkillState.ts
+++ b/src/services/skillSearch/remoteSkillState.ts
@@ -1,0 +1,2 @@
+/** Stub - not included in source snapshot. See issue #473. */
+export {}

--- a/src/services/skillSearch/signals.ts
+++ b/src/services/skillSearch/signals.ts
@@ -1,0 +1,3 @@
+/** Stub - not included in source snapshot. See issue #473. */
+export {}
+export type DiscoverySignal = any

--- a/src/services/skillSearch/telemetry.ts
+++ b/src/services/skillSearch/telemetry.ts
@@ -1,0 +1,2 @@
+/** Stub - not included in source snapshot. See issue #473. */
+export {}

--- a/src/services/tips/types.ts
+++ b/src/services/tips/types.ts
@@ -1,0 +1,4 @@
+/** Stub - not included in source snapshot. See issue #473. */
+export {}
+export type Tip = any
+export type TipContext = any

--- a/src/skills/mcpSkills.ts
+++ b/src/skills/mcpSkills.ts
@@ -1,0 +1,4 @@
+/** Stub - not included in source snapshot. See issue #473. */
+export {}
+
+export function fetchMcpSkillsForClient(..._args: any[]): any { return null }

--- a/src/ssh/SSHSessionManager.ts
+++ b/src/ssh/SSHSessionManager.ts
@@ -1,0 +1,3 @@
+/** Stub - not included in source snapshot. See issue #473. */
+export {}
+export type SSHSessionManager = any

--- a/src/ssh/createSSHSession.ts
+++ b/src/ssh/createSSHSession.ts
@@ -1,0 +1,9 @@
+/** Stub - not included in source snapshot. See issue #473. */
+export {}
+export type SSHSession = any
+
+export function SSHSessionError(..._args: any[]): any { return null }
+
+export function createLocalSSHSession(..._args: any[]): any { return null }
+
+export function createSSHSession(..._args: any[]): any { return null }

--- a/src/tasks/LocalWorkflowTask/LocalWorkflowTask.ts
+++ b/src/tasks/LocalWorkflowTask/LocalWorkflowTask.ts
@@ -1,0 +1,9 @@
+/** Stub - not included in source snapshot. See issue #473. */
+export {}
+export type LocalWorkflowTaskState = any
+
+export function killWorkflowTask(..._args: any[]): any { return null }
+
+export function retryWorkflowAgent(..._args: any[]): any { return null }
+
+export function skipWorkflowAgent(..._args: any[]): any { return null }

--- a/src/tools/DiscoverSkillsTool/prompt.ts
+++ b/src/tools/DiscoverSkillsTool/prompt.ts
@@ -1,0 +1,4 @@
+/** Stub - not included in source snapshot. See issue #473. */
+export {}
+
+export function DISCOVER_SKILLS_TOOL_NAME(..._args: any[]): any { return null }

--- a/src/tools/OverflowTestTool/OverflowTestTool.ts
+++ b/src/tools/OverflowTestTool/OverflowTestTool.ts
@@ -1,0 +1,4 @@
+/** Stub - not included in source snapshot. See issue #473. */
+export {}
+
+export function OVERFLOW_TEST_TOOL_NAME(..._args: any[]): any { return null }

--- a/src/tools/ReviewArtifactTool/ReviewArtifactTool.ts
+++ b/src/tools/ReviewArtifactTool/ReviewArtifactTool.ts
@@ -1,0 +1,4 @@
+/** Stub - not included in source snapshot. See issue #473. */
+export {}
+
+export function ReviewArtifactTool(..._args: any[]): any { return null }

--- a/src/tools/SendUserFileTool/prompt.ts
+++ b/src/tools/SendUserFileTool/prompt.ts
@@ -1,0 +1,4 @@
+/** Stub - not included in source snapshot. See issue #473. */
+export {}
+
+export function SEND_USER_FILE_TOOL_NAME(..._args: any[]): any { return null }

--- a/src/tools/SnipTool/prompt.ts
+++ b/src/tools/SnipTool/prompt.ts
@@ -1,0 +1,4 @@
+/** Stub - not included in source snapshot. See issue #473. */
+export {}
+
+export function SNIP_TOOL_NAME(..._args: any[]): any { return null }

--- a/src/tools/TerminalCaptureTool/prompt.ts
+++ b/src/tools/TerminalCaptureTool/prompt.ts
@@ -1,0 +1,4 @@
+/** Stub - not included in source snapshot. See issue #473. */
+export {}
+
+export function TERMINAL_CAPTURE_TOOL_NAME(..._args: any[]): any { return null }

--- a/src/tools/VerifyPlanExecutionTool/constants.ts
+++ b/src/tools/VerifyPlanExecutionTool/constants.ts
@@ -1,0 +1,4 @@
+/** Stub - not included in source snapshot. See issue #473. */
+export {}
+
+export function VERIFY_PLAN_EXECUTION_TOOL_NAME(..._args: any[]): any { return null }

--- a/src/tools/WebBrowserTool/WebBrowserPanel.ts
+++ b/src/tools/WebBrowserTool/WebBrowserPanel.ts
@@ -1,0 +1,4 @@
+/** Stub - not included in source snapshot. See issue #473. */
+export {}
+
+export function WebBrowserPanel(..._args: any[]): any { return null }

--- a/src/tools/WorkflowTool/WorkflowPermissionRequest.ts
+++ b/src/tools/WorkflowTool/WorkflowPermissionRequest.ts
@@ -1,0 +1,4 @@
+/** Stub - not included in source snapshot. See issue #473. */
+export {}
+
+export function WorkflowPermissionRequest(..._args: any[]): any { return null }

--- a/src/tools/WorkflowTool/WorkflowTool.ts
+++ b/src/tools/WorkflowTool/WorkflowTool.ts
@@ -1,0 +1,4 @@
+/** Stub - not included in source snapshot. See issue #473. */
+export {}
+
+export function WorkflowTool(..._args: any[]): any { return null }

--- a/src/tools/WorkflowTool/createWorkflowCommand.ts
+++ b/src/tools/WorkflowTool/createWorkflowCommand.ts
@@ -1,0 +1,7 @@
+/**
+ * Stub — WorkflowTool createWorkflowCommand not included in source snapshot.
+ * See src/types/message.ts for the same scoping caveat (issue #473).
+ */
+export {}
+
+export function getWorkflowCommands(..._args: any[]): any { return null }

--- a/src/types/claude-agent-sdk.d.ts
+++ b/src/types/claude-agent-sdk.d.ts
@@ -1,0 +1,9 @@
+/**
+ * Type declarations for @anthropic-ai/claude-agent-sdk
+ * Stub — package not included in source snapshot. See issue #473.
+ */
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+declare module '@anthropic-ai/claude-agent-sdk' {
+  export type PermissionMode = any
+}

--- a/src/types/env.d.ts
+++ b/src/types/env.d.ts
@@ -1,0 +1,53 @@
+/**
+ * Augment NodeJS.ProcessEnv to declare build-time variables.
+ * Without these declarations, TypeScript infers literal types from
+ * the build-time substitution values (e.g. "external"), causing
+ * TS2367 "unintentional comparison" errors on gating checks like
+ * `("external" as string) === 'ant'` which are meant for dead-code elimination.
+ */
+
+declare namespace NodeJS {
+  interface ProcessEnv {
+    USER_TYPE?: string
+  }
+}
+
+// PromiseWithResolvers was added in ES2023 but our target may not include it
+interface PromiseWithResolvers<T> {
+  promise: Promise<T>
+  resolve: (value: T | PromiseLike<T>) => void
+  reject: (reason?: any) => void
+}
+
+// Test globals (bun test)
+declare const describe: (name: string, fn: () => void) => void
+declare const test: (name: string, fn: () => void | Promise<void>) => void
+declare const it: (name: string, fn: () => void | Promise<void>) => void
+declare const expect: any
+declare const beforeEach: (fn: () => void | Promise<void>) => void
+declare const afterEach: (fn: () => void | Promise<void>) => void
+declare const beforeAll: (fn: () => void | Promise<void>) => void
+declare const afterAll: (fn: () => void | Promise<void>) => void
+
+// Internal-only names hoisted by React Compiler output or gated behind
+// build-time dead-code elimination (`"external" === 'ant'`). These are never
+// reached at runtime in the open-source build, but TypeScript needs them
+// resolved to type-check the dead branches.
+declare const GateOverridesWarning: any
+declare const ExperimentEnrollmentNotice: any
+declare const TungstenPill: any
+declare const Gates: any
+declare const UltraplanChoiceDialog: any
+declare const UltraplanLaunchDialog: any
+declare const launchUltraplan: any
+declare const apiMetricsRef: any
+declare const computeTtftText: any
+declare const assistantMessage: any
+declare const model: any
+declare const getSdkBetas: any
+declare const getContextWindowForModel: any
+declare const COMPACT_MAX_OUTPUT_TOKENS: any
+declare const resolveAntModel: any
+declare const getAntModelOverrideConfig: any
+declare const HOOK_TIMING_DISPLAY_THRESHOLD_MS: any
+declare function logForDebugging(...args: any[]): void

--- a/src/types/external-packages.d.ts
+++ b/src/types/external-packages.d.ts
@@ -1,0 +1,99 @@
+/**
+ * Type declarations for external packages not installed in this snapshot.
+ * See src/types/message.ts for the same scoping caveat (issue #473).
+ */
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+declare module '@ant/claude-for-chrome-mcp' {
+  export type BROWSER_TOOLS = any
+  export const BROWSER_TOOLS: any
+  export type ClaudeForChromeContext = any
+  export const ClaudeForChromeContext: any
+  export const createClaudeForChromeMcpServer: any
+  export type Logger = any
+  export const Logger: any
+  export type PermissionMode = any
+  export const PermissionMode: any
+}
+declare module '@ant/computer-use-input' {
+  export type ComputerUseInput = any
+  export const ComputerUseInput: any
+  export type ComputerUseInputAPI = any
+  export const ComputerUseInputAPI: any
+}
+declare module '@ant/computer-use-mcp' {
+  export type ComputerExecutor = any
+  export const ComputerExecutor: any
+  export type DisplayGeometry = any
+  export const DisplayGeometry: any
+  export type FrontmostApp = any
+  export const FrontmostApp: any
+  export type InstalledApp = any
+  export const InstalledApp: any
+  export type ResolvePrepareCaptureResult = any
+  export const ResolvePrepareCaptureResult: any
+  export type RunningApp = any
+  export const RunningApp: any
+  export type ScreenshotResult = any
+  export const ScreenshotResult: any
+  export type ScreenshotDims = any
+  export const ScreenshotDims: any
+  export const API_RESIZE_PARAMS: any
+  export const targetImageSize: any
+  export const buildComputerUseTools: any
+  export const createComputerUseMcpServer: any
+  export const bindSessionContext: any
+  export type CuPermissionResponse = any
+  export const CuPermissionResponse: any
+  export const DEFAULT_GRANT_FLAGS: any
+  export type ComputerUseSessionContext = any
+  export const ComputerUseSessionContext: any
+  export type CuCallToolResult = any
+  export const CuCallToolResult: any
+  export type CuPermissionRequest = any
+  export const CuPermissionRequest: any
+}
+declare module '@ant/computer-use-mcp/sentinelApps' {
+  export const sentinelApps: any[]
+}
+declare module '@ant/computer-use-mcp/types' {
+  export type SentinelApp = any
+}
+declare module '@ant/computer-use-swift' {
+  export type ComputerUseAPI = any
+  export const ComputerUseAPI: any
+}
+declare module '@anthropic-ai/mcpb' {
+  export type McpbManifest = any
+  export const McpbManifest: any
+  export type McpbUserConfigurationOption = any
+  export const McpbUserConfigurationOption: any
+}
+declare module '@aws-sdk/client-bedrock' {
+  export class BedrockClient { }
+  export const ListFoundationModelsCommand: any
+}
+declare module '@aws-sdk/client-sts' {
+  export class STSClient { }
+}
+declare module '@opentelemetry/exporter-logs-otlp-grpc' { export class OTLPLogExporter {} }
+declare module '@opentelemetry/exporter-logs-otlp-proto' { export class OTLPLogExporter {} }
+declare module '@opentelemetry/exporter-metrics-otlp-grpc' { export class OTLPMetricExporter {} }
+declare module '@opentelemetry/exporter-metrics-otlp-http' { export class OTLPMetricExporter {} }
+declare module '@opentelemetry/exporter-metrics-otlp-proto' { export class OTLPMetricExporter {} }
+declare module '@opentelemetry/exporter-prometheus' { export class PrometheusExporter {} }
+declare module '@opentelemetry/exporter-trace-otlp-http' { export class OTLPTraceExporter {} }
+declare module '@opentelemetry/exporter-trace-otlp-proto' { export class OTLPTraceExporter {} }
+declare module 'asciichart' { export function plot(data: number[], options?: any): string }
+declare module 'audio-capture-napi' {
+  const _: any
+  export default _
+  export function isNativeAudioAvailable(): boolean
+  export function isNativeRecordingActive(): boolean
+  export function startNativeRecording(): void
+  export function stopNativeRecording(): void
+}
+declare module 'cacache' { const _: any; export default _ }
+declare module 'image-processor-napi' { const _: any; export default _ }
+declare module 'plist' { export function parse(input: string): any; export function build(obj: any): string }
+declare module 'url-handler-napi' { const _: any; export default _ }

--- a/src/types/fileSuggestion.ts
+++ b/src/types/fileSuggestion.ts
@@ -1,0 +1,3 @@
+/** Stub - not included in source snapshot. See issue #473. */
+export {}
+export type FileSuggestionCommandInput = any

--- a/src/types/ink-elements.d.ts
+++ b/src/types/ink-elements.d.ts
@@ -1,0 +1,17 @@
+/**
+ * Augment React's JSX.IntrinsicElements with custom ink elements.
+ * These are native terminal UI elements rendered by the ink framework.
+ * With jsx: "react-jsx", TypeScript resolves JSX.IntrinsicElements from
+ * the react module, so we must augment that namespace rather than the
+ * global JSX namespace.
+ */
+import type {} from 'react'
+
+declare module 'react' {
+  namespace JSX {
+    interface IntrinsicElements {
+      'ink-box': any
+      'ink-text': any
+    }
+  }
+}

--- a/src/types/markdown-modules.d.ts
+++ b/src/types/markdown-modules.d.ts
@@ -1,0 +1,14 @@
+/**
+ * Type declarations for markdown file imports.
+ * The skills system imports .md files as string content.
+ */
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+declare module '*.md' {
+  const content: string
+  export default content
+}
+declare module '*SKILL.md' {
+  const content: string
+  export default content
+}

--- a/src/types/messageQueueTypes.ts
+++ b/src/types/messageQueueTypes.ts
@@ -1,0 +1,4 @@
+/** Stub - not included in source snapshot. See issue #473. */
+export {}
+export type QueueOperation = any
+export type QueueOperationMessage = any

--- a/src/types/notebook.ts
+++ b/src/types/notebook.ts
@@ -1,0 +1,9 @@
+/** Stub - not included in source snapshot. See issue #473. */
+export {}
+export type NotebookCell = any
+export type NotebookCellOutput = any
+export type NotebookCellSource = any
+export type NotebookCellSourceOutput = any
+export type NotebookCellType = any
+export type NotebookContent = any
+export type NotebookOutputImage = any

--- a/src/types/statusLine.ts
+++ b/src/types/statusLine.ts
@@ -1,0 +1,3 @@
+/** Stub - not included in source snapshot. See issue #473. */
+export {}
+export type StatusLineCommandInput = any

--- a/src/utils/attributionHooks.ts
+++ b/src/utils/attributionHooks.ts
@@ -1,0 +1,11 @@
+/**
+ * Stub — attributionHooks not included in source snapshot.
+ * See src/types/message.ts for the same scoping caveat (issue #473).
+ */
+export {}
+
+export function clearAttributionCaches(..._args: any[]): any { return null }
+
+export function registerAttributionHooks(..._args: any[]): any { return null }
+
+export function sweepFileContentCache(..._args: any[]): any { return null }

--- a/src/utils/attributionTrailer.ts
+++ b/src/utils/attributionTrailer.ts
@@ -1,0 +1,4 @@
+/** Stub - not included in source snapshot. See issue #473. */
+export {}
+
+export function buildPRTrailers(..._args: any[]): any { return null }

--- a/src/utils/ccshareResume.ts
+++ b/src/utils/ccshareResume.ts
@@ -1,0 +1,6 @@
+/** Stub - not included in source snapshot. See issue #473. */
+export {}
+
+export function loadCcshare(..._args: any[]): any { return null }
+
+export function parseCcshareId(..._args: any[]): any { return null }

--- a/src/utils/eventLoopStallDetector.ts
+++ b/src/utils/eventLoopStallDetector.ts
@@ -1,0 +1,4 @@
+/** Stub - not included in source snapshot. See issue #473. */
+export {}
+
+export function startEventLoopStallDetector(..._args: any[]): any { return null }

--- a/src/utils/postCommitAttribution.ts
+++ b/src/utils/postCommitAttribution.ts
@@ -1,0 +1,7 @@
+/**
+ * Stub — postCommitAttribution not included in source snapshot.
+ * See src/types/message.ts for the same scoping caveat (issue #473).
+ */
+export {}
+
+export function installPrepareCommitMsgHook(..._args: any[]): any { return null }

--- a/src/utils/sdkHeapDumpMonitor.ts
+++ b/src/utils/sdkHeapDumpMonitor.ts
@@ -1,0 +1,4 @@
+/** Stub - not included in source snapshot. See issue #473. */
+export {}
+
+export function startSdkMemoryMonitor(..._args: any[]): any { return null }

--- a/src/utils/sessionDataUploader.ts
+++ b/src/utils/sessionDataUploader.ts
@@ -1,0 +1,4 @@
+/** Stub - not included in source snapshot. See issue #473. */
+export {}
+
+export function createSessionTurnUploader(..._args: any[]): any { return null }

--- a/src/utils/systemThemeWatcher.ts
+++ b/src/utils/systemThemeWatcher.ts
@@ -1,0 +1,7 @@
+/**
+ * Stub — systemThemeWatcher not included in source snapshot.
+ * See src/types/message.ts for the same scoping caveat (issue #473).
+ */
+export {}
+
+export function watchSystemTheme(..._args: any[]): any { return null }

--- a/src/utils/taskSummary.ts
+++ b/src/utils/taskSummary.ts
@@ -1,0 +1,6 @@
+/** Stub - not included in source snapshot. See issue #473. */
+export {}
+
+export function maybeGenerateTaskSummary(..._args: any[]): any { return null }
+
+export function shouldGenerateTaskSummary(..._args: any[]): any { return null }

--- a/src/utils/udsClient.ts
+++ b/src/utils/udsClient.ts
@@ -1,0 +1,6 @@
+/** Stub - not included in source snapshot. See issue #473. */
+export {}
+
+export function listAllLiveSessions(..._args: any[]): any { return null }
+
+export function sendToUdsSocket(..._args: any[]): any { return null }

--- a/src/utils/udsMessaging.ts
+++ b/src/utils/udsMessaging.ts
@@ -1,0 +1,6 @@
+/** Stub - not included in source snapshot. See issue #473. */
+export {}
+
+export function getDefaultUdsSocketPath(..._args: any[]): any { return null }
+
+export function startUdsMessaging(..._args: any[]): any { return null }


### PR DESCRIPTION
## Summary
- Add TypeScript stub files for modules not included in the open-source snapshot (issue #473)
- Stubs provide minimal type-safe exports so the project compiles without the closed-source artifacts
- Files cover assistant, bridge, CLI handlers, commands, components, services, tools, utils, and infrastructure layers

## Test plan
- `tsc --noEmit` compiles successfully with stubs present