### PR TITLE
fix(web-search): surface diagnostic when adapter returns 0 hits with no native fallback

### DIFF
--- a/src/tools/WebSearchTool/WebSearchTool.test.ts
+++ b/src/tools/WebSearchTool/WebSearchTool.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, test } from 'bun:test'
+import type { ProviderOutput } from './providers/types.js'
+import { __test } from './WebSearchTool.js'
+
+const { buildEmptyAdapterResultHint, formatProviderOutputWithEmptyHint } = __test
+
+describe('buildEmptyAdapterResultHint', () => {
+  test('names the active provider and the failing backend', () => {
+    const msg = buildEmptyAdapterResultHint('minimax', 'duckduckgo')
+    expect(msg).toContain('minimax')
+    expect(msg).toContain('duckduckgo')
+  })
+
+  test('includes the actionable env-var list so the user can pick one', () => {
+    const msg = buildEmptyAdapterResultHint('moonshot', 'duckduckgo')
+    for (const key of [
+      'FIRECRAWL_API_KEY',
+      'TAVILY_API_KEY',
+      'EXA_API_KEY',
+      'JINA_API_KEY',
+      'BING_API_KEY',
+      'MOJEEK_API_KEY',
+      'LINKUP_API_KEY',
+      'YOU_API_KEY',
+    ]) {
+      expect(msg).toContain(key)
+    }
+  })
+
+  test('mentions the native-provider escape hatch', () => {
+    const msg = buildEmptyAdapterResultHint('nvidia-nim', 'duckduckgo')
+    expect(msg).toMatch(/Anthropic/)
+    expect(msg).toMatch(/Vertex/)
+    expect(msg).toMatch(/Foundry/)
+  })
+})
+
+describe('formatProviderOutputWithEmptyHint', () => {
+  test('replaces the empty placeholder with a diagnostic when 0 hits', () => {
+    const po: ProviderOutput = {
+      hits: [],
+      providerName: 'duckduckgo',
+      durationSeconds: 0.42,
+    }
+    const out = formatProviderOutputWithEmptyHint(po, 'cat facts', 'minimax')
+    expect(out.results.length).toBe(1)
+    expect(out.results[0]).toMatch(/^No results from "duckduckgo"/)
+    expect(out.durationSeconds).toBe(0.42)
+    expect(out.query).toBe('cat facts')
+  })
+
+  test('does not mutate the result when hits are present', () => {
+    const po: ProviderOutput = {
+      hits: [
+        {
+          title: 'Cats',
+          url: 'https://example.com/cats',
+          description: 'About cats.',
+        },
+      ],
+      providerName: 'duckduckgo',
+      durationSeconds: 1.2,
+    }
+    const out = formatProviderOutputWithEmptyHint(po, 'cat facts', 'minimax')
+    // hits-present case is delegated to the unmodified formatProviderOutput
+    // path, so the snippet block + tool_use_id are preserved.
+    expect(out.results.length).toBe(2)
+    expect(typeof out.results[0]).toBe('string')
+    expect(out.results[0]).toContain('Cats')
+    expect(out.results[0]).toContain('https://example.com/cats')
+  })
+})

--- a/src/tools/WebSearchTool/WebSearchTool.ts
+++ b/src/tools/WebSearchTool/WebSearchTool.ts
@@ -116,6 +116,32 @@ function formatProviderOutput(po: ProviderOutput, query: string): Output {
   }
 }
 
+function buildEmptyAdapterResultHint(provider: string, providerName: string): string {
+  return (
+    `No results from "${providerName}" search backend for provider "${provider}". ` +
+    `The default DuckDuckGo backend is rate-limited from many networks (datacenter IPs, VPNs, repeated requests) and returns 0 results when blocked. ` +
+    `For reliable web search on this provider, set one of: ` +
+    `FIRECRAWL_API_KEY, TAVILY_API_KEY, EXA_API_KEY, JINA_API_KEY, BING_API_KEY, MOJEEK_API_KEY, LINKUP_API_KEY, YOU_API_KEY — ` +
+    `or switch to an Anthropic / Vertex / Foundry provider that supports the native web_search tool.`
+  )
+}
+
+function formatProviderOutputWithEmptyHint(
+  po: ProviderOutput,
+  query: string,
+  provider: string,
+): Output {
+  const base = formatProviderOutput(po, query)
+  // Replace the "No results found." placeholder with a diagnostic hint when
+  // we know the next layer (native Anthropic web_search) will also produce
+  // 0 silently for this provider. Hits-present case is unchanged.
+  if (po.hits.length > 0) return base
+  return {
+    ...base,
+    results: [buildEmptyAdapterResultHint(provider, po.providerName)],
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Native Anthropic + Codex paths (unchanged, tightly coupled to SDK)
 // ---------------------------------------------------------------------------
@@ -326,6 +352,8 @@ function makeOutputFromCodexWebSearchResponse(
 
 export const __test = {
   makeOutputFromCodexWebSearchResponse,
+  buildEmptyAdapterResultHint,
+  formatProviderOutputWithEmptyHint,
 }
 
 async function runCodexWebSearch(
@@ -663,7 +691,24 @@ export const WebSearchTool = buildTool({
         if (isExplicitAdapter || providerOutput.hits.length > 0) {
           return { data: formatProviderOutput(providerOutput, input.query) }
         }
-        // Auto mode with 0 hits: fall through to native
+        // Auto mode with 0 hits: only fall through to native when a real
+        // native fallback exists. For openai-shim providers (minimax,
+        // moonshot, nvidia-nim, github copilot, etc.) the native path
+        // silently returns "Did 0 searches" because those providers do
+        // not support Anthropic's web_search_20250305 tool — same root
+        // cause as the catch branch below. Surface the empty result with
+        // an actionable note so users see why nothing came back.
+        if (!hasNativeSearchFallback()) {
+          return {
+            data: formatProviderOutputWithEmptyHint(
+              providerOutput,
+              input.query,
+              getAPIProvider(),
+            ),
+          }
+        }
+        // Auto mode + 0 hits + native fallback available: fall through to
+        // native (Anthropic/Vertex/Foundry/Codex) and let it try.
       } catch (err) {
         // Explicit adapter: throw the real error (no silent native fallback)
         if (isExplicitAdapter) throw err


### PR DESCRIPTION
## Summary

- For openai-shim providers (minimax, moonshot, nvidia-nim, github copilot, etc.) `hasNativeSearchFallback()` is false, so when the DuckDuckGo adapter returns 0 hits in auto mode the call() path silently falls through to the native Anthropic `web_search_20250305` tool. Those providers don't support that tool, producing a silent `Did 0 searches` with no signal that the default DDG backend is rate-limited or that no API-key backend is configured.
- Convert the silent fallthrough into an actionable result that names the active provider, the failing backend, and the env vars to set (`FIRECRAWL_API_KEY` / `TAVILY_API_KEY` / `EXA_API_KEY` / `JINA_API_KEY` / `BING_API_KEY` / `MOJEEK_API_KEY` / `LINKUP_API_KEY` / `YOU_API_KEY`) plus the native-provider escape hatch (Anthropic / Vertex / Foundry).
- Same root-cause family as the existing catch branch directly below — that already throws an actionable error for the throw-on-failure case; this matches it for the success-with-0-hits case.

## Impact

- user-facing impact: openai-shim provider users who hit a DDG rate-limit or have no paid backend configured now see a diagnostic naming the rate-limit and the env vars to set, instead of an unexplained `Did 0 searches`.
- developer/maintainer impact: small. New helpers `buildEmptyAdapterResultHint` and `formatProviderOutputWithEmptyHint` are file-local; exported under `__test` for unit coverage following the existing pattern in this file.

## Testing

- [x] `bun run build`
- [x] `bun run smoke`
- [x] focused tests:
  - `bun test src/tools/WebSearchTool/WebSearchTool.test.ts` → 5/5
  - `bun test src/tools/WebSearchTool/WebSearchTool.test.ts src/tools/WebSearchTool/providers/index.test.ts src/tools/WebSearchTool/providers/duckduckgo.test.ts src/tools/WebSearchTool/providers/types.test.ts src/tools/WebSearchTool/providers/custom.test.ts` → 83/83 (combined run, no mock-module surface leaks)

## Notes

- provider/model path tested: openai-shim path (auto mode + 0-hit adapter result + no native fallback) — verified via the new bun:test cases. Auto mode + native fallback available is unchanged: still falls through so Anthropic / Vertex / Foundry / Codex can serve the result. Explicit adapter mode is unchanged.
- This addresses the openai-shim share of #614 (e.g. `rebootclaw`'s Minimax report). Does **not** cover the Codex `responses` API path (the original reporter's setup) which routes through `runCodexWebSearch` — that has its own response-parsing semantics and warrants a separate look once a current-main repro lands.
- Related: #994 (DuckDuckGo rate-limit silent failure) — same code path, same diagnostic surface.

Fixes #614
