### PR TITLE
feat: auto-detect and persist project conventions to wiki

### DIFF
--- a/src/commands/wiki/index.ts
+++ b/src/commands/wiki/index.ts
@@ -4,7 +4,7 @@ const wiki = {
   type: 'local-jsx',
   name: 'wiki',
   description: 'Initialize and inspect the OpenClaude project wiki',
-  argumentHint: '[init|status]',
+  argumentHint: '[init|status|scan]',
   immediate: true,
   load: () => import('./wiki.js'),
 } satisfies Command

--- a/src/commands/wiki/index.ts
+++ b/src/commands/wiki/index.ts
@@ -4,7 +4,7 @@ const wiki = {
   type: 'local-jsx',
   name: 'wiki',
   description: 'Initialize and inspect the OpenClaude project wiki',
-  argumentHint: '[init|status|scan]',
+  argumentHint: '[init|status|scan|ingest <path>]',
   immediate: true,
   load: () => import('./wiki.js'),
 } satisfies Command

--- a/src/commands/wiki/wiki.tsx
+++ b/src/commands/wiki/wiki.tsx
@@ -3,6 +3,7 @@ import { COMMON_HELP_ARGS, COMMON_INFO_ARGS } from '../../constants/xml.js'
 import { ingestLocalWikiSource } from '../../services/wiki/ingest.js'
 import { initializeWiki } from '../../services/wiki/init.js'
 import { getWikiStatus } from '../../services/wiki/status.js'
+import { forceScanConventions } from '../../services/wiki/conventions.js'
 import type {
   LocalJSXCommandCall,
   LocalJSXCommandOnDone,
@@ -10,18 +11,20 @@ import type {
 import { getCwd } from '../../utils/cwd.js'
 
 function renderHelp(): string {
-  return `Usage: /wiki [init|status|ingest <path>]
+  return `Usage: /wiki [init|status|scan|ingest <path>]
 
 Manage the OpenClaude project wiki stored in .openclaude/wiki.
 
 Commands:
   /wiki init    Initialize the wiki structure in the current project
   /wiki status  Show wiki status and page/source counts
+  /wiki scan    Re-scan project conventions (build system, test framework, linting, etc.)
   /wiki ingest  Ingest a local file into wiki sources
 
 Examples:
   /wiki init
   /wiki status
+  /wiki scan
   /wiki ingest README.md`
 }
 
@@ -48,7 +51,7 @@ function formatStatus(status: Awaited<ReturnType<typeof getWikiStatus>>): string
     return `OpenClaude wiki is not initialized in this project.\n\nRun /wiki init to create ${status.root}.`
   }
 
-  return [
+  const lines = [
     'OpenClaude wiki status',
     '',
     `Root: ${status.root}`,
@@ -57,8 +60,15 @@ function formatStatus(status: Awaited<ReturnType<typeof getWikiStatus>>): string
     `Schema: ${status.hasSchema ? 'present' : 'missing'}`,
     `Index: ${status.hasIndex ? 'present' : 'missing'}`,
     `Log: ${status.hasLog ? 'present' : 'missing'}`,
+    `Conventions: ${status.hasConventions ? 'present' : 'not yet scanned'}`,
     `Last updated: ${status.lastUpdatedAt ?? 'unknown'}`,
-  ].join('\n')
+  ]
+
+  if (status.conventionsScannedAt) {
+    lines.push(`Conventions last scanned: ${status.conventionsScannedAt}`)
+  }
+
+  return lines.join('\n')
 }
 
 function formatIngestResult(
@@ -105,6 +115,21 @@ async function runWikiCommand(
     onDone(formatIngestResult(await ingestLocalWikiSource(cwd, pathArg)), {
       display: 'system',
     })
+    return
+  }
+
+  if (normalized === 'scan') {
+    const result = await forceScanConventions(cwd)
+    onDone(
+      [
+        'Project conventions scanned and saved.',
+        '',
+        result.markdown,
+        '',
+        '_Run `/wiki status` to verify._',
+      ].join('\n'),
+      { display: 'system' },
+    )
     return
   }
 

--- a/src/commands/wiki/wiki.tsx
+++ b/src/commands/wiki/wiki.tsx
@@ -120,6 +120,13 @@ async function runWikiCommand(
 
   if (normalized === 'scan') {
     const result = await forceScanConventions(cwd)
+    if (!result.saved) {
+      onDone(
+        'The wiki is not initialized yet. Run `/wiki init` first, then `/wiki scan`.',
+        { display: 'system' },
+      )
+      return
+    }
     onDone(
       [
         'Project conventions scanned and saved.',

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -416,6 +416,12 @@ export function startDeferredPrefetches(): void {
   }
   void countFilesRoundedRg(getCwd(), AbortSignal.timeout(3000), []);
 
+  // Project convention scanner — reads config files and persists to wiki.
+  // No-op if wiki isn't initialized (~1 stat call).
+  void import('./services/wiki/conventions.js').then(({ scanAndSaveConventions }) =>
+    scanAndSaveConventions(getCwd()),
+  );
+
   // Analytics and feature flag initialization
   void initializeAnalyticsGates();
   void prefetchOfficialMcpUrls();

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -446,9 +446,9 @@ export function startDeferredPrefetches(): void {
   // the trust dialog has been accepted — never before trust is established in
   // an interactive session. No-op if the wiki isn't initialized (~1 stat call).
   if (getIsNonInteractiveSession() || checkHasTrustDialogAccepted()) {
-    void import('./services/wiki/conventions.js').then(({ scanAndSaveConventions }) =>
-      scanAndSaveConventions(getCwd()),
-    );
+    void import('./services/wiki/conventions.js')
+      .then(({ scanAndSaveConventions }) => scanAndSaveConventions(getCwd()))
+      .catch(logError);
   }
 
   // Analytics and feature flag initialization

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -440,6 +440,12 @@ export function startDeferredPrefetches(): void {
     cleanupCountFilesSignal,
   );
 
+  // Project convention scanner — reads config files and persists to wiki.
+  // No-op if wiki isn't initialized (~1 stat call).
+  void import('./services/wiki/conventions.js').then(({ scanAndSaveConventions }) =>
+    scanAndSaveConventions(getCwd()),
+  );
+
   // Analytics and feature flag initialization
   void initializeAnalyticsGates();
   void prefetchOfficialMcpUrls();

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -440,11 +440,16 @@ export function startDeferredPrefetches(): void {
     cleanupCountFilesSignal,
   );
 
-  // Project convention scanner — reads config files and persists to wiki.
-  // No-op if wiki isn't initialized (~1 stat call).
-  void import('./services/wiki/conventions.js').then(({ scanAndSaveConventions }) =>
-    scanAndSaveConventions(getCwd()),
-  );
+  // Project convention scanner — reads config files and runs git (via project
+  // identity), then persists to the wiki. Gate on trust exactly like
+  // prefetchSystemContextIfSafe above: run when trust is implicit (--print) or
+  // the trust dialog has been accepted — never before trust is established in
+  // an interactive session. No-op if the wiki isn't initialized (~1 stat call).
+  if (getIsNonInteractiveSession() || checkHasTrustDialogAccepted()) {
+    void import('./services/wiki/conventions.js').then(({ scanAndSaveConventions }) =>
+      scanAndSaveConventions(getCwd()),
+    );
+  }
 
   // Analytics and feature flag initialization
   void initializeAnalyticsGates();

--- a/src/services/wiki/conventions.test.ts
+++ b/src/services/wiki/conventions.test.ts
@@ -1,0 +1,149 @@
+import { afterEach, expect, test } from 'bun:test'
+import { mkdtemp, mkdir, rm, writeFile } from 'fs/promises'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { scanProjectConventions } from './conventions.js'
+import { initializeWiki } from './init.js'
+import { getWikiPaths } from './paths.js'
+import { scanAndSaveConventions, forceScanConventions } from './conventions.js'
+
+const tempDirs: string[] = []
+
+afterEach(async () => {
+  await Promise.all(
+    tempDirs.splice(0).map(dir => rm(dir, { recursive: true, force: true })),
+  )
+})
+
+async function makeProjectDir(): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), 'openclaude-conventions-'))
+  tempDirs.push(dir)
+  return dir
+}
+
+test('scanProjectConventions detects package.json conventions', async () => {
+  const cwd = await makeProjectDir()
+  await writeFile(
+    join(cwd, 'package.json'),
+    JSON.stringify({
+      name: 'test-project',
+      scripts: { test: 'bun test', build: 'bun run build.ts' },
+      devDependencies: { vitest: '^1.0.0', typescript: '^5.0.0' },
+    }),
+    'utf8',
+  )
+  await writeFile(
+    join(cwd, 'tsconfig.json'),
+    JSON.stringify({
+      compilerOptions: {
+        target: 'ES2023',
+        module: 'ESNext',
+        strict: true,
+        jsx: 'react-jsx',
+      },
+    }),
+    'utf8',
+  )
+
+  const result = await scanProjectConventions(cwd)
+
+  expect(result.markdown).toContain('test-project')
+  expect(result.markdown).toContain('Package Manager')
+  expect(result.markdown).toContain('TypeScript Config')
+  expect(result.markdown).toContain('ES2023')
+  expect(result.markdown).toContain('vitest')
+  expect(result.markdown).toContain('ESNext')
+  expect(result.identity.name).toBe('test-project')
+  expect(result.fingerprint).toHaveLength(16)
+})
+
+test('scanProjectConventions handles project with no config files', async () => {
+  const cwd = await makeProjectDir()
+  const result = await scanProjectConventions(cwd)
+
+  // Should still return a markdown with the directory name
+  expect(result.markdown).toBeTruthy()
+  expect(result.sections).toHaveLength(0)
+  expect(result.identity.name).toBeTruthy()
+})
+
+test('scanProjectConventions detects ESLint config', async () => {
+  const cwd = await makeProjectDir()
+  await writeFile(
+    join(cwd, 'package.json'),
+    JSON.stringify({
+      name: 'lint-project',
+    }),
+    'utf8',
+  )
+  await writeFile(
+    join(cwd, '.eslintrc.json'),
+    JSON.stringify({
+      extends: ['eslint:recommended', 'plugin:@typescript-eslint/recommended'],
+      plugins: ['@typescript-eslint'],
+    }),
+    'utf8',
+  )
+
+  const result = await scanProjectConventions(cwd)
+  expect(result.markdown).toContain('ESLint Config')
+})
+
+test('scanAndSaveConventions creates conventions page in wiki', async () => {
+  const cwd = await makeProjectDir()
+  await initializeWiki(cwd)
+  await writeFile(
+    join(cwd, 'package.json'),
+    JSON.stringify({
+      name: 'wiki-project',
+      scripts: { test: 'bun test' },
+    }),
+    'utf8',
+  )
+
+  const result = await scanAndSaveConventions(cwd)
+  expect(result).not.toBeNull()
+  expect(result!.markdown).toContain('wiki-project')
+  expect(result!.fingerprint).toHaveLength(16)
+
+  // Verify it was written to the wiki
+  const paths = getWikiPaths(cwd)
+  const wikiContent = await Bun.file(paths.conventionsFile).text()
+  expect(wikiContent).toContain('wiki-project')
+})
+
+test('scanAndSaveConventions returns null on no change', async () => {
+  const cwd = await makeProjectDir()
+  await initializeWiki(cwd)
+  await writeFile(
+    join(cwd, 'package.json'),
+    JSON.stringify({
+      name: 'no-change',
+      scripts: { test: 'bun test' },
+    }),
+    'utf8',
+  )
+
+  const first = await scanAndSaveConventions(cwd)
+  expect(first).not.toBeNull()
+
+  const second = await scanAndSaveConventions(cwd)
+  expect(second).toBeNull()
+})
+
+test('forceScanConventions always returns result', async () => {
+  const cwd = await makeProjectDir()
+  await initializeWiki(cwd)
+  await writeFile(
+    join(cwd, 'package.json'),
+    JSON.stringify({ name: 'force-scan' }),
+    'utf8',
+  )
+
+  const first = await forceScanConventions(cwd)
+  expect(first).not.toBeNull()
+
+  const second = await forceScanConventions(cwd)
+  expect(second).not.toBeNull()
+  expect(second.fingerprint).toBe(first.fingerprint)
+})

--- a/src/services/wiki/conventions.test.ts
+++ b/src/services/wiki/conventions.test.ts
@@ -147,3 +147,63 @@ test('forceScanConventions always returns result', async () => {
   expect(second).not.toBeNull()
   expect(second.fingerprint).toBe(first.fingerprint)
 })
+
+// PR #1010 review fix #2: fingerprint must cover identity, not just config
+// sections, or an identity-only change leaves conventions.md stale.
+test('scanAndSaveConventions re-saves when only identity changes', async () => {
+  const cwd = await makeProjectDir()
+  await initializeWiki(cwd)
+  await writeFile(
+    join(cwd, 'package.json'),
+    JSON.stringify({ name: 'id-change', scripts: { test: 'bun test' } }),
+    'utf8',
+  )
+
+  const first = await scanAndSaveConventions(cwd)
+  expect(first).not.toBeNull()
+
+  // Identity-only change: a new source file shifts the language counts, but no
+  // scanned config section changes. The cache must still invalidate.
+  await writeFile(join(cwd, 'main.py'), 'print(1)\n', 'utf8')
+
+  const second = await scanAndSaveConventions(cwd)
+  expect(second).not.toBeNull()
+  expect(second!.fingerprint).not.toBe(first!.fingerprint)
+})
+
+// PR #1010 review fix #3: /wiki scan must not crash (ENOENT) before /wiki init.
+test('forceScanConventions does not write cache or throw before /wiki init', async () => {
+  const cwd = await makeProjectDir()
+  await writeFile(
+    join(cwd, 'package.json'),
+    JSON.stringify({ name: 'no-wiki' }),
+    'utf8',
+  )
+
+  // Must not throw even though .openclaude/ does not exist.
+  const result = await forceScanConventions(cwd)
+  expect(result.saved).toBe(false)
+
+  // The cache file must NOT have been created (its directory is missing).
+  const { conventionsCacheFile } = getWikiPaths(cwd)
+  expect(await Bun.file(conventionsCacheFile).exists()).toBe(false)
+})
+
+// PR #1010 integration fix #4: a saved scan reindexes so the conventions page
+// is listed in the wiki index (the index pipeline post-dates the original PR).
+test('scanAndSaveConventions reindexes so conventions appears in the wiki index', async () => {
+  const cwd = await makeProjectDir()
+  await initializeWiki(cwd)
+  await writeFile(
+    join(cwd, 'package.json'),
+    JSON.stringify({ name: 'indexed', scripts: { test: 'bun test' } }),
+    'utf8',
+  )
+
+  const result = await scanAndSaveConventions(cwd)
+  expect(result?.saved).toBe(true)
+
+  const { indexFile } = getWikiPaths(cwd)
+  const index = await Bun.file(indexFile).text()
+  expect(index).toContain('Project Conventions')
+})

--- a/src/services/wiki/conventions.ts
+++ b/src/services/wiki/conventions.ts
@@ -1,0 +1,428 @@
+import { createHash } from 'crypto'
+import { readFile, writeFile } from 'fs/promises'
+import { getWikiPaths } from './paths.js'
+import { getProjectIdentity } from './identity.js'
+import type { ConventionResult } from './types.js'
+
+// ─── Config File Detection ────────────────────────────────────────
+
+type Scanner = {
+  /** Relative file path(s) to check. First existing one wins. */
+  files: string[]
+  /** Extract conventions from the file content. Returns markdown bullet lines. */
+  extract: (content: string, filePath: string) => string[]
+  /** Human-readable section heading */
+  label: string
+}
+
+async function tryRead(
+  cwd: string,
+  ...paths: string[]
+): Promise<{ content: string; filePath: string } | null> {
+  for (const p of paths) {
+    try {
+      const content = await readFile(`${cwd}/${p}`, { encoding: 'utf-8' })
+      return { content, filePath: p }
+    } catch {
+      continue
+    }
+  }
+  return null
+}
+
+function extractPackageManager(content: string): string[] {
+  try {
+    const pkg = JSON.parse(content) as {
+      packageManager?: string
+      scripts?: Record<string, string>
+      devDependencies?: Record<string, string>
+      dependencies?: Record<string, string>
+    }
+    const lines: string[] = []
+
+    // Package manager detection
+    if (pkg.packageManager) {
+      lines.push(`- Package manager: **${pkg.packageManager}**`)
+    } else {
+      // Infer from lock file or common patterns
+      lines.push('- Package manager: (not explicitly declared)')
+    }
+
+    // Test framework
+    const allDeps = { ...pkg.devDependencies, ...pkg.dependencies }
+    const testFrameworks: string[] = []
+    if (allDeps?.vitest) testFrameworks.push('vitest')
+    if (allDeps?.jest) testFrameworks.push('jest')
+    if (allDeps?.mocha) testFrameworks.push('mocha')
+    if (allDeps?.ava) testFrameworks.push('ava')
+    if (allDeps?.tape) testFrameworks.push('tape')
+    if (allDeps?.uvu) testFrameworks.push('uvu')
+    if (testFrameworks.length > 0) {
+      lines.push(`- Test framework: **${testFrameworks.join(', ')}**`)
+    }
+
+    // Test script
+    if (pkg.scripts?.test) {
+      lines.push(`- Test command: \`${pkg.scripts.test}\``)
+    }
+
+    // Build script
+    if (pkg.scripts?.build) {
+      lines.push(`- Build command: \`${pkg.scripts.build}\``)
+    }
+
+    // TypeScript
+    if (allDeps?.typescript) {
+      lines.push('- TypeScript: **detected** (in devDependencies)')
+    }
+
+    // Lint
+    if (pkg.scripts?.lint) {
+      lines.push(`- Lint command: \`${pkg.scripts.lint}\``)
+    }
+    if (pkg.scripts?.['lint:fix']) {
+      lines.push(`- Lint fix command: \`${pkg.scripts['lint:fix']}\``)
+    }
+
+    // Format
+    if (pkg.scripts?.format) {
+      lines.push(`- Format command: \`${pkg.scripts.format}\``)
+    }
+
+    // Typecheck
+    if (pkg.scripts?.typecheck) {
+      lines.push(`- Typecheck command: \`${pkg.scripts.typecheck}\``)
+    }
+
+    return lines
+  } catch {
+    return ['- (unable to parse package.json)']
+  }
+}
+
+function extractTSConfig(content: string): string[] {
+  try {
+    const cfg = JSON.parse(content) as {
+      compilerOptions?: {
+        target?: string
+        module?: string
+        strict?: boolean
+        jsx?: string
+        moduleResolution?: string
+        outDir?: string
+      }
+    }
+    const opts = cfg.compilerOptions
+    if (!opts) return ['- (no compilerOptions)']
+    const lines: string[] = []
+    if (opts.target) lines.push(`- Target: **${opts.target}**`)
+    if (opts.module) lines.push(`- Module: **${opts.module}**`)
+    if (opts.moduleResolution)
+      lines.push(`- Module resolution: **${opts.moduleResolution}**`)
+    lines.push(`- Strict mode: **${opts.strict === false ? 'off' : 'on'}**`)
+    if (opts.jsx) lines.push(`- JSX: **${opts.jsx}**`)
+    if (opts.outDir) lines.push(`- Output: **${opts.outDir}**`)
+    return lines
+  } catch {
+    return ['- (unable to parse tsconfig.json)']
+  }
+}
+
+function extractESLintConfig(content: string, filePath: string): string[] {
+  const lines: string[] = []
+  try {
+    // ESLint 9 flat config
+    if (filePath.endsWith('.mjs') || content.includes('export default')) {
+      const pluginMatch = content.match(/from\s+['"](@[^'"]+\/eslint-plugin[^'"]*|eslint-plugin-[^'"]+)['"]/g)
+      if (pluginMatch) {
+        const plugins = [...new Set(pluginMatch.map(m => m.replace(/from\s+['"]/, '').replace(/['"]$/, '')))]
+        lines.push(`- Plugins: ${plugins.join(', ')}`)
+      }
+      if (content.includes('typescript-eslint') || content.includes('@typescript-eslint')) {
+        lines.push('- TypeScript ESLint: **enabled**')
+      }
+    } else {
+      // Legacy .eslintrc
+      try {
+        const cfg = JSON.parse(content) as {
+          extends?: string | string[]
+          plugins?: string[]
+          parser?: string
+        }
+        if (cfg.extends) {
+          const exts = Array.isArray(cfg.extends) ? cfg.extends : [cfg.extends]
+          if (exts.some(e => e.includes('typescript'))) {
+            lines.push('- TypeScript ESLint: **enabled**')
+          }
+        }
+        if (cfg.plugins?.length) {
+          lines.push(`- Plugins: ${cfg.plugins.join(', ')}`)
+        }
+      } catch {
+        // Raw JS config file — skip structured parsing
+      }
+    }
+  } catch {
+    // ignore
+  }
+  if (lines.length === 0) {
+    lines.push('- ESLint: **detected** (custom config)')
+  }
+  return lines
+}
+
+function extractPrettierConfig(content: string): string[] {
+  const lines: string[] = []
+  try {
+    const cfg = JSON.parse(content) as {
+      semi?: boolean
+      singleQuote?: boolean
+      tabWidth?: number
+      useTabs?: boolean
+      trailingComma?: string
+      printWidth?: number
+    }
+    if (cfg.semi !== undefined) lines.push(`- Semicolons: **${cfg.semi ? 'yes' : 'no'}**`)
+    if (cfg.singleQuote !== undefined) lines.push(`- Quotes: **${cfg.singleQuote ? 'single' : 'double'}**`)
+    if (cfg.tabWidth !== undefined) lines.push(`- Tab width: **${cfg.tabWidth}**`)
+    if (cfg.useTabs !== undefined) lines.push(`- Indent: **${cfg.useTabs ? 'tabs' : 'spaces'}**`)
+    if (cfg.trailingComma) lines.push(`- Trailing commas: **${cfg.trailingComma}**`)
+    if (cfg.printWidth) lines.push(`- Print width: **${cfg.printWidth}**`)
+  } catch {
+    lines.push('- Prettier: **detected** (custom config)')
+  }
+  return lines
+}
+
+function extractDockerfile(content: string): string[] {
+  const lines: string[] = []
+  const baseImage = content.match(/FROM\s+(\S+)/i)
+  if (baseImage) lines.push(`- Base image: \`${baseImage[1]}\``)
+  if (content.match(/EXPOSE\s+\d+/i)) lines.push('- Container exposes ports')
+  if (content.match(/MULTI-STAGE/i) || (content.match(/FROM\s+/gi)?.length ?? 0) > 1) {
+    lines.push('- Multi-stage build: **yes**')
+  }
+  return lines
+}
+
+const SCANNERS: Scanner[] = [
+  {
+    label: 'Package Manager & Scripts',
+    files: ['package.json'],
+    extract: content => extractPackageManager(content),
+  },
+  {
+    label: 'TypeScript Config',
+    files: ['tsconfig.json', 'tsconfig.app.json'],
+    extract: content => extractTSConfig(content),
+  },
+  {
+    label: 'ESLint Config',
+    files: [
+      'eslint.config.mjs',
+      'eslint.config.js',
+      '.eslintrc.json',
+      '.eslintrc.js',
+      '.eslintrc.yml',
+      '.eslintrc.yaml',
+    ],
+    extract: (content, filePath) => extractESLintConfig(content, filePath),
+  },
+  {
+    label: 'Prettier Config',
+    files: ['.prettierrc', '.prettierrc.json', '.prettierrc.js', '.prettierrc.yaml', '.prettierrc.yml', 'prettier.config.js'],
+    extract: content => extractPrettierConfig(content),
+  },
+  {
+    label: 'Docker',
+    files: ['Dockerfile', 'docker-compose.yml', 'docker-compose.yaml'],
+    extract: content => extractDockerfile(content),
+  },
+  {
+    label: 'CI/CD',
+    files: ['.github/workflows/pr-checks.yml', '.github/workflows/ci.yml', '.github/workflows/test.yml'],
+    extract: content => {
+      const lines: string[] = []
+      const name = content.match(/name:\s*(.+)/)
+      if (name) lines.push(`- Pipeline: **${name[1]}**`)
+      if (content.includes('on:')) lines.push('- Trigger: CI workflow defined')
+      return lines.length > 0 ? lines : ['- CI: **detected** (GitHub Actions)']
+    },
+  },
+  {
+    label: 'Lockfile',
+    files: ['bun.lock', 'bun.lockb', 'package-lock.json', 'yarn.lock', 'pnpm-lock.yaml'],
+    extract: (_, filePath) => {
+      const lockMap: Record<string, string> = {
+        'bun.lock': 'bun',
+        'bun.lockb': 'bun',
+        'package-lock.json': 'npm',
+        'yarn.lock': 'yarn',
+        'pnpm-lock.yaml': 'pnpm',
+      }
+      const pm = Object.entries(lockMap).find(([key]) => filePath.endsWith(key))
+      return pm ? [`- Lockfile: **${pm[1]}** (${filePath})`] : []
+    },
+  },
+]
+
+// ─── Fingerprint ──────────────────────────────────────────────────
+
+function computeFingerprint(results: { label: string; lines: string[] }[]): string {
+  const hash = createHash('sha256')
+  for (const r of results) {
+    hash.update(r.label)
+    for (const line of r.lines) {
+      hash.update(line)
+    }
+  }
+  return hash.digest('hex').slice(0, 16)
+}
+
+// ─── Main Scan ────────────────────────────────────────────────────
+
+export type ScanResult = {
+  sections: { label: string; lines: string[] }[]
+  markdown: string
+  fingerprint: string
+  identity: ReturnType<typeof getProjectIdentity>
+}
+
+/**
+ * Scan the project for conventions by reading config files.
+ * Returns structured results and a markdown summary.
+ */
+export async function scanProjectConventions(cwd: string): Promise<ScanResult> {
+  const identity = getProjectIdentity(cwd)
+  const sections: { label: string; lines: string[] }[] = []
+
+  for (const scanner of SCANNERS) {
+    const file = await tryRead(cwd, ...scanner.files)
+    if (file) {
+      const lines = scanner.extract(file.content, file.filePath)
+      if (lines.length > 0) {
+        sections.push({ label: scanner.label, lines })
+      }
+    }
+  }
+
+  const markdown = formatConventions(identity, sections)
+  const fingerprint = computeFingerprint(sections)
+
+  return { sections, markdown, fingerprint, identity }
+}
+
+function formatConventions(
+  identity: ReturnType<typeof getProjectIdentity>,
+  sections: { label: string; lines: string[] }[],
+): string {
+  const parts: string[] = [
+    '# Project Conventions',
+    '',
+    `Auto-detected conventions for **${identity.name}**.`,
+    `Last scanned: ${new Date().toISOString()}`,
+    '',
+  ]
+
+  // Language summary
+  if (identity.languages.length > 0) {
+    parts.push(
+      '## Languages',
+      '',
+      ...identity.languages.map(l => `- **${l.name}**: ${l.fileCount} files`),
+      '',
+    )
+  }
+
+  // Monorepo
+  if (identity.isMonorepo) {
+    parts.push('', '> **Monorepo**: workspaces detected.', '')
+  }
+
+  // Git
+  parts.push('', '## Git', '', `- Default branch: **${identity.mainBranch}**`, '')
+
+  // Detected conventions
+  for (const section of sections) {
+    parts.push(`## ${section.label}`, '', ...section.lines, '')
+  }
+
+  parts.push('---', '', '_This page is auto-generated. Run `/wiki scan` to refresh._', '')
+
+  return parts.join('\n')
+}
+
+// ─── Cache ─────────────────────────────────────────────────────────
+
+type CacheEntry = {
+  fingerprint: string
+  scannedAt: string
+}
+
+async function readCache(cwd: string): Promise<CacheEntry | null> {
+  const { conventionsCacheFile } = getWikiPaths(cwd)
+  try {
+    const raw = await readFile(conventionsCacheFile, { encoding: 'utf-8' })
+    return JSON.parse(raw) as CacheEntry
+  } catch {
+    return null
+  }
+}
+
+async function writeCache(cwd: string, fingerprint: string): Promise<void> {
+  const { conventionsCacheFile } = getWikiPaths(cwd)
+  const entry: CacheEntry = { fingerprint, scannedAt: new Date().toISOString() }
+  await writeFile(conventionsCacheFile, JSON.stringify(entry, null, 2), { encoding: 'utf-8' })
+}
+
+/**
+ * Scan and save conventions to the wiki if they've changed.
+ * Returns the convention result if updated, or null if unchanged.
+ */
+export async function scanAndSaveConventions(cwd: string): Promise<ConventionResult | null> {
+  const scan = await scanProjectConventions(cwd)
+  const cached = await readCache(cwd)
+
+  if (cached?.fingerprint === scan.fingerprint) {
+    return null // No change
+  }
+
+  // Write the convention page to the wiki
+  const { conventionsFile } = getWikiPaths(cwd)
+  try {
+    await writeFile(conventionsFile, scan.markdown, { encoding: 'utf-8' })
+  } catch {
+    // Wiki may not be initialized — silently skip
+    return null
+  }
+
+  await writeCache(cwd, scan.fingerprint)
+
+  return {
+    markdown: scan.markdown,
+    fingerprint: scan.fingerprint,
+    scannedAt: new Date().toISOString(),
+  }
+}
+
+/**
+ * Force re-scan and return the result without caching.
+ */
+export async function forceScanConventions(cwd: string): Promise<ConventionResult> {
+  const scan = await scanProjectConventions(cwd)
+  const { conventionsFile } = getWikiPaths(cwd)
+
+  try {
+    await writeFile(conventionsFile, scan.markdown, { encoding: 'utf-8' })
+  } catch {
+    // Wiki not initialized — result still returned
+  }
+
+  await writeCache(cwd, scan.fingerprint)
+
+  return {
+    markdown: scan.markdown,
+    fingerprint: scan.fingerprint,
+    scannedAt: new Date().toISOString(),
+  }
+}

--- a/src/services/wiki/conventions.ts
+++ b/src/services/wiki/conventions.ts
@@ -1,7 +1,8 @@
 import { createHash } from 'crypto'
 import { readFile, writeFile } from 'fs/promises'
 import { getWikiPaths } from './paths.js'
-import { getProjectIdentity } from './identity.js'
+import { getProjectIdentity, type ProjectIdentity } from './identity.js'
+import { rebuildWikiIndex } from './indexBuilder.js'
 import type { ConventionResult } from './types.js'
 
 // ─── Config File Detection ────────────────────────────────────────
@@ -268,8 +269,21 @@ const SCANNERS: Scanner[] = [
 
 // ─── Fingerprint ──────────────────────────────────────────────────
 
-function computeFingerprint(results: { label: string; lines: string[] }[]): string {
+function computeFingerprint(
+  identity: ProjectIdentity,
+  results: { label: string; lines: string[] }[],
+): string {
   const hash = createHash('sha256')
+  // Identity fields are rendered into the page (name, languages, monorepo,
+  // default branch), so a change in any of them must invalidate the cache even
+  // when the detected config sections are unchanged. (We can't just hash the
+  // final markdown — it embeds a "Last scanned" timestamp that always differs.)
+  hash.update(identity.name)
+  hash.update(identity.isMonorepo ? 'mono' : 'single')
+  hash.update(identity.mainBranch)
+  for (const lang of identity.languages) {
+    hash.update(`${lang.name}:${lang.fileCount}`)
+  }
   for (const r of results) {
     hash.update(r.label)
     for (const line of r.lines) {
@@ -307,7 +321,7 @@ export async function scanProjectConventions(cwd: string): Promise<ScanResult> {
   }
 
   const markdown = formatConventions(identity, sections)
-  const fingerprint = computeFingerprint(sections)
+  const fingerprint = computeFingerprint(identity, sections)
 
   return { sections, markdown, fingerprint, identity }
 }
@@ -397,11 +411,14 @@ export async function scanAndSaveConventions(cwd: string): Promise<ConventionRes
   }
 
   await writeCache(cwd, scan.fingerprint)
+  // Reindex so the (possibly new) conventions page is listed in the wiki index.
+  await rebuildWikiIndex(cwd).catch(() => {})
 
   return {
     markdown: scan.markdown,
     fingerprint: scan.fingerprint,
     scannedAt: new Date().toISOString(),
+    saved: true,
   }
 }
 
@@ -412,17 +429,27 @@ export async function forceScanConventions(cwd: string): Promise<ConventionResul
   const scan = await scanProjectConventions(cwd)
   const { conventionsFile } = getWikiPaths(cwd)
 
+  let saved = false
   try {
     await writeFile(conventionsFile, scan.markdown, { encoding: 'utf-8' })
+    saved = true
   } catch {
-    // Wiki not initialized — result still returned
+    // Wiki not initialized (.openclaude/wiki is missing). Don't touch the cache
+    // file below — its directory is missing too and writeFile would throw
+    // ENOENT, crashing `/wiki scan`. The caller surfaces a "run /wiki init"
+    // message based on `saved`.
   }
 
-  await writeCache(cwd, scan.fingerprint)
+  if (saved) {
+    await writeCache(cwd, scan.fingerprint)
+    // Reindex so the (possibly new) conventions page is listed in the index.
+    await rebuildWikiIndex(cwd).catch(() => {})
+  }
 
   return {
     markdown: scan.markdown,
     fingerprint: scan.fingerprint,
     scannedAt: new Date().toISOString(),
+    saved,
   }
 }

--- a/src/services/wiki/conventions.ts
+++ b/src/services/wiki/conventions.ts
@@ -299,7 +299,7 @@ export type ScanResult = {
   sections: { label: string; lines: string[] }[]
   markdown: string
   fingerprint: string
-  identity: ReturnType<typeof getProjectIdentity>
+  identity: ProjectIdentity
 }
 
 /**
@@ -307,7 +307,7 @@ export type ScanResult = {
  * Returns structured results and a markdown summary.
  */
 export async function scanProjectConventions(cwd: string): Promise<ScanResult> {
-  const identity = getProjectIdentity(cwd)
+  const identity = await getProjectIdentity(cwd)
   const sections: { label: string; lines: string[] }[] = []
 
   for (const scanner of SCANNERS) {
@@ -327,7 +327,7 @@ export async function scanProjectConventions(cwd: string): Promise<ScanResult> {
 }
 
 function formatConventions(
-  identity: ReturnType<typeof getProjectIdentity>,
+  identity: ProjectIdentity,
   sections: { label: string; lines: string[] }[],
 ): string {
   const parts: string[] = [
@@ -405,9 +405,13 @@ export async function scanAndSaveConventions(cwd: string): Promise<ConventionRes
   const { conventionsFile } = getWikiPaths(cwd)
   try {
     await writeFile(conventionsFile, scan.markdown, { encoding: 'utf-8' })
-  } catch {
-    // Wiki may not be initialized — silently skip
-    return null
+  } catch (error) {
+    // Only a missing wiki (ENOENT) is an expected "not initialized" skip;
+    // surface real failures (EACCES, EROFS, …) instead of masking them.
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+      return null
+    }
+    throw error
   }
 
   await writeCache(cwd, scan.fingerprint)
@@ -433,11 +437,14 @@ export async function forceScanConventions(cwd: string): Promise<ConventionResul
   try {
     await writeFile(conventionsFile, scan.markdown, { encoding: 'utf-8' })
     saved = true
-  } catch {
-    // Wiki not initialized (.openclaude/wiki is missing). Don't touch the cache
-    // file below — its directory is missing too and writeFile would throw
-    // ENOENT, crashing `/wiki scan`. The caller surfaces a "run /wiki init"
-    // message based on `saved`.
+  } catch (error) {
+    // Only ENOENT means the wiki isn't initialized — leave saved=false so the
+    // cache write below is skipped (its dir is missing too) and the caller
+    // surfaces a "run /wiki init" message. Surface any other failure
+    // (EACCES, EROFS, …) instead of masking it as "not initialized".
+    if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
+      throw error
+    }
   }
 
   if (saved) {

--- a/src/services/wiki/identity.ts
+++ b/src/services/wiki/identity.ts
@@ -1,0 +1,128 @@
+import { execFileSync } from 'child_process'
+import { basename } from 'path'
+import { getFsImplementation } from '../../utils/fsOperations.js'
+
+export type ProjectIdentity = {
+  name: string
+  /** Detected primary languages sorted by file count descending */
+  languages: { name: string; fileCount: number }[]
+  /** Whether the project uses npm workspaces or similar */
+  isMonorepo: boolean
+  /** Main/default branch name (usually "main" or "master") */
+  mainBranch: string
+}
+
+/**
+ * Detect primary languages in the project by counting source files.
+ * Uses a sync glob-like approach (readdir + extension check) for speed.
+ * Limit to 3 most common for brevity in context.
+ */
+function detectLanguages(cwd: string): { name: string; fileCount: number }[] {
+  const fs = getFsImplementation()
+  const counts: Record<string, number> = {}
+  const EXTENSION_MAP: Record<string, string> = {
+    '.ts': 'TypeScript',
+    '.tsx': 'TypeScript',
+    '.js': 'JavaScript',
+    '.jsx': 'JavaScript',
+    '.mjs': 'JavaScript',
+    '.cjs': 'JavaScript',
+    '.py': 'Python',
+    '.go': 'Go',
+    '.rs': 'Rust',
+    '.rb': 'Ruby',
+    '.java': 'Java',
+    '.kt': 'Kotlin',
+    '.cs': 'C#',
+    '.swift': 'Swift',
+    '.c': 'C',
+    '.cpp': 'C++',
+    '.h': 'C/C++ Header',
+    '.hpp': 'C++ Header',
+  }
+
+  try {
+    const entries = fs.readdirSync(cwd)
+    for (const entry of entries) {
+      if (!entry.isFile()) continue
+      const ext = entry.name.slice(entry.name.lastIndexOf('.')).toLowerCase()
+      const lang = EXTENSION_MAP[ext]
+      if (lang) {
+        counts[lang] = (counts[lang] ?? 0) + 1
+      }
+    }
+  } catch {
+    // Directory not readable — skip
+  }
+
+  return Object.entries(counts)
+    .map(([name, fileCount]) => ({ name, fileCount }))
+    .sort((a, b) => b.fileCount - a.fileCount)
+    .slice(0, 3)
+}
+
+/**
+ * Detect whether the project is a monorepo by checking for workspace config.
+ * Handles npm/pnpm/yarn workspaces and bun workspaces.
+ */
+function detectMonorepo(cwd: string): boolean {
+  const fs = getFsImplementation()
+  const pkgPath = `${cwd}/package.json`
+  try {
+    const raw = fs.readFileSync(pkgPath, { encoding: 'utf-8' })
+    const pkg = JSON.parse(raw) as Record<string, unknown>
+    if (pkg.workspaces) return true
+  } catch {
+    // No package.json or invalid JSON
+  }
+
+  // Check for pnpm workspace
+  try {
+    fs.readFileSync(`${cwd}/pnpm-workspace.yaml`, { encoding: 'utf-8' })
+    return true
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Detect the main branch name from git.
+ */
+function detectMainBranch(cwd: string): string {
+  try {
+    const output = execFileSync('git', ['symbolic-ref', 'refs/remotes/origin/HEAD'], {
+      cwd,
+      encoding: 'utf-8',
+      timeout: 2000,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    }) as string
+    return output.trim().replace('refs/remotes/origin/', '')
+  } catch {
+    return 'main'
+  }
+}
+
+/**
+ * Build a project identity fingerprint.
+ */
+export function getProjectIdentity(cwd: string): ProjectIdentity {
+  let name = basename(cwd)
+
+  const fs = getFsImplementation()
+  try {
+    const raw = fs.readFileSync(`${cwd}/package.json`, { encoding: 'utf-8' })
+    const pkg = JSON.parse(raw) as { name?: string }
+    if (pkg.name) {
+      name = pkg.name
+    }
+  } catch {
+    // No package.json — use directory name
+  }
+
+  return {
+    name,
+    languages: detectLanguages(cwd),
+    isMonorepo: detectMonorepo(cwd),
+    mainBranch: detectMainBranch(cwd),
+  }
+}

--- a/src/services/wiki/identity.ts
+++ b/src/services/wiki/identity.ts
@@ -1,5 +1,5 @@
-import { execFileSync } from 'child_process'
 import { basename } from 'path'
+import { execa } from 'execa'
 import { getFsImplementation } from '../../utils/fsOperations.js'
 
 export type ProjectIdentity = {
@@ -86,17 +86,20 @@ function detectMonorepo(cwd: string): boolean {
 }
 
 /**
- * Detect the main branch name from git.
+ * Detect the main branch name from git. Uses async execa (the service-layer
+ * subprocess convention) so the startup scan never blocks the event loop.
  */
-function detectMainBranch(cwd: string): string {
+async function detectMainBranch(cwd: string): Promise<string> {
   try {
-    const output = execFileSync('git', ['symbolic-ref', 'refs/remotes/origin/HEAD'], {
-      cwd,
-      encoding: 'utf-8',
-      timeout: 2000,
-      stdio: ['ignore', 'pipe', 'pipe'],
-    }) as string
-    return output.trim().replace('refs/remotes/origin/', '')
+    const result = await execa(
+      'git',
+      ['symbolic-ref', 'refs/remotes/origin/HEAD'],
+      { cwd, timeout: 2000, stdin: 'ignore', reject: false },
+    )
+    if (result.failed || typeof result.stdout !== 'string') {
+      return 'main'
+    }
+    return result.stdout.trim().replace('refs/remotes/origin/', '') || 'main'
   } catch {
     return 'main'
   }
@@ -105,7 +108,7 @@ function detectMainBranch(cwd: string): string {
 /**
  * Build a project identity fingerprint.
  */
-export function getProjectIdentity(cwd: string): ProjectIdentity {
+export async function getProjectIdentity(cwd: string): Promise<ProjectIdentity> {
   let name = basename(cwd)
 
   const fs = getFsImplementation()
@@ -123,6 +126,6 @@ export function getProjectIdentity(cwd: string): ProjectIdentity {
     name,
     languages: detectLanguages(cwd),
     isMonorepo: detectMonorepo(cwd),
-    mainBranch: detectMainBranch(cwd),
+    mainBranch: await detectMainBranch(cwd),
   }
 }

--- a/src/services/wiki/init.test.ts
+++ b/src/services/wiki/init.test.ts
@@ -30,6 +30,7 @@ test('initializeWiki creates the expected wiki scaffold', async () => {
     join('.openclaude', 'wiki', 'index.md'),
     join('.openclaude', 'wiki', 'log.md'),
     join('.openclaude', 'wiki', 'pages', 'architecture.md'),
+    join('.openclaude', 'wiki', 'pages', 'conventions.md'),
   ])
   expect(await readFile(paths.schemaFile, 'utf8')).toContain(
     '# OpenClaude Wiki Schema',
@@ -40,6 +41,9 @@ test('initializeWiki creates the expected wiki scaffold', async () => {
   )
   expect(await readFile(join(paths.pagesDir, 'architecture.md'), 'utf8')).toContain(
     '# Architecture',
+  )
+  expect(await readFile(paths.conventionsFile, 'utf8')).toContain(
+    '# Project Conventions',
   )
 })
 

--- a/src/services/wiki/init.ts
+++ b/src/services/wiki/init.ts
@@ -88,6 +88,33 @@ High-level architecture notes for ${projectName}.
 `
 }
 
+function buildConventionsTemplate(projectName: string): string {
+  return `# Project Conventions
+
+Auto-detected conventions for ${projectName}.
+
+## Build System
+
+- Detected on first scan.
+
+## Test Framework
+
+- Detected on first scan.
+
+## Package Manager
+
+- Detected on first scan.
+
+## Linting & Formatting
+
+- Detected on first scan.
+
+## Related
+
+- Run \`/wiki scan\` to re-scan project conventions.
+`
+}
+
 async function ensureFile(
   filePath: string,
   content: string,
@@ -128,6 +155,11 @@ export async function initializeWiki(cwd: string): Promise<WikiInitResult> {
   await ensureFile(
     `${paths.pagesDir}/architecture.md`,
     buildArchitectureTemplate(projectName),
+    createdFiles,
+  )
+  await ensureFile(
+    paths.conventionsFile,
+    buildConventionsTemplate(projectName),
     createdFiles,
   )
 

--- a/src/services/wiki/paths.ts
+++ b/src/services/wiki/paths.ts
@@ -14,5 +14,7 @@ export function getWikiPaths(cwd: string): WikiPaths {
     schemaFile: join(root, 'schema.md'),
     indexFile: join(root, 'index.md'),
     logFile: join(root, 'log.md'),
+    conventionsFile: join(root, 'pages', 'conventions.md'),
+    conventionsCacheFile: join(cwd, OPENCLAUDE_DIRNAME, '.conventions-cache.json'),
   }
 }

--- a/src/services/wiki/status.test.ts
+++ b/src/services/wiki/status.test.ts
@@ -27,6 +27,8 @@ test('getWikiStatus reports uninitialized wiki state', async () => {
   expect(status.initialized).toBe(false)
   expect(status.pageCount).toBe(0)
   expect(status.sourceCount).toBe(0)
+  expect(status.hasConventions).toBe(false)
+  expect(status.conventionsScannedAt).toBeNull()
   expect(status.lastUpdatedAt).toBeNull()
 })
 
@@ -46,10 +48,12 @@ test('getWikiStatus counts pages and sources for initialized wiki', async () => 
   const status = await getWikiStatus(cwd)
 
   expect(status.initialized).toBe(true)
-  expect(status.pageCount).toBe(2)
+  expect(status.pageCount).toBe(3)
   expect(status.sourceCount).toBe(1)
   expect(status.hasSchema).toBe(true)
   expect(status.hasIndex).toBe(true)
   expect(status.hasLog).toBe(true)
+  expect(status.hasConventions).toBe(true)
+  expect(status.conventionsScannedAt).toBeNull()
   expect(status.lastUpdatedAt).not.toBeNull()
 })

--- a/src/services/wiki/status.ts
+++ b/src/services/wiki/status.ts
@@ -1,4 +1,4 @@
-import { readdir, stat } from 'fs/promises'
+import { readFile, readdir, stat } from 'fs/promises'
 import { getWikiPaths } from './paths.js'
 import type { WikiStatus } from './types.js'
 
@@ -50,17 +50,29 @@ async function getLastUpdatedAt(pathsToCheck: string[]): Promise<string | null> 
   return new Date(Math.max(...mtimes)).toISOString()
 }
 
+async function readCacheFile(cachePath: string): Promise<{ scannedAt: string } | null> {
+  try {
+    const raw = await readFile(cachePath, { encoding: 'utf-8' })
+    const entry = JSON.parse(raw) as { scannedAt: string }
+    return entry.scannedAt ? entry : null
+  } catch {
+    return null
+  }
+}
+
 export async function getWikiStatus(cwd: string): Promise<WikiStatus> {
   const paths = getWikiPaths(cwd)
 
-  const [hasRoot, hasSchema, hasIndex, hasLog, pages, sources] =
+  const [hasRoot, hasSchema, hasIndex, hasLog, hasConventions, pages, sources, cacheEntry] =
     await Promise.all([
       pathExists(paths.root),
       pathExists(paths.schemaFile),
       pathExists(paths.indexFile),
       pathExists(paths.logFile),
+      pathExists(paths.conventionsFile),
       listMarkdownFiles(paths.pagesDir),
       listMarkdownFiles(paths.sourcesDir),
+      readCacheFile(paths.conventionsCacheFile),
     ])
 
   return {
@@ -71,6 +83,8 @@ export async function getWikiStatus(cwd: string): Promise<WikiStatus> {
     hasSchema,
     hasIndex,
     hasLog,
+    hasConventions,
+    conventionsScannedAt: cacheEntry?.scannedAt ?? null,
     lastUpdatedAt: await getLastUpdatedAt([
       paths.schemaFile,
       paths.indexFile,

--- a/src/services/wiki/types.ts
+++ b/src/services/wiki/types.ts
@@ -5,6 +5,8 @@ export type WikiPaths = {
   schemaFile: string
   indexFile: string
   logFile: string
+  conventionsFile: string
+  conventionsCacheFile: string
 }
 
 export type WikiInitResult = {
@@ -22,6 +24,8 @@ export type WikiStatus = {
   hasSchema: boolean
   hasIndex: boolean
   hasLog: boolean
+  hasConventions: boolean
+  conventionsScannedAt: string | null
   lastUpdatedAt: string | null
 }
 
@@ -30,4 +34,13 @@ export type WikiIngestResult = {
   sourceNote: string
   summary: string
   title: string
+}
+
+export type ConventionResult = {
+  /** Free-text markdown describing project conventions */
+  markdown: string
+  /** Fingerprint hash derived from scanned file contents (for change detection) */
+  fingerprint: string
+  /** ISO timestamp of last scan */
+  scannedAt: string
 }

--- a/src/services/wiki/types.ts
+++ b/src/services/wiki/types.ts
@@ -43,4 +43,6 @@ export type ConventionResult = {
   fingerprint: string
   /** ISO timestamp of last scan */
   scannedAt: string
+  /** Whether the page was actually written (false when the wiki isn't initialized). */
+  saved: boolean
 }


### PR DESCRIPTION
## Summary

Adds a convention scanner that reads project config files (package.json, tsconfig.json, eslint, prettier, Dockerfile, CI workflows, lockfiles) on startup and saves extracted conventions to .openclaude/wiki/pages/conventions.md. Includes a fingerprint cache to avoid redundant writes and a /wiki scan command for manual re-scans.

New modules:
- src/services/wiki/conventions.ts — scanner + cache + save
- src/services/wiki/identity.ts — project identity (name, languages, monorepo)
- src/services/wiki/conventions.test.ts — 7 tests

Modified:
- paths/types/init/status — extended wiki infrastructure for conventions
- wiki.tsx/index — added /wiki scan command
- main.tsx — fires scan via startDeferredPrefetches
- init.test.ts/status.test.ts — updated for new conventions page/fields

 Impact

  - user-facing impact: After running /wiki init in a project, the agent now automatically knows the project's package manager, test framework, build/lint commands, TypeScript config, lint/format rules, and CI
  setup — no need to tell it every session. A new /wiki scan command lets users force a re-scan at any time. The /wiki status output now shows convention page status.
  - developer/maintainer impact: 3 new files (conventions.ts, identity.ts, conventions.test.ts), 7 modified. The scanner is extensible — adding a new config file type means adding one entry to the SCANNERS array.
  Fingerprint-based caching prevents redundant writes on subsequent sessions.

  Testing

  - bun run build — compiles cleanly
  - bun run smoke — verified (build + version check passes)
  - focused tests: bun test src/services/wiki/ — 11 pass, 0 fail (53 expect() calls)
  - Typecheck: bun run typecheck — zero errors in services/wiki or commands/wiki modules

  Notes

  - provider/model path tested: N/A (no provider/model changes)
  - screenshots attached (if UI changed): N/A (CLI-only, no UI changes)
  - follow-up work or known limitations:
    - Scanner runs after REPL render (via startDeferredPrefetches), so conventions aren't available on the very first turn of a fresh session. Subsequent sessions reuse the cached fingerprint.
    - Currently reads top-level config files only — doesn't recurse into monorepo packages (future work)
    - Wiki must be initialized with /wiki init before scanning starts (no auto-init)
    - Language detection is limited to the project root directory (no recursive file counting)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `/wiki scan` to detect and document project conventions (build system, test framework, package manager, linting/formatting).
  * Wiki initialization now creates a **Project Conventions** page.
  * Background convention scanning runs automatically when trust is established, keeping the page current.

* **Improvements**
  * Updated wiki help to advertise the new supported options.
  * Wiki status now reflects whether conventions exist and when they were last scanned.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->