### PR TITLE
fix(shims): strip x-anthropic-billing-header from system prompt forwarded to OpenAI/Codex (#607)

### DIFF
--- a/src/services/api/codexShim.test.ts
+++ b/src/services/api/codexShim.test.ts
@@ -6,6 +6,7 @@ import {
   codexStreamToAnthropic,
   convertAnthropicMessagesToResponsesInput,
   convertCodexResponseToAnthropicMessage,
+  convertSystemPrompt,
   convertToolsToResponsesTools,
 } from './codexShim.js'
 import { __test as webSearchToolTest } from '../../tools/WebSearchTool/WebSearchTool.js'
@@ -880,6 +881,43 @@ describe('Codex request translation', () => {
 
     expect(textDeltas.join('')).toBe(
       'I should note that the user role requires a briefly concise friendly response format.',
+    )
+  })
+})
+
+describe('convertSystemPrompt', () => {
+  test('strips Anthropic attribution header block from text-block array (#607)', () => {
+    const result = convertSystemPrompt([
+      {
+        type: 'text',
+        text:
+          'x-anthropic-billing-header: cc_version=0.8.0.abc123; ' +
+          'cc_entrypoint=cli;',
+      },
+      { type: 'text', text: 'You are Claude Code.' },
+      { type: 'text', text: 'Project context: bun + react.' },
+    ])
+
+    expect(result).not.toContain('x-anthropic-billing-header')
+    expect(result).not.toContain('cc_version=')
+    expect(result).toContain('You are Claude Code.')
+    expect(result).toContain('Project context: bun + react.')
+  })
+
+  test('returns empty string when only the attribution block is present', () => {
+    const result = convertSystemPrompt([
+      {
+        type: 'text',
+        text: 'x-anthropic-billing-header: cc_version=0.8.0.abc;',
+      },
+    ])
+
+    expect(result).toBe('')
+  })
+
+  test('passes plain string system prompts through untouched', () => {
+    expect(convertSystemPrompt('You are Claude Code.')).toBe(
+      'You are Claude Code.',
     )
   })
 })

--- a/src/services/api/codexShim.ts
+++ b/src/services/api/codexShim.ts
@@ -121,7 +121,7 @@ function normalizeToolUseId(toolUseId: string | undefined): {
   }
 }
 
-function convertSystemPrompt(system: unknown): string {
+export function convertSystemPrompt(system: unknown): string {
   if (!system) return ''
   if (typeof system === 'string') return system
   if (Array.isArray(system)) {
@@ -129,6 +129,10 @@ function convertSystemPrompt(system: unknown): string {
       .map((block: { type?: string; text?: string }) =>
         block.type === 'text' ? (block.text ?? '') : '',
       )
+      // Drop the Anthropic billing/attribution block — Codex's Responses API
+      // doesn't parse it and the per-build fingerprint just churns the
+      // upstream prompt cache.
+      .filter(text => !text.startsWith('x-anthropic-billing-header'))
       .join('\n\n')
   }
   return String(system)

--- a/src/services/api/openaiShim.test.ts
+++ b/src/services/api/openaiShim.test.ts
@@ -4923,3 +4923,99 @@ test('Z.AI: thinking mode enabled when requested', async () => {
   expect(requestBody?.max_completion_tokens).toBeUndefined()
   expect(requestBody?.max_tokens).toBe(1024)
 })
+
+test('strips Anthropic attribution header block from chat-completions system prompt (#607)', async () => {
+  let capturedBody: Record<string, unknown> | undefined
+
+  globalThis.fetch = (async (_input, init) => {
+    capturedBody = JSON.parse(String(init?.body)) as Record<string, unknown>
+
+    return new Response(
+      JSON.stringify({
+        id: 'chatcmpl-1',
+        model: 'gpt-4o',
+        choices: [
+          {
+            message: { role: 'assistant', content: 'ok' },
+            finish_reason: 'stop',
+          },
+        ],
+        usage: { prompt_tokens: 8, completion_tokens: 3, total_tokens: 11 },
+      }),
+      { headers: { 'Content-Type': 'application/json' } },
+    )
+  }) as FetchType
+
+  const client = createOpenAIShimClient({}) as OpenAIShimClient
+
+  await client.beta.messages.create({
+    model: 'gpt-4o',
+    system: [
+      {
+        type: 'text',
+        text:
+          'x-anthropic-billing-header: cc_version=0.8.0.abc123; ' +
+          'cc_entrypoint=cli;',
+      },
+      { type: 'text', text: 'You are Claude Code, helpful assistant.' },
+      { type: 'text', text: 'Project context: bun + react.' },
+    ],
+    messages: [{ role: 'user', content: 'hello' }],
+    max_tokens: 64,
+    stream: false,
+  })
+
+  const messages = capturedBody?.messages as Array<{ role: string; content: string }>
+  const sysMsg = messages.find(m => m.role === 'system')
+  expect(sysMsg).toBeDefined()
+  expect(sysMsg?.content).not.toContain('x-anthropic-billing-header')
+  expect(sysMsg?.content).not.toContain('cc_version=')
+  expect(sysMsg?.content).toContain('You are Claude Code, helpful assistant.')
+  expect(sysMsg?.content).toContain('Project context: bun + react.')
+})
+
+test('strips Anthropic attribution header block from responses-API instructions (#607)', async () => {
+  process.env.OPENAI_API_FORMAT = 'responses'
+  let capturedBody: Record<string, unknown> | undefined
+
+  globalThis.fetch = (async (_input, init) => {
+    capturedBody = JSON.parse(String(init?.body)) as Record<string, unknown>
+
+    return new Response(
+      JSON.stringify({
+        id: 'resp-1',
+        model: 'gpt-5.4',
+        output: [
+          {
+            type: 'message',
+            role: 'assistant',
+            content: [{ type: 'output_text', text: 'ok' }],
+          },
+        ],
+        usage: { input_tokens: 8, output_tokens: 3, total_tokens: 11 },
+      }),
+      { headers: { 'Content-Type': 'application/json' } },
+    )
+  }) as FetchType
+
+  const client = createOpenAIShimClient({ defaultHeaders: {} }) as OpenAIShimClient
+
+  await client.beta.messages.create({
+    model: 'gpt-5.4',
+    system: [
+      {
+        type: 'text',
+        text: 'x-anthropic-billing-header: cc_version=0.8.0.abc123; cc_entrypoint=cli;',
+      },
+      { type: 'text', text: 'You are Claude Code.' },
+    ],
+    messages: [{ role: 'user', content: 'hello' }],
+    max_tokens: 64,
+    stream: false,
+  })
+
+  const instructions = capturedBody?.instructions as string
+  expect(instructions).not.toContain('x-anthropic-billing-header')
+  expect(instructions).not.toContain('cc_version=')
+  expect(instructions).toContain('You are Claude Code.')
+})

--- a/src/services/api/openaiShim.ts
+++ b/src/services/api/openaiShim.ts
@@ -248,6 +248,11 @@ function convertSystemPrompt(
       .map((block: { type?: string; text?: string }) =>
         block.type === 'text' ? block.text ?? '' : '',
       )
+      // Drop the Anthropic billing/attribution block — it's only meaningful to
+      // Anthropic's `_parse_cc_header` and is dead weight (plus a churning
+      // per-build fingerprint that busts prefix KV cache) for OpenAI-compat
+      // providers like local Ollama / llama.cpp / Codex pass-throughs.
+      .filter(text => !text.startsWith('x-anthropic-billing-header'))
       .join('\n\n')
   }
   return String(system)


### PR DESCRIPTION
## Summary

- drop blocks starting with `x-anthropic-billing-header` inside `convertSystemPrompt` for both `openaiShim.ts` and `codexShim.ts` so the Anthropic billing/attribution string never reaches non-Anthropic providers
- export `convertSystemPrompt` from `codexShim.ts` (pure helper) so the strip can be unit-tested directly
- add focused tests: openaiShim e2e (chat-completions + Responses API) asserting the line is absent from `messages[system].content` / `instructions`, plus codexShim unit tests for the array, only-attribution, and plain-string cases

## Why

`getAttributionHeader()` in `src/constants/system.ts` builds a single `x-anthropic-billing-header: cc_version=<MACRO.VERSION>.<fingerprint>; cc_entrypoint=<entrypoint>; …` string and `claude.ts:1390-1401` prepends it to the system-prompt block array unconditionally. Anthropic's API needs it (server-side `_parse_cc_header`), but for OpenAI / Codex / Ollama / llama.cpp / Codex pass-throughs it's:

- token waste in every system prompt,
- a per-build fingerprint that churns the upstream / local prompt cache, and
- the same source the unsloth post (linked in #607) flagged as the ~90% slowdown for local models.

Non-Anthropic traffic flows through these two `convertSystemPrompt` helpers (chat-completions builds `result.push({ role: 'system', content: sysText })`, Responses API + Codex set `body.instructions = sysText`), so filtering at that single chokepoint is the surgical fix.

## Impact

- user-facing impact: faster local-model latency + smaller prompts on every non-Anthropic provider — no env var to toggle, just works. Users on Anthropic see no change (the block is built into Anthropic-shaped requests directly and never flows through these helpers).
- developer/maintainer impact: `convertSystemPrompt` becomes the single source of truth for stripping Anthropic-only system blocks before forwarding. `codexShim.convertSystemPrompt` is now exported, but it's a pure function with no side effects.

## Testing

- [x] `bun run build`
- [x] `bun run smoke`
- [x] focused tests:
  - `bun test src/services/api/openaiShim.test.ts src/services/api/codexShim.test.ts` → 121 pass / 0 fail
  - `bun test src/services/api/` (full surface, lessons-learned guardrail against mock.module leak — no new mocks added) → 488 pass / 0 fail

## Notes

- provider/model path tested: chat-completions (`gpt-4o`) + Responses API (`gpt-5.4`) via the openaiShim e2e tests; codex Responses path via the unit test on the now-exported helper
- screenshots attached (if UI changed): n/a
- follow-up work or known limitations: the `convertSystemPrompt` helpers are still duplicated across `openaiShim.ts` and `codexShim.ts`. Happy to extract a shared `stripAnthropicAttribution` util in a follow-up if preferred — kept the diff minimal here so reviewers can see the fix without churn.

Closes #607.