### PR TITLE
fix(agent): ensure main agent waits for subagent completion

### DIFF
--- a/src/tools/AgentTool/AgentTool.tsx
+++ b/src/tools/AgentTool/AgentTool.tsx
@@ -1341,7 +1341,7 @@ The agent is now running and will receive instructions via mailbox.`
     }
     if (data.status === 'async_launched') {
       const prefix = `Async agent launched successfully.\nagentId: ${data.agentId} (internal ID - do not mention to user. Use SendMessage with to: '${data.agentId}' to continue this agent.)\nThe agent is working in the background. You will be notified automatically when it completes.`;
-      const instructions = data.canReadOutputFile ? `Do not duplicate this agent's work — avoid working with the same files or topics it is using. Work on non-overlapping tasks, or briefly tell the user what you launched and end your response.\noutput_file: ${data.outputFile}\nIf asked, you can check progress before completion by using ${FILE_READ_TOOL_NAME} or ${BASH_TOOL_NAME} tail on the output file.` : `Briefly tell the user what you launched and end your response. Do not generate any other text — agent results will arrive in a subsequent message.`;
+      const instructions = data.canReadOutputFile ? `Do not duplicate this agent's work — avoid working with the same files or topics it is using. Briefly tell the user what you launched and end your response — agent results will arrive in a subsequent message. You may continue first ONLY if you have other tasks on clearly different files that this agent is not touching.\noutput_file: ${data.outputFile}\nIf asked, you can check progress before completion by using ${FILE_READ_TOOL_NAME} or ${BASH_TOOL_NAME} tail on the output file.` : `Briefly tell the user what you launched and end your response. Do not generate any other text — agent results will arrive in a subsequent message.`;
       const text = `${prefix}\n${instructions}`;
       return {
         tool_use_id: toolUseID,


### PR DESCRIPTION
## Summary

- **Updated subagent tool result instructions**: Modified the text returned to the model when an asynchronous agent is launched (or a synchronous agent is backgrounded) in `src/tools/AgentTool/AgentTool.tsx`.
- **Strict "End Turn" directive**: The instructions now explicitly command the model to "end your response" immediately after launching, with a strict conditional for any continuation.
- **Why it changed**: Previously, the model was often rationalizing "parallel" work on the same files it had just delegated to a subagent. This led to duplicated costs (two agents working on one problem) and race conditions where the main agent would read files while the subagent was trying to modify them. 
 
This happened after few seconds the agent was spawned:

<img width="595" height="239" alt="Screenshot_20260505_231005" src="https://github.com/user-attachments/assets/753cbcec-125e-4314-ae85-9a09384e4e66" />


## Impact

- **User-facing impact**: Reduced API costs and improved reliability. The CLI will now reliably wait for subagent results rather than racing ahead and performing redundant work.
- **Developer/maintainer impact**: Cleaner orchestration logs and more predictable agent behavior. The stricter prompt boundary reduces "lazy" delegation where the parent doesn't properly hand off control.

## Testing

- [x] `bun run build`
- [ ] `bun run smoke`
- [x] focused tests: Verified instruction clarity by reviewing `tool_result` content in `AgentTool.tsx`.

## Notes

- **Provider/model path tested**: Tested with Anthropic Sonnet 4.6, Kimi K2.6, DeepSeek V4. Verified the change with Opus 4.7 and Gemini 3.1 Pro - both confirmed independently this fix correctly addresses the issue, as did subsequent tests with the cheaper models.
- **Screenshots attached (if UI changed)**: N/A (Instruction change only).
- **Follow-up work or known limitations**: The fix is very surgical and addresses the faulty behavior I experienced. Similar stricter instructions could be applied to `teammate_spawned` and `remote_launched` result blocks for full consistency across all multi-agent spawn paths - I didn't change those because I have no test cases, but analysis shows same issue potentially there too.

What to look out for specifically:

>The bug is in the first branch. It explicitly authorizes the agent not to wait:
>
>"Work on non-overlapping tasks, **or** briefly tell the user what you launched and end your response."
>
>The **or** makes ending optional. The "Do not duplicate this agent's work" framing reinforces it by presupposing the agent will keep working. So the model picks the path that keeps it active. The second branch works because it's unambiguous: end and wait.
