### PR TITLE
fix(cli): replace createRequire with static import for teammate.js (#1026)

### DIFF
--- a/src/state/AppStateStore.ts
+++ b/src/state/AppStateStore.ts
@@ -1,5 +1,5 @@
 import type { Notification } from 'src/context/notifications.js'
-import { createRequire } from 'node:module'
+import { isTeammate, isPlanModeRequired } from '../utils/teammate.js'
 import type { TodoList } from 'src/utils/todo/types.js'
 import type { BridgePermissionCallbacks } from '../bridge/bridgePermissionCallbacks.js'
 import type { Command } from '../commands.js'
@@ -457,14 +457,8 @@ export type AppStateStore = Store<AppState>
 
 export function getDefaultAppState(): AppState {
   // Determine initial permission mode for teammates spawned with plan_mode_required
-  // Use lazy require to avoid circular dependency with teammate.ts
-  const runtimeRequire = createRequire(import.meta.url)
-  /* eslint-disable @typescript-eslint/no-require-imports */
-  const teammateUtils =
-    runtimeRequire('../utils/teammate.js') as typeof import('../utils/teammate.js')
-  /* eslint-enable @typescript-eslint/no-require-imports */
   const initialMode: PermissionMode =
-    teammateUtils.isTeammate() && teammateUtils.isPlanModeRequired()
+    isTeammate() && isPlanModeRequired()
       ? 'plan'
       : 'default'
 


### PR DESCRIPTION
﻿**Fixes #1026**

#### The Issue
In commit 1f66d32 (#1020), `require('../utils/teammate.js')` was changed to `createRequire(import.meta.url)('../utils/teammate.js')` in `getDefaultAppState()`. 
While this likely fixed an ESM/CJS warning in the test environment, `createRequire` bypasses the Bun bundler entirely. As a result, `teammate.js` was no longer inlined into `dist/cli.mjs`. 

At runtime in the published npm package, `import.meta.url` points to `dist/cli.mjs`, so the dynamic require attempts to resolve `<package-root>/utils/teammate.js`. However, `utils/` is not included in the npm `files` array, causing an immediate crash on startup: `Cannot find module '../utils/teammate.js'`.

#### The Fix
- Replaced the dynamic `createRequire` with a standard static `import` at the top of the file.
- The bundler now correctly analyzes the import and inlines `isTeammate()` and `isPlanModeRequired()` directly into `dist/cli.mjs`, removing the external file dependency entirely.
- The original comment regarding a circular dependency with teammate.ts appears to be stale, as teammate.ts only relies on an import type from AppState.ts which gets erased at compile time.
