### PR TITLE
fix(openai-shim): strip `store` when baseUrl points at Cerebras (#1023)

### DIFF
--- a/src/services/api/openaiShim.test.ts
+++ b/src/services/api/openaiShim.test.ts
@@ -4098,6 +4098,38 @@ test('Moonshot: uses max_tokens (not max_completion_tokens) and strips store', a
   expect(requestBody?.store).toBeUndefined()
 })
 
+test('Cerebras: strips unsupported store on chat_completions (#1023)', async () => {
+  process.env.OPENAI_BASE_URL = 'https://api.cerebras.ai/v1'
+  process.env.OPENAI_API_KEY = 'csk-test'
+
+  let requestBody: Record<string, unknown> | undefined
+  globalThis.fetch = (async (_input, init) => {
+    requestBody = JSON.parse(String(init?.body))
+    return new Response(
+      JSON.stringify({
+        id: 'chatcmpl-1',
+        model: 'llama3.1-8b',
+        choices: [
+          { message: { role: 'assistant', content: 'ok' }, finish_reason: 'stop' },
+        ],
+        usage: { prompt_tokens: 3, completion_tokens: 1, total_tokens: 4 },
+      }),
+      { headers: { 'Content-Type': 'application/json' } },
+    )
+  }) as FetchType
+
+  const client = createOpenAIShimClient({}) as OpenAIShimClient
+  await client.beta.messages.create({
+    model: 'llama3.1-8b',
+    system: 'you are cerebras',
+    messages: [{ role: 'user', content: 'hi' }],
+    max_tokens: 64,
+    stream: false,
+  })
+
+  expect(requestBody?.store).toBeUndefined()
+})
+
 test('Groq: keeps max_completion_tokens and strips unsupported store', async () => {
   process.env.OPENAI_BASE_URL = 'https://api.groq.com/openai/v1'
   process.env.OPENAI_API_KEY = 'gsk-test'

--- a/src/services/api/openaiShim.ts
+++ b/src/services/api/openaiShim.ts
@@ -156,6 +156,17 @@ function hasGeminiApiHost(baseUrl: string | undefined): boolean {
   }
 }
 
+function hasCerebrasApiHost(baseUrl: string | undefined): boolean {
+  if (!baseUrl) return false
+
+  try {
+    const host = new URL(baseUrl).hostname.toLowerCase()
+    return host === 'api.cerebras.ai' || host.endsWith('.cerebras.ai')
+  } catch {
+    return false
+  }
+}
+
 function normalizeDeepSeekReasoningEffort(
   effort: 'low' | 'medium' | 'high' | 'xhigh',
 ): 'high' | 'max' {
@@ -1594,7 +1605,8 @@ class OpenAIShimMessages {
     const shouldStripResponsesStore =
       (shimConfig.removeBodyFields ?? []).includes('store') ||
       isGeminiMode() ||
-      hasGeminiApiHost(request.baseUrl)
+      hasGeminiApiHost(request.baseUrl) ||
+      hasCerebrasApiHost(request.baseUrl)
 
     if (
       shimConfig.maxTokensField === 'max_tokens' &&


### PR DESCRIPTION
## Summary

- The OpenAI shim already strips the `store` field for Gemini hosts (and explicit `removeBodyFields: ['store']` gateways like Groq / Mistral / Moonshot). Cerebras Cloud's chat-completions endpoint rejects `store` the same way: `400 store: property 'store' is unsupported`.
- Add `hasCerebrasApiHost` symmetric to `hasGeminiApiHost`, and OR it into the existing `shouldStripResponsesStore` gate. Matches `api.cerebras.ai` and `*.cerebras.ai` so the Custom provider path (used in #1023) is covered too.

## Impact

- user-facing impact: users on `Custom Carebras` (or any base URL pointing at Cerebras Cloud) can send chat messages without hitting the 400. Reproduces directly from the #1023 log.
- developer/maintainer impact: one shared host check, mirrors the Gemini precedent. No gateway preset added — host-based detection covers both Custom-provider and any future preset that doesn't carry `removeBodyFields`.

## Testing

- [x] `bun run build`
- [x] `bun run smoke` → `0.9.2 (OpenClaude)`
- [x] focused tests:
  - `bun test src/services/api/openaiShim.test.ts` → 88 pass / 0 fail (new `Cerebras: strips unsupported store on chat_completions (#1023)` case + existing Groq/Gemini/etc. coverage holds)

## Notes

- provider/model path tested: chat_completions through the OpenAI shim with `OPENAI_BASE_URL=https://api.cerebras.ai/v1`, `model=llama3.1-8b`. Asserts `requestBody.store` is undefined post-strip.
- responses-API path is unchanged — Cerebras only ships chat_completions, so no second hook needed.
- follow-up work or known limitations: a dedicated `cerebras` gateway preset (with model list + `removeBodyFields: ['store']`) could be added separately if maintainers want it surfaced in the picker — out of scope for this fix.