### PR TITLE
fix: resolve PowerShell as default shell on Windows when CLAUDE_CODE_USE_POWERSHELL_TOOL=true

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -306,6 +306,12 @@ ANTHROPIC_API_KEY=sk-ant-your-key-here
 # Disable "Co-authored-by" line in git commits made by OpenClaude
 # OPENCLAUDE_DISABLE_CO_AUTHORED_BY=1
 
+# Enable PowerShell tool on Windows as the default shell for ! commands and bash-mode.
+# Without this, OpenClaude uses bash (Git Bash / WSL / MSYS2) on Windows.
+# Set to 1/true to activate; set to 0/false to explicitly disable.
+# Only takes effect on Windows; ignored on macOS and Linux.
+# OPENCLAUDE_USE_POWERSHELL_TOOL=1
+
 # Disable strict tool schema normalization for non-Gemini providers
 # Useful when MCP tools with complex optional params (e.g. list[dict])
 # trigger "Extra required key ... supplied" errors from OpenAI-compatible endpoints

--- a/src/services/tips/tipRegistry.ts
+++ b/src/services/tips/tipRegistry.ts
@@ -238,11 +238,11 @@ const externalTips: Tip[] = [
   {
     id: 'powershell-tool-env',
     content: async () =>
-      'Set CLAUDE_CODE_USE_POWERSHELL_TOOL=1 to enable the PowerShell tool (preview)',
+      'Set OPENCLAUDE_USE_POWERSHELL_TOOL=1 to enable the PowerShell tool (preview)',
     cooldownSessions: 10,
     isRelevant: async () =>
       getPlatform() === 'windows' &&
-      process.env.CLAUDE_CODE_USE_POWERSHELL_TOOL === undefined,
+      process.env.OPENCLAUDE_USE_POWERSHELL_TOOL === undefined,
   },
   {
     id: 'status-line',

--- a/src/services/tips/tipRegistry.ts
+++ b/src/services/tips/tipRegistry.ts
@@ -242,7 +242,8 @@ const externalTips: Tip[] = [
     cooldownSessions: 10,
     isRelevant: async () =>
       getPlatform() === 'windows' &&
-      process.env.OPENCLAUDE_USE_POWERSHELL_TOOL === undefined,
+      process.env.OPENCLAUDE_USE_POWERSHELL_TOOL === undefined &&
+      process.env.CLAUDE_CODE_USE_POWERSHELL_TOOL === undefined,
   },
   {
     id: 'status-line',

--- a/src/utils/shell/resolveDefaultShell.ts
+++ b/src/utils/shell/resolveDefaultShell.ts
@@ -1,14 +1,22 @@
+import { isEnvTruthy } from '../envUtils.js'
+import { getPlatform } from '../platform.js'
 import { getInitialSettings } from '../settings/settings.js'
 
 /**
  * Resolve the default shell for input-box `!` commands.
  *
  * Resolution order (docs/design/ps-shell-selection.md §4.2):
- *   settings.defaultShell → 'bash'
+ *   settings.defaultShell -> (Windows + OPENCLAUDE_USE_POWERSHELL_TOOL) -> 'bash'
  *
- * Platform default is 'bash' everywhere — we do NOT auto-flip Windows to
- * PowerShell (would break existing Windows users with bash hooks).
+ * Platform default is 'bash' on all platforms, unless the user has explicitly
+ * opted into PowerShell via OPENCLAUDE_USE_POWERSHELL_TOOL=true on Windows.
+ * This restores the upstream behavior where setting the env var also makes
+ * PowerShell the default for ! commands without requiring a separate
+ * settings.defaultShell change.
  */
 export function resolveDefaultShell(): 'bash' | 'powershell' {
-  return getInitialSettings().defaultShell ?? 'bash'
+  return getInitialSettings().defaultShell ??
+    (getPlatform() === 'windows' && isEnvTruthy(process.env.OPENCLAUDE_USE_POWERSHELL_TOOL)
+      ? 'powershell'
+      : 'bash')
 }

--- a/src/utils/shell/resolveDefaultShell.ts
+++ b/src/utils/shell/resolveDefaultShell.ts
@@ -1,6 +1,7 @@
 import { isEnvTruthy } from '../envUtils.js'
 import { getPlatform } from '../platform.js'
 import { getInitialSettings } from '../settings/settings.js'
+import { getPowershellToolEnv } from './shellToolUtils.js'
 
 /**
  * Resolve the default shell for input-box `!` commands.
@@ -9,14 +10,15 @@ import { getInitialSettings } from '../settings/settings.js'
  *   settings.defaultShell -> (Windows + OPENCLAUDE_USE_POWERSHELL_TOOL) -> 'bash'
  *
  * Platform default is 'bash' on all platforms, unless the user has explicitly
- * opted into PowerShell via OPENCLAUDE_USE_POWERSHELL_TOOL=true on Windows.
+ * opted into PowerShell via OPENCLAUDE_USE_POWERSHELL_TOOL=true (or the legacy
+ * CLAUDE_CODE_USE_POWERSHELL_TOOL) on Windows.
  * This restores the upstream behavior where setting the env var also makes
  * PowerShell the default for ! commands without requiring a separate
  * settings.defaultShell change.
  */
 export function resolveDefaultShell(): 'bash' | 'powershell' {
   return getInitialSettings().defaultShell ??
-    (getPlatform() === 'windows' && isEnvTruthy(process.env.OPENCLAUDE_USE_POWERSHELL_TOOL)
+    (getPlatform() === 'windows' && isEnvTruthy(getPowershellToolEnv())
       ? 'powershell'
       : 'bash')
 }

--- a/src/utils/shell/shellToolUtils.test.ts
+++ b/src/utils/shell/shellToolUtils.test.ts
@@ -32,7 +32,7 @@ afterEach(() => {
 })
 
 // ═══════════════════════════════════════════════════════════════════════════
-// Tests that do NOT use mock.module (run first — no mock interference)
+// getPowershellToolEnv — platform-agnostic, no mocks needed
 // ═══════════════════════════════════════════════════════════════════════════
 
 // ── getPowershellToolEnv ──────────────────────────────────────────────────
@@ -63,39 +63,45 @@ describe('getPowershellToolEnv', () => {
   })
 })
 
-// ── isPowerShellToolEnabled (Windows — process.platform === 'win32') ──────
+// ── isPowerShellToolEnabled (Windows) ────────────────────────────────────
 
 describe('isPowerShellToolEnabled (Windows)', () => {
   test('enabled when preferred env var is truthy (external user)', async () => {
+    mock.module('../platform.js', () => ({ getPlatform: () => 'windows' }))
     process.env.OPENCLAUDE_USE_POWERSHELL_TOOL = '1'
     const { isPowerShellToolEnabled } = await import('./shellToolUtils.js')
     expect(isPowerShellToolEnabled()).toBe(true)
   })
 
   test('enabled when only legacy env var is truthy (external user)', async () => {
+    mock.module('../platform.js', () => ({ getPlatform: () => 'windows' }))
     process.env.CLAUDE_CODE_USE_POWERSHELL_TOOL = 'true'
     const { isPowerShellToolEnabled } = await import('./shellToolUtils.js')
     expect(isPowerShellToolEnabled()).toBe(true)
   })
 
   test('disabled when neither env var is set (external user)', async () => {
+    mock.module('../platform.js', () => ({ getPlatform: () => 'windows' }))
     const { isPowerShellToolEnabled } = await import('./shellToolUtils.js')
     expect(isPowerShellToolEnabled()).toBe(false)
   })
 
   test('disabled when preferred is falsy and legacy is unset (external user)', async () => {
+    mock.module('../platform.js', () => ({ getPlatform: () => 'windows' }))
     process.env.OPENCLAUDE_USE_POWERSHELL_TOOL = '0'
     const { isPowerShellToolEnabled } = await import('./shellToolUtils.js')
     expect(isPowerShellToolEnabled()).toBe(false)
   })
 
   test('enabled for ant user when env var is unset (default-on)', async () => {
+    mock.module('../platform.js', () => ({ getPlatform: () => 'windows' }))
     process.env.USER_TYPE = 'ant'
     const { isPowerShellToolEnabled } = await import('./shellToolUtils.js')
     expect(isPowerShellToolEnabled()).toBe(true)
   })
 
   test('disabled for ant user when preferred is explicitly falsy', async () => {
+    mock.module('../platform.js', () => ({ getPlatform: () => 'windows' }))
     process.env.USER_TYPE = 'ant'
     process.env.OPENCLAUDE_USE_POWERSHELL_TOOL = '0'
     const { isPowerShellToolEnabled } = await import('./shellToolUtils.js')
@@ -103,6 +109,7 @@ describe('isPowerShellToolEnabled (Windows)', () => {
   })
 
   test('disabled for ant user when legacy is explicitly falsy and preferred is unset', async () => {
+    mock.module('../platform.js', () => ({ getPlatform: () => 'windows' }))
     process.env.USER_TYPE = 'ant'
     process.env.CLAUDE_CODE_USE_POWERSHELL_TOOL = 'false'
     const { isPowerShellToolEnabled } = await import('./shellToolUtils.js')
@@ -110,15 +117,17 @@ describe('isPowerShellToolEnabled (Windows)', () => {
   })
 })
 
-// ── resolveDefaultShell (Windows — real platform) ─────────────────────────
+// ── resolveDefaultShell (Windows) ─────────────────────────────────────────
 
 describe('resolveDefaultShell (Windows)', () => {
   test('returns bash by default on Windows without env var', async () => {
+    mock.module('../platform.js', () => ({ getPlatform: () => 'windows' }))
     const { resolveDefaultShell } = await import('./resolveDefaultShell.js')
     expect(resolveDefaultShell()).toBe('bash')
   })
 
   test('returns powershell when preferred env var is truthy on Windows', async () => {
+    mock.module('../platform.js', () => ({ getPlatform: () => 'windows' }))
     process.env.OPENCLAUDE_USE_POWERSHELL_TOOL = '1'
     mock.module('../settings/settings.js', () => ({
       getInitialSettings: () => ({}),
@@ -129,6 +138,7 @@ describe('resolveDefaultShell (Windows)', () => {
   })
 
   test('returns powershell when only legacy env var is truthy on Windows', async () => {
+    mock.module('../platform.js', () => ({ getPlatform: () => 'windows' }))
     process.env.CLAUDE_CODE_USE_POWERSHELL_TOOL = 'true'
     mock.module('../settings/settings.js', () => ({
       getInitialSettings: () => ({}),
@@ -139,6 +149,7 @@ describe('resolveDefaultShell (Windows)', () => {
   })
 
   test('preferred env var wins over legacy for default shell', async () => {
+    mock.module('../platform.js', () => ({ getPlatform: () => 'windows' }))
     process.env.OPENCLAUDE_USE_POWERSHELL_TOOL = '1'
     process.env.CLAUDE_CODE_USE_POWERSHELL_TOOL = '0'
     mock.module('../settings/settings.js', () => ({
@@ -150,6 +161,7 @@ describe('resolveDefaultShell (Windows)', () => {
   })
 
   test('settings.defaultShell overrides env var', async () => {
+    mock.module('../platform.js', () => ({ getPlatform: () => 'windows' }))
     process.env.OPENCLAUDE_USE_POWERSHELL_TOOL = '1'
     mock.module('../settings/settings.js', () => ({
       getInitialSettings: () => ({ defaultShell: 'bash' as const }),
@@ -160,6 +172,7 @@ describe('resolveDefaultShell (Windows)', () => {
   })
 
   test('settings.defaultShell=powershell wins regardless of env var', async () => {
+    mock.module('../platform.js', () => ({ getPlatform: () => 'windows' }))
     mock.module('../settings/settings.js', () => ({
       getInitialSettings: () => ({ defaultShell: 'powershell' as const }),
     }))
@@ -169,25 +182,18 @@ describe('resolveDefaultShell (Windows)', () => {
   })
 })
 
-// ═══════════════════════════════════════════════════════════════════════════
-// Tests that use mock.module for platform (MUST RUN LAST)
-// mock.module in Bun cannot be reliably restored — it leaks across tests
-// ═══════════════════════════════════════════════════════════════════════════
+// ── non-Windows tests ─────────────────────────────────────────────────────
 
 describe('isPowerShellToolEnabled (non-Windows)', () => {
   test('returns false on macOS even with env var set', async () => {
-    mock.module('../platform.js', () => ({
-      getPlatform: () => 'macos',
-    }))
+    mock.module('../platform.js', () => ({ getPlatform: () => 'macos' }))
     process.env.OPENCLAUDE_USE_POWERSHELL_TOOL = '1'
     const { isPowerShellToolEnabled } = await import('./shellToolUtils.js')
     expect(isPowerShellToolEnabled()).toBe(false)
   })
 
   test('returns false on Linux even with legacy env var set', async () => {
-    mock.module('../platform.js', () => ({
-      getPlatform: () => 'linux',
-    }))
+    mock.module('../platform.js', () => ({ getPlatform: () => 'linux' }))
     process.env.CLAUDE_CODE_USE_POWERSHELL_TOOL = '1'
     const { isPowerShellToolEnabled } = await import('./shellToolUtils.js')
     expect(isPowerShellToolEnabled()).toBe(false)
@@ -196,10 +202,8 @@ describe('isPowerShellToolEnabled (non-Windows)', () => {
 
 describe('resolveDefaultShell (non-Windows)', () => {
   test('returns bash on non-Windows even with env var set', async () => {
+    mock.module('../platform.js', () => ({ getPlatform: () => 'macos' }))
     process.env.OPENCLAUDE_USE_POWERSHELL_TOOL = '1'
-    mock.module('../platform.js', () => ({
-      getPlatform: () => 'macos',
-    }))
     mock.module('../settings/settings.js', () => ({
       getInitialSettings: () => ({}),
     }))

--- a/src/utils/shell/shellToolUtils.test.ts
+++ b/src/utils/shell/shellToolUtils.test.ts
@@ -122,8 +122,12 @@ describe('isPowerShellToolEnabled (Windows)', () => {
 describe('resolveDefaultShell (Windows)', () => {
   test('returns bash by default on Windows without env var', async () => {
     mock.module('../platform.js', () => ({ getPlatform: () => 'windows' }))
+    mock.module('../settings/settings.js', () => ({
+      getInitialSettings: () => ({}),
+    }))
     const { resolveDefaultShell } = await import('./resolveDefaultShell.js')
     expect(resolveDefaultShell()).toBe('bash')
+    mock.module('../settings/settings.js', () => ({}))
   })
 
   test('returns powershell when preferred env var is truthy on Windows', async () => {

--- a/src/utils/shell/shellToolUtils.test.ts
+++ b/src/utils/shell/shellToolUtils.test.ts
@@ -1,5 +1,17 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test'
 
+// ── cache-bust helper ──────────────────────────────────────────────────────
+// When the full test suite runs, other files may import shellToolUtils /
+// platform / settings before us. Those cached modules already have their
+// imports resolved to the real modules. mock.module replaces the registry
+// entry but can't rewire already-resolved static imports inside cached
+// modules. Cache-busting query strings force a fresh module evaluation
+// that resolves imports through the mock registry.
+let cacheBust = 0
+function fresh(file: string) {
+  return `${file}?t=${cacheBust++}`
+}
+
 // ── env hygiene ────────────────────────────────────────────────────────────
 const originalEnv = {
   OPENCLAUDE_USE_POWERSHELL_TOOL: process.env.OPENCLAUDE_USE_POWERSHELL_TOOL,
@@ -31,34 +43,30 @@ afterEach(() => {
   }
 })
 
-// ═══════════════════════════════════════════════════════════════════════════
-// getPowershellToolEnv — platform-agnostic, no mocks needed
-// ═══════════════════════════════════════════════════════════════════════════
-
 // ── getPowershellToolEnv ──────────────────────────────────────────────────
 
 describe('getPowershellToolEnv', () => {
   test('returns undefined when neither env var is set', async () => {
-    const { getPowershellToolEnv } = await import('./shellToolUtils.js')
+    const { getPowershellToolEnv } = await import(fresh('./shellToolUtils.js'))
     expect(getPowershellToolEnv()).toBeUndefined()
   })
 
   test('returns preferred when OPENCLAUDE_USE_POWERSHELL_TOOL is set', async () => {
     process.env.OPENCLAUDE_USE_POWERSHELL_TOOL = '1'
-    const { getPowershellToolEnv } = await import('./shellToolUtils.js')
+    const { getPowershellToolEnv } = await import(fresh('./shellToolUtils.js'))
     expect(getPowershellToolEnv()).toBe('1')
   })
 
   test('returns legacy fallback when only CLAUDE_CODE_USE_POWERSHELL_TOOL is set', async () => {
     process.env.CLAUDE_CODE_USE_POWERSHELL_TOOL = 'true'
-    const { getPowershellToolEnv } = await import('./shellToolUtils.js')
+    const { getPowershellToolEnv } = await import(fresh('./shellToolUtils.js'))
     expect(getPowershellToolEnv()).toBe('true')
   })
 
   test('preferred wins when both env vars are set', async () => {
     process.env.OPENCLAUDE_USE_POWERSHELL_TOOL = '1'
     process.env.CLAUDE_CODE_USE_POWERSHELL_TOOL = '0'
-    const { getPowershellToolEnv } = await import('./shellToolUtils.js')
+    const { getPowershellToolEnv } = await import(fresh('./shellToolUtils.js'))
     expect(getPowershellToolEnv()).toBe('1')
   })
 })
@@ -69,34 +77,34 @@ describe('isPowerShellToolEnabled (Windows)', () => {
   test('enabled when preferred env var is truthy (external user)', async () => {
     mock.module('../platform.js', () => ({ getPlatform: () => 'windows' }))
     process.env.OPENCLAUDE_USE_POWERSHELL_TOOL = '1'
-    const { isPowerShellToolEnabled } = await import('./shellToolUtils.js')
+    const { isPowerShellToolEnabled } = await import(fresh('./shellToolUtils.js'))
     expect(isPowerShellToolEnabled()).toBe(true)
   })
 
   test('enabled when only legacy env var is truthy (external user)', async () => {
     mock.module('../platform.js', () => ({ getPlatform: () => 'windows' }))
     process.env.CLAUDE_CODE_USE_POWERSHELL_TOOL = 'true'
-    const { isPowerShellToolEnabled } = await import('./shellToolUtils.js')
+    const { isPowerShellToolEnabled } = await import(fresh('./shellToolUtils.js'))
     expect(isPowerShellToolEnabled()).toBe(true)
   })
 
   test('disabled when neither env var is set (external user)', async () => {
     mock.module('../platform.js', () => ({ getPlatform: () => 'windows' }))
-    const { isPowerShellToolEnabled } = await import('./shellToolUtils.js')
+    const { isPowerShellToolEnabled } = await import(fresh('./shellToolUtils.js'))
     expect(isPowerShellToolEnabled()).toBe(false)
   })
 
   test('disabled when preferred is falsy and legacy is unset (external user)', async () => {
     mock.module('../platform.js', () => ({ getPlatform: () => 'windows' }))
     process.env.OPENCLAUDE_USE_POWERSHELL_TOOL = '0'
-    const { isPowerShellToolEnabled } = await import('./shellToolUtils.js')
+    const { isPowerShellToolEnabled } = await import(fresh('./shellToolUtils.js'))
     expect(isPowerShellToolEnabled()).toBe(false)
   })
 
   test('enabled for ant user when env var is unset (default-on)', async () => {
     mock.module('../platform.js', () => ({ getPlatform: () => 'windows' }))
     process.env.USER_TYPE = 'ant'
-    const { isPowerShellToolEnabled } = await import('./shellToolUtils.js')
+    const { isPowerShellToolEnabled } = await import(fresh('./shellToolUtils.js'))
     expect(isPowerShellToolEnabled()).toBe(true)
   })
 
@@ -104,7 +112,7 @@ describe('isPowerShellToolEnabled (Windows)', () => {
     mock.module('../platform.js', () => ({ getPlatform: () => 'windows' }))
     process.env.USER_TYPE = 'ant'
     process.env.OPENCLAUDE_USE_POWERSHELL_TOOL = '0'
-    const { isPowerShellToolEnabled } = await import('./shellToolUtils.js')
+    const { isPowerShellToolEnabled } = await import(fresh('./shellToolUtils.js'))
     expect(isPowerShellToolEnabled()).toBe(false)
   })
 
@@ -112,12 +120,17 @@ describe('isPowerShellToolEnabled (Windows)', () => {
     mock.module('../platform.js', () => ({ getPlatform: () => 'windows' }))
     process.env.USER_TYPE = 'ant'
     process.env.CLAUDE_CODE_USE_POWERSHELL_TOOL = 'false'
-    const { isPowerShellToolEnabled } = await import('./shellToolUtils.js')
+    const { isPowerShellToolEnabled } = await import(fresh('./shellToolUtils.js'))
     expect(isPowerShellToolEnabled()).toBe(false)
   })
 })
 
 // ── resolveDefaultShell (Windows) ─────────────────────────────────────────
+// resolveDefaultShell statically imports getPowershellToolEnv from
+// shellToolUtils. If shellToolUtils was cached by a prior test file, its
+// static import of platform is already resolved to the real module —
+// mock.module can't rewire it. We break the chain by mocking shellToolUtils
+// itself with a fresh getPowershellToolEnv closure over process.env.
 
 describe('resolveDefaultShell (Windows)', () => {
   test('returns bash by default on Windows without env var', async () => {
@@ -125,9 +138,15 @@ describe('resolveDefaultShell (Windows)', () => {
     mock.module('../settings/settings.js', () => ({
       getInitialSettings: () => ({}),
     }))
-    const { resolveDefaultShell } = await import('./resolveDefaultShell.js')
+    mock.module('./shellToolUtils.js', () => ({
+      getPowershellToolEnv: () =>
+        process.env.OPENCLAUDE_USE_POWERSHELL_TOOL ??
+        process.env.CLAUDE_CODE_USE_POWERSHELL_TOOL,
+    }))
+    const { resolveDefaultShell } = await import(fresh('./resolveDefaultShell.js'))
     expect(resolveDefaultShell()).toBe('bash')
     mock.module('../settings/settings.js', () => ({}))
+    mock.module('./shellToolUtils.js', () => ({}))
   })
 
   test('returns powershell when preferred env var is truthy on Windows', async () => {
@@ -136,9 +155,15 @@ describe('resolveDefaultShell (Windows)', () => {
     mock.module('../settings/settings.js', () => ({
       getInitialSettings: () => ({}),
     }))
-    const { resolveDefaultShell } = await import('./resolveDefaultShell.js')
+    mock.module('./shellToolUtils.js', () => ({
+      getPowershellToolEnv: () =>
+        process.env.OPENCLAUDE_USE_POWERSHELL_TOOL ??
+        process.env.CLAUDE_CODE_USE_POWERSHELL_TOOL,
+    }))
+    const { resolveDefaultShell } = await import(fresh('./resolveDefaultShell.js'))
     expect(resolveDefaultShell()).toBe('powershell')
     mock.module('../settings/settings.js', () => ({}))
+    mock.module('./shellToolUtils.js', () => ({}))
   })
 
   test('returns powershell when only legacy env var is truthy on Windows', async () => {
@@ -147,9 +172,15 @@ describe('resolveDefaultShell (Windows)', () => {
     mock.module('../settings/settings.js', () => ({
       getInitialSettings: () => ({}),
     }))
-    const { resolveDefaultShell } = await import('./resolveDefaultShell.js')
+    mock.module('./shellToolUtils.js', () => ({
+      getPowershellToolEnv: () =>
+        process.env.OPENCLAUDE_USE_POWERSHELL_TOOL ??
+        process.env.CLAUDE_CODE_USE_POWERSHELL_TOOL,
+    }))
+    const { resolveDefaultShell } = await import(fresh('./resolveDefaultShell.js'))
     expect(resolveDefaultShell()).toBe('powershell')
     mock.module('../settings/settings.js', () => ({}))
+    mock.module('./shellToolUtils.js', () => ({}))
   })
 
   test('preferred env var wins over legacy for default shell', async () => {
@@ -159,9 +190,15 @@ describe('resolveDefaultShell (Windows)', () => {
     mock.module('../settings/settings.js', () => ({
       getInitialSettings: () => ({}),
     }))
-    const { resolveDefaultShell } = await import('./resolveDefaultShell.js')
+    mock.module('./shellToolUtils.js', () => ({
+      getPowershellToolEnv: () =>
+        process.env.OPENCLAUDE_USE_POWERSHELL_TOOL ??
+        process.env.CLAUDE_CODE_USE_POWERSHELL_TOOL,
+    }))
+    const { resolveDefaultShell } = await import(fresh('./resolveDefaultShell.js'))
     expect(resolveDefaultShell()).toBe('powershell')
     mock.module('../settings/settings.js', () => ({}))
+    mock.module('./shellToolUtils.js', () => ({}))
   })
 
   test('settings.defaultShell overrides env var', async () => {
@@ -170,9 +207,15 @@ describe('resolveDefaultShell (Windows)', () => {
     mock.module('../settings/settings.js', () => ({
       getInitialSettings: () => ({ defaultShell: 'bash' as const }),
     }))
-    const { resolveDefaultShell } = await import('./resolveDefaultShell.js')
+    mock.module('./shellToolUtils.js', () => ({
+      getPowershellToolEnv: () =>
+        process.env.OPENCLAUDE_USE_POWERSHELL_TOOL ??
+        process.env.CLAUDE_CODE_USE_POWERSHELL_TOOL,
+    }))
+    const { resolveDefaultShell } = await import(fresh('./resolveDefaultShell.js'))
     expect(resolveDefaultShell()).toBe('bash')
     mock.module('../settings/settings.js', () => ({}))
+    mock.module('./shellToolUtils.js', () => ({}))
   })
 
   test('settings.defaultShell=powershell wins regardless of env var', async () => {
@@ -180,9 +223,15 @@ describe('resolveDefaultShell (Windows)', () => {
     mock.module('../settings/settings.js', () => ({
       getInitialSettings: () => ({ defaultShell: 'powershell' as const }),
     }))
-    const { resolveDefaultShell } = await import('./resolveDefaultShell.js')
+    mock.module('./shellToolUtils.js', () => ({
+      getPowershellToolEnv: () =>
+        process.env.OPENCLAUDE_USE_POWERSHELL_TOOL ??
+        process.env.CLAUDE_CODE_USE_POWERSHELL_TOOL,
+    }))
+    const { resolveDefaultShell } = await import(fresh('./resolveDefaultShell.js'))
     expect(resolveDefaultShell()).toBe('powershell')
     mock.module('../settings/settings.js', () => ({}))
+    mock.module('./shellToolUtils.js', () => ({}))
   })
 })
 
@@ -192,14 +241,14 @@ describe('isPowerShellToolEnabled (non-Windows)', () => {
   test('returns false on macOS even with env var set', async () => {
     mock.module('../platform.js', () => ({ getPlatform: () => 'macos' }))
     process.env.OPENCLAUDE_USE_POWERSHELL_TOOL = '1'
-    const { isPowerShellToolEnabled } = await import('./shellToolUtils.js')
+    const { isPowerShellToolEnabled } = await import(fresh('./shellToolUtils.js'))
     expect(isPowerShellToolEnabled()).toBe(false)
   })
 
   test('returns false on Linux even with legacy env var set', async () => {
     mock.module('../platform.js', () => ({ getPlatform: () => 'linux' }))
     process.env.CLAUDE_CODE_USE_POWERSHELL_TOOL = '1'
-    const { isPowerShellToolEnabled } = await import('./shellToolUtils.js')
+    const { isPowerShellToolEnabled } = await import(fresh('./shellToolUtils.js'))
     expect(isPowerShellToolEnabled()).toBe(false)
   })
 })
@@ -211,7 +260,12 @@ describe('resolveDefaultShell (non-Windows)', () => {
     mock.module('../settings/settings.js', () => ({
       getInitialSettings: () => ({}),
     }))
-    const { resolveDefaultShell } = await import('./resolveDefaultShell.js')
+    mock.module('./shellToolUtils.js', () => ({
+      getPowershellToolEnv: () =>
+        process.env.OPENCLAUDE_USE_POWERSHELL_TOOL ??
+        process.env.CLAUDE_CODE_USE_POWERSHELL_TOOL,
+    }))
+    const { resolveDefaultShell } = await import(fresh('./resolveDefaultShell.js'))
     expect(resolveDefaultShell()).toBe('bash')
   })
 })

--- a/src/utils/shell/shellToolUtils.test.ts
+++ b/src/utils/shell/shellToolUtils.test.ts
@@ -1,0 +1,209 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test'
+
+// ── env hygiene ────────────────────────────────────────────────────────────
+const originalEnv = {
+  OPENCLAUDE_USE_POWERSHELL_TOOL: process.env.OPENCLAUDE_USE_POWERSHELL_TOOL,
+  CLAUDE_CODE_USE_POWERSHELL_TOOL: process.env.CLAUDE_CODE_USE_POWERSHELL_TOOL,
+  USER_TYPE: process.env.USER_TYPE,
+}
+
+beforeEach(() => {
+  delete process.env.OPENCLAUDE_USE_POWERSHELL_TOOL
+  delete process.env.CLAUDE_CODE_USE_POWERSHELL_TOOL
+  delete process.env.USER_TYPE
+})
+
+afterEach(() => {
+  if (originalEnv.OPENCLAUDE_USE_POWERSHELL_TOOL === undefined) {
+    delete process.env.OPENCLAUDE_USE_POWERSHELL_TOOL
+  } else {
+    process.env.OPENCLAUDE_USE_POWERSHELL_TOOL = originalEnv.OPENCLAUDE_USE_POWERSHELL_TOOL
+  }
+  if (originalEnv.CLAUDE_CODE_USE_POWERSHELL_TOOL === undefined) {
+    delete process.env.CLAUDE_CODE_USE_POWERSHELL_TOOL
+  } else {
+    process.env.CLAUDE_CODE_USE_POWERSHELL_TOOL = originalEnv.CLAUDE_CODE_USE_POWERSHELL_TOOL
+  }
+  if (originalEnv.USER_TYPE === undefined) {
+    delete process.env.USER_TYPE
+  } else {
+    process.env.USER_TYPE = originalEnv.USER_TYPE
+  }
+})
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Tests that do NOT use mock.module (run first — no mock interference)
+// ═══════════════════════════════════════════════════════════════════════════
+
+// ── getPowershellToolEnv ──────────────────────────────────────────────────
+
+describe('getPowershellToolEnv', () => {
+  test('returns undefined when neither env var is set', async () => {
+    const { getPowershellToolEnv } = await import('./shellToolUtils.js')
+    expect(getPowershellToolEnv()).toBeUndefined()
+  })
+
+  test('returns preferred when OPENCLAUDE_USE_POWERSHELL_TOOL is set', async () => {
+    process.env.OPENCLAUDE_USE_POWERSHELL_TOOL = '1'
+    const { getPowershellToolEnv } = await import('./shellToolUtils.js')
+    expect(getPowershellToolEnv()).toBe('1')
+  })
+
+  test('returns legacy fallback when only CLAUDE_CODE_USE_POWERSHELL_TOOL is set', async () => {
+    process.env.CLAUDE_CODE_USE_POWERSHELL_TOOL = 'true'
+    const { getPowershellToolEnv } = await import('./shellToolUtils.js')
+    expect(getPowershellToolEnv()).toBe('true')
+  })
+
+  test('preferred wins when both env vars are set', async () => {
+    process.env.OPENCLAUDE_USE_POWERSHELL_TOOL = '1'
+    process.env.CLAUDE_CODE_USE_POWERSHELL_TOOL = '0'
+    const { getPowershellToolEnv } = await import('./shellToolUtils.js')
+    expect(getPowershellToolEnv()).toBe('1')
+  })
+})
+
+// ── isPowerShellToolEnabled (Windows — process.platform === 'win32') ──────
+
+describe('isPowerShellToolEnabled (Windows)', () => {
+  test('enabled when preferred env var is truthy (external user)', async () => {
+    process.env.OPENCLAUDE_USE_POWERSHELL_TOOL = '1'
+    const { isPowerShellToolEnabled } = await import('./shellToolUtils.js')
+    expect(isPowerShellToolEnabled()).toBe(true)
+  })
+
+  test('enabled when only legacy env var is truthy (external user)', async () => {
+    process.env.CLAUDE_CODE_USE_POWERSHELL_TOOL = 'true'
+    const { isPowerShellToolEnabled } = await import('./shellToolUtils.js')
+    expect(isPowerShellToolEnabled()).toBe(true)
+  })
+
+  test('disabled when neither env var is set (external user)', async () => {
+    const { isPowerShellToolEnabled } = await import('./shellToolUtils.js')
+    expect(isPowerShellToolEnabled()).toBe(false)
+  })
+
+  test('disabled when preferred is falsy and legacy is unset (external user)', async () => {
+    process.env.OPENCLAUDE_USE_POWERSHELL_TOOL = '0'
+    const { isPowerShellToolEnabled } = await import('./shellToolUtils.js')
+    expect(isPowerShellToolEnabled()).toBe(false)
+  })
+
+  test('enabled for ant user when env var is unset (default-on)', async () => {
+    process.env.USER_TYPE = 'ant'
+    const { isPowerShellToolEnabled } = await import('./shellToolUtils.js')
+    expect(isPowerShellToolEnabled()).toBe(true)
+  })
+
+  test('disabled for ant user when preferred is explicitly falsy', async () => {
+    process.env.USER_TYPE = 'ant'
+    process.env.OPENCLAUDE_USE_POWERSHELL_TOOL = '0'
+    const { isPowerShellToolEnabled } = await import('./shellToolUtils.js')
+    expect(isPowerShellToolEnabled()).toBe(false)
+  })
+
+  test('disabled for ant user when legacy is explicitly falsy and preferred is unset', async () => {
+    process.env.USER_TYPE = 'ant'
+    process.env.CLAUDE_CODE_USE_POWERSHELL_TOOL = 'false'
+    const { isPowerShellToolEnabled } = await import('./shellToolUtils.js')
+    expect(isPowerShellToolEnabled()).toBe(false)
+  })
+})
+
+// ── resolveDefaultShell (Windows — real platform) ─────────────────────────
+
+describe('resolveDefaultShell (Windows)', () => {
+  test('returns bash by default on Windows without env var', async () => {
+    const { resolveDefaultShell } = await import('./resolveDefaultShell.js')
+    expect(resolveDefaultShell()).toBe('bash')
+  })
+
+  test('returns powershell when preferred env var is truthy on Windows', async () => {
+    process.env.OPENCLAUDE_USE_POWERSHELL_TOOL = '1'
+    mock.module('../settings/settings.js', () => ({
+      getInitialSettings: () => ({}),
+    }))
+    const { resolveDefaultShell } = await import('./resolveDefaultShell.js')
+    expect(resolveDefaultShell()).toBe('powershell')
+    mock.module('../settings/settings.js', () => ({}))
+  })
+
+  test('returns powershell when only legacy env var is truthy on Windows', async () => {
+    process.env.CLAUDE_CODE_USE_POWERSHELL_TOOL = 'true'
+    mock.module('../settings/settings.js', () => ({
+      getInitialSettings: () => ({}),
+    }))
+    const { resolveDefaultShell } = await import('./resolveDefaultShell.js')
+    expect(resolveDefaultShell()).toBe('powershell')
+    mock.module('../settings/settings.js', () => ({}))
+  })
+
+  test('preferred env var wins over legacy for default shell', async () => {
+    process.env.OPENCLAUDE_USE_POWERSHELL_TOOL = '1'
+    process.env.CLAUDE_CODE_USE_POWERSHELL_TOOL = '0'
+    mock.module('../settings/settings.js', () => ({
+      getInitialSettings: () => ({}),
+    }))
+    const { resolveDefaultShell } = await import('./resolveDefaultShell.js')
+    expect(resolveDefaultShell()).toBe('powershell')
+    mock.module('../settings/settings.js', () => ({}))
+  })
+
+  test('settings.defaultShell overrides env var', async () => {
+    process.env.OPENCLAUDE_USE_POWERSHELL_TOOL = '1'
+    mock.module('../settings/settings.js', () => ({
+      getInitialSettings: () => ({ defaultShell: 'bash' as const }),
+    }))
+    const { resolveDefaultShell } = await import('./resolveDefaultShell.js')
+    expect(resolveDefaultShell()).toBe('bash')
+    mock.module('../settings/settings.js', () => ({}))
+  })
+
+  test('settings.defaultShell=powershell wins regardless of env var', async () => {
+    mock.module('../settings/settings.js', () => ({
+      getInitialSettings: () => ({ defaultShell: 'powershell' as const }),
+    }))
+    const { resolveDefaultShell } = await import('./resolveDefaultShell.js')
+    expect(resolveDefaultShell()).toBe('powershell')
+    mock.module('../settings/settings.js', () => ({}))
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Tests that use mock.module for platform (MUST RUN LAST)
+// mock.module in Bun cannot be reliably restored — it leaks across tests
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('isPowerShellToolEnabled (non-Windows)', () => {
+  test('returns false on macOS even with env var set', async () => {
+    mock.module('../platform.js', () => ({
+      getPlatform: () => 'macos',
+    }))
+    process.env.OPENCLAUDE_USE_POWERSHELL_TOOL = '1'
+    const { isPowerShellToolEnabled } = await import('./shellToolUtils.js')
+    expect(isPowerShellToolEnabled()).toBe(false)
+  })
+
+  test('returns false on Linux even with legacy env var set', async () => {
+    mock.module('../platform.js', () => ({
+      getPlatform: () => 'linux',
+    }))
+    process.env.CLAUDE_CODE_USE_POWERSHELL_TOOL = '1'
+    const { isPowerShellToolEnabled } = await import('./shellToolUtils.js')
+    expect(isPowerShellToolEnabled()).toBe(false)
+  })
+})
+
+describe('resolveDefaultShell (non-Windows)', () => {
+  test('returns bash on non-Windows even with env var set', async () => {
+    process.env.OPENCLAUDE_USE_POWERSHELL_TOOL = '1'
+    mock.module('../platform.js', () => ({
+      getPlatform: () => 'macos',
+    }))
+    mock.module('../settings/settings.js', () => ({
+      getInitialSettings: () => ({}),
+    }))
+    const { resolveDefaultShell } = await import('./resolveDefaultShell.js')
+    expect(resolveDefaultShell()).toBe('bash')
+  })
+})

--- a/src/utils/shell/shellToolUtils.ts
+++ b/src/utils/shell/shellToolUtils.ts
@@ -17,6 +17,6 @@ export const SHELL_TOOL_NAMES: string[] = [BASH_TOOL_NAME, POWERSHELL_TOOL_NAME]
 export function isPowerShellToolEnabled(): boolean {
   if (getPlatform() !== 'windows') return false
   return process.env.USER_TYPE === 'ant'
-    ? !isEnvDefinedFalsy(process.env.CLAUDE_CODE_USE_POWERSHELL_TOOL)
-    : isEnvTruthy(process.env.CLAUDE_CODE_USE_POWERSHELL_TOOL)
+    ? !isEnvDefinedFalsy(process.env.OPENCLAUDE_USE_POWERSHELL_TOOL)
+    : isEnvTruthy(process.env.OPENCLAUDE_USE_POWERSHELL_TOOL)
 }

--- a/src/utils/shell/shellToolUtils.ts
+++ b/src/utils/shell/shellToolUtils.ts
@@ -6,6 +6,19 @@ import { getPlatform } from '../platform.js'
 export const SHELL_TOOL_NAMES: string[] = [BASH_TOOL_NAME, POWERSHELL_TOOL_NAME]
 
 /**
+ * Resolve the PowerShell-tool env var with backward-compatible fallback.
+ *
+ *   explicit OPENCLAUDE_USE_POWERSHELL_TOOL
+ *   else fall back to CLAUDE_CODE_USE_POWERSHELL_TOOL (legacy)
+ */
+export function getPowershellToolEnv(): string | undefined {
+  return (
+    process.env.OPENCLAUDE_USE_POWERSHELL_TOOL ??
+    process.env.CLAUDE_CODE_USE_POWERSHELL_TOOL
+  )
+}
+
+/**
  * Runtime gate for PowerShellTool. Windows-only (the permission engine uses
  * Win32-specific path normalizations). Ant defaults on (opt-out via env=0);
  * external defaults off (opt-in via env=1).
@@ -17,6 +30,6 @@ export const SHELL_TOOL_NAMES: string[] = [BASH_TOOL_NAME, POWERSHELL_TOOL_NAME]
 export function isPowerShellToolEnabled(): boolean {
   if (getPlatform() !== 'windows') return false
   return process.env.USER_TYPE === 'ant'
-    ? !isEnvDefinedFalsy(process.env.OPENCLAUDE_USE_POWERSHELL_TOOL)
-    : isEnvTruthy(process.env.OPENCLAUDE_USE_POWERSHELL_TOOL)
+    ? !isEnvDefinedFalsy(getPowershellToolEnv())
+    : isEnvTruthy(getPowershellToolEnv())
 }


### PR DESCRIPTION
## Summary

When users set `CLAUDE_CODE_USE_POWERSHELL_TOOL=true` to enable the PowerShell tool on Windows, also resolve PowerShell as the default shell for `!` commands and bash-mode.

Previously, users had to separately configure `defaultShell: powershell` in settings.json even after enabling the env var. This change makes the env var a single opt-in switch that fully activates PowerShell on Windows.

## Change

`src/utils/shell/resolveDefaultShell.ts` — added Windows + env var check in the fallback chain:

```
settings.defaultShell -> (Windows + CLAUDE_CODE_USE_POWERSHELL_TOOL) -> 'bash'
```

## Safety

- **No change for existing users unless they explicitly set the env var.** Without `CLAUDE_CODE_USE_POWERSHELL_TOOL=true`, behavior is identical.
- Follows the same pattern already used elsewhere (`isEnvTruthy`, `getPlatform`).
- Non-Windows platforms unaffected.
