### PR TITLE
fix(openai-shim): strip `store` when baseUrl points at Mistral

### DIFF
--- a/src/services/api/openaiShim.test.ts
+++ b/src/services/api/openaiShim.test.ts
@@ -6273,6 +6273,11 @@ test('Mistral host fallback: strips store on an unresolved Mistral-host route (#
   // The shim sets `store: false` on every chat_completions body; without the
   // fallback this unresolved route would forward it and hit Mistral's 422.
   expect(requestBody?.store).toBeUndefined()
+  // #739's Mistral 422 rejects `max_completion_tokens` as well — the host
+  // fallback must also map it to `max_tokens` on the unresolved route, since
+  // the generic config leaves the `max_completion_tokens` default.
+  expect(requestBody?.max_completion_tokens).toBeUndefined()
+  expect(requestBody?.max_tokens).toBe(64)
 })
 
 test('hasMistralApiHost matches the Mistral host and its subdomains only', () => {

--- a/src/services/api/openaiShim.test.ts
+++ b/src/services/api/openaiShim.test.ts
@@ -4162,6 +4162,38 @@ test('Local provider (vLLM/Ollama/etc.): strips unsupported store on chat_comple
   expect(requestBody?.store).toBeUndefined()
 })
 
+test('Mistral: strips unsupported store on chat_completions (#739)', async () => {
+  process.env.OPENAI_BASE_URL = 'https://api.mistral.ai/v1'
+  process.env.OPENAI_API_KEY = 'mistral-test'
+
+  let requestBody: Record<string, unknown> | undefined
+  globalThis.fetch = (async (_input, init) => {
+    requestBody = JSON.parse(String(init?.body))
+    return new Response(
+      JSON.stringify({
+        id: 'chatcmpl-1',
+        model: 'codestral-2508',
+        choices: [
+          { message: { role: 'assistant', content: 'ok' }, finish_reason: 'stop' },
+        ],
+        usage: { prompt_tokens: 3, completion_tokens: 1, total_tokens: 4 },
+      }),
+      { headers: { 'Content-Type': 'application/json' } },
+    )
+  }) as FetchType
+
+  const client = createOpenAIShimClient({}) as OpenAIShimClient
+  await client.beta.messages.create({
+    model: 'codestral-2508',
+    system: 'you are mistral',
+    messages: [{ role: 'user', content: 'hi' }],
+    max_tokens: 64,
+    stream: false,
+  })
+
+  expect(requestBody?.store).toBeUndefined()
+})
+
 test('Groq: keeps max_completion_tokens and strips unsupported store', async () => {
   process.env.OPENAI_BASE_URL = 'https://api.groq.com/openai/v1'
   process.env.OPENAI_API_KEY = 'gsk-test'

--- a/src/services/api/openaiShim.test.ts
+++ b/src/services/api/openaiShim.test.ts
@@ -5,7 +5,7 @@ import { asMockFetch } from '../../test/typedMocks.js'
 import { _clearRegistryForTesting, ensureIntegrationsLoaded, registerGateway } from '../../integrations/index.ts'
 import { applyProviderFlag } from '../../utils/providerFlag.ts'
 import { applyProviderProfileToProcessEnv } from '../../utils/providerProfiles.ts'
-import { createOpenAIShimClient } from './openaiShim.ts'
+import { createOpenAIShimClient, hasMistralApiHost } from './openaiShim.ts'
 import * as realCodexShim from './codexShim.js'
 import * as realGithubModelsCredentials from '../../utils/githubModelsCredentials.js'
 
@@ -6233,6 +6233,58 @@ test('Mistral: strips unsupported store on chat_completions (#739)', async () =>
   })
 
   expect(requestBody?.store).toBeUndefined()
+})
+
+test('Mistral host fallback: strips store on an unresolved Mistral-host route (#739)', async () => {
+  // `api.mistral.ai/v1` resolves to the Mistral descriptor route, whose
+  // removeBodyFields already strips `store` — so the test above passes even
+  // without the hasMistralApiHost fallback. This case pins the fallback's real
+  // value: a Mistral-host proxy (`proxy.mistral.ai`) that does NOT resolve to a
+  // descriptor route (resolveRouteIdFromBaseUrl returns null, no
+  // removeBodyFields), so `store` is stripped *only* by hasMistralApiHost.
+  process.env.OPENAI_BASE_URL = 'https://proxy.mistral.ai/v1'
+  process.env.OPENAI_API_KEY = 'mistral-test'
+
+  let requestBody: Record<string, unknown> | undefined
+  globalThis.fetch = (async (_input, init) => {
+    requestBody = JSON.parse(String(init?.body))
+    return new Response(
+      JSON.stringify({
+        id: 'chatcmpl-1',
+        model: 'codestral-2508',
+        choices: [
+          { message: { role: 'assistant', content: 'ok' }, finish_reason: 'stop' },
+        ],
+        usage: { prompt_tokens: 3, completion_tokens: 1, total_tokens: 4 },
+      }),
+      { headers: { 'Content-Type': 'application/json' } },
+    )
+  }) as FetchType
+
+  const client = createOpenAIShimClient({}) as OpenAIShimClient
+  await client.beta.messages.create({
+    model: 'codestral-2508',
+    system: 'you are mistral',
+    messages: [{ role: 'user', content: 'hi' }],
+    max_tokens: 64,
+    stream: false,
+  })
+
+  // The shim sets `store: false` on every chat_completions body; without the
+  // fallback this unresolved route would forward it and hit Mistral's 422.
+  expect(requestBody?.store).toBeUndefined()
+})
+
+test('hasMistralApiHost matches the Mistral host and its subdomains only', () => {
+  expect(hasMistralApiHost('https://api.mistral.ai/v1')).toBe(true)
+  expect(hasMistralApiHost('https://proxy.mistral.ai/v1')).toBe(true)
+  expect(hasMistralApiHost('https://eu.mistral.ai/v1')).toBe(true)
+  // Non-Mistral hosts (and look-alikes) must keep `store`.
+  expect(hasMistralApiHost('https://api.openai.com/v1')).toBe(false)
+  expect(hasMistralApiHost('https://notmistral.ai/v1')).toBe(false)
+  expect(hasMistralApiHost('https://api.mistral.ai.evil.com/v1')).toBe(false)
+  expect(hasMistralApiHost(undefined)).toBe(false)
+  expect(hasMistralApiHost('not a url')).toBe(false)
 })
 
 test('Groq: keeps max_completion_tokens and strips unsupported store', async () => {

--- a/src/services/api/openaiShim.test.ts
+++ b/src/services/api/openaiShim.test.ts
@@ -6203,6 +6203,38 @@ test('Local provider (vLLM/Ollama/etc.): strips unsupported store on chat_comple
   expect(requestBody?.store).toBeUndefined()
 })
 
+test('Mistral: strips unsupported store on chat_completions (#739)', async () => {
+  process.env.OPENAI_BASE_URL = 'https://api.mistral.ai/v1'
+  process.env.OPENAI_API_KEY = 'mistral-test'
+
+  let requestBody: Record<string, unknown> | undefined
+  globalThis.fetch = (async (_input, init) => {
+    requestBody = JSON.parse(String(init?.body))
+    return new Response(
+      JSON.stringify({
+        id: 'chatcmpl-1',
+        model: 'codestral-2508',
+        choices: [
+          { message: { role: 'assistant', content: 'ok' }, finish_reason: 'stop' },
+        ],
+        usage: { prompt_tokens: 3, completion_tokens: 1, total_tokens: 4 },
+      }),
+      { headers: { 'Content-Type': 'application/json' } },
+    )
+  }) as FetchType
+
+  const client = createOpenAIShimClient({}) as OpenAIShimClient
+  await client.beta.messages.create({
+    model: 'codestral-2508',
+    system: 'you are mistral',
+    messages: [{ role: 'user', content: 'hi' }],
+    max_tokens: 64,
+    stream: false,
+  })
+
+  expect(requestBody?.store).toBeUndefined()
+})
+
 test('Groq: keeps max_completion_tokens and strips unsupported store', async () => {
   process.env.OPENAI_BASE_URL = 'https://api.groq.com/openai/v1'
   process.env.OPENAI_API_KEY = 'gsk-test'

--- a/src/services/api/openaiShim.ts
+++ b/src/services/api/openaiShim.ts
@@ -3159,8 +3159,13 @@ class OpenAIShimMessages {
       hasMistralApiHost(request.baseUrl) ||
       isLocal
 
+    // Mistral's chat completions reject `max_completion_tokens` (and `store`).
+    // When the route resolves to the Mistral descriptor the config already maps
+    // to `max_tokens`; on the host-detected fallback (`hasMistralApiHost`) the
+    // generic default leaves `max_completion_tokens`, so map it here too.
     if (
-      shimConfig.maxTokensField === 'max_tokens' &&
+      (shimConfig.maxTokensField === 'max_tokens' ||
+        hasMistralApiHost(request.baseUrl)) &&
       body.max_completion_tokens !== undefined
     ) {
       body.max_tokens = body.max_completion_tokens

--- a/src/services/api/openaiShim.ts
+++ b/src/services/api/openaiShim.ts
@@ -157,6 +157,17 @@ function hasCerebrasApiHost(baseUrl: string | undefined): boolean {
   }
 }
 
+function hasMistralApiHost(baseUrl: string | undefined): boolean {
+  if (!baseUrl) return false
+
+  try {
+    const host = new URL(baseUrl).hostname.toLowerCase()
+    return host === 'api.mistral.ai' || host.endsWith('.mistral.ai')
+  } catch {
+    return false
+  }
+}
+
 function normalizeDeepSeekReasoningEffort(
   effort: 'low' | 'medium' | 'high' | 'xhigh',
 ): 'high' | 'max' {
@@ -1607,6 +1618,7 @@ class OpenAIShimMessages {
       isGeminiMode() ||
       hasGeminiApiHost(request.baseUrl) ||
       hasCerebrasApiHost(request.baseUrl) ||
+      hasMistralApiHost(request.baseUrl) ||
       isLocal
 
     if (

--- a/src/services/api/openaiShim.ts
+++ b/src/services/api/openaiShim.ts
@@ -223,6 +223,17 @@ function hasCerebrasApiHost(baseUrl: string | undefined): boolean {
   }
 }
 
+function hasMistralApiHost(baseUrl: string | undefined): boolean {
+  if (!baseUrl) return false
+
+  try {
+    const host = new URL(baseUrl).hostname.toLowerCase()
+    return host === 'api.mistral.ai' || host.endsWith('.mistral.ai')
+  } catch {
+    return false
+  }
+}
+
 function formatRetryAfterHint(response: Response): string {
   const ra = response.headers.get('retry-after')
   return ra ? ` (Retry-After: ${ra})` : ''
@@ -3145,6 +3156,7 @@ class OpenAIShimMessages {
       isGeminiMode() ||
       hasGeminiApiHost(request.baseUrl) ||
       hasCerebrasApiHost(request.baseUrl) ||
+      hasMistralApiHost(request.baseUrl) ||
       isLocal
 
     if (

--- a/src/services/api/openaiShim.ts
+++ b/src/services/api/openaiShim.ts
@@ -223,7 +223,7 @@ function hasCerebrasApiHost(baseUrl: string | undefined): boolean {
   }
 }
 
-function hasMistralApiHost(baseUrl: string | undefined): boolean {
+export function hasMistralApiHost(baseUrl: string | undefined): boolean {
   if (!baseUrl) return false
 
   try {


### PR DESCRIPTION
## Summary

Mistral's chat-completions endpoint rejects requests with a `store` field — `422 body.store: Extra inputs are not permitted` (see #739) — and also rejects `max_completion_tokens` for some models. The shim already strips `store` for Gemini and Cerebras hosts via `hasGeminiApiHost` / `hasCerebrasApiHost` (PRs #959, #1040). This adds the symmetric Mistral host check (`hasMistralApiHost`) so a request routed at a Mistral host — **without** `CLAUDE_CODE_USE_MISTRAL=1` engaging the gateway profile — gets the same two adjustments: `store` stripped, and `max_completion_tokens` mapped to `max_tokens`.

The standard `https://api.mistral.ai/v1` URL already resolves to the Mistral gateway descriptor on `main`, so the real new delta here is **unresolved `.mistral.ai` hosts** — e.g. `proxy.mistral.ai` or other subdomains that don't match the descriptor route — which previously fell through untouched and 422'd.

## Impact

- **Users:** `OPENAI_BASE_URL` pointing at a Mistral host that isn't the canonical descriptor route (e.g. `proxy.mistral.ai`) no longer 422s on `store`, and no longer sends an unsupported `max_completion_tokens`.
- **Devs:** new `hasMistralApiHost(baseUrl)` predicate (hostname-based, handles subdomains + look-alikes + invalid URLs); one OR added to `shouldStripResponsesStore`, and the `max_completion_tokens`→`max_tokens` mapping now also fires when `hasMistralApiHost(request.baseUrl)` is true.

## Testing

- [x] `Mistral: strips unsupported store on chat_completions (#739)` mirrors the Cerebras/Gemini cases.
- [x] `Mistral host fallback: strips store on an unresolved Mistral-host route` exercises the `hasMistralApiHost` path on a `proxy.mistral.ai` URL that does not resolve to the descriptor route (fails without this change), and asserts `max_completion_tokens` is mapped to `max_tokens`.
- [x] `hasMistralApiHost` predicate test for subdomains and look-alikes.
- [x] `bun test src/services/api/openaiShim.test.ts` — green.
- [x] `bun run build` — bundle clean.

## Notes

- Scope: for Mistral hosts that aren't the canonical descriptor route, strip `store` and map `max_completion_tokens`→`max_tokens`. The full Mistral profile (devstral defaults etc.) still requires `CLAUDE_CODE_USE_MISTRAL=1` to engage the gateway descriptor at `src/integrations/gateways/mistral.ts`.
- Related to #739.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed OpenAI-compatible requests to Mistral endpoints by automatically removing unsupported top-level `store` fields (including responses-style requests).
  * Improved Mistral endpoint detection for `.mistral.ai` subdomains and invalid URL handling, and enhanced `max_tokens`/`max_completion_tokens` compatibility so only the supported value is sent.

* **Tests**
  * Added Mistral-specific coverage validating request shaping for both direct and fallback host cases, plus unit tests for host-matching behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
