### PR TITLE
fix(openai-shim): strip `store` for local providers (vLLM, custom)

### DIFF
--- a/src/services/api/openaiShim.test.ts
+++ b/src/services/api/openaiShim.test.ts
@@ -4130,6 +4130,38 @@ test('Cerebras: strips unsupported store on chat_completions (#1023)', async () 
   expect(requestBody?.store).toBeUndefined()
 })
 
+test('Local provider (vLLM/Ollama/etc.): strips unsupported store on chat_completions (#672)', async () => {
+  process.env.OPENAI_BASE_URL = 'http://localhost:8000/v1'
+  process.env.OPENAI_API_KEY = 'sk-local'
+
+  let requestBody: Record<string, unknown> | undefined
+  globalThis.fetch = (async (_input, init) => {
+    requestBody = JSON.parse(String(init?.body))
+    return new Response(
+      JSON.stringify({
+        id: 'chatcmpl-1',
+        model: 'qwen-3.5-27b',
+        choices: [
+          { message: { role: 'assistant', content: 'ok' }, finish_reason: 'stop' },
+        ],
+        usage: { prompt_tokens: 3, completion_tokens: 1, total_tokens: 4 },
+      }),
+      { headers: { 'Content-Type': 'application/json' } },
+    )
+  }) as FetchType
+
+  const client = createOpenAIShimClient({}) as OpenAIShimClient
+  await client.beta.messages.create({
+    model: 'qwen-3.5-27b',
+    system: 'you are local',
+    messages: [{ role: 'user', content: 'hi' }],
+    max_tokens: 64,
+    stream: false,
+  })
+
+  expect(requestBody?.store).toBeUndefined()
+})
+
 test('Groq: keeps max_completion_tokens and strips unsupported store', async () => {
   process.env.OPENAI_BASE_URL = 'https://api.groq.com/openai/v1'
   process.env.OPENAI_API_KEY = 'gsk-test'

--- a/src/services/api/openaiShim.ts
+++ b/src/services/api/openaiShim.ts
@@ -1613,7 +1613,8 @@ class OpenAIShimMessages {
       (shimConfig.removeBodyFields ?? []).includes('store') ||
       isGeminiMode() ||
       hasGeminiApiHost(request.baseUrl) ||
-      hasCerebrasApiHost(request.baseUrl)
+      hasCerebrasApiHost(request.baseUrl) ||
+      isLocal
 
     if (
       shimConfig.maxTokensField === 'max_tokens' &&


### PR DESCRIPTION
## Summary

Local OpenAI-compatible servers (vLLM, llama.cpp, custom self-hosted gateways) frequently validate request bodies against a strict JSON schema and reject unknown fields with 400. The shim sends `store: false` — an OpenAI-only flag for cloud conversation persistence — and already strips it for cloud hosts that share the same intolerance (Gemini #959, Cerebras #1040). Local servers have no remote-storage concept and belong in the same bucket.

This PR adds `isLocal` to `shouldStripResponsesStore`, so any baseUrl resolved by `isLocalProviderUrl()` (`localhost` / `127.0.0.1` / `::1` / `0.0.0.0`) gets the field removed.

## Impact

- **Users:** strict local backends (vLLM + Qwen, llama.cpp custom builds) no longer 400 on first request. Lenient ones (Ollama) already ignored the field — no behavior change for them.
- **Devs:** single-line OR added to existing strip predicate. Pattern matches the merged Cerebras/Gemini host predicates.

## Testing

- [x] New unit test: `Local provider (vLLM/Ollama/etc.): strips unsupported store on chat_completions (#672)` covers `http://localhost:8000/v1`.
- [x] `bun test src/services/api/openaiShim.test.ts` — 92 pass / 0 fail.
- [x] `bun run build` — bundle clean.
- [x] `bun run smoke` — 0.9.2 OK.

## Notes

- Scope: `store`-only. Issue #672 also lists a separate `max_tokens=32000` default colliding with vLLM `max_model_len=32768` — that's a model-context concern, not a wire-shape one, and would need to land on the catalog/context side. Out of scope here.
- Closes #672 (store symptom).