### PR TITLE
fix(bashSecurity): reject nested heredoc ranges in stripSafeHeredocSubstitutions

### DIFF
--- a/src/tools/BashTool/bashSecurity.test.ts
+++ b/src/tools/BashTool/bashSecurity.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, test } from 'bun:test'
+
+import { stripSafeHeredocSubstitutions } from './bashSecurity.js'
+
+describe('stripSafeHeredocSubstitutions', () => {
+  test('strips a single safe heredoc substitution', () => {
+    const cmd = "git commit -m $(cat <<'EOF'\nfix: whatever\nEOF\n)"
+    const result = stripSafeHeredocSubstitutions(cmd)
+    expect(result).toBe('git commit -m ')
+  })
+
+  test('returns null for nested heredoc substitutions (stale-index regression)', () => {
+    const cmd = "$(cat <<'OUTER'\n$(cat <<'INNER'\ndata\nINNER)\nOUTER)"
+    const result = stripSafeHeredocSubstitutions(cmd)
+    expect(result).toBeNull()
+  })
+
+  test('returns null when no heredoc substitution is present', () => {
+    const result = stripSafeHeredocSubstitutions('echo hello world')
+    expect(result).toBeNull()
+  })
+
+  test('strips multiple non-nested heredoc substitutions', () => {
+    const cmd = "$(cat <<'A'\nfoo\nA) $(cat <<'B'\nbar\nB)"
+    const result = stripSafeHeredocSubstitutions(cmd)
+    expect(result).toBe(' ')
+  })
+})

--- a/src/tools/BashTool/bashSecurity.ts
+++ b/src/tools/BashTool/bashSecurity.ts
@@ -570,6 +570,22 @@ export function stripSafeHeredocSubstitutions(command: string): string | null {
     }
   }
   if (!found) return null
+
+  // SECURITY: Reject nested matches — same logic as isSafeHeredoc.
+  // When one range is nested inside another, processing in reverse order leaves
+  // outer.end stale after the inner strip. result.slice(outer.end) then skips
+  // any suffix after the outer heredoc (e.g., `; rm -rf /`), silently dropping
+  // it from the remaining text and hiding it from downstream validators.
+  // Return null so callers fall back to full command validation.
+  for (const outer of ranges) {
+    for (const inner of ranges) {
+      if (inner === outer) continue
+      if (inner.start > outer.start && inner.start < outer.end) {
+        return null
+      }
+    }
+  }
+
   for (let i = ranges.length - 1; i >= 0; i--) {
     const r = ranges[i]!
     result = result.slice(0, r.start) + result.slice(r.end)


### PR DESCRIPTION
## Summary

`isSafeHeredoc` already rejects nested `$(cat <<'A'...A)` matches to prevent a stale-index bug when stripping in reverse order (see existing comment at line ~450). `stripSafeHeredocSubstitutions` was missing the same guard.

**The bug:** When two heredoc ranges are nested (inner inside outer), stripping in reverse order leaves `outer.end` stale after the inner strip. `result.slice(outer.end)` then skips any trailing content after the outer heredoc — for example `` ; rm -rf / `` — silently hiding it from downstream validators.

**The fix:** Return `null` on nested ranges so callers fall back to full command validation. Same semantics as `isSafeHeredoc` — nested heredocs are extremely rare in legitimate use and are a red flag regardless.

**Attack surface:** `stripSafeHeredocSubstitutions` is exported and used by `hasSafeHeredocSubstitution`. The primary security path (`validateSafeCommandSubstitution` → `isSafeHeredoc`) is already protected — this closes the gap in the secondary export.

## Test plan

- [ ] `stripSafeHeredocSubstitutions('echo x $(cat <<\'A\'\n$(cat <<\'B\'\nB)\nA) ; rm -rf /')` → `null` (was returning `'echo x '`, dropping the ` ; rm -rf /` suffix)
- [ ] `stripSafeHeredocSubstitutions('echo x $(cat <<\'EOF\'\nconteúdo\nEOF\n)')` → `'echo x '` (normal case unaffected)
- [ ] `hasSafeHeredocSubstitution` returns `false` for nested case (was `true`)

## Related

Found via static analysis / code review of `bashSecurity.ts`. Also reporting two lower-severity issues in a separate issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)