### PR TITLE
docs: update setup guides to clarify the only available auth method for Gemini

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ Advanced and source-build guides:
 | --- | --- | --- |
 | OpenAI-compatible | `/provider` or env vars | Works with OpenAI, OpenRouter, DeepSeek, Groq, Mistral, LM Studio, and other compatible `/v1` servers |
 | Hicap | `/provider` or OpenAI-compatible env vars | Uses `api-key` auth, discovers models from unauthenticated `/models`, and supports Responses mode for `gpt-` models |
-| Gemini | `/provider` or env vars | Supports API key, access token, or local ADC workflow on current `main` |
+| Gemini | `/provider` or env vars | Supports API key only |
 | GitHub Models | `/onboard-github` | Interactive onboarding with saved credentials |
 | Codex OAuth | `/provider` | Opens ChatGPT sign-in in your browser and stores Codex credentials securely |
 | Codex | `/provider` | Uses existing Codex CLI auth, OpenClaude secure storage, or env credentials |

--- a/docs/advanced-setup.md
+++ b/docs/advanced-setup.md
@@ -86,9 +86,6 @@ export GEMINI_API_KEY=...
 export GEMINI_MODEL=gemini-3-flash-preview
 ```
 
-If you prefer access-token or ADC-based Gemini auth instead of an API key, use
-the guided `/provider` flow.
-
 ### Gemini via OpenRouter
 
 ```bash


### PR DESCRIPTION
Gemini authentication with Access token and local ADC workflow is mentioned to be supported. However, only API key authentication is available.

## Summary

- Clarified the Gemini authentication methods
- To match the reality

## Impact

- user-facing impact:
- developer/maintainer impact:

## Testing

- [ ] `bun run build`
- [ ] `bun run smoke`
- [ ] focused tests:

## Notes

- provider/model path tested:
- screenshots attached (if UI changed):
- follow-up work or known limitations:
