### PR TITLE
perf(local): add OPENCLAUDE_LOCAL_FAST_PATH to skip cloud-only transforms

### DIFF
--- a/src/services/api/openaiShim.ts
+++ b/src/services/api/openaiShim.ts
@@ -56,12 +56,14 @@ import { buildAnthropicUsageFromRawUsage } from './cacheMetrics.js'
 import { compressToolHistory } from './compressToolHistory.js'
 import { fetchWithProxyRetry } from './fetchWithProxyRetry.js'
 import {
+  getLocalFastPathConfig,
   getLocalProviderRetryBaseUrls,
   getGithubEndpointType,
   isLocalProviderUrl,
   resolveRuntimeCodexCredentials,
   resolveProviderRequest,
   shouldAttemptLocalToollessRetry,
+  type LocalFastPathConfig,
 } from './providerConfig.js'
 import {
   buildOpenAICompatibilityErrorMessage,
@@ -814,8 +816,13 @@ function normalizeSchemaForOpenAI(
 
 function convertTools(
   tools: Array<{ name: string; description?: string; input_schema?: Record<string, unknown> }>,
+  options: { skipStrict?: boolean } = {},
 ): OpenAITool[] {
   const isGemini = isGeminiMode()
+  const strict =
+    !isGemini &&
+    !isEnvTruthy(process.env.OPENCLAUDE_DISABLE_STRICT_TOOLS) &&
+    !options.skipStrict
 
   return tools
     .filter(t => t.name !== 'ToolSearchTool') // Not relevant for OpenAI
@@ -838,10 +845,7 @@ function convertTools(
         function: {
           name: t.name,
           description: t.description ?? '',
-          parameters: normalizeSchemaForOpenAI(
-            schema,
-            !isGemini && !isEnvTruthy(process.env.OPENCLAUDE_DISABLE_STRICT_TOOLS),
-          ),
+          parameters: normalizeSchemaForOpenAI(schema, strict),
         },
       }
     })
@@ -1550,14 +1554,20 @@ class OpenAIShimMessages {
     params: ShimCreateParams,
     options?: { signal?: AbortSignal; headers?: Record<string, string> },
   ): Promise<Response> {
-    const compressedMessages = compressToolHistory(
-      params.messages as Array<{
-        role: string
-        message?: { role?: string; content?: unknown }
-        content?: unknown
-      }>,
-      request.resolvedModel,
-    )
+    // Local backends (llama.cpp, vLLM, Ollama, LM Studio, …) do not implement
+    // the cloud-side caching/strict-validation behaviours that several of our
+    // pre-send transforms target. Computing the fast-path config once here
+    // lets us skip those transforms uniformly. See providerConfig.ts.
+    const fastPath: LocalFastPathConfig = getLocalFastPathConfig(request.baseUrl)
+
+    const rawMessages = params.messages as Array<{
+      role: string
+      message?: { role?: string; content?: unknown }
+      content?: unknown
+    }>
+    const compressedMessages = fastPath.skipToolHistoryCompression
+      ? rawMessages
+      : compressToolHistory(rawMessages, request.resolvedModel)
     const runtimeShimContext = resolveOpenAIShimRuntimeContext({
       processEnv: process.env,
       baseUrl: request.baseUrl,
@@ -1663,6 +1673,7 @@ class OpenAIShimMessages {
           description?: string
           input_schema?: Record<string, unknown>
         }>,
+        { skipStrict: fastPath.skipStrictTools },
       )
       if (converted.length > 0) {
         body.tools = converted
@@ -1897,14 +1908,21 @@ class OpenAIShimMessages {
     // depth so spurious insertion-order differences across rebuilds of
     // `body` (spread-merge, conditional assignments above) don't bust
     // the provider's prefix hash.
-    let serializedBody = stableStringify(
-      request.transport === 'responses' ? buildResponsesBody() : body,
-    )
+    //
+    // Local backends do not implement prefix caching, so the deep key-sort
+    // is pure CPU overhead per request (issue #1016). Drop to the native
+    // `JSON.stringify` fast path when the fast-path config opts out.
+    const serializeBody = (): string => {
+      const payload =
+        request.transport === 'responses' ? buildResponsesBody() : body
+      return fastPath.skipStableStringify
+        ? JSON.stringify(payload)
+        : stableStringify(payload)
+    }
+    let serializedBody = serializeBody()
 
     const refreshSerializedBody = (): void => {
-      serializedBody = stableStringify(
-        request.transport === 'responses' ? buildResponsesBody() : body,
-      )
+      serializedBody = serializeBody()
     }
 
     const buildFetchInit = () => ({

--- a/src/services/api/providerConfig.localFastPath.test.ts
+++ b/src/services/api/providerConfig.localFastPath.test.ts
@@ -1,0 +1,103 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+
+import { getLocalFastPathConfig } from './providerConfig.js'
+
+const ENV_VAR = 'OPENCLAUDE_LOCAL_FAST_PATH'
+const originalEnv = process.env[ENV_VAR]
+
+beforeEach(() => {
+  delete process.env[ENV_VAR]
+})
+
+afterEach(() => {
+  if (originalEnv === undefined) {
+    delete process.env[ENV_VAR]
+  } else {
+    process.env[ENV_VAR] = originalEnv
+  }
+})
+
+describe('getLocalFastPathConfig — auto-detect from baseUrl', () => {
+  test('engages on loopback', () => {
+    const cfg = getLocalFastPathConfig('http://localhost:11434/v1')
+    expect(cfg.enabled).toBe(true)
+    expect(cfg.skipStableStringify).toBe(true)
+    expect(cfg.skipStrictTools).toBe(true)
+    expect(cfg.skipToolHistoryCompression).toBe(true)
+  })
+
+  test('engages on private IPv4', () => {
+    expect(getLocalFastPathConfig('http://192.168.1.10:8000/v1').enabled).toBe(true)
+    expect(getLocalFastPathConfig('http://10.0.0.5:8000/v1').enabled).toBe(true)
+    expect(getLocalFastPathConfig('http://172.16.5.1:8000/v1').enabled).toBe(true)
+  })
+
+  test('engages on .local hostnames', () => {
+    expect(getLocalFastPathConfig('http://gpu-rig.local:11434/v1').enabled).toBe(true)
+  })
+
+  test('does not engage on public hosts', () => {
+    const cfg = getLocalFastPathConfig('https://api.openai.com/v1')
+    expect(cfg.enabled).toBe(false)
+    expect(cfg.skipStableStringify).toBe(false)
+    expect(cfg.skipStrictTools).toBe(false)
+    expect(cfg.skipToolHistoryCompression).toBe(false)
+  })
+
+  test('does not engage when baseUrl is undefined', () => {
+    expect(getLocalFastPathConfig(undefined).enabled).toBe(false)
+  })
+})
+
+describe('getLocalFastPathConfig — explicit env override', () => {
+  test('OPENCLAUDE_LOCAL_FAST_PATH=1 forces on against a public host', () => {
+    process.env[ENV_VAR] = '1'
+    const cfg = getLocalFastPathConfig('https://api.openai.com/v1')
+    expect(cfg.enabled).toBe(true)
+    expect(cfg.skipStableStringify).toBe(true)
+  })
+
+  test('OPENCLAUDE_LOCAL_FAST_PATH=0 forces off against localhost', () => {
+    process.env[ENV_VAR] = '0'
+    const cfg = getLocalFastPathConfig('http://localhost:11434/v1')
+    expect(cfg.enabled).toBe(false)
+    expect(cfg.skipStrictTools).toBe(false)
+  })
+
+  test('accepts truthy aliases (true / on / yes)', () => {
+    for (const v of ['true', 'on', 'yes', 'TRUE', 'On']) {
+      process.env[ENV_VAR] = v
+      expect(getLocalFastPathConfig('https://api.openai.com/v1').enabled).toBe(true)
+    }
+  })
+
+  test('accepts falsy aliases (false / off / no)', () => {
+    for (const v of ['false', 'off', 'no', 'FALSE', 'Off']) {
+      process.env[ENV_VAR] = v
+      expect(getLocalFastPathConfig('http://localhost:11434/v1').enabled).toBe(false)
+    }
+  })
+
+  test('"auto" / empty string fall through to baseUrl detection', () => {
+    process.env[ENV_VAR] = 'auto'
+    expect(getLocalFastPathConfig('http://localhost:11434/v1').enabled).toBe(true)
+    expect(getLocalFastPathConfig('https://api.openai.com/v1').enabled).toBe(false)
+
+    process.env[ENV_VAR] = ''
+    expect(getLocalFastPathConfig('http://localhost:11434/v1').enabled).toBe(true)
+  })
+
+  test('garbage values fall through to auto-detect', () => {
+    process.env[ENV_VAR] = 'maybe'
+    expect(getLocalFastPathConfig('http://localhost:11434/v1').enabled).toBe(true)
+    expect(getLocalFastPathConfig('https://api.openai.com/v1').enabled).toBe(false)
+  })
+
+  test('explicit env arg takes precedence over process.env', () => {
+    process.env[ENV_VAR] = '0'
+    const cfg = getLocalFastPathConfig('https://api.openai.com/v1', {
+      [ENV_VAR]: '1',
+    } as NodeJS.ProcessEnv)
+    expect(cfg.enabled).toBe(true)
+  })
+})

--- a/src/services/api/providerConfig.ts
+++ b/src/services/api/providerConfig.ts
@@ -357,6 +357,70 @@ export function isLocalProviderUrl(baseUrl: string | undefined): boolean {
   }
 }
 
+// Fast-path opt-outs that are safe (and beneficial) when the provider is a
+// local OpenAI-compatible endpoint. These features are designed for cloud
+// behaviours that do not exist on local backends:
+//   - byte-stable serialization (`stableStringify`) targets implicit prefix
+//     caching on OpenAI/Kimi/DeepSeek/Codex; local backends do not hash
+//     request prefixes, so the deep key-sort is pure CPU overhead.
+//   - strict tool-schema normalization rewrites Anthropic schemas to the
+//     `additionalProperties: false` shape required by Groq/Azure; local
+//     llama.cpp/vLLM accept either form, so the recursive walk is wasted.
+//   - tool-result compression tiers tool_result blocks for stateless cloud
+//     providers; on a single-user local box where the conversation lives
+//     in RAM, the tier-walk is wasted unless the user opts back in.
+//
+// Issue #1016 traced cumulative client-side overhead as the dominant cause
+// of v0.5+ regressions against ~45 tok/s local models: against a 200ms cloud
+// API the layers are invisible, but against multi-second local round-trips
+// they multiply per-call.
+//
+// Set `OPENCLAUDE_LOCAL_FAST_PATH=1` to force it on, `=0` to force off, or
+// leave it unset to let `isLocalProviderUrl` decide. The opt-out is intended
+// to be conservative: if the env var is set explicitly, callers can audit
+// regressions; if not, behaviour only changes for hosts already classified
+// as local by the existing detector (loopback, RFC1918, .local, ULA/LL).
+const LOCAL_FAST_PATH_ENV = 'OPENCLAUDE_LOCAL_FAST_PATH'
+
+export type LocalFastPathConfig = {
+  enabled: boolean
+  skipStableStringify: boolean
+  skipStrictTools: boolean
+  skipToolHistoryCompression: boolean
+}
+
+const LOCAL_FAST_PATH_OFF: LocalFastPathConfig = {
+  enabled: false,
+  skipStableStringify: false,
+  skipStrictTools: false,
+  skipToolHistoryCompression: false,
+}
+
+const LOCAL_FAST_PATH_ON: LocalFastPathConfig = {
+  enabled: true,
+  skipStableStringify: true,
+  skipStrictTools: true,
+  skipToolHistoryCompression: true,
+}
+
+function parseLocalFastPathOverride(raw: string | undefined): boolean | undefined {
+  if (raw === undefined) return undefined
+  const v = raw.trim().toLowerCase()
+  if (v === '' || v === 'auto') return undefined
+  if (v === '0' || v === 'false' || v === 'off' || v === 'no') return false
+  if (v === '1' || v === 'true' || v === 'on' || v === 'yes') return true
+  return undefined
+}
+
+export function getLocalFastPathConfig(
+  baseUrl: string | undefined,
+  env: NodeJS.ProcessEnv = process.env,
+): LocalFastPathConfig {
+  const override = parseLocalFastPathOverride(env[LOCAL_FAST_PATH_ENV])
+  const enabled = override ?? isLocalProviderUrl(baseUrl)
+  return enabled ? LOCAL_FAST_PATH_ON : LOCAL_FAST_PATH_OFF
+}
+
 function trimTrailingSlash(value: string): string {
   return value.replace(/\/+$/, '')
 }


### PR DESCRIPTION
## Summary

Adds an opt-out — auto-detected for local hosts, overridable via `OPENCLAUDE_LOCAL_FAST_PATH` — that skips three pre-send transforms which target cloud behaviours that local OpenAI-compatible backends (llama.cpp, vLLM, Ollama, LM Studio, …) do not implement:

| Transform | Cloud purpose | Why it is wasted on local |
|---|---|---|
| `stableStringify` body serialization | byte-identity for OpenAI/Kimi/DeepSeek/Codex implicit prefix caching | local backends hash nothing — deep key-sort is pure CPU |
| Strict tool-schema rewrite (`additionalProperties: false`) | required by Groq/Azure strict mode | llama.cpp / vLLM / Ollama accept the original Anthropic shape |
| `compressToolHistory` tier walk | tiered compression for stateless cloud providers | local conversation lives in RAM; tier walk is pure CPU per request |

Issue #1016 traced cumulative client-side overhead as the dominant cause of v0.5+ regressions against ~45 tok/s local models — against a 200ms cloud API the layers are invisible, but against multi-second local round-trips they multiply per call. The proposed fix in the issue was an env-var opt-out; this PR ships it with auto-detect as the default so users don't have to know about it.

## How it works

- `getLocalFastPathConfig(baseUrl)` returns a flag bundle. `enabled` is `true` when the env var forces it on, `false` when it forces it off, otherwise it falls back to the existing `isLocalProviderUrl` (loopback / RFC1918 / `.local` / ULA / link-local).
- Override values: `1` / `true` / `on` / `yes` force on; `0` / `false` / `off` / `no` force off; `auto` / empty / unset / garbage fall through to detection.
- Wired at three call sites in `openaiShim._doOpenAIRequest`. Cloud paths are byte-for-byte unchanged when `enabled` is false. The GitHub Copilot `/responses` retry path keeps `stableStringify` since it is GitHub-specific and never reachable for a local baseUrl.

## Test plan

- [x] `bun test src/services/api/providerConfig.localFastPath.test.ts` (12/12)
- [x] `bun test src/services/api/openaiShim` (103/103)
- [x] `bun test src/services/api` (505/505)
- [x] `bun run typecheck` — no new errors introduced
- [ ] Manual: `OPENAI_BASE_URL=http://localhost:11434/v1 openclaude` shows reduced per-request CPU (issue reporter to confirm against their 25-min repro)

## Closes

Closes #1016
