### PR TITLE
fix(openai-shim): redact ?auth=, ?passwd=, ?pwd= in diagnostic URLs

### DIFF
--- a/src/services/api/openaiShim.ts
+++ b/src/services/api/openaiShim.ts
@@ -70,6 +70,7 @@ import {
 } from './openaiErrorClassification.js'
 import { sanitizeSchemaForOpenAICompat } from '../../utils/schemaSanitizer.js'
 import { redactSecretValueForDisplay } from '../../utils/providerProfile.js'
+import { shouldRedactUrlQueryParam } from '../../utils/urlRedaction.js'
 import {
   normalizeToolArguments,
   hasToolFieldMapping,
@@ -102,19 +103,6 @@ const COPILOT_HEADERS: Record<string, string> = {
   'Editor-Plugin-Version': 'copilot-chat/0.26.7',
   'Copilot-Integration-Id': 'vscode-chat',
 }
-
-const SENSITIVE_URL_QUERY_PARAM_NAMES = [
-  'api_key',
-  'key',
-  'token',
-  'access_token',
-  'refresh_token',
-  'signature',
-  'sig',
-  'secret',
-  'password',
-  'authorization',
-]
 
 function isGithubModelsMode(): boolean {
   return isEnvTruthy(process.env.CLAUDE_CODE_USE_GITHUB)
@@ -176,11 +164,6 @@ function normalizeDeepSeekReasoningEffort(
 function formatRetryAfterHint(response: Response): string {
   const ra = response.headers.get('retry-after')
   return ra ? ` (Retry-After: ${ra})` : ''
-}
-
-function shouldRedactUrlQueryParam(name: string): boolean {
-  const lower = name.toLowerCase()
-  return SENSITIVE_URL_QUERY_PARAM_NAMES.some(token => lower.includes(token))
 }
 
 function redactUrlForDiagnostics(url: string): string {

--- a/src/utils/urlRedaction.test.ts
+++ b/src/utils/urlRedaction.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, test } from 'bun:test'
 
-import { redactUrlForDisplay } from './urlRedaction.ts'
+import {
+  redactUrlForDisplay,
+  shouldRedactUrlQueryParam,
+} from './urlRedaction.ts'
 
 describe('redactUrlForDisplay', () => {
   test('redacts credentials and sensitive query params for valid URLs', () => {
@@ -34,5 +37,56 @@ describe('redactUrlForDisplay', () => {
   test('keeps non-sensitive URLs unchanged', () => {
     const url = 'http://localhost:11434/v1?model=llama3.1:8b'
     expect(redactUrlForDisplay(url)).toBe(url)
+  })
+
+  // Regression: the openaiShim copy of this list dropped these four names,
+  // so `?passwd=…`, `?pwd=…`, `?auth=…`, `?apikey=…` (the no-underscore
+  // form) were leaking into self-heal/error diagnostic logs (#1069). Pin
+  // them here so any future fork of the list trips the test instead of
+  // silently regressing.
+  test('redacts passwd / pwd / auth / apikey variants', () => {
+    expect(
+      redactUrlForDisplay('https://api.example.com/v1?passwd=hunter2'),
+    ).toBe('https://api.example.com/v1?passwd=redacted')
+    expect(
+      redactUrlForDisplay('https://api.example.com/v1?pwd=hunter2'),
+    ).toBe('https://api.example.com/v1?pwd=redacted')
+    expect(
+      redactUrlForDisplay('https://api.example.com/v1?auth=Bearer-XYZ'),
+    ).toBe('https://api.example.com/v1?auth=redacted')
+    expect(
+      redactUrlForDisplay('https://api.example.com/v1?apikey=sk-abc'),
+    ).toBe('https://api.example.com/v1?apikey=redacted')
+  })
+})
+
+describe('shouldRedactUrlQueryParam', () => {
+  test('catches the canonical credential param names', () => {
+    for (const name of [
+      'api_key',
+      'apikey',
+      'api-key',
+      'key',
+      'token',
+      'access_token',
+      'access-token',
+      'refresh_token',
+      'signature',
+      'sig',
+      'secret',
+      'password',
+      'passwd',
+      'pwd',
+      'auth',
+      'authorization',
+    ]) {
+      expect(shouldRedactUrlQueryParam(name)).toBe(true)
+    }
+  })
+
+  test('does not flag unrelated param names', () => {
+    for (const name of ['model', 'temperature', 'foo', 'session_id', 'user_id']) {
+      expect(shouldRedactUrlQueryParam(name)).toBe(false)
+    }
   })
 })

--- a/src/utils/urlRedaction.ts
+++ b/src/utils/urlRedaction.ts
@@ -15,7 +15,13 @@ const SENSITIVE_URL_QUERY_PARAM_TOKENS = [
   'authorization',
 ]
 
-function shouldRedactUrlQueryParam(name: string): boolean {
+/**
+ * Single source of truth for "which query-param names look like
+ * credentials". Exported so other diagnostic-log code paths (notably
+ * `openaiShim.redactUrlForDiagnostics`) can use the same coverage as
+ * `redactUrlForDisplay` instead of forking a copy that drifts.
+ */
+export function shouldRedactUrlQueryParam(name: string): boolean {
   const lower = name.toLowerCase()
   return SENSITIVE_URL_QUERY_PARAM_TOKENS.some(token => lower.includes(token))
 }


### PR DESCRIPTION
## Summary

The credential-query-param redactor in `openaiShim.redactUrlForDiagnostics` was a fork of the canonical helper in `src/utils/urlRedaction.ts` and had drifted — the shim copy was missing four names (`apikey`, `passwd`, `pwd`, `auth`). Three of them (`passwd`, `pwd`, `auth`) are not substrings of any shim-list token, so the substring-match code path emitted them verbatim into the self-heal retry log, transport-error log, HTTP-error log, and toolless retry log.

A user with `OPENAI_BASE_URL=https://gateway.example.com/v1?auth=Bearer-XYZ` (or `?passwd=…` / `?pwd=…`) would see the credential written to their debug log on every retry/error path, even though the URL was being passed through `redactUrlForDiagnostics` first.

## Fix

- Export `shouldRedactUrlQueryParam` from `src/utils/urlRedaction.ts` as the single source of truth.
- Delete the local copy + the local 10-entry `SENSITIVE_URL_QUERY_PARAM_NAMES` constant in `src/services/api/openaiShim.ts`; import the shared helper.
- Pin the four regressions (`?passwd=`, `?pwd=`, `?auth=`, `?apikey=`) in `urlRedaction.test.ts` so any future re-fork trips the test instead of silently re-leaking.

The post-redaction `redactSecretValueForDisplay(serialized, process.env)` pass is unchanged — that is the second layer that catches credentials hardcoded directly into the URL string when the param name itself is non-obvious.

## Test plan

- [x] `bun test src/utils/urlRedaction src/services/api/openaiShim` (110/110)
- [x] `bun test src/services/api src/utils` (1319/1319)
- [x] Reproduced the leak against pre-patch source: `passwd`, `pwd`, `auth` all returned `false` from the shim's `shouldRedactUrlQueryParam`; post-patch they return `true`.

## Closes

Closes #1069
