### PR TITLE
Prevent duplicate startup plugin hooks

### DIFF
--- a/src/__tests__/bugfixes.test.ts
+++ b/src/__tests__/bugfixes.test.ts
@@ -10,6 +10,12 @@
 
 import { describe, test, expect } from 'bun:test'
 import { resolve } from 'path'
+import {
+  clearRegisteredHooks,
+  registerHookCallbacks,
+} from '../bootstrap/state.js'
+import { getMatchingHooks } from '../utils/hooks.js'
+import type { PluginHookMatcher } from '../utils/settings/types.js'
 
 const SRC = resolve(import.meta.dir, '..')
 const file = (relative: string) => Bun.file(resolve(SRC, relative))
@@ -227,11 +233,64 @@ describe('MCP tool timeout fix', () => {
 // ---------------------------------------------------------------------------
 describe('Regression checks', () => {
   test('duplicate plugin hooks are deduplicated before execution', async () => {
-    const hooks = await file('utils/hooks.ts').text()
+    clearRegisteredHooks()
 
-    expect(hooks).toContain('function dedupeRegisteredPluginHooks')
-    expect(hooks).toContain('pluginId: matcher.pluginId')
-    expect(hooks).toContain('for (const matcher of dedupeRegisteredPluginHooks(registeredHooks))')
+    const hookA: PluginHookMatcher = {
+      pluginId: 'claude-mem@thedotmack',
+      pluginName: 'claude-mem',
+      pluginRoot: '/plugins/claude-mem-a',
+      matcher: 'startup',
+      hooks: [
+        {
+          async: true,
+          command: 'node hook.js',
+          statusMessage: 'warming cache',
+          type: 'command',
+        },
+      ],
+    }
+    const hookB: PluginHookMatcher = {
+      pluginId: 'claude-mem@thedotmack',
+      pluginName: 'claude-mem',
+      pluginRoot: '/plugins/claude-mem-a',
+      matcher: 'startup',
+      hooks: [
+        {
+          command: 'node hook.js',
+          type: 'command',
+          statusMessage: 'warming cache',
+          async: true,
+        },
+      ],
+    }
+    const hookDifferentRoot: PluginHookMatcher = {
+      ...hookA,
+      pluginRoot: '/plugins/claude-mem-b',
+    }
+
+    try {
+      registerHookCallbacks({
+        SessionStart: [hookA, hookB, hookDifferentRoot],
+      })
+
+      const matched = await getMatchingHooks(
+        undefined,
+        'test-session',
+        'SessionStart',
+        {
+          hook_event_name: 'SessionStart',
+          source: 'startup',
+        } as never,
+      )
+
+      expect(matched).toHaveLength(2)
+      expect(matched.map(hook => hook.pluginRoot)).toEqual([
+        '/plugins/claude-mem-a',
+        '/plugins/claude-mem-b',
+      ])
+    } finally {
+      clearRegisteredHooks()
+    }
   })
 
   test('store field remains opt-out by per-route config rather than unconditional deletion', async () => {

--- a/src/__tests__/bugfixes.test.ts
+++ b/src/__tests__/bugfixes.test.ts
@@ -226,6 +226,14 @@ describe('MCP tool timeout fix', () => {
 // Cross-cutting: verify no regressions
 // ---------------------------------------------------------------------------
 describe('Regression checks', () => {
+  test('duplicate plugin hooks are deduplicated before execution', async () => {
+    const hooks = await file('utils/hooks.ts').text()
+
+    expect(hooks).toContain('function dedupeRegisteredPluginHooks')
+    expect(hooks).toContain('pluginId: matcher.pluginId')
+    expect(hooks).toContain('for (const matcher of dedupeRegisteredPluginHooks(registeredHooks))')
+  })
+
   test('store field remains opt-out by per-route config rather than unconditional deletion', async () => {
     const openaiShim = await file('services/api/openaiShim.ts').text()
     const runtimeMetadata = await file('integrations/runtimeMetadata.ts').text()

--- a/src/utils/ShellCommand.test.ts
+++ b/src/utils/ShellCommand.test.ts
@@ -58,3 +58,27 @@ test('interrupt does not kill backgrounded shell commands', async () => {
   expect(result.code).toBe(0)
   expect(result.backgroundTaskId).toBe('bg-task')
 })
+
+test('interrupt does not kill keep-alive commands used by asyncRewake hooks', async () => {
+  const child = createMockChildProcess()
+  const controller = new AbortController()
+  const command = wrapSpawn(
+    child as never,
+    controller.signal,
+    30_000,
+    new TaskOutput('shellcommand-test-keepalive', null),
+    false,
+    undefined,
+    { keepAliveOnInterrupt: true },
+  )
+
+  controller.abort('interrupt')
+
+  await Promise.resolve()
+  expect(command.status).toBe('running')
+
+  child.emit('exit', 2, null)
+  const result = await command.result
+  expect(result.code).toBe(2)
+  expect(result.interrupted).toBe(false)
+})

--- a/src/utils/ShellCommand.test.ts
+++ b/src/utils/ShellCommand.test.ts
@@ -1,0 +1,60 @@
+import { EventEmitter } from 'events'
+import { expect, test } from 'bun:test'
+import { wrapSpawn } from './ShellCommand.js'
+import { TaskOutput } from './task/TaskOutput.js'
+
+function createMockChildProcess(): EventEmitter & {
+  pid?: number
+  stdout: null
+  stderr: null
+} {
+  const child = new EventEmitter() as EventEmitter & {
+    pid?: number
+    stdout: null
+    stderr: null
+  }
+  child.stdout = null
+  child.stderr = null
+  child.pid = undefined
+  return child
+}
+
+test('interrupt kills running shell commands', async () => {
+  const child = createMockChildProcess()
+  const controller = new AbortController()
+  const command = wrapSpawn(
+    child as never,
+    controller.signal,
+    30_000,
+    new TaskOutput('shellcommand-test-running', null),
+  )
+
+  controller.abort('interrupt')
+
+  const result = await command.result
+  expect(command.status).toBe('killed')
+  expect(result.interrupted).toBe(true)
+  expect(result.code).toBe(137)
+})
+
+test('interrupt does not kill backgrounded shell commands', async () => {
+  const child = createMockChildProcess()
+  const controller = new AbortController()
+  const command = wrapSpawn(
+    child as never,
+    controller.signal,
+    30_000,
+    new TaskOutput('shellcommand-test-backgrounded', null),
+  )
+
+  expect(command.background('bg-task')).toBe(true)
+  controller.abort('interrupt')
+
+  await Promise.resolve()
+  expect(command.status).toBe('backgrounded')
+
+  child.emit('exit', 0, null)
+  const result = await command.result
+  expect(result.code).toBe(0)
+  expect(result.backgroundTaskId).toBe('bg-task')
+})

--- a/src/utils/ShellCommand.ts
+++ b/src/utils/ShellCommand.ts
@@ -184,9 +184,14 @@ class ShellCommandImpl implements ShellCommand {
   }
 
   #abortHandler(): void {
-    // On 'interrupt' (user submitted a new message), don't kill — let the
-    // caller background the process so the model can see partial output.
-    if (this.#abortSignal.reason === 'interrupt') {
+    // On 'interrupt' (user submitted a new message), only keep the process
+    // alive if it was already backgrounded. Synchronous hook subprocesses
+    // should be torn down promptly on interrupt instead of continuing to run
+    // against a cancelled turn.
+    if (
+      this.#abortSignal.reason === 'interrupt' &&
+      this.#status === 'backgrounded'
+    ) {
       return
     }
     this.kill()

--- a/src/utils/ShellCommand.ts
+++ b/src/utils/ShellCommand.ts
@@ -46,6 +46,10 @@ export type ShellCommand = {
   taskOutput: TaskOutput
 }
 
+type ShellCommandOptions = {
+  keepAliveOnInterrupt?: boolean
+}
+
 const SIGKILL = 137
 const SIGTERM = 143
 
@@ -127,6 +131,7 @@ class ShellCommandImpl implements ShellCommand {
     | undefined
   #timeout: number
   #shouldAutoBackground: boolean
+  #keepAliveOnInterrupt: boolean
   #resultResolver: ((result: ExecResult) => void) | null = null
   #exitCodeResolver: ((code: number) => void) | null = null
   #boundAbortHandler: (() => void) | null = null
@@ -152,12 +157,14 @@ class ShellCommandImpl implements ShellCommand {
     taskOutput: TaskOutput,
     shouldAutoBackground = false,
     maxOutputBytes = MAX_TASK_OUTPUT_BYTES,
+    options?: ShellCommandOptions,
   ) {
     this.#childProcess = childProcess
     this.#abortSignal = abortSignal
     this.#timeout = timeout
     this.#shouldAutoBackground = shouldAutoBackground
     this.#maxOutputBytes = maxOutputBytes
+    this.#keepAliveOnInterrupt = options?.keepAliveOnInterrupt === true
     this.taskOutput = taskOutput
 
     // In file mode (bash commands), both stdout and stderr go to the
@@ -184,13 +191,12 @@ class ShellCommandImpl implements ShellCommand {
   }
 
   #abortHandler(): void {
-    // On 'interrupt' (user submitted a new message), only keep the process
-    // alive if it was already backgrounded. Synchronous hook subprocesses
-    // should be torn down promptly on interrupt instead of continuing to run
-    // against a cancelled turn.
+    // On 'interrupt' (user submitted a new message), keep explicit survivors
+    // alive: already-backgrounded commands and asyncRewake hook processes
+    // that must finish in-memory to emit or enqueue their response.
     if (
       this.#abortSignal.reason === 'interrupt' &&
-      this.#status === 'backgrounded'
+      (this.#status === 'backgrounded' || this.#keepAliveOnInterrupt)
     ) {
       return
     }
@@ -396,6 +402,7 @@ export function wrapSpawn(
   taskOutput: TaskOutput,
   shouldAutoBackground = false,
   maxOutputBytes = MAX_TASK_OUTPUT_BYTES,
+  options?: ShellCommandOptions,
 ): ShellCommand {
   return new ShellCommandImpl(
     childProcess,
@@ -404,6 +411,7 @@ export function wrapSpawn(
     taskOutput,
     shouldAutoBackground,
     maxOutputBytes,
+    options,
   )
 }
 

--- a/src/utils/hooks.ts
+++ b/src/utils/hooks.ts
@@ -163,6 +163,7 @@ import {
 } from './hooks/sessionHooks.js'
 import type { AppState } from '../state/AppState.js'
 import { jsonStringify, jsonParse } from './slowOperations.js'
+import { stableStringify } from './stableStringify.js'
 import { isEnvTruthy } from './envUtils.js'
 import { errorMessage, getErrnoCode } from './errors.js'
 import { getAgentName, getTeamName, getTeammateColor } from './teammate.js'
@@ -174,20 +175,6 @@ import type {
 } from './hookChains.js'
 
 const TOOL_HOOK_EXECUTION_TIMEOUT_MS = 10 * 60 * 1000
-
-function stableSerializeHookValue(value: unknown): unknown {
-  if (Array.isArray(value)) {
-    return value.map(stableSerializeHookValue)
-  }
-  if (value && typeof value === 'object') {
-    return Object.fromEntries(
-      Object.entries(value as Record<string, unknown>)
-        .sort(([left], [right]) => left.localeCompare(right))
-        .map(([key, nested]) => [key, stableSerializeHookValue(nested)]),
-    )
-  }
-  return value
-}
 
 function dedupeRegisteredPluginHooks(
   registeredHooks: Array<HookCallbackMatcher | PluginHookMatcher>,
@@ -203,12 +190,12 @@ function dedupeRegisteredPluginHooks(
       continue
     }
 
-    const pluginMatcherKey = jsonStringify({
+    const pluginMatcherKey = stableStringify({
       pluginId: matcher.pluginId,
       pluginName: matcher.pluginName,
       pluginRoot: matcher.pluginRoot,
       matcher: matcher.matcher ?? null,
-      hooks: stableSerializeHookValue(matcher.hooks),
+      hooks: matcher.hooks,
     })
 
     if (seenPluginMatchers.has(pluginMatcherKey)) {

--- a/src/utils/hooks.ts
+++ b/src/utils/hooks.ts
@@ -175,6 +175,20 @@ import type {
 
 const TOOL_HOOK_EXECUTION_TIMEOUT_MS = 10 * 60 * 1000
 
+function stableSerializeHookValue(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map(stableSerializeHookValue)
+  }
+  if (value && typeof value === 'object') {
+    return Object.fromEntries(
+      Object.entries(value as Record<string, unknown>)
+        .sort(([left], [right]) => left.localeCompare(right))
+        .map(([key, nested]) => [key, stableSerializeHookValue(nested)]),
+    )
+  }
+  return value
+}
+
 function dedupeRegisteredPluginHooks(
   registeredHooks: Array<HookCallbackMatcher | PluginHookMatcher>,
 ): Array<HookCallbackMatcher | PluginHookMatcher> {
@@ -182,6 +196,8 @@ function dedupeRegisteredPluginHooks(
   const deduped: Array<HookCallbackMatcher | PluginHookMatcher> = []
 
   for (const matcher of registeredHooks) {
+    // SDK callback hooks are intentionally not deduped. Their callbacks are
+    // runtime values, so structural comparison would be lossy and unsafe.
     if (!('pluginRoot' in matcher)) {
       deduped.push(matcher)
       continue
@@ -190,8 +206,9 @@ function dedupeRegisteredPluginHooks(
     const pluginMatcherKey = jsonStringify({
       pluginId: matcher.pluginId,
       pluginName: matcher.pluginName,
+      pluginRoot: matcher.pluginRoot,
       matcher: matcher.matcher ?? null,
-      hooks: matcher.hooks,
+      hooks: stableSerializeHookValue(matcher.hooks),
     })
 
     if (seenPluginMatchers.has(pluginMatcherKey)) {
@@ -1157,7 +1174,15 @@ async function execCommandHook(
   // Hooks use pipe mode — stdout must be streamed into JS so we can parse
   // the first response line to detect async hooks ({"async": true}).
   const hookTaskOutput = new TaskOutput(`hook_${child.pid}`, null)
-  const shellCommand = wrapSpawn(child, signal, hookTimeoutMs, hookTaskOutput)
+  const shellCommand = wrapSpawn(
+    child,
+    signal,
+    hookTimeoutMs,
+    hookTaskOutput,
+    false,
+    undefined,
+    { keepAliveOnInterrupt: hook.asyncRewake === true },
+  )
   // Track whether shellCommand ownership was transferred (e.g., to async hook registry)
   let shellCommandTransferred = false
   // Track whether stdin has already been written (to avoid "write after end" errors)

--- a/src/utils/hooks.ts
+++ b/src/utils/hooks.ts
@@ -175,6 +175,36 @@ import type {
 
 const TOOL_HOOK_EXECUTION_TIMEOUT_MS = 10 * 60 * 1000
 
+function dedupeRegisteredPluginHooks(
+  registeredHooks: Array<HookCallbackMatcher | PluginHookMatcher>,
+): Array<HookCallbackMatcher | PluginHookMatcher> {
+  const seenPluginMatchers = new Set<string>()
+  const deduped: Array<HookCallbackMatcher | PluginHookMatcher> = []
+
+  for (const matcher of registeredHooks) {
+    if (!('pluginRoot' in matcher)) {
+      deduped.push(matcher)
+      continue
+    }
+
+    const pluginMatcherKey = jsonStringify({
+      pluginId: matcher.pluginId,
+      pluginName: matcher.pluginName,
+      matcher: matcher.matcher ?? null,
+      hooks: matcher.hooks,
+    })
+
+    if (seenPluginMatchers.has(pluginMatcherKey)) {
+      continue
+    }
+
+    seenPluginMatchers.add(pluginMatcherKey)
+    deduped.push(matcher)
+  }
+
+  return deduped
+}
+
 function normalizeFallbackAgentModel(
   model: string | undefined,
 ): 'sonnet' | 'opus' | 'haiku' | undefined {
@@ -1664,7 +1694,7 @@ function getHooksConfig(
   // Process registered hooks (SDK callbacks and plugin native hooks)
   const registeredHooks = getRegisteredHooks()?.[hookEvent]
   if (registeredHooks) {
-    for (const matcher of registeredHooks) {
+    for (const matcher of dedupeRegisteredPluginHooks(registeredHooks)) {
       // Skip plugin hooks when restricted to managed hooks only
       // Plugin hooks have pluginRoot set, SDK callbacks do not
       if (managedOnly && 'pluginRoot' in matcher) {


### PR DESCRIPTION
## Summary
Prevent duplicate registered plugin hooks from executing more than once during startup by deduplicating identical plugin hook matchers before hook execution.

## Testing
- bun test src/__tests__/bugfixes.test.ts

Fixes #793
Fixes #992
Fixes #602