### PR TITLE
fix(ollama): parse text-based tool calls as fallback (#1053)

### DIFF
--- a/src/services/api/openaiShim.ollamaTextToolCalls.test.ts
+++ b/src/services/api/openaiShim.ollamaTextToolCalls.test.ts
@@ -371,3 +371,55 @@ describe('Ollama streaming — visible text before real structured tool_calls (P
     expect((toolStarts[0].content_block as Record<string, string>).name).toBe('Bash')
   })
 })
+
+describe('Ollama streaming — visible prose before text-based tool-call fallback (P2 buffered path)', () => {
+  beforeEach(() => {
+    process.env.OLLAMA_BASE_URL = 'http://localhost:11434'
+    process.env.OPENAI_API_KEY = 'test-key'
+    process.env.OPENAI_BASE_URL = 'http://localhost:11434/v1'
+  })
+  afterEach(() => {
+    delete process.env.OLLAMA_BASE_URL
+    delete process.env.OPENAI_API_KEY
+    delete process.env.OPENAI_BASE_URL
+  })
+
+  test('visible prose before text-based JSON tool call is preserved in emitted text_delta', async () => {
+    // Repro: Ollama model emits prose then tool-call JSON as plain text (no delta.tool_calls).
+    // Before fix: hasEmittedContentStart === false in the fallback branch, so the prose in
+    // ollamaTextBuffer was discarded — only the synthetic tool_use block was emitted.
+    globalThis.fetch = (async () =>
+      makeSseResponse(
+        makeChunks([
+          ollamaChunk('I will inspect the file.\n'),
+          ollamaChunk('{"name":"Read","arguments":{"file_path":"/tmp/foo.ts"}}'),
+          ollamaChunk('', 'stop'),
+        ]),
+      )) as unknown as FetchType
+
+    const client = createOpenAIShimClient({}) as OpenAIShimClient
+    const result = await client.beta.messages
+      .create({
+        model: 'qwen2.5:7b',
+        messages: [{ role: 'user', content: 'read the file' }],
+        max_tokens: 64,
+        stream: true,
+      })
+      .withResponse()
+
+    const events: Record<string, unknown>[] = []
+    for await (const event of result.data) events.push(event)
+
+    const allText = events
+      .filter(e => e.type === 'content_block_delta' && (e.delta as Record<string, string>)?.type === 'text_delta')
+      .map(e => (e.delta as Record<string, string>).text)
+      .join('')
+    expect(allText).toContain('I will inspect the file.')
+
+    const toolStarts = events.filter(
+      e => e.type === 'content_block_start' && (e.content_block as Record<string, string>)?.type === 'tool_use',
+    )
+    expect(toolStarts).toHaveLength(1)
+    expect((toolStarts[0].content_block as Record<string, string>).name).toBe('Read')
+  })
+})

--- a/src/services/api/openaiShim.ollamaTextToolCalls.test.ts
+++ b/src/services/api/openaiShim.ollamaTextToolCalls.test.ts
@@ -207,12 +207,15 @@ const ollamaToolChunk = (toolCalls: unknown[], finishReason?: string) => ({
 })
 
 describe('Ollama streaming — think-tag filtering on text-tool fallback (P1)', () => {
+  let originalFetch: FetchType
   beforeEach(() => {
+    originalFetch = globalThis.fetch
     process.env.OLLAMA_BASE_URL = 'http://localhost:11434'
     process.env.OPENAI_API_KEY = 'test-key'
     process.env.OPENAI_BASE_URL = 'http://localhost:11434/v1'
   })
   afterEach(() => {
+    globalThis.fetch = originalFetch
     delete process.env.OLLAMA_BASE_URL
     delete process.env.OPENAI_API_KEY
     delete process.env.OPENAI_BASE_URL
@@ -258,12 +261,15 @@ describe('Ollama streaming — think-tag filtering on text-tool fallback (P1)', 
 })
 
 describe('Ollama streaming — plain text response with no tool calls', () => {
+  let originalFetch: FetchType
   beforeEach(() => {
+    originalFetch = globalThis.fetch
     process.env.OLLAMA_BASE_URL = 'http://localhost:11434'
     process.env.OPENAI_API_KEY = 'test-key'
     process.env.OPENAI_BASE_URL = 'http://localhost:11434/v1'
   })
   afterEach(() => {
+    globalThis.fetch = originalFetch
     delete process.env.OLLAMA_BASE_URL
     delete process.env.OPENAI_API_KEY
     delete process.env.OPENAI_BASE_URL
@@ -362,12 +368,15 @@ describe('Ollama streaming — plain text response with no tool calls', () => {
 })
 
 describe('Ollama streaming — visible text before real structured tool_calls (P2)', () => {
+  let originalFetch: FetchType
   beforeEach(() => {
+    originalFetch = globalThis.fetch
     process.env.OLLAMA_BASE_URL = 'http://localhost:11434'
     process.env.OPENAI_API_KEY = 'test-key'
     process.env.OPENAI_BASE_URL = 'http://localhost:11434/v1'
   })
   afterEach(() => {
+    globalThis.fetch = originalFetch
     delete process.env.OLLAMA_BASE_URL
     delete process.env.OPENAI_API_KEY
     delete process.env.OPENAI_BASE_URL
@@ -416,12 +425,15 @@ describe('Ollama streaming — visible text before real structured tool_calls (P
 })
 
 describe('Ollama streaming — visible prose before text-based tool-call fallback (P2 buffered path)', () => {
+  let originalFetch: FetchType
   beforeEach(() => {
+    originalFetch = globalThis.fetch
     process.env.OLLAMA_BASE_URL = 'http://localhost:11434'
     process.env.OPENAI_API_KEY = 'test-key'
     process.env.OPENAI_BASE_URL = 'http://localhost:11434/v1'
   })
   afterEach(() => {
+    globalThis.fetch = originalFetch
     delete process.env.OLLAMA_BASE_URL
     delete process.env.OPENAI_API_KEY
     delete process.env.OPENAI_BASE_URL
@@ -464,5 +476,101 @@ describe('Ollama streaming — visible prose before text-based tool-call fallbac
     )
     expect(toolStarts).toHaveLength(1)
     expect((toolStarts[0].content_block as Record<string, string>).name).toBe('Read')
+  })
+})
+
+describe('parseTextToolCalls — pretty-printed bare JSON detection', () => {
+  test('detects bare JSON with whitespace/newline between { and "name"', () => {
+    const text = '{\n  "name": "Bash",\n  "arguments": {"command": "ls"}\n}'
+    const { calls } = parseTextToolCalls(text)
+    expect(calls).toHaveLength(1)
+    expect(calls[0].name).toBe('Bash')
+    expect(calls[0].arguments).toEqual({ command: 'ls' })
+  })
+
+  test('detects bare JSON with spaces between { and "type"', () => {
+    const text = '{  "type": "function", "function": {"name": "Grep", "arguments": {"pattern": "foo"}}}'
+    const { calls } = parseTextToolCalls(text)
+    expect(calls).toHaveLength(1)
+    expect(calls[0].name).toBe('Grep')
+  })
+})
+
+describe('Ollama streaming — non-stop terminal finish reasons flush buffer', () => {
+  let originalFetch: FetchType
+  beforeEach(() => {
+    originalFetch = globalThis.fetch
+    process.env.OLLAMA_BASE_URL = 'http://localhost:11434'
+    process.env.OPENAI_API_KEY = 'test-key'
+    process.env.OPENAI_BASE_URL = 'http://localhost:11434/v1'
+  })
+  afterEach(() => {
+    globalThis.fetch = originalFetch
+    delete process.env.OLLAMA_BASE_URL
+    delete process.env.OPENAI_API_KEY
+    delete process.env.OPENAI_BASE_URL
+  })
+
+  test('buffered text is flushed when finish_reason is "length"', async () => {
+    globalThis.fetch = (async () =>
+      makeSseResponse(
+        makeChunks([
+          ollamaChunk('Partial response cut off by'),
+          ollamaChunk('', 'length'),
+        ]),
+      )) as unknown as FetchType
+
+    const client = createOpenAIShimClient({}) as OpenAIShimClient
+    const result = await client.beta.messages
+      .create({
+        model: 'qwen2.5:7b',
+        messages: [{ role: 'user', content: 'Hi' }],
+        max_tokens: 8,
+        stream: true,
+      })
+      .withResponse()
+
+    const events: Record<string, unknown>[] = []
+    for await (const event of result.data) events.push(event)
+
+    const allText = events
+      .filter(e => e.type === 'content_block_delta' && (e.delta as Record<string, string>)?.type === 'text_delta')
+      .map(e => (e.delta as Record<string, string>).text)
+      .join('')
+    expect(allText).toContain('Partial response cut off by')
+  })
+
+  test('text-tool JSON is extracted when finish_reason is "length" but finish_reason stays "length"', async () => {
+    globalThis.fetch = (async () =>
+      makeSseResponse(
+        makeChunks([
+          ollamaChunk('{"name":"Bash","arguments":{"command":"ls"}}'),
+          ollamaChunk('', 'length'),
+        ]),
+      )) as unknown as FetchType
+
+    const client = createOpenAIShimClient({}) as OpenAIShimClient
+    const result = await client.beta.messages
+      .create({
+        model: 'qwen2.5:7b',
+        messages: [{ role: 'user', content: 'run ls' }],
+        max_tokens: 8,
+        stream: true,
+      })
+      .withResponse()
+
+    const events: Record<string, unknown>[] = []
+    for await (const event of result.data) events.push(event)
+
+    const toolStarts = events.filter(
+      e => e.type === 'content_block_start' && (e.content_block as Record<string, string>)?.type === 'tool_use',
+    )
+    expect(toolStarts).toHaveLength(1)
+    expect((toolStarts[0].content_block as Record<string, string>).name).toBe('Bash')
+
+    // finish_reason must NOT be remapped to 'tool_calls' for non-stop reasons
+    const messageDelta = events.find(e => e.type === 'message_delta') as Record<string, unknown> | undefined
+    const delta = messageDelta?.delta as Record<string, unknown> | undefined
+    expect(delta?.stop_reason).not.toBe('tool_use')
   })
 })

--- a/src/services/api/openaiShim.ollamaTextToolCalls.test.ts
+++ b/src/services/api/openaiShim.ollamaTextToolCalls.test.ts
@@ -158,6 +158,34 @@ describe('parseTextToolCalls', () => {
     const [start, end] = toolCallRanges[0]
     expect(text.slice(start, end)).toBe(call)
   })
+
+  // Regression: fenced/bare ranges must only be added to toolCallRanges AFTER
+  // parseAndAdd confirms acceptance — rejected blocks must not silently strip text.
+  test('fenced block with bad JSON: no call emitted, range not in toolCallRanges', () => {
+    const { calls, toolCallRanges } = parseTextToolCalls('```json\n{bad json}\n```')
+    expect(calls).toHaveLength(0)
+    expect(toolCallRanges).toHaveLength(0)
+  })
+
+  test('fenced block without name field: no call emitted, range not in toolCallRanges', () => {
+    const { calls, toolCallRanges } = parseTextToolCalls('```json\n{"foo":"bar"}\n```')
+    expect(calls).toHaveLength(0)
+    expect(toolCallRanges).toHaveLength(0)
+  })
+
+  test('duplicate fenced blocks: second block not in toolCallRanges', () => {
+    const block = '```json\n{"name":"Read","arguments":{"file_path":"x"}}\n```'
+    const { calls, toolCallRanges } = parseTextToolCalls(block + '\n' + block)
+    expect(calls).toHaveLength(1)
+    expect(toolCallRanges).toHaveLength(1)
+  })
+
+  test('duplicate bare JSON: second occurrence not in toolCallRanges', () => {
+    const call = '{"name":"Bash","arguments":{"command":"ls"}}'
+    const { calls, toolCallRanges } = parseTextToolCalls(call + '\n' + call)
+    expect(calls).toHaveLength(1)
+    expect(toolCallRanges).toHaveLength(1)
+  })
 })
 
 // ---------------------------------------------------------------------------

--- a/src/services/api/openaiShim.ollamaTextToolCalls.test.ts
+++ b/src/services/api/openaiShim.ollamaTextToolCalls.test.ts
@@ -7,6 +7,7 @@
  *   2. Fenced ```json``` block
  *   3. {type:"function",function:{name,arguments}} shape
  *   4. Deduplication by name:args key
+ *   5. P1 context guard — bare JSON in explanatory prose is skipped
  */
 import { describe, expect, test } from 'bun:test'
 import { parseTextToolCalls } from './openaiShim.js'
@@ -14,7 +15,7 @@ import { parseTextToolCalls } from './openaiShim.js'
 describe('parseTextToolCalls', () => {
   test('parses bare JSON object {"name","arguments"} shape', () => {
     const text = `Let me read that file.\n{"name":"Read","arguments":{"file_path":"/tmp/foo.ts"}}`
-    const calls = parseTextToolCalls(text)
+    const { calls } = parseTextToolCalls(text)
     expect(calls).toHaveLength(1)
     expect(calls[0].name).toBe('Read')
     expect(calls[0].arguments).toEqual({ file_path: '/tmp/foo.ts' })
@@ -23,7 +24,7 @@ describe('parseTextToolCalls', () => {
 
   test('parses fenced ```json``` block', () => {
     const text = 'I will run this:\n```json\n{"name":"Bash","arguments":{"command":"ls -la"}}\n```'
-    const calls = parseTextToolCalls(text)
+    const { calls } = parseTextToolCalls(text)
     expect(calls).toHaveLength(1)
     expect(calls[0].name).toBe('Bash')
     expect(calls[0].arguments).toEqual({ command: 'ls -la' })
@@ -31,14 +32,14 @@ describe('parseTextToolCalls', () => {
 
   test('parses fenced ``` block (no language tag)', () => {
     const text = '```\n{"name":"Glob","arguments":{"pattern":"src/**/*.ts"}}\n```'
-    const calls = parseTextToolCalls(text)
+    const { calls } = parseTextToolCalls(text)
     expect(calls).toHaveLength(1)
     expect(calls[0].name).toBe('Glob')
   })
 
   test('parses {type:"function",function:{name,arguments}} shape', () => {
     const text = '{"type":"function","function":{"name":"Grep","arguments":{"pattern":"TODO","path":"src"}}}'
-    const calls = parseTextToolCalls(text)
+    const { calls } = parseTextToolCalls(text)
     expect(calls).toHaveLength(1)
     expect(calls[0].name).toBe('Grep')
     expect(calls[0].arguments).toEqual({ pattern: 'TODO', path: 'src' })
@@ -47,7 +48,7 @@ describe('parseTextToolCalls', () => {
   test('parses {type:"function"} shape when arguments is a JSON string', () => {
     const args = JSON.stringify({ file_path: '/tmp/x.ts' })
     const text = `{"type":"function","function":{"name":"Read","arguments":${JSON.stringify(args)}}}`
-    const calls = parseTextToolCalls(text)
+    const { calls } = parseTextToolCalls(text)
     expect(calls).toHaveLength(1)
     expect(calls[0].name).toBe('Read')
     expect(calls[0].arguments).toEqual({ file_path: '/tmp/x.ts' })
@@ -56,7 +57,7 @@ describe('parseTextToolCalls', () => {
   test('deduplicates by name:args key', () => {
     const snippet = '{"name":"Read","arguments":{"file_path":"/tmp/foo.ts"}}'
     const text = `${snippet}\nSome text\n${snippet}`
-    const calls = parseTextToolCalls(text)
+    const { calls } = parseTextToolCalls(text)
     expect(calls).toHaveLength(1)
   })
 
@@ -65,23 +66,50 @@ describe('parseTextToolCalls', () => {
       '{"name":"Read","arguments":{"file_path":"a.ts"}}',
       '{"name":"Bash","arguments":{"command":"echo hi"}}',
     ].join('\n')
-    const calls = parseTextToolCalls(text)
+    const { calls } = parseTextToolCalls(text)
     expect(calls).toHaveLength(2)
     expect(calls.map(c => c.name)).toEqual(['Read', 'Bash'])
   })
 
   test('returns empty array for plain text with no JSON', () => {
-    const calls = parseTextToolCalls('I think you should check the file manually.')
+    const { calls } = parseTextToolCalls('I think you should check the file manually.')
     expect(calls).toHaveLength(0)
   })
 
   test('ignores malformed JSON', () => {
-    const calls = parseTextToolCalls('{"name":"Read","arguments":{broken}')
+    const { calls } = parseTextToolCalls('{"name":"Read","arguments":{broken}')
     expect(calls).toHaveLength(0)
   })
 
   test('ignores JSON objects without name or type:function', () => {
-    const calls = parseTextToolCalls('{"foo":"bar","baz":42}')
+    const { calls } = parseTextToolCalls('{"foo":"bar","baz":42}')
     expect(calls).toHaveLength(0)
+  })
+
+  // P1 context guard — bare JSON followed by explanatory prose must not be extracted
+  test('skips bare JSON immediately followed by explanatory text (P1 guard)', () => {
+    const text =
+      'Here is an example call: {"name":"Bash","arguments":{"command":"ls"}}. Note that you must use this format.'
+    const { calls } = parseTextToolCalls(text)
+    expect(calls).toHaveLength(0)
+  })
+
+  test('still parses bare JSON with only trailing whitespace (no trailing context)', () => {
+    const text = 'Running the command:\n{"name":"Bash","arguments":{"command":"ls"}}\n'
+    const { calls } = parseTextToolCalls(text)
+    expect(calls).toHaveLength(1)
+    expect(calls[0].name).toBe('Bash')
+  })
+
+  // toolCallRanges covers the extracted JSON so callers can strip it from text
+  test('returns toolCallRanges covering extracted bare JSON', () => {
+    const call = '{"name":"Bash","arguments":{"command":"ls"}}'
+    const prefix = 'Running:\n'
+    const text = prefix + call
+    const { calls, toolCallRanges } = parseTextToolCalls(text)
+    expect(calls).toHaveLength(1)
+    expect(toolCallRanges).toHaveLength(1)
+    const [start, end] = toolCallRanges[0]
+    expect(text.slice(start, end)).toBe(call)
   })
 })

--- a/src/services/api/openaiShim.ollamaTextToolCalls.test.ts
+++ b/src/services/api/openaiShim.ollamaTextToolCalls.test.ts
@@ -9,8 +9,39 @@
  *   4. Deduplication by name:args key
  *   5. P1 context guard — bare JSON in explanatory prose is skipped
  */
-import { describe, expect, test } from 'bun:test'
-import { parseTextToolCalls } from './openaiShim.js'
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import { createOpenAIShimClient, parseTextToolCalls } from './openaiShim.js'
+
+type FetchType = typeof globalThis.fetch
+
+type OpenAIShimClient = {
+  beta: {
+    messages: {
+      create: (
+        params: Record<string, unknown>,
+      ) => Promise<unknown> & {
+        withResponse: () => Promise<{ data: AsyncIterable<Record<string, unknown>> }>
+      }
+    }
+  }
+}
+
+function makeSseResponse(lines: string[]): Response {
+  const encoder = new TextEncoder()
+  return new Response(
+    new ReadableStream({
+      start(controller) {
+        for (const line of lines) controller.enqueue(encoder.encode(line))
+        controller.close()
+      },
+    }),
+    { headers: { 'Content-Type': 'text/event-stream' } },
+  )
+}
+
+function makeChunks(chunks: unknown[]): string[] {
+  return [...chunks.map(c => `data: ${JSON.stringify(c)}\n\n`), 'data: [DONE]\n\n']
+}
 
 describe('parseTextToolCalls', () => {
   test('parses bare JSON object {"name","arguments"} shape', () => {
@@ -111,5 +142,128 @@ describe('parseTextToolCalls', () => {
     expect(toolCallRanges).toHaveLength(1)
     const [start, end] = toolCallRanges[0]
     expect(text.slice(start, end)).toBe(call)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Streaming integration tests — require the full shim pipeline
+// ---------------------------------------------------------------------------
+
+const ollamaChunk = (content: string, finishReason?: string) => ({
+  id: 'chatcmpl-1',
+  object: 'chat.completion.chunk',
+  model: 'qwen2.5:7b',
+  choices: [{ index: 0, delta: { content }, finish_reason: finishReason ?? null }],
+})
+
+const ollamaToolChunk = (toolCalls: unknown[], finishReason?: string) => ({
+  id: 'chatcmpl-1',
+  object: 'chat.completion.chunk',
+  model: 'qwen2.5:7b',
+  choices: [{ index: 0, delta: { tool_calls: toolCalls }, finish_reason: finishReason ?? null }],
+})
+
+describe('Ollama streaming — think-tag filtering on text-tool fallback (P1)', () => {
+  beforeEach(() => {
+    process.env.OLLAMA_BASE_URL = 'http://localhost:11434'
+    process.env.OPENAI_API_KEY = 'test-key'
+    process.env.OPENAI_BASE_URL = 'http://localhost:11434/v1'
+  })
+  afterEach(() => {
+    delete process.env.OLLAMA_BASE_URL
+    delete process.env.OPENAI_API_KEY
+    delete process.env.OPENAI_BASE_URL
+  })
+
+  test('<think> content is NOT emitted as assistant text when text-tool fallback fires', async () => {
+    // Repro: model emits <think>private plan</think> followed by tool-call JSON.
+    // accumulatedText is raw; stripRanges leaves the <think> block unless we filter it.
+    globalThis.fetch = (async () =>
+      makeSseResponse(
+        makeChunks([
+          ollamaChunk('<think>private plan</think>{"name":"Bash","arguments":{"command":"ls"}}'),
+          ollamaChunk('', 'stop'),
+        ]),
+      )) as unknown as FetchType
+
+    const client = createOpenAIShimClient({}) as OpenAIShimClient
+    const result = await client.beta.messages
+      .create({
+        model: 'qwen2.5:7b',
+        messages: [{ role: 'user', content: 'run ls' }],
+        max_tokens: 64,
+        stream: true,
+      })
+      .withResponse()
+
+    const events: Record<string, unknown>[] = []
+    for await (const event of result.data) events.push(event)
+
+    const textDeltas = events.filter(
+      e => e.type === 'content_block_delta' && (e.delta as Record<string, string>)?.type === 'text_delta',
+    )
+    for (const d of textDeltas) {
+      expect((d.delta as Record<string, string>).text).not.toContain('<think>')
+    }
+
+    const toolStarts = events.filter(
+      e => e.type === 'content_block_start' && (e.content_block as Record<string, string>)?.type === 'tool_use',
+    )
+    expect(toolStarts).toHaveLength(1)
+    expect((toolStarts[0].content_block as Record<string, string>).name).toBe('Bash')
+  })
+})
+
+describe('Ollama streaming — visible text before real structured tool_calls (P2)', () => {
+  beforeEach(() => {
+    process.env.OLLAMA_BASE_URL = 'http://localhost:11434'
+    process.env.OPENAI_API_KEY = 'test-key'
+    process.env.OPENAI_BASE_URL = 'http://localhost:11434/v1'
+  })
+  afterEach(() => {
+    delete process.env.OLLAMA_BASE_URL
+    delete process.env.OPENAI_API_KEY
+    delete process.env.OPENAI_BASE_URL
+  })
+
+  test('visible assistant text is preserved when real delta.tool_calls follow it', async () => {
+    // Repro: Ollama endpoint emits visible prose first, then real structured tool_calls.
+    // Before fix: ollamaTextBuffer was discarded when the text block closed.
+    globalThis.fetch = (async () =>
+      makeSseResponse(
+        makeChunks([
+          ollamaChunk('Let me check that.'),
+          ollamaToolChunk([
+            { index: 0, id: 'call_1', type: 'function', function: { name: 'Bash', arguments: '{"command":"ls"}' } },
+          ]),
+          { id: 'chatcmpl-1', object: 'chat.completion.chunk', model: 'qwen2.5:7b',
+            choices: [{ index: 0, delta: {}, finish_reason: 'tool_calls' }] },
+        ]),
+      )) as unknown as FetchType
+
+    const client = createOpenAIShimClient({}) as OpenAIShimClient
+    const result = await client.beta.messages
+      .create({
+        model: 'qwen2.5:7b',
+        messages: [{ role: 'user', content: 'run ls' }],
+        max_tokens: 64,
+        stream: true,
+      })
+      .withResponse()
+
+    const events: Record<string, unknown>[] = []
+    for await (const event of result.data) events.push(event)
+
+    const allText = events
+      .filter(e => e.type === 'content_block_delta' && (e.delta as Record<string, string>)?.type === 'text_delta')
+      .map(e => (e.delta as Record<string, string>).text)
+      .join('')
+    expect(allText).toContain('Let me check that.')
+
+    const toolStarts = events.filter(
+      e => e.type === 'content_block_start' && (e.content_block as Record<string, string>)?.type === 'tool_use',
+    )
+    expect(toolStarts).toHaveLength(1)
+    expect((toolStarts[0].content_block as Record<string, string>).name).toBe('Bash')
   })
 })

--- a/src/services/api/openaiShim.ollamaTextToolCalls.test.ts
+++ b/src/services/api/openaiShim.ollamaTextToolCalls.test.ts
@@ -125,6 +125,21 @@ describe('parseTextToolCalls', () => {
     expect(calls).toHaveLength(0)
   })
 
+  // P1 context guard — fenced block followed by explanatory prose must also be skipped
+  test('skips fenced JSON block immediately followed by explanatory text (P1 guard fenced)', () => {
+    const text =
+      'Here is the format to use:\n```json\n{"name":"Bash","arguments":{"command":"echo example"}}\n```\nDo not execute it yet.'
+    const { calls } = parseTextToolCalls(text)
+    expect(calls).toHaveLength(0)
+  })
+
+  test('still parses fenced JSON block with nothing after the closing fence', () => {
+    const text = 'Running the command:\n```json\n{"name":"Bash","arguments":{"command":"ls"}}\n```'
+    const { calls } = parseTextToolCalls(text)
+    expect(calls).toHaveLength(1)
+    expect(calls[0].name).toBe('Bash')
+  })
+
   test('still parses bare JSON with only trailing whitespace (no trailing context)', () => {
     const text = 'Running the command:\n{"name":"Bash","arguments":{"command":"ls"}}\n'
     const { calls } = parseTextToolCalls(text)

--- a/src/services/api/openaiShim.ollamaTextToolCalls.test.ts
+++ b/src/services/api/openaiShim.ollamaTextToolCalls.test.ts
@@ -573,4 +573,70 @@ describe('Ollama streaming — non-stop terminal finish reasons flush buffer', (
     const delta = messageDelta?.delta as Record<string, unknown> | undefined
     expect(delta?.stop_reason).not.toBe('tool_use')
   })
+
+  test('buffered text is flushed when finish_reason is "content_filter"', async () => {
+    globalThis.fetch = (async () =>
+      makeSseResponse(
+        makeChunks([
+          ollamaChunk('Text stopped by content filter'),
+          ollamaChunk('', 'content_filter'),
+        ]),
+      )) as unknown as FetchType
+
+    const client = createOpenAIShimClient({}) as OpenAIShimClient
+    const result = await client.beta.messages
+      .create({
+        model: 'qwen2.5:7b',
+        messages: [{ role: 'user', content: 'Hi' }],
+        max_tokens: 8,
+        stream: true,
+      })
+      .withResponse()
+
+    const events: Record<string, unknown>[] = []
+    for await (const event of result.data) events.push(event)
+
+    const allText = events
+      .filter(e => e.type === 'content_block_delta' && (e.delta as Record<string, string>)?.type === 'text_delta')
+      .map(e => (e.delta as Record<string, string>).text)
+      .join('')
+    expect(allText).toContain('Text stopped by content filter')
+
+    const messageDelta = events.find(e => e.type === 'message_delta') as Record<string, unknown> | undefined
+    const delta = messageDelta?.delta as Record<string, unknown> | undefined
+    expect(delta?.stop_reason).not.toBe('tool_use')
+  })
+
+  test('buffered text is flushed when finish_reason is "safety"', async () => {
+    globalThis.fetch = (async () =>
+      makeSseResponse(
+        makeChunks([
+          ollamaChunk('Text stopped by safety check'),
+          ollamaChunk('', 'safety'),
+        ]),
+      )) as unknown as FetchType
+
+    const client = createOpenAIShimClient({}) as OpenAIShimClient
+    const result = await client.beta.messages
+      .create({
+        model: 'qwen2.5:7b',
+        messages: [{ role: 'user', content: 'Hi' }],
+        max_tokens: 8,
+        stream: true,
+      })
+      .withResponse()
+
+    const events: Record<string, unknown>[] = []
+    for await (const event of result.data) events.push(event)
+
+    const allText = events
+      .filter(e => e.type === 'content_block_delta' && (e.delta as Record<string, string>)?.type === 'text_delta')
+      .map(e => (e.delta as Record<string, string>).text)
+      .join('')
+    expect(allText).toContain('Text stopped by safety check')
+
+    const messageDelta = events.find(e => e.type === 'message_delta') as Record<string, unknown> | undefined
+    const delta = messageDelta?.delta as Record<string, unknown> | undefined
+    expect(delta?.stop_reason).not.toBe('tool_use')
+  })
 })

--- a/src/services/api/openaiShim.ollamaTextToolCalls.test.ts
+++ b/src/services/api/openaiShim.ollamaTextToolCalls.test.ts
@@ -1,0 +1,87 @@
+/**
+ * Unit tests for parseTextToolCalls — the Ollama text-based tool call
+ * fallback parser introduced in fix/#1053.
+ *
+ * Covers the four formats requested in the PR review:
+ *   1. Bare JSON object  {"name":"X","arguments":{}}
+ *   2. Fenced ```json``` block
+ *   3. {type:"function",function:{name,arguments}} shape
+ *   4. Deduplication by name:args key
+ */
+import { describe, expect, test } from 'bun:test'
+import { parseTextToolCalls } from './openaiShim.js'
+
+describe('parseTextToolCalls', () => {
+  test('parses bare JSON object {"name","arguments"} shape', () => {
+    const text = `Let me read that file.\n{"name":"Read","arguments":{"file_path":"/tmp/foo.ts"}}`
+    const calls = parseTextToolCalls(text)
+    expect(calls).toHaveLength(1)
+    expect(calls[0].name).toBe('Read')
+    expect(calls[0].arguments).toEqual({ file_path: '/tmp/foo.ts' })
+    expect(calls[0].id).toMatch(/^ollama_tc_\d+$/)
+  })
+
+  test('parses fenced ```json``` block', () => {
+    const text = 'I will run this:\n```json\n{"name":"Bash","arguments":{"command":"ls -la"}}\n```'
+    const calls = parseTextToolCalls(text)
+    expect(calls).toHaveLength(1)
+    expect(calls[0].name).toBe('Bash')
+    expect(calls[0].arguments).toEqual({ command: 'ls -la' })
+  })
+
+  test('parses fenced ``` block (no language tag)', () => {
+    const text = '```\n{"name":"Glob","arguments":{"pattern":"src/**/*.ts"}}\n```'
+    const calls = parseTextToolCalls(text)
+    expect(calls).toHaveLength(1)
+    expect(calls[0].name).toBe('Glob')
+  })
+
+  test('parses {type:"function",function:{name,arguments}} shape', () => {
+    const text = '{"type":"function","function":{"name":"Grep","arguments":{"pattern":"TODO","path":"src"}}}'
+    const calls = parseTextToolCalls(text)
+    expect(calls).toHaveLength(1)
+    expect(calls[0].name).toBe('Grep')
+    expect(calls[0].arguments).toEqual({ pattern: 'TODO', path: 'src' })
+  })
+
+  test('parses {type:"function"} shape when arguments is a JSON string', () => {
+    const args = JSON.stringify({ file_path: '/tmp/x.ts' })
+    const text = `{"type":"function","function":{"name":"Read","arguments":${JSON.stringify(args)}}}`
+    const calls = parseTextToolCalls(text)
+    expect(calls).toHaveLength(1)
+    expect(calls[0].name).toBe('Read')
+    expect(calls[0].arguments).toEqual({ file_path: '/tmp/x.ts' })
+  })
+
+  test('deduplicates by name:args key', () => {
+    const snippet = '{"name":"Read","arguments":{"file_path":"/tmp/foo.ts"}}'
+    const text = `${snippet}\nSome text\n${snippet}`
+    const calls = parseTextToolCalls(text)
+    expect(calls).toHaveLength(1)
+  })
+
+  test('returns multiple distinct calls', () => {
+    const text = [
+      '{"name":"Read","arguments":{"file_path":"a.ts"}}',
+      '{"name":"Bash","arguments":{"command":"echo hi"}}',
+    ].join('\n')
+    const calls = parseTextToolCalls(text)
+    expect(calls).toHaveLength(2)
+    expect(calls.map(c => c.name)).toEqual(['Read', 'Bash'])
+  })
+
+  test('returns empty array for plain text with no JSON', () => {
+    const calls = parseTextToolCalls('I think you should check the file manually.')
+    expect(calls).toHaveLength(0)
+  })
+
+  test('ignores malformed JSON', () => {
+    const calls = parseTextToolCalls('{"name":"Read","arguments":{broken}')
+    expect(calls).toHaveLength(0)
+  })
+
+  test('ignores JSON objects without name or type:function', () => {
+    const calls = parseTextToolCalls('{"foo":"bar","baz":42}')
+    expect(calls).toHaveLength(0)
+  })
+})

--- a/src/services/api/openaiShim.ollamaTextToolCalls.test.ts
+++ b/src/services/api/openaiShim.ollamaTextToolCalls.test.ts
@@ -214,6 +214,110 @@ describe('Ollama streaming — think-tag filtering on text-tool fallback (P1)', 
   })
 })
 
+describe('Ollama streaming — plain text response with no tool calls', () => {
+  beforeEach(() => {
+    process.env.OLLAMA_BASE_URL = 'http://localhost:11434'
+    process.env.OPENAI_API_KEY = 'test-key'
+    process.env.OPENAI_BASE_URL = 'http://localhost:11434/v1'
+  })
+  afterEach(() => {
+    delete process.env.OLLAMA_BASE_URL
+    delete process.env.OPENAI_API_KEY
+    delete process.env.OPENAI_BASE_URL
+  })
+
+  test('plain text in two chunks (content then stop) is emitted as text_delta', async () => {
+    globalThis.fetch = (async () =>
+      makeSseResponse(
+        makeChunks([
+          ollamaChunk('Hello from Ollama.'),
+          ollamaChunk('', 'stop'),
+        ]),
+      )) as unknown as FetchType
+
+    const client = createOpenAIShimClient({}) as OpenAIShimClient
+    const result = await client.beta.messages
+      .create({
+        model: 'qwen2.5:7b',
+        messages: [{ role: 'user', content: 'Hi' }],
+        max_tokens: 64,
+        stream: true,
+      })
+      .withResponse()
+
+    const events: Record<string, unknown>[] = []
+    for await (const event of result.data) events.push(event)
+
+    const allText = events
+      .filter(e => e.type === 'content_block_delta' && (e.delta as Record<string, string>)?.type === 'text_delta')
+      .map(e => (e.delta as Record<string, string>).text)
+      .join('')
+
+    expect(allText).toBe('Hello from Ollama.')
+    expect(events.filter(e => e.type === 'content_block_start' && (e.content_block as Record<string, string>)?.type === 'tool_use')).toHaveLength(0)
+    expect(events.some(e => e.type === 'message_stop')).toBe(true)
+  })
+
+  test('plain text in single chunk (content + stop) is emitted as text_delta', async () => {
+    globalThis.fetch = (async () =>
+      makeSseResponse(
+        makeChunks([ollamaChunk('Hello from Ollama.', 'stop')]),
+      )) as unknown as FetchType
+
+    const client = createOpenAIShimClient({}) as OpenAIShimClient
+    const result = await client.beta.messages
+      .create({
+        model: 'qwen2.5:7b',
+        messages: [{ role: 'user', content: 'Hi' }],
+        max_tokens: 64,
+        stream: true,
+      })
+      .withResponse()
+
+    const events: Record<string, unknown>[] = []
+    for await (const event of result.data) events.push(event)
+
+    const allText = events
+      .filter(e => e.type === 'content_block_delta' && (e.delta as Record<string, string>)?.type === 'text_delta')
+      .map(e => (e.delta as Record<string, string>).text)
+      .join('')
+
+    expect(allText).toBe('Hello from Ollama.')
+  })
+
+  test('multi-chunk plain text (no tool calls) assembles correctly', async () => {
+    globalThis.fetch = (async () =>
+      makeSseResponse(
+        makeChunks([
+          ollamaChunk('Hello '),
+          ollamaChunk('from '),
+          ollamaChunk('Ollama.'),
+          ollamaChunk('', 'stop'),
+        ]),
+      )) as unknown as FetchType
+
+    const client = createOpenAIShimClient({}) as OpenAIShimClient
+    const result = await client.beta.messages
+      .create({
+        model: 'qwen2.5:7b',
+        messages: [{ role: 'user', content: 'Hi' }],
+        max_tokens: 64,
+        stream: true,
+      })
+      .withResponse()
+
+    const events: Record<string, unknown>[] = []
+    for await (const event of result.data) events.push(event)
+
+    const allText = events
+      .filter(e => e.type === 'content_block_delta' && (e.delta as Record<string, string>)?.type === 'text_delta')
+      .map(e => (e.delta as Record<string, string>).text)
+      .join('')
+
+    expect(allText).toBe('Hello from Ollama.')
+  })
+})
+
 describe('Ollama streaming — visible text before real structured tool_calls (P2)', () => {
   beforeEach(() => {
     process.env.OLLAMA_BASE_URL = 'http://localhost:11434'

--- a/src/services/api/openaiShim.ts
+++ b/src/services/api/openaiShim.ts
@@ -1015,8 +1015,10 @@ function repairPossiblyTruncatedObjectJson(raw: string): string | null {
 //   {"type":"function","function":{"name":"X","arguments":{...}}}
 // ---------------------------------------------------------------------------
 
-const TOOL_CALL_TEXT_RE =
-  /```(?:json)?\s*\n?\s*(\{[\s\S]*?\})\s*\n?\s*```|(\{"(?:name|type)"\s*:[\s\S]*?\})/g
+// Fenced code block arm: non-greedy is safe because ``` acts as terminator.
+const FENCED_TOOL_CALL_RE = /```(?:json)?\s*\n?\s*(\{[\s\S]*?\})\s*\n?\s*```/g
+// Bare JSON arm: marks candidate start positions only; balanced extraction follows.
+const BARE_TOOL_CALL_START_RE = /\{"(?:name|type)"\s*:/g
 
 interface ParsedTextToolCall {
   id: string
@@ -1027,56 +1029,101 @@ interface ParsedTextToolCall {
 // Module-level counter ensures unique IDs across calls within a session.
 let _textToolCallCounter = 0
 
+// Walks forward from `start` (which must be `{`) tracking string/escape/brace
+// state and returns the substring up to and including the matching `}`, or
+// null if the braces are never balanced (truncated input).
+function extractBalancedJson(text: string, start: number): string | null {
+  let depth = 0
+  let inString = false
+  let escape = false
+  for (let i = start; i < text.length; i++) {
+    const c = text[i]!
+    if (escape) { escape = false; continue }
+    if (c === '\\' && inString) { escape = true; continue }
+    if (c === '"') { inString = !inString; continue }
+    if (inString) continue
+    if (c === '{') depth++
+    else if (c === '}') {
+      depth--
+      if (depth === 0) return text.slice(start, i + 1)
+    }
+  }
+  return null
+}
+
+function parseAndAdd(
+  raw: string,
+  results: ParsedTextToolCall[],
+  seen: Set<string>,
+): void {
+  let obj: Record<string, unknown>
+  try {
+    obj = JSON.parse(raw)
+  } catch {
+    return
+  }
+
+  let name: string | undefined
+  let args: Record<string, unknown> = {}
+
+  if (typeof obj['name'] === 'string') {
+    // {"name": "X", "arguments": {...}}
+    name = obj['name'] as string
+    args = (obj['arguments'] as Record<string, unknown>) ?? {}
+  } else if (
+    obj['type'] === 'function' &&
+    typeof (obj['function'] as any)?.name === 'string'
+  ) {
+    // {"type":"function","function":{"name":"X","arguments":{...}}}
+    const fn = obj['function'] as { name: string; arguments?: unknown }
+    name = fn.name
+    const rawArgs = fn.arguments
+    args =
+      typeof rawArgs === 'string'
+        ? (() => {
+            try {
+              return JSON.parse(rawArgs)
+            } catch {
+              return {}
+            }
+          })()
+        : (rawArgs as Record<string, unknown>) ?? {}
+  }
+
+  if (!name) return
+
+  const dedupKey = `${name}:${JSON.stringify(args)}`
+  if (seen.has(dedupKey)) return
+  seen.add(dedupKey)
+
+  results.push({ id: `ollama_tc_${++_textToolCallCounter}`, name, arguments: args })
+}
+
 /** Exported for unit testing only. */
 export function parseTextToolCalls(text: string): ParsedTextToolCall[] {
   const results: ParsedTextToolCall[] = []
   const seen = new Set<string>()
+  const fencedRanges: Array<[number, number]> = []
 
-  for (const match of text.matchAll(TOOL_CALL_TEXT_RE)) {
-    const raw = (match[1] ?? match[2] ?? '').trim()
-    if (!raw) continue
+  // Pass 1: fenced code blocks — regex is safe, ``` bounds the non-greedy match.
+  for (const match of text.matchAll(FENCED_TOOL_CALL_RE)) {
+    const raw = (match[1] ?? '').trim()
+    fencedRanges.push([match.index!, match.index! + match[0].length])
+    if (raw) parseAndAdd(raw, results, seen)
+  }
 
-    let obj: Record<string, unknown>
-    try {
-      obj = JSON.parse(raw)
-    } catch {
-      continue
+  // Pass 2: bare JSON — use the brace scanner so nested objects are captured fully.
+  // processedRanges grows as we extract; inner objects nested inside an outer
+  // tool call are skipped because their start falls inside an already-extracted range.
+  const processedRanges: Array<[number, number]> = [...fencedRanges]
+  for (const match of text.matchAll(BARE_TOOL_CALL_START_RE)) {
+    const start = match.index!
+    if (processedRanges.some(([s, e]) => start >= s && start < e)) continue
+    const raw = extractBalancedJson(text, start)
+    if (raw) {
+      processedRanges.push([start, start + raw.length])
+      parseAndAdd(raw, results, seen)
     }
-
-    let name: string | undefined
-    let args: Record<string, unknown> = {}
-
-    if (typeof obj['name'] === 'string') {
-      // {"name": "X", "arguments": {...}}
-      name = obj['name'] as string
-      args = (obj['arguments'] as Record<string, unknown>) ?? {}
-    } else if (
-      obj['type'] === 'function' &&
-      typeof (obj['function'] as any)?.name === 'string'
-    ) {
-      // {"type":"function","function":{"name":"X","arguments":{...}}}
-      const fn = obj['function'] as { name: string; arguments?: unknown }
-      name = fn.name
-      const rawArgs = fn.arguments
-      args =
-        typeof rawArgs === 'string'
-          ? (() => {
-              try {
-                return JSON.parse(rawArgs)
-              } catch {
-                return {}
-              }
-            })()
-          : (rawArgs as Record<string, unknown>) ?? {}
-    }
-
-    if (!name) continue
-
-    const dedupKey = `${name}:${JSON.stringify(args)}`
-    if (seen.has(dedupKey)) continue
-    seen.add(dedupKey)
-
-    results.push({ id: `ollama_tc_${++_textToolCallCounter}`, name, arguments: args })
   }
 
   return results

--- a/src/services/api/openaiShim.ts
+++ b/src/services/api/openaiShim.ts
@@ -1749,17 +1749,27 @@ async function* openaiStreamToAnthropic(
                 contentBlockIndex++
                 hasClosedThinking = true
               }
-              if (hasEmittedContentStart) {
-                // Flush buffered Ollama text before closing the text block so
-                // visible prose that preceded a real structured tool call is not lost.
-                if (isOllamaStream && ollamaTextBuffer) {
+              // Flush buffered Ollama text before processing the tool call.
+              // Must run before hasEmittedContentStart check because for Ollama
+              // streams the text block may not have been opened yet (we buffer
+              // instead of emitting during the streaming phase).
+              if (isOllamaStream && ollamaTextBuffer) {
+                if (!hasEmittedContentStart) {
                   yield {
-                    type: 'content_block_delta',
+                    type: 'content_block_start',
                     index: contentBlockIndex,
-                    delta: { type: 'text_delta', text: ollamaTextBuffer },
+                    content_block: { type: 'text', text: '' },
                   }
-                  ollamaTextBuffer = ''
+                  hasEmittedContentStart = true
                 }
+                yield {
+                  type: 'content_block_delta',
+                  index: contentBlockIndex,
+                  delta: { type: 'text_delta', text: ollamaTextBuffer },
+                }
+                ollamaTextBuffer = ''
+              }
+              if (hasEmittedContentStart) {
                 yield* closeActiveContentBlock()
               }
 

--- a/src/services/api/openaiShim.ts
+++ b/src/services/api/openaiShim.ts
@@ -81,6 +81,7 @@ import {
   classifyOpenAINetworkFailure,
 } from './openaiErrorClassification.js'
 import { sanitizeSchemaForOpenAICompat } from '../../utils/schemaSanitizer.js'
+import { isOllamaProvider } from '../../utils/model/ollamaModels.js'
 import { redactSecretValueForDisplay } from '../../utils/providerProfile.js'
 import { shouldRedactUrlQueryParam } from '../../utils/urlRedaction.js'
 import {
@@ -1042,6 +1043,86 @@ function repairPossiblyTruncatedObjectJson(raw: string): string | null {
   }
 }
 
+// ---------------------------------------------------------------------------
+// Ollama text-based tool call parser (fix for #1053)
+//
+// When Ollama models cannot emit structured tool_calls via the OpenAI-compat
+// API, they fall back to printing the call as a JSON block in the response
+// text. This parser extracts those calls so the agent loop can execute them.
+//
+// Supported formats emitted by qwen2.5-coder, llama3.x, phi-4, gemma:
+//   ```json\n{"name":"X","arguments":{...}}\n```
+//   {"name":"X","arguments":{...}}
+//   {"type":"function","function":{"name":"X","arguments":{...}}}
+// ---------------------------------------------------------------------------
+
+const TOOL_CALL_TEXT_RE =
+  /```(?:json)?\s*\n?\s*(\{[\s\S]*?\})\s*\n?\s*```|(\{"(?:name|type)"\s*:[\s\S]*?\})/g
+
+interface ParsedTextToolCall {
+  id: string
+  name: string
+  arguments: Record<string, unknown>
+}
+
+// Module-level counter ensures unique IDs across calls within a session.
+let _textToolCallCounter = 0
+
+/** Exported for unit testing only. */
+export function parseTextToolCalls(text: string): ParsedTextToolCall[] {
+  const results: ParsedTextToolCall[] = []
+  const seen = new Set<string>()
+
+  for (const match of text.matchAll(TOOL_CALL_TEXT_RE)) {
+    const raw = (match[1] ?? match[2] ?? '').trim()
+    if (!raw) continue
+
+    let obj: Record<string, unknown>
+    try {
+      obj = JSON.parse(raw)
+    } catch {
+      continue
+    }
+
+    let name: string | undefined
+    let args: Record<string, unknown> = {}
+
+    if (typeof obj['name'] === 'string') {
+      // {"name": "X", "arguments": {...}}
+      name = obj['name'] as string
+      args = (obj['arguments'] as Record<string, unknown>) ?? {}
+    } else if (
+      obj['type'] === 'function' &&
+      typeof (obj['function'] as any)?.name === 'string'
+    ) {
+      // {"type":"function","function":{"name":"X","arguments":{...}}}
+      const fn = obj['function'] as { name: string; arguments?: unknown }
+      name = fn.name
+      const rawArgs = fn.arguments
+      args =
+        typeof rawArgs === 'string'
+          ? (() => {
+              try {
+                return JSON.parse(rawArgs)
+              } catch {
+                return {}
+              }
+            })()
+          : (rawArgs as Record<string, unknown>) ?? {}
+    }
+
+    if (!name) continue
+
+    const dedupKey = `${name}:${JSON.stringify(args)}`
+    if (seen.has(dedupKey)) continue
+    seen.add(dedupKey)
+
+    results.push({ id: `ollama_tc_${++_textToolCallCounter}`, name, arguments: args })
+  }
+
+  return results
+}
+
 /**
  * Async generator that transforms an OpenAI SSE stream into
  * Anthropic-format BetaRawMessageStreamEvent objects.
@@ -1312,6 +1393,8 @@ async function* openaiStreamToAnthropic(
   let lastStopReason: 'tool_use' | 'max_tokens' | 'end_turn' | null = null
   let hasEmittedFinalUsage = false
   let hasProcessedFinishReason = false
+  // Accumulated text for Ollama text-based tool call fallback parsing (#1053)
+  let accumulatedText = ''
   const streamState = createStreamState()
   let bufferedRawToolCallsText: string | null = null
 
@@ -1549,6 +1632,7 @@ async function* openaiStreamToAnthropic(
             hasClosedThinking = true
           }
 
+          accumulatedText += delta.content
           if (
             !hasEmittedContentStart &&
             bufferedRawToolCallsText === null &&
@@ -1750,6 +1834,38 @@ async function* openaiStreamToAnthropic(
             }
 
             yield { type: 'content_block_stop', index: tc.index }
+          }
+
+          // Ollama text-based tool call fallback (#1053):
+          // Ollama models output tool calls as JSON text instead of structured
+          // tool_calls API fields. When finish_reason=stop with no API-level
+          // tool calls, scan accumulated text for JSON tool call patterns and
+          // emit them as proper tool_use events so the agentic loop continues.
+          if (
+            choice.finish_reason === 'stop' &&
+            activeToolCalls.size === 0 &&
+            isOllamaProvider()
+          ) {
+            const textToolCalls = parseTextToolCalls(accumulatedText)
+            if (textToolCalls.length > 0) {
+              for (const tc of textToolCalls) {
+                const toolBlockIndex = contentBlockIndex
+                yield {
+                  type: 'content_block_start',
+                  index: toolBlockIndex,
+                  content_block: { type: 'tool_use', id: tc.id, name: tc.name, input: {} },
+                }
+                contentBlockIndex++
+                yield {
+                  type: 'content_block_delta',
+                  index: toolBlockIndex,
+                  delta: { type: 'input_json_delta', partial_json: JSON.stringify(tc.arguments) },
+                }
+                yield { type: 'content_block_stop', index: toolBlockIndex }
+              }
+              // Override so stopReason becomes 'tool_use' and the loop continues
+              choice.finish_reason = 'tool_calls'
+            }
           }
 
           const stopReason =

--- a/src/services/api/openaiShim.ts
+++ b/src/services/api/openaiShim.ts
@@ -1574,12 +1574,10 @@ async function* openaiStreamToAnthropic(
               ollamaClosedContentBlock = true
               if (hasEmittedContentStart) {
                 const stripped = stripRanges(accumulatedText, toolCallRanges).trim()
-                // Also remove <think>...</think> blocks — accumulatedText is raw
-                // (unfiltered), so think content that was already hidden from the
-                // user would otherwise re-surface here.
-                const strippedVisible = stripped
-                  .replace(/<think>[\s\S]*?<\/think>/gi, '')
-                  .trim()
+                // Use stripThinkTags (handles closed pairs, unterminated opens, and
+                // orphan tags) so hidden <think> content in the raw accumulator never
+                // resurfaces as visible assistant text in the fallback path.
+                const strippedVisible = stripThinkTags(stripped).trim()
                 if (strippedVisible) {
                   yield {
                     type: 'content_block_delta',

--- a/src/services/api/openaiShim.ts
+++ b/src/services/api/openaiShim.ts
@@ -71,6 +71,7 @@ import {
   classifyOpenAINetworkFailure,
 } from './openaiErrorClassification.js'
 import { sanitizeSchemaForOpenAICompat } from '../../utils/schemaSanitizer.js'
+import { isOllamaProvider } from '../../utils/model/ollamaModels.js'
 import { redactSecretValueForDisplay } from '../../utils/providerProfile.js'
 import { shouldRedactUrlQueryParam } from '../../utils/urlRedaction.js'
 import {
@@ -1001,6 +1002,86 @@ function repairPossiblyTruncatedObjectJson(raw: string): string | null {
   }
 }
 
+// ---------------------------------------------------------------------------
+// Ollama text-based tool call parser (fix for #1053)
+//
+// When Ollama models cannot emit structured tool_calls via the OpenAI-compat
+// API, they fall back to printing the call as a JSON block in the response
+// text. This parser extracts those calls so the agent loop can execute them.
+//
+// Supported formats emitted by qwen2.5-coder, llama3.x, phi-4, gemma:
+//   ```json\n{"name":"X","arguments":{...}}\n```
+//   {"name":"X","arguments":{...}}
+//   {"type":"function","function":{"name":"X","arguments":{...}}}
+// ---------------------------------------------------------------------------
+
+const TOOL_CALL_TEXT_RE =
+  /```(?:json)?\s*\n?\s*(\{[\s\S]*?\})\s*\n?\s*```|(\{"(?:name|type)"\s*:[\s\S]*?\})/g
+
+interface ParsedTextToolCall {
+  id: string
+  name: string
+  arguments: Record<string, unknown>
+}
+
+// Module-level counter ensures unique IDs across calls within a session.
+let _textToolCallCounter = 0
+
+/** Exported for unit testing only. */
+export function parseTextToolCalls(text: string): ParsedTextToolCall[] {
+  const results: ParsedTextToolCall[] = []
+  const seen = new Set<string>()
+
+  for (const match of text.matchAll(TOOL_CALL_TEXT_RE)) {
+    const raw = (match[1] ?? match[2] ?? '').trim()
+    if (!raw) continue
+
+    let obj: Record<string, unknown>
+    try {
+      obj = JSON.parse(raw)
+    } catch {
+      continue
+    }
+
+    let name: string | undefined
+    let args: Record<string, unknown> = {}
+
+    if (typeof obj['name'] === 'string') {
+      // {"name": "X", "arguments": {...}}
+      name = obj['name'] as string
+      args = (obj['arguments'] as Record<string, unknown>) ?? {}
+    } else if (
+      obj['type'] === 'function' &&
+      typeof (obj['function'] as any)?.name === 'string'
+    ) {
+      // {"type":"function","function":{"name":"X","arguments":{...}}}
+      const fn = obj['function'] as { name: string; arguments?: unknown }
+      name = fn.name
+      const rawArgs = fn.arguments
+      args =
+        typeof rawArgs === 'string'
+          ? (() => {
+              try {
+                return JSON.parse(rawArgs)
+              } catch {
+                return {}
+              }
+            })()
+          : (rawArgs as Record<string, unknown>) ?? {}
+    }
+
+    if (!name) continue
+
+    const dedupKey = `${name}:${JSON.stringify(args)}`
+    if (seen.has(dedupKey)) continue
+    seen.add(dedupKey)
+
+    results.push({ id: `ollama_tc_${++_textToolCallCounter}`, name, arguments: args })
+  }
+
+  return results
+}
+
 /**
  * Async generator that transforms an OpenAI SSE stream into
  * Anthropic-format BetaRawMessageStreamEvent objects.
@@ -1029,6 +1110,8 @@ async function* openaiStreamToAnthropic(
   let lastStopReason: 'tool_use' | 'max_tokens' | 'end_turn' | null = null
   let hasEmittedFinalUsage = false
   let hasProcessedFinishReason = false
+  // Accumulated text for Ollama text-based tool call fallback parsing (#1053)
+  let accumulatedText = ''
   const streamState = createStreamState()
   let bufferedRawToolCallsText: string | null = null
 
@@ -1264,6 +1347,7 @@ async function* openaiStreamToAnthropic(
             hasClosedThinking = true
           }
 
+          accumulatedText += delta.content
           if (
             !hasEmittedContentStart &&
             bufferedRawToolCallsText === null &&
@@ -1465,6 +1549,38 @@ async function* openaiStreamToAnthropic(
             }
 
             yield { type: 'content_block_stop', index: tc.index }
+          }
+
+          // Ollama text-based tool call fallback (#1053):
+          // Ollama models output tool calls as JSON text instead of structured
+          // tool_calls API fields. When finish_reason=stop with no API-level
+          // tool calls, scan accumulated text for JSON tool call patterns and
+          // emit them as proper tool_use events so the agentic loop continues.
+          if (
+            choice.finish_reason === 'stop' &&
+            activeToolCalls.size === 0 &&
+            isOllamaProvider()
+          ) {
+            const textToolCalls = parseTextToolCalls(accumulatedText)
+            if (textToolCalls.length > 0) {
+              for (const tc of textToolCalls) {
+                const toolBlockIndex = contentBlockIndex
+                yield {
+                  type: 'content_block_start',
+                  index: toolBlockIndex,
+                  content_block: { type: 'tool_use', id: tc.id, name: tc.name, input: {} },
+                }
+                contentBlockIndex++
+                yield {
+                  type: 'content_block_delta',
+                  index: toolBlockIndex,
+                  delta: { type: 'input_json_delta', partial_json: JSON.stringify(tc.arguments) },
+                }
+                yield { type: 'content_block_stop', index: toolBlockIndex }
+              }
+              // Override so stopReason becomes 'tool_use' and the loop continues
+              choice.finish_reason = 'tool_calls'
+            }
           }
 
           const stopReason =

--- a/src/services/api/openaiShim.ts
+++ b/src/services/api/openaiShim.ts
@@ -1056,8 +1056,10 @@ function repairPossiblyTruncatedObjectJson(raw: string): string | null {
 //   {"type":"function","function":{"name":"X","arguments":{...}}}
 // ---------------------------------------------------------------------------
 
-const TOOL_CALL_TEXT_RE =
-  /```(?:json)?\s*\n?\s*(\{[\s\S]*?\})\s*\n?\s*```|(\{"(?:name|type)"\s*:[\s\S]*?\})/g
+// Fenced code block arm: non-greedy is safe because ``` acts as terminator.
+const FENCED_TOOL_CALL_RE = /```(?:json)?\s*\n?\s*(\{[\s\S]*?\})\s*\n?\s*```/g
+// Bare JSON arm: marks candidate start positions only; balanced extraction follows.
+const BARE_TOOL_CALL_START_RE = /\{"(?:name|type)"\s*:/g
 
 interface ParsedTextToolCall {
   id: string
@@ -1068,56 +1070,101 @@ interface ParsedTextToolCall {
 // Module-level counter ensures unique IDs across calls within a session.
 let _textToolCallCounter = 0
 
+// Walks forward from `start` (which must be `{`) tracking string/escape/brace
+// state and returns the substring up to and including the matching `}`, or
+// null if the braces are never balanced (truncated input).
+function extractBalancedJson(text: string, start: number): string | null {
+  let depth = 0
+  let inString = false
+  let escape = false
+  for (let i = start; i < text.length; i++) {
+    const c = text[i]!
+    if (escape) { escape = false; continue }
+    if (c === '\\' && inString) { escape = true; continue }
+    if (c === '"') { inString = !inString; continue }
+    if (inString) continue
+    if (c === '{') depth++
+    else if (c === '}') {
+      depth--
+      if (depth === 0) return text.slice(start, i + 1)
+    }
+  }
+  return null
+}
+
+function parseAndAdd(
+  raw: string,
+  results: ParsedTextToolCall[],
+  seen: Set<string>,
+): void {
+  let obj: Record<string, unknown>
+  try {
+    obj = JSON.parse(raw)
+  } catch {
+    return
+  }
+
+  let name: string | undefined
+  let args: Record<string, unknown> = {}
+
+  if (typeof obj['name'] === 'string') {
+    // {"name": "X", "arguments": {...}}
+    name = obj['name'] as string
+    args = (obj['arguments'] as Record<string, unknown>) ?? {}
+  } else if (
+    obj['type'] === 'function' &&
+    typeof (obj['function'] as any)?.name === 'string'
+  ) {
+    // {"type":"function","function":{"name":"X","arguments":{...}}}
+    const fn = obj['function'] as { name: string; arguments?: unknown }
+    name = fn.name
+    const rawArgs = fn.arguments
+    args =
+      typeof rawArgs === 'string'
+        ? (() => {
+            try {
+              return JSON.parse(rawArgs)
+            } catch {
+              return {}
+            }
+          })()
+        : (rawArgs as Record<string, unknown>) ?? {}
+  }
+
+  if (!name) return
+
+  const dedupKey = `${name}:${JSON.stringify(args)}`
+  if (seen.has(dedupKey)) return
+  seen.add(dedupKey)
+
+  results.push({ id: `ollama_tc_${++_textToolCallCounter}`, name, arguments: args })
+}
+
 /** Exported for unit testing only. */
 export function parseTextToolCalls(text: string): ParsedTextToolCall[] {
   const results: ParsedTextToolCall[] = []
   const seen = new Set<string>()
+  const fencedRanges: Array<[number, number]> = []
 
-  for (const match of text.matchAll(TOOL_CALL_TEXT_RE)) {
-    const raw = (match[1] ?? match[2] ?? '').trim()
-    if (!raw) continue
+  // Pass 1: fenced code blocks — regex is safe, ``` bounds the non-greedy match.
+  for (const match of text.matchAll(FENCED_TOOL_CALL_RE)) {
+    const raw = (match[1] ?? '').trim()
+    fencedRanges.push([match.index!, match.index! + match[0].length])
+    if (raw) parseAndAdd(raw, results, seen)
+  }
 
-    let obj: Record<string, unknown>
-    try {
-      obj = JSON.parse(raw)
-    } catch {
-      continue
+  // Pass 2: bare JSON — use the brace scanner so nested objects are captured fully.
+  // processedRanges grows as we extract; inner objects nested inside an outer
+  // tool call are skipped because their start falls inside an already-extracted range.
+  const processedRanges: Array<[number, number]> = [...fencedRanges]
+  for (const match of text.matchAll(BARE_TOOL_CALL_START_RE)) {
+    const start = match.index!
+    if (processedRanges.some(([s, e]) => start >= s && start < e)) continue
+    const raw = extractBalancedJson(text, start)
+    if (raw) {
+      processedRanges.push([start, start + raw.length])
+      parseAndAdd(raw, results, seen)
     }
-
-    let name: string | undefined
-    let args: Record<string, unknown> = {}
-
-    if (typeof obj['name'] === 'string') {
-      // {"name": "X", "arguments": {...}}
-      name = obj['name'] as string
-      args = (obj['arguments'] as Record<string, unknown>) ?? {}
-    } else if (
-      obj['type'] === 'function' &&
-      typeof (obj['function'] as any)?.name === 'string'
-    ) {
-      // {"type":"function","function":{"name":"X","arguments":{...}}}
-      const fn = obj['function'] as { name: string; arguments?: unknown }
-      name = fn.name
-      const rawArgs = fn.arguments
-      args =
-        typeof rawArgs === 'string'
-          ? (() => {
-              try {
-                return JSON.parse(rawArgs)
-              } catch {
-                return {}
-              }
-            })()
-          : (rawArgs as Record<string, unknown>) ?? {}
-    }
-
-    if (!name) continue
-
-    const dedupKey = `${name}:${JSON.stringify(args)}`
-    if (seen.has(dedupKey)) continue
-    seen.add(dedupKey)
-
-    results.push({ id: `ollama_tc_${++_textToolCallCounter}`, name, arguments: args })
   }
 
   return results

--- a/src/services/api/openaiShim.ts
+++ b/src/services/api/openaiShim.ts
@@ -1750,6 +1750,16 @@ async function* openaiStreamToAnthropic(
                 hasClosedThinking = true
               }
               if (hasEmittedContentStart) {
+                // Flush buffered Ollama text before closing the text block so
+                // visible prose that preceded a real structured tool call is not lost.
+                if (isOllamaStream && ollamaTextBuffer) {
+                  yield {
+                    type: 'content_block_delta',
+                    index: contentBlockIndex,
+                    delta: { type: 'text_delta', text: ollamaTextBuffer },
+                  }
+                  ollamaTextBuffer = ''
+                }
                 yield* closeActiveContentBlock()
               }
 
@@ -1849,11 +1859,17 @@ async function* openaiStreamToAnthropic(
               ollamaClosedContentBlock = true
               if (hasEmittedContentStart) {
                 const stripped = stripRanges(accumulatedText, toolCallRanges).trim()
-                if (stripped) {
+                // Also remove <think>...</think> blocks — accumulatedText is raw
+                // (unfiltered), so think content that was already hidden from the
+                // user would otherwise re-surface here.
+                const strippedVisible = stripped
+                  .replace(/<think>[\s\S]*?<\/think>/gi, '')
+                  .trim()
+                if (strippedVisible) {
                   yield {
                     type: 'content_block_delta',
                     index: contentBlockIndex,
-                    delta: { type: 'text_delta', text: stripped },
+                    delta: { type: 'text_delta', text: strippedVisible },
                   }
                 }
                 yield* closeActiveContentBlock()

--- a/src/services/api/openaiShim.ts
+++ b/src/services/api/openaiShim.ts
@@ -69,6 +69,7 @@ import {
   getLocalFastPathConfig,
   getLocalProviderRetryBaseUrls,
   getGithubEndpointType,
+  isLikelyOllamaEndpoint,
   isLocalProviderUrl,
   resolveRuntimeCodexCredentials,
   resolveProviderRequest,
@@ -81,7 +82,6 @@ import {
   classifyOpenAINetworkFailure,
 } from './openaiErrorClassification.js'
 import { sanitizeSchemaForOpenAICompat } from '../../utils/schemaSanitizer.js'
-import { isOllamaProvider } from '../../utils/model/ollamaModels.js'
 import { redactSecretValueForDisplay } from '../../utils/providerProfile.js'
 import { shouldRedactUrlQueryParam } from '../../utils/urlRedaction.js'
 import {
@@ -2189,7 +2189,7 @@ class OpenAIShimMessages {
               ? anthropicSsePassthrough(response, request.resolvedModel, options?.signal)
               : isGeminiStream
                 ? geminiSseToAnthropic(response, request.resolvedModel, options?.signal)
-                : openaiStreamToAnthropic(response, request.resolvedModel, options?.signal, isOllamaProvider()),
+                : openaiStreamToAnthropic(response, request.resolvedModel, options?.signal, isLikelyOllamaEndpoint(request.baseUrl)),
         )
       }
 

--- a/src/services/api/openaiShim.ts
+++ b/src/services/api/openaiShim.ts
@@ -1162,8 +1162,13 @@ export function parseTextToolCalls(text: string): {
   const fencedRanges: Array<[number, number]> = []
 
   // Pass 1: fenced code blocks — regex is safe, ``` bounds the non-greedy match.
+  // Context guard: same heuristic as Pass 2 — if non-whitespace, non-`{` text
+  // immediately follows the closing fence, the model is explaining a format rather
+  // than calling a tool; skip to avoid false positives on fenced examples.
   for (const match of text.matchAll(FENCED_TOOL_CALL_RE)) {
     const raw = (match[1] ?? '').trim()
+    const after = text.slice(match.index! + match[0].length).trimStart()
+    if (after.length > 0 && !after.startsWith('{')) continue
     fencedRanges.push([match.index!, match.index! + match[0].length])
     if (raw) parseAndAdd(raw, results, seen)
   }

--- a/src/services/api/openaiShim.ts
+++ b/src/services/api/openaiShim.ts
@@ -1059,7 +1059,9 @@ function repairPossiblyTruncatedObjectJson(raw: string): string | null {
 // Fenced code block arm: non-greedy is safe because ``` acts as terminator.
 const FENCED_TOOL_CALL_RE = /```(?:json)?\s*\n?\s*(\{[\s\S]*?\})\s*\n?\s*```/g
 // Bare JSON arm: marks candidate start positions only; balanced extraction follows.
-const BARE_TOOL_CALL_START_RE = /\{"(?:name|type)"\s*:/g
+// Allow optional whitespace (including newlines) before the property key so
+// pretty-printed objects like "{\n  \"name\":" are detected.
+const BARE_TOOL_CALL_START_RE = /\{\s*"(?:name|type)"\s*:/g
 
 interface ParsedTextToolCall {
   id: string
@@ -1456,6 +1458,7 @@ async function* openaiStreamToAnthropic(
   response: Response,
   model: string,
   signal?: AbortSignal,
+  isOllama = false,
 ): AsyncGenerator<AnthropicStreamEvent> {
   const messageId = makeMessageId()
   let contentBlockIndex = 0
@@ -1478,7 +1481,9 @@ async function* openaiStreamToAnthropic(
   let hasProcessedFinishReason = false
   // Accumulated text for Ollama text-based tool call fallback parsing (#1053)
   let accumulatedText = ''
-  const isOllamaStream = isOllamaProvider()
+  // Use the resolved value threaded from the call site (resolveProviderRequest)
+  // rather than re-reading env vars inside the generator.
+  const isOllamaStream = isOllama
   // Buffer Ollama text deltas so raw tool-call JSON is never emitted as text_delta
   // before extraction at finish_reason=stop (P2 fix for #1053).
   let ollamaTextBuffer = ''
@@ -1874,13 +1879,17 @@ async function* openaiStreamToAnthropic(
           // Ollama text-based tool call fallback (#1053):
           // Must run before closeActiveContentBlock so the text buffer can be flushed
           // with tool-call JSON stripped (P2). Ollama models emit tool calls as raw
-          // JSON text; scan accumulated text when finish_reason=stop with no API tool calls.
-          let ollamaClosedContentBlock = false
-          if (
-            choice.finish_reason === 'stop' &&
+          // JSON text; scan accumulated text on any terminal finish reason with no
+          // API tool calls. finish_reason is mutated to 'tool_calls' only for 'stop'
+          // so the JSON fallback remains scoped to normal completions.
+          const OLLAMA_TERMINAL_REASONS = new Set(['stop', 'length', 'content_filter', 'safety'])
+          const isTerminalOllamaFinish =
+            OLLAMA_TERMINAL_REASONS.has(choice.finish_reason ?? '') &&
             activeToolCalls.size === 0 &&
             isOllamaStream
-          ) {
+          const originalFinishReason = choice.finish_reason
+          let ollamaClosedContentBlock = false
+          if (isTerminalOllamaFinish) {
             const { calls: textToolCalls, toolCallRanges } = parseTextToolCalls(accumulatedText)
             if (textToolCalls.length > 0) {
               ollamaClosedContentBlock = true
@@ -1929,7 +1938,11 @@ async function* openaiStreamToAnthropic(
                 }
                 yield { type: 'content_block_stop', index: toolBlockIndex }
               }
-              choice.finish_reason = 'tool_calls'
+              // Only remap finish_reason to 'tool_calls' for the normal stop case;
+              // non-stop terminal reasons keep their original reason.
+              if (originalFinishReason === 'stop') {
+                choice.finish_reason = 'tool_calls'
+              }
             } else if (ollamaTextBuffer) {
               // No tool calls — flush the buffered text before the normal close below.
               // Open a text block first if one is not already open (guards the edge case
@@ -2176,7 +2189,7 @@ class OpenAIShimMessages {
               ? anthropicSsePassthrough(response, request.resolvedModel, options?.signal)
               : isGeminiStream
                 ? geminiSseToAnthropic(response, request.resolvedModel, options?.signal)
-                : openaiStreamToAnthropic(response, request.resolvedModel, options?.signal),
+                : openaiStreamToAnthropic(response, request.resolvedModel, options?.signal, isOllamaProvider()),
         )
       }
 

--- a/src/services/api/openaiShim.ts
+++ b/src/services/api/openaiShim.ts
@@ -1867,18 +1867,33 @@ async function* openaiStreamToAnthropic(
             const { calls: textToolCalls, toolCallRanges } = parseTextToolCalls(accumulatedText)
             if (textToolCalls.length > 0) {
               ollamaClosedContentBlock = true
+              // Compute visible prose (tool-call JSON stripped, think-tags removed).
+              // Use accumulatedText (raw) as source because toolCallRanges are relative to it.
+              const stripped = stripRanges(accumulatedText, toolCallRanges).trim()
+              const strippedVisible = stripThinkTags(stripped).trim()
               if (hasEmittedContentStart) {
-                const stripped = stripRanges(accumulatedText, toolCallRanges).trim()
-                // Use stripThinkTags (handles closed pairs, unterminated opens, and
-                // orphan tags) so hidden <think> content in the raw accumulator never
-                // resurfaces as visible assistant text in the fallback path.
-                const strippedVisible = stripThinkTags(stripped).trim()
+                // Text block was already open — emit stripped prose then close it.
                 if (strippedVisible) {
                   yield {
                     type: 'content_block_delta',
                     index: contentBlockIndex,
                     delta: { type: 'text_delta', text: strippedVisible },
                   }
+                }
+                yield* closeActiveContentBlock()
+              } else if (strippedVisible) {
+                // Text was buffered (Ollama path, hasEmittedContentStart === false).
+                // Open a text block, emit the visible prose before the tool call, close it.
+                yield {
+                  type: 'content_block_start',
+                  index: contentBlockIndex,
+                  content_block: { type: 'text', text: '' },
+                }
+                hasEmittedContentStart = true
+                yield {
+                  type: 'content_block_delta',
+                  index: contentBlockIndex,
+                  delta: { type: 'text_delta', text: strippedVisible },
                 }
                 yield* closeActiveContentBlock()
               }

--- a/src/services/api/openaiShim.ts
+++ b/src/services/api/openaiShim.ts
@@ -1464,17 +1464,27 @@ async function* openaiStreamToAnthropic(
                 contentBlockIndex++
                 hasClosedThinking = true
               }
-              if (hasEmittedContentStart) {
-                // Flush buffered Ollama text before closing the text block so
-                // visible prose that preceded a real structured tool call is not lost.
-                if (isOllamaStream && ollamaTextBuffer) {
+              // Flush buffered Ollama text before processing the tool call.
+              // Must run before hasEmittedContentStart check because for Ollama
+              // streams the text block may not have been opened yet (we buffer
+              // instead of emitting during the streaming phase).
+              if (isOllamaStream && ollamaTextBuffer) {
+                if (!hasEmittedContentStart) {
                   yield {
-                    type: 'content_block_delta',
+                    type: 'content_block_start',
                     index: contentBlockIndex,
-                    delta: { type: 'text_delta', text: ollamaTextBuffer },
+                    content_block: { type: 'text', text: '' },
                   }
-                  ollamaTextBuffer = ''
+                  hasEmittedContentStart = true
                 }
+                yield {
+                  type: 'content_block_delta',
+                  index: contentBlockIndex,
+                  delta: { type: 'text_delta', text: ollamaTextBuffer },
+                }
+                ollamaTextBuffer = ''
+              }
+              if (hasEmittedContentStart) {
                 yield* closeActiveContentBlock()
               }
 

--- a/src/services/api/openaiShim.ts
+++ b/src/services/api/openaiShim.ts
@@ -1140,8 +1140,23 @@ function parseAndAdd(
   results.push({ id: `ollama_tc_${++_textToolCallCounter}`, name, arguments: args })
 }
 
+/** Removes character ranges from `text`, returning the remaining content. */
+function stripRanges(text: string, ranges: Array<[number, number]>): string {
+  const sorted = [...ranges].sort((a, b) => a[0] - b[0])
+  let result = ''
+  let pos = 0
+  for (const [s, e] of sorted) {
+    result += text.slice(pos, s)
+    pos = e
+  }
+  return result + text.slice(pos)
+}
+
 /** Exported for unit testing only. */
-export function parseTextToolCalls(text: string): ParsedTextToolCall[] {
+export function parseTextToolCalls(text: string): {
+  calls: ParsedTextToolCall[]
+  toolCallRanges: Array<[number, number]>
+} {
   const results: ParsedTextToolCall[] = []
   const seen = new Set<string>()
   const fencedRanges: Array<[number, number]> = []
@@ -1162,12 +1177,16 @@ export function parseTextToolCalls(text: string): ParsedTextToolCall[] {
     if (processedRanges.some(([s, e]) => start >= s && start < e)) continue
     const raw = extractBalancedJson(text, start)
     if (raw) {
+      // Context guard: if non-whitespace, non-`{` text immediately follows the JSON
+      // the model is likely explaining, not calling — skip to avoid false positives.
+      const after = text.slice(start + raw.length).trimStart()
+      if (after.length > 0 && !after.startsWith('{')) continue
       processedRanges.push([start, start + raw.length])
       parseAndAdd(raw, results, seen)
     }
   }
 
-  return results
+  return { calls: results, toolCallRanges: processedRanges }
 }
 
 /**
@@ -1442,6 +1461,10 @@ async function* openaiStreamToAnthropic(
   let hasProcessedFinishReason = false
   // Accumulated text for Ollama text-based tool call fallback parsing (#1053)
   let accumulatedText = ''
+  const isOllamaStream = isOllamaProvider()
+  // Buffer Ollama text deltas so raw tool-call JSON is never emitted as text_delta
+  // before extraction at finish_reason=stop (P2 fix for #1053).
+  let ollamaTextBuffer = ''
   const streamState = createStreamState()
   let bufferedRawToolCallsText: string | null = null
 
@@ -1680,7 +1703,12 @@ async function* openaiStreamToAnthropic(
           }
 
           accumulatedText += delta.content
-          if (
+          if (isOllamaStream) {
+            const visible = thinkFilter.feed(delta.content)
+            if (visible) {
+              ollamaTextBuffer += visible
+            }
+          } else if (
             !hasEmittedContentStart &&
             bufferedRawToolCallsText === null &&
             couldBeRawToolCallsRequestedPrefix(delta.content)
@@ -1806,6 +1834,56 @@ async function* openaiStreamToAnthropic(
             contentBlockIndex++
             hasClosedThinking = true
           }
+          // Ollama text-based tool call fallback (#1053):
+          // Must run before closeActiveContentBlock so the text buffer can be flushed
+          // with tool-call JSON stripped (P2). Ollama models emit tool calls as raw
+          // JSON text; scan accumulated text when finish_reason=stop with no API tool calls.
+          let ollamaClosedContentBlock = false
+          if (
+            choice.finish_reason === 'stop' &&
+            activeToolCalls.size === 0 &&
+            isOllamaStream
+          ) {
+            const { calls: textToolCalls, toolCallRanges } = parseTextToolCalls(accumulatedText)
+            if (textToolCalls.length > 0) {
+              ollamaClosedContentBlock = true
+              if (hasEmittedContentStart) {
+                const stripped = stripRanges(accumulatedText, toolCallRanges).trim()
+                if (stripped) {
+                  yield {
+                    type: 'content_block_delta',
+                    index: contentBlockIndex,
+                    delta: { type: 'text_delta', text: stripped },
+                  }
+                }
+                yield* closeActiveContentBlock()
+              }
+              for (const tc of textToolCalls) {
+                const toolBlockIndex = contentBlockIndex
+                yield {
+                  type: 'content_block_start',
+                  index: toolBlockIndex,
+                  content_block: { type: 'tool_use', id: tc.id, name: tc.name, input: {} },
+                }
+                contentBlockIndex++
+                yield {
+                  type: 'content_block_delta',
+                  index: toolBlockIndex,
+                  delta: { type: 'input_json_delta', partial_json: JSON.stringify(tc.arguments) },
+                }
+                yield { type: 'content_block_stop', index: toolBlockIndex }
+              }
+              choice.finish_reason = 'tool_calls'
+            } else if (ollamaTextBuffer && hasEmittedContentStart) {
+              yield {
+                type: 'content_block_delta',
+                index: contentBlockIndex,
+                delta: { type: 'text_delta', text: ollamaTextBuffer },
+              }
+            }
+          }
+
+          // Flush bufferedRawToolCallsText for non-Ollama providers
           const parsedBufferedToolCalls = bufferedRawToolCallsText
             ? parseRawToolCallsRequestedText(bufferedRawToolCallsText)
             : null
@@ -1816,8 +1894,9 @@ async function* openaiStreamToAnthropic(
             yield* emitTextDelta(bufferedRawToolCallsText)
             bufferedRawToolCallsText = null
           }
-          // Close any open content blocks
-          if (hasEmittedContentStart) {
+
+          // Close any open content blocks (skipped when Ollama already closed it above)
+          if (hasEmittedContentStart && !ollamaClosedContentBlock) {
             yield* closeActiveContentBlock()
           }
           // Close active tool calls
@@ -1881,38 +1960,6 @@ async function* openaiStreamToAnthropic(
             }
 
             yield { type: 'content_block_stop', index: tc.index }
-          }
-
-          // Ollama text-based tool call fallback (#1053):
-          // Ollama models output tool calls as JSON text instead of structured
-          // tool_calls API fields. When finish_reason=stop with no API-level
-          // tool calls, scan accumulated text for JSON tool call patterns and
-          // emit them as proper tool_use events so the agentic loop continues.
-          if (
-            choice.finish_reason === 'stop' &&
-            activeToolCalls.size === 0 &&
-            isOllamaProvider()
-          ) {
-            const textToolCalls = parseTextToolCalls(accumulatedText)
-            if (textToolCalls.length > 0) {
-              for (const tc of textToolCalls) {
-                const toolBlockIndex = contentBlockIndex
-                yield {
-                  type: 'content_block_start',
-                  index: toolBlockIndex,
-                  content_block: { type: 'tool_use', id: tc.id, name: tc.name, input: {} },
-                }
-                contentBlockIndex++
-                yield {
-                  type: 'content_block_delta',
-                  index: toolBlockIndex,
-                  delta: { type: 'input_json_delta', partial_json: JSON.stringify(tc.arguments) },
-                }
-                yield { type: 'content_block_stop', index: toolBlockIndex }
-              }
-              // Override so stopReason becomes 'tool_use' and the loop continues
-              choice.finish_reason = 'tool_calls'
-            }
           }
 
           const stopReason =

--- a/src/services/api/openaiShim.ts
+++ b/src/services/api/openaiShim.ts
@@ -1898,7 +1898,18 @@ async function* openaiStreamToAnthropic(
                 yield { type: 'content_block_stop', index: toolBlockIndex }
               }
               choice.finish_reason = 'tool_calls'
-            } else if (ollamaTextBuffer && hasEmittedContentStart) {
+            } else if (ollamaTextBuffer) {
+              // No tool calls — flush the buffered text before the normal close below.
+              // Open a text block first if one is not already open (guards the edge case
+              // where hasEmittedContentStart is false but the buffer has content).
+              if (!hasEmittedContentStart) {
+                yield {
+                  type: 'content_block_start',
+                  index: contentBlockIndex,
+                  content_block: { type: 'text', text: '' },
+                }
+                hasEmittedContentStart = true
+              }
               yield {
                 type: 'content_block_delta',
                 index: contentBlockIndex,

--- a/src/services/api/openaiShim.ts
+++ b/src/services/api/openaiShim.ts
@@ -1099,8 +1099,23 @@ function parseAndAdd(
   results.push({ id: `ollama_tc_${++_textToolCallCounter}`, name, arguments: args })
 }
 
+/** Removes character ranges from `text`, returning the remaining content. */
+function stripRanges(text: string, ranges: Array<[number, number]>): string {
+  const sorted = [...ranges].sort((a, b) => a[0] - b[0])
+  let result = ''
+  let pos = 0
+  for (const [s, e] of sorted) {
+    result += text.slice(pos, s)
+    pos = e
+  }
+  return result + text.slice(pos)
+}
+
 /** Exported for unit testing only. */
-export function parseTextToolCalls(text: string): ParsedTextToolCall[] {
+export function parseTextToolCalls(text: string): {
+  calls: ParsedTextToolCall[]
+  toolCallRanges: Array<[number, number]>
+} {
   const results: ParsedTextToolCall[] = []
   const seen = new Set<string>()
   const fencedRanges: Array<[number, number]> = []
@@ -1121,12 +1136,16 @@ export function parseTextToolCalls(text: string): ParsedTextToolCall[] {
     if (processedRanges.some(([s, e]) => start >= s && start < e)) continue
     const raw = extractBalancedJson(text, start)
     if (raw) {
+      // Context guard: if non-whitespace, non-`{` text immediately follows the JSON
+      // the model is likely explaining, not calling — skip to avoid false positives.
+      const after = text.slice(start + raw.length).trimStart()
+      if (after.length > 0 && !after.startsWith('{')) continue
       processedRanges.push([start, start + raw.length])
       parseAndAdd(raw, results, seen)
     }
   }
 
-  return results
+  return { calls: results, toolCallRanges: processedRanges }
 }
 
 /**
@@ -1159,6 +1178,10 @@ async function* openaiStreamToAnthropic(
   let hasProcessedFinishReason = false
   // Accumulated text for Ollama text-based tool call fallback parsing (#1053)
   let accumulatedText = ''
+  const isOllamaStream = isOllamaProvider()
+  // Buffer Ollama text deltas so raw tool-call JSON is never emitted as text_delta
+  // before extraction at finish_reason=stop (P2 fix for #1053).
+  let ollamaTextBuffer = ''
   const streamState = createStreamState()
   let bufferedRawToolCallsText: string | null = null
 
@@ -1395,7 +1418,12 @@ async function* openaiStreamToAnthropic(
           }
 
           accumulatedText += delta.content
-          if (
+          if (isOllamaStream) {
+            const visible = thinkFilter.feed(delta.content)
+            if (visible) {
+              ollamaTextBuffer += visible
+            }
+          } else if (
             !hasEmittedContentStart &&
             bufferedRawToolCallsText === null &&
             couldBeRawToolCallsRequestedPrefix(delta.content)
@@ -1521,6 +1549,56 @@ async function* openaiStreamToAnthropic(
             contentBlockIndex++
             hasClosedThinking = true
           }
+          // Ollama text-based tool call fallback (#1053):
+          // Must run before closeActiveContentBlock so the text buffer can be flushed
+          // with tool-call JSON stripped (P2). Ollama models emit tool calls as raw
+          // JSON text; scan accumulated text when finish_reason=stop with no API tool calls.
+          let ollamaClosedContentBlock = false
+          if (
+            choice.finish_reason === 'stop' &&
+            activeToolCalls.size === 0 &&
+            isOllamaStream
+          ) {
+            const { calls: textToolCalls, toolCallRanges } = parseTextToolCalls(accumulatedText)
+            if (textToolCalls.length > 0) {
+              ollamaClosedContentBlock = true
+              if (hasEmittedContentStart) {
+                const stripped = stripRanges(accumulatedText, toolCallRanges).trim()
+                if (stripped) {
+                  yield {
+                    type: 'content_block_delta',
+                    index: contentBlockIndex,
+                    delta: { type: 'text_delta', text: stripped },
+                  }
+                }
+                yield* closeActiveContentBlock()
+              }
+              for (const tc of textToolCalls) {
+                const toolBlockIndex = contentBlockIndex
+                yield {
+                  type: 'content_block_start',
+                  index: toolBlockIndex,
+                  content_block: { type: 'tool_use', id: tc.id, name: tc.name, input: {} },
+                }
+                contentBlockIndex++
+                yield {
+                  type: 'content_block_delta',
+                  index: toolBlockIndex,
+                  delta: { type: 'input_json_delta', partial_json: JSON.stringify(tc.arguments) },
+                }
+                yield { type: 'content_block_stop', index: toolBlockIndex }
+              }
+              choice.finish_reason = 'tool_calls'
+            } else if (ollamaTextBuffer && hasEmittedContentStart) {
+              yield {
+                type: 'content_block_delta',
+                index: contentBlockIndex,
+                delta: { type: 'text_delta', text: ollamaTextBuffer },
+              }
+            }
+          }
+
+          // Flush bufferedRawToolCallsText for non-Ollama providers
           const parsedBufferedToolCalls = bufferedRawToolCallsText
             ? parseRawToolCallsRequestedText(bufferedRawToolCallsText)
             : null
@@ -1531,8 +1609,9 @@ async function* openaiStreamToAnthropic(
             yield* emitTextDelta(bufferedRawToolCallsText)
             bufferedRawToolCallsText = null
           }
-          // Close any open content blocks
-          if (hasEmittedContentStart) {
+
+          // Close any open content blocks (skipped when Ollama already closed it above)
+          if (hasEmittedContentStart && !ollamaClosedContentBlock) {
             yield* closeActiveContentBlock()
           }
           // Close active tool calls
@@ -1596,38 +1675,6 @@ async function* openaiStreamToAnthropic(
             }
 
             yield { type: 'content_block_stop', index: tc.index }
-          }
-
-          // Ollama text-based tool call fallback (#1053):
-          // Ollama models output tool calls as JSON text instead of structured
-          // tool_calls API fields. When finish_reason=stop with no API-level
-          // tool calls, scan accumulated text for JSON tool call patterns and
-          // emit them as proper tool_use events so the agentic loop continues.
-          if (
-            choice.finish_reason === 'stop' &&
-            activeToolCalls.size === 0 &&
-            isOllamaProvider()
-          ) {
-            const textToolCalls = parseTextToolCalls(accumulatedText)
-            if (textToolCalls.length > 0) {
-              for (const tc of textToolCalls) {
-                const toolBlockIndex = contentBlockIndex
-                yield {
-                  type: 'content_block_start',
-                  index: toolBlockIndex,
-                  content_block: { type: 'tool_use', id: tc.id, name: tc.name, input: {} },
-                }
-                contentBlockIndex++
-                yield {
-                  type: 'content_block_delta',
-                  index: toolBlockIndex,
-                  delta: { type: 'input_json_delta', partial_json: JSON.stringify(tc.arguments) },
-                }
-                yield { type: 'content_block_stop', index: toolBlockIndex }
-              }
-              // Override so stopReason becomes 'tool_use' and the loop continues
-              choice.finish_reason = 'tool_calls'
-            }
           }
 
           const stopReason =

--- a/src/services/api/openaiShim.ts
+++ b/src/services/api/openaiShim.ts
@@ -1096,12 +1096,12 @@ function parseAndAdd(
   raw: string,
   results: ParsedTextToolCall[],
   seen: Set<string>,
-): void {
+): boolean {
   let obj: Record<string, unknown>
   try {
     obj = JSON.parse(raw)
   } catch {
-    return
+    return false
   }
 
   let name: string | undefined
@@ -1131,13 +1131,14 @@ function parseAndAdd(
         : (rawArgs as Record<string, unknown>) ?? {}
   }
 
-  if (!name) return
+  if (!name) return false
 
   const dedupKey = `${name}:${JSON.stringify(args)}`
-  if (seen.has(dedupKey)) return
+  if (seen.has(dedupKey)) return false
   seen.add(dedupKey)
 
   results.push({ id: `ollama_tc_${++_textToolCallCounter}`, name, arguments: args })
+  return true
 }
 
 /** Removes character ranges from `text`, returning the remaining content. */
@@ -1160,6 +1161,11 @@ export function parseTextToolCalls(text: string): {
   const results: ParsedTextToolCall[] = []
   const seen = new Set<string>()
   const fencedRanges: Array<[number, number]> = []
+  // acceptedRanges tracks only ranges where parseAndAdd confirmed a valid tool
+  // call was emitted — these are what callers strip from text.  fencedRanges
+  // (all fenced blocks regardless of acceptance) is kept separately so Pass 2
+  // can skip over them and avoid double-processing.
+  const acceptedRanges: Array<[number, number]> = []
 
   // Pass 1: fenced code blocks — regex is safe, ``` bounds the non-greedy match.
   // Context guard: same heuristic as Pass 2 — if non-whitespace, non-`{` text
@@ -1169,8 +1175,11 @@ export function parseTextToolCalls(text: string): {
     const raw = (match[1] ?? '').trim()
     const after = text.slice(match.index! + match[0].length).trimStart()
     if (after.length > 0 && !after.startsWith('{')) continue
-    fencedRanges.push([match.index!, match.index! + match[0].length])
-    if (raw) parseAndAdd(raw, results, seen)
+    const range: [number, number] = [match.index!, match.index! + match[0].length]
+    fencedRanges.push(range)
+    if (raw && parseAndAdd(raw, results, seen)) {
+      acceptedRanges.push(range)
+    }
   }
 
   // Pass 2: bare JSON — use the brace scanner so nested objects are captured fully.
@@ -1186,12 +1195,15 @@ export function parseTextToolCalls(text: string): {
       // the model is likely explaining, not calling — skip to avoid false positives.
       const after = text.slice(start + raw.length).trimStart()
       if (after.length > 0 && !after.startsWith('{')) continue
-      processedRanges.push([start, start + raw.length])
-      parseAndAdd(raw, results, seen)
+      const range: [number, number] = [start, start + raw.length]
+      processedRanges.push(range)
+      if (parseAndAdd(raw, results, seen)) {
+        acceptedRanges.push(range)
+      }
     }
   }
 
-  return { calls: results, toolCallRanges: processedRanges }
+  return { calls: results, toolCallRanges: acceptedRanges }
 }
 
 /**

--- a/src/services/api/openaiShim.ts
+++ b/src/services/api/openaiShim.ts
@@ -1859,12 +1859,10 @@ async function* openaiStreamToAnthropic(
               ollamaClosedContentBlock = true
               if (hasEmittedContentStart) {
                 const stripped = stripRanges(accumulatedText, toolCallRanges).trim()
-                // Also remove <think>...</think> blocks — accumulatedText is raw
-                // (unfiltered), so think content that was already hidden from the
-                // user would otherwise re-surface here.
-                const strippedVisible = stripped
-                  .replace(/<think>[\s\S]*?<\/think>/gi, '')
-                  .trim()
+                // Use stripThinkTags (handles closed pairs, unterminated opens, and
+                // orphan tags) so hidden <think> content in the raw accumulator never
+                // resurfaces as visible assistant text in the fallback path.
+                const strippedVisible = stripThinkTags(stripped).trim()
                 if (strippedVisible) {
                   yield {
                     type: 'content_block_delta',

--- a/src/services/api/openaiShim.ts
+++ b/src/services/api/openaiShim.ts
@@ -1465,6 +1465,16 @@ async function* openaiStreamToAnthropic(
                 hasClosedThinking = true
               }
               if (hasEmittedContentStart) {
+                // Flush buffered Ollama text before closing the text block so
+                // visible prose that preceded a real structured tool call is not lost.
+                if (isOllamaStream && ollamaTextBuffer) {
+                  yield {
+                    type: 'content_block_delta',
+                    index: contentBlockIndex,
+                    delta: { type: 'text_delta', text: ollamaTextBuffer },
+                  }
+                  ollamaTextBuffer = ''
+                }
                 yield* closeActiveContentBlock()
               }
 
@@ -1564,11 +1574,17 @@ async function* openaiStreamToAnthropic(
               ollamaClosedContentBlock = true
               if (hasEmittedContentStart) {
                 const stripped = stripRanges(accumulatedText, toolCallRanges).trim()
-                if (stripped) {
+                // Also remove <think>...</think> blocks — accumulatedText is raw
+                // (unfiltered), so think content that was already hidden from the
+                // user would otherwise re-surface here.
+                const strippedVisible = stripped
+                  .replace(/<think>[\s\S]*?<\/think>/gi, '')
+                  .trim()
+                if (strippedVisible) {
                   yield {
                     type: 'content_block_delta',
                     index: contentBlockIndex,
-                    delta: { type: 'text_delta', text: stripped },
+                    delta: { type: 'text_delta', text: strippedVisible },
                   }
                 }
                 yield* closeActiveContentBlock()


### PR DESCRIPTION
## Problem

Closes #1053.

When using Ollama as a provider, many models (`qwen2.5-coder`, `llama3.x`, `phi-4`, `gemma`) do not emit structured `tool_calls` fields in the streaming SSE response. Instead they write the call intent as a JSON block inside the response text:

```
{"name":"Bash","arguments":{"command":"ls"}}
```

or wrapped in a code fence:

```json
{"name":"Bash","arguments":{"command":"ls"}}
```

The agent loop never receives tool calls for these models, so it falls through to the no-tool-call path and either stalls or responds with raw JSON as text.

## Solution

Add `parseTextToolCalls(text)` in `openaiShim.ts` — a fallback parser that activates only when `delta.tool_calls` is absent and the accumulated text contains a JSON block that matches one of three known tool-call shapes:

1. `{"name":"X","arguments":{...}}` — bare object
2. ` ```json\n{...}\n``` ` — fenced block
3. `{"type":"function","function":{"name":"X","arguments":{...}}}` — OpenAI function shape

The parser is guarded behind `isOllamaProvider()` so it does not affect Anthropic, OpenAI, or other providers.

## Changes

- `src/services/api/openaiShim.ts` — `parseTextToolCalls` + integration in the streaming accumulator
- `src/services/api/openaiShim.ollamaTextToolCalls.test.ts` — unit tests covering all four cases requested in review: bare JSON, fenced block, `{type:function}` shape, and deduplication by `name:args` key

_Resubmission of #1065 — rebased on clean upstream/main, no unrelated files._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Recover JSON-formatted tool calls emitted as plain text by Ollama-style responses, strip internal "thinking" markers, preserve visible prose ordering, and ensure streaming finish reasons are handled correctly when recovered tool calls are emitted.

* **Tests**
  * Added unit and end-to-end streaming tests covering multiple embedded JSON shapes, deduplication, malformed cases, buffering behavior, and finish/recovery scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->