### PR TITLE
docs(skills): document user-level skills and improve discovery tip

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ Advanced and source-build guides:
 - **Images**: URL and base64 image inputs for providers that support vision
 - **Provider profiles**: Guided setup plus saved user-level provider profile support
 - **Local and remote model backends**: Cloud APIs, local servers, and Apple Silicon local inference
+- **Skills**: reusable slash-command workflows per project (`.claude/skills/`) or for every project ([user-level skills](docs/user-skills.md))
 
 ## Provider Notes
 

--- a/docs/user-skills.md
+++ b/docs/user-skills.md
@@ -1,6 +1,6 @@
 # User-Level Skills
 
-Skills you place in `~/.claude/skills/` (or `~/.openclaude/skills/` on new installs) are available in **every project**, regardless of which directory you open.
+Skills you place in `~/.openclaude/skills/` are available in **every project**, regardless of which directory you open.
 
 This is useful for personal workflows — commit rituals, session wrap-ups, bug-hunt flows — that you want available everywhere without copying files into each repo.
 
@@ -9,31 +9,32 @@ This is useful for personal workflows — commit rituals, session wrap-ups, bug-
 | Location | Scope |
 |----------|-------|
 | `<project>/.claude/skills/` | Current project only |
-| `~/.claude/skills/` | All projects (user-level) |
-| `~/.openclaude/skills/` | All projects (new installs without a legacy `~/.claude/`) |
+| `~/.openclaude/skills/` | All projects (default for new installs) |
+| `~/.claude/skills/` | All projects (legacy installs only — see below) |
 
-OpenClaude checks `~/.claude/` first if that directory already exists, otherwise uses `~/.openclaude/`. Run this to confirm which one applies to you:
+OpenClaude uses `~/.openclaude/` by default. It falls back to `~/.claude/` only when `~/.openclaude` does not exist and `~/.claude` already does (legacy installs). You can also override either path by setting `CLAUDE_CONFIG_DIR`. Run this to confirm which one applies to you:
 
 ```bash
 # macOS / Linux
-ls ~/.claude/skills/ 2>/dev/null || ls ~/.openclaude/skills/ 2>/dev/null || echo "neither exists yet"
+ls ~/.openclaude/skills/ 2>/dev/null || ls ~/.claude/skills/ 2>/dev/null || echo "neither exists yet"
 
 # Windows (PowerShell)
-if (Test-Path "$env:USERPROFILE\.claude\skills") { "$env:USERPROFILE\.claude\skills" }
-elseif (Test-Path "$env:USERPROFILE\.openclaude\skills") { "$env:USERPROFILE\.openclaude\skills" }
+if (Test-Path "$env:USERPROFILE\.openclaude\skills") { "$env:USERPROFILE\.openclaude\skills" }
+elseif (Test-Path "$env:USERPROFILE\.claude\skills") { "$env:USERPROFILE\.claude\skills" }
 else { "neither exists yet — create one" }
 ```
 
 ## Create the directory
 
 ```bash
-# macOS / Linux — pick whichever path applies to you
-mkdir -p ~/.claude/skills
-# or
+# macOS / Linux (new install — use .openclaude)
 mkdir -p ~/.openclaude/skills
 
-# Windows (PowerShell)
-New-Item -ItemType Directory -Force "$env:USERPROFILE\.claude\skills"
+# macOS / Linux (legacy install where ~/.claude already exists)
+mkdir -p ~/.claude/skills
+
+# Windows (PowerShell — new install)
+New-Item -ItemType Directory -Force "$env:USERPROFILE\.openclaude\skills"
 ```
 
 ## Skill format
@@ -41,7 +42,7 @@ New-Item -ItemType Directory -Force "$env:USERPROFILE\.claude\skills"
 Each skill lives in its own subdirectory with a `SKILL.md` file:
 
 ```
-~/.claude/skills/
+~/.openclaude/skills/
 └── my-commit-ritual/
     └── SKILL.md
 ```
@@ -70,4 +71,4 @@ After creating a skill, open OpenClaude in any project and run `/skills` to conf
 
 ## Why project skills stop at the git root
 
-Project-level `.claude/skills/` directories are scoped to their git repository on purpose: skills from a parent directory should not leak into unrelated child projects. User-level skills (`~/.claude/skills/`) are the correct mechanism for cross-project workflows.
+Project-level `.claude/skills/` directories are scoped to their git repository on purpose: skills from a parent directory should not leak into unrelated child projects. User-level skills (`~/.openclaude/skills/` or `~/.claude/skills/` for legacy installs) are the correct mechanism for cross-project workflows.

--- a/docs/user-skills.md
+++ b/docs/user-skills.md
@@ -1,0 +1,73 @@
+# User-Level Skills
+
+Skills you place in `~/.claude/skills/` (or `~/.openclaude/skills/` on new installs) are available in **every project**, regardless of which directory you open.
+
+This is useful for personal workflows — commit rituals, session wrap-ups, bug-hunt flows — that you want available everywhere without copying files into each repo.
+
+## Where to put them
+
+| Location | Scope |
+|----------|-------|
+| `<project>/.claude/skills/` | Current project only |
+| `~/.claude/skills/` | All projects (user-level) |
+| `~/.openclaude/skills/` | All projects (new installs without a legacy `~/.claude/`) |
+
+OpenClaude checks `~/.claude/` first if that directory already exists, otherwise uses `~/.openclaude/`. Run this to confirm which one applies to you:
+
+```bash
+# macOS / Linux
+ls ~/.claude/skills/ 2>/dev/null || ls ~/.openclaude/skills/ 2>/dev/null || echo "neither exists yet"
+
+# Windows (PowerShell)
+if (Test-Path "$env:USERPROFILE\.claude\skills") { "$env:USERPROFILE\.claude\skills" }
+elseif (Test-Path "$env:USERPROFILE\.openclaude\skills") { "$env:USERPROFILE\.openclaude\skills" }
+else { "neither exists yet — create one" }
+```
+
+## Create the directory
+
+```bash
+# macOS / Linux — pick whichever path applies to you
+mkdir -p ~/.claude/skills
+# or
+mkdir -p ~/.openclaude/skills
+
+# Windows (PowerShell)
+New-Item -ItemType Directory -Force "$env:USERPROFILE\.claude\skills"
+```
+
+## Skill format
+
+Each skill lives in its own subdirectory with a `SKILL.md` file:
+
+```
+~/.claude/skills/
+└── my-commit-ritual/
+    └── SKILL.md
+```
+
+A minimal `SKILL.md`:
+
+```markdown
+---
+description: My personal commit ritual
+---
+
+Run lint, typecheck, stage specific files, and commit with a conventional message.
+Never use `git add .` or `git add -A`.
+```
+
+Frontmatter fields:
+
+| Field | Default | Description |
+|-------|---------|-------------|
+| `description` | — | One-line summary shown in `/skills` |
+| `user-invocable` | `true` | Set to `false` to hide from slash-command tab completion |
+
+## Verify discovery
+
+After creating a skill, open OpenClaude in any project and run `/skills` to confirm it appears in the list.
+
+## Why project skills stop at the git root
+
+Project-level `.claude/skills/` directories are scoped to their git repository on purpose: skills from a parent directory should not leak into unrelated child projects. User-level skills (`~/.claude/skills/`) are the correct mechanism for cross-project workflows.

--- a/src/services/tips/tipRegistry.ts
+++ b/src/services/tips/tipRegistry.ts
@@ -390,7 +390,7 @@ const externalTips: Tip[] = [
   {
     id: 'custom-commands',
     content: async () =>
-      'Create skills by adding .md files to .claude/skills/ in your project or ~/.claude/skills/ for skills that work in any project',
+      'Skills let you create personal slash commands. Add a skill-name/SKILL.md to .claude/skills/ in your project, or to ~/.claude/skills/ (create the folder if it doesn\'t exist) to make it available in every project. Run /skills to see what\'s loaded.',
     cooldownSessions: 15,
     async isRelevant() {
       const config = getGlobalConfig()

--- a/src/services/tips/tipRegistry.ts
+++ b/src/services/tips/tipRegistry.ts
@@ -390,7 +390,7 @@ const externalTips: Tip[] = [
   {
     id: 'custom-commands',
     content: async () =>
-      'Skills let you create personal slash commands. Add a skill-name/SKILL.md to .claude/skills/ in your project, or to ~/.claude/skills/ (create the folder if it doesn\'t exist) to make it available in every project. Run /skills to see what\'s loaded.',
+      'Skills let you create personal slash commands. Add a skill-name/SKILL.md to .claude/skills/ in your project, or to ~/.openclaude/skills/ (create the folder if it doesn\'t exist) to make it available in every project. Run /skills to see what\'s loaded.',
     cooldownSessions: 15,
     async isRelevant() {
       const config = getGlobalConfig()

--- a/src/services/tips/tipRegistry.ts
+++ b/src/services/tips/tipRegistry.ts
@@ -20,6 +20,7 @@ import {
   modelSupportsEffort,
 } from '../../utils/effort.js'
 import { env } from '../../utils/env.js'
+import { getClaudeConfigHomeDir } from '../../utils/envUtils.js'
 import { cacheKeys } from '../../utils/fileStateCache.js'
 import { getWorktreeCount } from '../../utils/git.js'
 import {
@@ -389,8 +390,10 @@ const externalTips: Tip[] = [
   },
   {
     id: 'custom-commands',
-    content: async () =>
-      'Skills let you create personal slash commands. Add a skill-name/SKILL.md to .claude/skills/ in your project, or to ~/.openclaude/skills/ (create the folder if it doesn\'t exist) to make it available in every project. Run /skills to see what\'s loaded.',
+    content: async () => {
+      const userSkillDir = `${getClaudeConfigHomeDir()}/skills`
+      return `Skills let you create personal slash commands. Add a skill-name/SKILL.md to .claude/skills/ in your project, or to ${userSkillDir}/ (create the folder if it doesn't exist) to make it available in every project. Run /skills to see what's loaded.`
+    },
     cooldownSessions: 15,
     async isRelevant() {
       const config = getGlobalConfig()


### PR DESCRIPTION
## Problem

Users running openclaude in a separate git repository cannot see skills from a parent directory — the walk stops at the nearest git root by design. The correct cross-project mechanism is `~/.claude/skills/`, and the code already supports it (`loadSkillsDir.ts` line ~725). The gap is purely discoverability:

- The folder is never created by `init` or onboarding
- No documentation mentions it
- The only hint is a startup tip after 10+ uses, and even that tip is vague

## Changes

**`docs/user-skills.md`** (new, ~73 lines)
- Project vs user-level scope explained
- How to create the directory on macOS/Linux and Windows
- Minimum `SKILL.md` format with required frontmatter fields

**`src/services/tips/tipRegistry.ts`**
- Sharpens the existing vague tip to name `~/.claude/skills/` explicitly and link to the new doc

**`README.md`**
- One-line pointer to `docs/user-skills.md` under the skills section

_Resubmission of #1066 — rebased on clean upstream/main, no unrelated files._