### PR TITLE
Feat/xai grok 4 3 default

### DIFF
--- a/src/integrations/brands/xai.ts
+++ b/src/integrations/brands/xai.ts
@@ -13,6 +13,7 @@ export default defineBrand({
     supportsPreciseTokenCount: false,
   },
   modelIds: [
+    'grok-4.3',
     'grok-4',
     'grok-3',
   ],

--- a/src/integrations/models/xai.ts
+++ b/src/integrations/models/xai.ts
@@ -18,7 +18,7 @@ export default [
     classification: ['chat', 'reasoning', 'vision', 'coding'],
     defaultModel: 'grok-4.3',
     capabilities: grokCapabilities,
-    contextWindow: 2_000_000,
+    contextWindow: 1_000_000,
     maxOutputTokens: 32_768,
   }),
   defineModel({

--- a/src/integrations/models/xai.ts
+++ b/src/integrations/models/xai.ts
@@ -11,6 +11,17 @@ const grokCapabilities = {
 
 export default [
   defineModel({
+    id: 'grok-4.3',
+    label: 'Grok 4.3',
+    brandId: 'xai',
+    vendorId: 'xai',
+    classification: ['chat', 'reasoning', 'vision', 'coding'],
+    defaultModel: 'grok-4.3',
+    capabilities: grokCapabilities,
+    contextWindow: 2_000_000,
+    maxOutputTokens: 32_768,
+  }),
+  defineModel({
     id: 'grok-4',
     label: 'Grok 4',
     brandId: 'xai',

--- a/src/integrations/routeMetadata.test.ts
+++ b/src/integrations/routeMetadata.test.ts
@@ -104,7 +104,7 @@ test('resolveActiveRouteIdFromEnv keeps MiniMax primary base over stale API base
 
 test.each([
   ['MiniMax', 'https://api.minimax.io/v1', 'MiniMax-M2.7', 'minimax'],
-  ['xAI', 'https://api.x.ai/v1', 'grok-4', 'xai'],
+  ['xAI', 'https://api.x.ai/v1', 'grok-4.3', 'xai'],
   ['NVIDIA NIM', 'https://integrate.api.nvidia.com/v1', 'nvidia/llama-3.1-nemotron-70b-instruct', 'nvidia-nim'],
   ['OpenRouter', 'https://openrouter.ai/api/v1', 'openai/gpt-5-mini', 'openrouter'],
   ['DeepSeek', 'https://api.deepseek.com/v1', 'deepseek-v4-pro', 'deepseek'],

--- a/src/integrations/vendors/xai.ts
+++ b/src/integrations/vendors/xai.ts
@@ -5,7 +5,7 @@ export default defineVendor({
   label: 'xAI',
   classification: 'openai-compatible',
   defaultBaseUrl: 'https://api.x.ai/v1',
-  defaultModel: 'grok-4',
+  defaultModel: 'grok-4.3',
   requiredEnvVars: ['XAI_API_KEY'],
   setup: {
     requiresAuth: true,
@@ -34,6 +34,12 @@ export default defineVendor({
   catalog: {
     source: 'static',
     models: [
+      {
+        id: 'grok-4.3',
+        apiName: 'grok-4.3',
+        label: 'Grok 4.3',
+        modelDescriptorId: 'grok-4.3',
+      },
       {
         id: 'grok-4',
         apiName: 'grok-4',

--- a/src/services/api/client.test.ts
+++ b/src/services/api/client.test.ts
@@ -651,7 +651,7 @@ test('env-only xAI fallback replaces stale OpenAI credentials and model env', as
   })
 
   expect(process.env.CLAUDE_CODE_USE_OPENAI).toBe('1')
-  expect(process.env.OPENAI_MODEL).toBe('grok-4')
+  expect(process.env.OPENAI_MODEL).toBe('grok-4.3')
   expect(process.env.OPENAI_API_KEY).toBe('xai-test-key')
 })
 

--- a/src/utils/context.test.ts
+++ b/src/utils/context.test.ts
@@ -265,7 +265,7 @@ test('env-only xAI key uses provider-specific context and output caps before cli
   delete process.env.CLAUDE_CODE_MAX_OUTPUT_TOKENS
   delete process.env.OPENAI_MODEL
 
-  expect(getContextWindowForModel('grok-4.3')).toBe(2_000_000)
+  expect(getContextWindowForModel('grok-4.3')).toBe(1_000_000)
   expect(getModelMaxOutputTokens('grok-4.3')).toEqual({
     default: 32_768,
     upperLimit: 32_768,

--- a/src/utils/context.test.ts
+++ b/src/utils/context.test.ts
@@ -265,6 +265,12 @@ test('env-only xAI key uses provider-specific context and output caps before cli
   delete process.env.CLAUDE_CODE_MAX_OUTPUT_TOKENS
   delete process.env.OPENAI_MODEL
 
+  expect(getContextWindowForModel('grok-4.3')).toBe(2_000_000)
+  expect(getModelMaxOutputTokens('grok-4.3')).toEqual({
+    default: 32_768,
+    upperLimit: 32_768,
+  })
+  expect(getMaxOutputTokensForModel('grok-4.3')).toBe(32_768)
   expect(getContextWindowForModel('grok-4')).toBe(2_000_000)
   expect(getModelMaxOutputTokens('grok-4')).toEqual({
     default: 32_768,

--- a/src/utils/model/configs.ts
+++ b/src/utils/model/configs.ts
@@ -47,7 +47,7 @@ export const CLAUDE_3_7_SONNET_CONFIG = {
   codex: 'gpt-5.5',
   'nvidia-nim': 'nvidia/llama-3.1-nemotron-70b-instruct',
   minimax: 'MiniMax-M2.5',
-  xai: 'grok-4',
+  xai: 'grok-4.3',
 } as const satisfies LegacyProviderModelConfig
 
 export const CLAUDE_3_5_V2_SONNET_CONFIG = {
@@ -62,7 +62,7 @@ export const CLAUDE_3_5_V2_SONNET_CONFIG = {
   codex: 'gpt-5.5',
   'nvidia-nim': 'nvidia/llama-3.1-nemotron-70b-instruct',
   minimax: 'MiniMax-M2.5',
-  xai: 'grok-4',
+  xai: 'grok-4.3',
 } as const satisfies LegacyProviderModelConfig
 
 export const CLAUDE_3_5_HAIKU_CONFIG = {
@@ -77,7 +77,7 @@ export const CLAUDE_3_5_HAIKU_CONFIG = {
   codex: 'gpt-5.5',
   'nvidia-nim': 'nvidia/llama-3.1-nemotron-70b-instruct',
   minimax: 'MiniMax-M2.5',
-  xai: 'grok-4',
+  xai: 'grok-4.3',
 } as const satisfies LegacyProviderModelConfig
 
 export const CLAUDE_HAIKU_4_5_CONFIG = {
@@ -92,7 +92,7 @@ export const CLAUDE_HAIKU_4_5_CONFIG = {
   codex: 'gpt-5.5',
   'nvidia-nim': 'nvidia/llama-3.1-nemotron-70b-instruct',
   minimax: 'MiniMax-M2.5',
-  xai: 'grok-4',
+  xai: 'grok-4.3',
 } as const satisfies LegacyProviderModelConfig
 
 export const CLAUDE_SONNET_4_CONFIG = {
@@ -107,7 +107,7 @@ export const CLAUDE_SONNET_4_CONFIG = {
   codex: 'gpt-5.5',
   'nvidia-nim': 'nvidia/llama-3.1-nemotron-70b-instruct',
   minimax: 'MiniMax-M2.5',
-  xai: 'grok-4',
+  xai: 'grok-4.3',
 } as const satisfies LegacyProviderModelConfig
 
 export const CLAUDE_SONNET_4_5_CONFIG = {
@@ -122,7 +122,7 @@ export const CLAUDE_SONNET_4_5_CONFIG = {
   codex: 'gpt-5.5',
   'nvidia-nim': 'nvidia/llama-3.1-nemotron-70b-instruct',
   minimax: 'MiniMax-M2.5',
-  xai: 'grok-4',
+  xai: 'grok-4.3',
 } as const satisfies LegacyProviderModelConfig
 
 export const CLAUDE_OPUS_4_CONFIG = {
@@ -137,7 +137,7 @@ export const CLAUDE_OPUS_4_CONFIG = {
   codex: 'gpt-5.5',
   'nvidia-nim': 'nvidia/llama-3.1-nemotron-70b-instruct',
   minimax: 'MiniMax-M2.5',
-  xai: 'grok-4',
+  xai: 'grok-4.3',
 } as const satisfies LegacyProviderModelConfig
 
 export const CLAUDE_OPUS_4_1_CONFIG = {
@@ -152,7 +152,7 @@ export const CLAUDE_OPUS_4_1_CONFIG = {
   codex: 'gpt-5.5',
   'nvidia-nim': 'nvidia/llama-3.1-nemotron-70b-instruct',
   minimax: 'MiniMax-M2.5',
-  xai: 'grok-4',
+  xai: 'grok-4.3',
 } as const satisfies LegacyProviderModelConfig
 
 export const CLAUDE_OPUS_4_5_CONFIG = {
@@ -167,7 +167,7 @@ export const CLAUDE_OPUS_4_5_CONFIG = {
   codex: 'gpt-5.5',
   'nvidia-nim': 'nvidia/llama-3.1-nemotron-70b-instruct',
   minimax: 'MiniMax-M2.5',
-  xai: 'grok-4',
+  xai: 'grok-4.3',
 } as const satisfies LegacyProviderModelConfig
 
 export const CLAUDE_OPUS_4_6_CONFIG = {
@@ -182,7 +182,7 @@ export const CLAUDE_OPUS_4_6_CONFIG = {
   codex: 'gpt-5.5',
   'nvidia-nim': 'nvidia/llama-3.1-nemotron-70b-instruct',
   minimax: 'MiniMax-M2.5',
-  xai: 'grok-4',
+  xai: 'grok-4.3',
 } as const satisfies LegacyProviderModelConfig
 
 export const CLAUDE_OPUS_4_7_CONFIG = {
@@ -197,7 +197,7 @@ export const CLAUDE_OPUS_4_7_CONFIG = {
   codex: 'gpt-5.5',
   'nvidia-nim': 'nvidia/llama-3.1-nemotron-70b-instruct',
   minimax: 'MiniMax-M2.5',
-  xai: 'grok-4',
+  xai: 'grok-4.3',
 } as const satisfies LegacyProviderModelConfig
 
 export const CLAUDE_SONNET_4_6_CONFIG = {
@@ -212,7 +212,7 @@ export const CLAUDE_SONNET_4_6_CONFIG = {
   codex: 'gpt-5.5',
   'nvidia-nim': 'nvidia/llama-3.1-nemotron-70b-instruct',
   minimax: 'MiniMax-M2.5',
-  xai: 'grok-4',
+  xai: 'grok-4.3',
 } as const satisfies LegacyProviderModelConfig
 
 // @[MODEL LAUNCH]: Register the new config here.

--- a/src/utils/model/model.ts
+++ b/src/utils/model/model.ts
@@ -203,7 +203,7 @@ export function getDefaultOpusModel(): ModelName {
   }
   // xAI — flagship Grok model for "opus"-equivalent.
   if (getAPIProvider() === 'xai') {
-    return process.env.OPENAI_MODEL || 'grok-4'
+    return process.env.OPENAI_MODEL || 'grok-4.3'
   }
   // 3P providers (Bedrock, Vertex, Foundry) — kept as a separate branch
   // since 3P availability lags firstParty and these will diverge again at
@@ -249,7 +249,7 @@ export function getDefaultSonnetModel(): ModelName {
   }
   // xAI — flagship Grok model for "sonnet"-equivalent.
   if (getAPIProvider() === 'xai') {
-    return process.env.OPENAI_MODEL || 'grok-4'
+    return process.env.OPENAI_MODEL || 'grok-4.3'
   }
   // Default to Sonnet 4.5 for 3P since they may not have 4.6 yet
   if (getAPIProvider() !== 'firstParty') {
@@ -363,9 +363,9 @@ export function getDefaultMainLoopModelSetting(): ModelName | ModelAlias {
   if (getAPIProvider() === 'codex') {
     return process.env.OPENAI_MODEL || 'gpt-5.5'
   }
-  // xAI provider: always use the configured Grok model (default grok-4)
+  // xAI provider: always use the configured Grok model (default grok-4.3)
   if (getAPIProvider() === 'xai') {
-    return process.env.OPENAI_MODEL || 'grok-4'
+    return process.env.OPENAI_MODEL || 'grok-4.3'
   }
   // MiniMax provider: always use the configured MiniMax model
   if (getAPIProvider() === 'minimax') {

--- a/src/utils/providerFlag.test.ts
+++ b/src/utils/providerFlag.test.ts
@@ -339,7 +339,7 @@ describe('applyProviderFlag - xai', () => {
     expect(result.error).toBeUndefined()
     expect(process.env.CLAUDE_CODE_USE_OPENAI).toBe('1')
     expect(process.env.OPENAI_BASE_URL).toBe('https://api.x.ai/v1')
-    expect(process.env.OPENAI_MODEL).toBe('grok-4')
+    expect(process.env.OPENAI_MODEL).toBe('grok-4.3')
   })
 
   test('sets OPENAI_MODEL when --model is provided', () => {

--- a/src/utils/providerFlag.ts
+++ b/src/utils/providerFlag.ts
@@ -288,7 +288,7 @@ export function applyProviderFlag(
     case 'xai':
       process.env.CLAUDE_CODE_USE_OPENAI = '1'
       process.env.OPENAI_BASE_URL ??= 'https://api.x.ai/v1'
-      process.env.OPENAI_MODEL ??= 'grok-4'
+      process.env.OPENAI_MODEL ??= defaultModel ?? 'grok-4.3'
       if (model) process.env.OPENAI_MODEL = model
       if (process.env.XAI_API_KEY && !process.env.OPENAI_API_KEY) {
         process.env.OPENAI_API_KEY = process.env.XAI_API_KEY

--- a/src/utils/providerProfile.test.ts
+++ b/src/utils/providerProfile.test.ts
@@ -171,7 +171,7 @@ test('xai launch uses descriptor defaults and persisted xAI key', async () => {
 
   assert.equal(env.CLAUDE_CODE_USE_OPENAI, '1')
   assert.equal(env.OPENAI_BASE_URL, 'https://api.x.ai/v1')
-  assert.equal(env.OPENAI_MODEL, 'grok-4')
+  assert.equal(env.OPENAI_MODEL, 'grok-4.3')
   assert.equal(env.OPENAI_API_KEY, 'xai-persisted-key')
   assert.equal(env.XAI_API_KEY, 'xai-persisted-key')
 })

--- a/src/utils/providerProfile.ts
+++ b/src/utils/providerProfile.ts
@@ -690,7 +690,7 @@ function buildXaiProfileEnv(options: {
     XAI_API_KEY: key,
   }
   const defaultBaseUrl = getRouteDefaultBaseUrl('xai') ?? 'https://api.x.ai/v1'
-  const defaultModel = getRouteDefaultModel('xai') ?? 'grok-4'
+  const defaultModel = getRouteDefaultModel('xai') ?? 'grok-4.3'
   const env: ProfileEnv = {
     OPENAI_BASE_URL:
       sanitizeProviderConfigValue(options.baseUrl, secretSource) ||


### PR DESCRIPTION
## Summary

  - Added Grok 4.3 (`grok-4.3`) to the xAI provider model metadata, brand registry, and static catalog.
  - Updated xAI default model resolution paths from `grok-4` to `grok-4.3` for provider launch, provider profiles, legacy model mappings, and main Opus/Sonnet/default model selection.
  - Kept Grok 4 and Grok 3 available for explicit selection/backward compatibility.
  - Updated focused tests to cover the new xAI default and Grok 4.3 context/output metadata.

  ## Impact

  - user-facing impact: xAI now defaults to Grok 4.3 in provider selection/launch flows while still allowing users to explicitly choose Grok 4 or Grok 3.
  - developer/maintainer impact: xAI defaults are now centralized around the descriptor default (`getRouteDefaultModel('xai')`) where applicable, reducing future drift between provider metadata, flags, and profile
  launch behavior.

  ## Testing

  - [x] `bun run build`
  - [ ] `bun run smoke`
  - [x] focused tests:
    - `bun run integrations:check`
    - `bun test src/integrations/artifactGenerator.test.ts src/integrations/routeMetadata.test.ts src/utils/providerFlag.test.ts src/utils/providerProfile.test.ts src/utils/context.test.ts
  src/services/api/client.test.ts`
    - `bun test`
    - `git diff --check`
    
    
    
<img width="638" height="624" alt="Screenshot 2026-05-08 at 11 58 29 PM" src="https://github.com/user-attachments/assets/9b50a43f-759b-4e76-af17-474cb8be1015" />


  ## Notes

  - provider/model path tested: xAI provider defaults, provider flag launch, provider profile launch, env-only xAI fallback, context/output metadata lookup, and explicit model override preservation.
  - screenshots attached (if UI changed): no screenshots; no UI layout changed.
  - follow-up work or known limitations: `bun run typecheck` currently exits with code 2 due to existing broad repo type errors outside the xAI/Grok changed files. Build and full Bun test suite pass.