### PR TITLE
Fix theme picker OpenClaude branding

### DIFF
--- a/src/components/ThemePicker.tsx
+++ b/src/components/ThemePicker.tsx
@@ -48,7 +48,7 @@ const DEMO_PATCH: StructuredPatchHunk = {
   lines: [
     ' function greet() {',
     '-  console.log("Hello, World!");',
-    '+  console.log("Hello, Claude!");',
+    '+  console.log("Hello, OpenClaude!");',
     ' }',
   ],
 }


### PR DESCRIPTION
## Summary

Updates the startup theme picker demo patch so the added sample line refers to `OpenClaude` instead of `Claude`.

## Details

- Changed the hard-coded demo diff in `src/components/ThemePicker.tsx`.
- The theme picker preview now renders:

```js
console.log("Hello, OpenClaude!");
```

- This keeps the first-run/theme selection experience aligned with OpenClaude branding.

## Validation

Ran the validation steps recommended by `CONTRIBUTING.md`:

```bash
bun install
bun run build
bun run smoke
```

Results:

- `bun install` completed successfully.
- `bun run build` completed successfully and built `dist/cli.mjs` plus `dist/sdk.mjs`.
- `bun run smoke` completed successfully and printed:

```text
0.9.2 (OpenClaude)
```

Note: the build and smoke steps emitted existing external dependency warnings marked by the build script as "may be ok".