### PR TITLE
Fix effort persistence display across sessions

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -330,6 +330,13 @@ ANTHROPIC_API_KEY=sk-ant-your-key-here
 # Turn on whichever audience you're debugging; both can run together.
 # OPENCLAUDE_LOG_TOKEN_USAGE=verbose
 
+# Set the effort level for this OpenClaude process.
+# Accepted values: low, medium, high, max, auto, unset.
+# This environment variable overrides the persisted global /effort setting while
+# it is present. Use /effort inside OpenClaude when you want to save a global
+# default for future sessions; use auto/unset here to ignore saved effort.
+# CLAUDE_CODE_EFFORT_LEVEL=medium
+
 # Custom timeout for API requests in milliseconds (default: varies)
 # API_TIMEOUT_MS=60000
 

--- a/docs/advanced-setup.md
+++ b/docs/advanced-setup.md
@@ -220,10 +220,17 @@ export OPENAI_MODEL=gpt-4o
 | `CODEX_HOME` | Codex only | Alternative Codex home directory |
 | `OPENCLAUDE_DISABLE_CO_AUTHORED_BY` | No | Suppress the default `Co-Authored-By` trailer in generated git commits |
 | `OPENCLAUDE_LOG_TOKEN_USAGE` | No | When truthy (e.g. `verbose`), emits one JSON line on stderr per API request with input/output/cache tokens and the resolved provider. **User-facing debug output** — complements the REPL display controlled by `/config showCacheStats`. Distinct from `CLAUDE_CODE_ENABLE_TOKEN_USAGE_ATTACHMENT`, which is **model-facing** (injects context usage info into the prompt itself). Both can run together. |
+| `CLAUDE_CODE_EFFORT_LEVEL` | No | Override model effort for the current process. Accepted values: `low`, `medium`, `high`, `max`, `auto`, or `unset`. This takes precedence over the global `/effort` setting while present. |
 
 Model env vars are provider-scoped: Anthropic-native sessions read
 `ANTHROPIC_MODEL`, OpenAI-compatible sessions read `OPENAI_MODEL`, Gemini reads
 `GEMINI_MODEL`, and Mistral reads `MISTRAL_MODEL`.
+
+`/effort` saves a global default in user settings for future OpenClaude
+sessions. `CLAUDE_CODE_EFFORT_LEVEL` is a launch/session override: when it is
+set, it wins over the saved `/effort` value without changing that saved value.
+Use `CLAUDE_CODE_EFFORT_LEVEL=auto` or `unset` to ignore saved effort for the
+current process.
 
 ## Runtime Hardening
 

--- a/src/commands/effort/effort.tsx
+++ b/src/commands/effort/effort.tsx
@@ -195,22 +195,14 @@ function EffortPickerWrapper({ onDone }: { onDone: LocalJSXCommandOnDone }) {
   const usesOpenAIEffort = modelUsesOpenAIEffort(model);
 
   function handleSelect(effort: EffortValue | undefined) {
-    const persistable = toPersistableEffort(effort);
-    if (persistable !== undefined) {
-      updateSettingsForSource('userSettings', {
-        effortLevel: persistable
-      });
+    const result = effort === undefined ? unsetEffortLevel() : setEffortValue(effort);
+    if (result.effortUpdate) {
+      setAppState(prev => ({
+        ...prev,
+        effortValue: result.effortUpdate?.value
+      }));
     }
-    logEvent('tengu_effort_command', {
-      effort: (effort ?? 'auto') as AnalyticsMetadata_I_VERIFIED_THIS_IS_NOT_CODE_OR_FILEPATHS
-    });
-    setAppState(prev => ({
-      ...prev,
-      effortValue: effort
-    }));
-    const description = effort ? getEffortValueDescription(effort) : 'Use default effort level for your model';
-    const suffix = persistable !== undefined ? '' : ' (this session only)';
-    onDone(`Set effort level to ${effort ?? 'auto'}${suffix}: ${description}`);
+    onDone(result.message);
   }
 
   function handleCancel() {

--- a/src/commands/effort/effort.tsx
+++ b/src/commands/effort/effort.tsx
@@ -4,7 +4,7 @@ import { useMainLoopModel } from '../../hooks/useMainLoopModel.js';
 import { type AnalyticsMetadata_I_VERIFIED_THIS_IS_NOT_CODE_OR_FILEPATHS, logEvent } from '../../services/analytics/index.js';
 import { useAppState, useSetAppState } from '../../state/AppState.js';
 import type { LocalJSXCommandOnDone } from '../../types/command.js';
-import { type EffortValue, getDisplayedEffortLevel, getEffortEnvOverride, getEffortValueDescription, isEffortLevel, isOpenAIEffortLevel, modelUsesOpenAIEffort, openAIEffortToStandard, toPersistableEffort } from '../../utils/effort.js';
+import { type EffortValue, getDisplayedEffortLevel, getEffortEnvOverride, getEffortValueDescription, isEffortLevel, isOpenAIEffortLevel, openAIEffortToStandard, toPersistableEffort } from '../../utils/effort.js';
 import { EffortPicker } from '../../components/EffortPicker.js';
 import { updateSettingsForSource } from '../../utils/settings/settings.js';
 const COMMON_HELP_ARGS = ['help', '-h', '--help'];
@@ -191,8 +191,6 @@ export async function call(onDone: LocalJSXCommandOnDone, _context: unknown, arg
 
 function EffortPickerWrapper({ onDone }: { onDone: LocalJSXCommandOnDone }) {
   const setAppState = useSetAppState();
-  const model = useMainLoopModel();
-  const usesOpenAIEffort = modelUsesOpenAIEffort(model);
 
   function handleSelect(effort: EffortValue | undefined) {
     const result = effort === undefined ? unsetEffortLevel() : setEffortValue(effort);

--- a/src/components/EffortPicker.tsx
+++ b/src/components/EffortPicker.tsx
@@ -1,7 +1,7 @@
 import type { ReactNode } from 'react'
 import { Box, Text } from '../ink.js'
 import { useMainLoopModel } from '../hooks/useMainLoopModel.js'
-import { useAppState, useSetAppState } from '../state/AppState.js'
+import { useAppState } from '../state/AppState.js'
 import type { EffortLevel } from '../utils/effort.js'
 import {
   getAvailableEffortLevels,
@@ -35,7 +35,6 @@ type Props = {
 export function EffortPicker({ onSelect, onCancel }: Props) {
   const model = useMainLoopModel()
   const appStateEffort = useAppState((s: any) => s.effortValue)
-  const setAppState = useSetAppState()
   const provider = getAPIProvider()
   const usesOpenAIEffort = modelUsesOpenAIEffort(model)
   const availableLevels = getAvailableEffortLevels(model)
@@ -72,10 +71,6 @@ export function EffortPicker({ onSelect, onCancel }: Props) {
 
   function handleSelect(value: string) {
     if (value === 'auto') {
-      setAppState(prev => ({
-        ...prev,
-        effortValue: undefined,
-      }))
       onSelect(undefined)
     } else {
       // Normalize OpenAI-shaped 'xhigh' to the standard EffortLevel ('max')
@@ -84,10 +79,6 @@ export function EffortPicker({ onSelect, onCancel }: Props) {
       const effortLevel = isOpenAIEffortLevel(value)
         ? openAIEffortToStandard(value)
         : (value as EffortLevel)
-      setAppState(prev => ({
-        ...prev,
-        effortValue: effortLevel,
-      }))
       onSelect(effortLevel)
     }
   }

--- a/src/components/StartupScreen.test.ts
+++ b/src/components/StartupScreen.test.ts
@@ -269,6 +269,14 @@ describe('detectProvider — explicit dedicated-provider env flags', () => {
 })
 
 describe('detectProvider — startup effort display', () => {
+  test('OpenAI startup banner uses provider alias default when no saved or env effort is set', () => {
+    setupOpenAIMode('https://api.openai.com/v1', 'gpt-5.4')
+
+    const result = detectProvider()
+
+    expect(result.model).toBe('gpt-5.4 (high)')
+  })
+
   test('OpenAI startup banner uses saved /effort over provider alias default', () => {
     setupOpenAIMode('https://api.openai.com/v1', 'gpt-5.4')
     setSessionSettingsCache({ settings: { effortLevel: 'medium' }, errors: [] })

--- a/src/components/StartupScreen.test.ts
+++ b/src/components/StartupScreen.test.ts
@@ -43,11 +43,12 @@ const ENV_KEYS = [
   'OPENAI_MODEL',
   'GEMINI_MODEL',
   'MISTRAL_MODEL',
-  'ANTHROPIC_MODEL',
   'CLAUDE_MODEL',
+  'CLAUDE_CODE_EFFORT_LEVEL',
   'NVIDIA_NIM',
   'MINIMAX_API_KEY',
   'XAI_API_KEY',
+  'ANTHROPIC_MODEL',
   'ANTHROPIC_DEFAULT_OPUS_MODEL',
   'ANTHROPIC_DEFAULT_SONNET_MODEL',
   'ANTHROPIC_DEFAULT_HAIKU_MODEL',
@@ -264,6 +265,27 @@ describe('detectProvider — explicit dedicated-provider env flags', () => {
     setupOpenAIMode('https://openrouter.ai/api/v1', 'any-model')
     process.env.MINIMAX_API_KEY = 'test-key'
     expect(detectProvider().name).toBe('MiniMax')
+  })
+})
+
+describe('detectProvider — startup effort display', () => {
+  test('OpenAI startup banner uses saved /effort over provider alias default', () => {
+    setupOpenAIMode('https://api.openai.com/v1', 'gpt-5.4')
+    setSessionSettingsCache({ settings: { effortLevel: 'medium' }, errors: [] })
+
+    const result = detectProvider()
+
+    expect(result.model).toBe('gpt-5.4 (medium)')
+  })
+
+  test('OpenAI startup banner uses CLAUDE_CODE_EFFORT_LEVEL over saved /effort', () => {
+    setupOpenAIMode('https://api.openai.com/v1', 'gpt-5.4')
+    setSessionSettingsCache({ settings: { effortLevel: 'medium' }, errors: [] })
+    process.env.CLAUDE_CODE_EFFORT_LEVEL = 'low'
+
+    const result = detectProvider()
+
+    expect(result.model).toBe('gpt-5.4 (low)')
   })
 })
 

--- a/src/components/StartupScreen.ts
+++ b/src/components/StartupScreen.ts
@@ -11,10 +11,15 @@ import {
   resolveRouteIdFromBaseUrl,
 } from '../integrations/routeMetadata.js'
 import { getLocalOpenAICompatibleProviderLabel } from '../utils/providerDiscovery.js'
-import { getSettings_DEPRECATED } from '../utils/settings/settings.js'
+import { getInitialSettings } from '../utils/settings/settings.js'
 import { parseUserSpecifiedModel } from '../utils/model/model.js'
 import { DEFAULT_GEMINI_MODEL } from '../utils/providerProfile.js'
 import { getGlobalConfig } from '../utils/config.js'
+import {
+  getDisplayedEffortLevel,
+  getInitialEffortSetting,
+  modelSupportsEffort,
+} from '../utils/effort.js'
 import { ANSI_DIM, ANSI_RESET, ansiRgb } from '../utils/terminalAnsi.js'
 import {
   resolveLogoPalette,
@@ -145,18 +150,20 @@ export function detectProvider(modelOverride?: string): { name: string; model: s
     else if (/bankr/i.test(baseUrl)) name = 'Bankr'
     else if (/bankr/i.test(rawModel)) name = 'Bankr'
     else if (isLocal) name = getLocalOpenAICompatibleProviderLabel(baseUrl)
-    
-    // Resolve model alias to actual model name + reasoning effort
+
     let displayModel = resolvedRequest.resolvedModel
-    if (resolvedRequest.reasoning?.effort) {
-      displayModel = `${displayModel} (${resolvedRequest.reasoning.effort})`
+    // Display the same effective effort as the in-app header/status UI. The
+    // provider alias may carry a default reasoning effort, but saved /effort
+    // and CLAUDE_CODE_EFFORT_LEVEL must take precedence in the startup banner.
+    if (modelSupportsEffort(displayModel)) {
+      displayModel = `${displayModel} (${getDisplayedEffortLevel(displayModel, getInitialEffortSetting())})`
     }
-    
+
     return { name, model: displayModel, baseUrl, isLocal }
   }
 
   // Default: Anthropic - check settings.model first, then env vars
-  const settings = getSettings_DEPRECATED() || {}
+  const settings = getInitialSettings() || {}
   const modelSetting = modelOverride || process.env.ANTHROPIC_MODEL || process.env.CLAUDE_MODEL || settings.model || 'claude-sonnet-4-6'
   const resolvedModel = parseUserSpecifiedModel(modelSetting)
   const baseUrl = process.env.ANTHROPIC_BASE_URL ?? 'https://api.anthropic.com'

--- a/src/components/StartupScreen.ts
+++ b/src/components/StartupScreen.ts
@@ -17,8 +17,10 @@ import { DEFAULT_GEMINI_MODEL } from '../utils/providerProfile.js'
 import { getGlobalConfig } from '../utils/config.js'
 import {
   getDisplayedEffortLevel,
+  getEffortEnvOverride,
   getInitialEffortSetting,
   modelSupportsEffort,
+  openAIEffortToStandard,
 } from '../utils/effort.js'
 import { ANSI_DIM, ANSI_RESET, ansiRgb } from '../utils/terminalAnsi.js'
 import {
@@ -156,7 +158,14 @@ export function detectProvider(modelOverride?: string): { name: string; model: s
     // provider alias may carry a default reasoning effort, but saved /effort
     // and CLAUDE_CODE_EFFORT_LEVEL must take precedence in the startup banner.
     if (modelSupportsEffort(displayModel)) {
-      displayModel = `${displayModel} (${getDisplayedEffortLevel(displayModel, getInitialEffortSetting())})`
+      const savedEffort = getInitialEffortSetting()
+      const aliasDefaultEffort =
+        getEffortEnvOverride() === undefined &&
+        savedEffort === undefined &&
+        resolvedRequest.reasoning?.effort
+          ? openAIEffortToStandard(resolvedRequest.reasoning.effort)
+          : undefined
+      displayModel = `${displayModel} (${getDisplayedEffortLevel(displayModel, savedEffort ?? aliasDefaultEffort)})`
     }
 
     return { name, model: displayModel, baseUrl, isLocal }

--- a/src/utils/effort.codex.test.ts
+++ b/src/utils/effort.codex.test.ts
@@ -165,3 +165,29 @@ test('e2e: max on non-Opus Anthropic model still clamps to high', async () => {
 
   expect(resolveAppliedEffort('claude-sonnet-4-6', 'max')).toBe('high')
 })
+
+
+test('getEffortSuffix shows the effective displayed effort for supported models', async () => {
+  const { getDisplayedEffortLevel, getEffortSuffix } =
+    await importFreshEffortModule({
+      provider: 'openai',
+      supportsCodexReasoningEffort: true,
+    })
+
+  expect(getEffortSuffix('gpt-5.4', 'medium')).toBe(' with medium effort')
+
+  const displayedDefault = getDisplayedEffortLevel('gpt-5.4', undefined)
+  expect(getEffortSuffix('gpt-5.4', undefined)).toBe(
+    ` with ${displayedDefault} effort`,
+  )
+})
+
+test('getEffortSuffix stays hidden for models without effort controls', async () => {
+  const { getEffortSuffix } = await importFreshEffortModule({
+    provider: 'codex',
+    supportsCodexReasoningEffort: false,
+  })
+
+  expect(getEffortSuffix('gpt-5.3-codex-spark', 'medium')).toBe('')
+  expect(getEffortSuffix('gpt-5.3-codex-spark', undefined)).toBe('')
+})

--- a/src/utils/effort.codex.test.ts
+++ b/src/utils/effort.codex.test.ts
@@ -3,12 +3,10 @@ import {
   acquireSharedMutationLock,
   releaseSharedMutationLock,
 } from '../test/sharedMutationLock.js'
-// Import the real auth.js and providerConfig.js up front so we can spread
-// their export surfaces into mock factories. `mock.module()` is process-global
-// in bun:test and `mock.restore()` does not undo it (see user.test.ts), so
-// any module we mock here needs to keep the full original export shape — or
-// downstream tests that load it via openaiShim/client/codexShim crash with
-// "Export named 'X' not found in module".
+// Import the real modules up front so we can spread their export surfaces into
+// mock factories. `mock.module()` is process-global in bun:test and
+// `mock.restore()` does not undo it (see user.test.ts), so mocked modules need
+// to keep the full original export shape.
 import * as actualAuth from './auth.js'
 import * as actualProviderConfig from '../services/api/providerConfig.js'
 import * as actualThinking from './thinking.js'
@@ -16,12 +14,67 @@ import * as actualGrowthbook from 'src/services/analytics/growthbook.js'
 import * as actualProviders from './model/providers.js'
 import * as actualModelSupportOverrides from './model/modelSupportOverrides.js'
 
+const ENV_KEYS = [
+  'CLAUDE_CODE_USE_BEDROCK',
+  'CLAUDE_CODE_USE_FOUNDRY',
+  'CLAUDE_CODE_USE_GEMINI',
+  'CLAUDE_CODE_USE_GITHUB',
+  'CLAUDE_CODE_USE_MISTRAL',
+  'CLAUDE_CODE_USE_OPENAI',
+  'CLAUDE_CODE_USE_VERTEX',
+  'CLAUDE_CODE_PROVIDER_PROFILE_ENV_APPLIED',
+  'MISTRAL_BASE_URL',
+  'OPENAI_BASE_URL',
+  'OPENAI_MODEL',
+  'OPENAI_API_BASE',
+  'XAI_API_KEY',
+  'MINIMAX_API_KEY',
+] as const
+
+const originalEnv: Record<string, string | undefined> = {}
+type TestProvider = 'codex' | 'openai' | 'firstParty'
+
+function resolveProviderFromEnv(): TestProvider {
+  if (process.env.CLAUDE_CODE_USE_OPENAI) {
+    const baseUrl = process.env.OPENAI_BASE_URL ?? ''
+    const model = process.env.OPENAI_MODEL ?? ''
+    return baseUrl.includes('/backend-api/codex') || model.startsWith('codex')
+      ? 'codex'
+      : 'openai'
+  }
+  return 'firstParty'
+}
+
+function installProviderMock(provider?: TestProvider): void {
+  mock.module('./model/providers.js', () => ({
+    ...actualProviders,
+    getAPIProvider: () => provider ?? resolveProviderFromEnv(),
+    getAPIProviderForStatsig: () => provider ?? resolveProviderFromEnv(),
+    isFirstPartyAnthropicBaseUrl: () => true,
+    isGithubNativeAnthropicMode: () => false,
+    usesAnthropicAccountFlow: () =>
+      (provider ?? resolveProviderFromEnv()) === 'firstParty',
+  }))
+}
+
 beforeEach(async () => {
   await acquireSharedMutationLock('utils/effort.codex.test.ts')
+  mock.restore()
+  installProviderMock()
+  for (const key of ENV_KEYS) {
+    originalEnv[key] = process.env[key]
+  }
 })
 
 afterEach(() => {
   try {
+    for (const key of ENV_KEYS) {
+      if (originalEnv[key] === undefined) {
+        delete process.env[key]
+      } else {
+        process.env[key] = originalEnv[key]
+      }
+    }
     mock.restore()
   } finally {
     releaseSharedMutationLock()
@@ -29,20 +82,29 @@ afterEach(() => {
 })
 
 async function importFreshEffortModule(options: {
-  provider: 'codex' | 'openai'
-  supportsCodexReasoningEffort: boolean
+  provider: TestProvider
+  supportsCodexReasoningEffort?: boolean
 }) {
-  mock.module('./model/providers.js', () => ({
-    ...actualProviders,
-    getAPIProvider: () => options.provider,
-  }))
+  for (const key of ENV_KEYS) {
+    delete process.env[key]
+  }
+  installProviderMock(options.provider)
+  if (options.provider === 'codex') {
+    process.env.CLAUDE_CODE_USE_OPENAI = '1'
+    process.env.OPENAI_MODEL = 'gpt-5.4'
+  } else if (options.provider === 'openai') {
+    process.env.CLAUDE_CODE_USE_OPENAI = '1'
+    process.env.OPENAI_BASE_URL = 'https://api.openai.com/v1'
+    process.env.OPENAI_MODEL = 'gpt-5.4'
+  }
   mock.module('./model/modelSupportOverrides.js', () => ({
     ...actualModelSupportOverrides,
     get3PModelCapabilityOverride: () => undefined,
   }))
   mock.module('../services/api/providerConfig.js', () => ({
     ...actualProviderConfig,
-    supportsCodexReasoningEffort: () => options.supportsCodexReasoningEffort,
+    supportsCodexReasoningEffort: () =>
+      options.supportsCodexReasoningEffort ?? true,
   }))
   mock.module('./auth.js', () => ({
     ...actualAuth,
@@ -63,21 +125,25 @@ async function importFreshEffortModule(options: {
   return import(`./effort.js?ts=${Date.now()}-${Math.random()}`)
 }
 
-test('gpt-5.4 on the ChatGPT Codex backend supports effort selection', async () => {
-  const { getAvailableEffortLevels, modelSupportsEffort } =
-    await importFreshEffortModule({
-      provider: 'codex',
-      supportsCodexReasoningEffort: true,
-    })
+test(
+  'gpt-5.4 on the ChatGPT Codex backend supports effort selection',
+  async () => {
+    const { getAvailableEffortLevels, modelSupportsEffort } =
+      await importFreshEffortModule({
+        provider: 'codex',
+        supportsCodexReasoningEffort: true,
+      })
 
-  expect(modelSupportsEffort('gpt-5.4')).toBe(true)
-  expect(getAvailableEffortLevels('gpt-5.4')).toEqual([
-    'low',
-    'medium',
-    'high',
-    'xhigh',
-  ])
-})
+    expect(modelSupportsEffort('gpt-5.4')).toBe(true)
+    expect(getAvailableEffortLevels('gpt-5.4')).toEqual([
+      'low',
+      'medium',
+      'high',
+      'xhigh',
+    ])
+  },
+  15_000,
+)
 
 test('gpt-5.4 on the OpenAI provider still supports effort selection', async () => {
   const { getAvailableEffortLevels, modelSupportsEffort } =
@@ -133,7 +199,7 @@ test('standardEffortToOpenAI maps max to xhigh for shim payload', async () => {
   expect(openAIEffortToStandard('high')).toBe('high')
 })
 
-test('e2e: xhigh → persisted max → resolveAppliedEffort → wire xhigh on OpenAI/Codex (no high clamp)', async () => {
+test('e2e: xhigh -> persisted max -> resolveAppliedEffort -> wire xhigh on OpenAI/Codex (no high clamp)', async () => {
   const {
     toPersistableEffort,
     resolveAppliedEffort,
@@ -148,7 +214,7 @@ test('e2e: xhigh → persisted max → resolveAppliedEffort → wire xhigh on Op
   expect(persisted).toBe('max')
 
   // App state holds 'max'. Non-Opus 'max' must NOT be downgraded to 'high'
-  // when the model uses the OpenAI effort scheme — the shim converts back
+  // when the model uses the OpenAI effort scheme; the shim converts back
   // to 'xhigh' on the wire.
   const applied = resolveAppliedEffort('gpt-5.4', persisted)
   expect(applied).toBe('max')
@@ -159,13 +225,12 @@ test('e2e: xhigh → persisted max → resolveAppliedEffort → wire xhigh on Op
 
 test('e2e: max on non-Opus Anthropic model still clamps to high', async () => {
   const { resolveAppliedEffort } = await importFreshEffortModule({
-    provider: 'firstParty' as unknown as 'openai',
+    provider: 'firstParty',
     supportsCodexReasoningEffort: false,
   })
 
   expect(resolveAppliedEffort('claude-sonnet-4-6', 'max')).toBe('high')
 })
-
 
 test('getEffortSuffix shows the effective displayed effort for supported models', async () => {
   const { getDisplayedEffortLevel, getEffortSuffix } =

--- a/src/utils/effort.codex.test.ts
+++ b/src/utils/effort.codex.test.ts
@@ -57,6 +57,15 @@ function installProviderMock(provider?: TestProvider): void {
   }))
 }
 
+function restoreProcessGlobalMocks(): void {
+  mock.module('./model/providers.js', () => actualProviders)
+  mock.module('./model/modelSupportOverrides.js', () => actualModelSupportOverrides)
+  mock.module('../services/api/providerConfig.js', () => actualProviderConfig)
+  mock.module('./auth.js', () => actualAuth)
+  mock.module('./thinking.js', () => actualThinking)
+  mock.module('src/services/analytics/growthbook.js', () => actualGrowthbook)
+}
+
 beforeEach(async () => {
   await acquireSharedMutationLock('utils/effort.codex.test.ts')
   mock.restore()
@@ -76,6 +85,7 @@ afterEach(() => {
       }
     }
     mock.restore()
+    restoreProcessGlobalMocks()
   } finally {
     releaseSharedMutationLock()
   }

--- a/src/utils/effort.ts
+++ b/src/utils/effort.ts
@@ -3,6 +3,7 @@ import { isUltrathinkEnabled } from './thinking.js'
 import { getInitialSettings } from './settings/settings.js'
 import { isProSubscriber, isMaxSubscriber, isTeamSubscriber } from './auth.js'
 import { getFeatureValue_CACHED_MAY_BE_STALE } from 'src/services/analytics/growthbook.js'
+import { getAntModelOverrideConfig, resolveAntModel } from './model/antModels.js'
 import { getAPIProvider } from './model/providers.js'
 import { get3PModelCapabilityOverride } from './model/modelSupportOverrides.js'
 import { supportsCodexReasoningEffort } from '../services/api/providerConfig.js'
@@ -150,7 +151,7 @@ export function parseEffortValue(value: unknown): EffortValue | undefined {
  * (which only accepts string levels) never rejects a write.
  */
 export function toPersistableEffort(
-  value: EffortValue | undefined,
+  value: EffortValue | OpenAIEffortLevel | undefined,
 ): EffortLevel | undefined {
   if (value === 'low' || value === 'medium' || value === 'high') {
     return value
@@ -247,18 +248,15 @@ export function getDisplayedEffortLevel(
 
 /**
  * Build the ` with {level} effort` suffix shown in Logo/Spinner.
- * Returns empty string if the user hasn't explicitly set an effort value.
- * Delegates to resolveAppliedEffort() so the displayed level matches what
- * the API actually receives (including max→high clamp for non-Opus models).
+ * Uses the same effective/displayed level as the bottom-right effort indicator,
+ * so visible UI matches the effort that resolveAppliedEffort() will apply.
  */
 export function getEffortSuffix(
   model: string,
   effortValue: EffortValue | undefined,
 ): string {
-  if (effortValue === undefined) return ''
-  const resolved = resolveAppliedEffort(model, effortValue)
-  if (resolved === undefined) return ''
-  return ` with ${convertEffortValueToLevel(resolved)} effort`
+  if (!modelSupportsEffort(model)) return ''
+  return ` with ${getDisplayedEffortLevel(model, effortValue)} effort`
 }
 
 export function isValidNumericEffort(value: number): boolean {


### PR DESCRIPTION
This PR fixes effort display and persistence mismatches across the `/effort`
picker, the startup banner, and in-app effort labels.

Previously, `/effort medium` could appear active in one part of the UI while a
new session's startup banner still showed a provider alias/default effort such
as `high`. The issue was caused by effort display being split across several
paths with slightly different precedence rules.

This PR makes those paths consistently respect:

1. `CLAUDE_CODE_EFFORT_LEVEL`
2. saved global `/effort`
3. provider alias reasoning default, when present
4. model/default fallback

## What Changed

- Fixed `/effort` picker persistence:
  - picker selections now route through the same persistence helpers as direct
    `/effort` commands;
  - selecting Auto from the picker now clears the persisted global
    `effortLevel`, matching `/effort auto`;
  - `EffortPicker` no longer mutates app state before persistence succeeds.

- Fixed startup banner effort display:
  - saved `/effort` and `CLAUDE_CODE_EFFORT_LEVEL` now take precedence over
    provider alias defaults;
  - provider alias defaults are still preserved when no saved or env override
    exists, so aliases like `gpt-5.4` continue to display their configured
    default effort accurately.

- Unified in-app effort display:
  - `getEffortSuffix()` now uses the same displayed/effective effort level as
    the bottom-right effort indicator;
  - unsupported models still suppress effort suffixes.

- Cleaned up effort command wiring:
  - removed stale OpenAI-effort picker wiring left after centralizing picker
    state updates through the command result path.

- Updated effort utility typing/imports:
  - imported ant-model helpers used by effort logic;
  - widened `toPersistableEffort()` input typing so OpenAI-style `xhigh`
    normalization is accepted.

- Updated docs:
  - documented `CLAUDE_CODE_EFFORT_LEVEL` in `.env.example`;
  - documented `/effort` persistence vs env override precedence in
    `docs/advanced-setup.md`.

## Tests

Added coverage for:

- startup banner uses provider alias default when no saved/env effort exists;
- startup banner uses saved `/effort` over provider alias default;
- startup banner uses `CLAUDE_CODE_EFFORT_LEVEL` over saved `/effort`;
- effort suffix uses the effective displayed effort for supported models;
- unsupported models do not show effort suffixes.

## Validation

Ran focused tests:

```bash
bun test src/components/StartupScreen.test.ts src/utils/effort.codex.test.ts
```

Result:

```text
48 pass
0 fail
72 expect() calls
```

Also ran:

```bash
git diff --check origin/main...HEAD
```

Result: no whitespace errors.

## Notes

The full repo `bun run typecheck` still reports broad unrelated baseline issues
in generated/missing-module and non-effort areas.