### PR TITLE
Centralize OpenClaude display name

### DIFF
--- a/src/components/HelpV2/General.tsx
+++ b/src/components/HelpV2/General.tsx
@@ -1,11 +1,12 @@
 import { c as _c } from "react-compiler-runtime";
+import { PRODUCT_DISPLAY_NAME } from '../../constants/product.js';
 import { Box, Text } from '../../ink.js';
 import { PromptInputHelpMenu } from '../PromptInput/PromptInputHelpMenu.js';
 export function General() {
   const $ = _c(2);
   let t0;
   if ($[0] === Symbol.for("react.memo_cache_sentinel")) {
-    t0 = <Box><Text>Claude understands your codebase, makes edits with your permission, and executes commands — right from your terminal.</Text></Box>;
+    t0 = <Box><Text>{PRODUCT_DISPLAY_NAME} understands your codebase, makes edits with your permission, and executes commands — right from your terminal.</Text></Box>;
     $[0] = t0;
   } else {
     t0 = $[0];

--- a/src/components/InterruptedByUser.tsx
+++ b/src/components/InterruptedByUser.tsx
@@ -1,10 +1,11 @@
 import { c as _c } from "react-compiler-runtime";
+import { PRODUCT_DISPLAY_NAME } from '../constants/product.js';
 import { Text } from '../ink.js';
 export function InterruptedByUser() {
   const $ = _c(1);
   let t0;
   if ($[0] === Symbol.for("react.memo_cache_sentinel")) {
-    t0 = <><Text dimColor={true}>Interrupted </Text>{false ? <Text dimColor={true}>· [internal] /issue to report a model issue</Text> : <Text dimColor={true}>· What should Claude do instead?</Text>}</>;
+    t0 = <><Text dimColor={true}>Interrupted </Text>{false ? <Text dimColor={true}>· [internal] /issue to report a model issue</Text> : <Text dimColor={true}>· What should {PRODUCT_DISPLAY_NAME} do instead?</Text>}</>;
     $[0] = t0;
   } else {
     t0 = $[0];

--- a/src/components/Onboarding.tsx
+++ b/src/components/Onboarding.tsx
@@ -19,6 +19,7 @@ import { Select } from './CustomSelect/select.js';
 import { WelcomeV2 } from './LogoV2/WelcomeV2.js';
 import { PressEnterToContinue } from './PressEnterToContinue.js';
 import { ThemePicker } from './ThemePicker.js';
+import { OrderedList } from './ui/OrderedList.js';
 type StepId = 'preflight' | 'theme' | 'oauth' | 'api-key' | 'security' | 'terminal-setup';
 interface OnboardingStep {
   id: StepId;
@@ -63,15 +64,33 @@ export function Onboarding({
     />
     </Box>;
   const securityStep = <Box flexDirection="column" gap={1} paddingLeft={1}>
-      <Text bold>Security note:</Text>
+      <Text bold>Security notes:</Text>
       <Box flexDirection="column" width={70}>
-        <Text>{PRODUCT_DISPLAY_NAME} can make mistakes</Text>
-        <Text dimColor wrap="wrap">
-          You should always review {PRODUCT_DISPLAY_NAME}&apos;s responses,
-          especially when
-          <Newline />
-          running code.
-        </Text>
+        {/**
+         * OrderedList misnumbers items when rendering conditionally,
+         * so put all items in the if/else
+         */}
+        <OrderedList>
+          <OrderedList.Item>
+            <Text>{PRODUCT_DISPLAY_NAME} can make mistakes</Text>
+            <Text dimColor wrap="wrap">
+              You should always review {PRODUCT_DISPLAY_NAME}&apos;s responses,
+              especially when
+              <Newline />
+              running code.
+              <Newline />
+            </Text>
+          </OrderedList.Item>
+          <OrderedList.Item>
+            <Text>
+              Due to prompt injection risks, only use it with code you trust
+            </Text>
+            <Text dimColor wrap="wrap">
+              Repository files and tool output can contain instructions that try
+              to steer {PRODUCT_DISPLAY_NAME} toward unsafe tool use.
+            </Text>
+          </OrderedList.Item>
+        </OrderedList>
       </Box>
       <PressEnterToContinue />
     </Box>;

--- a/src/components/Onboarding.tsx
+++ b/src/components/Onboarding.tsx
@@ -2,8 +2,9 @@ import { c as _c } from "react-compiler-runtime";
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { type AnalyticsMetadata_I_VERIFIED_THIS_IS_NOT_CODE_OR_FILEPATHS, logEvent } from 'src/services/analytics/index.js';
 import { setupTerminal, shouldOfferTerminalSetup } from '../commands/terminalSetup/terminalSetup.js';
+import { PRODUCT_DISPLAY_NAME } from '../constants/product.js';
 import { useExitOnCtrlCDWithKeybindings } from '../hooks/useExitOnCtrlCDWithKeybindings.js';
-import { Box, Link, Newline, Text, useTheme } from '../ink.js';
+import { Box, Newline, Text, useTheme } from '../ink.js';
 import { useKeybindings } from '../keybindings/useKeybinding.js';
 import { isAnthropicAuthEnabled } from '../utils/auth.js';
 import { normalizeApiKeyForConfig } from '../utils/authPortable.js';
@@ -18,7 +19,6 @@ import { Select } from './CustomSelect/select.js';
 import { WelcomeV2 } from './LogoV2/WelcomeV2.js';
 import { PressEnterToContinue } from './PressEnterToContinue.js';
 import { ThemePicker } from './ThemePicker.js';
-import { OrderedList } from './ui/OrderedList.js';
 type StepId = 'preflight' | 'theme' | 'oauth' | 'api-key' | 'security' | 'terminal-setup';
 interface OnboardingStep {
   id: StepId;
@@ -63,33 +63,15 @@ export function Onboarding({
     />
     </Box>;
   const securityStep = <Box flexDirection="column" gap={1} paddingLeft={1}>
-      <Text bold>Security notes:</Text>
+      <Text bold>Security note:</Text>
       <Box flexDirection="column" width={70}>
-        {/**
-         * OrderedList misnumbers items when rendering conditionally,
-         * so put all items in the if/else
-         */}
-        <OrderedList>
-          <OrderedList.Item>
-            <Text>Claude can make mistakes</Text>
-            <Text dimColor wrap="wrap">
-              You should always review Claude&apos;s responses, especially when
-              <Newline />
-              running code.
-              <Newline />
-            </Text>
-          </OrderedList.Item>
-          <OrderedList.Item>
-            <Text>
-              Due to prompt injection risks, only use it with code you trust
-            </Text>
-            <Text dimColor wrap="wrap">
-              For more details see:
-              <Newline />
-              <Link url="https://code.claude.com/docs/en/security" />
-            </Text>
-          </OrderedList.Item>
-        </OrderedList>
+        <Text>{PRODUCT_DISPLAY_NAME} can make mistakes</Text>
+        <Text dimColor wrap="wrap">
+          You should always review {PRODUCT_DISPLAY_NAME}&apos;s responses,
+          especially when
+          <Newline />
+          running code.
+        </Text>
       </Box>
       <PressEnterToContinue />
     </Box>;
@@ -146,7 +128,7 @@ export function Onboarding({
     steps.push({
       id: 'terminal-setup',
       component: <Box flexDirection="column" gap={1} paddingLeft={1}>
-          <Text bold>Use OpenClaude&apos;s terminal setup?</Text>
+          <Text bold>Use {PRODUCT_DISPLAY_NAME}&apos;s terminal setup?</Text>
           <Box flexDirection="column" width={70} gap={1}>
             <Text>
               For the optimal coding experience, enable the recommended settings

--- a/src/components/OutputStylePicker.tsx
+++ b/src/components/OutputStylePicker.tsx
@@ -1,6 +1,7 @@
 import { c as _c } from "react-compiler-runtime";
 import * as React from 'react';
 import { useCallback, useEffect, useState } from 'react';
+import { PRODUCT_DISPLAY_NAME } from '../constants/product.js';
 import { getAllOutputStyles, OUTPUT_STYLE_CONFIG, type OutputStyleConfig } from '../constants/outputStyles.js';
 import { Box, Text } from '../ink.js';
 import type { OutputStyle } from '../utils/config.js';
@@ -9,7 +10,7 @@ import type { OptionWithDescription } from './CustomSelect/select.js';
 import { Select } from './CustomSelect/select.js';
 import { Dialog } from './design-system/Dialog.js';
 const DEFAULT_OUTPUT_STYLE_LABEL = 'Default';
-const DEFAULT_OUTPUT_STYLE_DESCRIPTION = 'Claude completes coding tasks efficiently and provides concise responses';
+const DEFAULT_OUTPUT_STYLE_DESCRIPTION = `${PRODUCT_DISPLAY_NAME} completes coding tasks efficiently and provides concise responses`;
 function mapConfigsToOptions(styles: {
   [styleName: string]: OutputStyleConfig | null;
 }): OptionWithDescription[] {

--- a/src/components/ThinkingToggle.tsx
+++ b/src/components/ThinkingToggle.tsx
@@ -1,6 +1,7 @@
 import { c as _c } from "react-compiler-runtime";
 import * as React from 'react';
 import { useState } from 'react';
+import { PRODUCT_DISPLAY_NAME } from '../constants/product.js';
 import { useExitOnCtrlCDWithKeybindings } from 'src/hooks/useExitOnCtrlCDWithKeybindings.js';
 import { Box, Text } from '../ink.js';
 import { useKeybinding } from '../keybindings/useKeybinding.js';
@@ -30,11 +31,11 @@ export function ThinkingToggle(t0) {
     t1 = [{
       value: "true",
       label: "Enabled",
-      description: "Claude will think before responding"
+      description: `${PRODUCT_DISPLAY_NAME} will think before responding`
     }, {
       value: "false",
       label: "Disabled",
-      description: "Claude will respond without extended thinking"
+      description: `${PRODUCT_DISPLAY_NAME} will respond without extended thinking`
     }];
     $[0] = t1;
   } else {

--- a/src/components/agents/AgentDetail.tsx
+++ b/src/components/agents/AgentDetail.tsx
@@ -1,6 +1,7 @@
 import { c as _c } from "react-compiler-runtime";
 import figures from 'figures';
 import * as React from 'react';
+import { PRODUCT_DISPLAY_NAME } from '../../constants/product.js';
 import type { KeyboardEvent } from '../../ink/events/keyboard-event.js';
 import { Box, Text } from '../../ink.js';
 import { useKeybinding } from '../../keybindings/useKeybinding.js';
@@ -92,7 +93,7 @@ export function AgentDetail(t0) {
   }
   let t10;
   if ($[9] === Symbol.for("react.memo_cache_sentinel")) {
-    t10 = <Text><Text bold={true}>Description</Text> (tells Claude when to use this agent):</Text>;
+    t10 = <Text><Text bold={true}>Description</Text> (tells {PRODUCT_DISPLAY_NAME} when to use this agent):</Text>;
     $[9] = t10;
   } else {
     t10 = $[9];

--- a/src/components/agents/AgentsList.tsx
+++ b/src/components/agents/AgentsList.tsx
@@ -1,6 +1,7 @@
 import { c as _c } from "react-compiler-runtime";
 import figures from 'figures';
 import * as React from 'react';
+import { PRODUCT_DISPLAY_NAME } from '../../constants/product.js';
 import type { SettingSource } from 'src/utils/settings/constants.js';
 import type { KeyboardEvent } from '../../ink/events/keyboard-event.js';
 import { Box, Text } from '../../ink.js';
@@ -242,7 +243,7 @@ export function AgentsList(t0) {
         let t25;
         let t26;
         if ($[58] === Symbol.for("react.memo_cache_sentinel")) {
-          t24 = <Text dimColor={true}>No agents found. Create specialized subagents that Claude can delegate to.</Text>;
+          t24 = <Text dimColor={true}>No agents found. Create specialized subagents that {PRODUCT_DISPLAY_NAME} can delegate to.</Text>;
           t25 = <Text dimColor={true}>Each subagent has its own context window, custom system prompt, and specific tools.</Text>;
           t26 = <Text dimColor={true}>Try creating: Code Reviewer, Code Simplifier, Security Reviewer, Tech Lead, or UX Reviewer.</Text>;
           $[58] = t24;

--- a/src/components/agents/new-agent-creation/wizard-steps/ConfirmStep.tsx
+++ b/src/components/agents/new-agent-creation/wizard-steps/ConfirmStep.tsx
@@ -1,5 +1,6 @@
 import { c as _c } from "react-compiler-runtime";
 import React, { type ReactNode } from 'react';
+import { PRODUCT_DISPLAY_NAME } from '../../../../constants/product.js';
 import type { KeyboardEvent } from '../../../../ink/events/keyboard-event.js';
 import { Box, Text } from '../../../../ink.js';
 import { useKeybinding } from '../../../../keybindings/useKeybinding.js';
@@ -216,7 +217,7 @@ export function ConfirmStep(t0) {
     }
     t11 = memoryDisplayElement;
     if ($[54] === Symbol.for("react.memo_cache_sentinel")) {
-      t12 = <Box marginTop={1}><Text><Text bold={true}>Description</Text> (tells Claude when to use this agent):</Text></Box>;
+      t12 = <Box marginTop={1}><Text><Text bold={true}>Description</Text> (tells {PRODUCT_DISPLAY_NAME} when to use this agent):</Text></Box>;
       $[54] = t12;
     } else {
       t12 = $[54];

--- a/src/components/agents/new-agent-creation/wizard-steps/DescriptionStep.tsx
+++ b/src/components/agents/new-agent-creation/wizard-steps/DescriptionStep.tsx
@@ -1,5 +1,6 @@
 import { c as _c } from "react-compiler-runtime";
 import React, { type ReactNode, useCallback, useState } from 'react';
+import { PRODUCT_DISPLAY_NAME } from '../../../../constants/product.js';
 import { Box, Text } from '../../../../ink.js';
 import { useKeybinding } from '../../../../keybindings/useKeybinding.js';
 import { editPromptInEditor } from '../../../../utils/promptEditor.js';
@@ -86,7 +87,7 @@ export function DescriptionStep() {
   }
   let t5;
   if ($[8] === Symbol.for("react.memo_cache_sentinel")) {
-    t5 = <Text>When should Claude use this agent?</Text>;
+    t5 = <Text>When should {PRODUCT_DISPLAY_NAME} use this agent?</Text>;
     $[8] = t5;
   } else {
     t5 = $[8];
@@ -111,7 +112,7 @@ export function DescriptionStep() {
   }
   let t8;
   if ($[15] !== t6 || $[16] !== t7) {
-    t8 = <WizardDialogLayout subtitle="Description (tell Claude when to use this agent)" footerText={t4}><Box flexDirection="column">{t5}{t6}{t7}</Box></WizardDialogLayout>;
+    t8 = <WizardDialogLayout subtitle={`Description (tell ${PRODUCT_DISPLAY_NAME} when to use this agent)`} footerText={t4}><Box flexDirection="column">{t5}{t6}{t7}</Box></WizardDialogLayout>;
     $[15] = t6;
     $[16] = t7;
     $[17] = t8;

--- a/src/components/agents/new-agent-creation/wizard-steps/MethodStep.tsx
+++ b/src/components/agents/new-agent-creation/wizard-steps/MethodStep.tsx
@@ -1,5 +1,6 @@
 import { c as _c } from "react-compiler-runtime";
 import React, { type ReactNode } from 'react';
+import { PRODUCT_DISPLAY_NAME } from '../../../../constants/product.js';
 import { Box } from '../../../../ink.js';
 import { ConfigurableShortcutHint } from '../../../ConfigurableShortcutHint.js';
 import { Select } from '../../../CustomSelect/select.js';
@@ -19,7 +20,7 @@ export function MethodStep() {
   let t0;
   if ($[0] === Symbol.for("react.memo_cache_sentinel")) {
     t0 = [{
-      label: "Generate with Claude (recommended)",
+      label: `Generate with ${PRODUCT_DISPLAY_NAME} (recommended)`,
       value: "generate"
     }, {
       label: "Manual configuration",

--- a/src/components/hooks/HooksConfigMenu.tsx
+++ b/src/components/hooks/HooksConfigMenu.tsx
@@ -13,6 +13,7 @@ import { c as _c } from "react-compiler-runtime";
  */
 import * as React from 'react';
 import { useCallback, useMemo, useState } from 'react';
+import { PRODUCT_DISPLAY_NAME } from '../../constants/product.js';
 import type { HookEvent } from 'src/entrypoints/agentSdkTypes.js';
 import { useAppState, useAppStateStore } from 'src/state/AppState.js';
 import type { CommandResultDisplay } from '../../commands.js';
@@ -351,7 +352,7 @@ export function HooksConfigMenu(t0) {
     }
     let t32;
     if ($[53] !== disabledByPolicy) {
-      t32 = !disabledByPolicy && <Text dimColor={true}>To re-enable hooks, remove "disableAllHooks" from settings.json or ask Claude.</Text>;
+      t32 = !disabledByPolicy && <Text dimColor={true}>To re-enable hooks, remove "disableAllHooks" from settings.json or ask {PRODUCT_DISPLAY_NAME}.</Text>;
       $[53] = disabledByPolicy;
       $[54] = t32;
     } else {

--- a/src/components/hooks/SelectEventMode.tsx
+++ b/src/components/hooks/SelectEventMode.tsx
@@ -10,6 +10,7 @@ import { c as _c } from "react-compiler-runtime";
 
 import figures from 'figures';
 import * as React from 'react';
+import { PRODUCT_DISPLAY_NAME } from '../../constants/product.js';
 import type { HookEvent } from 'src/entrypoints/agentSdkTypes.js';
 import type { HookEventMetadata } from 'src/utils/hooks/hooksConfigManager.js';
 import { Box, Link, Text } from '../../ink.js';
@@ -53,7 +54,7 @@ export function SelectEventMode(t0) {
   }
   let t3;
   if ($[4] === Symbol.for("react.memo_cache_sentinel")) {
-    t3 = <Box flexDirection="column"><Text dimColor={true}>{figures.info} This menu is read-only. To add or modify hooks, edit settings.json directly or ask Claude.{" "}<Link url="https://code.claude.com/docs/en/hooks">Learn more</Link></Text></Box>;
+    t3 = <Box flexDirection="column"><Text dimColor={true}>{figures.info} This menu is read-only. To add or modify hooks, edit settings.json directly or ask {PRODUCT_DISPLAY_NAME}.{" "}<Link url="https://code.claude.com/docs/en/hooks">Learn more</Link></Text></Box>;
     $[4] = t3;
   } else {
     t3 = $[4];

--- a/src/components/hooks/SelectHookMode.tsx
+++ b/src/components/hooks/SelectHookMode.tsx
@@ -7,6 +7,7 @@ import { c as _c } from "react-compiler-runtime";
  * confirmation.
  */
 import * as React from 'react';
+import { PRODUCT_DISPLAY_NAME } from '../../constants/product.js';
 import type { HookEvent } from 'src/entrypoints/agentSdkTypes.js';
 import type { HookEventMetadata } from 'src/utils/hooks/hooksConfigManager.js';
 import { Box, Text } from '../../ink.js';
@@ -35,7 +36,7 @@ export function SelectHookMode(t0) {
   if (hooksForSelectedMatcher.length === 0) {
     let t1;
     if ($[0] === Symbol.for("react.memo_cache_sentinel")) {
-      t1 = <Box flexDirection="column" gap={1}><Text dimColor={true}>No hooks configured for this event.</Text><Text dimColor={true}>To add hooks, edit settings.json directly or ask Claude.</Text></Box>;
+      t1 = <Box flexDirection="column" gap={1}><Text dimColor={true}>No hooks configured for this event.</Text><Text dimColor={true}>To add hooks, edit settings.json directly or ask {PRODUCT_DISPLAY_NAME}.</Text></Box>;
       $[0] = t1;
     } else {
       t1 = $[0];

--- a/src/components/hooks/SelectMatcherMode.tsx
+++ b/src/components/hooks/SelectMatcherMode.tsx
@@ -6,6 +6,7 @@ import { c as _c } from "react-compiler-runtime";
  * and simply lets the user drill into each matcher to see its hooks.
  */
 import * as React from 'react';
+import { PRODUCT_DISPLAY_NAME } from '../../constants/product.js';
 import type { HookEvent } from 'src/entrypoints/agentSdkTypes.js';
 import { Box, Text } from '../../ink.js';
 import { type HookSource, hookSourceInlineDisplayString, type IndividualHookConfig } from '../../utils/hooks/hooksSettings.js';
@@ -67,7 +68,7 @@ export function SelectMatcherMode(t0) {
     const t2 = `${selectedEvent} - Matchers`;
     let t3;
     if ($[7] === Symbol.for("react.memo_cache_sentinel")) {
-      t3 = <Box flexDirection="column" gap={1}><Text dimColor={true}>No hooks configured for this event.</Text><Text dimColor={true}>To add hooks, edit settings.json directly or ask Claude.</Text></Box>;
+      t3 = <Box flexDirection="column" gap={1}><Text dimColor={true}>No hooks configured for this event.</Text><Text dimColor={true}>To add hooks, edit settings.json directly or ask {PRODUCT_DISPLAY_NAME}.</Text></Box>;
       $[7] = t3;
     } else {
       t3 = $[7];

--- a/src/components/hooks/ViewHookMode.tsx
+++ b/src/components/hooks/ViewHookMode.tsx
@@ -6,6 +6,7 @@ import { c as _c } from "react-compiler-runtime";
  * confirmation screen and directs users to settings.json or Claude for edits.
  */
 import * as React from 'react';
+import { PRODUCT_DISPLAY_NAME } from '../../constants/product.js';
 import { Box, Text } from '../../ink.js';
 import { hookSourceDescriptionDisplayString, type IndividualHookConfig } from '../../utils/hooks/hooksSettings.js';
 import { Dialog } from '../design-system/Dialog.js';
@@ -133,7 +134,7 @@ export function ViewHookMode(t0) {
   }
   let t14;
   if ($[32] === Symbol.for("react.memo_cache_sentinel")) {
-    t14 = <Text dimColor={true}>To modify or remove this hook, edit settings.json directly or ask Claude to help.</Text>;
+    t14 = <Text dimColor={true}>To modify or remove this hook, edit settings.json directly or ask {PRODUCT_DISPLAY_NAME} to help.</Text>;
     $[32] = t14;
   } else {
     t14 = $[32];

--- a/src/components/permissions/BashPermissionRequest/bashToolUseOptions.tsx
+++ b/src/components/permissions/BashPermissionRequest/bashToolUseOptions.tsx
@@ -1,3 +1,4 @@
+import { PRODUCT_DISPLAY_NAME } from '../../../constants/product.js';
 import { BASH_TOOL_NAME } from '../../../tools/BashTool/toolName.js';
 import { extractOutputRedirections } from '../../../utils/bash/commands.js';
 import { isClassifierPermissionsEnabled } from '../../../utils/permissions/bashClassifier.js';
@@ -64,7 +65,7 @@ export function bashToolUseOptions({
       type: 'input',
       label: 'Yes',
       value: 'yes',
-      placeholder: 'and tell Claude what to do next',
+      placeholder: `and tell ${PRODUCT_DISPLAY_NAME} what to do next`,
       onChange: onAcceptFeedbackChange,
       allowEmptySubmitToCancel: true
     });
@@ -132,7 +133,7 @@ export function bashToolUseOptions({
       type: 'input',
       label: 'No',
       value: 'no',
-      placeholder: 'and tell Claude what to do differently',
+      placeholder: `and tell ${PRODUCT_DISPLAY_NAME} what to do differently`,
       onChange: onRejectFeedbackChange,
       allowEmptySubmitToCancel: true
     });

--- a/src/components/permissions/ComputerUseApproval/ComputerUseApproval.tsx
+++ b/src/components/permissions/ComputerUseApproval/ComputerUseApproval.tsx
@@ -5,6 +5,7 @@ import { DEFAULT_GRANT_FLAGS } from '@ant/computer-use-mcp/types';
 import figures from 'figures';
 import * as React from 'react';
 import { useMemo, useState } from 'react';
+import { PRODUCT_DISPLAY_NAME } from '../../../constants/product.js';
 import { Box, Text } from '../../../ink.js';
 import { execFileNoThrow } from '../../../utils/execFileNoThrow.js';
 import { plural } from '../../../utils/stringUtils.js';
@@ -161,7 +162,7 @@ function ComputerUseTccPanel(t0) {
   }
   let t7;
   if ($[15] === Symbol.for("react.memo_cache_sentinel")) {
-    t7 = <Text dimColor={true}>Grant the missing permissions in System Settings, then select "Try again". macOS may require you to restart OpenClaude after granting Screen Recording.</Text>;
+    t7 = <Text dimColor={true}>Grant the missing permissions in System Settings, then select "Try again". macOS may require you to restart {PRODUCT_DISPLAY_NAME} after granting Screen Recording.</Text>;
     $[15] = t7;
   } else {
     t7 = $[15];
@@ -261,7 +262,7 @@ function ComputerUseAppListPanel(t0) {
   let t8;
   if ($[9] === Symbol.for("react.memo_cache_sentinel")) {
     t8 = {
-      label: <Text>Deny, and tell Claude what to do differently <Text bold={true}>(esc)</Text></Text>,
+      label: <Text>Deny, and tell {PRODUCT_DISPLAY_NAME} what to do differently <Text bold={true}>(esc)</Text></Text>,
       value: "deny"
     };
     $[9] = t8;
@@ -372,7 +373,7 @@ function ComputerUseAppListPanel(t0) {
   }
   let t16;
   if ($[30] !== request.willHide) {
-    t16 = request.willHide && request.willHide.length > 0 ? <Text dimColor={true}>{request.willHide.length} other{" "}{plural(request.willHide.length, "app")} will be hidden while Claude works.</Text> : null;
+    t16 = request.willHide && request.willHide.length > 0 ? <Text dimColor={true}>{request.willHide.length} other{" "}{plural(request.willHide.length, "app")} will be hidden while {PRODUCT_DISPLAY_NAME} works.</Text> : null;
     $[30] = request.willHide;
     $[31] = t16;
   } else {

--- a/src/components/permissions/EnterPlanModePermissionRequest/EnterPlanModePermissionRequest.tsx
+++ b/src/components/permissions/EnterPlanModePermissionRequest/EnterPlanModePermissionRequest.tsx
@@ -1,6 +1,7 @@
 import { c as _c } from "react-compiler-runtime";
 import React from 'react';
 import { handlePlanModeTransition } from '../../../bootstrap/state.js';
+import { PRODUCT_DISPLAY_NAME } from '../../../constants/product.js';
 import { Box, Text } from '../../../ink.js';
 import { type AnalyticsMetadata_I_VERIFIED_THIS_IS_NOT_CODE_OR_FILEPATHS, logEvent } from '../../../services/analytics/index.js';
 import { useAppState } from '../../../state/AppState.js';
@@ -49,14 +50,14 @@ export function EnterPlanModePermissionRequest(t0) {
   const handleResponse = t1;
   let t2;
   if ($[5] === Symbol.for("react.memo_cache_sentinel")) {
-    t2 = <Text>OpenClaude wants to enter plan mode to explore and design an implementation approach.</Text>;
+    t2 = <Text>{PRODUCT_DISPLAY_NAME} wants to enter plan mode to explore and design an implementation approach.</Text>;
     $[5] = t2;
   } else {
     t2 = $[5];
   }
   let t3;
   if ($[6] === Symbol.for("react.memo_cache_sentinel")) {
-    t3 = <Box marginTop={1} flexDirection="column"><Text dimColor={true}>In plan mode, OpenClaude will:</Text><Text dimColor={true}> · Explore the codebase thoroughly</Text><Text dimColor={true}> · Identify existing patterns</Text><Text dimColor={true}> · Design an implementation strategy</Text><Text dimColor={true}> · Present a plan for your approval</Text></Box>;
+    t3 = <Box marginTop={1} flexDirection="column"><Text dimColor={true}>In plan mode, {PRODUCT_DISPLAY_NAME} will:</Text><Text dimColor={true}> · Explore the codebase thoroughly</Text><Text dimColor={true}> · Identify existing patterns</Text><Text dimColor={true}> · Design an implementation strategy</Text><Text dimColor={true}> · Present a plan for your approval</Text></Box>;
     $[6] = t3;
   } else {
     t3 = $[6];

--- a/src/components/permissions/ExitPlanModePermissionRequest/ExitPlanModePermissionRequest.tsx
+++ b/src/components/permissions/ExitPlanModePermissionRequest/ExitPlanModePermissionRequest.tsx
@@ -24,7 +24,7 @@ import { toIDEDisplayName } from '../../../utils/ide.js';
 import { logError } from '../../../utils/log.js';
 import { enqueuePendingNotification } from '../../../utils/messageQueueManager.js';
 import { createUserMessage } from '../../../utils/messages.js';
-import { getMainLoopModel, getRuntimeMainLoopModel } from '../../../utils/model/model.js';
+import { getMainLoopModel, getRuntimeMainLoopModel, modelDisplayString } from '../../../utils/model/model.js';
 import { createPromptRuleContent, isClassifierPermissionsEnabled, PROMPT_PREFIX } from '../../../utils/permissions/bashClassifier.js';
 import { type PermissionMode, toExternalPermissionMode } from '../../../utils/permissions/PermissionMode.js';
 import type { PermissionUpdate } from '../../../utils/permissions/PermissionUpdateSchema.js';
@@ -149,6 +149,7 @@ export function ExitPlanModePermissionRequest({
     isAutoModeAvailable,
     isBypassPermissionsModeAvailable
   } = toolPermissionContext;
+  const planAuthorName = modelDisplayString(toolUseConfirm.assistantMessage.message.model);
   const options = useMemo(() => buildPlanApprovalOptions({
     showClearContext,
     showUltraplan,
@@ -156,8 +157,9 @@ export function ExitPlanModePermissionRequest({
     isAutoModeAvailable,
     isBypassPermissionsModeAvailable,
     assistantDisplayName: PRODUCT_DISPLAY_NAME,
+    planAuthorName,
     onFeedbackChange: setPlanFeedback
-  }), [showClearContext, showUltraplan, usage, mode, isAutoModeAvailable, isBypassPermissionsModeAvailable]);
+  }), [showClearContext, showUltraplan, usage, mode, isAutoModeAvailable, isBypassPermissionsModeAvailable, planAuthorName]);
   function onImagePaste(base64Image: string, mediaType?: string, filename?: string, dimensions?: ImageDimensions, _sourcePath?: string) {
     const pasteId = nextPasteIdRef.current++;
     const newContent: PastedContent = {
@@ -629,7 +631,7 @@ export function ExitPlanModePermissionRequest({
       <PermissionDialog color="planMode" title="Ready to code?" innerPaddingX={0} workerBadge={workerBadge}>
         <Box flexDirection="column" marginTop={1}>
           <Box paddingX={1} flexDirection="column">
-            <Text>Here is {PRODUCT_DISPLAY_NAME}&apos;s plan:</Text>
+            <Text>Here is {planAuthorName}&apos;s plan:</Text>
           </Box>
           <Box borderColor="subtle" borderStyle="dashed" flexDirection="column" borderLeft={false} borderRight={false} paddingX={1} marginBottom={1}
         // Necessary for Windows Terminal to render properly
@@ -646,7 +648,7 @@ export function ExitPlanModePermissionRequest({
                 </Box>}
             {!useStickyFooter && <>
                 <Text dimColor>
-                  {PRODUCT_DISPLAY_NAME} has written up a plan and is ready to execute. Would
+                  {planAuthorName} has written up a plan and is ready to execute. Would
                   you like to proceed?
                 </Text>
                 <Box marginTop={1}>
@@ -680,6 +682,7 @@ export function buildPlanApprovalOptions({
   isAutoModeAvailable,
   isBypassPermissionsModeAvailable,
   assistantDisplayName,
+  planAuthorName,
   onFeedbackChange
 }: {
   showClearContext: boolean;
@@ -688,6 +691,7 @@ export function buildPlanApprovalOptions({
   isAutoModeAvailable: boolean | undefined;
   isBypassPermissionsModeAvailable: boolean | undefined;
   assistantDisplayName: string;
+  planAuthorName: string;
   onFeedbackChange: (v: string) => void;
 }): OptionWithDescription<ResponseValue>[] {
   const options: OptionWithDescription<ResponseValue>[] = [];
@@ -742,7 +746,7 @@ export function buildPlanApprovalOptions({
     type: 'input',
     label: 'No, keep planning',
     value: 'no',
-    placeholder: `Tell ${assistantDisplayName} what to change`,
+    placeholder: `Tell ${planAuthorName} what to change`,
     description: 'shift+tab to approve with this feedback',
     onChange: onFeedbackChange
   });

--- a/src/components/permissions/ExitPlanModePermissionRequest/ExitPlanModePermissionRequest.tsx
+++ b/src/components/permissions/ExitPlanModePermissionRequest/ExitPlanModePermissionRequest.tsx
@@ -8,6 +8,7 @@ import { useAppState, useAppStateStore, useSetAppState } from 'src/state/AppStat
 import { getSdkBetas, getSessionId, isSessionPersistenceDisabled, setHasExitedPlanMode, setNeedsAutoModeExitAttachment, setNeedsPlanModeExitAttachment } from '../../../bootstrap/state.js';
 import { generateSessionName } from '../../../commands/rename/generateSessionName.js';
 import { launchUltraplan } from '../../../commands/ultraplan.js';
+import { PRODUCT_DISPLAY_NAME } from '../../../constants/product.js';
 import type { KeyboardEvent } from '../../../ink/events/keyboard-event.js';
 import { Box, Text } from '../../../ink.js';
 import type { AppState } from '../../../state/AppStateStore.js';
@@ -23,7 +24,7 @@ import { toIDEDisplayName } from '../../../utils/ide.js';
 import { logError } from '../../../utils/log.js';
 import { enqueuePendingNotification } from '../../../utils/messageQueueManager.js';
 import { createUserMessage } from '../../../utils/messages.js';
-import { getMainLoopModel, getRuntimeMainLoopModel, modelDisplayString } from '../../../utils/model/model.js';
+import { getMainLoopModel, getRuntimeMainLoopModel } from '../../../utils/model/model.js';
 import { createPromptRuleContent, isClassifierPermissionsEnabled, PROMPT_PREFIX } from '../../../utils/permissions/bashClassifier.js';
 import { type PermissionMode, toExternalPermissionMode } from '../../../utils/permissions/PermissionMode.js';
 import type { PermissionUpdate } from '../../../utils/permissions/PermissionUpdateSchema.js';
@@ -148,16 +149,15 @@ export function ExitPlanModePermissionRequest({
     isAutoModeAvailable,
     isBypassPermissionsModeAvailable
   } = toolPermissionContext;
-  const planAuthorName = modelDisplayString(toolUseConfirm.assistantMessage.message.model);
   const options = useMemo(() => buildPlanApprovalOptions({
     showClearContext,
     showUltraplan,
     usedPercent: showClearContext ? getContextUsedPercent(usage, mode) : null,
     isAutoModeAvailable,
     isBypassPermissionsModeAvailable,
-    planAuthorName,
+    assistantDisplayName: PRODUCT_DISPLAY_NAME,
     onFeedbackChange: setPlanFeedback
-  }), [showClearContext, showUltraplan, usage, mode, isAutoModeAvailable, isBypassPermissionsModeAvailable, planAuthorName]);
+  }), [showClearContext, showUltraplan, usage, mode, isAutoModeAvailable, isBypassPermissionsModeAvailable]);
   function onImagePaste(base64Image: string, mediaType?: string, filename?: string, dimensions?: ImageDimensions, _sourcePath?: string) {
     const pasteId = nextPasteIdRef.current++;
     const newContent: PastedContent = {
@@ -602,7 +602,7 @@ export function ExitPlanModePermissionRequest({
     }
     return <PermissionDialog color="planMode" title="Exit plan mode?" workerBadge={workerBadge}>
         <Box flexDirection="column" paddingX={1} marginTop={1}>
-          <Text>OpenClaude wants to exit plan mode</Text>
+          <Text>{PRODUCT_DISPLAY_NAME} wants to exit plan mode</Text>
           <Box marginTop={1}>
             <Select options={[{
             label: 'Yes',
@@ -629,7 +629,7 @@ export function ExitPlanModePermissionRequest({
       <PermissionDialog color="planMode" title="Ready to code?" innerPaddingX={0} workerBadge={workerBadge}>
         <Box flexDirection="column" marginTop={1}>
           <Box paddingX={1} flexDirection="column">
-            <Text>Here is {planAuthorName}&apos;s plan:</Text>
+            <Text>Here is {PRODUCT_DISPLAY_NAME}&apos;s plan:</Text>
           </Box>
           <Box borderColor="subtle" borderStyle="dashed" flexDirection="column" borderLeft={false} borderRight={false} paddingX={1} marginBottom={1}
         // Necessary for Windows Terminal to render properly
@@ -646,7 +646,7 @@ export function ExitPlanModePermissionRequest({
                 </Box>}
             {!useStickyFooter && <>
                 <Text dimColor>
-                  {planAuthorName} has written up a plan and is ready to execute. Would
+                  {PRODUCT_DISPLAY_NAME} has written up a plan and is ready to execute. Would
                   you like to proceed?
                 </Text>
                 <Box marginTop={1}>
@@ -679,7 +679,7 @@ export function buildPlanApprovalOptions({
   usedPercent,
   isAutoModeAvailable,
   isBypassPermissionsModeAvailable,
-  planAuthorName,
+  assistantDisplayName,
   onFeedbackChange
 }: {
   showClearContext: boolean;
@@ -687,7 +687,7 @@ export function buildPlanApprovalOptions({
   usedPercent: number | null;
   isAutoModeAvailable: boolean | undefined;
   isBypassPermissionsModeAvailable: boolean | undefined;
-  planAuthorName: string;
+  assistantDisplayName: string;
   onFeedbackChange: (v: string) => void;
 }): OptionWithDescription<ResponseValue>[] {
   const options: OptionWithDescription<ResponseValue>[] = [];
@@ -734,7 +734,7 @@ export function buildPlanApprovalOptions({
   });
   if (showUltraplan) {
     options.push({
-      label: 'No, refine with Ultraplan on OpenClaude on the web',
+      label: `No, refine with Ultraplan on ${assistantDisplayName} on the web`,
       value: 'ultraplan'
     });
   }
@@ -742,7 +742,7 @@ export function buildPlanApprovalOptions({
     type: 'input',
     label: 'No, keep planning',
     value: 'no',
-    placeholder: `Tell ${planAuthorName} what to change`,
+    placeholder: `Tell ${assistantDisplayName} what to change`,
     description: 'shift+tab to approve with this feedback',
     onChange: onFeedbackChange
   });

--- a/src/components/permissions/FilePermissionDialog/permissionOptions.tsx
+++ b/src/components/permissions/FilePermissionDialog/permissionOptions.tsx
@@ -2,6 +2,7 @@ import { homedir } from 'os';
 import { basename, join, sep } from 'path';
 import React, { type ReactNode } from 'react';
 import { getOriginalCwd } from '../../../bootstrap/state.js';
+import { PRODUCT_DISPLAY_NAME } from '../../../constants/product.js';
 import { Text } from '../../../ink.js';
 import { getShortcutDisplay } from '../../../keybindings/shortcutFormat.js';
 import type { ToolPermissionContext } from '../../../Tool.js';
@@ -76,7 +77,7 @@ export function getFilePermissionOptions({
       type: 'input',
       label: 'Yes',
       value: 'yes',
-      placeholder: 'and tell Claude what to do next',
+      placeholder: `and tell ${PRODUCT_DISPLAY_NAME} what to do next`,
       onChange: onAcceptFeedbackChange,
       allowEmptySubmitToCancel: true,
       option: {
@@ -104,7 +105,7 @@ export function getFilePermissionOptions({
   // persisted permission rules.
   if ((inClaudeFolder || inGlobalClaudeFolder) && operationType !== 'read') {
     options.push({
-      label: 'Yes, and allow OpenClaude to edit its own settings for this session',
+      label: `Yes, and allow ${PRODUCT_DISPLAY_NAME} to edit its own settings for this session`,
       value: 'yes-claude-folder',
       option: {
         type: 'accept-session',
@@ -155,7 +156,7 @@ export function getFilePermissionOptions({
       type: 'input',
       label: 'No',
       value: 'no',
-      placeholder: 'and tell Claude what to do differently',
+      placeholder: `and tell ${PRODUCT_DISPLAY_NAME} what to do differently`,
       onChange: onRejectFeedbackChange,
       allowEmptySubmitToCancel: true,
       option: {

--- a/src/components/permissions/PermissionPrompt.tsx
+++ b/src/components/permissions/PermissionPrompt.tsx
@@ -1,5 +1,6 @@
 import { c as _c } from "react-compiler-runtime";
 import React, { type ReactNode, useCallback, useMemo, useState } from 'react';
+import { PRODUCT_DISPLAY_NAME } from '../../constants/product.js';
 import { Box, Text } from '../../ink.js';
 import type { KeybindingAction } from '../../keybindings/types.js';
 import { useKeybindings } from '../../keybindings/useKeybinding.js';
@@ -28,8 +29,8 @@ export type PermissionPromptProps<T extends string> = {
   toolAnalyticsContext?: ToolAnalyticsContext;
 };
 const DEFAULT_PLACEHOLDERS: Record<FeedbackType, string> = {
-  accept: 'tell OpenClaude what to do next',
-  reject: 'tell OpenClaude what to do differently'
+  accept: `tell ${PRODUCT_DISPLAY_NAME} what to do next`,
+  reject: `tell ${PRODUCT_DISPLAY_NAME} what to do differently`
 };
 
 /**

--- a/src/components/permissions/PermissionRequest.tsx
+++ b/src/components/permissions/PermissionRequest.tsx
@@ -1,6 +1,7 @@
 import { c as _c } from "react-compiler-runtime";
 import { feature } from 'bun:bundle';
 import * as React from 'react';
+import { PRODUCT_DISPLAY_NAME } from 'src/constants/product.js';
 import { EnterPlanModeTool } from 'src/tools/EnterPlanModeTool/EnterPlanModeTool.js';
 import { ExitPlanModeV2Tool } from 'src/tools/ExitPlanModeTool/ExitPlanModeV2Tool.js';
 import { useNotifyAfterTimeout } from '../../hooks/useNotifyAfterTimeout.js';
@@ -128,18 +129,18 @@ export type ToolUseConfirm<Input extends AnyObject = AnyObject> = {
 function getNotificationMessage(toolUseConfirm: ToolUseConfirm): string {
   const toolName = toolUseConfirm.tool.userFacingName(toolUseConfirm.input as never);
   if (toolUseConfirm.tool === ExitPlanModeV2Tool) {
-    return 'OpenClaude needs your approval for the plan';
+    return `${PRODUCT_DISPLAY_NAME} needs your approval for the plan`;
   }
   if (toolUseConfirm.tool === EnterPlanModeTool) {
-    return 'OpenClaude wants to enter plan mode';
+    return `${PRODUCT_DISPLAY_NAME} wants to enter plan mode`;
   }
   if (feature('REVIEW_ARTIFACT') && toolUseConfirm.tool === ReviewArtifactTool) {
-    return 'OpenClaude needs your approval for a review artifact';
+    return `${PRODUCT_DISPLAY_NAME} needs your approval for a review artifact`;
   }
   if (!toolName || toolName.trim() === '') {
-    return 'OpenClaude needs your attention';
+    return `${PRODUCT_DISPLAY_NAME} needs your attention`;
   }
-  return `OpenClaude needs your permission to use ${toolName}`;
+  return `${PRODUCT_DISPLAY_NAME} needs your permission to use ${toolName}`;
 }
 
 // TODO: Move this to Tool.renderPermissionRequest

--- a/src/components/permissions/PowerShellPermissionRequest/powershellToolUseOptions.tsx
+++ b/src/components/permissions/PowerShellPermissionRequest/powershellToolUseOptions.tsx
@@ -1,3 +1,4 @@
+import { PRODUCT_DISPLAY_NAME } from '../../../constants/product.js';
 import { POWERSHELL_TOOL_NAME } from '../../../tools/PowerShellTool/toolName.js';
 import type { PermissionUpdate } from '../../../utils/permissions/PermissionUpdateSchema.js';
 import { shouldShowAlwaysAllowOptions } from '../../../utils/permissions/permissionsLoader.js';
@@ -27,7 +28,7 @@ export function powershellToolUseOptions({
       type: 'input',
       label: 'Yes',
       value: 'yes',
-      placeholder: 'and tell Claude what to do next',
+      placeholder: `and tell ${PRODUCT_DISPLAY_NAME} what to do next`,
       onChange: onAcceptFeedbackChange,
       allowEmptySubmitToCancel: true
     });
@@ -76,7 +77,7 @@ export function powershellToolUseOptions({
       type: 'input',
       label: 'No',
       value: 'no',
-      placeholder: 'and tell Claude what to do differently',
+      placeholder: `and tell ${PRODUCT_DISPLAY_NAME} what to do differently`,
       onChange: onRejectFeedbackChange,
       allowEmptySubmitToCancel: true
     });

--- a/src/components/permissions/SandboxPermissionRequest.tsx
+++ b/src/components/permissions/SandboxPermissionRequest.tsx
@@ -1,5 +1,6 @@
 import { c as _c } from "react-compiler-runtime";
 import * as React from 'react';
+import { PRODUCT_DISPLAY_NAME } from 'src/constants/product.js';
 import { Box, Text } from 'src/ink.js';
 import { type NetworkHostPattern, shouldAllowManagedSandboxDomainsOnly } from 'src/utils/sandbox/sandbox-adapter.js';
 import { type AnalyticsMetadata_I_VERIFIED_THIS_IS_NOT_CODE_OR_FILEPATHS, logEvent } from '../../services/analytics/index.js';
@@ -88,7 +89,7 @@ export function SandboxPermissionRequest(t0) {
   let t6;
   if ($[6] === Symbol.for("react.memo_cache_sentinel")) {
     t6 = {
-      label: <Text>No, and tell Claude what to do differently <Text bold={true}>(esc)</Text></Text>,
+      label: <Text>No, and tell {PRODUCT_DISPLAY_NAME} what to do differently <Text bold={true}>(esc)</Text></Text>,
       value: "no"
     };
     $[6] = t6;

--- a/src/components/permissions/SkillPermissionRequest/SkillPermissionRequest.tsx
+++ b/src/components/permissions/SkillPermissionRequest/SkillPermissionRequest.tsx
@@ -2,6 +2,7 @@ import { c as _c } from "react-compiler-runtime";
 import React, { useCallback, useMemo } from 'react';
 import { logError } from 'src/utils/log.js';
 import { getOriginalCwd } from '../../../bootstrap/state.js';
+import { PRODUCT_DISPLAY_NAME } from '../../../constants/product.js';
 import { Box, Text } from '../../../ink.js';
 import { sanitizeToolNameForAnalytics } from '../../../services/analytics/metadata.js';
 import { SKILL_TOOL_NAME } from '../../../tools/SkillTool/constants.js';
@@ -303,7 +304,7 @@ export function SkillPermissionRequest(props) {
   const t12 = `Use skill "${skill}"?`;
   let t13;
   if ($[33] === Symbol.for("react.memo_cache_sentinel")) {
-    t13 = <Text>Claude may use instructions, code, or files from this Skill.</Text>;
+    t13 = <Text>{PRODUCT_DISPLAY_NAME} may use instructions, code, or files from this Skill.</Text>;
     $[33] = t13;
   } else {
     t13 = $[33];

--- a/src/components/permissions/WebFetchPermissionRequest/WebFetchPermissionRequest.tsx
+++ b/src/components/permissions/WebFetchPermissionRequest/WebFetchPermissionRequest.tsx
@@ -1,5 +1,6 @@
 import { c as _c } from "react-compiler-runtime";
 import React, { useMemo } from 'react';
+import { PRODUCT_DISPLAY_NAME } from '../../../constants/product.js';
 import { Box, Text, useTheme } from '../../../ink.js';
 import { WebFetchTool } from '../../../tools/WebFetchTool/WebFetchTool.js';
 import { shouldShowAlwaysAllowOptions } from '../../../utils/permissions/permissionsLoader.js';
@@ -101,7 +102,7 @@ export function WebFetchPermissionRequest(t0) {
     let t5;
     if ($[9] === Symbol.for("react.memo_cache_sentinel")) {
       t5 = {
-        label: <Text>No, and tell Claude what to do differently <Text bold={true}>(esc)</Text></Text>,
+        label: <Text>No, and tell {PRODUCT_DISPLAY_NAME} what to do differently <Text bold={true}>(esc)</Text></Text>,
         value: "no"
       };
       $[9] = t5;
@@ -211,7 +212,7 @@ export function WebFetchPermissionRequest(t0) {
   }
   let t11;
   if ($[27] === Symbol.for("react.memo_cache_sentinel")) {
-    t11 = <Text>Do you want to allow Claude to fetch this content?</Text>;
+    t11 = <Text>Do you want to allow {PRODUCT_DISPLAY_NAME} to fetch this content?</Text>;
     $[27] = t11;
   } else {
     t11 = $[27];

--- a/src/components/permissions/rules/AddWorkspaceDirectory.tsx
+++ b/src/components/permissions/rules/AddWorkspaceDirectory.tsx
@@ -5,6 +5,7 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useDebounceCallback } from 'usehooks-ts';
 import { addDirHelpMessage, validateDirectoryForWorkspace } from '../../../commands/add-dir/validation.js';
 import TextInput from '../../../components/TextInput.js';
+import { PRODUCT_DISPLAY_NAME } from '../../../constants/product.js';
 import type { KeyboardEvent } from '../../../ink/events/keyboard-event.js';
 import { Box, Text } from '../../../ink.js';
 import { useKeybinding } from '../../../keybindings/useKeybinding.js';
@@ -40,7 +41,7 @@ function PermissionDescription() {
   const $ = _c(1);
   let t0;
   if ($[0] === Symbol.for("react.memo_cache_sentinel")) {
-    t0 = <Text dimColor={true}>OpenClaude will be able to read files in this directory and make edits when auto-accept edits is on.</Text>;
+    t0 = <Text dimColor={true}>{PRODUCT_DISPLAY_NAME} will be able to read files in this directory and make edits when auto-accept edits is on.</Text>;
     $[0] = t0;
   } else {
     t0 = $[0];

--- a/src/components/permissions/rules/PermissionRuleList.tsx
+++ b/src/components/permissions/rules/PermissionRuleList.tsx
@@ -8,6 +8,7 @@ import { applyPermissionUpdate, persistPermissionUpdate } from 'src/utils/permis
 import type { PermissionUpdateDestination } from 'src/utils/permissions/PermissionUpdateSchema.js';
 import type { CommandResultDisplay } from '../../../commands.js';
 import { Select } from '../../../components/CustomSelect/select.js';
+import { PRODUCT_DISPLAY_NAME } from '../../../constants/product.js';
 import { useExitOnCtrlCDWithKeybindings } from '../../../hooks/useExitOnCtrlCDWithKeybindings.js';
 import { useSearchInput } from '../../../hooks/useSearchInput.js';
 import type { KeyboardEvent } from '../../../ink/events/keyboard-event.js';
@@ -388,9 +389,9 @@ function PermissionRulesTab(t0) {
     let t8;
     if ($[10] === Symbol.for("react.memo_cache_sentinel")) {
       t8 = {
-        allow: "OpenClaude won't ask before using allowed tools.",
-        ask: "OpenClaude will always ask for confirmation before using these tools.",
-        deny: "OpenClaude will always reject requests to use denied tools."
+        allow: `${PRODUCT_DISPLAY_NAME} won't ask before using allowed tools.`,
+        ask: `${PRODUCT_DISPLAY_NAME} will always ask for confirmation before using these tools.`,
+        deny: `${PRODUCT_DISPLAY_NAME} will always reject requests to use denied tools.`
       };
       $[10] = t8;
     } else {
@@ -1098,7 +1099,7 @@ export function PermissionRuleList(t0) {
   }
   let t28;
   if ($[89] === Symbol.for("react.memo_cache_sentinel")) {
-    t28 = <Text>OpenClaude can read files in the workspace, and make edits when auto-accept edits is on.</Text>;
+    t28 = <Text>{PRODUCT_DISPLAY_NAME} can read files in the workspace, and make edits when auto-accept edits is on.</Text>;
     $[89] = t28;
   } else {
     t28 = $[89];

--- a/src/components/permissions/rules/RemoveWorkspaceDirectory.tsx
+++ b/src/components/permissions/rules/RemoveWorkspaceDirectory.tsx
@@ -2,6 +2,7 @@ import { c as _c } from "react-compiler-runtime";
 import * as React from 'react';
 import { useCallback } from 'react';
 import { Select } from '../../../components/CustomSelect/select.js';
+import { PRODUCT_DISPLAY_NAME } from '../../../constants/product.js';
 import { Box, Text } from '../../../ink.js';
 import type { ToolPermissionContext } from '../../../Tool.js';
 import { applyPermissionUpdate } from '../../../utils/permissions/PermissionUpdate.js';
@@ -68,7 +69,7 @@ export function RemoveWorkspaceDirectory(t0) {
   }
   let t4;
   if ($[10] === Symbol.for("react.memo_cache_sentinel")) {
-    t4 = <Text>OpenClaude will no longer have access to files in this directory.</Text>;
+    t4 = <Text>{PRODUCT_DISPLAY_NAME} will no longer have access to files in this directory.</Text>;
     $[10] = t4;
   } else {
     t4 = $[10];

--- a/src/constants/product.ts
+++ b/src/constants/product.ts
@@ -1,3 +1,4 @@
+export const PRODUCT_DISPLAY_NAME = 'OpenClaude'
 export const PRODUCT_URL = 'https://claude.com/claude-code'
 
 // Claude Code Remote session URLs

--- a/src/constants/system.ts
+++ b/src/constants/system.ts
@@ -6,13 +6,14 @@ import { logForDebugging } from '../utils/debug.js'
 import { isEnvDefinedFalsy } from '../utils/envUtils.js'
 import { getAPIProvider } from '../utils/model/providers.js'
 import { getWorkload } from '../utils/workloadContext.js'
+import { PRODUCT_DISPLAY_NAME } from './product.js'
 
 const DEFAULT_PREFIX =
-  `You are OpenClaude, an open-source coding agent and CLI.`
+  `You are ${PRODUCT_DISPLAY_NAME}, an open-source coding agent and CLI.`
 const AGENT_SDK_CLAUDE_CODE_PRESET_PREFIX =
-  `You are OpenClaude, an open-source coding agent and CLI running within the Claude Agent SDK.`
+  `You are ${PRODUCT_DISPLAY_NAME}, an open-source coding agent and CLI running within the Claude Agent SDK.`
 const AGENT_SDK_PREFIX =
-  `You are OpenClaude, built on the Claude Agent SDK.`
+  `You are ${PRODUCT_DISPLAY_NAME}, built on the Claude Agent SDK.`
 
 const CLI_SYSPROMPT_PREFIX_VALUES = [
   DEFAULT_PREFIX,

--- a/src/tools/AskUserQuestionTool/AskUserQuestionTool.tsx
+++ b/src/tools/AskUserQuestionTool/AskUserQuestionTool.tsx
@@ -4,6 +4,7 @@ import * as React from 'react';
 import { getAllowedChannels, getQuestionPreviewFormat } from 'src/bootstrap/state.js';
 import { MessageResponse } from 'src/components/MessageResponse.js';
 import { BLACK_CIRCLE } from 'src/constants/figures.js';
+import { PRODUCT_DISPLAY_NAME } from 'src/constants/product.js';
 import { getModeColor } from 'src/utils/permissions/PermissionMode.js';
 import { z } from 'zod/v4';
 import { Box, Text } from '../../ink.js';
@@ -87,7 +88,7 @@ function AskUserQuestionResultMessage(t0) {
   } = t0;
   let t1;
   if ($[0] === Symbol.for("react.memo_cache_sentinel")) {
-    t1 = <Box flexDirection="row"><Text color={getModeColor("default")}>{BLACK_CIRCLE} </Text><Text>User answered Claude's questions:</Text></Box>;
+    t1 = <Box flexDirection="row"><Text color={getModeColor("default")}>{BLACK_CIRCLE} </Text><Text>User answered {PRODUCT_DISPLAY_NAME}&apos;s questions:</Text></Box>;
     $[0] = t1;
   } else {
     t1 = $[0];

--- a/src/tools/BashTool/BashToolResultMessage.tsx
+++ b/src/tools/BashTool/BashToolResultMessage.tsx
@@ -4,6 +4,7 @@ import { removeSandboxViolationTags } from 'src/utils/sandbox/sandbox-ui-utils.j
 import FullWidthRow from '../../components/design-system/FullWidthRow.js';
 import { KeyboardShortcutHint } from '../../components/design-system/KeyboardShortcutHint.js';
 import { MessageResponse } from '../../components/MessageResponse.js';
+import { PRODUCT_DISPLAY_NAME } from '../../constants/product.js';
 import { OutputLine } from '../../components/shell/OutputLine.js';
 import { ShellTimeDisplay } from '../../components/shell/ShellTimeDisplay.js';
 import { Box, Text } from '../../ink.js';
@@ -101,7 +102,7 @@ export default function BashToolResultMessage(t0) {
       if (isImage) {
         let t8;
         if ($[11] === Symbol.for("react.memo_cache_sentinel")) {
-          t8 = <MessageResponse height={1}><FullWidthRow><Text dimColor={true}>[Image data detected and sent to Claude]</Text></FullWidthRow></MessageResponse>;
+          t8 = <MessageResponse height={1}><FullWidthRow><Text dimColor={true}>[Image data detected and sent to {PRODUCT_DISPLAY_NAME}]</Text></FullWidthRow></MessageResponse>;
           $[11] = t8;
         } else {
           t8 = $[11];

--- a/src/tools/EnterPlanModeTool/UI.tsx
+++ b/src/tools/EnterPlanModeTool/UI.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { BLACK_CIRCLE } from 'src/constants/figures.js';
+import { PRODUCT_DISPLAY_NAME } from 'src/constants/product.js';
 import { getModeColor } from 'src/utils/permissions/PermissionMode.js';
 import { Box, Text } from '../../ink.js';
 import type { ToolProgressData } from '../../Tool.js';
@@ -19,7 +20,7 @@ export function renderToolResultMessage(_output: Output, _progressMessagesForMes
       </Box>
       <Box paddingLeft={2}>
         <Text dimColor>
-          Claude is now exploring and designing an implementation approach.
+          {PRODUCT_DISPLAY_NAME} is now exploring and designing an implementation approach.
         </Text>
       </Box>
     </Box>;

--- a/src/tools/PowerShellTool/UI.tsx
+++ b/src/tools/PowerShellTool/UI.tsx
@@ -3,6 +3,7 @@ import * as React from 'react';
 import { KeyboardShortcutHint } from '../../components/design-system/KeyboardShortcutHint.js';
 import { FallbackToolUseErrorMessage } from '../../components/FallbackToolUseErrorMessage.js';
 import { MessageResponse } from '../../components/MessageResponse.js';
+import { PRODUCT_DISPLAY_NAME } from '../../constants/product.js';
 import { OutputLine } from '../../components/shell/OutputLine.js';
 import { ShellProgressMessage } from '../../components/shell/ShellProgressMessage.js';
 import { ShellTimeDisplay } from '../../components/shell/ShellTimeDisplay.js';
@@ -98,7 +99,7 @@ export function renderToolResultMessage(content: Out, progressMessagesForMessage
   } = content;
   if (isImage) {
     return <MessageResponse height={1}>
-        <Text dimColor>[Image data detected and sent to Claude]</Text>
+        <Text dimColor>[Image data detected and sent to {PRODUCT_DISPLAY_NAME}]</Text>
       </MessageResponse>;
   }
   return <Box flexDirection="column">

--- a/src/tools/WebFetchTool/WebFetchTool.ts
+++ b/src/tools/WebFetchTool/WebFetchTool.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod/v4'
+import { PRODUCT_DISPLAY_NAME } from '../../constants/product.js'
 import { buildTool, type ToolDef } from '../../Tool.js'
 import type { PermissionUpdate } from '../../types/permissions.js'
 import { formatFileSize } from '../../utils/format.js'
@@ -88,9 +89,9 @@ export const WebFetchTool = buildTool({
     const { url } = input as { url: string }
     try {
       const hostname = new URL(url).hostname
-      return `Claude wants to fetch content from ${hostname}`
+      return `${PRODUCT_DISPLAY_NAME} wants to fetch content from ${hostname}`
     } catch {
-      return `Claude wants to fetch content from this URL`
+      return `${PRODUCT_DISPLAY_NAME} wants to fetch content from this URL`
     }
   },
   userFacingName() {
@@ -162,7 +163,7 @@ export const WebFetchTool = buildTool({
     if (askRule) {
       return {
         behavior: 'ask',
-        message: `Claude requested permissions to use ${WebFetchTool.name}, but you haven't granted it yet.`,
+        message: `${PRODUCT_DISPLAY_NAME} requested permissions to use ${WebFetchTool.name}, but you haven't granted it yet.`,
         decisionReason: {
           type: 'rule',
           rule: askRule,
@@ -189,7 +190,7 @@ export const WebFetchTool = buildTool({
 
     return {
       behavior: 'ask',
-      message: `Claude requested permissions to use ${WebFetchTool.name}, but you haven't granted it yet.`,
+      message: `${PRODUCT_DISPLAY_NAME} requested permissions to use ${WebFetchTool.name}, but you haven't granted it yet.`,
       suggestions: buildSuggestions(ruleContent),
     }
   },

--- a/src/tools/WebSearchTool/WebSearchTool.ts
+++ b/src/tools/WebSearchTool/WebSearchTool.ts
@@ -2,6 +2,7 @@ import type {
   BetaContentBlock,
   BetaWebSearchTool20250305,
 } from '@anthropic-ai/sdk/resources/beta/messages/messages.mjs'
+import { PRODUCT_DISPLAY_NAME } from 'src/constants/product.js'
 import { getAPIProvider } from 'src/utils/model/providers.js'
 import type { PermissionResult } from 'src/utils/permissions/PermissionResult.js'
 
@@ -556,7 +557,7 @@ export const WebSearchTool = buildTool({
   maxResultSizeChars: 100_000,
   shouldDefer: true,
   async description(input) {
-    return `Claude wants to search the web for: ${input.query}`
+    return `${PRODUCT_DISPLAY_NAME} wants to search the web for: ${input.query}`
   },
   userFacingName() {
     return 'Web Search'

--- a/src/utils/permissions/filesystem.ts
+++ b/src/utils/permissions/filesystem.ts
@@ -13,6 +13,7 @@ import {
 } from 'src/tools/FileEditTool/constants.js'
 import type { z } from 'zod/v4'
 import { getOriginalCwd, getSessionId } from '../../bootstrap/state.js'
+import { PRODUCT_DISPLAY_NAME } from '../../constants/product.js'
 import { checkStatsigFeatureGate_CACHED_MAY_BE_STALE } from '../../services/analytics/growthbook.js'
 import type { AnyObject, Tool, ToolPermissionContext } from '../../Tool.js'
 import { FILE_READ_TOOL_NAME } from '../../tools/FileReadTool/prompt.js'
@@ -642,7 +643,7 @@ export function checkPathSafetyForAutoEdit(
     if (hasSuspiciousWindowsPathPattern(pathToCheck)) {
       return {
         safe: false,
-        message: `Claude requested permissions to write to ${path}, which contains a suspicious Windows path pattern that requires manual approval.`,
+        message: `${PRODUCT_DISPLAY_NAME} requested permissions to write to ${path}, which contains a suspicious Windows path pattern that requires manual approval.`,
         classifierApprovable: false,
       }
     }
@@ -653,7 +654,7 @@ export function checkPathSafetyForAutoEdit(
     if (isClaudeConfigFilePath(pathToCheck)) {
       return {
         safe: false,
-        message: `Claude requested permissions to write to ${path}, but you haven't granted it yet.`,
+        message: `${PRODUCT_DISPLAY_NAME} requested permissions to write to ${path}, but you haven't granted it yet.`,
         classifierApprovable: true,
       }
     }
@@ -664,7 +665,7 @@ export function checkPathSafetyForAutoEdit(
     if (isDangerousFilePathToAutoEdit(pathToCheck)) {
       return {
         safe: false,
-        message: `Claude requested permissions to edit ${path} which is a sensitive file.`,
+        message: `${PRODUCT_DISPLAY_NAME} requested permissions to edit ${path} which is a sensitive file.`,
         classifierApprovable: true,
       }
     }
@@ -1045,7 +1046,7 @@ export function checkReadPermissionForTool(
   if (typeof tool.getPath !== 'function') {
     return {
       behavior: 'ask',
-      message: `Claude requested permissions to use ${tool.name}, but you haven't granted it yet.`,
+      message: `${PRODUCT_DISPLAY_NAME} requested permissions to use ${tool.name}, but you haven't granted it yet.`,
     }
   }
   const path = tool.getPath(input)
@@ -1064,7 +1065,7 @@ export function checkReadPermissionForTool(
     if (pathToCheck.startsWith('\\\\') || pathToCheck.startsWith('//')) {
       return {
         behavior: 'ask',
-        message: `Claude requested permissions to read from ${path}, which appears to be a UNC path that could access network resources.`,
+        message: `${PRODUCT_DISPLAY_NAME} requested permissions to read from ${path}, which appears to be a UNC path that could access network resources.`,
         decisionReason: {
           type: 'other',
           reason: 'UNC path detected (defense-in-depth check)',
@@ -1078,7 +1079,7 @@ export function checkReadPermissionForTool(
     if (hasSuspiciousWindowsPathPattern(pathToCheck)) {
       return {
         behavior: 'ask',
-        message: `Claude requested permissions to read from ${path}, which contains a suspicious Windows path pattern that requires manual approval.`,
+        message: `${PRODUCT_DISPLAY_NAME} requested permissions to read from ${path}, which contains a suspicious Windows path pattern that requires manual approval.`,
         decisionReason: {
           type: 'other',
           reason:
@@ -1122,7 +1123,7 @@ export function checkReadPermissionForTool(
     if (askRule) {
       return {
         behavior: 'ask',
-        message: `Claude requested permissions to read from ${path}, but you haven't granted it yet.`,
+        message: `${PRODUCT_DISPLAY_NAME} requested permissions to read from ${path}, but you haven't granted it yet.`,
         decisionReason: {
           type: 'rule',
           rule: askRule,
@@ -1189,7 +1190,7 @@ export function checkReadPermissionForTool(
   // At this point, isInWorkingDir is false (from step #6), so path is outside working directories
   return {
     behavior: 'ask',
-    message: `Claude requested permissions to read from ${path}, but you haven't granted it yet.`,
+    message: `${PRODUCT_DISPLAY_NAME} requested permissions to read from ${path}, but you haven't granted it yet.`,
     suggestions: generateSuggestions(
       path,
       'read',
@@ -1221,7 +1222,7 @@ export function checkWritePermissionForTool<Input extends AnyObject>(
   if (typeof tool.getPath !== 'function') {
     return {
       behavior: 'ask',
-      message: `Claude requested permissions to use ${tool.name}, but you haven't granted it yet.`,
+      message: `${PRODUCT_DISPLAY_NAME} requested permissions to use ${tool.name}, but you haven't granted it yet.`,
     }
   }
   const path = tool.getPath(input)
@@ -1358,7 +1359,7 @@ export function checkWritePermissionForTool<Input extends AnyObject>(
     if (askRule) {
       return {
         behavior: 'ask',
-        message: `Claude requested permissions to write to ${path}, but you haven't granted it yet.`,
+        message: `${PRODUCT_DISPLAY_NAME} requested permissions to write to ${path}, but you haven't granted it yet.`,
         decisionReason: {
           type: 'rule',
           rule: askRule,
@@ -1405,7 +1406,7 @@ export function checkWritePermissionForTool<Input extends AnyObject>(
   // 5. Default to asking for permission
   return {
     behavior: 'ask',
-    message: `Claude requested permissions to write to ${path}, but you haven't granted it yet.`,
+    message: `${PRODUCT_DISPLAY_NAME} requested permissions to write to ${path}, but you haven't granted it yet.`,
     suggestions: generateSuggestions(
       path,
       'write',

--- a/src/utils/permissions/permissions.ts
+++ b/src/utils/permissions/permissions.ts
@@ -1,5 +1,6 @@
 import { feature } from 'bun:bundle'
 import { APIUserAbortError } from '@anthropic-ai/sdk'
+import { PRODUCT_DISPLAY_NAME } from '../../constants/product.js'
 import type { CanUseToolFn } from '../../hooks/useCanUseTool.js'
 import {
   getToolNameForPermissionCheck,
@@ -205,7 +206,7 @@ export function createPermissionRequestMessage(
   }
 
   // Default message without listing allowed commands
-  const message = `Claude requested permissions to use ${toolName}, but you haven't granted it yet.`
+  const message = `${PRODUCT_DISPLAY_NAME} requested permissions to use ${toolName}, but you haven't granted it yet.`
 
   return message
 }


### PR DESCRIPTION
This PR continues the Claude-to-OpenClaude branding cleanup by centralizing the product display name and replacing scattered user-facing hard-coded references with the shared value.

## What Changed

- Added `PRODUCT_DISPLAY_NAME = 'OpenClaude'` in `src/constants/product.ts`.
- Updated prompt identity and CLI-facing system copy to use the shared product display name.
- Replaced user-facing `Claude`, `Claude's`, and hard-coded `OpenClaude` references across:
  - onboarding
  - permission prompts and permission dialogs
  - plan-mode approval copy
  - hook configuration UI
  - agent creation and agent detail UI
  - web fetch/search and filesystem permission messages
- Simplified onboarding security copy:
  - changed `Security notes:` to `Security note:`
  - removed numbering since only one note remains
  - removed the prompt-injection security note
  - updated the remaining note to say `OpenClaude can make mistakes`

## Notes

I intentionally left references alone where they refer to specific external products, APIs, SDKs, docs, or compatibility surfaces, such as Claude API, Claude Agent SDK, Claude Desktop, Claude.ai, Claude Code docs, and `.claude` paths.

## Testing

- Ran `bun test src/constants/promptIdentity.test.ts`
  - 4 tests passed
  - 0 failures
- Ran `git diff --check`
  - no whitespace errors reported
  - only existing CRLF working-copy warnings were shown