### PR TITLE
feat(integrations): add descriptor-scoped model catalog helpers

### DIFF
--- a/src/integrations/modelCatalog/catalog.test.ts
+++ b/src/integrations/modelCatalog/catalog.test.ts
@@ -1,0 +1,320 @@
+import { afterAll, beforeEach, describe, expect, test } from 'bun:test'
+
+import type {
+  AnthropicProxyDescriptor,
+  GatewayDescriptor,
+  ModelDescriptor,
+  VendorDescriptor,
+} from '../descriptors.js'
+import { ensureIntegrationsLoaded } from '../index.js'
+import {
+  _clearRegistryForTesting,
+  registerAnthropicProxy,
+  registerGateway,
+  registerModel,
+  registerVendor,
+} from '../registry.js'
+import {
+  findRouteCatalogEntry,
+  getRouteCatalogEntries,
+  getRouteModelCatalog,
+  resolveRouteCatalogEntry,
+  resolveRouteCatalogModelMetadata,
+} from './catalog.js'
+
+beforeEach(() => {
+  _clearRegistryForTesting()
+})
+
+afterAll(() => {
+  _clearRegistryForTesting()
+  ensureIntegrationsLoaded()
+})
+
+function makeVendor(
+  id: string,
+  overrides?: Partial<VendorDescriptor>,
+): VendorDescriptor {
+  return {
+    id,
+    label: id,
+    classification: 'openai-compatible',
+    defaultBaseUrl: 'https://example.com/v1',
+    defaultModel: 'model-a',
+    setup: { requiresAuth: true, authMode: 'api-key' },
+    transportConfig: { kind: 'openai-compatible' },
+    ...overrides,
+  }
+}
+
+function makeGateway(
+  id: string,
+  overrides?: Partial<GatewayDescriptor>,
+): GatewayDescriptor {
+  return {
+    id,
+    label: id,
+    setup: { requiresAuth: true, authMode: 'api-key' },
+    transportConfig: { kind: 'openai-compatible' },
+    ...overrides,
+  }
+}
+
+function makeAnthropicProxy(
+  id: string,
+  overrides?: Partial<AnthropicProxyDescriptor>,
+): AnthropicProxyDescriptor {
+  return {
+    id,
+    label: id,
+    classification: 'anthropic-proxy',
+    defaultBaseUrl: 'https://proxy.example.com',
+    defaultModel: 'claude-sonnet',
+    setup: { requiresAuth: true, authMode: 'api-key' },
+    envVarConfig: {
+      authTokenEnvVar: 'PROXY_API_KEY',
+      baseUrlEnvVar: 'PROXY_BASE_URL',
+    },
+    capabilities: {},
+    transportConfig: { kind: 'anthropic-proxy' },
+    ...overrides,
+  }
+}
+
+function makeModel(
+  id: string,
+  overrides?: Partial<ModelDescriptor>,
+): ModelDescriptor {
+  return {
+    id,
+    label: id,
+    vendorId: 'openai',
+    classification: ['chat'],
+    defaultModel: id,
+    capabilities: {},
+    ...overrides,
+  }
+}
+
+describe('route-scoped model catalog helpers', () => {
+  test('reads catalog data from the route descriptor', () => {
+    registerVendor(
+      makeVendor('acme', {
+        catalog: {
+          source: 'static',
+          models: [{ id: 'acme-model', apiName: 'acme/model' }],
+        },
+      }),
+    )
+
+    expect(getRouteModelCatalog('acme')?.source).toBe('static')
+    expect(getRouteCatalogEntries('acme')).toEqual([
+      { id: 'acme-model', apiName: 'acme/model' },
+    ])
+  })
+
+  test('finds entries by route-local id and apiName', () => {
+    registerGateway(
+      makeGateway('gw-a', {
+        catalog: {
+          source: 'static',
+          models: [{ id: 'entry-a', apiName: 'provider/model-a' }],
+        },
+      }),
+    )
+
+    expect(findRouteCatalogEntry('gw-a', 'entry-a')?.apiName).toBe(
+      'provider/model-a',
+    )
+    expect(findRouteCatalogEntry('gw-a', 'provider/model-a')?.id).toBe(
+      'entry-a',
+    )
+  })
+
+  test('keeps duplicate model names isolated across routes', () => {
+    registerGateway(
+      makeGateway('route-a', {
+        catalog: {
+          source: 'static',
+          models: [{ id: 'shared-id', apiName: 'same-api-name' }],
+        },
+      }),
+    )
+    registerGateway(
+      makeGateway('route-b', {
+        catalog: {
+          source: 'static',
+          models: [{ id: 'shared-id', apiName: 'same-api-name' }],
+        },
+      }),
+    )
+
+    expect(resolveRouteCatalogEntry('route-a', 'same-api-name')?.routeId).toBe(
+      'route-a',
+    )
+    expect(resolveRouteCatalogEntry('route-b', 'same-api-name')?.routeId).toBe(
+      'route-b',
+    )
+    expect(findRouteCatalogEntry('missing-route', 'same-api-name')).toBeUndefined()
+  })
+
+  test('resolves modelDescriptorId and shared default model names within one route', () => {
+    registerModel(
+      makeModel('shared-model', {
+        label: 'Shared Model',
+        defaultModel: 'vendor-default-name',
+        capabilities: { supportsReasoning: true },
+        contextWindow: 128_000,
+        maxOutputTokens: 16_384,
+      }),
+    )
+    registerVendor(
+      makeVendor('vendor-a', {
+        catalog: {
+          source: 'static',
+          models: [
+            {
+              id: 'route-model',
+              apiName: 'vendor-a-model',
+              modelDescriptorId: 'shared-model',
+            },
+          ],
+        },
+      }),
+    )
+
+    const entry = resolveRouteCatalogEntry('vendor-a', 'vendor-default-name')
+
+    expect(entry?.id).toBe('route-model')
+    expect(entry?.modelDescriptor?.id).toBe('shared-model')
+  })
+
+  test('uses providerModelMap only for the requested route', () => {
+    registerModel(
+      makeModel('shared-model', {
+        defaultModel: 'global-name',
+        providerModelMap: {
+          'route-a': 'route-a-name',
+          'route-b': 'route-b-name',
+        },
+      }),
+    )
+    registerGateway(
+      makeGateway('route-a', {
+        catalog: {
+          source: 'static',
+          models: [
+            {
+              id: 'route-a-entry',
+              apiName: 'route-a-api',
+              modelDescriptorId: 'shared-model',
+            },
+          ],
+        },
+      }),
+    )
+    registerGateway(
+      makeGateway('route-b', {
+        catalog: {
+          source: 'static',
+          models: [
+            {
+              id: 'route-b-entry',
+              apiName: 'route-b-api',
+              modelDescriptorId: 'shared-model',
+            },
+          ],
+        },
+      }),
+    )
+
+    expect(findRouteCatalogEntry('route-a', 'route-a-name')?.id).toBe(
+      'route-a-entry',
+    )
+    expect(findRouteCatalogEntry('route-a', 'route-b-name')).toBeUndefined()
+    expect(findRouteCatalogEntry('route-b', 'route-b-name')?.id).toBe(
+      'route-b-entry',
+    )
+  })
+
+  test('merges shared model metadata with route entry overrides', () => {
+    registerModel(
+      makeModel('shared-model', {
+        label: 'Shared Label',
+        defaultModel: 'shared-model',
+        capabilities: {
+          supportsStreaming: true,
+          supportsReasoning: false,
+        },
+        contextWindow: 200_000,
+        maxOutputTokens: 8_192,
+      }),
+    )
+    registerGateway(
+      makeGateway('route-a', {
+        catalog: {
+          source: 'static',
+          models: [
+            {
+              id: 'route-model',
+              apiName: 'route-model-api',
+              label: 'Route Label',
+              modelDescriptorId: 'shared-model',
+              capabilities: { supportsReasoning: true },
+              contextWindow: 128_000,
+              transportOverrides: {
+                openaiShim: {
+                  maxTokensField: 'max_tokens',
+                  removeBodyFields: ['store'],
+                },
+              },
+            },
+          ],
+        },
+      }),
+    )
+
+    const metadata = resolveRouteCatalogModelMetadata('route-a', 'route-model-api')
+
+    expect(metadata).toMatchObject({
+      routeId: 'route-a',
+      id: 'route-model',
+      apiName: 'route-model-api',
+      label: 'Route Label',
+      contextWindow: 128_000,
+      maxOutputTokens: 8_192,
+      capabilities: {
+        supportsStreaming: true,
+        supportsReasoning: true,
+      },
+      transportOverrides: {
+        openaiShim: {
+          maxTokensField: 'max_tokens',
+          removeBodyFields: ['store'],
+        },
+      },
+    })
+  })
+
+  test('supports anthropic proxy route catalogs without changing transport ownership', () => {
+    registerAnthropicProxy(
+      makeAnthropicProxy('proxy-a', {
+        catalog: {
+          source: 'static',
+          models: [
+            {
+              id: 'proxy-claude',
+              apiName: 'proxy-claude-api',
+              capabilities: { supportsVision: true },
+            },
+          ],
+        },
+      }),
+    )
+
+    const metadata = resolveRouteCatalogModelMetadata('proxy-a', 'proxy-claude-api')
+
+    expect(metadata?.routeId).toBe('proxy-a')
+    expect(metadata?.capabilities.supportsVision).toBe(true)
+  })
+})

--- a/src/integrations/modelCatalog/catalog.ts
+++ b/src/integrations/modelCatalog/catalog.ts
@@ -1,0 +1,170 @@
+import { ensureIntegrationsLoaded } from '../index.js'
+import {
+  getAnthropicProxy,
+  getGateway,
+  getModel,
+  getVendor,
+} from '../registry.js'
+import type {
+  CapabilityFlags,
+  ModelCatalogConfig,
+  ModelCatalogEntry,
+  ModelDescriptor,
+  NormalizedRouteCatalogEntry,
+  RouteDescriptor,
+  RouteModelRuntimeMetadata,
+} from './types.js'
+
+export function getRouteDescriptor(
+  routeId: string,
+): RouteDescriptor | undefined {
+  ensureIntegrationsLoaded()
+  return (
+    getGateway(routeId) ??
+    getVendor(routeId) ??
+    getAnthropicProxy(routeId)
+  )
+}
+
+export function getRouteModelCatalog(
+  routeId: string,
+): ModelCatalogConfig | undefined {
+  return getRouteDescriptor(routeId)?.catalog
+}
+
+export function getRouteCatalogEntries(routeId: string): ModelCatalogEntry[] {
+  return getRouteModelCatalog(routeId)?.models ?? []
+}
+
+export function findRouteCatalogEntry(
+  routeId: string,
+  modelRef: string,
+): ModelCatalogEntry | undefined {
+  const normalizedRef = normalizeReference(modelRef)
+  if (!normalizedRef) {
+    return undefined
+  }
+
+  for (const entry of getRouteCatalogEntries(routeId)) {
+    if (
+      getEntryReferences(routeId, entry).some(
+        reference => normalizeReference(reference) === normalizedRef,
+      )
+    ) {
+      return entry
+    }
+  }
+
+  return undefined
+}
+
+export function resolveRouteCatalogEntry(
+  routeId: string,
+  modelRef: string,
+): NormalizedRouteCatalogEntry | undefined {
+  const route = getRouteDescriptor(routeId)
+  const entry = findRouteCatalogEntry(routeId, modelRef)
+  if (!route || !entry) {
+    return undefined
+  }
+
+  const modelDescriptor = entry.modelDescriptorId
+    ? getModel(entry.modelDescriptorId)
+    : undefined
+
+  return {
+    ...entry,
+    capabilities: entry.capabilities ? { ...entry.capabilities } : undefined,
+    transportOverrides: entry.transportOverrides
+      ? {
+          ...entry.transportOverrides,
+          openaiShim: entry.transportOverrides.openaiShim
+            ? { ...entry.transportOverrides.openaiShim }
+            : undefined,
+        }
+      : undefined,
+    routeId,
+    routeLabel: route.label,
+    modelDescriptor,
+  }
+}
+
+export function resolveRouteCatalogModelMetadata(
+  routeId: string,
+  modelRef: string,
+): RouteModelRuntimeMetadata | undefined {
+  const entry = resolveRouteCatalogEntry(routeId, modelRef)
+  if (!entry) {
+    return undefined
+  }
+
+  const modelDescriptor = entry.modelDescriptor
+  const capabilities = mergeCapabilities(
+    modelDescriptor?.capabilities,
+    entry.capabilities,
+  )
+
+  return {
+    routeId,
+    routeLabel: entry.routeLabel,
+    id: entry.id,
+    apiName: entry.apiName,
+    label: entry.label ?? modelDescriptor?.label ?? entry.id,
+    default: entry.default,
+    hidden: entry.hidden,
+    modelDescriptorId: entry.modelDescriptorId,
+    modelDescriptor,
+    capabilities,
+    contextWindow: entry.contextWindow ?? modelDescriptor?.contextWindow,
+    maxOutputTokens: entry.maxOutputTokens ?? modelDescriptor?.maxOutputTokens,
+    transportOverrides: entry.transportOverrides,
+    notes: entry.notes,
+  }
+}
+
+function getEntryReferences(
+  routeId: string,
+  entry: ModelCatalogEntry,
+): string[] {
+  const references = [
+    entry.id,
+    entry.apiName,
+    entry.modelDescriptorId,
+  ].filter((value): value is string => Boolean(value))
+
+  const modelDescriptor = entry.modelDescriptorId
+    ? getModel(entry.modelDescriptorId)
+    : undefined
+
+  if (modelDescriptor) {
+    references.push(
+      modelDescriptor.id,
+      modelDescriptor.defaultModel,
+      ...getRouteSpecificModelNames(routeId, modelDescriptor),
+    )
+  }
+
+  return Array.from(new Set(references))
+}
+
+function getRouteSpecificModelNames(
+  routeId: string,
+  modelDescriptor: ModelDescriptor,
+): string[] {
+  const mappedName = modelDescriptor.providerModelMap?.[routeId]
+  return mappedName ? [mappedName] : []
+}
+
+function mergeCapabilities(
+  modelCapabilities?: CapabilityFlags,
+  routeCapabilities?: CapabilityFlags,
+): CapabilityFlags {
+  return {
+    ...(modelCapabilities ?? {}),
+    ...(routeCapabilities ?? {}),
+  }
+}
+
+function normalizeReference(value: string): string {
+  return value.trim().toLowerCase()
+}

--- a/src/integrations/modelCatalog/schema.json
+++ b/src/integrations/modelCatalog/schema.json
@@ -1,0 +1,223 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://openclaude.local/schemas/modelCatalogConfig.schema.json",
+  "title": "ModelCatalogConfig",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["source"],
+  "properties": {
+    "source": {
+      "enum": ["static", "dynamic", "hybrid"]
+    },
+    "discovery": {
+      "$ref": "#/$defs/ModelDiscoveryConfig"
+    },
+    "discoveryCacheTtl": {
+      "oneOf": [
+        {
+          "type": "number",
+          "minimum": 0
+        },
+        {
+          "type": "string",
+          "pattern": "^[0-9]+[mhd]$"
+        }
+      ]
+    },
+    "discoveryRefreshMode": {
+      "enum": ["manual", "on-open", "background-if-stale", "startup"]
+    },
+    "allowManualRefresh": {
+      "type": "boolean"
+    },
+    "models": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/ModelCatalogEntry"
+      }
+    }
+  },
+  "$defs": {
+    "ModelDiscoveryConfig": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["kind"],
+      "properties": {
+        "kind": {
+          "enum": ["openai-compatible", "ollama", "custom"]
+        },
+        "requiresAuth": {
+          "type": "boolean"
+        },
+        "path": {
+          "type": "string"
+        },
+        "parse": {
+          "enum": ["openai-models-list", "ollama-tags", "custom"]
+        },
+        "mapModel": {}
+      }
+    },
+    "ModelCatalogEntry": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "apiName"],
+      "properties": {
+        "id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "apiName": {
+          "type": "string",
+          "minLength": 1
+        },
+        "label": {
+          "type": "string"
+        },
+        "default": {
+          "type": "boolean"
+        },
+        "hidden": {
+          "type": "boolean"
+        },
+        "modelDescriptorId": {
+          "type": "string",
+          "minLength": 1
+        },
+        "capabilities": {
+          "$ref": "#/$defs/CapabilityFlags"
+        },
+        "contextWindow": {
+          "type": "number",
+          "exclusiveMinimum": 0
+        },
+        "maxOutputTokens": {
+          "type": "number",
+          "exclusiveMinimum": 0
+        },
+        "transportOverrides": {
+          "$ref": "#/$defs/CatalogTransportOverrides"
+        },
+        "notes": {
+          "type": "string"
+        }
+      }
+    },
+    "CapabilityFlags": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "supportsVision": {
+          "type": "boolean"
+        },
+        "supportsStreaming": {
+          "type": "boolean"
+        },
+        "supportsFunctionCalling": {
+          "type": "boolean"
+        },
+        "supportsJsonMode": {
+          "type": "boolean"
+        },
+        "supportsReasoning": {
+          "type": "boolean"
+        },
+        "supportsPreciseTokenCount": {
+          "type": "boolean"
+        },
+        "supportsEmbeddings": {
+          "type": "boolean"
+        }
+      }
+    },
+    "CatalogTransportOverrides": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "openaiShim": {
+          "$ref": "#/$defs/OpenAIShimTransportConfig"
+        }
+      }
+    },
+    "OpenAIShimTransportConfig": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "headers": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "supportsApiFormatSelection": {
+          "type": "boolean"
+        },
+        "supportsAuthHeaders": {
+          "type": "boolean"
+        },
+        "ui": {
+          "$ref": "#/$defs/OpenAIShimUiConfig"
+        },
+        "defaultAuthHeader": {
+          "$ref": "#/$defs/OpenAIShimAuthHeaderConfig"
+        },
+        "responsesApiModelPrefixes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "preserveReasoningContent": {
+          "type": "boolean"
+        },
+        "requireReasoningContentOnAssistantMessages": {
+          "type": "boolean"
+        },
+        "reasoningContentFallback": {
+          "enum": ["", "omit"]
+        },
+        "thinkingRequestFormat": {
+          "enum": ["none", "deepseek-compatible"]
+        },
+        "maxTokensField": {
+          "enum": ["max_tokens", "max_completion_tokens"]
+        },
+        "removeBodyFields": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "OpenAIShimAuthHeaderConfig": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name"],
+      "properties": {
+        "name": {
+          "type": "string",
+          "minLength": 1
+        },
+        "scheme": {
+          "enum": ["bearer", "raw"]
+        }
+      }
+    },
+    "OpenAIShimUiConfig": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "showAuthHeader": {
+          "type": "boolean"
+        },
+        "showAuthHeaderValue": {
+          "type": "boolean"
+        },
+        "showCustomHeaders": {
+          "type": "boolean"
+        }
+      }
+    }
+  }
+}

--- a/src/integrations/modelCatalog/schema.test.ts
+++ b/src/integrations/modelCatalog/schema.test.ts
@@ -1,0 +1,198 @@
+import { describe, expect, test } from 'bun:test'
+
+import type { ModelCatalogConfig } from './types.js'
+import { validateModelCatalogConfig } from './schema.js'
+
+describe('validateModelCatalogConfig', () => {
+  test('accepts a descriptor-era static catalog', () => {
+    const catalog: ModelCatalogConfig = {
+      source: 'static',
+      models: [
+        {
+          id: 'gpt-5.4',
+          apiName: 'gpt-5.4',
+          label: 'GPT-5.4',
+          modelDescriptorId: 'gpt-5.4',
+          capabilities: { supportsReasoning: true },
+          contextWindow: 1_050_000,
+          maxOutputTokens: 128_000,
+        },
+      ],
+    }
+
+    const result = validateModelCatalogConfig(catalog, {
+      routeId: 'openai',
+      knownModelIds: ['gpt-5.4'],
+    })
+
+    expect(result).toEqual({ valid: true, errors: [] })
+  })
+
+  test('rejects invalid catalog source values', () => {
+    const result = validateModelCatalogConfig({
+      source: 'provider-json',
+      models: [],
+    })
+
+    expect(result.valid).toBe(false)
+    expect(result.errors.some(error => error.includes('/source'))).toBe(true)
+  })
+
+  test('rejects catalog entries without apiName', () => {
+    const result = validateModelCatalogConfig({
+      source: 'static',
+      models: [{ id: 'missing-api-name' }],
+    })
+
+    expect(result.valid).toBe(false)
+    expect(result.errors.some(error => error.includes('apiName'))).toBe(true)
+  })
+
+  test('rejects duplicate ids and api names within one route only', () => {
+    const result = validateModelCatalogConfig(
+      {
+        source: 'static',
+        models: [
+          { id: 'model-a', apiName: 'provider/model-a' },
+          { id: 'MODEL-A', apiName: 'provider/model-b' },
+          { id: 'model-c', apiName: 'Provider/Model-A' },
+        ],
+      },
+      { routeId: 'openrouter' },
+    )
+
+    expect(result.valid).toBe(false)
+    expect(result.errors).toContain(
+      'Duplicate catalog entry id "MODEL-A" in route "openrouter"; first used by "model-a"',
+    )
+    expect(result.errors).toContain(
+      'Duplicate catalog apiName "Provider/Model-A" in route "openrouter"; first used by "model-a"',
+    )
+  })
+
+  test('rejects unknown modelDescriptorId when known ids are supplied', () => {
+    const result = validateModelCatalogConfig(
+      {
+        source: 'static',
+        models: [
+          {
+            id: 'route-model',
+            apiName: 'route-model',
+            modelDescriptorId: 'missing-model',
+          },
+        ],
+      },
+      { routeId: 'acme', knownModelIds: ['known-model'] },
+    )
+
+    expect(result.valid).toBe(false)
+    expect(result.errors).toContain(
+      'Catalog entry "route-model" in route "acme" references missing model descriptor "missing-model"',
+    )
+  })
+
+  test('accepts discovery mapModel functions through runtime validation', () => {
+    const catalog: ModelCatalogConfig = {
+      source: 'dynamic',
+      discovery: {
+        kind: 'custom',
+        mapModel: raw => {
+          if (typeof raw !== 'object' || raw === null) {
+            return null
+          }
+          return { id: 'dynamic-model', apiName: 'dynamic-model' }
+        },
+      },
+    }
+
+    const result = validateModelCatalogConfig(catalog)
+
+    expect(result).toEqual({ valid: true, errors: [] })
+  })
+
+  test('rejects unsupported top-level function properties', () => {
+    const result = validateModelCatalogConfig({
+      source: 'static',
+      unexpected: () => 'x',
+      models: [],
+    })
+
+    expect(result.valid).toBe(false)
+    expect(
+      result.errors.some(error =>
+        error.includes('/ has unsupported property "unexpected"'),
+      ),
+    ).toBe(true)
+  })
+
+  test('rejects unsupported nested function properties under discovery', () => {
+    const result = validateModelCatalogConfig({
+      source: 'dynamic',
+      discovery: {
+        kind: 'custom',
+        unexpected: () => 'x',
+      },
+    })
+
+    expect(result.valid).toBe(false)
+    expect(
+      result.errors.some(error =>
+        error.includes('/discovery has unsupported property "unexpected"'),
+      ),
+    ).toBe(true)
+  })
+
+  test('rejects function values on non-function catalog fields', () => {
+    const result = validateModelCatalogConfig({
+      source: 'dynamic',
+      discovery: {
+        kind: 'custom',
+        path: () => '/models',
+      },
+    })
+
+    expect(result.valid).toBe(false)
+    expect(
+      result.errors.some(error => error.includes('/discovery/path')),
+    ).toBe(true)
+  })
+
+  test('rejects non-function discovery mapModel values', () => {
+    const result = validateModelCatalogConfig({
+      source: 'dynamic',
+      discovery: {
+        kind: 'custom',
+        mapModel: 'not-a-function',
+      },
+    })
+
+    expect(result.valid).toBe(false)
+    expect(result.errors).toContain(
+      'Catalog discovery mapModel must be a function when provided',
+    )
+  })
+
+  test('validates transportOverrides.openaiShim shape', () => {
+    const result = validateModelCatalogConfig({
+      source: 'static',
+      models: [
+        {
+          id: 'bad-override',
+          apiName: 'bad-override',
+          transportOverrides: {
+            openaiShim: {
+              removeBodyFields: ['store', 123],
+            },
+          },
+        },
+      ],
+    })
+
+    expect(result.valid).toBe(false)
+    expect(
+      result.errors.some(error =>
+        error.includes('/models/0/transportOverrides/openaiShim/removeBodyFields/1'),
+      ),
+    ).toBe(true)
+  })
+})

--- a/src/integrations/modelCatalog/schema.ts
+++ b/src/integrations/modelCatalog/schema.ts
@@ -1,0 +1,151 @@
+import Ajv2020 from 'ajv/dist/2020.js'
+import type { ErrorObject } from 'ajv'
+
+import modelCatalogSchema from './schema.json' with { type: 'json' }
+import type {
+  ModelCatalogConfig,
+  RouteCatalogValidationOptions,
+  RouteCatalogValidationResult,
+} from './types.js'
+
+const ajv = new Ajv2020({
+  allErrors: true,
+  strict: true,
+  allowUnionTypes: true,
+})
+
+const validateCatalogShape = ajv.compile(modelCatalogSchema)
+
+export function validateModelCatalogConfig(
+  catalog: unknown,
+  options: RouteCatalogValidationOptions = {},
+): RouteCatalogValidationResult {
+  const errors: string[] = []
+
+  const shapeIsValid = validateCatalogShape(catalog)
+  if (!shapeIsValid) {
+    errors.push(...formatAjvErrors(validateCatalogShape.errors ?? []))
+  }
+
+  if (shapeIsValid && isCatalogLike(catalog)) {
+    errors.push(...validateCatalogRuntimeValues(catalog))
+
+    if (options.validateSemantics !== false) {
+      errors.push(...validateRouteCatalogSemantics(catalog, options))
+    }
+  }
+
+  return {
+    valid: errors.length === 0,
+    errors,
+  }
+}
+
+export const validateRouteCatalogConfig = validateModelCatalogConfig
+
+function validateRouteCatalogSemantics(
+  catalog: ModelCatalogConfig,
+  options: RouteCatalogValidationOptions,
+): string[] {
+  const errors: string[] = []
+  const routeLabel = options.routeId ? ` in route "${options.routeId}"` : ''
+  const seenEntryIds = new Map<string, string>()
+  const seenApiNames = new Map<string, string>()
+  const knownModelIds = options.knownModelIds
+    ? new Set(Array.from(options.knownModelIds))
+    : undefined
+  let defaultCount = 0
+
+  for (const entry of catalog.models ?? []) {
+    const entryId = entry.id.trim()
+    const apiName = entry.apiName.trim()
+
+    if (!entryId) {
+      errors.push(`Catalog entry${routeLabel} has an empty id`)
+    } else {
+      const normalizedEntryId = normalizeReference(entryId)
+      const previousEntryId = seenEntryIds.get(normalizedEntryId)
+      if (previousEntryId) {
+        errors.push(
+          `Duplicate catalog entry id "${entry.id}"${routeLabel}; first used by "${previousEntryId}"`,
+        )
+      } else {
+        seenEntryIds.set(normalizedEntryId, entry.id)
+      }
+    }
+
+    if (!apiName) {
+      errors.push(`Catalog entry "${entry.id}"${routeLabel} has an empty apiName`)
+    } else {
+      const normalizedApiName = normalizeReference(apiName)
+      const previousApiName = seenApiNames.get(normalizedApiName)
+      if (previousApiName) {
+        errors.push(
+          `Duplicate catalog apiName "${entry.apiName}"${routeLabel}; first used by "${previousApiName}"`,
+        )
+      } else {
+        seenApiNames.set(normalizedApiName, entry.id)
+      }
+    }
+
+    if (entry.default) {
+      defaultCount++
+    }
+
+    if (
+      knownModelIds &&
+      entry.modelDescriptorId &&
+      !knownModelIds.has(entry.modelDescriptorId)
+    ) {
+      errors.push(
+        `Catalog entry "${entry.id}"${routeLabel} references missing model descriptor "${entry.modelDescriptorId}"`,
+      )
+    }
+  }
+
+  if (defaultCount > 1) {
+    errors.push(`Catalog${routeLabel} has ${defaultCount} default entries`)
+  }
+
+  return errors
+}
+
+function validateCatalogRuntimeValues(catalog: ModelCatalogConfig): string[] {
+  const errors: string[] = []
+
+  if (
+    catalog.discovery &&
+    'mapModel' in catalog.discovery &&
+    catalog.discovery.mapModel !== undefined &&
+    typeof catalog.discovery.mapModel !== 'function'
+  ) {
+    errors.push('Catalog discovery mapModel must be a function when provided')
+  }
+
+  return errors
+}
+
+function isCatalogLike(value: unknown): value is ModelCatalogConfig {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    'source' in value &&
+    typeof (value as { source?: unknown }).source === 'string'
+  )
+}
+
+function formatAjvErrors(errors: ErrorObject[]): string[] {
+  return errors.map(error => {
+    const path = error.instancePath || '/'
+    const message = error.message ?? 'is invalid'
+    if (error.keyword === 'additionalProperties') {
+      const property = String(error.params.additionalProperty)
+      return `${path} has unsupported property "${property}"`
+    }
+    return `${path} ${message}`
+  })
+}
+
+function normalizeReference(value: string): string {
+  return value.trim().toLowerCase()
+}

--- a/src/integrations/modelCatalog/types.ts
+++ b/src/integrations/modelCatalog/types.ts
@@ -1,0 +1,64 @@
+import type {
+  AnthropicProxyDescriptor,
+  CapabilityFlags,
+  CatalogTransportOverrides,
+  GatewayDescriptor,
+  ModelCatalogEntry,
+  ModelDescriptor,
+  VendorDescriptor,
+} from '../descriptors.js'
+
+export type {
+  AnthropicProxyDescriptor,
+  CapabilityFlags,
+  CatalogTransportOverrides,
+  DiscoveryRefreshMode,
+  DurationString,
+  GatewayDescriptor,
+  ModelCatalogConfig,
+  ModelCatalogEntry,
+  ModelDiscoveryConfig,
+  ModelDiscoveryKind,
+  ModelDescriptor,
+  OpenAIShimTransportConfig,
+  VendorDescriptor,
+} from '../descriptors.js'
+
+export type RouteDescriptor =
+  | VendorDescriptor
+  | GatewayDescriptor
+  | AnthropicProxyDescriptor
+
+export type NormalizedRouteCatalogEntry = ModelCatalogEntry & {
+  routeId: string
+  routeLabel: string
+  modelDescriptor?: ModelDescriptor
+}
+
+export interface RouteCatalogValidationOptions {
+  routeId?: string
+  knownModelIds?: Iterable<string>
+  validateSemantics?: boolean
+}
+
+export interface RouteCatalogValidationResult {
+  valid: boolean
+  errors: string[]
+}
+
+export interface RouteModelRuntimeMetadata {
+  routeId: string
+  routeLabel: string
+  id: string
+  apiName: string
+  label: string
+  default?: boolean
+  hidden?: boolean
+  modelDescriptorId?: string
+  modelDescriptor?: ModelDescriptor
+  capabilities: CapabilityFlags
+  contextWindow?: number
+  maxOutputTokens?: number
+  transportOverrides?: CatalogTransportOverrides
+  notes?: string
+}

--- a/src/integrations/registry.test.ts
+++ b/src/integrations/registry.test.ts
@@ -10,6 +10,7 @@ import {
   getAllModels,
   getAllVendors,
   getBrand,
+  getCatalogForAnthropicProxy,
   getCatalogEntriesForRoute,
   getGateway,
   getModelsForBrand,
@@ -203,6 +204,24 @@ describe('catalog helpers', () => {
     expect(entries[0]!.id).toBe('m1')
   })
 
+  test('getCatalogEntriesForRoute returns anthropic proxy catalog models', () => {
+    registerAnthropicProxy(
+      makeAnthropicProxy('proxy-1', {
+        catalog: {
+          source: 'static',
+          models: [
+            { id: 'claude-proxy-sonnet', apiName: 'claude-sonnet' },
+          ],
+        },
+      }),
+    )
+
+    expect(getCatalogForAnthropicProxy('proxy-1')?.source).toBe('static')
+    const entries = getCatalogEntriesForRoute('proxy-1')
+    expect(entries).toHaveLength(1)
+    expect(entries[0]!.id).toBe('claude-proxy-sonnet')
+  })
+
   test('getModelsForGateway enriches with shared model descriptors', () => {
     registerGateway(
       makeGateway('gw-1', {
@@ -254,6 +273,86 @@ describe('validateIntegrationRegistry', () => {
     expect(result.errors.some(e => e.includes('missing-model'))).toBe(true)
   })
 
+  test('does not run entry semantic validation after catalog shape errors', () => {
+    registerGateway(
+      makeGateway('gw-malformed', {
+        catalog: {
+          source: 'static',
+          models: [{ id: 'e1' }],
+        } as never,
+      }),
+    )
+
+    const result = validateIntegrationRegistry()
+    expect(result.valid).toBe(false)
+    expect(result.errors.some(e => e.includes('/models/0'))).toBe(true)
+  })
+
+  test('returns schema errors instead of throwing for malformed preset catalog models', () => {
+    registerVendor(makeVendor('openai'))
+    registerGateway(
+      makeGateway('gw-malformed-preset-catalog', {
+        defaultBaseUrl: 'https://gateway.example.com/v1',
+        preset: {
+          id: 'gateway-preset',
+          description: 'Gateway preset',
+          vendorId: 'openai',
+          apiKeyEnvVars: ['GATEWAY_KEY'],
+        },
+        catalog: {
+          source: 'static',
+          models: { id: 'not-an-array' },
+        } as never,
+      }),
+    )
+
+    const result = validateIntegrationRegistry()
+    expect(result.valid).toBe(false)
+    expect(
+      result.errors.some(error =>
+        error.includes('/models') && error.includes('array'),
+      ),
+    ).toBe(true)
+  })
+
+  test('catches non-function discovery mapModel values in route catalogs', () => {
+    registerGateway(
+      makeGateway('gw-bad-map-model', {
+        catalog: {
+          source: 'dynamic',
+          discovery: { kind: 'custom', mapModel: 'not-a-function' },
+        } as never,
+      }),
+    )
+
+    const result = validateIntegrationRegistry()
+    expect(result.valid).toBe(false)
+    expect(result.errors).toContain(
+      'Catalog discovery mapModel must be a function when provided',
+    )
+  })
+
+  test('validates anthropic proxy catalog references', () => {
+    registerAnthropicProxy(
+      makeAnthropicProxy('proxy-bad', {
+        catalog: {
+          source: 'static',
+          models: [
+            {
+              id: 'e1',
+              apiName: 'claude',
+              modelDescriptorId: 'missing-proxy-model',
+            },
+          ],
+        },
+      }),
+    )
+
+    const result = validateIntegrationRegistry()
+    expect(result.valid).toBe(false)
+    expect(result.errors.some(e => e.includes('missing-proxy-model'))).toBe(true)
+  })
+
   test('catches duplicate catalog entry ids within same route', () => {
     registerGateway(
       makeGateway('gw-dup', {
@@ -269,6 +368,24 @@ describe('validateIntegrationRegistry', () => {
     const result = validateIntegrationRegistry()
     expect(result.valid).toBe(false)
     expect(result.errors.some(e => e.includes('Duplicate catalog entry id'))).toBe(true)
+  })
+
+  test('catches duplicate catalog api names within same route', () => {
+    registerGateway(
+      makeGateway('gw-dup-api', {
+        catalog: {
+          source: 'static',
+          models: [
+            { id: 'e1', apiName: 'provider/model' },
+            { id: 'e2', apiName: ' Provider/Model ' },
+          ],
+        },
+      }),
+    )
+
+    const result = validateIntegrationRegistry()
+    expect(result.valid).toBe(false)
+    expect(result.errors.some(e => e.includes('Duplicate catalog apiName'))).toBe(true)
   })
 
   test('catches catalog default flags when route defaultModel is set', () => {

--- a/src/integrations/registry.ts
+++ b/src/integrations/registry.ts
@@ -10,6 +10,7 @@ import type {
   RegistryValidationResult,
   VendorDescriptor,
 } from './descriptors.js'
+import { validateModelCatalogConfig } from './modelCatalog/schema.js'
 
 const _brands = new Map<string, BrandDescriptor>()
 const _vendors = new Map<string, VendorDescriptor>()
@@ -116,6 +117,10 @@ export function getCatalogForVendor(vendorId: string): import('./descriptors.js'
   return _vendors.get(vendorId)?.catalog
 }
 
+export function getCatalogForAnthropicProxy(anthropicProxyId: string): import('./descriptors.js').ModelCatalogConfig | undefined {
+  return _anthropicProxies.get(anthropicProxyId)?.catalog
+}
+
 export function getCatalogEntriesForRoute(routeId: string): ModelCatalogEntry[] {
   const gateway = _gateways.get(routeId)
   if (gateway?.catalog?.models) {
@@ -124,6 +129,10 @@ export function getCatalogEntriesForRoute(routeId: string): ModelCatalogEntry[] 
   const vendor = _vendors.get(routeId)
   if (vendor?.catalog?.models) {
     return vendor.catalog.models
+  }
+  const anthropicProxy = _anthropicProxies.get(routeId)
+  if (anthropicProxy?.catalog?.models) {
+    return anthropicProxy.catalog.models
   }
   return []
 }
@@ -248,9 +257,11 @@ export function validateIntegrationRegistry(): RegistryValidationResult {
 
     const defaultModelValue =
       'defaultModel' in route ? route.defaultModel : undefined
+    const catalogModels = route.catalog?.models
     const hasCatalogDefaultModel =
-      (route.catalog?.models?.find(model => model.default) ??
-        route.catalog?.models?.[0]) !== undefined
+      Array.isArray(catalogModels) &&
+      (catalogModels.find(model => model.default) ?? catalogModels[0]) !==
+        undefined
     const hasDefaultModel =
       typeof defaultModelValue === 'string'
         ? defaultModelValue.trim().length > 0
@@ -278,15 +289,29 @@ export function validateIntegrationRegistry(): RegistryValidationResult {
   const routes: Array<{ id: string; catalog?: import('./descriptors.js').ModelCatalogConfig }> = [
     ...allGateways.map(g => ({ id: g.id, catalog: g.catalog })),
     ...allVendors.map(v => ({ id: v.id, catalog: v.catalog })),
+    ...allAnthropicProxies.map(p => ({ id: p.id, catalog: p.catalog })),
   ]
 
   for (const route of routes) {
     if (!route.catalog) continue
 
     const catalog = route.catalog
-    const entryIds = new Set<string>()
+    const catalogShapeValidation = validateModelCatalogConfig(catalog, {
+      routeId: route.id,
+      validateSemantics: false,
+    })
+    if (!catalogShapeValidation.valid) {
+      errors.push(...catalogShapeValidation.errors)
+      continue
+    }
+
+    const entryIds = new Map<string, string>()
+    const entryApiNames = new Map<string, string>()
     let defaultCount = 0
-    const routeDescriptor = _gateways.get(route.id) ?? _vendors.get(route.id)
+    const routeDescriptor =
+      _gateways.get(route.id) ??
+      _vendors.get(route.id) ??
+      _anthropicProxies.get(route.id)
     const explicitDefaultModel =
       routeDescriptor &&
       'defaultModel' in routeDescriptor &&
@@ -294,10 +319,25 @@ export function validateIntegrationRegistry(): RegistryValidationResult {
 
     for (const entry of catalog.models ?? []) {
       // Duplicate entry ids within route
-      if (entryIds.has(entry.id)) {
-        errors.push(`Duplicate catalog entry id "${entry.id}" in route "${route.id}"`)
+      const normalizedEntryId = normalizeCatalogReference(entry.id)
+      const previousEntryId = entryIds.get(normalizedEntryId)
+      if (previousEntryId) {
+        errors.push(
+          `Duplicate catalog entry id "${entry.id}" in route "${route.id}"; first used by "${previousEntryId}"`,
+        )
+      } else {
+        entryIds.set(normalizedEntryId, entry.id)
       }
-      entryIds.add(entry.id)
+
+      const normalizedApiName = normalizeCatalogReference(entry.apiName)
+      const previousApiName = entryApiNames.get(normalizedApiName)
+      if (previousApiName) {
+        errors.push(
+          `Duplicate catalog apiName "${entry.apiName}" in route "${route.id}"; first used by "${previousApiName}"`,
+        )
+      } else {
+        entryApiNames.set(normalizedApiName, entry.id)
+      }
 
       // modelDescriptorId must point to existing shared model
       if (entry.modelDescriptorId && !_models.has(entry.modelDescriptorId)) {
@@ -375,6 +415,10 @@ export function validateIntegrationRegistry(): RegistryValidationResult {
     errors,
     warnings,
   }
+}
+
+function normalizeCatalogReference(value: string): string {
+  return value.trim().toLowerCase()
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Part 1 of the split model-catalog rollout. This PR is descriptor-aligned and intentionally small:

- validates existing descriptor-owned `ModelCatalogConfig` shapes
- keeps descriptor `discovery.mapModel` functions valid while rejecting unsupported function-valued properties through AJV
- adds route-scoped catalog lookup and normalization helpers
- re-exports descriptor-era catalog types instead of introducing a provider catalog type system
- wires catalog shape validation into integration registry validation
- skips route-level semantic checks after catalog shape validation fails, so malformed descriptors report schema errors without unsafe assumptions
- covers route-scoped lookup, duplicate route isolation, model descriptor resolution, `providerModelMap` matching, OpenAI shim override validation, and malformed catalog validation

## Stack Direction Update

This stack has been reworked to align with #910's descriptor-era integration architecture.

The catalog work is no longer a separate provider-catalog registry. Catalog metadata remains route-owned through existing integration descriptors (`VendorDescriptor`, `GatewayDescriptor`, `AnthropicProxyDescriptor`) and existing `ModelCatalogConfig` / `ModelCatalogEntry` types.

This PR only adds descriptor-catalog validation and route-scoped lookup/normalization helpers.

Follow-up branches are constrained to descriptor-owned route metadata and concrete consumers. They will not introduce `PROVIDER_CATALOGS`, production provider JSON catalogs, global model lookup, or catalog-driven runtime routing.

## Why This Exists / First Consumer

This foundation removes the current duplication risk around descriptor catalog handling before adding more model metadata. Without a shared validator and route-scoped lookup contract, every consumer that needs model availability, aliases, context limits, output limits, or transport overrides has to traverse descriptor catalogs independently and make its own assumptions about malformed catalog shape, route matching, and shared model descriptor resolution.

The first concrete consumer in this PR is `validateIntegrationRegistry()`: descriptor-owned catalogs are now part of registry validation, so malformed catalog data fails during `integrations:check` instead of surfacing later in runtime/model-picker code. The immediate follow-up consumer is `codex/model-catalog-09-metadata-consumers`, which moves runtime/context/model-option metadata reads to the route-scoped helpers introduced here. Earlier follow-up branches only enrich descriptor-owned catalog data so that consumer migration has validated metadata to read.

The boundaries that keep this from becoming a second provider abstraction are intentional and enforced by the API shape: catalog data is owned by route descriptors, lookups require route context, shared metadata stays in `ModelDescriptor`, generated artifacts are derived from descriptors, and catalog metadata does not choose request endpoints or runtime transport. There is no provider JSON registry, no `PROVIDER_CATALOGS`, no global model lookup by name, and no catalog-driven routing layer.

This can merge before the first runtime consumer because registry validation is already a concrete consumer and it gives the later descriptor-enrichment slices a safe gate. If maintainers prefer not to merge foundation-only code, this PR can be queued with the first catalog-enrichment follow-up, but it should land before broad consumer rewiring so those consumers do not each recreate their own validation and route-resolution rules.

## Explicit Non-Goals

- no production `src/integrations/modelCatalog/providers/*.json`
- no `ProviderCatalog` registry or generated `PROVIDER_CATALOGS`
- no OpenCode Go or other new provider/gateway data
- no endpoint/protocol routing layer in catalog metadata
- no public model lookup by model name alone

## Follow-up Stack

The remaining slices keep #910's descriptor registry as the source of truth:

1. `codex/model-catalog-02-core-catalogs`
   - enrich core vendor/gateway descriptors with route-owned catalog metadata
2. `codex/model-catalog-03-direct-provider-catalogs`
   - add descriptor-owned catalogs for direct providers without creating provider JSON registries
3. `codex/model-catalog-04-gateway-catalogs`
   - add route-owned static/hybrid catalogs and discovery metadata for gateways
4. `codex/model-catalog-05-anthropic-cloud-catalogs`
   - add catalog metadata for Bedrock/Vertex/Foundry while preserving dedicated transport behavior
5. `codex/model-catalog-06-large-provider-catalogs`
   - add or discover large catalogs through descriptor-owned static/hybrid catalog metadata
6. `codex/model-catalog-07-custom-compat-catalog`
   - improve custom/OpenAI-compatible catalog handling without global model ownership
7. `codex/model-catalog-08-generated-registry`
   - extend descriptor artifact generation and validation, not a separate provider catalog registry
8. `codex/model-catalog-09-metadata-consumers`
   - migrate metadata consumers to route-scoped descriptor catalog helpers
9. `codex/model-catalog-10-runtime-endpoints`
   - only add runtime metadata through descriptor-compatible fields; no separate endpoint/protocol routing layer
10. `codex/model-catalog-11-integration-source-of-truth`
    - consolidate remaining duplication around descriptor-owned catalogs
11. `codex/model-catalog-12-app-surface-cleanup`
    - update UI/helper surfaces to use route-scoped descriptor catalog metadata
12. `codex/model-catalog-13-docs`
    - document descriptor-era catalog authoring and the no-global-catalog rule

## Validation

- `bun test src/integrations/modelCatalog/schema.test.ts src/integrations/modelCatalog/catalog.test.ts`
- `bun test src/integrations/index.test.ts src/integrations/registry.test.ts src/integrations/modelCatalog/schema.test.ts src/integrations/modelCatalog/catalog.test.ts`
- `bun test src/integrations/modelCatalog/schema.test.ts src/integrations/modelCatalog/catalog.test.ts src/integrations/index.test.ts src/integrations/registry.test.ts src/integrations/artifactGenerator.test.ts src/integrations/discoveryService.test.ts src/integrations/runtimeMetadata.test.ts src/utils/context.test.ts src/services/api/providerConfig.test.ts src/services/api/providerConfig.openai-compatible.test.ts src/utils/model/modelOptions.routeCatalog.test.ts src/utils/model/modelOptions.github.test.ts src/utils/model/minimaxModels.test.ts src/utils/model/routeCatalogOptions.test.ts`
- `bun run integrations:check`
- `bun run build`

`bun run typecheck` still fails on current `upstream/main` in unrelated areas (missing modules and existing test/type issues outside this slice), so it is not a useful gate for this PR yet.
