### PR TITLE
fix: replace unsupported Unicode glyphs with widely available alternatives

### DIFF
--- a/src/components/AgentProgressLine.tsx
+++ b/src/components/AgentProgressLine.tsx
@@ -113,7 +113,7 @@ export function AgentProgressLine(t0: Props) {
   }
   let t10;
   if ($[25] !== getStatusText || $[26] !== isBackgrounded || $[27] !== isLast) {
-    t10 = !isBackgrounded && <Box paddingLeft={3} flexDirection="row"><Text dimColor={true}>{isLast ? "   \u23BF  " : "\u2502  \u23BF  "}</Text><Text dimColor={true}>{getStatusText()}</Text></Box>;
+    t10 = !isBackgrounded && <Box paddingLeft={3} flexDirection="row"><Text dimColor={true}>{isLast ? "   \u2514  " : "\u2502  \u2514  "}</Text><Text dimColor={true}>{getStatusText()}</Text></Box>;
     $[25] = getStatusText;
     $[26] = isBackgrounded;
     $[27] = isLast;

--- a/src/components/MessageResponse.tsx
+++ b/src/components/MessageResponse.tsx
@@ -19,7 +19,7 @@ export function MessageResponse(t0) {
   }
   let t1;
   if ($[0] === Symbol.for("react.memo_cache_sentinel")) {
-    t1 = <NoSelect fromLeftEdge={true} flexShrink={0}><Text dimColor={true}>{"  "}⎿  </Text></NoSelect>;
+    t1 = <NoSelect fromLeftEdge={true} flexShrink={0}><Text dimColor={true}>{"  "}└  </Text></NoSelect>;
     $[0] = t1;
   } else {
     t1 = $[0];
@@ -58,7 +58,7 @@ export function MessageResponse(t0) {
 
 // This is a context that is used to determine if the message response
 // is rendered as a descendant of another MessageResponse. We use it
-// to avoid rendering nested ⎿ characters.
+// to avoid rendering nested └ characters.
 const MessageResponseContext = React.createContext(false);
 function MessageResponseProvider(t0) {
   const $ = _c(2);

--- a/src/components/messages/CollapsedReadSearchContent.tsx
+++ b/src/components/messages/CollapsedReadSearchContent.tsx
@@ -235,18 +235,18 @@ export function CollapsedReadSearchContent({
       })}
         {message.hookInfos && message.hookInfos.length > 0 && <>
             <Text dimColor>
-              {'  ⎿  '}Ran {message.hookCount} PreToolUse{' '}
+              {'  └  '}Ran {message.hookCount} PreToolUse{' '}
               {message.hookCount === 1 ? 'hook' : 'hooks'} (
               {formatSecondsShort(message.hookTotalMs ?? 0)})
             </Text>
             {message.hookInfos.map((info, idx) => <Text key={`hook-${idx}`} dimColor>
-                {'     ⎿ '}
+                {'     └ '}
                 {info.command} ({formatSecondsShort(info.durationMs ?? 0)})
               </Text>)}
           </>}
         {message.relevantMemories?.map(m => <Box key={m.path} flexDirection="column" marginTop={1}>
             <Text dimColor>
-              {'  ⎿  '}Recalled {basename(m.path)}
+              {'  └  '}Recalled {basename(m.path)}
             </Text>
             <Box paddingLeft={5}>
               <Text>
@@ -460,12 +460,12 @@ export function CollapsedReadSearchContent({
         </Text>
       </Box>
       {isActiveGroup && displayedHint !== undefined &&
-    // Row layout: 5-wide gutter for ⎿, then a flex column for the text.
+    // Row layout: 5-wide gutter for └, then a flex column for the text.
     // Ink's wrap stays inside the right column so continuation lines
-    // indent under ⎿. MAX_HINT_CHARS in commandAsHint caps total at ~5 lines.
+    // indent under └. MAX_HINT_CHARS in commandAsHint caps total at ~5 lines.
     <Box flexDirection="row">
           <Box width={5} flexShrink={0}>
-            <Text dimColor>{'  ⎿  '}</Text>
+            <Text dimColor>{'  └  '}</Text>
           </Box>
           <Box flexDirection="column" flexGrow={1}>
             {displayedHint.split('\n').map((line, i, arr) => <Text key={`hint-${i}`} dimColor>
@@ -475,7 +475,7 @@ export function CollapsedReadSearchContent({
           </Box>
         </Box>}
       {message.hookTotalMs !== undefined && message.hookTotalMs > 0 && <Text dimColor>
-          {'  ⎿  '}Ran {message.hookCount} PreToolUse{' '}
+          {'  └  '}Ran {message.hookCount} PreToolUse{' '}
           {message.hookCount === 1 ? 'hook' : 'hooks'} (
           {formatSecondsShort(message.hookTotalMs)})
         </Text>}

--- a/src/components/messages/SystemTextMessage.tsx
+++ b/src/components/messages/SystemTextMessage.tsx
@@ -295,7 +295,7 @@ function StopHookSummaryMessage(t0) {
     const t3 = hookCount === 1 ? "hook" : "hooks";
     let t4;
     if ($[5] !== hookCount || $[6] !== message.hookLabel || $[7] !== t3 || $[8] !== totalStr) {
-      t4 = <Text dimColor={true}>{"  \u23BF  "}Ran {hookCount} {message.hookLabel}{" "}{t3}{totalStr}</Text>;
+      t4 = <Text dimColor={true}>{"  \u2514  "}Ran {hookCount} {message.hookLabel}{" "}{t3}{totalStr}</Text>;
       $[5] = hookCount;
       $[6] = message.hookLabel;
       $[7] = t3;
@@ -421,7 +421,7 @@ function _temp3(info_0, idx_0) {
 }
 function _temp2(info, idx) {
   const durationStr = false && info.durationMs !== undefined ? ` (${formatSecondsShort(info.durationMs)})` : "";
-  return <Text key={`cmd-${idx}`} dimColor={true}>{"     \u23BF "}{info.command === "prompt" ? `prompt: ${info.promptText || ""}` : info.command}{durationStr}</Text>;
+  return <Text key={`cmd-${idx}`} dimColor={true}>{"     \u2514 "}{info.command === "prompt" ? `prompt: ${info.promptText || ""}` : info.command}{durationStr}</Text>;
 }
 function _temp(sum, h) {
   return sum + (h.durationMs ?? 0);

--- a/src/components/messages/SystemTextMessage.tsx
+++ b/src/components/messages/SystemTextMessage.tsx
@@ -375,7 +375,7 @@ function StopHookSummaryMessage(t0) {
   }
   let t12;
   if ($[31] !== preventedContinuation || $[32] !== stopReason) {
-    t12 = preventedContinuation && stopReason && <Text><Text dimColor={true}>⎿  </Text>{stopReason}</Text>;
+    t12 = preventedContinuation && stopReason && <Text><Text dimColor={true}>└  </Text>{stopReason}</Text>;
     $[31] = preventedContinuation;
     $[32] = stopReason;
     $[33] = t12;
@@ -384,7 +384,7 @@ function StopHookSummaryMessage(t0) {
   }
   let t13;
   if ($[34] !== hookErrors || $[35] !== message.hookLabel) {
-    t13 = hookErrors.length > 0 && hookErrors.map((err, idx_1) => <Text key={idx_1}><Text dimColor={true}>⎿  </Text>{message.hookLabel ?? "Stop"} hook error: {err}</Text>);
+    t13 = hookErrors.length > 0 && hookErrors.map((err, idx_1) => <Text key={idx_1}><Text dimColor={true}>└  </Text>{message.hookLabel ?? "Stop"} hook error: {err}</Text>);
     $[34] = hookErrors;
     $[35] = message.hookLabel;
     $[36] = t13;
@@ -417,7 +417,7 @@ function StopHookSummaryMessage(t0) {
 }
 function _temp3(info_0, idx_0) {
   const durationStr_0 = false && info_0.durationMs !== undefined ? ` (${formatSecondsShort(info_0.durationMs)})` : "";
-  return <Text key={`cmd-${idx_0}`} dimColor={true}>⎿  {info_0.command === "prompt" ? `prompt: ${info_0.promptText || ""}` : info_0.command}{durationStr_0}</Text>;
+  return <Text key={`cmd-${idx_0}`} dimColor={true}>└  {info_0.command === "prompt" ? `prompt: ${info_0.promptText || ""}` : info_0.command}{durationStr_0}</Text>;
 }
 function _temp2(info, idx) {
   const durationStr = false && info.durationMs !== undefined ? ` (${formatSecondsShort(info.durationMs)})` : "";
@@ -797,7 +797,7 @@ function BridgeStatusMessage(t0) {
   }
   let t5;
   if ($[4] !== message.upgradeNudge) {
-    t5 = message.upgradeNudge && <Text dimColor={true}>⎿ {message.upgradeNudge}</Text>;
+    t5 = message.upgradeNudge && <Text dimColor={true}>└ {message.upgradeNudge}</Text>;
     $[4] = message.upgradeNudge;
     $[5] = t5;
   } else {

--- a/src/components/messages/UserLocalCommandOutputMessage.tsx
+++ b/src/components/messages/UserLocalCommandOutputMessage.tsx
@@ -71,7 +71,7 @@ function IndentedContent(t0) {
   }
   let t1;
   if ($[2] === Symbol.for("react.memo_cache_sentinel")) {
-    t1 = <Text dimColor={true}>{"  \u23BF  "}</Text>;
+    t1 = <Text dimColor={true}>{"  \u2514  "}</Text>;
     $[2] = t1;
   } else {
     t1 = $[2];
@@ -148,7 +148,7 @@ function CloudLaunchContent(t0) {
   }
   let t6;
   if ($[14] !== rest) {
-    t6 = rest && <FullWidthRow><Text dimColor={true}>{"  \u23BF  "}</Text><Text dimColor={true}>{rest}</Text></FullWidthRow>;
+    t6 = rest && <FullWidthRow><Text dimColor={true}>{"  \u2514  "}</Text><Text dimColor={true}>{rest}</Text></FullWidthRow>;
     $[14] = rest;
     $[15] = t6;
   } else {

--- a/src/components/permissions/PermissionDecisionDebugInfo.tsx
+++ b/src/components/permissions/PermissionDecisionDebugInfo.tsx
@@ -62,7 +62,7 @@ function PermissionDecisionInfoItem(t0) {
             return <Box flexDirection="column">{Array.from(decisionReason.reasons.entries()).map(t2 => {
                 const [subcommand, result] = t2;
                 const icon = result.behavior === "allow" ? color("success", theme)(figures.tick) : color("error", theme)(figures.cross);
-                return <Box flexDirection="column" key={subcommand}><Text>{icon} {subcommand}</Text>{result.decisionReason !== undefined && result.decisionReason.type !== "subcommandResults" && <Text><Text dimColor={true}>{"  "}⎿{"  "}</Text><Ansi>{decisionReasonDisplayString(result.decisionReason)}</Ansi></Text>}{result.behavior === "ask" && <SuggestedRules suggestions={result.suggestions} />}</Box>;
+                return <Box flexDirection="column" key={subcommand}><Text>{icon} {subcommand}</Text>{result.decisionReason !== undefined && result.decisionReason.type !== "subcommandResults" && <Text><Text dimColor={true}>{"  "}└{"  "}</Text><Ansi>{decisionReasonDisplayString(result.decisionReason)}</Ansi></Text>}{result.behavior === "ask" && <SuggestedRules suggestions={result.suggestions} />}</Box>;
               })}</Box>;
           }
         default:
@@ -127,7 +127,7 @@ function SuggestedRules(t0) {
       }
       T1 = Text;
       if ($[8] === Symbol.for("react.memo_cache_sentinel")) {
-        t2 = <Text dimColor={true}>{"  "}⎿{"  "}</Text>;
+        t2 = <Text dimColor={true}>{"  "}└{"  "}</Text>;
         $[8] = t2;
       } else {
         t2 = $[8];

--- a/src/ink/render-node-to-output.ts
+++ b/src/ink/render-node-to-output.ts
@@ -657,7 +657,7 @@ function renderNodeToOutput(
       // 'from-left-edge' extends the exclusion from col 0 so any
       // upstream indentation (tool prefix, tree lines) is covered too
       // — a multi-row drag over a diff gutter shouldn't pick up the
-      // `  ⎿  ` prefix on row 0 or the blank cells under it on row 1+.
+      // `  └  ` prefix on row 0 or the blank cells under it on row 1+.
       if (node.style.noSelect) {
         const boxX = Math.floor(x)
         const fromEdge = node.style.noSelect === 'from-left-edge'

--- a/src/ink/searchHighlight.ts
+++ b/src/ink/searchHighlight.ts
@@ -44,7 +44,7 @@ export function applySearchHighlight(
     // extractRowText (selection.ts):
     //   - SpacerTail: 2nd cell of a wide char, no char of its own
     //   - SpacerHead: end-of-line padding when a wide char wraps
-    //   - noSelect: gutters (⎿, line numbers) — same exclusion as
+    //   - noSelect: gutters (└, line numbers) — same exclusion as
     //     applySelectionOverlay. "Highlight what you see" still holds for
     //     content; gutters aren't search targets.
     // Lowercasing per-char (not on the joined string at the end) means

--- a/src/screens/REPL.tsx
+++ b/src/screens/REPL.tsx
@@ -3301,7 +3301,7 @@ export function REPL({
               });
               // In fullscreen the command just showed as a centered modal
               // pane — the notification above is enough feedback. Adding
-              // "❯ /config" + "⎿ dismissed" to the transcript is clutter
+              // "❯ /config" + "└ dismissed" to the transcript is clutter
               // (those messages are type:system subtype:local_command —
               // user-visible but NOT sent to the model, so skipping them
               // doesn't change model context). Outside fullscreen the

--- a/src/tools/AgentTool/UI.tsx
+++ b/src/tools/AgentTool/UI.tsx
@@ -530,7 +530,7 @@ export function renderToolUseProgressMessage(progressMessages: ProgressMessage<P
   // After grouping, displayedMessages can be empty when the only progress so
   // far is an assistant tool_use for a search/read op (grouped but not yet
   // counted, since counts increment on tool_result). Fall back to the
-  // initializing text so MessageResponse doesn't render a bare ⎿.
+  // initializing text so MessageResponse doesn't render a bare └.
   if (displayedMessages.length === 0 && !(isTranscriptMode && prompt)) {
     return <MessageResponse height={1}>
         <Text dimColor>{INITIALIZING_TEXT}</Text>

--- a/src/tools/BashTool/commentLabel.ts
+++ b/src/tools/BashTool/commentLabel.ts
@@ -3,7 +3,7 @@
  * return the comment text stripped of the `#` prefix. Otherwise undefined.
  *
  * Under fullscreen mode this is the non-verbose tool-use label AND the
- * collapse-group ⎿ hint — it's what Claude wrote for the human to read.
+ * collapse-group └ hint — it's what Claude wrote for the human to read.
  */
 export function extractBashCommentLabel(command: string): string | undefined {
   const nl = command.indexOf('\n')

--- a/src/tools/GrepTool/UI.tsx
+++ b/src/tools/GrepTool/UI.tsx
@@ -63,7 +63,7 @@ function SearchResultSummary(t0) {
   if (verbose) {
     let t5;
     if ($[11] === Symbol.for("react.memo_cache_sentinel")) {
-      t5 = <Text dimColor={true}>  ⎿  </Text>;
+      t5 = <Text dimColor={true}>  └  </Text>;
       $[11] = t5;
     } else {
       t5 = $[11];

--- a/src/tools/LSPTool/UI.tsx
+++ b/src/tools/LSPTool/UI.tsx
@@ -104,7 +104,7 @@ function LSPResultSummary(t0) {
   if (verbose) {
     let t4;
     if ($[9] === Symbol.for("react.memo_cache_sentinel")) {
-      t4 = <Text dimColor={true}>  ⎿  </Text>;
+      t4 = <Text dimColor={true}>  └  </Text>;
       $[9] = t4;
     } else {
       t4 = $[9];

--- a/src/utils/collapseReadSearch.ts
+++ b/src/utils/collapseReadSearch.ts
@@ -118,9 +118,9 @@ function isMemoryWriteOrEdit(toolName: string, toolInput: unknown): boolean {
 const MAX_HINT_CHARS = 300
 
 /**
- * Format a bash command for the ⎿ hint. Drops blank lines, collapses runs of
+ * Format a bash command for the └ hint. Drops blank lines, collapses runs of
  * inline whitespace, then caps total length. Newlines are preserved so the
- * renderer can indent continuation lines under ⎿.
+ * renderer can indent continuation lines under └.
  */
 function commandAsHint(command: string): string {
   const cleaned =
@@ -921,7 +921,7 @@ export function collapseReadSearchGroups(
       // This preserves the visual ordering where the collapsed badge appears at the position
       // of the first tool use, not displaced by intervening skippable messages.
       // Exception: nested_memory attachments are pushed through even during a group so
-      // ⎿ Loaded lines cluster tightly instead of being split by the badge's marginTop.
+      // └ Loaded lines cluster tightly instead of being split by the badge's marginTop.
       if (
         currentGroup.messages.length > 0 &&
         !(msg.type === 'attachment' && msg.attachment.type === 'nested_memory')

--- a/src/utils/permissions/PermissionMode.ts
+++ b/src/utils/permissions/PermissionMode.ts
@@ -59,21 +59,21 @@ const PERMISSION_MODE_CONFIG: Partial<
   acceptEdits: {
     title: 'Accept edits',
     shortTitle: 'Accept',
-    symbol: '⏵⏵',
+    symbol: '▶▶',
     color: 'autoAccept',
     external: 'acceptEdits',
   },
   bypassPermissions: {
     title: 'Bypass Permissions',
     shortTitle: 'Bypass',
-    symbol: '⏵⏵',
+    symbol: '▶▶',
     color: 'error',
     external: 'bypassPermissions',
   },
   dontAsk: {
     title: "Don't Ask",
     shortTitle: 'DontAsk',
-    symbol: '⏵⏵',
+    symbol: '▶▶',
     color: 'error',
     external: 'dontAsk',
   },
@@ -82,7 +82,7 @@ const PERMISSION_MODE_CONFIG: Partial<
         auto: {
           title: 'Auto mode',
           shortTitle: 'Auto',
-          symbol: '⏵⏵',
+          symbol: '▶▶',
           color: 'warning' as ModeColorKey,
           external: 'default' as ExternalPermissionMode,
         },

--- a/src/utils/processUserInput/processSlashCommand.tsx
+++ b/src/utils/processUserInput/processSlashCommand.tsx
@@ -580,7 +580,7 @@ async function getMessagesForSlashCommand(commandName: string, args: string, set
 
               // In fullscreen the command just showed as a centered modal
               // pane — the transient notification is enough feedback. The
-              // "❯ /config" + "⎿ dismissed" transcript entries are
+              // "❯ /config" + "└ dismissed" transcript entries are
               // type:system subtype:local_command (user-visible but NOT sent
               // to the model), so skipping them doesn't affect model context.
               // Outside fullscreen keep them so scrollback shows what ran.

--- a/src/utils/terminal.ts
+++ b/src/utils/terminal.ts
@@ -5,7 +5,7 @@ import sliceAnsi from './sliceAnsi.js'
 
 // Text rendering utilities for terminal display
 const MAX_LINES_TO_SHOW = 3
-// Account for MessageResponse prefix ("  ⎿ " = 5 chars) + parent width
+// Account for MessageResponse prefix ("  └ " = 5 chars) + parent width
 // reduction (columns - 5 in tool result rendering)
 const PADDING_TO_PREVENT_OVERFLOW = 10
 


### PR DESCRIPTION
## Summary

Replace TUI characters from obscure Unicode blocks that render as tofu boxes on most Linux terminal fonts:

- U+23F5 → U+25B6 (▶▶) — permission mode indicator
- U+23BF → U+2514 (└) — tool output connector bracket

## Why

U+23F5 and U+23BF are not present in **any** common monospace terminal font, including:
- All Nerd Font variants (Hack, JetBrains Mono, DejaVu Sans Mono, FiraCode)
- Default fonts on Ubuntu, Debian, Arch minimal installs
- Fonts available in Windows terminal emulators (MobaXterm, PuTTY)

The replacements (U+25B6 and U+2514) are universally supported across all terminal fonts and platforms.

Verified by inspecting font cmap tables with fontTools — confirmed Hack Nerd Font, JetBrains Mono Nerd Font, and DejaVu Sans Mono Nerd Font all lack U+23F5 and U+23BF.

## Why Windows SSH clients are affected

When you SSH from a Windows machine (MobaXterm, PuTTY) into a Linux server running OpenClaude, the server sends raw UTF-8 bytes over the wire. Rendering happens entirely on the client side. Unlike native Windows Terminal or macOS Terminal which use font fallback chains (trying multiple fonts until one has the glyph), MobaXterm and PuTTY use a single configured font with no fallback. If that font lacks a glyph, you get a tofu box regardless of locale settings or any server-side configuration. The server is sending the characters correctly but the client has nothing to draw.

## Affected platforms

- Linux terminals: kitty, xterm, Ptyxis, GNOME Terminal (minimal installs)
- Windows SSH clients: MobaXterm, PuTTY (single-font rendering, no fallback chain)
- mosh sessions (limited Unicode support, only BMP width tables)
- macOS is unaffected (SF Mono + Apple symbol fonts cover these blocks)

## Related upstream issues

- anthropics/claude-code#24102
- anthropics/claude-code#39127
- anthropics/claude-code#53080
- anthropics/claude-code#46841

## Changes

15 source files updated. Simple character substitutions only, no logic changes.

## Test plan

- [ ] Verify the replacement renders correctly in the status bar (permission mode indicator)
- [ ] Verify the replacement renders correctly as tool output connector in message responses
- [ ] Confirm no visual regression on macOS Terminal / iTerm2
- [ ] Confirm rendering on Linux with default fonts (no fonts-symbola installed)
