### PR TITLE
fix: validate plugin component paths

### DIFF
--- a/src/utils/plugins/pluginLoader.test.ts
+++ b/src/utils/plugins/pluginLoader.test.ts
@@ -5,6 +5,7 @@ import { describe, expect, test } from 'bun:test'
 
 import type { LoadedPlugin } from '../../types/plugin.js'
 import {
+  createPluginFromPath,
   mergePluginSources,
   resolveExistingPluginComponentPath,
   resolvePluginComponentPath,
@@ -77,6 +78,17 @@ describe('mergePluginSources', () => {
   })
 })
 
+async function createDirectoryLink(
+  target: string,
+  linkPath: string,
+): Promise<void> {
+  await symlink(
+    target,
+    linkPath,
+    process.platform === 'win32' ? 'junction' : 'dir',
+  )
+}
+
 describe('resolvePluginComponentPath', () => {
   test('keeps relative component paths inside the plugin directory', () => {
     const pluginRoot = resolve(tmpdir(), 'plugin')
@@ -141,12 +153,7 @@ describe('resolvePluginComponentPath', () => {
       await mkdir(skillsDir, { recursive: true })
       await mkdir(outsideSkillDir, { recursive: true })
       await writeFile(join(outsideSkillDir, 'SKILL.md'), '# escaped skill\n')
-      try {
-        await symlink(outsideSkillDir, linkPath, 'dir')
-      } catch {
-        // Some Windows environments require elevated privileges for symlinks.
-        return
-      }
+      await createDirectoryLink(outsideSkillDir, linkPath)
 
       await expect(
         resolveExistingPluginComponentPath(
@@ -158,6 +165,69 @@ describe('resolvePluginComponentPath', () => {
         exists: true,
         outOfBounds: true,
       })
+    } finally {
+      await rm(tempRoot, { recursive: true, force: true })
+    }
+  })
+
+  test('rejects auto-detected component directories whose real targets escape the plugin directory', async () => {
+    const tempRoot = await mkdtemp(join(tmpdir(), 'plugin-paths-'))
+    try {
+      const pluginRoot = join(tempRoot, 'plugin')
+      await mkdir(pluginRoot, { recursive: true })
+
+      const linkedDirectories = [
+        'commands',
+        'agents',
+        'skills',
+        'output-styles',
+      ] as const
+      for (const directory of linkedDirectories) {
+        const outsideDirectory = join(tempRoot, `outside-${directory}`)
+        await mkdir(outsideDirectory, { recursive: true })
+        await createDirectoryLink(outsideDirectory, join(pluginRoot, directory))
+      }
+
+      const { plugin, errors } = await createPluginFromPath(
+        pluginRoot,
+        'test-source',
+        true,
+        'test-plugin',
+      )
+
+      expect(plugin.commandsPath).toBeUndefined()
+      expect(plugin.agentsPath).toBeUndefined()
+      expect(plugin.skillsPath).toBeUndefined()
+      expect(plugin.outputStylesPath).toBeUndefined()
+      expect(errors).toHaveLength(4)
+      expect(errors).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            type: 'generic-error',
+            error: expect.stringContaining(
+              'Command directory commands resolves outside plugin directory',
+            ),
+          }),
+          expect.objectContaining({
+            type: 'generic-error',
+            error: expect.stringContaining(
+              'Agent directory agents resolves outside plugin directory',
+            ),
+          }),
+          expect.objectContaining({
+            type: 'generic-error',
+            error: expect.stringContaining(
+              'Skill directory skills resolves outside plugin directory',
+            ),
+          }),
+          expect.objectContaining({
+            type: 'generic-error',
+            error: expect.stringContaining(
+              'Output style directory output-styles resolves outside plugin directory',
+            ),
+          }),
+        ]),
+      )
     } finally {
       await rm(tempRoot, { recursive: true, force: true })
     }

--- a/src/utils/plugins/pluginLoader.test.ts
+++ b/src/utils/plugins/pluginLoader.test.ts
@@ -98,6 +98,27 @@ describe('resolvePluginComponentPath', () => {
     )
   })
 
+  test('keeps plugin-root component paths inside the plugin directory', async () => {
+    const tempRoot = await mkdtemp(join(tmpdir(), 'plugin-paths-'))
+    try {
+      const pluginRoot = join(tempRoot, 'plugin')
+      await mkdir(pluginRoot, { recursive: true })
+
+      expect(resolvePluginComponentPath(pluginRoot, './')).toBe(
+        resolve(pluginRoot),
+      )
+      await expect(
+        resolveExistingPluginComponentPath(pluginRoot, './'),
+      ).resolves.toMatchObject({
+        fullPath: resolve(pluginRoot),
+        exists: true,
+        outOfBounds: false,
+      })
+    } finally {
+      await rm(tempRoot, { recursive: true, force: true })
+    }
+  })
+
   test('rejects component paths that traverse outside the plugin directory', () => {
     expect(resolvePluginComponentPath('/tmp/plugin', '../secret.md')).toBeNull()
     expect(

--- a/src/utils/plugins/pluginLoader.test.ts
+++ b/src/utils/plugins/pluginLoader.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, test } from 'bun:test'
 
 import type { LoadedPlugin } from '../../types/plugin.js'
-import { mergePluginSources } from './pluginLoader.js'
+import {
+  mergePluginSources,
+  resolvePluginComponentPath,
+} from './pluginLoader.js'
 
 function marketplacePlugin(
   name: string,
@@ -67,5 +70,24 @@ describe('mergePluginSources', () => {
       source: legacy.source,
       plugin: legacy.name,
     })
+  })
+})
+
+describe('resolvePluginComponentPath', () => {
+  test('keeps relative component paths inside the plugin directory', () => {
+    expect(resolvePluginComponentPath('/tmp/plugin', 'commands/build.md')).toBe(
+      '/tmp/plugin/commands/build.md',
+    )
+  })
+
+  test('rejects component paths that traverse outside the plugin directory', () => {
+    expect(resolvePluginComponentPath('/tmp/plugin', '../secret.md')).toBeNull()
+    expect(
+      resolvePluginComponentPath('/tmp/plugin', 'commands/../../secret.md'),
+    ).toBeNull()
+  })
+
+  test('rejects absolute component paths outside the plugin directory', () => {
+    expect(resolvePluginComponentPath('/tmp/plugin', '/etc/passwd')).toBeNull()
   })
 })

--- a/src/utils/plugins/pluginLoader.test.ts
+++ b/src/utils/plugins/pluginLoader.test.ts
@@ -1,8 +1,12 @@
+import { mkdtemp, mkdir, rm, symlink, writeFile } from 'fs/promises'
+import { tmpdir } from 'os'
+import { join, resolve } from 'path'
 import { describe, expect, test } from 'bun:test'
 
 import type { LoadedPlugin } from '../../types/plugin.js'
 import {
   mergePluginSources,
+  resolveExistingPluginComponentPath,
   resolvePluginComponentPath,
 } from './pluginLoader.js'
 
@@ -75,8 +79,10 @@ describe('mergePluginSources', () => {
 
 describe('resolvePluginComponentPath', () => {
   test('keeps relative component paths inside the plugin directory', () => {
-    expect(resolvePluginComponentPath('/tmp/plugin', 'commands/build.md')).toBe(
-      '/tmp/plugin/commands/build.md',
+    const pluginRoot = resolve(tmpdir(), 'plugin')
+
+    expect(resolvePluginComponentPath(pluginRoot, 'commands/build.md')).toBe(
+      resolve(pluginRoot, 'commands/build.md'),
     )
   })
 
@@ -89,5 +95,71 @@ describe('resolvePluginComponentPath', () => {
 
   test('rejects absolute component paths outside the plugin directory', () => {
     expect(resolvePluginComponentPath('/tmp/plugin', '/etc/passwd')).toBeNull()
+  })
+
+  test('rejects file symlink component paths whose real target escapes the plugin directory', async () => {
+    const tempRoot = await mkdtemp(join(tmpdir(), 'plugin-paths-'))
+    try {
+      const pluginRoot = join(tempRoot, 'plugin')
+      const commandsDir = join(pluginRoot, 'commands')
+      const outsideFile = join(tempRoot, 'secret.md')
+      const linkPath = join(commandsDir, 'link-to-secret.md')
+
+      await mkdir(commandsDir, { recursive: true })
+      await writeFile(outsideFile, '# secret\n')
+      try {
+        await symlink(outsideFile, linkPath)
+      } catch {
+        // Some Windows environments require elevated privileges for symlinks.
+        return
+      }
+
+      await expect(
+        resolveExistingPluginComponentPath(
+          pluginRoot,
+          'commands/link-to-secret.md',
+        ),
+      ).resolves.toMatchObject({
+        fullPath: linkPath,
+        exists: true,
+        outOfBounds: true,
+      })
+    } finally {
+      await rm(tempRoot, { recursive: true, force: true })
+    }
+  })
+
+  test('rejects directory symlink skill paths whose SKILL.md real target escapes the plugin directory', async () => {
+    const tempRoot = await mkdtemp(join(tmpdir(), 'plugin-paths-'))
+    try {
+      const pluginRoot = join(tempRoot, 'plugin')
+      const skillsDir = join(pluginRoot, 'skills')
+      const outsideSkillDir = join(tempRoot, 'outside-skill')
+      const linkPath = join(skillsDir, 'linked-skill')
+      const skillPath = join(linkPath, 'SKILL.md')
+
+      await mkdir(skillsDir, { recursive: true })
+      await mkdir(outsideSkillDir, { recursive: true })
+      await writeFile(join(outsideSkillDir, 'SKILL.md'), '# escaped skill\n')
+      try {
+        await symlink(outsideSkillDir, linkPath, 'dir')
+      } catch {
+        // Some Windows environments require elevated privileges for symlinks.
+        return
+      }
+
+      await expect(
+        resolveExistingPluginComponentPath(
+          pluginRoot,
+          'skills/linked-skill/SKILL.md',
+        ),
+      ).resolves.toMatchObject({
+        fullPath: skillPath,
+        exists: true,
+        outOfBounds: true,
+      })
+    } finally {
+      await rm(tempRoot, { recursive: true, force: true })
+    }
   })
 })

--- a/src/utils/plugins/pluginLoader.ts
+++ b/src/utils/plugins/pluginLoader.ts
@@ -1349,7 +1349,6 @@ export function resolvePluginComponentPath(
   const relativePath = relative(root, fullPath)
 
   if (
-    relativePath === '' ||
     relativePath === '..' ||
     relativePath.startsWith(`..${sep}`) ||
     isAbsolute(relativePath)

--- a/src/utils/plugins/pluginLoader.ts
+++ b/src/utils/plugins/pluginLoader.ts
@@ -45,7 +45,7 @@ import {
   symlink,
 } from 'fs/promises'
 import memoize from 'lodash-es/memoize.js'
-import { basename, dirname, join, relative, resolve, sep } from 'path'
+import { basename, dirname, isAbsolute, join, relative, resolve, sep } from 'path'
 import { getInlinePlugins } from '../../bootstrap/state.js'
 import {
   BUILTIN_MARKETPLACE_NAME,
@@ -1282,15 +1282,31 @@ async function validatePluginPaths(
   // Parallelize the async pathExists checks
   const checks = await Promise.all(
     relPaths.map(async relPath => {
-      const fullPath = join(pluginPath, relPath)
+      const fullPath = resolvePluginComponentPath(pluginPath, relPath)
+      if (!fullPath) {
+        return { relPath, fullPath, exists: false, outOfBounds: true }
+      }
       return { relPath, fullPath, exists: await pathExists(fullPath) }
     }),
   )
   // Process results in original order to keep error/log ordering deterministic
   const validPaths: string[] = []
-  for (const { relPath, fullPath, exists } of checks) {
+  for (const { relPath, fullPath, exists, outOfBounds } of checks) {
+    if (outOfBounds) {
+      logForDebugging(
+        `${componentLabel} path ${relPath} ${contextLabel} resolves outside plugin directory ${pluginPath} for ${pluginName}`,
+        { level: 'warn' },
+      )
+      errors.push({
+        type: 'generic-error',
+        source,
+        plugin: pluginName,
+        error: `${componentLabel} path ${relPath} resolves outside plugin directory for ${pluginName}`,
+      })
+      continue
+    }
     if (exists) {
-      validPaths.push(fullPath)
+      validPaths.push(fullPath!)
     } else {
       logForDebugging(
         `${componentLabel} path ${relPath} ${contextLabel} not found at ${fullPath} for ${pluginName}`,
@@ -1305,12 +1321,32 @@ async function validatePluginPaths(
         type: 'path-not-found',
         source,
         plugin: pluginName,
-        path: fullPath,
+        path: fullPath!,
         component,
       })
     }
   }
   return validPaths
+}
+
+export function resolvePluginComponentPath(
+  pluginPath: string,
+  componentPath: string,
+): string | null {
+  const root = resolve(pluginPath)
+  const fullPath = resolve(root, componentPath)
+  const relativePath = relative(root, fullPath)
+
+  if (
+    relativePath === '' ||
+    relativePath === '..' ||
+    relativePath.startsWith(`..${sep}`) ||
+    isAbsolute(relativePath)
+  ) {
+    return null
+  }
+
+  return fullPath
 }
 
 /**
@@ -1421,7 +1457,20 @@ export async function createPluginFromPath(
             return { commandName, metadata, kind: 'skip' as const }
           }
           if (metadata.source) {
-            const fullPath = join(pluginPath, metadata.source)
+            const fullPath = resolvePluginComponentPath(
+              pluginPath,
+              metadata.source,
+            )
+            if (!fullPath) {
+              return {
+                commandName,
+                metadata,
+                kind: 'source' as const,
+                fullPath,
+                exists: false,
+                outOfBounds: true,
+              }
+            }
             return {
               commandName,
               metadata,
@@ -1444,8 +1493,21 @@ export async function createPluginFromPath(
           continue
         }
         // kind === 'source'
+        if ('outOfBounds' in check && check.outOfBounds) {
+          logForDebugging(
+            `Command ${check.commandName} path ${check.metadata.source} specified in manifest resolves outside plugin directory ${pluginPath} for ${manifest.name}`,
+            { level: 'warn' },
+          )
+          errors.push({
+            type: 'generic-error',
+            source,
+            plugin: manifest.name,
+            error: `Command ${check.commandName} path ${check.metadata.source} resolves outside plugin directory for ${manifest.name}`,
+          })
+          continue
+        }
         if (check.exists) {
-          validPaths.push(check.fullPath)
+          validPaths.push(check.fullPath!)
           commandsMetadata[check.commandName] = check.metadata
         } else {
           logForDebugging(
@@ -1461,7 +1523,7 @@ export async function createPluginFromPath(
             type: 'path-not-found',
             source,
             plugin: manifest.name,
-            path: check.fullPath,
+            path: check.fullPath!,
             component: 'commands',
           })
         }
@@ -1487,7 +1549,10 @@ export async function createPluginFromPath(
           if (typeof cmdPath !== 'string') {
             return { cmdPath, kind: 'invalid' as const }
           }
-          const fullPath = join(pluginPath, cmdPath)
+          const fullPath = resolvePluginComponentPath(pluginPath, cmdPath)
+          if (!fullPath) {
+            return { cmdPath, kind: 'out-of-bounds' as const }
+          }
           return {
             cmdPath,
             kind: 'path' as const,
@@ -1503,6 +1568,19 @@ export async function createPluginFromPath(
             `Unexpected command format in manifest for ${manifest.name}`,
             { level: 'error' },
           )
+          continue
+        }
+        if (check.kind === 'out-of-bounds') {
+          logForDebugging(
+            `Command path ${check.cmdPath} specified in manifest resolves outside plugin directory ${pluginPath} for ${manifest.name}`,
+            { level: 'warn' },
+          )
+          errors.push({
+            type: 'generic-error',
+            source,
+            plugin: manifest.name,
+            error: `Command path ${check.cmdPath} resolves outside plugin directory for ${manifest.name}`,
+          })
           continue
         }
         if (check.exists) {
@@ -2487,7 +2565,20 @@ async function finishLoadingPluginFromPath(
             if (!metadata || typeof metadata !== 'object' || !metadata.source) {
               return { commandName, metadata, skip: true as const }
             }
-            const fullPath = join(pluginPath, metadata.source)
+            const fullPath = resolvePluginComponentPath(
+              pluginPath,
+              metadata.source,
+            )
+            if (!fullPath) {
+              return {
+                commandName,
+                metadata,
+                skip: false as const,
+                fullPath,
+                exists: false,
+                outOfBounds: true,
+              }
+            }
             return {
               commandName,
               metadata,
@@ -2499,8 +2590,21 @@ async function finishLoadingPluginFromPath(
         )
         for (const check of checks) {
           if (check.skip) continue
+          if ('outOfBounds' in check && check.outOfBounds) {
+            logForDebugging(
+              `Command ${check.commandName} path ${check.metadata.source} from marketplace entry resolves outside plugin directory ${pluginPath} for ${entry.name}`,
+              { level: 'warn' },
+            )
+            errors.push({
+              type: 'generic-error',
+              source: pluginId,
+              plugin: entry.name,
+              error: `Command ${check.commandName} path ${check.metadata.source} resolves outside plugin directory for ${entry.name}`,
+            })
+            continue
+          }
           if (check.exists) {
-            validPaths.push(check.fullPath)
+            validPaths.push(check.fullPath!)
             commandsMetadata[check.commandName] = check.metadata
           } else {
             logForDebugging(
@@ -2516,7 +2620,7 @@ async function finishLoadingPluginFromPath(
               type: 'path-not-found',
               source: pluginId,
               plugin: entry.name,
-              path: check.fullPath,
+              path: check.fullPath!,
               component: 'commands',
             })
           }
@@ -2538,7 +2642,10 @@ async function finishLoadingPluginFromPath(
             if (typeof cmdPath !== 'string') {
               return { cmdPath, kind: 'invalid' as const }
             }
-            const fullPath = join(pluginPath, cmdPath)
+            const fullPath = resolvePluginComponentPath(pluginPath, cmdPath)
+            if (!fullPath) {
+              return { cmdPath, kind: 'out-of-bounds' as const }
+            }
             return {
               cmdPath,
               kind: 'path' as const,
@@ -2554,6 +2661,19 @@ async function finishLoadingPluginFromPath(
               `Unexpected command format in marketplace entry for ${entry.name}`,
               { level: 'error' },
             )
+            continue
+          }
+          if (check.kind === 'out-of-bounds') {
+            logForDebugging(
+              `Command path ${check.cmdPath} from marketplace entry resolves outside plugin directory ${pluginPath} for ${entry.name}`,
+              { level: 'warn' },
+            )
+            errors.push({
+              type: 'generic-error',
+              source: pluginId,
+              plugin: entry.name,
+              error: `Command path ${check.cmdPath} resolves outside plugin directory for ${entry.name}`,
+            })
             continue
           }
           if (check.exists) {
@@ -2620,17 +2740,33 @@ async function finishLoadingPluginFromPath(
       // (once in a debug log template, once in the if) — now called once.
       const checks = await Promise.all(
         skillPaths.map(async skillPath => {
-          const fullPath = join(pluginPath, skillPath)
+          const fullPath = resolvePluginComponentPath(pluginPath, skillPath)
+          if (!fullPath) {
+            return { skillPath, fullPath, exists: false, outOfBounds: true }
+          }
           return { skillPath, fullPath, exists: await pathExists(fullPath) }
         }),
       )
       const validPaths: string[] = []
-      for (const { skillPath, fullPath, exists } of checks) {
+      for (const { skillPath, fullPath, exists, outOfBounds } of checks) {
+        if (outOfBounds) {
+          logForDebugging(
+            `Skill path ${skillPath} from marketplace entry resolves outside plugin directory ${pluginPath} for ${entry.name}`,
+            { level: 'warn' },
+          )
+          errors.push({
+            type: 'generic-error',
+            source: pluginId,
+            plugin: entry.name,
+            error: `Skill path ${skillPath} resolves outside plugin directory for ${entry.name}`,
+          })
+          continue
+        }
         logForDebugging(
           `Checking skill path: ${skillPath} -> ${fullPath} (exists: ${exists})`,
         )
         if (exists) {
-          validPaths.push(fullPath)
+          validPaths.push(fullPath!)
         } else {
           logForDebugging(
             `Skill path ${skillPath} from marketplace entry not found at ${fullPath} for ${entry.name}`,
@@ -2645,7 +2781,7 @@ async function finishLoadingPluginFromPath(
             type: 'path-not-found',
             source: pluginId,
             plugin: entry.name,
-            path: fullPath,
+            path: fullPath!,
             component: 'skills',
           })
         }
@@ -2738,7 +2874,20 @@ async function finishLoadingPluginFromPath(
             if (!metadata || typeof metadata !== 'object' || !metadata.source) {
               return { commandName, metadata, skip: true as const }
             }
-            const fullPath = join(pluginPath, metadata.source)
+            const fullPath = resolvePluginComponentPath(
+              pluginPath,
+              metadata.source,
+            )
+            if (!fullPath) {
+              return {
+                commandName,
+                metadata,
+                skip: false as const,
+                fullPath,
+                exists: false,
+                outOfBounds: true,
+              }
+            }
             return {
               commandName,
               metadata,
@@ -2750,8 +2899,21 @@ async function finishLoadingPluginFromPath(
         )
         for (const check of checks) {
           if (check.skip) continue
+          if ('outOfBounds' in check && check.outOfBounds) {
+            logForDebugging(
+              `Command ${check.commandName} path ${check.metadata.source} from marketplace entry resolves outside plugin directory ${pluginPath} for ${entry.name}`,
+              { level: 'warn' },
+            )
+            errors.push({
+              type: 'generic-error',
+              source: pluginId,
+              plugin: entry.name,
+              error: `Command ${check.commandName} path ${check.metadata.source} resolves outside plugin directory for ${entry.name}`,
+            })
+            continue
+          }
           if (check.exists) {
-            validPaths.push(check.fullPath)
+            validPaths.push(check.fullPath!)
             commandsMetadata[check.commandName] = check.metadata
           } else {
             logForDebugging(
@@ -2767,7 +2929,7 @@ async function finishLoadingPluginFromPath(
               type: 'path-not-found',
               source: pluginId,
               plugin: entry.name,
-              path: check.fullPath,
+              path: check.fullPath!,
               component: 'commands',
             })
           }
@@ -2792,7 +2954,10 @@ async function finishLoadingPluginFromPath(
             if (typeof cmdPath !== 'string') {
               return { cmdPath, kind: 'invalid' as const }
             }
-            const fullPath = join(pluginPath, cmdPath)
+            const fullPath = resolvePluginComponentPath(pluginPath, cmdPath)
+            if (!fullPath) {
+              return { cmdPath, kind: 'out-of-bounds' as const }
+            }
             return {
               cmdPath,
               kind: 'path' as const,
@@ -2808,6 +2973,19 @@ async function finishLoadingPluginFromPath(
               `Unexpected command format in marketplace entry for ${entry.name}`,
               { level: 'error' },
             )
+            continue
+          }
+          if (check.kind === 'out-of-bounds') {
+            logForDebugging(
+              `Command path ${check.cmdPath} from marketplace entry resolves outside plugin directory ${pluginPath} for ${entry.name}`,
+              { level: 'warn' },
+            )
+            errors.push({
+              type: 'generic-error',
+              source: pluginId,
+              plugin: entry.name,
+              error: `Command path ${check.cmdPath} resolves outside plugin directory for ${entry.name}`,
+            })
             continue
           }
           if (check.exists) {

--- a/src/utils/plugins/pluginLoader.ts
+++ b/src/utils/plugins/pluginLoader.ts
@@ -1279,15 +1279,12 @@ async function validatePluginPaths(
   contextLabel: string,
   errors: PluginError[],
 ): Promise<string[]> {
-  // Parallelize the async pathExists checks
+  // Parallelize the async path checks
   const checks = await Promise.all(
-    relPaths.map(async relPath => {
-      const fullPath = resolvePluginComponentPath(pluginPath, relPath)
-      if (!fullPath) {
-        return { relPath, fullPath, exists: false, outOfBounds: true }
-      }
-      return { relPath, fullPath, exists: await pathExists(fullPath) }
-    }),
+    relPaths.map(async relPath => ({
+      relPath,
+      ...(await resolveExistingPluginComponentPath(pluginPath, relPath)),
+    })),
   )
   // Process results in original order to keep error/log ordering deterministic
   const validPaths: string[] = []
@@ -1347,6 +1344,48 @@ export function resolvePluginComponentPath(
   }
 
   return fullPath
+}
+
+type ResolvedPluginComponentPath =
+  | { fullPath: null; exists: false; outOfBounds: true }
+  | { fullPath: string; exists: false; outOfBounds: false }
+  | { fullPath: string; exists: true; outOfBounds: false }
+  | { fullPath: string; exists: true; outOfBounds: true }
+
+export async function resolveExistingPluginComponentPath(
+  pluginPath: string,
+  componentPath: string,
+): Promise<ResolvedPluginComponentPath> {
+  const fullPath = resolvePluginComponentPath(pluginPath, componentPath)
+  if (!fullPath) {
+    return { fullPath: null, exists: false, outOfBounds: true }
+  }
+
+  if (!(await pathExists(fullPath))) {
+    return { fullPath, exists: false, outOfBounds: false }
+  }
+
+  const root = resolve(pluginPath)
+  const [realRoot, realTarget] = await Promise.all([
+    realpath(root),
+    realpath(fullPath),
+  ])
+
+  return {
+    fullPath,
+    exists: true,
+    outOfBounds: !isPathInside(realRoot, realTarget),
+  }
+}
+
+function isPathInside(rootPath: string, targetPath: string): boolean {
+  const relativePath = relative(rootPath, targetPath)
+  return (
+    relativePath === '' ||
+    (!relativePath.startsWith(`..${sep}`) &&
+      relativePath !== '..' &&
+      !isAbsolute(relativePath))
+  )
 }
 
 /**
@@ -1457,26 +1496,14 @@ export async function createPluginFromPath(
             return { commandName, metadata, kind: 'skip' as const }
           }
           if (metadata.source) {
-            const fullPath = resolvePluginComponentPath(
-              pluginPath,
-              metadata.source,
-            )
-            if (!fullPath) {
-              return {
-                commandName,
-                metadata,
-                kind: 'source' as const,
-                fullPath,
-                exists: false,
-                outOfBounds: true,
-              }
-            }
             return {
               commandName,
               metadata,
               kind: 'source' as const,
-              fullPath,
-              exists: await pathExists(fullPath),
+              ...(await resolveExistingPluginComponentPath(
+                pluginPath,
+                metadata.source,
+              )),
             }
           }
           if (metadata.content) {
@@ -1549,15 +1576,10 @@ export async function createPluginFromPath(
           if (typeof cmdPath !== 'string') {
             return { cmdPath, kind: 'invalid' as const }
           }
-          const fullPath = resolvePluginComponentPath(pluginPath, cmdPath)
-          if (!fullPath) {
-            return { cmdPath, kind: 'out-of-bounds' as const }
-          }
           return {
             cmdPath,
             kind: 'path' as const,
-            fullPath,
-            exists: await pathExists(fullPath),
+            ...(await resolveExistingPluginComponentPath(pluginPath, cmdPath)),
           }
         }),
       )
@@ -1570,7 +1592,7 @@ export async function createPluginFromPath(
           )
           continue
         }
-        if (check.kind === 'out-of-bounds') {
+        if (check.outOfBounds) {
           logForDebugging(
             `Command path ${check.cmdPath} specified in manifest resolves outside plugin directory ${pluginPath} for ${manifest.name}`,
             { level: 'warn' },
@@ -2565,26 +2587,14 @@ async function finishLoadingPluginFromPath(
             if (!metadata || typeof metadata !== 'object' || !metadata.source) {
               return { commandName, metadata, skip: true as const }
             }
-            const fullPath = resolvePluginComponentPath(
-              pluginPath,
-              metadata.source,
-            )
-            if (!fullPath) {
-              return {
-                commandName,
-                metadata,
-                skip: false as const,
-                fullPath,
-                exists: false,
-                outOfBounds: true,
-              }
-            }
             return {
               commandName,
               metadata,
               skip: false as const,
-              fullPath,
-              exists: await pathExists(fullPath),
+              ...(await resolveExistingPluginComponentPath(
+                pluginPath,
+                metadata.source,
+              )),
             }
           }),
         )
@@ -2642,15 +2652,10 @@ async function finishLoadingPluginFromPath(
             if (typeof cmdPath !== 'string') {
               return { cmdPath, kind: 'invalid' as const }
             }
-            const fullPath = resolvePluginComponentPath(pluginPath, cmdPath)
-            if (!fullPath) {
-              return { cmdPath, kind: 'out-of-bounds' as const }
-            }
             return {
               cmdPath,
               kind: 'path' as const,
-              fullPath,
-              exists: await pathExists(fullPath),
+              ...(await resolveExistingPluginComponentPath(pluginPath, cmdPath)),
             }
           }),
         )
@@ -2663,7 +2668,7 @@ async function finishLoadingPluginFromPath(
             )
             continue
           }
-          if (check.kind === 'out-of-bounds') {
+          if (check.outOfBounds) {
             logForDebugging(
               `Command path ${check.cmdPath} from marketplace entry resolves outside plugin directory ${pluginPath} for ${entry.name}`,
               { level: 'warn' },
@@ -2740,11 +2745,10 @@ async function finishLoadingPluginFromPath(
       // (once in a debug log template, once in the if) — now called once.
       const checks = await Promise.all(
         skillPaths.map(async skillPath => {
-          const fullPath = resolvePluginComponentPath(pluginPath, skillPath)
-          if (!fullPath) {
-            return { skillPath, fullPath, exists: false, outOfBounds: true }
+          return {
+            skillPath,
+            ...(await resolveExistingPluginComponentPath(pluginPath, skillPath)),
           }
-          return { skillPath, fullPath, exists: await pathExists(fullPath) }
         }),
       )
       const validPaths: string[] = []
@@ -2874,26 +2878,14 @@ async function finishLoadingPluginFromPath(
             if (!metadata || typeof metadata !== 'object' || !metadata.source) {
               return { commandName, metadata, skip: true as const }
             }
-            const fullPath = resolvePluginComponentPath(
-              pluginPath,
-              metadata.source,
-            )
-            if (!fullPath) {
-              return {
-                commandName,
-                metadata,
-                skip: false as const,
-                fullPath,
-                exists: false,
-                outOfBounds: true,
-              }
-            }
             return {
               commandName,
               metadata,
               skip: false as const,
-              fullPath,
-              exists: await pathExists(fullPath),
+              ...(await resolveExistingPluginComponentPath(
+                pluginPath,
+                metadata.source,
+              )),
             }
           }),
         )
@@ -2954,15 +2946,10 @@ async function finishLoadingPluginFromPath(
             if (typeof cmdPath !== 'string') {
               return { cmdPath, kind: 'invalid' as const }
             }
-            const fullPath = resolvePluginComponentPath(pluginPath, cmdPath)
-            if (!fullPath) {
-              return { cmdPath, kind: 'out-of-bounds' as const }
-            }
             return {
               cmdPath,
               kind: 'path' as const,
-              fullPath,
-              exists: await pathExists(fullPath),
+              ...(await resolveExistingPluginComponentPath(pluginPath, cmdPath)),
             }
           }),
         )
@@ -2975,7 +2962,7 @@ async function finishLoadingPluginFromPath(
             )
             continue
           }
-          if (check.kind === 'out-of-bounds') {
+          if (check.outOfBounds) {
             logForDebugging(
               `Command path ${check.cmdPath} from marketplace entry resolves outside plugin directory ${pluginPath} for ${entry.name}`,
               { level: 'warn' },

--- a/src/utils/plugins/pluginLoader.ts
+++ b/src/utils/plugins/pluginLoader.ts
@@ -1326,6 +1326,20 @@ async function validatePluginPaths(
   return validPaths
 }
 
+async function resolveDefaultPluginComponentDirectory(
+  pluginPath: string,
+  relPath: string,
+  componentLabel: string,
+): Promise<
+  ResolvedPluginComponentPath & { relPath: string; componentLabel: string }
+> {
+  return {
+    relPath,
+    componentLabel,
+    ...(await resolveExistingPluginComponentPath(pluginPath, relPath)),
+  }
+}
+
 export function resolvePluginComponentPath(
   pluginPath: string,
   componentPath: string,
@@ -1453,23 +1467,60 @@ export async function createPluginFromPath(
   }
 
   // Step 3: Auto-detect optional directories in parallel
-  const [
-    commandsDirExists,
-    agentsDirExists,
-    skillsDirExists,
-    outputStylesDirExists,
-  ] = await Promise.all([
-    !manifest.commands ? pathExists(join(pluginPath, 'commands')) : false,
-    !manifest.agents ? pathExists(join(pluginPath, 'agents')) : false,
-    !manifest.skills ? pathExists(join(pluginPath, 'skills')) : false,
+  const defaultDirectoryChecks = await Promise.all([
+    !manifest.commands
+      ? resolveDefaultPluginComponentDirectory(
+          pluginPath,
+          'commands',
+          'Command',
+        )
+      : null,
+    !manifest.agents
+      ? resolveDefaultPluginComponentDirectory(pluginPath, 'agents', 'Agent')
+      : null,
+    !manifest.skills
+      ? resolveDefaultPluginComponentDirectory(pluginPath, 'skills', 'Skill')
+      : null,
     !manifest.outputStyles
-      ? pathExists(join(pluginPath, 'output-styles'))
-      : false,
+      ? resolveDefaultPluginComponentDirectory(
+          pluginPath,
+          'output-styles',
+          'Output style',
+        )
+      : null,
   ])
 
-  const commandsPath = join(pluginPath, 'commands')
-  if (commandsDirExists) {
-    plugin.commandsPath = commandsPath
+  for (const check of defaultDirectoryChecks) {
+    if (!check) continue
+    if (check.outOfBounds) {
+      logForDebugging(
+        `${check.componentLabel} directory ${check.relPath} resolves outside plugin directory ${pluginPath} for ${manifest.name}`,
+        { level: 'warn' },
+      )
+      errors.push({
+        type: 'generic-error',
+        source,
+        plugin: manifest.name,
+        error: `${check.componentLabel} directory ${check.relPath} resolves outside plugin directory for ${manifest.name}`,
+      })
+      continue
+    }
+    if (!check.exists) continue
+
+    switch (check.relPath) {
+      case 'commands':
+        plugin.commandsPath = check.fullPath
+        break
+      case 'agents':
+        plugin.agentsPath = check.fullPath
+        break
+      case 'skills':
+        plugin.skillsPath = check.fullPath
+        break
+      case 'output-styles':
+        plugin.outputStylesPath = check.fullPath
+        break
+    }
   }
 
   // Step 3a: Process additional command paths from manifest
@@ -1633,13 +1684,7 @@ export async function createPluginFromPath(
     }
   }
 
-  // Step 4: Register agents directory if detected
-  const agentsPath = join(pluginPath, 'agents')
-  if (agentsDirExists) {
-    plugin.agentsPath = agentsPath
-  }
-
-  // Step 4a: Process additional agent paths from manifest
+  // Step 4: Process additional agent paths from manifest
   if (manifest.agents) {
     const agentPaths = Array.isArray(manifest.agents)
       ? manifest.agents
@@ -1661,13 +1706,7 @@ export async function createPluginFromPath(
     }
   }
 
-  // Step 4b: Register skills directory if detected
-  const skillsPath = join(pluginPath, 'skills')
-  if (skillsDirExists) {
-    plugin.skillsPath = skillsPath
-  }
-
-  // Step 4c: Process additional skill paths from manifest
+  // Step 5: Process additional skill paths from manifest
   if (manifest.skills) {
     const skillPaths = Array.isArray(manifest.skills)
       ? manifest.skills
@@ -1689,13 +1728,7 @@ export async function createPluginFromPath(
     }
   }
 
-  // Step 4d: Register output-styles directory if detected
-  const outputStylesPath = join(pluginPath, 'output-styles')
-  if (outputStylesDirExists) {
-    plugin.outputStylesPath = outputStylesPath
-  }
-
-  // Step 4e: Process additional output style paths from manifest
+  // Step 6: Process additional output style paths from manifest
   if (manifest.outputStyles) {
     const outputStylePaths = Array.isArray(manifest.outputStyles)
       ? manifest.outputStyles
@@ -1717,7 +1750,7 @@ export async function createPluginFromPath(
     }
   }
 
-  // Step 5: Load hooks configuration
+  // Step 7: Load hooks configuration
   let mergedHooks: HooksSettings | undefined
   const loadedHookPaths = new Set<string>() // Track loaded hook files
 
@@ -1865,7 +1898,7 @@ export async function createPluginFromPath(
     plugin.hooksConfig = mergedHooks
   }
 
-  // Step 6: Load plugin settings
+  // Step 8: Load plugin settings
   // Settings can come from settings.json in the plugin directory or from manifest.settings
   // Only allowlisted keys are kept (currently: agent)
   const pluginSettings = await loadPluginSettings(pluginPath, manifest)


### PR DESCRIPTION
## Summary

Validates plugin component paths before loading command, agent, and skill files so marketplace-provided paths cannot escape the installed plugin directory via traversal or absolute paths.

## Changes

- Adds `resolvePluginComponentPath()` to resolve component paths against the plugin root and reject out-of-bounds paths.
- Applies the guard to plugin component path loading, including marketplace command/skill paths and shared component path validation.
- Adds focused unit coverage for valid relative paths, traversal attempts, and absolute paths.

## Testing

- `npx -y bun@1.3.13 install --frozen-lockfile`
- `npx -y bun@1.3.13 test src/utils/plugins/pluginLoader.test.ts`
- `npx -y bun@1.3.13 run build`
- `npx -y bun@1.3.13 run smoke`

Note: I also ran `npx -y bun@1.3.13 run typecheck`; it still reports existing repository-wide type errors unrelated to this change. There are no `src/utils/plugins/pluginLoader.ts` errors after this patch.

Fixes #1058