### PR TITLE
feat: auto-register allowlisted channel plugins so --channels flag is optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-﻿# OpenClaude
+# OpenClaude
 
 OpenClaude is an open-source coding-agent CLI for cloud and local model providers.
 
@@ -124,7 +124,7 @@ If you have [Ollama](https://ollama.com) installed, you can skip the env var set
 ollama launch openclaude --model qwen2.5-coder:7b
 ```
 
-This automatically sets `ANTHROPIC_BASE_URL`, model routing, and auth so all API traffic goes through your local Ollama instance. Works with any model you have pulled â€” local or cloud.
+This automatically sets `ANTHROPIC_BASE_URL`, model routing, and auth so all API traffic goes through your local Ollama instance. Works with any model you have pulled — local or cloud.
 
 ## Setup Guides
 
@@ -165,7 +165,7 @@ Advanced and source-build guides:
 
 ## Channels (Telegram, Discord, etc.)
 
-OpenClaude can receive messages from external messaging platforms and reply through them â€” all inside your terminal session.
+OpenClaude can receive messages from external messaging platforms and reply through them — all inside your terminal session.
 
 ### How it works
 
@@ -187,7 +187,7 @@ Inside OpenClaude:
 1. Run `/install-plugin telegram` to install the Telegram channel plugin
 2. Run `/telegram:configure` to set your bot token (create one via [@BotFather](https://t.me/BotFather))
 3. Restart OpenClaude or run `/reload-plugins`
-4. Send a message to your bot on Telegram â€” Claude will receive and reply
+4. Send a message to your bot on Telegram — Claude will receive and reply
 
 Approved channel plugins (Telegram, Discord, iMessage) are auto-registered when they connect. No `--channels` flag needed for these official plugins.
 
@@ -200,7 +200,7 @@ For custom or unsigned channel servers, use the `--channels` flag:
 openclaude --channels plugin:my-channel@my-marketplace
 
 # Local development server
-openclaude --dangerously-load-development-channels --channels server:my-local-server
+openclaude --dangerously-load-development-channels server:my-local-server
 ```
 
 ### Permissions

--- a/README.md
+++ b/README.md
@@ -161,6 +161,51 @@ Advanced and source-build guides:
 - **Images**: URL and base64 image inputs for providers that support vision
 - **Provider profiles**: Guided setup plus saved user-level provider profile support
 - **Local and remote model backends**: Cloud APIs, local servers, and Apple Silicon local inference
+- **Channel messaging**: Receive and reply to messages from Telegram, Discord, and other channel plugins
+
+## Channels (Telegram, Discord, etc.)
+
+OpenClaude can receive messages from external messaging platforms and reply through them — all inside your terminal session.
+
+### How it works
+
+Channel plugins are MCP servers that bridge a messaging platform (Telegram, Discord, iMessage) to OpenClaude. When someone sends you a message:
+
+1. The plugin forwards it to OpenClaude as a channel notification
+2. OpenClaude wraps the message in a `<channel>` tag and queues it
+3. The model sees the message, decides how to reply, and calls the plugin's reply tool
+4. The plugin sends the reply back to the messaging platform
+
+### Quick start with Telegram
+
+```bash
+openclaude
+```
+
+Inside OpenClaude:
+
+1. Run `/install-plugin telegram` to install the Telegram channel plugin
+2. Run `/telegram:configure` to set your bot token (create one via [@BotFather](https://t.me/BotFather))
+3. Restart OpenClaude or run `/reload-plugins`
+4. Send a message to your bot on Telegram — Claude will receive and reply
+
+Approved channel plugins (Telegram, Discord, iMessage) are auto-registered when they connect. No `--channels` flag needed.
+
+### Custom / development channels
+
+For custom or unsigned channel servers, use the `--channels` flag:
+
+```bash
+# Plugin from a marketplace
+openclaude --channels plugin:my-channel@my-marketplace
+
+# Local development server
+openclaude --dangerously-load-development-channels --channels server:my-local-server
+```
+
+### Permissions
+
+Channel tools (reply, send, etc.) are auto-allowed for the session when a channel server registers. This means Claude can reply to channel messages without prompting you for permission each time.
 
 ## Provider Notes
 

--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ Inside OpenClaude:
 3. Restart OpenClaude or run `/reload-plugins`
 4. Send a message to your bot on Telegram — Claude will receive and reply
 
-Approved channel plugins (Telegram, Discord, iMessage) are auto-registered when they connect. No `--channels` flag needed.
+Approved channel plugins (Telegram, Discord, iMessage) are auto-registered when they connect. No `--channels` flag needed for these official plugins.
 
 ### Custom / development channels
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# OpenClaude
+﻿# OpenClaude
 
 OpenClaude is an open-source coding-agent CLI for cloud and local model providers.
 
@@ -124,7 +124,7 @@ If you have [Ollama](https://ollama.com) installed, you can skip the env var set
 ollama launch openclaude --model qwen2.5-coder:7b
 ```
 
-This automatically sets `ANTHROPIC_BASE_URL`, model routing, and auth so all API traffic goes through your local Ollama instance. Works with any model you have pulled — local or cloud.
+This automatically sets `ANTHROPIC_BASE_URL`, model routing, and auth so all API traffic goes through your local Ollama instance. Works with any model you have pulled â€” local or cloud.
 
 ## Setup Guides
 
@@ -165,7 +165,7 @@ Advanced and source-build guides:
 
 ## Channels (Telegram, Discord, etc.)
 
-OpenClaude can receive messages from external messaging platforms and reply through them — all inside your terminal session.
+OpenClaude can receive messages from external messaging platforms and reply through them â€” all inside your terminal session.
 
 ### How it works
 
@@ -187,7 +187,7 @@ Inside OpenClaude:
 1. Run `/install-plugin telegram` to install the Telegram channel plugin
 2. Run `/telegram:configure` to set your bot token (create one via [@BotFather](https://t.me/BotFather))
 3. Restart OpenClaude or run `/reload-plugins`
-4. Send a message to your bot on Telegram — Claude will receive and reply
+4. Send a message to your bot on Telegram â€” Claude will receive and reply
 
 Approved channel plugins (Telegram, Discord, iMessage) are auto-registered when they connect. No `--channels` flag needed for these official plugins.
 

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -20,6 +20,7 @@ const version = pkg.version
 // Most Anthropic-internal features stay off; open-build features can be
 // selectively enabled here when their full source exists in the mirror.
 const featureFlags: Record<string, boolean> = {
+<<<<<<< HEAD
   // ── Disabled: require Anthropic infrastructure or missing source ─────
   VOICE_MODE: false,              // Push-to-talk STT via claude.ai OAuth endpoint
   PROACTIVE: false,               // Autonomous agent mode (missing proactive/ module)
@@ -60,6 +61,30 @@ const featureFlags: Record<string, boolean> = {
   VERIFICATION_AGENT: true,           // Built-in read-only agent for test/verification
   PROMPT_CACHE_BREAK_DETECTION: true, // Detect & log unexpected prompt cache invalidations
   HOOK_PROMPTS: true,                 // Allow tools to request interactive user prompts
+  VOICE_MODE: false,
+  PROACTIVE: false,
+  KAIROS: false,
+  BRIDGE_MODE: false,
+  DAEMON: false,
+  AGENT_TRIGGERS: false,
+  MONITOR_TOOL: false,
+  ABLATION_BASELINE: false,
+  DUMP_SYSTEM_PROMPT: false,
+  CACHED_MICROCOMPACT: false,
+  COORDINATOR_MODE: false,
+  CONTEXT_COLLAPSE: false,
+  COMMIT_ATTRIBUTION: false,
+  TEAMMEM: false,
+  UDS_INBOX: false,
+  BG_SESSIONS: false,
+  AWAY_SUMMARY: false,
+  TRANSCRIPT_CLASSIFIER: false,
+  WEB_BROWSER_TOOL: false,
+  MESSAGE_ACTIONS: false,
+  BUDDY: true,
+  CHICAGO_MCP: false,
+  COWORKER_TYPE_TELEMETRY: false,
+  KAIROS_CHANNELS: true,              // Channel messaging (Telegram, Discord, iMessage) via MCP
 }
 
 // ── Pre-process: replace feature() calls with boolean literals ──────

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -1,10 +1,10 @@
-﻿/**
- * OpenClaude build script â€” bundles the TypeScript source into a single
+/**
+ * OpenClaude build script — bundles the TypeScript source into a single
  * distributable JS file using Bun's bundler.
  *
  * Handles:
  * - bun:bundle feature() flags for the open build
- * - MACRO.* globals â†’ inlined version/build-time constants
+ * - MACRO.* globals → inlined version/build-time constants
  * - src/ path aliases
  */
 
@@ -20,7 +20,7 @@ const version = pkg.version
 // Most Anthropic-internal features stay off; open-build features can be
 // selectively enabled here when their full source exists in the mirror.
 const featureFlags: Record<string, boolean> = {
-  // â”€â”€ Disabled: require Anthropic infrastructure or missing source â”€â”€â”€â”€â”€
+  // ── Disabled: require Anthropic infrastructure or missing source ─────
   VOICE_MODE: false,              // Push-to-talk STT via claude.ai OAuth endpoint
   PROACTIVE: false,               // Autonomous agent mode (missing proactive/ module)
   KAIROS: false,                  // Persistent assistant/session mode (cloud backend)
@@ -37,7 +37,7 @@ const featureFlags: Record<string, boolean> = {
   COWORKER_TYPE_TELEMETRY: false, // Telemetry for agent/coworker type classification
   MCP_SKILLS: false,              // Dynamic MCP skill discovery
 
-  // â”€â”€ Enabled: upstream defaults â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
+  // ── Enabled: upstream defaults ──────────────────────────────────────
   COORDINATOR_MODE: true,             // Multi-agent coordinator with worker delegation
   BUILTIN_EXPLORE_PLAN_AGENTS: true,  // Built-in Explore/Plan specialized subagents
   BUDDY: true,                        // Buddy mode for paired programming
@@ -45,12 +45,12 @@ const featureFlags: Record<string, boolean> = {
   TEAMMEM: true,                      // Team memory management
   MESSAGE_ACTIONS: true,              // Message action buttons in the UI
 
-  // â”€â”€ Enabled: new activations â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
+  // ── Enabled: new activations ────────────────────────────────────────
   DUMP_SYSTEM_PROMPT: true,           // --dump-system-prompt CLI flag for debugging
   CACHED_MICROCOMPACT: true,          // Cache-aware tool result truncation optimization
   AWAY_SUMMARY: true,                 // "While you were away" recap after 5min blur
   TRANSCRIPT_CLASSIFIER: true,        // Auto-approval classifier for safe tool uses
-  ULTRATHINK: true,                   // Deep thinking mode â€” type "ultrathink" to boost reasoning
+  ULTRATHINK: true,                   // Deep thinking mode — type "ultrathink" to boost reasoning
   TOKEN_BUDGET: true,                 // Token budget tracking with usage warnings
   HISTORY_PICKER: true,               // Enhanced interactive prompt history picker
   QUICK_SEARCH: true,                 // Ctrl+G quick search across prompts
@@ -63,11 +63,11 @@ const featureFlags: Record<string, boolean> = {
   KAIROS_CHANNELS: true,              // Channel messaging (Telegram, Discord, iMessage) via MCP
 }
 
-// â”€â”€ Pre-process: replace feature() calls with boolean literals â”€â”€â”€â”€â”€â”€
+// ── Pre-process: replace feature() calls with boolean literals ──────
 // Bun v1.3.9+ resolves `import { feature } from 'bun:bundle'` natively
 // before plugins can intercept it via onResolve. The bun: namespace is
 // handled by Bun's C++ resolver which runs before the JS plugin phase,
-// so the previous onResolve/onLoad shim was silently ineffective â€” ALL
+// so the previous onResolve/onLoad shim was silently ineffective — ALL
 // feature() calls evaluated to false regardless of the featureFlags map.
 //
 // Fix: pre-process source files to strip the bun:bundle import and
@@ -77,7 +77,7 @@ const featureFlags: Record<string, boolean> = {
 // Match feature('FLAG') calls, including multi-line: feature(\n  'FLAG',\n)
 const featureCallRe = /\bfeature\(\s*['"](\w+)['"][,\s]*\)/gs
 const featureImportRe = /import\s*\{[^}]*\bfeature\b[^}]*\}\s*from\s*['"]bun:bundle['"];?\s*\n?/g
-const modifiedFiles = new Map<string, string>() // path â†’ original content
+const modifiedFiles = new Map<string, string>() // path → original content
 
 function preProcessFeatureFlags(dir: string) {
   for (const ent of readdirSync(dir, { withFileTypes: true })) {
@@ -406,7 +406,7 @@ export const SeverityNumber = {};
                 checkAndRegister(m[4], fileDir, m[1] || m[3] || '')
               }
 
-              // Collect dynamic requires: require('...') â€” these are used
+              // Collect dynamic requires: require('...') — these are used
               // behind feature() gates and become live when flags are enabled.
               for (const m of code.matchAll(/require\(\s*['"](\.\.?\/[^'"]+)['"]\s*\)/g)) {
                 checkAndRegister(m[1], fileDir, '')
@@ -459,10 +459,10 @@ if (!result.success) {
   }
   process.exitCode = 1
 } else {
-  console.log(`âœ“ Built openclaude v${version} â†’ dist/cli.mjs`)
+  console.log(`✓ Built openclaude v${version} → dist/cli.mjs`)
 }
 
-// â”€â”€ SDK Bundle Build â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
+// ── SDK Bundle Build ──────────────────────────────────────────────────────
 // SDK is a separate bundle for npm consumption - must NOT bundle React/Ink
 console.log('Building SDK bundle...')
 
@@ -634,7 +634,7 @@ sdkResult = await Bun.build({
           path: args.path,
           namespace: 'sdk-missing-stub',
         }))
-        // Stub src/keybindings/ â€” React-dependent keybinding system not needed in SDK
+        // Stub src/keybindings/ — React-dependent keybinding system not needed in SDK
         build.onResolve({ filter: /^src\/keybindings\// }, (args) => ({
           path: args.path,
           namespace: 'sdk-missing-stub',
@@ -643,13 +643,13 @@ sdkResult = await Bun.build({
           path: args.path,
           namespace: 'sdk-missing-stub',
         }))
-        // Stub react-compiler-runtime â€” not needed in SDK bundle
+        // Stub react-compiler-runtime — not needed in SDK bundle
         build.onResolve({ filter: /^react-compiler-runtime$/ }, () => ({
           path: 'react-compiler-runtime',
           namespace: 'sdk-missing-stub',
         }))
         // Stub TUI-only React hook files that leak into SDK via tool imports.
-        // These are imported transitively through spawnMultiAgent â†’ It2SetupPrompt
+        // These are imported transitively through spawnMultiAgent → It2SetupPrompt
         // and through keybinding hooks. The SDK doesn't use TUI features.
         for (const hookPath of [
           'useDoublePress.js', 'useExitOnCtrlCD.js', 'useExitOnCtrlCDWithKeybindings.js',
@@ -661,13 +661,13 @@ sdkResult = await Bun.build({
             namespace: 'sdk-missing-stub',
           }))
         }
-        // Stub It2SetupPrompt.tsx â€” TUI component pulled in by spawnMultiAgent
+        // Stub It2SetupPrompt.tsx — TUI component pulled in by spawnMultiAgent
         build.onResolve({ filter: /It2SetupPrompt\.js$/ }, (args) => ({
           path: args.path,
           namespace: 'sdk-missing-stub',
         }))
 
-        // Stub react/jsx-dev-runtime with local no-op â€” tool .tsx files compile
+        // Stub react/jsx-dev-runtime with local no-op — tool .tsx files compile
         // to jsxDEV() calls that are never rendered in SDK headless mode.
         // This eliminates the external react/jsx-dev-runtime import entirely.
         build.onResolve({ filter: /^react\/jsx-dev-runtime$/ }, () => ({
@@ -747,7 +747,7 @@ export const Fragment = null;
         const fs = require('fs')
         const pathMod = require('path')
         const srcDir = pathMod.resolve(__dirname, '..', 'src')
-        const sdkStubExports = new Map<string, Set<string>>() // module path â†’ set of imported names
+        const sdkStubExports = new Map<string, Set<string>>() // module path → set of imported names
 
         function scanSdkStubImports() {
           function register(specifier: string, namedPart: string) {
@@ -758,7 +758,7 @@ export const Fragment = null;
             if (!sdkStubExports.has(specifier)) sdkStubExports.set(specifier, new Set())
             const names = sdkStubExports.get(specifier)!
             for (const s of rawNames) {
-              // Handle "originalName as localName" â€” export BOTH names
+              // Handle "originalName as localName" — export BOTH names
               // because Bun validates the original export name exists
               const asMatch = s.match(/^(\w+)\s+as\s+(\w+)$/)
               if (asMatch) {
@@ -890,16 +890,16 @@ if (!sdkResult.success) {
   }
   process.exitCode = 1
 } else {
-  console.log(`âœ“ Built SDK bundle â†’ dist/sdk.mjs`)
+  console.log(`✓ Built SDK bundle → dist/sdk.mjs`)
 }
 
 } finally {
   // Always restore source files, even if Bun.build() throws
   restoreModifiedFiles()
-  console.log(`  ðŸ”„ feature-flags: pre-processed ${numModified} files (restored)`)
+  console.log(`  🔄 feature-flags: pre-processed ${numModified} files (restored)`)
 }
 
-// â”€â”€ Validate SDK bundle for React/Ink leakage â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
+// ── Validate SDK bundle for React/Ink leakage ──────────────────────────────
 if (sdkResult?.success) {
   const sdkBundle = readFileSync('./dist/sdk.mjs', 'utf-8')
   // Patterns that indicate React/Ink code leaked into the SDK bundle.
@@ -914,15 +914,15 @@ if (sdkResult?.success) {
     if (match) leaks.push(match[0])
   }
   if (leaks.length > 0) {
-    console.error(`\nâŒ SDK bundle contains React/Ink imports (must be stubbed):`)
+    console.error(`\n❌ SDK bundle contains React/Ink imports (must be stubbed):`)
     for (const leak of leaks) console.error(`   - ${leak}`)
     process.exitCode = 1
   } else {
-    console.log(`âœ“ SDK bundle: no React/Ink leakage detected`)
+    console.log(`✓ SDK bundle: no React/Ink leakage detected`)
   }
 }
 
-// â”€â”€ Validate external lists â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
+// ── Validate external lists ──────────────────────────────────────────────
 if (result?.success && sdkResult?.success) {
   console.log('\nValidating external lists...')
   const validation = Bun.spawnSync(['bun', 'run', 'scripts/validate-externals.ts'], {

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -1,10 +1,10 @@
-/**
- * OpenClaude build script — bundles the TypeScript source into a single
+﻿/**
+ * OpenClaude build script â€” bundles the TypeScript source into a single
  * distributable JS file using Bun's bundler.
  *
  * Handles:
  * - bun:bundle feature() flags for the open build
- * - MACRO.* globals → inlined version/build-time constants
+ * - MACRO.* globals â†’ inlined version/build-time constants
  * - src/ path aliases
  */
 
@@ -20,7 +20,7 @@ const version = pkg.version
 // Most Anthropic-internal features stay off; open-build features can be
 // selectively enabled here when their full source exists in the mirror.
 const featureFlags: Record<string, boolean> = {
-  // ── Disabled: require Anthropic infrastructure or missing source ─────
+  // â”€â”€ Disabled: require Anthropic infrastructure or missing source â”€â”€â”€â”€â”€
   VOICE_MODE: false,              // Push-to-talk STT via claude.ai OAuth endpoint
   PROACTIVE: false,               // Autonomous agent mode (missing proactive/ module)
   KAIROS: false,                  // Persistent assistant/session mode (cloud backend)
@@ -37,7 +37,7 @@ const featureFlags: Record<string, boolean> = {
   COWORKER_TYPE_TELEMETRY: false, // Telemetry for agent/coworker type classification
   MCP_SKILLS: false,              // Dynamic MCP skill discovery
 
-  // ── Enabled: upstream defaults ──────────────────────────────────────
+  // â”€â”€ Enabled: upstream defaults â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
   COORDINATOR_MODE: true,             // Multi-agent coordinator with worker delegation
   BUILTIN_EXPLORE_PLAN_AGENTS: true,  // Built-in Explore/Plan specialized subagents
   BUDDY: true,                        // Buddy mode for paired programming
@@ -45,12 +45,12 @@ const featureFlags: Record<string, boolean> = {
   TEAMMEM: true,                      // Team memory management
   MESSAGE_ACTIONS: true,              // Message action buttons in the UI
 
-  // ── Enabled: new activations ────────────────────────────────────────
+  // â”€â”€ Enabled: new activations â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
   DUMP_SYSTEM_PROMPT: true,           // --dump-system-prompt CLI flag for debugging
   CACHED_MICROCOMPACT: true,          // Cache-aware tool result truncation optimization
   AWAY_SUMMARY: true,                 // "While you were away" recap after 5min blur
   TRANSCRIPT_CLASSIFIER: true,        // Auto-approval classifier for safe tool uses
-  ULTRATHINK: true,                   // Deep thinking mode — type "ultrathink" to boost reasoning
+  ULTRATHINK: true,                   // Deep thinking mode â€” type "ultrathink" to boost reasoning
   TOKEN_BUDGET: true,                 // Token budget tracking with usage warnings
   HISTORY_PICKER: true,               // Enhanced interactive prompt history picker
   QUICK_SEARCH: true,                 // Ctrl+G quick search across prompts
@@ -63,11 +63,11 @@ const featureFlags: Record<string, boolean> = {
   KAIROS_CHANNELS: true,              // Channel messaging (Telegram, Discord, iMessage) via MCP
 }
 
-// ── Pre-process: replace feature() calls with boolean literals ──────
+// â”€â”€ Pre-process: replace feature() calls with boolean literals â”€â”€â”€â”€â”€â”€
 // Bun v1.3.9+ resolves `import { feature } from 'bun:bundle'` natively
 // before plugins can intercept it via onResolve. The bun: namespace is
 // handled by Bun's C++ resolver which runs before the JS plugin phase,
-// so the previous onResolve/onLoad shim was silently ineffective — ALL
+// so the previous onResolve/onLoad shim was silently ineffective â€” ALL
 // feature() calls evaluated to false regardless of the featureFlags map.
 //
 // Fix: pre-process source files to strip the bun:bundle import and
@@ -77,7 +77,7 @@ const featureFlags: Record<string, boolean> = {
 // Match feature('FLAG') calls, including multi-line: feature(\n  'FLAG',\n)
 const featureCallRe = /\bfeature\(\s*['"](\w+)['"][,\s]*\)/gs
 const featureImportRe = /import\s*\{[^}]*\bfeature\b[^}]*\}\s*from\s*['"]bun:bundle['"];?\s*\n?/g
-const modifiedFiles = new Map<string, string>() // path → original content
+const modifiedFiles = new Map<string, string>() // path â†’ original content
 
 function preProcessFeatureFlags(dir: string) {
   for (const ent of readdirSync(dir, { withFileTypes: true })) {
@@ -406,7 +406,7 @@ export const SeverityNumber = {};
                 checkAndRegister(m[4], fileDir, m[1] || m[3] || '')
               }
 
-              // Collect dynamic requires: require('...') — these are used
+              // Collect dynamic requires: require('...') â€” these are used
               // behind feature() gates and become live when flags are enabled.
               for (const m of code.matchAll(/require\(\s*['"](\.\.?\/[^'"]+)['"]\s*\)/g)) {
                 checkAndRegister(m[1], fileDir, '')
@@ -459,10 +459,10 @@ if (!result.success) {
   }
   process.exitCode = 1
 } else {
-  console.log(`✓ Built openclaude v${version} → dist/cli.mjs`)
+  console.log(`âœ“ Built openclaude v${version} â†’ dist/cli.mjs`)
 }
 
-// ── SDK Bundle Build ──────────────────────────────────────────────────────
+// â”€â”€ SDK Bundle Build â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 // SDK is a separate bundle for npm consumption - must NOT bundle React/Ink
 console.log('Building SDK bundle...')
 
@@ -634,7 +634,7 @@ sdkResult = await Bun.build({
           path: args.path,
           namespace: 'sdk-missing-stub',
         }))
-        // Stub src/keybindings/ — React-dependent keybinding system not needed in SDK
+        // Stub src/keybindings/ â€” React-dependent keybinding system not needed in SDK
         build.onResolve({ filter: /^src\/keybindings\// }, (args) => ({
           path: args.path,
           namespace: 'sdk-missing-stub',
@@ -643,13 +643,13 @@ sdkResult = await Bun.build({
           path: args.path,
           namespace: 'sdk-missing-stub',
         }))
-        // Stub react-compiler-runtime — not needed in SDK bundle
+        // Stub react-compiler-runtime â€” not needed in SDK bundle
         build.onResolve({ filter: /^react-compiler-runtime$/ }, () => ({
           path: 'react-compiler-runtime',
           namespace: 'sdk-missing-stub',
         }))
         // Stub TUI-only React hook files that leak into SDK via tool imports.
-        // These are imported transitively through spawnMultiAgent → It2SetupPrompt
+        // These are imported transitively through spawnMultiAgent â†’ It2SetupPrompt
         // and through keybinding hooks. The SDK doesn't use TUI features.
         for (const hookPath of [
           'useDoublePress.js', 'useExitOnCtrlCD.js', 'useExitOnCtrlCDWithKeybindings.js',
@@ -661,13 +661,13 @@ sdkResult = await Bun.build({
             namespace: 'sdk-missing-stub',
           }))
         }
-        // Stub It2SetupPrompt.tsx — TUI component pulled in by spawnMultiAgent
+        // Stub It2SetupPrompt.tsx â€” TUI component pulled in by spawnMultiAgent
         build.onResolve({ filter: /It2SetupPrompt\.js$/ }, (args) => ({
           path: args.path,
           namespace: 'sdk-missing-stub',
         }))
 
-        // Stub react/jsx-dev-runtime with local no-op — tool .tsx files compile
+        // Stub react/jsx-dev-runtime with local no-op â€” tool .tsx files compile
         // to jsxDEV() calls that are never rendered in SDK headless mode.
         // This eliminates the external react/jsx-dev-runtime import entirely.
         build.onResolve({ filter: /^react\/jsx-dev-runtime$/ }, () => ({
@@ -747,7 +747,7 @@ export const Fragment = null;
         const fs = require('fs')
         const pathMod = require('path')
         const srcDir = pathMod.resolve(__dirname, '..', 'src')
-        const sdkStubExports = new Map<string, Set<string>>() // module path → set of imported names
+        const sdkStubExports = new Map<string, Set<string>>() // module path â†’ set of imported names
 
         function scanSdkStubImports() {
           function register(specifier: string, namedPart: string) {
@@ -758,7 +758,7 @@ export const Fragment = null;
             if (!sdkStubExports.has(specifier)) sdkStubExports.set(specifier, new Set())
             const names = sdkStubExports.get(specifier)!
             for (const s of rawNames) {
-              // Handle "originalName as localName" — export BOTH names
+              // Handle "originalName as localName" â€” export BOTH names
               // because Bun validates the original export name exists
               const asMatch = s.match(/^(\w+)\s+as\s+(\w+)$/)
               if (asMatch) {
@@ -890,16 +890,16 @@ if (!sdkResult.success) {
   }
   process.exitCode = 1
 } else {
-  console.log(`✓ Built SDK bundle → dist/sdk.mjs`)
+  console.log(`âœ“ Built SDK bundle â†’ dist/sdk.mjs`)
 }
 
 } finally {
   // Always restore source files, even if Bun.build() throws
   restoreModifiedFiles()
-  console.log(`  🔄 feature-flags: pre-processed ${numModified} files (restored)`)
+  console.log(`  ðŸ”„ feature-flags: pre-processed ${numModified} files (restored)`)
 }
 
-// ── Validate SDK bundle for React/Ink leakage ──────────────────────────────
+// â”€â”€ Validate SDK bundle for React/Ink leakage â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 if (sdkResult?.success) {
   const sdkBundle = readFileSync('./dist/sdk.mjs', 'utf-8')
   // Patterns that indicate React/Ink code leaked into the SDK bundle.
@@ -914,15 +914,15 @@ if (sdkResult?.success) {
     if (match) leaks.push(match[0])
   }
   if (leaks.length > 0) {
-    console.error(`\n❌ SDK bundle contains React/Ink imports (must be stubbed):`)
+    console.error(`\nâŒ SDK bundle contains React/Ink imports (must be stubbed):`)
     for (const leak of leaks) console.error(`   - ${leak}`)
     process.exitCode = 1
   } else {
-    console.log(`✓ SDK bundle: no React/Ink leakage detected`)
+    console.log(`âœ“ SDK bundle: no React/Ink leakage detected`)
   }
 }
 
-// ── Validate external lists ──────────────────────────────────────────────
+// â”€â”€ Validate external lists â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 if (result?.success && sdkResult?.success) {
   console.log('\nValidating external lists...')
   const validation = Bun.spawnSync(['bun', 'run', 'scripts/validate-externals.ts'], {

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -20,7 +20,6 @@ const version = pkg.version
 // Most Anthropic-internal features stay off; open-build features can be
 // selectively enabled here when their full source exists in the mirror.
 const featureFlags: Record<string, boolean> = {
-<<<<<<< HEAD
   // ── Disabled: require Anthropic infrastructure or missing source ─────
   VOICE_MODE: false,              // Push-to-talk STT via claude.ai OAuth endpoint
   PROACTIVE: false,               // Autonomous agent mode (missing proactive/ module)
@@ -36,7 +35,7 @@ const featureFlags: Record<string, boolean> = {
   WEB_BROWSER_TOOL: false,        // Built-in browser automation (source not mirrored)
   CHICAGO_MCP: false,             // Computer-use MCP (native Swift modules stubbed)
   COWORKER_TYPE_TELEMETRY: false, // Telemetry for agent/coworker type classification
-  MCP_SKILLS: false,              // Dynamic MCP skill discovery (src/skills/mcpSkills.ts not mirrored; enabling this causes "fetchMcpSkillsForClient is not a function" when MCP servers with resources connect — see #856)
+  MCP_SKILLS: false,              // Dynamic MCP skill discovery
 
   // ── Enabled: upstream defaults ──────────────────────────────────────
   COORDINATOR_MODE: true,             // Multi-agent coordinator with worker delegation
@@ -61,29 +60,6 @@ const featureFlags: Record<string, boolean> = {
   VERIFICATION_AGENT: true,           // Built-in read-only agent for test/verification
   PROMPT_CACHE_BREAK_DETECTION: true, // Detect & log unexpected prompt cache invalidations
   HOOK_PROMPTS: true,                 // Allow tools to request interactive user prompts
-  VOICE_MODE: false,
-  PROACTIVE: false,
-  KAIROS: false,
-  BRIDGE_MODE: false,
-  DAEMON: false,
-  AGENT_TRIGGERS: false,
-  MONITOR_TOOL: false,
-  ABLATION_BASELINE: false,
-  DUMP_SYSTEM_PROMPT: false,
-  CACHED_MICROCOMPACT: false,
-  COORDINATOR_MODE: false,
-  CONTEXT_COLLAPSE: false,
-  COMMIT_ATTRIBUTION: false,
-  TEAMMEM: false,
-  UDS_INBOX: false,
-  BG_SESSIONS: false,
-  AWAY_SUMMARY: false,
-  TRANSCRIPT_CLASSIFIER: false,
-  WEB_BROWSER_TOOL: false,
-  MESSAGE_ACTIONS: false,
-  BUDDY: true,
-  CHICAGO_MCP: false,
-  COWORKER_TYPE_TELEMETRY: false,
   KAIROS_CHANNELS: true,              // Channel messaging (Telegram, Discord, iMessage) via MCP
 }
 

--- a/src/bootstrap/state.ts
+++ b/src/bootstrap/state.ts
@@ -215,6 +215,10 @@ type State = {
   // --dangerously-load-development-channels (so ChannelsNotice can name the
   // right flag in policy-blocked messages)
   hasDevChannels: boolean
+  // True only when --channels was explicitly passed on the CLI. Controls TUI
+  // guard behaviour independently of allowedChannels, which may also be
+  // populated by official-plugin auto-registration without explicit opt-in.
+  channelModeEnabled: boolean
   // Dir containing the session's `.jsonl`; null = derive from originalCwd.
   sessionProjectDir: string | null
   // Cached prompt cache 1h TTL allowlist from GrowthBook (session-stable)
@@ -404,6 +408,7 @@ function getInitialState(): State {
     // Channel server allowlist from --channels flag
     allowedChannels: [],
     hasDevChannels: false,
+    channelModeEnabled: false,
     // Session project dir (null = derive from originalCwd)
     sessionProjectDir: null,
     // Prompt cache 1h allowlist (null = not yet fetched from GrowthBook)
@@ -1717,6 +1722,14 @@ export function getAllowedChannels(): ChannelEntry[] {
 
 export function setAllowedChannels(entries: ChannelEntry[]): void {
   STATE.allowedChannels = entries
+}
+
+export function getChannelModeEnabled(): boolean {
+  return STATE.channelModeEnabled
+}
+
+export function setChannelModeEnabled(value: boolean): void {
+  STATE.channelModeEnabled = value
 }
 
 export function getHasDevChannels(): boolean {

--- a/src/cli/print.ts
+++ b/src/cli/print.ts
@@ -1664,7 +1664,7 @@ function runHeadlessStreaming(
       // handler re-runs the full gate); just avoids dead buttons.
       let capabilities: { experimental?: Record<string, unknown> } | undefined
       if (
-        (feature('KAIROS') || feature('KAIROS_CHANNELS')) &&
+        true /* channels enabled */ &&
         connection.type === 'connected' &&
         connection.capabilities.experimental
       ) {
@@ -1850,9 +1850,18 @@ function runHeadlessStreaming(
       : undefined
 
   // Abort the current operation when a 'now' priority message arrives.
+  // Also wake the run loop when channel messages (priority 'next') arrive
+  // while the model is idle — without this, channel notifications enqueued
+  // between runs would sit in the queue until the next SDK message.
   subscribeToCommandQueue(() => {
     if (abortController && getCommandsByMaxPriority('now').length > 0) {
       abortController.abort('interrupt')
+    }
+    // Channel messages and other 'next' priority items: kick off run() if idle.
+    // run() checks `running` and returns immediately if already active, so this
+    // is safe to call unconditionally.
+    if (!running && hasCommandsInQueue()) {
+      void run()
     }
   })
 
@@ -1992,7 +2001,7 @@ function runHeadlessStreaming(
           // (setNotificationHandler replaces, not stacks) and no-ops for
           // non-allowlisted servers (one feature-flag check).
           for (const client of allMcpClients) {
-            reregisterChannelHandlerAfterReconnect(client)
+            reregisterChannelHandlerAfterReconnect(client, setAppState)
           }
 
           const allTools = buildAllTools(appState)
@@ -3183,7 +3192,7 @@ function runHeadlessStreaming(
             }
             if (result.client.type === 'connected') {
               registerElicitationHandlers([result.client])
-              reregisterChannelHandlerAfterReconnect(result.client)
+              reregisterChannelHandlerAfterReconnect(result.client, setAppState)
               sendControlResponseSuccess(message)
             } else {
               const errorMessage =
@@ -3274,7 +3283,7 @@ function runHeadlessStreaming(
             }))
             if (result.client.type === 'connected') {
               registerElicitationHandlers([result.client])
-              reregisterChannelHandlerAfterReconnect(result.client)
+              reregisterChannelHandlerAfterReconnect(result.client, setAppState)
               sendControlResponseSuccess(message)
             } else {
               const errorMessage =
@@ -3296,6 +3305,7 @@ function runHeadlessStreaming(
               ...dynamicMcpState.clients,
             ],
             output,
+            setAppState,
           )
         } else if (message.request.subtype === 'mcp_authenticate') {
           const { serverName } = message.request
@@ -4654,6 +4664,7 @@ function handleChannelEnable(
   serverName: string,
   connectionPool: readonly MCPServerConnection[],
   output: Stream<StdoutMessage>,
+  setAppState: (f: (prev: AppState) => AppState) => void,
 ): void {
   const respondError = (error: string) =>
     output.enqueue({
@@ -4661,7 +4672,7 @@ function handleChannelEnable(
       response: { subtype: 'error', request_id: requestId, error },
     })
 
-  if (!(feature('KAIROS') || feature('KAIROS_CHANNELS'))) {
+  if (false /* channels always enabled */) {
     return respondError('channels feature not available in this build')
   }
 
@@ -4715,6 +4726,27 @@ function handleChannelEnable(
     `${entry.name}@${entry.marketplace}` as AnalyticsMetadata_I_VERIFIED_THIS_IS_NOT_CODE_OR_FILEPATHS
   logMCPDebug(serverName, 'Channel notifications registered')
   logEvent('tengu_mcp_channel_enable', { plugin: pluginId })
+
+  // Auto-allow all tools from this channel server so the user
+  // isn't prompted every time Claude replies via the channel.
+  {
+    const serverRule = getMcpPrefix(serverName).slice(0, -2) // strip trailing __
+    setAppState(prev => {
+      const sessionRules =
+        prev.toolPermissionContext.alwaysAllowRules.session ?? []
+      if (sessionRules.includes(serverRule)) return prev
+      return {
+        ...prev,
+        toolPermissionContext: {
+          ...prev.toolPermissionContext,
+          alwaysAllowRules: {
+            ...prev.toolPermissionContext.alwaysAllowRules,
+            session: [...sessionRules, serverRule],
+          },
+        },
+      }
+    })
+  }
 
   // Identical enqueue shape to the interactive register block in
   // useManageMCPConnections. drainCommandQueue processes it between turns —
@@ -4775,8 +4807,9 @@ function handleChannelEnable(
  */
 function reregisterChannelHandlerAfterReconnect(
   connection: MCPServerConnection,
+  setAppState: (f: (prev: AppState) => AppState) => void,
 ): void {
-  if (!(feature('KAIROS') || feature('KAIROS_CHANNELS'))) return
+  if (false /* channels always enabled */) return
   if (connection.type !== 'connected') return
 
   const gate = gateChannelServer(
@@ -4785,6 +4818,26 @@ function reregisterChannelHandlerAfterReconnect(
     connection.config.pluginSource,
   )
   if (gate.action !== 'register') return
+
+  // Auto-allow all tools from this channel server (same as handleChannelEnable)
+  {
+    const serverRule = getMcpPrefix(connection.name).slice(0, -2)
+    setAppState(prev => {
+      const sessionRules =
+        prev.toolPermissionContext.alwaysAllowRules.session ?? []
+      if (sessionRules.includes(serverRule)) return prev
+      return {
+        ...prev,
+        toolPermissionContext: {
+          ...prev.toolPermissionContext,
+          alwaysAllowRules: {
+            ...prev.toolPermissionContext.alwaysAllowRules,
+            session: [...sessionRules, serverRule],
+          },
+        },
+      }
+    })
+  }
 
   const entry = findChannelEntry(connection.name, getAllowedChannels())
   const pluginId =

--- a/src/cli/print.ts
+++ b/src/cli/print.ts
@@ -4727,25 +4727,37 @@ function handleChannelEnable(
   logMCPDebug(serverName, 'Channel notifications registered')
   logEvent('tengu_mcp_channel_enable', { plugin: pluginId })
 
-  // Auto-allow all tools from this channel server so the user
-  // isn't prompted every time Claude replies via the channel.
-  {
-    const serverRule = getMcpPrefix(serverName).slice(0, -2) // strip trailing __
+  // Only auto-allow the minimal set of known channel reply tools,
+  // and only for official non-dev plugin channel entries.
+  if (entry?.kind === 'plugin' && entry?.dev !== true) {
+    const toolPrefix = getMcpPrefix(serverName)
+    const channelToolRules = [
+      `${toolPrefix}reply`,
+      `${toolPrefix}send`,
+    ]
     setAppState(prev => {
       const sessionRules =
         prev.toolPermissionContext.alwaysAllowRules.session ?? []
-      if (sessionRules.includes(serverRule)) return prev
+      const nextRules = channelToolRules.filter(
+        rule => !sessionRules.includes(rule),
+      )
+      if (nextRules.length === 0) return prev
       return {
         ...prev,
         toolPermissionContext: {
           ...prev.toolPermissionContext,
           alwaysAllowRules: {
             ...prev.toolPermissionContext.alwaysAllowRules,
-            session: [...sessionRules, serverRule],
+            session: [...sessionRules, ...nextRules],
           },
         },
       }
     })
+  } else {
+    logMCPDebug(
+      serverName,
+      'Skipping channel tool auto-allow for non-plugin or dev entry',
+    )
   }
 
   // Identical enqueue shape to the interactive register block in
@@ -4819,27 +4831,40 @@ function reregisterChannelHandlerAfterReconnect(
   )
   if (gate.action !== 'register') return
 
-  // Auto-allow all tools from this channel server (same as handleChannelEnable)
-  {
-    const serverRule = getMcpPrefix(connection.name).slice(0, -2)
+  const entry = findChannelEntry(connection.name, getAllowedChannels())
+
+  // Only auto-allow the minimal set of known channel reply tools,
+  // and only for official non-dev plugin channel entries.
+  if (entry?.kind === 'plugin' && entry?.dev !== true) {
+    const toolPrefix = getMcpPrefix(connection.name)
+    const channelToolRules = [
+      `${toolPrefix}reply`,
+      `${toolPrefix}send`,
+    ]
     setAppState(prev => {
       const sessionRules =
         prev.toolPermissionContext.alwaysAllowRules.session ?? []
-      if (sessionRules.includes(serverRule)) return prev
+      const nextRules = channelToolRules.filter(
+        rule => !sessionRules.includes(rule),
+      )
+      if (nextRules.length === 0) return prev
       return {
         ...prev,
         toolPermissionContext: {
           ...prev.toolPermissionContext,
           alwaysAllowRules: {
             ...prev.toolPermissionContext.alwaysAllowRules,
-            session: [...sessionRules, serverRule],
+            session: [...sessionRules, ...nextRules],
           },
         },
       }
     })
+  } else {
+    logMCPDebug(
+      connection.name,
+      'Skipping channel tool auto-allow for non-plugin or dev entry',
+    )
   }
-
-  const entry = findChannelEntry(connection.name, getAllowedChannels())
   const pluginId =
     entry?.kind === 'plugin'
       ? (`${entry.name}@${entry.marketplace}` as AnalyticsMetadata_I_VERIFIED_THIS_IS_NOT_CODE_OR_FILEPATHS)

--- a/src/cli/print.ts
+++ b/src/cli/print.ts
@@ -1,4 +1,4 @@
-﻿// biome-ignore-all assist/source/organizeImports: internal-only import markers must not be reordered
+// biome-ignore-all assist/source/organizeImports: internal-only import markers must not be reordered
 import { feature } from 'bun:bundle'
 import { readFile, stat } from 'fs/promises'
 import { dirname } from 'path'
@@ -598,13 +598,13 @@ export async function runHeadless(
     if (SandboxManager.isSandboxRequired()) {
       process.stderr.write(
         `\nError: sandbox required but unavailable: ${sandboxUnavailableReason}\n` +
-          `  sandbox.failIfUnavailable is set â€” refusing to start without a working sandbox.\n\n`,
+          `  sandbox.failIfUnavailable is set — refusing to start without a working sandbox.\n\n`,
       )
       gracefulShutdownSync(1)
       return
     }
     process.stderr.write(
-      `\nâš  Sandbox disabled: ${sandboxUnavailableReason}\n` +
+      `\n⚠  Sandbox disabled: ${sandboxUnavailableReason}\n` +
         `  Commands will run WITHOUT sandboxing. Network and filesystem restrictions will NOT be enforced.\n\n`,
     )
   } else if (SandboxManager.isSandboxingEnabled()) {
@@ -614,7 +614,7 @@ export async function runHeadless(
     try {
       await SandboxManager.initialize(structuredIO.createSandboxAskCallback())
     } catch (err) {
-      process.stderr.write(`\nâŒ Sandbox Error: ${errorMessage(err)}\n`)
+      process.stderr.write(`\n❌ Sandbox Error: ${errorMessage(err)}\n`)
       gracefulShutdownSync(1, 'other')
       return
     }
@@ -689,7 +689,7 @@ export async function runHeadless(
     restoredWorkerState: structuredIO.restoredWorkerState,
   })
 
-  // SessionStart hooks can emit initialUserMessage â€” the first user turn for
+  // SessionStart hooks can emit initialUserMessage — the first user turn for
   // headless orchestrator sessions where stdin is empty and additionalContext
   // alone (an attachment, not a turn) would leave the REPL with nothing to
   // respond to. The hook promise is awaited inside loadInitialMessages, so the
@@ -955,7 +955,7 @@ export async function runHeadless(
   logHeadlessProfilerTurn()
 
   // Drain any in-flight memory extraction before shutdown. The response is
-  // already flushed above, so this adds no user-visible latency â€” it just
+  // already flushed above, so this adds no user-visible latency — it just
   // delays process exit so gracefulShutdownSync's 5s failsafe doesn't kill
   // the forked agent mid-flight. Gated by isExtractModeActive so the
   // tengu_slate_thimble flag controls non-interactive extraction end-to-end.
@@ -1013,7 +1013,7 @@ function runHeadlessStreaming(
   let shutdownPromptInjected = false
   let heldBackResult: StdoutMessage | null = null
   let abortController: AbortController | undefined
-  // Same queue sendRequest() enqueues to â€” one FIFO for everything.
+  // Same queue sendRequest() enqueues to — one FIFO for everything.
   const output = structuredIO.outbound
 
   // Ctrl+C in -p mode: abort the in-flight query, then shut down gracefully.
@@ -1045,9 +1045,9 @@ function runHeadlessStreaming(
   })
 
   // Wire the central onChangeAppState mode-diff hook to the SDK output stream.
-  // This fires whenever ANY code path mutates toolPermissionContext.mode â€”
+  // This fires whenever ANY code path mutates toolPermissionContext.mode —
   // Shift+Tab, ExitPlanMode dialog, /plan slash command, rewind, bridge
-  // set_permission_mode, the query loop, stop_task â€” rather than the two
+  // set_permission_mode, the query loop, stop_task — rather than the two
   // paths that previously went through a bespoke wrapper.
   // The wrapper's body was fully redundant (it enqueued here AND called
   // notifySessionMetadataChanged, both of which onChangeAppState now covers);
@@ -1150,7 +1150,7 @@ function runHeadlessStreaming(
   )
 
   // Client-supplied readFileState seeds (via seed_read_state control request).
-  // The stdin IIFE runs concurrently with ask() â€” a seed arriving mid-turn
+  // The stdin IIFE runs concurrently with ask() — a seed arriving mid-turn
   // would be lost to ask()'s clone-then-replace (QueryEngine.ts finally block)
   // if written directly into readFileState. Instead, seeds land here, merge
   // into getReadFileCache's view (readFileState-wins-ties: seeds fill gaps),
@@ -1263,7 +1263,7 @@ function runHeadlessStreaming(
       ) {
         continue
       }
-      // Skip SDK MCP servers â€” elicitation flows through SdkControlClientTransport
+      // Skip SDK MCP servers — elicitation flows through SdkControlClientTransport
       if (connection.config.type === 'sdk') {
         continue
       }
@@ -1286,7 +1286,7 @@ function runHeadlessStreaming(
               mode: mode as AnalyticsMetadata_I_VERIFIED_THIS_IS_NOT_CODE_OR_FILEPATHS,
             })
 
-            // Run elicitation hooks first â€” they can provide a response programmatically
+            // Run elicitation hooks first — they can provide a response programmatically
             const hookResponse = await runElicitationHooks(
               serverName,
               request.params,
@@ -1376,7 +1376,7 @@ function runHeadlessStreaming(
         elicitationRegistered.add(serverName)
       } catch {
         // setRequestHandler throws if the client wasn't created with
-        // elicitation capability â€” skip silently
+        // elicitation capability — skip silently
       }
     }
   }
@@ -1397,7 +1397,7 @@ function runHeadlessStreaming(
     const hasPendingSdkClients = sdkClients.some(c => c.type === 'pending')
     // Check if any SDK clients failed their handshake and need to be retried.
     // Without this, a client that lands in 'failed' (e.g. handshake timeout on
-    // a WS reconnect race) stays failed forever â€” its name satisfies the
+    // a WS reconnect race) stays failed forever — its name satisfies the
     // connectedServerNames diff but it contributes zero tools.
     const hasFailedSdkClients = sdkClients.some(c => c.type === 'failed')
 
@@ -1427,7 +1427,7 @@ function runHeadlessStreaming(
       sdkTools = sdkSetup.tools
 
       // Store SDK MCP tools in appState so subagents can access them via
-      // assembleToolPool. Only tools are stored here â€” SDK clients are already
+      // assembleToolPool. Only tools are stored here — SDK clients are already
       // merged separately in the query loop (allMcpClients) and mcp_status handler.
       // Use both old (connectedServerNames) and new (currentServerNames) to remove
       // stale SDK tools when servers are added or removed.
@@ -1498,7 +1498,7 @@ function runHeadlessStreaming(
   // Mirrors the REPL's useReplBridge hook: the handle is created when
   // `remote_control` is enabled and torn down when disabled.
   let bridgeHandle: ReplBridgeHandle | null = null
-  // Cursor into mutableMessages â€” tracks how far we've forwarded.
+  // Cursor into mutableMessages — tracks how far we've forwarded.
   // Same index-based diff as useReplBridge's lastWrittenIndexRef.
   let bridgeLastForwardedIndex = 0
 
@@ -1507,7 +1507,7 @@ function runHeadlessStreaming(
   // and stays alive during permission waits) and again after the turn.
   //
   // writeMessages has its own UUID-based dedup (initialMessageUUIDs,
-  // recentPostedUUIDs) â€” the index cursor here is a pre-filter to avoid
+  // recentPostedUUIDs) — the index cursor here is a pre-filter to avoid
   // O(n) re-scanning of already-sent messages on every call.
   function forwardMessagesToBridge(): void {
     if (!bridgeHandle) return
@@ -1660,7 +1660,7 @@ function runHeadlessStreaming(
           : undefined
       // Capabilities passthrough with allowlist pre-filter. The IDE reads
       // experimental['claude/channel'] to decide whether to show the
-      // Enable-channel prompt â€” only echo it if channel_enable would
+      // Enable-channel prompt — only echo it if channel_enable would
       // actually pass the allowlist. Not a security boundary (the
       // handler re-runs the full gate); just avoids dead buttons.
       let capabilities: { experimental?: Record<string, unknown> } | undefined
@@ -1765,14 +1765,14 @@ function runHeadlessStreaming(
     currentCommands = await getCommands(cwd())
 
     // Preserve SDK-provided agents (--agents CLI flag or SDK initialize
-    // control_request) â€” both inject via parseAgentsFromJson with
+    // control_request) — both inject via parseAgentsFromJson with
     // source='flagSettings'. loadMarkdownFilesForSubdir never assigns this
     // source, so it cleanly discriminates "injected, not disk-loadable".
     //
     // The previous filter used a negative set-diff (!freshAgentTypes.has(a))
     // which also matched plugin agents that were in the poisoned initial
     // currentAgents but correctly excluded from freshAgentDefs after managed
-    // settings applied â€” leaking policy-blocked agents into the init message.
+    // settings applied — leaking policy-blocked agents into the init message.
     // See gh-23085: isBridgeEnabled() at Commander-definition time poisoned
     // the settings cache before setEligibility(true) ran.
     const sdkAgents = currentAgents.filter(a => a.source === 'flagSettings')
@@ -1852,7 +1852,7 @@ function runHeadlessStreaming(
 
   // Abort the current operation when a 'now' priority message arrives.
   // Also wake the run loop when channel messages (priority 'next') arrive
-  // while the model is idle â€” without this, channel notifications enqueued
+  // while the model is idle — without this, channel notifications enqueued
   // between runs would sit in the queue until the next SDK message.
   subscribeToCommandQueue(() => {
     if (abortController && getCommandsByMaxPriority('now').length > 0) {
@@ -1921,7 +1921,7 @@ function runHeadlessStreaming(
       setupPluginHookHotReload()
     }
 
-    // Only main-thread commands (agentId===undefined) â€” subagent
+    // Only main-thread commands (agentId===undefined) — subagent
     // notifications are drained by the subagent's mid-turn gate in query.ts.
     // Defined outside the try block so it's accessible in the post-finally
     // queue re-checks at the bottom of run().
@@ -1998,7 +1998,7 @@ function runHeadlessStreaming(
           registerElicitationHandlers(allMcpClients)
           // Channel handlers for servers allowlisted via --channels at
           // construction time (or enableChannel() mid-session). Runs every
-          // turn like registerElicitationHandlers â€” idempotent per-client
+          // turn like registerElicitationHandlers — idempotent per-client
           // (setNotificationHandler replaces, not stacks) and no-ops for
           // non-allowlisted servers (one feature-flag check).
           for (const client of allMcpClients) {
@@ -2065,7 +2065,7 @@ function runHeadlessStreaming(
             )
 
             // Only emit a task_notification SDK event when a <status> tag is
-            // present â€” that means this is a terminal notification (completed/
+            // present — that means this is a terminal notification (completed/
             // failed/stopped). Stream events from enqueueStreamEvent carry no
             // <status> (they're progress pings); emitting them here would
             // default to 'completed' and falsely close the task for SDK
@@ -2383,7 +2383,7 @@ function runHeadlessStreaming(
         await drainCommandQueue()
 
         // Check for running background tasks before exiting.
-        // Exclude in_process_teammate â€” teammates are long-lived by design
+        // Exclude in_process_teammate — teammates are long-lived by design
         // (status: 'running' for their whole lifetime, cleaned up by the
         // shutdown protocol, not by transitioning to 'completed'). Waiting
         // on them here loops forever (gh-30008). Same exclusion already
@@ -2699,7 +2699,7 @@ function runHeadlessStreaming(
 
   // Cron scheduler: runs scheduled_tasks.json tasks in SDK/-p mode.
   // Mirrors REPL's useScheduledTasks hook. Fired prompts enqueue + kick
-  // off run() directly â€” unlike REPL, there's no queue subscriber here
+  // off run() directly — unlike REPL, there's no queue subscriber here
   // that drains on enqueue while idle. The run() mutex makes this safe
   // during an active turn: the call no-ops and the post-run recheck at
   // the end of run() picks up the queued command.
@@ -2714,8 +2714,8 @@ function runHeadlessStreaming(
           value: prompt,
           uuid: randomUUID(),
           priority: 'later',
-          // System-generated â€” matches useScheduledTasks.ts REPL equivalent.
-          // Without this, messages.ts metaProp eval is {} â†’ prompt leaks
+          // System-generated — matches useScheduledTasks.ts REPL equivalent.
+          // Without this, messages.ts metaProp eval is {} → prompt leaks
           // into visible transcript when cron fires mid-turn in -p mode.
           isMeta: true,
           // Threaded to cc_workload= in the billing-header attribution block
@@ -2787,17 +2787,17 @@ function runHeadlessStreaming(
     (callbackUrl: string) => void
   >()
   // Track servers where the manual callback was actually invoked (so the
-  // automatic reconnect path knows to skip â€” the extension will reconnect).
+  // automatic reconnect path knows to skip — the extension will reconnect).
   const oauthManualCallbackUsed = new Set<string>()
   // Track OAuth auth-only promises so mcp_oauth_callback_url can await
   // token exchange completion. Reconnect is handled separately by the
-  // extension via handleAuthDone â†’ mcp_reconnect.
+  // extension via handleAuthDone → mcp_reconnect.
   const oauthAuthPromises = new Map<string, Promise<void>>()
 
   // In-flight Anthropic OAuth flow (claude_authenticate). Single-slot: a
   // second authenticate request cleans up the first. The service holds the
   // PKCE verifier + localhost listener; the promise settles after
-  // installOAuthTokens â€” after it resolves, the in-process memoized token
+  // installOAuthTokens — after it resolves, the in-process memoized token
   // cache is already cleared and the next API call picks up the new creds.
   let claudeOAuth: {
     service: OAuthService
@@ -2814,7 +2814,7 @@ function runHeadlessStreaming(
     let initialized = false
     logForDiagnosticsNoPII('info', 'cli_message_loop_started')
     for await (const message of structuredIO.structuredInput) {
-      // Non-user events are handled inline (no queue). startedâ†’completed in
+      // Non-user events are handled inline (no queue). started→completed in
       // the same tick carries no information, so only fire completed.
       // control_response is reported by StructuredIO.processLine (which also
       // sees orphans that never yield here).
@@ -2859,7 +2859,7 @@ function runHeadlessStreaming(
           suggestionState.lastEmitted = null
           suggestionState.pendingSuggestion = null
           sendControlResponseSuccess(message)
-          break // exits for-await â†’ falls through to inputClosed=true drain below
+          break // exits for-await → falls through to inputClosed=true drain below
         } else if (message.request.subtype === 'initialize') {
           // SDK MCP server names from the initialize message
           // Populated by both browser and ProcessTransport sessions
@@ -3021,20 +3021,20 @@ function runHeadlessStreaming(
           try {
             // expandPath: all other readFileState writers normalize (~, relative,
             // session cwd vs process cwd). FileEditTool looks up by expandPath'd
-            // key â€” a verbatim client path would miss.
+            // key — a verbatim client path would miss.
             const normalizedPath = expandPath(message.request.path)
             // Check disk mtime before reading content. If the file changed
             // since the client's observation, readFile would return C_current
-            // but we'd store it with the client's M_observed â€” getChangedFiles
+            // but we'd store it with the client's M_observed — getChangedFiles
             // then sees disk > cache.timestamp, re-reads, diffs C_current vs
             // C_current = empty, emits no attachment, and the model is never
-            // told about the C_observed â†’ C_current change. Skipping the seed
-            // makes Edit fail "file not read yet" â†’ forces a fresh Read.
+            // told about the C_observed → C_current change. Skipping the seed
+            // makes Edit fail "file not read yet" → forces a fresh Read.
             // Math.floor matches FileReadTool and getFileModificationTime.
             const diskMtime = Math.floor((await stat(normalizedPath)).mtimeMs)
             if (diskMtime <= message.request.mtime) {
               const raw = await readFile(normalizedPath, 'utf-8')
-              // Strip BOM + normalize CRLFâ†’LF to match readFileInRange and
+              // Strip BOM + normalize CRLF→LF to match readFileInRange and
               // readFileSyncWithMetadata. FileEditTool's content-compare
               // fallback (for Windows mtime bumps without content change)
               // compares against LF-normalized disk reads.
@@ -3049,7 +3049,7 @@ function runHeadlessStreaming(
               })
             }
           } catch {
-            // ENOENT etc â€” skip seeding but still succeed
+            // ENOENT etc — skip seeding but still succeed
           }
           sendControlResponseSuccess(message)
         } else if (message.request.subtype === 'mcp_set_servers') {
@@ -3083,7 +3083,7 @@ function runHeadlessStreaming(
             )
             currentAgents = [...r.agentDefinitions.allAgents, ...sdkAgents]
 
-            // Reload succeeded â€” gather response data best-effort so a
+            // Reload succeeded — gather response data best-effort so a
             // read failure doesn't mask the successful state change.
             // allSettled so one failure doesn't discard the others.
             let plugins: SDKControlReloadPluginsResponse['plugins'] = []
@@ -3299,7 +3299,7 @@ function runHeadlessStreaming(
           handleChannelEnable(
             message.request_id,
             message.request.serverName,
-            // Pool spread matches mcp_status â€” all three client sources.
+            // Pool spread matches mcp_status — all three client sources.
             [
               ...currentAppState.mcp.clients,
               ...sdkClients,
@@ -3369,13 +3369,13 @@ function runHeadlessStreaming(
               }
 
               // Store auth-only promise for mcp_oauth_callback_url handler.
-              // Don't swallow errors â€” the callback handler needs to detect
+              // Don't swallow errors — the callback handler needs to detect
               // auth failures and report them to the caller.
               oauthAuthPromises.set(serverName, oauthPromise)
 
-              // Handle background completion â€” reconnect after auth.
+              // Handle background completion — reconnect after auth.
               // When manual callback is used, skip the reconnect here;
-              // the extension's handleAuthDone â†’ mcp_reconnect handles it
+              // the extension's handleAuthDone → mcp_reconnect handles it
               // (which also updates dynamicMcpState for tool registration).
               const fullFlowPromise = oauthPromise
                 .then(async () => {
@@ -3383,7 +3383,7 @@ function runHeadlessStreaming(
                   if (isMcpServerDisabled(serverName)) {
                     return
                   }
-                  // Skip reconnect if the manual callback path was used â€”
+                  // Skip reconnect if the manual callback path was used —
                   // handleAuthDone will do it via mcp_reconnect (which
                   // updates dynamicMcpState for tool registration).
                   if (oauthManualCallbackUsed.has(serverName)) {
@@ -3487,7 +3487,7 @@ function runHeadlessStreaming(
               oauthManualCallbackUsed.add(serverName)
               submit(callbackUrl)
               // Wait for auth (token exchange) to complete before responding.
-              // Reconnect is handled by the extension via handleAuthDone â†’
+              // Reconnect is handled by the extension via handleAuthDone →
               // mcp_reconnect (which updates dynamicMcpState for tools).
               const authPromise = oauthAuthPromises.get(serverName)
               if (authPromise) {
@@ -3515,8 +3515,8 @@ function runHeadlessStreaming(
         } else if (message.request.subtype === 'claude_authenticate') {
           // Anthropic OAuth over the control channel. The SDK client owns
           // the user's browser (we're headless in -p mode); we hand back
-          // both URLs and wait. Automatic URL â†’ localhost listener catches
-          // the redirect if the browser is on this host; manual URL â†’ the
+          // both URLs and wait. Automatic URL → localhost listener catches
+          // the redirect if the browser is on this host; manual URL → the
           // success page shows "code#state" for claude_oauth_callback.
           const { loginWithClaudeAi } = message.request
 
@@ -3524,7 +3524,7 @@ function runHeadlessStreaming(
           // and nulls the manual resolver. The prior `flow` promise is left
           // pending (AuthCodeListener.close() does not reject) but its object
           // graph becomes unreachable once the server handle is released and
-          // is GC'd â€” no fd or port is held.
+          // is GC'd — no fd or port is held.
           claudeOAuth?.service.cleanup()
 
           logEvent('tengu_oauth_flow_start', {
@@ -3556,9 +3556,9 @@ function runHeadlessStreaming(
               },
             )
             .then(async tokens => {
-              // installOAuthTokens: performLogout (clear stale state) â†’
-              // store profile â†’ saveOAuthTokensIfNeeded â†’ clearOAuthTokenCache
-              // â†’ clearAuthRelatedCaches. After this resolves, the memoized
+              // installOAuthTokens: performLogout (clear stale state) →
+              // store profile → saveOAuthTokensIfNeeded → clearOAuthTokenCache
+              // → clearAuthRelatedCaches. After this resolves, the memoized
               // getClaudeAIOAuthTokens in this process is invalidated; the
               // next API call re-reads keychain/file and works. No respawn.
               await installOAuthTokens(tokens)
@@ -3616,7 +3616,7 @@ function runHeadlessStreaming(
               'No active claude_authenticate flow',
             )
           } else {
-            // Inject the manual code synchronously â€” must happen in stdin
+            // Inject the manual code synchronously — must happen in stdin
             // message order so a subsequent claude_authenticate doesn't
             // replace the service before this code lands.
             if (message.request.subtype === 'claude_oauth_callback') {
@@ -3625,7 +3625,7 @@ function runHeadlessStreaming(
                 state: message.request.state,
               })
             }
-            // Detach the await â€” the stdin reader is serial and blocking
+            // Detach the await — the stdin reader is serial and blocking
             // here deadlocks claude_oauth_wait_for_completion: flow may
             // only resolve via a future claude_oauth_callback on stdin,
             // which can't be read while we're parked. Capture the binding;
@@ -3698,7 +3698,7 @@ function runHeadlessStreaming(
             sendControlResponseSuccess(message, {})
           }
         } else if (message.request.subtype === 'apply_flag_settings') {
-          // Snapshot the current model before applying â€” we need to detect
+          // Snapshot the current model before applying — we need to detect
           // model switches so we can inject breadcrumbs and notify listeners.
           const prevModel = getMainLoopModel()
 
@@ -3721,7 +3721,7 @@ function runHeadlessStreaming(
           // Route through notifyChange so fanOut() resets the settings cache
           // before listeners run. The subscriber at :392 calls
           // applySettingsChange for us. Pre-#20625 this was a direct
-          // applySettingsChange() call that relied on its own internal reset â€”
+          // applySettingsChange() call that relied on its own internal reset —
           // now that the reset is centralized in fanOut, a direct call here
           // would read stale cached settings and silently drop the update.
           // Bonus: going through notifyChange also tells the other subscribers
@@ -3757,7 +3757,7 @@ function runHeadlessStreaming(
         } else if (message.request.subtype === 'get_settings') {
           const currentAppState = getAppState()
           const model = getMainLoopModel()
-          // modelSupportsEffort gate matches claude.ts â€” applied.effort must
+          // modelSupportsEffort gate matches claude.ts — applied.effort must
           // mirror what actually goes to the API, not just what's configured.
           const effort = modelSupportsEffort(model)
             ? resolveAppliedEffort(model, currentAppState.effortValue)
@@ -3766,7 +3766,7 @@ function runHeadlessStreaming(
             ...getSettingsWithSources(),
             applied: {
               model,
-              // Numeric effort (internal-only) â†’ null; SDK schema is string-level only.
+              // Numeric effort (internal-only) → null; SDK schema is string-level only.
               effort: typeof effort === 'string' ? effort : null,
             },
           })
@@ -3788,7 +3788,7 @@ function runHeadlessStreaming(
           const { description, persist } = message.request
           // Reuse the live controller only if it has not already been aborted
           // (e.g. by interrupt()); an aborted signal would cause queryHaiku to
-          // immediately throw APIUserAbortError â†’ {title: null}.
+          // immediately throw APIUserAbortError → {title: null}.
           const titleSignal = (
             abortController && !abortController.signal.aborted
               ? abortController
@@ -3806,7 +3806,7 @@ function runHeadlessStreaming(
               }
               sendControlResponseSuccess(message, { title })
             } catch (e) {
-              // Unreachable in practice â€” generateSessionTitle wraps its
+              // Unreachable in practice — generateSessionTitle wraps its
               // own body and returns null, saveAiGeneratedTitle is wrapped
               // above. Propagate (not swallow) so unexpected failures are
               // visible to the SDK caller (hostComms.ts catches and logs).
@@ -3814,20 +3814,20 @@ function runHeadlessStreaming(
             }
           })()
         } else if (message.request.subtype === 'side_question') {
-          // Same fire-and-forget pattern as generate_session_title above â€”
+          // Same fire-and-forget pattern as generate_session_title above —
           // the forked agent's API roundtrip must not block the stdin loop.
           //
           // The snapshot captured by stopHooks (for querySource === 'sdk')
           // holds the exact systemPrompt/userContext/systemContext/messages
           // sent on the last main-thread turn. Reusing them gives a byte-
-          // identical prefix â†’ prompt cache hit.
+          // identical prefix → prompt cache hit.
           //
-          // Fallback (resume before first turn completes â€” no snapshot yet):
+          // Fallback (resume before first turn completes — no snapshot yet):
           // rebuild from scratch. buildSideQuestionFallbackParams mirrors
           // QueryEngine.ts:ask()'s system prompt assembly (including
           // --system-prompt / --append-system-prompt) so the rebuilt prefix
           // matches in the common case. May still miss the cache for
-          // coordinator mode or memory-mechanics extras â€” acceptable, the
+          // coordinator mode or memory-mechanics extras — acceptable, the
           // alternative is the side question failing entirely.
           const { question } = message.request
           void (async () => {
@@ -3840,7 +3840,7 @@ function runHeadlessStreaming(
                     // already-aborted controller; createChildAbortController in
                     // createSubagentContext would propagate it and the fork
                     // would die before sending a request. The controller is
-                    // not part of the cache key â€” swapping in a fresh one is
+                    // not part of the cache key — swapping in a fresh one is
                     // safe. Same guard as generate_session_title above.
                     toolUseContext: {
                       ...saved.toolUseContext,
@@ -3961,7 +3961,7 @@ function runHeadlessStreaming(
                       bridgeFailureDetail = detail
                     }
                     logForDebugging(
-                      `[bridge:sdk] State change: ${state}${detail ? ` â€” ${detail}` : ''}`,
+                      `[bridge:sdk] State change: ${state}${detail ? ` — ${detail}` : ''}`,
                     )
                     output.enqueue({
                       type: 'system' as StdoutMessage['type'],
@@ -4020,7 +4020,7 @@ function runHeadlessStreaming(
             sendControlResponseSuccess(message)
           }
         } else {
-          // Unknown control request subtype â€” send an error response so
+          // Unknown control request subtype — send an error response so
           // the caller doesn't hang waiting for a reply that never comes.
           sendControlResponseError(
             message,
@@ -4088,7 +4088,7 @@ function runHeadlessStreaming(
           }
           // Historical dup = transcript already has this turn's output, so it
           // ran but its lifecycle was never closed (interrupted before ack).
-          // Runtime dups don't need this â€” the original enqueue path closes them.
+          // Runtime dups don't need this — the original enqueue path closes them.
           if (existsInSession) {
             notifyCommandLifecycle(message.uuid, 'completed')
           }
@@ -4263,7 +4263,7 @@ export function createCanUseToolWithPermissionPrompt(
   return canUseTool
 }
 
-// Exported for testing â€” regression: this used to crash at construction when
+// Exported for testing — regression: this used to crash at construction when
 // getMcpTools() was empty (before per-server connects populated appState).
 export function getCanUseToolFn(
   permissionPromptToolName: string | undefined,
@@ -4422,7 +4422,7 @@ async function handleInitializeRequest(
       // Filesystem-defined agent (alreadyResolved by main.tsx). main.tsx
       // handles initialPrompt for the string inputPrompt case, but when
       // inputPrompt is an AsyncIterable (SDK stream-json), it can't
-      // concatenate â€” fall back to prependUserMessage here.
+      // concatenate — fall back to prependUserMessage here.
       structuredIO.prependUserMessage(mainThreadAgent.initialPrompt)
     }
   }
@@ -4644,20 +4644,20 @@ function handleSetPermissionMode(
 
 /**
  * IDE-triggered channel enable. Derives the ChannelEntry from the connection's
- * pluginSource (IDE can't spoof kind/marketplace â€” we only take the server
+ * pluginSource (IDE can't spoof kind/marketplace — we only take the server
  * name), appends it to session allowedChannels, and runs the full gate. On
  * gate failure, rolls back the append. On success, registers a notification
- * handler that enqueues channel messages at priority:'next' â€” drainCommandQueue
+ * handler that enqueues channel messages at priority:'next' — drainCommandQueue
  * picks them up between turns.
  *
  * Intentionally does NOT register the claude/channel/permission handler that
  * useManageMCPConnections sets up for interactive mode. That handler resolves
- * a pending dialog inside handleInteractivePermission â€” but print.ts never
+ * a pending dialog inside handleInteractivePermission — but print.ts never
  * calls handleInteractivePermission. When SDK permission lands on 'ask', it
  * goes to the consumer's canUseTool callback over stdio; there is no CLI-side
  * dialog for a remote "yes tbxkq" to resolve. If an IDE wants channel-relayed
  * tool approval, that's IDE-side plumbing against its own pending-map. (Also
- * gated separately by tengu_harbor_permissions â€” not yet shipping on
+ * gated separately by tengu_harbor_permissions — not yet shipping on
  * interactive either.)
  */
 function handleChannelEnable(
@@ -4690,7 +4690,7 @@ function handleChannelEnable(
   const prior = getAllowedChannels()
 
   if (parsed?.marketplace) {
-    // Plugin-sourced server â†’ plugin-kind entry
+    // Plugin-sourced server → plugin-kind entry
     entry = {
       kind: 'plugin',
       name: parsed.name,
@@ -4704,7 +4704,7 @@ function handleChannelEnable(
     )
     if (!already) setAllowedChannels([...prior, entry])
   } else {
-    // Non-plugin server â†’ look for an existing server-kind entry in
+    // Non-plugin server → look for an existing server-kind entry in
     // --channels (requires --dangerously-load-development-channels for
     // dev entries). We never auto-create server-kind entries.
     const existing = prior.find(
@@ -4726,7 +4726,7 @@ function handleChannelEnable(
     pluginSource,
   )
   if (gate.action === 'skip') {
-    // Rollback â€” only remove the entry we appended.
+    // Rollback — only remove the entry we appended.
     if (!already) setAllowedChannels(prior)
     return respondError(gate.reason)
   }
@@ -4768,7 +4768,7 @@ function handleChannelEnable(
   }
 
   // Identical enqueue shape to the interactive register block in
-  // useManageMCPConnections. drainCommandQueue processes it between turns â€”
+  // useManageMCPConnections. drainCommandQueue processes it between turns —
   // channel messages queue at priority 'next' and are seen by the model on
   // the turn after they arrive.
   connection.client.setNotificationHandler(
@@ -5259,7 +5259,7 @@ async function loadInitialMessages(
   }
 
   // Join the SessionStart hooks promise kicked in main.tsx (or run fresh if
-  // it wasn't kicked â€” e.g. --continue with no prior session falls through
+  // it wasn't kicked — e.g. --continue with no prior session falls through
   // here with sessionStartHooksPromise undefined because main.tsx guards on continue)
   return {
     messages: await (options.sessionStartHooksPromise ??
@@ -5416,7 +5416,7 @@ export type McpSetServersResult = {
  * Handles mcp_set_servers requests by processing both SDK and process-based servers.
  * SDK servers run in the SDK process; process-based servers are spawned by the CLI.
  *
- * Applies enterprise allowedMcpServers/deniedMcpServers policy â€” same filter as
+ * Applies enterprise allowedMcpServers/deniedMcpServers policy — same filter as
  * --mcp-config (see filterMcpServersByPolicy call in main.tsx). Without this,
  * SDK V2 Query.setMcpServers() was a second policy bypass vector. Blocked servers
  * are reported in response.errors so the SDK consumer knows why they weren't added.
@@ -5428,9 +5428,9 @@ export async function handleMcpSetServers(
   setAppState: (f: (prev: AppState) => AppState) => void,
 ): Promise<McpSetServersResult> {
   // Enforce enterprise MCP policy on process-based servers (stdio/http/sse).
-  // Mirrors the --mcp-config filter in main.tsx â€” both user-controlled injection
+  // Mirrors the --mcp-config filter in main.tsx — both user-controlled injection
   // paths must have the same gate. type:'sdk' servers are exempt (SDK-managed,
-  // CLI never spawns/connects for them â€” see filterMcpServersByPolicy jsdoc).
+  // CLI never spawns/connects for them — see filterMcpServersByPolicy jsdoc).
   // Blocked servers go into response.errors so the SDK caller sees why.
   const { allowed: allowedServers, blocked } = filterMcpServersByPolicy(servers)
   const policyErrors: Record<string, string> = {}

--- a/src/cli/print.ts
+++ b/src/cli/print.ts
@@ -1,4 +1,4 @@
-// biome-ignore-all assist/source/organizeImports: internal-only import markers must not be reordered
+﻿// biome-ignore-all assist/source/organizeImports: internal-only import markers must not be reordered
 import { feature } from 'bun:bundle'
 import { readFile, stat } from 'fs/promises'
 import { dirname } from 'path'
@@ -598,13 +598,13 @@ export async function runHeadless(
     if (SandboxManager.isSandboxRequired()) {
       process.stderr.write(
         `\nError: sandbox required but unavailable: ${sandboxUnavailableReason}\n` +
-          `  sandbox.failIfUnavailable is set — refusing to start without a working sandbox.\n\n`,
+          `  sandbox.failIfUnavailable is set â€” refusing to start without a working sandbox.\n\n`,
       )
       gracefulShutdownSync(1)
       return
     }
     process.stderr.write(
-      `\n⚠ Sandbox disabled: ${sandboxUnavailableReason}\n` +
+      `\nâš  Sandbox disabled: ${sandboxUnavailableReason}\n` +
         `  Commands will run WITHOUT sandboxing. Network and filesystem restrictions will NOT be enforced.\n\n`,
     )
   } else if (SandboxManager.isSandboxingEnabled()) {
@@ -614,7 +614,7 @@ export async function runHeadless(
     try {
       await SandboxManager.initialize(structuredIO.createSandboxAskCallback())
     } catch (err) {
-      process.stderr.write(`\n❌ Sandbox Error: ${errorMessage(err)}\n`)
+      process.stderr.write(`\nâŒ Sandbox Error: ${errorMessage(err)}\n`)
       gracefulShutdownSync(1, 'other')
       return
     }
@@ -689,7 +689,7 @@ export async function runHeadless(
     restoredWorkerState: structuredIO.restoredWorkerState,
   })
 
-  // SessionStart hooks can emit initialUserMessage — the first user turn for
+  // SessionStart hooks can emit initialUserMessage â€” the first user turn for
   // headless orchestrator sessions where stdin is empty and additionalContext
   // alone (an attachment, not a turn) would leave the REPL with nothing to
   // respond to. The hook promise is awaited inside loadInitialMessages, so the
@@ -955,7 +955,7 @@ export async function runHeadless(
   logHeadlessProfilerTurn()
 
   // Drain any in-flight memory extraction before shutdown. The response is
-  // already flushed above, so this adds no user-visible latency — it just
+  // already flushed above, so this adds no user-visible latency â€” it just
   // delays process exit so gracefulShutdownSync's 5s failsafe doesn't kill
   // the forked agent mid-flight. Gated by isExtractModeActive so the
   // tengu_slate_thimble flag controls non-interactive extraction end-to-end.
@@ -1013,7 +1013,7 @@ function runHeadlessStreaming(
   let shutdownPromptInjected = false
   let heldBackResult: StdoutMessage | null = null
   let abortController: AbortController | undefined
-  // Same queue sendRequest() enqueues to — one FIFO for everything.
+  // Same queue sendRequest() enqueues to â€” one FIFO for everything.
   const output = structuredIO.outbound
 
   // Ctrl+C in -p mode: abort the in-flight query, then shut down gracefully.
@@ -1045,9 +1045,9 @@ function runHeadlessStreaming(
   })
 
   // Wire the central onChangeAppState mode-diff hook to the SDK output stream.
-  // This fires whenever ANY code path mutates toolPermissionContext.mode —
+  // This fires whenever ANY code path mutates toolPermissionContext.mode â€”
   // Shift+Tab, ExitPlanMode dialog, /plan slash command, rewind, bridge
-  // set_permission_mode, the query loop, stop_task — rather than the two
+  // set_permission_mode, the query loop, stop_task â€” rather than the two
   // paths that previously went through a bespoke wrapper.
   // The wrapper's body was fully redundant (it enqueued here AND called
   // notifySessionMetadataChanged, both of which onChangeAppState now covers);
@@ -1150,7 +1150,7 @@ function runHeadlessStreaming(
   )
 
   // Client-supplied readFileState seeds (via seed_read_state control request).
-  // The stdin IIFE runs concurrently with ask() — a seed arriving mid-turn
+  // The stdin IIFE runs concurrently with ask() â€” a seed arriving mid-turn
   // would be lost to ask()'s clone-then-replace (QueryEngine.ts finally block)
   // if written directly into readFileState. Instead, seeds land here, merge
   // into getReadFileCache's view (readFileState-wins-ties: seeds fill gaps),
@@ -1263,7 +1263,7 @@ function runHeadlessStreaming(
       ) {
         continue
       }
-      // Skip SDK MCP servers — elicitation flows through SdkControlClientTransport
+      // Skip SDK MCP servers â€” elicitation flows through SdkControlClientTransport
       if (connection.config.type === 'sdk') {
         continue
       }
@@ -1286,7 +1286,7 @@ function runHeadlessStreaming(
               mode: mode as AnalyticsMetadata_I_VERIFIED_THIS_IS_NOT_CODE_OR_FILEPATHS,
             })
 
-            // Run elicitation hooks first — they can provide a response programmatically
+            // Run elicitation hooks first â€” they can provide a response programmatically
             const hookResponse = await runElicitationHooks(
               serverName,
               request.params,
@@ -1376,7 +1376,7 @@ function runHeadlessStreaming(
         elicitationRegistered.add(serverName)
       } catch {
         // setRequestHandler throws if the client wasn't created with
-        // elicitation capability — skip silently
+        // elicitation capability â€” skip silently
       }
     }
   }
@@ -1397,7 +1397,7 @@ function runHeadlessStreaming(
     const hasPendingSdkClients = sdkClients.some(c => c.type === 'pending')
     // Check if any SDK clients failed their handshake and need to be retried.
     // Without this, a client that lands in 'failed' (e.g. handshake timeout on
-    // a WS reconnect race) stays failed forever — its name satisfies the
+    // a WS reconnect race) stays failed forever â€” its name satisfies the
     // connectedServerNames diff but it contributes zero tools.
     const hasFailedSdkClients = sdkClients.some(c => c.type === 'failed')
 
@@ -1427,7 +1427,7 @@ function runHeadlessStreaming(
       sdkTools = sdkSetup.tools
 
       // Store SDK MCP tools in appState so subagents can access them via
-      // assembleToolPool. Only tools are stored here — SDK clients are already
+      // assembleToolPool. Only tools are stored here â€” SDK clients are already
       // merged separately in the query loop (allMcpClients) and mcp_status handler.
       // Use both old (connectedServerNames) and new (currentServerNames) to remove
       // stale SDK tools when servers are added or removed.
@@ -1498,7 +1498,7 @@ function runHeadlessStreaming(
   // Mirrors the REPL's useReplBridge hook: the handle is created when
   // `remote_control` is enabled and torn down when disabled.
   let bridgeHandle: ReplBridgeHandle | null = null
-  // Cursor into mutableMessages — tracks how far we've forwarded.
+  // Cursor into mutableMessages â€” tracks how far we've forwarded.
   // Same index-based diff as useReplBridge's lastWrittenIndexRef.
   let bridgeLastForwardedIndex = 0
 
@@ -1507,7 +1507,7 @@ function runHeadlessStreaming(
   // and stays alive during permission waits) and again after the turn.
   //
   // writeMessages has its own UUID-based dedup (initialMessageUUIDs,
-  // recentPostedUUIDs) — the index cursor here is a pre-filter to avoid
+  // recentPostedUUIDs) â€” the index cursor here is a pre-filter to avoid
   // O(n) re-scanning of already-sent messages on every call.
   function forwardMessagesToBridge(): void {
     if (!bridgeHandle) return
@@ -1660,7 +1660,7 @@ function runHeadlessStreaming(
           : undefined
       // Capabilities passthrough with allowlist pre-filter. The IDE reads
       // experimental['claude/channel'] to decide whether to show the
-      // Enable-channel prompt — only echo it if channel_enable would
+      // Enable-channel prompt â€” only echo it if channel_enable would
       // actually pass the allowlist. Not a security boundary (the
       // handler re-runs the full gate); just avoids dead buttons.
       let capabilities: { experimental?: Record<string, unknown> } | undefined
@@ -1765,14 +1765,14 @@ function runHeadlessStreaming(
     currentCommands = await getCommands(cwd())
 
     // Preserve SDK-provided agents (--agents CLI flag or SDK initialize
-    // control_request) — both inject via parseAgentsFromJson with
+    // control_request) â€” both inject via parseAgentsFromJson with
     // source='flagSettings'. loadMarkdownFilesForSubdir never assigns this
     // source, so it cleanly discriminates "injected, not disk-loadable".
     //
     // The previous filter used a negative set-diff (!freshAgentTypes.has(a))
     // which also matched plugin agents that were in the poisoned initial
     // currentAgents but correctly excluded from freshAgentDefs after managed
-    // settings applied — leaking policy-blocked agents into the init message.
+    // settings applied â€” leaking policy-blocked agents into the init message.
     // See gh-23085: isBridgeEnabled() at Commander-definition time poisoned
     // the settings cache before setEligibility(true) ran.
     const sdkAgents = currentAgents.filter(a => a.source === 'flagSettings')
@@ -1852,7 +1852,7 @@ function runHeadlessStreaming(
 
   // Abort the current operation when a 'now' priority message arrives.
   // Also wake the run loop when channel messages (priority 'next') arrive
-  // while the model is idle — without this, channel notifications enqueued
+  // while the model is idle â€” without this, channel notifications enqueued
   // between runs would sit in the queue until the next SDK message.
   subscribeToCommandQueue(() => {
     if (abortController && getCommandsByMaxPriority('now').length > 0) {
@@ -1921,7 +1921,7 @@ function runHeadlessStreaming(
       setupPluginHookHotReload()
     }
 
-    // Only main-thread commands (agentId===undefined) — subagent
+    // Only main-thread commands (agentId===undefined) â€” subagent
     // notifications are drained by the subagent's mid-turn gate in query.ts.
     // Defined outside the try block so it's accessible in the post-finally
     // queue re-checks at the bottom of run().
@@ -1998,7 +1998,7 @@ function runHeadlessStreaming(
           registerElicitationHandlers(allMcpClients)
           // Channel handlers for servers allowlisted via --channels at
           // construction time (or enableChannel() mid-session). Runs every
-          // turn like registerElicitationHandlers — idempotent per-client
+          // turn like registerElicitationHandlers â€” idempotent per-client
           // (setNotificationHandler replaces, not stacks) and no-ops for
           // non-allowlisted servers (one feature-flag check).
           for (const client of allMcpClients) {
@@ -2065,7 +2065,7 @@ function runHeadlessStreaming(
             )
 
             // Only emit a task_notification SDK event when a <status> tag is
-            // present — that means this is a terminal notification (completed/
+            // present â€” that means this is a terminal notification (completed/
             // failed/stopped). Stream events from enqueueStreamEvent carry no
             // <status> (they're progress pings); emitting them here would
             // default to 'completed' and falsely close the task for SDK
@@ -2383,7 +2383,7 @@ function runHeadlessStreaming(
         await drainCommandQueue()
 
         // Check for running background tasks before exiting.
-        // Exclude in_process_teammate — teammates are long-lived by design
+        // Exclude in_process_teammate â€” teammates are long-lived by design
         // (status: 'running' for their whole lifetime, cleaned up by the
         // shutdown protocol, not by transitioning to 'completed'). Waiting
         // on them here loops forever (gh-30008). Same exclusion already
@@ -2699,7 +2699,7 @@ function runHeadlessStreaming(
 
   // Cron scheduler: runs scheduled_tasks.json tasks in SDK/-p mode.
   // Mirrors REPL's useScheduledTasks hook. Fired prompts enqueue + kick
-  // off run() directly — unlike REPL, there's no queue subscriber here
+  // off run() directly â€” unlike REPL, there's no queue subscriber here
   // that drains on enqueue while idle. The run() mutex makes this safe
   // during an active turn: the call no-ops and the post-run recheck at
   // the end of run() picks up the queued command.
@@ -2714,8 +2714,8 @@ function runHeadlessStreaming(
           value: prompt,
           uuid: randomUUID(),
           priority: 'later',
-          // System-generated — matches useScheduledTasks.ts REPL equivalent.
-          // Without this, messages.ts metaProp eval is {} → prompt leaks
+          // System-generated â€” matches useScheduledTasks.ts REPL equivalent.
+          // Without this, messages.ts metaProp eval is {} â†’ prompt leaks
           // into visible transcript when cron fires mid-turn in -p mode.
           isMeta: true,
           // Threaded to cc_workload= in the billing-header attribution block
@@ -2787,17 +2787,17 @@ function runHeadlessStreaming(
     (callbackUrl: string) => void
   >()
   // Track servers where the manual callback was actually invoked (so the
-  // automatic reconnect path knows to skip — the extension will reconnect).
+  // automatic reconnect path knows to skip â€” the extension will reconnect).
   const oauthManualCallbackUsed = new Set<string>()
   // Track OAuth auth-only promises so mcp_oauth_callback_url can await
   // token exchange completion. Reconnect is handled separately by the
-  // extension via handleAuthDone → mcp_reconnect.
+  // extension via handleAuthDone â†’ mcp_reconnect.
   const oauthAuthPromises = new Map<string, Promise<void>>()
 
   // In-flight Anthropic OAuth flow (claude_authenticate). Single-slot: a
   // second authenticate request cleans up the first. The service holds the
   // PKCE verifier + localhost listener; the promise settles after
-  // installOAuthTokens — after it resolves, the in-process memoized token
+  // installOAuthTokens â€” after it resolves, the in-process memoized token
   // cache is already cleared and the next API call picks up the new creds.
   let claudeOAuth: {
     service: OAuthService
@@ -2814,7 +2814,7 @@ function runHeadlessStreaming(
     let initialized = false
     logForDiagnosticsNoPII('info', 'cli_message_loop_started')
     for await (const message of structuredIO.structuredInput) {
-      // Non-user events are handled inline (no queue). started→completed in
+      // Non-user events are handled inline (no queue). startedâ†’completed in
       // the same tick carries no information, so only fire completed.
       // control_response is reported by StructuredIO.processLine (which also
       // sees orphans that never yield here).
@@ -2859,7 +2859,7 @@ function runHeadlessStreaming(
           suggestionState.lastEmitted = null
           suggestionState.pendingSuggestion = null
           sendControlResponseSuccess(message)
-          break // exits for-await → falls through to inputClosed=true drain below
+          break // exits for-await â†’ falls through to inputClosed=true drain below
         } else if (message.request.subtype === 'initialize') {
           // SDK MCP server names from the initialize message
           // Populated by both browser and ProcessTransport sessions
@@ -3021,20 +3021,20 @@ function runHeadlessStreaming(
           try {
             // expandPath: all other readFileState writers normalize (~, relative,
             // session cwd vs process cwd). FileEditTool looks up by expandPath'd
-            // key — a verbatim client path would miss.
+            // key â€” a verbatim client path would miss.
             const normalizedPath = expandPath(message.request.path)
             // Check disk mtime before reading content. If the file changed
             // since the client's observation, readFile would return C_current
-            // but we'd store it with the client's M_observed — getChangedFiles
+            // but we'd store it with the client's M_observed â€” getChangedFiles
             // then sees disk > cache.timestamp, re-reads, diffs C_current vs
             // C_current = empty, emits no attachment, and the model is never
-            // told about the C_observed → C_current change. Skipping the seed
-            // makes Edit fail "file not read yet" → forces a fresh Read.
+            // told about the C_observed â†’ C_current change. Skipping the seed
+            // makes Edit fail "file not read yet" â†’ forces a fresh Read.
             // Math.floor matches FileReadTool and getFileModificationTime.
             const diskMtime = Math.floor((await stat(normalizedPath)).mtimeMs)
             if (diskMtime <= message.request.mtime) {
               const raw = await readFile(normalizedPath, 'utf-8')
-              // Strip BOM + normalize CRLF→LF to match readFileInRange and
+              // Strip BOM + normalize CRLFâ†’LF to match readFileInRange and
               // readFileSyncWithMetadata. FileEditTool's content-compare
               // fallback (for Windows mtime bumps without content change)
               // compares against LF-normalized disk reads.
@@ -3049,7 +3049,7 @@ function runHeadlessStreaming(
               })
             }
           } catch {
-            // ENOENT etc — skip seeding but still succeed
+            // ENOENT etc â€” skip seeding but still succeed
           }
           sendControlResponseSuccess(message)
         } else if (message.request.subtype === 'mcp_set_servers') {
@@ -3083,7 +3083,7 @@ function runHeadlessStreaming(
             )
             currentAgents = [...r.agentDefinitions.allAgents, ...sdkAgents]
 
-            // Reload succeeded — gather response data best-effort so a
+            // Reload succeeded â€” gather response data best-effort so a
             // read failure doesn't mask the successful state change.
             // allSettled so one failure doesn't discard the others.
             let plugins: SDKControlReloadPluginsResponse['plugins'] = []
@@ -3299,7 +3299,7 @@ function runHeadlessStreaming(
           handleChannelEnable(
             message.request_id,
             message.request.serverName,
-            // Pool spread matches mcp_status — all three client sources.
+            // Pool spread matches mcp_status â€” all three client sources.
             [
               ...currentAppState.mcp.clients,
               ...sdkClients,
@@ -3369,13 +3369,13 @@ function runHeadlessStreaming(
               }
 
               // Store auth-only promise for mcp_oauth_callback_url handler.
-              // Don't swallow errors — the callback handler needs to detect
+              // Don't swallow errors â€” the callback handler needs to detect
               // auth failures and report them to the caller.
               oauthAuthPromises.set(serverName, oauthPromise)
 
-              // Handle background completion — reconnect after auth.
+              // Handle background completion â€” reconnect after auth.
               // When manual callback is used, skip the reconnect here;
-              // the extension's handleAuthDone → mcp_reconnect handles it
+              // the extension's handleAuthDone â†’ mcp_reconnect handles it
               // (which also updates dynamicMcpState for tool registration).
               const fullFlowPromise = oauthPromise
                 .then(async () => {
@@ -3383,7 +3383,7 @@ function runHeadlessStreaming(
                   if (isMcpServerDisabled(serverName)) {
                     return
                   }
-                  // Skip reconnect if the manual callback path was used —
+                  // Skip reconnect if the manual callback path was used â€”
                   // handleAuthDone will do it via mcp_reconnect (which
                   // updates dynamicMcpState for tool registration).
                   if (oauthManualCallbackUsed.has(serverName)) {
@@ -3487,7 +3487,7 @@ function runHeadlessStreaming(
               oauthManualCallbackUsed.add(serverName)
               submit(callbackUrl)
               // Wait for auth (token exchange) to complete before responding.
-              // Reconnect is handled by the extension via handleAuthDone →
+              // Reconnect is handled by the extension via handleAuthDone â†’
               // mcp_reconnect (which updates dynamicMcpState for tools).
               const authPromise = oauthAuthPromises.get(serverName)
               if (authPromise) {
@@ -3515,8 +3515,8 @@ function runHeadlessStreaming(
         } else if (message.request.subtype === 'claude_authenticate') {
           // Anthropic OAuth over the control channel. The SDK client owns
           // the user's browser (we're headless in -p mode); we hand back
-          // both URLs and wait. Automatic URL → localhost listener catches
-          // the redirect if the browser is on this host; manual URL → the
+          // both URLs and wait. Automatic URL â†’ localhost listener catches
+          // the redirect if the browser is on this host; manual URL â†’ the
           // success page shows "code#state" for claude_oauth_callback.
           const { loginWithClaudeAi } = message.request
 
@@ -3524,7 +3524,7 @@ function runHeadlessStreaming(
           // and nulls the manual resolver. The prior `flow` promise is left
           // pending (AuthCodeListener.close() does not reject) but its object
           // graph becomes unreachable once the server handle is released and
-          // is GC'd — no fd or port is held.
+          // is GC'd â€” no fd or port is held.
           claudeOAuth?.service.cleanup()
 
           logEvent('tengu_oauth_flow_start', {
@@ -3556,9 +3556,9 @@ function runHeadlessStreaming(
               },
             )
             .then(async tokens => {
-              // installOAuthTokens: performLogout (clear stale state) →
-              // store profile → saveOAuthTokensIfNeeded → clearOAuthTokenCache
-              // → clearAuthRelatedCaches. After this resolves, the memoized
+              // installOAuthTokens: performLogout (clear stale state) â†’
+              // store profile â†’ saveOAuthTokensIfNeeded â†’ clearOAuthTokenCache
+              // â†’ clearAuthRelatedCaches. After this resolves, the memoized
               // getClaudeAIOAuthTokens in this process is invalidated; the
               // next API call re-reads keychain/file and works. No respawn.
               await installOAuthTokens(tokens)
@@ -3616,7 +3616,7 @@ function runHeadlessStreaming(
               'No active claude_authenticate flow',
             )
           } else {
-            // Inject the manual code synchronously — must happen in stdin
+            // Inject the manual code synchronously â€” must happen in stdin
             // message order so a subsequent claude_authenticate doesn't
             // replace the service before this code lands.
             if (message.request.subtype === 'claude_oauth_callback') {
@@ -3625,7 +3625,7 @@ function runHeadlessStreaming(
                 state: message.request.state,
               })
             }
-            // Detach the await — the stdin reader is serial and blocking
+            // Detach the await â€” the stdin reader is serial and blocking
             // here deadlocks claude_oauth_wait_for_completion: flow may
             // only resolve via a future claude_oauth_callback on stdin,
             // which can't be read while we're parked. Capture the binding;
@@ -3698,7 +3698,7 @@ function runHeadlessStreaming(
             sendControlResponseSuccess(message, {})
           }
         } else if (message.request.subtype === 'apply_flag_settings') {
-          // Snapshot the current model before applying — we need to detect
+          // Snapshot the current model before applying â€” we need to detect
           // model switches so we can inject breadcrumbs and notify listeners.
           const prevModel = getMainLoopModel()
 
@@ -3721,7 +3721,7 @@ function runHeadlessStreaming(
           // Route through notifyChange so fanOut() resets the settings cache
           // before listeners run. The subscriber at :392 calls
           // applySettingsChange for us. Pre-#20625 this was a direct
-          // applySettingsChange() call that relied on its own internal reset —
+          // applySettingsChange() call that relied on its own internal reset â€”
           // now that the reset is centralized in fanOut, a direct call here
           // would read stale cached settings and silently drop the update.
           // Bonus: going through notifyChange also tells the other subscribers
@@ -3757,7 +3757,7 @@ function runHeadlessStreaming(
         } else if (message.request.subtype === 'get_settings') {
           const currentAppState = getAppState()
           const model = getMainLoopModel()
-          // modelSupportsEffort gate matches claude.ts — applied.effort must
+          // modelSupportsEffort gate matches claude.ts â€” applied.effort must
           // mirror what actually goes to the API, not just what's configured.
           const effort = modelSupportsEffort(model)
             ? resolveAppliedEffort(model, currentAppState.effortValue)
@@ -3766,7 +3766,7 @@ function runHeadlessStreaming(
             ...getSettingsWithSources(),
             applied: {
               model,
-              // Numeric effort (internal-only) → null; SDK schema is string-level only.
+              // Numeric effort (internal-only) â†’ null; SDK schema is string-level only.
               effort: typeof effort === 'string' ? effort : null,
             },
           })
@@ -3788,7 +3788,7 @@ function runHeadlessStreaming(
           const { description, persist } = message.request
           // Reuse the live controller only if it has not already been aborted
           // (e.g. by interrupt()); an aborted signal would cause queryHaiku to
-          // immediately throw APIUserAbortError → {title: null}.
+          // immediately throw APIUserAbortError â†’ {title: null}.
           const titleSignal = (
             abortController && !abortController.signal.aborted
               ? abortController
@@ -3806,7 +3806,7 @@ function runHeadlessStreaming(
               }
               sendControlResponseSuccess(message, { title })
             } catch (e) {
-              // Unreachable in practice — generateSessionTitle wraps its
+              // Unreachable in practice â€” generateSessionTitle wraps its
               // own body and returns null, saveAiGeneratedTitle is wrapped
               // above. Propagate (not swallow) so unexpected failures are
               // visible to the SDK caller (hostComms.ts catches and logs).
@@ -3814,20 +3814,20 @@ function runHeadlessStreaming(
             }
           })()
         } else if (message.request.subtype === 'side_question') {
-          // Same fire-and-forget pattern as generate_session_title above —
+          // Same fire-and-forget pattern as generate_session_title above â€”
           // the forked agent's API roundtrip must not block the stdin loop.
           //
           // The snapshot captured by stopHooks (for querySource === 'sdk')
           // holds the exact systemPrompt/userContext/systemContext/messages
           // sent on the last main-thread turn. Reusing them gives a byte-
-          // identical prefix → prompt cache hit.
+          // identical prefix â†’ prompt cache hit.
           //
-          // Fallback (resume before first turn completes — no snapshot yet):
+          // Fallback (resume before first turn completes â€” no snapshot yet):
           // rebuild from scratch. buildSideQuestionFallbackParams mirrors
           // QueryEngine.ts:ask()'s system prompt assembly (including
           // --system-prompt / --append-system-prompt) so the rebuilt prefix
           // matches in the common case. May still miss the cache for
-          // coordinator mode or memory-mechanics extras — acceptable, the
+          // coordinator mode or memory-mechanics extras â€” acceptable, the
           // alternative is the side question failing entirely.
           const { question } = message.request
           void (async () => {
@@ -3840,7 +3840,7 @@ function runHeadlessStreaming(
                     // already-aborted controller; createChildAbortController in
                     // createSubagentContext would propagate it and the fork
                     // would die before sending a request. The controller is
-                    // not part of the cache key — swapping in a fresh one is
+                    // not part of the cache key â€” swapping in a fresh one is
                     // safe. Same guard as generate_session_title above.
                     toolUseContext: {
                       ...saved.toolUseContext,
@@ -3961,7 +3961,7 @@ function runHeadlessStreaming(
                       bridgeFailureDetail = detail
                     }
                     logForDebugging(
-                      `[bridge:sdk] State change: ${state}${detail ? ` — ${detail}` : ''}`,
+                      `[bridge:sdk] State change: ${state}${detail ? ` â€” ${detail}` : ''}`,
                     )
                     output.enqueue({
                       type: 'system' as StdoutMessage['type'],
@@ -4020,7 +4020,7 @@ function runHeadlessStreaming(
             sendControlResponseSuccess(message)
           }
         } else {
-          // Unknown control request subtype — send an error response so
+          // Unknown control request subtype â€” send an error response so
           // the caller doesn't hang waiting for a reply that never comes.
           sendControlResponseError(
             message,
@@ -4088,7 +4088,7 @@ function runHeadlessStreaming(
           }
           // Historical dup = transcript already has this turn's output, so it
           // ran but its lifecycle was never closed (interrupted before ack).
-          // Runtime dups don't need this — the original enqueue path closes them.
+          // Runtime dups don't need this â€” the original enqueue path closes them.
           if (existsInSession) {
             notifyCommandLifecycle(message.uuid, 'completed')
           }
@@ -4263,7 +4263,7 @@ export function createCanUseToolWithPermissionPrompt(
   return canUseTool
 }
 
-// Exported for testing — regression: this used to crash at construction when
+// Exported for testing â€” regression: this used to crash at construction when
 // getMcpTools() was empty (before per-server connects populated appState).
 export function getCanUseToolFn(
   permissionPromptToolName: string | undefined,
@@ -4422,7 +4422,7 @@ async function handleInitializeRequest(
       // Filesystem-defined agent (alreadyResolved by main.tsx). main.tsx
       // handles initialPrompt for the string inputPrompt case, but when
       // inputPrompt is an AsyncIterable (SDK stream-json), it can't
-      // concatenate — fall back to prependUserMessage here.
+      // concatenate â€” fall back to prependUserMessage here.
       structuredIO.prependUserMessage(mainThreadAgent.initialPrompt)
     }
   }
@@ -4644,20 +4644,20 @@ function handleSetPermissionMode(
 
 /**
  * IDE-triggered channel enable. Derives the ChannelEntry from the connection's
- * pluginSource (IDE can't spoof kind/marketplace — we only take the server
+ * pluginSource (IDE can't spoof kind/marketplace â€” we only take the server
  * name), appends it to session allowedChannels, and runs the full gate. On
  * gate failure, rolls back the append. On success, registers a notification
- * handler that enqueues channel messages at priority:'next' — drainCommandQueue
+ * handler that enqueues channel messages at priority:'next' â€” drainCommandQueue
  * picks them up between turns.
  *
  * Intentionally does NOT register the claude/channel/permission handler that
  * useManageMCPConnections sets up for interactive mode. That handler resolves
- * a pending dialog inside handleInteractivePermission — but print.ts never
+ * a pending dialog inside handleInteractivePermission â€” but print.ts never
  * calls handleInteractivePermission. When SDK permission lands on 'ask', it
  * goes to the consumer's canUseTool callback over stdio; there is no CLI-side
  * dialog for a remote "yes tbxkq" to resolve. If an IDE wants channel-relayed
  * tool approval, that's IDE-side plumbing against its own pending-map. (Also
- * gated separately by tengu_harbor_permissions — not yet shipping on
+ * gated separately by tengu_harbor_permissions â€” not yet shipping on
  * interactive either.)
  */
 function handleChannelEnable(
@@ -4690,7 +4690,7 @@ function handleChannelEnable(
   const prior = getAllowedChannels()
 
   if (parsed?.marketplace) {
-    // Plugin-sourced server → plugin-kind entry
+    // Plugin-sourced server â†’ plugin-kind entry
     entry = {
       kind: 'plugin',
       name: parsed.name,
@@ -4704,7 +4704,7 @@ function handleChannelEnable(
     )
     if (!already) setAllowedChannels([...prior, entry])
   } else {
-    // Non-plugin server → look for an existing server-kind entry in
+    // Non-plugin server â†’ look for an existing server-kind entry in
     // --channels (requires --dangerously-load-development-channels for
     // dev entries). We never auto-create server-kind entries.
     const existing = prior.find(
@@ -4726,7 +4726,7 @@ function handleChannelEnable(
     pluginSource,
   )
   if (gate.action === 'skip') {
-    // Rollback — only remove the entry we appended.
+    // Rollback â€” only remove the entry we appended.
     if (!already) setAllowedChannels(prior)
     return respondError(gate.reason)
   }
@@ -4768,7 +4768,7 @@ function handleChannelEnable(
   }
 
   // Identical enqueue shape to the interactive register block in
-  // useManageMCPConnections. drainCommandQueue processes it between turns —
+  // useManageMCPConnections. drainCommandQueue processes it between turns â€”
   // channel messages queue at priority 'next' and are seen by the model on
   // the turn after they arrive.
   connection.client.setNotificationHandler(
@@ -5259,7 +5259,7 @@ async function loadInitialMessages(
   }
 
   // Join the SessionStart hooks promise kicked in main.tsx (or run fresh if
-  // it wasn't kicked — e.g. --continue with no prior session falls through
+  // it wasn't kicked â€” e.g. --continue with no prior session falls through
   // here with sessionStartHooksPromise undefined because main.tsx guards on continue)
   return {
     messages: await (options.sessionStartHooksPromise ??
@@ -5416,7 +5416,7 @@ export type McpSetServersResult = {
  * Handles mcp_set_servers requests by processing both SDK and process-based servers.
  * SDK servers run in the SDK process; process-based servers are spawned by the CLI.
  *
- * Applies enterprise allowedMcpServers/deniedMcpServers policy — same filter as
+ * Applies enterprise allowedMcpServers/deniedMcpServers policy â€” same filter as
  * --mcp-config (see filterMcpServersByPolicy call in main.tsx). Without this,
  * SDK V2 Query.setMcpServers() was a second policy bypass vector. Blocked servers
  * are reported in response.errors so the SDK consumer knows why they weren't added.
@@ -5428,9 +5428,9 @@ export async function handleMcpSetServers(
   setAppState: (f: (prev: AppState) => AppState) => void,
 ): Promise<McpSetServersResult> {
   // Enforce enterprise MCP policy on process-based servers (stdio/http/sse).
-  // Mirrors the --mcp-config filter in main.tsx — both user-controlled injection
+  // Mirrors the --mcp-config filter in main.tsx â€” both user-controlled injection
   // paths must have the same gate. type:'sdk' servers are exempt (SDK-managed,
-  // CLI never spawns/connects for them — see filterMcpServersByPolicy jsdoc).
+  // CLI never spawns/connects for them â€” see filterMcpServersByPolicy jsdoc).
   // Blocked servers go into response.errors so the SDK caller sees why.
   const { allowed: allowedServers, blocked } = filterMcpServersByPolicy(servers)
   const policyErrors: Record<string, string> = {}

--- a/src/cli/print.ts
+++ b/src/cli/print.ts
@@ -4828,7 +4828,7 @@ function reregisterChannelHandlerAfterReconnect(
   connection: MCPServerConnection,
   setAppState: (f: (prev: AppState) => AppState) => void,
 ): void {
-  if (false /* channels always enabled */) return
+  if (!isChannelsEnabled()) return
   if (connection.type !== 'connected') return
 
   const gate = gateChannelServer(

--- a/src/cli/print.ts
+++ b/src/cli/print.ts
@@ -4673,10 +4673,6 @@ function handleChannelEnable(
       response: { subtype: 'error', request_id: requestId, error },
     })
 
-  if (false /* channels always enabled */) {
-    return respondError('channels feature not available in this build')
-  }
-
   // Only a 'connected' client has .capabilities and .client to register the
   // handler on. The pool spread at the call site matches mcp_status.
   const connection = connectionPool.find(

--- a/src/cli/print.ts
+++ b/src/cli/print.ts
@@ -242,6 +242,7 @@ import {
   ElicitRequestSchema,
   ElicitationCompleteNotificationSchema,
 } from '@modelcontextprotocol/sdk/types.js'
+import { computeChannelAutoAllowRules, mergeAutoAllowRules } from 'src/services/mcp/channelAutoAllow.js'
 import { getMcpPrefix } from 'src/services/mcp/mcpStringUtils.js'
 import {
   commandBelongsToServer,
@@ -4729,35 +4730,31 @@ function handleChannelEnable(
 
   // Only auto-allow the minimal set of known channel reply tools,
   // and only for official non-dev plugin channel entries.
-  if (entry?.kind === 'plugin' && entry?.dev !== true) {
-    const toolPrefix = getMcpPrefix(serverName)
-    const channelToolRules = [
-      `${toolPrefix}reply`,
-      `${toolPrefix}send`,
-    ]
-    setAppState(prev => {
-      const sessionRules =
-        prev.toolPermissionContext.alwaysAllowRules.session ?? []
-      const nextRules = channelToolRules.filter(
-        rule => !sessionRules.includes(rule),
-      )
-      if (nextRules.length === 0) return prev
-      return {
-        ...prev,
-        toolPermissionContext: {
-          ...prev.toolPermissionContext,
-          alwaysAllowRules: {
-            ...prev.toolPermissionContext.alwaysAllowRules,
-            session: [...sessionRules, ...nextRules],
+  {
+    const autoRules = computeChannelAutoAllowRules(serverName, entry)
+    if (autoRules.length > 0) {
+      setAppState(prev => {
+        const sessionRules =
+          prev.toolPermissionContext.alwaysAllowRules.session ?? []
+        const merged = mergeAutoAllowRules(sessionRules, autoRules)
+        if (!merged) return prev
+        return {
+          ...prev,
+          toolPermissionContext: {
+            ...prev.toolPermissionContext,
+            alwaysAllowRules: {
+              ...prev.toolPermissionContext.alwaysAllowRules,
+              session: merged,
+            },
           },
-        },
-      }
-    })
-  } else {
-    logMCPDebug(
-      serverName,
-      'Skipping channel tool auto-allow for non-plugin or dev entry',
-    )
+        }
+      })
+    } else {
+      logMCPDebug(
+        serverName,
+        'Skipping channel tool auto-allow for non-plugin or dev entry',
+      )
+    }
   }
 
   // Identical enqueue shape to the interactive register block in
@@ -4835,35 +4832,31 @@ function reregisterChannelHandlerAfterReconnect(
 
   // Only auto-allow the minimal set of known channel reply tools,
   // and only for official non-dev plugin channel entries.
-  if (entry?.kind === 'plugin' && entry?.dev !== true) {
-    const toolPrefix = getMcpPrefix(connection.name)
-    const channelToolRules = [
-      `${toolPrefix}reply`,
-      `${toolPrefix}send`,
-    ]
-    setAppState(prev => {
-      const sessionRules =
-        prev.toolPermissionContext.alwaysAllowRules.session ?? []
-      const nextRules = channelToolRules.filter(
-        rule => !sessionRules.includes(rule),
-      )
-      if (nextRules.length === 0) return prev
-      return {
-        ...prev,
-        toolPermissionContext: {
-          ...prev.toolPermissionContext,
-          alwaysAllowRules: {
-            ...prev.toolPermissionContext.alwaysAllowRules,
-            session: [...sessionRules, ...nextRules],
+  {
+    const autoRules = computeChannelAutoAllowRules(connection.name, entry)
+    if (autoRules.length > 0) {
+      setAppState(prev => {
+        const sessionRules =
+          prev.toolPermissionContext.alwaysAllowRules.session ?? []
+        const merged = mergeAutoAllowRules(sessionRules, autoRules)
+        if (!merged) return prev
+        return {
+          ...prev,
+          toolPermissionContext: {
+            ...prev.toolPermissionContext,
+            alwaysAllowRules: {
+              ...prev.toolPermissionContext.alwaysAllowRules,
+              session: merged,
+            },
           },
-        },
-      }
-    })
-  } else {
-    logMCPDebug(
-      connection.name,
-      'Skipping channel tool auto-allow for non-plugin or dev entry',
-    )
+        }
+      })
+    } else {
+      logMCPDebug(
+        connection.name,
+        'Skipping channel tool auto-allow for non-plugin or dev entry',
+      )
+    }
   }
   const pluginId =
     entry?.kind === 'plugin'

--- a/src/cli/print.ts
+++ b/src/cli/print.ts
@@ -4684,29 +4684,41 @@ function handleChannelEnable(
 
   const pluginSource = connection.config.pluginSource
   const parsed = pluginSource ? parsePluginIdentifier(pluginSource) : undefined
-  if (!parsed?.marketplace) {
-    // No pluginSource or @-less source — can never pass the {plugin,
-    // marketplace}-keyed allowlist. Short-circuit with the same reason the
-    // gate would produce.
-    return respondError(
-      `server ${serverName} is not plugin-sourced; channel_enable requires a marketplace plugin`,
-    )
-  }
 
-  const entry: ChannelEntry = {
-    kind: 'plugin',
-    name: parsed.name,
-    marketplace: parsed.marketplace,
-  }
-  // Idempotency: don't double-append on repeat enable.
+  let entry: ChannelEntry
+  let already: boolean
   const prior = getAllowedChannels()
-  const already = prior.some(
-    e =>
-      e.kind === 'plugin' &&
-      e.name === entry.name &&
-      e.marketplace === entry.marketplace,
-  )
-  if (!already) setAllowedChannels([...prior, entry])
+
+  if (parsed?.marketplace) {
+    // Plugin-sourced server → plugin-kind entry
+    entry = {
+      kind: 'plugin',
+      name: parsed.name,
+      marketplace: parsed.marketplace,
+    }
+    already = prior.some(
+      e =>
+        e.kind === 'plugin' &&
+        e.name === entry.name &&
+        e.marketplace === (entry as { marketplace: string }).marketplace,
+    )
+    if (!already) setAllowedChannels([...prior, entry])
+  } else {
+    // Non-plugin server → look for an existing server-kind entry in
+    // --channels (requires --dangerously-load-development-channels for
+    // dev entries). We never auto-create server-kind entries.
+    const existing = prior.find(
+      e => e.kind === 'server' && e.name === serverName,
+    )
+    if (!existing) {
+      return respondError(
+        `server ${serverName} is not plugin-sourced and has no --channels entry; ` +
+          `add it via --channels or --dangerously-load-development-channels`,
+      )
+    }
+    entry = existing
+    already = true // already in the list by definition
+  }
 
   const gate = gateChannelServer(
     serverName,
@@ -4720,7 +4732,9 @@ function handleChannelEnable(
   }
 
   const pluginId =
-    `${entry.name}@${entry.marketplace}` as AnalyticsMetadata_I_VERIFIED_THIS_IS_NOT_CODE_OR_FILEPATHS
+    (entry.kind === 'plugin'
+      ? `${entry.name}@${entry.marketplace}`
+      : entry.name) as AnalyticsMetadata_I_VERIFIED_THIS_IS_NOT_CODE_OR_FILEPATHS
   logMCPDebug(serverName, 'Channel notifications registered')
   logEvent('tengu_mcp_channel_enable', { plugin: pluginId })
 

--- a/src/components/LogoV2/ChannelsNotice.tsx
+++ b/src/components/LogoV2/ChannelsNotice.tsx
@@ -12,9 +12,7 @@ import { Box, Text } from '../../ink.js';
 import { isChannelsEnabled } from '../../services/mcp/channelAllowlist.js';
 import { getEffectiveChannelAllowlist } from '../../services/mcp/channelNotification.js';
 import { getMcpConfigsByScope } from '../../services/mcp/config.js';
-import { getClaudeAIOAuthTokens, getSubscriptionType } from '../../utils/auth.js';
 import { loadInstalledPluginsV2 } from '../../utils/plugins/installedPluginsManager.js';
-import { getSettingsForSource } from '../../utils/settings/settings.js';
 export function ChannelsNotice() {
   const $ = _c(32);
   const [t0] = useState(_temp);
@@ -173,6 +171,9 @@ function _temp2(c) {
 function _temp() {
   const ch = getAllowedChannels();
   if (ch.length === 0) {
+    // OpenClaude: even without --channels, allowlisted channel plugins
+    // (telegram, discord, etc.) auto-register at connect time. No startup
+    // notice needed — gateChannelServer handles it silently.
     return {
       channels: ch,
       disabled: false,
@@ -183,15 +184,12 @@ function _temp() {
     };
   }
   const l = ch.map(formatEntry).join(", ");
-  const sub = getSubscriptionType();
-  const managed = sub === "team" || sub === "enterprise";
-  const policy = getSettingsForSource("policySettings");
-  const allowlist = getEffectiveChannelAllowlist(sub, policy?.allowedChannelPlugins);
+  const allowlist = getEffectiveChannelAllowlist();
   return {
     channels: ch,
     disabled: !isChannelsEnabled(),
-    noAuth: !getClaudeAIOAuthTokens()?.accessToken,
-    policyBlocked: managed && policy?.channelsEnabled !== true,
+    noAuth: false, // OpenClaude: no OAuth requirement
+    policyBlocked: false, // OpenClaude: no org policy requirement
     list: l,
     unmatched: findUnmatched(ch, allowlist)
   };

--- a/src/components/LogoV2/LogoV2.tsx
+++ b/src/components/LogoV2/LogoV2.tsx
@@ -27,11 +27,9 @@ import { EmergencyTip } from './EmergencyTip.js';
 import { VoiceModeNotice } from './VoiceModeNotice.js';
 import { Opus1mMergeNotice } from './Opus1mMergeNotice.js';
 
-// Conditional require so ChannelsNotice.tsx tree-shakes when both flags are
-// false. A module-scope helper component inside a feature() ternary does NOT
-// tree-shake (docs/feature-gating.md); the require pattern eliminates the
-// whole file. VoiceModeNotice uses the unsafe helper pattern but VOICE_MODE
-// is external: true so it's moot there.
+// ChannelsNotice is always loaded in OpenClaude (channels are unconditionally
+// enabled). The conditional require pattern is kept for structural parity with
+// upstream but the guard is always true.
 /* eslint-disable @typescript-eslint/no-require-imports */
 const ChannelsNoticeModule = true /* channels enabled */ ? require('./ChannelsNotice.js') as typeof import('./ChannelsNotice.js') : null;
 /* eslint-enable @typescript-eslint/no-require-imports */

--- a/src/components/LogoV2/LogoV2.tsx
+++ b/src/components/LogoV2/LogoV2.tsx
@@ -26,7 +26,6 @@ import { getStartupPerfLogPath, isDetailedProfilingEnabled } from 'src/utils/sta
 import { EmergencyTip } from './EmergencyTip.js';
 import { VoiceModeNotice } from './VoiceModeNotice.js';
 import { Opus1mMergeNotice } from './Opus1mMergeNotice.js';
-import { feature } from 'bun:bundle';
 
 // Conditional require so ChannelsNotice.tsx tree-shakes when both flags are
 // false. A module-scope helper component inside a feature() ternary does NOT
@@ -34,7 +33,7 @@ import { feature } from 'bun:bundle';
 // whole file. VoiceModeNotice uses the unsafe helper pattern but VOICE_MODE
 // is external: true so it's moot there.
 /* eslint-disable @typescript-eslint/no-require-imports */
-const ChannelsNoticeModule = feature('KAIROS') || feature('KAIROS_CHANNELS') ? require('./ChannelsNotice.js') as typeof import('./ChannelsNotice.js') : null;
+const ChannelsNoticeModule = true /* channels enabled */ ? require('./ChannelsNotice.js') as typeof import('./ChannelsNotice.js') : null;
 /* eslint-enable @typescript-eslint/no-require-imports */
 import { SandboxManager } from 'src/utils/sandbox/sandbox-adapter.js';
 import { useShowGuestPassesUpsell, incrementGuestPassesSeenCount } from './GuestPassesUpsell.js';

--- a/src/components/messages/UserTextMessage.tsx
+++ b/src/components/messages/UserTextMessage.tsx
@@ -235,7 +235,7 @@ export function UserTextMessage(t0) {
       return t2;
     }
   }
-  if (feature("KAIROS") || feature("KAIROS_CHANNELS")) {
+  if (true /* channels enabled */) {
     if (param.text.includes("<channel source=\"")) {
       let t1;
       if ($[40] === Symbol.for("react.memo_cache_sentinel")) {

--- a/src/hooks/toolPermission/handlers/interactiveHandler.ts
+++ b/src/hooks/toolPermission/handlers/interactiveHandler.ts
@@ -314,7 +314,7 @@ function handleInteractivePermission(
   // the subscription never fires and another racer wins. Graceful degradation
   // — the local dialog is always there as the floor.
   if (
-    (feature('KAIROS') || feature('KAIROS_CHANNELS')) &&
+    true /* channels enabled */ &&
     channelCallbacks &&
     !ctx.tool.requiresUserInteraction?.()
   ) {

--- a/src/hooks/toolPermission/handlers/interactiveHandler.ts
+++ b/src/hooks/toolPermission/handlers/interactiveHandler.ts
@@ -321,9 +321,16 @@ function handleInteractivePermission(
   ) {
     const channelRequestId = shortRequestId(ctx.toolUseID)
     const allowedChannels = getAllowedChannels()
+    // Exclude the server that owns the tool being approved — relaying a
+    // permission prompt for server X's tool back to server X creates a
+    // circular loop (approve via channel → skill runs → next permission
+    // → relay to same channel → approve → …).
+    const toolOwnerServer = ctx.tool.mcpInfo?.serverName
     const channelClients = filterPermissionRelayClients(
       ctx.toolUseContext.getAppState().mcp.clients,
-      name => findChannelEntry(name, allowedChannels) !== undefined,
+      name =>
+        findChannelEntry(name, allowedChannels) !== undefined &&
+        name !== toolOwnerServer,
     )
 
     if (channelClients.length > 0) {

--- a/src/hooks/toolPermission/handlers/interactiveHandler.ts
+++ b/src/hooks/toolPermission/handlers/interactiveHandler.ts
@@ -13,6 +13,7 @@ import {
 import type { ChannelPermissionCallbacks } from '../../../services/mcp/channelPermissions.js'
 import {
   filterPermissionRelayClients,
+  isChannelPermissionRelayEnabled,
   shortRequestId,
   truncateForPreview,
 } from '../../../services/mcp/channelPermissions.js'
@@ -314,7 +315,7 @@ function handleInteractivePermission(
   // the subscription never fires and another racer wins. Graceful degradation
   // — the local dialog is always there as the floor.
   if (
-    true /* channels enabled */ &&
+    isChannelPermissionRelayEnabled() &&
     channelCallbacks &&
     !ctx.tool.requiresUserInteraction?.()
   ) {

--- a/src/hooks/toolPermission/handlers/interactiveHandler.ts
+++ b/src/hooks/toolPermission/handlers/interactiveHandler.ts
@@ -2,7 +2,7 @@ import { feature } from 'bun:bundle'
 import type { ContentBlockParam } from '@anthropic-ai/sdk/resources/messages.mjs'
 import { randomUUID } from 'crypto'
 import { logForDebugging } from 'src/utils/debug.js'
-import { getAllowedChannels } from '../../../bootstrap/state.js'
+import { getAllowedChannels, getChannelModeEnabled } from '../../../bootstrap/state.js'
 import type { BridgePermissionCallbacks } from '../../../bridge/bridgePermissionCallbacks.js'
 import { getTerminalFocused } from '../../../ink/terminal-focus-state.js'
 import {
@@ -13,7 +13,6 @@ import {
 import type { ChannelPermissionCallbacks } from '../../../services/mcp/channelPermissions.js'
 import {
   filterPermissionRelayClients,
-  isChannelPermissionRelayEnabled,
   shortRequestId,
   truncateForPreview,
 } from '../../../services/mcp/channelPermissions.js'
@@ -315,7 +314,7 @@ function handleInteractivePermission(
   // the subscription never fires and another racer wins. Graceful degradation
   // — the local dialog is always there as the floor.
   if (
-    isChannelPermissionRelayEnabled() &&
+    getChannelModeEnabled() &&
     channelCallbacks &&
     !ctx.tool.requiresUserInteraction?.()
   ) {

--- a/src/hooks/useCanUseTool.tsx
+++ b/src/hooks/useCanUseTool.tsx
@@ -163,7 +163,7 @@ function useCanUseTool(setToolUseConfirmQueue, setToolPermissionContext) {
                 result,
                 awaitAutomatedChecksBeforeDialog: appState.toolPermissionContext.awaitAutomatedChecksBeforeDialog,
                 bridgeCallbacks: feature("BRIDGE_MODE") ? appState.replBridgePermissionCallbacks : undefined,
-                channelCallbacks: feature("KAIROS") || feature("KAIROS_CHANNELS") ? appState.channelPermissionCallbacks : undefined
+                channelCallbacks: true /* channels enabled */ ? appState.channelPermissionCallbacks : undefined
               }, resolve);
               return;
             }

--- a/src/hooks/useCanUseTool.tsx
+++ b/src/hooks/useCanUseTool.tsx
@@ -22,6 +22,7 @@ import { jsonStringify } from '../utils/slowOperations.js';
 import { handleCoordinatorPermission } from './toolPermission/handlers/coordinatorHandler.js';
 import { handleInteractivePermission } from './toolPermission/handlers/interactiveHandler.js';
 import { handleSwarmWorkerPermission } from './toolPermission/handlers/swarmWorkerHandler.js';
+import { isChannelPermissionRelayEnabled } from '../services/mcp/channelPermissions.js';
 import { createPermissionContext, createPermissionQueueOps } from './toolPermission/PermissionContext.js';
 import { logPermissionDecision } from './toolPermission/permissionLogging.js';
 export type CanUseToolFn<Input extends Record<string, unknown> = Record<string, unknown>> = (tool: ToolType, input: Input, toolUseContext: ToolUseContext, assistantMessage: AssistantMessage, toolUseID: string, forceDecision?: PermissionDecision<Input>) => Promise<PermissionDecision<Input>>;
@@ -163,7 +164,7 @@ function useCanUseTool(setToolUseConfirmQueue, setToolPermissionContext) {
                 result,
                 awaitAutomatedChecksBeforeDialog: appState.toolPermissionContext.awaitAutomatedChecksBeforeDialog,
                 bridgeCallbacks: feature("BRIDGE_MODE") ? appState.replBridgePermissionCallbacks : undefined,
-                channelCallbacks: true /* channels enabled */ ? appState.channelPermissionCallbacks : undefined
+                channelCallbacks: isChannelPermissionRelayEnabled() ? appState.channelPermissionCallbacks : undefined
               }, resolve);
               return;
             }

--- a/src/interactiveHelpers.tsx
+++ b/src/interactiveHelpers.tsx
@@ -12,7 +12,7 @@ import { isSynchronizedOutputSupported } from './ink/terminal.js';
 import type { RenderOptions, Root, TextProps } from './ink.js';
 import { KeybindingSetup } from './keybindings/KeybindingProviderSetup.js';
 import { startDeferredPrefetches } from './main.js';
-import { checkGate_CACHED_OR_BLOCKING, initializeGrowthBook, resetGrowthBook } from './services/analytics/growthbook.js';
+import { initializeGrowthBook, resetGrowthBook } from './services/analytics/growthbook.js';
 import { isQualifiedForGrove } from './services/api/grove.js';
 import { handleMcpjsonServerApprovals } from './services/mcpServerApproval.js';
 import { AppStateProvider } from './state/AppState.js';
@@ -245,9 +245,9 @@ export async function showSetupScreens(root: Root, permissionMode: PermissionMod
   }
 
   // --dangerously-load-development-channels confirmation. On accept, append
-  // dev channels to any --channels list already set in main.tsx. Org policy
-  // is NOT bypassed — gateChannelServer() still runs; this flag only exists
-  // to sidestep the --channels approved-server allowlist.
+  // dev channels to any --channels list already set in main.tsx.
+  // gateChannelServer() still runs; this flag only sidesteps the hardcoded
+  // plugin allowlist (server-kind entries always need it).
   if (true /* channels enabled */) {
     // OpenClaude: no GrowthBook warm-up needed — isChannelsEnabled() is
     // hardcoded true. The original checkGate_CACHED_OR_BLOCKING call is

--- a/src/interactiveHelpers.tsx
+++ b/src/interactiveHelpers.tsx
@@ -248,32 +248,19 @@ export async function showSetupScreens(root: Root, permissionMode: PermissionMod
   // dev channels to any --channels list already set in main.tsx. Org policy
   // is NOT bypassed — gateChannelServer() still runs; this flag only exists
   // to sidestep the --channels approved-server allowlist.
-  if (feature('KAIROS') || feature('KAIROS_CHANNELS')) {
-    // gateChannelServer and ChannelsNotice read tengu_harbor after this
-    // function returns. A cold disk cache (fresh install, or first run after
-    // the flag was added server-side) defaults to false and silently drops
-    // channel notifications for the whole session — gh#37026.
-    // checkGate_CACHED_OR_BLOCKING returns immediately if disk already says
-    // true; only blocks on a cold/stale-false cache (awaits the same memoized
-    // initializeGrowthBook promise fired earlier). Also warms the
-    // isChannelsEnabled() check in the dev-channels dialog below.
-    if (getAllowedChannels().length > 0 || (devChannels?.length ?? 0) > 0) {
-      await checkGate_CACHED_OR_BLOCKING('tengu_harbor');
-    }
+  if (true /* channels enabled */) {
+    // OpenClaude: no GrowthBook warm-up needed — isChannelsEnabled() is
+    // hardcoded true. The original checkGate_CACHED_OR_BLOCKING call is
+    // removed (stubbed to always return false in the no-telemetry build).
     if (devChannels && devChannels.length > 0) {
-      const [{
+      const {
         isChannelsEnabled
-      }, {
-        getClaudeAIOAuthTokens
-      }] = await Promise.all([import('./services/mcp/channelAllowlist.js'), import('./utils/auth.js')]);
-      // Skip the dialog when channels are blocked (tengu_harbor off or no
-      // OAuth) — accepting then immediately seeing "not available" in
-      // ChannelsNotice is worse than no dialog. Append entries anyway so
-      // ChannelsNotice renders the blocked branch with the dev entries
-      // named. dev:true here is for the flag label in ChannelsNotice
-      // (hasNonDev check); the allowlist bypass it also grants is moot
-      // since the gate blocks upstream.
-      if (!isChannelsEnabled() || !getClaudeAIOAuthTokens()?.accessToken) {
+      } = await import('./services/mcp/channelAllowlist.js');
+      // Skip the dialog only when channels are globally disabled (shouldn't
+      // happen in OpenClaude since isChannelsEnabled() returns true).
+      // Always show the confirmation dialog — dev channels bypass the
+      // allowlist and carry prompt-injection risk.
+      if (!isChannelsEnabled()) {
         setAllowedChannels([...getAllowedChannels(), ...devChannels.map(c => ({
           ...c,
           dev: true

--- a/src/interactiveHelpers.tsx
+++ b/src/interactiveHelpers.tsx
@@ -1,9 +1,8 @@
-import { feature } from 'bun:bundle';
 import { appendFileSync } from 'fs';
 import React from 'react';
 import { logEvent } from 'src/services/analytics/index.js';
 import { gracefulShutdown, gracefulShutdownSync } from 'src/utils/gracefulShutdown.js';
-import { type ChannelEntry, getAllowedChannels, setAllowedChannels, setHasDevChannels, setSessionTrustAccepted, setStatsStore } from './bootstrap/state.js';
+import { type ChannelEntry, getAllowedChannels, setAllowedChannels, setChannelModeEnabled, setHasDevChannels, setSessionTrustAccepted, setStatsStore } from './bootstrap/state.js';
 import type { Command } from './commands.js';
 import { createStatsStore, type StatsStore } from './context/stats.js';
 import { getSystemContext } from './context.js';
@@ -183,7 +182,7 @@ export async function showSetupScreens(root: Root, permissionMode: PermissionMod
   // Track current repo path for teleport directory switching (fire-and-forget)
   // This must happen AFTER trust to prevent untrusted directories from poisoning the mapping
   void updateGithubRepoPathMapping();
-  if (feature('LODESTONE')) {
+  if (false) {
     updateDeepLinkTerminalPreference();
   }
 
@@ -231,7 +230,7 @@ export async function showSetupScreens(root: Root, permissionMode: PermissionMod
     } = await import('./components/BypassPermissionsModeDialog.js');
     await showSetupDialog(root, done => <BypassPermissionsModeDialog onAccept={done} />);
   }
-  if (feature('TRANSCRIPT_CLASSIFIER')) {
+  if (true) {
     // Only show the opt-in dialog if auto mode actually resolved — if the
     // gate denied it (org not allowlisted, settings disabled), showing
     // consent for an unavailable feature is pointless. The
@@ -266,6 +265,7 @@ export async function showSetupScreens(root: Root, permissionMode: PermissionMod
           dev: true
         }))]);
         setHasDevChannels(true);
+        setChannelModeEnabled(true);
       } else {
         const {
           DevChannelsDialog
@@ -278,6 +278,7 @@ export async function showSetupScreens(root: Root, permissionMode: PermissionMod
             dev: true
           }))]);
           setHasDevChannels(true);
+          setChannelModeEnabled(true);
           void done();
         }} />);
       }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1636,7 +1636,7 @@ async function run(): Promise<CommanderCommand> {
     // devChannels is deferred: showSetupScreens shows a confirmation dialog
     // and only appends to allowedChannels on accept.
     let devChannels: ChannelEntry[] | undefined;
-    if (feature('KAIROS') || feature('KAIROS_CHANNELS')) {
+    if (true /* channels enabled */) {
       // Parse plugin:name@marketplace / server:Y tags into typed entries.
       // Tag decides trust model downstream: plugin-kind hits marketplace
       // verification + GrowthBook allowlist, server-kind always fails
@@ -3829,7 +3829,7 @@ async function run(): Promise<CommanderCommand> {
   if (feature('KAIROS')) {
     program.addOption(new Option('--assistant', 'Force assistant mode (Agent SDK daemon use)').hideHelp());
   }
-  if (feature('KAIROS') || feature('KAIROS_CHANNELS')) {
+  if (true /* channels enabled */) {
     program.addOption(new Option('--channels <servers...>', 'MCP servers whose channel notifications (inbound push) should register this session. Space-separated server names.').hideHelp());
     program.addOption(new Option('--dangerously-load-development-channels <servers...>', 'Load channel servers not on the approved allowlist. For local channel development only. Shows a confirmation dialog at startup.').hideHelp());
   }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -168,7 +168,7 @@ import { setCwd } from 'src/utils/Shell.js';
 import { type ProcessedResume, processResumedConversation } from 'src/utils/sessionRestore.js';
 import { parseSettingSourcesFlag } from 'src/utils/settings/constants.js';
 import { plural } from 'src/utils/stringUtils.js';
-import { type ChannelEntry, getInitialMainLoopModel, getIsNonInteractiveSession, getSdkBetas, getSessionId, getUserMsgOptIn, setAllowedChannels, setAllowedSettingSources, setChromeFlagOverride, setClientType, setCwdState, setDirectConnectServerUrl, setFlagSettingsPath, setInitialMainLoopModel, setInlinePlugins, setIsInteractive, setKairosActive, setOriginalCwd, setQuestionPreviewFormat, setSdkBetas, setSessionBypassPermissionsMode, setSessionPersistenceDisabled, setSessionSource, setUserMsgOptIn, switchSession } from './bootstrap/state.js';
+import { type ChannelEntry, getInitialMainLoopModel, getIsNonInteractiveSession, getSdkBetas, getSessionId, getUserMsgOptIn, setAllowedChannels, setAllowedSettingSources, setChannelModeEnabled, setChromeFlagOverride, setClientType, setCwdState, setDirectConnectServerUrl, setFlagSettingsPath, setInitialMainLoopModel, setInlinePlugins, setIsInteractive, setKairosActive, setOriginalCwd, setQuestionPreviewFormat, setSdkBetas, setSessionBypassPermissionsMode, setSessionPersistenceDisabled, setSessionSource, setUserMsgOptIn, switchSession } from './bootstrap/state.js';
 
 /* eslint-disable @typescript-eslint/no-require-imports */
 const autoModeStateModule = feature('TRANSCRIPT_CLASSIFIER') ? require('./utils/permissions/autoModeState.js') as typeof import('./utils/permissions/autoModeState.js') : null;
@@ -1689,6 +1689,7 @@ async function run(): Promise<CommanderCommand> {
       if (rawChannels && rawChannels.length > 0) {
         channelEntries = parseChannelEntries(rawChannels, '--channels');
         setAllowedChannels(channelEntries);
+        setChannelModeEnabled(true);
       }
       if (!isNonInteractiveSession) {
         if (rawDev && rawDev.length > 0) {

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3830,8 +3830,8 @@ async function run(): Promise<CommanderCommand> {
     program.addOption(new Option('--assistant', 'Force assistant mode (Agent SDK daemon use)').hideHelp());
   }
   if (true /* channels enabled */) {
-    program.addOption(new Option('--channels <servers...>', 'MCP servers whose channel notifications (inbound push) should register this session. Space-separated server names.').hideHelp());
-    program.addOption(new Option('--dangerously-load-development-channels <servers...>', 'Load channel servers not on the approved allowlist. For local channel development only. Shows a confirmation dialog at startup.').hideHelp());
+    program.addOption(new Option('--channels <channel-spec...>', 'MCP channel specs whose channel notifications (inbound push) should register this session. Each entry must be explicitly tagged, for example server:<name> or plugin:<name>@<marketplace>.').hideHelp());
+    program.addOption(new Option('--dangerously-load-development-channels <channel-spec...>', 'Load channel specs not on the approved allowlist. Each entry must be explicitly tagged, for example server:<name> or plugin:<name>@<marketplace>. For local channel development only. Shows a confirmation dialog at startup.').hideHelp());
   }
 
   // Teammate identity options (set by leader when spawning tmux teammates)

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1639,11 +1639,10 @@ async function run(): Promise<CommanderCommand> {
     if (true /* channels enabled */) {
       // Parse plugin:name@marketplace / server:Y tags into typed entries.
       // Tag decides trust model downstream: plugin-kind hits marketplace
-      // verification + GrowthBook allowlist, server-kind always fails
-      // allowlist (schema is plugin-only) unless dev flag is set.
-      // Untagged or marketplace-less plugin entries are hard errors —
-      // silently not-matching in the gate would look like channels are
-      // "on" but nothing ever fires.
+      // verification + hardcoded allowlist, server-kind requires dev flag
+      // (--dangerously-load-development-channels). Untagged or marketplace-less
+      // plugin entries are hard errors — silently not-matching in the gate
+      // would look like channels are "on" but nothing ever fires.
       const parseChannelEntries = (raw: string[], flag: string): ChannelEntry[] => {
         const entries: ChannelEntry[] = [];
         const bad: string[] = [];

--- a/src/screens/REPL.tsx
+++ b/src/screens/REPL.tsx
@@ -209,7 +209,7 @@ import { useIDEIntegration } from '../hooks/useIDEIntegration.js';
 import exit from '../commands/exit/index.js';
 import { ExitFlow } from '../components/ExitFlow.js';
 import { getCurrentWorktreeSession } from '../utils/worktree.js';
-import { popAllEditable, enqueue, type SetAppState, getCommandQueue, getCommandQueueLength, removeByFilter } from '../utils/messageQueueManager.js';
+import { popAllEditable, enqueue, type SetAppState, getCommandQueue, getCommandQueueLength, removeByFilter, recheckCommandQueue } from '../utils/messageQueueManager.js';
 import { useCommandQueue } from '../hooks/useCommandQueue.js';
 import { SessionBackgroundHint } from '../components/SessionBackgroundHint.js';
 import { startBackgroundSession } from '../tasks/LocalMainSessionTask.js';
@@ -2964,6 +2964,12 @@ export function REPL({
       // running→idle. Returns false if a newer query owns the guard
       // (cancel+resubmit race where the stale finally fires as a microtask).
       if (queryGuard.end(thisGeneration)) {
+        // Bump the queue snapshot so useQueueProcessor re-checks any
+        // commands that arrived while this query was running. Without
+        // this, Ink's reconciler can coalesce the guard→idle and
+        // snapshot state changes into a single render where the
+        // useEffect deps don't change enough to re-fire.
+        recheckCommandQueue();
         setLastQueryCompletionTime(Date.now());
         skipIdleCheckRef.current = false;
         // Always reset loading state in finally - this ensures cleanup even

--- a/src/services/mcp/channelAllowlist.ts
+++ b/src/services/mcp/channelAllowlist.ts
@@ -1,8 +1,9 @@
 /**
  * Approved channel plugins allowlist. --channels plugin:name@marketplace
  * entries only register if {marketplace, plugin} is on this list. server:
- * entries are allowed directly in OpenClaude. The
- * --dangerously-load-development-channels flag bypasses for both kinds.
+ * entries can be specified directly in OpenClaude, but only dev-flagged
+ * server entries register via --dangerously-load-development-channels. The
+ * flag bypasses the allowlist for both kinds.
  *
  * OpenClaude: hardcoded allowlist replaces GrowthBook-sourced list.
  * Custom channels work via --dangerously-load-development-channels.

--- a/src/services/mcp/channelAllowlist.ts
+++ b/src/services/mcp/channelAllowlist.ts
@@ -1,46 +1,29 @@
 /**
  * Approved channel plugins allowlist. --channels plugin:name@marketplace
  * entries only register if {marketplace, plugin} is on this list. server:
- * entries always fail (schema is plugin-only). The
+ * entries are allowed directly in OpenClaude. The
  * --dangerously-load-development-channels flag bypasses for both kinds.
- * Lives in GrowthBook so it can be updated without a release.
  *
- * Plugin-level granularity: if a plugin is approved, all its channel
- * servers are. Per-server gating was overengineering — a plugin that
- * sprouts a malicious second server is already compromised, and per-server
- * entries would break on harmless plugin refactors.
- *
- * The allowlist check is a pure {marketplace, plugin} comparison against
- * the user's typed tag. The gate's separate 'marketplace' step verifies
- * the tag matches what's actually installed before this check runs.
+ * OpenClaude: hardcoded allowlist replaces GrowthBook-sourced list.
+ * Custom channels work via --dangerously-load-development-channels.
  */
 
-import { z } from 'zod/v4'
-import { lazySchema } from '../../utils/lazySchema.js'
 import { parsePluginIdentifier } from '../../utils/plugins/pluginIdentifier.js'
-import { getFeatureValue_CACHED_MAY_BE_STALE } from '../analytics/growthbook.js'
 
 export type ChannelAllowlistEntry = {
   marketplace: string
   plugin: string
 }
 
-const ChannelAllowlistSchema = lazySchema(() =>
-  z.array(
-    z.object({
-      marketplace: z.string(),
-      plugin: z.string(),
-    }),
-  ),
-)
-
 export function getChannelAllowlist(): ChannelAllowlistEntry[] {
-  const raw = getFeatureValue_CACHED_MAY_BE_STALE<unknown>(
-    'tengu_harbor_ledger',
-    [],
-  )
-  const parsed = ChannelAllowlistSchema().safeParse(raw)
-  return parsed.success ? parsed.data : []
+  // OpenClaude: hardcode official channel plugins so they work without
+  // GrowthBook. Custom channels still work via --dangerously-load-development-channels.
+  return [
+    { marketplace: 'claude-plugins-official', plugin: 'telegram' },
+    { marketplace: 'claude-plugins-official', plugin: 'discord' },
+    { marketplace: 'claude-plugins-official', plugin: 'imessage' },
+    { marketplace: 'claude-plugins-official', plugin: 'fakechat' },
+  ]
 }
 
 /**
@@ -49,7 +32,8 @@ export function getChannelAllowlist(): ChannelAllowlistEntry[] {
  * Default false; GrowthBook 5-min refresh.
  */
 export function isChannelsEnabled(): boolean {
-  return getFeatureValue_CACHED_MAY_BE_STALE('tengu_harbor', false)
+  // OpenClaude: bypass GrowthBook gate — channels always available
+  return true
 }
 
 /**

--- a/src/services/mcp/channelAutoAllow.test.ts
+++ b/src/services/mcp/channelAutoAllow.test.ts
@@ -1,0 +1,180 @@
+/**
+ * Tests for channelAutoAllow — the trust boundary that controls which
+ * tool permission rules are auto-granted for channel servers.
+ *
+ * Validates:
+ *   - Only official non-dev plugin entries get auto-allow rules
+ *   - Only reply/send tools are allowed (not arbitrary server tools)
+ *   - Dev entries get nothing
+ *   - Server-kind entries get nothing
+ *   - Merge is idempotent (repeated reconnects don't widen permissions)
+ *   - A plugin exposing extra tools does not inherit broader trust
+ */
+import { describe, expect, test } from 'bun:test'
+import type { ChannelEntry } from '../../bootstrap/state.js'
+import {
+  computeChannelAutoAllowRules,
+  mergeAutoAllowRules,
+} from './channelAutoAllow.js'
+
+// ---------------------------------------------------------------------------
+// computeChannelAutoAllowRules
+// ---------------------------------------------------------------------------
+
+describe('computeChannelAutoAllowRules', () => {
+  test('returns reply and send rules for official plugin entry', () => {
+    const entry: ChannelEntry = {
+      kind: 'plugin',
+      name: 'telegram',
+      marketplace: 'claude-plugins-official',
+    }
+    const rules = computeChannelAutoAllowRules('plugin:telegram:abc', entry)
+    expect(rules).toHaveLength(2)
+    // Rules must contain exactly reply and send with the correct MCP prefix
+    expect(rules[0]).toMatch(/^mcp__.*__reply$/)
+    expect(rules[1]).toMatch(/^mcp__.*__send$/)
+  })
+
+  test('rules use normalised server name in prefix', () => {
+    const entry: ChannelEntry = {
+      kind: 'plugin',
+      name: 'telegram',
+      marketplace: 'claude-plugins-official',
+    }
+    const rules = computeChannelAutoAllowRules('plugin:telegram:abc', entry)
+    // "plugin:telegram:abc" normalised: colons → underscores
+    expect(rules[0]).toContain('plugin_telegram_abc')
+    expect(rules[1]).toContain('plugin_telegram_abc')
+  })
+
+  test('returns empty array for dev plugin entry', () => {
+    const entry: ChannelEntry = {
+      kind: 'plugin',
+      name: 'custom-chat',
+      marketplace: 'my-marketplace',
+      dev: true,
+    }
+    const rules = computeChannelAutoAllowRules('plugin:custom-chat:abc', entry)
+    expect(rules).toEqual([])
+  })
+
+  test('returns empty array for server-kind entry', () => {
+    const entry: ChannelEntry = { kind: 'server', name: 'my-bridge' }
+    const rules = computeChannelAutoAllowRules('my-bridge', entry)
+    expect(rules).toEqual([])
+  })
+
+  test('returns empty array for server-kind entry even with dev flag', () => {
+    const entry: ChannelEntry = {
+      kind: 'server',
+      name: 'my-bridge',
+      dev: true,
+    }
+    const rules = computeChannelAutoAllowRules('my-bridge', entry)
+    expect(rules).toEqual([])
+  })
+
+  test('returns empty array for undefined entry', () => {
+    const rules = computeChannelAutoAllowRules('unknown-server', undefined)
+    expect(rules).toEqual([])
+  })
+
+  test('only produces reply and send — no broader server-level rule', () => {
+    const entry: ChannelEntry = {
+      kind: 'plugin',
+      name: 'telegram',
+      marketplace: 'claude-plugins-official',
+    }
+    const rules = computeChannelAutoAllowRules('plugin:telegram:abc', entry)
+    // No rule should be a prefix-only (server-level) rule like "mcp__plugin_telegram_abc"
+    for (const rule of rules) {
+      // Every rule must have content after the last __ (a tool name)
+      const parts = rule.split('__')
+      expect(parts.length).toBeGreaterThanOrEqual(3)
+      expect(parts[parts.length - 1]).toBeTruthy() // non-empty tool name
+    }
+    // Ensure only reply and send — not any hypothetical third tool
+    const toolNames = rules.map(r => r.split('__').pop())
+    expect(toolNames).toEqual(['reply', 'send'])
+  })
+})
+
+// ---------------------------------------------------------------------------
+// mergeAutoAllowRules
+// ---------------------------------------------------------------------------
+
+describe('mergeAutoAllowRules', () => {
+  test('adds new rules to empty existing list', () => {
+    const result = mergeAutoAllowRules([], ['rule_a', 'rule_b'])
+    expect(result).toEqual(['rule_a', 'rule_b'])
+  })
+
+  test('adds new rules alongside existing rules', () => {
+    const result = mergeAutoAllowRules(['existing'], ['rule_a', 'rule_b'])
+    expect(result).toEqual(['existing', 'rule_a', 'rule_b'])
+  })
+
+  test('returns null when all rules already exist (idempotent)', () => {
+    const result = mergeAutoAllowRules(
+      ['rule_a', 'rule_b'],
+      ['rule_a', 'rule_b'],
+    )
+    expect(result).toBeNull()
+  })
+
+  test('only adds rules that are new (partial overlap)', () => {
+    const result = mergeAutoAllowRules(['rule_a'], ['rule_a', 'rule_b'])
+    expect(result).toEqual(['rule_a', 'rule_b'])
+  })
+
+  test('returns null for empty new rules', () => {
+    const result = mergeAutoAllowRules(['existing'], [])
+    expect(result).toBeNull()
+  })
+
+  test('repeated reconnects are idempotent', () => {
+    // Simulate: first connect adds rules, second connect is a no-op
+    const entry: ChannelEntry = {
+      kind: 'plugin',
+      name: 'telegram',
+      marketplace: 'claude-plugins-official',
+    }
+    const rules = computeChannelAutoAllowRules('plugin:telegram:abc', entry)
+    const afterFirst = mergeAutoAllowRules([], rules)!
+    expect(afterFirst).toHaveLength(2)
+
+    const afterSecond = mergeAutoAllowRules(afterFirst, rules)
+    expect(afterSecond).toBeNull() // no change — idempotent
+  })
+
+  test('different servers get separate rules without duplication', () => {
+    const telegramEntry: ChannelEntry = {
+      kind: 'plugin',
+      name: 'telegram',
+      marketplace: 'claude-plugins-official',
+    }
+    const discordEntry: ChannelEntry = {
+      kind: 'plugin',
+      name: 'discord',
+      marketplace: 'claude-plugins-official',
+    }
+
+    const tgRules = computeChannelAutoAllowRules(
+      'plugin:telegram:abc',
+      telegramEntry,
+    )
+    const dcRules = computeChannelAutoAllowRules(
+      'plugin:discord:xyz',
+      discordEntry,
+    )
+
+    let session = mergeAutoAllowRules([], tgRules)!
+    expect(session).toHaveLength(2)
+
+    session = mergeAutoAllowRules(session, dcRules)!
+    expect(session).toHaveLength(4)
+
+    // All four rules should be distinct
+    expect(new Set(session).size).toBe(4)
+  })
+})

--- a/src/services/mcp/channelAutoAllow.test.ts
+++ b/src/services/mcp/channelAutoAllow.test.ts
@@ -22,17 +22,16 @@ import {
 // ---------------------------------------------------------------------------
 
 describe('computeChannelAutoAllowRules', () => {
-  test('returns reply and send rules for official plugin entry', () => {
+  test('returns reply rule for official plugin entry', () => {
     const entry: ChannelEntry = {
       kind: 'plugin',
       name: 'telegram',
       marketplace: 'claude-plugins-official',
     }
     const rules = computeChannelAutoAllowRules('plugin:telegram:abc', entry)
-    expect(rules).toHaveLength(2)
-    // Rules must contain exactly reply and send with the correct MCP prefix
+    expect(rules).toHaveLength(1)
+    // Rules must contain exactly reply with the correct MCP prefix
     expect(rules[0]).toMatch(/^mcp__.*__reply$/)
-    expect(rules[1]).toMatch(/^mcp__.*__send$/)
   })
 
   test('rules use normalised server name in prefix', () => {
@@ -44,7 +43,6 @@ describe('computeChannelAutoAllowRules', () => {
     const rules = computeChannelAutoAllowRules('plugin:telegram:abc', entry)
     // "plugin:telegram:abc" normalised: colons → underscores
     expect(rules[0]).toContain('plugin_telegram_abc')
-    expect(rules[1]).toContain('plugin_telegram_abc')
   })
 
   test('returns empty array for dev plugin entry', () => {
@@ -79,7 +77,7 @@ describe('computeChannelAutoAllowRules', () => {
     expect(rules).toEqual([])
   })
 
-  test('only produces reply and send — no broader server-level rule', () => {
+  test('only produces reply — no broader server-level rule', () => {
     const entry: ChannelEntry = {
       kind: 'plugin',
       name: 'telegram',
@@ -93,9 +91,9 @@ describe('computeChannelAutoAllowRules', () => {
       expect(parts.length).toBeGreaterThanOrEqual(3)
       expect(parts[parts.length - 1]).toBeTruthy() // non-empty tool name
     }
-    // Ensure only reply and send — not any hypothetical third tool
+    // Ensure only reply — send goes through normal permission prompt
     const toolNames = rules.map(r => r.split('__').pop())
-    expect(toolNames).toEqual(['reply', 'send'])
+    expect(toolNames).toEqual(['reply'])
   })
 })
 
@@ -141,7 +139,7 @@ describe('mergeAutoAllowRules', () => {
     }
     const rules = computeChannelAutoAllowRules('plugin:telegram:abc', entry)
     const afterFirst = mergeAutoAllowRules([], rules)!
-    expect(afterFirst).toHaveLength(2)
+    expect(afterFirst).toHaveLength(1)
 
     const afterSecond = mergeAutoAllowRules(afterFirst, rules)
     expect(afterSecond).toBeNull() // no change — idempotent
@@ -169,12 +167,12 @@ describe('mergeAutoAllowRules', () => {
     )
 
     let session = mergeAutoAllowRules([], tgRules)!
-    expect(session).toHaveLength(2)
+    expect(session).toHaveLength(1)
 
     session = mergeAutoAllowRules(session, dcRules)!
-    expect(session).toHaveLength(4)
+    expect(session).toHaveLength(2)
 
-    // All four rules should be distinct
-    expect(new Set(session).size).toBe(4)
+    // All two rules should be distinct
+    expect(new Set(session).size).toBe(2)
   })
 })

--- a/src/services/mcp/channelAutoAllow.test.ts
+++ b/src/services/mcp/channelAutoAllow.test.ts
@@ -1,5 +1,5 @@
-﻿/**
- * Tests for channelAutoAllow â€” the trust boundary that controls which
+/**
+ * Tests for channelAutoAllow — the trust boundary that controls which
  * tool permission rules are auto-granted for channel servers.
  *
  * Validates:
@@ -41,7 +41,7 @@ describe('computeChannelAutoAllowRules', () => {
       marketplace: 'claude-plugins-official',
     }
     const rules = computeChannelAutoAllowRules('plugin:telegram:abc', entry)
-    // "plugin:telegram:abc" normalised: colons â†’ underscores
+    // "plugin:telegram:abc" normalised: colons → underscores
     expect(rules[0]).toContain('plugin_telegram_abc')
   })
 
@@ -77,7 +77,7 @@ describe('computeChannelAutoAllowRules', () => {
     expect(rules).toEqual([])
   })
 
-  test('only produces reply â€” no broader server-level rule', () => {
+  test('only produces reply — no broader server-level rule', () => {
     const entry: ChannelEntry = {
       kind: 'plugin',
       name: 'telegram',
@@ -91,7 +91,7 @@ describe('computeChannelAutoAllowRules', () => {
       expect(parts.length).toBeGreaterThanOrEqual(3)
       expect(parts[parts.length - 1]).toBeTruthy() // non-empty tool name
     }
-    // Ensure only reply â€” send goes through normal permission prompt
+    // Ensure only reply — send goes through normal permission prompt
     const toolNames = rules.map(r => r.split('__').pop())
     expect(toolNames).toEqual(['reply'])
   })
@@ -142,7 +142,7 @@ describe('mergeAutoAllowRules', () => {
     expect(afterFirst).toHaveLength(1)
 
     const afterSecond = mergeAutoAllowRules(afterFirst, rules)
-    expect(afterSecond).toBeNull() // no change â€” idempotent
+    expect(afterSecond).toBeNull() // no change — idempotent
   })
 
   test('different servers get separate rules without duplication', () => {

--- a/src/services/mcp/channelAutoAllow.test.ts
+++ b/src/services/mcp/channelAutoAllow.test.ts
@@ -1,5 +1,5 @@
-/**
- * Tests for channelAutoAllow — the trust boundary that controls which
+﻿/**
+ * Tests for channelAutoAllow â€” the trust boundary that controls which
  * tool permission rules are auto-granted for channel servers.
  *
  * Validates:
@@ -41,7 +41,7 @@ describe('computeChannelAutoAllowRules', () => {
       marketplace: 'claude-plugins-official',
     }
     const rules = computeChannelAutoAllowRules('plugin:telegram:abc', entry)
-    // "plugin:telegram:abc" normalised: colons → underscores
+    // "plugin:telegram:abc" normalised: colons â†’ underscores
     expect(rules[0]).toContain('plugin_telegram_abc')
   })
 
@@ -77,7 +77,7 @@ describe('computeChannelAutoAllowRules', () => {
     expect(rules).toEqual([])
   })
 
-  test('only produces reply — no broader server-level rule', () => {
+  test('only produces reply â€” no broader server-level rule', () => {
     const entry: ChannelEntry = {
       kind: 'plugin',
       name: 'telegram',
@@ -91,7 +91,7 @@ describe('computeChannelAutoAllowRules', () => {
       expect(parts.length).toBeGreaterThanOrEqual(3)
       expect(parts[parts.length - 1]).toBeTruthy() // non-empty tool name
     }
-    // Ensure only reply — send goes through normal permission prompt
+    // Ensure only reply â€” send goes through normal permission prompt
     const toolNames = rules.map(r => r.split('__').pop())
     expect(toolNames).toEqual(['reply'])
   })
@@ -142,7 +142,7 @@ describe('mergeAutoAllowRules', () => {
     expect(afterFirst).toHaveLength(1)
 
     const afterSecond = mergeAutoAllowRules(afterFirst, rules)
-    expect(afterSecond).toBeNull() // no change — idempotent
+    expect(afterSecond).toBeNull() // no change â€” idempotent
   })
 
   test('different servers get separate rules without duplication', () => {

--- a/src/services/mcp/channelAutoAllow.ts
+++ b/src/services/mcp/channelAutoAllow.ts
@@ -4,9 +4,9 @@
  * can be tested independently.
  *
  * Trust model: only official (non-dev) plugin entries get auto-allow, and
- * only for the minimal set of known reply/send tools. Server-kind entries,
- * dev entries, and unrecognised entries get nothing — the user must
- * approve manually.
+ * only for the reply tool (responding to inbound traffic). The broader
+ * send tool (proactive outbound) goes through the normal permission
+ * prompt. Server-kind, dev, and unrecognised entries get nothing.
  */
 import type { ChannelEntry } from '../../bootstrap/state.js'
 import { getMcpPrefix } from './mcpStringUtils.js'
@@ -27,7 +27,7 @@ export function computeChannelAutoAllowRules(
     return []
   }
   const toolPrefix = getMcpPrefix(serverName)
-  return [`${toolPrefix}reply`, `${toolPrefix}send`]
+  return [`${toolPrefix}reply`]
 }
 
 /**

--- a/src/services/mcp/channelAutoAllow.ts
+++ b/src/services/mcp/channelAutoAllow.ts
@@ -1,0 +1,44 @@
+/**
+ * Computes the auto-allow rules for a channel server. Extracted from the
+ * inline logic in useManageMCPConnections/print.ts so the trust boundary
+ * can be tested independently.
+ *
+ * Trust model: only official (non-dev) plugin entries get auto-allow, and
+ * only for the minimal set of known reply/send tools. Server-kind entries,
+ * dev entries, and unrecognised entries get nothing — the user must
+ * approve manually.
+ */
+import type { ChannelEntry } from '../../bootstrap/state.js'
+import { getMcpPrefix } from './mcpStringUtils.js'
+
+/**
+ * Returns the tool permission rules that should be auto-allowed for a
+ * channel server, or an empty array if none should be granted.
+ *
+ * @param serverName  MCP server name (e.g. "plugin:telegram:abc")
+ * @param entry       The channel entry from the session list, or undefined
+ * @returns           Tool rules like ["mcp__plugin_telegram_abc__reply", ...]
+ */
+export function computeChannelAutoAllowRules(
+  serverName: string,
+  entry: ChannelEntry | undefined,
+): string[] {
+  if (entry?.kind !== 'plugin' || entry?.dev === true) {
+    return []
+  }
+  const toolPrefix = getMcpPrefix(serverName)
+  return [`${toolPrefix}reply`, `${toolPrefix}send`]
+}
+
+/**
+ * Merges new auto-allow rules into an existing session rules array,
+ * deduplicating. Returns null if no new rules need to be added.
+ */
+export function mergeAutoAllowRules(
+  existingRules: string[],
+  newRules: string[],
+): string[] | null {
+  const toAdd = newRules.filter(rule => !existingRules.includes(rule))
+  if (toAdd.length === 0) return null
+  return [...existingRules, ...toAdd]
+}

--- a/src/services/mcp/channelAutoAllow.ts
+++ b/src/services/mcp/channelAutoAllow.ts
@@ -1,4 +1,4 @@
-/**
+﻿/**
  * Computes the auto-allow rules for a channel server. Extracted from the
  * inline logic in useManageMCPConnections/print.ts so the trust boundary
  * can be tested independently.

--- a/src/services/mcp/channelAutoAllow.ts
+++ b/src/services/mcp/channelAutoAllow.ts
@@ -35,8 +35,8 @@ export function computeChannelAutoAllowRules(
  * deduplicating. Returns null if no new rules need to be added.
  */
 export function mergeAutoAllowRules(
-  existingRules: string[],
-  newRules: string[],
+  existingRules: readonly string[],
+  newRules: readonly string[],
 ): string[] | null {
   const toAdd = newRules.filter(rule => !existingRules.includes(rule))
   if (toAdd.length === 0) return null

--- a/src/services/mcp/channelNotification.test.ts
+++ b/src/services/mcp/channelNotification.test.ts
@@ -1,11 +1,11 @@
 /**
  * Focused tests for the channel notification trust-sensitive paths:
  *   - gateChannelServer(): approved plugin, dev channel, non-allowlisted,
- *     server-kind, auto-registration, marketplace verification
+ *     server-kind, marketplace verification
  *   - findChannelEntry(): plugin vs server matching
  *
- * These validate that the OpenClaude trust model change (auto-register for
- * approved plugins, explicit opt-in for everything else) behaves correctly.
+ * These validate that the OpenClaude trust model: explicit opt-in via
+ * --channels for all entries (no auto-registration).
  */
 import {
   describe,
@@ -37,9 +37,6 @@ beforeEach(() => {
 
   mock.module('../../bootstrap/state.js', () => ({
     getAllowedChannels: () => mockAllowedChannels,
-    setAllowedChannels: (entries: ChannelEntry[]) => {
-      mockAllowedChannels = entries
-    },
   }))
 
   mock.module('./channelAllowlist.js', () => ({
@@ -171,32 +168,19 @@ describe('gateChannelServer — approved plugin path', () => {
     expect(result.action).toBe('register')
   })
 
-  test('auto-registers an approved plugin not yet in --channels', async () => {
+  test('skips an approved plugin NOT in --channels list (no auto-registration)', async () => {
     const { gateChannelServer } = await loadModule()
-    // No pre-existing channels — should auto-add
+    // Plugin is on the hardcoded allowlist but NOT in --channels
     mockAllowedChannels = []
     const result = gateChannelServer(
       'plugin:telegram:abc',
       CHANNEL_CAP,
       'telegram@claude-plugins-official',
     )
-    expect(result.action).toBe('register')
-    // Verify the entry was auto-added
-    expect(mockAllowedChannels).toHaveLength(1)
-    expect(mockAllowedChannels[0]).toEqual({
-      kind: 'plugin',
-      name: 'telegram',
-      marketplace: 'claude-plugins-official',
-    })
-  })
-
-  test('auto-registration is idempotent (does not duplicate entries)', async () => {
-    const { gateChannelServer } = await loadModule()
-    mockAllowedChannels = [
-      { kind: 'plugin', name: 'telegram', marketplace: 'claude-plugins-official' },
-    ]
-    gateChannelServer('plugin:telegram:abc', CHANNEL_CAP, 'telegram@claude-plugins-official')
-    expect(mockAllowedChannels).toHaveLength(1)
+    expect(result.action).toBe('skip')
+    expect((result as any).kind).toBe('session')
+    // Verify no auto-registration occurred
+    expect(mockAllowedChannels).toHaveLength(0)
   })
 })
 

--- a/src/services/mcp/channelNotification.test.ts
+++ b/src/services/mcp/channelNotification.test.ts
@@ -1,0 +1,349 @@
+/**
+ * Focused tests for the channel notification trust-sensitive paths:
+ *   - gateChannelServer(): approved plugin, dev channel, non-allowlisted,
+ *     server-kind, auto-registration, marketplace verification
+ *   - findChannelEntry(): plugin vs server matching
+ *
+ * These validate that the OpenClaude trust model change (auto-register for
+ * approved plugins, explicit opt-in for everything else) behaves correctly.
+ */
+import {
+  describe,
+  expect,
+  test,
+  mock,
+  beforeEach,
+  afterEach,
+} from 'bun:test'
+import type { ServerCapabilities } from '@modelcontextprotocol/sdk/types.js'
+import type { ChannelEntry } from '../../bootstrap/state.js'
+
+// ---------------------------------------------------------------------------
+// Module-level mocks — isolate from real global state
+// ---------------------------------------------------------------------------
+
+let mockAllowedChannels: ChannelEntry[] = []
+let mockChannelsEnabled = true
+const mockAllowlist = [
+  { marketplace: 'claude-plugins-official', plugin: 'telegram' },
+  { marketplace: 'claude-plugins-official', plugin: 'discord' },
+  { marketplace: 'claude-plugins-official', plugin: 'imessage' },
+  { marketplace: 'claude-plugins-official', plugin: 'fakechat' },
+]
+
+beforeEach(() => {
+  mockAllowedChannels = []
+  mockChannelsEnabled = true
+
+  mock.module('../../bootstrap/state.js', () => ({
+    getAllowedChannels: () => mockAllowedChannels,
+    setAllowedChannels: (entries: ChannelEntry[]) => {
+      mockAllowedChannels = entries
+    },
+  }))
+
+  mock.module('./channelAllowlist.js', () => ({
+    getChannelAllowlist: () => mockAllowlist,
+    isChannelsEnabled: () => mockChannelsEnabled,
+  }))
+})
+
+afterEach(() => {
+  mock.restore()
+})
+
+// Dynamic import to pick up mocks — bust module cache each time
+async function loadModule() {
+  return await import(`./channelNotification.ts?ts=${Date.now()}`)
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const CHANNEL_CAP: ServerCapabilities = {
+  experimental: { 'claude/channel': {} },
+}
+
+const NO_CHANNEL_CAP: ServerCapabilities = { experimental: {} }
+
+// ---------------------------------------------------------------------------
+// findChannelEntry
+// ---------------------------------------------------------------------------
+
+describe('findChannelEntry', () => {
+  test('matches plugin-kind entry by second segment of server name', async () => {
+    const { findChannelEntry } = await loadModule()
+    const channels: ChannelEntry[] = [
+      { kind: 'plugin', name: 'telegram', marketplace: 'claude-plugins-official' },
+    ]
+    const result = findChannelEntry('plugin:telegram:abc', channels)
+    expect(result).toEqual(channels[0])
+  })
+
+  test('matches server-kind entry by exact name', async () => {
+    const { findChannelEntry } = await loadModule()
+    const channels: ChannelEntry[] = [
+      { kind: 'server', name: 'my-slack-bridge' },
+    ]
+    const result = findChannelEntry('my-slack-bridge', channels)
+    expect(result).toEqual(channels[0])
+  })
+
+  test('returns undefined when no match', async () => {
+    const { findChannelEntry } = await loadModule()
+    const channels: ChannelEntry[] = [
+      { kind: 'plugin', name: 'discord', marketplace: 'claude-plugins-official' },
+    ]
+    expect(findChannelEntry('plugin:telegram:abc', channels)).toBeUndefined()
+    expect(findChannelEntry('unknown-server', channels)).toBeUndefined()
+  })
+
+  test('does not match plugin entry against bare name', async () => {
+    const { findChannelEntry } = await loadModule()
+    const channels: ChannelEntry[] = [
+      { kind: 'plugin', name: 'telegram', marketplace: 'claude-plugins-official' },
+    ]
+    // bare name "telegram" should NOT match a plugin entry
+    expect(findChannelEntry('telegram', channels)).toBeUndefined()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// gateChannelServer — capability check
+// ---------------------------------------------------------------------------
+
+describe('gateChannelServer — capability check', () => {
+  test('skips servers without claude/channel capability', async () => {
+    const { gateChannelServer } = await loadModule()
+    const result = gateChannelServer('plugin:telegram:abc', NO_CHANNEL_CAP, 'telegram@claude-plugins-official')
+    expect(result.action).toBe('skip')
+    expect((result as any).kind).toBe('capability')
+  })
+
+  test('skips servers with undefined capabilities', async () => {
+    const { gateChannelServer } = await loadModule()
+    const result = gateChannelServer('plugin:telegram:abc', undefined, 'telegram@claude-plugins-official')
+    expect(result.action).toBe('skip')
+    expect((result as any).kind).toBe('capability')
+  })
+
+  test('passes servers with claude/channel: {} capability', async () => {
+    const { gateChannelServer } = await loadModule()
+    // Pre-add an allowed channel entry
+    mockAllowedChannels = [
+      { kind: 'plugin', name: 'telegram', marketplace: 'claude-plugins-official' },
+    ]
+    const result = gateChannelServer('plugin:telegram:abc', CHANNEL_CAP, 'telegram@claude-plugins-official')
+    expect(result.action).toBe('register')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// gateChannelServer — runtime disabled
+// ---------------------------------------------------------------------------
+
+describe('gateChannelServer — runtime disabled', () => {
+  test('skips when channels feature is disabled', async () => {
+    mockChannelsEnabled = false
+    const { gateChannelServer } = await loadModule()
+    const result = gateChannelServer('plugin:telegram:abc', CHANNEL_CAP, 'telegram@claude-plugins-official')
+    expect(result.action).toBe('skip')
+    expect((result as any).kind).toBe('disabled')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// gateChannelServer — approved plugin path
+// ---------------------------------------------------------------------------
+
+describe('gateChannelServer — approved plugin path', () => {
+  test('registers an approved plugin that is in --channels list', async () => {
+    const { gateChannelServer } = await loadModule()
+    mockAllowedChannels = [
+      { kind: 'plugin', name: 'telegram', marketplace: 'claude-plugins-official' },
+    ]
+    const result = gateChannelServer(
+      'plugin:telegram:abc',
+      CHANNEL_CAP,
+      'telegram@claude-plugins-official',
+    )
+    expect(result.action).toBe('register')
+  })
+
+  test('auto-registers an approved plugin not yet in --channels', async () => {
+    const { gateChannelServer } = await loadModule()
+    // No pre-existing channels — should auto-add
+    mockAllowedChannels = []
+    const result = gateChannelServer(
+      'plugin:telegram:abc',
+      CHANNEL_CAP,
+      'telegram@claude-plugins-official',
+    )
+    expect(result.action).toBe('register')
+    // Verify the entry was auto-added
+    expect(mockAllowedChannels).toHaveLength(1)
+    expect(mockAllowedChannels[0]).toEqual({
+      kind: 'plugin',
+      name: 'telegram',
+      marketplace: 'claude-plugins-official',
+    })
+  })
+
+  test('auto-registration is idempotent (does not duplicate entries)', async () => {
+    const { gateChannelServer } = await loadModule()
+    mockAllowedChannels = [
+      { kind: 'plugin', name: 'telegram', marketplace: 'claude-plugins-official' },
+    ]
+    gateChannelServer('plugin:telegram:abc', CHANNEL_CAP, 'telegram@claude-plugins-official')
+    expect(mockAllowedChannels).toHaveLength(1)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// gateChannelServer — non-allowlisted plugin
+// ---------------------------------------------------------------------------
+
+describe('gateChannelServer — non-allowlisted plugin', () => {
+  test('skips a plugin not on the approved allowlist', async () => {
+    const { gateChannelServer } = await loadModule()
+    // Plugin in session list but NOT in hardcoded allowlist
+    mockAllowedChannels = [
+      { kind: 'plugin', name: 'evil-chat', marketplace: 'evil-marketplace' },
+    ]
+    const result = gateChannelServer(
+      'plugin:evil-chat:xyz',
+      CHANNEL_CAP,
+      'evil-chat@evil-marketplace',
+    )
+    expect(result.action).toBe('skip')
+    expect((result as any).kind).toBe('allowlist')
+  })
+
+  test('does not auto-register a non-allowlisted plugin', async () => {
+    const { gateChannelServer } = await loadModule()
+    mockAllowedChannels = []
+    const result = gateChannelServer(
+      'plugin:evil-chat:xyz',
+      CHANNEL_CAP,
+      'evil-chat@evil-marketplace',
+    )
+    expect(result.action).toBe('skip')
+    expect((result as any).kind).toBe('session')
+    expect(mockAllowedChannels).toHaveLength(0)
+  })
+
+  test('non-allowlisted plugin with dev flag DOES register', async () => {
+    const { gateChannelServer } = await loadModule()
+    mockAllowedChannels = [
+      { kind: 'plugin', name: 'custom-chat', marketplace: 'my-marketplace', dev: true },
+    ]
+    const result = gateChannelServer(
+      'plugin:custom-chat:xyz',
+      CHANNEL_CAP,
+      'custom-chat@my-marketplace',
+    )
+    expect(result.action).toBe('register')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// gateChannelServer — marketplace verification
+// ---------------------------------------------------------------------------
+
+describe('gateChannelServer — marketplace verification', () => {
+  test('rejects when installed marketplace does not match entry', async () => {
+    const { gateChannelServer } = await loadModule()
+    mockAllowedChannels = [
+      { kind: 'plugin', name: 'telegram', marketplace: 'claude-plugins-official' },
+    ]
+    // pluginSource says "evil-marketplace" but entry expects "claude-plugins-official"
+    const result = gateChannelServer(
+      'plugin:telegram:abc',
+      CHANNEL_CAP,
+      'telegram@evil-marketplace',
+    )
+    expect(result.action).toBe('skip')
+    expect((result as any).kind).toBe('marketplace')
+  })
+
+  test('rejects when pluginSource has no marketplace (@-less)', async () => {
+    const { gateChannelServer } = await loadModule()
+    mockAllowedChannels = [
+      { kind: 'plugin', name: 'telegram', marketplace: 'claude-plugins-official' },
+    ]
+    const result = gateChannelServer(
+      'plugin:telegram:abc',
+      CHANNEL_CAP,
+      'telegram', // no @marketplace
+    )
+    expect(result.action).toBe('skip')
+    expect((result as any).kind).toBe('marketplace')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// gateChannelServer — server-kind path
+// ---------------------------------------------------------------------------
+
+describe('gateChannelServer — server-kind entries', () => {
+  test('rejects server-kind entry WITHOUT dev flag', async () => {
+    const { gateChannelServer } = await loadModule()
+    mockAllowedChannels = [{ kind: 'server', name: 'my-bridge' }]
+    const result = gateChannelServer('my-bridge', CHANNEL_CAP, undefined)
+    expect(result.action).toBe('skip')
+    expect((result as any).kind).toBe('allowlist')
+    expect((result as any).reason).toContain(
+      '--dangerously-load-development-channels',
+    )
+  })
+
+  test('registers server-kind entry WITH dev flag', async () => {
+    const { gateChannelServer } = await loadModule()
+    mockAllowedChannels = [{ kind: 'server', name: 'my-bridge', dev: true }]
+    const result = gateChannelServer('my-bridge', CHANNEL_CAP, undefined)
+    expect(result.action).toBe('register')
+  })
+
+  test('server-kind dev entry is not blocked by allowlist', async () => {
+    const { gateChannelServer } = await loadModule()
+    // "my-bridge" is not on the hardcoded plugin allowlist — doesn't matter,
+    // server-kind with dev=true bypasses the plugin allowlist entirely
+    mockAllowedChannels = [{ kind: 'server', name: 'my-bridge', dev: true }]
+    const result = gateChannelServer('my-bridge', CHANNEL_CAP, undefined)
+    expect(result.action).toBe('register')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// gateChannelServer — dev channel path (plugin with dev flag)
+// ---------------------------------------------------------------------------
+
+describe('gateChannelServer — dev channel path', () => {
+  test('dev plugin bypasses allowlist entirely', async () => {
+    const { gateChannelServer } = await loadModule()
+    mockAllowedChannels = [
+      { kind: 'plugin', name: 'my-custom', marketplace: 'my-custom-marketplace', dev: true },
+    ]
+    const result = gateChannelServer(
+      'plugin:my-custom:abc',
+      CHANNEL_CAP,
+      'my-custom@my-custom-marketplace',
+    )
+    expect(result.action).toBe('register')
+  })
+
+  test('dev plugin still requires marketplace match', async () => {
+    const { gateChannelServer } = await loadModule()
+    mockAllowedChannels = [
+      { kind: 'plugin', name: 'my-custom', marketplace: 'expected-marketplace', dev: true },
+    ]
+    const result = gateChannelServer(
+      'plugin:my-custom:abc',
+      CHANNEL_CAP,
+      'my-custom@wrong-marketplace',
+    )
+    expect(result.action).toBe('skip')
+    expect((result as any).kind).toBe('marketplace')
+  })
+})

--- a/src/services/mcp/channelNotification.test.ts
+++ b/src/services/mcp/channelNotification.test.ts
@@ -1,4 +1,4 @@
-﻿/**
+/**
  * Focused tests for the channel notification trust-sensitive paths:
  *   - gateChannelServer(): approved plugin, dev channel, non-allowlisted,
  *     server-kind, marketplace verification
@@ -24,7 +24,7 @@ import {
 } from '../../bootstrap/state.js'
 
 // ---------------------------------------------------------------------------
-// Module-level mocks â€” isolate from real global state
+// Module-level mocks — isolate from real global state
 // ---------------------------------------------------------------------------
 
 let mockChannelsEnabled = true
@@ -55,7 +55,7 @@ afterEach(() => {
   setAllowedChannels([])
 })
 
-// Dynamic import to pick up mocks â€” bust module cache each time
+// Dynamic import to pick up mocks — bust module cache each time
 async function loadModule() {
   return await import(`./channelNotification.ts?ts=${Date.now()}`)
 }
@@ -113,10 +113,10 @@ describe('findChannelEntry', () => {
 })
 
 // ---------------------------------------------------------------------------
-// gateChannelServer â€” capability check
+// gateChannelServer — capability check
 // ---------------------------------------------------------------------------
 
-describe('gateChannelServer â€” capability check', () => {
+describe('gateChannelServer — capability check', () => {
   test('skips servers without claude/channel capability', async () => {
     const { gateChannelServer } = await loadModule()
     const result = gateChannelServer('plugin:telegram:abc', NO_CHANNEL_CAP, 'telegram@claude-plugins-official')
@@ -141,10 +141,10 @@ describe('gateChannelServer â€” capability check', () => {
 })
 
 // ---------------------------------------------------------------------------
-// gateChannelServer â€” runtime disabled
+// gateChannelServer — runtime disabled
 // ---------------------------------------------------------------------------
 
-describe('gateChannelServer â€” runtime disabled', () => {
+describe('gateChannelServer — runtime disabled', () => {
   test('skips when channels feature is disabled', async () => {
     mockChannelsEnabled = false
     const { gateChannelServer } = await loadModule()
@@ -155,10 +155,10 @@ describe('gateChannelServer â€” runtime disabled', () => {
 })
 
 // ---------------------------------------------------------------------------
-// gateChannelServer â€” approved plugin path
+// gateChannelServer — approved plugin path
 // ---------------------------------------------------------------------------
 
-describe('gateChannelServer â€” approved plugin path', () => {
+describe('gateChannelServer — approved plugin path', () => {
   test('registers an approved plugin that is in --channels list', async () => {
     const { gateChannelServer } = await loadModule()
     setAllowedChannels([{ kind: 'plugin', name: 'telegram', marketplace: 'claude-plugins-official' }])
@@ -206,10 +206,10 @@ describe('gateChannelServer â€” approved plugin path', () => {
 })
 
 // ---------------------------------------------------------------------------
-// gateChannelServer â€” non-allowlisted plugin
+// gateChannelServer — non-allowlisted plugin
 // ---------------------------------------------------------------------------
 
-describe('gateChannelServer â€” non-allowlisted plugin', () => {
+describe('gateChannelServer — non-allowlisted plugin', () => {
   test('skips a plugin not on the approved allowlist', async () => {
     const { gateChannelServer } = await loadModule()
     // Plugin in session list but NOT in hardcoded allowlist
@@ -249,10 +249,10 @@ describe('gateChannelServer â€” non-allowlisted plugin', () => {
 })
 
 // ---------------------------------------------------------------------------
-// gateChannelServer â€” marketplace verification
+// gateChannelServer — marketplace verification
 // ---------------------------------------------------------------------------
 
-describe('gateChannelServer â€” marketplace verification', () => {
+describe('gateChannelServer — marketplace verification', () => {
   test('rejects when installed marketplace does not match entry', async () => {
     const { gateChannelServer } = await loadModule()
     setAllowedChannels([{ kind: 'plugin', name: 'telegram', marketplace: 'claude-plugins-official' }])
@@ -280,10 +280,10 @@ describe('gateChannelServer â€” marketplace verification', () => {
 })
 
 // ---------------------------------------------------------------------------
-// gateChannelServer â€” server-kind path
+// gateChannelServer — server-kind path
 // ---------------------------------------------------------------------------
 
-describe('gateChannelServer â€” server-kind entries', () => {
+describe('gateChannelServer — server-kind entries', () => {
   test('rejects server-kind entry WITHOUT dev flag', async () => {
     const { gateChannelServer } = await loadModule()
     setAllowedChannels([{ kind: 'server', name: 'my-bridge' }])
@@ -304,7 +304,7 @@ describe('gateChannelServer â€” server-kind entries', () => {
 
   test('server-kind dev entry is not blocked by allowlist', async () => {
     const { gateChannelServer } = await loadModule()
-    // "my-bridge" is not on the hardcoded plugin allowlist â€” doesn't matter,
+    // "my-bridge" is not on the hardcoded plugin allowlist — doesn't matter,
     // server-kind with dev=true bypasses the plugin allowlist entirely
     setAllowedChannels([{ kind: 'server', name: 'my-bridge', dev: true }])
     const result = gateChannelServer('my-bridge', CHANNEL_CAP, undefined)
@@ -313,10 +313,10 @@ describe('gateChannelServer â€” server-kind entries', () => {
 })
 
 // ---------------------------------------------------------------------------
-// gateChannelServer â€” dev channel path (plugin with dev flag)
+// gateChannelServer — dev channel path (plugin with dev flag)
 // ---------------------------------------------------------------------------
 
-describe('gateChannelServer â€” dev channel path', () => {
+describe('gateChannelServer — dev channel path', () => {
   test('dev plugin bypasses allowlist entirely', async () => {
     const { gateChannelServer } = await loadModule()
     setAllowedChannels([{ kind: 'plugin', name: 'my-custom', marketplace: 'my-custom-marketplace', dev: true }])

--- a/src/services/mcp/channelNotification.test.ts
+++ b/src/services/mcp/channelNotification.test.ts
@@ -1,4 +1,4 @@
-/**
+﻿/**
  * Focused tests for the channel notification trust-sensitive paths:
  *   - gateChannelServer(): approved plugin, dev channel, non-allowlisted,
  *     server-kind, marketplace verification
@@ -24,7 +24,7 @@ import {
 } from '../../bootstrap/state.js'
 
 // ---------------------------------------------------------------------------
-// Module-level mocks — isolate from real global state
+// Module-level mocks â€” isolate from real global state
 // ---------------------------------------------------------------------------
 
 let mockChannelsEnabled = true
@@ -55,7 +55,7 @@ afterEach(() => {
   setAllowedChannels([])
 })
 
-// Dynamic import to pick up mocks — bust module cache each time
+// Dynamic import to pick up mocks â€” bust module cache each time
 async function loadModule() {
   return await import(`./channelNotification.ts?ts=${Date.now()}`)
 }
@@ -113,10 +113,10 @@ describe('findChannelEntry', () => {
 })
 
 // ---------------------------------------------------------------------------
-// gateChannelServer — capability check
+// gateChannelServer â€” capability check
 // ---------------------------------------------------------------------------
 
-describe('gateChannelServer — capability check', () => {
+describe('gateChannelServer â€” capability check', () => {
   test('skips servers without claude/channel capability', async () => {
     const { gateChannelServer } = await loadModule()
     const result = gateChannelServer('plugin:telegram:abc', NO_CHANNEL_CAP, 'telegram@claude-plugins-official')
@@ -141,10 +141,10 @@ describe('gateChannelServer — capability check', () => {
 })
 
 // ---------------------------------------------------------------------------
-// gateChannelServer — runtime disabled
+// gateChannelServer â€” runtime disabled
 // ---------------------------------------------------------------------------
 
-describe('gateChannelServer — runtime disabled', () => {
+describe('gateChannelServer â€” runtime disabled', () => {
   test('skips when channels feature is disabled', async () => {
     mockChannelsEnabled = false
     const { gateChannelServer } = await loadModule()
@@ -155,10 +155,10 @@ describe('gateChannelServer — runtime disabled', () => {
 })
 
 // ---------------------------------------------------------------------------
-// gateChannelServer — approved plugin path
+// gateChannelServer â€” approved plugin path
 // ---------------------------------------------------------------------------
 
-describe('gateChannelServer — approved plugin path', () => {
+describe('gateChannelServer â€” approved plugin path', () => {
   test('registers an approved plugin that is in --channels list', async () => {
     const { gateChannelServer } = await loadModule()
     setAllowedChannels([{ kind: 'plugin', name: 'telegram', marketplace: 'claude-plugins-official' }])
@@ -206,10 +206,10 @@ describe('gateChannelServer — approved plugin path', () => {
 })
 
 // ---------------------------------------------------------------------------
-// gateChannelServer — non-allowlisted plugin
+// gateChannelServer â€” non-allowlisted plugin
 // ---------------------------------------------------------------------------
 
-describe('gateChannelServer — non-allowlisted plugin', () => {
+describe('gateChannelServer â€” non-allowlisted plugin', () => {
   test('skips a plugin not on the approved allowlist', async () => {
     const { gateChannelServer } = await loadModule()
     // Plugin in session list but NOT in hardcoded allowlist
@@ -249,10 +249,10 @@ describe('gateChannelServer — non-allowlisted plugin', () => {
 })
 
 // ---------------------------------------------------------------------------
-// gateChannelServer — marketplace verification
+// gateChannelServer â€” marketplace verification
 // ---------------------------------------------------------------------------
 
-describe('gateChannelServer — marketplace verification', () => {
+describe('gateChannelServer â€” marketplace verification', () => {
   test('rejects when installed marketplace does not match entry', async () => {
     const { gateChannelServer } = await loadModule()
     setAllowedChannels([{ kind: 'plugin', name: 'telegram', marketplace: 'claude-plugins-official' }])
@@ -280,10 +280,10 @@ describe('gateChannelServer — marketplace verification', () => {
 })
 
 // ---------------------------------------------------------------------------
-// gateChannelServer — server-kind path
+// gateChannelServer â€” server-kind path
 // ---------------------------------------------------------------------------
 
-describe('gateChannelServer — server-kind entries', () => {
+describe('gateChannelServer â€” server-kind entries', () => {
   test('rejects server-kind entry WITHOUT dev flag', async () => {
     const { gateChannelServer } = await loadModule()
     setAllowedChannels([{ kind: 'server', name: 'my-bridge' }])
@@ -304,7 +304,7 @@ describe('gateChannelServer — server-kind entries', () => {
 
   test('server-kind dev entry is not blocked by allowlist', async () => {
     const { gateChannelServer } = await loadModule()
-    // "my-bridge" is not on the hardcoded plugin allowlist — doesn't matter,
+    // "my-bridge" is not on the hardcoded plugin allowlist â€” doesn't matter,
     // server-kind with dev=true bypasses the plugin allowlist entirely
     setAllowedChannels([{ kind: 'server', name: 'my-bridge', dev: true }])
     const result = gateChannelServer('my-bridge', CHANNEL_CAP, undefined)
@@ -313,10 +313,10 @@ describe('gateChannelServer — server-kind entries', () => {
 })
 
 // ---------------------------------------------------------------------------
-// gateChannelServer — dev channel path (plugin with dev flag)
+// gateChannelServer â€” dev channel path (plugin with dev flag)
 // ---------------------------------------------------------------------------
 
-describe('gateChannelServer — dev channel path', () => {
+describe('gateChannelServer â€” dev channel path', () => {
   test('dev plugin bypasses allowlist entirely', async () => {
     const { gateChannelServer } = await loadModule()
     setAllowedChannels([{ kind: 'plugin', name: 'my-custom', marketplace: 'my-custom-marketplace', dev: true }])

--- a/src/services/mcp/channelNotification.test.ts
+++ b/src/services/mcp/channelNotification.test.ts
@@ -20,7 +20,9 @@ import type { ServerCapabilities } from '@modelcontextprotocol/sdk/types.js'
 import type { ChannelEntry } from '../../bootstrap/state.js'
 import {
   getAllowedChannels,
+  getChannelModeEnabled,
   setAllowedChannels,
+  setChannelModeEnabled,
 } from '../../bootstrap/state.js'
 
 // ---------------------------------------------------------------------------
@@ -109,6 +111,48 @@ describe('findChannelEntry', () => {
     ]
     // bare name "telegram" should NOT match a plugin entry
     expect(findChannelEntry('telegram', channels)).toBeUndefined()
+  })
+
+  test('matches plugin by name AND marketplace when pluginSource is given', async () => {
+    const { findChannelEntry } = await loadModule()
+    const channels: ChannelEntry[] = [
+      { kind: 'plugin', name: 'telegram', marketplace: 'my-marketplace' },
+      { kind: 'plugin', name: 'telegram', marketplace: 'claude-plugins-official' },
+    ]
+    // Should prefer the entry whose marketplace matches the installed plugin source
+    const result = findChannelEntry('plugin:telegram:abc', channels, 'telegram@claude-plugins-official')
+    expect(result).toBe(channels[1])
+  })
+
+  test('falls back to name-only match when pluginSource marketplace does not match any entry', async () => {
+    const { findChannelEntry } = await loadModule()
+    const channels: ChannelEntry[] = [
+      { kind: 'plugin', name: 'telegram', marketplace: 'claude-plugins-official' },
+    ]
+    // pluginSource marketplace 'other-marketplace' does not match the entry,
+    // but name-only fallback should still pick it up
+    const result = findChannelEntry('plugin:telegram:abc', channels, 'telegram@other-marketplace')
+    expect(result).toBe(channels[0])
+  })
+
+  test('marketplace match is ignored when pluginSource has no marketplace', async () => {
+    const { findChannelEntry } = await loadModule()
+    const channels: ChannelEntry[] = [
+      { kind: 'plugin', name: 'telegram', marketplace: 'claude-plugins-official' },
+    ]
+    // No @ sign means no marketplace parsing; fallback to name-only
+    const result = findChannelEntry('plugin:telegram:abc', channels, 'telegram')
+    expect(result).toBe(channels[0])
+  })
+
+  test('marketplace matching does not affect server-kind entries', async () => {
+    const { findChannelEntry } = await loadModule()
+    const channels: ChannelEntry[] = [
+      { kind: 'server', name: 'my-bridge' },
+    ]
+    // pluginSource is irrelevant for server-kind entries
+    const result = findChannelEntry('my-bridge', channels, 'telegram@claude-plugins-official')
+    expect(result).toBe(channels[0])
   })
 })
 
@@ -338,5 +382,33 @@ describe('gateChannelServer — dev channel path', () => {
     )
     expect(result.action).toBe('skip')
     expect((result as any).kind).toBe('marketplace')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// channelModeEnabled — dev channel state
+// ---------------------------------------------------------------------------
+
+describe('channelModeEnabled — dev channel state', () => {
+  test('setChannelModeEnabled propagates to getChannelModeEnabled', async () => {
+    expect(getChannelModeEnabled()).toBe(false)
+    setChannelModeEnabled(true)
+    expect(getChannelModeEnabled()).toBe(true)
+    setChannelModeEnabled(false)
+    expect(getChannelModeEnabled()).toBe(false)
+  })
+
+  test('accepting dev channels (simulated) enables channel mode', async () => {
+    // Simulate what interactiveHelpers does on dev channel accept
+    expect(getChannelModeEnabled()).toBe(false)
+    setAllowedChannels([{ kind: 'plugin', name: 'my-custom', marketplace: 'my-marketplace', dev: true }])
+    setChannelModeEnabled(true)
+    expect(getChannelModeEnabled()).toBe(true)
+    // With channel mode on, gateChannelServer should register the dev plugin
+    const { gateChannelServer } = await loadModule()
+    const result = gateChannelServer('plugin:my-custom:abc', CHANNEL_CAP, 'my-custom@my-marketplace')
+    expect(result.action).toBe('register')
+    // Reset for subsequent tests
+    setChannelModeEnabled(false)
   })
 })

--- a/src/services/mcp/channelNotification.test.ts
+++ b/src/services/mcp/channelNotification.test.ts
@@ -4,8 +4,9 @@
  *     server-kind, marketplace verification
  *   - findChannelEntry(): plugin vs server matching
  *
- * These validate that the OpenClaude trust model: explicit opt-in via
- * --channels for all entries (no auto-registration).
+ * These validate the OpenClaude trust model: allowlisted channel plugins
+ * auto-register when they connect; custom/unsigned servers require
+ * explicit --channels opt-in.
  */
 import {
   describe,
@@ -17,12 +18,15 @@ import {
 } from 'bun:test'
 import type { ServerCapabilities } from '@modelcontextprotocol/sdk/types.js'
 import type { ChannelEntry } from '../../bootstrap/state.js'
+import {
+  getAllowedChannels,
+  setAllowedChannels,
+} from '../../bootstrap/state.js'
 
 // ---------------------------------------------------------------------------
 // Module-level mocks — isolate from real global state
 // ---------------------------------------------------------------------------
 
-let mockAllowedChannels: ChannelEntry[] = []
 let mockChannelsEnabled = true
 const mockAllowlist = [
   { marketplace: 'claude-plugins-official', plugin: 'telegram' },
@@ -32,21 +36,23 @@ const mockAllowlist = [
 ]
 
 beforeEach(() => {
-  mockAllowedChannels = []
   mockChannelsEnabled = true
-
-  mock.module('../../bootstrap/state.js', () => ({
-    getAllowedChannels: () => mockAllowedChannels,
-  }))
+  setAllowedChannels([])
 
   mock.module('./channelAllowlist.js', () => ({
     getChannelAllowlist: () => mockAllowlist,
+    isChannelAllowlisted: (pluginSource: string) =>
+      mockAllowlist.some((e) => {
+        const parts = pluginSource.split('@')
+        return parts.length === 2 && e.plugin === parts[0] && e.marketplace === parts[1]
+      }),
     isChannelsEnabled: () => mockChannelsEnabled,
   }))
 })
 
 afterEach(() => {
   mock.restore()
+  setAllowedChannels([])
 })
 
 // Dynamic import to pick up mocks — bust module cache each time
@@ -128,9 +134,7 @@ describe('gateChannelServer — capability check', () => {
   test('passes servers with claude/channel: {} capability', async () => {
     const { gateChannelServer } = await loadModule()
     // Pre-add an allowed channel entry
-    mockAllowedChannels = [
-      { kind: 'plugin', name: 'telegram', marketplace: 'claude-plugins-official' },
-    ]
+    setAllowedChannels([{ kind: 'plugin', name: 'telegram', marketplace: 'claude-plugins-official' }])
     const result = gateChannelServer('plugin:telegram:abc', CHANNEL_CAP, 'telegram@claude-plugins-official')
     expect(result.action).toBe('register')
   })
@@ -157,9 +161,7 @@ describe('gateChannelServer — runtime disabled', () => {
 describe('gateChannelServer — approved plugin path', () => {
   test('registers an approved plugin that is in --channels list', async () => {
     const { gateChannelServer } = await loadModule()
-    mockAllowedChannels = [
-      { kind: 'plugin', name: 'telegram', marketplace: 'claude-plugins-official' },
-    ]
+    setAllowedChannels([{ kind: 'plugin', name: 'telegram', marketplace: 'claude-plugins-official' }])
     const result = gateChannelServer(
       'plugin:telegram:abc',
       CHANNEL_CAP,
@@ -168,19 +170,38 @@ describe('gateChannelServer — approved plugin path', () => {
     expect(result.action).toBe('register')
   })
 
-  test('skips an approved plugin NOT in --channels list (no auto-registration)', async () => {
+  test('auto-registers an approved plugin NOT in --channels list', async () => {
     const { gateChannelServer } = await loadModule()
     // Plugin is on the hardcoded allowlist but NOT in --channels
-    mockAllowedChannels = []
+    // Should auto-register via setAllowedChannels()
+    setAllowedChannels([])
     const result = gateChannelServer(
       'plugin:telegram:abc',
       CHANNEL_CAP,
       'telegram@claude-plugins-official',
     )
-    expect(result.action).toBe('skip')
-    expect((result as any).kind).toBe('session')
-    // Verify no auto-registration occurred
-    expect(mockAllowedChannels).toHaveLength(0)
+    expect(result.action).toBe('register')
+    // Verify auto-registration added the entry
+    expect(getAllowedChannels()).toHaveLength(1)
+    expect(getAllowedChannels()[0]).toEqual({
+      kind: 'plugin',
+      name: 'telegram',
+      marketplace: 'claude-plugins-official',
+      dev: false,
+    })
+  })
+
+  test('registers an approved plugin that is already in --channels list', async () => {
+    const { gateChannelServer } = await loadModule()
+    setAllowedChannels([{ kind: 'plugin', name: 'telegram', marketplace: 'claude-plugins-official' }])
+    const result = gateChannelServer(
+      'plugin:telegram:abc',
+      CHANNEL_CAP,
+      'telegram@claude-plugins-official',
+    )
+    expect(result.action).toBe('register')
+    // Verify no duplicate entry added
+    expect(getAllowedChannels()).toHaveLength(1)
   })
 })
 
@@ -192,9 +213,7 @@ describe('gateChannelServer — non-allowlisted plugin', () => {
   test('skips a plugin not on the approved allowlist', async () => {
     const { gateChannelServer } = await loadModule()
     // Plugin in session list but NOT in hardcoded allowlist
-    mockAllowedChannels = [
-      { kind: 'plugin', name: 'evil-chat', marketplace: 'evil-marketplace' },
-    ]
+    setAllowedChannels([{ kind: 'plugin', name: 'evil-chat', marketplace: 'evil-marketplace' }])
     const result = gateChannelServer(
       'plugin:evil-chat:xyz',
       CHANNEL_CAP,
@@ -206,7 +225,7 @@ describe('gateChannelServer — non-allowlisted plugin', () => {
 
   test('does not auto-register a non-allowlisted plugin', async () => {
     const { gateChannelServer } = await loadModule()
-    mockAllowedChannels = []
+    setAllowedChannels([])
     const result = gateChannelServer(
       'plugin:evil-chat:xyz',
       CHANNEL_CAP,
@@ -214,14 +233,12 @@ describe('gateChannelServer — non-allowlisted plugin', () => {
     )
     expect(result.action).toBe('skip')
     expect((result as any).kind).toBe('session')
-    expect(mockAllowedChannels).toHaveLength(0)
+    expect(getAllowedChannels()).toHaveLength(0)
   })
 
   test('non-allowlisted plugin with dev flag DOES register', async () => {
     const { gateChannelServer } = await loadModule()
-    mockAllowedChannels = [
-      { kind: 'plugin', name: 'custom-chat', marketplace: 'my-marketplace', dev: true },
-    ]
+    setAllowedChannels([{ kind: 'plugin', name: 'custom-chat', marketplace: 'my-marketplace', dev: true }])
     const result = gateChannelServer(
       'plugin:custom-chat:xyz',
       CHANNEL_CAP,
@@ -238,9 +255,7 @@ describe('gateChannelServer — non-allowlisted plugin', () => {
 describe('gateChannelServer — marketplace verification', () => {
   test('rejects when installed marketplace does not match entry', async () => {
     const { gateChannelServer } = await loadModule()
-    mockAllowedChannels = [
-      { kind: 'plugin', name: 'telegram', marketplace: 'claude-plugins-official' },
-    ]
+    setAllowedChannels([{ kind: 'plugin', name: 'telegram', marketplace: 'claude-plugins-official' }])
     // pluginSource says "evil-marketplace" but entry expects "claude-plugins-official"
     const result = gateChannelServer(
       'plugin:telegram:abc',
@@ -253,9 +268,7 @@ describe('gateChannelServer — marketplace verification', () => {
 
   test('rejects when pluginSource has no marketplace (@-less)', async () => {
     const { gateChannelServer } = await loadModule()
-    mockAllowedChannels = [
-      { kind: 'plugin', name: 'telegram', marketplace: 'claude-plugins-official' },
-    ]
+    setAllowedChannels([{ kind: 'plugin', name: 'telegram', marketplace: 'claude-plugins-official' }])
     const result = gateChannelServer(
       'plugin:telegram:abc',
       CHANNEL_CAP,
@@ -273,7 +286,7 @@ describe('gateChannelServer — marketplace verification', () => {
 describe('gateChannelServer — server-kind entries', () => {
   test('rejects server-kind entry WITHOUT dev flag', async () => {
     const { gateChannelServer } = await loadModule()
-    mockAllowedChannels = [{ kind: 'server', name: 'my-bridge' }]
+    setAllowedChannels([{ kind: 'server', name: 'my-bridge' }])
     const result = gateChannelServer('my-bridge', CHANNEL_CAP, undefined)
     expect(result.action).toBe('skip')
     expect((result as any).kind).toBe('allowlist')
@@ -284,7 +297,7 @@ describe('gateChannelServer — server-kind entries', () => {
 
   test('registers server-kind entry WITH dev flag', async () => {
     const { gateChannelServer } = await loadModule()
-    mockAllowedChannels = [{ kind: 'server', name: 'my-bridge', dev: true }]
+    setAllowedChannels([{ kind: 'server', name: 'my-bridge', dev: true }])
     const result = gateChannelServer('my-bridge', CHANNEL_CAP, undefined)
     expect(result.action).toBe('register')
   })
@@ -293,7 +306,7 @@ describe('gateChannelServer — server-kind entries', () => {
     const { gateChannelServer } = await loadModule()
     // "my-bridge" is not on the hardcoded plugin allowlist — doesn't matter,
     // server-kind with dev=true bypasses the plugin allowlist entirely
-    mockAllowedChannels = [{ kind: 'server', name: 'my-bridge', dev: true }]
+    setAllowedChannels([{ kind: 'server', name: 'my-bridge', dev: true }])
     const result = gateChannelServer('my-bridge', CHANNEL_CAP, undefined)
     expect(result.action).toBe('register')
   })
@@ -306,9 +319,7 @@ describe('gateChannelServer — server-kind entries', () => {
 describe('gateChannelServer — dev channel path', () => {
   test('dev plugin bypasses allowlist entirely', async () => {
     const { gateChannelServer } = await loadModule()
-    mockAllowedChannels = [
-      { kind: 'plugin', name: 'my-custom', marketplace: 'my-custom-marketplace', dev: true },
-    ]
+    setAllowedChannels([{ kind: 'plugin', name: 'my-custom', marketplace: 'my-custom-marketplace', dev: true }])
     const result = gateChannelServer(
       'plugin:my-custom:abc',
       CHANNEL_CAP,
@@ -319,9 +330,7 @@ describe('gateChannelServer — dev channel path', () => {
 
   test('dev plugin still requires marketplace match', async () => {
     const { gateChannelServer } = await loadModule()
-    mockAllowedChannels = [
-      { kind: 'plugin', name: 'my-custom', marketplace: 'expected-marketplace', dev: true },
-    ]
+    setAllowedChannels([{ kind: 'plugin', name: 'my-custom', marketplace: 'expected-marketplace', dev: true }])
     const result = gateChannelServer(
       'plugin:my-custom:abc',
       CHANNEL_CAP,

--- a/src/services/mcp/channelNotification.ts
+++ b/src/services/mcp/channelNotification.ts
@@ -10,23 +10,26 @@
  * The model sees where the message came from and decides which tool to reply
  * with (the channel's MCP tool, SendUserMessage, or both).
  *
- * feature('KAIROS') || feature('KAIROS_CHANNELS'). Runtime gate tengu_harbor.
- * Requires claude.ai OAuth auth — API key users are blocked until
- * console gets a channelsEnabled admin surface. Teams/Enterprise orgs
- * must explicitly opt in via channelsEnabled: true in managed settings.
+ * feature('KAIROS') || feature('KAIROS_CHANNELS') (replaced with true in
+ * OpenClaude build). Runtime gate via isChannelsEnabled() — always true
+ * in OpenClaude. No OAuth or org policy requirement.
+ *
+ * OpenClaude auto-registration: allowlisted plugins (telegram, discord,
+ * imessage, fakechat) are auto-registered when they connect — no --channels
+ * flag required. Custom channels still need --channels or
+ * --dangerously-load-development-channels.
  */
 
 import type { ServerCapabilities } from '@modelcontextprotocol/sdk/types.js'
 import { z } from 'zod/v4'
-import { type ChannelEntry, getAllowedChannels } from '../../bootstrap/state.js'
-import { CHANNEL_TAG } from '../../constants/xml.js'
 import {
-  getClaudeAIOAuthTokens,
-  getSubscriptionType,
-} from '../../utils/auth.js'
+  type ChannelEntry,
+  getAllowedChannels,
+  setAllowedChannels,
+} from '../../bootstrap/state.js'
+import { CHANNEL_TAG } from '../../constants/xml.js'
 import { lazySchema } from '../../utils/lazySchema.js'
 import { parsePluginIdentifier } from '../../utils/plugins/pluginIdentifier.js'
-import { getSettingsForSource } from '../../utils/settings/settings.js'
 import { escapeXmlAttr } from '../../utils/xml.js'
 import {
   type ChannelAllowlistEntry,
@@ -116,22 +119,20 @@ export function wrapChannelMessage(
 }
 
 /**
- * Effective allowlist for the current session. Team/enterprise orgs can set
- * allowedChannelPlugins in managed settings — when set, it REPLACES the
- * GrowthBook ledger (admin owns the trust decision). Undefined falls back
- * to the ledger. Unmanaged users always get the ledger.
+ * Effective allowlist for the current session. OpenClaude: simplified to
+ * always return the hardcoded allowlist. Org overrides (allowedChannelPlugins)
+ * are accepted if provided for forward-compatibility.
  *
- * Callers already read sub/policy for the policy gate — pass them in to
- * avoid double-reading getSettingsForSource (uncached).
+ * Signature kept for backward-compat with ChannelsNotice.tsx.
  */
 export function getEffectiveChannelAllowlist(
-  sub: ReturnType<typeof getSubscriptionType>,
-  orgList: ChannelAllowlistEntry[] | undefined,
+  _sub?: string,
+  orgList?: ChannelAllowlistEntry[] | undefined,
 ): {
   entries: ChannelAllowlistEntry[]
   source: 'org' | 'ledger'
 } {
-  if ((sub === 'team' || sub === 'enterprise') && orgList) {
+  if (orgList && orgList.length > 0) {
     return { entries: orgList, source: 'org' }
   }
   return { entries: getChannelAllowlist(), source: 'ledger' }
@@ -175,14 +176,16 @@ export function findChannelEntry(
 /**
  * Gate an MCP server's channel-notification path. Caller checks
  * feature('KAIROS') || feature('KAIROS_CHANNELS') first (build-time
- * elimination). Gate order: capability → runtime gate (tengu_harbor) →
- * auth (OAuth only) → org policy → session --channels → allowlist.
- * API key users are blocked at the auth layer — channels requires
- * claude.ai auth; console orgs have no admin opt-in surface yet.
+ * elimination). Gate order: capability → runtime gate (isChannelsEnabled) →
+ * session --channels (with auto-register for allowlisted plugins) →
+ * marketplace verification → allowlist.
  *
- *   skip      Not a channel server, or managed org hasn't opted in, or
- *             not in session --channels. Connection stays up; handler
- *             not registered.
+ * OpenClaude: OAuth and org policy gates removed. Allowlisted plugins
+ * (telegram, discord, etc.) auto-register without --channels. Custom
+ * channels still need explicit --channels or dev-channels flag.
+ *
+ *   skip      Not a channel server, or not allowlisted/registered.
+ *             Connection stays up; handler not registered.
  *   register  Subscribe to notifications/claude/channel.
  *
  * Which servers can connect at all is governed by allowedMcpServers —
@@ -208,6 +211,7 @@ export function gateChannelServer(
   // Overall runtime gate. After capability so normal MCP servers never hit
   // this path. Before auth/policy so the killswitch works regardless of
   // session state.
+  // OpenClaude: isChannelsEnabled() now always returns true (no GrowthBook).
   if (!isChannelsEnabled()) {
     return {
       action: 'skip',
@@ -216,43 +220,47 @@ export function gateChannelServer(
     }
   }
 
-  // OAuth-only. API key users (console) are blocked — there's no
-  // channelsEnabled admin surface in console yet, so the policy opt-in
-  // flow doesn't exist for them. Drop this when console parity lands.
-  if (!getClaudeAIOAuthTokens()?.accessToken) {
-    return {
-      action: 'skip',
-      kind: 'auth',
-      reason: 'channels requires claude.ai authentication (run /login)',
-    }
-  }
-
-  // Teams/Enterprise opt-in. Managed orgs must explicitly enable channels.
-  // Default OFF — absent or false blocks. Keyed off subscription tier, not
-  // "policy settings exist" — a team org with zero configured policy keys
-  // (remote endpoint returns 404) is still a managed org and must not fall
-  // through to the unmanaged path.
-  const sub = getSubscriptionType()
-  const managed = sub === 'team' || sub === 'enterprise'
-  const policy = managed ? getSettingsForSource('policySettings') : undefined
-  if (managed && policy?.channelsEnabled !== true) {
-    return {
-      action: 'skip',
-      kind: 'policy',
-      reason:
-        'channels not enabled by org policy (set channelsEnabled: true in managed settings)',
-    }
-  }
+  // OpenClaude: OAuth and org policy gates removed.
+  // Original Claude Code requires claude.ai OAuth and Teams/Enterprise
+  // channelsEnabled policy. OpenClaude users control their own setup
+  // (API key or OAuth) and have no managed org admin console, so these
+  // gates are bypassed. The session allowlist (--channels flag) and
+  // capability check remain as the security boundary.
 
   // User-level session opt-in. A server must be explicitly listed in
   // --channels to push inbound this session — protects against a trusted
   // server surprise-adding the capability.
-  const entry = findChannelEntry(serverName, getAllowedChannels())
+  //
+  // OpenClaude auto-registration: if the server isn't in the session list
+  // but IS on the hardcoded plugin allowlist, auto-add it. This means
+  // allowlisted plugins (telegram, discord, etc.) work without --channels.
+  // Custom/non-allowlisted channels still need --channels or
+  // --dangerously-load-development-channels.
+  let entry = findChannelEntry(serverName, getAllowedChannels())
+  if (!entry && pluginSource) {
+    // Check if this plugin is on the hardcoded allowlist
+    const { name, marketplace } = parsePluginIdentifier(pluginSource)
+    if (
+      marketplace &&
+      getChannelAllowlist().some(
+        e => e.plugin === name && e.marketplace === marketplace,
+      )
+    ) {
+      // Auto-register: create a session entry so downstream gates pass
+      const autoEntry: ChannelEntry = {
+        kind: 'plugin',
+        name,
+        marketplace,
+      }
+      setAllowedChannels([...getAllowedChannels(), autoEntry])
+      entry = autoEntry
+    }
+  }
   if (!entry) {
     return {
       action: 'skip',
       kind: 'session',
-      reason: `server ${serverName} not in --channels list for this session`,
+      reason: `server ${serverName} not in --channels list for this session (use --channels plugin:<name>@<marketplace> or install an approved channel plugin)`,
     }
   }
 
@@ -280,10 +288,9 @@ export function gateChannelServer(
     // not the session-wide bit) bypasses — so accepting the dev dialog for
     // one entry doesn't leak allowlist-bypass to --channels entries.
     if (!entry.dev) {
-      const { entries, source } = getEffectiveChannelAllowlist(
-        sub,
-        policy?.allowedChannelPlugins,
-      )
+      // OpenClaude: use hardcoded allowlist from getChannelAllowlist()
+      // instead of GrowthBook + org policy. No sub/policy variables needed.
+      const entries = getChannelAllowlist()
       if (
         !entries.some(
           e => e.plugin === entry.name && e.marketplace === entry.marketplace,
@@ -292,24 +299,16 @@ export function gateChannelServer(
         return {
           action: 'skip',
           kind: 'allowlist',
-          reason:
-            source === 'org'
-              ? `plugin ${entry.name}@${entry.marketplace} is not on your org's approved channels list (set allowedChannelPlugins in managed settings)`
-              : `plugin ${entry.name}@${entry.marketplace} is not on the approved channels allowlist (use --dangerously-load-development-channels for local dev)`,
+          reason: `plugin ${entry.name}@${entry.marketplace} is not on the approved channels allowlist (use --dangerously-load-development-channels for local dev)`,
         }
       }
     }
   } else {
-    // server-kind: allowlist schema is {marketplace, plugin} — a server entry
-    // can never match. Without this, --channels server:plugin:foo:bar would
-    // match a plugin's runtime name and register with no allowlist check.
-    if (!entry.dev) {
-      return {
-        action: 'skip',
-        kind: 'allowlist',
-        reason: `server ${entry.name} is not on the approved channels allowlist (use --dangerously-load-development-channels for local dev)`,
-      }
-    }
+    // server-kind: in original Claude Code, server entries always fail the
+    // allowlist (schema is plugin-only). OpenClaude: allow server-kind
+    // entries since the user explicitly opted in via --channels. The session
+    // allowlist check above (findChannelEntry) already verified the server
+    // was named in --channels.
   }
 
   return { action: 'register' }

--- a/src/services/mcp/channelNotification.ts
+++ b/src/services/mcp/channelNotification.ts
@@ -14,10 +14,9 @@
  * OpenClaude build). Runtime gate via isChannelsEnabled() — always true
  * in OpenClaude. No OAuth or org policy requirement.
  *
- * OpenClaude auto-registration: allowlisted plugins (telegram, discord,
- * imessage, fakechat) are auto-registered when they connect — no --channels
- * flag required. Custom channels still need --channels or
- * --dangerously-load-development-channels.
+ * OpenClaude: allowlisted plugins (telegram, discord, imessage, fakechat)
+ * pass the allowlist check automatically when listed via --channels.
+ * Custom channels need --dangerously-load-development-channels.
  */
 
 import type { ServerCapabilities } from '@modelcontextprotocol/sdk/types.js'
@@ -25,7 +24,6 @@ import { z } from 'zod/v4'
 import {
   type ChannelEntry,
   getAllowedChannels,
-  setAllowedChannels,
 } from '../../bootstrap/state.js'
 import { CHANNEL_TAG } from '../../constants/xml.js'
 import { lazySchema } from '../../utils/lazySchema.js'
@@ -177,12 +175,11 @@ export function findChannelEntry(
  * Gate an MCP server's channel-notification path. Caller checks
  * feature('KAIROS') || feature('KAIROS_CHANNELS') first (build-time
  * elimination). Gate order: capability → runtime gate (isChannelsEnabled) →
- * session --channels (with auto-register for allowlisted plugins) →
- * marketplace verification → allowlist.
+ * session --channels → marketplace verification → allowlist.
  *
- * OpenClaude: OAuth and org policy gates removed. Allowlisted plugins
- * (telegram, discord, etc.) auto-register without --channels. Custom
- * channels still need explicit --channels or dev-channels flag.
+ * OpenClaude: OAuth and org policy gates removed. The session allowlist
+ * (--channels flag) and capability check remain as the security boundary.
+ * Users must explicitly opt in via --channels for all channel servers.
  *
  *   skip      Not a channel server, or not allowlisted/registered.
  *             Connection stays up; handler not registered.
@@ -229,33 +226,9 @@ export function gateChannelServer(
 
   // User-level session opt-in. A server must be explicitly listed in
   // --channels to push inbound this session — protects against a trusted
-  // server surprise-adding the capability.
-  //
-  // OpenClaude auto-registration: if the server isn't in the session list
-  // but IS on the hardcoded plugin allowlist, auto-add it. This means
-  // allowlisted plugins (telegram, discord, etc.) work without --channels.
-  // Custom/non-allowlisted channels still need --channels or
-  // --dangerously-load-development-channels.
-  let entry = findChannelEntry(serverName, getAllowedChannels())
-  if (!entry && pluginSource) {
-    // Check if this plugin is on the hardcoded allowlist
-    const { name, marketplace } = parsePluginIdentifier(pluginSource)
-    if (
-      marketplace &&
-      getChannelAllowlist().some(
-        e => e.plugin === name && e.marketplace === marketplace,
-      )
-    ) {
-      // Auto-register: create a session entry so downstream gates pass
-      const autoEntry: ChannelEntry = {
-        kind: 'plugin',
-        name,
-        marketplace,
-      }
-      setAllowedChannels([...getAllowedChannels(), autoEntry])
-      entry = autoEntry
-    }
-  }
+  // server surprise-adding the capability. No auto-registration: even
+  // allowlisted plugins require explicit --channels opt-in.
+  const entry = findChannelEntry(serverName, getAllowedChannels())
   if (!entry) {
     return {
       action: 'skip',

--- a/src/services/mcp/channelNotification.ts
+++ b/src/services/mcp/channelNotification.ts
@@ -304,11 +304,18 @@ export function gateChannelServer(
       }
     }
   } else {
-    // server-kind: in original Claude Code, server entries always fail the
-    // allowlist (schema is plugin-only). OpenClaude: allow server-kind
-    // entries since the user explicitly opted in via --channels. The session
-    // allowlist check above (findChannelEntry) already verified the server
-    // was named in --channels.
+    // server-kind entries are never covered by the plugin allowlist, so keep
+    // the original safety boundary: manually configured MCP servers must be
+    // marked as development entries before they can register for inbound
+    // channel notifications.
+    if (!entry.dev) {
+      return {
+        action: 'skip',
+        kind: 'allowlist',
+        reason:
+          'server entries require --dangerously-load-development-channels before they can register as channels',
+      }
+    }
   }
 
   return { action: 'register' }

--- a/src/services/mcp/channelNotification.ts
+++ b/src/services/mcp/channelNotification.ts
@@ -1,9 +1,9 @@
-﻿/**
- * Channel notifications â€” lets an MCP server push user messages into the
+/**
+ * Channel notifications — lets an MCP server push user messages into the
  * conversation. A "channel" (Discord, Slack, SMS, etc.) is just an MCP server
  * that:
- *   - exposes tools for outbound messages (e.g. `send_message`) â€” standard MCP
- *   - sends `notifications/claude/channel` notifications for inbound â€” this file
+ *   - exposes tools for outbound messages (e.g. `send_message`) — standard MCP
+ *   - sends `notifications/claude/channel` notifications for inbound — this file
  *
  * The notification handler wraps the content in a <channel> tag and
  * enqueues it. SleepTool polls hasCommandsInQueue() and wakes within 1s.
@@ -11,7 +11,7 @@
  * with (the channel's MCP tool, SendUserMessage, or both).
  *
  * feature('KAIROS') || feature('KAIROS_CHANNELS') (replaced with true in
- * OpenClaude build). Runtime gate via isChannelsEnabled() â€” always true
+ * OpenClaude build). Runtime gate via isChannelsEnabled() — always true
  * in OpenClaude. No OAuth or org policy requirement.
  *
  * OpenClaude: allowlisted plugins (telegram, discord, imessage, fakechat)
@@ -42,7 +42,7 @@ export const ChannelMessageNotificationSchema = lazySchema(() =>
     method: z.literal('notifications/claude/channel'),
     params: z.object({
       content: z.string(),
-      // Opaque passthrough â€” thread_id, user, whatever the channel wants the
+      // Opaque passthrough — thread_id, user, whatever the channel wants the
       // model to see. Rendered as attributes on the <channel> tag.
       meta: z.record(z.string(), z.string()).optional(),
     }),
@@ -53,13 +53,13 @@ export const ChannelMessageNotificationSchema = lazySchema(() =>
  * Structured permission reply from a channel server. Servers that support
  * this declare `capabilities.experimental['claude/channel/permission']` and
  * emit this event INSTEAD of relaying "yes tbxkq" as text via
- * notifications/claude/channel. Explicit opt-in per server â€” a channel that
+ * notifications/claude/channel. Explicit opt-in per server — a channel that
  * just wants to relay text never becomes a permission surface by accident.
  *
  * The server parses the user's reply (spec: /^\s*(y|yes|n|no)\s+([a-km-z]{5})\s*$/i)
  * and emits {request_id, behavior}. CC matches request_id against its
  * pending map. Unlike the regex-intercept approach, text in the general
- * channel can never accidentally match â€” approval requires the server
+ * channel can never accidentally match — approval requires the server
  * to deliberately emit this specific event.
  */
 export const CHANNEL_PERMISSION_METHOD =
@@ -75,14 +75,14 @@ export const ChannelPermissionNotificationSchema = lazySchema(() =>
 )
 
 /**
- * Outbound: CC â†’ server. Fired from interactiveHandler.ts when a
+ * Outbound: CC → server. Fired from interactiveHandler.ts when a
  * permission dialog opens and the server has declared the permission
  * capability. Server formats the message for its platform (Telegram
  * markdown, iMessage rich text, Discord embed) and sends it to the
  * human. When the human replies "yes tbxkq", the server parses that
  * against PERMISSION_REPLY_RE and emits the inbound schema above.
  *
- * Not a zod schema â€” CC SENDS this, doesn't validate it. A type here
+ * Not a zod schema — CC SENDS this, doesn't validate it. A type here
  * keeps both halves of the protocol documented side by side.
  */
 export const CHANNEL_PERMISSION_REQUEST_METHOD =
@@ -91,14 +91,14 @@ export type ChannelPermissionRequestParams = {
   request_id: string
   tool_name: string
   description: string
-  /** JSON-stringified tool input, truncated to 200 chars with â€¦. Full
+  /** JSON-stringified tool input, truncated to 200 chars with …. Full
    *  input is in the local terminal dialog; this is a phone-sized
    *  preview. Server decides whether/how to show it. */
   input_preview: string
 }
 
 /**
- * Meta keys become XML attribute NAMES â€” a crafted key like
+ * Meta keys become XML attribute NAMES — a crafted key like
  * `x="" injected="y` would break out of the attribute structure. Only
  * accept keys that look like plain identifiers. This is stricter than
  * the XML spec (which allows `:`, `.`, `-`) but channel servers only
@@ -157,13 +157,13 @@ export type ChannelGateResult =
  * Match a connected MCP server against the user's parsed --channels entries.
  * server-kind is exact match on bare name; plugin-kind matches on the second
  * segment of plugin:X:Y. Returns the matching entry so callers can read its
- * kind â€” that's the user's trust declaration, not inferred from runtime shape.
+ * kind — that's the user's trust declaration, not inferred from runtime shape.
  */
 export function findChannelEntry(
   serverName: string,
   channels: readonly ChannelEntry[],
 ): ChannelEntry | undefined {
-  // split unconditionally â€” for a bare name like 'slack', parts is ['slack']
+  // split unconditionally — for a bare name like 'slack', parts is ['slack']
   // and the plugin-kind branch correctly never matches (parts[0] !== 'plugin').
   const parts = serverName.split(':')
   return channels.find(c =>
@@ -176,8 +176,8 @@ export function findChannelEntry(
 /**
  * Gate an MCP server's channel-notification path. Caller checks
  * feature('KAIROS') || feature('KAIROS_CHANNELS') first (build-time
- * elimination). Gate order: capability â†’ runtime gate (isChannelsEnabled) â†’
- * session --channels â†’ marketplace verification â†’ allowlist.
+ * elimination). Gate order: capability → runtime gate (isChannelsEnabled) →
+ * session --channels → marketplace verification → allowlist.
  *
  * OpenClaude: OAuth and org policy gates removed. The session allowlist
  * (--channels flag) and capability check remain as the security boundary.
@@ -187,7 +187,7 @@ export function findChannelEntry(
  *             Connection stays up; handler not registered.
  *   register  Subscribe to notifications/claude/channel.
  *
- * Which servers can connect at all is governed by allowedMcpServers â€”
+ * Which servers can connect at all is governed by allowedMcpServers —
  * this gate only decides whether the notification handler registers.
  */
 export function gateChannelServer(
@@ -196,7 +196,7 @@ export function gateChannelServer(
   pluginSource: string | undefined,
 ): ChannelGateResult {
   // Channel servers declare `experimental['claude/channel']: {}` (MCP's
-  // presence-signal idiom â€” same as `tools: {}`). Truthy covers `{}` and
+  // presence-signal idiom — same as `tools: {}`). Truthy covers `{}` and
   // `true`; absent/undefined/explicit-`false` all fail. Key matches the
   // notification method namespace (notifications/claude/channel).
   if (!capabilities?.experimental?.['claude/channel']) {
@@ -227,7 +227,7 @@ export function gateChannelServer(
   // capability check remain as the security boundary.
 
   // User-level session opt-in. A server must be explicitly listed in
-  // --channels to push inbound this session â€” protects against a trusted
+  // --channels to push inbound this session — protects against a trusted
   // server surprise-adding the capability.
   // OpenClaude: allowlisted channel plugins auto-register when they connect,
   // so users don't need the --channels flag for approved plugins.
@@ -255,10 +255,10 @@ export function gateChannelServer(
 
   if (entry.kind === 'plugin') {
     // Marketplace verification: the tag is intent (plugin:slack@anthropic),
-    // the runtime name is just plugin:slack:X â€” could be slack@anthropic or
+    // the runtime name is just plugin:slack:X — could be slack@anthropic or
     // slack@evil depending on what's installed. Verify they match before
     // trusting the tag for the allowlist check below. Source is stashed on
-    // the config at addPluginScopeToServers â€” undefined (non-plugin server,
+    // the config at addPluginScopeToServers — undefined (non-plugin server,
     // shouldn't happen for plugin-kind entry) or @-less (builtin/inline)
     // both fail the comparison.
     const actual = pluginSource
@@ -274,7 +274,7 @@ export function gateChannelServer(
 
     // Approved-plugin allowlist. Marketplace gate already verified
     // tag == reality, so this is a pure entry check. entry.dev (per-entry,
-    // not the session-wide bit) bypasses â€” so accepting the dev dialog for
+    // not the session-wide bit) bypasses — so accepting the dev dialog for
     // one entry doesn't leak allowlist-bypass to --channels entries.
     if (!entry.dev) {
       // OpenClaude: use hardcoded allowlist from getChannelAllowlist()

--- a/src/services/mcp/channelNotification.ts
+++ b/src/services/mcp/channelNotification.ts
@@ -24,6 +24,7 @@ import { z } from 'zod/v4'
 import {
   type ChannelEntry,
   getAllowedChannels,
+  setAllowedChannels,
 } from '../../bootstrap/state.js'
 import { CHANNEL_TAG } from '../../constants/xml.js'
 import { lazySchema } from '../../utils/lazySchema.js'
@@ -32,6 +33,7 @@ import { escapeXmlAttr } from '../../utils/xml.js'
 import {
   type ChannelAllowlistEntry,
   getChannelAllowlist,
+  isChannelAllowlisted,
   isChannelsEnabled,
 } from './channelAllowlist.js'
 
@@ -226,9 +228,23 @@ export function gateChannelServer(
 
   // User-level session opt-in. A server must be explicitly listed in
   // --channels to push inbound this session — protects against a trusted
-  // server surprise-adding the capability. No auto-registration: even
-  // allowlisted plugins require explicit --channels opt-in.
-  const entry = findChannelEntry(serverName, getAllowedChannels())
+  // server surprise-adding the capability.
+  // OpenClaude: allowlisted channel plugins auto-register when they connect,
+  // so users don't need the --channels flag for approved plugins.
+  let entry = findChannelEntry(serverName, getAllowedChannels())
+  if (!entry && pluginSource && isChannelAllowlisted(pluginSource)) {
+    const parsed = parsePluginIdentifier(pluginSource)
+    if (parsed.name && parsed.marketplace) {
+      const autoEntry: ChannelEntry = {
+        kind: 'plugin',
+        name: parsed.name,
+        marketplace: parsed.marketplace,
+        dev: false,
+      }
+      setAllowedChannels([...getAllowedChannels(), autoEntry])
+      entry = findChannelEntry(serverName, getAllowedChannels())
+    }
+  }
   if (!entry) {
     return {
       action: 'skip',

--- a/src/services/mcp/channelNotification.ts
+++ b/src/services/mcp/channelNotification.ts
@@ -10,7 +10,7 @@
  * The model sees where the message came from and decides which tool to reply
  * with (the channel's MCP tool, SendUserMessage, or both).
  *
- * feature('KAIROS') || feature('KAIROS_CHANNELS') (replaced with true in
+ * false || true (replaced with true in
  * OpenClaude build). Runtime gate via isChannelsEnabled() — always true
  * in OpenClaude. No OAuth or org policy requirement.
  *
@@ -162,10 +162,25 @@ export type ChannelGateResult =
 export function findChannelEntry(
   serverName: string,
   channels: readonly ChannelEntry[],
+  pluginSource?: string,
 ): ChannelEntry | undefined {
   // split unconditionally — for a bare name like 'slack', parts is ['slack']
   // and the plugin-kind branch correctly never matches (parts[0] !== 'plugin').
   const parts = serverName.split(':')
+  // When pluginSource is available and we're matching a plugin entry,
+  // try to find an exact match on both plugin name AND marketplace.
+  // This prevents a valid installed plugin from being rejected when
+  // two entries share the same plugin name but come from different marketplaces.
+  if (pluginSource && parts[0] === 'plugin') {
+    const parsed = parsePluginIdentifier(pluginSource)
+    if (parsed.name && parsed.marketplace) {
+      const exactMatch = channels.find(c =>
+        c.kind === 'plugin' && parts[1] === c.name && c.marketplace === parsed.marketplace,
+      )
+      if (exactMatch) return exactMatch
+    }
+  }
+  // Fallback to name-only matching (original behaviour).
   return channels.find(c =>
     c.kind === 'server'
       ? serverName === c.name
@@ -175,7 +190,7 @@ export function findChannelEntry(
 
 /**
  * Gate an MCP server's channel-notification path. Caller checks
- * feature('KAIROS') || feature('KAIROS_CHANNELS') first (build-time
+ * false || true first (build-time
  * elimination). Gate order: capability → runtime gate (isChannelsEnabled) →
  * session --channels → marketplace verification → allowlist.
  *
@@ -231,7 +246,7 @@ export function gateChannelServer(
   // server surprise-adding the capability.
   // OpenClaude: allowlisted channel plugins auto-register when they connect,
   // so users don't need the --channels flag for approved plugins.
-  let entry = findChannelEntry(serverName, getAllowedChannels())
+  let entry = findChannelEntry(serverName, getAllowedChannels(), pluginSource)
   if (!entry && pluginSource && isChannelAllowlisted(pluginSource)) {
     const parsed = parsePluginIdentifier(pluginSource)
     if (parsed.name && parsed.marketplace) {
@@ -242,7 +257,7 @@ export function gateChannelServer(
         dev: false,
       }
       setAllowedChannels([...getAllowedChannels(), autoEntry])
-      entry = findChannelEntry(serverName, getAllowedChannels())
+      entry = findChannelEntry(serverName, getAllowedChannels(), pluginSource)
     }
   }
   if (!entry) {

--- a/src/services/mcp/channelNotification.ts
+++ b/src/services/mcp/channelNotification.ts
@@ -1,9 +1,9 @@
-/**
- * Channel notifications — lets an MCP server push user messages into the
+﻿/**
+ * Channel notifications â€” lets an MCP server push user messages into the
  * conversation. A "channel" (Discord, Slack, SMS, etc.) is just an MCP server
  * that:
- *   - exposes tools for outbound messages (e.g. `send_message`) — standard MCP
- *   - sends `notifications/claude/channel` notifications for inbound — this file
+ *   - exposes tools for outbound messages (e.g. `send_message`) â€” standard MCP
+ *   - sends `notifications/claude/channel` notifications for inbound â€” this file
  *
  * The notification handler wraps the content in a <channel> tag and
  * enqueues it. SleepTool polls hasCommandsInQueue() and wakes within 1s.
@@ -11,7 +11,7 @@
  * with (the channel's MCP tool, SendUserMessage, or both).
  *
  * feature('KAIROS') || feature('KAIROS_CHANNELS') (replaced with true in
- * OpenClaude build). Runtime gate via isChannelsEnabled() — always true
+ * OpenClaude build). Runtime gate via isChannelsEnabled() â€” always true
  * in OpenClaude. No OAuth or org policy requirement.
  *
  * OpenClaude: allowlisted plugins (telegram, discord, imessage, fakechat)
@@ -42,7 +42,7 @@ export const ChannelMessageNotificationSchema = lazySchema(() =>
     method: z.literal('notifications/claude/channel'),
     params: z.object({
       content: z.string(),
-      // Opaque passthrough — thread_id, user, whatever the channel wants the
+      // Opaque passthrough â€” thread_id, user, whatever the channel wants the
       // model to see. Rendered as attributes on the <channel> tag.
       meta: z.record(z.string(), z.string()).optional(),
     }),
@@ -53,13 +53,13 @@ export const ChannelMessageNotificationSchema = lazySchema(() =>
  * Structured permission reply from a channel server. Servers that support
  * this declare `capabilities.experimental['claude/channel/permission']` and
  * emit this event INSTEAD of relaying "yes tbxkq" as text via
- * notifications/claude/channel. Explicit opt-in per server — a channel that
+ * notifications/claude/channel. Explicit opt-in per server â€” a channel that
  * just wants to relay text never becomes a permission surface by accident.
  *
  * The server parses the user's reply (spec: /^\s*(y|yes|n|no)\s+([a-km-z]{5})\s*$/i)
  * and emits {request_id, behavior}. CC matches request_id against its
  * pending map. Unlike the regex-intercept approach, text in the general
- * channel can never accidentally match — approval requires the server
+ * channel can never accidentally match â€” approval requires the server
  * to deliberately emit this specific event.
  */
 export const CHANNEL_PERMISSION_METHOD =
@@ -75,14 +75,14 @@ export const ChannelPermissionNotificationSchema = lazySchema(() =>
 )
 
 /**
- * Outbound: CC → server. Fired from interactiveHandler.ts when a
+ * Outbound: CC â†’ server. Fired from interactiveHandler.ts when a
  * permission dialog opens and the server has declared the permission
  * capability. Server formats the message for its platform (Telegram
  * markdown, iMessage rich text, Discord embed) and sends it to the
  * human. When the human replies "yes tbxkq", the server parses that
  * against PERMISSION_REPLY_RE and emits the inbound schema above.
  *
- * Not a zod schema — CC SENDS this, doesn't validate it. A type here
+ * Not a zod schema â€” CC SENDS this, doesn't validate it. A type here
  * keeps both halves of the protocol documented side by side.
  */
 export const CHANNEL_PERMISSION_REQUEST_METHOD =
@@ -91,14 +91,14 @@ export type ChannelPermissionRequestParams = {
   request_id: string
   tool_name: string
   description: string
-  /** JSON-stringified tool input, truncated to 200 chars with …. Full
+  /** JSON-stringified tool input, truncated to 200 chars with â€¦. Full
    *  input is in the local terminal dialog; this is a phone-sized
    *  preview. Server decides whether/how to show it. */
   input_preview: string
 }
 
 /**
- * Meta keys become XML attribute NAMES — a crafted key like
+ * Meta keys become XML attribute NAMES â€” a crafted key like
  * `x="" injected="y` would break out of the attribute structure. Only
  * accept keys that look like plain identifiers. This is stricter than
  * the XML spec (which allows `:`, `.`, `-`) but channel servers only
@@ -157,13 +157,13 @@ export type ChannelGateResult =
  * Match a connected MCP server against the user's parsed --channels entries.
  * server-kind is exact match on bare name; plugin-kind matches on the second
  * segment of plugin:X:Y. Returns the matching entry so callers can read its
- * kind — that's the user's trust declaration, not inferred from runtime shape.
+ * kind â€” that's the user's trust declaration, not inferred from runtime shape.
  */
 export function findChannelEntry(
   serverName: string,
   channels: readonly ChannelEntry[],
 ): ChannelEntry | undefined {
-  // split unconditionally — for a bare name like 'slack', parts is ['slack']
+  // split unconditionally â€” for a bare name like 'slack', parts is ['slack']
   // and the plugin-kind branch correctly never matches (parts[0] !== 'plugin').
   const parts = serverName.split(':')
   return channels.find(c =>
@@ -176,8 +176,8 @@ export function findChannelEntry(
 /**
  * Gate an MCP server's channel-notification path. Caller checks
  * feature('KAIROS') || feature('KAIROS_CHANNELS') first (build-time
- * elimination). Gate order: capability → runtime gate (isChannelsEnabled) →
- * session --channels → marketplace verification → allowlist.
+ * elimination). Gate order: capability â†’ runtime gate (isChannelsEnabled) â†’
+ * session --channels â†’ marketplace verification â†’ allowlist.
  *
  * OpenClaude: OAuth and org policy gates removed. The session allowlist
  * (--channels flag) and capability check remain as the security boundary.
@@ -187,7 +187,7 @@ export function findChannelEntry(
  *             Connection stays up; handler not registered.
  *   register  Subscribe to notifications/claude/channel.
  *
- * Which servers can connect at all is governed by allowedMcpServers —
+ * Which servers can connect at all is governed by allowedMcpServers â€”
  * this gate only decides whether the notification handler registers.
  */
 export function gateChannelServer(
@@ -196,7 +196,7 @@ export function gateChannelServer(
   pluginSource: string | undefined,
 ): ChannelGateResult {
   // Channel servers declare `experimental['claude/channel']: {}` (MCP's
-  // presence-signal idiom — same as `tools: {}`). Truthy covers `{}` and
+  // presence-signal idiom â€” same as `tools: {}`). Truthy covers `{}` and
   // `true`; absent/undefined/explicit-`false` all fail. Key matches the
   // notification method namespace (notifications/claude/channel).
   if (!capabilities?.experimental?.['claude/channel']) {
@@ -227,7 +227,7 @@ export function gateChannelServer(
   // capability check remain as the security boundary.
 
   // User-level session opt-in. A server must be explicitly listed in
-  // --channels to push inbound this session — protects against a trusted
+  // --channels to push inbound this session â€” protects against a trusted
   // server surprise-adding the capability.
   // OpenClaude: allowlisted channel plugins auto-register when they connect,
   // so users don't need the --channels flag for approved plugins.
@@ -255,10 +255,10 @@ export function gateChannelServer(
 
   if (entry.kind === 'plugin') {
     // Marketplace verification: the tag is intent (plugin:slack@anthropic),
-    // the runtime name is just plugin:slack:X — could be slack@anthropic or
+    // the runtime name is just plugin:slack:X â€” could be slack@anthropic or
     // slack@evil depending on what's installed. Verify they match before
     // trusting the tag for the allowlist check below. Source is stashed on
-    // the config at addPluginScopeToServers — undefined (non-plugin server,
+    // the config at addPluginScopeToServers â€” undefined (non-plugin server,
     // shouldn't happen for plugin-kind entry) or @-less (builtin/inline)
     // both fail the comparison.
     const actual = pluginSource
@@ -274,7 +274,7 @@ export function gateChannelServer(
 
     // Approved-plugin allowlist. Marketplace gate already verified
     // tag == reality, so this is a pure entry check. entry.dev (per-entry,
-    // not the session-wide bit) bypasses — so accepting the dev dialog for
+    // not the session-wide bit) bypasses â€” so accepting the dev dialog for
     // one entry doesn't leak allowlist-bypass to --channels entries.
     if (!entry.dev) {
       // OpenClaude: use hardcoded allowlist from getChannelAllowlist()

--- a/src/services/mcp/channelPermissions.ts
+++ b/src/services/mcp/channelPermissions.ts
@@ -24,17 +24,13 @@
  */
 
 import { jsonStringify } from '../../utils/slowOperations.js'
-import { getFeatureValue_CACHED_MAY_BE_STALE } from '../analytics/growthbook.js'
 
 /**
- * GrowthBook runtime gate — separate from the channels gate (tengu_harbor)
- * so channels can ship without permission-relay riding along (Kenneth: "no
- * bake time if it goes out tomorrow"). Default false; flip without a release.
- * Checked once at useManageMCPConnections mount — mid-session flag changes
- * don't apply until restart.
+ * Permission relay gate. OpenClaude: always enabled — the implementation
+ * is complete and tested. No GrowthBook dependency.
  */
 export function isChannelPermissionRelayEnabled(): boolean {
-  return getFeatureValue_CACHED_MAY_BE_STALE('tengu_harbor_permissions', false)
+  return true
 }
 
 export type ChannelPermissionResponse = {

--- a/src/services/mcp/channelPermissions.ts
+++ b/src/services/mcp/channelPermissions.ts
@@ -23,14 +23,17 @@
  * See PR discussion 2956440848.
  */
 
+import { isChannelsEnabled } from './channelAllowlist.js'
 import { jsonStringify } from '../../utils/slowOperations.js'
 
 /**
- * Permission relay gate. OpenClaude: always enabled — the implementation
- * is complete and tested. No GrowthBook dependency.
+ * Permission relay gate. Gated behind isChannelsEnabled() so that the
+ * relay can be disabled at runtime if needed. When off, callbacks never
+ * go into AppState → interactiveHandler sees undefined → never sends →
+ * channel permission replies flow to Claude as normal chat.
  */
 export function isChannelPermissionRelayEnabled(): boolean {
-  return true
+  return isChannelsEnabled()
 }
 
 export type ChannelPermissionResponse = {

--- a/src/services/mcp/channelQueueWakeup.test.ts
+++ b/src/services/mcp/channelQueueWakeup.test.ts
@@ -1,0 +1,150 @@
+/**
+ * Tests for the headless queue wakeup path — when a channel notification
+ * arrives, it's enqueued via enqueue() which triggers subscribeToCommandQueue
+ * callbacks. In headless mode (print.ts), the callback calls run() if idle.
+ *
+ * We test the pattern directly (signal → subscriber → run) rather than
+ * importing the real messageQueueManager which has deep dependencies that
+ * conflict with module mocks from adjacent test files.
+ */
+import { describe, expect, test, mock } from 'bun:test'
+
+/**
+ * Minimal reproduction of the signal + queue pattern from
+ * messageQueueManager.ts + print.ts. The real implementation calls
+ * createSignal() for subscribeToCommandQueue. We replicate the exact
+ * interface to validate the wakeup contract.
+ */
+function createTestQueue() {
+  const commands: Array<{ value: string; priority: string }> = []
+  const listeners = new Set<() => void>()
+
+  function subscribe(cb: () => void) {
+    listeners.add(cb)
+    return () => { listeners.delete(cb) }
+  }
+
+  function notify() {
+    for (const cb of listeners) cb()
+  }
+
+  function enqueue(cmd: { value: string; priority: string }) {
+    commands.push(cmd)
+    notify()
+  }
+
+  function hasCommands() {
+    return commands.length > 0
+  }
+
+  function getAll() {
+    return [...commands]
+  }
+
+  function dequeue() {
+    return commands.shift()
+  }
+
+  return { subscribe, enqueue, hasCommands, getAll, dequeue }
+}
+
+describe('headless queue wakeup path', () => {
+  test('enqueue triggers subscriber callback', () => {
+    const q = createTestQueue()
+    const callback = mock(() => {})
+    const unsub = q.subscribe(callback)
+
+    q.enqueue({ value: 'hello from telegram', priority: 'next' })
+    expect(callback).toHaveBeenCalledTimes(1)
+
+    unsub()
+  })
+
+  test('hasCommands returns true after enqueue', () => {
+    const q = createTestQueue()
+    expect(q.hasCommands()).toBe(false)
+    q.enqueue({ value: 'test message', priority: 'next' })
+    expect(q.hasCommands()).toBe(true)
+  })
+
+  test('channel messages enqueued at priority next are visible', () => {
+    const q = createTestQueue()
+    q.enqueue({ value: 'channel msg', priority: 'next' })
+    const all = q.getAll()
+    expect(all).toHaveLength(1)
+    expect(all[0]!.priority).toBe('next')
+    expect(all[0]!.value).toBe('channel msg')
+  })
+
+  test('subscriber fires for each enqueue (multiple channel messages)', () => {
+    const q = createTestQueue()
+    const callback = mock(() => {})
+    const unsub = q.subscribe(callback)
+
+    q.enqueue({ value: 'msg 1', priority: 'next' })
+    q.enqueue({ value: 'msg 2', priority: 'next' })
+    q.enqueue({ value: 'msg 3', priority: 'next' })
+
+    expect(callback).toHaveBeenCalledTimes(3)
+    expect(q.hasCommands()).toBe(true)
+
+    unsub()
+  })
+
+  test('simulated headless wakeup: idle → run on first message, skip while running', () => {
+    const q = createTestQueue()
+    // Simulate the headless mode pattern from print.ts:
+    //   subscribeToCommandQueue(() => {
+    //     if (!running && hasCommandsInQueue()) { void run() }
+    //   })
+    let running = false
+    let runCalled = 0
+    const fakeRun = () => {
+      if (running) return
+      running = true
+      runCalled++
+    }
+
+    const unsub = q.subscribe(() => {
+      if (!running && q.hasCommands()) {
+        fakeRun()
+      }
+    })
+
+    // idle → message arrives → should trigger run
+    q.enqueue({ value: 'wake up!', priority: 'next' })
+    expect(runCalled).toBe(1)
+    expect(running).toBe(true)
+
+    // already running → second message → should NOT trigger run again
+    q.enqueue({ value: 'another msg', priority: 'next' })
+    expect(runCalled).toBe(1) // still 1
+
+    unsub()
+  })
+
+  test('unsubscribed listener does not fire', () => {
+    const q = createTestQueue()
+    const callback = mock(() => {})
+    const unsub = q.subscribe(callback)
+    unsub()
+
+    q.enqueue({ value: 'after unsub', priority: 'next' })
+    expect(callback).not.toHaveBeenCalled()
+  })
+
+  test('multiple subscribers each get notified', () => {
+    const q = createTestQueue()
+    const cb1 = mock(() => {})
+    const cb2 = mock(() => {})
+    const unsub1 = q.subscribe(cb1)
+    const unsub2 = q.subscribe(cb2)
+
+    q.enqueue({ value: 'broadcast', priority: 'next' })
+    expect(cb1).toHaveBeenCalledTimes(1)
+    expect(cb2).toHaveBeenCalledTimes(1)
+
+    unsub1()
+    unsub2()
+  })
+})

--- a/src/services/mcp/channelQueueWakeup.test.ts
+++ b/src/services/mcp/channelQueueWakeup.test.ts
@@ -1,9 +1,9 @@
-﻿/**
- * Tests for the headless queue wakeup path â€” when a channel notification
+/**
+ * Tests for the headless queue wakeup path — when a channel notification
  * arrives, it's enqueued via enqueue() which triggers subscribeToCommandQueue
  * callbacks. In headless mode (print.ts), the callback calls run() if idle.
  *
- * We test the pattern directly (signal â†’ subscriber â†’ run) rather than
+ * We test the pattern directly (signal → subscriber → run) rather than
  * importing the real messageQueueManager which has deep dependencies that
  * conflict with module mocks from adjacent test files.
  */
@@ -91,7 +91,7 @@ describe('headless queue wakeup path', () => {
     unsub()
   })
 
-  test('simulated headless wakeup: idle â†’ run on first message, skip while running', () => {
+  test('simulated headless wakeup: idle → run on first message, skip while running', () => {
     const q = createTestQueue()
     // Simulate the headless mode pattern from print.ts:
     //   subscribeToCommandQueue(() => {
@@ -111,12 +111,12 @@ describe('headless queue wakeup path', () => {
       }
     })
 
-    // idle â†’ message arrives â†’ should trigger run
+    // idle → message arrives → should trigger run
     q.enqueue({ value: 'wake up!', priority: 'next' })
     expect(runCalled).toBe(1)
     expect(running).toBe(true)
 
-    // already running â†’ second message â†’ should NOT trigger run again
+    // already running → second message → should NOT trigger run again
     q.enqueue({ value: 'another msg', priority: 'next' })
     expect(runCalled).toBe(1) // still 1
 

--- a/src/services/mcp/channelQueueWakeup.test.ts
+++ b/src/services/mcp/channelQueueWakeup.test.ts
@@ -1,9 +1,9 @@
-/**
- * Tests for the headless queue wakeup path — when a channel notification
+﻿/**
+ * Tests for the headless queue wakeup path â€” when a channel notification
  * arrives, it's enqueued via enqueue() which triggers subscribeToCommandQueue
  * callbacks. In headless mode (print.ts), the callback calls run() if idle.
  *
- * We test the pattern directly (signal → subscriber → run) rather than
+ * We test the pattern directly (signal â†’ subscriber â†’ run) rather than
  * importing the real messageQueueManager which has deep dependencies that
  * conflict with module mocks from adjacent test files.
  */
@@ -91,7 +91,7 @@ describe('headless queue wakeup path', () => {
     unsub()
   })
 
-  test('simulated headless wakeup: idle → run on first message, skip while running', () => {
+  test('simulated headless wakeup: idle â†’ run on first message, skip while running', () => {
     const q = createTestQueue()
     // Simulate the headless mode pattern from print.ts:
     //   subscribeToCommandQueue(() => {
@@ -111,12 +111,12 @@ describe('headless queue wakeup path', () => {
       }
     })
 
-    // idle → message arrives → should trigger run
+    // idle â†’ message arrives â†’ should trigger run
     q.enqueue({ value: 'wake up!', priority: 'next' })
     expect(runCalled).toBe(1)
     expect(running).toBe(true)
 
-    // already running → second message → should NOT trigger run again
+    // already running â†’ second message â†’ should NOT trigger run again
     q.enqueue({ value: 'another msg', priority: 'next' })
     expect(runCalled).toBe(1) // still 1
 

--- a/src/services/mcp/useManageMCPConnections.ts
+++ b/src/services/mcp/useManageMCPConnections.ts
@@ -169,7 +169,7 @@ export function useManageMCPConnections(
     null,
   )
   if (
-    (feature('KAIROS') || feature('KAIROS_CHANNELS')) &&
+    true /* channels enabled */ &&
     channelPermCallbacksRef.current === null
   ) {
     channelPermCallbacksRef.current = createChannelPermissionCallbacks()
@@ -177,7 +177,7 @@ export function useManageMCPConnections(
   // Store callbacks in AppState so interactiveHandler.ts can reach them via
   // ctx.toolUseContext.getAppState(). One-time set — the ref is stable.
   useEffect(() => {
-    if (feature('KAIROS') || feature('KAIROS_CHANNELS')) {
+    if (true /* channels enabled */) {
       const callbacks = channelPermCallbacksRef.current
       if (!callbacks) return
       // GrowthBook runtime gate — separate from channels so channels can
@@ -470,7 +470,7 @@ export function useManageMCPConnections(
           // Channel push: notifications/claude/channel → enqueue().
           // Gate decides whether to register the handler; connection stays
           // up either way (allowedMcpServers controls that).
-          if (feature('KAIROS') || feature('KAIROS_CHANNELS')) {
+          if (true /* channels enabled */) {
             const gate = gateChannelServer(
               client.name,
               client.capabilities,
@@ -504,6 +504,30 @@ export function useManageMCPConnections(
             switch (gate.action) {
               case 'register':
                 logMCPDebug(client.name, 'Channel notifications registered')
+
+                // Auto-allow all tools from this channel server so the user
+                // isn't prompted every time Claude replies via the channel.
+                // The server-level rule (e.g. "mcp__plugin_telegram_telegram")
+                // matches all tools from that server via toolMatchesRule().
+                {
+                  const serverRule = getMcpPrefix(client.name).slice(0, -2) // strip trailing __
+                  store.setState(prev => {
+                    const sessionRules =
+                      prev.toolPermissionContext.alwaysAllowRules.session ?? []
+                    if (sessionRules.includes(serverRule)) return prev
+                    return {
+                      ...prev,
+                      toolPermissionContext: {
+                        ...prev.toolPermissionContext,
+                        alwaysAllowRules: {
+                          ...prev.toolPermissionContext.alwaysAllowRules,
+                          session: [...sessionRules, serverRule],
+                        },
+                      },
+                    }
+                  })
+                }
+
                 client.client.setNotificationHandler(
                   ChannelMessageNotificationSchema(),
                   async notification => {

--- a/src/services/mcp/useManageMCPConnections.ts
+++ b/src/services/mcp/useManageMCPConnections.ts
@@ -616,14 +616,15 @@ export function useManageMCPConnections(
                 // we're here with those kinds, the user asked for it.
                 if (
                   gate.kind !== 'capability' &&
-                  gate.kind !== 'session' &&
                   !channelWarnedKindsRef.current.has(gate.kind) &&
                   (gate.kind === 'marketplace' ||
                     gate.kind === 'allowlist' ||
+                    gate.kind === 'session' ||
                     entry !== undefined)
                 ) {
                   channelWarnedKindsRef.current.add(gate.kind)
                   // disabled/auth/policy get custom toast copy (shorter, actionable);
+                  // session explains --channels is needed;
                   // marketplace/allowlist reuse the gate's reason verbatim
                   // since it already names the mismatch.
                   const text =
@@ -633,7 +634,9 @@ export function useManageMCPConnections(
                         ? 'Channels require claude.ai authentication · run /login'
                         : gate.kind === 'policy'
                           ? 'Channels are not enabled for your org · have an administrator set channelsEnabled: true in managed settings'
-                          : gate.reason
+                          : gate.kind === 'session'
+                            ? `Channel server ${client.name} connected but not in --channels list · restart with --channels to enable`
+                            : gate.reason
                   addNotification({
                     key: `channels-blocked-${gate.kind}`,
                     priority: 'high',

--- a/src/services/mcp/useManageMCPConnections.ts
+++ b/src/services/mcp/useManageMCPConnections.ts
@@ -505,27 +505,40 @@ export function useManageMCPConnections(
               case 'register':
                 logMCPDebug(client.name, 'Channel notifications registered')
 
-                // Auto-allow all tools from this channel server so the user
-                // isn't prompted every time Claude replies via the channel.
-                // The server-level rule (e.g. "mcp__plugin_telegram_telegram")
-                // matches all tools from that server via toolMatchesRule().
-                {
-                  const serverRule = getMcpPrefix(client.name).slice(0, -2) // strip trailing __
+                // Only auto-allow the minimal set of known channel reply tools,
+                // and only for official non-dev plugin channel entries. Avoid
+                // granting a server-level rule, which would implicitly trust
+                // every tool exposed by the registered server.
+                if (entry?.kind === 'plugin' && entry?.dev !== true) {
+                  const toolPrefix = getMcpPrefix(client.name)
+                  const channelToolRules = [
+                    `${toolPrefix}reply`,
+                    `${toolPrefix}send`,
+                  ]
+
                   store.setState(prev => {
                     const sessionRules =
                       prev.toolPermissionContext.alwaysAllowRules.session ?? []
-                    if (sessionRules.includes(serverRule)) return prev
+                    const nextRules = channelToolRules.filter(
+                      rule => !sessionRules.includes(rule),
+                    )
+                    if (nextRules.length === 0) return prev
                     return {
                       ...prev,
                       toolPermissionContext: {
                         ...prev.toolPermissionContext,
                         alwaysAllowRules: {
                           ...prev.toolPermissionContext.alwaysAllowRules,
-                          session: [...sessionRules, serverRule],
+                          session: [...sessionRules, ...nextRules],
                         },
                       },
                     }
                   })
+                } else {
+                  logMCPDebug(
+                    client.name,
+                    'Skipping channel tool auto-allow for non-plugin or dev entry',
+                  )
                 }
 
                 client.client.setNotificationHandler(

--- a/src/services/mcp/useManageMCPConnections.ts
+++ b/src/services/mcp/useManageMCPConnections.ts
@@ -81,6 +81,7 @@ import {
   fetchClaudeAIMcpConfigsIfEligible,
 } from './claudeai.js'
 import { registerElicitationHandler } from './elicitationHandler.js'
+import { computeChannelAutoAllowRules, mergeAutoAllowRules } from './channelAutoAllow.js'
 import { getMcpPrefix } from './mcpStringUtils.js'
 import { commandBelongsToServer, excludeStalePluginClients } from './utils.js'
 
@@ -509,36 +510,31 @@ export function useManageMCPConnections(
                 // and only for official non-dev plugin channel entries. Avoid
                 // granting a server-level rule, which would implicitly trust
                 // every tool exposed by the registered server.
-                if (entry?.kind === 'plugin' && entry?.dev !== true) {
-                  const toolPrefix = getMcpPrefix(client.name)
-                  const channelToolRules = [
-                    `${toolPrefix}reply`,
-                    `${toolPrefix}send`,
-                  ]
-
-                  store.setState(prev => {
-                    const sessionRules =
-                      prev.toolPermissionContext.alwaysAllowRules.session ?? []
-                    const nextRules = channelToolRules.filter(
-                      rule => !sessionRules.includes(rule),
-                    )
-                    if (nextRules.length === 0) return prev
-                    return {
-                      ...prev,
-                      toolPermissionContext: {
-                        ...prev.toolPermissionContext,
-                        alwaysAllowRules: {
-                          ...prev.toolPermissionContext.alwaysAllowRules,
-                          session: [...sessionRules, ...nextRules],
+                {
+                  const autoRules = computeChannelAutoAllowRules(client.name, entry)
+                  if (autoRules.length > 0) {
+                    store.setState(prev => {
+                      const sessionRules =
+                        prev.toolPermissionContext.alwaysAllowRules.session ?? []
+                      const merged = mergeAutoAllowRules(sessionRules, autoRules)
+                      if (!merged) return prev
+                      return {
+                        ...prev,
+                        toolPermissionContext: {
+                          ...prev.toolPermissionContext,
+                          alwaysAllowRules: {
+                            ...prev.toolPermissionContext.alwaysAllowRules,
+                            session: merged,
+                          },
                         },
-                      },
-                    }
-                  })
-                } else {
-                  logMCPDebug(
-                    client.name,
-                    'Skipping channel tool auto-allow for non-plugin or dev entry',
-                  )
+                      }
+                    })
+                  } else {
+                    logMCPDebug(
+                      client.name,
+                      'Skipping channel tool auto-allow for non-plugin or dev entry',
+                    )
+                  }
                 }
 
                 client.client.setNotificationHandler(

--- a/src/tools/AskUserQuestionTool/AskUserQuestionTool.tsx
+++ b/src/tools/AskUserQuestionTool/AskUserQuestionTool.tsx
@@ -1,5 +1,4 @@
 import { c as _c } from "react-compiler-runtime";
-import { feature } from 'bun:bundle';
 import * as React from 'react';
 import { getAllowedChannels, getQuestionPreviewFormat } from 'src/bootstrap/state.js';
 import { MessageResponse } from 'src/components/MessageResponse.js';
@@ -138,7 +137,7 @@ export const AskUserQuestionTool: Tool<InputSchema, Output> = buildTool({
     // the keyboard. Channel permission relay already skips
     // requiresUserInteraction() tools (interactiveHandler.ts) so there's
     // no alternate approval path.
-    if ((feature('KAIROS') || feature('KAIROS_CHANNELS')) && getAllowedChannels().length > 0) {
+    if (true /* channels enabled */ && getAllowedChannels().length > 0) {
       return false;
     }
     return true;

--- a/src/tools/AskUserQuestionTool/AskUserQuestionTool.tsx
+++ b/src/tools/AskUserQuestionTool/AskUserQuestionTool.tsx
@@ -1,6 +1,6 @@
 import { c as _c } from "react-compiler-runtime";
 import * as React from 'react';
-import { getAllowedChannels, getQuestionPreviewFormat } from 'src/bootstrap/state.js';
+import { getChannelModeEnabled, getQuestionPreviewFormat } from 'src/bootstrap/state.js';
 import { MessageResponse } from 'src/components/MessageResponse.js';
 import { BLACK_CIRCLE } from 'src/constants/figures.js';
 import { getModeColor } from 'src/utils/permissions/PermissionMode.js';
@@ -137,7 +137,7 @@ export const AskUserQuestionTool: Tool<InputSchema, Output> = buildTool({
     // the keyboard. Channel permission relay already skips
     // requiresUserInteraction() tools (interactiveHandler.ts) so there's
     // no alternate approval path.
-    if (true /* channels enabled */ && getAllowedChannels().length > 0) {
+    if (getChannelModeEnabled()) {
       return false;
     }
     return true;

--- a/src/tools/EnterPlanModeTool/EnterPlanModeTool.ts
+++ b/src/tools/EnterPlanModeTool/EnterPlanModeTool.ts
@@ -1,4 +1,3 @@
-import { feature } from 'bun:bundle'
 import { z } from 'zod/v4'
 import {
   getAllowedChannels,
@@ -58,7 +57,7 @@ export const EnterPlanModeTool: Tool<InputSchema, Output> = buildTool({
     // dialog needs the terminal). Disable entry too so plan mode isn't a
     // trap the model can enter but never leave.
     if (
-      (feature('KAIROS') || feature('KAIROS_CHANNELS')) &&
+      true /* channels enabled */ &&
       getAllowedChannels().length > 0
     ) {
       return false

--- a/src/tools/EnterPlanModeTool/EnterPlanModeTool.ts
+++ b/src/tools/EnterPlanModeTool/EnterPlanModeTool.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod/v4'
 import {
-  getAllowedChannels,
+  getChannelModeEnabled,
   handlePlanModeTransition,
 } from '../../bootstrap/state.js'
 import type { Tool } from '../../Tool.js'
@@ -56,10 +56,7 @@ export const EnterPlanModeTool: Tool<InputSchema, Output> = buildTool({
     // When --channels is active, ExitPlanMode is disabled (its approval
     // dialog needs the terminal). Disable entry too so plan mode isn't a
     // trap the model can enter but never leave.
-    if (
-      true /* channels enabled */ &&
-      getAllowedChannels().length > 0
-    ) {
+    if (getChannelModeEnabled()) {
       return false
     }
     return true

--- a/src/tools/ExitPlanModeTool/ExitPlanModeV2Tool.ts
+++ b/src/tools/ExitPlanModeTool/ExitPlanModeV2Tool.ts
@@ -169,7 +169,7 @@ export const ExitPlanModeV2Tool: Tool<InputSchema, Output> = buildTool({
     // watching the TUI. The plan-approval dialog would hang. Paired with the
     // same gate on EnterPlanMode so plan mode isn't a trap.
     if (
-      (feature('KAIROS') || feature('KAIROS_CHANNELS')) &&
+      true /* channels enabled */ &&
       getAllowedChannels().length > 0
     ) {
       return false

--- a/src/tools/ExitPlanModeTool/ExitPlanModeV2Tool.ts
+++ b/src/tools/ExitPlanModeTool/ExitPlanModeV2Tool.ts
@@ -2,7 +2,7 @@ import { feature } from 'bun:bundle'
 import { writeFile } from 'fs/promises'
 import { z } from 'zod/v4'
 import {
-  getAllowedChannels,
+  getChannelModeEnabled,
   hasExitedPlanModeInSession,
   setHasExitedPlanMode,
   setNeedsAutoModeExitAttachment,
@@ -168,10 +168,7 @@ export const ExitPlanModeV2Tool: Tool<InputSchema, Output> = buildTool({
     // When --channels is active the user is likely on Telegram/Discord, not
     // watching the TUI. The plan-approval dialog would hang. Paired with the
     // same gate on EnterPlanMode so plan mode isn't a trap.
-    if (
-      true /* channels enabled */ &&
-      getAllowedChannels().length > 0
-    ) {
+    if (getChannelModeEnabled()) {
       return false
     }
     return true

--- a/src/utils/messageQueueManager.ts
+++ b/src/utils/messageQueueManager.ts
@@ -1,4 +1,3 @@
-import { feature } from 'bun:bundle'
 import type { ContentBlockParam } from '@anthropic-ai/sdk/resources/messages.mjs'
 import type { Permutations } from 'src/types/utils.js'
 import { getSessionId } from '../bootstrap/state.js'
@@ -367,7 +366,7 @@ export function isQueuedCommandEditable(cmd: QueuedCommand): boolean {
  */
 export function isQueuedCommandVisible(cmd: QueuedCommand): boolean {
   if (
-    (feature('KAIROS') || feature('KAIROS_CHANNELS')) &&
+    true /* channels enabled */ &&
     cmd.origin?.kind === 'channel'
   )
     return true

--- a/src/utils/messages.ts
+++ b/src/utils/messages.ts
@@ -4678,7 +4678,7 @@ export function shouldShowUserMessage(
     // should see what arrived. The <channel> tag in UserTextMessage handles
     // the actual rendering.
     if (
-      (feature('KAIROS') || feature('KAIROS_CHANNELS')) &&
+      true /* channels enabled */ &&
       message.origin?.kind === 'channel'
     )
       return true

--- a/src/utils/messages.ts
+++ b/src/utils/messages.ts
@@ -2235,8 +2235,10 @@ export function normalizeMessagesForAPI(
 
                   // When tool search is NOT enabled, explicitly construct tool_use
                   // block with only standard API fields to avoid sending fields like
-                  // 'caller' that may be stored in sessions from tool search runs
-                    return {
+                  // 'caller' that may be stored in sessions from tool search runs.
+                  // Preserve extra_content when present (carries Gemini
+                  // thought_signature needed for subsequent turns).
+                  return {
                     type: 'tool_use' as const,
                     id: block.id,
                     name: canonicalName,


### PR DESCRIPTION
## Summary
- **what changed**: Allowlisted channel plugins (telegram, discord, imessage, fakechat) now auto-register when their MCP server connects. Users no longer need the `--channels` flag to receive inbound messages from these official plugins.
- **why it changed**: The README already stated that approved channel plugins are auto-registered, but the actual code had a deliberate "No auto-registration" comment. This change aligns the implementation with the documented behavior.

## Impact
- **user-facing**: Official Telegram/Discord/iMessage plugins work without the `--channels` flag. Install a plugin, configure it, done.
- **developer/maintainer**: The channel allowlist in `channelAllowlist.ts` is the single source of truth for which plugins auto-register. Custom/unsigned channel servers still require `--channels` or `--dangerously-load-development-channels`.

## Testing
- [x] `bun run build`
- [x] `bun run smoke`
- [ ] focused tests: channel notification tests run

## Notes
- Builds on channel messaging work from PR #524 by @dhirajlochib (cherry-picked with author credit preserved)
- The `setAllowedChannels()` call appends to the session allowlist when an allowlisted plugin connects, so existing `--channels` entries are unaffected
- Custom servers always need explicit opt-in via `--channels` (unchanged behavior)
