### PR TITLE
fix(openai): add GPT-5.5 Responses API compatibility support

### DIFF
--- a/src/services/api/providerConfig.ts
+++ b/src/services/api/providerConfig.ts
@@ -622,6 +622,10 @@ export function resolveProviderRequest(options?: {
       ? undefined
       : parseOpenAICompatibleApiFormat(options?.apiFormat) ??
         parseOpenAICompatibleApiFormat(process.env.OPENAI_API_FORMAT)
+  const normalizedBaseModel = descriptor.baseModel.trim().toLowerCase()
+  const shouldForceResponsesApi =
+    normalizedBaseModel === 'gpt-5.5' ||
+    normalizedBaseModel === 'gpt-5.5-mini'
   const supportsRequestedApiFormat =
     requestedApiFormat !== 'responses' ||
     (() => {
@@ -642,7 +646,7 @@ export function resolveProviderRequest(options?: {
     shouldUseCodexTransport(requestedModel, finalBaseUrl) ||
       (isGithubCopilot && shouldUseGithubResponsesApi(githubResolvedModel))
       ? 'codex_responses'
-      : requestedApiFormat === 'responses' && supportsRequestedApiFormat
+      : (requestedApiFormat === 'responses' || shouldForceResponsesApi) && supportsRequestedApiFormat
         ? 'responses'
         : 'chat_completions'
 


### PR DESCRIPTION
This PR ports the minimal OpenAI Responses API compatibility logic from #906 onto the current latest main branch to fix GPT-5.5 reasoning/tool-call failures.

Fixes GPT-5.5 tool/function calling compatibility with OpenAI APIs.

Problem:
GPT-5.5 requests using reasoning/tool workflows fail with:

  Function tools with reasoning_effort are not supported for gpt-5.5 in /v1/chat/completions

Root cause:
GPT-5.5 reasoning workflows require the OpenAI /v1/responses API, but the current implementation still routes requests through the legacy /v1/chat/completions endpoint.

Changes:
- Port relevant OpenAI Responses API compatibility logic from PR #906
- Update OpenAI request handling in openaiShim
- Add missing zaiProvider utility dependency
- Preserve latest upstream provider/profile architecture

Validation:
- Project builds successfully
- GPT-5.5 no longer fails on reasoning_effort
- Responses API routing works correctly
- Minimal surgical diff against latest main

Related:
- PR #906

## Summary

- what changed
- why it changed

## Impact

- user-facing impact:
- developer/maintainer impact:

## Testing

- [ ] `bun run build`
- [ ] `bun run smoke`
- [ ] focused tests:

## Notes

- provider/model path tested:
- screenshots attached (if UI changed):
- follow-up work or known limitations:


Note: zaiProvider.ts was included because the updated openaiShim now shares reasoning/thinking compatibility logic across OpenAI-compatible providers (DeepSeek, Moonshot/Kimi, Z.AI). The helper is a small isolated dependency required by the newer shim implementation from #906.
