### PR TITLE
fix(bashSecurity): tighten fc -e detection to avoid long-flag false positives

### DIFF
--- a/src/tools/BashTool/bashSecurity.test.ts
+++ b/src/tools/BashTool/bashSecurity.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, test } from 'bun:test'
 
-import { stripSafeHeredocSubstitutions } from './bashSecurity.js'
+import {
+  bashCommandIsSafe_DEPRECATED,
+  stripSafeHeredocSubstitutions,
+} from './bashSecurity.js'
 
 describe('stripSafeHeredocSubstitutions', () => {
   test('strips a single safe heredoc substitution', () => {
@@ -24,5 +27,49 @@ describe('stripSafeHeredocSubstitutions', () => {
     const cmd = "$(cat <<'A'\nfoo\nA) $(cat <<'B'\nbar\nB)"
     const result = stripSafeHeredocSubstitutions(cmd)
     expect(result).toBe(' ')
+  })
+})
+
+describe('validateZshDangerousCommands: fc -e detection (#1051 BUG-01)', () => {
+  // Regression: the previous regex `/\s-\S*e/` matched any flag whose body
+  // contained an `e` anywhere, so legitimate fc invocations with unrelated
+  // long-style flags like `-reset`, `-reverse`, or `-message` (real or not,
+  // users do type them) tripped the dangerous-zsh check and surfaced an
+  // interactive permission prompt to the user. The replacement caps the
+  // short-flag bundle at 4 chars total and requires `e` to be the last
+  // letter before whitespace or end-of-string.
+  test('asks for `fc -e vim ls` (real `-e` editor flag)', () => {
+    const result = bashCommandIsSafe_DEPRECATED('fc -e vim ls')
+    expect(result.behavior).toBe('ask')
+  })
+
+  test('asks for bundled short flags ending in e (`fc -le ls`)', () => {
+    const result = bashCommandIsSafe_DEPRECATED('fc -le ls')
+    expect(result.behavior).toBe('ask')
+  })
+
+  test('asks for 3-char bundled short flags ending in e (`fc -lne ls`)', () => {
+    const result = bashCommandIsSafe_DEPRECATED('fc -lne ls')
+    expect(result.behavior).toBe('ask')
+  })
+
+  test('does not ask for `fc -reset` (false positive on `-reset`)', () => {
+    const result = bashCommandIsSafe_DEPRECATED('fc -reset')
+    expect(result.behavior).not.toBe('ask')
+  })
+
+  test('does not ask for `fc -reverse` (false positive on `-reverse`)', () => {
+    const result = bashCommandIsSafe_DEPRECATED('fc -reverse')
+    expect(result.behavior).not.toBe('ask')
+  })
+
+  test('does not ask for `fc -message` (false positive on `-message`)', () => {
+    const result = bashCommandIsSafe_DEPRECATED('fc -message')
+    expect(result.behavior).not.toBe('ask')
+  })
+
+  test('does not ask for `fc -l` (safe list flag)', () => {
+    const result = bashCommandIsSafe_DEPRECATED('fc -l')
+    expect(result.behavior).not.toBe('ask')
   })
 })

--- a/src/tools/BashTool/bashSecurity.ts
+++ b/src/tools/BashTool/bashSecurity.ts
@@ -2236,10 +2236,14 @@ function validateZshDangerousCommands(
     }
   }
 
-  // Check for `fc -e` which allows executing arbitrary commands via editor
+  // Check for `fc -e` which allows executing arbitrary commands via editor.
   // fc without -e is safe (just lists history), but -e specifies an editor
-  // to run on the command, effectively an eval
-  if (baseCmd === 'fc' && /\s-\S*e/.test(trimmed)) {
+  // to run on the command, effectively an eval. The regex requires `e` to
+  // be the last letter in a short POSIX-style flag bundle (matches `-e`,
+  // `-le`, `-lne`) and caps the bundle at 4 chars total so unrelated
+  // long-style flags like `-reset`, `-reverse`, or `-message` do not
+  // false-positive on `e` appearing mid-flag or at the end of a long word.
+  if (baseCmd === 'fc' && /\s-[a-zA-Z]{0,3}e(?:\s|$)/.test(trimmed)) {
     logEvent('tengu_bash_security_check_triggered', {
       checkId: BASH_SECURITY_CHECK_IDS.ZSH_DANGEROUS_COMMANDS,
       subId: 2,


### PR DESCRIPTION
### Summary

Closes #1051 (BUG-01).

`validateZshDangerousCommands` in `src/tools/BashTool/bashSecurity.ts` checks for `fc -e <editor>` because that flag invokes an editor on a history line, effectively an `eval`. The current regex `/\s-\S*e/` only requires `e` to appear *somewhere* after `-`, so any flag that happens to contain `e` — `-reset`, `-reverse`, `-message`, etc. — trips the "dangerous fc" path and surfaces an interactive permission prompt to the user even though those flags do not invoke an editor.

### Change

Replace with `/\s-[a-zA-Z]{0,3}e(?:\s|$)/` so:

- `e` must be the **last** letter in the flag bundle (followed by whitespace or end-of-string), not anywhere inside it.
- The bundle is **capped at 4 chars total**, matching the shape of real POSIX `fc` short-flag bundles (`-e`, `-le`, `-lne`).

The bundle cap is what distinguishes this from the issue's initial suggested fix `/\s-[a-zA-Z]*e(?:\s|$)/`, which still false-positives on `-reverse` and `-message` because both end in `e` and the unbounded `*` swallows the entire word. Verified against both inputs (the suggested-fix regex matches them; the capped regex does not).

### Test plan

New `validateZshDangerousCommands: fc -e detection (#1051 BUG-01)` describe block in `bashSecurity.test.ts` covers:

| Input            | Expected | Why                              |
|------------------|----------|----------------------------------|
| `fc -e vim ls`   | ask      | real `-e` editor flag            |
| `fc -le ls`      | ask      | bundled short flags ending in e  |
| `fc -lne ls`     | ask      | 3-char bundled short flags       |
| `fc -reset`      | not ask  | long-style flag, ends in `t`     |
| `fc -reverse`    | not ask  | long-style flag, ends in `e`     |
| `fc -message`    | not ask  | long-style flag, ends in `e`     |
| `fc -l`          | not ask  | safe list flag                   |

Local `bun` is not on this machine; regex behaviour was double-checked under `node` against the same input set with both the old and new patterns and matches the table above.

This PR addresses **BUG-01** only. **BUG-03** is already fixed in #1050. **BUG-05** (sync/async validator-list duplication) is a maintenance refactor that touches a different surface and is left for a separate PR.