### PR TITLE
feat(provider): add Venice official provider

### DIFF
--- a/src/commands/provider/provider.test.tsx
+++ b/src/commands/provider/provider.test.tsx
@@ -350,6 +350,25 @@ test('buildProfileSaveMessage labels descriptor-backed gateway profiles consiste
   expect(message).not.toContain('sk-secret-12345678')
 })
 
+test('buildProfileSaveMessage labels descriptor-backed Venice profiles consistently', () => {
+  const message = buildProfileSaveMessage(
+    'openai',
+    {
+      OPENAI_API_KEY: 'sk-venice-secret-12345678',
+      VENICE_API_KEY: 'sk-venice-secret-12345678',
+      OPENAI_MODEL: 'venice-uncensored',
+      OPENAI_BASE_URL: 'https://api.venice.ai/api/v1',
+    },
+    'D:/codings/Opensource/openclaude/.openclaude-profile.json',
+  )
+
+  expect(message).toContain('Saved Venice profile.')
+  expect(message).toContain('Model: venice-uncensored')
+  expect(message).toContain('Endpoint: https://api.venice.ai/api/v1')
+  expect(message).toContain('Credentials: configured')
+  expect(message).not.toContain('sk-venice-secret-12345678')
+})
+
 test('buildProfileSaveMessage describes Gemini access token / ADC mode clearly', () => {
   const message = buildProfileSaveMessage(
     'gemini',
@@ -571,6 +590,22 @@ test('buildCurrentProviderSummary recognizes descriptor-backed openai-compatible
   expect(summary.providerLabel).toBe('OpenRouter')
   expect(summary.modelLabel).toBe('openai/gpt-5-mini')
   expect(summary.endpointLabel).toBe('https://openrouter.ai/api/v1')
+})
+
+test('buildCurrentProviderSummary recognizes Venice routes', () => {
+  const summary = buildCurrentProviderSummary({
+    processEnv: {
+      CLAUDE_CODE_USE_OPENAI: '1',
+      OPENAI_MODEL: 'venice-uncensored',
+      OPENAI_BASE_URL: 'https://api.venice.ai/api/v1',
+      VENICE_API_KEY: 'sk-venice-secret',
+    },
+    persisted: null,
+  })
+
+  expect(summary.providerLabel).toBe('Venice')
+  expect(summary.modelLabel).toBe('venice-uncensored')
+  expect(summary.endpointLabel).toBe('https://api.venice.ai/api/v1')
 })
 
 test('buildCurrentProviderSummary does not relabel local gpt-5.4 providers as Codex when custom base URL is set', () => {

--- a/src/components/ProviderManager.test.tsx
+++ b/src/components/ProviderManager.test.tsx
@@ -126,6 +126,7 @@ const PRESET_ORDER = [
   'OpenAI',
   'OpenRouter',
   'Together AI',
+  'Venice',
   'xAI',
   'Z.AI - GLM Coding Plan',
   'Custom',

--- a/src/integrations/compatibility.test.ts
+++ b/src/integrations/compatibility.test.ts
@@ -35,6 +35,7 @@ const EXPECTED_PRESETS = [
   'nvidia-nim',
   'minimax',
   'xai',
+  'venice',
   'zai',
   'bankr',
   'atomic-chat',

--- a/src/integrations/generated/integrationArtifacts.generated.ts
+++ b/src/integrations/generated/integrationArtifacts.generated.ts
@@ -9,6 +9,7 @@ import vendorGemini from '../vendors/gemini.js'
 import vendorMinimax from '../vendors/minimax.js'
 import vendorMoonshot from '../vendors/moonshot.js'
 import vendorOpenai from '../vendors/openai.js'
+import vendorVenice from '../vendors/venice.js'
 import vendorXai from '../vendors/xai.js'
 import vendorZai from '../vendors/zai.js'
 import gatewayAtomicChat from '../gateways/atomic-chat.js'
@@ -55,7 +56,7 @@ import modelOpenaiCompatibleAlias from '../models/openai-compatible-alias.js'
 import modelQwen from '../models/qwen.js'
 import modelXai from '../models/xai.js'
 
-export const VENDOR_DESCRIPTORS = [vendorAnthropic, vendorBankr, vendorDeepseek, vendorGemini, vendorMinimax, vendorMoonshot, vendorOpenai, vendorXai, vendorZai] as const satisfies readonly VendorDescriptor[]
+export const VENDOR_DESCRIPTORS = [vendorAnthropic, vendorBankr, vendorDeepseek, vendorGemini, vendorMinimax, vendorMoonshot, vendorOpenai, vendorVenice, vendorXai, vendorZai] as const satisfies readonly VendorDescriptor[]
 export const GATEWAY_DESCRIPTORS = [gatewayAtomicChat, gatewayAzureOpenai, gatewayBedrock, gatewayCustom, gatewayDashscopeCn, gatewayDashscopeIntl, gatewayGithub, gatewayGroq, gatewayHicap, gatewayKimiCode, gatewayLmstudio, gatewayMistral, gatewayNvidiaNim, gatewayOllama, gatewayOpenrouter, gatewayTogether, gatewayVertex] as const satisfies readonly GatewayDescriptor[]
 export const ANTHROPIC_PROXY_DESCRIPTORS = [] as const satisfies readonly AnthropicProxyDescriptor[]
 export const BRAND_DESCRIPTORS = [brandClaude, brandDeepseek, brandGemini, brandGlm, brandGpt, brandKimi, brandLlama, brandMinimax, brandMistral, brandNemotron, brandOpenaiCompatibleAlias, brandQwen, brandXai] as const satisfies readonly BrandDescriptor[]
@@ -292,6 +293,19 @@ export const PROVIDER_PRESET_MANIFEST = [
     ]
   },
   {
+    "preset": "venice",
+    "routeKind": "vendor",
+    "routeId": "venice",
+    "vendorId": "venice",
+    "description": "Venice OpenAI-compatible endpoint",
+    "apiKeyEnvVars": [
+      "VENICE_API_KEY"
+    ],
+    "modelEnvVars": [
+      "OPENAI_MODEL"
+    ]
+  },
+  {
     "preset": "xai",
     "routeKind": "vendor",
     "routeId": "xai",
@@ -363,6 +377,7 @@ export const ORDERED_PROVIDER_PRESETS = [
   "openai",
   "openrouter",
   "together",
+  "venice",
   "xai",
   "zai",
   "custom"

--- a/src/integrations/routeMetadata.test.ts
+++ b/src/integrations/routeMetadata.test.ts
@@ -3,8 +3,11 @@ import { expect, test } from 'bun:test'
 import {
   getRouteCredentialEnvVars,
   getRouteCredentialValue,
+  getRouteDefaultBaseUrl,
+  getRouteDefaultModel,
   getRouteProviderTypeLabel,
   resolveActiveRouteIdFromEnv,
+  resolveRouteIdFromBaseUrl,
 } from './routeMetadata.js'
 
 test('getRouteProviderTypeLabel uses descriptor transport kinds for provider labels', () => {
@@ -41,7 +44,10 @@ test('getRouteCredentialEnvVars keeps descriptor env vars and openai fallback fo
     'HICAP_API_KEY',
     'OPENAI_API_KEY',
   ])
-  expect(getRouteCredentialEnvVars('custom')).toEqual(['OPENAI_API_KEY'])
+  expect(getRouteCredentialEnvVars('venice')).toEqual([
+    'VENICE_API_KEY',
+    'OPENAI_API_KEY',
+  ])
 })
 
 test('getRouteCredentialValue reads the first configured route credential', () => {
@@ -57,6 +63,13 @@ test('getRouteCredentialValue reads the first configured route credential', () =
   ).toBe('sk-openai-fallback')
 })
 
+test('Venice route metadata uses official OpenAI-compatible defaults', () => {
+  expect(getRouteDefaultBaseUrl('venice')).toBe('https://api.venice.ai/api/v1')
+  expect(getRouteDefaultModel('venice')).toBe('venice-uncensored')
+  expect(resolveRouteIdFromBaseUrl('https://api.venice.ai/api/v1')).toBe('venice')
+  expect(resolveRouteIdFromBaseUrl('https://api.venice.ai/api/v1/chat/completions')).toBe('venice')
+})
+
 test('resolveActiveRouteIdFromEnv treats MiniMax credential-only env as MiniMax', () => {
   expect(
     resolveActiveRouteIdFromEnv({
@@ -65,6 +78,13 @@ test('resolveActiveRouteIdFromEnv treats MiniMax credential-only env as MiniMax'
   ).toBe('minimax')
 })
 
+test('resolveActiveRouteIdFromEnv treats Venice credential-only env as Venice', () => {
+  expect(
+    resolveActiveRouteIdFromEnv({
+      VENICE_API_KEY: 'venice-key',
+    }),
+  ).toBe('venice')
+})
 test('resolveActiveRouteIdFromEnv treats xAI credential-only env as xAI', () => {
   expect(
     resolveActiveRouteIdFromEnv({
@@ -109,6 +129,7 @@ test.each([
   ['OpenRouter', 'https://openrouter.ai/api/v1', 'openai/gpt-5-mini', 'openrouter'],
   ['DeepSeek', 'https://api.deepseek.com/v1', 'deepseek-v4-pro', 'deepseek'],
   ['Hicap', 'https://api.hicap.ai/v1', 'claude-opus-4.7', 'hicap'],
+  ['Venice', 'https://api.venice.ai/api/v1', 'venice-uncensored', 'venice'],
 ])(
   'resolveActiveRouteIdFromEnv refines generic OpenAI profile by %s base URL',
   (_label, baseUrl, model, expectedRouteId) => {

--- a/src/integrations/routeMetadata.ts
+++ b/src/integrations/routeMetadata.ts
@@ -203,6 +203,18 @@ export function isXaiBaseUrl(value: string | undefined): boolean {
   }
 }
 
+export function isVeniceBaseUrl(value: string | undefined): boolean {
+  const trimmed = value?.trim()
+  if (!trimmed) {
+    return false
+  }
+
+  try {
+    return new URL(trimmed).hostname.toLowerCase() === 'api.venice.ai'
+  } catch {
+    return false
+  }
+}
 export function getMiniMaxBaseUrlOverride(
   processEnv: NodeJS.ProcessEnv = process.env,
 ): string | undefined {
@@ -285,15 +297,32 @@ export function hasMiniMaxEnvOnlyProviderIntent(
   )
 }
 
+export function hasVeniceEnvOnlyProviderIntent(
+  processEnv: NodeJS.ProcessEnv = process.env,
+): boolean {
+  return (
+    hasNonEmptyEnvValue(processEnv.VENICE_API_KEY) &&
+    !hasNonEmptyEnvValue(processEnv.OPENAI_API_KEY) &&
+    !hasNonEmptyEnvValue(processEnv.XAI_API_KEY) &&
+    !hasNonEmptyEnvValue(processEnv.MINIMAX_API_KEY) &&
+    !hasConflictingOpenAIBaseUrlForRoute(processEnv, isVeniceBaseUrl) &&
+    hasNoExplicitNonOpenAICompatibleProvider(processEnv)
+  )
+}
+
 export function resolveEnvOnlyProviderRouteId(
   processEnv: NodeJS.ProcessEnv = process.env,
-): 'xai' | 'minimax' | null {
+): 'xai' | 'minimax' | 'venice' | null {
   if (hasXaiEnvOnlyProviderIntent(processEnv)) {
     return 'xai'
   }
 
   if (hasMiniMaxEnvOnlyProviderIntent(processEnv)) {
     return 'minimax'
+  }
+
+  if (hasVeniceEnvOnlyProviderIntent(processEnv)) {
+    return 'venice'
   }
 
   return null

--- a/src/integrations/vendors/venice.ts
+++ b/src/integrations/vendors/venice.ts
@@ -1,0 +1,49 @@
+import { defineVendor } from '../define.js'
+
+export default defineVendor({
+  id: 'venice',
+  label: 'Venice',
+  classification: 'openai-compatible',
+  defaultBaseUrl: 'https://api.venice.ai/api/v1',
+  defaultModel: 'venice-uncensored',
+  requiredEnvVars: ['VENICE_API_KEY'],
+  setup: {
+    requiresAuth: true,
+    authMode: 'api-key',
+    credentialEnvVars: ['VENICE_API_KEY'],
+  },
+  transportConfig: {
+    kind: 'openai-compatible',
+    openaiShim: {
+      supportsApiFormatSelection: false,
+      supportsAuthHeaders: false,
+    },
+  },
+  preset: {
+    id: 'venice',
+    description: 'Venice OpenAI-compatible endpoint',
+    apiKeyEnvVars: ['VENICE_API_KEY'],
+    modelEnvVars: ['OPENAI_MODEL'],
+  },
+  validation: {
+    kind: 'credential-env',
+    routing: {
+      matchDefaultBaseUrl: true,
+      matchBaseUrlHosts: ['api.venice.ai'],
+    },
+    credentialEnvVars: ['VENICE_API_KEY', 'OPENAI_API_KEY'],
+    missingCredentialMessage:
+      'Venice auth is required. Set VENICE_API_KEY or OPENAI_API_KEY.',
+  },
+  catalog: {
+    source: 'static',
+    models: [
+      {
+        id: 'venice-uncensored',
+        apiName: 'venice-uncensored',
+        label: 'Venice Uncensored',
+      },
+    ],
+  },
+  usage: { supported: true },
+})

--- a/src/utils/providerFlag.test.ts
+++ b/src/utils/providerFlag.test.ts
@@ -24,6 +24,7 @@ const ENV_KEYS = [
   'BNKR_API_KEY',
   'XAI_API_KEY',
   'MINIMAX_API_KEY',
+  'VENICE_API_KEY',
   'MISTRAL_MODEL',
   'ANTHROPIC_MODEL',
 ]
@@ -53,6 +54,7 @@ const RESET_KEYS = [
   'BNKR_API_KEY',
   'XAI_API_KEY',
   'MINIMAX_API_KEY',
+  'VENICE_API_KEY',
   'MISTRAL_MODEL',
   'ANTHROPIC_MODEL',
 ] as const
@@ -119,6 +121,7 @@ describe('VALID_PROVIDERS', () => {
     expect(VALID_PROVIDERS).toContain('openrouter')
     expect(VALID_PROVIDERS).toContain('atomic-chat')
     expect(VALID_PROVIDERS).toContain('zai')
+    expect(VALID_PROVIDERS).toContain('venice')
   })
 })
 
@@ -330,6 +333,20 @@ describe('applyProviderFlag - zai', () => {
   })
 })
 
+describe('applyProviderFlag - venice', () => {
+  test('sets Venice OpenAI-compatible defaults and mirrors VENICE_API_KEY', () => {
+    process.env.VENICE_API_KEY = 'venice-secret-key'
+
+    const result = applyProviderFlag('venice', [])
+
+    expect(result.error).toBeUndefined()
+    expect(process.env.CLAUDE_CODE_USE_OPENAI).toBe('1')
+    expect(process.env.OPENAI_BASE_URL).toBe('https://api.venice.ai/api/v1')
+    expect(process.env.OPENAI_MODEL).toBe('venice-uncensored')
+    expect(process.env.OPENAI_API_KEY).toBe('venice-secret-key')
+  })
+})
+
 describe('applyProviderFlag - xai', () => {
   test('sets CLAUDE_CODE_USE_OPENAI=1 with xAI defaults when unset', () => {
     delete process.env.OPENAI_BASE_URL
@@ -338,7 +355,7 @@ describe('applyProviderFlag - xai', () => {
     const result = applyProviderFlag('xai', [])
     expect(result.error).toBeUndefined()
     expect(process.env.CLAUDE_CODE_USE_OPENAI).toBe('1')
-    expect(process.env.OPENAI_BASE_URL).toBe('https://api.x.ai/v1')
+    expect(process.env.OPENAI_BASE_URL as string | undefined).toBe('https://api.x.ai/v1')
     expect(process.env.OPENAI_MODEL).toBe('grok-4.3')
   })
 
@@ -353,7 +370,7 @@ describe('applyProviderFlag - xai', () => {
 
     applyProviderFlag('xai', [])
 
-    expect(process.env.OPENAI_API_KEY).toBe('xai-secret-key')
+    expect(process.env.OPENAI_API_KEY as string | undefined).toBe('xai-secret-key')
   })
 
   test('does not override existing OPENAI_API_KEY when both keys are set', () => {

--- a/src/utils/providerFlag.ts
+++ b/src/utils/providerFlag.ts
@@ -37,6 +37,7 @@ const PREFERRED_PROVIDER_ORDER = [
   'ollama',
   'nvidia-nim',
   'minimax',
+  'venice',
 ] as const
 
 function buildValidProviders(): string[] {
@@ -193,9 +194,12 @@ export function applyProviderFlag(
             process.env.OPENAI_API_KEY === process.env.XAI_API_KEY
           ? 'xai'
           : process.env.OPENAI_API_KEY !== undefined &&
-              process.env.OPENAI_API_KEY === process.env.MINIMAX_API_KEY
-            ? 'minimax'
-            : null
+              process.env.OPENAI_API_KEY === process.env.VENICE_API_KEY
+            ? 'venice'
+            : process.env.OPENAI_API_KEY !== undefined &&
+                process.env.OPENAI_API_KEY === process.env.MINIMAX_API_KEY
+              ? 'minimax'
+              : null
 
   delete process.env.CLAUDE_CODE_USE_OPENAI
   delete process.env.CLAUDE_CODE_USE_GEMINI
@@ -292,6 +296,16 @@ export function applyProviderFlag(
       if (model) process.env.OPENAI_MODEL = model
       if (process.env.XAI_API_KEY && !process.env.OPENAI_API_KEY) {
         process.env.OPENAI_API_KEY = process.env.XAI_API_KEY
+      }
+      break
+
+    case 'venice':
+      process.env.CLAUDE_CODE_USE_OPENAI = '1'
+      process.env.OPENAI_BASE_URL ??= defaultBaseUrl ?? 'https://api.venice.ai/api/v1'
+      process.env.OPENAI_MODEL ??= defaultModel ?? 'venice-uncensored'
+      if (model) process.env.OPENAI_MODEL = model
+      if (process.env.VENICE_API_KEY && !process.env.OPENAI_API_KEY) {
+        process.env.OPENAI_API_KEY = process.env.VENICE_API_KEY
       }
       break
   }

--- a/src/utils/providerProfile.ts
+++ b/src/utils/providerProfile.ts
@@ -90,6 +90,7 @@ const PROFILE_ENV_KEYS = [
   'BNKR_API_KEY',
   'BANKR_MODEL',
   'XAI_API_KEY',
+  'VENICE_API_KEY',
 ] as const
 
 export type CompatibilityProfileMode =
@@ -112,6 +113,7 @@ const SECRET_ENV_KEYS = [
   'MISTRAL_API_KEY',
   'BNKR_API_KEY',
   'XAI_API_KEY',
+  'VENICE_API_KEY',
 ] as const
 
 export type ProviderProfile =
@@ -166,6 +168,7 @@ export type ProfileEnv = {
   BNKR_API_KEY?: string
   BANKR_MODEL?: string
   XAI_API_KEY?: string
+  VENICE_API_KEY?: string
 }
 
 export type ProfileFile = {
@@ -185,7 +188,8 @@ type SecretValueSource = Partial<
     | 'MINIMAX_API_KEY'
     | 'MISTRAL_API_KEY'
     | 'BNKR_API_KEY'
-    | 'XAI_API_KEY',
+    | 'XAI_API_KEY'
+    | 'VENICE_API_KEY',
     string | undefined
   >
 >
@@ -455,6 +459,46 @@ export function buildMiniMaxProfileEnv(options: {
     MINIMAX_API_KEY: key,
     MINIMAX_BASE_URL: defaultBaseUrl,
     MINIMAX_MODEL: defaultModel,
+  }
+}
+
+export function buildVeniceProfileEnv(options: {
+  model?: string | null
+  baseUrl?: string | null
+  apiKey?: string | null
+  processEnv?: NodeJS.ProcessEnv
+}): ProfileEnv | null {
+  const processEnv = options.processEnv ?? process.env
+  const key = sanitizeApiKey(options.apiKey ?? processEnv.VENICE_API_KEY)
+  if (!key) {
+    return null
+  }
+
+  const defaultBaseUrl = getRouteDefaultBaseUrl('venice')
+  const defaultModel = getRouteDefaultModel('venice')
+  if (!defaultBaseUrl || !defaultModel) {
+    throw new Error('Venice route defaults are missing from integration metadata.')
+  }
+  const secretSource: SecretValueSource = {
+    OPENAI_API_KEY: key,
+    VENICE_API_KEY: key,
+  }
+
+  return {
+    OPENAI_BASE_URL:
+      sanitizeProviderConfigValue(options.baseUrl, secretSource) ||
+      sanitizeProviderConfigValue(processEnv.OPENAI_BASE_URL, secretSource) ||
+      defaultBaseUrl,
+    OPENAI_MODEL:
+      normalizeProfileModel(
+        sanitizeProviderConfigValue(options.model, secretSource),
+      ) ||
+      normalizeProfileModel(
+        sanitizeProviderConfigValue(processEnv.OPENAI_MODEL, secretSource),
+      ) ||
+      defaultModel,
+    OPENAI_API_KEY: key,
+    VENICE_API_KEY: key,
   }
 }
 

--- a/src/utils/providerProfiles.test.ts
+++ b/src/utils/providerProfiles.test.ts
@@ -58,6 +58,7 @@ const RESTORED_KEYS = [
   'BNKR_API_KEY',
   'BANKR_MODEL',
   'XAI_API_KEY',
+  'VENICE_API_KEY',
   'HICAP_API_KEY',
 ] as const
 
@@ -176,6 +177,17 @@ function buildXaiProfile(overrides: Partial<ProviderProfile> = {}): ProviderProf
     baseUrl: 'https://api.x.ai/v1',
     model: 'grok-4',
     apiKey: 'xai-test-key',
+    ...overrides,
+  })
+}
+
+function buildVeniceProfile(overrides: Partial<ProviderProfile> = {}): ProviderProfile {
+  return buildProfile({
+    provider: 'venice',
+    name: 'Venice',
+    baseUrl: 'https://api.venice.ai/api/v1',
+    model: 'venice-uncensored',
+    apiKey: 'venice-test-key',
     ...overrides,
   })
 }
@@ -463,6 +475,25 @@ describe('applyProviderProfileToProcessEnv', () => {
     expect(process.env.OPENAI_AUTH_HEADER_VALUE).toBeUndefined()
     expect(process.env.ANTHROPIC_CUSTOM_HEADERS).toBeUndefined()
   })
+
+  test('venice profile applies OpenAI-compatible env with VENICE_API_KEY mirror', async () => {
+    const { applyProviderProfileToProcessEnv } =
+      await importFreshProviderProfileModules()
+    process.env.CLAUDE_CODE_USE_GEMINI = '1'
+
+    applyProviderProfileToProcessEnv(buildVeniceProfile())
+    const { getAPIProvider: getFreshAPIProvider } =
+      await importFreshProvidersModule()
+
+    expect(process.env.CLAUDE_CODE_USE_GEMINI).toBeUndefined()
+    expect(String(process.env.CLAUDE_CODE_USE_OPENAI)).toBe('1')
+    expect(process.env.OPENAI_BASE_URL).toBe('https://api.venice.ai/api/v1')
+    expect(process.env.OPENAI_MODEL).toBe('venice-uncensored')
+    expect(process.env.OPENAI_API_KEY).toBe('venice-test-key')
+    expect(process.env.VENICE_API_KEY).toBe('venice-test-key')
+    expect(getFreshAPIProvider()).toBe('openai')
+  })
+
 
   test('legacy OpenAI profile on restricted route ignores advanced settings', async () => {
     const { applyProviderProfileToProcessEnv } =
@@ -1053,6 +1084,20 @@ describe('getProviderPresetDefaults', () => {
     expect(defaults.requiresApiKey).toBe(true)
   })
 
+  test('venice preset defaults to the official Venice endpoint', async () => {
+    const { getProviderPresetDefaults } = await importFreshProviderProfileModules()
+    process.env.VENICE_API_KEY = 'venice-live-key'
+
+    const defaults = getProviderPresetDefaults('venice')
+
+    expect(defaults.provider).toBe('venice')
+    expect(defaults.name).toBe('Venice')
+    expect(defaults.baseUrl).toBe('https://api.venice.ai/api/v1')
+    expect(defaults.model).toBe('venice-uncensored')
+    expect(defaults.apiKey).toBe('venice-live-key')
+    expect(defaults.requiresApiKey).toBe(true)
+  })
+
   test('zai preset defaults to Z.AI GLM Coding Plan endpoint', async () => {
     const { getProviderPresetDefaults } = await importFreshProviderProfileModules()
 
@@ -1223,6 +1268,46 @@ describe('setActiveProviderProfile', () => {
         OPENAI_BASE_URL: 'https://api.deepseek.com/v1',
         OPENAI_MODEL: 'deepseek-chat',
         OPENAI_API_KEY: 'sk-deepseek-live',
+      })
+    } finally {
+      process.chdir(originalCwd)
+      rmSync(tempDir, { recursive: true, force: true })
+      rmSync(configDir, { recursive: true, force: true })
+    }
+  })
+
+  test('persists Venice profiles using a legacy-compatible openai startup profile', async () => {
+    const tempDir = mkdtempSync(join(tmpdir(), 'openclaude-provider-'))
+    const configDir = mkdtempSync(join(tmpdir(), 'openclaude-provider-config-'))
+    process.chdir(tempDir)
+    process.env.CLAUDE_CONFIG_DIR = configDir
+
+    try {
+      const { setActiveProviderProfile } =
+        await importFreshProviderProfileModules()
+      const veniceProfile = buildVeniceProfile({
+        id: 'venice_prof',
+        model: 'venice-uncensored, venice-coding',
+      })
+
+      saveMockGlobalConfig(current => ({
+        ...current,
+        providerProfiles: [veniceProfile],
+      }))
+
+      const result = setActiveProviderProfile('venice_prof')
+      const persisted = JSON.parse(
+        readFileSync(join(configDir, '.openclaude-profile.json'), 'utf8'),
+      )
+
+      expect(result?.id).toBe('venice_prof')
+      expect(existsSync(join(tempDir, '.openclaude-profile.json'))).toBe(false)
+      expect(persisted.profile).toBe('openai')
+      expect(persisted.env).toEqual({
+        OPENAI_BASE_URL: 'https://api.venice.ai/api/v1',
+        OPENAI_MODEL: 'venice-uncensored',
+        OPENAI_API_KEY: 'venice-test-key',
+        VENICE_API_KEY: 'venice-test-key',
       })
     } finally {
       process.chdir(originalCwd)

--- a/src/utils/providerProfiles.ts
+++ b/src/utils/providerProfiles.ts
@@ -21,6 +21,7 @@ import {
   buildMistralProfileEnv,
   buildNvidiaNimProfileEnv,
   buildOpenAIProfileEnv,
+  buildVeniceProfileEnv,
   buildVertexProfileEnv,
   clearManagedProfileEnv,
   type ProfileEnv,
@@ -522,6 +523,10 @@ function isProcessEnvAlignedWithProfile(
     (profile.baseUrl?.toLowerCase().includes('x.ai')
       ? !includeApiKey ||
         sameOptionalEnvValue(processEnv.XAI_API_KEY, profile.apiKey)
+      : true) &&
+    (profile.baseUrl?.toLowerCase().includes('api.venice.ai')
+      ? !includeApiKey ||
+        sameOptionalEnvValue(processEnv.VENICE_API_KEY, profile.apiKey)
       : true)
   )
 }
@@ -636,6 +641,9 @@ export function applyProviderProfileToProcessEnv(profile: ProviderProfile): void
       }
       if (route.routeId === 'xai' || profile.baseUrl.toLowerCase().includes('x.ai')) {
         openAIProfileEnv.XAI_API_KEY = profile.apiKey
+      }
+      if (route.routeId === 'venice' || profile.baseUrl.toLowerCase().includes('api.venice.ai')) {
+        openAIProfileEnv.VENICE_API_KEY = profile.apiKey
       }
     }
     if (route.gatewayId === 'nvidia-nim') {
@@ -935,6 +943,9 @@ function buildOpenAICompatibleStartupEnv(
     if (activeProfile.baseUrl?.toLowerCase().includes('x.ai')) {
       env.XAI_API_KEY = activeProfile.apiKey
     }
+    if (activeProfile.baseUrl?.toLowerCase().includes('api.venice.ai')) {
+      env.VENICE_API_KEY = activeProfile.apiKey
+    }
   } else {
     delete env.OPENAI_API_KEY
   }
@@ -1034,6 +1045,19 @@ function buildStartupProfileFromActiveProfile(
           }) ?? null
         return env
           ? { profile: 'minimax', env: applySupportedProfileCustomHeaders(activeProfile, env) }
+          : null
+      }
+
+      if (route.vendorId === 'venice') {
+        const env =
+          buildVeniceProfileEnv({
+            model: getPrimaryModel(activeProfile.model),
+            baseUrl: activeProfile.baseUrl,
+            apiKey: activeProfile.apiKey,
+            processEnv: process.env,
+          }) ?? null
+        return env
+          ? { profile: 'openai', env: applySupportedProfileCustomHeaders(activeProfile, env) }
           : null
       }
 

--- a/src/utils/providerStartupOverrides.test.ts
+++ b/src/utils/providerStartupOverrides.test.ts
@@ -14,6 +14,7 @@ describe('clearStartupProviderOverrides', () => {
           OPENAI_BASE_URL: 'https://api.minimax.io/v1',
           OPENAI_MODEL: 'minimax-m2.7',
           MINIMAX_API_KEY: 'sk-minimax',
+          VENICE_API_KEY: 'sk-venice',
           KEEP_ME: '1',
         },
       }),
@@ -33,6 +34,7 @@ describe('clearStartupProviderOverrides', () => {
           OPENAI_BASE_URL: undefined,
           OPENAI_MODEL: undefined,
           MINIMAX_API_KEY: undefined,
+          VENICE_API_KEY: undefined,
         }),
       }),
     )

--- a/src/utils/providerStartupOverrides.ts
+++ b/src/utils/providerStartupOverrides.ts
@@ -38,6 +38,7 @@ export const STARTUP_PROVIDER_OVERRIDE_ENV_KEYS = [
   'MINIMAX_MODEL',
   'NVIDIA_API_KEY',
   'NVIDIA_NIM',
+  'VENICE_API_KEY',
 ] as const
 
 type GlobalConfigWithEnv = {


### PR DESCRIPTION
  ## Summary                                                                                                                                                                                                                                                                  

  - Added Venice as an official descriptor-backed OpenAI-compatible provider.
  - Configured Venice with `https://api.venice.ai/api/v1`, `VENICE_API_KEY`, and default model `venice-uncensored`.
  - Added provider/profile/env handling sonVenice appears in `/provider`, persists correctly, mirrors `VENICE_API_KEY`, and displays as Venice instead of generic OpenAI-compatible.

  ## Impact

  - Users can select Venice directly from the provider picker or use `--provider venice`.
  - Venice profiles run through the existing OpenAI-compatible transport using:
    - `CLAUDE_CODE_USE_OPENAI=1`
    - `OPENAI_BASE_URL=https://api.venice.ai/api/v1`
    - `OPENAI_MODEL=venice-uncensored`
    - `OPENAI_API_KEY`
    - `VENICE_API_KEY`
  - Startup override cleanup now clears stale `VENICE_API_KEY`.

  ## Testing
                                       n
  - `bun run integrations:generate`
  - `bun run integrations:check`       n
  - `bun test src/integrations/compatibility.test.ts src/integrations/routeMetadata.test.ts src/utils/providerProfiles.test.ts src/utils/providerStartupOverrides.test.ts src/utils/providerFlag.test.ts src/components/ProviderManager.test.tsx
  src/commands/provider/provider.test.tsx`
  - `bun run build`                    n
  - Manual smoke test confirmed Venice works with a real Venice API key.

  ## Notes

  - `bun run typecheck` still fails due existing repo-wide unrelated TypeScript errors; no Venice/touched-file diagnostics were found after filtering the typecheck output.
  - Venice is intentionally implementednas an OpenAI-compatible provider, not a new legacy transport/provider type.