### PR TITLE
fix(bashPermissions): block command substitution in array subscript position

### DIFF
--- a/src/tools/BashTool/bashPermissions.test.ts
+++ b/src/tools/BashTool/bashPermissions.test.ts
@@ -1,8 +1,8 @@
-import { afterEach, expect, test } from 'bun:test'
+import { afterEach, describe, expect, test } from 'bun:test'
 
 import { getEmptyToolPermissionContext } from '../../Tool.js'
 import { SandboxManager } from '../../utils/sandbox/sandbox-adapter.js'
-import { bashToolHasPermission } from './bashPermissions.js'
+import { bashToolHasPermission, stripAllLeadingEnvVars } from './bashPermissions.js'
 
 const originalSandboxMethods = {
   isSandboxingEnabled: SandboxManager.isSandboxingEnabled,
@@ -56,4 +56,34 @@ test('sandbox auto-allow still enforces Bash path constraints', async () => {
   expect(result.behavior).toBe('ask')
   expect(result.message).toContain('was blocked')
   expect(result.message).toContain('passwd')
+})
+
+// SEC-02 regression: array subscript with command substitution must NOT be stripped.
+// Bash executes FOO[$(cmd)]=val as a side effect; if the pattern matched the
+// subscript, the env-var prefix would be stripped while $(cmd) silently ran.
+describe('stripAllLeadingEnvVars — SEC-02 subscript expansion guard', () => {
+  test('does not strip env var whose subscript contains $()', () => {
+    const cmd = 'FOO[$(id)]=val denied_cmd'
+    // Pattern must NOT match — command stays intact, deny check sees the full string.
+    expect(stripAllLeadingEnvVars(cmd)).toBe(cmd.trim())
+  })
+
+  test('does not strip env var whose subscript contains ${var}', () => {
+    const cmd = 'ARR[${evil}]=x ls'
+    expect(stripAllLeadingEnvVars(cmd)).toBe(cmd.trim())
+  })
+
+  test('does not strip env var whose subscript contains a backtick', () => {
+    const cmd = 'X[`id`]=1 echo hi'
+    expect(stripAllLeadingEnvVars(cmd)).toBe(cmd.trim())
+  })
+
+  test('still strips a safe numeric array subscript', () => {
+    // FOO[0]=val cmd → cmd (safe, no expansion in subscript)
+    expect(stripAllLeadingEnvVars('FOO[0]=val cmd')).toBe('cmd')
+  })
+
+  test('still strips a safe identifier array subscript', () => {
+    expect(stripAllLeadingEnvVars('ARR[idx]=x ls')).toBe('ls')
+  })
 })

--- a/src/tools/BashTool/bashPermissions.ts
+++ b/src/tools/BashTool/bashPermissions.ts
@@ -733,8 +733,14 @@ export function stripAllLeadingEnvVars(
   // dangerous forms like $(cmd), ${var}, and $((expr)). This means
   // FOO=$VAR is not stripped — adding $VAR matching creates ReDoS risk
   // (CodeQL #671) and $VAR bypasses are low-priority.
+  //
+  // SECURITY: Array subscript uses [^\]$`{(]* (not [^\]]*) to block command
+  // substitution in subscript position. Bash executes FOO[$(cmd)]=val as a
+  // side effect during assignment parsing; if the pattern matched $(cmd) in
+  // the subscript, the env-var prefix would be stripped while the substitution
+  // silently executed — bypassing deny rules that block the substituted command.
   const ENV_VAR_PATTERN =
-    /^([A-Za-z_][A-Za-z0-9_]*(?:\[[^\]]*\])?)\+?=(?:'[^'\n\r]*'|"(?:\\.|[^"$`\\\n\r])*"|\\.|[^ \t\n\r$`;|&()<>\\\\'"])*[ \t]+/
+    /^([A-Za-z_][A-Za-z0-9_]*(?:\[[^\]$`{(]*\])?)\+?=(?:'[^'\n\r]*'|"(?:\\.|[^"$`\\\n\r])*"|\\.|[^ \t\n\r$`;|&()<>\\\\'"])*[ \t]+/
 
   let stripped = command
   let previousStripped = ''


### PR DESCRIPTION
## Problem

`stripAllLeadingEnvVars` used `[^\]]*` for the array subscript component of `ENV_VAR_PATTERN`. This character class accepts `$(cmd)`, `${var}`, and backtick expressions.

**The exploit:** Bash evaluates array subscripts during assignment parsing as a side effect. A command like:

```
FOO[$(denied_cmd)]=val harmless_cmd
```

causes the deny-rule check to strip the env-var prefix and see only `harmless_cmd` — while bash has already executed `$(denied_cmd)` as a side effect of parsing the assignment. This allows a denied command to run by hiding it in a subscript, with a harmless command as the main body.

## Fix

Changed the subscript character class from `[^\]]*` to `[^\]$\`{(]*`, blocking all bash expansion forms:

| Excluded char | Blocks |
|---|---|
| `$` | `$(cmd)`, `${var}`, `$((expr))` |
| `` ` `` | backtick command substitution |
| `{` | belt-and-suspenders for `${var}` |
| `(` | belt-and-suspenders for `$(cmd)` |

Safe subscripts (`FOO[0]`, `FOO[idx]`, `ARR[i+1]`) continue to match and strip correctly.

## Tests

5 new cases in `bashPermissions.test.ts`:
- `FOO[$(id)]=val denied_cmd` → NOT stripped (pattern rejected)
- `ARR[${evil}]=x ls` → NOT stripped
- `X[\`id\`]=1 echo hi` → NOT stripped
- `FOO[0]=val cmd` → strips to `cmd` ✅
- `ARR[idx]=x ls` → strips to `ls` ✅