### PR TITLE
Keep Codex OAuth provider active after onboarding

### DIFF
--- a/src/components/ProviderManager.test.tsx
+++ b/src/components/ProviderManager.test.tsx
@@ -1097,6 +1097,14 @@ test('ProviderManager first-run Codex OAuth switches the current session after l
   const onDone = mock(() => {})
   const applySavedProfileToCurrentSession = mock(async () => null)
   const persistCredentials = mock(() => {})
+  const setActiveProviderProfile = mock((profileId: string) => ({
+    id: profileId,
+    provider: 'openai',
+    name: 'Codex OAuth',
+    baseUrl: 'https://chatgpt.com/backend-api/codex',
+    model: 'codexplan',
+    apiKey: '',
+  }))
   const addProviderProfile = mock((payload: {
     provider: string
     name: string
@@ -1118,6 +1126,7 @@ test('ProviderManager first-run Codex OAuth switches the current session after l
     {
       addProviderProfile,
       applySavedProfileToCurrentSession,
+      setActiveProviderProfile,
       useCodexOAuthFlow: ({ onAuthenticated }) => {
         React.useEffect(() => {
           void onAuthenticated({
@@ -1163,6 +1172,9 @@ test('ProviderManager first-run Codex OAuth switches the current session after l
     }),
     expect.objectContaining({ makeActive: false }),
   )
+  expect(setActiveProviderProfile).toHaveBeenCalledWith(
+    'provider_codex_oauth',
+  )
   expect(applySavedProfileToCurrentSession).toHaveBeenCalled()
   expect(persistCredentials).toHaveBeenCalledWith({
     profileId: 'provider_codex_oauth',
@@ -1189,6 +1201,14 @@ test('ProviderManager first-run Codex OAuth reports next-startup fallback when s
     async () => 'validation failed',
   )
   const persistCredentials = mock(() => {})
+  const setActiveProviderProfile = mock((profileId: string) => ({
+    id: profileId,
+    provider: 'openai',
+    name: 'Codex OAuth',
+    baseUrl: 'https://chatgpt.com/backend-api/codex',
+    model: 'codexplan',
+    apiKey: '',
+  }))
   const addProviderProfile = mock((payload: {
     provider: string
     name: string
@@ -1210,6 +1230,7 @@ test('ProviderManager first-run Codex OAuth reports next-startup fallback when s
     {
       addProviderProfile,
       applySavedProfileToCurrentSession,
+      setActiveProviderProfile,
       useCodexOAuthFlow: ({ onAuthenticated }) => {
         React.useEffect(() => {
           void onAuthenticated({
@@ -1248,6 +1269,9 @@ test('ProviderManager first-run Codex OAuth reports next-startup fallback when s
   expect(persistCredentials).toHaveBeenCalledWith({
     profileId: 'provider_codex_oauth',
   })
+  expect(setActiveProviderProfile).toHaveBeenCalledWith(
+    'provider_codex_oauth',
+  )
   expect(onDone).toHaveBeenCalledWith(
     expect.objectContaining({
       action: 'saved',
@@ -1290,6 +1314,14 @@ test('ProviderManager does not hijack a manual Codex profile when OAuth credenti
   }))
   const updateProviderProfile = mock(() => manualProfile)
   const persistCredentials = mock(() => {})
+  const setActiveProviderProfile = mock((profileId: string) => ({
+    id: profileId,
+    provider: 'openai',
+    name: 'Codex OAuth',
+    baseUrl: 'https://chatgpt.com/backend-api/codex',
+    model: 'codexplan',
+    apiKey: '',
+  }))
 
   mockProviderManagerDependencies(
     () => undefined,
@@ -1297,6 +1329,7 @@ test('ProviderManager does not hijack a manual Codex profile when OAuth credenti
     {
       addProviderProfile,
       getProviderProfiles: () => [manualProfile],
+      setActiveProviderProfile,
       updateProviderProfile,
       useCodexOAuthFlow: ({ onAuthenticated }) => {
         const hasAuthenticated = React.useRef(false)
@@ -1341,6 +1374,9 @@ test('ProviderManager does not hijack a manual Codex profile when OAuth credenti
 
   expect(addProviderProfile).toHaveBeenCalledTimes(1)
   expect(updateProviderProfile).not.toHaveBeenCalled()
+  expect(setActiveProviderProfile).toHaveBeenCalledWith(
+    'provider_codex_oauth',
+  )
   expect(persistCredentials).toHaveBeenCalledWith({
     profileId: 'provider_codex_oauth',
   })

--- a/src/components/ProviderManager.tsx
+++ b/src/components/ProviderManager.tsx
@@ -1813,9 +1813,9 @@ export function ProviderManager({ mode, onDone }: Props): React.ReactNode {
             }
 
             const active =
-              existing && activeProfileId !== saved.id
-                ? setActiveProviderProfile(saved.id)
-                : saved
+              activeProfileId === saved.id
+                ? saved
+                : setActiveProviderProfile(saved.id)
             if (!active) {
               setErrorMessage(
                 'Codex OAuth login finished, but the provider could not be set as the startup provider.',


### PR DESCRIPTION
## Summary
- make Codex OAuth first-run onboarding set the saved OAuth profile as the active provider profile
- keep current-session activation aligned with next-startup provider selection
- add regression coverage for successful setup, fallback warning, and manual Codex profile coexistence

## Verification
- bun test src/components/ProviderManager.test.tsx