### PR TITLE
fix(mcp): fail-closed on token count error + respect maxChars budget

### DIFF
--- a/src/utils/mcpValidation.test.ts
+++ b/src/utils/mcpValidation.test.ts
@@ -20,7 +20,11 @@ mock.module('../services/analytics/growthbook.js', () => ({
 }))
 
 mock.module('../services/tokenEstimation.js', () => ({
-  roughTokenCountEstimation: () => tokenState.roughCount,
+  // Return tokenState.roughCount only when explicitly set high by a test (> 0).
+  // When roughCount is 0 (post-afterEach reset), return a small neutral value so
+  // this mock does not cause hybridContextStrategy or other test files to treat
+  // every message as oversized if the mock leaks past afterAll.
+  roughTokenCountEstimation: () => (tokenState.roughCount > 0 ? tokenState.roughCount : 100),
   countMessagesTokensWithAPI: async () => tokenState.apiReturn,
 }))
 
@@ -40,6 +44,11 @@ describe('mcpContentNeedsTruncation — SEC-04 fail-closed on null', () => {
   })
 
   afterEach(() => {
+    // Reset to 0 so that if the mock leaks to later files, roughTokenCountEstimation
+    // returns the neutral fallback (100) instead of 26000, which would break
+    // hybridContextStrategy and other token-sensitive test files.
+    tokenState.roughCount = 0
+    tokenState.apiReturn = null
     process.env.MAX_MCP_OUTPUT_TOKENS = ''
   })
 
@@ -68,10 +77,12 @@ describe('mcpContentNeedsTruncation — SEC-04 fail-closed on null', () => {
 
 describe('truncateMcpContent — SEC-05 budget invariant', () => {
   beforeEach(() => {
+    tokenState.roughCount = 26000
     process.env.MAX_MCP_OUTPUT_TOKENS = ''
   })
 
   afterEach(() => {
+    tokenState.roughCount = 0
     process.env.MAX_MCP_OUTPUT_TOKENS = ''
   })
 

--- a/src/utils/mcpValidation.test.ts
+++ b/src/utils/mcpValidation.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, test } from 'bun:test'
+
+/**
+ * SEC-05 regression: truncateMcpContent must keep total output within maxChars.
+ * We test the budget-reservation logic directly without the full module (which
+ * has analytics side-effects on import).
+ */
+describe('truncation budget — SEC-05 regression', () => {
+  // Inline the fixed logic so the test is self-contained and fast.
+  function truncateWithBudget(content: string, maxChars: number, msg: string): string {
+    const budget = Math.max(0, maxChars - msg.length)
+    return content.slice(0, budget) + msg
+  }
+
+  test('total length does not exceed maxChars', () => {
+    const msg = '\n\n[OUTPUT TRUNCATED — limit reached]'
+    const maxChars = 200
+    const content = 'x'.repeat(500)
+    const result = truncateWithBudget(content, maxChars, msg)
+    expect(result.length).toBeLessThanOrEqual(maxChars)
+    expect(result).toContain('[OUTPUT TRUNCATED')
+  })
+
+  test('content shorter than budget is returned as-is plus message', () => {
+    const msg = '[TRUNCATED]'
+    const maxChars = 200
+    const content = 'hello'
+    const result = truncateWithBudget(content, maxChars, msg)
+    expect(result).toBe('hello[TRUNCATED]')
+    expect(result.length).toBeLessThanOrEqual(maxChars)
+  })
+
+  test('budget floors at 0 when message alone exceeds maxChars', () => {
+    const msg = 'x'.repeat(300)
+    const maxChars = 100
+    const result = truncateWithBudget('content', maxChars, msg)
+    // budget = max(0, 100-300) = 0 → no content chars, just msg
+    expect(result).toBe(msg)
+  })
+})

--- a/src/utils/mcpValidation.test.ts
+++ b/src/utils/mcpValidation.test.ts
@@ -1,75 +1,79 @@
-import { afterAll, afterEach, beforeEach, describe, expect, mock, test } from 'bun:test'
+import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test'
 import { mcpContentNeedsTruncation, truncateMcpContent } from './mcpValidation.js'
+import * as realGrowthbook from '../services/analytics/growthbook.js'
+import * as realTokenEstimation from '../services/tokenEstimation.js'
+import * as realImageResizer from './imageResizer.js'
+import * as realLog from './log.js'
 
-// Mutable state shared between mock factories and test cases via closure.
-// Factories close over this object and read it at call time, so per-test
-// mutations (e.g. tokenState.apiReturn = 1000) take effect correctly.
+// 60_000-char inputs: real roughTokenCountEstimation returns 15_000, which exceeds
+// DEFAULT_MAX_MCP_OUTPUT_TOKENS * MCP_TOKEN_COUNT_THRESHOLD_FACTOR (25_000 * 0.5 = 12_500),
+// so the threshold-check is bypassed and countMessagesTokensWithAPI is exercised —
+// without mocking roughTokenCountEstimation. This prevents leakage into autoCompact
+// tests that rely on the real rough-count to determine the compaction threshold.
 const tokenState = {
-  // > DEFAULT_MAX_MCP_OUTPUT_TOKENS * MCP_TOKEN_COUNT_THRESHOLD_FACTOR (12500)
-  // so the rough-count early-return is bypassed and the API is always called.
-  roughCount: 26000,
   apiReturn: null as number | null,
 }
 
-mock.module('../services/analytics/growthbook.js', () => ({
-  // Only intercept the mcpValidation flag (tengu_satin_quoll); return defaultValue
-  // for all other flags so this mock does not affect unrelated test files that
-  // import growthbook.js after this suite runs (e.g. analyzeContext, hybridContextStrategy).
-  getFeatureValue_CACHED_MAY_BE_STALE: (flag: string, defaultValue: unknown) =>
-    flag === 'tengu_satin_quoll' ? null : defaultValue,
-}))
+function applyMocks() {
+  mock.module('../services/analytics/growthbook.js', () => ({
+    // Only intercept the mcpValidation flag (tengu_satin_quoll); return defaultValue
+    // for all other flags so this mock does not affect unrelated test files.
+    getFeatureValue_CACHED_MAY_BE_STALE: (flag: string, defaultValue: unknown) =>
+      flag === 'tengu_satin_quoll' ? null : defaultValue,
+  }))
+  mock.module('../services/tokenEstimation.js', () => ({
+    // Spread the real module so roughTokenCountEstimation is never replaced.
+    // Only countMessagesTokensWithAPI is controlled per-test via tokenState.
+    ...realTokenEstimation,
+    countMessagesTokensWithAPI: async () => tokenState.apiReturn,
+  }))
+  mock.module('./imageResizer.js', () => ({
+    compressImageBlock: async (block: unknown) => block,
+  }))
+  mock.module('./log.js', () => ({ logError: () => {} }))
+}
 
-mock.module('../services/tokenEstimation.js', () => ({
-  // Return tokenState.roughCount only when explicitly set high by a test (> 0).
-  // When roughCount is 0 (post-afterEach reset), return a small neutral value so
-  // this mock does not cause hybridContextStrategy or other test files to treat
-  // every message as oversized if the mock leaks past afterAll.
-  roughTokenCountEstimation: () => (tokenState.roughCount > 0 ? tokenState.roughCount : 100),
-  countMessagesTokensWithAPI: async () => tokenState.apiReturn,
-}))
-
-mock.module('./imageResizer.js', () => ({
-  compressImageBlock: async (block: unknown) => block,
-}))
-
-mock.module('./log.js', () => ({ logError: () => {} }))
+function restoreMocks() {
+  mock.restore()
+  mock.module('../services/analytics/growthbook.js', () => realGrowthbook)
+  mock.module('../services/tokenEstimation.js', () => realTokenEstimation)
+  mock.module('./imageResizer.js', () => realImageResizer)
+  mock.module('./log.js', () => realLog)
+}
 
 // ---------- SEC-04: fail-closed on null ----------
 
 describe('mcpContentNeedsTruncation — SEC-04 fail-closed on null', () => {
   beforeEach(() => {
-    tokenState.roughCount = 26000
+    applyMocks()
     tokenState.apiReturn = null
     process.env.MAX_MCP_OUTPUT_TOKENS = ''
   })
 
   afterEach(() => {
-    // Reset to 0 so that if the mock leaks to later files, roughTokenCountEstimation
-    // returns the neutral fallback (100) instead of 26000, which would break
-    // hybridContextStrategy and other token-sensitive test files.
-    tokenState.roughCount = 0
+    restoreMocks()
     tokenState.apiReturn = null
     process.env.MAX_MCP_OUTPUT_TOKENS = ''
   })
 
   test('null token count returns true (fail-closed)', async () => {
     tokenState.apiReturn = null
-    expect(await mcpContentNeedsTruncation('x'.repeat(500))).toBe(true)
+    expect(await mcpContentNeedsTruncation('x'.repeat(60_000))).toBe(true)
   })
 
   test('token count below limit returns false', async () => {
     tokenState.apiReturn = 1000
-    expect(await mcpContentNeedsTruncation('x'.repeat(500))).toBe(false)
+    expect(await mcpContentNeedsTruncation('x'.repeat(60_000))).toBe(false)
   })
 
   test('token count above limit returns true', async () => {
     tokenState.apiReturn = 26000
-    expect(await mcpContentNeedsTruncation('x'.repeat(500))).toBe(true)
+    expect(await mcpContentNeedsTruncation('x'.repeat(60_000))).toBe(true)
   })
 
   test('token count exactly at limit returns false', async () => {
     tokenState.apiReturn = 25000
-    expect(await mcpContentNeedsTruncation('x'.repeat(500))).toBe(false)
+    expect(await mcpContentNeedsTruncation('x'.repeat(60_000))).toBe(false)
   })
 })
 
@@ -77,12 +81,12 @@ describe('mcpContentNeedsTruncation — SEC-04 fail-closed on null', () => {
 
 describe('truncateMcpContent — SEC-05 budget invariant', () => {
   beforeEach(() => {
-    tokenState.roughCount = 26000
+    applyMocks()
     process.env.MAX_MCP_OUTPUT_TOKENS = ''
   })
 
   afterEach(() => {
-    tokenState.roughCount = 0
+    restoreMocks()
     process.env.MAX_MCP_OUTPUT_TOKENS = ''
   })
 
@@ -90,7 +94,7 @@ describe('truncateMcpContent — SEC-05 budget invariant', () => {
     // MAX_MCP_OUTPUT_TOKENS=1 → maxChars=4; notice is ~200 chars → exceeds budget.
     // Before the fix: budget=0, result = '' + notice (overflow). After: sliced to maxChars.
     process.env.MAX_MCP_OUTPUT_TOKENS = '1'
-    const result = await truncateMcpContent('x'.repeat(500))
+    const result = await truncateMcpContent('x'.repeat(60_000))
     expect(typeof result).toBe('string')
     expect((result as string).length).toBeLessThanOrEqual(4)
   })
@@ -98,7 +102,7 @@ describe('truncateMcpContent — SEC-05 budget invariant', () => {
   test('block result total chars do not exceed maxChars when notice exceeds budget', async () => {
     process.env.MAX_MCP_OUTPUT_TOKENS = '1'
     const result = await truncateMcpContent([
-      { type: 'text', text: 'x'.repeat(500) },
+      { type: 'text', text: 'x'.repeat(60_000) },
     ] as Parameters<typeof truncateMcpContent>[0])
     expect(Array.isArray(result)).toBe(true)
     const totalChars = (result as Array<{ type: string; text?: string }>).reduce(
@@ -110,12 +114,10 @@ describe('truncateMcpContent — SEC-05 budget invariant', () => {
 
   test('string result within standard budget includes notice', async () => {
     // Default MAX_MCP_OUTPUT_TOKENS=25000 → maxChars=100000.
-    // 500-char content + notice << 100000 → content is preserved intact.
-    const result = await truncateMcpContent('x'.repeat(500))
+    // 60000-char content + notice << 100000 → content is preserved intact.
+    const result = await truncateMcpContent('x'.repeat(60_000))
     expect(typeof result).toBe('string')
     expect((result as string).length).toBeLessThanOrEqual(25000 * 4)
     expect(result as string).toContain('[OUTPUT TRUNCATED')
   })
 })
-
-afterAll(() => mock.restore())

--- a/src/utils/mcpValidation.test.ts
+++ b/src/utils/mcpValidation.test.ts
@@ -1,74 +1,104 @@
-import { describe, expect, test } from 'bun:test'
+import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test'
+import { mcpContentNeedsTruncation, truncateMcpContent } from './mcpValidation.js'
 
-/**
- * SEC-05 regression: truncateMcpContent must keep total output within maxChars.
- * We test the budget-reservation logic directly without the full module (which
- * has analytics side-effects on import).
- */
-describe('truncation budget — SEC-05 regression', () => {
-  // Inline the fixed logic so the test is self-contained and fast.
-  function truncateWithBudget(content: string, maxChars: number, msg: string): string {
-    if (msg.length >= maxChars) {
-      return msg.slice(0, maxChars)
-    }
-    const budget = maxChars - msg.length
-    return content.slice(0, budget) + msg
-  }
+// Mutable state shared between mock factories and test cases via closure.
+// Factories close over this object and read it at call time, so per-test
+// mutations (e.g. tokenState.apiReturn = 1000) take effect correctly.
+const tokenState = {
+  // > DEFAULT_MAX_MCP_OUTPUT_TOKENS * MCP_TOKEN_COUNT_THRESHOLD_FACTOR (12500)
+  // so the rough-count early-return is bypassed and the API is always called.
+  roughCount: 26000,
+  apiReturn: null as number | null,
+}
 
-  test('total length does not exceed maxChars', () => {
-    const msg = '\n\n[OUTPUT TRUNCATED — limit reached]'
-    const maxChars = 200
-    const content = 'x'.repeat(500)
-    const result = truncateWithBudget(content, maxChars, msg)
-    expect(result.length).toBeLessThanOrEqual(maxChars)
-    expect(result).toContain('[OUTPUT TRUNCATED')
+mock.module('../services/analytics/growthbook.js', () => ({
+  getFeatureValue_CACHED_MAY_BE_STALE: () => null,
+}))
+
+mock.module('../services/tokenEstimation.js', () => ({
+  roughTokenCountEstimation: () => tokenState.roughCount,
+  countMessagesTokensWithAPI: async () => tokenState.apiReturn,
+}))
+
+mock.module('./imageResizer.js', () => ({
+  compressImageBlock: async (block: unknown) => block,
+}))
+
+mock.module('./log.js', () => ({ logError: () => {} }))
+
+// ---------- SEC-04: fail-closed on null ----------
+
+describe('mcpContentNeedsTruncation — SEC-04 fail-closed on null', () => {
+  beforeEach(() => {
+    tokenState.roughCount = 26000
+    tokenState.apiReturn = null
+    process.env.MAX_MCP_OUTPUT_TOKENS = ''
   })
 
-  test('content shorter than budget is returned as-is plus message', () => {
-    const msg = '[TRUNCATED]'
-    const maxChars = 200
-    const content = 'hello'
-    const result = truncateWithBudget(content, maxChars, msg)
-    expect(result).toBe('hello[TRUNCATED]')
-    expect(result.length).toBeLessThanOrEqual(maxChars)
+  afterEach(() => {
+    process.env.MAX_MCP_OUTPUT_TOKENS = ''
   })
 
-  test('message alone exceeds maxChars — total is capped at maxChars', () => {
-    // Repro: MAX_MCP_OUTPUT_TOKENS=1 → maxChars=4, but notice is always longer.
-    // Previously: budget=0, result = '' + msg (300 chars) > maxChars (100). Bug.
-    // Now: result = msg.slice(0, maxChars) — invariant holds.
-    const msg = 'x'.repeat(300)
-    const maxChars = 100
-    const result = truncateWithBudget('content', maxChars, msg)
-    expect(result.length).toBeLessThanOrEqual(maxChars)
-    expect(result).toBe(msg.slice(0, maxChars))
+  test('null token count returns true (fail-closed)', async () => {
+    tokenState.apiReturn = null
+    expect(await mcpContentNeedsTruncation('x'.repeat(500))).toBe(true)
+  })
+
+  test('token count below limit returns false', async () => {
+    tokenState.apiReturn = 1000
+    expect(await mcpContentNeedsTruncation('x'.repeat(500))).toBe(false)
+  })
+
+  test('token count above limit returns true', async () => {
+    tokenState.apiReturn = 26000
+    expect(await mcpContentNeedsTruncation('x'.repeat(500))).toBe(true)
+  })
+
+  test('token count exactly at limit returns false', async () => {
+    tokenState.apiReturn = 25000
+    expect(await mcpContentNeedsTruncation('x'.repeat(500))).toBe(false)
   })
 })
 
-/**
- * SEC-04 regression: mcpContentNeedsTruncation must fail-closed when
- * countMessagesTokensWithAPI returns null (not just when it throws).
- */
-describe('mcpContentNeedsTruncation fail-closed on null — SEC-04 regression', () => {
-  // Inline the fixed evaluation logic without importing the full module.
-  function evaluateTokenCount(tokenCount: number | null, limit: number): boolean {
-    if (tokenCount == null) return true
-    return tokenCount > limit
-  }
+// ---------- SEC-05: output stays within budget ----------
 
-  test('null token count returns true (fail-closed)', () => {
-    expect(evaluateTokenCount(null, 50000)).toBe(true)
+describe('truncateMcpContent — SEC-05 budget invariant', () => {
+  beforeEach(() => {
+    process.env.MAX_MCP_OUTPUT_TOKENS = ''
   })
 
-  test('token count below limit returns false', () => {
-    expect(evaluateTokenCount(1000, 50000)).toBe(false)
+  afterEach(() => {
+    process.env.MAX_MCP_OUTPUT_TOKENS = ''
   })
 
-  test('token count above limit returns true', () => {
-    expect(evaluateTokenCount(60000, 50000)).toBe(true)
+  test('string result does not exceed maxChars when notice exceeds budget', async () => {
+    // MAX_MCP_OUTPUT_TOKENS=1 → maxChars=4; notice is ~200 chars → exceeds budget.
+    // Before the fix: budget=0, result = '' + notice (overflow). After: sliced to maxChars.
+    process.env.MAX_MCP_OUTPUT_TOKENS = '1'
+    const result = await truncateMcpContent('x'.repeat(500))
+    expect(typeof result).toBe('string')
+    expect((result as string).length).toBeLessThanOrEqual(4)
   })
 
-  test('token count exactly at limit returns false', () => {
-    expect(evaluateTokenCount(50000, 50000)).toBe(false)
+  test('block result total chars do not exceed maxChars when notice exceeds budget', async () => {
+    process.env.MAX_MCP_OUTPUT_TOKENS = '1'
+    const result = await truncateMcpContent([
+      { type: 'text', text: 'x'.repeat(500) },
+    ] as Parameters<typeof truncateMcpContent>[0])
+    expect(Array.isArray(result)).toBe(true)
+    const totalChars = (result as Array<{ type: string; text?: string }>).reduce(
+      (sum, b) => sum + (b.text?.length ?? 0),
+      0,
+    )
+    expect(totalChars).toBeLessThanOrEqual(4)
+  })
+
+  test('string result within standard budget includes notice', async () => {
+    // Default MAX_MCP_OUTPUT_TOKENS=25000 → maxChars=100000.
+    // 500-char content + notice << 100000 → content is preserved intact.
+    const result = await truncateMcpContent('x'.repeat(500))
+    expect(typeof result).toBe('string')
+    expect((result as string).length).toBeLessThanOrEqual(25000 * 4)
+    expect(result as string).toContain('[OUTPUT TRUNCATED')
   })
 })

--- a/src/utils/mcpValidation.test.ts
+++ b/src/utils/mcpValidation.test.ts
@@ -8,7 +8,10 @@ import { describe, expect, test } from 'bun:test'
 describe('truncation budget — SEC-05 regression', () => {
   // Inline the fixed logic so the test is self-contained and fast.
   function truncateWithBudget(content: string, maxChars: number, msg: string): string {
-    const budget = Math.max(0, maxChars - msg.length)
+    if (msg.length >= maxChars) {
+      return msg.slice(0, maxChars)
+    }
+    const budget = maxChars - msg.length
     return content.slice(0, budget) + msg
   }
 
@@ -30,11 +33,42 @@ describe('truncation budget — SEC-05 regression', () => {
     expect(result.length).toBeLessThanOrEqual(maxChars)
   })
 
-  test('budget floors at 0 when message alone exceeds maxChars', () => {
+  test('message alone exceeds maxChars — total is capped at maxChars', () => {
+    // Repro: MAX_MCP_OUTPUT_TOKENS=1 → maxChars=4, but notice is always longer.
+    // Previously: budget=0, result = '' + msg (300 chars) > maxChars (100). Bug.
+    // Now: result = msg.slice(0, maxChars) — invariant holds.
     const msg = 'x'.repeat(300)
     const maxChars = 100
     const result = truncateWithBudget('content', maxChars, msg)
-    // budget = max(0, 100-300) = 0 → no content chars, just msg
-    expect(result).toBe(msg)
+    expect(result.length).toBeLessThanOrEqual(maxChars)
+    expect(result).toBe(msg.slice(0, maxChars))
+  })
+})
+
+/**
+ * SEC-04 regression: mcpContentNeedsTruncation must fail-closed when
+ * countMessagesTokensWithAPI returns null (not just when it throws).
+ */
+describe('mcpContentNeedsTruncation fail-closed on null — SEC-04 regression', () => {
+  // Inline the fixed evaluation logic without importing the full module.
+  function evaluateTokenCount(tokenCount: number | null, limit: number): boolean {
+    if (tokenCount == null) return true
+    return tokenCount > limit
+  }
+
+  test('null token count returns true (fail-closed)', () => {
+    expect(evaluateTokenCount(null, 50000)).toBe(true)
+  })
+
+  test('token count below limit returns false', () => {
+    expect(evaluateTokenCount(1000, 50000)).toBe(false)
+  })
+
+  test('token count above limit returns true', () => {
+    expect(evaluateTokenCount(60000, 50000)).toBe(true)
+  })
+
+  test('token count exactly at limit returns false', () => {
+    expect(evaluateTokenCount(50000, 50000)).toBe(false)
   })
 })

--- a/src/utils/mcpValidation.test.ts
+++ b/src/utils/mcpValidation.test.ts
@@ -12,7 +12,11 @@ const tokenState = {
 }
 
 mock.module('../services/analytics/growthbook.js', () => ({
-  getFeatureValue_CACHED_MAY_BE_STALE: () => null,
+  // Only intercept the mcpValidation flag (tengu_satin_quoll); return defaultValue
+  // for all other flags so this mock does not affect unrelated test files that
+  // import growthbook.js after this suite runs (e.g. analyzeContext, hybridContextStrategy).
+  getFeatureValue_CACHED_MAY_BE_STALE: (flag: string, defaultValue: unknown) =>
+    flag === 'tengu_satin_quoll' ? null : defaultValue,
 }))
 
 mock.module('../services/tokenEstimation.js', () => ({

--- a/src/utils/mcpValidation.test.ts
+++ b/src/utils/mcpValidation.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test'
+import { afterAll, afterEach, beforeEach, describe, expect, mock, test } from 'bun:test'
 import { mcpContentNeedsTruncation, truncateMcpContent } from './mcpValidation.js'
 
 // Mutable state shared between mock factories and test cases via closure.
@@ -102,3 +102,5 @@ describe('truncateMcpContent — SEC-05 budget invariant', () => {
     expect(result as string).toContain('[OUTPUT TRUNCATED')
   })
 })
+
+afterAll(() => mock.restore())

--- a/src/utils/mcpValidation.ts
+++ b/src/utils/mcpValidation.ts
@@ -172,8 +172,9 @@ export async function mcpContentNeedsTruncation(
     return !!(tokenCount && tokenCount > getMaxMcpOutputTokens())
   } catch (error) {
     logError(error)
-    // Assume no truncation needed on error
-    return false
+    // Fail-closed: if token count is unavailable, assume truncation is needed
+    // to prevent oversized MCP output from bypassing the token limit.
+    return true
   }
 }
 
@@ -186,11 +187,15 @@ export async function truncateMcpContent(
   const truncationMsg = getTruncationMessage()
 
   if (typeof content === 'string') {
-    return truncateString(content, maxChars) + truncationMsg
+    // Reserve space for the truncation message so total stays within maxChars.
+    const budget = Math.max(0, maxChars - truncationMsg.length)
+    return truncateString(content, budget) + truncationMsg
   } else {
+    // Same reservation for block content.
+    const budget = Math.max(0, maxChars - truncationMsg.length)
     const truncatedBlocks = await truncateContentBlocks(
       content as ContentBlockParam[],
-      maxChars,
+      budget,
     )
     truncatedBlocks.push({ type: 'text', text: truncationMsg })
     return truncatedBlocks

--- a/src/utils/mcpValidation.ts
+++ b/src/utils/mcpValidation.ts
@@ -169,7 +169,9 @@ export async function mcpContentNeedsTruncation(
         : [{ role: 'user' as const, content }]
 
     const tokenCount = await countMessagesTokensWithAPI(messages, [])
-    return !!(tokenCount && tokenCount > getMaxMcpOutputTokens())
+    // null means token count is unavailable — fail-closed (same as throw path)
+    if (tokenCount == null) return true
+    return tokenCount > getMaxMcpOutputTokens()
   } catch (error) {
     logError(error)
     // Fail-closed: if token count is unavailable, assume truncation is needed
@@ -187,12 +189,17 @@ export async function truncateMcpContent(
   const truncationMsg = getTruncationMessage()
 
   if (typeof content === 'string') {
-    // Reserve space for the truncation message so total stays within maxChars.
-    const budget = Math.max(0, maxChars - truncationMsg.length)
+    // When the notice itself exceeds the budget, return only the notice (capped).
+    if (truncationMsg.length >= maxChars) {
+      return truncationMsg.slice(0, maxChars)
+    }
+    const budget = maxChars - truncationMsg.length
     return truncateString(content, budget) + truncationMsg
   } else {
-    // Same reservation for block content.
-    const budget = Math.max(0, maxChars - truncationMsg.length)
+    if (truncationMsg.length >= maxChars) {
+      return [{ type: 'text', text: truncationMsg.slice(0, maxChars) }]
+    }
+    const budget = maxChars - truncationMsg.length
     const truncatedBlocks = await truncateContentBlocks(
       content as ContentBlockParam[],
       budget,


### PR DESCRIPTION
## Summary

Two related fixes in `src/utils/mcpValidation.ts` found during security audit (SEC-04 and SEC-05):

- **SEC-04 (fail-open on token count API error)**: `mcpContentNeedsTruncation` returned `false` on `countMessagesTokensWithAPI` failure, allowing oversized MCP output to bypass truncation entirely. Changed to fail-closed (`return true`) so content is truncated when the token count cannot be confirmed safe.

- **SEC-05 (truncation message outside budget)**: `truncateMcpContent` sliced content to `maxChars` then appended the ~200-char truncation notice, producing output larger than the declared limit. Fixed by reserving space for the message before slicing: `const budget = Math.max(0, maxChars - truncationMsg.length)`.

## Changes

- `src/utils/mcpValidation.ts` — two targeted line changes
- `src/utils/mcpValidation.test.ts` — new regression test for SEC-05 budget invariant (self-contained, no module import to avoid analytics side-effects on init)

## Test plan

- [x] `bun test src/utils/mcpValidation.test.ts` — 3/3 pass
- [x] No new TypeScript errors (verified against pre-existing baseline of 22 errors)
- [x] Full test suite: same 19 pre-existing failures, no new regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Content validation now conservatively requests truncation when token counting is unavailable or errors, preventing under-truncation.
  * Truncation logic now counts the truncation notice toward the output budget, ensuring final content plus notice never exceeds limits.

* **Tests**
  * Added tests covering token-count edge cases and strict truncation/notice budgeting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->