### PR TITLE
Streamline preset provider onboarding

### DIFF
--- a/src/components/ProviderManager.test.tsx
+++ b/src/components/ProviderManager.test.tsx
@@ -175,6 +175,7 @@ function mockProviderProfilesModule(options?: {
           baseUrl: 'http://localhost:11434/v1',
           model: 'llama3.1:8b',
           apiKey: '',
+          requiresApiKey: false,
         }
       }
 
@@ -185,6 +186,7 @@ function mockProviderProfilesModule(options?: {
           baseUrl: 'http://127.0.0.1:1337/v1',
           model: 'Qwen3_5-4B_Q4_K_M',
           apiKey: '',
+          requiresApiKey: false,
         }
       }
 
@@ -195,6 +197,29 @@ function mockProviderProfilesModule(options?: {
           baseUrl: 'http://localhost:11434/v1',
           model: 'custom-model',
           apiKey: '',
+          requiresApiKey: true,
+        }
+      }
+
+      if (preset === 'azure-openai') {
+        return {
+          provider: 'azure-openai',
+          name: 'Azure OpenAI',
+          baseUrl: 'https://YOUR-RESOURCE-NAME.openai.azure.com/openai/v1',
+          model: 'YOUR-DEPLOYMENT-NAME',
+          apiKey: '',
+          requiresApiKey: true,
+        }
+      }
+
+      if (preset === 'openai') {
+        return {
+          provider: 'openai',
+          name: 'OpenAI',
+          baseUrl: 'https://api.openai.com/v1',
+          model: 'gpt-5.4',
+          apiKey: '',
+          requiresApiKey: true,
         }
       }
 
@@ -205,6 +230,7 @@ function mockProviderProfilesModule(options?: {
           baseUrl: 'https://api.minimax.io/v1',
           model: 'MiniMax-M2.7',
           apiKey: '',
+          requiresApiKey: true,
         }
       }
 
@@ -215,6 +241,7 @@ function mockProviderProfilesModule(options?: {
           baseUrl: 'https://api.hicap.ai/v1',
           model: 'claude-opus-4.7',
           apiKey: '',
+          requiresApiKey: true,
         }
       }
 
@@ -224,6 +251,7 @@ function mockProviderProfilesModule(options?: {
         baseUrl: 'http://localhost:11434/v1',
         model: 'mock-model',
         apiKey: '',
+        requiresApiKey: true,
       }
     },
     getProviderProfiles: options?.getProviderProfiles ?? (() => []),
@@ -598,7 +626,171 @@ test('ProviderManager shows API mode picker for custom OpenAI-compatible provide
   }
 })
 
-test('ProviderManager skips advanced auth fields when adding MiniMax', async () => {
+test('ProviderManager keeps full setup flow for presets with placeholder endpoint defaults', async () => {
+  mockProviderManagerDependencies(() => undefined, async () => undefined)
+
+  const nonce = `${Date.now()}-${Math.random()}`
+  const { ProviderManager } = await import(`./ProviderManager.js?ts=${nonce}`)
+  const mounted = await mountProviderManager(ProviderManager)
+
+  try {
+    await waitForFrameOutput(mounted.getOutput, frame =>
+      frame.includes('Provider manager'),
+    )
+
+    mounted.stdin.write('\r')
+    await waitForFrameOutput(mounted.getOutput, frame =>
+      frame.includes('Choose provider preset'),
+    )
+
+    await navigateToPreset(mounted.stdin, 'Azure OpenAI')
+    mounted.stdin.write('\r')
+    const nameOutput = await waitForFrameOutput(mounted.getOutput, frame =>
+      frame.includes('Create provider profile') &&
+      frame.includes('Provider name'),
+    )
+
+    expect(nameOutput).toContain('Azure OpenAI')
+    expect(nameOutput).not.toContain('Step 1 of 2: Default model')
+
+    mounted.stdin.write('\r')
+    const baseUrlOutput = await waitForFrameOutput(mounted.getOutput, frame =>
+      frame.includes('Base URL'),
+    )
+    expect(baseUrlOutput).toContain('YOUR-RESOURCE-NAME')
+  } finally {
+    await mounted.dispose()
+  }
+})
+
+test('ProviderManager asks for model and API key when adding OpenAI preset', async () => {
+  const addProviderProfile = mock((payload: any) => ({
+    id: 'openai_profile',
+    ...payload,
+  }))
+
+  mockProviderManagerDependencies(() => undefined, async () => undefined, {
+    addProviderProfile,
+  })
+
+  const nonce = `${Date.now()}-${Math.random()}`
+  const { ProviderManager } = await import(`./ProviderManager.js?ts=${nonce}`)
+  const mounted = await mountProviderManager(ProviderManager)
+
+  try {
+    await waitForFrameOutput(mounted.getOutput, frame =>
+      frame.includes('Provider manager'),
+    )
+
+    mounted.stdin.write('\r')
+    await waitForFrameOutput(mounted.getOutput, frame =>
+      frame.includes('Choose provider preset'),
+    )
+
+    await navigateToPreset(mounted.stdin, 'OpenAI')
+    mounted.stdin.write('\r')
+    const modelOutput = await waitForFrameOutput(mounted.getOutput, frame =>
+      frame.includes('Create provider profile') &&
+      frame.includes('Step 1 of 2: Default model'),
+    )
+
+    expect(modelOutput).toContain('OpenAI')
+    expect(modelOutput).toContain('gpt-5.4')
+    expect(modelOutput).not.toContain('Provider name')
+    expect(modelOutput).not.toContain('Base URL')
+    expect(modelOutput).not.toContain('API mode')
+    expect(modelOutput).not.toContain('Custom headers')
+
+    mounted.stdin.write('\r')
+    const keyOutput = await waitForFrameOutput(mounted.getOutput, frame =>
+      frame.includes('Step 2 of 2: API key'),
+    )
+    expect(keyOutput).not.toContain('Provider name')
+    expect(keyOutput).not.toContain('Base URL')
+    expect(keyOutput).not.toContain('API mode')
+    expect(keyOutput).not.toContain('Custom headers')
+
+    mounted.stdin.write('sk-openai-test')
+    await Bun.sleep(25)
+    mounted.stdin.write('\r')
+
+    await waitForCondition(() => addProviderProfile.mock.calls.length > 0)
+    expect(addProviderProfile).toHaveBeenCalledWith(
+      expect.objectContaining({
+        provider: 'openai',
+        name: 'OpenAI',
+        baseUrl: 'https://api.openai.com/v1',
+        model: 'gpt-5.4',
+        apiKey: 'sk-openai-test',
+        apiFormat: 'responses',
+      }),
+      expect.objectContaining({ makeActive: true }),
+    )
+  } finally {
+    await mounted.dispose()
+  }
+})
+
+test('ProviderManager saves OpenAI preset GPT-5 models with Responses API', async () => {
+  const addProviderProfile = mock((payload: any) => ({
+    id: 'openai_profile',
+    ...payload,
+  }))
+
+  mockProviderManagerDependencies(() => undefined, async () => undefined, {
+    addProviderProfile,
+  })
+
+  const nonce = `${Date.now()}-${Math.random()}`
+  const { ProviderManager } = await import(`./ProviderManager.js?ts=${nonce}`)
+  const mounted = await mountProviderManager(ProviderManager)
+
+  try {
+    await waitForFrameOutput(mounted.getOutput, frame =>
+      frame.includes('Provider manager'),
+    )
+
+    mounted.stdin.write('\r')
+    await waitForFrameOutput(mounted.getOutput, frame =>
+      frame.includes('Choose provider preset'),
+    )
+
+    await navigateToPreset(mounted.stdin, 'OpenAI')
+    mounted.stdin.write('\r')
+    await waitForFrameOutput(mounted.getOutput, frame =>
+      frame.includes('Step 1 of 2: Default model'),
+    )
+
+    mounted.stdin.write('\u0015')
+    await Bun.sleep(25)
+    mounted.stdin.write('gpt-5.5')
+    await waitForFrameOutput(mounted.getOutput, frame =>
+      frame.includes('gpt-5.5'),
+    )
+    mounted.stdin.write('\r')
+    await waitForFrameOutput(mounted.getOutput, frame =>
+      frame.includes('Step 2 of 2: API key'),
+    )
+
+    mounted.stdin.write('sk-openai-test')
+    await Bun.sleep(25)
+    mounted.stdin.write('\r')
+
+    await waitForCondition(() => addProviderProfile.mock.calls.length > 0)
+    expect(addProviderProfile).toHaveBeenCalledWith(
+      expect.objectContaining({
+        provider: 'openai',
+        model: 'gpt-5.5',
+        apiFormat: 'responses',
+      }),
+      expect.objectContaining({ makeActive: true }),
+    )
+  } finally {
+    await mounted.dispose()
+  }
+})
+
+test('ProviderManager skips advanced setup fields when adding MiniMax preset', async () => {
   mockProviderManagerDependencies(() => undefined, async () => undefined)
 
   const nonce = `${Date.now()}-${Math.random()}`
@@ -617,44 +809,41 @@ test('ProviderManager skips advanced auth fields when adding MiniMax', async () 
 
     await navigateToPreset(mounted.stdin, 'MiniMax')
     mounted.stdin.write('\r')
-    await waitForFrameOutput(mounted.getOutput, frame =>
+    const modelOutput = await waitForFrameOutput(mounted.getOutput, frame =>
       frame.includes('Create provider profile') &&
-      frame.includes('Provider name'),
+      frame.includes('Step 1 of 2: Default model'),
     )
 
-    mounted.stdin.write('\r')
-    await waitForFrameOutput(mounted.getOutput, frame =>
-      frame.includes('Base URL'),
-    )
-    mounted.stdin.write('\r')
-    await waitForFrameOutput(mounted.getOutput, frame =>
-      frame.includes('Default model'),
-    )
-    mounted.stdin.write('\r')
+    expect(modelOutput).toContain('MiniMax')
+    expect(modelOutput).toContain('MiniMax-M2.7')
+    expect(modelOutput).not.toContain('Provider name')
+    expect(modelOutput).not.toContain('Base URL')
+    expect(modelOutput).not.toContain('API mode')
+    expect(modelOutput).not.toContain('Auth header')
+    expect(modelOutput).not.toContain('Custom headers')
 
-    const output = await waitForFrameOutput(mounted.getOutput, frame =>
-      frame.includes('API key'),
+    mounted.stdin.write('\r')
+    const keyOutput = await waitForFrameOutput(mounted.getOutput, frame =>
+      frame.includes('Step 2 of 2: API key'),
     )
-    expect(output).not.toContain('API mode')
-    expect(output).not.toContain('Auth header')
-    expect(output).not.toContain('Custom headers')
+    expect(keyOutput).not.toContain('Provider name')
+    expect(keyOutput).not.toContain('Base URL')
+    expect(keyOutput).not.toContain('API mode')
+    expect(keyOutput).not.toContain('Auth header')
+    expect(keyOutput).not.toContain('Custom headers')
   } finally {
     await mounted.dispose()
   }
 })
 
-test('ProviderManager explains when Hicap non-gpt responses mode is saved as chat completions', async () => {
+test('ProviderManager saves Hicap preset non-GPT model with Chat Completions', async () => {
+  const addProviderProfile = mock((payload: any) => ({
+    id: 'hicap_profile',
+    ...payload,
+  }))
+
   mockProviderManagerDependencies(() => undefined, async () => undefined, {
-    addProviderProfile: (payload: any) => ({
-      id: 'hicap_profile',
-      ...payload,
-      apiFormat:
-        payload.provider === 'hicap' &&
-        payload.model === 'claude-opus-4.7' &&
-        payload.apiFormat === 'responses'
-          ? 'chat_completions'
-          : payload.apiFormat,
-    }),
+    addProviderProfile,
   })
 
   const nonce = `${Date.now()}-${Math.random()}`
@@ -673,41 +862,30 @@ test('ProviderManager explains when Hicap non-gpt responses mode is saved as cha
 
     await navigateToPreset(mounted.stdin, 'Hicap')
     mounted.stdin.write('\r')
-    await waitForFrameOutput(mounted.getOutput, frame =>
-      frame.includes('Provider name'),
+    const modelOutput = await waitForFrameOutput(mounted.getOutput, frame =>
+      frame.includes('Step 1 of 2: Default model'),
     )
+
+    expect(modelOutput).toContain('Hicap')
+    expect(modelOutput).toContain('claude-opus-4.7')
 
     mounted.stdin.write('\r')
     await waitForFrameOutput(mounted.getOutput, frame =>
-      frame.includes('Base URL'),
+      frame.includes('Step 2 of 2: API key'),
     )
-    mounted.stdin.write('\r')
-    await waitForFrameOutput(mounted.getOutput, frame =>
-      frame.includes('Default model'),
-    )
-    mounted.stdin.write('\r')
-    await waitForFrameOutput(mounted.getOutput, frame =>
-      frame.includes('API mode'),
-    )
-
-    mounted.stdin.write('j')
+    mounted.stdin.write('hicap-test-key')
     await Bun.sleep(25)
     mounted.stdin.write('\r')
-    const apiKeyOutput = await waitForFrameOutput(mounted.getOutput, frame =>
-      frame.includes('Step 5 of 6: API key'),
-    )
-    expect(apiKeyOutput).not.toContain('Auth header')
-    expect(apiKeyOutput).not.toContain('Auth header value')
-    mounted.stdin.write('\r')
-    await waitForFrameOutput(mounted.getOutput, frame =>
-      frame.includes('Step 6 of 6: Custom headers'),
-    )
-    mounted.stdin.write('\r')
 
-    const output = await waitForFrameOutput(mounted.getOutput, frame =>
-      frame.includes('Hicap only supports the Responses API for gpt- models'),
+    await waitForCondition(() => addProviderProfile.mock.calls.length > 0)
+    expect(addProviderProfile).toHaveBeenCalledWith(
+      expect.objectContaining({
+        provider: 'hicap',
+        model: 'claude-opus-4.7',
+        apiFormat: 'chat_completions',
+      }),
+      expect.objectContaining({ makeActive: true }),
     )
-    expect(output).toMatch(/saved\s+using Chat Completions/)
   } finally {
     await mounted.dispose()
   }

--- a/src/components/ProviderManager.tsx
+++ b/src/components/ProviderManager.tsx
@@ -2,6 +2,7 @@ import figures from 'figures'
 import * as React from 'react'
 import { DEFAULT_CODEX_BASE_URL } from '../services/api/providerConfig.js'
 import { Box, Text } from '../ink.js'
+import { useTerminalSize } from '../hooks/useTerminalSize.js'
 import { useKeybinding } from '../keybindings/useKeybinding.js'
 import { useSetAppState } from '../state/AppState.js'
 import type { ProviderProfile } from '../utils/config.js'
@@ -95,6 +96,8 @@ type Screen =
   | 'select-atomic-chat-model'
   | 'codex-oauth'
   | 'form'
+  | 'preset-model'
+  | 'preset-api-key'
   | 'select-active'
   | 'select-edit'
   | 'select-delete'
@@ -227,6 +230,16 @@ function presetToDraft(preset: ProviderPreset): ProviderDraft {
     authHeaderValue: '',
     customHeaders: '',
   }
+}
+
+function isSetupPlaceholder(value: string): boolean {
+  return /\bYOUR[-_\s]/i.test(value) || /<[^>]+>/.test(value)
+}
+
+function canUseStreamlinedPresetFlow(draft: ProviderDraft): boolean {
+  // Descriptor placeholder defaults mean the endpoint/model are user-specific,
+  // so those presets still need the full setup form.
+  return !isSetupPlaceholder(draft.baseUrl) && !isSetupPlaceholder(draft.model)
 }
 
 function profileSummary(profile: ProviderProfile, isActive: boolean): string {
@@ -483,6 +496,8 @@ function CodexOAuthSetup({
 }
 
 export function ProviderManager({ mode, onDone }: Props): React.ReactNode {
+  const { columns: terminalColumns } = useTerminalSize()
+  const inputColumns = Math.max(20, Math.min(80, terminalColumns - 4))
   const setAppState = useSetAppState()
   const initialGithubCredentialSource = getGithubCredentialSourceFromEnv()
   const initialIsGithubActive = isEnvTruthy(process.env.CLAUDE_CODE_USE_GITHUB)
@@ -515,6 +530,7 @@ export function ProviderManager({ mode, onDone }: Props): React.ReactNode {
   const [draft, setDraft] = React.useState<ProviderDraft>(() =>
     presetToDraft('ollama'),
   )
+  const [presetRequiresApiKey, setPresetRequiresApiKey] = React.useState(false)
   const [formStepIndex, setFormStepIndex] = React.useState(0)
   const [cursorOffset, setCursorOffset] = React.useState(0)
   const [statusMessage, setStatusMessage] = React.useState<string | undefined>()
@@ -1086,6 +1102,7 @@ export function ProviderManager({ mode, onDone }: Props): React.ReactNode {
 
   function startCreateFromPreset(preset: ProviderPreset): void {
     const defaults = getProviderPresetDefaults(preset)
+    const provider = defaults.provider ?? 'openai'
     const nextDraft = {
       name: defaults.name,
       baseUrl: defaults.baseUrl,
@@ -1097,8 +1114,9 @@ export function ProviderManager({ mode, onDone }: Props): React.ReactNode {
       customHeaders: '',
     }
     setEditingProfileId(null)
-    setDraftProvider(defaults.provider ?? 'openai')
+    setDraftProvider(provider)
     setDraft(nextDraft)
+    setPresetRequiresApiKey(defaults.requiresApiKey)
     setFormStepIndex(0)
     setCursorOffset(nextDraft.name.length)
     setErrorMessage(undefined)
@@ -1115,7 +1133,13 @@ export function ProviderManager({ mode, onDone }: Props): React.ReactNode {
       return
     }
 
-    setScreen('form')
+    if (preset === 'custom' || !canUseStreamlinedPresetFlow(nextDraft)) {
+      setScreen('form')
+      return
+    }
+
+    setCursorOffset(nextDraft.model.length)
+    setScreen('preset-model')
   }
 
   function startEditProfile(profileId: string): void {
@@ -1128,14 +1152,19 @@ export function ProviderManager({ mode, onDone }: Props): React.ReactNode {
     setEditingProfileId(profileId)
     setDraftProvider(existing.provider ?? 'openai')
     setDraft(nextDraft)
+    setPresetRequiresApiKey(false)
     setFormStepIndex(0)
     setCursorOffset(nextDraft.name.length)
     setErrorMessage(undefined)
     setScreen('form')
   }
 
-  function persistDraft(nextDraft: ProviderDraft = draft): void {
-    const routeId = resolveProviderEditorRouteId(draftProvider, nextDraft.baseUrl)
+  function persistDraft(
+    nextDraft: ProviderDraft = draft,
+    provider: ProviderProfile['provider'] = draftProvider,
+    profileId: string | null = editingProfileId,
+  ): void {
+    const routeId = resolveProviderEditorRouteId(provider, nextDraft.baseUrl)
     const supportsApiFormat = routeSupportsApiFormatSelection(routeId)
     const showsAuthHeader = routeShowsAuthHeader(routeId)
     const showsAuthHeaderValue = routeShowsAuthHeaderValue(routeId)
@@ -1155,7 +1184,7 @@ export function ProviderManager({ mode, onDone }: Props): React.ReactNode {
       nextDraft.apiFormat !== 'responses' ||
       !routeSupportsResponsesModel(routeId, nextDraft.model)
     const payload: ProviderProfileInput = {
-      provider: draftProvider,
+      provider,
       name: nextDraft.name,
       baseUrl: nextDraft.baseUrl,
       model: nextDraft.model,
@@ -1180,8 +1209,8 @@ export function ProviderManager({ mode, onDone }: Props): React.ReactNode {
           : undefined,
     }
 
-    const saved = editingProfileId
-      ? updateProviderProfile(editingProfileId, payload)
+    const saved = profileId
+      ? updateProviderProfile(profileId, payload)
       : addProviderProfile(payload, { makeActive: true })
 
     if (!saved) {
@@ -1203,7 +1232,7 @@ export function ProviderManager({ mode, onDone }: Props): React.ReactNode {
 
     refreshProfiles()
     const successMessage =
-      editingProfileId
+      profileId
         ? `Updated provider: ${saved.name}`
         : `Added provider: ${saved.name} (now active)`
     const adjustedApiFormat =
@@ -1234,6 +1263,23 @@ export function ProviderManager({ mode, onDone }: Props): React.ReactNode {
     setFormStepIndex(0)
     setErrorMessage(undefined)
     returnToMenu()
+  }
+
+  function applyPresetApiFormat(
+    nextDraft: ProviderDraft,
+    provider: ProviderProfile['provider'],
+  ): ProviderDraft {
+    const routeId = resolveProviderEditorRouteId(provider, nextDraft.baseUrl)
+    const apiFormat =
+      routeSupportsApiFormatSelection(routeId) &&
+      routeSupportsResponsesModel(routeId, nextDraft.model)
+        ? 'responses'
+        : 'chat_completions'
+
+    return {
+      ...nextDraft,
+      apiFormat,
+    }
   }
 
   function renderAtomicChatSelection(): React.ReactNode {
@@ -1444,6 +1490,27 @@ export function ProviderManager({ mode, onDone }: Props): React.ReactNode {
     isActive: screen === 'form',
   })
 
+  function handleBackFromPresetModel(): void {
+    setErrorMessage(undefined)
+    setScreen('select-preset')
+  }
+
+  useKeybinding('confirm:no', handleBackFromPresetModel, {
+    context: 'Settings',
+    isActive: screen === 'preset-model',
+  })
+
+  function handleBackFromPresetApiKey(): void {
+    setErrorMessage(undefined)
+    setCursorOffset(draft.model.length)
+    setScreen('preset-model')
+  }
+
+  useKeybinding('confirm:no', handleBackFromPresetApiKey, {
+    context: 'Settings',
+    isActive: screen === 'preset-api-key',
+  })
+
   function renderPresetSelection(): React.ReactNode {
     const canUseCodexOAuth = !isBareMode()
     const options: OptionWithDescription<string>[] = ORDERED_PROVIDER_PRESETS.map(preset => {
@@ -1483,7 +1550,7 @@ export function ProviderManager({ mode, onDone }: Props): React.ReactNode {
           {mode === 'first-run' ? 'Set up provider' : 'Choose provider preset'}
         </Text>
         <Text dimColor>
-          Pick a preset, then confirm base URL, model, and API key.
+          Pick a preset, then complete the details it needs.
         </Text>
         <Select
           options={options}
@@ -1576,7 +1643,7 @@ export function ProviderManager({ mode, onDone }: Props): React.ReactNode {
                   ? '*'
                   : undefined
               }
-              columns={80}
+              columns={inputColumns}
               cursorOffset={cursorOffset}
               onChangeCursorOffset={setCursorOffset}
             />
@@ -1585,6 +1652,136 @@ export function ProviderManager({ mode, onDone }: Props): React.ReactNode {
         {errorMessage && <Text color="error">{errorMessage}</Text>}
         <Text dimColor>
           Press Enter to continue. Press Esc to go back.
+        </Text>
+      </Box>
+    )
+  }
+
+  function renderPresetModel(): React.ReactNode {
+    const needsApiKey = presetRequiresApiKey && !draft.apiKey.trim()
+
+    return (
+      <Box flexDirection="column" gap={1}>
+        <Text color="remember" bold>
+          Create provider profile
+        </Text>
+        <Text dimColor>
+          Choose the default model for {draft.name}. Endpoint and advanced
+          details are already configured by the preset.
+        </Text>
+        <Text dimColor>
+          Provider type:{' '}
+          {getRouteProviderTypeLabel(resolveProfileRoute(draftProvider).routeId)}
+        </Text>
+        <Text dimColor>
+          Step 1 of {needsApiKey ? 2 : 1}: Default model
+        </Text>
+        <Box flexDirection="row" gap={1}>
+          <Text>{figures.pointer}</Text>
+          <TextInput
+            value={draft.model}
+            onChange={value =>
+              setDraft(prev => ({
+                ...prev,
+                model: value,
+              }))
+            }
+            onSubmit={value => {
+              const model = value.trim()
+              if (!model) {
+                setErrorMessage('Default model is required.')
+                return
+              }
+
+              const nextDraft = applyPresetApiFormat(
+                {
+                  ...draft,
+                  model,
+                },
+                draftProvider,
+              )
+              setDraft(nextDraft)
+              setErrorMessage(undefined)
+
+              if (needsApiKey) {
+                setCursorOffset(0)
+                setScreen('preset-api-key')
+                return
+              }
+
+              persistDraft(nextDraft, draftProvider, null)
+            }}
+            focus={true}
+            showCursor={true}
+            placeholder={`Enter model${figures.ellipsis}`}
+            columns={inputColumns}
+            cursorOffset={cursorOffset}
+            onChangeCursorOffset={setCursorOffset}
+          />
+        </Box>
+        {errorMessage && <Text color="error">{errorMessage}</Text>}
+        <Text dimColor>
+          Press Enter to continue. Press Esc to go back.
+        </Text>
+      </Box>
+    )
+  }
+
+  function renderPresetApiKey(): React.ReactNode {
+    return (
+      <Box flexDirection="column" gap={1}>
+        <Text color="remember" bold>
+          Create provider profile
+        </Text>
+        <Text dimColor>
+          Enter the API key for {draft.name}. Other preset details are already
+          configured.
+        </Text>
+        <Text dimColor>
+          Provider type:{' '}
+          {getRouteProviderTypeLabel(resolveProfileRoute(draftProvider).routeId)}
+        </Text>
+        <Text dimColor>Step 2 of 2: API key</Text>
+        <Box flexDirection="row" gap={1}>
+          <Text>{figures.pointer}</Text>
+          <TextInput
+            value={draft.apiKey}
+            onChange={value =>
+              setDraft(prev => ({
+                ...prev,
+                apiKey: value,
+              }))
+            }
+            onSubmit={value => {
+              const apiKey = value.trim()
+              if (!apiKey) {
+                setErrorMessage(`API key is required for ${draft.name}.`)
+                return
+              }
+
+              const nextDraft = applyPresetApiFormat(
+                {
+                  ...draft,
+                  apiKey,
+                },
+                draftProvider,
+              )
+              setDraft(nextDraft)
+              setErrorMessage(undefined)
+              persistDraft(nextDraft, draftProvider, null)
+            }}
+            focus={true}
+            showCursor={true}
+            placeholder={`Enter API key${figures.ellipsis}`}
+            mask="*"
+            columns={inputColumns}
+            cursorOffset={cursorOffset}
+            onChangeCursorOffset={setCursorOffset}
+          />
+        </Box>
+        {errorMessage && <Text color="error">{errorMessage}</Text>}
+        <Text dimColor>
+          Press Enter to save. Press Esc to go back.
         </Text>
       </Box>
     )
@@ -1861,6 +2058,12 @@ export function ProviderManager({ mode, onDone }: Props): React.ReactNode {
       break
     case 'form':
       content = renderForm()
+      break
+    case 'preset-model':
+      content = renderPresetModel()
+      break
+    case 'preset-api-key':
+      content = renderPresetApiKey()
       break
     case 'select-active':
       content = renderProfileSelection(

--- a/src/utils/providerProfiles.test.ts
+++ b/src/utils/providerProfiles.test.ts
@@ -1098,6 +1098,22 @@ describe('getProviderPresetDefaults', () => {
     expect(defaults.requiresApiKey).toBe(true)
   })
 
+  test('xai preset ignores stale generic OpenAI model when creating defaults', async () => {
+    const { getProviderPresetDefaults } = await importFreshProviderProfileModules()
+    process.env.OPENAI_MODEL = 'gpt-5.4'
+    process.env.OPENAI_BASE_URL = 'https://api.openai.com/v1'
+    process.env.XAI_API_KEY = 'xai-live-key'
+
+    const defaults = getProviderPresetDefaults('xai')
+
+    expect(defaults.provider).toBe('xai')
+    expect(defaults.name).toBe('xAI')
+    expect(defaults.baseUrl).toBe('https://api.x.ai/v1')
+    expect(defaults.model).toBe('grok-4.3')
+    expect(defaults.apiKey).toBe('xai-live-key')
+    expect(defaults.requiresApiKey).toBe(true)
+  })
+
   test('zai preset defaults to Z.AI GLM Coding Plan endpoint', async () => {
     const { getProviderPresetDefaults } = await importFreshProviderProfileModules()
 

--- a/src/utils/providerProfiles.ts
+++ b/src/utils/providerProfiles.ts
@@ -284,11 +284,17 @@ export function getProviderPresetDefaults(
   preset: ProviderPreset,
 ): ProviderPresetDefaults {
   const metadata = getProviderPresetUiMetadata(preset)
+  // Keep preset-pinned endpoints/models even when generic OpenAI env values
+  // are present, but still read provider-specific credential env vars above.
+  const routeDefaults =
+    preset === 'custom'
+      ? metadata
+      : getProviderPresetUiMetadata(preset, {})
   return {
     provider: metadata.provider,
     name: metadata.name,
-    baseUrl: metadata.baseUrl,
-    model: metadata.model,
+    baseUrl: routeDefaults.baseUrl,
+    model: routeDefaults.model,
     apiKey: metadata.apiKey,
     requiresApiKey: metadata.requiresApiKey,
   }


### PR DESCRIPTION
## Summary
- skip provider name, base URL, API mode, auth header, and custom header prompts for known provider presets
- keep model selection and required API key entry for known presets
- keep the full advanced setup flow for Custom providers
- prevent xAI and other known presets from inheriting stale generic OpenAI endpoint/model defaults

## Verification
- bun test src/components/ProviderManager.test.tsx src/utils/providerProfiles.test.ts src/integrations/routeMetadata.test.ts src/integrations/index.test.ts
