### PR TITLE
fix(codex): normalize empty MCP object schemas

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ web/*.tsbuildinfo
 .env
 .env.*
 !.env.example
+auth.json
 .openclaude-profile.json
 .openclaude/
 reports/

--- a/src/services/api/codexShim.test.ts
+++ b/src/services/api/codexShim.test.ts
@@ -505,6 +505,26 @@ describe('Codex request translation', () => {
     expect(valueSchema.description).toBe('Any JSON value')
   })
 
+  test('drops orphan required keys when Ruflo MCP schema has no properties', () => {
+    const tools = convertToolsToResponsesTools([
+      {
+        name: 'mcp__ruflo__daa_workflow_create',
+        description: 'Create a Ruflo DAA workflow',
+        input_schema: {
+          type: 'object',
+          required: ['steps'],
+        },
+      },
+    ])
+
+    expect(tools[0].parameters).toEqual({
+      type: 'object',
+      properties: {},
+      required: [],
+      additionalProperties: false,
+    })
+  })
+
   test('infers object type for untyped schemas with nested properties', () => {
     const tools = convertToolsToResponsesTools([
       {

--- a/src/services/api/codexShim.test.ts
+++ b/src/services/api/codexShim.test.ts
@@ -481,6 +481,109 @@ describe('Codex request translation', () => {
     ])
   })
 
+  test('defaults untyped MCP tool properties to string for Codex strict mode (issue #1114)', () => {
+    // Repro from issue #1114: MCP server (Ruflo) registers a `value` parameter
+    // with no `type`, which makes Codex strict mode 400 with
+    // "schema must have a 'type' key".
+    const tools = convertToolsToResponsesTools([
+      {
+        name: 'mcp__ruflo__config_set',
+        description: 'Set a Ruflo config value',
+        input_schema: {
+          type: 'object',
+          properties: {
+            key: { type: 'string' },
+            value: { description: 'Any JSON value' },
+          },
+          required: ['key', 'value'],
+        },
+      },
+    ])
+
+    const valueSchema = (tools[0].parameters as Record<string, Record<string, Record<string, unknown>>>).properties.value
+    expect(valueSchema.type).toBe('string')
+    expect(valueSchema.description).toBe('Any JSON value')
+  })
+
+  test('infers object type for untyped schemas with nested properties', () => {
+    const tools = convertToolsToResponsesTools([
+      {
+        name: 'mcp__nest__call',
+        input_schema: {
+          type: 'object',
+          properties: {
+            payload: {
+              properties: { name: { type: 'string' } },
+            },
+          },
+        },
+      },
+    ])
+
+    const payload = (tools[0].parameters as Record<string, Record<string, Record<string, unknown>>>).properties.payload
+    expect(payload.type).toBe('object')
+  })
+
+  test('infers array type for untyped schemas with items', () => {
+    const tools = convertToolsToResponsesTools([
+      {
+        name: 'mcp__list__call',
+        input_schema: {
+          type: 'object',
+          properties: {
+            tags: { items: { type: 'string' } },
+          },
+        },
+      },
+    ])
+
+    const tags = (tools[0].parameters as Record<string, Record<string, Record<string, unknown>>>).properties.tags
+    expect(tags.type).toBe('array')
+  })
+
+  test('infers type from enum values when type is missing', () => {
+    const tools = convertToolsToResponsesTools([
+      {
+        name: 'mcp__enum__call',
+        input_schema: {
+          type: 'object',
+          properties: {
+            mode: { enum: ['fast', 'slow'] },
+            level: { enum: [1, 2, 3] },
+            ratio: { enum: [0.5, 1.5] },
+            flag: { enum: [true, false] },
+          },
+        },
+      },
+    ])
+
+    const props = (tools[0].parameters as Record<string, Record<string, Record<string, unknown>>>).properties
+    expect(props.mode.type).toBe('string')
+    expect(props.level.type).toBe('integer')
+    expect(props.ratio.type).toBe('number')
+    expect(props.flag.type).toBe('boolean')
+  })
+
+  test('leaves combinator-only schemas untyped to preserve alternatives', () => {
+    const tools = convertToolsToResponsesTools([
+      {
+        name: 'mcp__combo__call',
+        input_schema: {
+          type: 'object',
+          properties: {
+            either: {
+              anyOf: [{ type: 'string' }, { type: 'number' }],
+            },
+          },
+        },
+      },
+    ])
+
+    const either = (tools[0].parameters as Record<string, Record<string, Record<string, unknown>>>).properties.either
+    expect(either.type).toBeUndefined()
+    expect(either.anyOf).toEqual([{ type: 'string' }, { type: 'number' }])
+  })
+
   test('converts assistant tool use and user tool result into Responses items', () => {
     const items = convertAnthropicMessagesToResponsesInput([
       {

--- a/src/services/api/codexShim.ts
+++ b/src/services/api/codexShim.ts
@@ -394,7 +394,6 @@ function enforceStrictSchema(schema: unknown): Record<string, unknown> {
       !Array.isArray(record.properties)
     ) {
       const props = record.properties as Record<string, unknown>
-      const allKeys = Object.keys(props)
 
       const enforcedProps: Record<string, unknown> = {}
       for (const [key, value] of Object.entries(props)) {
@@ -417,7 +416,8 @@ function enforceStrictSchema(schema: unknown): Record<string, unknown> {
       record.properties = enforcedProps
       record.required = Object.keys(enforcedProps)
     } else {
-      // No properties — empty required array
+      // No properties — empty object schema with empty required array
+      record.properties = {}
       record.required = []
     }
   }

--- a/src/services/api/codexShim.ts
+++ b/src/services/api/codexShim.ts
@@ -310,6 +310,63 @@ export function convertAnthropicMessagesToResponsesInput(
 }
 
 /**
+ * Codex Responses strict mode requires every schema node to declare a `type`.
+ * MCP tools sometimes register properties with no `type` (e.g. a generic
+ * `value` parameter intended to accept any JSON), which triggers a 400 from
+ * the Responses API: `schema must have a 'type' key`. Infer one from sibling
+ * keys, fall back to `string` for fully empty nodes, and leave combinator-only
+ * schemas alone (their branches carry the real type info).
+ */
+function ensureSchemaType(record: Record<string, unknown>): void {
+  const raw = record.type
+  if (typeof raw === 'string') return
+  if (Array.isArray(raw) && raw.length > 0) return
+
+  if (record.properties && typeof record.properties === 'object') {
+    record.type = 'object'
+    return
+  }
+  if ('items' in record) {
+    record.type = 'array'
+    return
+  }
+  if (Array.isArray((record as Record<string, unknown>).anyOf) ||
+      Array.isArray((record as Record<string, unknown>).oneOf) ||
+      Array.isArray((record as Record<string, unknown>).allOf)) {
+    // Combinator-only schemas keep their semantics; forcing a `type` here
+    // would silently narrow the alternatives.
+    return
+  }
+  if (Array.isArray(record.enum) && record.enum.length > 0) {
+    const sample = typeof record.enum[0]
+    if (sample === 'string' || sample === 'boolean') {
+      record.type = sample
+      return
+    }
+    if (sample === 'number') {
+      record.type = record.enum.every(v => Number.isInteger(v)) ? 'integer' : 'number'
+      return
+    }
+  }
+  if ('const' in record) {
+    const sample = typeof record.const
+    if (sample === 'string' || sample === 'boolean') {
+      record.type = sample
+      return
+    }
+    if (sample === 'number') {
+      record.type = Number.isInteger(record.const) ? 'integer' : 'number'
+      return
+    }
+  }
+
+  // Permissive default: strict mode demands a concrete type, and `string`
+  // round-trips through JSON.stringify for callers that need to forward raw
+  // values to the underlying tool.
+  record.type = 'string'
+}
+
+/**
  * Recursively enforces Codex strict-mode constraints on a JSON schema:
  * - Every `object` type gets `additionalProperties: false`
  * - All property keys are listed in `required`
@@ -317,6 +374,8 @@ export function convertAnthropicMessagesToResponsesInput(
  */
 function enforceStrictSchema(schema: unknown): Record<string, unknown> {
   const record = sanitizeSchemaForOpenAICompat(schema)
+
+  ensureSchemaType(record)
 
   // Codex Responses rejects JSON Schema's standard `uri` string format.
   // Keep URL validation in the tool layer and send a plain string here.


### PR DESCRIPTION
## Summary
- Normalize Codex strict schemas for MCP object tools that provide `required` keys without `properties`.
- Emit explicit empty `properties: {}` and `required: []` for empty object schemas.
- Add `auth.json` to `.gitignore` and cover the Ruflo `daa_workflow_create` regression.

Related to #1114

## Test plan
- [x] `bun test src/services/api/codexShim.test.ts`