### PR TITLE
Migrate legacy config home to .openclaude

### DIFF
--- a/src/components/permissions/FilePermissionDialog/permissionOptions.tsx
+++ b/src/components/permissions/FilePermissionDialog/permissionOptions.tsx
@@ -28,16 +28,20 @@ export function isInClaudeFolder(filePath: string): boolean {
 }
 
 /**
- * Check if a path is within the global ~/.claude/ folder.
+ * Check if a path is within the global ~/.openclaude/ folder, or the legacy
+ * ~/.claude/ folder during migration.
  * This is used to determine whether to show the special ".claude folder" permission option
  * for files in the user's home directory.
  */
 export function isInGlobalClaudeFolder(filePath: string): boolean {
   const absolutePath = expandPath(filePath);
-  const globalClaudeFolderPath = join(homedir(), '.claude');
   const normalizedAbsolutePath = normalizeCaseForComparison(absolutePath);
-  const normalizedGlobalClaudeFolderPath = normalizeCaseForComparison(globalClaudeFolderPath);
-  return normalizedAbsolutePath.startsWith(normalizedGlobalClaudeFolderPath + sep.toLowerCase()) || normalizedAbsolutePath.startsWith(normalizedGlobalClaudeFolderPath + '/');
+  const globalClaudeFolderPaths = [join(homedir(), '.openclaude'), join(homedir(), '.claude')];
+
+  return globalClaudeFolderPaths.some(globalClaudeFolderPath => {
+    const normalizedGlobalClaudeFolderPath = normalizeCaseForComparison(globalClaudeFolderPath);
+    return normalizedAbsolutePath.startsWith(normalizedGlobalClaudeFolderPath + sep.toLowerCase()) || normalizedAbsolutePath.startsWith(normalizedGlobalClaudeFolderPath + '/');
+  });
 }
 export type PermissionOption = {
   type: 'accept-once';

--- a/src/components/skills/SkillsMenu.tsx
+++ b/src/components/skills/SkillsMenu.tsx
@@ -106,7 +106,7 @@ export function SkillsMenu(t0) {
   if (skills.length === 0) {
     let t3;
     if ($[6] === Symbol.for("react.memo_cache_sentinel")) {
-      t3 = <FullWidthRow><Text dimColor={true}>Create skills in .claude/skills/ or ~/.claude/skills/</Text></FullWidthRow>;
+      t3 = <FullWidthRow><Text dimColor={true}>Create skills in .claude/skills/&lt;name&gt;/SKILL.md or ~/.openclaude/skills/&lt;name&gt;/SKILL.md</Text></FullWidthRow>;
       $[6] = t3;
     } else {
       t3 = $[6];

--- a/src/services/tips/tipRegistry.ts
+++ b/src/services/tips/tipRegistry.ts
@@ -390,7 +390,7 @@ const externalTips: Tip[] = [
   {
     id: 'custom-commands',
     content: async () =>
-      'Create skills by adding .md files to .claude/skills/ in your project or ~/.claude/skills/ for skills that work in any project',
+      'Create skills at .claude/skills/<name>/SKILL.md in your project or ~/.openclaude/skills/<name>/SKILL.md for skills that work in any project',
     cooldownSessions: 15,
     async isRelevant() {
       const config = getGlobalConfig()

--- a/src/tools/FileEditTool/constants.ts
+++ b/src/tools/FileEditTool/constants.ts
@@ -4,8 +4,11 @@ export const FILE_EDIT_TOOL_NAME = 'Edit'
 // Permission pattern for granting session-level access to the project's .claude/ folder
 export const CLAUDE_FOLDER_PERMISSION_PATTERN = '/.claude/**'
 
-// Permission pattern for granting session-level access to the global ~/.claude/ folder
-export const GLOBAL_CLAUDE_FOLDER_PERMISSION_PATTERN = '~/.claude/**'
+// Permission pattern for granting session-level access to the global ~/.openclaude/ folder
+export const GLOBAL_CLAUDE_FOLDER_PERMISSION_PATTERN = '~/.openclaude/**'
+
+// Legacy alias kept so existing session-level rules still work during migration.
+export const LEGACY_GLOBAL_CLAUDE_FOLDER_PERMISSION_PATTERN = '~/.claude/**'
 
 export const FILE_UNEXPECTEDLY_MODIFIED_ERROR =
   'File has been unexpectedly modified. Read it again before attempting to write it.'

--- a/src/utils/env.test.ts
+++ b/src/utils/env.test.ts
@@ -41,14 +41,14 @@ async function importFreshEnvModule() {
   return import(`./env.js?ts=${Date.now()}-${Math.random()}`)
 }
 
-// getGlobalClaudeFile — three migration branches
+// getGlobalClaudeFile — default path plus explicit override compatibility
 
 test('getGlobalClaudeFile: new install returns .openclaude.json when neither file exists', async () => {
   const { getGlobalClaudeFile } = await importFreshEnvModule()
   expect(getGlobalClaudeFile()).toBe(join(tempDir, '.openclaude.json'))
 })
 
-test('getGlobalClaudeFile: existing user keeps .claude.json when only legacy file exists', async () => {
+test('getGlobalClaudeFile: explicit config dir keeps .claude.json fallback when only legacy file exists', async () => {
   writeFileSync(join(tempDir, '.claude.json'), '{}')
   const { getGlobalClaudeFile } = await importFreshEnvModule()
   expect(getGlobalClaudeFile()).toBe(join(tempDir, '.claude.json'))
@@ -59,4 +59,17 @@ test('getGlobalClaudeFile: migrated user uses .openclaude.json when both files e
   writeFileSync(join(tempDir, '.openclaude.json'), '{}')
   const { getGlobalClaudeFile } = await importFreshEnvModule()
   expect(getGlobalClaudeFile()).toBe(join(tempDir, '.openclaude.json'))
+})
+
+test('resolveGlobalClaudeFile: failed default migration keeps legacy file when new file is missing', async () => {
+  writeFileSync(join(tempDir, '.claude.json'), '{}')
+  const { resolveGlobalClaudeFile } = await importFreshEnvModule()
+
+  expect(
+    resolveGlobalClaudeFile({
+      homeDir: tempDir,
+      migrationSucceeded: false,
+      existsSync: path => path === join(tempDir, '.claude.json'),
+    }),
+  ).toBe(join(tempDir, '.claude.json'))
 })

--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -3,12 +3,39 @@ import { homedir } from 'os'
 import { join } from 'path'
 import { fileSuffixForOauthConfig } from '../constants/oauth.js'
 import { isRunningWithBun } from './bundledMode.js'
-import { getClaudeConfigHomeDir, isEnvTruthy } from './envUtils.js'
+import {
+  getClaudeConfigHomeDir,
+  isEnvTruthy,
+  migrateLegacyClaudeConfigHome,
+} from './envUtils.js'
 import { findExecutable } from './findExecutable.js'
 import { getFsImplementation } from './fsOperations.js'
 import { which } from './which.js'
 
 type Platform = 'win32' | 'darwin' | 'linux'
+
+export function resolveGlobalClaudeFile(options: {
+  configDirEnv?: string
+  homeDir?: string
+  oauthSuffix?: string
+  migrationSucceeded?: boolean
+  existsSync: (path: string) => boolean
+}): string {
+  const oauthSuffix = options.oauthSuffix ?? ''
+  const configDir = options.configDirEnv || options.homeDir || homedir()
+  const hasExplicitConfigDir = Boolean(options.configDirEnv)
+  const newFilename = `.openclaude${oauthSuffix}.json`
+  const legacyFilename = `.claude${oauthSuffix}.json`
+
+  if (
+    (hasExplicitConfigDir || options.migrationSucceeded === false) &&
+    !options.existsSync(join(configDir, newFilename)) &&
+    options.existsSync(join(configDir, legacyFilename))
+  ) {
+    return join(configDir, legacyFilename)
+  }
+  return join(configDir, newFilename)
+}
 
 // Config and data paths
 export const getGlobalClaudeFile = memoize((): string => {
@@ -23,19 +50,23 @@ export const getGlobalClaudeFile = memoize((): string => {
 
   const oauthSuffix = fileSuffixForOauthConfig()
   const configDir = process.env.CLAUDE_CONFIG_DIR || homedir()
+  const hasExplicitConfigDir = Boolean(process.env.CLAUDE_CONFIG_DIR)
+  let migrationSucceeded = true
 
-  // Default to .openclaude.json. Fall back to .claude.json only if the new
-  // file doesn't exist yet and the legacy one does (same migration pattern
-  // as resolveClaudeConfigHomeDir for the config directory).
-  const newFilename = `.openclaude${oauthSuffix}.json`
-  const legacyFilename = `.claude${oauthSuffix}.json`
-  if (
-    !getFsImplementation().existsSync(join(configDir, newFilename)) &&
-    getFsImplementation().existsSync(join(configDir, legacyFilename))
-  ) {
-    return join(configDir, legacyFilename)
+  if (!hasExplicitConfigDir) {
+    migrationSucceeded = migrateLegacyClaudeConfigHome({ homeDir: configDir })
   }
-  return join(configDir, newFilename)
+
+  // Default installs hard-cut to .openclaude.json after the migration above.
+  // Explicit CLAUDE_CONFIG_DIR users keep the legacy filename fallback because
+  // that env var is the opt-out for automatic migration.
+  return resolveGlobalClaudeFile({
+    configDirEnv: process.env.CLAUDE_CONFIG_DIR,
+    homeDir: configDir,
+    oauthSuffix,
+    migrationSucceeded,
+    existsSync: path => getFsImplementation().existsSync(path),
+  })
 })
 
 const hasInternetAccess = memoize(async (): Promise<boolean> => {

--- a/src/utils/envUtils.ts
+++ b/src/utils/envUtils.ts
@@ -1,13 +1,150 @@
 import memoize from 'lodash-es/memoize.js'
-import { existsSync } from 'fs'
+import {
+  copyFileSync,
+  lstatSync,
+  mkdirSync,
+  readlinkSync,
+  readdirSync,
+  statSync,
+  symlinkSync,
+} from 'fs'
 import { homedir } from 'os'
-import { join } from 'path'
+import { dirname, join } from 'path'
+
+const LEGACY_GLOBAL_CONFIG_FILE_RE =
+  /^\.claude(?:-(?:custom|local|staging)-oauth)?\.json$/
+
+function getErrnoCode(error: unknown): string | undefined {
+  if (
+    error &&
+    typeof error === 'object' &&
+    'code' in error &&
+    typeof error.code === 'string'
+  ) {
+    return error.code
+  }
+  return undefined
+}
+
+function pathExists(path: string): boolean {
+  try {
+    lstatSync(path)
+    return true
+  } catch (error) {
+    if (getErrnoCode(error) === 'ENOENT') {
+      return false
+    }
+    return true
+  }
+}
+
+function pathIsDirectory(path: string): boolean {
+  try {
+    return lstatSync(path).isDirectory()
+  } catch {
+    return false
+  }
+}
+
+function getSymlinkType(source: string): 'dir' | 'file' | 'junction' {
+  if (process.platform !== 'win32') {
+    return 'file'
+  }
+
+  try {
+    return statSync(source).isDirectory() ? 'junction' : 'file'
+  } catch {
+    return 'file'
+  }
+}
+
+function copyMissingPathSync(source: string, destination: string): void {
+  const sourceStats = lstatSync(source)
+
+  if (sourceStats.isDirectory()) {
+    if (!pathExists(destination)) {
+      // Match fsOperations' recursive mkdir behavior while keeping this module
+      // independent from the config-home resolver it backs.
+      mkdirSync(destination, { recursive: true })
+    } else if (!lstatSync(destination).isDirectory()) {
+      throw new Error(`Cannot migrate ${source}: ${destination} is not a directory`)
+    }
+
+    for (const entry of readdirSync(source)) {
+      copyMissingPathSync(join(source, entry), join(destination, entry))
+    }
+    return
+  }
+
+  if (pathExists(destination)) {
+    return
+  }
+
+  mkdirSync(dirname(destination), { recursive: true })
+
+  if (sourceStats.isSymbolicLink()) {
+    symlinkSync(readlinkSync(source), destination, getSymlinkType(source))
+    return
+  }
+
+  if (sourceStats.isFile()) {
+    copyFileSync(source, destination)
+  }
+}
+
+function getLegacyGlobalConfigFiles(homeDir: string): string[] {
+  try {
+    return readdirSync(homeDir).filter(file =>
+      LEGACY_GLOBAL_CONFIG_FILE_RE.test(file),
+    )
+  } catch (error) {
+    if (getErrnoCode(error) === 'ENOENT') {
+      return []
+    }
+    throw error
+  }
+}
+
+export function migrateLegacyClaudeConfigHome(options?: {
+  configDirEnv?: string
+  homeDir?: string
+}): boolean {
+  if (options?.configDirEnv) {
+    return true
+  }
+
+  const homeDir = options?.homeDir ?? homedir()
+  const openClaudeDir = join(homeDir, '.openclaude')
+  const legacyClaudeDir = join(homeDir, '.claude')
+
+  try {
+    const legacyDirExists = pathIsDirectory(legacyClaudeDir)
+    const legacyGlobalConfigFiles = getLegacyGlobalConfigFiles(homeDir)
+
+    if (!legacyDirExists && legacyGlobalConfigFiles.length === 0) {
+      return true
+    }
+
+    if (legacyDirExists) {
+      copyMissingPathSync(legacyClaudeDir, openClaudeDir)
+    }
+
+    for (const legacyFile of legacyGlobalConfigFiles) {
+      const openClaudeFile = legacyFile.replace(/^\.claude/, '.openclaude')
+      copyMissingPathSync(
+        join(homeDir, legacyFile),
+        join(homeDir, openClaudeFile),
+      )
+    }
+    return true
+  } catch {
+    return false
+  }
+}
 
 export function resolveClaudeConfigHomeDir(options?: {
   configDirEnv?: string
   homeDir?: string
-  openClaudeExists?: boolean
-  legacyClaudeExists?: boolean
 }): string {
   if (options?.configDirEnv) {
     return options.configDirEnv.normalize('NFC')
@@ -15,17 +152,6 @@ export function resolveClaudeConfigHomeDir(options?: {
 
   const homeDir = options?.homeDir ?? homedir()
   const openClaudeDir = join(homeDir, '.openclaude')
-  const legacyClaudeDir = join(homeDir, '.claude')
-  const openClaudeExists =
-    options?.openClaudeExists ?? existsSync(openClaudeDir)
-  const legacyClaudeExists =
-    options?.legacyClaudeExists ?? existsSync(legacyClaudeDir)
-
-  // Preserve existing user config/install state until we ship an explicit
-  // migration. New installs (neither path exists) use ~/.openclaude.
-  if (!openClaudeExists && legacyClaudeExists) {
-    return legacyClaudeDir.normalize('NFC')
-  }
 
   return openClaudeDir.normalize('NFC')
 }
@@ -33,9 +159,30 @@ export function resolveClaudeConfigHomeDir(options?: {
 // Memoized: 150+ callers, many on hot paths. Keyed off CLAUDE_CONFIG_DIR so
 // tests that change the env var get a fresh value without explicit cache.clear.
 export const getClaudeConfigHomeDir = memoize(
-  (): string => resolveClaudeConfigHomeDir({
-    configDirEnv: process.env.CLAUDE_CONFIG_DIR,
-  }),
+  (): string => {
+    const configDirEnv = process.env.CLAUDE_CONFIG_DIR
+    const homeDir = homedir()
+    const migrationSucceeded = migrateLegacyClaudeConfigHome({
+      configDirEnv,
+      homeDir,
+    })
+    const openClaudeDir = join(homeDir, '.openclaude')
+    const legacyClaudeDir = join(homeDir, '.claude')
+
+    if (
+      !configDirEnv &&
+      !migrationSucceeded &&
+      !pathIsDirectory(openClaudeDir) &&
+      pathExists(legacyClaudeDir)
+    ) {
+      return legacyClaudeDir.normalize('NFC')
+    }
+
+    return resolveClaudeConfigHomeDir({
+      configDirEnv,
+      homeDir,
+    })
+  },
   () => process.env.CLAUDE_CONFIG_DIR,
 )
 

--- a/src/utils/openclaudePaths.test.ts
+++ b/src/utils/openclaudePaths.test.ts
@@ -1,6 +1,14 @@
 import { afterEach, describe, expect, mock, test } from 'bun:test'
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'fs'
 import * as fsPromises from 'fs/promises'
-import { homedir } from 'os'
+import { homedir, tmpdir } from 'os'
 import { join } from 'path'
 
 const originalEnv = { ...process.env }
@@ -36,23 +44,158 @@ describe('OpenClaude paths', () => {
     expect(
       resolveClaudeConfigHomeDir({
         homeDir: homedir(),
-        openClaudeExists: true,
-        legacyClaudeExists: false,
       }),
     ).toBe(join(homedir(), '.openclaude'))
   })
 
-  test('falls back to ~/.claude when legacy config exists and ~/.openclaude does not', async () => {
+  test('hard-cuts user config home to ~/.openclaude by default', async () => {
     delete process.env.CLAUDE_CONFIG_DIR
     const { resolveClaudeConfigHomeDir } = await importFreshEnvUtils()
 
     expect(
       resolveClaudeConfigHomeDir({
         homeDir: homedir(),
-        openClaudeExists: false,
-        legacyClaudeExists: true,
       }),
-    ).toBe(join(homedir(), '.claude'))
+    ).toBe(join(homedir(), '.openclaude'))
+  })
+
+  test('migrates legacy config home and global config files to .openclaude', async () => {
+    const tempHome = mkdtempSync(join(tmpdir(), 'openclaude-paths-test-'))
+    try {
+      mkdirSync(join(tempHome, '.claude', 'skills', 'legacy-skill'), {
+        recursive: true,
+      })
+      writeFileSync(
+        join(tempHome, '.claude', 'skills', 'legacy-skill', 'SKILL.md'),
+        'legacy skill',
+      )
+      writeFileSync(join(tempHome, '.claude', 'settings.json'), '{}')
+      writeFileSync(join(tempHome, '.claude.json'), '{"legacy":true}')
+      writeFileSync(
+        join(tempHome, '.claude-custom-oauth.json'),
+        '{"custom":true}',
+      )
+
+      const { migrateLegacyClaudeConfigHome } = await importFreshEnvUtils()
+
+      expect(migrateLegacyClaudeConfigHome({ homeDir: tempHome })).toBe(true)
+      expect(
+        readFileSync(
+          join(tempHome, '.openclaude', 'skills', 'legacy-skill', 'SKILL.md'),
+          'utf8',
+        ),
+      ).toBe('legacy skill')
+      expect(existsSync(join(tempHome, '.openclaude', 'settings.json'))).toBe(
+        true,
+      )
+      expect(readFileSync(join(tempHome, '.openclaude.json'), 'utf8')).toBe(
+        '{"legacy":true}',
+      )
+      expect(
+        readFileSync(join(tempHome, '.openclaude-custom-oauth.json'), 'utf8'),
+      ).toBe('{"custom":true}')
+    } finally {
+      rmSync(tempHome, { recursive: true, force: true })
+    }
+  })
+
+  test('migration preserves existing .openclaude data while copying missing legacy data', async () => {
+    const tempHome = mkdtempSync(join(tmpdir(), 'openclaude-paths-test-'))
+    try {
+      mkdirSync(join(tempHome, '.claude', 'skills', 'legacy-skill'), {
+        recursive: true,
+      })
+      mkdirSync(join(tempHome, '.openclaude', 'skills'), { recursive: true })
+      writeFileSync(join(tempHome, '.claude', 'settings.json'), 'legacy')
+      writeFileSync(join(tempHome, '.openclaude', 'settings.json'), 'current')
+      writeFileSync(
+        join(tempHome, '.claude', 'skills', 'legacy-skill', 'SKILL.md'),
+        'legacy skill',
+      )
+
+      const { migrateLegacyClaudeConfigHome } = await importFreshEnvUtils()
+
+      expect(migrateLegacyClaudeConfigHome({ homeDir: tempHome })).toBe(true)
+      expect(
+        readFileSync(join(tempHome, '.openclaude', 'settings.json'), 'utf8'),
+      ).toBe('current')
+      expect(
+        readFileSync(
+          join(tempHome, '.openclaude', 'skills', 'legacy-skill', 'SKILL.md'),
+          'utf8',
+        ),
+      ).toBe('legacy skill')
+    } finally {
+      rmSync(tempHome, { recursive: true, force: true })
+    }
+  })
+
+  test('migration skips explicit CLAUDE_CONFIG_DIR overrides', async () => {
+    const tempHome = mkdtempSync(join(tmpdir(), 'openclaude-paths-test-'))
+    try {
+      mkdirSync(join(tempHome, '.claude'), { recursive: true })
+      writeFileSync(join(tempHome, '.claude', 'settings.json'), 'legacy')
+
+      const { migrateLegacyClaudeConfigHome } = await importFreshEnvUtils()
+
+      expect(
+        migrateLegacyClaudeConfigHome({
+          configDirEnv: join(tempHome, 'custom-config'),
+          homeDir: tempHome,
+        }),
+      ).toBe(true)
+      expect(existsSync(join(tempHome, '.openclaude'))).toBe(false)
+    } finally {
+      rmSync(tempHome, { recursive: true, force: true })
+    }
+  })
+
+  test('migration fails closed when .openclaude collides with a non-directory', async () => {
+    const tempHome = mkdtempSync(join(tmpdir(), 'openclaude-paths-test-'))
+    try {
+      writeFileSync(join(tempHome, '.openclaude'), 'not a directory')
+      mkdirSync(join(tempHome, '.claude'), { recursive: true })
+      writeFileSync(join(tempHome, '.claude', 'settings.json'), 'legacy')
+
+      const { migrateLegacyClaudeConfigHome } = await importFreshEnvUtils()
+
+      expect(migrateLegacyClaudeConfigHome({ homeDir: tempHome })).toBe(false)
+    } finally {
+      rmSync(tempHome, { recursive: true, force: true })
+    }
+  })
+
+  test('migration ignores non-directory legacy config homes', async () => {
+    const tempHome = mkdtempSync(join(tmpdir(), 'openclaude-paths-test-'))
+    try {
+      writeFileSync(join(tempHome, '.claude'), 'not a directory')
+
+      const { migrateLegacyClaudeConfigHome } = await importFreshEnvUtils()
+
+      expect(migrateLegacyClaudeConfigHome({ homeDir: tempHome })).toBe(true)
+      expect(existsSync(join(tempHome, '.openclaude'))).toBe(false)
+    } finally {
+      rmSync(tempHome, { recursive: true, force: true })
+    }
+  })
+
+  test('config home falls back to legacy when migration fails on a non-directory .openclaude collision', async () => {
+    const tempHome = mkdtempSync(join(tmpdir(), 'openclaude-paths-test-'))
+    try {
+      writeFileSync(join(tempHome, '.openclaude'), 'not a directory')
+      mkdirSync(join(tempHome, '.claude'), { recursive: true })
+      mock.module('os', () => ({
+        homedir: () => tempHome,
+        tmpdir,
+      }))
+      delete process.env.CLAUDE_CONFIG_DIR
+
+      const { getClaudeConfigHomeDir } = await importFreshEnvUtils()
+
+      expect(getClaudeConfigHomeDir()).toBe(join(tempHome, '.claude'))
+    } finally {
+      rmSync(tempHome, { recursive: true, force: true })
+    }
   })
 
   test('default plans directory uses ~/.openclaude/plans', async () => {

--- a/src/utils/openclaudeUiSurfaces.test.ts
+++ b/src/utils/openclaudeUiSurfaces.test.ts
@@ -1,9 +1,24 @@
-import { describe, expect, test } from 'bun:test'
+import { afterEach, describe, expect, test } from 'bun:test'
+import { homedir } from 'os'
 import { join } from 'path'
 
+import { isInGlobalClaudeFolder } from '../components/permissions/FilePermissionDialog/permissionOptions.tsx'
 import { optionForPermissionSaveDestination } from '../components/permissions/rules/AddPermissionRules.tsx'
-import { isClaudeSettingsPath } from './permissions/filesystem.ts'
+import {
+  getClaudeSkillScope,
+  isClaudeSettingsPath,
+} from './permissions/filesystem.ts'
 import { getValidationTip } from './settings/validationTips.ts'
+
+const originalConfigDir = process.env.CLAUDE_CONFIG_DIR
+
+afterEach(() => {
+  if (originalConfigDir === undefined) {
+    delete process.env.CLAUDE_CONFIG_DIR
+  } else {
+    process.env.CLAUDE_CONFIG_DIR = originalConfigDir
+  }
+})
 
 describe('OpenClaude settings path surfaces', () => {
   test('isClaudeSettingsPath recognizes project .openclaude settings files', () => {
@@ -40,6 +55,61 @@ describe('OpenClaude settings path surfaces', () => {
       description: 'Saved in .openclaude/settings.local.json',
       value: 'localSettings',
     })
+  })
+
+  test('permission dialog treats ~/.openclaude as the global Claude folder', () => {
+    process.env.CLAUDE_CONFIG_DIR = join(homedir(), '.openclaude')
+
+    expect(
+      isInGlobalClaudeFolder(
+        join(homedir(), '.openclaude', 'settings.json'),
+      ),
+    ).toBe(true)
+    expect(
+      isInGlobalClaudeFolder(join(homedir(), '.claude', 'settings.json')),
+    ).toBe(true)
+  })
+
+  test('permission dialog does not treat arbitrary CLAUDE_CONFIG_DIR as the global Claude folder', () => {
+    process.env.CLAUDE_CONFIG_DIR = join(homedir(), 'custom-openclaude')
+
+    expect(
+      isInGlobalClaudeFolder(
+        join(homedir(), 'custom-openclaude', 'settings.json'),
+      ),
+    ).toBe(false)
+  })
+
+  test('global skill scope recognizes ~/.openclaude and legacy ~/.claude skills', () => {
+    process.env.CLAUDE_CONFIG_DIR = join(homedir(), '.openclaude')
+
+    expect(
+      getClaudeSkillScope(
+        join(homedir(), '.openclaude', 'skills', 'demo', 'SKILL.md'),
+      ),
+    ).toEqual({
+      skillName: 'demo',
+      pattern: '~/.openclaude/skills/demo/**',
+    })
+
+    expect(
+      getClaudeSkillScope(
+        join(homedir(), '.claude', 'skills', 'legacy', 'SKILL.md'),
+      ),
+    ).toEqual({
+      skillName: 'legacy',
+      pattern: '~/.claude/skills/legacy/**',
+    })
+  })
+
+  test('global skill scope does not emit fixed rules for arbitrary CLAUDE_CONFIG_DIR skills', () => {
+    process.env.CLAUDE_CONFIG_DIR = join(homedir(), 'custom-openclaude')
+
+    expect(
+      getClaudeSkillScope(
+        join(homedir(), 'custom-openclaude', 'skills', 'demo', 'SKILL.md'),
+      ),
+    ).toBe(null)
   })
 })
 

--- a/src/utils/permissions/filesystem.ts
+++ b/src/utils/permissions/filesystem.ts
@@ -10,6 +10,7 @@ import {
   CLAUDE_FOLDER_PERMISSION_PATTERN,
   FILE_EDIT_TOOL_NAME,
   GLOBAL_CLAUDE_FOLDER_PERMISSION_PATTERN,
+  LEGACY_GLOBAL_CLAUDE_FOLDER_PERMISSION_PATTERN,
 } from 'src/tools/FileEditTool/constants.js'
 import type { z } from 'zod/v4'
 import { getOriginalCwd, getSessionId } from '../../bootstrap/state.js'
@@ -95,8 +96,10 @@ export function normalizeCaseForComparison(path: string): string {
 }
 
 /**
- * If filePath is inside a .claude/skills/{name}/ directory (project or global),
- * return the skill name and a session-allow pattern scoped to just that skill.
+ * If filePath is inside a .claude/skills/{name}/ directory (project) or
+ * .openclaude/skills/{name}/ directory (global), plus the legacy global
+ * .claude/skills path, return the skill name and a session-allow pattern
+ * scoped to just that skill.
  * Used to offer a narrower "allow edits to this skill only" option in the
  * permission dialog and SDK suggestions, so iterating on one skill doesn't
  * require granting session access to all of .claude/ (settings.json, hooks/, etc.).
@@ -111,6 +114,10 @@ export function getClaudeSkillScope(
     {
       dir: expandPath(join(getOriginalCwd(), '.claude', 'skills')),
       prefix: '/.claude/skills/',
+    },
+    {
+      dir: expandPath(join(homedir(), '.openclaude', 'skills')),
+      prefix: '~/.openclaude/skills/',
     },
     {
       dir: expandPath(join(homedir(), '.claude', 'skills')),
@@ -1282,19 +1289,23 @@ export function checkWritePermissionForTool<Input extends AnyObject>(
     'allow',
   )
   if (claudeFolderAllowRule) {
-    // Check if this rule is scoped under .claude/ (project or global).
-    // Accepts both the broad patterns ('/.claude/**', '~/.claude/**') and
-    // narrowed ones like '/.claude/skills/my-skill/**' so users can grant
+    // Check if this rule is scoped under a Claude config folder.
+    // Accepts broad project/global patterns ('/.claude/**',
+    // '~/.openclaude/**', and legacy '~/.claude/**') plus narrowed skill
+    // patterns like '~/.openclaude/skills/my-skill/**' so users can grant
     // session access to a single skill without also exposing settings.json
     // or hooks/. The rule already matched the path via matchingRuleForInput;
     // this is an additional scope check. Reject '..' to prevent a rule like
-    // '/.claude/../**' from leaking this bypass outside .claude/.
+    // '/.claude/../**' from leaking this bypass outside the config folder.
     const ruleContent = claudeFolderAllowRule.ruleValue.ruleContent
     if (
       ruleContent &&
       (ruleContent.startsWith(CLAUDE_FOLDER_PERMISSION_PATTERN.slice(0, -2)) ||
         ruleContent.startsWith(
           GLOBAL_CLAUDE_FOLDER_PERMISSION_PATTERN.slice(0, -2),
+        ) ||
+        ruleContent.startsWith(
+          LEGACY_GLOBAL_CLAUDE_FOLDER_PERMISSION_PATTERN.slice(0, -2),
         )) &&
       !ruleContent.includes('..') &&
       ruleContent.endsWith('/**')

--- a/src/utils/skills/skillChangeDetector.ts
+++ b/src/utils/skills/skillChangeDetector.ts
@@ -172,7 +172,7 @@ async function getWatchablePaths(): Promise<string[]> {
   const fs = getFsImplementation()
   const paths: string[] = []
 
-  // User skills directory (~/.claude/skills)
+  // User skills directory (~/.openclaude/skills)
   const userSkillsPath = getSkillsPath('userSettings', 'skills')
   if (userSkillsPath) {
     try {
@@ -183,7 +183,7 @@ async function getWatchablePaths(): Promise<string[]> {
     }
   }
 
-  // User commands directory (~/.claude/commands)
+  // User commands directory (~/.openclaude/commands)
   const userCommandsPath = getSkillsPath('userSettings', 'commands')
   if (userCommandsPath) {
     try {


### PR DESCRIPTION
## Summary

- migrate legacy `~/.claude` config-home data into `~/.openclaude` before default config resolution
- hard-cut the default config home to `~/.openclaude` while preserving explicit `CLAUDE_CONFIG_DIR` overrides
- update user-facing skill guidance to point global skills at `~/.openclaude/skills`
- add tests for legacy-only migration, both-path merge behavior, global config file migration, and explicit override behavior

## Why

The previous resolver kept legacy installs on `~/.claude` when `~/.openclaude` did not exist. That avoided immediate data loss, but it also kept both paths alive as user-facing destinations and created a footgun: creating `~/.openclaude` manually could flip resolution on the next startup and strand existing legacy data.

This makes migration explicit and then treats `~/.openclaude` as the default config home.

Closes #1120.

## Validation

- `bun test src/utils/openclaudePaths.test.ts src/utils/env.test.ts`
