### PR TITLE
fix: replace raw AbortSignal.timeout with cleanup-safe helper

### DIFF
--- a/scripts/no-raw-abort-signal-timeout.test.ts
+++ b/scripts/no-raw-abort-signal-timeout.test.ts
@@ -1,0 +1,118 @@
+import { readdirSync, readFileSync, statSync } from 'node:fs'
+import { join, relative, sep } from 'node:path'
+import { describe, expect, test } from 'bun:test'
+
+const REPO_ROOT = join(import.meta.dir, '..')
+const SCAN_ROOTS = ['src', 'scripts']
+const SOURCE_EXTENSIONS = new Set([
+  '.cjs',
+  '.cts',
+  '.js',
+  '.jsx',
+  '.mjs',
+  '.mts',
+  '.ts',
+  '.tsx',
+])
+const FORBIDDEN_TIMEOUT_SIGNAL_RE = /AbortSignal\s*\.\s*timeout\s*\(/
+
+type Finding = {
+  path: string
+  line: number
+  column: number
+  source: string
+}
+
+function extensionOf(path: string): string {
+  const dot = path.lastIndexOf('.')
+  return dot === -1 ? '' : path.slice(dot)
+}
+
+function* walk(dir: string): Generator<string> {
+  for (const entry of readdirSync(dir)) {
+    const absolute = join(dir, entry)
+    const stats = statSync(absolute)
+    if (stats.isDirectory()) {
+      yield* walk(absolute)
+      continue
+    }
+    if (stats.isFile() && SOURCE_EXTENSIONS.has(extensionOf(entry))) {
+      yield absolute
+    }
+  }
+}
+
+function isAllowedDocumentationLine(line: string): boolean {
+  const trimmed = line.trim()
+  const isComment =
+    trimmed.startsWith('//') ||
+    trimmed.startsWith('*') ||
+    trimmed.startsWith('/*')
+
+  return (
+    isComment &&
+    /\b(avoid|bug|Bun|clearTimeout|forbid|lazy|leak|memory|must not|instead)\b/i.test(
+      trimmed,
+    )
+  )
+}
+
+function isAllowedTestFixtureLine(line: string): boolean {
+  const trimmed = line.trim()
+  const isStringOrRegexFixture =
+    /["'`].*AbortSignal\s*\.\s*timeout\s*\(/.test(trimmed) ||
+    /\/.*AbortSignal.*timeout.*\\?\(/.test(trimmed)
+
+  return (
+    isStringOrRegexFixture &&
+    /\b(forbidden|fixture|guard|pattern|raw|regression)\b/i.test(trimmed)
+  )
+}
+
+function isAllowedOccurrence(path: string, line: string): boolean {
+  if (path === 'src/utils/combinedAbortSignal.ts') return true
+
+  if (path.endsWith('.test.ts') || path.endsWith('.test.tsx')) {
+    return isAllowedDocumentationLine(line) || isAllowedTestFixtureLine(line)
+  }
+
+  return isAllowedDocumentationLine(line)
+}
+
+function findRawTimeoutSignalUsages(): Finding[] {
+  const findings: Finding[] = []
+
+  for (const root of SCAN_ROOTS) {
+    for (const absolute of walk(join(REPO_ROOT, root))) {
+      const path = relative(REPO_ROOT, absolute).split(sep).join('/')
+      const lines = readFileSync(absolute, 'utf-8').split(/\r?\n/)
+
+      lines.forEach((source, index) => {
+        const match = FORBIDDEN_TIMEOUT_SIGNAL_RE.exec(source)
+        if (!match || isAllowedOccurrence(path, source)) return
+
+        findings.push({
+          path,
+          line: index + 1,
+          column: match.index + 1,
+          source: source.trim(),
+        })
+      })
+    }
+  }
+
+  return findings
+}
+
+describe('raw timeout signal guard', () => {
+  test('source files use cleanup-safe timeout signal helpers', () => {
+    const findings = findRawTimeoutSignalUsages()
+
+    expect(
+      findings.map(
+        finding =>
+          `${finding.path}:${finding.line}:${finding.column} ${finding.source}`,
+      ),
+    ).toEqual([])
+  })
+})

--- a/src/bridge/initReplBridge.ts
+++ b/src/bridge/initReplBridge.ts
@@ -30,6 +30,7 @@ import {
   getClaudeAIOAuthTokens,
   handleOAuth401Error,
 } from '../utils/auth.js'
+import { createCombinedAbortSignal } from '../utils/combinedAbortSignal.js'
 import { getGlobalConfig, saveGlobalConfig } from '../utils/config.js'
 import { logForDebugging } from '../utils/debug.js'
 import { stripDisplayTagsAllowEmpty } from '../utils/displayTags.js'
@@ -333,8 +334,11 @@ export async function initReplBridge(
   const generateAndPatch = (input: string, bridgeSessionId: string): void => {
     const gen = ++genSeq
     const atCount = userMessageCount
-    void generateSessionTitle(input, AbortSignal.timeout(15_000)).then(
-      generated => {
+    const { signal, cleanup } = createCombinedAbortSignal(undefined, {
+      timeoutMs: 15_000,
+    })
+    void generateSessionTitle(input, signal)
+      .then(generated => {
         if (
           generated &&
           gen === genSeq &&
@@ -343,8 +347,8 @@ export async function initReplBridge(
         ) {
           patch(generated, bridgeSessionId, atCount)
         }
-      },
-    )
+      })
+      .finally(cleanup)
   }
   const onUserMessage = (text: string, bridgeSessionId: string): boolean => {
     if (hasExplicitTitle || getCurrentSessionTitle(getSessionId())) {

--- a/src/bridge/replBridge.ts
+++ b/src/bridge/replBridge.ts
@@ -14,6 +14,7 @@ import {
   logEvent,
 } from '../services/analytics/index.js'
 import { registerCleanup } from '../utils/cleanupRegistry.js'
+import { createCombinedAbortSignal } from '../utils/combinedAbortSignal.js'
 import {
   handleIngressMessage,
   handleServerControlRequest,
@@ -454,13 +455,21 @@ export async function initBridgeCore(
       }
     }
   } else {
-    const createdSessionId = await createSession({
-      environmentId,
-      title,
-      gitRepoUrl,
-      branch,
-      signal: AbortSignal.timeout(15_000),
+    const { signal, cleanup } = createCombinedAbortSignal(undefined, {
+      timeoutMs: 15_000,
     })
+    let createdSessionId: string | null
+    try {
+      createdSessionId = await createSession({
+        environmentId,
+        title,
+        gitRepoUrl,
+        branch,
+        signal,
+      })
+    } finally {
+      cleanup()
+    }
 
     if (!createdSessionId) {
       logForDebugging(
@@ -761,13 +770,21 @@ export async function initBridgeCore(
     const currentTitle = getCurrentTitle()
 
     // Create a new session on the now-registered environment
-    const newSessionId = await createSession({
-      environmentId,
-      title: currentTitle,
-      gitRepoUrl,
-      branch,
-      signal: AbortSignal.timeout(15_000),
+    const { signal, cleanup } = createCombinedAbortSignal(undefined, {
+      timeoutMs: 15_000,
     })
+    let newSessionId: string | null
+    try {
+      newSessionId = await createSession({
+        environmentId,
+        title: currentTitle,
+        gitRepoUrl,
+        branch,
+        signal,
+      })
+    } finally {
+      cleanup()
+    }
 
     if (!newSessionId) {
       logForDebugging(

--- a/src/commands/clear/conversation.ts
+++ b/src/commands/clear/conversation.ts
@@ -22,6 +22,7 @@ import {
 } from '../../tasks/LocalAgentTask/LocalAgentTask.js'
 import { isLocalShellTask } from '../../tasks/LocalShellTask/guards.js'
 import { asAgentId } from '../../types/ids.js'
+import { createCombinedAbortSignal } from '../../utils/combinedAbortSignal.js'
 import type { Message } from '../../types/message.js'
 import { createEmptyAttributionState } from '../../utils/commitAttribution.js'
 import type { FileStateCache } from '../../utils/fileStateCache.js'
@@ -66,12 +67,19 @@ export async function clearConversation({
   // Execute SessionEnd hooks before clearing (bounded by
   // CLAUDE_CODE_SESSIONEND_HOOKS_TIMEOUT_MS, default 1.5s)
   const sessionEndTimeoutMs = getSessionEndHookTimeoutMs()
-  await executeSessionEndHooks('clear', {
-    getAppState,
-    setAppState,
-    signal: AbortSignal.timeout(sessionEndTimeoutMs),
+  const { signal, cleanup } = createCombinedAbortSignal(undefined, {
     timeoutMs: sessionEndTimeoutMs,
   })
+  try {
+    await executeSessionEndHooks('clear', {
+      getAppState,
+      setAppState,
+      signal,
+      timeoutMs: sessionEndTimeoutMs,
+    })
+  } finally {
+    cleanup()
+  }
 
   // Signal to inference that this conversation's cache can be evicted.
   const lastRequestId = getLastMainRequestId()

--- a/src/hooks/fileSuggestions.ts
+++ b/src/hooks/fileSuggestions.ts
@@ -14,6 +14,7 @@ import {
 import { logEvent } from '../services/analytics/index.js'
 import type { FileSuggestionCommandInput } from '../types/fileSuggestion.js'
 import { getGlobalConfig } from '../utils/config.js'
+import { createCombinedAbortSignal } from '../utils/combinedAbortSignal.js'
 import { getCwd } from '../utils/cwd.js'
 import { logForDebugging } from '../utils/debug.js'
 import { errorMessage } from '../utils/errors.js'
@@ -521,7 +522,9 @@ async function getProjectFiles(
  * Returns a FileIndex populated for fast fuzzy search
  */
 export async function getPathsForSuggestions(): Promise<FileIndex> {
-  const signal = AbortSignal.timeout(10_000)
+  const { signal, cleanup } = createCombinedAbortSignal(undefined, {
+    timeoutMs: 10_000,
+  })
   const index = getFileIndex()
 
   try {
@@ -564,6 +567,8 @@ export async function getPathsForSuggestions(): Promise<FileIndex> {
     }
   } catch (error) {
     logError(error)
+  } finally {
+    cleanup()
   }
 
   return index

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -108,6 +108,7 @@ import { setupClaudeInChrome, shouldAutoEnableClaudeInChrome, shouldEnableClaude
 import { getContextWindowForModel } from './utils/context.js';
 import { loadConversationForResume } from './utils/conversationRecovery.js';
 import { buildDeepLinkBanner } from './utils/deepLink/banner.js';
+import { createCombinedAbortSignal } from './utils/combinedAbortSignal.js';
 import { hasNodeOption, isBareMode, isEnvTruthy, isInProtectedNamespace } from './utils/envUtils.js';
 import { refreshExampleCommands } from './utils/exampleCommands.js';
 import type { FpsMetrics } from './utils/fpsTracker.js';
@@ -414,7 +415,11 @@ export function startDeferredPrefetches(): void {
   if (isEnvTruthy(process.env.CLAUDE_CODE_USE_VERTEX) && !isEnvTruthy(process.env.CLAUDE_CODE_SKIP_VERTEX_AUTH)) {
     void prefetchGcpCredentialsIfSafe();
   }
-  void countFilesRoundedRg(getCwd(), AbortSignal.timeout(3000), []);
+  const { signal: countFilesSignal, cleanup: cleanupCountFilesSignal } =
+    createCombinedAbortSignal(undefined, { timeoutMs: 3000 });
+  void countFilesRoundedRg(getCwd(), countFilesSignal, []).finally(
+    cleanupCountFilesSignal,
+  );
 
   // Analytics and feature flag initialization
   void initializeAnalyticsGates();

--- a/src/screens/REPL.tsx
+++ b/src/screens/REPL.tsx
@@ -33,6 +33,7 @@ import { updateLastInteractionTime, getLastInteractionTime, getOriginalCwd, getP
 import { asSessionId, asAgentId } from '../types/ids.js';
 import { logForDebugging } from '../utils/debug.js';
 import { QueryGuard } from '../utils/QueryGuard.js';
+import { createCombinedAbortSignal } from '../utils/combinedAbortSignal.js';
 import { isEnvTruthy } from '../utils/envUtils.js';
 import { formatTokens, truncateToWidth } from '../utils/format.js';
 import { consumeEarlyInput } from '../utils/earlyInput.js';
@@ -1804,12 +1805,19 @@ export function REPL({
       // Fire SessionEnd hooks for the current session before starting the
       // resumed one, mirroring the /clear flow in conversation.ts.
       const sessionEndTimeoutMs = getSessionEndHookTimeoutMs();
-      await executeSessionEndHooks('resume', {
-        getAppState: () => store.getState(),
-        setAppState,
-        signal: AbortSignal.timeout(sessionEndTimeoutMs),
-        timeoutMs: sessionEndTimeoutMs
+      const { signal, cleanup } = createCombinedAbortSignal(undefined, {
+        timeoutMs: sessionEndTimeoutMs,
       });
+      try {
+        await executeSessionEndHooks('resume', {
+          getAppState: () => store.getState(),
+          setAppState,
+          signal,
+          timeoutMs: sessionEndTimeoutMs
+        });
+      } finally {
+        cleanup();
+      }
 
       // Process session start hooks for resume
       const hookMessages = await processSessionStartHooks('resume', {

--- a/src/services/api/codexOAuth.ts
+++ b/src/services/api/codexOAuth.ts
@@ -15,6 +15,7 @@ import {
   getCodexOAuthClientId,
   parseChatgptAccountId,
 } from './codexOAuthShared.js'
+import { createCombinedAbortSignal } from '../../utils/combinedAbortSignal.js'
 
 type CodexOAuthTokenResponse = {
   id_token?: string
@@ -127,27 +128,34 @@ async function exchangeAuthorizationCode(options: {
     code_verifier: options.codeVerifier,
   })
 
-  const response = await fetch(`${CODEX_OAUTH_ISSUER}/oauth/token`, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/x-www-form-urlencoded',
-    },
-    body,
-    signal: options.signal
-      ? AbortSignal.any([options.signal, AbortSignal.timeout(15_000)])
-      : AbortSignal.timeout(15_000),
+  const { signal, cleanup } = createCombinedAbortSignal(options.signal, {
+    timeoutMs: 15_000,
   })
+  let payload: CodexOAuthTokenResponse
+  try {
+    const response = await fetch(`${CODEX_OAUTH_ISSUER}/oauth/token`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded',
+      },
+      body,
+      signal,
+    })
 
-  if (!response.ok) {
-    const errorText = await response.text().catch(() => '')
-    throw new Error(
-      errorText.trim()
-        ? `Codex OAuth token exchange failed (${response.status}): ${errorText.trim()}`
-        : `Codex OAuth token exchange failed with status ${response.status}.`,
-    )
+    if (!response.ok) {
+      const errorText = await response.text().catch(() => '')
+      throw new Error(
+        errorText.trim()
+          ? `Codex OAuth token exchange failed (${response.status}): ${errorText.trim()}`
+          : `Codex OAuth token exchange failed with status ${response.status}.`,
+      )
+    }
+
+    payload = (await response.json()) as CodexOAuthTokenResponse
+  } finally {
+    cleanup()
   }
 
-  const payload = (await response.json()) as CodexOAuthTokenResponse
   const accessToken = asTrimmedString(payload.access_token)
   const refreshToken = asTrimmedString(payload.refresh_token)
   if (!accessToken || !refreshToken) {

--- a/src/services/api/codexOAuthShared.ts
+++ b/src/services/api/codexOAuthShared.ts
@@ -1,3 +1,5 @@
+import { createCombinedAbortSignal } from '../../utils/combinedAbortSignal.js'
+
 export const CODEX_OAUTH_ISSUER = 'https://auth.openai.com'
 export const CODEX_REFRESH_URL = `${CODEX_OAUTH_ISSUER}/oauth/token`
 export const DEFAULT_CODEX_OAUTH_CLIENT_ID = 'app_EMoamEEZ73f0CkXaXp7hrann'
@@ -109,31 +111,38 @@ export async function exchangeCodexIdTokenForApiKey(
     subject_token_type: CODEX_ID_TOKEN_SUBJECT_TYPE,
   })
 
-  const response = await fetch(CODEX_REFRESH_URL, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/x-www-form-urlencoded',
-    },
-    body,
-    signal: AbortSignal.timeout(15_000),
+  const { signal, cleanup } = createCombinedAbortSignal(undefined, {
+    timeoutMs: 15_000,
   })
+  try {
+    const response = await fetch(CODEX_REFRESH_URL, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded',
+      },
+      body,
+      signal,
+    })
 
-  if (!response.ok) {
-    const bodyText = await response.text().catch(() => '')
-    throw new Error(
-      bodyText.trim()
-        ? `Codex API key exchange failed (${response.status}): ${bodyText.trim()}`
-        : `Codex API key exchange failed with status ${response.status}.`,
-    )
+    if (!response.ok) {
+      const bodyText = await response.text().catch(() => '')
+      throw new Error(
+        bodyText.trim()
+          ? `Codex API key exchange failed (${response.status}): ${bodyText.trim()}`
+          : `Codex API key exchange failed with status ${response.status}.`,
+      )
+    }
+
+    const payload = (await response.json()) as { access_token?: string }
+    const apiKey = asTrimmedString(payload.access_token)
+    if (!apiKey) {
+      throw new Error(
+        'Codex API key exchange completed, but no API key token was returned.',
+      )
+    }
+
+    return apiKey
+  } finally {
+    cleanup()
   }
-
-  const payload = (await response.json()) as { access_token?: string }
-  const apiKey = asTrimmedString(payload.access_token)
-  if (!apiKey) {
-    throw new Error(
-      'Codex API key exchange completed, but no API key token was returned.',
-    )
-  }
-
-  return apiKey
 }

--- a/src/services/api/codexUsage.ts
+++ b/src/services/api/codexUsage.ts
@@ -2,6 +2,7 @@ import {
   readCodexCredentialsAsync,
   refreshCodexAccessTokenIfNeeded,
 } from '../../utils/codexCredentials.js'
+import { createCombinedAbortSignal } from '../../utils/combinedAbortSignal.js'
 import { logForDebugging } from '../../utils/debug.js'
 import { isBareMode } from '../../utils/envUtils.js'
 import {
@@ -435,21 +436,28 @@ export async function fetchCodexUsage(): Promise<CodexUsageData> {
     )
   }
 
-  const response = await fetch(getCodexUsageUrl(request.baseUrl), {
-    method: 'GET',
-    headers: {
-      Accept: 'application/json',
-      Authorization: `Bearer ${credentials.apiKey}`,
-      'chatgpt-account-id': credentials.accountId,
-      originator: 'openclaude',
-    },
-    signal: AbortSignal.timeout(5000),
+  const { signal, cleanup } = createCombinedAbortSignal(undefined, {
+    timeoutMs: 5000,
   })
+  try {
+    const response = await fetch(getCodexUsageUrl(request.baseUrl), {
+      method: 'GET',
+      headers: {
+        Accept: 'application/json',
+        Authorization: `Bearer ${credentials.apiKey}`,
+        'chatgpt-account-id': credentials.accountId,
+        originator: 'openclaude',
+      },
+      signal,
+    })
 
-  if (!response.ok) {
-    const errorBody = await response.text().catch(() => 'unknown error')
-    throw new Error(`Codex usage error ${response.status}: ${errorBody}`)
+    if (!response.ok) {
+      const errorBody = await response.text().catch(() => 'unknown error')
+      throw new Error(`Codex usage error ${response.status}: ${errorBody}`)
+    }
+
+    return normalizeCodexUsagePayload(await response.json())
+  } finally {
+    cleanup()
   }
-
-  return normalizeCodexUsagePayload(await response.json())
 }

--- a/src/services/api/minimaxUsage/fetch.ts
+++ b/src/services/api/minimaxUsage/fetch.ts
@@ -1,3 +1,4 @@
+import { createCombinedAbortSignal } from '../../../utils/combinedAbortSignal.js'
 import { logForDebugging } from '../../../utils/debug.js'
 import { getClaudeCodeUserAgent } from '../../../utils/userAgent.js'
 import {
@@ -86,42 +87,49 @@ export async function fetchMiniMaxUsage(): Promise<MiniMaxUsageData> {
 
   for (const usageUrl of usageUrls) {
     let response: Response
+    const { signal, cleanup } = createCombinedAbortSignal(undefined, {
+      timeoutMs: 5000,
+    })
     try {
-      response = await fetch(usageUrl, {
-        method: 'GET',
-        headers: {
-          Accept: 'application/json',
-          Authorization: `Bearer ${apiKey}`,
-          'Content-Type': 'application/json',
-          'User-Agent': getClaudeCodeUserAgent(),
-        },
-        signal: AbortSignal.timeout(5000),
-      })
-    } catch (error) {
-      logForDebugging(
-        `[minimax] usage request failed for ${usageUrl}: ${error instanceof Error ? error.message : String(error)}`,
-        { level: 'warn' },
-      )
-      lastFatalError =
-        error instanceof Error ? error : new Error(String(error))
-      continue
-    }
-
-    if (!response.ok) {
-      const errorBody = await response.text().catch(() => '')
-      if ([400, 401, 403, 404].includes(response.status)) {
-        nonFatalFailures.push({ status: response.status, body: errorBody })
+      try {
+        response = await fetch(usageUrl, {
+          method: 'GET',
+          headers: {
+            Accept: 'application/json',
+            Authorization: `Bearer ${apiKey}`,
+            'Content-Type': 'application/json',
+            'User-Agent': getClaudeCodeUserAgent(),
+          },
+          signal,
+        })
+      } catch (error) {
+        logForDebugging(
+          `[minimax] usage request failed for ${usageUrl}: ${error instanceof Error ? error.message : String(error)}`,
+          { level: 'warn' },
+        )
+        lastFatalError =
+          error instanceof Error ? error : new Error(String(error))
         continue
       }
-      lastFatalError = new Error(
-        `MiniMax usage error ${response.status}: ${errorBody || 'unknown error'}`,
-      )
-      continue
-    }
 
-    const normalized = normalizeMiniMaxUsagePayload(await response.json())
-    if (normalized.availability === 'available') {
-      return normalized
+      if (!response.ok) {
+        const errorBody = await response.text().catch(() => '')
+        if ([400, 401, 403, 404].includes(response.status)) {
+          nonFatalFailures.push({ status: response.status, body: errorBody })
+          continue
+        }
+        lastFatalError = new Error(
+          `MiniMax usage error ${response.status}: ${errorBody || 'unknown error'}`,
+        )
+        continue
+      }
+
+      const normalized = normalizeMiniMaxUsagePayload(await response.json())
+      if (normalized.availability === 'available') {
+        return normalized
+      }
+    } finally {
+      cleanup()
     }
   }
 

--- a/src/services/mcp/auth.ts
+++ b/src/services/mcp/auth.ts
@@ -33,6 +33,7 @@ import { parse } from 'url'
 import xss from 'xss'
 import { MCP_CLIENT_METADATA_URL } from '../../constants/oauth.js'
 import { openBrowser } from '../../utils/browser.js'
+import { createCombinedAbortSignal } from '../../utils/combinedAbortSignal.js'
 import { getClaudeConfigHomeDir } from '../../utils/envUtils.js'
 import { errorMessage, getErrnoCode } from '../../utils/errors.js'
 import * as lockfile from '../../utils/lockfile.js'
@@ -265,41 +266,16 @@ export async function normalizeOAuthErrorBody(
  */
 function createAuthFetch(): FetchLike {
   return async (url: string | URL, init?: RequestInit) => {
-    const timeoutSignal = AbortSignal.timeout(AUTH_REQUEST_TIMEOUT_MS)
     const isPost = init?.method?.toUpperCase() === 'POST'
-
-    // No existing signal - just use timeout
-    if (!init?.signal) {
-      // eslint-disable-next-line eslint-plugin-n/no-unsupported-features/node-builtins
-      const response = await fetch(url, { ...init, signal: timeoutSignal })
-      return isPost ? normalizeOAuthErrorBody(response) : response
-    }
-
-    // Combine signals: abort when either fires
-    const controller = new AbortController()
-    const abort = () => controller.abort()
-
-    init.signal.addEventListener('abort', abort)
-    timeoutSignal.addEventListener('abort', abort)
-
-    // Cleanup to prevent event listener leaks after fetch completes
-    const cleanup = () => {
-      init.signal?.removeEventListener('abort', abort)
-      timeoutSignal.removeEventListener('abort', abort)
-    }
-
-    if (init.signal.aborted) {
-      controller.abort()
-    }
-
+    const { signal, cleanup } = createCombinedAbortSignal(init?.signal, {
+      timeoutMs: AUTH_REQUEST_TIMEOUT_MS,
+    })
     try {
       // eslint-disable-next-line eslint-plugin-n/no-unsupported-features/node-builtins
-      const response = await fetch(url, { ...init, signal: controller.signal })
+      const response = await fetch(url, { ...init, signal })
+      return isPost ? await normalizeOAuthErrorBody(response) : response
+    } finally {
       cleanup()
-      return isPost ? normalizeOAuthErrorBody(response) : response
-    } catch (error) {
-      cleanup()
-      throw error
     }
   }
 }

--- a/src/services/mcp/xaa.ts
+++ b/src/services/mcp/xaa.ts
@@ -22,6 +22,7 @@ import {
 } from '@modelcontextprotocol/sdk/client/auth.js'
 import type { FetchLike } from '@modelcontextprotocol/sdk/shared/transport.js'
 import { z } from 'zod/v4'
+import { createCombinedAbortSignal } from '../../utils/combinedAbortSignal.js'
 import { lazySchema } from '../../utils/lazySchema.js'
 import { logMCPDebug } from '../../utils/log.js'
 import { jsonStringify } from '../../utils/slowOperations.js'
@@ -35,19 +36,18 @@ const ID_TOKEN_TYPE = 'urn:ietf:params:oauth:token-type:id_token'
 
 /**
  * Creates a fetch wrapper that enforces the XAA request timeout and optionally
- * composes a caller-provided abort signal. Using AbortSignal.any ensures the
+ * composes a caller-provided abort signal. Combining both signals ensures the
  * user's cancel (e.g. Esc in the auth menu) actually aborts in-flight requests
  * rather than being clobbered by the timeout signal.
  */
 function makeXaaFetch(abortSignal?: AbortSignal): FetchLike {
   return (url, init) => {
-    const timeout = AbortSignal.timeout(XAA_REQUEST_TIMEOUT_MS)
-    const signal = abortSignal
-      ? // eslint-disable-next-line eslint-plugin-n/no-unsupported-features/node-builtins
-        AbortSignal.any([timeout, abortSignal])
-      : timeout
+    const { signal, cleanup } = createCombinedAbortSignal(init?.signal, {
+      signalB: abortSignal,
+      timeoutMs: XAA_REQUEST_TIMEOUT_MS,
+    })
     // eslint-disable-next-line eslint-plugin-n/no-unsupported-features/node-builtins
-    return fetch(url, { ...init, signal })
+    return fetch(url, { ...init, signal }).finally(cleanup)
   }
 }
 

--- a/src/services/mcp/xaaIdpLogin.ts
+++ b/src/services/mcp/xaaIdpLogin.ts
@@ -20,6 +20,7 @@ import { createServer, type Server } from 'http'
 import { parse } from 'url'
 import xss from 'xss'
 import { openBrowser } from '../../utils/browser.js'
+import { createCombinedAbortSignal } from '../../utils/combinedAbortSignal.js'
 import { isEnvTruthy } from '../../utils/envUtils.js'
 import { toError } from '../../utils/errors.js'
 import { logMCPDebug } from '../../utils/log.js'
@@ -204,36 +205,43 @@ export async function discoverOidc(
 ): Promise<OpenIdProviderDiscoveryMetadata> {
   const base = idpIssuer.endsWith('/') ? idpIssuer : idpIssuer + '/'
   const url = new URL('.well-known/openid-configuration', base)
-  // eslint-disable-next-line eslint-plugin-n/no-unsupported-features/node-builtins
-  const res = await fetch(url, {
-    headers: { Accept: 'application/json' },
-    signal: AbortSignal.timeout(IDP_REQUEST_TIMEOUT_MS),
+  const { signal, cleanup } = createCombinedAbortSignal(undefined, {
+    timeoutMs: IDP_REQUEST_TIMEOUT_MS,
   })
-  if (!res.ok) {
-    throw new Error(
-      `XAA IdP: OIDC discovery failed: HTTP ${res.status} at ${url}`,
-    )
-  }
-  // Captive portals and proxy auth pages return 200 with HTML. res.json()
-  // throws a raw SyntaxError before safeParse can give a useful message.
-  let body: unknown
   try {
-    body = await res.json()
-  } catch {
-    throw new Error(
-      `XAA IdP: OIDC discovery returned non-JSON at ${url} (captive portal or proxy?)`,
-    )
+    // eslint-disable-next-line eslint-plugin-n/no-unsupported-features/node-builtins
+    const res = await fetch(url, {
+      headers: { Accept: 'application/json' },
+      signal,
+    })
+    if (!res.ok) {
+      throw new Error(
+        `XAA IdP: OIDC discovery failed: HTTP ${res.status} at ${url}`,
+      )
+    }
+    // Captive portals and proxy auth pages return 200 with HTML. res.json()
+    // throws a raw SyntaxError before safeParse can give a useful message.
+    let body: unknown
+    try {
+      body = await res.json()
+    } catch {
+      throw new Error(
+        `XAA IdP: OIDC discovery returned non-JSON at ${url} (captive portal or proxy?)`,
+      )
+    }
+    const parsed = OpenIdProviderDiscoveryMetadataSchema.safeParse(body)
+    if (!parsed.success) {
+      throw new Error(`XAA IdP: invalid OIDC metadata: ${parsed.error.message}`)
+    }
+    if (new URL(parsed.data.token_endpoint).protocol !== 'https:') {
+      throw new Error(
+        `XAA IdP: refusing non-HTTPS token endpoint: ${parsed.data.token_endpoint}`,
+      )
+    }
+    return parsed.data
+  } finally {
+    cleanup()
   }
-  const parsed = OpenIdProviderDiscoveryMetadataSchema.safeParse(body)
-  if (!parsed.success) {
-    throw new Error(`XAA IdP: invalid OIDC metadata: ${parsed.error.message}`)
-  }
-  if (new URL(parsed.data.token_endpoint).protocol !== 'https:') {
-    throw new Error(
-      `XAA IdP: refusing non-HTTPS token endpoint: ${parsed.data.token_endpoint}`,
-    )
-  }
-  return parsed.data
 }
 
 /**
@@ -456,12 +464,16 @@ export async function acquireIdpIdToken(
     authorizationCode,
     codeVerifier,
     redirectUri,
-    fetchFn: (url, init) =>
+    fetchFn: (url, init) => {
+      const { signal, cleanup } = createCombinedAbortSignal(init?.signal, {
+        timeoutMs: IDP_REQUEST_TIMEOUT_MS,
+      })
       // eslint-disable-next-line eslint-plugin-n/no-unsupported-features/node-builtins
-      fetch(url, {
+      return fetch(url, {
         ...init,
-        signal: AbortSignal.timeout(IDP_REQUEST_TIMEOUT_MS),
-      }),
+        signal,
+      }).finally(cleanup)
+    },
   })
   if (!tokens.id_token) {
     throw new Error(

--- a/src/tools/WebSearchTool/providers/custom.ts
+++ b/src/tools/WebSearchTool/providers/custom.ts
@@ -27,6 +27,7 @@
  */
 
 import type { SearchInput, SearchProvider } from './types.js'
+import { createCombinedAbortSignal } from '../../../utils/combinedAbortSignal.js'
 import {
   applyDomainFilters,
   normalizeHit,
@@ -587,14 +588,13 @@ async function fetchWithRetry(url: string, init: RequestInit, signal?: AbortSign
   let lastStatus: number | undefined
 
   for (let attempt = 0; attempt < 2; attempt++) {
-    // Compose timeout with caller signal via AbortSignal.any so each attempt
+    // Compose timeout with caller signal so each attempt
     // has a fresh timeout and we don't leak an abort listener on `signal`
     // (the previous implementation added one per attempt and never removed
     // it, and the listener kept a reference to a stale AbortController).
-    const timeoutSignal = AbortSignal.timeout(timeoutMs)
-    const combined = signal
-      ? AbortSignal.any([signal, timeoutSignal])
-      : timeoutSignal
+    const { signal: combined, cleanup } = createCombinedAbortSignal(signal, {
+      timeoutMs,
+    })
 
     lastStatus = undefined
     try {
@@ -611,8 +611,8 @@ async function fetchWithRetry(url: string, init: RequestInit, signal?: AbortSign
       // Caller-initiated abort wins — propagate without retry or rewrite.
       if (signal?.aborted) throw lastErr
 
-      // Timeout (TimeoutError on Bun/Node, or AbortError with timeoutSignal aborted).
-      if (timeoutSignal.aborted) {
+      // Timeout (TimeoutError on Bun/Node, or AbortError with timeout signal aborted).
+      if (combined.aborted) {
         throw new Error(`Custom search timed out after ${timeoutSec}s`)
       }
 
@@ -622,6 +622,8 @@ async function fetchWithRetry(url: string, init: RequestInit, signal?: AbortSign
         continue
       }
       throw lastErr
+    } finally {
+      cleanup()
     }
   }
   throw lastErr!

--- a/src/upstreamproxy/upstreamproxy.ts
+++ b/src/upstreamproxy/upstreamproxy.ts
@@ -23,6 +23,7 @@ import { mkdir, readFile, unlink, writeFile } from 'fs/promises'
 import { homedir } from 'os'
 import { join } from 'path'
 import { registerCleanup } from '../utils/cleanupRegistry.js'
+import { createCombinedAbortSignal } from '../utils/combinedAbortSignal.js'
 import { logForDebugging } from '../utils/debug.js'
 import { isEnvTruthy } from '../utils/envUtils.js'
 import { isENOENT } from '../utils/errors.js'
@@ -269,20 +270,28 @@ async function downloadCaBundle(
   outPath: string,
 ): Promise<boolean> {
   try {
-    // eslint-disable-next-line eslint-plugin-n/no-unsupported-features/node-builtins
-    const resp = await fetch(`${baseUrl}/v1/code/upstreamproxy/ca-cert`, {
-      // Bun has no default fetch timeout — a hung endpoint would block CLI
-      // startup forever. 5s is generous for a small PEM.
-      signal: AbortSignal.timeout(5000),
+    const { signal, cleanup } = createCombinedAbortSignal(undefined, {
+      timeoutMs: 5000,
     })
-    if (!resp.ok) {
-      logForDebugging(
-        `[upstreamproxy] ca-cert fetch ${resp.status}; proxy disabled`,
-        { level: 'warn' },
-      )
-      return false
+    let ccrCa: string
+    try {
+      // eslint-disable-next-line eslint-plugin-n/no-unsupported-features/node-builtins
+      const resp = await fetch(`${baseUrl}/v1/code/upstreamproxy/ca-cert`, {
+        // Bun has no default fetch timeout — a hung endpoint would block CLI
+        // startup forever. 5s is generous for a small PEM.
+        signal,
+      })
+      if (!resp.ok) {
+        logForDebugging(
+          `[upstreamproxy] ca-cert fetch ${resp.status}; proxy disabled`,
+          { level: 'warn' },
+        )
+        return false
+      }
+      ccrCa = await resp.text()
+    } finally {
+      cleanup()
     }
-    const ccrCa = await resp.text()
     if (!isValidPemContent(ccrCa)) {
       logForDebugging(
         `[upstreamproxy] ca-cert response is not valid PEM; proxy disabled`,

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -40,6 +40,7 @@ import {
   modelSupportsStructuredOutputs,
   shouldUseGlobalCacheScope,
 } from './betas.js'
+import { createCombinedAbortSignal } from './combinedAbortSignal.js'
 import { getCwd } from './cwd.js'
 import { logForDebugging } from './debug.js'
 import { isEnvTruthy } from './envUtils.js'
@@ -554,11 +555,19 @@ export async function logContextMetrics(
     ignorePatternsByRoot,
     currentDir,
   )
-  const fileCount = await countFilesRoundedRg(
-    currentDir,
-    AbortSignal.timeout(1000),
-    normalizedIgnorePatterns,
-  )
+  const { signal, cleanup } = createCombinedAbortSignal(undefined, {
+    timeoutMs: 1000,
+  })
+  let fileCount: number
+  try {
+    fileCount = await countFilesRoundedRg(
+      currentDir,
+      signal,
+      normalizedIgnorePatterns,
+    )
+  } finally {
+    cleanup()
+  }
 
   // Calculate tool metrics
   let mcpToolsCount = 0

--- a/src/utils/apiPreconnect.ts
+++ b/src/utils/apiPreconnect.ts
@@ -24,6 +24,7 @@
  */
 
 import { getOauthConfig } from '../constants/oauth.js'
+import { createCombinedAbortSignal } from './combinedAbortSignal.js'
 import { isEnvTruthy } from './envUtils.js'
 import { getAPIProvider } from './model/providers.js'
 
@@ -69,9 +70,14 @@ export function preconnectAnthropicApi(): void {
   // for keep-alive pool reuse immediately after headers arrive. 10s timeout
   // so a slow network doesn't hang the process; abort is fine since the real
   // request will handshake fresh if needed.
+  const { signal, cleanup } = createCombinedAbortSignal(undefined, {
+    timeoutMs: 10_000,
+  })
   // eslint-disable-next-line eslint-plugin-n/no-unsupported-features/node-builtins
   void fetch(baseUrl, {
     method: 'HEAD',
-    signal: AbortSignal.timeout(10_000),
-  }).catch(() => {})
+    signal,
+  })
+    .catch(() => {})
+    .finally(cleanup)
 }

--- a/src/utils/autoUpdater.ts
+++ b/src/utils/autoUpdater.ts
@@ -9,6 +9,7 @@ import {
   logEvent,
 } from 'src/services/analytics/index.js'
 import { type ReleaseChannel, saveGlobalConfig } from './config.js'
+import { createCombinedAbortSignal } from './combinedAbortSignal.js'
 import { getAPIProvider } from './model/providers.js'
 import { logForDebugging } from './debug.js'
 import { env } from './env.js'
@@ -32,6 +33,20 @@ const GCS_BUCKET_URL =
   'https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases'
 
 class AutoUpdaterError extends ClaudeError {}
+
+async function withTimeoutSignal<T>(
+  timeoutMs: number,
+  run: (signal: AbortSignal) => Promise<T>,
+): Promise<T> {
+  const { signal, cleanup } = createCombinedAbortSignal(undefined, {
+    timeoutMs,
+  })
+  try {
+    return await run(signal)
+  } finally {
+    cleanup()
+  }
+}
 
 export type InstallStatus =
   | 'success'
@@ -330,10 +345,12 @@ export async function getLatestVersion(
 
   // Run from home directory to avoid reading project-level .npmrc
   // which could be maliciously crafted to redirect to an attacker's registry
-  const result = await execFileNoThrowWithCwd(
-    'npm',
-    ['view', `${MACRO.PACKAGE_URL}@${npmTag}`, 'version', '--prefer-online'],
-    { abortSignal: AbortSignal.timeout(5000), cwd: homedir() },
+  const result = await withTimeoutSignal(5000, abortSignal =>
+    execFileNoThrowWithCwd(
+      'npm',
+      ['view', `${MACRO.PACKAGE_URL}@${npmTag}`, 'version', '--prefer-online'],
+      { abortSignal, cwd: homedir() },
+    ),
   )
   if (result.code !== 0) {
     logForDebugging(`npm view failed with code ${result.code}`)
@@ -361,10 +378,12 @@ export type NpmDistTags = {
  */
 export async function getNpmDistTags(): Promise<NpmDistTags> {
   // Run from home directory to avoid reading project-level .npmrc
-  const result = await execFileNoThrowWithCwd(
-    'npm',
-    ['view', MACRO.PACKAGE_URL, 'dist-tags', '--json', '--prefer-online'],
-    { abortSignal: AbortSignal.timeout(5000), cwd: homedir() },
+  const result = await withTimeoutSignal(5000, abortSignal =>
+    execFileNoThrowWithCwd(
+      'npm',
+      ['view', MACRO.PACKAGE_URL, 'dist-tags', '--json', '--prefer-online'],
+      { abortSignal, cwd: homedir() },
+    ),
   )
 
   if (result.code !== 0) {
@@ -435,11 +454,13 @@ export async function getVersionHistory(limit: number): Promise<string[]> {
   const packageUrl = MACRO.NATIVE_PACKAGE_URL ?? MACRO.PACKAGE_URL
 
   // Run from home directory to avoid reading project-level .npmrc
-  const result = await execFileNoThrowWithCwd(
-    'npm',
-    ['view', packageUrl, 'versions', '--json', '--prefer-online'],
-    // Longer timeout for version list
-    { abortSignal: AbortSignal.timeout(30000), cwd: homedir() },
+  const result = await withTimeoutSignal(30000, abortSignal =>
+    execFileNoThrowWithCwd(
+      'npm',
+      ['view', packageUrl, 'versions', '--json', '--prefer-online'],
+      // Longer timeout for version list
+      { abortSignal, cwd: homedir() },
+    ),
   )
 
   if (result.code !== 0) {

--- a/src/utils/codexCredentials.ts
+++ b/src/utils/codexCredentials.ts
@@ -1,4 +1,5 @@
 import { isBareMode } from './envUtils.js'
+import { createCombinedAbortSignal } from './combinedAbortSignal.js'
 import { getSecureStorage } from './secureStorage/index.js'
 import {
   asTrimmedString,
@@ -310,21 +311,29 @@ export async function refreshCodexAccessTokenIfNeeded(options?: {
         refresh_token: current.refreshToken,
       })
 
-      const response = await fetch(CODEX_REFRESH_URL, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/x-www-form-urlencoded',
-        },
-        body,
-        signal: AbortSignal.timeout(15_000),
+      const { signal, cleanup } = createCombinedAbortSignal(undefined, {
+        timeoutMs: 15_000,
       })
+      let payload: CodexTokenRefreshResponse
+      try {
+        const response = await fetch(CODEX_REFRESH_URL, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/x-www-form-urlencoded',
+          },
+          body,
+          signal,
+        })
 
-      if (!response.ok) {
-        const bodyText = await response.text().catch(() => '')
-        throw new Error(getRefreshErrorMessage(response.status, bodyText))
+        if (!response.ok) {
+          const bodyText = await response.text().catch(() => '')
+          throw new Error(getRefreshErrorMessage(response.status, bodyText))
+        }
+
+        payload = (await response.json()) as CodexTokenRefreshResponse
+      } finally {
+        cleanup()
       }
-
-      const payload = (await response.json()) as CodexTokenRefreshResponse
       const accessToken = asTrimmedString(payload.access_token)
       if (!accessToken) {
         throw new Error(

--- a/src/utils/combinedAbortSignal.test.ts
+++ b/src/utils/combinedAbortSignal.test.ts
@@ -1,0 +1,190 @@
+import { describe, expect, test } from 'bun:test'
+
+import { createCombinedAbortSignal } from './combinedAbortSignal.js'
+
+const delay = (ms: number): Promise<void> =>
+  new Promise(resolve => setTimeout(resolve, ms))
+
+function waitForAbort(signal: AbortSignal, timeoutMs = 1000): Promise<void> {
+  if (signal.aborted) return Promise.resolve()
+  return new Promise((resolve, reject) => {
+    let failTimer: ReturnType<typeof setTimeout>
+    const onAbort = () => {
+      signal.removeEventListener('abort', onAbort)
+      clearTimeout(failTimer)
+      resolve()
+    }
+
+    // Keep a ref'ed timer active while awaiting the helper's unref'ed timer.
+    // Without this guard, Bun on Windows can leave the test waiting forever.
+    failTimer = setTimeout(() => {
+      signal.removeEventListener('abort', onAbort)
+      reject(new Error(`AbortSignal did not abort within ${timeoutMs}ms`))
+    }, timeoutMs)
+
+    signal.addEventListener('abort', onAbort, { once: true })
+    if (signal.aborted) onAbort()
+  })
+}
+
+function instrumentAbortListeners(signal: AbortSignal): {
+  added: unknown[]
+  removed: unknown[]
+  restore: () => void
+} {
+  const added: unknown[] = []
+  const removed: unknown[] = []
+  const originalAdd = signal.addEventListener.bind(signal)
+  const originalRemove = signal.removeEventListener.bind(signal)
+
+  signal.addEventListener = ((type, listener, options) => {
+    if (type === 'abort') added.push(listener)
+    return originalAdd(type, listener, options)
+  }) as AbortSignal['addEventListener']
+
+  signal.removeEventListener = ((type, listener, options) => {
+    if (type === 'abort') removed.push(listener)
+    return originalRemove(type, listener, options)
+  }) as AbortSignal['removeEventListener']
+
+  return {
+    added,
+    removed,
+    restore: () => {
+      signal.addEventListener = originalAdd as AbortSignal['addEventListener']
+      signal.removeEventListener =
+        originalRemove as AbortSignal['removeEventListener']
+    },
+  }
+}
+
+describe('createCombinedAbortSignal', () => {
+  test('timeout aborts the combined signal after timeoutMs', async () => {
+    const { signal, cleanup } = createCombinedAbortSignal(undefined, {
+      timeoutMs: 5,
+    })
+
+    try {
+      await waitForAbort(signal)
+
+      expect(signal.aborted).toBe(true)
+      expect(signal.reason).toBeInstanceOf(DOMException)
+      expect((signal.reason as DOMException).name).toBe('TimeoutError')
+    } finally {
+      cleanup()
+    }
+  })
+
+  test('cleanup clears the timeout before it fires', async () => {
+    const { signal, cleanup } = createCombinedAbortSignal(undefined, {
+      timeoutMs: 5,
+    })
+
+    cleanup()
+    await delay(20)
+
+    expect(signal.aborted).toBe(false)
+  })
+
+  test('cleanup removes listeners from input signals', () => {
+    const sourceA = new AbortController()
+    const sourceB = new AbortController()
+    const listenersA = instrumentAbortListeners(sourceA.signal)
+    const listenersB = instrumentAbortListeners(sourceB.signal)
+
+    try {
+      const { signal, cleanup } = createCombinedAbortSignal(sourceA.signal, {
+        signalB: sourceB.signal,
+        timeoutMs: 100,
+      })
+
+      expect(listenersA.added).toHaveLength(1)
+      expect(listenersB.added).toHaveLength(1)
+
+      cleanup()
+
+      expect(listenersA.removed).toEqual(listenersA.added)
+      expect(listenersB.removed).toEqual(listenersB.added)
+
+      sourceA.abort()
+      sourceB.abort()
+      expect(signal.aborted).toBe(false)
+    } finally {
+      listenersA.restore()
+      listenersB.restore()
+    }
+  })
+
+  test('aborting the input signal aborts the combined signal', () => {
+    const source = new AbortController()
+    const { signal, cleanup } = createCombinedAbortSignal(source.signal, {
+      timeoutMs: 100,
+    })
+    const reason = new Error('caller cancelled')
+
+    try {
+      source.abort(reason)
+
+      expect(signal.aborted).toBe(true)
+      expect(signal.reason).toBe(reason)
+    } finally {
+      cleanup()
+    }
+  })
+
+  test('aborting signalB aborts the combined signal', () => {
+    const sourceA = new AbortController()
+    const sourceB = new AbortController()
+    const { signal, cleanup } = createCombinedAbortSignal(sourceA.signal, {
+      signalB: sourceB.signal,
+      timeoutMs: 100,
+    })
+    const reason = new Error('secondary cancelled')
+
+    try {
+      sourceB.abort(reason)
+
+      expect(signal.aborted).toBe(true)
+      expect(signal.reason).toBe(reason)
+    } finally {
+      cleanup()
+    }
+  })
+
+  test('already-aborted input signal returns an already-aborted combined signal', () => {
+    const source = new AbortController()
+    const reason = new Error('already cancelled')
+    source.abort(reason)
+
+    const { signal, cleanup } = createCombinedAbortSignal(source.signal, {
+      timeoutMs: 100,
+    })
+
+    try {
+      expect(signal.aborted).toBe(true)
+      expect(signal.reason).toBe(reason)
+    } finally {
+      cleanup()
+    }
+  })
+
+  test('cleanup is safe to call after completion', async () => {
+    const { signal, cleanup } = createCombinedAbortSignal(undefined, {
+      timeoutMs: 5,
+    })
+
+    await waitForAbort(signal)
+
+    expect(() => cleanup()).not.toThrow()
+  })
+
+  test('cleanup is safe to call more than once', () => {
+    const { cleanup } = createCombinedAbortSignal(undefined, {
+      timeoutMs: 100,
+    })
+
+    cleanup()
+
+    expect(() => cleanup()).not.toThrow()
+  })
+})

--- a/src/utils/combinedAbortSignal.ts
+++ b/src/utils/combinedAbortSignal.ts
@@ -19,29 +19,42 @@ export function createCombinedAbortSignal(
   const { signalB, timeoutMs } = opts ?? {}
   const combined = createAbortController()
 
-  if (signal?.aborted || signalB?.aborted) {
-    combined.abort()
+  if (signal?.aborted) {
+    combined.abort(signal.reason)
+    return { signal: combined.signal, cleanup: () => {} }
+  }
+  if (signalB?.aborted) {
+    combined.abort(signalB.reason)
     return { signal: combined.signal, cleanup: () => {} }
   }
 
   let timer: ReturnType<typeof setTimeout> | undefined
-  const abortCombined = () => {
-    if (timer !== undefined) clearTimeout(timer)
-    combined.abort()
+  let cleaned = false
+  const cleanup = () => {
+    if (cleaned) return
+    cleaned = true
+    if (timer !== undefined) {
+      clearTimeout(timer)
+      timer = undefined
+    }
+    signal?.removeEventListener('abort', abortFromSignal)
+    signalB?.removeEventListener('abort', abortFromSignalB)
   }
+  const abortCombined = (reason?: unknown) => {
+    cleanup()
+    combined.abort(reason)
+  }
+  const abortFromSignal = () => abortCombined(signal?.reason)
+  const abortFromSignalB = () => abortCombined(signalB?.reason)
+  const abortFromTimeout = () =>
+    abortCombined(new DOMException('The operation timed out.', 'TimeoutError'))
 
   if (timeoutMs !== undefined) {
-    timer = setTimeout(abortCombined, timeoutMs)
+    timer = setTimeout(abortFromTimeout, timeoutMs)
     timer.unref?.()
   }
-  signal?.addEventListener('abort', abortCombined)
-  signalB?.addEventListener('abort', abortCombined)
-
-  const cleanup = () => {
-    if (timer !== undefined) clearTimeout(timer)
-    signal?.removeEventListener('abort', abortCombined)
-    signalB?.removeEventListener('abort', abortCombined)
-  }
+  signal?.addEventListener('abort', abortFromSignal)
+  signalB?.addEventListener('abort', abortFromSignalB)
 
   return { signal: combined.signal, cleanup }
 }

--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -3,6 +3,7 @@ import { homedir } from 'os'
 import { join } from 'path'
 import { fileSuffixForOauthConfig } from '../constants/oauth.js'
 import { isRunningWithBun } from './bundledMode.js'
+import { createCombinedAbortSignal } from './combinedAbortSignal.js'
 import {
   getClaudeConfigHomeDir,
   isEnvTruthy,
@@ -72,10 +73,17 @@ export const getGlobalClaudeFile = memoize((): string => {
 const hasInternetAccess = memoize(async (): Promise<boolean> => {
   try {
     const { default: axiosClient } = await import('axios')
-    await axiosClient.head('http://1.1.1.1', {
-      signal: AbortSignal.timeout(1000),
+    const { signal, cleanup } = createCombinedAbortSignal(undefined, {
+      timeoutMs: 1000,
     })
-    return true
+    try {
+      await axiosClient.head('http://1.1.1.1', {
+        signal,
+      })
+      return true
+    } finally {
+      cleanup()
+    }
   } catch {
     return false
   }

--- a/src/utils/gracefulShutdown.ts
+++ b/src/utils/gracefulShutdown.ts
@@ -37,6 +37,7 @@ import {
 } from '../services/analytics/index.js'
 import type { AppState } from '../state/AppState.js'
 import { runCleanupFunctions } from './cleanupRegistry.js'
+import { createCombinedAbortSignal } from './combinedAbortSignal.js'
 import { logForDebugging } from './debug.js'
 import { logForDiagnosticsNoPII } from './diagLogs.js'
 import { isEnvTruthy } from './envUtils.js'
@@ -479,14 +480,19 @@ export async function gracefulShutdown(
   // Execute SessionEnd hooks. Bound both the per-hook default timeout and the
   // overall execution via a single budget (CLAUDE_CODE_SESSIONEND_HOOKS_TIMEOUT_MS,
   // default 1.5s). hook.timeout in settings is respected up to this cap.
+  const { signal, cleanup } = createCombinedAbortSignal(undefined, {
+    timeoutMs: sessionEndTimeoutMs,
+  })
   try {
     await executeSessionEndHooks(reason, {
       ...options,
-      signal: AbortSignal.timeout(sessionEndTimeoutMs),
+      signal,
       timeoutMs: sessionEndTimeoutMs,
     })
   } catch {
     // Ignore SessionEnd hook exceptions (including AbortError on timeout)
+  } finally {
+    cleanup()
   }
 
   // Log startup perf before analytics shutdown flushes/cancels timers

--- a/src/utils/hooks.ts
+++ b/src/utils/hooks.ts
@@ -4850,7 +4850,9 @@ export async function executeStatusLineCommand(
   }
 
   // Use provided signal or create a default one
-  const abortSignal = signal || AbortSignal.timeout(timeoutMs)
+  const { signal: abortSignal, cleanup } = signal
+    ? { signal, cleanup: () => {} }
+    : createCombinedAbortSignal(undefined, { timeoutMs })
 
   try {
     // Convert status input to JSON
@@ -4897,6 +4899,8 @@ export async function executeStatusLineCommand(
   } catch (error) {
     logForDebugging(`Status hook failed: ${error}`, { level: 'error' })
     return undefined
+  } finally {
+    cleanup()
   }
 }
 
@@ -4940,7 +4944,9 @@ export async function executeFileSuggestionCommand(
   }
 
   // Use provided signal or create a default one
-  const abortSignal = signal || AbortSignal.timeout(timeoutMs)
+  const { signal: abortSignal, cleanup } = signal
+    ? { signal, cleanup: () => {} }
+    : createCombinedAbortSignal(undefined, { timeoutMs })
 
   try {
     const jsonInput = jsonStringify(fileSuggestionInput)
@@ -4969,6 +4975,8 @@ export async function executeFileSuggestionCommand(
       level: 'error',
     })
     return []
+  } finally {
+    cleanup()
   }
 }
 

--- a/src/utils/markdownConfigLoader.ts
+++ b/src/utils/markdownConfigLoader.ts
@@ -9,6 +9,7 @@ import {
   logEvent,
 } from 'src/services/analytics/index.js'
 import { getProjectRoot } from '../bootstrap/state.js'
+import { createCombinedAbortSignal } from './combinedAbortSignal.js'
 import { logForDebugging } from './debug.js'
 import { getClaudeConfigHomeDir, isEnvTruthy } from './envUtils.js'
 import { isFsInaccessible } from './errors.js'
@@ -562,7 +563,9 @@ async function loadMarkdownFiles(dir: string): Promise<
   //
   // Why both? Ripgrep has poor startup performance in native builds.
   const useNative = isEnvTruthy(process.env.CLAUDE_CODE_USE_NATIVE_FILE_SEARCH)
-  const signal = AbortSignal.timeout(3000)
+  const { signal, cleanup } = createCombinedAbortSignal(undefined, {
+    timeoutMs: 3000,
+  })
   let files: string[]
   try {
     files = useNative
@@ -578,6 +581,8 @@ async function loadMarkdownFiles(dir: string): Promise<
     // ripGrep rejects on inaccessible target paths.
     if (isFsInaccessible(e)) return []
     throw e
+  } finally {
+    cleanup()
   }
 
   const results = await Promise.all(

--- a/src/utils/model/benchmark.ts
+++ b/src/utils/model/benchmark.ts
@@ -6,6 +6,7 @@
  */
 
 import { getAPIProvider } from './providers.js'
+import { createCombinedAbortSignal } from '../combinedAbortSignal.js'
 
 export interface BenchmarkResult {
   model: string
@@ -69,6 +70,9 @@ export async function benchmarkModel(
   let totalTokens = 0
   let firstTokenMs: number | null = null
 
+  const { signal, cleanup } = createCombinedAbortSignal(undefined, {
+    timeoutMs: TIMEOUT_MS,
+  })
   try {
     const response = await fetch(endpoint, {
       method: 'POST',
@@ -82,7 +86,7 @@ export async function benchmarkModel(
         max_tokens: MAX_TOKENS,
         stream: true,
       }),
-      signal: AbortSignal.timeout(TIMEOUT_MS),
+      signal,
     })
 
     if (!response.ok) {
@@ -163,6 +167,8 @@ export async function benchmarkModel(
       success: false,
       error: error instanceof Error ? error.message : 'Unknown error',
     }
+  } finally {
+    cleanup()
   }
 }
 


### PR DESCRIPTION
## Summary

- Replaced raw runtime `AbortSignal.timeout()` call sites with `createCombinedAbortSignal(..., { timeoutMs })` or equivalent cleanup-safe wrappers.
- Ensured timeout timers are released with `cleanup()` via `try/finally` for awaited operations and `.finally(cleanup)` for fire-and-forget promise chains.
- Made `createCombinedAbortSignal().cleanup()` idempotent and preserved abort reasons for input signals, secondary signals, and timeout aborts.
- Added focused helper tests plus a repository guard test that prevents new raw runtime `AbortSignal.timeout(` usage. The guard only allows the helper, explanatory docs, and intentional forbidden-pattern fixtures in tests.
- Follow-up: made the helper timeout tests deterministic across Bun environments by keeping a ref'ed fail-fast timer active while awaiting the production helper's unref'ed timeout timer.

## Why

The existing helper documents a Bun memory-retention issue where `AbortSignal.timeout()` timers are finalized lazily and can retain roughly 2.4KB per call until the timeout fires. This PR applies the cleanup-safe abstraction consistently across API/OAuth, MCP, hook, bridge, preconnect, updater, and provider flows.

## Impact

- User-facing: lower native memory retention on repeated timed operations, especially hooks, fetches, MCP auth/XAA requests, preconnects, usage polling, and bridge operations.
- Maintainer-facing: timeout signal behavior is centralized, cleanup is idempotent, existing abort signals are preserved, and the guard test blocks future raw runtime `AbortSignal.timeout()` regressions.

## Validation

- `bun test src/utils/combinedAbortSignal.test.ts scripts/no-raw-abort-signal-timeout.test.ts`
- Repeated helper test stability check: `for i in 1 2 3 4 5; do bun test src/utils/combinedAbortSignal.test.ts >/tmp/combinedAbortSignal-test-$i.log || exit 1; done`
- Nearby touched-area tests: `bun test src/utils/combinedAbortSignal.test.ts scripts/no-raw-abort-signal-timeout.test.ts src/utils/apiPreconnect.test.ts src/services/api/codexOAuth.test.ts src/services/api/codexUsage.test.ts src/services/api/minimaxUsage.test.ts src/services/mcp/auth.test.ts src/services/mcp/client.test.ts src/tools/WebSearchTool/providers/custom.test.ts src/upstreamproxy/upstreamproxy.test.ts src/utils/api.test.ts src/utils/codexCredentials.test.ts src/utils/hookChains.test.ts src/screens/replStartupGates.test.ts`
- `bun run build`
- `bun run smoke`
- Raw usage audit: `rg -n "AbortSignal\\s*\\.\\s*timeout\\s*\\(" -S --glob '!node_modules/**' --glob '!dist/**' --glob '!coverage/**' .` now reports only explanatory documentation comments in `src/utils/combinedAbortSignal.ts` and `src/services/mcp/client.ts`.

## Full-suite note

I also ran `bun test` and `env -u OPENAI_API_KEY -u OPENAI_BASE_URL -u OPENAI_API_BASE -u OPENAI_MODEL -u CLAUDE_CODE_USE_OPENAI bun test --max-concurrency=1`. In this desktop checkout, the full suite still reports existing order/env-sensitive failures in provider/profile/model tests and one knowledge-graph stress test. The reported failing files pass when run directly, and the timeout-specific plus touched-area validation above passes.
