### PR TITLE
feat(provider): add Qiniu provider support

### DIFF
--- a/src/integrations/brands/qiniu.ts
+++ b/src/integrations/brands/qiniu.ts
@@ -1,0 +1,16 @@
+import { defineBrand } from '../define.js'
+
+export default defineBrand({
+  id: 'qiniu',
+  label: 'Qiniu',
+  canonicalVendorId: 'qiniu',
+  defaultCapabilities: {
+    supportsVision: false,
+    supportsStreaming: true,
+    supportsFunctionCalling: true,
+    supportsJsonMode: true,
+    supportsReasoning: false,
+    supportsPreciseTokenCount: false,
+  },
+  modelIds: ['deepseek-v3'],
+})

--- a/src/integrations/compatibility.test.ts
+++ b/src/integrations/compatibility.test.ts
@@ -36,6 +36,7 @@ const EXPECTED_PRESETS = [
   'minimax',
   'xai',
   'venice',
+  'qiniu',
   'zai',
   'bankr',
   'atomic-chat',

--- a/src/integrations/generated/integrationArtifacts.generated.ts
+++ b/src/integrations/generated/integrationArtifacts.generated.ts
@@ -9,6 +9,7 @@ import vendorGemini from '../vendors/gemini.js'
 import vendorMinimax from '../vendors/minimax.js'
 import vendorMoonshot from '../vendors/moonshot.js'
 import vendorOpenai from '../vendors/openai.js'
+import vendorQiniu from '../vendors/qiniu.js'
 import vendorVenice from '../vendors/venice.js'
 import vendorXai from '../vendors/xai.js'
 import vendorZai from '../vendors/zai.js'
@@ -40,6 +41,7 @@ import brandMinimax from '../brands/minimax.js'
 import brandMistral from '../brands/mistral.js'
 import brandNemotron from '../brands/nemotron.js'
 import brandOpenaiCompatibleAlias from '../brands/openai-compatible-alias.js'
+import brandQiniu from '../brands/qiniu.js'
 import brandQwen from '../brands/qwen.js'
 import brandXai from '../brands/xai.js'
 import modelClaude from '../models/claude.js'
@@ -53,14 +55,15 @@ import modelMinimax from '../models/minimax.js'
 import modelMistral from '../models/mistral.js'
 import modelNemotron from '../models/nemotron.js'
 import modelOpenaiCompatibleAlias from '../models/openai-compatible-alias.js'
+import modelQiniu from '../models/qiniu.js'
 import modelQwen from '../models/qwen.js'
 import modelXai from '../models/xai.js'
 
-export const VENDOR_DESCRIPTORS = [vendorAnthropic, vendorBankr, vendorDeepseek, vendorGemini, vendorMinimax, vendorMoonshot, vendorOpenai, vendorVenice, vendorXai, vendorZai] as const satisfies readonly VendorDescriptor[]
+export const VENDOR_DESCRIPTORS = [vendorAnthropic, vendorBankr, vendorDeepseek, vendorGemini, vendorMinimax, vendorMoonshot, vendorOpenai, vendorQiniu, vendorVenice, vendorXai, vendorZai] as const satisfies readonly VendorDescriptor[]
 export const GATEWAY_DESCRIPTORS = [gatewayAtomicChat, gatewayAzureOpenai, gatewayBedrock, gatewayCustom, gatewayDashscopeCn, gatewayDashscopeIntl, gatewayGithub, gatewayGroq, gatewayHicap, gatewayKimiCode, gatewayLmstudio, gatewayMistral, gatewayNvidiaNim, gatewayOllama, gatewayOpenrouter, gatewayTogether, gatewayVertex] as const satisfies readonly GatewayDescriptor[]
 export const ANTHROPIC_PROXY_DESCRIPTORS = [] as const satisfies readonly AnthropicProxyDescriptor[]
-export const BRAND_DESCRIPTORS = [brandClaude, brandDeepseek, brandGemini, brandGlm, brandGpt, brandKimi, brandLlama, brandMinimax, brandMistral, brandNemotron, brandOpenaiCompatibleAlias, brandQwen, brandXai] as const satisfies readonly BrandDescriptor[]
-export const MODEL_DESCRIPTOR_GROUPS = [modelClaude, modelDeepseek, modelGemini, modelGlm, modelGpt, modelKimi, modelLlama, modelMinimax, modelMistral, modelNemotron, modelOpenaiCompatibleAlias, modelQwen, modelXai] as const satisfies readonly (readonly ModelDescriptor[])[]
+export const BRAND_DESCRIPTORS = [brandClaude, brandDeepseek, brandGemini, brandGlm, brandGpt, brandKimi, brandLlama, brandMinimax, brandMistral, brandNemotron, brandOpenaiCompatibleAlias, brandQiniu, brandQwen, brandXai] as const satisfies readonly BrandDescriptor[]
+export const MODEL_DESCRIPTOR_GROUPS = [modelClaude, modelDeepseek, modelGemini, modelGlm, modelGpt, modelKimi, modelLlama, modelMinimax, modelMistral, modelNemotron, modelOpenaiCompatibleAlias, modelQiniu, modelQwen, modelXai] as const satisfies readonly (readonly ModelDescriptor[])[]
 export const MODEL_DESCRIPTORS = MODEL_DESCRIPTOR_GROUPS.flat() satisfies readonly ModelDescriptor[]
 
 export const PROVIDER_PRESET_MANIFEST = [
@@ -282,6 +285,16 @@ export const PROVIDER_PRESET_MANIFEST = [
     ]
   },
   {
+    "preset": "qiniu",
+    "routeKind": "vendor",
+    "routeId": "qiniu",
+    "vendorId": "qiniu",
+    "description": "Qiniu OpenAI-compatible endpoint",
+    "apiKeyEnvVars": [
+      "QINIU_API_KEY"
+    ]
+  },
+  {
     "preset": "together",
     "routeKind": "gateway",
     "routeId": "together",
@@ -376,6 +389,7 @@ export const ORDERED_PROVIDER_PRESETS = [
   "nvidia-nim",
   "openai",
   "openrouter",
+  "qiniu",
   "together",
   "venice",
   "xai",

--- a/src/integrations/index.test.ts
+++ b/src/integrations/index.test.ts
@@ -22,6 +22,23 @@ describe('loaded registry validation', () => {
     expect(result.errors).toHaveLength(0)
   })
 
+  test('Qiniu has shared brand and model descriptors wired to its route catalog', () => {
+    expect(getBrandsForVendor('qiniu').map(brand => brand.id)).toContain(
+      'qiniu',
+    )
+    expect(getModelsForVendor('qiniu').map(model => model.id)).toContain(
+      'deepseek-v3',
+    )
+    expect(
+      getCatalogEntriesForRoute('qiniu').every(entry =>
+        Boolean(entry.modelDescriptorId),
+      ),
+    ).toBe(true)
+    expect(routeSupportsApiFormatSelection('qiniu')).toBe(false)
+    expect(routeSupportsAuthHeaders('qiniu')).toBe(false)
+    expect(routeSupportsCustomHeaders('qiniu')).toBe(false)
+  })
+
   test('MiniMax has shared brand and model descriptors wired to its route catalog', () => {
     expect(getBrandsForVendor('minimax').map(brand => brand.id)).toContain(
       'minimax',

--- a/src/integrations/models/qiniu.ts
+++ b/src/integrations/models/qiniu.ts
@@ -1,0 +1,22 @@
+import { defineModel } from '../define.js'
+
+export default [
+  defineModel({
+    id: 'deepseek-v3',
+    label: 'DeepSeek V3',
+    brandId: 'qiniu',
+    vendorId: 'qiniu',
+    classification: ['chat', 'coding'],
+    defaultModel: 'deepseek-v3',
+    capabilities: {
+      supportsVision: false,
+      supportsStreaming: true,
+      supportsFunctionCalling: true,
+      supportsJsonMode: true,
+      supportsReasoning: false,
+      supportsPreciseTokenCount: false,
+    },
+    contextWindow: 128_000,
+    maxOutputTokens: 8_192,
+  }),
+]

--- a/src/integrations/routeMetadata.test.ts
+++ b/src/integrations/routeMetadata.test.ts
@@ -48,6 +48,10 @@ test('getRouteCredentialEnvVars keeps descriptor env vars and openai fallback fo
     'VENICE_API_KEY',
     'OPENAI_API_KEY',
   ])
+  expect(getRouteCredentialEnvVars('qiniu')).toEqual([
+    'QINIU_API_KEY',
+    'OPENAI_API_KEY',
+  ])
 })
 
 test('getRouteCredentialValue reads the first configured route credential', () => {
@@ -70,6 +74,15 @@ test('Venice route metadata uses official OpenAI-compatible defaults', () => {
   expect(resolveRouteIdFromBaseUrl('https://api.venice.ai/api/v1/chat/completions')).toBe('venice')
 })
 
+test('Qiniu route metadata uses official OpenAI-compatible defaults', () => {
+  expect(getRouteDefaultBaseUrl('qiniu')).toBe('https://api.qnaigc.com/v1')
+  expect(getRouteDefaultModel('qiniu')).toBe('deepseek-v3')
+  expect(resolveRouteIdFromBaseUrl('https://api.qnaigc.com/v1')).toBe('qiniu')
+  expect(resolveRouteIdFromBaseUrl('https://api.qnaigc.com/v1/chat/completions')).toBe(
+    'qiniu',
+  )
+})
+
 test('resolveActiveRouteIdFromEnv treats MiniMax credential-only env as MiniMax', () => {
   expect(
     resolveActiveRouteIdFromEnv({
@@ -84,6 +97,14 @@ test('resolveActiveRouteIdFromEnv treats Venice credential-only env as Venice', 
       VENICE_API_KEY: 'venice-key',
     }),
   ).toBe('venice')
+})
+
+test('resolveActiveRouteIdFromEnv treats Qiniu credential-only env as Qiniu', () => {
+  expect(
+    resolveActiveRouteIdFromEnv({
+      QINIU_API_KEY: 'qiniu-key',
+    }),
+  ).toBe('qiniu')
 })
 test('resolveActiveRouteIdFromEnv treats xAI credential-only env as xAI', () => {
   expect(
@@ -130,6 +151,7 @@ test.each([
   ['DeepSeek', 'https://api.deepseek.com/v1', 'deepseek-v4-pro', 'deepseek'],
   ['Hicap', 'https://api.hicap.ai/v1', 'claude-opus-4.7', 'hicap'],
   ['Venice', 'https://api.venice.ai/api/v1', 'venice-uncensored', 'venice'],
+  ['Qiniu', 'https://api.qnaigc.com/v1', 'deepseek-v3', 'qiniu'],
 ])(
   'resolveActiveRouteIdFromEnv refines generic OpenAI profile by %s base URL',
   (_label, baseUrl, model, expectedRouteId) => {

--- a/src/integrations/routeMetadata.ts
+++ b/src/integrations/routeMetadata.ts
@@ -215,6 +215,19 @@ export function isVeniceBaseUrl(value: string | undefined): boolean {
     return false
   }
 }
+
+export function isQiniuBaseUrl(value: string | undefined): boolean {
+  const trimmed = value?.trim()
+  if (!trimmed) {
+    return false
+  }
+
+  try {
+    return new URL(trimmed).hostname.toLowerCase() === 'api.qnaigc.com'
+  } catch {
+    return false
+  }
+}
 export function getMiniMaxBaseUrlOverride(
   processEnv: NodeJS.ProcessEnv = process.env,
 ): string | undefined {
@@ -241,6 +254,22 @@ export function getXaiBaseUrlOverride(
 
   const openAIApiBase = processEnv.OPENAI_API_BASE?.trim()
   if (isXaiBaseUrl(openAIApiBase)) {
+    return openAIApiBase
+  }
+
+  return undefined
+}
+
+export function getQiniuBaseUrlOverride(
+  processEnv: NodeJS.ProcessEnv = process.env,
+): string | undefined {
+  const openAIBaseUrl = processEnv.OPENAI_BASE_URL?.trim()
+  if (isQiniuBaseUrl(openAIBaseUrl)) {
+    return openAIBaseUrl
+  }
+
+  const openAIApiBase = processEnv.OPENAI_API_BASE?.trim()
+  if (isQiniuBaseUrl(openAIApiBase)) {
     return openAIApiBase
   }
 
@@ -305,14 +334,29 @@ export function hasVeniceEnvOnlyProviderIntent(
     !hasNonEmptyEnvValue(processEnv.OPENAI_API_KEY) &&
     !hasNonEmptyEnvValue(processEnv.XAI_API_KEY) &&
     !hasNonEmptyEnvValue(processEnv.MINIMAX_API_KEY) &&
+    !hasNonEmptyEnvValue(processEnv.QINIU_API_KEY) &&
     !hasConflictingOpenAIBaseUrlForRoute(processEnv, isVeniceBaseUrl) &&
+    hasNoExplicitNonOpenAICompatibleProvider(processEnv)
+  )
+}
+
+export function hasQiniuEnvOnlyProviderIntent(
+  processEnv: NodeJS.ProcessEnv = process.env,
+): boolean {
+  return (
+    hasNonEmptyEnvValue(processEnv.QINIU_API_KEY) &&
+    !hasNonEmptyEnvValue(processEnv.OPENAI_API_KEY) &&
+    !hasNonEmptyEnvValue(processEnv.XAI_API_KEY) &&
+    !hasNonEmptyEnvValue(processEnv.MINIMAX_API_KEY) &&
+    !hasNonEmptyEnvValue(processEnv.VENICE_API_KEY) &&
+    !hasConflictingOpenAIBaseUrlForRoute(processEnv, isQiniuBaseUrl) &&
     hasNoExplicitNonOpenAICompatibleProvider(processEnv)
   )
 }
 
 export function resolveEnvOnlyProviderRouteId(
   processEnv: NodeJS.ProcessEnv = process.env,
-): 'xai' | 'minimax' | 'venice' | null {
+): 'xai' | 'minimax' | 'venice' | 'qiniu' | null {
   if (hasXaiEnvOnlyProviderIntent(processEnv)) {
     return 'xai'
   }
@@ -323,6 +367,10 @@ export function resolveEnvOnlyProviderRouteId(
 
   if (hasVeniceEnvOnlyProviderIntent(processEnv)) {
     return 'venice'
+  }
+
+  if (hasQiniuEnvOnlyProviderIntent(processEnv)) {
+    return 'qiniu'
   }
 
   return null

--- a/src/integrations/runtimeMetadata.ts
+++ b/src/integrations/runtimeMetadata.ts
@@ -366,6 +366,7 @@ export function usesAnthropicNativeMessageFormat(options?: {
     | 'nvidia-nim'
     | 'minimax'
     | 'mistral'
+    | 'qiniu'
 }): boolean {
   const processEnv = options?.processEnv ?? process.env
   const providerCategory = options?.providerCategory

--- a/src/integrations/vendors/qiniu.ts
+++ b/src/integrations/vendors/qiniu.ts
@@ -1,0 +1,53 @@
+import { defineVendor } from '../define.js'
+
+export default defineVendor({
+  id: 'qiniu',
+  label: 'Qiniu',
+  classification: 'openai-compatible',
+  defaultBaseUrl: 'https://api.qnaigc.com/v1',
+  defaultModel: 'deepseek-v3',
+  requiredEnvVars: ['QINIU_API_KEY'],
+  setup: {
+    requiresAuth: true,
+    authMode: 'api-key',
+    credentialEnvVars: ['QINIU_API_KEY'],
+  },
+  transportConfig: {
+    kind: 'openai-compatible',
+    openaiShim: {
+      supportsApiFormatSelection: false,
+      supportsAuthHeaders: false,
+    },
+  },
+  preset: {
+    id: 'qiniu',
+    description: 'Qiniu OpenAI-compatible endpoint',
+    apiKeyEnvVars: ['QINIU_API_KEY'],
+  },
+  validation: {
+    kind: 'credential-env',
+    routing: {
+      matchDefaultBaseUrl: true,
+      matchBaseUrlHosts: ['api.qnaigc.com'],
+    },
+    credentialEnvVars: ['QINIU_API_KEY', 'OPENAI_API_KEY'],
+    missingCredentialMessage:
+      'Qiniu auth is required. Set QINIU_API_KEY or OPENAI_API_KEY.',
+  },
+  catalog: {
+    source: 'hybrid',
+    discovery: { kind: 'openai-compatible' },
+    discoveryCacheTtl: '1d',
+    discoveryRefreshMode: 'background-if-stale',
+    allowManualRefresh: true,
+    models: [
+      {
+        id: 'deepseek-v3',
+        apiName: 'deepseek-v3',
+        label: 'DeepSeek V3',
+        modelDescriptorId: 'deepseek-v3',
+      },
+    ],
+  },
+  usage: { supported: false },
+})

--- a/src/services/api/client.ts
+++ b/src/services/api/client.ts
@@ -36,6 +36,7 @@ import {
 } from '../../utils/envUtils.js'
 import {
   getMiniMaxBaseUrlOverride,
+  getQiniuBaseUrlOverride,
   getRouteDefaultBaseUrl,
   getRouteDefaultModel,
   getXaiBaseUrlOverride,
@@ -157,6 +158,22 @@ function applyXaiEnvOnlyDefaults(): void {
       : undefined) ??
     getRouteDefaultModel('xai')
   process.env.OPENAI_API_KEY = process.env.XAI_API_KEY
+  delete process.env.OPENAI_API_FORMAT
+  delete process.env.OPENAI_AUTH_HEADER
+  delete process.env.OPENAI_AUTH_SCHEME
+  delete process.env.OPENAI_AUTH_HEADER_VALUE
+}
+
+function applyQiniuEnvOnlyDefaults(): void {
+  const baseUrlOverride = getQiniuBaseUrlOverride()
+  const modelOverride = process.env.OPENAI_MODEL?.trim() || undefined
+
+  process.env.CLAUDE_CODE_USE_OPENAI = '1'
+  process.env.OPENAI_BASE_URL =
+    baseUrlOverride ?? getRouteDefaultBaseUrl('qiniu')
+  process.env.OPENAI_MODEL =
+    modelOverride ?? getRouteDefaultModel('qiniu')
+  process.env.OPENAI_API_KEY = process.env.QINIU_API_KEY
   delete process.env.OPENAI_API_FORMAT
   delete process.env.OPENAI_AUTH_HEADER
   delete process.env.OPENAI_AUTH_SCHEME
@@ -287,16 +304,21 @@ export async function getAnthropicClient({
   const envOnlyProviderRouteId = resolveEnvOnlyProviderRouteId(process.env)
   const useXaiEnvOnlyProvider = envOnlyProviderRouteId === 'xai'
   const useMiniMaxEnvOnlyProvider = envOnlyProviderRouteId === 'minimax'
+  const useQiniuEnvOnlyProvider = envOnlyProviderRouteId === 'qiniu'
   if (useMiniMaxEnvOnlyProvider) {
     applyMiniMaxEnvOnlyDefaults()
   }
   if (useXaiEnvOnlyProvider) {
     applyXaiEnvOnlyDefaults()
   }
+  if (useQiniuEnvOnlyProvider) {
+    applyQiniuEnvOnlyDefaults()
+  }
 
   if (
     useMiniMaxEnvOnlyProvider ||
     useXaiEnvOnlyProvider ||
+    useQiniuEnvOnlyProvider ||
     isEnvTruthy(process.env.CLAUDE_CODE_USE_OPENAI) ||
     isEnvTruthy(process.env.CLAUDE_CODE_USE_GITHUB) ||
     isEnvTruthy(process.env.CLAUDE_CODE_USE_GEMINI) ||

--- a/src/services/api/openaiShim.ts
+++ b/src/services/api/openaiShim.ts
@@ -1995,6 +1995,7 @@ class OpenAIShimMessages {
     let response: Response | undefined
     const provider = request.baseUrl.includes('nvidia') ? 'nvidia-nim'
       : request.baseUrl.includes('minimax') ? 'minimax'
+      : request.baseUrl.includes('qnaigc') ? 'qiniu'
       : request.baseUrl.includes('localhost:11434') || request.baseUrl.includes('localhost:11435') ? 'ollama'
       : request.baseUrl.includes('anthropic') ? 'anthropic'
       : 'openai'

--- a/src/utils/model/configs.ts
+++ b/src/utils/model/configs.ts
@@ -48,6 +48,7 @@ export const CLAUDE_3_7_SONNET_CONFIG = {
   'nvidia-nim': 'nvidia/llama-3.1-nemotron-70b-instruct',
   minimax: 'MiniMax-M2.5',
   xai: 'grok-4.3',
+  qiniu: 'deepseek-v3',
 } as const satisfies LegacyProviderModelConfig
 
 export const CLAUDE_3_5_V2_SONNET_CONFIG = {
@@ -63,6 +64,7 @@ export const CLAUDE_3_5_V2_SONNET_CONFIG = {
   'nvidia-nim': 'nvidia/llama-3.1-nemotron-70b-instruct',
   minimax: 'MiniMax-M2.5',
   xai: 'grok-4.3',
+  qiniu: 'deepseek-v3',
 } as const satisfies LegacyProviderModelConfig
 
 export const CLAUDE_3_5_HAIKU_CONFIG = {
@@ -78,6 +80,7 @@ export const CLAUDE_3_5_HAIKU_CONFIG = {
   'nvidia-nim': 'nvidia/llama-3.1-nemotron-70b-instruct',
   minimax: 'MiniMax-M2.5',
   xai: 'grok-4.3',
+  qiniu: 'deepseek-v3',
 } as const satisfies LegacyProviderModelConfig
 
 export const CLAUDE_HAIKU_4_5_CONFIG = {
@@ -93,6 +96,7 @@ export const CLAUDE_HAIKU_4_5_CONFIG = {
   'nvidia-nim': 'nvidia/llama-3.1-nemotron-70b-instruct',
   minimax: 'MiniMax-M2.5',
   xai: 'grok-4.3',
+  qiniu: 'deepseek-v3',
 } as const satisfies LegacyProviderModelConfig
 
 export const CLAUDE_SONNET_4_CONFIG = {
@@ -108,6 +112,7 @@ export const CLAUDE_SONNET_4_CONFIG = {
   'nvidia-nim': 'nvidia/llama-3.1-nemotron-70b-instruct',
   minimax: 'MiniMax-M2.5',
   xai: 'grok-4.3',
+  qiniu: 'deepseek-v3',
 } as const satisfies LegacyProviderModelConfig
 
 export const CLAUDE_SONNET_4_5_CONFIG = {
@@ -123,6 +128,7 @@ export const CLAUDE_SONNET_4_5_CONFIG = {
   'nvidia-nim': 'nvidia/llama-3.1-nemotron-70b-instruct',
   minimax: 'MiniMax-M2.5',
   xai: 'grok-4.3',
+  qiniu: 'deepseek-v3',
 } as const satisfies LegacyProviderModelConfig
 
 export const CLAUDE_OPUS_4_CONFIG = {
@@ -138,6 +144,7 @@ export const CLAUDE_OPUS_4_CONFIG = {
   'nvidia-nim': 'nvidia/llama-3.1-nemotron-70b-instruct',
   minimax: 'MiniMax-M2.5',
   xai: 'grok-4.3',
+  qiniu: 'deepseek-v3',
 } as const satisfies LegacyProviderModelConfig
 
 export const CLAUDE_OPUS_4_1_CONFIG = {
@@ -153,6 +160,7 @@ export const CLAUDE_OPUS_4_1_CONFIG = {
   'nvidia-nim': 'nvidia/llama-3.1-nemotron-70b-instruct',
   minimax: 'MiniMax-M2.5',
   xai: 'grok-4.3',
+  qiniu: 'deepseek-v3',
 } as const satisfies LegacyProviderModelConfig
 
 export const CLAUDE_OPUS_4_5_CONFIG = {
@@ -168,6 +176,7 @@ export const CLAUDE_OPUS_4_5_CONFIG = {
   'nvidia-nim': 'nvidia/llama-3.1-nemotron-70b-instruct',
   minimax: 'MiniMax-M2.5',
   xai: 'grok-4.3',
+  qiniu: 'deepseek-v3',
 } as const satisfies LegacyProviderModelConfig
 
 export const CLAUDE_OPUS_4_6_CONFIG = {
@@ -183,6 +192,7 @@ export const CLAUDE_OPUS_4_6_CONFIG = {
   'nvidia-nim': 'nvidia/llama-3.1-nemotron-70b-instruct',
   minimax: 'MiniMax-M2.5',
   xai: 'grok-4.3',
+  qiniu: 'deepseek-v3',
 } as const satisfies LegacyProviderModelConfig
 
 export const CLAUDE_OPUS_4_7_CONFIG = {
@@ -198,6 +208,7 @@ export const CLAUDE_OPUS_4_7_CONFIG = {
   'nvidia-nim': 'nvidia/llama-3.1-nemotron-70b-instruct',
   minimax: 'MiniMax-M2.5',
   xai: 'grok-4.3',
+  qiniu: 'deepseek-v3',
 } as const satisfies LegacyProviderModelConfig
 
 export const CLAUDE_SONNET_4_6_CONFIG = {
@@ -213,6 +224,7 @@ export const CLAUDE_SONNET_4_6_CONFIG = {
   'nvidia-nim': 'nvidia/llama-3.1-nemotron-70b-instruct',
   minimax: 'MiniMax-M2.5',
   xai: 'grok-4.3',
+  qiniu: 'deepseek-v3',
 } as const satisfies LegacyProviderModelConfig
 
 // @[MODEL LAUNCH]: Register the new config here.

--- a/src/utils/model/model.ts
+++ b/src/utils/model/model.ts
@@ -76,6 +76,9 @@ export function getSmallFastModel(): ModelName {
   if (getAPIProvider() === 'xai') {
     return process.env.OPENAI_MODEL || 'grok-3'
   }
+  if (getAPIProvider() === 'qiniu') {
+    return process.env.OPENAI_MODEL || 'deepseek-v3'
+  }
   return getDefaultHaikuModel()
 }
 
@@ -126,7 +129,8 @@ export function getUserSpecifiedModelSetting(): ModelSetting | undefined {
       provider === 'github' ||
       provider === 'nvidia-nim' ||
       provider === 'minimax' ||
-      provider === 'xai'
+      provider === 'xai' ||
+      provider === 'qiniu'
     specifiedModel =
       (provider === 'gemini' ? process.env.GEMINI_MODEL : undefined) ||
       (provider === 'mistral' ? process.env.MISTRAL_MODEL : undefined) ||
@@ -205,6 +209,9 @@ export function getDefaultOpusModel(): ModelName {
   if (getAPIProvider() === 'xai') {
     return process.env.OPENAI_MODEL || 'grok-4.3'
   }
+  if (getAPIProvider() === 'qiniu') {
+    return process.env.OPENAI_MODEL || 'deepseek-v3'
+  }
   // 3P providers (Bedrock, Vertex, Foundry) — kept as a separate branch
   // since 3P availability lags firstParty and these will diverge again at
   // the next model launch. Keep 3P on Opus 4.6 until they roll out 4.7.
@@ -251,6 +258,9 @@ export function getDefaultSonnetModel(): ModelName {
   if (getAPIProvider() === 'xai') {
     return process.env.OPENAI_MODEL || 'grok-4.3'
   }
+  if (getAPIProvider() === 'qiniu') {
+    return process.env.OPENAI_MODEL || 'deepseek-v3'
+  }
   // Default to Sonnet 4.5 for 3P since they may not have 4.6 yet
   if (getAPIProvider() !== 'firstParty') {
     return getModelStrings().sonnet45
@@ -294,6 +304,9 @@ export function getDefaultHaikuModel(): ModelName {
   // xAI — faster Grok model for "haiku"-equivalent.
   if (getAPIProvider() === 'xai') {
     return process.env.OPENAI_MODEL || 'grok-3'
+  }
+  if (getAPIProvider() === 'qiniu') {
+    return process.env.OPENAI_MODEL || 'deepseek-v3'
   }
 
   // Haiku 4.5 is available on all platforms (first-party, Foundry, Bedrock, Vertex)
@@ -370,6 +383,9 @@ export function getDefaultMainLoopModelSetting(): ModelName | ModelAlias {
   // MiniMax provider: always use the configured MiniMax model
   if (getAPIProvider() === 'minimax') {
     return process.env.OPENAI_MODEL || 'MiniMax-M2.7'
+  }
+  if (getAPIProvider() === 'qiniu') {
+    return process.env.OPENAI_MODEL || 'deepseek-v3'
   }
 
   // Ants default to defaultModel from flag config, or Opus 1M if not configured
@@ -562,6 +578,7 @@ export function getPublicModelDisplayName(model: ModelName): string | null {
     getAPIProvider() === 'github' ||
     getAPIProvider() === 'xai' ||
     getAPIProvider() === 'minimax' ||
+    getAPIProvider() === 'qiniu' ||
     getAPIProvider() === 'nvidia-nim' ||
     getAPIProvider() === 'mistral'
   ) {

--- a/src/utils/model/providers.test.ts
+++ b/src/utils/model/providers.test.ts
@@ -9,6 +9,7 @@ const originalEnv = {
   CLAUDE_CODE_USE_FOUNDRY: process.env.CLAUDE_CODE_USE_FOUNDRY,
   NVIDIA_NIM: process.env.NVIDIA_NIM,
   MINIMAX_API_KEY: process.env.MINIMAX_API_KEY,
+  QINIU_API_KEY: process.env.QINIU_API_KEY,
   OPENAI_BASE_URL: process.env.OPENAI_BASE_URL,
   OPENAI_API_BASE: process.env.OPENAI_API_BASE,
   OPENAI_MODEL: process.env.OPENAI_MODEL,
@@ -24,6 +25,7 @@ afterEach(() => {
   process.env.CLAUDE_CODE_USE_FOUNDRY = originalEnv.CLAUDE_CODE_USE_FOUNDRY
   process.env.NVIDIA_NIM = originalEnv.NVIDIA_NIM
   process.env.MINIMAX_API_KEY = originalEnv.MINIMAX_API_KEY
+  process.env.QINIU_API_KEY = originalEnv.QINIU_API_KEY
   process.env.OPENAI_BASE_URL = originalEnv.OPENAI_BASE_URL
   process.env.OPENAI_API_BASE = originalEnv.OPENAI_API_BASE
   process.env.OPENAI_MODEL = originalEnv.OPENAI_MODEL
@@ -43,6 +45,7 @@ function clearProviderEnv(): void {
   delete process.env.CLAUDE_CODE_USE_FOUNDRY
   delete process.env.NVIDIA_NIM
   delete process.env.MINIMAX_API_KEY
+  delete process.env.QINIU_API_KEY
   delete process.env.OPENAI_BASE_URL
   delete process.env.OPENAI_API_BASE
   delete process.env.OPENAI_MODEL
@@ -199,6 +202,24 @@ test('env-only MiniMax API key resolves to the minimax provider', async () => {
 
   const { getAPIProvider } = await importFreshProvidersModule()
   expect(getAPIProvider()).toBe('minimax')
+})
+
+test('descriptor-backed Qiniu routes keep the legacy qiniu provider category', async () => {
+  clearProviderEnv()
+  process.env.CLAUDE_CODE_USE_OPENAI = '1'
+  process.env.OPENAI_BASE_URL = 'https://api.qnaigc.com/v1'
+  process.env.QINIU_API_KEY = 'qiniu-key'
+
+  const { getAPIProvider } = await importFreshProvidersModule()
+  expect(getAPIProvider()).toBe('qiniu')
+})
+
+test('env-only Qiniu API key resolves to the qiniu provider', async () => {
+  clearProviderEnv()
+  process.env.QINIU_API_KEY = 'qiniu-key'
+
+  const { getAPIProvider } = await importFreshProvidersModule()
+  expect(getAPIProvider()).toBe('qiniu')
 })
 
 test('conflicting OpenAI base prevents env-only MiniMax provider label', async () => {

--- a/src/utils/model/providers.ts
+++ b/src/utils/model/providers.ts
@@ -22,6 +22,7 @@ export type LegacyAPIProvider =
   | 'minimax'
   | 'mistral'
   | 'xai'
+  | 'qiniu'
 
 // Backward-compatible public alias. Keep importing APIProvider where callers
 // intentionally consume the legacy category surface.
@@ -51,6 +52,8 @@ export function getAPIProvider(): LegacyAPIProvider {
       return 'minimax'
     case 'xai':
       return 'xai'
+    case 'qiniu':
+      return 'qiniu'
     case 'openai':
     case 'custom':
       if (isEnvTruthy(process.env.NVIDIA_NIM)) {

--- a/src/utils/providerAutoDetect.test.ts
+++ b/src/utils/providerAutoDetect.test.ts
@@ -112,6 +112,22 @@ describe('detectProviderFromEnv — priority order', () => {
     })
   })
 
+  test('QINIU_API_KEY detected', () => {
+    expect(scan({ QINIU_API_KEY: 'qn-x' })).toEqual({
+      kind: 'qiniu',
+      source: 'QINIU_API_KEY set',
+    })
+  })
+
+  test('MINIMAX_API_KEY wins over QINIU_API_KEY', () => {
+    expect(
+      scan({
+        MINIMAX_API_KEY: 'mm-x',
+        QINIU_API_KEY: 'qn-x',
+      }),
+    ).toEqual({ kind: 'minimax', source: 'MINIMAX_API_KEY set' })
+  })
+
   test('XAI_API_KEY detected', () => {
     expect(scan({ XAI_API_KEY: 'xai-x' })).toEqual({
       kind: 'xai',

--- a/src/utils/providerAutoDetect.ts
+++ b/src/utils/providerAutoDetect.ts
@@ -16,9 +16,10 @@
  *   5. GEMINI_API_KEY or GOOGLE_API_KEY
  *   6. MISTRAL_API_KEY
  *   7. MINIMAX_API_KEY
- *   8. XAI_API_KEY
- *   9. Local Ollama reachable (default localhost:11434)
- *  10. Local LM Studio reachable (default localhost:1234)
+ *   8. QINIU_API_KEY
+ *   9. XAI_API_KEY
+ *  10. Local Ollama reachable (default localhost:11434)
+ *  11. Local LM Studio reachable (default localhost:1234)
  *
  * Local-service probes are parallelized and cheap (short timeout, no
  * request body). Env scans are synchronous and run first so we don't make
@@ -41,6 +42,7 @@ export type DetectedProviderKind =
   | 'gemini'
   | 'mistral'
   | 'minimax'
+  | 'qiniu'
   | 'xai'
   | 'ollama'
   | 'lm-studio'
@@ -159,6 +161,10 @@ export function detectProviderFromEnv(
 
   if (envHasNonEmpty(env, 'MINIMAX_API_KEY')) {
     return { kind: 'minimax', source: 'MINIMAX_API_KEY set' }
+  }
+
+  if (envHasNonEmpty(env, 'QINIU_API_KEY')) {
+    return { kind: 'qiniu', source: 'QINIU_API_KEY set' }
   }
 
   if (envHasNonEmpty(env, 'XAI_API_KEY')) {

--- a/src/utils/providerFlag.test.ts
+++ b/src/utils/providerFlag.test.ts
@@ -308,6 +308,17 @@ describe('applyProviderFlag - minimax', () => {
   })
 })
 
+describe('applyProviderFlag - qiniu', () => {
+  test('preserves Qiniu default base URL and model semantics', () => {
+    const result = applyProviderFlag('qiniu', [])
+
+    expect(result.error).toBeUndefined()
+    expect(process.env.CLAUDE_CODE_USE_OPENAI).toBe('1')
+    expect(process.env.OPENAI_BASE_URL).toBe('https://api.qnaigc.com/v1')
+    expect(process.env.OPENAI_MODEL).toBe('deepseek-v3')
+  })
+})
+
 describe('applyProviderFlag - nvidia-nim', () => {
   test('maps NVIDIA_API_KEY into the OPENAI-compatible auth env when present', () => {
     process.env.NVIDIA_API_KEY = 'nvidia-live-key'

--- a/src/utils/providerFlag.ts
+++ b/src/utils/providerFlag.ts
@@ -38,6 +38,7 @@ const PREFERRED_PROVIDER_ORDER = [
   'nvidia-nim',
   'minimax',
   'venice',
+  'qiniu',
 ] as const
 
 function buildValidProviders(): string[] {
@@ -197,9 +198,12 @@ export function applyProviderFlag(
               process.env.OPENAI_API_KEY === process.env.VENICE_API_KEY
             ? 'venice'
             : process.env.OPENAI_API_KEY !== undefined &&
-                process.env.OPENAI_API_KEY === process.env.MINIMAX_API_KEY
-              ? 'minimax'
-              : null
+                process.env.OPENAI_API_KEY === process.env.QINIU_API_KEY
+              ? 'qiniu'
+              : process.env.OPENAI_API_KEY !== undefined &&
+                  process.env.OPENAI_API_KEY === process.env.MINIMAX_API_KEY
+                ? 'minimax'
+                : null
 
   delete process.env.CLAUDE_CODE_USE_OPENAI
   delete process.env.CLAUDE_CODE_USE_GEMINI

--- a/src/utils/providerProfile.ts
+++ b/src/utils/providerProfile.ts
@@ -91,6 +91,7 @@ const PROFILE_ENV_KEYS = [
   'BANKR_MODEL',
   'XAI_API_KEY',
   'VENICE_API_KEY',
+  'QINIU_API_KEY',
 ] as const
 
 export type CompatibilityProfileMode =
@@ -114,6 +115,7 @@ const SECRET_ENV_KEYS = [
   'BNKR_API_KEY',
   'XAI_API_KEY',
   'VENICE_API_KEY',
+  'QINIU_API_KEY',
 ] as const
 
 export type ProviderProfile =
@@ -130,6 +132,7 @@ export type ProviderProfile =
   | 'bedrock'
   | 'vertex'
   | 'xai'
+  | 'qiniu'
 
 export type ProfileEnv = {
   ANTHROPIC_BASE_URL?: string
@@ -169,6 +172,7 @@ export type ProfileEnv = {
   BANKR_MODEL?: string
   XAI_API_KEY?: string
   VENICE_API_KEY?: string
+  QINIU_API_KEY?: string
 }
 
 export type ProfileFile = {
@@ -189,7 +193,8 @@ type SecretValueSource = Partial<
     | 'MISTRAL_API_KEY'
     | 'BNKR_API_KEY'
     | 'XAI_API_KEY'
-    | 'VENICE_API_KEY',
+    | 'VENICE_API_KEY'
+    | 'QINIU_API_KEY',
     string | undefined
   >
 >
@@ -303,7 +308,8 @@ export function isProviderProfile(value: unknown): value is ProviderProfile {
     value === 'github' ||
     value === 'bedrock' ||
     value === 'vertex' ||
-    value === 'xai'
+    value === 'xai' ||
+    value === 'qiniu'
   )
 }
 
@@ -499,6 +505,46 @@ export function buildVeniceProfileEnv(options: {
       defaultModel,
     OPENAI_API_KEY: key,
     VENICE_API_KEY: key,
+  }
+}
+
+export function buildQiniuProfileEnv(options: {
+  model?: string | null
+  baseUrl?: string | null
+  apiKey?: string | null
+  processEnv?: NodeJS.ProcessEnv
+}): ProfileEnv | null {
+  const processEnv = options.processEnv ?? process.env
+  const key = sanitizeApiKey(options.apiKey ?? processEnv.QINIU_API_KEY)
+  if (!key) {
+    return null
+  }
+
+  const defaultBaseUrl = getRouteDefaultBaseUrl('qiniu')
+  const defaultModel = getRouteDefaultModel('qiniu')
+  if (!defaultBaseUrl || !defaultModel) {
+    throw new Error('Qiniu route defaults are missing from integration metadata.')
+  }
+  const secretSource: SecretValueSource = {
+    OPENAI_API_KEY: key,
+    QINIU_API_KEY: key,
+  }
+
+  return {
+    OPENAI_BASE_URL:
+      sanitizeProviderConfigValue(options.baseUrl, secretSource) ||
+      sanitizeProviderConfigValue(processEnv.OPENAI_BASE_URL, secretSource) ||
+      defaultBaseUrl,
+    OPENAI_MODEL:
+      normalizeProfileModel(
+        sanitizeProviderConfigValue(options.model, secretSource),
+      ) ||
+      normalizeProfileModel(
+        sanitizeProviderConfigValue(processEnv.OPENAI_MODEL, secretSource),
+      ) ||
+      defaultModel,
+    OPENAI_API_KEY: key,
+    QINIU_API_KEY: key,
   }
 }
 

--- a/src/utils/providerProfiles.ts
+++ b/src/utils/providerProfiles.ts
@@ -19,6 +19,7 @@ import {
   buildGithubProfileEnv,
   buildMiniMaxProfileEnv,
   buildMistralProfileEnv,
+  buildQiniuProfileEnv,
   buildNvidiaNimProfileEnv,
   buildOpenAIProfileEnv,
   buildVeniceProfileEnv,
@@ -629,6 +630,9 @@ export function applyProviderProfileToProcessEnv(profile: ProviderProfile): void
       if (route.vendorId === 'minimax' || profile.baseUrl.toLowerCase().includes('minimax')) {
         openAIProfileEnv.MINIMAX_API_KEY = profile.apiKey
       }
+      if (route.vendorId === 'qiniu' || profile.baseUrl.toLowerCase().includes('qnaigc')) {
+        openAIProfileEnv.QINIU_API_KEY = profile.apiKey
+      }
       if (
         route.gatewayId === 'nvidia-nim' ||
         profile.baseUrl.toLowerCase().includes('nvidia') ||
@@ -1058,6 +1062,19 @@ function buildStartupProfileFromActiveProfile(
           }) ?? null
         return env
           ? { profile: 'openai', env: applySupportedProfileCustomHeaders(activeProfile, env) }
+          : null
+      }
+
+      if (route.vendorId === 'qiniu') {
+        const env =
+          buildQiniuProfileEnv({
+            model: getPrimaryModel(activeProfile.model),
+            baseUrl: activeProfile.baseUrl,
+            apiKey: activeProfile.apiKey,
+            processEnv: process.env,
+          }) ?? null
+        return env
+          ? { profile: 'qiniu', env: applySupportedProfileCustomHeaders(activeProfile, env) }
           : null
       }
 

--- a/src/utils/status.test.ts
+++ b/src/utils/status.test.ts
@@ -26,7 +26,8 @@ async function readPropertyValue(
     | 'openai'
     | 'codex'
     | 'nvidia-nim'
-    | 'minimax',
+    | 'minimax'
+    | 'qiniu',
 ): Promise<unknown> {
   mock.restore()
   mock.module('./model/providers.js', () => ({
@@ -72,6 +73,19 @@ test('buildAPIProviderProperties labels MiniMax sessions', async () => {
     'https://api.minimax.chat/v1',
   )
   expect(await readPropertyValue('Model', 'minimax')).toBe('MiniMax-M2.5')
+})
+
+test('buildAPIProviderProperties labels Qiniu sessions', async () => {
+  process.env.CLAUDE_CODE_USE_OPENAI = '1'
+  process.env.QINIU_API_KEY = 'qiniu-key'
+  process.env.OPENAI_BASE_URL = 'https://api.qnaigc.com/v1'
+  process.env.OPENAI_MODEL = 'deepseek-v3'
+
+  expect(await readPropertyValue('API provider', 'qiniu')).toBe('Qiniu')
+  expect(await readPropertyValue('Qiniu base URL', 'qiniu')).toBe(
+    'https://api.qnaigc.com/v1',
+  )
+  expect(await readPropertyValue('Model', 'qiniu')).toBe('deepseek-v3')
 })
 
 test('buildAPIProviderProperties keeps Codex-specific labels on the shared OpenAI-compatible path', async () => {

--- a/src/utils/status.tsx
+++ b/src/utils/status.tsx
@@ -40,6 +40,7 @@ const API_PROVIDER_LABELS: Partial<Record<APIProvider, string>> = {
   minimax: 'MiniMax',
   mistral: 'Mistral',
   xai: 'xAI',
+  qiniu: 'Qiniu',
 };
 
 const OPENAI_COMPATIBLE_STATUS_METADATA: Partial<
@@ -64,6 +65,9 @@ const OPENAI_COMPATIBLE_STATUS_METADATA: Partial<
   },
   minimax: {
     baseUrlLabel: 'MiniMax base URL',
+  },
+  qiniu: {
+    baseUrlLabel: 'Qiniu base URL',
   },
   xai: {
     baseUrlLabel: 'xAI base URL',


### PR DESCRIPTION
## Summary

- Added support for Qiniu AI (七牛云) as a new model provider.

## Impact

- `src/utils/providerFlag.test.ts` - Tests provider flags including Qiniu-related behavior.
- `src/utils/model/providers.test.ts` - Tests model provider registry and Qiniu model wiring.
- `src/utils/providerAutoDetect.test.ts` - Tests auto-detection paths that recognize Qiniu endpoints.
- `src/integrations/routeMetadata.test.ts` - Tests route metadata for integrations including Qiniu routes.
- `src/utils/providerAutoDetect.ts` - Implements hostname and URL heuristics for Qiniu provider detection.
- `src/utils/status.test.ts` - Tests status utilities affected by Qiniu provider handling.
- `src/integrations/index.test.ts` - Integration index tests covering Qiniu vendor registration.
- `src/integrations/compatibility.test.ts` - Compatibility tests for Qiniu integration contracts.
- `src/services/api/openaiShim.ts` - OpenAI-compatible shim adjustments for Qiniu API behavior.
- `src/integrations/runtimeMetadata.ts` - Runtime integration metadata entries for Qiniu.
- `src/utils/status.tsx` - UI status helpers referencing Qiniu provider state.
- `src/utils/providerFlag.ts` - CLI and config flags for selecting and validating Qiniu.
- `src/utils/providerProfiles.ts` - Provider profile bundle including Qiniu profile definitions.
- `src/utils/providerProfile.ts` - Core provider profile logic and Qiniu-specific profile rules.
- `src/utils/model/model.ts` - Model types and wiring that include Qiniu catalog entries.
- `src/services/api/client.ts` - API client configuration and routing for Qiniu endpoints.
- `src/utils/model/configs.ts` - Model configuration tables extended for Qiniu models.
- `src/integrations/routeMetadata.ts` - Static route metadata for Qiniu integration routes.
- `src/utils/model/providers.ts` - Provider registry and model lists including Qiniu.
- `src/integrations/generated/integrationArtifacts.generated.ts` - Generated artifacts listing Qiniu integration assets.
- `src/integrations/vendors/qiniu.ts` - Qiniu vendor integration module.
- `src/integrations/models/qiniu.ts` - Qiniu model definitions for the integrations layer.
- `src/integrations/brands/qiniu.ts` - Qiniu brand assets and metadata for the UI.

## Testing

- [x] `bun run build`
- [x] `bun run smoke`