### PR TITLE
feat(plugins): support compound engineering native aliases

### DIFF
--- a/docs/changes/2026-05-12-compound-engineering-native-plugin-integration.md
+++ b/docs/changes/2026-05-12-compound-engineering-native-plugin-integration.md
@@ -1,0 +1,41 @@
+# Compound Engineering Native Plugin Integration
+
+Date: 2026-05-12
+
+## Summary
+
+OpenClaude now has a tested native path for Compound Engineering shaped plugins. The plugin loader recognizes metadata-only manifests with default `skills/` and `agents/` directories, plugin skills keep their namespaced canonical command names, and plugins can opt into direct slash command aliases with `directSkillAliases: true`.
+
+## Files Changed
+
+- `src/utils/plugins/schemas.ts`
+- `src/utils/plugins/loadPluginCommands.ts`
+- `src/utils/plugins/pluginSkillAliases.ts`
+- `src/utils/plugins/pluginSkillAliases.test.ts`
+- `src/utils/plugins/pluginAliasCollisions.ts`
+- `src/utils/plugins/pluginAliasCollisions.test.ts`
+- `src/commands.ts`
+- `src/utils/frontmatterParser.ts`
+- `src/utils/plugins/pluginLoaderCompound.test.ts`
+- `src/utils/plugins/loadPluginCommands.test.ts`
+- `src/tools/AgentTool/loadAgentsDir.test.ts`
+- `tests/plugin-compound-engineering-smoke.test.ts`
+- `tests/fixtures/plugins/compound-engineering/**`
+- `docs/plugins/compound-engineering.md`
+
+## Why
+
+Compound Engineering expects commands such as `/ce-plan`, `/ce-work`, and `/lfg`, while OpenClaude's plugin safety model uses namespaced canonical command names such as `/compound-engineering:ce-plan`. This change preserves namespacing as the default and adds direct aliases only through explicit plugin opt-in.
+
+## Verification
+
+- `bun test src/utils/plugins/pluginLoaderCompound.test.ts src/utils/plugins/loadPluginCommands.test.ts src/utils/plugins/pluginSkillAliases.test.ts src/utils/plugins/pluginAliasCollisions.test.ts src/tools/AgentTool/loadAgentsDir.test.ts tests/plugin-compound-engineering-smoke.test.ts`
+- `bun run build`
+- `/Users/besi/.agents/bin/semgrep-gate scan --profile stop <changed paths>`
+- `sentrux gate .`
+- `bun run typecheck` was attempted. The repo still has broad pre-existing typecheck failures unrelated to this change; a filtered pass for the changed surfaces returned no errors.
+- Browser test applicability was checked with `agent-browser` installed, but no browser route was exercised because this change only touches CLI/plugin loader behavior, tests, fixtures, and docs.
+
+## Follow-Ups
+
+- The Compound Engineering plugin manifest must set `directSkillAliases: true` before installed CE builds expose `/ce-plan`, `/ce-work`, and `/lfg` as direct aliases.

--- a/docs/plugins/compound-engineering.md
+++ b/docs/plugins/compound-engineering.md
@@ -1,0 +1,61 @@
+# Compound Engineering Plugin
+
+Compound Engineering can run as a native OpenClaude plugin through the existing marketplace, plugin, skill, and agent loaders. No generated command files or converter output are required for OpenClaude to load its `skills/` and `agents/` directories.
+
+## Install
+
+Add the marketplace, then install the plugin:
+
+```bash
+openclaude plugin marketplace add https://github.com/LLMpsycho/compound-engineering-plugin --sparse .claude-plugin plugins
+openclaude plugin install compound-engineering@compound-engineering-plugin
+```
+
+For a repo-local install, add `--scope local` to both commands.
+
+If OpenClaude is already running, reload plugin state inside the session:
+
+```text
+/reload-plugins
+```
+
+## Commands
+
+OpenClaude keeps the namespaced plugin command as the canonical identity:
+
+```text
+/compound-engineering:ce-plan
+/compound-engineering:ce-work
+/compound-engineering:lfg
+```
+
+Plugins that set `directSkillAliases: true` in `.claude-plugin/plugin.json` can also expose direct aliases from each skill's `name` or `aliases` frontmatter:
+
+```text
+/ce-plan
+/ce-work
+/lfg
+```
+
+Direct aliases are skipped when they collide with an existing command name or alias. The canonical namespaced command remains available even when a direct alias is skipped.
+
+## Agents
+
+Compound Engineering agents in `agents/*.agent.md` load through the normal plugin agent path and appear with plugin namespaced agent types such as:
+
+```text
+compound-engineering:ce-repo-research-analyst
+```
+
+Plugin agents may declare descriptive metadata such as `description`, `model`, `tools`, and `color`. Per-agent `permissionMode`, `hooks`, and `mcpServers` remain ignored for marketplace safety. Plugin-level hooks and MCP servers must be declared at the plugin manifest boundary instead.
+
+## Verify
+
+Use these checks after install or update:
+
+```bash
+openclaude plugin list
+openclaude plugin validate /path/to/compound-engineering-plugin/plugins/compound-engineering/.claude-plugin/plugin.json
+```
+
+In an OpenClaude session, open slash command autocomplete and check for the namespaced commands. If the installed plugin manifest opts into direct aliases, also check `/ce-plan`, `/ce-work`, and `/lfg`.

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -93,19 +93,13 @@ const forceSnip = feature('HISTORY_SNIP')
   ? require('./commands/force-snip.js').default
   : null
 const workflowsCmd = feature('WORKFLOW_SCRIPTS')
-  ? (
-      require('./commands/workflows/index.js') as typeof import('./commands/workflows/index.js')
-    ).default
+  ? require('./commands/workflows/index.js').default
   : null
 const webCmd = feature('CCR_REMOTE_SETUP')
-  ? (
-      require('./commands/remote-setup/index.js') as typeof import('./commands/remote-setup/index.js')
-    ).default
+  ? require('./commands/remote-setup/index.js').default
   : null
 const clearSkillIndexCache = feature('EXPERIMENTAL_SKILL_SEARCH')
-  ? (
-      require('./services/skillSearch/localSearch.js') as typeof import('./services/skillSearch/localSearch.js')
-    ).clearSkillIndexCache
+  ? require('./services/skillSearch/localSearch.js').clearSkillIndexCache
   : null
 const subscribePr = feature('KAIROS_GITHUB_WEBHOOKS')
   ? require('./commands/subscribe-pr.js').default
@@ -115,19 +109,13 @@ const ultraplan = feature('ULTRAPLAN')
   : null
 const torch = feature('TORCH') ? require('./commands/torch.js').default : null
 const peersCmd = feature('UDS_INBOX')
-  ? (
-      require('./commands/peers/index.js') as typeof import('./commands/peers/index.js')
-    ).default
+  ? require('./commands/peers/index.js').default
   : null
 const forkCmd = feature('FORK_SUBAGENT')
-  ? (
-      require('./commands/fork/index.js') as typeof import('./commands/fork/index.js')
-    ).default
+  ? require('./commands/fork/index.js').default
   : null
 const buddy = isBuddyEnabled()
-  ? (
-      require('./commands/buddy/index.js') as typeof import('./commands/buddy/index.js')
-    ).default
+  ? require('./commands/buddy/index.js').default
   : null
 /* eslint-enable @typescript-eslint/no-require-imports */
 import thinkback from './commands/thinkback/index.js'
@@ -178,6 +166,7 @@ import {
   getPluginSkills,
   clearPluginSkillsCache,
 } from './utils/plugins/loadPluginCommands.js'
+import { removeCollidingPluginAliases } from './utils/plugins/pluginAliasCollisions.js'
 import memoize from 'lodash-es/memoize.js'
 import { isUsing3PServices, isClaudeAISubscriber } from './utils/auth.js'
 import { isFirstPartyAnthropicBaseUrl } from './utils/model/providers.js'
@@ -422,9 +411,7 @@ async function getSkills(cwd: string): Promise<{
 
 /* eslint-disable @typescript-eslint/no-require-imports */
 const getWorkflowCommands = feature('WORKFLOW_SCRIPTS')
-  ? (
-      require('./tools/WorkflowTool/createWorkflowCommand.js') as typeof import('./tools/WorkflowTool/createWorkflowCommand.js')
-    ).getWorkflowCommands
+  ? require('./tools/WorkflowTool/createWorkflowCommand.js').getWorkflowCommands
   : null
 /* eslint-enable @typescript-eslint/no-require-imports */
 
@@ -455,11 +442,8 @@ export function meetsAvailabilityRequirement(cmd: Command | null | undefined): b
         )
           return true
         break
-      default: {
-        const _exhaustive: never = a
-        void _exhaustive
+      default:
         break
-      }
     }
   }
   return false
@@ -480,7 +464,7 @@ const loadAllCommands = memoize(async (cwd: string): Promise<Command[]> => {
     getWorkflowCommands ? getWorkflowCommands(cwd) : Promise.resolve([]),
   ])
 
-  return [
+  return removeCollidingPluginAliases([
     ...bundledSkills,
     ...builtinPluginSkills,
     ...skillDirCommands,
@@ -488,7 +472,7 @@ const loadAllCommands = memoize(async (cwd: string): Promise<Command[]> => {
     ...pluginCommands,
     ...pluginSkills,
     ...COMMANDS(),
-  ]
+  ])
 })
 
 /**

--- a/src/tools/AgentTool/loadAgentsDir.test.ts
+++ b/src/tools/AgentTool/loadAgentsDir.test.ts
@@ -2,11 +2,15 @@ import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
 import { mkdtemp, mkdir, rm, writeFile } from 'fs/promises'
 import { tmpdir } from 'os'
 import { dirname, join } from 'path'
+import { resetStateForTests, setInlinePlugins } from '../../bootstrap/state.js'
 import {
   clearAgentDefinitionsCache,
   getAgentDefinitionsWithOverrides,
+  isCustomAgent,
+  isPluginAgent,
 } from './loadAgentsDir.js'
 import { loadMarkdownFilesForSubdir } from '../../utils/markdownConfigLoader.js'
+import { clearPluginCache } from '../../utils/plugins/pluginLoader.js'
 
 const originalEnv = {
   CLAUDE_CONFIG_DIR: process.env.CLAUDE_CONFIG_DIR,
@@ -16,21 +20,30 @@ const originalEnv = {
 }
 
 let tempDir: string
+const compoundFixturePath = join(
+  process.cwd(),
+  'tests/fixtures/plugins/compound-engineering',
+)
 
 beforeEach(async () => {
   tempDir = await mkdtemp(join(tmpdir(), 'openclaude-agents-test-'))
   process.env.CLAUDE_CONFIG_DIR = join(tempDir, '.openclaude')
   process.env.CLAUDE_CODE_USE_NATIVE_FILE_SEARCH = '1'
   delete process.env.CLAUDE_CODE_SIMPLE
+  resetStateForTests()
+  clearPluginCache('test setup')
   clearAgentDefinitionsCache()
   loadMarkdownFilesForSubdir.cache.clear?.()
 })
 
 afterEach(async () => {
+  setInlinePlugins([])
+  clearPluginCache('test cleanup')
   await rm(tempDir, { recursive: true, force: true })
   restoreEnv('CLAUDE_CONFIG_DIR')
   restoreEnv('CLAUDE_CODE_SIMPLE')
   restoreEnv('CLAUDE_CODE_USE_NATIVE_FILE_SEARCH')
+  resetStateForTests()
   clearAgentDefinitionsCache()
   loadMarkdownFilesForSubdir.cache.clear?.()
 })
@@ -110,6 +123,38 @@ describe('agent definition loading', () => {
     const { activeAgents } = await getAgentDefinitionsWithOverrides(projectDir)
     const agent = activeAgents.find(agent => agent.agentType === 'shared-agent')
 
-    expect(agent?.getSystemPrompt()).toBe('openclaude prompt')
+    expect(agent).toBeDefined()
+    if (!agent || !isCustomAgent(agent)) {
+      throw new Error('Expected shared-agent to load as a custom agent')
+    }
+
+    expect(agent.getSystemPrompt()).toBe('openclaude prompt')
+  })
+
+  test('loads Compound-shaped plugin agents without granting per-agent permission escalation fields', async () => {
+    setInlinePlugins([compoundFixturePath])
+    clearPluginCache('inline plugin changed')
+    clearAgentDefinitionsCache()
+
+    const { activeAgents } = await getAgentDefinitionsWithOverrides(tempDir)
+    const agent = activeAgents.find(
+      agent => agent.agentType === 'compound-engineering:ce-repo-research-analyst',
+    )
+
+    expect(agent).toBeDefined()
+    if (!agent || !isPluginAgent(agent)) {
+      throw new Error('Expected Compound fixture agent to load as a plugin agent')
+    }
+
+    expect(agent.source).toBe('plugin')
+    expect(agent.plugin).toBe('compound-engineering@inline')
+    expect(agent.whenToUse).toBe('Research repository structure and conventions')
+    expect(agent.model).toBe('inherit')
+    expect(agent.tools).toEqual(['Read', 'Grep'])
+    expect(agent.color).toBe('blue')
+    expect(agent.getSystemPrompt()).toContain('Research the repository')
+    expect(agent && Object.hasOwn(agent, 'permissionMode')).toBe(false)
+    expect(agent && Object.hasOwn(agent, 'hooks')).toBe(false)
+    expect(agent && Object.hasOwn(agent, 'mcpServers')).toBe(false)
   })
 })

--- a/src/utils/frontmatterParser.ts
+++ b/src/utils/frontmatterParser.ts
@@ -15,6 +15,7 @@ export type FrontmatterData = {
   // Only applicable to memory files; narrowed via parseMemoryType() in src/memdir/memoryTypes.ts
   type?: string | null
   'argument-hint'?: string | null
+  aliases?: string | string[] | null
   when_to_use?: string | null
   version?: string | null
   // Only applicable to slash commands -- a string similar to a boolean env var
@@ -61,6 +62,10 @@ export type FrontmatterData = {
 export type ParsedMarkdown = {
   frontmatter: FrontmatterData
   content: string
+}
+
+function isFrontmatterData(value: unknown): value is FrontmatterData {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
 }
 
 // Characters that require quoting in YAML values (when unquoted)
@@ -146,16 +151,16 @@ export function parseFrontmatter(
 
   let frontmatter: FrontmatterData = {}
   try {
-    const parsed = parseYaml(frontmatterText) as FrontmatterData | null
-    if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+    const parsed = parseYaml(frontmatterText)
+    if (isFrontmatterData(parsed)) {
       frontmatter = parsed
     }
   } catch {
     // YAML parsing failed - try again after quoting problematic values
     try {
       const quotedText = quoteProblematicValues(frontmatterText)
-      const parsed = parseYaml(quotedText) as FrontmatterData | null
-      if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+      const parsed = parseYaml(quotedText)
+      if (isFrontmatterData(parsed)) {
         frontmatter = parsed
       }
     } catch (retryError) {
@@ -340,6 +345,10 @@ export type FrontmatterShell = 'bash' | 'powershell'
 
 const FRONTMATTER_SHELLS: readonly FrontmatterShell[] = ['bash', 'powershell']
 
+function isFrontmatterShell(value: string): value is FrontmatterShell {
+  return FRONTMATTER_SHELLS.some(shell => shell === value)
+}
+
 /**
  * Parse and validate the `shell:` frontmatter field.
  *
@@ -359,8 +368,8 @@ export function parseShellFrontmatter(
   if (normalized === '') {
     return undefined
   }
-  if ((FRONTMATTER_SHELLS as readonly string[]).includes(normalized)) {
-    return normalized as FrontmatterShell
+  if (isFrontmatterShell(normalized)) {
+    return normalized
   }
   logForDebugging(
     `Frontmatter 'shell: ${value}' in ${source} is not recognized. Valid values: ${FRONTMATTER_SHELLS.join(', ')}. Falling back to bash.`,

--- a/src/utils/plugins/loadPluginCommands.test.ts
+++ b/src/utils/plugins/loadPluginCommands.test.ts
@@ -1,0 +1,68 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import { mkdtemp, rm } from 'fs/promises'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { resetStateForTests, setInlinePlugins } from '../../bootstrap/state.js'
+import { getCommandName } from '../../types/command.js'
+import { clearPluginCache } from './pluginLoader.js'
+import { clearPluginSkillsCache, getPluginSkills } from './loadPluginCommands.js'
+
+const originalEnv = {
+  CLAUDE_CONFIG_DIR: process.env.CLAUDE_CONFIG_DIR,
+  CLAUDE_CODE_SIMPLE: process.env.CLAUDE_CODE_SIMPLE,
+}
+
+const compoundFixturePath = join(process.cwd(), 'tests/fixtures/plugins/compound-engineering')
+
+let tempDir: string
+
+beforeEach(async () => {
+  tempDir = await mkdtemp(join(tmpdir(), 'openclaude-plugin-skills-test-'))
+  process.env.CLAUDE_CONFIG_DIR = join(tempDir, '.openclaude')
+  delete process.env.CLAUDE_CODE_SIMPLE
+  resetStateForTests()
+  clearPluginCache('test setup')
+  clearPluginSkillsCache()
+})
+
+afterEach(async () => {
+  setInlinePlugins([])
+  clearPluginCache('test cleanup')
+  clearPluginSkillsCache()
+  await rm(tempDir, { recursive: true, force: true })
+  restoreEnv('CLAUDE_CONFIG_DIR')
+  restoreEnv('CLAUDE_CODE_SIMPLE')
+  resetStateForTests()
+})
+
+function restoreEnv(key: keyof typeof originalEnv): void {
+  const originalValue = originalEnv[key]
+  if (originalValue === undefined) delete process.env[key]
+  else process.env[key] = originalValue
+}
+
+describe('getPluginSkills', () => {
+  test('loads Compound-shaped plugin skills as canonical namespaced commands', async () => {
+    setInlinePlugins([compoundFixturePath])
+    clearPluginCache('inline plugin changed')
+    clearPluginSkillsCache()
+
+    const skills = await getPluginSkills()
+    const cePlan = skills.find(
+      skill => skill.name === 'compound-engineering:ce-plan',
+    )
+    const lfg = skills.find(skill => skill.name === 'compound-engineering:lfg')
+
+    expect(cePlan).toBeDefined()
+    if (!cePlan || cePlan.type !== 'prompt') {
+      throw new Error('Expected ce-plan to load as a prompt command')
+    }
+
+    expect(cePlan.source).toBe('plugin')
+    expect(cePlan.loadedFrom).toBe('plugin')
+    expect(cePlan.aliases).toBeUndefined()
+    expect(getCommandName(cePlan)).toBe('compound-engineering:ce-plan')
+    expect(cePlan.allowedTools).toEqual(['Read', 'Grep'])
+    expect(lfg).toBeDefined()
+  })
+})

--- a/src/utils/plugins/loadPluginCommands.ts
+++ b/src/utils/plugins/loadPluginCommands.ts
@@ -35,6 +35,11 @@ import {
   substituteUserConfigInContent,
 } from './pluginOptionsStorage.js'
 import type { CommandMetadata, PluginManifest } from './schemas.js'
+import {
+  buildDirectSkillAliases,
+  stringFrontmatter,
+  stringListFrontmatter,
+} from './pluginSkillAliases.js'
 import { walkPluginMarkdown } from './walkPluginMarkdown.js'
 
 // Similar to MarkdownFile but for plugin sources
@@ -263,20 +268,22 @@ function createPluginCommand(
       substitutedAllowedTools,
     )
 
-    const argumentHint = frontmatter['argument-hint'] as string | undefined
+    const argumentHint = stringFrontmatter(frontmatter['argument-hint'])
     const argumentNames = parseArgumentNames(
-      frontmatter.arguments as string | string[] | undefined,
+      stringListFrontmatter(frontmatter.arguments),
     )
-    const whenToUse = frontmatter.when_to_use as string | undefined
-    const version = frontmatter.version as string | undefined
-    const displayName = frontmatter.name as string | undefined
+    const whenToUse = stringFrontmatter(frontmatter.when_to_use)
+    const version = stringFrontmatter(frontmatter.version)
+    const displayName =
+      typeof frontmatter.name === 'string' ? frontmatter.name : undefined
 
     // Handle model configuration, resolving aliases like 'haiku', 'sonnet', 'opus'
+    const modelName = stringFrontmatter(frontmatter.model)
     const model =
-      frontmatter.model === 'inherit'
+      modelName === 'inherit'
         ? undefined
-        : frontmatter.model
-          ? parseUserSpecifiedModel(frontmatter.model as string)
+        : modelName
+          ? parseUserSpecifiedModel(modelName)
           : undefined
 
     const effortRaw = frontmatter['effort']
@@ -299,10 +306,18 @@ function createPluginCommand(
         : parseBooleanFrontmatter(userInvocableValue)
 
     const shell = parseShellFrontmatter(frontmatter.shell, commandName)
+    const aliases = buildDirectSkillAliases({
+      commandName,
+      displayName,
+      frontmatter,
+      pluginManifest,
+      isSkillCommand: isSkill || config.isSkillMode,
+    })
 
     return {
       type: 'prompt',
       name: commandName,
+      aliases,
       description,
       hasUserSpecifiedDescription: validatedDescription !== null,
       allowedTools,
@@ -324,6 +339,9 @@ function createPluginCommand(
       isHidden: !userInvocable,
       progressMessage: isSkill || config.isSkillMode ? 'loading' : 'running',
       userFacingName(): string {
+        if (isSkill || config.isSkillMode) {
+          return commandName
+        }
         return displayName || commandName
       },
       async getPromptForCommand(args, context) {

--- a/src/utils/plugins/pluginAliasCollisions.test.ts
+++ b/src/utils/plugins/pluginAliasCollisions.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, test } from 'bun:test'
+import type { Command } from '../../types/command.js'
+import { removeCollidingPluginAliases } from './pluginAliasCollisions.js'
+
+function promptCommand(
+  name: string,
+  options: {
+    aliases?: string[]
+    source?: 'builtin' | 'plugin' | 'mcp' | 'bundled'
+    loadedFrom?: Command['loadedFrom']
+  } = {},
+): Command {
+  return {
+    type: 'prompt',
+    name,
+    aliases: options.aliases,
+    description: name + ' description',
+    progressMessage: 'loading',
+    contentLength: 0,
+    source: options.source ?? 'builtin',
+    loadedFrom: options.loadedFrom,
+    async getPromptForCommand() {
+      return []
+    },
+  }
+}
+
+describe('removeCollidingPluginAliases', () => {
+  test('removes direct aliases that collide with command names', () => {
+    const commands = removeCollidingPluginAliases([
+      promptCommand('compound-engineering:help', {
+        source: 'plugin',
+        loadedFrom: 'plugin',
+        aliases: ['help', 'ce-help'],
+      }),
+      promptCommand('help'),
+    ])
+
+    expect(commands[0]?.name).toBe('compound-engineering:help')
+    expect(commands[0]?.aliases).toEqual(['ce-help'])
+  })
+
+  test('removes direct aliases that collide with existing aliases', () => {
+    const commands = removeCollidingPluginAliases([
+      promptCommand('compound-engineering:continue', {
+        source: 'plugin',
+        loadedFrom: 'plugin',
+        aliases: ['continue', 'ce-continue'],
+      }),
+      promptCommand('resume', { aliases: ['continue'] }),
+    ])
+
+    expect(commands[0]?.aliases).toEqual(['ce-continue'])
+  })
+
+  test('keeps the first plugin alias and removes later duplicate plugin aliases', () => {
+    const commands = removeCollidingPluginAliases([
+      promptCommand('compound-engineering:ce-plan', {
+        source: 'plugin',
+        loadedFrom: 'plugin',
+        aliases: ['ce-plan'],
+      }),
+      promptCommand('other-plugin:ce-plan', {
+        source: 'plugin',
+        loadedFrom: 'plugin',
+        aliases: ['ce-plan'],
+      }),
+    ])
+
+    expect(commands[0]?.aliases).toEqual(['ce-plan'])
+    expect(commands[1]?.aliases).toBeUndefined()
+  })
+})

--- a/src/utils/plugins/pluginAliasCollisions.ts
+++ b/src/utils/plugins/pluginAliasCollisions.ts
@@ -1,0 +1,75 @@
+import type { Command } from '../../types/command.js'
+import { getCommandName } from '../../types/command.js'
+import { logForDebugging } from '../debug.js'
+
+function isPluginAliasCommand(command: Command): boolean {
+  return (
+    command.type === 'prompt' &&
+    command.source === 'plugin' &&
+    command.loadedFrom === 'plugin'
+  )
+}
+
+function commandNames(command: Command): string[] {
+  const visibleName = getCommandName(command)
+  return visibleName === command.name
+    ? [command.name]
+    : [command.name, visibleName]
+}
+
+export function removeCollidingPluginAliases(commands: Command[]): Command[] {
+  const reservedNames = new Set(
+    commands.flatMap(command =>
+      isPluginAliasCommand(command)
+        ? commandNames(command)
+        : [...commandNames(command), ...(command.aliases ?? [])],
+    ),
+  )
+  const claimedAliases = new Set<string>()
+
+  return commands.map(command => {
+    if (!command.aliases || command.aliases.length === 0) {
+      return command
+    }
+
+    if (!isPluginAliasCommand(command)) {
+      for (const alias of command.aliases) {
+        claimedAliases.add(alias)
+      }
+      return command
+    }
+
+    const aliases = command.aliases.filter(alias => {
+      if (reservedNames.has(alias) || claimedAliases.has(alias)) {
+        logForDebugging(
+          'Skipping plugin alias ' +
+            alias +
+            ' for ' +
+            command.name +
+            ' because another command already owns that name',
+          { level: 'warn' },
+        )
+        return false
+      }
+
+      claimedAliases.add(alias)
+      return true
+    })
+
+    if (aliases.length === command.aliases.length) {
+      return command
+    }
+
+    if (aliases.length === 0) {
+      return {
+        ...command,
+        aliases: undefined,
+      }
+    }
+
+    return {
+      ...command,
+      aliases,
+    }
+  })
+}

--- a/src/utils/plugins/pluginLoaderCompound.test.ts
+++ b/src/utils/plugins/pluginLoaderCompound.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, test } from 'bun:test'
+import { join } from 'path'
+
+import { createPluginFromPath } from './pluginLoader.js'
+
+const compoundFixturePath = join(
+  process.cwd(),
+  'tests/fixtures/plugins/compound-engineering',
+)
+
+describe('createPluginFromPath with Compound-shaped plugins', () => {
+  test('loads a metadata-only manifest with default component directories', async () => {
+    const { plugin, errors } = await createPluginFromPath(
+      compoundFixturePath,
+      'compound-engineering@fixture',
+      true,
+      'compound-engineering',
+    )
+
+    expect(errors).toEqual([])
+    expect(plugin.name).toBe('compound-engineering')
+    expect(plugin.manifest.skills).toBeUndefined()
+    expect(plugin.manifest.agents).toBeUndefined()
+    expect(plugin.skillsPath).toBe(join(compoundFixturePath, 'skills'))
+    expect(plugin.agentsPath).toBe(join(compoundFixturePath, 'agents'))
+  })
+})

--- a/src/utils/plugins/pluginSkillAliases.test.ts
+++ b/src/utils/plugins/pluginSkillAliases.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, test } from 'bun:test'
+import type { PluginManifest } from './schemas.js'
+import { buildDirectSkillAliases } from './pluginSkillAliases.js'
+
+const optInManifest: PluginManifest = {
+  name: 'compound-engineering',
+  directSkillAliases: true,
+}
+
+describe('buildDirectSkillAliases', () => {
+  test('uses skill name and aliases frontmatter when the plugin opts in', () => {
+    expect(
+      buildDirectSkillAliases({
+        commandName: 'compound-engineering:ce-plan',
+        displayName: 'ce-plan',
+        frontmatter: { aliases: ['plan-with-ce'] },
+        pluginManifest: optInManifest,
+        isSkillCommand: true,
+      }),
+    ).toEqual(['ce-plan', 'plan-with-ce'])
+  })
+
+  test('ignores invalid alias metadata without dropping valid aliases', () => {
+    expect(
+      buildDirectSkillAliases({
+        commandName: 'compound-engineering:ce-plan',
+        displayName: '../bad',
+        frontmatter: { aliases: ['valid_alias', 'bad alias'] },
+        pluginManifest: optInManifest,
+        isSkillCommand: true,
+      }),
+    ).toEqual(['valid_alias'])
+  })
+
+  test('requires plugin opt-in and a skill command', () => {
+    expect(
+      buildDirectSkillAliases({
+        commandName: 'plugin:ce-plan',
+        displayName: 'ce-plan',
+        frontmatter: {},
+        pluginManifest: { name: 'plugin' },
+        isSkillCommand: true,
+      }),
+    ).toBeUndefined()
+    expect(
+      buildDirectSkillAliases({
+        commandName: 'plugin:ce-plan',
+        displayName: 'ce-plan',
+        frontmatter: {},
+        pluginManifest: optInManifest,
+        isSkillCommand: false,
+      }),
+    ).toBeUndefined()
+  })
+})

--- a/src/utils/plugins/pluginSkillAliases.ts
+++ b/src/utils/plugins/pluginSkillAliases.ts
@@ -1,0 +1,72 @@
+import type { FrontmatterData } from '../frontmatterParser.js'
+import type { PluginManifest } from './schemas.js'
+
+const COMMAND_NAME_PATTERN = /^[a-zA-Z0-9:_-]+$/
+
+export function stringFrontmatter(value: unknown): string | undefined {
+  return typeof value === 'string' ? value : undefined
+}
+
+export function stringListFrontmatter(
+  value: unknown,
+): string | string[] | undefined {
+  if (typeof value === 'string') {
+    return value
+  }
+
+  if (Array.isArray(value) && value.every(item => typeof item === 'string')) {
+    return value
+  }
+
+  return undefined
+}
+
+function parseAliasCandidates(value: unknown): string[] {
+  if (typeof value === 'string') {
+    return value
+      .split(',')
+      .map(alias => alias.trim())
+      .filter(alias => alias.length > 0)
+  }
+
+  if (Array.isArray(value)) {
+    return value.flatMap(parseAliasCandidates)
+  }
+
+  return []
+}
+
+export function buildDirectSkillAliases(options: {
+  commandName: string
+  displayName: string | undefined
+  frontmatter: FrontmatterData
+  pluginManifest: PluginManifest
+  isSkillCommand: boolean
+}): string[] | undefined {
+  if (
+    !options.pluginManifest.directSkillAliases ||
+    !options.isSkillCommand
+  ) {
+    return undefined
+  }
+
+  const candidates = [
+    ...(options.displayName ? [options.displayName] : []),
+    ...parseAliasCandidates(options.frontmatter.aliases),
+  ]
+  const aliases: string[] = []
+
+  for (const candidate of candidates) {
+    if (
+      candidate === options.commandName ||
+      !COMMAND_NAME_PATTERN.test(candidate) ||
+      aliases.includes(candidate)
+    ) {
+      continue
+    }
+
+    aliases.push(candidate)
+  }
+
+  return aliases.length > 0 ? aliases : undefined
+}

--- a/src/utils/plugins/schemas.ts
+++ b/src/utils/plugins/schemas.ts
@@ -316,6 +316,12 @@ const PluginManifestMetadataSchema = lazySchema(() =>
       .describe(
         'Plugins that must be enabled for this plugin to function. Bare names (no "@marketplace") are resolved against the declaring plugin\'s own marketplace.',
       ),
+    directSkillAliases: z
+      .boolean()
+      .optional()
+      .describe(
+        'When true, plugin skills may expose direct slash command aliases from their SKILL.md name or aliases frontmatter while keeping the namespaced plugin command canonical.',
+      ),
   }),
 )
 

--- a/tests/fixtures/plugins/compound-engineering/.claude-plugin/plugin.json
+++ b/tests/fixtures/plugins/compound-engineering/.claude-plugin/plugin.json
@@ -1,0 +1,5 @@
+{
+  "name": "compound-engineering",
+  "version": "0.0.0-fixture",
+  "description": "Compound Engineering shaped fixture for OpenClaude plugin loading tests"
+}

--- a/tests/fixtures/plugins/compound-engineering/agents/ce-repo-research-analyst.agent.md
+++ b/tests/fixtures/plugins/compound-engineering/agents/ce-repo-research-analyst.agent.md
@@ -1,0 +1,15 @@
+---
+name: ce-repo-research-analyst
+description: "Research repository structure and conventions"
+model: inherit
+tools: Read, Grep
+color: blue
+permissionMode: bypassPermissions
+hooks:
+  Stop: []
+mcpServers:
+  unsafe:
+    command: unsafe-server
+---
+
+Research the repository and return concise implementation guidance.

--- a/tests/fixtures/plugins/compound-engineering/skills/ce-plan/SKILL.md
+++ b/tests/fixtures/plugins/compound-engineering/skills/ce-plan/SKILL.md
@@ -1,0 +1,12 @@
+---
+name: ce-plan
+description: "Create structured plans for implementation work"
+argument-hint: "[feature description]"
+allowed-tools:
+  - Read
+  - Grep
+---
+
+# Create Technical Plan
+
+Plan implementation work from the provided feature description.

--- a/tests/fixtures/plugins/compound-engineering/skills/lfg/SKILL.md
+++ b/tests/fixtures/plugins/compound-engineering/skills/lfg/SKILL.md
@@ -1,0 +1,9 @@
+---
+name: lfg
+description: "Run the full autonomous engineering pipeline"
+argument-hint: "[feature description]"
+---
+
+# LFG
+
+Run the full pipeline.

--- a/tests/plugin-compound-engineering-smoke.test.ts
+++ b/tests/plugin-compound-engineering-smoke.test.ts
@@ -1,0 +1,99 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import { mkdir, mkdtemp, rm, writeFile } from 'fs/promises'
+import { tmpdir } from 'os'
+import { dirname, join } from 'path'
+import { resetStateForTests, setInlinePlugins } from '../src/bootstrap/state.js'
+import { clearCommandsCache, findCommand, getCommands } from '../src/commands.js'
+import { clearPluginCache } from '../src/utils/plugins/pluginLoader.js'
+
+const originalEnv = { CLAUDE_CONFIG_DIR: process.env.CLAUDE_CONFIG_DIR, CLAUDE_CODE_SIMPLE: process.env.CLAUDE_CODE_SIMPLE }
+
+let tempDir: string
+
+beforeEach(async () => {
+  tempDir = await mkdtemp(join(tmpdir(), 'openclaude-ce-smoke-'))
+  process.env.CLAUDE_CONFIG_DIR = join(tempDir, '.openclaude')
+  delete process.env.CLAUDE_CODE_SIMPLE
+  resetStateForTests()
+  clearPluginCache('test setup')
+  clearCommandsCache()
+})
+
+afterEach(async () => {
+  setInlinePlugins([])
+  clearPluginCache('test cleanup')
+  clearCommandsCache()
+  await rm(tempDir, { recursive: true, force: true })
+  restoreEnv('CLAUDE_CONFIG_DIR')
+  restoreEnv('CLAUDE_CODE_SIMPLE')
+  resetStateForTests()
+})
+
+function restoreEnv(key: keyof typeof originalEnv): void {
+  const originalValue = originalEnv[key]
+  if (originalValue === undefined) delete process.env[key]
+  else process.env[key] = originalValue
+}
+
+async function writeFileWithParents(filePath: string, content: string): Promise<void> {
+  await mkdir(dirname(filePath), { recursive: true })
+  await writeFile(filePath, content)
+}
+
+async function writeCompoundEngineeringPlugin(): Promise<string> {
+  const pluginPath = join(tempDir, 'compound-engineering')
+  await writeFileWithParents(
+    join(pluginPath, '.claude-plugin', 'plugin.json'),
+    JSON.stringify({
+      name: 'compound-engineering',
+      version: '0.0.0-smoke',
+      directSkillAliases: true,
+    }),
+  )
+
+  await writeFileWithParents(
+    join(pluginPath, 'skills', 'ce-plan', 'SKILL.md'),
+    `---
+name: ce-plan
+description: "Create structured plans"
+---
+
+# Plan
+
+Create a plan.
+`,
+  )
+  await writeFileWithParents(
+    join(pluginPath, 'skills', 'help', 'SKILL.md'),
+    `---
+name: help
+description: "Intentional built-in collision"
+---
+
+# Help Collision
+
+This skill must not steal /help.
+`,
+  )
+  return pluginPath
+}
+
+describe('Compound Engineering native plugin smoke', () => {
+  test('full command registry exposes direct CE aliases without shadowing built-ins', async () => {
+    const pluginPath = await writeCompoundEngineeringPlugin()
+    setInlinePlugins([pluginPath])
+    clearPluginCache('inline plugin changed')
+    clearCommandsCache()
+
+    const commands = await getCommands(tempDir)
+    const cePlan = findCommand('ce-plan', commands)
+    const help = findCommand('help', commands)
+    const canonicalHelp = commands.find(
+      command => command.name === 'compound-engineering:help',
+    )
+
+    expect(cePlan?.name).toBe('compound-engineering:ce-plan')
+    expect(help?.name).toBe('help')
+    expect(canonicalHelp?.aliases).toBeUndefined()
+  })
+})


### PR DESCRIPTION
## Summary

- what changed
- why it changed

## Impact

- user-facing impact:
- developer/maintainer impact:

## Testing

- [ ] `bun run build`
- [ ] `bun run smoke`
- [ ] focused tests:

## Notes

- provider/model path tested:
- screenshots attached (if UI changed):
- follow-up work or known limitations:
