### PR TITLE
fix: hide missing-module slash command stubs (Issue #1132)

### DIFF
--- a/src/commands.test.ts
+++ b/src/commands.test.ts
@@ -1,9 +1,38 @@
 import { describe, expect, test } from 'bun:test'
-import { builtInCommandNames, formatDescriptionWithSource } from './commands.js'
+import {
+  builtInCommandNames,
+  formatDescriptionWithSource,
+} from './commands.js'
+import { isCommand } from './types/command.js'
 
 describe('builtInCommandNames', () => {
   test('includes the LSP command', () => {
     expect(builtInCommandNames()).toContain('lsp')
+  })
+})
+
+describe('isCommand', () => {
+  test('rejects generated missing-module noop stubs', () => {
+    function noop19() {
+      return null
+    }
+
+    expect(isCommand(noop19)).toBe(false)
+    expect(isCommand({ isHidden: true, name: 'stub' })).toBe(false)
+  })
+
+  test('accepts real command objects', () => {
+    expect(
+      isCommand({
+        type: 'local',
+        name: 'example',
+        description: 'example command',
+        supportsNonInteractive: false,
+        load: async () => ({
+          call: async () => ({ type: 'skip' }),
+        }),
+      }),
+    ).toBe(true)
   })
 })
 

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -218,6 +218,7 @@ import { getSettingSourceName } from './utils/settings/constants.js'
 import {
   type Command,
   getCommandName,
+  isCommand,
   isCommandEnabled,
 } from './types/command.js'
 
@@ -366,7 +367,7 @@ const COMMANDS = memoize((): Command[] => [
   ...(process.env.USER_TYPE === 'ant' && !process.env.IS_DEMO
     ? INTERNAL_ONLY_COMMANDS
     : []),
-])
+].filter(isCommand))
 
 export const builtInCommandNames = memoize(
   (): Set<string> =>

--- a/src/types/command.ts
+++ b/src/types/command.ts
@@ -205,6 +205,23 @@ export type CommandBase = {
 export type Command = CommandBase &
   (PromptCommand | LocalCommand | LocalJSXCommand)
 
+/** Runtime guard for values that are allowed into command registries. */
+export function isCommand(value: unknown): value is Command {
+  if (typeof value !== 'object' || value === null) return false
+
+  const maybeCommand = value as {
+    name?: unknown
+    type?: unknown
+  }
+
+  return (
+    typeof maybeCommand.name === 'string' &&
+    (maybeCommand.type === 'prompt' ||
+      maybeCommand.type === 'local' ||
+      maybeCommand.type === 'local-jsx')
+  )
+}
+
 /** Resolves the user-visible name, falling back to `cmd.name` when not overridden. */
 export function getCommandName(cmd: CommandBase): string {
   return cmd.userFacingName?.() ?? cmd.name


### PR DESCRIPTION
## Summary

- filter built-in command registration through a runtime `isCommand` guard so generated missing-module `noopN` functions do not enter `COMMANDS()`
- add focused regression coverage for rejecting noop-style stubs while still accepting valid command objects
- fix slash-command autocomplete leaking internal tree-shaking stubs like `noop19` and `noop22` into the user-visible command list
- fix issue #1132 

## Impact

- user-facing impact: slash-command autocomplete no longer shows internal tree-shaking stubs as selectable commands
- developer/maintainer impact: command registration now validates runtime command shape before commands are exposed, which makes open-build missing-module stubs safer

## Testing

- [x] `bun run build`
- [x] `bun run smoke`