### PR TITLE
feat: add sponsored tips with frequency-gated display

### DIFF
--- a/src/services/tips/sponsoredTips.test.ts
+++ b/src/services/tips/sponsoredTips.test.ts
@@ -1,0 +1,155 @@
+import { describe, expect, mock, test } from 'bun:test'
+
+type StubSettings = {
+  sponsoredTipsEnabled?: boolean
+  sponsoredTipsFrequency?: number
+  spinnerTipsEnabled?: boolean
+}
+
+const settingsRef: { value: StubSettings } = { value: {} }
+const configRef: {
+  value: { numStartups: number; sponsoredTipsHistory?: { lastShownAt: number; totalShown: number } }
+} = { value: { numStartups: 100 } }
+
+// mock.module is process-global — install once, then mutate the refs per test.
+mock.module('../../utils/settings/settings.js', () => ({
+  getSettings_DEPRECATED: () => settingsRef.value,
+  getInitialSettings: () => settingsRef.value,
+  getSettingsForSource: () => undefined,
+}))
+
+mock.module('../../utils/config.js', () => ({
+  getGlobalConfig: () => configRef.value,
+  saveGlobalConfig: (mut: (c: typeof configRef.value) => typeof configRef.value) => {
+    configRef.value = mut(configRef.value)
+  },
+}))
+
+async function freshImport() {
+  const stamp = `${Date.now()}-${Math.random()}`
+  return {
+    sponsoredTips: await import(`./sponsoredTips.ts?ts=${stamp}`),
+    tipHistory: await import(`./tipHistory.ts?ts=${stamp}`),
+  }
+}
+
+function resetState(settings: StubSettings = {}, numStartups = 100) {
+  settingsRef.value = settings
+  configRef.value = { numStartups }
+}
+
+describe('sponsoredTipsEnabled', () => {
+  test('defaults to true when no settings present', async () => {
+    resetState()
+    const { sponsoredTips } = await freshImport()
+    expect(sponsoredTips.sponsoredTipsEnabled()).toBe(true)
+  })
+
+  test('returns false when explicitly disabled', async () => {
+    resetState({ sponsoredTipsEnabled: false })
+    const { sponsoredTips } = await freshImport()
+    expect(sponsoredTips.sponsoredTipsEnabled()).toBe(false)
+  })
+
+  test('returns false when frequency is 0', async () => {
+    resetState({ sponsoredTipsFrequency: 0 })
+    const { sponsoredTips } = await freshImport()
+    expect(sponsoredTips.sponsoredTipsEnabled()).toBe(false)
+  })
+})
+
+describe('getSponsoredTipsFrequency', () => {
+  test('defaults to 10', async () => {
+    resetState()
+    const { sponsoredTips } = await freshImport()
+    expect(sponsoredTips.getSponsoredTipsFrequency()).toBe(10)
+  })
+
+  test('honors user-configured frequency', async () => {
+    resetState({ sponsoredTipsFrequency: 25 })
+    const { sponsoredTips } = await freshImport()
+    expect(sponsoredTips.getSponsoredTipsFrequency()).toBe(25)
+  })
+
+  test('rejects negative values', async () => {
+    resetState({ sponsoredTipsFrequency: -5 })
+    const { sponsoredTips } = await freshImport()
+    expect(sponsoredTips.getSponsoredTipsFrequency()).toBe(10)
+  })
+})
+
+describe('sponsored tip catalog', () => {
+  test('has exactly 4 Atomic tips', async () => {
+    resetState()
+    const { sponsoredTips } = await freshImport()
+    expect(sponsoredTips.sponsoredTips.length).toBe(4)
+    expect(
+      sponsoredTips.sponsoredTips.every(
+        (t: { sponsor?: { name: string; url?: string } }) =>
+          t.sponsor?.name === 'Atomic Chat' &&
+          t.sponsor.url === 'https://atomic.chat/',
+      ),
+    ).toBe(true)
+  })
+
+  test('all tips have unique ids prefixed with atomic-', async () => {
+    resetState()
+    const { sponsoredTips } = await freshImport()
+    const ids = sponsoredTips.sponsoredTips.map((t: { id: string }) => t.id)
+    expect(new Set(ids).size).toBe(ids.length)
+    expect(ids.every((id: string) => id.startsWith('atomic-'))).toBe(true)
+  })
+
+  test('rendered content embeds sponsor name, tip body, and URL', async () => {
+    resetState()
+    const { sponsoredTips } = await freshImport()
+    const tip = sponsoredTips.sponsoredTips[0]
+    const rendered: string = await tip.content({ theme: 'dark' })
+    // ANSI codes wrap the strings — assert on plain substrings
+    expect(rendered).toContain('Sponsored')
+    expect(rendered).toContain('Atomic Chat')
+    expect(rendered).toContain('Setup free local models')
+    expect(rendered).toContain('https://atomic.chat/')
+  })
+
+  test('isRelevant follows sponsoredTipsEnabled', async () => {
+    resetState({ sponsoredTipsEnabled: false })
+    const { sponsoredTips } = await freshImport()
+    const results = await Promise.all(
+      sponsoredTips.sponsoredTips.map((t: { isRelevant: () => Promise<boolean> }) =>
+        t.isRelevant(),
+      ),
+    )
+    expect(results.every((r: boolean) => r === false)).toBe(true)
+  })
+})
+
+describe('sponsored history tracking', () => {
+  test('records lastShownAt and increments totalShown', async () => {
+    resetState({}, 50)
+    const { tipHistory } = await freshImport()
+    tipHistory.recordSponsoredTipShown()
+    expect(configRef.value.sponsoredTipsHistory).toEqual({
+      lastShownAt: 50,
+      totalShown: 1,
+    })
+    tipHistory.recordSponsoredTipShown()
+    expect(configRef.value.sponsoredTipsHistory).toEqual({
+      lastShownAt: 50,
+      totalShown: 2,
+    })
+  })
+
+  test('getSessionsSinceLastSponsored returns Infinity when never shown', async () => {
+    resetState({}, 100)
+    const { tipHistory } = await freshImport()
+    expect(tipHistory.getSessionsSinceLastSponsored()).toBe(Infinity)
+  })
+
+  test('getSessionsSinceLastSponsored returns delta from current startups', async () => {
+    resetState({}, 100)
+    configRef.value.sponsoredTipsHistory = { lastShownAt: 92, totalShown: 3 }
+    const { tipHistory } = await freshImport()
+    expect(tipHistory.getSessionsSinceLastSponsored()).toBe(8)
+  })
+})

--- a/src/services/tips/sponsoredTips.ts
+++ b/src/services/tips/sponsoredTips.ts
@@ -1,0 +1,89 @@
+import chalk from 'chalk'
+import { color } from '../../components/design-system/color.js'
+import { getSettings_DEPRECATED } from '../../utils/settings/settings.js'
+import type { Tip, TipContext, TipSponsor } from './types.js'
+
+const DEFAULT_FREQUENCY = 10
+
+export function sponsoredTipsEnabled(): boolean {
+  const settings = getSettings_DEPRECATED()
+  if (settings.sponsoredTipsEnabled === false) return false
+  if (settings.sponsoredTipsFrequency === 0) return false
+  return true
+}
+
+export function getSponsoredTipsFrequency(): number {
+  const settings = getSettings_DEPRECATED()
+  const f = settings.sponsoredTipsFrequency
+  if (typeof f === 'number' && f >= 0) return f
+  return DEFAULT_FREQUENCY
+}
+
+const ATOMIC: TipSponsor = {
+  name: 'Atomic Chat',
+  url: 'https://atomic.chat/',
+}
+
+function renderSponsoredTip(
+  sponsor: TipSponsor,
+  body: string,
+  ctx: TipContext,
+): string {
+  const green = color('success', ctx.theme)
+  const label = sponsor.label ?? 'Sponsored'
+  const badge = green(`${label} · ${sponsor.name}`)
+  const text = green(body)
+  const url = sponsor.url ? ` ${chalk.dim(sponsor.url)}` : ''
+  return `${badge} — ${text}${url}`
+}
+
+export const sponsoredTips: Tip[] = [
+  {
+    id: 'atomic-setup-local',
+    sponsor: ATOMIC,
+    content: async ctx =>
+      renderSponsoredTip(
+        ATOMIC,
+        'Setup free local models with Atomic Chat',
+        ctx,
+      ),
+    cooldownSessions: 20,
+    isRelevant: async () => sponsoredTipsEnabled(),
+  },
+  {
+    id: 'atomic-free-access',
+    sponsor: ATOMIC,
+    content: async ctx =>
+      renderSponsoredTip(
+        ATOMIC,
+        'Atomic Chat local models give you free access to OpenClaude',
+        ctx,
+      ),
+    cooldownSessions: 20,
+    isRelevant: async () => sponsoredTipsEnabled(),
+  },
+  {
+    id: 'atomic-turboquant-context',
+    sponsor: ATOMIC,
+    content: async ctx =>
+      renderSponsoredTip(
+        ATOMIC,
+        'Increase your context window with TurboQuant in Atomic Chat local models',
+        ctx,
+      ),
+    cooldownSessions: 20,
+    isRelevant: async () => sponsoredTipsEnabled(),
+  },
+  {
+    id: 'atomic-ram-savings',
+    sponsor: ATOMIC,
+    content: async ctx =>
+      renderSponsoredTip(
+        ATOMIC,
+        '30% less RAM usage with Atomic Chat local models',
+        ctx,
+      ),
+    cooldownSessions: 20,
+    isRelevant: async () => sponsoredTipsEnabled(),
+  },
+]

--- a/src/services/tips/tipHistory.ts
+++ b/src/services/tips/tipHistory.ts
@@ -15,3 +15,24 @@ export function getSessionsSinceLastShown(tipId: string): number {
   if (!lastShown) return Infinity
   return config.numStartups - lastShown
 }
+
+export function recordSponsoredTipShown(): void {
+  const numStartups = getGlobalConfig().numStartups
+  saveGlobalConfig(c => {
+    const prev = c.sponsoredTipsHistory ?? { lastShownAt: 0, totalShown: 0 }
+    return {
+      ...c,
+      sponsoredTipsHistory: {
+        lastShownAt: numStartups,
+        totalShown: prev.totalShown + 1,
+      },
+    }
+  })
+}
+
+export function getSessionsSinceLastSponsored(): number {
+  const config = getGlobalConfig()
+  const lastShown = config.sponsoredTipsHistory?.lastShownAt
+  if (!lastShown) return Infinity
+  return config.numStartups - lastShown
+}

--- a/src/services/tips/tipRegistry.ts
+++ b/src/services/tips/tipRegistry.ts
@@ -53,6 +53,7 @@ import {
   formatCreditAmount,
   getCachedReferrerReward,
 } from '../api/referral.js'
+import { sponsoredTips } from './sponsoredTips.js'
 import { getSessionsSinceLastShown } from './tipHistory.js'
 import type { Tip, TipContext } from './types.js'
 
@@ -638,13 +639,16 @@ export async function getRelevantTips(context?: TipContext): Promise<Tip[]> {
   const override = settings.spinnerTipsOverride
   const customTips = getCustomTips()
 
-  // If excludeDefault is true and there are custom tips, skip built-in tips entirely
+  // If excludeDefault is true and there are custom tips, skip built-in tips entirely.
+  // Sponsored tips are also excluded — user has opted into their own list.
   if (override?.excludeDefault && customTips.length > 0) {
     return customTips
   }
 
-  // Otherwise, filter built-in tips as before and combine with custom
-  const tips = [...externalTips, ...internalOnlyTips]
+  // Otherwise, filter built-in tips as before and combine with custom + sponsored.
+  // The scheduler enforces the sponsored frequency cap; this just returns
+  // everything currently eligible.
+  const tips = [...externalTips, ...internalOnlyTips, ...sponsoredTips]
   const isRelevant = await Promise.all(tips.map(_ => _.isRelevant(context)))
   const filtered = tips
     .filter((_, index) => isRelevant[index])

--- a/src/services/tips/tipScheduler.test.ts
+++ b/src/services/tips/tipScheduler.test.ts
@@ -1,0 +1,164 @@
+import { describe, expect, mock, test } from 'bun:test'
+import type { Tip } from './types.js'
+
+const settingsRef: {
+  value: {
+    sponsoredTipsEnabled?: boolean
+    sponsoredTipsFrequency?: number
+    spinnerTipsEnabled?: boolean
+  }
+} = { value: {} }
+const configRef: {
+  value: {
+    numStartups: number
+    tipsHistory?: Record<string, number>
+    sponsoredTipsHistory?: { lastShownAt: number; totalShown: number }
+  }
+} = { value: { numStartups: 100 } }
+
+const relevantTipsRef: { value: Tip[] } = { value: [] }
+
+mock.module('../../utils/settings/settings.js', () => ({
+  getSettings_DEPRECATED: () => settingsRef.value,
+  getInitialSettings: () => settingsRef.value,
+  getSettingsForSource: () => undefined,
+}))
+
+mock.module('../../utils/config.js', () => ({
+  getGlobalConfig: () => configRef.value,
+  saveGlobalConfig: (mut: (c: typeof configRef.value) => typeof configRef.value) => {
+    configRef.value = mut(configRef.value)
+  },
+}))
+
+mock.module('./tipRegistry.js', () => ({
+  getRelevantTips: async () => relevantTipsRef.value,
+}))
+
+mock.module('../analytics/index.js', () => ({
+  logEvent: () => undefined,
+}))
+
+async function freshScheduler() {
+  const stamp = `${Date.now()}-${Math.random()}`
+  return import(`./tipScheduler.ts?ts=${stamp}`)
+}
+
+function makeTip(id: string, sponsored = false): Tip {
+  return {
+    id,
+    content: async () => id,
+    cooldownSessions: 0,
+    isRelevant: async () => true,
+    ...(sponsored
+      ? { sponsor: { name: 'Atomic Chat', url: 'https://atomic.chat/' } }
+      : {}),
+  }
+}
+
+function setState(opts: {
+  numStartups?: number
+  lastSponsored?: number
+  frequency?: number
+  enabled?: boolean
+  tips: Tip[]
+}) {
+  configRef.value = {
+    numStartups: opts.numStartups ?? 100,
+    ...(opts.lastSponsored !== undefined
+      ? { sponsoredTipsHistory: { lastShownAt: opts.lastSponsored, totalShown: 1 } }
+      : {}),
+  }
+  settingsRef.value = {
+    sponsoredTipsFrequency: opts.frequency,
+    sponsoredTipsEnabled: opts.enabled,
+  }
+  relevantTipsRef.value = opts.tips
+}
+
+describe('getTipToShowOnSpinner — sponsored partitioning', () => {
+  test('picks sponsored when cap met and sponsored tips eligible', async () => {
+    setState({
+      numStartups: 100,
+      lastSponsored: 80, // 20 sessions ago, frequency 10 → eligible
+      frequency: 10,
+      tips: [makeTip('regular-1'), makeTip('atomic-x', true)],
+    })
+    const { getTipToShowOnSpinner } = await freshScheduler()
+    const pick = await getTipToShowOnSpinner()
+    expect(pick?.id).toBe('atomic-x')
+  })
+
+  test('falls back to regular when cap not met', async () => {
+    setState({
+      numStartups: 100,
+      lastSponsored: 95, // only 5 sessions ago, frequency 10 → blocked
+      frequency: 10,
+      tips: [makeTip('regular-1'), makeTip('atomic-x', true)],
+    })
+    const { getTipToShowOnSpinner } = await freshScheduler()
+    const pick = await getTipToShowOnSpinner()
+    expect(pick?.id).toBe('regular-1')
+  })
+
+  test('frequency=0 disables sponsored entirely', async () => {
+    setState({
+      numStartups: 100,
+      lastSponsored: 1,
+      frequency: 0,
+      tips: [makeTip('regular-1'), makeTip('atomic-x', true)],
+    })
+    const { getTipToShowOnSpinner } = await freshScheduler()
+    const pick = await getTipToShowOnSpinner()
+    expect(pick?.id).toBe('regular-1')
+  })
+
+  test('first-ever sponsored slot is eligible (no history)', async () => {
+    setState({
+      numStartups: 100,
+      // no lastSponsored → Infinity sessions
+      frequency: 10,
+      tips: [makeTip('regular-1'), makeTip('atomic-x', true)],
+    })
+    const { getTipToShowOnSpinner } = await freshScheduler()
+    const pick = await getTipToShowOnSpinner()
+    expect(pick?.id).toBe('atomic-x')
+  })
+
+  test('returns undefined when no tips at all', async () => {
+    setState({ tips: [] })
+    const { getTipToShowOnSpinner } = await freshScheduler()
+    expect(await getTipToShowOnSpinner()).toBeUndefined()
+  })
+
+  test('spinnerTipsEnabled=false short-circuits everything', async () => {
+    setState({
+      numStartups: 100,
+      lastSponsored: 50,
+      frequency: 10,
+      tips: [makeTip('atomic-x', true)],
+    })
+    settingsRef.value = { ...settingsRef.value, spinnerTipsEnabled: false }
+    const { getTipToShowOnSpinner } = await freshScheduler()
+    expect(await getTipToShowOnSpinner()).toBeUndefined()
+  })
+})
+
+describe('recordShownTip — sponsored side effects', () => {
+  test('records sponsored history when tip has sponsor', async () => {
+    setState({ numStartups: 100, tips: [] })
+    const { recordShownTip } = await freshScheduler()
+    recordShownTip(makeTip('atomic-x', true))
+    expect(configRef.value.sponsoredTipsHistory).toEqual({
+      lastShownAt: 100,
+      totalShown: 1,
+    })
+  })
+
+  test('does not record sponsored history for regular tips', async () => {
+    setState({ numStartups: 100, tips: [] })
+    const { recordShownTip } = await freshScheduler()
+    recordShownTip(makeTip('regular-1'))
+    expect(configRef.value.sponsoredTipsHistory).toBeUndefined()
+  })
+})

--- a/src/services/tips/tipScheduler.ts
+++ b/src/services/tips/tipScheduler.ts
@@ -3,7 +3,13 @@ import {
   type AnalyticsMetadata_I_VERIFIED_THIS_IS_NOT_CODE_OR_FILEPATHS,
   logEvent,
 } from '../analytics/index.js'
-import { getSessionsSinceLastShown, recordTipShown } from './tipHistory.js'
+import { getSponsoredTipsFrequency } from './sponsoredTips.js'
+import {
+  getSessionsSinceLastShown,
+  getSessionsSinceLastSponsored,
+  recordSponsoredTipShown,
+  recordTipShown,
+} from './tipHistory.js'
 import { getRelevantTips } from './tipRegistry.js'
 import type { Tip, TipContext } from './types.js'
 
@@ -29,6 +35,17 @@ export function selectTipWithLongestTimeSinceShown(
   return tipsWithSessions[0]?.tip
 }
 
+/**
+ * Decide whether this pick is eligible to show a sponsored tip.
+ * Enforces a 1-in-N cap: a sponsored tip can only show if no sponsored tip
+ * has been shown in the last N startups. Setting frequency to 0 disables.
+ */
+function isSponsoredSlotEligible(): boolean {
+  const frequency = getSponsoredTipsFrequency()
+  if (frequency === 0) return false
+  return getSessionsSinceLastSponsored() >= frequency
+}
+
 export async function getTipToShowOnSpinner(
   context?: TipContext,
 ): Promise<Tip | undefined> {
@@ -42,12 +59,25 @@ export async function getTipToShowOnSpinner(
     return undefined
   }
 
-  return selectTipWithLongestTimeSinceShown(tips)
+  const sponsored = tips.filter(t => t.sponsor)
+  const regular = tips.filter(t => !t.sponsor)
+
+  // Sponsored slot first, gated by the 1-in-N cap. Falls back to regular
+  // if no sponsored tip is currently eligible (e.g., cap not met, none relevant).
+  if (sponsored.length > 0 && isSponsoredSlotEligible()) {
+    const pick = selectTipWithLongestTimeSinceShown(sponsored)
+    if (pick) return pick
+  }
+
+  return selectTipWithLongestTimeSinceShown(regular)
 }
 
 export function recordShownTip(tip: Tip): void {
   // Record in history
   recordTipShown(tip.id)
+  if (tip.sponsor) {
+    recordSponsoredTipShown()
+  }
 
   // Log event for analytics
   logEvent('tengu_tip_shown', {

--- a/src/services/tips/types.ts
+++ b/src/services/tips/types.ts
@@ -1,0 +1,22 @@
+import type { FileStateCache } from '../../utils/fileStateCache.js'
+import type { ThemeName } from '../../utils/theme.js'
+
+export type TipContext = {
+  theme: ThemeName
+  readFileState?: FileStateCache
+  bashTools?: Set<string>
+}
+
+export type TipSponsor = {
+  name: string
+  url?: string
+  label?: string
+}
+
+export type Tip = {
+  id: string
+  content: (ctx: TipContext) => Promise<string>
+  cooldownSessions: number
+  isRelevant: (ctx?: TipContext) => Promise<boolean>
+  sponsor?: TipSponsor
+}

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -294,6 +294,13 @@ export type GlobalConfig = {
     [tipId: string]: number // Key is tipId, value is the numStartups when tip was last shown
   }
 
+  // Sponsored tip throttling. lastShownAt is numStartups when last sponsored tip
+  // was displayed; used with sponsoredTipsFrequency to enforce a 1-in-N cap.
+  sponsoredTipsHistory?: {
+    lastShownAt: number
+    totalShown: number
+  }
+
   // /buddy companion soul — bones regenerated from userId on read. See src/buddy/.
   companion?: import('../buddy/types.js').StoredCompanion
   companionMuted?: boolean
@@ -703,6 +710,7 @@ export const GLOBAL_CONFIG_KEYS = [
   'diffTool',
   'env',
   'tipsHistory',
+  'sponsoredTipsHistory',
   'todoFeatureEnabled',
   'showExpandedTodos',
   'messageIdleNotifThresholdMs',

--- a/src/utils/settings/types.ts
+++ b/src/utils/settings/types.ts
@@ -678,6 +678,20 @@ export const SettingsSchema = lazySchema(() =>
         .boolean()
         .optional()
         .describe('Whether to show tips in the spinner'),
+      sponsoredTipsEnabled: z
+        .boolean()
+        .optional()
+        .describe(
+          'Whether to show sponsored partner tips alongside regular tips (default: true). Disabling does not affect regular tips.',
+        ),
+      sponsoredTipsFrequency: z
+        .number()
+        .int()
+        .min(0)
+        .optional()
+        .describe(
+          'Show at most 1 sponsored tip per N spinner picks. Default 10. Set 0 to disable sponsored tips.',
+        ),
       spinnerVerbs: z
         .object({
           mode: z.enum(['append', 'replace']),


### PR DESCRIPTION
Implement sponsored tip system with registry, scheduler integration, and config-gated frequency control. Sponsored tips appear based on startup count frequency (default: 1 per 10 startups) and are tracked separately from regular tip history.


<img width="1118" height="755" alt="Screenshot 2026-05-13 at 4 07 32 PM" src="https://github.com/user-attachments/assets/f050837e-04e9-4f7d-8b1d-cd5fa0e916e8" />
