### PR TITLE
fix(integrations): cap gpt-5.5 context window at Codex effective limit (#1118)

### DIFF
--- a/src/integrations/models/gpt.ts
+++ b/src/integrations/models/gpt.ts
@@ -29,7 +29,12 @@ function gptModel(
 }
 
 export default [
-  gptModel('gpt-5.5', 'GPT-5.5', 1_050_000, 128_000),
+  // gpt-5.5 via Codex transport caps at ~272k effective input tokens; the
+  // 1.05M API descriptor value caused /context to under-report usage and
+  // auto-compact to fire too late, yielding 500 "input exceeds the context
+  // window" mid-turn (issue #1118). Use the conservative Codex limit so
+  // compaction kicks in before the request fails.
+  gptModel('gpt-5.5', 'GPT-5.5', 272_000, 128_000),
   gptModel('gpt-5.5-mini', 'GPT-5.5 Mini', 400_000, 128_000),
   gptModel('gpt-5.5-nano', 'GPT-5.5 Nano', 400_000, 128_000),
   gptModel('gpt-5.4', 'GPT-5.4', 1_050_000, 128_000),

--- a/src/utils/context.test.ts
+++ b/src/utils/context.test.ts
@@ -199,6 +199,19 @@ test('gpt-4o clamps oversized max output overrides to the provider limit', () =>
   expect(getMaxOutputTokensForModel('gpt-4o')).toBe(16_384)
 })
 
+test('gpt-5.5 uses conservative Codex-route context window (issue #1118)', () => {
+  process.env.CLAUDE_CODE_USE_OPENAI = '1'
+  delete process.env.CLAUDE_CODE_MAX_OUTPUT_TOKENS
+  delete process.env.OPENAI_MODEL
+
+  // gpt-5.5 is primarily routed through the Codex transport in this repo
+  // (see src/services/api/providerConfig.ts). The 1.05M API descriptor value
+  // caused /context to under-report and auto-compact to fire too late,
+  // resulting in mid-turn 500s. The descriptor is pinned to the Codex
+  // effective limit until provider-aware context windows land.
+  expect(getContextWindowForModel('gpt-5.5')).toBe(272_000)
+})
+
 test('gpt-5.4 family uses provider-specific context and output caps', () => {
   process.env.CLAUDE_CODE_USE_OPENAI = '1'
   delete process.env.CLAUDE_CODE_MAX_OUTPUT_TOKENS


### PR DESCRIPTION
## Summary

Cap the `gpt-5.5` model descriptor at the Codex effective context limit (~272k) so `/context` and auto-compact match the practical request budget on the Codex transport.

Closes #1118

## Problem

`gpt-5.5` was declared with `contextWindow: 1_050_000` — the OpenAI direct-API ceiling. In this repo `gpt-5.5` is primarily routed through the Codex transport (`src/services/api/providerConfig.ts:42-46`), whose practical request limit is ~272k. The mismatch caused:

- `/context` to under-report usage (`gpt-5.5 · 268.4k/1.1m tokens (26%)` while the request actually overran)
- `autoCompact.ts` to fire after the budget was already blown
- Mid-turn 500: `API Error: 500 Your input exceeds the context window of this model`

Reporter pointed at the exact descriptor line: `src/integrations/models/gpt.ts:32`.

## Root Cause

`getContextWindowForModel` in `src/utils/context.ts:79` resolves via `resolveModelRuntimeLimits` which falls through to `modelDescriptor.contextWindow` when there's no Codex-specific catalog entry. The descriptor value flows into every consumer that reasons about the budget. No provider-aware override existed for Codex.

## Fix

Pin the `gpt-5.5` descriptor to `272_000`. Other entries (`gpt-5.5-mini`, `gpt-5.5-nano`, `gpt-5.4`) are left untouched — they have separate values and weren't confirmed to share the Codex constraint in the report.

Architecturally the correct long-term fix is to add a Codex catalog entry via `src/integrations/runtimeMetadata.ts` so direct-OpenAI users keep the 1.05M ceiling. Tracked as a follow-up so this PR stays scoped.

## Files Changed

- `src/integrations/models/gpt.ts` — descriptor value + 5-line rationale comment
- `src/utils/context.test.ts` — regression test pinning `getContextWindowForModel('gpt-5.5')` to 272k

## Verification

**Automated**
- [x] New regression test: `gpt-5.5 uses conservative Codex-route context window (issue #1118)`
- [x] Test fails against `1_050_000`, passes with this fix
- [x] `bun test src/utils/context.test.ts src/integrations/models/` — 37/37 pass
- [x] `bun test src/services/api/codexShim.test.ts` — pass (no asserts on the changed value)

**Manual**
- [ ] Reporter (Windows 11 / pwsh / Codex GPT-5.5) to verify the 500 no longer fires before auto-compact

## Risk / Side Effects

- `/context` will now show realistic budgets for `gpt-5.5`.
- Auto-compact engages earlier on `gpt-5.5` sessions.
- Direct-OpenAI API users of `gpt-5.5` (rare in this repo) will under-use the 1.05M ceiling until the provider-aware override lands. Conservative wrong > broken right.

## How to Test This PR Locally

```bash
gh pr checkout <PR-number>
bun install
bun test src/utils/context.test.ts
# Then exercise the original repro:
#   openclaude → Codex GPT-5.5 → tool search/read crossing ~272k
# /context should reflect a tight budget; auto-compact engages before 500.
```

## Checklist

- [x] Linked issue (#1118)
- [x] Regression test added
- [x] No new dependencies
- [x] No fingerprints / network leaks
- [x] Self-reviewed the diff

Reported by @luckyabsoluter, root-cause pointer credited; diagnostic context from @Vasanthdev2004.
