### PR TITLE
fix(errors): surface re-auth hint on OAuth token expiry 401s (#1042)

### DIFF
--- a/src/services/api/openaiErrorClassification.test.ts
+++ b/src/services/api/openaiErrorClassification.test.ts
@@ -70,6 +70,29 @@ test('classifies context-overflow responses', () => {
   expect(failure.retryable).toBe(false)
 })
 
+test('401 "token expired" surfaces a re-auth hint, not the generic API-key hint (issue #1042)', () => {
+  const failure = classifyOpenAIHttpFailure({
+    status: 401,
+    body: 'IDE token expired: unauthorized: token expired',
+  })
+
+  expect(failure.category).toBe('auth_invalid')
+  expect(failure.hint).toContain('/onboard-github')
+  expect(failure.hint).toContain('/login')
+  expect(failure.hint).not.toContain('API key')
+})
+
+test('401 without expired-token signal keeps the generic API-key hint', () => {
+  const failure = classifyOpenAIHttpFailure({
+    status: 401,
+    body: 'invalid_api_key: incorrect API key provided',
+  })
+
+  expect(failure.category).toBe('auth_invalid')
+  expect(failure.hint).toContain('API key')
+  expect(failure.hint).not.toContain('/onboard-github')
+})
+
 test('classifies tool compatibility failures', () => {
   const failure = classifyOpenAIHttpFailure({
     status: 400,

--- a/src/services/api/openaiErrorClassification.ts
+++ b/src/services/api/openaiErrorClassification.ts
@@ -270,13 +270,24 @@ export function classifyOpenAIHttpFailure(options: {
   const isLocalHost = isLocalhostLikeHostname(hostname)
 
   if (options.status === 401 || options.status === 403) {
+    // OAuth-issued tokens (GitHub Models via /onboard-github, Codex) expire
+    // and surface as 401 with a "token expired" body. The generic API-key
+    // hint sends users hunting for a key they never set — point them at the
+    // re-auth command instead. Issue #1042.
+    const lowerBody = body.toLowerCase()
+    const isExpiredOAuthToken =
+      lowerBody.includes('token expired') ||
+      lowerBody.includes('token has expired') ||
+      lowerBody.includes('token revoked')
     return {
       source: 'http',
       category: 'auth_invalid',
       retryable: false,
       status: options.status,
       message: body,
-      hint: 'Authentication failed. Verify API key, token source, and endpoint-specific auth headers.',
+      hint: isExpiredOAuthToken
+        ? 'OAuth token expired. Re-authenticate with /onboard-github (GitHub Models) or /login (Codex / Claude) and try again.'
+        : 'Authentication failed. Verify API key, token source, and endpoint-specific auth headers.',
     }
   }
 


### PR DESCRIPTION
## Summary

Surface a re-auth hint on 401s whose body indicates OAuth token expiry, instead of the generic "verify API key" message that sends users hunting for a key they never set.

Closes #1042

## Problem

GitHub Models onboarding (`/onboard-github`) and Codex use OAuth tokens that expire. When they do, the upstream returns 401 with a body like:

```
IDE token expired: unauthorized: token expired
```

The classifier was returning the generic hint:

> Authentication failed. Verify API key, token source, and endpoint-specific auth headers.

…which is misleading for OAuth flows — users don't have an API key to verify; they need to re-authenticate. Reporter (@petchnarit) hit exactly this; @Meetpatel006 chimed in with the correct workaround ("re-login and try again") but the error itself never said that.

## Root Cause

`classifyOpenAIHttpFailure` in `src/services/api/openaiErrorClassification.ts:272-281` returned a single static hint for all 401/403 cases, regardless of whether the failure was an invalid API key or an expired OAuth token.

## Fix

Detect `token expired` / `token has expired` / `token revoked` in the response body. When matched, return a hint pointing at `/onboard-github` (GitHub Models) and `/login` (Codex / Claude). Non-matching 401s keep the existing generic hint so the bad-API-key case is unchanged.

## Files Changed

- `src/services/api/openaiErrorClassification.ts` — branch on body content for the 401/403 hint, 7-line rationale comment referencing the issue
- `src/services/api/openaiErrorClassification.test.ts` — two regression tests: one for the new re-auth branch, one confirming the bad-API-key branch is preserved

## Verification

**Automated**
- [x] Two regression tests added (`401 "token expired" surfaces a re-auth hint`, `401 without expired-token signal keeps the generic API-key hint`)
- [x] `bun test src/services/api/openaiErrorClassification.test.ts` — 15/15 pass

**Manual**
- [ ] Reporter to confirm the new hint appears the next time the token expires

## Risk / Side Effects

- Pure error-message change for one branch of a classifier. No request behavior changes.
- Heuristic is substring-based; a future provider whose 401 body mentions "token expired" in some other context would also get the re-auth hint. That's acceptable — re-auth is a reasonable first thing to try on a 401.

## How to Test This PR Locally

```bash
gh pr checkout <PR-number>
bun install
bun test src/services/api/openaiErrorClassification.test.ts
# Real-world repro: trigger a 401 with an expired GitHub Models token
# (or simulate by feeding a 401 with the body 'token expired' through any
# OpenAI-compatible code path). New hint should mention /onboard-github.
```

## Checklist

- [x] Linked issue (#1042)
- [x] Regression test added (positive + negative)
- [x] No new dependencies
- [x] No fingerprints / network leaks
- [x] Self-reviewed the diff

Reported by @petchnarit; workaround surfaced by @Meetpatel006.
