### PR TITLE
feat(groq): dynamic model discovery with mapModel filtering and hybrid catalog

### DIFF
--- a/src/integrations/discoveryService.test.ts
+++ b/src/integrations/discoveryService.test.ts
@@ -415,6 +415,66 @@ describe('discoverModelsForRoute', () => {
     expect(result?.routeId).toBe('lmstudio')
     expect(result?.source).toBe('network')
   })
+
+  test('openai-compatible discovery applies mapModel to filter and shape raw entries', async () => {
+    const { discoverModelsForRoute } = await loadDiscoveryServiceModule()
+
+    registerGateway({
+      id: 'mapmodel-test',
+      label: 'MapModel Test',
+      category: 'aggregating',
+      defaultBaseUrl: 'https://mapmodel-test.example/v1',
+      setup: {
+        requiresAuth: true,
+        authMode: 'api-key',
+        credentialEnvVars: ['MAPMODEL_TEST_API_KEY'],
+      },
+      transportConfig: { kind: 'openai-compatible' },
+      catalog: {
+        source: 'dynamic',
+        discovery: {
+          kind: 'openai-compatible',
+          mapModel(raw: unknown) {
+            const model = raw as { id?: string; active?: boolean; context_window?: number }
+            if (!model.id || model.active === false) return null
+            if (/(guard|whisper)/i.test(model.id)) return null
+            return {
+              id: model.id,
+              apiName: model.id,
+              label: model.id,
+              ...(model.context_window ? { contextWindow: model.context_window } : {}),
+            }
+          },
+        },
+        discoveryCacheTtl: '1d',
+      },
+    })
+
+    setMockFetch(mock(() =>
+      Promise.resolve(
+        new Response(
+          JSON.stringify({
+            data: [
+              { id: 'llama-3.3-70b', context_window: 131072 },
+              { id: 'whisper-large-v3' },
+              { id: 'llama-guard-3' },
+              { id: 'inactive-model', active: false },
+            ],
+          }),
+          { status: 200, headers: { 'Content-Type': 'application/json' } },
+        ),
+      )
+    ) as unknown as typeof globalThis.fetch)
+
+    const result = await discoverModelsForRoute('mapmodel-test', {
+      forceRefresh: true,
+    })
+
+    expect(result?.source).toBe('network')
+    expect(result?.models).toEqual([
+      { id: 'llama-3.3-70b', apiName: 'llama-3.3-70b', label: 'llama-3.3-70b', contextWindow: 131072 },
+    ])
+  })
 })
 
 describe('probeRouteReadiness', () => {

--- a/src/integrations/discoveryService.ts
+++ b/src/integrations/discoveryService.ts
@@ -23,6 +23,7 @@ import type {
   OllamaGenerationReadiness,
 } from '../utils/providerDiscovery.js'
 import {
+  fetchOpenAICompatibleModelsRaw,
   listOpenAICompatibleModels,
   probeOllamaModelCatalog,
   probeAtomicChatReadiness,
@@ -236,6 +237,25 @@ async function runDiscovery(
     }
 
     case 'openai-compatible': {
+      if (discovery.mapModel) {
+        const rawModels = await fetchOpenAICompatibleModelsRaw({
+          baseUrl: getRouteBaseUrl(routeId, options),
+          apiKey: getRouteDiscoveryApiKey(routeId, options),
+          headers: getRouteDiscoveryHeaders(routeId, options),
+        })
+        if (rawModels === null) {
+          return null
+        }
+        const entries: ModelCatalogEntry[] = []
+        for (const raw of rawModels) {
+          const entry = discovery.mapModel(raw)
+          if (entry !== null) {
+            entries.push(entry)
+          }
+        }
+        return entries
+      }
+
       const models = await listOpenAICompatibleModels({
         baseUrl: getRouteBaseUrl(routeId, options),
         apiKey: getRouteDiscoveryApiKey(routeId, options),

--- a/src/integrations/gateways/groq.ts
+++ b/src/integrations/gateways/groq.ts
@@ -26,7 +26,7 @@ export default defineGateway({
     vendorId: 'openai',
   },
   catalog: {
-    source: 'dynamic',
+    source: 'hybrid',
     discovery: {
       kind: 'openai-compatible',
       mapModel(raw: unknown) {
@@ -34,19 +34,23 @@ export default defineGateway({
         if (!model.id || model.active === false) {
           return null
         }
-        if (/^(whisper-|distil-whisper-|llama-guard-|playai-)/i.test(model.id)) {
+        if (/(whisper|distil-whisper|llama-guard|prompt-guard|safeguard|playai|orpheus)/i.test(model.id)) {
           return null
         }
         return {
           id: model.id,
           apiName: model.id,
           label: model.id,
+          ...(model.context_window ? { contextWindow: model.context_window } : {}),
         }
       },
     },
     discoveryCacheTtl: '1d',
     discoveryRefreshMode: 'background-if-stale',
     allowManualRefresh: true,
+    models: [
+      { id: 'groq-llama-3.3-70b', apiName: 'llama-3.3-70b-versatile', label: 'Llama 3.3 70B', modelDescriptorId: 'llama-3.3-70b-versatile' },
+    ],
   },
   usage: { supported: false },
 })

--- a/src/integrations/gateways/groq.ts
+++ b/src/integrations/gateways/groq.ts
@@ -16,7 +16,7 @@ export default defineGateway({
     kind: 'openai-compatible',
     openaiShim: {
       supportsAuthHeaders: true,
-      removeBodyFields: ['store'],
+      removeBodyFields: ['store', 'reasoning_effort'],
     },
   },
   preset: {
@@ -26,10 +26,27 @@ export default defineGateway({
     vendorId: 'openai',
   },
   catalog: {
-    source: 'static',
-    models: [
-      { id: 'groq-llama-3.3-70b', apiName: 'llama-3.3-70b-versatile', label: 'Llama 3.3 70B', modelDescriptorId: 'llama-3.3-70b-versatile' },
-    ],
+    source: 'dynamic',
+    discovery: {
+      kind: 'openai-compatible',
+      mapModel(raw: unknown) {
+        const model = raw as { id?: string; active?: boolean; context_window?: number }
+        if (!model.id || model.active === false) {
+          return null
+        }
+        if (/^(whisper-|distil-whisper-|llama-guard-|playai-)/i.test(model.id)) {
+          return null
+        }
+        return {
+          id: model.id,
+          apiName: model.id,
+          label: model.id,
+        }
+      },
+    },
+    discoveryCacheTtl: '1d',
+    discoveryRefreshMode: 'background-if-stale',
+    allowManualRefresh: true,
   },
   usage: { supported: false },
 })

--- a/src/utils/providerDiscovery.ts
+++ b/src/utils/providerDiscovery.ts
@@ -297,6 +297,44 @@ export async function listOpenAICompatibleModels(options?: {
   }
 }
 
+export async function fetchOpenAICompatibleModelsRaw(options?: {
+  baseUrl?: string
+  apiKey?: string
+  headers?: Record<string, string>
+}): Promise<Record<string, unknown>[] | null> {
+  const { signal, clear } = withTimeoutSignal(5000)
+  try {
+    const baseUrl = getOpenAICompatibleModelsBaseUrl(options?.baseUrl)
+    const isBankr = baseUrl.toLowerCase().includes('bankr')
+    const headers = {
+      ...(options?.headers ?? {}),
+      ...(options?.apiKey
+        ? isBankr
+          ? { 'X-API-Key': options.apiKey }
+          : { Authorization: `Bearer ${options.apiKey}` }
+        : {}),
+    }
+    const response = await fetch(`${baseUrl}/models`, {
+      method: 'GET',
+      headers: Object.keys(headers).length > 0 ? headers : undefined,
+      signal,
+    })
+    if (!response.ok) {
+      return null
+    }
+
+    const data = (await response.json()) as {
+      data?: Array<Record<string, unknown>>
+    }
+
+    return data.data ?? null
+  } catch {
+    return null
+  } finally {
+    clear()
+  }
+}
+
 export async function hasLocalAtomicChat(baseUrl?: string): Promise<boolean> {
   const { signal, clear } = withTimeoutSignal(1200)
   try {


### PR DESCRIPTION
## Summary

- **What changed:**
  - Switched Groq's catalog `source` from `'dynamic'` to `'hybrid'` so the curated static entry (`groq-llama-3.3-70b` → `llama-3.3-70b-versatile`) is always surfaced ahead of live-discovered models
  - Added a `mapModel` function to filter out non-chat models from Groq's `/models` API response: speech-synthesis (`orpheus`), ASR (`whisper`, `distil-whisper`), safety-classifiers (`llama-guard`, `prompt-guard`, `safeguard`), and TTS utilities (`playai`)
  - Maps `context_window` from the raw API response onto each `ModelCatalogEntry.contextWindow`
  - Extended `discoveryService.ts` to invoke `mapModel` (via `fetchOpenAICompatibleModelsRaw`) when a gateway supplies a custom mapper, falling back to the existing string-list path otherwise
  - Added `fetchOpenAICompatibleModelsRaw()` to `providerDiscovery.ts` for returning full raw model objects instead of just IDs
  - Added a new unit test in `discoveryService.test.ts` covering the `mapModel` code path end-to-end

- **Why it changed:**
  - Groq's `/models` endpoint returns ~40+ entries mixing chat models with guard classifiers, ASR/TTS models, and inactive models. Without filtering, users would see unusable models in the selector that produce errors when selected.
  - The original `'dynamic'`-only source dropped the curated `llama-3.3-70b-versatile` entry with its `modelDescriptorId` link; `'hybrid'` restores it.
  - `context_window` was silently discarded surfacing it enables smarter context-window-aware logic downstream.

## Screenshot

- Before
<img width="1521" height="324" alt="image" src="https://github.com/user-attachments/assets/fadb064e-f553-4da2-b873-368f23522394" />

- After
<img width="1543" height="531" alt="image" src="https://github.com/user-attachments/assets/c1391bbc-e4af-4717-a62c-1f8c231d2412" />

## Impact

- **User-facing impact:** Groq model list in the UI/TUI will now show only real chat-completion models (e.g. `llama-3.3-70b-versatile`, `llama-4-scout`, `qwen3-32b`, etc.) no more guard/whisper/TTS noise. Context window sizes will be populated automatically.
- **Developer/maintainer impact:** Introduces the `mapModel` escape hatch in `ModelDiscoveryConfig` for any future gateway that needs provider-specific filtering or field remapping beyond the default `id` only mapping.

## Testing

- [x] `bun run build`
- [x] `bun run smoke`
- [x] focused tests:
  - `bun test src/integrations` : 99 pass, 0 fail
  - `bun test src/utils/providerDiscovery.test.ts` : 18 pass, 0 fail
  - `bun test src/services/api` : 511 pass, 0 fail
  - Live end-to-end against `https://api.groq.com/openai/v1/models` with `forceRefresh: true`  : confirmed guard/whisper/orpheus/safeguard models excluded, contextWindow populated
  
  
## Notes

- **Provider/model path tested:** Groq → `https://api.groq.com/openai/v1` → `/models` → `mapModel` filter → `discoverModelsForRoute('groq', { forceRefresh: true })`
- **Screenshots attached:** N/A (no UI changes, model list is terminal/TUI)
- **Follow-up work / known limitations:**
  - The `orpheus` filter may need revisiting if Groq adds chat-capable models with "orpheus" in the name in future
  - Other aggregating gateways (OpenRouter, Together) could also benefit from `mapModel` filtering but are out of scope for this PR

