### PR TITLE
fix(security): warn at startup when 3P provider + permissive mode skips classifier (#244)

### DIFF
--- a/src/setup.ts
+++ b/src/setup.ts
@@ -41,6 +41,7 @@ import { hasWorktreeCreateHook } from './utils/hooks.js'
 import { checkAndRestoreITerm2Backup } from './utils/iTermBackup.js'
 import { logError } from './utils/log.js'
 import { getRecentActivity } from './utils/logoV2Utils.js'
+import { getAPIProvider } from './utils/model/providers.js'
 import { lockCurrentVersion } from './utils/nativeInstaller/index.js'
 import type { PermissionMode } from './utils/permissions/PermissionMode.js'
 import { getPlanSlug } from './utils/plans.js'
@@ -400,6 +401,30 @@ export async function setup(
       process.exit(1)
     }
 
+  }
+
+  // Surface a startup warning when permissive permission modes are combined
+  // with a third-party provider. modelSupportsAutoMode() short-circuits to
+  // false for non-firstParty providers when USER_TYPE !== 'ant' (see
+  // utils/betas.ts), so the AI-based tool-call classifier never runs in this
+  // configuration even though acceptEdits / bypassPermissions / --dangerously-
+  // skip-permissions auto-allow tool calls. Static pattern checks still
+  // apply; the warning makes the absent safety layer visible to the user.
+  // Tracks #244 finding 1.
+  if (
+    process.env.USER_TYPE !== 'ant' &&
+    getAPIProvider() !== 'firstParty' &&
+    (permissionMode === 'acceptEdits' ||
+      permissionMode === 'bypassPermissions' ||
+      allowDangerouslySkipPermissions)
+  ) {
+    // biome-ignore lint/suspicious/noConsole:: intentional console output
+    console.warn(
+      chalk.yellow(
+        'Warning: AI safety classifier is not active for third-party providers.',
+      ) +
+        '\nTool calls are validated by static pattern checks only. Use caution with untrusted codebases.',
+    )
   }
 
   if (process.env.NODE_ENV === 'test') {

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -405,14 +405,12 @@ export async function setup(
 
   // Surface a startup warning when permissive permission modes are combined
   // with a third-party provider. modelSupportsAutoMode() short-circuits to
-  // false for non-firstParty providers when USER_TYPE !== 'ant' (see
-  // utils/betas.ts), so the AI-based tool-call classifier never runs in this
-  // configuration even though acceptEdits / bypassPermissions / --dangerously-
-  // skip-permissions auto-allow tool calls. Static pattern checks still
-  // apply; the warning makes the absent safety layer visible to the user.
-  // Tracks #244 finding 1.
+  // false for non-firstParty providers (see utils/betas.ts), so the AI-based
+  // tool-call classifier never runs in this configuration even though
+  // acceptEdits / bypassPermissions / --dangerously-skip-permissions auto-
+  // allow tool calls. Static pattern checks still apply; the warning makes
+  // the absent safety layer visible to the user. Tracks #244 finding 1.
   if (
-    process.env.USER_TYPE !== 'ant' &&
     getAPIProvider() !== 'firstParty' &&
     (permissionMode === 'acceptEdits' ||
       permissionMode === 'bypassPermissions' ||


### PR DESCRIPTION
## Summary

Addresses finding 1 of #244.

`modelSupportsAutoMode()` short-circuits to `false` for non-`firstParty` providers when `USER_TYPE !== 'ant'` ([src/utils/betas.ts:166](https://github.com/Gitlawb/openclaude/blob/main/src/utils/betas.ts#L166)), so the AI-based tool-call classifier never runs in that configuration. `acceptEdits`, `bypassPermissions`, and `--dangerously-skip-permissions` all auto-allow tool calls — combining them with a third-party provider means tool calls are gated only by static pattern checks, with no visible signal that the AI safety review layer is absent.

This is exactly the split-brain risk @auriti flagged in [the issue](https://github.com/Gitlawb/openclaude/issues/244): first-party Claude models are trained to resist prompt injection; a small/local 3P model has no such guarantee, so a crafted payload in a codebase can emit dangerous commands that pass the static pattern checks.

## Change

In `src/setup.ts`, after the existing root/sudo bypass-permissions safety check, print a `chalk.yellow` warning to stderr when **all** of the following are true:

- `process.env.USER_TYPE !== 'ant'` (external user — same gate `modelSupportsAutoMode` uses)
- `getAPIProvider() !== 'firstParty'` (third-party provider)
- permissive mode is active: `acceptEdits`, `bypassPermissions`, or `--dangerously-skip-permissions`

## What this does NOT change

- Static pattern checks (`bashSecurity`, path traversal, dangerous-removal-paths, sandbox enforcement) — still run for all providers, unchanged.
- First-party / Bedrock / Vertex / Foundry behavior — unchanged.
- `default` permission mode — no warning, since tool calls still prompt.
- ANT internal builds (`USER_TYPE === 'ant'`) — no warning, since the classifier is available.

## Test plan

- [x] `bash -n`-style review of the conditional — no syntax issues.
- [x] Import order matches the surrounding alphabetical block (`logoV2Utils.js` → `model/providers.js` → `nativeInstaller/index.js`).
- [ ] `bun test` not run locally (bun not installed on this machine); CI will run it.

The change is one self-contained branch with three short conditions and a `console.warn` call, no shared-state touches, no test fixtures to update.

## Related

- Finding 3 of #244 already landed in #246.
- Finding 2 (`--dangerously-skip-permissions` sandbox gate was employee-only) appears to have been refactored out of `src/setup.ts`; this PR intentionally leaves it alone.