### PR TITLE
fix(model picker): skip Codex/GPT options when OPENAI_BASE_URL is non-OpenAI (#1119)

### DIFF
--- a/src/utils/model/modelOptions.openaiBaseUrl.test.ts
+++ b/src/utils/model/modelOptions.openaiBaseUrl.test.ts
@@ -1,0 +1,49 @@
+import { afterEach, beforeEach, expect, test } from 'bun:test'
+import { isOpenAIOrCodexBaseUrl } from './modelOptions.js'
+
+const originalBaseUrl = process.env.OPENAI_BASE_URL
+
+beforeEach(() => {
+  delete process.env.OPENAI_BASE_URL
+})
+
+afterEach(() => {
+  if (originalBaseUrl === undefined) {
+    delete process.env.OPENAI_BASE_URL
+  } else {
+    process.env.OPENAI_BASE_URL = originalBaseUrl
+  }
+})
+
+test('treats unset OPENAI_BASE_URL as vanilla OpenAI', () => {
+  expect(isOpenAIOrCodexBaseUrl()).toBe(true)
+})
+
+test('treats empty / whitespace OPENAI_BASE_URL as vanilla OpenAI', () => {
+  process.env.OPENAI_BASE_URL = '   '
+  expect(isOpenAIOrCodexBaseUrl()).toBe(true)
+})
+
+test.each([
+  'https://api.openai.com/v1',
+  'https://API.OPENAI.COM/v1',
+  'https://chatgpt.com/backend-api',
+  'https://chatgpt.com/backend-api/codex',
+  'https://api.codex.openai.example.test/v1',
+])('treats %s as OpenAI/Codex', baseUrl => {
+  process.env.OPENAI_BASE_URL = baseUrl
+  expect(isOpenAIOrCodexBaseUrl()).toBe(true)
+})
+
+test.each([
+  'https://api.kimi.com/coding/',
+  'https://api.z.ai/api/anthropic',
+  'https://openrouter.ai/api/v1',
+  'https://api.sambanova.ai',
+  'https://integrate.api.nvidia.com/v1',
+  'https://api.deepinfra.com/v1/openai',
+  'http://localhost:11434/v1',
+])('treats %s as non-OpenAI', baseUrl => {
+  process.env.OPENAI_BASE_URL = baseUrl
+  expect(isOpenAIOrCodexBaseUrl()).toBe(false)
+})

--- a/src/utils/model/modelOptions.ts
+++ b/src/utils/model/modelOptions.ts
@@ -330,6 +330,23 @@ function getCodexSparkOption(): ModelOption {
   }
 }
 
+// Mirrors the base-URL sniffing pattern already used by isNvidiaNimProvider().
+// `getAPIProvider() === 'openai'` is set for any OpenAI-compatible endpoint
+// (Kimi, Z.AI, OpenRouter, SambaNova, …), so it can't be used alone to decide
+// whether the hardcoded GPT/Codex catalog applies. When OPENAI_BASE_URL is
+// unset we assume vanilla api.openai.com; otherwise we only treat known
+// OpenAI / Codex / ChatGPT hosts as a match. Tracks #1119.
+export function isOpenAIOrCodexBaseUrl(): boolean {
+  const baseUrl = process.env.OPENAI_BASE_URL?.trim()
+  if (!baseUrl) return true
+  const lower = baseUrl.toLowerCase()
+  return (
+    lower.includes('openai.com') ||
+    lower.includes('chatgpt.com') ||
+    lower.includes('codex')
+  )
+}
+
 function getCodexModelOptions(): ModelOption[] {
   return [
     {
@@ -546,8 +563,16 @@ function getModelOptionsBase(fastMode = false): ModelOption[] {
   // PAYG 3P: Default (Sonnet 4.5) + Sonnet (3P custom) or Sonnet 4.6/1M + Opus (3P custom) or Opus 4.1/Opus 4.6/Opus1M + Haiku + Opus 4.1
   const payg3pOptions = [getDefaultOptionForUser(fastMode)]
 
-  // Add Codex models for openai and codex providers
-  if (getAPIProvider() === 'openai' || getAPIProvider() === 'codex') {
+  // Add Codex models for openai and codex providers.
+  // For the generic 'openai' route the user may be pointed at a non-OpenAI
+  // OpenAI-compatible endpoint (Kimi, Z.AI, OpenRouter, SambaNova, …); the
+  // hardcoded GPT/Codex catalog isn't reachable through those endpoints, so
+  // injecting it just clutters the /model picker (#1119). The 'codex' route
+  // is routing-specific, so we always keep it.
+  if (
+    getAPIProvider() === 'codex' ||
+    (getAPIProvider() === 'openai' && isOpenAIOrCodexBaseUrl())
+  ) {
     payg3pOptions.push(...getCodexModelOptions())
   }
 


### PR DESCRIPTION
## Summary

Addresses the narrow first PR @Vasanthdev2004 [explicitly asked for](https://github.com/Gitlawb/openclaude/issues/1119#issuecomment-4430190083) in #1119:

> A clean first PR would be the narrower Codex/GPT option suppression for non-OpenAI endpoints, with tests around `getModelOptionsBase()`.

`getAPIProvider()` returns `'openai'` for every OpenAI-compatible endpoint, including Kimi (`api.kimi.com`), Z.AI (`api.z.ai`), OpenRouter, SambaNova, DeepInfra, local `llama-server`, etc. The previous unconditional injection of `getCodexModelOptions()` at `src/utils/model/modelOptions.ts:550` for `getAPIProvider() === 'openai'` meant the `/model` picker offered `gpt-5.5`, `gpt-5.4`, `gpt-5.3-codex`, `gpt-5.3-codex-spark`, `gpt-5.2-codex`, `gpt-5.1-codex-max`, `gpt-5.1-codex-mini`, `gpt-5.5-mini`, `gpt-5.4-mini` etc. for users whose base URL has nothing to do with OpenAI — exactly the symptom reported by @suenot.

## Change

`src/utils/model/modelOptions.ts`:

1. New `isOpenAIOrCodexBaseUrl()` helper. Mirrors the URL-sniffing pattern already in `isNvidiaNimProvider()` (`src/utils/model/nvidiaNimModels.ts:10`). Unset / empty / whitespace `OPENAI_BASE_URL` falls back to vanilla `api.openai.com` semantics (keep injection); otherwise only `openai.com`, `chatgpt.com`, and `codex` hosts match. Case-insensitive.

2. Tightened guard at the injection site:

   ```diff
   - if (getAPIProvider() === 'openai' || getAPIProvider() === 'codex') {
   + if (
   +   getAPIProvider() === 'codex' ||
   +   (getAPIProvider() === 'openai' && isOpenAIOrCodexBaseUrl())
   + ) {
       payg3pOptions.push(...getCodexModelOptions())
     }
   ```

   The `'codex'` route is routing-specific and always keeps injection. The `'openai'` route is only treated as Codex/GPT-capable when the base URL is consistent with that.

## What this does NOT do

Out of scope, per the maintainer's split of the issue into two pieces:

- Surfacing `agentModels` from `settings.json` in `/model` — the larger UX feature requiring a `/model` vs `/provider` boundary design pass.
- Unifying `providerProfiles` into the `/model` picker.

Both stay open on the issue thread for a follow-up.

## Test plan

New `src/utils/model/modelOptions.openaiBaseUrl.test.ts` covers the helper directly with positive/negative cases drawn from the issue body:

| `OPENAI_BASE_URL`                            | Expected | Why                              |
|----------------------------------------------|----------|----------------------------------|
| unset                                        | true     | defaults to vanilla OpenAI       |
| `'   '`                                      | true     | whitespace-only treated as unset |
| `https://api.openai.com/v1`                  | true     | canonical                        |
| `https://API.OPENAI.COM/v1`                  | true     | case-insensitive                 |
| `https://chatgpt.com/backend-api`            | true     | ChatGPT route                    |
| `https://chatgpt.com/backend-api/codex`      | true     | Codex via ChatGPT                |
| `https://api.codex.openai.example.test/v1`  | true     | matches 'codex' substring        |
| `https://api.kimi.com/coding/`               | false    | from #1119 repro                 |
| `https://api.z.ai/api/anthropic`             | false    | from #1119 repro                 |
| `https://openrouter.ai/api/v1`               | false    | from #1119 repro                 |
| `https://api.sambanova.ai`                   | false    | from #1119 repro                 |
| `https://integrate.api.nvidia.com/v1`        | false    | NIM endpoint                     |
| `https://api.deepinfra.com/v1/openai`        | false    | DeepInfra                        |
| `http://localhost:11434/v1`                  | false    | local llama-server               |

- [x] Diff reviewed locally; helper is pure and side-effect-free.
- [x] Test cases cover both the false-positive (clutter) and false-negative (vanilla OpenAI still works) directions.
- [ ] `bun test` not run locally — `bun` isn't installed on this machine. CI will run it. Happy to amend if the table needs additional cases.

## Related

- Issue #1119 (parent).
- #1141 (gnanam1990) handles a related concern (#1118 GPT-5.5 context window cap) but doesn't touch the `/model` picker — independent.