### PR TITLE
fix(agent): prevent mid-flight peeking and taking over of forks

### DIFF
--- a/src/tools/AgentTool/prompt.ts
+++ b/src/tools/AgentTool/prompt.ts
@@ -88,9 +88,11 @@ Fork yourself (omit \`subagent_type\`) when the intermediate tool output isn't w
 
 Forks are cheap because they share your prompt cache. Don't set \`model\` on a fork \u2014 a different model can't reuse the parent's cache. Pass a short \`name\` (one or two words, lowercase) so the user can see the fork in the teams panel and steer it mid-run.
 
-**Don't peek.** The tool result includes an \`output_file\` path — do not Read or tail it unless the user explicitly asks for a progress check. You get a completion notification; trust it. Reading the transcript mid-flight pulls the fork's tool noise into your context, which defeats the point of forking.
+**Don't peek.** The tool result includes an \`output_file\` path — do not Read or tail it unless the user explicitly asks for a progress check. You get a completion notification; trust it. Reading the transcript mid-flight pulls the fork's tool noise into your context, which defeats the point of forking. If you need to course-correct, use SendMessage — never Read.
 
 **Don't race.** After launching, you know nothing about what the fork found. Never fabricate or predict fork results in any format — not as prose, summary, or structured output. The notification arrives as a user-role message in a later turn; it is never something you write yourself. If the user asks a follow-up before the notification lands, tell them the fork is still running — give status, not a guess.
+
+**Don't take over.** A fork that looks stuck is usually in its read phase, not failing. Course-correct with SendMessage; never write its output yourself or discard its result when it lands. Override belongs to the Review phase.
 
 **Writing a fork prompt.** Since the fork inherits your context, the prompt is a *directive* — what to do, not what the situation is. Be specific about scope: what's in, what's out, what another agent is handling. Don't re-explain background.
 `


### PR DESCRIPTION
## Summary

- **Misbehavior Fixed:** Addressed a failure mode where the main agent would "peek" at a sub-agent's output file mid-flight, interpret early exploration (the "read phase") as failure or thrasher, and then "take over" the task by performing the work itself in the main context. This defeated the purpose of forking, pulling noise into the parent context, and often resulted in lower-quality output compared to allowing the agent to self-correct.
- **The Fix:** Updated the `AgentTool` system prompt to strictly separate "Observation" from "Review." 
  - Refined the **Don't peek** rule to provide an immediate alternative: use `SendMessage` for course-correction instead of `Read`.
  - Introduced a new **Don't take over** directive that reframes apparent "stuck" behavior as a normal part of the research phase and explicitly forbids overriding or discarding agent results until the legitimate **Review phase**.


## Impact

- **User-facing impact:** Improved agent reliability and stability. Users will see fewer instances of the main agent "interrupting" and doing redundant work while a sub-agent is already assigned.
- **Developer/maintainer impact:** Hardens the boundaries of the agentic framework. Reduces context pollution in the main session by ensuring sub-agent "noise" stays in the fork.

## Testing

- [x] `bun run build`
- [ ] `bun run smoke`
- [x] focused tests: Reviewed tool definitions for `SendMessage` and `Read` to ensure the prompt references valid and available tools.

## Notes

- **Provider/model path tested:** Logic verified against DeepSeek v4 Flash and Kimi K 2.6 within the agentic framework, behaving noticeably more robust with the rule in place, waiting correctly for a plan agent to finish, sending course-correction when the forked agent reads the wrong files and resisting the "temptation" to take over.

- **Collaborative Design:** The instruction set was elaborated and refined with **Opus 4.7** to ensure the cognitive reframing (selection bias and the read-before-synthesis phase) was robust, and the final implementation was verified for clarity and adherence to the agentic framework by **Gemini Pro 3.1** with no further changes and the recommendation to proceed with the commit as-is.

- **Screenshots attached:** 
Example of the main agent taking over its planning agent, because it "peeked" and thought "it was wrong".  The agent was not instructed to use SendMessage to course correct, and instead took over. In fact, after the take over and plan execution, the planning agent finished, and got further information that made the main agent do another turn to add what his research was missing - the planning agent's purpose was defeated by the main-agent take-over and led to incomplete, lower quality work. This was the motivation to start the investigation.

<img width="943" height="851" alt="image" src="https://github.com/user-attachments/assets/ebc35194-4049-4fc8-a663-8874d5b601e4" />

- Note. The provided "fix" by the agentic model was not used (hence it is cut here), only the symptomatic explanations were used with more capable models to provide a surgical, short and unambiguous fix to address the core problem. 
- About the seemingly double "course-correct" addition. The first addition is not replacable by only the "don't take over" instruction. They catch different triggers, and the earlier catch is the cheaper one.
