### PR TITLE
fix(openai-shim): restore reasoning support for proxy and localhost providers

### DIFF
--- a/src/integrations/runtimeMetadata.ts
+++ b/src/integrations/runtimeMetadata.ts
@@ -163,6 +163,28 @@ function inferRemoteModelOpenAIShimConfig(
     }
   }
 
+  if (normalizedModel.includes('mimo')) {
+    return {
+      preserveReasoningContent: true,
+      requireReasoningContentOnAssistantMessages: true,
+      reasoningContentFallback: '',
+      thinkingRequestFormat: 'deepseek-compatible',
+      maxTokensField: 'max_tokens',
+      removeBodyFields: ['store'],
+    }
+  }
+
+  if (normalizedModel.includes('glm')) {
+    return {
+      preserveReasoningContent: true,
+      requireReasoningContentOnAssistantMessages: true,
+      reasoningContentFallback: '',
+      thinkingRequestFormat: 'deepseek-compatible',
+      maxTokensField: 'max_tokens',
+      removeBodyFields: ['store'],
+    }
+  }
+
   return undefined
 }
 

--- a/src/integrations/runtimeMetadata.ts
+++ b/src/integrations/runtimeMetadata.ts
@@ -263,6 +263,9 @@ export function resolveOpenAIShimRuntimeContext(options?: {
           ...(remoteModelInferredConfig?.thinkingRequestFormat !== undefined
             ? { thinkingRequestFormat: remoteModelInferredConfig.thinkingRequestFormat }
             : {}),
+          ...(remoteModelInferredConfig?.removeBodyFields !== undefined
+            ? { removeBodyFields: remoteModelInferredConfig.removeBodyFields }
+            : {}),
         }
       : remoteModelInferredConfig
 

--- a/src/integrations/runtimeMetadata.ts
+++ b/src/integrations/runtimeMetadata.ts
@@ -178,6 +178,8 @@ function inferRemoteModelOpenAIShimConfig(
       requireReasoningContentOnAssistantMessages: true,
       reasoningContentFallback: '',
       thinkingRequestFormat: 'deepseek-compatible',
+      maxTokensField: 'max_completion_tokens',
+      removeBodyFields: ['store'],
     }
   }
 
@@ -187,6 +189,8 @@ function inferRemoteModelOpenAIShimConfig(
       requireReasoningContentOnAssistantMessages: true,
       reasoningContentFallback: '',
       thinkingRequestFormat: 'deepseek-compatible',
+      maxTokensField: 'max_tokens',
+      removeBodyFields: ['store'],
     }
   }
 

--- a/src/integrations/runtimeMetadata.ts
+++ b/src/integrations/runtimeMetadata.ts
@@ -215,12 +215,29 @@ export function resolveOpenAIShimRuntimeContext(options?: {
     descriptor && routeId
       ? getCatalogEntryForModel(routeId, options?.model)
       : null
+  const remoteModelInferredConfig = inferRemoteModelOpenAIShimConfig(options?.model)
   const inferredConfig =
     options?.treatAsLocal === true
       ? {
           maxTokensField: 'max_tokens' as const,
+          // Local proxies (e.g. key routers like grouter) may forward to remote
+          // reasoning models that require reasoning_content. Preserve the
+          // model-inferred config for reasoning fields so local routing doesn't
+          // strip thinking continuity.
+          ...(remoteModelInferredConfig?.preserveReasoningContent !== undefined
+            ? { preserveReasoningContent: remoteModelInferredConfig.preserveReasoningContent }
+            : {}),
+          ...(remoteModelInferredConfig?.requireReasoningContentOnAssistantMessages !== undefined
+            ? { requireReasoningContentOnAssistantMessages: remoteModelInferredConfig.requireReasoningContentOnAssistantMessages }
+            : {}),
+          ...(remoteModelInferredConfig?.reasoningContentFallback !== undefined
+            ? { reasoningContentFallback: remoteModelInferredConfig.reasoningContentFallback }
+            : {}),
+          ...(remoteModelInferredConfig?.thinkingRequestFormat !== undefined
+            ? { thinkingRequestFormat: remoteModelInferredConfig.thinkingRequestFormat }
+            : {}),
         }
-      : inferRemoteModelOpenAIShimConfig(options?.model)
+      : remoteModelInferredConfig
 
   return {
     routeId,

--- a/src/integrations/runtimeMetadata.ts
+++ b/src/integrations/runtimeMetadata.ts
@@ -92,10 +92,19 @@ function mergeOpenAIShimConfig(
   entryConfig: Partial<OpenAIShimTransportConfig> | undefined,
   inferredConfig: Partial<OpenAIShimTransportConfig> | undefined,
 ): OpenAIShimTransportConfig {
+  const descriptorMaxTokensField =
+    entryConfig?.maxTokensField ?? baseConfig?.maxTokensField
+
   return {
     ...baseConfig,
     ...entryConfig,
     ...inferredConfig,
+    // Preserve descriptor-level maxTokensField over model-inferred value.
+    // Direct providers (e.g. Xiaomi) declare their own token field in the
+    // descriptor; model-name inference should not override it.
+    ...(descriptorMaxTokensField !== undefined
+      ? { maxTokensField: descriptorMaxTokensField }
+      : {}),
     removeBodyFields: mergeRemoveBodyFields(
       baseConfig?.removeBodyFields,
       entryConfig?.removeBodyFields,

--- a/src/integrations/runtimeMetadata.ts
+++ b/src/integrations/runtimeMetadata.ts
@@ -169,8 +169,6 @@ function inferRemoteModelOpenAIShimConfig(
       requireReasoningContentOnAssistantMessages: true,
       reasoningContentFallback: '',
       thinkingRequestFormat: 'deepseek-compatible',
-      maxTokensField: 'max_tokens',
-      removeBodyFields: ['store'],
     }
   }
 
@@ -180,8 +178,6 @@ function inferRemoteModelOpenAIShimConfig(
       requireReasoningContentOnAssistantMessages: true,
       reasoningContentFallback: '',
       thinkingRequestFormat: 'deepseek-compatible',
-      maxTokensField: 'max_tokens',
-      removeBodyFields: ['store'],
     }
   }
 

--- a/src/integrations/runtimeMetadata.ts
+++ b/src/integrations/runtimeMetadata.ts
@@ -250,7 +250,13 @@ export function resolveOpenAIShimRuntimeContext(options?: {
   const inferredConfig =
     options?.treatAsLocal === true
       ? {
-          maxTokensField: 'max_tokens' as const,
+          // Don't hardcode maxTokensField here — let the descriptor (via
+          // mergeOpenAIShimConfig) or the model-inferred value take precedence.
+          // Hardcoding 'max_tokens' breaks providers like MiMo that require
+          // 'max_completion_tokens', even when accessed through a local proxy.
+          ...(remoteModelInferredConfig?.maxTokensField !== undefined
+            ? { maxTokensField: remoteModelInferredConfig.maxTokensField }
+            : { maxTokensField: 'max_tokens' as const }),
           // Local proxies (e.g. key routers like grouter) may forward to remote
           // reasoning models that require reasoning_content. Preserve the
           // model-inferred config for reasoning fields so local routing doesn't

--- a/src/services/api/openaiShim.ts
+++ b/src/services/api/openaiShim.ts
@@ -487,11 +487,13 @@ function convertMessages(
   system: unknown,
   options?: {
     preserveReasoningContent?: boolean
+    requireReasoningContentOnAssistantMessages?: boolean
     reasoningContentFallback?: '' | 'omit'
     preserveGeminiThoughtSignature?: boolean
   },
 ): OpenAIMessage[] {
   const preserveReasoningContent = options?.preserveReasoningContent === true
+  const requireReasoningContent = options?.requireReasoningContentOnAssistantMessages === true
   const reasoningContentFallback = options?.reasoningContentFallback
   const preserveGeminiThoughtSignature = options?.preserveGeminiThoughtSignature === true
   const result: OpenAIMessage[] = []
@@ -608,12 +610,14 @@ function convertMessages(
           const thinkingText = (thinkingBlock as { thinking?: string } | undefined)?.thinking
           if (typeof thinkingText === 'string' && thinkingText.trim().length > 0) {
             assistantMsg.reasoning_content = thinkingText
-          } else if (
-            toolUses.length > 0 &&
-            reasoningContentFallback === ''
-          ) {
+          } else if (reasoningContentFallback === '') {
             assistantMsg.reasoning_content = ''
           }
+        } else if (requireReasoningContent) {
+          // Provider requires reasoning_content on every assistant message but
+          // preserveReasoningContent is not set (no thinking block to echo).
+          // Attach empty string to satisfy API validation.
+          assistantMsg.reasoning_content = ''
         }
 
         if (toolUses.length > 0) {
@@ -699,6 +703,14 @@ function convertMessages(
           })(),
         }
 
+        // For providers that require reasoning_content on every assistant message,
+        // attach an empty string when no thinking block is present.
+        if (preserveReasoningContent && reasoningContentFallback === '') {
+          assistantMsg.reasoning_content = ''
+        } else if (requireReasoningContent) {
+          assistantMsg.reasoning_content = ''
+        }
+
         if (assistantMsg.content) {
           result.push(assistantMsg)
         }
@@ -720,10 +732,18 @@ function convertMessages(
     // assistant response to satisfy the strict role sequence:
     // ... -> assistant (calls) -> tool (results) -> assistant (semantic) -> user (next)
     if (prev && prev.role === 'tool' && msg.role === 'user') {
-      coalesced.push({
+      const syntheticMsg: OpenAIMessage = {
         role: 'assistant',
         content: '[Tool execution interrupted by user]',
-      })
+      }
+      // Providers that require reasoning_content on every assistant message
+      // need it on this synthetic message too, or the API returns 400.
+      if (preserveReasoningContent && reasoningContentFallback === '') {
+        syntheticMsg.reasoning_content = ''
+      } else if (requireReasoningContent) {
+        syntheticMsg.reasoning_content = ''
+      }
+      coalesced.push(syntheticMsg)
     }
 
     const lastAfterPossibleInjection = coalesced[coalesced.length - 1]
@@ -765,6 +785,18 @@ function convertMessages(
           ...(lastAfterPossibleInjection.tool_calls ?? []),
           ...msg.tool_calls,
         ]
+      }
+
+      // Preserve reasoning_content when coalescing assistant messages.
+      // Prefer the incoming message's reasoning_content if present, otherwise
+      // keep the existing one. Both cannot be preserved simultaneously since
+      // the field is singular per message.
+      if (
+        msg.role === 'assistant' &&
+        msg.reasoning_content !== undefined &&
+        lastAfterPossibleInjection.role === 'assistant'
+      ) {
+        lastAfterPossibleInjection.reasoning_content = msg.reasoning_content
       }
     } else {
       coalesced.push(msg)
@@ -1782,6 +1814,7 @@ class OpenAIShimMessages {
     const shimConfig = runtimeShimContext.openaiShimConfig
     const openaiMessages = convertMessages(compressedMessages, params.system, {
       preserveReasoningContent: shimConfig.preserveReasoningContent,
+      requireReasoningContentOnAssistantMessages: shimConfig.requireReasoningContentOnAssistantMessages,
       reasoningContentFallback: shimConfig.reasoningContentFallback,
       preserveGeminiThoughtSignature: shouldPreserveGeminiThoughtSignature(
         request.resolvedModel,

--- a/src/services/api/openaiShim.ts
+++ b/src/services/api/openaiShim.ts
@@ -788,15 +788,19 @@ function convertMessages(
       }
 
       // Preserve reasoning_content when coalescing assistant messages.
-      // Prefer the incoming message's reasoning_content if present, otherwise
-      // keep the existing one. Both cannot be preserved simultaneously since
-      // the field is singular per message.
+      // Never overwrite a non-empty reasoning_content with an empty one,
+      // since empty values are fallback placeholders while non-empty ones
+      // carry actual thinking text that providers require.
       if (
         msg.role === 'assistant' &&
         msg.reasoning_content !== undefined &&
         lastAfterPossibleInjection.role === 'assistant'
       ) {
-        lastAfterPossibleInjection.reasoning_content = msg.reasoning_content
+        const existing = lastAfterPossibleInjection.reasoning_content
+        const incoming = msg.reasoning_content
+        if (typeof existing !== 'string' || existing.length === 0 || incoming.length > 0) {
+          lastAfterPossibleInjection.reasoning_content = incoming
+        }
       }
     } else {
       coalesced.push(msg)


### PR DESCRIPTION
Fixes reasoning model compatibility issues for OpenAI-compatible localhost/proxy setups.

  Previously, providers that require reasoning_content (DeepSeek, MiMo, Moonshot/Kimi, ZAI, etc.) could fail with:

  400 OpenAI API error 400: data:{"error":{"code":"400","message":"Param Incorrect","param":"The reasoning_content in
  the thinking mode must be passed back to the API.","type":""}}

  during multi-turn agent workflows.

  This especially affected local proxy/key-router setups such as:

  - localhost OpenAI-compatible endpoints
  - GRouter
  - reverse proxy gateways

  Root Cause

  Two independent issues caused the failures:

  1. requireReasoningContentOnAssistantMessages was never consumed

  The flag existed in provider descriptors and was configured by:

  - DeepSeek
  - Moonshot/Kimi
  - MiMo
  - ZAI
  - kimi-code

  However, the OpenAI shim message conversion pipeline never actually used the flag.

  As a result, assistant messages could lose reasoning_content during agent execution.

  2. treatAsLocal bypassed model inference

  The treatAsLocal code path skipped model-name-based config inference entirely.

  This prevented localhost/proxy endpoints from inheriting reasoning-specific behavior even when the routed model was
  clearly identifiable, such as:

  - mimo-v2.5-pro
  - deepseek-reasoner
  - other reasoning-capable providers

  Changes

  src/services/api/openaiShim.ts

  Implemented 5 fixes in convertMessages():

  - Pass requireReasoningContentOnAssistantMessages into the conversion pipeline
  - Attach reasoning_content: '' to assistant messages when required by provider config
  - Remove the toolUses.length > 0 restriction so plain-text assistant messages are also handled
  - Preserve reasoning_content during assistant-message coalescing
  - Add fallback reasoning_content to synthetic assistant messages created during tool/user alternation
  - Add handling for non-array-content assistant messages

  src/integrations/runtimeMetadata.ts

  - Merge reasoning-related fields from inferRemoteModelOpenAIShimConfig() into the treatAsLocal branch
  - Allows localhost/proxy endpoints to inherit correct reasoning behavior from model-name inference

  Provider Impact

  Fixes reasoning-agent failures for:

  - DeepSeek
  - Moonshot/Kimi
  - MiMo
  - ZAI
  - future providers using requireReasoningContentOnAssistantMessages: true

  Also enables reasoning models to work correctly through:

  - localhost OpenAI-compatible endpoints
  - proxy routers
  - API gateways

  No behavior changes for providers that do not use the flag.

  Tested

  - bun run build ✅
  - bun run smoke ✅
  - bun test src/services/api/openaiShim → 104 pass / 0 fail ✅

  Manual validation:

  - MiMo v2.5 Pro via GRouter (localhost:3103) ✅
  - MiMo v2.5 Pro via direct Xiaomi endpoint ✅

  Verified:

  - Explore agents
  - background agents
  - multi-turn reasoning flows
  - reasoning-content persistence

  Follow-up

  Some reasoning providers (Qwen/QwQ/GLM/etc.) are not yet included in inferRemoteModelOpenAIShimConfig().

  Once entries are added, the treatAsLocal fix ensures they will automatically work through localhost/proxy setups as
  well.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extended support for additional AI model families with optimized configuration handling.
  * Improved reasoning content preservation during message processing and model interactions.

* **Bug Fixes**
  * Fixed configuration value overriding to preserve explicitly set token field settings.
  * Enhanced reasoning content persistence across message operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->