### PR TITLE
Fix provider profile startup precedence (Issue #1156)

### DIFF
--- a/src/entrypoints/cli.tsx
+++ b/src/entrypoints/cli.tsx
@@ -108,8 +108,14 @@ async function main(): Promise<void> {
     applySafeConfigEnvironmentVariables()
   }
 
+  const hasConfiguredProviderProfile = await (async () => {
+    const { getActiveProviderProfile } = await import('../utils/providerProfiles.js')
+    return getActiveProviderProfile() !== undefined
+  })()
+
   const startupEnv = await buildStartupEnvFromProfile({
     processEnv: process.env,
+    hasConfiguredProviderProfile,
   })
   if (startupEnv !== process.env) {
     const startupProfileError = await getProviderValidationError(startupEnv)

--- a/src/utils/providerProfile.test.ts
+++ b/src/utils/providerProfile.test.ts
@@ -1125,6 +1125,29 @@ test('buildStartupEnvFromProfile preserves plural-profile env when the legacy fi
   assert.equal(env.CLAUDE_CODE_PROVIDER_PROFILE_ENV_APPLIED_ID, 'saved_moonshot')
 })
 
+test('buildStartupEnvFromProfile ignores the legacy file when a configured provider profile already selected a concrete env', async () => {
+  const processEnv: NodeJS.ProcessEnv = {
+    CLAUDE_CODE_USE_OPENAI: '1',
+    OPENAI_BASE_URL: 'https://api.moonshot.ai/v1',
+    OPENAI_MODEL: 'kimi-k2.6',
+  }
+
+  const env = await buildStartupEnvFromProfile({
+    persisted: profile('openai', {
+      OPENAI_API_KEY: 'sk-stale',
+      OPENAI_MODEL: 'Meta-Llama-3.1-70B-Instruct',
+      OPENAI_BASE_URL: 'https://api.sambanova.ai/v1',
+    }),
+    processEnv,
+    hasConfiguredProviderProfile: true,
+  })
+
+  assert.equal(env, processEnv)
+  assert.equal(env.OPENAI_BASE_URL, 'https://api.moonshot.ai/v1')
+  assert.equal(env.OPENAI_MODEL, 'kimi-k2.6')
+  assert.equal(env.OPENAI_API_KEY, undefined)
+})
+
 test('buildStartupEnvFromProfile falls back to legacy file when plural system has not applied', async () => {
   // Counter-example: first-run user with only the legacy file (no plural
   // active profile yet). The legacy file is the correct source, so the
@@ -1146,6 +1169,48 @@ test('buildStartupEnvFromProfile falls back to legacy file when plural system ha
   assert.equal(env.OPENAI_API_KEY, 'sk-legacy')
   assert.equal(env.OPENAI_BASE_URL, 'https://api.openai.com/v1')
   assert.equal(env.OPENAI_MODEL, 'gpt-4o')
+})
+
+test('buildStartupEnvFromProfile still falls back to the legacy file when configured profiles exist but startup env is incomplete', async () => {
+  const processEnv = {
+    CLAUDE_CODE_USE_OPENAI: '1',
+  }
+
+  const env = await buildStartupEnvFromProfile({
+    persisted: profile('openai', {
+      OPENAI_API_KEY: 'sk-legacy',
+      OPENAI_MODEL: 'gpt-4o',
+      OPENAI_BASE_URL: 'https://api.openai.com/v1',
+    }),
+    processEnv,
+    hasConfiguredProviderProfile: true,
+  })
+
+  assert.notEqual(env, processEnv)
+  assert.equal(env.OPENAI_API_KEY, 'sk-legacy')
+  assert.equal(env.OPENAI_BASE_URL, 'https://api.openai.com/v1')
+  assert.equal(env.OPENAI_MODEL, 'gpt-4o')
+})
+
+test('buildStartupEnvFromProfile ignores falsey provider flags when deciding whether a configured profile already selected startup env', async () => {
+  const processEnv = {
+    CLAUDE_CODE_USE_OPENAI: '0',
+    OPENAI_BASE_URL: 'https://api.stale.example/v1',
+    OPENAI_MODEL: 'stale-model',
+  }
+
+  const env = await buildStartupEnvFromProfile({
+    persisted: profile('openai', {
+      OPENAI_API_KEY: 'sk-legacy',
+      OPENAI_MODEL: 'gpt-4o',
+      OPENAI_BASE_URL: 'https://api.openai.com/v1',
+    }),
+    processEnv,
+    hasConfiguredProviderProfile: true,
+  })
+
+  assert.notEqual(env, processEnv)
+  assert.equal(env.OPENAI_API_KEY, 'sk-legacy')
 })
 
 test('buildStartupEnvFromProfile treats explicit falsey provider flags as user intent', async () => {

--- a/src/utils/providerProfile.ts
+++ b/src/utils/providerProfile.ts
@@ -926,6 +926,61 @@ export function hasExplicitProviderSelection(
   )
 }
 
+function hasConcreteProviderSelection(
+  processEnv: NodeJS.ProcessEnv = process.env,
+): boolean {
+  if (processEnv.CLAUDE_CODE_PROVIDER_PROFILE_ENV_APPLIED === '1') {
+    return true
+  }
+
+  if (isEnvTruthy(processEnv.CLAUDE_CODE_USE_OPENAI)) {
+    return (
+      sanitizeProviderConfigValue(processEnv.OPENAI_BASE_URL) !== undefined ||
+      sanitizeProviderConfigValue(processEnv.OPENAI_API_BASE) !== undefined ||
+      normalizeProfileModel(
+        sanitizeProviderConfigValue(processEnv.OPENAI_MODEL),
+      ) !== undefined
+    )
+  }
+
+  if (isEnvTruthy(processEnv.CLAUDE_CODE_USE_GEMINI)) {
+    return (
+      sanitizeProviderConfigValue(processEnv.GEMINI_BASE_URL) !== undefined ||
+      normalizeProfileModel(
+        sanitizeProviderConfigValue(processEnv.GEMINI_MODEL),
+      ) !== undefined ||
+      sanitizeApiKey(processEnv.GEMINI_API_KEY) !== undefined ||
+      sanitizeApiKey(processEnv.GOOGLE_API_KEY) !== undefined
+    )
+  }
+
+  if (isEnvTruthy(processEnv.CLAUDE_CODE_USE_MISTRAL)) {
+    return (
+      sanitizeProviderConfigValue(processEnv.MISTRAL_BASE_URL) !== undefined ||
+      normalizeProfileModel(
+        sanitizeProviderConfigValue(processEnv.MISTRAL_MODEL),
+      ) !== undefined ||
+      sanitizeApiKey(processEnv.MISTRAL_API_KEY) !== undefined
+    )
+  }
+
+  if (isEnvTruthy(processEnv.CLAUDE_CODE_USE_GITHUB)) {
+    return (
+      sanitizeApiKey(processEnv.GITHUB_TOKEN) !== undefined ||
+      sanitizeApiKey(processEnv.GH_TOKEN) !== undefined ||
+      normalizeProfileModel(
+        sanitizeProviderConfigValue(processEnv.OPENAI_MODEL),
+      ) !== undefined
+    )
+  }
+
+  return (
+    isEnvTruthy(processEnv.CLAUDE_CODE_USE_BEDROCK) ||
+    isEnvTruthy(processEnv.CLAUDE_CODE_USE_VERTEX) ||
+    isEnvTruthy(processEnv.CLAUDE_CODE_USE_FOUNDRY)
+  )
+}
+
 export function selectAutoProfile(
   recommendedOllamaModel: string | null,
 ): ProviderProfile {
@@ -1374,6 +1429,7 @@ export async function buildStartupEnvFromProfile(options?: {
   persisted?: ProfileFile | null
   goal?: RecommendationGoal
   processEnv?: NodeJS.ProcessEnv
+  hasConfiguredProviderProfile?: boolean
   getOllamaChatBaseUrl?: (baseUrl?: string) => string
   resolveOllamaDefaultModel?: (goal: RecommendationGoal) => Promise<string>
   readGeminiAccessToken?: () => string | undefined
@@ -1382,6 +1438,8 @@ export async function buildStartupEnvFromProfile(options?: {
   const persisted = options?.persisted ?? loadProfileFile()
 
   const profileManagedEnv = processEnv.CLAUDE_CODE_PROVIDER_PROFILE_ENV_APPLIED === '1'
+  const hasConfiguredProviderProfile =
+    options?.hasConfiguredProviderProfile ?? false
 
   // The single-profile file in the user config directory is a
   // first-run / fallback mechanism. The newer plural provider-profile
@@ -1396,6 +1454,18 @@ export async function buildStartupEnvFromProfile(options?: {
   // "banner shows gpt-4o / api.openai.com even though my saved profile is
   // Moonshot" bug.
   if (profileManagedEnv) {
+    return processEnv
+  }
+
+  // If startup already has a concrete provider selection and the modern
+  // plural-profile system is configured, keep trusting that selection.
+  // This prevents the legacy single-profile file from becoming a silent
+  // third precedence layer when `/provider` profiles or explicit env/flags
+  // already chose a provider before startup fallback runs.
+  if (
+    hasConfiguredProviderProfile &&
+    hasConcreteProviderSelection(processEnv)
+  ) {
     return processEnv
   }
 


### PR DESCRIPTION
## What changed

This PR fixes startup precedence between the legacy `.openclaude-profile.json` fallback and the newer multi-profile provider system stored in `settings.local.json`.

Changes included:

- thread a configured-provider-profile signal from CLI bootstrap into `buildStartupEnvFromProfile()`
- skip the legacy single-profile fallback when a modern configured provider profile has already selected a concrete startup provider configuration
- preserve the legacy file as a first-run fallback when startup env is incomplete
- treat falsey `CLAUDE_CODE_USE_*` values like disabled flags so they do not count as active startup provider selections
- add regression coverage for:
  - stale legacy file vs active configured profile
  - configured profiles with incomplete startup env
  - falsey provider flags during startup precedence checks

## Why it changed

Issue #1156 reported that users with both:

- a legacy `.openclaude-profile.json`, and
- a saved `/provider` profile in `settings.local.json`

could start OpenClaude with the wrong provider, base URL, or model because the legacy file still participated in startup precedence and could silently override the newer saved profile.

The intended behavior is that saved `/provider` profiles are the source of truth once configured, while the legacy single-profile file remains fallback-only.

## User and developer impact

- users with saved provider profiles should consistently get the provider they selected via `/provider`
- stale legacy profile files should no longer silently override newer saved provider settings at startup
- first-run and fallback behavior remains intact when the modern profile system has not yet established a concrete provider selection
- disabled provider flags such as `CLAUDE_CODE_USE_OPENAI=0` no longer count as active startup intent for the new precedence guard

## Provider path tested

This change affects provider startup selection and precedence, especially the OpenAI-compatible path used by saved `/provider` profiles and legacy profile fallback behavior.

Focused coverage was added for:

- OpenAI-compatible saved profile precedence over stale legacy fallback
- legacy fallback when startup env is incomplete
- falsey provider flag handling in the new startup guard

## Checks run

```bash
bun test src/utils/providerProfile.test.ts --test-name-pattern "buildStartupEnvFromProfile"
bun run build
bun run smoke
```

Results:

- `bun test ...buildStartupEnvFromProfile` -> 11 pass, 0 fail
- `bun run build` -> passed
- `bun run smoke` -> passed

Smoke output:

```text
0.10.0 (OpenClaude)
```

## Notes

- This PR is intentionally focused on startup precedence and regression coverage for issue #1156.