### PR TITLE
Stabilize skill loader test isolation

### DIFF
--- a/src/skills/loadSkillsDir.test.ts
+++ b/src/skills/loadSkillsDir.test.ts
@@ -36,7 +36,16 @@ test('loads flat and nested skills with colon namespaces', async () => {
     clearSkillCaches()
 
     const skills = await getSkillDirCommands(cwd)
-    const promptSkills = skills.filter(skill => skill.type === 'prompt')
+    const fixtureSkillsRoot = join(configDir, '.claude', 'skills')
+    const promptSkills = skills.filter(
+      (
+        skill,
+      ): skill is Extract<(typeof skills)[number], { type: 'prompt' }> & {
+        skillRoot: string
+      } =>
+        skill.type === 'prompt' &&
+        skill.skillRoot?.startsWith(fixtureSkillsRoot) === true,
+    )
     const skillNames = promptSkills.map(skill => skill.name).sort()
 
     assert.deepEqual(skillNames, [


### PR DESCRIPTION
## Summary
- Narrow the prompt-skill assertion in `loadSkillsDir.test.ts` to the temp fixture skills root.
- Prevent globally/user-installed prompt skills from leaking into this test and making the expected skill-name list flaky.

## Validation
- `bun test src/skills/loadSkillsDir.test.ts`

## Notes
This is a tiny test-only cleanup from a fork. No runtime behavior changes.
