### PR TITLE
docs(ollama): drop `ollama launch openclaude` instructions (#1134)

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,16 +116,6 @@ $env:OPENAI_MODEL="qwen2.5-coder:7b"
 openclaude
 ```
 
-### Using Ollama's launch command
-
-If you have [Ollama](https://ollama.com) installed, you can skip the env var setup entirely:
-
-```bash
-ollama launch openclaude --model qwen2.5-coder:7b
-```
-
-This automatically sets `ANTHROPIC_BASE_URL`, model routing, and auth so all API traffic goes through your local Ollama instance. Works with any model you have pulled — local or cloud.
-
 ## Setup Guides
 
 Beginner-friendly guides:
@@ -150,7 +140,7 @@ Advanced and source-build guides:
 | Codex OAuth | `/provider` | Opens ChatGPT sign-in in your browser and stores Codex credentials securely |
 | Codex | `/provider` | Uses existing Codex CLI auth, OpenClaude secure storage, or env credentials |
 | Xiaomi MiMo | `/provider` or env vars | OpenAI-compatible API at `https://api.xiaomimimo.com/v1`; uses `MIMO_API_KEY` and defaults to `mimo-v2.5-pro` |
-| Ollama | `/provider`, env vars, or `ollama launch` | Local inference with no API key |
+| Ollama | `/provider` or env vars | Local inference with no API key |
 | Atomic Chat | `/provider`, env vars, or `bun run dev:atomic-chat` | Local Model Provider; auto-detects loaded models |
 | Bedrock / Vertex / Foundry | env vars | Additional provider integrations for supported environments |
 

--- a/docs/advanced-setup.md
+++ b/docs/advanced-setup.md
@@ -99,16 +99,6 @@ OpenRouter model availability changes over time. If a model stops working, try a
 
 ### Ollama
 
-Using `ollama launch` (recommended if you have Ollama installed):
-
-```bash
-ollama launch openclaude --model llama3.3:70b
-```
-
-This handles all environment setup automatically — no env vars needed. Works with any local or cloud model available in your Ollama instance.
-
-Using environment variables manually:
-
 ```bash
 ollama pull llama3.3:70b
 


### PR DESCRIPTION
## Summary

- Remove the `### Using Ollama's launch command` section from `README.md` and `docs/advanced-setup.md`.
- Remove `ollama launch` from the Ollama row of the Supported Providers table in `README.md`.
- Why: the syntax was docs-only when added in #716, gated on companion `ollama/ollama#15618` which is still open and unmerged ~4 weeks later. Users following these instructions get `Error: unknown integration: openclaude` (originally #744, now #1134).

## Impact

- user-facing impact: README no longer advertises a command that errors out on every install. Env-var setup (already present immediately above the removed section) is now the single documented Ollama path.
- developer/maintainer impact: none — pure docs delete. Internal `buildLaunchEnv` test names that mention "ollama launch" refer to the `provider-launch.ts` profile loader and are unrelated to the upstream `ollama` CLI command.

## Testing

- [x] `bun run build` — green
- [ ] `bun run smoke` — fails on this checkout with `Cannot find package '@orama/orama'`; reproduces on clean `main` HEAD `4d2de51` (pre-existing local env issue, unrelated to this docs change)
- [x] focused tests: n/a (docs only)

## Notes

- provider/model path tested: n/a (docs only)
- screenshots attached (if UI changed): n/a
- follow-up work or known limitations: if `ollama/ollama#15618` lands upstream, the removed sections can be reintroduced verbatim in a separate docs PR.

Closes #1134