### PR TITLE
feat(model-picker): surface inactive provider profiles in /model (#1119 piece 2)

### DIFF
--- a/docs/advanced-setup.md
+++ b/docs/advanced-setup.md
@@ -523,7 +523,13 @@ Supported values:
   profile-only custom model IDs.
 - `profile`: show only explicitly configured profile models.
 
-Use `--provider ollama` when you want a local-only path. Auto mode falls back to OpenAI when no viable local chat model is installed.
+When you have more than one saved provider profile, `/model` also lists models
+from your **inactive** profiles, grouped under their profile name. Selecting one
+activates that provider profile and switches to the chosen model in a single
+step, reconciling fast mode if the target provider cannot run it. These
+cross-profile entries appear only in the interactive `/model` picker — they are
+never returned to SDK/automation callers and are hidden from inline pickers
+(such as the prompt hotkey or Settings), which cannot switch the active profile. Auto mode falls back to OpenAI when no viable local chat model is installed.
 
 Use `--provider atomic-chat` when you want Atomic Chat as the local Apple Silicon provider.
 

--- a/docs/advanced-setup.md
+++ b/docs/advanced-setup.md
@@ -523,13 +523,19 @@ Supported values:
   profile-only custom model IDs.
 - `profile`: show only explicitly configured profile models.
 
-When you have more than one saved provider profile, `/model` also lists models
-from your **inactive** profiles, grouped under their profile name. Selecting one
-activates that provider profile and switches to the chosen model in a single
-step, reconciling fast mode if the target provider cannot run it. These
-cross-profile entries appear only in the interactive `/model` picker — they are
-never returned to SDK/automation callers and are hidden from inline pickers
-(such as the prompt hotkey or Settings), which cannot switch the active profile. Auto mode falls back to OpenAI when no viable local chat model is installed.
+When the provider-profile env workflow is active (i.e. a profile has been
+applied and `CLAUDE_CODE_PROVIDER_PROFILE_ENV_APPLIED=1` is set — as it is after
+launching with a saved profile) and you have more than one saved provider
+profile, `/model` also lists models from your **inactive** profiles, grouped
+under their profile name. Selecting one activates that provider profile and
+switches to the chosen model in a single step, reconciling fast mode if the
+target provider cannot run it. These cross-profile entries appear only in the
+interactive `/model` picker — they are never returned to SDK/automation callers
+and are hidden from inline pickers (such as the prompt hotkey or Settings),
+which cannot switch the active profile. Simply having multiple profiles
+configured without the env workflow active does not surface them.
+
+Use `--provider ollama` when you want a local-only path. Auto mode falls back to OpenAI when no viable local chat model is installed.
 
 Use `--provider atomic-chat` when you want Atomic Chat as the local Apple Silicon provider.
 

--- a/src/cli/print.sdkModelOptions.test.ts
+++ b/src/cli/print.sdkModelOptions.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, test } from 'bun:test'
+
+import { selectSdkModelOptions } from './print.js'
+import {
+  encodeSwitchProfileValue,
+  type ModelOption,
+} from '../utils/model/modelOptions.js'
+
+// Regression for issue #1119: the interactive `/model` picker surfaces
+// inactive-provider-profile entries whose `value` is an encoded
+// `__switch_profile__:<id>:<model>` string. Those are UI-only affordances and
+// must never reach the SDK `initialize.models` response — they are not real,
+// selectable model ids. selectSdkModelOptions is the single gate the SDK
+// `modelInfos` builder runs every option through, so this asserts it strips
+// them.
+describe('selectSdkModelOptions — keeps cross-profile switch entries out of SDK models', () => {
+  const realOptions: ModelOption[] = [
+    { value: null, label: 'Default (recommended)', description: 'default' },
+    { value: 'sonnet', label: 'Sonnet', description: 'Sonnet 4.6' },
+    { value: 'opus', label: 'Opus', description: 'Opus 4.8' },
+  ]
+
+  test('drops encoded __switch_profile__ options', () => {
+    const switchOption: ModelOption = {
+      value: encodeSwitchProfileValue('profile-2', 'qwen3-coder'),
+      label: 'qwen3-coder · My Ollama',
+      description: 'Switch to My Ollama (http://localhost:11434/v1)',
+      switchToProfileId: 'profile-2',
+    }
+
+    const selected = selectSdkModelOptions([
+      realOptions[0]!,
+      switchOption,
+      realOptions[1]!,
+      realOptions[2]!,
+    ])
+
+    expect(selected).toEqual(realOptions)
+    // No surviving option carries the UI-only encoded value or the
+    // switchToProfileId marker.
+    expect(
+      selected.some(
+        o =>
+          typeof o.value === 'string' &&
+          o.value.startsWith('__switch_profile__:'),
+      ),
+    ).toBe(false)
+    expect(selected.some(o => o.switchToProfileId !== undefined)).toBe(false)
+  })
+
+  test('passes through a list with no switch entries unchanged', () => {
+    expect(selectSdkModelOptions(realOptions)).toEqual(realOptions)
+  })
+})

--- a/src/cli/print.sdkModelOptions.test.ts
+++ b/src/cli/print.sdkModelOptions.test.ts
@@ -51,4 +51,26 @@ describe('selectSdkModelOptions — keeps cross-profile switch entries out of SD
   test('passes through a list with no switch entries unchanged', () => {
     expect(selectSdkModelOptions(realOptions)).toEqual(realOptions)
   })
+
+  // Collision regression: a real, configured custom model id may literally
+  // start with `__switch_profile__:`. The gate keys on the explicit
+  // `switchToProfileId` marker (only synthesized switch entries carry it), so
+  // such an id must still reach SDK consumers rather than being mistaken for a
+  // UI-only profile-switch affordance.
+  test('keeps a real custom model id that starts with the switch-profile prefix', () => {
+    const collidingOption: ModelOption = {
+      value: '__switch_profile__:vendor:model',
+      label: 'Oddly-named custom model',
+      description: 'A real selectable model id, no switchToProfileId marker',
+    }
+
+    const selected = selectSdkModelOptions([
+      realOptions[0]!,
+      collidingOption,
+      realOptions[1]!,
+    ])
+
+    expect(selected).toContain(collidingOption)
+    expect(selected).toEqual([realOptions[0]!, collidingOption, realOptions[1]!])
+  })
 })

--- a/src/cli/print.ts
+++ b/src/cli/print.ts
@@ -274,7 +274,10 @@ import {
   modelDisplayString,
   parseUserSpecifiedModel,
 } from 'src/utils/model/model.js'
-import { getModelOptions } from 'src/utils/model/modelOptions.js'
+import {
+  getModelOptions,
+  parseSwitchProfileValue,
+} from 'src/utils/model/modelOptions.js'
 import {
   modelSupportsEffort,
   getAvailableEffortLevels,
@@ -1356,7 +1359,14 @@ function runHeadlessStreaming(
     })
   }
 
-  const modelOptions = getModelOptions()
+  // getModelOptions() now also returns inactive-provider-profile entries whose
+  // `value` is an encoded `__switch_profile__:<id>:<model>` string. Those are
+  // UI-only affordances for the interactive `/model` switcher — they are not
+  // real, selectable model ids, so they must not leak into the SDK `models`
+  // response. Drop them before building ModelInfo.
+  const modelOptions = getModelOptions().filter(
+    option => parseSwitchProfileValue(option.value) === null,
+  )
   const modelInfos: ModelInfo[] = modelOptions.map((option): ModelInfo => {
     const modelId = option.value === null ? 'default' : option.value
     const resolvedModel =

--- a/src/cli/print.ts
+++ b/src/cli/print.ts
@@ -276,7 +276,6 @@ import {
 } from 'src/utils/model/model.js'
 import {
   getModelOptions,
-  parseSwitchProfileValue,
   type ModelOption,
 } from 'src/utils/model/modelOptions.js'
 import {
@@ -394,9 +393,14 @@ const extractMemoriesModule = feature('EXTRACT_MEMORIES')
  * #1119). Those are UI-only affordances for the interactive `/model` switcher —
  * they are not real, selectable model ids — so they must never reach SDK
  * consumers. Exported so the exclusion is unit-testable.
+ *
+ * Filter on the explicit `switchToProfileId` marker rather than the encoded
+ * `value` prefix: a legitimate custom model id that happens to start with
+ * `__switch_profile__:` must still reach SDK consumers, and only the synthesized
+ * profile-switch options carry `switchToProfileId`.
  */
 export function selectSdkModelOptions(options: ModelOption[]): ModelOption[] {
-  return options.filter(option => parseSwitchProfileValue(option.value) === null)
+  return options.filter(option => option.switchToProfileId === undefined)
 }
 
 const SHUTDOWN_TEAM_PROMPT = `<system-reminder>

--- a/src/cli/print.ts
+++ b/src/cli/print.ts
@@ -277,6 +277,7 @@ import {
 import {
   getModelOptions,
   parseSwitchProfileValue,
+  type ModelOption,
 } from 'src/utils/model/modelOptions.js'
 import {
   modelSupportsEffort,
@@ -385,6 +386,18 @@ const extractMemoriesModule = feature('EXTRACT_MEMORIES')
   ? (require('../services/extractMemories/extractMemories.js') as typeof import('../services/extractMemories/extractMemories.js'))
   : null
 /* eslint-enable @typescript-eslint/no-require-imports */
+
+/**
+ * Select the model options that are safe to expose through the SDK `models`
+ * response. `getModelOptions()` also returns inactive-provider-profile entries
+ * whose `value` is an encoded `__switch_profile__:<id>:<model>` string (issue
+ * #1119). Those are UI-only affordances for the interactive `/model` switcher —
+ * they are not real, selectable model ids — so they must never reach SDK
+ * consumers. Exported so the exclusion is unit-testable.
+ */
+export function selectSdkModelOptions(options: ModelOption[]): ModelOption[] {
+  return options.filter(option => parseSwitchProfileValue(option.value) === null)
+}
 
 const SHUTDOWN_TEAM_PROMPT = `<system-reminder>
 You are running in non-interactive mode and cannot return a response to the user until your team is shut down.
@@ -1359,14 +1372,7 @@ function runHeadlessStreaming(
     })
   }
 
-  // getModelOptions() now also returns inactive-provider-profile entries whose
-  // `value` is an encoded `__switch_profile__:<id>:<model>` string. Those are
-  // UI-only affordances for the interactive `/model` switcher — they are not
-  // real, selectable model ids, so they must not leak into the SDK `models`
-  // response. Drop them before building ModelInfo.
-  const modelOptions = getModelOptions().filter(
-    option => parseSwitchProfileValue(option.value) === null,
-  )
+  const modelOptions = selectSdkModelOptions(getModelOptions())
   const modelInfos: ModelInfo[] = modelOptions.map((option): ModelInfo => {
     const modelId = option.value === null ? 'default' : option.value
     const resolvedModel =

--- a/src/commands/model/model.fastModeSwitch.test.ts
+++ b/src/commands/model/model.fastModeSwitch.test.ts
@@ -1,0 +1,94 @@
+import { afterEach, expect, mock, test } from 'bun:test'
+
+import * as actualFastMode from '../../utils/fastMode.js'
+
+// Regression for #1119 / jatmn review on PR #1164 — the cross-profile
+// `/model` branch must run the same fast-mode reconciliation as the regular
+// switch path. The pure helper `reconcileFastModeForSwitch` encodes the rule
+// both branches call.
+
+afterEach(() => {
+  mock.restore()
+})
+
+function mockFastMode(
+  overrides: Partial<typeof actualFastMode> = {},
+): void {
+  // Keep full surface to avoid cross-file mock.module leaks (lessons learned
+  // 2026-04-30). Override only the symbols this test needs.
+  mock.module('../../utils/fastMode.js', () => ({
+    ...actualFastMode,
+    ...overrides,
+  }))
+}
+
+async function importFreshModule(
+  suffix: string,
+): Promise<typeof import('./model.js')> {
+  return import(`./model.js?${suffix}`) as Promise<typeof import('./model.js')>
+}
+
+test('returns "unchanged" when fast mode is disabled at the process level', async () => {
+  mockFastMode({
+    isFastModeEnabled: () => false,
+    isFastModeSupportedByModel: () => true,
+    isFastModeAvailable: () => true,
+  })
+  const mod = await importFreshModule('fast-disabled')
+  expect(mod.reconcileFastModeForSwitch('claude-opus-4-7', true)).toBe(
+    'unchanged',
+  )
+})
+
+test('returns "off" when target model does not support fast mode and fastMode latched', async () => {
+  const clearFastModeCooldown = mock(() => undefined)
+  mockFastMode({
+    isFastModeEnabled: () => true,
+    isFastModeSupportedByModel: (m: string | null) =>
+      m?.startsWith('claude-opus') ?? false,
+    isFastModeAvailable: () => true,
+    clearFastModeCooldown,
+  })
+  const mod = await importFreshModule('fast-off')
+  expect(mod.reconcileFastModeForSwitch('gpt-5-mini', true)).toBe('off')
+  expect(clearFastModeCooldown).toHaveBeenCalledTimes(1)
+})
+
+test('returns "on" when target supports fast mode and it is available and latched', async () => {
+  mockFastMode({
+    isFastModeEnabled: () => true,
+    isFastModeSupportedByModel: () => true,
+    isFastModeAvailable: () => true,
+    clearFastModeCooldown: () => undefined,
+  })
+  const mod = await importFreshModule('fast-on')
+  expect(mod.reconcileFastModeForSwitch('claude-opus-4-7', true)).toBe('on')
+})
+
+test('returns "unchanged" when fastMode is not currently latched', async () => {
+  mockFastMode({
+    isFastModeEnabled: () => true,
+    isFastModeSupportedByModel: () => true,
+    isFastModeAvailable: () => true,
+    clearFastModeCooldown: () => undefined,
+  })
+  const mod = await importFreshModule('fast-unlatched')
+  expect(mod.reconcileFastModeForSwitch('claude-opus-4-7', false)).toBe(
+    'unchanged',
+  )
+})
+
+test('returns "off" for the cross-profile switch target when fastMode is latched on Anthropic and the new profile model is unsupported (#1119)', async () => {
+  mockFastMode({
+    isFastModeEnabled: () => true,
+    isFastModeSupportedByModel: (m: string | null) =>
+      m === 'claude-opus-4-7',
+    isFastModeAvailable: () => true,
+    clearFastModeCooldown: () => undefined,
+  })
+  const mod = await importFreshModule('fast-cross-profile')
+  // User had fast mode on while running Anthropic Opus, then picks an OpenAI
+  // profile from the picker — the new profile's model can't run fast mode, so
+  // the reconciler must drop it.
+  expect(mod.reconcileFastModeForSwitch('gpt-5-mini', true)).toBe('off')
+})

--- a/src/commands/model/model.test.tsx
+++ b/src/commands/model/model.test.tsx
@@ -1244,6 +1244,81 @@ test('/model applies auto provider surface for single-model descriptor profiles'
   }
 })
 
+test('/model discovery override still surfaces inactive-profile switch options (#1119)', async () => {
+  // Regression for #1164 [P2]: descriptor/legacy discovery contexts pass an
+  // optionsOverride built from the active profile's route models only. Because
+  // the picker uses `optionsOverride ?? getModelOptions()`, the unified switcher
+  // for other configured profiles must be re-appended to the override, or it
+  // disappears entirely for provider-profile discovery paths.
+  const activeProfile = {
+    id: 'openrouter-profile',
+    name: 'OpenRouter',
+    provider: 'openrouter',
+    baseUrl: 'https://openrouter.ai/api/v1',
+    model: 'openai/gpt-oss-120b:free',
+    apiKey: 'sk-openrouter',
+  }
+  const inactiveProfile = {
+    id: 'kimi-profile',
+    name: 'Kimi',
+    provider: 'openai',
+    baseUrl: 'https://api.moonshot.ai/v1',
+    model: 'kimi-k2',
+    apiKey: 'sk-kimi',
+  }
+  process.env.CLAUDE_CODE_USE_OPENAI = '1'
+  process.env.OPENAI_BASE_URL = activeProfile.baseUrl
+  process.env.OPENAI_API_KEY = activeProfile.apiKey
+  delete process.env.OPENROUTER_API_KEY
+  process.env.OPENAI_MODEL = activeProfile.model
+  process.env.CLAUDE_CODE_PROVIDER_PROFILE_ENV_APPLIED = '1'
+  process.env.CLAUDE_CODE_PROVIDER_PROFILE_ENV_APPLIED_ID = activeProfile.id
+  delete process.env.CLAUDE_CODE_USE_GEMINI
+  delete process.env.CLAUDE_CODE_USE_GITHUB
+  delete process.env.CLAUDE_CODE_USE_MISTRAL
+  delete process.env.CLAUDE_CODE_USE_BEDROCK
+  delete process.env.CLAUDE_CODE_USE_VERTEX
+  delete process.env.CLAUDE_CODE_USE_FOUNDRY
+  delete process.env.OPENAI_API_BASE
+
+  mockDescriptorDiscovery({
+    cachedModels: [{ id: 'profile-model', apiName: activeProfile.model }],
+  })
+  mockProviderProfiles({
+    getActiveProviderProfile: () => activeProfile,
+    getProviderProfiles: () => [activeProfile, inactiveProfile],
+    getProfileModelOptions: (profile: { model: string; name: string }) => [
+      { value: profile.model, label: profile.model, description: profile.name },
+    ],
+  })
+
+  const rendered = await renderModelCommandWithCapturedPicker(
+    'descriptor-picker-inactive-switch-options',
+  )
+  try {
+    const override = rendered.getCapturedProps()
+      .optionsOverride as ModelOption[]
+    const switchOptions = override.filter(
+      opt => opt.switchToProfileId !== undefined,
+    )
+    expect(switchOptions.map(opt => opt.switchToProfileId)).toContain(
+      'kimi-profile',
+    )
+    expect(
+      switchOptions.some(
+        opt => opt.value === encodeSwitchProfileValue('kimi-profile', 'kimi-k2'),
+      ),
+    ).toBe(true)
+    // The active profile's own route model is still present as a normal option.
+    expect(
+      override.some(opt => opt.value === activeProfile.model),
+    ).toBe(true)
+  } finally {
+    rendered.instance.unmount()
+    rendered.stdout.end()
+  }
+})
+
 test('/model applies auto provider surface for single-model static descriptor profiles', async () => {
   const activeProfile = {
     id: 'opengateway-profile',

--- a/src/commands/model/model.test.tsx
+++ b/src/commands/model/model.test.tsx
@@ -17,10 +17,14 @@ import type { ModelOption } from '../../utils/model/modelOptions.js'
 import type { ModelSetting } from '../../utils/model/model.js'
 import type { SettingsJson } from '../../utils/settings/types.js'
 import * as actualFastModeForModelTest from '../../utils/fastMode.js'
+import * as actualExtraUsageForModelTest from '../../utils/extraUsage.js'
 
 // Snapshot the real fast-mode module up front so the cross-profile switch test
 // can mock it with a full surface and restore the real one afterwards.
 const REAL_FAST_MODE_FOR_MODEL_TEST = { ...actualFastModeForModelTest }
+// Same for extraUsage, so the cross-profile confirmation test can force the
+// `Billed as extra usage` branch and restore the real surface afterwards.
+const REAL_EXTRA_USAGE_FOR_MODEL_TEST = { ...actualExtraUsageForModelTest }
 
 type SettingsModule = typeof import('../../utils/settings/settings.js')
 
@@ -2908,5 +2912,84 @@ test('cross-profile /model switch drops fast mode when the target provider canno
   } finally {
     instance.unmount()
     mock.module('../../utils/fastMode.js', () => REAL_FAST_MODE_FOR_MODEL_TEST)
+  }
+})
+
+test('cross-profile /model switch surfaces the selected effort and extra-usage notice (#1119)', async () => {
+  // jatmn review: the cross-profile branch built its own confirmation and
+  // returned before the regular `/model` logic that appends the selected effort
+  // and the cost-impacting `Billed as extra usage` notice. Selecting a target
+  // through an inactive profile must show the same feedback the direct model
+  // path does.
+  mock.module('../../utils/extraUsage.js', () => ({
+    ...REAL_EXTRA_USAGE_FOR_MODEL_TEST,
+    isBilledAsExtraUsage: () => true,
+  }))
+  mockProviderProfiles({
+    setActiveProviderProfile: (profileId: string) => ({
+      id: profileId,
+      name: 'OpenAI',
+      provider: 'openai',
+      baseUrl: 'https://api.openai.com/v1',
+      model: 'gpt-5-mini',
+    }),
+  } as never)
+
+  let capturedOnSelect:
+    | ((model: string | null, effort: unknown) => void)
+    | undefined
+  mock.module('../../components/ModelPicker.js', () => ({
+    ModelPicker: function MockModelPicker(props: {
+      onSelect?: (model: string | null, effort: unknown) => void
+    }): React.ReactNode {
+      capturedOnSelect = props.onSelect
+      return null
+    },
+  }))
+
+  const { getDefaultAppState } = await import('../../state/AppState.js')
+  let doneMessage: string | undefined
+  const { call } = await importFreshModelModule('cross-profile-confirmation')
+  const element = await call(
+    (message?: string) => {
+      doneMessage = message
+    },
+    {} as never,
+    '',
+  )
+  const { AppStateProvider } = await import('../../state/AppState.js')
+  const { render } = await import('../../ink.js')
+  const stdout = new PassThrough()
+  ;(stdout as unknown as { columns: number }).columns = 120
+  const instance = await render(
+    <AppStateProvider
+      initialState={
+        {
+          ...getDefaultAppState(),
+          fastMode: false,
+          mainLoopModel: 'claude-sonnet-4-6',
+        } as never
+      }
+      onChangeAppState={() => {}}
+    >
+      {element}
+    </AppStateProvider>,
+    stdout as unknown as NodeJS.WriteStream,
+  )
+
+  try {
+    await waitForCondition(() => capturedOnSelect !== undefined)
+    capturedOnSelect?.(
+      encodeSwitchProfileValue('profile_openai', 'gpt-5-mini'),
+      'high',
+    )
+
+    await waitForCondition(() => doneMessage !== undefined)
+    expect(doneMessage).toContain('Switched to')
+    expect(doneMessage).toContain('high effort')
+    expect(doneMessage).toContain('Billed as extra usage')
+  } finally {
+    instance.unmount()
+    mock.module('../../utils/extraUsage.js', () => REAL_EXTRA_USAGE_FOR_MODEL_TEST)
   }
 })

--- a/src/commands/model/model.test.tsx
+++ b/src/commands/model/model.test.tsx
@@ -12,9 +12,15 @@ import {
   resetSettingsCache,
   setSessionSettingsCache,
 } from '../../utils/settings/settingsCache.js'
+import { encodeSwitchProfileValue } from '../../utils/model/modelOptions.js'
 import type { ModelOption } from '../../utils/model/modelOptions.js'
 import type { ModelSetting } from '../../utils/model/model.js'
 import type { SettingsJson } from '../../utils/settings/types.js'
+import * as actualFastModeForModelTest from '../../utils/fastMode.js'
+
+// Snapshot the real fast-mode module up front so the cross-profile switch test
+// can mock it with a full surface and restore the real one afterwards.
+const REAL_FAST_MODE_FOR_MODEL_TEST = { ...actualFastModeForModelTest }
 
 type SettingsModule = typeof import('../../utils/settings/settings.js')
 
@@ -2729,4 +2735,89 @@ test('/model does not auto-refresh descriptor models when nonessential traffic i
 
   expect(result).toBeTruthy()
   expect(discoverModelsForRoute).not.toHaveBeenCalled()
+})
+
+test('cross-profile /model switch drops latched fast mode before activating an unsupported target profile (#1119)', async () => {
+  // Fast mode is enabled on the source provider; activating the target profile
+  // flips isFastModeEnabled() to false (the new provider can't use fast mode).
+  // This guards the ordering bug: reconcileFastModeForSwitch must evaluate
+  // against the source provider (before activation), otherwise it short-circuits
+  // to 'unchanged' once the new provider is active and leaves fastMode latched.
+  let targetProfileActivated = false
+  mock.module('../../utils/fastMode.js', () => ({
+    ...REAL_FAST_MODE_FOR_MODEL_TEST,
+    isFastModeEnabled: () => !targetProfileActivated,
+    isFastModeSupportedByModel: (m: string | null) => m === 'claude-opus-4-7',
+    isFastModeAvailable: () => true,
+    clearFastModeCooldown: () => {},
+  }))
+  mockProviderProfiles({
+    setActiveProviderProfile: (profileId: string) => {
+      targetProfileActivated = true
+      return {
+        id: profileId,
+        name: 'OpenAI',
+        provider: 'openai',
+        baseUrl: 'https://api.openai.com/v1',
+        model: 'gpt-5-mini',
+      }
+    },
+  } as never)
+
+  let capturedOnSelect:
+    | ((model: string | null, effort: unknown) => void)
+    | undefined
+  mock.module('../../components/ModelPicker.js', () => ({
+    ModelPicker: function MockModelPicker(props: {
+      onSelect?: (model: string | null, effort: unknown) => void
+    }): React.ReactNode {
+      capturedOnSelect = props.onSelect
+      return null
+    },
+  }))
+
+  const { getDefaultAppState } = await import('../../state/AppState.js')
+  const observedStates: Array<{ fastMode?: boolean }> = []
+  const { call } = await importFreshModelModule('fast-cross-profile-order')
+  const element = await call(() => {}, {} as never, '')
+  const { AppStateProvider } = await import('../../state/AppState.js')
+  const { render } = await import('../../ink.js')
+  const stdout = new PassThrough()
+  ;(stdout as unknown as { columns: number }).columns = 120
+  const instance = await render(
+    <AppStateProvider
+      initialState={
+        {
+          ...getDefaultAppState(),
+          fastMode: true,
+          mainLoopModel: 'claude-opus-4-7',
+        } as never
+      }
+      onChangeAppState={({
+        newState,
+      }: {
+        newState: { fastMode?: boolean }
+      }) => {
+        observedStates.push(newState)
+      }}
+    >
+      {element}
+    </AppStateProvider>,
+    stdout as unknown as NodeJS.WriteStream,
+  )
+
+  await waitForCondition(() => capturedOnSelect !== undefined)
+  capturedOnSelect?.(
+    encodeSwitchProfileValue('profile_openai', 'gpt-5-mini'),
+    undefined,
+  )
+
+  await waitForCondition(() =>
+    observedStates.some(state => state.fastMode === false),
+  )
+  expect(observedStates.at(-1)?.fastMode).toBe(false)
+
+  instance.unmount()
+  // Restore the real fast-mode module for sibling tests in this file.
+  mock.module('../../utils/fastMode.js', () => REAL_FAST_MODE_FOR_MODEL_TEST)
 })

--- a/src/commands/model/model.test.tsx
+++ b/src/commands/model/model.test.tsx
@@ -2806,18 +2806,107 @@ test('cross-profile /model switch drops latched fast mode before activating an u
     stdout as unknown as NodeJS.WriteStream,
   )
 
-  await waitForCondition(() => capturedOnSelect !== undefined)
-  capturedOnSelect?.(
-    encodeSwitchProfileValue('profile_openai', 'gpt-5-mini'),
-    undefined,
+  try {
+    await waitForCondition(() => capturedOnSelect !== undefined)
+    capturedOnSelect?.(
+      encodeSwitchProfileValue('profile_openai', 'gpt-5-mini'),
+      undefined,
+    )
+
+    await waitForCondition(() =>
+      observedStates.some(state => state.fastMode === false),
+    )
+    expect(observedStates.at(-1)?.fastMode).toBe(false)
+  } finally {
+    instance.unmount()
+    // Restore the real fast-mode module for sibling tests in this file.
+    mock.module('../../utils/fastMode.js', () => REAL_FAST_MODE_FOR_MODEL_TEST)
+  }
+})
+
+test('cross-profile /model switch drops fast mode when the target provider cannot run it even though the model name passes source-side support (#1119)', async () => {
+  // jatmn review edge case: the target model name passes isFastModeSupportedByModel
+  // on the SOURCE provider, so the pre-activation reconcile returns 'on'. But the
+  // target provider cannot run fast mode (isFastModeEnabled() flips false after
+  // activation). The post-activation re-check must still force fastMode off rather
+  // than leaving it latched and printing "Fast mode ON".
+  let targetProfileActivated = false
+  mock.module('../../utils/fastMode.js', () => ({
+    ...REAL_FAST_MODE_FOR_MODEL_TEST,
+    // Model name passes support on both sides; only the provider gating changes.
+    isFastModeSupportedByModel: () => true,
+    isFastModeAvailable: () => true,
+    isFastModeEnabled: () => !targetProfileActivated,
+    clearFastModeCooldown: () => {},
+  }))
+  mockProviderProfiles({
+    setActiveProviderProfile: (profileId: string) => {
+      targetProfileActivated = true
+      return {
+        id: profileId,
+        name: 'Custom Shim',
+        provider: 'openai',
+        baseUrl: 'https://shim.example/v1',
+        model: 'claude-opus-4-6',
+      }
+    },
+  } as never)
+
+  let capturedOnSelect:
+    | ((model: string | null, effort: unknown) => void)
+    | undefined
+  mock.module('../../components/ModelPicker.js', () => ({
+    ModelPicker: function MockModelPicker(props: {
+      onSelect?: (model: string | null, effort: unknown) => void
+    }): React.ReactNode {
+      capturedOnSelect = props.onSelect
+      return null
+    },
+  }))
+
+  const { getDefaultAppState } = await import('../../state/AppState.js')
+  const observedStates: Array<{ fastMode?: boolean }> = []
+  const { call } = await importFreshModelModule('fast-cross-profile-capability')
+  const element = await call(() => {}, {} as never, '')
+  const { AppStateProvider } = await import('../../state/AppState.js')
+  const { render } = await import('../../ink.js')
+  const stdout = new PassThrough()
+  ;(stdout as unknown as { columns: number }).columns = 120
+  const instance = await render(
+    <AppStateProvider
+      initialState={
+        {
+          ...getDefaultAppState(),
+          fastMode: true,
+          mainLoopModel: 'claude-opus-4-6',
+        } as never
+      }
+      onChangeAppState={({
+        newState,
+      }: {
+        newState: { fastMode?: boolean }
+      }) => {
+        observedStates.push(newState)
+      }}
+    >
+      {element}
+    </AppStateProvider>,
+    stdout as unknown as NodeJS.WriteStream,
   )
 
-  await waitForCondition(() =>
-    observedStates.some(state => state.fastMode === false),
-  )
-  expect(observedStates.at(-1)?.fastMode).toBe(false)
+  try {
+    await waitForCondition(() => capturedOnSelect !== undefined)
+    capturedOnSelect?.(
+      encodeSwitchProfileValue('profile_shim', 'claude-opus-4-6'),
+      undefined,
+    )
 
-  instance.unmount()
-  // Restore the real fast-mode module for sibling tests in this file.
-  mock.module('../../utils/fastMode.js', () => REAL_FAST_MODE_FOR_MODEL_TEST)
+    await waitForCondition(() =>
+      observedStates.some(state => state.fastMode === false),
+    )
+    expect(observedStates.at(-1)?.fastMode).toBe(false)
+  } finally {
+    instance.unmount()
+    mock.module('../../utils/fastMode.js', () => REAL_FAST_MODE_FOR_MODEL_TEST)
+  }
 })

--- a/src/commands/model/model.test.tsx
+++ b/src/commands/model/model.test.tsx
@@ -2778,11 +2778,15 @@ test('cross-profile /model switch drops latched fast mode before activating an u
   } as never)
 
   let capturedOnSelect:
-    | ((model: string | null, effort: unknown) => void)
+    | ((model: string | null, effort: unknown, switchToProfileId?: string) => void)
     | undefined
   mock.module('../../components/ModelPicker.js', () => ({
     ModelPicker: function MockModelPicker(props: {
-      onSelect?: (model: string | null, effort: unknown) => void
+      onSelect?: (
+        model: string | null,
+        effort: unknown,
+        switchToProfileId?: string,
+      ) => void
     }): React.ReactNode {
       capturedOnSelect = props.onSelect
       return null
@@ -2824,6 +2828,9 @@ test('cross-profile /model switch drops latched fast mode before activating an u
     capturedOnSelect?.(
       encodeSwitchProfileValue('profile_openai', 'gpt-5-mini'),
       undefined,
+      // The real ModelPicker threads the selected switch option's marker; the
+      // mock picker mirrors that so handleSelect activates the profile.
+      'profile_openai',
     )
 
     await waitForCondition(() =>
@@ -2875,11 +2882,15 @@ test('cross-profile /model switch drops fast mode when the target provider canno
   } as never)
 
   let capturedOnSelect:
-    | ((model: string | null, effort: unknown) => void)
+    | ((model: string | null, effort: unknown, switchToProfileId?: string) => void)
     | undefined
   mock.module('../../components/ModelPicker.js', () => ({
     ModelPicker: function MockModelPicker(props: {
-      onSelect?: (model: string | null, effort: unknown) => void
+      onSelect?: (
+        model: string | null,
+        effort: unknown,
+        switchToProfileId?: string,
+      ) => void
     }): React.ReactNode {
       capturedOnSelect = props.onSelect
       return null
@@ -2921,6 +2932,9 @@ test('cross-profile /model switch drops fast mode when the target provider canno
     capturedOnSelect?.(
       encodeSwitchProfileValue('profile_shim', 'claude-opus-4-6'),
       undefined,
+      // The real ModelPicker threads the selected switch option's marker; the
+      // mock picker mirrors that so handleSelect activates the profile.
+      'profile_shim',
     )
 
     await waitForCondition(() =>
@@ -2963,11 +2977,15 @@ test('cross-profile /model switch surfaces the selected effort and extra-usage n
   } as never)
 
   let capturedOnSelect:
-    | ((model: string | null, effort: unknown) => void)
+    | ((model: string | null, effort: unknown, switchToProfileId?: string) => void)
     | undefined
   mock.module('../../components/ModelPicker.js', () => ({
     ModelPicker: function MockModelPicker(props: {
-      onSelect?: (model: string | null, effort: unknown) => void
+      onSelect?: (
+        model: string | null,
+        effort: unknown,
+        switchToProfileId?: string,
+      ) => void
     }): React.ReactNode {
       capturedOnSelect = props.onSelect
       return null
@@ -3009,6 +3027,9 @@ test('cross-profile /model switch surfaces the selected effort and extra-usage n
     capturedOnSelect?.(
       encodeSwitchProfileValue('profile_openai', 'gpt-5-mini'),
       'high',
+      // The real ModelPicker threads the selected switch option's marker; the
+      // mock picker mirrors that so handleSelect activates the profile.
+      'profile_openai',
     )
 
     await waitForCondition(() => doneMessage !== undefined)
@@ -3018,5 +3039,102 @@ test('cross-profile /model switch surfaces the selected effort and extra-usage n
   } finally {
     instance.unmount()
     mock.module('../../utils/extraUsage.js', () => REAL_EXTRA_USAGE_FOR_MODEL_TEST)
+  }
+})
+
+test('cross-profile /model does NOT switch a literal prefixed model id lacking the switch marker (#1164)', async () => {
+  // jatmn [P2]: a real custom model id such as
+  // `__switch_profile__:profile_openai:gpt-5-mini` parses like a switch value
+  // and `profile_openai` exists — but the selected option carried NO
+  // switchToProfileId marker, so it must be applied as a literal model, never
+  // activating the provider. The mock picker mirrors the real one by threading
+  // an UNDEFINED marker for this non-switch option.
+  let activatedProfileId: string | null = null
+  mockProviderProfiles({
+    getProviderProfiles: () => [
+      {
+        id: 'profile_openai',
+        name: 'OpenAI',
+        provider: 'openai',
+        baseUrl: 'https://api.openai.com/v1',
+        model: 'gpt-5-mini',
+      },
+    ],
+    setActiveProviderProfile: (profileId: string) => {
+      activatedProfileId = profileId
+      return {
+        id: profileId,
+        name: 'OpenAI',
+        provider: 'openai',
+        baseUrl: 'https://api.openai.com/v1',
+        model: 'gpt-5-mini',
+      }
+    },
+  } as never)
+
+  let capturedOnSelect:
+    | ((model: string | null, effort: unknown, switchToProfileId?: string) => void)
+    | undefined
+  mock.module('../../components/ModelPicker.js', () => ({
+    ModelPicker: function MockModelPicker(props: {
+      onSelect?: (
+        model: string | null,
+        effort: unknown,
+        switchToProfileId?: string,
+      ) => void
+    }): React.ReactNode {
+      capturedOnSelect = props.onSelect
+      return null
+    },
+  }))
+
+  const { getDefaultAppState } = await import('../../state/AppState.js')
+  let doneMessage: string | undefined
+  const { call } = await importFreshModelModule('literal-prefixed-no-switch')
+  const element = await call(
+    (message?: string) => {
+      doneMessage = message
+    },
+    {} as never,
+    '',
+  )
+  const { AppStateProvider } = await import('../../state/AppState.js')
+  const { render } = await import('../../ink.js')
+  const stdout = new PassThrough()
+  ;(stdout as unknown as { columns: number }).columns = 120
+  const instance = await render(
+    <AppStateProvider
+      initialState={
+        {
+          ...getDefaultAppState(),
+          fastMode: false,
+          mainLoopModel: 'claude-sonnet-4-6',
+        } as never
+      }
+      onChangeAppState={() => {}}
+    >
+      {element}
+    </AppStateProvider>,
+    stdout as unknown as NodeJS.WriteStream,
+  )
+
+  try {
+    await waitForCondition(() => capturedOnSelect !== undefined)
+    // Same encoded string, but NO marker threaded — this is a literal custom id.
+    capturedOnSelect?.(
+      encodeSwitchProfileValue('profile_openai', 'gpt-5-mini'),
+      undefined,
+      undefined,
+    )
+
+    await waitForCondition(() => doneMessage !== undefined)
+    // Applied as a literal model, provider never activated.
+    expect(activatedProfileId).toBeNull()
+    expect(doneMessage).not.toContain('Switched to')
+    expect(doneMessage).toContain(
+      encodeSwitchProfileValue('profile_openai', 'gpt-5-mini'),
+    )
+  } finally {
+    instance.unmount()
   }
 })

--- a/src/commands/model/model.test.tsx
+++ b/src/commands/model/model.test.tsx
@@ -2756,6 +2756,15 @@ test('cross-profile /model switch drops latched fast mode before activating an u
     clearFastModeCooldown: () => {},
   }))
   mockProviderProfiles({
+    getProviderProfiles: () => [
+      {
+        id: 'profile_openai',
+        name: 'OpenAI',
+        provider: 'openai',
+        baseUrl: 'https://api.openai.com/v1',
+        model: 'gpt-5-mini',
+      },
+    ],
     setActiveProviderProfile: (profileId: string) => {
       targetProfileActivated = true
       return {
@@ -2844,6 +2853,15 @@ test('cross-profile /model switch drops fast mode when the target provider canno
     clearFastModeCooldown: () => {},
   }))
   mockProviderProfiles({
+    getProviderProfiles: () => [
+      {
+        id: 'profile_shim',
+        name: 'Custom Shim',
+        provider: 'openai',
+        baseUrl: 'https://shim.example/v1',
+        model: 'claude-opus-4-6',
+      },
+    ],
     setActiveProviderProfile: (profileId: string) => {
       targetProfileActivated = true
       return {
@@ -2926,6 +2944,15 @@ test('cross-profile /model switch surfaces the selected effort and extra-usage n
     isBilledAsExtraUsage: () => true,
   }))
   mockProviderProfiles({
+    getProviderProfiles: () => [
+      {
+        id: 'profile_openai',
+        name: 'OpenAI',
+        provider: 'openai',
+        baseUrl: 'https://api.openai.com/v1',
+        model: 'gpt-5-mini',
+      },
+    ],
     setActiveProviderProfile: (profileId: string) => ({
       id: profileId,
       name: 'OpenAI',

--- a/src/commands/model/model.tsx
+++ b/src/commands/model/model.tsx
@@ -685,15 +685,30 @@ function ModelPickerWrapper({
         mainLoopModelForSession: null,
       }))
 
-      if (switchFastMode === 'off') {
+      // Re-evaluate fast mode AFTER activation: the pre-activation reconcile
+      // gates on the *source* provider, so its 'on' result can be stale when
+      // the target provider can't actually run fast mode (e.g. switching from
+      // first-party to a third-party OpenAI-compatible profile whose model name
+      // still passes the source-side support check). isFastModeEnabled() now
+      // reflects the target provider, so force fastMode off whenever it is no
+      // longer genuinely supported (jatmn review, #1119).
+      const fastModeSupportedNow =
+        isFastModeEnabled() &&
+        isFastModeSupportedByModel(switchTarget.model) &&
+        isFastModeAvailable()
+      const shouldTurnFastModeOff =
+        (isFastMode ?? false) &&
+        (switchFastMode === 'off' || !fastModeSupportedNow)
+
+      if (shouldTurnFastModeOff) {
         setAppState(prev => ({ ...prev, fastMode: false }))
       }
 
       let switchMessage = `Switched to ${chalk.bold(activated.name)} · model ${chalk.bold(switchTarget.model)}`
-      if (switchFastMode === 'on') {
-        switchMessage += ' · Fast mode ON'
-      } else if (switchFastMode === 'off') {
+      if (shouldTurnFastModeOff) {
         switchMessage += ' · Fast mode OFF'
+      } else if ((isFastMode ?? false) && fastModeSupportedNow) {
+        switchMessage += ' · Fast mode ON'
       }
       onDone(switchMessage)
       return

--- a/src/commands/model/model.tsx
+++ b/src/commands/model/model.tsx
@@ -705,10 +705,29 @@ function ModelPickerWrapper({
       }
 
       let switchMessage = `Switched to ${chalk.bold(activated.name)} · model ${chalk.bold(switchTarget.model)}`
+      // Mirror the regular switch confirmation so a cross-profile selection
+      // surfaces the same cost-impacting feedback: the selected effort and the
+      // `Billed as extra usage` notice (jatmn review, #1119). The picker already
+      // decodes effort for switch values, so omitting it here would silently
+      // hide reasoning/extra-usage information the direct model path shows.
+      if (effort !== undefined) {
+        switchMessage += ` with ${chalk.bold(effort)} effort`
+      }
+      const crossProfileFastModeOn =
+        (isFastMode ?? false) && fastModeSupportedNow && !shouldTurnFastModeOff
       if (shouldTurnFastModeOff) {
         switchMessage += ' · Fast mode OFF'
-      } else if ((isFastMode ?? false) && fastModeSupportedNow) {
+      } else if (crossProfileFastModeOn) {
         switchMessage += ' · Fast mode ON'
+      }
+      if (
+        isBilledAsExtraUsage(
+          switchTarget.model,
+          crossProfileFastModeOn,
+          isOpus1mMergeEnabled(),
+        )
+      ) {
+        switchMessage += ' · Billed as extra usage'
       }
       onDone(switchMessage)
       return

--- a/src/commands/model/model.tsx
+++ b/src/commands/model/model.tsx
@@ -46,7 +46,10 @@ import {
   checkOpus1mAccess,
   checkSonnet1mAccess,
 } from '../../utils/model/check1mAccess.js'
-import type { ModelOption } from '../../utils/model/modelOptions.js'
+import {
+  parseSwitchProfileValue,
+  type ModelOption,
+} from '../../utils/model/modelOptions.js'
 import { buildRouteCatalogModelOptions, mergeRouteCatalogEntries } from '../../utils/model/routeCatalogOptions.js'
 import { discoverOpenAICompatibleModelOptions } from '../../utils/model/openaiModelDiscovery.js'
 import {
@@ -63,6 +66,7 @@ import {
   getActiveOpenAIModelOptionsCache,
   getActiveProviderProfile,
   setActiveOpenAIModelOptionsCache,
+  setActiveProviderProfile,
 } from '../../utils/providerProfiles.js'
 
 type ModelDiscoveryContext =
@@ -379,6 +383,35 @@ function ModelPickerWrapper({
   }
 
   const handleSelect = (model: string | null, effort: EffortLevel | undefined) => {
+    // Cross-profile switch from /model picker (issue #1119). The composite
+    // value carries the profile id; activate that profile first so subsequent
+    // requests use the new OPENAI_BASE_URL / OPENAI_API_KEY, then drop down to
+    // the regular model-switch path with the bare model string.
+    const switchTarget = parseSwitchProfileValue(model)
+    if (switchTarget) {
+      const activated = setActiveProviderProfile(switchTarget.profileId)
+      if (!activated) {
+        onDone(`Could not activate provider profile "${switchTarget.profileId}".`, {
+          display: 'system',
+        })
+        return
+      }
+      logEvent('tengu_model_command_menu', {
+        action: 'switch_profile' as AnalyticsMetadata_I_VERIFIED_THIS_IS_NOT_CODE_OR_FILEPATHS,
+        from_model: String(mainLoopModel) as AnalyticsMetadata_I_VERIFIED_THIS_IS_NOT_CODE_OR_FILEPATHS,
+        to_model: String(switchTarget.model) as AnalyticsMetadata_I_VERIFIED_THIS_IS_NOT_CODE_OR_FILEPATHS,
+      })
+      setAppState(prev => ({
+        ...prev,
+        mainLoopModel: switchTarget.model,
+        mainLoopModelForSession: null,
+      }))
+      onDone(
+        `Switched to ${chalk.bold(activated.name)} · model ${chalk.bold(switchTarget.model)}`,
+      )
+      return
+    }
+
     logEvent('tengu_model_command_menu', {
       action: String(model) as AnalyticsMetadata_I_VERIFIED_THIS_IS_NOT_CODE_OR_FILEPATHS,
       from_model: String(mainLoopModel) as AnalyticsMetadata_I_VERIFIED_THIS_IS_NOT_CODE_OR_FILEPATHS,

--- a/src/commands/model/model.tsx
+++ b/src/commands/model/model.tsx
@@ -342,6 +342,31 @@ function getOpenAIDiscoveryRequestOptions(routeId?: string | null): {
   }
 }
 
+// Reconciles fast-mode state when /model picks a new target — both the regular
+// switch path and the cross-profile switch path (#1119 / jatmn review) call
+// this so a latched fastMode never carries past a model that can't support it.
+// Pure: returns the result and lets callers apply state mutations.
+export type FastModeReconcileResult = 'on' | 'off' | 'unchanged'
+
+export function reconcileFastModeForSwitch(
+  targetModel: string | null,
+  isFastModeOn: boolean,
+): FastModeReconcileResult {
+  if (!isFastModeEnabled()) return 'unchanged'
+  clearFastModeCooldown()
+  if (!isFastModeSupportedByModel(targetModel) && isFastModeOn) {
+    return 'off'
+  }
+  if (
+    isFastModeSupportedByModel(targetModel) &&
+    isFastModeAvailable() &&
+    isFastModeOn
+  ) {
+    return 'on'
+  }
+  return 'unchanged'
+}
+
 export function shouldAutoRefreshRouteCatalog(options: {
   catalog: ModelCatalogConfig
   hasCachedModels: boolean
@@ -646,9 +671,26 @@ function ModelPickerWrapper({
         mainLoopModel: switchTarget.model,
         mainLoopModelForSession: null,
       }))
-      onDone(
-        `Switched to ${chalk.bold(activated.name)} · model ${chalk.bold(switchTarget.model)}`,
+
+      // Run the same fast-mode reconciliation as the regular switch path —
+      // otherwise a user with fastMode latched on Anthropic would carry the
+      // latched state into the new profile even when its model can't support
+      // it (jatmn review, #1119).
+      const switchFastMode = reconcileFastModeForSwitch(
+        switchTarget.model,
+        isFastMode,
       )
+      if (switchFastMode === 'off') {
+        setAppState(prev => ({ ...prev, fastMode: false }))
+      }
+
+      let switchMessage = `Switched to ${chalk.bold(activated.name)} · model ${chalk.bold(switchTarget.model)}`
+      if (switchFastMode === 'on') {
+        switchMessage += ' · Fast mode ON'
+      } else if (switchFastMode === 'off') {
+        switchMessage += ' · Fast mode OFF'
+      }
+      onDone(switchMessage)
       return
     }
 
@@ -677,23 +719,21 @@ function ModelPickerWrapper({
       message += ` with ${chalk.bold(effort)} effort`
     }
 
-    let wasFastModeToggledOn: boolean | undefined
-    if (isFastModeEnabled()) {
-      clearFastModeCooldown()
-      if (!isFastModeSupportedByModel(model) && isFastMode) {
-        setAppState(prev => ({
-          ...prev,
-          fastMode: false,
-        }))
-        wasFastModeToggledOn = false
-      } else if (
-        isFastModeSupportedByModel(model) &&
-        isFastModeAvailable() &&
-        isFastMode
-      ) {
-        message += ' · Fast mode ON'
-        wasFastModeToggledOn = true
-      }
+    const fastModeResult = reconcileFastModeForSwitch(model, isFastMode)
+    if (fastModeResult === 'off') {
+      setAppState(prev => ({
+        ...prev,
+        fastMode: false,
+      }))
+    }
+    const wasFastModeToggledOn: boolean | undefined =
+      fastModeResult === 'on'
+        ? true
+        : fastModeResult === 'off'
+        ? false
+        : undefined
+    if (fastModeResult === 'on') {
+      message += ' · Fast mode ON'
     }
 
     if (

--- a/src/commands/model/model.tsx
+++ b/src/commands/model/model.tsx
@@ -654,6 +654,19 @@ function ModelPickerWrapper({
         )
         return
       }
+      // Run the same fast-mode reconciliation as the regular switch path —
+      // otherwise a user with fastMode latched on Anthropic would carry the
+      // latched state into the new profile even when its model can't support
+      // it (jatmn review, #1119). This MUST run before setActiveProviderProfile:
+      // reconcileFastModeForSwitch gates on isFastModeEnabled(), which reads the
+      // *active* provider, so once the target profile is activated it reflects
+      // the new (fast-mode-less) provider and short-circuits to 'unchanged',
+      // leaving fastMode latched on.
+      const switchFastMode = reconcileFastModeForSwitch(
+        switchTarget.model,
+        isFastMode ?? false,
+      )
+
       const activated = setActiveProviderProfile(switchTarget.profileId)
       if (!activated) {
         onDone(`Could not activate provider profile "${switchTarget.profileId}".`, {
@@ -672,14 +685,6 @@ function ModelPickerWrapper({
         mainLoopModelForSession: null,
       }))
 
-      // Run the same fast-mode reconciliation as the regular switch path —
-      // otherwise a user with fastMode latched on Anthropic would carry the
-      // latched state into the new profile even when its model can't support
-      // it (jatmn review, #1119).
-      const switchFastMode = reconcileFastModeForSwitch(
-        switchTarget.model,
-        isFastMode ?? false,
-      )
       if (switchFastMode === 'off') {
         setAppState(prev => ({ ...prev, fastMode: false }))
       }

--- a/src/commands/model/model.tsx
+++ b/src/commands/model/model.tsx
@@ -639,20 +639,29 @@ function ModelPickerWrapper({
     })
   }
 
-  const handleSelect = (model: string | null, effort: EffortLevel | undefined) => {
+  const handleSelect = (
+    model: string | null,
+    effort: EffortLevel | undefined,
+    switchToProfileId?: string,
+  ) => {
     // Cross-profile switch from /model picker (issue #1119). The composite
     // value carries the profile id; activate that profile first so subsequent
     // requests use the new OPENAI_BASE_URL / OPENAI_API_KEY, then drop down to
     // the regular model-switch path with the bare model string.
     //
-    // Only treat the value as a switch when its decoded profile id maps to a
-    // real configured provider profile. Every synthesized switch option (built
-    // with a `switchToProfileId` marker) does; a custom model id that merely
-    // starts with the `__switch_profile__:` prefix does not, and must be applied
-    // as a literal model instead of activating a nonexistent profile.
+    // Only treat the value as a switch when the SELECTED OPTION carried the
+    // `switchToProfileId` marker (threaded here by the picker) — not merely
+    // because the value parses as `__switch_profile__:<profileId>:<model>` for
+    // an existing profile. A real custom model id such as
+    // `__switch_profile__:profile_openai:gpt-5-mini` (where `profile_openai`
+    // happens to exist) is a plain option with no marker, and must be applied
+    // as a literal model rather than activating the provider. Cross-check the
+    // decoded profile id against the threaded marker and a real configured
+    // profile before switching.
     const decodedSwitch = parseSwitchProfileValue(model)
     const switchTarget =
       decodedSwitch &&
+      switchToProfileId === decodedSwitch.profileId &&
       getProviderProfiles().some(p => p.id === decodedSwitch.profileId)
         ? decodedSwitch
         : null

--- a/src/commands/model/model.tsx
+++ b/src/commands/model/model.tsx
@@ -140,6 +140,31 @@ function getOpenAIDiscoveryRequestOptions(routeId?: string | null): {
   }
 }
 
+// Reconciles fast-mode state when /model picks a new target — both the regular
+// switch path and the cross-profile switch path (#1119 / jatmn review) call
+// this so a latched fastMode never carries past a model that can't support it.
+// Pure: returns the result and lets callers apply state mutations.
+export type FastModeReconcileResult = 'on' | 'off' | 'unchanged'
+
+export function reconcileFastModeForSwitch(
+  targetModel: string | null,
+  isFastModeOn: boolean,
+): FastModeReconcileResult {
+  if (!isFastModeEnabled()) return 'unchanged'
+  clearFastModeCooldown()
+  if (!isFastModeSupportedByModel(targetModel) && isFastModeOn) {
+    return 'off'
+  }
+  if (
+    isFastModeSupportedByModel(targetModel) &&
+    isFastModeAvailable() &&
+    isFastModeOn
+  ) {
+    return 'on'
+  }
+  return 'unchanged'
+}
+
 export function shouldAutoRefreshRouteCatalog(options: {
   catalog: ModelCatalogConfig
   hasCachedModels: boolean
@@ -406,9 +431,26 @@ function ModelPickerWrapper({
         mainLoopModel: switchTarget.model,
         mainLoopModelForSession: null,
       }))
-      onDone(
-        `Switched to ${chalk.bold(activated.name)} · model ${chalk.bold(switchTarget.model)}`,
+
+      // Run the same fast-mode reconciliation as the regular switch path —
+      // otherwise a user with fastMode latched on Anthropic would carry the
+      // latched state into the new profile even when its model can't support
+      // it (jatmn review, #1119).
+      const switchFastMode = reconcileFastModeForSwitch(
+        switchTarget.model,
+        isFastMode,
       )
+      if (switchFastMode === 'off') {
+        setAppState(prev => ({ ...prev, fastMode: false }))
+      }
+
+      let switchMessage = `Switched to ${chalk.bold(activated.name)} · model ${chalk.bold(switchTarget.model)}`
+      if (switchFastMode === 'on') {
+        switchMessage += ' · Fast mode ON'
+      } else if (switchFastMode === 'off') {
+        switchMessage += ' · Fast mode OFF'
+      }
+      onDone(switchMessage)
       return
     }
 
@@ -429,23 +471,21 @@ function ModelPickerWrapper({
       message += ` with ${chalk.bold(effort)} effort`
     }
 
-    let wasFastModeToggledOn: boolean | undefined
-    if (isFastModeEnabled()) {
-      clearFastModeCooldown()
-      if (!isFastModeSupportedByModel(model) && isFastMode) {
-        setAppState(prev => ({
-          ...prev,
-          fastMode: false,
-        }))
-        wasFastModeToggledOn = false
-      } else if (
-        isFastModeSupportedByModel(model) &&
-        isFastModeAvailable() &&
-        isFastMode
-      ) {
-        message += ' · Fast mode ON'
-        wasFastModeToggledOn = true
-      }
+    const fastModeResult = reconcileFastModeForSwitch(model, isFastMode)
+    if (fastModeResult === 'off') {
+      setAppState(prev => ({
+        ...prev,
+        fastMode: false,
+      }))
+    }
+    const wasFastModeToggledOn: boolean | undefined =
+      fastModeResult === 'on'
+        ? true
+        : fastModeResult === 'off'
+        ? false
+        : undefined
+    if (fastModeResult === 'on') {
+      message += ' · Fast mode ON'
     }
 
     if (

--- a/src/commands/model/model.tsx
+++ b/src/commands/model/model.tsx
@@ -53,6 +53,7 @@ import {
 } from '../../utils/model/check1mAccess.js'
 import {
   getDefaultOptionForUser,
+  getInactiveProviderProfileOptions,
   parseSwitchProfileValue,
   type ModelOption,
 } from '../../utils/model/modelOptions.js'
@@ -318,6 +319,46 @@ function getLegacyOpenAIOptionsOverride(options: {
       profileModelSurface: options.profileModelSurface,
     },
   )
+}
+
+// The picker renders `optionsOverride ?? getModelOptions()`. getModelOptions()
+// appends inactive-profile switch entries (issue #1119) when a provider profile
+// env is applied, but the discovery/refresh override lists are built from
+// mergeActiveProfileModelOptions, which only merges the ACTIVE profile's route
+// models. Without re-appending here, the unified `/model` switcher disappears
+// for descriptor-backed and legacy OpenAI-compatible discovery contexts
+// (OpenRouter/Kimi/MiniMax, refreshed local profiles). Mirror getModelOptions()
+// so any override list carries the same inactive-profile switch options.
+function withInactiveProfileSwitchOptions(
+  options: ModelOption[],
+): ModelOption[] {
+  if (process.env.CLAUDE_CODE_PROVIDER_PROFILE_ENV_APPLIED !== '1') {
+    return options
+  }
+  const activeProfile = getActiveProviderProfile()
+  const switchOptions = getInactiveProviderProfileOptions(activeProfile?.id)
+  if (switchOptions.length === 0) {
+    return options
+  }
+  const present = new Set(
+    options.flatMap(option =>
+      typeof option.value === 'string' ? [option.value] : [],
+    ),
+  )
+  const additions = switchOptions.filter(option => {
+    if (typeof option.value !== 'string' || present.has(option.value)) {
+      return false
+    }
+    // Apply the org allowlist to the decoded target model, mirroring
+    // getModelOptions()'s allowlist pass, so a restricted switch target is not
+    // surfaced. handleSelect re-checks this before activating regardless.
+    const target =
+      option.switchToProfileId !== undefined
+        ? parseSwitchProfileValue(option.value)?.model ?? option.value
+        : option.value
+    return isModelAllowed(target)
+  })
+  return additions.length > 0 ? [...options, ...additions] : options
 }
 
 function getOpenAIDiscoveryRequestOptions(routeId?: string | null): {
@@ -958,7 +999,11 @@ function ModelPickerWrapper({
         isFastModeSupportedByModel(mainLoopModel) &&
         isFastModeAvailable()
       }
-      optionsOverride={optionsOverride}
+      optionsOverride={
+        optionsOverride
+          ? withInactiveProfileSwitchOptions(optionsOverride)
+          : undefined
+      }
       discoveryState={discoveryState}
       onRefresh={
         discoveryContext?.canRefresh

--- a/src/commands/model/model.tsx
+++ b/src/commands/model/model.tsx
@@ -53,6 +53,7 @@ import {
 } from '../../utils/model/check1mAccess.js'
 import {
   getDefaultOptionForUser,
+  parseSwitchProfileValue,
   type ModelOption,
 } from '../../utils/model/modelOptions.js'
 import { buildRouteCatalogModelOptions, mergeRouteCatalogEntries } from '../../utils/model/routeCatalogOptions.js'
@@ -73,6 +74,7 @@ import {
   getConfiguredProfileModelOptions,
   setActiveOpenAIRouteModelOptionsCache,
   setActiveOpenAIModelOptionsCache,
+  setActiveProviderProfile,
 } from '../../utils/providerProfiles.js'
 import { parseModelList } from '../../utils/providerModels.js'
 import { getInitialSettings } from '../../utils/settings/settings.js'
@@ -612,6 +614,44 @@ function ModelPickerWrapper({
   }
 
   const handleSelect = (model: string | null, effort: EffortLevel | undefined) => {
+    // Cross-profile switch from /model picker (issue #1119). The composite
+    // value carries the profile id; activate that profile first so subsequent
+    // requests use the new OPENAI_BASE_URL / OPENAI_API_KEY, then drop down to
+    // the regular model-switch path with the bare model string.
+    const switchTarget = parseSwitchProfileValue(model)
+    if (switchTarget) {
+      // Apply the org allowlist to the decoded target model, not the composite
+      // value, so a permitted cross-profile model is not wrongly rejected.
+      if (!isModelAllowed(switchTarget.model)) {
+        onDone(
+          `Model '${switchTarget.model}' is not available. Your organization restricts model selection.`,
+          { display: 'system' },
+        )
+        return
+      }
+      const activated = setActiveProviderProfile(switchTarget.profileId)
+      if (!activated) {
+        onDone(`Could not activate provider profile "${switchTarget.profileId}".`, {
+          display: 'system',
+        })
+        return
+      }
+      logEvent('tengu_model_command_menu', {
+        action: 'switch_profile' as AnalyticsMetadata_I_VERIFIED_THIS_IS_NOT_CODE_OR_FILEPATHS,
+        from_model: String(mainLoopModel) as AnalyticsMetadata_I_VERIFIED_THIS_IS_NOT_CODE_OR_FILEPATHS,
+        to_model: String(switchTarget.model) as AnalyticsMetadata_I_VERIFIED_THIS_IS_NOT_CODE_OR_FILEPATHS,
+      })
+      setAppState(prev => ({
+        ...prev,
+        mainLoopModel: switchTarget.model,
+        mainLoopModelForSession: null,
+      }))
+      onDone(
+        `Switched to ${chalk.bold(activated.name)} · model ${chalk.bold(switchTarget.model)}`,
+      )
+      return
+    }
+
     if (model && !isModelAllowed(model)) {
       onDone(
         `Model '${model}' is not available. Your organization restricts model selection.`,

--- a/src/commands/model/model.tsx
+++ b/src/commands/model/model.tsx
@@ -678,7 +678,7 @@ function ModelPickerWrapper({
       // it (jatmn review, #1119).
       const switchFastMode = reconcileFastModeForSwitch(
         switchTarget.model,
-        isFastMode,
+        isFastMode ?? false,
       )
       if (switchFastMode === 'off') {
         setAppState(prev => ({ ...prev, fastMode: false }))
@@ -719,7 +719,7 @@ function ModelPickerWrapper({
       message += ` with ${chalk.bold(effort)} effort`
     }
 
-    const fastModeResult = reconcileFastModeForSwitch(model, isFastMode)
+    const fastModeResult = reconcileFastModeForSwitch(model, isFastMode ?? false)
     if (fastModeResult === 'off') {
       setAppState(prev => ({
         ...prev,
@@ -891,6 +891,7 @@ function ModelPickerWrapper({
       onSelect={handleSelect}
       onCancel={handleCancel}
       isStandaloneCommand
+      allowProfileSwitch
       showFastModeNotice={
         isFastModeEnabled() &&
         isFastMode &&

--- a/src/commands/model/model.tsx
+++ b/src/commands/model/model.tsx
@@ -72,6 +72,7 @@ import {
   getActiveOpenAIRouteModelOptionsCache,
   getActiveProviderProfile,
   getConfiguredProfileModelOptions,
+  getProviderProfiles,
   setActiveOpenAIRouteModelOptionsCache,
   setActiveOpenAIModelOptionsCache,
   setActiveProviderProfile,
@@ -643,7 +644,18 @@ function ModelPickerWrapper({
     // value carries the profile id; activate that profile first so subsequent
     // requests use the new OPENAI_BASE_URL / OPENAI_API_KEY, then drop down to
     // the regular model-switch path with the bare model string.
-    const switchTarget = parseSwitchProfileValue(model)
+    //
+    // Only treat the value as a switch when its decoded profile id maps to a
+    // real configured provider profile. Every synthesized switch option (built
+    // with a `switchToProfileId` marker) does; a custom model id that merely
+    // starts with the `__switch_profile__:` prefix does not, and must be applied
+    // as a literal model instead of activating a nonexistent profile.
+    const decodedSwitch = parseSwitchProfileValue(model)
+    const switchTarget =
+      decodedSwitch &&
+      getProviderProfiles().some(p => p.id === decodedSwitch.profileId)
+        ? decodedSwitch
+        : null
     if (switchTarget) {
       // Apply the org allowlist to the decoded target model, not the composite
       // value, so a permitted cross-profile model is not wrongly rejected.

--- a/src/components/ModelPicker.test.tsx
+++ b/src/components/ModelPicker.test.tsx
@@ -248,6 +248,16 @@ const CROSS_PROFILE_OPTIONS = [
     value: `${SWITCH_PROFILE_VALUE_PREFIX}work:gpt-5.5`,
     label: 'Switch to Work · gpt-5.5',
     description: 'Inactive provider profile',
+    // Genuine switch option carries the marker (as production builds it).
+    switchToProfileId: 'work',
+  },
+  {
+    // A real custom model id that merely starts with the switch prefix but is
+    // NOT a switch option (no switchToProfileId marker). It must stay visible in
+    // inline pickers — the filter keys on the marker, not the raw value prefix.
+    value: `${SWITCH_PROFILE_VALUE_PREFIX}vendor:gpt-5.4`,
+    label: 'Prefixed Custom Model',
+    description: 'Literal custom model, not a switch',
   },
 ]
 
@@ -276,10 +286,13 @@ test('hides cross-profile switch options when allowProfileSwitch is falsy', asyn
     await waitForCondition(() => stripAnsi(getOutput()).includes('Active Model'))
     const rendered = stripAnsi(getOutput())
     expect(rendered).toContain('Active Model')
-    // The inline picker cannot honor a profile switch, so the encoded option
-    // must never surface.
+    // The inline picker cannot honor a profile switch, so the marked switch
+    // option must never surface.
     expect(rendered).not.toContain('Switch to Work')
     expect(rendered).not.toContain(SWITCH_PROFILE_VALUE_PREFIX)
+    // ...but a real custom model that merely starts with the prefix is NOT a
+    // switch (no marker) and must remain visible.
+    expect(rendered).toContain('Prefixed Custom Model')
   } finally {
     instance.unmount()
     stdin.end()

--- a/src/components/ModelPicker.test.tsx
+++ b/src/components/ModelPicker.test.tsx
@@ -335,3 +335,4 @@ test('shows cross-profile switch options when allowProfileSwitch is set', async 
     stdout.end()
   }
 })
+

--- a/src/components/ModelPicker.test.tsx
+++ b/src/components/ModelPicker.test.tsx
@@ -10,6 +10,7 @@ import {
   acquireSharedMutationLock,
   releaseSharedMutationLock,
 } from '../test/sharedMutationLock.js'
+import { SWITCH_PROFILE_VALUE_PREFIX } from '../utils/model/modelOptions.js'
 import {
   resetSettingsCache,
   setSessionSettingsCache,
@@ -201,6 +202,120 @@ test('matches current model to override options case-insensitively', async () =>
     const rendered = stripAnsi(output)
     expect(rendered).toContain('GLM 5.2')
     expect(rendered).not.toContain('Current model')
+  } finally {
+    instance.unmount()
+    stdin.end()
+    stdout.end()
+  }
+})
+
+function makeStdio(): {
+  stdin: PassThrough & {
+    isTTY: boolean
+    setRawMode: (mode: boolean) => void
+    ref: () => void
+    unref: () => void
+  }
+  stdout: PassThrough
+  getOutput: () => string
+} {
+  let output = ''
+  const stdout = new PassThrough()
+  const stdin = new PassThrough() as PassThrough & {
+    isTTY: boolean
+    setRawMode: (mode: boolean) => void
+    ref: () => void
+    unref: () => void
+  }
+  stdin.isTTY = true
+  stdin.setRawMode = () => {}
+  stdin.ref = () => {}
+  stdin.unref = () => {}
+  ;(stdout as unknown as { columns: number }).columns = 120
+  stdout.on('data', chunk => {
+    output += chunk.toString()
+  })
+  return { stdin, stdout, getOutput: () => output }
+}
+
+const CROSS_PROFILE_OPTIONS = [
+  {
+    value: 'claude-opus-4-6',
+    label: 'Active Model',
+    description: 'Current profile',
+  },
+  {
+    value: `${SWITCH_PROFILE_VALUE_PREFIX}work:gpt-5.5`,
+    label: 'Switch to Work · gpt-5.5',
+    description: 'Inactive provider profile',
+  },
+]
+
+test('hides cross-profile switch options when allowProfileSwitch is falsy', async () => {
+  const { ModelPicker } = await import(
+    `./ModelPicker.js?cross-profile-hidden-${Date.now()}`
+  )
+  const { stdin, stdout, getOutput } = makeStdio()
+
+  const instance = await render(
+    <AppStateProvider initialState={getDefaultAppState()}>
+      <ModelPicker
+        initial="claude-opus-4-6"
+        onSelect={() => {}}
+        optionsOverride={CROSS_PROFILE_OPTIONS}
+      />
+    </AppStateProvider>,
+    {
+      stdin: stdin as unknown as NodeJS.ReadStream,
+      stdout: stdout as unknown as NodeJS.WriteStream,
+      exitOnCtrlC: false,
+    },
+  )
+
+  try {
+    await waitForCondition(() => stripAnsi(getOutput()).includes('Active Model'))
+    const rendered = stripAnsi(getOutput())
+    expect(rendered).toContain('Active Model')
+    // The inline picker cannot honor a profile switch, so the encoded option
+    // must never surface.
+    expect(rendered).not.toContain('Switch to Work')
+    expect(rendered).not.toContain(SWITCH_PROFILE_VALUE_PREFIX)
+  } finally {
+    instance.unmount()
+    stdin.end()
+    stdout.end()
+  }
+})
+
+test('shows cross-profile switch options when allowProfileSwitch is set', async () => {
+  const { ModelPicker } = await import(
+    `./ModelPicker.js?cross-profile-shown-${Date.now()}`
+  )
+  const { stdin, stdout, getOutput } = makeStdio()
+
+  const instance = await render(
+    <AppStateProvider initialState={getDefaultAppState()}>
+      <ModelPicker
+        initial="claude-opus-4-6"
+        onSelect={() => {}}
+        allowProfileSwitch
+        optionsOverride={CROSS_PROFILE_OPTIONS}
+      />
+    </AppStateProvider>,
+    {
+      stdin: stdin as unknown as NodeJS.ReadStream,
+      stdout: stdout as unknown as NodeJS.WriteStream,
+      exitOnCtrlC: false,
+    },
+  )
+
+  try {
+    await waitForCondition(() =>
+      stripAnsi(getOutput()).includes('Switch to Work'),
+    )
+    const rendered = stripAnsi(getOutput())
+    expect(rendered).toContain('Active Model')
+    expect(rendered).toContain('Switch to Work')
   } finally {
     instance.unmount()
     stdin.end()

--- a/src/components/ModelPicker.tsx
+++ b/src/components/ModelPicker.tsx
@@ -11,7 +11,7 @@ import { useAppState, useSetAppState } from '../state/AppState.js';
 import { convertEffortValueToLevel, type EffortLevel, getAvailableEffortLevels, getDefaultEffortForModel, modelSupportsEffort, modelSupportsMaxEffort, resolvePickerEffortPersistence, toPersistableEffort } from '../utils/effort.js';
 import { isModelAllowed } from '../utils/model/modelAllowlist.js';
 import { getDefaultMainLoopModel, type ModelSetting, modelDisplayString, parseUserSpecifiedModel } from '../utils/model/model.js';
-import { getModelOptions, type ModelOption, parseSwitchProfileValue } from '../utils/model/modelOptions.js';
+import { getModelOptions, type ModelOption, parseSwitchProfileValue, resolveSelectedSwitchProfileId } from '../utils/model/modelOptions.js';
 import { getSettingsForSource, updateSettingsForSource } from '../utils/settings/settings.js';
 import { ConfigurableShortcutHint } from './ConfigurableShortcutHint.js';
 import { Select } from './CustomSelect/index.js';
@@ -327,12 +327,16 @@ export function ModelPicker(t0) {
         onSelect(null, selectedEffort);
         return;
       }
-      // Thread the selected option's cross-profile marker (issue #1119) so the
+      // Thread the presented option's cross-profile marker (issue #1119) so the
       // /model command activates a provider only for a genuine switch option,
       // never for a literal custom id that merely starts with the prefix.
-      // selectOptions is already captured in this memo's deps, and its entries
-      // spread the source ModelOption's `switchToProfileId`.
-      const selectedSwitchProfileId = selectOptions.find(o => o.value === selectedValue)?.switchToProfileId;
+      // selectOptions is the actual presented list (already captured in this
+      // memo's deps) and its entries spread the source ModelOption's
+      // `switchToProfileId`. If two options share the selected value (a literal
+      // custom id colliding with an encoded switch value), the selection is
+      // ambiguous — the Select cannot tell them apart — so treat it as NOT a
+      // switch rather than letting the literal borrow another option's marker.
+      const selectedSwitchProfileId = resolveSelectedSwitchProfileId(selectOptions, selectedValue);
       onSelect(selectedValue, selectedEffort, selectedSwitchProfileId);
     };
     $[35] = effort;
@@ -482,17 +486,18 @@ function _temp2(s_0) {
 function _temp(s) {
   return isFastModeEnabled() ? s.fastMode : false;
 }
-// A picker value is a genuine cross-profile switch only when a synthesized
-// option with that exact value carries the `switchToProfileId` marker. A
-// literal custom model id that merely starts with `__switch_profile__:` is a
-// plain option with no marker and must NOT be decoded — otherwise the display
-// resolver would strip a real model id down to its `:`-tail. getModelOptions()
-// is the authority for the switch options (they only appear in the base list,
-// never in a discovery override, and discovered ids never carry the prefix).
+// A picker value is a genuine cross-profile switch only when the option with
+// that exact value carries the `switchToProfileId` marker. A literal custom
+// model id that merely starts with `__switch_profile__:` is a plain option with
+// no marker and must NOT be decoded — otherwise the display resolver would
+// strip a real model id down to its `:`-tail. getModelOptions() is the
+// authority for the switch options (they only appear in the base list, never in
+// a discovery override, and discovered ids never carry the prefix). If two
+// options share the value (a literal id colliding with an encoded switch
+// value), the match is ambiguous, so require exactly one option and treat that
+// lone option's marker as authoritative.
 function isGenuineSwitchProfileValue(value: string): boolean {
-  return getModelOptions().some(
-    opt => opt.value === value && opt.switchToProfileId !== undefined,
-  );
+  return resolveSelectedSwitchProfileId(getModelOptions(), value) !== undefined;
 }
 function resolveOptionModel(value?: string): string | undefined {
   if (!value) return undefined;

--- a/src/components/ModelPicker.tsx
+++ b/src/components/ModelPicker.tsx
@@ -26,7 +26,18 @@ export type ModelPickerDiscoveryState = {
 export type Props = {
   initial: string | null;
   sessionModel?: ModelSetting;
-  onSelect: (model: string | null, effort: EffortLevel | undefined) => void;
+  /**
+   * `switchToProfileId` is the marker of the selected cross-profile option
+   * (issue #1119). It is defined only when the picked option is a genuine
+   * "switch profile" entry, so consumers must gate profile activation on this
+   * marker rather than re-parsing the encoded value — a literal custom model id
+   * that merely starts with `__switch_profile__:` arrives with it undefined.
+   */
+  onSelect: (
+    model: string | null,
+    effort: EffortLevel | undefined,
+    switchToProfileId?: string,
+  ) => void;
   onCancel?: () => void;
   isStandaloneCommand?: boolean;
   showFastModeNotice?: boolean;
@@ -316,7 +327,13 @@ export function ModelPicker(t0) {
         onSelect(null, selectedEffort);
         return;
       }
-      onSelect(selectedValue, selectedEffort);
+      // Thread the selected option's cross-profile marker (issue #1119) so the
+      // /model command activates a provider only for a genuine switch option,
+      // never for a literal custom id that merely starts with the prefix.
+      // selectOptions is already captured in this memo's deps, and its entries
+      // spread the source ModelOption's `switchToProfileId`.
+      const selectedSwitchProfileId = selectOptions.find(o => o.value === selectedValue)?.switchToProfileId;
+      onSelect(selectedValue, selectedEffort, selectedSwitchProfileId);
     };
     $[35] = effort;
     $[36] = hasToggledEffort;
@@ -465,6 +482,18 @@ function _temp2(s_0) {
 function _temp(s) {
   return isFastModeEnabled() ? s.fastMode : false;
 }
+// A picker value is a genuine cross-profile switch only when a synthesized
+// option with that exact value carries the `switchToProfileId` marker. A
+// literal custom model id that merely starts with `__switch_profile__:` is a
+// plain option with no marker and must NOT be decoded — otherwise the display
+// resolver would strip a real model id down to its `:`-tail. getModelOptions()
+// is the authority for the switch options (they only appear in the base list,
+// never in a discovery override, and discovered ids never carry the prefix).
+function isGenuineSwitchProfileValue(value: string): boolean {
+  return getModelOptions().some(
+    opt => opt.value === value && opt.switchToProfileId !== undefined,
+  );
+}
 function resolveOptionModel(value?: string): string | undefined {
   if (!value) return undefined;
   if (value === NO_PREFERENCE) return getDefaultMainLoopModel();
@@ -472,8 +501,11 @@ function resolveOptionModel(value?: string): string | undefined {
   // `__switch_profile__:<profileId>:<model>`. Effort / display logic needs
   // the bare target model id (e.g. `gpt-5.4`) — otherwise
   // `modelSupportsEffort` sees the prefixed string and reports
-  // "Effort not supported" even for reasoning-capable models.
-  const switched = parseSwitchProfileValue(value);
+  // "Effort not supported" even for reasoning-capable models. Decode only when
+  // the value is a genuine marker-backed switch option, not any prefixed id.
+  const switched = isGenuineSwitchProfileValue(value)
+    ? parseSwitchProfileValue(value)
+    : null;
   return parseUserSpecifiedModel(switched ? switched.model : value);
 }
 function EffortLevelIndicator(t0) {

--- a/src/components/ModelPicker.tsx
+++ b/src/components/ModelPicker.tsx
@@ -11,7 +11,7 @@ import { useAppState, useSetAppState } from '../state/AppState.js';
 import { convertEffortValueToLevel, type EffortLevel, getAvailableEffortLevels, getDefaultEffortForModel, modelSupportsEffort, modelSupportsMaxEffort, resolvePickerEffortPersistence, toPersistableEffort } from '../utils/effort.js';
 import { isModelAllowed } from '../utils/model/modelAllowlist.js';
 import { getDefaultMainLoopModel, type ModelSetting, modelDisplayString, parseUserSpecifiedModel } from '../utils/model/model.js';
-import { getModelOptions, type ModelOption, parseSwitchProfileValue, SWITCH_PROFILE_VALUE_PREFIX } from '../utils/model/modelOptions.js';
+import { getModelOptions, type ModelOption, parseSwitchProfileValue } from '../utils/model/modelOptions.js';
 import { getSettingsForSource, updateSettingsForSource } from '../utils/settings/settings.js';
 import { ConfigurableShortcutHint } from './ConfigurableShortcutHint.js';
 import { Select } from './CustomSelect/index.js';
@@ -126,13 +126,11 @@ export function ModelPicker(t0) {
   // onSelect, which decodes the value and activates the target profile. Strip
   // them for inline pickers (allowProfileSwitch falsy) so a hotkey/Settings
   // selection never writes the raw `__switch_profile__:...` value as a model.
+  // Key on the `switchToProfileId` marker, not the raw value prefix, so a real
+  // custom model id that merely starts with `__switch_profile__:` is not hidden.
   const modelOptions = allowProfileSwitch
     ? modelOptionsBase
-    : modelOptionsBase.filter(
-        opt =>
-          typeof opt.value !== 'string' ||
-          !opt.value.startsWith(SWITCH_PROFILE_VALUE_PREFIX),
-      );
+    : modelOptionsBase.filter(opt => opt.switchToProfileId === undefined);
   let t4;
   bb0: {
     if (initial !== null && isModelAllowed(initial) && !modelOptions.some(opt => optionMatchesPickerValue(opt, initial))) {

--- a/src/components/ModelPicker.tsx
+++ b/src/components/ModelPicker.tsx
@@ -10,7 +10,7 @@ import { useKeybindings } from '../keybindings/useKeybinding.js';
 import { useAppState, useSetAppState } from '../state/AppState.js';
 import { convertEffortValueToLevel, type EffortLevel, getDefaultEffortForModel, modelSupportsEffort, modelSupportsMaxEffort, resolvePickerEffortPersistence, toPersistableEffort } from '../utils/effort.js';
 import { getDefaultMainLoopModel, type ModelSetting, modelDisplayString, parseUserSpecifiedModel } from '../utils/model/model.js';
-import { getModelOptions, type ModelOption } from '../utils/model/modelOptions.js';
+import { getModelOptions, type ModelOption, parseSwitchProfileValue } from '../utils/model/modelOptions.js';
 import { getSettingsForSource, updateSettingsForSource } from '../utils/settings/settings.js';
 import { ConfigurableShortcutHint } from './ConfigurableShortcutHint.js';
 import { Select } from './CustomSelect/index.js';
@@ -414,7 +414,14 @@ function _temp(s) {
 }
 function resolveOptionModel(value?: string): string | undefined {
   if (!value) return undefined;
-  return value === NO_PREFERENCE ? getDefaultMainLoopModel() : parseUserSpecifiedModel(value);
+  if (value === NO_PREFERENCE) return getDefaultMainLoopModel();
+  // Cross-profile entries from /model encode the picker value as
+  // `__switch_profile__:<profileId>:<model>`. Effort / display logic needs
+  // the bare target model id (e.g. `gpt-5.4`) — otherwise
+  // `modelSupportsEffort` sees the prefixed string and reports
+  // "Effort not supported" even for reasoning-capable models.
+  const switched = parseSwitchProfileValue(value);
+  return parseUserSpecifiedModel(switched ? switched.model : value);
 }
 function EffortLevelIndicator(t0) {
   const $ = _c(5);

--- a/src/components/ModelPicker.tsx
+++ b/src/components/ModelPicker.tsx
@@ -11,7 +11,7 @@ import { useAppState, useSetAppState } from '../state/AppState.js';
 import { convertEffortValueToLevel, type EffortLevel, getAvailableEffortLevels, getDefaultEffortForModel, modelSupportsEffort, modelSupportsMaxEffort, resolvePickerEffortPersistence, toPersistableEffort } from '../utils/effort.js';
 import { isModelAllowed } from '../utils/model/modelAllowlist.js';
 import { getDefaultMainLoopModel, type ModelSetting, modelDisplayString, parseUserSpecifiedModel } from '../utils/model/model.js';
-import { getModelOptions, type ModelOption, parseSwitchProfileValue } from '../utils/model/modelOptions.js';
+import { getModelOptions, type ModelOption, parseSwitchProfileValue, SWITCH_PROFILE_VALUE_PREFIX } from '../utils/model/modelOptions.js';
 import { getSettingsForSource, updateSettingsForSource } from '../utils/settings/settings.js';
 import { ConfigurableShortcutHint } from './ConfigurableShortcutHint.js';
 import { Select } from './CustomSelect/index.js';
@@ -42,6 +42,14 @@ export type Props = {
   optionsOverride?: ModelOption[];
   discoveryState?: ModelPickerDiscoveryState;
   onRefresh?: () => void;
+  /**
+   * Allow cross-profile "switch profile" options (issue #1119) to appear in the
+   * list. These carry an encoded `__switch_profile__:<id>:<model>` value that
+   * only the `/model` command's onSelect knows how to activate. Inline pickers
+   * (prompt hotkey, Settings) that write the raw value to `mainLoopModel` must
+   * leave this off so they never surface an option they cannot honor.
+   */
+  allowProfileSwitch?: boolean;
 };
 const NO_PREFERENCE = '__NO_PREFERENCE__';
 function normalizeModelPickerValue(value: unknown): string | null {
@@ -86,7 +94,8 @@ export function ModelPicker(t0) {
     skipSettingsWrite,
     optionsOverride,
     discoveryState,
-    onRefresh
+    onRefresh,
+    allowProfileSwitch
   } = t0;
   const setAppState = useSetAppState();
   const exitState = useExitOnCtrlCDWithKeybindings();
@@ -112,7 +121,18 @@ export function ModelPicker(t0) {
   } else {
     t3 = $[3];
   }
-  const modelOptions = optionsOverride ?? t3;
+  const modelOptionsBase = optionsOverride ?? t3;
+  // Cross-profile switch options can only be honored by the /model command's
+  // onSelect, which decodes the value and activates the target profile. Strip
+  // them for inline pickers (allowProfileSwitch falsy) so a hotkey/Settings
+  // selection never writes the raw `__switch_profile__:...` value as a model.
+  const modelOptions = allowProfileSwitch
+    ? modelOptionsBase
+    : modelOptionsBase.filter(
+        opt =>
+          typeof opt.value !== 'string' ||
+          !opt.value.startsWith(SWITCH_PROFILE_VALUE_PREFIX),
+      );
   let t4;
   bb0: {
     if (initial !== null && isModelAllowed(initial) && !modelOptions.some(opt => optionMatchesPickerValue(opt, initial))) {

--- a/src/components/ModelPicker.tsx
+++ b/src/components/ModelPicker.tsx
@@ -11,7 +11,7 @@ import { useAppState, useSetAppState } from '../state/AppState.js';
 import { convertEffortValueToLevel, type EffortLevel, getAvailableEffortLevels, getDefaultEffortForModel, modelSupportsEffort, modelSupportsMaxEffort, resolvePickerEffortPersistence, toPersistableEffort } from '../utils/effort.js';
 import { isModelAllowed } from '../utils/model/modelAllowlist.js';
 import { getDefaultMainLoopModel, type ModelSetting, modelDisplayString, parseUserSpecifiedModel } from '../utils/model/model.js';
-import { getModelOptions, type ModelOption } from '../utils/model/modelOptions.js';
+import { getModelOptions, type ModelOption, parseSwitchProfileValue } from '../utils/model/modelOptions.js';
 import { getSettingsForSource, updateSettingsForSource } from '../utils/settings/settings.js';
 import { ConfigurableShortcutHint } from './ConfigurableShortcutHint.js';
 import { Select } from './CustomSelect/index.js';
@@ -449,7 +449,14 @@ function _temp(s) {
 }
 function resolveOptionModel(value?: string): string | undefined {
   if (!value) return undefined;
-  return value === NO_PREFERENCE ? getDefaultMainLoopModel() : parseUserSpecifiedModel(value);
+  if (value === NO_PREFERENCE) return getDefaultMainLoopModel();
+  // Cross-profile entries from /model encode the picker value as
+  // `__switch_profile__:<profileId>:<model>`. Effort / display logic needs
+  // the bare target model id (e.g. `gpt-5.4`) — otherwise
+  // `modelSupportsEffort` sees the prefixed string and reports
+  // "Effort not supported" even for reasoning-capable models.
+  const switched = parseSwitchProfileValue(value);
+  return parseUserSpecifiedModel(switched ? switched.model : value);
 }
 function EffortLevelIndicator(t0) {
   const $ = _c(5);

--- a/src/utils/model/modelOptions.crossProfile.test.ts
+++ b/src/utils/model/modelOptions.crossProfile.test.ts
@@ -22,6 +22,8 @@ import * as actualSettings from '../settings/settings.js'
 import * as actualModelAllowlist from './modelAllowlist.js'
 import * as actualOllamaModels from './ollamaModels.js'
 import * as actualNvidiaModels from './nvidiaNimModels.js'
+import * as actualMiniMaxModels from './minimaxModels.js'
+import * as actualXiaomiModels from './xiaomi-mimoModels.js'
 import type { ModelOption } from './modelOptions.js'
 import type { ProviderProfile } from '../config.js'
 import type { SettingsJson } from '../settings/types.js'
@@ -37,6 +39,8 @@ const realSettings = { ...actualSettings }
 const realModelAllowlist = { ...actualModelAllowlist }
 const realOllamaModels = { ...actualOllamaModels }
 const realNvidiaModels = { ...actualNvidiaModels }
+const realMiniMaxModels = { ...actualMiniMaxModels }
+const realXiaomiModels = { ...actualXiaomiModels }
 
 // bun's mock.module is process-wide and mock.restore() does NOT undo it, so
 // per-test mocks installed in a harness would persist and leak into later
@@ -72,6 +76,9 @@ let activeNvidiaOverride: { cachedModels: ModelOption[] } | null = null
 // Flips the Claude subscriber branch on (and optionally Max tier). Gated so it
 // doesn't leak subscriber state into sibling suites.
 let activeSubscriberOverride: { max?: boolean } | null = null
+// Drive the MiniMax / Xiaomi MiMo catalog early-return branches. Gated + passthrough.
+let activeMiniMaxOverride: { cachedModels: ModelOption[] } | null = null
+let activeXiaomiOverride: { cachedModels: ModelOption[] } | null = null
 
 mock.module('./ollamaModels.js', () => ({
   ...realOllamaModels,
@@ -91,6 +98,26 @@ mock.module('./nvidiaNimModels.js', () => ({
     activeNvidiaOverride
       ? activeNvidiaOverride.cachedModels
       : realNvidiaModels.getCachedNvidiaNimModelOptions(),
+}))
+
+mock.module('./minimaxModels.js', () => ({
+  ...realMiniMaxModels,
+  isMiniMaxProvider: () =>
+    activeMiniMaxOverride ? true : realMiniMaxModels.isMiniMaxProvider(),
+  getCachedMiniMaxModelOptions: () =>
+    activeMiniMaxOverride
+      ? activeMiniMaxOverride.cachedModels
+      : realMiniMaxModels.getCachedMiniMaxModelOptions(),
+}))
+
+mock.module('./xiaomi-mimoModels.js', () => ({
+  ...realXiaomiModels,
+  isXiaomiMimoProvider: () =>
+    activeXiaomiOverride ? true : realXiaomiModels.isXiaomiMimoProvider(),
+  getCachedXiaomiMimoModelOptions: () =>
+    activeXiaomiOverride
+      ? activeXiaomiOverride.cachedModels
+      : realXiaomiModels.getCachedXiaomiMimoModelOptions(),
 }))
 
 mock.module('../settings/settings.js', () => ({
@@ -202,6 +229,8 @@ beforeEach(() => {
   activeApiProviderOverride = null
   activeNvidiaOverride = null
   activeSubscriberOverride = null
+  activeMiniMaxOverride = null
+  activeXiaomiOverride = null
   setSessionSettingsCache({ settings: {}, errors: [] })
   resetModelStringsForTestingOnly()
 })
@@ -216,6 +245,8 @@ afterEach(() => {
   activeApiProviderOverride = null
   activeNvidiaOverride = null
   activeSubscriberOverride = null
+  activeMiniMaxOverride = null
+  activeXiaomiOverride = null
   resetSettingsCache()
   resetModelStringsForTestingOnly()
 })
@@ -695,6 +726,81 @@ test('getModelOptionsBase: Claude subscriber branch appends inactive profile opt
         .map(o => o.switchToProfileId),
     ).toContain('profile_remote')
   })
+})
+
+test('getModelOptionsBase: MiniMax catalog branch appends inactive profile options', async () => {
+  const { active, inactive } = activeAndInactivePair()
+  activeMiniMaxOverride = {
+    cachedModels: [
+      { value: 'MiniMax-M2.7', label: 'MiniMax-M2.7', description: 'MiniMax' },
+    ],
+  }
+  await withProfileEnvApplied(async () => {
+    const { getModelOptions } = await importFreshModelOptionsModule({
+      getProviderProfiles: () => [active, inactive],
+      getActiveProviderProfile: () => active,
+      getProfileModelOptions: profile => [
+        { value: profile.model, label: profile.model, description: profile.name },
+      ],
+    })
+    const options = getModelOptions(false)
+    expect(options.some(o => o.value === 'MiniMax-M2.7')).toBe(true)
+    expect(
+      options
+        .filter(o => o.switchToProfileId !== undefined)
+        .map(o => o.switchToProfileId),
+    ).toContain('profile_remote')
+  })
+})
+
+test('getModelOptionsBase: Xiaomi MiMo catalog branch appends inactive profile options', async () => {
+  const { active, inactive } = activeAndInactivePair()
+  activeXiaomiOverride = {
+    cachedModels: [
+      { value: 'mimo-v2.5-pro', label: 'mimo-v2.5-pro', description: 'MiMo' },
+    ],
+  }
+  await withProfileEnvApplied(async () => {
+    const { getModelOptions } = await importFreshModelOptionsModule({
+      getProviderProfiles: () => [active, inactive],
+      getActiveProviderProfile: () => active,
+      getProfileModelOptions: profile => [
+        { value: profile.model, label: profile.model, description: profile.name },
+      ],
+    })
+    const options = getModelOptions(false)
+    expect(options.some(o => o.value === 'mimo-v2.5-pro')).toBe(true)
+    expect(
+      options
+        .filter(o => o.switchToProfileId !== undefined)
+        .map(o => o.switchToProfileId),
+    ).toContain('profile_remote')
+  })
+})
+
+test('getModelOptionsBase: ant branch appends inactive profile options', async () => {
+  const { active, inactive } = activeAndInactivePair()
+  const prevUserType = process.env.USER_TYPE
+  process.env.USER_TYPE = 'ant'
+  try {
+    await withProfileEnvApplied(async () => {
+      const { getModelOptions } = await importFreshModelOptionsModule({
+        getProviderProfiles: () => [active, inactive],
+        getActiveProviderProfile: () => active,
+        getProfileModelOptions: profile => [
+          { value: profile.model, label: profile.model, description: profile.name },
+        ],
+      })
+      expect(
+        getModelOptions(false)
+          .filter(o => o.switchToProfileId !== undefined)
+          .map(o => o.switchToProfileId),
+      ).toContain('profile_remote')
+    })
+  } finally {
+    if (prevUserType === undefined) delete process.env.USER_TYPE
+    else process.env.USER_TYPE = prevUserType
+  }
 })
 
 test('getModelOptions: allowlist checks a non-switch custom id verbatim, not decoded', async () => {

--- a/src/utils/model/modelOptions.crossProfile.test.ts
+++ b/src/utils/model/modelOptions.crossProfile.test.ts
@@ -18,7 +18,10 @@ import * as actualProviderProfiles from '../providerProfiles.js'
 import * as actualProviders from './providers.js'
 import * as actualAuth from '../auth.js'
 import * as actualProviderConfig from '../../services/api/providerConfig.js'
+import * as actualSettings from '../settings/settings.js'
+import * as actualModelAllowlist from './modelAllowlist.js'
 import type { ProviderProfile } from '../config.js'
+import type { SettingsJson } from '../settings/types.js'
 
 // Snapshot the real modules before any mock.module runs. bun live-repoints the
 // `actual*` namespaces to the active mock, so these plain-object copies are the
@@ -27,6 +30,8 @@ const realProviderProfiles = { ...actualProviderProfiles }
 const realProviders = { ...actualProviders }
 const realAuth = { ...actualAuth }
 const realProviderConfig = { ...actualProviderConfig }
+const realSettings = { ...actualSettings }
+const realModelAllowlist = { ...actualModelAllowlist }
 
 // bun's mock.module is process-wide and mock.restore() does NOT undo it, so
 // per-test mocks installed in a harness would persist and leak into later
@@ -42,6 +47,31 @@ let activeProfilesOverride: Partial<typeof actualProviderProfiles> | null = null
 // providerConfig surface so the persisted mock doesn't strip resolveProviderRequest
 // etc. from later suites (e.g. providerConfig.local).
 let activeCacheScopeOverride: string | null = null
+// Overrides getSettings_DEPRECATED (read by BOTH the filterModelOptionsByAllowlist
+// gate in modelOptions.ts AND isModelAllowed in modelAllowlist.js) only while an
+// allowlist test sets it. Many sibling suites (ModelPicker/ProviderManager/...)
+// mock.module('../settings/settings.js') process-wide, which defeats
+// setSessionSettingsCache, so drive the allowlist deterministically here rather
+// than through the shared settings cache. Gated + passthrough so it doesn't leak.
+let activeSettingsOverride: SettingsJson | null = null
+
+mock.module('../settings/settings.js', () => ({
+  ...realSettings,
+  getSettings_DEPRECATED: () =>
+    activeSettingsOverride ?? realSettings.getSettings_DEPRECATED(),
+}))
+
+// Sibling suites (ModelPicker/...) also mock modelAllowlist's isModelAllowed
+// process-wide, so override it here too (gated + passthrough) and drive it from
+// the same activeSettingsOverride allowlist, matching the gate above. Mirrors
+// the agent.test.ts allowlist pattern.
+mock.module('./modelAllowlist.js', () => ({
+  ...realModelAllowlist,
+  isModelAllowed: (model: string) => {
+    const allowlist = activeSettingsOverride?.availableModels
+    return allowlist ? allowlist.includes(model) : realModelAllowlist.isModelAllowed(model)
+  },
+}))
 
 mock.module('../../services/api/providerConfig.js', () => ({
   ...realProviderConfig,
@@ -124,15 +154,17 @@ async function importFreshModelOptionsModule(
 beforeEach(() => {
   activeProfilesOverride = null
   activeCacheScopeOverride = null
+  activeSettingsOverride = null
   setSessionSettingsCache({ settings: {}, errors: [] })
   resetModelStringsForTestingOnly()
 })
 
 afterEach(() => {
-  // Clear the gates so the persisted provider/auth/profile/providerConfig mocks
-  // fall through to the real implementations for every later suite.
+  // Clear the gates so the persisted provider/auth/profile/providerConfig/settings
+  // mocks fall through to the real implementations for every later suite.
   activeProfilesOverride = null
   activeCacheScopeOverride = null
+  activeSettingsOverride = null
   resetSettingsCache()
   resetModelStringsForTestingOnly()
 })
@@ -427,10 +459,11 @@ test('getModelOptions: allowlist filters cross-profile options by the decoded ta
   })
 
   // Only glm-5.1 (and the active model) are permitted; blocked-model is not.
-  setSessionSettingsCache({
-    settings: { availableModels: ['kimi-k2.6', 'glm-5.1'] },
-    errors: [],
-  })
+  // Drive the allowlist through the gated getSettings_DEPRECATED override so it
+  // is immune to sibling suites that mock the settings module process-wide.
+  activeSettingsOverride = {
+    availableModels: ['kimi-k2.6', 'glm-5.1'],
+  } as SettingsJson
 
   const previousFlag = process.env.CLAUDE_CODE_PROVIDER_PROFILE_ENV_APPLIED
   process.env.CLAUDE_CODE_PROVIDER_PROFILE_ENV_APPLIED = '1'

--- a/src/utils/model/modelOptions.crossProfile.test.ts
+++ b/src/utils/model/modelOptions.crossProfile.test.ts
@@ -399,3 +399,63 @@ test('getModelOptionsBase: 3P path omits inactive profile options when env NOT a
     }
   }
 })
+
+test('getModelOptions: allowlist filters cross-profile options by the decoded target model', async () => {
+  // Regression for #1119: filterModelOptionsByAllowlist must evaluate the
+  // allowlist against the decoded target model (parseSwitchProfileValue(value).model),
+  // not the raw `__switch_profile__:<id>:<model>` wrapper. An allowed cross-profile
+  // model must stay; a denied one must drop. Uses this suite's per-test isolated
+  // settings cache (set below, reset in afterEach) rather than the shared cache
+  // that made the earlier version flaky.
+  const active = buildProviderProfileFixture({
+    id: 'profile_active',
+    name: 'Active',
+    baseUrl: 'https://api.kimi.com/coding/',
+    model: 'kimi-k2.6',
+  })
+  const allowedInactive = buildProviderProfileFixture({
+    id: 'profile_allowed',
+    name: 'GLM',
+    baseUrl: 'https://api.z.ai/api/anthropic',
+    model: 'glm-5.1',
+  })
+  const deniedInactive = buildProviderProfileFixture({
+    id: 'profile_denied',
+    name: 'Blocked',
+    baseUrl: 'https://blocked.example/v1',
+    model: 'blocked-model',
+  })
+
+  // Only glm-5.1 (and the active model) are permitted; blocked-model is not.
+  setSessionSettingsCache({
+    settings: { availableModels: ['kimi-k2.6', 'glm-5.1'] },
+    errors: [],
+  })
+
+  const previousFlag = process.env.CLAUDE_CODE_PROVIDER_PROFILE_ENV_APPLIED
+  process.env.CLAUDE_CODE_PROVIDER_PROFILE_ENV_APPLIED = '1'
+  try {
+    const { getModelOptions } = await importFreshModelOptionsModule({
+      getProviderProfiles: () => [active, allowedInactive, deniedInactive],
+      getActiveProviderProfile: () => active,
+      getProfileModelOptions: profile => [
+        { value: profile.model, label: profile.model, description: profile.name },
+      ],
+    })
+
+    const switchTargets = getModelOptions(false)
+      .filter(o => o.switchToProfileId !== undefined)
+      .map(o => o.switchToProfileId)
+
+    // Allowed cross-profile model kept; denied one filtered out by the decoded
+    // (not the encoded) model id.
+    expect(switchTargets).toContain('profile_allowed')
+    expect(switchTargets).not.toContain('profile_denied')
+  } finally {
+    if (previousFlag === undefined) {
+      delete process.env.CLAUDE_CODE_PROVIDER_PROFILE_ENV_APPLIED
+    } else {
+      process.env.CLAUDE_CODE_PROVIDER_PROFILE_ENV_APPLIED = previousFlag
+    }
+  }
+})

--- a/src/utils/model/modelOptions.crossProfile.test.ts
+++ b/src/utils/model/modelOptions.crossProfile.test.ts
@@ -803,6 +803,92 @@ test('getModelOptionsBase: ant branch appends inactive profile options', async (
   }
 })
 
+test('getModelOptionsBase: Max/Team Premium subscriber branch appends inactive profile options', async () => {
+  // The Pro/standard subscriber branch is covered above; this locks the
+  // separate Max / Team Premium early return (isMaxSubscriber ||
+  // isTeamPremiumSubscriber), which builds its own premiumOptions array and
+  // must push ...inactiveProfileOptions before returning.
+  const { active, inactive } = activeAndInactivePair()
+  activeSubscriberOverride = { max: true }
+  await withProfileEnvApplied(async () => {
+    const { getModelOptions } = await importFreshModelOptionsModule({
+      getProviderProfiles: () => [active, inactive],
+      getActiveProviderProfile: () => active,
+      getProfileModelOptions: profile => [
+        { value: profile.model, label: profile.model, description: profile.name },
+      ],
+    })
+    expect(
+      getModelOptions(false)
+        .filter(o => o.switchToProfileId !== undefined)
+        .map(o => o.switchToProfileId),
+    ).toContain('profile_remote')
+  })
+})
+
+test('getModelOptionsBase: NVIDIA NIM empty-catalog fallback still appends inactive profile options', async () => {
+  // The catalog branch above exercises the non-empty return; this locks the
+  // `[defaultOption, ...inactiveProfileOptions]` fallback taken when the cached
+  // catalog is empty, which previously dropped the inactive switch options.
+  const { active, inactive } = activeAndInactivePair()
+  activeNvidiaOverride = { cachedModels: [] }
+  await withProfileEnvApplied(async () => {
+    const { getModelOptions } = await importFreshModelOptionsModule({
+      getProviderProfiles: () => [active, inactive],
+      getActiveProviderProfile: () => active,
+      getProfileModelOptions: profile => [
+        { value: profile.model, label: profile.model, description: profile.name },
+      ],
+    })
+    const options = getModelOptions(false)
+    // No catalog model surfaced, but the inactive switcher is still restored.
+    expect(options.some(o => o.value === 'nvidia/model')).toBe(false)
+    expect(
+      options
+        .filter(o => o.switchToProfileId !== undefined)
+        .map(o => o.switchToProfileId),
+    ).toContain('profile_remote')
+  })
+})
+
+test('getModelOptionsBase: MiniMax empty-catalog fallback still appends inactive profile options', async () => {
+  const { active, inactive } = activeAndInactivePair()
+  activeMiniMaxOverride = { cachedModels: [] }
+  await withProfileEnvApplied(async () => {
+    const { getModelOptions } = await importFreshModelOptionsModule({
+      getProviderProfiles: () => [active, inactive],
+      getActiveProviderProfile: () => active,
+      getProfileModelOptions: profile => [
+        { value: profile.model, label: profile.model, description: profile.name },
+      ],
+    })
+    expect(
+      getModelOptions(false)
+        .filter(o => o.switchToProfileId !== undefined)
+        .map(o => o.switchToProfileId),
+    ).toContain('profile_remote')
+  })
+})
+
+test('getModelOptionsBase: Xiaomi MiMo empty-catalog fallback still appends inactive profile options', async () => {
+  const { active, inactive } = activeAndInactivePair()
+  activeXiaomiOverride = { cachedModels: [] }
+  await withProfileEnvApplied(async () => {
+    const { getModelOptions } = await importFreshModelOptionsModule({
+      getProviderProfiles: () => [active, inactive],
+      getActiveProviderProfile: () => active,
+      getProfileModelOptions: profile => [
+        { value: profile.model, label: profile.model, description: profile.name },
+      ],
+    })
+    expect(
+      getModelOptions(false)
+        .filter(o => o.switchToProfileId !== undefined)
+        .map(o => o.switchToProfileId),
+    ).toContain('profile_remote')
+  })
+})
+
 test('getModelOptions: allowlist checks a non-switch custom id verbatim, not decoded', async () => {
   // Regression for #1164 [P2]: filterModelOptionsByAllowlist must only decode
   // genuine switch options (identified by `switchToProfileId`), not any string

--- a/src/utils/model/modelOptions.crossProfile.test.ts
+++ b/src/utils/model/modelOptions.crossProfile.test.ts
@@ -17,17 +17,87 @@ import {
 import * as actualProviderProfiles from '../providerProfiles.js'
 import * as actualProviders from './providers.js'
 import * as actualAuth from '../auth.js'
+import * as actualProviderConfig from '../../services/api/providerConfig.js'
 import type { ProviderProfile } from '../config.js'
 
 // Snapshot the real modules before any mock.module runs. bun live-repoints the
-// `actual*` namespaces to the active mock once a per-test mock.module is
-// installed, so a later harness call spreading `...actualProviders` would copy a
-// stale mock (with the previous test's overrides) rather than the genuine
-// module. These plain-object copies are the stable handle used to build the
-// mocks from a clean base each call.
+// `actual*` namespaces to the active mock, so these plain-object copies are the
+// stable handle on the genuine implementations.
 const realProviderProfiles = { ...actualProviderProfiles }
 const realProviders = { ...actualProviders }
 const realAuth = { ...actualAuth }
+const realProviderConfig = { ...actualProviderConfig }
+
+// bun's mock.module is process-wide and mock.restore() does NOT undo it, so
+// per-test mocks installed in a harness would persist and leak into later
+// suites (e.g. providerConfig's cache-scope tests reading a pinned
+// getAPIProvider). Instead install each mock ONCE here, gated on this flag, and
+// delegate to the real implementation whenever a cross-profile test is not
+// actively running. afterEach clears the flag, so the persisted mock becomes a
+// transparent passthrough for every other file. Same pattern as the
+// cross-spawn/file-suggestions leak fix (#1667).
+let activeProfilesOverride: Partial<typeof actualProviderProfiles> | null = null
+// Overrides getAdditionalModelOptionsCacheScope (used by getModelOptions to pick
+// the openai-scope branch) only while a test sets it. Keeps the full
+// providerConfig surface so the persisted mock doesn't strip resolveProviderRequest
+// etc. from later suites (e.g. providerConfig.local).
+let activeCacheScopeOverride: string | null = null
+
+mock.module('../../services/api/providerConfig.js', () => ({
+  ...realProviderConfig,
+  getAdditionalModelOptionsCacheScope: () =>
+    activeCacheScopeOverride ??
+    realProviderConfig.getAdditionalModelOptionsCacheScope(),
+}))
+
+mock.module('../providerProfiles.js', () => ({
+  ...realProviderProfiles,
+  getProviderProfiles: (...args: Parameters<typeof realProviderProfiles.getProviderProfiles>) =>
+    (activeProfilesOverride?.getProviderProfiles ??
+      realProviderProfiles.getProviderProfiles)(...args),
+  getActiveProviderProfile: (...args: Parameters<typeof realProviderProfiles.getActiveProviderProfile>) =>
+    (activeProfilesOverride?.getActiveProviderProfile ??
+      realProviderProfiles.getActiveProviderProfile)(...args),
+  getProfileModelOptions: (...args: Parameters<typeof realProviderProfiles.getProfileModelOptions>) =>
+    (activeProfilesOverride?.getProfileModelOptions ??
+      realProviderProfiles.getProfileModelOptions)(...args),
+}))
+
+// The 3P path reads getAPIProvider + subscriber checks; pin them to a stable
+// 3P-openai non-subscriber shape only while a cross-profile test is active.
+mock.module('./providers.js', () => ({
+  ...realProviders,
+  getAPIProvider: () =>
+    activeProfilesOverride ? 'openai' : realProviders.getAPIProvider(),
+  getAPIProviderForStatsig: () =>
+    activeProfilesOverride
+      ? 'openai'
+      : realProviders.getAPIProviderForStatsig(),
+  isFirstPartyAnthropicBaseUrl: (...args: Parameters<typeof realProviders.isFirstPartyAnthropicBaseUrl>) =>
+    activeProfilesOverride
+      ? false
+      : realProviders.isFirstPartyAnthropicBaseUrl(...args),
+  isGithubNativeAnthropicMode: (...args: Parameters<typeof realProviders.isGithubNativeAnthropicMode>) =>
+    activeProfilesOverride
+      ? false
+      : realProviders.isGithubNativeAnthropicMode(...args),
+  usesAnthropicAccountFlow: (...args: Parameters<typeof realProviders.usesAnthropicAccountFlow>) =>
+    activeProfilesOverride
+      ? false
+      : realProviders.usesAnthropicAccountFlow(...args),
+}))
+
+mock.module('../auth.js', () => ({
+  ...realAuth,
+  isClaudeAISubscriber: (...args: Parameters<typeof realAuth.isClaudeAISubscriber>) =>
+    activeProfilesOverride ? false : realAuth.isClaudeAISubscriber(...args),
+  isMaxSubscriber: (...args: Parameters<typeof realAuth.isMaxSubscriber>) =>
+    activeProfilesOverride ? false : realAuth.isMaxSubscriber(...args),
+  isTeamPremiumSubscriber: (...args: Parameters<typeof realAuth.isTeamPremiumSubscriber>) =>
+    activeProfilesOverride
+      ? false
+      : realAuth.isTeamPremiumSubscriber(...args),
+}))
 
 function buildProviderProfileFixture(
   overrides: Partial<ProviderProfile> = {},
@@ -46,43 +116,23 @@ function buildProviderProfileFixture(
 async function importFreshModelOptionsModule(
   providerProfilesMock: Partial<typeof actualProviderProfiles>,
 ) {
-  mock.restore()
-  mock.module('../providerProfiles.js', () => ({
-    ...realProviderProfiles,
-    ...providerProfilesMock,
-  }))
-  // The 3P path also reads getAPIProvider and a handful of subscriber checks;
-  // pin them to a stable 3P-openai shape so the picker exercises the inactive
-  // profile branch we care about.
-  mock.module('./providers.js', () => ({
-    ...realProviders,
-    getAPIProvider: () => 'openai',
-    getAPIProviderForStatsig: () => 'openai',
-    isFirstPartyAnthropicBaseUrl: () => false,
-    isGithubNativeAnthropicMode: () => false,
-    usesAnthropicAccountFlow: () => false,
-  }))
-  // Subscriber checks short-circuit the 3P path with a Claude.AI-shaped option
-  // list and never reach the inactive-profile append. Pin to non-subscriber
-  // for these tests so the openai 3P branch runs end-to-end.
-  mock.module('../auth.js', () => ({
-    ...realAuth,
-    isClaudeAISubscriber: () => false,
-    isMaxSubscriber: () => false,
-    isTeamPremiumSubscriber: () => false,
-  }))
+  activeProfilesOverride = providerProfilesMock
   const nonce = `${Date.now()}-${Math.random()}`
   return import(`./modelOptions.js?ts=${nonce}`)
 }
 
 beforeEach(() => {
-  mock.restore()
+  activeProfilesOverride = null
+  activeCacheScopeOverride = null
   setSessionSettingsCache({ settings: {}, errors: [] })
   resetModelStringsForTestingOnly()
 })
 
 afterEach(() => {
-  mock.restore()
+  // Clear the gates so the persisted provider/auth/profile/providerConfig mocks
+  // fall through to the real implementations for every later suite.
+  activeProfilesOverride = null
+  activeCacheScopeOverride = null
   resetSettingsCache()
   resetModelStringsForTestingOnly()
 })
@@ -291,11 +341,9 @@ test('getModelOptionsBase: local OpenAI-compatible scope still appends inactive 
   const previousFlag = process.env.CLAUDE_CODE_PROVIDER_PROFILE_ENV_APPLIED
   process.env.CLAUDE_CODE_PROVIDER_PROFILE_ENV_APPLIED = '1'
   // Force the local OpenAI-compatible branch by pinning the scope getter to
-  // an `openai:` value. The real source reads the global config; we override
-  // it directly to keep the test hermetic.
-  mock.module('../../services/api/providerConfig.js', () => ({
-    getAdditionalModelOptionsCacheScope: () => 'openai:http://localhost:11434/v1',
-  }))
+  // an `openai:` value (via the gated override installed at module load, which
+  // keeps the rest of providerConfig real so it can't leak into other suites).
+  activeCacheScopeOverride = 'openai:http://localhost:11434/v1'
   try {
     const { getModelOptions, parseSwitchProfileValue } =
       await importFreshModelOptionsModule({

--- a/src/utils/model/modelOptions.crossProfile.test.ts
+++ b/src/utils/model/modelOptions.crossProfile.test.ts
@@ -19,6 +19,16 @@ import * as actualProviders from './providers.js'
 import * as actualAuth from '../auth.js'
 import type { ProviderProfile } from '../config.js'
 
+// Snapshot the real modules before any mock.module runs. bun live-repoints the
+// `actual*` namespaces to the active mock once a per-test mock.module is
+// installed, so a later harness call spreading `...actualProviders` would copy a
+// stale mock (with the previous test's overrides) rather than the genuine
+// module. These plain-object copies are the stable handle used to build the
+// mocks from a clean base each call.
+const realProviderProfiles = { ...actualProviderProfiles }
+const realProviders = { ...actualProviders }
+const realAuth = { ...actualAuth }
+
 function buildProviderProfileFixture(
   overrides: Partial<ProviderProfile> = {},
 ): ProviderProfile {
@@ -38,14 +48,14 @@ async function importFreshModelOptionsModule(
 ) {
   mock.restore()
   mock.module('../providerProfiles.js', () => ({
-    ...actualProviderProfiles,
+    ...realProviderProfiles,
     ...providerProfilesMock,
   }))
   // The 3P path also reads getAPIProvider and a handful of subscriber checks;
   // pin them to a stable 3P-openai shape so the picker exercises the inactive
   // profile branch we care about.
   mock.module('./providers.js', () => ({
-    ...actualProviders,
+    ...realProviders,
     getAPIProvider: () => 'openai',
     getAPIProviderForStatsig: () => 'openai',
     isFirstPartyAnthropicBaseUrl: () => false,
@@ -56,7 +66,7 @@ async function importFreshModelOptionsModule(
   // list and never reach the inactive-profile append. Pin to non-subscriber
   // for these tests so the openai 3P branch runs end-to-end.
   mock.module('../auth.js', () => ({
-    ...actualAuth,
+    ...realAuth,
     isClaudeAISubscriber: () => false,
     isMaxSubscriber: () => false,
     isTeamPremiumSubscriber: () => false,
@@ -250,69 +260,6 @@ test('getModelOptionsBase: 3P path includes inactive profile options when env ap
       profileId: 'profile_inactive',
       model: 'glm-5.1',
     })
-  } finally {
-    if (previousFlag === undefined) {
-      delete process.env.CLAUDE_CODE_PROVIDER_PROFILE_ENV_APPLIED
-    } else {
-      process.env.CLAUDE_CODE_PROVIDER_PROFILE_ENV_APPLIED = previousFlag
-    }
-  }
-})
-
-test('getModelOptionsBase: allowlist matches the decoded cross-profile model, not the encoded value', async () => {
-  // Regression for #1164 review: the option's value is the encoded
-  // `__switch_profile__:<id>:glm-5.1`. An allowlist that permits the bare model
-  // `glm-5.1` must keep the cross-profile entry (and an allowlist without it
-  // must drop the entry).
-  const active = buildProviderProfileFixture({
-    id: 'profile_active',
-    name: 'Active',
-    model: 'sonnet',
-  })
-  const inactive = buildProviderProfileFixture({
-    id: 'profile_inactive',
-    name: 'GLM',
-    baseUrl: 'https://api.z.ai/api/anthropic',
-    model: 'glm-5.1',
-  })
-
-  const previousFlag = process.env.CLAUDE_CODE_PROVIDER_PROFILE_ENV_APPLIED
-  process.env.CLAUDE_CODE_PROVIDER_PROFILE_ENV_APPLIED = '1'
-  try {
-    setSessionSettingsCache({
-      settings: { availableModels: ['glm-5.1'] },
-      errors: [],
-    })
-    const allowed = await importFreshModelOptionsModule({
-      getProviderProfiles: () => [active, inactive],
-      getActiveProviderProfile: () => active,
-      getProfileModelOptions: profile => [
-        { value: profile.model, label: profile.model, description: profile.name },
-      ],
-    })
-    expect(
-      allowed
-        .getModelOptions(false)
-        .some(o => o.switchToProfileId === 'profile_inactive'),
-    ).toBe(true)
-
-    // Same profile, but the decoded model is not on the allowlist → dropped.
-    setSessionSettingsCache({
-      settings: { availableModels: ['some-other-model'] },
-      errors: [],
-    })
-    const denied = await importFreshModelOptionsModule({
-      getProviderProfiles: () => [active, inactive],
-      getActiveProviderProfile: () => active,
-      getProfileModelOptions: profile => [
-        { value: profile.model, label: profile.model, description: profile.name },
-      ],
-    })
-    expect(
-      denied
-        .getModelOptions(false)
-        .some(o => o.switchToProfileId === 'profile_inactive'),
-    ).toBe(false)
   } finally {
     if (previousFlag === undefined) {
       delete process.env.CLAUDE_CODE_PROVIDER_PROFILE_ENV_APPLIED

--- a/src/utils/model/modelOptions.crossProfile.test.ts
+++ b/src/utils/model/modelOptions.crossProfile.test.ts
@@ -1,0 +1,287 @@
+import { afterEach, beforeEach, expect, test } from 'bun:test'
+import { mock } from 'bun:test'
+
+import { resetModelStringsForTestingOnly } from '../../bootstrap/state.js'
+import {
+  resetSettingsCache,
+  setSessionSettingsCache,
+} from '../settings/settingsCache.js'
+
+// Mock surface: keep the original providerProfiles export shape and only
+// override `getProviderProfiles` / `getActiveProviderProfile` /
+// `getProfileModelOptions` per test. Anything else (setActiveProviderProfile,
+// etc.) stays as the real implementation so we don't break unrelated callers
+// loaded in the same `bun test` invocation. See `src/utils/user.test.ts` for
+// the canonical pattern; this is the same lesson as the 2026-04-30 mock-leak
+// note in lessons_learned.md.
+import * as actualProviderProfiles from '../providerProfiles.js'
+import * as actualProviders from './providers.js'
+import * as actualAuth from '../auth.js'
+
+function buildProviderProfileFixture(
+  overrides: Partial<actualProviderProfiles.ProviderProfile> = {},
+): actualProviderProfiles.ProviderProfile {
+  return {
+    id: 'profile_default',
+    name: 'Default Profile',
+    provider: 'openai',
+    baseUrl: 'https://api.example.com/v1',
+    model: 'example-model',
+    apiKey: 'sk-example',
+    ...overrides,
+  }
+}
+
+async function importFreshModelOptionsModule(
+  providerProfilesMock: Partial<typeof actualProviderProfiles>,
+) {
+  mock.restore()
+  mock.module('../providerProfiles.js', () => ({
+    ...actualProviderProfiles,
+    ...providerProfilesMock,
+  }))
+  // The 3P path also reads getAPIProvider and a handful of subscriber checks;
+  // pin them to a stable 3P-openai shape so the picker exercises the inactive
+  // profile branch we care about.
+  mock.module('./providers.js', () => ({
+    ...actualProviders,
+    getAPIProvider: () => 'openai',
+    getAPIProviderForStatsig: () => 'openai',
+    isFirstPartyAnthropicBaseUrl: () => false,
+    isGithubNativeAnthropicMode: () => false,
+    usesAnthropicAccountFlow: () => false,
+  }))
+  // Subscriber checks short-circuit the 3P path with a Claude.AI-shaped option
+  // list and never reach the inactive-profile append. Pin to non-subscriber
+  // for these tests so the openai 3P branch runs end-to-end.
+  mock.module('../auth.js', () => ({
+    ...actualAuth,
+    isClaudeAISubscriber: () => false,
+    isMaxSubscriber: () => false,
+    isTeamPremiumSubscriber: () => false,
+  }))
+  const nonce = `${Date.now()}-${Math.random()}`
+  return import(`./modelOptions.js?ts=${nonce}`)
+}
+
+beforeEach(() => {
+  mock.restore()
+  setSessionSettingsCache({ settings: {}, errors: [] })
+  resetModelStringsForTestingOnly()
+})
+
+afterEach(() => {
+  mock.restore()
+  resetSettingsCache()
+  resetModelStringsForTestingOnly()
+})
+
+test('parseSwitchProfileValue: round-trips encoded payload', async () => {
+  const { encodeSwitchProfileValue, parseSwitchProfileValue } =
+    await importFreshModelOptionsModule({})
+  const encoded = encodeSwitchProfileValue('profile_kimi_k26', 'kimi-k2.6')
+  expect(parseSwitchProfileValue(encoded)).toEqual({
+    profileId: 'profile_kimi_k26',
+    model: 'kimi-k2.6',
+  })
+})
+
+test('parseSwitchProfileValue: preserves colons inside model name', async () => {
+  // OpenRouter model strings carry `:` segments (`vendor/model:variant`); the
+  // parser must split only on the FIRST colon after the prefix so the model
+  // half keeps its inner colons. Regression guard against a naive
+  // `value.split(':')`.
+  const { encodeSwitchProfileValue, parseSwitchProfileValue } =
+    await importFreshModelOptionsModule({})
+  const encoded = encodeSwitchProfileValue(
+    'profile_openrouter',
+    'deepseek/deepseek-v4-flash:nitro',
+  )
+  expect(parseSwitchProfileValue(encoded)).toEqual({
+    profileId: 'profile_openrouter',
+    model: 'deepseek/deepseek-v4-flash:nitro',
+  })
+})
+
+test('parseSwitchProfileValue: returns null for plain model strings', async () => {
+  const { parseSwitchProfileValue } = await importFreshModelOptionsModule({})
+  expect(parseSwitchProfileValue('claude-sonnet-4-6')).toBeNull()
+  expect(parseSwitchProfileValue(null)).toBeNull()
+  expect(parseSwitchProfileValue('__switch_profile__:')).toBeNull()
+  expect(parseSwitchProfileValue('__switch_profile__:only-id:')).toBeNull()
+})
+
+test('getInactiveProviderProfileOptions: omits the active profile', async () => {
+  const profileA = buildProviderProfileFixture({
+    id: 'profile_a',
+    name: 'A',
+    baseUrl: 'https://a.example.com/v1',
+    model: 'a-model',
+  })
+  const profileB = buildProviderProfileFixture({
+    id: 'profile_b',
+    name: 'B',
+    baseUrl: 'https://b.example.com/v1',
+    model: 'b-model',
+  })
+  const { getInactiveProviderProfileOptions } =
+    await importFreshModelOptionsModule({
+      getProviderProfiles: () => [profileA, profileB],
+      getActiveProviderProfile: () => profileA,
+      getProfileModelOptions: profile => [
+        { value: profile.model, label: profile.model, description: profile.name },
+      ],
+    })
+
+  const options = getInactiveProviderProfileOptions('profile_a')
+  expect(options).toHaveLength(1)
+  expect(options[0]?.switchToProfileId).toBe('profile_b')
+  expect(options[0]?.label).toContain('b-model')
+  expect(options[0]?.label).toContain('B')
+  expect(options[0]?.description).toContain('https://b.example.com/v1')
+  expect(typeof options[0]?.value).toBe('string')
+  expect(options[0]?.value).toContain('profile_b')
+  expect(options[0]?.value).toContain('b-model')
+})
+
+test('getInactiveProviderProfileOptions: surfaces all configured profiles when none is active', async () => {
+  // Edge: if the caller passes `undefined` (no active profile yet — e.g. on a
+  // pristine first-run before env is applied), every configured profile should
+  // appear. Guards against a stray `filter` that drops everything when the
+  // active id is missing.
+  const profileA = buildProviderProfileFixture({
+    id: 'profile_a',
+    name: 'A',
+    model: 'a-model',
+  })
+  const profileB = buildProviderProfileFixture({
+    id: 'profile_b',
+    name: 'B',
+    model: 'b-model',
+  })
+  const { getInactiveProviderProfileOptions } =
+    await importFreshModelOptionsModule({
+      getProviderProfiles: () => [profileA, profileB],
+      getActiveProviderProfile: () => null,
+      getProfileModelOptions: profile => [
+        { value: profile.model, label: profile.model, description: profile.name },
+      ],
+    })
+
+  const options = getInactiveProviderProfileOptions(undefined)
+  expect(options.map(o => o.switchToProfileId)).toEqual([
+    'profile_a',
+    'profile_b',
+  ])
+})
+
+test('getInactiveProviderProfileOptions: explodes multi-model profiles into one option per model', async () => {
+  // Issue #1119 use case: one OpenRouter profile with several `agentModels`
+  // exposed as comma-separated `model`. Each model should become its own
+  // picker entry so the user can pick the exact one they want, not just the
+  // primary.
+  const multi = buildProviderProfileFixture({
+    id: 'profile_or',
+    name: 'OpenRouter',
+    baseUrl: 'https://openrouter.ai/api/v1',
+    model: 'deepseek/deepseek-v4-flash:nitro,glm-5.1,MiniMax-M2.5',
+  })
+  const { getInactiveProviderProfileOptions } =
+    await importFreshModelOptionsModule({
+      getProviderProfiles: () => [multi],
+      getActiveProviderProfile: () => null,
+      getProfileModelOptions: () => [
+        {
+          value: 'deepseek/deepseek-v4-flash:nitro',
+          label: 'deepseek/deepseek-v4-flash:nitro',
+          description: 'OpenRouter',
+        },
+        { value: 'glm-5.1', label: 'glm-5.1', description: 'OpenRouter' },
+        {
+          value: 'MiniMax-M2.5',
+          label: 'MiniMax-M2.5',
+          description: 'OpenRouter',
+        },
+      ],
+    })
+  const options = getInactiveProviderProfileOptions(undefined)
+  expect(options).toHaveLength(3)
+  expect(options.every(o => o.switchToProfileId === 'profile_or')).toBe(true)
+  expect(options.map(o => o.label.split(' · ')[0])).toEqual([
+    'deepseek/deepseek-v4-flash:nitro',
+    'glm-5.1',
+    'MiniMax-M2.5',
+  ])
+})
+
+test('getModelOptionsBase: 3P path includes inactive profile options when env applied', async () => {
+  const active = buildProviderProfileFixture({
+    id: 'profile_active',
+    name: 'Active',
+    baseUrl: 'https://api.kimi.com/coding/',
+    model: 'kimi-k2.6',
+  })
+  const inactive = buildProviderProfileFixture({
+    id: 'profile_inactive',
+    name: 'GLM',
+    baseUrl: 'https://api.z.ai/api/anthropic',
+    model: 'glm-5.1',
+  })
+
+  const previousFlag = process.env.CLAUDE_CODE_PROVIDER_PROFILE_ENV_APPLIED
+  process.env.CLAUDE_CODE_PROVIDER_PROFILE_ENV_APPLIED = '1'
+  try {
+    const { getModelOptions, parseSwitchProfileValue } =
+      await importFreshModelOptionsModule({
+        getProviderProfiles: () => [active, inactive],
+        getActiveProviderProfile: () => active,
+        getProfileModelOptions: profile => [
+          { value: profile.model, label: profile.model, description: profile.name },
+        ],
+      })
+
+    const options = getModelOptions(false)
+    const switchOptions = options.filter(o => o.switchToProfileId !== undefined)
+    expect(switchOptions.length).toBeGreaterThan(0)
+    expect(switchOptions[0]?.switchToProfileId).toBe('profile_inactive')
+    const parsed = parseSwitchProfileValue(switchOptions[0]!.value)
+    expect(parsed).toEqual({
+      profileId: 'profile_inactive',
+      model: 'glm-5.1',
+    })
+  } finally {
+    if (previousFlag === undefined) {
+      delete process.env.CLAUDE_CODE_PROVIDER_PROFILE_ENV_APPLIED
+    } else {
+      process.env.CLAUDE_CODE_PROVIDER_PROFILE_ENV_APPLIED = previousFlag
+    }
+  }
+})
+
+test('getModelOptionsBase: 3P path omits inactive profile options when env NOT applied', async () => {
+  // If the user hasn't gone through `/provider` yet (profile env not applied),
+  // surfacing cross-profile switching would be confusing — they haven't opted
+  // into the multi-profile workflow at all. Guard against that.
+  const inactive = buildProviderProfileFixture({
+    id: 'profile_inactive',
+    name: 'GLM',
+    model: 'glm-5.1',
+  })
+  const previousFlag = process.env.CLAUDE_CODE_PROVIDER_PROFILE_ENV_APPLIED
+  delete process.env.CLAUDE_CODE_PROVIDER_PROFILE_ENV_APPLIED
+  try {
+    const { getModelOptions } = await importFreshModelOptionsModule({
+      getProviderProfiles: () => [inactive],
+      getActiveProviderProfile: () => null,
+      getProfileModelOptions: profile => [
+        { value: profile.model, label: profile.model, description: profile.name },
+      ],
+    })
+    const options = getModelOptions(false)
+    expect(options.every(o => o.switchToProfileId === undefined)).toBe(true)
+  } finally {
+    if (previousFlag !== undefined) {
+      process.env.CLAUDE_CODE_PROVIDER_PROFILE_ENV_APPLIED = previousFlag
+    }
+  }
+})

--- a/src/utils/model/modelOptions.crossProfile.test.ts
+++ b/src/utils/model/modelOptions.crossProfile.test.ts
@@ -17,10 +17,11 @@ import {
 import * as actualProviderProfiles from '../providerProfiles.js'
 import * as actualProviders from './providers.js'
 import * as actualAuth from '../auth.js'
+import type { ProviderProfile } from '../config.js'
 
 function buildProviderProfileFixture(
-  overrides: Partial<actualProviderProfiles.ProviderProfile> = {},
-): actualProviderProfiles.ProviderProfile {
+  overrides: Partial<ProviderProfile> = {},
+): ProviderProfile {
   return {
     id: 'profile_default',
     name: 'Default Profile',
@@ -162,7 +163,7 @@ test('getInactiveProviderProfileOptions: surfaces all configured profiles when n
   const { getInactiveProviderProfileOptions } =
     await importFreshModelOptionsModule({
       getProviderProfiles: () => [profileA, profileB],
-      getActiveProviderProfile: () => null,
+      getActiveProviderProfile: () => undefined,
       getProfileModelOptions: profile => [
         { value: profile.model, label: profile.model, description: profile.name },
       ],
@@ -189,7 +190,7 @@ test('getInactiveProviderProfileOptions: explodes multi-model profiles into one 
   const { getInactiveProviderProfileOptions } =
     await importFreshModelOptionsModule({
       getProviderProfiles: () => [multi],
-      getActiveProviderProfile: () => null,
+      getActiveProviderProfile: () => undefined,
       getProfileModelOptions: () => [
         {
           value: 'deepseek/deepseek-v4-flash:nitro',
@@ -249,6 +250,69 @@ test('getModelOptionsBase: 3P path includes inactive profile options when env ap
       profileId: 'profile_inactive',
       model: 'glm-5.1',
     })
+  } finally {
+    if (previousFlag === undefined) {
+      delete process.env.CLAUDE_CODE_PROVIDER_PROFILE_ENV_APPLIED
+    } else {
+      process.env.CLAUDE_CODE_PROVIDER_PROFILE_ENV_APPLIED = previousFlag
+    }
+  }
+})
+
+test('getModelOptionsBase: allowlist matches the decoded cross-profile model, not the encoded value', async () => {
+  // Regression for #1164 review: the option's value is the encoded
+  // `__switch_profile__:<id>:glm-5.1`. An allowlist that permits the bare model
+  // `glm-5.1` must keep the cross-profile entry (and an allowlist without it
+  // must drop the entry).
+  const active = buildProviderProfileFixture({
+    id: 'profile_active',
+    name: 'Active',
+    model: 'sonnet',
+  })
+  const inactive = buildProviderProfileFixture({
+    id: 'profile_inactive',
+    name: 'GLM',
+    baseUrl: 'https://api.z.ai/api/anthropic',
+    model: 'glm-5.1',
+  })
+
+  const previousFlag = process.env.CLAUDE_CODE_PROVIDER_PROFILE_ENV_APPLIED
+  process.env.CLAUDE_CODE_PROVIDER_PROFILE_ENV_APPLIED = '1'
+  try {
+    setSessionSettingsCache({
+      settings: { availableModels: ['glm-5.1'] },
+      errors: [],
+    })
+    const allowed = await importFreshModelOptionsModule({
+      getProviderProfiles: () => [active, inactive],
+      getActiveProviderProfile: () => active,
+      getProfileModelOptions: profile => [
+        { value: profile.model, label: profile.model, description: profile.name },
+      ],
+    })
+    expect(
+      allowed
+        .getModelOptions(false)
+        .some(o => o.switchToProfileId === 'profile_inactive'),
+    ).toBe(true)
+
+    // Same profile, but the decoded model is not on the allowlist → dropped.
+    setSessionSettingsCache({
+      settings: { availableModels: ['some-other-model'] },
+      errors: [],
+    })
+    const denied = await importFreshModelOptionsModule({
+      getProviderProfiles: () => [active, inactive],
+      getActiveProviderProfile: () => active,
+      getProfileModelOptions: profile => [
+        { value: profile.model, label: profile.model, description: profile.name },
+      ],
+    })
+    expect(
+      denied
+        .getModelOptions(false)
+        .some(o => o.switchToProfileId === 'profile_inactive'),
+    ).toBe(false)
   } finally {
     if (previousFlag === undefined) {
       delete process.env.CLAUDE_CODE_PROVIDER_PROFILE_ENV_APPLIED
@@ -327,7 +391,7 @@ test('getModelOptionsBase: 3P path omits inactive profile options when env NOT a
   try {
     const { getModelOptions } = await importFreshModelOptionsModule({
       getProviderProfiles: () => [inactive],
-      getActiveProviderProfile: () => null,
+      getActiveProviderProfile: () => undefined,
       getProfileModelOptions: profile => [
         { value: profile.model, label: profile.model, description: profile.name },
       ],

--- a/src/utils/model/modelOptions.crossProfile.test.ts
+++ b/src/utils/model/modelOptions.crossProfile.test.ts
@@ -21,6 +21,7 @@ import * as actualProviderConfig from '../../services/api/providerConfig.js'
 import * as actualSettings from '../settings/settings.js'
 import * as actualModelAllowlist from './modelAllowlist.js'
 import * as actualOllamaModels from './ollamaModels.js'
+import * as actualNvidiaModels from './nvidiaNimModels.js'
 import type { ModelOption } from './modelOptions.js'
 import type { ProviderProfile } from '../config.js'
 import type { SettingsJson } from '../settings/types.js'
@@ -35,6 +36,7 @@ const realProviderConfig = { ...actualProviderConfig }
 const realSettings = { ...actualSettings }
 const realModelAllowlist = { ...actualModelAllowlist }
 const realOllamaModels = { ...actualOllamaModels }
+const realNvidiaModels = { ...actualNvidiaModels }
 
 // bun's mock.module is process-wide and mock.restore() does NOT undo it, so
 // per-test mocks installed in a harness would persist and leak into later
@@ -62,6 +64,14 @@ let activeSettingsOverride: SettingsJson | null = null
 // cross-profile test can assert the branch still appends inactive-profile
 // options (#1164). Gated + passthrough so it can't leak into other suites.
 let activeOllamaOverride: { cachedModels: ModelOption[] } | null = null
+// Pins getAPIProvider to a specific value (e.g. 'github') so the corresponding
+// early-return branch in getModelOptionsBase runs. Gated + passthrough.
+let activeApiProviderOverride: string | null = null
+// Drives the NVIDIA NIM catalog early-return branch. Gated + passthrough.
+let activeNvidiaOverride: { cachedModels: ModelOption[] } | null = null
+// Flips the Claude subscriber branch on (and optionally Max tier). Gated so it
+// doesn't leak subscriber state into sibling suites.
+let activeSubscriberOverride: { max?: boolean } | null = null
 
 mock.module('./ollamaModels.js', () => ({
   ...realOllamaModels,
@@ -71,6 +81,16 @@ mock.module('./ollamaModels.js', () => ({
     activeOllamaOverride
       ? activeOllamaOverride.cachedModels
       : realOllamaModels.getCachedOllamaModelOptions(),
+}))
+
+mock.module('./nvidiaNimModels.js', () => ({
+  ...realNvidiaModels,
+  isNvidiaNimProvider: () =>
+    activeNvidiaOverride ? true : realNvidiaModels.isNvidiaNimProvider(),
+  getCachedNvidiaNimModelOptions: () =>
+    activeNvidiaOverride
+      ? activeNvidiaOverride.cachedModels
+      : realNvidiaModels.getCachedNvidiaNimModelOptions(),
 }))
 
 mock.module('../settings/settings.js', () => ({
@@ -116,7 +136,8 @@ mock.module('../providerProfiles.js', () => ({
 mock.module('./providers.js', () => ({
   ...realProviders,
   getAPIProvider: () =>
-    activeProfilesOverride ? 'openai' : realProviders.getAPIProvider(),
+    activeApiProviderOverride ??
+    (activeProfilesOverride ? 'openai' : realProviders.getAPIProvider()),
   getAPIProviderForStatsig: () =>
     activeProfilesOverride
       ? 'openai'
@@ -138,9 +159,13 @@ mock.module('./providers.js', () => ({
 mock.module('../auth.js', () => ({
   ...realAuth,
   isClaudeAISubscriber: (...args: Parameters<typeof realAuth.isClaudeAISubscriber>) =>
-    activeProfilesOverride ? false : realAuth.isClaudeAISubscriber(...args),
+    activeSubscriberOverride
+      ? true
+      : activeProfilesOverride ? false : realAuth.isClaudeAISubscriber(...args),
   isMaxSubscriber: (...args: Parameters<typeof realAuth.isMaxSubscriber>) =>
-    activeProfilesOverride ? false : realAuth.isMaxSubscriber(...args),
+    activeSubscriberOverride
+      ? !!activeSubscriberOverride.max
+      : activeProfilesOverride ? false : realAuth.isMaxSubscriber(...args),
   isTeamPremiumSubscriber: (...args: Parameters<typeof realAuth.isTeamPremiumSubscriber>) =>
     activeProfilesOverride
       ? false
@@ -174,6 +199,9 @@ beforeEach(() => {
   activeCacheScopeOverride = null
   activeSettingsOverride = null
   activeOllamaOverride = null
+  activeApiProviderOverride = null
+  activeNvidiaOverride = null
+  activeSubscriberOverride = null
   setSessionSettingsCache({ settings: {}, errors: [] })
   resetModelStringsForTestingOnly()
 })
@@ -185,6 +213,9 @@ afterEach(() => {
   activeCacheScopeOverride = null
   activeSettingsOverride = null
   activeOllamaOverride = null
+  activeApiProviderOverride = null
+  activeNvidiaOverride = null
+  activeSubscriberOverride = null
   resetSettingsCache()
   resetModelStringsForTestingOnly()
 })
@@ -567,4 +598,132 @@ test('getModelOptions: allowlist filters cross-profile options by the decoded ta
       process.env.CLAUDE_CODE_PROVIDER_PROFILE_ENV_APPLIED = previousFlag
     }
   }
+})
+
+// Shared fixtures for the "other provider branches also append inactive
+// profiles" cases (#1164 [P2]). Each branch previously returned before the
+// inactive-profile options were appended, dropping the cross-profile switcher.
+function activeAndInactivePair() {
+  const active = buildProviderProfileFixture({
+    id: 'profile_active',
+    name: 'Active',
+    model: 'active-model',
+  })
+  const inactive = buildProviderProfileFixture({
+    id: 'profile_remote',
+    name: 'GLM',
+    baseUrl: 'https://api.z.ai/api/anthropic',
+    model: 'glm-5.1',
+  })
+  return { active, inactive }
+}
+
+async function withProfileEnvApplied(run: () => Promise<void>) {
+  const previousFlag = process.env.CLAUDE_CODE_PROVIDER_PROFILE_ENV_APPLIED
+  process.env.CLAUDE_CODE_PROVIDER_PROFILE_ENV_APPLIED = '1'
+  try {
+    await run()
+  } finally {
+    if (previousFlag === undefined) {
+      delete process.env.CLAUDE_CODE_PROVIDER_PROFILE_ENV_APPLIED
+    } else {
+      process.env.CLAUDE_CODE_PROVIDER_PROFILE_ENV_APPLIED = previousFlag
+    }
+  }
+}
+
+test('getModelOptionsBase: GitHub Copilot branch appends inactive profile options', async () => {
+  const { active, inactive } = activeAndInactivePair()
+  activeApiProviderOverride = 'github'
+  await withProfileEnvApplied(async () => {
+    const { getModelOptions } = await importFreshModelOptionsModule({
+      getProviderProfiles: () => [active, inactive],
+      getActiveProviderProfile: () => active,
+      getProfileModelOptions: profile => [
+        { value: profile.model, label: profile.model, description: profile.name },
+      ],
+    })
+    const switchOptions = getModelOptions(false).filter(
+      o => o.switchToProfileId !== undefined,
+    )
+    expect(switchOptions.map(o => o.switchToProfileId)).toContain(
+      'profile_remote',
+    )
+  })
+})
+
+test('getModelOptionsBase: NVIDIA NIM catalog branch appends inactive profile options', async () => {
+  const { active, inactive } = activeAndInactivePair()
+  activeNvidiaOverride = {
+    cachedModels: [
+      { value: 'nvidia/model', label: 'nvidia/model', description: 'NVIDIA' },
+    ],
+  }
+  await withProfileEnvApplied(async () => {
+    const { getModelOptions } = await importFreshModelOptionsModule({
+      getProviderProfiles: () => [active, inactive],
+      getActiveProviderProfile: () => active,
+      getProfileModelOptions: profile => [
+        { value: profile.model, label: profile.model, description: profile.name },
+      ],
+    })
+    const options = getModelOptions(false)
+    // Catalog model still present, and the inactive switcher restored.
+    expect(options.some(o => o.value === 'nvidia/model')).toBe(true)
+    expect(
+      options
+        .filter(o => o.switchToProfileId !== undefined)
+        .map(o => o.switchToProfileId),
+    ).toContain('profile_remote')
+  })
+})
+
+test('getModelOptionsBase: Claude subscriber branch appends inactive profile options', async () => {
+  const { active, inactive } = activeAndInactivePair()
+  activeSubscriberOverride = {} // Pro/standard tier
+  await withProfileEnvApplied(async () => {
+    const { getModelOptions } = await importFreshModelOptionsModule({
+      getProviderProfiles: () => [active, inactive],
+      getActiveProviderProfile: () => active,
+      getProfileModelOptions: profile => [
+        { value: profile.model, label: profile.model, description: profile.name },
+      ],
+    })
+    expect(
+      getModelOptions(false)
+        .filter(o => o.switchToProfileId !== undefined)
+        .map(o => o.switchToProfileId),
+    ).toContain('profile_remote')
+  })
+})
+
+test('getModelOptions: allowlist checks a non-switch custom id verbatim, not decoded', async () => {
+  // Regression for #1164 [P2]: filterModelOptionsByAllowlist must only decode
+  // genuine switch options (identified by `switchToProfileId`), not any string
+  // that happens to start with `__switch_profile__:`. A custom model id with
+  // that literal prefix but no marker must be checked as-is — decoding it would
+  // evaluate the allowlist against the wrong (inner) model and wrongly drop it.
+  const literal = '__switch_profile__:sneaky:real-model'
+  const active = buildProviderProfileFixture({
+    id: 'profile_active',
+    name: 'Active',
+    model: literal,
+  })
+  // Allow the literal id (verbatim). Its decoded inner model `real-model` is NOT
+  // listed, so the old prefix-based decode would have dropped it.
+  activeSettingsOverride = { availableModels: [literal] } as SettingsJson
+
+  await withProfileEnvApplied(async () => {
+    const { getModelOptions } = await importFreshModelOptionsModule({
+      getProviderProfiles: () => [active],
+      getActiveProviderProfile: () => active,
+      // Active profile's own model options are appended WITHOUT a
+      // switchToProfileId marker, so this exercises the non-switch path.
+      getProfileModelOptions: () => [
+        { value: literal, label: 'Sneaky', description: 'custom' },
+      ],
+    })
+    const values = getModelOptions(false).map(o => o.value)
+    expect(values).toContain(literal)
+  })
 })

--- a/src/utils/model/modelOptions.crossProfile.test.ts
+++ b/src/utils/model/modelOptions.crossProfile.test.ts
@@ -20,6 +20,8 @@ import * as actualAuth from '../auth.js'
 import * as actualProviderConfig from '../../services/api/providerConfig.js'
 import * as actualSettings from '../settings/settings.js'
 import * as actualModelAllowlist from './modelAllowlist.js'
+import * as actualOllamaModels from './ollamaModels.js'
+import type { ModelOption } from './modelOptions.js'
 import type { ProviderProfile } from '../config.js'
 import type { SettingsJson } from '../settings/types.js'
 
@@ -32,6 +34,7 @@ const realAuth = { ...actualAuth }
 const realProviderConfig = { ...actualProviderConfig }
 const realSettings = { ...actualSettings }
 const realModelAllowlist = { ...actualModelAllowlist }
+const realOllamaModels = { ...actualOllamaModels }
 
 // bun's mock.module is process-wide and mock.restore() does NOT undo it, so
 // per-test mocks installed in a harness would persist and leak into later
@@ -54,6 +57,21 @@ let activeCacheScopeOverride: string | null = null
 // setSessionSettingsCache, so drive the allowlist deterministically here rather
 // than through the shared settings cache. Gated + passthrough so it doesn't leak.
 let activeSettingsOverride: SettingsJson | null = null
+// Drives the Ollama early-return branch in getModelOptionsBase. When set, the
+// gated mock reports an Ollama provider with this fixed cached-model list so a
+// cross-profile test can assert the branch still appends inactive-profile
+// options (#1164). Gated + passthrough so it can't leak into other suites.
+let activeOllamaOverride: { cachedModels: ModelOption[] } | null = null
+
+mock.module('./ollamaModels.js', () => ({
+  ...realOllamaModels,
+  isOllamaProvider: () =>
+    activeOllamaOverride ? true : realOllamaModels.isOllamaProvider(),
+  getCachedOllamaModelOptions: () =>
+    activeOllamaOverride
+      ? activeOllamaOverride.cachedModels
+      : realOllamaModels.getCachedOllamaModelOptions(),
+}))
 
 mock.module('../settings/settings.js', () => ({
   ...realSettings,
@@ -155,6 +173,7 @@ beforeEach(() => {
   activeProfilesOverride = null
   activeCacheScopeOverride = null
   activeSettingsOverride = null
+  activeOllamaOverride = null
   setSessionSettingsCache({ settings: {}, errors: [] })
   resetModelStringsForTestingOnly()
 })
@@ -165,6 +184,7 @@ afterEach(() => {
   activeProfilesOverride = null
   activeCacheScopeOverride = null
   activeSettingsOverride = null
+  activeOllamaOverride = null
   resetSettingsCache()
   resetModelStringsForTestingOnly()
 })
@@ -395,6 +415,62 @@ test('getModelOptionsBase: local OpenAI-compatible scope still appends inactive 
       profileId: 'profile_remote',
       model: 'glm-5.1',
     })
+  } finally {
+    if (previousFlag === undefined) {
+      delete process.env.CLAUDE_CODE_PROVIDER_PROFILE_ENV_APPLIED
+    } else {
+      process.env.CLAUDE_CODE_PROVIDER_PROFILE_ENV_APPLIED = previousFlag
+    }
+  }
+})
+
+test('getModelOptionsBase: active Ollama profile still surfaces inactive profile options', async () => {
+  // Regression for #1164: the `isOllamaProvider()` early return ran before the
+  // inactive-profile compute, so a user whose active profile is a local Ollama
+  // endpoint only saw the Ollama models and lost the cross-profile switcher,
+  // forcing the exact `/provider` round-trip this PR removes. The inactive
+  // options are now hoisted above the Ollama branch and appended to its returns.
+  const active = buildProviderProfileFixture({
+    id: 'profile_ollama',
+    name: 'Local Ollama',
+    baseUrl: 'http://localhost:11434/v1',
+    model: 'llama3.2',
+  })
+  const inactive = buildProviderProfileFixture({
+    id: 'profile_remote',
+    name: 'GLM',
+    baseUrl: 'https://api.z.ai/api/anthropic',
+    model: 'glm-5.1',
+  })
+
+  const previousFlag = process.env.CLAUDE_CODE_PROVIDER_PROFILE_ENV_APPLIED
+  process.env.CLAUDE_CODE_PROVIDER_PROFILE_ENV_APPLIED = '1'
+  // Force the Ollama branch with a non-empty cached-model list so it takes the
+  // `[default, ...ollamaModels, ...inactiveProfileOptions]` return path.
+  activeOllamaOverride = {
+    cachedModels: [
+      { value: 'llama3.2', label: 'llama3.2', description: 'Local Ollama' },
+    ],
+  }
+  try {
+    const { getModelOptions, parseSwitchProfileValue } =
+      await importFreshModelOptionsModule({
+        getProviderProfiles: () => [active, inactive],
+        getActiveProviderProfile: () => active,
+        getProfileModelOptions: profile => [
+          { value: profile.model, label: profile.model, description: profile.name },
+        ],
+      })
+
+    const options = getModelOptions(false)
+    // The Ollama model is still present...
+    expect(options.some(o => o.value === 'llama3.2')).toBe(true)
+    // ...and the inactive profile now appears as a switch option.
+    const switchOptions = options.filter(o => o.switchToProfileId !== undefined)
+    expect(switchOptions.length).toBeGreaterThan(0)
+    expect(switchOptions[0]?.switchToProfileId).toBe('profile_remote')
+    const parsed = parseSwitchProfileValue(switchOptions[0]!.value)
+    expect(parsed).toEqual({ profileId: 'profile_remote', model: 'glm-5.1' })
   } finally {
     if (previousFlag === undefined) {
       delete process.env.CLAUDE_CODE_PROVIDER_PROFILE_ENV_APPLIED

--- a/src/utils/model/modelOptions.crossProfile.test.ts
+++ b/src/utils/model/modelOptions.crossProfile.test.ts
@@ -258,6 +258,61 @@ test('getModelOptionsBase: 3P path includes inactive profile options when env ap
   }
 })
 
+test('getModelOptionsBase: local OpenAI-compatible scope still appends inactive profile options', async () => {
+  // Regression for #1164: when the active profile is a local OpenAI-compatible
+  // endpoint (Ollama, lm-studio, etc.), the scope-based early return used to
+  // skip the inactive-profile compute and the cross-profile switcher
+  // disappeared from `/model`. Now the inactive options are hoisted above the
+  // early return and forwarded in this branch too.
+  const active = buildProviderProfileFixture({
+    id: 'profile_local',
+    name: 'Local Ollama',
+    baseUrl: 'http://localhost:11434/v1',
+    model: 'llama3.2',
+  })
+  const inactive = buildProviderProfileFixture({
+    id: 'profile_remote',
+    name: 'GLM',
+    baseUrl: 'https://api.z.ai/api/anthropic',
+    model: 'glm-5.1',
+  })
+
+  const previousFlag = process.env.CLAUDE_CODE_PROVIDER_PROFILE_ENV_APPLIED
+  process.env.CLAUDE_CODE_PROVIDER_PROFILE_ENV_APPLIED = '1'
+  // Force the local OpenAI-compatible branch by pinning the scope getter to
+  // an `openai:` value. The real source reads the global config; we override
+  // it directly to keep the test hermetic.
+  mock.module('../../services/api/providerConfig.js', () => ({
+    getAdditionalModelOptionsCacheScope: () => 'openai:http://localhost:11434/v1',
+  }))
+  try {
+    const { getModelOptions, parseSwitchProfileValue } =
+      await importFreshModelOptionsModule({
+        getProviderProfiles: () => [active, inactive],
+        getActiveProviderProfile: () => active,
+        getProfileModelOptions: profile => [
+          { value: profile.model, label: profile.model, description: profile.name },
+        ],
+      })
+
+    const options = getModelOptions(false)
+    const switchOptions = options.filter(o => o.switchToProfileId !== undefined)
+    expect(switchOptions.length).toBeGreaterThan(0)
+    expect(switchOptions[0]?.switchToProfileId).toBe('profile_remote')
+    const parsed = parseSwitchProfileValue(switchOptions[0]!.value)
+    expect(parsed).toEqual({
+      profileId: 'profile_remote',
+      model: 'glm-5.1',
+    })
+  } finally {
+    if (previousFlag === undefined) {
+      delete process.env.CLAUDE_CODE_PROVIDER_PROFILE_ENV_APPLIED
+    } else {
+      process.env.CLAUDE_CODE_PROVIDER_PROFILE_ENV_APPLIED = previousFlag
+    }
+  }
+})
+
 test('getModelOptionsBase: 3P path omits inactive profile options when env NOT applied', async () => {
   // If the user hasn't gone through `/provider` yet (profile env not applied),
   // surfacing cross-profile switching would be confusing — they haven't opted

--- a/src/utils/model/modelOptions.switchMarker.test.ts
+++ b/src/utils/model/modelOptions.switchMarker.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, test } from 'bun:test'
+import {
+  encodeSwitchProfileValue,
+  resolveSelectedSwitchProfileId,
+  type ModelOption,
+} from './modelOptions.js'
+
+// resolveSelectedSwitchProfileId is the presented-option authority for whether
+// a /model selection activates a provider (#1119/#1164). It must key on the
+// actual option carrying the marker, and treat duplicate-value matches as
+// ambiguous so a literal custom id cannot borrow another option's marker.
+describe('resolveSelectedSwitchProfileId', () => {
+  const switchValue = encodeSwitchProfileValue('work', 'gpt-5.5')
+
+  test('returns the marker of the single matching switch option', () => {
+    const options: ModelOption[] = [
+      { value: 'claude-opus-4-6', label: 'Active', description: 'Active' },
+      { value: switchValue, label: 'Switch to Work', description: 'Switch', switchToProfileId: 'work' },
+    ]
+    expect(resolveSelectedSwitchProfileId(options, switchValue)).toBe('work')
+  })
+
+  test('returns undefined for a literal option with no marker', () => {
+    const options: ModelOption[] = [
+      { value: switchValue, label: 'Literal custom model', description: 'Literal' },
+    ]
+    expect(resolveSelectedSwitchProfileId(options, switchValue)).toBeUndefined()
+  })
+
+  test('returns undefined when two options share the selected value (ambiguous)', () => {
+    // A literal custom id whose value collides with an encoded switch value must
+    // NOT borrow the switch option's marker.
+    const options: ModelOption[] = [
+      { value: switchValue, label: 'Switch to Work', description: 'Switch', switchToProfileId: 'work' },
+      { value: switchValue, label: 'Literal custom model', description: 'Literal' },
+    ]
+    expect(resolveSelectedSwitchProfileId(options, switchValue)).toBeUndefined()
+  })
+
+  test('returns undefined when nothing matches the selected value', () => {
+    const options: ModelOption[] = [
+      { value: 'claude-opus-4-6', label: 'Active', description: 'Active' },
+    ]
+    expect(resolveSelectedSwitchProfileId(options, switchValue)).toBeUndefined()
+  })
+})

--- a/src/utils/model/modelOptions.ts
+++ b/src/utils/model/modelOptions.ts
@@ -104,6 +104,23 @@ export function encodeSwitchProfileValue(profileId: string, model: string): stri
   return `${SWITCH_PROFILE_VALUE_PREFIX}${profileId}:${model}`
 }
 
+/**
+ * Resolve the cross-profile switch marker (`switchToProfileId`) for a selected
+ * picker value from the PRESENTED options list — the authority for whether the
+ * selection is a genuine profile switch (#1119/#1164). Only a single option
+ * with that value is authoritative: if two options share the value (a literal
+ * custom model id colliding with an encoded switch value), the Select cannot
+ * tell them apart, so the selection is ambiguous and resolves to `undefined`
+ * rather than letting the literal borrow another option's marker.
+ */
+export function resolveSelectedSwitchProfileId(
+  options: ReadonlyArray<Pick<ModelOption, 'value' | 'switchToProfileId'>>,
+  selectedValue: ModelSetting,
+): string | undefined {
+  const matches = options.filter(option => option.value === selectedValue)
+  return matches.length === 1 ? matches[0]!.switchToProfileId : undefined
+}
+
 function getScopedAdditionalModelOptions(): ModelOption[] {
   const config = getGlobalConfig()
   const activeScope = getAdditionalModelOptionsCacheScope()

--- a/src/utils/model/modelOptions.ts
+++ b/src/utils/model/modelOptions.ts
@@ -1023,10 +1023,18 @@ function filterModelOptionsByAllowlist(options: ModelOption[]): ModelOption[] {
   const settings = getSettings_DEPRECATED() || {}
   const filtered = !settings.availableModels
     ? options // No restrictions
-    : options.filter(
-    opt =>
-      opt.value === null || (opt.value !== null && isModelAllowed(opt.value)),
-  )
+    : options.filter(opt => {
+        if (opt.value === null) {
+          return true
+        }
+        // Cross-profile options carry an encoded
+        // `__switch_profile__:<id>:<model>` value; evaluate the allowlist
+        // against the decoded target model so an allowed model is not dropped
+        // just because of the switch wrapper.
+        const effectiveModel =
+          parseSwitchProfileValue(opt.value)?.model ?? opt.value
+        return isModelAllowed(effectiveModel)
+      })
 
   // Select state uses option values as identity keys. If two entries share the
   // same value (e.g. provider-specific aliases collapsing to one model ID),

--- a/src/utils/model/modelOptions.ts
+++ b/src/utils/model/modelOptions.ts
@@ -37,6 +37,7 @@ import {
   getActiveOpenAIModelOptionsCache,
   getActiveProviderProfile,
   getProfileModelOptions,
+  getProviderProfiles,
 } from '../providerProfiles.js'
 import { getCachedOllamaModelOptions, isOllamaProvider } from './ollamaModels.js'
 import { getCachedNvidiaNimModelOptions, isNvidiaNimProvider } from './nvidiaNimModels.js'
@@ -51,6 +52,51 @@ export type ModelOption = {
   label: string
   description: string
   descriptionForModel?: string
+  /**
+   * When set, selecting this option also activates the named provider profile
+   * before switching the main-loop model. Encoded into `value` as a
+   * `SWITCH_PROFILE_VALUE_PREFIX`-prefixed string so the picker's `value`
+   * channel stays a plain string; consumers must call `parseSwitchProfileValue`
+   * on `value` (or read `switchToProfileId` directly) before treating it as a
+   * model setting. Used to surface inactive `providerProfiles` from the
+   * `/model` picker (issue #1119).
+   */
+  switchToProfileId?: string
+}
+
+/**
+ * Prefix encoded into `ModelOption.value` for options that, when selected,
+ * should activate a different provider profile before applying the model.
+ * Format: `${SWITCH_PROFILE_VALUE_PREFIX}<profileId>:<model>`. Two profiles can
+ * legally expose the same model string under different base URLs, so the
+ * profile id is part of the value to keep options unique.
+ */
+export const SWITCH_PROFILE_VALUE_PREFIX = '__switch_profile__:'
+
+export type ParsedSwitchProfileValue = {
+  profileId: string
+  model: string
+}
+
+export function parseSwitchProfileValue(
+  value: ModelSetting,
+): ParsedSwitchProfileValue | null {
+  if (typeof value !== 'string' || !value.startsWith(SWITCH_PROFILE_VALUE_PREFIX)) {
+    return null
+  }
+  const tail = value.slice(SWITCH_PROFILE_VALUE_PREFIX.length)
+  const sep = tail.indexOf(':')
+  if (sep <= 0 || sep === tail.length - 1) {
+    return null
+  }
+  return {
+    profileId: tail.slice(0, sep),
+    model: tail.slice(sep + 1),
+  }
+}
+
+export function encodeSwitchProfileValue(profileId: string, model: string): string {
+  return `${SWITCH_PROFILE_VALUE_PREFIX}${profileId}:${model}`
 }
 
 function getScopedAdditionalModelOptions(): ModelOption[] {
@@ -526,13 +572,25 @@ function getModelOptionsBase(fastMode = false): ModelOption[] {
   // getActiveProviderProfile which would affect users with inactive profiles.
   const profileEnvApplied = process.env.CLAUDE_CODE_PROVIDER_PROFILE_ENV_APPLIED === '1'
   const profileModelOptions: ModelOption[] = []
+  let activeProfileId: string | undefined
   if (profileEnvApplied) {
     const activeProfile = getActiveProviderProfile()
     if (activeProfile) {
+      activeProfileId = activeProfile.id
       const models = getProfileModelOptions(activeProfile)
       profileModelOptions.push(...models)
     }
   }
+
+  // Inactive provider profile options. Surfaces each configured-but-inactive
+  // provider profile's models in the picker so users can switch active provider
+  // + model from `/model` instead of having to round-trip through `/provider`
+  // (issue #1119). Only built when the active profile env is applied so we
+  // don't expose this affordance to users who haven't opted into the
+  // multi-profile workflow.
+  const inactiveProfileOptions: ModelOption[] = profileEnvApplied
+    ? getInactiveProviderProfileOptions(activeProfileId)
+    : []
 
   // PAYG 1P API: Default (Sonnet) + Sonnet 1M + Opus 4.7 + Opus 4.6 + Opus 1M + Haiku
   if (getAPIProvider() === 'firstParty') {
@@ -551,6 +609,7 @@ function getModelOptionsBase(fastMode = false): ModelOption[] {
     }
     payg1POptions.push(getHaiku45Option())
     payg1POptions.push(...profileModelOptions)
+    payg1POptions.push(...inactiveProfileOptions)
     return payg1POptions
   }
 
@@ -592,7 +651,42 @@ function getModelOptionsBase(fastMode = false): ModelOption[] {
     payg3pOptions.push(getHaikuOption())
   }
   payg3pOptions.push(...profileModelOptions)
+  payg3pOptions.push(...inactiveProfileOptions)
   return payg3pOptions
+}
+
+/**
+ * Build picker options for each provider profile that is NOT currently active.
+ * Selecting one of these activates the profile (swapping `OPENAI_BASE_URL` /
+ * `OPENAI_API_KEY` / etc. via `setActiveProviderProfile`) and then sets the
+ * main-loop model to the chosen entry — the equivalent of `/provider` followed
+ * by `/model`, but in one step. See issue #1119.
+ */
+export function getInactiveProviderProfileOptions(
+  activeProfileId: string | undefined,
+): ModelOption[] {
+  const profiles = getProviderProfiles()
+  const options: ModelOption[] = []
+  for (const profile of profiles) {
+    if (profile.id === activeProfileId) {
+      continue
+    }
+    const baseOptions = getProfileModelOptions(profile)
+    for (const baseOption of baseOptions) {
+      const modelValue =
+        typeof baseOption.value === 'string' ? baseOption.value : ''
+      if (!modelValue) {
+        continue
+      }
+      options.push({
+        value: encodeSwitchProfileValue(profile.id, modelValue),
+        label: `${modelValue} · ${profile.name}`,
+        description: `Switch to ${profile.name} (${profile.baseUrl})`,
+        switchToProfileId: profile.id,
+      })
+    }
+  }
+  return options
 }
 
 // @[MODEL LAUNCH]: Add the new model ID to the appropriate family pattern below

--- a/src/utils/model/modelOptions.ts
+++ b/src/utils/model/modelOptions.ts
@@ -495,7 +495,11 @@ function getModelOptionsBase(fastMode = false): ModelOption[] {
     : []
 
   if (getAPIProvider() === 'github') {
-    return [getDefaultOptionForUser(fastMode), ...getCopilotModelOptions()]
+    return [
+      getDefaultOptionForUser(fastMode),
+      ...getCopilotModelOptions(),
+      ...inactiveProfileOptions,
+    ]
   }
 
   // When using Ollama, show models from the Ollama server instead of Claude models
@@ -526,9 +530,9 @@ function getModelOptionsBase(fastMode = false): ModelOption[] {
     const defaultOption = getDefaultOptionForUser(fastMode)
     const nvidiaModels = getCachedNvidiaNimModelOptions()
     if (nvidiaModels.length > 0) {
-      return [defaultOption, ...nvidiaModels]
+      return [defaultOption, ...nvidiaModels, ...inactiveProfileOptions]
     }
-    return [defaultOption]
+    return [defaultOption, ...inactiveProfileOptions]
   }
 
   // When using MiniMax, show models from the MiniMax catalog
@@ -536,9 +540,9 @@ function getModelOptionsBase(fastMode = false): ModelOption[] {
     const defaultOption = getDefaultOptionForUser(fastMode)
     const minimaxModels = getCachedMiniMaxModelOptions()
     if (minimaxModels.length > 0) {
-      return [defaultOption, ...minimaxModels]
+      return [defaultOption, ...minimaxModels, ...inactiveProfileOptions]
     }
-    return [defaultOption]
+    return [defaultOption, ...inactiveProfileOptions]
   }
 
   // When using Xiaomi MiMo, show models from the MiMo catalog
@@ -546,9 +550,9 @@ function getModelOptionsBase(fastMode = false): ModelOption[] {
     const defaultOption = getDefaultOptionForUser(fastMode)
     const xiaomiMimoModels = getCachedXiaomiMimoModelOptions()
     if (xiaomiMimoModels.length > 0) {
-      return [defaultOption, ...xiaomiMimoModels]
+      return [defaultOption, ...xiaomiMimoModels, ...inactiveProfileOptions]
     }
-    return [defaultOption]
+    return [defaultOption, ...inactiveProfileOptions]
   }
 
   if (process.env.USER_TYPE === 'ant') {
@@ -566,6 +570,7 @@ function getModelOptionsBase(fastMode = false): ModelOption[] {
       getSonnet46Option(),
       getSonnet46_1MOption(),
       getHaiku45Option(),
+      ...inactiveProfileOptions,
     ]
   }
 
@@ -583,6 +588,7 @@ function getModelOptionsBase(fastMode = false): ModelOption[] {
       }
 
       premiumOptions.push(MaxHaiku45Option)
+      premiumOptions.push(...inactiveProfileOptions)
       return premiumOptions
     }
 
@@ -602,6 +608,7 @@ function getModelOptionsBase(fastMode = false): ModelOption[] {
     }
 
     standardOptions.push(MaxHaiku45Option)
+    standardOptions.push(...inactiveProfileOptions)
     return standardOptions
   }
 
@@ -1031,9 +1038,14 @@ function filterModelOptionsByAllowlist(options: ModelOption[]): ModelOption[] {
         // Cross-profile options carry an encoded
         // `__switch_profile__:<id>:<model>` value; evaluate the allowlist
         // against the decoded target model so an allowed model is not dropped
-        // just because of the switch wrapper.
+        // just because of the switch wrapper. Only decode genuine switch
+        // options — identified by the `switchToProfileId` marker, not the raw
+        // string prefix — so a normal custom model id that happens to start with
+        // `__switch_profile__:` is checked verbatim rather than mis-parsed.
         const effectiveModel =
-          parseSwitchProfileValue(opt.value)?.model ?? opt.value
+          opt.switchToProfileId !== undefined
+            ? parseSwitchProfileValue(opt.value)?.model ?? opt.value
+            : opt.value
         return isModelAllowed(effectiveModel)
       })
 

--- a/src/utils/model/modelOptions.ts
+++ b/src/utils/model/modelOptions.ts
@@ -573,6 +573,40 @@ function getModelOptionsBase(fastMode = false): ModelOption[] {
     return standardOptions
   }
 
+  // When a provider profile's env is applied, collect its models so they
+  // can be appended to the picker options below.
+  // We check PROFILE_ENV_APPLIED to avoid the ?? profiles[0] fallback in
+  // getActiveProviderProfile which would affect users with inactive profiles.
+  //
+  // Hoisted above the local OpenAI-compatible early return because users with
+  // a local profile active (Ollama, lm-studio, etc.) still need the unified
+  // `/model` switcher to surface every other configured profile — otherwise
+  // they have to round-trip through `/provider`.
+  const profileEnvApplied = process.env.CLAUDE_CODE_PROVIDER_PROFILE_ENV_APPLIED === '1'
+  const profileModelOptions: ModelOption[] = []
+  let activeProfileId: string | undefined
+  if (profileEnvApplied) {
+    const activeProfile = getActiveProviderProfile()
+    if (activeProfile) {
+      activeProfileId = activeProfile.id
+      const models = getProfileModelOptions(activeProfile)
+      profileModelOptions.push(...models)
+    }
+  }
+
+  // Inactive provider profile options. Surfaces each configured-but-inactive
+  // provider profile's models in the picker so users can switch active provider
+  // + model from `/model` instead of having to round-trip through `/provider`
+  // (issue #1119). Only built when the active profile env is applied so we
+  // don't expose this affordance to users who haven't opted into the
+  // multi-profile workflow.
+  const inactiveProfileOptions: ModelOption[] = profileEnvApplied
+    ? getInactiveProviderProfileOptions(activeProfileId)
+    : []
+
+  // Local OpenAI-compatible / route-catalog scope. Inactive-profile options are
+  // appended here too so the unified `/model` switcher still surfaces every
+  // other configured profile while a local/route profile is active (#1119).
   const activeRouteCatalogOptions = getActiveOpenAIRouteCatalogOptions()
   const openAIModelOptionsScope = getAdditionalModelOptionsCacheScope()
   const activeProfile = getActiveProviderProfile()
@@ -595,34 +629,9 @@ function getModelOptionsBase(fastMode = false): ModelOption[] {
         sourceOptions,
         activeRouteCatalogOptions,
       ),
+      ...inactiveProfileOptions,
     ]
   }
-
-  // When a provider profile's env is applied, collect its models so they
-  // can be appended to the standard picker options below.
-  // We check PROFILE_ENV_APPLIED to avoid the ?? profiles[0] fallback in
-  // getActiveProviderProfile which would affect users with inactive profiles.
-  const profileEnvApplied = process.env.CLAUDE_CODE_PROVIDER_PROFILE_ENV_APPLIED === '1'
-  const profileModelOptions: ModelOption[] = []
-  let activeProfileId: string | undefined
-  if (profileEnvApplied) {
-    const activeProfile = getActiveProviderProfile()
-    if (activeProfile) {
-      activeProfileId = activeProfile.id
-      const models = getProfileModelOptions(activeProfile)
-      profileModelOptions.push(...models)
-    }
-  }
-
-  // Inactive provider profile options. Surfaces each configured-but-inactive
-  // provider profile's models in the picker so users can switch active provider
-  // + model from `/model` instead of having to round-trip through `/provider`
-  // (issue #1119). Only built when the active profile env is applied so we
-  // don't expose this affordance to users who haven't opted into the
-  // multi-profile workflow.
-  const inactiveProfileOptions: ModelOption[] = profileEnvApplied
-    ? getInactiveProviderProfileOptions(activeProfileId)
-    : []
 
   // PAYG 1P API: Default (Sonnet) + Sonnet 1M + Opus 4.8 + Opus 4.7 + Opus 4.6 + Opus 1M + Haiku
   if (getAPIProvider() === 'firstParty') {

--- a/src/utils/model/modelOptions.ts
+++ b/src/utils/model/modelOptions.ts
@@ -42,6 +42,7 @@ import {
   getActiveOpenAIModelOptionsCache,
   getActiveProviderProfile,
   getProfileModelOptions,
+  getProviderProfiles,
 } from '../providerProfiles.js'
 import { getCachedOllamaModelOptions, isOllamaProvider } from './ollamaModels.js'
 import { getCachedNvidiaNimModelOptions, isNvidiaNimProvider } from './nvidiaNimModels.js'
@@ -56,6 +57,51 @@ export type ModelOption = {
   label: string
   description: string
   descriptionForModel?: string
+  /**
+   * When set, selecting this option also activates the named provider profile
+   * before switching the main-loop model. Encoded into `value` as a
+   * `SWITCH_PROFILE_VALUE_PREFIX`-prefixed string so the picker's `value`
+   * channel stays a plain string; consumers must call `parseSwitchProfileValue`
+   * on `value` (or read `switchToProfileId` directly) before treating it as a
+   * model setting. Used to surface inactive `providerProfiles` from the
+   * `/model` picker (issue #1119).
+   */
+  switchToProfileId?: string
+}
+
+/**
+ * Prefix encoded into `ModelOption.value` for options that, when selected,
+ * should activate a different provider profile before applying the model.
+ * Format: `${SWITCH_PROFILE_VALUE_PREFIX}<profileId>:<model>`. Two profiles can
+ * legally expose the same model string under different base URLs, so the
+ * profile id is part of the value to keep options unique.
+ */
+export const SWITCH_PROFILE_VALUE_PREFIX = '__switch_profile__:'
+
+export type ParsedSwitchProfileValue = {
+  profileId: string
+  model: string
+}
+
+export function parseSwitchProfileValue(
+  value: ModelSetting,
+): ParsedSwitchProfileValue | null {
+  if (typeof value !== 'string' || !value.startsWith(SWITCH_PROFILE_VALUE_PREFIX)) {
+    return null
+  }
+  const tail = value.slice(SWITCH_PROFILE_VALUE_PREFIX.length)
+  const sep = tail.indexOf(':')
+  if (sep <= 0 || sep === tail.length - 1) {
+    return null
+  }
+  return {
+    profileId: tail.slice(0, sep),
+    model: tail.slice(sep + 1),
+  }
+}
+
+export function encodeSwitchProfileValue(profileId: string, model: string): string {
+  return `${SWITCH_PROFILE_VALUE_PREFIX}${profileId}:${model}`
 }
 
 function getScopedAdditionalModelOptions(): ModelOption[] {
@@ -558,13 +604,25 @@ function getModelOptionsBase(fastMode = false): ModelOption[] {
   // getActiveProviderProfile which would affect users with inactive profiles.
   const profileEnvApplied = process.env.CLAUDE_CODE_PROVIDER_PROFILE_ENV_APPLIED === '1'
   const profileModelOptions: ModelOption[] = []
+  let activeProfileId: string | undefined
   if (profileEnvApplied) {
     const activeProfile = getActiveProviderProfile()
     if (activeProfile) {
+      activeProfileId = activeProfile.id
       const models = getProfileModelOptions(activeProfile)
       profileModelOptions.push(...models)
     }
   }
+
+  // Inactive provider profile options. Surfaces each configured-but-inactive
+  // provider profile's models in the picker so users can switch active provider
+  // + model from `/model` instead of having to round-trip through `/provider`
+  // (issue #1119). Only built when the active profile env is applied so we
+  // don't expose this affordance to users who haven't opted into the
+  // multi-profile workflow.
+  const inactiveProfileOptions: ModelOption[] = profileEnvApplied
+    ? getInactiveProviderProfileOptions(activeProfileId)
+    : []
 
   // PAYG 1P API: Default (Sonnet) + Sonnet 1M + Opus 4.8 + Opus 4.7 + Opus 4.6 + Opus 1M + Haiku
   if (getAPIProvider() === 'firstParty') {
@@ -584,6 +642,7 @@ function getModelOptionsBase(fastMode = false): ModelOption[] {
     }
     payg1POptions.push(getHaiku45Option())
     payg1POptions.push(...profileModelOptions)
+    payg1POptions.push(...inactiveProfileOptions)
     return payg1POptions
   }
 
@@ -627,7 +686,42 @@ function getModelOptionsBase(fastMode = false): ModelOption[] {
     payg3pOptions.push(getHaikuOption())
   }
   payg3pOptions.push(...profileModelOptions)
+  payg3pOptions.push(...inactiveProfileOptions)
   return payg3pOptions
+}
+
+/**
+ * Build picker options for each provider profile that is NOT currently active.
+ * Selecting one of these activates the profile (swapping `OPENAI_BASE_URL` /
+ * `OPENAI_API_KEY` / etc. via `setActiveProviderProfile`) and then sets the
+ * main-loop model to the chosen entry — the equivalent of `/provider` followed
+ * by `/model`, but in one step. See issue #1119.
+ */
+export function getInactiveProviderProfileOptions(
+  activeProfileId: string | undefined,
+): ModelOption[] {
+  const profiles = getProviderProfiles()
+  const options: ModelOption[] = []
+  for (const profile of profiles) {
+    if (profile.id === activeProfileId) {
+      continue
+    }
+    const baseOptions = getProfileModelOptions(profile)
+    for (const baseOption of baseOptions) {
+      const modelValue =
+        typeof baseOption.value === 'string' ? baseOption.value : ''
+      if (!modelValue) {
+        continue
+      }
+      options.push({
+        value: encodeSwitchProfileValue(profile.id, modelValue),
+        label: `${modelValue} · ${profile.name}`,
+        description: `Switch to ${profile.name} (${profile.baseUrl})`,
+        switchToProfileId: profile.id,
+      })
+    }
+  }
+  return options
 }
 
 // @[MODEL LAUNCH]: Add the new model ID to the appropriate family pattern below

--- a/src/utils/model/modelOptions.ts
+++ b/src/utils/model/modelOptions.ts
@@ -463,6 +463,37 @@ function getCopilotModelOptions(): ModelOption[] {
 }
 
 function getModelOptionsBase(fastMode = false): ModelOption[] {
+  // When a provider profile's env is applied, collect its models so they
+  // can be appended to the picker options below.
+  // We check PROFILE_ENV_APPLIED to avoid the ?? profiles[0] fallback in
+  // getActiveProviderProfile which would affect users with inactive profiles.
+  //
+  // Hoisted above the local OpenAI-compatible early returns (Ollama and the
+  // route-catalog scope) because users with a local profile active still need
+  // the unified `/model` switcher to surface every other configured profile —
+  // otherwise they have to round-trip through `/provider` (issue #1119).
+  const profileEnvApplied = process.env.CLAUDE_CODE_PROVIDER_PROFILE_ENV_APPLIED === '1'
+  const profileModelOptions: ModelOption[] = []
+  let activeProfileId: string | undefined
+  if (profileEnvApplied) {
+    const activeProfile = getActiveProviderProfile()
+    if (activeProfile) {
+      activeProfileId = activeProfile.id
+      const models = getProfileModelOptions(activeProfile)
+      profileModelOptions.push(...models)
+    }
+  }
+
+  // Inactive provider profile options. Surfaces each configured-but-inactive
+  // provider profile's models in the picker so users can switch active provider
+  // + model from `/model` instead of having to round-trip through `/provider`
+  // (issue #1119). Only built when the active profile env is applied so we
+  // don't expose this affordance to users who haven't opted into the
+  // multi-profile workflow.
+  const inactiveProfileOptions: ModelOption[] = profileEnvApplied
+    ? getInactiveProviderProfileOptions(activeProfileId)
+    : []
+
   if (getAPIProvider() === 'github') {
     return [getDefaultOptionForUser(fastMode), ...getCopilotModelOptions()]
   }
@@ -472,7 +503,7 @@ function getModelOptionsBase(fastMode = false): ModelOption[] {
     const defaultOption = getDefaultOptionForUser(fastMode)
     const ollamaModels = getCachedOllamaModelOptions()
     if (ollamaModels.length > 0) {
-      return [defaultOption, ...ollamaModels]
+      return [defaultOption, ...ollamaModels, ...inactiveProfileOptions]
     }
     // Fallback: if models not yet fetched, show current model instead of Claude models
     const currentModel = getUserSpecifiedModelSetting() ?? getInitialMainLoopModel()
@@ -484,9 +515,10 @@ function getModelOptionsBase(fastMode = false): ModelOption[] {
           label: currentModel,
           description: 'Currently configured Ollama model',
         },
+        ...inactiveProfileOptions,
       ]
     }
-    return [defaultOption]
+    return [defaultOption, ...inactiveProfileOptions]
   }
 
   // When using NVIDIA NIM, show models from the NVIDIA catalog
@@ -572,37 +604,6 @@ function getModelOptionsBase(fastMode = false): ModelOption[] {
     standardOptions.push(MaxHaiku45Option)
     return standardOptions
   }
-
-  // When a provider profile's env is applied, collect its models so they
-  // can be appended to the picker options below.
-  // We check PROFILE_ENV_APPLIED to avoid the ?? profiles[0] fallback in
-  // getActiveProviderProfile which would affect users with inactive profiles.
-  //
-  // Hoisted above the local OpenAI-compatible early return because users with
-  // a local profile active (Ollama, lm-studio, etc.) still need the unified
-  // `/model` switcher to surface every other configured profile — otherwise
-  // they have to round-trip through `/provider`.
-  const profileEnvApplied = process.env.CLAUDE_CODE_PROVIDER_PROFILE_ENV_APPLIED === '1'
-  const profileModelOptions: ModelOption[] = []
-  let activeProfileId: string | undefined
-  if (profileEnvApplied) {
-    const activeProfile = getActiveProviderProfile()
-    if (activeProfile) {
-      activeProfileId = activeProfile.id
-      const models = getProfileModelOptions(activeProfile)
-      profileModelOptions.push(...models)
-    }
-  }
-
-  // Inactive provider profile options. Surfaces each configured-but-inactive
-  // provider profile's models in the picker so users can switch active provider
-  // + model from `/model` instead of having to round-trip through `/provider`
-  // (issue #1119). Only built when the active profile env is applied so we
-  // don't expose this affordance to users who haven't opted into the
-  // multi-profile workflow.
-  const inactiveProfileOptions: ModelOption[] = profileEnvApplied
-    ? getInactiveProviderProfileOptions(activeProfileId)
-    : []
 
   // Local OpenAI-compatible / route-catalog scope. Inactive-profile options are
   // appended here too so the unified `/model` switcher still surfaces every


### PR DESCRIPTION
## Summary

Follow-up to #1146 (which lands the Codex/GPT suppression piece). This PR addresses the second piece @Vasanthdev2004 [split out](https://github.com/Gitlawb/openclaude/issues/1119#issuecomment-4430190083) — making `/model` a single switcher across configured `providerProfiles` instead of forcing a `/provider` round-trip.

- `ModelOption` gains an optional `switchToProfileId`. Existing options leave it unset and behave exactly as today.
- `getInactiveProviderProfileOptions()` enumerates every configured profile that isn't the active one and emits a picker entry per model, labelled `<model> · <profile.name>` so the user can see they're changing providers, not just the model — addresses Vasanthdev's concern about confusing "change model only" with "change provider/base URL/API key".
- Each entry's `value` is encoded with `__switch_profile__:<id>:<model>` so the picker's plain-string `value` channel stays the source of truth and same-named models under different base URLs (e.g. `gpt-4o` on multiple OpenAI-compatible endpoints) stay disambiguated. Decoded via the new `parseSwitchProfileValue` helper.
- `/model`'s `handleSelect` detects the prefix, calls `setActiveProviderProfile(id)` (the same call path `/provider` uses — applies env, persists active profile, refreshes startup file), then sets `mainLoopModel` to the bare model string. No new env-management surface.
- Only surfaces inactive options when `CLAUDE_CODE_PROVIDER_PROFILE_ENV_APPLIED` is set, so users who haven't opted into the multi-profile workflow don't see the affordance.

With @suenot's 4-profile repro (Kimi active, GLM-5.1 / DeepSeek V4 Flash / MiniMax inactive), the picker now reads:

```
 1. Default (recommended)
 2. <Sonnet/Opus/Haiku 3P entries>
 3. kimi-k2.6 ✓                                Provider: Kimi
 4. glm-5.1 · GLM-5.1 (Z.AI)                   Switch to GLM-5.1 (Z.AI) (https://api.z.ai/api/anthropic)
 5. deepseek/deepseek-v4-flash:nitro · …       Switch to DeepSeek V4 Flash (OpenRouter) (https://openrouter.ai/api/v1)
 6. MiniMax-M2.5 · MiniMax (SambaNova)         Switch to MiniMax (SambaNova) (https://api.sambanova.ai)
```

## Impact

- user-facing impact: `/model` becomes the unified switcher requested in #1119 for multi-profile users. Users with a single profile see no behavior change (no inactive profiles → empty append).
- developer/maintainer impact: one new field on `ModelOption` (optional, no downstream consumer requires it), two small pure helpers (`parseSwitchProfileValue` / `encodeSwitchProfileValue`), and one new `handleSelect` branch in the `/model` command. No change to `ModelPicker`'s `onSelect: (model, effort)` shape — the profile id is carried through the `value` channel.

## Testing

- [x] `bun run build` — green
- [x] focused tests: `bun test src/utils/model/modelOptions.crossProfile.test.ts` — 8/8 pass (round-trip encode/parse, `:` preservation for OpenRouter model strings, active-filter, multi-model explosion, env-applied vs not).
- [x] combined mock-leak guard: `bun test src/utils/model/ src/commands/model/ src/utils/providerProfiles.test.ts` — 165/165 pass.
- [ ] `bun run smoke` — fails on this checkout with `Cannot find package '@orama/orama'`; reproduces on clean `main` HEAD `4d2de51` (pre-existing local env issue, unrelated to this change).

## Notes

- provider/model path tested: `getModelOptions()` 3P path (`getAPIProvider() === 'openai'`, non-subscriber, profile env applied). The 1P path also appends `inactiveProfileOptions` so a 1P user with extra 3P profiles configured can still see them, mirroring how `profileModelOptions` is already appended in both branches.
- The `:` separator inside the encoded `value` only splits on the FIRST colon — explicitly tested with `deepseek/deepseek-v4-flash:nitro` since OpenRouter model strings carry `:` segments.
- Out of scope: surfacing `agentModels` from `settings.json` (different shape — those are subagent-routing entries with their own `base_url`/`api_key`; a separate UX decision about whether to expose subagent providers as first-class `/model` options).
- Per the 2026-04-30 lesson on bun:test `mock.module` surface leaks: every `mock.module(path, factory)` call in the new test file spreads `import * as actual from path` and only overrides the symbols the test needs.

Refs #1119 — piece 2 of two.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * The unified **/model** picker now supports cross-profile switching in one step, including fast-mode reconciliation when moving to a different provider profile.

* **Improvements**
  * Confirmation messages now reflect the final fast-mode state, preserve selected effort, and include “Billed as extra usage” when applicable.
  * Cross-profile switch options are hidden from inline pickers and removed from SDK/headless model lists; allowlist checks apply to the decoded target model.

* **Documentation**
  * Clarified provider-profile picker behavior and limits in advanced setup.

* **Tests**
  * Added coverage for switch value parsing, allowlist gating, and fast-mode edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->