### PR TITLE
feat(provider): add Gitlawb Opengateway as default provider with MiMo

### DIFF
--- a/src/components/ProviderManager.test.tsx
+++ b/src/components/ProviderManager.test.tsx
@@ -98,13 +98,14 @@ async function waitForCondition(
 }
 
 // Provider list is sorted from generated preset metadata by description, with
-// Codex OAuth injected into slot 7 and Custom always pinned last. Keep the
-// target-by-label indirection here so these tests survive future list edits
-// without hardcoding raw key counts.
+// Gitlawb Opengateway pinned first, Codex OAuth injected after DeepSeek, and
+// Custom always pinned last. Keep the target-by-label indirection here so
+// these tests survive future list edits without hardcoding raw key counts.
 //
 // Order matches ProviderManager.renderPresetSelection() when
 // canUseCodexOAuth === true (default in mocked tests).
 const PRESET_ORDER = [
+  'Gitlawb Opengateway',
   'Anthropic',
   'Alibaba Coding Plan (China)',
   'Alibaba Coding Plan',

--- a/src/components/ProviderManager.tsx
+++ b/src/components/ProviderManager.tsx
@@ -219,16 +219,25 @@ function toDraft(profile: ProviderProfile): ProviderDraft {
 }
 
 function getPresetLabel(preset: ProviderPreset, label: string): React.ReactNode {
-  if (preset !== 'xiaomi-mimo') {
-    return label
+  if (preset === 'gitlawb-opengateway') {
+    return (
+      <Text>
+        <Text>{label} </Text>
+        <Text color="success" bold>[FREE]</Text>
+      </Text>
+    )
   }
 
-  return (
-    <Text>
-      <Text>{label} </Text>
-      <Text color="success" bold>[Sponsor]</Text>
-    </Text>
-  )
+  if (preset === 'xiaomi-mimo') {
+    return (
+      <Text>
+        <Text>{label} </Text>
+        <Text color="success" bold>[Sponsor]</Text>
+      </Text>
+    )
+  }
+
+  return label
 }
 
 function presetToDraft(preset: ProviderPreset): ProviderDraft {

--- a/src/components/ProviderManager.tsx
+++ b/src/components/ProviderManager.tsx
@@ -1545,7 +1545,9 @@ export function ProviderManager({ mode, onDone }: Props): React.ReactNode {
     })
 
     if (canUseCodexOAuth) {
-      options.splice(6, 0, {
+      // Insert after DeepSeek so Codex OAuth keeps its established position
+      // in the picker even with Gitlawb Opengateway pinned at the top.
+      options.splice(7, 0, {
         value: 'codex-oauth',
         label: (
           <Text>

--- a/src/integrations/artifactGenerator.ts
+++ b/src/integrations/artifactGenerator.ts
@@ -232,6 +232,16 @@ function compareProviderPresetEntries(
     return 0
   }
 
+  // Pin Gitlawb Opengateway first — the free zero-config default
+  // (Xiaomi partnership). Surfaces ahead of anthropic so users without
+  // their own provider credentials hit the working option immediately.
+  if (leftPreset === 'gitlawb-opengateway') {
+    return -1
+  }
+  if (rightPreset === 'gitlawb-opengateway') {
+    return 1
+  }
+
   if (leftPreset === 'anthropic') {
     return -1
   }

--- a/src/integrations/compatibility.test.ts
+++ b/src/integrations/compatibility.test.ts
@@ -40,6 +40,7 @@ const EXPECTED_PRESETS = [
   'zai',
   'bankr',
   'atomic-chat',
+  'gitlawb-opengateway',
 ] as const satisfies readonly ProviderPreset[]
 
 describe('compatibility mappings', () => {

--- a/src/integrations/gateways/gitlawb-opengateway.ts
+++ b/src/integrations/gateways/gitlawb-opengateway.ts
@@ -1,0 +1,77 @@
+import { defineGateway } from '../define.js'
+
+export default defineGateway({
+  id: 'gitlawb-opengateway',
+  label: 'Gitlawb Opengateway',
+  category: 'aggregating',
+  defaultBaseUrl: 'https://opengateway.gitlawb.com/v1/xiaomi-mimo',
+  defaultModel: 'mimo-v2.5-pro',
+  supportsModelRouting: true,
+  vendorId: 'xiaomi-mimo',
+  setup: {
+    requiresAuth: false,
+    authMode: 'none',
+  },
+  transportConfig: {
+    kind: 'openai-compatible',
+    openaiShim: {
+      defaultAuthHeader: {
+        name: 'api-key',
+        scheme: 'raw',
+      },
+      preserveReasoningContent: true,
+      requireReasoningContentOnAssistantMessages: true,
+      reasoningContentFallback: '',
+      maxTokensField: 'max_completion_tokens',
+      supportsApiFormatSelection: false,
+      supportsAuthHeaders: false,
+    },
+  },
+  preset: {
+    id: 'gitlawb-opengateway',
+    description: 'Gitlawb Opengateway — free hosted MiMo (Xiaomi partnership)',
+    label: 'Gitlawb Opengateway',
+    name: 'Gitlawb Opengateway',
+    vendorId: 'xiaomi-mimo',
+    modelEnvVars: ['OPENAI_MODEL'],
+    baseUrlEnvVars: ['OPENGATEWAY_BASE_URL', 'OPENAI_BASE_URL'],
+    fallbackBaseUrl: 'https://opengateway.gitlawb.com/v1/xiaomi-mimo',
+    fallbackModel: 'mimo-v2.5-pro',
+  },
+  catalog: {
+    source: 'static',
+    models: [
+      {
+        id: 'opengateway-mimo-v2.5-pro',
+        apiName: 'mimo-v2.5-pro',
+        label: 'MiMo V2.5 Pro (via Opengateway)',
+        modelDescriptorId: 'mimo-v2.5-pro',
+      },
+      {
+        id: 'opengateway-mimo-v2-pro',
+        apiName: 'mimo-v2-pro',
+        label: 'MiMo V2 Pro (via Opengateway)',
+        modelDescriptorId: 'mimo-v2-pro',
+      },
+      {
+        id: 'opengateway-mimo-v2.5',
+        apiName: 'mimo-v2.5',
+        label: 'MiMo V2.5 (via Opengateway)',
+        modelDescriptorId: 'mimo-v2.5',
+      },
+      {
+        id: 'opengateway-mimo-v2-omni',
+        apiName: 'mimo-v2-omni',
+        label: 'MiMo V2 Omni (via Opengateway)',
+        modelDescriptorId: 'mimo-v2-omni',
+      },
+      {
+        id: 'opengateway-mimo-v2-flash',
+        apiName: 'mimo-v2-flash',
+        label: 'MiMo V2 Flash (via Opengateway)',
+        modelDescriptorId: 'mimo-v2-flash',
+      },
+    ],
+  },
+  usage: { supported: false },
+})

--- a/src/integrations/generated/integrationArtifacts.generated.ts
+++ b/src/integrations/generated/integrationArtifacts.generated.ts
@@ -20,6 +20,7 @@ import gatewayCustom from '../gateways/custom.js'
 import gatewayDashscopeCn from '../gateways/dashscope-cn.js'
 import gatewayDashscopeIntl from '../gateways/dashscope-intl.js'
 import gatewayGithub from '../gateways/github.js'
+import gatewayGitlawbOpengateway from '../gateways/gitlawb-opengateway.js'
 import gatewayGroq from '../gateways/groq.js'
 import gatewayHicap from '../gateways/hicap.js'
 import gatewayKimiCode from '../gateways/kimi-code.js'
@@ -60,13 +61,32 @@ import modelXai from '../models/xai.js'
 import modelXiaomiMimo from '../models/xiaomi-mimo.js'
 
 export const VENDOR_DESCRIPTORS = [vendorAnthropic, vendorBankr, vendorDeepseek, vendorGemini, vendorMinimax, vendorMoonshot, vendorOpenai, vendorVenice, vendorXai, vendorXiaomiMimo, vendorZai] as const satisfies readonly VendorDescriptor[]
-export const GATEWAY_DESCRIPTORS = [gatewayAtomicChat, gatewayAzureOpenai, gatewayBedrock, gatewayCustom, gatewayDashscopeCn, gatewayDashscopeIntl, gatewayGithub, gatewayGroq, gatewayHicap, gatewayKimiCode, gatewayLmstudio, gatewayMistral, gatewayNvidiaNim, gatewayOllama, gatewayOpenrouter, gatewayTogether, gatewayVertex] as const satisfies readonly GatewayDescriptor[]
+export const GATEWAY_DESCRIPTORS = [gatewayAtomicChat, gatewayAzureOpenai, gatewayBedrock, gatewayCustom, gatewayDashscopeCn, gatewayDashscopeIntl, gatewayGithub, gatewayGitlawbOpengateway, gatewayGroq, gatewayHicap, gatewayKimiCode, gatewayLmstudio, gatewayMistral, gatewayNvidiaNim, gatewayOllama, gatewayOpenrouter, gatewayTogether, gatewayVertex] as const satisfies readonly GatewayDescriptor[]
 export const ANTHROPIC_PROXY_DESCRIPTORS = [] as const satisfies readonly AnthropicProxyDescriptor[]
 export const BRAND_DESCRIPTORS = [brandClaude, brandDeepseek, brandGemini, brandGlm, brandGpt, brandKimi, brandLlama, brandMinimax, brandMistral, brandNemotron, brandOpenaiCompatibleAlias, brandQwen, brandXai, brandXiaomiMimo] as const satisfies readonly BrandDescriptor[]
 export const MODEL_DESCRIPTOR_GROUPS = [modelClaude, modelDeepseek, modelGemini, modelGlm, modelGpt, modelKimi, modelLlama, modelMinimax, modelMistral, modelNemotron, modelOpenaiCompatibleAlias, modelQwen, modelXai, modelXiaomiMimo] as const satisfies readonly (readonly ModelDescriptor[])[]
 export const MODEL_DESCRIPTORS = MODEL_DESCRIPTOR_GROUPS.flat() satisfies readonly ModelDescriptor[]
 
 export const PROVIDER_PRESET_MANIFEST = [
+  {
+    "preset": "gitlawb-opengateway",
+    "routeKind": "gateway",
+    "routeId": "gitlawb-opengateway",
+    "vendorId": "xiaomi-mimo",
+    "gatewayId": "gitlawb-opengateway",
+    "description": "Gitlawb Opengateway — free hosted MiMo (Xiaomi partnership)",
+    "label": "Gitlawb Opengateway",
+    "name": "Gitlawb Opengateway",
+    "baseUrlEnvVars": [
+      "OPENGATEWAY_BASE_URL",
+      "OPENAI_BASE_URL"
+    ],
+    "modelEnvVars": [
+      "OPENAI_MODEL"
+    ],
+    "fallbackBaseUrl": "https://opengateway.gitlawb.com/v1/xiaomi-mimo",
+    "fallbackModel": "mimo-v2.5-pro"
+  },
   {
     "preset": "anthropic",
     "routeKind": "vendor",
@@ -375,6 +395,7 @@ export const PROVIDER_PRESET_MANIFEST = [
 ] as const satisfies readonly ProviderPresetManifestEntry[]
 export type ProviderPreset = (typeof PROVIDER_PRESET_MANIFEST)[number]['preset']
 export const ORDERED_PROVIDER_PRESETS = [
+  "gitlawb-opengateway",
   "anthropic",
   "dashscope-cn",
   "dashscope-intl",

--- a/src/utils/providerAutoDetect.test.ts
+++ b/src/utils/providerAutoDetect.test.ts
@@ -273,7 +273,7 @@ describe('detectBestProvider — orchestrator', () => {
     expect(result?.kind).toBe('ollama')
   })
 
-  test('skipLocal prevents network probes', async () => {
+  test('skipLocal prevents network probes and falls back to opengateway', async () => {
     let probeCalled = false
     const fetchImpl = (async () => {
       probeCalled = true
@@ -286,11 +286,12 @@ describe('detectBestProvider — orchestrator', () => {
       skipLocal: true,
       hasCodexAuth: () => false,
     })
-    expect(result).toBeNull()
+    expect(result?.kind).toBe('gitlawb-opengateway')
+    expect(result?.model).toBe('mimo-v2.5-pro')
     expect(probeCalled).toBe(false)
   })
 
-  test('completely empty environment returns null', async () => {
+  test('completely empty environment falls back to Gitlawb Opengateway', async () => {
     const fetchImpl = (async () => {
       throw new Error('nothing reachable')
     }) as typeof fetch
@@ -300,6 +301,38 @@ describe('detectBestProvider — orchestrator', () => {
       fetchImpl,
       timeoutMs: 100,
       hasCodexAuth: () => false,
+    })
+    expect(result?.kind).toBe('gitlawb-opengateway')
+    expect(result?.baseUrl).toBe('https://opengateway.gitlawb.com/v1/xiaomi-mimo')
+    expect(result?.model).toBe('mimo-v2.5-pro')
+  })
+
+  test('OPENGATEWAY_BASE_URL env overrides the opengateway fallback base URL', async () => {
+    const fetchImpl = (async () => {
+      throw new Error('nothing reachable')
+    }) as typeof fetch
+
+    const result = await detectBestProvider({
+      env: { OPENGATEWAY_BASE_URL: 'http://localhost:8181/v1/xiaomi-mimo' },
+      fetchImpl,
+      timeoutMs: 100,
+      hasCodexAuth: () => false,
+    })
+    expect(result?.kind).toBe('gitlawb-opengateway')
+    expect(result?.baseUrl).toBe('http://localhost:8181/v1/xiaomi-mimo')
+  })
+
+  test('skipOpengatewayFallback returns null when nothing else is detected', async () => {
+    const fetchImpl = (async () => {
+      throw new Error('nothing reachable')
+    }) as typeof fetch
+
+    const result = await detectBestProvider({
+      env: {},
+      fetchImpl,
+      timeoutMs: 100,
+      hasCodexAuth: () => false,
+      skipOpengatewayFallback: true,
     })
     expect(result).toBeNull()
   })

--- a/src/utils/providerAutoDetect.ts
+++ b/src/utils/providerAutoDetect.ts
@@ -45,6 +45,7 @@ export type DetectedProviderKind =
   | 'xai'
   | 'ollama'
   | 'lm-studio'
+  | 'gitlawb-opengateway'
 
 export type DetectedProvider = {
   kind: DetectedProviderKind
@@ -267,6 +268,26 @@ export async function detectLocalService(options?: {
  * Orchestrator: env scan first (sync, free), then local-service probes
  * (async, ~1-2s worst case) only if nothing was found in env.
  */
+const OPENGATEWAY_DEFAULT_BASE_URL = 'https://opengateway.gitlawb.com/v1/xiaomi-mimo'
+const OPENGATEWAY_DEFAULT_MODEL = 'mimo-v2.5-pro'
+
+/**
+ * Zero-config fallback: the Gitlawb Opengateway exposes free MiMo inference
+ * (Xiaomi partnership) without requiring any API key. This is the default
+ * any fresh install lands on when no credentials or local services exist.
+ */
+function defaultOpengatewayProvider(env: EnvLike): DetectedProvider {
+  const baseUrl =
+    (typeof env.OPENGATEWAY_BASE_URL === 'string' && env.OPENGATEWAY_BASE_URL.trim()) ||
+    OPENGATEWAY_DEFAULT_BASE_URL
+  return {
+    kind: 'gitlawb-opengateway',
+    source: 'Gitlawb Opengateway (free MiMo — no key required)',
+    baseUrl,
+    model: OPENGATEWAY_DEFAULT_MODEL,
+  }
+}
+
 export async function detectBestProvider(options?: {
   env?: EnvLike
   fetchImpl?: typeof fetch
@@ -275,6 +296,11 @@ export async function detectBestProvider(options?: {
   skipLocal?: boolean
   /** Override for Codex auth-file detection. See detectProviderFromEnv. */
   hasCodexAuth?: () => boolean
+  /**
+   * Disable the Gitlawb Opengateway fallback. Returns null when no other
+   * provider is detected. Use this in tests that need to assert "nothing found".
+   */
+  skipOpengatewayFallback?: boolean
 }): Promise<DetectedProvider | null> {
   const env = options?.env ?? process.env
 
@@ -284,11 +310,16 @@ export async function detectBestProvider(options?: {
   })
   if (fromEnv) return fromEnv
 
-  if (options?.skipLocal) return null
+  if (!options?.skipLocal) {
+    const local = await detectLocalService({
+      env,
+      fetchImpl: options?.fetchImpl,
+      timeoutMs: options?.timeoutMs,
+    })
+    if (local) return local
+  }
 
-  return detectLocalService({
-    env,
-    fetchImpl: options?.fetchImpl,
-    timeoutMs: options?.timeoutMs,
-  })
+  if (options?.skipOpengatewayFallback) return null
+
+  return defaultOpengatewayProvider(env)
 }


### PR DESCRIPTION
Registers https://opengateway.gitlawb.com/v1/xiaomi-mimo as a first-class gateway descriptor in openclaude. Pins it first in the provider picker order (ahead of anthropic) and surfaces it with a green [FREE] badge in the picker UI. Wires detectBestProvider() to fall back to opengateway with mimo-v2.5-pro when no other credentials or local services are detected, making fresh installs work zero-config during the Xiaomi free-inference partnership window.

- src/integrations/gateways/gitlawb-opengateway.ts: gateway descriptor, static catalog of all five mimo models, requiresAuth: false
- src/integrations/artifactGenerator.ts: sort comparator pins gitlawb-opengateway before anthropic
- src/utils/providerAutoDetect.ts: opengateway is the last-resort fallback; OPENGATEWAY_BASE_URL env override for local dev; skipOpengatewayFallback escape hatch for tests
- src/components/ProviderManager.tsx: getPresetLabel renders a green [FREE] badge for the opengateway preset, matching the existing [Sponsor] badge pattern used for xiaomi-mimo