### PR TITLE
fix(plugins): use mergeHooksSettings in marketplace supplement path (#1055)

### DIFF
--- a/src/utils/plugins/pluginLoader.test.ts
+++ b/src/utils/plugins/pluginLoader.test.ts
@@ -8,6 +8,7 @@ import type { LoadedPlugin } from '../../types/plugin.js'
 import {
   clearPluginCache,
   createPluginFromPath,
+  mergeHooksSettings,
   mergePluginSources,
   resolveExistingPluginComponentPath,
   resolvePluginComponentPath,
@@ -84,6 +85,55 @@ describe('mergePluginSources', () => {
       source: legacy.source,
       plugin: legacy.name,
     })
+  })
+})
+
+describe('mergeHooksSettings', () => {
+  // Regression for #1055: the marketplace-supplement path previously used
+  // object spread, which replaced the entire per-event matcher array from
+  // plugin.json with the marketplace entry's array. mergeHooksSettings is
+  // the helper that must be used at that call site; this test locks in
+  // the concat-not-replace contract the call site depends on.
+  test('concatenates per-event matcher arrays instead of replacing them', () => {
+    const base = {
+      PreToolUse: [{ matcher: 'Bash', hooks: [{ type: 'command', command: 'A' }] }],
+    } as never
+    const additional = {
+      PreToolUse: [{ matcher: 'Bash', hooks: [{ type: 'command', command: 'B' }] }],
+    } as never
+
+    const merged = mergeHooksSettings(base, additional) as never as {
+      PreToolUse: Array<{ hooks: Array<{ command: string }> }>
+    }
+
+    expect(merged.PreToolUse).toHaveLength(2)
+    expect(merged.PreToolUse[0].hooks[0].command).toBe('A')
+    expect(merged.PreToolUse[1].hooks[0].command).toBe('B')
+  })
+
+  test('keeps disjoint events from both inputs', () => {
+    const base = {
+      PreToolUse: [{ matcher: 'Bash', hooks: [{ type: 'command', command: 'pre' }] }],
+    } as never
+    const additional = {
+      PostToolUse: [{ matcher: 'Bash', hooks: [{ type: 'command', command: 'post' }] }],
+    } as never
+
+    const merged = mergeHooksSettings(base, additional) as never as {
+      PreToolUse: unknown[]
+      PostToolUse: unknown[]
+    }
+
+    expect(merged.PreToolUse).toHaveLength(1)
+    expect(merged.PostToolUse).toHaveLength(1)
+  })
+
+  test('returns additional unchanged when base is undefined', () => {
+    const additional = {
+      PreToolUse: [{ matcher: 'Bash', hooks: [{ type: 'command', command: 'X' }] }],
+    } as never
+
+    expect(mergeHooksSettings(undefined, additional)).toBe(additional)
   })
 })
 

--- a/src/utils/plugins/pluginLoader.ts
+++ b/src/utils/plugins/pluginLoader.ts
@@ -2022,9 +2022,12 @@ async function loadPluginSettings(
 }
 
 /**
- * Merge two HooksSettings objects
+ * Merge two HooksSettings objects. Concatenates matcher arrays for events
+ * that appear in both `base` and `additional`. Exported so callers (and
+ * tests) can verify the supplement path keeps both sets of matchers
+ * rather than dropping the base ones via object spread.
  */
-function mergeHooksSettings(
+export function mergeHooksSettings(
   base: HooksSettings | undefined,
   additional: HooksSettings,
 ): HooksSettings {
@@ -3141,12 +3144,15 @@ async function finishLoadingPluginFromPath(
       }
     }
 
-    // Supplement hooks from marketplace entry
+    // Supplement hooks from marketplace entry. Object spread would replace
+    // each event's matcher array wholesale, silently dropping matchers that
+    // plugin.json already registered for the same event. mergeHooksSettings
+    // concatenates per-event arrays the way the rest of this file does.
     if (entry.hooks) {
-      plugin.hooksConfig = {
-        ...(plugin.hooksConfig || {}),
-        ...(entry.hooks as HooksSettings),
-      }
+      plugin.hooksConfig = mergeHooksSettings(
+        plugin.hooksConfig,
+        entry.hooks as HooksSettings,
+      )
     }
   }
 


### PR DESCRIPTION
Fixes #1055.

## Problem

In `finishLoadingPluginFromPath`, the marketplace supplement path was building `plugin.hooksConfig` with an object spread:

\`\`\`ts
if (entry.hooks) {
  plugin.hooksConfig = {
    ...(plugin.hooksConfig || {}),
    ...(entry.hooks as HooksSettings),
  }
}
\`\`\`

\`HooksSettings\` values are matcher arrays keyed by event name (\`PreToolUse\`, \`PostToolUse\`, ...). Object spread replaces the entire per-event array from \`plugin.json\` with the marketplace entry's array, silently dropping any matchers the manifest already registered for that event.

\`mergeHooksSettings\` already exists in this file (used by \`createPluginFromPath\` for the analogous merge) and concatenates per-event matcher arrays correctly. It was just never wired into the marketplace supplement path.

## Fix

- Switch the supplement path to \`mergeHooksSettings(plugin.hooksConfig, entry.hooks as HooksSettings)\`.
- Export \`mergeHooksSettings\` so the concat-not-replace contract that the call site now depends on can be locked in by a unit test.

## Tests

Added three unit tests in \`pluginLoader.test.ts\`:

- Same-event matchers from \`base\` and \`additional\` end up concatenated (regression case for #1055).
- Disjoint events from both inputs are preserved.
- \`additional\` is returned unchanged when \`base\` is \`undefined\`.

\`\`\`
bun test src/utils/plugins/pluginLoader.test.ts
 16 pass
 0 fail
\`\`\`