### PR TITLE
feat(provider): auto-switch on rate limit via providerFallbackChain (#768)

### DIFF
--- a/src/query.ts
+++ b/src/query.ts
@@ -99,6 +99,7 @@ import { runTools } from './services/tools/toolOrchestration.js'
 import { applyToolResultBudget } from './utils/toolResultStorage.js'
 import { resolveNextFallbackProviderFromState } from './utils/providerFallback.js'
 import { setActiveProviderProfile } from './utils/providerProfiles.js'
+import { getPrimaryModel } from './utils/providerModels.js'
 import { recordContentReplacement } from './utils/sessionStorage.js'
 import { handleStopHooks } from './query/stopHooks.js'
 import { buildQueryConfig } from './query/config.js'
@@ -1388,6 +1389,26 @@ async function* queryLoop(
           const activated = setActiveProviderProfile(fallback.nextProfileId)
           if (activated) {
             const fromLabel = fallback.fromProfileId ?? 'previous provider'
+            // Update the in-session model to the activated profile's primary
+            // model so the retry doesn't keep sending the rate-limited
+            // provider's model id against the new endpoint. Without this, the
+            // outer loop re-derives `currentModel` from
+            // `appState.mainLoopModelForSession ?? appState.mainLoopModel`,
+            // which still holds the previous provider's model (e.g. a Claude
+            // id), and `resolveProviderRequest` lets that explicit
+            // `options.model` win over the new profile's OPENAI_MODEL. Mirror
+            // the model_fallback branch above which updates both
+            // `toolUseContext.options.mainLoopModel` and the in-session app
+            // state.
+            const activatedModel = getPrimaryModel(activated.model)
+            if (activatedModel) {
+              toolUseContext.setAppState(prev => ({
+                ...prev,
+                mainLoopModel: activatedModel,
+                mainLoopModelForSession: null,
+              }))
+              toolUseContext.options.mainLoopModel = activatedModel
+            }
             // System informational, NOT an assistant API error. The original
             // 429 is still withheld upstream, so SDK hosts that terminate on
             // `error: 'rate_limit'` assistant messages don't see one for this

--- a/src/query.ts
+++ b/src/query.ts
@@ -1388,11 +1388,17 @@ async function* queryLoop(
           const activated = setActiveProviderProfile(fallback.nextProfileId)
           if (activated) {
             const fromLabel = fallback.fromProfileId ?? 'previous provider'
-            yield createAssistantAPIErrorMessage({
-              content:
-                `Provider ${fromLabel} rate-limited — switched to ${activated.name}. Retrying turn.`,
-              error: 'rate_limit',
-            })
+            // System informational, NOT an assistant API error. The original
+            // 429 is still withheld upstream, so SDK hosts that terminate on
+            // `error: 'rate_limit'` assistant messages don't see one for this
+            // retry path — they only get the final tagged message if the
+            // entire fallback chain is exhausted (handled by `yield
+            // lastMessage` below). Mirrors the existing model-fallback notice
+            // at the model_fallback recovery branch.
+            yield createSystemMessage(
+              `Provider ${fromLabel} rate-limited — switched to ${activated.name}. Retrying turn.`,
+              'warning',
+            )
             const next: State = {
               messages: messagesForQuery,
               toolUseContext,

--- a/src/query.ts
+++ b/src/query.ts
@@ -907,6 +907,25 @@ async function* queryLoop(
             if (isWithheldMaxOutputTokens(message)) {
               withheld = true
             }
+            // Withhold rate-limit errors when a providerFallbackChain entry is
+            // still available, so SDK consumers that terminate on yielded
+            // errors don't see the original 429 before queryLoop has a chance
+            // to switch providers and retry (jatmn review on #1176). The
+            // recovery branch below mirrors the same querySource / one-shot
+            // guards. If no fallback resolves, the recovery branch falls
+            // through to the standard error-termination path which yields
+            // the original error so the user still sees it.
+            if (
+              !hasAttemptedProviderFallback &&
+              querySource !== 'compact' &&
+              querySource !== 'session_memory' &&
+              message.type === 'assistant' &&
+              message.isApiErrorMessage === true &&
+              message.error === 'rate_limit' &&
+              resolveNextFallbackProviderFromState() !== null
+            ) {
+              withheld = true
+            }
             if (!withheld) {
               yield yieldMessage
             }
@@ -1392,9 +1411,12 @@ async function* queryLoop(
             continue
           }
         }
-        // No fallback configured / chain exhausted / activation failed — fall
-        // through to the standard API-error termination below so the user
-        // still sees the original rate-limit message.
+        // No fallback configured / chain exhausted / activation failed — yield
+        // the original rate-limit message now (the streaming withhold gate
+        // suppressed it so SDK consumers wouldn't see it before we knew a
+        // fallback was possible) and fall through to the standard API-error
+        // termination below.
+        yield lastMessage
       }
 
       // Skip stop hooks when the last message is an API error (rate limit,

--- a/src/query.ts
+++ b/src/query.ts
@@ -97,6 +97,8 @@ import { StreamingToolExecutor } from './services/tools/StreamingToolExecutor.js
 import { queryCheckpoint } from './utils/queryProfiler.js'
 import { runTools } from './services/tools/toolOrchestration.js'
 import { applyToolResultBudget } from './utils/toolResultStorage.js'
+import { resolveNextFallbackProviderFromState } from './utils/providerFallback.js'
+import { setActiveProviderProfile } from './utils/providerProfiles.js'
 import { recordContentReplacement } from './utils/sessionStorage.js'
 import { handleStopHooks } from './query/stopHooks.js'
 import { buildQueryConfig } from './query/config.js'
@@ -211,6 +213,11 @@ type State = {
   maxOutputTokensOverride: number | undefined
   pendingToolUseSummary: Promise<ToolUseSummaryMessage | null> | undefined
   stopHookActive: boolean | undefined
+  // One-shot guard for the provider-fallback recovery branch (issue #768).
+  // Set when we swap active provider in response to a rate-limit assistant
+  // error, cleared at next_turn / continuation_nudge / token_budget_continuation
+  // so a fresh user turn can fall back again.
+  hasAttemptedProviderFallback: boolean
   turnCount: number
   // Count of consecutive continuation nudges within the current turn.
   // Capped at MAX_CONTINUATION_NUDGES to prevent infinite nudge loops
@@ -287,6 +294,7 @@ async function* queryLoop(
     stopHookActive: undefined,
     maxOutputTokensRecoveryCount: 0,
     hasAttemptedReactiveCompact: false,
+    hasAttemptedProviderFallback: false,
     turnCount: 1,
     continuationNudgeCount: 0,
     pendingToolUseSummary: undefined,
@@ -329,6 +337,7 @@ async function* queryLoop(
       autoCompactTracking,
       maxOutputTokensRecoveryCount,
       hasAttemptedReactiveCompact,
+      hasAttemptedProviderFallback,
       maxOutputTokensOverride,
       pendingToolUseSummary,
       stopHookActive,
@@ -1177,6 +1186,7 @@ async function* queryLoop(
               autoCompactTracking: tracking,
               maxOutputTokensRecoveryCount,
               hasAttemptedReactiveCompact,
+              hasAttemptedProviderFallback,
               maxOutputTokensOverride: undefined,
               pendingToolUseSummary: undefined,
               stopHookActive: undefined,
@@ -1231,6 +1241,7 @@ async function* queryLoop(
             autoCompactTracking: undefined,
             maxOutputTokensRecoveryCount,
             hasAttemptedReactiveCompact: true,
+            hasAttemptedProviderFallback,
             maxOutputTokensOverride: undefined,
             pendingToolUseSummary: undefined,
             stopHookActive: undefined,
@@ -1287,6 +1298,7 @@ async function* queryLoop(
             autoCompactTracking: tracking,
             maxOutputTokensRecoveryCount,
             hasAttemptedReactiveCompact,
+            hasAttemptedProviderFallback,
             maxOutputTokensOverride: ESCALATED_MAX_TOKENS,
             pendingToolUseSummary: undefined,
             stopHookActive: undefined,
@@ -1316,6 +1328,7 @@ async function* queryLoop(
             autoCompactTracking: tracking,
             maxOutputTokensRecoveryCount: maxOutputTokensRecoveryCount + 1,
             hasAttemptedReactiveCompact,
+            hasAttemptedProviderFallback,
             maxOutputTokensOverride: undefined,
             pendingToolUseSummary: undefined,
             stopHookActive: undefined,
@@ -1332,6 +1345,56 @@ async function* queryLoop(
 
         // Recovery exhausted — surface the withheld error now.
         yield lastMessage
+      }
+
+      // Provider-fallback recovery (#768). When the active provider returns
+      // a rate-limit error and the user has configured an ordered
+      // `providerFallbackChain`, swap to the next chain entry and retry the
+      // turn once instead of bubbling the error to the UI. Skip for
+      // compact / session_memory fork queries — those are forked workers
+      // operating on the original conversation's tail; switching the active
+      // provider mid-fork would change the credentials the outer turn just
+      // committed to. Mirrors the pre-flight blocking-limit guard at
+      // ~query.ts:691.
+      const isWithheldRateLimit =
+        !hasAttemptedProviderFallback &&
+        querySource !== 'compact' &&
+        querySource !== 'session_memory' &&
+        lastMessage?.type === 'assistant' &&
+        lastMessage.isApiErrorMessage === true &&
+        lastMessage.error === 'rate_limit'
+      if (isWithheldRateLimit) {
+        const fallback = resolveNextFallbackProviderFromState()
+        if (fallback !== null) {
+          const activated = setActiveProviderProfile(fallback.nextProfileId)
+          if (activated) {
+            const fromLabel = fallback.fromProfileId ?? 'previous provider'
+            yield createAssistantAPIErrorMessage({
+              content:
+                `Provider ${fromLabel} rate-limited — switched to ${activated.name}. Retrying turn.`,
+              error: 'rate_limit',
+            })
+            const next: State = {
+              messages: messagesForQuery,
+              toolUseContext,
+              autoCompactTracking: tracking,
+              maxOutputTokensRecoveryCount,
+              hasAttemptedReactiveCompact,
+              hasAttemptedProviderFallback: true,
+              maxOutputTokensOverride: undefined,
+              pendingToolUseSummary: undefined,
+              stopHookActive: undefined,
+              turnCount,
+              continuationNudgeCount: state.continuationNudgeCount,
+              transition: { reason: 'provider_fallback_retry' },
+            }
+            state = next
+            continue
+          }
+        }
+        // No fallback configured / chain exhausted / activation failed — fall
+        // through to the standard API-error termination below so the user
+        // still sees the original rate-limit message.
       }
 
       // Skip stop hooks when the last message is an API error (rate limit,
@@ -1374,6 +1437,10 @@ async function* queryLoop(
           // here caused an infinite loop: compact → still too long → error →
           // stop hook blocking → compact → … burning thousands of API calls.
           hasAttemptedReactiveCompact,
+          // Same logic for the provider-fallback guard — a stop-hook blocking
+          // error after a fallback switch is unrelated to which provider is
+          // active, so preserve rather than re-fall-back.
+          hasAttemptedProviderFallback,
           maxOutputTokensOverride: undefined,
           pendingToolUseSummary: undefined,
           stopHookActive: true,
@@ -1411,6 +1478,7 @@ async function* queryLoop(
             autoCompactTracking: tracking,
             maxOutputTokensRecoveryCount: 0,
             hasAttemptedReactiveCompact: false,
+            hasAttemptedProviderFallback: false,
             maxOutputTokensOverride: undefined,
             pendingToolUseSummary: undefined,
             stopHookActive: undefined,
@@ -1493,6 +1561,7 @@ async function* queryLoop(
               autoCompactTracking: tracking,
               maxOutputTokensRecoveryCount: 0,
               hasAttemptedReactiveCompact: false,
+              hasAttemptedProviderFallback: false,
               maxOutputTokensOverride: undefined,
               pendingToolUseSummary: undefined,
               stopHookActive: undefined,
@@ -1903,6 +1972,7 @@ async function* queryLoop(
       turnCount: nextTurnCount,
       maxOutputTokensRecoveryCount: 0,
       hasAttemptedReactiveCompact: false,
+      hasAttemptedProviderFallback: false,
       continuationNudgeCount: 0,
       pendingToolUseSummary: nextPendingToolUseSummary,
       maxOutputTokensOverride: undefined,

--- a/src/utils/providerFallback.test.ts
+++ b/src/utils/providerFallback.test.ts
@@ -1,0 +1,185 @@
+import { afterEach, beforeEach, expect, test } from 'bun:test'
+import { mock } from 'bun:test'
+
+import {
+  resetSettingsCache,
+  setSessionSettingsCache,
+} from './settings/settingsCache.js'
+
+import * as actualProviderProfiles from './providerProfiles.js'
+
+function buildProfile(
+  overrides: Partial<actualProviderProfiles.ProviderProfile> = {},
+): actualProviderProfiles.ProviderProfile {
+  return {
+    id: 'profile_x',
+    name: 'X',
+    provider: 'openai',
+    baseUrl: 'https://api.example.com/v1',
+    model: 'example-model',
+    apiKey: 'sk-x',
+    ...overrides,
+  }
+}
+
+async function importFreshProviderFallback(
+  profileMocks: Partial<typeof actualProviderProfiles>,
+) {
+  mock.restore()
+  mock.module('./providerProfiles.js', () => ({
+    ...actualProviderProfiles,
+    ...profileMocks,
+  }))
+  const nonce = `${Date.now()}-${Math.random()}`
+  return import(`./providerFallback.js?ts=${nonce}`)
+}
+
+beforeEach(() => {
+  mock.restore()
+  setSessionSettingsCache({ settings: {}, errors: [] })
+})
+
+afterEach(() => {
+  mock.restore()
+  resetSettingsCache()
+})
+
+test('getProviderFallbackChain: returns [] when unset', async () => {
+  const { getProviderFallbackChain } = await importFreshProviderFallback({})
+  expect(getProviderFallbackChain()).toEqual([])
+})
+
+test('getProviderFallbackChain: returns configured ids', async () => {
+  setSessionSettingsCache({
+    settings: {
+      providerFallbackChain: ['profile_a', 'profile_b'],
+    } as unknown as Record<string, unknown>,
+    errors: [],
+  })
+  const { getProviderFallbackChain } = await importFreshProviderFallback({})
+  expect(getProviderFallbackChain()).toEqual(['profile_a', 'profile_b'])
+})
+
+test('getProviderFallbackChain: filters non-string + empty entries', async () => {
+  // Setting could be hand-edited to a malformed shape. Defensive filter keeps
+  // the resolver from crashing on garbage without making it the source of a
+  // hard error during a rate-limit recovery flow.
+  setSessionSettingsCache({
+    settings: {
+      providerFallbackChain: ['profile_a', '', null, 5, 'profile_b'],
+    } as unknown as Record<string, unknown>,
+    errors: [],
+  })
+  const { getProviderFallbackChain } = await importFreshProviderFallback({})
+  expect(getProviderFallbackChain()).toEqual(['profile_a', 'profile_b'])
+})
+
+test('resolveNextFallbackProvider: empty chain → null', async () => {
+  const { resolveNextFallbackProvider } = await importFreshProviderFallback({})
+  expect(resolveNextFallbackProvider('profile_a', [], [])).toBeNull()
+})
+
+test('resolveNextFallbackProvider: returns next after active', async () => {
+  const a = buildProfile({ id: 'profile_a', name: 'A' })
+  const b = buildProfile({ id: 'profile_b', name: 'B' })
+  const { resolveNextFallbackProvider } = await importFreshProviderFallback({})
+
+  const result = resolveNextFallbackProvider(
+    'profile_a',
+    ['profile_a', 'profile_b'],
+    [a, b],
+  )
+  expect(result?.nextProfileId).toBe('profile_b')
+  expect(result?.nextProfile.name).toBe('B')
+  expect(result?.fromProfileId).toBe('profile_a')
+})
+
+test('resolveNextFallbackProvider: does not wrap when active is the last entry', async () => {
+  // Wrapping would let "everything rate-limited" cycle back to the first
+  // profile that already failed and produce a churn loop. Exhaust silently
+  // and let the caller surface the original error.
+  const a = buildProfile({ id: 'profile_a' })
+  const b = buildProfile({ id: 'profile_b' })
+  const { resolveNextFallbackProvider } = await importFreshProviderFallback({})
+
+  const result = resolveNextFallbackProvider(
+    'profile_b',
+    ['profile_a', 'profile_b'],
+    [a, b],
+  )
+  expect(result).toBeNull()
+})
+
+test('resolveNextFallbackProvider: active not in chain → starts from chain[0]', async () => {
+  // User landed on a non-chain profile via `/provider` ad-hoc — treat the
+  // chain as an absolute priority list and start from the top instead of
+  // refusing to do anything.
+  const a = buildProfile({ id: 'profile_a' })
+  const b = buildProfile({ id: 'profile_b' })
+  const c = buildProfile({ id: 'profile_c' })
+  const { resolveNextFallbackProvider } = await importFreshProviderFallback({})
+
+  const result = resolveNextFallbackProvider(
+    'profile_c',
+    ['profile_a', 'profile_b'],
+    [a, b, c],
+  )
+  expect(result?.nextProfileId).toBe('profile_a')
+  expect(result?.fromProfileId).toBe('profile_c')
+})
+
+test('resolveNextFallbackProvider: skips chain entries that no longer resolve to real profiles', async () => {
+  // Chain may reference a deleted profile id. Don't surface that as a hard
+  // failure — keep advancing.
+  const a = buildProfile({ id: 'profile_a' })
+  const c = buildProfile({ id: 'profile_c' })
+  const { resolveNextFallbackProvider } = await importFreshProviderFallback({})
+
+  const result = resolveNextFallbackProvider(
+    'profile_a',
+    ['profile_a', 'profile_missing', 'profile_c'],
+    [a, c],
+  )
+  expect(result?.nextProfileId).toBe('profile_c')
+})
+
+test('resolveNextFallbackProvider: null active + chain configured → chain[0]', async () => {
+  // Edge case: pristine session with no active profile yet. The chain still
+  // serves as a priority list so the first entry wins.
+  const a = buildProfile({ id: 'profile_a' })
+  const { resolveNextFallbackProvider } = await importFreshProviderFallback({})
+
+  const result = resolveNextFallbackProvider(null, ['profile_a'], [a])
+  expect(result?.nextProfileId).toBe('profile_a')
+  expect(result?.fromProfileId).toBeNull()
+})
+
+test('resolveNextFallbackProvider: every candidate missing → null', async () => {
+  const { resolveNextFallbackProvider } = await importFreshProviderFallback({})
+  const result = resolveNextFallbackProvider(
+    'profile_a',
+    ['profile_a', 'profile_b'],
+    [], // no profiles exist
+  )
+  expect(result).toBeNull()
+})
+
+test('resolveNextFallbackProviderFromState: pulls chain + active from real settings/state', async () => {
+  const a = buildProfile({ id: 'profile_a' })
+  const b = buildProfile({ id: 'profile_b' })
+  setSessionSettingsCache({
+    settings: {
+      providerFallbackChain: ['profile_a', 'profile_b'],
+    } as unknown as Record<string, unknown>,
+    errors: [],
+  })
+  const { resolveNextFallbackProviderFromState } =
+    await importFreshProviderFallback({
+      getProviderProfiles: () => [a, b],
+      getActiveProviderProfile: () => a,
+    })
+
+  const result = resolveNextFallbackProviderFromState()
+  expect(result?.nextProfileId).toBe('profile_b')
+  expect(result?.fromProfileId).toBe('profile_a')
+})

--- a/src/utils/providerFallback.test.ts
+++ b/src/utils/providerFallback.test.ts
@@ -6,12 +6,13 @@ import {
   setSessionSettingsCache,
 } from './settings/settingsCache.js'
 
+import * as actualConfig from './config.js'
 import * as actualProviderProfiles from './providerProfiles.js'
 import * as actualSettings from './settings/settings.js'
 
 function buildProfile(
-  overrides: Partial<actualProviderProfiles.ProviderProfile> = {},
-): actualProviderProfiles.ProviderProfile {
+  overrides: Partial<actualConfig.ProviderProfile> = {},
+): actualConfig.ProviderProfile {
   return {
     id: 'profile_x',
     name: 'X',

--- a/src/utils/providerFallback.test.ts
+++ b/src/utils/providerFallback.test.ts
@@ -7,6 +7,7 @@ import {
 } from './settings/settingsCache.js'
 
 import * as actualProviderProfiles from './providerProfiles.js'
+import * as actualSettings from './settings/settings.js'
 
 function buildProfile(
   overrides: Partial<actualProviderProfiles.ProviderProfile> = {},
@@ -24,11 +25,22 @@ function buildProfile(
 
 async function importFreshProviderFallback(
   profileMocks: Partial<typeof actualProviderProfiles>,
+  settingsOverride: Record<string, unknown> = {},
 ) {
   mock.restore()
   mock.module('./providerProfiles.js', () => ({
     ...actualProviderProfiles,
     ...profileMocks,
+  }))
+  // Stub `getSettings_DEPRECATED` directly so the resolver sees the test's
+  // intended `providerFallbackChain` regardless of session-cache reset
+  // behavior under nonced re-imports. setSessionSettingsCache() works under
+  // bun locally but doesn't survive a fresh `import('?ts=...')` because the
+  // settings module loads its own cache instance on each fresh import.
+  mock.module('./settings/settings.js', () => ({
+    ...actualSettings,
+    getSettings_DEPRECATED: () => settingsOverride,
+    getInitialSettings: () => settingsOverride,
   }))
   const nonce = `${Date.now()}-${Math.random()}`
   return import(`./providerFallback.js?ts=${nonce}`)
@@ -50,13 +62,10 @@ test('getProviderFallbackChain: returns [] when unset', async () => {
 })
 
 test('getProviderFallbackChain: returns configured ids', async () => {
-  setSessionSettingsCache({
-    settings: {
-      providerFallbackChain: ['profile_a', 'profile_b'],
-    } as unknown as Record<string, unknown>,
-    errors: [],
-  })
-  const { getProviderFallbackChain } = await importFreshProviderFallback({})
+  const { getProviderFallbackChain } = await importFreshProviderFallback(
+    {},
+    { providerFallbackChain: ['profile_a', 'profile_b'] },
+  )
   expect(getProviderFallbackChain()).toEqual(['profile_a', 'profile_b'])
 })
 
@@ -64,13 +73,12 @@ test('getProviderFallbackChain: filters non-string + empty entries', async () =>
   // Setting could be hand-edited to a malformed shape. Defensive filter keeps
   // the resolver from crashing on garbage without making it the source of a
   // hard error during a rate-limit recovery flow.
-  setSessionSettingsCache({
-    settings: {
+  const { getProviderFallbackChain } = await importFreshProviderFallback(
+    {},
+    {
       providerFallbackChain: ['profile_a', '', null, 5, 'profile_b'],
-    } as unknown as Record<string, unknown>,
-    errors: [],
-  })
-  const { getProviderFallbackChain } = await importFreshProviderFallback({})
+    },
+  )
   expect(getProviderFallbackChain()).toEqual(['profile_a', 'profile_b'])
 })
 
@@ -167,17 +175,14 @@ test('resolveNextFallbackProvider: every candidate missing → null', async () =
 test('resolveNextFallbackProviderFromState: pulls chain + active from real settings/state', async () => {
   const a = buildProfile({ id: 'profile_a' })
   const b = buildProfile({ id: 'profile_b' })
-  setSessionSettingsCache({
-    settings: {
-      providerFallbackChain: ['profile_a', 'profile_b'],
-    } as unknown as Record<string, unknown>,
-    errors: [],
-  })
   const { resolveNextFallbackProviderFromState } =
-    await importFreshProviderFallback({
-      getProviderProfiles: () => [a, b],
-      getActiveProviderProfile: () => a,
-    })
+    await importFreshProviderFallback(
+      {
+        getProviderProfiles: () => [a, b],
+        getActiveProviderProfile: () => a,
+      },
+      { providerFallbackChain: ['profile_a', 'profile_b'] },
+    )
 
   const result = resolveNextFallbackProviderFromState()
   expect(result?.nextProfileId).toBe('profile_b')

--- a/src/utils/providerFallback.ts
+++ b/src/utils/providerFallback.ts
@@ -1,0 +1,97 @@
+// Auto-switch active provider when the current one returns a rate-limit /
+// quota error. Reads an ordered `providerFallbackChain` from user settings
+// (list of providerProfile ids) and advances past the currently-active id.
+// See issue #768 — "auto-switch to next configured provider on rate limit".
+//
+// Kept narrow and side-effect-free here. The query loop is responsible for
+// calling `setActiveProviderProfile()` once a target profile is resolved and
+// for emitting the inline user notification; this module only answers
+// "given the chain + the active profile, which profile id comes next, and
+// does it exist as a real configured profile?".
+
+import { getSettings_DEPRECATED } from './settings/settings.js'
+import {
+  getActiveProviderProfile,
+  getProviderProfiles,
+  type ProviderProfile,
+} from './providerProfiles.js'
+
+export type ProviderFallbackResolution = {
+  /** The profile id that comes next in the chain after `activeProfileId`. */
+  nextProfileId: string
+  /** The resolved profile object; safe to pass to `setActiveProviderProfile`. */
+  nextProfile: ProviderProfile
+  /** The profile id this resolution is moving away from. May be null when no
+   *  profile was active (rare: chain attempted from a pristine session). */
+  fromProfileId: string | null
+}
+
+/**
+ * Read the configured fallback chain. Returns an empty array when unset so
+ * callers can simply ask `getProviderFallbackChain().length === 0` instead of
+ * threading `undefined`.
+ */
+export function getProviderFallbackChain(): string[] {
+  const settings = getSettings_DEPRECATED()
+  const chain = (settings as { providerFallbackChain?: unknown }).providerFallbackChain
+  if (!Array.isArray(chain)) {
+    return []
+  }
+  return chain.filter((id): id is string => typeof id === 'string' && id.length > 0)
+}
+
+/**
+ * Find the next provider profile in the chain after the currently-active one.
+ *
+ * Semantics:
+ * - If no chain is configured → null
+ * - If the active profile is not in the chain → start from the beginning of
+ *   the chain (lets the chain serve as an absolute priority list for users
+ *   who landed on a non-chain profile via `/provider`).
+ * - If the active profile IS in the chain → return the next entry after it.
+ * - If the active profile is the last entry → null (exhausted; we don't wrap
+ *   to avoid an infinite "ratelimit → ratelimit → first profile" loop in
+ *   degraded networks).
+ * - If a candidate id in the chain doesn't resolve to an actual profile in
+ *   `providerProfiles` → skip and continue advancing.
+ */
+export function resolveNextFallbackProvider(
+  activeProfileId: string | null,
+  chain: string[] = getProviderFallbackChain(),
+  profiles: ProviderProfile[] = getProviderProfiles(),
+): ProviderFallbackResolution | null {
+  if (chain.length === 0) {
+    return null
+  }
+
+  const profilesById = new Map(profiles.map(p => [p.id, p]))
+  const activeIdx = activeProfileId === null ? -1 : chain.indexOf(activeProfileId)
+  // -1 covers both "no active profile" and "active not in chain"; both fall
+  // through to "start from chain[0]" per the doc comment above.
+  const startIdx = activeIdx === -1 ? 0 : activeIdx + 1
+
+  for (let i = startIdx; i < chain.length; i++) {
+    const candidate = chain[i]
+    if (!candidate || candidate === activeProfileId) {
+      continue
+    }
+    const profile = profilesById.get(candidate)
+    if (profile) {
+      return {
+        nextProfileId: candidate,
+        nextProfile: profile,
+        fromProfileId: activeProfileId,
+      }
+    }
+  }
+
+  return null
+}
+
+/**
+ * Convenience: read both chain and current active profile from settings/state
+ * and resolve in one call. Returns null when there's nothing to fall back to.
+ */
+export function resolveNextFallbackProviderFromState(): ProviderFallbackResolution | null {
+  return resolveNextFallbackProvider(getActiveProviderProfile()?.id ?? null)
+}

--- a/src/utils/providerFallback.ts
+++ b/src/utils/providerFallback.ts
@@ -10,10 +10,10 @@
 // does it exist as a real configured profile?".
 
 import { getSettings_DEPRECATED } from './settings/settings.js'
+import { type ProviderProfile } from './config.js'
 import {
   getActiveProviderProfile,
   getProviderProfiles,
-  type ProviderProfile,
 } from './providerProfiles.js'
 
 export type ProviderFallbackResolution = {

--- a/src/utils/settings/types.ts
+++ b/src/utils/settings/types.ts
@@ -757,6 +757,15 @@ export const SettingsSchema = lazySchema(() =>
             'Use "default" key as fallback. Model name must exist in agentModels. ' +
             'Example: { "Explore": "deepseek-chat", "general-purpose": "gpt-4o", "default": "gpt-4o" }',
         ),
+      providerFallbackChain: z
+        .array(z.string())
+        .optional()
+        .describe(
+          'Ordered list of providerProfile ids. When the active provider returns a rate-limit ' +
+            'or quota error, OpenClaude advances to the next profile in this list (starting after ' +
+            'the currently-active id) and retries the turn. ' +
+            'Example: ["provider_anthropic", "provider_openai", "provider_ollama"]',
+        ),
       fastMode: z
         .boolean()
         .optional()


### PR DESCRIPTION
## Summary

Implements the "smallest useful version" @paulerrr described in #768 — when the active provider returns a rate-limit error and the user has configured an ordered fallback list, swap to the next provider and retry the turn instead of dropping the task and surfacing the error.

Three pieces:

1. **Settings schema.** New optional `providerFallbackChain: string[]` field on the user-settings schema (`src/utils/settings/types.ts`). List of `providerProfile` ids, ordered by preference. Example:

   ```json
   {
     "providerFallbackChain": [
       "provider_anthropic",
       "provider_openai",
       "provider_ollama"
     ]
   }
   ```

2. **`src/utils/providerFallback.ts` resolver** (pure, side-effect-free):
   - `getProviderFallbackChain()` — reads + defensively filters non-string / empty entries so a malformed hand-edit doesn't crash the recovery flow
   - `resolveNextFallbackProvider(activeId, chain, profiles)` — pure function: next entry past `activeId`; skips chain entries that no longer resolve to a real profile; refuses to wrap past the last entry (avoids a degraded-network churn loop); starts from `chain[0]` when the active profile isn't in the chain (treats the chain as an absolute priority list); returns `null` on exhaustion
   - `resolveNextFallbackProviderFromState()` — convenience that pulls chain + active from settings/state
   - 11 unit tests cover each branch + malformed input

3. **Query-loop recovery branch** in `src/query.ts`, sibling to the existing reactive-compact / context-overflow recovery paths:
   - Detects `lastMessage.error === 'rate_limit'` on an `isApiErrorMessage` assistant message
   - **Skips for compact / session_memory fork query sources** — those are forked workers operating against the parent turn's already-committed credential set; switching mid-fork would change credentials under the parent. Mirrors the pre-flight blocking-limit guard at `src/query.ts:~691`.
   - Calls `setActiveProviderProfile()` (same code path `/provider` uses; persists active profile, swaps env vars including `OPENAI_BASE_URL` / `OPENAI_API_KEY`, refreshes the startup file)
   - Emits an inline `Provider <from> rate-limited — switched to <to>` assistant message tagged `error: 'rate_limit'` so the UI / transcript renders it consistently with other rate-limit messages
   - One-shot per turn via `state.hasAttemptedProviderFallback`; reset at `next_turn` / `continuation_nudge` / `token_budget_continuation` so a fresh user turn can fall back again
   - On no-fallback-configured / chain-exhausted / activation-failed → falls through to the standard rate-limit termination so the user still sees the original error

## Impact

- user-facing impact: opt-in via `providerFallbackChain` setting. Users who don't set it see no behavior change. Users who set it get automatic recovery on rate-limit / 429 with an inline `Provider X rate-limited — switched to Y` notification. Backed by the same `setActiveProviderProfile` swap `/provider` performs, so subsequent turns continue against the new provider until the user picks differently.
- developer/maintainer impact: one new optional settings field, one new pure module + tests, and one new query-loop branch that mirrors the existing reactive-compact / context-overflow recovery shape (same one-shot state-field + reset-site pattern). No changes to existing error classification or message creation.

## What this does NOT do

Out of scope per the issue's explicit "smallest useful version" framing. Each is a clean follow-up:

- A `/switch` slash command for manual provider switching without waiting for a failure (the issue lists this as a separate item).
- A `/provider next` UI affordance.
- Quota-vs-burst-429 disambiguation. Today the branch treats any `error: 'rate_limit'` assistant message the same way. If the chain is healthy this is fine; the one-shot guard prevents thrashing.
- Per-provider error-type filters (e.g. "fall back on quota but not on burst 429"). Easy to layer on a `providerFallbackErrorTypes` field later without changing the recovery shape.

## Testing

- [x] `bun run build` — green
- [x] focused tests: `bun test src/utils/providerFallback.test.ts` — 11/11 pass
- [x] combined run: `bun test src/utils/providerFallback.test.ts src/utils/model/ src/utils/providerProfiles.test.ts src/services/api/errors.test.ts src/services/compact` — 172/172 pass (mock-leak guard on the new test file via `import * as actual from path` spreads, per the 2026-04-30 lesson)
- [ ] `bun run smoke` — fails on this checkout with `Cannot find package '@orama/orama'`; reproduces on clean upstream `main` HEAD `94e8ff3` (pre-existing local env issue, unrelated to this change)
- [x] no new query-loop integration tests — the existing reactive-compact / context-overflow / max-output-tokens recovery branches in `src/query.ts` aren't covered by query-loop tests either (no `query.test.ts` harness in the repo today). Happy to add one alongside this if you'd prefer — it would be the first of its kind.

## Notes

- provider/model path tested: any provider that surfaces `error: 'rate_limit'`. That's already emitted from 5+ sites in `src/services/api/errors.ts` (Anthropic 429, quota-limit, no-headers 429, etc.) plus the OpenAI-compat shim's `rate_limited` category.
- The encoded fallback list is intentionally just profile ids — model selection follows the activated profile's `model` field, same as `/provider` switching. Cross-profile model overrides are a separate concern (matches the boundary @Vasanthdev2004 drew in #1119 piece 2).
- The `Provider X rate-limited — switched to Y` notification is emitted as an assistant `createAssistantAPIErrorMessage` with `error: 'rate_limit'` rather than a user/system meta message so the existing rate-limit transcript / styling renders it. If you prefer a distinct surface (e.g. a `meta`-style user message instead), happy to swap.

Closes #768