### PR TITLE
feat(nvidia-nim): dynamic model discovery via integrate.api.nvidia.com (#1099)

### DIFF
--- a/src/integrations/gateways/nvidia-nim.test.ts
+++ b/src/integrations/gateways/nvidia-nim.test.ts
@@ -1,0 +1,132 @@
+// Direct unit tests for the NVIDIA NIM gateway's `catalog.discovery.mapModel`
+// filter. The generic discoveryService flow is covered by the
+// `mapmodel-test` case in discoveryService.test.ts; this file pins the
+// NVIDIA-specific exclusion regex against representative model ids the live
+// `https://integrate.api.nvidia.com/v1/models` endpoint returns, so the
+// filter doesn't silently start admitting embedding / ASR / safety / image
+// models into the /model picker as NVIDIA's catalog grows.
+
+import { describe, expect, test } from 'bun:test'
+import nvidiaNim from './nvidia-nim.js'
+
+const mapModel = nvidiaNim.catalog?.discovery?.mapModel
+
+function shape(id: string, extras: Record<string, unknown> = {}) {
+  return { id, ...extras }
+}
+
+describe('nvidia-nim gateway mapModel filter', () => {
+  test('mapModel is wired and gateway uses hybrid catalog', () => {
+    expect(mapModel).toBeDefined()
+    expect(nvidiaNim.catalog?.source).toBe('hybrid')
+    expect(nvidiaNim.catalog?.discovery?.kind).toBe('openai-compatible')
+    expect(nvidiaNim.catalog?.discoveryCacheTtl).toBe('1d')
+    expect(nvidiaNim.catalog?.discoveryRefreshMode).toBe('background-if-stale')
+    expect(nvidiaNim.catalog?.allowManualRefresh).toBe(true)
+  })
+
+  test('keeps chat / instruct / reasoning / code models', () => {
+    if (!mapModel) throw new Error('mapModel missing')
+    const keep = [
+      'nvidia/llama-3.1-nemotron-70b-instruct',
+      'meta/llama-3.3-70b-instruct',
+      'qwen/qwen3-coder-480b-a35b-instruct',
+      'deepseek-ai/deepseek-v4-pro',
+      'mistralai/mixtral-8x22b-instruct-v0.1',
+      'microsoft/phi-4-mini-instruct',
+      'google/gemma-3-27b-it',
+      'moonshotai/kimi-k2.6',
+      'meta/llama-3.2-90b-vision-instruct',
+      'qwen/qwq-32b',
+    ]
+    for (const id of keep) {
+      expect(mapModel(shape(id))).toEqual({
+        id,
+        apiName: id,
+        label: id,
+      })
+    }
+  })
+
+  test('drops embedding / retriever / reranker models', () => {
+    if (!mapModel) throw new Error('mapModel missing')
+    const drop = [
+      'nvidia/embed-qa-4',
+      'nvidia/nv-embedqa-mistral-7b-v2',
+      'nvidia/nemoretriever-parse-1b',
+      'nvidia/nv-rerank-qa-mistral-4b-v3',
+    ]
+    for (const id of drop) {
+      expect(mapModel(shape(id))).toBeNull()
+    }
+  })
+
+  test('drops ASR / TTS / voice models', () => {
+    if (!mapModel) throw new Error('mapModel missing')
+    const drop = [
+      'openai/whisper-large-v3',
+      'nvidia/parakeet-rnnt-1.1b',
+      'nvidia/canary-1b',
+      'nvidia/riva-asr',
+      'nvidia/nemo-tts',
+    ]
+    for (const id of drop) {
+      expect(mapModel(shape(id))).toBeNull()
+    }
+  })
+
+  test('drops image-gen / vision-only embedding models', () => {
+    if (!mapModel) throw new Error('mapModel missing')
+    const drop = [
+      'stabilityai/sdxl-turbo',
+      'black-forest-labs/flux.1-dev',
+      'stabilityai/stable-diffusion-3-medium',
+      'microsoft/kosmos-2',
+      'microsoft/florence-2',
+      'nvidia/nvclip',
+    ]
+    for (const id of drop) {
+      expect(mapModel(shape(id))).toBeNull()
+    }
+  })
+
+  test('drops safety / guard / reward models', () => {
+    if (!mapModel) throw new Error('mapModel missing')
+    const drop = [
+      'meta/llama-guard-3-8b',
+      'nvidia/llama-3.1-nemoguard-8b-content-safety',
+      'nvidia/nemotron-content-safety',
+      'nvidia/nemotron-3-reward-340b',
+    ]
+    for (const id of drop) {
+      expect(mapModel(shape(id))).toBeNull()
+    }
+  })
+
+  test('drops inactive entries regardless of id', () => {
+    if (!mapModel) throw new Error('mapModel missing')
+    expect(
+      mapModel(shape('meta/llama-3.3-70b-instruct', { active: false })),
+    ).toBeNull()
+  })
+
+  test('drops entries without id', () => {
+    if (!mapModel) throw new Error('mapModel missing')
+    expect(mapModel({})).toBeNull()
+    expect(mapModel({ id: '' })).toBeNull()
+  })
+
+  test('forwards context_window when present', () => {
+    if (!mapModel) throw new Error('mapModel missing')
+    expect(
+      mapModel(
+        shape('meta/llama-3.3-70b-instruct', { context_window: 131072 }),
+      ),
+    ).toEqual({
+      id: 'meta/llama-3.3-70b-instruct',
+      apiName: 'meta/llama-3.3-70b-instruct',
+      label: 'meta/llama-3.3-70b-instruct',
+      contextWindow: 131072,
+    })
+  })
+})

--- a/src/integrations/gateways/nvidia-nim.test.ts
+++ b/src/integrations/gateways/nvidia-nim.test.ts
@@ -75,6 +75,23 @@ describe('nvidia-nim gateway mapModel filter', () => {
     }
   })
 
+  test('drops non-chat live-catalog entries that have no chat marker', () => {
+    if (!mapModel) throw new Error('mapModel missing')
+    // Reviewer-named bad ids the live NVIDIA endpoint currently returns. The
+    // previous exclusion regex admitted them silently; the allowlist drops
+    // them because none carry an instruct/chat/reasoning/code marker.
+    const drop = [
+      'baai/bge-m3',
+      'google/deplot',
+      'nvidia/ai-synthetic-video-detector',
+      'nvidia/gliner-pii',
+      'nvidia/ising-calibration-llama-3-8b',
+    ]
+    for (const id of drop) {
+      expect(mapModel(shape(id))).toBeNull()
+    }
+  })
+
   test('drops image-gen / vision-only embedding models', () => {
     if (!mapModel) throw new Error('mapModel missing')
     const drop = [

--- a/src/integrations/gateways/nvidia-nim.ts
+++ b/src/integrations/gateways/nvidia-nim.ts
@@ -1,5 +1,20 @@
 import { defineGateway } from '../define.js'
 
+// Patterns for catalog entries returned by https://integrate.api.nvidia.com/v1/models
+// that are NOT chat/instruct models and would clutter the /model picker:
+//   - embedding / retrieval / reranking
+//   - ASR (whisper, parakeet, canary, riva)
+//   - TTS / voice / audio
+//   - image generation (sdxl, flux, kosmos, stable-diffusion)
+//   - safety / guard / reward
+//   - vision-only models without a chat tail (note: chat models that *also* have
+//     vision keep "-vision-" but match an instruct/chat tail and stay)
+//
+// Anchored as substrings rather than word-boundaries because NVIDIA ids use
+// `/` and `-` inconsistently (e.g. `nvidia/embed-qa-4`, `microsoft/florence-2`).
+const NVIDIA_NON_CHAT_PATTERN =
+  /(embed|retriever|rerank|reward|nemoguard|content-safety|guard|whisper|parakeet|canary|riva|stable-diffusion|sdxl|flux|kosmos|florence|nvclip|colpali|pho-tabuloud|tts|voice)/i
+
 export default defineGateway({
   id: 'nvidia-nim',
   label: 'NVIDIA NIM',
@@ -35,9 +50,41 @@ export default defineGateway({
     },
   },
   catalog: {
-    source: 'static',
+    source: 'hybrid',
+    discovery: {
+      kind: 'openai-compatible',
+      mapModel(raw: unknown) {
+        const model = raw as {
+          id?: string
+          active?: boolean
+          context_window?: number
+        }
+        if (!model.id || model.active === false) {
+          return null
+        }
+        if (NVIDIA_NON_CHAT_PATTERN.test(model.id)) {
+          return null
+        }
+        return {
+          id: model.id,
+          apiName: model.id,
+          label: model.id,
+          ...(model.context_window
+            ? { contextWindow: model.context_window }
+            : {}),
+        }
+      },
+    },
+    discoveryCacheTtl: '1d',
+    discoveryRefreshMode: 'background-if-stale',
+    allowManualRefresh: true,
     models: [
-      { id: 'nvidia-llama-3.1-nemotron-70b', apiName: 'nvidia/llama-3.1-nemotron-70b-instruct', label: 'Llama 3.1 Nemotron 70B', modelDescriptorId: 'nvidia/llama-3.1-nemotron-70b-instruct' },
+      {
+        id: 'nvidia-llama-3.1-nemotron-70b',
+        apiName: 'nvidia/llama-3.1-nemotron-70b-instruct',
+        label: 'Llama 3.1 Nemotron 70B',
+        modelDescriptorId: 'nvidia/llama-3.1-nemotron-70b-instruct',
+      },
     ],
   },
   usage: { supported: false },

--- a/src/integrations/gateways/nvidia-nim.ts
+++ b/src/integrations/gateways/nvidia-nim.ts
@@ -1,19 +1,23 @@
 import { defineGateway } from '../define.js'
 
-// Patterns for catalog entries returned by https://integrate.api.nvidia.com/v1/models
-// that are NOT chat/instruct models and would clutter the /model picker:
-//   - embedding / retrieval / reranking
-//   - ASR (whisper, parakeet, canary, riva)
-//   - TTS / voice / audio
-//   - image generation (sdxl, flux, kosmos, stable-diffusion)
-//   - safety / guard / reward
-//   - vision-only models without a chat tail (note: chat models that *also* have
-//     vision keep "-vision-" but match an instruct/chat tail and stay)
+// Positive allowlist for catalog entries returned by
+// https://integrate.api.nvidia.com/v1/models. An id must match at least one
+// of these chat/instruct/reasoning/code markers to land in the /model picker.
+// This is the inverse of the previous exclusion-based filter, which silently
+// admitted any non-chat model whose id did not contain one of a fixed set of
+// keywords (e.g. `baai/bge-m3`, `google/deplot`, `nvidia/gliner-pii`).
 //
-// Anchored as substrings rather than word-boundaries because NVIDIA ids use
-// `/` and `-` inconsistently (e.g. `nvidia/embed-qa-4`, `microsoft/florence-2`).
+// Substring match against the raw id is intentional — NVIDIA mixes `/`, `-`,
+// and `_` separators inconsistently, and most chat ids carry an unambiguous
+// instruct/reasoning/code marker somewhere in the id.
+const NVIDIA_CHAT_MODEL_PATTERN =
+  /(instruct|chat(?:qa)?|nemotron|reasoning|reasoner|thinker|thinking|coder|codellama|starcoder|codestral|mathstral|magistral|ministral|devstral|codegemma|qwq|hermes|openchat|magpie|kimi|gpt-?oss|jamba|palmyra|dbrx|seed-oss|yi-large|glm-?\d|minimax-m|mistral-(?:large|medium|small|nemotron|\d)|mixtral|deepseek-(?:v\d|r\d|coder)|llama-?[34]|qwen-?\d|gemma-?\d|phi-?\d|granite-?\d)/i
+
+// Defense-in-depth blacklist: even if an entry slips through the allowlist
+// (e.g. an "instruct"-tuned classifier), reject anything that is clearly not
+// a generic chat model.
 const NVIDIA_NON_CHAT_PATTERN =
-  /(embed|retriever|rerank|reward|nemoguard|content-safety|guard|whisper|parakeet|canary|riva|stable-diffusion|sdxl|flux|kosmos|florence|nvclip|colpali|pho-tabuloud|tts|voice)/i
+  /(embed|retriever|rerank|reward|nemoguard|content-safety|guard|whisper|parakeet|canary|riva|stable-diffusion|sdxl|flux|kosmos|florence|nvclip|colpali|tts|voice|tabular|gliner|video-detector|deplot|ising)/i
 
 export default defineGateway({
   id: 'nvidia-nim',
@@ -60,6 +64,9 @@ export default defineGateway({
           context_window?: number
         }
         if (!model.id || model.active === false) {
+          return null
+        }
+        if (!NVIDIA_CHAT_MODEL_PATTERN.test(model.id)) {
           return null
         }
         if (NVIDIA_NON_CHAT_PATTERN.test(model.id)) {

--- a/src/utils/model/nvidiaNimModels.test.ts
+++ b/src/utils/model/nvidiaNimModels.test.ts
@@ -1,0 +1,119 @@
+// Regression coverage for the inline `/model <id>` -> persisted-discovery
+// fallback path in `getDiscoveredNvidiaNimModelIds()`. The cache key it
+// builds must match the partition the descriptor picker
+// (`getOpenAIDiscoveryRequestOptions` in src/commands/model/model.tsx)
+// writes to — same `(baseUrl, apiKey, headers)` triple — or the inline
+// validator looks in a different partition than the picker just wrote.
+//
+// Previous rounds of #1177 closed the apiKey-mismatch case. This test
+// pins the remaining headers-mismatch case flagged in jatmn's
+// 2026-05-21 re-review.
+
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import { getDiscoveryCacheKey } from '../../integrations/discoveryService.js'
+import { parseCustomHeadersEnv } from '../providerCustomHeaders.js'
+
+const ROUTE = 'nvidia-nim'
+
+function withEnv<T>(
+  patch: Record<string, string | undefined>,
+  fn: () => T,
+): T {
+  const saved: Record<string, string | undefined> = {}
+  for (const key of Object.keys(patch)) {
+    saved[key] = process.env[key]
+    const value = patch[key]
+    if (value === undefined) {
+      delete process.env[key]
+    } else {
+      process.env[key] = value
+    }
+  }
+  try {
+    return fn()
+  } finally {
+    for (const key of Object.keys(saved)) {
+      const previous = saved[key]
+      if (previous === undefined) {
+        delete process.env[key]
+      } else {
+        process.env[key] = previous
+      }
+    }
+  }
+}
+
+describe('nvidia-nim discovery cache key parity', () => {
+  beforeEach(() => {
+    delete process.env.ANTHROPIC_CUSTOM_HEADERS
+  })
+
+  afterEach(() => {
+    delete process.env.ANTHROPIC_CUSTOM_HEADERS
+  })
+
+  test('custom headers move the partition off the no-headers default', () => {
+    const baseUrl = 'https://integrate.api.nvidia.com/v1'
+    const apiKey = 'nvapi-test'
+
+    const without = getDiscoveryCacheKey(ROUTE, { baseUrl, apiKey })
+    const withHeaders = getDiscoveryCacheKey(ROUTE, {
+      baseUrl,
+      apiKey,
+      headers: { 'x-tenant': 'acme' },
+    })
+
+    expect(withHeaders).not.toBe(without)
+  })
+
+  test('inline validator key matches the picker key for the same headers env', () => {
+    const baseUrl = 'https://integrate.api.nvidia.com/v1'
+    const apiKey = 'nvapi-test'
+
+    withEnv(
+      {
+        ANTHROPIC_CUSTOM_HEADERS: 'x-tenant=acme,x-env=prod',
+      },
+      () => {
+        const pickerKey = getDiscoveryCacheKey(ROUTE, {
+          baseUrl,
+          apiKey,
+          headers: parseCustomHeadersEnv(
+            process.env.ANTHROPIC_CUSTOM_HEADERS,
+          ),
+        })
+
+        // Mirror what `getDiscoveredNvidiaNimModelIds()` now does.
+        const inlineKey = getDiscoveryCacheKey(ROUTE, {
+          baseUrl,
+          apiKey,
+          headers: parseCustomHeadersEnv(
+            process.env.ANTHROPIC_CUSTOM_HEADERS,
+          ),
+        })
+
+        expect(inlineKey).toBe(pickerKey)
+      },
+    )
+  })
+
+  test('absent ANTHROPIC_CUSTOM_HEADERS leaves picker and inline keys identical', () => {
+    const baseUrl = 'https://integrate.api.nvidia.com/v1'
+    const apiKey = 'nvapi-test'
+
+    delete process.env.ANTHROPIC_CUSTOM_HEADERS
+
+    const pickerKey = getDiscoveryCacheKey(ROUTE, {
+      baseUrl,
+      apiKey,
+      headers: parseCustomHeadersEnv(process.env.ANTHROPIC_CUSTOM_HEADERS),
+    })
+    const inlineKey = getDiscoveryCacheKey(ROUTE, {
+      baseUrl,
+      apiKey,
+      headers: parseCustomHeadersEnv(process.env.ANTHROPIC_CUSTOM_HEADERS),
+    })
+
+    expect(inlineKey).toBe(pickerKey)
+  })
+})

--- a/src/utils/model/nvidiaNimModels.ts
+++ b/src/utils/model/nvidiaNimModels.ts
@@ -6,6 +6,8 @@
 import type { ModelOption } from './modelOptions.js'
 import { getAPIProvider } from './providers.js'
 import { isEnvTruthy } from '../envUtils.js'
+import { getCachedModels } from '../../integrations/discoveryCache.js'
+import { getDiscoveryCacheKey } from '../../integrations/discoveryService.js'
 
 export function isNvidiaNimProvider(): boolean {
   // Check if explicitly set via NVIDIA_NIM or via provider flag
@@ -166,4 +168,24 @@ export function getCachedNvidiaNimModelOptions(): ModelOption[] {
     cachedNvidiaNimOptions = getNvidiaNimModels()
   }
   return cachedNvidiaNimOptions
+}
+
+/**
+ * Returns the persisted discovery cache entries for the NVIDIA NIM route, if
+ * any are present on disk. Used by validateModel so that inline `/model <id>`
+ * accepts models surfaced by dynamic discovery — not only the static list.
+ */
+export async function getDiscoveredNvidiaNimModelIds(): Promise<string[]> {
+  try {
+    const cacheKey = getDiscoveryCacheKey('nvidia-nim', {
+      baseUrl: process.env.OPENAI_BASE_URL,
+      apiKey: process.env.NVIDIA_API_KEY,
+    })
+    const cached = await getCachedModels(cacheKey, Number.MAX_SAFE_INTEGER, {
+      includeStale: true,
+    })
+    return cached?.models.map(entry => entry.apiName) ?? []
+  } catch {
+    return []
+  }
 }

--- a/src/utils/model/nvidiaNimModels.ts
+++ b/src/utils/model/nvidiaNimModels.ts
@@ -10,6 +10,7 @@ import { getCachedModels } from '../../integrations/discoveryCache.js'
 import { getDiscoveryCacheKey } from '../../integrations/discoveryService.js'
 import { resolveRouteCredentialValue } from '../../integrations/routeMetadata.js'
 import { resolveProviderRequest } from '../../services/api/providerConfig.js'
+import { parseCustomHeadersEnv } from '../providerCustomHeaders.js'
 
 export function isNvidiaNimProvider(): boolean {
   // Check if explicitly set via NVIDIA_NIM or via provider flag
@@ -205,9 +206,19 @@ export async function getDiscoveredNvidiaNimModelIds(): Promise<string[]> {
       processEnv: process.env,
     })
 
+    // Include custom headers in the cache key so this read lands in the
+    // same partition the picker (`getOpenAIDiscoveryRequestOptions` in
+    // src/commands/model/model.tsx) writes to. The picker passes
+    // `headers: parseCustomHeadersEnv(process.env.ANTHROPIC_CUSTOM_HEADERS)`
+    // into `getDiscoveryCacheKey`; without it, two users sharing a
+    // baseUrl/apiKey but differing in `ANTHROPIC_CUSTOM_HEADERS` end up
+    // on different cache partitions and the inline `/model <id>`
+    // validator misses the discovered ids the picker just persisted
+    // (jatmn re-review on #1177).
     const cacheKey = getDiscoveryCacheKey('nvidia-nim', {
       baseUrl: request.baseUrl,
       apiKey,
+      headers: parseCustomHeadersEnv(process.env.ANTHROPIC_CUSTOM_HEADERS),
     })
     const cached = await getCachedModels(cacheKey, Number.MAX_SAFE_INTEGER, {
       includeStale: true,

--- a/src/utils/model/nvidiaNimModels.ts
+++ b/src/utils/model/nvidiaNimModels.ts
@@ -8,6 +8,8 @@ import { getAPIProvider } from './providers.js'
 import { isEnvTruthy } from '../envUtils.js'
 import { getCachedModels } from '../../integrations/discoveryCache.js'
 import { getDiscoveryCacheKey } from '../../integrations/discoveryService.js'
+import { resolveRouteCredentialValue } from '../../integrations/routeMetadata.js'
+import { resolveProviderRequest } from '../../services/api/providerConfig.js'
 
 export function isNvidiaNimProvider(): boolean {
   // Check if explicitly set via NVIDIA_NIM or via provider flag
@@ -174,12 +176,38 @@ export function getCachedNvidiaNimModelOptions(): ModelOption[] {
  * Returns the persisted discovery cache entries for the NVIDIA NIM route, if
  * any are present on disk. Used by validateModel so that inline `/model <id>`
  * accepts models surfaced by dynamic discovery — not only the static list.
+ *
+ * The cache key must be derived from the same `(routeId, baseUrl, apiKey,
+ * headers)` shape that the descriptor picker / startup discovery uses, or the
+ * inline validator looks in a different partition than the one the picker
+ * actually wrote (see #1177 P2 review): the picker calls
+ * `resolveRouteCredentialValue()` for the active route, whose credential list
+ * for `nvidia-nim` includes both `NVIDIA_API_KEY` *and* `OPENAI_API_KEY` for
+ * OpenAI-compatible setups. Hard-coding `process.env.NVIDIA_API_KEY` here
+ * silently mis-partitioned the cache for users authenticating via
+ * `OPENAI_API_KEY`.
  */
 export async function getDiscoveredNvidiaNimModelIds(): Promise<string[]> {
   try {
-    const cacheKey = getDiscoveryCacheKey('nvidia-nim', {
+    // Mirror the picker side (`getOpenAIDiscoveryRequestOptions` in
+    // src/commands/model/model.tsx): pull baseUrl from the resolved provider
+    // request and let `resolveRouteCredentialValue` walk the route's full
+    // credential list. Falling back to undefined keeps the cache key shape
+    // identical to the picker's even when the env var is missing — both
+    // sides will hash the same `apiKeyHash: ''` partition in that case.
+    const request = resolveProviderRequest({
+      model: process.env.OPENAI_MODEL,
       baseUrl: process.env.OPENAI_BASE_URL,
-      apiKey: process.env.NVIDIA_API_KEY,
+    })
+    const apiKey = resolveRouteCredentialValue({
+      routeId: 'nvidia-nim',
+      baseUrl: request.baseUrl,
+      processEnv: process.env,
+    })
+
+    const cacheKey = getDiscoveryCacheKey('nvidia-nim', {
+      baseUrl: request.baseUrl,
+      apiKey,
     })
     const cached = await getCachedModels(cacheKey, Number.MAX_SAFE_INTEGER, {
       includeStale: true,

--- a/src/utils/model/validateModel.ts
+++ b/src/utils/model/validateModel.ts
@@ -11,7 +11,11 @@ import {
 } from '@anthropic-ai/sdk'
 import { getModelStrings } from './modelStrings.js'
 import { getCachedOllamaModelOptions, isOllamaProvider } from './ollamaModels.js'
-import { getCachedNvidiaNimModelOptions, isNvidiaNimProvider } from './nvidiaNimModels.js'
+import {
+  getCachedNvidiaNimModelOptions,
+  getDiscoveredNvidiaNimModelIds,
+  isNvidiaNimProvider,
+} from './nvidiaNimModels.js'
 import { getCachedMiniMaxModelOptions, isMiniMaxProvider } from './minimaxModels.js'
 
 // Cache valid models to avoid repeated API calls
@@ -49,20 +53,36 @@ export async function validateModel(
     // If cache is empty, fall through to API validation
   }
 
-  // For NVIDIA NIM provider, validate against cached model list
+  // For NVIDIA NIM provider, validate against cached model list (static
+  // catalog first, then the persisted discovery cache so that ids surfaced
+  // only via dynamic discovery are still accepted on the inline `/model <id>`
+  // path).
   if (isNvidiaNimProvider()) {
     const nvidiaModels = getCachedNvidiaNimModelOptions()
-    const found = nvidiaModels.some(m => m.value === normalizedModel)
-    if (found) {
+    if (nvidiaModels.some(m => m.value === normalizedModel)) {
       validModelCache.set(normalizedModel, true)
       return { valid: true }
     }
-    if (nvidiaModels.length > 0) {
+    const discoveredIds = await getDiscoveredNvidiaNimModelIds()
+    if (discoveredIds.includes(normalizedModel)) {
+      validModelCache.set(normalizedModel, true)
+      return { valid: true }
+    }
+    if (nvidiaModels.length > 0 || discoveredIds.length > 0) {
+      const names = [
+        ...nvidiaModels.map(m => m.value),
+        ...discoveredIds.filter(
+          id => !nvidiaModels.some(m => m.value === id),
+        ),
+      ]
       const MAX_SHOWN = 5
-      const names = nvidiaModels.map(m => m.value)
       const shown = names.slice(0, MAX_SHOWN).join(', ')
-      const suffix = names.length > MAX_SHOWN ? ` and ${names.length - MAX_SHOWN} more` : ''
-      return { valid: false, error: `Model '${normalizedModel}' not found in NVIDIA NIM catalog. Available: ${shown}${suffix}` }
+      const suffix =
+        names.length > MAX_SHOWN ? ` and ${names.length - MAX_SHOWN} more` : ''
+      return {
+        valid: false,
+        error: `Model '${normalizedModel}' not found in NVIDIA NIM catalog. Available: ${shown}${suffix}`,
+      }
     }
   }
 


### PR DESCRIPTION
## Summary

Closes the dynamic-discovery half of #1099 by mirroring #1143's Groq hybrid-catalog pattern on the NVIDIA NIM gateway.

- `src/integrations/gateways/nvidia-nim.ts` — `catalog.source: 'static'` (single entry) → `catalog.source: 'hybrid'` with a `discovery.mapModel` filter against `https://integrate.api.nvidia.com/v1/models`.
- Filter regex `NVIDIA_NON_CHAT_PATTERN` excludes the non-chat catalog NVIDIA returns: embeddings, retrievers, rerankers, ASR (whisper, parakeet, canary, riva), TTS / voice, image-gen (SDXL, flux, stable-diffusion, kosmos, florence), `nvclip`, safety / guard / `nemoguard` / content-safety, reward models.
- Settings match the Groq descriptor: `discoveryCacheTtl: '1d'`, `discoveryRefreshMode: 'background-if-stale'`, `allowManualRefresh: true`.
- Existing Nemotron 70B static entry stays as the hybrid fallback when discovery is unavailable.

## Out of scope

`src/utils/model/nvidiaNimModels.ts` (the parallel env-var path used when `NVIDIA_NIM=1` or `OPENAI_BASE_URL` contains `nvidia`) is unchanged. That path has its own hand-rolled list; wiring it through the discovery service is a separate, larger change. This PR addresses the descriptor-backed half so profile users get dynamic discovery without touching the env-var path's sync API.

## Tests

- New `src/integrations/gateways/nvidia-nim.test.ts` (9 tests, 39 expect calls) pinning the filter regex against representative real NVIDIA model ids:
  - Keeps chat / instruct / reasoning / code (Nemotron, Llama, Qwen, DeepSeek, Mixtral, Phi, Gemma, Kimi, vision-instruct, QwQ).
  - Drops embedding / retriever / rerank.
  - Drops ASR / TTS / voice.
  - Drops image-gen / vision-only embedding.
  - Drops safety / guard / reward.
  - Drops `active: false` and empty-id entries.
  - Forwards `context_window` when present.

Local: `bun test src/integrations/` → 94/94 pass. `bun run build` clean.

## Test plan

- [ ] Live run against `https://integrate.api.nvidia.com/v1/models` with `NVIDIA_API_KEY` set, confirm `/model` picker shows only chat ids.
- [ ] `bun test src/integrations/` green in CI.
- [ ] Existing static fallback still resolves when the live endpoint is unreachable.