### PR TITLE
fix(promptinput): keep bash-mode `!` out of the local mirror (#1179)

### DIFF
--- a/src/components/TextInput.test.tsx
+++ b/src/components/TextInput.test.tsx
@@ -259,6 +259,62 @@ test('TextInput resyncs local mirror after parent strips bash-mode `!` from empt
   expect(output).not.toContain('!')
 })
 
+// Regression: when the buffer is non-empty and the cursor is at offset 0,
+// typing `!` must prepend `!` to the buffer rather than emit a bare `!`
+// onChange (which would clobber the buffer to "").
+function PrependBangTextInput(): React.ReactNode {
+  const [value, setValue] = React.useState('git status')
+  const [cursorOffset, setCursorOffset] = React.useState(0)
+  return (
+    <AppStateProvider>
+      <TextInput
+        value={value}
+        onChange={nextValue => {
+          if (nextValue.startsWith('!')) {
+            setValue(nextValue.slice(1))
+            setCursorOffset(0)
+            return
+          }
+          setValue(nextValue)
+        }}
+        onSubmit={() => {}}
+        placeholder="Type here..."
+        columns={60}
+        cursorOffset={cursorOffset}
+        onChangeCursorOffset={setCursorOffset}
+        focus
+        showCursor
+        multiline
+      />
+    </AppStateProvider>
+  )
+}
+
+test('TextInput prepends `!` to existing buffer when cursor is at offset 0', async () => {
+  const { stdout, stdin, getOutput } = createTestStreams()
+  const root = await createRoot({
+    stdout: stdout as unknown as NodeJS.WriteStream,
+    stdin: stdin as unknown as NodeJS.ReadStream,
+    patchConsole: false,
+  })
+
+  root.render(<PrependBangTextInput />)
+
+  await Bun.sleep(50)
+  stdin.write('!')
+  await Bun.sleep(25)
+
+  const output = stripAnsi(extractLastFrame(getOutput()))
+
+  root.unmount()
+  stdin.end()
+  stdout.end()
+  await Bun.sleep(25)
+
+  expect(output).toContain('git status')
+  expect(output).not.toMatch(/^!\s*$/m)
+})
+
 test('TextInput renders typed characters before delayed parent value commits', async () => {
   const { stdout, stdin, getOutput } = createTestStreams()
   const root = await createRoot({

--- a/src/components/TextInput.test.tsx
+++ b/src/components/TextInput.test.tsx
@@ -191,6 +191,74 @@ function DelayedControlledVimTextInput(): React.ReactNode {
   )
 }
 
+// Regression for #1179: parent strips the leading `!` after entering bash
+// mode (numerically: input stays "", cursor stays 0). The local mirror in
+// useTextInput must resync to the parent state even though the prop values
+// didn't change since lastSeen, otherwise the next keystroke lands beside the
+// stale `!` and the buffer shows `!g`, `g!`, or similar instead of `g`.
+function BashModeStrippingTextInput(): React.ReactNode {
+  const [value, setValue] = React.useState('')
+  const [cursorOffset, setCursorOffset] = React.useState(0)
+  return (
+    <AppStateProvider>
+      <TextInput
+        value={value}
+        onChange={nextValue => {
+          // Mimic PromptInput.onChange: when leading `!` arrives at start,
+          // strip it back to the empty buffer (mode switches in real code).
+          if (nextValue.startsWith('!')) {
+            setValue(nextValue.slice(1))
+            setCursorOffset(nextValue.length - 1)
+            return
+          }
+          setValue(nextValue)
+        }}
+        onSubmit={() => {}}
+        placeholder="Type here..."
+        columns={60}
+        cursorOffset={cursorOffset}
+        onChangeCursorOffset={setCursorOffset}
+        focus
+        showCursor
+        multiline
+      />
+    </AppStateProvider>
+  )
+}
+
+test('TextInput resyncs local mirror after parent strips bash-mode `!` from empty input', async () => {
+  const { stdout, stdin, getOutput } = createTestStreams()
+  const root = await createRoot({
+    stdout: stdout as unknown as NodeJS.WriteStream,
+    stdin: stdin as unknown as NodeJS.ReadStream,
+    patchConsole: false,
+  })
+
+  root.render(<BashModeStrippingTextInput />)
+
+  await Bun.sleep(50)
+  stdin.write('!')
+  await Bun.sleep(25)
+  stdin.write('g')
+  await Bun.sleep(25)
+  stdin.write('i')
+  await Bun.sleep(25)
+  stdin.write('t')
+  await Bun.sleep(25)
+
+  const output = stripAnsi(extractLastFrame(getOutput()))
+
+  root.unmount()
+  stdin.end()
+  stdout.end()
+  await Bun.sleep(25)
+
+  expect(output).toContain('git')
+  expect(output).not.toContain('!git')
+  expect(output).not.toContain('git!')
+  expect(output).not.toContain('!')
+})
+
 test('TextInput renders typed characters before delayed parent value commits', async () => {
   const { stdout, stdin, getOutput } = createTestStreams()
   const root = await createRoot({

--- a/src/hooks/useTextInput.ts
+++ b/src/hooks/useTextInput.ts
@@ -485,7 +485,11 @@ export function useTextInput({
                 // eslint-disable-next-line custom-rules/no-lookbehind-regex -- .replace(re, str) on 1-2 char keystrokes: no-match returns same string (Object.is), regex never runs
                 .replace(/(?<=[^\\\r\n])\r$/, '')
                 .replace(/\r/g, '\n')
-              if (cursor.isAtStart() && isInputModeCharacter(input)) {
+              if (
+                cursor.text.length === 0 &&
+                cursor.isAtStart() &&
+                isInputModeCharacter(input)
+              ) {
                 // Issue #1179: emit the mode character as a one-shot
                 // onChange notification but do NOT advance the local cursor
                 // mirror. Returning undefined here means setValue is not

--- a/src/hooks/useTextInput.ts
+++ b/src/hooks/useTextInput.ts
@@ -486,7 +486,19 @@ export function useTextInput({
                 .replace(/(?<=[^\\\r\n])\r$/, '')
                 .replace(/\r/g, '\n')
               if (cursor.isAtStart() && isInputModeCharacter(input)) {
-                return cursor.insert(text).left()
+                // Issue #1179: emit the mode character as a one-shot
+                // onChange notification but do NOT advance the local cursor
+                // mirror. Returning undefined here means setValue is not
+                // called, so liveValueRef="" / liveOffsetRef=0 stay clean
+                // and the parent's strip handler operates on (and renders
+                // into) an empty buffer. Previous behaviour was
+                // `cursor.insert(text).left()` which left `!` in the local
+                // mirror, and because the parent's strip leaves controlled
+                // props numerically equal to what they were before the
+                // keystroke, useLayoutEffect never resynced the mirror — so
+                // the next character landed beside the retained `!`.
+                onChange(text)
+                return undefined
               }
               return cursor.insert(text)
             }


### PR DESCRIPTION
## Summary

Closes #1179. Typing `!` into empty input is meant to enter bash mode and leave the prompt buffer empty (the `!` only shows in the mode prefix). Before this patch, the `!` stayed in the buffer and the cursor was wedged before it: e.g. `!git status` with the caret at position 0 instead of an empty buffer.

## Root cause

`useTextInput`'s default keystroke handler had a special case at the start of an empty buffer for the input-mode character:

```ts
if (cursor.isAtStart() && isInputModeCharacter(input)) {
  return cursor.insert(text).left()
}
```

That produced a cursor with `text="!"` and `offset=0`, which `setValue("!", 0)` then committed into the local mirror (`liveValueRef="!"`, `liveOffsetRef=0`) and emitted as `onChange("!")`.

`PromptInput.detectModeEntry` stripped the controlled parent value back to `""` with cursor `0` — values the controlled props already held. Because the parent props ended up numerically identical to what they were before the keystroke, React did not re-render PromptInput, the `useLayoutEffect` in `useTextInput` never re-ran, and the local mirror kept `!` at offset 0.

The next keystroke read `liveValueRef="!"` / `liveOffsetRef=0`, so inserts landed *before* the retained `!`, producing `!git status` with the cursor pinned at 0.

## Fix

`src/hooks/useTextInput.ts` — at the same special case, emit `onChange(text)` as a one-shot mode-entry notification and return `undefined` so `setValue` is not called. The local mirror stays at `""` / offset 0, the parent's strip remains a no-op on the controlled state, and the next character types into a clean buffer.

## Test

New regression in `src/components/TextInput.test.tsx`:

- Mounts a controlled `TextInput` with a parent `onChange` that mirrors `PromptInput`'s strip (`setValue('')` when the new value starts with `!`).
- Types `!` then `g` then `i` then `t`.
- Asserts the rendered frame contains `git`, and does NOT contain `!`, `!git`, or `git!`.

Before the fix the test fails (`Received: "git!"`). After the fix all 4 tests in the file pass.

## Validation

- `bun test src/components/TextInput.test.tsx` → 4/4 pass.
- `bun test src/components/PromptInput/ src/hooks/` → 24/24 pass.
- `bun run build` clean.

## Test plan

- [ ] Manual: type `!git status` on Ubuntu Linux 24.04 — buffer renders `git status`, mode prefix shows `!`, cursor stays at end of typed text.
- [ ] Manual: paste `!ls -la` into empty input — buffer renders `ls -la`, mode prefix shows `!`. (This path goes through `detectModeEntry`'s multi-char branch and was already working.)
- [ ] CI green.