### PR TITLE
fix: show vision-specific error when provider returns 404 for image requests

### DIFF
--- a/src/integrations/gateways/gitlawb-opengateway.ts
+++ b/src/integrations/gateways/gitlawb-opengateway.ts
@@ -28,12 +28,12 @@ export default defineGateway({
   },
   transportConfig: {
     kind: 'openai-compatible',
-    headers: {
-      'Accept-Encoding': 'identity',
-    },
     openaiShim: {
       // Opengateway expects `Authorization: Bearer ogw_live_...`. Previous
       // `api-key` raw header was a leftover from the direct-Xiaomi era.
+      headers: {
+        'Accept-Encoding': 'identity',
+      },
       defaultAuthHeader: {
         name: 'authorization',
         scheme: 'bearer',

--- a/src/integrations/gateways/gitlawb-opengateway.ts
+++ b/src/integrations/gateways/gitlawb-opengateway.ts
@@ -14,10 +14,10 @@ export default defineGateway({
   },
   transportConfig: {
     kind: 'openai-compatible',
-    headers: {
-      'Accept-Encoding': 'identity',
-    },
     openaiShim: {
+      headers: {
+        'Accept-Encoding': 'identity',
+      },
       defaultAuthHeader: {
         name: 'api-key',
         scheme: 'raw',

--- a/src/integrations/gateways/gitlawb-opengateway.ts
+++ b/src/integrations/gateways/gitlawb-opengateway.ts
@@ -28,6 +28,9 @@ export default defineGateway({
   },
   transportConfig: {
     kind: 'openai-compatible',
+    headers: {
+      'Accept-Encoding': 'identity',
+    },
     openaiShim: {
       // Opengateway expects `Authorization: Bearer ogw_live_...`. Previous
       // `api-key` raw header was a leftover from the direct-Xiaomi era.

--- a/src/integrations/gateways/gitlawb-opengateway.ts
+++ b/src/integrations/gateways/gitlawb-opengateway.ts
@@ -14,6 +14,9 @@ export default defineGateway({
   },
   transportConfig: {
     kind: 'openai-compatible',
+    headers: {
+      'Accept-Encoding': 'identity',
+    },
     openaiShim: {
       defaultAuthHeader: {
         name: 'api-key',

--- a/src/services/api/errors.openaiCompatibility.test.ts
+++ b/src/services/api/errors.openaiCompatibility.test.ts
@@ -28,6 +28,24 @@ test('maps endpoint_not_found category markers to actionable setup guidance', ()
   expect(text).toContain('/v1')
 })
 
+test('vision_not_supported shows image-specific guidance for remote host', () => {
+  const error = APIError.generate(
+    404,
+    undefined,
+    'OpenAI API error 404: Not Found [openai_category=vision_not_supported,host=opengateway.gitlawb.com] Hint: The provider returned 404 for a request containing images.',
+    new Headers(),
+  )
+
+  const message = getAssistantMessageFromError(error, 'mimo-v2.5-pro')
+  const text = getFirstText(message)
+
+  expect(message.isApiErrorMessage).toBe(true)
+  expect(text).toContain('images')
+  expect(text).toContain('mimo-v2.5-pro')
+  expect(text).toContain('opengateway.gitlawb.com')
+  expect(text).not.toContain('OPENAI_BASE_URL')
+})
+
 test('endpoint_not_found from a remote host shows the actual host, not Ollama (issue #926)', () => {
   const error = APIError.generate(
     404,

--- a/src/services/api/errors.ts
+++ b/src/services/api/errors.ts
@@ -96,6 +96,12 @@ function mapOpenAICompatibilityFailureToAssistantMessage(options: {
         error: 'invalid_request',
       })
 
+    case 'vision_not_supported':
+      return createAssistantAPIErrorMessage({
+        content: `The provider at ${options.host} returned 404 for a request containing images. The model (${options.model}) may not support image/vision inputs. Try removing images from your message, or ${switchCmd} to a vision-capable model.`,
+        error: 'invalid_request',
+      })
+
     case 'model_not_found':
       return createAssistantAPIErrorMessage({
         content: `The selected model (${options.model}) is not available on this provider. Run ${switchCmd} to choose another model, or verify installed local models (for Ollama: ollama list).`,

--- a/src/services/api/errors.ts
+++ b/src/services/api/errors.ts
@@ -97,6 +97,12 @@ function mapOpenAICompatibilityFailureToAssistantMessage(options: {
         error: 'invalid_request',
       })
 
+    case 'vision_not_supported':
+      return createAssistantAPIErrorMessage({
+        content: `The provider at ${options.host} returned 404 for a request containing images. The model (${options.model}) may not support image/vision inputs. Try removing images from your message, or ${switchCmd} to a vision-capable model.`,
+        error: 'invalid_request',
+      })
+
     case 'model_not_found':
       return createAssistantAPIErrorMessage({
         content: `The selected model (${options.model}) is not available on this provider. Run ${switchCmd} to choose another model, or verify installed local models (for Ollama: ollama list).`,

--- a/src/services/api/openaiErrorClassification.test.ts
+++ b/src/services/api/openaiErrorClassification.test.ts
@@ -60,6 +60,18 @@ test('classifies generic 404 responses as endpoint_not_found', () => {
   expect(failure.hint).toContain('/v1')
 })
 
+test('classifies 404 with images as vision_not_supported', () => {
+  const failure = classifyOpenAIHttpFailure({
+    status: 404,
+    body: 'Not Found',
+    hasImages: true,
+  })
+
+  expect(failure.category).toBe('vision_not_supported')
+  expect(failure.retryable).toBe(false)
+  expect(failure.hint).toContain('image')
+})
+
 test('classifies context-overflow responses', () => {
   const failure = classifyOpenAIHttpFailure({
     status: 500,

--- a/src/services/api/openaiErrorClassification.ts
+++ b/src/services/api/openaiErrorClassification.ts
@@ -7,6 +7,7 @@ export type OpenAICompatibilityFailureCategory =
   | 'rate_limited'
   | 'model_not_found'
   | 'endpoint_not_found'
+  | 'vision_not_supported'
   | 'context_overflow'
   | 'tool_call_incompatible'
   | 'malformed_provider_response'
@@ -38,6 +39,7 @@ const OPENAI_COMPATIBILITY_FAILURE_CATEGORIES: ReadonlySet<OpenAICompatibilityFa
     'rate_limited',
     'model_not_found',
     'endpoint_not_found',
+    'vision_not_supported',
     'context_overflow',
     'tool_call_incompatible',
     'malformed_provider_response',
@@ -264,6 +266,7 @@ export function classifyOpenAIHttpFailure(options: {
   status: number
   body: string
   url?: string
+  hasImages?: boolean
 }): OpenAICompatibilityFailure {
   const body = options.body ?? ''
   const hostname = options.url ? getHostname(options.url) : null
@@ -310,6 +313,18 @@ export function classifyOpenAIHttpFailure(options: {
       status: options.status,
       message: body,
       hint: 'The selected model is not installed or not available on this endpoint.',
+    }
+  }
+
+  if (options.status === 404 && options.hasImages) {
+    return {
+      source: 'http',
+      category: 'vision_not_supported',
+      retryable: false,
+      status: options.status,
+      message: body,
+      requestUrl: options.url,
+      hint: 'The provider returned 404 for a request containing images. The model may not support vision/image inputs.',
     }
   }
 

--- a/src/services/api/openaiShim.test.ts
+++ b/src/services/api/openaiShim.test.ts
@@ -705,6 +705,89 @@ test('applies descriptor static headers before client and request headers', asyn
   expect(capturedHeaders?.get('x-override-header')).toBe('from-request')
 })
 
+test('opengateway sends Accept-Encoding: identity header on chat requests', async () => {
+  let capturedHeaders: Headers | undefined
+
+  registerGateway({
+    id: 'gitlawb-opengateway-test',
+    label: 'Gitlawb Opengateway',
+    category: 'aggregating',
+    defaultBaseUrl: 'https://opengateway.gitlawb.com/v1/xiaomi-mimo',
+    defaultModel: 'mimo-v2.5-pro',
+    setup: {
+      requiresAuth: false,
+      authMode: 'none',
+    },
+    transportConfig: {
+      kind: 'openai-compatible',
+      openaiShim: {
+        headers: {
+          'Accept-Encoding': 'identity',
+        },
+        defaultAuthHeader: {
+          name: 'api-key',
+          scheme: 'raw',
+        },
+        preserveReasoningContent: true,
+        requireReasoningContentOnAssistantMessages: true,
+        reasoningContentFallback: '',
+        maxTokensField: 'max_completion_tokens',
+        supportsApiFormatSelection: false,
+        supportsAuthHeaders: false,
+      },
+    },
+  })
+
+  process.env.CLAUDE_CODE_USE_OPENAI = '1'
+  process.env.OPENAI_BASE_URL = 'https://opengateway.gitlawb.com/v1/xiaomi-mimo'
+  process.env.OPENAI_MODEL = 'mimo-v2.5-pro'
+
+  globalThis.fetch = (async (_input, init) => {
+    capturedHeaders = new Headers(init?.headers)
+
+    return new Response(
+      JSON.stringify({
+        id: 'chatcmpl-1',
+        model: 'mimo-v2.5-pro',
+        choices: [
+          {
+            message: {
+              role: 'assistant',
+              content: 'ok',
+            },
+            finish_reason: 'stop',
+          },
+        ],
+        usage: {
+          prompt_tokens: 8,
+          completion_tokens: 3,
+          total_tokens: 11,
+        },
+      }),
+      {
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      },
+    )
+  }) as FetchType
+
+  const client = createOpenAIShimClient({}) as OpenAIShimClient
+
+  await client.beta.messages.create(
+    {
+      model: 'mimo-v2.5-pro',
+      system: 'test system',
+      messages: [{ role: 'user', content: 'hello' }],
+      max_tokens: 64,
+      stream: false,
+    },
+    {},
+  )
+
+  expect(capturedHeaders?.get('Accept-Encoding')).toBe('identity')
+})
+
 test('strips Anthropic-specific headers on GitHub Codex transport requests', async () => {
   let capturedHeaders: Headers | undefined
 

--- a/src/services/api/openaiShim.ts
+++ b/src/services/api/openaiShim.ts
@@ -2578,6 +2578,25 @@ class OpenAIShimMessages {
     // Local backends do not implement prefix caching, so the deep key-sort
     // is pure CPU overhead per request (issue #1016). Drop to the native
     // `JSON.stringify` fast path when the fast-path config opts out.
+    const bodyContainsImages = (): boolean => {
+      if (request.transport === 'responses') {
+        const responsesBody = buildResponsesBody()
+        const input = responsesBody.input as Array<Record<string, unknown>> | undefined
+        if (!Array.isArray(input)) return false
+        return input.some(item => {
+          const content = item.content as Array<Record<string, unknown>> | undefined
+          return Array.isArray(content) && content.some(part => part.type === 'input_image')
+        })
+      }
+      const messages = body.messages as Array<Record<string, unknown>> | undefined
+      if (!Array.isArray(messages)) return false
+      return messages.some(msg => {
+        const content = msg.content
+        if (!Array.isArray(content)) return false
+        return content.some((part: Record<string, unknown>) => part.type === 'image_url')
+      })
+    }
+
     const serializeBody = (): string => {
       const payload =
         effectiveTransport === 'responses' ? buildResponsesBody()
@@ -2658,7 +2677,7 @@ class OpenAIShimMessages {
           status,
           body: errorBody,
           url: requestUrl,
-          hasImages: serializedBody.includes('"image_url"'),
+          hasImages: bodyContainsImages(),
         })
       const failureWithUrl = { ...failure, requestUrl: failure.requestUrl ?? requestUrl }
       const redactedUrl = redactUrlForDiagnostics(requestUrl)
@@ -2786,7 +2805,7 @@ class OpenAIShimMessages {
           const responsesFailure = classifyOpenAIHttpFailure({
             status: responsesResponse.status,
             body: responsesErrorBody,
-            hasImages: serializedBody.includes('"image_url"'),
+            hasImages: bodyContainsImages(),
           })
           let responsesErrorResponse: object | undefined
           try { responsesErrorResponse = JSON.parse(responsesErrorBody) } catch { /* raw text */ }
@@ -2805,7 +2824,7 @@ class OpenAIShimMessages {
       const failure = classifyOpenAIHttpFailure({
         status: response.status,
         body: errorBody,
-        hasImages: serializedBody.includes('"image_url"'),
+        hasImages: bodyContainsImages(),
       })
 
       if (

--- a/src/services/api/openaiShim.ts
+++ b/src/services/api/openaiShim.ts
@@ -2569,15 +2569,6 @@ class OpenAIShimMessages {
       return false
     }
 
-    // WHY: byte-identity required for implicit prefix caching in
-    // OpenAI/Kimi/DeepSeek. stableStringify sorts object keys at every
-    // depth so spurious insertion-order differences across rebuilds of
-    // `body` (spread-merge, conditional assignments above) don't bust
-    // the provider's prefix hash.
-    //
-    // Local backends do not implement prefix caching, so the deep key-sort
-    // is pure CPU overhead per request (issue #1016). Drop to the native
-    // `JSON.stringify` fast path when the fast-path config opts out.
     const bodyContainsImages = (): boolean => {
       if (request.transport === 'responses') {
         const responsesBody = buildResponsesBody()
@@ -2597,6 +2588,15 @@ class OpenAIShimMessages {
       })
     }
 
+    // WHY: byte-identity required for implicit prefix caching in
+    // OpenAI/Kimi/DeepSeek. stableStringify sorts object keys at every
+    // depth so spurious insertion-order differences across rebuilds of
+    // `body` (spread-merge, conditional assignments above) don't bust
+    // the provider's prefix hash.
+    //
+    // Local backends do not implement prefix caching, so the deep key-sort
+    // is pure CPU overhead per request (issue #1016). Drop to the native
+    // `JSON.stringify` fast path when the fast-path config opts out.
     const serializeBody = (): string => {
       const payload =
         effectiveTransport === 'responses' ? buildResponsesBody()

--- a/src/services/api/openaiShim.ts
+++ b/src/services/api/openaiShim.ts
@@ -2198,6 +2198,7 @@ class OpenAIShimMessages {
           status,
           body: errorBody,
           url: requestUrl,
+          hasImages: serializedBody.includes('"image_url"'),
         })
       const failureWithUrl = { ...failure, requestUrl: failure.requestUrl ?? requestUrl }
       const redactedUrl = redactUrlForDiagnostics(requestUrl)
@@ -2325,6 +2326,7 @@ class OpenAIShimMessages {
           const responsesFailure = classifyOpenAIHttpFailure({
             status: responsesResponse.status,
             body: responsesErrorBody,
+            hasImages: serializedBody.includes('"image_url"'),
           })
           let responsesErrorResponse: object | undefined
           try { responsesErrorResponse = JSON.parse(responsesErrorBody) } catch { /* raw text */ }
@@ -2343,6 +2345,7 @@ class OpenAIShimMessages {
       const failure = classifyOpenAIHttpFailure({
         status: response.status,
         body: errorBody,
+        hasImages: serializedBody.includes('"image_url"'),
       })
 
       if (

--- a/src/services/api/openaiShim.ts
+++ b/src/services/api/openaiShim.ts
@@ -2112,15 +2112,6 @@ class OpenAIShimMessages {
       return false
     }
 
-    // WHY: byte-identity required for implicit prefix caching in
-    // OpenAI/Kimi/DeepSeek. stableStringify sorts object keys at every
-    // depth so spurious insertion-order differences across rebuilds of
-    // `body` (spread-merge, conditional assignments above) don't bust
-    // the provider's prefix hash.
-    //
-    // Local backends do not implement prefix caching, so the deep key-sort
-    // is pure CPU overhead per request (issue #1016). Drop to the native
-    // `JSON.stringify` fast path when the fast-path config opts out.
     const bodyContainsImages = (): boolean => {
       if (request.transport === 'responses') {
         const responsesBody = buildResponsesBody()
@@ -2140,6 +2131,15 @@ class OpenAIShimMessages {
       })
     }
 
+    // WHY: byte-identity required for implicit prefix caching in
+    // OpenAI/Kimi/DeepSeek. stableStringify sorts object keys at every
+    // depth so spurious insertion-order differences across rebuilds of
+    // `body` (spread-merge, conditional assignments above) don't bust
+    // the provider's prefix hash.
+    //
+    // Local backends do not implement prefix caching, so the deep key-sort
+    // is pure CPU overhead per request (issue #1016). Drop to the native
+    // `JSON.stringify` fast path when the fast-path config opts out.
     const serializeBody = (): string => {
       const payload =
         request.transport === 'responses' ? buildResponsesBody() : body

--- a/src/services/api/openaiShim.ts
+++ b/src/services/api/openaiShim.ts
@@ -2658,6 +2658,7 @@ class OpenAIShimMessages {
           status,
           body: errorBody,
           url: requestUrl,
+          hasImages: serializedBody.includes('"image_url"'),
         })
       const failureWithUrl = { ...failure, requestUrl: failure.requestUrl ?? requestUrl }
       const redactedUrl = redactUrlForDiagnostics(requestUrl)
@@ -2785,6 +2786,7 @@ class OpenAIShimMessages {
           const responsesFailure = classifyOpenAIHttpFailure({
             status: responsesResponse.status,
             body: responsesErrorBody,
+            hasImages: serializedBody.includes('"image_url"'),
           })
           let responsesErrorResponse: object | undefined
           try { responsesErrorResponse = JSON.parse(responsesErrorBody) } catch { /* raw text */ }
@@ -2803,6 +2805,7 @@ class OpenAIShimMessages {
       const failure = classifyOpenAIHttpFailure({
         status: response.status,
         body: errorBody,
+        hasImages: serializedBody.includes('"image_url"'),
       })
 
       if (

--- a/src/services/api/openaiShim.ts
+++ b/src/services/api/openaiShim.ts
@@ -2121,6 +2121,25 @@ class OpenAIShimMessages {
     // Local backends do not implement prefix caching, so the deep key-sort
     // is pure CPU overhead per request (issue #1016). Drop to the native
     // `JSON.stringify` fast path when the fast-path config opts out.
+    const bodyContainsImages = (): boolean => {
+      if (request.transport === 'responses') {
+        const responsesBody = buildResponsesBody()
+        const input = responsesBody.input as Array<Record<string, unknown>> | undefined
+        if (!Array.isArray(input)) return false
+        return input.some(item => {
+          const content = item.content as Array<Record<string, unknown>> | undefined
+          return Array.isArray(content) && content.some(part => part.type === 'input_image')
+        })
+      }
+      const messages = body.messages as Array<Record<string, unknown>> | undefined
+      if (!Array.isArray(messages)) return false
+      return messages.some(msg => {
+        const content = msg.content
+        if (!Array.isArray(content)) return false
+        return content.some((part: Record<string, unknown>) => part.type === 'image_url')
+      })
+    }
+
     const serializeBody = (): string => {
       const payload =
         request.transport === 'responses' ? buildResponsesBody() : body
@@ -2198,7 +2217,7 @@ class OpenAIShimMessages {
           status,
           body: errorBody,
           url: requestUrl,
-          hasImages: serializedBody.includes('"image_url"'),
+          hasImages: bodyContainsImages(),
         })
       const failureWithUrl = { ...failure, requestUrl: failure.requestUrl ?? requestUrl }
       const redactedUrl = redactUrlForDiagnostics(requestUrl)
@@ -2326,7 +2345,7 @@ class OpenAIShimMessages {
           const responsesFailure = classifyOpenAIHttpFailure({
             status: responsesResponse.status,
             body: responsesErrorBody,
-            hasImages: serializedBody.includes('"image_url"'),
+            hasImages: bodyContainsImages(),
           })
           let responsesErrorResponse: object | undefined
           try { responsesErrorResponse = JSON.parse(responsesErrorBody) } catch { /* raw text */ }
@@ -2345,7 +2364,7 @@ class OpenAIShimMessages {
       const failure = classifyOpenAIHttpFailure({
         status: response.status,
         body: errorBody,
-        hasImages: serializedBody.includes('"image_url"'),
+        hasImages: bodyContainsImages(),
       })
 
       if (


### PR DESCRIPTION
## Summary

When a user sends images to a provider/model that doesn't support vision (e.g., MiMo V2.5 Pro via opengateway.gitlawb.com), the provider returns HTTP 404. Previously this showed a misleading "verify OPENAI_BASE_URL" message with no mention of images.

Now detects image content in the request body and classifies the 404 as `vision_not_supported`, showing a clear message: the model may not support image/vision inputs, with a suggestion to remove images or switch to a vision-capable model.

Also moves the `Accept-Encoding: identity` header for the Opengateway gateway from `transportConfig.headers` (model discovery only) to `transportConfig.openaiShim.headers` (used for chat/completions requests), ensuring the header is actually sent on API calls.

## Changes

- **`openaiErrorClassification.ts`**: Added `vision_not_supported` failure category and detection logic — when a 404 occurs and the request contains image content, it's classified as vision-not-supported instead of generic endpoint-not-found
- **`openaiShim.ts`**: Passes `hasImages` flag to `classifyOpenAIHttpFailure` via a `bodyContainsImages()` helper that inspects structured message content blocks (`type: 'image_url'` for chat completions, `type: 'input_image'` for responses) instead of substring-matching the serialized JSON
- **`errors.ts`**: Added user-facing message for `vision_not_supported` that names the provider, model, and suggests removing images or switching models
- **`gitlawb-opengateway.ts`**: Moved `Accept-Encoding: identity` from `transportConfig.headers` to `transportConfig.openaiShim.headers` so it is sent on chat/completions requests, not just model discovery
- **Tests**: Added tests in `openaiErrorClassification.test.ts`, `errors.openaiCompatibility.test.ts`, and a request-capture test in `openaiShim.test.ts` verifying the Accept-Encoding header is sent

## Before / After

**Before** (confusing):
> Provider endpoint at opengateway.gitlawb.com returned 404. Verify OPENAI_BASE_URL is correct and that the selected model (mimo-v2.5-pro) is supported by this provider.

**After** (actionable):
> The provider at opengateway.gitlawb.com returned 404 for a request containing images. The model (mimo-v2.5-pro) may not support image/vision inputs. Try removing images from your message, or /model to a vision-capable model.

## Test plan

- [x] `bun test src/services/api/openaiErrorClassification.test.ts` — 16 pass
- [x] `bun test src/services/api/errors.openaiCompatibility.test.ts` — 5 pass
- [x] `bun test src/services/api/openaiShim.test.ts` — 95 pass (including new opengateway header capture test)
- [ ] Manual: paste 2 images with MiMo V2.5 Pro on opengateway.gitlawb.com and verify the new error message appears
- [ ] Manual: verify text-only requests still work normally

🤖 Generated with [OpenClaude](https://github.com/Gitlawb/openclaude)