### PR TITLE
fix: use mistral-vibe-cli-latest as default model for Mistral AI

### DIFF
--- a/src/integrations/brands/mistral.ts
+++ b/src/integrations/brands/mistral.ts
@@ -13,6 +13,7 @@ export default defineBrand({
     supportsPreciseTokenCount: false,
   },
   modelIds: [
+    'mistral-vibe-cli-latest',
     'mistral-large-latest',
     'mistral-small-latest',
     'devstral-latest',

--- a/src/integrations/gateways/mistral.ts
+++ b/src/integrations/gateways/mistral.ts
@@ -14,7 +14,7 @@ export default defineGateway({
   label: 'Mistral AI',
   category: 'hosted',
   defaultBaseUrl: 'https://api.mistral.ai/v1',
-  defaultModel: 'devstral-latest',
+  defaultModel: 'mistral-vibe-cli-latest',
   supportsModelRouting: true,
   setup: {
     requiresAuth: true,
@@ -47,6 +47,7 @@ export default defineGateway({
   catalog: {
     source: 'static',
     models: [
+      { id: 'mistral-vibe-cli', apiName: 'mistral-vibe-cli-latest', label: 'Vibe CLI Latest', modelDescriptorId: 'mistral-vibe-cli-latest' },
       { id: 'mistral-devstral', apiName: 'devstral-latest', label: 'Devstral Latest', modelDescriptorId: 'devstral-latest' },
     ],
   },

--- a/src/integrations/models/mistral.ts
+++ b/src/integrations/models/mistral.ts
@@ -31,6 +31,7 @@ function mistralModel(
 export default [
   mistralModel('mistral-large-latest', 'Mistral Large Latest', 256_000, 32_768),
   mistralModel('mistral-small-latest', 'Mistral Small Latest', 256_000, 32_768),
+  mistralModel('mistral-vibe-cli-latest', 'Vibe CLI Latest', 262_144, 32_768),
   mistralModel('devstral-latest', 'Devstral Latest', 256_000, 32_768),
   mistralModel('ministral-3b-latest', 'Ministral 3B Latest', 256_000, 32_768),
   mistralModel('mixtral-8x7b-32768', 'Mixtral 8x7B 32768', 32_768, 32_768),

--- a/src/utils/providerProfile.ts
+++ b/src/utils/providerProfile.ts
@@ -44,7 +44,7 @@ export const DEFAULT_GEMINI_BASE_URL =
   'https://generativelanguage.googleapis.com/v1beta/openai'
 export const DEFAULT_GEMINI_MODEL = 'gemini-3-flash-preview'
 export const DEFAULT_MISTRAL_BASE_URL = 'https://api.mistral.ai/v1'
-export const DEFAULT_MISTRAL_MODEL = 'devstral-latest'
+export const DEFAULT_MISTRAL_MODEL = 'mistral-vibe-cli-latest'
 
 const PROFILE_ENV_KEYS = [
   'CLAUDE_CODE_USE_OPENAI',

--- a/src/utils/providerProfiles.test.ts
+++ b/src/utils/providerProfiles.test.ts
@@ -2041,3 +2041,9 @@ describe('setActiveProviderProfile model cache', () => {
     ])
   })
 })
+
+test('DEFAULT_MISTRAL_MODEL matches the mistral gateway defaultModel', async () => {
+  const { DEFAULT_MISTRAL_MODEL } = await import('./providerProfile.js')
+  const { default: mistralGateway } = await import('../integrations/gateways/mistral.js')
+  expect(DEFAULT_MISTRAL_MODEL).toBe(mistralGateway.defaultModel)
+})

--- a/src/utils/providerProfiles.test.ts
+++ b/src/utils/providerProfiles.test.ts
@@ -2045,5 +2045,6 @@ describe('setActiveProviderProfile model cache', () => {
 test('DEFAULT_MISTRAL_MODEL matches the mistral gateway defaultModel', async () => {
   const { DEFAULT_MISTRAL_MODEL } = await import('./providerProfile.js')
   const { default: mistralGateway } = await import('../integrations/gateways/mistral.js')
-  expect(DEFAULT_MISTRAL_MODEL).toBe(mistralGateway.defaultModel)
+  expect(mistralGateway.defaultModel).toBeDefined()
+  expect(DEFAULT_MISTRAL_MODEL).toBe(mistralGateway.defaultModel!)
 })


### PR DESCRIPTION
## Summary

Changes the default model for the Mistral AI gateway from `devstral-latest` to `mistral-vibe-cli-latest`. The vibe model has better rate limits and is more current.

`devstral-latest` is kept in the catalog as an available alternative.

## Changes

- **`mistral.ts`**: Updated `defaultModel` from `'devstral-latest'` to `'mistral-vibe-cli-latest'`
- **`mistral.ts`**: Added `mistral-vibe-cli-latest` to the static model catalog

## Verification

- [x] Tested `mistral-vibe-cli-latest` against `https://api.mistral.ai/v1/chat/completions` — responds correctly
- [x] `bun test src/services/api/openaiShim.test.ts` — 95 pass
- [x] `bun run build` — clean

Closes #1181

🤖 Generated with [OpenClaude](https://github.com/Gitlawb/openclaude)