### PR TITLE
feat(export): add Markdown and JSON conversation exports

### DIFF
--- a/src/commands/export/export.test.ts
+++ b/src/commands/export/export.test.ts
@@ -1,0 +1,294 @@
+import { describe, expect, test } from 'bun:test'
+import { mkdtemp, readFile, readdir, rm } from 'fs/promises'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import React from 'react'
+
+import type { ExportFormat } from '../../utils/exportFormats.js'
+
+let importCounter = 0
+
+async function importExportCommand(): Promise<typeof import('./export.js')> {
+  importCounter += 1
+  return import(`./export.js?export-test-${importCounter}`) as Promise<
+    typeof import('./export.js')
+  >
+}
+
+function defaultMessages(): unknown[] {
+  return [
+    {
+      type: 'user',
+      uuid: '00000000-0000-4000-8000-000000000001',
+      timestamp: '2026-05-13T12:00:00Z',
+      message: { role: 'user', content: [{ type: 'text', text: 'hello' }] },
+    },
+  ]
+}
+
+async function withExportTestCwd<T>(fn: (cwd: string) => Promise<T>): Promise<T> {
+  const cwd = await mkdtemp(join(tmpdir(), 'openclaude-export-test-'))
+  try {
+    return await fn(cwd)
+  } finally {
+    await rm(cwd, { recursive: true, force: true })
+  }
+}
+
+async function listFiles(cwd: string): Promise<string[]> {
+  return (await readdir(cwd)).sort()
+}
+
+async function runExport(args: string, messages: unknown[] = defaultMessages()): Promise<string> {
+  const { call } = await importExportCommand()
+  let message = ''
+  const result = await call(
+    value => {
+      message = value ?? ''
+    },
+    {
+      messages,
+      options: { tools: [] },
+    } as never,
+    args,
+  )
+  expect(result).toBeNull()
+  return message
+}
+
+async function openExportDialog(args: string, messages: unknown[] = defaultMessages()): Promise<React.ReactNode> {
+  const { call } = await importExportCommand()
+  return call(
+    () => {},
+    {
+      messages,
+      options: { tools: [] },
+    } as never,
+    args,
+  )
+}
+
+describe('/export direct filename', () => {
+  test('writes Markdown for .md filenames without forcing .txt', async () => {
+    await withExportTestCwd(async cwd => {
+      const filename = join(cwd, 'transcript.md')
+      const message = await runExport(filename)
+
+      const content = await readFile(filename, 'utf8')
+      expect(content).toContain('# Conversation Export')
+      expect(content).toContain('## User')
+      expect(content).toContain('hello')
+      expect(message).toBe(`Conversation exported to: ${filename}`)
+    })
+  })
+
+  test('writes Markdown for .markdown filenames without rewriting to .md', async () => {
+    await withExportTestCwd(async cwd => {
+      const filename = join(cwd, 'transcript.markdown')
+      await runExport(filename)
+
+      const content = await readFile(filename, 'utf8')
+      expect(content).toContain('# Conversation Export')
+      expect(content).toContain('hello')
+    })
+  })
+
+  test('canonicalizes .markdown to .md when --format is explicit', async () => {
+    await withExportTestCwd(async cwd => {
+      await runExport(`--format markdown ${join(cwd, 'transcript.markdown')}`)
+
+      const content = await readFile(join(cwd, 'transcript.md'), 'utf8')
+      expect(content).toContain('# Conversation Export')
+      expect(await listFiles(cwd)).toEqual(['transcript.md'])
+    })
+  })
+
+  test('writes direct absolute filenames without nesting them under cwd', async () => {
+    await withExportTestCwd(async cwd => {
+      const absolutePath = join(cwd, 'absolute-transcript.md')
+
+      const message = await runExport(absolutePath)
+
+      const content = await readFile(absolutePath, 'utf8')
+      expect(content).toContain('# Conversation Export')
+      expect(message).toBe(`Conversation exported to: ${absolutePath}`)
+    })
+  })
+
+  test('honors quoted filenames', async () => {
+    await withExportTestCwd(async cwd => {
+      await runExport(`"${join(cwd, 'quoted transcript.md')}"`)
+
+      const content = await readFile(join(cwd, 'quoted transcript.md'), 'utf8')
+      expect(content).toContain('# Conversation Export')
+    })
+  })
+
+  test('writes JSON for .json filenames without forcing .txt', async () => {
+    await withExportTestCwd(async cwd => {
+      await runExport(join(cwd, 'transcript.json'))
+
+      const parsed = JSON.parse(await readFile(join(cwd, 'transcript.json'), 'utf8'))
+      expect(parsed.version).toBe(1)
+      expect(parsed.messages[0].content[0].text).toBe('hello')
+    })
+  })
+
+  test('writes runtime tool results as semantic tool JSON messages', async () => {
+    await withExportTestCwd(async cwd => {
+      await runExport(join(cwd, 'transcript.json'), [
+        {
+          type: 'user',
+          uuid: '00000000-0000-4000-8000-000000000002',
+          timestamp: '2026-05-13T12:00:01Z',
+          message: {
+            role: 'user',
+            content: [
+              { type: 'tool_result', tool_use_id: 'call-1', content: 'tool output' },
+            ],
+          },
+        },
+      ])
+
+      const parsed = JSON.parse(await readFile(join(cwd, 'transcript.json'), 'utf8'))
+      expect(parsed.messages[0].type).toBe('tool')
+      expect(parsed.messages[0].role).toBe('tool')
+      expect(parsed.messages[0].internalType).toBeUndefined()
+      expect(parsed.messages[0].rawType).toBeUndefined()
+    })
+  })
+
+  test('keeps existing extensionless filename behavior as .txt', async () => {
+    await withExportTestCwd(async cwd => {
+      await runExport(join(cwd, 'transcript'))
+
+      const content = await readFile(join(cwd, 'transcript.txt'), 'utf8')
+      expect(content).toContain('hello')
+      expect(content).not.toContain('# Conversation Export')
+      expect(content).not.toContain('"version": 1')
+    })
+  })
+
+  test('keeps unknown filename extensions on the existing plain text path', async () => {
+    await withExportTestCwd(async cwd => {
+      await runExport(join(cwd, 'transcript.csv'))
+
+      const content = await readFile(join(cwd, 'transcript.txt'), 'utf8')
+      expect(content).toContain('hello')
+      expect(content).not.toContain('# Conversation Export')
+      expect(await listFiles(cwd)).toEqual(['transcript.txt'])
+    })
+  })
+
+  test('--format overrides filename extension and normalizes output extension', async () => {
+    await withExportTestCwd(async cwd => {
+      await runExport(`--format json ${join(cwd, 'transcript.txt')}`)
+
+      const parsed = JSON.parse(await readFile(join(cwd, 'transcript.json'), 'utf8'))
+      expect(parsed.version).toBe(1)
+      expect(await listFiles(cwd)).toEqual(['transcript.json'])
+    })
+  })
+
+  test('-f markdown overrides filename extension at command level', async () => {
+    await withExportTestCwd(async cwd => {
+      await runExport(`-f markdown ${join(cwd, 'transcript.txt')}`)
+
+      const content = await readFile(join(cwd, 'transcript.md'), 'utf8')
+      expect(content).toContain('# Conversation Export')
+      expect(await listFiles(cwd)).toEqual(['transcript.md'])
+    })
+  })
+
+  test('flag after filename overrides extension at command level', async () => {
+    await withExportTestCwd(async cwd => {
+      await runExport(`${join(cwd, 'transcript')} -f json`)
+
+      const parsed = JSON.parse(await readFile(join(cwd, 'transcript.json'), 'utf8'))
+      expect(parsed.version).toBe(1)
+      expect(await listFiles(cwd)).toEqual(['transcript.json'])
+    })
+  })
+
+  test('keeps explicit .txt export behavior', async () => {
+    await withExportTestCwd(async cwd => {
+      await runExport(join(cwd, 'transcript.txt'))
+
+      const content = await readFile(join(cwd, 'transcript.txt'), 'utf8')
+      expect(content).toContain('hello')
+      expect(content).not.toContain('# Conversation Export')
+      expect(content).not.toContain('"version": 1')
+    })
+  })
+
+  test('reports unsupported formats without writing a file', async () => {
+    await withExportTestCwd(async cwd => {
+      const message = await runExport(`--format xml ${join(cwd, 'transcript')}`)
+
+      expect(message).toContain('Unsupported export format: xml')
+      expect(await listFiles(cwd)).toEqual([])
+    })
+  })
+
+  test('reports unsupported options without writing a file', async () => {
+    await withExportTestCwd(async cwd => {
+      const message = await runExport(`--formt json ${join(cwd, 'transcript')}`)
+
+      expect(message).toContain('Unsupported export option: --formt')
+      expect(await listFiles(cwd)).toEqual([])
+    })
+  })
+
+  test('uses --format as the interactive dialog default when no filename is provided', async () => {
+    await withExportTestCwd(async () => {
+      const result = await openExportDialog('--format json')
+
+      expect(React.isValidElement(result)).toBe(true)
+      expect((result as React.ReactElement<{ defaultFormat: ExportFormat }>).props.defaultFormat).toBe('json')
+    })
+  })
+
+  test('uses -f as the interactive dialog default when no filename is provided', async () => {
+    await withExportTestCwd(async () => {
+      const result = await openExportDialog('-f json')
+
+      expect(React.isValidElement(result)).toBe(true)
+      expect((result as React.ReactElement<{ defaultFormat: ExportFormat }>).props.defaultFormat).toBe('json')
+    })
+  })
+
+  test('generates prompt-based .txt default filenames for interactive export', async () => {
+    await withExportTestCwd(async () => {
+      const { call } = await importExportCommand()
+      const result = await call(
+        () => {},
+        {
+          messages: [
+            {
+              type: 'user',
+              uuid: '00000000-0000-4000-8000-000000000001',
+              timestamp: '2026-05-13T12:00:00Z',
+              message: { role: 'user', content: [{ type: 'text', text: 'Hello, Export World!\nsecond line' }] },
+            },
+          ],
+          options: { tools: [] },
+        } as never,
+        '',
+      )
+
+      expect(React.isValidElement(result)).toBe(true)
+      const defaultFilename = (result as React.ReactElement<{ defaultFilename: string }>).props.defaultFilename
+      expect(defaultFilename).toMatch(/^\d{4}-\d{2}-\d{2}-\d{6}-hello-export-world\.txt$/)
+    })
+  })
+
+  test('falls back to conversation timestamp .txt filenames for interactive export', async () => {
+    await withExportTestCwd(async () => {
+      const result = await openExportDialog('', [])
+
+      expect(React.isValidElement(result)).toBe(true)
+      const defaultFilename = (result as React.ReactElement<{ defaultFilename: string }>).props.defaultFilename
+      expect(defaultFilename).toMatch(/^conversation-\d{4}-\d{2}-\d{2}-\d{6}\.txt$/)
+    })
+  })
+})

--- a/src/commands/export/export.tsx
+++ b/src/commands/export/export.tsx
@@ -1,11 +1,12 @@
-import { join } from 'path';
 import React from 'react';
 import { ExportDialog } from '../../components/ExportDialog.js';
 import type { ToolUseContext } from '../../Tool.js';
 import type { LocalJSXCommandOnDone } from '../../types/command.js';
 import type { Message } from '../../types/message.js';
 import { getCwd } from '../../utils/cwd.js';
-import { renderMessagesToPlainText } from '../../utils/exportRenderer.js';
+import type { ExportFormat } from '../../utils/exportFormats.js';
+import { ensureExportFilenameExtension, inferExportFormatFromFilename, parseExportArgs, resolveExportFilepath } from '../../utils/exportFormats.js';
+import { renderMessagesForExport } from '../../utils/exportRenderer.js';
 import { writeFileSync_DEPRECATED } from '../../utils/slowOperations.js';
 function formatTimestamp(date: Date): string {
   const year = date.getFullYear();
@@ -46,20 +47,29 @@ export function sanitizeFilename(text: string): string {
   .replace(/-+/g, '-') // Replace multiple hyphens with single
   .replace(/^-|-$/g, ''); // Remove leading/trailing hyphens
 }
-async function exportWithReactRenderer(context: ToolUseContext): Promise<string> {
-  const tools = context.options.tools || [];
-  return renderMessagesToPlainText(context.messages, tools);
-}
 export async function call(onDone: LocalJSXCommandOnDone, context: ToolUseContext, args: string): Promise<React.ReactNode> {
-  // Render the conversation content
-  const content = await exportWithReactRenderer(context);
+  const tools = context.options.tools || [];
 
-  // If args are provided, write directly to file and skip dialog
-  const filename = args.trim();
-  if (filename) {
-    const finalFilename = filename.endsWith('.txt') ? filename : filename.replace(/\.[^.]+$/, '') + '.txt';
-    const filepath = join(getCwd(), finalFilename);
+  // Parse arguments for --format flag and filename
+  const parsed = parseExportArgs(args);
+  if (parsed.error) {
+    onDone(parsed.error);
+    return null;
+  }
+
+  // Determine format: --format flag > filename extension > text default
+  const format: ExportFormat = parsed.format
+    ?? (parsed.filename ? inferExportFormatFromFilename(parsed.filename) : null)
+    ?? 'text';
+
+  // If args are provided, render and write directly to file
+  if (parsed.filename) {
     try {
+      const content = await renderMessagesForExport(context.messages, tools, { format });
+      const finalFilename = ensureExportFilenameExtension(parsed.filename, format, {
+        preserveMarkdownExtension: parsed.format === undefined,
+      });
+      const filepath = resolveExportFilepath(getCwd(), finalFilename);
       writeFileSync_DEPRECATED(filepath, content, {
         encoding: 'utf-8',
         flush: true
@@ -75,16 +85,15 @@ export async function call(onDone: LocalJSXCommandOnDone, context: ToolUseContex
   // Generate default filename from first prompt or timestamp
   const firstPrompt = extractFirstPrompt(context.messages);
   const timestamp = formatTimestamp(new Date());
-  let defaultFilename: string;
-  if (firstPrompt) {
-    const sanitized = sanitizeFilename(firstPrompt);
-    defaultFilename = sanitized ? `${timestamp}-${sanitized}.txt` : `conversation-${timestamp}.txt`;
-  } else {
-    defaultFilename = `conversation-${timestamp}.txt`;
-  }
+  const sanitized = firstPrompt ? sanitizeFilename(firstPrompt) : '';
+  const defaultFilename = sanitized
+    ? `${timestamp}-${sanitized}.txt`
+    : `conversation-${timestamp}.txt`;
 
   // Return the dialog component when no args provided
-  return <ExportDialog content={content} defaultFilename={defaultFilename} onDone={result => {
+  return <ExportDialog defaultFilename={defaultFilename} defaultFormat={format} getContent={async (f) => {
+    return renderMessagesForExport(context.messages, tools, { format: f });
+  }} onDone={result => {
     onDone(result.message);
   }} />;
 }

--- a/src/components/ExportDialog.test.tsx
+++ b/src/components/ExportDialog.test.tsx
@@ -1,0 +1,697 @@
+import { PassThrough } from 'node:stream'
+
+import { afterAll, afterEach, expect, mock, test } from 'bun:test'
+import { mkdtemp, readFile, rm } from 'fs/promises'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import React from 'react'
+import stripAnsi from 'strip-ansi'
+
+import { createRoot } from '../ink.js'
+import { KeybindingSetup } from '../keybindings/KeybindingProviderSetup.js'
+import { AppStateProvider } from '../state/AppState.js'
+import type { ExportFormat } from '../utils/exportFormats.js'
+
+const setClipboard = mock(async (_content: string) => '')
+
+mock.module('../ink/termio/osc.js', () => ({
+  setClipboard,
+}))
+
+async function importExportDialog(): Promise<typeof import('./ExportDialog.js')> {
+  return import(`./ExportDialog.js?dialog-test-${Date.now()}-${Math.random()}`) as Promise<
+    typeof import('./ExportDialog.js')
+  >
+}
+
+function createTestStreams() {
+  let output = ''
+  const stdout = new PassThrough()
+  const stdin = new PassThrough() as PassThrough & {
+    isTTY: boolean
+    setRawMode: (mode: boolean) => void
+    ref: () => void
+    unref: () => void
+  }
+  stdin.isTTY = true
+  stdin.setRawMode = () => {}
+  stdin.ref = () => {}
+  stdin.unref = () => {}
+  ;(stdout as unknown as { columns: number }).columns = 120
+  stdout.on('data', chunk => {
+    output += chunk.toString()
+  })
+  return { stdout, stdin, getOutput: () => stripAnsi(output) }
+}
+
+async function waitForCondition(
+  predicate: () => boolean,
+  timeoutMs = 3000,
+): Promise<void> {
+  const startedAt = Date.now()
+  while (Date.now() - startedAt < timeoutMs) {
+    if (predicate()) return
+    await Bun.sleep(10)
+  }
+  throw new Error('Timed out waiting for ExportDialog test state')
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void
+  let reject!: (error: unknown) => void
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res
+    reject = rej
+  })
+  return { promise, resolve, reject }
+}
+
+afterEach(() => {
+  setClipboard.mockClear()
+})
+
+afterAll(() => {
+  mock.restore()
+})
+
+test('shows export format choices before export method choices', async () => {
+  const { ExportDialog } = await importExportDialog()
+  const { stdout, stdin, getOutput } = createTestStreams()
+  const root = await createRoot({
+    stdout: stdout as unknown as NodeJS.WriteStream,
+    stdin: stdin as unknown as NodeJS.ReadStream,
+    patchConsole: false,
+  })
+
+  try {
+    root.render(
+      <AppStateProvider>
+        <KeybindingSetup>
+          <ExportDialog
+            defaultFilename="conversation.txt"
+            defaultFormat="text"
+            getContent={async () => 'content'}
+            onDone={() => {}}
+          />
+        </KeybindingSetup>
+      </AppStateProvider>,
+    )
+
+    await waitForCondition(() => getOutput().includes('Plain Text (.txt)'))
+    const output = getOutput()
+    expect(output).toContain('Select export format:')
+    expect(output).toContain('Plain Text (.txt)')
+    expect(output).toContain('Markdown (.md)')
+    expect(output).toContain('JSON (.json)')
+    expect(output).not.toContain('Copy to clipboard')
+  } finally {
+    root.unmount()
+    stdin.end()
+    stdout.end()
+    await Bun.sleep(0)
+  }
+})
+
+test('copies the selected format to the clipboard', async () => {
+  const { ExportDialog } = await importExportDialog()
+  const { stdout, stdin, getOutput } = createTestStreams()
+  const root = await createRoot({
+    stdout: stdout as unknown as NodeJS.WriteStream,
+    stdin: stdin as unknown as NodeJS.ReadStream,
+    patchConsole: false,
+  })
+  const requestedFormats: ExportFormat[] = []
+  const doneMessages: string[] = []
+
+  try {
+    root.render(
+      <AppStateProvider>
+        <KeybindingSetup>
+          <ExportDialog
+            defaultFilename="conversation.txt"
+            defaultFormat="text"
+            getContent={async format => {
+              requestedFormats.push(format)
+              return `${format} content`
+            }}
+            onDone={result => {
+              doneMessages.push(result.message)
+            }}
+          />
+        </KeybindingSetup>
+      </AppStateProvider>,
+    )
+
+    await waitForCondition(() => getOutput().includes('JSON (.json)'))
+    stdin.write('3')
+    await waitForCondition(() => getOutput().includes('Copy to clipboard'))
+    stdin.write('1')
+    await waitForCondition(() => doneMessages.length === 1)
+
+    expect(requestedFormats).toEqual(['json'])
+    expect(setClipboard).toHaveBeenCalledWith('json content')
+    expect(doneMessages[0]).toBe('Conversation copied to clipboard')
+  } finally {
+    root.unmount()
+    stdin.end()
+    stdout.end()
+    await Bun.sleep(0)
+  }
+})
+
+test('uses the default format when confirming the format step', async () => {
+  const { ExportDialog } = await importExportDialog()
+  const { stdout, stdin, getOutput } = createTestStreams()
+  const root = await createRoot({
+    stdout: stdout as unknown as NodeJS.WriteStream,
+    stdin: stdin as unknown as NodeJS.ReadStream,
+    patchConsole: false,
+  })
+  const requestedFormats: ExportFormat[] = []
+  const doneMessages: string[] = []
+
+  try {
+    root.render(
+      <AppStateProvider>
+        <KeybindingSetup>
+          <ExportDialog
+            defaultFilename="conversation.txt"
+            defaultFormat="json"
+            getContent={async format => {
+              requestedFormats.push(format)
+              return `${format} content`
+            }}
+            onDone={result => {
+              doneMessages.push(result.message)
+            }}
+          />
+        </KeybindingSetup>
+      </AppStateProvider>,
+    )
+
+    await waitForCondition(() => getOutput().includes('JSON (.json)'))
+    stdin.write('\r')
+    await waitForCondition(() => getOutput().includes('Copy to clipboard'))
+    stdin.write('1')
+    await waitForCondition(() => doneMessages.length === 1)
+
+    expect(requestedFormats).toEqual(['json'])
+    expect(setClipboard).toHaveBeenCalledWith('json content')
+    expect(doneMessages[0]).toBe('Conversation copied to clipboard')
+  } finally {
+    root.unmount()
+    stdin.end()
+    stdout.end()
+    await Bun.sleep(0)
+  }
+})
+
+test('reports clipboard export failures through onDone', async () => {
+  const { ExportDialog } = await importExportDialog()
+  const { stdout, stdin, getOutput } = createTestStreams()
+  const root = await createRoot({
+    stdout: stdout as unknown as NodeJS.WriteStream,
+    stdin: stdin as unknown as NodeJS.ReadStream,
+    patchConsole: false,
+  })
+  const doneMessages: string[] = []
+
+  try {
+    root.render(
+      <AppStateProvider>
+        <KeybindingSetup>
+          <ExportDialog
+            defaultFilename="conversation.txt"
+            defaultFormat="text"
+            getContent={async () => {
+              throw new Error('render failed')
+            }}
+            onDone={result => {
+              doneMessages.push(result.message)
+            }}
+          />
+        </KeybindingSetup>
+      </AppStateProvider>,
+    )
+
+    await waitForCondition(() => getOutput().includes('Plain Text (.txt)'))
+    stdin.write('1')
+    await waitForCondition(() => getOutput().includes('Copy to clipboard'))
+    stdin.write('1')
+    await waitForCondition(() => doneMessages.length === 1)
+
+    expect(doneMessages[0]).toBe('Failed to copy conversation: render failed')
+    expect(setClipboard).not.toHaveBeenCalled()
+  } finally {
+    root.unmount()
+    stdin.end()
+    stdout.end()
+    await Bun.sleep(0)
+  }
+})
+
+test('ignores repeated clipboard export input while content is rendering', async () => {
+  const { ExportDialog } = await importExportDialog()
+  const { stdout, stdin, getOutput } = createTestStreams()
+  const root = await createRoot({
+    stdout: stdout as unknown as NodeJS.WriteStream,
+    stdin: stdin as unknown as NodeJS.ReadStream,
+    patchConsole: false,
+  })
+  const content = deferred<string>()
+  const requestedFormats: ExportFormat[] = []
+  const doneMessages: string[] = []
+
+  try {
+    root.render(
+      <AppStateProvider>
+        <KeybindingSetup>
+          <ExportDialog
+            defaultFilename="conversation.txt"
+            defaultFormat="text"
+            getContent={async format => {
+              requestedFormats.push(format)
+              return content.promise
+            }}
+            onDone={result => {
+              doneMessages.push(result.message)
+            }}
+          />
+        </KeybindingSetup>
+      </AppStateProvider>,
+    )
+
+    await waitForCondition(() => getOutput().includes('Plain Text (.txt)'))
+    stdin.write('1')
+    await waitForCondition(() => getOutput().includes('Copy to clipboard'))
+    stdin.write('1')
+    await Bun.sleep(10)
+    stdin.write('1')
+    await waitForCondition(() => requestedFormats.length === 1)
+    content.resolve('text content')
+    await waitForCondition(() => doneMessages.length === 1)
+
+    expect(requestedFormats).toEqual(['text'])
+    expect(setClipboard).toHaveBeenCalledTimes(1)
+    expect(doneMessages).toEqual(['Conversation copied to clipboard'])
+  } finally {
+    root.unmount()
+    stdin.end()
+    stdout.end()
+    await Bun.sleep(0)
+  }
+})
+
+test('saves the selected format to a normalized file path', async () => {
+  const { ExportDialog } = await importExportDialog()
+  const dir = await mkdtemp(join(tmpdir(), 'openclaude-export-dialog-test-'))
+  const { stdout, stdin, getOutput } = createTestStreams()
+  const root = await createRoot({
+    stdout: stdout as unknown as NodeJS.WriteStream,
+    stdin: stdin as unknown as NodeJS.ReadStream,
+    patchConsole: false,
+  })
+  const requestedFormats: ExportFormat[] = []
+  const doneMessages: string[] = []
+
+  try {
+    root.render(
+      <AppStateProvider>
+        <KeybindingSetup>
+          <ExportDialog
+            defaultFilename={join(dir, 'conversation.txt')}
+            defaultFormat="text"
+            getContent={async format => {
+              requestedFormats.push(format)
+              return `${format} content`
+            }}
+            onDone={result => {
+              doneMessages.push(result.message)
+            }}
+          />
+        </KeybindingSetup>
+      </AppStateProvider>,
+    )
+
+    await waitForCondition(() => getOutput().includes('Markdown (.md)'))
+    stdin.write('2')
+    await waitForCondition(() => getOutput().includes('Save to file'))
+    stdin.write('2')
+    await waitForCondition(() => getOutput().includes('Enter filename:'))
+    stdin.write('\r')
+    await waitForCondition(() => doneMessages.length === 1)
+
+    const outputPath = join(dir, 'conversation.md')
+    expect(requestedFormats).toEqual(['markdown'])
+    expect(await readFile(outputPath, 'utf8')).toBe('markdown content')
+    expect(doneMessages[0]).toBe(`Conversation exported to: ${outputPath}`)
+  } finally {
+    root.unmount()
+    stdin.end()
+    stdout.end()
+    await rm(dir, { recursive: true, force: true })
+    await Bun.sleep(0)
+  }
+})
+
+test('uses the default format extension when saving to a file', async () => {
+  const { ExportDialog } = await importExportDialog()
+  const dir = await mkdtemp(join(tmpdir(), 'openclaude-export-dialog-test-'))
+  const { stdout, stdin, getOutput } = createTestStreams()
+  const root = await createRoot({
+    stdout: stdout as unknown as NodeJS.WriteStream,
+    stdin: stdin as unknown as NodeJS.ReadStream,
+    patchConsole: false,
+  })
+  const requestedFormats: ExportFormat[] = []
+  const doneMessages: string[] = []
+
+  try {
+    root.render(
+      <AppStateProvider>
+        <KeybindingSetup>
+          <ExportDialog
+            defaultFilename={join(dir, 'conversation.txt')}
+            defaultFormat="json"
+            getContent={async format => {
+              requestedFormats.push(format)
+              return `${format} content`
+            }}
+            onDone={result => {
+              doneMessages.push(result.message)
+            }}
+          />
+        </KeybindingSetup>
+      </AppStateProvider>,
+    )
+
+    await waitForCondition(() => getOutput().includes('JSON (.json)'))
+    stdin.write('\r')
+    await waitForCondition(() => getOutput().includes('Save to file'))
+    stdin.write('2')
+    await waitForCondition(() => getOutput().includes('Enter filename:'))
+    stdin.write('\r')
+    await waitForCondition(() => doneMessages.length === 1)
+
+    const outputPath = join(dir, 'conversation.json')
+    expect(requestedFormats).toEqual(['json'])
+    expect(await readFile(outputPath, 'utf8')).toBe('json content')
+    expect(doneMessages[0]).toBe(`Conversation exported to: ${outputPath}`)
+  } finally {
+    root.unmount()
+    stdin.end()
+    stdout.end()
+    await rm(dir, { recursive: true, force: true })
+    await Bun.sleep(0)
+  }
+})
+
+test('preserves .markdown filename extension when saving Markdown from the dialog', async () => {
+  const { ExportDialog } = await importExportDialog()
+  const dir = await mkdtemp(join(tmpdir(), 'openclaude-export-dialog-test-'))
+  const { stdout, stdin, getOutput } = createTestStreams()
+  const root = await createRoot({
+    stdout: stdout as unknown as NodeJS.WriteStream,
+    stdin: stdin as unknown as NodeJS.ReadStream,
+    patchConsole: false,
+  })
+  const doneMessages: string[] = []
+
+  try {
+    root.render(
+      <AppStateProvider>
+        <KeybindingSetup>
+          <ExportDialog
+            defaultFilename={join(dir, 'conversation.markdown')}
+            defaultFormat="markdown"
+            getContent={async () => 'markdown content'}
+            onDone={result => {
+              doneMessages.push(result.message)
+            }}
+          />
+        </KeybindingSetup>
+      </AppStateProvider>,
+    )
+
+    await waitForCondition(() => getOutput().includes('Markdown (.md)'))
+    stdin.write('\r')
+    await waitForCondition(() => getOutput().includes('Save to file'))
+    stdin.write('2')
+    await waitForCondition(() => getOutput().includes('Enter filename:'))
+    stdin.write('\r')
+    await waitForCondition(() => doneMessages.length === 1)
+
+    const outputPath = join(dir, 'conversation.markdown')
+    expect(await readFile(outputPath, 'utf8')).toBe('markdown content')
+    expect(doneMessages[0]).toBe(`Conversation exported to: ${outputPath}`)
+  } finally {
+    root.unmount()
+    stdin.end()
+    stdout.end()
+    await rm(dir, { recursive: true, force: true })
+    await Bun.sleep(0)
+  }
+})
+
+test('ignores repeated file export submit while content is rendering', async () => {
+  const { ExportDialog } = await importExportDialog()
+  const dir = await mkdtemp(join(tmpdir(), 'openclaude-export-dialog-test-'))
+  const { stdout, stdin, getOutput } = createTestStreams()
+  const root = await createRoot({
+    stdout: stdout as unknown as NodeJS.WriteStream,
+    stdin: stdin as unknown as NodeJS.ReadStream,
+    patchConsole: false,
+  })
+  const content = deferred<string>()
+  const requestedFormats: ExportFormat[] = []
+  const doneMessages: string[] = []
+
+  try {
+    root.render(
+      <AppStateProvider>
+        <KeybindingSetup>
+          <ExportDialog
+            defaultFilename={join(dir, 'conversation.txt')}
+            defaultFormat="text"
+            getContent={async format => {
+              requestedFormats.push(format)
+              return content.promise
+            }}
+            onDone={result => {
+              doneMessages.push(result.message)
+            }}
+          />
+        </KeybindingSetup>
+      </AppStateProvider>,
+    )
+
+    await waitForCondition(() => getOutput().includes('Plain Text (.txt)'))
+    stdin.write('1')
+    await waitForCondition(() => getOutput().includes('Save to file'))
+    stdin.write('2')
+    await waitForCondition(() => getOutput().includes('Enter filename:'))
+    stdin.write('\r')
+    await Bun.sleep(10)
+    stdin.write('\r')
+    await waitForCondition(() => requestedFormats.length === 1)
+    content.resolve('text content')
+    await waitForCondition(() => doneMessages.length === 1)
+
+    const outputPath = join(dir, 'conversation.txt')
+    expect(requestedFormats).toEqual(['text'])
+    expect(await readFile(outputPath, 'utf8')).toBe('text content')
+    expect(doneMessages).toEqual([`Conversation exported to: ${outputPath}`])
+  } finally {
+    root.unmount()
+    stdin.end()
+    stdout.end()
+    await rm(dir, { recursive: true, force: true })
+    await Bun.sleep(0)
+  }
+})
+
+test('reports file export failures through onDone', async () => {
+  const { ExportDialog } = await importExportDialog()
+  const { stdout, stdin, getOutput } = createTestStreams()
+  const root = await createRoot({
+    stdout: stdout as unknown as NodeJS.WriteStream,
+    stdin: stdin as unknown as NodeJS.ReadStream,
+    patchConsole: false,
+  })
+  const doneMessages: string[] = []
+
+  try {
+    root.render(
+      <AppStateProvider>
+        <KeybindingSetup>
+          <ExportDialog
+            defaultFilename="conversation.txt"
+            defaultFormat="text"
+            getContent={async () => {
+              throw new Error('render failed')
+            }}
+            onDone={result => {
+              doneMessages.push(result.message)
+            }}
+          />
+        </KeybindingSetup>
+      </AppStateProvider>,
+    )
+
+    await waitForCondition(() => getOutput().includes('Plain Text (.txt)'))
+    stdin.write('1')
+    await waitForCondition(() => getOutput().includes('Save to file'))
+    stdin.write('2')
+    await waitForCondition(() => getOutput().includes('Enter filename:'))
+    stdin.write('\r')
+    await waitForCondition(() => doneMessages.length === 1)
+
+    expect(doneMessages[0]).toBe('Failed to export conversation: render failed')
+    expect(setClipboard).not.toHaveBeenCalled()
+  } finally {
+    root.unmount()
+    stdin.end()
+    stdout.end()
+    await Bun.sleep(0)
+  }
+})
+
+test('Escape goes back from filename to method before exporting', async () => {
+  const { ExportDialog } = await importExportDialog()
+  const { stdout, stdin, getOutput } = createTestStreams()
+  const root = await createRoot({
+    stdout: stdout as unknown as NodeJS.WriteStream,
+    stdin: stdin as unknown as NodeJS.ReadStream,
+    patchConsole: false,
+  })
+  const requestedFormats: ExportFormat[] = []
+  const doneMessages: string[] = []
+
+  try {
+    root.render(
+      <AppStateProvider>
+        <KeybindingSetup>
+          <ExportDialog
+            defaultFilename="conversation.txt"
+            defaultFormat="text"
+            getContent={async format => {
+              requestedFormats.push(format)
+              return 'text content'
+            }}
+            onDone={result => {
+              doneMessages.push(result.message)
+            }}
+          />
+        </KeybindingSetup>
+      </AppStateProvider>,
+    )
+
+    await waitForCondition(() => getOutput().includes('Plain Text (.txt)'))
+    stdin.write('1')
+    await waitForCondition(() => getOutput().includes('Save to file'))
+    stdin.write('2')
+    await waitForCondition(() => getOutput().includes('Enter filename:'))
+    stdin.write('\u001B')
+    await Bun.sleep(150)
+    stdin.write('1')
+    await waitForCondition(() => doneMessages.length === 1)
+
+    expect(requestedFormats).toEqual(['text'])
+    expect(doneMessages).toEqual(['Conversation copied to clipboard'])
+  } finally {
+    root.unmount()
+    stdin.end()
+    stdout.end()
+    await Bun.sleep(0)
+  }
+})
+
+test('Escape goes back from method to format before exporting', async () => {
+  const { ExportDialog } = await importExportDialog()
+  const { stdout, stdin, getOutput } = createTestStreams()
+  const root = await createRoot({
+    stdout: stdout as unknown as NodeJS.WriteStream,
+    stdin: stdin as unknown as NodeJS.ReadStream,
+    patchConsole: false,
+  })
+  const requestedFormats: ExportFormat[] = []
+  const doneMessages: string[] = []
+
+  try {
+    root.render(
+      <AppStateProvider>
+        <KeybindingSetup>
+          <ExportDialog
+            defaultFilename="conversation.txt"
+            defaultFormat="text"
+            getContent={async format => {
+              requestedFormats.push(format)
+              return `${format} content`
+            }}
+            onDone={result => {
+              doneMessages.push(result.message)
+            }}
+          />
+        </KeybindingSetup>
+      </AppStateProvider>,
+    )
+
+    await waitForCondition(() => getOutput().includes('Plain Text (.txt)'))
+    stdin.write('1')
+    await waitForCondition(() => getOutput().includes('Copy to clipboard'))
+    stdin.write('\u001B')
+    await Bun.sleep(150)
+    stdin.write('3')
+    await Bun.sleep(20)
+    stdin.write('1')
+    await waitForCondition(() => doneMessages.length === 1)
+
+    expect(requestedFormats).toEqual(['json'])
+    expect(doneMessages).toEqual(['Conversation copied to clipboard'])
+  } finally {
+    root.unmount()
+    stdin.end()
+    stdout.end()
+    await Bun.sleep(0)
+  }
+})
+
+test('Escape at the format step cancels export once', async () => {
+  const { ExportDialog } = await importExportDialog()
+  const { stdout, stdin, getOutput } = createTestStreams()
+  const root = await createRoot({
+    stdout: stdout as unknown as NodeJS.WriteStream,
+    stdin: stdin as unknown as NodeJS.ReadStream,
+    patchConsole: false,
+  })
+  const doneMessages: string[] = []
+
+  try {
+    root.render(
+      <AppStateProvider>
+        <KeybindingSetup>
+          <ExportDialog
+            defaultFilename="conversation.txt"
+            defaultFormat="text"
+            getContent={async () => 'content'}
+            onDone={result => {
+              doneMessages.push(result.message)
+            }}
+          />
+        </KeybindingSetup>
+      </AppStateProvider>,
+    )
+
+    await waitForCondition(() => getOutput().includes('Plain Text (.txt)'))
+    stdin.write('\u001B')
+    stdin.write('\u001B')
+    await waitForCondition(() => doneMessages.length === 1)
+
+    expect(doneMessages).toEqual(['Export cancelled'])
+  } finally {
+    root.unmount()
+    stdin.end()
+    stdout.end()
+    await Bun.sleep(0)
+  }
+})

--- a/src/components/ExportDialog.tsx
+++ b/src/components/ExportDialog.tsx
@@ -1,11 +1,12 @@
-import { join } from 'path';
-import React, { useCallback, useState } from 'react';
+import React, { useCallback, useRef, useState } from 'react';
 import type { ExitState } from '../hooks/useExitOnCtrlCDWithKeybindings.js';
 import { useTerminalSize } from '../hooks/useTerminalSize.js';
 import { setClipboard } from '../ink/termio/osc.js';
-import { Box, Text } from '../ink.js';
+import { Box, Text, useInput } from '../ink.js';
 import { useKeybinding } from '../keybindings/useKeybinding.js';
 import { getCwd } from '../utils/cwd.js';
+import type { ExportFormat } from '../utils/exportFormats.js';
+import { ensureExportFilenameExtension, resolveExportFilepath } from '../utils/exportFormats.js';
 import { writeFileSync_DEPRECATED } from '../utils/slowOperations.js';
 import { ConfigurableShortcutHint } from './ConfigurableShortcutHint.js';
 import { Select } from './CustomSelect/select.js';
@@ -14,50 +15,93 @@ import { Dialog } from './design-system/Dialog.js';
 import { KeyboardShortcutHint } from './design-system/KeyboardShortcutHint.js';
 import TextInput from './TextInput.js';
 type ExportDialogProps = {
-  content: string;
   defaultFilename: string;
+  defaultFormat: ExportFormat;
+  getContent: (format: ExportFormat) => Promise<string>;
   onDone: (result: {
     success: boolean;
     message: string;
   }) => void;
 };
-type ExportOption = 'clipboard' | 'file';
+type DialogStep = 'format' | 'method' | 'filename';
 export function ExportDialog({
-  content,
   defaultFilename,
+  defaultFormat,
+  getContent,
   onDone
 }: ExportDialogProps): React.ReactNode {
-  const [, setSelectedOption] = useState<ExportOption | null>(null);
-  const [filename, setFilename] = useState<string>(defaultFilename);
-  const [cursorOffset, setCursorOffset] = useState<number>(defaultFilename.length);
-  const [showFilenameInput, setShowFilenameInput] = useState(false);
+  const [step, setStep] = useState<DialogStep>('format');
+  const [selectedFormat, setSelectedFormat] = useState<ExportFormat>(defaultFormat);
+  const [isExporting, setIsExporting] = useState(false);
+  const isExportingRef = useRef(false);
+  const formatFilenames: Record<ExportFormat, string> = {
+    text: ensureExportFilenameExtension(defaultFilename, 'text'),
+    markdown: ensureExportFilenameExtension(defaultFilename, 'markdown', {
+      preserveMarkdownExtension: true,
+    }),
+    json: ensureExportFilenameExtension(defaultFilename, 'json'),
+  };
+  const [filename, setFilename] = useState<string>(formatFilenames[defaultFormat]);
+  const [cursorOffset, setCursorOffset] = useState<number>(formatFilenames[defaultFormat].length);
   const {
     columns
   } = useTerminalSize();
 
-  // Handle going back from filename input to option selection
+  // Handle going back through steps
   const handleGoBack = useCallback(() => {
-    setShowFilenameInput(false);
-    setSelectedOption(null);
-  }, []);
+    if (step === 'filename') {
+      setStep('method');
+    } else if (step === 'method') {
+      setStep('format');
+    }
+  }, [step]);
+
+  const handleSelectFormat = (value: string): void => {
+    const format = value as ExportFormat;
+    setSelectedFormat(format);
+    const newFilename = ensureExportFilenameExtension(filename, format, {
+      preserveMarkdownExtension: true,
+    });
+    setFilename(newFilename);
+    setCursorOffset(newFilename.length);
+    setStep('method');
+  };
+
   const handleSelectOption = async (value: string): Promise<void> => {
+    if (isExportingRef.current) return;
     if (value === 'clipboard') {
-      // Copy to clipboard immediately
-      const raw = await setClipboard(content);
-      if (raw) process.stdout.write(raw);
-      onDone({
-        success: true,
-        message: 'Conversation copied to clipboard'
-      });
+      isExportingRef.current = true;
+      setIsExporting(true);
+      try {
+        const content = await getContent(selectedFormat);
+        const raw = await setClipboard(content);
+        if (raw) process.stdout.write(raw);
+        onDone({
+          success: true,
+          message: 'Conversation copied to clipboard'
+        });
+      } catch (error) {
+        isExportingRef.current = false;
+        setIsExporting(false);
+        onDone({
+          success: false,
+          message: `Failed to copy conversation: ${error instanceof Error ? error.message : 'Unknown error'}`
+        });
+      }
     } else if (value === 'file') {
-      setSelectedOption('file');
-      setShowFilenameInput(true);
+      setStep('filename');
     }
   };
-  const handleFilenameSubmit = () => {
-    const finalFilename = filename.endsWith('.txt') ? filename : filename.replace(/\.[^.]+$/, '') + '.txt';
-    const filepath = join(getCwd(), finalFilename);
+  const handleFilenameSubmit = async () => {
+    if (isExportingRef.current) return;
+    isExportingRef.current = true;
+    setIsExporting(true);
+    const finalFilename = ensureExportFilenameExtension(filename, selectedFormat, {
+      preserveMarkdownExtension: true,
+    });
+    const filepath = resolveExportFilepath(getCwd(), finalFilename);
     try {
+      const content = await getContent(selectedFormat);
       writeFileSync_DEPRECATED(filepath, content, {
         encoding: 'utf-8',
         flush: true
@@ -67,6 +111,8 @@ export function ExportDialog({
         message: `Conversation exported to: ${filepath}`
       });
     } catch (error) {
+      isExportingRef.current = false;
+      setIsExporting(false);
       onDone({
         success: false,
         message: `Failed to export conversation: ${error instanceof Error ? error.message : 'Unknown error'}`
@@ -74,10 +120,10 @@ export function ExportDialog({
     }
   };
 
-  // Dialog calls onCancel when Escape is pressed. If we are in the filename
-  // input sub-screen, go back to the option list instead of closing entirely.
+  // Dialog calls onCancel when Escape is pressed.
   const handleCancel = useCallback(() => {
-    if (showFilenameInput) {
+    if (isExportingRef.current) return;
+    if (step !== 'format') {
       handleGoBack();
     } else {
       onDone({
@@ -85,20 +131,35 @@ export function ExportDialog({
         message: 'Export cancelled'
       });
     }
-  }, [showFilenameInput, handleGoBack, onDone]);
-  const options = [{
+  }, [step, handleGoBack, onDone]);
+
+  const formatOptions = [{
+    label: 'Plain Text (.txt)',
+    value: 'text',
+    description: 'Plain text format'
+  }, {
+    label: 'Markdown (.md)',
+    value: 'markdown',
+    description: 'Markdown format for readable archives'
+  }, {
+    label: 'JSON (.json)',
+    value: 'json',
+    description: 'Structured JSON for programmatic use'
+  }];
+
+  const methodOptions = [{
     label: 'Copy to clipboard',
     value: 'clipboard',
     description: 'Copy the conversation to your system clipboard'
   }, {
     label: 'Save to file',
     value: 'file',
-    description: 'Save the conversation to a file in the current directory'
+    description: `Save as ${selectedFormat} to a file in the current directory`
   }];
 
   // Custom input guide that changes based on dialog state
   function renderInputGuide(exitState: ExitState): React.ReactNode {
-    if (showFilenameInput) {
+    if (step === 'filename') {
       return <Byline>
           <KeyboardShortcutHint shortcut="Enter" action="save" />
           <ConfigurableShortcutHint action="confirm:no" context="Confirmation" fallback="Esc" description="go back" />
@@ -107,20 +168,30 @@ export function ExportDialog({
     if (exitState.pending) {
       return <Text>Press {exitState.keyName} again to exit</Text>;
     }
-    return <ConfigurableShortcutHint action="confirm:no" context="Confirmation" fallback="Esc" description="cancel" />;
+    return <ConfigurableShortcutHint action="confirm:no" context="Confirmation" fallback="Esc" description={step === 'format' ? 'cancel' : 'go back'} />;
   }
 
   // Use Settings context so 'n' key doesn't cancel (allows typing 'n' in filename input)
   useKeybinding('confirm:no', handleCancel, {
     context: 'Settings',
-    isActive: showFilenameInput
+    isActive: step === 'filename'
   });
-  return <Dialog title="Export Conversation" subtitle="Select export method:" color="permission" onCancel={handleCancel} inputGuide={renderInputGuide} isCancelActive={!showFilenameInput}>
-      {!showFilenameInput ? <Select options={options} onChange={handleSelectOption} onCancel={handleCancel} /> : <Box flexDirection="column">
+  useInput((_input, key, event) => {
+    if (key.escape && !isExportingRef.current) {
+      event.stopImmediatePropagation();
+      handleCancel();
+    }
+  }, {
+    isActive: step !== 'format'
+  });
+  return <Dialog title="Export Conversation" subtitle={step === 'format' ? 'Select export format:' : step === 'method' ? 'Select export method:' : 'Enter filename:'} color="permission" onCancel={handleCancel} inputGuide={renderInputGuide} isCancelActive={step !== 'filename'}>
+      {step === 'format' && <Select options={formatOptions} defaultValue={selectedFormat} defaultFocusValue={selectedFormat} onChange={handleSelectFormat} onCancel={handleCancel} isDisabled={isExporting} />}
+      {step === 'method' && <Select options={methodOptions} onChange={handleSelectOption} onCancel={handleCancel} isDisabled={isExporting} />}
+      {step === 'filename' && <Box flexDirection="column">
           <Text>Enter filename:</Text>
           <Box flexDirection="row" gap={1} marginTop={1}>
             <Text>&gt;</Text>
-            <TextInput value={filename} onChange={setFilename} onSubmit={handleFilenameSubmit} focus={true} showCursor={true} columns={columns} cursorOffset={cursorOffset} onChangeCursorOffset={setCursorOffset} />
+            <TextInput value={filename} onChange={isExporting ? () => {} : setFilename} onSubmit={handleFilenameSubmit} onExit={handleCancel} disableEscapeDoublePress={true} focus={!isExporting} showCursor={!isExporting} columns={columns} cursorOffset={cursorOffset} onChangeCursorOffset={setCursorOffset} />
           </Box>
         </Box>}
     </Dialog>;

--- a/src/utils/exportFormats.test.ts
+++ b/src/utils/exportFormats.test.ts
@@ -1,0 +1,242 @@
+import { describe, expect, test } from 'bun:test'
+
+import {
+  ensureExportFilenameExtension,
+  extensionForExportFormat,
+  inferExportFormatFromFilename,
+  normalizeExportFormat,
+  parseExportArgs,
+  resolveExportFilepath,
+} from './exportFormats.js'
+
+describe('normalizeExportFormat', () => {
+  test('normalizes text variants', () => {
+    expect(normalizeExportFormat('text')).toBe('text')
+    expect(normalizeExportFormat('txt')).toBe('text')
+    expect(normalizeExportFormat('TEXT')).toBe('text')
+    expect(normalizeExportFormat(' TxT ')).toBe('text')
+  })
+
+  test('normalizes markdown variants', () => {
+    expect(normalizeExportFormat('markdown')).toBe('markdown')
+    expect(normalizeExportFormat('md')).toBe('markdown')
+    expect(normalizeExportFormat('Markdown')).toBe('markdown')
+    expect(normalizeExportFormat(' MD ')).toBe('markdown')
+  })
+
+  test('normalizes json', () => {
+    expect(normalizeExportFormat('json')).toBe('json')
+    expect(normalizeExportFormat('JSON')).toBe('json')
+    expect(normalizeExportFormat(' Json ')).toBe('json')
+  })
+
+  test('returns null for unknown', () => {
+    expect(normalizeExportFormat('xml')).toBeNull()
+    expect(normalizeExportFormat('')).toBeNull()
+    expect(normalizeExportFormat('csv')).toBeNull()
+  })
+})
+
+describe('inferExportFormatFromFilename', () => {
+  test('infers from .txt', () => {
+    expect(inferExportFormatFromFilename('a.txt')).toBe('text')
+  })
+
+  test('infers from .md', () => {
+    expect(inferExportFormatFromFilename('a.md')).toBe('markdown')
+  })
+
+  test('infers from .markdown', () => {
+    expect(inferExportFormatFromFilename('a.markdown')).toBe('markdown')
+  })
+
+  test('infers from .json', () => {
+    expect(inferExportFormatFromFilename('a.json')).toBe('json')
+  })
+
+  test('returns null for no extension', () => {
+    expect(inferExportFormatFromFilename('a')).toBeNull()
+  })
+
+  test('returns null for unknown extension', () => {
+    expect(inferExportFormatFromFilename('a.csv')).toBeNull()
+  })
+})
+
+describe('extensionForExportFormat', () => {
+  test('returns .txt for text', () => {
+    expect(extensionForExportFormat('text')).toBe('.txt')
+  })
+
+  test('returns .md for markdown', () => {
+    expect(extensionForExportFormat('markdown')).toBe('.md')
+  })
+
+  test('returns .json for json', () => {
+    expect(extensionForExportFormat('json')).toBe('.json')
+  })
+})
+
+describe('ensureExportFilenameExtension', () => {
+  test('adds extension when none', () => {
+    expect(ensureExportFilenameExtension('a', 'text')).toBe('a.txt')
+  })
+
+  test('replaces wrong extension for markdown', () => {
+    expect(ensureExportFilenameExtension('a.json', 'markdown')).toBe('a.md')
+  })
+
+  test('replaces wrong extension for json', () => {
+    expect(ensureExportFilenameExtension('a.txt', 'json')).toBe('a.json')
+  })
+
+  test('handles name with dots', () => {
+    expect(ensureExportFilenameExtension('my.conversation.txt', 'json')).toBe('my.conversation.json')
+  })
+
+  test('normalizes trailing dot filenames without duplicating separators', () => {
+    expect(ensureExportFilenameExtension('conversation.', 'json')).toBe('conversation.json')
+  })
+
+  test('does not treat dots in directory names as filename extensions', () => {
+    expect(ensureExportFilenameExtension('logs.v1/transcript', 'json')).toBe('logs.v1/transcript.json')
+  })
+
+  test('does not treat a dotfile name as an extension-only filename', () => {
+    expect(ensureExportFilenameExtension('.env', 'text')).toBe('.env.txt')
+  })
+
+  test('preserves correct extension', () => {
+    expect(ensureExportFilenameExtension('a.md', 'markdown')).toBe('a.md')
+  })
+
+  test('preserves supported .markdown extension', () => {
+    expect(ensureExportFilenameExtension('a.markdown', 'markdown', {
+      preserveMarkdownExtension: true,
+    })).toBe('a.markdown')
+  })
+
+  test('canonicalizes .markdown to .md by default', () => {
+    expect(ensureExportFilenameExtension('a.markdown', 'markdown')).toBe('a.md')
+  })
+})
+
+describe('parseExportArgs', () => {
+  test('empty args', () => {
+    expect(parseExportArgs('')).toEqual({})
+  })
+
+  test('filename only', () => {
+    expect(parseExportArgs('transcript.txt')).toEqual({ filename: 'transcript.txt' })
+  })
+
+  test('--format json with filename', () => {
+    expect(parseExportArgs('--format json transcript')).toEqual({
+      format: 'json',
+      filename: 'transcript',
+    })
+  })
+
+  test('-f md with filename', () => {
+    expect(parseExportArgs('-f md transcript.txt')).toEqual({
+      format: 'markdown',
+      filename: 'transcript.txt',
+    })
+  })
+
+  test('format flag overrides extension', () => {
+    const result = parseExportArgs('--format json transcript.txt')
+    expect(result.format).toBe('json')
+    expect(result.filename).toBe('transcript.txt')
+  })
+
+  test('unsupported format returns error', () => {
+    const result = parseExportArgs('--format xml transcript')
+    expect(result.error).toContain('Unsupported export format: xml')
+  })
+
+  test('unsupported dash-prefixed option returns error', () => {
+    const result = parseExportArgs('--formt json transcript')
+    expect(result.error).toContain('Unsupported export option: --formt')
+  })
+
+  test('missing format value returns error', () => {
+    const result = parseExportArgs('--format')
+    expect(result.error).toContain('Missing value for --format')
+  })
+
+  test('-f short form', () => {
+    expect(parseExportArgs('-f text conversation')).toEqual({
+      format: 'text',
+      filename: 'conversation',
+    })
+  })
+
+  test('format markdown', () => {
+    expect(parseExportArgs('--format markdown output')).toEqual({
+      format: 'markdown',
+      filename: 'output',
+    })
+  })
+
+  test('preserves filenames with spaces', () => {
+    expect(parseExportArgs('my conversation.txt')).toEqual({
+      filename: 'my conversation.txt',
+    })
+  })
+
+  test('preserves filename with spaces and format flag', () => {
+    expect(parseExportArgs('--format json my conversation')).toEqual({
+      format: 'json',
+      filename: 'my conversation',
+    })
+  })
+
+  test('format flag after filename', () => {
+    expect(parseExportArgs('output --format json')).toEqual({
+      format: 'json',
+      filename: 'output',
+    })
+  })
+
+  test('parses quoted filenames', () => {
+    expect(parseExportArgs('--format json "my conversation"')).toEqual({
+      format: 'json',
+      filename: 'my conversation',
+    })
+  })
+
+  test('treats quoted flag-looking tokens as filenames', () => {
+    expect(parseExportArgs('"--format"')).toEqual({
+      filename: '--format',
+    })
+  })
+
+  test('supports -- terminator for dash-leading filenames', () => {
+    expect(parseExportArgs('-- --format')).toEqual({
+      filename: '--format',
+    })
+  })
+
+  test('parses quoted format values', () => {
+    expect(parseExportArgs('--format "md" transcript')).toEqual({
+      format: 'markdown',
+      filename: 'transcript',
+    })
+  })
+
+  test('reports unterminated quoted strings', () => {
+    const result = parseExportArgs('--format json "my conversation')
+    expect(result.error).toContain('Unterminated quoted string')
+  })
+})
+
+describe('resolveExportFilepath', () => {
+  test('resolves relative export filenames under the current working directory', () => {
+    expect(resolveExportFilepath('/work/project', 'transcript.md')).toBe('/work/project/transcript.md')
+  })
+
+  test('preserves absolute export filenames', () => {
+    expect(resolveExportFilepath('/work/project', '/tmp/transcript.md')).toBe('/tmp/transcript.md')
+  })
+})

--- a/src/utils/exportFormats.ts
+++ b/src/utils/exportFormats.ts
@@ -1,0 +1,195 @@
+/**
+ * Export format types and helpers for multi-format conversation export.
+ */
+
+import { extname, isAbsolute, join } from 'path'
+
+export type ExportFormat = 'text' | 'markdown' | 'json'
+
+/**
+ * Normalize a user-provided format string to an ExportFormat.
+ * Returns null for unrecognized values.
+ */
+export function normalizeExportFormat(value: string): ExportFormat | null {
+  const lower = value.toLowerCase().trim()
+  switch (lower) {
+    case 'text':
+    case 'txt':
+      return 'text'
+    case 'markdown':
+    case 'md':
+      return 'markdown'
+    case 'json':
+      return 'json'
+    default:
+      return null
+  }
+}
+
+/**
+ * Infer export format from a filename's extension.
+ * Returns null if the extension doesn't map to a known format.
+ */
+export function inferExportFormatFromFilename(filename: string): ExportFormat | null {
+  const ext = extname(filename)
+  if (!ext || ext === '.') return null
+  return normalizeExportFormat(ext.slice(1))
+}
+
+/**
+ * Get the canonical file extension for an export format.
+ */
+export function extensionForExportFormat(format: ExportFormat): '.txt' | '.md' | '.json' {
+  switch (format) {
+    case 'text':
+      return '.txt'
+    case 'markdown':
+      return '.md'
+    case 'json':
+      return '.json'
+  }
+}
+
+/**
+ * Ensure a filename has the correct extension for the given export format.
+ * Strips any existing extension and appends the canonical one.
+ */
+export function ensureExportFilenameExtension(
+  filename: string,
+  format: ExportFormat,
+  { preserveMarkdownExtension = false }: { preserveMarkdownExtension?: boolean } = {},
+): string {
+  const ext = extensionForExportFormat(format)
+  const currentExt = extname(filename)
+  if (format === 'markdown' && preserveMarkdownExtension && currentExt.toLowerCase() === '.markdown') {
+    return filename
+  }
+  const base = currentExt
+    ? filename.slice(0, currentExt === '.' ? -1 : -currentExt.length)
+    : filename
+  return base + ext
+}
+
+export function resolveExportFilepath(cwd: string, filename: string): string {
+  return isAbsolute(filename) ? filename : join(cwd, filename)
+}
+
+const SUPPORTED_FORMATS = 'Supported formats: text, markdown, json.'
+
+function tokenizeExportArgs(args: string): {
+  tokens: Array<{ value: string; quoted: boolean }>
+  error?: string
+} {
+  const tokens: Array<{ value: string; quoted: boolean }> = []
+  let current = ''
+  let quote: '"' | "'" | null = null
+  let tokenStarted = false
+  let tokenQuoted = false
+
+  for (let i = 0; i < args.length; i++) {
+    const ch = args[i]!
+
+    if (quote) {
+      if (ch === quote) {
+        quote = null
+        continue
+      }
+      if (quote === '"' && ch === '\\' && i + 1 < args.length) {
+        const next = args[i + 1]!
+        if (next === '"' || next === '\\') {
+          current += next
+          i += 1
+          continue
+        }
+      }
+      current += ch
+      continue
+    }
+
+    if (ch === '"' || ch === "'") {
+      quote = ch
+      tokenStarted = true
+      tokenQuoted = true
+      continue
+    }
+
+    if (/\s/.test(ch)) {
+      if (tokenStarted) {
+        tokens.push({ value: current, quoted: tokenQuoted })
+        current = ''
+        tokenStarted = false
+        tokenQuoted = false
+      }
+      continue
+    }
+
+    current += ch
+    tokenStarted = true
+  }
+
+  if (quote) {
+    return { tokens, error: 'Unterminated quoted string in /export arguments.' }
+  }
+
+  if (tokenStarted) {
+    tokens.push({ value: current, quoted: tokenQuoted })
+  }
+
+  return { tokens }
+}
+
+/**
+ * Parse /export command arguments.
+ *
+ * Supported flags:
+ *   --format <value>  or  -f <value>
+ *
+ * Returns parsed filename, format, and optional error string.
+ */
+export function parseExportArgs(args: string): {
+  filename?: string
+  format?: ExportFormat
+  error?: string
+} {
+  const tokenized = tokenizeExportArgs(args)
+  if (tokenized.error) return { error: tokenized.error }
+
+  const tokens = tokenized.tokens
+  if (tokens.length === 0) return {}
+
+  let format: ExportFormat | undefined
+  let error: string | undefined
+  const filenameTokens: string[] = []
+
+  for (let i = 0; i < tokens.length; i++) {
+    const token = tokens[i]!
+    if (!token.quoted && token.value === '--') {
+      filenameTokens.push(...tokens.slice(i + 1).map(t => t.value))
+      break
+    }
+    if (!token.quoted && (token.value === '--format' || token.value === '-f')) {
+      const value = tokens[++i]?.value
+      if (!value) {
+        error = `Missing value for ${token.value}. ${SUPPORTED_FORMATS}`
+        break
+      }
+      const normalized = normalizeExportFormat(value)
+      if (!normalized) {
+        error = `Unsupported export format: ${value}. ${SUPPORTED_FORMATS}`
+        break
+      }
+      format = normalized
+    } else if (!token.quoted && token.value.startsWith('-') && token.value !== '-') {
+      error = `Unsupported export option: ${token.value}. Supported options: --format, -f.`
+      break
+    } else {
+      filenameTokens.push(token.value)
+    }
+  }
+
+  const filename = filenameTokens.length > 0 ? filenameTokens.join(' ') : undefined
+
+  if (error) return { filename, format, error }
+
+  return { filename, format }
+}

--- a/src/utils/exportRenderer.test.ts
+++ b/src/utils/exportRenderer.test.ts
@@ -1,0 +1,963 @@
+import { describe, expect, test } from 'bun:test'
+
+import { renderMessagesToJSON, renderMessagesToMarkdown } from './exportRenderer.js'
+
+// Minimal Message-shaped objects (Message = any in this codebase)
+function userMessage(text: string) {
+  return {
+    type: 'user',
+    message: { role: 'user', content: [{ type: 'text', text }] },
+    timestamp: '2026-05-13T12:00:00Z',
+  }
+}
+
+function assistantMessage(text: string) {
+  return {
+    type: 'assistant',
+    message: { role: 'assistant', content: [{ type: 'text', text }] },
+    timestamp: '2026-05-13T12:00:01Z',
+  }
+}
+
+function toolUseMessage(toolName: string, input: Record<string, unknown>) {
+  return {
+    type: 'assistant',
+    message: {
+      role: 'assistant',
+      content: [
+        { type: 'tool_use', id: 'tool-123', name: toolName, input },
+      ],
+    },
+    timestamp: '2026-05-13T12:00:02Z',
+  }
+}
+
+function toolResultMessage(content: string, isError = false) {
+  return {
+    type: 'tool',
+    message: {
+      role: 'tool',
+      content: [
+        { type: 'tool_result', tool_use_id: 'tool-123', content, is_error: isError },
+      ],
+    },
+    timestamp: '2026-05-13T12:00:03Z',
+  }
+}
+
+describe('renderMessagesToMarkdown', () => {
+  test('includes conversation export header', () => {
+    const md = renderMessagesToMarkdown([userMessage('hello')])
+    expect(md).toContain('# Conversation Export')
+    expect(md).toContain('Format: Markdown')
+  })
+
+  test('includes exported timestamp', () => {
+    const md = renderMessagesToMarkdown([])
+    expect(md).toMatch(/Exported: \d{4}-\d{2}-\d{2}T/)
+  })
+
+  test('renders user and assistant headings', () => {
+    const md = renderMessagesToMarkdown([
+      userMessage('hello'),
+      assistantMessage('world'),
+    ])
+    expect(md).toContain('## User')
+    expect(md).toContain('## Assistant')
+  })
+
+  test('preserves text content', () => {
+    const md = renderMessagesToMarkdown([userMessage('hello world')])
+    expect(md).toContain('hello world')
+  })
+
+  test('renders tool use blocks', () => {
+    const md = renderMessagesToMarkdown([
+      toolUseMessage('Bash', { command: 'ls -la' }),
+    ])
+    expect(md).toContain('### Tool Use: Bash')
+    expect(md).toContain('```json')
+    expect(md).toContain('ls -la')
+  })
+
+  test('uses a longer Markdown fence when tool input contains backticks', () => {
+    const md = renderMessagesToMarkdown([
+      toolUseMessage('Bash', { command: 'printf "```"' }),
+    ])
+    expect(md).toContain('````json')
+    expect(md).toContain('printf \\"```\\"')
+  })
+
+  test('renders tool result blocks', () => {
+    const md = renderMessagesToMarkdown([
+      toolResultMessage('file1.txt\nfile2.txt'),
+    ])
+    expect(md).toContain('## Tool Result')
+    expect(md).toContain('file1.txt')
+    // Should NOT have duplicate sub-heading since message heading already says "Tool Result"
+    expect(md).not.toContain('### Tool Result')
+  })
+
+  test('uses a longer Markdown fence when tool output contains backticks', () => {
+    const md = renderMessagesToMarkdown([
+      toolResultMessage('before\n```\ninside\n```\nafter'),
+    ])
+    expect(md).toContain('````text')
+    expect(md).toContain('before\n```\ninside\n```\nafter')
+  })
+
+  test('marks errored tool results from runtime is_error field', () => {
+    const md = renderMessagesToMarkdown([
+      toolResultMessage('failure output', true),
+    ])
+    expect(md).toContain('failure output')
+    expect(md).toContain('*(Error)*')
+  })
+
+  test('renders tool result from runtime shape (type: user with tool_result content)', () => {
+    // Real runtime: tool results are type:'user' messages with tool_result content blocks
+    const runtimeToolResult = {
+      type: 'user',
+      message: {
+        role: 'user',
+        content: [{ type: 'tool_result', tool_use_id: 'tu-1', content: 'output text' }],
+      },
+    }
+    const md = renderMessagesToMarkdown([runtimeToolResult])
+    expect(md).toContain('## Tool Result')
+    expect(md).toContain('output text')
+    expect(md).not.toContain('## User')
+    expect(md).not.toContain('### Tool Result')
+  })
+
+  test('does not label mixed human text and tool result content as a tool result message', () => {
+    const mixedMessage = {
+      type: 'user',
+      message: {
+        role: 'user',
+        content: [
+          { type: 'tool_result', tool_use_id: 'tu-1', content: 'tool output' },
+          { type: 'text', text: 'human follow-up' },
+        ],
+      },
+    }
+    const md = renderMessagesToMarkdown([mixedMessage])
+    expect(md).toContain('## User')
+    expect(md).toContain('### Tool Result')
+    expect(md).toContain('human follow-up')
+  })
+
+  test('treats system-reminder siblings as tool result metadata', () => {
+    const runtimeToolResult = {
+      type: 'user',
+      message: {
+        role: 'user',
+        content: [
+          { type: 'tool_result', tool_use_id: 'tu-1', content: 'tool output' },
+          { type: 'text', text: '<system-reminder>note</system-reminder>' },
+        ],
+      },
+    }
+    const md = renderMessagesToMarkdown([runtimeToolResult])
+    expect(md).toContain('## Tool Result')
+    expect(md).not.toContain('## User')
+    expect(md).not.toContain('<system-reminder>')
+  })
+
+  test('handles empty messages array', () => {
+    const md = renderMessagesToMarkdown([])
+    expect(md).toContain('# Conversation Export')
+    expect(md).not.toContain('## User')
+  })
+
+  test('handles null/undefined messages gracefully', () => {
+    const md = renderMessagesToMarkdown([null, undefined] as any)
+    expect(md).toContain('# Conversation Export')
+  })
+
+  test('renders image placeholder', () => {
+    const msg = {
+      type: 'user',
+      message: {
+        role: 'user',
+        content: [{ type: 'image', source: { type: 'base64', media_type: 'image/png' } }],
+      },
+    }
+    const md = renderMessagesToMarkdown([msg])
+    expect(md).toContain('[Image attachment]')
+  })
+
+  test('skips progress messages', () => {
+    const progressMsg = { type: 'progress', message: { role: 'user', content: [{ type: 'text', text: 'Loading...' }] } }
+    const md = renderMessagesToMarkdown([progressMsg, userMessage('hello')])
+    expect(md).not.toContain('## Progress')
+    expect(md).toContain('## User')
+  })
+
+  test('skips attachment messages', () => {
+    const attMsg = { type: 'attachment', attachment: { type: 'file', name: 'test.txt' } }
+    const md = renderMessagesToMarkdown([attMsg, userMessage('hello')])
+    expect(md).not.toContain('## Attachment')
+    expect(md).toContain('## User')
+  })
+
+  test('skips system api_metrics messages', () => {
+    const metricsMsg = { type: 'system', subtype: 'api_metrics', message: { role: 'system', content: [] } }
+    const md = renderMessagesToMarkdown([metricsMsg, userMessage('hello')])
+    expect(md).not.toContain('## System')
+    expect(md).toContain('## User')
+  })
+
+  test('skips messages with empty content', () => {
+    const emptyMsg = { type: 'system', message: { role: 'system', content: [] } }
+    const md = renderMessagesToMarkdown([emptyMsg, userMessage('hello')])
+    expect(md).not.toContain('## System')
+    expect(md).toContain('## User')
+  })
+
+  test('skips thinking blocks', () => {
+    const msg = {
+      type: 'assistant',
+      message: {
+        role: 'assistant',
+        content: [{ type: 'thinking', thinking: 'Let me think about this...' }],
+      },
+    }
+    const md = renderMessagesToMarkdown([msg])
+    expect(md).not.toContain('Let me think about this...')
+    expect(md).not.toContain('## Assistant')
+  })
+
+  test('skips redacted thinking blocks', () => {
+    const msg = {
+      type: 'assistant',
+      message: {
+        role: 'assistant',
+        content: [{ type: 'redacted_thinking' }],
+      },
+    }
+    const md = renderMessagesToMarkdown([msg])
+    expect(md).not.toContain('redacted_thinking')
+    // Should skip the message entirely since it has no visible content
+    expect(md).not.toContain('## Assistant')
+  })
+
+  test('renders top-level system message content', () => {
+    const md = renderMessagesToMarkdown([
+      {
+        type: 'system',
+        subtype: 'local_command',
+        content: 'local command output',
+      },
+    ])
+    expect(md).toContain('## System')
+    expect(md).toContain('local command output')
+  })
+
+  test('renders local command output wrappers without leaking XML tags', () => {
+    const md = renderMessagesToMarkdown([
+      {
+        type: 'user',
+        message: {
+          role: 'user',
+          content: '<local-command-stdout>command output</local-command-stdout>',
+        },
+      },
+    ] as any)
+    expect(md).toContain('## Local Command Output')
+    expect(md).toContain('command output')
+    expect(md).not.toContain('<local-command-stdout>')
+  })
+
+  test('renders combined terminal output wrappers without leaking XML tags', () => {
+    const md = renderMessagesToMarkdown([
+      {
+        type: 'user',
+        message: {
+          role: 'user',
+          content: '<bash-stdout>stdout text</bash-stdout><bash-stderr>stderr text</bash-stderr>',
+        },
+      },
+    ] as any)
+    expect(md).toContain('## Bash Output')
+    expect(md).toContain('### STDOUT')
+    expect(md).toContain('stdout text')
+    expect(md).toContain('### STDERR')
+    expect(md).toContain('stderr text')
+    expect(md).not.toContain('<bash-stdout>')
+    expect(md).not.toContain('<bash-stderr>')
+  })
+
+  test('renders bash input wrappers without leaking XML tags', () => {
+    const md = renderMessagesToMarkdown([
+      {
+        type: 'user',
+        message: {
+          role: 'user',
+          content: [{ type: 'text', text: '<bash-input>ls -la</bash-input>' }],
+        },
+      },
+    ] as any)
+    expect(md).toContain('## Bash Input')
+    expect(md).toContain('ls -la')
+    expect(md).not.toContain('<bash-input>')
+  })
+
+  test('renders terminal wrappers with internal siblings as system output in Markdown', () => {
+    const md = renderMessagesToMarkdown([
+      {
+        type: 'user',
+        message: {
+          role: 'user',
+          content: [
+            { type: 'text', text: '<bash-stdout>stdout text</bash-stdout>' },
+            { type: 'text', text: '<system-reminder>hidden metadata</system-reminder>' },
+          ],
+        },
+      },
+    ] as any)
+    expect(md).toContain('## Bash Output')
+    expect(md).toContain('stdout text')
+    expect(md).not.toContain('## User')
+    expect(md).not.toContain('<system-reminder>')
+  })
+
+  test('renders unknown content block payload in Markdown', () => {
+    const md = renderMessagesToMarkdown([
+      {
+        type: 'assistant',
+        message: {
+          role: 'assistant',
+          content: [{ type: 'server_tool_use', id: 'srv-1', name: 'web_search' }],
+        },
+      },
+    ])
+    expect(md).toContain('*[server_tool_use content block]*')
+    expect(md).toContain('```json')
+    expect(md).toContain('"id": "srv-1"')
+    expect(md).toContain('"name": "web_search"')
+  })
+
+  test('handles malformed numeric message types in Markdown', () => {
+    const md = renderMessagesToMarkdown([
+      {
+        type: 42,
+        message: { content: [{ type: 'text', text: 'numeric type' }] },
+      },
+    ] as any)
+    expect(md).toContain('## 42')
+    expect(md).toContain('numeric type')
+  })
+
+  test('skips internal meta and command breadcrumb messages in Markdown', () => {
+    const md = renderMessagesToMarkdown([
+      {
+        type: 'user',
+        isMeta: true,
+        message: { role: 'user', content: [{ type: 'text', text: 'internal caveat' }] },
+      },
+      {
+        type: 'user',
+        message: { role: 'user', content: '<command-name>/model</command-name>' },
+      },
+      {
+        type: 'user',
+        message: { role: 'user', content: '<system-reminder>hidden</system-reminder>' },
+      },
+      {
+        type: 'user',
+        message: { role: 'user', content: [{ type: 'text', text: '<system-reminder>hidden array</system-reminder>' }] },
+      },
+      userMessage('visible user text'),
+    ] as any)
+    expect(md).not.toContain('internal caveat')
+    expect(md).not.toContain('<command-name>')
+    expect(md).not.toContain('<system-reminder>')
+    expect(md).toContain('visible user text')
+  })
+
+  test('filters internal text blocks while preserving mixed real content in Markdown', () => {
+    const md = renderMessagesToMarkdown([
+      {
+        type: 'user',
+        message: {
+          role: 'user',
+          content: [
+            { type: 'text', text: '<command-name>/export</command-name>' },
+            { type: 'text', text: 'real user content' },
+          ],
+        },
+      },
+    ] as any)
+    expect(md).toContain('## User')
+    expect(md).toContain('real user content')
+    expect(md).not.toContain('<command-name>')
+  })
+
+  test('does not drop visible Markdown text that contains internal tag wrappers', () => {
+    const md = renderMessagesToMarkdown([
+      {
+        type: 'user',
+        message: {
+          role: 'user',
+          content: [{ type: 'text', text: 'visible before <command-name>/export</command-name> visible after' }],
+        },
+      },
+    ] as any)
+    expect(md).toContain('## User')
+    expect(md).toContain('visible before  visible after')
+    expect(md).not.toContain('<command-name>')
+  })
+
+  test('strips system reminders embedded in visible Markdown text', () => {
+    const md = renderMessagesToMarkdown([
+      userMessage('visible before <system-reminder>hidden</system-reminder> visible after'),
+    ])
+    expect(md).toContain('visible before  visible after')
+    expect(md).not.toContain('<system-reminder>')
+    expect(md).not.toContain('hidden')
+  })
+
+  test('renders Markdown fallback for non-array unknown content', () => {
+    const md = renderMessagesToMarkdown([
+      {
+        type: 'custom',
+        content: { value: 42 },
+      },
+    ] as any)
+    expect(md).toContain('## Custom')
+    expect(md).toContain('*[unknown content]*')
+    expect(md).toContain('"value": 42')
+  })
+
+  test('renders Markdown fallback for primitive array entries', () => {
+    const md = renderMessagesToMarkdown([
+      {
+        type: 'assistant',
+        message: {
+          role: 'assistant',
+          content: ['primitive content'],
+        },
+      },
+    ] as any)
+    expect(md).toContain('## Assistant')
+    expect(md).toContain('*[unknown content]*')
+    expect(md).toContain('primitive content')
+  })
+})
+
+describe('renderMessagesToJSON', () => {
+  test('produces valid JSON', () => {
+    const json = renderMessagesToJSON([userMessage('hello')])
+    expect(() => JSON.parse(json)).not.toThrow()
+  })
+
+  test('includes version: 1', () => {
+    const parsed = JSON.parse(renderMessagesToJSON([]))
+    expect(parsed.version).toBe(1)
+  })
+
+  test('includes format: json', () => {
+    const parsed = JSON.parse(renderMessagesToJSON([]))
+    expect(parsed.format).toBe('json')
+  })
+
+  test('includes exportedAt as ISO string', () => {
+    const parsed = JSON.parse(renderMessagesToJSON([]))
+    expect(parsed.exportedAt).toMatch(/^\d{4}-\d{2}-\d{2}T/)
+  })
+
+  test('includes messageCount', () => {
+    const parsed = JSON.parse(renderMessagesToJSON([userMessage('a'), assistantMessage('b')]))
+    expect(parsed.messageCount).toBe(2)
+  })
+
+  test('preserves message order', () => {
+    const parsed = JSON.parse(renderMessagesToJSON([
+      userMessage('first'),
+      assistantMessage('second'),
+      userMessage('third'),
+    ]))
+    expect(parsed.messages[0].content[0].text).toBe('first')
+    expect(parsed.messages[1].content[0].text).toBe('second')
+    expect(parsed.messages[2].content[0].text).toBe('third')
+  })
+
+  test('includes message type and role', () => {
+    const parsed = JSON.parse(renderMessagesToJSON([userMessage('hello')]))
+    expect(parsed.messages[0].type).toBe('user')
+    expect(parsed.messages[0].role).toBe('user')
+  })
+
+  test('handles tool_use content blocks', () => {
+    const parsed = JSON.parse(renderMessagesToJSON([toolUseMessage('Read', { file_path: '/test.ts' })]))
+    const content = parsed.messages[0].content[0]
+    expect(content.type).toBe('tool_use')
+    expect(content.name).toBe('Read')
+    expect(content.input.file_path).toBe('/test.ts')
+  })
+
+  test('handles tool_result content blocks', () => {
+    const parsed = JSON.parse(renderMessagesToJSON([toolResultMessage('result text', true)]))
+    expect(parsed.messages[0].role).toBe('tool')
+    const content = parsed.messages[0].content[0]
+    expect(content.type).toBe('tool_result')
+    expect(content.content).toBe('result text')
+    expect(content.isError).toBe(true)
+  })
+
+  test('exports runtime tool_result messages as semantic tool messages', () => {
+    const runtimeToolResult = {
+      type: 'user',
+      message: {
+        role: 'user',
+        content: [{ type: 'tool_result', tool_use_id: 'tu-1', content: 'output' }],
+      },
+    }
+    const parsed = JSON.parse(renderMessagesToJSON([runtimeToolResult]))
+    expect(parsed.messages[0].type).toBe('tool')
+    expect(parsed.messages[0].role).toBe('tool')
+    expect(parsed.messages[0].internalType).toBeUndefined()
+    expect(parsed.messages[0].rawType).toBeUndefined()
+    expect(parsed.messages[0].content[0].type).toBe('tool_result')
+  })
+
+  test('keeps mixed human text and tool result content as a user message', () => {
+    const mixedMessage = {
+      type: 'user',
+      message: {
+        role: 'user',
+        content: [
+          { type: 'tool_result', tool_use_id: 'tu-1', content: 'tool output' },
+          { type: 'text', text: 'human follow-up' },
+        ],
+      },
+    }
+    const parsed = JSON.parse(renderMessagesToJSON([mixedMessage]))
+    expect(parsed.messages[0].type).toBe('user')
+    expect(parsed.messages[0].role).toBe('user')
+    expect(parsed.messages[0].internalType).toBeUndefined()
+    expect(parsed.messages[0].content.map((block: { type: string }) => block.type)).toEqual([
+      'tool_result',
+      'text',
+    ])
+  })
+
+  test('keeps mixed non-text content and tool result content as a user message', () => {
+    const mixedMessage = {
+      type: 'user',
+      message: {
+        role: 'user',
+        content: [
+          { type: 'tool_result', tool_use_id: 'tu-1', content: 'tool output' },
+          { type: 'image', source: { type: 'base64', media_type: 'image/png', data: 'abc' } },
+        ],
+      },
+    }
+    const parsed = JSON.parse(renderMessagesToJSON([mixedMessage]))
+    expect(parsed.messages[0].type).toBe('user')
+    expect(parsed.messages[0].role).toBe('user')
+    expect(parsed.messages[0].content.map((block: { type: string }) => block.type)).toEqual([
+      'tool_result',
+      'image',
+    ])
+  })
+
+  test('exports system-reminder siblings as semantic tool messages', () => {
+    const runtimeToolResult = {
+      type: 'user',
+      message: {
+        role: 'user',
+        content: [
+          { type: 'tool_result', tool_use_id: 'tu-1', content: 'tool output' },
+          { type: 'text', text: '<system-reminder>note</system-reminder>' },
+        ],
+      },
+    }
+    const parsed = JSON.parse(renderMessagesToJSON([runtimeToolResult]))
+    expect(parsed.messages[0].type).toBe('tool')
+    expect(parsed.messages[0].role).toBe('tool')
+    expect(parsed.messages[0].internalType).toBeUndefined()
+    expect(parsed.messages[0].rawType).toBeUndefined()
+    expect(parsed.messages[0].content).toHaveLength(1)
+  })
+
+  test('safely handles non-serializable content', () => {
+    const cyclic: any = { a: 1 }
+    cyclic.self = cyclic
+    const msg = {
+      type: 'assistant',
+      message: {
+        role: 'assistant',
+        content: [{ type: 'tool_use', id: 'tool-1', name: 'Cyclic', input: cyclic }],
+      },
+    }
+    const parsed = JSON.parse(renderMessagesToJSON([msg]))
+    expect(parsed.messages[0].content[0].input).toEqual({
+      a: 1,
+      self: '[Circular]',
+    })
+  })
+
+  test('safely handles throwing getters in JSON content', () => {
+    const hostile = {}
+    Object.defineProperty(hostile, 'boom', {
+      enumerable: true,
+      get() {
+        throw new Error('getter exploded')
+      },
+    })
+    const msg = {
+      type: 'assistant',
+      message: {
+        role: 'assistant',
+        content: [{ type: 'tool_use', id: 'tool-1', name: 'Hostile', input: hostile }],
+      },
+    }
+    const parsed = JSON.parse(renderMessagesToJSON([msg]))
+    expect(parsed.messages[0].content[0].input).toEqual({
+      boom: '[Unserializable]',
+    })
+  })
+
+  test('exports unknown message types with stable public type and raw type', () => {
+    const parsed = JSON.parse(renderMessagesToJSON([{ type: 'custom' }]))
+    expect(parsed.messages[0].type).toBe('unknown')
+    expect(parsed.messages[0].role).toBe('unknown')
+    expect(parsed.messages[0].rawType).toBe('custom')
+  })
+
+  test('does not emit empty rawType for malformed messages without a type', () => {
+    const parsed = JSON.parse(renderMessagesToJSON([{}] as any))
+    expect(parsed.messages[0].type).toBe('unknown')
+    expect(parsed.messages[0].role).toBe('unknown')
+    expect(parsed.messages[0].rawType).toBeUndefined()
+  })
+
+  test('normalizes camelCase tool result ids', () => {
+    const parsed = JSON.parse(renderMessagesToJSON([
+      {
+        type: 'tool',
+        message: {
+          role: 'tool',
+          content: [{ type: 'tool_result', toolUseId: 'camel-id', content: 'ok', isError: false }],
+        },
+      },
+    ]))
+    expect(parsed.messages[0].content[0].toolUseId).toBe('camel-id')
+    expect(parsed.messages[0].content[0].isError).toBe(false)
+  })
+
+  test('preserves timestamp when present', () => {
+    const parsed = JSON.parse(renderMessagesToJSON([userMessage('hello')]))
+    expect(parsed.messages[0].timestamp).toBe('2026-05-13T12:00:00Z')
+  })
+
+  test('uses 2-space indentation', () => {
+    const json = renderMessagesToJSON([userMessage('hello')])
+    expect(json).toContain('  "version"')
+  })
+
+  test('filters out progress messages', () => {
+    const progressMsg = { type: 'progress', message: { role: 'user', content: [{ type: 'text', text: 'Loading...' }] } }
+    const parsed = JSON.parse(renderMessagesToJSON([progressMsg, userMessage('hello')]))
+    expect(parsed.messageCount).toBe(1)
+    expect(parsed.messages[0].type).toBe('user')
+  })
+
+  test('filters out attachment messages', () => {
+    const attMsg = { type: 'attachment', attachment: { type: 'file' } }
+    const parsed = JSON.parse(renderMessagesToJSON([attMsg, userMessage('hello')]))
+    expect(parsed.messageCount).toBe(1)
+  })
+
+  test('skips thinking content blocks', () => {
+    const msg = {
+      type: 'assistant',
+      message: {
+        role: 'assistant',
+        content: [{ type: 'thinking', thinking: 'inner thoughts' }],
+      },
+    }
+    const parsed = JSON.parse(renderMessagesToJSON([msg]))
+    expect(parsed.messageCount).toBe(0)
+  })
+
+  test('skips redacted_thinking content blocks', () => {
+    const msg = {
+      type: 'assistant',
+      message: {
+        role: 'assistant',
+        content: [{ type: 'redacted_thinking' }],
+      },
+    }
+    const parsed = JSON.parse(renderMessagesToJSON([msg]))
+    expect(parsed.messageCount).toBe(0)
+  })
+
+  test('preserves top-level system message content', () => {
+    const parsed = JSON.parse(renderMessagesToJSON([
+      {
+        type: 'system',
+        subtype: 'local_command',
+        content: 'local command output',
+        timestamp: '2026-05-13T12:00:04Z',
+      },
+    ]))
+    expect(parsed.messageCount).toBe(1)
+    expect(parsed.messages[0].type).toBe('system')
+    expect(parsed.messages[0].subtype).toBe('local_command')
+    expect(parsed.messages[0].content[0]).toEqual({
+      type: 'text',
+      text: 'local command output',
+    })
+  })
+
+  test('exports local command output wrappers as semantic system messages', () => {
+    const parsed = JSON.parse(renderMessagesToJSON([
+      {
+        type: 'user',
+        message: {
+          role: 'user',
+          content: '<local-command-stderr>command failed</local-command-stderr>',
+        },
+      },
+    ] as any))
+    expect(parsed.messages[0].type).toBe('system')
+    expect(parsed.messages[0].role).toBe('system')
+    expect(parsed.messages[0].subtype).toBe('local_command')
+    expect(parsed.messages[0].stream).toBe('stderr')
+    expect(parsed.messages[0].content[0].text).toBe('command failed')
+  })
+
+  test('exports terminal output wrappers with attributes', () => {
+    const parsed = JSON.parse(renderMessagesToJSON([
+      {
+        type: 'user',
+        message: {
+          role: 'user',
+          content: '<bash-stdout format="persisted">persisted output</bash-stdout>',
+        },
+      },
+    ] as any))
+    expect(parsed.messages[0].type).toBe('system')
+    expect(parsed.messages[0].subtype).toBe('bash_output')
+    expect(parsed.messages[0].content[0].text).toBe('persisted output')
+  })
+
+  test('strips system reminders embedded in visible JSON text', () => {
+    const parsed = JSON.parse(renderMessagesToJSON([
+      userMessage('visible before <system-reminder>hidden</system-reminder> visible after'),
+    ]))
+    expect(parsed.messages[0].content[0].text).toBe('visible before  visible after')
+  })
+
+  test('strips system reminders nested inside tool result content', () => {
+    const parsed = JSON.parse(renderMessagesToJSON([
+      {
+        type: 'user',
+        message: {
+          role: 'user',
+          content: [
+            {
+              type: 'tool_result',
+              tool_use_id: 'tu-1',
+              content: [
+                { type: 'text', text: 'visible <system-reminder>hidden</system-reminder>' },
+              ],
+            },
+          ],
+        },
+      },
+    ] as any))
+    expect(parsed.messages[0].content[0].content[0].text).toBe('visible')
+    expect(JSON.stringify(parsed)).not.toContain('system-reminder')
+    expect(JSON.stringify(parsed)).not.toContain('hidden')
+  })
+
+  test('exports combined terminal output wrappers as semantic system messages', () => {
+    const parsed = JSON.parse(renderMessagesToJSON([
+      {
+        type: 'user',
+        message: {
+          role: 'user',
+          content: '<bash-stdout>stdout text</bash-stdout><bash-stderr>stderr text</bash-stderr>',
+        },
+      },
+    ] as any))
+    expect(parsed.messages[0].type).toBe('system')
+    expect(parsed.messages[0].role).toBe('system')
+    expect(parsed.messages[0].subtype).toBe('bash_output')
+    expect(parsed.messages[0].stream).toBe('mixed')
+    expect(parsed.messages[0].content).toEqual([
+      { type: 'text', text: 'stdout text', stream: 'stdout' },
+      { type: 'text', text: 'stderr text', stream: 'stderr' },
+    ])
+  })
+
+  test('exports bash input wrappers as semantic system messages', () => {
+    const parsed = JSON.parse(renderMessagesToJSON([
+      {
+        type: 'user',
+        message: {
+          role: 'user',
+          content: [{ type: 'text', text: '<bash-input>npm test</bash-input>' }],
+        },
+      },
+    ] as any))
+    expect(parsed.messages[0].type).toBe('system')
+    expect(parsed.messages[0].role).toBe('system')
+    expect(parsed.messages[0].subtype).toBe('bash_input')
+    expect(parsed.messages[0].stream).toBe('stdin')
+    expect(parsed.messages[0].content[0].text).toBe('npm test')
+  })
+
+  test('exports terminal wrappers with internal siblings as semantic system messages', () => {
+    const parsed = JSON.parse(renderMessagesToJSON([
+      {
+        type: 'user',
+        message: {
+          role: 'user',
+          content: [
+            { type: 'text', text: '<bash-stderr>stderr text</bash-stderr>' },
+            { type: 'text', text: '<system-reminder>hidden metadata</system-reminder>' },
+          ],
+        },
+      },
+    ] as any))
+    expect(parsed.messages[0].type).toBe('system')
+    expect(parsed.messages[0].role).toBe('system')
+    expect(parsed.messages[0].subtype).toBe('bash_output')
+    expect(parsed.messages[0].stream).toBe('stderr')
+    expect(parsed.messages[0].content).toEqual([{ type: 'text', text: 'stderr text' }])
+  })
+
+  test('preserves sourceIndex when internal messages are filtered', () => {
+    const parsed = JSON.parse(renderMessagesToJSON([
+      { type: 'progress', message: { role: 'user', content: [{ type: 'text', text: 'loading' }] } },
+      userMessage('visible'),
+    ] as any))
+    expect(parsed.messages[0].index).toBe(0)
+    expect(parsed.messages[0].sourceIndex).toBe(1)
+  })
+
+  test('skips synthetic missing tool-result placeholders', () => {
+    const parsed = JSON.parse(renderMessagesToJSON([
+      {
+        type: 'user',
+        message: {
+          role: 'user',
+          content: [
+            {
+              type: 'tool_result',
+              tool_use_id: 'missing',
+              content: '[Tool result missing due to internal error]',
+              is_error: true,
+            },
+          ],
+        },
+      },
+      userMessage('visible'),
+    ] as any))
+    expect(parsed.messageCount).toBe(1)
+    expect(parsed.messages[0].content[0].text).toBe('visible')
+  })
+
+  test('skips synthetic missing tool-result placeholders with internal siblings', () => {
+    const parsed = JSON.parse(renderMessagesToJSON([
+      {
+        type: 'user',
+        message: {
+          role: 'user',
+          content: [
+            {
+              type: 'tool_result',
+              tool_use_id: 'missing',
+              content: '[Tool result missing due to internal error]',
+              is_error: true,
+            },
+            { type: 'text', text: '<system-reminder>hidden metadata</system-reminder>' },
+          ],
+        },
+      },
+      userMessage('visible'),
+    ] as any))
+    expect(parsed.messageCount).toBe(1)
+    expect(parsed.messages[0].content[0].text).toBe('visible')
+  })
+
+  test('preserves unknown content block type while sanitizing its value', () => {
+    const parsed = JSON.parse(renderMessagesToJSON([
+      {
+        type: 'assistant',
+        message: {
+          role: 'assistant',
+          content: [{ type: 'server_tool_use', id: 'srv-1', name: 'web_search' }],
+        },
+      },
+    ]))
+    expect(parsed.messages[0].content[0].type).toBe('server_tool_use')
+    expect(parsed.messages[0].content[0].value).toEqual({
+      type: 'server_tool_use',
+      id: 'srv-1',
+      name: 'web_search',
+    })
+  })
+
+  test('skips internal meta and command breadcrumb messages in JSON', () => {
+    const parsed = JSON.parse(renderMessagesToJSON([
+      {
+        type: 'user',
+        isMeta: true,
+        message: { role: 'user', content: [{ type: 'text', text: 'internal caveat' }] },
+      },
+      {
+        type: 'user',
+        message: { role: 'user', content: '<command-name>/model</command-name>' },
+      },
+      {
+        type: 'user',
+        message: { role: 'user', content: '<system-reminder>hidden</system-reminder>' },
+      },
+      {
+        type: 'user',
+        message: { role: 'user', content: [{ type: 'text', text: '<system-reminder>hidden array</system-reminder>' }] },
+      },
+      userMessage('visible user text'),
+    ] as any))
+    expect(parsed.messageCount).toBe(1)
+    expect(parsed.messages[0].content[0].text).toBe('visible user text')
+  })
+
+  test('filters internal text blocks while preserving mixed real content in JSON', () => {
+    const parsed = JSON.parse(renderMessagesToJSON([
+      {
+        type: 'user',
+        message: {
+          role: 'user',
+          content: [
+            { type: 'text', text: '<command-name>/export</command-name>' },
+            { type: 'text', text: 'real user content' },
+          ],
+        },
+      },
+    ] as any))
+    expect(parsed.messageCount).toBe(1)
+    expect(parsed.messages[0].content).toEqual([{ type: 'text', text: 'real user content' }])
+  })
+
+  test('does not drop visible JSON text that contains internal tag wrappers', () => {
+    const parsed = JSON.parse(renderMessagesToJSON([
+      {
+        type: 'user',
+        message: {
+          role: 'user',
+          content: [{ type: 'text', text: 'visible before <command-name>/export</command-name> visible after' }],
+        },
+      },
+    ] as any))
+    expect(parsed.messageCount).toBe(1)
+    expect(parsed.messages[0].type).toBe('user')
+    expect(parsed.messages[0].content[0].text).toBe('visible before  visible after')
+  })
+})

--- a/src/utils/exportRenderer.tsx
+++ b/src/utils/exportRenderer.tsx
@@ -7,6 +7,23 @@ import type { KeybindingContextName } from '../keybindings/types.js';
 import { AppStateProvider } from '../state/AppState.js';
 import type { Tools } from '../Tool.js';
 import type { Message } from '../types/message.js';
+import {
+  BASH_INPUT_TAG,
+  BASH_STDERR_TAG,
+  BASH_STDOUT_TAG,
+  CHANNEL_MESSAGE_TAG,
+  COMMAND_ARGS_TAG,
+  COMMAND_MESSAGE_TAG,
+  COMMAND_NAME_TAG,
+  CROSS_SESSION_MESSAGE_TAG,
+  LOCAL_COMMAND_CAVEAT_TAG,
+  LOCAL_COMMAND_STDERR_TAG,
+  LOCAL_COMMAND_STDOUT_TAG,
+  TASK_NOTIFICATION_TAG,
+  TEAMMATE_MESSAGE_TAG,
+  TICK_TAG,
+} from '../constants/xml.js';
+import type { ExportFormat } from './exportFormats.js';
 import { renderToAnsiString } from './staticRender.js';
 
 /**
@@ -94,4 +111,666 @@ export async function renderMessagesToPlainText(messages: Message[], tools: Tool
     columns
   });
   return parts.join('');
+}
+
+/**
+ * Message types that are internal UI state and should be excluded from exports.
+ */
+const SKIP_MESSAGE_TYPES = new Set(['progress', 'attachment'])
+
+/**
+ * System message subtypes that are internal metrics and should be excluded.
+ */
+const SKIP_SYSTEM_SUBTYPES = new Set(['api_metrics'])
+
+const INTERNAL_TEXT_TAGS = [
+  COMMAND_ARGS_TAG,
+  COMMAND_MESSAGE_TAG,
+  COMMAND_NAME_TAG,
+  LOCAL_COMMAND_CAVEAT_TAG,
+  TASK_NOTIFICATION_TAG,
+  TICK_TAG,
+  TEAMMATE_MESSAGE_TAG,
+  CHANNEL_MESSAGE_TAG,
+  CROSS_SESSION_MESSAGE_TAG,
+]
+const INTERNAL_TEXT_TAG_REGEXES = INTERNAL_TEXT_TAGS.map(tag => internalTagRegex(tag))
+
+const SYNTHETIC_TOOL_RESULT_PLACEHOLDER = '[Tool result missing due to internal error]'
+
+/**
+ * Render messages as human-readable Markdown.
+ * Produces structured output directly from Message[] without relying on
+ * the terminal UI renderer (which is optimized for ANSI display).
+ */
+export function renderMessagesToMarkdown(messages: Message[], _tools?: Tools, _columns?: number): string {
+  const lines: string[] = []
+
+  lines.push('# Conversation Export')
+  lines.push('')
+  lines.push(`Exported: ${new Date().toISOString()}`)
+  lines.push('Format: Markdown')
+  lines.push('')
+
+  for (const msg of messages) {
+    if (!msg || typeof msg !== 'object') continue
+
+    const msgType = String(msg.type ?? 'unknown')
+
+    if (!shouldExportStructuredMessage(msg, msgType)) continue
+
+    const content = extractMessageContent(msg)
+
+    // Build rendered content first, so we can skip the heading if empty
+    const contentLines: string[] = []
+
+    if (content == null) {
+      // Some system/status messages carry no user-visible export content.
+      continue
+    }
+
+    // Determine the display heading — tool_result blocks inside user messages
+    // should show as "Tool Result" not "User"
+    const terminalOutputs = getTerminalOutputs(content)
+    const isToolResultMessage = (msgType === 'user' || msgType === 'tool') && isToolResultMessageContent(content)
+    const heading = terminalOutputs
+      ? terminalHeading(terminalOutputs)
+      : isToolResultMessage ? 'Tool Result' : messageHeading(msgType)
+
+    if (typeof content === 'string') {
+      renderTextMarkdown(content, contentLines)
+    } else if (Array.isArray(content)) {
+      for (const block of content) {
+        if (!block || typeof block !== 'object') {
+          renderUnknownContentMarkdown(block, contentLines)
+          continue
+        }
+        renderContentBlockMarkdown(block as Record<string, unknown>, contentLines, isToolResultMessage)
+      }
+      if (contentLines.length > 0) contentLines.push('')
+    } else {
+      renderUnknownContentMarkdown(content, contentLines)
+    }
+
+    // Only emit heading + content if there's something meaningful
+    if (contentLines.every(l => l === '')) continue
+
+    lines.push(`## ${heading}`)
+    lines.push('')
+    lines.push(...contentLines)
+  }
+
+  return lines.join('\n')
+}
+
+function messageHeading(type: string): string {
+  switch (type) {
+    case 'user': return 'User'
+    case 'assistant': return 'Assistant'
+    case 'system': return 'System'
+    case 'tool': return 'Tool Result'
+    default: return type.charAt(0).toUpperCase() + type.slice(1)
+  }
+}
+
+function renderContentBlockMarkdown(block: Record<string, unknown>, lines: string[], skipSubheading = false): void {
+  const type = block.type as string | undefined
+
+  if (type === 'text') {
+    const text = typeof block.text === 'string' ? block.text : ''
+    renderTextMarkdown(text, lines)
+    return
+  }
+
+  if (type === 'tool_use') {
+    const name = typeof block.name === 'string' ? block.name : 'unknown'
+    lines.push(`### Tool Use: ${name}`)
+    lines.push('')
+    const input = block.input
+    if (input != null) {
+      const inputJson = safeStringify(input, 2)
+      const marker = markdownFenceFor(inputJson)
+      lines.push(`${marker}json`)
+      lines.push(inputJson)
+      lines.push(marker)
+      lines.push('')
+    }
+    return
+  }
+
+  if (type === 'tool_result') {
+    if (!skipSubheading) {
+      lines.push('### Tool Result')
+      lines.push('')
+    }
+    const resultContent = block.content
+    if (resultContent != null) {
+      const asString = typeof resultContent === 'string'
+        ? stripSystemReminderBlocks(resultContent)
+        : safeStringify(resultContent, 2)
+      const fence = looksLikeJson(asString) ? 'json' : 'text'
+      const marker = markdownFenceFor(asString)
+      lines.push(`${marker}${fence}`)
+      lines.push(asString)
+      lines.push(marker)
+      lines.push('')
+    }
+    if (block.isError || block.is_error) {
+      lines.push('*(Error)*')
+      lines.push('')
+    }
+    return
+  }
+
+  if (type === 'image') {
+    lines.push('[Image attachment]')
+    lines.push('')
+    return
+  }
+
+  if (type === 'thinking') {
+    return
+  }
+
+  if (type === 'redacted_thinking') {
+    // Redacted thinking contains no readable content
+    return
+  }
+
+  // Unknown block type — render what we can
+  lines.push(`*[${type ?? 'unknown'} content block]*`)
+  lines.push('')
+  const serialized = safeStringify(block, 2)
+  const marker = markdownFenceFor(serialized)
+  lines.push(`${marker}json`)
+  lines.push(serialized)
+  lines.push(marker)
+  lines.push('')
+}
+
+function extractMessageContent(msg: Record<string, unknown>): unknown {
+  if ('message' in msg && msg.message && typeof msg.message === 'object') {
+    return (msg.message as Record<string, unknown>).content
+  }
+  if ('content' in msg) {
+    return msg.content
+  }
+  return null
+}
+
+function looksLikeJson(s: string): boolean {
+  const trimmed = s.trim()
+  return (trimmed.startsWith('{') && trimmed.endsWith('}')) ||
+    (trimmed.startsWith('[') && trimmed.endsWith(']'))
+}
+
+function markdownFenceFor(content: string): string {
+  let longest = 0
+  for (const match of content.matchAll(/`+/g)) {
+    longest = Math.max(longest, match[0].length)
+  }
+  return '`'.repeat(Math.max(3, longest + 1))
+}
+
+function safeStringify(value: unknown, indent?: number): string {
+  try {
+    return JSON.stringify(safeJsonValue(value), null, indent)
+  } catch {
+    return String(value)
+  }
+}
+
+/**
+ * Render messages as versioned, pretty-printed JSON suitable for
+ * programmatic consumption.
+ */
+export function renderMessagesToJSON(messages: Message[], _tools?: Tools): string {
+  // Filter out internal UI message types
+  const filtered = messages.flatMap((msg, sourceIndex) => {
+    if (!msg || typeof msg !== 'object') return []
+    const msgType = String((msg as Record<string, unknown>).type ?? '')
+    return shouldExportStructuredMessage(msg as Record<string, unknown>, msgType)
+      ? [{ msg, sourceIndex }]
+      : []
+  })
+
+  const exportedMessages = filtered.map(({ msg, sourceIndex }, index) => {
+    const msgType = String((msg as Record<string, unknown>).type ?? 'unknown')
+
+    const content = extractMessageContent(msg as Record<string, unknown>)
+    const terminalOutputs = getTerminalOutputs(content)
+    const exportedType = toExportedMessageType(msgType, content)
+    const role = toRoleForContent(msgType, content)
+
+    const exportedContent = serializeContentBlocks(content)
+    const timestamp = (msg as Record<string, unknown>).timestamp as string | undefined
+
+    const result: Record<string, unknown> = {
+      index,
+      sourceIndex,
+      type: exportedType,
+      role,
+      content: exportedContent,
+    }
+    if (exportedType === 'unknown' && msgType && msgType !== 'unknown') {
+      result.rawType = msgType
+    }
+    const subtype = (msg as Record<string, unknown>).subtype
+    if (terminalOutputs) {
+      result.subtype = terminalOutputs.every(output => output.source === 'bash')
+        ? terminalOutputs.every(output => output.stream === 'stdin') ? 'bash_input' : 'bash_output'
+        : 'local_command'
+      result.stream = terminalOutputs.every(output => output.stream === terminalOutputs[0]!.stream)
+        ? terminalOutputs[0]!.stream
+        : 'mixed'
+    } else if (typeof subtype === 'string') {
+      result.subtype = subtype
+    }
+    if (typeof timestamp === 'string') {
+      result.timestamp = timestamp
+    }
+    return result
+  })
+
+  const output = {
+    version: 1,
+    format: 'json',
+    exportedAt: new Date().toISOString(),
+    messageCount: exportedMessages.length,
+    messages: exportedMessages,
+  }
+
+  return safeStringify(output, 2)
+}
+
+function toRole(type: string): string {
+  switch (type) {
+    case 'user':
+    case 'assistant':
+    case 'system':
+    case 'tool':
+      return type
+    default:
+      return 'unknown'
+  }
+}
+
+function toExportedMessageType(msgType: string, content: unknown): string {
+  if (getTerminalOutputs(content)) return 'system'
+  if (isToolResultMessageContent(content)) return 'tool'
+  if (msgType === 'user' || msgType === 'assistant' || msgType === 'system' || msgType === 'tool') {
+    return msgType
+  }
+  if (msgType !== 'unknown') return 'unknown'
+  return msgType
+}
+
+function toRoleForContent(msgType: string, content: unknown): string {
+  if (getTerminalOutputs(content)) {
+    return 'system'
+  }
+  if (isToolResultMessageContent(content)) {
+    return 'tool'
+  }
+  return toRole(msgType)
+}
+
+function isToolResultMessageContent(content: unknown): boolean {
+  if (!Array.isArray(content)) return false
+  const hasToolResult = content.some(isToolResultBlock)
+  if (!hasToolResult) return false
+  return content.every(block => isToolResultBlock(block) || isInternalTextBlock(block))
+}
+
+function isToolResultBlock(block: unknown): boolean {
+  return !!block && typeof block === 'object' && (block as Record<string, unknown>).type === 'tool_result'
+}
+
+function isTextBlock(block: unknown): block is { type: 'text'; text: string } {
+  return !!block &&
+    typeof block === 'object' &&
+    (block as Record<string, unknown>).type === 'text' &&
+    typeof (block as Record<string, unknown>).text === 'string'
+}
+
+function isInternalTextBlock(block: unknown): boolean {
+  return isTextBlock(block) && isInternalText(block.text)
+}
+
+function serializeContentBlocks(content: unknown): unknown[] {
+  if (content == null) return []
+  const terminalOutputs = getTerminalOutputs(content)
+  if (terminalOutputs) return serializeTerminalOutputs(terminalOutputs)
+  if (typeof content === 'string') return [{ type: 'text', text: stripTopLevelInternalText(content) }]
+
+  if (!Array.isArray(content)) {
+    return [{ type: 'unknown', value: safeJsonValue(content) }]
+  }
+
+  return content
+    .filter(block => !(isTextBlock(block) && isInternalText(block.text)))
+    .flatMap(serializeContentBlock)
+}
+
+function serializeContentBlock(block: unknown): unknown | unknown[] {
+  if (!block || typeof block !== 'object') {
+    return { type: 'unknown', value: safeJsonValue(block) }
+  }
+
+  const b = block as Record<string, unknown>
+  const type = typeof b.type === 'string' ? b.type : 'unknown'
+
+  switch (type) {
+    case 'text':
+      if (typeof b.text !== 'string') {
+        return {
+          type: 'text',
+          text: '',
+        }
+      }
+      {
+        const withoutReminders = stripSystemReminderBlocks(b.text)
+        const terminalOutputs = parseTerminalOutputs(withoutReminders)
+        if (terminalOutputs) return serializeTerminalOutputs(terminalOutputs)
+        const strippedText = stripTopLevelInternalText(b.text)
+        return {
+          type: 'text',
+          text: strippedText,
+        }
+      }
+    case 'tool_use':
+      return {
+        type: 'tool_use',
+        ...(b.id != null ? { id: safeJsonValue(b.id) } : {}),
+        ...(b.name != null ? { name: String(b.name) } : {}),
+        ...(b.input != null ? { input: safeJsonValue(b.input) } : {}),
+      }
+    case 'tool_result':
+      const toolUseId = b.tool_use_id ?? b.toolUseId
+      const isError = b.is_error ?? b.isError
+      return {
+        type: 'tool_result',
+        ...(toolUseId != null ? { toolUseId: String(toolUseId) } : {}),
+        ...(b.content != null ? { content: safeJsonValue(b.content) } : {}),
+        ...(isError != null ? { isError: !!isError } : {}),
+      }
+    case 'image':
+      return { type: 'image', ...(b.source != null ? { source: safeJsonValue(b.source) } : {}) }
+    case 'thinking':
+    case 'redacted_thinking':
+      return []
+    default:
+      return { type, value: safeJsonValue(b) }
+  }
+}
+
+function safeJsonValue(value: unknown, seen = new WeakSet<object>()): unknown {
+  if (value == null || typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') {
+    if (typeof value === 'string') return stripSystemReminderBlocks(value)
+    return value
+  }
+  if (typeof value === 'bigint') return `${value}n`
+  if (typeof value === 'symbol') return value.toString()
+  if (typeof value === 'function') return '[Function]'
+  if (typeof value === 'undefined') return null
+
+  if (value instanceof Date) {
+    return Number.isNaN(value.getTime()) ? null : value.toISOString()
+  }
+
+  if (value instanceof Error) {
+    return {
+      name: value.name,
+      message: value.message,
+      ...(value.stack ? { stack: value.stack } : {}),
+    }
+  }
+
+  if (Array.isArray(value)) {
+    if (seen.has(value)) return '[Circular]'
+    seen.add(value)
+    try {
+      return value.map(item => safeJsonValue(item, seen))
+    } catch {
+      return '[Unserializable]'
+    } finally {
+      seen.delete(value)
+    }
+  }
+
+  if (typeof value === 'object') {
+    if (seen.has(value)) return '[Circular]'
+    seen.add(value)
+    try {
+      const result: Record<string, unknown> = {}
+      let keys: string[]
+      try {
+        keys = Object.keys(value as Record<string, unknown>)
+      } catch {
+        return '[Unserializable]'
+      }
+      for (const key of keys) {
+        try {
+          result[key] = safeJsonValue((value as Record<string, unknown>)[key], seen)
+        } catch {
+          result[key] = '[Unserializable]'
+        }
+      }
+      return result
+    } finally {
+      seen.delete(value)
+    }
+  }
+
+  return String(value)
+}
+
+function shouldExportStructuredMessage(msg: Record<string, unknown>, msgType: string): boolean {
+  if (SKIP_MESSAGE_TYPES.has(msgType)) return false
+  if (msgType === 'system' && SKIP_SYSTEM_SUBTYPES.has(String(msg.subtype ?? ''))) return false
+  if (msg.isMeta === true || msg.isCompactSummary === true) return false
+
+  const content = extractMessageContent(msg)
+  if (isSyntheticContent(content)) return false
+
+  return hasExportableStructuredContent(content) || !isKnownMessageType(msgType)
+}
+
+function isSyntheticContent(content: unknown): boolean {
+  if (!Array.isArray(content)) return false
+  const first = content[0]
+  const hasSyntheticToolResult = content.some(isSyntheticToolResultBlock)
+  return (isTextBlock(first) &&
+    (first.text === '[Request interrupted by user]' ||
+      first.text === '[Request interrupted by user for tool use]' ||
+      first.text === '[Request cancelled]' ||
+      first.text === '[Tool use rejected]' ||
+      first.text === '[No response requested]')) ||
+    (hasSyntheticToolResult && content.every(block => isSyntheticToolResultBlock(block) || isInternalTextBlock(block)))
+}
+
+function isInternalText(text: string): boolean {
+  return stripTopLevelInternalText(text).length === 0
+}
+
+function isSyntheticToolResultBlock(block: unknown): boolean {
+  if (!isToolResultBlock(block)) return false
+  const content = (block as Record<string, unknown>).content
+  return content === SYNTHETIC_TOOL_RESULT_PLACEHOLDER ||
+    (Array.isArray(content) && content.every(item => isTextBlock(item) && item.text === SYNTHETIC_TOOL_RESULT_PLACEHOLDER))
+}
+
+type TerminalOutput = {
+  source: 'local_command' | 'bash'
+  stream: 'stdin' | 'stdout' | 'stderr'
+  text: string
+}
+
+function getTerminalOutputs(content: unknown): TerminalOutput[] | null {
+  if (typeof content === 'string') return parseTerminalOutputs(content)
+  if (!Array.isArray(content)) return null
+  const visibleBlocks = content.filter(block => block != null && !(isTextBlock(block) && isInternalText(block.text)))
+  if (visibleBlocks.length !== 1) return null
+  const [block] = visibleBlocks
+  return isTextBlock(block) ? parseTerminalOutputs(block.text) : null
+}
+
+function parseTerminalOutputs(text: string): TerminalOutput[] | null {
+  let remaining = text.trim()
+  if (!remaining) return null
+
+  const outputs: TerminalOutput[] = []
+  while (remaining) {
+    const output = parseWrappedOutputPrefix(remaining)
+    if (!output) return null
+    outputs.push(output.output)
+    remaining = output.rest.trimStart()
+  }
+
+  return outputs.length > 0 ? outputs : null
+}
+
+function parseWrappedOutputPrefix(text: string): { output: TerminalOutput; rest: string } | null {
+  for (const { tag, source, stream } of TERMINAL_OUTPUT_DEFINITIONS) {
+    const openTagPrefix = `<${tag}`
+    const closeTag = `</${tag}>`
+    if (!text.startsWith(openTagPrefix)) continue
+    const afterTag = text[openTagPrefix.length]
+    if (afterTag !== '>' && !/\s/.test(afterTag ?? '')) continue
+    const openTagEnd = text.indexOf('>')
+    if (openTagEnd === -1) return null
+    const closeIndex = text.indexOf(closeTag, openTagEnd + 1)
+    if (closeIndex === -1) return null
+    return {
+      output: {
+        source,
+        stream,
+        text: text.slice(openTagEnd + 1, closeIndex),
+      },
+      rest: text.slice(closeIndex + closeTag.length),
+    }
+  }
+  return null
+}
+
+const TERMINAL_OUTPUT_DEFINITIONS: ReadonlyArray<{
+  tag: string
+  source: TerminalOutput['source']
+  stream: TerminalOutput['stream']
+}> = [
+  { tag: BASH_INPUT_TAG, source: 'bash', stream: 'stdin' },
+  { tag: LOCAL_COMMAND_STDOUT_TAG, source: 'local_command', stream: 'stdout' },
+  { tag: LOCAL_COMMAND_STDERR_TAG, source: 'local_command', stream: 'stderr' },
+  { tag: BASH_STDOUT_TAG, source: 'bash', stream: 'stdout' },
+  { tag: BASH_STDERR_TAG, source: 'bash', stream: 'stderr' },
+]
+
+function terminalHeading(outputs: TerminalOutput[]): string {
+  if (outputs.every(output => output.source === 'bash')) {
+    return outputs.every(output => output.stream === 'stdin') ? 'Bash Input' : 'Bash Output'
+  }
+  return 'Local Command Output'
+}
+
+function renderTextMarkdown(text: string, lines: string[]): void {
+  if (!text) return
+  const withoutReminders = stripSystemReminderBlocks(text)
+  const terminalOutputs = parseTerminalOutputs(withoutReminders)
+  const strippedText = terminalOutputs ? withoutReminders : stripTopLevelInternalText(text)
+  if (!strippedText) return
+  if (!terminalOutputs) {
+    lines.push(strippedText)
+    lines.push('')
+    return
+  }
+  for (const output of terminalOutputs) {
+    if (terminalOutputs.length > 1) {
+      lines.push(`### ${output.stream.toUpperCase()}`)
+      lines.push('')
+    }
+    if (output.text.trim()) {
+      lines.push(output.text)
+      lines.push('')
+    }
+  }
+}
+
+function serializeTerminalOutputs(outputs: TerminalOutput[]): unknown[] {
+  return outputs.map(output => ({
+    type: 'text',
+    text: output.text,
+    ...(outputs.length > 1 ? { stream: output.stream } : {}),
+  }))
+}
+
+function renderUnknownContentMarkdown(content: unknown, lines: string[]): void {
+  lines.push('*[unknown content]*')
+  lines.push('')
+  const serialized = safeStringify(content, 2)
+  const marker = markdownFenceFor(serialized)
+  lines.push(`${marker}json`)
+  lines.push(serialized)
+  lines.push(marker)
+  lines.push('')
+}
+
+function stripSystemReminderBlocks(text: string): string {
+  return text.replace(/<system-reminder\b[^>]*>[\s\S]*?<\/system-reminder>/g, '').trim()
+}
+
+function stripTopLevelInternalText(text: string): string {
+  let stripped = stripSystemReminderBlocks(text)
+  for (const regex of INTERNAL_TEXT_TAG_REGEXES) {
+    stripped = stripped.replace(regex, '')
+  }
+  return stripped.trim()
+}
+
+function internalTagRegex(tag: string): RegExp {
+  const escaped = escapeRegExp(tag)
+  return new RegExp(`<${escaped}\\b[^>]*>[\\s\\S]*?<\\/${escaped}>`, 'g')
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
+
+function isKnownMessageType(type: string): boolean {
+  return type === 'user' || type === 'assistant' || type === 'system' || type === 'tool'
+}
+
+function hasExportableStructuredContent(content: unknown): boolean {
+  if (content == null) return false
+  if (typeof content === 'string') {
+    return content.trim().length > 0 && !isInternalText(content)
+  }
+  if (!Array.isArray(content)) return true
+
+  return content.some(block => {
+    if (isTextBlock(block)) {
+      return block.text.trim().length > 0 && !isInternalText(block.text)
+    }
+    if (!block || typeof block !== 'object') return block != null
+    const type = (block as Record<string, unknown>).type
+    if (type === 'thinking' || type === 'redacted_thinking') return false
+    return true
+  })
+}
+
+/**
+ * Render messages for export in the specified format.
+ */
+export async function renderMessagesForExport(
+  messages: Message[],
+  tools: Tools,
+  { format, columns }: { format: ExportFormat; columns?: number },
+): Promise<string> {
+  switch (format) {
+    case 'text':
+      return renderMessagesToPlainText(messages, tools, columns)
+    case 'markdown':
+      return renderMessagesToMarkdown(messages, tools, columns)
+    case 'json':
+      return renderMessagesToJSON(messages, tools)
+  }
 }


### PR DESCRIPTION
## Summary

Adds multi-format conversation export for `/export` while preserving the existing plain-text behavior as the default.

- Adds Markdown and JSON renderers alongside the existing plain-text renderer.
- Centralizes export format parsing, inference, extension normalization, and direct-file path resolution.
- Supports `--format` / `-f` for explicit format selection, with the flag overriding filename extensions.
- Updates the interactive export dialog so users can choose Text, Markdown, or JSON before copying to clipboard or saving to a file.
- Keeps generated filenames as `.txt` by default unless the user explicitly selects another format.
- Adds focused coverage for parsing, filename handling, command behavior, dialog behavior, Markdown output, and JSON schema/safety.
- Hardens the affected command tests against Bun/global mock leakage found by the full CI suite after rebasing onto current `main`.

## How It Works

### Direct `/export` usage

The command resolves the export format from either an explicit flag or the provided filename extension:

- `/export transcript.txt` writes plain text to `transcript.txt`.
- `/export transcript.md` writes Markdown to `transcript.md`.
- `/export transcript.markdown` writes Markdown and preserves the `.markdown` extension.
- `/export transcript.json` writes JSON to `transcript.json`.
- `/export transcript` preserves existing behavior and writes plain text to `transcript.txt`.
- `/export --format json transcript.txt` writes JSON to `transcript.json`.
- `/export -f md transcript.json` writes Markdown to `transcript.md`.

Unsupported format values return a helpful error instead of silently falling back to text. Unknown filename extensions continue to resolve to plain text, preserving the previous default behavior.

### Interactive dialog

The dialog now starts with a format selection step and then lets the user choose clipboard or file export. Content rendering is lazy per selected format, so clipboard export still works and file export writes the correct format-specific content and extension.

### JSON schema

JSON exports are versioned and stable at `version: 1`. The top-level payload includes:

- `version`
- `format`
- `exportedAt`
- `messageCount`
- `messages`

Each exported message includes a stable index and normalized semantic fields. Runtime tool-result messages are exported as tool messages instead of confusing `type: "user"` / `role: "tool"` pairs. Internal terminal wrapper tags are normalized into useful system messages, while hidden reasoning and internal reminders are excluded from structured exports.

### Safety and compatibility

- No new dependencies were added.
- The existing `renderMessagesToPlainText()` path remains in place.
- Clipboard export still uses rendered content for the selected format.
- JSON rendering safely handles circular values, symbols, bigint values, throwing getters, proxies, errors, dates, and unknown content blocks without exposing non-serializable objects.
- Markdown and JSON exports strip internal system-reminder wrappers and avoid leaking hidden thinking content.

## CI Follow-up

This branch has been rebased onto current `Gitlawb/openclaude:main`. The previous CI run exposed test-order/global-state issues, so this update also:

- Makes `/export` command tests use isolated absolute temp paths for direct-save assertions, avoiding leaked global `cwd` mocks from unrelated tests while keeping relative path behavior covered in `resolveExportFilepath()` tests.
- Completes the `src/tools.lsp.test.ts` LSP manager mock and avoids importing the SDK barrel through a runtime test helper.
- Makes the KnowledgeGraph corruption test assert against the actual Orama persistence directory instead of assuming a specific config-home path.

## Value

This makes conversation export useful for more workflows without disrupting existing users:

- Text remains the default for simple archives and existing scripts.
- Markdown gives users readable, shareable conversation documents.
- JSON gives users a versioned format for post-processing, archival, and tooling integrations.
- Centralized format handling makes future export formats less error-prone.

## Validation

Run with Bun 1.3.13, matching `.bun-version` on current `main`:

- `bun test --max-concurrency=1 src/utils/exportFormats.test.ts src/utils/exportRenderer.test.ts src/commands/export/export.test.ts src/components/ExportDialog.test.tsx src/tools.lsp.test.ts src/utils/knowledgeGraph.stress.test.ts`
- `git diff --check`
- `bun run build`
- `bun run smoke`

A full local `bun test --max-concurrency=1` now gets past the export, LSP, and KnowledgeGraph failures from the failed CI run. In this shell it still reports two provider/discovery tests affected by local provider environment/cache state; the GitHub Actions rerun on the pushed branch is the clean-run source of truth.
