### PR TITLE
fix(ui): prevent prompt layout corruption when renaming session

### DIFF
--- a/src/components/PromptInput/PromptInput.tsx
+++ b/src/components/PromptInput/PromptInput.tsx
@@ -2286,13 +2286,13 @@ function PromptInput({
       {swarmBanner ? <>
           <Text color={swarmBanner.bgColor}>
             {swarmBanner.text ? <>
-                {'─'.repeat(Math.max(0, columns - stringWidth(swarmBanner.text) - 4))}
+                {'─'.repeat(Math.min(columns - 1, Math.max(0, columns - stringWidth(swarmBanner.text) - 4)))}
                 <Text backgroundColor={swarmBanner.bgColor} color="inverseText">
                   {' '}
                   {swarmBanner.text}{' '}
                 </Text>
                 {'──'}
-              </> : '─'.repeat(columns)}
+              </> : '─'.repeat(Math.max(0, columns - 1))}
           </Text>
           <Box flexDirection="row" width="100%">
             <PromptInputModeIndicator mode={mode} isLoading={isLoading} viewingAgentName={viewingAgentName} viewingAgentColor={viewingAgentColor} />
@@ -2300,7 +2300,7 @@ function PromptInput({
               {textInputElement}
             </Box>
           </Box>
-          <Text color={swarmBanner.bgColor}>{'─'.repeat(columns)}</Text>
+          <Text color={swarmBanner.bgColor}>{'─'.repeat(Math.max(0, columns - 1))}</Text>
         </> : <Box flexDirection="row" alignItems="flex-start" justifyContent="flex-start" borderColor={getBorderColor()} borderStyle="round" borderLeft={false} borderRight={false} borderBottom width="100%" borderText={buildBorderText(showFastIcon ?? false, showFastIconHint, fastModeCooldown)}>
           <PromptInputModeIndicator mode={mode} isLoading={isLoading} viewingAgentName={viewingAgentName} viewingAgentColor={viewingAgentColor} />
           <Box flexGrow={1} flexShrink={1} onClick={handleInputClick}>


### PR DESCRIPTION
  Summary

   - What changed: 
       - Capped the repetition of border characters (─) in the session banner within PromptInput.tsx to Math.max(0, columns - 1).
       - Applied the same safety margin to the top line calculation that includes the session name.
   - Why it changed: 
       - Fixes #1203. When the border characters exactly matched the terminal width (columns), many terminal emulators would automatically wrap to the next line. This caused the prompt box borders to shift and appear as multiple broken lines, especially visible after using /rename.

  Impact

   - User-facing impact: 
       - The prompt window design now stays perfectly intact after renaming a session. No more broken borders or layout corruption in the input area.
   - Developer/maintainer impact: 
       - Stabilized UI rendering in the core PromptInput component by preventing off-by-one terminal wrap issues.

  Testing

   - [x] bun run build
   - [x] bun run smoke
   - [x] Focused tests: Manual verification of the /rename command. The banner  now displays correctly without triggering unwanted line wraps, even when the terminal is resized.

  Notes

   - Provider/model path tested: N/A (Pure UI fix).
   - Screenshots attached: See #1203 for the "before" state. The "after" state shows a clean single-line border.
   - Follow-up work or known limitations: None. Using columns - 1 is a standard practice in terminal UIs to ensure stability across different shell environments.

