### PR TITLE
test: add shared mutation lock timeout guard

### DIFF
--- a/src/test/sharedMutationLock.test.ts
+++ b/src/test/sharedMutationLock.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, test } from 'bun:test'
+import { createSharedMutationLockForTesting } from './sharedMutationLock.js'
+
+describe('sharedMutationLock', () => {
+  test('uses the default timeout when no timeout is provided', async () => {
+    const lock = createSharedMutationLockForTesting(20)
+
+    await lock.acquireSharedMutationLock('default-timeout-holder')
+    try {
+      await expect(
+        lock.acquireSharedMutationLock('default-timeout-waiter'),
+      ).rejects.toThrow(
+        'Timed out after 20ms acquiring shared test mutation lock for default-timeout-waiter',
+      )
+    } finally {
+      lock.releaseSharedMutationLock()
+    }
+  })
+
+  test('honors an explicit timeout override in the scoped error', async () => {
+    const lock = createSharedMutationLockForTesting()
+
+    await lock.acquireSharedMutationLock('custom-timeout-holder')
+    try {
+      await expect(
+        lock.acquireSharedMutationLock('custom-timeout-waiter', 10),
+      ).rejects.toThrow(
+        'Timed out after 10ms acquiring shared test mutation lock for custom-timeout-waiter',
+      )
+    } finally {
+      lock.releaseSharedMutationLock()
+    }
+  })
+
+  test('release allows the next waiter to acquire the lock', async () => {
+    const lock = createSharedMutationLockForTesting()
+
+    await lock.acquireSharedMutationLock('first-holder')
+    const waiter = lock.acquireSharedMutationLock('next-waiter')
+    lock.releaseSharedMutationLock()
+
+    await expect(waiter).resolves.toBeUndefined()
+    lock.releaseSharedMutationLock()
+  })
+})

--- a/src/test/sharedMutationLock.ts
+++ b/src/test/sharedMutationLock.ts
@@ -1,19 +1,60 @@
-import { acquireEnvMutex, releaseEnvMutex } from '../entrypoints/sdk/shared.js'
+import {
+  acquireEnvMutex,
+  createEnvMutexForTesting,
+  releaseEnvMutex,
+  type MutexAcquireOptions,
+  type MutexAcquireResult,
+} from '../entrypoints/sdk/shared.js'
 
-export async function acquireSharedMutationLock(
-  scope: string,
-  timeoutMs?: number,
-): Promise<void> {
-  const result =
-    timeoutMs === undefined
-      ? await acquireEnvMutex()
-      : await acquireEnvMutex({ timeoutMs })
+type AcquireEnvMutex = (
+  options?: MutexAcquireOptions,
+) => Promise<MutexAcquireResult>
 
-  if (!result.acquired) {
-    throw new Error(`Timed out acquiring shared test mutation lock for ${scope}`)
+export const DEFAULT_SHARED_MUTATION_LOCK_TIMEOUT_MS = 5 * 60 * 1000
+
+function createSharedMutationLock(
+  acquire: AcquireEnvMutex,
+  release: () => void,
+  defaultTimeoutMs: number,
+) {
+  return {
+    async acquireSharedMutationLock(
+      scope: string,
+      timeoutMs?: number,
+    ): Promise<void> {
+      const effectiveTimeoutMs = timeoutMs ?? defaultTimeoutMs
+      const result = await acquire({ timeoutMs: effectiveTimeoutMs })
+
+      if (!result.acquired) {
+        throw new Error(
+          `Timed out after ${effectiveTimeoutMs}ms acquiring shared test mutation lock for ${scope}`,
+        )
+      }
+    },
+    releaseSharedMutationLock(): void {
+      release()
+    },
   }
 }
 
+const sharedMutationLock = createSharedMutationLock(
+  acquireEnvMutex,
+  releaseEnvMutex,
+  DEFAULT_SHARED_MUTATION_LOCK_TIMEOUT_MS,
+)
+
+export const acquireSharedMutationLock =
+  sharedMutationLock.acquireSharedMutationLock
+
 export function releaseSharedMutationLock(): void {
-  releaseEnvMutex()
+  sharedMutationLock.releaseSharedMutationLock()
+}
+
+export function createSharedMutationLockForTesting(defaultTimeoutMs = 50) {
+  const isolated = createEnvMutexForTesting()
+  return createSharedMutationLock(
+    isolated.acquireEnvMutex,
+    isolated.releaseEnvMutex,
+    defaultTimeoutMs,
+  )
 }


### PR DESCRIPTION
## Summary

This is a follow-up to the non-blocking recommendation from #1192.

`acquireSharedMutationLock()` now uses a default timeout when callers do not pass one, so a missed release fails with a scoped error instead of potentially hanging the entire smoke/test run indefinitely.

The change keeps explicit timeout overrides working and adds isolated mutex coverage for:

- default timeout behavior
- explicit timeout override behavior
- release handoff to a waiting caller

## Why

#1192 hardened the smoke/test suite by serializing tests that mutate process-global state behind the shared mutation lock. Reviewers approved that PR, but suggested a follow-up guard: if a test forgets to release the shared lock, the next waiter should fail with a useful scoped error rather than leaving smoke stuck forever.

This PR adds that guard while keeping the timeout long enough, five minutes, to avoid failing legitimate file-wide serialization on slower CI.

## Impact

- No user-facing runtime behavior changes.
- Only test helper behavior changes.
- Existing callers of `acquireSharedMutationLock(scope)` now get a bounded wait.
- Existing callers that pass `timeoutMs` keep their explicit timeout behavior.
- Timeout errors include the waiting test scope to make the stuck lock easier to diagnose.

## Validation

Ran per `CONTRIBUTING.md` plus focused tests for the changed helper:

```bash
bun test src/test/sharedMutationLock.test.ts tests/sdk/shared-utils.test.ts
```

Result:

- 19 pass
- 0 fail
- 31 expect calls

```bash
bun run build
```

Result:

- Built `openclaude v0.12.0` to `dist/cli.mjs`
- Built SDK bundle to `dist/sdk.mjs`
- SDK bundle: no React/Ink leakage detected
- CLI bundle externals valid: 0 missing, 10 external
- SDK bundle externals valid: 0 missing, 14 external
- SDK type declarations in sync: 56 exports match

```bash
bun run smoke
```

Result:

- Build passed
- CLI version check output: `0.12.0 (OpenClaude)`