### PR TITLE
fix(TaskListV2): revert overflowX hidden that hides task text labels

### DIFF
--- a/src/components/TaskListV2.tsx
+++ b/src/components/TaskListV2.tsx
@@ -361,7 +361,7 @@ function TaskItem(t0) {
   }
   let t12;
   if ($[34] !== t10 || $[35] !== t11) {
-    t12 = <Box flexDirection="column" width="100%" overflowX="hidden">{t10}{t11}</Box>;
+    t12 = <Box flexDirection="column" width="100%">{t10}{t11}</Box>;
     $[34] = t10;
     $[35] = t11;
     $[36] = t12;


### PR DESCRIPTION
Apologies — the overflowX="hidden" I added in #1211 was meant to fix the orphaned task icons, but it clips the subject text to nothing when items are nested inside MessageResponse. 

Separately, while investigating I noticed a lot of the spinner jitter, occasional mid-screen garbage characters, and other animation glitches disappear when openclaude is run under bun instead of node. The bin shebang currently uses node, and the dev script does too. From what I could see, the difference comes down to how the two runtimes handle stdout write atomicity and microtask scheduling , bun keeps frames coherent end-to-end while node tends to expose intermediate render states. This is probably why CC uses bun.
