### PR TITLE
fix(query): stop repeated tool-failure loops

### DIFF
--- a/src/query.ts
+++ b/src/query.ts
@@ -99,6 +99,10 @@ import { runTools } from './services/tools/toolOrchestration.js'
 import { applyToolResultBudget } from './utils/toolResultStorage.js'
 import { recordContentReplacement } from './utils/sessionStorage.js'
 import { handleStopHooks } from './query/stopHooks.js'
+import {
+  createToolFailureLoopGuardState,
+  updateToolFailureLoopGuard,
+} from './query/toolFailureLoopGuard.js'
 import { buildQueryConfig } from './query/config.js'
 import { getGlobalConfig } from './utils/config.js'
 import { productionDeps, type QueryDeps } from './query/deps.js'
@@ -304,6 +308,7 @@ async function* queryLoop(
   // trigger point. Loop-local (not on State) to avoid touching the 7 continue
   // sites.
   let taskBudgetRemaining: number | undefined = undefined
+  const toolFailureGuardState = createToolFailureLoopGuardState()
 
   // Snapshot immutable env/statsig/session state once at entry. See QueryConfig
   // for what's included and why feature() gates are intentionally excluded.
@@ -1591,6 +1596,75 @@ async function* queryLoop(
       await finalizeArcTurn()
     }
 
+    // We were aborted during tool calls
+    if (toolUseContext.abortController.signal.aborted) {
+      // chicago MCP: auto-unhide + lock release when aborted mid-tool-call.
+      // This is the most likely Ctrl+C path for CU (e.g. slow screenshot).
+      // Main thread only — see stopHooks.ts for the subagent rationale.
+      if (feature('CHICAGO_MCP') && !toolUseContext.agentId) {
+        try {
+          const { cleanupComputerUseAfterTurn } = await import(
+            './utils/computerUse/cleanup.js'
+          )
+          await cleanupComputerUseAfterTurn(toolUseContext)
+        } catch {
+          // Failures are silent — this is dogfooding cleanup, not critical path
+        }
+      }
+      // Skip the interruption message for submit-interrupts — the queued
+      // user message that follows provides sufficient context.
+      if (toolUseContext.abortController.signal.reason !== 'interrupt') {
+        yield createUserInterruptionMessage({
+          toolUse: true,
+        })
+      }
+      // Check maxTurns before returning when aborted
+      const nextTurnCountOnAbort = turnCount + 1
+      if (maxTurns && nextTurnCountOnAbort > maxTurns) {
+        yield createAttachmentMessage({
+          type: 'max_turns_reached',
+          maxTurns,
+          turnCount: nextTurnCountOnAbort,
+        })
+      }
+      return { reason: 'aborted_tools' }
+    }
+
+    // If a hook indicated to prevent continuation, stop here
+    if (shouldPreventContinuation) {
+      return { reason: 'hook_stopped' }
+    }
+
+    const toolFailureLoopDecision = updateToolFailureLoopGuard({
+      state: toolFailureGuardState,
+      toolUseBlocks,
+      toolResults,
+    })
+    if (toolFailureLoopDecision.tripped) {
+      logForDebugging(
+        `Tool failure loop guard tripped: kind=${toolFailureLoopDecision.kind} ` +
+          `threshold=${toolFailureLoopDecision.threshold} ` +
+          `hasToolName=${toolFailureLoopDecision.toolName !== undefined} ` +
+          `hasErrorCategory=${toolFailureLoopDecision.errorCategory !== undefined} ` +
+          `hasPath=${toolFailureLoopDecision.path !== undefined}`,
+      )
+      logEvent('tengu_tool_failure_loop_guard_tripped', {
+        threshold: toolFailureLoopDecision.threshold,
+        isPathTrip: toolFailureLoopDecision.kind === 'path',
+        isSignatureTrip: toolFailureLoopDecision.kind === 'signature',
+        isCategoryTrip: toolFailureLoopDecision.kind === 'category',
+        hasToolName: toolFailureLoopDecision.toolName !== undefined,
+        hasErrorCategory:
+          toolFailureLoopDecision.errorCategory !== undefined,
+        hasPath: toolFailureLoopDecision.path !== undefined,
+        queryDepth: queryTracking.depth,
+      })
+      yield createAssistantAPIErrorMessage({
+        content: toolFailureLoopDecision.message,
+      })
+      return { reason: 'tool_failure_loop' }
+    }
+
     // Generate tool use summary after tool batch completes — passed to next recursive call
     let nextPendingToolUseSummary:
       | Promise<ToolUseSummaryMessage | null>
@@ -1662,45 +1736,6 @@ async function* queryLoop(
           return null
         })
         .catch(() => null)
-    }
-
-    // We were aborted during tool calls
-    if (toolUseContext.abortController.signal.aborted) {
-      // chicago MCP: auto-unhide + lock release when aborted mid-tool-call.
-      // This is the most likely Ctrl+C path for CU (e.g. slow screenshot).
-      // Main thread only — see stopHooks.ts for the subagent rationale.
-      if (feature('CHICAGO_MCP') && !toolUseContext.agentId) {
-        try {
-          const { cleanupComputerUseAfterTurn } = await import(
-            './utils/computerUse/cleanup.js'
-          )
-          await cleanupComputerUseAfterTurn(toolUseContext)
-        } catch {
-          // Failures are silent — this is dogfooding cleanup, not critical path
-        }
-      }
-      // Skip the interruption message for submit-interrupts — the queued
-      // user message that follows provides sufficient context.
-      if (toolUseContext.abortController.signal.reason !== 'interrupt') {
-        yield createUserInterruptionMessage({
-          toolUse: true,
-        })
-      }
-      // Check maxTurns before returning when aborted
-      const nextTurnCountOnAbort = turnCount + 1
-      if (maxTurns && nextTurnCountOnAbort > maxTurns) {
-        yield createAttachmentMessage({
-          type: 'max_turns_reached',
-          maxTurns,
-          turnCount: nextTurnCountOnAbort,
-        })
-      }
-      return { reason: 'aborted_tools' }
-    }
-
-    // If a hook indicated to prevent continuation, stop here
-    if (shouldPreventContinuation) {
-      return { reason: 'hook_stopped' }
     }
 
     if (tracking?.compacted) {

--- a/src/query/toolFailureLoopGuard.test.ts
+++ b/src/query/toolFailureLoopGuard.test.ts
@@ -1,0 +1,552 @@
+import { expect, test } from 'bun:test'
+
+import type { ToolUseBlock } from '@anthropic-ai/sdk/resources/index.mjs'
+import {
+  createToolFailureLoopGuardState,
+  getToolFailureLoopThreshold,
+  updateToolFailureLoopGuard,
+} from './toolFailureLoopGuard.js'
+
+const querySourceFile = new URL('../query.ts', import.meta.url)
+
+function toolUse(
+  id: string,
+  name: string,
+  input: Record<string, unknown> = {},
+): ToolUseBlock {
+  return {
+    type: 'tool_use',
+    id,
+    name,
+    input,
+  } as ToolUseBlock
+}
+
+function toolResult(
+  toolUseId: string,
+  content: string,
+  isError = true,
+): { type: 'user'; message: { content: unknown[] } } {
+  return {
+    type: 'user',
+    message: {
+      content: [
+        {
+          type: 'tool_result',
+          tool_use_id: toolUseId,
+          content,
+          ...(isError ? { is_error: true } : {}),
+        },
+      ],
+    },
+  }
+}
+
+function update(
+  state = createToolFailureLoopGuardState(),
+  toolUseBlocks: ToolUseBlock[],
+  results: ReturnType<typeof toolResult>[],
+  threshold = 3,
+) {
+  return updateToolFailureLoopGuard({
+    state,
+    toolUseBlocks,
+    toolResults: results,
+    threshold,
+  })
+}
+
+test('three identical tool failures trip the guard', () => {
+  const state = createToolFailureLoopGuardState()
+
+  expect(
+    update(state, [toolUse('a', 'Edit')], [
+      toolResult('a', 'Error writing file: failed to replace text'),
+    ]).tripped,
+  ).toBe(false)
+  expect(
+    update(state, [toolUse('b', 'Edit')], [
+      toolResult('b', 'Error writing file: failed to replace text'),
+    ]).tripped,
+  ).toBe(false)
+
+  const decision = update(state, [toolUse('c', 'Edit')], [
+    toolResult('c', 'Error writing file: failed to replace text'),
+  ])
+
+  if (!decision.tripped) {
+    throw new Error('Expected repeated Edit failures to trip the guard')
+  }
+  expect(decision.message).toContain('`Edit` failed 3 times')
+  expect(decision.message).toContain('`FileWriteError`')
+})
+
+test('multiple failures in the same batch each increment the counters', () => {
+  const state = createToolFailureLoopGuardState()
+
+  const decision = update(
+    state,
+    [
+      toolUse('a', 'Edit'),
+      toolUse('b', 'Edit'),
+      toolUse('c', 'Edit'),
+    ],
+    [
+      toolResult('a', 'Error writing file: failed to replace text'),
+      toolResult('b', 'Error writing file: failed to replace text'),
+      toolResult('c', 'Error writing file: failed to replace text'),
+    ],
+  )
+
+  expect(decision.tripped).toBe(true)
+})
+
+test('different tools with different error categories do not trip early', () => {
+  const state = createToolFailureLoopGuardState()
+
+  update(state, [toolUse('a', 'Edit')], [
+    toolResult('a', 'Error writing file: failed to replace text'),
+  ])
+  update(state, [toolUse('b', 'Read')], [
+    toolResult('b', 'ENOENT: no such file or directory'),
+  ])
+  const decision = update(state, [toolUse('c', 'Bash')], [
+    toolResult('c', 'No such tool available: Bash'),
+  ])
+
+  expect(decision.tripped).toBe(false)
+})
+
+test('a successful tool result resets the counter', () => {
+  const state = createToolFailureLoopGuardState()
+
+  update(state, [toolUse('a', 'Edit')], [
+    toolResult('a', 'Error writing file: failed to replace text'),
+  ])
+  update(state, [toolUse('b', 'Edit')], [
+    toolResult('b', 'Error writing file: failed to replace text'),
+  ])
+  update(state, [toolUse('c', 'Read')], [toolResult('c', 'ok', false)])
+  const decision = update(state, [toolUse('d', 'Edit')], [
+    toolResult('d', 'Error writing file: failed to replace text'),
+  ])
+
+  expect(decision.tripped).toBe(false)
+})
+
+test('a successful tool result in the same batch resets the no-success streak', () => {
+  const state = createToolFailureLoopGuardState()
+
+  update(state, [toolUse('a', 'Edit')], [
+    toolResult('a', 'Error writing file: failed to replace text'),
+  ])
+  update(
+    state,
+    [toolUse('b', 'Edit'), toolUse('c', 'Read')],
+    [
+      toolResult('b', 'Error writing file: failed to replace text'),
+      toolResult('c', 'ok', false),
+    ],
+  )
+  update(state, [toolUse('d', 'Edit')], [
+    toolResult('d', 'Error writing file: failed to replace text'),
+  ])
+  const decision = update(state, [toolUse('e', 'Edit')], [
+    toolResult('e', 'Error writing file: failed to replace text'),
+  ])
+
+  expect(decision.tripped).toBe(false)
+})
+
+test('user aborts, user rejections, and streaming fallback discards are ignored', () => {
+  const state = createToolFailureLoopGuardState()
+
+  const ignoredMessages = [
+    'Interrupted by user',
+    'Request interrupted by user',
+    'User rejected tool use',
+    "The user doesn't want to proceed with this tool use",
+    "The user doesn't want to take this action right now",
+    'Streaming fallback - tool execution discarded',
+    'Cancelled: parallel tool call abc was skipped',
+  ]
+
+  for (const [index, message] of ignoredMessages.entries()) {
+    const id = `ignored-${index}`
+    const decision = update(state, [toolUse(id, 'Edit')], [
+      toolResult(id, message),
+    ])
+    expect(decision.tripped).toBe(false)
+  }
+
+  const decision = update(state, [toolUse('real', 'Edit')], [
+    toolResult('real', 'Error writing file: failed to replace text'),
+  ])
+  expect(decision.tripped).toBe(false)
+})
+
+test('synthetic tool errors are recognized through wrappers', () => {
+  const state = createToolFailureLoopGuardState()
+
+  const ignoredMessages = [
+    '[Request interrupted by user for tool use]',
+    '<tool_use_error>Error: Streaming fallback - tool execution discarded</tool_use_error>',
+    '<tool_use_error>Cancelled: parallel tool call Write errored</tool_use_error>',
+  ]
+
+  for (const [index, message] of ignoredMessages.entries()) {
+    const id = `wrapped-${index}`
+    const decision = update(state, [toolUse(id, 'Write')], [
+      toolResult(id, message),
+    ])
+    expect(decision.tripped).toBe(false)
+  }
+
+  const decision = update(
+    state,
+    [toolUse('real', 'Write')],
+    [toolResult('real', 'Error writing file: failed')],
+    2,
+  )
+
+  expect(decision.tripped).toBe(false)
+})
+
+test('ignored synthetic errors do not reset an existing failure streak', () => {
+  const state = createToolFailureLoopGuardState()
+
+  update(state, [toolUse('a', 'Edit')], [
+    toolResult('a', 'Error writing file: failed to replace text'),
+  ])
+  update(state, [toolUse('b', 'Edit')], [
+    toolResult('b', 'Request interrupted by user'),
+  ])
+  const decision = update(
+    state,
+    [toolUse('c', 'Edit')],
+    [toolResult('c', 'Error writing file: failed to replace text')],
+    2,
+  )
+
+  expect(decision.tripped).toBe(true)
+})
+
+test('non-error tool results reset even when their content resembles an ignored synthetic message', () => {
+  const state = createToolFailureLoopGuardState()
+
+  update(state, [toolUse('a', 'Bash')], [
+    toolResult('a', 'grep found an exact line: Interrupted by user'),
+  ])
+  update(state, [toolUse('b', 'Bash')], [
+    toolResult('b', 'Interrupted by user', false),
+  ])
+  const decision = update(
+    state,
+    [toolUse('c', 'Bash')],
+    [toolResult('c', 'grep found an exact line: Interrupted by user')],
+    2,
+  )
+
+  expect(decision.tripped).toBe(false)
+})
+
+test('real tool errors that merely mention ignored phrases are still counted', () => {
+  const state = createToolFailureLoopGuardState()
+
+  update(state, [toolUse('a', 'Bash')], [
+    toolResult(
+      'a',
+      'grep failed while matching literal text "Interrupted by user"',
+    ),
+  ])
+  const decision = update(
+    state,
+    [toolUse('b', 'Bash')],
+    [
+      toolResult(
+        'b',
+        'grep failed while matching literal text "Interrupted by user"',
+      ),
+    ],
+    2,
+  )
+
+  expect(decision.tripped).toBe(true)
+})
+
+test('same failing file_path across repeated failures trips the guard', () => {
+  const state = createToolFailureLoopGuardState()
+
+  update(state, [toolUse('a', 'Write', { file_path: 'src//foo.ts/' })], [
+    toolResult('a', 'Error writing file: EACCES'),
+  ])
+  update(state, [toolUse('b', 'Edit', { path: 'src/foo.ts' })], [
+    toolResult('b', 'InputValidationError: old_string not found'),
+  ])
+  const decision = update(
+    state,
+    [toolUse('c', 'NotebookEdit', { notebook_path: 'src\\foo.ts' })],
+    [toolResult('c', 'No such tool available: NotebookEdit')],
+  )
+
+  if (!decision.tripped) {
+    throw new Error('Expected repeated path failures to trip the guard')
+  }
+  expect(decision.message).toContain('The path `src/foo.ts` failed 3 times.')
+})
+
+test('a successful tool result resets a failing path counter', () => {
+  const state = createToolFailureLoopGuardState()
+
+  update(state, [toolUse('a', 'Write', { file_path: '/tmp/blocked.txt' })], [
+    toolResult('a', 'Error writing file: EACCES'),
+  ])
+  update(state, [toolUse('b', 'Read')], [toolResult('b', 'ok', false)])
+  const decision = update(
+    state,
+    [toolUse('c', 'Edit', { file_path: '/tmp/blocked.txt' })],
+    [toolResult('c', 'Error writing file: EACCES')],
+    2,
+  )
+
+  expect(decision.tripped).toBe(false)
+})
+
+test('same error category across repeated no-success failures trips the guard', () => {
+  const state = createToolFailureLoopGuardState()
+
+  update(state, [toolUse('a', 'Edit')], [
+    toolResult('a', '<tool_use_error>Error writing file: one</tool_use_error>'),
+  ])
+  update(state, [toolUse('b', 'Write')], [
+    toolResult('b', 'Error writing file: two'),
+  ])
+  const decision = update(state, [toolUse('c', 'NotebookEdit')], [
+    toolResult('c', 'Error writing file: three'),
+  ])
+
+  if (!decision.tripped) {
+    throw new Error('Expected repeated category failures to trip the guard')
+  }
+  expect(decision.message).toContain('Tool calls failed 3 times')
+  expect(decision.message).toContain('`FileWriteError`')
+})
+
+test('repeated invalid fallback tool calls trip as no-such-tool failures', () => {
+  const state = createToolFailureLoopGuardState()
+
+  update(state, [toolUse('a', 'ReadFile')], [
+    toolResult('a', 'No such tool available: ReadFile'),
+  ])
+  const decision = update(
+    state,
+    [toolUse('b', 'ReadFile')],
+    [toolResult('b', 'No such tool available: ReadFile')],
+    2,
+  )
+
+  if (!decision.tripped) {
+    throw new Error('Expected repeated invalid fallback tools to trip the guard')
+  }
+  expect(decision.message).toContain('`ReadFile` failed 2 times')
+  expect(decision.message).toContain('`NoSuchTool`')
+})
+
+test('content arrays and multi-block user messages are inspected', () => {
+  const state = createToolFailureLoopGuardState()
+
+  const result = {
+    type: 'user' as const,
+    message: {
+      content: [
+        {
+          type: 'text',
+          text: 'regular user text should not matter',
+        },
+        {
+          type: 'tool_result',
+          tool_use_id: 'a',
+          is_error: true,
+          content: [{ type: 'text', text: 'Error writing file: one' }],
+        },
+      ],
+    },
+  }
+
+  update(state, [toolUse('a', 'Write')], [result], 2)
+  const decision = update(
+    state,
+    [toolUse('b', 'Edit')],
+    [toolResult('b', 'Error writing file: two')],
+    2,
+  )
+
+  expect(decision.tripped).toBe(true)
+})
+
+test('permission and not-found errors use specific categories before generic write errors', () => {
+  const permissionState = createToolFailureLoopGuardState()
+
+  update(
+    permissionState,
+    [toolUse('a', 'Write')],
+    [toolResult('a', 'Error writing file: EACCES permission denied')],
+    2,
+  )
+  const permissionDecision = update(
+    permissionState,
+    [toolUse('b', 'Write')],
+    [toolResult('b', 'Error writing file: EPERM permission denied')],
+    2,
+  )
+
+  if (!permissionDecision.tripped) {
+    throw new Error('Expected repeated permission failures to trip the guard')
+  }
+  expect(permissionDecision.message).toContain('`PermissionError`')
+
+  const notFoundState = createToolFailureLoopGuardState()
+
+  update(
+    notFoundState,
+    [toolUse('c', 'Write')],
+    [toolResult('c', 'Error writing file: ENOENT not found')],
+    2,
+  )
+  const notFoundDecision = update(
+    notFoundState,
+    [toolUse('d', 'Write')],
+    [toolResult('d', 'Error writing file: ENOENT not found')],
+    2,
+  )
+
+  if (!notFoundDecision.tripped) {
+    throw new Error('Expected repeated not-found failures to trip the guard')
+  }
+  expect(notFoundDecision.message).toContain('`NotFound`')
+})
+
+test('threshold override can be passed directly', () => {
+  const state = createToolFailureLoopGuardState()
+
+  update(
+    state,
+    [toolUse('a', 'Edit')],
+    [toolResult('a', 'InputValidationError: missing path')],
+    2,
+  )
+  const decision = update(
+    state,
+    [toolUse('b', 'Edit')],
+    [toolResult('b', 'Invalid tool parameters: missing path')],
+    2,
+  )
+
+  if (!decision.tripped) {
+    throw new Error('Expected threshold override to trip the guard')
+  }
+  expect(getToolFailureLoopThreshold('0')).toBe(0)
+  expect(getToolFailureLoopThreshold('bad')).toBe(3)
+})
+
+test('environment threshold parsing trims valid integers and rejects invalid values', () => {
+  expect(getToolFailureLoopThreshold(' 2 ')).toBe(2)
+  expect(getToolFailureLoopThreshold('')).toBe(3)
+  expect(getToolFailureLoopThreshold('-1')).toBe(3)
+  expect(getToolFailureLoopThreshold('1.5')).toBe(3)
+})
+
+test('zero threshold disables counting and invalid explicit thresholds fall back to default', () => {
+  const disabledState = createToolFailureLoopGuardState()
+
+  for (const id of ['a', 'b', 'c']) {
+    const decision = update(
+      disabledState,
+      [toolUse(id, 'Edit')],
+      [toolResult(id, 'Error writing file: failed to replace text')],
+      0,
+    )
+    expect(decision.tripped).toBe(false)
+  }
+
+  const fallbackState = createToolFailureLoopGuardState()
+
+  update(
+    fallbackState,
+    [toolUse('d', 'Edit')],
+    [toolResult('d', 'Error writing file: failed to replace text')],
+    -1,
+  )
+  update(
+    fallbackState,
+    [toolUse('e', 'Edit')],
+    [toolResult('e', 'Error writing file: failed to replace text')],
+    -1,
+  )
+  const decision = update(
+    fallbackState,
+    [toolUse('f', 'Edit')],
+    [toolResult('f', 'Error writing file: failed to replace text')],
+    -1,
+  )
+
+  expect(decision.tripped).toBe(true)
+})
+
+test('unsafe threshold values fall back to the default', () => {
+  const state = createToolFailureLoopGuardState()
+
+  update(
+    state,
+    [toolUse('a', 'Edit')],
+    [toolResult('a', 'Error writing file: failed to replace text')],
+    Number.MAX_SAFE_INTEGER + 1,
+  )
+  update(
+    state,
+    [toolUse('b', 'Edit')],
+    [toolResult('b', 'Error writing file: failed to replace text')],
+    Number.MAX_SAFE_INTEGER + 1,
+  )
+  const decision = update(
+    state,
+    [toolUse('c', 'Edit')],
+    [toolResult('c', 'Error writing file: failed to replace text')],
+    Number.MAX_SAFE_INTEGER + 1,
+  )
+
+  expect(decision.tripped).toBe(true)
+  expect(getToolFailureLoopThreshold(String(Number.MAX_SAFE_INTEGER + 1))).toBe(
+    3,
+  )
+})
+
+test('query loop checks the guard before optional follow-up work', async () => {
+  const source = await Bun.file(querySourceFile).text()
+  const guardIndex = source.indexOf(
+    'const toolFailureLoopDecision = updateToolFailureLoopGuard',
+  )
+  const summaryIndex = source.indexOf('let nextPendingToolUseSummary')
+  const attachmentsIndex = source.indexOf(
+    "logEvent('tengu_query_before_attachments'",
+  )
+
+  expect(guardIndex).toBeGreaterThan(-1)
+  expect(summaryIndex).toBeGreaterThan(-1)
+  expect(attachmentsIndex).toBeGreaterThan(-1)
+  expect(guardIndex).toBeLessThan(summaryIndex)
+  expect(guardIndex).toBeLessThan(attachmentsIndex)
+})
+
+test('query loop emits a path-safe diagnostic when the guard trips', async () => {
+  const source = await Bun.file(querySourceFile).text()
+  const tripIndex = source.indexOf('Tool failure loop guard tripped:')
+
+  expect(tripIndex).toBeGreaterThan(-1)
+  expect(source).not.toContain('path: toolFailureLoopDecision.path')
+  expect(source).not.toContain('tool=${toolFailureLoopDecision.toolName')
+  expect(source).not.toContain(
+    'category=${toolFailureLoopDecision.errorCategory',
+  )
+  expect(source).not.toContain('${toolFailureLoopDecision.path}')
+})

--- a/src/query/toolFailureLoopGuard.ts
+++ b/src/query/toolFailureLoopGuard.ts
@@ -1,0 +1,356 @@
+import type { ToolUseBlock } from '@anthropic-ai/sdk/resources/index.mjs'
+
+import type { AttachmentMessage, UserMessage } from '../types/message.js'
+
+const DEFAULT_TOOL_FAILURE_LOOP_THRESHOLD = 3
+const MAX_FALLBACK_CATEGORY_LENGTH = 120
+
+export type ToolFailureLoopGuardState = {
+  signatureCounts: Map<string, number>
+  categoryCounts: Map<string, number>
+  pathCounts: Map<string, number>
+}
+
+export type ToolFailureLoopGuardDecision =
+  | { tripped: false }
+  | {
+      tripped: true
+      message: string
+      threshold: number
+      kind: 'signature' | 'category' | 'path'
+      toolName?: string
+      errorCategory?: string
+      path?: string
+    }
+
+export function createToolFailureLoopGuardState(): ToolFailureLoopGuardState {
+  return {
+    signatureCounts: new Map(),
+    categoryCounts: new Map(),
+    pathCounts: new Map(),
+  }
+}
+
+export function getToolFailureLoopThreshold(
+  value = process.env.CLAUDE_CODE_TOOL_FAILURE_LOOP_THRESHOLD,
+): number {
+  if (value === undefined) {
+    return DEFAULT_TOOL_FAILURE_LOOP_THRESHOLD
+  }
+
+  const trimmed = value.trim()
+  if (!/^\d+$/.test(trimmed)) {
+    return DEFAULT_TOOL_FAILURE_LOOP_THRESHOLD
+  }
+
+  const parsed = Number(trimmed)
+  return Number.isSafeInteger(parsed)
+    ? parsed
+    : DEFAULT_TOOL_FAILURE_LOOP_THRESHOLD
+}
+
+export function updateToolFailureLoopGuard(params: {
+  state: ToolFailureLoopGuardState
+  toolUseBlocks: ToolUseBlock[]
+  toolResults: (UserMessage | AttachmentMessage)[]
+  threshold?: number
+}): ToolFailureLoopGuardDecision {
+  const threshold = normalizeThreshold(params.threshold)
+  if (threshold === 0) {
+    return { tripped: false }
+  }
+
+  const toolUseById = new Map(
+    params.toolUseBlocks.map(block => [block.id, block]),
+  )
+  const failures: FailureInfo[] = []
+  let hasSuccess = false
+
+  for (const block of getToolResultBlocks(params.toolResults)) {
+    const content = toolResultContentToString(block.content)
+
+    if (block.is_error !== true) {
+      hasSuccess = true
+      continue
+    }
+
+    if (isIgnoredSyntheticToolResult(content)) {
+      continue
+    }
+
+    const toolUse = toolUseById.get(String(block.tool_use_id ?? ''))
+    const toolName = toolUse?.name ?? 'unknown'
+    const errorCategory = normalizeErrorCategory(content)
+    failures.push({
+      toolName,
+      errorCategory,
+      path: extractNormalizedPath(toolUse?.input),
+    })
+  }
+
+  if (hasSuccess) {
+    resetToolFailureLoopGuard(params.state)
+    return { tripped: false }
+  }
+
+  for (const failure of failures) {
+    const signatureCount = incrementCounter(
+      params.state.signatureCounts,
+      `${failure.toolName}\0${failure.errorCategory}`,
+    )
+    const categoryCount = incrementCounter(
+      params.state.categoryCounts,
+      failure.errorCategory,
+    )
+    const pathCount = failure.path
+      ? incrementCounter(params.state.pathCounts, failure.path)
+      : 0
+
+    if (pathCount >= threshold && failure.path) {
+      return {
+        tripped: true,
+        kind: 'path',
+        threshold,
+        path: failure.path,
+        message: createTripMessage({
+          kind: 'path',
+          threshold,
+          path: failure.path,
+        }),
+      }
+    }
+
+    if (signatureCount >= threshold) {
+      return {
+        tripped: true,
+        kind: 'signature',
+        threshold,
+        toolName: failure.toolName,
+        errorCategory: failure.errorCategory,
+        message: createTripMessage({
+          kind: 'signature',
+          threshold,
+          toolName: failure.toolName,
+          errorCategory: failure.errorCategory,
+        }),
+      }
+    }
+
+    if (categoryCount >= threshold) {
+      return {
+        tripped: true,
+        kind: 'category',
+        threshold,
+        errorCategory: failure.errorCategory,
+        message: createTripMessage({
+          kind: 'category',
+          threshold,
+          errorCategory: failure.errorCategory,
+        }),
+      }
+    }
+  }
+
+  return { tripped: false }
+}
+
+type ToolResultBlockLike = {
+  type: 'tool_result'
+  tool_use_id?: unknown
+  content?: unknown
+  is_error?: unknown
+}
+
+type FailureInfo = {
+  toolName: string
+  errorCategory: string
+  path: string | undefined
+}
+
+function normalizeThreshold(threshold: number | undefined): number {
+  if (threshold === undefined) {
+    return getToolFailureLoopThreshold()
+  }
+  if (!Number.isSafeInteger(threshold) || threshold < 0) {
+    return DEFAULT_TOOL_FAILURE_LOOP_THRESHOLD
+  }
+  return threshold
+}
+
+function resetToolFailureLoopGuard(state: ToolFailureLoopGuardState): void {
+  state.signatureCounts.clear()
+  state.categoryCounts.clear()
+  state.pathCounts.clear()
+}
+
+function getToolResultBlocks(
+  messages: (UserMessage | AttachmentMessage)[],
+): ToolResultBlockLike[] {
+  const blocks: ToolResultBlockLike[] = []
+
+  for (const message of messages) {
+    if (message?.type !== 'user' || !Array.isArray(message.message?.content)) {
+      continue
+    }
+
+    for (const block of message.message.content) {
+      if (isToolResultBlock(block)) {
+        blocks.push(block)
+      }
+    }
+  }
+
+  return blocks
+}
+
+function isToolResultBlock(block: unknown): block is ToolResultBlockLike {
+  return (
+    typeof block === 'object' &&
+    block !== null &&
+    (block as { type?: unknown }).type === 'tool_result'
+  )
+}
+
+function toolResultContentToString(content: unknown): string {
+  if (typeof content === 'string') {
+    return content
+  }
+
+  if (Array.isArray(content)) {
+    return content.map(toolResultContentToString).join(' ')
+  }
+
+  if (typeof content === 'object' && content !== null) {
+    const text = (content as { text?: unknown }).text
+    if (typeof text === 'string') {
+      return text
+    }
+  }
+
+  if (content === undefined || content === null) {
+    return ''
+  }
+
+  return String(content)
+}
+
+function isIgnoredSyntheticToolResult(content: string): boolean {
+  const normalized = normalizeToolResultText(content).toLowerCase()
+  const unbracketed = normalized.replace(/^\[(.*)\]$/, '$1').trim()
+  const withoutErrorPrefix = unbracketed.replace(/^error:\s*/, '').trim()
+
+  return (
+    withoutErrorPrefix === 'interrupted by user' ||
+    withoutErrorPrefix.startsWith('request interrupted by user') ||
+    withoutErrorPrefix === 'user rejected tool use' ||
+    withoutErrorPrefix.startsWith(
+      "the user doesn't want to proceed with this tool use",
+    ) ||
+    withoutErrorPrefix.startsWith(
+      "the user doesn't want to take this action right now",
+    ) ||
+    withoutErrorPrefix === 'streaming fallback - tool execution discarded' ||
+    withoutErrorPrefix.startsWith('cancelled: parallel tool call')
+  )
+}
+
+function normalizeErrorCategory(content: string): string {
+  const normalized = normalizeToolResultText(content)
+
+  if (/\bInputValidationError\b/i.test(normalized)) {
+    return 'InputValidationError'
+  }
+  if (/Invalid tool parameters/i.test(normalized)) {
+    return 'InputValidationError'
+  }
+  if (/No such tool available/i.test(normalized)) {
+    return 'NoSuchTool'
+  }
+  if (/\b(EACCES|EPERM)\b/i.test(normalized)) {
+    return 'PermissionError'
+  }
+  if (/permission denied/i.test(normalized)) {
+    return 'PermissionError'
+  }
+  if (/\bENOENT\b/i.test(normalized) || /not found/i.test(normalized)) {
+    return 'NotFound'
+  }
+  if (/Error writing file/i.test(normalized)) {
+    return 'FileWriteError'
+  }
+
+  return (
+    normalized.toLowerCase().slice(0, MAX_FALLBACK_CATEGORY_LENGTH) ||
+    'unknown error'
+  )
+}
+
+function normalizeToolResultText(content: string): string {
+  return content
+    .replace(/<\/?tool_use_error[^>]*>/gi, ' ')
+    .replace(/\s+/g, ' ')
+    .trim()
+}
+
+function extractNormalizedPath(input: unknown): string | undefined {
+  if (typeof input !== 'object' || input === null) {
+    return undefined
+  }
+
+  const record = input as Record<string, unknown>
+  for (const field of ['file_path', 'path', 'notebook_path']) {
+    const value = record[field]
+    if (typeof value !== 'string') {
+      continue
+    }
+    const normalized = normalizePath(value)
+    if (normalized) {
+      return normalized
+    }
+  }
+
+  return undefined
+}
+
+function normalizePath(path: string): string {
+  const normalized = path
+    .trim()
+    .replace(/\\/g, '/')
+    .replace(/\/{2,}/g, '/')
+    .replace(/\/+$/g, '')
+
+  return normalized === '' && path.trim().startsWith('/') ? '/' : normalized
+}
+
+function incrementCounter(counts: Map<string, number>, key: string): number {
+  const next = (counts.get(key) ?? 0) + 1
+  counts.set(key, next)
+  return next
+}
+
+function createTripMessage(
+  detail:
+    | { kind: 'path'; threshold: number; path: string }
+    | {
+        kind: 'signature'
+        threshold: number
+        toolName: string
+        errorCategory: string
+      }
+    | { kind: 'category'; threshold: number; errorCategory: string },
+): string {
+  let reason: string
+  if (detail.kind === 'path') {
+    reason = `The path \`${detail.path}\` failed ${detail.threshold} times.`
+  } else if (detail.kind === 'signature') {
+    reason = `\`${detail.toolName}\` failed ${detail.threshold} times with \`${detail.errorCategory}\`.`
+  } else {
+    reason = `Tool calls failed ${detail.threshold} times with \`${detail.errorCategory}\`.`
+  }
+
+  return [
+    'Stopped: repeated tool failures detected.',
+    '',
+    `${reason} Please inspect permissions, path, or tool schema before retrying.`,
+  ].join('\n')
+}

--- a/src/query/transitions.ts
+++ b/src/query/transitions.ts
@@ -1,0 +1,22 @@
+export type Terminal =
+  | { reason: 'blocking_limit' }
+  | { reason: 'image_error' }
+  | { reason: 'model_error'; error: unknown }
+  | { reason: 'aborted_streaming' }
+  | { reason: 'prompt_too_long' }
+  | { reason: 'completed' }
+  | { reason: 'stop_hook_prevented' }
+  | { reason: 'aborted_tools' }
+  | { reason: 'hook_stopped' }
+  | { reason: 'max_turns'; turnCount: number }
+  | { reason: 'tool_failure_loop' }
+
+export type Continue =
+  | { reason: 'collapse_drain_retry'; committed: number }
+  | { reason: 'reactive_compact_retry' }
+  | { reason: 'max_output_tokens_escalate' }
+  | { reason: 'max_output_tokens_recovery'; attempt: number }
+  | { reason: 'stop_hook_blocking' }
+  | { reason: 'token_budget_continuation' }
+  | { reason: 'continuation_nudge' }
+  | { reason: 'next_turn' }


### PR DESCRIPTION
## Summary
- Add a query-level tool failure loop guard that tracks repeated failing tool results by tool/error category, error category, and normalized path.
- Stop the query loop with a clear assistant-visible diagnostic before another model call when repeated failures hit the threshold.
- Cover repeated write/edit failures, invalid fallback tool calls, synthetic user interruptions/rejections, success resets, threshold parsing, and integration ordering.

## Why
Issue #1102 reports runaway loops where the model repeatedly retries failed file writes/edits or invalid fallback tool calls, burning tokens without making progress. This change adds a small circuit breaker in the query loop rather than refactoring individual tools.

This does not repair the underlying file-write failure or provider/tool-schema issue. It stops the runaway loop and gives the user a concrete diagnostic so they can inspect permissions, paths, or tool schema before retrying.

## Validation
- `bun test src/query/toolFailureLoopGuard.test.ts` passed: 22 tests.
- `bun run build` passed.
- `git diff --check` passed.
- `bun run typecheck` still fails on existing repo-wide snapshot/type issues unrelated to this change, including missing modules/exports and pre-existing `src/query.ts` references outside the guard path.
