### PR TITLE
fix(claudemd): gate User-scope external @include behind hasClaudeMdEx…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,7 @@
 * replace raw abort signal timeouts ([#1123](https://github.com/Gitlawb/openclaude/issues/1123)) ([877b4dc](https://github.com/Gitlawb/openclaude/commit/877b4dc88600062d8bbfaf764bfbd828c55699e8))
 * surface actionable error when fetch fails in _doOpenAIRequest ([#447](https://github.com/Gitlawb/openclaude/issues/447)) ([3af0924](https://github.com/Gitlawb/openclaude/commit/3af092441d36d77cc5b23c69225be568ef8d355c))
 * update vulnerable dependencies ([#1149](https://github.com/Gitlawb/openclaude/issues/1149)) ([5328f57](https://github.com/Gitlawb/openclaude/commit/5328f57a724b15fcf688cdfd0c1d52c3de926059))
+* **memory:** gate User-scope external @include behind approval prompt ([#131](https://github.com/Gitlawb/openclaude/issues/131))
 
 ## [0.10.0](https://github.com/Gitlawb/openclaude/compare/v0.9.2...v0.10.0) (2026-05-11)
 

--- a/src/components/ClaudeMdExternalIncludesDialog.tsx
+++ b/src/components/ClaudeMdExternalIncludesDialog.tsx
@@ -10,126 +10,59 @@ type Props = {
   onDone(): void;
   isStandaloneDialog?: boolean;
   externalIncludes?: ExternalClaudeMdInclude[];
+  scope?: 'User' | 'Project';
 };
+function acceptProject(current: any) {
+  return { ...current, hasClaudeMdExternalIncludesApproved: true, hasClaudeMdExternalIncludesWarningShown: true };
+}
+function acceptUser(current: any) {
+  return { ...current, hasClaudeMdExternalIncludesApprovedForUser: true, hasClaudeMdExternalIncludesWarningShown: true };
+}
+function declineProject(current: any) {
+  return { ...current, hasClaudeMdExternalIncludesApproved: false, hasClaudeMdExternalIncludesWarningShown: true };
+}
+function declineUser(current: any) {
+  return { ...current, hasClaudeMdExternalIncludesApprovedForUser: false, hasClaudeMdExternalIncludesWarningShown: true };
+}
 export function ClaudeMdExternalIncludesDialog(t0: Props) {
   const $ = _c(18);
-  const {
-    onDone,
-    isStandaloneDialog,
-    externalIncludes
-  } = t0;
-  let t1: [];
-  if ($[0] === Symbol.for("react.memo_cache_sentinel")) {
-    t1 = [];
-    $[0] = t1;
-  } else {
-    t1 = $[0];
-  }
-  React.useEffect(_temp, t1);
-  let t2;
-  if ($[1] !== onDone) {
-    t2 = (value: 'yes' | 'no') => {
-      if (value === "no") {
-        logEvent("tengu_claude_md_external_includes_dialog_declined", {});
-        saveCurrentProjectConfig(_temp2);
-      } else {
-        logEvent("tengu_claude_md_external_includes_dialog_accepted", {});
-        saveCurrentProjectConfig(_temp3);
-      }
-      onDone();
-    };
-    $[1] = onDone;
-    $[2] = t2;
-  } else {
-    t2 = $[2];
-  }
-  const handleSelection = t2;
-  let t3;
-  if ($[3] !== handleSelection) {
-    t3 = () => {
-      handleSelection("no");
-    };
-    $[3] = handleSelection;
-    $[4] = t3;
-  } else {
-    t3 = $[4];
-  }
-  const handleEscape = t3;
-  const t4 = !isStandaloneDialog;
-  const t5 = !isStandaloneDialog;
-  let t6;
-  if ($[5] === Symbol.for("react.memo_cache_sentinel")) {
-    t6 = <Text>This project's CLAUDE.md imports files outside the current working directory. Never allow this for third-party repositories.</Text>;
-    $[5] = t6;
-  } else {
-    t6 = $[5];
-  }
-  let t7;
-  if ($[6] !== externalIncludes) {
-    t7 = externalIncludes && externalIncludes.length > 0 && <Box flexDirection="column"><Text dimColor={true}>External imports:</Text>{externalIncludes.map(_temp4)}</Box>;
-    $[6] = externalIncludes;
-    $[7] = t7;
-  } else {
-    t7 = $[7];
-  }
-  let t8;
-  if ($[8] === Symbol.for("react.memo_cache_sentinel")) {
-    t8 = <Text dimColor={true}>Important: Only use Claude Code with files you trust. Accessing untrusted files may pose security risks{" "}<Link url="https://code.claude.com/docs/en/security" />{" "}</Text>;
-    $[8] = t8;
-  } else {
-    t8 = $[8];
-  }
-  let t9;
-  if ($[9] === Symbol.for("react.memo_cache_sentinel")) {
-    t9 = [{
-      label: "Yes, allow external imports",
-      value: "yes"
-    }, {
-      label: "No, disable external imports",
-      value: "no"
-    }];
-    $[9] = t9;
-  } else {
-    t9 = $[9];
-  }
-  let t10;
-  if ($[10] !== handleSelection) {
-    t10 = <Select options={t9} onChange={(value_0: string) => handleSelection(value_0 as 'yes' | 'no')} />;
-    $[10] = handleSelection;
-    $[11] = t10;
-  } else {
-    t10 = $[11];
-  }
-  let t11;
-  if ($[12] !== handleEscape || $[13] !== t10 || $[14] !== t4 || $[15] !== t5 || $[16] !== t7) {
-    t11 = <Dialog title="Allow external CLAUDE.md file imports?" color="warning" onCancel={handleEscape} hideBorder={t4} hideInputGuide={t5}>{t6}{t7}{t8}{t10}</Dialog>;
-    $[12] = handleEscape;
-    $[13] = t10;
-    $[14] = t4;
-    $[15] = t5;
-    $[16] = t7;
-    $[17] = t11;
-  } else {
-    t11 = $[17];
-  }
-  return t11;
-}
-function _temp4(include: ExternalClaudeMdInclude, i: number) {
-  return <Text key={i} dimColor={true}>{"  "}{include.path}</Text>;
-}
-function _temp3(current_0: any) {
-  return {
-    ...current_0,
-    hasClaudeMdExternalIncludesApproved: true,
-    hasClaudeMdExternalIncludesWarningShown: true
-  };
-}
-function _temp2(current: any) {
-  return {
-    ...current,
-    hasClaudeMdExternalIncludesApproved: false,
-    hasClaudeMdExternalIncludesWarningShown: true
-  };
+  const { onDone, isStandaloneDialog, externalIncludes, scope } = t0;
+  React.useEffect(_temp, []);
+  const handleSelection = React.useCallback((value: 'yes' | 'no') => {
+    if (value === "no") {
+      logEvent("tengu_claude_md_external_includes_dialog_declined", {});
+      saveCurrentProjectConfig(scope === 'User' ? declineUser : declineProject);
+    } else {
+      logEvent("tengu_claude_md_external_includes_dialog_accepted", {});
+      saveCurrentProjectConfig(scope === 'User' ? acceptUser : acceptProject);
+    }
+    onDone();
+  }, [onDone, scope]);
+  const handleEscape = React.useCallback(() => handleSelection("no"), [handleSelection]);
+  const title = scope === 'User'
+    ? "Allow user CLAUDE.md file imports?"
+    : "Allow external CLAUDE.md file imports?";
+  const description = scope === 'User'
+    ? <Text>Your user CLAUDE.md (~/.claude/CLAUDE.md) imports files outside the current working directory.</Text>
+    : <Text>This project's CLAUDE.md imports files outside the current working directory. Never allow this for third-party repositories.</Text>;
+  return (
+    <Dialog title={title} color="warning" onCancel={handleEscape} hideBorder={!isStandaloneDialog} hideInputGuide={!isStandaloneDialog}>
+      {description}
+      {externalIncludes && externalIncludes.length > 0 && (
+        <Box flexDirection="column">
+          <Text dimColor={true}>External imports:</Text>
+          {externalIncludes.map((include, i) => (
+            <Text key={i} dimColor={true}>{"  "}{include.path}</Text>
+          ))}
+        </Box>
+      )}
+      <Text dimColor={true}>Important: Only use Claude Code with files you trust. Accessing untrusted files may pose security risks{" "}<Link url="https://code.claude.com/docs/en/security" />{" "}</Text>
+      <Select options={[
+        { label: "Yes, allow external imports", value: "yes" },
+        { label: "No, disable external imports", value: "no" },
+      ]} onChange={(value: string) => handleSelection(value as 'yes' | 'no')} />
+    </Dialog>
+  );
 }
 function _temp() {
   logEvent("tengu_claude_md_includes_dialog_shown", {});

--- a/src/components/ClaudeMdExternalIncludesDialog.tsx
+++ b/src/components/ClaudeMdExternalIncludesDialog.tsx
@@ -16,13 +16,13 @@ function acceptProject(current: any) {
   return { ...current, hasClaudeMdExternalIncludesApproved: true, hasClaudeMdExternalIncludesWarningShown: true };
 }
 function acceptUser(current: any) {
-  return { ...current, hasClaudeMdExternalIncludesApprovedForUser: true, hasClaudeMdExternalIncludesWarningShown: true };
+  return { ...current, hasClaudeMdExternalIncludesApprovedForUser: true, hasClaudeMdExternalIncludesWarningShownForUser: true };
 }
 function declineProject(current: any) {
   return { ...current, hasClaudeMdExternalIncludesApproved: false, hasClaudeMdExternalIncludesWarningShown: true };
 }
 function declineUser(current: any) {
-  return { ...current, hasClaudeMdExternalIncludesApprovedForUser: false, hasClaudeMdExternalIncludesWarningShown: true };
+  return { ...current, hasClaudeMdExternalIncludesApprovedForUser: false, hasClaudeMdExternalIncludesWarningShownForUser: true };
 }
 export function ClaudeMdExternalIncludesDialog(t0: Props) {
   const $ = _c(18);

--- a/src/components/Settings/Config.tsx
+++ b/src/components/Settings/Config.tsx
@@ -1553,7 +1553,7 @@ export function Config({
           <ClaudeMdExternalIncludesDialog onDone={() => {
         setShowSubmenu(null);
         setTabsHidden(false);
-      }} externalIncludes={getExternalClaudeMdIncludes(memoryFiles)} />
+      }} externalIncludes={getExternalClaudeMdIncludes(memoryFiles, ['Project', 'Local'])} scope="Project" />
           <Text dimColor>
             <Byline>
               <KeyboardShortcutHint shortcut="Enter" action="confirm" />

--- a/src/components/Settings/Config.tsx
+++ b/src/components/Settings/Config.tsx
@@ -201,8 +201,10 @@ export function Config({
   const memoryFiles = React.use(getMemoryFiles(true));
   function getPendingExternalIncludesScope(): 'User' | 'Project' | null {
     const cfg = getCurrentProjectConfig();
-    if (!cfg.hasClaudeMdExternalIncludesApprovedForUser && hasExternalClaudeMdIncludes(memoryFiles, ['User'])) return 'User';
-    if (!cfg.hasClaudeMdExternalIncludesApproved && hasExternalClaudeMdIncludes(memoryFiles, ['Project', 'Local'])) return 'Project';
+    // Project/Local first (mirrors startup priority in shouldShowClaudeMdExternalIncludesWarning)
+    if (!cfg.hasClaudeMdExternalIncludesApproved && !cfg.hasClaudeMdExternalIncludesWarningShown && hasExternalClaudeMdIncludes(memoryFiles, ['Project', 'Local'])) return 'Project';
+    // User second
+    if (!cfg.hasClaudeMdExternalIncludesApprovedForUser && !cfg.hasClaudeMdExternalIncludesWarningShownForUser && hasExternalClaudeMdIncludes(memoryFiles, ['User'])) return 'User';
     return null;
   }
   const pendingScope = getPendingExternalIncludesScope();

--- a/src/components/Settings/Config.tsx
+++ b/src/components/Settings/Config.tsx
@@ -198,7 +198,14 @@ export function Config({
   const isConnectedToIde = hasAccessToIDEExtensionDiffFeature(context.options.mcpClients);
   const isFileCheckpointingAvailable = !isEnvTruthy(process.env.CLAUDE_CODE_DISABLE_FILE_CHECKPOINTING);
   const memoryFiles = React.use(getMemoryFiles(true));
-  const shouldShowExternalIncludesToggle = hasExternalClaudeMdIncludes(memoryFiles);
+  function getPendingExternalIncludesScope(): 'User' | 'Project' | null {
+    const cfg = getCurrentProjectConfig();
+    if (!cfg.hasClaudeMdExternalIncludesApprovedForUser && hasExternalClaudeMdIncludes(memoryFiles, ['User'])) return 'User';
+    if (!cfg.hasClaudeMdExternalIncludesApproved && hasExternalClaudeMdIncludes(memoryFiles, ['Project', 'Local'])) return 'Project';
+    return null;
+  }
+  const pendingScope = getPendingExternalIncludesScope();
+  const shouldShowExternalIncludesToggle = pendingScope !== null;
   const autoUpdaterDisabledReason = getAutoUpdaterDisabledReason();
   function onChangeMainModelConfig(value: string | null): void {
     const previousModel = mainLoopModel;
@@ -1030,20 +1037,16 @@ export function Config({
         };
       });
     }
-  }] : []), ...(shouldShowExternalIncludesToggle ? [{
+  }] : []),   ...(shouldShowExternalIncludesToggle ? [{
     id: 'showExternalIncludesDialog',
-    label: 'External CLAUDE.md includes',
+    label: pendingScope === 'User' ? 'User CLAUDE.md external includes' : 'External CLAUDE.md includes',
     value: (() => {
-      const projectConfig = getCurrentProjectConfig();
-      if (projectConfig.hasClaudeMdExternalIncludesApproved) {
-        return 'true';
-      } else {
-        return 'false';
-      }
+      const cfg = getCurrentProjectConfig();
+      return cfg[pendingScope === 'User' ? 'hasClaudeMdExternalIncludesApprovedForUser' : 'hasClaudeMdExternalIncludesApproved'] ? 'true' : 'false';
     })(),
     type: 'managedEnum' as const,
     onChange() {
-      // Will be handled by toggleSetting function
+      // Handled by toggleSetting -> setShowSubmenu('ExternalIncludes')
     }
   }] : []), ...(process.env.ANTHROPIC_API_KEY && !isRunningOnHomespace() ? [{
     id: 'apiKey',
@@ -1578,11 +1581,11 @@ export function Config({
               <ConfigurableShortcutHint action="confirm:no" context="Confirmation" fallback="Esc" description="cancel" />
             </Byline>
           </Text>
-        </> : showSubmenu === 'ExternalIncludes' ? <>
+        </> : showSubmenu === 'ExternalIncludes' && pendingScope ? <>
           <ClaudeMdExternalIncludesDialog onDone={() => {
         setShowSubmenu(null);
         setTabsHidden(false);
-      }} externalIncludes={getExternalClaudeMdIncludes(memoryFiles, ['Project', 'Local'])} scope="Project" />
+      }} externalIncludes={getExternalClaudeMdIncludes(memoryFiles, pendingScope === 'User' ? ['User'] : ['Project', 'Local'])} scope={pendingScope} />
           <Text dimColor>
             <Byline>
               <KeyboardShortcutHint shortcut="Enter" action="confirm" />

--- a/src/components/Settings/Config.tsx
+++ b/src/components/Settings/Config.tsx
@@ -1582,7 +1582,7 @@ export function Config({
           <ClaudeMdExternalIncludesDialog onDone={() => {
         setShowSubmenu(null);
         setTabsHidden(false);
-      }} externalIncludes={getExternalClaudeMdIncludes(memoryFiles)} />
+      }} externalIncludes={getExternalClaudeMdIncludes(memoryFiles, ['Project', 'Local'])} scope="Project" />
           <Text dimColor>
             <Byline>
               <KeyboardShortcutHint shortcut="Enter" action="confirm" />

--- a/src/components/Settings/Config.tsx
+++ b/src/components/Settings/Config.tsx
@@ -199,7 +199,14 @@ export function Config({
   const isConnectedToIde = hasAccessToIDEExtensionDiffFeature(context.options.mcpClients);
   const isFileCheckpointingAvailable = !isEnvTruthy(process.env.CLAUDE_CODE_DISABLE_FILE_CHECKPOINTING);
   const memoryFiles = React.use(getMemoryFiles(true));
-  const shouldShowExternalIncludesToggle = hasExternalClaudeMdIncludes(memoryFiles);
+  function getPendingExternalIncludesScope(): 'User' | 'Project' | null {
+    const cfg = getCurrentProjectConfig();
+    if (!cfg.hasClaudeMdExternalIncludesApprovedForUser && hasExternalClaudeMdIncludes(memoryFiles, ['User'])) return 'User';
+    if (!cfg.hasClaudeMdExternalIncludesApproved && hasExternalClaudeMdIncludes(memoryFiles, ['Project', 'Local'])) return 'Project';
+    return null;
+  }
+  const pendingScope = getPendingExternalIncludesScope();
+  const shouldShowExternalIncludesToggle = pendingScope !== null;
   const autoUpdaterDisabledReason = getAutoUpdaterDisabledReason();
   function onChangeMainModelConfig(value: string | null): void {
     const previousModel = mainLoopModel;
@@ -1001,20 +1008,16 @@ export function Config({
         };
       });
     }
-  }] : []), ...(shouldShowExternalIncludesToggle ? [{
+  }] : []),   ...(shouldShowExternalIncludesToggle ? [{
     id: 'showExternalIncludesDialog',
-    label: 'External CLAUDE.md includes',
+    label: pendingScope === 'User' ? 'User CLAUDE.md external includes' : 'External CLAUDE.md includes',
     value: (() => {
-      const projectConfig = getCurrentProjectConfig();
-      if (projectConfig.hasClaudeMdExternalIncludesApproved) {
-        return 'true';
-      } else {
-        return 'false';
-      }
+      const cfg = getCurrentProjectConfig();
+      return cfg[pendingScope === 'User' ? 'hasClaudeMdExternalIncludesApprovedForUser' : 'hasClaudeMdExternalIncludesApproved'] ? 'true' : 'false';
     })(),
     type: 'managedEnum' as const,
     onChange() {
-      // Will be handled by toggleSetting function
+      // Handled by toggleSetting -> setShowSubmenu('ExternalIncludes')
     }
   }] : []), ...(process.env.ANTHROPIC_API_KEY && !isRunningOnHomespace() ? [{
     id: 'apiKey',
@@ -1549,11 +1552,11 @@ export function Config({
               <ConfigurableShortcutHint action="confirm:no" context="Confirmation" fallback="Esc" description="cancel" />
             </Byline>
           </Text>
-        </> : showSubmenu === 'ExternalIncludes' ? <>
+        </> : showSubmenu === 'ExternalIncludes' && pendingScope ? <>
           <ClaudeMdExternalIncludesDialog onDone={() => {
         setShowSubmenu(null);
         setTabsHidden(false);
-      }} externalIncludes={getExternalClaudeMdIncludes(memoryFiles, ['Project', 'Local'])} scope="Project" />
+      }} externalIncludes={getExternalClaudeMdIncludes(memoryFiles, pendingScope === 'User' ? ['User'] : ['Project', 'Local'])} scope={pendingScope} />
           <Text dimColor>
             <Byline>
               <KeyboardShortcutHint shortcut="Enter" action="confirm" />

--- a/src/components/Settings/Config.tsx
+++ b/src/components/Settings/Config.tsx
@@ -200,8 +200,10 @@ export function Config({
   const memoryFiles = React.use(getMemoryFiles(true));
   function getPendingExternalIncludesScope(): 'User' | 'Project' | null {
     const cfg = getCurrentProjectConfig();
-    if (!cfg.hasClaudeMdExternalIncludesApprovedForUser && hasExternalClaudeMdIncludes(memoryFiles, ['User'])) return 'User';
-    if (!cfg.hasClaudeMdExternalIncludesApproved && hasExternalClaudeMdIncludes(memoryFiles, ['Project', 'Local'])) return 'Project';
+    // Project/Local first (mirrors startup priority in shouldShowClaudeMdExternalIncludesWarning)
+    if (!cfg.hasClaudeMdExternalIncludesApproved && !cfg.hasClaudeMdExternalIncludesWarningShown && hasExternalClaudeMdIncludes(memoryFiles, ['Project', 'Local'])) return 'Project';
+    // User second
+    if (!cfg.hasClaudeMdExternalIncludesApprovedForUser && !cfg.hasClaudeMdExternalIncludesWarningShownForUser && hasExternalClaudeMdIncludes(memoryFiles, ['User'])) return 'User';
     return null;
   }
   const pendingScope = getPendingExternalIncludesScope();

--- a/src/interactiveHelpers.tsx
+++ b/src/interactiveHelpers.tsx
@@ -172,12 +172,16 @@ export async function showSetupScreens(root: Root, permissionMode: PermissionMod
     }
 
     // Check for claude.md includes that need approval
-    if (await shouldShowClaudeMdExternalIncludesWarning()) {
-      const externalIncludes = getExternalClaudeMdIncludes(await getMemoryFiles(true));
+    const warningScope = await shouldShowClaudeMdExternalIncludesWarning()
+    if (warningScope !== 'None') {
+      const files = await getMemoryFiles(true);
+      const externalIncludes = warningScope === 'User'
+        ? getExternalClaudeMdIncludes(files, ['User'])
+        : getExternalClaudeMdIncludes(files, ['Project', 'Local']);
       const {
         ClaudeMdExternalIncludesDialog
       } = await import('./components/ClaudeMdExternalIncludesDialog.js');
-      await showSetupDialog(root, done => <ClaudeMdExternalIncludesDialog onDone={done} isStandaloneDialog externalIncludes={externalIncludes} />);
+      await showSetupDialog(root, done => <ClaudeMdExternalIncludesDialog onDone={done} isStandaloneDialog externalIncludes={externalIncludes} scope={warningScope} />);
     }
   }
 

--- a/src/interactiveHelpers.tsx
+++ b/src/interactiveHelpers.tsx
@@ -171,12 +171,16 @@ export async function showSetupScreens(root: Root, permissionMode: PermissionMod
     }
 
     // Check for claude.md includes that need approval
-    if (await shouldShowClaudeMdExternalIncludesWarning()) {
-      const externalIncludes = getExternalClaudeMdIncludes(await getMemoryFiles(true));
+    const warningScope = await shouldShowClaudeMdExternalIncludesWarning()
+    if (warningScope !== 'None') {
+      const files = await getMemoryFiles(true);
+      const externalIncludes = warningScope === 'User'
+        ? getExternalClaudeMdIncludes(files, ['User'])
+        : getExternalClaudeMdIncludes(files, ['Project', 'Local']);
       const {
         ClaudeMdExternalIncludesDialog
       } = await import('./components/ClaudeMdExternalIncludesDialog.js');
-      await showSetupDialog(root, done => <ClaudeMdExternalIncludesDialog onDone={done} isStandaloneDialog externalIncludes={externalIncludes} />);
+      await showSetupDialog(root, done => <ClaudeMdExternalIncludesDialog onDone={done} isStandaloneDialog externalIncludes={externalIncludes} scope={warningScope} />);
     }
   }
 

--- a/src/utils/claudemd.ts
+++ b/src/utils/claudemd.ts
@@ -1231,6 +1231,7 @@ export async function getManagedAndUserConditionalRules(
   processedPaths: Set<string>,
 ): Promise<MemoryFileInfo[]> {
   const result: MemoryFileInfo[] = []
+  const config = getCurrentProjectConfig()
 
   // Process Managed conditional .claude/rules/*.md files
   const managedClaudeRulesDir = getManagedClaudeRulesDir()
@@ -1246,14 +1247,18 @@ export async function getManagedAndUserConditionalRules(
 
   if (isSettingSourceEnabled('userSettings')) {
     // Process User conditional .claude/rules/*.md files
+    // Gate external includes through the same User-scope approval flag
+    // as unconditional User rules, so declining approval blocks the
+    // conditional path too.
     const userClaudeRulesDir = getUserClaudeRulesDir()
+    const includeExternalForUser = config.hasClaudeMdExternalIncludesApprovedForUser ?? false
     result.push(
       ...(await processConditionedMdRules(
         targetPath,
         userClaudeRulesDir,
         'User',
         processedPaths,
-        true,
+        includeExternalForUser,
       )),
     )
   }

--- a/src/utils/claudemd.ts
+++ b/src/utils/claudemd.ts
@@ -813,6 +813,10 @@ export const getMemoryFiles = memoize(
       forceIncludeExternal ||
       config.hasClaudeMdExternalIncludesApproved ||
       false
+    const includeExternalForUser =
+      forceIncludeExternal ||
+      config.hasClaudeMdExternalIncludesApprovedForUser ||
+      false
 
     // Process Managed file first (always loaded - policy settings)
     const managedClaudeMd = getMemoryPath('Managed')
@@ -844,7 +848,7 @@ export const getMemoryFiles = memoize(
           userClaudeMd,
           'User',
           processedPaths,
-          includeExternal, // Global external-includes gate (line 812)
+          includeExternalForUser, // User-scope external-includes gate
         )),
       )
       // Process User ~/.claude/rules/*.md files
@@ -854,7 +858,7 @@ export const getMemoryFiles = memoize(
           rulesDir: userClaudeRulesDir,
           type: 'User',
           processedPaths,
-           includeExternal,
+          includeExternal: includeExternalForUser, // User-scope external-includes gate
           conditionalRule: false,
         })),
       )
@@ -1426,9 +1430,11 @@ export type ExternalClaudeMdInclude = {
 
 export function getExternalClaudeMdIncludes(
   files: MemoryFileInfo[],
+  types?: MemoryType[],
 ): ExternalClaudeMdInclude[] {
   const externals: ExternalClaudeMdInclude[] = []
   for (const file of files) {
+    if (types && !types.includes(file.type)) continue
     if (file.parent && !pathInOriginalCwd(file.path)) {
       externals.push({ path: file.path, parent: file.parent })
     }
@@ -1436,20 +1442,27 @@ export function getExternalClaudeMdIncludes(
   return externals
 }
 
-export function hasExternalClaudeMdIncludes(files: MemoryFileInfo[]): boolean {
-  return getExternalClaudeMdIncludes(files).length > 0
+export function hasExternalClaudeMdIncludes(files: MemoryFileInfo[], types?: MemoryType[]): boolean {
+  return getExternalClaudeMdIncludes(files, types).length > 0
 }
 
-export async function shouldShowClaudeMdExternalIncludesWarning(): Promise<boolean> {
-  const config = getCurrentProjectConfig()
-  if (
-    config.hasClaudeMdExternalIncludesApproved ||
-    config.hasClaudeMdExternalIncludesWarningShown
-  ) {
-    return false
-  }
+export type ExternalIncludesScope = 'User' | 'Project' | 'None'
 
-  return hasExternalClaudeMdIncludes(await getMemoryFiles(true))
+export async function shouldShowClaudeMdExternalIncludesWarning(): Promise<ExternalIncludesScope> {
+  const config = getCurrentProjectConfig()
+  const files = await getMemoryFiles(true)
+
+  const hasProjectExternals =
+    !config.hasClaudeMdExternalIncludesApproved &&
+    hasExternalClaudeMdIncludes(files, ['Project', 'Local'])
+
+  const hasUserExternals =
+    !config.hasClaudeMdExternalIncludesApprovedForUser &&
+    hasExternalClaudeMdIncludes(files, ['User'])
+
+  if (hasProjectExternals) return 'Project'
+  if (hasUserExternals) return 'User'
+  return 'None'
 }
 
 /**

--- a/src/utils/claudemd.ts
+++ b/src/utils/claudemd.ts
@@ -844,7 +844,7 @@ export const getMemoryFiles = memoize(
           userClaudeMd,
           'User',
           processedPaths,
-          true, // User memory can always include external files
+          includeExternal, // Global external-includes gate (line 812)
         )),
       )
       // Process User ~/.claude/rules/*.md files
@@ -854,7 +854,7 @@ export const getMemoryFiles = memoize(
           rulesDir: userClaudeRulesDir,
           type: 'User',
           processedPaths,
-          includeExternal: true,
+           includeExternal,
           conditionalRule: false,
         })),
       )

--- a/src/utils/claudemd.ts
+++ b/src/utils/claudemd.ts
@@ -1454,10 +1454,12 @@ export async function shouldShowClaudeMdExternalIncludesWarning(): Promise<Exter
 
   const hasProjectExternals =
     !config.hasClaudeMdExternalIncludesApproved &&
+    !config.hasClaudeMdExternalIncludesWarningShown &&
     hasExternalClaudeMdIncludes(files, ['Project', 'Local'])
 
   const hasUserExternals =
     !config.hasClaudeMdExternalIncludesApprovedForUser &&
+    !config.hasClaudeMdExternalIncludesWarningShownForUser &&
     hasExternalClaudeMdIncludes(files, ['User'])
 
   if (hasProjectExternals) return 'Project'

--- a/src/utils/claudemd.ts
+++ b/src/utils/claudemd.ts
@@ -1429,7 +1429,7 @@ export function getExternalClaudeMdIncludes(
 ): ExternalClaudeMdInclude[] {
   const externals: ExternalClaudeMdInclude[] = []
   for (const file of files) {
-    if (file.type !== 'User' && file.parent && !pathInOriginalCwd(file.path)) {
+    if (file.parent && !pathInOriginalCwd(file.path)) {
       externals.push({ path: file.path, parent: file.parent })
     }
   }

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -116,6 +116,7 @@ export type ProjectConfig = {
   hasClaudeMdExternalIncludesApproved?: boolean
   hasClaudeMdExternalIncludesApprovedForUser?: boolean
   hasClaudeMdExternalIncludesWarningShown?: boolean
+  hasClaudeMdExternalIncludesWarningShownForUser?: boolean
   // MCP server approval fields - migrated to settings but kept for backward compatibility
   enabledMcpjsonServers?: string[]
   disabledMcpjsonServers?: string[]
@@ -148,6 +149,7 @@ const DEFAULT_PROJECT_CONFIG: ProjectConfig = {
   hasClaudeMdExternalIncludesApproved: false,
   hasClaudeMdExternalIncludesApprovedForUser: false,
   hasClaudeMdExternalIncludesWarningShown: false,
+  hasClaudeMdExternalIncludesWarningShownForUser: false,
 }
 
 export type InstallMethod = 'local' | 'native' | 'global' | 'unknown'

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -114,6 +114,7 @@ export type ProjectConfig = {
   hasCompletedProjectOnboarding?: boolean
   projectOnboardingSeenCount: number
   hasClaudeMdExternalIncludesApproved?: boolean
+  hasClaudeMdExternalIncludesApprovedForUser?: boolean
   hasClaudeMdExternalIncludesWarningShown?: boolean
   // MCP server approval fields - migrated to settings but kept for backward compatibility
   enabledMcpjsonServers?: string[]
@@ -145,6 +146,7 @@ const DEFAULT_PROJECT_CONFIG: ProjectConfig = {
   hasTrustDialogAccepted: false,
   projectOnboardingSeenCount: 0,
   hasClaudeMdExternalIncludesApproved: false,
+  hasClaudeMdExternalIncludesApprovedForUser: false,
   hasClaudeMdExternalIncludesWarningShown: false,
 }
 


### PR DESCRIPTION
Summary
- What changed — src/utils/claudemd.ts lines 847 and 857. In getMemoryFiles() the User-scope processMemoryFile() call and the processMdRules() call for ~/.claude/rules/*.md both passed includeExternal: true verbatim. Changed both to pass includeExternal, which is derived from config.hasClaudeMdExternalIncludesApproved || forceIncludeExternal || false at line 812–815.

- Why it changed — The explicit true hardcoded the gate to always open for User memory, regardless of the user's preference. Project- and Local-scope memory already honoured the gate; only User-scope bypassed it. The flow was:
  1. includeExternal is set at the top of getMemoryFiles() by checking config.hasClaudeMdExternalIncludesApproved.  
  2. Managed and Project memory consume this value correctly.  
  3. User memory ignored it and forced true unconditionally.  
  The fix removes the hardcoded override so all three scopes share the same approval gate.

Impact
- user-facing — Users who have not approved external @include in their config will now see the approval prompt when their ~/.claude/CLAUDE.md or ~/.claude/rules/*.md references an external file. Previously that prompt never appeared for User memory, allowing a malicious repo or symlink to read arbitrary files silently.
- developer/maintainer — Two-line, no-signature-change patch. The includeExternal variable is already in scope and already used on all other memory paths. No new exports, no new config keys, no behavioural change for users who have already approved external includes.

Testing
- [ ] bun run build
- [ ] bun run smoke
- focused tests:
  1. Set hasClaudeMdExternalIncludesApproved = false in config. Add @include /etc/hostname to ~/.claude/CLAUDE.md. Call getMemoryFiles() — the external file must not be loaded.
  2. Set hasClaudeMdExternalIncludesApproved = true. Repeat — the external file must be loaded.
  3. Repeat steps 1–2 for a ~/.claude/rules/external.md that uses @include. Confirm the same gating applies.

Notes
- provider/model path tested — memory file loading; no provider or model involved.
- screenshots — none.
- follow-up / known limitations — The config default remains false (unchanged). Users upgrading from a version where the bypass existed will see the approval prompt for the first time; no silent behaviour change is introduced for already-approved configs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * External Claude.md imports now support separate approval controls for user-level and project-level includes, providing more granular configuration management and scope-specific warning messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->