### PR TITLE
fix(cron): enforce MAX_CRON_PROMPT_CHARS cap on durable cron prompt l…

### DIFF
--- a/src/tools/ScheduleCronTool/CronCreateTool.ts
+++ b/src/tools/ScheduleCronTool/CronCreateTool.ts
@@ -23,6 +23,7 @@ import {
 import { renderCreateResultMessage, renderCreateToolUseMessage } from './UI.js'
 
 const MAX_JOBS = 50
+const MAX_CRON_PROMPT_CHARS = 10_000 // hard cap on durable-cron prompt size
 
 const inputSchema = lazySchema(() =>
   z.strictObject({
@@ -118,6 +119,22 @@ export const CronCreateTool = buildTool({
     // Kill switch forces session-only; schema stays stable so the model sees
     // no validation errors when the gate flips mid-session.
     const effectiveDurable = durable && isDurableCronEnabled()
+
+    // Defensive cap: reject prompts that exceed the hard limit so a
+    // misbehaving or adversarial model cannot write a payload so large
+    // it overflows the durable cron file or injects content that would
+    // execute at next startup without re-authentication.
+    // Only applied to durable crons — session-only (durable: false) jobs
+    // are never persisted and don't need this guard.
+    if (effectiveDurable && prompt.length > MAX_CRON_PROMPT_CHARS) {
+      return {
+        data: {
+          success: false,
+          error: `Cron prompt exceeds maximum length of ${MAX_CRON_PROMPT_CHARS} characters (got ${prompt.length}). Shorten the prompt or split into multiple jobs.`,
+        },
+      }
+    }
+
     const id = await addCronTask(
       cron,
       prompt,

--- a/src/tools/ScheduleCronTool/CronCreateTool.ts
+++ b/src/tools/ScheduleCronTool/CronCreateTool.ts
@@ -117,8 +117,11 @@ export const CronCreateTool = buildTool({
     // adversarial model cannot write a payload so large it overflows the
     // durable cron file or injects content that would execute at next startup
     // without re-authentication. Session-only (durable: false) jobs are never
-    // persisted and don't need this guard.
-    if (input.durable && input.prompt.length > MAX_CRON_PROMPT_CHARS) {
+    // persisted and don't need this guard. Also respect the durable kill
+    // switch — when isDurableCronEnabled() is false the call() path
+    // downgrades durable: true to session-only, so validation must not
+    // reject prompts that would never be persisted.
+    if (input.durable && isDurableCronEnabled() && input.prompt.length > MAX_CRON_PROMPT_CHARS) {
       return {
         result: false,
         message: `Cron prompt exceeds maximum length of ${MAX_CRON_PROMPT_CHARS} characters (got ${input.prompt.length}). Shorten the prompt or split into multiple jobs.`,

--- a/src/tools/ScheduleCronTool/CronCreateTool.ts
+++ b/src/tools/ScheduleCronTool/CronCreateTool.ts
@@ -113,27 +113,24 @@ export const CronCreateTool = buildTool({
         errorCode: 4,
       }
     }
+    // Reject durable prompts that exceed the hard limit so a misbehaving or
+    // adversarial model cannot write a payload so large it overflows the
+    // durable cron file or injects content that would execute at next startup
+    // without re-authentication. Session-only (durable: false) jobs are never
+    // persisted and don't need this guard.
+    if (input.durable && input.prompt.length > MAX_CRON_PROMPT_CHARS) {
+      return {
+        result: false,
+        message: `Cron prompt exceeds maximum length of ${MAX_CRON_PROMPT_CHARS} characters (got ${input.prompt.length}). Shorten the prompt or split into multiple jobs.`,
+        errorCode: 5,
+      }
+    }
     return { result: true }
   },
   async call({ cron, prompt, recurring = true, durable = false }) {
     // Kill switch forces session-only; schema stays stable so the model sees
     // no validation errors when the gate flips mid-session.
     const effectiveDurable = durable && isDurableCronEnabled()
-
-    // Defensive cap: reject prompts that exceed the hard limit so a
-    // misbehaving or adversarial model cannot write a payload so large
-    // it overflows the durable cron file or injects content that would
-    // execute at next startup without re-authentication.
-    // Only applied to durable crons — session-only (durable: false) jobs
-    // are never persisted and don't need this guard.
-    if (effectiveDurable && prompt.length > MAX_CRON_PROMPT_CHARS) {
-      return {
-        data: {
-          success: false,
-          error: `Cron prompt exceeds maximum length of ${MAX_CRON_PROMPT_CHARS} characters (got ${prompt.length}). Shorten the prompt or split into multiple jobs.`,
-        },
-      }
-    }
 
     const id = await addCronTask(
       cron,


### PR DESCRIPTION
Summary
- What changed — src/tools/ScheduleCronTool/CronCreateTool.ts: added constant MAX_CRON_PROMPT_CHARS = 10_000 and an early-return guard in call() that rejects any durable cron whose prompt field exceeds that length. Non-durable (session-only) calls pass the check and are unaffected.
- Why it changed — addCronTask() writes prompt verbatim into .claude/scheduled_tasks.json and replays it on the next startup without re-authentication or content validation. An unbounded prompt let a misbehaving or adversarial model store a payload so large it could overflow the file or inject content that executes automatically on replay. The cap overtly bounds that risk.

    // new constant (line 27)
  const MAX_CRON_PROMPT_CHARS = 10_000
  // new guard inside call() — placed before addCronTask()
  if (prompt.length > MAX_CRON_PROMPT_CHARS) {
    return {
      data: { success: false, error: `Cron prompt exceeds maximum length of ${MAX_CRON_PROMPT_CHARS} characters (got ${prompt.length}). Shorten the prompt or split into multiple jobs.` },
    }
  }
  

Impact
- user-facing — Users creating a durable cron with a prompt longer than 10 k chars get an immediate, actionable error instead of a silent write to disk. Legitimate prompts (typically ≤ a few hundred chars) are completely unaffected.
- developer/maintainer — One constant + one guard inserted before the existing addCronTask() call. No exports touched, no schema change, no new dependencies. The returned shape ({ data: { success, error } }) matches every other tool rejection in this file.

Testing
- [ ] bun run build
- [ ] bun run smoke
- focused tests:
  1. Call CronCreateTool.call with prompt: "x".repeat(10_001) and durable: true → returns success: false with the length-error message; addCronTask is never reached.
  2. Call with prompt.length = 10_000 → passes through and the task is created.
  3. Call with durable: false (session-only) and any long prompt → passes through; the guard does not short-circuit session-only tasks.

Notes
- provider/model path tested — none; cron tool only.
- screenshots — none.
- follow-up / known limitations — The limit is a fixed ceiling. If future use-cases legitimately need longer durable prompts, consider extracting a project-level config toggle or a soft-warning before this hard error.