### PR TITLE
feat(settings): per-model context_window and max_output_tokens overrides

### DIFF
--- a/docs/advanced-setup.md
+++ b/docs/advanced-setup.md
@@ -402,6 +402,34 @@ Model env vars are provider-scoped: first-party Anthropic sessions read
 `GEMINI_MODEL`, and Mistral reads `MISTRAL_MODEL`. For manual Bedrock, Vertex,
 or Foundry launches, select the model with `--model`.
 
+### Per-model limit overrides (`settings.json`)
+
+When a custom OpenAI-compatible provider does not expose context metadata from
+`/v1/models`, you can pin a model's context window and max output tokens. In
+addition to the `CLAUDE_CODE_OPENAI_CONTEXT_WINDOWS` /
+`CLAUDE_CODE_OPENAI_MAX_OUTPUT_TOKENS` env vars above, you can set a
+`modelLimits` map in your `settings.json` (the same file `/config` writes, e.g.
+`~/.openclaude/settings.json`):
+
+```json
+{
+  "modelLimits": {
+    "my-custom-deployment": { "contextWindow": 262144, "maxOutputTokens": 32768 },
+    "api.private-llm.test:my-custom-deployment": { "contextWindow": 1000000 }
+  }
+}
+```
+
+- **Key matching** — keys match the model api-name exactly, or by prefix (e.g.
+  `my-custom` matches `my-custom-deployment-v2`). A host-qualified key
+  (`<host>:<model>`, where `<host>` is the `OPENAI_BASE_URL` hostname) wins over
+  a bare model key, so the same model name on two endpoints can carry different
+  limits. Either field may be omitted to override only one limit.
+- **Precedence** — env-var overrides (exact, then prefix) win over `modelLimits`,
+  which in turn wins over the built-in catalog / discovery-cache values, which
+  win over the descriptor default. So an env override always takes priority, and
+  `modelLimits` only applies where no env override is set.
+
 ## Runtime Hardening
 
 Use these commands to validate your setup and catch mistakes early:

--- a/docs/advanced-setup.md
+++ b/docs/advanced-setup.md
@@ -378,6 +378,7 @@ The **OpenClaude VS Code extension** can store the key in Secret Storage and set
 | `OPENAI_API_BASE` | No | Compatibility alias for `OPENAI_BASE_URL` |
 | `OPENCLAUDE_OLLAMA_NUM_CTX` | Ollama only | Request-level Ollama context window. Defaults to `32768`; set a larger value for longer same-session history if your model and hardware can handle it. |
 | `CLAUDE_CODE_OPENAI_CONTEXT_WINDOWS` | No | JSON map of OpenAI-compatible model names to context windows, such as `{"custom-model":1000000}`. Use this when a custom provider does not expose context metadata from `/v1/models`. |
+| `CLAUDE_CODE_OPENAI_MAX_OUTPUT_TOKENS` | No | JSON map of OpenAI-compatible model names to max output tokens, such as `{"custom-model":32768}`. Use this when a custom provider does not expose output-limit metadata from `/v1/models`. |
 | `OPENCODE_API_KEY` | OpenCode Zen / Go | Shared API key for OpenCode Zen (pay-as-you-go) and OpenCode Go (subscription); get yours from https://opencode.ai |
 | `MIMO_API_KEY` | Xiaomi MiMo route | Xiaomi MiMo API key for `https://api.xiaomimimo.com/v1`; mirrored into the OpenAI-compatible auth env when the MiMo route is active |
 | `CLAUDE_CODE_USE_GEMINI` | Gemini only | Set to `1` to enable the direct Gemini provider path |

--- a/docs/advanced-setup.md
+++ b/docs/advanced-setup.md
@@ -422,10 +422,14 @@ addition to the `CLAUDE_CODE_OPENAI_CONTEXT_WINDOWS` /
 ```
 
 - **Key matching** — keys match the model api-name exactly, or by prefix (e.g.
-  `my-custom` matches `my-custom-deployment-v2`). A host-qualified key
-  (`<host>:<model>`, where `<host>` is the `OPENAI_BASE_URL` hostname) wins over
-  a bare model key, so the same model name on two endpoints can carry different
-  limits. Either field may be omitted to override only one limit.
+  `my-custom` matches `my-custom-deployment-v2`). An **exact** key always wins
+  over a **prefix** key. A host-qualified key (`<host>:<model>`, where `<host>`
+  is the `OPENAI_BASE_URL` hostname) only wins over a bare key **within the same
+  match kind** — a host-qualified exact key beats a bare exact key, and a
+  host-qualified prefix beats a bare prefix, but a bare exact key still beats a
+  host-qualified prefix. So to give the same model different limits per endpoint,
+  use host-qualified **exact** keys for each endpoint. Either field may be
+  omitted to override only one limit.
 - **Precedence** — from highest to lowest: an **exact** env-var override → the
   built-in catalog / discovery-cache value → a **prefix** env-var override →
   `modelLimits` → the descriptor default. So env-var overrides always win over

--- a/docs/advanced-setup.md
+++ b/docs/advanced-setup.md
@@ -423,16 +423,19 @@ addition to the `CLAUDE_CODE_OPENAI_CONTEXT_WINDOWS` /
 
 - **Key matching** — keys match the model api-name exactly, or by prefix (e.g.
   `my-custom` matches `my-custom-deployment-v2`). An **exact** key always wins
-  over a **prefix** key. A host-qualified key (`<host>:<model>`, where `<host>`
-  is the `OPENAI_BASE_URL` hostname) only wins over a bare key **within the same
-  match kind** — a host-qualified exact key beats a bare exact key, and a
-  host-qualified prefix beats a bare prefix, but a bare exact key still beats a
-  host-qualified prefix. So to give the same model different limits per endpoint,
-  use host-qualified **exact** keys for each endpoint. Either field may be
+  over a **prefix** key. A host-qualified key (`<host>:<model>`) only wins over a
+  bare key **within the same match kind** — a host-qualified exact key beats a
+  bare exact key, and a host-qualified prefix beats a bare prefix, but a bare
+  exact key still beats a host-qualified prefix. So to give the same model
+  different limits per endpoint, use host-qualified **exact** keys for each
+  endpoint. `<host>` is the `OPENAI_BASE_URL` host **including the port when the
+  URL has one** (`new URL(baseUrl).host`): for `http://localhost:4000/v1` the
+  key is `localhost:4000:my-model`, not `localhost:my-model`. Either field may be
   omitted to override only one limit.
 - **Precedence** — from highest to lowest: an **exact** env-var override → the
-  built-in catalog / discovery-cache value → a **prefix** env-var override →
-  `modelLimits` → the descriptor default. So env-var overrides always win over
+  built-in catalog value → the discovery-cache value → a **prefix** env-var
+  override → `modelLimits` → the descriptor default. (The built-in catalog is
+  checked before the discovery cache.) So env-var overrides always win over
   `modelLimits`, and `modelLimits` mainly fills in models that have no built-in
   metadata (a known catalog model keeps its catalog limit unless you set an
   *exact* env override for it).

--- a/docs/advanced-setup.md
+++ b/docs/advanced-setup.md
@@ -425,10 +425,12 @@ addition to the `CLAUDE_CODE_OPENAI_CONTEXT_WINDOWS` /
   (`<host>:<model>`, where `<host>` is the `OPENAI_BASE_URL` hostname) wins over
   a bare model key, so the same model name on two endpoints can carry different
   limits. Either field may be omitted to override only one limit.
-- **Precedence** — env-var overrides (exact, then prefix) win over `modelLimits`,
-  which in turn wins over the built-in catalog / discovery-cache values, which
-  win over the descriptor default. So an env override always takes priority, and
-  `modelLimits` only applies where no env override is set.
+- **Precedence** — from highest to lowest: an **exact** env-var override → the
+  built-in catalog / discovery-cache value → a **prefix** env-var override →
+  `modelLimits` → the descriptor default. So env-var overrides always win over
+  `modelLimits`, and `modelLimits` mainly fills in models that have no built-in
+  metadata (a known catalog model keeps its catalog limit unless you set an
+  *exact* env override for it).
 
 ## Runtime Hardening
 

--- a/docs/integrations/common-pitfalls.md
+++ b/docs/integrations/common-pitfalls.md
@@ -138,9 +138,9 @@ Adding built-in context or output limits to
 
 Safer rule:
 Put built-in model metadata in `src/integrations/models/`. Keep
-`openaiContextWindows.ts` focused on documented env overrides such as
-`CLAUDE_CODE_OPENAI_CONTEXT_WINDOWS` and
-`CLAUDE_CODE_OPENAI_MAX_OUTPUT_TOKENS`.
+`openaiContextWindows.ts` focused on documented user overrides — the
+`CLAUDE_CODE_OPENAI_CONTEXT_WINDOWS` / `CLAUDE_CODE_OPENAI_MAX_OUTPUT_TOKENS`
+env vars and the `settings.json` `modelLimits` map — not a built-in table.
 
 ## Pitfall 13: Forgetting the compatibility layer
 

--- a/docs/integrations/how-to/add-model.md
+++ b/docs/integrations/how-to/add-model.md
@@ -179,13 +179,16 @@ Model lookup should prefer:
    `modelDescriptorId`;
 3. global shared model descriptors under `src/integrations/models/` for legacy
    and custom OpenAI-compatible model names;
-4. documented env overrides from `src/utils/model/openaiContextWindows.ts`
-   (`CLAUDE_CODE_OPENAI_CONTEXT_WINDOWS` and
-   `CLAUDE_CODE_OPENAI_MAX_OUTPUT_TOKENS`).
+4. documented user overrides from `src/utils/model/openaiContextWindows.ts` —
+   the `CLAUDE_CODE_OPENAI_CONTEXT_WINDOWS` / `CLAUDE_CODE_OPENAI_MAX_OUTPUT_TOKENS`
+   env vars and the `modelLimits` map in `settings.json` (see the
+   `modelLimits` section in `docs/advanced-setup.md` for key matching and
+   precedence).
 
-`openaiContextWindows.ts` is compatibility glue for user-provided env
-overrides. It should not grow a second built-in model table. Built-in model
-limits belong in model descriptor files.
+`openaiContextWindows.ts` is compatibility glue for user-provided overrides
+(env vars and the `settings.json` `modelLimits` map). It should not grow a
+second built-in model table. Built-in model limits belong in model descriptor
+files.
 
 ## What not to do
 

--- a/src/integrations/runtimeMetadata.modelLimits.test.ts
+++ b/src/integrations/runtimeMetadata.modelLimits.test.ts
@@ -1,0 +1,130 @@
+import { afterEach, beforeEach, expect, mock, test } from 'bun:test'
+import {
+  acquireSharedMutationLock,
+  releaseSharedMutationLock,
+} from '../test/sharedMutationLock.js'
+
+// Integration coverage for the `modelLimits` settings override flowing through
+// the real runtime resolution path (CodeRabbit review on PR #1164/#1234). The
+// per-symbol tests in openaiContextWindows.test.ts exercise the lookup helpers
+// directly; this drives the full chain via resolveModelRuntimeLimits, which is
+// what runtime code actually calls. It also confirms the settings fallback is
+// reached (resolveModelRuntimeLimits calls the settings-aware
+// getOpenAIContextWindow / getOpenAIMaxOutputTokens, not a settings-blind
+// variant) for prefix and host-qualified keys, and that env overrides win.
+
+type ConfigShape = {
+  modelLimits?: Record<
+    string,
+    { contextWindow?: number; maxOutputTokens?: number } | null
+  > | null
+}
+
+let mockConfig: ConfigShape = {}
+// Gate the getGlobalConfig override so the process-global mock.module is a
+// transparent passthrough to the real config whenever this suite is not the one
+// running — otherwise a later integrations test that reads getGlobalConfig()
+// would see this suite's stub config leak in.
+let configOverrideActive = false
+let realConfigModule: typeof import('../utils/config.js') | undefined
+
+beforeEach(async () => {
+  await acquireSharedMutationLock('integrations/runtimeMetadata.modelLimits.test.ts')
+  mock.restore()
+  mockConfig = {}
+  realConfigModule ??= (await import(
+    `../utils/config.js?modelLimitsReal=${Date.now()}-${Math.random()}`
+  )) as typeof import('../utils/config.js')
+  const real = realConfigModule
+  mock.module('../utils/config.js', () => ({
+    ...real,
+    getGlobalConfig: () =>
+      configOverrideActive ? mockConfig : real.getGlobalConfig(),
+  }))
+  configOverrideActive = true
+})
+
+afterEach(() => {
+  try {
+    mock.restore()
+    configOverrideActive = false
+  } finally {
+    releaseSharedMutationLock()
+  }
+})
+
+async function importFresh() {
+  const nonce = `${Date.now()}-${Math.random()}`
+  return import(`./runtimeMetadata.js?ts=${nonce}`)
+}
+
+test('resolveModelRuntimeLimits resolves settings modelLimits for an exact model key', async () => {
+  mockConfig = {
+    modelLimits: {
+      'my-custom-deployment': { contextWindow: 123_456, maxOutputTokens: 4_096 },
+    },
+  }
+  const { resolveModelRuntimeLimits } = await importFresh()
+
+  const limits = resolveModelRuntimeLimits({
+    model: 'my-custom-deployment',
+    processEnv: {},
+  })
+
+  expect(limits.contextWindow).toBe(123_456)
+  expect(limits.maxOutputTokens).toBe(4_096)
+})
+
+test('resolveModelRuntimeLimits prefers a host-qualified settings key', async () => {
+  mockConfig = {
+    modelLimits: {
+      'my-custom-deployment': { contextWindow: 100_000 },
+      'api.private-llm.test:my-custom-deployment': { contextWindow: 262_144 },
+    },
+  }
+  const { resolveModelRuntimeLimits } = await importFresh()
+
+  const limits = resolveModelRuntimeLimits({
+    model: 'my-custom-deployment',
+    baseUrl: 'https://api.private-llm.test/v1',
+    processEnv: {},
+  })
+
+  expect(limits.contextWindow).toBe(262_144)
+})
+
+test('resolveModelRuntimeLimits resolves a prefix settings key', async () => {
+  mockConfig = {
+    modelLimits: {
+      'my-custom': { contextWindow: 333_333 },
+    },
+  }
+  const { resolveModelRuntimeLimits } = await importFresh()
+
+  const limits = resolveModelRuntimeLimits({
+    model: 'my-custom-deployment-v2',
+    processEnv: {},
+  })
+
+  expect(limits.contextWindow).toBe(333_333)
+})
+
+test('resolveModelRuntimeLimits lets an env override win over settings modelLimits', async () => {
+  mockConfig = {
+    modelLimits: {
+      'my-custom-deployment': { contextWindow: 999 },
+    },
+  }
+  const { resolveModelRuntimeLimits } = await importFresh()
+
+  const limits = resolveModelRuntimeLimits({
+    model: 'my-custom-deployment',
+    processEnv: {
+      CLAUDE_CODE_OPENAI_CONTEXT_WINDOWS: JSON.stringify({
+        'my-custom-deployment': 111_111,
+      }),
+    },
+  })
+
+  expect(limits.contextWindow).toBe(111_111)
+})

--- a/src/integrations/runtimeMetadata.modelLimits.test.ts
+++ b/src/integrations/runtimeMetadata.modelLimits.test.ts
@@ -13,41 +13,43 @@ import {
 // getOpenAIContextWindow / getOpenAIMaxOutputTokens, not a settings-blind
 // variant) for prefix and host-qualified keys, and that env overrides win.
 
-type ConfigShape = {
+type SettingsShape = {
   modelLimits?: Record<
     string,
-    { contextWindow?: number; maxOutputTokens?: number } | null
-  > | null
+    { contextWindow?: number; maxOutputTokens?: number }
+  >
 }
 
-let mockConfig: ConfigShape = {}
-// Gate the getGlobalConfig override so the process-global mock.module is a
-// transparent passthrough to the real config whenever this suite is not the one
-// running — otherwise a later integrations test that reads getGlobalConfig()
-// would see this suite's stub config leak in.
-let configOverrideActive = false
-let realConfigModule: typeof import('../utils/config.js') | undefined
+let mockSettings: SettingsShape = {}
+// Gate the getInitialSettings override so the process-global mock.module is a
+// transparent passthrough to the real settings whenever this suite is not the
+// one running — otherwise a later integrations test that reads
+// getInitialSettings() would see this suite's stub settings leak in.
+let settingsOverrideActive = false
+let realSettingsModule:
+  | typeof import('../utils/settings/settings.js')
+  | undefined
 
 beforeEach(async () => {
   await acquireSharedMutationLock('integrations/runtimeMetadata.modelLimits.test.ts')
   mock.restore()
-  mockConfig = {}
-  realConfigModule ??= (await import(
-    `../utils/config.js?modelLimitsReal=${Date.now()}-${Math.random()}`
-  )) as typeof import('../utils/config.js')
-  const real = realConfigModule
-  mock.module('../utils/config.js', () => ({
+  mockSettings = {}
+  realSettingsModule ??= (await import(
+    `../utils/settings/settings.js?modelLimitsReal=${Date.now()}-${Math.random()}`
+  )) as typeof import('../utils/settings/settings.js')
+  const real = realSettingsModule
+  mock.module('../utils/settings/settings.js', () => ({
     ...real,
-    getGlobalConfig: () =>
-      configOverrideActive ? mockConfig : real.getGlobalConfig(),
+    getInitialSettings: () =>
+      settingsOverrideActive ? mockSettings : real.getInitialSettings(),
   }))
-  configOverrideActive = true
+  settingsOverrideActive = true
 })
 
 afterEach(() => {
   try {
     mock.restore()
-    configOverrideActive = false
+    settingsOverrideActive = false
   } finally {
     releaseSharedMutationLock()
   }
@@ -59,7 +61,7 @@ async function importFresh() {
 }
 
 test('resolveModelRuntimeLimits resolves settings modelLimits for an exact model key', async () => {
-  mockConfig = {
+  mockSettings = {
     modelLimits: {
       'my-custom-deployment': { contextWindow: 123_456, maxOutputTokens: 4_096 },
     },
@@ -76,7 +78,7 @@ test('resolveModelRuntimeLimits resolves settings modelLimits for an exact model
 })
 
 test('resolveModelRuntimeLimits prefers a host-qualified settings key', async () => {
-  mockConfig = {
+  mockSettings = {
     modelLimits: {
       'my-custom-deployment': { contextWindow: 100_000 },
       'api.private-llm.test:my-custom-deployment': { contextWindow: 262_144 },
@@ -94,7 +96,7 @@ test('resolveModelRuntimeLimits prefers a host-qualified settings key', async ()
 })
 
 test('resolveModelRuntimeLimits resolves a prefix settings key', async () => {
-  mockConfig = {
+  mockSettings = {
     modelLimits: {
       'my-custom': { contextWindow: 333_333 },
     },
@@ -110,7 +112,7 @@ test('resolveModelRuntimeLimits resolves a prefix settings key', async () => {
 })
 
 test('resolveModelRuntimeLimits lets an env override win over settings modelLimits', async () => {
-  mockConfig = {
+  mockSettings = {
     modelLimits: {
       'my-custom-deployment': { contextWindow: 999 },
     },

--- a/src/integrations/runtimeMetadata.modelLimits.test.ts
+++ b/src/integrations/runtimeMetadata.modelLimits.test.ts
@@ -134,3 +134,31 @@ test('resolveModelRuntimeLimits lets an env override win over settings modelLimi
 
   expect(limits.contextWindow).toBe(111_111)
 })
+
+test('resolveModelRuntimeLimits lets a broad env-prefix override win over an exact settings key', async () => {
+  // Regression for the env/settings precedence drift: a broad env-prefix
+  // override (`my-custom`) must not be silently overtaken by a more specific
+  // settings entry (`my-custom-deployment`). Covers both contextWindow and
+  // maxOutputTokens.
+  mockSettings = {
+    modelLimits: {
+      'my-custom-deployment': { contextWindow: 999, maxOutputTokens: 111 },
+    },
+  }
+  const { resolveModelRuntimeLimits } = await importFresh()
+
+  const limits = resolveModelRuntimeLimits({
+    model: 'my-custom-deployment',
+    processEnv: {
+      CLAUDE_CODE_OPENAI_CONTEXT_WINDOWS: JSON.stringify({
+        'my-custom': 111_111,
+      }),
+      CLAUDE_CODE_OPENAI_MAX_OUTPUT_TOKENS: JSON.stringify({
+        'my-custom': 4_096,
+      }),
+    },
+  })
+
+  expect(limits.contextWindow).toBe(111_111)
+  expect(limits.maxOutputTokens).toBe(4_096)
+})

--- a/src/integrations/runtimeMetadata.modelLimits.test.ts
+++ b/src/integrations/runtimeMetadata.modelLimits.test.ts
@@ -4,14 +4,23 @@ import {
   releaseSharedMutationLock,
 } from '../test/sharedMutationLock.js'
 
+// @ts-expect-error -- query-string cache-buster: the `?...` suffix makes Bun
+// treat this as a distinct module id, bypassing other suites'
+// mock.module('../utils/settings/settings.js') registrations so we capture the
+// genuine module. Importing it at module scope (once) keeps the real-module
+// load out of beforeEach, where the cold dynamic import sat right at Bun's 5s
+// hook-timeout boundary.
+import * as realSettingsModule from '../utils/settings/settings.js?modelLimitsRealSettings'
+
 // Integration coverage for the `modelLimits` settings override flowing through
 // the real runtime resolution path (CodeRabbit review on PR #1164/#1234). The
 // per-symbol tests in openaiContextWindows.test.ts exercise the lookup helpers
 // directly; this drives the full chain via resolveModelRuntimeLimits, which is
 // what runtime code actually calls. It also confirms the settings fallback is
 // reached (resolveModelRuntimeLimits calls the settings-aware
-// getOpenAIContextWindow / getOpenAIMaxOutputTokens, not a settings-blind
-// variant) for prefix and host-qualified keys, and that env overrides win.
+// getOpenAIContextWindowMatches / getOpenAIMaxOutputTokenMatches, not a
+// settings-blind variant) for prefix and host-qualified keys, and that env
+// overrides win.
 
 type SettingsShape = {
   modelLimits?: Record<
@@ -26,22 +35,17 @@ let mockSettings: SettingsShape = {}
 // one running — otherwise a later integrations test that reads
 // getInitialSettings() would see this suite's stub settings leak in.
 let settingsOverrideActive = false
-let realSettingsModule:
-  | typeof import('../utils/settings/settings.js')
-  | undefined
 
 beforeEach(async () => {
   await acquireSharedMutationLock('integrations/runtimeMetadata.modelLimits.test.ts')
   mock.restore()
   mockSettings = {}
-  realSettingsModule ??= (await import(
-    `../utils/settings/settings.js?modelLimitsReal=${Date.now()}-${Math.random()}`
-  )) as typeof import('../utils/settings/settings.js')
-  const real = realSettingsModule
   mock.module('../utils/settings/settings.js', () => ({
-    ...real,
+    ...realSettingsModule,
     getInitialSettings: () =>
-      settingsOverrideActive ? mockSettings : real.getInitialSettings(),
+      settingsOverrideActive
+        ? mockSettings
+        : realSettingsModule.getInitialSettings(),
   }))
   settingsOverrideActive = true
 })

--- a/src/integrations/runtimeMetadata.ts
+++ b/src/integrations/runtimeMetadata.ts
@@ -465,12 +465,14 @@ export function resolveModelRuntimeLimits(options: {
   return {
     contextWindow:
       externalContextWindow.exact ??
+      externalContextWindow.settings ??
       catalogEntry?.contextWindow ??
       cachedCatalogEntry?.contextWindow ??
       externalContextWindow.prefix ??
       modelDescriptor?.contextWindow,
     maxOutputTokens:
       externalMaxOutputTokens.exact ??
+      externalMaxOutputTokens.settings ??
       catalogEntry?.maxOutputTokens ??
       cachedCatalogEntry?.maxOutputTokens ??
       externalMaxOutputTokens.prefix ??

--- a/src/integrations/runtimeMetadata.ts
+++ b/src/integrations/runtimeMetadata.ts
@@ -462,28 +462,28 @@ export function resolveModelRuntimeLimits(options: {
     runtimeEnv,
   )
 
-  // Precedence: env overrides (exact, then prefix) are the highest-priority
-  // user overrides and must win over everything — mirroring the scalar
-  // getOpenAIContextWindow (`env(exact ?? prefix) ?? settings`). The settings.json
-  // `modelLimits` override then takes precedence over the built-in catalog /
-  // discovery-cache values (#478 is an override mechanism), which in turn beat
-  // the descriptor default. Keeping `settings` below `prefix` is the fix for the
-  // env/settings drift: a broad env-prefix override must not be silently
-  // overtaken by a settings entry.
+  // Precedence: an exact env override wins outright; then the built-in
+  // catalog / discovery-cache value (a `:cloud` variant must take its known
+  // catalog limit rather than inherit a broad base-model env *prefix*); then a
+  // broad env *prefix* override; then the settings.json `modelLimits` override;
+  // then the descriptor default. The key fix for the env/settings drift is
+  // keeping `settings` strictly below `prefix` so a broad env-prefix override is
+  // never silently overtaken by a settings entry — matching the scalar
+  // getOpenAIContextWindow, where env (exact or prefix) beats settings.
   return {
     contextWindow:
       externalContextWindow.exact ??
-      externalContextWindow.prefix ??
-      externalContextWindow.settings ??
       catalogEntry?.contextWindow ??
       cachedCatalogEntry?.contextWindow ??
+      externalContextWindow.prefix ??
+      externalContextWindow.settings ??
       modelDescriptor?.contextWindow,
     maxOutputTokens:
       externalMaxOutputTokens.exact ??
-      externalMaxOutputTokens.prefix ??
-      externalMaxOutputTokens.settings ??
       catalogEntry?.maxOutputTokens ??
       cachedCatalogEntry?.maxOutputTokens ??
+      externalMaxOutputTokens.prefix ??
+      externalMaxOutputTokens.settings ??
       modelDescriptor?.maxOutputTokens,
   }
 }

--- a/src/integrations/runtimeMetadata.ts
+++ b/src/integrations/runtimeMetadata.ts
@@ -462,20 +462,28 @@ export function resolveModelRuntimeLimits(options: {
     runtimeEnv,
   )
 
+  // Precedence: env overrides (exact, then prefix) are the highest-priority
+  // user overrides and must win over everything — mirroring the scalar
+  // getOpenAIContextWindow (`env(exact ?? prefix) ?? settings`). The settings.json
+  // `modelLimits` override then takes precedence over the built-in catalog /
+  // discovery-cache values (#478 is an override mechanism), which in turn beat
+  // the descriptor default. Keeping `settings` below `prefix` is the fix for the
+  // env/settings drift: a broad env-prefix override must not be silently
+  // overtaken by a settings entry.
   return {
     contextWindow:
       externalContextWindow.exact ??
+      externalContextWindow.prefix ??
       externalContextWindow.settings ??
       catalogEntry?.contextWindow ??
       cachedCatalogEntry?.contextWindow ??
-      externalContextWindow.prefix ??
       modelDescriptor?.contextWindow,
     maxOutputTokens:
       externalMaxOutputTokens.exact ??
+      externalMaxOutputTokens.prefix ??
       externalMaxOutputTokens.settings ??
       catalogEntry?.maxOutputTokens ??
       cachedCatalogEntry?.maxOutputTokens ??
-      externalMaxOutputTokens.prefix ??
       modelDescriptor?.maxOutputTokens,
   }
 }

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -239,6 +239,13 @@ export type GlobalConfig = {
   apiKeyHelper?: string
   projects?: Record<string, ProjectConfig>
   numStartups: number
+  // Per-model context window / max output token overrides, keyed by model name
+  // (optionally host-qualified as `<host>:<model>`). Resolved between env-var
+  // overrides and the built-in catalog. See openaiContextWindows.ts.
+  modelLimits?: Record<
+    string,
+    { contextWindow?: number; maxOutputTokens?: number } | null
+  >
   installMethod?: InstallMethod
   autoUpdates?: boolean
   // Flag to distinguish protection-based disabling from user preference

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -239,13 +239,6 @@ export type GlobalConfig = {
   apiKeyHelper?: string
   projects?: Record<string, ProjectConfig>
   numStartups: number
-  // Per-model context window / max output token overrides, keyed by model name
-  // (optionally host-qualified as `<host>:<model>`). Resolved between env-var
-  // overrides and the built-in catalog. See openaiContextWindows.ts.
-  modelLimits?: Record<
-    string,
-    { contextWindow?: number; maxOutputTokens?: number } | null
-  >
   installMethod?: InstallMethod
   autoUpdates?: boolean
   // Flag to distinguish protection-based disabling from user preference

--- a/src/utils/model/openaiContextWindows.test.ts
+++ b/src/utils/model/openaiContextWindows.test.ts
@@ -12,32 +12,47 @@ const originalEnv = {
   OPENAI_BASE_URL: process.env.OPENAI_BASE_URL,
 }
 
-type ConfigShape = {
+type SettingsShape = {
+  // Deliberately permissive (allows null entries) so the defensive-handling
+  // test can feed malformed shapes that real settings typing would reject.
   modelLimits?: Record<
     string,
     { contextWindow?: number; maxOutputTokens?: number } | null
-  > | null
+  >
 }
 
-let mockConfig: ConfigShape = {}
+let mockSettings: SettingsShape = {}
+// Gate the getInitialSettings override so the process-global mock.module is a
+// transparent passthrough to the real settings whenever this suite is not the
+// one running — settings.js is read by many suites, so a stub must not leak.
+let settingsOverrideActive = false
+let realSettingsModule:
+  | typeof import('../settings/settings.js')
+  | undefined
 
 beforeEach(async () => {
   await acquireSharedMutationLock('openaiContextWindows.test.ts')
   mock.restore()
-  mockConfig = {}
+  mockSettings = {}
   delete process.env.CLAUDE_CODE_OPENAI_CONTEXT_WINDOWS
   delete process.env.CLAUDE_CODE_OPENAI_MAX_OUTPUT_TOKENS
   delete process.env.OPENAI_BASE_URL
-  const actualConfig = await import(`../config.js?ts=${Date.now()}-${Math.random()}`)
-  mock.module('../config.js', () => ({
-    ...actualConfig,
-    getGlobalConfig: () => mockConfig,
+  realSettingsModule ??= (await import(
+    `../settings/settings.js?ts=${Date.now()}-${Math.random()}`
+  )) as typeof import('../settings/settings.js')
+  const real = realSettingsModule
+  mock.module('../settings/settings.js', () => ({
+    ...real,
+    getInitialSettings: () =>
+      settingsOverrideActive ? mockSettings : real.getInitialSettings(),
   }))
+  settingsOverrideActive = true
 })
 
 afterEach(() => {
   try {
     mock.restore()
+    settingsOverrideActive = false
     for (const [key, value] of Object.entries(originalEnv)) {
       if (value === undefined) {
         delete process.env[key]
@@ -56,7 +71,7 @@ async function importFresh() {
 }
 
 test('settings modelLimits resolves context window when no env override is set', async () => {
-  mockConfig = {
+  mockSettings = {
     modelLimits: {
       'qwen3.6-plus': { contextWindow: 1_048_576, maxOutputTokens: 32_768 },
     },
@@ -71,7 +86,7 @@ test('env override takes precedence over settings modelLimits', async () => {
   process.env.CLAUDE_CODE_OPENAI_CONTEXT_WINDOWS = JSON.stringify({
     'qwen3.6-plus': 524_288,
   })
-  mockConfig = {
+  mockSettings = {
     modelLimits: {
       'qwen3.6-plus': { contextWindow: 1_048_576 },
     },
@@ -82,7 +97,7 @@ test('env override takes precedence over settings modelLimits', async () => {
 })
 
 test('settings modelLimits supports prefix matching on the model name', async () => {
-  mockConfig = {
+  mockSettings = {
     modelLimits: {
       'qwen3': { contextWindow: 262_144 },
     },
@@ -94,7 +109,7 @@ test('settings modelLimits supports prefix matching on the model name', async ()
 
 test('settings modelLimits supports host-qualified keys', async () => {
   process.env.OPENAI_BASE_URL = 'https://openrouter.ai/api/v1'
-  mockConfig = {
+  mockSettings = {
     modelLimits: {
       'qwen3.6-plus': { contextWindow: 200_000 },
       'openrouter.ai:qwen3.6-plus': { contextWindow: 1_048_576 },
@@ -106,7 +121,7 @@ test('settings modelLimits supports host-qualified keys', async () => {
 })
 
 test('missing modelLimits returns undefined', async () => {
-  mockConfig = {}
+  mockSettings = {}
   const { getOpenAIContextWindow, getOpenAIMaxOutputTokens } = await importFresh()
 
   expect(getOpenAIContextWindow('whatever')).toBeUndefined()
@@ -114,7 +129,7 @@ test('missing modelLimits returns undefined', async () => {
 })
 
 test('invalid modelLimits entries are skipped without throwing', async () => {
-  mockConfig = {
+  mockSettings = {
     modelLimits: {
       'bad-zero': { contextWindow: 0 },
       'bad-negative': { contextWindow: -1 },

--- a/src/utils/model/openaiContextWindows.test.ts
+++ b/src/utils/model/openaiContextWindows.test.ts
@@ -1,0 +1,131 @@
+import { afterEach, beforeEach, expect, mock, test } from 'bun:test'
+import {
+  acquireSharedMutationLock,
+  releaseSharedMutationLock,
+} from '../../test/sharedMutationLock.js'
+
+const originalEnv = {
+  CLAUDE_CODE_OPENAI_CONTEXT_WINDOWS:
+    process.env.CLAUDE_CODE_OPENAI_CONTEXT_WINDOWS,
+  CLAUDE_CODE_OPENAI_MAX_OUTPUT_TOKENS:
+    process.env.CLAUDE_CODE_OPENAI_MAX_OUTPUT_TOKENS,
+  OPENAI_BASE_URL: process.env.OPENAI_BASE_URL,
+}
+
+type ConfigShape = {
+  modelLimits?: Record<
+    string,
+    { contextWindow?: number; maxOutputTokens?: number } | null
+  > | null
+}
+
+let mockConfig: ConfigShape = {}
+
+beforeEach(async () => {
+  await acquireSharedMutationLock('openaiContextWindows.test.ts')
+  mock.restore()
+  mockConfig = {}
+  delete process.env.CLAUDE_CODE_OPENAI_CONTEXT_WINDOWS
+  delete process.env.CLAUDE_CODE_OPENAI_MAX_OUTPUT_TOKENS
+  delete process.env.OPENAI_BASE_URL
+  const actualConfig = await import(`../config.js?ts=${Date.now()}-${Math.random()}`)
+  mock.module('../config.js', () => ({
+    ...actualConfig,
+    getGlobalConfig: () => mockConfig,
+  }))
+})
+
+afterEach(() => {
+  try {
+    mock.restore()
+    for (const [key, value] of Object.entries(originalEnv)) {
+      if (value === undefined) {
+        delete process.env[key]
+      } else {
+        process.env[key] = value
+      }
+    }
+  } finally {
+    releaseSharedMutationLock('openaiContextWindows.test.ts')
+  }
+})
+
+async function importFresh() {
+  const nonce = `${Date.now()}-${Math.random()}`
+  return await import(`./openaiContextWindows.js?ts=${nonce}`)
+}
+
+test('settings modelLimits resolves context window when no env override is set', async () => {
+  mockConfig = {
+    modelLimits: {
+      'qwen3.6-plus': { contextWindow: 1_048_576, maxOutputTokens: 32_768 },
+    },
+  }
+  const { getOpenAIContextWindow, getOpenAIMaxOutputTokens } = await importFresh()
+
+  expect(getOpenAIContextWindow('qwen3.6-plus')).toBe(1_048_576)
+  expect(getOpenAIMaxOutputTokens('qwen3.6-plus')).toBe(32_768)
+})
+
+test('env override takes precedence over settings modelLimits', async () => {
+  process.env.CLAUDE_CODE_OPENAI_CONTEXT_WINDOWS = JSON.stringify({
+    'qwen3.6-plus': 524_288,
+  })
+  mockConfig = {
+    modelLimits: {
+      'qwen3.6-plus': { contextWindow: 1_048_576 },
+    },
+  }
+  const { getOpenAIContextWindow } = await importFresh()
+
+  expect(getOpenAIContextWindow('qwen3.6-plus')).toBe(524_288)
+})
+
+test('settings modelLimits supports prefix matching on the model name', async () => {
+  mockConfig = {
+    modelLimits: {
+      'qwen3': { contextWindow: 262_144 },
+    },
+  }
+  const { getOpenAIContextWindow } = await importFresh()
+
+  expect(getOpenAIContextWindow('qwen3.6-plus')).toBe(262_144)
+})
+
+test('settings modelLimits supports host-qualified keys', async () => {
+  process.env.OPENAI_BASE_URL = 'https://openrouter.ai/api/v1'
+  mockConfig = {
+    modelLimits: {
+      'qwen3.6-plus': { contextWindow: 200_000 },
+      'openrouter.ai:qwen3.6-plus': { contextWindow: 1_048_576 },
+    },
+  }
+  const { getOpenAIContextWindow } = await importFresh()
+
+  expect(getOpenAIContextWindow('qwen3.6-plus')).toBe(1_048_576)
+})
+
+test('missing modelLimits returns undefined', async () => {
+  mockConfig = {}
+  const { getOpenAIContextWindow, getOpenAIMaxOutputTokens } = await importFresh()
+
+  expect(getOpenAIContextWindow('whatever')).toBeUndefined()
+  expect(getOpenAIMaxOutputTokens('whatever')).toBeUndefined()
+})
+
+test('invalid modelLimits entries are skipped without throwing', async () => {
+  mockConfig = {
+    modelLimits: {
+      'bad-zero': { contextWindow: 0 },
+      'bad-negative': { contextWindow: -1 },
+      'bad-shape': null,
+      'good': { contextWindow: 64_000 },
+    },
+  }
+  const { getOpenAIContextWindow } = await importFresh()
+
+  expect(getOpenAIContextWindow('bad-zero')).toBeUndefined()
+  expect(getOpenAIContextWindow('bad-negative')).toBeUndefined()
+  expect(getOpenAIContextWindow('bad-shape')).toBeUndefined()
+  expect(getOpenAIContextWindow('good')).toBe(64_000)
+})

--- a/src/utils/model/openaiContextWindows.test.ts
+++ b/src/utils/model/openaiContextWindows.test.ts
@@ -123,6 +123,21 @@ test('settings modelLimits supports host-qualified keys', async () => {
   expect(getOpenAIContextWindow('qwen3.6-plus')).toBe(1_048_576)
 })
 
+test('host-qualified prefix key wins over a bare exact model key', async () => {
+  // A host-qualified prefix is more specific than a bare exact match, so the
+  // per-endpoint limit must win even when a bare exact key also matches.
+  process.env.OPENAI_BASE_URL = 'https://openrouter.ai/api/v1'
+  mockSettings = {
+    modelLimits: {
+      'qwen3.6-plus': { contextWindow: 200_000 },
+      'openrouter.ai:qwen3': { contextWindow: 1_048_576 },
+    },
+  }
+  const { getOpenAIContextWindow } = await importFresh()
+
+  expect(getOpenAIContextWindow('qwen3.6-plus')).toBe(1_048_576)
+})
+
 test('missing modelLimits returns undefined', async () => {
   mockSettings = {}
   const { getOpenAIContextWindow, getOpenAIMaxOutputTokens } = await importFresh()

--- a/src/utils/model/openaiContextWindows.test.ts
+++ b/src/utils/model/openaiContextWindows.test.ts
@@ -46,7 +46,7 @@ afterEach(() => {
       }
     }
   } finally {
-    releaseSharedMutationLock('openaiContextWindows.test.ts')
+    releaseSharedMutationLock()
   }
 })
 

--- a/src/utils/model/openaiContextWindows.test.ts
+++ b/src/utils/model/openaiContextWindows.test.ts
@@ -123,9 +123,12 @@ test('settings modelLimits supports host-qualified keys', async () => {
   expect(getOpenAIContextWindow('qwen3.6-plus')).toBe(1_048_576)
 })
 
-test('host-qualified prefix key wins over a bare exact model key', async () => {
-  // A host-qualified prefix is more specific than a bare exact match, so the
-  // per-endpoint limit must win even when a bare exact key also matches.
+test('a bare exact key beats a host-qualified prefix for a different model', async () => {
+  // An exact match wins over any prefix, including a host-qualified one. Here
+  // the host-qualified `openrouter.ai:qwen3` only prefix-matches, while
+  // `qwen3.6-plus` is an exact match for the requested model, so the exact
+  // bare limit must win. To force a per-endpoint override for this model the
+  // user supplies a host-qualified EXACT key (covered by the test above).
   process.env.OPENAI_BASE_URL = 'https://openrouter.ai/api/v1'
   mockSettings = {
     modelLimits: {
@@ -135,7 +138,7 @@ test('host-qualified prefix key wins over a bare exact model key', async () => {
   }
   const { getOpenAIContextWindow } = await importFresh()
 
-  expect(getOpenAIContextWindow('qwen3.6-plus')).toBe(1_048_576)
+  expect(getOpenAIContextWindow('qwen3.6-plus')).toBe(200_000)
 })
 
 test('missing modelLimits returns undefined', async () => {

--- a/src/utils/model/openaiContextWindows.test.ts
+++ b/src/utils/model/openaiContextWindows.test.ts
@@ -4,6 +4,14 @@ import {
   releaseSharedMutationLock,
 } from '../../test/sharedMutationLock.js'
 
+// @ts-expect-error -- query-string cache-buster: the `?...` suffix makes Bun
+// treat this as a distinct module id, bypassing other suites'
+// mock.module('../settings/settings.js') registrations so we capture the
+// genuine module. Importing it at module scope (once) keeps the real-module
+// load out of beforeEach, where the cold dynamic import sat right at Bun's 5s
+// hook-timeout boundary and intermittently failed the first test.
+import * as realSettingsModule from '../settings/settings.js?openaiContextWindowsRealSettings'
+
 const originalEnv = {
   CLAUDE_CODE_OPENAI_CONTEXT_WINDOWS:
     process.env.CLAUDE_CODE_OPENAI_CONTEXT_WINDOWS,
@@ -26,9 +34,6 @@ let mockSettings: SettingsShape = {}
 // transparent passthrough to the real settings whenever this suite is not the
 // one running — settings.js is read by many suites, so a stub must not leak.
 let settingsOverrideActive = false
-let realSettingsModule:
-  | typeof import('../settings/settings.js')
-  | undefined
 
 beforeEach(async () => {
   await acquireSharedMutationLock('openaiContextWindows.test.ts')
@@ -37,14 +42,12 @@ beforeEach(async () => {
   delete process.env.CLAUDE_CODE_OPENAI_CONTEXT_WINDOWS
   delete process.env.CLAUDE_CODE_OPENAI_MAX_OUTPUT_TOKENS
   delete process.env.OPENAI_BASE_URL
-  realSettingsModule ??= (await import(
-    `../settings/settings.js?ts=${Date.now()}-${Math.random()}`
-  )) as typeof import('../settings/settings.js')
-  const real = realSettingsModule
   mock.module('../settings/settings.js', () => ({
-    ...real,
+    ...realSettingsModule,
     getInitialSettings: () =>
-      settingsOverrideActive ? mockSettings : real.getInitialSettings(),
+      settingsOverrideActive
+        ? mockSettings
+        : realSettingsModule.getInitialSettings(),
   }))
   settingsOverrideActive = true
 })

--- a/src/utils/model/openaiContextWindows.ts
+++ b/src/utils/model/openaiContextWindows.ts
@@ -119,19 +119,21 @@ function lookupByModel(
   const hostQualifiedModel =
     baseUrlHost && modelName ? `${baseUrlHost}:${modelName}` : undefined
 
-  // A host-qualified key (`<host>:<model>`) is strictly more specific than a
-  // bare model key, so ANY host-qualified match — exact OR prefix — must
-  // outrank a bare match. Rank both host-qualified forms in the high-priority
-  // `exact` tier ahead of the bare exact match; leave only the bare prefix in
-  // the low-priority `prefix` tier. Otherwise a bare exact (`qwen3.6-plus`)
-  // would beat a host-qualified prefix (`openrouter.ai:qwen3`) and the
-  // advertised per-endpoint disambiguation would fail for versioned families.
+  // Match precedence, high to low: host-qualified exact, bare exact,
+  // host-qualified prefix, bare prefix. Within each match kind a host-qualified
+  // key (`<host>:<model>`) beats the bare key, so the same model name can carry
+  // a different limit per endpoint via a host-qualified EXACT key. An exact
+  // match always beats a prefix — including a host-qualified prefix — so a
+  // precise `gpt-4o` entry is not overridden by an `api.foo.com:gpt-4` prefix
+  // that only matches a different, shorter model name. (Consumers read
+  // `exact ?? prefix`.)
   return {
     exact:
       lookupExactByKey(entries, hostQualifiedModel) ??
-      lookupPrefixByKey(entries, hostQualifiedModel) ??
       lookupExactByKey(entries, modelName),
-    prefix: lookupPrefixByKey(entries, modelName),
+    prefix:
+      lookupPrefixByKey(entries, hostQualifiedModel) ??
+      lookupPrefixByKey(entries, modelName),
   }
 }
 

--- a/src/utils/model/openaiContextWindows.ts
+++ b/src/utils/model/openaiContextWindows.ts
@@ -9,7 +9,7 @@
  * Resolution order: env var → settings.json `modelLimits` → built-in catalog.
  */
 
-import { getGlobalConfig } from '../config.js'
+import { getInitialSettings } from '../settings/settings.js'
 
 type LimitEnvVar =
   | 'CLAUDE_CODE_OPENAI_CONTEXT_WINDOWS'
@@ -146,7 +146,7 @@ function lookupExternalLimit(
 function readSettingsLimits(key: SettingsLimitKey): Record<string, number> {
   let limits: unknown
   try {
-    limits = getGlobalConfig().modelLimits
+    limits = getInitialSettings().modelLimits
   } catch {
     return {}
   }

--- a/src/utils/model/openaiContextWindows.ts
+++ b/src/utils/model/openaiContextWindows.ts
@@ -2,13 +2,20 @@
  * Runtime overrides for OpenAI-compatible model limits.
  *
  * Built-in model limits, including legacy aliases, live in
- * src/integrations/models. These helpers only preserve the documented JSON env
- * override path for custom/private deployments.
+ * src/integrations/models. These helpers preserve the documented JSON env
+ * override path for custom/private deployments and a `modelLimits` settings
+ * map for the same effect via settings.json.
+ *
+ * Resolution order: env var → settings.json `modelLimits` → built-in catalog.
  */
+
+import { getGlobalConfig } from '../config.js'
 
 type LimitEnvVar =
   | 'CLAUDE_CODE_OPENAI_CONTEXT_WINDOWS'
   | 'CLAUDE_CODE_OPENAI_MAX_OUTPUT_TOKENS'
+
+type SettingsLimitKey = 'contextWindow' | 'maxOutputTokens'
 
 function readExternalLimits(
   envVarName: LimitEnvVar,
@@ -114,14 +121,48 @@ function lookupExternalLimit(
   )
 }
 
+function readSettingsLimits(key: SettingsLimitKey): Record<string, number> {
+  let limits: unknown
+  try {
+    limits = getGlobalConfig().modelLimits
+  } catch {
+    return {}
+  }
+  if (!limits || typeof limits !== 'object' || Array.isArray(limits)) {
+    return {}
+  }
+  const result: Record<string, number> = {}
+  for (const [modelName, entry] of Object.entries(limits)) {
+    if (!entry || typeof entry !== 'object') continue
+    const value = (entry as Record<string, unknown>)[key]
+    if (typeof value === 'number' && Number.isFinite(value) && value > 0) {
+      const trimmed = modelName.trim()
+      if (trimmed.length > 0) {
+        result[trimmed] = value
+      }
+    }
+  }
+  return result
+}
+
+function lookupSettingsLimit(
+  key: SettingsLimitKey,
+  model: string | undefined,
+  processEnv: NodeJS.ProcessEnv,
+): number | undefined {
+  return lookupByModel(readSettingsLimits(key), model, processEnv)
+}
+
 export function getOpenAIContextWindow(
   model: string | undefined,
   processEnv: NodeJS.ProcessEnv = process.env,
 ): number | undefined {
-  return lookupExternalLimit(
-    'CLAUDE_CODE_OPENAI_CONTEXT_WINDOWS',
-    model,
-    processEnv,
+  return (
+    lookupExternalLimit(
+      'CLAUDE_CODE_OPENAI_CONTEXT_WINDOWS',
+      model,
+      processEnv,
+    ) ?? lookupSettingsLimit('contextWindow', model, processEnv)
   )
 }
 
@@ -129,9 +170,11 @@ export function getOpenAIMaxOutputTokens(
   model: string | undefined,
   processEnv: NodeJS.ProcessEnv = process.env,
 ): number | undefined {
-  return lookupExternalLimit(
-    'CLAUDE_CODE_OPENAI_MAX_OUTPUT_TOKENS',
-    model,
-    processEnv,
+  return (
+    lookupExternalLimit(
+      'CLAUDE_CODE_OPENAI_MAX_OUTPUT_TOKENS',
+      model,
+      processEnv,
+    ) ?? lookupSettingsLimit('maxOutputTokens', model, processEnv)
   )
 }

--- a/src/utils/model/openaiContextWindows.ts
+++ b/src/utils/model/openaiContextWindows.ts
@@ -16,7 +16,13 @@ type LimitEnvVar =
   | 'CLAUDE_CODE_OPENAI_MAX_OUTPUT_TOKENS'
 
 export type OpenAILimitOverrideMatches = {
+  // Exact env-var override match (highest precedence).
   exact?: number
+  // settings.json `modelLimits` match (exact or prefix). Sits between the exact
+  // env override and the built-in catalog, mirroring the documented resolution
+  // order env → settings → catalog.
+  settings?: number
+  // Prefix env-var override match (lowest precedence among overrides).
   prefix?: number
 }
 
@@ -187,11 +193,14 @@ export function getOpenAIContextWindowMatches(
   model: string | undefined,
   processEnv: NodeJS.ProcessEnv = process.env,
 ): OpenAILimitOverrideMatches {
-  return lookupExternalLimitMatches(
-    'CLAUDE_CODE_OPENAI_CONTEXT_WINDOWS',
-    model,
-    processEnv,
-  )
+  return {
+    ...lookupExternalLimitMatches(
+      'CLAUDE_CODE_OPENAI_CONTEXT_WINDOWS',
+      model,
+      processEnv,
+    ),
+    settings: lookupSettingsLimit('contextWindow', model, processEnv),
+  }
 }
 
 export function getOpenAIMaxOutputTokens(
@@ -211,9 +220,12 @@ export function getOpenAIMaxOutputTokenMatches(
   model: string | undefined,
   processEnv: NodeJS.ProcessEnv = process.env,
 ): OpenAILimitOverrideMatches {
-  return lookupExternalLimitMatches(
-    'CLAUDE_CODE_OPENAI_MAX_OUTPUT_TOKENS',
-    model,
-    processEnv,
-  )
+  return {
+    ...lookupExternalLimitMatches(
+      'CLAUDE_CODE_OPENAI_MAX_OUTPUT_TOKENS',
+      model,
+      processEnv,
+    ),
+    settings: lookupSettingsLimit('maxOutputTokens', model, processEnv),
+  }
 }

--- a/src/utils/model/openaiContextWindows.ts
+++ b/src/utils/model/openaiContextWindows.ts
@@ -119,13 +119,19 @@ function lookupByModel(
   const hostQualifiedModel =
     baseUrlHost && modelName ? `${baseUrlHost}:${modelName}` : undefined
 
+  // A host-qualified key (`<host>:<model>`) is strictly more specific than a
+  // bare model key, so ANY host-qualified match — exact OR prefix — must
+  // outrank a bare match. Rank both host-qualified forms in the high-priority
+  // `exact` tier ahead of the bare exact match; leave only the bare prefix in
+  // the low-priority `prefix` tier. Otherwise a bare exact (`qwen3.6-plus`)
+  // would beat a host-qualified prefix (`openrouter.ai:qwen3`) and the
+  // advertised per-endpoint disambiguation would fail for versioned families.
   return {
     exact:
       lookupExactByKey(entries, hostQualifiedModel) ??
-      lookupExactByKey(entries, modelName),
-    prefix:
       lookupPrefixByKey(entries, hostQualifiedModel) ??
-      lookupPrefixByKey(entries, modelName),
+      lookupExactByKey(entries, modelName),
+    prefix: lookupPrefixByKey(entries, modelName),
   }
 }
 

--- a/src/utils/model/openaiContextWindows.ts
+++ b/src/utils/model/openaiContextWindows.ts
@@ -6,7 +6,13 @@
  * override path for custom/private deployments and a `modelLimits` settings
  * map for the same effect via settings.json.
  *
- * Resolution order: env var → settings.json `modelLimits` → built-in catalog.
+ * This module only produces the *override candidates* (exact/prefix env-var
+ * matches and the settings `modelLimits` match); it does not decide the overall
+ * precedence. The authoritative runtime chain — exact env override, then the
+ * catalog/discovery cache, then the prefix env override, then settings
+ * `modelLimits`, then the descriptor default — is applied by
+ * resolveModelRuntimeLimits in integrations/runtimeMetadata.ts. Keep precedence
+ * changes there, not duplicated here.
  */
 
 import { getInitialSettings } from '../settings/settings.js'
@@ -16,13 +22,14 @@ type LimitEnvVar =
   | 'CLAUDE_CODE_OPENAI_MAX_OUTPUT_TOKENS'
 
 export type OpenAILimitOverrideMatches = {
-  // Exact env-var override match (highest precedence).
+  // Exact env-var override match.
   exact?: number
-  // settings.json `modelLimits` match (exact or prefix). Sits between the exact
-  // env override and the built-in catalog, mirroring the documented resolution
-  // order env → settings → catalog.
+  // settings.json `modelLimits` match (exact or prefix). Just a candidate here;
+  // its position in the overall precedence is decided by resolveModelRuntimeLimits
+  // (integrations/runtimeMetadata.ts), which applies settings after the exact and
+  // prefix env overrides and the catalog/discovery cache.
   settings?: number
-  // Prefix env-var override match (lowest precedence among overrides).
+  // Prefix env-var override match.
   prefix?: number
 }
 

--- a/src/utils/model/openaiContextWindows.ts
+++ b/src/utils/model/openaiContextWindows.ts
@@ -2,9 +2,14 @@
  * Runtime overrides for OpenAI-compatible model limits.
  *
  * Built-in model limits, including legacy aliases, live in
- * src/integrations/models. These helpers only preserve the documented JSON env
- * override path for custom/private deployments.
+ * src/integrations/models. These helpers preserve the documented JSON env
+ * override path for custom/private deployments and a `modelLimits` settings
+ * map for the same effect via settings.json.
+ *
+ * Resolution order: env var → settings.json `modelLimits` → built-in catalog.
  */
+
+import { getGlobalConfig } from '../config.js'
 
 type LimitEnvVar =
   | 'CLAUDE_CODE_OPENAI_CONTEXT_WINDOWS'
@@ -14,6 +19,8 @@ export type OpenAILimitOverrideMatches = {
   exact?: number
   prefix?: number
 }
+
+type SettingsLimitKey = 'contextWindow' | 'maxOutputTokens'
 
 function readExternalLimits(
   envVarName: LimitEnvVar,
@@ -130,14 +137,49 @@ function lookupExternalLimit(
   return matches.exact ?? matches.prefix
 }
 
+function readSettingsLimits(key: SettingsLimitKey): Record<string, number> {
+  let limits: unknown
+  try {
+    limits = getGlobalConfig().modelLimits
+  } catch {
+    return {}
+  }
+  if (!limits || typeof limits !== 'object' || Array.isArray(limits)) {
+    return {}
+  }
+  const result: Record<string, number> = {}
+  for (const [modelName, entry] of Object.entries(limits)) {
+    if (!entry || typeof entry !== 'object') continue
+    const value = (entry as Record<string, unknown>)[key]
+    if (typeof value === 'number' && Number.isFinite(value) && value > 0) {
+      const trimmed = modelName.trim()
+      if (trimmed.length > 0) {
+        result[trimmed] = value
+      }
+    }
+  }
+  return result
+}
+
+function lookupSettingsLimit(
+  key: SettingsLimitKey,
+  model: string | undefined,
+  processEnv: NodeJS.ProcessEnv,
+): number | undefined {
+  const matches = lookupByModel(readSettingsLimits(key), model, processEnv)
+  return matches.exact ?? matches.prefix
+}
+
 export function getOpenAIContextWindow(
   model: string | undefined,
   processEnv: NodeJS.ProcessEnv = process.env,
 ): number | undefined {
-  return lookupExternalLimit(
-    'CLAUDE_CODE_OPENAI_CONTEXT_WINDOWS',
-    model,
-    processEnv,
+  return (
+    lookupExternalLimit(
+      'CLAUDE_CODE_OPENAI_CONTEXT_WINDOWS',
+      model,
+      processEnv,
+    ) ?? lookupSettingsLimit('contextWindow', model, processEnv)
   )
 }
 
@@ -156,10 +198,12 @@ export function getOpenAIMaxOutputTokens(
   model: string | undefined,
   processEnv: NodeJS.ProcessEnv = process.env,
 ): number | undefined {
-  return lookupExternalLimit(
-    'CLAUDE_CODE_OPENAI_MAX_OUTPUT_TOKENS',
-    model,
-    processEnv,
+  return (
+    lookupExternalLimit(
+      'CLAUDE_CODE_OPENAI_MAX_OUTPUT_TOKENS',
+      model,
+      processEnv,
+    ) ?? lookupSettingsLimit('maxOutputTokens', model, processEnv)
   )
 }
 

--- a/src/utils/settings/types.ts
+++ b/src/utils/settings/types.ts
@@ -757,6 +757,32 @@ export const SettingsSchema = lazySchema(() =>
             'Use "default" key as fallback. Model name must exist in agentModels. ' +
             'Example: { "Explore": "deepseek-chat", "general-purpose": "gpt-4o", "default": "gpt-4o" }',
         ),
+      modelLimits: z
+        .record(
+          z.string(),
+          z.object({
+            contextWindow: z
+              .number()
+              .int()
+              .positive()
+              .optional()
+              .describe('Total context window size in tokens.'),
+            maxOutputTokens: z
+              .number()
+              .int()
+              .positive()
+              .optional()
+              .describe('Maximum output tokens per response.'),
+          }),
+        )
+        .optional()
+        .describe(
+          'Per-model overrides for context window and max output tokens. ' +
+            'Used for OpenAI-compatible models whose limits are not in the built-in catalog. ' +
+            'Keys are matched against the model name (exact match preferred, then prefix). ' +
+            'CLAUDE_CODE_OPENAI_CONTEXT_WINDOWS / CLAUDE_CODE_OPENAI_MAX_OUTPUT_TOKENS env vars take precedence. ' +
+            'Example: { "qwen3.6-plus": { "contextWindow": 1048576, "maxOutputTokens": 32768 } }',
+        ),
       fastMode: z
         .boolean()
         .optional()

--- a/src/utils/settings/types.ts
+++ b/src/utils/settings/types.ts
@@ -789,6 +789,32 @@ export const SettingsSchema = lazySchema(() =>
             'the currently-active id) and retries the turn. ' +
             'Example: ["provider_anthropic", "provider_openai", "provider_ollama"]',
         ),
+      modelLimits: z
+        .record(
+          z.string(),
+          z.object({
+            contextWindow: z
+              .number()
+              .int()
+              .positive()
+              .optional()
+              .describe('Total context window size in tokens.'),
+            maxOutputTokens: z
+              .number()
+              .int()
+              .positive()
+              .optional()
+              .describe('Maximum output tokens per response.'),
+          }),
+        )
+        .optional()
+        .describe(
+          'Per-model overrides for context window and max output tokens. ' +
+            'Used for OpenAI-compatible models whose limits are not in the built-in catalog. ' +
+            'Keys are matched against the model name (exact match preferred, then prefix). ' +
+            'CLAUDE_CODE_OPENAI_CONTEXT_WINDOWS / CLAUDE_CODE_OPENAI_MAX_OUTPUT_TOKENS env vars take precedence. ' +
+            'Example: { "qwen3.6-plus": { "contextWindow": 1048576, "maxOutputTokens": 32768 } }',
+        ),
       fastMode: z
         .boolean()
         .optional()


### PR DESCRIPTION
## Summary

Adds a `modelLimits` map to `settings.json` so users can declare the context window and max output tokens for OpenAI-compatible models that are not in the built-in catalog. The new path complements the existing `CLAUDE_CODE_OPENAI_CONTEXT_WINDOWS` / `CLAUDE_CODE_OPENAI_MAX_OUTPUT_TOKENS` env vars.

Resolution order (as implemented after the follow-up commits): exact env override → catalog/discovery cache → prefix env override → `modelLimits` → descriptor default. In other words the built-in catalog/discovery cache still wins over `modelLimits`, and `modelLimits` only supplies a value when neither an exact env override, a cached catalog entry, nor a prefix env override matched — before falling through to the conservative descriptor default.

Key matching precedence, high to low: host-qualified exact, bare exact, host-qualified prefix, bare prefix. An exact match always beats a prefix — including a host-qualified prefix — and within a given match kind a `"<host>:<model>"` host-qualified key beats the bare key. To set a different limit for the same model name per endpoint, supply a host-qualified **exact** key (e.g. `"openrouter.ai:qwen3.6-plus"`); a bare exact key is not overridden by a host-qualified prefix that only matches a different, shorter model name.

### Example

```jsonc
{
  "modelLimits": {
    "qwen3.6-plus": { "contextWindow": 1048576, "maxOutputTokens": 32768 }
  }
}
```

Fixes the auto-compact-too-early failure mode reported on the issue, where `qwen3.6-plus` (1M-token model on OpenRouter) fell back to the conservative 128k default and fired auto-compact at ~167k of usable context. After this change, the user can declare the real window in `settings.json` once and the status bar plus auto-compact both pick it up.

Matches the local/manual configuration direction the maintainer endorsed on the issue.

## Testing

`modelLimits` is read from `getInitialSettings()` (settings.json), not the global config. Focused coverage:
- settings-only resolution (exact, prefix, host-qualified matching)
- exact env override precedence over `modelLimits`
- catalog/discovery cache precedence over `modelLimits`
- prefix env override precedence over `modelLimits`
- invalid entries (zero, negative, null) skipped; missing config no-op
- descriptor default fallback when nothing matches

```
bun test src/utils/model/openaiContextWindows.test.ts   # pass
bun test src/utils/context.test.ts                       # pass (no regression)
bun run build                                            # ✓
```

Closes #478


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added per-model `modelLimits` overrides in `settings.json` for `contextWindow` and `maxOutputTokens`, supporting exact, prefix, and host-qualified (`<host>:<model>`) matching.
  * Added `CLAUDE_CODE_OPENAI_MAX_OUTPUT_TOKENS` for max-output-token overrides for OpenAI-compatible providers.
* **Bug Fixes**
  * Updated model limit resolution precedence so settings-based overrides are applied after env prefix matches and before model descriptor defaults, with host-qualified keys taking priority.
* **Documentation**
  * Expanded advanced setup and model lookup docs to clarify new variables, key matching, and override order.
* **Tests**
  * Added unit and integration tests covering env/settings precedence and matching behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->