### PR TITLE
fix(bash): preserve captured stdout in error message on non-zero exit

### DIFF
--- a/src/tools/BashTool/BashTool.errorOutput.test.ts
+++ b/src/tools/BashTool/BashTool.errorOutput.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from 'bun:test'
 import { BashTool } from './BashTool.js'
+import { getEmptyToolPermissionContext } from '../../Tool.js'
 import { ShellError } from '../../utils/errors.js'
 import { formatError } from '../../utils/toolErrors.js'
 
@@ -13,9 +14,11 @@ import { formatError } from '../../utils/toolErrors.js'
 // the captured output alongside the exit code.
 
 function makeCtx() {
+  const toolPermissionContext = getEmptyToolPermissionContext()
   return {
     abortController: new AbortController(),
-    getAppState: () => ({ toolPermissionContext: { mode: 'default' } } as never),
+    options: { isNonInteractiveSession: false },
+    getAppState: () => ({ toolPermissionContext } as never),
     setAppState: () => undefined,
     setToolJSX: undefined,
     toolUseId: 'test-bash-error-output',

--- a/src/tools/BashTool/BashTool.errorOutput.test.ts
+++ b/src/tools/BashTool/BashTool.errorOutput.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, test } from 'bun:test'
+import { BashTool } from './BashTool.js'
+import { ShellError } from '../../utils/errors.js'
+import { formatError } from '../../utils/toolErrors.js'
+
+// Regression for #1231 — non-zero exit must not hide captured stdout/stderr.
+// The Bash tool runs with a merged-fd setup (both streams to one file), so
+// captured output lives on result.stdout. Before the fix, the throw passed
+// stdout='' and put the merged output in the stderr slot of ShellError, which
+// worked through formatError but lost the semantic mapping and made it easy
+// for the failure path to drop output if downstream consumers only inspected
+// stdout. These tests lock the contract: getErrorParts/formatError surface
+// the captured output alongside the exit code.
+
+function makeCtx() {
+  return {
+    abortController: new AbortController(),
+    getAppState: () => ({ toolPermissionContext: { mode: 'default' } } as never),
+    setAppState: () => undefined,
+    setToolJSX: undefined,
+    toolUseId: 'test-bash-error-output',
+  } as never
+}
+
+async function expectShellError(command: string): Promise<ShellError> {
+  try {
+    await BashTool.call({ command, description: 'r' } as never, makeCtx())
+    throw new Error('expected ShellError')
+  } catch (e) {
+    if (!(e instanceof ShellError)) throw e
+    return e
+  }
+}
+
+describe('BashTool error output (#1231)', () => {
+  test('captured stdout/stderr appear in formatted error on non-zero exit', async () => {
+    const err = await expectShellError(
+      'echo stdout-line; echo stderr-line >&2; exit 1',
+    )
+    expect(err.code).toBe(1)
+    const formatted = formatError(err)
+    expect(formatted).toContain('Exit code 1')
+    expect(formatted).toContain('stdout-line')
+    expect(formatted).toContain('stderr-line')
+  })
+
+  test('"command not found" message reaches the formatted error', async () => {
+    const err = await expectShellError('no_such_command_xyz_1231')
+    expect(err.code).not.toBe(0)
+    const formatted = formatError(err)
+    expect(formatted).toContain(`Exit code ${err.code}`)
+    expect(formatted.toLowerCase()).toContain('not found')
+  })
+
+  test('captured output is carried on the stdout slot (semantic mapping)', async () => {
+    const err = await expectShellError('echo merged-line; exit 2')
+    expect(err.stdout).toContain('merged-line')
+    expect(err.code).toBe(2)
+  })
+
+  test('empty-output failure still surfaces the exit code', async () => {
+    const err = await expectShellError('exit 1')
+    expect(err.code).toBe(1)
+    expect(formatError(err)).toBe('Exit code 1')
+  })
+})

--- a/src/tools/BashTool/BashTool.tsx
+++ b/src/tools/BashTool/BashTool.tsx
@@ -702,12 +702,6 @@ export const BashTool = buildTool({
       if (result.stdout && result.stdout.includes(".git/index.lock': File exists")) {
         logEvent('tengu_git_index_lock_error', {});
       }
-      if (interpretationResult.isError && !isInterrupt) {
-        // Only add exit code if it's actually an error
-        if (result.code !== 0) {
-          stdoutAccumulator.append(`Exit code ${result.code}`);
-        }
-      }
       if (!preventCwdChanges) {
         const appState = getAppState();
         if (resetCwdIfOutsideProject(appState.toolPermissionContext)) {
@@ -721,10 +715,13 @@ export const BashTool = buildTool({
         throw new Error(result.preSpawnError);
       }
       if (interpretationResult.isError && !isInterrupt) {
-        // stderr is merged into stdout (merged fd); outputWithSbFailures
-        // already has the full output. Pass '' for stdout to avoid
-        // duplication in getErrorParts() and processBashCommand.
-        throw new ShellError('', outputWithSbFailures, result.code, result.interrupted);
+        // Merged-fd setup puts both streams into result.stdout. Carry it on
+        // the stdout slot of ShellError (matches PowerShellTool.tsx:595) so
+        // getErrorParts() emits the captured output alongside "Exit code N"
+        // — without this, a non-zero exit hides the very output users need
+        // to debug the failure (issue #1231). result.stderr is empty in
+        // file mode but populated in pipe mode (hooks).
+        throw new ShellError(outputWithSbFailures, result.stderr || '', result.code, result.interrupted);
       }
       wasInterrupted = result.interrupted;
     } finally {


### PR DESCRIPTION
## Summary

Close #1231. When a Bash command exits non-zero, surface the captured stdout/stderr alongside the exit code so users can debug failures without forcing `; exit 0`.

## What changed

- `BashTool.tsx` — throw `ShellError(outputWithSbFailures, result.stderr || '', result.code, ...)`. Previously the merged output was passed in the stderr slot with `stdout=''`. The data reached `formatError()` either way, but the swap made the contract fragile: a downstream consumer that only read `error.stdout` would lose the output. Now matches `PowerShellTool.tsx:595`.
- Drops the dead `stdoutAccumulator.append("Exit code N")` — the throw discards the accumulator, and `getErrorParts()` already prepends `Exit code N` from `error.code`. The original comment at `PowerShellTool.tsx:570` already flagged this as dead.
- Adds `BashTool.errorOutput.test.ts` covering the issue's repro and adjacent cases (command-not-found, empty-output failure, slot-mapping contract).

## Verification

Reproduced the issue's `fail_with_output` scenario locally — `formatError` now produces:

```
Exit code 1
stdout-line
stderr-line
```

which `FallbackToolUseErrorMessage` renders as:

```
Error: Exit code 1
stdout-line
stderr-line
```

## Test plan

- [x] `bun test src/tools/BashTool/ src/utils/toolErrors.test.ts` — 105 pass, 0 fail
- [x] Manual repro of `echo a; echo b >&2; exit 1` — output appears in error
- [x] `exit 1` with no output — emits only `Exit code 1` (unchanged behavior)