### PR TITLE
feat(diagnostics): show request payload size breakdown

### DIFF
--- a/src/commands.test.ts
+++ b/src/commands.test.ts
@@ -9,6 +9,10 @@ describe('builtInCommandNames', () => {
   test('includes the LSP command', () => {
     expect(builtInCommandNames()).toContain('lsp')
   })
+
+  test('includes the request-size diagnostic command', () => {
+    expect(builtInCommandNames()).toContain('request-size')
+  })
 })
 
 describe('isCommand', () => {

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -43,6 +43,10 @@ import onboarding from './commands/onboarding/index.js'
 import pr_comments from './commands/pr_comments/index.js'
 import releaseNotes from './commands/release-notes/index.js'
 import rename from './commands/rename/index.js'
+import {
+  requestSize,
+  requestSizeNonInteractive,
+} from './commands/request-size/index.js'
 import resume from './commands/resume/index.js'
 import review, { ultrareview } from './commands/review.js'
 import session from './commands/session/index.js'
@@ -317,6 +321,8 @@ const COMMANDS = memoize((): Command[] => [
   releaseNotes,
   reloadPlugins,
   rename,
+  requestSize,
+  requestSizeNonInteractive,
   resume,
   session,
   skills,

--- a/src/commands/request-size/index.ts
+++ b/src/commands/request-size/index.ts
@@ -1,0 +1,24 @@
+import type { Command } from '../../commands.js'
+import { getIsNonInteractiveSession } from '../../bootstrap/state.js'
+
+export const requestSize = {
+  type: 'local-jsx',
+  name: 'request-size',
+  description: 'Show estimated request payload size and top contributors',
+  isEnabled: () => !getIsNonInteractiveSession(),
+  load: () => import('./request-size.js'),
+} satisfies Command
+
+export const requestSizeNonInteractive = {
+  type: 'local',
+  name: 'request-size',
+  description: 'Show estimated request payload size and top contributors',
+  supportsNonInteractive: true,
+  get isHidden() {
+    return !getIsNonInteractiveSession()
+  },
+  isEnabled: () => getIsNonInteractiveSession(),
+  load: () => import('./request-size-noninteractive.js'),
+} satisfies Command
+
+export default requestSize

--- a/src/commands/request-size/index.ts
+++ b/src/commands/request-size/index.ts
@@ -4,7 +4,7 @@ import { getIsNonInteractiveSession } from '../../bootstrap/state.js'
 export const requestSize = {
   type: 'local-jsx',
   name: 'request-size',
-  description: 'Show estimated request payload size and top contributors',
+  description: 'Show estimated request context load and top contributors',
   isEnabled: () => !getIsNonInteractiveSession(),
   load: () => import('./request-size.js'),
 } satisfies Command
@@ -12,7 +12,7 @@ export const requestSize = {
 export const requestSizeNonInteractive = {
   type: 'local',
   name: 'request-size',
-  description: 'Show estimated request payload size and top contributors',
+  description: 'Show estimated request context load and top contributors',
   supportsNonInteractive: true,
   get isHidden() {
     return !getIsNonInteractiveSession()

--- a/src/commands/request-size/request-size-noninteractive.ts
+++ b/src/commands/request-size/request-size-noninteractive.ts
@@ -13,9 +13,9 @@ export const call: LocalCommandCall = async (_args, context) => {
     value = formatRequestSizeReport(report)
   } catch {
     value = [
-      'Request size',
+      'Request context size',
       '',
-      'Unable to estimate request size for the current context.',
+      'Unable to estimate request context size for the current context.',
     ].join('\n')
   }
 

--- a/src/commands/request-size/request-size-noninteractive.ts
+++ b/src/commands/request-size/request-size-noninteractive.ts
@@ -1,0 +1,27 @@
+import type { LocalCommandCall } from '../../types/command.js'
+import {
+  createRequestSizeReport,
+  formatRequestSizeReport,
+} from '../../utils/requestSizeBreakdown.js'
+import { collectContextData } from '../context/context-noninteractive.js'
+
+export const call: LocalCommandCall = async (_args, context) => {
+  let value: string
+  try {
+    const data = await collectContextData(context)
+    const report = createRequestSizeReport(data)
+    value = formatRequestSizeReport(report)
+  } catch {
+    value = [
+      'Request size',
+      '',
+      'Unable to estimate request size for the current context.',
+    ].join('\n')
+  }
+
+  return {
+    type: 'text',
+    value,
+    display: 'skip',
+  }
+}

--- a/src/commands/request-size/request-size.test.ts
+++ b/src/commands/request-size/request-size.test.ts
@@ -138,7 +138,7 @@ test('interactive command failures still render transient output', async () => {
   expect(isValidElement(result)).toBe(true)
   expect(
     (result as { props: { reportText: string } }).props.reportText,
-  ).toContain('Unable to estimate request size')
+  ).toContain('Unable to estimate request context size')
   expect(onDone).not.toHaveBeenCalled()
 })
 
@@ -157,7 +157,7 @@ test('noninteractive command returns a text result without provider credentials'
 
   expect(result.type).toBe('text')
   expect(result.type === 'text' ? result.value : '').toContain(
-    'Estimated request size:',
+    'Estimated context load:',
   )
   expect(result.type === 'text' ? result.display : undefined).toBe('skip')
 })
@@ -185,7 +185,7 @@ test('noninteractive slash command returns text without transcript messages', as
   )
 
   expect(result.shouldQuery).toBe(false)
-  expect(result.resultText).toContain('Estimated request size:')
+  expect(result.resultText).toContain('Estimated context load:')
   expect(result.messages).toEqual([])
 })
 
@@ -214,7 +214,7 @@ test('noninteractive command failures return text without transcript messages', 
   )
 
   expect(result.shouldQuery).toBe(false)
-  expect(result.resultText).toContain('Unable to estimate request size')
+  expect(result.resultText).toContain('Unable to estimate request context size')
   expect(result.messages).toEqual([])
 })
 
@@ -251,7 +251,7 @@ test('slash command processing does not create transcript messages after close',
   const localJSX = await waitForCaptured(() => capturedToolJSX)
   expect(localJSX.jsx.props).toEqual(
     expect.objectContaining({
-      reportText: expect.stringContaining('Estimated request size:'),
+      reportText: expect.stringContaining('Estimated context load:'),
     }),
   )
 

--- a/src/commands/request-size/request-size.test.ts
+++ b/src/commands/request-size/request-size.test.ts
@@ -1,0 +1,263 @@
+import { afterEach, beforeEach, expect, mock, test } from 'bun:test'
+import { isValidElement } from 'react'
+import {
+  acquireSharedMutationLock,
+  releaseSharedMutationLock,
+} from '../../test/sharedMutationLock.js'
+import type { ContextData } from '../../utils/analyzeContext.js'
+import { processSlashCommand } from '../../utils/processUserInput/processSlashCommand.js'
+
+const originalEnv = {
+  ANTHROPIC_API_KEY: process.env.ANTHROPIC_API_KEY,
+  OPENAI_API_KEY: process.env.OPENAI_API_KEY,
+}
+
+function restoreEnv(key: keyof typeof originalEnv): void {
+  const value = originalEnv[key]
+  if (value === undefined) {
+    delete process.env[key]
+  } else {
+    process.env[key] = value
+  }
+}
+
+function makeContextData(): ContextData {
+  return {
+    categories: [
+      { name: 'System prompt', tokens: 1_000, color: 'permission' },
+      { name: 'Messages', tokens: 2_000, color: 'permission' },
+    ],
+    totalTokens: 3_000,
+    maxTokens: 200_000,
+    rawMaxTokens: 200_000,
+    percentage: 2,
+    gridRows: [],
+    model: 'test-model',
+    memoryFiles: [],
+    mcpTools: [],
+    agents: [],
+    isAutoCompactEnabled: false,
+    messageBreakdown: {
+      toolCallTokens: 0,
+      toolResultTokens: 0,
+      attachmentTokens: 0,
+      assistantMessageTokens: 1_000,
+      userMessageTokens: 1_000,
+      toolCallsByType: [],
+      attachmentsByType: [],
+    },
+    apiUsage: null,
+  }
+}
+
+beforeEach(async () => {
+  await acquireSharedMutationLock('request-size.test.ts')
+})
+
+afterEach(() => {
+  try {
+    restoreEnv('ANTHROPIC_API_KEY')
+    restoreEnv('OPENAI_API_KEY')
+    mock.restore()
+  } finally {
+    releaseSharedMutationLock()
+  }
+})
+
+function waitForCaptured<T>(getValue: () => T | undefined): Promise<T> {
+  return new Promise((resolve, reject) => {
+    let attempts = 0
+    const check = () => {
+      const value = getValue()
+      if (value !== undefined) {
+        resolve(value)
+        return
+      }
+      attempts += 1
+      if (attempts > 50) {
+        reject(new Error('Timed out waiting for captured value'))
+        return
+      }
+      setTimeout(check, 0)
+    }
+    check()
+  })
+}
+
+test('interactive command renders a transient report without provider credentials', async () => {
+  delete process.env.ANTHROPIC_API_KEY
+  delete process.env.OPENAI_API_KEY
+
+  const collectContextData = mock(async () => makeContextData())
+  mock.module('../context/context-noninteractive.js', () => ({
+    collectContextData,
+  }))
+
+  const nonce = `${Date.now()}-${Math.random()}`
+  const { call } = await import(`./request-size.tsx?ts=${nonce}`)
+  const onDone = mock(() => {})
+  const result = await call(onDone as never, {} as never, '')
+
+  expect(collectContextData).toHaveBeenCalledTimes(1)
+  expect(isValidElement(result)).toBe(true)
+  expect(onDone).not.toHaveBeenCalled()
+})
+
+test('closing the interactive report skips transcript output', async () => {
+  const collectContextData = mock(async () => makeContextData())
+  mock.module('../context/context-noninteractive.js', () => ({
+    collectContextData,
+  }))
+
+  const nonce = `${Date.now()}-${Math.random()}`
+  const { call } = await import(`./request-size.tsx?ts=${nonce}`)
+  const onDone = mock(() => {})
+  const result = await call(onDone as never, {} as never, '')
+
+  expect(isValidElement(result)).toBe(true)
+
+  const props = (result as { props: { onClose: () => void } }).props
+  props.onClose()
+
+  expect(onDone).toHaveBeenCalledWith(undefined, { display: 'skip' })
+})
+
+test('interactive command failures still render transient output', async () => {
+  const collectContextData = mock(async () => {
+    throw new Error('boom')
+  })
+  mock.module('../context/context-noninteractive.js', () => ({
+    collectContextData,
+  }))
+
+  const nonce = `${Date.now()}-${Math.random()}`
+  const { call } = await import(`./request-size.tsx?ts=${nonce}`)
+  const onDone = mock(() => {})
+  const result = await call(onDone as never, {} as never, '')
+
+  expect(isValidElement(result)).toBe(true)
+  expect(
+    (result as { props: { reportText: string } }).props.reportText,
+  ).toContain('Unable to estimate request size')
+  expect(onDone).not.toHaveBeenCalled()
+})
+
+test('noninteractive command returns a text result without provider credentials', async () => {
+  delete process.env.ANTHROPIC_API_KEY
+  delete process.env.OPENAI_API_KEY
+
+  const collectContextData = mock(async () => makeContextData())
+  mock.module('../context/context-noninteractive.js', () => ({
+    collectContextData,
+  }))
+
+  const nonce = `${Date.now()}-${Math.random()}`
+  const { call } = await import(`./request-size-noninteractive.ts?ts=${nonce}`)
+  const result = await call('', {} as never)
+
+  expect(result.type).toBe('text')
+  expect(result.type === 'text' ? result.value : '').toContain(
+    'Estimated request size:',
+  )
+  expect(result.type === 'text' ? result.display : undefined).toBe('skip')
+})
+
+test('noninteractive slash command returns text without transcript messages', async () => {
+  const collectContextData = mock(async () => makeContextData())
+  mock.module('../context/context-noninteractive.js', () => ({
+    collectContextData,
+  }))
+
+  const nonce = `${Date.now()}-${Math.random()}`
+  const { requestSizeNonInteractive } = await import(`./index.ts?ts=${nonce}`)
+  const result = await processSlashCommand(
+    '/request-size',
+    [],
+    [],
+    [],
+    {
+      options: {
+        commands: [requestSizeNonInteractive],
+        isNonInteractiveSession: true,
+      },
+    } as never,
+    mock(() => {}) as never,
+  )
+
+  expect(result.shouldQuery).toBe(false)
+  expect(result.resultText).toContain('Estimated request size:')
+  expect(result.messages).toEqual([])
+})
+
+test('noninteractive command failures return text without transcript messages', async () => {
+  const collectContextData = mock(async () => {
+    throw new Error('boom')
+  })
+  mock.module('../context/context-noninteractive.js', () => ({
+    collectContextData,
+  }))
+
+  const nonce = `${Date.now()}-${Math.random()}`
+  const { requestSizeNonInteractive } = await import(`./index.ts?ts=${nonce}`)
+  const result = await processSlashCommand(
+    '/request-size',
+    [],
+    [],
+    [],
+    {
+      options: {
+        commands: [requestSizeNonInteractive],
+        isNonInteractiveSession: true,
+      },
+    } as never,
+    mock(() => {}) as never,
+  )
+
+  expect(result.shouldQuery).toBe(false)
+  expect(result.resultText).toContain('Unable to estimate request size')
+  expect(result.messages).toEqual([])
+})
+
+test('slash command processing does not create transcript messages after close', async () => {
+  const collectContextData = mock(async () => makeContextData())
+  mock.module('../context/context-noninteractive.js', () => ({
+    collectContextData,
+  }))
+
+  const nonce = `${Date.now()}-${Math.random()}`
+  const { requestSize } = await import(`./index.ts?ts=${nonce}`)
+  let capturedToolJSX:
+    | {
+        jsx: { props: { onClose: () => void } }
+      }
+    | undefined
+
+  const pendingResult = processSlashCommand(
+    '/request-size',
+    [],
+    [],
+    [],
+    {
+      options: {
+        commands: [requestSize],
+        isNonInteractiveSession: false,
+      },
+    } as never,
+    mock(value => {
+      capturedToolJSX = value as typeof capturedToolJSX
+    }) as never,
+  )
+
+  const localJSX = await waitForCaptured(() => capturedToolJSX)
+  expect(localJSX.jsx.props).toEqual(
+    expect.objectContaining({
+      reportText: expect.stringContaining('Estimated request size:'),
+    }),
+  )
+
+  localJSX.jsx.props.onClose()
+  const result = await pendingResult
+
+  expect(result.shouldQuery).toBe(false)
+  expect(result.messages).toEqual([])
+})

--- a/src/commands/request-size/request-size.tsx
+++ b/src/commands/request-size/request-size.tsx
@@ -1,0 +1,56 @@
+import * as React from 'react'
+import { Pane } from '../../components/design-system/Pane.js'
+import { Box, Text } from '../../ink.js'
+import { useKeybinding } from '../../keybindings/useKeybinding.js'
+import type { LocalJSXCommandCall } from '../../types/command.js'
+import {
+  createRequestSizeReport,
+  formatRequestSizeReport,
+} from '../../utils/requestSizeBreakdown.js'
+import { collectContextData } from '../context/context-noninteractive.js'
+
+type RequestSizeReportViewProps = {
+  reportText: string
+  onClose: () => void
+}
+
+export function RequestSizeReportView({
+  reportText,
+  onClose,
+}: RequestSizeReportViewProps): React.ReactNode {
+  useKeybinding('confirm:no', onClose, { context: 'Confirmation' })
+
+  return (
+    <Pane color="permission">
+      <Box flexDirection="column">
+        {reportText.split('\n').map((line, index) => (
+          <Text key={index}>{line.length > 0 ? line : ' '}</Text>
+        ))}
+        <Box marginTop={1}>
+          <Text dimColor>(press esc to close)</Text>
+        </Box>
+      </Box>
+    </Pane>
+  )
+}
+
+export const call: LocalJSXCommandCall = async (onDone, context) => {
+  let reportText: string
+  try {
+    const data = await collectContextData(context)
+    const report = createRequestSizeReport(data)
+    reportText = formatRequestSizeReport(report)
+  } catch {
+    reportText = [
+      'Request size',
+      '',
+      'Unable to estimate request size for the current context.',
+    ].join('\n')
+  }
+
+  const close = () => {
+    onDone(undefined, { display: 'skip' })
+  }
+
+  return <RequestSizeReportView reportText={reportText} onClose={close} />
+}

--- a/src/commands/request-size/request-size.tsx
+++ b/src/commands/request-size/request-size.tsx
@@ -42,9 +42,9 @@ export const call: LocalJSXCommandCall = async (onDone, context) => {
     reportText = formatRequestSizeReport(report)
   } catch {
     reportText = [
-      'Request size',
+      'Request context size',
       '',
-      'Unable to estimate request size for the current context.',
+      'Unable to estimate request context size for the current context.',
     ].join('\n')
   }
 

--- a/src/integrations/discoveryService.test.ts
+++ b/src/integrations/discoveryService.test.ts
@@ -14,6 +14,7 @@ const originalEnv = {
   OPENROUTER_API_KEY: process.env.OPENROUTER_API_KEY,
   OPENAI_BASE_URL: process.env.OPENAI_BASE_URL,
   OPENAI_API_BASE: process.env.OPENAI_API_BASE,
+  OPENAI_API_KEY: process.env.OPENAI_API_KEY,
   OPENAI_MODEL: process.env.OPENAI_MODEL,
   CLAUDE_CODE_USE_OPENAI: process.env.CLAUDE_CODE_USE_OPENAI,
   CLAUDE_CODE_USE_GEMINI: process.env.CLAUDE_CODE_USE_GEMINI,
@@ -52,6 +53,7 @@ function restoreEnvValue(
 function clearProviderEnv(): void {
   delete process.env.OPENAI_BASE_URL
   delete process.env.OPENAI_API_BASE
+  delete process.env.OPENAI_API_KEY
   delete process.env.OPENAI_MODEL
   delete process.env.CLAUDE_CODE_USE_OPENAI
   delete process.env.CLAUDE_CODE_USE_GEMINI
@@ -81,6 +83,7 @@ afterEach(() => {
     restoreEnvValue('OPENROUTER_API_KEY')
     restoreEnvValue('OPENAI_BASE_URL')
     restoreEnvValue('OPENAI_API_BASE')
+    restoreEnvValue('OPENAI_API_KEY')
     restoreEnvValue('OPENAI_MODEL')
     restoreEnvValue('CLAUDE_CODE_USE_OPENAI')
     restoreEnvValue('CLAUDE_CODE_USE_GEMINI')

--- a/src/types/command.ts
+++ b/src/types/command.ts
@@ -14,7 +14,7 @@ import type { Message } from './message.js'
 import type { PluginManifest } from './plugin.js'
 
 export type LocalCommandResult =
-  | { type: 'text'; value: string }
+  | { type: 'text'; value: string; display?: 'skip' }
   | {
       type: 'compact'
       compactionResult: CompactionResult

--- a/src/utils/analyzeContext.mcp.test.ts
+++ b/src/utils/analyzeContext.mcp.test.ts
@@ -1,0 +1,143 @@
+import { afterEach, describe, expect, mock, test } from 'bun:test'
+import {
+  acquireSharedMutationLock,
+  releaseSharedMutationLock,
+} from '../test/sharedMutationLock.js'
+import * as realTokenEstimation from '../services/tokenEstimation.js'
+import { createRequestSizeReport } from './requestSizeBreakdown.js'
+import type { ContextData } from './analyzeContext.js'
+
+function makeMcpTool(name: string) {
+  return {
+    name,
+    isMcp: true,
+    inputJSONSchema: { type: 'object', properties: {} },
+    prompt: async () => `Prompt for ${name}`,
+  } as never
+}
+
+function makeContextData(overrides: Partial<ContextData> = {}): ContextData {
+  return {
+    categories: [],
+    totalTokens: 0,
+    maxTokens: 200_000,
+    rawMaxTokens: 200_000,
+    percentage: 0,
+    gridRows: [],
+    model: 'test-model',
+    memoryFiles: [],
+    mcpTools: [],
+    agents: [],
+    isAutoCompactEnabled: false,
+    apiUsage: null,
+    ...overrides,
+  }
+}
+
+async function loadAnalyzeContextForTesting() {
+  return import(`./analyzeContext.js?ts=${Date.now()}-${Math.random()}`)
+}
+
+async function withMcpTokenMocks(
+  isToolSearchEnabled: boolean,
+  run: () => Promise<void>,
+) {
+  await acquireSharedMutationLock('analyzeContext.mcp.test.ts')
+  try {
+    mock.module('../services/tokenEstimation.js', () => ({
+      ...realTokenEstimation,
+      countMessagesTokensWithAPI: mock(async () => 1_500),
+      countTokensViaHaikuFallback: mock(async () => null),
+    }))
+    mock.module('./toolSearch.js', () => ({
+      isToolSearchEnabled: mock(async () => isToolSearchEnabled),
+    }))
+
+    await run()
+  } finally {
+    mock.restore()
+    releaseSharedMutationLock()
+  }
+}
+
+afterEach(() => {
+  mock.restore()
+})
+
+describe('countMcpToolTokens', () => {
+  test('marks MCP tools loaded and request-size groups them by server when Tool Search is not deferred', async () => {
+    await withMcpTokenMocks(false, async () => {
+      const { countMcpToolTokens } = await loadAnalyzeContextForTesting()
+      const result = await countMcpToolTokens(
+        [
+          makeMcpTool('mcp__alpha__search'),
+          makeMcpTool('mcp__beta__list'),
+        ],
+        async () => ({ mode: 'default' }) as never,
+        { activeAgents: [] } as never,
+        'test-model',
+        [],
+      )
+
+      expect(result.deferredToolTokens).toBe(0)
+      expect(result.mcpToolDetails.every(tool => tool.isLoaded)).toBe(true)
+
+      const report = createRequestSizeReport(
+        makeContextData({
+          categories: [
+            {
+              name: 'MCP tools',
+              tokens: result.mcpToolTokens,
+              color: 'permission',
+            },
+          ],
+          mcpTools: result.mcpToolDetails,
+        }),
+      )
+      const labels = report.contributors.map(contributor => contributor.label)
+
+      expect(labels).toContain('MCP server alpha')
+      expect(labels).toContain('MCP server beta')
+      expect(labels).not.toContain('MCP tool schemas')
+    })
+  })
+
+  test('keeps deferred MCP schemas excluded from the outgoing request estimate when Tool Search is deferred', async () => {
+    await withMcpTokenMocks(true, async () => {
+      const { countMcpToolTokens } = await loadAnalyzeContextForTesting()
+      const result = await countMcpToolTokens(
+        [
+          makeMcpTool('mcp__alpha__search'),
+          makeMcpTool('mcp__beta__list'),
+        ],
+        async () => ({ mode: 'default' }) as never,
+        { activeAgents: [] } as never,
+        'test-model',
+        [],
+      )
+
+      expect(result.mcpToolTokens).toBe(0)
+      expect(result.deferredToolTokens).toBeGreaterThan(0)
+      expect(result.mcpToolDetails.every(tool => !tool.isLoaded)).toBe(true)
+
+      const report = createRequestSizeReport(
+        makeContextData({
+          categories: [
+            {
+              name: 'MCP tools (deferred)',
+              tokens: result.deferredToolTokens,
+              color: 'inactive',
+              isDeferred: true,
+            },
+          ],
+          mcpTools: result.mcpToolDetails,
+        }),
+      )
+      const labels = report.contributors.map(contributor => contributor.label)
+
+      expect(report.estimatedTokens).toBe(0)
+      expect(labels).not.toContain('MCP server alpha')
+      expect(labels).not.toContain('MCP server beta')
+    })
+  })
+})

--- a/src/utils/analyzeContext.messageBreakdown.test.ts
+++ b/src/utils/analyzeContext.messageBreakdown.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, mock, test } from 'bun:test'
+import { mkdtemp, rm } from 'fs/promises'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import {
+  acquireSharedMutationLock,
+  releaseSharedMutationLock,
+} from '../test/sharedMutationLock.js'
+import * as realTokenEstimation from '../services/tokenEstimation.js'
+
+async function loadAnalyzeContextForTesting() {
+  return import(`./analyzeContext.js?ts=${Date.now()}-${Math.random()}`)
+}
+
+describe('approximateMessageTokens', () => {
+  test('counts inline user image blocks as attachments/media', async () => {
+    await acquireSharedMutationLock('analyzeContext.messageBreakdown.test.ts')
+    const originalFixtureRoot = process.env.CLAUDE_CODE_TEST_FIXTURES_ROOT
+    const fixtureRoot = await mkdtemp(join(tmpdir(), 'openclaude-vcr-'))
+    process.env.CLAUDE_CODE_TEST_FIXTURES_ROOT = fixtureRoot
+
+    try {
+      const { approximateMessageTokensForTesting } =
+        await loadAnalyzeContextForTesting()
+      const breakdown = await approximateMessageTokensForTesting([
+        {
+          type: 'user',
+          message: {
+            role: 'user',
+            content: [
+              {
+                type: 'image',
+                source: {
+                  type: 'base64',
+                  media_type: 'image/png',
+                  data: 'abc123',
+                },
+              },
+              { type: 'text', text: 'hello' },
+            ],
+          },
+        },
+      ])
+
+      expect(breakdown.attachmentTokens).toBe(2_000)
+      expect(breakdown.attachmentsByType.get('image')).toBe(2_000)
+      expect(breakdown.userMessageTokens).toBeGreaterThan(0)
+    } finally {
+      if (originalFixtureRoot === undefined) {
+        delete process.env.CLAUDE_CODE_TEST_FIXTURES_ROOT
+      } else {
+        process.env.CLAUDE_CODE_TEST_FIXTURES_ROOT = originalFixtureRoot
+      }
+      await rm(fixtureRoot, { recursive: true, force: true })
+      releaseSharedMutationLock()
+    }
+  })
+
+  test('uses local message estimates when provider token counters are unavailable', async () => {
+    await acquireSharedMutationLock('analyzeContext.messageBreakdown.test.ts')
+    const originalFixtureRoot = process.env.CLAUDE_CODE_TEST_FIXTURES_ROOT
+    const fixtureRoot = await mkdtemp(join(tmpdir(), 'openclaude-vcr-'))
+    process.env.CLAUDE_CODE_TEST_FIXTURES_ROOT = fixtureRoot
+
+    try {
+      const countMessagesTokensWithAPI = mock(async () => null)
+      const countTokensViaHaikuFallback = mock(async () => null)
+      mock.module('../services/tokenEstimation.js', () => ({
+        ...realTokenEstimation,
+        countMessagesTokensWithAPI,
+        countTokensViaHaikuFallback,
+      }))
+
+      const { approximateMessageTokensForTesting } =
+        await loadAnalyzeContextForTesting()
+      const breakdown = await approximateMessageTokensForTesting([
+        {
+          type: 'user',
+          message: {
+            role: 'user',
+            content: 'hello from an environment with no token counter',
+          },
+        },
+      ])
+
+      expect(countMessagesTokensWithAPI).toHaveBeenCalled()
+      expect(countTokensViaHaikuFallback).toHaveBeenCalled()
+      expect(breakdown.totalTokens).toBeGreaterThan(0)
+      expect(breakdown.userMessageTokens).toBeGreaterThan(0)
+    } finally {
+      mock.restore()
+      if (originalFixtureRoot === undefined) {
+        delete process.env.CLAUDE_CODE_TEST_FIXTURES_ROOT
+      } else {
+        process.env.CLAUDE_CODE_TEST_FIXTURES_ROOT = originalFixtureRoot
+      }
+      await rm(fixtureRoot, { recursive: true, force: true })
+      releaseSharedMutationLock()
+    }
+  })
+
+  test('uses media-aware estimates instead of serialized base64 length', async () => {
+    await acquireSharedMutationLock('analyzeContext.messageBreakdown.test.ts')
+    const originalFixtureRoot = process.env.CLAUDE_CODE_TEST_FIXTURES_ROOT
+    const fixtureRoot = await mkdtemp(join(tmpdir(), 'openclaude-vcr-'))
+    process.env.CLAUDE_CODE_TEST_FIXTURES_ROOT = fixtureRoot
+
+    try {
+      const { approximateMessageTokensForTesting } =
+        await loadAnalyzeContextForTesting()
+      const breakdown = await approximateMessageTokensForTesting([
+        {
+          type: 'user',
+          message: {
+            role: 'user',
+            content: [
+              {
+                type: 'image',
+                source: {
+                  type: 'base64',
+                  media_type: 'image/png',
+                  data: 'a'.repeat(80_000),
+                },
+              },
+            ],
+          },
+        },
+      ])
+
+      expect(breakdown.attachmentTokens).toBe(2_000)
+      expect(breakdown.attachmentsByType.get('image')).toBe(2_000)
+    } finally {
+      if (originalFixtureRoot === undefined) {
+        delete process.env.CLAUDE_CODE_TEST_FIXTURES_ROOT
+      } else {
+        process.env.CLAUDE_CODE_TEST_FIXTURES_ROOT = originalFixtureRoot
+      }
+      await rm(fixtureRoot, { recursive: true, force: true })
+      releaseSharedMutationLock()
+    }
+  })
+})

--- a/src/utils/analyzeContext.ts
+++ b/src/utils/analyzeContext.ts
@@ -19,6 +19,7 @@ import {
   countMessagesTokensWithAPI,
   countTokensViaHaikuFallback,
   roughTokenCountEstimation,
+  roughTokenCountEstimationForMessages,
 } from '../services/tokenEstimation.js'
 import { estimateSkillFrontmatterTokens } from '../skills/loadSkillsDir.js'
 import {
@@ -93,19 +94,38 @@ async function countTokensWithFallback(
 
   try {
     const fallbackResult = await countTokensViaHaikuFallback(messages, tools)
-    if (fallbackResult === null) {
-      logForDebugging(
-        `countTokensWithFallback: haiku fallback also returned null (${tools.length} tools)`,
-      )
+    if (fallbackResult !== null) {
+      return fallbackResult
     }
-    return fallbackResult
+    logForDebugging(
+      `countTokensWithFallback: haiku fallback also returned null (${tools.length} tools), using local estimate`,
+    )
   } catch (err) {
     logForDebugging(
-      `countTokensWithFallback: haiku fallback failed: ${errorMessage(err)}`,
+      `countTokensWithFallback: haiku fallback failed: ${errorMessage(err)}, using local estimate`,
     )
     logError(err)
-    return null
   }
+
+  return estimateTokensLocally(messages, tools)
+}
+
+function estimateTokensLocally(
+  messages: Anthropic.Beta.Messages.BetaMessageParam[],
+  tools: Anthropic.Beta.Messages.BetaToolUnion[],
+): number {
+  const messageTokens = roughTokenCountEstimationForMessages(
+    messages.map(message => ({
+      type: message.role,
+      message: { content: message.content },
+    })),
+  )
+  const toolTokens =
+    tools.length > 0
+      ? TOOL_TOKEN_COUNT_OVERHEAD + roughTokenCountEstimation(jsonStringify(tools))
+      : 0
+
+  return messageTokens + toolTokens
 }
 
 interface ContextCategory {
@@ -785,8 +805,7 @@ function processAssistantMessage(
 ): void {
   // Process each content block individually
   for (const block of msg.message.content) {
-    const blockStr = jsonStringify(block)
-    const blockTokens = roughTokenCountEstimation(blockStr)
+    const blockTokens = estimateMessageBlockTokens('assistant', block)
 
     if ('type' in block && block.type === 'tool_use') {
       breakdown.toolCallTokens += blockTokens
@@ -817,8 +836,7 @@ function processUserMessage(
 
   // Process each content block individually
   for (const block of msg.message.content) {
-    const blockStr = jsonStringify(block)
-    const blockTokens = roughTokenCountEstimation(blockStr)
+    const blockTokens = estimateMessageBlockTokens('user', block)
 
     if ('type' in block && block.type === 'tool_result') {
       breakdown.toolResultTokens += blockTokens
@@ -829,6 +847,13 @@ function processUserMessage(
         toolName,
         (breakdown.toolResultsByType.get(toolName) || 0) + blockTokens,
       )
+    } else if (isInlineMediaBlock(block)) {
+      breakdown.attachmentTokens += blockTokens
+      const mediaType = String(block.type)
+      breakdown.attachmentsByType.set(
+        mediaType,
+        (breakdown.attachmentsByType.get(mediaType) || 0) + blockTokens,
+      )
     } else {
       // Text blocks or other non-tool content
       breakdown.userMessageTokens += blockTokens
@@ -836,12 +861,34 @@ function processUserMessage(
   }
 }
 
+function isInlineMediaBlock(block: unknown): block is { type: string } {
+  return (
+    typeof block === 'object' &&
+    block !== null &&
+    'type' in block &&
+    (block.type === 'image' ||
+      block.type === 'document' ||
+      block.type === 'container_upload')
+  )
+}
+
+function estimateMessageBlockTokens(
+  role: 'assistant' | 'user',
+  block: unknown,
+): number {
+  return roughTokenCountEstimationForMessages([
+    {
+      type: role,
+      message: { content: [block] },
+    },
+  ])
+}
+
 function processAttachment(
   msg: AttachmentMessage,
   breakdown: MessageBreakdown,
 ): void {
-  const contentStr = jsonStringify(msg.attachment)
-  const tokens = roughTokenCountEstimation(contentStr)
+  const tokens = roughTokenCountEstimationForMessages([msg])
   breakdown.attachmentTokens += tokens
   const attachType = msg.attachment.type || 'unknown'
   breakdown.attachmentsByType.set(
@@ -913,6 +960,12 @@ async function approximateMessageTokens(
 
   breakdown.totalTokens = approximateMessageTokens ?? 0
   return breakdown
+}
+
+export async function approximateMessageTokensForTesting(
+  messages: Message[],
+): Promise<MessageBreakdown> {
+  return approximateMessageTokens(messages)
 }
 
 export async function analyzeContextUsage(

--- a/src/utils/analyzeContext.ts
+++ b/src/utils/analyzeContext.ts
@@ -724,7 +724,8 @@ export async function countMcpToolTokens(
       name: tool.name,
       serverName: tool.name.split('__')[1] || 'unknown',
       tokens: mcpToolTokensByTool[i]!,
-      isLoaded: loadedMcpToolNames.has(tool.name) || !isDeferredTool(tool),
+      isLoaded:
+        !isDeferred || loadedMcpToolNames.has(tool.name) || !isDeferredTool(tool),
     })
   }
 

--- a/src/utils/context.test.ts
+++ b/src/utils/context.test.ts
@@ -16,6 +16,7 @@ const originalEnv = {
     process.env.CLAUDE_CODE_OPENAI_MAX_OUTPUT_TOKENS,
   OPENAI_BASE_URL: process.env.OPENAI_BASE_URL,
   OPENAI_API_BASE: process.env.OPENAI_API_BASE,
+  OPENAI_API_KEY: process.env.OPENAI_API_KEY,
   OPENAI_MODEL: process.env.OPENAI_MODEL,
   MINIMAX_API_KEY: process.env.MINIMAX_API_KEY,
   XAI_API_KEY: process.env.XAI_API_KEY,
@@ -29,6 +30,7 @@ beforeEach(async () => {
   delete process.env.CLAUDE_CODE_OPENAI_MAX_OUTPUT_TOKENS
   delete process.env.OPENAI_BASE_URL
   delete process.env.OPENAI_API_BASE
+  delete process.env.OPENAI_API_KEY
   delete process.env.OPENAI_MODEL
   delete process.env.MINIMAX_API_KEY
   delete process.env.XAI_API_KEY
@@ -73,6 +75,11 @@ afterEach(() => {
       delete process.env.OPENAI_API_BASE
     } else {
       process.env.OPENAI_API_BASE = originalEnv.OPENAI_API_BASE
+    }
+    if (originalEnv.OPENAI_API_KEY === undefined) {
+      delete process.env.OPENAI_API_KEY
+    } else {
+      process.env.OPENAI_API_KEY = originalEnv.OPENAI_API_KEY
     }
     if (originalEnv.MINIMAX_API_KEY === undefined) {
       delete process.env.MINIMAX_API_KEY

--- a/src/utils/processUserInput/processSlashCommand.tsx
+++ b/src/utils/processUserInput/processSlashCommand.tsx
@@ -443,7 +443,10 @@ export async function processSlashCommand(inputString: string, precedingInputBlo
     return {
       messages: [],
       shouldQuery: false,
+      allowedTools,
       model,
+      effort,
+      resultText,
       nextInput,
       submitNextInput
     };
@@ -705,6 +708,15 @@ async function getMessagesForSlashCommand(commandName: string, args: string, set
             }
 
             // Text result — use system message so it doesn't render as a user bubble
+            if (result.display === 'skip') {
+              return {
+                messages: [],
+                shouldQuery: false,
+                command,
+                resultText: result.value
+              };
+            }
+
             return {
               messages: [userMessage, createCommandInputMessage(`<local-command-stdout>${result.value}</local-command-stdout>`)],
               shouldQuery: false,

--- a/src/utils/requestSizeBreakdown.test.ts
+++ b/src/utils/requestSizeBreakdown.test.ts
@@ -1,0 +1,432 @@
+import { describe, expect, test } from 'bun:test'
+import type { ContextData } from './analyzeContext.js'
+import {
+  createRequestSizeReport,
+  formatRequestSizeReport,
+} from './requestSizeBreakdown.js'
+
+function makeContextData(overrides: Partial<ContextData> = {}): ContextData {
+  return {
+    categories: [],
+    totalTokens: 0,
+    maxTokens: 200_000,
+    rawMaxTokens: 200_000,
+    percentage: 0,
+    gridRows: [],
+    model: 'test-model',
+    memoryFiles: [],
+    mcpTools: [],
+    agents: [],
+    isAutoCompactEnabled: false,
+    messageBreakdown: {
+      toolCallTokens: 0,
+      toolResultTokens: 0,
+      attachmentTokens: 0,
+      assistantMessageTokens: 0,
+      userMessageTokens: 0,
+      toolCallsByType: [],
+      attachmentsByType: [],
+    },
+    apiUsage: null,
+    ...overrides,
+  }
+}
+
+describe('request size breakdown', () => {
+  test('large tool result appears as a top contributor', () => {
+    const report = createRequestSizeReport(
+      makeContextData({
+        categories: [{ name: 'Messages', tokens: 20_000, color: 'permission' }],
+        messageBreakdown: {
+          toolCallTokens: 500,
+          toolResultTokens: 16_000,
+          attachmentTokens: 0,
+          assistantMessageTokens: 1_500,
+          userMessageTokens: 2_000,
+          toolCallsByType: [
+            { name: 'Bash', callTokens: 500, resultTokens: 16_000 },
+          ],
+          attachmentsByType: [],
+        },
+      }),
+    )
+
+    expect(report.topContributors[0]?.label).toBe('Tool results')
+    expect(report.topContributors[0]?.tokens).toBe(16_000)
+  })
+
+  test('uses rough message contributors when the Messages category is unavailable', () => {
+    const report = createRequestSizeReport(
+      makeContextData({
+        categories: [],
+        messageBreakdown: {
+          toolCallTokens: 500,
+          toolResultTokens: 16_000,
+          attachmentTokens: 0,
+          assistantMessageTokens: 1_500,
+          userMessageTokens: 2_000,
+          toolCallsByType: [
+            { name: 'Bash', callTokens: 500, resultTokens: 16_000 },
+          ],
+          attachmentsByType: [],
+        },
+      }),
+    )
+
+    expect(report.estimatedTokens).toBe(20_000)
+    expect(report.topContributors[0]).toEqual(
+      expect.objectContaining({ label: 'Tool results', tokens: 16_000 }),
+    )
+  })
+
+  test('message contributor estimates are reconciled to the Messages category total', () => {
+    const report = createRequestSizeReport(
+      makeContextData({
+        categories: [{ name: 'Messages', tokens: 1_000, color: 'permission' }],
+        messageBreakdown: {
+          toolCallTokens: 0,
+          toolResultTokens: 8_000,
+          attachmentTokens: 0,
+          assistantMessageTokens: 500,
+          userMessageTokens: 500,
+          toolCallsByType: [
+            { name: 'Bash', callTokens: 0, resultTokens: 8_000 },
+          ],
+          attachmentsByType: [],
+        },
+      }),
+    )
+
+    const toolResults = report.contributors.find(
+      contributor => contributor.label === 'Tool results',
+    )
+    const conversationHistory = report.contributors.find(
+      contributor => contributor.label === 'Conversation history',
+    )
+
+    expect(report.estimatedTokens).toBe(1_000)
+    expect(toolResults?.tokens).toBe(889)
+    expect(conversationHistory?.tokens).toBe(111)
+  })
+
+  test('message contributor rounding preserves the Messages category total', () => {
+    const report = createRequestSizeReport(
+      makeContextData({
+        categories: [{ name: 'Messages', tokens: 2, color: 'permission' }],
+        messageBreakdown: {
+          toolCallTokens: 1,
+          toolResultTokens: 1,
+          attachmentTokens: 1,
+          assistantMessageTokens: 0,
+          userMessageTokens: 0,
+          toolCallsByType: [{ name: 'Bash', callTokens: 1, resultTokens: 1 }],
+          attachmentsByType: [{ name: 'image', tokens: 1 }],
+        },
+      }),
+    )
+
+    const messageContributorTokens = report.contributors
+      .filter(contributor =>
+        ['tool_calls', 'tool_results', 'attachments'].includes(
+          contributor.kind,
+        ),
+      )
+      .reduce((sum, contributor) => sum + contributor.tokens, 0)
+
+    expect(report.estimatedTokens).toBe(2)
+    expect(messageContributorTokens).toBe(2)
+    expect(report.contributors).not.toContainEqual(
+      expect.objectContaining({ label: 'Other request content' }),
+    )
+  })
+
+  test('MCP tool schemas are grouped by server', () => {
+    const report = createRequestSizeReport(
+      makeContextData({
+        categories: [{ name: 'MCP tools', tokens: 30_000, color: 'permission' }],
+        mcpTools: [
+          {
+            name: 'mcp__github__search',
+            serverName: 'github',
+            tokens: 20_000,
+            isLoaded: true,
+          },
+          {
+            name: 'mcp__linear__list',
+            serverName: 'linear',
+            tokens: 10_000,
+            isLoaded: true,
+          },
+        ],
+      }),
+    )
+
+    expect(report.contributors.map(c => c.label)).toContain('MCP server github')
+    expect(report.contributors.map(c => c.label)).toContain('MCP server linear')
+  })
+
+  test('MCP server rounding preserves the MCP tools category total', () => {
+    const report = createRequestSizeReport(
+      makeContextData({
+        categories: [{ name: 'MCP tools', tokens: 2, color: 'permission' }],
+        mcpTools: [
+          {
+            name: 'mcp__one__search',
+            serverName: 'one',
+            tokens: 1,
+            isLoaded: true,
+          },
+          {
+            name: 'mcp__two__search',
+            serverName: 'two',
+            tokens: 1,
+            isLoaded: true,
+          },
+          {
+            name: 'mcp__three__search',
+            serverName: 'three',
+            tokens: 1,
+            isLoaded: true,
+          },
+        ],
+      }),
+    )
+
+    const mcpTokens = report.contributors
+      .filter(contributor => contributor.kind === 'mcp_tool_schemas')
+      .reduce((sum, contributor) => sum + contributor.tokens, 0)
+
+    expect(report.estimatedTokens).toBe(2)
+    expect(mcpTokens).toBe(2)
+    expect(report.contributors).not.toContainEqual(
+      expect.objectContaining({ label: 'Other request content' }),
+    )
+  })
+
+  test('deferred MCP schemas are excluded from the outgoing request estimate', () => {
+    const report = createRequestSizeReport(
+      makeContextData({
+        categories: [
+          {
+            name: 'MCP tools (deferred)',
+            tokens: 50_000,
+            color: 'inactive',
+            isDeferred: true,
+          },
+        ],
+        mcpTools: [
+          {
+            name: 'mcp__github__search',
+            serverName: 'github',
+            tokens: 50_000,
+            isLoaded: false,
+          },
+        ],
+      }),
+    )
+
+    expect(report.contributors.map(c => c.label)).not.toContain(
+      'MCP server github',
+    )
+    expect(report.estimatedTokens).toBe(0)
+  })
+
+  test('attachments and media are counted separately from conversation history', () => {
+    const report = createRequestSizeReport(
+      makeContextData({
+        categories: [{ name: 'Messages', tokens: 12_500, color: 'permission' }],
+        messageBreakdown: {
+          toolCallTokens: 0,
+          toolResultTokens: 0,
+          attachmentTokens: 8_000,
+          assistantMessageTokens: 2_000,
+          userMessageTokens: 2_500,
+          toolCallsByType: [],
+          attachmentsByType: [{ name: 'image', tokens: 8_000 }],
+        },
+      }),
+    )
+
+    expect(report.contributors).toContainEqual(
+      expect.objectContaining({ label: 'Attachments/media', tokens: 8_000 }),
+    )
+    expect(report.contributors).toContainEqual(
+      expect.objectContaining({ label: 'Conversation history', tokens: 4_500 }),
+    )
+  })
+
+  test('built-in tool schemas are counted separately', () => {
+    const report = createRequestSizeReport(
+      makeContextData({
+        categories: [
+          { name: 'System prompt', tokens: 1_000, color: 'permission' },
+          { name: 'System tools', tokens: 7_000, color: 'permission' },
+        ],
+      }),
+    )
+
+    expect(report.contributors).toContainEqual(
+      expect.objectContaining({ label: 'Tool schemas', tokens: 7_000 }),
+    )
+  })
+
+  test('formatted report does not print secret-looking contributor names', () => {
+    const report = createRequestSizeReport(
+      makeContextData({
+        categories: [{ name: 'MCP tools', tokens: 1_000, color: 'permission' }],
+        mcpTools: [
+          {
+            name: 'mcp__sk-test-secret123456789__tool',
+            serverName: 'sk-test-secret123456789',
+            tokens: 1_000,
+            isLoaded: true,
+          },
+        ],
+      }),
+    )
+
+    const output = formatRequestSizeReport(report)
+
+    expect(output).toContain('MCP server redacted')
+    expect(output).not.toContain('sk-test-secret123456789')
+  })
+
+  test('formatted report redacts common token prefixes from contributor names', () => {
+    const output = formatRequestSizeReport(
+      createRequestSizeReport(
+        makeContextData({
+          categories: [{ name: 'MCP tools', tokens: 4_000, color: 'permission' }],
+          mcpTools: [
+            {
+              name: 'mcp__github__tool',
+              serverName: `ghp_${'a'.repeat(36)}`,
+              tokens: 1_000,
+              isLoaded: true,
+            },
+            {
+              name: 'mcp__github-fine__tool',
+              serverName: `github_pat_${'b'.repeat(82)}`,
+              tokens: 1_000,
+              isLoaded: true,
+            },
+            {
+              name: 'mcp__aws__tool',
+              serverName: `AKIA${'A'.repeat(16)}`,
+              tokens: 1_000,
+              isLoaded: true,
+            },
+            {
+              name: 'mcp__slack__tool',
+              serverName: `xoxb-1234567890-1234567890-${'c'.repeat(24)}`,
+              tokens: 1_000,
+              isLoaded: true,
+            },
+          ],
+        }),
+      ),
+    )
+
+    expect(output).not.toContain('ghp_')
+    expect(output).not.toContain('github_pat_')
+    expect(output).not.toContain('AKIA')
+    expect(output).not.toContain('xoxb-')
+    expect(output).toContain('MCP server redacted')
+  })
+
+  test('formatted tool details redact secrets and preserve the markdown table', () => {
+    const report = createRequestSizeReport(
+      makeContextData({
+        categories: [{ name: 'Messages', tokens: 9_000, color: 'permission' }],
+        messageBreakdown: {
+          toolCallTokens: 0,
+          toolResultTokens: 9_000,
+          attachmentTokens: 0,
+          assistantMessageTokens: 0,
+          userMessageTokens: 0,
+          toolCallsByType: [
+            {
+              name: 'Fetch|token=sk-test-secret123456789',
+              callTokens: 0,
+              resultTokens: 9_000,
+            },
+          ],
+          attachmentsByType: [],
+        },
+      }),
+    )
+
+    const output = formatRequestSizeReport(report)
+
+    expect(output).toContain('Fetch/token=redacted')
+    expect(output).not.toContain('sk-test-secret123456789')
+    expect(output).not.toContain('Fetch|token=')
+  })
+
+  test('unknown request categories are reported as other request content', () => {
+    const report = createRequestSizeReport(
+      makeContextData({
+        categories: [
+          { name: 'Provider shim overhead', tokens: 1_250, color: 'inactive' },
+        ],
+      }),
+    )
+
+    expect(report.contributors).toContainEqual(
+      expect.objectContaining({
+        label: 'Other request content',
+        tokens: 1_250,
+      }),
+    )
+  })
+
+  test('empty context formats without fake contributors', () => {
+    const report = createRequestSizeReport(makeContextData())
+
+    expect(report.estimatedTokens).toBe(0)
+    expect(formatRequestSizeReport(report)).toContain(
+      'No request contributors found',
+    )
+  })
+
+  test('formats an estimate without provider credentials', () => {
+    const originalAnthropicKey = process.env.ANTHROPIC_API_KEY
+    const originalOpenAIKey = process.env.OPENAI_API_KEY
+    delete process.env.ANTHROPIC_API_KEY
+    delete process.env.OPENAI_API_KEY
+
+    try {
+      const output = formatRequestSizeReport(
+        createRequestSizeReport(
+          makeContextData({
+            categories: [
+              { name: 'System prompt', tokens: 1_000, color: 'permission' },
+              { name: 'Messages', tokens: 2_000, color: 'permission' },
+            ],
+            messageBreakdown: {
+              toolCallTokens: 0,
+              toolResultTokens: 0,
+              attachmentTokens: 0,
+              assistantMessageTokens: 1_000,
+              userMessageTokens: 1_000,
+              toolCallsByType: [],
+              attachmentsByType: [],
+            },
+          }),
+        ),
+      )
+
+      expect(output).toContain('Estimated request size:')
+    } finally {
+      if (originalAnthropicKey === undefined) {
+        delete process.env.ANTHROPIC_API_KEY
+      } else {
+        process.env.ANTHROPIC_API_KEY = originalAnthropicKey
+      }
+      if (originalOpenAIKey === undefined) {
+        delete process.env.OPENAI_API_KEY
+      } else {
+        process.env.OPENAI_API_KEY = originalOpenAIKey
+      }
+    }
+  })
+})

--- a/src/utils/requestSizeBreakdown.test.ts
+++ b/src/utils/requestSizeBreakdown.test.ts
@@ -362,6 +362,66 @@ describe('request size breakdown', () => {
     expect(output).not.toContain('Fetch|token=')
   })
 
+  test('formatted report describes a token-derived context estimate with media caveat', () => {
+    const output = formatRequestSizeReport(
+      createRequestSizeReport(
+        makeContextData({
+          categories: [
+            { name: 'System prompt', tokens: 1_000, color: 'permission' },
+            { name: 'Messages', tokens: 2_000, color: 'permission' },
+          ],
+          messageBreakdown: {
+            toolCallTokens: 0,
+            toolResultTokens: 0,
+            attachmentTokens: 1_000,
+            assistantMessageTokens: 500,
+            userMessageTokens: 500,
+            toolCallsByType: [],
+            attachmentsByType: [{ name: 'image', tokens: 1_000 }],
+          },
+        }),
+      ),
+    )
+
+    expect(output).toContain('Request context size')
+    expect(output).toContain('Estimated context load:')
+    expect(output).toContain('rough byte equivalent at ~4 bytes/token')
+    expect(output).toContain(
+      'This is a context/token estimate, not the serialized JSON request-body size.',
+    )
+    expect(output).toContain(
+      'Base64 image/PDF/media payloads may be much larger on the wire.',
+    )
+    expect(output).not.toContain('Estimated request size:')
+  })
+
+  test('formatted report does not print request content', () => {
+    const output = formatRequestSizeReport(
+      createRequestSizeReport(
+        makeContextData({
+          categories: [{ name: 'Messages', tokens: 8_000, color: 'permission' }],
+          messageBreakdown: {
+            toolCallTokens: 0,
+            toolResultTokens: 0,
+            attachmentTokens: 8_000,
+            assistantMessageTokens: 0,
+            userMessageTokens: 0,
+            toolCallsByType: [],
+            attachmentsByType: [
+              {
+                name: 'image/png;base64,SECRET_IMAGE_BYTES_SHOULD_NOT_PRINT',
+                tokens: 8_000,
+              },
+            ],
+          },
+        }),
+      ),
+    )
+
+    expect(output).toContain('Attachments/media')
+    expect(output).not.toContain('SECRET_IMAGE_BYTES_SHOULD_NOT_PRINT')
+  })
+
   test('unknown request categories are reported as other request content', () => {
     const report = createRequestSizeReport(
       makeContextData({
@@ -415,7 +475,7 @@ describe('request size breakdown', () => {
         ),
       )
 
-      expect(output).toContain('Estimated request size:')
+      expect(output).toContain('Estimated context load:')
     } finally {
       if (originalAnthropicKey === undefined) {
         delete process.env.ANTHROPIC_API_KEY

--- a/src/utils/requestSizeBreakdown.ts
+++ b/src/utils/requestSizeBreakdown.ts
@@ -1,0 +1,387 @@
+import type { ContextData } from './analyzeContext.js'
+import { redactSecrets } from '../services/teamMemorySync/secretScanner.js'
+import { formatFileSize, formatTokens } from './format.js'
+import { redactUrlForDisplay } from './urlRedaction.js'
+
+const ESTIMATED_BYTES_PER_TOKEN = 4
+
+type ContributorKind =
+  | 'system_prompt'
+  | 'tool_schemas'
+  | 'mcp_tool_schemas'
+  | 'conversation_history'
+  | 'tool_calls'
+  | 'tool_results'
+  | 'attachments'
+  | 'memory'
+  | 'agents'
+  | 'skills'
+  | 'other'
+
+export type RequestSizeContributor = {
+  label: string
+  kind: ContributorKind
+  tokens: number
+  bytes: number
+  details?: string
+}
+
+export type RequestSizeReport = {
+  estimatedTokens: number
+  estimatedBytes: number
+  contributors: RequestSizeContributor[]
+  topContributors: RequestSizeContributor[]
+}
+
+function estimateBytes(tokens: number): number {
+  return Math.max(0, Math.round(tokens * ESTIMATED_BYTES_PER_TOKEN))
+}
+
+function sanitizeDisplayName(value: string | undefined): string {
+  const raw = (value ?? 'unknown').trim() || 'unknown'
+  const secretRedacted = redactSecrets(raw).replace(/\[REDACTED\]/g, 'redacted')
+  const printable = redactUrlForDisplay(secretRedacted)
+    .replace(/[^\x20-\x7e]/g, '?')
+    .replace(/\|/g, '/')
+    .replace(/sk-ant-[A-Za-z0-9_-]{8,}/g, 'redacted')
+    .replace(/sk-[A-Za-z0-9_-]{8,}/g, 'redacted')
+    .replace(/AIza[A-Za-z0-9_-]{20,}/g, 'redacted')
+    .replace(
+      /((?:api[_-]?key|token|secret|password|passwd|pwd|auth|authorization)=)[^,\s;|)]+/gi,
+      '$1redacted',
+    )
+
+  return printable.length > 80 ? `${printable.slice(0, 77)}...` : printable
+}
+
+function categoryTokens(data: ContextData, names: string[]): number {
+  return data.categories
+    .filter(category => names.includes(category.name))
+    .reduce((sum, category) => sum + category.tokens, 0)
+}
+
+function isRequestPayloadCategory(category: ContextData['categories'][number]) {
+  if ((category as { isDeferred?: boolean }).isDeferred) return false
+  return ![
+    'Free space',
+    'Autocompact buffer',
+    'Compact buffer',
+    'MCP tools (deferred)',
+    'System tools (deferred)',
+  ].includes(category.name)
+}
+
+function requestCategoryTokenTotal(data: ContextData): number {
+  return data.categories
+    .filter(isRequestPayloadCategory)
+    .reduce((sum, category) => sum + category.tokens, 0)
+}
+
+function addContributor(
+  contributors: RequestSizeContributor[],
+  label: string,
+  kind: ContributorKind,
+  tokens: number,
+  details?: string,
+) {
+  if (tokens <= 0) return
+  contributors.push({
+    label,
+    kind,
+    tokens,
+    bytes: estimateBytes(tokens),
+    details,
+  })
+}
+
+function topDetail(
+  rows: Array<{ name: string; tokens: number }>,
+  label: string,
+): string | undefined {
+  const top = rows
+    .filter(row => row.tokens > 0)
+    .sort((a, b) => b.tokens - a.tokens)
+    .slice(0, 3)
+
+  if (top.length === 0) return undefined
+
+  return `${label}: ${top
+    .map(row => `${sanitizeDisplayName(row.name)} ${formatTokens(row.tokens)}`)
+    .join(', ')}`
+}
+
+function addMcpContributors(
+  data: ContextData,
+  contributors: RequestSizeContributor[],
+) {
+  const mcpCategoryTokens = categoryTokens(data, ['MCP tools'])
+  const loadedTools = data.mcpTools.filter(tool => tool.isLoaded !== false)
+
+  if (loadedTools.length === 0) {
+    addContributor(
+      contributors,
+      'MCP tool schemas',
+      'mcp_tool_schemas',
+      mcpCategoryTokens,
+    )
+    return
+  }
+
+  const byServer = new Map<string, number>()
+  for (const tool of loadedTools) {
+    const serverName = sanitizeDisplayName(tool.serverName || 'unknown')
+    byServer.set(serverName, (byServer.get(serverName) ?? 0) + tool.tokens)
+  }
+
+  const serverEntries = [...byServer.entries()]
+  const scaledServerTokens =
+    mcpCategoryTokens > 0
+      ? scaleTokenParts(
+          serverEntries.map(([, tokens]) => tokens),
+          mcpCategoryTokens,
+        )
+      : serverEntries.map(([, tokens]) => tokens)
+
+  for (const [index, [serverName]] of serverEntries.entries()) {
+    addContributor(
+      contributors,
+      `MCP server ${serverName}`,
+      'mcp_tool_schemas',
+      scaledServerTokens[index] ?? 0,
+    )
+  }
+}
+
+function scaleTokens(tokens: number, scale: number): number {
+  return Math.max(0, Math.round(tokens * scale))
+}
+
+function scaleTokenParts(tokens: number[], targetTotal: number): number[] {
+  if (targetTotal <= 0) return tokens.map(tokenCount => Math.max(0, tokenCount))
+
+  const rawTotal = tokens.reduce((sum, tokenCount) => sum + tokenCount, 0)
+  if (rawTotal <= 0) return tokens.map(() => 0)
+
+  const scaled = tokens.map((tokenCount, index) => {
+    const exact = (tokenCount / rawTotal) * targetTotal
+    const floor = Math.floor(exact)
+    return {
+      index,
+      tokens: floor,
+      remainder: exact - floor,
+    }
+  })
+
+  let remaining =
+    targetTotal - scaled.reduce((sum, part) => sum + part.tokens, 0)
+  for (const part of [...scaled].sort((a, b) => b.remainder - a.remainder)) {
+    if (remaining <= 0) break
+    part.tokens += 1
+    remaining -= 1
+  }
+
+  return scaled
+    .sort((a, b) => a.index - b.index)
+    .map(part => Math.max(0, part.tokens))
+}
+
+export function createRequestSizeReport(data: ContextData): RequestSizeReport {
+  const contributors: RequestSizeContributor[] = []
+  const messageBreakdown = data.messageBreakdown
+  const messageCategoryTokens = categoryTokens(data, ['Messages'])
+
+  addContributor(
+    contributors,
+    'System prompt',
+    'system_prompt',
+    categoryTokens(data, ['System prompt']),
+  )
+  addContributor(
+    contributors,
+    'Tool schemas',
+    'tool_schemas',
+    categoryTokens(data, ['System tools', '[internal] System tools']),
+  )
+  addMcpContributors(data, contributors)
+  addContributor(
+    contributors,
+    'Memory files',
+    'memory',
+    categoryTokens(data, ['Memory files']),
+    data.memoryFiles.length > 0
+      ? `${data.memoryFiles.length} memory file${data.memoryFiles.length === 1 ? '' : 's'}`
+      : undefined,
+  )
+  addContributor(
+    contributors,
+    'Custom agents',
+    'agents',
+    categoryTokens(data, ['Custom agents']),
+    data.agents.length > 0
+      ? `${data.agents.length} custom agent${data.agents.length === 1 ? '' : 's'}`
+      : undefined,
+  )
+  addContributor(
+    contributors,
+    'Skills',
+    'skills',
+    categoryTokens(data, ['Skills']),
+    data.skills
+      ? `${data.skills.includedSkills}/${data.skills.totalSkills} skills included`
+      : undefined,
+  )
+
+  if (messageBreakdown) {
+    const rawConversationTokens =
+      messageBreakdown.assistantMessageTokens +
+      messageBreakdown.userMessageTokens
+    const rawMessageContributorTokens =
+      rawConversationTokens +
+      messageBreakdown.toolCallTokens +
+      messageBreakdown.toolResultTokens +
+      messageBreakdown.attachmentTokens
+    const messageScale =
+      messageCategoryTokens > 0 && rawMessageContributorTokens > 0
+        ? messageCategoryTokens / rawMessageContributorTokens
+        : 1
+    const [
+      conversationTokens,
+      toolCallTokens,
+      toolResultTokens,
+      attachmentTokens,
+    ] =
+      messageCategoryTokens > 0
+        ? scaleTokenParts(
+            [
+              rawConversationTokens,
+              messageBreakdown.toolCallTokens,
+              messageBreakdown.toolResultTokens,
+              messageBreakdown.attachmentTokens,
+            ],
+            messageCategoryTokens,
+          )
+        : [
+            rawConversationTokens,
+            messageBreakdown.toolCallTokens,
+            messageBreakdown.toolResultTokens,
+            messageBreakdown.attachmentTokens,
+          ]
+
+    addContributor(
+      contributors,
+      'Conversation history',
+      'conversation_history',
+      conversationTokens ?? 0,
+    )
+    addContributor(
+      contributors,
+      'Tool calls',
+      'tool_calls',
+      toolCallTokens ?? 0,
+      topDetail(
+        messageBreakdown.toolCallsByType.map(tool => ({
+          name: tool.name,
+          tokens: scaleTokens(tool.callTokens, messageScale),
+        })),
+        'Top calls',
+      ),
+    )
+    addContributor(
+      contributors,
+      'Tool results',
+      'tool_results',
+      toolResultTokens ?? 0,
+      topDetail(
+        messageBreakdown.toolCallsByType.map(tool => ({
+          name: tool.name,
+          tokens: scaleTokens(tool.resultTokens, messageScale),
+        })),
+        'Top results',
+      ),
+    )
+    addContributor(
+      contributors,
+      'Attachments/media',
+      'attachments',
+      attachmentTokens ?? 0,
+      topDetail(
+        messageBreakdown.attachmentsByType.map(attachment => ({
+          name: attachment.name,
+          tokens: scaleTokens(attachment.tokens, messageScale),
+        })),
+        'Top media',
+      ),
+    )
+  }
+
+  const accountedTokens = contributors.reduce(
+    (sum, contributor) => sum + contributor.tokens,
+    0,
+  )
+  const categoryTotal = requestCategoryTokenTotal(data)
+  const unaccountedTokens = Math.max(0, categoryTotal - accountedTokens)
+  addContributor(
+    contributors,
+    'Other request content',
+    'other',
+    unaccountedTokens,
+  )
+
+  const sortedContributors = contributors
+    .filter(contributor => contributor.tokens > 0)
+    .sort((a, b) => b.tokens - a.tokens)
+
+  const contributorTotal = sortedContributors.reduce(
+    (sum, contributor) => sum + contributor.tokens,
+    0,
+  )
+  const estimatedTokens = categoryTotal > 0 ? categoryTotal : contributorTotal
+
+  return {
+    estimatedTokens,
+    estimatedBytes: estimateBytes(estimatedTokens),
+    contributors: sortedContributors,
+    topContributors: sortedContributors.slice(0, 10),
+  }
+}
+
+export function formatRequestSizeReport(report: RequestSizeReport): string {
+  const lines = [
+    'Request size',
+    '',
+    `Estimated request size: ${formatFileSize(report.estimatedBytes)} (~${formatTokens(report.estimatedTokens)} tokens)`,
+    [
+      'Estimate method: current context diagnostics at ~4 bytes/token;',
+      'provider-specific JSON wrappers can vary.',
+    ].join(' '),
+    [
+      'Privacy: shows contributor names and sizes only;',
+      'request content is not printed.',
+    ].join(' '),
+    '',
+  ]
+
+  if (report.topContributors.length === 0) {
+    lines.push('No request contributors found for the current context.')
+    return lines.join('\n')
+  }
+
+  lines.push('Top contributors:')
+  lines.push('')
+  lines.push('| # | Contributor | Tokens | Estimated size |')
+  lines.push('|---|-------------|--------|----------------|')
+
+  for (const [index, contributor] of report.topContributors.entries()) {
+    const details = contributor.details ? ` (${contributor.details})` : ''
+    lines.push(
+      [
+        `| ${index + 1}`,
+        contributor.label + details,
+        formatTokens(contributor.tokens),
+        `${formatFileSize(contributor.bytes)} |`,
+      ].join(' | '),
+    )
+  }
+
+  return lines.join('\n')
+}

--- a/src/utils/requestSizeBreakdown.ts
+++ b/src/utils/requestSizeBreakdown.ts
@@ -43,6 +43,7 @@ function sanitizeDisplayName(value: string | undefined): string {
   const printable = redactUrlForDisplay(secretRedacted)
     .replace(/[^\x20-\x7e]/g, '?')
     .replace(/\|/g, '/')
+    .replace(/(base64,)[^,\s;|)]+/gi, '$1redacted')
     .replace(/sk-ant-[A-Za-z0-9_-]{8,}/g, 'redacted')
     .replace(/sk-[A-Za-z0-9_-]{8,}/g, 'redacted')
     .replace(/AIza[A-Za-z0-9_-]{20,}/g, 'redacted')
@@ -347,12 +348,12 @@ export function createRequestSizeReport(data: ContextData): RequestSizeReport {
 
 export function formatRequestSizeReport(report: RequestSizeReport): string {
   const lines = [
-    'Request size',
+    'Request context size',
     '',
-    `Estimated request size: ${formatFileSize(report.estimatedBytes)} (~${formatTokens(report.estimatedTokens)} tokens)`,
+    `Estimated context load: ${formatFileSize(report.estimatedBytes)} (~${formatTokens(report.estimatedTokens)} tokens; rough byte equivalent at ~4 bytes/token)`,
     [
-      'Estimate method: current context diagnostics at ~4 bytes/token;',
-      'provider-specific JSON wrappers can vary.',
+      'Caveat: This is a context/token estimate, not the serialized JSON request-body size.',
+      'Base64 image/PDF/media payloads may be much larger on the wire.',
     ].join(' '),
     [
       'Privacy: shows contributor names and sizes only;',
@@ -368,8 +369,8 @@ export function formatRequestSizeReport(report: RequestSizeReport): string {
 
   lines.push('Top contributors:')
   lines.push('')
-  lines.push('| # | Contributor | Tokens | Estimated size |')
-  lines.push('|---|-------------|--------|----------------|')
+  lines.push('| # | Contributor | Tokens | Context byte equiv. |')
+  lines.push('|---|-------------|--------|---------------------|')
 
   for (const [index, contributor] of report.topContributors.entries()) {
     const details = contributor.details ? ` (${contributor.details})` : ''


### PR DESCRIPTION
## Summary
- Add a read-only `/request-size` diagnostic command for interactive and non-interactive sessions.
- Show estimated request size plus top contributors across system prompt, built-in tool schemas, MCP schemas grouped by server, conversation history, tool calls, tool results, attachments/media, memory, agents, skills, and uncategorized request content.
- Keep diagnostic output out of the transcript/model-visible context, redact secret-looking contributor names, and avoid printing request contents.
- Add local token-count fallback and media-aware attachment estimates so diagnostics still work without provider credentials and do not over-rank base64 media payloads.
- Harden provider test isolation against ambient `OPENAI_API_KEY` values.

Fixes #736

## Validation
- `bun install --frozen-lockfile`
- `bun run smoke`
- `bun test --max-concurrency=1` (2780 pass, 0 fail)
- `python -m pip install -r python/requirements.txt`
- `python -m pytest -q python/tests` (44 pass, 0 fail)
- `bun run security:pr-scan -- --base upstream/main`
- `bun run test:provider` (562 pass, 0 fail)
- `npm run test:provider-recommendation` (75 pass, 0 fail)
- `bun install --cwd web --frozen-lockfile`
- `bun run --cwd web typecheck`
- `bun run --cwd web build`
- `git diff --check`
