### PR TITLE
feat(doctor): warn local-model users about large context contributors

### DIFF
--- a/src/__tests__/doctorContextWarnings.test.ts
+++ b/src/__tests__/doctorContextWarnings.test.ts
@@ -1,0 +1,153 @@
+import { describe, expect, test } from 'bun:test'
+import { getEmptyToolPermissionContext, type Tool } from '../Tool.js'
+import type { AgentDefinitionsResult } from '../tools/AgentTool/loadAgentsDir.js'
+import { checkContextWarnings } from '../utils/doctorContextWarnings.js'
+
+const emptyPermissionContext = async () => getEmptyToolPermissionContext()
+
+function mcpTool(serverName: string, toolName: string, descriptionLength: number): Tool {
+  return {
+    name: `mcp__${serverName}__${toolName}`,
+    isMcp: true,
+    mcpInfo: { serverName, toolName },
+    inputJSONSchema: { type: 'object', properties: {} },
+    async prompt() {
+      return 'x'.repeat(descriptionLength)
+    },
+  } as unknown as Tool
+}
+
+function mcpToolThatReadsPermissionContext(): Tool {
+  return {
+    name: 'mcp__permissionserver__search',
+    isMcp: true,
+    mcpInfo: { serverName: 'permissionserver', toolName: 'search' },
+    inputJSONSchema: { type: 'object', properties: {} },
+    async prompt({ getToolPermissionContext }) {
+      await getToolPermissionContext()
+      return 'permission-aware tool'
+    },
+  } as unknown as Tool
+}
+
+function toolSearchTool(): Tool {
+  return {
+    name: 'ToolSearch',
+    isMcp: false,
+    inputJSONSchema: { type: 'object', properties: {} },
+    async prompt() {
+      return 'search deferred tools'
+    },
+  } as unknown as Tool
+}
+
+describe('checkContextWarnings', () => {
+  test('estimated MCP warning includes prompt descriptions and top server contributors', async () => {
+    const warnings = await checkContextWarnings(
+      [mcpTool('github', 'search', 80_000), mcpTool('linear', 'list', 40_000)],
+      null,
+      emptyPermissionContext,
+      { memoryFiles: [], mcpTokenStrategy: 'estimate' },
+    )
+
+    expect(warnings.mcpWarning?.currentValue).toBeGreaterThan(25_000)
+    expect(warnings.mcpWarning?.details).toEqual([
+      expect.stringMatching(/^github: 1 tools \(~20,\d+ tokens\)$/),
+      expect.stringMatching(/^linear: 1 tools \(~10,\d+ tokens\)$/),
+    ])
+  })
+
+  test('large agent descriptions list top contributors', async () => {
+    const agentDefinitions: AgentDefinitionsResult = {
+      activeAgents: [
+        {
+          agentType: 'planner',
+          whenToUse: 'x'.repeat(80_000),
+          source: 'userSettings',
+          getSystemPrompt: () => '',
+        },
+        {
+          agentType: 'reviewer',
+          whenToUse: 'x'.repeat(20_000),
+          source: 'projectSettings',
+          getSystemPrompt: () => '',
+        },
+      ],
+      allAgents: [],
+    }
+
+    const warnings = await checkContextWarnings(
+      [],
+      agentDefinitions,
+      emptyPermissionContext,
+      { memoryFiles: [] },
+    )
+
+    expect(warnings.agentWarning?.details).toEqual([
+      expect.stringMatching(/^planner: ~20,\d+ tokens$/),
+      expect.stringMatching(/^reviewer: ~5,\d+ tokens$/),
+    ])
+  })
+
+  test('large CLAUDE.md warnings show file paths and sizes', async () => {
+    const warnings = await checkContextWarnings(
+      [],
+      null,
+      emptyPermissionContext,
+      {
+        memoryFiles: [
+          {
+            path: '/repo/CLAUDE.md',
+            type: 'Project',
+            content: 'x'.repeat(50_000),
+          },
+          {
+            path: '/repo/.claude/rules/backend.md',
+            type: 'Project',
+            content: 'y'.repeat(45_000),
+          },
+        ],
+      },
+    )
+
+    expect(warnings.claudeMdWarning?.details).toEqual([
+      '/repo/CLAUDE.md: 50,000 chars',
+      '/repo/.claude/rules/backend.md: 45,000 chars',
+    ])
+  })
+
+  test('keeps unrelated context warnings when Tool Search accounting fails', async () => {
+    const previousToolSearch = process.env.ENABLE_TOOL_SEARCH
+    process.env.ENABLE_TOOL_SEARCH = 'auto'
+    try {
+      const warnings = await checkContextWarnings(
+        [toolSearchTool(), mcpToolThatReadsPermissionContext()],
+        null,
+        async () => {
+          throw new Error('permission context unavailable')
+        },
+        {
+          memoryFiles: [
+            {
+              path: '/repo/CLAUDE.md',
+              type: 'Project',
+              content: 'x'.repeat(50_000),
+            },
+          ],
+          includeUnreachableRules: false,
+          mcpTokenStrategy: 'estimate',
+        },
+      )
+
+      expect(warnings.claudeMdWarning?.message).toContain(
+        'Large CLAUDE.md file detected',
+      )
+    } finally {
+      if (previousToolSearch === undefined) {
+        delete process.env.ENABLE_TOOL_SEARCH
+      } else {
+        process.env.ENABLE_TOOL_SEARCH = previousToolSearch
+      }
+    }
+  })
+})

--- a/src/__tests__/doctorContextWarnings.test.ts
+++ b/src/__tests__/doctorContextWarnings.test.ts
@@ -150,4 +150,29 @@ describe('checkContextWarnings', () => {
       }
     }
   })
+
+  test('keeps CLAUDE.md warning when unreachable-rules diagnostics fail', async () => {
+    const warnings = await checkContextWarnings(
+      [],
+      null,
+      async () => {
+        throw new Error('permission context unavailable')
+      },
+      {
+        memoryFiles: [
+          {
+            path: '/repo/CLAUDE.md',
+            type: 'Project',
+            content: 'x'.repeat(50_000),
+          },
+        ],
+      },
+    )
+
+    expect(warnings.claudeMdWarning?.message).toContain(
+      'Large CLAUDE.md file detected',
+    )
+    expect(warnings.mcpWarning).toBeNull()
+    expect(warnings.unreachableRulesWarning).toBeNull()
+  })
 })

--- a/src/__tests__/statusNoticeLocalModel.test.ts
+++ b/src/__tests__/statusNoticeLocalModel.test.ts
@@ -350,4 +350,20 @@ describe('startup status notices', () => {
     expect(ids).toContain('large-agent-descriptions')
     expect(ids).not.toContain('local-model-context-load')
   })
+
+  test('local providers keep generic context notices while aggregate warning is pending', () => {
+    const context = {
+      config: {},
+      agentDefinitions: largeAgentDefinitions,
+      memoryFiles: [largeMemoryFile],
+      isLocalModel: true,
+      localModelContextLoad: undefined,
+    } as StatusNoticeContext
+
+    const ids = getActiveContextNoticeIds(context)
+
+    expect(ids).toContain('large-memory-files')
+    expect(ids).toContain('large-agent-descriptions')
+    expect(ids).not.toContain('local-model-context-load')
+  })
 })

--- a/src/__tests__/statusNoticeLocalModel.test.ts
+++ b/src/__tests__/statusNoticeLocalModel.test.ts
@@ -1,0 +1,353 @@
+import { describe, expect, test } from 'bun:test'
+import { getEmptyToolPermissionContext, type Tool } from '../Tool.js'
+import type { AgentDefinitionsResult } from '../tools/AgentTool/loadAgentsDir.js'
+import { TOOL_SEARCH_TOOL_NAME } from '../tools/ToolSearchTool/constants.js'
+import type { MemoryFileInfo } from '../utils/claudemd.js'
+import type { ContextWarning, ContextWarnings } from '../utils/doctorContextWarnings.js'
+import {
+  statusNoticeDefinitions,
+  type StatusNoticeContext,
+} from '../utils/statusNoticeDefinitions.js'
+import {
+  buildLocalModelContextLoad,
+  checkLocalModelContextLoad,
+  isActiveProviderLocalModel,
+} from '../utils/statusNoticeLocalModel.js'
+
+const emptyPermissionContext = async () => getEmptyToolPermissionContext()
+const CONTEXT_NOTICE_IDS = new Set([
+  'large-memory-files',
+  'large-agent-descriptions',
+  'local-model-context-load',
+])
+
+async function withEnv<T>(
+  overrides: Record<string, string | undefined>,
+  run: () => Promise<T> | T,
+): Promise<T> {
+  const previous = new Map(
+    Object.keys(overrides).map(key => [key, process.env[key]]),
+  )
+
+  for (const [key, value] of Object.entries(overrides)) {
+    if (value === undefined) {
+      delete process.env[key]
+    } else {
+      process.env[key] = value
+    }
+  }
+
+  try {
+    return await run()
+  } finally {
+    for (const [key, value] of previous) {
+      if (value === undefined) {
+        delete process.env[key]
+      } else {
+        process.env[key] = value
+      }
+    }
+  }
+}
+
+function getActiveContextNoticeIds(context: StatusNoticeContext): string[] {
+  return statusNoticeDefinitions
+    .filter(notice => CONTEXT_NOTICE_IDS.has(notice.id))
+    .filter(notice => notice.isActive(context))
+    .map(notice => notice.id)
+}
+
+function warning(
+  type: ContextWarning['type'],
+  currentValue: number,
+  message: string,
+  details: string[] = [],
+): ContextWarning {
+  return {
+    type,
+    severity: 'warning',
+    message,
+    details,
+    currentValue,
+    threshold: 1,
+  }
+}
+
+function mcpTool(descriptionLength: number): Tool {
+  return {
+    name: 'mcp__bigserver__search',
+    isMcp: true,
+    mcpInfo: { serverName: 'bigserver', toolName: 'search' },
+    inputJSONSchema: { type: 'object', properties: {} },
+    async prompt() {
+      return 'x'.repeat(descriptionLength)
+    },
+  } as unknown as Tool
+}
+
+function mcpToolWithCircularSchema(): Tool {
+  const schema: Record<string, unknown> = { type: 'object' }
+  schema.self = schema
+
+  return {
+    name: 'mcp__badserver__bad',
+    isMcp: true,
+    mcpInfo: { serverName: 'badserver', toolName: 'bad' },
+    inputJSONSchema: schema,
+    async prompt() {
+      return 'bad schema tool'
+    },
+  } as unknown as Tool
+}
+
+function toolSearchTool(): Tool {
+  return {
+    name: TOOL_SEARCH_TOOL_NAME,
+    isMcp: false,
+    inputJSONSchema: { type: 'object', properties: {} },
+    async prompt() {
+      return 'search deferred tools'
+    },
+  } as unknown as Tool
+}
+
+const largeMemoryFile: MemoryFileInfo = {
+  path: '/repo/CLAUDE.md',
+  type: 'Project',
+  content: 'x'.repeat(50_000),
+}
+
+const largeAgentDefinitions: AgentDefinitionsResult = {
+  activeAgents: [
+    {
+      agentType: 'planner',
+      whenToUse: 'x'.repeat(80_000),
+      source: 'userSettings',
+      getSystemPrompt: () => '',
+    },
+  ],
+  allAgents: [],
+}
+
+describe('buildLocalModelContextLoad', () => {
+  test('returns null when no context thresholds are exceeded', () => {
+    const result = buildLocalModelContextLoad({
+      claudeMdWarning: null,
+      agentWarning: null,
+      mcpWarning: null,
+      unreachableRulesWarning: null,
+    })
+
+    expect(result).toBeNull()
+  })
+
+  test('formats compact startup lines and preserves doctor details', () => {
+    const warnings: ContextWarnings = {
+      mcpWarning: warning('mcp_tools', 31_200, 'Large MCP tools context', [
+        'github: 21 tools (~31,200 tokens)',
+      ]),
+      agentWarning: warning('agent_descriptions', 16_500, 'Large agent descriptions', [
+        'planner: ~9,000 tokens',
+      ]),
+      claudeMdWarning: warning('claudemd_files', 2, 'Large CLAUDE.md files', [
+        '/repo/CLAUDE.md: 51,200 chars',
+        '/repo/.claude/CLAUDE.md: 44,000 chars',
+      ]),
+      unreachableRulesWarning: warning('unreachable_rules', 1, 'Shadowed rule'),
+    }
+
+    const result = buildLocalModelContextLoad(warnings)
+
+    expect(result?.lines).toEqual([
+      'MCP tools: ~31.2k tokens',
+      'Agent descriptions: ~16.5k tokens',
+      'CLAUDE.md: 2 large files',
+    ])
+    expect(result?.contributors[1]?.details).toEqual([
+      'planner: ~9,000 tokens',
+    ])
+  })
+})
+
+describe('checkLocalModelContextLoad', () => {
+  test('returns null for cloud providers with the same large MCP context', async () => {
+    const result = await checkLocalModelContextLoad(
+      [mcpTool(120_000)],
+      null,
+      [],
+      emptyPermissionContext,
+      'https://api.anthropic.com',
+    )
+
+    expect(result).toBeNull()
+  })
+
+  test('warns for local providers when MCP prompt descriptions exceed the threshold', async () => {
+    const result = await checkLocalModelContextLoad(
+      [mcpTool(120_000)],
+      null,
+      [],
+      emptyPermissionContext,
+      'http://localhost:11434/v1',
+    )
+
+    expect(result?.lines).toEqual(['MCP tools: ~30k tokens'])
+    expect(result?.contributors[0]?.details).toEqual([
+      expect.stringMatching(/^bigserver: 1 tools \(~30,\d+ tokens\)$/),
+    ])
+  })
+
+  test('does not warn about MCP tools deferred by Tool Search', async () => {
+    await withEnv(
+      {
+        ENABLE_TOOL_SEARCH: 'true',
+        ANTHROPIC_MODEL: 'claude-sonnet-4',
+        OPENAI_MODEL: undefined,
+        CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS: undefined,
+        CLAUDE_CODE_USE_OPENAI: undefined,
+        CLAUDE_CODE_USE_GITHUB: undefined,
+        CLAUDE_CODE_USE_GEMINI: undefined,
+        CLAUDE_CODE_USE_MISTRAL: undefined,
+        CLAUDE_CODE_USE_BEDROCK: undefined,
+        CLAUDE_CODE_USE_VERTEX: undefined,
+        CLAUDE_CODE_USE_FOUNDRY: undefined,
+      },
+      async () => {
+        const result = await checkLocalModelContextLoad(
+          [toolSearchTool(), mcpTool(120_000)],
+          null,
+          [],
+          emptyPermissionContext,
+          'http://localhost:11434/v1',
+        )
+
+        expect(result).toBeNull()
+      },
+    )
+  })
+
+  test('summarizes large memory files without reading from disk', async () => {
+    const result = await checkLocalModelContextLoad(
+      [],
+      null,
+      [
+        {
+          path: '/repo/CLAUDE.md',
+          type: 'Project',
+          content: 'x'.repeat(50_000),
+        },
+      ],
+      emptyPermissionContext,
+      'http://localhost:1234/v1',
+    )
+
+    expect(result?.lines).toEqual(['CLAUDE.md: 1 large file'])
+    expect(result?.contributors[0]?.details).toEqual([
+      '/repo/CLAUDE.md: 50,000 chars',
+    ])
+  })
+
+  test('does not suppress context-load warnings when permission diagnostics fail', async () => {
+    const result = await checkLocalModelContextLoad(
+      [],
+      null,
+      [largeMemoryFile],
+      async () => {
+        throw new Error('permission context unavailable')
+      },
+      'http://localhost:1234/v1',
+    )
+
+    expect(result?.lines).toEqual(['CLAUDE.md: 1 large file'])
+  })
+
+  test('does not suppress other context warnings when an MCP schema cannot be serialized', async () => {
+    const result = await checkLocalModelContextLoad(
+      [mcpToolWithCircularSchema()],
+      null,
+      [largeMemoryFile],
+      emptyPermissionContext,
+      'http://localhost:1234/v1',
+    )
+
+    expect(result?.lines).toEqual(['CLAUDE.md: 1 large file'])
+  })
+})
+
+describe('active provider local detection', () => {
+  test('ignores stale local OPENAI_BASE_URL when the active provider is Anthropic cloud', () => {
+    expect(
+      isActiveProviderLocalModel({
+        OPENAI_BASE_URL: 'http://localhost:11434/v1',
+      }),
+    ).toBe(false)
+  })
+
+  test('detects local Anthropic-compatible base URLs for the active Anthropic provider', () => {
+    expect(
+      isActiveProviderLocalModel({
+        ANTHROPIC_BASE_URL: 'http://localhost:8080',
+      }),
+    ).toBe(true)
+  })
+})
+
+describe('startup status notices', () => {
+  test('local providers use the aggregate context warning without duplicate generic notices', () => {
+    const context = {
+      config: {},
+      agentDefinitions: largeAgentDefinitions,
+      memoryFiles: [largeMemoryFile],
+      isLocalModel: true,
+      localModelContextLoad: {
+        contributors: [
+          {
+            id: 'claudemd_files',
+            message: 'Large CLAUDE.md file detected',
+            details: ['/repo/CLAUDE.md: 50,000 chars'],
+            summary: 'CLAUDE.md: 1 large file',
+          },
+        ],
+        lines: ['CLAUDE.md: 1 large file'],
+      },
+    } as StatusNoticeContext
+
+    const ids = getActiveContextNoticeIds(context)
+
+    expect(ids).toContain('local-model-context-load')
+    expect(ids).not.toContain('large-memory-files')
+    expect(ids).not.toContain('large-agent-descriptions')
+  })
+
+  test('cloud providers keep existing generic context notices', () => {
+    const context = {
+      config: {},
+      agentDefinitions: largeAgentDefinitions,
+      memoryFiles: [largeMemoryFile],
+      isLocalModel: false,
+      localModelContextLoad: null,
+    } as StatusNoticeContext
+
+    const ids = getActiveContextNoticeIds(context)
+
+    expect(ids).toContain('large-memory-files')
+    expect(ids).toContain('large-agent-descriptions')
+    expect(ids).not.toContain('local-model-context-load')
+  })
+
+  test('local providers fall back to generic context notices when aggregate warning is unavailable', () => {
+    const context = {
+      config: {},
+      agentDefinitions: largeAgentDefinitions,
+      memoryFiles: [largeMemoryFile],
+      isLocalModel: true,
+      localModelContextLoad: null,
+    } as StatusNoticeContext
+
+    const ids = getActiveContextNoticeIds(context)
+
+    expect(ids).toContain('large-memory-files')
+    expect(ids).toContain('large-agent-descriptions')
+    expect(ids).not.toContain('local-model-context-load')
+  })
+})

--- a/src/components/StatusNotices.tsx
+++ b/src/components/StatusNotices.tsx
@@ -6,6 +6,9 @@ import type { MemoryFileInfo } from '../utils/claudemd.js';
 import { getMemoryFiles } from '../utils/claudemd.js';
 import { getGlobalConfig } from '../utils/config.js';
 import { getActiveNotices, type StatusNoticeContext } from '../utils/statusNoticeDefinitions.js';
+import { useAppState } from '../state/AppState.js';
+import { assembleToolPool } from '../tools.js';
+import { checkLocalModelContextLoad, isActiveProviderLocalModel, type LocalModelContextWarning } from '../utils/statusNoticeLocalModel.js';
 type Props = {
   agentDefinitions?: AgentDefinitionsResult;
 };
@@ -35,7 +38,12 @@ export function StatusNotices(t0) {
   const {
     agentDefinitions
   } = t0 === undefined ? {} : t0;
+  const mcpTools = useAppState(s => s.mcp.tools);
+  const toolPermissionContext = useAppState(s => s.toolPermissionContext);
+  const tools = React.useMemo(() => assembleToolPool(toolPermissionContext, mcpTools), [toolPermissionContext, mcpTools]);
   const [memoryFiles, setMemoryFiles] = React.useState(cachedMemoryFiles);
+  const [localModelContextLoad, setLocalModelContextLoad] = React.useState<LocalModelContextWarning | null | undefined>(undefined);
+  const isLocalModel = isActiveProviderLocalModel();
   let t1;
   if ($[0] === Symbol.for("react.memo_cache_sentinel")) {
     t1 = () => {
@@ -52,11 +60,37 @@ export function StatusNotices(t0) {
     t1 = $[0];
   }
   React.useEffect(t1, [t1]);
+  React.useEffect(() => {
+    let cancelled = false;
+    if (!isLocalModel) {
+      setLocalModelContextLoad(null);
+      return;
+    }
+    void checkLocalModelContextLoad(
+      tools,
+      agentDefinitions,
+      memoryFiles,
+      async () => toolPermissionContext,
+    ).then(warning => {
+      if (!cancelled) {
+        setLocalModelContextLoad(warning);
+      }
+    }).catch(() => {
+      if (!cancelled) {
+        setLocalModelContextLoad(null);
+      }
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [agentDefinitions, isLocalModel, memoryFiles, toolPermissionContext, tools]);
   const t2 = getGlobalConfig();
   const context = {
     config: t2,
     agentDefinitions,
-    memoryFiles
+    memoryFiles,
+    isLocalModel,
+    localModelContextLoad
   };
   const activeNotices = getActiveNotices(context);
   if (activeNotices.length === 0) {

--- a/src/screens/Doctor.tsx
+++ b/src/screens/Doctor.tsx
@@ -18,9 +18,11 @@ import { useExitOnCtrlCDWithKeybindings } from '../hooks/useExitOnCtrlCDWithKeyb
 import { Box, Text } from '../ink.js';
 import { useKeybindings } from '../keybindings/useKeybinding.js';
 import { useAppState } from '../state/AppState.js';
+import { assembleToolPool } from '../tools.js';
 import { getPluginErrorMessage } from '../types/plugin.js';
 import { getGcsDistTags, getNpmDistTags, type NpmDistTags } from '../utils/autoUpdater.js';
 import { type ContextWarnings, checkContextWarnings } from '../utils/doctorContextWarnings.js';
+import { buildLocalModelContextLoad, isActiveProviderLocalModel } from '../utils/statusNoticeLocalModel.js';
 import { type DiagnosticInfo, getDoctorDiagnostic } from '../utils/doctorDiagnostic.js';
 import { validateBoundedIntEnvVar } from '../utils/envValidation.js';
 import { pathExists } from '../utils/file.js';
@@ -98,7 +100,7 @@ function DistTagsDisplay(t0) {
   return t3;
 }
 export function Doctor(t0) {
-  const $ = _c(84);
+  const $ = _c(88);
   const {
     onDone
   } = t0;
@@ -107,15 +109,10 @@ export function Doctor(t0) {
   const toolPermissionContext = useAppState(_temp3);
   const pluginsErrors = useAppState(_temp4);
   useExitOnCtrlCDWithKeybindings();
-  let t1;
-  if ($[0] !== mcpTools) {
-    t1 = mcpTools || [];
-    $[0] = mcpTools;
-    $[1] = t1;
-  } else {
-    t1 = $[1];
-  }
-  const tools = t1;
+  const tools = useMemo(
+    () => assembleToolPool(toolPermissionContext, mcpTools || []),
+    [toolPermissionContext, mcpTools],
+  );
   const [diagnostic, setDiagnostic] = useState(null);
   const [agentInfo, setAgentInfo] = useState(null);
   const [contextWarnings, setContextWarnings] = useState(null);
@@ -469,36 +466,54 @@ export function Doctor(t0) {
   } else {
     t38 = $[72];
   }
+  const isLocalModel = isActiveProviderLocalModel();
+  const localModelContextLoad = isLocalModel ? buildLocalModelContextLoad(contextWarnings) : null;
   let t39;
-  if ($[73] !== contextWarnings) {
-    t39 = contextWarnings && (contextWarnings.claudeMdWarning || contextWarnings.agentWarning || contextWarnings.mcpWarning) && <Box flexDirection="column"><Text bold={true}>Context Usage Warnings</Text>{contextWarnings.claudeMdWarning && <><Text>└{" "}<Text color="warning">{figures.warning} {contextWarnings.claudeMdWarning.message}</Text></Text><Text>{"  "}└ Files:</Text>{contextWarnings.claudeMdWarning.details.map(_temp16)}</>}{contextWarnings.agentWarning && <><Text>└{" "}<Text color="warning">{figures.warning} {contextWarnings.agentWarning.message}</Text></Text><Text>{"  "}└ Top contributors:</Text>{contextWarnings.agentWarning.details.map(_temp17)}</>}{contextWarnings.mcpWarning && <><Text>└{" "}<Text color="warning">{figures.warning} {contextWarnings.mcpWarning.message}</Text></Text><Text>{"  "}└ MCP servers:</Text>{contextWarnings.mcpWarning.details.map(_temp18)}</>}</Box>;
+  if ($[73] !== contextWarnings || $[74] !== localModelContextLoad) {
+    t39 = !localModelContextLoad && contextWarnings && (contextWarnings.claudeMdWarning || contextWarnings.agentWarning || contextWarnings.mcpWarning) && <Box flexDirection="column"><Text bold={true}>Context Usage Warnings</Text>{contextWarnings.claudeMdWarning && <><Text>└{" "}<Text color="warning">{figures.warning} {contextWarnings.claudeMdWarning.message}</Text></Text><Text>{"  "}└ Files:</Text>{contextWarnings.claudeMdWarning.details.map(_temp16)}</>}{contextWarnings.agentWarning && <><Text>└{" "}<Text color="warning">{figures.warning} {contextWarnings.agentWarning.message}</Text></Text><Text>{"  "}└ Top contributors:</Text>{contextWarnings.agentWarning.details.map(_temp17)}</>}{contextWarnings.mcpWarning && <><Text>└{" "}<Text color="warning">{figures.warning} {contextWarnings.mcpWarning.message}</Text></Text><Text>{"  "}└ MCP servers:</Text>{contextWarnings.mcpWarning.details.map(_temp18)}</>}</Box>;
     $[73] = contextWarnings;
-    $[74] = t39;
+    $[74] = localModelContextLoad;
+    $[75] = t39;
   } else {
-    t39 = $[74];
+    t39 = $[75];
+  }
+  let t39b;
+  if ($[76] !== localModelContextLoad) {
+    t39b = localModelContextLoad && <Box flexDirection="column"><Text bold={true}>Local Model Context Load</Text><Text>└ Large context loaded before turn one for this local provider:</Text>{localModelContextLoad.contributors.map(_temp19)}<Text dimColor={true}>└ Disable unused MCP servers, agents, or oversized memory files to free context.</Text></Box>;
+    $[76] = localModelContextLoad;
+    $[77] = t39b;
+  } else {
+    t39b = $[77];
   }
   let t40;
-  if ($[75] === Symbol.for("react.memo_cache_sentinel")) {
+  if ($[78] === Symbol.for("react.memo_cache_sentinel")) {
     t40 = <Box><PressEnterToContinue /></Box>;
-    $[75] = t40;
+    $[78] = t40;
   } else {
-    t40 = $[75];
+    t40 = $[78];
   }
   let t41;
-  if ($[76] !== t23 || $[77] !== t30 || $[78] !== t35 || $[79] !== t36 || $[80] !== t37 || $[81] !== t38 || $[82] !== t39) {
-    t41 = <Pane>{t23}{t30}{t31}{t32}{t33}{t34}{t35}{t36}{t37}{t38}{t39}{t40}</Pane>;
-    $[76] = t23;
-    $[77] = t30;
-    $[78] = t35;
-    $[79] = t36;
-    $[80] = t37;
-    $[81] = t38;
-    $[82] = t39;
-    $[83] = t41;
+  if ($[79] !== t23 || $[80] !== t30 || $[81] !== t35 || $[82] !== t36 || $[83] !== t37 || $[84] !== t38 || $[85] !== t39 || $[86] !== t39b) {
+    t41 = <Pane>{t23}{t30}{t31}{t32}{t33}{t34}{t35}{t36}{t37}{t38}{t39}{t39b}{t40}</Pane>;
+    $[79] = t23;
+    $[80] = t30;
+    $[81] = t35;
+    $[82] = t36;
+    $[83] = t37;
+    $[84] = t38;
+    $[85] = t39;
+    $[86] = t39b;
+    $[87] = t41;
   } else {
-    t41 = $[83];
+    t41 = $[87];
   }
   return t41;
+}
+function _temp19(contributor) {
+  return <React.Fragment key={contributor.id}><Text>└{" "}<Text color="warning">{figures.warning} {contributor.message}</Text></Text>{contributor.details.map(_temp20)}</React.Fragment>;
+}
+function _temp20(detail, i) {
+  return <Text key={i} dimColor={true}>{"  "}└ {detail}</Text>;
 }
 function _temp18(detail_2, i_8) {
   return <Text key={i_8} dimColor={true}>{"    "}└ {detail_2}</Text>;

--- a/src/utils/analyzeContext.mcp.test.ts
+++ b/src/utils/analyzeContext.mcp.test.ts
@@ -1,0 +1,78 @@
+import { afterAll, describe, expect, mock, test } from 'bun:test'
+import {
+  getEmptyToolPermissionContext,
+  type Tool,
+  type ToolPermissionContext,
+} from '../Tool.js'
+import {
+  acquireSharedMutationLock,
+  releaseSharedMutationLock,
+} from '../test/sharedMutationLock.js'
+import * as realTokenEstimation from '../services/tokenEstimation.js'
+
+await acquireSharedMutationLock('utils/analyzeContext.mcp.test.ts')
+
+const countMessagesTokensWithAPI = mock(async () => 40_500)
+
+mock.module('../services/tokenEstimation.js', () => ({
+  ...realTokenEstimation,
+  countMessagesTokensWithAPI,
+  countTokensViaHaikuFallback: mock(async () => null),
+  roughTokenCountEstimation: (content: string, bytesPerToken = 4) =>
+    Math.round(content.length / bytesPerToken),
+}))
+
+mock.module('./toolSearch.js', () => ({
+  isToolSearchEnabled: mock(async () => false),
+}))
+
+mock.module('../tools/ToolSearchTool/prompt.js', () => ({
+  TOOL_SEARCH_TOOL_NAME: 'ToolSearch',
+  isDeferredTool: (tool: Tool) => tool.isMcp === true,
+}))
+
+const { countMcpToolTokens } = await import('./analyzeContext.js')
+
+afterAll(() => {
+  try {
+    mock.restore()
+  } finally {
+    releaseSharedMutationLock()
+  }
+})
+
+function mcpTool(name: string, descriptionLength: number): Tool {
+  return {
+    name,
+    isMcp: true,
+    mcpInfo: { serverName: name.split('__')[1], toolName: name.split('__')[2] },
+    inputJSONSchema: { type: 'object', properties: {} },
+    async prompt() {
+      return 'x'.repeat(descriptionLength)
+    },
+  } as unknown as Tool
+}
+
+const emptyPermissionContext = async (): Promise<ToolPermissionContext> =>
+  getEmptyToolPermissionContext()
+
+describe('countMcpToolTokens', () => {
+  test('marks MCP tools as loaded when Tool Search is disabled', async () => {
+    const result = await countMcpToolTokens(
+      [
+        mcpTool('mcp__github__search', 80_000),
+        mcpTool('mcp__linear__list', 40_000),
+      ],
+      emptyPermissionContext,
+      null,
+      'claude-sonnet-4',
+    )
+
+    expect(result.mcpToolTokens).toBe(40_000)
+    expect(result.deferredToolTokens).toBe(0)
+    expect(result.mcpToolDetails.map(tool => tool.isLoaded)).toEqual([
+      true,
+      true,
+    ])
+  })
+})

--- a/src/utils/analyzeContext.mcp.test.ts
+++ b/src/utils/analyzeContext.mcp.test.ts
@@ -1,20 +1,30 @@
-import { afterEach, describe, expect, mock, test } from 'bun:test'
-import {
-  acquireSharedMutationLock,
-  releaseSharedMutationLock,
-} from '../test/sharedMutationLock.js'
-import * as realTokenEstimation from '../services/tokenEstimation.js'
+import { describe, expect, test } from 'bun:test'
+import type { Tool } from '../Tool.js'
+import { TOOL_SEARCH_TOOL_NAME } from '../tools/ToolSearchTool/constants.js'
+import { countMcpToolTokens } from './analyzeContext.js'
 import { createRequestSizeReport } from './requestSizeBreakdown.js'
 import type { ContextData } from './analyzeContext.js'
 
-function makeMcpTool(name: string) {
+function makeMcpTool(name: string): Tool {
   return {
     name,
     isMcp: true,
     inputJSONSchema: { type: 'object', properties: {} },
     prompt: async () => `Prompt for ${name}`,
-  } as never
+  } as unknown as Tool
 }
+
+function makeToolSearchTool(): Tool {
+  return {
+    name: TOOL_SEARCH_TOOL_NAME,
+    isMcp: false,
+    inputJSONSchema: { type: 'object', properties: {} },
+    prompt: async () => 'Fetch deferred tools',
+  } as unknown as Tool
+}
+
+const emptyPermissionContext = async () => ({ mode: 'default' }) as never
+const countToolDefinitions = async () => 1_500
 
 function makeContextData(overrides: Partial<ContextData> = {}): ContextData {
   return {
@@ -34,110 +44,74 @@ function makeContextData(overrides: Partial<ContextData> = {}): ContextData {
   }
 }
 
-async function loadAnalyzeContextForTesting() {
-  return import(`./analyzeContext.js?ts=${Date.now()}-${Math.random()}`)
-}
-
-async function withMcpTokenMocks(
-  isToolSearchEnabled: boolean,
-  run: () => Promise<void>,
-) {
-  await acquireSharedMutationLock('analyzeContext.mcp.test.ts')
-  try {
-    mock.module('../services/tokenEstimation.js', () => ({
-      ...realTokenEstimation,
-      countMessagesTokensWithAPI: mock(async () => 1_500),
-      countTokensViaHaikuFallback: mock(async () => null),
-    }))
-    mock.module('./toolSearch.js', () => ({
-      isToolSearchEnabled: mock(async () => isToolSearchEnabled),
-    }))
-
-    await run()
-  } finally {
-    mock.restore()
-    releaseSharedMutationLock()
-  }
-}
-
-afterEach(() => {
-  mock.restore()
-})
-
 describe('countMcpToolTokens', () => {
   test('marks MCP tools loaded and request-size groups them by server when Tool Search is not deferred', async () => {
-    await withMcpTokenMocks(false, async () => {
-      const { countMcpToolTokens } = await loadAnalyzeContextForTesting()
-      const result = await countMcpToolTokens(
-        [
-          makeMcpTool('mcp__alpha__search'),
-          makeMcpTool('mcp__beta__list'),
+    const result = await countMcpToolTokens(
+      [makeMcpTool('mcp__alpha__search'), makeMcpTool('mcp__beta__list')],
+      emptyPermissionContext,
+      { activeAgents: [] } as never,
+      'test-model',
+      [],
+      countToolDefinitions,
+    )
+
+    expect(result.deferredToolTokens).toBe(0)
+    expect(result.mcpToolDetails.every(tool => tool.isLoaded)).toBe(true)
+
+    const report = createRequestSizeReport(
+      makeContextData({
+        categories: [
+          {
+            name: 'MCP tools',
+            tokens: result.mcpToolTokens,
+            color: 'permission',
+          },
         ],
-        async () => ({ mode: 'default' }) as never,
-        { activeAgents: [] } as never,
-        'test-model',
-        [],
-      )
+        mcpTools: result.mcpToolDetails,
+      }),
+    )
+    const labels = report.contributors.map(contributor => contributor.label)
 
-      expect(result.deferredToolTokens).toBe(0)
-      expect(result.mcpToolDetails.every(tool => tool.isLoaded)).toBe(true)
-
-      const report = createRequestSizeReport(
-        makeContextData({
-          categories: [
-            {
-              name: 'MCP tools',
-              tokens: result.mcpToolTokens,
-              color: 'permission',
-            },
-          ],
-          mcpTools: result.mcpToolDetails,
-        }),
-      )
-      const labels = report.contributors.map(contributor => contributor.label)
-
-      expect(labels).toContain('MCP server alpha')
-      expect(labels).toContain('MCP server beta')
-      expect(labels).not.toContain('MCP tool schemas')
-    })
+    expect(labels).toContain('MCP server alpha')
+    expect(labels).toContain('MCP server beta')
+    expect(labels).not.toContain('MCP tool schemas')
   })
 
   test('keeps deferred MCP schemas excluded from the outgoing request estimate when Tool Search is deferred', async () => {
-    await withMcpTokenMocks(true, async () => {
-      const { countMcpToolTokens } = await loadAnalyzeContextForTesting()
-      const result = await countMcpToolTokens(
-        [
-          makeMcpTool('mcp__alpha__search'),
-          makeMcpTool('mcp__beta__list'),
+    const result = await countMcpToolTokens(
+      [
+        makeToolSearchTool(),
+        makeMcpTool('mcp__alpha__search'),
+        makeMcpTool('mcp__beta__list'),
+      ],
+      emptyPermissionContext,
+      { activeAgents: [] } as never,
+      'test-model',
+      [],
+      countToolDefinitions,
+    )
+
+    expect(result.mcpToolTokens).toBe(0)
+    expect(result.deferredToolTokens).toBeGreaterThan(0)
+    expect(result.mcpToolDetails.every(tool => !tool.isLoaded)).toBe(true)
+
+    const report = createRequestSizeReport(
+      makeContextData({
+        categories: [
+          {
+            name: 'MCP tools (deferred)',
+            tokens: result.deferredToolTokens,
+            color: 'inactive',
+            isDeferred: true,
+          },
         ],
-        async () => ({ mode: 'default' }) as never,
-        { activeAgents: [] } as never,
-        'test-model',
-        [],
-      )
+        mcpTools: result.mcpToolDetails,
+      }),
+    )
+    const labels = report.contributors.map(contributor => contributor.label)
 
-      expect(result.mcpToolTokens).toBe(0)
-      expect(result.deferredToolTokens).toBeGreaterThan(0)
-      expect(result.mcpToolDetails.every(tool => !tool.isLoaded)).toBe(true)
-
-      const report = createRequestSizeReport(
-        makeContextData({
-          categories: [
-            {
-              name: 'MCP tools (deferred)',
-              tokens: result.deferredToolTokens,
-              color: 'inactive',
-              isDeferred: true,
-            },
-          ],
-          mcpTools: result.mcpToolDetails,
-        }),
-      )
-      const labels = report.contributors.map(contributor => contributor.label)
-
-      expect(report.estimatedTokens).toBe(0)
-      expect(labels).not.toContain('MCP server alpha')
-      expect(labels).not.toContain('MCP server beta')
-    })
+    expect(report.estimatedTokens).toBe(0)
+    expect(labels).not.toContain('MCP server alpha')
+    expect(labels).not.toContain('MCP server beta')
   })
 })

--- a/src/utils/analyzeContext.mcp.test.ts
+++ b/src/utils/analyzeContext.mcp.test.ts
@@ -1,4 +1,4 @@
-import { afterAll, describe, expect, mock, test } from 'bun:test'
+import { afterAll, describe, expect, test } from 'bun:test'
 import {
   getEmptyToolPermissionContext,
   type Tool,
@@ -8,37 +8,12 @@ import {
   acquireSharedMutationLock,
   releaseSharedMutationLock,
 } from '../test/sharedMutationLock.js'
-import * as realTokenEstimation from '../services/tokenEstimation.js'
+import { countMcpToolTokens } from './analyzeContext.js'
 
 await acquireSharedMutationLock('utils/analyzeContext.mcp.test.ts')
 
-const countMessagesTokensWithAPI = mock(async () => 40_500)
-
-mock.module('../services/tokenEstimation.js', () => ({
-  ...realTokenEstimation,
-  countMessagesTokensWithAPI,
-  countTokensViaHaikuFallback: mock(async () => null),
-  roughTokenCountEstimation: (content: string, bytesPerToken = 4) =>
-    Math.round(content.length / bytesPerToken),
-}))
-
-mock.module('./toolSearch.js', () => ({
-  isToolSearchEnabled: mock(async () => false),
-}))
-
-mock.module('../tools/ToolSearchTool/prompt.js', () => ({
-  TOOL_SEARCH_TOOL_NAME: 'ToolSearch',
-  isDeferredTool: (tool: Tool) => tool.isMcp === true,
-}))
-
-const { countMcpToolTokens } = await import('./analyzeContext.js')
-
 afterAll(() => {
-  try {
-    mock.restore()
-  } finally {
-    releaseSharedMutationLock()
-  }
+  releaseSharedMutationLock()
 })
 
 function mcpTool(name: string, descriptionLength: number): Tool {
@@ -58,6 +33,8 @@ const emptyPermissionContext = async (): Promise<ToolPermissionContext> =>
 
 describe('countMcpToolTokens', () => {
   test('marks MCP tools as loaded when Tool Search is disabled', async () => {
+    const countToolDefinitions = async () => 40_500
+
     const result = await countMcpToolTokens(
       [
         mcpTool('mcp__github__search', 80_000),
@@ -66,6 +43,8 @@ describe('countMcpToolTokens', () => {
       emptyPermissionContext,
       null,
       'claude-sonnet-4',
+      undefined,
+      countToolDefinitions,
     )
 
     expect(result.mcpToolTokens).toBe(40_000)

--- a/src/utils/analyzeContext.ts
+++ b/src/utils/analyzeContext.ts
@@ -639,6 +639,7 @@ export async function countMcpToolTokens(
   agentInfo: AgentDefinitionsResult | null,
   model: string,
   messages?: Message[],
+  countToolDefinitionTokensForContext = countToolDefinitionTokens,
 ): Promise<{
   mcpToolTokens: number
   mcpToolDetails: McpTool[]
@@ -648,7 +649,7 @@ export async function countMcpToolTokens(
   const mcpTools = tools.filter(tool => tool.isMcp)
   const mcpToolDetails: McpTool[] = []
   // Single bulk API call for all MCP tools (instead of N individual calls)
-  const totalTokensRaw = await countToolDefinitionTokens(
+  const totalTokensRaw = await countToolDefinitionTokensForContext(
     mcpTools,
     getToolPermissionContext,
     agentInfo,

--- a/src/utils/analyzeContext.ts
+++ b/src/utils/analyzeContext.ts
@@ -704,7 +704,8 @@ export async function countMcpToolTokens(
       name: tool.name,
       serverName: tool.name.split('__')[1] || 'unknown',
       tokens: mcpToolTokensByTool[i]!,
-      isLoaded: loadedMcpToolNames.has(tool.name) || !isDeferredTool(tool),
+      isLoaded:
+        !isDeferred || loadedMcpToolNames.has(tool.name) || !isDeferredTool(tool),
     })
   }
 

--- a/src/utils/analyzeContext.ts
+++ b/src/utils/analyzeContext.ts
@@ -619,6 +619,7 @@ export async function countMcpToolTokens(
   agentInfo: AgentDefinitionsResult | null,
   model: string,
   messages?: Message[],
+  countToolDefinitionTokensForContext = countToolDefinitionTokens,
 ): Promise<{
   mcpToolTokens: number
   mcpToolDetails: McpTool[]
@@ -628,7 +629,7 @@ export async function countMcpToolTokens(
   const mcpTools = tools.filter(tool => tool.isMcp)
   const mcpToolDetails: McpTool[] = []
   // Single bulk API call for all MCP tools (instead of N individual calls)
-  const totalTokensRaw = await countToolDefinitionTokens(
+  const totalTokensRaw = await countToolDefinitionTokensForContext(
     mcpTools,
     getToolPermissionContext,
     agentInfo,

--- a/src/utils/doctorContextWarnings.ts
+++ b/src/utils/doctorContextWarnings.ts
@@ -54,6 +54,16 @@ export type ContextWarnings = {
   unreachableRulesWarning: ContextWarning | null
 }
 
+async function safeWarning(
+  run: () => Promise<ContextWarning | null>,
+): Promise<ContextWarning | null> {
+  try {
+    return await run()
+  } catch {
+    return null
+  }
+}
+
 async function checkClaudeMdFiles(
   memoryFiles?: MemoryFileInfo[],
 ): Promise<ContextWarning | null> {
@@ -345,16 +355,18 @@ export async function checkContextWarnings(
   const includeUnreachableRules = options.includeUnreachableRules ?? true
   const [claudeMdWarning, agentWarning, mcpWarning, unreachableRulesWarning] =
     await Promise.all([
-      checkClaudeMdFiles(options.memoryFiles),
-      checkAgentDescriptions(agentInfo),
-      checkMcpTools(
-        tools,
-        getToolPermissionContext,
-        agentInfo,
-        options.mcpTokenStrategy,
+      safeWarning(() => checkClaudeMdFiles(options.memoryFiles)),
+      safeWarning(() => checkAgentDescriptions(agentInfo)),
+      safeWarning(() =>
+        checkMcpTools(
+          tools,
+          getToolPermissionContext,
+          agentInfo,
+          options.mcpTokenStrategy,
+        ),
       ),
       includeUnreachableRules
-        ? checkUnreachableRules(getToolPermissionContext)
+        ? safeWarning(() => checkUnreachableRules(getToolPermissionContext))
         : Promise.resolve(null),
     ])
 

--- a/src/utils/doctorContextWarnings.ts
+++ b/src/utils/doctorContextWarnings.ts
@@ -6,6 +6,7 @@ import {
   getLargeMemoryFiles,
   getMemoryFiles,
   MAX_MEMORY_CHARACTER_COUNT,
+  type MemoryFileInfo,
 } from './claudemd.js'
 import { getMainLoopModel } from './model/model.js'
 import { permissionRuleValueToString } from './permissions/permissionRuleParser.js'
@@ -18,7 +19,20 @@ import {
 import { plural } from './stringUtils.js'
 
 // Thresholds (matching status notices and existing patterns)
-const MCP_TOOLS_THRESHOLD = 25_000 // 15k tokens
+const MCP_TOOLS_THRESHOLD = 25_000
+
+type McpToolTokenDetail = {
+  name: string
+  serverName?: string
+  tokens: number
+  isLoaded?: boolean
+}
+
+export type CheckContextWarningsOptions = {
+  memoryFiles?: MemoryFileInfo[]
+  mcpTokenStrategy?: 'api' | 'estimate'
+  includeUnreachableRules?: boolean
+}
 
 export type ContextWarning = {
   type:
@@ -40,8 +54,10 @@ export type ContextWarnings = {
   unreachableRulesWarning: ContextWarning | null
 }
 
-async function checkClaudeMdFiles(): Promise<ContextWarning | null> {
-  const largeFiles = getLargeMemoryFiles(await getMemoryFiles())
+async function checkClaudeMdFiles(
+  memoryFiles?: MemoryFileInfo[],
+): Promise<ContextWarning | null> {
+  const largeFiles = getLargeMemoryFiles(memoryFiles ?? (await getMemoryFiles()))
 
   // This already filters for files > 40k chars each
   if (largeFiles.length === 0) {
@@ -116,10 +132,134 @@ async function checkAgentDescriptions(
 /**
  * Check MCP tools token count
  */
+async function estimateMcpToolTokens(
+  tools: Tool[],
+  getToolPermissionContext: () => Promise<ToolPermissionContext>,
+  agentInfo: AgentDefinitionsResult | null,
+): Promise<{
+  mcpToolTokens: number
+  mcpToolDetails: McpToolTokenDetail[]
+}> {
+  const mcpTools = tools.filter(tool => tool.isMcp)
+  const estimates = await Promise.all(
+    mcpTools.map(async tool => {
+      let description = ''
+      try {
+        description = await tool.prompt({
+          getToolPermissionContext,
+          tools,
+          agents: agentInfo?.activeAgents ?? [],
+        })
+      } catch {
+        description = ''
+      }
+
+      let definitionForEstimate: string
+      try {
+        definitionForEstimate = JSON.stringify({
+          name: tool.name,
+          description,
+          input_schema: tool.inputJSONSchema ?? {},
+        })
+      } catch {
+        definitionForEstimate = JSON.stringify({
+          name: tool.name,
+          description,
+          input_schema: {},
+        })
+      }
+
+      return {
+        name: tool.name,
+        serverName: tool.mcpInfo?.serverName ?? tool.name.split('__')[1],
+        tokens: roughTokenCountEstimation(definitionForEstimate),
+        isLoaded: true,
+      }
+    }),
+  )
+
+  const model = getMainLoopModel()
+  const { isToolSearchEnabled } = await import('./toolSearch.js')
+  const { isDeferredTool } = await import('../tools/ToolSearchTool/prompt.js')
+  let isDeferred = false
+  try {
+    isDeferred = await isToolSearchEnabled(
+      model,
+      tools,
+      getToolPermissionContext,
+      agentInfo?.activeAgents ?? [],
+      'analyzeMcp',
+    )
+  } catch {
+    isDeferred = false
+  }
+
+  const mcpToolDetails = estimates.map((detail, index) => ({
+    ...detail,
+    isLoaded: !isDeferred || !isDeferredTool(mcpTools[index]!),
+  }))
+
+  const mcpToolTokens = mcpToolDetails
+    .filter(detail => detail.isLoaded)
+    .reduce((total, detail) => total + detail.tokens, 0)
+
+  return { mcpToolTokens, mcpToolDetails }
+}
+
+function buildMcpToolsWarning(
+  mcpToolTokens: number,
+  mcpToolDetails: McpToolTokenDetail[],
+  estimated: boolean,
+): ContextWarning | null {
+  if (mcpToolTokens <= MCP_TOOLS_THRESHOLD) {
+    return null
+  }
+
+  const toolsByServer = new Map<string, { count: number; tokens: number }>()
+
+  for (const tool of mcpToolDetails) {
+    if (tool.isLoaded === false) {
+      continue
+    }
+
+    const serverName = tool.serverName ?? tool.name.split('__')[1] ?? 'unknown'
+    const current = toolsByServer.get(serverName) || { count: 0, tokens: 0 }
+    toolsByServer.set(serverName, {
+      count: current.count + 1,
+      tokens: current.tokens + tool.tokens,
+    })
+  }
+
+  const sortedServers = Array.from(toolsByServer.entries()).sort(
+    (a, b) => b[1].tokens - a[1].tokens,
+  )
+
+  const details = sortedServers
+    .slice(0, 5)
+    .map(
+      ([name, info]) =>
+        `${name}: ${info.count} tools (~${info.tokens.toLocaleString()} tokens)`,
+    )
+
+  if (sortedServers.length > 5) {
+    details.push(`(${sortedServers.length - 5} more servers)`)
+  }
+
+  return {
+    type: 'mcp_tools',
+    severity: 'warning',
+    message: `Large MCP tools context (~${mcpToolTokens.toLocaleString()} tokens${estimated ? ' estimated' : ''} > ${MCP_TOOLS_THRESHOLD.toLocaleString()})`,
+    details,
+    currentValue: mcpToolTokens,
+    threshold: MCP_TOOLS_THRESHOLD,
+  }
+}
+
 async function checkMcpTools(
   tools: Tool[],
   getToolPermissionContext: () => Promise<ToolPermissionContext>,
   agentInfo: AgentDefinitionsResult | null,
+  tokenStrategy: CheckContextWarningsOptions['mcpTokenStrategy'] = 'api',
 ): Promise<ContextWarning | null> {
   const mcpTools = tools.filter(tool => tool.isMcp)
 
@@ -127,6 +267,15 @@ async function checkMcpTools(
   // when doctor command runs, as it executes before MCP connections are established
   if (mcpTools.length === 0) {
     return null
+  }
+
+  if (tokenStrategy === 'estimate') {
+    const { mcpToolTokens, mcpToolDetails } = await estimateMcpToolTokens(
+      tools,
+      getToolPermissionContext,
+      agentInfo,
+    )
+    return buildMcpToolsWarning(mcpToolTokens, mcpToolDetails, true)
   }
 
   try {
@@ -139,70 +288,14 @@ async function checkMcpTools(
       model,
     )
 
-    if (mcpToolTokens <= MCP_TOOLS_THRESHOLD) {
-      return null
-    }
-
-    // Group tools by server
-    const toolsByServer = new Map<string, { count: number; tokens: number }>()
-
-    for (const tool of mcpToolDetails) {
-      // Extract server name from tool name (format: mcp__servername__toolname)
-      const parts = tool.name.split('__')
-      const serverName = parts[1] || 'unknown'
-
-      const current = toolsByServer.get(serverName) || { count: 0, tokens: 0 }
-      toolsByServer.set(serverName, {
-        count: current.count + 1,
-        tokens: current.tokens + tool.tokens,
-      })
-    }
-
-    // Sort servers by token count
-    const sortedServers = Array.from(toolsByServer.entries()).sort(
-      (a, b) => b[1].tokens - a[1].tokens,
-    )
-
-    const details = sortedServers
-      .slice(0, 5)
-      .map(
-        ([name, info]) =>
-          `${name}: ${info.count} tools (~${info.tokens.toLocaleString()} tokens)`,
-      )
-
-    if (sortedServers.length > 5) {
-      details.push(`(${sortedServers.length - 5} more servers)`)
-    }
-
-    return {
-      type: 'mcp_tools',
-      severity: 'warning',
-      message: `Large MCP tools context (~${mcpToolTokens.toLocaleString()} tokens > ${MCP_TOOLS_THRESHOLD.toLocaleString()})`,
-      details,
-      currentValue: mcpToolTokens,
-      threshold: MCP_TOOLS_THRESHOLD,
-    }
+    return buildMcpToolsWarning(mcpToolTokens, mcpToolDetails, false)
   } catch (_error) {
-    // If token counting fails, fall back to character-based estimation
-    const estimatedTokens = mcpTools.reduce((total, tool) => {
-      const chars = (tool.name?.length || 0) + tool.description.length
-      return total + roughTokenCountEstimation(chars.toString())
-    }, 0)
-
-    if (estimatedTokens <= MCP_TOOLS_THRESHOLD) {
-      return null
-    }
-
-    return {
-      type: 'mcp_tools',
-      severity: 'warning',
-      message: `Large MCP tools context (~${estimatedTokens.toLocaleString()} tokens estimated > ${MCP_TOOLS_THRESHOLD.toLocaleString()})`,
-      details: [
-        `${mcpTools.length} MCP tools detected (token count estimated)`,
-      ],
-      currentValue: estimatedTokens,
-      threshold: MCP_TOOLS_THRESHOLD,
-    }
+    const { mcpToolTokens, mcpToolDetails } = await estimateMcpToolTokens(
+      tools,
+      getToolPermissionContext,
+      agentInfo,
+    )
+    return buildMcpToolsWarning(mcpToolTokens, mcpToolDetails, true)
   }
 }
 
@@ -247,13 +340,22 @@ export async function checkContextWarnings(
   tools: Tool[],
   agentInfo: AgentDefinitionsResult | null,
   getToolPermissionContext: () => Promise<ToolPermissionContext>,
+  options: CheckContextWarningsOptions = {},
 ): Promise<ContextWarnings> {
+  const includeUnreachableRules = options.includeUnreachableRules ?? true
   const [claudeMdWarning, agentWarning, mcpWarning, unreachableRulesWarning] =
     await Promise.all([
-      checkClaudeMdFiles(),
+      checkClaudeMdFiles(options.memoryFiles),
       checkAgentDescriptions(agentInfo),
-      checkMcpTools(tools, getToolPermissionContext, agentInfo),
-      checkUnreachableRules(getToolPermissionContext),
+      checkMcpTools(
+        tools,
+        getToolPermissionContext,
+        agentInfo,
+        options.mcpTokenStrategy,
+      ),
+      includeUnreachableRules
+        ? checkUnreachableRules(getToolPermissionContext)
+        : Promise.resolve(null),
     ])
 
   return {

--- a/src/utils/statusNoticeDefinitions.tsx
+++ b/src/utils/statusNoticeDefinitions.tsx
@@ -12,6 +12,7 @@ import type { AgentDefinitionsResult } from '../tools/AgentTool/loadAgentsDir.js
 import { getAgentDescriptionsTotalTokens, AGENT_DESCRIPTIONS_THRESHOLD } from './statusNoticeHelpers.js';
 import { isSupportedJetBrainsTerminal, toIDEDisplayName, getTerminalIdeType } from './ide.js';
 import { isJetBrainsPluginInstalledCachedSync } from './jetbrains.js';
+import type { LocalModelContextWarning } from './statusNoticeLocalModel.js';
 
 // Types
 export type StatusNoticeType = 'warning' | 'info';
@@ -19,6 +20,8 @@ export type StatusNoticeContext = {
   config: ReturnType<typeof getGlobalConfig>;
   agentDefinitions?: AgentDefinitionsResult;
   memoryFiles: MemoryFileInfo[];
+  isLocalModel?: boolean;
+  localModelContextLoad?: LocalModelContextWarning | null;
 };
 export type StatusNoticeDefinition = {
   id: string;
@@ -31,7 +34,12 @@ export type StatusNoticeDefinition = {
 const largeMemoryFilesNotice: StatusNoticeDefinition = {
   id: 'large-memory-files',
   type: 'warning',
-  isActive: ctx => getLargeMemoryFiles(ctx.memoryFiles).length > 0,
+  isActive: ctx => {
+    if (ctx.isLocalModel && ctx.localModelContextLoad !== null) {
+      return false;
+    }
+    return getLargeMemoryFiles(ctx.memoryFiles).length > 0;
+  },
   render: ctx => {
     const largeMemoryFiles = getLargeMemoryFiles(ctx.memoryFiles);
     return <>
@@ -141,6 +149,9 @@ const largeAgentDescriptionsNotice: StatusNoticeDefinition = {
   id: 'large-agent-descriptions',
   type: 'warning',
   isActive: context => {
+    if (context.isLocalModel && context.localModelContextLoad !== null) {
+      return false;
+    }
     const totalTokens = getAgentDescriptionsTotalTokens(context.agentDefinitions);
     return totalTokens > AGENT_DESCRIPTIONS_THRESHOLD;
   },
@@ -187,9 +198,34 @@ const jetbrainsPluginNotice: StatusNoticeDefinition = {
       </Box>;
   }
 };
+const localModelContextLoadNotice: StatusNoticeDefinition = {
+  id: 'local-model-context-load',
+  type: 'warning',
+  isActive: context => context.localModelContextLoad != null,
+  render: context => {
+    const warning = context.localModelContextLoad
+    if (!warning) return null
+    return <Box flexDirection="column" marginTop={1}>
+        <Box flexDirection="row">
+          <Text color="warning">{figures.warning}</Text>
+          <Text color="warning">
+            Large context loaded for local model:
+          </Text>
+        </Box>
+        {warning.lines.map((line, i) => (
+          <Box key={i} flexDirection="row" marginLeft={3}>
+            <Text color="warning">{'\u2212'} {line}</Text>
+          </Box>
+        ))}
+        <Box flexDirection="row" marginLeft={3}>
+          <Text dimColor>Run /doctor for details or disable noisy plugins</Text>
+        </Box>
+      </Box>
+  }
+};
 
 // All notice definitions
-export const statusNoticeDefinitions: StatusNoticeDefinition[] = [largeMemoryFilesNotice, largeAgentDescriptionsNotice, claudeAiSubscriberExternalTokenNotice, apiKeyConflictNotice, bothAuthMethodsNotice, jetbrainsPluginNotice];
+export const statusNoticeDefinitions: StatusNoticeDefinition[] = [largeMemoryFilesNotice, largeAgentDescriptionsNotice, localModelContextLoadNotice, claudeAiSubscriberExternalTokenNotice, apiKeyConflictNotice, bothAuthMethodsNotice, jetbrainsPluginNotice];
 
 // Helper functions for external use
 export function getActiveNotices(context: StatusNoticeContext): StatusNoticeDefinition[] {

--- a/src/utils/statusNoticeDefinitions.tsx
+++ b/src/utils/statusNoticeDefinitions.tsx
@@ -35,7 +35,7 @@ const largeMemoryFilesNotice: StatusNoticeDefinition = {
   id: 'large-memory-files',
   type: 'warning',
   isActive: ctx => {
-    if (ctx.isLocalModel && ctx.localModelContextLoad !== null) {
+    if (ctx.isLocalModel && ctx.localModelContextLoad) {
       return false;
     }
     return getLargeMemoryFiles(ctx.memoryFiles).length > 0;
@@ -149,7 +149,7 @@ const largeAgentDescriptionsNotice: StatusNoticeDefinition = {
   id: 'large-agent-descriptions',
   type: 'warning',
   isActive: context => {
-    if (context.isLocalModel && context.localModelContextLoad !== null) {
+    if (context.isLocalModel && context.localModelContextLoad) {
       return false;
     }
     const totalTokens = getAgentDescriptionsTotalTokens(context.agentDefinitions);

--- a/src/utils/statusNoticeLocalModel.ts
+++ b/src/utils/statusNoticeLocalModel.ts
@@ -1,0 +1,162 @@
+import { resolveActiveRouteIdFromEnv } from '../integrations/routeMetadata.js'
+import { isLocalProviderUrl } from '../services/api/providerConfig.js'
+import type { Tool, ToolPermissionContext } from '../Tool.js'
+import type { AgentDefinitionsResult } from '../tools/AgentTool/loadAgentsDir.js'
+import type { MemoryFileInfo } from './claudemd.js'
+import {
+  checkContextWarnings,
+  type ContextWarning,
+  type ContextWarnings,
+} from './doctorContextWarnings.js'
+import { formatTokens } from './format.js'
+import { isEnvTruthy } from './envUtils.js'
+import { plural } from './stringUtils.js'
+
+type ContributorId = 'mcp_tools' | 'agent_descriptions' | 'claudemd_files'
+
+export type LocalModelContextContributor = {
+  id: ContributorId
+  message: string
+  details: string[]
+  summary: string
+}
+
+export type LocalModelContextWarning = {
+  contributors: LocalModelContextContributor[]
+  lines: string[]
+}
+
+function summarizeContextWarning(
+  warning: ContextWarning,
+): LocalModelContextContributor | null {
+  switch (warning.type) {
+    case 'mcp_tools':
+      return {
+        id: warning.type,
+        message: warning.message,
+        details: warning.details,
+        summary: `MCP tools: ~${formatTokens(warning.currentValue)} tokens`,
+      }
+    case 'agent_descriptions':
+      return {
+        id: warning.type,
+        message: warning.message,
+        details: warning.details,
+        summary: `Agent descriptions: ~${formatTokens(warning.currentValue)} tokens`,
+      }
+    case 'claudemd_files':
+      return {
+        id: warning.type,
+        message: warning.message,
+        details: warning.details,
+        summary: `CLAUDE.md: ${warning.currentValue} large ${plural(warning.currentValue, 'file')}`,
+      }
+    case 'unreachable_rules':
+      return null
+  }
+}
+
+export function buildLocalModelContextLoad(
+  warnings: ContextWarnings | null | undefined,
+): LocalModelContextWarning | null {
+  if (!warnings) {
+    return null
+  }
+
+  const contributors = [
+    warnings.mcpWarning,
+    warnings.agentWarning,
+    warnings.claudeMdWarning,
+  ]
+    .filter((warning): warning is ContextWarning => warning !== null)
+    .map(summarizeContextWarning)
+    .filter(
+      (contributor): contributor is LocalModelContextContributor =>
+        contributor !== null,
+    )
+
+  if (contributors.length === 0) {
+    return null
+  }
+
+  return {
+    contributors,
+    lines: contributors.map(contributor => contributor.summary),
+  }
+}
+
+function readConfiguredBaseUrl(value: string | undefined): string | undefined {
+  const trimmed = value?.trim()
+  if (!trimmed || trimmed === 'undefined' || trimmed === 'null') {
+    return undefined
+  }
+  return trimmed
+}
+
+export function resolveActiveProviderBaseUrl(
+  processEnv: NodeJS.ProcessEnv = process.env,
+): string | undefined {
+  if (
+    isEnvTruthy(processEnv.CLAUDE_CODE_USE_FOUNDRY) ||
+    isEnvTruthy(processEnv.CLAUDE_CODE_USE_BEDROCK) ||
+    isEnvTruthy(processEnv.CLAUDE_CODE_USE_VERTEX)
+  ) {
+    return undefined
+  }
+
+  const routeId = resolveActiveRouteIdFromEnv(processEnv)
+
+  switch (routeId) {
+    case 'anthropic':
+      return readConfiguredBaseUrl(processEnv.ANTHROPIC_BASE_URL)
+    case 'gemini':
+      return (
+        readConfiguredBaseUrl(processEnv.GEMINI_BASE_URL) ??
+        readConfiguredBaseUrl(processEnv.OPENAI_API_BASE)
+      )
+    case 'mistral':
+      return (
+        readConfiguredBaseUrl(processEnv.MISTRAL_BASE_URL) ??
+        readConfiguredBaseUrl(processEnv.OPENAI_API_BASE)
+      )
+    case 'bedrock':
+    case 'vertex':
+      return undefined
+    default:
+      return (
+        readConfiguredBaseUrl(processEnv.OPENAI_BASE_URL) ??
+        readConfiguredBaseUrl(processEnv.OPENAI_API_BASE)
+      )
+  }
+}
+
+export function isActiveProviderLocalModel(
+  processEnv: NodeJS.ProcessEnv = process.env,
+): boolean {
+  return isLocalProviderUrl(resolveActiveProviderBaseUrl(processEnv))
+}
+
+export async function checkLocalModelContextLoad(
+  tools: Tool[],
+  agentDefinitions: AgentDefinitionsResult | null | undefined,
+  memoryFiles: MemoryFileInfo[],
+  getToolPermissionContext: () => Promise<ToolPermissionContext>,
+  baseUrl?: string,
+): Promise<LocalModelContextWarning | null> {
+  const resolvedBaseUrl = baseUrl ?? resolveActiveProviderBaseUrl()
+  if (!isLocalProviderUrl(resolvedBaseUrl)) {
+    return null
+  }
+
+  const warnings = await checkContextWarnings(
+    tools,
+    agentDefinitions ?? null,
+    getToolPermissionContext,
+    {
+      memoryFiles,
+      mcpTokenStrategy: 'estimate',
+      includeUnreachableRules: false,
+    },
+  )
+  return buildLocalModelContextLoad(warnings)
+}


### PR DESCRIPTION
## Summary

- Add a compact startup warning for active local providers when pre-turn context contributors exceed existing thresholds.
- Add a `/doctor` Local Model Context Load section with detailed contributors for MCP tools, agent descriptions, and large CLAUDE.md files.
- Reuse and harden `checkContextWarnings()` so MCP accounting is Tool Search-aware, supports startup-safe estimates, and keeps unrelated warnings when one diagnostic path fails.
- Keep cloud-provider startup behavior unchanged while preserving `/doctor` context diagnostics.

## Why

Local-model users pay for context pollution immediately. Issue #999 reports plugin-provided context bloating local-model sessions before the user sends the first turn. This PR surfaces the largest contributors early and points users to `/doctor` for details.

## Implementation Notes

- Detects local-model mode from the active provider route instead of stale inactive base URL variables.
- Uses the full assembled tool pool for MCP context accounting so Tool Search deferral is reflected correctly.
- Suppresses duplicate generic startup context notices only when the local aggregate warning is available; otherwise the existing generic notices remain visible.
- Separates unreachable permission-rule diagnostics from local context-load warnings in `/doctor`.

## Validation

- `bun test src/utils/analyzeContext.mcp.test.ts src/__tests__/doctorContextWarnings.test.ts src/__tests__/statusNoticeLocalModel.test.ts src/services/api/providerConfig.local.test.ts` — 37 pass, 0 fail
- `bun run build` — pass
- `git diff --check origin/main..HEAD` — pass
- `bun test` — 2770 pass, 2 fail in untouched baseline areas:
  - `src/utils/context.test.ts`: `env-only MiniMax key uses provider-specific context and output caps before client setup`
  - `src/integrations/discoveryService.test.ts`: `discoverModelsForRoute > uses built-in openai-compatible discovery and caches results for dynamic routes`

Closes #999.
