### PR TITLE
fix(loader): batch markdown reads + cap file size to unblock startup

### DIFF
--- a/src/utils/markdownConfigLoader.scaling.test.ts
+++ b/src/utils/markdownConfigLoader.scaling.test.ts
@@ -1,0 +1,113 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import { mkdtemp, mkdir, rm, writeFile } from 'fs/promises'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { loadMarkdownFilesForSubdir } from './markdownConfigLoader.js'
+import {
+  acquireSharedMutationLock,
+  releaseSharedMutationLock,
+} from '../test/sharedMutationLock.js'
+
+// Regression for #769 — large agent/skill/Obsidian dirs froze the REPL at
+// startup because loadMarkdownFiles spawned one readFile per file via
+// `Promise.all`, opening thousands of fds and burning the event loop on
+// parseFrontmatter. The fix batches reads to 32 at a time and skips files
+// over CLAUDE_CODE_MAX_MARKDOWN_FILE_SIZE_BYTES (default 256 KiB) so that
+// vault notes dragged in via symlink don't load multi-MB blobs into memory.
+
+const SAVED_ENV = {
+  CLAUDE_CONFIG_DIR: process.env.CLAUDE_CONFIG_DIR,
+  CLAUDE_CODE_USE_NATIVE_FILE_SEARCH:
+    process.env.CLAUDE_CODE_USE_NATIVE_FILE_SEARCH,
+  CLAUDE_CODE_MAX_MARKDOWN_FILE_SIZE_BYTES:
+    process.env.CLAUDE_CODE_MAX_MARKDOWN_FILE_SIZE_BYTES,
+}
+
+let tempDir: string
+
+function restore(key: keyof typeof SAVED_ENV): void {
+  const value = SAVED_ENV[key]
+  if (value === undefined) {
+    delete process.env[key]
+  } else {
+    process.env[key] = value
+  }
+}
+
+beforeEach(async () => {
+  await acquireSharedMutationLock('markdownConfigLoader.scaling.test.ts')
+  tempDir = await mkdtemp(join(tmpdir(), 'openclaude-md-scaling-'))
+  process.env.CLAUDE_CONFIG_DIR = join(tempDir, '.openclaude')
+  process.env.CLAUDE_CODE_USE_NATIVE_FILE_SEARCH = '1'
+  delete process.env.CLAUDE_CODE_MAX_MARKDOWN_FILE_SIZE_BYTES
+  loadMarkdownFilesForSubdir.cache.clear?.()
+})
+
+afterEach(async () => {
+  try {
+    await rm(tempDir, { recursive: true, force: true })
+    restore('CLAUDE_CONFIG_DIR')
+    restore('CLAUDE_CODE_USE_NATIVE_FILE_SEARCH')
+    restore('CLAUDE_CODE_MAX_MARKDOWN_FILE_SIZE_BYTES')
+    loadMarkdownFilesForSubdir.cache.clear?.()
+  } finally {
+    releaseSharedMutationLock()
+  }
+})
+
+async function writeAgent(
+  dir: string,
+  name: string,
+  body = `You are ${name}.`,
+): Promise<void> {
+  await mkdir(dir, { recursive: true })
+  await writeFile(
+    join(dir, `${name}.md`),
+    `---\nname: ${name}\ndescription: "test"\n---\n\n${body}\n`,
+  )
+}
+
+describe('loadMarkdownFilesForSubdir (#769 scaling)', () => {
+  test('loads >batch-size agent files without losing any', async () => {
+    const agentsDir = join(process.env.CLAUDE_CONFIG_DIR!, 'agents')
+    const total = 80 // > MARKDOWN_LOAD_BATCH_SIZE (32) to exercise multiple batches
+    for (let i = 0; i < total; i++) {
+      await writeAgent(agentsDir, `agent-${String(i).padStart(3, '0')}`)
+    }
+
+    const files = await loadMarkdownFilesForSubdir('agents', tempDir)
+
+    expect(files.length).toBe(total)
+    const names = files.map(f => f.frontmatter['name']).sort()
+    expect(names[0]).toBe('agent-000')
+    expect(names[total - 1]).toBe(`agent-${String(total - 1).padStart(3, '0')}`)
+  })
+
+  test('skips files exceeding the max size and keeps small siblings', async () => {
+    const agentsDir = join(process.env.CLAUDE_CONFIG_DIR!, 'agents')
+    process.env.CLAUDE_CODE_MAX_MARKDOWN_FILE_SIZE_BYTES = '1024'
+    loadMarkdownFilesForSubdir.cache.clear?.()
+
+    await writeAgent(agentsDir, 'tiny')
+    // 2 KiB body to push the second file above the 1 KiB cap
+    await writeAgent(agentsDir, 'huge', 'x'.repeat(2048))
+
+    const files = await loadMarkdownFilesForSubdir('agents', tempDir)
+
+    const loadedNames = files.map(f => f.frontmatter['name'])
+    expect(loadedNames).toContain('tiny')
+    expect(loadedNames).not.toContain('huge')
+  })
+
+  test('size cap is overridable via env var', async () => {
+    const agentsDir = join(process.env.CLAUDE_CONFIG_DIR!, 'agents')
+    process.env.CLAUDE_CODE_MAX_MARKDOWN_FILE_SIZE_BYTES = '65536'
+    loadMarkdownFilesForSubdir.cache.clear?.()
+
+    await writeAgent(agentsDir, 'roomy', 'y'.repeat(8 * 1024))
+
+    const files = await loadMarkdownFilesForSubdir('agents', tempDir)
+
+    expect(files.map(f => f.frontmatter['name'])).toContain('roomy')
+  })
+})

--- a/src/utils/markdownConfigLoader.scaling.test.ts
+++ b/src/utils/markdownConfigLoader.scaling.test.ts
@@ -2,7 +2,11 @@ import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
 import { mkdtemp, mkdir, rm, writeFile } from 'fs/promises'
 import { tmpdir } from 'os'
 import { join } from 'path'
-import { loadMarkdownFilesForSubdir } from './markdownConfigLoader.js'
+import {
+  clearOversizedMarkdownSkipsForTesting,
+  getOversizedMarkdownSkips,
+  loadMarkdownFilesForSubdir,
+} from './markdownConfigLoader.js'
 import {
   acquireSharedMutationLock,
   releaseSharedMutationLock,
@@ -41,6 +45,7 @@ beforeEach(async () => {
   process.env.CLAUDE_CODE_USE_NATIVE_FILE_SEARCH = '1'
   delete process.env.CLAUDE_CODE_MAX_MARKDOWN_FILE_SIZE_BYTES
   loadMarkdownFilesForSubdir.cache.clear?.()
+  clearOversizedMarkdownSkipsForTesting()
 })
 
 afterEach(async () => {
@@ -50,6 +55,7 @@ afterEach(async () => {
     restore('CLAUDE_CODE_USE_NATIVE_FILE_SEARCH')
     restore('CLAUDE_CODE_MAX_MARKDOWN_FILE_SIZE_BYTES')
     loadMarkdownFilesForSubdir.cache.clear?.()
+    clearOversizedMarkdownSkipsForTesting()
   } finally {
     releaseSharedMutationLock()
   }
@@ -97,6 +103,42 @@ describe('loadMarkdownFilesForSubdir (#769 scaling)', () => {
     const loadedNames = files.map(f => f.frontmatter['name'])
     expect(loadedNames).toContain('tiny')
     expect(loadedNames).not.toContain('huge')
+  })
+
+  test('records skipped oversized files and emits one stderr warning', async () => {
+    const agentsDir = join(process.env.CLAUDE_CONFIG_DIR!, 'agents')
+    process.env.CLAUDE_CODE_MAX_MARKDOWN_FILE_SIZE_BYTES = '1024'
+    loadMarkdownFilesForSubdir.cache.clear?.()
+
+    const captured: string[] = []
+    const origWrite = process.stderr.write.bind(process.stderr)
+    ;(process.stderr.write as unknown as (s: string) => boolean) = (
+      s: string,
+    ): boolean => {
+      captured.push(s)
+      return true
+    }
+
+    try {
+      await writeAgent(agentsDir, 'huge-a', 'a'.repeat(2048))
+      await writeAgent(agentsDir, 'huge-b', 'b'.repeat(2048))
+      await loadMarkdownFilesForSubdir('agents', tempDir)
+
+      const skips = getOversizedMarkdownSkips()
+      expect(skips.length).toBe(2)
+      expect(skips.every(s => s.maxBytes === 1024)).toBe(true)
+      expect(skips.every(s => s.sizeBytes > 1024)).toBe(true)
+
+      const warnings = captured.filter(line =>
+        line.includes('skipping oversized markdown config file'),
+      )
+      expect(warnings.length).toBe(1)
+      expect(warnings[0]).toContain(
+        'CLAUDE_CODE_MAX_MARKDOWN_FILE_SIZE_BYTES',
+      )
+    } finally {
+      ;(process.stderr.write as unknown) = origWrite
+    }
   })
 
   test('size cap is overridable via env var', async () => {

--- a/src/utils/markdownConfigLoader.ts
+++ b/src/utils/markdownConfigLoader.ts
@@ -40,6 +40,29 @@ export type ClaudeConfigDirectory = (typeof CLAUDE_CONFIG_DIRECTORIES)[number]
 
 const PROJECT_CONFIG_DIR_NAMES = ['.claude', '.openclaude'] as const
 
+// Concurrency cap for parallel readFile + parseFrontmatter when loading
+// commands/agents/skills/etc. With unbounded Promise.all, a directory holding
+// thousands of markdown files (e.g., an Obsidian vault symlinked into
+// ~/.openclaude/agents — see issue #769) opens that many fds and blocks the
+// event loop on parse work, freezing the REPL at startup. Batching keeps fd
+// pressure and CPU bursts bounded.
+const MARKDOWN_LOAD_BATCH_SIZE = 32
+
+// Max file size to ingest. Legitimate commands/agents/skills are small (a few
+// KB). Files larger than this are almost always vault notes or unrelated docs
+// that got dragged in via symlink — reading them all into memory causes the
+// same freeze (#769). Override with CLAUDE_CODE_MAX_MARKDOWN_FILE_SIZE_BYTES.
+const DEFAULT_MAX_MARKDOWN_FILE_SIZE_BYTES = 256 * 1024
+
+function getMaxMarkdownFileSizeBytes(): number {
+  const raw = process.env.CLAUDE_CODE_MAX_MARKDOWN_FILE_SIZE_BYTES
+  if (!raw) return DEFAULT_MAX_MARKDOWN_FILE_SIZE_BYTES
+  const parsed = Number.parseInt(raw, 10)
+  return Number.isFinite(parsed) && parsed > 0
+    ? parsed
+    : DEFAULT_MAX_MARKDOWN_FILE_SIZE_BYTES
+}
+
 export type MarkdownFile = {
   filePath: string
   baseDir: string
@@ -585,27 +608,49 @@ async function loadMarkdownFiles(dir: string): Promise<
     cleanup()
   }
 
-  const results = await Promise.all(
-    files.map(async filePath => {
-      try {
-        const rawContent = await readFile(filePath, { encoding: 'utf-8' })
-        const { frontmatter, content } = parseFrontmatter(rawContent, filePath)
+  const maxFileSize = getMaxMarkdownFileSizeBytes()
+  const results: ({
+    filePath: string
+    frontmatter: FrontmatterData
+    content: string
+  } | null)[] = []
 
-        return {
-          filePath,
-          frontmatter,
-          content,
+  // Batch reads to cap fd usage and event-loop blocking on huge directories
+  // (issue #769). Unbounded Promise.all on a multi-thousand-file vault freezes
+  // the REPL during startup; 32 at a time keeps progress streaming.
+  for (let i = 0; i < files.length; i += MARKDOWN_LOAD_BATCH_SIZE) {
+    const batch = files.slice(i, i + MARKDOWN_LOAD_BATCH_SIZE)
+    const batchResults = await Promise.all(
+      batch.map(async filePath => {
+        try {
+          const fileStat = await stat(filePath)
+          if (fileStat.size > maxFileSize) {
+            logForDebugging(
+              `Skipping oversized markdown file ${filePath} (${fileStat.size} bytes > ${maxFileSize} max). Set CLAUDE_CODE_MAX_MARKDOWN_FILE_SIZE_BYTES to override.`,
+              { level: 'warn' },
+            )
+            return null
+          }
+          const rawContent = await readFile(filePath, { encoding: 'utf-8' })
+          const { frontmatter, content } = parseFrontmatter(rawContent, filePath)
+
+          return {
+            filePath,
+            frontmatter,
+            content,
+          }
+        } catch (error) {
+          const errorMessage =
+            error instanceof Error ? error.message : String(error)
+          logForDebugging(
+            `Failed to read/parse markdown file:  ${filePath}: ${errorMessage}`,
+          )
+          return null
         }
-      } catch (error) {
-        const errorMessage =
-          error instanceof Error ? error.message : String(error)
-        logForDebugging(
-          `Failed to read/parse markdown file:  ${filePath}: ${errorMessage}`,
-        )
-        return null
-      }
-    }),
-  )
+      }),
+    )
+    results.push(...batchResults)
+  }
 
   return results.filter(_ => _ !== null)
 }

--- a/src/utils/markdownConfigLoader.ts
+++ b/src/utils/markdownConfigLoader.ts
@@ -63,6 +63,42 @@ function getMaxMarkdownFileSizeBytes(): number {
     : DEFAULT_MAX_MARKDOWN_FILE_SIZE_BYTES
 }
 
+export type OversizedMarkdownSkip = {
+  filePath: string
+  sizeBytes: number
+  maxBytes: number
+}
+
+// Track files skipped because they exceeded the size cap so the override is
+// discoverable without `/debug` — a silent skip would just look like "my
+// custom agent disappeared". First skip in a process also emits one stderr
+// warning naming the override env var. Keyed by filePath so subsequent loads
+// of the same file don't re-warn.
+const oversizedMarkdownSkips = new Map<string, OversizedMarkdownSkip>()
+let oversizedSkipStderrWarned = false
+
+export function getOversizedMarkdownSkips(): OversizedMarkdownSkip[] {
+  return Array.from(oversizedMarkdownSkips.values())
+}
+
+export function clearOversizedMarkdownSkipsForTesting(): void {
+  oversizedMarkdownSkips.clear()
+  oversizedSkipStderrWarned = false
+}
+
+function recordOversizedSkip(skip: OversizedMarkdownSkip): void {
+  if (oversizedMarkdownSkips.has(skip.filePath)) return
+  oversizedMarkdownSkips.set(skip.filePath, skip)
+  if (!oversizedSkipStderrWarned) {
+    oversizedSkipStderrWarned = true
+    process.stderr.write(
+      `openclaude: skipping oversized markdown config file ${skip.filePath} ` +
+        `(${skip.sizeBytes} bytes > ${skip.maxBytes} max). Set ` +
+        `CLAUDE_CODE_MAX_MARKDOWN_FILE_SIZE_BYTES to raise the cap.\n`,
+    )
+  }
+}
+
 export type MarkdownFile = {
   filePath: string
   baseDir: string
@@ -625,6 +661,11 @@ async function loadMarkdownFiles(dir: string): Promise<
         try {
           const fileStat = await stat(filePath)
           if (fileStat.size > maxFileSize) {
+            recordOversizedSkip({
+              filePath,
+              sizeBytes: fileStat.size,
+              maxBytes: maxFileSize,
+            })
             logForDebugging(
               `Skipping oversized markdown file ${filePath} (${fileStat.size} bytes > ${maxFileSize} max). Set CLAUDE_CODE_MAX_MARKDOWN_FILE_SIZE_BYTES to override.`,
               { level: 'warn' },


### PR DESCRIPTION
## Summary

Refs #769. REPL froze indefinitely at "Initializing/Indexing" (CPU 100%, Ctrl+C dead) when `~/.openclaude/agents` had 40+ markdown files — common for ECC repo users and anyone who symlinked an Obsidian vault into the agents dir. `loadMarkdownFiles` was doing unbounded `Promise.all` over every file ripgrep returned, opening that many fds at once and blocking the event loop on `parseFrontmatter` for the entire batch before yielding.

## What changed

- **Commit 1** (`5b1e298`): two-part fix in `src/utils/markdownConfigLoader.ts`
  - Batched concurrent reads to `MARKDOWN_LOAD_BATCH_SIZE = 32`. Matches the `READ_BATCH_SIZE` pattern already used by `listSessionsImpl.ts`. fd usage now constant; the event loop yields between batches so the renderer can paint progress.
  - Pre-stat and skip files larger than 256 KiB by default. Legitimate commands/agents/skills/output-styles are kilobytes; oversized markdown almost always means a vault note pulled in via symlink, and loading multi-MB blobs into memory drives the RSS/GC pressure that caused the freeze. Override with `CLAUDE_CODE_MAX_MARKDOWN_FILE_SIZE_BYTES` for power users with intentionally large config files. Skipped files emit a `logForDebugging` warning naming the path + size so a missing agent is diagnosable.
- **Commit 2** (`d32ede5`): regression tests covering >batch-size loads (80 files), the oversized-skip behavior, and the env override.

## Scope notes

The issue also mentions project file indexing hangs on large `node_modules`. That's a separate code path (`src/hooks/fileSuggestions.ts` `FileIndex`, fed by git ls-files) — node_modules is normally excluded via `.gitignore`. Splitting it off keeps this PR focused on the reproducible part of #769; happy to follow up if maintainers want it bundled.

## Test plan

- [x] `bun test src/utils/markdownConfigLoader.scaling.test.ts` — 3 pass
- [x] `bun test src/tools/AgentTool/loadAgentsDir.test.ts` — 3 pass (existing)
- [ ] Manual: drop 200 dummy agent files into `~/.openclaude/agents`, observe REPL starts within a second instead of hanging.