### PR TITLE
fix(ink): correct stringWidth JS fallback for symbol characters

### DIFF
--- a/src/ink/stringWidth.test.ts
+++ b/src/ink/stringWidth.test.ts
@@ -1,0 +1,56 @@
+import { expect, test, describe } from 'bun:test'
+import { stringWidthJavaScript } from './stringWidth.js'
+
+describe('stringWidthJavaScript', () => {
+  test('handles ASCII', () => {
+    expect(stringWidthJavaScript('abc')).toBe(3)
+    expect(stringWidthJavaScript('  ')).toBe(2)
+    expect(stringWidthJavaScript('')).toBe(0)
+  })
+
+  test('handles wide characters', () => {
+    expect(stringWidthJavaScript('你好')).toBe(4)
+    expect(stringWidthJavaScript('こんにちは')).toBe(10)
+  })
+
+  test('handles emoji', () => {
+    expect(stringWidthJavaScript('😀')).toBe(2)
+    expect(stringWidthJavaScript('👨‍👩‍👧‍👦')).toBe(2) // Family emoji (grapheme cluster)
+    expect(stringWidthJavaScript('🇺🇸')).toBe(2) // Regional indicator
+  })
+
+  test('handles ANSI escape sequences', () => {
+    expect(stringWidthJavaScript('\x1b[31mred\x1b[39m')).toBe(3)
+    expect(stringWidthJavaScript('\x1b[1mbold\x1b[22m')).toBe(4)
+  })
+
+  test('handles symbols (Issue #1230)', () => {
+    // These symbols should be width 1
+    expect(stringWidthJavaScript('⚠')).toBe(1) // U+26A0
+    expect(stringWidthJavaScript('✓')).toBe(1) // U+2713
+    expect(stringWidthJavaScript('✖')).toBe(1) // U+2716
+    expect(stringWidthJavaScript('ℹ')).toBe(1) // U+2139
+    expect(stringWidthJavaScript('⚙')).toBe(1) // U+2699
+    expect(stringWidthJavaScript('⚡')).toBe(2) // U+26A1 (Wide by default)
+  })
+
+  test('handles spinner symbols (PR Feedback)', () => {
+    // These symbols were specifically requested in the PR feedback
+    expect(stringWidthJavaScript('✳')).toBe(1) // U+2733
+    expect(stringWidthJavaScript('✢')).toBe(1) // U+2722
+    expect(stringWidthJavaScript('✶')).toBe(1) // U+2736
+    expect(stringWidthJavaScript('✻')).toBe(1) // U+273B
+    expect(stringWidthJavaScript('✽')).toBe(1) // U+273D
+  })
+
+  test('handles variation selectors', () => {
+    // VS16 should make it width 2 if it's an emoji
+    // Note: The behavior depends on whether the base character is in EMOJI_REGEX
+    expect(stringWidthJavaScript('⚠️')).toBe(2) // ⚠ (U+26A0) + VS16 (U+FE0F)
+  })
+
+  test('handles mixed content', () => {
+    expect(stringWidthJavaScript('Error ⚠')).toBe(7)
+    expect(stringWidthJavaScript('Done ✓')).toBe(6)
+  })
+})

--- a/src/ink/stringWidth.ts
+++ b/src/ink/stringWidth.ts
@@ -17,7 +17,7 @@ const EMOJI_REGEX = emojiRegex()
  * which correctly treats ambiguous-width characters as narrow (width 1) as
  * recommended by the Unicode standard for Western contexts.
  */
-function stringWidthJavaScript(str: string): number {
+export function stringWidthJavaScript(str: string): number {
   if (typeof str !== 'string' || str.length === 0) {
     return 0
   }
@@ -70,7 +70,20 @@ function stringWidthJavaScript(str: string): number {
     // Check for emoji first (most emoji sequences are width 2)
     EMOJI_REGEX.lastIndex = 0
     if (EMOJI_REGEX.test(grapheme)) {
-      width += getEmojiWidth(grapheme)
+      const graphemeWidth = getEmojiWidth(grapheme)
+      // If it's a single codepoint and getEmojiWidth returned 2, double-check
+      // if it should actually be narrow (width 1). Many symbols are matched
+      // by emoji-regex but render as width 1 in terminals unless qualified
+      // by VS16.
+      if (graphemeWidth === 2 && [...grapheme].length === 1) {
+        const codePoint = grapheme.codePointAt(0)!
+        // Symbol ranges (U+2000 - U+2BFF) are narrow by default
+        if (codePoint >= 0x2000 && codePoint <= 0x2bff) {
+          width += eastAsianWidth(codePoint, { ambiguousAsWide: false })
+          continue
+        }
+      }
+      width += graphemeWidth
       continue
     }
 


### PR DESCRIPTION
## Summary

- **What changed**: Improved the JavaScript fallback for `stringWidth` to correctly calculate the terminal width of symbol characters (range `U+2000` - `U+2BFF`). Single-codepoint symbols in this range are now treated as width 1 unless they are explicitly qualified by an emoji variation selector (VS16).
- **Why it changed**: This fix addresses #1230. Under Node.js, the previous fallback logic incorrectly reported a width of 2 for certain symbols (like the `✳` used in spinners), leading to layout misalignments, ghost characters, and "collapsed" UI elements due to desynchronization between the engine's model and the actual terminal state.

## Impact

- **User-facing impact**: Fixes rendering artifacts (broken spinners, shifting text) when running OpenClaude under Node.js. The CLI UI is now stable and consistent regardless of the runtime engine (Bun vs Node.js).
- **Developer/maintainer impact**: Better parity between Bun and JS implementations of the terminal engine, reducing engine-specific bug reports.

## Testing

- [x] `bun run build`
- [x] `bun test src/ink/` (16 pass, 0 fail)
- [x] Focused tests: Verified with a custom reproduction script covering:
     - Narrow symbols (`·`, `✳`, `✔`, `✽`) -> Width 1
     - Emoji presentation symbols (`⚠️`, `✅`) -> Width 2
     - Complex graphemes (Family emoji) -> Width 2
     - Standard emojis (`😃`) -> Width 2

## Notes

- **Provider/model path tested**: N/A (Terminal engine fix).
- **Follow-up work or known limitations**: This fix specifically targets the symbol range reported in #1230. The implementation continues to rely on `eastAsianWidth` for underlying Unicode property lookups.
- **Related Issue**: Fixes #1230
