### PR TITLE
fix(xml): guard escapeXml/escapeXmlAttr against null and undefined (#1247)

### DIFF
--- a/src/utils/xml.test.ts
+++ b/src/utils/xml.test.ts
@@ -1,0 +1,33 @@
+import { expect, test } from 'bun:test'
+
+import { escapeXml, escapeXmlAttr } from './xml.js'
+
+test('escapeXml escapes the core XML metacharacters', () => {
+  expect(escapeXml('<tag>&"\'</tag>')).toBe(
+    '&lt;tag&gt;&amp;"\'&lt;/tag&gt;',
+  )
+})
+
+test('escapeXml returns an empty string for null and undefined (#1247)', () => {
+  // Regression: BashTool / ShellError surface `stdout` and `stderr` as null
+  // when the stream produced nothing. processBashCommand piped those straight
+  // into escapeXml, and the previous `s.replace(...)` call crashed the REPL
+  // with `TypeError: Cannot read properties of null (reading 'replace')`.
+  expect(escapeXml(null)).toBe('')
+  expect(escapeXml(undefined)).toBe('')
+})
+
+test('escapeXml passes empty string through unchanged', () => {
+  expect(escapeXml('')).toBe('')
+})
+
+test('escapeXmlAttr also escapes quotes', () => {
+  expect(escapeXmlAttr('"hi"&\'<bye>')).toBe(
+    '&quot;hi&quot;&amp;&apos;&lt;bye&gt;',
+  )
+})
+
+test('escapeXmlAttr inherits the null/undefined tolerance', () => {
+  expect(escapeXmlAttr(null)).toBe('')
+  expect(escapeXmlAttr(undefined)).toBe('')
+})

--- a/src/utils/xml.ts
+++ b/src/utils/xml.ts
@@ -2,15 +2,22 @@
  * Escape XML/HTML special characters for safe interpolation into element
  * text content (between tags). Use when untrusted strings (process stdout,
  * user input, external data) go inside `<tag>${here}</tag>`.
+ *
+ * Accepts null/undefined and returns an empty string. Shell-tool outputs
+ * (BashTool/ShellError) frequently surface `stderr` / `stdout` as null when
+ * the stream produced nothing, and the previous `s.replace` call crashed the
+ * REPL with `TypeError: Cannot read properties of null` (#1247).
  */
-export function escapeXml(s: string): string {
+export function escapeXml(s: string | null | undefined): string {
+  if (s == null) return ''
   return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
 }
 
 /**
  * Escape for interpolation into a double- or single-quoted attribute value:
- * `<tag attr="${here}">`. Escapes quotes in addition to `& < >`.
+ * `<tag attr="${here}">`. Escapes quotes in addition to `& < >`. Same
+ * null/undefined tolerance as `escapeXml`.
  */
-export function escapeXmlAttr(s: string): string {
+export function escapeXmlAttr(s: string | null | undefined): string {
   return escapeXml(s).replace(/"/g, '&quot;').replace(/'/g, '&apos;')
 }


### PR DESCRIPTION
## Summary

- `escapeXml(s: string)` crashed with `TypeError: Cannot read properties of null (reading 'replace')` when called with `null` / `undefined`.
- BashTool result `stderr` and ShellError `stdout`/`stderr` surface as null when the stream produced nothing, and `processBashCommand` piped them straight in.
- Widen the parameter type to `string | null | undefined` and short-circuit to `''`. `escapeXmlAttr` delegates to `escapeXml` so the guard propagates.

## Impact

- user-facing: REPL no longer crashes mid-session when an empty-stderr shell command flows through `!` bash mode (or any other path that escapes nullable stdout/stderr). Reported on v0.12.0, Node 24.0.2 with nproxy preload (#1247).
- developer/maintainer: defensive widening at one call site instead of pushing `?? ''` to every caller (20 refs in tree).

## Testing

- [x] `bun run build`
- [x] `bun run smoke`
- [x] focused tests: new `src/utils/xml.test.ts` — 5 cases covering metachar escaping, null + undefined → `''`, empty string passthrough, and `escapeXmlAttr` quote escaping + inherited null guard. 5/0.

## Notes

- provider/model path tested: n/a (utility fix); reproduced the original crash by calling `escapeXml(null)` against pre-fix main → throws; post-fix → `''`.
- screenshots attached: n/a.
- follow-up: none. The 20 existing callers can keep passing non-null values; the guard is just a backstop for the BashTool null-leak path.

Closes #1247.