### PR TITLE
fix: add null guard to escapeXml to prevent TypeError from null processBashCommand output

### DIFF
--- a/src/utils/xml.ts
+++ b/src/utils/xml.ts
@@ -1,15 +1,16 @@
 /**
  * Escape XML/HTML special characters for safe interpolation into element
  * text content (between tags). Use when untrusted strings (process stdout,
- * user input, external data) go inside `<tag>${here}</tag>`.
+ * user input, external data) go inside <tag>${here}</tag>.
  */
 export function escapeXml(s: string): string {
+  if (s == null) return ''
   return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
 }
 
 /**
  * Escape for interpolation into a double- or single-quoted attribute value:
- * `<tag attr="${here}">`. Escapes quotes in addition to `& < >`.
+ * <tag attr="${here}">. Escapes quotes in addition to & < >.
  */
 export function escapeXmlAttr(s: string): string {
   return escapeXml(s).replace(/"/g, '&quot;').replace(/'/g, '&apos;')


### PR DESCRIPTION
## Summary

Fixes #1247

`processBashCommand` can return `null`, which gets passed to `escapeXml`. Without a null guard, `escapeXml` calls `.replace()` on `null`, throwing:

```
TypeError: Cannot read properties of null (reading 'replace')
```

## Changes

Added a null check at the top of `escapeXml` in `src/utils/xml.ts`. When `s` is `null` or `undefined`, the function now returns an empty string instead of crashing.

```ts
export function escapeXml(s: string): string {
  if (s == null) return ''
  return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
}
```

This is a minimal, safe fix that preserves existing behavior for all non-null inputs.