### PR TITLE
feat(safety): warn at startup when 3P provider + permissive mode skip the AI classifier

### DIFF
--- a/src/components/StatusNotices.tsx
+++ b/src/components/StatusNotices.tsx
@@ -1,6 +1,7 @@
 import { c as _c } from "react-compiler-runtime";
 import * as React from 'react';
 import { Box } from '../ink.js';
+import { useAppState } from '../state/AppState.js';
 import type { AgentDefinitionsResult } from '../tools/AgentTool/loadAgentsDir.js';
 import type { MemoryFileInfo } from '../utils/claudemd.js';
 import { getMemoryFiles } from '../utils/claudemd.js';
@@ -53,10 +54,14 @@ export function StatusNotices(t0) {
   }
   React.useEffect(t1, [t1]);
   const t2 = getGlobalConfig();
-  const context = {
+  const permissionMode = useAppState(s => s.toolPermissionContext.mode);
+  const mainLoopModel = useAppState(s => s.mainLoopModel);
+  const context: StatusNoticeContext = {
     config: t2,
     agentDefinitions,
-    memoryFiles
+    memoryFiles,
+    permissionMode,
+    mainLoopModel: mainLoopModel ?? undefined,
   };
   const activeNotices = getActiveNotices(context);
   if (activeNotices.length === 0) {

--- a/src/utils/statusNoticeDefinitions.safety.test.tsx
+++ b/src/utils/statusNoticeDefinitions.safety.test.tsx
@@ -1,0 +1,141 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test'
+import type { StatusNoticeContext } from './statusNoticeDefinitions.js'
+import { getActiveNotices } from './statusNoticeDefinitions.js'
+
+// Regression coverage for issue #244 — the two safety-related status notices
+// that warn 3P users when they are running without the AI classifier or with
+// `--dangerously-skip-permissions` outside a sandbox.
+
+// Empty baseline context (no large-memory/agent-description triggers).
+function buildContext(
+  overrides?: Partial<StatusNoticeContext>,
+): StatusNoticeContext {
+  return {
+    config: {} as StatusNoticeContext['config'],
+    memoryFiles: [],
+    ...overrides,
+  }
+}
+
+function activeIds(ctx: StatusNoticeContext): string[] {
+  return getActiveNotices(ctx).map(n => n.id)
+}
+
+const SAVED_ARGV = process.argv
+const SAVED_API_KEY = process.env.ANTHROPIC_API_KEY
+
+beforeEach(() => {
+  // Reset argv each test so the dangerously-skip-permissions detector starts
+  // from a known baseline.
+  process.argv = [...SAVED_ARGV.filter(a => a !== '--dangerously-skip-permissions')]
+  // Other status notices read auth state via getAnthropicApiKeyWithSource,
+  // which throws when no key/token is present. Seed a dummy so getActiveNotices
+  // can iterate every notice without unrelated failures crashing the test.
+  process.env.ANTHROPIC_API_KEY = process.env.ANTHROPIC_API_KEY ?? 'sk-test-dummy'
+})
+
+afterEach(() => {
+  process.argv = SAVED_ARGV
+  if (SAVED_API_KEY === undefined) {
+    delete process.env.ANTHROPIC_API_KEY
+  } else {
+    process.env.ANTHROPIC_API_KEY = SAVED_API_KEY
+  }
+  mock.restore()
+})
+
+describe('third-party permissive mode notice (#244 finding 1)', () => {
+  test('fires when 3P + acceptEdits + classifier-off model', async () => {
+    mock.module('./model/providers.js', () => ({
+      getAPIProvider: () => 'openai',
+    }))
+    mock.module('./betas.js', () => ({
+      modelSupportsAutoMode: () => false,
+    }))
+    const { getActiveNotices: freshGetActiveNotices } = await import(
+      `./statusNoticeDefinitions.js?ts=${Date.now()}`
+    )
+    const ctx = buildContext({ permissionMode: 'acceptEdits', mainLoopModel: 'gpt-5.4' })
+    const ids = freshGetActiveNotices(ctx).map((n: { id: string }) => n.id)
+    expect(ids).toContain('third-party-permissive-mode')
+  })
+
+  test('fires when 3P + bypassPermissions', async () => {
+    mock.module('./model/providers.js', () => ({
+      getAPIProvider: () => 'openai',
+    }))
+    mock.module('./betas.js', () => ({
+      modelSupportsAutoMode: () => false,
+    }))
+    const { getActiveNotices: freshGetActiveNotices } = await import(
+      `./statusNoticeDefinitions.js?ts=${Date.now()}`
+    )
+    const ctx = buildContext({ permissionMode: 'bypassPermissions', mainLoopModel: 'llama3.1' })
+    const ids = freshGetActiveNotices(ctx).map((n: { id: string }) => n.id)
+    expect(ids).toContain('third-party-permissive-mode')
+  })
+
+  test('suppressed in default mode even on 3P', async () => {
+    mock.module('./model/providers.js', () => ({
+      getAPIProvider: () => 'openai',
+    }))
+    mock.module('./betas.js', () => ({
+      modelSupportsAutoMode: () => false,
+    }))
+    const { getActiveNotices: freshGetActiveNotices } = await import(
+      `./statusNoticeDefinitions.js?ts=${Date.now()}`
+    )
+    const ctx = buildContext({ permissionMode: 'default', mainLoopModel: 'gpt-5.4' })
+    const ids = freshGetActiveNotices(ctx).map((n: { id: string }) => n.id)
+    expect(ids).not.toContain('third-party-permissive-mode')
+  })
+
+  test('suppressed on firstParty Anthropic in acceptEdits', async () => {
+    mock.module('./model/providers.js', () => ({
+      getAPIProvider: () => 'firstParty',
+    }))
+    mock.module('./betas.js', () => ({
+      modelSupportsAutoMode: () => true,
+    }))
+    const { getActiveNotices: freshGetActiveNotices } = await import(
+      `./statusNoticeDefinitions.js?ts=${Date.now()}`
+    )
+    const ctx = buildContext({ permissionMode: 'acceptEdits', mainLoopModel: 'claude-opus-4-7' })
+    const ids = freshGetActiveNotices(ctx).map((n: { id: string }) => n.id)
+    expect(ids).not.toContain('third-party-permissive-mode')
+  })
+
+  test('suppressed when classifier supports the model (defensive)', async () => {
+    mock.module('./model/providers.js', () => ({
+      getAPIProvider: () => 'openai',
+    }))
+    mock.module('./betas.js', () => ({
+      modelSupportsAutoMode: () => true,
+    }))
+    const { getActiveNotices: freshGetActiveNotices } = await import(
+      `./statusNoticeDefinitions.js?ts=${Date.now()}`
+    )
+    const ctx = buildContext({ permissionMode: 'acceptEdits', mainLoopModel: 'mystery-model' })
+    const ids = freshGetActiveNotices(ctx).map((n: { id: string }) => n.id)
+    expect(ids).not.toContain('third-party-permissive-mode')
+  })
+})
+
+describe('dangerously-skip-permissions sandbox notice (#244 finding 2)', () => {
+  test('fires when --dangerously-skip-permissions is in argv', () => {
+    process.argv = [...process.argv, '--dangerously-skip-permissions']
+    expect(activeIds(buildContext())).toContain('dangerously-skip-permissions-no-sandbox')
+  })
+
+  test('fires when permission mode is bypassPermissions (e.g. settings defaultMode)', () => {
+    expect(activeIds(buildContext({ permissionMode: 'bypassPermissions' }))).toContain(
+      'dangerously-skip-permissions-no-sandbox',
+    )
+  })
+
+  test('does not fire in default mode without the flag', () => {
+    expect(activeIds(buildContext({ permissionMode: 'default' }))).not.toContain(
+      'dangerously-skip-permissions-no-sandbox',
+    )
+  })
+})

--- a/src/utils/statusNoticeDefinitions.tsx
+++ b/src/utils/statusNoticeDefinitions.tsx
@@ -12,6 +12,9 @@ import type { AgentDefinitionsResult } from '../tools/AgentTool/loadAgentsDir.js
 import { getAgentDescriptionsTotalTokens, AGENT_DESCRIPTIONS_THRESHOLD } from './statusNoticeHelpers.js';
 import { isSupportedJetBrainsTerminal, toIDEDisplayName, getTerminalIdeType } from './ide.js';
 import { isJetBrainsPluginInstalledCachedSync } from './jetbrains.js';
+import type { PermissionMode } from './permissions/PermissionMode.js';
+import { modelSupportsAutoMode } from './betas.js';
+import { getAPIProvider } from './model/providers.js';
 
 // Types
 export type StatusNoticeType = 'warning' | 'info';
@@ -19,6 +22,11 @@ export type StatusNoticeContext = {
   config: ReturnType<typeof getGlobalConfig>;
   agentDefinitions?: AgentDefinitionsResult;
   memoryFiles: MemoryFileInfo[];
+  /** Active session permission mode. Used by the 3P-safety notices. */
+  permissionMode?: PermissionMode;
+  /** Current main-loop model id. Used by the 3P-safety notices to decide
+   * whether the AI classifier would actually run. */
+  mainLoopModel?: string;
 };
 export type StatusNoticeDefinition = {
   id: string;
@@ -188,8 +196,46 @@ const jetbrainsPluginNotice: StatusNoticeDefinition = {
   }
 };
 
+// Permissive permission modes (acceptEdits, bypassPermissions, auto) suppress
+// the per-tool consent prompt that normally gives the user a moment to inspect
+// what the model is about to do. On first-party Claude, the AI safety
+// classifier (gated by `modelSupportsAutoMode`) is the backstop that catches
+// PI-driven dangerous calls in that consent-free path. For 3P providers the
+// classifier never runs (betas.ts:166), so users get the consent shortcut
+// without the safety net — silently. See issue #244 finding 1.
+const PERMISSIVE_MODES_REQUIRING_CLASSIFIER: ReadonlyArray<PermissionMode> = [
+  'acceptEdits',
+  'bypassPermissions',
+];
+const thirdPartyPermissiveModeNotice: StatusNoticeDefinition = {
+  id: 'third-party-permissive-mode',
+  type: 'warning',
+  isActive: ctx => {
+    const mode = ctx.permissionMode;
+    if (!mode || !PERMISSIVE_MODES_REQUIRING_CLASSIFIER.includes(mode)) {
+      return false;
+    }
+    // If the active model supports the AI classifier the safety net is in place,
+    // so suppress the notice even on 3P. Treat unknown model as classifier-off.
+    if (ctx.mainLoopModel && modelSupportsAutoMode(ctx.mainLoopModel)) {
+      return false;
+    }
+    return getAPIProvider() !== 'firstParty';
+  },
+  render: ctx => {
+    const mode = ctx.permissionMode;
+    return <Box flexDirection="row">
+        <Text color="warning">{figures.warning}</Text>
+        <Text color="warning">
+          <Text bold>{mode}</Text> mode is active on a third-party provider —
+          tool calls run without the AI safety classifier.
+          <Text dimColor> Inspect tool calls manually, especially when working with untrusted code.</Text>
+        </Text>
+      </Box>;
+  }
+};
 // All notice definitions
-export const statusNoticeDefinitions: StatusNoticeDefinition[] = [largeMemoryFilesNotice, largeAgentDescriptionsNotice, claudeAiSubscriberExternalTokenNotice, apiKeyConflictNotice, bothAuthMethodsNotice, jetbrainsPluginNotice];
+export const statusNoticeDefinitions: StatusNoticeDefinition[] = [largeMemoryFilesNotice, largeAgentDescriptionsNotice, claudeAiSubscriberExternalTokenNotice, apiKeyConflictNotice, bothAuthMethodsNotice, jetbrainsPluginNotice, thirdPartyPermissiveModeNotice];
 
 // Helper functions for external use
 export function getActiveNotices(context: StatusNoticeContext): StatusNoticeDefinition[] {

--- a/src/utils/statusNoticeDefinitions.tsx
+++ b/src/utils/statusNoticeDefinitions.tsx
@@ -234,8 +234,34 @@ const thirdPartyPermissiveModeNotice: StatusNoticeDefinition = {
       </Box>;
   }
 };
+// `--dangerously-skip-permissions` (a.k.a. bypassPermissions) auto-approves
+// every tool call. On first-party builds an employee-only sandbox check
+// (Docker/Bubblewrap + no internet) gates this flag; external users skip the
+// check entirely (setup.ts), so the flag is effectively "run any command with
+// no review". Warn loudly. Detection reads from process.argv so the notice
+// fires from the first frame, before any AppState mode change propagates.
+// See issue #244 finding 2.
+function hasDangerouslySkipPermissionsArg(): boolean {
+  return process.argv.includes('--dangerously-skip-permissions');
+}
+const dangerouslySkipPermissionsNotice: StatusNoticeDefinition = {
+  id: 'dangerously-skip-permissions-no-sandbox',
+  type: 'warning',
+  isActive: ctx =>
+    hasDangerouslySkipPermissionsArg() ||
+    ctx.permissionMode === 'bypassPermissions',
+  render: () => <Box flexDirection="row">
+      <Text color="warning">{figures.warning}</Text>
+      <Text color="warning">
+        <Text bold>--dangerously-skip-permissions</Text> bypasses every tool
+        consent check.
+        <Text dimColor> Only use inside a sandbox with no internet access. Restart without the flag to re-enable prompts.</Text>
+      </Text>
+    </Box>
+};
+
 // All notice definitions
-export const statusNoticeDefinitions: StatusNoticeDefinition[] = [largeMemoryFilesNotice, largeAgentDescriptionsNotice, claudeAiSubscriberExternalTokenNotice, apiKeyConflictNotice, bothAuthMethodsNotice, jetbrainsPluginNotice, thirdPartyPermissiveModeNotice];
+export const statusNoticeDefinitions: StatusNoticeDefinition[] = [largeMemoryFilesNotice, largeAgentDescriptionsNotice, claudeAiSubscriberExternalTokenNotice, apiKeyConflictNotice, bothAuthMethodsNotice, jetbrainsPluginNotice, thirdPartyPermissiveModeNotice, dangerouslySkipPermissionsNotice];
 
 // Helper functions for external use
 export function getActiveNotices(context: StatusNoticeContext): StatusNoticeDefinition[] {


### PR DESCRIPTION
## Summary

Refs #244. Surfaces two existing-but-silent safety gaps for third-party provider users via startup status notices. No enforcement change — this PR only adds visible warnings on top of the existing gating logic.

## Findings addressed

**Finding 1 — AI classifier never runs on 3P (`betas.ts:166`).** `modelSupportsAutoMode` returns `false` for every non-firstParty provider, so the classifier that reviews tool calls in context before execution doesn't fire. In `acceptEdits` / `bypassPermissions`, the per-tool consent prompt is also suppressed — users get the consent shortcut without the safety net, with zero indication.

**Finding 2 — `--dangerously-skip-permissions` sandbox gate is employee-only (`isAntEmployee()`).** External users (all OpenClaude users) skip the Docker/Bubblewrap container + no-internet check. The flag becomes "run any command with full internet access, no consent prompt, no safety net."

## What changed

- **Commit 1** (`a2bae76`): `thirdPartyPermissiveModeNotice` — fires when `permissionMode ∈ {acceptEdits, bypassPermissions}` ∧ `getAPIProvider() !== 'firstParty'` ∧ `!modelSupportsAutoMode(mainLoopModel)`. Reuses existing helpers — no new policy logic, just a label. Plumbing in `StatusNoticeContext` adds `permissionMode` and `mainLoopModel`, populated via `useAppState` in `StatusNotices.tsx`.
- **Commit 2** (`7df1a8e`): `dangerouslySkipPermissionsNotice` — fires when `process.argv` carries `--dangerously-skip-permissions` OR active mode is `bypassPermissions` (covers `settings.json` `defaultMode`). argv detection means the notice surfaces on the same first frame the flag was passed.
- **Commit 3** (`70a0e25`): 8 test cases across both notices, including the suppressed-on-default and suppressed-on-firstParty paths so a future regression that always shows the warning is caught.

## What this PR does NOT do

- Does not change the sandbox gate to apply universally — that's a maintainer policy call.
- Does not run the classifier for 3P — that requires PI probes to be wired for those providers (out of scope).
- Does not block any tool call. Behavior is purely warning-only.

## Test plan

- [x] `bun test src/utils/statusNoticeDefinitions.safety.test.tsx` — 8 pass
- [ ] Manual: launch with `--dangerously-skip-permissions` on a 3P provider, verify both notices show; toggle Shift+Tab to acceptEdits on 3P, verify the permissive-mode notice shows; switch to firstParty Anthropic, verify both disappear.