### PR TITLE
fix(json-schema): support top-level non-object roots via wrap/unwrap

### DIFF
--- a/src/tools/SyntheticOutputTool/SyntheticOutputTool.test.ts
+++ b/src/tools/SyntheticOutputTool/SyntheticOutputTool.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, test } from 'bun:test'
+import { createSyntheticOutputTool } from './SyntheticOutputTool.js'
+
+// Regression for #1256 — `--json-schema` failed when the user passed a
+// top-level array (or any non-object root) because the Anthropic tool_use
+// block requires the `input` field to be a JSON object. The tool now wraps
+// non-object roots as `{result: <orig>}` and unwraps before emitting
+// structured_output, so the CLI returns the exact shape the caller asked for.
+
+const ARRAY_OF_OBJECTS_SCHEMA = {
+  type: 'array',
+  items: {
+    type: 'object',
+    properties: { name: { type: 'string' } },
+    required: ['name'],
+  },
+} as const
+
+const STRING_ROOT_SCHEMA = { type: 'string' } as const
+
+const OBJECT_SCHEMA = {
+  type: 'object',
+  properties: { count: { type: 'integer' } },
+  required: ['count'],
+  additionalProperties: false,
+} as const
+
+describe('createSyntheticOutputTool (#1256 root schema wrapping)', () => {
+  test('top-level array root: wraps inputJSONSchema as object envelope', () => {
+    const result = createSyntheticOutputTool({ ...ARRAY_OF_OBJECTS_SCHEMA })
+    if (!('tool' in result)) throw new Error(`expected tool: ${result.error}`)
+    const schema = result.tool.inputJSONSchema as Record<string, unknown>
+    expect(schema.type).toBe('object')
+    expect((schema.properties as Record<string, unknown>).result).toEqual(
+      ARRAY_OF_OBJECTS_SCHEMA,
+    )
+    expect(schema.required).toEqual(['result'])
+  })
+
+  test('top-level array root: structured_output unwraps to plain array', async () => {
+    const result = createSyntheticOutputTool({ ...ARRAY_OF_OBJECTS_SCHEMA })
+    if (!('tool' in result)) throw new Error(`expected tool: ${result.error}`)
+
+    const payload = [{ name: 'one' }, { name: 'two' }]
+    const callResult = await result.tool.call(
+      { result: payload },
+      undefined as never,
+    )
+    expect(callResult.structured_output).toEqual(payload)
+  })
+
+  test('top-level string root: same wrap-and-unwrap behaviour', async () => {
+    const result = createSyntheticOutputTool({ ...STRING_ROOT_SCHEMA })
+    if (!('tool' in result)) throw new Error(`expected tool: ${result.error}`)
+    const schema = result.tool.inputJSONSchema as Record<string, unknown>
+    expect(schema.type).toBe('object')
+
+    const callResult = await result.tool.call(
+      { result: 'hello' },
+      undefined as never,
+    )
+    expect(callResult.structured_output).toBe('hello')
+  })
+
+  test('object root: passes through untouched', async () => {
+    const result = createSyntheticOutputTool({ ...OBJECT_SCHEMA })
+    if (!('tool' in result)) throw new Error(`expected tool: ${result.error}`)
+    expect(result.tool.inputJSONSchema).toEqual(OBJECT_SCHEMA)
+
+    const callResult = await result.tool.call(
+      { count: 5 },
+      undefined as never,
+    )
+    expect(callResult.structured_output).toEqual({ count: 5 })
+  })
+
+  test('wrapped tool rejects payloads that violate the inner schema', async () => {
+    const result = createSyntheticOutputTool({ ...ARRAY_OF_OBJECTS_SCHEMA })
+    if (!('tool' in result)) throw new Error(`expected tool: ${result.error}`)
+    await expect(
+      result.tool.call({ result: [{ wrong: 'shape' }] }, undefined as never),
+    ).rejects.toThrow(/schema/)
+  })
+})

--- a/src/tools/SyntheticOutputTool/SyntheticOutputTool.ts
+++ b/src/tools/SyntheticOutputTool/SyntheticOutputTool.ts
@@ -124,6 +124,33 @@ export function createSyntheticOutputTool(
   return result
 }
 
+// Anthropic tool_use blocks require the input to be a JSON object — the
+// `input` field is typed as a map. A top-level array (or any non-object root)
+// schema is valid JSON Schema but cannot be expressed as a tool input, so the
+// model emits `{}` and downstream validation fails (issue #1256). Wrap
+// non-object root schemas as `{result: <orig>}` so the model has a valid
+// object to fill, then unwrap before emitting `structured_output`. Users see
+// the same shape they asked for.
+const WRAPPED_FIELD = 'result'
+
+function isObjectRootSchema(schema: Record<string, unknown>): boolean {
+  const t = schema['type']
+  if (t === 'object') return true
+  if (Array.isArray(t) && t.includes('object')) return true
+  return false
+}
+
+function wrapNonObjectSchema(
+  schema: Record<string, unknown>,
+): Record<string, unknown> {
+  return {
+    type: 'object',
+    properties: { [WRAPPED_FIELD]: schema },
+    required: [WRAPPED_FIELD],
+    additionalProperties: false,
+  }
+}
+
 function buildSyntheticOutputTool(
   jsonSchema: Record<string, unknown>,
 ): CreateResult {
@@ -133,12 +160,17 @@ function buildSyntheticOutputTool(
     if (!isValidSchema) {
       return { error: ajv.errorsText(ajv.errors) }
     }
-    const validateSchema = ajv.compile(jsonSchema)
+
+    const needsWrapping = !isObjectRootSchema(jsonSchema)
+    const effectiveSchema = needsWrapping
+      ? wrapNonObjectSchema(jsonSchema)
+      : jsonSchema
+    const validateSchema = ajv.compile(effectiveSchema)
 
     return {
       tool: {
         ...SyntheticOutputTool,
-        inputJSONSchema: jsonSchema as ToolInputJSONSchema,
+        inputJSONSchema: effectiveSchema as ToolInputJSONSchema,
         async call(input) {
           const isValid = validateSchema(input)
           if (!isValid) {
@@ -150,9 +182,15 @@ function buildSyntheticOutputTool(
               `StructuredOutput schema mismatch: ${(errors ?? '').slice(0, 150)}`,
             )
           }
+          // Unwrap the synthetic `{result: ...}` envelope before surfacing so
+          // the CLI emits the array (or whatever non-object shape) the user
+          // actually asked for.
+          const structured = needsWrapping
+            ? (input as Record<string, unknown>)[WRAPPED_FIELD]
+            : input
           return {
             data: 'Structured output provided successfully',
-            structured_output: input,
+            structured_output: structured,
           }
         },
       },


### PR DESCRIPTION
## Summary

Closes #1256. `--json-schema` failed with "Failed to provide valid structured output after maximum retries" whenever the root `type` was not `object`. Object schemas worked, arrays nested inside objects worked — only top-level non-objects broke.

## Root cause

The Anthropic tool_use block requires the `input` field to be a JSON object (typed `Record<string, unknown>`). When `SyntheticOutputTool` used a user array schema as `inputJSONSchema` directly, the model had no valid object shape to emit and returned `{}` — failing Ajv validation every retry.

## Fix

In `buildSyntheticOutputTool`, detect non-object root schemas and wrap as:

```json
{
  "type": "object",
  "properties": { "result": <orig schema> },
  "required": ["result"],
  "additionalProperties": false
}
```

After Ajv validates the wrapped payload, unwrap `input.result` before emitting `structured_output`. The CLI returns the same array/string/number the caller asked for. Object roots pass through unchanged.

## Test plan

- [x] `bun test src/tools/SyntheticOutputTool/SyntheticOutputTool.test.ts` — 5 pass (top-level array wrap, array unwrap, string wrap, object pass-through, inner-schema violation still rejected)
- [ ] Manual: `openclaude -p 'Return []' --json-schema '{"type":"array","items":...}' --dangerously-skip-permissions` — emits `[]` instead of retry exhaustion