### PR TITLE
fix(codex-stream): recover tool args delivered only via done events

### DIFF
--- a/src/services/api/codexShim.test.ts
+++ b/src/services/api/codexShim.test.ts
@@ -1015,6 +1015,98 @@ describe('Codex request translation', () => {
       'I should note that the user role requires a briefly concise friendly response format.',
     )
   })
+
+  // Regression for #1259 — codexspark / gpt-5.3-codex-spark backend delivers
+  // complete function-call arguments only via the terminal `done` event with
+  // zero `delta` events in between. Without handling either `done` variant,
+  // the Anthropic tool_use block closed with `input: {}` and Glob/Bash/etc.
+  // failed validation with "required parameter X is missing".
+  async function collectToolArgs(responseText: string): Promise<string> {
+    const stream = new ReadableStream({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode(responseText))
+        controller.close()
+      },
+    })
+
+    const argsParts: string[] = []
+    for await (const event of codexStreamToAnthropic(
+      new Response(stream),
+      'gpt-5.3-codex-spark',
+    )) {
+      const delta = (event as {
+        delta?: { type?: string; partial_json?: string }
+      }).delta
+      if (
+        delta?.type === 'input_json_delta' &&
+        typeof delta.partial_json === 'string'
+      ) {
+        argsParts.push(delta.partial_json)
+      }
+    }
+    return argsParts.join('')
+  }
+
+  test('Codex stream: tool args delivered only via function_call_arguments.done (#1259)', async () => {
+    const args = '{"path":"./openclaude-codex-repro","pattern":"**/*.md"}'
+    const responseText = [
+      'event: response.output_item.added',
+      `data: {"type":"response.output_item.added","item":{"id":"fc_1","call_id":"call_1","type":"function_call","name":"Glob","arguments":""},"output_index":0,"sequence_number":0}`,
+      '',
+      'event: response.function_call_arguments.done',
+      `data: {"type":"response.function_call_arguments.done","item_id":"fc_1","arguments":${JSON.stringify(args)},"output_index":0,"sequence_number":1}`,
+      '',
+      'event: response.output_item.done',
+      `data: {"type":"response.output_item.done","item":{"id":"fc_1","call_id":"call_1","type":"function_call","name":"Glob","arguments":${JSON.stringify(args)}},"output_index":0,"sequence_number":2}`,
+      '',
+      'event: response.completed',
+      'data: {"type":"response.completed","response":{"id":"resp_1","status":"completed","model":"gpt-5.3-codex-spark","output":[],"usage":{"input_tokens":2,"output_tokens":3}},"sequence_number":3}',
+      '',
+    ].join('\n')
+
+    expect(await collectToolArgs(responseText)).toBe(args)
+  })
+
+  test('Codex stream: tool args fallback via output_item.done when no delta + no arguments.done', async () => {
+    const args = '{"command":"ls -la"}'
+    const responseText = [
+      'event: response.output_item.added',
+      `data: {"type":"response.output_item.added","item":{"id":"fc_1","call_id":"call_1","type":"function_call","name":"Bash","arguments":""},"output_index":0,"sequence_number":0}`,
+      '',
+      'event: response.output_item.done',
+      `data: {"type":"response.output_item.done","item":{"id":"fc_1","call_id":"call_1","type":"function_call","name":"Bash","arguments":${JSON.stringify(args)}},"output_index":0,"sequence_number":1}`,
+      '',
+      'event: response.completed',
+      'data: {"type":"response.completed","response":{"id":"resp_1","status":"completed","model":"gpt-5.3-codex-spark","output":[],"usage":{"input_tokens":2,"output_tokens":3}},"sequence_number":2}',
+      '',
+    ].join('\n')
+
+    expect(await collectToolArgs(responseText)).toBe(args)
+  })
+
+  test('Codex stream: delta path still works when present (no duplication on done)', async () => {
+    const args = '{"path":"./x","pattern":"**/*.ts"}'
+    const responseText = [
+      'event: response.output_item.added',
+      `data: {"type":"response.output_item.added","item":{"id":"fc_1","call_id":"call_1","type":"function_call","name":"Glob","arguments":""},"output_index":0,"sequence_number":0}`,
+      '',
+      'event: response.function_call_arguments.delta',
+      `data: {"type":"response.function_call_arguments.delta","item_id":"fc_1","delta":${JSON.stringify(args)},"output_index":0,"sequence_number":1}`,
+      '',
+      'event: response.function_call_arguments.done',
+      `data: {"type":"response.function_call_arguments.done","item_id":"fc_1","arguments":${JSON.stringify(args)},"output_index":0,"sequence_number":2}`,
+      '',
+      'event: response.output_item.done',
+      `data: {"type":"response.output_item.done","item":{"id":"fc_1","call_id":"call_1","type":"function_call","name":"Glob","arguments":${JSON.stringify(args)}},"output_index":0,"sequence_number":3}`,
+      '',
+      'event: response.completed',
+      'data: {"type":"response.completed","response":{"id":"resp_1","status":"completed","model":"gpt-5.3-codex-spark","output":[],"usage":{"input_tokens":2,"output_tokens":3}},"sequence_number":4}',
+      '',
+    ].join('\n')
+
+    // Delta wins; done branches must NOT re-emit and double the JSON.
+    expect(await collectToolArgs(responseText)).toBe(args)
+  })
 })
 
 describe('convertSystemPrompt', () => {

--- a/src/services/api/codexShim.ts
+++ b/src/services/api/codexShim.ts
@@ -791,7 +791,7 @@ export async function* codexStreamToAnthropic(
   const messageId = makeMessageId()
   const toolBlocksByItemId = new Map<
     string,
-    { index: number; toolUseId: string }
+    { index: number; toolUseId: string; emittedArgs: string }
   >()
   let activeTextBlockIndex: number | null = null
   const thinkFilter = createThinkTagFilter()
@@ -852,9 +852,12 @@ export async function* codexStreamToAnthropic(
         yield* closeActiveTextBlock()
         const blockIndex = nextContentBlockIndex++
         const toolUseId = item.call_id ?? item.id ?? `call_${blockIndex}`
+        const initialArgs =
+          typeof item.arguments === 'string' ? item.arguments : ''
         toolBlocksByItemId.set(String(item.id ?? toolUseId), {
           index: blockIndex,
           toolUseId,
+          emittedArgs: initialArgs,
         })
         sawToolUse = true
 
@@ -869,13 +872,13 @@ export async function* codexStreamToAnthropic(
           },
         }
 
-        if (item.arguments) {
+        if (initialArgs) {
           yield {
             type: 'content_block_delta',
             index: blockIndex,
             delta: {
               type: 'input_json_delta',
-              partial_json: item.arguments,
+              partial_json: initialArgs,
             },
           }
         }
@@ -911,13 +914,43 @@ export async function* codexStreamToAnthropic(
     if (event.event === 'response.function_call_arguments.delta') {
       const toolBlock = toolBlocksByItemId.get(String(payload.item_id ?? ''))
       if (toolBlock) {
-        yield {
-          type: 'content_block_delta',
-          index: toolBlock.index,
-          delta: {
-            type: 'input_json_delta',
-            partial_json: payload.delta ?? '',
-          },
+        const delta = typeof payload.delta === 'string' ? payload.delta : ''
+        if (delta) {
+          toolBlock.emittedArgs += delta
+          yield {
+            type: 'content_block_delta',
+            index: toolBlock.index,
+            delta: {
+              type: 'input_json_delta',
+              partial_json: delta,
+            },
+          }
+        }
+      }
+      continue
+    }
+
+    // Some Codex Responses backends (codexspark / gpt-5.3-codex-spark) deliver
+    // the *complete* function-call arguments only via the terminal
+    // `response.function_call_arguments.done` event, with zero
+    // `response.function_call_arguments.delta` events in between. Without
+    // handling `done`, the tool block closed with `input: {}` and downstream
+    // tool validation failed with "required parameter X is missing" (#1259).
+    if (event.event === 'response.function_call_arguments.done') {
+      const toolBlock = toolBlocksByItemId.get(String(payload.item_id ?? ''))
+      if (toolBlock) {
+        const fullArgs =
+          typeof payload.arguments === 'string' ? payload.arguments : ''
+        if (fullArgs && !toolBlock.emittedArgs) {
+          toolBlock.emittedArgs = fullArgs
+          yield {
+            type: 'content_block_delta',
+            index: toolBlock.index,
+            delta: {
+              type: 'input_json_delta',
+              partial_json: fullArgs,
+            },
+          }
         }
       }
       continue
@@ -928,6 +961,22 @@ export async function* codexStreamToAnthropic(
       if (item?.type === 'function_call') {
         const toolBlock = toolBlocksByItemId.get(String(item.id ?? ''))
         if (toolBlock) {
+          // Backstop for backends that skip the dedicated `function_call_arguments.done`
+          // event entirely and only put the full arguments on `output_item.done`.
+          // Same #1259 failure mode; trust whichever channel actually carried the data.
+          const finalArgs =
+            typeof item.arguments === 'string' ? item.arguments : ''
+          if (finalArgs && !toolBlock.emittedArgs) {
+            toolBlock.emittedArgs = finalArgs
+            yield {
+              type: 'content_block_delta',
+              index: toolBlock.index,
+              delta: {
+                type: 'input_json_delta',
+                partial_json: finalArgs,
+              },
+            }
+          }
           yield {
             type: 'content_block_stop',
             index: toolBlock.index,


### PR DESCRIPTION
## Summary

Closes #1259. `codexspark` / `gpt-5.3-codex-spark` deliver the complete function-call arguments only through the terminal `response.function_call_arguments.done` (and sometimes only `response.output_item.done`), with zero `response.function_call_arguments.delta` events in between. The Anthropic-compat stream adapter ignored both done channels for arguments, so the routed-agent tool_use block closed with `input: {}` and Glob/Bash/etc. failed validation with "required parameter X is missing."

## What changed

`src/services/api/codexShim.ts` — `codexStreamToAnthropic`:

1. Track `emittedArgs` per tool block (Map value gains a third field). Seeded from `output_item.added.item.arguments` when the provider front-loads them there.
2. New handler for `response.function_call_arguments.done` — if no deltas streamed (`!emittedArgs`), emit the full `arguments` string as one `input_json_delta`.
3. Backstop in `response.output_item.done`: when `item.arguments` is non-empty and `emittedArgs` is still empty, emit them before the `content_block_stop`. Covers backends that skip the dedicated arguments-done event entirely.

The `!toolBlock.emittedArgs` guard on both done branches prevents double emission when deltas already streamed.

## Test plan

- [x] `bun test src/services/api/codexShim.test.ts` — 43 pass (40 existing + 3 regression covering: args via `function_call_arguments.done` only, args via `output_item.done` only, delta wins / no duplication)
- [ ] Manual: agent-routed `Glob` call through codexspark per issue's repro — input now carries `{path, pattern}` instead of `{}`.