### PR TITLE
fix(codex-strict): widen optional fields to nullable + strip null from inputs

### DIFF
--- a/src/services/api/codexShim.test.ts
+++ b/src/services/api/codexShim.test.ts
@@ -230,7 +230,7 @@ describe('Codex provider config', () => {
 })
 
 describe('Codex request translation', () => {
-  test('normalizes optional parameters into strict Responses schemas', () => {
+  test('normalizes optional parameters into strict Responses schemas (#1264 — optional → nullable)', () => {
     const tools = convertToolsToResponsesTools([
       {
         name: 'Agent',
@@ -248,6 +248,9 @@ describe('Codex request translation', () => {
       },
     ])
 
+    // Strict mode requires every key in `required`; originally-optional
+    // fields must therefore be widened to allow `null` so the model can
+    // emit null instead of fabricating a placeholder value (#1264).
     expect(tools).toEqual([
       {
         type: 'function',
@@ -258,7 +261,7 @@ describe('Codex request translation', () => {
           properties: {
             description: { type: 'string' },
             prompt: { type: 'string' },
-            subagent_type: { type: 'string' },
+            subagent_type: { type: ['string', 'null'] },
           },
           required: ['description', 'prompt', 'subagent_type'],
           additionalProperties: false,
@@ -328,7 +331,7 @@ describe('Codex request translation', () => {
           type: 'object',
           properties: {
             pattern: { type: 'string', description: 'Search pattern' },
-            path: { type: 'string' },
+            path: { type: ['string', 'null'] },
           },
           required: ['pattern', 'path'],
           additionalProperties: false,
@@ -364,7 +367,7 @@ describe('Codex request translation', () => {
           type: 'object',
           properties: {
             pattern: { type: 'string', description: 'Glob pattern' },
-            path: { type: 'string' },
+            path: { type: ['string', 'null'] },
           },
           required: ['pattern', 'path'],
           additionalProperties: false,
@@ -477,7 +480,8 @@ describe('Codex request translation', () => {
           type: 'object',
           properties: {
             priority: {
-              type: 'integer',
+              // Originally-optional (no `required` array) → nullable widening per #1264.
+              type: ['integer', 'null'],
               description: 'Priority: 0=low, 1=medium, 2=high, 3=urgent',
               enum: [0, 1, 2, 3],
             },
@@ -550,7 +554,8 @@ describe('Codex request translation', () => {
     ])
 
     const payload = (tools[0].parameters as Record<string, Record<string, Record<string, unknown>>>).properties.payload
-    expect(payload.type).toBe('object')
+    // Originally-optional (no top-level `required` array) → widened to nullable per #1264.
+    expect(payload.type).toEqual(['object', 'null'])
   })
 
   test('infers array type for untyped schemas with items', () => {
@@ -567,7 +572,8 @@ describe('Codex request translation', () => {
     ])
 
     const tags = (tools[0].parameters as Record<string, Record<string, Record<string, unknown>>>).properties.tags
-    expect(tags.type).toBe('array')
+    // Originally-optional → widened to nullable.
+    expect(tags.type).toEqual(['array', 'null'])
   })
 
   test('infers type from enum values when type is missing', () => {
@@ -587,10 +593,11 @@ describe('Codex request translation', () => {
     ])
 
     const props = (tools[0].parameters as Record<string, Record<string, Record<string, unknown>>>).properties
-    expect(props.mode.type).toBe('string')
-    expect(props.level.type).toBe('integer')
-    expect(props.ratio.type).toBe('number')
-    expect(props.flag.type).toBe('boolean')
+    // All originally-optional (no `required` array) → nullable widening per #1264.
+    expect(props.mode.type).toEqual(['string', 'null'])
+    expect(props.level.type).toEqual(['integer', 'null'])
+    expect(props.ratio.type).toEqual(['number', 'null'])
+    expect(props.flag.type).toEqual(['boolean', 'null'])
   })
 
   test('leaves combinator-only schemas untyped to preserve alternatives', () => {
@@ -1106,6 +1113,46 @@ describe('Codex request translation', () => {
 
     // Delta wins; done branches must NOT re-emit and double the JSON.
     expect(await collectToolArgs(responseText)).toBe(args)
+  })
+
+  // Regression for #1264 — Read tool has `pages?: string` (optional). Codex
+  // strict mode previously made it a required non-null string, so the model
+  // emitted `pages: ""` as a placeholder and Read rejected the call before
+  // reading the file. After the fix `pages` is typed `['string', 'null']`,
+  // the model can emit `null` instead, and `normalizeToolInputForValidation`
+  // strips nulls so the tool sees the field as missing (which is what it
+  // expected for optional fields all along).
+  test('Read.pages: optional → nullable in strict schema (#1264)', () => {
+    const tools = convertToolsToResponsesTools([
+      {
+        name: 'Read',
+        description: 'Read a file',
+        input_schema: {
+          type: 'object',
+          properties: {
+            file_path: { type: 'string' },
+            limit: { type: 'number' },
+            offset: { type: 'number' },
+            pages: {
+              type: 'string',
+              description: 'Page range for PDFs (e.g. "1-5")',
+            },
+          },
+          required: ['file_path'],
+          additionalProperties: false,
+        },
+      },
+    ])
+
+    const params = tools[0].parameters as Record<string, unknown>
+    const props = params.properties as Record<string, Record<string, unknown>>
+    expect(props.file_path.type).toBe('string')
+    // Optional fields widened to allow null
+    expect(props.limit.type).toEqual(['number', 'null'])
+    expect(props.offset.type).toEqual(['number', 'null'])
+    expect(props.pages.type).toEqual(['string', 'null'])
+    // Strict mode still lists every key in required
+    expect(params.required).toEqual(['file_path', 'limit', 'offset', 'pages'])
   })
 })
 

--- a/src/services/api/codexShim.test.ts
+++ b/src/services/api/codexShim.test.ts
@@ -230,7 +230,7 @@ describe('Codex provider config', () => {
 })
 
 describe('Codex request translation', () => {
-  test('normalizes optional parameters into strict Responses schemas', () => {
+  test('normalizes optional parameters into strict Responses schemas (#1264 — optional → nullable)', () => {
     const tools = convertToolsToResponsesTools([
       {
         name: 'Agent',
@@ -248,6 +248,9 @@ describe('Codex request translation', () => {
       },
     ])
 
+    // Strict mode requires every key in `required`; originally-optional
+    // fields must therefore be widened to allow `null` so the model can
+    // emit null instead of fabricating a placeholder value (#1264).
     expect(tools).toEqual([
       {
         type: 'function',
@@ -258,7 +261,7 @@ describe('Codex request translation', () => {
           properties: {
             description: { type: 'string' },
             prompt: { type: 'string' },
-            subagent_type: { type: 'string' },
+            subagent_type: { type: ['string', 'null'] },
           },
           required: ['description', 'prompt', 'subagent_type'],
           additionalProperties: false,
@@ -328,7 +331,7 @@ describe('Codex request translation', () => {
           type: 'object',
           properties: {
             pattern: { type: 'string', description: 'Search pattern' },
-            path: { type: 'string' },
+            path: { type: ['string', 'null'] },
           },
           required: ['pattern', 'path'],
           additionalProperties: false,
@@ -364,7 +367,7 @@ describe('Codex request translation', () => {
           type: 'object',
           properties: {
             pattern: { type: 'string', description: 'Glob pattern' },
-            path: { type: 'string' },
+            path: { type: ['string', 'null'] },
           },
           required: ['pattern', 'path'],
           additionalProperties: false,
@@ -477,7 +480,8 @@ describe('Codex request translation', () => {
           type: 'object',
           properties: {
             priority: {
-              type: 'integer',
+              // Originally-optional (no `required` array) → nullable widening per #1264.
+              type: ['integer', 'null'],
               description: 'Priority: 0=low, 1=medium, 2=high, 3=urgent',
               enum: [0, 1, 2, 3],
             },
@@ -550,7 +554,8 @@ describe('Codex request translation', () => {
     ])
 
     const payload = (tools[0].parameters as Record<string, Record<string, Record<string, unknown>>>).properties.payload
-    expect(payload.type).toBe('object')
+    // Originally-optional (no top-level `required` array) → widened to nullable per #1264.
+    expect(payload.type).toEqual(['object', 'null'])
   })
 
   test('infers array type for untyped schemas with items', () => {
@@ -567,7 +572,8 @@ describe('Codex request translation', () => {
     ])
 
     const tags = (tools[0].parameters as Record<string, Record<string, Record<string, unknown>>>).properties.tags
-    expect(tags.type).toBe('array')
+    // Originally-optional → widened to nullable.
+    expect(tags.type).toEqual(['array', 'null'])
   })
 
   test('infers type from enum values when type is missing', () => {
@@ -587,10 +593,11 @@ describe('Codex request translation', () => {
     ])
 
     const props = (tools[0].parameters as Record<string, Record<string, Record<string, unknown>>>).properties
-    expect(props.mode.type).toBe('string')
-    expect(props.level.type).toBe('integer')
-    expect(props.ratio.type).toBe('number')
-    expect(props.flag.type).toBe('boolean')
+    // All originally-optional (no `required` array) → nullable widening per #1264.
+    expect(props.mode.type).toEqual(['string', 'null'])
+    expect(props.level.type).toEqual(['integer', 'null'])
+    expect(props.ratio.type).toEqual(['number', 'null'])
+    expect(props.flag.type).toEqual(['boolean', 'null'])
   })
 
   test('leaves combinator-only schemas untyped to preserve alternatives', () => {
@@ -1014,6 +1021,46 @@ describe('Codex request translation', () => {
     expect(textDeltas.join('')).toBe(
       'I should note that the user role requires a briefly concise friendly response format.',
     )
+  })
+
+  // Regression for #1264 — Read tool has `pages?: string` (optional). Codex
+  // strict mode previously made it a required non-null string, so the model
+  // emitted `pages: ""` as a placeholder and Read rejected the call before
+  // reading the file. After the fix `pages` is typed `['string', 'null']`,
+  // the model can emit `null` instead, and `normalizeToolInputForValidation`
+  // strips nulls so the tool sees the field as missing (which is what it
+  // expected for optional fields all along).
+  test('Read.pages: optional → nullable in strict schema (#1264)', () => {
+    const tools = convertToolsToResponsesTools([
+      {
+        name: 'Read',
+        description: 'Read a file',
+        input_schema: {
+          type: 'object',
+          properties: {
+            file_path: { type: 'string' },
+            limit: { type: 'number' },
+            offset: { type: 'number' },
+            pages: {
+              type: 'string',
+              description: 'Page range for PDFs (e.g. "1-5")',
+            },
+          },
+          required: ['file_path'],
+          additionalProperties: false,
+        },
+      },
+    ])
+
+    const params = tools[0].parameters as Record<string, unknown>
+    const props = params.properties as Record<string, Record<string, unknown>>
+    expect(props.file_path.type).toBe('string')
+    // Optional fields widened to allow null
+    expect(props.limit.type).toEqual(['number', 'null'])
+    expect(props.offset.type).toEqual(['number', 'null'])
+    expect(props.pages.type).toEqual(['string', 'null'])
+    // Strict mode still lists every key in required
+    expect(params.required).toEqual(['file_path', 'limit', 'offset', 'pages'])
   })
 })
 

--- a/src/services/api/codexShim.ts
+++ b/src/services/api/codexShim.ts
@@ -367,9 +367,35 @@ function ensureSchemaType(record: Record<string, unknown>): void {
 }
 
 /**
+ * Codex Responses strict mode requires every property to appear in `required`,
+ * so originally-optional fields lose their optionality on the wire. The
+ * documented workaround is to widen the property `type` to allow `null` —
+ * the field is still "required", but the model can satisfy it by emitting
+ * null instead of fabricating a placeholder. Without this, Codex emits
+ * `pages: ""` for the optional Read.pages field and OpenClaude rejects the
+ * tool call before reading the file (#1264).
+ *
+ * Mirrors the openai-shim normalization that landed in #471 for non-strict
+ * Chat Completions; the strict path needs the nullable trick because we
+ * cannot just omit the key from `required`.
+ */
+function widenTypeToNullable(type: unknown): unknown {
+  if (type === undefined) return type
+  if (typeof type === 'string') {
+    return type === 'null' ? type : [type, 'null']
+  }
+  if (Array.isArray(type)) {
+    return type.includes('null') ? type : [...type, 'null']
+  }
+  return type
+}
+
+/**
  * Recursively enforces Codex strict-mode constraints on a JSON schema:
  * - Every `object` type gets `additionalProperties: false`
  * - All property keys are listed in `required`
+ * - Originally-optional properties get `type: [<orig>, 'null']` so the model
+ *   can emit `null` rather than a placeholder value (#1264)
  * - Nested schemas (properties, items, anyOf/oneOf/allOf) are processed too
  */
 function enforceStrictSchema(schema: unknown): Record<string, unknown> {
@@ -395,12 +421,23 @@ function enforceStrictSchema(schema: unknown): Record<string, unknown> {
     ) {
       const props = record.properties as Record<string, unknown>
 
+      // Capture original optionality BEFORE we overwrite required. When the
+      // schema didn't have an explicit `required` array, treat every field
+      // as optional (matches JSON Schema semantics).
+      const originalRequired: Set<string> | null = Array.isArray(record.required)
+        ? new Set(
+            (record.required as unknown[]).filter(
+              (k): k is string => typeof k === 'string',
+            ),
+          )
+        : null
+
       const enforcedProps: Record<string, unknown> = {}
       for (const [key, value] of Object.entries(props)) {
         const strictValue = enforceStrictSchema(value)
         // If the resulting schema is an empty object (no properties), OpenAI structured outputs will likely
         // strip it silently and then complain about a 'required' mismatch if it remains in the required list.
-        // E.g. z.record() objects (like AskUserQuestion.answers) lose their schema due to additionalProperties 
+        // E.g. z.record() objects (like AskUserQuestion.answers) lose their schema due to additionalProperties
         // restrictions. We can safely drop these from the schema sent to the LLM.
         if (
           strictValue &&
@@ -410,6 +447,14 @@ function enforceStrictSchema(schema: unknown): Record<string, unknown> {
           (!strictValue.properties || Object.keys(strictValue.properties).length === 0)
         ) {
           continue
+        }
+        // Originally-optional → widen type to permit `null` so the model can
+        // satisfy the strict-required slot without fabricating a placeholder
+        // value (#1264). Originally-required fields stay typed as authored.
+        const wasOptional =
+          originalRequired === null || !originalRequired.has(key)
+        if (wasOptional && strictValue.type !== undefined) {
+          strictValue.type = widenTypeToNullable(strictValue.type)
         }
         enforcedProps[key] = strictValue
       }

--- a/src/services/tools/toolExecution.test.ts
+++ b/src/services/tools/toolExecution.test.ts
@@ -134,6 +134,53 @@ describe('normalizeToolInputForValidation', () => {
       options: [],
     }
 
-    expect(normalizeToolInputForValidation({ name: 'Read' } as never, input)).toBe(input)
+    // Tool name not AskUserQuestion → only null-stripping applies; no nulls → identity
+    const result = normalizeToolInputForValidation({ name: 'Read' } as never, input)
+    expect(result).toEqual(input)
+  })
+
+  // Regression for #1264 — Codex strict schema mode widens optional fields to
+  // `type: [<orig>, 'null']`. The model emits `null` to indicate "not set",
+  // but tool Zod schemas type optional fields as `T | undefined`, not
+  // `T | null`. Strip top-level nulls so the field reaches the tool as
+  // missing (matches what the model intended).
+  test('strips top-level null values from tool input (#1264)', () => {
+    const input = {
+      file_path: '/tmp/foo.txt',
+      limit: 20,
+      offset: 1,
+      pages: null,
+    }
+    expect(
+      normalizeToolInputForValidation({ name: 'Read' } as never, input),
+    ).toEqual({
+      file_path: '/tmp/foo.txt',
+      limit: 20,
+      offset: 1,
+    })
+  })
+
+  test('keeps non-null falsy values (0, empty string, false)', () => {
+    const input = {
+      offset: 0,
+      label: '',
+      enabled: false,
+    }
+    expect(
+      normalizeToolInputForValidation({ name: 'Read' } as never, input),
+    ).toEqual(input)
+  })
+
+  test('does not recurse into nested objects (top-level only)', () => {
+    const input = {
+      file_path: '/tmp/foo.txt',
+      meta: { nested: null },
+    }
+    expect(
+      normalizeToolInputForValidation({ name: 'Read' } as never, input),
+    ).toEqual({
+      file_path: '/tmp/foo.txt',
+      meta: { nested: null },
+    })
   })
 })

--- a/src/services/tools/toolExecution.test.ts
+++ b/src/services/tools/toolExecution.test.ts
@@ -203,4 +203,86 @@ describe('normalizeToolInputForValidation', () => {
     )
     expect(byFlag).toBe(input)
   })
+
+  // Regression for #1266 follow-up review: when an MCP tool's
+  // `inputJSONSchema` is available, strip top-level nulls for properties
+  // that were originally optional AND non-nullable. The Codex side widens
+  // those to nullable type unions (#1264), so the model emits `null` to
+  // satisfy a slot it didn't intend to fill — but the MCP server's AJV
+  // runs against the unmodified schema and rejects the null.
+  test('MCP: strips null for originally-optional, non-nullable property', () => {
+    const input = { query: 'foo', limit: null }
+    const result = normalizeToolInputForValidation(
+      {
+        name: 'mcp__example__search',
+        inputJSONSchema: {
+          type: 'object',
+          properties: {
+            query: { type: 'string' },
+            limit: { type: 'number' },
+          },
+          required: ['query'],
+        },
+      } as never,
+      input,
+    )
+    expect(result).toEqual({ query: 'foo' })
+  })
+
+  test('MCP: keeps null for required-nullable property', () => {
+    const input = { query: 'foo', cursor: null }
+    const result = normalizeToolInputForValidation(
+      {
+        name: 'mcp__example__search',
+        inputJSONSchema: {
+          type: 'object',
+          properties: {
+            query: { type: 'string' },
+            cursor: { type: ['string', 'null'] },
+          },
+          required: ['query', 'cursor'],
+        },
+      } as never,
+      input,
+    )
+    expect(result).toEqual(input)
+  })
+
+  test('MCP: keeps null for optional-nullable property', () => {
+    const input = { query: 'foo', tag: null }
+    const result = normalizeToolInputForValidation(
+      {
+        name: 'mcp__example__search',
+        inputJSONSchema: {
+          type: 'object',
+          properties: {
+            query: { type: 'string' },
+            tag: { type: ['string', 'null'] },
+          },
+          required: ['query'],
+        },
+      } as never,
+      input,
+    )
+    expect(result).toEqual(input)
+  })
+
+  test('MCP: identity preserved when no nulls present', () => {
+    const input = { query: 'foo', limit: 10 }
+    const result = normalizeToolInputForValidation(
+      {
+        name: 'mcp__example__search',
+        inputJSONSchema: {
+          type: 'object',
+          properties: {
+            query: { type: 'string' },
+            limit: { type: 'number' },
+          },
+          required: ['query'],
+        },
+      } as never,
+      input,
+    )
+    expect(result).toBe(input)
+  })
 })

--- a/src/services/tools/toolExecution.test.ts
+++ b/src/services/tools/toolExecution.test.ts
@@ -134,6 +134,73 @@ describe('normalizeToolInputForValidation', () => {
       options: [],
     }
 
-    expect(normalizeToolInputForValidation({ name: 'Read' } as never, input)).toBe(input)
+    // Tool name not AskUserQuestion → only null-stripping applies; no nulls → identity
+    const result = normalizeToolInputForValidation({ name: 'Read' } as never, input)
+    expect(result).toEqual(input)
+  })
+
+  // Regression for #1264 — Codex strict schema mode widens optional fields to
+  // `type: [<orig>, 'null']`. The model emits `null` to indicate "not set",
+  // but tool Zod schemas type optional fields as `T | undefined`, not
+  // `T | null`. Strip top-level nulls so the field reaches the tool as
+  // missing (matches what the model intended).
+  test('strips top-level null values from tool input (#1264)', () => {
+    const input = {
+      file_path: '/tmp/foo.txt',
+      limit: 20,
+      offset: 1,
+      pages: null,
+    }
+    expect(
+      normalizeToolInputForValidation({ name: 'Read' } as never, input),
+    ).toEqual({
+      file_path: '/tmp/foo.txt',
+      limit: 20,
+      offset: 1,
+    })
+  })
+
+  test('keeps non-null falsy values (0, empty string, false)', () => {
+    const input = {
+      offset: 0,
+      label: '',
+      enabled: false,
+    }
+    expect(
+      normalizeToolInputForValidation({ name: 'Read' } as never, input),
+    ).toEqual(input)
+  })
+
+  test('does not recurse into nested objects (top-level only)', () => {
+    const input = {
+      file_path: '/tmp/foo.txt',
+      meta: { nested: null },
+    }
+    expect(
+      normalizeToolInputForValidation({ name: 'Read' } as never, input),
+    ).toEqual({
+      file_path: '/tmp/foo.txt',
+      meta: { nested: null },
+    })
+  })
+
+  // MCP servers own their JSON Schema and may treat `null` as a meaningful
+  // value or require a nullable argument. We forward args verbatim through
+  // src/services/mcp/client.ts, so pre-stripping nulls would make the server
+  // see "missing" instead of the model's intentional `null`. Skip the strip
+  // for MCP tools entirely.
+  test('preserves top-level null values for MCP tools', () => {
+    const input = { account: null, query: 'foo' }
+    const byName = normalizeToolInputForValidation(
+      { name: 'mcp__example__search' } as never,
+      input,
+    )
+    expect(byName).toBe(input)
+
+    const byFlag = normalizeToolInputForValidation(
+      { name: 'search', isMcp: true } as never,
+      input,
+    )
+    expect(byFlag).toBe(input)
   })
 })

--- a/src/services/tools/toolExecution.ts
+++ b/src/services/tools/toolExecution.ts
@@ -659,8 +659,81 @@ function stripNullToolInputProperties(input: unknown): unknown {
   return cleaned
 }
 
+/**
+ * Schema-aware top-level null strip for MCP tool inputs.
+ *
+ * Codex strict mode forces every MCP tool property into `required` and widens
+ * originally-optional fields to `type: [<orig>, 'null']` so the model can
+ * emit `null` to satisfy a slot it didn't intend to fill. But the MCP
+ * server's own AJV runs against the unmodified `inputJSONSchema`, where
+ * those fields are still typed narrowly (e.g. `limit?: number`). Forwarding
+ * the literal `null` produced by the strict-mode escape hatch surfaces as
+ * `data/limit must be number` before `callTool` ever runs.
+ *
+ * Resolution: only strip a top-level null when the original MCP schema (a)
+ * does not list the property as `required` AND (b) does not advertise `null`
+ * in its type. Required-nullable fields stay intact — the server asked for a
+ * null sentinel and we honour it. Optional-nullable fields are also kept,
+ * matching the same intent on the MCP side.
+ */
+function stripNullPropertiesAgainstMcpSchema(
+  input: unknown,
+  inputJSONSchema: Tool['inputJSONSchema'],
+): unknown {
+  if (!isRecord(input)) return input
+
+  // No schema → no information to make the call. Forward the input untouched,
+  // matching the prior MCP exemption — the server's own validator is the
+  // source of truth.
+  if (!inputJSONSchema || typeof inputJSONSchema !== 'object') return input
+
+  const schema = inputJSONSchema as Record<string, unknown>
+  const properties =
+    isRecord(schema.properties)
+      ? (schema.properties as Record<string, unknown>)
+      : null
+  const requiredSet = new Set(
+    Array.isArray(schema.required)
+      ? (schema.required as unknown[]).filter(
+          (k): k is string => typeof k === 'string',
+        )
+      : [],
+  )
+
+  const isOriginallyNullable = (propSchema: unknown): boolean => {
+    if (!isRecord(propSchema)) return false
+    const t = propSchema.type
+    if (t === 'null') return true
+    if (Array.isArray(t) && t.includes('null')) return true
+    return false
+  }
+
+  let hasStrippable = false
+  for (const [key, value] of Object.entries(input)) {
+    if (value !== null) continue
+    if (requiredSet.has(key)) continue
+    if (properties && isOriginallyNullable(properties[key])) continue
+    hasStrippable = true
+    break
+  }
+  if (!hasStrippable) return input
+
+  const cleaned: Record<string, unknown> = {}
+  for (const [key, value] of Object.entries(input)) {
+    if (
+      value === null &&
+      !requiredSet.has(key) &&
+      !(properties && isOriginallyNullable(properties[key]))
+    ) {
+      continue
+    }
+    cleaned[key] = value
+  }
+  return cleaned
+}
+
 export function normalizeToolInputForValidation(
-  tool: Pick<Tool, 'name' | 'isMcp'>,
+  tool: Pick<Tool, 'name' | 'isMcp' | 'inputJSONSchema'>,
   input: unknown,
 ): unknown {
   // Generic top-level null strip first: Codex strict schemas widen optional
@@ -668,13 +741,20 @@ export function normalizeToolInputForValidation(
   // "not set" even though tool Zod schemas type optional as `T | undefined`.
   // Strip nulls so the field reaches the tool as missing.
   //
-  // Scope: built-in tools only. MCP tools own their JSON Schema and may
-  // accept/require `null`; we forward args verbatim to the server, so don't
-  // pre-strip them. `mcp__` prefix mirrors isMcpTool() and the analytics
-  // gating elsewhere in this file.
+  // MCP tools own their JSON Schema and may legitimately accept or require a
+  // `null` value, so we cannot blindly strip nulls there. But we also widen
+  // their optional fields to nullable on the Codex side (#1264), and the
+  // model uses that null sentinel for any field it didn't intend to fill —
+  // which the server-side AJV against the unmodified schema then rejects.
+  // For MCP, use schema-aware stripping: drop nulls only for properties that
+  // were originally optional AND non-nullable in `inputJSONSchema`, keeping
+  // required-nullable / optional-nullable fields intact. `mcp__` prefix
+  // mirrors isMcpTool() and the analytics gating elsewhere in this file.
   const isMcp =
     tool.isMcp === true || (typeof tool.name === 'string' && tool.name.startsWith('mcp__'))
-  const denulled = isMcp ? input : stripNullToolInputProperties(input)
+  const denulled = isMcp
+    ? stripNullPropertiesAgainstMcpSchema(input, tool.inputJSONSchema)
+    : stripNullToolInputProperties(input)
 
   if (!isRecord(denulled)) {
     return denulled

--- a/src/services/tools/toolExecution.ts
+++ b/src/services/tools/toolExecution.ts
@@ -615,40 +615,83 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value)
 }
 
+/**
+ * Drop top-level keys whose value is exactly `null`. OpenAI's strict schema
+ * mode for tool inputs requires every property to appear in `required`; the
+ * documented escape hatch for originally-optional fields is `type: [<orig>,
+ * 'null']`, which makes the model emit `null` to indicate "not set". Zod
+ * schemas on the tool side type those fields as `T | undefined`, not `T |
+ * null`, so the null arrives and fails `safeParse` with a confusing
+ * "Invalid …" message before the tool even runs (#1264). Strip nulls so the
+ * field reaches the tool as missing, which is what the model intended.
+ *
+ * Top-level only — we don't crawl arrays or nested objects, because tools
+ * that genuinely structure their inputs do not currently use `null` as a
+ * meaningful sentinel anywhere. If that changes, narrow this to known
+ * optional fields per tool descriptor.
+ */
+function stripNullToolInputProperties(input: unknown): unknown {
+  if (!isRecord(input)) return input
+  let hasNull = false
+  for (const value of Object.values(input)) {
+    if (value === null) {
+      hasNull = true
+      break
+    }
+  }
+  // Preserve identity when there's nothing to strip — call sites
+  // (and tests) rely on `===`/`.toBe(input)` for the no-op path.
+  if (!hasNull) return input
+
+  const cleaned: Record<string, unknown> = {}
+  for (const [key, value] of Object.entries(input)) {
+    if (value === null) continue
+    cleaned[key] = value
+  }
+  return cleaned
+}
+
 export function normalizeToolInputForValidation(
   tool: Pick<Tool, 'name'>,
   input: unknown,
 ): unknown {
-  if (!isRecord(input)) {
-    return input
+  // Generic top-level null strip first: Codex strict schemas widen optional
+  // fields to nullable type unions, so the model can emit `null` to indicate
+  // "not set" even though tool Zod schemas type optional as `T | undefined`.
+  // Strip nulls so the field reaches the tool as missing.
+  const denulled = stripNullToolInputProperties(input)
+
+  if (!isRecord(denulled)) {
+    return denulled
   }
 
   if (tool.name === FILE_READ_TOOL_NAME) {
-    // Codex strict tool schemas can emit placeholder pages: "" / null for
-    // non-PDF reads. Treat those the same as omission before zod validation.
-    const pages = input.pages
-    if (pages === null || (typeof pages === 'string' && pages.trim() === '')) {
-      const { pages: _pages, ...rest } = input
+    // Codex strict tool schemas can also emit placeholder pages: "" for
+    // non-PDF reads. The generic null strip above already handled `null`,
+    // so just guard against the empty-string variant here.
+    const pages = denulled.pages
+    if (typeof pages === 'string' && pages.trim() === '') {
+      const { pages: _pages, ...rest } = denulled
       return rest
     }
-    return input
+    return denulled
   }
 
   if (tool.name !== ASK_USER_QUESTION_TOOL_NAME) {
-    return input
+    return denulled
   }
 
-  if (Array.isArray(input.questions)) {
-    return input
+  if (Array.isArray(denulled.questions)) {
+    return denulled
   }
 
-  const { question, header, options, multiSelect, ...rest } = input
+  const { question, header, options, multiSelect, ...rest } = denulled
   if (
     typeof question !== 'string' ||
     typeof header !== 'string' ||
     !Array.isArray(options)
   ) {
-    return input
+    return denulled
   }
 
   return {

--- a/src/services/tools/toolExecution.ts
+++ b/src/services/tools/toolExecution.ts
@@ -615,40 +615,98 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value)
 }
 
+/**
+ * Drop top-level keys whose value is exactly `null`. OpenAI's strict schema
+ * mode for tool inputs requires every property to appear in `required`; the
+ * documented escape hatch for originally-optional fields is `type: [<orig>,
+ * 'null']`, which makes the model emit `null` to indicate "not set". Zod
+ * schemas on the tool side type those fields as `T | undefined`, not `T |
+ * null`, so the null arrives and fails `safeParse` with a confusing
+ * "Invalid …" message before the tool even runs (#1264). Strip nulls so the
+ * field reaches the tool as missing, which is what the model intended.
+ *
+ * Built-in tools only. MCP servers are open-world: each carries its own
+ * JSON Schema (`inputJSONSchema`), which we forward verbatim through
+ * `src/services/mcp/client.ts`, and a server may legitimately treat `null`
+ * as a meaningful value or even require a nullable argument. Silently
+ * dropping the key here would make AJV/the server see "missing" instead of
+ * the model's intentional `null`. Skip MCP tools entirely and let their own
+ * schema validation decide.
+ *
+ * Top-level only — we don't crawl arrays or nested objects, because tools
+ * that genuinely structure their inputs do not currently use `null` as a
+ * meaningful sentinel anywhere. If that changes, narrow this to known
+ * optional fields per tool descriptor.
+ */
+function stripNullToolInputProperties(input: unknown): unknown {
+  if (!isRecord(input)) return input
+  let hasNull = false
+  for (const value of Object.values(input)) {
+    if (value === null) {
+      hasNull = true
+      break
+    }
+  }
+  // Preserve identity when there's nothing to strip — call sites
+  // (and tests) rely on `===`/`.toBe(input)` for the no-op path.
+  if (!hasNull) return input
+
+  const cleaned: Record<string, unknown> = {}
+  for (const [key, value] of Object.entries(input)) {
+    if (value === null) continue
+    cleaned[key] = value
+  }
+  return cleaned
+}
+
 export function normalizeToolInputForValidation(
-  tool: Pick<Tool, 'name'>,
+  tool: Pick<Tool, 'name' | 'isMcp'>,
   input: unknown,
 ): unknown {
-  if (!isRecord(input)) {
-    return input
+  // Generic top-level null strip first: Codex strict schemas widen optional
+  // fields to nullable type unions, so the model can emit `null` to indicate
+  // "not set" even though tool Zod schemas type optional as `T | undefined`.
+  // Strip nulls so the field reaches the tool as missing.
+  //
+  // Scope: built-in tools only. MCP tools own their JSON Schema and may
+  // accept/require `null`; we forward args verbatim to the server, so don't
+  // pre-strip them. `mcp__` prefix mirrors isMcpTool() and the analytics
+  // gating elsewhere in this file.
+  const isMcp =
+    tool.isMcp === true || (typeof tool.name === 'string' && tool.name.startsWith('mcp__'))
+  const denulled = isMcp ? input : stripNullToolInputProperties(input)
+
+  if (!isRecord(denulled)) {
+    return denulled
   }
 
   if (tool.name === FILE_READ_TOOL_NAME) {
-    // Codex strict tool schemas can emit placeholder pages: "" / null for
-    // non-PDF reads. Treat those the same as omission before zod validation.
-    const pages = input.pages
-    if (pages === null || (typeof pages === 'string' && pages.trim() === '')) {
-      const { pages: _pages, ...rest } = input
+    // Codex strict tool schemas can also emit placeholder pages: "" for
+    // non-PDF reads. The generic null strip above already handled `null`,
+    // so just guard against the empty-string variant here.
+    const pages = denulled.pages
+    if (typeof pages === 'string' && pages.trim() === '') {
+      const { pages: _pages, ...rest } = denulled
       return rest
     }
-    return input
+    return denulled
   }
 
   if (tool.name !== ASK_USER_QUESTION_TOOL_NAME) {
-    return input
+    return denulled
   }
 
-  if (Array.isArray(input.questions)) {
-    return input
+  if (Array.isArray(denulled.questions)) {
+    return denulled
   }
 
-  const { question, header, options, multiSelect, ...rest } = input
+  const { question, header, options, multiSelect, ...rest } = denulled
   if (
     typeof question !== 'string' ||
     typeof header !== 'string' ||
     !Array.isArray(options)
   ) {
-    return input
+    return denulled
   }
 
   return {


### PR DESCRIPTION
## Summary

Closes #1264. Codex Responses strict mode requires every property to appear in `required`, so `enforceStrictSchema` listed every key — but kept their types narrow. Originally-optional fields like `Read.pages` turned into required non-null strings, the model fabricated placeholder values (`pages: ""`), and OpenClaude rejected the call before reading the file with `Invalid pages parameter: ""`.

## Two-piece fix

### 1. `enforceStrictSchema` widens optional types to nullable

`src/services/api/codexShim.ts`. Capture the original `required` set before overwriting it. For each property NOT in the original set, transform its type to allow `null` (e.g. `{type: 'string'}` → `{type: ['string', 'null']}`). Strict mode still lists every key in `required`, but now the model can emit `null` for optional slots instead of fabricating placeholders.

Mirrors the openai-shim normalization that landed in #471 for the non-strict Chat Completions path. Strict mode needs the nullable widening because we cannot drop the key from `required`.

### 2. `normalizeToolInputForValidation` strips top-level nulls

`src/services/tools/toolExecution.ts`. Tool Zod schemas type optional fields as `T | undefined`, not `T | null`. When the model emits `null` under the new schema, strip those top-level keys before `safeParse` so the tool sees the field as missing — which is what an optional field has always meant.

Top-level only; tools don't currently use `null` as a meaningful nested sentinel. Identity preserved on the no-op path (no nulls present) so existing `.toBe(input)` assertions still hold.

## Test plan

- [x] `bun test src/services/api/codexShim.test.ts src/services/tools/toolExecution.test.ts` — 51 pass
  - existing strict-schema snapshots updated to reflect optional → nullable widening
  - new `Read.pages: optional → nullable` regression covering exact #1264 shape
  - null stripping at top level; falsy-but-not-null (0/'',false) preserved; no recursion
- [ ] Manual: per #1264 repro — `Read` on a non-PDF with `limit`+`offset` and no `pages` — now succeeds instead of failing input validation