### PR TITLE
fix(stdin,mcp): guard rawModeEnabledCount and defer MCP connections to prevent input freeze (#603)

### DIFF
--- a/src/ink/components/App.tsx
+++ b/src/ink/components/App.tsx
@@ -224,6 +224,13 @@ export default class App extends PureComponent<Props, State> {
     }
     stdin.setEncoding('utf8');
     if (isEnabled) {
+      // Guard against negative count from async races or effect cleanup bugs.
+      // If count is negative, reset to 0 so setup runs on this enable.
+      if (this.rawModeEnabledCount < 0) {
+        logForDebugging(`handleSetRawMode: recovering rawModeEnabledCount from ${this.rawModeEnabledCount} to 0`);
+        this.rawModeEnabledCount = 0;
+      }
+
       // Ensure raw mode is enabled only once
       if (this.rawModeEnabledCount === 0) {
         // Stop early input capture right before we add our own readable handler.
@@ -272,6 +279,13 @@ export default class App extends PureComponent<Props, State> {
         });
       }
       this.rawModeEnabledCount++;
+      return;
+    }
+
+    // Guard against unbalanced disable calls (e.g. from rapid mount/unmount
+    // during MCP-driven re-renders). Prevent count from going negative.
+    if (this.rawModeEnabledCount <= 0) {
+      logForDebugging(`handleSetRawMode: ignoring disable call with count=${this.rawModeEnabledCount}`);
       return;
     }
 

--- a/src/services/mcp/useManageMCPConnections.ts
+++ b/src/services/mcp/useManageMCPConnections.ts
@@ -204,7 +204,7 @@ export function useManageMCPConnections(
   // in a single setAppState call via setTimeout. Using a time-based window
   // (instead of queueMicrotask) ensures updates are batched even when
   // connection callbacks arrive at different times due to network I/O.
-  const MCP_BATCH_FLUSH_MS = 16
+  const MCP_BATCH_FLUSH_MS = 100
   type PendingUpdate = MCPServerConnection & {
     tools?: Tool[]
     commands?: Command[]
@@ -1008,7 +1008,17 @@ export function useManageMCPConnections(
       })
     }
 
-    void loadAndConnectMcpConfigs()
+    // Defer MCP connections by one event-loop tick to ensure Ink's stdin
+    // raw-mode setup (handleSetRawMode in App.tsx) has fully committed
+    // before any async MCP callback can trigger a re-render. Mitigates the
+    // race described in issue #603 where rapid mount/unmount during early
+    // MCP state updates could corrupt rawModeEnabledCount or deregister
+    // stdin listeners before they were fully attached.
+    setTimeout(() => {
+      if (!cancelled) {
+        void loadAndConnectMcpConfigs()
+      }
+    }, 0)
 
     return () => {
       cancelled = true


### PR DESCRIPTION
## Summary

Fixes the terminal input freeze reported in #603.

### Root cause
MCP plugin connections (especially HTTP/SSE servers with OAuth) trigger `setAppState` callbacks that cause rapid React re-renders. During those re-renders, `useInput` components can mount/unmount in quick succession, calling `setRawMode(true)` / `setRawMode(false)`. Because `rawModeEnabledCount` in Ink's `App.tsx` was unguarded, it could be driven negative. Once negative, subsequent `setRawMode(true)` calls skip the stdin listener setup (guard is `count === 0`), leaving the terminal completely unresponsive to keystrokes.

### Changes
- **src/ink/components/App.tsx**
  - Guard `rawModeEnabledCount` on the enable path: if negative, reset to `0` before checking `count === 0`.
  - Guard `rawModeEnabledCount` on the disable path: if `<= 0`, ignore the call instead of decrementing further.
- **src/services/mcp/useManageMCPConnections.ts**
  - Increase `MCP_BATCH_FLUSH_MS` from `16 ms` to `100 ms` to batch more MCP state updates into fewer React commits.
  - Defer `loadAndConnectMcpConfigs()` by one `setTimeout(..., 0)` tick so Ink's initial stdin raw-mode setup fully commits before any MCP async callback can interleave with it.

### Test plan
- [x] `bun run build` succeeds with no bundle errors
- [x] Existing `bun test ./src/services/mcp/client.test.ts` passes
- [x] Existing `bun test ./src/ink/parse-keypress.test.ts` passes
- [x] Existing `bun test ./src/ink/reconciler.test.ts` passes
- [ ] Interactive verification on Windows (requires local repro environment with MCP plugins configured)

Generated with [Devin](https://cli.devin.ai/docs)