### PR TITLE
fix: treat blank Read.pages as omitted

### DIFF
--- a/src/services/tools/toolExecution.test.ts
+++ b/src/services/tools/toolExecution.test.ts
@@ -35,6 +35,41 @@ describe('getSchemaValidationErrorOverride', () => {
 })
 
 describe('normalizeToolInputForValidation', () => {
+  test('treats blank Read.pages as omitted', () => {
+    expect(
+      normalizeToolInputForValidation({ name: 'Read' } as never, {
+        file_path: '/tmp/example.txt',
+        offset: 1,
+        limit: 20,
+        pages: '',
+      }),
+    ).toEqual({
+      file_path: '/tmp/example.txt',
+      offset: 1,
+      limit: 20,
+    })
+
+    expect(
+      normalizeToolInputForValidation({ name: 'Read' } as never, {
+        file_path: '/tmp/example.txt',
+        pages: '   ',
+      }),
+    ).toEqual({
+      file_path: '/tmp/example.txt',
+    })
+  })
+
+  test('treats null Read.pages as omitted', () => {
+    expect(
+      normalizeToolInputForValidation({ name: 'Read' } as never, {
+        file_path: '/tmp/example.txt',
+        pages: null,
+      }),
+    ).toEqual({
+      file_path: '/tmp/example.txt',
+    })
+  })
+
   test('wraps Gemini-style single AskUserQuestion payloads', () => {
     const normalized = normalizeToolInputForValidation(AskUserQuestionTool, {
       header: 'Location',

--- a/src/services/tools/toolExecution.ts
+++ b/src/services/tools/toolExecution.ts
@@ -619,7 +619,22 @@ export function normalizeToolInputForValidation(
   tool: Pick<Tool, 'name'>,
   input: unknown,
 ): unknown {
-  if (tool.name !== ASK_USER_QUESTION_TOOL_NAME || !isRecord(input)) {
+  if (!isRecord(input)) {
+    return input
+  }
+
+  if (tool.name === FILE_READ_TOOL_NAME) {
+    // Codex strict tool schemas can emit placeholder pages: "" / null for
+    // non-PDF reads. Treat those the same as omission before zod validation.
+    const pages = input.pages
+    if (pages === null || (typeof pages === 'string' && pages.trim() === '')) {
+      const { pages: _pages, ...rest } = input
+      return rest
+    }
+    return input
+  }
+
+  if (tool.name !== ASK_USER_QUESTION_TOOL_NAME) {
     return input
   }
 


### PR DESCRIPTION
## Summary

Treat blank or null `Read.pages` values as omission before validation so Codex strict-schema placeholder arguments no longer break non-PDF reads.

## Changes

- normalize `Read.pages` values of `""`, whitespace, or `null` away before Read input validation
- add regression coverage for blank and null `Read.pages` payloads

## Testing

- `git diff --check`
- attempted `bun test src/services/tools/toolExecution.test.ts` *(blocked in this checkout: Bun cannot resolve `bun:bundle` while loading the test graph)*
- attempted `bun run typecheck` *(repo currently has many unrelated pre-existing type errors on `main`)*

Fixes Gitlawb/openclaude#1264