### PR TITLE
fix(bash): show output for ! shell commands

### DIFF
--- a/src/utils/processUserInput/processBashCommand.test.tsx
+++ b/src/utils/processUserInput/processBashCommand.test.tsx
@@ -64,3 +64,34 @@ test('processBashCommand returns successful shell output as visible bash stdout'
   expect(visibleText).toContain('<bash-input>printf visible-1265</bash-input>')
   expect(visibleText).toContain('<bash-stdout>visible-1265')
 })
+
+test('processBashCommand preserves background task metadata', async () => {
+  BashTool.call = (async () => ({
+    data: {
+      stdout: '',
+      stderr: '',
+      interrupted: false,
+      backgroundTaskId: 'bg-review-1',
+      backgroundedByUser: true,
+    },
+  })) as unknown as typeof BashTool.call
+
+  const result = await processBashCommand(
+    'sleep 60',
+    [],
+    [],
+    makeContext(),
+    () => {},
+  )
+
+  expect(result.shouldQuery).toBe(false)
+
+  const visibleText = result.messages
+    .filter(message => message.type === 'user' && !message.isMeta)
+    .map(message => getContentText(message.message.content))
+    .join('\n')
+
+  expect(visibleText).toContain('Command was manually backgrounded by user')
+  expect(visibleText).toContain('bg-review-1')
+  expect(visibleText).toContain('Output is being written to:')
+})

--- a/src/utils/processUserInput/processBashCommand.test.tsx
+++ b/src/utils/processUserInput/processBashCommand.test.tsx
@@ -1,0 +1,66 @@
+import { afterEach, beforeEach, expect, test } from 'bun:test'
+import { getEmptyToolPermissionContext } from '../../Tool.js'
+import { BashTool } from '../../tools/BashTool/BashTool.js'
+import {
+  acquireSharedMutationLock,
+  releaseSharedMutationLock,
+} from '../../test/sharedMutationLock.js'
+import { getContentText } from '../messages.js'
+import { processBashCommand } from './processBashCommand.js'
+
+const originalCall = BashTool.call
+
+beforeEach(async () => {
+  await acquireSharedMutationLock('utils/processUserInput/processBashCommand.test.tsx')
+})
+
+afterEach(() => {
+  try {
+    BashTool.call = originalCall
+  } finally {
+    releaseSharedMutationLock()
+  }
+})
+
+function makeContext() {
+  return {
+    abortController: new AbortController(),
+    options: {
+      verbose: false,
+      isNonInteractiveSession: false,
+    },
+    getAppState() {
+      return {
+        toolPermissionContext: getEmptyToolPermissionContext(),
+      }
+    },
+  } as never
+}
+
+test('processBashCommand returns successful shell output as visible bash stdout', async () => {
+  BashTool.call = (async () => ({
+    data: {
+      stdout: 'visible-1265\n',
+      stderr: '',
+      interrupted: false,
+    },
+  })) as unknown as typeof BashTool.call
+
+  const result = await processBashCommand(
+    'printf visible-1265',
+    [],
+    [],
+    makeContext(),
+    () => {},
+  )
+
+  expect(result.shouldQuery).toBe(false)
+
+  const visibleText = result.messages
+    .filter(message => message.type === 'user' && !message.isMeta)
+    .map(message => getContentText(message.message.content))
+    .join('\n')
+
+  expect(visibleText).toContain('<bash-input>printf visible-1265</bash-input>')
+  expect(visibleText).toContain('<bash-stdout>visible-1265')
+})

--- a/src/utils/processUserInput/processBashCommand.tsx
+++ b/src/utils/processUserInput/processBashCommand.tsx
@@ -95,14 +95,16 @@ export async function processBashCommand(inputString: string, precedingInputBloc
     }
     const stderr = data.stderr;
     let stdout = escapeXml(data.stdout);
-    if (data.persistedOutputPath) {
-      // Reuse the model-facing formatter only for large persisted output so the
-      // UI can unwrap the trusted <persisted-output> marker.
+    if (data.persistedOutputPath || data.backgroundTaskId) {
+      // Reuse the model-facing formatter when it adds metadata the user needs,
+      // such as persisted-output markers or background task IDs.
       const mapped = await processToolResultBlock(shellTool, {
         ...data,
         stderr: ''
       }, randomUUID());
-      stdout = typeof mapped.content === 'string' ? mapped.content : stdout;
+      if (typeof mapped.content === 'string') {
+        stdout = data.persistedOutputPath ? mapped.content : escapeXml(mapped.content);
+      }
     }
     return {
       messages: [createSyntheticUserCaveatMessage(), userMessage, ...attachmentMessages, createUserMessage({

--- a/src/utils/processUserInput/processBashCommand.tsx
+++ b/src/utils/processUserInput/processBashCommand.tsx
@@ -94,19 +94,16 @@ export async function processBashCommand(inputString: string, precedingInputBloc
       throw new Error('No result received from shell command');
     }
     const stderr = data.stderr;
-    // Reuse the same formatting pipeline as inline !`cmd` bash (promptShellExecution)
-    // and model-initiated Bash. When BashTool.call() persists large output to disk,
-    // data.persistedOutputPath is set and the formatter wraps in <persisted-output>.
-    // Pass stderr:'' to keep it separate for the <bash-stderr> UI tag.
-    const mapped = await processToolResultBlock(shellTool, {
-      ...data,
-      stderr: ''
-    }, randomUUID());
-    // mapped.content may contain our own <persisted-output> wrapper (trusted
-    // XML from buildLargeToolResultMessage). Escaping it would turn structural
-    // tags into &lt;persisted-output&gt;, breaking the model's parse and
-    // UserBashOutputMessage's extractTag. Escape the raw fallback only.
-    const stdout = typeof mapped.content === 'string' ? mapped.content : escapeXml(data.stdout);
+    let stdout = escapeXml(data.stdout);
+    if (data.persistedOutputPath) {
+      // Reuse the model-facing formatter only for large persisted output so the
+      // UI can unwrap the trusted <persisted-output> marker.
+      const mapped = await processToolResultBlock(shellTool, {
+        ...data,
+        stderr: ''
+      }, randomUUID());
+      stdout = typeof mapped.content === 'string' ? mapped.content : stdout;
+    }
     return {
       messages: [createSyntheticUserCaveatMessage(), userMessage, ...attachmentMessages, createUserMessage({
         content: `<bash-stdout>${stdout}</bash-stdout><bash-stderr>${escapeXml(stderr)}</bash-stderr>`


### PR DESCRIPTION
## Summary
- render successful `!` shell command output directly from the shell tool result
- preserve the persisted-output formatter only for large persisted command output
- add a regression test for visible bash stdout from `processBashCommand`

## Validation
- `bun test src/utils/processUserInput/processBashCommand.test.tsx`

Fixes #1265.