### PR TITLE
fix(provider): respect falsey provider flags at startup

### DIFF
--- a/src/utils/providerProfile.test.ts
+++ b/src/utils/providerProfile.test.ts
@@ -1276,7 +1276,7 @@ test('buildStartupEnvFromProfile respects explicit falsey provider flags and doe
   assert.equal('OPENAI_API_KEY' in env, false)
 })
 
-test('buildStartupEnvFromProfile treats explicit falsey provider flags as user intent', async () => {
+test('buildStartupEnvFromProfile applies a different saved profile when one provider flag is falsey', async () => {
   const processEnv = {
     CLAUDE_CODE_USE_OPENAI: '0',
   }
@@ -1289,11 +1289,10 @@ test('buildStartupEnvFromProfile treats explicit falsey provider flags as user i
     processEnv,
   })
 
-  // Explicit CLAUDE_CODE_USE_OPENAI=0 should be respected — return processEnv unchanged
-  // Do NOT inject a Gemini profile when the user has explicitly disabled OpenAI
-  assert.equal(env, processEnv)
-  assert.equal(env.CLAUDE_CODE_USE_OPENAI, '0')
-  assert.equal('CLAUDE_CODE_USE_GEMINI' in env, false)
+  assert.notEqual(env, processEnv)
+  assert.equal(env.CLAUDE_CODE_USE_GEMINI, '1')
+  assert.equal(env.GEMINI_API_KEY, 'gem-persisted')
+  assert.equal(env.GEMINI_MODEL, 'gemini-2.5-flash')
 })
 
 test('maskSecretForDisplay preserves only a short prefix and suffix', () => {

--- a/src/utils/providerProfile.test.ts
+++ b/src/utils/providerProfile.test.ts
@@ -1253,7 +1253,7 @@ test('buildStartupEnvFromProfile still falls back to the legacy file when config
   assert.equal(env.OPENAI_MODEL, 'gpt-4o')
 })
 
-test('buildStartupEnvFromProfile ignores falsey provider flags when deciding whether a configured profile already selected startup env', async () => {
+test('buildStartupEnvFromProfile respects explicit falsey provider flags and does not override them', async () => {
   const processEnv = {
     CLAUDE_CODE_USE_OPENAI: '0',
     OPENAI_BASE_URL: 'https://api.stale.example/v1',
@@ -1270,8 +1270,10 @@ test('buildStartupEnvFromProfile ignores falsey provider flags when deciding whe
     hasConfiguredProviderProfile: true,
   })
 
-  assert.notEqual(env, processEnv)
-  assert.equal(env.OPENAI_API_KEY, 'sk-legacy')
+  // Explicit CLAUDE_CODE_USE_OPENAI=0 should be respected — return processEnv unchanged
+  assert.equal(env, processEnv)
+  assert.equal(env.CLAUDE_CODE_USE_OPENAI, '0')
+  assert.equal('OPENAI_API_KEY' in env, false)
 })
 
 test('buildStartupEnvFromProfile treats explicit falsey provider flags as user intent', async () => {
@@ -1287,12 +1289,11 @@ test('buildStartupEnvFromProfile treats explicit falsey provider flags as user i
     processEnv,
   })
 
-  assert.equal(env.CLAUDE_CODE_USE_OPENAI, undefined)
-  assert.equal(env.CLAUDE_CODE_USE_GEMINI, '1')
-  assert.equal(env.GEMINI_API_KEY, 'gem-persisted')
-  assert.equal(env.GEMINI_MODEL, 'gemini-2.5-flash')
-  assert.equal(env.GEMINI_BASE_URL, 'https://generativelanguage.googleapis.com/v1beta/openai')
-  assert.equal(env.GEMINI_AUTH_MODE, 'api-key')
+  // Explicit CLAUDE_CODE_USE_OPENAI=0 should be respected — return processEnv unchanged
+  // Do NOT inject a Gemini profile when the user has explicitly disabled OpenAI
+  assert.equal(env, processEnv)
+  assert.equal(env.CLAUDE_CODE_USE_OPENAI, '0')
+  assert.equal('CLAUDE_CODE_USE_GEMINI' in env, false)
 })
 
 test('maskSecretForDisplay preserves only a short prefix and suffix', () => {

--- a/src/utils/providerProfile.ts
+++ b/src/utils/providerProfile.ts
@@ -853,7 +853,7 @@ export function buildCompatibilityProcessEnv(options: {
   const nextEnv: NodeJS.ProcessEnv = { ...options.profileEnv }
   const flag = getCompatibilityProfileFlag(options.compatibilityMode)
 
-  if (flag) {
+  if (flag && (env[flag] === undefined || isEnvTruthy(env[flag]))) {
     nextEnv[flag] = '1'
   }
 
@@ -1503,6 +1503,16 @@ export async function buildStartupEnvFromProfile(options?: {
   // "banner shows gpt-4o / api.openai.com even though my saved profile is
   // Moonshot" bug.
   if (profileManagedEnv) {
+    return processEnv
+  }
+
+  // If the user explicitly disabled a provider via env (e.g. CLAUDE_CODE_USE_OPENAI=0),
+  // respect that choice and do NOT inject default profile env. This prevents the
+  // fallback logic from overriding an intentional opt-out.
+  if (
+    processEnv.CLAUDE_CODE_USE_OPENAI !== undefined &&
+    !isEnvTruthy(processEnv.CLAUDE_CODE_USE_OPENAI)
+  ) {
     return processEnv
   }
 

--- a/src/utils/providerProfile.ts
+++ b/src/utils/providerProfile.ts
@@ -1506,16 +1506,6 @@ export async function buildStartupEnvFromProfile(options?: {
     return processEnv
   }
 
-  // If the user explicitly disabled a provider via env (e.g. CLAUDE_CODE_USE_OPENAI=0),
-  // respect that choice and do NOT inject default profile env. This prevents the
-  // fallback logic from overriding an intentional opt-out.
-  if (
-    processEnv.CLAUDE_CODE_USE_OPENAI !== undefined &&
-    !isEnvTruthy(processEnv.CLAUDE_CODE_USE_OPENAI)
-  ) {
-    return processEnv
-  }
-
   // If startup already has a concrete provider selection and the modern
   // plural-profile system is configured, keep trusting that selection.
   // This prevents the legacy single-profile file from becoming a silent

--- a/src/utils/providerProfile.ts
+++ b/src/utils/providerProfile.ts
@@ -993,6 +993,34 @@ function hasExplicitFalseyProviderFlag(
   )
 }
 
+function isProfileExplicitlyDisabled(
+  profile: ProviderProfile,
+  processEnv: NodeJS.ProcessEnv = process.env,
+): boolean {
+  switch (profile) {
+    case 'openai':
+    case 'codex':
+      return isEnvDefinedFalsy(processEnv.CLAUDE_CODE_USE_OPENAI)
+    case 'github':
+      return isEnvDefinedFalsy(processEnv.CLAUDE_CODE_USE_GITHUB)
+    case 'gemini':
+      return isEnvDefinedFalsy(processEnv.CLAUDE_CODE_USE_GEMINI)
+    case 'mistral':
+      return isEnvDefinedFalsy(processEnv.CLAUDE_CODE_USE_MISTRAL)
+    case 'bedrock':
+      return isEnvDefinedFalsy(processEnv.CLAUDE_CODE_USE_BEDROCK)
+    case 'vertex':
+      return isEnvDefinedFalsy(processEnv.CLAUDE_CODE_USE_VERTEX)
+    case 'anthropic':
+    case 'ollama':
+    case 'atomic-chat':
+    case 'nvidia-nim':
+    case 'minimax':
+    case 'xai':
+      return false
+  }
+}
+
 function hasConcreteProviderSelection(
   processEnv: NodeJS.ProcessEnv = process.env,
 ): boolean {
@@ -1524,7 +1552,11 @@ export async function buildStartupEnvFromProfile(options?: {
     return processEnv
   }
 
-  if (hasExplicitFalseyProviderFlag(processEnv)) {
+  if (!persisted && hasExplicitFalseyProviderFlag(processEnv)) {
+    return processEnv
+  }
+
+  if (persisted && isProfileExplicitlyDisabled(persisted.profile, processEnv)) {
     return processEnv
   }
 

--- a/src/utils/providerProfile.ts
+++ b/src/utils/providerProfile.ts
@@ -37,7 +37,11 @@ export {
   sanitizeApiKey,
   sanitizeProviderConfigValue,
 } from './providerSecrets.js'
-import { getClaudeConfigHomeDir, isEnvTruthy } from './envUtils.js'
+import {
+  getClaudeConfigHomeDir,
+  isEnvDefinedFalsy,
+  isEnvTruthy,
+} from './envUtils.js'
 
 export const PROFILE_FILE_NAME = '.openclaude-profile.json'
 export const DEFAULT_GEMINI_BASE_URL =
@@ -975,6 +979,20 @@ export function hasExplicitProviderSelection(
   )
 }
 
+function hasExplicitFalseyProviderFlag(
+  processEnv: NodeJS.ProcessEnv = process.env,
+): boolean {
+  return (
+    isEnvDefinedFalsy(processEnv.CLAUDE_CODE_USE_OPENAI) ||
+    isEnvDefinedFalsy(processEnv.CLAUDE_CODE_USE_GITHUB) ||
+    isEnvDefinedFalsy(processEnv.CLAUDE_CODE_USE_GEMINI) ||
+    isEnvDefinedFalsy(processEnv.CLAUDE_CODE_USE_MISTRAL) ||
+    isEnvDefinedFalsy(processEnv.CLAUDE_CODE_USE_BEDROCK) ||
+    isEnvDefinedFalsy(processEnv.CLAUDE_CODE_USE_VERTEX) ||
+    isEnvDefinedFalsy(processEnv.CLAUDE_CODE_USE_FOUNDRY)
+  )
+}
+
 function hasConcreteProviderSelection(
   processEnv: NodeJS.ProcessEnv = process.env,
 ): boolean {
@@ -1503,6 +1521,10 @@ export async function buildStartupEnvFromProfile(options?: {
   // "banner shows gpt-4o / api.openai.com even though my saved profile is
   // Moonshot" bug.
   if (profileManagedEnv) {
+    return processEnv
+  }
+
+  if (hasExplicitFalseyProviderFlag(processEnv)) {
     return processEnv
   }
 


### PR DESCRIPTION
## Summary
- keep startup profile fallback from overriding explicit falsey provider flags such as `CLAUDE_CODE_USE_OPENAI=0`
- restores the behavior expected by PR #1254 tests and fixes the false OpenAI API key warning reported in #1245

## Validation
- `bun test src/utils/providerProfile.test.ts`

Fixes #1245.