### PR TITLE
docs(windows): add npm global PATH fix

### DIFF
--- a/docs/non-technical-setup.md
+++ b/docs/non-technical-setup.md
@@ -78,12 +78,29 @@ At that point, you can ask it to:
 Cause:
 
 - npm installed the package, but your terminal has not refreshed yet
+- on Windows, npm's global bin folder may not be in your user `Path`
 
 Fix:
 
 1. Close the terminal
 2. Open a new terminal
 3. Run `openclaude` again
+
+On Windows PowerShell, if that still does not work, add npm's global bin folder
+to your user `Path`, then open a new PowerShell window:
+
+```powershell
+$npmPrefix = npm config get prefix
+$currentUserPath = [Environment]::GetEnvironmentVariable("Path", "User")
+
+if (($currentUserPath -split ';') -notcontains $npmPrefix) {
+    [Environment]::SetEnvironmentVariable(
+        "Path",
+        "$currentUserPath;$npmPrefix",
+        "User"
+    )
+}
+```
 
 ### Invalid API key
 

--- a/docs/quick-start-windows.md
+++ b/docs/quick-start-windows.md
@@ -103,6 +103,23 @@ Close PowerShell, open a new one, and try again:
 openclaude
 ```
 
+If PowerShell still says `openclaude` is not recognized, npm's global bin
+folder may be missing from your user `Path`. Add it, then open a new
+PowerShell window:
+
+```powershell
+$npmPrefix = npm config get prefix
+$currentUserPath = [Environment]::GetEnvironmentVariable("Path", "User")
+
+if (($currentUserPath -split ';') -notcontains $npmPrefix) {
+    [Environment]::SetEnvironmentVariable(
+        "Path",
+        "$currentUserPath;$npmPrefix",
+        "User"
+    )
+}
+```
+
 ## 5. If Your Provider Fails
 
 Check the basics:


### PR DESCRIPTION
## Summary
- document the Windows PowerShell fix for npm global installs where `openclaude` is not found
- add the workaround to the Windows quick start and non-technical setup troubleshooting sections

## Validation
- docs-only change; not run

Fixes #760.