### PR TITLE
docs(vertex): clarify Claude on Vertex setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ Advanced and source-build guides:
 | Xiaomi MiMo | `/provider` or env vars | OpenAI-compatible API at `https://api.xiaomimimo.com/v1`; uses `MIMO_API_KEY` and defaults to `mimo-v2.5-pro` |
 | Ollama | `/provider` or env vars | Local inference with no API key |
 | Atomic Chat | `/provider`, env vars, or `bun run dev:atomic-chat` | Local Model Provider; auto-detects loaded models |
-| Bedrock / Vertex / Foundry | env vars | Additional provider integrations for supported environments |
+| Bedrock / Vertex / Foundry | env vars | Anthropic-family cloud routes; Vertex is for Claude on Vertex AI, not arbitrary Model Garden models |
 
 ## What Works
 

--- a/docs/advanced-setup.md
+++ b/docs/advanced-setup.md
@@ -86,6 +86,37 @@ export GEMINI_API_KEY=...
 export GEMINI_MODEL=gemini-3-flash-preview
 ```
 
+### Claude on Vertex AI
+
+The Vertex route uses Anthropic's Claude-on-Vertex API. It is not a general
+Vertex AI Model Garden adapter for Gemini or arbitrary partner models; use the
+Gemini provider for Gemini models and OpenAI-compatible routes for compatible
+third-party gateways.
+
+Authentication uses Google Application Default Credentials through
+`google-auth-library`. There is no `OPENAI_API_KEY`-style API key for this
+route. Authenticate with either a service-account file or local ADC:
+
+```bash
+gcloud auth application-default login
+```
+
+Minimal setup:
+
+```bash
+export CLAUDE_CODE_USE_VERTEX=1
+export ANTHROPIC_VERTEX_PROJECT_ID=my-gcp-project
+export GOOGLE_CLOUD_PROJECT=my-gcp-project
+export CLOUD_ML_REGION=us-east5
+export ANTHROPIC_MODEL=claude-sonnet-4-6
+
+openclaude
+```
+
+`CLOUD_ML_REGION` is optional and defaults to `us-east5`. Model-specific
+Vertex region override variables are also supported for Claude models; see
+`src/services/api/client.ts` for the current override names.
+
 ### Gemini via OpenRouter
 
 ```bash

--- a/docs/advanced-setup.md
+++ b/docs/advanced-setup.md
@@ -108,9 +108,8 @@ export CLAUDE_CODE_USE_VERTEX=1
 export ANTHROPIC_VERTEX_PROJECT_ID=my-gcp-project
 export GOOGLE_CLOUD_PROJECT=my-gcp-project
 export CLOUD_ML_REGION=us-east5
-export ANTHROPIC_MODEL=claude-sonnet-4-6
 
-openclaude
+openclaude --model claude-sonnet-4-6
 ```
 
 `CLOUD_ML_REGION` is optional and defaults to `us-east5`. Model-specific
@@ -252,9 +251,10 @@ export OPENAI_MODEL=gpt-4o
 | `OPENCLAUDE_DISABLE_CO_AUTHORED_BY` | No | Suppress the default `Co-Authored-By` trailer in generated git commits |
 | `OPENCLAUDE_LOG_TOKEN_USAGE` | No | When truthy (e.g. `verbose`), emits one JSON line on stderr per API request with input/output/cache tokens and the resolved provider. **User-facing debug output** — complements the REPL display controlled by `/config showCacheStats`. Distinct from `CLAUDE_CODE_ENABLE_TOKEN_USAGE_ATTACHMENT`, which is **model-facing** (injects context usage info into the prompt itself). Both can run together. |
 
-Model env vars are provider-scoped: Anthropic-native sessions read
+Model env vars are provider-scoped: first-party Anthropic sessions read
 `ANTHROPIC_MODEL`, OpenAI-compatible sessions read `OPENAI_MODEL`, Gemini reads
-`GEMINI_MODEL`, and Mistral reads `MISTRAL_MODEL`.
+`GEMINI_MODEL`, and Mistral reads `MISTRAL_MODEL`. For manual Bedrock, Vertex,
+or Foundry launches, select the model with `--model`.
 
 ## Runtime Hardening
 

--- a/docs/advanced-setup.md
+++ b/docs/advanced-setup.md
@@ -115,7 +115,7 @@ openclaude
 
 `CLOUD_ML_REGION` is optional and defaults to `us-east5`. Model-specific
 Vertex region override variables are also supported for Claude models; see
-`src/services/api/client.ts` for the current override names.
+`src/utils/envUtils.ts` for the current override names.
 
 ### Gemini via OpenRouter
 


### PR DESCRIPTION
## Summary
- clarify that the Vertex route is Claude-on-Vertex, not a general Vertex Model Garden adapter
- document ADC/service-account auth expectations and minimal env vars
- update the provider table so users do not expect arbitrary Vertex models

Fixes #965.

## Testing
- Not run; docs-only change.