### PR TITLE
docs(ollama): explain context length for chat history

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,12 @@ openclaude
 ```
 
 On Windows, set `$env:OLLAMA_CONTEXT_LENGTH="64000"` in the terminal that starts
-`ollama serve` if the model truncates chat history.
+`ollama serve` if the model truncates chat history. If Ollama is already running
+from the desktop app or a background process, quit that server first or apply the
+same setting in Ollama's UI/settings path where available before restarting.
+Then run
+`ollama ps` after the model loads and confirm the active `CONTEXT` value is
+larger.
 
 ## Setup Guides
 

--- a/README.md
+++ b/README.md
@@ -115,6 +115,10 @@ export OPENAI_MODEL=qwen2.5-coder:7b
 openclaude
 ```
 
+If a local Ollama model appears to forget earlier messages in the same chat,
+raise Ollama's context length before starting the Ollama server, for example
+`OLLAMA_CONTEXT_LENGTH=64000 ollama serve`.
+
 Windows PowerShell:
 
 ```powershell
@@ -124,6 +128,9 @@ $env:OPENAI_MODEL="qwen2.5-coder:7b"
 
 openclaude
 ```
+
+On Windows, set `$env:OLLAMA_CONTEXT_LENGTH="64000"` in the terminal that starts
+`ollama serve` if the model truncates chat history.
 
 ## Setup Guides
 

--- a/README.md
+++ b/README.md
@@ -133,8 +133,7 @@ On Windows, set `$env:OLLAMA_CONTEXT_LENGTH="64000"` in the terminal that starts
 `ollama serve` if the model truncates chat history. If Ollama is already running
 from the desktop app or a background process, quit that server first or apply the
 same setting in Ollama's UI/settings path where available before restarting.
-Then run
-`ollama ps` after the model loads and confirm the active `CONTEXT` value is
+After the model loads, run `ollama ps` and confirm the active `CONTEXT` value is
 larger.
 
 ## Setup Guides

--- a/docs/advanced-setup.md
+++ b/docs/advanced-setup.md
@@ -126,6 +126,12 @@ $env:OLLAMA_CONTEXT_LENGTH="64000"
 ollama serve
 ```
 
+If Ollama is already running from the desktop app or a background server, stop
+that existing server first or apply the setting through Ollama's UI/settings
+path where available before restarting it. Otherwise OpenClaude can keep using
+the old server process with the smaller context even after you set the
+environment variable.
+
 ### Atomic Chat (local, Apple Silicon)
 
 ```bash

--- a/docs/advanced-setup.md
+++ b/docs/advanced-setup.md
@@ -107,6 +107,25 @@ export OPENAI_BASE_URL=http://localhost:11434/v1
 export OPENAI_MODEL=llama3.3:70b
 ```
 
+Ollama may start local models with a small context window. OpenClaude sends the
+system prompt plus the current conversation every turn, so a small Ollama
+context can make the model appear to forget earlier same-session messages. If
+that happens, restart the Ollama server with a larger context length:
+
+```bash
+OLLAMA_CONTEXT_LENGTH=64000 ollama serve
+```
+
+Check the active allocation with `ollama ps`; the `CONTEXT` column should show
+the larger value. Higher context uses more memory and may slow smaller systems.
+
+On Windows PowerShell:
+
+```powershell
+$env:OLLAMA_CONTEXT_LENGTH="64000"
+ollama serve
+```
+
 ### Atomic Chat (local, Apple Silicon)
 
 ```bash

--- a/docs/quick-start-mac-linux.md
+++ b/docs/quick-start-mac-linux.md
@@ -68,6 +68,16 @@ openclaude
 
 No API key is needed for Ollama local models.
 
+If the model answers as if it cannot remember earlier messages in the same
+chat, restart Ollama with a larger context window:
+
+```bash
+OLLAMA_CONTEXT_LENGTH=64000 ollama serve
+```
+
+Run `ollama ps` after the model loads to confirm the `CONTEXT` value. Larger
+contexts use more memory and can slow the model.
+
 ### Option D: LM Studio
 
 Install LM Studio first from:

--- a/docs/quick-start-windows.md
+++ b/docs/quick-start-windows.md
@@ -68,6 +68,17 @@ openclaude
 
 No API key is needed for Ollama local models.
 
+If the model answers as if it cannot remember earlier messages in the same
+chat, start Ollama from PowerShell with a larger context window:
+
+```powershell
+$env:OLLAMA_CONTEXT_LENGTH="64000"
+ollama serve
+```
+
+Run `ollama ps` after the model loads to confirm the `CONTEXT` value. Larger
+contexts use more memory and can slow the model.
+
 ### Option D: LM Studio
 
 Install LM Studio first from:

--- a/docs/quick-start-windows.md
+++ b/docs/quick-start-windows.md
@@ -69,12 +69,18 @@ openclaude
 No API key is needed for Ollama local models.
 
 If the model answers as if it cannot remember earlier messages in the same
-chat, start Ollama from PowerShell with a larger context window:
+chat, restart Ollama from PowerShell with a larger context window:
 
 ```powershell
 $env:OLLAMA_CONTEXT_LENGTH="64000"
 ollama serve
 ```
+
+If Ollama is already running from the desktop app or a background server, quit
+that server first or use Ollama's UI/settings path where available to apply the
+same context setting before restarting it. Starting a second `ollama serve` can
+fail because port `11434` is already in use, and OpenClaude may keep talking to
+the old server with the smaller context.
 
 Run `ollama ps` after the model loads to confirm the `CONTEXT` value. Larger
 contexts use more memory and can slow the model.


### PR DESCRIPTION
## Summary
- document that Ollama context length can cause local models to appear to forget same-session messages
- add macOS/Linux and Windows examples for starting Ollama with a larger context
- link the quick setup docs to the known workaround from issue #141

Fixes #141.

## Testing
- Not run; docs-only change.