### PR TITLE
fix(openai-shim): handle image tool results per provider

### DIFF
--- a/src/integrations/descriptors.ts
+++ b/src/integrations/descriptors.ts
@@ -15,6 +15,10 @@ export type TransportKind =
 
 export type OpenAIShimTokenField = 'max_tokens' | 'max_completion_tokens'
 export type OpenAIShimAuthScheme = 'bearer' | 'raw'
+export type OpenAIShimToolResultImageHandling =
+  | 'tool-message'
+  | 'split-user-message'
+  | 'text-only'
 
 export interface OpenAIShimAuthHeaderConfig {
   name: string
@@ -40,6 +44,7 @@ export interface OpenAIShimTransportConfig {
   thinkingRequestFormat?: 'none' | 'deepseek-compatible'
   maxTokensField?: OpenAIShimTokenField
   removeBodyFields?: string[]
+  toolResultImageHandling?: OpenAIShimToolResultImageHandling
 }
 
 export interface CapabilityFlags {

--- a/src/integrations/gateways/gitlawb-opengateway.ts
+++ b/src/integrations/gateways/gitlawb-opengateway.ts
@@ -28,6 +28,7 @@ export default defineGateway({
       },
       maxTokensField: 'max_completion_tokens',
       removeBodyFields: ['store', 'stream_options'],
+      toolResultImageHandling: 'split-user-message',
       supportsApiFormatSelection: false,
       supportsAuthHeaders: false,
     },

--- a/src/integrations/runtimeMetadata.ts
+++ b/src/integrations/runtimeMetadata.ts
@@ -148,6 +148,7 @@ function inferRemoteModelOpenAIShimConfig(
       requireReasoningContentOnAssistantMessages: true,
       maxTokensField: 'max_completion_tokens',
       removeBodyFields: ['store', 'stream_options'],
+      toolResultImageHandling: 'split-user-message',
     }
   }
 
@@ -159,6 +160,7 @@ function inferRemoteModelOpenAIShimConfig(
       thinkingRequestFormat: 'deepseek-compatible',
       maxTokensField: 'max_tokens',
       removeBodyFields: ['store'],
+      toolResultImageHandling: 'text-only',
     }
   }
 

--- a/src/integrations/vendors/deepseek.ts
+++ b/src/integrations/vendors/deepseek.ts
@@ -21,6 +21,7 @@ export default defineVendor({
       thinkingRequestFormat: 'deepseek-compatible',
       maxTokensField: 'max_tokens',
       removeBodyFields: ['store'],
+      toolResultImageHandling: 'text-only',
       supportsApiFormatSelection: false,
       supportsAuthHeaders: false,
     },

--- a/src/integrations/vendors/xiaomi-mimo.ts
+++ b/src/integrations/vendors/xiaomi-mimo.ts
@@ -59,6 +59,7 @@ export default defineVendor({
       requireReasoningContentOnAssistantMessages: true,
       maxTokensField: 'max_completion_tokens',
       removeBodyFields: ['store', 'stream_options'],
+      toolResultImageHandling: 'split-user-message',
       supportsApiFormatSelection: false,
       supportsAuthHeaders: false,
     },

--- a/src/services/api/openaiShim.test.ts
+++ b/src/services/api/openaiShim.test.ts
@@ -5744,6 +5744,113 @@ test('Xiaomi MiMo image tool results are split into a user image message', async
   })
 })
 
+test('Xiaomi MiMo image tool results keep multiple tool messages contiguous', async () => {
+  process.env.OPENAI_BASE_URL = 'https://api.xiaomimimo.com/v1'
+  process.env.OPENAI_MODEL = 'mimo-v2.5'
+  process.env.MIMO_API_KEY = 'mimo-test-key'
+  delete process.env.OPENAI_API_KEY
+  let requestBody: Record<string, unknown> | undefined
+
+  globalThis.fetch = (async (_input, init) => {
+    requestBody = JSON.parse(String(init?.body))
+
+    return new Response(
+      JSON.stringify({
+        id: 'chatcmpl-mimo',
+        model: 'mimo-v2.5',
+        choices: [
+          {
+            message: {
+              role: 'assistant',
+              content: 'done',
+            },
+            finish_reason: 'stop',
+          },
+        ],
+      }),
+      {
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      },
+    )
+  }) as FetchType
+
+  const client = createOpenAIShimClient({}) as OpenAIShimClient
+
+  await client.beta.messages.create({
+    model: 'mimo-v2.5',
+    system: 'test system',
+    messages: [
+      { role: 'user', content: 'Read these files' },
+      {
+        role: 'assistant',
+        content: [
+          {
+            type: 'tool_use',
+            id: 'call_text',
+            name: 'Read',
+            input: { file_path: 'notes.txt' },
+          },
+          {
+            type: 'tool_use',
+            id: 'call_image',
+            name: 'Read',
+            input: { file_path: 'appicon.png' },
+          },
+        ],
+      },
+      {
+        role: 'user',
+        content: [
+          {
+            type: 'tool_result',
+            tool_use_id: 'call_text',
+            content: 'notes',
+          },
+          {
+            type: 'tool_result',
+            tool_use_id: 'call_image',
+            content: [
+              { type: 'text', text: 'Read appicon.png' },
+              {
+                type: 'image',
+                source: {
+                  type: 'base64',
+                  media_type: 'image/png',
+                  data: 'ZmFrZQ==',
+                },
+              },
+            ],
+          },
+        ],
+      },
+    ],
+    max_tokens: 64,
+    stream: false,
+  })
+
+  const messages = requestBody?.messages as Array<Record<string, unknown>>
+  const firstToolIndex = messages.findIndex(message => message.role === 'tool')
+  expect(messages[firstToolIndex]).toMatchObject({
+    role: 'tool',
+    tool_call_id: 'call_text',
+    content: 'notes',
+  })
+  expect(messages[firstToolIndex + 1]).toMatchObject({
+    role: 'tool',
+    tool_call_id: 'call_image',
+    content: 'Read appicon.png',
+  })
+  expect(messages[firstToolIndex + 2]).toMatchObject({
+    role: 'assistant',
+    content: 'Tool returned image content; attaching it for analysis.',
+  })
+  expect(messages[firstToolIndex + 3]).toMatchObject({
+    role: 'user',
+  })
+})
+
 test('collapses multiple text blocks into a single string for DeepSeek compatibility (issue #774)', async () => {
   let requestBody: Record<string, unknown> | undefined
 

--- a/src/services/api/openaiShim.test.ts
+++ b/src/services/api/openaiShim.test.ts
@@ -5558,6 +5558,192 @@ test('collapses multiple text blocks in tool_result to string for DeepSeek compa
   expect(toolMessages[0].content).toBe('line one\n\nline two')
 })
 
+test('DeepSeek image tool results become text-only tool messages', async () => {
+  process.env.OPENAI_BASE_URL = 'https://api.deepseek.com/v1'
+  process.env.OPENAI_MODEL = 'deepseek-v4-pro'
+  process.env.DEEPSEEK_API_KEY = 'deepseek-test-key'
+  let requestBody: Record<string, unknown> | undefined
+
+  globalThis.fetch = (async (_input, init) => {
+    requestBody = JSON.parse(String(init?.body))
+
+    return new Response(
+      JSON.stringify({
+        id: 'chatcmpl-1',
+        model: 'deepseek-v4-pro',
+        choices: [
+          {
+            message: {
+              role: 'assistant',
+              content: 'done',
+            },
+            finish_reason: 'stop',
+          },
+        ],
+        usage: {
+          prompt_tokens: 12,
+          completion_tokens: 4,
+          total_tokens: 16,
+        },
+      }),
+      {
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      },
+    )
+  }) as FetchType
+
+  const client = createOpenAIShimClient({}) as OpenAIShimClient
+
+  await client.beta.messages.create({
+    model: 'deepseek-v4-pro',
+    system: 'test system',
+    messages: [
+      { role: 'user', content: 'Read this image' },
+      {
+        role: 'assistant',
+        content: [
+          {
+            type: 'tool_use',
+            id: 'call_image_1',
+            name: 'Read',
+            input: { file_path: 'appicon.png' },
+          },
+        ],
+      },
+      {
+        role: 'user',
+        content: [
+          {
+            type: 'tool_result',
+            tool_use_id: 'call_image_1',
+            content: [
+              { type: 'text', text: 'Read appicon.png' },
+              {
+                type: 'image',
+                source: {
+                  type: 'base64',
+                  media_type: 'image/png',
+                  data: 'ZmFrZQ==',
+                },
+              },
+            ],
+          },
+        ],
+      },
+    ],
+    max_tokens: 64,
+    stream: false,
+  })
+
+  const messages = requestBody?.messages as Array<Record<string, unknown>>
+  const toolMessages = messages.filter(message => message.role === 'tool')
+  expect(toolMessages.length).toBe(1)
+  expect(typeof toolMessages[0].content).toBe('string')
+  expect(toolMessages[0].content).toContain('Read appicon.png')
+  expect(toolMessages[0].content).toContain('Image content omitted')
+  expect(messages.some(message => Array.isArray(message.content))).toBe(false)
+})
+
+test('Xiaomi MiMo image tool results are split into a user image message', async () => {
+  process.env.OPENAI_BASE_URL = 'https://api.xiaomimimo.com/v1'
+  process.env.OPENAI_MODEL = 'mimo-v2.5'
+  process.env.MIMO_API_KEY = 'mimo-test-key'
+  delete process.env.OPENAI_API_KEY
+  let requestBody: Record<string, unknown> | undefined
+
+  globalThis.fetch = (async (_input, init) => {
+    requestBody = JSON.parse(String(init?.body))
+
+    return new Response(
+      JSON.stringify({
+        id: 'chatcmpl-mimo',
+        model: 'mimo-v2.5',
+        choices: [
+          {
+            message: {
+              role: 'assistant',
+              content: 'done',
+            },
+            finish_reason: 'stop',
+          },
+        ],
+      }),
+      {
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      },
+    )
+  }) as FetchType
+
+  const client = createOpenAIShimClient({}) as OpenAIShimClient
+
+  await client.beta.messages.create({
+    model: 'mimo-v2.5',
+    system: 'test system',
+    messages: [
+      { role: 'user', content: 'Read this image' },
+      {
+        role: 'assistant',
+        content: [
+          {
+            type: 'tool_use',
+            id: 'call_image_2',
+            name: 'Read',
+            input: { file_path: 'appicon.png' },
+          },
+        ],
+      },
+      {
+        role: 'user',
+        content: [
+          {
+            type: 'tool_result',
+            tool_use_id: 'call_image_2',
+            content: [
+              { type: 'text', text: 'Read appicon.png' },
+              {
+                type: 'image',
+                source: {
+                  type: 'base64',
+                  media_type: 'image/png',
+                  data: 'ZmFrZQ==',
+                },
+              },
+            ],
+          },
+        ],
+      },
+    ],
+    max_tokens: 64,
+    stream: false,
+  })
+
+  const messages = requestBody?.messages as Array<Record<string, unknown>>
+  const toolMessageIndex = messages.findIndex(message => message.role === 'tool')
+  expect(toolMessageIndex).toBeGreaterThan(-1)
+  expect(messages[toolMessageIndex].content).toBe('Read appicon.png')
+  expect(messages[toolMessageIndex + 1]).toMatchObject({
+    role: 'assistant',
+    content: 'Tool returned image content; attaching it for analysis.',
+  })
+  const userImageMessage = messages[toolMessageIndex + 2] as {
+    role?: string
+    content?: Array<{ type: string; text?: string; image_url?: { url: string } }>
+  }
+  expect(userImageMessage.role).toBe('user')
+  expect(userImageMessage.content?.[0]).toEqual({
+    type: 'text',
+    text: 'Image returned by tool result call_image_2.',
+  })
+  expect(userImageMessage.content?.[1]).toEqual({
+    type: 'image_url',
+    image_url: { url: 'data:image/png;base64,ZmFrZQ==' },
+  })
+})
+
 test('collapses multiple text blocks into a single string for DeepSeek compatibility (issue #774)', async () => {
   let requestBody: Record<string, unknown> | undefined
 

--- a/src/services/api/openaiShim.ts
+++ b/src/services/api/openaiShim.ts
@@ -35,6 +35,7 @@ import { isBareMode, isEnvTruthy } from '../../utils/envUtils.js'
 import { resolveGeminiCredential } from '../../utils/geminiAuth.js'
 import { hydrateGeminiAccessTokenFromSecureStorage } from '../../utils/geminiCredentials.js'
 import { hydrateGithubModelsTokenFromSecureStorage } from '../../utils/githubModelsCredentials.js'
+import type { OpenAIShimToolResultImageHandling } from '../../integrations/descriptors.js'
 import { resolveOpenAIShimRuntimeContext } from '../../integrations/runtimeMetadata.js'
 import { resolveRouteCredentialValue } from '../../integrations/routeMetadata.js'
 import {
@@ -252,7 +253,7 @@ function sleepMs(ms: number): Promise<void> {
 
 interface OpenAIMessage {
   role: 'system' | 'user' | 'assistant' | 'tool'
-  content?: string | Array<{ type: string; text?: string; image_url?: { url: string } }>
+  content?: string | OpenAIContentPart[]
   tool_calls?: Array<{
     id: string
     type: 'function'
@@ -269,6 +270,12 @@ interface OpenAIMessage {
    * block captured when the original response was translated.
    */
   reasoning_content?: string
+}
+
+type OpenAIContentPart = {
+  type: string
+  text?: string
+  image_url?: { url: string }
 }
 
 interface OpenAITool {
@@ -304,7 +311,7 @@ function convertSystemPrompt(
 function convertToolResultContent(
   content: unknown,
   isError?: boolean,
-): string | Array<{ type: string; text?: string; image_url?: { url: string } }> {
+): string | OpenAIContentPart[] {
   if (typeof content === 'string') {
     return isError ? `Error: ${content}` : content
   }
@@ -313,11 +320,7 @@ function convertToolResultContent(
     return isError ? `Error: ${text}` : text
   }
 
-  const parts: Array<{
-    type: string
-    text?: string
-    image_url?: { url: string }
-  }> = []
+  const parts: OpenAIContentPart[] = []
   for (const block of content) {
     if (block?.type === 'text' && typeof block.text === 'string') {
       parts.push({ type: 'text', text: block.text })
@@ -367,9 +370,60 @@ function convertToolResultContent(
   return parts
 }
 
+function hasImageContentPart(content: string | OpenAIContentPart[]): boolean {
+  return Array.isArray(content) && content.some(part => part.type === 'image_url')
+}
+
+function splitToolResultImagesForProvider(
+  content: string | OpenAIContentPart[],
+  toolUseId: string,
+  handling: OpenAIShimToolResultImageHandling,
+): {
+  toolContent: string | OpenAIContentPart[]
+  assistantContent?: string
+  userImageContent?: OpenAIContentPart[]
+} {
+  if (!Array.isArray(content) || !hasImageContentPart(content)) {
+    return { toolContent: content }
+  }
+
+  const textParts = content.filter(part => part.type === 'text')
+  const imageParts = content.filter(part => part.type === 'image_url')
+  const text = textParts
+    .map(part => part.text?.trim())
+    .filter((part): part is string => !!part)
+    .join('\n\n')
+
+  if (handling === 'text-only') {
+    const omitted =
+      '[Image content omitted: this provider does not accept image_url parts in tool results.]'
+    return {
+      toolContent: text ? `${text}\n\n${omitted}` : omitted,
+    }
+  }
+
+  if (handling === 'split-user-message') {
+    return {
+      toolContent:
+        text ||
+        'Tool returned image content; the image is attached in the next user message.',
+      assistantContent: 'Tool returned image content; attaching it for analysis.',
+      userImageContent: [
+        {
+          type: 'text',
+          text: `Image returned by tool result ${toolUseId}.`,
+        },
+        ...imageParts,
+      ],
+    }
+  }
+
+  return { toolContent: content }
+}
+
 function convertContentBlocks(
   content: unknown,
-): string | Array<{ type: string; text?: string; image_url?: { url: string } }> {
+): string | OpenAIContentPart[] {
   if (typeof content === 'string') return content
   if (!Array.isArray(content)) return String(content ?? '')
 
@@ -489,11 +543,14 @@ function convertMessages(
     preserveReasoningContent?: boolean
     reasoningContentFallback?: '' | 'omit'
     preserveGeminiThoughtSignature?: boolean
+    toolResultImageHandling?: OpenAIShimToolResultImageHandling
   },
 ): OpenAIMessage[] {
   const preserveReasoningContent = options?.preserveReasoningContent === true
   const reasoningContentFallback = options?.reasoningContentFallback
   const preserveGeminiThoughtSignature = options?.preserveGeminiThoughtSignature === true
+  const toolResultImageHandling =
+    options?.toolResultImageHandling ?? 'tool-message'
   const result: OpenAIMessage[] = []
   const knownToolCallIds = new Set<string>()
 
@@ -546,11 +603,32 @@ function convertMessages(
         for (const tr of toolResults) {
           const id = tr.tool_use_id ?? 'unknown'
           if (knownToolCallIds.has(id)) {
+            const convertedToolContent = convertToolResultContent(
+              tr.content,
+              tr.is_error,
+            )
+            const converted = splitToolResultImagesForProvider(
+              convertedToolContent,
+              String(id),
+              toolResultImageHandling,
+            )
             result.push({
               role: 'tool',
               tool_call_id: id,
-              content: convertToolResultContent(tr.content, tr.is_error),
+              content: converted.toolContent,
             })
+            if (converted.assistantContent) {
+              result.push({
+                role: 'assistant',
+                content: converted.assistantContent,
+              })
+            }
+            if (converted.userImageContent) {
+              result.push({
+                role: 'user',
+                content: converted.userImageContent,
+              })
+            }
           } else {
             logForDebugging(
               `Dropping orphan tool_result for ID: ${id} to prevent API error`,
@@ -1787,6 +1865,7 @@ class OpenAIShimMessages {
         request.resolvedModel,
         request.baseUrl,
       ),
+      toolResultImageHandling: shimConfig.toolResultImageHandling,
     })
 
     const body: Record<string, unknown> = {

--- a/src/services/api/openaiShim.ts
+++ b/src/services/api/openaiShim.ts
@@ -600,6 +600,7 @@ function convertMessages(
         // Mistral/OpenAI strictly require tool messages to follow an assistant message with tool_calls.
         // If the user interrupted (ESC) and a synthetic tool_result was generated without a recorded tool_use,
         // emitting it here would cause a "role must alternate" or "unexpected role" error.
+        const deferredToolImageMessages: OpenAIMessage[] = []
         for (const tr of toolResults) {
           const id = tr.tool_use_id ?? 'unknown'
           if (knownToolCallIds.has(id)) {
@@ -618,13 +619,13 @@ function convertMessages(
               content: converted.toolContent,
             })
             if (converted.assistantContent) {
-              result.push({
+              deferredToolImageMessages.push({
                 role: 'assistant',
                 content: converted.assistantContent,
               })
             }
             if (converted.userImageContent) {
-              result.push({
+              deferredToolImageMessages.push({
                 role: 'user',
                 content: converted.userImageContent,
               })
@@ -635,6 +636,7 @@ function convertMessages(
             )
           }
         }
+        result.push(...deferredToolImageMessages)
 
         // Emit remaining user content
         if (otherContent.length > 0) {


### PR DESCRIPTION
## Summary
- add provider-gated handling for image content returned inside tool_result blocks
- keep OpenAI default behavior unchanged
- make DeepSeek tool-result images text-only so sessions do not 400 on image_url
- split Xiaomi MiMo/OpenGateway image tool results into tool text plus a user image message

Fixes #425.

## Testing
- bun test src/services/api/openaiShim.test.ts -t "DeepSeek image tool results"
- bun test src/services/api/openaiShim.test.ts -t "Xiaomi MiMo image tool results"
- bun test src/services/api/openaiShim.test.ts -t "preserves image tool results"
- bun test src/services/api/openaiShim.test.ts -t "preserves mixed text and image tool results"
- git diff --check