### PR TITLE
fix(query): keep tool failure guard across unrelated successes

### DIFF
--- a/src/query/toolFailureLoopGuard.test.ts
+++ b/src/query/toolFailureLoopGuard.test.ts
@@ -338,6 +338,49 @@ test('successful reads do not reset repeated write failures for the same path', 
   expect(decision.message).toContain('The path `E:/project/nui.lua` failed 3 times.')
 })
 
+test('unrelated successes in the same batch do not hide repeated path failures', () => {
+  const state = createToolFailureLoopGuardState()
+
+  update(
+    state,
+    [
+      toolUse('a', 'Edit', { file_path: 'src/a.ts' }),
+      toolUse('read-a', 'Read', { file_path: 'src/other.ts' }),
+    ],
+    [
+      toolResult('a', 'Error writing file: failed to replace text'),
+      toolResult('read-a', 'file contents', false),
+    ],
+  )
+  update(
+    state,
+    [
+      toolUse('b', 'Write', { file_path: 'src/a.ts' }),
+      toolUse('read-b', 'Read', { file_path: 'src/other.ts' }),
+    ],
+    [
+      toolResult('b', 'Invalid tool parameters: malformed fallback script'),
+      toolResult('read-b', 'file contents', false),
+    ],
+  )
+  const decision = update(
+    state,
+    [
+      toolUse('c', 'NotebookEdit', { notebook_path: 'src/a.ts' }),
+      toolUse('read-c', 'Read', { file_path: 'src/other.ts' }),
+    ],
+    [
+      toolResult('c', 'No such tool available: NotebookEdit'),
+      toolResult('read-c', 'file contents', false),
+    ],
+  )
+
+  if (!decision.tripped) {
+    throw new Error('Expected repeated path failures to survive batch successes')
+  }
+  expect(decision.message).toContain('The path `src/a.ts` failed 3 times.')
+})
+
 test('unrelated successful tools do not reset repeated same-tool failure signatures', () => {
   const state = createToolFailureLoopGuardState()
 

--- a/src/query/toolFailureLoopGuard.test.ts
+++ b/src/query/toolFailureLoopGuard.test.ts
@@ -117,7 +117,7 @@ test('different tools with different error categories do not trip early', () => 
   expect(decision.tripped).toBe(false)
 })
 
-test('a successful tool result resets the counter', () => {
+test('a successful result from the same tool resets the counter', () => {
   const state = createToolFailureLoopGuardState()
 
   update(state, [toolUse('a', 'Edit')], [
@@ -126,7 +126,7 @@ test('a successful tool result resets the counter', () => {
   update(state, [toolUse('b', 'Edit')], [
     toolResult('b', 'Error writing file: failed to replace text'),
   ])
-  update(state, [toolUse('c', 'Read')], [toolResult('c', 'ok', false)])
+  update(state, [toolUse('c', 'Edit')], [toolResult('c', 'ok', false)])
   const decision = update(state, [toolUse('d', 'Edit')], [
     toolResult('d', 'Error writing file: failed to replace text'),
   ])
@@ -134,7 +134,7 @@ test('a successful tool result resets the counter', () => {
   expect(decision.tripped).toBe(false)
 })
 
-test('a successful tool result in the same batch resets the no-success streak', () => {
+test('a successful result from the same tool in the same batch resets the no-success streak', () => {
   const state = createToolFailureLoopGuardState()
 
   update(state, [toolUse('a', 'Edit')], [
@@ -142,17 +142,14 @@ test('a successful tool result in the same batch resets the no-success streak', 
   ])
   update(
     state,
-    [toolUse('b', 'Edit'), toolUse('c', 'Read')],
+    [toolUse('b', 'Edit'), toolUse('c', 'Edit')],
     [
       toolResult('b', 'Error writing file: failed to replace text'),
       toolResult('c', 'ok', false),
     ],
   )
-  update(state, [toolUse('d', 'Edit')], [
+  const decision = update(state, [toolUse('d', 'Edit')], [
     toolResult('d', 'Error writing file: failed to replace text'),
-  ])
-  const decision = update(state, [toolUse('e', 'Edit')], [
-    toolResult('e', 'Error writing file: failed to replace text'),
   ])
 
   expect(decision.tripped).toBe(false)
@@ -295,13 +292,15 @@ test('same failing file_path across repeated failures trips the guard', () => {
   expect(decision.message).toContain('The path `src/foo.ts` failed 3 times.')
 })
 
-test('a successful tool result resets a failing path counter', () => {
+test('a successful mutating tool result resets a failing path counter', () => {
   const state = createToolFailureLoopGuardState()
 
   update(state, [toolUse('a', 'Write', { file_path: '/tmp/blocked.txt' })], [
     toolResult('a', 'Error writing file: EACCES'),
   ])
-  update(state, [toolUse('b', 'Read')], [toolResult('b', 'ok', false)])
+  update(state, [toolUse('b', 'Write', { file_path: '/tmp/blocked.txt' })], [
+    toolResult('b', 'ok', false),
+  ])
   const decision = update(
     state,
     [toolUse('c', 'Edit', { file_path: '/tmp/blocked.txt' })],
@@ -310,6 +309,96 @@ test('a successful tool result resets a failing path counter', () => {
   )
 
   expect(decision.tripped).toBe(false)
+})
+
+test('successful reads do not reset repeated write failures for the same path', () => {
+  const state = createToolFailureLoopGuardState()
+
+  update(state, [toolUse('a', 'Edit', { file_path: 'E:\\project\\nui.lua' })], [
+    toolResult('a', 'Error writing file: failed to replace text'),
+  ])
+  update(state, [toolUse('b', 'Read', { file_path: 'E:/project/nui.lua' })], [
+    toolResult('b', 'file contents', false),
+  ])
+  update(state, [toolUse('c', 'Write', { file_path: 'E:/project/nui.lua' })], [
+    toolResult('c', 'Invalid tool parameters: malformed fallback script'),
+  ])
+  update(state, [toolUse('d', 'Read', { file_path: 'E:/project/nui.lua' })], [
+    toolResult('d', 'file contents', false),
+  ])
+  const decision = update(state, [
+    toolUse('e', 'Edit', { file_path: 'E:/project/nui.lua' }),
+  ], [
+    toolResult('e', 'Error writing file: failed to replace text'),
+  ])
+
+  if (!decision.tripped) {
+    throw new Error('Expected repeated path failures to survive Read successes')
+  }
+  expect(decision.message).toContain('The path `E:/project/nui.lua` failed 3 times.')
+})
+
+test('unrelated successful tools do not reset repeated same-tool failure signatures', () => {
+  const state = createToolFailureLoopGuardState()
+
+  update(state, [toolUse('a', 'Edit')], [
+    toolResult('a', 'Error writing file: failed to replace text'),
+  ])
+  update(state, [toolUse('b', 'Read')], [toolResult('b', 'ok', false)])
+  update(state, [toolUse('c', 'Edit')], [
+    toolResult('c', 'Error writing file: failed to replace text'),
+  ])
+  update(state, [toolUse('d', 'Bash')], [
+    toolResult('d', 'Python 3.13.7', false),
+  ])
+  const decision = update(state, [toolUse('e', 'Edit')], [
+    toolResult('e', 'Error writing file: failed to replace text'),
+  ])
+
+  if (!decision.tripped) {
+    throw new Error('Expected unrelated successes not to reset Edit failures')
+  }
+  expect(decision.message).toContain('`Edit` failed 3 times')
+  expect(decision.message).toContain('`FileWriteError`')
+})
+
+test('a successful result from the same tool resets persistent signatures', () => {
+  const state = createToolFailureLoopGuardState()
+
+  update(state, [toolUse('a', 'Edit')], [
+    toolResult('a', 'Error writing file: failed to replace text'),
+  ])
+  update(state, [toolUse('b', 'Edit')], [toolResult('b', 'ok', false)])
+  update(state, [toolUse('c', 'Edit')], [
+    toolResult('c', 'Error writing file: failed to replace text'),
+  ])
+  const decision = update(state, [toolUse('d', 'Edit')], [
+    toolResult('d', 'Error writing file: failed to replace text'),
+  ])
+
+  expect(decision.tripped).toBe(false)
+})
+
+test('repeated invalid fallback commands trip despite unrelated successful reads', () => {
+  const state = createToolFailureLoopGuardState()
+
+  update(state, [toolUse('a', 'Bash')], [
+    toolResult('a', 'Invalid tool parameters: malformed Python heredoc'),
+  ])
+  update(state, [toolUse('b', 'Read')], [toolResult('b', 'file contents', false)])
+  update(state, [toolUse('c', 'Bash')], [
+    toolResult('c', 'Invalid tool parameters: malformed Python heredoc'),
+  ])
+  update(state, [toolUse('d', 'Read')], [toolResult('d', 'file contents', false)])
+  const decision = update(state, [toolUse('e', 'Bash')], [
+    toolResult('e', 'Invalid tool parameters: malformed Python heredoc'),
+  ])
+
+  if (!decision.tripped) {
+    throw new Error('Expected repeated Bash validation failures to trip')
+  }
+  expect(decision.message).toContain('`Bash` failed 3 times')
+  expect(decision.message).toContain('`InputValidationError`')
 })
 
 test('same error category across repeated no-success failures trips the guard', () => {

--- a/src/query/toolFailureLoopGuard.ts
+++ b/src/query/toolFailureLoopGuard.ts
@@ -6,6 +6,7 @@ const DEFAULT_TOOL_FAILURE_LOOP_THRESHOLD = 3
 const MAX_FALLBACK_CATEGORY_LENGTH = 120
 
 export type ToolFailureLoopGuardState = {
+  persistentSignatureCounts: Map<string, number>
   signatureCounts: Map<string, number>
   categoryCounts: Map<string, number>
   pathCounts: Map<string, number>
@@ -25,6 +26,7 @@ export type ToolFailureLoopGuardDecision =
 
 export function createToolFailureLoopGuardState(): ToolFailureLoopGuardState {
   return {
+    persistentSignatureCounts: new Map(),
     signatureCounts: new Map(),
     categoryCounts: new Map(),
     pathCounts: new Map(),
@@ -65,12 +67,24 @@ export function updateToolFailureLoopGuard(params: {
   )
   const failures: FailureInfo[] = []
   let hasSuccess = false
+  const successfulToolNames = new Set<string>()
+  const successfulMutationPaths = new Set<string>()
 
   for (const block of getToolResultBlocks(params.toolResults)) {
     const content = toolResultContentToString(block.content)
+    const toolUse = toolUseById.get(String(block.tool_use_id ?? ''))
 
     if (block.is_error !== true) {
       hasSuccess = true
+      if (toolUse?.name) {
+        successfulToolNames.add(toolUse.name)
+      }
+      if (toolUse && isMutatingFileTool(toolUse.name)) {
+        const path = extractNormalizedPath(toolUse.input)
+        if (path) {
+          successfulMutationPaths.add(path)
+        }
+      }
       continue
     }
 
@@ -78,7 +92,6 @@ export function updateToolFailureLoopGuard(params: {
       continue
     }
 
-    const toolUse = toolUseById.get(String(block.tool_use_id ?? ''))
     const toolName = toolUse?.name ?? 'unknown'
     const errorCategory = normalizeErrorCategory(content)
     failures.push({
@@ -88,8 +101,35 @@ export function updateToolFailureLoopGuard(params: {
     })
   }
 
+  for (const toolName of successfulToolNames) {
+    resetPersistentToolSignatures(params.state, toolName)
+  }
+
+  for (const failure of failures) {
+    const persistentSignatureCount = incrementCounter(
+      params.state.persistentSignatureCounts,
+      `${failure.toolName}\0${failure.errorCategory}`,
+    )
+
+    if (persistentSignatureCount >= threshold) {
+      return {
+        tripped: true,
+        kind: 'signature',
+        threshold,
+        toolName: failure.toolName,
+        errorCategory: failure.errorCategory,
+        message: createTripMessage({
+          kind: 'signature',
+          threshold,
+          toolName: failure.toolName,
+          errorCategory: failure.errorCategory,
+        }),
+      }
+    }
+  }
+
   if (hasSuccess) {
-    resetToolFailureLoopGuard(params.state)
+    resetToolFailureLoopGuard(params.state, successfulMutationPaths)
     return { tripped: false }
   }
 
@@ -177,10 +217,36 @@ function normalizeThreshold(threshold: number | undefined): number {
   return threshold
 }
 
-function resetToolFailureLoopGuard(state: ToolFailureLoopGuardState): void {
+function resetToolFailureLoopGuard(
+  state: ToolFailureLoopGuardState,
+  successfulMutationPaths: Set<string>,
+): void {
   state.signatureCounts.clear()
   state.categoryCounts.clear()
-  state.pathCounts.clear()
+  for (const path of successfulMutationPaths) {
+    state.pathCounts.delete(path)
+  }
+}
+
+function resetPersistentToolSignatures(
+  state: ToolFailureLoopGuardState,
+  toolName: string,
+): void {
+  const prefix = `${toolName}\0`
+  for (const key of state.persistentSignatureCounts.keys()) {
+    if (key.startsWith(prefix)) {
+      state.persistentSignatureCounts.delete(key)
+    }
+  }
+}
+
+function isMutatingFileTool(toolName: string): boolean {
+  return (
+    toolName === 'Edit' ||
+    toolName === 'MultiEdit' ||
+    toolName === 'Write' ||
+    toolName === 'NotebookEdit'
+  )
 }
 
 function getToolResultBlocks(

--- a/src/query/toolFailureLoopGuard.ts
+++ b/src/query/toolFailureLoopGuard.ts
@@ -128,6 +128,27 @@ export function updateToolFailureLoopGuard(params: {
     }
   }
 
+  for (const failure of failures) {
+    if (!failure.path || successfulMutationPaths.has(failure.path)) {
+      continue
+    }
+
+    const pathCount = incrementCounter(params.state.pathCounts, failure.path)
+    if (pathCount >= threshold) {
+      return {
+        tripped: true,
+        kind: 'path',
+        threshold,
+        path: failure.path,
+        message: createTripMessage({
+          kind: 'path',
+          threshold,
+          path: failure.path,
+        }),
+      }
+    }
+  }
+
   if (hasSuccess) {
     resetToolFailureLoopGuard(params.state, successfulMutationPaths)
     return { tripped: false }
@@ -142,24 +163,6 @@ export function updateToolFailureLoopGuard(params: {
       params.state.categoryCounts,
       failure.errorCategory,
     )
-    const pathCount = failure.path
-      ? incrementCounter(params.state.pathCounts, failure.path)
-      : 0
-
-    if (pathCount >= threshold && failure.path) {
-      return {
-        tripped: true,
-        kind: 'path',
-        threshold,
-        path: failure.path,
-        message: createTripMessage({
-          kind: 'path',
-          threshold,
-          path: failure.path,
-        }),
-      }
-    }
-
     if (signatureCount >= threshold) {
       return {
         tripped: true,


### PR DESCRIPTION
## Summary
- keep repeated same-tool failure signatures across unrelated successful tool calls
- preserve file-path failure streaks when a successful Read only confirms the file still has not changed
- clear persistent signatures only after the same tool succeeds, and clear path streaks only after successful mutating file tools

Fixes #1102.

## Testing
- bun test src/query/toolFailureLoopGuard.test.ts
- git diff --check