### PR TITLE
fix(compact): clear native tool results after time compaction

### DIFF
--- a/src/services/compact/microCompact.test.ts
+++ b/src/services/compact/microCompact.test.ts
@@ -124,4 +124,54 @@ describe('microCompact MCP tool compaction', () => {
     expect(result).toBeDefined()
     expect(result.messages.length).toBe(messages.length)
   })
+
+  test('time-based microcompact clears native toolUseResult for old compacted results', async () => {
+    const { maybeTimeBasedMicrocompact, TIME_BASED_MC_CLEARED_MESSAGE } =
+      await import('./microCompact.js')
+    const oldAssistant = {
+      ...assistantWithToolUse('Read', 'tool-read-old'),
+      timestamp: new Date(Date.now() - 120 * 60_000).toISOString(),
+    }
+    const oldResult = createUserMessage({
+      content: [
+        {
+          type: 'tool_result' as const,
+          tool_use_id: 'tool-read-old',
+          content: 'old file content',
+        },
+      ],
+      toolUseResult: { content: 'old file content' },
+    })
+    const recentAssistant = {
+      ...assistantWithToolUse('Read', 'tool-read-recent'),
+      timestamp: new Date(Date.now() - 120 * 60_000).toISOString(),
+    }
+    const recentResult = createUserMessage({
+      content: [
+        {
+          type: 'tool_result' as const,
+          tool_use_id: 'tool-read-recent',
+          content: 'recent file content',
+        },
+      ],
+      toolUseResult: { content: 'recent file content' },
+    })
+
+    const result = maybeTimeBasedMicrocompact(
+      [oldAssistant, oldResult, recentAssistant, recentResult],
+      'repl_main_thread',
+      { enabled: true, gapThresholdMinutes: 60, keepRecent: 1 },
+    )
+
+    expect(result).not.toBeNull()
+    const compactedOld = result!.messages[1]!
+    const keptRecent = result!.messages[3]!
+    expect(
+      (compactedOld.message.content as Array<{ content: string }>)[0]!.content,
+    ).toBe(TIME_BASED_MC_CLEARED_MESSAGE)
+    expect(compactedOld.toolUseResult).toBeUndefined()
+    expect(keptRecent.toolUseResult).toEqual({
+      content: 'recent file content',
+    })
+  })
 })

--- a/src/services/compact/microCompact.ts
+++ b/src/services/compact/microCompact.ts
@@ -421,8 +421,8 @@ async function cachedMicrocompactPath(
 export function evaluateTimeBasedTrigger(
   messages: Message[],
   querySource: QuerySource | undefined,
+  config: TimeBasedMCConfig = getTimeBasedMCConfig(),
 ): { gapMinutes: number; config: TimeBasedMCConfig } | null {
-  const config = getTimeBasedMCConfig()
   // Require an explicit main-thread querySource. isMainThreadSource treats
   // undefined as main-thread (for cached-MC backward-compat), but several
   // callers (/context, /compact, analyzeContext) invoke microcompactMessages
@@ -442,11 +442,16 @@ export function evaluateTimeBasedTrigger(
   return { gapMinutes, config }
 }
 
-function maybeTimeBasedMicrocompact(
+export function maybeTimeBasedMicrocompact(
   messages: Message[],
   querySource: QuerySource | undefined,
+  configOverride?: TimeBasedMCConfig,
 ): MicrocompactResult | null {
-  const trigger = evaluateTimeBasedTrigger(messages, querySource)
+  const trigger = evaluateTimeBasedTrigger(
+    messages,
+    querySource,
+    configOverride,
+  )
   if (!trigger) {
     return null
   }
@@ -487,6 +492,9 @@ function maybeTimeBasedMicrocompact(
     return {
       ...message,
       message: { ...message.message, content: newContent },
+      // The prompt content no longer contains the original tool result, so
+      // keeping the duplicate native payload only grows long-session memory.
+      toolUseResult: undefined,
     }
   })
 


### PR DESCRIPTION
## Summary
- clear retained native toolUseResult payloads when time-based microcompact replaces old tool result content
- keep recent tool results untouched so current UI details remain available
- add regression coverage for old compacted tool results dropping duplicate native output

Fixes #546.

## Testing
- bun test src/services/compact/microCompact.test.ts src/utils/toolResultStorage.test.ts
- git diff --check