### PR TITLE
fix(permissions): persist protected file edit approvals

### DIFF
--- a/src/components/permissions/FilePermissionDialog/usePermissionHandler.ts
+++ b/src/components/permissions/FilePermissionDialog/usePermissionHandler.ts
@@ -128,10 +128,13 @@ function handleAcceptSession(
     return
   }
 
-  // Generate permission updates if path is provided
-  const suggestions = path
-    ? generateSuggestions(path, operationType, toolPermissionContext)
-    : []
+  // Prefer the permission check's own suggestions. Safety-check prompts can
+  // include a narrow exact-file session rule; recomputing generic suggestions
+  // after the user is already in acceptEdits mode can otherwise produce no
+  // effective update and make the same protected file prompt again.
+  const suggestions =
+    toolUseConfirm.permissionResult.suggestions ??
+    (path ? generateSuggestions(path, operationType, toolPermissionContext) : [])
 
   onDone()
   // Pass permission updates directly to onAllow

--- a/src/utils/permissions/filesystem.acceptEdits.test.ts
+++ b/src/utils/permissions/filesystem.acceptEdits.test.ts
@@ -1,0 +1,94 @@
+import { afterEach, beforeEach, expect, test } from 'bun:test'
+import { mkdtemp, rm } from 'fs/promises'
+import { join } from 'path'
+import { tmpdir } from 'os'
+
+import { setOriginalCwd, getOriginalCwd } from '../../bootstrap/state.js'
+import type { Tool } from '../../Tool.js'
+import { FILE_EDIT_TOOL_NAME } from '../../tools/FileEditTool/constants.js'
+import { applyPermissionUpdate } from './PermissionUpdate.js'
+import type { ToolPermissionContext } from '../../Tool.js'
+import { checkWritePermissionForTool } from './filesystem.js'
+
+const editTool = {
+  name: FILE_EDIT_TOOL_NAME,
+  getPath(input: { file_path?: unknown }) {
+    return String(input.file_path)
+  },
+} as unknown as Tool<{ file_path: string }>
+
+function permissionContext(
+  overrides: Partial<ToolPermissionContext> = {},
+): ToolPermissionContext {
+  return {
+    mode: 'acceptEdits',
+    additionalWorkingDirectories: new Map(),
+    alwaysAllowRules: {},
+    alwaysDenyRules: {},
+    alwaysAskRules: {},
+    isBypassPermissionsModeAvailable: false,
+    ...overrides,
+  }
+}
+
+let originalCwd: string
+let tempDir: string
+
+beforeEach(async () => {
+  originalCwd = getOriginalCwd()
+  tempDir = await mkdtemp(join(tmpdir(), 'openclaude-perms-'))
+  setOriginalCwd(tempDir)
+})
+
+afterEach(async () => {
+  setOriginalCwd(originalCwd)
+  await rm(tempDir, { recursive: true, force: true })
+})
+
+test('acceptEdits allows normal writes inside the working directory', () => {
+  const filePath = join(tempDir, 'src.ts')
+  const decision = checkWritePermissionForTool(
+    editTool,
+    { file_path: filePath },
+    permissionContext(),
+  )
+
+  expect(decision.behavior).toBe('allow')
+})
+
+test('protected file session approval sticks to the exact file only', () => {
+  const envPath = join(tempDir, '.mcp.json')
+  const firstDecision = checkWritePermissionForTool(
+    editTool,
+    { file_path: envPath },
+    permissionContext(),
+  )
+
+  expect(firstDecision.behavior).toBe('ask')
+  expect(firstDecision.suggestions).toEqual([
+    {
+      type: 'addRules',
+      rules: [{ toolName: FILE_EDIT_TOOL_NAME, ruleContent: '/.mcp.json' }],
+      behavior: 'allow',
+      destination: 'session',
+    },
+  ])
+
+  const updatedContext = applyPermissionUpdate(
+    permissionContext(),
+    firstDecision.suggestions![0]!,
+  )
+  const secondDecision = checkWritePermissionForTool(
+    editTool,
+    { file_path: envPath },
+    updatedContext,
+  )
+  const otherSensitiveFileDecision = checkWritePermissionForTool(
+    editTool,
+    { file_path: join(tempDir, '.gitconfig') },
+    updatedContext,
+  )
+
+  expect(secondDecision.behavior).toBe('allow')
+  expect(otherSensitiveFileDecision.behavior).toBe('ask')
+})

--- a/src/utils/permissions/filesystem.acceptEdits.test.ts
+++ b/src/utils/permissions/filesystem.acceptEdits.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, expect, test } from 'bun:test'
-import { mkdtemp, rm } from 'fs/promises'
+import { mkdtemp, rm, symlink, unlink, writeFile } from 'fs/promises'
 import { join } from 'path'
 import { tmpdir } from 'os'
 
@@ -91,4 +91,52 @@ test('protected file session approval sticks to the exact file only', () => {
 
   expect(secondDecision.behavior).toBe('allow')
   expect(otherSensitiveFileDecision.behavior).toBe('ask')
+})
+
+test('protected file session approval follows the approved symlink target only', async () => {
+  const approvedTarget = join(tempDir, '.mcp.json')
+  const retargetedFile = join(tempDir, '.gitconfig')
+  const linkPath = join(tempDir, 'approved-link')
+  await writeFile(approvedTarget, '{}')
+  await writeFile(retargetedFile, '[user]\n')
+  await symlink(approvedTarget, linkPath)
+
+  const firstDecision = checkWritePermissionForTool(
+    editTool,
+    { file_path: linkPath },
+    permissionContext(),
+  )
+
+  expect(firstDecision.behavior).toBe('ask')
+  expect(firstDecision.suggestions).toEqual([
+    {
+      type: 'addRules',
+      rules: [{ toolName: FILE_EDIT_TOOL_NAME, ruleContent: '/.mcp.json' }],
+      behavior: 'allow',
+      destination: 'session',
+    },
+  ])
+
+  const updatedContext = applyPermissionUpdate(
+    permissionContext(),
+    firstDecision.suggestions![0]!,
+  )
+  expect(
+    checkWritePermissionForTool(
+      editTool,
+      { file_path: linkPath },
+      updatedContext,
+    ).behavior,
+  ).toBe('allow')
+
+  await unlink(linkPath)
+  await symlink(retargetedFile, linkPath)
+
+  expect(
+    checkWritePermissionForTool(
+      editTool,
+      { file_path: linkPath },
+      updatedContext,
+    ).behavior,
+  ).toBe('ask')
 })

--- a/src/utils/permissions/filesystem.ts
+++ b/src/utils/permissions/filesystem.ts
@@ -776,6 +776,42 @@ function rootPathForSource(source: PermissionRuleSource): string {
   }
 }
 
+function exactSessionEditRuleForPath(path: string): PermissionUpdate {
+  const absolutePath = expandPath(path)
+  const originalCwd = expandPath(getOriginalCwd())
+  const relativeToCwd = relativePath(originalCwd, absolutePath)
+  const ruleContent =
+    relativeToCwd &&
+    !relativeToCwd.startsWith(`..${DIR_SEP}`) &&
+    relativeToCwd !== '..'
+      ? prependDirSep(relativeToCwd)
+      : prependDirSep(toPosixPath(absolutePath))
+
+  return {
+    type: 'addRules',
+    rules: [{ toolName: FILE_EDIT_TOOL_NAME, ruleContent }],
+    behavior: 'allow',
+    destination: 'session',
+  }
+}
+
+function isExactSessionEditRuleForPath(
+  rule: PermissionRule | null,
+  path: string,
+): boolean {
+  if (
+    !rule ||
+    rule.source !== 'session' ||
+    rule.ruleBehavior !== 'allow' ||
+    rule.ruleValue.toolName !== FILE_EDIT_TOOL_NAME
+  ) {
+    return false
+  }
+  const expectedRule =
+    exactSessionEditRuleForPath(path).rules[0]?.ruleContent
+  return rule.ruleValue.ruleContent === expectedRule
+}
+
 function prependDirSep(path: string): string {
   return posix.join(DIR_SEP, path)
 }
@@ -1326,14 +1362,41 @@ export function checkWritePermissionForTool<Input extends AnyObject>(
   // permission to edit protected files
   const safetyCheck = checkPathSafetyForAutoEdit(path, pathsToCheck)
   if (!safetyCheck.safe) {
+    const exactSessionAllowRule = matchingRuleForInput(
+      path,
+      {
+        ...toolPermissionContext,
+        alwaysAllowRules: {
+          session: toolPermissionContext.alwaysAllowRules.session ?? [],
+        },
+      },
+      'edit',
+      'allow',
+    )
+    if (isExactSessionEditRuleForPath(exactSessionAllowRule, path)) {
+      return {
+        behavior: 'allow',
+        updatedInput: input,
+        decisionReason: {
+          type: 'rule',
+          rule: exactSessionAllowRule,
+        },
+      }
+    }
+
     // SDK suggestion: if under .claude/skills/{name}/, emit the narrowed
     // session-scoped addRules that step 1.6 will honor on the next call.
     // Everything else (.claude/settings.json, .git/, .vscode/, .idea/) falls
     // back to generateSuggestions — its setMode suggestion doesn't bypass
     // this check, but preserving it avoids a surprising empty array.
     const skillScope = getClaudeSkillScope(path)
-    const safetySuggestions: PermissionUpdate[] = skillScope
-      ? [
+    const exactFileSuggestion = safetyCheck.classifierApprovable
+      ? [exactSessionEditRuleForPath(path)]
+      : []
+    const safetySuggestions: PermissionUpdate[] = [
+      ...exactFileSuggestion,
+      ...(skillScope
+        ? [
           {
             type: 'addRules',
             rules: [
@@ -1346,7 +1409,13 @@ export function checkWritePermissionForTool<Input extends AnyObject>(
             destination: 'session',
           },
         ]
-      : generateSuggestions(path, 'write', toolPermissionContext, pathsToCheck)
+        : generateSuggestions(
+            path,
+            'write',
+            toolPermissionContext,
+            pathsToCheck,
+          )),
+    ]
     return {
       behavior: 'ask',
       message: safetyCheck.message,

--- a/src/utils/permissions/filesystem.ts
+++ b/src/utils/permissions/filesystem.ts
@@ -777,7 +777,7 @@ function rootPathForSource(source: PermissionRuleSource): string {
 }
 
 function exactSessionEditRuleForPath(path: string): PermissionUpdate {
-  const absolutePath = expandPath(path)
+  const absolutePath = toPosixPath(expandPath(path))
   const originalCwd = expandPath(getOriginalCwd())
   const relativeToCwd = relativePath(originalCwd, absolutePath)
   const ruleContent =
@@ -785,7 +785,7 @@ function exactSessionEditRuleForPath(path: string): PermissionUpdate {
     !relativeToCwd.startsWith(`..${DIR_SEP}`) &&
     relativeToCwd !== '..'
       ? prependDirSep(relativeToCwd)
-      : prependDirSep(toPosixPath(absolutePath))
+      : `${DIR_SEP}${absolutePath}`
 
   return {
     type: 'addRules',
@@ -810,6 +810,19 @@ function isExactSessionEditRuleForPath(
   const expectedRule =
     exactSessionEditRuleForPath(path).rules[0]?.ruleContent
   return rule.ruleValue.ruleContent === expectedRule
+}
+
+function exactSessionEditRuleTargetForUnsafePath(
+  requestedPath: string,
+  pathsToCheck: readonly string[],
+): string {
+  for (const pathToCheck of pathsToCheck) {
+    const check = checkPathSafetyForAutoEdit(pathToCheck, [pathToCheck])
+    if (!check.safe && check.classifierApprovable) {
+      return pathToCheck
+    }
+  }
+  return requestedPath
 }
 
 function prependDirSep(path: string): string {
@@ -1362,25 +1375,27 @@ export function checkWritePermissionForTool<Input extends AnyObject>(
   // permission to edit protected files
   const safetyCheck = checkPathSafetyForAutoEdit(path, pathsToCheck)
   if (!safetyCheck.safe) {
-    const exactSessionAllowRule = matchingRuleForInput(
-      path,
-      {
-        ...toolPermissionContext,
-        alwaysAllowRules: {
-          session: toolPermissionContext.alwaysAllowRules.session ?? [],
+    for (const pathToCheck of pathsToCheck) {
+      const exactSessionAllowRule = matchingRuleForInput(
+        pathToCheck,
+        {
+          ...toolPermissionContext,
+          alwaysAllowRules: {
+            session: toolPermissionContext.alwaysAllowRules.session ?? [],
+          },
         },
-      },
-      'edit',
-      'allow',
-    )
-    if (isExactSessionEditRuleForPath(exactSessionAllowRule, path)) {
-      return {
-        behavior: 'allow',
-        updatedInput: input,
-        decisionReason: {
-          type: 'rule',
-          rule: exactSessionAllowRule,
-        },
+        'edit',
+        'allow',
+      )
+      if (isExactSessionEditRuleForPath(exactSessionAllowRule, pathToCheck)) {
+        return {
+          behavior: 'allow',
+          updatedInput: input,
+          decisionReason: {
+            type: 'rule',
+            rule: exactSessionAllowRule,
+          },
+        }
       }
     }
 
@@ -1391,7 +1406,11 @@ export function checkWritePermissionForTool<Input extends AnyObject>(
     // this check, but preserving it avoids a surprising empty array.
     const skillScope = getClaudeSkillScope(path)
     const exactFileSuggestion = safetyCheck.classifierApprovable
-      ? [exactSessionEditRuleForPath(path)]
+      ? [
+        exactSessionEditRuleForPath(
+          exactSessionEditRuleTargetForUnsafePath(path, pathsToCheck),
+        ),
+      ]
       : []
     const safetySuggestions: PermissionUpdate[] = [
       ...exactFileSuggestion,


### PR DESCRIPTION
## Summary
- preserve safety-check permission suggestions when accepting a file prompt for the session
- add exact-file session approvals for classifier-approvable protected edit paths
- keep acceptEdits from broadly bypassing safety checks while preventing repeated prompts for the same approved file

Fixes #1180.

## Testing
- bun test src/utils/permissions/filesystem.acceptEdits.test.ts src/components/permissions/MonitorPermissionRequest/MonitorPermissionRequest.test.tsx
- git diff --check