### PR TITLE
feat: add AtomCode (GitCode) gateway for DeepSeek V4 models

### DIFF
--- a/src/components/ProviderManager.test.tsx
+++ b/src/components/ProviderManager.test.tsx
@@ -113,6 +113,7 @@ const PRESET_ORDER = [
   'Anthropic',
   'Alibaba Coding Plan (China)',
   'Alibaba Coding Plan',
+  'AtomCode (GitCode)',
   'Azure OpenAI',
   'Bankr',
   'DeepSeek',

--- a/src/components/ProviderManager.tsx
+++ b/src/components/ProviderManager.tsx
@@ -1547,7 +1547,7 @@ export function ProviderManager({ mode, onDone }: Props): React.ReactNode {
     if (canUseCodexOAuth) {
       // Insert after DeepSeek so Codex OAuth keeps its established position
       // in the picker even with Gitlawb Opengateway pinned at the top.
-      options.splice(7, 0, {
+      options.splice(8, 0, {
         value: 'codex-oauth',
         label: (
           <Text>

--- a/src/integrations/compatibility.test.ts
+++ b/src/integrations/compatibility.test.ts
@@ -16,6 +16,7 @@ import type { ProviderPreset } from '../utils/providerProfiles.js'
 
 const EXPECTED_PRESETS = [
   'anthropic',
+  'atomcode',
   'openai',
   'ollama',
   'kimi-code',

--- a/src/integrations/gateways/atomcode.ts
+++ b/src/integrations/gateways/atomcode.ts
@@ -1,0 +1,73 @@
+import { defineGateway } from '../define.js'
+
+export default defineGateway({
+  id: 'atomcode',
+  label: 'AtomCode (GitCode)',
+  category: 'hosted',
+  defaultBaseUrl: 'https://api-ai.gitcode.com/v1',
+  defaultModel: 'deepseek-v4-flash',
+  supportsModelRouting: true,
+  setup: {
+    requiresAuth: true,
+    authMode: 'api-key',
+    credentialEnvVars: ['ATOMCODE_API_KEY'],
+  },
+  startup: {
+    probeReadiness: 'openai-compatible-models',
+  },
+  transportConfig: {
+    kind: 'openai-compatible',
+    openaiShim: {
+      supportsAuthHeaders: false,
+      headers: {
+        'User-Agent': 'atomcode/4.22.3',
+        'x-atomcode-client': 'atomcode-air',
+      },
+    },
+  },
+  preset: {
+    id: 'atomcode',
+    description: 'AtomCode (GitCode) DeepSeek API endpoint',
+    apiKeyEnvVars: ['ATOMCODE_API_KEY'],
+    baseUrlEnvVars: ['ATOMCODE_BASE_URL'],
+    modelEnvVars: ['OPENAI_MODEL'],
+    vendorId: 'deepseek',
+  },
+  validation: {
+    kind: 'credential-env',
+    routing: {
+      matchBaseUrlHosts: ['api-ai.gitcode.com'],
+    },
+    credentialEnvVars: ['ATOMCODE_API_KEY'],
+    missingCredentialMessage:
+      'Set ATOMCODE_API_KEY for the AtomCode (GitCode) provider.',
+  },
+  catalog: {
+    source: 'hybrid',
+    discovery: { kind: 'openai-compatible' },
+    discoveryCacheTtl: '1d',
+    discoveryRefreshMode: 'background-if-stale',
+    allowManualRefresh: true,
+    models: [
+      {
+        id: 'atomcode-deepseek-v4-flash',
+        apiName: 'deepseek-v4-flash',
+        label: 'DeepSeek V4 Flash',
+        modelDescriptorId: 'deepseek-v4-flash',
+      },
+      {
+        id: 'atomcode-deepseek-v4-pro',
+        apiName: 'deepseek-v4-pro',
+        label: 'DeepSeek V4 Pro',
+        modelDescriptorId: 'deepseek-v4-pro',
+      },
+      {
+        id: 'atomcode-deepseek-chat',
+        apiName: 'deepseek-chat',
+        label: 'DeepSeek Chat',
+        modelDescriptorId: 'deepseek-chat',
+      },
+    ],
+  },
+  usage: { supported: false },
+})

--- a/src/integrations/generated/integrationArtifacts.generated.ts
+++ b/src/integrations/generated/integrationArtifacts.generated.ts
@@ -13,6 +13,7 @@ import vendorVenice from '../vendors/venice.js'
 import vendorXai from '../vendors/xai.js'
 import vendorXiaomiMimo from '../vendors/xiaomi-mimo.js'
 import vendorZai from '../vendors/zai.js'
+import gatewayAtomcode from '../gateways/atomcode.js'
 import gatewayAtomicChat from '../gateways/atomic-chat.js'
 import gatewayAzureOpenai from '../gateways/azure-openai.js'
 import gatewayBedrock from '../gateways/bedrock.js'
@@ -61,7 +62,7 @@ import modelXai from '../models/xai.js'
 import modelXiaomiMimo from '../models/xiaomi-mimo.js'
 
 export const VENDOR_DESCRIPTORS = [vendorAnthropic, vendorBankr, vendorDeepseek, vendorGemini, vendorMinimax, vendorMoonshot, vendorOpenai, vendorVenice, vendorXai, vendorXiaomiMimo, vendorZai] as const satisfies readonly VendorDescriptor[]
-export const GATEWAY_DESCRIPTORS = [gatewayAtomicChat, gatewayAzureOpenai, gatewayBedrock, gatewayCustom, gatewayDashscopeCn, gatewayDashscopeIntl, gatewayGithub, gatewayGitlawbOpengateway, gatewayGroq, gatewayHicap, gatewayKimiCode, gatewayLmstudio, gatewayMistral, gatewayNvidiaNim, gatewayOllama, gatewayOpenrouter, gatewayTogether, gatewayVertex] as const satisfies readonly GatewayDescriptor[]
+export const GATEWAY_DESCRIPTORS = [gatewayAtomcode, gatewayAtomicChat, gatewayAzureOpenai, gatewayBedrock, gatewayCustom, gatewayDashscopeCn, gatewayDashscopeIntl, gatewayGithub, gatewayGitlawbOpengateway, gatewayGroq, gatewayHicap, gatewayKimiCode, gatewayLmstudio, gatewayMistral, gatewayNvidiaNim, gatewayOllama, gatewayOpenrouter, gatewayTogether, gatewayVertex] as const satisfies readonly GatewayDescriptor[]
 export const ANTHROPIC_PROXY_DESCRIPTORS = [] as const satisfies readonly AnthropicProxyDescriptor[]
 export const BRAND_DESCRIPTORS = [brandClaude, brandDeepseek, brandGemini, brandGlm, brandGpt, brandKimi, brandLlama, brandMinimax, brandMistral, brandNemotron, brandOpenaiCompatibleAlias, brandQwen, brandXai, brandXiaomiMimo] as const satisfies readonly BrandDescriptor[]
 export const MODEL_DESCRIPTOR_GROUPS = [modelClaude, modelDeepseek, modelGemini, modelGlm, modelGpt, modelKimi, modelLlama, modelMinimax, modelMistral, modelNemotron, modelOpenaiCompatibleAlias, modelQwen, modelXai, modelXiaomiMimo] as const satisfies readonly (readonly ModelDescriptor[])[]
@@ -123,6 +124,23 @@ export const PROVIDER_PRESET_MANIFEST = [
     "description": "Alibaba DashScope International endpoint",
     "apiKeyEnvVars": [
       "DASHSCOPE_API_KEY"
+    ]
+  },
+  {
+    "preset": "atomcode",
+    "routeKind": "gateway",
+    "routeId": "atomcode",
+    "vendorId": "deepseek",
+    "gatewayId": "atomcode",
+    "description": "AtomCode (GitCode) DeepSeek API endpoint",
+    "apiKeyEnvVars": [
+      "ATOMCODE_API_KEY"
+    ],
+    "baseUrlEnvVars": [
+      "ATOMCODE_BASE_URL"
+    ],
+    "modelEnvVars": [
+      "OPENAI_MODEL"
     ]
   },
   {
@@ -399,6 +417,7 @@ export const ORDERED_PROVIDER_PRESETS = [
   "anthropic",
   "dashscope-cn",
   "dashscope-intl",
+  "atomcode",
   "azure-openai",
   "bankr",
   "deepseek",

--- a/src/services/api/openaiShim.test.ts
+++ b/src/services/api/openaiShim.test.ts
@@ -705,6 +705,167 @@ test('applies descriptor static headers before client and request headers', asyn
   expect(capturedHeaders?.get('x-override-header')).toBe('from-request')
 })
 
+test('preserves descriptor User-Agent override over client default User-Agent', async () => {
+  let capturedHeaders: Headers | undefined
+
+  registerGateway({
+    id: 'shim-ua-test',
+    label: 'Shim UA Test',
+    category: 'hosted',
+    defaultBaseUrl: 'https://shim-ua-test.example/v1',
+    defaultModel: 'shim-test-model',
+    setup: {
+      requiresAuth: true,
+      authMode: 'api-key',
+      credentialEnvVars: ['OPENAI_API_KEY'],
+    },
+    transportConfig: {
+      kind: 'openai-compatible',
+      openaiShim: {
+        headers: {
+          'User-Agent': 'atomcode-test/1.0',
+        },
+      },
+    },
+  })
+
+  process.env.CLAUDE_CODE_USE_OPENAI = '1'
+  process.env.OPENAI_BASE_URL = 'https://shim-ua-test.example/v1'
+  process.env.OPENAI_MODEL = 'shim-test-model'
+
+  globalThis.fetch = (async (_input, init) => {
+    capturedHeaders = new Headers(init?.headers)
+
+    return new Response(
+      JSON.stringify({
+        id: 'chatcmpl-1',
+        model: 'shim-test-model',
+        choices: [
+          {
+            message: {
+              role: 'assistant',
+              content: 'ok',
+            },
+            finish_reason: 'stop',
+          },
+        ],
+        usage: {
+          prompt_tokens: 8,
+          completion_tokens: 3,
+          total_tokens: 11,
+        },
+      }),
+      {
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      },
+    )
+  }) as FetchType
+
+  const client = createOpenAIShimClient({
+    defaultHeaders: {
+      'User-Agent': 'from-client',
+    },
+  }) as OpenAIShimClient
+
+  await client.beta.messages.create(
+    {
+      model: 'shim-test-model',
+      system: 'test system',
+      messages: [{ role: 'user', content: 'hello' }],
+      max_tokens: 64,
+      stream: false,
+    },
+  )
+
+  // Descriptor User-Agent should win over client default User-Agent
+  expect(capturedHeaders?.get('User-Agent')).toBe('atomcode-test/1.0')
+})
+
+test('does not clobber per-request User-Agent with descriptor User-Agent', async () => {
+  let capturedHeaders: Headers | undefined
+
+  registerGateway({
+    id: 'shim-ua-request-test',
+    label: 'Shim UA Request Test',
+    category: 'hosted',
+    defaultBaseUrl: 'https://shim-ua-request-test.example/v1',
+    defaultModel: 'shim-test-model',
+    setup: {
+      requiresAuth: true,
+      authMode: 'api-key',
+      credentialEnvVars: ['OPENAI_API_KEY'],
+    },
+    transportConfig: {
+      kind: 'openai-compatible',
+      openaiShim: {
+        headers: {
+          'User-Agent': 'atomcode-test/1.0',
+        },
+      },
+    },
+  })
+
+  process.env.CLAUDE_CODE_USE_OPENAI = '1'
+  process.env.OPENAI_BASE_URL = 'https://shim-ua-request-test.example/v1'
+  process.env.OPENAI_MODEL = 'shim-test-model'
+
+  globalThis.fetch = (async (_input, init) => {
+    capturedHeaders = new Headers(init?.headers)
+
+    return new Response(
+      JSON.stringify({
+        id: 'chatcmpl-1',
+        model: 'shim-test-model',
+        choices: [
+          {
+            message: {
+              role: 'assistant',
+              content: 'ok',
+            },
+            finish_reason: 'stop',
+          },
+        ],
+        usage: {
+          prompt_tokens: 8,
+          completion_tokens: 3,
+          total_tokens: 11,
+        },
+      }),
+      {
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      },
+    )
+  }) as FetchType
+
+  const client = createOpenAIShimClient({
+    defaultHeaders: {
+      'User-Agent': 'from-client',
+    },
+  }) as OpenAIShimClient
+
+  await client.beta.messages.create(
+    {
+      model: 'shim-test-model',
+      system: 'test system',
+      messages: [{ role: 'user', content: 'hello' }],
+      max_tokens: 64,
+      stream: false,
+    },
+    {
+      headers: {
+        'User-Agent': 'from-caller',
+      },
+    },
+  )
+
+  // Per-request caller User-Agent should win over descriptor User-Agent
+  expect(capturedHeaders?.get('User-Agent')).toBe('from-caller')
+})
+
 test('strips Anthropic-specific headers on GitHub Codex transport requests', async () => {
   let capturedHeaders: Headers | undefined
 

--- a/src/services/api/openaiShim.ts
+++ b/src/services/api/openaiShim.ts
@@ -2043,6 +2043,23 @@ class OpenAIShimMessages {
       }
     }
 
+    // Route descriptor headers (shimConfig.headers) are gateway-specific defaults
+    // that should take priority over the generic client defaultHeaders but yield
+    // to per-request caller headers (options.headers). Filter Anthropic-specific
+    // keys and use exact (case-sensitive) comparison: some servers like
+    // user-agent matching are case-sensitive.
+    if (shimConfig.headers) {
+      const callerHeaderNames = new Set(Object.keys(options?.headers ?? {}))
+      Object.assign(
+        headers,
+        Object.fromEntries(
+          Object.entries(filterAnthropicHeaders(shimConfig.headers)).filter(
+            ([k]) => !callerHeaderNames.has(k),
+          ),
+        ),
+      )
+    }
+
     if (isGithubCopilot) {
       Object.assign(headers, COPILOT_HEADERS)
     } else if (isGithubModels) {


### PR DESCRIPTION
Adds a new gateway integration for AtomCode (GitCode) at api-ai.gitcode.com/v1, providing access to DeepSeek V4 Flash and V4 Pro models.

Key details:
- Default endpoint: https://api-ai.gitcode.com/v1
- Auth: ATOMCODE_API_KEY env var
- Identity header: User-Agent: atomcode/4.22.3 (required by API gateway)
- Custom header: x-atomcode-client: atomcode-air
- Base URL override: ATOMCODE_BASE_URL
- Models: deepseek-v4-flash, deepseek-v4-pro, deepseek-chat

Also includes a generic fix in openaiShim.ts to preserve route descriptor  headers 
## Summary

- what changed
- why it changed

## Impact

- user-facing impact:
- developer/maintainer impact:

## Testing

- [x] `bun run build`
- [x] `bun run smoke`
- [ ] focused tests:

## Notes

- provider/model path tested:
- screenshots attached (if UI changed):
- follow-up work or known limitations:
