### PR TITLE
feat(xai): add xAI/Grok OAuth provider (browser + device-code)

### DIFF
--- a/src/cli/handlers/xaiAuth.test.ts
+++ b/src/cli/handlers/xaiAuth.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, expect, mock, test } from 'bun:test'
+import { afterEach, beforeEach, expect, test } from 'bun:test'
 import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
@@ -7,6 +7,7 @@ import {
   acquireSharedMutationLock,
   releaseSharedMutationLock,
 } from '../../test/sharedMutationLock.js'
+import { setClaudeConfigHomeDirForTesting } from '../../utils/envUtils.js'
 
 // CLAUDE_CODE_SIMPLE puts utils that touch secure storage into a no-op
 // "bare" mode — clearXaiCredentials() succeeds without touching the
@@ -22,21 +23,21 @@ const originalCwd = process.cwd()
 
 beforeEach(async () => {
   await acquireSharedMutationLock('cli/handlers/xaiAuth.test.ts')
-  // Other test files (ProviderManager.test.tsx) use `mock.module(...)`
-  // to stub providerProfiles/providerProfile, which leaks across files
-  // within the same `bun test` process. Without resetting, our
-  // freshly-imported modules still hit the stub and `addProviderProfile`
-  // becomes a no-op. Restore before importing real modules below.
-  mock.restore()
   tempConfigDir = mkdtempSync(join(tmpdir(), 'openclaude-xai-cli-config-'))
   tempCwd = mkdtempSync(join(tmpdir(), 'openclaude-xai-cli-cwd-'))
   process.chdir(tempCwd)
   process.env.CLAUDE_CONFIG_DIR = tempConfigDir
   process.env.CLAUDE_CODE_SIMPLE = '1'
+  // Other test files (SQLiteProvider, knowledgeGraph, …) call
+  // setClaudeConfigHomeDirForTesting and may leak the override. Pin it
+  // to our temp dir so clearPersistedXaiOAuthProfile's path resolution
+  // lands on the file we just wrote.
+  setClaudeConfigHomeDirForTesting(tempConfigDir)
 })
 
 afterEach(() => {
   try {
+    setClaudeConfigHomeDirForTesting(undefined)
     process.chdir(originalCwd)
     rmSync(tempConfigDir, { recursive: true, force: true })
     rmSync(tempCwd, { recursive: true, force: true })
@@ -66,7 +67,34 @@ async function freshHandlerModules() {
   const profilesUtils = (await import(
     `../../utils/providerProfiles.js?ts=${nonce}`
   )) as typeof import('../../utils/providerProfiles.js')
-  return { handlers, profileUtils, profilesUtils }
+  const startupOverridesUtils = (await import(
+    `../../utils/providerStartupOverrides.js?ts=${nonce}`
+  )) as typeof import('../../utils/providerStartupOverrides.js')
+  const xaiCredentialsUtils = (await import(
+    `../../utils/xaiCredentials.js?ts=${nonce}`
+  )) as typeof import('../../utils/xaiCredentials.js')
+  // Bundle the real exports xaiLogout needs into a deps object the test
+  // can inject. xaiLogout's static imports were captured against the
+  // (Codex-mocked) versions when xaiAuth.js was first evaluated; passing
+  // these explicitly bypasses that capture without any further mock
+  // gymnastics.
+  //
+  // `clearPersistedXaiOAuthProfile` is wrapped to pin the configDir to
+  // our temp dir — other test files run in parallel and call
+  // `setClaudeConfigHomeDirForTesting`, so the default-path resolution
+  // inside the real helper can't be trusted in the broader suite. The
+  // production code still calls it with no args (default path); this
+  // wrapper only fences the test.
+  const xaiLogoutDeps = {
+    clearXaiCredentials: xaiCredentialsUtils.clearXaiCredentials,
+    clearPersistedXaiOAuthProfile: () =>
+      profileUtils.clearPersistedXaiOAuthProfile({ configDir: tempConfigDir }),
+    getProviderProfiles: profilesUtils.getProviderProfiles,
+    deleteProviderProfile: profilesUtils.deleteProviderProfile,
+    clearStartupProviderOverrides:
+      startupOverridesUtils.clearStartupProviderOverrides,
+  }
+  return { handlers, profileUtils, profilesUtils, xaiLogoutDeps }
 }
 
 function readProfileFile(): { profile?: string; env?: Record<string, unknown> } | null {
@@ -108,7 +136,7 @@ function writeMarkerStartupProfile(): string {
 // process. In-memory `getProviderProfiles()` lookups aren't reliable
 // here; the startup-file path is what users actually hit at next launch.
 test('xaiLogout removes the marker-tagged startup profile', async () => {
-  const { handlers, profileUtils } = await freshHandlerModules()
+  const { handlers, profileUtils, xaiLogoutDeps } = await freshHandlerModules()
 
   const startupPath = writeMarkerStartupProfile()
   expect(
@@ -117,23 +145,23 @@ test('xaiLogout removes the marker-tagged startup profile', async () => {
     ),
   ).toBe(true)
 
-  await handlers.xaiLogout()
+  await handlers.xaiLogout(xaiLogoutDeps)
 
   expect(existsSync(startupPath)).toBe(false)
   expect(readProfileFile()).toBeNull()
 })
 
 test('xaiLogout is a no-op when there is no stored OAuth profile', async () => {
-  const { handlers } = await freshHandlerModules()
+  const { handlers, xaiLogoutDeps } = await freshHandlerModules()
 
   // No prior /provider setup. Should not crash and should not write any
   // startup file.
-  await handlers.xaiLogout()
+  await handlers.xaiLogout(xaiLogoutDeps)
   expect(readProfileFile()).toBeNull()
 })
 
 test('xaiLogout leaves unrelated startup profiles intact', async () => {
-  const { handlers } = await freshHandlerModules()
+  const { handlers, xaiLogoutDeps } = await freshHandlerModules()
 
   // Simulate a non-xAI startup file (e.g. an openai profile).
   const path = join(tempConfigDir, '.openclaude-profile.json')
@@ -153,7 +181,7 @@ test('xaiLogout leaves unrelated startup profiles intact', async () => {
     ),
   )
 
-  await handlers.xaiLogout()
+  await handlers.xaiLogout(xaiLogoutDeps)
 
   // Unrelated profile must survive.
   expect(existsSync(path)).toBe(true)

--- a/src/cli/handlers/xaiAuth.test.ts
+++ b/src/cli/handlers/xaiAuth.test.ts
@@ -1,0 +1,162 @@
+import { afterEach, beforeEach, expect, mock, test } from 'bun:test'
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import {
+  acquireSharedMutationLock,
+  releaseSharedMutationLock,
+} from '../../test/sharedMutationLock.js'
+
+// CLAUDE_CODE_SIMPLE puts utils that touch secure storage into a no-op
+// "bare" mode — clearXaiCredentials() succeeds without touching the
+// keychain, so the test can assert the rest of the cleanup independently.
+const SAVED_ENV = {
+  CLAUDE_CONFIG_DIR: process.env.CLAUDE_CONFIG_DIR,
+  CLAUDE_CODE_SIMPLE: process.env.CLAUDE_CODE_SIMPLE,
+}
+
+let tempConfigDir = ''
+let tempCwd = ''
+const originalCwd = process.cwd()
+
+beforeEach(async () => {
+  await acquireSharedMutationLock('cli/handlers/xaiAuth.test.ts')
+  // Other test files (ProviderManager.test.tsx) use `mock.module(...)`
+  // to stub providerProfiles/providerProfile, which leaks across files
+  // within the same `bun test` process. Without resetting, our
+  // freshly-imported modules still hit the stub and `addProviderProfile`
+  // becomes a no-op. Restore before importing real modules below.
+  mock.restore()
+  tempConfigDir = mkdtempSync(join(tmpdir(), 'openclaude-xai-cli-config-'))
+  tempCwd = mkdtempSync(join(tmpdir(), 'openclaude-xai-cli-cwd-'))
+  process.chdir(tempCwd)
+  process.env.CLAUDE_CONFIG_DIR = tempConfigDir
+  process.env.CLAUDE_CODE_SIMPLE = '1'
+})
+
+afterEach(() => {
+  try {
+    process.chdir(originalCwd)
+    rmSync(tempConfigDir, { recursive: true, force: true })
+    rmSync(tempCwd, { recursive: true, force: true })
+    if (SAVED_ENV.CLAUDE_CONFIG_DIR === undefined) {
+      delete process.env.CLAUDE_CONFIG_DIR
+    } else {
+      process.env.CLAUDE_CONFIG_DIR = SAVED_ENV.CLAUDE_CONFIG_DIR
+    }
+    if (SAVED_ENV.CLAUDE_CODE_SIMPLE === undefined) {
+      delete process.env.CLAUDE_CODE_SIMPLE
+    } else {
+      process.env.CLAUDE_CODE_SIMPLE = SAVED_ENV.CLAUDE_CODE_SIMPLE
+    }
+  } finally {
+    releaseSharedMutationLock()
+  }
+})
+
+async function freshHandlerModules() {
+  const nonce = `${Date.now()}-${Math.random()}`
+  const handlers = (await import(`./xaiAuth.js?ts=${nonce}`)) as typeof import(
+    './xaiAuth.js'
+  )
+  const profileUtils = (await import(
+    `../../utils/providerProfile.js?ts=${nonce}`
+  )) as typeof import('../../utils/providerProfile.js')
+  const profilesUtils = (await import(
+    `../../utils/providerProfiles.js?ts=${nonce}`
+  )) as typeof import('../../utils/providerProfiles.js')
+  return { handlers, profileUtils, profilesUtils }
+}
+
+function readProfileFile(): { profile?: string; env?: Record<string, unknown> } | null {
+  const path = join(tempConfigDir, '.openclaude-profile.json')
+  if (!existsSync(path)) return null
+  return JSON.parse(readFileSync(path, 'utf8'))
+}
+
+function writeMarkerStartupProfile(): string {
+  const path = join(tempConfigDir, '.openclaude-profile.json')
+  writeFileSync(
+    path,
+    JSON.stringify(
+      {
+        profile: 'xai',
+        env: {
+          OPENAI_BASE_URL: 'https://api.x.ai/v1',
+          OPENAI_MODEL: 'grok-4.3',
+          XAI_CREDENTIAL_SOURCE: 'oauth',
+        },
+        createdAt: new Date().toISOString(),
+      },
+      null,
+      2,
+    ),
+  )
+  return path
+}
+
+// Regression: a user who configured xAI OAuth via /provider and later
+// runs `openclaude auth xai logout` previously only had secure storage
+// cleared. The marker-tagged .openclaude-profile.json survived, leaving
+// startup in a half-logged-out state — validation would still accept
+// XAI_CREDENTIAL_SOURCE=oauth while openaiShim could no longer resolve
+// a token.
+//
+// Asserts file-level cleanup directly because Bun's `mock.module(...)`
+// in ProviderManager.test.tsx leaks providerProfiles stubs into this
+// process. In-memory `getProviderProfiles()` lookups aren't reliable
+// here; the startup-file path is what users actually hit at next launch.
+test('xaiLogout removes the marker-tagged startup profile', async () => {
+  const { handlers, profileUtils } = await freshHandlerModules()
+
+  const startupPath = writeMarkerStartupProfile()
+  expect(
+    profileUtils.isPersistedXaiOAuthProfile(
+      profileUtils.loadProfileFile({ configDir: tempConfigDir }),
+    ),
+  ).toBe(true)
+
+  await handlers.xaiLogout()
+
+  expect(existsSync(startupPath)).toBe(false)
+  expect(readProfileFile()).toBeNull()
+})
+
+test('xaiLogout is a no-op when there is no stored OAuth profile', async () => {
+  const { handlers } = await freshHandlerModules()
+
+  // No prior /provider setup. Should not crash and should not write any
+  // startup file.
+  await handlers.xaiLogout()
+  expect(readProfileFile()).toBeNull()
+})
+
+test('xaiLogout leaves unrelated startup profiles intact', async () => {
+  const { handlers } = await freshHandlerModules()
+
+  // Simulate a non-xAI startup file (e.g. an openai profile).
+  const path = join(tempConfigDir, '.openclaude-profile.json')
+  writeFileSync(
+    path,
+    JSON.stringify(
+      {
+        profile: 'openai',
+        env: {
+          OPENAI_BASE_URL: 'https://api.openai.com/v1',
+          OPENAI_MODEL: 'gpt-4o',
+        },
+        createdAt: new Date().toISOString(),
+      },
+      null,
+      2,
+    ),
+  )
+
+  await handlers.xaiLogout()
+
+  // Unrelated profile must survive.
+  expect(existsSync(path)).toBe(true)
+  const parsed = JSON.parse(readFileSync(path, 'utf8'))
+  expect(parsed.profile).toBe('openai')
+})

--- a/src/cli/handlers/xaiAuth.ts
+++ b/src/cli/handlers/xaiAuth.ts
@@ -184,7 +184,32 @@ async function runDeviceCodeFlow(): Promise<void> {
 // the matching profile without needing UI state.
 const XAI_OAUTH_PROVIDER_NAME = 'xAI OAuth'
 
-export async function xaiLogout(): Promise<void> {
+/**
+ * Dependencies for `xaiLogout`. Tests inject real implementations to
+ * bypass `mock.module(...)` stubs that other test files install for
+ * providerProfile / providerProfiles — Bun's module mocks leak across
+ * files in the same process and `mock.restore()` doesn't undo them.
+ * Production callers omit this argument and get the static imports.
+ */
+export type XaiLogoutDeps = {
+  clearXaiCredentials?: typeof clearXaiCredentials
+  clearPersistedXaiOAuthProfile?: typeof clearPersistedXaiOAuthProfile
+  getProviderProfiles?: typeof getProviderProfiles
+  deleteProviderProfile?: typeof deleteProviderProfile
+  clearStartupProviderOverrides?: typeof clearStartupProviderOverrides
+}
+
+export async function xaiLogout(deps?: XaiLogoutDeps): Promise<void> {
+  const _clearXaiCredentials = deps?.clearXaiCredentials ?? clearXaiCredentials
+  const _clearPersistedXaiOAuthProfile =
+    deps?.clearPersistedXaiOAuthProfile ?? clearPersistedXaiOAuthProfile
+  const _getProviderProfiles =
+    deps?.getProviderProfiles ?? getProviderProfiles
+  const _deleteProviderProfile =
+    deps?.deleteProviderProfile ?? deleteProviderProfile
+  const _clearStartupProviderOverrides =
+    deps?.clearStartupProviderOverrides ?? clearStartupProviderOverrides
+
   // Mirror the /provider UI logout sequence so a user who configured
   // xAI OAuth interactively and then ran `openclaude auth xai logout`
   // ends up in a clean state. Without all four steps, the
@@ -195,7 +220,7 @@ export async function xaiLogout(): Promise<void> {
   // out cleanly.
   //
   // 1. Clear stored OAuth tokens from secure storage.
-  const cleared = clearXaiCredentials()
+  const cleared = _clearXaiCredentials()
   if (!cleared.success) {
     process.stderr.write(
       `Could not clear xAI credentials: ${cleared.warning ?? 'unknown error'}\n`,
@@ -208,14 +233,14 @@ export async function xaiLogout(): Promise<void> {
   // The CLI has no React state telling it which profile id corresponds
   // to the OAuth profile, so match on the canonical name + xai provider
   // — the /provider UI always uses this exact name.
-  const xaiOAuthProfile = getProviderProfiles().find(
+  const xaiOAuthProfile = _getProviderProfiles().find(
     profile =>
       profile.provider === 'xai' &&
       profile.name === XAI_OAUTH_PROVIDER_NAME,
   )
   let activeProfileWasCleared = false
   if (xaiOAuthProfile) {
-    const result = deleteProviderProfile(xaiOAuthProfile.id)
+    const result = _deleteProviderProfile(xaiOAuthProfile.id)
     if (!result.removed) {
       process.stderr.write(
         'xAI credentials were cleared, but the xAI OAuth provider profile could not be removed.\n',
@@ -228,13 +253,13 @@ export async function xaiLogout(): Promise<void> {
 
   // 3. Remove the marker-tagged startup profile file so validation
   // doesn't keep accepting XAI_CREDENTIAL_SOURCE=oauth at next launch.
-  clearPersistedXaiOAuthProfile()
+  _clearPersistedXaiOAuthProfile()
 
   // 4. Clear the global-settings startup-provider override if the
   // active profile changed — otherwise a stale settings.json override
   // can re-pin the (now-deleted) xAI profile on next launch.
   const settingsOverrideError = activeProfileWasCleared
-    ? clearStartupProviderOverrides()
+    ? _clearStartupProviderOverrides()
     : null
 
   if (settingsOverrideError) {

--- a/src/cli/handlers/xaiAuth.ts
+++ b/src/cli/handlers/xaiAuth.ts
@@ -19,6 +19,12 @@ import {
   readXaiCredentialsAsync,
 } from '../../utils/xaiCredentials.js'
 import { isBareMode } from '../../utils/envUtils.js'
+import { clearPersistedXaiOAuthProfile } from '../../utils/providerProfile.js'
+import {
+  deleteProviderProfile,
+  getProviderProfiles,
+} from '../../utils/providerProfiles.js'
+import { clearStartupProviderOverrides } from '../../utils/providerStartupOverrides.js'
 
 export type XaiLoginFlow = 'browser' | 'device-code'
 
@@ -99,6 +105,14 @@ function listenForManualCode(onLine: (line: string) => void): () => void {
   const stdin = process.stdin
   let buffer = ''
   let active = true
+  // Record the paused state BEFORE we touch it. We only need to resume
+  // stdin if it was paused, and we must only re-pause it on cleanup if
+  // we were the ones who resumed it — otherwise a one-shot CLI process
+  // (`openclaude auth xai login`) stays alive after a successful
+  // browser flow because the resumed stdin keeps the event loop busy,
+  // and the user sees the command "hang" until they hit Ctrl+D.
+  const wasPaused =
+    typeof stdin.isPaused === 'function' ? stdin.isPaused() : false
 
   const onData = (chunk: Buffer | string): void => {
     if (!active) return
@@ -113,13 +127,17 @@ function listenForManualCode(onLine: (line: string) => void): () => void {
   }
 
   stdin.on('data', onData)
-  // resume() in case some other code paused stdin; idempotent.
-  if (typeof stdin.resume === 'function') stdin.resume()
+  if (wasPaused && typeof stdin.resume === 'function') {
+    stdin.resume()
+  }
 
   return () => {
     if (!active) return
     active = false
     stdin.removeListener('data', onData)
+    if (wasPaused && typeof stdin.pause === 'function') {
+      stdin.pause()
+    }
   }
 }
 
@@ -161,13 +179,68 @@ async function runDeviceCodeFlow(): Promise<void> {
   }
 }
 
+// The provider-name constant used by the /provider UI when it creates an
+// xAI OAuth profile. Kept in sync so the CLI logout can find and remove
+// the matching profile without needing UI state.
+const XAI_OAUTH_PROVIDER_NAME = 'xAI OAuth'
+
 export async function xaiLogout(): Promise<void> {
-  const result = clearXaiCredentials()
-  if (!result.success) {
+  // Mirror the /provider UI logout sequence so a user who configured
+  // xAI OAuth interactively and then ran `openclaude auth xai logout`
+  // ends up in a clean state. Without all four steps, the
+  // marker-tagged .openclaude-profile.json survives, startup
+  // validation still accepts XAI_CREDENTIAL_SOURCE=oauth, but
+  // openaiShim can't resolve a token — the next non-interactive xAI
+  // launch hits api.x.ai without credentials instead of being logged
+  // out cleanly.
+  //
+  // 1. Clear stored OAuth tokens from secure storage.
+  const cleared = clearXaiCredentials()
+  if (!cleared.success) {
     process.stderr.write(
-      `Could not clear xAI credentials: ${result.warning ?? 'unknown error'}\n`,
+      `Could not clear xAI credentials: ${cleared.warning ?? 'unknown error'}\n`,
     )
     process.exitCode = 1
+    return
+  }
+
+  // 2. Remove the xAI OAuth provider profile from global config (if any).
+  // The CLI has no React state telling it which profile id corresponds
+  // to the OAuth profile, so match on the canonical name + xai provider
+  // — the /provider UI always uses this exact name.
+  const xaiOAuthProfile = getProviderProfiles().find(
+    profile =>
+      profile.provider === 'xai' &&
+      profile.name === XAI_OAUTH_PROVIDER_NAME,
+  )
+  let activeProfileWasCleared = false
+  if (xaiOAuthProfile) {
+    const result = deleteProviderProfile(xaiOAuthProfile.id)
+    if (!result.removed) {
+      process.stderr.write(
+        'xAI credentials were cleared, but the xAI OAuth provider profile could not be removed.\n',
+      )
+      process.exitCode = 1
+      return
+    }
+    activeProfileWasCleared = Boolean(result.activeProfileId)
+  }
+
+  // 3. Remove the marker-tagged startup profile file so validation
+  // doesn't keep accepting XAI_CREDENTIAL_SOURCE=oauth at next launch.
+  clearPersistedXaiOAuthProfile()
+
+  // 4. Clear the global-settings startup-provider override if the
+  // active profile changed — otherwise a stale settings.json override
+  // can re-pin the (now-deleted) xAI profile on next launch.
+  const settingsOverrideError = activeProfileWasCleared
+    ? clearStartupProviderOverrides()
+    : null
+
+  if (settingsOverrideError) {
+    process.stderr.write(
+      `xAI OAuth logged out. Warning: could not clear startup provider override (${settingsOverrideError}).\n`,
+    )
     return
   }
   process.stderr.write('xAI OAuth credentials cleared.\n')

--- a/src/cli/handlers/xaiAuth.ts
+++ b/src/cli/handlers/xaiAuth.ts
@@ -1,0 +1,191 @@
+/**
+ * `openclaude auth xai ...` command handlers.
+ *
+ * `login`   — browser OAuth (loopback callback on 127.0.0.1:56121).
+ * `device`  — device-code flow for SSH / headless hosts.
+ * `logout`  — clears stored xAI OAuth credentials.
+ * `status`  — prints whether credentials are stored and whose account.
+ */
+
+import {
+  pollXaiDeviceCode,
+  requestXaiDeviceCode,
+  XaiOAuthService,
+} from '../../services/api/xaiOAuth.js'
+import { openBrowser } from '../../utils/browser.js'
+import {
+  clearXaiCredentials,
+  persistXaiOAuthTokens,
+  readXaiCredentialsAsync,
+} from '../../utils/xaiCredentials.js'
+import { isBareMode } from '../../utils/envUtils.js'
+
+export type XaiLoginFlow = 'browser' | 'device-code'
+
+export async function xaiLogin(options: {
+  flow: XaiLoginFlow
+}): Promise<void> {
+  if (isBareMode()) {
+    process.stderr.write(
+      'xAI OAuth is unavailable in --bare mode (secure storage is disabled).\n',
+    )
+    process.exitCode = 1
+    return
+  }
+
+  if (options.flow === 'browser') {
+    await runBrowserFlow()
+  } else {
+    await runDeviceCodeFlow()
+  }
+}
+
+async function runBrowserFlow(): Promise<void> {
+  const service = new XaiOAuthService()
+  let cleanupStdin: (() => void) | null = null
+  try {
+    process.stderr.write('Starting xAI OAuth (browser sign-in)…\n')
+    const handle = await service.beginOAuthFlow()
+
+    process.stderr.write(
+      `\nIf the browser does not open, visit:\n${handle.authUrl}\n\n`,
+    )
+    const opened = await openBrowser(handle.authUrl)
+    if (!opened) {
+      process.stderr.write(
+        'Could not open a browser automatically. Open the URL above manually.\n',
+      )
+    }
+
+    process.stderr.write(
+      'If xAI shows "Could not establish connection" (CORS/firewall), copy\n' +
+        'the code shown on that page and paste it here, then press Enter.\n' +
+        '(Otherwise just wait — the browser will redirect automatically.)\n\n' +
+        'Code> ',
+    )
+
+    cleanupStdin = listenForManualCode(code => handle.submitManualCode(code))
+    const tokens = await handle.waitForTokens()
+    cleanupStdin?.()
+    cleanupStdin = null
+
+    const saved = persistXaiOAuthTokens(tokens)
+    if (!saved.success) {
+      process.stderr.write(
+        `xAI login succeeded, but credentials could not be saved: ${saved.warning ?? 'unknown error'}\n`,
+      )
+      process.exitCode = 1
+      return
+    }
+    process.stderr.write(
+      `\nxAI login complete${tokens.email ? ` (${tokens.email})` : ''}.\n`,
+    )
+  } catch (error) {
+    process.stderr.write(
+      `\nxAI OAuth failed: ${error instanceof Error ? error.message : String(error)}\n`,
+    )
+    process.exitCode = 1
+  } finally {
+    cleanupStdin?.()
+  }
+}
+
+/**
+ * Read one line of stdin, trim, hand to `onLine`. Used as a recovery path
+ * when xAI's loopback push fails — the user can paste the authorization
+ * code from xAI's auth page directly into the terminal.
+ */
+function listenForManualCode(onLine: (line: string) => void): () => void {
+  const stdin = process.stdin
+  let buffer = ''
+  let active = true
+
+  const onData = (chunk: Buffer | string): void => {
+    if (!active) return
+    buffer += typeof chunk === 'string' ? chunk : chunk.toString('utf8')
+    const newlineIdx = buffer.indexOf('\n')
+    if (newlineIdx === -1) return
+    const line = buffer.slice(0, newlineIdx).replace(/\r$/, '').trim()
+    buffer = buffer.slice(newlineIdx + 1)
+    if (line.length > 0) {
+      onLine(line)
+    }
+  }
+
+  stdin.on('data', onData)
+  // resume() in case some other code paused stdin; idempotent.
+  if (typeof stdin.resume === 'function') stdin.resume()
+
+  return () => {
+    if (!active) return
+    active = false
+    stdin.removeListener('data', onData)
+  }
+}
+
+async function runDeviceCodeFlow(): Promise<void> {
+  try {
+    process.stderr.write('Starting xAI device-code login…\n')
+    const { code, tokenEndpoint } = await requestXaiDeviceCode()
+    const url = code.verificationUriComplete ?? code.verificationUri
+    process.stderr.write(
+      `\nOpen this URL in a browser and enter the code below:\n${url}\nCode: ${code.userCode}\n\n`,
+    )
+    if (!code.verificationUriComplete) {
+      process.stderr.write(
+        `(If the URL above does not pre-fill the code, paste it manually.)\n\n`,
+      )
+    } else {
+      await openBrowser(url).catch(() => false)
+    }
+    const tokens = await pollXaiDeviceCode({
+      deviceCode: code,
+      tokenEndpoint,
+    })
+    const saved = persistXaiOAuthTokens(tokens)
+    if (!saved.success) {
+      process.stderr.write(
+        `xAI device login succeeded, but credentials could not be saved: ${saved.warning ?? 'unknown error'}\n`,
+      )
+      process.exitCode = 1
+      return
+    }
+    process.stderr.write(
+      `xAI device-code login complete${tokens.email ? ` (${tokens.email})` : ''}.\n`,
+    )
+  } catch (error) {
+    process.stderr.write(
+      `xAI device-code login failed: ${error instanceof Error ? error.message : String(error)}\n`,
+    )
+    process.exitCode = 1
+  }
+}
+
+export async function xaiLogout(): Promise<void> {
+  const result = clearXaiCredentials()
+  if (!result.success) {
+    process.stderr.write(
+      `Could not clear xAI credentials: ${result.warning ?? 'unknown error'}\n`,
+    )
+    process.exitCode = 1
+    return
+  }
+  process.stderr.write('xAI OAuth credentials cleared.\n')
+}
+
+export async function xaiStatus(): Promise<void> {
+  const blob = await readXaiCredentialsAsync()
+  if (!blob) {
+    process.stderr.write('xAI: no OAuth credentials stored.\n')
+    return
+  }
+  const identity =
+    blob.email ?? blob.displayName ?? blob.accountId ?? 'unknown account'
+  const expiresStr =
+    blob.expiresAt && Number.isFinite(blob.expiresAt)
+      ? new Date(blob.expiresAt).toISOString()
+      : 'unknown'
+  process.stderr.write(
+    `xAI: signed in as ${identity}\n  token expires: ${expiresStr}\n`,
+  )
+}

--- a/src/components/ProviderManager.test.tsx
+++ b/src/components/ProviderManager.test.tsx
@@ -117,6 +117,7 @@ const PRESET_ORDER = [
   'Bankr',
   'DeepSeek',
   'Codex OAuth',
+  'xAI OAuth (Grok)',
   'Google Gemini',
   'Groq',
   'Hicap',

--- a/src/components/ProviderManager.tsx
+++ b/src/components/ProviderManager.tsx
@@ -585,6 +585,11 @@ function XaiManualCodeInput({
           if (trimmed) onSubmit(trimmed)
         }}
         mask="*"
+        // The parent `XaiOAuthSetup` owns Esc via `useKeybinding('confirm:no')`.
+        // Without this flag, BaseTextInput's child-effect Esc handler runs
+        // before the parent keybinding, triggering the "press Esc again to
+        // clear" double-press flow and swallowing the cancel.
+        disableEscapeDoublePress
       />
     </Box>
   )

--- a/src/components/ProviderManager.tsx
+++ b/src/components/ProviderManager.tsx
@@ -19,9 +19,15 @@ import { getPrimaryModel, hasMultipleModels, parseModelList } from '../utils/pro
 import {
   applySavedProfileToCurrentSession,
   buildCodexOAuthProfileEnv,
+  buildXaiOAuthProfileEnv,
   clearPersistedCodexOAuthProfile,
+  clearPersistedXaiOAuthProfile,
   createProfileFile,
 } from '../utils/providerProfile.js'
+import {
+  clearXaiCredentials,
+  readXaiCredentialsAsync,
+} from '../utils/xaiCredentials.js'
 import {
   getProviderPresetUiMetadata,
   getRouteProviderTypeLabel,
@@ -75,6 +81,7 @@ import {
 import { Pane } from './design-system/Pane.js'
 import TextInput from './TextInput.js'
 import { useCodexOAuthFlow } from './useCodexOAuthFlow.js'
+import { useXaiOAuthFlow } from './useXaiOAuthFlow.js'
 
 export type ProviderManagerResult = {
   action: 'saved' | 'cancelled' | 'activated'
@@ -95,6 +102,7 @@ type Screen =
   | 'select-ollama-model'
   | 'select-atomic-chat-model'
   | 'codex-oauth'
+  | 'xai-oauth'
   | 'form'
   | 'preset-model'
   | 'preset-api-key'
@@ -202,6 +210,9 @@ const GITHUB_PROVIDER_DEFAULT_MODEL = 'github:copilot'
 const GITHUB_PROVIDER_DEFAULT_BASE_URL = 'https://models.github.ai/inference'
 const CODEX_OAUTH_PROVIDER_NAME = 'Codex OAuth'
 const CODEX_OAUTH_PROVIDER_MODEL = 'codexplan'
+const XAI_OAUTH_PROVIDER_NAME = 'xAI OAuth'
+const XAI_OAUTH_PROVIDER_MODEL = 'grok-4.3'
+const XAI_OAUTH_PROVIDER_BASE_URL = 'https://api.x.ai/v1'
 
 type GithubCredentialSource = 'stored' | 'env' | 'none'
 
@@ -430,6 +441,155 @@ function isCodexOAuthProfile(
   return Boolean(profile && profileId && profile.id === profileId)
 }
 
+function findXaiOAuthProfile(
+  profiles: ProviderProfile[],
+  profileId?: string,
+): ProviderProfile | undefined {
+  if (!profileId) return undefined
+  return profiles.find(profile => profile.id === profileId)
+}
+
+function isXaiOAuthProfile(
+  profile: ProviderProfile | null | undefined,
+  profileId?: string,
+): boolean {
+  return Boolean(profile && profileId && profile.id === profileId)
+}
+
+function XaiOAuthSetup({
+  onBack,
+  onConfigured,
+}: {
+  onBack: () => void
+  onConfigured: (
+    tokens: {
+      accessToken: string
+      refreshToken: string
+      idToken?: string
+      accountId?: string
+      email?: string
+      displayName?: string
+      tokenEndpoint: string
+      expiresAt?: number
+    },
+    persistCredentials: () => void,
+  ) => void | Promise<void>
+}): React.ReactNode {
+  const handleAuthenticated = React.useCallback(
+    async (tokens: Parameters<typeof onConfigured>[0], persist: () => void) => {
+      await onConfigured(tokens, persist)
+    },
+    [onConfigured],
+  )
+  useKeybinding('confirm:no', onBack)
+
+  const status = useXaiOAuthFlow({
+    onAuthenticated: handleAuthenticated,
+  })
+
+  if (status.state === 'error') {
+    return (
+      <Box flexDirection="column" gap={1}>
+        <Text color="error" bold>
+          xAI OAuth failed
+        </Text>
+        <Text>{status.message}</Text>
+        <Text dimColor>Press Enter or Esc to go back.</Text>
+        <Select
+          options={[
+            {
+              value: 'back',
+              label: 'Back',
+              description: 'Return to provider presets',
+            },
+          ]}
+          onChange={onBack}
+          onCancel={onBack}
+          visibleOptionCount={1}
+        />
+      </Box>
+    )
+  }
+
+  return (
+    <Box flexDirection="column" gap={1}>
+      <Text color="remember" bold>
+        xAI OAuth (Grok)
+      </Text>
+      <Text>
+        Sign in with your xAI account in the browser. OpenClaude will store
+        the resulting OAuth credentials securely and switch this session to
+        Grok when setup completes.
+      </Text>
+      <Text dimColor>
+        The xAI consent screen may label the app "Grok Build" — that's
+        expected. OpenClaude uses xAI's shared OAuth client.
+      </Text>
+      {status.state === 'starting' ? (
+        <Text dimColor>
+          Starting local callback on 127.0.0.1:56121 and preparing your
+          browser…
+        </Text>
+      ) : status.browserOpened === false ? (
+        <>
+          <Text color="warning">
+            Browser did not open automatically. Visit this URL to continue:
+          </Text>
+          <Text>{status.authUrl}</Text>
+        </>
+      ) : status.browserOpened === true ? (
+        <>
+          <Text dimColor>
+            Browser opened. Finish the xAI sign-in there and this setup will
+            complete automatically.
+          </Text>
+          <Text>{status.authUrl}</Text>
+        </>
+      ) : (
+        <Text dimColor>Opening your browser…</Text>
+      )}
+      {status.state === 'waiting' ? (
+        <>
+          <Text dimColor>
+            If xAI shows "Could not establish connection", paste the code
+            below and press Enter:
+          </Text>
+          <XaiManualCodeInput onSubmit={status.submitManualCode} />
+        </>
+      ) : null}
+      <Text dimColor>Press Esc to cancel and go back.</Text>
+    </Box>
+  )
+}
+
+function XaiManualCodeInput({
+  onSubmit,
+}: {
+  onSubmit: (code: string) => void
+}): React.ReactNode {
+  const [value, setValue] = React.useState('')
+  const [cursorOffset, setCursorOffset] = React.useState(0)
+  const { columns: terminalColumns } = useTerminalSize()
+  const inputColumns = Math.max(20, Math.min(80, terminalColumns - 8))
+  return (
+    <Box>
+      <Text>Code › </Text>
+      <TextInput
+        value={value}
+        onChange={setValue}
+        cursorOffset={cursorOffset}
+        onChangeCursorOffset={setCursorOffset}
+        columns={inputColumns}
+        onSubmit={submitted => {
+          const trimmed = submitted.trim()
+          if (trimmed) onSubmit(trimmed)
+        }}
+        mask="*"
+      />
+    </Box>
+  )
+}
+
 function CodexOAuthSetup({
   onBack,
   onConfigured,
@@ -562,6 +722,11 @@ export function ProviderManager({ mode, onDone }: Props): React.ReactNode {
     React.useState(false)
   const [storedCodexOAuthProfileId, setStoredCodexOAuthProfileId] =
     React.useState<string | undefined>()
+  const [hasStoredXaiOAuthCredentials, setHasStoredXaiOAuthCredentials] =
+    React.useState(false)
+  const [storedXaiOAuthProfileId, setStoredXaiOAuthProfileId] =
+    React.useState<string | undefined>()
+  const xaiRefreshEpochRef = React.useRef(0)
   const [ollamaSelection, setOllamaSelection] = React.useState<OllamaSelectionState>({
     state: 'idle',
   })
@@ -662,13 +827,27 @@ export function ProviderManager({ mode, onDone }: Props): React.ReactNode {
             },
           ]
         : []),
+      ...(hasStoredXaiOAuthCredentials
+        ? [
+            {
+              value: 'logout-xai-oauth',
+              label: 'Log out xAI OAuth',
+              description: 'Clear securely stored xAI OAuth credentials',
+            },
+          ]
+        : []),
       {
         value: 'done',
         label: 'Done',
         description: 'Return to chat',
       },
     ],
-    [hasSelectableProviders, hasProfiles, hasStoredCodexOAuthCredentials],
+    [
+      hasSelectableProviders,
+      hasProfiles,
+      hasStoredCodexOAuthCredentials,
+      hasStoredXaiOAuthCredentials,
+    ],
   )
 
   const refreshGithubProviderState = React.useCallback((): void => {
@@ -727,15 +906,49 @@ export function ProviderManager({ mode, onDone }: Props): React.ReactNode {
     })()
   }, [])
 
+  const refreshXaiOAuthCredentialState = React.useCallback((): void => {
+    if (isBareMode()) {
+      xaiRefreshEpochRef.current += 1
+      setHasStoredXaiOAuthCredentials(false)
+      setStoredXaiOAuthProfileId(undefined)
+      return
+    }
+
+    const refreshEpoch = ++xaiRefreshEpochRef.current
+    void (async () => {
+      const credentials = await readXaiCredentialsAsync()
+      if (refreshEpoch !== xaiRefreshEpochRef.current) {
+        return
+      }
+
+      setHasStoredXaiOAuthCredentials(
+        Boolean(credentials?.accessToken && credentials?.refreshToken),
+      )
+      // xAI credentials don't carry a profile id; resolve it by finding the
+      // active OAuth-flavored xAI profile (env marker XAI_CREDENTIAL_SOURCE).
+      const profiles = getProviderProfiles()
+      const oauthProfile = profiles.find(
+        p => p.provider === 'xai' && p.name === XAI_OAUTH_PROVIDER_NAME,
+      )
+      setStoredXaiOAuthProfileId(oauthProfile?.id)
+    })()
+  }, [])
+
   React.useEffect(() => {
     refreshGithubProviderState()
     refreshCodexOAuthCredentialState()
+    refreshXaiOAuthCredentialState()
 
     return () => {
       githubRefreshEpochRef.current += 1
       codexRefreshEpochRef.current += 1
+      xaiRefreshEpochRef.current += 1
     }
-  }, [refreshCodexOAuthCredentialState, refreshGithubProviderState])
+  }, [
+    refreshCodexOAuthCredentialState,
+    refreshGithubProviderState,
+    refreshXaiOAuthCredentialState,
+  ])
 
   React.useEffect(() => {
     if (screen !== 'select-ollama-model') {
@@ -876,6 +1089,33 @@ export function ProviderManager({ mode, onDone }: Props): React.ReactNode {
     return `${options.prefix}. OpenClaude switched to it for this session.`
   }
 
+  function buildXaiOAuthActivationMessage(options: {
+    prefix: string
+    activationWarning: string | null
+    warnings: string[]
+  }): string {
+    if (options.activationWarning) {
+      return `${options.prefix}. Saved for next startup. Warning: ${options.warnings.join('; ')}.`
+    }
+    if (options.warnings.length > 0) {
+      return `${options.prefix}. OpenClaude switched to it for this session with warnings: ${options.warnings.join('; ')}.`
+    }
+    return `${options.prefix}. OpenClaude switched to it for this session.`
+  }
+
+  async function activateXaiOAuthSession(options?: {
+    model?: string
+  }): Promise<string | null> {
+    const stored = await readXaiCredentialsAsync()
+    if (!stored?.accessToken || !stored?.refreshToken) {
+      return 'stored xAI OAuth credentials could not be loaded'
+    }
+    const env = buildXaiOAuthProfileEnv({ model: options?.model })
+    return applySavedProfileToCurrentSession({
+      profileFile: createProfileFile('xai', env),
+    })
+  }
+
   async function activateCodexOAuthSession(tokens?: {
     accessToken: string
     refreshToken?: string
@@ -981,9 +1221,17 @@ export function ProviderManager({ mode, onDone }: Props): React.ReactNode {
         active,
         storedCodexOAuthProfileId,
       )
-      const activationWarning = isActiveCodexOAuth
+      const isActiveXaiOAuth = isXaiOAuthProfile(
+        active,
+        storedXaiOAuthProfileId,
+      )
+      const codexActivationWarning = isActiveCodexOAuth
         ? await activateCodexOAuthSession()
         : null
+      const xaiActivationWarning = isActiveXaiOAuth
+        ? await activateXaiOAuthSession({ model: newModel })
+        : null
+      const activationWarning = codexActivationWarning ?? xaiActivationWarning
 
       refreshProfiles()
       const activationMessage = isActiveCodexOAuth
@@ -997,9 +1245,20 @@ export function ProviderManager({ mode, onDone }: Props): React.ReactNode {
                 : null,
             ].filter((warning): warning is string => Boolean(warning)),
           })
-        : settingsOverrideError
-          ? `Active provider: ${active.name}. Warning: could not clear startup provider override (${settingsOverrideError}).`
-          : `Active provider: ${active.name}`
+        : isActiveXaiOAuth
+          ? buildXaiOAuthActivationMessage({
+              prefix: `Active provider: ${active.name}`,
+              activationWarning,
+              warnings: [
+                activationWarning,
+                settingsOverrideError
+                  ? `could not clear startup provider override (${settingsOverrideError})`
+                  : null,
+              ].filter((warning): warning is string => Boolean(warning)),
+            })
+          : settingsOverrideError
+            ? `Active provider: ${active.name}. Warning: could not clear startup provider override (${settingsOverrideError}).`
+            : `Active provider: ${active.name}`
       setStatusMessage(activationMessage)
       setIsActivating(false)
       onDone({
@@ -1535,6 +1794,7 @@ export function ProviderManager({ mode, onDone }: Props): React.ReactNode {
 
   function renderPresetSelection(): React.ReactNode {
     const canUseCodexOAuth = !isBareMode()
+    const canUseXaiOAuth = !isBareMode()
     const options: OptionWithDescription<string>[] = ORDERED_PROVIDER_PRESETS.map(preset => {
       const metadata = getProviderPresetUiMetadata(preset)
       return {
@@ -1557,6 +1817,17 @@ export function ProviderManager({ mode, onDone }: Props): React.ReactNode {
         ),
         description:
           'Sign in with ChatGPT in your browser and store Codex credentials securely',
+      })
+    }
+
+    if (canUseXaiOAuth) {
+      // Place xAI OAuth directly under Codex OAuth so both browser-sign-in
+      // options group together visually.
+      options.splice(canUseCodexOAuth ? 8 : 7, 0, {
+        value: 'xai-oauth',
+        label: 'xAI OAuth (Grok)',
+        description:
+          'Sign in with your xAI account in the browser and store credentials securely',
       })
     }
 
@@ -1585,6 +1856,10 @@ export function ProviderManager({ mode, onDone }: Props): React.ReactNode {
             }
             if (value === 'codex-oauth') {
               setScreen('codex-oauth')
+              return
+            }
+            if (value === 'xai-oauth') {
+              setScreen('xai-oauth')
               return
             }
             startCreateFromPreset(value as ProviderPreset)
@@ -1915,6 +2190,47 @@ export function ProviderManager({ mode, onDone }: Props): React.ReactNode {
                 )
                 break
               }
+              case 'logout-xai-oauth': {
+                const cleared = clearXaiCredentials()
+                if (!cleared.success) {
+                  setErrorMessage(
+                    cleared.warning ??
+                      'Could not clear xAI OAuth credentials.',
+                  )
+                  break
+                }
+
+                setHasStoredXaiOAuthCredentials(false)
+                setStoredXaiOAuthProfileId(undefined)
+                const xaiProfile = findXaiOAuthProfile(
+                  getProviderProfiles(),
+                  storedXaiOAuthProfileId,
+                )
+                let settingsOverrideError: string | null = null
+                if (xaiProfile) {
+                  const result = deleteProviderProfile(xaiProfile.id)
+                  if (!result.removed) {
+                    setErrorMessage(
+                      'xAI OAuth credentials were cleared, but the xAI profile could not be removed.',
+                    )
+                    refreshProfiles()
+                    break
+                  }
+
+                  clearPersistedXaiOAuthProfile()
+                  settingsOverrideError = result.activeProfileId
+                    ? clearStartupProviderOverrideFromUserSettings()
+                    : null
+                }
+
+                refreshProfiles()
+                setStatusMessage(
+                  settingsOverrideError
+                    ? `xAI OAuth logged out. Warning: could not clear startup provider override (${settingsOverrideError}).`
+                    : 'xAI OAuth logged out.',
+                )
+                break
+              }
               default:
                 closeWithCancelled('Provider manager closed')
                 break
@@ -2003,6 +2319,85 @@ export function ProviderManager({ mode, onDone }: Props): React.ReactNode {
       break
     case 'select-atomic-chat-model':
       content = renderAtomicChatSelection()
+      break
+    case 'xai-oauth':
+      content = (
+        <XaiOAuthSetup
+          onBack={() => setScreen('select-preset')}
+          onConfigured={async (tokens, persistCredentials) => {
+            const payload: ProviderProfileInput = {
+              provider: 'xai',
+              name: XAI_OAUTH_PROVIDER_NAME,
+              baseUrl: XAI_OAUTH_PROVIDER_BASE_URL,
+              model: XAI_OAUTH_PROVIDER_MODEL,
+              apiKey: '',
+            }
+
+            const existing = findXaiOAuthProfile(
+              getProviderProfiles(),
+              storedXaiOAuthProfileId,
+            )
+            const saved = existing
+              ? updateProviderProfile(existing.id, payload)
+              : addProviderProfile(payload, { makeActive: false })
+
+            if (!saved) {
+              setErrorMessage(
+                'xAI OAuth login finished, but the provider profile could not be saved.',
+              )
+              returnToMenu()
+              return
+            }
+
+            const active =
+              activeProfileId === saved.id
+                ? saved
+                : setActiveProviderProfile(saved.id)
+
+            if (!active) {
+              setErrorMessage(
+                'xAI OAuth login finished, but the provider could not be set as the startup provider.',
+              )
+              returnToMenu()
+              return
+            }
+
+            persistCredentials()
+            const settingsOverrideError =
+              clearStartupProviderOverrideFromUserSettings()
+            const activationWarning = await activateXaiOAuthSession({
+              model: saved.model,
+            })
+            setHasStoredXaiOAuthCredentials(true)
+            setStoredXaiOAuthProfileId(saved.id)
+            refreshProfiles()
+            const warnings = [
+              activationWarning,
+              settingsOverrideError
+                ? `could not clear startup provider override (${settingsOverrideError})`
+                : null,
+            ].filter((warning): warning is string => Boolean(warning))
+            const message = buildXaiOAuthActivationMessage({
+              prefix: 'xAI OAuth configured',
+              activationWarning,
+              warnings,
+            })
+
+            if (mode === 'first-run') {
+              onDone({
+                action: 'saved',
+                activeProfileId: active.id,
+                message,
+              })
+              return
+            }
+
+            setStatusMessage(message)
+            setErrorMessage(undefined)
+            returnToMenu()
+          }}
+        />
+      )
       break
     case 'codex-oauth':
       content = (
@@ -2130,6 +2525,11 @@ export function ProviderManager({ mode, onDone }: Props): React.ReactNode {
               profiles,
               storedCodexOAuthProfileId,
             )?.id === profileId
+          const deletedXaiOAuthProfile =
+            findXaiOAuthProfile(
+              profiles,
+              storedXaiOAuthProfileId,
+            )?.id === profileId
           const result = deleteProviderProfile(profileId)
           if (!result.removed) {
             setErrorMessage('Could not delete provider.')
@@ -2145,6 +2545,19 @@ export function ProviderManager({ mode, onDone }: Props): React.ReactNode {
                 setStoredCodexOAuthProfileId(undefined)
               }
               clearPersistedCodexOAuthProfile()
+            }
+            if (deletedXaiOAuthProfile) {
+              const cleared = clearXaiCredentials()
+              if (!cleared.success) {
+                setErrorMessage(
+                  cleared.warning ??
+                    'Provider deleted, but xAI OAuth credentials could not be cleared.',
+                )
+              } else {
+                setStoredXaiOAuthProfileId(undefined)
+                setHasStoredXaiOAuthCredentials(false)
+              }
+              clearPersistedXaiOAuthProfile()
             }
             const settingsOverrideError = result.activeProfileId
               ? clearStartupProviderOverrideFromUserSettings()

--- a/src/components/ProviderManager.tsx
+++ b/src/components/ProviderManager.tsx
@@ -1797,6 +1797,21 @@ export function ProviderManager({ mode, onDone }: Props): React.ReactNode {
     isActive: screen === 'preset-api-key',
   })
 
+  // xAI OAuth setup renders a TextInput for the manual-code recovery
+  // path, which registers its own useInput listener. The child-component
+  // useKeybinding inside XaiOAuthSetup ends up racing the input handler
+  // and can lose. Register Esc at the top level — same pattern that
+  // makes Esc work on preset-api-key (which also has a TextInput).
+  function handleBackFromXaiOAuth(): void {
+    setErrorMessage(undefined)
+    setScreen('select-preset')
+  }
+
+  useKeybinding('confirm:no', handleBackFromXaiOAuth, {
+    context: 'Settings',
+    isActive: screen === 'xai-oauth',
+  })
+
   function renderPresetSelection(): React.ReactNode {
     const canUseCodexOAuth = !isBareMode()
     const canUseXaiOAuth = !isBareMode()

--- a/src/components/ProviderManager.tsx
+++ b/src/components/ProviderManager.tsx
@@ -2388,6 +2388,16 @@ export function ProviderManager({ mode, onDone }: Props): React.ReactNode {
             const activationWarning = await activateXaiOAuthSession({
               model: saved.model,
             })
+            // Update the running session's model — otherwise the next
+            // request keeps hitting the previous provider's model name
+            // (e.g. kimi-k2.6) and gets a 400 "Model not found" against
+            // api.x.ai. Mirrors the activateSelectedProvider /
+            // saveAndCloseProvider flows.
+            setAppState(prev => ({
+              ...prev,
+              mainLoopModel: getPrimaryModel(saved.model),
+              mainLoopModelForSession: null,
+            }))
             setHasStoredXaiOAuthCredentials(true)
             setStoredXaiOAuthProfileId(saved.id)
             refreshProfiles()

--- a/src/components/useXaiOAuthFlow.test.tsx
+++ b/src/components/useXaiOAuthFlow.test.tsx
@@ -1,0 +1,166 @@
+import { PassThrough } from 'node:stream'
+
+import { afterEach, beforeEach, expect, test } from 'bun:test'
+import React from 'react'
+
+import { createRoot, Text } from '../ink.js'
+import {
+  acquireSharedMutationLock,
+  releaseSharedMutationLock,
+} from '../test/sharedMutationLock.js'
+import type {
+  XaiOAuthFlowHandle,
+  XaiOAuthService,
+} from '../services/api/xaiOAuth.js'
+import { useXaiOAuthFlow } from './useXaiOAuthFlow.js'
+
+function createTestStreams(): {
+  stdout: PassThrough
+  stdin: PassThrough & {
+    isTTY: boolean
+    setRawMode: (mode: boolean) => void
+    ref: () => void
+    unref: () => void
+  }
+} {
+  const stdout = new PassThrough()
+  const stdin = new PassThrough() as PassThrough & {
+    isTTY: boolean
+    setRawMode: (mode: boolean) => void
+    ref: () => void
+    unref: () => void
+  }
+  stdin.isTTY = true
+  stdin.setRawMode = () => {}
+  stdin.ref = () => {}
+  stdin.unref = () => {}
+  ;(stdout as unknown as { columns: number }).columns = 120
+  return { stdout, stdin }
+}
+
+beforeEach(async () => {
+  await acquireSharedMutationLock('components/useXaiOAuthFlow.test.tsx')
+})
+
+afterEach(() => {
+  releaseSharedMutationLock()
+})
+
+// Probe component — just exercises the hook. We never read its output;
+// we assert on the service mock's call sequence.
+function HookProbe({
+  service,
+}: {
+  service: Pick<XaiOAuthService, 'beginOAuthFlow' | 'cleanup'>
+}) {
+  // Memoize so the hook's useEffect doesn't re-fire on every render —
+  // setStatus inside the hook triggers re-renders, and fresh deps each
+  // render would loop infinitely (and inflate the cancel counter).
+  const onAuthenticated = React.useCallback(async () => {
+    /* never reached in these tests */
+  }, [])
+  const deps = React.useMemo(
+    () => ({
+      createOAuthService: () => service,
+      openBrowser: async () => true,
+      isBareMode: () => false,
+      persistXaiOAuthTokens: () => ({ success: true }),
+    }),
+    [service],
+  )
+  useXaiOAuthFlow({ onAuthenticated, deps })
+  return React.createElement(Text, null, 'probe')
+}
+
+function deferredHandle(): {
+  resolveBegin: (handle: XaiOAuthFlowHandle) => void
+  rejectBegin: (error: Error) => void
+  beginPromise: Promise<XaiOAuthFlowHandle>
+  handleCancelCount: () => number
+  serviceCleanupCount: () => number
+  makeHandle: () => XaiOAuthFlowHandle
+  service: Pick<XaiOAuthService, 'beginOAuthFlow' | 'cleanup'>
+} {
+  let cancelCount = 0
+  let cleanupCount = 0
+  let resolveBegin!: (handle: XaiOAuthFlowHandle) => void
+  let rejectBegin!: (error: Error) => void
+  const beginPromise = new Promise<XaiOAuthFlowHandle>((resolve, reject) => {
+    resolveBegin = resolve
+    rejectBegin = reject
+  })
+  const makeHandle = (): XaiOAuthFlowHandle => ({
+    authUrl: 'https://auth.x.ai/oauth2/authorize?stub=1',
+    waitForTokens: () => new Promise(() => undefined), // never resolves
+    submitManualCode: () => undefined,
+    cancel: () => {
+      cancelCount++
+    },
+  })
+  const service = {
+    beginOAuthFlow: () => beginPromise,
+    cleanup: () => {
+      cleanupCount++
+    },
+  }
+  return {
+    resolveBegin,
+    rejectBegin,
+    beginPromise,
+    handleCancelCount: () => cancelCount,
+    serviceCleanupCount: () => cleanupCount,
+    makeHandle,
+    service,
+  }
+}
+
+// P2 regression: if the user presses Esc / unmounts the React tree
+// while `beginOAuthFlow()` is still awaiting discovery or starting the
+// loopback server, cleanup runs before the service has a callback
+// handle. Then beginOAuthFlow() resolves and the freshly-started
+// loopback server stays open — next attempt fails with EADDRINUSE on
+// the fixed 56121 port.
+test('cancellation mid-start cancels the handle once beginOAuthFlow resolves', async () => {
+  const d = deferredHandle()
+  const { stdout, stdin } = createTestStreams()
+  const root = await createRoot({
+    stdout: stdout as unknown as NodeJS.WriteStream,
+    stdin: stdin as unknown as NodeJS.ReadStream,
+    patchConsole: false,
+  })
+  root.render(React.createElement(HookProbe, { service: d.service }))
+
+  // Unmount while beginOAuthFlow is still pending — simulates Esc /
+  // component unmount during the discovery+listen phase.
+  await Bun.sleep(10)
+  expect(d.handleCancelCount()).toBe(0)
+  root.unmount()
+  expect(d.serviceCleanupCount()).toBeGreaterThanOrEqual(1)
+
+  // Now resolve beginOAuthFlow — the IIFE inside the hook should see
+  // `cancelled === true` and close the handle.
+  d.resolveBegin(d.makeHandle())
+  await Bun.sleep(20)
+  expect(d.handleCancelCount()).toBe(1)
+})
+
+test('handle cancel also fires when unmount happens after handle exists', async () => {
+  const d = deferredHandle()
+  const { stdout, stdin } = createTestStreams()
+  const root = await createRoot({
+    stdout: stdout as unknown as NodeJS.WriteStream,
+    stdin: stdin as unknown as NodeJS.ReadStream,
+    patchConsole: false,
+  })
+  root.render(React.createElement(HookProbe, { service: d.service }))
+
+  // Let beginOAuthFlow resolve first.
+  d.resolveBegin(d.makeHandle())
+  await Bun.sleep(20)
+  expect(d.handleCancelCount()).toBe(0)
+
+  // Now unmount. The cleanup function should close the handle that's
+  // already tracked in activeHandle.
+  root.unmount()
+  expect(d.handleCancelCount()).toBe(1)
+})

--- a/src/components/useXaiOAuthFlow.ts
+++ b/src/components/useXaiOAuthFlow.ts
@@ -1,0 +1,131 @@
+import * as React from 'react'
+
+import {
+  XaiOAuthService,
+  type XaiOAuthFlowHandle,
+  type XaiOAuthTokens,
+} from '../services/api/xaiOAuth.js'
+import { openBrowser } from '../utils/browser.js'
+import { isBareMode } from '../utils/envUtils.js'
+import { persistXaiOAuthTokens } from '../utils/xaiCredentials.js'
+
+export type XaiOAuthFlowStatus =
+  | { state: 'starting' }
+  | {
+      state: 'waiting'
+      authUrl: string
+      browserOpened: boolean | null
+      submitManualCode: (code: string) => void
+    }
+  | {
+      state: 'error'
+      message: string
+    }
+
+type XaiPersistFn = () => void
+
+type XaiOAuthServiceLike = Pick<
+  XaiOAuthService,
+  'beginOAuthFlow' | 'cleanup'
+>
+
+type XaiOAuthFlowDependencies = {
+  createOAuthService?: () => XaiOAuthServiceLike
+  openBrowser?: typeof openBrowser
+  persistXaiOAuthTokens?: typeof persistXaiOAuthTokens
+  isBareMode?: typeof isBareMode
+}
+
+function createDefaultOAuthService(): XaiOAuthServiceLike {
+  return new XaiOAuthService()
+}
+
+export function useXaiOAuthFlow(options: {
+  onAuthenticated: (
+    tokens: XaiOAuthTokens,
+    persistCredentials: XaiPersistFn,
+  ) => void | Promise<void>
+  deps?: XaiOAuthFlowDependencies
+}): XaiOAuthFlowStatus {
+  const { onAuthenticated } = options
+  const createOAuthService =
+    options.deps?.createOAuthService ?? createDefaultOAuthService
+  const openBrowserFn = options.deps?.openBrowser ?? openBrowser
+  const persistFn =
+    options.deps?.persistXaiOAuthTokens ?? persistXaiOAuthTokens
+  const isBareModeFn = options.deps?.isBareMode ?? isBareMode
+  const [status, setStatus] = React.useState<XaiOAuthFlowStatus>({
+    state: 'starting',
+  })
+
+  React.useEffect(() => {
+    if (isBareModeFn()) {
+      setStatus({
+        state: 'error',
+        message:
+          'xAI OAuth is unavailable in --bare because secure storage is disabled.',
+      })
+      return
+    }
+
+    let cancelled = false
+    const oauthService = createOAuthService()
+
+    void (async () => {
+      let handle: XaiOAuthFlowHandle | null = null
+      try {
+        handle = await oauthService.beginOAuthFlow()
+        if (cancelled) return
+
+        setStatus({
+          state: 'waiting',
+          authUrl: handle.authUrl,
+          browserOpened: null,
+          submitManualCode: handle.submitManualCode,
+        })
+        const browserOpened = await openBrowserFn(handle.authUrl)
+        if (cancelled) return
+        setStatus({
+          state: 'waiting',
+          authUrl: handle.authUrl,
+          browserOpened,
+          submitManualCode: handle.submitManualCode,
+        })
+
+        const tokens = await handle.waitForTokens()
+        if (cancelled) return
+
+        const persistCredentials: XaiPersistFn = () => {
+          const saved = persistFn(tokens)
+          if (!saved.success) {
+            throw new Error(
+              saved.warning ??
+                'xAI OAuth succeeded, but credentials could not be saved securely.',
+            )
+          }
+        }
+
+        await onAuthenticated(tokens, persistCredentials)
+      } catch (error) {
+        if (cancelled) return
+        setStatus({
+          state: 'error',
+          message: error instanceof Error ? error.message : String(error),
+        })
+      }
+    })()
+
+    return () => {
+      cancelled = true
+      oauthService.cleanup()
+    }
+  }, [
+    createOAuthService,
+    isBareModeFn,
+    onAuthenticated,
+    openBrowserFn,
+    persistFn,
+  ])
+
+  return status
+}

--- a/src/components/useXaiOAuthFlow.ts
+++ b/src/components/useXaiOAuthFlow.ts
@@ -69,13 +69,24 @@ export function useXaiOAuthFlow(options: {
     }
 
     let cancelled = false
+    // Tracked so the cleanup function can close a callback server that
+    // beginOAuthFlow() may have started while cleanup was running.
+    // Without this, pressing Esc during discovery / port binding leaves
+    // the loopback server bound on the fixed port (56121), and the next
+    // OAuth attempt fails with EADDRINUSE.
+    let activeHandle: XaiOAuthFlowHandle | null = null
     const oauthService = createOAuthService()
 
     void (async () => {
-      let handle: XaiOAuthFlowHandle | null = null
       try {
-        handle = await oauthService.beginOAuthFlow()
-        if (cancelled) return
+        const handle = await oauthService.beginOAuthFlow()
+        activeHandle = handle
+        if (cancelled) {
+          // Cleanup already ran; the service hadn't tracked the handle
+          // yet, so service.cleanup() was a no-op. Close it now.
+          handle.cancel()
+          return
+        }
 
         setStatus({
           state: 'waiting',
@@ -117,6 +128,11 @@ export function useXaiOAuthFlow(options: {
 
     return () => {
       cancelled = true
+      // Close the handle if beginOAuthFlow() finished AFTER cleanup ran
+      // — the IIFE's `if (cancelled) handle.cancel()` covers this too,
+      // but calling here as well is idempotent and gives us the close
+      // path for the common "handle exists by unmount" case.
+      activeHandle?.cancel()
       oauthService.cleanup()
     }
   }, [

--- a/src/integrations/descriptors.ts
+++ b/src/integrations/descriptors.ts
@@ -202,6 +202,20 @@ export type ValidationMetadata =
       expiredCredentialMessage: string
       invalidCredentialMessage: string
     }
+  // xAI accepts either an API key (XAI_API_KEY) or stored OAuth
+  // credentials (browser/device-code login). Validation passes when any of
+  // the following hold:
+  //   1. one of `credentialEnvVars` is non-empty in env
+  //   2. one of `credentialSourceEnvMarkers` matches in env (e.g.
+  //      XAI_CREDENTIAL_SOURCE=oauth, set by the OAuth profile)
+  //   3. stored OAuth credentials exist (resolved async via the runtime)
+  | {
+      routing?: ValidationRoutingMetadata
+      kind: 'xai-credential'
+      credentialEnvVars: string[]
+      credentialSourceEnvMarkers?: Record<string, string[]>
+      missingCredentialMessage: string
+    }
 
 export interface VendorDescriptor {
   id: string

--- a/src/integrations/models/xai.ts
+++ b/src/integrations/models/xai.ts
@@ -33,6 +33,20 @@ export default [
     maxOutputTokens: 32_768,
   }),
   defineModel({
+    id: 'grok-code-fast-1',
+    label: 'Grok Code Fast 1',
+    brandId: 'xai',
+    vendorId: 'xai',
+    classification: ['chat', 'reasoning', 'coding'],
+    defaultModel: 'grok-code-fast-1',
+    capabilities: {
+      ...grokCapabilities,
+      supportsVision: false,
+    },
+    contextWindow: 256_000,
+    maxOutputTokens: 64_000,
+  }),
+  defineModel({
     id: 'grok-3',
     label: 'Grok 3',
     brandId: 'xai',

--- a/src/integrations/vendors/xai.ts
+++ b/src/integrations/vendors/xai.ts
@@ -29,7 +29,7 @@ export default defineVendor({
     },
     credentialEnvVars: ['XAI_API_KEY'],
     missingCredentialMessage:
-      'XAI_API_KEY is required for the xAI provider.',
+      'XAI_API_KEY is required, or sign in with `openclaude auth xai login` (browser OAuth) or `openclaude auth xai device` (remote hosts).',
   },
   catalog: {
     source: 'static',
@@ -45,6 +45,12 @@ export default defineVendor({
         apiName: 'grok-4',
         label: 'Grok 4',
         modelDescriptorId: 'grok-4',
+      },
+      {
+        id: 'grok-code-fast-1',
+        apiName: 'grok-code-fast-1',
+        label: 'Grok Code Fast 1',
+        modelDescriptorId: 'grok-code-fast-1',
       },
       {
         id: 'grok-3',

--- a/src/integrations/vendors/xai.ts
+++ b/src/integrations/vendors/xai.ts
@@ -22,12 +22,17 @@ export default defineVendor({
     modelEnvVars: ['OPENAI_MODEL'],
   },
   validation: {
-    kind: 'credential-env',
+    kind: 'xai-credential',
     routing: {
       matchDefaultBaseUrl: true,
       matchBaseUrlHosts: ['api.x.ai'],
     },
     credentialEnvVars: ['XAI_API_KEY'],
+    // Saved OAuth profiles tag their env with this marker so validation
+    // passes without re-reading secure storage.
+    credentialSourceEnvMarkers: {
+      XAI_CREDENTIAL_SOURCE: ['oauth'],
+    },
     missingCredentialMessage:
       'XAI_API_KEY is required, or sign in with `openclaude auth xai login` (browser OAuth) or `openclaude auth xai device` (remote hosts).',
   },

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -4129,6 +4129,24 @@ async function run(): Promise<CommanderCommand> {
     await authLogout();
   });
 
+  const xaiAuth = auth.command('xai').description('Sign in to xAI (Grok) with browser OAuth or device code').configureHelp(createSortedHelpConfig());
+  xaiAuth.command('login').description('Browser OAuth sign-in for an xAI account').action(async () => {
+    const { xaiLogin } = await import('./cli/handlers/xaiAuth.js');
+    await xaiLogin({ flow: 'browser' });
+  });
+  xaiAuth.command('device').description('Device-code sign-in for remote hosts (no localhost callback needed)').action(async () => {
+    const { xaiLogin } = await import('./cli/handlers/xaiAuth.js');
+    await xaiLogin({ flow: 'device-code' });
+  });
+  xaiAuth.command('logout').description('Clear stored xAI OAuth credentials').action(async () => {
+    const { xaiLogout } = await import('./cli/handlers/xaiAuth.js');
+    await xaiLogout();
+  });
+  xaiAuth.command('status').description('Show xAI OAuth credential status').action(async () => {
+    const { xaiStatus } = await import('./cli/handlers/xaiAuth.js');
+    await xaiStatus();
+  });
+
   /**
    * Helper function to handle marketplace command errors consistently.
    * Logs the error and exits the process with status 1.

--- a/src/services/api/client.test.ts
+++ b/src/services/api/client.test.ts
@@ -637,6 +637,10 @@ test('routes env-only xAI requests through the OpenAI-compatible shim', async ()
 
   expect(capturedUrl).toBe('https://api.x.ai/v1/chat/completions')
   expect(capturedHeaders?.get('authorization')).toBe('Bearer xai-test-key')
+  // xAI prompt caching: x-grok-conv-id pins the session to one backend so the
+  // cached system prompt and conversation history can be reused. Mirrors the
+  // Hermes implementation (RELEASE_v0.8.0 PR #5604).
+  expect(capturedHeaders?.get('x-grok-conv-id')).toBeTruthy()
   expect(capturedBody?.model).toBe('grok-4')
   expect(response).toMatchObject({
     role: 'assistant',

--- a/src/services/api/openaiShim.ts
+++ b/src/services/api/openaiShim.ts
@@ -35,8 +35,13 @@ import { isBareMode, isEnvTruthy } from '../../utils/envUtils.js'
 import { resolveGeminiCredential } from '../../utils/geminiAuth.js'
 import { hydrateGeminiAccessTokenFromSecureStorage } from '../../utils/geminiCredentials.js'
 import { hydrateGithubModelsTokenFromSecureStorage } from '../../utils/githubModelsCredentials.js'
+import { resolveXaiAccessToken } from '../../utils/xaiCredentials.js'
 import { resolveOpenAIShimRuntimeContext } from '../../integrations/runtimeMetadata.js'
-import { resolveRouteCredentialValue } from '../../integrations/routeMetadata.js'
+import {
+  isXaiBaseUrl,
+  resolveRouteCredentialValue,
+} from '../../integrations/routeMetadata.js'
+import { getSessionId } from '../../bootstrap/state.js'
 import {
   createThinkTagFilter,
   stripThinkTags,
@@ -1976,10 +1981,23 @@ class OpenAIShimMessages {
       baseUrl: request.baseUrl,
       processEnv: process.env,
     })
+    // xAI OAuth: when the active route is xAI and no API key is set, fall
+    // back to a stored OAuth access token (auto-refreshed). The token is
+    // sent as a Bearer to api.x.ai/v1 — same surface as an API key.
+    const isXaiRoute =
+      runtimeShimContext.routeId === 'xai' || isXaiBaseUrl(request.baseUrl)
+    const xaiOAuthToken =
+      isXaiRoute &&
+      !this.providerOverride?.apiKey &&
+      !routeCredential &&
+      !process.env.OPENAI_API_KEY
+        ? await resolveXaiAccessToken()
+        : undefined
     const apiKey =
       this.providerOverride?.apiKey ??
       routeCredential ??
       process.env.OPENAI_API_KEY ??
+      xaiOAuthToken ??
       ''
     const configuredAuthHeaderValue = process.env.OPENAI_AUTH_HEADER_VALUE?.trim()
     const customAuthHeader = process.env.OPENAI_AUTH_HEADER?.trim()
@@ -2048,6 +2066,14 @@ class OpenAIShimMessages {
     } else if (isGithubModels) {
       headers['Accept'] = 'application/vnd.github+json'
       headers['X-GitHub-Api-Version'] = '2022-11-28'
+    }
+
+    // xAI / Grok prompt caching. Pinning the session id via x-grok-conv-id
+    // routes follow-up requests to the same backend so xAI can reuse the
+    // cached system prompt and conversation history. Mirrors the Hermes
+    // implementation (RELEASE_v0.8.0 PR #5604).
+    if (isXaiRoute) {
+      headers['x-grok-conv-id'] ??= getSessionId()
     }
 
     const buildChatCompletionsUrl = (baseUrl: string): string => {

--- a/src/services/api/xaiOAuth.ts
+++ b/src/services/api/xaiOAuth.ts
@@ -1,0 +1,630 @@
+/**
+ * xAI OAuth service.
+ *
+ * Two flows supported, mirroring openclaw's reference implementation:
+ *
+ * 1. Authorization code + PKCE with a loopback redirect on 127.0.0.1:56121.
+ *    Best UX on a developer's own machine.
+ * 2. Device code — for remote/VPS hosts where you can't open a browser.
+ *
+ * After completion the access token is sent as a Bearer to api.x.ai/v1 —
+ * the same code path as `XAI_API_KEY`. The OAuth-issued credential is just
+ * a refreshable substitute for the API key.
+ */
+
+import { randomBytes } from 'node:crypto'
+
+import {
+  generateCodeChallenge,
+  generateCodeVerifier,
+  generateState,
+} from '../oauth/crypto.js'
+import {
+  startXaiOAuthCallback,
+  type XaiOAuthCallbackHandle,
+} from './xaiOAuthCallback.js'
+import {
+  asTrimmedString,
+  deriveExpiresMsFromJwt,
+  fetchXaiOAuthDiscovery,
+  getXaiOAuthCallbackHost,
+  getXaiOAuthCallbackPort,
+  getXaiOAuthClientId,
+  getXaiOAuthRedirectUri,
+  requireTrustedXaiOAuthEndpoint,
+  XAI_DEVICE_CODE_GRANT_TYPE,
+  XAI_OAUTH_CALLBACK_PATH,
+  XAI_OAUTH_REFERRER,
+  XAI_OAUTH_SCOPE,
+} from './xaiOAuthShared.js'
+import { createCombinedAbortSignal } from '../../utils/combinedAbortSignal.js'
+
+const XAI_OAUTH_FETCH_TIMEOUT_MS = 30_000
+const XAI_DEVICE_CODE_DEFAULT_INTERVAL_MS = 5_000
+const XAI_DEVICE_CODE_MIN_INTERVAL_MS = 1_000
+const XAI_DEVICE_CODE_SLOW_DOWN_INCREMENT_MS = 5_000
+
+export type XaiOAuthTokens = {
+  accessToken: string
+  refreshToken: string
+  idToken?: string
+  expiresAt?: number
+  tokenEndpoint: string
+  email?: string
+  displayName?: string
+  accountId?: string
+}
+
+export type XaiDeviceCode = {
+  deviceCode: string
+  userCode: string
+  verificationUri: string
+  verificationUriComplete?: string
+  expiresInMs: number
+  intervalMs: number
+}
+
+type XaiTokenResponse = {
+  access_token?: string
+  refresh_token?: string
+  id_token?: string
+  expires_in?: number | string
+  token_type?: string
+}
+
+type XaiErrorResponse = {
+  error?: string
+  error_description?: string
+}
+
+function readErrorMessage(
+  context: string,
+  status: number,
+  body: unknown,
+): string {
+  const json = (body ?? {}) as XaiErrorResponse
+  const err = asTrimmedString(json.error)
+  const desc = asTrimmedString(json.error_description)
+  if (err && desc) return `${context} failed (${status}): ${err} (${desc})`
+  if (err) return `${context} failed (${status}): ${err}`
+  return `${context} failed (${status})`
+}
+
+async function readJson(response: Response): Promise<unknown> {
+  try {
+    return await response.json()
+  } catch {
+    return null
+  }
+}
+
+function normalizeExpiresAt(
+  expiresIn: unknown,
+  now: number,
+): number | undefined {
+  const seconds =
+    typeof expiresIn === 'number'
+      ? expiresIn
+      : typeof expiresIn === 'string'
+        ? Number.parseFloat(expiresIn)
+        : Number.NaN
+  if (!Number.isFinite(seconds) || seconds <= 0) return undefined
+  return now + seconds * 1000
+}
+
+function decodeJwt(token: string | undefined): Record<string, unknown> {
+  if (!token) return {}
+  const part = token.split('.')[1]
+  if (!part) return {}
+  try {
+    const json = Buffer.from(part, 'base64url').toString('utf8')
+    const parsed = JSON.parse(json)
+    return parsed && typeof parsed === 'object'
+      ? (parsed as Record<string, unknown>)
+      : {}
+  } catch {
+    return {}
+  }
+}
+
+function extractIdentity(tokens: { idToken?: string; accessToken: string }): {
+  email?: string
+  displayName?: string
+  accountId?: string
+} {
+  const payload = decodeJwt(tokens.idToken ?? tokens.accessToken)
+  return {
+    email: asTrimmedString(payload.email),
+    displayName: asTrimmedString(payload.name),
+    accountId: asTrimmedString(payload.sub),
+  }
+}
+
+function parseTokenResponse(
+  body: unknown,
+  tokenEndpoint: string,
+  options: {
+    requireRefreshToken?: boolean
+    previousRefreshToken?: string
+  } = {},
+): XaiOAuthTokens {
+  const json = (body ?? {}) as XaiTokenResponse
+  const accessToken = asTrimmedString(json.access_token)
+  if (!accessToken) {
+    throw new Error('xAI OAuth token response is missing access_token')
+  }
+  const refreshToken =
+    asTrimmedString(json.refresh_token) ?? options.previousRefreshToken
+  if (options.requireRefreshToken && !refreshToken) {
+    throw new Error(
+      'xAI OAuth token response is missing refresh_token. The offline_access scope may have been rejected.',
+    )
+  }
+  const idToken = asTrimmedString(json.id_token)
+  const now = Date.now()
+  // RFC 6749 expires_in is preferred; fall back to the access-token JWT exp
+  // so callers get an absolute expiry even when xAI omits expires_in. The
+  // id-token exp reflects OIDC session lifetime, not the access token, so we
+  // don't use it here.
+  const expiresAt =
+    normalizeExpiresAt(json.expires_in, now) ??
+    deriveExpiresMsFromJwt(accessToken)
+  const identity = extractIdentity({ idToken, accessToken })
+  return {
+    accessToken,
+    refreshToken: refreshToken ?? '',
+    ...(idToken ? { idToken } : {}),
+    ...(expiresAt ? { expiresAt } : {}),
+    tokenEndpoint,
+    ...identity,
+  }
+}
+
+function buildXaiAuthorizeUrl(params: {
+  authorizationEndpoint: string
+  state: string
+  nonce: string
+  codeChallenge: string
+  redirectUri: string
+}): string {
+  const url = new URL(
+    requireTrustedXaiOAuthEndpoint(
+      params.authorizationEndpoint,
+      'authorization endpoint',
+    ),
+  )
+  url.searchParams.set('response_type', 'code')
+  url.searchParams.set('client_id', getXaiOAuthClientId())
+  url.searchParams.set('redirect_uri', params.redirectUri)
+  url.searchParams.set('scope', XAI_OAUTH_SCOPE)
+  url.searchParams.set('state', params.state)
+  url.searchParams.set('nonce', params.nonce)
+  url.searchParams.set('code_challenge', params.codeChallenge)
+  url.searchParams.set('code_challenge_method', 'S256')
+  url.searchParams.set('plan', 'generic')
+  url.searchParams.set('referrer', XAI_OAUTH_REFERRER)
+  return url.toString()
+}
+
+async function exchangeXaiToken(params: {
+  tokenEndpoint: string
+  body: Record<string, string>
+  context: string
+  requireRefreshToken?: boolean
+  previousRefreshToken?: string
+  signal?: AbortSignal
+}): Promise<XaiOAuthTokens> {
+  const { signal, cleanup } = createCombinedAbortSignal(params.signal, {
+    timeoutMs: XAI_OAUTH_FETCH_TIMEOUT_MS,
+  })
+  try {
+    const response = await fetch(
+      requireTrustedXaiOAuthEndpoint(params.tokenEndpoint, 'token endpoint'),
+      {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/x-www-form-urlencoded',
+          Accept: 'application/json',
+        },
+        body: new URLSearchParams(params.body).toString(),
+        signal,
+      },
+    )
+    const body = await readJson(response)
+    if (!response.ok) {
+      throw new Error(readErrorMessage(params.context, response.status, body))
+    }
+    return parseTokenResponse(body, params.tokenEndpoint, {
+      requireRefreshToken: params.requireRefreshToken,
+      previousRefreshToken: params.previousRefreshToken,
+    })
+  } finally {
+    cleanup()
+  }
+}
+
+type XaiOAuthServiceOptions = {
+  callbackPort?: number
+  callbackHost?: string
+  startCallbackServer?: typeof startXaiOAuthCallback
+}
+
+export type XaiOAuthFlowHandle = {
+  /** The authorize URL the user must open in a browser. */
+  authUrl: string
+  /**
+   * Resolves with tokens once xAI completes the flow — either by hitting the
+   * loopback redirect or by the caller providing the code via
+   * `submitManualCode`.
+   */
+  waitForTokens: () => Promise<XaiOAuthTokens>
+  /**
+   * Recover from a failed loopback push. xAI's auth page shows the user a
+   * code when its CORS push to the loopback fails; pass that code here to
+   * complete the flow without a redirect.
+   */
+  submitManualCode: (code: string) => void
+  cancel: () => void
+}
+
+export class XaiOAuthService {
+  private callbackHandle: XaiOAuthCallbackHandle | null = null
+  private tokenAbortController: AbortController | null = null
+  private manualResolver: ((code: string) => void) | null = null
+  private manualRejecter: ((error: Error) => void) | null = null
+  private cancellationError: Error | null = null
+
+  constructor(private readonly options: XaiOAuthServiceOptions = {}) {}
+
+  private buildCancellationError(): Error {
+    return this.cancellationError ?? new Error('xAI OAuth flow was cancelled.')
+  }
+
+  /**
+   * Begin the OAuth flow. Returns a handle the caller can use to start the
+   * browser, wait for tokens, or recover with a manual code paste.
+   *
+   * The loopback callback server stays open until tokens are obtained, the
+   * caller submits a manual code, or `cancel()` is invoked. CORS preflight
+   * from `auth.x.ai` is echoed so xAI's browser-side fetch can reach us.
+   */
+  async beginOAuthFlow(): Promise<XaiOAuthFlowHandle> {
+    // Reset cross-flow state so a reused service instance starts clean.
+    this.cancellationError = null
+
+    const discovery = await fetchXaiOAuthDiscovery()
+    const codeVerifier = generateCodeVerifier()
+    const codeChallenge = await generateCodeChallenge(codeVerifier)
+    const state = generateState()
+    const nonce = randomBytes(16).toString('hex')
+    const callbackPort =
+      this.options.callbackPort ?? getXaiOAuthCallbackPort()
+    const callbackHost =
+      this.options.callbackHost ?? getXaiOAuthCallbackHost()
+    const startCallback =
+      this.options.startCallbackServer ?? startXaiOAuthCallback
+
+    let callbackHandle: XaiOAuthCallbackHandle
+    try {
+      callbackHandle = await startCallback({
+        port: callbackPort,
+        host: callbackHost,
+        callbackPath: XAI_OAUTH_CALLBACK_PATH,
+        successTitle: 'xAI OAuth complete',
+      })
+    } catch (error) {
+      const code = (error as NodeJS.ErrnoException | undefined)?.code
+      if (code === 'EADDRINUSE') {
+        throw new Error(
+          `xAI OAuth needs ${callbackHost}:${callbackPort} for its callback. Close the app using that port (or use device-code login) and try again.`,
+        )
+      }
+      throw error
+    }
+    this.callbackHandle = callbackHandle
+
+    const redirectUri = `http://${callbackHost}:${callbackHandle.port}${XAI_OAUTH_CALLBACK_PATH}`
+    const authUrl = buildXaiAuthorizeUrl({
+      authorizationEndpoint: discovery.authorizationEndpoint,
+      state,
+      nonce,
+      codeChallenge,
+      redirectUri,
+    })
+
+    // Manual paste path: a separate promise that resolves with the code if
+    // the user pastes one (recovery when the loopback CORS push fails).
+    // Reject path so cleanup() can actively unblock callers waiting on
+    // waitForTokens — otherwise cancel() would hang forever.
+    type ManualOutcome = { kind: 'code'; code: string }
+    let manualResolver: ((outcome: ManualOutcome) => void) | null = null
+    let manualRejecter: ((error: Error) => void) | null = null
+    const manualPromise = new Promise<ManualOutcome>((resolve, reject) => {
+      manualResolver = resolve
+      manualRejecter = reject
+    })
+    this.manualResolver = (code: string) => manualResolver?.({ kind: 'code', code })
+    this.manualRejecter = manualRejecter
+
+    const waitForTokens = async (): Promise<XaiOAuthTokens> => {
+      // Wrap the loopback promise so its rejection after the manual path wins
+      // (e.g. server closed by cleanup) is swallowed instead of bubbling as
+      // an unhandledRejection.
+      const callbackOutcome: Promise<ManualOutcome | null> = callbackHandle
+        .waitForCallback()
+        .then(result => {
+          if (result.state !== state) {
+            throw new Error('xAI OAuth callback returned a mismatched state.')
+          }
+          return { kind: 'code', code: result.code } as ManualOutcome
+        })
+      // Ensure no unhandledRejection if the loopback rejects after we've
+      // already resolved via manual paste.
+      callbackOutcome.catch(() => undefined)
+
+      const outcome = await Promise.race([callbackOutcome, manualPromise])
+      if (!outcome) {
+        throw new Error('xAI OAuth produced no authorization code.')
+      }
+
+      const tokenAbortController = new AbortController()
+      this.tokenAbortController = tokenAbortController
+      try {
+        return await exchangeXaiToken({
+          tokenEndpoint: discovery.tokenEndpoint,
+          context: 'xAI OAuth token exchange',
+          requireRefreshToken: true,
+          signal: tokenAbortController.signal,
+          body: {
+            grant_type: 'authorization_code',
+            code: outcome.code,
+            redirect_uri: redirectUri,
+            client_id: getXaiOAuthClientId(),
+            code_verifier: codeVerifier,
+            // xAI re-validates these PKCE fields at token exchange.
+            code_challenge: codeChallenge,
+            code_challenge_method: 'S256',
+          },
+        })
+      } finally {
+        if (this.tokenAbortController === tokenAbortController) {
+          this.tokenAbortController = null
+        }
+        this.cleanup()
+      }
+    }
+
+    return {
+      authUrl,
+      waitForTokens,
+      submitManualCode: (code: string) => {
+        const trimmed = code.trim()
+        if (!trimmed) return
+        // Manual paste skips state validation by design: in xAI's OOB
+        // recovery flow the user reads the code directly from auth.x.ai
+        // (not an attacker-controlled redirect), and PKCE + one-shot codes
+        // prevent the code from being redeemed by anyone without our
+        // code_verifier. The redirect_uri at exchange is the same one xAI
+        // bound the code to, so a swapped code fails the exchange.
+        this.manualResolver?.(trimmed)
+        this.manualResolver = null
+        this.manualRejecter = null
+      },
+      cancel: () => {
+        this.cancellationError = new Error('xAI OAuth flow was cancelled.')
+        this.cleanup()
+      },
+    }
+  }
+
+  /**
+   * Legacy callback-style entry point — kicks off the flow, opens the
+   * browser via `authUrlHandler`, and returns tokens. No manual-code
+   * recovery; use `beginOAuthFlow` for richer UX.
+   */
+  async startOAuthFlow(
+    authUrlHandler: (authUrl: string) => Promise<void>,
+  ): Promise<XaiOAuthTokens> {
+    const handle = await this.beginOAuthFlow()
+    await authUrlHandler(handle.authUrl)
+    return handle.waitForTokens()
+  }
+
+  cleanup(): void {
+    const cancellation = this.buildCancellationError()
+    this.tokenAbortController?.abort(cancellation)
+    this.tokenAbortController = null
+    // Actively reject any pending waitForTokens — without this a `cancel()`
+    // mid-flight (or component unmount) would leave the promise hanging
+    // forever because Promise.race never settles.
+    this.manualRejecter?.(cancellation)
+    this.manualRejecter = null
+    this.manualResolver = null
+    this.callbackHandle?.close()
+    this.callbackHandle = null
+  }
+}
+
+export async function requestXaiDeviceCode(options?: {
+  signal?: AbortSignal
+}): Promise<{ code: XaiDeviceCode; tokenEndpoint: string }> {
+  const discovery = await fetchXaiOAuthDiscovery({ signal: options?.signal })
+  if (!discovery.deviceAuthorizationEndpoint) {
+    throw new Error(
+      'xAI OAuth discovery did not advertise a device authorization endpoint.',
+    )
+  }
+  const { signal, cleanup } = createCombinedAbortSignal(options?.signal, {
+    timeoutMs: XAI_OAUTH_FETCH_TIMEOUT_MS,
+  })
+  try {
+    const response = await fetch(
+      requireTrustedXaiOAuthEndpoint(
+        discovery.deviceAuthorizationEndpoint,
+        'device authorization endpoint',
+      ),
+      {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/x-www-form-urlencoded',
+          Accept: 'application/json',
+        },
+        body: new URLSearchParams({
+          client_id: getXaiOAuthClientId(),
+          scope: XAI_OAUTH_SCOPE,
+        }).toString(),
+        signal,
+      },
+    )
+    const body = await readJson(response)
+    if (!response.ok) {
+      throw new Error(
+        readErrorMessage('xAI device code request', response.status, body),
+      )
+    }
+    const json = (body ?? {}) as Record<string, unknown>
+    const deviceCode = asTrimmedString(json.device_code)
+    const userCode = asTrimmedString(json.user_code)
+    const verificationUri = asTrimmedString(json.verification_uri)
+    const verificationUriComplete = asTrimmedString(
+      json.verification_uri_complete,
+    )
+    if (!deviceCode || !userCode || !verificationUri) {
+      throw new Error(
+        'xAI device code response missing device_code, user_code, or verification_uri',
+      )
+    }
+    const expiresIn =
+      typeof json.expires_in === 'number'
+        ? json.expires_in
+        : typeof json.expires_in === 'string'
+          ? Number.parseFloat(json.expires_in)
+          : Number.NaN
+    const interval =
+      typeof json.interval === 'number'
+        ? json.interval
+        : typeof json.interval === 'string'
+          ? Number.parseFloat(json.interval)
+          : Number.NaN
+    return {
+      code: {
+        deviceCode,
+        userCode,
+        verificationUri: requireTrustedXaiOAuthEndpoint(
+          verificationUri,
+          'device verification URI',
+        ),
+        ...(verificationUriComplete
+          ? {
+              verificationUriComplete: requireTrustedXaiOAuthEndpoint(
+                verificationUriComplete,
+                'complete device verification URI',
+              ),
+            }
+          : {}),
+        expiresInMs: Number.isFinite(expiresIn) && expiresIn > 0
+          ? expiresIn * 1000
+          : 5 * 60 * 1000,
+        intervalMs: Number.isFinite(interval) && interval > 0
+          ? interval * 1000
+          : XAI_DEVICE_CODE_DEFAULT_INTERVAL_MS,
+      },
+      tokenEndpoint: discovery.tokenEndpoint,
+    }
+  } finally {
+    cleanup()
+  }
+}
+
+export async function pollXaiDeviceCode(params: {
+  deviceCode: XaiDeviceCode
+  tokenEndpoint: string
+  signal?: AbortSignal
+}): Promise<XaiOAuthTokens> {
+  const deadline = Date.now() + params.deviceCode.expiresInMs
+  let intervalMs = params.deviceCode.intervalMs
+
+  while (Date.now() < deadline) {
+    if (params.signal?.aborted) {
+      throw new Error('xAI device authorization was cancelled.')
+    }
+    const { signal, cleanup } = createCombinedAbortSignal(params.signal, {
+      timeoutMs: XAI_OAUTH_FETCH_TIMEOUT_MS,
+    })
+    let body: unknown
+    let status: number
+    try {
+      const response = await fetch(
+        requireTrustedXaiOAuthEndpoint(params.tokenEndpoint, 'token endpoint'),
+        {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/x-www-form-urlencoded',
+            Accept: 'application/json',
+          },
+          body: new URLSearchParams({
+            grant_type: XAI_DEVICE_CODE_GRANT_TYPE,
+            client_id: getXaiOAuthClientId(),
+            device_code: params.deviceCode.deviceCode,
+          }).toString(),
+          signal,
+        },
+      )
+      status = response.status
+      body = await readJson(response)
+      if (response.ok) {
+        return parseTokenResponse(body, params.tokenEndpoint, {
+          requireRefreshToken: true,
+        })
+      }
+    } finally {
+      cleanup()
+    }
+
+    const error = asTrimmedString(
+      ((body ?? {}) as XaiErrorResponse).error,
+    )
+    if (error === 'authorization_pending') {
+      await sleep(Math.max(intervalMs, XAI_DEVICE_CODE_MIN_INTERVAL_MS))
+      continue
+    }
+    if (error === 'slow_down') {
+      intervalMs += XAI_DEVICE_CODE_SLOW_DOWN_INCREMENT_MS
+      await sleep(intervalMs)
+      continue
+    }
+    if (error === 'access_denied' || error === 'authorization_denied') {
+      throw new Error('xAI device authorization was denied.')
+    }
+    if (error === 'expired_token') {
+      throw new Error('xAI device code expired. Re-run the login.')
+    }
+    throw new Error(readErrorMessage('xAI device token exchange', status, body))
+  }
+  throw new Error('xAI device authorization timed out.')
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms))
+}
+
+export async function refreshXaiAccessToken(params: {
+  refreshToken: string
+  tokenEndpoint: string
+  signal?: AbortSignal
+}): Promise<XaiOAuthTokens> {
+  return exchangeXaiToken({
+    tokenEndpoint: params.tokenEndpoint,
+    context: 'xAI OAuth refresh',
+    signal: params.signal,
+    // Some OAuth servers omit refresh_token on a refresh response (the same
+    // refresh token stays valid). Carry it forward so callers never get an
+    // empty refreshToken back from a successful refresh.
+    previousRefreshToken: params.refreshToken,
+    body: {
+      grant_type: 'refresh_token',
+      client_id: getXaiOAuthClientId(),
+      refresh_token: params.refreshToken,
+    },
+  })
+}

--- a/src/services/api/xaiOAuthCallback.test.ts
+++ b/src/services/api/xaiOAuthCallback.test.ts
@@ -1,0 +1,219 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import { createServer } from 'node:http'
+import type { AddressInfo } from 'node:net'
+
+import { startXaiOAuthCallback } from './xaiOAuthCallback.js'
+
+/**
+ * Acquire an OS-assigned ephemeral port the test can hand back. Bun's test
+ * runner can pile concurrent files; we don't want them stomping on each
+ * other or on a developer's actual 56121.
+ */
+async function getEphemeralPort(): Promise<number> {
+  const server = createServer()
+  await new Promise<void>((resolve, reject) => {
+    server.once('error', reject)
+    server.listen(0, '127.0.0.1', () => resolve())
+  })
+  const port = (server.address() as AddressInfo).port
+  await new Promise<void>(resolve => server.close(() => resolve()))
+  return port
+}
+
+async function startTestServer() {
+  const port = await getEphemeralPort()
+  const handle = await startXaiOAuthCallback({
+    port,
+    host: '127.0.0.1',
+    callbackPath: '/callback',
+    successTitle: 'xAI OAuth complete',
+  })
+  return { handle, port }
+}
+
+describe('startXaiOAuthCallback (CORS-aware loopback for xAI auth)', () => {
+  let cleanup: (() => void) | null = null
+
+  beforeEach(() => {
+    cleanup = null
+  })
+
+  afterEach(() => {
+    cleanup?.()
+    cleanup = null
+  })
+
+  test('OPTIONS preflight from auth.x.ai returns 204 with CORS echo', async () => {
+    const { handle, port } = await startTestServer()
+    cleanup = () => handle.close()
+
+    const res = await fetch(`http://127.0.0.1:${port}/callback`, {
+      method: 'OPTIONS',
+      headers: {
+        Origin: 'https://auth.x.ai',
+        'Access-Control-Request-Method': 'GET',
+      },
+    })
+    expect(res.status).toBe(204)
+    expect(res.headers.get('access-control-allow-origin')).toBe(
+      'https://auth.x.ai',
+    )
+    const allowMethods = res.headers.get('access-control-allow-methods') ?? ''
+    expect(allowMethods).toContain('GET')
+    // Don't leak the callback resolution to OPTIONS — the wait promise
+    // shouldn't have settled.
+    let settled = false
+    void handle.waitForCallback().then(
+      () => {
+        settled = true
+      },
+      () => {
+        settled = true
+      },
+    )
+    await Bun.sleep(20)
+    expect(settled).toBe(false)
+  })
+
+  test('OPTIONS from accounts.x.ai is also allowed', async () => {
+    const { handle, port } = await startTestServer()
+    cleanup = () => handle.close()
+
+    const res = await fetch(`http://127.0.0.1:${port}/callback`, {
+      method: 'OPTIONS',
+      headers: { Origin: 'https://accounts.x.ai' },
+    })
+    expect(res.status).toBe(204)
+    expect(res.headers.get('access-control-allow-origin')).toBe(
+      'https://accounts.x.ai',
+    )
+  })
+
+  test('OPTIONS from untrusted origin gets 204 but no CORS headers', async () => {
+    const { handle, port } = await startTestServer()
+    cleanup = () => handle.close()
+
+    const res = await fetch(`http://127.0.0.1:${port}/callback`, {
+      method: 'OPTIONS',
+      headers: { Origin: 'https://attacker.example.com' },
+    })
+    expect(res.status).toBe(204)
+    expect(res.headers.get('access-control-allow-origin')).toBeNull()
+  })
+
+  test('OPTIONS from http (non-https) x.ai is rejected', async () => {
+    const { handle, port } = await startTestServer()
+    cleanup = () => handle.close()
+
+    const res = await fetch(`http://127.0.0.1:${port}/callback`, {
+      method: 'OPTIONS',
+      headers: { Origin: 'http://auth.x.ai' },
+    })
+    expect(res.status).toBe(204)
+    expect(res.headers.get('access-control-allow-origin')).toBeNull()
+  })
+
+  test('OPTIONS from subdomain-spoof (auth.x.ai.evil.example.com) is rejected', async () => {
+    const { handle, port } = await startTestServer()
+    cleanup = () => handle.close()
+
+    const res = await fetch(`http://127.0.0.1:${port}/callback`, {
+      method: 'OPTIONS',
+      headers: { Origin: 'https://auth.x.ai.evil.example.com' },
+    })
+    expect(res.status).toBe(204)
+    expect(res.headers.get('access-control-allow-origin')).toBeNull()
+  })
+
+  test('GET /callback?code=&state= resolves waitForCallback with both', async () => {
+    const { handle, port } = await startTestServer()
+    cleanup = () => handle.close()
+
+    const callbackPromise = handle.waitForCallback()
+    const res = await fetch(
+      `http://127.0.0.1:${port}/callback?code=ABC123&state=xyz`,
+      { headers: { Origin: 'https://auth.x.ai' } },
+    )
+    expect(res.status).toBe(200)
+    expect(res.headers.get('content-type')).toContain('text/html')
+    expect(res.headers.get('access-control-allow-origin')).toBe(
+      'https://auth.x.ai',
+    )
+    const result = await callbackPromise
+    expect(result).toEqual({ code: 'ABC123', state: 'xyz' })
+  })
+
+  test('GET with ?error=access_denied rejects with a clear message', async () => {
+    const { handle, port } = await startTestServer()
+    cleanup = () => handle.close()
+
+    const callbackPromise = handle.waitForCallback()
+    const res = await fetch(
+      `http://127.0.0.1:${port}/callback?error=access_denied`,
+    )
+    expect(res.status).toBe(400)
+    await expect(callbackPromise).rejects.toThrow(/access_denied/)
+  })
+
+  test('GET to wrong path returns 404 and does not settle the callback', async () => {
+    const { handle, port } = await startTestServer()
+    cleanup = () => handle.close()
+
+    const res = await fetch(`http://127.0.0.1:${port}/something-else`)
+    expect(res.status).toBe(404)
+
+    let settled = false
+    void handle.waitForCallback().then(
+      () => {
+        settled = true
+      },
+      () => {
+        settled = true
+      },
+    )
+    await Bun.sleep(20)
+    expect(settled).toBe(false)
+  })
+
+  test('POST to /callback returns 405 with Allow header', async () => {
+    const { handle, port } = await startTestServer()
+    cleanup = () => handle.close()
+
+    const res = await fetch(`http://127.0.0.1:${port}/callback`, {
+      method: 'POST',
+      body: 'code=ABC&state=xyz',
+    })
+    expect(res.status).toBe(405)
+    expect(res.headers.get('allow') ?? '').toContain('GET')
+  })
+
+  test('successTitle is HTML-escaped in the success page', async () => {
+    const port = await getEphemeralPort()
+    const handle = await startXaiOAuthCallback({
+      port,
+      host: '127.0.0.1',
+      callbackPath: '/callback',
+      successTitle: '<script>alert(1)</script>',
+    })
+    cleanup = () => handle.close()
+
+    const callbackPromise = handle.waitForCallback()
+    const res = await fetch(
+      `http://127.0.0.1:${port}/callback?code=A&state=B`,
+    )
+    const body = await res.text()
+    expect(body).not.toContain('<script>alert(1)</script>')
+    expect(body).toContain('&lt;script&gt;')
+    await callbackPromise
+  })
+
+  test('close() before callback rejects waitForCallback', async () => {
+    const { handle } = await startTestServer()
+    const callbackPromise = handle.waitForCallback()
+    // Attach a no-op catch FIRST so the microtask rejection doesn't surface
+    // as unhandled before the assertion is in place.
+    callbackPromise.catch(() => undefined)
+    handle.close()
+    await expect(callbackPromise).rejects.toThrow(/closed/)
+  })
+})

--- a/src/services/api/xaiOAuthCallback.test.ts
+++ b/src/services/api/xaiOAuthCallback.test.ts
@@ -75,6 +75,29 @@ describe('startXaiOAuthCallback (CORS-aware loopback for xAI auth)', () => {
     expect(settled).toBe(false)
   })
 
+  // Without this header, Chrome/Edge block xAI's HTTPS-origin fetch to
+  // the loopback callback. The preflight succeeds, the actual GET never
+  // fires, the CLI never auto-detects success, and the user has to fall
+  // back to manual code paste. Regression-locked because this is silent
+  // — the only symptom is "auto-detect doesn't work".
+  test('OPTIONS preflight includes Access-Control-Allow-Private-Network', async () => {
+    const { handle, port } = await startTestServer()
+    cleanup = () => handle.close()
+
+    const res = await fetch(`http://127.0.0.1:${port}/callback`, {
+      method: 'OPTIONS',
+      headers: {
+        Origin: 'https://auth.x.ai',
+        'Access-Control-Request-Method': 'GET',
+        'Access-Control-Request-Private-Network': 'true',
+      },
+    })
+    expect(res.status).toBe(204)
+    expect(res.headers.get('access-control-allow-private-network')).toBe(
+      'true',
+    )
+  })
+
   test('OPTIONS from accounts.x.ai is also allowed', async () => {
     const { handle, port } = await startTestServer()
     cleanup = () => handle.close()

--- a/src/services/api/xaiOAuthCallback.ts
+++ b/src/services/api/xaiOAuthCallback.ts
@@ -1,0 +1,229 @@
+/**
+ * Loopback HTTP server that receives the xAI OAuth redirect.
+ *
+ * Unlike OpenClaude's general `AuthCodeListener`, this one explicitly answers
+ * CORS preflight (`OPTIONS`) for the xAI auth origins (`auth.x.ai`,
+ * `accounts.x.ai`). xAI's web client pushes the authorization code to the
+ * loopback URL via a browser-side fetch; without echoing CORS the browser
+ * blocks the push and the auth page falls back to "Could not establish
+ * connection". This mirrors openclaw's `waitForLocalOAuthCallback`.
+ */
+
+import { createServer, type IncomingMessage, type ServerResponse } from 'node:http'
+
+function escapeHtml(value: string): string {
+  return value.replace(
+    /[&<>"']/g,
+    ch =>
+      ({
+        '&': '&amp;',
+        '<': '&lt;',
+        '>': '&gt;',
+        '"': '&quot;',
+        "'": '&#39;',
+      })[ch] ?? ch,
+  )
+}
+
+export type XaiOAuthCallbackResult = {
+  code: string
+  state: string
+}
+
+export type XaiOAuthCallbackHandle = {
+  port: number
+  /** Resolves with the code+state once xAI hits the loopback. */
+  waitForCallback: () => Promise<XaiOAuthCallbackResult>
+  close: () => void
+}
+
+const DEFAULT_CORS_ALLOWLIST = ['auth.x.ai', 'accounts.x.ai'] as const
+
+function isAllowedOrigin(
+  origin: string | undefined,
+  allowlist: readonly string[],
+): boolean {
+  if (!origin) return false
+  try {
+    const url = new URL(origin)
+    if (url.protocol !== 'https:') return false
+    const host = url.hostname.toLowerCase()
+    return allowlist.some(allowed => host === allowed)
+  } catch {
+    return false
+  }
+}
+
+function applyCors(
+  req: IncomingMessage,
+  res: ServerResponse,
+  allowlist: readonly string[],
+): void {
+  const origin = typeof req.headers.origin === 'string'
+    ? req.headers.origin
+    : undefined
+  if (!isAllowedOrigin(origin, allowlist)) return
+  res.setHeader('Access-Control-Allow-Origin', origin!)
+  res.setHeader(
+    'Vary',
+    'Origin, Access-Control-Request-Method, Access-Control-Request-Headers',
+  )
+  const requestedMethod = req.headers['access-control-request-method']
+  if (typeof requestedMethod === 'string') {
+    res.setHeader('Access-Control-Allow-Methods', `${requestedMethod}, OPTIONS`)
+  } else {
+    res.setHeader('Access-Control-Allow-Methods', 'GET, OPTIONS')
+  }
+  const requestedHeaders = req.headers['access-control-request-headers']
+  if (typeof requestedHeaders === 'string' && requestedHeaders.trim()) {
+    res.setHeader('Access-Control-Allow-Headers', requestedHeaders)
+  }
+  res.setHeader('Access-Control-Max-Age', '600')
+}
+
+export async function startXaiOAuthCallback(params: {
+  port: number
+  host: string
+  callbackPath: string
+  successTitle?: string
+  corsOriginAllowlist?: readonly string[]
+}): Promise<XaiOAuthCallbackHandle> {
+  const allowlist = params.corsOriginAllowlist ?? DEFAULT_CORS_ALLOWLIST
+  const successTitle = params.successTitle ?? 'xAI OAuth complete'
+
+  let resolveCallback:
+    | ((result: XaiOAuthCallbackResult) => void)
+    | null = null
+  let rejectCallback: ((error: Error) => void) | null = null
+  let settled = false
+
+  const callbackPromise = new Promise<XaiOAuthCallbackResult>(
+    (resolve, reject) => {
+      resolveCallback = resolve
+      rejectCallback = reject
+    },
+  )
+  // Install a no-op rejection guard so closing the server before anyone has
+  // awaited the callback (e.g. cancel() during cleanup) doesn't surface as
+  // an unhandled rejection. Real awaiters still see the rejection via .then
+  // / await; this only neutralizes the "no listener attached yet" case.
+  callbackPromise.catch(() => undefined)
+
+  function settle(
+    next: () => void,
+    handler: () => void,
+  ): void {
+    if (settled) return
+    settled = true
+    try {
+      handler()
+    } finally {
+      next()
+    }
+  }
+
+  const server = createServer((req, res) => {
+    try {
+      applyCors(req, res, allowlist)
+      const url = new URL(req.url ?? '/', `http://${params.host}:${params.port}`)
+
+      if (req.method === 'OPTIONS') {
+        res.statusCode = 204
+        res.end()
+        return
+      }
+
+      if (url.pathname !== params.callbackPath) {
+        res.statusCode = 404
+        res.setHeader('Content-Type', 'text/plain')
+        res.end('Not found')
+        return
+      }
+
+      if (req.method !== 'GET') {
+        res.statusCode = 405
+        res.setHeader('Allow', 'GET, OPTIONS')
+        res.setHeader('Content-Type', 'text/plain')
+        res.end('Method not allowed')
+        return
+      }
+
+      const error = url.searchParams.get('error')
+      if (error) {
+        res.statusCode = 400
+        res.setHeader('Content-Type', 'text/plain')
+        res.end(`Authentication failed: ${error}`)
+        settle(
+          () => undefined,
+          () => rejectCallback?.(new Error(`xAI OAuth error: ${error}`)),
+        )
+        return
+      }
+
+      const code = url.searchParams.get('code')?.trim()
+      const state = url.searchParams.get('state')?.trim()
+
+      if (!code || !state) {
+        res.statusCode = 400
+        res.setHeader('Content-Type', 'text/plain')
+        res.end('Missing code or state')
+        settle(
+          () => undefined,
+          () => rejectCallback?.(new Error('xAI OAuth callback missing code or state')),
+        )
+        return
+      }
+
+      const safeTitle = escapeHtml(successTitle)
+      res.statusCode = 200
+      res.setHeader('Content-Type', 'text/html; charset=utf-8')
+      res.end(
+        `<!doctype html><html><head><meta charset="utf-8"/><title>${safeTitle}</title></head>` +
+          `<body style="font-family:sans-serif;padding:32px;line-height:1.5;color:#111827">` +
+          `<h1 style="margin:0 0 12px;font-size:22px">${safeTitle}</h1>` +
+          `<p>You can return to OpenClaude — the CLI will finish setup automatically.</p>` +
+          `</body></html>`,
+      )
+      settle(
+        () => undefined,
+        () => resolveCallback?.({ code, state }),
+      )
+    } catch (err) {
+      const wrapped = err instanceof Error ? err : new Error(String(err))
+      settle(
+        () => undefined,
+        () => rejectCallback?.(wrapped),
+      )
+    }
+  })
+
+  await new Promise<void>((resolve, reject) => {
+    server.once('error', reject)
+    server.listen(params.port, params.host, () => {
+      server.removeListener('error', reject)
+      resolve()
+    })
+  })
+
+  server.on('error', err => {
+    if (!settled) {
+      rejectCallback?.(err)
+    }
+  })
+
+  return {
+    port: params.port,
+    waitForCallback: () => callbackPromise,
+    close: () => {
+      if (!settled) {
+        settled = true
+        rejectCallback?.(new Error('xAI OAuth callback server closed.'))
+      }
+      try {
+        server.close()
+      } catch {
+        // ignore
+      }
+    },
+  }
+}

--- a/src/services/api/xaiOAuthCallback.ts
+++ b/src/services/api/xaiOAuthCallback.ts
@@ -68,16 +68,21 @@ function applyCors(
     'Vary',
     'Origin, Access-Control-Request-Method, Access-Control-Request-Headers',
   )
-  const requestedMethod = req.headers['access-control-request-method']
-  if (typeof requestedMethod === 'string') {
-    res.setHeader('Access-Control-Allow-Methods', `${requestedMethod}, OPTIONS`)
-  } else {
-    res.setHeader('Access-Control-Allow-Methods', 'GET, OPTIONS')
-  }
+  res.setHeader('Access-Control-Allow-Methods', 'GET, OPTIONS')
   const requestedHeaders = req.headers['access-control-request-headers']
-  if (typeof requestedHeaders === 'string' && requestedHeaders.trim()) {
-    res.setHeader('Access-Control-Allow-Headers', requestedHeaders)
-  }
+  res.setHeader(
+    'Access-Control-Allow-Headers',
+    typeof requestedHeaders === 'string' && requestedHeaders.trim().length > 0
+      ? requestedHeaders
+      : 'content-type',
+  )
+  // Chrome / Edge require this header when an HTTPS origin (auth.x.ai)
+  // fetches a private-network address (127.0.0.1). Without it the
+  // preflight succeeds but the actual GET is blocked, our server never
+  // receives the callback, and xAI's auth page falls back to manual code
+  // paste even though sign-in succeeded. See:
+  // https://wicg.github.io/private-network-access/
+  res.setHeader('Access-Control-Allow-Private-Network', 'true')
   res.setHeader('Access-Control-Max-Age', '600')
 }
 

--- a/src/services/api/xaiOAuthShared.test.ts
+++ b/src/services/api/xaiOAuthShared.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, test } from 'bun:test'
+
+import {
+  asTrimmedString,
+  decodeJwtPayload,
+  DEFAULT_XAI_OAUTH_CALLBACK_HOST,
+  DEFAULT_XAI_OAUTH_CALLBACK_PORT,
+  DEFAULT_XAI_OAUTH_CLIENT_ID,
+  deriveExpiresMsFromJwt,
+  escapeHtml,
+  getXaiOAuthCallbackHost,
+  getXaiOAuthCallbackPort,
+  getXaiOAuthClientId,
+  getXaiOAuthRedirectUri,
+  isTrustedXaiOAuthEndpoint,
+  requireTrustedXaiOAuthEndpoint,
+  XAI_OAUTH_CALLBACK_PATH,
+  XAI_OAUTH_DISCOVERY_URL,
+  XAI_OAUTH_ISSUER,
+} from './xaiOAuthShared.js'
+
+describe('xaiOAuthShared', () => {
+  test('uses the openclaw-published shared client_id by default', () => {
+    expect(getXaiOAuthClientId({} as NodeJS.ProcessEnv)).toBe(
+      DEFAULT_XAI_OAUTH_CLIENT_ID,
+    )
+  })
+
+  test('honours XAI_OAUTH_CLIENT_ID override', () => {
+    expect(
+      getXaiOAuthClientId({
+        XAI_OAUTH_CLIENT_ID: '  custom-client  ',
+      } as unknown as NodeJS.ProcessEnv),
+    ).toBe('custom-client')
+  })
+
+  test('clamps callback port to a valid range and falls back on garbage', () => {
+    expect(getXaiOAuthCallbackPort({} as NodeJS.ProcessEnv)).toBe(
+      DEFAULT_XAI_OAUTH_CALLBACK_PORT,
+    )
+    expect(
+      getXaiOAuthCallbackPort({
+        XAI_OAUTH_CALLBACK_PORT: '70000',
+      } as unknown as NodeJS.ProcessEnv),
+    ).toBe(DEFAULT_XAI_OAUTH_CALLBACK_PORT)
+    expect(
+      getXaiOAuthCallbackPort({
+        XAI_OAUTH_CALLBACK_PORT: '9999',
+      } as unknown as NodeJS.ProcessEnv),
+    ).toBe(9999)
+  })
+
+  test('only accepts loopback hosts', () => {
+    expect(getXaiOAuthCallbackHost({} as NodeJS.ProcessEnv)).toBe(
+      DEFAULT_XAI_OAUTH_CALLBACK_HOST,
+    )
+    expect(
+      getXaiOAuthCallbackHost({
+        XAI_OAUTH_CALLBACK_HOST: 'evil.example.com',
+      } as unknown as NodeJS.ProcessEnv),
+    ).toBe(DEFAULT_XAI_OAUTH_CALLBACK_HOST)
+    expect(
+      getXaiOAuthCallbackHost({
+        XAI_OAUTH_CALLBACK_HOST: 'localhost',
+      } as unknown as NodeJS.ProcessEnv),
+    ).toBe('localhost')
+  })
+
+  test('redirect URI uses the callback path', () => {
+    const uri = getXaiOAuthRedirectUri({} as NodeJS.ProcessEnv)
+    expect(uri).toBe(
+      `http://${DEFAULT_XAI_OAUTH_CALLBACK_HOST}:${DEFAULT_XAI_OAUTH_CALLBACK_PORT}${XAI_OAUTH_CALLBACK_PATH}`,
+    )
+  })
+
+  test('isTrustedXaiOAuthEndpoint requires https x.ai hosts', () => {
+    expect(isTrustedXaiOAuthEndpoint(`${XAI_OAUTH_ISSUER}/oauth/token`)).toBe(
+      true,
+    )
+    expect(isTrustedXaiOAuthEndpoint('https://accounts.x.ai/login')).toBe(true)
+    // http (not https)
+    expect(isTrustedXaiOAuthEndpoint('http://auth.x.ai/oauth/token')).toBe(
+      false,
+    )
+    // attacker-controlled host that just contains x.ai
+    expect(
+      isTrustedXaiOAuthEndpoint('https://auth.x.ai.evil.example.com/token'),
+    ).toBe(false)
+    expect(isTrustedXaiOAuthEndpoint('not-a-url')).toBe(false)
+  })
+
+  test('requireTrustedXaiOAuthEndpoint throws on untrusted host', () => {
+    expect(() =>
+      requireTrustedXaiOAuthEndpoint(
+        'https://attacker.example.com/oauth/token',
+        'token endpoint',
+      ),
+    ).toThrow(/untrusted token endpoint/)
+    expect(
+      requireTrustedXaiOAuthEndpoint(
+        'https://auth.x.ai/oauth/token',
+        'token endpoint',
+      ),
+    ).toBe('https://auth.x.ai/oauth/token')
+  })
+
+  test('XAI_OAUTH_DISCOVERY_URL points at the issuer well-known', () => {
+    expect(XAI_OAUTH_DISCOVERY_URL).toBe(
+      `${XAI_OAUTH_ISSUER}/.well-known/openid-configuration`,
+    )
+  })
+
+  test('decodeJwtPayload returns the JSON payload', () => {
+    const header = Buffer.from('{"alg":"none"}').toString('base64url')
+    const payload = Buffer.from('{"sub":"abc","exp":12345}').toString(
+      'base64url',
+    )
+    const token = `${header}.${payload}.`
+    expect(decodeJwtPayload(token)).toEqual({ sub: 'abc', exp: 12345 })
+  })
+
+  test('decodeJwtPayload tolerates garbage', () => {
+    expect(decodeJwtPayload(undefined)).toBeUndefined()
+    expect(decodeJwtPayload('not-a-jwt')).toBeUndefined()
+  })
+
+  test('deriveExpiresMsFromJwt converts exp seconds to ms', () => {
+    const payload = Buffer.from('{"exp":1700000000}').toString('base64url')
+    const token = `header.${payload}.`
+    expect(deriveExpiresMsFromJwt(token)).toBe(1700000000_000)
+  })
+
+  test('asTrimmedString filters empty / non-string', () => {
+    expect(asTrimmedString('  hello  ')).toBe('hello')
+    expect(asTrimmedString('   ')).toBeUndefined()
+    expect(asTrimmedString(123)).toBeUndefined()
+    expect(asTrimmedString(undefined)).toBeUndefined()
+  })
+
+  test('escapeHtml escapes the five HTML metacharacters', () => {
+    expect(escapeHtml(`<a href="x">'&'</a>`)).toBe(
+      '&lt;a href=&quot;x&quot;&gt;&#39;&amp;&#39;&lt;/a&gt;',
+    )
+  })
+})

--- a/src/services/api/xaiOAuthShared.ts
+++ b/src/services/api/xaiOAuthShared.ts
@@ -10,6 +10,8 @@
  * Bearer to `https://api.x.ai/v1`, so no proxy is involved.
  */
 
+import { createCombinedAbortSignal } from '../../utils/combinedAbortSignal.js'
+
 export const XAI_OAUTH_ISSUER = 'https://auth.x.ai'
 export const XAI_OAUTH_DISCOVERY_URL = `${XAI_OAUTH_ISSUER}/.well-known/openid-configuration`
 export const DEFAULT_XAI_OAUTH_CLIENT_ID = 'b1a00492-073a-47ea-816f-4c329264a828'
@@ -151,12 +153,21 @@ export async function fetchXaiOAuthDiscovery(options?: {
   timeoutMs?: number
 }): Promise<XaiOAuthDiscovery> {
   const fetchImpl = options?.fetchImpl ?? fetch
-  const signal =
-    options?.signal ?? AbortSignal.timeout(options?.timeoutMs ?? 15_000)
-  const response = await fetchImpl(XAI_OAUTH_DISCOVERY_URL, {
-    headers: { Accept: 'application/json' },
-    signal,
+  // Use the cleanup-safe helper instead of `AbortSignal.timeout(...)` so the
+  // underlying timer is cleared on success — raw timeout signals leak
+  // timers in Bun and are forbidden by the repo guard.
+  const { signal, cleanup } = createCombinedAbortSignal(options?.signal, {
+    timeoutMs: options?.timeoutMs ?? 15_000,
   })
+  let response: Response
+  try {
+    response = await fetchImpl(XAI_OAUTH_DISCOVERY_URL, {
+      headers: { Accept: 'application/json' },
+      signal,
+    })
+  } finally {
+    cleanup()
+  }
   if (!response.ok) {
     throw new Error(
       `xAI OAuth discovery failed with status ${response.status}`,

--- a/src/services/api/xaiOAuthShared.ts
+++ b/src/services/api/xaiOAuthShared.ts
@@ -1,0 +1,193 @@
+/**
+ * xAI OAuth shared constants and helpers.
+ *
+ * Mirrors the OAuth flow shipped by openclaw (`extensions/xai/xai-oauth.ts`),
+ * which is the canonical reference for the xAI shared OAuth client. The
+ * client_id is a public, xAI-issued credential intended for third-party CLI
+ * use; xAI may label the consent app "Grok Build" because it is shared.
+ *
+ * Inference works the same as an API key: the access token is sent as a
+ * Bearer to `https://api.x.ai/v1`, so no proxy is involved.
+ */
+
+export const XAI_OAUTH_ISSUER = 'https://auth.x.ai'
+export const XAI_OAUTH_DISCOVERY_URL = `${XAI_OAUTH_ISSUER}/.well-known/openid-configuration`
+export const DEFAULT_XAI_OAUTH_CLIENT_ID = 'b1a00492-073a-47ea-816f-4c329264a828'
+export const DEFAULT_XAI_OAUTH_CALLBACK_PORT = 56121
+export const DEFAULT_XAI_OAUTH_CALLBACK_HOST = '127.0.0.1'
+export const XAI_OAUTH_CALLBACK_PATH = '/callback'
+export const XAI_OAUTH_SCOPE =
+  'openid profile email offline_access grok-cli:access api:access'
+export const XAI_OAUTH_REFERRER = 'openclaude'
+export const XAI_DEVICE_CODE_GRANT_TYPE =
+  'urn:ietf:params:oauth:grant-type:device_code'
+
+const ALLOWED_XAI_OAUTH_CALLBACK_HOSTS = new Set([
+  '127.0.0.1',
+  'localhost',
+  '::1',
+])
+
+const TRUSTED_XAI_OAUTH_HOSTS = new Set(['x.ai'])
+
+export function asTrimmedString(value: unknown): string | undefined {
+  if (typeof value !== 'string') return undefined
+  const trimmed = value.trim()
+  return trimmed ? trimmed : undefined
+}
+
+export function getXaiOAuthClientId(
+  env: NodeJS.ProcessEnv = process.env,
+): string {
+  return (
+    asTrimmedString(env.XAI_OAUTH_CLIENT_ID) ?? DEFAULT_XAI_OAUTH_CLIENT_ID
+  )
+}
+
+export function getXaiOAuthCallbackPort(
+  env: NodeJS.ProcessEnv = process.env,
+): number {
+  const raw = asTrimmedString(env.XAI_OAUTH_CALLBACK_PORT)
+  if (!raw) return DEFAULT_XAI_OAUTH_CALLBACK_PORT
+  const parsed = Number.parseInt(raw, 10)
+  if (Number.isInteger(parsed) && parsed > 0 && parsed <= 65535) {
+    return parsed
+  }
+  return DEFAULT_XAI_OAUTH_CALLBACK_PORT
+}
+
+export function getXaiOAuthCallbackHost(
+  env: NodeJS.ProcessEnv = process.env,
+): string {
+  const raw = asTrimmedString(env.XAI_OAUTH_CALLBACK_HOST)
+  if (raw && ALLOWED_XAI_OAUTH_CALLBACK_HOSTS.has(raw)) return raw
+  return DEFAULT_XAI_OAUTH_CALLBACK_HOST
+}
+
+export function getXaiOAuthRedirectUri(
+  env: NodeJS.ProcessEnv = process.env,
+): string {
+  const host = getXaiOAuthCallbackHost(env)
+  const port = getXaiOAuthCallbackPort(env)
+  return `http://${host}:${port}${XAI_OAUTH_CALLBACK_PATH}`
+}
+
+export function isTrustedXaiOAuthEndpoint(endpoint: string): boolean {
+  try {
+    const url = new URL(endpoint)
+    if (url.protocol !== 'https:') return false
+    const hostname = url.hostname.toLowerCase()
+    if (TRUSTED_XAI_OAUTH_HOSTS.has(hostname)) return true
+    return [...TRUSTED_XAI_OAUTH_HOSTS].some(h => hostname.endsWith(`.${h}`))
+  } catch {
+    return false
+  }
+}
+
+export function requireTrustedXaiOAuthEndpoint(
+  endpoint: string,
+  label: string,
+): string {
+  if (!isTrustedXaiOAuthEndpoint(endpoint)) {
+    throw new Error(`xAI OAuth discovery returned untrusted ${label}`)
+  }
+  return endpoint
+}
+
+export function decodeJwtPayload(
+  token: string | undefined,
+): Record<string, unknown> | undefined {
+  if (!token) return undefined
+  const parts = token.split('.')
+  if (parts.length < 2) return undefined
+  try {
+    const normalized = parts[1].replace(/-/g, '+').replace(/_/g, '/')
+    const padded = normalized + '='.repeat((4 - (normalized.length % 4)) % 4)
+    const json = Buffer.from(padded, 'base64').toString('utf8')
+    const parsed = JSON.parse(json)
+    return parsed && typeof parsed === 'object'
+      ? (parsed as Record<string, unknown>)
+      : undefined
+  } catch {
+    return undefined
+  }
+}
+
+export function deriveExpiresMsFromJwt(
+  token: string | undefined,
+): number | undefined {
+  const payload = decodeJwtPayload(token)
+  if (!payload) return undefined
+  const exp = payload.exp
+  if (typeof exp !== 'number' || !Number.isFinite(exp) || exp <= 0) {
+    return undefined
+  }
+  return exp * 1000
+}
+
+export function escapeHtml(value: string): string {
+  return value.replace(
+    /[&<>"']/g,
+    ch =>
+      ({
+        '&': '&amp;',
+        '<': '&lt;',
+        '>': '&gt;',
+        '"': '&quot;',
+        "'": '&#39;',
+      })[ch] ?? ch,
+  )
+}
+
+export type XaiOAuthDiscovery = {
+  authorizationEndpoint: string
+  tokenEndpoint: string
+  deviceAuthorizationEndpoint?: string
+}
+
+export async function fetchXaiOAuthDiscovery(options?: {
+  fetchImpl?: typeof fetch
+  signal?: AbortSignal
+  timeoutMs?: number
+}): Promise<XaiOAuthDiscovery> {
+  const fetchImpl = options?.fetchImpl ?? fetch
+  const signal =
+    options?.signal ?? AbortSignal.timeout(options?.timeoutMs ?? 15_000)
+  const response = await fetchImpl(XAI_OAUTH_DISCOVERY_URL, {
+    headers: { Accept: 'application/json' },
+    signal,
+  })
+  if (!response.ok) {
+    throw new Error(
+      `xAI OAuth discovery failed with status ${response.status}`,
+    )
+  }
+  const json = (await response.json()) as Record<string, unknown>
+  const authorizationEndpoint = json.authorization_endpoint
+  const tokenEndpoint = json.token_endpoint
+  const deviceAuthorizationEndpoint = json.device_authorization_endpoint
+  if (
+    typeof authorizationEndpoint !== 'string' ||
+    typeof tokenEndpoint !== 'string'
+  ) {
+    throw new Error('xAI OAuth discovery response is missing endpoints')
+  }
+  return {
+    authorizationEndpoint: requireTrustedXaiOAuthEndpoint(
+      authorizationEndpoint,
+      'authorization endpoint',
+    ),
+    tokenEndpoint: requireTrustedXaiOAuthEndpoint(
+      tokenEndpoint,
+      'token endpoint',
+    ),
+    ...(typeof deviceAuthorizationEndpoint === 'string'
+      ? {
+          deviceAuthorizationEndpoint: requireTrustedXaiOAuthEndpoint(
+            deviceAuthorizationEndpoint,
+            'device authorization endpoint',
+          ),
+        }
+      : {}),
+  }
+}

--- a/src/utils/providerProfile.test.ts
+++ b/src/utils/providerProfile.test.ts
@@ -485,6 +485,82 @@ test('codex profiles require a chatgpt account id', () => {
   assert.equal(env, null)
 })
 
+// Regression: a user with `OPENAI_API_KEY=sk-openai-…` in their shell
+// who signs into xAI OAuth previously had that generic OpenAI key
+// promoted into both OPENAI_API_KEY and XAI_API_KEY for the xAI
+// profile, dropping XAI_CREDENTIAL_SOURCE. openaiShim then sent the
+// OpenAI key as a Bearer to api.x.ai/v1 — wrong account, wrong key,
+// 401 (and leaks the OpenAI key to xAI). Marker-tagged xAI OAuth
+// profiles must ignore generic OpenAI credentials entirely.
+test('xai OAuth profile ignores ambient OPENAI_API_KEY and preserves marker', async () => {
+  const env = await buildLaunchEnv({
+    profile: 'xai',
+    persisted: profile('xai', {
+      OPENAI_BASE_URL: 'https://api.x.ai/v1',
+      OPENAI_MODEL: 'grok-4.3',
+      XAI_CREDENTIAL_SOURCE: 'oauth',
+    }),
+    goal: 'balanced',
+    processEnv: {
+      OPENAI_API_KEY: 'sk-openai-shell-key',
+    },
+  })
+
+  // Marker survives so startup validation accepts the profile.
+  assert.equal(env.XAI_CREDENTIAL_SOURCE, 'oauth')
+  // OpenAI key is NOT promoted into the xAI bearer surface.
+  assert.equal(env.XAI_API_KEY, undefined)
+  // openaiShim short-circuits on OPENAI_API_KEY before checking the
+  // stored OAuth token, so it must also be cleared from the resulting
+  // process env (clearManagedProfileEnv + no promotion in profileEnv).
+  assert.equal(env.OPENAI_API_KEY, undefined)
+  // Base URL and model still come through.
+  assert.equal(env.OPENAI_BASE_URL, 'https://api.x.ai/v1')
+  assert.equal(env.OPENAI_MODEL, 'grok-4.3')
+})
+
+test('xai OAuth profile still honors an explicit XAI_API_KEY override', async () => {
+  const env = await buildLaunchEnv({
+    profile: 'xai',
+    persisted: profile('xai', {
+      OPENAI_BASE_URL: 'https://api.x.ai/v1',
+      OPENAI_MODEL: 'grok-4.3',
+      XAI_CREDENTIAL_SOURCE: 'oauth',
+    }),
+    goal: 'balanced',
+    processEnv: {
+      XAI_API_KEY: 'xai-explicit-override',
+      OPENAI_API_KEY: 'sk-openai-shell-key',
+    },
+  })
+
+  // Explicit XAI_API_KEY wins; the OAuth marker drops because we have
+  // a concrete bearer to send.
+  assert.equal(env.XAI_API_KEY, 'xai-explicit-override')
+  assert.equal(env.OPENAI_API_KEY, 'xai-explicit-override')
+  assert.equal(env.XAI_CREDENTIAL_SOURCE, undefined)
+})
+
+test('xai non-OAuth profile (legacy api-key flow) still accepts OPENAI_API_KEY fallback', async () => {
+  // Backward-compat: an xAI profile saved before the OAuth flow existed
+  // (no XAI_CREDENTIAL_SOURCE marker) used to inherit OPENAI_API_KEY
+  // for one-off connections. Don't break that path.
+  const env = await buildLaunchEnv({
+    profile: 'xai',
+    persisted: profile('xai', {
+      OPENAI_BASE_URL: 'https://api.x.ai/v1',
+      OPENAI_MODEL: 'grok-4.3',
+    }),
+    goal: 'balanced',
+    processEnv: {
+      OPENAI_API_KEY: 'xai-disguised-as-openai-key',
+    },
+  })
+
+  assert.equal(env.XAI_API_KEY, 'xai-disguised-as-openai-key')
+  assert.equal(env.OPENAI_API_KEY, 'xai-disguised-as-openai-key')
+})
+
 test('codex launch clears openai-compatible format and custom auth env', async () => {
   const env = await buildLaunchEnv({
     profile: 'codex',

--- a/src/utils/providerProfile.ts
+++ b/src/utils/providerProfile.ts
@@ -1341,17 +1341,35 @@ export async function buildLaunchEnv(options: {
   }
 
   if (options.profile === 'xai') {
-    const xaiKey =
-      sanitizeApiKey(processEnv.XAI_API_KEY) ||
-      sanitizeApiKey(persistedEnv.XAI_API_KEY) ||
-      sanitizeApiKey(processEnv.OPENAI_API_KEY) ||
-      sanitizeApiKey(persistedEnv.OPENAI_API_KEY)
+    // For OAuth-tagged profiles, do not fall back to OPENAI_API_KEY /
+    // persisted OPENAI_API_KEY. The user's shell OpenAI key is for
+    // api.openai.com — sending it as a bearer to api.x.ai/v1 just
+    // returns 401 (or worse, leaks the OpenAI key to xAI). When the
+    // saved profile is OAuth, only an explicit XAI_API_KEY can
+    // override; otherwise leave the env keyless and let openaiShim
+    // resolve the stored OAuth access token at request time.
+    const isOAuthProfile = persistedEnv.XAI_CREDENTIAL_SOURCE === 'oauth'
+    const xaiKey = isOAuthProfile
+      ? sanitizeApiKey(processEnv.XAI_API_KEY) ||
+        sanitizeApiKey(persistedEnv.XAI_API_KEY)
+      : sanitizeApiKey(processEnv.XAI_API_KEY) ||
+        sanitizeApiKey(persistedEnv.XAI_API_KEY) ||
+        sanitizeApiKey(processEnv.OPENAI_API_KEY) ||
+        sanitizeApiKey(persistedEnv.OPENAI_API_KEY)
 
     const env = buildXaiProfileEnv({
       model: shellOpenAIModel || persistedOpenAIModel,
       baseUrl: shellOpenAIBaseUrl || persistedOpenAIBaseUrl,
       apiKey: xaiKey,
-      processEnv,
+      // Scrub OPENAI_API_KEY before buildXaiProfileEnv reads processEnv
+      // so it can't be re-introduced via the internal fallback inside
+      // that helper. The shell key still survives in the wider
+      // processEnv copy returned by buildCompatibilityProcessEnv, but
+      // it won't be promoted into XAI_API_KEY / OPENAI_API_KEY for
+      // this profile's env.
+      processEnv: isOAuthProfile
+        ? { ...processEnv, OPENAI_API_KEY: undefined, XAI_API_KEY: undefined }
+        : processEnv,
     })
     const customHeaders = shellCustomHeaders || persistedCustomHeaders
     if (customHeaders) {
@@ -1360,18 +1378,24 @@ export async function buildLaunchEnv(options: {
     // Preserve the OAuth credential-source marker so startup validation
     // accepts an xAI OAuth profile (no XAI_API_KEY needed; openaiShim
     // resolves the stored access token at request time).
-    if (
-      !env.XAI_API_KEY &&
-      persistedEnv.XAI_CREDENTIAL_SOURCE === 'oauth'
-    ) {
+    if (!env.XAI_API_KEY && isOAuthProfile) {
       env.XAI_CREDENTIAL_SOURCE = 'oauth'
     }
 
-    return buildCompatibilityProcessEnv({
+    // For OAuth profiles, also clear any ambient OPENAI_API_KEY from
+    // the returned compatibility env. openaiShim's resolver checks
+    // process.env.OPENAI_API_KEY before falling back to the stored
+    // OAuth token; leaving the shell key there would short-circuit
+    // OAuth and send the wrong bearer to api.x.ai/v1.
+    const result = buildCompatibilityProcessEnv({
       processEnv,
       compatibilityMode: 'openai',
       profileEnv: env,
     })
+    if (isOAuthProfile && !env.XAI_API_KEY) {
+      delete result.OPENAI_API_KEY
+    }
+    return result
   }
 
   if (options.profile === 'ollama') {

--- a/src/utils/providerProfile.ts
+++ b/src/utils/providerProfile.ts
@@ -91,6 +91,7 @@ const PROFILE_ENV_KEYS = [
   'BNKR_API_KEY',
   'BANKR_MODEL',
   'XAI_API_KEY',
+  'XAI_CREDENTIAL_SOURCE',
   'VENICE_API_KEY',
   'MIMO_API_KEY',
 ] as const
@@ -171,6 +172,7 @@ export type ProfileEnv = {
   BNKR_API_KEY?: string
   BANKR_MODEL?: string
   XAI_API_KEY?: string
+  XAI_CREDENTIAL_SOURCE?: 'oauth'
   VENICE_API_KEY?: string
   MIMO_API_KEY?: string
 }
@@ -913,6 +915,43 @@ export function clearPersistedCodexOAuthProfile(
   for (const filePath of resolveProfileFileCleanupPaths(options)) {
     const persisted = readProfileFile(filePath)
     if (isPersistedCodexOAuthProfile(persisted)) {
+      rmSync(filePath, { force: true })
+      removedPath ??= filePath
+    }
+  }
+
+  return removedPath
+}
+
+const XAI_OAUTH_DEFAULT_BASE_URL = 'https://api.x.ai/v1'
+
+export function buildXaiOAuthProfileEnv(options: {
+  model?: string
+}): ProfileEnv {
+  return {
+    OPENAI_BASE_URL: XAI_OAUTH_DEFAULT_BASE_URL,
+    OPENAI_MODEL: options.model ?? 'grok-4.3',
+    XAI_CREDENTIAL_SOURCE: 'oauth',
+  }
+}
+
+export function isPersistedXaiOAuthProfile(
+  persisted: ProfileFile | null,
+): boolean {
+  return (
+    persisted?.profile === 'xai' &&
+    persisted.env.XAI_CREDENTIAL_SOURCE === 'oauth'
+  )
+}
+
+export function clearPersistedXaiOAuthProfile(
+  options?: ProfileFileLocation,
+): string | null {
+  let removedPath: string | null = null
+
+  for (const filePath of resolveProfileFileCleanupPaths(options)) {
+    const persisted = readProfileFile(filePath)
+    if (isPersistedXaiOAuthProfile(persisted)) {
       rmSync(filePath, { force: true })
       removedPath ??= filePath
     }

--- a/src/utils/providerProfile.ts
+++ b/src/utils/providerProfile.ts
@@ -1357,6 +1357,15 @@ export async function buildLaunchEnv(options: {
     if (customHeaders) {
       env.ANTHROPIC_CUSTOM_HEADERS = customHeaders
     }
+    // Preserve the OAuth credential-source marker so startup validation
+    // accepts an xAI OAuth profile (no XAI_API_KEY needed; openaiShim
+    // resolves the stored access token at request time).
+    if (
+      !env.XAI_API_KEY &&
+      persistedEnv.XAI_CREDENTIAL_SOURCE === 'oauth'
+    ) {
+      env.XAI_CREDENTIAL_SOURCE = 'oauth'
+    }
 
     return buildCompatibilityProcessEnv({
       processEnv,

--- a/src/utils/providerProfiles.test.ts
+++ b/src/utils/providerProfiles.test.ts
@@ -1228,6 +1228,64 @@ describe('setActiveProviderProfile', () => {
     }
   })
 
+  // xAI OAuth profile (provider='xai', no API key) must persist the
+  // startup file as profile='xai' with XAI_CREDENTIAL_SOURCE='oauth' so
+  // (a) startup validation accepts it without XAI_API_KEY, and (b)
+  // clearPersistedXaiOAuthProfile() can find and remove it on logout.
+  // Regression: previously written as profile='openai' with no marker,
+  // leaving a stale startup file that hit the missing-cred warning on
+  // every non-interactive launch after logout.
+  test('persists xAI OAuth profile with marker so logout cleanup can clear it', async () => {
+    const tempDir = mkdtempSync(join(tmpdir(), 'openclaude-provider-'))
+    const configDir = mkdtempSync(join(tmpdir(), 'openclaude-provider-config-'))
+    process.chdir(tempDir)
+    process.env.CLAUDE_CONFIG_DIR = configDir
+
+    try {
+      const { setActiveProviderProfile } =
+        await importFreshProviderProfileModules()
+      const { clearPersistedXaiOAuthProfile, isPersistedXaiOAuthProfile } =
+        await import('./providerProfile.js')
+
+      const xaiOAuthProfile = buildProfile({
+        id: 'xai_oauth_prof',
+        name: 'xAI OAuth',
+        provider: 'xai',
+        baseUrl: 'https://api.x.ai/v1',
+        model: 'grok-4.3',
+        apiKey: '',
+      })
+
+      saveMockGlobalConfig(current => ({
+        ...current,
+        providerProfiles: [xaiOAuthProfile],
+      }))
+
+      const result = setActiveProviderProfile('xai_oauth_prof', { configDir })
+      const profilePath = join(configDir, '.openclaude-profile.json')
+      const persisted = JSON.parse(readFileSync(profilePath, 'utf8'))
+
+      expect(result?.id).toBe('xai_oauth_prof')
+      expect(persisted.profile).toBe('xai')
+      expect(persisted.env.XAI_CREDENTIAL_SOURCE).toBe('oauth')
+      expect(persisted.env.OPENAI_BASE_URL).toBe('https://api.x.ai/v1')
+      expect(persisted.env.OPENAI_MODEL).toBe('grok-4.3')
+      // No leaked API key fields.
+      expect(persisted.env.OPENAI_API_KEY).toBeUndefined()
+      expect(persisted.env.XAI_API_KEY).toBeUndefined()
+
+      // Logout cleanup recognises and removes the marker-tagged file.
+      expect(isPersistedXaiOAuthProfile(persisted)).toBe(true)
+      const removed = clearPersistedXaiOAuthProfile({ configDir })
+      expect(removed).toBe(profilePath)
+      expect(existsSync(profilePath)).toBe(false)
+    } finally {
+      process.chdir(originalCwd)
+      rmSync(tempDir, { recursive: true, force: true })
+      rmSync(configDir, { recursive: true, force: true })
+    }
+  })
+
   test('persists no-key openai-compatible profiles for restart fallback', async () => {
     const tempDir = mkdtempSync(join(tmpdir(), 'openclaude-provider-'))
     const configDir = mkdtempSync(join(tmpdir(), 'openclaude-provider-config-'))

--- a/src/utils/providerProfiles.ts
+++ b/src/utils/providerProfiles.ts
@@ -22,6 +22,7 @@ import {
   buildNvidiaNimProfileEnv,
   buildOpenAIProfileEnv,
   buildVeniceProfileEnv,
+  buildXaiOAuthProfileEnv,
   buildXiaomiMimoProfileEnv,
   buildVertexProfileEnv,
   clearManagedProfileEnv,
@@ -1099,6 +1100,24 @@ function buildStartupProfileFromActiveProfile(
         return env
           ? { profile: 'openai', env: applySupportedProfileCustomHeaders(activeProfile, env) }
           : null
+      }
+
+      // xAI OAuth profile (provider=xai with no API key). Tag the startup
+      // file with profile='xai' + XAI_CREDENTIAL_SOURCE=oauth so:
+      //   1. validation accepts it at startup (no spurious
+      //      "XAI_API_KEY is required" before openaiShim resolves the
+      //      stored OAuth token)
+      //   2. `clearPersistedXaiOAuthProfile()` can identify and remove it
+      //      on logout, instead of leaving a stale openai-shaped file
+      //      pointing at api.x.ai with no credential.
+      if (route.vendorId === 'xai' && !activeProfile.apiKey) {
+        const env = applySupportedProfileCustomHeaders(activeProfile, {
+          ...buildXaiOAuthProfileEnv({
+            model: getPrimaryModel(activeProfile.model),
+          }),
+          OPENAI_BASE_URL: activeProfile.baseUrl,
+        })
+        return { profile: 'xai', env }
       }
 
       const env = buildOpenAICompatibleStartupEnv(activeProfile)

--- a/src/utils/providerValidation.test.ts
+++ b/src/utils/providerValidation.test.ts
@@ -37,6 +37,8 @@ const ENV_KEYS = [
   'GEMINI_ACCESS_TOKEN',
   'GEMINI_AUTH_MODE',
   'GOOGLE_APPLICATION_CREDENTIALS',
+  'XAI_API_KEY',
+  'XAI_CREDENTIAL_SOURCE',
 ] as const
 
 const originalEnv: Record<string, string | undefined> = {}
@@ -193,6 +195,78 @@ test('bankr validation accepts BNKR_API_KEY without OPENAI_API_KEY', async () =>
   delete process.env.OPENAI_API_KEY
 
   await expect(getProviderValidationError(process.env)).resolves.toBeNull()
+})
+
+// xAI accepts either XAI_API_KEY (legacy) or OAuth credentials. The OAuth
+// credentials path is the saved-profile flow: applying the profile sets
+// XAI_CREDENTIAL_SOURCE=oauth in process.env, so validation must not
+// require XAI_API_KEY when that marker is present.
+test('xai validation accepts XAI_API_KEY without OPENAI_API_KEY', async () => {
+  process.env.CLAUDE_CODE_USE_OPENAI = '1'
+  process.env.OPENAI_BASE_URL = 'https://api.x.ai/v1'
+  process.env.OPENAI_MODEL = 'grok-4.3'
+  process.env.XAI_API_KEY = 'xai-live-key'
+  delete process.env.OPENAI_API_KEY
+
+  await expect(getProviderValidationError(process.env)).resolves.toBeNull()
+})
+
+test('xai validation accepts XAI_CREDENTIAL_SOURCE=oauth without an API key', async () => {
+  process.env.CLAUDE_CODE_USE_OPENAI = '1'
+  process.env.OPENAI_BASE_URL = 'https://api.x.ai/v1'
+  process.env.OPENAI_MODEL = 'grok-4.3'
+  process.env.XAI_CREDENTIAL_SOURCE = 'oauth'
+  delete process.env.XAI_API_KEY
+  delete process.env.OPENAI_API_KEY
+
+  await expect(getProviderValidationError(process.env)).resolves.toBeNull()
+})
+
+test('xai validation surfaces sign-in guidance when no credential source is set', async () => {
+  process.env.CLAUDE_CODE_USE_OPENAI = '1'
+  process.env.OPENAI_BASE_URL = 'https://api.x.ai/v1'
+  process.env.OPENAI_MODEL = 'grok-4.3'
+  delete process.env.XAI_API_KEY
+  delete process.env.XAI_CREDENTIAL_SOURCE
+  delete process.env.OPENAI_API_KEY
+
+  // Inject "no stored credentials" so this test isn't sensitive to the
+  // developer's actual login state.
+  const error = await getProviderValidationError(process.env, {
+    hasStoredXaiOAuthCredentials: async () => false,
+  })
+  expect(error).not.toBeNull()
+  expect(error!).toContain('XAI_API_KEY is required')
+  expect(error!).toContain('openclaude auth xai login')
+})
+
+test('xai validation accepts stored OAuth credentials even without an env marker', async () => {
+  process.env.CLAUDE_CODE_USE_OPENAI = '1'
+  process.env.OPENAI_BASE_URL = 'https://api.x.ai/v1'
+  process.env.OPENAI_MODEL = 'grok-4.3'
+  delete process.env.XAI_API_KEY
+  delete process.env.XAI_CREDENTIAL_SOURCE
+  delete process.env.OPENAI_API_KEY
+
+  await expect(
+    getProviderValidationError(process.env, {
+      hasStoredXaiOAuthCredentials: async () => true,
+    }),
+  ).resolves.toBeNull()
+})
+
+test('xai validation ignores unrelated XAI_CREDENTIAL_SOURCE values', async () => {
+  process.env.CLAUDE_CODE_USE_OPENAI = '1'
+  process.env.OPENAI_BASE_URL = 'https://api.x.ai/v1'
+  process.env.OPENAI_MODEL = 'grok-4.3'
+  process.env.XAI_CREDENTIAL_SOURCE = 'something-else'
+  delete process.env.XAI_API_KEY
+  delete process.env.OPENAI_API_KEY
+
+  const error = await getProviderValidationError(process.env, {
+    hasStoredXaiOAuthCredentials: async () => false,
+  })
+  expect(error).not.toBeNull()
 })
 
 test('openai validation does not accept unrelated minimax credentials', async () => {

--- a/src/utils/providerValidation.ts
+++ b/src/utils/providerValidation.ts
@@ -31,6 +31,12 @@ import {
   type GeminiResolvedCredential,
   resolveGeminiCredential,
 } from './geminiAuth.js'
+import { readXaiCredentialsAsync } from './xaiCredentials.js'
+
+async function defaultHasStoredXaiOAuthCredentials(): Promise<boolean> {
+  const stored = await readXaiCredentialsAsync()
+  return Boolean(stored?.accessToken && stored?.refreshToken)
+}
 import { PROFILE_FILE_NAME } from './providerProfile.js'
 import {
   redactSecretValueForDisplay,
@@ -278,6 +284,7 @@ async function getDescriptorValidationError(
     resolveGeminiCredential?: (
       env: NodeJS.ProcessEnv,
     ) => Promise<GeminiResolvedCredential>
+    hasStoredXaiOAuthCredentials?: () => Promise<boolean>
   },
 ): Promise<string | null> {
   const validation = target.descriptor.validation
@@ -314,6 +321,40 @@ async function getDescriptorValidationError(
       }
 
       return null
+    }
+
+    case 'xai-credential': {
+      // 1. API key in env (legacy / explicit override path)
+      if (
+        validation.credentialEnvVars.some(envVar => hasNonEmptyEnvValue(env, envVar))
+      ) {
+        return null
+      }
+      // 2. OAuth profile marker, e.g. XAI_CREDENTIAL_SOURCE=oauth set by
+      // the saved profile's env. Cheap synchronous check before we touch
+      // secure storage.
+      const markers = validation.credentialSourceEnvMarkers
+      if (markers) {
+        for (const [markerEnv, allowedValues] of Object.entries(markers)) {
+          const value = env[markerEnv]?.trim()
+          if (value && allowedValues.includes(value)) {
+            return null
+          }
+        }
+      }
+      // 3. Stored OAuth credentials — covers the gap where a user has
+      // signed in (secure storage populated) but the profile env hasn't
+      // been applied yet (e.g. fresh process before applySavedProfile).
+      // Bare mode short-circuits inside readXaiCredentialsAsync, so this
+      // is safe to call unconditionally. Injectable so tests don't
+      // depend on the developer's actual login state.
+      const hasStored = options.hasStoredXaiOAuthCredentials
+        ? await options.hasStoredXaiOAuthCredentials()
+        : await defaultHasStoredXaiOAuthCredentials()
+      if (hasStored) {
+        return null
+      }
+      return validation.missingCredentialMessage
     }
   }
 }
@@ -374,6 +415,7 @@ export async function getProviderValidationError(
     resolveGeminiCredential?: (
       env: NodeJS.ProcessEnv,
     ) => Promise<GeminiResolvedCredential>
+    hasStoredXaiOAuthCredentials?: () => Promise<boolean>
   },
 ): Promise<string | null> {
   const secretSource: SecretValueSource = {
@@ -445,6 +487,7 @@ export async function getProviderValidationError(
         {
           request,
           resolveGeminiCredential: options?.resolveGeminiCredential,
+          hasStoredXaiOAuthCredentials: options?.hasStoredXaiOAuthCredentials,
         },
       )
 

--- a/src/utils/xaiCredentials.ts
+++ b/src/utils/xaiCredentials.ts
@@ -1,0 +1,264 @@
+/**
+ * Persistent storage and auto-refresh for xAI OAuth credentials.
+ *
+ * Modeled after `codexCredentials.ts`. Stores tokens via secure storage so
+ * they survive across sessions. Refreshes proactively when the access token
+ * is within ~60s of expiry.
+ */
+
+import { isBareMode } from './envUtils.js'
+import { getSecureStorage } from './secureStorage/index.js'
+import {
+  asTrimmedString,
+  decodeJwtPayload,
+  deriveExpiresMsFromJwt,
+} from '../services/api/xaiOAuthShared.js'
+import {
+  refreshXaiAccessToken,
+  type XaiOAuthTokens,
+} from '../services/api/xaiOAuth.js'
+
+export const XAI_STORAGE_KEY = 'xai' as const
+const XAI_TOKEN_REFRESH_SKEW_MS = 60_000
+const XAI_TOKEN_REFRESH_RETRY_COOLDOWN_MS = 60_000
+
+export type XaiCredentialBlob = {
+  accessToken: string
+  refreshToken: string
+  idToken?: string
+  expiresAt?: number
+  tokenEndpoint: string
+  email?: string
+  displayName?: string
+  accountId?: string
+  lastRefreshAt?: number
+  lastRefreshFailureAt?: number
+}
+
+let inFlightXaiRefresh:
+  | Promise<{ refreshed: boolean; credentials?: XaiCredentialBlob }>
+  | null = null
+let inMemoryLastRefreshFailureAt: number | null = null
+
+function getXaiSecureStorage() {
+  return getSecureStorage({ allowPlainTextFallback: false })
+}
+
+function normalizeXaiCredentialBlob(
+  value: unknown,
+): XaiCredentialBlob | undefined {
+  if (!value || typeof value !== 'object') return undefined
+  const record = value as Record<string, unknown>
+  const accessToken = asTrimmedString(record.accessToken)
+  const refreshToken = asTrimmedString(record.refreshToken)
+  const tokenEndpoint = asTrimmedString(record.tokenEndpoint)
+  if (!accessToken || !refreshToken || !tokenEndpoint) return undefined
+  return {
+    accessToken,
+    refreshToken,
+    tokenEndpoint,
+    idToken: asTrimmedString(record.idToken),
+    email: asTrimmedString(record.email),
+    displayName: asTrimmedString(record.displayName),
+    accountId: asTrimmedString(record.accountId),
+    expiresAt:
+      typeof record.expiresAt === 'number' && Number.isFinite(record.expiresAt)
+        ? record.expiresAt
+        : undefined,
+    lastRefreshAt:
+      typeof record.lastRefreshAt === 'number' &&
+      Number.isFinite(record.lastRefreshAt)
+        ? record.lastRefreshAt
+        : undefined,
+    lastRefreshFailureAt:
+      typeof record.lastRefreshFailureAt === 'number' &&
+      Number.isFinite(record.lastRefreshFailureAt)
+        ? record.lastRefreshFailureAt
+        : undefined,
+  }
+}
+
+function effectiveExpiresAt(blob: XaiCredentialBlob): number | undefined {
+  return blob.expiresAt ?? deriveExpiresMsFromJwt(blob.accessToken)
+}
+
+function shouldRefreshXaiToken(blob: XaiCredentialBlob): boolean {
+  const expiresAt = effectiveExpiresAt(blob)
+  if (expiresAt === undefined) return false
+  return expiresAt <= Date.now() + XAI_TOKEN_REFRESH_SKEW_MS
+}
+
+function isWithinRefreshFailureCooldown(
+  blob: XaiCredentialBlob,
+  now = Date.now(),
+): boolean {
+  const lastFailure = Math.max(
+    blob.lastRefreshFailureAt ?? 0,
+    inMemoryLastRefreshFailureAt ?? 0,
+  )
+  if (!lastFailure) return false
+  return now - lastFailure < XAI_TOKEN_REFRESH_RETRY_COOLDOWN_MS
+}
+
+export function readXaiCredentials(): XaiCredentialBlob | undefined {
+  if (isBareMode()) return undefined
+  try {
+    const data = getXaiSecureStorage().read()
+    return normalizeXaiCredentialBlob(data?.[XAI_STORAGE_KEY])
+  } catch {
+    return undefined
+  }
+}
+
+export async function readXaiCredentialsAsync(): Promise<
+  XaiCredentialBlob | undefined
+> {
+  if (isBareMode()) return undefined
+  try {
+    const data = await getXaiSecureStorage().readAsync()
+    return normalizeXaiCredentialBlob(data?.[XAI_STORAGE_KEY])
+  } catch {
+    return undefined
+  }
+}
+
+export function saveXaiCredentials(
+  blob: XaiCredentialBlob,
+): { success: boolean; warning?: string } {
+  if (isBareMode()) {
+    return {
+      success: false,
+      warning: 'Bare mode: secure storage is disabled.',
+    }
+  }
+  const normalized = normalizeXaiCredentialBlob(blob)
+  if (!normalized) {
+    return { success: false, warning: 'xAI credentials are incomplete.' }
+  }
+  const storage = getXaiSecureStorage()
+  const previous = storage.read() || {}
+  const next = {
+    ...(previous as Record<string, unknown>),
+    [XAI_STORAGE_KEY]: {
+      ...normalized,
+      lastRefreshAt: normalized.lastRefreshAt ?? Date.now(),
+    },
+  }
+  const result = storage.update(next as typeof previous)
+  if (result.success) {
+    const stored = normalizeXaiCredentialBlob(next[XAI_STORAGE_KEY])
+    inMemoryLastRefreshFailureAt = stored?.lastRefreshFailureAt ?? null
+  }
+  return result
+}
+
+export function clearXaiCredentials(): {
+  success: boolean
+  warning?: string
+} {
+  if (isBareMode()) return { success: true }
+  const storage = getXaiSecureStorage()
+  const previous = storage.read() || {}
+  const next = { ...(previous as Record<string, unknown>) }
+  delete next[XAI_STORAGE_KEY]
+  const result = storage.update(next as typeof previous)
+  if (result.success) inMemoryLastRefreshFailureAt = null
+  return result
+}
+
+function persistRefreshFailure(
+  blob: XaiCredentialBlob,
+  occurredAt: number,
+): void {
+  const result = saveXaiCredentials({
+    ...blob,
+    lastRefreshFailureAt: occurredAt,
+  })
+  if (!result.success) inMemoryLastRefreshFailureAt = occurredAt
+}
+
+function toBlob(tokens: XaiOAuthTokens, previous?: XaiCredentialBlob): XaiCredentialBlob {
+  return {
+    accessToken: tokens.accessToken,
+    refreshToken: tokens.refreshToken || previous?.refreshToken || '',
+    tokenEndpoint: tokens.tokenEndpoint,
+    idToken: tokens.idToken ?? previous?.idToken,
+    email: tokens.email ?? previous?.email,
+    displayName: tokens.displayName ?? previous?.displayName,
+    accountId: tokens.accountId ?? previous?.accountId,
+    expiresAt: tokens.expiresAt,
+    lastRefreshAt: Date.now(),
+  }
+}
+
+export function persistXaiOAuthTokens(
+  tokens: XaiOAuthTokens,
+): { success: boolean; warning?: string } {
+  return saveXaiCredentials(toBlob(tokens, readXaiCredentials()))
+}
+
+export async function refreshXaiAccessTokenIfNeeded(options?: {
+  force?: boolean
+}): Promise<{ refreshed: boolean; credentials?: XaiCredentialBlob }> {
+  if (isBareMode()) return { refreshed: false }
+
+  const current = await readXaiCredentialsAsync()
+  if (!current) return { refreshed: false }
+  if (!current.refreshToken) return { refreshed: false, credentials: current }
+  if (!options?.force && !shouldRefreshXaiToken(current)) {
+    return { refreshed: false, credentials: current }
+  }
+  if (!options?.force && isWithinRefreshFailureCooldown(current)) {
+    return { refreshed: false, credentials: current }
+  }
+  if (inFlightXaiRefresh) return inFlightXaiRefresh
+
+  inFlightXaiRefresh = (async () => {
+    const attemptedAt = Date.now()
+    try {
+      const tokens = await refreshXaiAccessToken({
+        refreshToken: current.refreshToken,
+        tokenEndpoint: current.tokenEndpoint,
+      })
+      const next = toBlob(tokens, current)
+      const save = saveXaiCredentials(next)
+      if (!save.success) {
+        throw new Error(
+          save.warning ??
+            'xAI token refresh succeeded but credentials could not be saved.',
+        )
+      }
+      return { refreshed: true, credentials: next }
+    } catch (error) {
+      persistRefreshFailure(current, attemptedAt)
+      throw error
+    } finally {
+      inFlightXaiRefresh = null
+    }
+  })()
+
+  return inFlightXaiRefresh
+}
+
+/**
+ * Resolve a usable xAI Bearer access token. Returns undefined if no
+ * credentials are stored or if a refresh is needed but failed.
+ */
+export async function resolveXaiAccessToken(): Promise<string | undefined> {
+  if (isBareMode()) return undefined
+  try {
+    const { credentials } = await refreshXaiAccessTokenIfNeeded()
+    const blob = credentials ?? (await readXaiCredentialsAsync())
+    return blob?.accessToken
+  } catch {
+    const blob = await readXaiCredentialsAsync()
+    return blob?.accessToken
+  }
+}
+
+// Exported only for tests/debugging.
+export function _decodeAccessTokenPayload(
+  blob: XaiCredentialBlob,
+): Record<string, unknown> | undefined {
+  return decodeJwtPayload(blob.accessToken)
+}


### PR DESCRIPTION
Sign in to xAI with your account instead of an API key. Inference uses the access token as a Bearer to api.x.ai/v1 (same surface as XAI_API_KEY) with automatic refresh ~60s before expiry.

CLI:  openclaude auth xai {login|device|status|logout}
UI:   /login → 3rd-party platform → xAI OAuth (Grok)

Implementation mirrors openclaw's xai-oauth (shared client_id, PKCE, OIDC discovery against auth.x.ai, trusted-host gating, refresh_token). The loopback callback server (127.0.0.1:56121) explicitly echoes CORS preflight for auth.x.ai / accounts.x.ai so xAI's browser-side push reaches us; if the loopback still fails (firewall, remote host), users can paste the code shown on xAI's auth page directly into the CLI or the ProviderManager input.

Also adds grok-code-fast-1 to the xAI catalog and the x-grok-conv-id prompt-caching header (mirrors hermes-agent).