### PR TITLE
fix: guard detectStubLeaks against TDZ in unbundled runs

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,12 +237,24 @@ Free tier at [firecrawl.dev](https://firecrawl.dev) includes 500 credits. The ke
 
 OpenClaude can be run as a headless gRPC service, allowing you to integrate its agentic capabilities (tools, bash, file editing) into other applications, CI/CD pipelines, or custom user interfaces. The server uses bidirectional streaming to send real-time text chunks, tool calls, and request permissions for sensitive commands.
 
+### Prerequisites
+
+- **Bun** (runtime) — install with:
+  ```bash
+  curl -fsSL https://bun.sh/install | bash
+  ```
+  or see [bun.sh/docs/installation](https://bun.sh/docs/installation)
+- Install project dependencies:
+  ```bash
+  bun install
+  ```
+
 ### 1. Start the gRPC Server
 
 Start the core engine as a gRPC service on `localhost:50051`:
 
 ```bash
-npm run dev:grpc
+bun run dev:grpc
 ```
 
 #### Configuration
@@ -259,7 +271,7 @@ We provide a lightweight CLI client that communicates exclusively over gRPC. It 
 In a separate terminal, run:
 
 ```bash
-npm run dev:grpc:cli
+bun run dev:grpc:cli
 ```
 
 *Note: The gRPC definitions are located in `src/proto/openclaude.proto`. You can use this file to generate clients in Python, Go, Rust, or any other language.*

--- a/README.md
+++ b/README.md
@@ -248,6 +248,10 @@ OpenClaude can be run as a headless gRPC service, allowing you to integrate its 
   ```bash
   bun install
   ```
+- **Python 3.10+** with `grpcio` (for the Python client):
+  ```bash
+  pip install grpcio
+  ```
 
 ### 1. Start the gRPC Server
 
@@ -274,7 +278,22 @@ In a separate terminal, run:
 bun run dev:grpc:cli
 ```
 
-*Note: The gRPC definitions are located in `src/proto/openclaude.proto`. You can use this file to generate clients in Python, Go, Rust, or any other language.*
+### 3. Run the Python Client
+
+A Python client is also available — it supports the same interactive streaming, tool calls, and permission prompts:
+
+```bash
+# Interactive mode
+python python/grpc_client/client.py
+
+# One-shot message
+python python/grpc_client/client.py --message "list files"
+
+# Custom host/port
+python python/grpc_client/client.py --host 0.0.0.0 --port 50051
+```
+
+*Note: The gRPC definitions are located in `src/proto/openclaude.proto`. You can use this file to generate clients in Go, Rust, or any other language.*
 
 ---
 

--- a/src/entrypoints/sdk/index.ts
+++ b/src/entrypoints/sdk/index.ts
@@ -24,27 +24,37 @@ import { init } from '../init.js'
  * If any resolved to a stub, it means a TUI dependency leaked through.
  */
 function detectStubLeaks(): void {
-  const criticalImports: Array<{ name: string; mod: Record<string, unknown> }> = [
+  const criticalImports: Array<{ name: string; mod: unknown }> = [
     // QueryEngine is the core SDK engine — must never be a stub
-    { name: 'QueryEngine', mod: QueryEngine as unknown as Record<string, unknown> },
+    { name: 'QueryEngine', mod: QueryEngine },
     // These are imported by this file and must be real modules, not stubs
-    { name: 'getTools', mod: getTools as unknown as Record<string, unknown> },
-    { name: 'init', mod: init as unknown as Record<string, unknown> },
+    { name: 'getTools', mod: getTools },
+    { name: 'init', mod: init },
   ]
 
   for (const { name, mod } of criticalImports) {
-    if ('__stub' in mod && mod.__stub === true) {
-      throw new Error(
-        `SDK init error: "${name}" resolved to a build stub at runtime. ` +
-        `This means a TUI/CLI dependency leaked into the SDK bundle. ` +
-        `Report this at https://github.com/Gitlawb/openclaude/issues`,
-      )
+    try {
+      if (mod !== null && typeof mod === 'object' && '__stub' in (mod as Record<string, unknown>) && (mod as Record<string, unknown>).__stub === true) {
+        throw new Error(
+          `SDK init error: "${name}" resolved to a build stub at runtime. ` +
+          `This means a TUI/CLI dependency leaked into the SDK bundle. ` +
+          `Report this at https://github.com/Gitlawb/openclaude/issues`,
+        )
+      }
+    } catch {
+      // Some imports may be in the temporal dead zone due to circular
+      // dependencies when running unbundled (e.g. Bun directly). This is
+      // harmless — the stub substitution only happens in the esbuild bundle.
     }
   }
 }
 
 // Run leak detection once at module load time.
-detectStubLeaks()
+try {
+  detectStubLeaks()
+} catch {
+  // Gracefully skip if any import is still in TDZ (unbundled runs).
+}
 
 // ============================================================================
 // Re-exports from shared types

--- a/src/entrypoints/sdk/index.ts
+++ b/src/entrypoints/sdk/index.ts
@@ -41,10 +41,23 @@ function detectStubLeaks(): void {
           `Report this at https://github.com/Gitlawb/openclaude/issues`,
         )
       }
-    } catch {
+      // Imports that resolve to classes/functions (not module namespace objects)
+      // also need stub-checking. esbuild stubs are plain objects, so checking
+      // typeof === 'function' is inherently safe — a real module will pass.
+      if (typeof mod === 'function' && '__stub' in (mod as unknown as Record<string, unknown>)) {
+        throw new Error(
+          `SDK init error: "${name}" resolved to a build stub at runtime. ` +
+          `This means a TUI/CLI dependency leaked into the SDK bundle. ` +
+          `Report this at https://github.com/Gitlawb/openclaude/issues`,
+        )
+      }
+    } catch (e: unknown) {
       // Some imports may be in the temporal dead zone due to circular
       // dependencies when running unbundled (e.g. Bun directly). This is
       // harmless — the stub substitution only happens in the esbuild bundle.
+      if (!(e instanceof ReferenceError)) {
+        throw e
+      }
     }
   }
 }
@@ -52,8 +65,11 @@ function detectStubLeaks(): void {
 // Run leak detection once at module load time.
 try {
   detectStubLeaks()
-} catch {
+} catch (e: unknown) {
   // Gracefully skip if any import is still in TDZ (unbundled runs).
+  if (!(e instanceof ReferenceError)) {
+    throw e
+  }
 }
 
 // ============================================================================


### PR DESCRIPTION
Prevents ReferenceError when circular dependencies cause QueryEngine to be in the temporal dead zone during module evaluation. The stub leak check is only meaningful in the esbuild bundle — harmless to skip when running directly with Bun.

## Summary

- what changed
- why it changed

## Impact

- user-facing impact:
- developer/maintainer impact:

## Testing

- [ ] `bun run build`
- [ ] `bun run smoke`
- [ ] focused tests:

## Notes

- provider/model path tested:
- screenshots attached (if UI changed):
- follow-up work or known limitations:
