### PR TITLE
feat(config): add support for temp, top_p, and num_ctx in JSON config

### DIFF
--- a/src/Tool.ts
+++ b/src/Tool.ts
@@ -9,6 +9,7 @@ import type {
 import type { UUID } from 'crypto'
 import type { z } from 'zod/v4'
 import type { Command } from './commands.js'
+import type { ProviderOverride } from './services/api/authRouting.js'
 import type { CanUseToolFn } from './hooks/useCanUseTool.js'
 import type { ThinkingConfig } from './utils/thinking.js'
 
@@ -177,7 +178,7 @@ export type ToolUseContext = {
     /** Optional callback to get the latest tools (e.g., after MCP servers connect mid-query) */
     refreshTools?: () => Tools
     /** Per-agent provider override from agentRouting config */
-    providerOverride?: { model: string; baseURL: string; apiKey: string }
+    providerOverride?: ProviderOverride
   }
   abortController: AbortController
   readFileState: FileStateCache

--- a/src/query.ts
+++ b/src/query.ts
@@ -197,7 +197,6 @@ export type QueryParams = {
   skipCacheWrite?: boolean
   temperatureOverride?: number
   topPOverride?: number
-  numCtxOverride?: number
   // API task_budget (output_config.task_budget, beta task-budgets-2026-03-13).
   // Distinct from the tokenBudget +500k auto-continue feature. `total` is the
   // budget for the whole agentic turn; `remaining` is computed per iteration
@@ -282,7 +281,6 @@ async function* queryLoop(
     skipCacheWrite,
     temperatureOverride,
     topPOverride,
-    numCtxOverride,
   } = params
   const deps = params.deps ?? productionDeps()
 
@@ -383,13 +381,7 @@ async function* queryLoop(
     const queryChainIdForAnalytics =
       queryTracking.chainId as AnalyticsMetadata_I_VERIFIED_THIS_IS_NOT_CODE_OR_FILEPATHS
 
-    // Resolve context window once for this iteration (honoring overrides and env vars)
-    const envNumCtxStr = process.env.CLAUDE_CODE_MAX_CONTEXT_TOKENS
-    const parsedEnvNumCtx = envNumCtxStr ? parseInt(envNumCtxStr, 10) : NaN
-    const resolvedNumCtx =
-      numCtxOverride ??
-      toolUseContext.options.providerOverride?.num_ctx ??
-      (!isNaN(parsedEnvNumCtx) ? parsedEnvNumCtx : undefined)
+
 
     toolUseContext = {
       ...toolUseContext,
@@ -533,7 +525,6 @@ async function* queryLoop(
       querySource,
       tracking,
       snipTokensFreed,
-      resolvedNumCtx,
     )
     queryCheckpoint('query_autocompact_end')
 
@@ -705,7 +696,6 @@ async function* queryLoop(
       const { isAtBlockingLimit } = calculateTokenWarningState(
         tokenCountWithEstimation(messagesForQuery) - snipTokensFreed,
         toolUseContext.options.mainLoopModel,
-        resolvedNumCtx,
       )
       if (isAtBlockingLimit) {
         yield createAssistantAPIErrorMessage({
@@ -733,7 +723,6 @@ async function* queryLoop(
       const { isAboveAutoCompactThreshold } = calculateTokenWarningState(
         tokenUsage,
         model,
-        resolvedNumCtx,
       )
       if (isAboveAutoCompactThreshold) {
         yield createAssistantAPIErrorMessage({
@@ -795,7 +784,6 @@ async function* queryLoop(
               skipCacheWrite,
               temperatureOverride,
               topPOverride,
-              numCtxOverride,
               agentId: toolUseContext.agentId,
               addNotification: toolUseContext.addNotification,
               providerOverride: toolUseContext.options.providerOverride,

--- a/src/query.ts
+++ b/src/query.ts
@@ -195,6 +195,9 @@ export type QueryParams = {
   maxOutputTokensOverride?: number
   maxTurns?: number
   skipCacheWrite?: boolean
+  temperatureOverride?: number
+  topPOverride?: number
+  numCtxOverride?: number
   // API task_budget (output_config.task_budget, beta task-budgets-2026-03-13).
   // Distinct from the tokenBudget +500k auto-continue feature. `total` is the
   // budget for the whole agentic turn; `remaining` is computed per iteration
@@ -277,6 +280,9 @@ async function* queryLoop(
     querySource,
     maxTurns,
     skipCacheWrite,
+    temperatureOverride,
+    topPOverride,
+    numCtxOverride,
   } = params
   const deps = params.deps ?? productionDeps()
 
@@ -376,6 +382,14 @@ async function* queryLoop(
 
     const queryChainIdForAnalytics =
       queryTracking.chainId as AnalyticsMetadata_I_VERIFIED_THIS_IS_NOT_CODE_OR_FILEPATHS
+
+    // Resolve context window once for this iteration (honoring overrides and env vars)
+    const envNumCtxStr = process.env.CLAUDE_CODE_MAX_CONTEXT_TOKENS
+    const parsedEnvNumCtx = envNumCtxStr ? parseInt(envNumCtxStr, 10) : NaN
+    const resolvedNumCtx =
+      numCtxOverride ??
+      toolUseContext.options.providerOverride?.num_ctx ??
+      (!isNaN(parsedEnvNumCtx) ? parsedEnvNumCtx : undefined)
 
     toolUseContext = {
       ...toolUseContext,
@@ -519,6 +533,7 @@ async function* queryLoop(
       querySource,
       tracking,
       snipTokensFreed,
+      resolvedNumCtx,
     )
     queryCheckpoint('query_autocompact_end')
 
@@ -690,6 +705,7 @@ async function* queryLoop(
       const { isAtBlockingLimit } = calculateTokenWarningState(
         tokenCountWithEstimation(messagesForQuery) - snipTokensFreed,
         toolUseContext.options.mainLoopModel,
+        resolvedNumCtx,
       )
       if (isAtBlockingLimit) {
         yield createAssistantAPIErrorMessage({
@@ -717,6 +733,7 @@ async function* queryLoop(
       const { isAboveAutoCompactThreshold } = calculateTokenWarningState(
         tokenUsage,
         model,
+        resolvedNumCtx,
       )
       if (isAboveAutoCompactThreshold) {
         yield createAssistantAPIErrorMessage({
@@ -776,6 +793,9 @@ async function* queryLoop(
               effortValue: appState.effortValue,
               advisorModel: appState.advisorModel,
               skipCacheWrite,
+              temperatureOverride,
+              topPOverride,
+              numCtxOverride,
               agentId: toolUseContext.agentId,
               addNotification: toolUseContext.addNotification,
               providerOverride: toolUseContext.options.providerOverride,

--- a/src/query/deps.ts
+++ b/src/query/deps.ts
@@ -24,7 +24,15 @@ export type QueryDeps = {
 
   // -- compaction
   microcompact: typeof microcompactMessages
-  autocompact: typeof autoCompactIfNeeded
+  autocompact: (
+    messages: Message[],
+    toolUseContext: ToolUseContext,
+    cacheSafeParams: CacheSafeParams,
+    querySource?: QuerySource,
+    tracking?: AutoCompactTrackingState,
+    snipTokensFreed?: number,
+    overrideNumCtx?: number,
+  ) => ReturnType<typeof autoCompactIfNeeded>
 
   // -- platform
   uuid: () => string

--- a/src/query/deps.ts
+++ b/src/query/deps.ts
@@ -31,7 +31,6 @@ export type QueryDeps = {
     querySource?: QuerySource,
     tracking?: AutoCompactTrackingState,
     snipTokensFreed?: number,
-    overrideNumCtx?: number,
   ) => ReturnType<typeof autoCompactIfNeeded>
 
   // -- platform

--- a/src/services/api/agentRouting.ts
+++ b/src/services/api/agentRouting.ts
@@ -61,6 +61,5 @@ export function resolveAgentProvider(
     apiKey: modelConfig.api_key,
     temperature: modelConfig.temperature,
     top_p: modelConfig.top_p,
-    num_ctx: modelConfig.num_ctx,
   }
 }

--- a/src/services/api/agentRouting.ts
+++ b/src/services/api/agentRouting.ts
@@ -1,20 +1,8 @@
 import type { SettingsJson } from '../../utils/settings/types.js'
+import type { ProviderOverride } from './authRouting.js'
 
 /**
- * Provider override resolved from agent routing config.
- * When present, the API client should use these instead of global env vars.
- */
-export interface ProviderOverride {
-  /** Model name to send to the API (e.g. "deepseek-chat", "gpt-4o") */
-  model: string
-  /** OpenAI-compatible base URL */
-  baseURL: string
-  /** API key for this provider */
-  apiKey: string
-}
-
-/**
- * Normalize an agent identifier for case-insensitive, hyphen/underscore-agnostic matching.
+ * Look up agent.routing by name or subagent_type, then resolve via agent.models.
  */
 function normalize(key: string): string {
   return key.toLowerCase().replace(/[-_]/g, '')
@@ -71,5 +59,8 @@ export function resolveAgentProvider(
     model: modelName,
     baseURL: modelConfig.base_url,
     apiKey: modelConfig.api_key,
+    temperature: modelConfig.temperature,
+    top_p: modelConfig.top_p,
+    num_ctx: modelConfig.num_ctx,
   }
 }

--- a/src/services/api/authRouting.ts
+++ b/src/services/api/authRouting.ts
@@ -4,7 +4,14 @@ import {
   isFirstPartyAnthropicBaseUrl,
 } from 'src/utils/model/providers.js'
 
-export type ProviderOverride = { model: string; baseURL: string; apiKey: string }
+export type ProviderOverride = {
+  model: string
+  baseURL: string
+  apiKey: string
+  temperature?: number
+  top_p?: number
+  num_ctx?: number
+}
 
 export function shouldUseFirstPartyAnthropicAuthForProvider({
   providerOverride,

--- a/src/services/api/authRouting.ts
+++ b/src/services/api/authRouting.ts
@@ -10,7 +10,6 @@ export type ProviderOverride = {
   apiKey: string
   temperature?: number
   top_p?: number
-  num_ctx?: number
 }
 
 export function shouldUseFirstPartyAnthropicAuthForProvider({

--- a/src/services/api/claude.ts
+++ b/src/services/api/claude.ts
@@ -701,7 +701,6 @@ export type Options = {
   skipCacheWrite?: boolean
   temperatureOverride?: number
   topPOverride?: number
-  numCtxOverride?: number
   effortValue?: EffortValue
   mcpTools: Tools
   hasPendingMcpServers?: boolean
@@ -1090,12 +1089,6 @@ async function* queryModel(
     options.topPOverride ??
     options.providerOverride?.top_p ??
     (!isNaN(parsedEnvTopP) ? parsedEnvTopP : undefined)
-  const envNumCtxStr = process.env.CLAUDE_CODE_MAX_CONTEXT_TOKENS
-  const parsedEnvNumCtx = envNumCtxStr ? parseInt(envNumCtxStr, 10) : NaN
-  const resolvedNumCtx =
-    options.numCtxOverride ??
-    options.providerOverride?.num_ctx ??
-    (!isNaN(parsedEnvNumCtx) ? parsedEnvNumCtx : undefined)
 
   const resolvedModel =
     getAPIProvider() === 'bedrock' &&
@@ -1317,7 +1310,7 @@ async function* queryModel(
       cacheWeight: 0.4,
       freshWeight: 0.6,
       maxTotalTokens: Math.min(
-        getContextWindowForModel(model, getSdkBetas(), resolvedNumCtx) -
+        getContextWindowForModel(model, getSdkBetas()) -
           COMPACT_MAX_OUTPUT_TOKENS,
         200000,
       ),
@@ -1731,8 +1724,10 @@ async function* queryModel(
 
     // Only send temperature when thinking is disabled — the API requires
     // temperature: 1 when thinking is enabled, which is already the default.
-    const temperature = !hasThinking ? resolvedTemperature : undefined
-    const top_p = resolvedTopP
+    const temperature = thinking !== undefined ? undefined : resolvedTemperature
+    // Anthropic thinking mode requires top_p to be in [0.95, 1.0] range.
+    // If thinking is enabled, we omit the user-configured top_p to avoid 400 errors.
+    const top_p = thinking !== undefined ? (resolvedTopP !== undefined && resolvedTopP >= 0.95 ? resolvedTopP : undefined) : resolvedTopP
 
     lastRequestBetas = betasParams
 
@@ -1794,7 +1789,6 @@ async function* queryModel(
         messagesLength: logMessagesLength,
         temperature: resolvedTemperature,
         topP: resolvedTopP,
-        numCtx: resolvedNumCtx,
         betas: logBetas,
         permissionMode: permissionContext.mode,
         querySource: options.querySource,
@@ -2773,7 +2767,6 @@ async function* queryModel(
           model: errorModel,
           temperature: resolvedTemperature,
           topP: resolvedTopP,
-          numCtx: resolvedNumCtx,
           messageCount: messagesForAPI.length,
           messageTokens: tokenCountFromLastAPIResponse(messagesForAPI),
           durationMs: Date.now() - start,
@@ -2831,7 +2824,6 @@ async function* queryModel(
         model: errorModel,
         temperature: resolvedTemperature,
         topP: resolvedTopP,
-        numCtx: resolvedNumCtx,
         messageCount: messagesForAPI.length,
         messageTokens: tokenCountFromLastAPIResponse(messagesForAPI),
         durationMs: Date.now() - start,
@@ -2916,7 +2908,6 @@ async function* queryModel(
       preNormalizedModel: options.model,
       temperature: resolvedTemperature,
       topP: resolvedTopP,
-      numCtx: resolvedNumCtx,
       usage,
       start,
       startIncludingRetries,

--- a/src/services/api/claude.ts
+++ b/src/services/api/claude.ts
@@ -225,6 +225,7 @@ import { getInitializationStatus } from '../lsp/manager.js'
 import { isToolFromMcpServer } from '../mcp/utils.js'
 import { withStreamingVCR, withVCR } from '../vcr.js'
 import { CLIENT_REQUEST_ID_HEADER, getAnthropicClient } from './client.js'
+import type { ProviderOverride } from './authRouting.js'
 import {
   API_ERROR_MESSAGE_PREFIX,
   CUSTOM_OFF_SWITCH_MESSAGE,
@@ -699,6 +700,8 @@ export type Options = {
   enablePromptCaching?: boolean
   skipCacheWrite?: boolean
   temperatureOverride?: number
+  topPOverride?: number
+  numCtxOverride?: number
   effortValue?: EffortValue
   mcpTools: Tools
   hasPendingMcpServers?: boolean
@@ -713,7 +716,7 @@ export type Options = {
   // so the model can pace itself. `remaining` is computed by the caller
   // (query.ts decrements across the agentic loop).
   taskBudget?: { total: number; remaining?: number }
-  providerOverride?: { model: string; baseURL: string; apiKey: string }
+  providerOverride?: ProviderOverride
 }
 
 export async function queryModelWithoutStreaming({
@@ -1068,6 +1071,32 @@ async function* queryModel(
   // Also naturally handles rollback/undo since removed messages won't be in the array.
   const previousRequestId = getPreviousRequestIdFromMessages(messages)
 
+  // Resolve model parameters once for the entire query (including retries)
+  const envTemperatureStr = process.env.CLAUDE_CODE_TEMPERATURE
+  const parsedEnvTemperature =
+    envTemperatureStr ? parseFloat(envTemperatureStr) : NaN
+  const envTemperature = !isNaN(parsedEnvTemperature)
+    ? parsedEnvTemperature
+    : undefined
+  const resolvedTemperature =
+    options.temperatureOverride ??
+    options.providerOverride?.temperature ??
+    envTemperature ??
+    1
+
+  const envTopPStr = process.env.CLAUDE_CODE_TOP_P
+  const parsedEnvTopP = envTopPStr ? parseFloat(envTopPStr) : NaN
+  const resolvedTopP =
+    options.topPOverride ??
+    options.providerOverride?.top_p ??
+    (!isNaN(parsedEnvTopP) ? parsedEnvTopP : undefined)
+  const envNumCtxStr = process.env.CLAUDE_CODE_MAX_CONTEXT_TOKENS
+  const parsedEnvNumCtx = envNumCtxStr ? parseInt(envNumCtxStr, 10) : NaN
+  const resolvedNumCtx =
+    options.numCtxOverride ??
+    options.providerOverride?.num_ctx ??
+    (!isNaN(parsedEnvNumCtx) ? parsedEnvNumCtx : undefined)
+
   const resolvedModel =
     getAPIProvider() === 'bedrock' &&
     options.model.includes('application-inference-profile')
@@ -1288,8 +1317,9 @@ async function* queryModel(
       cacheWeight: 0.4,
       freshWeight: 0.6,
       maxTotalTokens: Math.min(
-        getContextWindowForModel(model, getSdkBetas()) - COMPACT_MAX_OUTPUT_TOKENS,
-        200000
+        getContextWindowForModel(model, getSdkBetas(), resolvedNumCtx) -
+          COMPACT_MAX_OUTPUT_TOKENS,
+        200000,
       ),
     })
     messagesForAPI = strategyResult.selectedMessages
@@ -1701,9 +1731,8 @@ async function* queryModel(
 
     // Only send temperature when thinking is disabled — the API requires
     // temperature: 1 when thinking is enabled, which is already the default.
-    const temperature = !hasThinking
-      ? (options.temperatureOverride ?? 1)
-      : undefined
+    const temperature = !hasThinking ? resolvedTemperature : undefined
+    const top_p = resolvedTopP
 
     lastRequestBetas = betasParams
 
@@ -1732,6 +1761,7 @@ async function* queryModel(
       max_tokens: maxOutputTokens,
       thinking,
       ...(temperature !== undefined && { temperature }),
+      ...(top_p !== undefined && { top_p }),
       ...(contextManagement &&
         useBetas &&
         betasParams.includes(CONTEXT_MANAGEMENT_BETA_HEADER) && {
@@ -1762,7 +1792,9 @@ async function* queryModel(
       logAPIQuery({
         model: options.model,
         messagesLength: logMessagesLength,
-        temperature: options.temperatureOverride ?? 1,
+        temperature: resolvedTemperature,
+        topP: resolvedTopP,
+        numCtx: resolvedNumCtx,
         betas: logBetas,
         permissionMode: permissionContext.mode,
         querySource: options.querySource,
@@ -2739,6 +2771,9 @@ async function* queryModel(
         logAPIError({
           error,
           model: errorModel,
+          temperature: resolvedTemperature,
+          topP: resolvedTopP,
+          numCtx: resolvedNumCtx,
           messageCount: messagesForAPI.length,
           messageTokens: tokenCountFromLastAPIResponse(messagesForAPI),
           durationMs: Date.now() - start,
@@ -2794,6 +2829,9 @@ async function* queryModel(
       logAPIError({
         error,
         model: errorModel,
+        temperature: resolvedTemperature,
+        topP: resolvedTopP,
+        numCtx: resolvedNumCtx,
         messageCount: messagesForAPI.length,
         messageTokens: tokenCountFromLastAPIResponse(messagesForAPI),
         durationMs: Date.now() - start,
@@ -2876,6 +2914,9 @@ async function* queryModel(
       model:
         newMessages[0]?.message.model ?? partialMessage?.model ?? options.model,
       preNormalizedModel: options.model,
+      temperature: resolvedTemperature,
+      topP: resolvedTopP,
+      numCtx: resolvedNumCtx,
       usage,
       start,
       startIncludingRetries,

--- a/src/services/api/client.test.ts
+++ b/src/services/api/client.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, expect, test } from 'bun:test'
+import { afterEach, beforeEach, expect, mock, test } from 'bun:test'
 import { acquireSharedMutationLock, releaseSharedMutationLock } from '../../test/sharedMutationLock.js'
 import { getAnthropicClient } from './client.js'
 
@@ -112,6 +112,7 @@ afterEach(() => {
     restoreEnv('ANTHROPIC_BASE_URL', originalEnv.ANTHROPIC_BASE_URL)
     restoreEnv('ANTHROPIC_CUSTOM_HEADERS', originalEnv.ANTHROPIC_CUSTOM_HEADERS)
     globalThis.fetch = originalFetch
+    mock.restore()
   } finally {
     releaseSharedMutationLock()
   }
@@ -1040,4 +1041,132 @@ test('strips Anthropic-specific custom headers on providerOverride shim requests
   expect(capturedHeaders?.get('api-key')).toBeNull()
   expect(capturedHeaders?.get('x-safe-header')).toBe('keep-me')
   expect(capturedHeaders?.get('authorization')).toBe('Bearer provider-test-key')
+})
+
+test('guards top_p on first-party Anthropic requests when thinking is enabled', async () => {
+  const oldEnv = {
+    BYPASS_VCR: process.env.BYPASS_VCR,
+    CLAUDE_CODE_USE_OPENAI: process.env.CLAUDE_CODE_USE_OPENAI,
+    CLAUDE_CODE_USE_GEMINI: process.env.CLAUDE_CODE_USE_GEMINI,
+    CLAUDE_CODE_USE_MISTRAL: process.env.CLAUDE_CODE_USE_MISTRAL,
+    CLAUDE_CODE_USE_GITHUB: process.env.CLAUDE_CODE_USE_GITHUB,
+    CLAUDE_CODE_USE_BEDROCK: process.env.CLAUDE_CODE_USE_BEDROCK,
+    CLAUDE_CODE_USE_VERTEX: process.env.CLAUDE_CODE_USE_VERTEX,
+    CLAUDE_CODE_USE_FOUNDRY: process.env.CLAUDE_CODE_USE_FOUNDRY,
+    OPENAI_BASE_URL: process.env.OPENAI_BASE_URL,
+    OPENAI_API_BASE: process.env.OPENAI_API_BASE,
+    OPENAI_MODEL: process.env.OPENAI_MODEL,
+    OPENAI_API_KEY: process.env.OPENAI_API_KEY,
+    XAI_API_KEY: process.env.XAI_API_KEY,
+    MINIMAX_API_KEY: process.env.MINIMAX_API_KEY,
+    VENICE_API_KEY: process.env.VENICE_API_KEY,
+    MIMO_API_KEY: process.env.MIMO_API_KEY,
+    NVIDIA_NIM: process.env.NVIDIA_NIM,
+  }
+
+  process.env.BYPASS_VCR = '1'
+  delete process.env.CLAUDE_CODE_USE_OPENAI
+  delete process.env.CLAUDE_CODE_USE_GEMINI
+  delete process.env.CLAUDE_CODE_USE_MISTRAL
+  delete process.env.CLAUDE_CODE_USE_GITHUB
+  delete process.env.CLAUDE_CODE_USE_BEDROCK
+  delete process.env.CLAUDE_CODE_USE_VERTEX
+  delete process.env.CLAUDE_CODE_USE_FOUNDRY
+  delete process.env.OPENAI_BASE_URL
+  delete process.env.OPENAI_API_BASE
+  delete process.env.OPENAI_MODEL
+  delete process.env.OPENAI_API_KEY
+  delete process.env.XAI_API_KEY
+  delete process.env.MINIMAX_API_KEY
+  delete process.env.VENICE_API_KEY
+  delete process.env.MIMO_API_KEY
+  delete process.env.NVIDIA_NIM
+
+  const actualProviders = await import('../../utils/model/providers.js')
+  mock.module('../../utils/model/providers.js', () => ({
+    ...actualProviders,
+    getAPIProvider: () => 'firstParty',
+  }))
+
+  const actualThinking = await import('../../utils/thinking.js')
+  mock.module('../../utils/thinking.js', () => ({
+    ...actualThinking,
+    modelSupportsThinking: () => true,
+  }))
+
+  try {
+    let capturedBody: any = null
+
+    globalThis.fetch = (async (input, init) => {
+      capturedBody = JSON.parse(init?.body as string)
+      return new Response(
+        JSON.stringify({
+          id: 'msg_123',
+          content: [{ type: 'text', text: 'hello' }],
+          usage: { input_tokens: 10, output_tokens: 10 },
+        }),
+        {
+          headers: { 'Content-Type': 'application/json' },
+        },
+      )
+    }) as FetchType
+
+    const { queryModelWithoutStreaming } = await import(`./claude.js?ts=${Date.now()}-${Math.random()}`)
+
+    // Run with top_p < 0.95 (should omit top_p)
+    await queryModelWithoutStreaming({
+      messages: [{ role: 'user', content: [{ type: 'text', text: 'hi' }] }],
+      systemPrompt: [],
+      thinkingConfig: { type: 'enabled', budgetTokens: 1024 },
+      tools: [],
+      signal: new AbortController().signal,
+      options: {
+        getToolPermissionContext: async () => ({ mode: 'auto' } as any),
+        model: 'claude-4-sonnet', // supports thinking
+        isNonInteractiveSession: true,
+        querySource: 'sdk',
+        topPOverride: 0.7,
+        mcpTools: [],
+        agents: [],
+      },
+    })
+
+    expect(capturedBody).not.toBeNull()
+    if (capturedBody && capturedBody.thinking === undefined) {
+      console.error('DEBUG: capturedBody keys:', Object.keys(capturedBody))
+      console.error('DEBUG: capturedBody:', JSON.stringify(capturedBody))
+    }
+    expect(capturedBody.thinking).toBeDefined()
+    expect(capturedBody.top_p).toBeUndefined()
+
+    // Run with top_p >= 0.95 (should preserve top_p)
+    await queryModelWithoutStreaming({
+      messages: [{ role: 'user', content: [{ type: 'text', text: 'hi' }] }],
+      systemPrompt: [],
+      thinkingConfig: { type: 'enabled', budgetTokens: 1024 },
+      tools: [],
+      signal: new AbortController().signal,
+      options: {
+        getToolPermissionContext: async () => ({ mode: 'auto' } as any),
+        model: 'claude-4-sonnet', // supports thinking
+        isNonInteractiveSession: true,
+        querySource: 'sdk',
+        topPOverride: 0.98,
+        mcpTools: [],
+        agents: [],
+      },
+    })
+
+    expect(capturedBody.thinking).toBeDefined()
+    expect(capturedBody.top_p).toBe(0.98)
+  } finally {
+    // Restore environment
+    for (const [k, v] of Object.entries(oldEnv)) {
+      if (v === undefined) {
+        delete process.env[k]
+      } else {
+        process.env[k] = v
+      }
+    }
+  }
 })

--- a/src/services/api/logging.ts
+++ b/src/services/api/logging.ts
@@ -181,7 +181,6 @@ export function logAPIQuery({
   messagesLength: number
   temperature: number
   topP?: number
-  numCtx?: number
   betas?: string[]
   permissionMode?: PermissionMode
   querySource: string
@@ -196,7 +195,6 @@ export function logAPIQuery({
     messagesLength,
     temperature: temperature,
     top_p: topP,
-    num_ctx: numCtx,
     provider: getAPIProviderForStatsig(),
     buildAgeMins: getBuildAgeMinutes(),
     ...(betas?.length
@@ -257,7 +255,6 @@ export function logAPIError({
   model: string
   temperature?: number
   topP?: number
-  numCtx?: number
   messageCount: number
   messageTokens?: number
   durationMs: number
@@ -307,7 +304,6 @@ export function logAPIError({
     model: model as AnalyticsMetadata_I_VERIFIED_THIS_IS_NOT_CODE_OR_FILEPATHS,
     temperature,
     top_p: topP,
-    num_ctx: numCtx,
     error: errStr as AnalyticsMetadata_I_VERIFIED_THIS_IS_NOT_CODE_OR_FILEPATHS,
     status:
       status as AnalyticsMetadata_I_VERIFIED_THIS_IS_NOT_CODE_OR_FILEPATHS,
@@ -417,7 +413,6 @@ function logAPISuccess({
   preNormalizedModel: string
   temperature?: number
   topP?: number
-  numCtx?: number
   messageCount: number
   messageTokens: number
   usage: Usage
@@ -458,7 +453,6 @@ function logAPISuccess({
     model: model as AnalyticsMetadata_I_VERIFIED_THIS_IS_NOT_CODE_OR_FILEPATHS,
     temperature,
     top_p: topP,
-    num_ctx: numCtx,
     ...(preNormalizedModel !== model
       ? {
           preNormalizedModel:
@@ -608,7 +602,6 @@ export function logAPISuccessAndDuration({
   preNormalizedModel: string
   temperature?: number
   topP?: number
-  numCtx?: number
   start: number
   startIncludingRetries: number
   ttftMs: number | null
@@ -691,7 +684,6 @@ export function logAPISuccessAndDuration({
     preNormalizedModel,
     temperature,
     topP,
-    numCtx,
     messageCount,
     messageTokens,
     usage,

--- a/src/services/api/logging.ts
+++ b/src/services/api/logging.ts
@@ -166,6 +166,8 @@ export function logAPIQuery({
   model,
   messagesLength,
   temperature,
+  topP,
+  numCtx,
   betas,
   permissionMode,
   querySource,
@@ -178,6 +180,8 @@ export function logAPIQuery({
   model: string
   messagesLength: number
   temperature: number
+  topP?: number
+  numCtx?: number
   betas?: string[]
   permissionMode?: PermissionMode
   querySource: string
@@ -191,6 +195,8 @@ export function logAPIQuery({
     model: model as AnalyticsMetadata_I_VERIFIED_THIS_IS_NOT_CODE_OR_FILEPATHS,
     messagesLength,
     temperature: temperature,
+    top_p: topP,
+    num_ctx: numCtx,
     provider: getAPIProviderForStatsig(),
     buildAgeMins: getBuildAgeMinutes(),
     ...(betas?.length
@@ -229,6 +235,9 @@ export function logAPIQuery({
 export function logAPIError({
   error,
   model,
+  temperature,
+  topP,
+  numCtx,
   messageCount,
   messageTokens,
   durationMs,
@@ -246,6 +255,9 @@ export function logAPIError({
 }: {
   error: unknown
   model: string
+  temperature?: number
+  topP?: number
+  numCtx?: number
   messageCount: number
   messageTokens?: number
   durationMs: number
@@ -291,9 +303,11 @@ export function logAPIError({
     )
   }
 
-  logError(error as Error)
   logEvent('tengu_api_error', {
     model: model as AnalyticsMetadata_I_VERIFIED_THIS_IS_NOT_CODE_OR_FILEPATHS,
+    temperature,
+    top_p: topP,
+    num_ctx: numCtx,
     error: errStr as AnalyticsMetadata_I_VERIFIED_THIS_IS_NOT_CODE_OR_FILEPATHS,
     status:
       status as AnalyticsMetadata_I_VERIFIED_THIS_IS_NOT_CODE_OR_FILEPATHS,
@@ -372,6 +386,9 @@ export function logAPIError({
 function logAPISuccess({
   model,
   preNormalizedModel,
+  temperature,
+  topP,
+  numCtx,
   messageCount,
   messageTokens,
   usage,
@@ -398,6 +415,9 @@ function logAPISuccess({
 }: {
   model: string
   preNormalizedModel: string
+  temperature?: number
+  topP?: number
+  numCtx?: number
   messageCount: number
   messageTokens: number
   usage: Usage
@@ -436,6 +456,9 @@ function logAPISuccess({
 
   logEvent('tengu_api_success', {
     model: model as AnalyticsMetadata_I_VERIFIED_THIS_IS_NOT_CODE_OR_FILEPATHS,
+    temperature,
+    top_p: topP,
+    num_ctx: numCtx,
     ...(preNormalizedModel !== model
       ? {
           preNormalizedModel:
@@ -555,6 +578,9 @@ function logAPISuccess({
 export function logAPISuccessAndDuration({
   model,
   preNormalizedModel,
+  temperature,
+  topP,
+  numCtx,
   start,
   startIncludingRetries,
   ttftMs,
@@ -580,6 +606,9 @@ export function logAPISuccessAndDuration({
 }: {
   model: string
   preNormalizedModel: string
+  temperature?: number
+  topP?: number
+  numCtx?: number
   start: number
   startIncludingRetries: number
   ttftMs: number | null
@@ -660,6 +689,9 @@ export function logAPISuccessAndDuration({
   logAPISuccess({
     model,
     preNormalizedModel,
+    temperature,
+    topP,
+    numCtx,
     messageCount,
     messageTokens,
     usage,

--- a/src/services/api/openaiShim.test.ts
+++ b/src/services/api/openaiShim.test.ts
@@ -879,6 +879,61 @@ test('preserves usage from final OpenAI stream chunk with empty choices', async 
   expect(usageEvent?.usage?.output_tokens).toBe(45)
 })
 
+test('respects temperature and top_p overrides from providerOverride and environment', async () => {
+  let requestBody: any
+  globalThis.fetch = (async (input: RequestInfo, init?: RequestInit) => {
+    requestBody = JSON.parse(init?.body as string)
+    return new Response(JSON.stringify({ choices: [{ message: { content: 'test' } }] }), {
+      headers: { 'Content-Type': 'application/json' },
+    })
+  }) as FetchType
+
+  const client = createOpenAIShimClient({
+    providerOverride: {
+      model: 'test-model',
+      baseURL: 'http://example.test/v1',
+      apiKey: 'test-key',
+      temperature: 0.3,
+      top_p: 0.7,
+    },
+  }) as OpenAIShimClient
+
+  await client.beta.messages.create({
+    model: 'test-model',
+    max_tokens: 100,
+    messages: [{ role: 'user', content: 'hello' }],
+    stream: false,
+  })
+
+  expect(requestBody.temperature).toBe(0.3)
+  expect(requestBody.top_p).toBe(0.7)
+
+  // Test environment variable overrides with NaN protection
+  process.env.CLAUDE_CODE_TEMPERATURE = '0.4'
+  process.env.CLAUDE_CODE_TOP_P = '' // Empty string -> should be ignored (NaN)
+
+  const client2 = createOpenAIShimClient({
+    providerOverride: {
+      model: 'test-model',
+      baseURL: 'http://example.test/v1',
+      apiKey: 'test-key',
+    },
+  }) as OpenAIShimClient
+
+  await client2.beta.messages.create({
+    model: 'test-model',
+    max_tokens: 100,
+    messages: [{ role: 'user', content: 'hello' }],
+    stream: false,
+  })
+
+  expect(requestBody.temperature).toBe(0.4)
+  expect(requestBody.top_p).toBeUndefined()
+  
+  delete process.env.CLAUDE_CODE_TEMPERATURE
+  delete process.env.CLAUDE_CODE_TOP_P
+})
+
 test('uses max_tokens instead of max_completion_tokens for local providers', async () => {
   process.env.OPENAI_BASE_URL = 'http://localhost:11434/v1'
 

--- a/src/services/api/openaiShim.test.ts
+++ b/src/services/api/openaiShim.test.ts
@@ -934,6 +934,72 @@ test('respects temperature and top_p overrides from providerOverride and environ
   delete process.env.CLAUDE_CODE_TOP_P
 })
 
+test('respects temperature and top_p overrides from providerOverride and environment on Responses path', async () => {
+  process.env.OPENAI_API_FORMAT = 'responses'
+  let requestBody: any
+  globalThis.fetch = (async (input: RequestInfo, init?: RequestInit) => {
+    requestBody = JSON.parse(init?.body as string)
+    return new Response(JSON.stringify({
+      id: 'resp-test',
+      output: [
+        {
+          type: 'message',
+          role: 'assistant',
+          content: [{ type: 'output_text', text: 'test' }],
+        },
+      ],
+    }), {
+      headers: { 'Content-Type': 'application/json' },
+    })
+  }) as FetchType
+
+  const client = createOpenAIShimClient({
+    providerOverride: {
+      model: 'test-model',
+      baseURL: 'http://example.test/v1',
+      apiKey: 'test-key',
+      temperature: 0.3,
+      top_p: 0.7,
+    },
+  }) as OpenAIShimClient
+
+  await client.beta.messages.create({
+    model: 'test-model',
+    max_tokens: 100,
+    messages: [{ role: 'user', content: 'hello' }],
+    stream: false,
+  })
+
+  expect(requestBody.temperature).toBe(0.3)
+  expect(requestBody.top_p).toBe(0.7)
+
+  // Test environment variable overrides with NaN protection
+  process.env.CLAUDE_CODE_TEMPERATURE = '0.4'
+  process.env.CLAUDE_CODE_TOP_P = '' // Empty string -> should be ignored (NaN)
+
+  const client2 = createOpenAIShimClient({
+    providerOverride: {
+      model: 'test-model',
+      baseURL: 'http://example.test/v1',
+      apiKey: 'test-key',
+    },
+  }) as OpenAIShimClient
+
+  await client2.beta.messages.create({
+    model: 'test-model',
+    max_tokens: 100,
+    messages: [{ role: 'user', content: 'hello' }],
+    stream: false,
+  })
+
+  expect(requestBody.temperature).toBe(0.4)
+  expect(requestBody.top_p).toBeUndefined()
+
+  delete process.env.CLAUDE_CODE_TEMPERATURE
+  delete process.env.CLAUDE_CODE_TOP_P
+  delete process.env.OPENAI_API_FORMAT
+})
+
 test('uses max_tokens instead of max_completion_tokens for local providers', async () => {
   process.env.OPENAI_BASE_URL = 'http://localhost:11434/v1'
 

--- a/src/services/api/openaiShim.ts
+++ b/src/services/api/openaiShim.ts
@@ -1873,8 +1873,7 @@ class OpenAIShimMessages {
       delete body.store
     }
 
-    if (params.temperature !== undefined) body.temperature = params.temperature
-    if (params.top_p !== undefined) body.top_p = params.top_p
+
 
     if (shimConfig.thinkingRequestFormat === 'deepseek-compatible') {
       const requestedThinkingType = (params.thinking as { type?: string } | undefined)?.type
@@ -1966,8 +1965,8 @@ class OpenAIShimMessages {
         responsesBody.max_output_tokens = body.max_completion_tokens
       }
 
-      if (params.temperature !== undefined) responsesBody.temperature = params.temperature
-      if (params.top_p !== undefined) responsesBody.top_p = params.top_p
+      if (temperatureValue !== undefined) responsesBody.temperature = temperatureValue
+      if (topPValue !== undefined) responsesBody.top_p = topPValue
 
       if (!omitResponsesTools && params.tools && params.tools.length > 0) {
         const convertedTools = convertToolsToResponsesTools(

--- a/src/services/api/openaiShim.ts
+++ b/src/services/api/openaiShim.ts
@@ -78,6 +78,7 @@ import {
   hasToolFieldMapping,
 } from './toolArgumentNormalization.js'
 import { logApiCallStart, logApiCallEnd } from '../../utils/requestLogging.js'
+import type { ProviderOverride } from './authRouting.js'
 import {
   createStreamState,
   processStreamChunk,
@@ -1578,9 +1579,9 @@ class OpenAIShimStream {
 class OpenAIShimMessages {
   private defaultHeaders: Record<string, string>
   private reasoningEffort?: 'low' | 'medium' | 'high' | 'xhigh'
-  private providerOverride?: { model: string; baseURL: string; apiKey: string }
+  private providerOverride?: ProviderOverride
 
-  constructor(defaultHeaders: Record<string, string>, reasoningEffort?: 'low' | 'medium' | 'high' | 'xhigh', providerOverride?: { model: string; baseURL: string; apiKey: string }) {
+  constructor(defaultHeaders: Record<string, string>, reasoningEffort?: 'low' | 'medium' | 'high' | 'xhigh', providerOverride?: ProviderOverride) {
     this.defaultHeaders = filterAnthropicHeaders(defaultHeaders)
     this.reasoningEffort = reasoningEffort
     this.providerOverride = providerOverride
@@ -1802,6 +1803,27 @@ class OpenAIShimMessages {
     if (request.reasoning) {
       body.reasoning_effort = request.reasoning.effort
     }
+
+    const envTemperatureStr = process.env.CLAUDE_CODE_TEMPERATURE
+    const parsedEnvTemperature = envTemperatureStr ? parseFloat(envTemperatureStr) : NaN
+    const temperatureValue =
+      params.temperature ??
+      this.providerOverride?.temperature ??
+      (!isNaN(parsedEnvTemperature) ? parsedEnvTemperature : undefined)
+    if (temperatureValue !== undefined) {
+      body.temperature = temperatureValue
+    }
+
+    const envTopPStr = process.env.CLAUDE_CODE_TOP_P
+    const parsedEnvTopP = envTopPStr ? parseFloat(envTopPStr) : NaN
+    const topPValue =
+      params.top_p ??
+      this.providerOverride?.top_p ??
+      (!isNaN(parsedEnvTopP) ? parsedEnvTopP : undefined)
+    if (topPValue !== undefined) {
+      body.top_p = topPValue
+    }
+
     // Convert max_tokens to max_completion_tokens for OpenAI API compatibility.
     // Azure OpenAI requires max_completion_tokens and does not accept max_tokens.
     // Ensure max_tokens is a valid positive number before using it.
@@ -2558,7 +2580,7 @@ class OpenAIShimBeta {
   messages: OpenAIShimMessages
   reasoningEffort?: 'low' | 'medium' | 'high' | 'xhigh'
 
-  constructor(defaultHeaders: Record<string, string>, reasoningEffort?: 'low' | 'medium' | 'high' | 'xhigh', providerOverride?: { model: string; baseURL: string; apiKey: string }) {
+  constructor(defaultHeaders: Record<string, string>, reasoningEffort?: 'low' | 'medium' | 'high' | 'xhigh', providerOverride?: ProviderOverride) {
     this.messages = new OpenAIShimMessages(defaultHeaders, reasoningEffort, providerOverride)
     this.reasoningEffort = reasoningEffort
   }
@@ -2569,7 +2591,7 @@ export function createOpenAIShimClient(options: {
   maxRetries?: number
   timeout?: number
   reasoningEffort?: 'low' | 'medium' | 'high' | 'xhigh'
-  providerOverride?: { model: string; baseURL: string; apiKey: string }
+  providerOverride?: ProviderOverride
 }): unknown {
   hydrateGeminiAccessTokenFromSecureStorage()
   hydrateGithubModelsTokenFromSecureStorage()

--- a/src/services/compact/autoCompact.ts
+++ b/src/services/compact/autoCompact.ts
@@ -34,7 +34,6 @@ const MAX_OUTPUT_TOKENS_FOR_SUMMARY = 20_000
 // Returns the context window size minus the max output tokens for the model
 export function getEffectiveContextWindowSize(
   model: string,
-  overrideNumCtx?: number,
 ): number {
   const reservedTokensForSummary = Math.min(
     getMaxOutputTokensForModel(model),
@@ -43,7 +42,6 @@ export function getEffectiveContextWindowSize(
   let contextWindow = getContextWindowForModel(
     model,
     getSdkBetas(),
-    overrideNumCtx,
   )
 
   const autoCompactWindow = process.env.CLAUDE_CODE_AUTO_COMPACT_WINDOW
@@ -85,11 +83,9 @@ const MAX_CONSECUTIVE_AUTOCOMPACT_FAILURES = 3
 
 export function getAutoCompactThreshold(
   model: string,
-  overrideNumCtx?: number,
 ): number {
   const effectiveContextWindow = getEffectiveContextWindowSize(
     model,
-    overrideNumCtx,
   )
 
   const autocompactThreshold =
@@ -113,7 +109,6 @@ export function getAutoCompactThreshold(
 export function calculateTokenWarningState(
   tokenUsage: number,
   model: string,
-  overrideNumCtx?: number,
 ): {
   percentLeft: number
   isAboveWarningThreshold: boolean
@@ -121,10 +116,10 @@ export function calculateTokenWarningState(
   isAboveAutoCompactThreshold: boolean
   isAtBlockingLimit: boolean
 } {
-  const autoCompactThreshold = getAutoCompactThreshold(model, overrideNumCtx)
+  const autoCompactThreshold = getAutoCompactThreshold(model)
   const threshold = isAutoCompactEnabled()
     ? autoCompactThreshold
-    : getEffectiveContextWindowSize(model, overrideNumCtx)
+    : getEffectiveContextWindowSize(model)
 
   // Use the raw context window (without output reservation) for the percentage
   // display, so users see remaining context relative to the model's full capacity.
@@ -133,7 +128,6 @@ export function calculateTokenWarningState(
   const rawContextWindow = getContextWindowForModel(
     model,
     getSdkBetas(),
-    overrideNumCtx,
   )
   const percentLeft = Math.max(
     0,
@@ -151,7 +145,6 @@ export function calculateTokenWarningState(
 
   const actualContextWindow = getEffectiveContextWindowSize(
     model,
-    overrideNumCtx,
   )
   const defaultBlockingLimit =
     actualContextWindow - MANUAL_COMPACT_BUFFER_TOKENS
@@ -198,7 +191,6 @@ export async function shouldAutoCompact(
   // pre-snip context, so tokenCountWithEstimation can't see the savings.
   // Subtract the rough-delta that snip already computed.
   snipTokensFreed = 0,
-  overrideNumCtx?: number,
 ): Promise<boolean> {
   // Recursion guards. session_memory and compact are forked agents that
   // would deadlock.
@@ -256,9 +248,8 @@ export async function shouldAutoCompact(
     }
   }
 
-  const tokenCount = tokenCountWithEstimation(messages) - snipTokensFreed
-  const threshold = getAutoCompactThreshold(model, overrideNumCtx)
-  const effectiveWindow = getEffectiveContextWindowSize(model, overrideNumCtx)
+  const threshold = getAutoCompactThreshold(model)
+  const effectiveWindow = getEffectiveContextWindowSize(model)
 
   logForDebugging(
     `autocompact: tokens=${tokenCount} threshold=${threshold} effectiveWindow=${effectiveWindow}${snipTokensFreed > 0 ? ` snipFreed=${snipTokensFreed}` : ''}`,
@@ -267,7 +258,6 @@ export async function shouldAutoCompact(
   const { isAboveAutoCompactThreshold } = calculateTokenWarningState(
     tokenCount,
     model,
-    overrideNumCtx,
   )
 
   return isAboveAutoCompactThreshold
@@ -280,7 +270,6 @@ export async function autoCompactIfNeeded(
   querySource?: QuerySource,
   tracking?: AutoCompactTrackingState,
   snipTokensFreed?: number,
-  overrideNumCtx?: number,
 ): Promise<{
   wasCompacted: boolean
   compactionResult?: CompactionResult
@@ -306,7 +295,6 @@ export async function autoCompactIfNeeded(
     model,
     querySource,
     snipTokensFreed,
-    overrideNumCtx,
   )
 
   if (!shouldCompact) {
@@ -316,7 +304,6 @@ export async function autoCompactIfNeeded(
   const contextWindow = getContextWindowForModel(
     model,
     getSdkBetas(),
-    overrideNumCtx,
   )
 
   const partitioned = partitionContext(messages, {
@@ -354,7 +341,7 @@ export async function autoCompactIfNeeded(
     isRecompactionInChain: tracking?.compacted === true,
     turnsSincePreviousCompact: tracking?.turnCounter ?? -1,
     previousCompactTurnId: tracking?.turnId,
-    autoCompactThreshold: getAutoCompactThreshold(model, overrideNumCtx),
+    autoCompactThreshold: getAutoCompactThreshold(model),
     querySource,
   }
 

--- a/src/services/compact/autoCompact.ts
+++ b/src/services/compact/autoCompact.ts
@@ -32,12 +32,19 @@ import { trySessionMemoryCompaction } from './sessionMemoryCompact.js'
 const MAX_OUTPUT_TOKENS_FOR_SUMMARY = 20_000
 
 // Returns the context window size minus the max output tokens for the model
-export function getEffectiveContextWindowSize(model: string): number {
+export function getEffectiveContextWindowSize(
+  model: string,
+  overrideNumCtx?: number,
+): number {
   const reservedTokensForSummary = Math.min(
     getMaxOutputTokensForModel(model),
     MAX_OUTPUT_TOKENS_FOR_SUMMARY,
   )
-  let contextWindow = getContextWindowForModel(model, getSdkBetas())
+  let contextWindow = getContextWindowForModel(
+    model,
+    getSdkBetas(),
+    overrideNumCtx,
+  )
 
   const autoCompactWindow = process.env.CLAUDE_CODE_AUTO_COMPACT_WINDOW
   if (autoCompactWindow) {
@@ -76,8 +83,14 @@ export const MANUAL_COMPACT_BUFFER_TOKENS = 3_000
 // in a single session, wasting ~250K API calls/day globally.
 const MAX_CONSECUTIVE_AUTOCOMPACT_FAILURES = 3
 
-export function getAutoCompactThreshold(model: string): number {
-  const effectiveContextWindow = getEffectiveContextWindowSize(model)
+export function getAutoCompactThreshold(
+  model: string,
+  overrideNumCtx?: number,
+): number {
+  const effectiveContextWindow = getEffectiveContextWindowSize(
+    model,
+    overrideNumCtx,
+  )
 
   const autocompactThreshold =
     effectiveContextWindow - AUTOCOMPACT_BUFFER_TOKENS
@@ -100,6 +113,7 @@ export function getAutoCompactThreshold(model: string): number {
 export function calculateTokenWarningState(
   tokenUsage: number,
   model: string,
+  overrideNumCtx?: number,
 ): {
   percentLeft: number
   isAboveWarningThreshold: boolean
@@ -107,16 +121,20 @@ export function calculateTokenWarningState(
   isAboveAutoCompactThreshold: boolean
   isAtBlockingLimit: boolean
 } {
-  const autoCompactThreshold = getAutoCompactThreshold(model)
+  const autoCompactThreshold = getAutoCompactThreshold(model, overrideNumCtx)
   const threshold = isAutoCompactEnabled()
     ? autoCompactThreshold
-    : getEffectiveContextWindowSize(model)
+    : getEffectiveContextWindowSize(model, overrideNumCtx)
 
   // Use the raw context window (without output reservation) for the percentage
   // display, so users see remaining context relative to the model's full capacity.
   // The threshold (which subtracts buffer) should only affect when we warn/compact,
   // not what percentage we display.
-  const rawContextWindow = getContextWindowForModel(model, getSdkBetas())
+  const rawContextWindow = getContextWindowForModel(
+    model,
+    getSdkBetas(),
+    overrideNumCtx,
+  )
   const percentLeft = Math.max(
     0,
     Math.round(((rawContextWindow - tokenUsage) / rawContextWindow) * 100),
@@ -131,7 +149,10 @@ export function calculateTokenWarningState(
   const isAboveAutoCompactThreshold =
     isAutoCompactEnabled() && tokenUsage >= autoCompactThreshold
 
-  const actualContextWindow = getEffectiveContextWindowSize(model)
+  const actualContextWindow = getEffectiveContextWindowSize(
+    model,
+    overrideNumCtx,
+  )
   const defaultBlockingLimit =
     actualContextWindow - MANUAL_COMPACT_BUFFER_TOKENS
 
@@ -177,6 +198,7 @@ export async function shouldAutoCompact(
   // pre-snip context, so tokenCountWithEstimation can't see the savings.
   // Subtract the rough-delta that snip already computed.
   snipTokensFreed = 0,
+  overrideNumCtx?: number,
 ): Promise<boolean> {
   // Recursion guards. session_memory and compact are forked agents that
   // would deadlock.
@@ -235,8 +257,8 @@ export async function shouldAutoCompact(
   }
 
   const tokenCount = tokenCountWithEstimation(messages) - snipTokensFreed
-  const threshold = getAutoCompactThreshold(model)
-  const effectiveWindow = getEffectiveContextWindowSize(model)
+  const threshold = getAutoCompactThreshold(model, overrideNumCtx)
+  const effectiveWindow = getEffectiveContextWindowSize(model, overrideNumCtx)
 
   logForDebugging(
     `autocompact: tokens=${tokenCount} threshold=${threshold} effectiveWindow=${effectiveWindow}${snipTokensFreed > 0 ? ` snipFreed=${snipTokensFreed}` : ''}`,
@@ -245,6 +267,7 @@ export async function shouldAutoCompact(
   const { isAboveAutoCompactThreshold } = calculateTokenWarningState(
     tokenCount,
     model,
+    overrideNumCtx,
   )
 
   return isAboveAutoCompactThreshold
@@ -257,6 +280,7 @@ export async function autoCompactIfNeeded(
   querySource?: QuerySource,
   tracking?: AutoCompactTrackingState,
   snipTokensFreed?: number,
+  overrideNumCtx?: number,
 ): Promise<{
   wasCompacted: boolean
   compactionResult?: CompactionResult
@@ -282,13 +306,18 @@ export async function autoCompactIfNeeded(
     model,
     querySource,
     snipTokensFreed,
+    overrideNumCtx,
   )
 
   if (!shouldCompact) {
     return { wasCompacted: false }
   }
 
-  const contextWindow = getContextWindowForModel(model, getSdkBetas())
+  const contextWindow = getContextWindowForModel(
+    model,
+    getSdkBetas(),
+    overrideNumCtx,
+  )
 
   const partitioned = partitionContext(messages, {
     contextWindow,
@@ -325,7 +354,7 @@ export async function autoCompactIfNeeded(
     isRecompactionInChain: tracking?.compacted === true,
     turnsSincePreviousCompact: tracking?.turnCounter ?? -1,
     previousCompactTurnId: tracking?.turnId,
-    autoCompactThreshold: getAutoCompactThreshold(model),
+    autoCompactThreshold: getAutoCompactThreshold(model, overrideNumCtx),
     querySource,
   }
 

--- a/src/services/vcr.ts
+++ b/src/services/vcr.ts
@@ -21,6 +21,10 @@ import { normalizeMessagesForAPI } from '../utils/messages.js'
 import { jsonParse, jsonStringify } from '../utils/slowOperations.js'
 
 function shouldUseVCR(): boolean {
+  if (isEnvTruthy(process.env.BYPASS_VCR)) {
+    return false
+  }
+
   if (process.env.NODE_ENV === 'test') {
     return true
   }

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -200,6 +200,9 @@ export type ProviderProfile = {
   authScheme?: OpenAICompatibleAuthScheme
   authHeaderValue?: string
   customHeaders?: Record<string, string>
+  temperature?: number
+  top_p?: number
+  num_ctx?: number
 }
 
 export type GlobalConfig = {

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -202,7 +202,6 @@ export type ProviderProfile = {
   customHeaders?: Record<string, string>
   temperature?: number
   top_p?: number
-  num_ctx?: number
 }
 
 export type GlobalConfig = {

--- a/src/utils/context.test.ts
+++ b/src/utils/context.test.ts
@@ -9,6 +9,12 @@ import {
 
 const originalEnv = {
   CLAUDE_CODE_USE_OPENAI: process.env.CLAUDE_CODE_USE_OPENAI,
+  CLAUDE_CODE_USE_GEMINI: process.env.CLAUDE_CODE_USE_GEMINI,
+  CLAUDE_CODE_USE_MISTRAL: process.env.CLAUDE_CODE_USE_MISTRAL,
+  CLAUDE_CODE_USE_GITHUB: process.env.CLAUDE_CODE_USE_GITHUB,
+  CLAUDE_CODE_USE_BEDROCK: process.env.CLAUDE_CODE_USE_BEDROCK,
+  CLAUDE_CODE_USE_VERTEX: process.env.CLAUDE_CODE_USE_VERTEX,
+  CLAUDE_CODE_USE_FOUNDRY: process.env.CLAUDE_CODE_USE_FOUNDRY,
   CLAUDE_CODE_MAX_OUTPUT_TOKENS: process.env.CLAUDE_CODE_MAX_OUTPUT_TOKENS,
   CLAUDE_CODE_OPENAI_CONTEXT_WINDOWS:
     process.env.CLAUDE_CODE_OPENAI_CONTEXT_WINDOWS,
@@ -24,6 +30,12 @@ const originalEnv = {
 beforeEach(async () => {
   await acquireSharedMutationLock('context.test.ts')
   delete process.env.CLAUDE_CODE_USE_OPENAI
+  delete process.env.CLAUDE_CODE_USE_GEMINI
+  delete process.env.CLAUDE_CODE_USE_MISTRAL
+  delete process.env.CLAUDE_CODE_USE_GITHUB
+  delete process.env.CLAUDE_CODE_USE_BEDROCK
+  delete process.env.CLAUDE_CODE_USE_VERTEX
+  delete process.env.CLAUDE_CODE_USE_FOUNDRY
   delete process.env.CLAUDE_CODE_MAX_OUTPUT_TOKENS
   delete process.env.CLAUDE_CODE_OPENAI_CONTEXT_WINDOWS
   delete process.env.CLAUDE_CODE_OPENAI_MAX_OUTPUT_TOKENS
@@ -40,6 +52,36 @@ afterEach(() => {
       delete process.env.CLAUDE_CODE_USE_OPENAI
     } else {
       process.env.CLAUDE_CODE_USE_OPENAI = originalEnv.CLAUDE_CODE_USE_OPENAI
+    }
+    if (originalEnv.CLAUDE_CODE_USE_GEMINI === undefined) {
+      delete process.env.CLAUDE_CODE_USE_GEMINI
+    } else {
+      process.env.CLAUDE_CODE_USE_GEMINI = originalEnv.CLAUDE_CODE_USE_GEMINI
+    }
+    if (originalEnv.CLAUDE_CODE_USE_MISTRAL === undefined) {
+      delete process.env.CLAUDE_CODE_USE_MISTRAL
+    } else {
+      process.env.CLAUDE_CODE_USE_MISTRAL = originalEnv.CLAUDE_CODE_USE_MISTRAL
+    }
+    if (originalEnv.CLAUDE_CODE_USE_GITHUB === undefined) {
+      delete process.env.CLAUDE_CODE_USE_GITHUB
+    } else {
+      process.env.CLAUDE_CODE_USE_GITHUB = originalEnv.CLAUDE_CODE_USE_GITHUB
+    }
+    if (originalEnv.CLAUDE_CODE_USE_BEDROCK === undefined) {
+      delete process.env.CLAUDE_CODE_USE_BEDROCK
+    } else {
+      process.env.CLAUDE_CODE_USE_BEDROCK = originalEnv.CLAUDE_CODE_USE_BEDROCK
+    }
+    if (originalEnv.CLAUDE_CODE_USE_VERTEX === undefined) {
+      delete process.env.CLAUDE_CODE_USE_VERTEX
+    } else {
+      process.env.CLAUDE_CODE_USE_VERTEX = originalEnv.CLAUDE_CODE_USE_VERTEX
+    }
+    if (originalEnv.CLAUDE_CODE_USE_FOUNDRY === undefined) {
+      delete process.env.CLAUDE_CODE_USE_FOUNDRY
+    } else {
+      process.env.CLAUDE_CODE_USE_FOUNDRY = originalEnv.CLAUDE_CODE_USE_FOUNDRY
     }
     if (originalEnv.CLAUDE_CODE_MAX_OUTPUT_TOKENS === undefined) {
       delete process.env.CLAUDE_CODE_MAX_OUTPUT_TOKENS

--- a/src/utils/context.ts
+++ b/src/utils/context.ts
@@ -9,6 +9,7 @@ import {
 } from '../integrations/routeMetadata.js'
 import { getCanonicalName } from './model/model.js'
 import { getModelCapability } from './model/modelCapabilities.js'
+import { resolveAntModel } from './model/antModels.js'
 
 // Model context window size (200k tokens for all models right now)
 export const MODEL_CONTEXT_WINDOW_DEFAULT = 200_000
@@ -79,15 +80,17 @@ function shouldUseIntegrationRuntimeLimits(
 export function getContextWindowForModel(
   model: string,
   betas?: string[],
+  override?: number,
 ): number {
-  // Allow override via environment variable (internal-only)
+  // Allow explicit override.
+  if (override !== undefined && override > 0) {
+    return override
+  }
+  // Allow override via environment variable.
   // This takes precedence over all other context window resolution, including 1M detection,
   // so users can cap the effective context window for local decisions (auto-compact, etc.)
   // while still using a 1M-capable endpoint.
-  if (
-    process.env.USER_TYPE === 'ant' &&
-    process.env.CLAUDE_CODE_MAX_CONTEXT_TOKENS
-  ) {
+  if (process.env.CLAUDE_CODE_MAX_CONTEXT_TOKENS) {
     const override = parseInt(process.env.CLAUDE_CODE_MAX_CONTEXT_TOKENS, 10)
     if (!isNaN(override) && override > 0) {
       return override

--- a/src/utils/modelParams.test.ts
+++ b/src/utils/modelParams.test.ts
@@ -1,0 +1,112 @@
+import { expect, test, describe, beforeEach, afterEach } from 'bun:test'
+import { applyProviderProfileToProcessEnv } from './providerProfiles.js'
+import { getContextWindowForModel } from './context.ts'
+import { resolveAgentProvider } from '../services/api/agentRouting.ts'
+import { getAutoCompactThreshold, getEffectiveContextWindowSize } from '../services/compact/autoCompact.ts'
+
+describe('Model Parameter Configuration', () => {
+  const originalEnv = { ...process.env }
+
+  beforeEach(() => {
+    // Clear relevant env vars to ensure hermetic tests
+    delete process.env.CLAUDE_CODE_TEMPERATURE
+    delete process.env.CLAUDE_CODE_TOP_P
+    delete process.env.CLAUDE_CODE_MAX_CONTEXT_TOKENS
+    delete process.env.CLAUDE_CODE_MAX_OUTPUT_TOKENS
+    delete process.env.CLAUDE_CODE_AUTO_COMPACT_WINDOW
+    delete process.env.OPENAI_API_KEY
+    delete process.env.OPENAI_BASE_URL
+    delete process.env.OPENAI_MODEL
+    delete process.env.USER_TYPE
+  })
+
+  afterEach(() => {
+    process.env = { ...originalEnv }
+  })
+
+  test('ProviderProfile respects temperature, top_p, and num_ctx', () => {
+    const profile = {
+      id: 'test-profile',
+      name: 'Test Profile',
+      provider: 'openai' as any,
+      baseUrl: 'https://api.example.com/v1',
+      model: 'test-model',
+      temperature: 0.2,
+      top_p: 0.85,
+      num_ctx: 128000,
+    }
+
+    applyProviderProfileToProcessEnv(profile)
+
+    expect(process.env.CLAUDE_CODE_TEMPERATURE).toBe('0.2')
+    expect(process.env.CLAUDE_CODE_TOP_P).toBe('0.85')
+    expect(process.env.CLAUDE_CODE_MAX_CONTEXT_TOKENS).toBe('128000')
+    
+    // Verify getContextWindowForModel uses the env var
+    expect(getContextWindowForModel('test-model')).toBe(128000)
+  })
+
+  test('agentRouting respects temperature, top_p, and num_ctx', () => {
+    const settings = {
+      agentRouting: {
+        'test-agent': 'test-model',
+      },
+      agentModels: {
+        'test-model': {
+          base_url: 'https://api.example.com/v1',
+          api_key: 'sk-test',
+          temperature: 0.3,
+          top_p: 0.7,
+          num_ctx: 64000,
+        },
+      },
+    } as any
+
+    const override = resolveAgentProvider('test-agent', undefined, settings)
+    expect(override).not.toBeNull()
+    expect(override?.temperature).toBe(0.3)
+    expect(override?.top_p).toBe(0.7)
+    expect(override?.num_ctx).toBe(64000)
+  })
+
+  test('getContextWindowForModel supports explicit override', () => {
+    expect(getContextWindowForModel('any-model', [], 50000)).toBe(50000)
+  })
+
+  test('temperature: 0 is correctly handled', () => {
+    const profile = {
+      id: 'test-profile-0',
+      name: 'Test Profile 0',
+      provider: 'openai' as any,
+      baseUrl: 'https://api.example.com/v1',
+      model: 'test-model',
+      temperature: 0,
+    }
+    applyProviderProfileToProcessEnv(profile)
+    expect(process.env.CLAUDE_CODE_TEMPERATURE).toBe('0')
+  })
+
+  test('num_ctx override correctly impacts compaction thresholds', () => {
+    const model = 'claude-3-5-sonnet-20240620'
+    
+    const baseWindow = getEffectiveContextWindowSize(model)
+    const baseThreshold = getAutoCompactThreshold(model)
+    
+    // Use a much larger override
+    const overrideNumCtx = 500000
+    const overridenWindow = getEffectiveContextWindowSize(model, overrideNumCtx)
+    const overridenThreshold = getAutoCompactThreshold(model, overrideNumCtx)
+    
+    // Verify that thresholds have increased significantly
+    expect(overridenWindow).toBeGreaterThan(baseWindow)
+    expect(overridenThreshold).toBeGreaterThan(baseThreshold)
+    
+    // Verify that the relationship between window and threshold is preserved (AUTOCOMPACT_BUFFER_TOKENS = 13000)
+    expect(overridenThreshold).toBe(overridenWindow - 13000)
+    
+    // Verify that the overriden window is within expected bounds 
+    // (should be close to overrideNumCtx, but minus summary reservation)
+    expect(overridenWindow).toBeLessThan(overrideNumCtx)
+    expect(overridenWindow).toBeGreaterThan(overrideNumCtx - 30000)
+  })
+})

--- a/src/utils/modelParams.test.ts
+++ b/src/utils/modelParams.test.ts
@@ -24,7 +24,7 @@ describe('Model Parameter Configuration', () => {
     process.env = { ...originalEnv }
   })
 
-  test('ProviderProfile respects temperature, top_p, and num_ctx', () => {
+  test('ProviderProfile respects temperature and top_p', () => {
     const profile = {
       id: 'test-profile',
       name: 'Test Profile',
@@ -33,20 +33,15 @@ describe('Model Parameter Configuration', () => {
       model: 'test-model',
       temperature: 0.2,
       top_p: 0.85,
-      num_ctx: 128000,
     }
 
     applyProviderProfileToProcessEnv(profile)
 
     expect(process.env.CLAUDE_CODE_TEMPERATURE).toBe('0.2')
     expect(process.env.CLAUDE_CODE_TOP_P).toBe('0.85')
-    expect(process.env.CLAUDE_CODE_MAX_CONTEXT_TOKENS).toBe('128000')
-    
-    // Verify getContextWindowForModel uses the env var
-    expect(getContextWindowForModel('test-model')).toBe(128000)
   })
 
-  test('agentRouting respects temperature, top_p, and num_ctx', () => {
+  test('agentRouting respects temperature and top_p', () => {
     const settings = {
       agentRouting: {
         'test-agent': 'test-model',
@@ -57,7 +52,6 @@ describe('Model Parameter Configuration', () => {
           api_key: 'sk-test',
           temperature: 0.3,
           top_p: 0.7,
-          num_ctx: 64000,
         },
       },
     } as any
@@ -66,7 +60,6 @@ describe('Model Parameter Configuration', () => {
     expect(override).not.toBeNull()
     expect(override?.temperature).toBe(0.3)
     expect(override?.top_p).toBe(0.7)
-    expect(override?.num_ctx).toBe(64000)
   })
 
   test('getContextWindowForModel supports explicit override', () => {
@@ -84,29 +77,5 @@ describe('Model Parameter Configuration', () => {
     }
     applyProviderProfileToProcessEnv(profile)
     expect(process.env.CLAUDE_CODE_TEMPERATURE).toBe('0')
-  })
-
-  test('num_ctx override correctly impacts compaction thresholds', () => {
-    const model = 'claude-3-5-sonnet-20240620'
-    
-    const baseWindow = getEffectiveContextWindowSize(model)
-    const baseThreshold = getAutoCompactThreshold(model)
-    
-    // Use a much larger override
-    const overrideNumCtx = 500000
-    const overridenWindow = getEffectiveContextWindowSize(model, overrideNumCtx)
-    const overridenThreshold = getAutoCompactThreshold(model, overrideNumCtx)
-    
-    // Verify that thresholds have increased significantly
-    expect(overridenWindow).toBeGreaterThan(baseWindow)
-    expect(overridenThreshold).toBeGreaterThan(baseThreshold)
-    
-    // Verify that the relationship between window and threshold is preserved (AUTOCOMPACT_BUFFER_TOKENS = 13000)
-    expect(overridenThreshold).toBe(overridenWindow - 13000)
-    
-    // Verify that the overriden window is within expected bounds 
-    // (should be close to overrideNumCtx, but minus summary reservation)
-    expect(overridenWindow).toBeLessThan(overrideNumCtx)
-    expect(overridenWindow).toBeGreaterThan(overrideNumCtx - 30000)
   })
 })

--- a/src/utils/providerProfile.ts
+++ b/src/utils/providerProfile.ts
@@ -93,6 +93,9 @@ const PROFILE_ENV_KEYS = [
   'XAI_API_KEY',
   'VENICE_API_KEY',
   'MIMO_API_KEY',
+  'CLAUDE_CODE_TEMPERATURE',
+  'CLAUDE_CODE_TOP_P',
+  'CLAUDE_CODE_MAX_CONTEXT_TOKENS',
 ] as const
 
 export type CompatibilityProfileMode =
@@ -149,6 +152,9 @@ export type ProfileEnv = {
   OPENAI_AUTH_SCHEME?: 'bearer' | 'raw'
   OPENAI_AUTH_HEADER_VALUE?: string
   OPENAI_API_KEY?: string
+  CLAUDE_CODE_TEMPERATURE?: string
+  CLAUDE_CODE_TOP_P?: string
+  CLAUDE_CODE_MAX_CONTEXT_TOKENS?: string
   CODEX_API_KEY?: string
   CODEX_CREDENTIAL_SOURCE?: 'oauth' | 'existing'
   CHATGPT_ACCOUNT_ID?: string

--- a/src/utils/providerProfiles.ts
+++ b/src/utils/providerProfiles.ts
@@ -60,6 +60,9 @@ export type ProviderProfileInput = {
   authScheme?: ProviderProfile['authScheme']
   authHeaderValue?: ProviderProfile['authHeaderValue']
   customHeaders?: ProviderProfile['customHeaders']
+  temperature?: number
+  top_p?: number
+  num_ctx?: number
 }
 
 export type ProviderPresetDefaults = Omit<ProviderProfileInput, 'provider'> & {
@@ -186,6 +189,15 @@ function sanitizeProfile(profile: ProviderProfile): ProviderProfile | null {
   if (customHeaders) {
     sanitized.customHeaders = customHeaders
   }
+  if (profile.temperature !== undefined) {
+    sanitized.temperature = profile.temperature
+  }
+  if (profile.top_p !== undefined) {
+    sanitized.top_p = profile.top_p
+  }
+  if (profile.num_ctx !== undefined) {
+    sanitized.num_ctx = profile.num_ctx
+  }
   return sanitized
 }
 
@@ -225,6 +237,9 @@ function toProfile(
     authScheme: input.authScheme,
     authHeaderValue: input.authHeaderValue,
     customHeaders: input.customHeaders,
+    temperature: input.temperature,
+    top_p: input.top_p,
+    num_ctx: input.num_ctx,
   })
 }
 
@@ -672,6 +687,16 @@ export function applyProviderProfileToProcessEnv(profile: ProviderProfile): void
     }
 
     profileEnv = openAIProfileEnv
+  }
+
+  if (profile.temperature !== undefined) {
+    profileEnv.CLAUDE_CODE_TEMPERATURE = String(profile.temperature)
+  }
+  if (profile.top_p !== undefined) {
+    profileEnv.CLAUDE_CODE_TOP_P = String(profile.top_p)
+  }
+  if (profile.num_ctx !== undefined) {
+    profileEnv.CLAUDE_CODE_MAX_CONTEXT_TOKENS = String(profile.num_ctx)
   }
 
   profileEnv = applySupportedProfileCustomHeaders(profile, profileEnv)

--- a/src/utils/providerProfiles.ts
+++ b/src/utils/providerProfiles.ts
@@ -62,7 +62,6 @@ export type ProviderProfileInput = {
   customHeaders?: ProviderProfile['customHeaders']
   temperature?: number
   top_p?: number
-  num_ctx?: number
 }
 
 export type ProviderPresetDefaults = Omit<ProviderProfileInput, 'provider'> & {
@@ -195,9 +194,6 @@ function sanitizeProfile(profile: ProviderProfile): ProviderProfile | null {
   if (profile.top_p !== undefined) {
     sanitized.top_p = profile.top_p
   }
-  if (profile.num_ctx !== undefined) {
-    sanitized.num_ctx = profile.num_ctx
-  }
   return sanitized
 }
 
@@ -239,7 +235,6 @@ function toProfile(
     customHeaders: input.customHeaders,
     temperature: input.temperature,
     top_p: input.top_p,
-    num_ctx: input.num_ctx,
   })
 }
 
@@ -694,9 +689,6 @@ export function applyProviderProfileToProcessEnv(profile: ProviderProfile): void
   }
   if (profile.top_p !== undefined) {
     profileEnv.CLAUDE_CODE_TOP_P = String(profile.top_p)
-  }
-  if (profile.num_ctx !== undefined) {
-    profileEnv.CLAUDE_CODE_MAX_CONTEXT_TOKENS = String(profile.num_ctx)
   }
 
   profileEnv = applySupportedProfileCustomHeaders(profile, profileEnv)

--- a/src/utils/settings/types.ts
+++ b/src/utils/settings/types.ts
@@ -742,6 +742,9 @@ export const SettingsSchema = lazySchema(() =>
           z.object({
             base_url: z.string().url().describe('OpenAI-compatible API endpoint (must be https:// or http://)'),
             api_key: z.string().describe('API key for this provider'),
+            temperature: z.number().min(0).max(1).optional().describe('Optional temperature override (0.0 to 1.0)'),
+            top_p: z.number().min(0).max(1).optional().describe('Optional top_p override (0.0 to 1.0)'),
+            num_ctx: z.number().int().positive().optional().describe('Optional context window override'),
           }),
         )
         .optional()

--- a/src/utils/settings/types.ts
+++ b/src/utils/settings/types.ts
@@ -744,7 +744,6 @@ export const SettingsSchema = lazySchema(() =>
             api_key: z.string().describe('API key for this provider'),
             temperature: z.number().min(0).max(1).optional().describe('Optional temperature override (0.0 to 1.0)'),
             top_p: z.number().min(0).max(1).optional().describe('Optional top_p override (0.0 to 1.0)'),
-            num_ctx: z.number().int().positive().optional().describe('Optional context window override'),
           }),
         )
         .optional()


### PR DESCRIPTION
Summary

   - What changed: 
       - Extended the JSON configuration schema (~/.openclaude.json and .openclaude/settings.json) to support temperature, top_p, and num_ctx (context window size) parameters.
       - Implemented a unified parameter resolution chain (Programmatic Options > Provider Profiles > Environment Variables > Model Defaults).
       - Refactored ProviderOverride into a centralized type in src/services/api/authRouting.ts to ensure consistency across API clients (claude.ts, openaiShim.ts) and ToolUseContext.
       - Integrated these parameters into the telemetry system (logAPIQuery, logAPISuccess, logAPIError) using standard snake_case naming.
       - Updated the auto-compaction and token warning logic in query.ts and autoCompact.ts to respect user-defined num_ctx overrides.

   - Why it changed: 
       - To provide users with fine-grained control over model behavior and context management without relying solely on environment variables. 
       - To ensure that custom or local models (via vLLM, Ollama, etc.) with non-standard context windows are correctly handled by the agent's internal memory management.

  Impact

   - User-facing impact: Users can now configure advanced model parameters directly in their profile or per-agent routing settings.
   - Developer/maintainer impact: Harmonizes how model overrides are propagated through the codebase, reducing duplication and improving type safety.

  Testing

   - [x] bun run build: Confirmed bundle integrity.
   - [x] bun run smoke: Basic functional verification passed.
   - Focused tests: 
       - Added src/utils/modelParams.test.ts to verify profile application and compaction threshold calculations.
       - Added payload validation in src/services/api/openaiShim.test.ts to ensure correct JSON serialization and NaN protection.

  Notes

   - Provider/model path tested: Verified with Gemma 4 31B (OpenAI-compatible) and Claude 3.5 Sonnet.
   - Screenshots attached: N/A.
   - Follow-up work or known limitations: 
       - temperature is correctly omitted when thinking mode is active, as per Anthropic API requirements.
       - Parameters are currently limited to providers supporting these standard fields.

