### PR TITLE
fix(gemini): preserve streamed thought signatures

### DIFF
--- a/src/services/api/openaiShim.test.ts
+++ b/src/services/api/openaiShim.test.ts
@@ -1110,6 +1110,72 @@ test('preserves Gemini tool call extra_content in follow-up requests', async () 
   })
 })
 
+test('drops prior Gemini tool calls that have no thought signature', async () => {
+  process.env.OPENAI_BASE_URL = 'https://opengateway.gitlawb.com/v1'
+  let requestBody: Record<string, unknown> | undefined
+
+  globalThis.fetch = (async (_input, init) => {
+    requestBody = JSON.parse(String(init?.body))
+
+    return new Response(
+      JSON.stringify({
+        id: 'chatcmpl-1',
+        model: 'google/gemini-3.1-flash-lite-preview',
+        choices: [
+          {
+            message: {
+              role: 'assistant',
+              content: 'done',
+            },
+            finish_reason: 'stop',
+          },
+        ],
+      }),
+      {
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      },
+    )
+  }) as FetchType
+
+  const client = createOpenAIShimClient({}) as OpenAIShimClient
+
+  await client.beta.messages.create({
+    model: 'google/gemini-3.1-flash-lite-preview',
+    messages: [
+      { role: 'user', content: 'Use Glob' },
+      {
+        role: 'assistant',
+        content: [
+          {
+            type: 'tool_use',
+            id: 'call_glob_unsigned',
+            name: 'Glob',
+            input: { pattern: 'src/**/*.ts' },
+          },
+        ],
+      },
+      {
+        role: 'user',
+        content: [
+          {
+            type: 'tool_result',
+            tool_use_id: 'call_glob_unsigned',
+            content: 'src/index.ts',
+          },
+        ],
+      },
+    ],
+    max_tokens: 64,
+    stream: false,
+  })
+
+  const messages = requestBody?.messages as Array<Record<string, unknown>>
+  expect(messages.some(message => Array.isArray(message.tool_calls))).toBe(false)
+  expect(messages.some(message => message.role === 'tool')).toBe(false)
+})
+
 test('replays Gemini tool signatures for OpenGateway Gemini models', async () => {
   process.env.OPENAI_BASE_URL = 'https://opengateway.gitlawb.com/v1'
   let requestBody: Record<string, unknown> | undefined
@@ -1485,6 +1551,116 @@ test('strips unsupported stream_options for Xiaomi MiMo streams', async () => {
   })
   expect(requestBody).not.toHaveProperty('stream_options')
   expect(requestBody).not.toHaveProperty('store')
+})
+
+test('streams Gemini thought signatures that arrive after initial tool arguments', async () => {
+  process.env.OPENAI_MODEL = 'google/gemini-3.1-pro-preview'
+
+  globalThis.fetch = (async () => {
+    return makeSseResponse(makeStreamChunks([
+      {
+        id: 'chatcmpl-gemini-stream-sig-after-args',
+        object: 'chat.completion.chunk',
+        model: 'google/gemini-3.1-pro-preview',
+        choices: [
+          {
+            delta: {
+              role: 'assistant',
+              tool_calls: [
+                {
+                  index: 0,
+                  id: 'call_glob',
+                  type: 'function',
+                  function: {
+                    name: 'Glob',
+                    arguments: '{"pattern":"src/**/*.ts"}',
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+      {
+        id: 'chatcmpl-gemini-stream-sig-after-args',
+        object: 'chat.completion.chunk',
+        model: 'google/gemini-3.1-pro-preview',
+        choices: [
+          {
+            delta: {
+              tool_calls: [
+                {
+                  index: 0,
+                  extra_content: {
+                    google: {
+                      thought_signature: 'sig-after-initial-args',
+                    },
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+      {
+        id: 'chatcmpl-gemini-stream-sig-after-args',
+        object: 'chat.completion.chunk',
+        model: 'google/gemini-3.1-pro-preview',
+        choices: [
+          {
+            delta: {},
+            finish_reason: 'tool_calls',
+          },
+        ],
+      },
+    ]))
+  }) as FetchType
+
+  const client = createOpenAIShimClient({}) as OpenAIShimClient
+
+  const result = await client.beta.messages
+    .create({
+      model: 'google/gemini-3.1-pro-preview',
+      messages: [{ role: 'user', content: 'glob files' }],
+      max_tokens: 64,
+      stream: true,
+    })
+    .withResponse()
+
+  const events: Array<Record<string, unknown>> = []
+  for await (const event of result.data) {
+    events.push(event)
+  }
+
+  const toolStartIndex = events.findIndex(
+    event =>
+      event.type === 'content_block_start' &&
+      (event.content_block as Record<string, unknown> | undefined)?.type === 'tool_use',
+  )
+  const deltaIndex = events.findIndex(
+    event =>
+      event.type === 'content_block_delta' &&
+      (event.delta as Record<string, unknown> | undefined)?.type === 'input_json_delta',
+  )
+  const toolStart = events[toolStartIndex] as
+    | { content_block?: Record<string, unknown> }
+    | undefined
+
+  expect(toolStartIndex).toBeGreaterThan(-1)
+  expect(deltaIndex).toBeGreaterThan(-1)
+  expect(toolStartIndex).toBeLessThan(deltaIndex)
+
+  expect(toolStart?.content_block).toMatchObject({
+    type: 'tool_use',
+    id: 'call_glob',
+    name: 'Glob',
+    signature: 'sig-after-initial-args',
+    extra_content: {
+      google: {
+        thought_signature: 'sig-after-initial-args',
+      },
+    },
+  })
 })
 
 test('streams Gemini thought signatures that arrive after tool call start', async () => {

--- a/src/services/api/openaiShim.test.ts
+++ b/src/services/api/openaiShim.test.ts
@@ -1176,6 +1176,102 @@ test('drops prior Gemini tool calls that have no thought signature', async () =>
   expect(messages.some(message => message.role === 'tool')).toBe(false)
 })
 
+test('keeps semantic continuation after dropping unsigned Gemini tool history', async () => {
+  process.env.OPENAI_BASE_URL = 'https://opengateway.gitlawb.com/v1'
+  let requestBody: Record<string, unknown> | undefined
+
+  globalThis.fetch = (async (_input, init) => {
+    requestBody = JSON.parse(String(init?.body))
+
+    return new Response(
+      JSON.stringify({
+        id: 'chatcmpl-1',
+        model: 'google/gemini-3.1-flash-lite-preview',
+        choices: [
+          {
+            message: {
+              role: 'assistant',
+              content: 'restored session summary',
+            },
+            finish_reason: 'stop',
+          },
+        ],
+      }),
+      {
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      },
+    )
+  }) as FetchType
+
+  const client = createOpenAIShimClient({}) as OpenAIShimClient
+
+  await client.beta.messages.create({
+    model: 'google/gemini-3.1-flash-lite-preview',
+    messages: [
+      { role: 'user', content: 'Restore session' },
+      {
+        role: 'assistant',
+        content: [
+          {
+            type: 'tool_use',
+            id: 'call_restore_unsigned',
+            name: 'mcp__ruflo__session_restore',
+            input: { sessionId: 'session-1779413576935-lel1vw' },
+          },
+        ],
+      },
+      {
+        role: 'user',
+        content: [
+          {
+            type: 'tool_result',
+            tool_use_id: 'call_restore_unsigned',
+            content: '{"sessionId":"session-1779413576935-lel1vw"}',
+          },
+        ],
+      },
+      {
+        role: 'assistant',
+        content: [
+          {
+            type: 'tool_use',
+            id: 'call_task_list_unsigned',
+            name: 'mcp__ruflo__task_list',
+            input: {},
+          },
+        ],
+      },
+      {
+        role: 'user',
+        content: [
+          {
+            type: 'tool_result',
+            tool_use_id: 'call_task_list_unsigned',
+            content: '{"tasks":[],"total":0}',
+          },
+        ],
+      },
+      { role: 'user', content: 'tu as bug ?' },
+    ],
+    max_tokens: 64,
+    stream: false,
+  })
+
+  const messages = requestBody?.messages as Array<Record<string, unknown>>
+  expect(messages.some(message => Array.isArray(message.tool_calls))).toBe(false)
+  expect(messages.some(message => message.role === 'tool')).toBe(false)
+  expect(messages).toContainEqual({
+    role: 'user',
+    content: expect.stringContaining('tu as bug ?'),
+  })
+  expect(messages).toContainEqual({
+    role: 'assistant',
+    content: '[Previous unsigned Gemini tool results were omitted]',
+  })
+})
+
 test('replays Gemini tool signatures for OpenGateway Gemini models', async () => {
   process.env.OPENAI_BASE_URL = 'https://opengateway.gitlawb.com/v1'
   let requestBody: Record<string, unknown> | undefined

--- a/src/services/api/openaiShim.test.ts
+++ b/src/services/api/openaiShim.test.ts
@@ -1487,6 +1487,107 @@ test('strips unsupported stream_options for Xiaomi MiMo streams', async () => {
   expect(requestBody).not.toHaveProperty('store')
 })
 
+test('streams Gemini thought signatures that arrive after tool call start', async () => {
+  process.env.OPENAI_MODEL = 'google/gemini-3.1-pro-preview'
+
+  globalThis.fetch = (async () => {
+    return makeSseResponse(makeStreamChunks([
+      {
+        id: 'chatcmpl-gemini-stream-sig',
+        object: 'chat.completion.chunk',
+        model: 'google/gemini-3.1-pro-preview',
+        choices: [
+          {
+            delta: {
+              role: 'assistant',
+              tool_calls: [
+                {
+                  index: 0,
+                  id: 'call_1',
+                  type: 'function',
+                  function: {
+                    name: 'mcp__ruflo__session_restore',
+                    arguments: '',
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+      {
+        id: 'chatcmpl-gemini-stream-sig',
+        object: 'chat.completion.chunk',
+        model: 'google/gemini-3.1-pro-preview',
+        choices: [
+          {
+            delta: {
+              tool_calls: [
+                {
+                  index: 0,
+                  extra_content: {
+                    google: {
+                      thought_signature: 'sig-stream-late',
+                    },
+                  },
+                  function: {
+                    arguments: '{"sessionId":"abc"}',
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+      {
+        id: 'chatcmpl-gemini-stream-sig',
+        object: 'chat.completion.chunk',
+        model: 'google/gemini-3.1-pro-preview',
+        choices: [
+          {
+            delta: {},
+            finish_reason: 'tool_calls',
+          },
+        ],
+      },
+    ]))
+  }) as FetchType
+
+  const client = createOpenAIShimClient({}) as OpenAIShimClient
+
+  const result = await client.beta.messages
+    .create({
+      model: 'google/gemini-3.1-pro-preview',
+      messages: [{ role: 'user', content: 'restore session' }],
+      max_tokens: 64,
+      stream: true,
+    })
+    .withResponse()
+
+  const events: Array<Record<string, unknown>> = []
+  for await (const event of result.data) {
+    events.push(event)
+  }
+
+  const toolStart = events.find(
+    event =>
+      event.type === 'content_block_start' &&
+      (event.content_block as Record<string, unknown> | undefined)?.type === 'tool_use',
+  ) as { content_block?: Record<string, unknown> } | undefined
+
+  expect(toolStart?.content_block).toMatchObject({
+    type: 'tool_use',
+    id: 'call_1',
+    name: 'mcp__ruflo__session_restore',
+    signature: 'sig-stream-late',
+    extra_content: {
+      google: {
+        thought_signature: 'sig-stream-late',
+      },
+    },
+  })
+})
+
 test('preserves Grep tool pattern field in OpenAI-compatible schemas', async () => {
   let requestBody: Record<string, unknown> | undefined
 

--- a/src/services/api/openaiShim.ts
+++ b/src/services/api/openaiShim.ts
@@ -31,7 +31,13 @@ import {
   refreshCodexAccessTokenIfNeeded,
 } from '../../utils/codexCredentials.js'
 import { logForDebugging } from '../../utils/debug.js'
-import { isBareMode, isEnvTruthy } from '../../utils/envUtils.js'
+import {
+  isBareMode,
+  isEnvTruthy,
+  isGeminiEnvironment,
+  hasGeminiApiHost,
+  isGeminiModelName,
+} from '../../utils/envUtils.js'
 import { resolveGeminiCredential } from '../../utils/geminiAuth.js'
 import { hydrateGeminiAccessTokenFromSecureStorage } from '../../utils/geminiCredentials.js'
 import { hydrateGithubModelsTokenFromSecureStorage } from '../../utils/githubModelsCredentials.js'
@@ -98,7 +104,6 @@ type SecretValueSource = Partial<{
 const GITHUB_429_MAX_RETRIES = 3
 const GITHUB_429_BASE_DELAY_SEC = 1
 const GITHUB_429_MAX_DELAY_SEC = 32
-const GEMINI_API_HOST = 'generativelanguage.googleapis.com'
 const COPILOT_HEADERS: Record<string, string> = {
   'User-Agent': 'GitHubCopilotChat/0.26.7',
   'Editor-Version': 'vscode/1.99.3',
@@ -136,24 +141,6 @@ function filterAnthropicHeaders(
   return filtered
 }
 
-function hasGeminiApiHost(baseUrl: string | undefined): boolean {
-  if (!baseUrl) return false
-
-  try {
-    return new URL(baseUrl).hostname.toLowerCase() === GEMINI_API_HOST
-  } catch {
-    return false
-  }
-}
-
-function isGeminiModelName(model: string | undefined): boolean {
-  const normalized = model?.trim().toLowerCase()
-  return (
-    normalized?.startsWith('google/gemini-') === true ||
-    normalized?.startsWith('gemini-') === true
-  )
-}
-
 function shouldPreserveGeminiThoughtSignature(
   model: string | undefined,
   baseUrl?: string,
@@ -186,6 +173,42 @@ function mergeGeminiThoughtSignature(
       ...existingGoogle,
       thought_signature: signature,
     },
+  }
+}
+
+type PendingToolCallStart = {
+  id: string
+  name: string
+  index: number
+  input: Record<string, unknown>
+  extraContent?: Record<string, unknown>
+  signature?: string
+}
+
+function mergePendingToolCallSignature(
+  pending: PendingToolCallStart,
+  extraContent: Record<string, unknown> | undefined,
+): void {
+  const signature = geminiThoughtSignatureFromExtraContent(extraContent)
+  pending.extraContent = mergeGeminiThoughtSignature(
+    extraContent ?? pending.extraContent,
+    signature ?? pending.signature,
+  )
+  if (signature) {
+    pending.signature = signature
+  }
+}
+
+function makeToolUseContentBlock(
+  toolCall: PendingToolCallStart,
+): Record<string, unknown> {
+  return {
+    type: 'tool_use',
+    id: toolCall.id,
+    name: toolCall.name,
+    input: toolCall.input,
+    ...(toolCall.extraContent ? { extra_content: toolCall.extraContent } : {}),
+    ...(toolCall.signature ? { signature: toolCall.signature } : {}),
   }
 }
 
@@ -428,10 +451,7 @@ function convertContentBlocks(
 }
 
 function isGeminiMode(): boolean {
-  return (
-    isEnvTruthy(process.env.CLAUDE_CODE_USE_GEMINI) ||
-    hasGeminiApiHost(process.env.OPENAI_BASE_URL)
-  )
+  return isGeminiEnvironment()
 }
 
 function hydrateOpenAIShimCompatibilityEnv(
@@ -1020,6 +1040,8 @@ async function* openaiStreamToAnthropic(
       index: number
       jsonBuffer: string
       normalizeAtStop: boolean
+      startEmitted: boolean
+      pendingStart: PendingToolCallStart
     }
   >()
   let hasEmittedContentStart = false
@@ -1031,6 +1053,22 @@ async function* openaiStreamToAnthropic(
   let hasProcessedFinishReason = false
   const streamState = createStreamState()
   let bufferedRawToolCallsText: string | null = null
+
+  const flushToolCallStart = function* (
+    active: {
+      index: number
+      startEmitted: boolean
+      pendingStart: PendingToolCallStart
+    },
+  ): Generator<AnthropicStreamEvent> {
+    if (active.startEmitted) return
+    yield {
+      type: 'content_block_start',
+      index: active.index,
+      content_block: makeToolUseContentBlock(active.pendingStart),
+    }
+    active.startEmitted = true
+  }
 
   // Emit message_start
   yield {
@@ -1327,24 +1365,24 @@ async function* openaiStreamToAnthropic(
                 index: toolBlockIndex,
                 jsonBuffer: initialArguments,
                 normalizeAtStop,
-              })
-
-              yield {
-                type: 'content_block_start',
-                index: toolBlockIndex,
-                content_block: {
-                  type: 'tool_use',
+                startEmitted: false,
+                pendingStart: {
                   id: tc.id,
                   name: tc.function.name,
+                  index: toolBlockIndex,
                   input: {},
-                  ...(mergedToolExtraContent ? { extra_content: mergedToolExtraContent } : {}),
-                  ...(toolSignature ? { signature: toolSignature } : {}),
+                  extraContent: mergedToolExtraContent,
+                  signature: toolSignature,
                 },
-              }
+              })
               contentBlockIndex++
 
               // Emit any initial arguments
               if (tc.function.arguments && !normalizeAtStop) {
+                const active = activeToolCalls.get(tc.index)
+                if (active) {
+                  yield* flushToolCallStart(active)
+                }
                 yield {
                   type: 'content_block_delta',
                   index: toolBlockIndex,
@@ -1354,11 +1392,15 @@ async function* openaiStreamToAnthropic(
                   },
                 }
               }
-            } else if (tc.function?.arguments) {
+            } else if (tc.function?.arguments || tc.extra_content || delta.extra_content) {
               // Continuation of existing tool call
               const active = activeToolCalls.get(tc.index)
               if (active) {
-                if (tc.function.arguments) {
+                mergePendingToolCallSignature(
+                  active.pendingStart,
+                  tc.extra_content ?? delta.extra_content,
+                )
+                if (tc.function?.arguments) {
                   active.jsonBuffer += tc.function.arguments
                 }
 
@@ -1366,13 +1408,16 @@ async function* openaiStreamToAnthropic(
                   continue
                 }
 
-                yield {
-                  type: 'content_block_delta',
-                  index: active.index,
-                  delta: {
-                    type: 'input_json_delta',
-                    partial_json: tc.function.arguments,
-                  },
+                if (tc.function?.arguments) {
+                  yield* flushToolCallStart(active)
+                  yield {
+                    type: 'content_block_delta',
+                    index: active.index,
+                    delta: {
+                      type: 'input_json_delta',
+                      partial_json: tc.function.arguments,
+                    },
+                  }
                 }
               }
             }
@@ -1406,6 +1451,7 @@ async function* openaiStreamToAnthropic(
           }
           // Close active tool calls
           for (const [, tc] of activeToolCalls) {
+            yield* flushToolCallStart(tc)
             if (tc.normalizeAtStop) {
               let partialJson: string
               if (choice.finish_reason === 'length') {

--- a/src/services/api/openaiShim.ts
+++ b/src/services/api/openaiShim.ts
@@ -655,7 +655,6 @@ function convertMessages(
                   return null
                 }
 
-                knownToolCallIds.add(id)
                 const toolCall: NonNullable<
                   OpenAIMessage['tool_calls']
                 >[number] = {
@@ -670,20 +669,23 @@ function convertMessages(
                   },
                 }
 
-                // Preserve existing extra_content if present
                 if (tu.extra_content) {
                   toolCall.extra_content = { ...tu.extra_content }
                 }
 
-                // Gemini OpenAI-compatible endpoints require Google's
-                // thought_signature to be replayed with prior function-call
-                // parts. Preserve only real signatures received from the
-                // provider; synthetic placeholders are rejected by GMI.
+                // Gemini rejects replayed function-call parts that do not carry
+                // their original thought_signature. If a historical tool_use was
+                // recorded before the signature arrived, drop the call/result pair
+                // instead of sending an invalid functionCall back to Gemini.
                 if (preserveGeminiThoughtSignature) {
                   const signature =
                     tu.signature ??
                     geminiThoughtSignatureFromExtraContent(tu.extra_content) ??
                     (thinkingBlock as { signature?: string } | undefined)?.signature
+
+                  if (!signature && !isLastInHistory) {
+                    return null
+                  }
 
                   toolCall.extra_content = mergeGeminiThoughtSignature(
                     toolCall.extra_content,
@@ -691,6 +693,7 @@ function convertMessages(
                   )
                 }
 
+                knownToolCallIds.add(id)
                 return toolCall
               },
             )

--- a/src/services/api/openaiShim.ts
+++ b/src/services/api/openaiShim.ts
@@ -516,6 +516,7 @@ function convertMessages(
   const preserveGeminiThoughtSignature = options?.preserveGeminiThoughtSignature === true
   const result: OpenAIMessage[] = []
   const knownToolCallIds = new Set<string>()
+  let omittedUnsignedGeminiToolHistory = false
 
   // Pre-scan for all tool results in the history to identify valid tool calls
   const toolResultIds = new Set<string>()
@@ -684,6 +685,7 @@ function convertMessages(
                     (thinkingBlock as { signature?: string } | undefined)?.signature
 
                   if (!signature && !isLastInHistory) {
+                    omittedUnsignedGeminiToolHistory = true
                     return null
                   }
 
@@ -727,6 +729,13 @@ function convertMessages(
         }
       }
     }
+  }
+
+  if (omittedUnsignedGeminiToolHistory) {
+    result.push({
+      role: 'assistant',
+      content: '[Previous unsigned Gemini tool results were omitted]',
+    })
   }
 
   // Coalescing pass: merge consecutive messages of the same role.

--- a/src/utils/envUtils.ts
+++ b/src/utils/envUtils.ts
@@ -225,6 +225,37 @@ export function isEnvTruthy(envVar: string | boolean | undefined): boolean {
   return ['1', 'true', 'yes', 'on'].includes(normalizedValue)
 }
 
+const GEMINI_API_HOST = 'generativelanguage.googleapis.com'
+
+export function hasGeminiApiHost(baseUrl: string | undefined): boolean {
+  if (!baseUrl) return false
+
+  try {
+    return new URL(baseUrl).hostname.toLowerCase() === GEMINI_API_HOST
+  } catch {
+    return false
+  }
+}
+
+export function isGeminiModelName(model: string | undefined): boolean {
+  const normalized = model?.trim().toLowerCase()
+  return (
+    normalized?.startsWith('google/gemini-') === true ||
+    normalized?.startsWith('gemini-') === true ||
+    normalized?.includes('/gemini-') === true
+  )
+}
+
+export function isGeminiEnvironment(
+  processEnv: NodeJS.ProcessEnv = process.env,
+): boolean {
+  return (
+    isEnvTruthy(processEnv.CLAUDE_CODE_USE_GEMINI) ||
+    hasGeminiApiHost(processEnv.OPENAI_BASE_URL) ||
+    isGeminiModelName(processEnv.GEMINI_MODEL ?? processEnv.OPENAI_MODEL)
+  )
+}
+
 export function isEnvDefinedFalsy(
   envVar: string | boolean | undefined,
 ): boolean {

--- a/src/utils/messages.test.ts
+++ b/src/utils/messages.test.ts
@@ -1,0 +1,119 @@
+import { afterEach, beforeEach, expect, mock, test } from 'bun:test'
+import { acquireSharedMutationLock, releaseSharedMutationLock } from '../test/sharedMutationLock.js'
+
+const ENV_KEYS = [
+  'CLAUDE_CODE_USE_GEMINI',
+  'OPENAI_BASE_URL',
+  'OPENAI_MODEL',
+  'GEMINI_MODEL',
+]
+
+const originalEnv: Record<string, string | undefined> = {}
+
+beforeEach(async () => {
+  await acquireSharedMutationLock('utils/messages.test.ts')
+  for (const key of ENV_KEYS) {
+    originalEnv[key] = process.env[key]
+    delete process.env[key]
+  }
+})
+
+afterEach(() => {
+  try {
+    mock.restore()
+    for (const key of ENV_KEYS) {
+      if (originalEnv[key] === undefined) {
+        delete process.env[key]
+      } else {
+        process.env[key] = originalEnv[key]
+      }
+    }
+  } finally {
+    releaseSharedMutationLock()
+  }
+})
+
+async function importMessagesWithProvider(provider: string) {
+  mock.module('./model/providers.js', () => ({
+    getAPIProvider: () => provider,
+    usesAnthropicAccountFlow: () => provider === 'firstParty',
+    getAPIProviderForStatsig: () => provider,
+    isGithubNativeAnthropicMode: () => false,
+    isFirstPartyAnthropicBaseUrl: () => provider === 'firstParty',
+  }))
+  const nonce = `${Date.now()}-${Math.random()}`
+  return import(`./messages.ts?ts=${nonce}`)
+}
+
+function assistantWithGeminiToolMetadata() {
+  return {
+    type: 'assistant',
+    message: {
+      content: [
+        {
+          type: 'tool_use',
+          id: 'toolu_1',
+          name: 'Read',
+          input: { file_path: '/tmp/example.txt' },
+          extra_content: {
+            google: {
+              thought_signature: 'sig-from-gemini',
+            },
+          },
+          signature: 'sig-from-gemini',
+          caller: 'gemini-tool-search',
+        },
+      ],
+    },
+  }
+}
+
+test('normalizeMessagesForAPI strips Gemini tool metadata for non-Gemini providers', async () => {
+  const { normalizeMessagesForAPI } = await importMessagesWithProvider('anthropic')
+
+  const [normalized] = normalizeMessagesForAPI([
+    assistantWithGeminiToolMetadata(),
+  ])
+  const [toolUse] = normalized.message.content
+
+  expect(toolUse).toEqual({
+    type: 'tool_use',
+    id: 'toolu_1',
+    name: 'Read',
+    input: { file_path: '/tmp/example.txt' },
+  })
+})
+
+test('stripCallerFieldFromAssistantMessage strips Gemini tool metadata for non-Gemini providers', async () => {
+  const { stripCallerFieldFromAssistantMessage } = await importMessagesWithProvider('anthropic')
+
+  const stripped = stripCallerFieldFromAssistantMessage(
+    assistantWithGeminiToolMetadata(),
+  )
+  const [toolUse] = stripped.message.content
+
+  expect(toolUse).toEqual({
+    type: 'tool_use',
+    id: 'toolu_1',
+    name: 'Read',
+    input: { file_path: '/tmp/example.txt' },
+  })
+})
+
+test('normalizeMessagesForAPI preserves Gemini tool metadata in Gemini mode', async () => {
+  const { normalizeMessagesForAPI } = await importMessagesWithProvider('gemini')
+
+  const [normalized] = normalizeMessagesForAPI([
+    assistantWithGeminiToolMetadata(),
+  ])
+  const [toolUse] = normalized.message.content
+
+  expect(toolUse).toMatchObject({
+    extra_content: {
+      google: {
+        thought_signature: 'sig-from-gemini',
+      },
+    },
+    signature: 'sig-from-gemini',
+  })
+})

--- a/src/utils/messages.ts
+++ b/src/utils/messages.ts
@@ -75,7 +75,7 @@ import type {
 import { isAdvisorBlock } from './advisor.js'
 import { isAgentSwarmsEnabled } from './agentSwarmsEnabled.js'
 import { count } from './array.js'
-import { isEnvTruthy, isGeminiEnvironment } from './envUtils.js'
+import { isGeminiEnvironment } from './envUtils.js'
 import {
   type Attachment,
   type HookAttachment,
@@ -1771,8 +1771,12 @@ export function stripCallerFieldFromAssistantMessage(
           id: block.id,
           name: block.name,
           input: block.input,
-          ...((block as any).extra_content ? { extra_content: (block as any).extra_content } : {}),
-          ...((block as any).signature ? { signature: (block as any).signature } : {})
+          ...(isGeminiMode() && (block as any).extra_content
+            ? { extra_content: (block as any).extra_content }
+            : {}),
+          ...(isGeminiMode() && (block as any).signature
+            ? { signature: (block as any).signature }
+            : {}),
         }
       }),
     },
@@ -2229,12 +2233,13 @@ export function normalizeMessagesForAPI(
 
                   // When tool search is enabled, preserve all fields including 'caller'
                   if (toolSearchEnabled) {
-                    const { extra_content, ...restBlock } = block as any
+                    const { extra_content, signature, ...restBlock } = block as any
                     return {
                       ...restBlock,
                       name: canonicalName,
                       input: normalizedInput,
-                      ...(extra_content ? { extra_content } : {})
+                      ...(isGeminiMode() && extra_content ? { extra_content } : {}),
+                      ...(isGeminiMode() && signature ? { signature } : {}),
                     }
                   }
 
@@ -2246,8 +2251,12 @@ export function normalizeMessagesForAPI(
                     id: block.id,
                     name: canonicalName,
                     input: normalizedInput,
-                    ...((block as any).extra_content ? { extra_content: (block as any).extra_content } : {}),
-                    ...((block as any).signature ? { signature: (block as any).signature } : {})
+                    ...(isGeminiMode() && (block as any).extra_content
+                      ? { extra_content: (block as any).extra_content }
+                      : {}),
+                    ...(isGeminiMode() && (block as any).signature
+                      ? { signature: (block as any).signature }
+                      : {}),
                   }
                 }
                 return block

--- a/src/utils/messages.ts
+++ b/src/utils/messages.ts
@@ -75,7 +75,7 @@ import type {
 import { isAdvisorBlock } from './advisor.js'
 import { isAgentSwarmsEnabled } from './agentSwarmsEnabled.js'
 import { count } from './array.js'
-import { isEnvTruthy } from './envUtils.js'
+import { isEnvTruthy, isGeminiEnvironment } from './envUtils.js'
 import {
   type Attachment,
   type HookAttachment,
@@ -1731,6 +1731,10 @@ export function stripToolReferenceBlocksFromUserMessage(
   }
 }
 
+function isGeminiMode(): boolean {
+  return getAPIProvider() === 'gemini' || isGeminiEnvironment()
+}
+
 /**
  * Strips the 'caller' field from tool_use blocks in an assistant message.
  * The 'caller' field is only valid when the tool search beta is enabled.
@@ -1767,7 +1771,8 @@ export function stripCallerFieldFromAssistantMessage(
           id: block.id,
           name: block.name,
           input: block.input,
-          ...(getAPIProvider() === 'gemini' && (block as any).extra_content ? { extra_content: (block as any).extra_content } : {})
+          ...((block as any).extra_content ? { extra_content: (block as any).extra_content } : {}),
+          ...((block as any).signature ? { signature: (block as any).signature } : {})
         }
       }),
     },
@@ -2229,19 +2234,20 @@ export function normalizeMessagesForAPI(
                       ...restBlock,
                       name: canonicalName,
                       input: normalizedInput,
-                      ...(getAPIProvider() === 'gemini' && extra_content ? { extra_content } : {})
+                      ...(extra_content ? { extra_content } : {})
                     }
                   }
 
                   // When tool search is NOT enabled, explicitly construct tool_use
                   // block with only standard API fields to avoid sending fields like
                   // 'caller' that may be stored in sessions from tool search runs
-                    return {
+                  return {
                     type: 'tool_use' as const,
                     id: block.id,
                     name: canonicalName,
                     input: normalizedInput,
-                    ...(getAPIProvider() === 'gemini' && (block as any).extra_content ? { extra_content: (block as any).extra_content } : {})
+                    ...((block as any).extra_content ? { extra_content: (block as any).extra_content } : {}),
+                    ...((block as any).signature ? { signature: (block as any).signature } : {})
                   }
                 }
                 return block


### PR DESCRIPTION
## Summary
- Preserve Gemini `thought_signature` metadata when streamed tool-call chunks deliver `extra_content` after the tool call starts.
- Delay streaming `tool_use` start emission until pending Gemini signature metadata can be merged.
- **New**: Automatically prune historical Gemini tool calls that lack a `thought_signature`. This prevents Google API errors (HTTP 400) when replaying sessions that were partially recorded before the signature arrived.
- **New**: Maintain conversational continuity after pruning by appending a `[Previous unsigned Gemini tool results were omitted]` marker. This prevents the agent from entering a "dead state" where it fails to react to restored session history.
- **New**: Restore provider-specific guards in `src/utils/messages.ts` to prevent Gemini-specific metadata (`extra_content`, `signature`) from leaking into Anthropic-native requests.
- Factor shared Gemini environment/model detection into `src/utils/envUtils.ts` (`isGeminiEnvironment`, `hasGeminiApiHost`, `isGeminiModelName`) so `openaiShim.ts` and `messages.ts` use one detection path.

## Test plan
- [x] `bun test src/services/api/openaiShim.test.ts --test-name-pattern "streams Gemini thought signatures that arrive after tool call start"`
- [x] `bun test src/services/api/openaiShim.test.ts --test-name-pattern "replays Gemini tool signatures for OpenGateway Gemini models"`
- [x] `bun test src/services/api/openaiShim.test.ts --test-name-pattern "keeps semantic continuation after dropping unsigned Gemini tool history"`
- [x] `bun test src/utils/messages.test.ts` (Ensures no leak to Anthropic)
- [x] `bun test src/services/api/openaiShim.test.ts`
- [x] `bun run build`

## Checklist
- [x] Reviewed `CONTRIBUTING.md`
- [x] `git diff HEAD` checked for API keys, tokens, credentials, `.env`, `auth.json`, and personal paths
- [x] Commit authored with GitHub noreply email `210788251+gitdevine@users.noreply.github.com`
- [x] `.gitignore` covers `node_modules/`, `.env`, `auth.json`, and `dist/`

🤖 Generated with [OpenClaude](https://github.com/Gitlawb/openclaude)