### PR TITLE
fix(grpc): register built-in agents so Agent tool isn't always empty

### DIFF
--- a/src/grpc/server.ts
+++ b/src/grpc/server.ts
@@ -7,6 +7,7 @@ import { getTools } from '../tools.js'
 import { getDefaultAppState } from '../state/AppStateStore.js'
 import { AppState } from '../state/AppState.js'
 import { FileStateCache, READ_FILE_STATE_CACHE_SIZE } from '../utils/fileStateCache.js'
+import { getBuiltInAgents } from '../tools/AgentTool/builtInAgents.js'
 
 const PROTO_PATH = path.resolve(import.meta.dirname, '../proto/openclaude.proto')
 
@@ -90,7 +91,11 @@ export class GrpcServer {
             tools: getTools(appState.toolPermissionContext), // Gets all available tools
             commands: [], // Slash commands
             mcpClients: [],
-            agents: [],
+            // Register OpenClaude's built-in agents (general-purpose,
+            // statusline-setup, optional code-guide). Without this the Agent
+            // tool throws "Agent type 'general-purpose' not found" the moment
+            // the model tries to spawn a subagent for investigation.
+            agents: getBuiltInAgents(),
             ...(previousMessages.length > 0 ? { initialMessages: previousMessages } : {}),
             includePartialMessages: true,
             canUseTool: async (tool, input, context, assistantMsg, toolUseID) => {


### PR DESCRIPTION
The gRPC entrypoint constructed QueryEngine with `agents: []`, so the moment the model tried to spawn a subagent (e.g. `general-purpose` for project investigation) the Agent tool threw "Agent type 'general-purpose' not found. Available agents: " with nothing after the colon. The CLI entrypoint hydrates these via getBuiltInAgents(); do the same here so gRPC-hosted sessions (playground sandbox, etc.) get parity.