### PR TITLE
fix: harden XAA OAuth callback state handling

### DIFF
--- a/src/services/mcp/xaaIdpCallback.ts
+++ b/src/services/mcp/xaaIdpCallback.ts
@@ -1,0 +1,52 @@
+type XaaIdpCallbackParamValue = string | string[] | undefined
+
+export type XaaIdpCallbackValidationResult =
+  | { type: 'code'; code: string }
+  | { type: 'error'; error: string; errorDescription: string }
+  | { type: 'missing_code' }
+  | { type: 'state_mismatch' }
+
+function getFirstXaaIdpCallbackParam(
+  value: XaaIdpCallbackParamValue,
+): string | undefined {
+  if (Array.isArray(value)) {
+    return value.find(item => item.length > 0)
+  }
+  return value && value.length > 0 ? value : undefined
+}
+
+export function validateXaaIdpCallbackParams(
+  params: {
+    code?: XaaIdpCallbackParamValue
+    state?: XaaIdpCallbackParamValue
+    error?: XaaIdpCallbackParamValue
+    error_description?: XaaIdpCallbackParamValue
+  },
+  expectedState: string,
+): XaaIdpCallbackValidationResult {
+  const code = getFirstXaaIdpCallbackParam(params.code)
+  const state = getFirstXaaIdpCallbackParam(params.state)
+  const error = getFirstXaaIdpCallbackParam(params.error)
+  const errorDescription =
+    getFirstXaaIdpCallbackParam(params.error_description) ?? ''
+
+  if (state !== expectedState) {
+    return { type: 'state_mismatch' }
+  }
+
+  if (error) {
+    return { type: 'error', error, errorDescription }
+  }
+
+  if (!code) {
+    return { type: 'missing_code' }
+  }
+
+  return { type: 'code', code }
+}
+
+export function shouldCompleteXaaIdpCallback(
+  result: XaaIdpCallbackValidationResult,
+): boolean {
+  return result.type !== 'state_mismatch'
+}

--- a/src/services/mcp/xaaIdpLogin.test.ts
+++ b/src/services/mcp/xaaIdpLogin.test.ts
@@ -1,0 +1,62 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import {
+  shouldCompleteXaaIdpCallback,
+  validateXaaIdpCallbackParams,
+} from './xaaIdpCallback.js'
+
+test('XAA IdP callback rejects error parameters before state validation can be bypassed', () => {
+  const result = validateXaaIdpCallbackParams(
+    {
+      error: 'access_denied',
+      error_description: 'denied by provider',
+    },
+    'expected-state',
+  )
+
+  assert.deepEqual(result, { type: 'state_mismatch' })
+  assert.equal(shouldCompleteXaaIdpCallback(result), false)
+})
+
+test('XAA IdP callback accepts provider errors only when state matches', () => {
+  const result = validateXaaIdpCallbackParams(
+    {
+      state: 'expected-state',
+      error: 'access_denied',
+      error_description: 'denied by provider',
+    },
+    'expected-state',
+  )
+
+  assert.deepEqual(result, {
+    type: 'error',
+    error: 'access_denied',
+    errorDescription: 'denied by provider',
+  })
+  assert.equal(shouldCompleteXaaIdpCallback(result), true)
+})
+
+test('XAA IdP callback accepts authorization codes only when state matches', () => {
+  assert.deepEqual(
+    validateXaaIdpCallbackParams(
+      {
+        state: 'expected-state',
+        code: 'auth-code',
+      },
+      'expected-state',
+    ),
+    { type: 'code', code: 'auth-code' },
+  )
+
+  assert.deepEqual(
+    validateXaaIdpCallbackParams(
+      {
+        state: 'wrong-state',
+        code: 'auth-code',
+      },
+      'expected-state',
+    ),
+    { type: 'state_mismatch' },
+  )
+})

--- a/src/services/mcp/xaaIdpLogin.ts
+++ b/src/services/mcp/xaaIdpLogin.ts
@@ -28,6 +28,10 @@ import { getPlatform } from '../../utils/platform.js'
 import { getSecureStorage } from '../../utils/secureStorage/index.js'
 import { getInitialSettings } from '../../utils/settings/settings.js'
 import { jsonParse } from '../../utils/slowOperations.js'
+import {
+  shouldCompleteXaaIdpCallback,
+  validateXaaIdpCallbackParams,
+} from './xaaIdpCallback.js'
 import { buildRedirectUri, findAvailablePort } from './oauthPort.js'
 
 export function isXaaEnabled(): boolean {
@@ -332,30 +336,42 @@ function waitForCallback(
         res.end()
         return
       }
-      const code = parsed.query.code as string | undefined
-      const state = parsed.query.state as string | undefined
-      const err = parsed.query.error as string | undefined
+      const result = validateXaaIdpCallbackParams(
+        {
+          code: parsed.query.code,
+          state: parsed.query.state,
+          error: parsed.query.error,
+          error_description: parsed.query.error_description,
+        },
+        expectedState,
+      )
 
-      if (err) {
-        const desc = parsed.query.error_description as string | undefined
-        const safeErr = xss(err)
-        const safeDesc = desc ? xss(desc) : ''
+      if (!shouldCompleteXaaIdpCallback(result)) {
+        res.writeHead(400, { 'Content-Type': 'text/html' })
+        res.end('<html><body><h3>State mismatch</h3></body></html>')
+        return
+      }
+
+      if (result.type === 'error') {
+        const safeErr = xss(result.error)
+        const safeDesc = result.errorDescription
+          ? xss(result.errorDescription)
+          : ''
         res.writeHead(400, { 'Content-Type': 'text/html' })
         res.end(
           `<html><body><h3>IdP login failed</h3><p>${safeErr}</p><p>${safeDesc}</p></body></html>`,
         )
-        rejectOnce(new Error(`XAA IdP: ${err}${desc ? ` — ${desc}` : ''}`))
+        rejectOnce(
+          new Error(
+            `XAA IdP: ${result.error}${
+              result.errorDescription ? ` — ${result.errorDescription}` : ''
+            }`,
+          ),
+        )
         return
       }
 
-      if (state !== expectedState) {
-        res.writeHead(400, { 'Content-Type': 'text/html' })
-        res.end('<html><body><h3>State mismatch</h3></body></html>')
-        rejectOnce(new Error('XAA IdP: state mismatch (possible CSRF)'))
-        return
-      }
-
-      if (!code) {
+      if (result.type === 'missing_code') {
         res.writeHead(400, { 'Content-Type': 'text/html' })
         res.end('<html><body><h3>Missing code</h3></body></html>')
         rejectOnce(new Error('XAA IdP: callback missing code'))
@@ -366,7 +382,7 @@ function waitForCallback(
       res.end(
         '<html><body><h3>IdP login complete — you can close this window.</h3></body></html>',
       )
-      resolveOnce(code)
+      resolveOnce(result.code)
     })
 
     server.on('error', (err: NodeJS.ErrnoException) => {


### PR DESCRIPTION
## Summary

Fixes the XAA IdP OAuth callback path so callback `state` is validated before any provider error or authorization-code handling.

This closes the same class of issue described in GHSA-c73c-x77g-854r for the XAA IdP callback server: a forged `/callback?error=...` request without the expected `state` should not be able to terminate an active local OAuth login.

## Why

The main MCP OAuth callback already validates `state` before processing `error` parameters. The XAA IdP callback path still checked `error` first, which meant an unauthenticated cross-origin request with an `error` query parameter could reject the active login promise and close the temporary callback server without knowing the OAuth `state`.

For security-sensitive OAuth callback handling, invalid or missing state should be treated as a rejected request, not as completion of the active flow.

## What Changed

- Added a small XAA callback validation helper that normalizes query parameters and enforces `state` validation before `error` or `code` handling.
- Updated the XAA local callback server to return a 400 response for invalid state without resolving, rejecting, or cleaning up the active login flow.
- Preserved the existing terminal behavior for provider errors that include the expected state.
- Added focused regression coverage for:
  - `error` callbacks without state
  - provider errors with matching state
  - authorization codes with matching state
  - authorization codes with mismatched state

## Impact

Users running the XAA IdP MCP login flow are protected from forged callback requests that attempt to cancel the active login by sending only an `error` parameter. Legitimate IdP error callbacks still surface to the user when they include the expected state, and successful authorization-code callbacks continue to complete normally.

Provider path affected: XAA IdP MCP OAuth login only.

## Validation

Ran:

```bash
bun test src/services/mcp/auth.test.ts src/services/mcp/xaaIdpLogin.test.ts
bun run build
git diff --check
```

Results:

- Targeted MCP OAuth callback tests passed: 6 pass, 0 fail.
- Build passed for CLI and SDK bundles.
- Diff whitespace check passed.

Note: `bun run typecheck` was also attempted and still reports broad pre-existing repository type errors unrelated to this patch.

