### PR TITLE
fix(security): add dependabot config to suppress inherited Ruby alerts

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+updates:
+  # Node.js dependencies
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+
+  # Suppress inherited Ruby/bundler alerts (project does not use Ruby)
+  - package-ecosystem: "bundler"
+    directory: "/"
+    ignore:
+      - dependency-name: "*"


### PR DESCRIPTION
Project does not use Ruby/bundler. Nokogiri CVE alerts are inherited from upstream. Ignore all bundler deps and configure npm updates.

## Summary

- what changed
- why it changed

## Impact

- user-facing impact:
- developer/maintainer impact:

## Testing

- [ ] `bun run build`
- [ ] `bun run smoke`
- [ ] focused tests:

## Notes

- provider/model path tested:
- screenshots attached (if UI changed):
- follow-up work or known limitations:
