### PR TITLE
fix: add MACRO polyfill to allow direct CLI execution via Bun

### DIFF
--- a/src/entrypoints/cli.tsx
+++ b/src/entrypoints/cli.tsx
@@ -8,6 +8,16 @@ import {
   validateProviderEnvForStartupOrExit,
 } from '../utils/providerValidation.js'
 
+// OpenClaude: polyfill MACRO for local development.
+// @ts-ignore
+globalThis.MACRO ??= {
+  VERSION: '0.13.0-dev',
+  DISPLAY_VERSION: '0.13.0-dev',
+  BUILD_TIME: new Date().toISOString(),
+  ISSUES_EXPLAINER: 'report bugs on GitHub',
+  PACKAGE_URL: '@gitlawb/openclaude',
+}
+
 // OpenClaude: polyfill globalThis.File for Node < 20.
 // undici v7 references `File` at module evaluation time (webidl type
 // assertions). Node 18 lacks the global, causing a ReferenceError inside


### PR DESCRIPTION
**Problem**
When executing the CLI entrypoint directly using Bun (bun run src/entrypoints/cli.tsx) during local development, it throws a ReferenceError: MACRO is not defined.

The MACRO object contains compilation-time constants that are normally injected by the build tool/bundler during a production build. Because direct execution with Bun skips this injection phase, the missing global object crashes the script at startup.

**Solution**
Added a development fallback/polyfill for globalThis.MACRO directly inside src/entrypoints/cli.tsx.

If MACRO is not already defined by a bundler, it safely initializes with default development metadata (VERSION, BUILD_TIME, etc.). This allows developers to run and test the CLI script directly using Bun without breaking production build flows.