### PR TITLE
fix: preserve extra_content signatures to prevent Gemini 400 errors over proxies

### DIFF
--- a/src/utils/messages.ts
+++ b/src/utils/messages.ts
@@ -1767,7 +1767,7 @@ export function stripCallerFieldFromAssistantMessage(
           id: block.id,
           name: block.name,
           input: block.input,
-          ...(getAPIProvider() === 'gemini' && (block as any).extra_content ? { extra_content: (block as any).extra_content } : {})
+          ...(block.extra_content ? { extra_content: block.extra_content } : {})
         }
       }),
     },
@@ -2229,7 +2229,7 @@ export function normalizeMessagesForAPI(
                       ...restBlock,
                       name: canonicalName,
                       input: normalizedInput,
-                      ...(getAPIProvider() === 'gemini' && extra_content ? { extra_content } : {})
+                      ...(extra_content ? { extra_content } : {})
                     }
                   }
 
@@ -2241,7 +2241,7 @@ export function normalizeMessagesForAPI(
                     id: block.id,
                     name: canonicalName,
                     input: normalizedInput,
-                    ...(getAPIProvider() === 'gemini' && (block as any).extra_content ? { extra_content: (block as any).extra_content } : {})
+                    ...((block as any).extra_content ? { extra_content: (block as any).extra_content } : {})
                   }
                 }
                 return block


### PR DESCRIPTION
### **Problem**
When interacting with Gemini models—particularly through a proxy, custom gateway, or an OpenAI-compatible routing layer—the API returns a 400 Bad Request error:

`{"error":"Function call is missing a thought_signature in functionCall parts."}`

Gemini's reasoning models require a reasoning trail (encrypted inside extra_content.google.thought_signature) to be sent back with subsequent tool/function calls.

Previously, normalizeMessagesForAPI in src/utils/messages.ts was hardcoded to explicitly check if the provider was strictly 'gemini' before forwarding this block. If Gemini was being accessed through an alternate route (e.g., custom configuration on Windows/proxies), the codebase mistakenly identified it as a non-Gemini provider and stripped the extra_content payload entirely, causing the API to reject the request.

### **Solution**
Refactored Message Normalization: Modified src/utils/messages.ts to unconditionally preserve extra_content whenever it exists in the message history, stripping out the restrictive getAPIProvider() === 'gemini' safeguards. If a signature is present, it is now safely forwarded regardless of the nominal provider string.

### Resolves : 
#585 
