### PR TITLE
feat: add 1claw Intents API tools for on-chain transactions

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,10 +1,10 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 1,
   "workspaces": {
     "": {
       "name": "@gitlawb/openclaude",
       "dependencies": {
+        "@1claw/sdk": "^0.27.0",
         "@alcalzone/ansi-tokenize": "0.3.0",
         "@anthropic-ai/bedrock-sdk": "0.29.1",
         "@anthropic-ai/foundry-sdk": "0.2.3",
@@ -86,6 +86,8 @@
     "lodash-es": "4.18.1",
   },
   "packages": {
+    "@1claw/sdk": ["@1claw/sdk@0.27.0", "", {}, "sha512-cw0eS1Gh9ajuPkRU6imVF8YD4u2pFrbejoiphKf/vKAJpd4DwJBmcL+exXS3OwUn4V6ZaicljdbTjrwfBYLvPQ=="],
+
     "@alcalzone/ansi-tokenize": ["@alcalzone/ansi-tokenize@0.3.0", "", { "dependencies": { "ansi-styles": "^6.2.1", "is-fullwidth-code-point": "^5.0.0" } }, "sha512-p+CMKJ93HFmLkjXKlXiVGlMQEuRb6H0MokBSwUsX+S6BRX8eV5naFZpQJFfJHjRZY0Hmnqy1/r6UWl3x+19zYA=="],
 
     "@anthropic-ai/bedrock-sdk": ["@anthropic-ai/bedrock-sdk@0.29.1", "", { "dependencies": { "@anthropic-ai/sdk": ">=0.50.3 <1", "@aws-crypto/sha256-js": "^4.0.0", "@aws-sdk/client-bedrock-runtime": "^3.797.0", "@aws-sdk/credential-providers": "^3.796.0", "@smithy/eventstream-serde-node": "^2.0.10", "@smithy/fetch-http-handler": "^5.0.4", "@smithy/protocol-http": "^3.0.6", "@smithy/signature-v4": "^3.1.1", "@smithy/smithy-client": "^2.1.9", "@smithy/types": "^2.3.4", "@smithy/util-base64": "^2.0.0" } }, "sha512-eV3vqNvMEy9C5nBgZMlKFewgXoBcIuV/PERRQJIlot3Vd5lU8dVUS7YqkkbXLw8p/gkDmam3PPoPNYsEAmqivw=="],

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "prepack": "npm run build"
   },
   "dependencies": {
+    "@1claw/sdk": "^0.27.0",
     "@alcalzone/ansi-tokenize": "0.3.0",
     "@anthropic-ai/bedrock-sdk": "0.29.1",
     "@anthropic-ai/foundry-sdk": "0.2.3",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "build": "bun run scripts/build.ts",
     "integrations:generate": "bun run scripts/generate-integrations-artifacts.ts",
     "integrations:check": "bun run scripts/generate-integrations-artifacts.ts --check",
+    "setup": "bun run setup.ts",
     "dev": "bun run build && node dist/cli.mjs",
     "dev:profile": "bun run scripts/provider-launch.ts",
     "dev:profile:fast": "bun run scripts/provider-launch.ts auto --fast --bare",

--- a/scripts/externals.ts
+++ b/scripts/externals.ts
@@ -129,4 +129,6 @@ export const INTENTIONALLY_BUNDLED: string[] = [
   'vscode-languageserver-protocol',
   // File watching
   'chokidar',
+  // 1claw SDK (bundled — ESM extensionless imports break Node strict resolution)
+  '@1claw/sdk',
 ]

--- a/setup.ts
+++ b/setup.ts
@@ -75,7 +75,7 @@ function buildProviderProfileEnv(
   model: string,
   apiKey: string | undefined,
 ): Record<string, unknown> | null {
-  const keyOrPlaceholder = apiKey ?? 'shroud-managed'
+  const keyOrPlaceholder = apiKey ?? 'vault-managed'
   switch (provider.id) {
     case 'anthropic':
       return {
@@ -100,9 +100,8 @@ function buildProviderProfileEnv(
         profile: 'gemini',
         env: {
           GEMINI_API_KEY: keyOrPlaceholder,
-          CLAUDE_CODE_USE_OPENAI: '1',
-          OPENAI_BASE_URL: 'https://generativelanguage.googleapis.com/v1beta/openai/',
-          OPENAI_MODEL: model,
+          CLAUDE_CODE_USE_GEMINI: '1',
+          GEMINI_MODEL: model,
         },
         createdAt: new Date().toISOString(),
       }
@@ -111,9 +110,8 @@ function buildProviderProfileEnv(
         profile: 'mistral',
         env: {
           MISTRAL_API_KEY: keyOrPlaceholder,
-          CLAUDE_CODE_USE_OPENAI: '1',
-          OPENAI_BASE_URL: 'https://api.mistral.ai/v1/',
-          OPENAI_MODEL: model,
+          CLAUDE_CODE_USE_MISTRAL: '1',
+          MISTRAL_MODEL: model,
         },
         createdAt: new Date().toISOString(),
       }
@@ -190,7 +188,7 @@ function getConfigDir(): string {
 
 function saveConfig(config: OneclawConfig): void {
   const dir = getConfigDir()
-  if (!existsSync(dir)) mkdirSync(dir, { recursive: true })
+  if (!existsSync(dir)) mkdirSync(dir, { recursive: true, mode: 0o700 })
   writeFileSync(join(dir, 'oneclaw.json'), JSON.stringify(config, null, 2), { encoding: 'utf8', mode: 0o600 })
 }
 
@@ -375,16 +373,19 @@ async function main() {
       federation_enabled: enableOidc,
       federation_audiences: enableOidc ? ['https://api.anthropic.com'] : [],
     }
-    await client.agents.update(agentId, updatePayload as any)
+    const updateRes = await client.agents.update(agentId, updatePayload as any)
+    if (updateRes.error) throw new Error(`Agent update: ${updateRes.error.message}`)
     console.log('  Agent configured: Shroud + Intents enabled')
 
-    await client.access.grantAgent(vaultId, agentId, ['read'], { secretPathPattern: DEFAULT_POLICY_PATH_PATTERN })
+    const policyRes = await client.access.grantAgent(vaultId, agentId, ['read'], { secretPathPattern: DEFAULT_POLICY_PATH_PATTERN })
+    if (policyRes.error) throw new Error(`Policy: ${policyRes.error.message}`)
     console.log('  Policy granted: agent can read providers/**')
 
     if (authMode === 'byo-key' && providerApiKey) {
       const secretPath = PROVIDER_TO_SECRET_PATH[provider.envKey]
       if (secretPath) {
-        await client.secrets.set(vaultId, secretPath, providerApiKey, { type: 'api_key' })
+        const secretRes = await client.secrets.set(vaultId, secretPath, providerApiKey, { type: 'api_key' })
+        if (secretRes.error) throw new Error(`Secret: ${secretRes.error.message}`)
         console.log(`  API key stored in vault at ${secretPath}`)
       }
     }
@@ -405,7 +406,7 @@ async function main() {
     saveConfig(config)
     const configPath = join(getConfigDir(), 'oneclaw.json')
 
-    const profileEnv = buildProviderProfileEnv(provider, model, authMode === 'byo-key' ? providerApiKey : undefined)
+    const profileEnv = buildProviderProfileEnv(provider, model, undefined)
     if (profileEnv) {
       const profilePath = join(getConfigDir(), '.openclaude-profile.json')
       writeFileSync(profilePath, JSON.stringify(profileEnv, null, 2), { encoding: 'utf8', mode: 0o600 })

--- a/setup.ts
+++ b/setup.ts
@@ -1,0 +1,443 @@
+#!/usr/bin/env bun
+/**
+ * Standalone 1claw setup script.
+ *
+ * Interactive:
+ *   bun run setup
+ *
+ * Non-interactive (all flags):
+ *   bun run setup --key 1ck_... --provider anthropic --model claude-sonnet-4-6 --auth byo-key --provider-key sk-ant-...
+ *   bun run setup --key 1ck_... --provider openai --model gpt-4o --auth token-billing
+ *   bun run setup --key 1ck_... --provider anthropic --auth oidc-federation
+ *
+ * Partial flags work too — the script prompts only for missing values.
+ *
+ * Flags:
+ *   --key, -k          1claw human API key (1ck_ prefix)
+ *   --provider, -p     LLM provider: anthropic, openai, gemini, mistral, xai
+ *   --model, -m        Model name (defaults to provider's default)
+ *   --auth, -a         Auth mode: byo-key, token-billing, oidc-federation
+ *   --provider-key     Provider API key (required when --auth byo-key)
+ *   --help, -h         Show this help
+ */
+import { createClient } from '@1claw/sdk'
+import { existsSync, writeFileSync, mkdirSync } from 'node:fs'
+import { join } from 'node:path'
+import { homedir } from 'node:os'
+import readline from 'node:readline'
+
+const ONECLAW_BASE_URL = 'https://api.1claw.xyz'
+const DEFAULT_AGENT_SCOPES = ['**']
+const DEFAULT_POLICY_PATH_PATTERN = 'providers/**'
+
+const PROVIDER_TO_SECRET_PATH: Record<string, string> = {
+  ANTHROPIC_API_KEY: 'providers/anthropic/api-key',
+  OPENAI_API_KEY: 'providers/openai/api-key',
+  GEMINI_API_KEY: 'providers/gemini/api-key',
+  GOOGLE_API_KEY: 'providers/google/api-key',
+  MISTRAL_API_KEY: 'providers/mistral/api-key',
+  XAI_API_KEY: 'providers/xai/api-key',
+}
+
+interface OneclawConfig {
+  agentId: string
+  agentApiKey: string
+  vaultId: string
+  baseUrl: string
+  shroudEnabled: boolean
+  intentsEnabled: boolean
+  oidcFederationEnabled: boolean
+  providerSecretPaths: Record<string, string>
+  authMode?: string
+  selectedProvider?: string
+  selectedModel?: string
+}
+
+interface ProviderDef {
+  id: string
+  label: string
+  envKey: string
+  defaultModel: string
+  models: string[]
+  supportsOidc: boolean
+}
+
+const PROVIDERS: ProviderDef[] = [
+  { id: 'anthropic', label: 'Anthropic (Claude)', envKey: 'ANTHROPIC_API_KEY', defaultModel: 'claude-sonnet-4-6', models: ['claude-sonnet-4-6', 'claude-opus-4-6', 'claude-haiku-3-5'], supportsOidc: true },
+  { id: 'openai', label: 'OpenAI (GPT)', envKey: 'OPENAI_API_KEY', defaultModel: 'gpt-4o', models: ['gpt-4o', 'gpt-4o-mini', 'o3'], supportsOidc: false },
+  { id: 'gemini', label: 'Google (Gemini)', envKey: 'GEMINI_API_KEY', defaultModel: 'gemini-2.5-pro', models: ['gemini-2.5-pro', 'gemini-2.5-flash'], supportsOidc: false },
+  { id: 'mistral', label: 'Mistral', envKey: 'MISTRAL_API_KEY', defaultModel: 'mistral-large-latest', models: ['mistral-large-latest', 'mistral-medium-latest'], supportsOidc: false },
+  { id: 'xai', label: 'xAI (Grok)', envKey: 'XAI_API_KEY', defaultModel: 'grok-3', models: ['grok-3', 'grok-3-mini'], supportsOidc: false },
+]
+
+function buildProviderProfileEnv(
+  provider: ProviderDef,
+  model: string,
+  apiKey: string | undefined,
+): Record<string, unknown> | null {
+  const keyOrPlaceholder = apiKey ?? 'shroud-managed'
+  switch (provider.id) {
+    case 'anthropic':
+      return {
+        profile: 'anthropic',
+        env: apiKey
+          ? { ANTHROPIC_API_KEY: apiKey, ANTHROPIC_MODEL: model }
+          : { ANTHROPIC_MODEL: model },
+        createdAt: new Date().toISOString(),
+      }
+    case 'openai':
+      return {
+        profile: 'openai',
+        env: {
+          OPENAI_API_KEY: keyOrPlaceholder,
+          CLAUDE_CODE_USE_OPENAI: '1',
+          OPENAI_MODEL: model,
+        },
+        createdAt: new Date().toISOString(),
+      }
+    case 'gemini':
+      return {
+        profile: 'gemini',
+        env: {
+          GEMINI_API_KEY: keyOrPlaceholder,
+          CLAUDE_CODE_USE_OPENAI: '1',
+          OPENAI_BASE_URL: 'https://generativelanguage.googleapis.com/v1beta/openai/',
+          OPENAI_MODEL: model,
+        },
+        createdAt: new Date().toISOString(),
+      }
+    case 'mistral':
+      return {
+        profile: 'mistral',
+        env: {
+          MISTRAL_API_KEY: keyOrPlaceholder,
+          CLAUDE_CODE_USE_OPENAI: '1',
+          OPENAI_BASE_URL: 'https://api.mistral.ai/v1/',
+          OPENAI_MODEL: model,
+        },
+        createdAt: new Date().toISOString(),
+      }
+    case 'xai':
+      return {
+        profile: 'xai',
+        env: {
+          XAI_API_KEY: keyOrPlaceholder,
+          CLAUDE_CODE_USE_OPENAI: '1',
+          OPENAI_BASE_URL: 'https://api.x.ai/v1/',
+          OPENAI_MODEL: model,
+        },
+        createdAt: new Date().toISOString(),
+      }
+    default:
+      return null
+  }
+}
+
+// --- Arg parsing ---
+
+function parseArgs(argv: string[]): Record<string, string | true> {
+  const args: Record<string, string | true> = {}
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i]!
+    if (arg === '--help' || arg === '-h') { args.help = true; continue }
+
+    const aliases: Record<string, string> = {
+      '-k': '--key', '-p': '--provider', '-m': '--model', '-a': '--auth',
+    }
+    const name = aliases[arg] ?? arg
+    if (name.startsWith('--')) {
+      const key = name.slice(2)
+      const next = argv[i + 1]
+      if (next && !next.startsWith('-')) {
+        args[key] = next
+        i++
+      } else {
+        args[key] = true
+      }
+    }
+  }
+  return args
+}
+
+function printHelp() {
+  console.log(`
+Usage: bun run setup [options]
+
+Options:
+  --key, -k <key>            1claw human API key (1ck_ prefix)
+  --provider, -p <provider>  LLM provider: ${PROVIDERS.map(p => p.id).join(', ')}
+  --model, -m <model>        Model name (defaults to provider's default)
+  --auth, -a <mode>          Auth mode: byo-key, token-billing, oidc-federation
+  --provider-key <key>       Provider API key (required for --auth byo-key)
+  --help, -h                 Show this help
+
+Examples:
+  bun run setup
+  bun run setup --key 1ck_abc... --provider anthropic --auth oidc-federation
+  bun run setup -k 1ck_abc... -p openai -m gpt-4o -a byo-key --provider-key sk-...
+  bun run setup --key 1ck_abc... --provider anthropic --auth token-billing
+`)
+}
+
+// --- Utils ---
+
+function getConfigDir(): string {
+  const openclaudeDir = join(homedir(), '.openclaude')
+  const legacyDir = join(homedir(), '.claude')
+  if (!existsSync(openclaudeDir) && existsSync(legacyDir)) return legacyDir
+  return openclaudeDir
+}
+
+function saveConfig(config: OneclawConfig): void {
+  const dir = getConfigDir()
+  if (!existsSync(dir)) mkdirSync(dir, { recursive: true })
+  writeFileSync(join(dir, 'oneclaw.json'), JSON.stringify(config, null, 2), { encoding: 'utf8', mode: 0o600 })
+}
+
+let rl: readline.Interface | null = null
+
+function getReadline(): readline.Interface {
+  if (!rl) rl = readline.createInterface({ input: process.stdin, output: process.stdout })
+  return rl
+}
+
+function ask(question: string): Promise<string> {
+  return new Promise(resolve => getReadline().question(question, resolve))
+}
+
+function choose(prompt: string, options: { label: string; value: string }[]): Promise<string> {
+  return new Promise(resolve => {
+    console.log(`\n${prompt}\n`)
+    options.forEach((opt, i) => console.log(`  ${i + 1}) ${opt.label}`))
+    console.log()
+    const handler = async () => {
+      const answer = await ask('Choose (number): ')
+      const idx = parseInt(answer.trim(), 10) - 1
+      if (idx >= 0 && idx < options.length) {
+        resolve(options[idx]!.value)
+      } else {
+        console.log('Invalid choice, try again.')
+        await handler()
+      }
+    }
+    void handler()
+  })
+}
+
+// --- Main ---
+
+async function main() {
+  const flags = parseArgs(process.argv.slice(2))
+
+  if (flags.help) {
+    printHelp()
+    process.exit(0)
+  }
+
+  const isNonInteractive = Boolean(
+    typeof flags.key === 'string' &&
+    typeof flags.provider === 'string' &&
+    typeof flags.auth === 'string'
+  )
+
+  console.log('\n╔══════════════════════════════════════════════╗')
+  console.log('║       1claw Setup — OpenClaude Integration   ║')
+  console.log('╚══════════════════════════════════════════════╝\n')
+
+  if (!isNonInteractive) {
+    console.log('This will provision a 1claw agent, vault, and policies,')
+    console.log('then configure OpenClaude with your chosen LLM provider.\n')
+  }
+
+  // Step 1: 1claw API Key
+  let trimmedKey: string
+  if (typeof flags.key === 'string') {
+    trimmedKey = flags.key.trim()
+  } else {
+    trimmedKey = (await ask('Enter your 1claw API key (1ck_...): ')).trim()
+  }
+  if (!trimmedKey) {
+    console.error('No API key provided. Exiting.')
+    process.exit(1)
+  }
+
+  console.log(isNonInteractive ? 'Validating API key...' : '\nValidating API key...')
+  const client = createClient({ baseUrl: ONECLAW_BASE_URL, apiKey: trimmedKey })
+  try {
+    const authRes = await client.auth.apiKeyToken({ api_key: trimmedKey })
+    if (authRes.error) {
+      console.error(`Authentication failed: ${authRes.error.message}`)
+      process.exit(1)
+    }
+    console.log('Authenticated successfully.')
+  } catch (err: any) {
+    console.error(`Authentication failed: ${err?.message ?? err}`)
+    process.exit(1)
+  }
+
+  // Step 2: Choose Provider
+  let provider: ProviderDef
+  if (typeof flags.provider === 'string') {
+    const found = PROVIDERS.find(p => p.id === flags.provider)
+    if (!found) {
+      console.error(`Unknown provider: ${flags.provider}. Valid: ${PROVIDERS.map(p => p.id).join(', ')}`)
+      process.exit(1)
+    }
+    provider = found
+    console.log(`Provider: ${provider.label}`)
+  } else {
+    const providerId = await choose('Choose your LLM provider:', PROVIDERS.map(p => ({ label: p.label, value: p.id })))
+    provider = PROVIDERS.find(p => p.id === providerId)!
+  }
+
+  // Step 3: Choose Model
+  let model: string
+  if (typeof flags.model === 'string') {
+    model = flags.model
+    console.log(`Model: ${model}`)
+  } else if (isNonInteractive) {
+    model = provider.defaultModel
+    console.log(`Model: ${model} (default)`)
+  } else {
+    model = await choose(`Choose a ${provider.label} model:`, provider.models.map(m => ({ label: m, value: m })))
+  }
+
+  // Step 4: Auth Mode
+  let authMode: string
+  if (typeof flags.auth === 'string') {
+    const validModes = ['byo-key', 'token-billing', 'oidc-federation']
+    if (!validModes.includes(flags.auth)) {
+      console.error(`Unknown auth mode: ${flags.auth}. Valid: ${validModes.join(', ')}`)
+      process.exit(1)
+    }
+    if (flags.auth === 'oidc-federation' && !provider.supportsOidc) {
+      console.error(`OIDC federation is only supported for Anthropic.`)
+      process.exit(1)
+    }
+    authMode = flags.auth
+    console.log(`Auth: ${authMode}`)
+  } else {
+    const authOptions = [
+      { label: 'Use my own API key (stored in 1claw Vault)', value: 'byo-key' },
+      { label: '1Claw LLM Token Billing (no key needed)', value: 'token-billing' },
+    ]
+    if (provider.supportsOidc) {
+      authOptions.push({ label: 'OIDC Federation — keyless Anthropic access', value: 'oidc-federation' })
+    }
+    authMode = await choose('How should OpenClaude authenticate?', authOptions)
+  }
+
+  // Provider API key (BYO)
+  let providerApiKey: string | undefined
+  if (authMode === 'byo-key') {
+    if (typeof flags['provider-key'] === 'string') {
+      providerApiKey = flags['provider-key'].trim()
+    } else {
+      providerApiKey = (await ask(`\nEnter your ${provider.label} API key: `)).trim()
+    }
+    if (!providerApiKey) {
+      console.error('No provider API key provided. Exiting.')
+      process.exit(1)
+    }
+  }
+
+  // Step 5: Bootstrap
+  console.log('\nProvisioning resources...')
+  try {
+    const vaultRes = await client.vault.create({
+      name: 'openclaude-providers',
+      description: 'LLM provider API keys managed by OpenClaude',
+    })
+    if (vaultRes.error) throw new Error(`Vault: ${vaultRes.error.message}`)
+    const vaultId = vaultRes.data!.id
+    console.log(`  Vault created: ${vaultId}`)
+
+    const agentRes = await client.agents.create({
+      name: 'openclaude-agent',
+      scopes: DEFAULT_AGENT_SCOPES,
+      intents_api_enabled: true,
+    })
+    if (agentRes.error) throw new Error(`Agent: ${agentRes.error.message}`)
+    const agentId = agentRes.data!.agent.id
+    const agentApiKey = agentRes.data!.api_key
+    if (!agentApiKey) throw new Error('Agent created but no API key returned')
+    console.log(`  Agent created: ${agentId}`)
+
+    const enableOidc = authMode === 'oidc-federation'
+    const updatePayload: Record<string, unknown> = {
+      shroud_enabled: true,
+      shroud_config: {
+        pii_policy: 'redact',
+        injection_threshold: 0.7,
+        enable_secret_redaction: true,
+        enable_response_filtering: true,
+      },
+      federation_enabled: enableOidc,
+      federation_audiences: enableOidc ? ['https://api.anthropic.com'] : [],
+    }
+    await client.agents.update(agentId, updatePayload as any)
+    console.log('  Agent configured: Shroud + Intents enabled')
+
+    await client.access.grantAgent(vaultId, agentId, ['read'], { secretPathPattern: DEFAULT_POLICY_PATH_PATTERN })
+    console.log('  Policy granted: agent can read providers/**')
+
+    if (authMode === 'byo-key' && providerApiKey) {
+      const secretPath = PROVIDER_TO_SECRET_PATH[provider.envKey]
+      if (secretPath) {
+        await client.secrets.set(vaultId, secretPath, providerApiKey, { type: 'api_key' })
+        console.log(`  API key stored in vault at ${secretPath}`)
+      }
+    }
+
+    const config: OneclawConfig = {
+      agentId,
+      agentApiKey,
+      vaultId,
+      baseUrl: ONECLAW_BASE_URL,
+      shroudEnabled: true,
+      intentsEnabled: true,
+      oidcFederationEnabled: enableOidc,
+      providerSecretPaths: { ...PROVIDER_TO_SECRET_PATH },
+      authMode,
+      selectedProvider: provider.id,
+      selectedModel: model,
+    }
+    saveConfig(config)
+    const configPath = join(getConfigDir(), 'oneclaw.json')
+
+    const profileEnv = buildProviderProfileEnv(provider, model, authMode === 'byo-key' ? providerApiKey : undefined)
+    if (profileEnv) {
+      const profilePath = join(getConfigDir(), '.openclaude-profile.json')
+      writeFileSync(profilePath, JSON.stringify(profileEnv, null, 2), { encoding: 'utf8', mode: 0o600 })
+      console.log(`  Provider profile saved: ${profilePath}`)
+    }
+
+    console.log('\n═══════════════════════════════════════════')
+    console.log('  Setup complete!')
+    console.log('═══════════════════════════════════════════\n')
+    console.log(`  Provider:  ${provider.label}`)
+    console.log(`  Model:     ${model}`)
+    console.log(`  Auth:      ${authMode === 'byo-key' ? 'BYO Key (Vault)' : authMode === 'token-billing' ? '1Claw Token Billing' : 'OIDC Federation'}`)
+    console.log(`  Config:    ${configPath}`)
+    console.log()
+
+    if (authMode === 'token-billing') {
+      console.log('  NOTE: Enable LLM Token Billing at https://1claw.xyz → Billing')
+    }
+    if (authMode === 'oidc-federation') {
+      console.log('  NOTE: Register 1claw as OIDC IdP in Anthropic Console:')
+      console.log(`  Issuer: https://api.1claw.xyz  |  Sub: agent:${agentId}`)
+      console.log('  Guide: https://1claw.xyz/blog/oidc-federation-anthropic-wif-no-static-keys')
+    }
+
+    console.log('\n  Run OpenClaude to start using your configured provider.')
+    console.log('  Manage your agent and vault at https://1claw.xyz\n')
+  } catch (err: any) {
+    console.error(`\nSetup failed: ${err?.message ?? err}`)
+    process.exit(1)
+  }
+
+  rl?.close()
+}
+
+void main()

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -137,6 +137,7 @@ import plan from './commands/plan/index.js'
 import fast from './commands/fast/index.js'
 import passes from './commands/passes/index.js'
 import privacySettings from './commands/privacy-settings/index.js'
+import oneclaw from './commands/oneclaw/index.js'
 import provider from './commands/provider/index.js'
 import hooks from './commands/hooks/index.js'
 import files from './commands/files/index.js'
@@ -308,6 +309,7 @@ const COMMANDS = memoize((): Command[] => [
   memory,
   mobile,
   model,
+  oneclaw,
   onboardGithub,
   outputStyle,
   remoteEnv,

--- a/src/commands/oneclaw/index.ts
+++ b/src/commands/oneclaw/index.ts
@@ -1,0 +1,12 @@
+import type { Command } from '../../commands.js'
+
+const oneclaw = {
+  type: 'local-jsx',
+  name: '1claw',
+  aliases: ['oneclaw'],
+  description: 'Set up 1claw Vault, Shroud, and Intents integration',
+  argumentHint: '[setup|status|disable]',
+  load: () => import('./oneclaw.js'),
+} satisfies Command
+
+export default oneclaw

--- a/src/commands/oneclaw/oneclaw.tsx
+++ b/src/commands/oneclaw/oneclaw.tsx
@@ -1,0 +1,297 @@
+import * as React from 'react'
+import { useState, useEffect } from 'react'
+import { Box, Text } from '../../ink.js'
+import TextInput from '../../components/TextInput.js'
+import {
+  Select,
+  type OptionWithDescription,
+} from '../../components/CustomSelect/index.js'
+import { Dialog } from '../../components/design-system/Dialog.js'
+import { LoadingState } from '../../components/design-system/LoadingState.js'
+import { useTerminalSize } from '../../hooks/useTerminalSize.js'
+import type { LocalJSXCommandCall } from '../../types/command.js'
+import {
+  loadOneclawConfig,
+  saveOneclawConfig,
+  getOneclawBaseUrl,
+  PROVIDER_TO_SECRET_PATH,
+  type OneclawConfig,
+} from '../../utils/oneclaw.js'
+import {
+  createOneclawHumanClient,
+  resetOneclawClientCache,
+} from '../../utils/oneclawClient.js'
+
+type SetupStep =
+  | 'menu'
+  | 'enter-key'
+  | 'provisioning'
+  | 'done'
+  | 'status'
+  | 'disable'
+  | 'error'
+
+function OneclawSetup({
+  onDone,
+  initialAction,
+}: {
+  onDone: (result?: string) => void
+  initialAction?: string
+}) {
+  const [step, setStep] = useState<SetupStep>(() => {
+    if (initialAction === 'status') return 'status'
+    if (initialAction === 'disable') return 'disable'
+    return 'menu'
+  })
+  const [humanKey, setHumanKey] = useState('')
+  const [error, setError] = useState<string | null>(null)
+  const [result, setResult] = useState<OneclawConfig | null>(null)
+  const [statusInfo, setStatusInfo] = useState<string | null>(null)
+  const [cursorOffset, setCursorOffset] = useState(0)
+  const { columns } = useTerminalSize()
+
+  useEffect(() => {
+    if (step === 'status') {
+      const config = loadOneclawConfig()
+      if (!config) {
+        setStatusInfo('1claw is not configured. Run /1claw to set up.')
+      } else {
+        const lines = [
+          `Agent ID: ${config.agentId}`,
+          `Vault ID: ${config.vaultId}`,
+          `Base URL: ${config.baseUrl}`,
+          `Shroud: ${config.shroudEnabled ? 'enabled' : 'disabled'}`,
+          `Intents API: ${config.intentsEnabled ? 'enabled' : 'disabled'}`,
+          `OIDC Federation: ${config.oidcFederationEnabled ? 'enabled' : 'disabled'}`,
+        ]
+        setStatusInfo(lines.join('\n'))
+      }
+    }
+  }, [step])
+
+  useEffect(() => {
+    if (step === 'disable') {
+      const config = loadOneclawConfig()
+      if (!config) {
+        onDone('1claw is not configured.')
+        return
+      }
+      const emptyConfig: OneclawConfig = {
+        agentId: '',
+        agentApiKey: '',
+        vaultId: '',
+        baseUrl: '',
+        shroudEnabled: false,
+        intentsEnabled: false,
+        oidcFederationEnabled: false,
+        providerSecretPaths: {},
+      }
+      saveOneclawConfig(emptyConfig)
+      resetOneclawClientCache()
+      onDone('1claw integration disabled.')
+    }
+  }, [step, onDone])
+
+  async function runProvisioning(apiKey: string) {
+    setStep('provisioning')
+    try {
+      const baseUrl = getOneclawBaseUrl()
+      const humanClient = createOneclawHumanClient(apiKey)
+
+      const vaultRes = await humanClient.vault.create({
+        name: 'openclaude-providers',
+        description: 'LLM provider API keys managed by OpenClaude',
+      })
+      if (vaultRes.error) {
+        throw new Error(`Failed to create vault: ${vaultRes.error.message}`)
+      }
+      const vaultId = vaultRes.data!.id
+
+      const agentRes = await humanClient.agents.create({
+        name: 'openclaude-agent',
+        scopes: ['secrets/*'],
+        intents_api_enabled: true,
+        shroud_enabled: true,
+        shroud_config: {
+          pii_policy: 'redact',
+          injection_threshold: 0.7,
+          enable_secret_redaction: true,
+          enable_response_filtering: true,
+        },
+      })
+      if (agentRes.error) {
+        throw new Error(`Failed to create agent: ${agentRes.error.message}`)
+      }
+      const agentId = agentRes.data!.agent.id
+      const agentApiKey = agentRes.data!.api_key
+
+      if (!agentApiKey) {
+        throw new Error('Agent created but no API key returned')
+      }
+
+      const policyRes = await humanClient.access.grantAgent(
+        vaultId,
+        agentId,
+        ['read'],
+        { secretPathPattern: 'providers/*' },
+      )
+      if (policyRes.error) {
+        throw new Error(`Failed to create policy: ${policyRes.error.message}`)
+      }
+
+      const config: OneclawConfig = {
+        agentId,
+        agentApiKey,
+        vaultId,
+        baseUrl,
+        shroudEnabled: true,
+        intentsEnabled: true,
+        oidcFederationEnabled: false,
+        providerSecretPaths: { ...PROVIDER_TO_SECRET_PATH },
+      }
+      saveOneclawConfig(config)
+      resetOneclawClientCache()
+
+      setResult(config)
+      setStep('done')
+    } catch (err: any) {
+      setError(err?.message ?? String(err))
+      setStep('error')
+    }
+  }
+
+  if (step === 'status') {
+    return (
+      <Dialog>
+        <Box flexDirection="column" gap={1}>
+          <Text bold>1claw Integration Status</Text>
+          {statusInfo && <Text>{statusInfo}</Text>}
+          <Text dimColor>Press Enter to continue.</Text>
+        </Box>
+      </Dialog>
+    )
+  }
+
+  if (step === 'error') {
+    return (
+      <Dialog>
+        <Box flexDirection="column" gap={1}>
+          <Text bold color="red">Setup failed</Text>
+          <Text>{error}</Text>
+          <Text dimColor>Check your API key and try again with /1claw</Text>
+        </Box>
+      </Dialog>
+    )
+  }
+
+  if (step === 'done' && result) {
+    return (
+      <Dialog>
+        <Box flexDirection="column" gap={1}>
+          <Text bold color="green">1claw setup complete</Text>
+          <Text>Agent ID: {result.agentId}</Text>
+          <Text>Vault ID: {result.vaultId}</Text>
+          <Text dimColor>Agent API key saved to ~/.openclaude/oneclaw.json</Text>
+          <Box flexDirection="column" marginTop={1}>
+            <Text bold>Next steps:</Text>
+            <Text>  1. Store provider keys in vault via 1claw dashboard</Text>
+            <Text>     or run: openclaude with /provider and select 1claw</Text>
+            <Text>  2. Shroud proxy is enabled — LLM traffic will be inspected</Text>
+            <Text>  3. Intents API is enabled for on-chain transactions</Text>
+          </Box>
+        </Box>
+      </Dialog>
+    )
+  }
+
+  if (step === 'provisioning') {
+    return (
+      <Dialog>
+        <LoadingState label="Provisioning 1claw agent, vault, and policies..." />
+      </Dialog>
+    )
+  }
+
+  if (step === 'enter-key') {
+    return (
+      <Dialog>
+        <Box flexDirection="column" gap={1}>
+          <Text bold>Enter your 1claw human API key</Text>
+          <Text dimColor>
+            Get one at https://1claw.xyz → Settings → API Keys (1ck_ prefix)
+          </Text>
+          <Text dimColor>
+            This key is used once to provision resources and is not stored.
+          </Text>
+          <Box>
+            <Text>API Key: </Text>
+            <TextInput
+              value={humanKey}
+              onChange={setHumanKey}
+              onSubmit={async (value: string) => {
+                const trimmed = value.trim()
+                if (!trimmed) return
+                await runProvisioning(trimmed)
+              }}
+              placeholder="1ck_..."
+              columns={columns - 12}
+              cursorOffset={cursorOffset}
+              onChangeCursorOffset={setCursorOffset}
+              focus
+              showCursor
+            />
+          </Box>
+        </Box>
+      </Dialog>
+    )
+  }
+
+  const existingConfig = loadOneclawConfig()
+  const menuOptions: OptionWithDescription[] = existingConfig?.agentId
+    ? [
+        { label: 'Reconfigure', value: 'setup', description: 'Set up a new agent and vault' },
+        { label: 'Status', value: 'status', description: 'Show current 1claw configuration' },
+        { label: 'Disable', value: 'disable', description: 'Disable 1claw integration' },
+        { label: 'Cancel', value: 'cancel', description: 'Go back' },
+      ]
+    : [
+        { label: 'Set up 1claw', value: 'setup', description: 'Provision agent, vault, and policies' },
+        { label: 'Cancel', value: 'cancel', description: 'Go back' },
+      ]
+
+  return (
+    <Dialog>
+      <Box flexDirection="column" gap={1}>
+        <Text bold>1claw — HSM-backed secrets, Shroud proxy, Intents API</Text>
+        <Text dimColor>
+          Securely store provider API keys, proxy LLM traffic through Shroud,
+          and sign on-chain transactions — all without plaintext keys on disk.
+        </Text>
+        <Select
+          options={menuOptions}
+          onChange={(value: string) => {
+            switch (value) {
+              case 'setup':
+                setStep('enter-key')
+                break
+              case 'status':
+                setStep('status')
+                break
+              case 'disable':
+                setStep('disable')
+                break
+              case 'cancel':
+                onDone()
+                break
+            }
+          }}
+        />
+      </Box>
+    </Dialog>
+  )
+}
+
+export const call: LocalJSXCommandCall = async (onDone, _context, args) => {
+  const trimmed = args.trim().toLowerCase()
+  return <OneclawSetup onDone={onDone} initialAction={trimmed || undefined} />
+}

--- a/src/commands/oneclaw/oneclaw.tsx
+++ b/src/commands/oneclaw/oneclaw.tsx
@@ -13,6 +13,7 @@ import type { LocalJSXCommandCall } from '../../types/command.js'
 import {
   loadOneclawConfig,
   saveOneclawConfig,
+  deleteOneclawConfig,
   getOneclawBaseUrl,
   PROVIDER_TO_SECRET_PATH,
   DEFAULT_AGENT_SCOPES,
@@ -133,26 +134,18 @@ type SetupStep =
 function buildProfileForProvider(
   provider: ProviderOption,
   model: string,
-  apiKey: string | undefined,
+  _apiKey: string | undefined,
 ): { profile: ProviderProfile; env: ProfileEnv } | null {
   switch (provider.id) {
     case 'anthropic':
-      return apiKey
-        ? {
-            profile: 'anthropic' as ProviderProfile,
-            env: {
-              ANTHROPIC_API_KEY: apiKey,
-              ANTHROPIC_MODEL: model,
-            },
-          }
-        : {
-            profile: 'anthropic' as ProviderProfile,
-            env: { ANTHROPIC_MODEL: model },
-          }
+      return {
+        profile: 'anthropic' as ProviderProfile,
+        env: { ANTHROPIC_MODEL: model },
+      }
     case 'openai': {
       const env = buildOpenAIProfileEnv({
         goal: normalizeRecommendationGoal('balanced'),
-        apiKey: apiKey ?? 'shroud-managed',
+        apiKey: 'vault-managed',
         model,
         processEnv: {},
       })
@@ -160,7 +153,7 @@ function buildProfileForProvider(
     }
     case 'gemini': {
       const env = buildGeminiProfileEnv({
-        apiKey: apiKey ?? 'shroud-managed',
+        apiKey: 'vault-managed',
         model,
         authMode: 'api-key',
         processEnv: {},
@@ -169,7 +162,7 @@ function buildProfileForProvider(
     }
     case 'mistral': {
       const env = buildMistralProfileEnv({
-        apiKey: apiKey ?? 'shroud-managed',
+        apiKey: 'vault-managed',
         model,
         processEnv: {},
       })
@@ -178,7 +171,7 @@ function buildProfileForProvider(
     case 'xai': {
       const env = buildOpenAIProfileEnv({
         goal: normalizeRecommendationGoal('balanced'),
-        apiKey: apiKey ?? 'shroud-managed',
+        apiKey: 'vault-managed',
         model,
         baseUrl: 'https://api.x.ai/v1',
         processEnv: {},
@@ -233,22 +226,11 @@ function OneclawSetup({
 
   useEffect(() => {
     if (step.name === 'disable') {
-      const config = loadOneclawConfig()
-      if (!config) {
+      if (!loadOneclawConfig()) {
         onDone('1claw is not configured.')
         return
       }
-      const emptyConfig: OneclawConfig = {
-        agentId: '',
-        agentApiKey: '',
-        vaultId: '',
-        baseUrl: '',
-        shroudEnabled: false,
-        intentsEnabled: false,
-        oidcFederationEnabled: false,
-        providerSecretPaths: {},
-      }
-      saveOneclawConfig(emptyConfig)
+      deleteOneclawConfig()
       resetOneclawClientCache()
       onDone('1claw integration disabled.')
     }
@@ -280,7 +262,8 @@ function OneclawSetup({
     try {
       const baseUrl = getOneclawBaseUrl()
       const humanClient = createOneclawHumanClient(apiKey)
-      await humanClient.auth.apiKeyToken({ api_key: apiKey })
+      const authRes = await humanClient.auth.apiKeyToken({ api_key: apiKey })
+      if (authRes.error) throw new Error(`Authentication failed: ${authRes.error.message}`)
 
       const vaultRes = await humanClient.vault.create({
         name: 'openclaude-providers',
@@ -350,13 +333,7 @@ function OneclawSetup({
       saveOneclawConfig(config)
       resetOneclawClientCache()
 
-      if (authMode === 'byo-key' && providerApiKey) {
-        const profileResult = buildProfileForProvider(provider, model, providerApiKey)
-        if (profileResult) {
-          const profileFile = createProfileFile(profileResult.profile, profileResult.env)
-          saveProfileFile(profileFile)
-        }
-      } else if (authMode === 'token-billing' || authMode === 'oidc-federation') {
+      {
         const profileResult = buildProfileForProvider(provider, model, undefined)
         if (profileResult) {
           const profileFile = createProfileFile(profileResult.profile, profileResult.env)
@@ -437,6 +414,7 @@ function OneclawSetup({
               onChangeCursorOffset={setCursorOffset}
               focus
               showCursor
+              mask="*"
             />
           </Box>
         </Box>
@@ -564,7 +542,7 @@ function OneclawSetup({
       <Dialog title="1claw Setup" subtitle={`Enter ${step.provider.label} API Key`} onCancel={() => setStep({ name: 'choose-auth', humanKey: step.humanKey, provider: step.provider, model: step.model })}>
         <Box flexDirection="column" gap={1}>
           <Text>Enter your {step.provider.label} API key.</Text>
-          <Text dimColor>It will be stored in the 1claw Vault (HSM-encrypted, never on disk).</Text>
+          <Text dimColor>It will be stored in the 1claw Vault (HSM-encrypted).</Text>
           <Box>
             <Text>API Key: </Text>
             <TextInput
@@ -581,6 +559,7 @@ function OneclawSetup({
               onChangeCursorOffset={setProviderCursorOffset}
               focus
               showCursor
+              mask="*"
             />
           </Box>
         </Box>

--- a/src/commands/oneclaw/oneclaw.tsx
+++ b/src/commands/oneclaw/oneclaw.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useCallback } from 'react'
 import { Box, Text } from '../../ink.js'
 import TextInput from '../../components/TextInput.js'
 import {
@@ -15,21 +15,180 @@ import {
   saveOneclawConfig,
   getOneclawBaseUrl,
   PROVIDER_TO_SECRET_PATH,
+  DEFAULT_AGENT_SCOPES,
+  DEFAULT_POLICY_PATH_PATTERN,
   type OneclawConfig,
+  type OneclawAuthMode,
 } from '../../utils/oneclaw.js'
 import {
   createOneclawHumanClient,
   resetOneclawClientCache,
 } from '../../utils/oneclawClient.js'
+import {
+  createProfileFile,
+  saveProfileFile,
+  buildOpenAIProfileEnv,
+  buildGeminiProfileEnv,
+  buildMistralProfileEnv,
+  type ProfileEnv,
+  type ProviderProfile,
+} from '../../utils/providerProfile.js'
+import { normalizeRecommendationGoal } from '../../utils/providerRecommendation.js'
+
+type ProviderOption = {
+  id: string
+  label: string
+  description: string
+  envKey: string
+  defaultModel: string
+  models: { value: string; label: string; description: string }[]
+  profileType: ProviderProfile | null
+  supportsOidc: boolean
+}
+
+const PROVIDERS: ProviderOption[] = [
+  {
+    id: 'anthropic',
+    label: 'Anthropic (Claude)',
+    description: 'Claude Sonnet, Opus, Haiku — native provider',
+    envKey: 'ANTHROPIC_API_KEY',
+    defaultModel: 'claude-sonnet-4-6',
+    models: [
+      { value: 'claude-sonnet-4-6', label: 'Claude Sonnet 4.6', description: 'Best balance of speed and capability' },
+      { value: 'claude-opus-4-6', label: 'Claude Opus 4.6', description: 'Most capable, higher latency' },
+      { value: 'claude-haiku-3-5', label: 'Claude Haiku 3.5', description: 'Fastest, most affordable' },
+    ],
+    profileType: null,
+    supportsOidc: true,
+  },
+  {
+    id: 'openai',
+    label: 'OpenAI (GPT)',
+    description: 'GPT-4o, GPT-4o-mini, o3 — via OpenAI API',
+    envKey: 'OPENAI_API_KEY',
+    defaultModel: 'gpt-4o',
+    models: [
+      { value: 'gpt-4o', label: 'GPT-4o', description: 'Best balance of speed and capability' },
+      { value: 'gpt-4o-mini', label: 'GPT-4o Mini', description: 'Fastest, most affordable' },
+      { value: 'o3', label: 'o3', description: 'Advanced reasoning' },
+    ],
+    profileType: 'openai',
+    supportsOidc: false,
+  },
+  {
+    id: 'gemini',
+    label: 'Google (Gemini)',
+    description: 'Gemini 2.5 Pro, Flash — via Google AI API',
+    envKey: 'GEMINI_API_KEY',
+    defaultModel: 'gemini-2.5-pro',
+    models: [
+      { value: 'gemini-2.5-pro', label: 'Gemini 2.5 Pro', description: 'Most capable Gemini model' },
+      { value: 'gemini-2.5-flash', label: 'Gemini 2.5 Flash', description: 'Fast and efficient' },
+    ],
+    profileType: 'gemini',
+    supportsOidc: false,
+  },
+  {
+    id: 'mistral',
+    label: 'Mistral',
+    description: 'Mistral Large, Medium — via Mistral API',
+    envKey: 'MISTRAL_API_KEY',
+    defaultModel: 'mistral-large-latest',
+    models: [
+      { value: 'mistral-large-latest', label: 'Mistral Large', description: 'Most capable Mistral model' },
+      { value: 'mistral-medium-latest', label: 'Mistral Medium', description: 'Balanced performance' },
+    ],
+    profileType: 'mistral',
+    supportsOidc: false,
+  },
+  {
+    id: 'xai',
+    label: 'xAI (Grok)',
+    description: 'Grok models — via xAI API',
+    envKey: 'XAI_API_KEY',
+    defaultModel: 'grok-3',
+    models: [
+      { value: 'grok-3', label: 'Grok 3', description: 'Most capable xAI model' },
+      { value: 'grok-3-mini', label: 'Grok 3 Mini', description: 'Fast and efficient' },
+    ],
+    profileType: 'xai',
+    supportsOidc: false,
+  },
+]
 
 type SetupStep =
-  | 'menu'
-  | 'enter-key'
-  | 'provisioning'
-  | 'done'
-  | 'status'
-  | 'disable'
-  | 'error'
+  | { name: 'menu' }
+  | { name: 'enter-key' }
+  | { name: 'validating-key'; humanKey: string }
+  | { name: 'choose-provider'; humanKey: string }
+  | { name: 'choose-model'; humanKey: string; provider: ProviderOption }
+  | { name: 'choose-auth'; humanKey: string; provider: ProviderOption; model: string }
+  | { name: 'enter-provider-key'; humanKey: string; provider: ProviderOption; model: string }
+  | { name: 'bootstrapping'; humanKey: string; provider: ProviderOption; model: string; authMode: OneclawAuthMode; providerApiKey?: string }
+  | { name: 'done'; config: OneclawConfig; storedKeyCount: number }
+  | { name: 'status' }
+  | { name: 'disable' }
+  | { name: 'error'; message: string }
+
+function buildProfileForProvider(
+  provider: ProviderOption,
+  model: string,
+  apiKey: string | undefined,
+): { profile: ProviderProfile; env: ProfileEnv } | null {
+  switch (provider.id) {
+    case 'anthropic':
+      return apiKey
+        ? {
+            profile: 'anthropic' as ProviderProfile,
+            env: {
+              ANTHROPIC_API_KEY: apiKey,
+              ANTHROPIC_MODEL: model,
+            },
+          }
+        : {
+            profile: 'anthropic' as ProviderProfile,
+            env: { ANTHROPIC_MODEL: model },
+          }
+    case 'openai': {
+      const env = buildOpenAIProfileEnv({
+        goal: normalizeRecommendationGoal('balanced'),
+        apiKey: apiKey ?? 'shroud-managed',
+        model,
+        processEnv: {},
+      })
+      return env ? { profile: 'openai', env } : null
+    }
+    case 'gemini': {
+      const env = buildGeminiProfileEnv({
+        apiKey: apiKey ?? 'shroud-managed',
+        model,
+        authMode: 'api-key',
+        processEnv: {},
+      })
+      return env ? { profile: 'gemini', env } : null
+    }
+    case 'mistral': {
+      const env = buildMistralProfileEnv({
+        apiKey: apiKey ?? 'shroud-managed',
+        model,
+        processEnv: {},
+      })
+      return env ? { profile: 'mistral', env } : null
+    }
+    case 'xai': {
+      const env = buildOpenAIProfileEnv({
+        goal: normalizeRecommendationGoal('balanced'),
+        apiKey: apiKey ?? 'shroud-managed',
+        model,
+        baseUrl: 'https://api.x.ai/v1',
+        processEnv: {},
+      })
+      return env ? { profile: 'xai' as ProviderProfile, env } : null
+    }
+    default:
+      return null
+  }
+}
 
 function OneclawSetup({
   onDone,
@@ -39,19 +198,19 @@ function OneclawSetup({
   initialAction?: string
 }) {
   const [step, setStep] = useState<SetupStep>(() => {
-    if (initialAction === 'status') return 'status'
-    if (initialAction === 'disable') return 'disable'
-    return 'menu'
+    if (initialAction === 'status') return { name: 'status' }
+    if (initialAction === 'disable') return { name: 'disable' }
+    return { name: 'menu' }
   })
   const [humanKey, setHumanKey] = useState('')
-  const [error, setError] = useState<string | null>(null)
-  const [result, setResult] = useState<OneclawConfig | null>(null)
+  const [providerKey, setProviderKey] = useState('')
   const [statusInfo, setStatusInfo] = useState<string | null>(null)
   const [cursorOffset, setCursorOffset] = useState(0)
+  const [providerCursorOffset, setProviderCursorOffset] = useState(0)
   const { columns } = useTerminalSize()
 
   useEffect(() => {
-    if (step === 'status') {
+    if (step.name === 'status') {
       const config = loadOneclawConfig()
       if (!config) {
         setStatusInfo('1claw is not configured. Run /1claw to set up.')
@@ -60,6 +219,9 @@ function OneclawSetup({
           `Agent ID: ${config.agentId}`,
           `Vault ID: ${config.vaultId}`,
           `Base URL: ${config.baseUrl}`,
+          `Provider: ${config.selectedProvider ?? 'not set'}`,
+          `Model: ${config.selectedModel ?? 'not set'}`,
+          `Auth Mode: ${config.authMode ?? 'not set'}`,
           `Shroud: ${config.shroudEnabled ? 'enabled' : 'disabled'}`,
           `Intents API: ${config.intentsEnabled ? 'enabled' : 'disabled'}`,
           `OIDC Federation: ${config.oidcFederationEnabled ? 'enabled' : 'disabled'}`,
@@ -67,10 +229,10 @@ function OneclawSetup({
         setStatusInfo(lines.join('\n'))
       }
     }
-  }, [step])
+  }, [step.name])
 
   useEffect(() => {
-    if (step === 'disable') {
+    if (step.name === 'disable') {
       const config = loadOneclawConfig()
       if (!config) {
         onDone('1claw is not configured.')
@@ -90,27 +252,55 @@ function OneclawSetup({
       resetOneclawClientCache()
       onDone('1claw integration disabled.')
     }
-  }, [step, onDone])
+  }, [step.name, onDone])
 
-  async function runProvisioning(apiKey: string) {
-    setStep('provisioning')
+  const validateHumanKey = useCallback(async (apiKey: string) => {
+    setStep({ name: 'validating-key', humanKey: apiKey })
+    try {
+      const humanClient = createOneclawHumanClient(apiKey)
+      const authRes = await humanClient.auth.apiKeyToken({ api_key: apiKey })
+      if (authRes.error) {
+        setStep({ name: 'error', message: `Authentication failed: ${authRes.error.message}` })
+        return
+      }
+      setStep({ name: 'choose-provider', humanKey: apiKey })
+    } catch (err: any) {
+      setStep({ name: 'error', message: `Authentication failed: ${err?.message ?? String(err)}` })
+    }
+  }, [])
+
+  const runBootstrap = useCallback(async (
+    apiKey: string,
+    provider: ProviderOption,
+    model: string,
+    authMode: OneclawAuthMode,
+    providerApiKey?: string,
+  ) => {
+    setStep({ name: 'bootstrapping', humanKey: apiKey, provider, model, authMode, providerApiKey })
     try {
       const baseUrl = getOneclawBaseUrl()
       const humanClient = createOneclawHumanClient(apiKey)
+      await humanClient.auth.apiKeyToken({ api_key: apiKey })
 
       const vaultRes = await humanClient.vault.create({
         name: 'openclaude-providers',
         description: 'LLM provider API keys managed by OpenClaude',
       })
-      if (vaultRes.error) {
-        throw new Error(`Failed to create vault: ${vaultRes.error.message}`)
-      }
+      if (vaultRes.error) throw new Error(`Failed to create vault: ${vaultRes.error.message}`)
       const vaultId = vaultRes.data!.id
 
       const agentRes = await humanClient.agents.create({
         name: 'openclaude-agent',
-        scopes: ['secrets/*'],
+        scopes: DEFAULT_AGENT_SCOPES,
         intents_api_enabled: true,
+      })
+      if (agentRes.error) throw new Error(`Failed to create agent: ${agentRes.error.message}`)
+      const agentId = agentRes.data!.agent.id
+      const agentApiKeyVal = agentRes.data!.api_key
+      if (!agentApiKeyVal) throw new Error('Agent created but no API key returned')
+
+      const enableOidc = authMode === 'oidc-federation'
+      const updatePayload: Record<string, unknown> = {
         shroud_enabled: true,
         shroud_config: {
           pii_policy: 'redact',
@@ -118,103 +308,111 @@ function OneclawSetup({
           enable_secret_redaction: true,
           enable_response_filtering: true,
         },
-      })
-      if (agentRes.error) {
-        throw new Error(`Failed to create agent: ${agentRes.error.message}`)
+        federation_enabled: enableOidc,
+        federation_audiences: enableOidc ? ['https://api.anthropic.com'] : [],
       }
-      const agentId = agentRes.data!.agent.id
-      const agentApiKey = agentRes.data!.api_key
-
-      if (!agentApiKey) {
-        throw new Error('Agent created but no API key returned')
-      }
+      const updateRes = await humanClient.agents.update(
+        agentId,
+        updatePayload as Parameters<typeof humanClient.agents.update>[1],
+      )
+      if (updateRes.error) throw new Error(`Failed to configure agent: ${updateRes.error.message}`)
 
       const policyRes = await humanClient.access.grantAgent(
         vaultId,
         agentId,
         ['read'],
-        { secretPathPattern: 'providers/*' },
+        { secretPathPattern: DEFAULT_POLICY_PATH_PATTERN },
       )
-      if (policyRes.error) {
-        throw new Error(`Failed to create policy: ${policyRes.error.message}`)
+      if (policyRes.error) throw new Error(`Failed to create policy: ${policyRes.error.message}`)
+
+      let storedKeyCount = 0
+      if (authMode === 'byo-key' && providerApiKey) {
+        const secretPath = PROVIDER_TO_SECRET_PATH[provider.envKey]
+        if (secretPath) {
+          const res = await humanClient.secrets.set(vaultId, secretPath, providerApiKey, { type: 'api_key' })
+          if (!res.error) storedKeyCount++
+        }
       }
 
       const config: OneclawConfig = {
         agentId,
-        agentApiKey,
+        agentApiKey: agentApiKeyVal,
         vaultId,
         baseUrl,
         shroudEnabled: true,
         intentsEnabled: true,
-        oidcFederationEnabled: false,
+        oidcFederationEnabled: enableOidc,
         providerSecretPaths: { ...PROVIDER_TO_SECRET_PATH },
+        authMode,
+        selectedProvider: provider.id,
+        selectedModel: model,
       }
       saveOneclawConfig(config)
       resetOneclawClientCache()
 
-      setResult(config)
-      setStep('done')
+      if (authMode === 'byo-key' && providerApiKey) {
+        const profileResult = buildProfileForProvider(provider, model, providerApiKey)
+        if (profileResult) {
+          const profileFile = createProfileFile(profileResult.profile, profileResult.env)
+          saveProfileFile(profileFile)
+        }
+      } else if (authMode === 'token-billing' || authMode === 'oidc-federation') {
+        const profileResult = buildProfileForProvider(provider, model, undefined)
+        if (profileResult) {
+          const profileFile = createProfileFile(profileResult.profile, profileResult.env)
+          saveProfileFile(profileFile)
+        }
+      }
+
+      setStep({ name: 'done', config, storedKeyCount })
     } catch (err: any) {
-      setError(err?.message ?? String(err))
-      setStep('error')
+      setStep({ name: 'error', message: err?.message ?? String(err) })
     }
-  }
+  }, [])
 
-  if (step === 'status') {
+  if (step.name === 'status') {
     return (
-      <Dialog>
+      <Dialog title="1claw Integration Status" onCancel={() => onDone()}>
         <Box flexDirection="column" gap={1}>
-          <Text bold>1claw Integration Status</Text>
           {statusInfo && <Text>{statusInfo}</Text>}
-          <Text dimColor>Press Enter to continue.</Text>
+          <Text dimColor>Press Esc to close.</Text>
         </Box>
       </Dialog>
     )
   }
 
-  if (step === 'error') {
+  if (step.name === 'error') {
     return (
-      <Dialog>
+      <Dialog title="Setup failed" color="warning" onCancel={() => onDone()}>
         <Box flexDirection="column" gap={1}>
-          <Text bold color="red">Setup failed</Text>
-          <Text>{error}</Text>
-          <Text dimColor>Check your API key and try again with /1claw</Text>
+          <Text>{step.message}</Text>
+          <Select
+            options={[
+              { label: 'Try again', value: 'retry' },
+              { label: 'Cancel', value: 'cancel' },
+            ]}
+            onChange={(value: string) => {
+              if (value === 'retry') setStep({ name: 'enter-key' })
+              else onDone()
+            }}
+            onCancel={() => onDone()}
+          />
         </Box>
       </Dialog>
     )
   }
 
-  if (step === 'done' && result) {
+  if (step.name === 'validating-key') {
     return (
-      <Dialog>
-        <Box flexDirection="column" gap={1}>
-          <Text bold color="green">1claw setup complete</Text>
-          <Text>Agent ID: {result.agentId}</Text>
-          <Text>Vault ID: {result.vaultId}</Text>
-          <Text dimColor>Agent API key saved to ~/.openclaude/oneclaw.json</Text>
-          <Box flexDirection="column" marginTop={1}>
-            <Text bold>Next steps:</Text>
-            <Text>  1. Store provider keys in vault via 1claw dashboard</Text>
-            <Text>     or run: openclaude with /provider and select 1claw</Text>
-            <Text>  2. Shroud proxy is enabled — LLM traffic will be inspected</Text>
-            <Text>  3. Intents API is enabled for on-chain transactions</Text>
-          </Box>
-        </Box>
+      <Dialog title="1claw Setup">
+        <LoadingState message="Validating API key..." />
       </Dialog>
     )
   }
 
-  if (step === 'provisioning') {
+  if (step.name === 'enter-key') {
     return (
-      <Dialog>
-        <LoadingState label="Provisioning 1claw agent, vault, and policies..." />
-      </Dialog>
-    )
-  }
-
-  if (step === 'enter-key') {
-    return (
-      <Dialog>
+      <Dialog title="1claw Setup" subtitle="Step 1 of 4" onCancel={() => setStep({ name: 'menu' })}>
         <Box flexDirection="column" gap={1}>
           <Text bold>Enter your 1claw human API key</Text>
           <Text dimColor>
@@ -231,7 +429,7 @@ function OneclawSetup({
               onSubmit={async (value: string) => {
                 const trimmed = value.trim()
                 if (!trimmed) return
-                await runProvisioning(trimmed)
+                await validateHumanKey(trimmed)
               }}
               placeholder="1ck_..."
               columns={columns - 12}
@@ -246,39 +444,246 @@ function OneclawSetup({
     )
   }
 
+  if (step.name === 'choose-provider') {
+    const providerOptions: OptionWithDescription[] = PROVIDERS.map(p => ({
+      label: p.label,
+      value: p.id,
+      description: p.description,
+    }))
+
+    return (
+      <Dialog title="1claw Setup" subtitle="Step 2 of 4 — Choose Provider" onCancel={() => setStep({ name: 'enter-key' })}>
+        <Box flexDirection="column" gap={1}>
+          <Text>Which LLM provider do you want to use?</Text>
+          <Select
+            options={providerOptions}
+            inlineDescriptions
+            visibleOptionCount={PROVIDERS.length}
+            onChange={(value: string) => {
+              const provider = PROVIDERS.find(p => p.id === value)
+              if (provider) {
+                setStep({ name: 'choose-model', humanKey: step.humanKey, provider })
+              }
+            }}
+            onCancel={() => setStep({ name: 'enter-key' })}
+          />
+        </Box>
+      </Dialog>
+    )
+  }
+
+  if (step.name === 'choose-model') {
+    const modelOptions: OptionWithDescription[] = step.provider.models.map(m => ({
+      label: m.label,
+      value: m.value,
+      description: m.description,
+    }))
+
+    return (
+      <Dialog title="1claw Setup" subtitle="Step 3 of 4 — Choose Model" onCancel={() => setStep({ name: 'choose-provider', humanKey: step.humanKey })}>
+        <Box flexDirection="column" gap={1}>
+          <Text>Which {step.provider.label} model?</Text>
+          <Select
+            options={modelOptions}
+            defaultValue={step.provider.defaultModel}
+            defaultFocusValue={step.provider.defaultModel}
+            inlineDescriptions
+            visibleOptionCount={modelOptions.length}
+            onChange={(value: string) => {
+              setStep({ name: 'choose-auth', humanKey: step.humanKey, provider: step.provider, model: value })
+            }}
+            onCancel={() => setStep({ name: 'choose-provider', humanKey: step.humanKey })}
+          />
+        </Box>
+      </Dialog>
+    )
+  }
+
+  if (step.name === 'choose-auth') {
+    const authOptions: OptionWithDescription[] = [
+      {
+        label: 'Use my own API key',
+        value: 'byo-key',
+        description: `Enter your ${step.provider.label} API key — stored in 1claw Vault (HSM-encrypted)`,
+      },
+      {
+        label: '1Claw LLM Token Billing',
+        value: 'token-billing',
+        description: 'No API key needed — 1claw bills your account via Shroud proxy',
+      },
+    ]
+
+    if (step.provider.supportsOidc) {
+      authOptions.push({
+        label: 'OIDC Federation (keyless)',
+        value: 'oidc-federation',
+        description: '1claw exchanges tokens with Anthropic WIF — no static keys',
+      })
+    }
+
+    return (
+      <Dialog title="1claw Setup" subtitle="Step 4 of 4 — Authentication" onCancel={() => setStep({ name: 'choose-model', humanKey: step.humanKey, provider: step.provider })}>
+        <Box flexDirection="column" gap={1}>
+          <Text>How should OpenClaude authenticate with {step.provider.label}?</Text>
+          <Select
+            options={authOptions}
+            inlineDescriptions
+            visibleOptionCount={authOptions.length}
+            onChange={(value: string) => {
+              const authMode = value as OneclawAuthMode
+              if (authMode === 'byo-key') {
+                setProviderKey('')
+                setProviderCursorOffset(0)
+                setStep({ name: 'enter-provider-key', humanKey: step.humanKey, provider: step.provider, model: step.model })
+              } else {
+                void runBootstrap(step.humanKey, step.provider, step.model, authMode)
+              }
+            }}
+            onCancel={() => setStep({ name: 'choose-model', humanKey: step.humanKey, provider: step.provider })}
+          />
+          {step.provider.supportsOidc && (
+            <Text dimColor>
+              OIDC requires registering 1claw in Anthropic Console.{'\n'}
+              See: https://1claw.xyz/blog/oidc-federation-anthropic-wif-no-static-keys
+            </Text>
+          )}
+          <Text dimColor>
+            Token Billing requires LLM billing enabled at https://1claw.xyz → Billing
+          </Text>
+        </Box>
+      </Dialog>
+    )
+  }
+
+  if (step.name === 'enter-provider-key') {
+    const placeholder = step.provider.id === 'anthropic' ? 'sk-ant-...' :
+      step.provider.id === 'openai' ? 'sk-...' :
+      step.provider.id === 'gemini' ? 'AIza...' : '...'
+
+    return (
+      <Dialog title="1claw Setup" subtitle={`Enter ${step.provider.label} API Key`} onCancel={() => setStep({ name: 'choose-auth', humanKey: step.humanKey, provider: step.provider, model: step.model })}>
+        <Box flexDirection="column" gap={1}>
+          <Text>Enter your {step.provider.label} API key.</Text>
+          <Text dimColor>It will be stored in the 1claw Vault (HSM-encrypted, never on disk).</Text>
+          <Box>
+            <Text>API Key: </Text>
+            <TextInput
+              value={providerKey}
+              onChange={setProviderKey}
+              onSubmit={async (value: string) => {
+                const trimmed = value.trim()
+                if (!trimmed) return
+                await runBootstrap(step.humanKey, step.provider, step.model, 'byo-key', trimmed)
+              }}
+              placeholder={placeholder}
+              columns={columns - 12}
+              cursorOffset={providerCursorOffset}
+              onChangeCursorOffset={setProviderCursorOffset}
+              focus
+              showCursor
+            />
+          </Box>
+        </Box>
+      </Dialog>
+    )
+  }
+
+  if (step.name === 'bootstrapping') {
+    return (
+      <Dialog title="1claw Setup">
+        <LoadingState message="Provisioning agent, vault, and policies..." />
+      </Dialog>
+    )
+  }
+
+  if (step.name === 'done') {
+    const authModeLabel = step.config.authMode === 'byo-key' ? 'BYO Key (Vault)' :
+      step.config.authMode === 'token-billing' ? '1Claw Token Billing' :
+      step.config.authMode === 'oidc-federation' ? 'OIDC Federation' : 'Unknown'
+
+    return (
+      <Dialog title="1claw setup complete" onCancel={() => onDone()}>
+        <Box flexDirection="column" gap={1}>
+          <Text bold color="green">Setup complete</Text>
+          <Box flexDirection="column">
+            <Text>Provider: {step.config.selectedProvider}</Text>
+            <Text>Model: {step.config.selectedModel}</Text>
+            <Text>Auth: {authModeLabel}</Text>
+            <Text>Agent ID: {step.config.agentId}</Text>
+            <Text>Vault ID: {step.config.vaultId}</Text>
+          </Box>
+          {step.storedKeyCount > 0 && (
+            <Text color="green">{step.storedKeyCount} API key(s) stored in vault</Text>
+          )}
+          <Text dimColor>Config saved to ~/.openclaude/oneclaw.json</Text>
+          <Box flexDirection="column" marginTop={1}>
+            <Text bold>What happens now:</Text>
+            {step.config.authMode === 'byo-key' && (
+              <Text>  Your API key is HSM-encrypted in 1claw Vault — loaded at startup</Text>
+            )}
+            {step.config.authMode === 'token-billing' && (
+              <>
+                <Text>  LLM traffic routes through Shroud — billed to your 1claw account</Text>
+                <Text color="yellow">  Make sure LLM Token Billing is enabled at https://1claw.xyz → Billing</Text>
+              </>
+            )}
+            {step.config.authMode === 'oidc-federation' && (
+              <>
+                <Text>  Keyless Anthropic access via 1claw OIDC federation</Text>
+                <Text>  Register 1claw as OIDC IdP in Anthropic Console:</Text>
+                <Text>  Issuer: https://api.1claw.xyz  |  Sub: agent:{step.config.agentId}</Text>
+              </>
+            )}
+            <Text>  Shroud proxy enabled — LLM traffic inspected for secrets & PII</Text>
+            <Text>  Intents API enabled for on-chain transaction signing</Text>
+            <Text>  Manage at https://1claw.xyz</Text>
+          </Box>
+          <Text dimColor>Restart OpenClaude to apply changes. Press Esc to close.</Text>
+        </Box>
+      </Dialog>
+    )
+  }
+
+  // Main menu
   const existingConfig = loadOneclawConfig()
   const menuOptions: OptionWithDescription[] = existingConfig?.agentId
     ? [
-        { label: 'Reconfigure', value: 'setup', description: 'Set up a new agent and vault' },
+        { label: 'Reconfigure', value: 'setup', description: 'Set up a new agent, provider, and vault' },
         { label: 'Status', value: 'status', description: 'Show current 1claw configuration' },
         { label: 'Disable', value: 'disable', description: 'Disable 1claw integration' },
         { label: 'Cancel', value: 'cancel', description: 'Go back' },
       ]
     : [
-        { label: 'Set up 1claw', value: 'setup', description: 'Provision agent, vault, and policies' },
+        { label: 'Set up 1claw', value: 'setup', description: 'Choose provider, model, and auth — bootstrap everything' },
         { label: 'Cancel', value: 'cancel', description: 'Go back' },
       ]
 
   return (
-    <Dialog>
+    <Dialog title="1claw — Secure AI Agent Infrastructure" onCancel={() => onDone()}>
       <Box flexDirection="column" gap={1}>
-        <Text bold>1claw — HSM-backed secrets, Shroud proxy, Intents API</Text>
         <Text dimColor>
-          Securely store provider API keys, proxy LLM traffic through Shroud,
-          and sign on-chain transactions — all without plaintext keys on disk.
+          HSM-backed secrets, Shroud LLM proxy, OIDC federation, Intents API.{'\n'}
+          Choose your LLM provider, model, and how to authenticate — 1claw bootstraps everything.
         </Text>
+        {existingConfig?.selectedProvider && (
+          <Box flexDirection="column">
+            <Text dimColor>Current: {existingConfig.selectedProvider} / {existingConfig.selectedModel ?? 'default'} ({existingConfig.authMode ?? 'byo-key'})</Text>
+          </Box>
+        )}
         <Select
           options={menuOptions}
           onChange={(value: string) => {
             switch (value) {
               case 'setup':
-                setStep('enter-key')
+                setHumanKey('')
+                setCursorOffset(0)
+                setStep({ name: 'enter-key' })
                 break
               case 'status':
-                setStep('status')
+                setStep({ name: 'status' })
                 break
               case 'disable':
-                setStep('disable')
+                setStep({ name: 'disable' })
                 break
               case 'cancel':
                 onDone()

--- a/src/components/StartupScreen.ts
+++ b/src/components/StartupScreen.ts
@@ -16,6 +16,8 @@ import { parseUserSpecifiedModel } from '../utils/model/model.js'
 import { DEFAULT_GEMINI_MODEL } from '../utils/providerProfile.js'
 import { getGlobalConfig } from '../utils/config.js'
 import { ANSI_DIM, ANSI_RESET, ansiRgb } from '../utils/terminalAnsi.js'
+import { isShroudEnabled as isShroudEnabledForDisplay } from '../utils/oneclawShroud.js'
+import { getShroudBaseUrl as getShroudBaseUrlForDisplay, isOneclawConfigured as isOneclawConfiguredForDisplay } from '../utils/oneclaw.js'
 import {
   resolveLogoPalette,
   type RGB,
@@ -159,7 +161,12 @@ export function detectProvider(modelOverride?: string): { name: string; model: s
   const settings = getSettings_DEPRECATED() || {}
   const modelSetting = modelOverride || process.env.ANTHROPIC_MODEL || process.env.CLAUDE_MODEL || settings.model || 'claude-sonnet-4-6'
   const resolvedModel = parseUserSpecifiedModel(modelSetting)
-  const baseUrl = process.env.ANTHROPIC_BASE_URL ?? 'https://api.anthropic.com'
+  let baseUrl = process.env.ANTHROPIC_BASE_URL ?? 'https://api.anthropic.com'
+  try {
+    if (isShroudEnabledForDisplay() && isOneclawConfiguredForDisplay()) {
+      baseUrl = getShroudBaseUrlForDisplay() + '/v1'
+    }
+  } catch { /* ignore */ }
   const isLocal = isLocalProviderUrl(baseUrl)
   return { name: 'Anthropic', model: resolvedModel, baseUrl, isLocal }
 }

--- a/src/entrypoints/cli.tsx
+++ b/src/entrypoints/cli.tsx
@@ -146,13 +146,59 @@ async function main(): Promise<void> {
     hydrateGithubModelsTokenFromSecureStorage()
   }
 
-  // Populate provider API keys from 1claw Vault (fills gaps, does not override existing env)
   {
-    const { populateEnvFromVault } = await import('../utils/oneclawVault.js')
-    const vaultKeys = await populateEnvFromVault()
-    if (vaultKeys > 0) {
-      const { logForDebugging } = await import('../utils/debug.js')
-      logForDebugging(`1claw vault: loaded ${vaultKeys} provider key(s) from vault`)
+    const { isOneclawConfigured } = await import('../utils/oneclaw.js')
+    if (isOneclawConfigured()) {
+      const { populateEnvFromVault } = await import('../utils/oneclawVault.js')
+      const vaultKeys = await populateEnvFromVault()
+      if (vaultKeys > 0) {
+        const { logForDebugging } = await import('../utils/debug.js')
+        logForDebugging(`1claw vault: loaded ${vaultKeys} provider key(s) from vault`)
+      }
+    }
+  }
+
+  // Signal to auth subsystem that Shroud handles authentication for this session.
+  // Set early so isAnthropicAuthEnabled() can check a simple env flag instead of
+  // re-reading config files through bundler-wrapped ESM modules.
+  {
+    const { isOneclawConfigured, getOneclawAuthMode } = await import('../utils/oneclaw.js')
+    const { isShroudEnabled } = await import('../utils/oneclawShroud.js')
+    if (isOneclawConfigured() && isShroudEnabled()) {
+      const authMode = getOneclawAuthMode()
+      if (authMode === 'token-billing' || authMode === 'oidc-federation') {
+        process.env.ONECLAW_AUTH_ACTIVE = '1'
+        process.env.ONECLAW_AUTH_MODE = authMode
+      }
+    }
+  }
+
+  // First-run detection: if no provider is configured and no 1claw config exists,
+  // offer to run the 1claw setup wizard before continuing.
+  if (process.stdout.isTTY && !hasConfiguredProviderProfile) {
+    const { isOneclawConfigured } = await import('../utils/oneclaw.js')
+    const hasAnthropicKey = Boolean(process.env.ANTHROPIC_API_KEY)
+    const hasOpenAIKey = Boolean(process.env.OPENAI_API_KEY)
+    const hasAnyProvider = hasAnthropicKey || hasOpenAIKey ||
+      Boolean(process.env.GEMINI_API_KEY || process.env.GOOGLE_API_KEY) ||
+      Boolean(process.env.MISTRAL_API_KEY)
+
+    if (!hasAnyProvider && !isOneclawConfigured()) {
+      const { createInterface } = await import('node:readline')
+      const rl = createInterface({ input: process.stdin, output: process.stdout })
+      const answer = await new Promise<string>(resolve => {
+        rl.question(
+          '\n  No LLM provider configured. Set up with 1claw? (y/N) ',
+          resolve,
+        )
+      })
+      rl.close()
+
+      if (answer.trim().toLowerCase() === 'y') {
+        // biome-ignore lint/suspicious/noConsole:: intentional
+        console.log('  Run: bun run setup\n')
+        console.log('  Or start OpenClaude and use the /1claw command.\n')
+      }
     }
   }
 

--- a/src/entrypoints/cli.tsx
+++ b/src/entrypoints/cli.tsx
@@ -146,6 +146,16 @@ async function main(): Promise<void> {
     hydrateGithubModelsTokenFromSecureStorage()
   }
 
+  // Populate provider API keys from 1claw Vault (fills gaps, does not override existing env)
+  {
+    const { populateEnvFromVault } = await import('../utils/oneclawVault.js')
+    const vaultKeys = await populateEnvFromVault()
+    if (vaultKeys > 0) {
+      const { logForDebugging } = await import('../utils/debug.js')
+      logForDebugging(`1claw vault: loaded ${vaultKeys} provider key(s) from vault`)
+    }
+  }
+
   await validateProviderEnvForStartupOrExit()
 
   // #808: --model alone (no --provider) — route to the env var matching the

--- a/src/services/api/client.ts
+++ b/src/services/api/client.ts
@@ -497,6 +497,25 @@ export async function getAnthropicClient({
     return new AnthropicVertex(vertexArgs) as unknown as Anthropic
   }
 
+  // 1claw Shroud: route Anthropic traffic through TEE proxy when enabled
+  const shroudAnthropicRouting = await (async () => {
+    try {
+      const { applyShroudRouting } = await import('../../utils/oneclawShroud.js')
+      return applyShroudRouting({ provider: 'anthropic', model })
+    } catch { return null }
+  })()
+
+  if (shroudAnthropicRouting) {
+    const shroudHeaders = { ...defaultHeaders, ...shroudAnthropicRouting.headers }
+    return new Anthropic({
+      baseURL: shroudAnthropicRouting.baseUrl.replace(/\/v1$/, ''),
+      apiKey: 'shroud-managed',
+      ...ARGS,
+      defaultHeaders: shroudHeaders,
+      ...(isDebugToStdErr() && { logger: createStderrLogger() }),
+    })
+  }
+
   // Determine authentication method based on available tokens
   const clientConfig: ConstructorParameters<typeof Anthropic>[0] = {
     apiKey: isClaudeAiSubscriber ? null : apiKey || getAnthropicApiKey(),

--- a/src/services/api/client.ts
+++ b/src/services/api/client.ts
@@ -528,6 +528,7 @@ export async function getAnthropicClient({
           model: stripeModel,
           baseURL: shroudAnthropicRouting.baseUrl,
           apiKey: 'shroud-managed',
+          isShroudRouted: true,
         },
       }) as unknown as Anthropic
     }
@@ -539,6 +540,25 @@ export async function getAnthropicClient({
       defaultHeaders: shroudHeaders,
       ...(isDebugToStdErr() && { logger: createStderrLogger() }),
     })
+  }
+
+  // 1claw OIDC Federation: keyless Anthropic access via WIF
+  // Only used when the user has federation enabled and no existing auth
+  if (!isClaudeAiSubscriber && !apiKey && !getAnthropicApiKey()) {
+    const oidcToken = await (async () => {
+      try {
+        const { resolveAnthropicOidcToken } = await import('../../utils/oneclawOidc.js')
+        return resolveAnthropicOidcToken()
+      } catch { return null }
+    })()
+    if (oidcToken) {
+      return new Anthropic({
+        apiKey: oidcToken,
+        ...ARGS,
+        defaultHeaders,
+        ...(isDebugToStdErr() && { logger: createStderrLogger() }),
+      })
+    }
   }
 
   // Determine authentication method based on available tokens

--- a/src/services/api/client.ts
+++ b/src/services/api/client.ts
@@ -506,6 +506,31 @@ export async function getAnthropicClient({
   })()
 
   if (shroudAnthropicRouting) {
+    if (shroudAnthropicRouting.useOpenAICompat) {
+      // Token-billing: Stripe AI Gateway requires OpenAI-shaped /v1/chat/completions
+      // with Stripe-format model names (dots not hyphens, e.g. claude-sonnet-4.6).
+      const stripeModel = shroudAnthropicRouting.stripeModelName
+        ?? model ?? process.env.ANTHROPIC_MODEL ?? 'claude-sonnet-4.5'
+      const shroudHeaders = { ...defaultHeaders, ...shroudAnthropicRouting.headers }
+      const safeHeaders: Record<string, string> = {}
+      for (const [k, v] of Object.entries(shroudHeaders)) {
+        const lower = k.toLowerCase()
+        if (lower === 'authorization' || lower === 'x-api-key' || lower === 'api-key') continue
+        safeHeaders[k] = v
+      }
+      const { createOpenAIShimClient } = await import('./openaiShim.js')
+      return createOpenAIShimClient({
+        defaultHeaders: safeHeaders,
+        maxRetries,
+        timeout: parseInt(process.env.API_TIMEOUT_MS || String(600 * 1000), 10),
+        reasoningEffort: shimReasoningEffort,
+        providerOverride: {
+          model: stripeModel,
+          baseURL: shroudAnthropicRouting.baseUrl,
+          apiKey: 'shroud-managed',
+        },
+      }) as unknown as Anthropic
+    }
     const shroudHeaders = { ...defaultHeaders, ...shroudAnthropicRouting.headers }
     return new Anthropic({
       baseURL: shroudAnthropicRouting.baseUrl.replace(/\/v1$/, ''),

--- a/src/services/api/errors.ts
+++ b/src/services/api/errors.ts
@@ -948,9 +948,13 @@ export function getAssistantMessageFromError(
   ) {
     // 1claw Shroud auth: surface actionable error instead of generic "Not logged in"
     if (process.env.ONECLAW_AUTH_ACTIVE === '1') {
+      const authMode = process.env.ONECLAW_AUTH_MODE
+      const hint = authMode === 'oidc-federation'
+        ? 'OIDC federation error · Verify OIDC IdP is registered in Anthropic Console and agent has federation_enabled'
+        : 'Shroud auth error · Check 1claw agent credentials and ensure LLM Token Billing is enabled at https://1claw.xyz → Billing'
       return createAssistantAPIErrorMessage({
         error: 'authentication_failed',
-        content: 'Shroud auth error · Check 1claw agent credentials and ensure LLM Token Billing is enabled at https://1claw.xyz → Billing',
+        content: hint,
       })
     }
 

--- a/src/services/api/errors.ts
+++ b/src/services/api/errors.ts
@@ -946,6 +946,14 @@ export function getAssistantMessageFromError(
     error.message.toLowerCase().includes('x-api-key') &&
     getAPIProvider() === 'firstParty'
   ) {
+    // 1claw Shroud auth: surface actionable error instead of generic "Not logged in"
+    if (process.env.ONECLAW_AUTH_ACTIVE === '1') {
+      return createAssistantAPIErrorMessage({
+        error: 'authentication_failed',
+        content: 'Shroud auth error · Check 1claw agent credentials and ensure LLM Token Billing is enabled at https://1claw.xyz → Billing',
+      })
+    }
+
     // In CCR mode, auth is via JWTs - this is likely a transient network issue
     if (isCCRMode()) {
       return createAssistantAPIErrorMessage({

--- a/src/services/api/openaiShim.ts
+++ b/src/services/api/openaiShim.ts
@@ -1578,9 +1578,9 @@ class OpenAIShimStream {
 class OpenAIShimMessages {
   private defaultHeaders: Record<string, string>
   private reasoningEffort?: 'low' | 'medium' | 'high' | 'xhigh'
-  private providerOverride?: { model: string; baseURL: string; apiKey: string }
+  private providerOverride?: { model: string; baseURL: string; apiKey: string; isShroudRouted?: boolean }
 
-  constructor(defaultHeaders: Record<string, string>, reasoningEffort?: 'low' | 'medium' | 'high' | 'xhigh', providerOverride?: { model: string; baseURL: string; apiKey: string }) {
+  constructor(defaultHeaders: Record<string, string>, reasoningEffort?: 'low' | 'medium' | 'high' | 'xhigh', providerOverride?: { model: string; baseURL: string; apiKey: string; isShroudRouted?: boolean }) {
     this.defaultHeaders = filterAnthropicHeaders(defaultHeaders)
     this.reasoningEffort = reasoningEffort
     this.providerOverride = providerOverride
@@ -1843,8 +1843,7 @@ class OpenAIShimMessages {
       delete body.max_completion_tokens
     }
 
-    // Shroud→Anthropic via Stripe: Anthropic backend requires max_tokens
-    if (this.providerOverride && request.baseUrl.includes('shroud') && body.max_completion_tokens !== undefined) {
+    if (this.providerOverride?.isShroudRouted && body.max_completion_tokens !== undefined) {
       body.max_tokens = body.max_completion_tokens
       delete body.max_completion_tokens
     }
@@ -2102,8 +2101,13 @@ class OpenAIShimMessages {
       })()
       if (shroudRouting) {
         request = { ...request, baseUrl: shroudRouting.baseUrl }
+        for (const key of Object.keys(headers)) {
+          const lower = key.toLowerCase()
+          if (lower === 'authorization' || lower === 'x-api-key' || lower === 'api-key') {
+            delete headers[key]
+          }
+        }
         Object.assign(headers, shroudRouting.headers)
-        delete headers['Authorization']
       }
     }
 
@@ -2582,7 +2586,7 @@ class OpenAIShimBeta {
   messages: OpenAIShimMessages
   reasoningEffort?: 'low' | 'medium' | 'high' | 'xhigh'
 
-  constructor(defaultHeaders: Record<string, string>, reasoningEffort?: 'low' | 'medium' | 'high' | 'xhigh', providerOverride?: { model: string; baseURL: string; apiKey: string }) {
+  constructor(defaultHeaders: Record<string, string>, reasoningEffort?: 'low' | 'medium' | 'high' | 'xhigh', providerOverride?: { model: string; baseURL: string; apiKey: string; isShroudRouted?: boolean }) {
     this.messages = new OpenAIShimMessages(defaultHeaders, reasoningEffort, providerOverride)
     this.reasoningEffort = reasoningEffort
   }
@@ -2593,7 +2597,7 @@ export function createOpenAIShimClient(options: {
   maxRetries?: number
   timeout?: number
   reasoningEffort?: 'low' | 'medium' | 'high' | 'xhigh'
-  providerOverride?: { model: string; baseURL: string; apiKey: string }
+  providerOverride?: { model: string; baseURL: string; apiKey: string; isShroudRouted?: boolean }
 }): unknown {
   hydrateGeminiAccessTokenFromSecureStorage()
   hydrateGithubModelsTokenFromSecureStorage()

--- a/src/services/api/openaiShim.ts
+++ b/src/services/api/openaiShim.ts
@@ -1595,7 +1595,7 @@ class OpenAIShimMessages {
     let httpResponse: Response | undefined
 
     const promise = (async () => {
-      const request = resolveProviderRequest({ model: self.providerOverride?.model ?? params.model, baseUrl: self.providerOverride?.baseURL, reasoningEffortOverride: self.reasoningEffort })
+      let request = resolveProviderRequest({ model: self.providerOverride?.model ?? params.model, baseUrl: self.providerOverride?.baseURL, reasoningEffortOverride: self.reasoningEffort })
       const response = await self._doRequest(request, params, options)
       httpResponse = response
 
@@ -2082,6 +2082,21 @@ class OpenAIShimMessages {
       request.transport === 'responses'
         ? `${baseUrl}/responses`
         : buildChatCompletionsUrl(baseUrl)
+
+    // 1claw Shroud: route through TEE proxy when enabled.
+    // Shroud handles provider auth via vault reference, so we replace the
+    // base URL and merge Shroud-specific headers. Local providers are excluded.
+    const shroudRouting = isLocal ? null : await (async () => {
+      try {
+        const { applyShroudRouting } = await import('../../utils/oneclawShroud.js')
+        return applyShroudRouting({ model: request.resolvedModel })
+      } catch { return null }
+    })()
+    if (shroudRouting) {
+      request = { ...request, baseUrl: shroudRouting.baseUrl }
+      Object.assign(headers, shroudRouting.headers)
+      delete headers['Authorization']
+    }
 
     let activeBaseUrl = request.baseUrl
     let requestUrl = buildRequestUrl(activeBaseUrl)

--- a/src/services/api/openaiShim.ts
+++ b/src/services/api/openaiShim.ts
@@ -1843,6 +1843,12 @@ class OpenAIShimMessages {
       delete body.max_completion_tokens
     }
 
+    // Shroud→Anthropic via Stripe: Anthropic backend requires max_tokens
+    if (this.providerOverride && request.baseUrl.includes('shroud') && body.max_completion_tokens !== undefined) {
+      body.max_tokens = body.max_completion_tokens
+      delete body.max_completion_tokens
+    }
+
     for (const field of shimConfig.removeBodyFields ?? []) {
       delete body[field]
     }
@@ -2086,16 +2092,19 @@ class OpenAIShimMessages {
     // 1claw Shroud: route through TEE proxy when enabled.
     // Shroud handles provider auth via vault reference, so we replace the
     // base URL and merge Shroud-specific headers. Local providers are excluded.
-    const shroudRouting = isLocal ? null : await (async () => {
-      try {
-        const { applyShroudRouting } = await import('../../utils/oneclawShroud.js')
-        return applyShroudRouting({ model: request.resolvedModel })
-      } catch { return null }
-    })()
-    if (shroudRouting) {
-      request = { ...request, baseUrl: shroudRouting.baseUrl }
-      Object.assign(headers, shroudRouting.headers)
-      delete headers['Authorization']
+    // Skip when providerOverride is set — client-level routing already applied.
+    if (!this.providerOverride) {
+      const shroudRouting = isLocal ? null : await (async () => {
+        try {
+          const { applyShroudRouting } = await import('../../utils/oneclawShroud.js')
+          return applyShroudRouting({ model: request.resolvedModel })
+        } catch { return null }
+      })()
+      if (shroudRouting) {
+        request = { ...request, baseUrl: shroudRouting.baseUrl }
+        Object.assign(headers, shroudRouting.headers)
+        delete headers['Authorization']
+      }
     }
 
     let activeBaseUrl = request.baseUrl

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -48,6 +48,11 @@ import { TodoWriteTool } from './tools/TodoWriteTool/TodoWriteTool.js'
 import { ExitPlanModeV2Tool } from './tools/ExitPlanModeTool/ExitPlanModeV2Tool.js'
 import { TestingPermissionTool } from './tools/testing/TestingPermissionTool.js'
 import { GrepTool } from './tools/GrepTool/GrepTool.js'
+import {
+  OneclawSubmitTransactionTool,
+  OneclawSignTransactionTool,
+  OneclawSimulateTransactionTool,
+} from './tools/OneclawIntentsTool/OneclawIntentsTool.js'
 // Lazy require to break circular dependency: tools.ts -> TeamCreateTool/TeamDeleteTool -> ... -> tools.ts
 /* eslint-disable @typescript-eslint/no-require-imports */
 const getTeamCreateTool = () =>
@@ -229,6 +234,9 @@ export function getAllBaseTools(): Tools {
     ...(SubscribePRTool ? [SubscribePRTool] : []),
     ...(getPowerShellTool() ? [getPowerShellTool()] : []),
     ...(SnipTool ? [SnipTool] : []),
+    OneclawSubmitTransactionTool,
+    OneclawSignTransactionTool,
+    OneclawSimulateTransactionTool,
     ...(process.env.NODE_ENV === 'test' ? [TestingPermissionTool] : []),
     ListMcpResourcesTool,
     ReadMcpResourceTool,

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -48,11 +48,16 @@ import { TodoWriteTool } from './tools/TodoWriteTool/TodoWriteTool.js'
 import { ExitPlanModeV2Tool } from './tools/ExitPlanModeTool/ExitPlanModeV2Tool.js'
 import { TestingPermissionTool } from './tools/testing/TestingPermissionTool.js'
 import { GrepTool } from './tools/GrepTool/GrepTool.js'
-import {
-  OneclawSubmitTransactionTool,
-  OneclawSignTransactionTool,
-  OneclawSimulateTransactionTool,
-} from './tools/OneclawIntentsTool/OneclawIntentsTool.js'
+/* eslint-disable @typescript-eslint/no-require-imports */
+const OneclawIntentsTools: Tool[] = (() => {
+  try {
+    const { isOneclawConfigured } = require('./utils/oneclaw.js') as typeof import('./utils/oneclaw.js')
+    if (!isOneclawConfigured()) return []
+    const m = require('./tools/OneclawIntentsTool/OneclawIntentsTool.js') as typeof import('./tools/OneclawIntentsTool/OneclawIntentsTool.js')
+    return [m.OneclawSubmitTransactionTool, m.OneclawSignTransactionTool, m.OneclawSimulateTransactionTool]
+  } catch { return [] }
+})()
+/* eslint-enable @typescript-eslint/no-require-imports */
 // Lazy require to break circular dependency: tools.ts -> TeamCreateTool/TeamDeleteTool -> ... -> tools.ts
 /* eslint-disable @typescript-eslint/no-require-imports */
 const getTeamCreateTool = () =>
@@ -234,9 +239,7 @@ export function getAllBaseTools(): Tools {
     ...(SubscribePRTool ? [SubscribePRTool] : []),
     ...(getPowerShellTool() ? [getPowerShellTool()] : []),
     ...(SnipTool ? [SnipTool] : []),
-    OneclawSubmitTransactionTool,
-    OneclawSignTransactionTool,
-    OneclawSimulateTransactionTool,
+    ...OneclawIntentsTools,
     ...(process.env.NODE_ENV === 'test' ? [TestingPermissionTool] : []),
     ListMcpResourcesTool,
     ReadMcpResourceTool,

--- a/src/tools/OneclawIntentsTool/OneclawIntentsTool.ts
+++ b/src/tools/OneclawIntentsTool/OneclawIntentsTool.ts
@@ -97,7 +97,7 @@ function txResultToBlock(content: TxOutput, toolUseID: string): ToolResultBlockP
 
 function simResultToBlock(content: SimOutput, toolUseID: string): ToolResultBlockParam {
   const lines: string[] = [`Status: ${content.status}`]
-  if (content.gas_used) lines.push(`Gas used: ${content.gas_used}`)
+  if (content.gas_used != null) lines.push(`Gas used: ${content.gas_used}`)
   if (content.revert_reason) lines.push(`Revert: ${content.revert_reason}`)
   if (content.tenderly_url) lines.push(`Tenderly: ${content.tenderly_url}`)
   if (content.error) lines.push(`Error: ${content.error}`)
@@ -168,7 +168,7 @@ export const OneclawSubmitTransactionTool = buildTool({
         data: {
           status: res.data?.status ?? 'submitted',
           tx_hash: res.data?.tx_hash,
-          from: res.data?.to,
+          from: res.data?.from,
         },
       }
     } catch (err: any) {

--- a/src/tools/OneclawIntentsTool/OneclawIntentsTool.ts
+++ b/src/tools/OneclawIntentsTool/OneclawIntentsTool.ts
@@ -1,0 +1,321 @@
+import type { ToolResultBlockParam } from '@anthropic-ai/sdk/resources/index.mjs'
+import { z } from 'zod/v4'
+import { buildTool, type ToolDef } from '../../Tool.js'
+import { lazySchema } from '../../utils/lazySchema.js'
+import { isOneclawConfigured, loadOneclawConfig } from '../../utils/oneclaw.js'
+import { getOneclawAgentClient } from '../../utils/oneclawClient.js'
+import {
+  SUBMIT_TX_TOOL_NAME,
+  SIGN_TX_TOOL_NAME,
+  SIMULATE_TX_TOOL_NAME,
+} from './constants.js'
+import {
+  SUBMIT_TX_DESCRIPTION,
+  SUBMIT_TX_PROMPT,
+  SIGN_TX_DESCRIPTION,
+  SIGN_TX_PROMPT,
+  SIMULATE_TX_DESCRIPTION,
+  SIMULATE_TX_PROMPT,
+} from './prompt.js'
+
+const txInputSchema = lazySchema(() =>
+  z.strictObject({
+    chain: z
+      .string()
+      .describe(
+        'Target blockchain (e.g. "ethereum", "base", "sepolia", "arbitrum")',
+      ),
+    to: z.string().describe('Recipient address (0x...)'),
+    value: z
+      .string()
+      .optional()
+      .describe('Amount in ETH (e.g. "0.01"). Omit for contract calls with no value.'),
+    data: z
+      .string()
+      .optional()
+      .describe('Contract calldata hex (0x...). Required for contract interactions.'),
+    gas_limit: z
+      .number()
+      .optional()
+      .describe('Gas limit override'),
+  }),
+)
+type TxInputSchema = ReturnType<typeof txInputSchema>
+
+type TxOutput = {
+  status: string
+  tx_hash?: string
+  signed_tx?: string
+  from?: string
+  error?: string
+}
+
+type SimOutput = {
+  status: string
+  gas_used?: number
+  error?: string
+  revert_reason?: string
+  tenderly_url?: string
+}
+
+const txOutputSchema = lazySchema(() =>
+  z.object({
+    status: z.string(),
+    tx_hash: z.string().optional(),
+    signed_tx: z.string().optional(),
+    from: z.string().optional(),
+    error: z.string().optional(),
+  }),
+)
+type TxOutputSchema = ReturnType<typeof txOutputSchema>
+
+const simulateOutputSchema = lazySchema(() =>
+  z.object({
+    status: z.string(),
+    gas_used: z.number().optional(),
+    error: z.string().optional(),
+    revert_reason: z.string().optional(),
+    tenderly_url: z.string().optional(),
+  }),
+)
+type SimulateOutputSchema = ReturnType<typeof simulateOutputSchema>
+
+function isIntentsEnabled(): boolean {
+  if (!isOneclawConfigured()) return false
+  const config = loadOneclawConfig()
+  return config?.intentsEnabled === true
+}
+
+function txResultToBlock(content: TxOutput, toolUseID: string): ToolResultBlockParam {
+  const lines: string[] = [`Status: ${content.status}`]
+  if (content.tx_hash) lines.push(`TX Hash: ${content.tx_hash}`)
+  if (content.from) lines.push(`From: ${content.from}`)
+  if (content.signed_tx) lines.push(`Signed TX: ${content.signed_tx.slice(0, 66)}...`)
+  if (content.error) lines.push(`Error: ${content.error}`)
+  return { type: 'tool_result', tool_use_id: toolUseID, content: lines.join('\n') }
+}
+
+function simResultToBlock(content: SimOutput, toolUseID: string): ToolResultBlockParam {
+  const lines: string[] = [`Status: ${content.status}`]
+  if (content.gas_used) lines.push(`Gas used: ${content.gas_used}`)
+  if (content.revert_reason) lines.push(`Revert: ${content.revert_reason}`)
+  if (content.tenderly_url) lines.push(`Tenderly: ${content.tenderly_url}`)
+  if (content.error) lines.push(`Error: ${content.error}`)
+  return { type: 'tool_result', tool_use_id: toolUseID, content: lines.join('\n') }
+}
+
+export const OneclawSubmitTransactionTool = buildTool({
+  name: SUBMIT_TX_TOOL_NAME,
+  searchHint: 'submit on-chain EVM transaction via 1claw',
+  maxResultSizeChars: 10_000,
+
+  async description() {
+    return SUBMIT_TX_DESCRIPTION
+  },
+  async prompt() {
+    return SUBMIT_TX_PROMPT
+  },
+  get inputSchema(): TxInputSchema {
+    return txInputSchema()
+  },
+  get outputSchema(): TxOutputSchema {
+    return txOutputSchema()
+  },
+  isEnabled: isIntentsEnabled,
+  isReadOnly: () => false,
+  isConcurrencySafe: () => false,
+
+  async checkPermissions(input) {
+    return {
+      behavior: 'ask' as const,
+      updatedInput: input,
+      message: `Submit transaction: ${input.value ?? '0'} ETH to ${input.to} on ${input.chain}`,
+    }
+  },
+
+  renderToolUseMessage() {
+    return null
+  },
+
+  mapToolResultToToolResultBlockParam: txResultToBlock,
+
+  async call(input) {
+    const client = getOneclawAgentClient()
+    if (!client) {
+      return { data: { status: 'error', error: '1claw not configured. Run /1claw to set up.' } }
+    }
+
+    const config = loadOneclawConfig()
+    if (!config) {
+      return { data: { status: 'error', error: '1claw config not found' } }
+    }
+
+    try {
+      const res = await client.agents.submitTransaction(config.agentId, {
+        chain: input.chain,
+        to: input.to,
+        value: input.value ?? '0',
+        data: input.data ?? '0x',
+        simulate_first: false,
+        ...(input.gas_limit ? { gas_limit: input.gas_limit } : {}),
+      })
+
+      if (res.error) {
+        return { data: { status: 'error', error: res.error.message } }
+      }
+
+      return {
+        data: {
+          status: res.data?.status ?? 'submitted',
+          tx_hash: res.data?.tx_hash,
+          from: res.data?.to,
+        },
+      }
+    } catch (err: any) {
+      return { data: { status: 'error', error: err?.message ?? String(err) } }
+    }
+  },
+} satisfies ToolDef<TxInputSchema, TxOutput>)
+
+export const OneclawSignTransactionTool = buildTool({
+  name: SIGN_TX_TOOL_NAME,
+  searchHint: 'sign EVM transaction without broadcasting via 1claw',
+  maxResultSizeChars: 10_000,
+
+  async description() {
+    return SIGN_TX_DESCRIPTION
+  },
+  async prompt() {
+    return SIGN_TX_PROMPT
+  },
+  get inputSchema(): TxInputSchema {
+    return txInputSchema()
+  },
+  get outputSchema(): TxOutputSchema {
+    return txOutputSchema()
+  },
+  isEnabled: isIntentsEnabled,
+  isReadOnly: () => false,
+  isConcurrencySafe: () => false,
+
+  async checkPermissions(input) {
+    return {
+      behavior: 'ask' as const,
+      updatedInput: input,
+      message: `Sign transaction (no broadcast): ${input.value ?? '0'} ETH to ${input.to} on ${input.chain}`,
+    }
+  },
+
+  renderToolUseMessage() {
+    return null
+  },
+
+  mapToolResultToToolResultBlockParam: txResultToBlock,
+
+  async call(input) {
+    const client = getOneclawAgentClient()
+    if (!client) {
+      return { data: { status: 'error', error: '1claw not configured. Run /1claw to set up.' } }
+    }
+
+    const config = loadOneclawConfig()
+    if (!config) {
+      return { data: { status: 'error', error: '1claw config not found' } }
+    }
+
+    try {
+      const res = await client.agents.signTransaction(config.agentId, {
+        chain: input.chain,
+        to: input.to,
+        value: input.value ?? '0',
+        data: input.data ?? '0x',
+        ...(input.gas_limit ? { gas_limit: input.gas_limit } : {}),
+      })
+
+      if (res.error) {
+        return { data: { status: 'error', error: res.error.message } }
+      }
+
+      return {
+        data: {
+          status: 'signed',
+          tx_hash: res.data?.tx_hash,
+          signed_tx: res.data?.signed_tx ?? undefined,
+          from: res.data?.from,
+        },
+      }
+    } catch (err: any) {
+      return { data: { status: 'error', error: err?.message ?? String(err) } }
+    }
+  },
+} satisfies ToolDef<TxInputSchema, TxOutput>)
+
+export const OneclawSimulateTransactionTool = buildTool({
+  name: SIMULATE_TX_TOOL_NAME,
+  searchHint: 'simulate EVM transaction via Tenderly before signing',
+  maxResultSizeChars: 10_000,
+
+  async description() {
+    return SIMULATE_TX_DESCRIPTION
+  },
+  async prompt() {
+    return SIMULATE_TX_PROMPT
+  },
+  get inputSchema(): TxInputSchema {
+    return txInputSchema()
+  },
+  get outputSchema(): SimulateOutputSchema {
+    return simulateOutputSchema()
+  },
+  isEnabled: isIntentsEnabled,
+  isReadOnly: () => true,
+  isConcurrencySafe: () => true,
+
+  async checkPermissions(input) {
+    return { behavior: 'allow' as const, updatedInput: input }
+  },
+
+  renderToolUseMessage() {
+    return null
+  },
+
+  mapToolResultToToolResultBlockParam: simResultToBlock,
+
+  async call(input) {
+    const client = getOneclawAgentClient()
+    if (!client) {
+      return { data: { status: 'error', error: '1claw not configured. Run /1claw to set up.' } }
+    }
+
+    const config = loadOneclawConfig()
+    if (!config) {
+      return { data: { status: 'error', error: '1claw config not found' } }
+    }
+
+    try {
+      const res = await client.agents.simulateTransaction(config.agentId, {
+        chain: input.chain,
+        to: input.to,
+        value: input.value ?? '0',
+        data: input.data ?? '0x',
+        ...(input.gas_limit ? { gas_limit: input.gas_limit } : {}),
+      })
+
+      if (res.error) {
+        return { data: { status: 'error', error: res.error.message } }
+      }
+
+      return {
+        data: {
+          status: res.data?.status ?? 'unknown',
+          gas_used: res.data?.gas_used,
+          error: res.data?.error,
+          revert_reason: res.data?.revert_reason,
+          tenderly_url: res.data?.tenderly_dashboard_url,
+        },
+      }
+    } catch (err: any) {
+      return { data: { status: 'error', error: err?.message ?? String(err) } }
+    }
+  },
+} satisfies ToolDef<TxInputSchema, SimOutput>)

--- a/src/tools/OneclawIntentsTool/OneclawIntentsTool.ts
+++ b/src/tools/OneclawIntentsTool/OneclawIntentsTool.ts
@@ -3,7 +3,7 @@ import { z } from 'zod/v4'
 import { buildTool, type ToolDef } from '../../Tool.js'
 import { lazySchema } from '../../utils/lazySchema.js'
 import { isOneclawConfigured, loadOneclawConfig } from '../../utils/oneclaw.js'
-import { getOneclawAgentClient } from '../../utils/oneclawClient.js'
+import { getAuthenticatedAgentClient } from '../../utils/oneclawClient.js'
 import {
   SUBMIT_TX_TOOL_NAME,
   SIGN_TX_TOOL_NAME,
@@ -140,7 +140,7 @@ export const OneclawSubmitTransactionTool = buildTool({
   mapToolResultToToolResultBlockParam: txResultToBlock,
 
   async call(input) {
-    const client = getOneclawAgentClient()
+    const client = await getAuthenticatedAgentClient()
     if (!client) {
       return { data: { status: 'error', error: '1claw not configured. Run /1claw to set up.' } }
     }
@@ -213,7 +213,7 @@ export const OneclawSignTransactionTool = buildTool({
   mapToolResultToToolResultBlockParam: txResultToBlock,
 
   async call(input) {
-    const client = getOneclawAgentClient()
+    const client = await getAuthenticatedAgentClient()
     if (!client) {
       return { data: { status: 'error', error: '1claw not configured. Run /1claw to set up.' } }
     }
@@ -282,7 +282,7 @@ export const OneclawSimulateTransactionTool = buildTool({
   mapToolResultToToolResultBlockParam: simResultToBlock,
 
   async call(input) {
-    const client = getOneclawAgentClient()
+    const client = await getAuthenticatedAgentClient()
     if (!client) {
       return { data: { status: 'error', error: '1claw not configured. Run /1claw to set up.' } }
     }

--- a/src/tools/OneclawIntentsTool/constants.ts
+++ b/src/tools/OneclawIntentsTool/constants.ts
@@ -1,0 +1,3 @@
+export const SUBMIT_TX_TOOL_NAME = 'OneclawSubmitTransaction'
+export const SIGN_TX_TOOL_NAME = 'OneclawSignTransaction'
+export const SIMULATE_TX_TOOL_NAME = 'OneclawSimulateTransaction'

--- a/src/tools/OneclawIntentsTool/prompt.ts
+++ b/src/tools/OneclawIntentsTool/prompt.ts
@@ -1,0 +1,14 @@
+export const SUBMIT_TX_DESCRIPTION =
+  'Submit an on-chain EVM transaction via 1claw Intents API. The transaction is signed by HSM-backed keys and broadcast to the network. Private keys never leave the server.'
+
+export const SUBMIT_TX_PROMPT = `Use this tool to submit on-chain EVM transactions. The private key is managed by 1claw's HSM — you never see it. All transactions are subject to agent guardrails: chain allowlists, recipient allowlists, per-transaction value caps, and daily spending limits. Use testnets (chain: "sepolia") for development.`
+
+export const SIGN_TX_DESCRIPTION =
+  'Sign an EVM transaction without broadcasting (BYORPC). Returns the signed transaction hex for manual submission.'
+
+export const SIGN_TX_PROMPT = `Use this tool to sign a transaction without broadcasting it. Useful for MEV protection (Flashbots), batch submission, or custom RPC endpoints.`
+
+export const SIMULATE_TX_DESCRIPTION =
+  'Simulate a transaction using Tenderly before signing. Returns success/failure and gas estimates without spending real ETH.'
+
+export const SIMULATE_TX_PROMPT = `Use this tool to dry-run a transaction before committing real funds. Shows revert reasons, gas usage, and state changes.`

--- a/src/utils/oneclaw.ts
+++ b/src/utils/oneclaw.ts
@@ -1,0 +1,98 @@
+import { existsSync, readFileSync, writeFileSync, mkdirSync } from 'node:fs'
+import { join } from 'node:path'
+import { getClaudeConfigHomeDir } from './envUtils.js'
+
+const ONECLAW_CONFIG_FILE = 'oneclaw.json'
+const ONECLAW_BASE_URL = 'https://api.1claw.xyz'
+const SHROUD_BASE_URL = 'https://shroud.1claw.xyz'
+
+export interface OneclawConfig {
+  agentId: string
+  agentApiKey: string
+  vaultId: string
+  baseUrl: string
+  shroudEnabled: boolean
+  intentsEnabled: boolean
+  oidcFederationEnabled: boolean
+  providerSecretPaths: Record<string, string>
+}
+
+function getConfigDir(): string {
+  return getClaudeConfigHomeDir()
+}
+
+function getConfigPath(): string {
+  return join(getConfigDir(), ONECLAW_CONFIG_FILE)
+}
+
+export function loadOneclawConfig(): OneclawConfig | null {
+  const configPath = getConfigPath()
+  if (!existsSync(configPath)) return null
+
+  try {
+    const raw = readFileSync(configPath, 'utf8')
+    return JSON.parse(raw) as OneclawConfig
+  } catch {
+    return null
+  }
+}
+
+export function saveOneclawConfig(config: OneclawConfig): void {
+  const configDir = getConfigDir()
+  if (!existsSync(configDir)) {
+    mkdirSync(configDir, { recursive: true })
+  }
+  writeFileSync(getConfigPath(), JSON.stringify(config, null, 2), {
+    encoding: 'utf8',
+    mode: 0o600,
+  })
+}
+
+export function isOneclawConfigured(): boolean {
+  return loadOneclawConfig() !== null
+}
+
+export function getOneclawBaseUrl(): string {
+  return process.env.ONECLAW_BASE_URL ?? ONECLAW_BASE_URL
+}
+
+export function getShroudBaseUrl(): string {
+  return process.env.ONECLAW_SHROUD_URL ?? SHROUD_BASE_URL
+}
+
+export function getOneclawAgentApiKey(): string | undefined {
+  const config = loadOneclawConfig()
+  return process.env.ONECLAW_AGENT_API_KEY ?? config?.agentApiKey
+}
+
+export function getOneclawAgentId(): string | undefined {
+  const config = loadOneclawConfig()
+  return process.env.ONECLAW_AGENT_ID ?? config?.agentId
+}
+
+export function getOneclawVaultId(): string | undefined {
+  const config = loadOneclawConfig()
+  return process.env.ONECLAW_VAULT_ID ?? config?.vaultId
+}
+
+const PROVIDER_TO_SECRET_PATH: Record<string, string> = {
+  ANTHROPIC_API_KEY: 'providers/anthropic/api-key',
+  OPENAI_API_KEY: 'providers/openai/api-key',
+  GEMINI_API_KEY: 'providers/gemini/api-key',
+  GOOGLE_API_KEY: 'providers/google/api-key',
+  MISTRAL_API_KEY: 'providers/mistral/api-key',
+  BNKR_API_KEY: 'providers/bankr/api-key',
+  XAI_API_KEY: 'providers/xai/api-key',
+  VENICE_API_KEY: 'providers/venice/api-key',
+  MIMO_API_KEY: 'providers/mimo/api-key',
+  NVIDIA_API_KEY: 'providers/nvidia/api-key',
+  MINIMAX_API_KEY: 'providers/minimax/api-key',
+  CODEX_API_KEY: 'providers/codex/api-key',
+}
+
+export function getSecretPathForProvider(envKey: string): string {
+  const config = loadOneclawConfig()
+  return config?.providerSecretPaths[envKey] ?? PROVIDER_TO_SECRET_PATH[envKey] ?? `providers/${envKey.toLowerCase().replace(/_api_key$/, '')}/api-key`
+}
+
+export { ONECLAW_BASE_URL, SHROUD_BASE_URL, PROVIDER_TO_SECRET_PATH }

--- a/src/utils/oneclaw.ts
+++ b/src/utils/oneclaw.ts
@@ -1,4 +1,4 @@
-import { existsSync, readFileSync, writeFileSync, mkdirSync } from 'node:fs'
+import { existsSync, readFileSync, writeFileSync, mkdirSync, unlinkSync } from 'node:fs'
 import { join } from 'node:path'
 import { getClaudeConfigHomeDir } from './envUtils.js'
 
@@ -45,7 +45,7 @@ export function loadOneclawConfig(): OneclawConfig | null {
 export function saveOneclawConfig(config: OneclawConfig): void {
   const configDir = getConfigDir()
   if (!existsSync(configDir)) {
-    mkdirSync(configDir, { recursive: true })
+    mkdirSync(configDir, { recursive: true, mode: 0o700 })
   }
   writeFileSync(getConfigPath(), JSON.stringify(config, null, 2), {
     encoding: 'utf8',
@@ -54,11 +54,21 @@ export function saveOneclawConfig(config: OneclawConfig): void {
 }
 
 export function isOneclawConfigured(): boolean {
-  return loadOneclawConfig() !== null
+  const config = loadOneclawConfig()
+  return config !== null && Boolean(config.agentId) && Boolean(config.agentApiKey)
+}
+
+export function deleteOneclawConfig(): void {
+  const configPath = getConfigPath()
+  if (existsSync(configPath)) {
+    unlinkSync(configPath)
+  }
 }
 
 export function getOneclawBaseUrl(): string {
-  return process.env.ONECLAW_BASE_URL ?? ONECLAW_BASE_URL
+  if (process.env.ONECLAW_BASE_URL) return process.env.ONECLAW_BASE_URL
+  const config = loadOneclawConfig()
+  return config?.baseUrl || ONECLAW_BASE_URL
 }
 
 export function getShroudBaseUrl(): string {

--- a/src/utils/oneclaw.ts
+++ b/src/utils/oneclaw.ts
@@ -6,6 +6,8 @@ const ONECLAW_CONFIG_FILE = 'oneclaw.json'
 const ONECLAW_BASE_URL = 'https://api.1claw.xyz'
 const SHROUD_BASE_URL = 'https://shroud.1claw.xyz'
 
+export type OneclawAuthMode = 'byo-key' | 'token-billing' | 'oidc-federation'
+
 export interface OneclawConfig {
   agentId: string
   agentApiKey: string
@@ -15,6 +17,9 @@ export interface OneclawConfig {
   intentsEnabled: boolean
   oidcFederationEnabled: boolean
   providerSecretPaths: Record<string, string>
+  authMode?: OneclawAuthMode
+  selectedProvider?: string
+  selectedModel?: string
 }
 
 function getConfigDir(): string {
@@ -90,9 +95,33 @@ const PROVIDER_TO_SECRET_PATH: Record<string, string> = {
   CODEX_API_KEY: 'providers/codex/api-key',
 }
 
+export const DEFAULT_AGENT_SCOPES = ['**']
+export const DEFAULT_POLICY_PATH_PATTERN = 'providers/**'
+
 export function getSecretPathForProvider(envKey: string): string {
   const config = loadOneclawConfig()
   return config?.providerSecretPaths[envKey] ?? PROVIDER_TO_SECRET_PATH[envKey] ?? `providers/${envKey.toLowerCase().replace(/_api_key$/, '')}/api-key`
+}
+
+export function getOneclawAuthMode(): OneclawAuthMode | undefined {
+  const config = loadOneclawConfig()
+  return config?.authMode
+}
+
+export function shouldSkipVaultForProvider(envKey: string): boolean {
+  const config = loadOneclawConfig()
+  if (!config?.authMode || config.authMode === 'byo-key') return false
+
+  const providerEnvKeys: Record<string, string[]> = {
+    anthropic: ['ANTHROPIC_API_KEY'],
+    openai: ['OPENAI_API_KEY'],
+    gemini: ['GEMINI_API_KEY', 'GOOGLE_API_KEY'],
+    mistral: ['MISTRAL_API_KEY'],
+    xai: ['XAI_API_KEY'],
+  }
+
+  const selectedKeys = providerEnvKeys[config.selectedProvider ?? ''] ?? []
+  return selectedKeys.includes(envKey)
 }
 
 export { ONECLAW_BASE_URL, SHROUD_BASE_URL, PROVIDER_TO_SECRET_PATH }

--- a/src/utils/oneclawClient.ts
+++ b/src/utils/oneclawClient.ts
@@ -8,6 +8,7 @@ import {
 
 let cachedAgentClient: OneclawClient | null = null
 let agentAuthenticated = false
+let authAttempted = false
 
 export function getOneclawAgentClient(): OneclawClient | null {
   if (cachedAgentClient) return cachedAgentClient
@@ -31,12 +32,13 @@ export async function getAuthenticatedAgentClient(): Promise<OneclawClient | nul
   const client = getOneclawAgentClient()
   if (!client) return null
 
-  if (agentAuthenticated) return client
+  if (agentAuthenticated || authAttempted) return client
 
   const agentId = getOneclawAgentId()
   const apiKey = getOneclawAgentApiKey()
   if (!agentId || !apiKey) return client
 
+  authAttempted = true
   try {
     await client.auth.agentToken({ agent_id: agentId, api_key: apiKey })
     agentAuthenticated = true
@@ -58,6 +60,7 @@ export function createOneclawHumanClient(apiKey: string): OneclawClient {
 export function resetOneclawClientCache(): void {
   cachedAgentClient = null
   agentAuthenticated = false
+  authAttempted = false
 }
 
 export async function resolveSecretFromVault(

--- a/src/utils/oneclawClient.ts
+++ b/src/utils/oneclawClient.ts
@@ -1,0 +1,56 @@
+import { createClient, type OneclawClient } from '@1claw/sdk'
+import {
+  getOneclawBaseUrl,
+  getOneclawAgentApiKey,
+  getOneclawAgentId,
+  loadOneclawConfig,
+} from './oneclaw.js'
+
+let cachedAgentClient: OneclawClient | null = null
+
+export function getOneclawAgentClient(): OneclawClient | null {
+  if (cachedAgentClient) return cachedAgentClient
+
+  const apiKey = getOneclawAgentApiKey()
+  if (!apiKey) return null
+
+  const agentId = getOneclawAgentId()
+  const baseUrl = getOneclawBaseUrl()
+
+  cachedAgentClient = createClient({
+    baseUrl,
+    apiKey,
+    ...(agentId ? { agentId } : {}),
+  })
+
+  return cachedAgentClient
+}
+
+export function createOneclawHumanClient(apiKey: string): OneclawClient {
+  return createClient({
+    baseUrl: getOneclawBaseUrl(),
+    apiKey,
+  })
+}
+
+export function resetOneclawClientCache(): void {
+  cachedAgentClient = null
+}
+
+export async function resolveSecretFromVault(
+  secretPath: string,
+): Promise<string | null> {
+  const client = getOneclawAgentClient()
+  if (!client) return null
+
+  const config = loadOneclawConfig()
+  if (!config?.vaultId) return null
+
+  try {
+    const res = await client.secrets.get(config.vaultId, secretPath)
+    if (res.error) return null
+    return res.data?.value ?? null
+  } catch {
+    return null
+  }
+}

--- a/src/utils/oneclawClient.ts
+++ b/src/utils/oneclawClient.ts
@@ -7,6 +7,7 @@ import {
 } from './oneclaw.js'
 
 let cachedAgentClient: OneclawClient | null = null
+let agentAuthenticated = false
 
 export function getOneclawAgentClient(): OneclawClient | null {
   if (cachedAgentClient) return cachedAgentClient
@@ -26,6 +27,27 @@ export function getOneclawAgentClient(): OneclawClient | null {
   return cachedAgentClient
 }
 
+export async function getAuthenticatedAgentClient(): Promise<OneclawClient | null> {
+  const client = getOneclawAgentClient()
+  if (!client) return null
+
+  if (agentAuthenticated) return client
+
+  const agentId = getOneclawAgentId()
+  const apiKey = getOneclawAgentApiKey()
+  if (!agentId || !apiKey) return client
+
+  try {
+    await client.auth.agentToken({ agent_id: agentId, api_key: apiKey })
+    agentAuthenticated = true
+  } catch {
+    // Auth may fail if the agent uses a different auth method;
+    // the client still works for endpoints that accept the raw API key
+  }
+
+  return client
+}
+
 export function createOneclawHumanClient(apiKey: string): OneclawClient {
   return createClient({
     baseUrl: getOneclawBaseUrl(),
@@ -35,12 +57,13 @@ export function createOneclawHumanClient(apiKey: string): OneclawClient {
 
 export function resetOneclawClientCache(): void {
   cachedAgentClient = null
+  agentAuthenticated = false
 }
 
 export async function resolveSecretFromVault(
   secretPath: string,
 ): Promise<string | null> {
-  const client = getOneclawAgentClient()
+  const client = await getAuthenticatedAgentClient()
   if (!client) return null
 
   const config = loadOneclawConfig()

--- a/src/utils/oneclawShroud.ts
+++ b/src/utils/oneclawShroud.ts
@@ -1,0 +1,106 @@
+import { logForDebugging } from './debug.js'
+import {
+  isOneclawConfigured,
+  loadOneclawConfig,
+  getShroudBaseUrl,
+  getOneclawAgentApiKey,
+  getOneclawAgentId,
+  getSecretPathForProvider,
+} from './oneclaw.js'
+import { isEnvTruthy } from './envUtils.js'
+
+export interface ShroudRoutingResult {
+  baseUrl: string
+  headers: Record<string, string>
+  providerHint: string
+}
+
+const PROVIDER_ENV_TO_SHROUD_PROVIDER: Record<string, string> = {
+  OPENAI_API_KEY: 'openai',
+  ANTHROPIC_API_KEY: 'anthropic',
+  GEMINI_API_KEY: 'google',
+  GOOGLE_API_KEY: 'google',
+  MISTRAL_API_KEY: 'mistral',
+}
+
+export function isShroudEnabled(): boolean {
+  if (isEnvTruthy(process.env.ONECLAW_SHROUD_DISABLED)) return false
+  if (isEnvTruthy(process.env.ONECLAW_SHROUD_ENABLED)) return true
+
+  const config = loadOneclawConfig()
+  return config?.shroudEnabled === true
+}
+
+export function getShroudProvider(): string | null {
+  if (process.env.ONECLAW_SHROUD_PROVIDER) {
+    return process.env.ONECLAW_SHROUD_PROVIDER
+  }
+
+  if (isEnvTruthy(process.env.CLAUDE_CODE_USE_GEMINI)) return 'google'
+  if (isEnvTruthy(process.env.CLAUDE_CODE_USE_MISTRAL)) return 'mistral'
+
+  if (process.env.OPENAI_API_KEY || isEnvTruthy(process.env.CLAUDE_CODE_USE_OPENAI)) {
+    return 'openai'
+  }
+
+  if (process.env.ANTHROPIC_API_KEY) return 'anthropic'
+
+  return 'openai'
+}
+
+export function buildShroudHeaders(options?: {
+  model?: string
+  provider?: string
+}): Record<string, string> {
+  const agentApiKey = getOneclawAgentApiKey()
+  const agentId = getOneclawAgentId()
+
+  if (!agentApiKey || !agentId) return {}
+
+  const provider = options?.provider ?? getShroudProvider() ?? 'openai'
+
+  const headers: Record<string, string> = {
+    'X-Shroud-Agent-Key': `${agentId}:${agentApiKey}`,
+    'X-Shroud-Provider': provider,
+  }
+
+  const config = loadOneclawConfig()
+  if (config?.vaultId) {
+    const envKey = Object.entries(PROVIDER_ENV_TO_SHROUD_PROVIDER).find(
+      ([_, p]) => p === provider,
+    )?.[0]
+    if (envKey) {
+      const secretPath = getSecretPathForProvider(envKey)
+      headers['X-Shroud-Api-Key'] = `vault://${config.vaultId}/${secretPath}`
+    }
+  }
+
+  if (options?.model) {
+    headers['X-Shroud-Model'] = options.model
+  }
+
+  return headers
+}
+
+export function applyShroudRouting(options?: {
+  model?: string
+  provider?: string
+}): ShroudRoutingResult | null {
+  if (!isShroudEnabled()) return null
+  if (!isOneclawConfigured()) return null
+
+  const provider = options?.provider ?? getShroudProvider() ?? 'openai'
+  const headers = buildShroudHeaders({ ...options, provider })
+
+  if (!headers['X-Shroud-Agent-Key']) return null
+
+  const baseUrl = getShroudBaseUrl()
+
+  logForDebugging(`[Shroud] routing to ${baseUrl} via provider=${provider}`)
+
+  return {
+    baseUrl: `${baseUrl}/v1`,
+    headers,
+    providerHint: provider,
+  }
+}

--- a/src/utils/oneclawShroud.ts
+++ b/src/utils/oneclawShroud.ts
@@ -15,6 +15,7 @@ export interface ShroudRoutingResult {
   providerHint: string
   useOpenAICompat?: boolean
   stripeModelName?: string
+  isShroudRouted?: boolean
 }
 
 const PROVIDER_ENV_TO_SHROUD_PROVIDER: Record<string, string> = {
@@ -71,7 +72,7 @@ export function buildShroudHeaders(options?: {
 
   if (authMode === 'token-billing') {
     headers['X-Shroud-Billing'] = 'token'
-  } else if (config?.vaultId) {
+  } else if (authMode === 'byo-key' && config?.vaultId) {
     const envKey = Object.entries(PROVIDER_ENV_TO_SHROUD_PROVIDER).find(
       ([_, p]) => p === provider,
     )?.[0]
@@ -109,6 +110,7 @@ export function applyShroudRouting(options?: {
   if (!isOneclawConfigured()) return null
 
   const config = loadOneclawConfig()
+  if (config?.authMode === 'oidc-federation') return null
   const provider = options?.provider ?? getShroudProvider() ?? 'openai'
   const headers = buildShroudHeaders({ ...options, provider })
 
@@ -125,5 +127,6 @@ export function applyShroudRouting(options?: {
     providerHint: provider,
     useOpenAICompat: isTokenBilling,
     stripeModelName: isTokenBilling && options?.model ? toStripeModelName(options.model) : undefined,
+    isShroudRouted: true,
   }
 }

--- a/src/utils/oneclawShroud.ts
+++ b/src/utils/oneclawShroud.ts
@@ -13,6 +13,8 @@ export interface ShroudRoutingResult {
   baseUrl: string
   headers: Record<string, string>
   providerHint: string
+  useOpenAICompat?: boolean
+  stripeModelName?: string
 }
 
 const PROVIDER_ENV_TO_SHROUD_PROVIDER: Record<string, string> = {
@@ -65,7 +67,11 @@ export function buildShroudHeaders(options?: {
   }
 
   const config = loadOneclawConfig()
-  if (config?.vaultId) {
+  const authMode = config?.authMode
+
+  if (authMode === 'token-billing') {
+    headers['X-Shroud-Billing'] = 'token'
+  } else if (config?.vaultId) {
     const envKey = Object.entries(PROVIDER_ENV_TO_SHROUD_PROVIDER).find(
       ([_, p]) => p === provider,
     )?.[0]
@@ -76,10 +82,23 @@ export function buildShroudHeaders(options?: {
   }
 
   if (options?.model) {
-    headers['X-Shroud-Model'] = options.model
+    headers['X-Shroud-Model'] = authMode === 'token-billing'
+      ? toStripeModelName(options.model)
+      : options.model
   }
 
   return headers
+}
+
+/**
+ * Convert Anthropic API model names to Stripe AI Gateway format.
+ * Anthropic: claude-sonnet-4-5-20250929 → Stripe: claude-sonnet-4.5
+ * Anthropic: claude-opus-4-6            → Stripe: claude-opus-4.6
+ */
+function toStripeModelName(model: string): string {
+  let name = model.replace(/-\d{8}$/, '')
+  name = name.replace(/(\d+)-(\d+)$/, '$1.$2')
+  return name
 }
 
 export function applyShroudRouting(options?: {
@@ -89,18 +108,22 @@ export function applyShroudRouting(options?: {
   if (!isShroudEnabled()) return null
   if (!isOneclawConfigured()) return null
 
+  const config = loadOneclawConfig()
   const provider = options?.provider ?? getShroudProvider() ?? 'openai'
   const headers = buildShroudHeaders({ ...options, provider })
 
   if (!headers['X-Shroud-Agent-Key']) return null
 
   const baseUrl = getShroudBaseUrl()
+  const isTokenBilling = config?.authMode === 'token-billing'
 
-  logForDebugging(`[Shroud] routing to ${baseUrl} via provider=${provider}`)
+  logForDebugging(`[Shroud] routing to ${baseUrl} via provider=${provider} billing=${isTokenBilling}`)
 
   return {
     baseUrl: `${baseUrl}/v1`,
     headers,
     providerHint: provider,
+    useOpenAICompat: isTokenBilling,
+    stripeModelName: isTokenBilling && options?.model ? toStripeModelName(options.model) : undefined,
   }
 }

--- a/src/utils/oneclawVault.ts
+++ b/src/utils/oneclawVault.ts
@@ -1,0 +1,88 @@
+import { logForDebugging } from './debug.js'
+import {
+  isOneclawConfigured,
+  loadOneclawConfig,
+  getSecretPathForProvider,
+  shouldSkipVaultForProvider,
+  PROVIDER_TO_SECRET_PATH,
+} from './oneclaw.js'
+import { getAuthenticatedAgentClient } from './oneclawClient.js'
+
+const resolvedCache = new Map<string, string | null>()
+let initialized = false
+
+export async function resolveProviderKeyFromVault(
+  envKey: string,
+): Promise<string | null> {
+  if (shouldSkipVaultForProvider(envKey)) return null
+
+  if (resolvedCache.has(envKey)) {
+    return resolvedCache.get(envKey) ?? null
+  }
+
+  const client = await getAuthenticatedAgentClient()
+  if (!client) return null
+
+  const config = loadOneclawConfig()
+  if (!config?.vaultId) return null
+
+  const secretPath = getSecretPathForProvider(envKey)
+
+  try {
+    const res = await client.secrets.get(config.vaultId, secretPath)
+    if (res.error) {
+      logForDebugging(`1claw vault: ${envKey} not found at ${secretPath}`)
+      resolvedCache.set(envKey, null)
+      return null
+    }
+    const value = res.data?.value ?? null
+    resolvedCache.set(envKey, value)
+    return value
+  } catch (err) {
+    logForDebugging(`1claw vault: error resolving ${envKey}: ${err}`)
+    resolvedCache.set(envKey, null)
+    return null
+  }
+}
+
+export async function populateEnvFromVault(): Promise<number> {
+  if (initialized) return 0
+  if (!isOneclawConfigured()) return 0
+
+  const config = loadOneclawConfig()
+  if (!config?.vaultId) return 0
+
+  const client = await getAuthenticatedAgentClient()
+  if (!client) return 0
+
+  let count = 0
+
+  for (const [envKey, secretPath] of Object.entries(PROVIDER_TO_SECRET_PATH)) {
+    if (process.env[envKey]) continue
+    if (shouldSkipVaultForProvider(envKey)) continue
+
+    try {
+      const res = await client.secrets.get(config.vaultId, secretPath)
+      if (!res.error && res.data?.value) {
+        process.env[envKey] = res.data.value
+        resolvedCache.set(envKey, res.data.value)
+        count++
+        logForDebugging(`1claw vault: loaded ${envKey} from vault`)
+      }
+    } catch {
+      // Non-fatal -- key may not exist in vault
+    }
+  }
+
+  initialized = true
+  return count
+}
+
+export function clearVaultCache(): void {
+  resolvedCache.clear()
+  initialized = false
+}
+
+export function isVaultKeyResolutionAvailable(): boolean {
+  return isOneclawConfigured()
+}

--- a/src/utils/oneclawVault.ts
+++ b/src/utils/oneclawVault.ts
@@ -57,12 +57,13 @@ export async function populateEnvFromVault(): Promise<number> {
 
   let count = 0
 
-  for (const [envKey, secretPath] of Object.entries(PROVIDER_TO_SECRET_PATH)) {
+  for (const envKey of Object.keys(PROVIDER_TO_SECRET_PATH)) {
     if (process.env[envKey]) continue
     if (shouldSkipVaultForProvider(envKey)) continue
 
     try {
-      const res = await client.secrets.get(config.vaultId, secretPath)
+      const resolvedPath = getSecretPathForProvider(envKey)
+      const res = await client.secrets.get(config.vaultId, resolvedPath)
       if (!res.error && res.data?.value) {
         process.env[envKey] = res.data.value
         resolvedCache.set(envKey, res.data.value)


### PR DESCRIPTION
## Summary

Adds three model-callable tools for on-chain transaction management via 1claw Intents API, enabling the AI agent to submit, sign, and simulate blockchain transactions with policy guardrails.

- **`OneclawSubmitTransactionTool`**: Submit raw transaction intents with chain/to/value/data
- **`OneclawSignTransactionTool`**: Sign approved intents using 1claw's HSM-backed keys
- **`OneclawSimulateTransactionTool`**: Dry-run transactions before signing

### Extension/plugin pattern

Tools are **conditionally loaded** — they only register when 1claw is configured (`isOneclawConfigured()` returns true). This follows the same pattern as `MonitorTool`, `WorkflowTool`, and other optional tools:

\`\`\`typescript
const OneclawIntentsTools = (() => {
  try {
    const { isOneclawConfigured } = require('./utils/oneclaw.js')
    if (!isOneclawConfigured()) return []
    return [SubmitTool, SignTool, SimulateTool]
  } catch { return [] }
})()
\`\`\`

**Zero tool registration for non-1claw users** — the tools don't even load.

### Impact on existing code

- `tools.ts`: Replaces static import with conditional `require()` pattern (+11 lines, -8 lines)
- New files: `src/tools/OneclawIntentsTool/` (3 files, ~340 lines)

> Depends on #1310 (1claw Shroud integration)

## Test plan

- [ ] Without 1claw configured → verify Intents tools do not appear in tool list
- [ ] With 1claw configured → verify 3 Intents tools appear
- [ ] Submit a test transaction intent → verify it calls the Intents API
- [ ] Simulate a transaction → verify dry-run response


Made with [Cursor](https://cursor.com)