### PR TITLE
Fix Gitlawb Opengateway 401 issue

### DIFF
--- a/src/integrations/gateways/gitlawb-opengateway.ts
+++ b/src/integrations/gateways/gitlawb-opengateway.ts
@@ -9,22 +9,25 @@ export default defineGateway({
   supportsModelRouting: true,
   vendorId: 'openai',
   setup: {
-    requiresAuth: false,
-    authMode: 'none',
+    requiresAuth: true,
+    authMode: 'api-key',
+    credentialEnvVars: ['GITLAWB_API_KEY'],
   },
   validation: {
     kind: 'credential-env',
-    credentialEnvVars: [],
+    credentialEnvVars: ['GITLAWB_API_KEY', 'OPENAI_API_KEY'],
     routing: {
       matchBaseUrlHosts: ['opengateway.gitlawb.com', 'opengateway.fly.dev'],
     },
+    missingCredentialMessage:
+      'Set GITLAWB_API_KEY or OPENAI_API_KEY for the Gitlawb Opengateway provider.',
   },
   transportConfig: {
     kind: 'openai-compatible',
     openaiShim: {
       defaultAuthHeader: {
-        name: 'api-key',
-        scheme: 'raw',
+        name: 'Authorization',
+        scheme: 'bearer',
       },
       maxTokensField: 'max_completion_tokens',
       removeBodyFields: ['store', 'stream_options'],
@@ -38,6 +41,7 @@ export default defineGateway({
     label: 'Gitlawb Opengateway',
     name: 'Gitlawb Opengateway',
     vendorId: 'openai',
+    apiKeyEnvVars: ['GITLAWB_API_KEY'],
     modelEnvVars: ['OPENAI_MODEL'],
     baseUrlEnvVars: ['OPENGATEWAY_BASE_URL', 'OPENAI_BASE_URL'],
     fallbackBaseUrl: 'https://opengateway.gitlawb.com/v1',

--- a/src/integrations/generated/integrationArtifacts.generated.ts
+++ b/src/integrations/generated/integrationArtifacts.generated.ts
@@ -77,6 +77,9 @@ export const PROVIDER_PRESET_MANIFEST = [
     "description": "Gitlawb Opengateway — free hosted Xiaomi MiMo + GMI Cloud partner models",
     "label": "Gitlawb Opengateway",
     "name": "Gitlawb Opengateway",
+    "apiKeyEnvVars": [
+      "GITLAWB_API_KEY"
+    ],
     "baseUrlEnvVars": [
       "OPENGATEWAY_BASE_URL",
       "OPENAI_BASE_URL"

--- a/src/services/api/openaiShim.test.ts
+++ b/src/services/api/openaiShim.test.ts
@@ -2070,6 +2070,59 @@ test('xiaomi mimo route uses api-key auth header and max_completion_tokens', asy
   expect(capturedBody).not.toHaveProperty('max_tokens')
 })
 
+test('gitlawb opengateway route uses bearer auth and max_completion_tokens', async () => {
+  let capturedHeaders: Record<string, string> | undefined
+  let capturedBody: Record<string, unknown> | undefined
+
+  process.env.CLAUDE_CODE_USE_OPENAI = '1'
+  process.env.OPENAI_BASE_URL = 'https://opengateway.gitlawb.com/v1'
+  process.env.OPENAI_MODEL = 'mimo-v2.5-pro'
+  process.env.GITLAWB_API_KEY = 'gitlawb-live-key'
+  delete process.env.OPENAI_API_KEY
+
+  globalThis.fetch = (async (_input, init) => {
+    capturedHeaders = init?.headers as Record<string, string>
+    capturedBody = JSON.parse(String(init?.body)) as Record<string, unknown>
+
+    return new Response(
+      JSON.stringify({
+        id: 'chatcmpl-opengateway',
+        model: 'mimo-v2.5-pro',
+        choices: [
+          {
+            message: {
+              role: 'assistant',
+              content: 'ok',
+            },
+            finish_reason: 'stop',
+          },
+        ],
+      }),
+      {
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      },
+    )
+  }) as FetchType
+
+  const client = createOpenAIShimClient({}) as OpenAIShimClient
+
+  await client.beta.messages.create({
+    model: 'mimo-v2.5-pro',
+    messages: [{ role: 'user', content: 'hello' }],
+    max_tokens: 32,
+    stream: false,
+  })
+
+  expect(capturedHeaders).toMatchObject({
+    Authorization: 'Bearer gitlawb-live-key',
+  })
+  expect(capturedHeaders).not.toHaveProperty('api-key')
+  expect(capturedBody).toMatchObject({ max_completion_tokens: 32 })
+  expect(capturedBody).not.toHaveProperty('max_tokens')
+})
+
 test('does not use BNKR_API_KEY for non-Bankr OpenAI-compatible routes', async () => {
   let capturedAuthorization: string | null = null
 

--- a/src/utils/providerProfile.ts
+++ b/src/utils/providerProfile.ts
@@ -93,6 +93,7 @@ const PROFILE_ENV_KEYS = [
   'XAI_API_KEY',
   'VENICE_API_KEY',
   'MIMO_API_KEY',
+  'GITLAWB_API_KEY',
 ] as const
 
 export type CompatibilityProfileMode =
@@ -117,6 +118,7 @@ const SECRET_ENV_KEYS = [
   'XAI_API_KEY',
   'VENICE_API_KEY',
   'MIMO_API_KEY',
+  'GITLAWB_API_KEY',
 ] as const
 
 export type ProviderProfile =
@@ -173,6 +175,7 @@ export type ProfileEnv = {
   XAI_API_KEY?: string
   VENICE_API_KEY?: string
   MIMO_API_KEY?: string
+  GITLAWB_API_KEY?: string
 }
 
 export type ProfileFile = {
@@ -194,7 +197,8 @@ type SecretValueSource = Partial<
     | 'BNKR_API_KEY'
     | 'XAI_API_KEY'
     | 'VENICE_API_KEY'
-    | 'MIMO_API_KEY',
+    | 'MIMO_API_KEY'
+    | 'GITLAWB_API_KEY',
     string | undefined
   >
 >

--- a/src/utils/providerProfiles.ts
+++ b/src/utils/providerProfiles.ts
@@ -666,6 +666,9 @@ export function applyProviderProfileToProcessEnv(profile: ProviderProfile): void
       if (route.routeId === 'xiaomi-mimo' || profile.baseUrl.toLowerCase().includes('api.xiaomimimo.com') || profile.baseUrl.toLowerCase().includes('api.mimo-v2.com')) {
         openAIProfileEnv.MIMO_API_KEY = profile.apiKey
       }
+      if (route.routeId === 'gitlawb-opengateway' || profile.baseUrl.toLowerCase().includes('opengateway.gitlawb.com') || profile.baseUrl.toLowerCase().includes('opengateway.fly.dev')) {
+        openAIProfileEnv.GITLAWB_API_KEY = profile.apiKey
+      }
     }
     if (route.gatewayId === 'nvidia-nim') {
       openAIProfileEnv.NVIDIA_NIM = '1'

--- a/src/utils/providerValidation.test.ts
+++ b/src/utils/providerValidation.test.ts
@@ -244,17 +244,21 @@ test('xiaomi mimo validation accepts MIMO_API_KEY without OPENAI_API_KEY', async
   await expect(getProviderValidationError(process.env)).resolves.toBeNull()
 })
 
-test('opengateway validation allows no-auth access without OPENAI_API_KEY', async () => {
+test('opengateway validation reports missing auth without a gateway key', async () => {
   process.env.CLAUDE_CODE_USE_OPENAI = '1'
   process.env.OPENAI_BASE_URL = 'https://opengateway.gitlawb.com/v1'
+  delete process.env.GITLAWB_API_KEY
   delete process.env.OPENAI_API_KEY
 
-  await expect(getProviderValidationError(process.env)).resolves.toBeNull()
+  await expect(getProviderValidationError(process.env)).resolves.toBe(
+    'Set GITLAWB_API_KEY or OPENAI_API_KEY for the Gitlawb Opengateway provider.',
+  )
 })
 
-test('opengateway validation allows no-auth access with model-specific path', async () => {
+test('opengateway validation accepts GITLAWB_API_KEY with model-specific path', async () => {
   process.env.CLAUDE_CODE_USE_OPENAI = '1'
   process.env.OPENAI_BASE_URL = 'https://opengateway.gitlawb.com/v1/xiaomi-mimo'
+  process.env.GITLAWB_API_KEY = 'gitlawb-live-key'
   delete process.env.OPENAI_API_KEY
 
   await expect(getProviderValidationError(process.env)).resolves.toBeNull()


### PR DESCRIPTION
## Summary

- what changed
  - Changed Gitlawb Opengateway from no-auth setup to required API key setup.
  - Added `GITLAWB_API_KEY` as the provider-specific credential env var.
  - Updated OpenGateway requests to use `Authorization: Bearer <key>`.
  - Added profile/env handling so saved OpenGateway provider profiles populate `GITLAWB_API_KEY`.
  - Regenerated integration preset artifacts.
  - Added focused tests for OpenGateway auth headers and validation behavior.

- why it changed
  - Gitlawb Opengateway now requires an API key, and requests without the correct bearer auth header return `401 api_key_required`.
  
## Screenshot

- Before
<img width="1920" height="975" alt="596915605-91a02f36-3cf7-495b-8683-776be17ab99e" src="https://github.com/user-attachments/assets/82bfad39-3d83-43c1-9595-d4de17d007c3" />

- After
<img width="1487" height="897" alt="image" src="https://github.com/user-attachments/assets/f5890388-0f86-44d8-84ab-7a3dec43da8f" />




## Impact

- user-facing impact:
  - OpenGateway users can authenticate with `GITLAWB_API_KEY` or fallback `OPENAI_API_KEY`.
  - Missing OpenGateway credentials now show a provider-specific validation message.

- developer/maintainer impact:
  - OpenGateway auth behavior is descriptor-backed and covered by focused tests.
  - Provider profile env handling now includes `GITLAWB_API_KEY` as a tracked secret/env key.

## Testing

- [x] `bun run build`
- [x] `bun run smoke`
- [x] focused tests:
  - `bun test src/services/api/openaiShim.test.ts src/utils/providerValidation.test.ts`

## Notes

- provider/model path tested:
  - `https://opengateway.gitlawb.com/v1`
  - `https://opengateway.gitlawb.com/v1/xiaomi-mimo`
  - `mimo-v2.5-pro`
  - `GITLAWB_API_KEY`