### PR TITLE
Fix gitlawb-opengateway provider configuration to require and support…

### DIFF
--- a/src/integrations/gateways/gitlawb-opengateway.ts
+++ b/src/integrations/gateways/gitlawb-opengateway.ts
@@ -9,12 +9,14 @@ export default defineGateway({
   supportsModelRouting: true,
   vendorId: 'openai',
   setup: {
-    requiresAuth: false,
-    authMode: 'none',
+    requiresAuth: true,
+    authMode: 'api-key',
+    credentialEnvVars: ['OPENAI_API_KEY'],
   },
   validation: {
     kind: 'credential-env',
-    credentialEnvVars: [],
+    credentialEnvVars: ['OPENAI_API_KEY'],
+    missingCredentialMessage: 'Gitlawb Opengateway auth is required. Set OPENAI_API_KEY.',
     routing: {
       matchBaseUrlHosts: ['opengateway.gitlawb.com', 'opengateway.fly.dev'],
     },
@@ -22,14 +24,10 @@ export default defineGateway({
   transportConfig: {
     kind: 'openai-compatible',
     openaiShim: {
-      defaultAuthHeader: {
-        name: 'api-key',
-        scheme: 'raw',
-      },
       maxTokensField: 'max_completion_tokens',
       removeBodyFields: ['store', 'stream_options'],
       supportsApiFormatSelection: false,
-      supportsAuthHeaders: false,
+      supportsAuthHeaders: true,
     },
   },
   preset: {
@@ -37,6 +35,7 @@ export default defineGateway({
     description: 'Gitlawb Opengateway — free hosted Xiaomi MiMo + GMI Cloud partner models',
     label: 'Gitlawb Opengateway',
     name: 'Gitlawb Opengateway',
+    apiKeyEnvVars: ['OPENAI_API_KEY'],
     vendorId: 'openai',
     modelEnvVars: ['OPENAI_MODEL'],
     baseUrlEnvVars: ['OPENGATEWAY_BASE_URL', 'OPENAI_BASE_URL'],


### PR DESCRIPTION
## Summary
- **what changed**: 
  - Updated the `gitlawb-opengateway` definition in `src/integrations/gateways/gitlawb-opengateway.ts` to require authentication (`requiresAuth: true`, `authMode: 'api-key'`, `credentialEnvVars: ['OPENAI_API_KEY']`).
  - Added validation checks requiring `OPENAI_API_KEY` for hosts matching `opengateway.gitlawb.com`.
  - Removed the default raw `api-key` header format in `openaiShim` and set `supportsAuthHeaders: true` to fall back to the standard `Authorization: Bearer <key>` header scheme.
  - Added `apiKeyEnvVars: ['OPENAI_API_KEY']` to the preset.
- **why it changed**:
  - The previous preset assumed a public, credential-free gateway and raw `api-key` scheme, which failed with 401 errors. Gitlawb Opengateway requires standard Bearer token authentication.
## Impact
- **user-facing impact**: Users can now natively select, authenticate, and run OpenClaude through the Gitlawb Opengateway using their gateway API key.
- **developer/maintainer impact**: Aligns Gitlawb Opengateway with the standard OpenAI-compatible gateway setup pattern in the codebase.
## Testing
- [x] `bun run build` (verified output compatibility in `dist/`)
- [ ] `bun run smoke`
- [x] **focused tests**: Verified connection validation and diagnostic initialization using `openclaude doctor` with active `gitlawb-opengateway` profile.
## Notes
- **provider/model path tested**: `gitlawb-opengateway` / `mimo-v2.5-pro`
- **screenshots attached (if UI changed)**: N/A
- **follow-up work or known limitations**: N/A