### PR TITLE
feat(opengateway): require API key on /v1/* and switch to bearer auth

### DIFF
--- a/src/integrations/gateways/gitlawb-opengateway.ts
+++ b/src/integrations/gateways/gitlawb-opengateway.ts
@@ -9,12 +9,19 @@ export default defineGateway({
   supportsModelRouting: true,
   vendorId: 'openai',
   setup: {
-    requiresAuth: false,
-    authMode: 'none',
+    requiresAuth: true,
+    authMode: 'api-key',
+    credentialEnvVars: ['OPENGATEWAY_API_KEY', 'OPENAI_API_KEY'],
   },
   validation: {
     kind: 'credential-env',
-    credentialEnvVars: [],
+    // OPENGATEWAY_API_KEY first so users who set both don't get their generic
+    // OpenAI key sent to opengateway by accident. OPENAI_API_KEY kept as a
+    // fallback because that's where existing openclaude configs already hold it.
+    credentialEnvVars: ['OPENGATEWAY_API_KEY', 'OPENAI_API_KEY'],
+    missingCredentialMessage:
+      'OPENGATEWAY_API_KEY is required to use Gitlawb Opengateway.\n' +
+      'Mint a free API key at https://gitlawb.com/opengateway/keys and set it as OPENGATEWAY_API_KEY (or OPENAI_API_KEY when OPENAI_BASE_URL points at opengateway).',
     routing: {
       matchBaseUrlHosts: ['opengateway.gitlawb.com', 'opengateway.fly.dev'],
     },
@@ -22,9 +29,11 @@ export default defineGateway({
   transportConfig: {
     kind: 'openai-compatible',
     openaiShim: {
+      // Opengateway expects `Authorization: Bearer ogw_live_...`. Previous
+      // `api-key` raw header was a leftover from the direct-Xiaomi era.
       defaultAuthHeader: {
-        name: 'api-key',
-        scheme: 'raw',
+        name: 'authorization',
+        scheme: 'bearer',
       },
       maxTokensField: 'max_completion_tokens',
       removeBodyFields: ['store', 'stream_options'],
@@ -34,7 +43,7 @@ export default defineGateway({
   },
   preset: {
     id: 'gitlawb-opengateway',
-    description: 'Gitlawb Opengateway — free hosted Xiaomi MiMo + GMI Cloud partner models',
+    description: 'Gitlawb Opengateway — free hosted Xiaomi MiMo + GMI Cloud partner models (API key required, mint at https://gitlawb.com/opengateway/keys)',
     label: 'Gitlawb Opengateway',
     name: 'Gitlawb Opengateway',
     vendorId: 'openai',

--- a/src/integrations/generated/integrationArtifacts.generated.ts
+++ b/src/integrations/generated/integrationArtifacts.generated.ts
@@ -74,7 +74,7 @@ export const PROVIDER_PRESET_MANIFEST = [
     "routeId": "gitlawb-opengateway",
     "vendorId": "openai",
     "gatewayId": "gitlawb-opengateway",
-    "description": "Gitlawb Opengateway — free hosted Xiaomi MiMo + GMI Cloud partner models",
+    "description": "Gitlawb Opengateway — free hosted Xiaomi MiMo + GMI Cloud partner models (API key required, mint at https://gitlawb.com/opengateway/keys)",
     "label": "Gitlawb Opengateway",
     "name": "Gitlawb Opengateway",
     "baseUrlEnvVars": [

--- a/src/utils/providerAutoDetect.test.ts
+++ b/src/utils/providerAutoDetect.test.ts
@@ -273,7 +273,7 @@ describe('detectBestProvider — orchestrator', () => {
     expect(result?.kind).toBe('ollama')
   })
 
-  test('skipLocal prevents network probes and falls back to opengateway', async () => {
+  test('skipLocal + OPENGATEWAY_API_KEY falls back to opengateway without probing', async () => {
     let probeCalled = false
     const fetchImpl = (async () => {
       probeCalled = true
@@ -281,7 +281,7 @@ describe('detectBestProvider — orchestrator', () => {
     }) as typeof fetch
 
     const result = await detectBestProvider({
-      env: {},
+      env: { OPENGATEWAY_API_KEY: 'ogw_live_test_0000000000000000' },
       fetchImpl,
       skipLocal: true,
       hasCodexAuth: () => false,
@@ -291,7 +291,7 @@ describe('detectBestProvider — orchestrator', () => {
     expect(probeCalled).toBe(false)
   })
 
-  test('completely empty environment falls back to Gitlawb Opengateway', async () => {
+  test('completely empty environment returns null (opengateway needs an API key)', async () => {
     const fetchImpl = (async () => {
       throw new Error('nothing reachable')
     }) as typeof fetch
@@ -302,9 +302,9 @@ describe('detectBestProvider — orchestrator', () => {
       timeoutMs: 100,
       hasCodexAuth: () => false,
     })
-    expect(result?.kind).toBe('gitlawb-opengateway')
-    expect(result?.baseUrl).toBe('https://opengateway.gitlawb.com/v1')
-    expect(result?.model).toBe('mimo-v2.5-pro')
+    // As of 2026-05-22 opengateway requires a key; with no credentials in env
+    // we no longer auto-select it — the caller surfaces a setup prompt instead.
+    expect(result).toBeNull()
   })
 
   test('OPENGATEWAY_BASE_URL env overrides the opengateway fallback base URL', async () => {
@@ -313,7 +313,10 @@ describe('detectBestProvider — orchestrator', () => {
     }) as typeof fetch
 
     const result = await detectBestProvider({
-      env: { OPENGATEWAY_BASE_URL: 'http://localhost:8181/v1/xiaomi-mimo' },
+      env: {
+        OPENGATEWAY_API_KEY: 'ogw_live_test_0000000000000000',
+        OPENGATEWAY_BASE_URL: 'http://localhost:8181/v1/xiaomi-mimo',
+      },
       fetchImpl,
       timeoutMs: 100,
       hasCodexAuth: () => false,
@@ -328,7 +331,10 @@ describe('detectBestProvider — orchestrator', () => {
     }) as typeof fetch
 
     const result = await detectBestProvider({
-      env: { OPENGATEWAY_BASE_URL: 'https://opengateway.gitlawb.com/v1/xiaomi-mimo' },
+      env: {
+        OPENGATEWAY_API_KEY: 'ogw_live_test_0000000000000000',
+        OPENGATEWAY_BASE_URL: 'https://opengateway.gitlawb.com/v1/xiaomi-mimo',
+      },
       fetchImpl,
       timeoutMs: 100,
       hasCodexAuth: () => false,

--- a/src/utils/providerAutoDetect.ts
+++ b/src/utils/providerAutoDetect.ts
@@ -292,18 +292,25 @@ function normalizeOpengatewayBaseUrl(baseUrl: string): string {
 }
 
 /**
- * Zero-config fallback: the Gitlawb Opengateway exposes free partner inference
- * through a smart OpenAI-compatible route without requiring any API key. This
- * is the default any fresh install lands on when no credentials or local
- * services exist.
+ * Fallback: the Gitlawb Opengateway exposes free partner inference through a
+ * smart OpenAI-compatible route. As of 2026-05-22 it requires a per-user API
+ * key (mint at https://gitlawb.com/opengateway/keys); without a key we return
+ * null so the caller surfaces the missing-credential prompt instead of
+ * silently routing to an endpoint that will 401.
  */
-function defaultOpengatewayProvider(env: EnvLike): DetectedProvider {
+function defaultOpengatewayProvider(env: EnvLike): DetectedProvider | null {
+  const hasKey =
+    (typeof env.OPENGATEWAY_API_KEY === 'string' && env.OPENGATEWAY_API_KEY.trim().length > 0) ||
+    (typeof env.OPENAI_API_KEY === 'string' && env.OPENAI_API_KEY.trim().length > 0)
+  if (!hasKey) return null
+
   const baseUrl =
     (typeof env.OPENGATEWAY_BASE_URL === 'string' && env.OPENGATEWAY_BASE_URL.trim()) ||
     OPENGATEWAY_DEFAULT_BASE_URL
   return {
     kind: 'gitlawb-opengateway',
-    source: 'Gitlawb Opengateway (free partner models — no key required)',
+    source:
+      'Gitlawb Opengateway (free partner models — API key required, mint at https://gitlawb.com/opengateway/keys)',
     baseUrl: normalizeOpengatewayBaseUrl(baseUrl),
     model: OPENGATEWAY_DEFAULT_MODEL,
   }

--- a/src/utils/providerValidation.test.ts
+++ b/src/utils/providerValidation.test.ts
@@ -244,20 +244,44 @@ test('xiaomi mimo validation accepts MIMO_API_KEY without OPENAI_API_KEY', async
   await expect(getProviderValidationError(process.env)).resolves.toBeNull()
 })
 
-test('opengateway validation allows no-auth access without OPENAI_API_KEY', async () => {
+test('opengateway validation fails without OPENGATEWAY_API_KEY or OPENAI_API_KEY', async () => {
   process.env.CLAUDE_CODE_USE_OPENAI = '1'
   process.env.OPENAI_BASE_URL = 'https://opengateway.gitlawb.com/v1'
+  delete process.env.OPENAI_API_KEY
+  delete process.env.OPENGATEWAY_API_KEY
+
+  const error = await getProviderValidationError(process.env)
+  expect(error).not.toBeNull()
+  expect(error!).toContain('OPENGATEWAY_API_KEY')
+})
+
+test('opengateway validation passes when OPENGATEWAY_API_KEY is set', async () => {
+  process.env.CLAUDE_CODE_USE_OPENAI = '1'
+  process.env.OPENAI_BASE_URL = 'https://opengateway.gitlawb.com/v1'
+  process.env.OPENGATEWAY_API_KEY = 'ogw_live_test_0000000000000000'
   delete process.env.OPENAI_API_KEY
 
   await expect(getProviderValidationError(process.env)).resolves.toBeNull()
 })
 
-test('opengateway validation allows no-auth access with model-specific path', async () => {
+test('opengateway validation accepts OPENAI_API_KEY as fallback', async () => {
+  process.env.CLAUDE_CODE_USE_OPENAI = '1'
+  process.env.OPENAI_BASE_URL = 'https://opengateway.gitlawb.com/v1'
+  process.env.OPENAI_API_KEY = 'ogw_live_test_0000000000000000'
+  delete process.env.OPENGATEWAY_API_KEY
+
+  await expect(getProviderValidationError(process.env)).resolves.toBeNull()
+})
+
+test('opengateway validation still requires a key on the model-specific path', async () => {
   process.env.CLAUDE_CODE_USE_OPENAI = '1'
   process.env.OPENAI_BASE_URL = 'https://opengateway.gitlawb.com/v1/xiaomi-mimo'
   delete process.env.OPENAI_API_KEY
+  delete process.env.OPENGATEWAY_API_KEY
 
-  await expect(getProviderValidationError(process.env)).resolves.toBeNull()
+  const error = await getProviderValidationError(process.env)
+  expect(error).not.toBeNull()
+  expect(error!).toContain('OPENGATEWAY_API_KEY')
 })
 
 test('github validation stays descriptor-selected and reports missing auth', async () => {


### PR DESCRIPTION
Opengateway flipped from zero-auth to per-user API keys (mint at https://gitlawb.com/opengateway/keys). Update the client to match:

- Descriptor: setup.requiresAuth=true, authMode='api-key', credentialEnvVars=['OPENGATEWAY_API_KEY','OPENAI_API_KEY'] in both setup (used by the generator + auth-prompt) and validation (used by getProviderValidationError). Added missingCredentialMessage pointing users at the console URL.
- Transport: defaultAuthHeader changed from {name:'api-key',scheme:'raw'} to {name:'authorization',scheme:'bearer'} — the gateway only validates Authorization: Bearer ogw_live_..., the previous raw 'api-key' header was a leftover from the direct-Xiaomi era.
- Auto-detect: defaultOpengatewayProvider now returns null when no key env var is set instead of unconditionally selecting opengateway — surfaces the missing-credential prompt instead of silently routing to an endpoint that will 401.
- Tests: providerValidation.test.ts no-auth tests replaced with positive/negative key cases; providerAutoDetect.test.ts updated four fallback tests to include OPENGATEWAY_API_KEY (or assert null for the empty-env case).
- Regenerated integrationArtifacts.generated.ts via integrations:generate.
