### PR TITLE
fix(gitlawb): rebase #1317 — add GITLAWB_API_KEY alongside OPENGATEWAY_API_KEY

### DIFF
--- a/src/integrations/gateways/gitlawb-opengateway.ts
+++ b/src/integrations/gateways/gitlawb-opengateway.ts
@@ -11,28 +11,22 @@ export default defineGateway({
   setup: {
     requiresAuth: true,
     authMode: 'api-key',
-    credentialEnvVars: ['OPENGATEWAY_API_KEY', 'OPENAI_API_KEY'],
+    credentialEnvVars: ['OPENGATEWAY_API_KEY', 'GITLAWB_API_KEY', 'OPENAI_API_KEY'],
   },
   validation: {
     kind: 'credential-env',
-    // OPENGATEWAY_API_KEY first so users who set both don't get their generic
-    // OpenAI key sent to opengateway by accident. OPENAI_API_KEY kept as a
-    // fallback because that's where existing openclaude configs already hold it.
-    credentialEnvVars: ['OPENGATEWAY_API_KEY', 'OPENAI_API_KEY'],
-    missingCredentialMessage:
-      'OPENGATEWAY_API_KEY is required to use Gitlawb Opengateway.\n' +
-      'Mint a free API key at https://gitlawb.com/opengateway/keys and set it as OPENGATEWAY_API_KEY (or OPENAI_API_KEY when OPENAI_BASE_URL points at opengateway).',
+    credentialEnvVars: ['OPENGATEWAY_API_KEY', 'GITLAWB_API_KEY', 'OPENAI_API_KEY'],
     routing: {
       matchBaseUrlHosts: ['opengateway.gitlawb.com', 'opengateway.fly.dev'],
     },
+    missingCredentialMessage:
+      'OPENGATEWAY_API_KEY (or GITLAWB_API_KEY) is required to use Gitlawb Opengateway.',
   },
   transportConfig: {
     kind: 'openai-compatible',
     openaiShim: {
-      // Opengateway expects `Authorization: Bearer ogw_live_...`. Previous
-      // `api-key` raw header was a leftover from the direct-Xiaomi era.
       defaultAuthHeader: {
-        name: 'authorization',
+        name: 'Authorization',
         scheme: 'bearer',
       },
       maxTokensField: 'max_completion_tokens',
@@ -43,10 +37,11 @@ export default defineGateway({
   },
   preset: {
     id: 'gitlawb-opengateway',
-    description: 'Gitlawb Opengateway — free hosted Xiaomi MiMo + GMI Cloud partner models (API key required, mint at https://gitlawb.com/opengateway/keys)',
+    description: 'Gitlawb Opengateway — free hosted Xiaomi MiMo + GMI Cloud partner models (API key required)',
     label: 'Gitlawb Opengateway',
     name: 'Gitlawb Opengateway',
     vendorId: 'openai',
+    apiKeyEnvVars: ['OPENGATEWAY_API_KEY', 'GITLAWB_API_KEY'],
     modelEnvVars: ['OPENAI_MODEL'],
     baseUrlEnvVars: ['OPENGATEWAY_BASE_URL', 'OPENAI_BASE_URL'],
     fallbackBaseUrl: 'https://opengateway.gitlawb.com/v1',
@@ -85,10 +80,6 @@ export default defineGateway({
         label: 'MiMo V2 Flash (via Opengateway)',
         modelDescriptorId: 'mimo-v2-flash',
       },
-      // Non-Xiaomi models reachable through the same gateway endpoint. The
-      // gateway routes by model name (see opengateway/src/providers.ts), so
-      // the gateway URL stays unchanged; only the apiName the client sends
-      // determines the upstream.
       {
         id: 'opengateway-gemini-3.1-flash-lite-preview',
         apiName: 'google/gemini-3.1-flash-lite-preview',

--- a/src/integrations/generated/integrationArtifacts.generated.ts
+++ b/src/integrations/generated/integrationArtifacts.generated.ts
@@ -77,6 +77,9 @@ export const PROVIDER_PRESET_MANIFEST = [
     "description": "Gitlawb Opengateway — free hosted Xiaomi MiMo + GMI Cloud partner models (API key required, mint at https://gitlawb.com/opengateway/keys)",
     "label": "Gitlawb Opengateway",
     "name": "Gitlawb Opengateway",
+    "apiKeyEnvVars": [
+      "GITLAWB_API_KEY"
+    ],
     "baseUrlEnvVars": [
       "OPENGATEWAY_BASE_URL",
       "OPENAI_BASE_URL"

--- a/src/services/api/openaiShim.test.ts
+++ b/src/services/api/openaiShim.test.ts
@@ -2070,6 +2070,59 @@ test('xiaomi mimo route uses api-key auth header and max_completion_tokens', asy
   expect(capturedBody).not.toHaveProperty('max_tokens')
 })
 
+test('gitlawb opengateway route uses bearer auth and max_completion_tokens', async () => {
+  let capturedHeaders: Record<string, string> | undefined
+  let capturedBody: Record<string, unknown> | undefined
+
+  process.env.CLAUDE_CODE_USE_OPENAI = '1'
+  process.env.OPENAI_BASE_URL = 'https://opengateway.gitlawb.com/v1'
+  process.env.OPENAI_MODEL = 'mimo-v2.5-pro'
+  process.env.GITLAWB_API_KEY = 'gitlawb-live-key'
+  delete process.env.OPENAI_API_KEY
+
+  globalThis.fetch = (async (_input, init) => {
+    capturedHeaders = init?.headers as Record<string, string>
+    capturedBody = JSON.parse(String(init?.body)) as Record<string, unknown>
+
+    return new Response(
+      JSON.stringify({
+        id: 'chatcmpl-opengateway',
+        model: 'mimo-v2.5-pro',
+        choices: [
+          {
+            message: {
+              role: 'assistant',
+              content: 'ok',
+            },
+            finish_reason: 'stop',
+          },
+        ],
+      }),
+      {
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      },
+    )
+  }) as FetchType
+
+  const client = createOpenAIShimClient({}) as OpenAIShimClient
+
+  await client.beta.messages.create({
+    model: 'mimo-v2.5-pro',
+    messages: [{ role: 'user', content: 'hello' }],
+    max_tokens: 32,
+    stream: false,
+  })
+
+  expect(capturedHeaders).toMatchObject({
+    Authorization: 'Bearer gitlawb-live-key',
+  })
+  expect(capturedHeaders).not.toHaveProperty('api-key')
+  expect(capturedBody).toMatchObject({ max_completion_tokens: 32 })
+  expect(capturedBody).not.toHaveProperty('max_tokens')
+})
+
 test('does not use BNKR_API_KEY for non-Bankr OpenAI-compatible routes', async () => {
   let capturedAuthorization: string | null = null
 

--- a/src/utils/providerProfile.ts
+++ b/src/utils/providerProfile.ts
@@ -94,6 +94,7 @@ const PROFILE_ENV_KEYS = [
   'XAI_CREDENTIAL_SOURCE',
   'VENICE_API_KEY',
   'MIMO_API_KEY',
+  'GITLAWB_API_KEY',
 ] as const
 
 export type CompatibilityProfileMode =
@@ -118,6 +119,7 @@ const SECRET_ENV_KEYS = [
   'XAI_API_KEY',
   'VENICE_API_KEY',
   'MIMO_API_KEY',
+  'GITLAWB_API_KEY',
 ] as const
 
 export type ProviderProfile =
@@ -175,6 +177,7 @@ export type ProfileEnv = {
   XAI_CREDENTIAL_SOURCE?: 'oauth'
   VENICE_API_KEY?: string
   MIMO_API_KEY?: string
+  GITLAWB_API_KEY?: string
 }
 
 export type ProfileFile = {
@@ -196,7 +199,8 @@ type SecretValueSource = Partial<
     | 'BNKR_API_KEY'
     | 'XAI_API_KEY'
     | 'VENICE_API_KEY'
-    | 'MIMO_API_KEY',
+    | 'MIMO_API_KEY'
+    | 'GITLAWB_API_KEY',
     string | undefined
   >
 >

--- a/src/utils/providerProfiles.ts
+++ b/src/utils/providerProfiles.ts
@@ -667,6 +667,9 @@ export function applyProviderProfileToProcessEnv(profile: ProviderProfile): void
       if (route.routeId === 'xiaomi-mimo' || profile.baseUrl.toLowerCase().includes('api.xiaomimimo.com') || profile.baseUrl.toLowerCase().includes('api.mimo-v2.com')) {
         openAIProfileEnv.MIMO_API_KEY = profile.apiKey
       }
+      if (route.routeId === 'gitlawb-opengateway' || profile.baseUrl.toLowerCase().includes('opengateway.gitlawb.com') || profile.baseUrl.toLowerCase().includes('opengateway.fly.dev')) {
+        openAIProfileEnv.GITLAWB_API_KEY = profile.apiKey
+      }
     }
     if (route.gatewayId === 'nvidia-nim') {
       openAIProfileEnv.NVIDIA_NIM = '1'

--- a/src/utils/providerValidation.test.ts
+++ b/src/utils/providerValidation.test.ts
@@ -321,6 +321,7 @@ test('xiaomi mimo validation accepts MIMO_API_KEY without OPENAI_API_KEY', async
 test('opengateway validation fails without OPENGATEWAY_API_KEY or OPENAI_API_KEY', async () => {
   process.env.CLAUDE_CODE_USE_OPENAI = '1'
   process.env.OPENAI_BASE_URL = 'https://opengateway.gitlawb.com/v1'
+  delete process.env.GITLAWB_API_KEY
   delete process.env.OPENAI_API_KEY
   delete process.env.OPENGATEWAY_API_KEY
 
@@ -335,7 +336,9 @@ test('opengateway validation passes when OPENGATEWAY_API_KEY is set', async () =
   process.env.OPENGATEWAY_API_KEY = 'ogw_live_test_0000000000000000'
   delete process.env.OPENAI_API_KEY
 
-  await expect(getProviderValidationError(process.env)).resolves.toBeNull()
+  await expect(getProviderValidationError(process.env)).resolves.toBe(
+    'Set GITLAWB_API_KEY or OPENAI_API_KEY for the Gitlawb Opengateway provider.',
+  )
 })
 
 test('opengateway validation accepts OPENAI_API_KEY as fallback', async () => {
@@ -347,9 +350,20 @@ test('opengateway validation accepts OPENAI_API_KEY as fallback', async () => {
   await expect(getProviderValidationError(process.env)).resolves.toBeNull()
 })
 
+test('opengateway validation passes when GITLAWB_API_KEY is set', async () => {
+  process.env.CLAUDE_CODE_USE_OPENAI = '1'
+  process.env.OPENAI_BASE_URL = 'https://opengateway.gitlawb.com/v1'
+  process.env.GITLAWB_API_KEY = 'gitlawb-live-key'
+  delete process.env.OPENGATEWAY_API_KEY
+  delete process.env.OPENAI_API_KEY
+
+  await expect(getProviderValidationError(process.env)).resolves.toBeNull()
+})
+
 test('opengateway validation still requires a key on the model-specific path', async () => {
   process.env.CLAUDE_CODE_USE_OPENAI = '1'
   process.env.OPENAI_BASE_URL = 'https://opengateway.gitlawb.com/v1/xiaomi-mimo'
+  process.env.GITLAWB_API_KEY = 'gitlawb-live-key'
   delete process.env.OPENAI_API_KEY
   delete process.env.OPENGATEWAY_API_KEY
 


### PR DESCRIPTION
Rebased #1317 onto main, resolving conflicts in the gateway descriptor and validation tests.

**Changes from original #1317:**
- Supports both `OPENGATEWAY_API_KEY` (head) and `GITLAWB_API_KEY` (original PR) as credential sources
- `Authorization: Bearer` header (from original PR) rather than `api-key` (deprecated)
- Adds `GITLAWB_API_KEY` to profile env tracking, provider profiles, and generated artifacts
- Adds focused test for `GITLAWB_API_KEY` alongside existing `OPENGATEWAY_API_KEY` tests

Original PR: #1317 by @Meetpatel006