### PR TITLE
fix(attribution): make git attribution opt-in by default

### DIFF
--- a/src/commands/commit-message/commit-message.test.ts
+++ b/src/commands/commit-message/commit-message.test.ts
@@ -1,10 +1,31 @@
-import { describe, expect, it } from 'bun:test'
+import { afterEach, describe, expect, it } from 'bun:test'
+import { mkdtempSync, rmSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
 import {
+  getClaudeConfigHomeDir,
+  setClaudeConfigHomeDirForTesting,
+} from '../../utils/envUtils.js'
+import { resetSettingsCache } from '../../utils/settings/settingsCache.js'
+import {
+  call,
   formatCoAuthorTrailer,
   parseCoAuthor,
   stripMatchingQuotes,
   USAGE,
 } from './commit-message.js'
+
+let tempSettingsDir: string | null = null
+
+afterEach(() => {
+  setClaudeConfigHomeDirForTesting(undefined)
+  getClaudeConfigHomeDir.cache?.clear?.()
+  resetSettingsCache()
+  if (tempSettingsDir) {
+    rmSync(tempSettingsDir, { recursive: true, force: true })
+    tempSettingsDir = null
+  }
+})
 
 describe('commit-message command helpers', () => {
   it('parses quoted co-author names with a plain email', () => {
@@ -54,5 +75,16 @@ describe('commit-message command helpers', () => {
       '/commit-message set "Generated with OpenClaude using GPT-5.5"',
     )
     expect(USAGE).not.toContain('/commit-message set-attribution')
+  })
+
+  it('describes default reset as privacy-preserving', async () => {
+    tempSettingsDir = mkdtempSync(join(tmpdir(), 'openclaude-settings-'))
+    setClaudeConfigHomeDirForTesting(tempSettingsDir)
+    getClaudeConfigHomeDir.cache?.clear?.()
+
+    await expect(call('default', {} as never)).resolves.toEqual({
+      type: 'text',
+      value: 'Commit attribution reset to the privacy-preserving default.',
+    })
   })
 })

--- a/src/commands/commit-message/commit-message.ts
+++ b/src/commands/commit-message/commit-message.ts
@@ -138,7 +138,7 @@ export const call: LocalCommandCall = async args => {
       if (error) return { type: 'text', value: error }
       return {
         type: 'text',
-        value: 'Commit attribution reset to the OpenClaude default.',
+        value: 'Commit attribution reset to the privacy-preserving default.',
       }
     }
 

--- a/src/utils/attribution.test.ts
+++ b/src/utils/attribution.test.ts
@@ -1,8 +1,61 @@
-import { describe, expect, it } from 'bun:test'
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
+import { getClientType, setClientType } from '../bootstrap/state.js'
 import {
+  getAttributionTexts,
   getDefaultCommitCoAuthorEmail,
   getDefaultCommitCoAuthorName,
+  getEnhancedPRAttribution,
 } from './attribution.js'
+import {
+  resetSettingsCache,
+  setSessionSettingsCache,
+} from './settings/settingsCache.js'
+import type { SettingsJson } from './settings/types.js'
+
+const originalEnv = {
+  CLAUDE_CODE_USE_OPENAI: process.env.CLAUDE_CODE_USE_OPENAI,
+  OPENAI_MODEL: process.env.OPENAI_MODEL,
+  OPENCLAUDE_DISABLE_CO_AUTHORED_BY:
+    process.env.OPENCLAUDE_DISABLE_CO_AUTHORED_BY,
+  CLAUDE_CODE_REMOTE_SESSION_ID: process.env.CLAUDE_CODE_REMOTE_SESSION_ID,
+  SESSION_INGRESS_URL: process.env.SESSION_INGRESS_URL,
+  USER_TYPE: process.env.USER_TYPE,
+}
+const originalClientType = getClientType()
+
+const defaultPrAttribution =
+  '🤖 Generated with [OpenClaude](https://github.com/Gitlawb/openclaude)'
+
+function useSettings(settings: SettingsJson): void {
+  setSessionSettingsCache({ settings, errors: [] })
+}
+
+function restoreEnv(): void {
+  for (const [key, value] of Object.entries(originalEnv)) {
+    if (value === undefined) {
+      delete process.env[key]
+    } else {
+      process.env[key] = value
+    }
+  }
+}
+
+beforeEach(() => {
+  resetSettingsCache()
+  setClientType('cli')
+  process.env.CLAUDE_CODE_USE_OPENAI = '1'
+  process.env.OPENAI_MODEL = 'gpt-5.5'
+  delete process.env.OPENCLAUDE_DISABLE_CO_AUTHORED_BY
+  delete process.env.CLAUDE_CODE_REMOTE_SESSION_ID
+  delete process.env.SESSION_INGRESS_URL
+  delete process.env.USER_TYPE
+})
+
+afterEach(() => {
+  resetSettingsCache()
+  setClientType(originalClientType)
+  restoreEnv()
+})
 
 describe('getDefaultCommitCoAuthorName', () => {
   it('does not label unknown non-Claude provider models as Opus', () => {
@@ -61,6 +114,134 @@ describe('getDefaultCommitCoAuthorName', () => {
     )
     expect(getDefaultCommitCoAuthorEmail('firstParty')).toBe(
       'openclaude@gitlawb.com',
+    )
+  })
+})
+
+describe('getAttributionTexts', () => {
+  it('returns no commit or PR attribution when no attribution settings are configured', () => {
+    useSettings({})
+
+    expect(getAttributionTexts()).toEqual({ commit: '', pr: '' })
+  })
+
+  it('honors custom commit attribution exactly and keeps omitted PR attribution off', () => {
+    useSettings({
+      attribution: { commit: 'Signed-off-by: Human <h@example.com>' },
+    })
+
+    expect(getAttributionTexts()).toEqual({
+      commit: 'Signed-off-by: Human <h@example.com>',
+      pr: '',
+    })
+  })
+
+  it('keeps commit attribution off when configured as an empty string', () => {
+    useSettings({ attribution: { commit: '' } })
+
+    expect(getAttributionTexts()).toEqual({ commit: '', pr: '' })
+  })
+
+  it('honors custom PR attribution exactly and keeps omitted commit attribution off', () => {
+    useSettings({ attribution: { pr: 'Reviewed by release engineering.' } })
+
+    expect(getAttributionTexts()).toEqual({
+      commit: '',
+      pr: 'Reviewed by release engineering.',
+    })
+  })
+
+  it('keeps PR attribution off when configured as an empty string', () => {
+    useSettings({ attribution: { pr: '' } })
+
+    expect(getAttributionTexts()).toEqual({ commit: '', pr: '' })
+  })
+
+  it('preserves includeCoAuthoredBy true as an explicit old-default opt-in', () => {
+    useSettings({ includeCoAuthoredBy: true })
+
+    expect(getAttributionTexts()).toEqual({
+      commit: 'Co-Authored-By: OpenClaude (gpt-5.5) <openclaude@gitlawb.com>',
+      pr: defaultPrAttribution,
+    })
+  })
+
+  it('keeps attribution off when includeCoAuthoredBy is false', () => {
+    useSettings({ includeCoAuthoredBy: false })
+
+    expect(getAttributionTexts()).toEqual({ commit: '', pr: '' })
+  })
+
+  it('uses OPENCLAUDE_DISABLE_CO_AUTHORED_BY to disable the old default co-author trailer', () => {
+    process.env.OPENCLAUDE_DISABLE_CO_AUTHORED_BY = '1'
+    useSettings({ includeCoAuthoredBy: true })
+
+    expect(getAttributionTexts()).toEqual({
+      commit: '',
+      pr: defaultPrAttribution,
+    })
+  })
+
+  it('does not let OPENCLAUDE_DISABLE_CO_AUTHORED_BY override explicit commit attribution', () => {
+    process.env.OPENCLAUDE_DISABLE_CO_AUTHORED_BY = '1'
+    useSettings({
+      attribution: { commit: 'Reviewed-by: Human <h@example.com>' },
+    })
+
+    expect(getAttributionTexts()).toEqual({
+      commit: 'Reviewed-by: Human <h@example.com>',
+      pr: '',
+    })
+  })
+
+  it('preserves remote session attribution separately from local git attribution defaults', () => {
+    setClientType('remote')
+    process.env.CLAUDE_CODE_REMOTE_SESSION_ID = 'session_remote_123'
+    useSettings({})
+
+    expect(getAttributionTexts()).toEqual({
+      commit: 'https://claude.ai/code/session_remote_123',
+      pr: 'https://claude.ai/code/session_remote_123',
+    })
+  })
+})
+
+describe('getEnhancedPRAttribution', () => {
+  it('returns no PR attribution when no attribution settings are configured', async () => {
+    useSettings({})
+
+    await expect(
+      getEnhancedPRAttribution(() => {
+        throw new Error('app state should not be read when attribution is off')
+      }),
+    ).resolves.toBe('')
+  })
+
+  it('honors custom PR attribution exactly', async () => {
+    useSettings({ attribution: { pr: 'PR reviewed under repo policy.' } })
+
+    await expect(
+      getEnhancedPRAttribution(() => {
+        throw new Error('app state should not be read for custom attribution')
+      }),
+    ).resolves.toBe('PR reviewed under repo policy.')
+  })
+
+  it('honors explicit empty PR attribution exactly', async () => {
+    useSettings({ attribution: { pr: '' } })
+
+    await expect(
+      getEnhancedPRAttribution(() => {
+        throw new Error('app state should not be read for empty attribution')
+      }),
+    ).resolves.toBe('')
+  })
+
+  it('preserves includeCoAuthoredBy true as an explicit opt-in to generated PR attribution', async () => {
+    useSettings({ includeCoAuthoredBy: true })
+
+    await expect(getEnhancedPRAttribution(() => ({} as never))).resolves.toBe(
+      defaultPrAttribution,
     )
   })
 })

--- a/src/utils/attribution.ts
+++ b/src/utils/attribution.ts
@@ -39,6 +39,9 @@ export type AttributionTexts = {
   pr: string
 }
 
+const DEFAULT_PR_ATTRIBUTION =
+  '🤖 Generated with [OpenClaude](https://github.com/Gitlawb/openclaude)'
+
 function sanitizeCoAuthorNamePart(value: string): string {
   return value
     .replace(/[\r\n<>]/g, ' ')
@@ -101,8 +104,8 @@ export function getDefaultCommitCoAuthorEmail(_apiProvider: string): string {
  * Returns attribution text for commits and PRs based on user settings.
  * Handles:
  * - Dynamic model name via getPublicModelName()
- * - Custom attribution settings (settings.attribution.commit/pr)
- * - Backward compatibility with deprecated includeCoAuthoredBy setting
+ * - Explicit custom attribution settings (settings.attribution.commit/pr)
+ * - Backward compatibility with deprecated includeCoAuthoredBy setting as an opt-in
  * - Remote mode: returns session URL for attribution
  */
 export function getAttributionTexts(): AttributionTexts {
@@ -123,6 +126,21 @@ export function getAttributionTexts(): AttributionTexts {
     return { commit: '', pr: '' }
   }
 
+  const settings = getInitialSettings()
+
+  // Explicit attribution settings take precedence over the deprecated setting.
+  // Omitted fields stay off by default to avoid unrequested Git metadata.
+  if (settings.attribution) {
+    return {
+      commit: settings.attribution.commit ?? '',
+      pr: settings.attribution.pr ?? '',
+    }
+  }
+
+  if (settings.includeCoAuthoredBy !== true) {
+    return { commit: '', pr: '' }
+  }
+
   // First-party unknown models may be unreleased Claude codenames. Other
   // providers can safely use the configured public model string.
   const model = getMainLoopModel()
@@ -132,8 +150,6 @@ export function getAttributionTexts(): AttributionTexts {
     apiProvider,
     isInternalRepo: isInternalModelRepoCached(),
   })
-  const defaultAttribution =
-    '🤖 Generated with [OpenClaude](https://github.com/Gitlawb/openclaude)'
   const coAuthorEmail = getDefaultCommitCoAuthorEmail(apiProvider)
   const defaultCommit = isEnvTruthy(
     process.env.OPENCLAUDE_DISABLE_CO_AUTHORED_BY,
@@ -141,22 +157,7 @@ export function getAttributionTexts(): AttributionTexts {
     ? ''
     : `Co-Authored-By: ${modelName} <${coAuthorEmail}>`
 
-  const settings = getInitialSettings()
-
-  // New attribution setting takes precedence over deprecated includeCoAuthoredBy
-  if (settings.attribution) {
-    return {
-      commit: settings.attribution.commit ?? defaultCommit,
-      pr: settings.attribution.pr ?? defaultAttribution,
-    }
-  }
-
-  // Backward compatibility: deprecated includeCoAuthoredBy setting
-  if (settings.includeCoAuthoredBy === false) {
-    return { commit: '', pr: '' }
-  }
-
-  return { commit: defaultCommit, pr: defaultAttribution }
+  return { commit: defaultCommit, pr: DEFAULT_PR_ATTRIBUTION }
 }
 
 /**
@@ -352,7 +353,7 @@ async function getTranscriptStats(): Promise<{
  * - Shows Claude contribution percentage from commit attribution
  * - Shows N-shotted where N is the prompt count (1-shotted, 2-shotted, etc.)
  * - Shows short model name (e.g., claude-opus-4-5)
- * - Returns default attribution if stats can't be computed
+ * - Returns default attribution if explicitly enabled and stats can't be computed
  *
  * @param getAppState Function to get the current AppState (from command context)
  */
@@ -377,18 +378,20 @@ export async function getEnhancedPRAttribution(
 
   const settings = getInitialSettings()
 
-  // If user has custom PR attribution, use that
-  if (settings.attribution?.pr) {
+  // If user configured PR attribution, use the exact value. Omitted PR
+  // attribution stays off even if commit attribution is configured.
+  if (settings.attribution?.pr !== undefined) {
     return settings.attribution.pr
   }
-
-  // Backward compatibility: deprecated includeCoAuthoredBy setting
-  if (settings.includeCoAuthoredBy === false) {
+  if (settings.attribution) {
     return ''
   }
 
-  const defaultAttribution =
-    '🤖 Generated with [OpenClaude](https://github.com/Gitlawb/openclaude)'
+  // Backward compatibility: deprecated includeCoAuthoredBy setting is now an
+  // explicit opt-in for the old generated attribution behavior.
+  if (settings.includeCoAuthoredBy !== true) {
+    return ''
+  }
 
   // Get AppState first
   const appState = getAppState()
@@ -426,7 +429,7 @@ export async function getEnhancedPRAttribution(
   // If no attribution data, return default
   if (claudePercent === 0 && promptCount === 0 && memoryAccessCount === 0) {
     logForDebugging('PR Attribution: returning default (no data)')
-    return defaultAttribution
+    return DEFAULT_PR_ATTRIBUTION
   }
 
   // Build the enhanced attribution: "🤖 Generated with Claude Code (93% 3-shotted by claude-opus-4-5, 2 memories recalled)"

--- a/src/utils/settings/types.ts
+++ b/src/utils/settings/types.ts
@@ -361,14 +361,14 @@ export const SettingsSchema = lazySchema(() =>
         .optional()
         .describe(
           'Customize attribution text for commits and PRs. ' +
-            'Each field defaults to the standard Claude Code attribution if not set.',
+            'Unspecified fields are off by default; set a non-empty string to opt in.',
         ),
       includeCoAuthoredBy: z
         .boolean()
         .optional()
         .describe(
           'Deprecated: Use attribution instead. ' +
-            "Whether to include Claude's co-authored by attribution in commits and PRs (defaults to true)",
+            "Whether to include Claude's co-authored by attribution in commits and PRs (defaults to false)",
         ),
       includeGitInstructions: z
         .boolean()


### PR DESCRIPTION
## Summary
- Make local commit and PR attribution opt-in by default.
- Preserve explicit attribution via `settings.attribution.commit` and `settings.attribution.pr`.
- Preserve deprecated `includeCoAuthoredBy: true` as an explicit compatibility opt-in.
- Update settings/help wording to reflect the privacy-preserving default.

## Why
Partially addresses #1326. Private, regulated, and client-sensitive repositories may not allow AI/provider/model metadata in Git history or PR text unless explicitly enabled.

## Behavior
- Default local commit attribution: off
- Default local PR attribution: off
- Explicit custom attribution: honored
- Deprecated `includeCoAuthoredBy: true`: keeps old default behavior
- Deprecated `includeCoAuthoredBy: false`: off
- Remote session URL attribution remains unchanged because it is separate from local Git authoring metadata.

## Out of scope
- Memory write approval
- Auto-dream / memory persistence policy
- Repo-local policy files
- Commit-msg hook enforcement

## Testing
- `bun test src/utils/attribution.test.ts` - passed, 20 pass / 0 fail.
- `bun test src/commands/commit-message/commit-message.test.ts` - passed, 7 pass / 0 fail.
- `git diff --check` - passed.
- `bun run build` - passed.
- `bun test --max-concurrency=1` - local run reaches the changed commit-message tests successfully, but fails on 5 unrelated local/environment-sensitive tests: Gemini credential resolution, conversation recovery thinking-block filtering, startup provider alias resolution, and Bash command-not-found formatting. The CI-specific commit-message failure from the previous PR was fixed by making the test cache cleanup resilient when the cache object is absent.
- `bun run typecheck` - fails on existing repo-wide typecheck baseline with many unrelated missing-module/type errors.

Partially addresses #1326.