### PR TITLE
fix(agent): allow custom model overrides

### DIFF
--- a/src/tools/AgentTool/AgentTool.schema.test.ts
+++ b/src/tools/AgentTool/AgentTool.schema.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, test } from 'bun:test'
+import { inputSchema } from './AgentTool.js'
+
+const baseInput = {
+  description: 'Run check',
+  prompt: 'Check the implementation',
+}
+
+describe('AgentTool input schema model override', () => {
+  test('accepts aliases and custom provider-supported model IDs', () => {
+    const acceptedModels = [
+      'sonnet',
+      'opus',
+      'haiku',
+      'inherit',
+      'gpt-5.5',
+      'mimo-v2.5-pro',
+      'deepseek-v4-flash',
+      'deepseek/deepseek-v4-flash:nitro',
+      'qwen3-coder-next:cloud',
+      'custom_model-v1.2:fast',
+    ]
+
+    for (const model of acceptedModels) {
+      expect(inputSchema().safeParse({ ...baseInput, model }).success).toBe(
+        true,
+      )
+    }
+  })
+
+  test('rejects empty and whitespace-only model overrides', () => {
+    for (const model of ['', '   ']) {
+      expect(inputSchema().safeParse({ ...baseInput, model }).success).toBe(
+        false,
+      )
+    }
+  })
+
+  test('rejects non-string model overrides', () => {
+    for (const model of [null, 42, true, ['gpt-5.5']]) {
+      expect(inputSchema().safeParse({ ...baseInput, model }).success).toBe(
+        false,
+      )
+    }
+  })
+
+  test('trims accepted model overrides', () => {
+    const result = inputSchema().safeParse({
+      ...baseInput,
+      model: '  deepseek/deepseek-v4-flash:nitro  ',
+    })
+
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data.model).toBe('deepseek/deepseek-v4-flash:nitro')
+    }
+  })
+
+  test('describes aliases, custom model IDs, overrides, and inheritance', () => {
+    const description = inputSchema().shape.model.description
+
+    expect(description).toContain('sonnet')
+    expect(description).toContain('opus')
+    expect(description).toContain('haiku')
+    expect(description).toContain('provider-supported model ID')
+    expect(description).toContain('Takes precedence')
+    expect(description).toContain('inherit')
+  })
+})

--- a/src/tools/AgentTool/AgentTool.teammateModel.test.ts
+++ b/src/tools/AgentTool/AgentTool.teammateModel.test.ts
@@ -1,0 +1,203 @@
+import { afterEach, beforeEach, expect, mock, test } from 'bun:test'
+import type { ToolUseContext } from '../../Tool.js'
+import {
+  acquireSharedMutationLock,
+  releaseSharedMutationLock,
+} from '../../test/sharedMutationLock.js'
+
+type ModelAllowlistModule = typeof import('../../utils/model/modelAllowlist.js')
+type SpawnMultiAgentModule = typeof import('../shared/spawnMultiAgent.js')
+type SpawnTeammateConfig = Parameters<SpawnMultiAgentModule['spawnTeammate']>[0]
+
+let originalModelAllowlistModule: ModelAllowlistModule | undefined
+let originalSpawnMultiAgentModule: SpawnMultiAgentModule | undefined
+
+const originalEnv = {
+  CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS:
+    process.env.CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS,
+  CLAUDE_CODE_SUBAGENT_MODEL: process.env.CLAUDE_CODE_SUBAGENT_MODEL,
+}
+
+beforeEach(async () => {
+  await acquireSharedMutationLock(
+    'tools/AgentTool/AgentTool.teammateModel.test.ts',
+  )
+  process.env.CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS = '1'
+  delete process.env.CLAUDE_CODE_SUBAGENT_MODEL
+})
+
+afterEach(async () => {
+  try {
+    mock.restore()
+    if (originalModelAllowlistModule) {
+      mock.module(
+        '../../utils/model/modelAllowlist.js',
+        () => originalModelAllowlistModule!,
+      )
+    }
+    if (originalSpawnMultiAgentModule) {
+      mock.module(
+        '../shared/spawnMultiAgent.js',
+        () => originalSpawnMultiAgentModule!,
+      )
+    }
+    restoreEnv('CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS')
+    restoreEnv('CLAUDE_CODE_SUBAGENT_MODEL')
+  } finally {
+    releaseSharedMutationLock()
+  }
+})
+
+function restoreEnv(key: keyof typeof originalEnv): void {
+  const originalValue = originalEnv[key]
+  if (originalValue === undefined) {
+    delete process.env[key]
+  } else {
+    process.env[key] = originalValue
+  }
+}
+
+async function importActualModelAllowlist(): Promise<ModelAllowlistModule> {
+  return import(
+    `../../utils/model/modelAllowlist.ts?agentToolActual=${Date.now()}-${Math.random()}`
+  )
+}
+
+async function importActualSpawnMultiAgent(): Promise<SpawnMultiAgentModule> {
+  return import(
+    `../shared/spawnMultiAgent.ts?agentToolActual=${Date.now()}-${Math.random()}`
+  )
+}
+
+async function importAgentToolWithSpawnMock(): Promise<{
+  AgentTool: typeof import('./AgentTool.js').AgentTool
+  spawnTeammate: ReturnType<typeof mock>
+}> {
+  originalModelAllowlistModule ??= await importActualModelAllowlist()
+  originalSpawnMultiAgentModule ??= await importActualSpawnMultiAgent()
+  const spawnTeammate = mock(async () => ({
+    data: {
+      teammate_id: 'teammate-1',
+      agent_id: 'agent-1',
+      team_name: 'review-team',
+      name: 'worker-a',
+    },
+  }))
+
+  mock.module('../../utils/model/modelAllowlist.js', () => ({
+    ...originalModelAllowlistModule!,
+    isModelAllowed: (model: string) =>
+      model.trim().toLowerCase() === 'allowed-model',
+  }))
+  mock.module('../shared/spawnMultiAgent.js', () => ({
+    ...originalSpawnMultiAgentModule!,
+    spawnTeammate,
+  }))
+
+  const { AgentTool } = await import(
+    `./AgentTool.js?teammateModel=${Date.now()}-${Math.random()}`
+  )
+  return { AgentTool, spawnTeammate }
+}
+
+function makeToolUseContext(options: {
+  mainLoopModel?: string
+} = {}): ToolUseContext {
+  const appState = {
+    toolPermissionContext: { mode: 'default' },
+    teamContext: { teamName: 'review-team' },
+  }
+
+  return {
+    options: {
+      commands: [],
+      debug: false,
+      mainLoopModel: options.mainLoopModel ?? 'allowed-model',
+      tools: [],
+      verbose: false,
+      thinkingConfig: {},
+      mcpClients: [],
+      mcpResources: {},
+      isNonInteractiveSession: false,
+      agentDefinitions: { activeAgents: [], allAgents: [] },
+    },
+    abortController: new AbortController(),
+    readFileState: {},
+    messages: [],
+    getAppState: () => appState,
+    setAppState: () => {},
+    setInProgressToolUseIDs: () => {},
+    setResponseLength: () => {},
+    updateFileHistoryState: () => {},
+    updateAttributionState: () => {},
+  } as unknown as ToolUseContext
+}
+
+function getSpawnConfig(
+  spawnTeammate: ReturnType<typeof mock>,
+): SpawnTeammateConfig {
+  expect(spawnTeammate).toHaveBeenCalledTimes(1)
+  return spawnTeammate.mock.calls[0]![0] as SpawnTeammateConfig
+}
+
+function callTeammateAgentTool(
+  AgentTool: typeof import('./AgentTool.js').AgentTool,
+  input: {
+    model?: string
+  } = {},
+  contextOptions: {
+    mainLoopModel?: string
+  } = {},
+): ReturnType<typeof AgentTool.call> {
+  return AgentTool.call(
+    {
+      description: 'review',
+      prompt: 'check the branch',
+      team_name: 'review-team',
+      name: 'worker-a',
+      ...input,
+    },
+    makeToolUseContext(contextOptions),
+    mock(async () => ({ behavior: 'allow' })) as never,
+    { requestId: 'req-1' } as never,
+  )
+}
+
+test('rejects a disallowed custom model before spawning a teammate', async () => {
+  const { AgentTool, spawnTeammate } = await importAgentToolWithSpawnMock()
+
+  await expect(
+    callTeammateAgentTool(AgentTool, { model: 'forbidden-model' }),
+  ).rejects.toThrow(
+    "Model 'forbidden-model' is not available. Your organization restricts model selection.",
+  )
+  expect(spawnTeammate).not.toHaveBeenCalled()
+})
+
+test('trims an allowed custom model before spawning a teammate', async () => {
+  const { AgentTool, spawnTeammate } = await importAgentToolWithSpawnMock()
+
+  await callTeammateAgentTool(AgentTool, { model: '  allowed-model  ' })
+
+  expect(getSpawnConfig(spawnTeammate).model).toBe('allowed-model')
+})
+
+test('resolves inherit before spawning a teammate', async () => {
+  const { AgentTool, spawnTeammate } = await importAgentToolWithSpawnMock()
+
+  await callTeammateAgentTool(
+    AgentTool,
+    { model: ' InHerit ' },
+    { mainLoopModel: 'allowed-model' },
+  )
+
+  expect(getSpawnConfig(spawnTeammate).model).toBe('allowed-model')
+})
+
+test('leaves teammate default selection to spawn layer without a model override', async () => {
+  const { AgentTool, spawnTeammate } = await importAgentToolWithSpawnMock()
+
+  await callTeammateAgentTool(AgentTool)
+
+  expect(getSpawnConfig(spawnTeammate).model).toBeUndefined()
+})

--- a/src/tools/AgentTool/AgentTool.tsx
+++ b/src/tools/AgentTool/AgentTool.tsx
@@ -83,7 +83,7 @@ const baseInputSchema = lazySchema(() => z.object({
   description: z.string().describe('A short (3-5 word) description of the task'),
   prompt: z.string().describe('The task for the agent to perform'),
   subagent_type: z.string().optional().describe('The type of specialized agent to use for this task'),
-  model: z.enum(['sonnet', 'opus', 'haiku']).optional().describe("Optional model override for this agent. Takes precedence over the agent definition's model frontmatter. If omitted, uses the agent definition's model, or inherits from the parent."),
+  model: z.string().trim().min(1, 'Model cannot be empty').optional().describe("Optional model override for this agent. Accepts aliases such as sonnet, opus, haiku, inherit, or a provider-supported model ID. Takes precedence over the agent definition's model frontmatter. If omitted, uses the agent definition's model, or inherits from the parent."),
   run_in_background: z.boolean().optional().describe('Set to true to run this agent in the background. You will be notified when it completes.')
 }));
 

--- a/src/tools/AgentTool/AgentTool.tsx
+++ b/src/tools/AgentTool/AgentTool.tsx
@@ -287,6 +287,16 @@ export const AgentTool = buildTool({
       if (agentDef?.color) {
         setAgentColor(subagent_type!, agentDef.color);
       }
+      const rawTeammateModel = model ?? agentDef?.model;
+      const resolvedTeammateModel =
+        rawTeammateModel === undefined
+          ? undefined
+          : getAgentModel(
+              agentDef?.model,
+              toolUseContext.options.mainLoopModel,
+              model,
+              permissionMode
+            );
       const result = await spawnTeammate({
         name,
         prompt,
@@ -294,7 +304,7 @@ export const AgentTool = buildTool({
         team_name: teamName,
         use_splitpane: true,
         plan_mode_required: spawnMode === 'plan',
-        model: model ?? agentDef?.model,
+        model: resolvedTeammateModel,
         agent_type: subagent_type,
         invokingRequestId: assistantMessage?.requestId
       }, toolUseContext);

--- a/src/tools/AgentTool/UI.tsx
+++ b/src/tools/AgentTool/UI.tsx
@@ -23,7 +23,6 @@ import { getSearchOrReadFromContent, getSearchReadSummaryText } from '../../util
 import { getDisplayPath } from '../../utils/file.js';
 import { formatDuration, formatNumber } from '../../utils/format.js';
 import { buildSubagentLookups, createAssistantMessage, EMPTY_LOOKUPS } from '../../utils/messages.js';
-import type { ModelAlias } from '../../utils/model/aliases.js';
 import { getMainLoopModel, parseUserSpecifiedModel, renderModelName } from '../../utils/model/model.js';
 import type { Theme, ThemeName } from '../../utils/theme.js';
 import type { outputSchema, Progress, RemoteLaunchedOutput } from './AgentTool.js';
@@ -424,7 +423,7 @@ export function renderToolUseTag(input: Partial<{
   description: string;
   prompt: string;
   subagent_type: string;
-  model?: ModelAlias;
+  model?: string;
 }>): React.ReactNode {
   const tags: React.ReactNode[] = [];
   if (input.model) {

--- a/src/tools/AgentTool/runAgent.ts
+++ b/src/tools/AgentTool/runAgent.ts
@@ -59,7 +59,6 @@ import { createUserMessage } from '../../utils/messages.js'
 import { getAgentModel } from '../../utils/model/agent.js'
 import { resolveAgentProvider } from '../../services/api/agentRouting.js'
 import { getInitialSettings } from '../../utils/settings/settings.js'
-import type { ModelAlias } from '../../utils/model/aliases.js'
 import {
   clearAgentTranscriptSubdir,
   recordSidechainTranscript,
@@ -283,7 +282,7 @@ export async function* runAgent({
     abortController?: AbortController
     agentId?: AgentId
   }
-  model?: ModelAlias
+  model?: string
   maxTurns?: number
   /** Preserve toolUseResult on messages for subagents with viewable transcripts */
   preserveToolUseResults?: boolean

--- a/src/utils/model/agent.test.ts
+++ b/src/utils/model/agent.test.ts
@@ -3,13 +3,10 @@ import {
   acquireSharedMutationLock,
   releaseSharedMutationLock,
 } from '../../test/sharedMutationLock.js'
-import {
-  resetSettingsCache,
-  setSessionSettingsCache,
-} from '../settings/settingsCache.js'
 
 const originalSubagentModel = process.env.CLAUDE_CODE_SUBAGENT_MODEL
 const originalOpenAIModel = process.env.OPENAI_MODEL
+const allowedModelsRef: { value?: string[] } = { value: undefined }
 
 type MockProvider =
   | 'firstParty'
@@ -38,10 +35,30 @@ function mockProvider(
 }
 
 function setAvailableModelsForTest(availableModels?: string[]): void {
-  setSessionSettingsCache({
-    settings: availableModels === undefined ? {} : { availableModels },
-    errors: [],
-  })
+  allowedModelsRef.value = availableModels
+}
+
+// Keep resolver tests independent from process-global settings mocks in other
+// test files; modelAllowlist itself owns the detailed allowlist semantics.
+function mockModelAllowlist(): void {
+  mock.module('./modelAllowlist.js', () => ({
+    isModelAllowed: (model: string) => {
+      const availableModels = allowedModelsRef.value
+      if (availableModels === undefined) return true
+      if (availableModels.length === 0) return false
+
+      const normalizedModel = model.trim().toLowerCase()
+      return availableModels.some(
+        availableModel =>
+          availableModel.trim().toLowerCase() === normalizedModel,
+      )
+    },
+  }))
+}
+
+async function importAgentModule(): Promise<typeof import('./agent.js')> {
+  const stamp = `${Date.now()}-${Math.random()}`
+  return import(`./agent.ts?agent-test=${stamp}`)
 }
 
 describe('getAgentModel provider-aware fallback', () => {
@@ -49,13 +66,14 @@ describe('getAgentModel provider-aware fallback', () => {
     await acquireSharedMutationLock('utils/model/agent.test.ts')
     delete process.env.CLAUDE_CODE_SUBAGENT_MODEL
     setAvailableModelsForTest()
+    mockModelAllowlist()
   })
 
   // Restore all mocks after each test
   afterEach(() => {
     try {
       mock.restore()
-      resetSettingsCache()
+      setAvailableModelsForTest()
       if (originalSubagentModel === undefined) {
         delete process.env.CLAUDE_CODE_SUBAGENT_MODEL
       } else {
@@ -77,7 +95,7 @@ describe('getAgentModel provider-aware fallback', () => {
       mockProvider('firstParty', true)
 
       // Import after mock is set up
-      const { getAgentModel } = await import('./agent.js')
+      const { getAgentModel } = await importAgentModule()
       const result = getAgentModel('haiku', 'claude-sonnet-4-6', undefined, 'default')
 
       // Should resolve haiku alias, not inherit parent
@@ -88,7 +106,7 @@ describe('getAgentModel provider-aware fallback', () => {
     test('haiku alias resolves for Bedrock provider', async () => {
       mockProvider('bedrock')
 
-      const { getAgentModel } = await import('./agent.js')
+      const { getAgentModel } = await importAgentModule()
       const result = getAgentModel('haiku', 'claude-sonnet-4-6', undefined, 'default')
 
       // Should resolve haiku alias for Bedrock
@@ -98,7 +116,7 @@ describe('getAgentModel provider-aware fallback', () => {
     test('haiku alias resolves for Vertex provider', async () => {
       mockProvider('vertex')
 
-      const { getAgentModel } = await import('./agent.js')
+      const { getAgentModel } = await importAgentModule()
       const result = getAgentModel('haiku', 'claude-sonnet-4-6', undefined, 'default')
 
       // Should resolve haiku alias for Vertex
@@ -108,7 +126,7 @@ describe('getAgentModel provider-aware fallback', () => {
     test('haiku alias resolves for Foundry provider', async () => {
       mockProvider('foundry')
 
-      const { getAgentModel } = await import('./agent.js')
+      const { getAgentModel } = await importAgentModule()
       const result = getAgentModel('haiku', 'claude-sonnet-4-6', undefined, 'default')
 
       // Should resolve haiku alias for Foundry
@@ -120,7 +138,7 @@ describe('getAgentModel provider-aware fallback', () => {
     test('haiku alias inherits parent model for OpenAI provider', async () => {
       mockProvider('openai')
 
-      const { getAgentModel } = await import('./agent.js')
+      const { getAgentModel } = await importAgentModule()
       const result = getAgentModel('haiku', 'gpt-4o-mini', undefined, 'default')
 
       // Should inherit parent model for OpenAI (no haiku concept)
@@ -130,7 +148,7 @@ describe('getAgentModel provider-aware fallback', () => {
     test('haiku alias inherits parent model for Gemini provider', async () => {
       mockProvider('gemini')
 
-      const { getAgentModel } = await import('./agent.js')
+      const { getAgentModel } = await importAgentModule()
       const result = getAgentModel('haiku', 'gemini-2.5-pro', undefined, 'default')
 
       // Should inherit parent model for Gemini
@@ -141,7 +159,7 @@ describe('getAgentModel provider-aware fallback', () => {
       // firstParty provider but with custom URL (not official Anthropic)
       mockProvider('firstParty')
 
-      const { getAgentModel } = await import('./agent.js')
+      const { getAgentModel } = await importAgentModule()
       const result = getAgentModel('haiku', 'claude-sonnet-4-6', undefined, 'default')
 
       // Should inherit parent for custom Anthropic-compatible URL
@@ -151,7 +169,7 @@ describe('getAgentModel provider-aware fallback', () => {
     test('sonnet alias inherits parent model for OpenAI provider', async () => {
       mockProvider('openai')
 
-      const { getAgentModel } = await import('./agent.js')
+      const { getAgentModel } = await importAgentModule()
       const result = getAgentModel('sonnet', 'gpt-4o-mini', undefined, 'default')
 
       // Should inherit parent model for OpenAI
@@ -161,7 +179,7 @@ describe('getAgentModel provider-aware fallback', () => {
     test('haiku alias inherits parent model for Mistral provider', async () => {
       mockProvider('mistral')
 
-      const { getAgentModel } = await import('./agent.js')
+      const { getAgentModel } = await importAgentModule()
       const result = getAgentModel('haiku', 'mistral-small-latest', undefined, 'default')
 
       // Should inherit parent model for Mistral (no haiku concept)
@@ -171,7 +189,7 @@ describe('getAgentModel provider-aware fallback', () => {
     test('haiku alias inherits parent model for GitHub Copilot provider', async () => {
       mockProvider('github')
 
-      const { getAgentModel } = await import('./agent.js')
+      const { getAgentModel } = await importAgentModule()
       const result = getAgentModel('haiku', 'gpt-4o-mini', undefined, 'default')
 
       // Should inherit parent model for GitHub Copilot
@@ -181,7 +199,7 @@ describe('getAgentModel provider-aware fallback', () => {
     test('haiku alias inherits parent model for NVIDIA NIM provider', async () => {
       mockProvider('nvidia-nim')
 
-      const { getAgentModel } = await import('./agent.js')
+      const { getAgentModel } = await importAgentModule()
       const result = getAgentModel('haiku', 'meta/llama-3.1-8b-instruct', undefined, 'default')
 
       // Should inherit parent model for NVIDIA NIM (no haiku concept)
@@ -191,7 +209,7 @@ describe('getAgentModel provider-aware fallback', () => {
     test('haiku alias inherits parent model for MiniMax provider', async () => {
       mockProvider('minimax')
 
-      const { getAgentModel } = await import('./agent.js')
+      const { getAgentModel } = await importAgentModule()
       const result = getAgentModel('haiku', 'MiniMax-M2.5-highspeed', undefined, 'default')
 
       // Should inherit parent model for MiniMax (no haiku concept)
@@ -201,7 +219,7 @@ describe('getAgentModel provider-aware fallback', () => {
     test('haiku alias inherits parent model for Codex provider', async () => {
       mockProvider('codex')
 
-      const { getAgentModel } = await import('./agent.js')
+      const { getAgentModel } = await importAgentModule()
       const result = getAgentModel('haiku', 'gpt-5.5-mini', undefined, 'default')
 
       // Should inherit parent model for Codex provider (no haiku concept)
@@ -213,7 +231,7 @@ describe('getAgentModel provider-aware fallback', () => {
     test('inherit always returns parent model regardless of provider', async () => {
       mockProvider('openai')
 
-      const { getAgentModel } = await import('./agent.js')
+      const { getAgentModel } = await importAgentModule()
       const result = getAgentModel('inherit', 'gpt-4o', undefined, 'default')
 
       expect(result).toBe('gpt-4o')
@@ -222,7 +240,7 @@ describe('getAgentModel provider-aware fallback', () => {
     test('tool-specified inherit returns the runtime parent model', async () => {
       mockProvider('openai')
 
-      const { getAgentModel } = await import('./agent.js')
+      const { getAgentModel } = await importAgentModule()
       const result = getAgentModel(undefined, 'gpt-4o', 'inherit', 'default')
 
       expect(result).toBe('gpt-4o')
@@ -231,7 +249,7 @@ describe('getAgentModel provider-aware fallback', () => {
     test('tool-specified inherit is case-insensitive and trimmed', async () => {
       mockProvider('openai')
 
-      const { getAgentModel } = await import('./agent.js')
+      const { getAgentModel } = await importAgentModule()
       const result = getAgentModel(undefined, 'gpt-4o', ' InHerit ', 'default')
 
       expect(result).toBe('gpt-4o')
@@ -242,7 +260,7 @@ describe('getAgentModel provider-aware fallback', () => {
     test('preserves custom provider model IDs unchanged', async () => {
       mockProvider('openai')
 
-      const { getAgentModel } = await import('./agent.js')
+      const { getAgentModel } = await importAgentModule()
       const customModels = [
         'gpt-5.5',
         'mimo-v2.5-pro',
@@ -262,7 +280,7 @@ describe('getAgentModel provider-aware fallback', () => {
     test('trims custom provider model IDs before resolving', async () => {
       mockProvider('openai')
 
-      const { getAgentModel } = await import('./agent.js')
+      const { getAgentModel } = await importAgentModule()
       const result = getAgentModel(
         undefined,
         'claude-sonnet-4-6',
@@ -276,7 +294,7 @@ describe('getAgentModel provider-aware fallback', () => {
     test('preserves alias tier matching for tool-specified aliases', async () => {
       mockProvider('firstParty', true)
 
-      const { getAgentModel } = await import('./agent.js')
+      const { getAgentModel } = await importAgentModule()
 
       expect(
         getAgentModel(undefined, 'claude-sonnet-4-6', 'sonnet', 'default'),
@@ -298,7 +316,7 @@ describe('getAgentModel provider-aware fallback', () => {
       mockProvider('openai')
       delete process.env.OPENAI_MODEL
 
-      const { getAgentModel } = await import('./agent.js')
+      const { getAgentModel } = await importAgentModule()
       const result = getAgentModel(undefined, 'gpt-4o', 'haiku', 'default')
 
       expect(result).toBe('gpt-4o-mini')
@@ -309,7 +327,7 @@ describe('getAgentModel provider-aware fallback', () => {
       process.env.CLAUDE_CODE_SUBAGENT_MODEL =
         'deepseek/deepseek-v4-flash:nitro'
 
-      const { getAgentModel } = await import('./agent.js')
+      const { getAgentModel } = await importAgentModule()
       const result = getAgentModel(
         'haiku',
         'claude-sonnet-4-6',
@@ -324,7 +342,7 @@ describe('getAgentModel provider-aware fallback', () => {
       mockProvider('openai')
       setAvailableModelsForTest(['gpt-4o'])
 
-      const { getAgentModel } = await import('./agent.js')
+      const { getAgentModel } = await importAgentModule()
 
       expect(() =>
         getAgentModel(undefined, 'gpt-4o', 'gpt-5.5', 'default'),
@@ -337,7 +355,7 @@ describe('getAgentModel provider-aware fallback', () => {
       mockProvider('openai')
       setAvailableModelsForTest(['gpt-5.5'])
 
-      const { getAgentModel } = await import('./agent.js')
+      const { getAgentModel } = await importAgentModule()
       const result = getAgentModel(undefined, 'gpt-4o', 'gpt-5.5', 'default')
 
       expect(result).toBe('gpt-5.5')
@@ -348,7 +366,7 @@ describe('getAgentModel provider-aware fallback', () => {
       delete process.env.OPENAI_MODEL
       setAvailableModelsForTest(['haiku'])
 
-      const { getAgentModel } = await import('./agent.js')
+      const { getAgentModel } = await importAgentModule()
       const result = getAgentModel(undefined, 'gpt-4o', 'haiku', 'default')
 
       expect(result).toBe('gpt-4o-mini')
@@ -358,7 +376,7 @@ describe('getAgentModel provider-aware fallback', () => {
       mockProvider('firstParty', true)
       setAvailableModelsForTest(['claude-3-5-haiku-20241022'])
 
-      const { getAgentModel } = await import('./agent.js')
+      const { getAgentModel } = await importAgentModule()
 
       expect(() =>
         getAgentModel(
@@ -376,7 +394,7 @@ describe('getAgentModel provider-aware fallback', () => {
       mockProvider('firstParty', true)
       setAvailableModelsForTest(['claude-sonnet-4-6'])
 
-      const { getAgentModel } = await import('./agent.js')
+      const { getAgentModel } = await importAgentModule()
       const result = getAgentModel(
         undefined,
         'claude-sonnet-4-6',
@@ -391,7 +409,7 @@ describe('getAgentModel provider-aware fallback', () => {
       mockProvider('openai')
       setAvailableModelsForTest([])
 
-      const { getAgentModel } = await import('./agent.js')
+      const { getAgentModel } = await importAgentModule()
       const result = getAgentModel(undefined, 'gpt-4o', 'inherit', 'default')
 
       expect(result).toBe('gpt-4o')
@@ -400,7 +418,7 @@ describe('getAgentModel provider-aware fallback', () => {
     test('inherits Bedrock parent region prefix for non-prefixed Bedrock model IDs', async () => {
       mockProvider('bedrock')
 
-      const { getAgentModel } = await import('./agent.js')
+      const { getAgentModel } = await importAgentModule()
       const result = getAgentModel(
         undefined,
         'eu.anthropic.claude-sonnet-4-5-20250929-v1:0',
@@ -415,7 +433,7 @@ describe('getAgentModel provider-aware fallback', () => {
       mockProvider('bedrock')
       setAvailableModelsForTest(['anthropic.claude-3-5-sonnet-20241022-v2:0'])
 
-      const { getAgentModel } = await import('./agent.js')
+      const { getAgentModel } = await importAgentModule()
       const result = getAgentModel(
         undefined,
         'eu.anthropic.claude-sonnet-4-5-20250929-v1:0',
@@ -429,7 +447,7 @@ describe('getAgentModel provider-aware fallback', () => {
     test('preserves explicit Bedrock region prefix on tool-specified model IDs', async () => {
       mockProvider('bedrock')
 
-      const { getAgentModel } = await import('./agent.js')
+      const { getAgentModel } = await importAgentModule()
       const result = getAgentModel(
         undefined,
         'eu.anthropic.claude-sonnet-4-5-20250929-v1:0',
@@ -443,7 +461,7 @@ describe('getAgentModel provider-aware fallback', () => {
     test('does not apply Bedrock region prefixes to non-Bedrock custom IDs', async () => {
       mockProvider('bedrock')
 
-      const { getAgentModel } = await import('./agent.js')
+      const { getAgentModel } = await importAgentModule()
       const result = getAgentModel(
         undefined,
         'eu.anthropic.claude-sonnet-4-5-20250929-v1:0',
@@ -459,42 +477,42 @@ describe('getAgentModel provider-aware fallback', () => {
     test('returns true for official Anthropic API', async () => {
       mockProvider('firstParty', true)
 
-      const { checkIsClaudeNativeProvider } = await import('./agent.js')
+      const { checkIsClaudeNativeProvider } = await importAgentModule()
       expect(checkIsClaudeNativeProvider()).toBe(true)
     })
 
     test('returns true for Bedrock provider', async () => {
       mockProvider('bedrock')
 
-      const { checkIsClaudeNativeProvider } = await import('./agent.js')
+      const { checkIsClaudeNativeProvider } = await importAgentModule()
       expect(checkIsClaudeNativeProvider()).toBe(true)
     })
 
     test('returns true for Vertex provider', async () => {
       mockProvider('vertex')
 
-      const { checkIsClaudeNativeProvider } = await import('./agent.js')
+      const { checkIsClaudeNativeProvider } = await importAgentModule()
       expect(checkIsClaudeNativeProvider()).toBe(true)
     })
 
     test('returns true for Foundry provider', async () => {
       mockProvider('foundry')
 
-      const { checkIsClaudeNativeProvider } = await import('./agent.js')
+      const { checkIsClaudeNativeProvider } = await importAgentModule()
       expect(checkIsClaudeNativeProvider()).toBe(true)
     })
 
     test('returns false for OpenAI provider', async () => {
       mockProvider('openai')
 
-      const { checkIsClaudeNativeProvider } = await import('./agent.js')
+      const { checkIsClaudeNativeProvider } = await importAgentModule()
       expect(checkIsClaudeNativeProvider()).toBe(false)
     })
 
     test('returns false for custom Anthropic URL', async () => {
       mockProvider('firstParty')
 
-      const { checkIsClaudeNativeProvider } = await import('./agent.js')
+      const { checkIsClaudeNativeProvider } = await importAgentModule()
       expect(checkIsClaudeNativeProvider()).toBe(false)
     })
   })

--- a/src/utils/model/agent.test.ts
+++ b/src/utils/model/agent.test.ts
@@ -3,6 +3,10 @@ import {
   acquireSharedMutationLock,
   releaseSharedMutationLock,
 } from '../../test/sharedMutationLock.js'
+import {
+  resetSettingsCache,
+  setSessionSettingsCache,
+} from '../settings/settingsCache.js'
 
 const originalSubagentModel = process.env.CLAUDE_CODE_SUBAGENT_MODEL
 const originalOpenAIModel = process.env.OPENAI_MODEL
@@ -33,16 +37,25 @@ function mockProvider(
   }))
 }
 
+function setAvailableModelsForTest(availableModels?: string[]): void {
+  setSessionSettingsCache({
+    settings: availableModels === undefined ? {} : { availableModels },
+    errors: [],
+  })
+}
+
 describe('getAgentModel provider-aware fallback', () => {
   beforeEach(async () => {
     await acquireSharedMutationLock('utils/model/agent.test.ts')
     delete process.env.CLAUDE_CODE_SUBAGENT_MODEL
+    setAvailableModelsForTest()
   })
 
   // Restore all mocks after each test
   afterEach(() => {
     try {
       mock.restore()
+      resetSettingsCache()
       if (originalSubagentModel === undefined) {
         delete process.env.CLAUDE_CODE_SUBAGENT_MODEL
       } else {
@@ -307,8 +320,100 @@ describe('getAgentModel provider-aware fallback', () => {
       expect(result).toBe('deepseek/deepseek-v4-flash:nitro')
     })
 
+    test('rejects tool-specified custom model IDs outside availableModels', async () => {
+      mockProvider('openai')
+      setAvailableModelsForTest(['gpt-4o'])
+
+      const { getAgentModel } = await import('./agent.js')
+
+      expect(() =>
+        getAgentModel(undefined, 'gpt-4o', 'gpt-5.5', 'default'),
+      ).toThrow(
+        "Model 'gpt-5.5' is not available. Your organization restricts model selection.",
+      )
+    })
+
+    test('allows tool-specified custom model IDs inside availableModels', async () => {
+      mockProvider('openai')
+      setAvailableModelsForTest(['gpt-5.5'])
+
+      const { getAgentModel } = await import('./agent.js')
+      const result = getAgentModel(undefined, 'gpt-4o', 'gpt-5.5', 'default')
+
+      expect(result).toBe('gpt-5.5')
+    })
+
+    test('allows tool-specified aliases when the alias is in availableModels', async () => {
+      mockProvider('openai')
+      delete process.env.OPENAI_MODEL
+      setAvailableModelsForTest(['haiku'])
+
+      const { getAgentModel } = await import('./agent.js')
+      const result = getAgentModel(undefined, 'gpt-4o', 'haiku', 'default')
+
+      expect(result).toBe('gpt-4o-mini')
+    })
+
+    test('does not let tier-matching aliases bypass availableModels', async () => {
+      mockProvider('firstParty', true)
+      setAvailableModelsForTest(['claude-3-5-haiku-20241022'])
+
+      const { getAgentModel } = await import('./agent.js')
+
+      expect(() =>
+        getAgentModel(
+          undefined,
+          'claude-sonnet-4-6',
+          'sonnet',
+          'default',
+        ),
+      ).toThrow(
+        "Model 'sonnet' is not available. Your organization restricts model selection.",
+      )
+    })
+
+    test('keeps tier-matching aliases when the effective parent model is allowed', async () => {
+      mockProvider('firstParty', true)
+      setAvailableModelsForTest(['claude-sonnet-4-6'])
+
+      const { getAgentModel } = await import('./agent.js')
+      const result = getAgentModel(
+        undefined,
+        'claude-sonnet-4-6',
+        'sonnet',
+        'default',
+      )
+
+      expect(result).toBe('claude-sonnet-4-6')
+    })
+
+    test('keeps tool-specified inherit independent of availableModels', async () => {
+      mockProvider('openai')
+      setAvailableModelsForTest([])
+
+      const { getAgentModel } = await import('./agent.js')
+      const result = getAgentModel(undefined, 'gpt-4o', 'inherit', 'default')
+
+      expect(result).toBe('gpt-4o')
+    })
+
     test('inherits Bedrock parent region prefix for non-prefixed Bedrock model IDs', async () => {
       mockProvider('bedrock')
+
+      const { getAgentModel } = await import('./agent.js')
+      const result = getAgentModel(
+        undefined,
+        'eu.anthropic.claude-sonnet-4-5-20250929-v1:0',
+        'anthropic.claude-3-5-sonnet-20241022-v2:0',
+        'default',
+      )
+
+      expect(result).toBe('eu.anthropic.claude-3-5-sonnet-20241022-v2:0')
+    })
+
+    test('allows inherited Bedrock region prefixes when the requested model ID is allowed', async () => {
+      mockProvider('bedrock')
+      setAvailableModelsForTest(['anthropic.claude-3-5-sonnet-20241022-v2:0'])
 
       const { getAgentModel } = await import('./agent.js')
       const result = getAgentModel(

--- a/src/utils/model/agent.test.ts
+++ b/src/utils/model/agent.test.ts
@@ -4,15 +4,55 @@ import {
   releaseSharedMutationLock,
 } from '../../test/sharedMutationLock.js'
 
+const originalSubagentModel = process.env.CLAUDE_CODE_SUBAGENT_MODEL
+const originalOpenAIModel = process.env.OPENAI_MODEL
+
+type MockProvider =
+  | 'firstParty'
+  | 'bedrock'
+  | 'vertex'
+  | 'foundry'
+  | 'openai'
+  | 'gemini'
+  | 'mistral'
+  | 'github'
+  | 'nvidia-nim'
+  | 'minimax'
+  | 'codex'
+
+function mockProvider(
+  provider: MockProvider,
+  isFirstPartyAnthropicBaseUrl = false,
+): void {
+  mock.module('./providers.js', () => ({
+    getAPIProvider: () => provider,
+    getAPIProviderForStatsig: () => provider,
+    isFirstPartyAnthropicBaseUrl: () => isFirstPartyAnthropicBaseUrl,
+    isGithubNativeAnthropicMode: () => false,
+    usesAnthropicAccountFlow: () => provider === 'firstParty',
+  }))
+}
+
 describe('getAgentModel provider-aware fallback', () => {
   beforeEach(async () => {
     await acquireSharedMutationLock('utils/model/agent.test.ts')
+    delete process.env.CLAUDE_CODE_SUBAGENT_MODEL
   })
 
   // Restore all mocks after each test
   afterEach(() => {
     try {
       mock.restore()
+      if (originalSubagentModel === undefined) {
+        delete process.env.CLAUDE_CODE_SUBAGENT_MODEL
+      } else {
+        process.env.CLAUDE_CODE_SUBAGENT_MODEL = originalSubagentModel
+      }
+      if (originalOpenAIModel === undefined) {
+        delete process.env.OPENAI_MODEL
+      } else {
+        process.env.OPENAI_MODEL = originalOpenAIModel
+      }
     } finally {
       releaseSharedMutationLock()
     }
@@ -21,10 +61,7 @@ describe('getAgentModel provider-aware fallback', () => {
   describe('Claude-native providers', () => {
     test('haiku alias resolves to haiku model for official Anthropic API', async () => {
       // Mock providers to return firstParty with official URL
-      mock.module('./providers.js', () => ({
-        getAPIProvider: () => 'firstParty',
-        isFirstPartyAnthropicBaseUrl: () => true,
-      }))
+      mockProvider('firstParty', true)
 
       // Import after mock is set up
       const { getAgentModel } = await import('./agent.js')
@@ -36,10 +73,7 @@ describe('getAgentModel provider-aware fallback', () => {
     })
 
     test('haiku alias resolves for Bedrock provider', async () => {
-      mock.module('./providers.js', () => ({
-        getAPIProvider: () => 'bedrock',
-        isFirstPartyAnthropicBaseUrl: () => false,
-      }))
+      mockProvider('bedrock')
 
       const { getAgentModel } = await import('./agent.js')
       const result = getAgentModel('haiku', 'claude-sonnet-4-6', undefined, 'default')
@@ -49,10 +83,7 @@ describe('getAgentModel provider-aware fallback', () => {
     })
 
     test('haiku alias resolves for Vertex provider', async () => {
-      mock.module('./providers.js', () => ({
-        getAPIProvider: () => 'vertex',
-        isFirstPartyAnthropicBaseUrl: () => false,
-      }))
+      mockProvider('vertex')
 
       const { getAgentModel } = await import('./agent.js')
       const result = getAgentModel('haiku', 'claude-sonnet-4-6', undefined, 'default')
@@ -62,10 +93,7 @@ describe('getAgentModel provider-aware fallback', () => {
     })
 
     test('haiku alias resolves for Foundry provider', async () => {
-      mock.module('./providers.js', () => ({
-        getAPIProvider: () => 'foundry',
-        isFirstPartyAnthropicBaseUrl: () => false,
-      }))
+      mockProvider('foundry')
 
       const { getAgentModel } = await import('./agent.js')
       const result = getAgentModel('haiku', 'claude-sonnet-4-6', undefined, 'default')
@@ -77,10 +105,7 @@ describe('getAgentModel provider-aware fallback', () => {
 
   describe('Non-Claude-native providers', () => {
     test('haiku alias inherits parent model for OpenAI provider', async () => {
-      mock.module('./providers.js', () => ({
-        getAPIProvider: () => 'openai',
-        isFirstPartyAnthropicBaseUrl: () => false,
-      }))
+      mockProvider('openai')
 
       const { getAgentModel } = await import('./agent.js')
       const result = getAgentModel('haiku', 'gpt-4o-mini', undefined, 'default')
@@ -90,10 +115,7 @@ describe('getAgentModel provider-aware fallback', () => {
     })
 
     test('haiku alias inherits parent model for Gemini provider', async () => {
-      mock.module('./providers.js', () => ({
-        getAPIProvider: () => 'gemini',
-        isFirstPartyAnthropicBaseUrl: () => false,
-      }))
+      mockProvider('gemini')
 
       const { getAgentModel } = await import('./agent.js')
       const result = getAgentModel('haiku', 'gemini-2.5-pro', undefined, 'default')
@@ -104,10 +126,7 @@ describe('getAgentModel provider-aware fallback', () => {
 
     test('haiku alias inherits parent model for custom Anthropic-compatible URL', async () => {
       // firstParty provider but with custom URL (not official Anthropic)
-      mock.module('./providers.js', () => ({
-        getAPIProvider: () => 'firstParty',
-        isFirstPartyAnthropicBaseUrl: () => false,
-      }))
+      mockProvider('firstParty')
 
       const { getAgentModel } = await import('./agent.js')
       const result = getAgentModel('haiku', 'claude-sonnet-4-6', undefined, 'default')
@@ -117,10 +136,7 @@ describe('getAgentModel provider-aware fallback', () => {
     })
 
     test('sonnet alias inherits parent model for OpenAI provider', async () => {
-      mock.module('./providers.js', () => ({
-        getAPIProvider: () => 'openai',
-        isFirstPartyAnthropicBaseUrl: () => false,
-      }))
+      mockProvider('openai')
 
       const { getAgentModel } = await import('./agent.js')
       const result = getAgentModel('sonnet', 'gpt-4o-mini', undefined, 'default')
@@ -130,10 +146,7 @@ describe('getAgentModel provider-aware fallback', () => {
     })
 
     test('haiku alias inherits parent model for Mistral provider', async () => {
-      mock.module('./providers.js', () => ({
-        getAPIProvider: () => 'mistral',
-        isFirstPartyAnthropicBaseUrl: () => false,
-      }))
+      mockProvider('mistral')
 
       const { getAgentModel } = await import('./agent.js')
       const result = getAgentModel('haiku', 'mistral-small-latest', undefined, 'default')
@@ -143,10 +156,7 @@ describe('getAgentModel provider-aware fallback', () => {
     })
 
     test('haiku alias inherits parent model for GitHub Copilot provider', async () => {
-      mock.module('./providers.js', () => ({
-        getAPIProvider: () => 'github',
-        isFirstPartyAnthropicBaseUrl: () => false,
-      }))
+      mockProvider('github')
 
       const { getAgentModel } = await import('./agent.js')
       const result = getAgentModel('haiku', 'gpt-4o-mini', undefined, 'default')
@@ -156,10 +166,7 @@ describe('getAgentModel provider-aware fallback', () => {
     })
 
     test('haiku alias inherits parent model for NVIDIA NIM provider', async () => {
-      mock.module('./providers.js', () => ({
-        getAPIProvider: () => 'nvidia-nim',
-        isFirstPartyAnthropicBaseUrl: () => false,
-      }))
+      mockProvider('nvidia-nim')
 
       const { getAgentModel } = await import('./agent.js')
       const result = getAgentModel('haiku', 'meta/llama-3.1-8b-instruct', undefined, 'default')
@@ -169,10 +176,7 @@ describe('getAgentModel provider-aware fallback', () => {
     })
 
     test('haiku alias inherits parent model for MiniMax provider', async () => {
-      mock.module('./providers.js', () => ({
-        getAPIProvider: () => 'minimax',
-        isFirstPartyAnthropicBaseUrl: () => false,
-      }))
+      mockProvider('minimax')
 
       const { getAgentModel } = await import('./agent.js')
       const result = getAgentModel('haiku', 'MiniMax-M2.5-highspeed', undefined, 'default')
@@ -182,10 +186,7 @@ describe('getAgentModel provider-aware fallback', () => {
     })
 
     test('haiku alias inherits parent model for Codex provider', async () => {
-      mock.module('./providers.js', () => ({
-        getAPIProvider: () => 'codex',
-        isFirstPartyAnthropicBaseUrl: () => false,
-      }))
+      mockProvider('codex')
 
       const { getAgentModel } = await import('./agent.js')
       const result = getAgentModel('haiku', 'gpt-5.5-mini', undefined, 'default')
@@ -197,74 +198,196 @@ describe('getAgentModel provider-aware fallback', () => {
 
   describe('inherit behavior unchanged', () => {
     test('inherit always returns parent model regardless of provider', async () => {
-      mock.module('./providers.js', () => ({
-        getAPIProvider: () => 'openai',
-        isFirstPartyAnthropicBaseUrl: () => false,
-      }))
+      mockProvider('openai')
 
       const { getAgentModel } = await import('./agent.js')
       const result = getAgentModel('inherit', 'gpt-4o', undefined, 'default')
 
       expect(result).toBe('gpt-4o')
     })
+
+    test('tool-specified inherit returns the runtime parent model', async () => {
+      mockProvider('openai')
+
+      const { getAgentModel } = await import('./agent.js')
+      const result = getAgentModel(undefined, 'gpt-4o', 'inherit', 'default')
+
+      expect(result).toBe('gpt-4o')
+    })
+
+    test('tool-specified inherit is case-insensitive and trimmed', async () => {
+      mockProvider('openai')
+
+      const { getAgentModel } = await import('./agent.js')
+      const result = getAgentModel(undefined, 'gpt-4o', ' InHerit ', 'default')
+
+      expect(result).toBe('gpt-4o')
+    })
+  })
+
+  describe('tool-specified model override', () => {
+    test('preserves custom provider model IDs unchanged', async () => {
+      mockProvider('openai')
+
+      const { getAgentModel } = await import('./agent.js')
+      const customModels = [
+        'gpt-5.5',
+        'mimo-v2.5-pro',
+        'deepseek-v4-flash',
+        'deepseek/deepseek-v4-flash:nitro',
+        'qwen3-coder-next:cloud',
+        'custom_model-v1.2:fast',
+      ]
+
+      for (const customModel of customModels) {
+        expect(
+          getAgentModel(undefined, 'claude-sonnet-4-6', customModel, 'default'),
+        ).toBe(customModel)
+      }
+    })
+
+    test('trims custom provider model IDs before resolving', async () => {
+      mockProvider('openai')
+
+      const { getAgentModel } = await import('./agent.js')
+      const result = getAgentModel(
+        undefined,
+        'claude-sonnet-4-6',
+        '  qwen3-coder-next:cloud  ',
+        'default',
+      )
+
+      expect(result).toBe('qwen3-coder-next:cloud')
+    })
+
+    test('preserves alias tier matching for tool-specified aliases', async () => {
+      mockProvider('firstParty', true)
+
+      const { getAgentModel } = await import('./agent.js')
+
+      expect(
+        getAgentModel(undefined, 'claude-sonnet-4-6', 'sonnet', 'default'),
+      ).toBe('claude-sonnet-4-6')
+      expect(
+        getAgentModel(undefined, 'claude-opus-4-6', 'opus', 'default'),
+      ).toBe('claude-opus-4-6')
+      expect(
+        getAgentModel(
+          undefined,
+          'claude-3-5-haiku-20241022',
+          'haiku',
+          'default',
+        ),
+      ).toBe('claude-3-5-haiku-20241022')
+    })
+
+    test('keeps existing direct alias parsing for non-Claude providers', async () => {
+      mockProvider('openai')
+      delete process.env.OPENAI_MODEL
+
+      const { getAgentModel } = await import('./agent.js')
+      const result = getAgentModel(undefined, 'gpt-4o', 'haiku', 'default')
+
+      expect(result).toBe('gpt-4o-mini')
+    })
+
+    test('CLAUDE_CODE_SUBAGENT_MODEL overrides tool-specified custom model', async () => {
+      mockProvider('openai')
+      process.env.CLAUDE_CODE_SUBAGENT_MODEL =
+        'deepseek/deepseek-v4-flash:nitro'
+
+      const { getAgentModel } = await import('./agent.js')
+      const result = getAgentModel(
+        'haiku',
+        'claude-sonnet-4-6',
+        'gpt-5.5',
+        'default',
+      )
+
+      expect(result).toBe('deepseek/deepseek-v4-flash:nitro')
+    })
+
+    test('inherits Bedrock parent region prefix for non-prefixed Bedrock model IDs', async () => {
+      mockProvider('bedrock')
+
+      const { getAgentModel } = await import('./agent.js')
+      const result = getAgentModel(
+        undefined,
+        'eu.anthropic.claude-sonnet-4-5-20250929-v1:0',
+        'anthropic.claude-3-5-sonnet-20241022-v2:0',
+        'default',
+      )
+
+      expect(result).toBe('eu.anthropic.claude-3-5-sonnet-20241022-v2:0')
+    })
+
+    test('preserves explicit Bedrock region prefix on tool-specified model IDs', async () => {
+      mockProvider('bedrock')
+
+      const { getAgentModel } = await import('./agent.js')
+      const result = getAgentModel(
+        undefined,
+        'eu.anthropic.claude-sonnet-4-5-20250929-v1:0',
+        'us.anthropic.claude-3-5-sonnet-20241022-v2:0',
+        'default',
+      )
+
+      expect(result).toBe('us.anthropic.claude-3-5-sonnet-20241022-v2:0')
+    })
+
+    test('does not apply Bedrock region prefixes to non-Bedrock custom IDs', async () => {
+      mockProvider('bedrock')
+
+      const { getAgentModel } = await import('./agent.js')
+      const result = getAgentModel(
+        undefined,
+        'eu.anthropic.claude-sonnet-4-5-20250929-v1:0',
+        'deepseek/deepseek-v4-flash:nitro',
+        'default',
+      )
+
+      expect(result).toBe('deepseek/deepseek-v4-flash:nitro')
+    })
   })
 
   describe('checkIsClaudeNativeProvider helper', () => {
     test('returns true for official Anthropic API', async () => {
-      mock.module('./providers.js', () => ({
-        getAPIProvider: () => 'firstParty',
-        isFirstPartyAnthropicBaseUrl: () => true,
-      }))
+      mockProvider('firstParty', true)
 
       const { checkIsClaudeNativeProvider } = await import('./agent.js')
       expect(checkIsClaudeNativeProvider()).toBe(true)
     })
 
     test('returns true for Bedrock provider', async () => {
-      mock.module('./providers.js', () => ({
-        getAPIProvider: () => 'bedrock',
-        isFirstPartyAnthropicBaseUrl: () => false,
-      }))
+      mockProvider('bedrock')
 
       const { checkIsClaudeNativeProvider } = await import('./agent.js')
       expect(checkIsClaudeNativeProvider()).toBe(true)
     })
 
     test('returns true for Vertex provider', async () => {
-      mock.module('./providers.js', () => ({
-        getAPIProvider: () => 'vertex',
-        isFirstPartyAnthropicBaseUrl: () => false,
-      }))
+      mockProvider('vertex')
 
       const { checkIsClaudeNativeProvider } = await import('./agent.js')
       expect(checkIsClaudeNativeProvider()).toBe(true)
     })
 
     test('returns true for Foundry provider', async () => {
-      mock.module('./providers.js', () => ({
-        getAPIProvider: () => 'foundry',
-        isFirstPartyAnthropicBaseUrl: () => false,
-      }))
+      mockProvider('foundry')
 
       const { checkIsClaudeNativeProvider } = await import('./agent.js')
       expect(checkIsClaudeNativeProvider()).toBe(true)
     })
 
     test('returns false for OpenAI provider', async () => {
-      mock.module('./providers.js', () => ({
-        getAPIProvider: () => 'openai',
-        isFirstPartyAnthropicBaseUrl: () => false,
-      }))
+      mockProvider('openai')
 
       const { checkIsClaudeNativeProvider } = await import('./agent.js')
       expect(checkIsClaudeNativeProvider()).toBe(false)
     })
 
     test('returns false for custom Anthropic URL', async () => {
-      mock.module('./providers.js', () => ({
-        getAPIProvider: () => 'firstParty',
-        isFirstPartyAnthropicBaseUrl: () => false,
-      }))
+      mockProvider('firstParty')
 
       const { checkIsClaudeNativeProvider } = await import('./agent.js')
       expect(checkIsClaudeNativeProvider()).toBe(false)

--- a/src/utils/model/agent.ts
+++ b/src/utils/model/agent.ts
@@ -2,6 +2,7 @@ import type { PermissionMode } from '../permissions/PermissionMode.js'
 import { capitalize } from '../stringUtils.js'
 import { MODEL_ALIASES } from './aliases.js'
 import { applyBedrockRegionPrefix, getBedrockRegionPrefix } from './bedrock.js'
+import { isModelAllowed } from './modelAllowlist.js'
 import {
   getCanonicalName,
   getRuntimeMainLoopModel,
@@ -77,10 +78,16 @@ export function getAgentModel(
       })
     }
     if (aliasMatchesParentTier(trimmedToolSpecifiedModel, parentModel)) {
+      assertToolSpecifiedModelAllowed(trimmedToolSpecifiedModel, parentModel)
       return parentModel
     }
     const model = parseUserSpecifiedModel(trimmedToolSpecifiedModel)
-    return applyParentRegionPrefix(model, trimmedToolSpecifiedModel)
+    const effectiveModel = applyParentRegionPrefix(
+      model,
+      trimmedToolSpecifiedModel,
+    )
+    assertToolSpecifiedModelAllowed(trimmedToolSpecifiedModel, effectiveModel)
+    return effectiveModel
   }
 
   const agentModelWithExp = agentModel ?? getDefaultSubagentModel()
@@ -147,6 +154,21 @@ function aliasMatchesParentTier(alias: string, parentModel: string): boolean {
     default:
       return false
   }
+}
+
+function assertToolSpecifiedModelAllowed(
+  requestedModel: string,
+  effectiveModel: string,
+): void {
+  if (
+    isModelAllowed(requestedModel) ||
+    (effectiveModel !== requestedModel && isModelAllowed(effectiveModel))
+  ) {
+    return
+  }
+  throw new Error(
+    `Model '${requestedModel}' is not available. Your organization restricts model selection.`,
+  )
 }
 
 /**

--- a/src/utils/model/agent.ts
+++ b/src/utils/model/agent.ts
@@ -1,6 +1,6 @@
 import type { PermissionMode } from '../permissions/PermissionMode.js'
 import { capitalize } from '../stringUtils.js'
-import { MODEL_ALIASES, type ModelAlias } from './aliases.js'
+import { MODEL_ALIASES } from './aliases.js'
 import { applyBedrockRegionPrefix, getBedrockRegionPrefix } from './bedrock.js'
 import {
   getCanonicalName,
@@ -37,7 +37,7 @@ export function getDefaultSubagentModel(): string {
 export function getAgentModel(
   agentModel: string | undefined,
   parentModel: string,
-  toolSpecifiedModel?: ModelAlias,
+  toolSpecifiedModel?: string,
   permissionMode?: PermissionMode,
 ): string {
   if (process.env.CLAUDE_CODE_SUBAGENT_MODEL) {
@@ -67,12 +67,20 @@ export function getAgentModel(
   }
 
   // Prioritize tool-specified model if provided
-  if (toolSpecifiedModel) {
-    if (aliasMatchesParentTier(toolSpecifiedModel, parentModel)) {
+  const trimmedToolSpecifiedModel = toolSpecifiedModel?.trim()
+  if (trimmedToolSpecifiedModel) {
+    if (trimmedToolSpecifiedModel.toLowerCase() === 'inherit') {
+      return getRuntimeMainLoopModel({
+        permissionMode: permissionMode ?? 'default',
+        mainLoopModel: parentModel,
+        exceeds200kTokens: false,
+      })
+    }
+    if (aliasMatchesParentTier(trimmedToolSpecifiedModel, parentModel)) {
       return parentModel
     }
-    const model = parseUserSpecifiedModel(toolSpecifiedModel)
-    return applyParentRegionPrefix(model, toolSpecifiedModel)
+    const model = parseUserSpecifiedModel(trimmedToolSpecifiedModel)
+    return applyParentRegionPrefix(model, trimmedToolSpecifiedModel)
   }
 
   const agentModelWithExp = agentModel ?? getDefaultSubagentModel()


### PR DESCRIPTION
## Summary
- Allow the Agent tool's `model` override to accept any non-empty provider-supported model string.
- Preserve existing `sonnet`, `opus`, and `haiku` alias behavior.
- Preserve existing inheritance and environment override behavior.

## Why
Partially addresses #1333. Agents were limited to Claude-family aliases in the runtime tool schema even though users may want to delegate work to other configured/provider-supported models.

## Behavior
- `model: "sonnet"`, `"opus"`, and `"haiku"` continue to work.
- Custom model IDs such as `gpt-5.5`, `mimo-v2.5-pro`, and `deepseek/deepseek-v4-flash:nitro` are accepted.
- Empty or whitespace-only model values are rejected.

## Out of scope
- New provider/profile UI
- `/model` picker changes
- New API key storage
- Full cross-provider routing UX
- Changes to agent memory, permissions, or background execution

## Testing
- GitHub Actions `pr-checks` - passed (`smoke-and-tests`, `web`).
- `bun test src/tools/AgentTool/AgentTool.schema.test.ts src/tools/AgentTool/loadAgentsDir.test.ts src/utils/model/agent.test.ts src/services/api/agentRouting.test.ts` - passed, 53 pass / 0 fail.
- `git diff --check HEAD~1..HEAD` - passed.
- `bun run build` - passed.
- `bun run smoke` - passed.
- `bun install --frozen-lockfile` - passed, no lockfile changes.
- `python -m pip install -r python/requirements.txt` - passed, requirements already satisfied locally.
- `python -m pytest -q python/tests` - passed, 44 passed.
- `bun run security:pr-scan -- --base upstream/main` - passed, no suspicious additions found.
- `bun run test:provider` - passed, 596 pass / 0 fail.
- `npm run test:provider-recommendation` - passed, 78 pass / 0 fail.
- `bun install --cwd web --frozen-lockfile` - passed, no changes.
- `bun run --cwd web typecheck` - passed.
- `bun run --cwd web build` - passed.
- Local `bun test --max-concurrency=1` - hit unrelated environment-sensitive failures on this machine, but the same workflow command passed in GitHub Actions.

Partially addresses #1333
