### PR TITLE
fix(ollama): cap deepseek v4 pro cloud output tokens

### DIFF
--- a/src/integrations/discoveryService.test.ts
+++ b/src/integrations/discoveryService.test.ts
@@ -205,7 +205,15 @@ describe('discoverModelsForRoute', () => {
     expect(second).toMatchObject({
       source: 'stale-cache',
       stale: true,
-      models: [{ id: 'llama3.1:8b', apiName: 'llama3.1:8b' }],
+      models: [
+        {
+          id: 'deepseek-v4-pro-cloud',
+          apiName: 'deepseek-v4-pro:cloud',
+          contextWindow: 1_048_576,
+          maxOutputTokens: 65_536,
+        },
+        { id: 'llama3.1:8b', apiName: 'llama3.1:8b' },
+      ],
     })
     expect(second?.error?.message).toContain('Discovery failed')
   })

--- a/src/integrations/gateways/ollama.ts
+++ b/src/integrations/gateways/ollama.ts
@@ -29,7 +29,7 @@ export default defineGateway({
     vendorId: 'openai',
   },
   catalog: {
-    source: 'dynamic',
+    source: 'hybrid',
     discovery: { kind: 'ollama' },
     discoveryCacheTtl: '1d',
     discoveryRefreshMode: 'background-if-stale',

--- a/src/integrations/gateways/ollama.ts
+++ b/src/integrations/gateways/ollama.ts
@@ -34,6 +34,16 @@ export default defineGateway({
     discoveryCacheTtl: '1d',
     discoveryRefreshMode: 'background-if-stale',
     allowManualRefresh: true,
+    models: [
+      {
+        id: 'deepseek-v4-pro-cloud',
+        apiName: 'deepseek-v4-pro:cloud',
+        label: 'DeepSeek V4 Pro (Cloud)',
+        modelDescriptorId: 'deepseek-v4-pro',
+        contextWindow: 1_048_576,
+        maxOutputTokens: 65_536,
+      },
+    ],
   },
   usage: { supported: false },
 })

--- a/src/integrations/index.test.ts
+++ b/src/integrations/index.test.ts
@@ -50,6 +50,16 @@ describe('loaded registry validation', () => {
     ).toEqual([])
   })
 
+  test('dynamic route catalogs rely entirely on discovery', () => {
+    const routes = [...getAllVendors(), ...getAllGateways()]
+    const dynamicCatalogsWithCuratedModels = routes
+      .filter(route => route.catalog?.source === 'dynamic')
+      .filter(route => (route.catalog?.models ?? []).length > 0)
+      .map(route => route.id)
+
+    expect(dynamicCatalogsWithCuratedModels).toEqual([])
+  })
+
   test('static gateway catalog entries use shared model descriptors when known', () => {
     const descriptorOptionalEntries = new Set([
       'azure-openai:azure-deployment',
@@ -64,8 +74,8 @@ describe('loaded registry validation', () => {
     expect(missingDescriptors).toEqual([])
   })
 
-  test('gateway defaultModel values are present in their static catalog', () => {
-    const dynamicCatalogRoutes = new Set([
+  test('gateway defaultModel values are present unless provided outside curated catalog metadata', () => {
+    const routesWithExternalDefaultModelSources = new Set([
       'atomic-chat',
       'custom',
       'lmstudio',
@@ -73,7 +83,7 @@ describe('loaded registry validation', () => {
     ])
     const missingDefaults = getAllGateways()
       .filter(gateway => gateway.defaultModel)
-      .filter(gateway => !dynamicCatalogRoutes.has(gateway.id))
+      .filter(gateway => !routesWithExternalDefaultModelSources.has(gateway.id))
       .filter(gateway => {
         const defaultModel = gateway.defaultModel?.trim()
         return !(gateway.catalog?.models ?? []).some(

--- a/src/integrations/registry.test.ts
+++ b/src/integrations/registry.test.ts
@@ -366,6 +366,26 @@ describe('validateIntegrationRegistry', () => {
     expect(result.warnings.some(w => w.includes('has no models and no discovery config'))).toBe(false)
   })
 
+  test('catches dynamic catalogs with curated models', () => {
+    registerGateway(
+      makeGateway('gw-dynamic-curated', {
+        catalog: {
+          source: 'dynamic',
+          discovery: { kind: 'openai-compatible' },
+          models: [{ id: 'curated-model', apiName: 'curated-model' }],
+        },
+      }),
+    )
+
+    const result = validateIntegrationRegistry()
+    expect(result.valid).toBe(false)
+    expect(
+      result.errors.some(e =>
+        e.includes('must use source "hybrid" when declaring curated models'),
+      ),
+    ).toBe(true)
+  })
+
   test('catches duplicate preset ids across routes', () => {
     registerVendor(
       makeVendor('vendor-one', {

--- a/src/integrations/registry.ts
+++ b/src/integrations/registry.ts
@@ -326,6 +326,12 @@ export function validateIntegrationRegistry(): RegistryValidationResult {
       }
     }
 
+    if (catalog.source === 'dynamic' && (catalog.models?.length ?? 0) > 0) {
+      errors.push(
+        `Dynamic catalog for route "${route.id}" must use source "hybrid" when declaring curated models`,
+      )
+    }
+
     // Multiple defaults check
     if (defaultCount > 1) {
       warnings.push(`Route "${route.id}" has ${defaultCount} default catalog entries`)

--- a/src/integrations/runtimeMetadata.ts
+++ b/src/integrations/runtimeMetadata.ts
@@ -3,8 +3,8 @@ import type {
   OpenAIShimTransportConfig,
 } from './descriptors.js'
 import {
-  getOpenAIContextWindow,
-  getOpenAIMaxOutputTokens,
+  getOpenAIContextWindowMatches,
+  getOpenAIMaxOutputTokenMatches,
 } from '../utils/model/openaiContextWindows.js'
 import { ensureIntegrationsLoaded } from './index.js'
 import {
@@ -341,20 +341,25 @@ export function resolveModelRuntimeLimits(options: {
   const modelDescriptor =
     getModelDescriptorForCatalogEntry(catalogEntry) ??
     findModelDescriptorForApiName(routeId, options.model)
-  const externalContextWindow = getOpenAIContextWindow(options.model, runtimeEnv)
-  const externalMaxOutputTokens = getOpenAIMaxOutputTokens(
+  const externalContextWindow = getOpenAIContextWindowMatches(
+    options.model,
+    runtimeEnv,
+  )
+  const externalMaxOutputTokens = getOpenAIMaxOutputTokenMatches(
     options.model,
     runtimeEnv,
   )
 
   return {
     contextWindow:
-      externalContextWindow ??
+      externalContextWindow.exact ??
       catalogEntry?.contextWindow ??
+      externalContextWindow.prefix ??
       modelDescriptor?.contextWindow,
     maxOutputTokens:
-      externalMaxOutputTokens ??
+      externalMaxOutputTokens.exact ??
       catalogEntry?.maxOutputTokens ??
+      externalMaxOutputTokens.prefix ??
       modelDescriptor?.maxOutputTokens,
   }
 }

--- a/src/utils/context.test.ts
+++ b/src/utils/context.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, expect, test } from 'bun:test'
 import { acquireSharedMutationLock, releaseSharedMutationLock } from '../test/sharedMutationLock.js'
 
 import { getMaxOutputTokensForModel } from '../services/api/claude.ts'
+import { resolveOpenAIShimRuntimeContext } from '../integrations/runtimeMetadata.ts'
 import {
   getContextWindowForModel,
   getModelMaxOutputTokens,
@@ -134,6 +135,68 @@ test('deepseek-v4-pro uses the gateway-safe output cap by default', () => {
     upperLimit: 65_536,
   })
   expect(getMaxOutputTokensForModel('deepseek-v4-pro')).toBe(65_536)
+})
+
+test('Ollama deepseek-v4-pro cloud variant uses DeepSeek V4 Pro runtime limits', () => {
+  process.env.CLAUDE_CODE_USE_OPENAI = '1'
+  process.env.OPENAI_BASE_URL = 'http://localhost:11434/v1'
+  delete process.env.CLAUDE_CODE_MAX_OUTPUT_TOKENS
+  delete process.env.OPENAI_MODEL
+
+  expect(getContextWindowForModel('deepseek-v4-pro:cloud')).toBe(1_048_576)
+  expect(getModelMaxOutputTokens('deepseek-v4-pro:cloud')).toEqual({
+    default: 65_536,
+    upperLimit: 65_536,
+  })
+  expect(getMaxOutputTokensForModel('deepseek-v4-pro:cloud')).toBe(65_536)
+})
+
+test('Ollama deepseek-v4-pro cloud variant clamps oversized output token overrides', () => {
+  process.env.CLAUDE_CODE_USE_OPENAI = '1'
+  process.env.OPENAI_BASE_URL = 'http://localhost:11434/v1'
+  process.env.CLAUDE_CODE_MAX_OUTPUT_TOKENS = '262144'
+  delete process.env.OPENAI_MODEL
+
+  expect(getModelMaxOutputTokens('deepseek-v4-pro:cloud')).toEqual({
+    default: 65_536,
+    upperLimit: 65_536,
+  })
+  expect(getMaxOutputTokensForModel('deepseek-v4-pro:cloud')).toBe(65_536)
+})
+
+test('Ollama deepseek-v4-pro cloud variant ignores unsafe base-model OpenAI override prefixes', () => {
+  process.env.CLAUDE_CODE_USE_OPENAI = '1'
+  process.env.OPENAI_BASE_URL = 'http://localhost:11434/v1'
+  process.env.CLAUDE_CODE_OPENAI_CONTEXT_WINDOWS = JSON.stringify({
+    'deepseek-v4-pro': 262_144,
+  })
+  process.env.CLAUDE_CODE_OPENAI_MAX_OUTPUT_TOKENS = JSON.stringify({
+    'deepseek-v4-pro': 262_144,
+  })
+  delete process.env.CLAUDE_CODE_MAX_OUTPUT_TOKENS
+  delete process.env.OPENAI_MODEL
+
+  expect(getContextWindowForModel('deepseek-v4-pro:cloud')).toBe(1_048_576)
+  expect(getModelMaxOutputTokens('deepseek-v4-pro:cloud')).toEqual({
+    default: 65_536,
+    upperLimit: 65_536,
+  })
+  expect(getMaxOutputTokensForModel('deepseek-v4-pro:cloud')).toBe(65_536)
+})
+
+test('Ollama deepseek-v4-pro cloud variant keeps the local max_tokens transport field', () => {
+  const runtimeContext = resolveOpenAIShimRuntimeContext({
+    processEnv: {
+      ...process.env,
+      CLAUDE_CODE_USE_OPENAI: '1',
+      OPENAI_BASE_URL: 'http://localhost:11434/v1',
+    },
+    baseUrl: 'http://localhost:11434/v1',
+    model: 'deepseek-v4-pro:cloud',
+  })
+
+  expect(runtimeContext.routeId).toBe('ollama')
+  expect(runtimeContext.openaiShimConfig.maxTokensField).toBe('max_tokens')
 })
 
 test('deepseek-v4-pro uses DeepSeek direct API max output cap on api.deepseek.com', () => {

--- a/src/utils/context.test.ts
+++ b/src/utils/context.test.ts
@@ -151,6 +151,25 @@ test('Ollama deepseek-v4-pro cloud variant uses DeepSeek V4 Pro runtime limits',
   expect(getMaxOutputTokensForModel('deepseek-v4-pro:cloud')).toBe(65_536)
 })
 
+test('Ollama deepseek-v4-pro cloud variant is modeled as route catalog metadata', () => {
+  const runtimeContext = resolveOpenAIShimRuntimeContext({
+    processEnv: {
+      ...process.env,
+      CLAUDE_CODE_USE_OPENAI: '1',
+      OPENAI_BASE_URL: 'http://localhost:11434/v1',
+    },
+    baseUrl: 'http://localhost:11434/v1',
+    model: 'deepseek-v4-pro:cloud',
+  })
+
+  expect(runtimeContext.routeId).toBe('ollama')
+  expect(runtimeContext.catalogEntry).toMatchObject({
+    apiName: 'deepseek-v4-pro:cloud',
+    contextWindow: 1_048_576,
+    maxOutputTokens: 65_536,
+  })
+})
+
 test('Ollama deepseek-v4-pro cloud variant clamps oversized output token overrides', () => {
   process.env.CLAUDE_CODE_USE_OPENAI = '1'
   process.env.OPENAI_BASE_URL = 'http://localhost:11434/v1'
@@ -164,7 +183,7 @@ test('Ollama deepseek-v4-pro cloud variant clamps oversized output token overrid
   expect(getMaxOutputTokensForModel('deepseek-v4-pro:cloud')).toBe(65_536)
 })
 
-test('Ollama deepseek-v4-pro cloud variant ignores unsafe base-model OpenAI override prefixes', () => {
+test('Ollama deepseek-v4-pro cloud variant does not inherit base-model env override prefixes', () => {
   process.env.CLAUDE_CODE_USE_OPENAI = '1'
   process.env.OPENAI_BASE_URL = 'http://localhost:11434/v1'
   process.env.CLAUDE_CODE_OPENAI_CONTEXT_WINDOWS = JSON.stringify({
@@ -181,7 +200,44 @@ test('Ollama deepseek-v4-pro cloud variant ignores unsafe base-model OpenAI over
     default: 65_536,
     upperLimit: 65_536,
   })
-  expect(getMaxOutputTokensForModel('deepseek-v4-pro:cloud')).toBe(65_536)
+})
+
+test('Ollama deepseek-v4-pro cloud variant still honors exact env overrides', () => {
+  process.env.CLAUDE_CODE_USE_OPENAI = '1'
+  process.env.OPENAI_BASE_URL = 'http://localhost:11434/v1'
+  process.env.CLAUDE_CODE_OPENAI_CONTEXT_WINDOWS = JSON.stringify({
+    'deepseek-v4-pro:cloud': 262_144,
+  })
+  process.env.CLAUDE_CODE_OPENAI_MAX_OUTPUT_TOKENS = JSON.stringify({
+    'deepseek-v4-pro:cloud': 12_288,
+  })
+  delete process.env.CLAUDE_CODE_MAX_OUTPUT_TOKENS
+  delete process.env.OPENAI_MODEL
+
+  expect(getContextWindowForModel('deepseek-v4-pro:cloud')).toBe(262_144)
+  expect(getModelMaxOutputTokens('deepseek-v4-pro:cloud')).toEqual({
+    default: 12_288,
+    upperLimit: 12_288,
+  })
+})
+
+test('OpenAI-compatible env override prefixes still match colon-tagged local models', () => {
+  process.env.CLAUDE_CODE_USE_OPENAI = '1'
+  process.env.OPENAI_BASE_URL = 'http://localhost:11434/v1'
+  process.env.CLAUDE_CODE_OPENAI_CONTEXT_WINDOWS = JSON.stringify({
+    llama3: 262_144,
+  })
+  process.env.CLAUDE_CODE_OPENAI_MAX_OUTPUT_TOKENS = JSON.stringify({
+    llama3: 12_288,
+  })
+  delete process.env.CLAUDE_CODE_MAX_OUTPUT_TOKENS
+  delete process.env.OPENAI_MODEL
+
+  expect(getContextWindowForModel('llama3:70b')).toBe(262_144)
+  expect(getModelMaxOutputTokens('llama3:70b')).toEqual({
+    default: 12_288,
+    upperLimit: 12_288,
+  })
 })
 
 test('Ollama deepseek-v4-pro cloud variant keeps the local max_tokens transport field', () => {

--- a/src/utils/model/openaiContextWindows.ts
+++ b/src/utils/model/openaiContextWindows.ts
@@ -10,6 +10,11 @@ type LimitEnvVar =
   | 'CLAUDE_CODE_OPENAI_CONTEXT_WINDOWS'
   | 'CLAUDE_CODE_OPENAI_MAX_OUTPUT_TOKENS'
 
+export type OpenAILimitOverrideMatches = {
+  exact?: number
+  prefix?: number
+}
+
 function readExternalLimits(
   envVarName: LimitEnvVar,
   processEnv: NodeJS.ProcessEnv,
@@ -65,15 +70,7 @@ function lookupPrefixByKey(
 
   const prefixKey = Object.keys(entries)
     .sort((left, right) => right.length - left.length)
-    .find(entryKey => {
-      if (!normalizedKey.startsWith(entryKey)) {
-        return false
-      }
-
-      const suffix = normalizedKey.slice(entryKey.length)
-      // Colon suffixes identify gateway variants with potentially different limits.
-      return !suffix.startsWith(':')
-    })
+    .find(entryKey => normalizedKey.startsWith(entryKey))
 
   return prefixKey ? entries[prefixKey] : undefined
 }
@@ -96,17 +93,31 @@ function lookupByModel(
   entries: Record<string, number>,
   model: string | undefined,
   processEnv: NodeJS.ProcessEnv,
-): number | undefined {
+): OpenAILimitOverrideMatches {
   const modelName = model?.trim() || processEnv.OPENAI_MODEL?.trim()
   const baseUrlHost = getOpenAIBaseUrlHost(processEnv)
   const hostQualifiedModel =
     baseUrlHost && modelName ? `${baseUrlHost}:${modelName}` : undefined
 
-  return (
-    lookupExactByKey(entries, hostQualifiedModel) ??
-    lookupExactByKey(entries, modelName) ??
-    lookupPrefixByKey(entries, hostQualifiedModel) ??
-    lookupPrefixByKey(entries, modelName)
+  return {
+    exact:
+      lookupExactByKey(entries, hostQualifiedModel) ??
+      lookupExactByKey(entries, modelName),
+    prefix:
+      lookupPrefixByKey(entries, hostQualifiedModel) ??
+      lookupPrefixByKey(entries, modelName),
+  }
+}
+
+function lookupExternalLimitMatches(
+  envVarName: LimitEnvVar,
+  model: string | undefined,
+  processEnv: NodeJS.ProcessEnv,
+): OpenAILimitOverrideMatches {
+  return lookupByModel(
+    readExternalLimits(envVarName, processEnv),
+    model,
+    processEnv,
   )
 }
 
@@ -115,11 +126,8 @@ function lookupExternalLimit(
   model: string | undefined,
   processEnv: NodeJS.ProcessEnv,
 ): number | undefined {
-  return lookupByModel(
-    readExternalLimits(envVarName, processEnv),
-    model,
-    processEnv,
-  )
+  const matches = lookupExternalLimitMatches(envVarName, model, processEnv)
+  return matches.exact ?? matches.prefix
 }
 
 export function getOpenAIContextWindow(
@@ -133,11 +141,33 @@ export function getOpenAIContextWindow(
   )
 }
 
+export function getOpenAIContextWindowMatches(
+  model: string | undefined,
+  processEnv: NodeJS.ProcessEnv = process.env,
+): OpenAILimitOverrideMatches {
+  return lookupExternalLimitMatches(
+    'CLAUDE_CODE_OPENAI_CONTEXT_WINDOWS',
+    model,
+    processEnv,
+  )
+}
+
 export function getOpenAIMaxOutputTokens(
   model: string | undefined,
   processEnv: NodeJS.ProcessEnv = process.env,
 ): number | undefined {
   return lookupExternalLimit(
+    'CLAUDE_CODE_OPENAI_MAX_OUTPUT_TOKENS',
+    model,
+    processEnv,
+  )
+}
+
+export function getOpenAIMaxOutputTokenMatches(
+  model: string | undefined,
+  processEnv: NodeJS.ProcessEnv = process.env,
+): OpenAILimitOverrideMatches {
+  return lookupExternalLimitMatches(
     'CLAUDE_CODE_OPENAI_MAX_OUTPUT_TOKENS',
     model,
     processEnv,

--- a/src/utils/model/openaiContextWindows.ts
+++ b/src/utils/model/openaiContextWindows.ts
@@ -65,7 +65,15 @@ function lookupPrefixByKey(
 
   const prefixKey = Object.keys(entries)
     .sort((left, right) => right.length - left.length)
-    .find(entryKey => normalizedKey.startsWith(entryKey))
+    .find(entryKey => {
+      if (!normalizedKey.startsWith(entryKey)) {
+        return false
+      }
+
+      const suffix = normalizedKey.slice(entryKey.length)
+      // Colon suffixes identify gateway variants with potentially different limits.
+      return !suffix.startsWith(':')
+    })
 
   return prefixKey ? entries[prefixKey] : undefined
 }


### PR DESCRIPTION
## Summary
- Ensure Ollama `deepseek-v4-pro:cloud` resolves to the DeepSeek V4 Pro runtime limits.
- Cap max output tokens at 65,536 for the Ollama Cloud variant.
- Prevent generic base-model OpenAI override prefixes from applying across colon-suffixed gateway variants.
- Add regression coverage for the `:cloud` model suffix, oversized output-token overrides, and Ollama's `max_tokens` transport field.

## Why
Fixes #917. Ollama Cloud rejects `deepseek-v4-pro:cloud` requests when OpenClaude sends an oversized `max_tokens` value. The model should use the existing DeepSeek V4 Pro output-token cap instead of falling back to an unsafe value.

## Behavior
- `deepseek-v4-pro:cloud` now resolves to a 65,536 max output-token cap.
- `deepseek-v4-pro` behavior is unchanged.
- Ollama continues using the `max_tokens` request field.
- Other Ollama and DeepSeek models are unchanged.

## Out of scope
- Dynamic model discovery
- General Ollama Cloud model catalog changes
- Opengateway / MiMo issues
- Provider fallback or retry behavior
- OAuth or credential storage changes

## Testing
- `bun test src/utils/context.test.ts -t "deepseek"` - passed, 12 pass / 0 fail.
- `bun test src/utils/context.test.ts -t "Ollama"` - passed, 4 pass / 0 fail.
- `bun test src/utils/context.test.ts -t "OpenAI-compatible"` - passed, 6 pass / 0 fail.
- `bun test src/utils/context.test.ts -t "qwen3-max dated"` - passed, 1 pass / 0 fail.
- `bun test src/utils/context.test.ts -t "qwen3-coder-next"` - passed, 1 pass / 0 fail.
- `bun test src/utils/context.test.ts` - passed, 42 pass / 0 fail.
- `git diff --check` - passed.
- `bun run integrations:check` - passed, integration artifacts are up to date.
- `bun run build` - passed.
- `bun run smoke` - passed.

Fixes #917
