### PR TITLE
fix(permissions): respect accept edits for file writes

### DIFF
--- a/src/entrypoints/sdk/permissions.test.ts
+++ b/src/entrypoints/sdk/permissions.test.ts
@@ -1,0 +1,543 @@
+import {
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  test,
+} from 'bun:test'
+
+import { runWithSdkContext } from '../../bootstrap/state.js'
+import type { CanUseToolFn } from '../../hooks/useCanUseTool.js'
+import {
+  assistantMessage,
+  makeAppStateWithPermissionContext,
+  makeToolUseContext,
+} from '../../test/permissionTestHelpers.js'
+import {
+  acquireSharedMutationLock,
+  releaseSharedMutationLock,
+} from '../../test/sharedMutationLock.js'
+import type { ToolPermissionContext } from '../../Tool.js'
+import { FileEditTool } from '../../tools/FileEditTool/FileEditTool.js'
+import { FileReadTool } from '../../tools/FileReadTool/FileReadTool.js'
+import { FileWriteTool } from '../../tools/FileWriteTool/FileWriteTool.js'
+import { NotebookEditTool } from '../../tools/NotebookEditTool/NotebookEditTool.js'
+import type { SessionId } from '../../types/ids.js'
+import { hasPermissionsToUseTool } from '../../utils/permissions/permissions.js'
+import type { QueryPermissionMode, SDKPermissionRequestMessage } from './shared.js'
+import {
+  buildPermissionContext,
+  createDefaultCanUseTool,
+  createExternalCanUseTool,
+  createPermissionTarget,
+} from './permissions.js'
+import { query } from './query.js'
+import { unstable_v2_createSession } from './v2.js'
+
+const permissionTestTools = [
+  FileEditTool,
+  FileReadTool,
+  FileWriteTool,
+  NotebookEditTool,
+]
+const quietLogger = { warn: () => {} }
+
+type SdkEngineConfig = {
+  canUseTool: CanUseToolFn
+  getAppState: () => ReturnType<typeof makeAppStateWithPermissionContext>
+}
+
+function getQueryEngineConfig(sdkQuery: unknown): SdkEngineConfig {
+  return (sdkQuery as { _engine: { config: SdkEngineConfig } })._engine.config
+}
+
+function getSessionEngineConfig(session: unknown): SdkEngineConfig {
+  return (session as { _engine: { config: SdkEngineConfig } })._engine.config
+}
+
+function runWithSdkTestContext<T>(
+  cwd: string,
+  fn: () => T,
+  sessionId: string = 'sdk-test-session',
+): T {
+  return runWithSdkContext(
+    {
+      sessionId: sessionId as SessionId,
+      sessionProjectDir: null,
+      cwd,
+      originalCwd: cwd,
+    },
+    fn,
+  )
+}
+
+function checkSdkToolPermission(
+  cwd: string,
+  canUseTool: CanUseToolFn,
+  tool: Parameters<CanUseToolFn>[0],
+  input: Parameters<CanUseToolFn>[1],
+  toolUseContext: Parameters<CanUseToolFn>[2],
+  toolUseID: string,
+) {
+  return runWithSdkTestContext(cwd, () =>
+    canUseTool(tool, input, toolUseContext, assistantMessage, toolUseID),
+  )
+}
+
+function makeSdkPermissionHarness({
+  cwd,
+  permissionMode,
+  permissionContext,
+}: {
+  cwd: string
+  permissionMode?: QueryPermissionMode
+  permissionContext?: ToolPermissionContext
+}) {
+  const toolPermissionContext =
+    permissionContext ??
+    buildPermissionContext({
+      cwd,
+      permissionMode,
+    })
+  const appState = makeAppStateWithPermissionContext(toolPermissionContext)
+  const toolUseContext = makeToolUseContext(appState, permissionTestTools)
+  const permissionTarget = createPermissionTarget()
+  const requests: SDKPermissionRequestMessage[] = []
+
+  const canUseTool = createExternalCanUseTool(
+    undefined,
+    createDefaultCanUseTool(toolPermissionContext, quietLogger),
+    permissionTarget,
+    request => {
+      requests.push(request)
+      permissionTarget.pendingPermissionPrompts
+        .get(request.tool_use_id)
+        ?.resolve({
+          behavior: 'deny',
+          message: 'host denied permission request',
+          decisionReason: { type: 'mode', mode: 'default' },
+        })
+    },
+    undefined,
+    50,
+    'sdk-test-session',
+    quietLogger,
+    hasPermissionsToUseTool,
+  )
+
+  return {
+    canUseTool,
+    requests,
+    toolUseContext,
+  }
+}
+
+describe('SDK file write permissions', () => {
+  let workspace: string
+
+  beforeAll(async () => {
+    await acquireSharedMutationLock('entrypoints/sdk/permissions.test.ts')
+  })
+
+  afterAll(() => {
+    releaseSharedMutationLock()
+  })
+
+  beforeEach(() => {
+    workspace = mkdtempSync(join(tmpdir(), 'openclaude-sdk-permissions-'))
+  })
+
+  afterEach(() => {
+    rmSync(workspace, { recursive: true, force: true })
+  })
+
+  test('does not emit permission requests for FileEdit in acceptEdits mode', async () => {
+    const filePath = join(workspace, 'src', 'index.ts')
+    mkdirSync(join(workspace, 'src'))
+    writeFileSync(filePath, 'const value = 1\n')
+    const { canUseTool, requests, toolUseContext } = makeSdkPermissionHarness({
+      cwd: workspace,
+      permissionMode: 'acceptEdits',
+    })
+
+    const result = await checkSdkToolPermission(
+      workspace,
+      canUseTool,
+      FileEditTool,
+      {
+        file_path: filePath,
+        old_string: '1',
+        new_string: '2',
+      },
+      toolUseContext,
+      'toolu_sdk_file_edit',
+    )
+
+    expect(result.behavior).toBe('allow')
+    expect(requests).toHaveLength(0)
+  })
+
+  test('does not emit permission requests for FileWrite updates in acceptEdits mode', async () => {
+    const filePath = join(workspace, 'package.json')
+    writeFileSync(filePath, '{}\n')
+    const { canUseTool, requests, toolUseContext } = makeSdkPermissionHarness({
+      cwd: workspace,
+      permissionMode: 'acceptEdits',
+    })
+
+    const result = await checkSdkToolPermission(
+      workspace,
+      canUseTool,
+      FileWriteTool,
+      {
+        file_path: filePath,
+        content: '{"private": true}\n',
+      },
+      toolUseContext,
+      'toolu_sdk_file_write_update',
+    )
+
+    expect(result.behavior).toBe('allow')
+    expect(requests).toHaveLength(0)
+  })
+
+  test('does not emit permission requests for FileWrite creates in acceptEdits mode', async () => {
+    const filePath = join(workspace, 'new-file.ts')
+    const { canUseTool, requests, toolUseContext } = makeSdkPermissionHarness({
+      cwd: workspace,
+      permissionMode: 'acceptEdits',
+    })
+
+    const result = await checkSdkToolPermission(
+      workspace,
+      canUseTool,
+      FileWriteTool,
+      {
+        file_path: filePath,
+        content: 'export const value = 1\n',
+      },
+      toolUseContext,
+      'toolu_sdk_file_write_create',
+    )
+
+    expect(result.behavior).toBe('allow')
+    expect(requests).toHaveLength(0)
+  })
+
+  test('query() wires acceptEdits file writes through the internal resolver', async () => {
+    const filePath = join(workspace, 'query-entrypoint.ts')
+    const requests: SDKPermissionRequestMessage[] = []
+    const sdkQuery = query({
+      prompt: 'test prompt',
+      options: {
+        cwd: workspace,
+        permissionMode: 'acceptEdits',
+        onPermissionRequest: request => {
+          requests.push(request)
+        },
+      },
+    })
+    const config = getQueryEngineConfig(sdkQuery)
+
+    const result = await runWithSdkTestContext(
+      workspace,
+      () =>
+        config.canUseTool(
+          FileWriteTool,
+          {
+            file_path: filePath,
+            content: 'export const value = 1\n',
+          },
+          makeToolUseContext(config.getAppState(), permissionTestTools),
+          assistantMessage,
+          'toolu_sdk_query_file_write',
+        ),
+      sdkQuery.sessionId,
+    )
+
+    expect(result.behavior).toBe('allow')
+    expect(requests).toHaveLength(0)
+  })
+
+  test('unstable_v2_createSession wires acceptEdits file writes through the internal resolver', async () => {
+    const filePath = join(workspace, 'v2-entrypoint.ts')
+    const requests: SDKPermissionRequestMessage[] = []
+    const session = unstable_v2_createSession({
+      cwd: workspace,
+      permissionMode: 'acceptEdits',
+      onPermissionRequest: request => {
+        requests.push(request)
+      },
+    })
+    const config = getSessionEngineConfig(session)
+
+    try {
+      const result = await runWithSdkTestContext(
+        workspace,
+        () =>
+          config.canUseTool(
+            FileWriteTool,
+            {
+              file_path: filePath,
+              content: 'export const value = 1\n',
+            },
+            makeToolUseContext(config.getAppState(), permissionTestTools),
+            assistantMessage,
+            'toolu_sdk_v2_file_write',
+          ),
+        session.sessionId,
+      )
+
+      expect(result.behavior).toBe('allow')
+      expect(requests).toHaveLength(0)
+    } finally {
+      session.close()
+    }
+  })
+
+  test('does not emit permission requests for NotebookEdit in acceptEdits mode', async () => {
+    const filePath = join(workspace, 'analysis.ipynb')
+    writeFileSync(filePath, '{"cells":[],"metadata":{},"nbformat":4}\n')
+    const { canUseTool, requests, toolUseContext } = makeSdkPermissionHarness({
+      cwd: workspace,
+      permissionMode: 'acceptEdits',
+    })
+
+    const result = await checkSdkToolPermission(
+      workspace,
+      canUseTool,
+      NotebookEditTool,
+      {
+        notebook_path: filePath,
+        cell_id: 'cell-1',
+        new_source: 'print("ok")',
+        cell_type: 'code',
+        edit_mode: 'replace',
+      },
+      toolUseContext,
+      'toolu_sdk_notebook_edit',
+    )
+
+    expect(result.behavior).toBe('allow')
+    expect(requests).toHaveLength(0)
+  })
+
+  test('still emits permission requests for normal writes in default mode', async () => {
+    const filePath = join(workspace, 'default-mode.ts')
+    const { canUseTool, requests, toolUseContext } = makeSdkPermissionHarness({
+      cwd: workspace,
+      permissionMode: 'default',
+    })
+
+    const result = await checkSdkToolPermission(
+      workspace,
+      canUseTool,
+      FileWriteTool,
+      {
+        file_path: filePath,
+        content: 'export const value = 1\n',
+      },
+      toolUseContext,
+      'toolu_sdk_file_write_default',
+    )
+
+    expect(result.behavior).toBe('deny')
+    expect(requests).toHaveLength(1)
+  })
+
+  test('does not emit permission requests when explicit deny rules match in acceptEdits mode', async () => {
+    const filePath = join(workspace, 'blocked.ts')
+    const permissionContext = buildPermissionContext({
+      cwd: workspace,
+      permissionMode: 'acceptEdits',
+    })
+    const { canUseTool, requests, toolUseContext } = makeSdkPermissionHarness({
+      cwd: workspace,
+      permissionContext: {
+        ...permissionContext,
+        alwaysDenyRules: {
+          session: ['Edit(/blocked.ts)'],
+        },
+      },
+    })
+
+    const result = await checkSdkToolPermission(
+      workspace,
+      canUseTool,
+      FileWriteTool,
+      {
+        file_path: filePath,
+        content: 'export const value = 1\n',
+      },
+      toolUseContext,
+      'toolu_sdk_file_write_deny',
+    )
+
+    expect(result.behavior).toBe('deny')
+    expect(requests).toHaveLength(0)
+  })
+
+  test('does not emit permission requests for canonicalized denied paths in acceptEdits mode', async () => {
+    const filePath = join(workspace, 'BLOCKED.TS.')
+    const permissionContext = buildPermissionContext({
+      cwd: workspace,
+      permissionMode: 'acceptEdits',
+    })
+    const { canUseTool, requests, toolUseContext } = makeSdkPermissionHarness({
+      cwd: workspace,
+      permissionContext: {
+        ...permissionContext,
+        alwaysDenyRules: {
+          session: ['Edit(/blocked.ts)'],
+        },
+      },
+    })
+
+    const result = await checkSdkToolPermission(
+      workspace,
+      canUseTool,
+      FileWriteTool,
+      {
+        file_path: filePath,
+        content: 'export const value = 1\n',
+      },
+      toolUseContext,
+      'toolu_sdk_file_write_canonical_deny',
+    )
+
+    expect(result.behavior).toBe('deny')
+    expect(requests).toHaveLength(0)
+  })
+
+  test('does not emit permission requests for Windows short-name denied paths in acceptEdits mode', async () => {
+    const filePath = join(workspace, 'BLOCKE~1.TS')
+    const permissionContext = buildPermissionContext({
+      cwd: workspace,
+      permissionMode: 'acceptEdits',
+    })
+    const { canUseTool, requests, toolUseContext } = makeSdkPermissionHarness({
+      cwd: workspace,
+      permissionContext: {
+        ...permissionContext,
+        alwaysDenyRules: {
+          session: ['Edit(/blocked-file.ts)'],
+        },
+      },
+    })
+
+    const result = await checkSdkToolPermission(
+      workspace,
+      canUseTool,
+      FileWriteTool,
+      {
+        file_path: filePath,
+        content: 'export const value = 1\n',
+      },
+      toolUseContext,
+      'toolu_sdk_file_write_short_name_deny',
+    )
+
+    expect(result.behavior).toBe('deny')
+    expect(requests).toHaveLength(0)
+  })
+
+  test('still emits permission requests for safety checks in acceptEdits mode', async () => {
+    const gitDir = join(workspace, '.git')
+    const filePath = join(gitDir, 'config')
+    mkdirSync(gitDir)
+    const { canUseTool, requests, toolUseContext } = makeSdkPermissionHarness({
+      cwd: workspace,
+      permissionMode: 'acceptEdits',
+    })
+
+    const result = await checkSdkToolPermission(
+      workspace,
+      canUseTool,
+      FileWriteTool,
+      {
+        file_path: filePath,
+        content: '[core]\nrepositoryformatversion = 0\n',
+      },
+      toolUseContext,
+      'toolu_sdk_file_write_safety',
+    )
+
+    expect(result.behavior).toBe('deny')
+    expect(requests).toHaveLength(1)
+  })
+
+  test('still emits permission requests for FileRead in acceptEdits mode', async () => {
+    const filePath = join(workspace, 'readme.md')
+    writeFileSync(filePath, '# Read me\n')
+    const { canUseTool, requests, toolUseContext } = makeSdkPermissionHarness({
+      cwd: workspace,
+      permissionMode: 'acceptEdits',
+    })
+
+    const result = await checkSdkToolPermission(
+      workspace,
+      canUseTool,
+      FileReadTool,
+      {
+        file_path: filePath,
+      },
+      toolUseContext,
+      'toolu_sdk_file_read',
+    )
+
+    expect(result.behavior).toBe('deny')
+    expect(requests).toHaveLength(1)
+  })
+
+  test('keeps SDK secure-by-default behavior without external permission requests', async () => {
+    const filePath = join(workspace, 'secure-default.ts')
+    const permissionContext = buildPermissionContext({
+      cwd: workspace,
+      permissionMode: 'acceptEdits',
+    })
+    const permissionTarget = createPermissionTarget()
+    const canUseTool = createExternalCanUseTool(
+      undefined,
+      createDefaultCanUseTool(permissionContext, quietLogger),
+      permissionTarget,
+      undefined,
+      undefined,
+      50,
+      'sdk-test-session',
+      quietLogger,
+      hasPermissionsToUseTool,
+    )
+
+    const result = await runWithSdkTestContext(
+      workspace,
+      () =>
+        canUseTool(
+          FileWriteTool,
+          {
+            file_path: filePath,
+            content: 'export const value = 1\n',
+          },
+          makeToolUseContext(
+            makeAppStateWithPermissionContext(permissionContext),
+            permissionTestTools,
+          ),
+          assistantMessage,
+          'toolu_sdk_file_write_secure_default',
+        ),
+      'sdk-test-session',
+    )
+
+    expect(result.behavior).toBe('deny')
+  })
+})

--- a/src/entrypoints/sdk/permissions.ts
+++ b/src/entrypoints/sdk/permissions.ts
@@ -15,7 +15,10 @@ import {
   type ToolPermissionContext,
   type Tool,
 } from '../../Tool.js'
+import { FILE_EDIT_TOOL_NAME } from '../../tools/FileEditTool/constants.js'
+import { FILE_WRITE_TOOL_NAME } from '../../tools/FileWriteTool/constants.js'
 import { MCPTool } from '../../tools/MCPTool/MCPTool.js'
+import { NOTEBOOK_EDIT_TOOL_NAME } from '../../tools/NotebookEditTool/constants.js'
 import type { MCPServerConnection, ScopedMcpServerConfig } from '../../services/mcp/types.js'
 import { connectToServer, fetchToolsForClient } from '../../services/mcp/client.js'
 import type {
@@ -215,6 +218,12 @@ export function buildPermissionContext(options: PermissionContextOptions): ToolP
   }
 }
 
+const INTERNAL_FILE_WRITE_PERMISSION_TOOLS = new Set([
+  FILE_EDIT_TOOL_NAME,
+  FILE_WRITE_TOOL_NAME,
+  NOTEBOOK_EDIT_TOOL_NAME,
+])
+
 // ============================================================================
 // createExternalCanUseTool
 // ============================================================================
@@ -224,14 +233,15 @@ export function buildPermissionContext(options: PermissionContextOptions): ToolP
  * via respondToPermission().
  *
  * When a user-provided canUseTool callback exists, it takes priority.
- * Otherwise, a permission_request message is emitted to the SDK stream,
- * and the host can resolve it via respondToPermission() before the timeout.
+ * Otherwise, internal file-write permission rules may allow or deny edit/write
+ * tools before a permission_request message is emitted to the SDK stream.
  *
  * The flow:
  * 1. QueryEngine calls canUseTool(tool, input, ..., toolUseID, forceDecision)
  * 2. If forceDecision is set, honor it immediately
  * 3. If user canUseTool callback exists, delegate to it
- * 4. Otherwise, emit permission_request message and await external resolution
+ * 4. If internal file-write rules allow or deny edit/write tools, return that decision
+ * 5. Otherwise, emit permission_request message and await external resolution
  *
  * For async external resolution, hosts should listen for permission_request
  * SDKMessages and call respondToPermission(). The pending prompt is registered
@@ -248,6 +258,7 @@ export function createExternalCanUseTool(
   /** Session ID or getter for dynamic resolution (e.g. () => queryImpl.sessionId for fork/continue) */
   sessionId?: string | (() => string | undefined),
   logger?: SDKLogger,
+  internalCanUseTool?: CanUseToolFn,
 ): CanUseToolFn {
   const log = logger ?? defaultLogger
   /** Resolve sessionId - call getter if provided, otherwise return static value */
@@ -286,6 +297,22 @@ export function createExternalCanUseTool(
     // No user callback — if host registered an onPermissionRequest callback,
     // call it directly and await external resolution with timeout.
     if (toolUseID && onPermissionRequest) {
+      if (
+        internalCanUseTool &&
+        INTERNAL_FILE_WRITE_PERMISSION_TOOLS.has(tool.name)
+      ) {
+        const internalDecision = await internalCanUseTool(
+          tool,
+          input,
+          toolUseContext,
+          assistantMessage,
+          toolUseID,
+        )
+        if (internalDecision.behavior !== 'ask') {
+          return internalDecision
+        }
+      }
+
       const requestId = randomUUID()
       const messageUuid = randomUUID()
 

--- a/src/entrypoints/sdk/query.ts
+++ b/src/entrypoints/sdk/query.ts
@@ -20,6 +20,7 @@ import {
 } from '../../Tool.js'
 import { getTools } from '../../tools.js'
 import { createFileStateCacheWithSizeLimit } from '../../utils/fileStateCache.js'
+import { hasPermissionsToUseTool } from '../../utils/permissions/permissions.js'
 import { init } from '../init.js'
 import {
   resolveSessionFilePath,
@@ -1114,6 +1115,8 @@ export function query(params: {
     (msg) => { queryImpl.pushTimeout(msg) },
     options._permissionTimeoutMs ?? 30000,
     () => queryImpl.sessionId,
+    undefined,
+    hasPermissionsToUseTool,
   )
 
   // Create QueryEngine config

--- a/src/entrypoints/sdk/v2.ts
+++ b/src/entrypoints/sdk/v2.ts
@@ -19,6 +19,7 @@ import {
 } from '../../Tool.js'
 import { getTools } from '../../tools.js'
 import { createFileStateCacheWithSizeLimit } from '../../utils/fileStateCache.js'
+import { hasPermissionsToUseTool } from '../../utils/permissions/permissions.js'
 import { init } from '../init.js'
 import {
   resolveSessionFilePath,
@@ -514,6 +515,8 @@ function createEngineFromOptions(
     (msg) => { permissionTarget.pushTimeout?.(msg) },
     30000, // Default timeout
     sessionId,
+    undefined,
+    hasPermissionsToUseTool,
   )
 
   // Abort controller

--- a/src/test/permissionTestHelpers.ts
+++ b/src/test/permissionTestHelpers.ts
@@ -1,0 +1,84 @@
+import type { AssistantMessage } from '../types/message.js'
+import type {
+  ToolPermissionContext,
+  ToolUseContext,
+  Tools,
+} from '../Tool.js'
+import { getEmptyToolPermissionContext } from '../Tool.js'
+import { getDefaultAppState, type AppState } from '../state/AppStateStore.js'
+import {
+  createFileStateCacheWithSizeLimit,
+  READ_FILE_STATE_CACHE_SIZE,
+} from '../utils/fileStateCache.js'
+
+export const assistantMessage: AssistantMessage = {
+  type: 'assistant',
+  uuid: 'assistant-uuid',
+  message: {
+    id: 'msg_123',
+    type: 'message',
+    role: 'assistant',
+    content: [],
+    model: 'test-model',
+    stop_reason: null,
+    stop_sequence: null,
+    usage: {
+      input_tokens: 0,
+      output_tokens: 0,
+    },
+  },
+}
+
+export function makePermissionContext(
+  overrides: Partial<ToolPermissionContext> = {},
+): ToolPermissionContext {
+  return {
+    ...getEmptyToolPermissionContext(),
+    ...overrides,
+  }
+}
+
+export function makeAppStateWithPermissionContext(
+  toolPermissionContext: ToolPermissionContext,
+): AppState {
+  return {
+    ...getDefaultAppState(),
+    toolPermissionContext,
+  }
+}
+
+// Minimal ToolUseContext for permission checks; it is not a full execution harness.
+export function makeToolUseContext(
+  appState: AppState,
+  tools: Tools = [],
+): ToolUseContext {
+  let state = appState
+
+  return {
+    options: {
+      commands: [],
+      debug: false,
+      mainLoopModel: 'test-model',
+      tools,
+      verbose: false,
+      thinkingConfig: { type: 'disabled' },
+      mcpClients: [],
+      mcpResources: {},
+      isNonInteractiveSession: false,
+      agentDefinitions: { activeAgents: [], allAgents: [] },
+    },
+    abortController: new AbortController(),
+    readFileState: createFileStateCacheWithSizeLimit(
+      READ_FILE_STATE_CACHE_SIZE,
+    ),
+    messages: [],
+    getAppState: () => state,
+    setAppState: updater => {
+      state = updater(state)
+    },
+    setInProgressToolUseIDs: () => {},
+    setResponseLength: () => {},
+    updateFileHistoryState: () => {},
+    updateAttributionState: () => {},
+  }
+}

--- a/src/tools/FileEditTool/permissions.test.ts
+++ b/src/tools/FileEditTool/permissions.test.ts
@@ -1,0 +1,93 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  test,
+} from 'bun:test'
+
+import { getOriginalCwd, setOriginalCwd } from '../../bootstrap/state.js'
+import {
+  makeAppStateWithPermissionContext,
+  makePermissionContext,
+  makeToolUseContext,
+} from '../../test/permissionTestHelpers.js'
+import {
+  acquireSharedMutationLock,
+  releaseSharedMutationLock,
+} from '../../test/sharedMutationLock.js'
+import { FileEditTool } from './FileEditTool.js'
+
+describe('FileEditTool permissions', () => {
+  let originalCwd: string
+  let workspace: string
+
+  beforeAll(async () => {
+    await acquireSharedMutationLock('tools/FileEditTool/permissions.test.ts')
+  })
+
+  afterAll(() => {
+    releaseSharedMutationLock()
+  })
+
+  beforeEach(() => {
+    originalCwd = getOriginalCwd()
+    workspace = mkdtempSync(join(tmpdir(), 'openclaude-file-edit-'))
+    setOriginalCwd(workspace)
+  })
+
+  afterEach(() => {
+    setOriginalCwd(originalCwd)
+    rmSync(workspace, { recursive: true, force: true })
+  })
+
+  test('allows normal working-directory edits in acceptEdits mode', async () => {
+    const filePath = join(workspace, 'src', 'index.ts')
+    mkdirSync(join(workspace, 'src'))
+    writeFileSync(filePath, 'const value = 1\n')
+
+    const result = await FileEditTool.checkPermissions(
+      {
+        file_path: filePath,
+        old_string: '1',
+        new_string: '2',
+      },
+      makeToolUseContext(
+        makeAppStateWithPermissionContext(
+          makePermissionContext({ mode: 'acceptEdits' }),
+        ),
+        [FileEditTool],
+      ),
+    )
+
+    expect(result.behavior).toBe('allow')
+  })
+
+  test('asks for normal working-directory edits in default mode', async () => {
+    const filePath = join(workspace, 'src', 'default.ts')
+    mkdirSync(join(workspace, 'src'))
+    writeFileSync(filePath, 'const value = 1\n')
+
+    const result = await FileEditTool.checkPermissions(
+      {
+        file_path: filePath,
+        old_string: '1',
+        new_string: '2',
+      },
+      makeToolUseContext(
+        makeAppStateWithPermissionContext(
+          makePermissionContext({ mode: 'default' }),
+        ),
+        [FileEditTool],
+      ),
+    )
+
+    expect(result.behavior).toBe('ask')
+  })
+})

--- a/src/tools/FileWriteTool/constants.ts
+++ b/src/tools/FileWriteTool/constants.ts
@@ -1,0 +1,1 @@
+export const FILE_WRITE_TOOL_NAME = 'Write'

--- a/src/tools/FileWriteTool/permissions.test.ts
+++ b/src/tools/FileWriteTool/permissions.test.ts
@@ -1,0 +1,107 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  test,
+} from 'bun:test'
+
+import { getOriginalCwd, setOriginalCwd } from '../../bootstrap/state.js'
+import {
+  makeAppStateWithPermissionContext,
+  makePermissionContext,
+  makeToolUseContext,
+} from '../../test/permissionTestHelpers.js'
+import {
+  acquireSharedMutationLock,
+  releaseSharedMutationLock,
+} from '../../test/sharedMutationLock.js'
+import { FileWriteTool } from './FileWriteTool.js'
+
+describe('FileWriteTool permissions', () => {
+  let originalCwd: string
+  let workspace: string
+
+  beforeAll(async () => {
+    await acquireSharedMutationLock('tools/FileWriteTool/permissions.test.ts')
+  })
+
+  afterAll(() => {
+    releaseSharedMutationLock()
+  })
+
+  beforeEach(() => {
+    originalCwd = getOriginalCwd()
+    workspace = mkdtempSync(join(tmpdir(), 'openclaude-file-write-'))
+    setOriginalCwd(workspace)
+  })
+
+  afterEach(() => {
+    setOriginalCwd(originalCwd)
+    rmSync(workspace, { recursive: true, force: true })
+  })
+
+  test('allows normal working-directory updates in acceptEdits mode', async () => {
+    const filePath = join(workspace, 'package.json')
+    writeFileSync(filePath, '{}\n')
+
+    const result = await FileWriteTool.checkPermissions(
+      {
+        file_path: filePath,
+        content: '{"private": true}\n',
+      },
+      makeToolUseContext(
+        makeAppStateWithPermissionContext(
+          makePermissionContext({ mode: 'acceptEdits' }),
+        ),
+        [FileWriteTool],
+      ),
+    )
+
+    expect(result.behavior).toBe('allow')
+  })
+
+  test('allows normal working-directory creates in acceptEdits mode', async () => {
+    const filePath = join(workspace, 'new-file.ts')
+
+    const result = await FileWriteTool.checkPermissions(
+      {
+        file_path: filePath,
+        content: 'export const value = 1\n',
+      },
+      makeToolUseContext(
+        makeAppStateWithPermissionContext(
+          makePermissionContext({ mode: 'acceptEdits' }),
+        ),
+        [FileWriteTool],
+      ),
+    )
+
+    expect(result.behavior).toBe('allow')
+  })
+
+  test('asks for normal working-directory writes in default mode', async () => {
+    const filePath = join(workspace, 'default-mode.ts')
+
+    const result = await FileWriteTool.checkPermissions(
+      {
+        file_path: filePath,
+        content: 'export const value = 1\n',
+      },
+      makeToolUseContext(
+        makeAppStateWithPermissionContext(
+          makePermissionContext({ mode: 'default' }),
+        ),
+        [FileWriteTool],
+      ),
+    )
+
+    expect(result.behavior).toBe('ask')
+  })
+})

--- a/src/tools/FileWriteTool/prompt.ts
+++ b/src/tools/FileWriteTool/prompt.ts
@@ -1,6 +1,6 @@
 import { FILE_READ_TOOL_NAME } from '../FileReadTool/prompt.js'
 
-export const FILE_WRITE_TOOL_NAME = 'Write'
+export { FILE_WRITE_TOOL_NAME } from './constants.js'
 export const DESCRIPTION = 'Write a file to the local filesystem.'
 
 function getPreReadInstruction(): string {

--- a/src/utils/permissions/filesystem.test.ts
+++ b/src/utils/permissions/filesystem.test.ts
@@ -1,0 +1,751 @@
+import {
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  test,
+} from 'bun:test'
+import type { z } from 'zod/v4'
+
+import { getOriginalCwd, setOriginalCwd } from '../../bootstrap/state.js'
+import {
+  acquireSharedMutationLock,
+  releaseSharedMutationLock,
+} from '../../test/sharedMutationLock.js'
+import {
+  assistantMessage,
+  makeAppStateWithPermissionContext,
+  makePermissionContext,
+  makeToolUseContext,
+} from '../../test/permissionTestHelpers.js'
+import type { AnyObject, Tool, ToolPermissionContext } from '../../Tool.js'
+import { FileEditTool } from '../../tools/FileEditTool/FileEditTool.js'
+import { FileReadTool } from '../../tools/FileReadTool/FileReadTool.js'
+import { FileWriteTool } from '../../tools/FileWriteTool/FileWriteTool.js'
+import { NotebookEditTool } from '../../tools/NotebookEditTool/NotebookEditTool.js'
+import { applyPermissionUpdates } from './PermissionUpdate.js'
+import { checkWritePermissionForTool } from './filesystem.js'
+import { hasPermissionsToUseTool } from './permissions.js'
+
+const fileWriteTools = [FileEditTool, FileWriteTool, NotebookEditTool]
+
+async function checkToolPermission<Input extends AnyObject>(
+  tool: Tool<Input>,
+  input: z.infer<Input>,
+  toolPermissionContext: ToolPermissionContext,
+  toolUseID: string,
+) {
+  return hasPermissionsToUseTool(
+    tool,
+    input,
+    makeToolUseContext(
+      makeAppStateWithPermissionContext(toolPermissionContext),
+      fileWriteTools,
+    ),
+    assistantMessage,
+    toolUseID,
+  )
+}
+
+function linkDirectory(target: string, path: string) {
+  symlinkSync(target, path, process.platform === 'win32' ? 'junction' : 'dir')
+}
+
+describe('file write permissions', () => {
+  let originalCwd: string
+  let workspace: string
+
+  beforeAll(async () => {
+    await acquireSharedMutationLock('utils/permissions/filesystem.test.ts')
+  })
+
+  afterAll(() => {
+    releaseSharedMutationLock()
+  })
+
+  beforeEach(() => {
+    originalCwd = getOriginalCwd()
+    workspace = mkdtempSync(join(tmpdir(), 'openclaude-permissions-'))
+    setOriginalCwd(workspace)
+  })
+
+  afterEach(() => {
+    setOriginalCwd(originalCwd)
+    rmSync(workspace, { recursive: true, force: true })
+  })
+
+  test('allows FileEdit edits inside the working directory in acceptEdits mode', async () => {
+    const filePath = join(workspace, 'src', 'index.ts')
+    mkdirSync(join(workspace, 'src'))
+    writeFileSync(filePath, 'const value = 1\n')
+
+    const result = await checkToolPermission(
+      FileEditTool,
+      {
+        file_path: filePath,
+        old_string: '1',
+        new_string: '2',
+      },
+      makePermissionContext({ mode: 'acceptEdits' }),
+      'toolu_file_edit_accept_edits',
+    )
+
+    expect(result.behavior).toBe('allow')
+  })
+
+  test('allows FileWrite updates inside the working directory in acceptEdits mode', async () => {
+    const filePath = join(workspace, 'package.json')
+    writeFileSync(filePath, '{}\n')
+
+    const result = await checkToolPermission(
+      FileWriteTool,
+      {
+        file_path: filePath,
+        content: '{"private": true}\n',
+      },
+      makePermissionContext({ mode: 'acceptEdits' }),
+      'toolu_file_write_update_accept_edits',
+    )
+
+    expect(result.behavior).toBe('allow')
+  })
+
+  test('allows FileWrite creates inside the working directory in acceptEdits mode', async () => {
+    const filePath = join(workspace, 'new-file.ts')
+
+    const result = await checkToolPermission(
+      FileWriteTool,
+      {
+        file_path: filePath,
+        content: 'export const value = 1\n',
+      },
+      makePermissionContext({ mode: 'acceptEdits' }),
+      'toolu_file_write_create_accept_edits',
+    )
+
+    expect(result.behavior).toBe('allow')
+  })
+
+  test('allows NotebookEdit updates inside the working directory in acceptEdits mode', async () => {
+    const filePath = join(workspace, 'analysis.ipynb')
+    writeFileSync(filePath, '{"cells":[],"metadata":{},"nbformat":4}\n')
+
+    const result = await checkToolPermission(
+      NotebookEditTool,
+      {
+        notebook_path: filePath,
+        cell_id: 'cell-1',
+        new_source: 'print("ok")',
+        cell_type: 'code',
+        edit_mode: 'replace',
+      },
+      makePermissionContext({ mode: 'acceptEdits' }),
+      'toolu_notebook_edit_accept_edits',
+    )
+
+    expect(result.behavior).toBe('allow')
+  })
+
+  test('keeps read permissions unchanged for in-workspace trailing-dot segments', async () => {
+    const docsDir = join(workspace, 'docs.')
+    const filePath = join(docsDir, 'note.md')
+    mkdirSync(docsDir)
+    writeFileSync(filePath, '# note\n')
+
+    const result = await checkToolPermission(
+      FileReadTool,
+      {
+        file_path: filePath,
+      },
+      makePermissionContext({ mode: 'acceptEdits' }),
+      'toolu_file_read_trailing_dot_segment',
+    )
+
+    expect(result.behavior).toBe('allow')
+  })
+
+  test('allows edits and writes inside additional working directories in acceptEdits mode', async () => {
+    const additionalWorkspace = mkdtempSync(join(tmpdir(), 'openclaude-additional-'))
+    try {
+      const editPath = join(additionalWorkspace, 'edit.ts')
+      const writePath = join(additionalWorkspace, 'write.ts')
+      writeFileSync(editPath, 'export const value = 1\n')
+      const toolPermissionContext = makePermissionContext({
+        mode: 'acceptEdits',
+        additionalWorkingDirectories: new Map([
+          [
+            additionalWorkspace,
+            { path: additionalWorkspace, source: 'cliArg' },
+          ],
+        ]),
+      })
+
+      const editResult = await checkToolPermission(
+        FileEditTool,
+        {
+          file_path: editPath,
+          old_string: '1',
+          new_string: '2',
+        },
+        toolPermissionContext,
+        'toolu_file_edit_additional_accept_edits',
+      )
+      const writeResult = await checkToolPermission(
+        FileWriteTool,
+        {
+          file_path: writePath,
+          content: 'export const value = 1\n',
+        },
+        toolPermissionContext,
+        'toolu_file_write_additional_accept_edits',
+      )
+      const defaultResult = await checkToolPermission(
+        FileWriteTool,
+        {
+          file_path: writePath,
+          content: 'export const value = 2\n',
+        },
+        {
+          ...toolPermissionContext,
+          mode: 'default',
+        },
+        'toolu_file_write_additional_default',
+      )
+
+      expect(editResult.behavior).toBe('allow')
+      expect(writeResult.behavior).toBe('allow')
+      expect(defaultResult.behavior).toBe('ask')
+    } finally {
+      rmSync(additionalWorkspace, { recursive: true, force: true })
+    }
+  })
+
+  test('asks for the same normal file write in default mode', async () => {
+    const filePath = join(workspace, 'default-mode.ts')
+
+    const result = await checkToolPermission(
+      FileWriteTool,
+      {
+        file_path: filePath,
+        content: 'export const value = 1\n',
+      },
+      makePermissionContext({ mode: 'default' }),
+      'toolu_file_write_default',
+    )
+
+    expect(result.behavior).toBe('ask')
+  })
+
+  test('asks for normal writes outside allowed working directories in acceptEdits mode', async () => {
+    const outsideWorkspace = mkdtempSync(join(tmpdir(), 'openclaude-outside-'))
+    try {
+      const filePath = join(outsideWorkspace, 'regular.ts')
+
+      const result = await checkToolPermission(
+        FileWriteTool,
+        {
+          file_path: filePath,
+          content: 'export const value = 1\n',
+        },
+        makePermissionContext({ mode: 'acceptEdits' }),
+        'toolu_file_write_outside_accept_edits',
+      )
+
+      expect(result.behavior).toBe('ask')
+      expect(result.decisionReason?.type).toBe('workingDir')
+    } finally {
+      rmSync(outsideWorkspace, { recursive: true, force: true })
+    }
+  })
+
+  test('deny rules still win in acceptEdits mode', async () => {
+    const filePath = join(workspace, 'blocked.ts')
+
+    const result = await checkToolPermission(
+      FileWriteTool,
+      {
+        file_path: filePath,
+        content: 'export const value = 1\n',
+      },
+      makePermissionContext({
+        mode: 'acceptEdits',
+        alwaysDenyRules: {
+          session: ['Edit(/blocked.ts)'],
+        },
+      }),
+      'toolu_file_write_deny_accept_edits',
+    )
+
+    expect(result.behavior).toBe('deny')
+  })
+
+  test.each([
+    ['.git config', ['.git', 'config']],
+    ['VS Code settings', ['.vscode', 'settings.json']],
+    ['JetBrains settings', ['.idea', 'workspace.xml']],
+    ['Claude settings', ['.claude', 'settings.json']],
+    ['OpenClaude settings', ['.openclaude', 'settings.json']],
+    ['bash startup file', ['.bashrc']],
+    ['bash profile startup file', ['.bash_profile']],
+    ['zsh startup file', ['.zshrc']],
+    ['zsh profile startup file', ['.zprofile']],
+    ['profile startup file', ['.profile']],
+    ['git config file', ['.gitconfig']],
+    ['MCP config file', ['.mcp.json']],
+    ['suspicious Windows short path', ['GIT~1', 'config']],
+    ['Windows reserved device file', ['NUL.txt']],
+    ['Windows reserved device file with extension', ['COM1.log']],
+    ['Windows CONIN device file', ['CONIN$']],
+    ['Windows CONOUT device file with extension', ['CONOUT$.txt']],
+    ['Windows superscript COM device file', ['COM\u00b9.log']],
+    ['Windows superscript LPT device file', ['LPT\u00b2']],
+    ['Windows canonicalized .git directory with trailing dot', ['.git.', 'config']],
+    ['Windows canonicalized .git directory with trailing space', ['.git ', 'config']],
+    [
+      'Windows canonicalized VS Code directory with trailing dot',
+      ['.vscode.', 'settings.json'],
+    ],
+    [
+      'Windows canonicalized Claude directory with trailing space',
+      ['.claude ', 'settings.json'],
+    ],
+  ])('still asks for sensitive path in acceptEdits mode: %s', async (_, parts) => {
+    const filePath = join(workspace, ...parts)
+
+    const result = await checkToolPermission(
+      FileWriteTool,
+      {
+        file_path: filePath,
+        content: '{}\n',
+      },
+      makePermissionContext({ mode: 'acceptEdits' }),
+      `toolu_file_write_sensitive_${parts.join('_')}`,
+    )
+
+    expect(result.behavior).toBe('ask')
+    expect(result.decisionReason?.type).toBe('safetyCheck')
+  })
+
+  test('asks for trailing-dot path segments in acceptEdits mode', async () => {
+    const docsDir = join(workspace, 'docs.')
+    const filePath = join(docsDir, 'note.md')
+    mkdirSync(docsDir)
+
+    const result = await checkToolPermission(
+      FileWriteTool,
+      {
+        file_path: filePath,
+        content: '# Notes\n',
+      },
+      makePermissionContext({ mode: 'acceptEdits' }),
+      'toolu_file_write_trailing_dot',
+    )
+
+    expect(result.behavior).toBe('ask')
+    expect(result.decisionReason?.type).toBe('safetyCheck')
+  })
+
+  test('trailing-dot paths do not bypass deny rules in acceptEdits mode', async () => {
+    const filePath = join(workspace, 'blocked.ts.')
+
+    const result = await checkToolPermission(
+      FileWriteTool,
+      {
+        file_path: filePath,
+        content: 'export const value = 1\n',
+      },
+      makePermissionContext({
+        mode: 'acceptEdits',
+        alwaysDenyRules: {
+          session: ['Edit(/blocked.ts)'],
+        },
+      }),
+      'toolu_file_write_deny_trailing_dot',
+    )
+
+    expect(result.behavior).toBe('deny')
+    expect(result.decisionReason?.type).toBe('rule')
+  })
+
+  test('mixed-case paths do not bypass deny rules in acceptEdits mode', async () => {
+    const filePath = join(workspace, 'BLOCKED.TS')
+
+    const result = await checkToolPermission(
+      FileWriteTool,
+      {
+        file_path: filePath,
+        content: 'export const value = 1\n',
+      },
+      makePermissionContext({
+        mode: 'acceptEdits',
+        alwaysDenyRules: {
+          session: ['Edit(/blocked.ts)'],
+        },
+      }),
+      'toolu_file_write_deny_mixed_case',
+    )
+
+    expect(result.behavior).toBe('deny')
+    expect(result.decisionReason?.type).toBe('rule')
+  })
+
+  test('Windows short-name aliases do not downgrade deny rules in acceptEdits mode', async () => {
+    const filePath = join(workspace, 'BLOCKE~1.TS')
+
+    const result = await checkToolPermission(
+      FileWriteTool,
+      {
+        file_path: filePath,
+        content: 'export const value = 1\n',
+      },
+      makePermissionContext({
+        mode: 'acceptEdits',
+        alwaysDenyRules: {
+          session: ['Edit(/blocked-file.ts)'],
+        },
+      }),
+      'toolu_file_write_deny_short_name_alias',
+    )
+
+    expect(result.behavior).toBe('deny')
+    expect(result.decisionReason?.type).toBe('rule')
+  })
+
+  test('mixed-case paths do not bypass ask rules in acceptEdits mode', async () => {
+    const filePath = join(workspace, 'CONFIRM.TS')
+
+    const result = await checkToolPermission(
+      FileWriteTool,
+      {
+        file_path: filePath,
+        content: 'export const value = 1\n',
+      },
+      makePermissionContext({
+        mode: 'acceptEdits',
+        alwaysAskRules: {
+          session: ['Edit(/confirm.ts)'],
+        },
+      }),
+      'toolu_file_write_ask_mixed_case',
+    )
+
+    expect(result.behavior).toBe('ask')
+    expect(result.decisionReason?.type).toBe('rule')
+  })
+
+  test('trailing-space paths still require manual approval in acceptEdits mode', async () => {
+    const filePath = join(workspace, 'confirm.ts ')
+
+    const result = await checkToolPermission(
+      FileWriteTool,
+      {
+        file_path: filePath,
+        content: 'export const value = 1\n',
+      },
+      makePermissionContext({
+        mode: 'acceptEdits',
+        alwaysAskRules: {
+          session: ['Edit(/confirm.ts)'],
+        },
+      }),
+      'toolu_file_write_ask_trailing_space',
+    )
+
+    expect(result.behavior).toBe('ask')
+    expect(result.decisionReason?.type).toBe('safetyCheck')
+  })
+
+  test('still asks for UNC paths in acceptEdits mode', async () => {
+    const result = await checkToolPermission(
+      FileWriteTool,
+      {
+        file_path: '//server/share/file.ts',
+        content: 'export const value = 1\n',
+      },
+      makePermissionContext({ mode: 'acceptEdits' }),
+      'toolu_file_write_unc_accept_edits',
+    )
+
+    expect(result.behavior).toBe('ask')
+    expect(result.decisionReason?.type).toBe('safetyCheck')
+  })
+
+  test('still asks when a workspace symlink resolves outside allowed working directories', async () => {
+    const outsideWorkspace = mkdtempSync(join(tmpdir(), 'openclaude-outside-'))
+    try {
+      const targetPath = join(outsideWorkspace, 'target.ts')
+      const linkDir = join(workspace, 'linked-outside')
+      const linkedPath = join(linkDir, 'target.ts')
+      writeFileSync(targetPath, 'export const target = true\n')
+      linkDirectory(outsideWorkspace, linkDir)
+
+      const result = await checkToolPermission(
+        FileWriteTool,
+        {
+          file_path: linkedPath,
+          content: 'export const value = 1\n',
+        },
+        makePermissionContext({ mode: 'acceptEdits' }),
+        'toolu_file_write_linked_outside_accept_edits',
+      )
+
+      expect(result.behavior).toBe('ask')
+      expect(result.decisionReason?.type).toBe('workingDir')
+    } finally {
+      rmSync(outsideWorkspace, { recursive: true, force: true })
+    }
+  })
+
+  test('still asks when creating through a workspace symlink outside allowed working directories', async () => {
+    const outsideWorkspace = mkdtempSync(join(tmpdir(), 'openclaude-outside-'))
+    try {
+      const linkDir = join(workspace, 'linked-outside-create')
+      const linkedPath = join(linkDir, 'new.ts')
+      linkDirectory(outsideWorkspace, linkDir)
+
+      const result = await checkToolPermission(
+        FileWriteTool,
+        {
+          file_path: linkedPath,
+          content: 'export const value = 1\n',
+        },
+        makePermissionContext({ mode: 'acceptEdits' }),
+        'toolu_file_write_linked_outside_create_accept_edits',
+      )
+
+      expect(result.behavior).toBe('ask')
+      expect(result.decisionReason?.type).toBe('workingDir')
+    } finally {
+      rmSync(outsideWorkspace, { recursive: true, force: true })
+    }
+  })
+
+  test('still asks when a workspace symlink resolves to a sensitive path', async () => {
+    const outsideWorkspace = mkdtempSync(join(tmpdir(), 'openclaude-sensitive-'))
+    try {
+      const gitDir = join(outsideWorkspace, '.git')
+      const targetPath = join(gitDir, 'config')
+      const linkDir = join(workspace, 'linked-git')
+      const linkedPath = join(linkDir, 'config')
+      mkdirSync(gitDir)
+      writeFileSync(targetPath, '[core]\n')
+      linkDirectory(gitDir, linkDir)
+
+      const result = await checkToolPermission(
+        FileWriteTool,
+        {
+          file_path: linkedPath,
+          content: '[core]\nrepositoryformatversion = 0\n',
+        },
+        makePermissionContext({ mode: 'acceptEdits' }),
+        'toolu_file_write_linked_sensitive_accept_edits',
+      )
+
+      expect(result.behavior).toBe('ask')
+      expect(result.decisionReason?.type).toBe('safetyCheck')
+    } finally {
+      rmSync(outsideWorkspace, { recursive: true, force: true })
+    }
+  })
+
+  test('still asks when creating through a workspace symlink into a sensitive path', async () => {
+    const outsideWorkspace = mkdtempSync(join(tmpdir(), 'openclaude-sensitive-'))
+    try {
+      const gitDir = join(outsideWorkspace, '.git')
+      const linkDir = join(workspace, 'linked-git-create')
+      const linkedPath = join(linkDir, 'hooks', 'post-commit')
+      mkdirSync(gitDir)
+      linkDirectory(gitDir, linkDir)
+
+      const result = await checkToolPermission(
+        FileWriteTool,
+        {
+          file_path: linkedPath,
+          content: '#!/bin/sh\n',
+        },
+        makePermissionContext({ mode: 'acceptEdits' }),
+        'toolu_file_write_linked_sensitive_create_accept_edits',
+      )
+
+      expect(result.behavior).toBe('ask')
+      expect(result.decisionReason?.type).toBe('safetyCheck')
+    } finally {
+      rmSync(outsideWorkspace, { recursive: true, force: true })
+    }
+  })
+
+  test('safety checks still win over explicit allow rules in acceptEdits mode', () => {
+    const gitDir = join(workspace, '.git')
+    const filePath = join(gitDir, 'config')
+    mkdirSync(gitDir)
+
+    const result = checkWritePermissionForTool(
+      FileWriteTool,
+      {
+        file_path: filePath,
+        content: '[core]\nrepositoryformatversion = 0\n',
+      },
+      makePermissionContext({
+        mode: 'acceptEdits',
+        alwaysAllowRules: {
+          session: ['Edit(/.git/**)'],
+        },
+      }),
+    )
+
+    expect(result.behavior).toBe('ask')
+    expect(result.decisionReason?.type).toBe('safetyCheck')
+  })
+
+  test('pipeline safety checks still win over broad explicit allow rules', async () => {
+    const gitDir = join(workspace, '.git')
+    const filePath = join(gitDir, 'config')
+    mkdirSync(gitDir)
+
+    const result = await checkToolPermission(
+      FileWriteTool,
+      {
+        file_path: filePath,
+        content: '[core]\nrepositoryformatversion = 0\n',
+      },
+      makePermissionContext({
+        mode: 'acceptEdits',
+        alwaysAllowRules: {
+          session: ['Edit'],
+        },
+      }),
+      'toolu_write_git_config_allow_rule',
+    )
+
+    expect(result.behavior).toBe('ask')
+    expect(result.decisionReason?.type).toBe('safetyCheck')
+  })
+
+  test('session ask rules still override acceptEdits for normal working directory writes', async () => {
+    const filePath = join(workspace, 'session-ask.ts')
+
+    const result = await checkToolPermission(
+      FileWriteTool,
+      {
+        file_path: filePath,
+        content: 'export const value = 1\n',
+      },
+      makePermissionContext({
+        mode: 'acceptEdits',
+        alwaysAskRules: {
+          session: ['Edit(/session-ask.ts)'],
+        },
+      }),
+      'toolu_file_write_session_ask',
+    )
+
+    expect(result.behavior).toBe('ask')
+  })
+
+  test('explicit ask rules still override acceptEdits for normal working directory writes', async () => {
+    const filePath = join(workspace, 'persistent-ask.ts')
+
+    const result = await checkToolPermission(
+      FileWriteTool,
+      {
+        file_path: filePath,
+        content: 'export const value = 1\n',
+      },
+      makePermissionContext({
+        mode: 'acceptEdits',
+        alwaysAskRules: {
+          cliArg: ['Edit(/persistent-ask.ts)'],
+        },
+      }),
+      'toolu_file_write_explicit_ask',
+    )
+
+    expect(result.behavior).toBe('ask')
+  })
+
+  test('tool-level session ask rules still override acceptEdits for normal file edits', async () => {
+    const filePath = join(workspace, 'pipeline-session-ask.ts')
+    const appState = makeAppStateWithPermissionContext(
+      makePermissionContext({
+        mode: 'acceptEdits',
+        alwaysAskRules: {
+          session: ['Edit'],
+        },
+      }),
+    )
+
+    const result = await hasPermissionsToUseTool(
+      FileEditTool,
+      {
+        file_path: filePath,
+        old_string: '',
+        new_string: 'export const value = 1\n',
+      },
+      makeToolUseContext(appState, fileWriteTools),
+      assistantMessage,
+      'toolu_edit',
+    )
+
+    expect(result.behavior).toBe('ask')
+  })
+
+  test('applying the session acceptEdits suggestion allows the next normal file write', async () => {
+    const filePath = join(workspace, 'session-update.ts')
+    const appState = makeAppStateWithPermissionContext(
+      makePermissionContext({ mode: 'default' }),
+    )
+    const toolUseContext = makeToolUseContext(appState, fileWriteTools)
+    const input = {
+      file_path: filePath,
+      content: 'export const value = 1\n',
+    }
+
+    const firstResult = await hasPermissionsToUseTool(
+      FileWriteTool,
+      input,
+      toolUseContext,
+      assistantMessage,
+      'toolu_write_1',
+    )
+
+    expect(firstResult.behavior).toBe('ask')
+    if (firstResult.behavior !== 'ask') {
+      throw new Error(`Expected ask, got ${firstResult.behavior}`)
+    }
+    expect(firstResult.suggestions).toContainEqual({
+      type: 'setMode',
+      mode: 'acceptEdits',
+      destination: 'session',
+    })
+
+    toolUseContext.setAppState(prev => ({
+      ...prev,
+      toolPermissionContext: applyPermissionUpdates(
+        prev.toolPermissionContext,
+        firstResult.suggestions ?? [],
+      ),
+    }))
+
+    const secondResult = await hasPermissionsToUseTool(
+      FileWriteTool,
+      input,
+      toolUseContext,
+      assistantMessage,
+      'toolu_write_2',
+    )
+
+    expect(secondResult.behavior).toBe('allow')
+  })
+})

--- a/src/utils/permissions/filesystem.ts
+++ b/src/utils/permissions/filesystem.ts
@@ -95,6 +95,27 @@ export function normalizeCaseForComparison(path: string): string {
   return path.toLowerCase()
 }
 
+function isWindowsReservedDeviceSegment(segment: string): boolean {
+  return /^(CON|PRN|AUX|NUL|CONIN\$|CONOUT\$|COM[1-9\u00b9\u00b2\u00b3]|LPT[1-9\u00b9\u00b2\u00b3])(?:\..*)?$/i.test(segment)
+}
+
+function stripWindowsTrailingDotsAndSpaces(path: string): string {
+  return path
+    .split(/([\\/]+)/)
+    .map(segment => {
+      if (
+        segment === '' ||
+        segment === '.' ||
+        segment === '..' ||
+        /^[\\/]+$/.test(segment)
+      ) {
+        return segment
+      }
+      return segment.replace(/[.\s]+$/g, '') || segment
+    })
+    .join('')
+}
+
 /**
  * If filePath is inside a .claude/skills/{name}/ directory (project) or
  * .openclaude/skills/{name}/ directory (global), plus the legacy global
@@ -511,8 +532,8 @@ function isDangerousFilePathToAutoEdit(path: string): boolean {
  * - NTFS Alternate Data Streams (e.g., file.txt::$DATA or file.txt:stream)
  * - 8.3 short names (e.g., GIT~1, CLAUDE~1, SETTIN~1.JSON)
  * - Long path prefixes (e.g., \\?\C:\..., \\.\C:\..., //?/C:/..., //./C:/...)
- * - Trailing dots and spaces (e.g., .git., .claude , .bashrc...)
- * - DOS device names (e.g., .git.CON, settings.json.PRN, .bashrc.AUX)
+ * - Trailing dots and spaces (e.g., .git., blocked.ts., .bashrc...)
+ * - DOS device names (e.g., NUL, NUL.txt, COM1.log, CONOUT$)
  * - Three or more consecutive dots (e.g., .../file.txt, path/.../file, file...txt)
  *
  * When detected, these paths should always require manual approval to prevent
@@ -552,7 +573,10 @@ function isDangerousFilePathToAutoEdit(path: string): boolean {
  * @param path The path to check for suspicious patterns
  * @returns true if suspicious Windows path patterns are detected
  */
-function hasSuspiciousWindowsPathPattern(path: string): boolean {
+function hasSuspiciousWindowsPathPattern(
+  path: string,
+  options: { checkSegmentCanonicalAliases?: boolean } = {},
+): boolean {
   // Check for NTFS Alternate Data Streams
   // Look for ':' after position 2 to skip drive letters (e.g., C:\)
   // Examples: file.txt::$DATA, .bashrc:hidden, settings.json:stream
@@ -586,18 +610,44 @@ function hasSuspiciousWindowsPathPattern(path: string): boolean {
     return true
   }
 
-  // Check for trailing dots and spaces that Windows strips during path resolution
-  // Examples: .git., .claude , .bashrc..., settings.json.
-  // This can bypass string matching if ".git" is blocked but ".git." is used
-  if (/[.\s]+$/.test(path)) {
-    return true
-  }
+  if (options.checkSegmentCanonicalAliases) {
+    const pathSegments = path.split(/[\\/]+/)
 
-  // Check for DOS device names that Windows treats as special devices
-  // Examples: .git.CON, settings.json.PRN, .bashrc.AUX
-  // Device names: CON, PRN, AUX, NUL, COM1-9, LPT1-9
-  if (/\.(CON|PRN|AUX|NUL|COM[1-9]|LPT[1-9])$/i.test(path)) {
-    return true
+    // Check for trailing dots and spaces that Windows strips from each path
+    // segment during resolution. Examples: .git./config, .claude /settings.json,
+    // blocked.ts., settings.json.
+    // This can bypass rule matching if "blocked.ts" is denied but "blocked.ts." is used.
+    if (
+      pathSegments.some(
+        segment =>
+          segment !== '' &&
+          segment !== '.' &&
+          segment !== '..' &&
+          /[.\s]+$/.test(segment),
+        )
+    ) {
+      return true
+    }
+
+    // Check for DOS device names that Windows treats as special devices, including
+    // reserved basenames with extensions. Examples: NUL, NUL.txt, COM1.log.
+    if (
+      pathSegments.some(segment =>
+        isWindowsReservedDeviceSegment(segment.replace(/[.\s]+$/g, '')),
+      )
+    ) {
+      return true
+    }
+  } else {
+    // Preserve read-permission behavior: reads still use the historical whole-path
+    // checks, while auto-edit safety gets the stricter per-segment checks above.
+    if (/[.\s]+$/.test(path)) {
+      return true
+    }
+
+    if (/\.(CON|PRN|AUX|NUL|COM[1-9]|LPT[1-9])$/i.test(path)) {
+      return true
+    }
   }
 
   // Check for three or more consecutive dots (...) when used as a path component
@@ -647,7 +697,11 @@ export function checkPathSafetyForAutoEdit(
 
   // Check for suspicious Windows path patterns on all paths
   for (const pathToCheck of pathsToCheck) {
-    if (hasSuspiciousWindowsPathPattern(pathToCheck)) {
+    if (
+      hasSuspiciousWindowsPathPattern(pathToCheck, {
+        checkSegmentCanonicalAliases: true,
+      })
+    ) {
       return {
         safe: false,
         message: `${PRODUCT_DISPLAY_NAME} requested permissions to write to ${path}, which contains a suspicious Windows path pattern that requires manual approval.`,
@@ -685,9 +739,14 @@ export function checkPathSafetyForAutoEdit(
 export function allWorkingDirectories(
   context: ToolPermissionContext,
 ): Set<string> {
+  const additionalWorkingDirectories =
+    context.additionalWorkingDirectories as unknown as ReadonlyMap<
+      string,
+      unknown
+    >
   return new Set([
     getOriginalCwd(),
-    ...context.additionalWorkingDirectories.keys(),
+    ...additionalWorkingDirectories.keys(),
   ])
 }
 
@@ -975,6 +1034,7 @@ export function matchingRuleForInput(
   toolPermissionContext: ToolPermissionContext,
   toolType: 'edit' | 'read',
   behavior: 'allow' | 'deny' | 'ask',
+  options: { caseInsensitive?: boolean } = {},
 ): PermissionRule | null {
   let fileAbsolutePath = expandPath(path)
 
@@ -992,6 +1052,7 @@ export function matchingRuleForInput(
   // Check each root for a matching pattern
   for (const [root, patternMap] of patternsByRoot.entries()) {
     // Transform patterns for the ignore library
+    const patternLookup = new Map<string, string>()
     const patterns = Array.from(patternMap.keys()).map(pattern => {
       let adjustedPattern = pattern
 
@@ -1001,15 +1062,24 @@ export function matchingRuleForInput(
         adjustedPattern = adjustedPattern.slice(0, -3)
       }
 
-      return adjustedPattern
+      const patternForIgnore = options.caseInsensitive
+        ? normalizeCaseForComparison(adjustedPattern)
+        : adjustedPattern
+      patternLookup.set(patternForIgnore, pattern)
+
+      return patternForIgnore
     })
 
     const ig = ignore().add(patterns)
 
     // Use cross-platform relative path helper for POSIX-style patterns
     const relativePathStr = relativePath(
-      root ?? getCwd(),
-      fileAbsolutePath ?? getCwd(),
+      options.caseInsensitive
+        ? normalizeCaseForComparison(root ?? getCwd())
+        : root ?? getCwd(),
+      options.caseInsensitive
+        ? normalizeCaseForComparison(fileAbsolutePath ?? getCwd())
+        : fileAbsolutePath ?? getCwd(),
     )
 
     if (relativePathStr.startsWith(`..${DIR_SEP}`)) {
@@ -1026,19 +1096,143 @@ export function matchingRuleForInput(
 
     if (igResult.ignored && igResult.rule) {
       // Map the matched pattern back to the original rule
-      const originalPattern = igResult.rule.pattern
+      const originalPattern = patternLookup.get(igResult.rule.pattern)
 
-      // Check if this was a /** pattern we simplified
-      const withWildcard = originalPattern + '/**'
-      if (patternMap.has(withWildcard)) {
-        return patternMap.get(withWildcard) ?? null
-      }
-
-      return patternMap.get(originalPattern) ?? null
+      return originalPattern ? patternMap.get(originalPattern) ?? null : null
     }
   }
 
   // No matching rule found
+  return null
+}
+
+function pathsForFilesystemRuleMatching(paths: readonly string[]): string[] {
+  const result = new Set<string>()
+  for (const path of paths) {
+    result.add(path)
+    result.add(stripWindowsTrailingDotsAndSpaces(path))
+  }
+  return Array.from(result)
+}
+
+function windowsShortNameComparable(segment: string): string {
+  return normalizeCaseForComparison(segment).replace(/[^a-z0-9]/g, '')
+}
+
+function splitNameAndExtension(segment: string): {
+  basename: string
+  extension: string
+} {
+  const dotIndex = segment.lastIndexOf('.')
+  if (dotIndex <= 0) {
+    return { basename: segment, extension: '' }
+  }
+  return {
+    basename: segment.slice(0, dotIndex),
+    extension: segment.slice(dotIndex + 1),
+  }
+}
+
+function couldBeWindowsShortNameForSegment(
+  candidateSegment: string,
+  patternSegment: string,
+): boolean {
+  const shortNameMatch = candidateSegment.match(/^(.{1,6})~\d+(?:\.(.+))?$/i)
+  if (!shortNameMatch) {
+    return false
+  }
+
+  const candidateBasename = windowsShortNameComparable(shortNameMatch[1] ?? '')
+  const candidateExtension = windowsShortNameComparable(
+    (shortNameMatch[2] ?? '').slice(0, 3),
+  )
+  if (!candidateBasename) {
+    return false
+  }
+  const { basename, extension } = splitNameAndExtension(patternSegment)
+
+  return (
+    windowsShortNameComparable(basename).startsWith(candidateBasename) &&
+    (candidateExtension === '' ||
+      windowsShortNameComparable(extension).startsWith(candidateExtension))
+  )
+}
+
+function pathSegmentsCouldMatchWindowsShortName(
+  pattern: string,
+  relativePathStr: string,
+): boolean {
+  const matchesDescendants = pattern.endsWith('/**')
+  const adjustedPattern = matchesDescendants ? pattern.slice(0, -3) : pattern
+  if (/[*?[\]]/.test(adjustedPattern)) {
+    return false
+  }
+
+  const patternSegments = adjustedPattern
+    .replace(/^\/+/, '')
+    .split(DIR_SEP)
+    .filter(Boolean)
+  const pathSegments = relativePathStr
+    .replace(/^\/+/, '')
+    .split(DIR_SEP)
+    .filter(Boolean)
+
+  if (
+    matchesDescendants
+      ? pathSegments.length < patternSegments.length
+      : pathSegments.length !== patternSegments.length
+  ) {
+    return false
+  }
+
+  return patternSegments.every((patternSegment, index) => {
+    const pathSegment = pathSegments[index]
+    if (!pathSegment) {
+      return false
+    }
+    return (
+      normalizeCaseForComparison(pathSegment) ===
+        normalizeCaseForComparison(patternSegment) ||
+      couldBeWindowsShortNameForSegment(pathSegment, patternSegment)
+    )
+  })
+}
+
+function matchingRuleForPotentialWindowsShortName(
+  path: string,
+  toolPermissionContext: ToolPermissionContext,
+): PermissionRule | null {
+  if (!/~\d/.test(path)) {
+    return null
+  }
+
+  let fileAbsolutePath = expandPath(path)
+  if (getPlatform() === 'windows' && fileAbsolutePath.includes('\\')) {
+    fileAbsolutePath = windowsPathToPosixPath(fileAbsolutePath)
+  }
+
+  const patternsByRoot = getPatternsByRoot(
+    toolPermissionContext,
+    'edit',
+    'deny',
+  )
+
+  for (const [root, patternMap] of patternsByRoot.entries()) {
+    const relativePathStr = relativePath(
+      normalizeCaseForComparison(root ?? getCwd()),
+      normalizeCaseForComparison(fileAbsolutePath),
+    )
+    if (relativePathStr.startsWith(`..${DIR_SEP}`) || !relativePathStr) {
+      continue
+    }
+
+    for (const [pattern, rule] of patternMap.entries()) {
+      if (pathSegmentsCouldMatchWindowsShortName(pattern, relativePathStr)) {
+        return rule
+      }
+    }
+  }
+
   return null
 }
 
@@ -1237,12 +1431,14 @@ export function checkWritePermissionForTool<Input extends AnyObject>(
   // 1. Check for deny rules - check both the original path and resolved symlink path
   const pathsToCheck =
     precomputedPathsToCheck ?? getPathsForPermissionCheck(path)
-  for (const pathToCheck of pathsToCheck) {
+  const rulePathsToCheck = pathsForFilesystemRuleMatching(pathsToCheck)
+  for (const pathToCheck of rulePathsToCheck) {
     const denyRule = matchingRuleForInput(
       pathToCheck,
       toolPermissionContext,
       'edit',
       'deny',
+      { caseInsensitive: true },
     )
     if (denyRule) {
       return {
@@ -1251,6 +1447,21 @@ export function checkWritePermissionForTool<Input extends AnyObject>(
         decisionReason: {
           type: 'rule',
           rule: denyRule,
+        },
+      }
+    }
+
+    const windowsShortNameDenyRule = matchingRuleForPotentialWindowsShortName(
+      pathToCheck,
+      toolPermissionContext,
+    )
+    if (windowsShortNameDenyRule) {
+      return {
+        behavior: 'deny',
+        message: `Permission to edit ${path} has been denied.`,
+        decisionReason: {
+          type: 'rule',
+          rule: windowsShortNameDenyRule,
         },
       }
     }
@@ -1360,12 +1571,13 @@ export function checkWritePermissionForTool<Input extends AnyObject>(
   }
 
   // 2. Check for ask rules - check both the original path and resolved symlink path
-  for (const pathToCheck of pathsToCheck) {
+  for (const pathToCheck of rulePathsToCheck) {
     const askRule = matchingRuleForInput(
       pathToCheck,
       toolPermissionContext,
       'edit',
       'ask',
+      { caseInsensitive: true },
     )
     if (askRule) {
       return {
@@ -1377,6 +1589,7 @@ export function checkWritePermissionForTool<Input extends AnyObject>(
         },
       }
     }
+
   }
 
   // 3. If in acceptEdits or sandboxBashMode mode, allow all writes in original cwd


### PR DESCRIPTION
## Summary
- Make `acceptEdits` mode allow normal file edits/writes inside the working directory without repeated permission prompts.
- Preserve explicit deny rules and existing safety checks for sensitive paths, including case-insensitive and Windows-canonicalized aliases.
- Add regression coverage for the file edit/write permission flow and SDK permission-request suppression.

## Why
Fixes #1180. Users who enable `accept edits on` expect normal project file edits to proceed without repeated prompts, while sensitive paths should still require protection.

## Behavior
- Normal project file edits in `acceptEdits`: allowed.
- Normal project file writes/creates in `acceptEdits`: allowed.
- Default mode behavior is unchanged.
- Explicit deny rules still win.
- Explicit ask rules still require approval.
- Sensitive paths such as `.git`, shell config files, OpenClaude settings, suspicious Windows paths, and UNC paths still prompt or deny according to existing safety rules.

## Out of scope
- Changing provider/model behavior
- Changing Bash or PowerShell command permissions
- Adding `fullAccess`
- Broad permission-system redesign
- Weakening sensitive-path protections
- Opengateway, Codex, OAuth, memory, attribution, or agent-routing changes

## Testing
- `bun install --frozen-lockfile` — passed
- `bun install --cwd web --frozen-lockfile` — passed
- `python -m pip install -r python/requirements.txt` — passed
- `bun run smoke` — passed
- `python -m pytest -q python/tests` — passed, 44 tests
- `bun test src/entrypoints/sdk/permissions.test.ts src/utils/permissions/filesystem.test.ts src/tools/FileEditTool/permissions.test.ts src/tools/FileWriteTool/permissions.test.ts` — passed, 67 tests
- `bun run security:pr-scan -- --base upstream/main` — passed
- `bun run test:provider` — passed, 596 tests
- `npm run test:provider-recommendation` — passed, 78 tests
- `bun run --cwd web typecheck` — passed
- `bun run --cwd web build` — passed

Local full-suite note: `timeout 10m bun test --max-concurrency=1` completed with 2,942 passing tests and 5 failures in existing environment-sensitive/baseline tests outside this permission change. The failures were in Gemini ADC discovery, conversation recovery thinking-block stripping, startup model alias provider state, and shell-specific command-not-found output. The permission and SDK regression coverage added by this PR passes.

Fixes #1180
