### PR TITLE
fix(model): include profile models in descriptor picker

### DIFF
--- a/src/commands/model/model.test.tsx
+++ b/src/commands/model/model.test.tsx
@@ -281,6 +281,69 @@ test('descriptor model options include active profile configured models', async 
   ])
 })
 
+test('descriptor model options omit route defaults outside active profile models', async () => {
+  const activeProfile = {
+    id: 'mistral-profile',
+    name: 'Mistral AI',
+    provider: 'mistral',
+    baseUrl: 'https://api.mistral.ai/v1',
+    model: 'mistral-medium-latest, mistral-small-latest',
+    apiKey: 'sk-mistral',
+  }
+  process.env.CLAUDE_CODE_PROVIDER_PROFILE_ENV_APPLIED = '1'
+  process.env.CLAUDE_CODE_PROVIDER_PROFILE_ENV_APPLIED_ID = activeProfile.id
+
+  mock.module('../../utils/providerProfiles.js', () => ({
+    getActiveOpenAIModelOptionsCache: () => [],
+    getActiveProviderProfile: () => activeProfile,
+    getProfileModelOptions: () => [
+      {
+        value: 'mistral-medium-latest',
+        label: 'mistral-medium-latest',
+        description: 'Provider: Mistral AI',
+      },
+      {
+        value: 'mistral-small-latest',
+        label: 'mistral-small-latest',
+        description: 'Provider: Mistral AI',
+      },
+    ],
+    setActiveOpenAIModelOptionsCache: () => {},
+  }))
+
+  const { mergeActiveProfileModelOptions } =
+    await importFreshModelModule('descriptor-profile-model-filter')
+
+  expect(
+    mergeActiveProfileModelOptions(
+      'mistral',
+      [
+        {
+          value: 'devstral-latest',
+          label: 'Devstral Latest',
+          description: 'Recommended · Provider: Mistral AI',
+        },
+        {
+          value: 'mistral-small-latest',
+          label: 'Mistral Small Latest',
+          description: 'Provider: Mistral AI',
+        },
+      ],
+    ),
+  ).toEqual([
+    {
+      value: 'mistral-medium-latest',
+      label: 'mistral-medium-latest',
+      description: 'Provider: Mistral AI',
+    },
+    {
+      value: 'mistral-small-latest',
+      label: 'Mistral Small Latest',
+      description: 'Provider: Mistral AI',
+    },
+  ])
+})
+
 test('descriptor model options skip saved profile models for env-selected routes', async () => {
   const savedProfile = {
     id: 'mistral-profile',

--- a/src/commands/model/model.test.tsx
+++ b/src/commands/model/model.test.tsx
@@ -20,6 +20,10 @@ const originalEnv = {
   OPENROUTER_API_KEY: process.env.OPENROUTER_API_KEY,
   OPENAI_MODEL: process.env.OPENAI_MODEL,
   ANTHROPIC_CUSTOM_HEADERS: process.env.ANTHROPIC_CUSTOM_HEADERS,
+  CLAUDE_CODE_PROVIDER_PROFILE_ENV_APPLIED:
+    process.env.CLAUDE_CODE_PROVIDER_PROFILE_ENV_APPLIED,
+  CLAUDE_CODE_PROVIDER_PROFILE_ENV_APPLIED_ID:
+    process.env.CLAUDE_CODE_PROVIDER_PROFILE_ENV_APPLIED_ID,
   CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC:
     process.env.CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC,
 }
@@ -74,6 +78,14 @@ afterEach(() => {
     restoreEnv('OPENROUTER_API_KEY', originalEnv.OPENROUTER_API_KEY)
     restoreEnv('OPENAI_MODEL', originalEnv.OPENAI_MODEL)
     restoreEnv('ANTHROPIC_CUSTOM_HEADERS', originalEnv.ANTHROPIC_CUSTOM_HEADERS)
+    restoreEnv(
+      'CLAUDE_CODE_PROVIDER_PROFILE_ENV_APPLIED',
+      originalEnv.CLAUDE_CODE_PROVIDER_PROFILE_ENV_APPLIED,
+    )
+    restoreEnv(
+      'CLAUDE_CODE_PROVIDER_PROFILE_ENV_APPLIED_ID',
+      originalEnv.CLAUDE_CODE_PROVIDER_PROFILE_ENV_APPLIED_ID,
+    )
     restoreEnv(
       'CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC',
       originalEnv.CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC,
@@ -159,6 +171,7 @@ test('opens the model picker without awaiting descriptor-backed route refresh', 
   mock.module('../../utils/providerProfiles.js', () => ({
     getActiveOpenAIModelOptionsCache: () => [],
     getActiveProviderProfile: () => null,
+    getProfileModelOptions: () => [],
     setActiveOpenAIModelOptionsCache: () => {},
   }))
 
@@ -208,6 +221,112 @@ test('shouldAutoRefreshRouteCatalog respects discovery refresh modes', async () 
       stale: true,
     }),
   ).toBe(false)
+})
+
+test('descriptor model options include active profile configured models', async () => {
+  const activeProfile = {
+    id: 'mistral-profile',
+    name: 'Mistral AI',
+    provider: 'mistral',
+    baseUrl: 'https://api.mistral.ai/v1',
+    model: 'devstral-latest, mistral-medium-latest',
+    apiKey: 'sk-mistral',
+  }
+  process.env.CLAUDE_CODE_PROVIDER_PROFILE_ENV_APPLIED = '1'
+  process.env.CLAUDE_CODE_PROVIDER_PROFILE_ENV_APPLIED_ID = activeProfile.id
+
+  mock.module('../../utils/providerProfiles.js', () => ({
+    getActiveOpenAIModelOptionsCache: () => [],
+    getActiveProviderProfile: () => activeProfile,
+    getProfileModelOptions: () => [
+      {
+        value: 'devstral-latest',
+        label: 'devstral-latest',
+        description: 'Provider: Mistral AI',
+      },
+      {
+        value: 'mistral-medium-latest',
+        label: 'mistral-medium-latest',
+        description: 'Provider: Mistral AI',
+      },
+    ],
+    setActiveOpenAIModelOptionsCache: () => {},
+  }))
+
+  const { mergeActiveProfileModelOptions } =
+    await importFreshModelModule('descriptor-profile-model-merge')
+
+  expect(
+    mergeActiveProfileModelOptions(
+      'mistral',
+      [
+        {
+          value: 'devstral-latest',
+          label: 'Devstral Latest',
+          description: 'Recommended · Provider: Mistral AI',
+        },
+      ],
+    ),
+  ).toEqual([
+    {
+      value: 'devstral-latest',
+      label: 'Devstral Latest',
+      description: 'Recommended · Provider: Mistral AI',
+    },
+    {
+      value: 'mistral-medium-latest',
+      label: 'mistral-medium-latest',
+      description: 'Provider: Mistral AI',
+    },
+  ])
+})
+
+test('descriptor model options skip saved profile models for env-selected routes', async () => {
+  const savedProfile = {
+    id: 'mistral-profile',
+    name: 'Mistral AI',
+    provider: 'mistral',
+    baseUrl: 'https://api.mistral.ai/v1',
+    model: 'devstral-latest, mistral-medium-latest',
+    apiKey: 'sk-mistral',
+  }
+  delete process.env.CLAUDE_CODE_PROVIDER_PROFILE_ENV_APPLIED
+  delete process.env.CLAUDE_CODE_PROVIDER_PROFILE_ENV_APPLIED_ID
+
+  mock.module('../../utils/providerProfiles.js', () => ({
+    getActiveOpenAIModelOptionsCache: () => [],
+    getActiveProviderProfile: () => savedProfile,
+    getProfileModelOptions: () => [
+      {
+        value: 'mistral-medium-latest',
+        label: 'mistral-medium-latest',
+        description: 'Provider: Mistral AI',
+      },
+    ],
+    setActiveOpenAIModelOptionsCache: () => {},
+  }))
+
+  const { mergeActiveProfileModelOptions } =
+    await importFreshModelModule('descriptor-profile-model-env-skip')
+
+  expect(
+    mergeActiveProfileModelOptions(
+      'openrouter',
+      [
+        {
+          value: 'openai/gpt-5-mini',
+          label: 'GPT-5 Mini',
+          description: 'Provider: OpenRouter',
+        },
+      ],
+    ),
+  ).toEqual([
+    {
+      value: 'openai/gpt-5-mini',
+      label: 'GPT-5 Mini',
+      description: 'Provider: OpenRouter',
+    },
+  ])
 })
 
 test('/model refresh clears descriptor cache and reports updates', async () => {
@@ -264,6 +383,7 @@ test('/model refresh clears descriptor cache and reports updates', async () => {
   mock.module('../../utils/providerProfiles.js', () => ({
     getActiveOpenAIModelOptionsCache: () => [],
     getActiveProviderProfile: () => null,
+    getProfileModelOptions: () => [],
     setActiveOpenAIModelOptionsCache: () => {},
   }))
 
@@ -329,6 +449,7 @@ test('/model does not auto-refresh descriptor models when nonessential traffic i
   mock.module('../../utils/providerProfiles.js', () => ({
     getActiveOpenAIModelOptionsCache: () => [],
     getActiveProviderProfile: () => null,
+    getProfileModelOptions: () => [],
     setActiveOpenAIModelOptionsCache: () => {},
   }))
 

--- a/src/commands/model/model.tsx
+++ b/src/commands/model/model.tsx
@@ -131,18 +131,22 @@ export function mergeActiveProfileModelOptions(
     return routeOptions
   }
 
-  const merged = [...routeOptions]
-  const seen = new Set(
-    routeOptions
-      .map(option =>
-        typeof option.value === 'string'
-          ? option.value.trim().toLowerCase()
-          : '',
-      )
-      .filter(Boolean),
-  )
+  const profileOptions = getProfileModelOptions(activeProfile)
+  if (profileOptions.length === 0) {
+    return routeOptions
+  }
 
-  for (const option of getProfileModelOptions(activeProfile)) {
+  const routeOptionsByValue = new Map(
+    routeOptions.flatMap(option => {
+      const value =
+        typeof option.value === 'string' ? option.value.trim().toLowerCase() : ''
+      return value ? [[value, option] as const] : []
+    }),
+  )
+  const merged: ModelOption[] = []
+  const seen = new Set<string>()
+
+  for (const option of profileOptions) {
     const value = typeof option.value === 'string' ? option.value.trim() : ''
     const key = value.toLowerCase()
     if (!value || seen.has(key)) {
@@ -150,7 +154,7 @@ export function mergeActiveProfileModelOptions(
     }
 
     seen.add(key)
-    merged.push(option)
+    merged.push(routeOptionsByValue.get(key) ?? option)
   }
 
   return merged

--- a/src/commands/model/model.tsx
+++ b/src/commands/model/model.tsx
@@ -21,7 +21,9 @@ import {
   getRouteDescriptor,
   resolveRouteCredentialValue,
   resolveActiveRouteIdFromEnv,
+  resolveRouteIdFromBaseUrl,
 } from '../../integrations/routeMetadata.js'
+import { resolveProfileRoute } from '../../integrations/profileResolver.js'
 import {
   type AnalyticsMetadata_I_VERIFIED_THIS_IS_NOT_CODE_OR_FILEPATHS,
   logEvent,
@@ -62,6 +64,7 @@ import { parseCustomHeadersEnv } from '../../utils/providerCustomHeaders.js'
 import {
   getActiveOpenAIModelOptionsCache,
   getActiveProviderProfile,
+  getProfileModelOptions,
   setActiveOpenAIModelOptionsCache,
 } from '../../utils/providerProfiles.js'
 
@@ -106,6 +109,51 @@ function haveSameModelOptions(left: ModelOption[], right: ModelOption[]): boolea
       option.descriptionForModel === other.descriptionForModel
     )
   })
+}
+
+export function mergeActiveProfileModelOptions(
+  routeId: string,
+  routeOptions: ModelOption[],
+): ModelOption[] {
+  const activeProfile = getActiveProviderProfile()
+  if (!activeProfile) {
+    return routeOptions
+  }
+
+  const profileEnvApplied =
+    process.env.CLAUDE_CODE_PROVIDER_PROFILE_ENV_APPLIED === '1' &&
+    process.env.CLAUDE_CODE_PROVIDER_PROFILE_ENV_APPLIED_ID === activeProfile.id
+  const activeProfileRouteId =
+    resolveRouteIdFromBaseUrl(activeProfile.baseUrl) ??
+    resolveProfileRoute(activeProfile.provider).routeId
+
+  if (!profileEnvApplied || activeProfileRouteId !== routeId) {
+    return routeOptions
+  }
+
+  const merged = [...routeOptions]
+  const seen = new Set(
+    routeOptions
+      .map(option =>
+        typeof option.value === 'string'
+          ? option.value.trim().toLowerCase()
+          : '',
+      )
+      .filter(Boolean),
+  )
+
+  for (const option of getProfileModelOptions(activeProfile)) {
+    const value = typeof option.value === 'string' ? option.value.trim() : ''
+    const key = value.toLowerCase()
+    if (!value || seen.has(key)) {
+      continue
+    }
+
+    seen.add(key)
+    merged.push(option)
+  }
+
+  return merged
 }
 
 function getActiveRouteId(): string | null {
@@ -185,15 +233,17 @@ async function loadDescriptorDiscoveryContext(
       return null
     }
 
+    const routeOptions = buildRouteCatalogModelOptions(
+      routeLabel,
+      staticEntries,
+      routeDefaultModel,
+    )
+
     return {
       kind: 'descriptor',
       autoRefresh: false,
       canRefresh,
-      optionsOverride: buildRouteCatalogModelOptions(
-        routeLabel,
-        staticEntries,
-        routeDefaultModel,
-      ),
+      optionsOverride: mergeActiveProfileModelOptions(routeId, routeOptions),
       routeId,
       routeDefaultModel,
       routeLabel,
@@ -230,16 +280,18 @@ async function loadDescriptorDiscoveryContext(
     }
   }
 
+  const routeOptions = buildRouteCatalogModelOptions(
+    routeLabel,
+    mergedEntries,
+    routeDefaultModel,
+  )
+
   return {
     kind: 'descriptor',
     autoRefresh,
     canRefresh,
     discoveryState,
-    optionsOverride: buildRouteCatalogModelOptions(
-      routeLabel,
-      mergedEntries,
-      routeDefaultModel,
-    ),
+    optionsOverride: mergeActiveProfileModelOptions(routeId, routeOptions),
     routeId,
     routeDefaultModel,
     routeLabel,
@@ -461,10 +513,13 @@ function ModelPickerWrapper({
         },
       )
 
-      const nextOptions = buildRouteCatalogModelOptions(
-        discoveryContext.routeLabel,
-        result?.models ?? [],
-        discoveryContext.routeDefaultModel,
+      const nextOptions = mergeActiveProfileModelOptions(
+        discoveryContext.routeId,
+        buildRouteCatalogModelOptions(
+          discoveryContext.routeLabel,
+          result?.models ?? [],
+          discoveryContext.routeDefaultModel,
+        ),
       )
       const changed = !haveSameModelOptions(optionsOverride ?? [], nextOptions)
 
@@ -734,10 +789,13 @@ async function refreshModelsAndSummarize(): Promise<string> {
       ...getOpenAIDiscoveryRequestOptions(discoveryContext.routeId),
       forceRefresh: true,
     })
-    const nextOptions = buildRouteCatalogModelOptions(
-      discoveryContext.routeLabel,
-      result?.models ?? [],
-      discoveryContext.routeDefaultModel,
+    const nextOptions = mergeActiveProfileModelOptions(
+      discoveryContext.routeId,
+      buildRouteCatalogModelOptions(
+        discoveryContext.routeLabel,
+        result?.models ?? [],
+        discoveryContext.routeDefaultModel,
+      ),
     )
     const changed = !haveSameModelOptions(
       discoveryContext.optionsOverride,


### PR DESCRIPTION
## Summary

Fixes descriptor-backed `/model` pickers so they include models configured on the active provider profile, even when the provider's descriptor catalog or discovery results do not list every manually configured model.

This addresses #1360, where a Mistral profile configured with multiple comma- or semicolon-separated models only showed `devstral-latest` or the current first model in `/model`.

## Why

Provider profiles already support model-list fields such as:

```text
devstral-latest, mistral-medium-latest
```

However, descriptor-backed providers use `optionsOverride` in the `/model` command. That override was built only from the route catalog or discovered models, bypassing the active profile's configured model list. Mistral made this especially visible because its static descriptor catalog currently contains only `devstral-latest`.

## What Changed

- Added `mergeActiveProfileModelOptions()` to merge active profile-configured models into descriptor-backed `/model` options.
- Deduplicates profile models against route catalog/discovery options by model value.
- Scopes the merge so saved profile models are only included when the profile is actually applied and resolves to the same descriptor route currently shown.
- Applies the merge on initial descriptor picker load, automatic/manual descriptor refresh, and `/model refresh`.
- Added focused regression coverage for:
  - Mistral-style profile models being preserved when the Mistral profile is active.
  - Saved profile models not leaking into an unrelated env-selected descriptor route such as OpenRouter.

## Provider Impact

Affected provider path:

- Descriptor-backed `/model` provider routes, including Mistral.

Expected behavior:

- Active profile models remain selectable even if static catalog/discovery omits them.
- Existing catalog/discovery entries keep their labels and metadata.
- Saved-but-inactive profile models are not shown for unrelated env-selected providers.

## Validation

Ran:

```bash
bun test src/commands/model/model.test.tsx src/utils/model/routeCatalogOptions.test.ts
bun run build
git diff --check
```

Results:

- Focused tests passed: 8 pass / 0 fail.
- Build passed.
- Diff whitespace check passed.

Also ran:

```bash
bun run typecheck
```

Result:

- Failed on existing broad repo type errors unrelated to this branch, including missing module/type errors in bridge, plugin, session, and test files. This was not used as branch-specific validation.

## Notes

This is intentionally a core `/model` descriptor/profile fix rather than a Mistral catalog-only change, because the same issue can affect any descriptor-backed provider whose catalog or discovery results do not include manually configured profile models.