### PR TITLE
fix(model-picker): merge profile-configured models into descriptor catalog (#1360)

### DIFF
--- a/src/commands/model/model.tsx
+++ b/src/commands/model/model.tsx
@@ -47,7 +47,11 @@ import {
   checkSonnet1mAccess,
 } from '../../utils/model/check1mAccess.js'
 import type { ModelOption } from '../../utils/model/modelOptions.js'
-import { buildRouteCatalogModelOptions, mergeRouteCatalogEntries } from '../../utils/model/routeCatalogOptions.js'
+import {
+  buildRouteCatalogModelOptions,
+  mergeProfileConfiguredModels,
+  mergeRouteCatalogEntries,
+} from '../../utils/model/routeCatalogOptions.js'
 import { discoverOpenAICompatibleModelOptions } from '../../utils/model/openaiModelDiscovery.js'
 import {
   getDefaultMainLoopModelSetting,
@@ -174,7 +178,12 @@ async function loadDescriptorDiscoveryContext(
   const routeLabel = descriptor.label
   const routeDefaultModel =
     'defaultModel' in descriptor ? descriptor.defaultModel : undefined
-  const staticEntries = catalog.models ?? []
+  const activeProfile = getActiveProviderProfile()
+  const profileModelField = activeProfile?.model
+  const staticEntries = mergeProfileConfiguredModels(
+    catalog.models ?? [],
+    profileModelField,
+  )
   const trafficRestricted = isEssentialTrafficOnly()
   const canRefresh = Boolean(
     catalog.discovery && catalog.allowManualRefresh && !trafficRestricted,
@@ -463,7 +472,10 @@ function ModelPickerWrapper({
 
       const nextOptions = buildRouteCatalogModelOptions(
         discoveryContext.routeLabel,
-        result?.models ?? [],
+        mergeProfileConfiguredModels(
+          result?.models ?? [],
+          getActiveProviderProfile()?.model,
+        ),
         discoveryContext.routeDefaultModel,
       )
       const changed = !haveSameModelOptions(optionsOverride ?? [], nextOptions)
@@ -736,7 +748,10 @@ async function refreshModelsAndSummarize(): Promise<string> {
     })
     const nextOptions = buildRouteCatalogModelOptions(
       discoveryContext.routeLabel,
-      result?.models ?? [],
+      mergeProfileConfiguredModels(
+        result?.models ?? [],
+        getActiveProviderProfile()?.model,
+      ),
       discoveryContext.routeDefaultModel,
     )
     const changed = !haveSameModelOptions(

--- a/src/utils/model/routeCatalogOptions.test.ts
+++ b/src/utils/model/routeCatalogOptions.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, test } from 'bun:test'
 
-import { buildRouteCatalogModelOptions } from './routeCatalogOptions.js'
+import {
+  buildRouteCatalogModelOptions,
+  mergeProfileConfiguredModels,
+} from './routeCatalogOptions.js'
 
 describe('buildRouteCatalogModelOptions', () => {
   test('marks the route default model as recommended without catalog metadata', () => {
@@ -27,5 +30,93 @@ describe('buildRouteCatalogModelOptions', () => {
         descriptionForModel: 'Recommended · Provider: DeepSeek (deepseek-v4-pro)',
       },
     ])
+  })
+})
+
+describe('mergeProfileConfiguredModels', () => {
+  const staticMistral = [
+    {
+      id: 'mistral-vibe-cli',
+      apiName: 'mistral-vibe-cli-latest',
+      label: 'Mistral Vibe (CLI) Latest',
+      modelDescriptorId: 'mistral-vibe-cli-latest',
+    },
+    {
+      id: 'mistral-devstral',
+      apiName: 'devstral-latest',
+      label: 'Devstral Latest',
+      modelDescriptorId: 'devstral-latest',
+    },
+  ]
+
+  test('passes catalog through unchanged when profile model field is empty or undefined', () => {
+    expect(mergeProfileConfiguredModels(staticMistral, undefined)).toBe(staticMistral)
+    expect(mergeProfileConfiguredModels(staticMistral, '')).toBe(staticMistral)
+    expect(mergeProfileConfiguredModels(staticMistral, '   ;  , ')).toBe(staticMistral)
+  })
+
+  test('appends comma/semicolon-separated profile models that the catalog does not know about', () => {
+    const merged = mergeProfileConfiguredModels(
+      staticMistral,
+      'devstral-latest, mistral-medium-latest; codestral-mamba-latest',
+    )
+
+    expect(merged.map(entry => entry.apiName)).toEqual([
+      'mistral-vibe-cli-latest',
+      'devstral-latest',
+      'mistral-medium-latest',
+      'codestral-mamba-latest',
+    ])
+
+    const appended = merged[2]
+    expect(appended).toMatchObject({
+      apiName: 'mistral-medium-latest',
+      label: 'mistral-medium-latest',
+      modelDescriptorId: 'mistral-medium-latest',
+    })
+    expect(appended.id).toContain('mistral-medium-latest')
+  })
+
+  test('skips profile models that already exist in the catalog (case-insensitive)', () => {
+    const merged = mergeProfileConfiguredModels(
+      staticMistral,
+      'DEVSTRAL-LATEST, mistral-medium-latest',
+    )
+
+    expect(merged).toHaveLength(staticMistral.length + 1)
+    expect(merged.map(entry => entry.apiName)).toEqual([
+      'mistral-vibe-cli-latest',
+      'devstral-latest',
+      'mistral-medium-latest',
+    ])
+  })
+
+  test('passes single-model profile fields through to picker without duplication', () => {
+    const merged = mergeProfileConfiguredModels(staticMistral, 'devstral-latest')
+    expect(merged).toEqual(staticMistral)
+  })
+
+  test('appended profile models flow through buildRouteCatalogModelOptions as picker entries', () => {
+    const merged = mergeProfileConfiguredModels(
+      staticMistral,
+      'devstral-latest, mistral-medium-latest',
+    )
+    const options = buildRouteCatalogModelOptions(
+      'Mistral AI',
+      merged,
+      'devstral-latest',
+    )
+
+    expect(options.map(option => option.value)).toEqual([
+      'mistral-vibe-cli-latest',
+      'devstral-latest',
+      'mistral-medium-latest',
+    ])
+    const profileOption = options.find(option => option.value === 'mistral-medium-latest')
+    expect(profileOption).toMatchObject({
+      value: 'mistral-medium-latest',
+      label: 'mistral-medium-latest',
+      description: 'Provider: Mistral AI',
+    })
   })
 })

--- a/src/utils/model/routeCatalogOptions.ts
+++ b/src/utils/model/routeCatalogOptions.ts
@@ -1,4 +1,5 @@
 import type { ModelCatalogEntry } from '../../integrations/descriptors.js'
+import { parseModelList } from '../providerModels.js'
 import type { ModelOption } from './modelOptions.js'
 
 function toDescription(
@@ -18,6 +19,49 @@ function toDescription(
   parts.push(`Provider: ${routeLabel}`)
 
   return parts.join(' · ')
+}
+
+/**
+ * Append models the user typed into their provider profile's model field
+ * (comma- or semicolon-separated) onto a catalog entry list, skipping any
+ * that already exist by apiName (case-insensitive). Synthetic entries carry
+ * only id/apiName/label so they can flow through the same picker pipeline
+ * as descriptor-backed entries.
+ */
+export function mergeProfileConfiguredModels(
+  entries: ModelCatalogEntry[],
+  profileModelField: string | undefined,
+): ModelCatalogEntry[] {
+  if (!profileModelField) {
+    return entries
+  }
+
+  const configured = parseModelList(profileModelField)
+  if (configured.length === 0) {
+    return entries
+  }
+
+  const merged = [...entries]
+  const existingApiNames = new Set(
+    entries.map(entry => entry.apiName.toLowerCase()),
+  )
+
+  for (const model of configured) {
+    const key = model.toLowerCase()
+    if (existingApiNames.has(key)) {
+      continue
+    }
+
+    existingApiNames.add(key)
+    merged.push({
+      id: `profile-${model}`,
+      apiName: model,
+      label: model,
+      modelDescriptorId: model,
+    })
+  }
+
+  return merged
 }
 
 export function mergeRouteCatalogEntries(


### PR DESCRIPTION
Closes #1360.

## Summary

For provider routes that ship a descriptor-backed catalog (Mistral is the reported one, but any descriptor with a static or discovery-backed catalog is affected), the `/model` picker built its option list exclusively from the descriptor catalog and silently dropped every additional model the user had typed into the provider profile's comma/semicolon-separated `model` field.

Repro from #1360:
- `/provider` -> Add provider -> Mistral AI
- Step 3: enter `devstral-latest, mistral-medium-latest`
- `/model` -> only the descriptor catalog entries appear; `mistral-medium-latest` is invisible and unselectable.

Root cause in `loadDescriptorDiscoveryContext` (`src/commands/model/model.tsx`): `staticEntries = catalog.models ?? []` was passed straight into `buildRouteCatalogModelOptions`. `parseModelList(profile.model)` was already a utility on the codebase but nothing wired it into the descriptor picker path.

## Fix

- New helper `mergeProfileConfiguredModels(entries, profileModelField)` in `src/utils/model/routeCatalogOptions.ts` parses the profile's CSV/semicolon-separated model field via the existing `parseModelList`, appends any model not already present (case-insensitive on `apiName`), and synthesizes `{id, apiName, label, modelDescriptorId}` entries so the appended models flow through the same picker pipeline as descriptor entries and inherit the standard `Provider: <route>` description.
- `loadDescriptorDiscoveryContext` (`src/commands/model/model.tsx`) now resolves the active provider profile and merges its configured models into `staticEntries` before all downstream paths (static-only catalog, cached catalog, refresh result). The descriptor refresh handlers (`refreshAvailableModels`, the manual refresh in `applyManualRefresh`) merge the same way so a refresh does not wipe profile-configured entries.
- Synthetic profile entries deliberately do not set `default`, so the descriptor's `routeDefaultModel` continues to win the `Recommended` badge.

## Test plan

- [x] `bun test src/utils/model/routeCatalogOptions.test.ts` -> 6/6 pass (1 pre-existing + 5 new for `mergeProfileConfiguredModels` covering empty/undefined no-op, comma+semicolon parsing, case-insensitive dedup, single-model pass-through, end-to-end picker shape).
- [x] `bun test src/utils/model src/commands/model` -> 93/93 pass across 13 files.
- [x] `bun test` -> 2907/2910 pass (3 failing `/export direct filename` tests pre-existing on `upstream/main`, unrelated to this PR).
- [x] No production behavior change for users with single-model profile fields or for routes whose discovery already returns every catalog model.

## Notes

The synthetic entry shape uses `id: 'profile-<model>'` so the dedup pass cannot collide with catalog-issued ids while still giving a stable, readable id for downstream consumers that key by `entry.id`.