### PR TITLE
fix(codex-oauth): surface secret-tool failure reason on credential save (#1338)

### DIFF
--- a/src/utils/secureStorage/linuxSecretStorage.ts
+++ b/src/utils/secureStorage/linuxSecretStorage.ts
@@ -7,6 +7,39 @@ import {
 } from './macOsKeychainHelpers.js'
 import type { SecureStorage, SecureStorageData } from './index.js'
 
+const SECRET_TOOL_MISSING_HINT =
+  "secret-tool is not installed. Install libsecret-tools (Debian/Ubuntu: 'apt install libsecret-tools', Fedora: 'dnf install libsecret') and ensure a Secret Service provider (gnome-keyring or KWallet) is running."
+const SECRET_TOOL_RUNTIME_HINT =
+  "secret-tool failed to talk to the Secret Service. Make sure gnome-keyring or KWallet is running and the default keyring is unlocked (this commonly fails over SSH without an active desktop session)."
+
+function isMissingSecretToolError(error: unknown): boolean {
+  if (!error || typeof error !== 'object') return false
+  const code = (error as { code?: unknown }).code
+  if (code === 'ENOENT') return true
+  const message = (error as { message?: unknown }).message
+  return typeof message === 'string' && /ENOENT|not found|no such file/i.test(message)
+}
+
+function buildSecretToolFailureWarning(
+  result: ReturnType<typeof execaSync> | null,
+  thrown: unknown,
+): string {
+  if (isMissingSecretToolError(thrown)) {
+    return SECRET_TOOL_MISSING_HINT
+  }
+
+  const stderr = result?.stderr?.toString().trim()
+  if (stderr) {
+    return `secret-tool: ${stderr}`
+  }
+
+  if (typeof result?.exitCode === 'number' && result.exitCode !== 0) {
+    return `${SECRET_TOOL_RUNTIME_HINT} (exit code ${result.exitCode})`
+  }
+
+  return SECRET_TOOL_RUNTIME_HINT
+}
+
 /**
  * Linux-specific secure storage implementation using the secret-tool CLI.
  * secret-tool interacts with the Secret Service API (GNOME Keyring, KWallet, etc.).
@@ -39,6 +72,7 @@ export const linuxSecretStorage: SecureStorage = {
     return this.read()
   },
   update(data: SecureStorageData): { success: boolean; warning?: string } {
+    let result: ReturnType<typeof execaSync> | null = null
     try {
       const username = getUsername()
       const serviceName = getSecureStorageServiceName(
@@ -47,7 +81,7 @@ export const linuxSecretStorage: SecureStorage = {
       const payload = jsonStringify(data)
       // secret-tool store --label=[label] service [service] account [account]
       // The payload is passed via stdin
-      const result = execaSync(
+      result = execaSync(
         'secret-tool',
         [
           'store',
@@ -61,9 +95,19 @@ export const linuxSecretStorage: SecureStorage = {
         { input: payload, reject: false },
       )
 
-      return { success: result.exitCode === 0 }
-    } catch {
-      return { success: false }
+      if (result.exitCode === 0) {
+        return { success: true }
+      }
+
+      return {
+        success: false,
+        warning: buildSecretToolFailureWarning(result, null),
+      }
+    } catch (error) {
+      return {
+        success: false,
+        warning: buildSecretToolFailureWarning(result, error),
+      }
     }
   },
   delete(): boolean {

--- a/src/utils/secureStorage/platformStorage.test.ts
+++ b/src/utils/secureStorage/platformStorage.test.ts
@@ -194,6 +194,62 @@ describe("Secure Storage Platform Implementations", () => {
 
       expect(result).toEqual(testData);
     });
+
+    test("update surfaces secret-tool stderr in the failure warning", () => {
+      mockExecaSync.mockReturnValueOnce({
+        exitCode: 1,
+        stdout: "",
+        stderr: "Cannot autolaunch D-Bus without X11 $DISPLAY",
+      });
+
+      const result = linuxSecretStorage.update(testData);
+
+      expect(result.success).toBe(false);
+      expect(result.warning).toContain("secret-tool");
+      expect(result.warning).toContain("Cannot autolaunch D-Bus without X11");
+    });
+
+    test("update returns a missing-binary hint when secret-tool is not installed (ENOENT)", () => {
+      mockExecaSync.mockImplementationOnce(() => {
+        const err = new Error("spawnSync secret-tool ENOENT") as Error & {
+          code?: string
+        };
+        err.code = "ENOENT";
+        throw err;
+      });
+
+      const result = linuxSecretStorage.update(testData);
+
+      expect(result.success).toBe(false);
+      expect(result.warning).toContain("secret-tool is not installed");
+      expect(result.warning).toContain("libsecret-tools");
+    });
+
+    test("update falls back to the keyring-runtime hint when stderr is empty but the call fails", () => {
+      mockExecaSync.mockReturnValueOnce({
+        exitCode: 1,
+        stdout: "",
+        stderr: "",
+      });
+
+      const result = linuxSecretStorage.update(testData);
+
+      expect(result.success).toBe(false);
+      expect(result.warning).toContain("Secret Service");
+      expect(result.warning).toContain("exit code 1");
+    });
+
+    test("update returns success=true with no warning on exit code 0", () => {
+      mockExecaSync.mockReturnValueOnce({
+        exitCode: 0,
+        stdout: "",
+        stderr: "",
+      });
+
+      const result = linuxSecretStorage.update(testData);
+
+      expect(result).toEqual({ success: true });
+    });
   });
 
   describe("Platform Selection", () => {


### PR DESCRIPTION
Closes #1338.

## Summary

The Codex OAuth flow on Ubuntu / GNOME (and any Linux desktop without a working Secret Service) ends in the generic dialog:

> Codex OAuth succeeded, but credentials could not be saved securely.

That message is the catch-all fallback in \`useCodexOAuthFlow\` for when \`saveCodexCredentials\` returns \`{success: false}\` without a \`warning\`. Tracing it back: \`saveCodexCredentials\` opts out of plaintext fallback (\`allowPlainTextFallback: false\`), so on Linux it hits \`linuxSecretStorage.update\`, and that path swallowed every \`secret-tool\` failure mode into a bare \`{success: false}\` with no diagnostic. Two of the most common Linux failure modes:

1. The \`secret-tool\` CLI is not installed (\`libsecret-tools\` missing on Debian/Ubuntu, \`libsecret\` missing on Fedora).
2. The Secret Service / gnome-keyring is not running, the default keyring is locked, or there is no D-Bus session (very common over SSH without an active desktop session).

The result is identical from the user side: OAuth succeeded, generic save-failure message, no path forward.

## Fix

\`src/utils/secureStorage/linuxSecretStorage.ts\` \`update()\` now mirrors the existing pattern in \`windowsCredentialStorage\`:

- Capture the \`secret-tool\` stderr from the \`execaSync\` result and surface it verbatim (prefixed with \`secret-tool:\`) when present.
- Detect \`ENOENT\` (missing binary) both by \`error.code\` and the error message, and return an install hint that names the relevant package (\`libsecret-tools\` on apt, \`libsecret\` on dnf) plus the Secret Service requirement.
- Fall back to a Secret-Service-runtime hint plus the exit code when stderr is empty but the call still failed.

The warning flows through:
- \`linuxSecretStorage.update\` -> \`saveCodexCredentials\` (\`src/utils/codexCredentials.ts:207\`)
- -> \`persistCredentials\` in \`useCodexOAuthFlow\` (\`src/components/useCodexOAuthFlow.ts:103\`) where \`saved.warning\` is now non-empty, so the thrown \`Error.message\` carries the real reason.
- -> \`status.message\` rendered by both the \`ProviderManager\` (\`src/components/ProviderManager.tsx:632\`) and provider command (\`src/commands/provider/provider.tsx:1133\`) 'Codex OAuth failed' dialogs.

No dialog wiring change needed; the existing render already uses \`status.message\`.

## Test plan

- [x] \`bun test src/utils/secureStorage/platformStorage.test.ts\` -> 19/19 pass (4 new \"Linux secret-tool Interaction\" cases: stderr passthrough, ENOENT install hint, exit-code-only fallback, unchanged success path).
- [x] \`bun test src/utils/secureStorage src/utils/codexCredentials.test.ts src/components/useCodexOAuthFlow.test.ts\` -> 31/31 pass across 3 files.
- [x] \`bun test\` -> 2911/2914 pass (3 failing \`/export direct filename\` tests pre-existing on \`upstream/main\`, unrelated to this PR).

## Notes

Scope is intentionally limited to surfacing the existing-but-discarded failure reason on Linux. The behavior on success and on macOS / Windows is unchanged. macOS \`security\` CLI errors already surface through their own path, and Windows \`update\` already routes through \`getFailureWarning\`.