### PR TITLE
fix(release): verify npm latest tag and document @latest install

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,6 +79,40 @@ jobs:
       - name: Publish to npm
         run: npm publish --access public --provenance
 
+      - name: Verify npm latest dist-tag
+        env:
+          EXPECTED_VERSION: ${{ needs.release-please.outputs.version }}
+        run: |
+          set -euo pipefail
+
+          if [ -z "${EXPECTED_VERSION}" ]; then
+            echo "release-please did not provide an expected version" >&2
+            exit 1
+          fi
+
+          for attempt in $(seq 1 30); do
+            published_version="$(npm view @gitlawb/openclaude version 2>/dev/null || true)"
+            latest_tag="$(npm view @gitlawb/openclaude dist-tags.latest 2>/dev/null || true)"
+            latest_version="$(npm view @gitlawb/openclaude@latest version 2>/dev/null || true)"
+
+            echo "Attempt ${attempt}: version=${published_version:-<empty>} latest=${latest_tag:-<empty>} @latest=${latest_version:-<empty>} expected=${EXPECTED_VERSION}"
+
+            if [ "$published_version" = "$EXPECTED_VERSION" ] && \
+               [ "$latest_tag" = "$EXPECTED_VERSION" ] && \
+               [ "$latest_version" = "$EXPECTED_VERSION" ]; then
+              echo "npm latest verified for @gitlawb/openclaude@${EXPECTED_VERSION}"
+              exit 0
+            fi
+
+            sleep 10
+          done
+
+          echo "npm latest dist-tag did not resolve to ${EXPECTED_VERSION}" >&2
+          echo "Observed package version: ${published_version:-<empty>}" >&2
+          echo "Observed dist-tags.latest: ${latest_tag:-<empty>}" >&2
+          echo "Observed @latest version: ${latest_version:-<empty>}" >&2
+          exit 1
+
       - name: Release summary
         run: |
           {

--- a/README.md
+++ b/README.md
@@ -65,10 +65,18 @@ OpenClaude is also mirrored to GitLawb:
 ### Install
 
 ```bash
-npm install -g @gitlawb/openclaude
+npm install -g @gitlawb/openclaude@latest
 ```
 
 If the install later reports `ripgrep not found`, install ripgrep system-wide and confirm `rg --version` works in the same terminal before starting OpenClaude.
+
+**Verify / troubleshoot installed version:**
+
+```bash
+openclaude --version
+npm view @gitlawb/openclaude dist-tags
+npm install -g @gitlawb/openclaude@latest
+```
 
 ### Start
 

--- a/docs/advanced-setup.md
+++ b/docs/advanced-setup.md
@@ -7,7 +7,7 @@ This guide is for users who want source builds, Bun workflows, provider profiles
 ### Option A: npm
 
 ```bash
-npm install -g @gitlawb/openclaude
+npm install -g @gitlawb/openclaude@latest
 ```
 
 ### Option B: From source with Bun

--- a/docs/quick-start-mac-linux.md
+++ b/docs/quick-start-mac-linux.md
@@ -18,7 +18,7 @@ npm --version
 ## 2. Install OpenClaude
 
 ```bash
-npm install -g @gitlawb/openclaude
+npm install -g @gitlawb/openclaude@latest
 ```
 
 ## 3. Pick One Provider

--- a/docs/quick-start-windows.md
+++ b/docs/quick-start-windows.md
@@ -18,7 +18,7 @@ npm --version
 ## 2. Install OpenClaude
 
 ```powershell
-npm install -g @gitlawb/openclaude
+npm install -g @gitlawb/openclaude@latest
 ```
 
 ## 3. Pick One Provider

--- a/src/components/AutoUpdater.tsx
+++ b/src/components/AutoUpdater.tsx
@@ -190,7 +190,7 @@ export function AutoUpdater({
       {(autoUpdaterResult?.status === 'install_failed' || autoUpdaterResult?.status === 'no_permissions') && <Text color="error" wrap="truncate">
           ✗ Auto-update failed &middot; Try <Text bold>openclaude doctor</Text> or{' '}
           <Text bold>
-            {hasLocalInstall ? `cd ~/.openclaude/local && npm update ${MACRO.PACKAGE_URL}` : `npm i -g ${MACRO.PACKAGE_URL}`}
+            {hasLocalInstall ? `cd ~/.openclaude/local && npm update ${MACRO.PACKAGE_URL}` : `npm i -g ${MACRO.PACKAGE_URL}@latest`}
           </Text>
         </Text>}
     </Box>;

--- a/src/utils/autoUpdater.ts
+++ b/src/utils/autoUpdater.ts
@@ -529,7 +529,7 @@ To fix this issue:
     // Use specific version if provided, otherwise use latest
     const packageSpec = specificVersion
       ? `${MACRO.PACKAGE_URL}@${specificVersion}`
-      : MACRO.PACKAGE_URL
+      : `${MACRO.PACKAGE_URL}@latest`
 
     // Run from home directory to avoid reading project-level .npmrc/.bunfig.toml
     // which could be maliciously crafted to redirect to an attacker's registry

--- a/vscode-extension/openclaude-vscode/README.md
+++ b/vscode-extension/openclaude-vscode/README.md
@@ -28,7 +28,7 @@ A practical VS Code companion for OpenClaude with a project-aware **Control Cent
 ## Requirements
 
 - VS Code `1.95+`
-- `openclaude` available in your terminal PATH (`npm install -g @gitlawb/openclaude`)
+- `openclaude` available in your terminal PATH (`npm install -g @gitlawb/openclaude@latest`)
 
 ## Commands
 

--- a/vscode-extension/openclaude-vscode/src/extension.js
+++ b/vscode-extension/openclaude-vscode/src/extension.js
@@ -291,7 +291,7 @@ async function launchOpenClaude(options = {}) {
 
   if (!installed) {
     const action = await vscode.window.showErrorMessage(
-      `OpenClaude command not found: ${executable}. Install it with: npm install -g @gitlawb/openclaude`,
+      `OpenClaude command not found: ${executable}. Install it with: npm install -g @gitlawb/openclaude@latest`,
       'Open Setup Guide',
       'Open Repository',
     );

--- a/web/src/content.ts
+++ b/web/src/content.ts
@@ -1,4 +1,4 @@
-export const installCommand = 'npm install -g @gitlawb/openclaude'
+export const installCommand = 'npm install -g @gitlawb/openclaude@latest'
 
 export const features = [
   {


### PR DESCRIPTION
## Summary

Fixes #1364.

- Update global npm install instructions to use `@gitlawb/openclaude@latest`.
- Add troubleshooting commands so users can verify the npm `latest` dist-tag and installed CLI version.
- Add post-publish release verification that fails the release job if npm's `latest` tag does not resolve to the release-please version.
- Ensure the internal auto-updater and its manual fallback commands explicitly use `@latest` to prevent stale global installs.

## Why

A user reported that `npm install -g @gitlawb/openclaude` installed `0.8.0` instead of the expected newer release. If npm's `latest` dist-tag or registry propagation is stale, users can install outdated builds and miss recent fixes.

Using `@latest` in docs and internal updater logic makes the intended install target explicit, and release verification makes future npm tag drift visible immediately. The registry currently resolves correctly, so this PR is preventive: it makes the install explicit and adds release verification to catch future tag drift.

## Investigation

- `npm view @gitlawb/openclaude version`: `0.15.0`
- `npm view @gitlawb/openclaude dist-tags --json`: `{"latest":"0.15.0"}`
- `npm view @gitlawb/openclaude@latest version`: `0.15.0`
- Existing docs used `npm install -g @gitlawb/openclaude`.
- Existing release workflow did not verify npm's `latest` dist-tag after publish.

## Testing

- [x] `git grep -n "npm install -g @gitlawb/openclaude"`
- [x] `npm view @gitlawb/openclaude version`
- [x] `npm view @gitlawb/openclaude dist-tags --json`
- [x] `npm view @gitlawb/openclaude@latest version`
- [x] `git diff --check`
- [x] `bun run build`
- [ ] Release workflow verification will run on the next release.

## Notes

This PR does not publish to npm and does not manually mutate npm dist-tags. It only documents the explicit install target and verifies future releases. 

*Note: `bun run typecheck` currently fails globally on the main branch due to >15,000 preexisting errors, which appear unrelated to the minimal 2-line autoUpdater string changes introduced here.*
