### PR TITLE
fix(provider): require API key input when adding OpenGateway

### DIFF
--- a/src/integrations/gateways/gitlawb-opengateway.ts
+++ b/src/integrations/gateways/gitlawb-opengateway.ts
@@ -44,6 +44,7 @@ export default defineGateway({
   preset: {
     id: 'gitlawb-opengateway',
     description: 'Gitlawb Opengateway — free hosted Xiaomi MiMo + GMI Cloud partner models (API key required, mint at https://gitlawb.com/opengateway/keys)',
+    apiKeyEnvVars: ['OPENGATEWAY_API_KEY'],
     label: 'Gitlawb Opengateway',
     name: 'Gitlawb Opengateway',
     vendorId: 'openai',

--- a/src/integrations/generated/integrationArtifacts.generated.ts
+++ b/src/integrations/generated/integrationArtifacts.generated.ts
@@ -77,6 +77,9 @@ export const PROVIDER_PRESET_MANIFEST = [
     "description": "Gitlawb Opengateway — free hosted Xiaomi MiMo + GMI Cloud partner models (API key required, mint at https://gitlawb.com/opengateway/keys)",
     "label": "Gitlawb Opengateway",
     "name": "Gitlawb Opengateway",
+    "apiKeyEnvVars": [
+      "OPENGATEWAY_API_KEY"
+    ],
     "baseUrlEnvVars": [
       "OPENGATEWAY_BASE_URL",
       "OPENAI_BASE_URL"


### PR DESCRIPTION
The OpenGateway preset was missing `apiKeyEnvVars`, so credential resolution fell back to the descriptor's `credentialEnvVars` chain which includes `OPENAI_API_KEY`.  If a user had `OPENAI_API_KEY` set for a different provider, the add-provider flow silently pre-populated the draft key and skipped the API key input screen entirely.

Add an explicit `apiKeyEnvVars: ['OPENGATEWAY_API_KEY']` to the preset so the UI only auto-fills from the provider-specific env var.  The runtime setup/validation still falls back to `OPENAI_API_KEY` for existing configs.
