### PR TITLE
fix(openai-shim): strip image_url blocks on text-only providers (DeepSeek) (#1382)

### DIFF
--- a/src/services/api/openaiShim.test.ts
+++ b/src/services/api/openaiShim.test.ts
@@ -5983,3 +5983,120 @@ test('emits reasoning_effort from codex alias default when no override is passed
 
   expect(requestBody?.reasoning_effort).toBe('high')
 })
+
+test('strips image_url blocks and emits warning when provider is DeepSeek (#1382)', async () => {
+  process.env.OPENAI_BASE_URL = 'https://api.deepseek.com/v1'
+  process.env.OPENAI_API_KEY = 'sk-deepseek'
+
+  let requestBody: Record<string, unknown> | undefined
+  globalThis.fetch = (async (_input, init) => {
+    requestBody = JSON.parse(String(init?.body)) as Record<string, unknown>
+    return new Response(
+      JSON.stringify({
+        id: 'chatcmpl-1',
+        model: 'deepseek-v4-pro',
+        choices: [
+          {
+            message: { role: 'assistant', content: 'ok' },
+            finish_reason: 'stop',
+          },
+        ],
+        usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+      }),
+      { headers: { 'Content-Type': 'application/json' } },
+    )
+  }) as FetchType
+
+  const client = createOpenAIShimClient({}) as OpenAIShimClient
+  await client.beta.messages.create({
+    model: 'deepseek-v4-pro',
+    messages: [
+      {
+        role: 'user',
+        content: [
+          { type: 'text', text: 'What is in this image?' },
+          {
+            type: 'image',
+            source: {
+              type: 'base64',
+              media_type: 'image/png',
+              data: 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=',
+            },
+          },
+        ],
+      },
+    ],
+    max_tokens: 64,
+    stream: false,
+  })
+
+  const messages = (requestBody?.messages ?? []) as Array<{
+    role: string
+    content: unknown
+  }>
+  const userMsg = messages.find(m => m.role === 'user')
+  expect(userMsg).toBeDefined()
+  const content = userMsg!.content
+  // Whatever shape the shim chose (array of text parts or a collapsed string),
+  // it MUST NOT contain any image_url part that would 400 DeepSeek.
+  const serialised = JSON.stringify(content)
+  expect(serialised.includes('image_url')).toBe(false)
+  // And the model still sees the original text + a placeholder noting the
+  // image was dropped, so it can ask a follow-up if needed.
+  expect(serialised.includes('What is in this image?')).toBe(true)
+  expect(serialised.includes('image omitted')).toBe(true)
+})
+
+test('preserves image_url blocks on multimodal providers (regression guard)', async () => {
+  // The stripper is gated on hostname. A vanilla OpenAI base URL should still
+  // forward images verbatim — confirms isTextOnlyOpenAICompatProvider doesn't
+  // accidentally fire on the wider OpenAI-compatible population.
+  process.env.OPENAI_BASE_URL = 'https://api.openai.com/v1'
+  process.env.OPENAI_API_KEY = 'sk-openai'
+
+  let requestBody: Record<string, unknown> | undefined
+  globalThis.fetch = (async (_input, init) => {
+    requestBody = JSON.parse(String(init?.body)) as Record<string, unknown>
+    return new Response(
+      JSON.stringify({
+        id: 'chatcmpl-1',
+        model: 'gpt-4o',
+        choices: [
+          {
+            message: { role: 'assistant', content: 'ok' },
+            finish_reason: 'stop',
+          },
+        ],
+        usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+      }),
+      { headers: { 'Content-Type': 'application/json' } },
+    )
+  }) as FetchType
+
+  const client = createOpenAIShimClient({}) as OpenAIShimClient
+  await client.beta.messages.create({
+    model: 'gpt-4o',
+    messages: [
+      {
+        role: 'user',
+        content: [
+          { type: 'text', text: 'describe' },
+          {
+            type: 'image',
+            source: { type: 'url', url: 'https://example.com/img.png' },
+          },
+        ],
+      },
+    ],
+    max_tokens: 64,
+    stream: false,
+  })
+
+  const messages = (requestBody?.messages ?? []) as Array<{
+    role: string
+    content: unknown
+  }>
+  const serialised = JSON.stringify(messages.find(m => m.role === 'user')?.content)
+  expect(serialised.includes('image_url')).toBe(true)
+  expect(serialised.includes('https://example.com/img.png')).toBe(true)
+})

--- a/src/services/api/openaiShim.ts
+++ b/src/services/api/openaiShim.ts
@@ -65,6 +65,7 @@ import {
   getLocalProviderRetryBaseUrls,
   getGithubEndpointType,
   isLocalProviderUrl,
+  isTextOnlyOpenAICompatProvider,
   resolveRuntimeCodexCredentials,
   resolveProviderRequest,
   shouldAttemptLocalToollessRetry,
@@ -306,9 +307,48 @@ function convertSystemPrompt(
   return String(system)
 }
 
+function safeHostnameOrEmpty(baseUrl: string | undefined): string {
+  if (!baseUrl) return ''
+  try {
+    return new URL(baseUrl).hostname.toLowerCase()
+  } catch {
+    return ''
+  }
+}
+
+// Tracks providers that have already received the "images stripped" warning
+// in this process, keyed by hostname. The warning surfaces once per host so
+// users learn the limitation without spamming the terminal every turn. See
+// `noteImageStrippedForProvider`.
+const imageStripWarningEmittedHosts: Set<string> = new Set()
+
+function noteImageStrippedForProvider(providerHost: string): void {
+  if (!providerHost || imageStripWarningEmittedHosts.has(providerHost)) return
+  imageStripWarningEmittedHosts.add(providerHost)
+  process.stderr.write(
+    `Warning: ${providerHost} is text-only — image content was stripped from this request. ` +
+      `Use a multimodal provider (e.g. an OpenAI-compatible vision endpoint) to send images.\n`,
+  )
+  logForDebugging(
+    `[openaiShim] stripped image_url blocks for text-only provider ${providerHost}`,
+  )
+}
+
+/** Marker text inserted in place of a stripped image block. Kept short so it
+ * doesn't dominate the message; the surrounding prose still carries the user
+ * intent and the model can ask a follow-up if it needs more detail. */
+const STRIPPED_IMAGE_PLACEHOLDER =
+  '[image omitted: this provider does not accept image content]'
+
+type ConvertOptions = {
+  stripImages?: boolean
+  providerHost?: string
+}
+
 function convertToolResultContent(
   content: unknown,
   isError?: boolean,
+  options?: ConvertOptions,
 ): string | Array<{ type: string; text?: string; image_url?: { url: string } }> {
   if (typeof content === 'string') {
     return isError ? `Error: ${content}` : content
@@ -330,6 +370,11 @@ function convertToolResultContent(
     }
 
     if (block?.type === 'image') {
+      if (options?.stripImages) {
+        parts.push({ type: 'text', text: STRIPPED_IMAGE_PLACEHOLDER })
+        if (options.providerHost) noteImageStrippedForProvider(options.providerHost)
+        continue
+      }
       const source = block.source
       if (source?.type === 'url' && source.url) {
         parts.push({ type: 'image_url', image_url: { url: source.url } })
@@ -374,6 +419,7 @@ function convertToolResultContent(
 
 function convertContentBlocks(
   content: unknown,
+  options?: ConvertOptions,
 ): string | Array<{ type: string; text?: string; image_url?: { url: string } }> {
   if (typeof content === 'string') return content
   if (!Array.isArray(content)) return String(content ?? '')
@@ -385,6 +431,11 @@ function convertContentBlocks(
         parts.push({ type: 'text', text: block.text ?? '' })
         break
       case 'image': {
+        if (options?.stripImages) {
+          parts.push({ type: 'text', text: STRIPPED_IMAGE_PLACEHOLDER })
+          if (options.providerHost) noteImageStrippedForProvider(options.providerHost)
+          break
+        }
         const src = block.source
         if (src?.type === 'base64') {
           parts.push({
@@ -494,11 +545,17 @@ function convertMessages(
     preserveReasoningContent?: boolean
     reasoningContentFallback?: '' | 'omit'
     preserveGeminiThoughtSignature?: boolean
+    stripImages?: boolean
+    providerHost?: string
   },
 ): OpenAIMessage[] {
   const preserveReasoningContent = options?.preserveReasoningContent === true
   const reasoningContentFallback = options?.reasoningContentFallback
   const preserveGeminiThoughtSignature = options?.preserveGeminiThoughtSignature === true
+  const convertOpts: ConvertOptions = {
+    stripImages: options?.stripImages === true,
+    providerHost: options?.providerHost,
+  }
   const result: OpenAIMessage[] = []
   const knownToolCallIds = new Set<string>()
 
@@ -554,7 +611,7 @@ function convertMessages(
             result.push({
               role: 'tool',
               tool_call_id: id,
-              content: convertToolResultContent(tr.content, tr.is_error),
+              content: convertToolResultContent(tr.content, tr.is_error, convertOpts),
             })
           } else {
             logForDebugging(
@@ -567,13 +624,13 @@ function convertMessages(
         if (otherContent.length > 0) {
           result.push({
             role: 'user',
-            content: convertContentBlocks(otherContent),
+            content: convertContentBlocks(otherContent, convertOpts),
           })
         }
       } else {
         result.push({
           role: 'user',
-          content: convertContentBlocks(content),
+          content: convertContentBlocks(content, convertOpts),
         })
       }
     } else if (role === 'assistant') {
@@ -592,7 +649,7 @@ function convertMessages(
         const assistantMsg: OpenAIMessage = {
           role: 'assistant',
           content: (() => {
-            const c = convertContentBlocks(textContent)
+            const c = convertContentBlocks(textContent, convertOpts)
             return typeof c === 'string'
               ? c
               : Array.isArray(c)
@@ -695,7 +752,7 @@ function convertMessages(
         const assistantMsg: OpenAIMessage = {
           role: 'assistant',
           content: (() => {
-            const c = convertContentBlocks(content)
+            const c = convertContentBlocks(content, convertOpts)
             return typeof c === 'string'
               ? c
               : Array.isArray(c)
@@ -1785,6 +1842,7 @@ class OpenAIShimMessages {
       treatAsLocal: isLocalProviderUrl(request.baseUrl),
     })
     const shimConfig = runtimeShimContext.openaiShimConfig
+    const stripImagesForProvider = isTextOnlyOpenAICompatProvider(request.baseUrl)
     const openaiMessages = convertMessages(compressedMessages, params.system, {
       preserveReasoningContent: shimConfig.preserveReasoningContent,
       reasoningContentFallback: shimConfig.reasoningContentFallback,
@@ -1792,6 +1850,10 @@ class OpenAIShimMessages {
         request.resolvedModel,
         request.baseUrl,
       ),
+      stripImages: stripImagesForProvider,
+      providerHost: stripImagesForProvider
+        ? safeHostnameOrEmpty(request.baseUrl)
+        : undefined,
     })
 
     const body: Record<string, unknown> = {

--- a/src/services/api/providerConfig.textOnly.test.ts
+++ b/src/services/api/providerConfig.textOnly.test.ts
@@ -1,0 +1,39 @@
+import { expect, test } from 'bun:test'
+
+import { isTextOnlyOpenAICompatProvider } from './providerConfig.js'
+
+test('isTextOnlyOpenAICompatProvider: matches DeepSeek hosts', () => {
+  expect(isTextOnlyOpenAICompatProvider('https://api.deepseek.com/v1')).toBe(true)
+  expect(isTextOnlyOpenAICompatProvider('https://api.deepseek.com')).toBe(true)
+  expect(isTextOnlyOpenAICompatProvider('https://api.deepseek.com/chat/completions')).toBe(true)
+})
+
+test('isTextOnlyOpenAICompatProvider: matches DeepSeek subdomains', () => {
+  // The suffix match permits regional/tenant DNS like `eu.api.deepseek.com`
+  // without requiring an exact-host enumeration. Only protect the apex domain
+  // so unrelated providers that happen to embed `deepseek` in a path don't
+  // get a false positive (see baseUrl-with-deepseek-path test below).
+  expect(isTextOnlyOpenAICompatProvider('https://eu.api.deepseek.com/v1')).toBe(true)
+})
+
+test('isTextOnlyOpenAICompatProvider: does NOT match multimodal providers', () => {
+  expect(isTextOnlyOpenAICompatProvider('https://api.openai.com/v1')).toBe(false)
+  expect(isTextOnlyOpenAICompatProvider('https://api.anthropic.com')).toBe(false)
+  expect(isTextOnlyOpenAICompatProvider('http://localhost:11434/v1')).toBe(false)
+  expect(isTextOnlyOpenAICompatProvider('https://generativelanguage.googleapis.com/v1beta/openai')).toBe(false)
+})
+
+test('isTextOnlyOpenAICompatProvider: does NOT match URLs that merely mention the brand in a path', () => {
+  // Defensive: a proxy whose path happens to contain `deepseek` (model-routing
+  // gateways often do) is not necessarily text-only. We only suffix-match the
+  // hostname, never the path.
+  expect(
+    isTextOnlyOpenAICompatProvider('https://api.openrouter.ai/v1/deepseek/chat'),
+  ).toBe(false)
+})
+
+test('isTextOnlyOpenAICompatProvider: handles invalid / missing input safely', () => {
+  expect(isTextOnlyOpenAICompatProvider(undefined)).toBe(false)
+  expect(isTextOnlyOpenAICompatProvider('')).toBe(false)
+  expect(isTextOnlyOpenAICompatProvider('not a url')).toBe(false)
+})

--- a/src/services/api/providerConfig.ts
+++ b/src/services/api/providerConfig.ts
@@ -538,6 +538,36 @@ export function shouldAttemptLocalToollessRetry(options: {
   return isLikelyOllamaEndpoint(options.baseUrl)
 }
 
+/**
+ * OpenAI-compatible providers whose chat API is text-only and rejects
+ * `image_url` content parts. DeepSeek (#1382) returns 400 with
+ * `unknown variant image_url, expected text`, and because the failed message
+ * stays in conversation history the session is effectively dead — every
+ * subsequent turn re-sends the same payload and reproduces the error.
+ *
+ * Conservative match list. Add an entry only after confirming the provider's
+ * chat endpoint rejects multimodal blocks; defaulting to "forward" is safer
+ * than silently stripping on a provider that would have understood the image.
+ */
+const TEXT_ONLY_OPENAI_COMPAT_HOSTNAME_SUFFIXES: readonly string[] = [
+  'api.deepseek.com',
+  'deepseek.com',
+]
+
+export function isTextOnlyOpenAICompatProvider(
+  baseUrl: string | undefined,
+): boolean {
+  if (!baseUrl) return false
+  try {
+    const hostname = new URL(baseUrl).hostname.toLowerCase()
+    return TEXT_ONLY_OPENAI_COMPAT_HOSTNAME_SUFFIXES.some(
+      suffix => hostname === suffix || hostname.endsWith(`.${suffix}`),
+    )
+  } catch {
+    return false
+  }
+}
+
 export function isCodexBaseUrl(baseUrl: string | undefined): boolean {
   if (!baseUrl) return false
   try {


### PR DESCRIPTION
## Summary

DeepSeek's chat API is OpenAI-shape but text-only. Sending a message with an image returned 400 with `unknown variant image_url, expected text`, and because the failed message stayed in conversation history every subsequent turn replayed the same payload — the session was effectively dead until the user manually rewound.

This change detects text-only OpenAI-compatible providers by hostname suffix and replaces `image` content blocks with a short text marker before the request leaves the shim, with a once-per-host stderr warning the first time the strip triggers.

## Implementation

- New `isTextOnlyOpenAICompatProvider(baseUrl)` helper in `providerConfig.ts`. Conservative hostname-suffix allowlist (`api.deepseek.com` and the apex `deepseek.com`); easy to extend as we confirm other endpoints.
- `convertContentBlocks` and `convertToolResultContent` in `openaiShim.ts` accept a `ConvertOptions` carrier with `stripImages` + `providerHost`. When `stripImages` is on, both functions replace any `image` block with `[image omitted: this provider does not accept image content]`. The hostname is surfaced in a `process.stderr.write` warning that fires at most once per host per process (tracked via a module-scoped Set) so users learn the limitation without it spamming every turn.
- `convertMessages` propagates the options to each helper site (user prose, assistant prose, tool result).
- The shim's chat-completions request site gates on `isTextOnlyOpenAICompatProvider(request.baseUrl)` so the strip is a no-op for the wider OpenAI-compatible population.

## Test plan

- [x] `src/services/api/providerConfig.textOnly.test.ts` — 5 cases: apex + subdomain match, negative match against OpenAI/Anthropic/Ollama/Gemini, brand-in-path false-positive guard, invalid-input safety.
- [x] `src/services/api/openaiShim.test.ts` (two new tests): DeepSeek base URL drops `image_url` from the outgoing request while preserving surrounding text + the omission marker; OpenAI base URL forwards `image_url` verbatim (regression guard so the helper doesn't fire on multimodal hosts).
- [x] 110/110 of the touched test files pass locally.

Closes #1382