### PR TITLE
fix(bash): surface rolled-output file path on non-zero exit (#1359)

### DIFF
--- a/src/tools/BashTool/BashTool.errorOutput.test.ts
+++ b/src/tools/BashTool/BashTool.errorOutput.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, test } from 'bun:test'
-import { BashTool } from './BashTool.js'
+import {
+  BashTool,
+  appendPersistedOutputHint,
+  MAX_PERSISTED_SHELL_OUTPUT_SIZE,
+} from './BashTool.js'
 import { getEmptyToolPermissionContext } from '../../Tool.js'
 import { ShellError } from '../../utils/errors.js'
 import { formatError } from '../../utils/toolErrors.js'
@@ -88,5 +92,24 @@ describe('BashTool error output (#1231)', () => {
     // require the canonical phrasing so the model's prompt template can
     // anchor on it.
     expect(formatted).toMatch(/full output \(\d+ bytes\) saved to .+; read with the Read tool/)
+  })
+
+  // Follow-up to #1359 — persistShellOutputFile caps the saved roll file at
+  // MAX_PERSISTED_SHELL_OUTPUT_SIZE. When that cap engages the error marker
+  // must NOT claim the full output is on disk, or the model trusts a truncated
+  // file and can miss a failure that appears past the cap.
+  test('hint reports a cap instead of "full output" when the roll file was truncated', () => {
+    const original = MAX_PERSISTED_SHELL_OUTPUT_SIZE + 4096
+    const hint = appendPersistedOutputHint('preview', '/tmp/out', original, true)
+    expect(hint).not.toContain('full output')
+    expect(hint).toContain('capped')
+    expect(hint).toContain(`first ${MAX_PERSISTED_SHELL_OUTPUT_SIZE} bytes`)
+    expect(hint).toContain(`${original}-byte`)
+    expect(hint).toContain('/tmp/out')
+  })
+
+  test('hint keeps "full output" wording when the roll file fit under the cap', () => {
+    const hint = appendPersistedOutputHint('preview', '/tmp/out', 1234, false)
+    expect(hint).toMatch(/full output \(1234 bytes\) saved to \/tmp\/out; read with the Read tool/)
   })
 })

--- a/src/tools/BashTool/BashTool.errorOutput.test.ts
+++ b/src/tools/BashTool/BashTool.errorOutput.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from 'bun:test'
+import { existsSync, readFileSync, rmSync } from 'fs'
 import {
   BashTool,
   appendPersistedOutputHint,
@@ -81,17 +82,37 @@ describe('BashTool error output (#1231)', () => {
     // Generate ~50k bytes (well above BASH_MAX_OUTPUT_DEFAULT=30000) then
     // exit non-zero. The shell's rolling-file path engages once the in-memory
     // accumulator exceeds the cap.
-    const err = await expectShellError(
-      `for i in $(seq 1 700); do printf 'line %04d %s\\n' "$i" "padding-to-make-this-line-fat-enough-to-cross-the-limit"; done; exit 1`,
-    )
-    expect(err.code).toBe(1)
-    const formatted = formatError(err)
-    expect(formatted).toContain('Exit code 1')
-    // The marker tells the model the full output is on disk along with the
-    // byte count. We don't pin the exact path (it's a temp dir) but we do
-    // require the canonical phrasing so the model's prompt template can
-    // anchor on it.
-    expect(formatted).toMatch(/full output \(\d+ bytes\) saved to .+; read with the Read tool/)
+    let persistedPath: string | undefined
+    try {
+      const err = await expectShellError(
+        `for i in $(seq 1 700); do printf 'line %04d %s\\n' "$i" "padding-to-make-this-line-fat-enough-to-cross-the-limit"; done; exit 1`,
+      )
+      expect(err.code).toBe(1)
+      const formatted = formatError(err)
+      expect(formatted).toContain('Exit code 1')
+      // The marker tells the model the full output is on disk along with the
+      // byte count. We don't pin the exact path (it's a temp dir) but we do
+      // require the canonical phrasing so the model's prompt template can
+      // anchor on it.
+      const match = formatted.match(
+        /full output \(\d+ bytes\) saved to (.+); read with the Read tool/,
+      )
+      expect(match).not.toBeNull()
+      persistedPath = match?.[1]
+      expect(persistedPath).toBeDefined()
+
+      // The saved file must actually be readable and contain the late output
+      // that #1359 needs the model to recover — i.e. the tail line, which the
+      // truncated in-memory chunk dropped.
+      expect(existsSync(persistedPath!)).toBe(true)
+      const saved = readFileSync(persistedPath!, 'utf8')
+      expect(saved).toContain('line 0700')
+    } finally {
+      // Don't leave tool-results artifacts under the real project storage.
+      if (persistedPath && existsSync(persistedPath)) {
+        rmSync(persistedPath, { force: true })
+      }
+    }
   })
 
   // Follow-up to #1359 — persistShellOutputFile caps the saved roll file at

--- a/src/tools/BashTool/BashTool.errorOutput.test.ts
+++ b/src/tools/BashTool/BashTool.errorOutput.test.ts
@@ -173,4 +173,31 @@ describe('BashTool error output (#1231)', () => {
       rmSync(dir, { recursive: true, force: true })
     }
   })
+
+  // The capped destination must hold exactly the FIRST `maxSize` bytes of the
+  // source — no more, no less. Guards the bounded read range (an off-by-one on
+  // the inclusive `end` would spill one extra byte). Distinguishable halves
+  // prove only the head is written, and never the tail.
+  test('capped destination contains exactly the first maxSize bytes', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'persist-head-'))
+    const source = join(dir, 'roll.txt')
+    const cap = 2048
+    const head = 'A'.repeat(cap)
+    const tail = 'B'.repeat(cap)
+    writeFileSync(source, head + tail) // 2*cap bytes
+    let dest: string | undefined
+    try {
+      const persisted = await persistShellOutputFile(source, 'persist-head-test', cap)
+      expect(persisted).not.toBeNull()
+      dest = persisted!.path
+      expect(persisted!.truncated).toBe(true)
+      const saved = readFileSync(dest, 'utf8')
+      expect(saved.length).toBe(cap)
+      expect(saved).toBe(head) // exactly the head, no tail byte leaked in
+      expect(saved).not.toContain('B')
+    } finally {
+      if (dest && existsSync(dest)) rmSync(dest, { force: true })
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
 })

--- a/src/tools/BashTool/BashTool.errorOutput.test.ts
+++ b/src/tools/BashTool/BashTool.errorOutput.test.ts
@@ -1,9 +1,19 @@
 import { describe, expect, test } from 'bun:test'
-import { existsSync, readFileSync, rmSync } from 'fs'
+import {
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
 import {
   BashTool,
   appendPersistedOutputHint,
   MAX_PERSISTED_SHELL_OUTPUT_SIZE,
+  persistShellOutputFile,
 } from './BashTool.js'
 import { getEmptyToolPermissionContext } from '../../Tool.js'
 import { ShellError } from '../../utils/errors.js'
@@ -132,5 +142,35 @@ describe('BashTool error output (#1231)', () => {
   test('hint keeps "full output" wording when the roll file fit under the cap', () => {
     const hint = appendPersistedOutputHint('preview', '/tmp/out', 1234, false)
     expect(hint).toMatch(/full output \(1234 bytes\) saved to \/tmp\/out; read with the Read tool/)
+  })
+
+  // Follow-up to #1359 — when the roll file exceeds the cap, the cap must be
+  // applied to the saved copy, NOT to the shell's rolled-output source. The
+  // error fallback and resizeShellImageOutput still read the source, so
+  // mutating it would drop the very tail this persistence is meant to recover.
+  test('caps the destination copy and leaves the rolled-output source intact', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'persist-source-'))
+    const source = join(dir, 'roll.txt')
+    // 4 KiB of recoverable output; cap the saved copy at 1 KiB.
+    const body = 'x'.repeat(4096)
+    writeFileSync(source, body)
+    const cap = 1024
+    let dest: string | undefined
+    try {
+      const persisted = await persistShellOutputFile(source, 'persist-src-test', cap)
+      expect(persisted).not.toBeNull()
+      dest = persisted!.path
+      // Reported size is the original byte count; truncated flags the cap.
+      expect(persisted!.size).toBe(4096)
+      expect(persisted!.truncated).toBe(true)
+      // Source keeps every byte — its tail is still recoverable downstream.
+      expect(statSync(source).size).toBe(4096)
+      expect(readFileSync(source, 'utf8')).toBe(body)
+      // Destination copy is the one that got capped.
+      expect(statSync(dest).size).toBe(cap)
+    } finally {
+      if (dest && existsSync(dest)) rmSync(dest, { force: true })
+      rmSync(dir, { recursive: true, force: true })
+    }
   })
 })

--- a/src/tools/BashTool/BashTool.errorOutput.test.ts
+++ b/src/tools/BashTool/BashTool.errorOutput.test.ts
@@ -66,4 +66,27 @@ describe('BashTool error output (#1231)', () => {
     expect(err.code).toBe(1)
     expect(formatError(err)).toBe('Exit code 1')
   })
+
+  // Regression for #1359 — when the captured output rolls to a file because
+  // it exceeds getMaxOutputLength (default 30k bytes) AND the command exits
+  // non-zero, the model used to see only the truncated first chunk on
+  // result.stdout with no signal that the rest existed. The error path now
+  // persists the roll file into the tool-results dir and appends a marker
+  // pointing at it, so the model can FileRead the full output.
+  test('large-output non-zero exit persists output and embeds path in error', async () => {
+    // Generate ~50k bytes (well above BASH_MAX_OUTPUT_DEFAULT=30000) then
+    // exit non-zero. The shell's rolling-file path engages once the in-memory
+    // accumulator exceeds the cap.
+    const err = await expectShellError(
+      `for i in $(seq 1 700); do printf 'line %04d %s\\n' "$i" "padding-to-make-this-line-fat-enough-to-cross-the-limit"; done; exit 1`,
+    )
+    expect(err.code).toBe(1)
+    const formatted = formatError(err)
+    expect(formatted).toContain('Exit code 1')
+    // The marker tells the model the full output is on disk along with the
+    // byte count. We don't pin the exact path (it's a temp dir) but we do
+    // require the canonical phrasing so the model's prompt template can
+    // anchor on it.
+    expect(formatted).toMatch(/full output \(\d+ bytes\) saved to .+; read with the Read tool/)
+  })
 })

--- a/src/tools/BashTool/BashTool.tsx
+++ b/src/tools/BashTool/BashTool.tsx
@@ -311,6 +311,65 @@ import type { BashProgress } from '../../types/tools.js';
  * @param command The command to check
  * @returns false for commands that should not be auto-backgrounded (like sleep)
  */
+/**
+ * Maximum bytes we copy from a rolled-output file into the tool-results dir.
+ * Files larger than this are truncated before the link/copy so a runaway
+ * command does not blow up disk usage in the user's home dir.
+ */
+const MAX_PERSISTED_SHELL_OUTPUT_SIZE = 64 * 1024 * 1024;
+
+/**
+ * Copy the shell's rolled-output file into the tool-results dir so the model
+ * can read it back via FileRead. Used by both the success path and the
+ * non-zero-exit error path (issue #1359): without this on the error side,
+ * the ShellError carries only the truncated first chunk from `result.stdout`
+ * and the model has no way to recover the failure body, leaving it to ask
+ * the user to re-run with redirection.
+ *
+ * Returns the destination path and size on success; returns `null` if the
+ * roll file is missing or the link/copy itself fails. Callers fall back to
+ * the in-memory stdout preview in that case.
+ */
+async function persistShellOutputFile(
+  sourcePath: string,
+  taskId: string,
+): Promise<{ path: string; size: number } | null> {
+  try {
+    const fileStat = await fsStat(sourcePath);
+    const size = fileStat.size;
+    await ensureToolResultsDir();
+    const dest = getToolResultPath(taskId, false);
+    if (size > MAX_PERSISTED_SHELL_OUTPUT_SIZE) {
+      await fsTruncate(sourcePath, MAX_PERSISTED_SHELL_OUTPUT_SIZE);
+    }
+    try {
+      await link(sourcePath, dest);
+    } catch {
+      await copyFile(sourcePath, dest);
+    }
+    return { path: dest, size };
+  } catch {
+    // File may already be gone — caller's stdout preview is sufficient.
+    return null;
+  }
+}
+
+/**
+ * Append a "[…full output saved to <path>]" marker to the captured stdout
+ * carried on a ShellError. Pads with a blank line so the marker reads as a
+ * distinct paragraph regardless of whether `stdout` ended with a newline.
+ */
+function appendPersistedOutputHint(
+  stdout: string,
+  persistedPath: string,
+  persistedSize: number,
+): string {
+  const hint = `[output truncated above — full output (${persistedSize} bytes) saved to ${persistedPath}; read with the Read tool]`;
+  if (!stdout) return hint;
+  const trimmed = stdout.endsWith('\n') ? stdout.slice(0, -1) : stdout;
+  return `${trimmed}\n\n${hint}`;
+}
+
 function isAutobackgroundingAllowed(command: string): boolean {
   const parts = splitCommand_DEPRECATED(command);
   if (parts.length === 0) return true;
@@ -752,7 +811,29 @@ export const BashTool = buildTool({
         // — without this, a non-zero exit hides the very output users need
         // to debug the failure (issue #1231). result.stderr is empty in
         // file mode but populated in pipe mode (hooks).
-        throw new ShellError(outputWithSbFailures, result.stderr || '', result.code, result.interrupted);
+        //
+        // When the shell rolled output to a file (large output path), the
+        // first chunk on `result.stdout` is truncated. Hoist the persist
+        // step here so the error message can point at the full output
+        // (issue #1359) — otherwise the model sees only the exit code +
+        // the truncated chunk and has no signal that the rest exists. The
+        // persist step is identical to the success-path block below; both
+        // sites resolve the same `result.outputFilePath` / outputTaskId.
+        let errorStdout = outputWithSbFailures
+        if (result.outputFilePath && result.outputTaskId) {
+          const persistedForError = await persistShellOutputFile(
+            result.outputFilePath,
+            result.outputTaskId,
+          )
+          if (persistedForError) {
+            errorStdout = appendPersistedOutputHint(
+              errorStdout,
+              persistedForError.path,
+              persistedForError.size,
+            )
+          }
+        }
+        throw new ShellError(errorStdout, result.stderr || '', result.code, result.interrupted);
       }
       wasInterrupted = result.interrupted;
     } finally {
@@ -766,26 +847,16 @@ export const BashTool = buildTool({
     // stdout already contains the first chunk (from getStdout()). Copy the
     // output file to the tool-results dir so the model can read it via
     // FileRead. If > 64 MB, truncate after copying.
-    const MAX_PERSISTED_SIZE = 64 * 1024 * 1024;
     let persistedOutputPath: string | undefined;
     let persistedOutputSize: number | undefined;
     if (result.outputFilePath && result.outputTaskId) {
-      try {
-        const fileStat = await fsStat(result.outputFilePath);
-        persistedOutputSize = fileStat.size;
-        await ensureToolResultsDir();
-        const dest = getToolResultPath(result.outputTaskId, false);
-        if (fileStat.size > MAX_PERSISTED_SIZE) {
-          await fsTruncate(result.outputFilePath, MAX_PERSISTED_SIZE);
-        }
-        try {
-          await link(result.outputFilePath, dest);
-        } catch {
-          await copyFile(result.outputFilePath, dest);
-        }
-        persistedOutputPath = dest;
-      } catch {
-        // File may already be gone — stdout preview is sufficient
+      const persisted = await persistShellOutputFile(
+        result.outputFilePath,
+        result.outputTaskId,
+      );
+      if (persisted) {
+        persistedOutputPath = persisted.path;
+        persistedOutputSize = persisted.size;
       }
     }
     const commandType = input.command.split(' ')[0];

--- a/src/tools/BashTool/BashTool.tsx
+++ b/src/tools/BashTool/BashTool.tsx
@@ -297,7 +297,8 @@ const outputSchema = lazySchema(() => z.object({
   noOutputExpected: z.boolean().optional().describe('Whether the command is expected to produce no output on success'),
   structuredContent: z.array(z.any()).optional().describe('Structured content blocks'),
   persistedOutputPath: z.string().optional().describe('Path to the persisted full output in tool-results dir (set when output is too large for inline)'),
-  persistedOutputSize: z.number().optional().describe('Total size of the output in bytes (set when output is too large for inline)')
+  persistedOutputSize: z.number().optional().describe('Total size of the output in bytes (set when output is too large for inline)'),
+  persistedOutputTruncated: z.boolean().optional().describe('Whether the persisted file is capped (only the first portion of the output was saved)')
 }));
 type OutputSchema = ReturnType<typeof outputSchema>;
 export type Out = z.infer<OutputSchema>;
@@ -641,7 +642,8 @@ export const BashTool = buildTool({
     assistantAutoBackgrounded,
     structuredContent,
     persistedOutputPath,
-    persistedOutputSize
+    persistedOutputSize,
+    persistedOutputTruncated
   }, toolUseID): ToolResultBlockParam {
     // Handle structured content
     if (structuredContent && structuredContent.length > 0) {
@@ -676,7 +678,8 @@ export const BashTool = buildTool({
         originalSize: persistedOutputSize ?? 0,
         isJson: false,
         preview: preview.preview,
-        hasMore: preview.hasMore
+        hasMore: preview.hasMore,
+        truncated: persistedOutputTruncated
       });
     }
     let errorMessage = normalizedStderr.trim();
@@ -863,6 +866,7 @@ export const BashTool = buildTool({
     // FileRead. If > 64 MB, truncate after copying.
     let persistedOutputPath: string | undefined;
     let persistedOutputSize: number | undefined;
+    let persistedOutputTruncated: boolean | undefined;
     if (result.outputFilePath && result.outputTaskId) {
       const persisted = await persistShellOutputFile(
         result.outputFilePath,
@@ -871,6 +875,7 @@ export const BashTool = buildTool({
       if (persisted) {
         persistedOutputPath = persisted.path;
         persistedOutputSize = persisted.size;
+        persistedOutputTruncated = persisted.truncated;
       }
     }
     const commandType = input.command.split(' ')[0];
@@ -934,7 +939,8 @@ export const BashTool = buildTool({
       assistantAutoBackgrounded: result.assistantAutoBackgrounded,
       dangerouslyDisableSandbox: 'dangerouslyDisableSandbox' in input ? input.dangerouslyDisableSandbox as boolean | undefined : undefined,
       persistedOutputPath,
-      persistedOutputSize
+      persistedOutputSize,
+      persistedOutputTruncated
     };
     return {
       data

--- a/src/tools/BashTool/BashTool.tsx
+++ b/src/tools/BashTool/BashTool.tsx
@@ -331,23 +331,31 @@ export const MAX_PERSISTED_SHELL_OUTPUT_SIZE = 64 * 1024 * 1024;
  * roll file is missing or the link/copy itself fails. Callers fall back to
  * the in-memory stdout preview in that case.
  */
-async function persistShellOutputFile(
+export async function persistShellOutputFile(
   sourcePath: string,
   taskId: string,
+  maxSize: number = MAX_PERSISTED_SHELL_OUTPUT_SIZE,
 ): Promise<{ path: string; size: number; truncated: boolean } | null> {
   try {
     const fileStat = await fsStat(sourcePath);
     const size = fileStat.size;
     await ensureToolResultsDir();
     const dest = getToolResultPath(taskId, false);
-    const truncated = size > MAX_PERSISTED_SHELL_OUTPUT_SIZE;
+    const truncated = size > maxSize;
     if (truncated) {
-      await fsTruncate(sourcePath, MAX_PERSISTED_SHELL_OUTPUT_SIZE);
-    }
-    try {
-      await link(sourcePath, dest);
-    } catch {
+      // Cap the destination copy, never the shell's rolled-output source: the
+      // error fallback and resizeShellImageOutput still read `sourcePath`, so
+      // truncating it would drop the tail this persistence is meant to recover.
+      // A hardlink shares the inode, so the oversized path must copy first and
+      // truncate the copy.
       await copyFile(sourcePath, dest);
+      await fsTruncate(dest, maxSize);
+    } else {
+      try {
+        await link(sourcePath, dest);
+      } catch {
+        await copyFile(sourcePath, dest);
+      }
     }
     // `size` is the original (pre-cap) byte count, which the success path
     // reports as the output total. `truncated` tells the error path that the

--- a/src/tools/BashTool/BashTool.tsx
+++ b/src/tools/BashTool/BashTool.tsx
@@ -316,7 +316,7 @@ import type { BashProgress } from '../../types/tools.js';
  * Files larger than this are truncated before the link/copy so a runaway
  * command does not blow up disk usage in the user's home dir.
  */
-const MAX_PERSISTED_SHELL_OUTPUT_SIZE = 64 * 1024 * 1024;
+export const MAX_PERSISTED_SHELL_OUTPUT_SIZE = 64 * 1024 * 1024;
 
 /**
  * Copy the shell's rolled-output file into the tool-results dir so the model
@@ -333,13 +333,14 @@ const MAX_PERSISTED_SHELL_OUTPUT_SIZE = 64 * 1024 * 1024;
 async function persistShellOutputFile(
   sourcePath: string,
   taskId: string,
-): Promise<{ path: string; size: number } | null> {
+): Promise<{ path: string; size: number; truncated: boolean } | null> {
   try {
     const fileStat = await fsStat(sourcePath);
     const size = fileStat.size;
     await ensureToolResultsDir();
     const dest = getToolResultPath(taskId, false);
-    if (size > MAX_PERSISTED_SHELL_OUTPUT_SIZE) {
+    const truncated = size > MAX_PERSISTED_SHELL_OUTPUT_SIZE;
+    if (truncated) {
       await fsTruncate(sourcePath, MAX_PERSISTED_SHELL_OUTPUT_SIZE);
     }
     try {
@@ -347,7 +348,11 @@ async function persistShellOutputFile(
     } catch {
       await copyFile(sourcePath, dest);
     }
-    return { path: dest, size };
+    // `size` is the original (pre-cap) byte count, which the success path
+    // reports as the output total. `truncated` tells the error path that the
+    // saved file is capped at MAX_PERSISTED_SHELL_OUTPUT_SIZE so it does not
+    // describe a partial file as the full output.
+    return { path: dest, size, truncated };
   } catch {
     // File may already be gone — caller's stdout preview is sufficient.
     return null;
@@ -355,16 +360,24 @@ async function persistShellOutputFile(
 }
 
 /**
- * Append a "[…full output saved to <path>]" marker to the captured stdout
- * carried on a ShellError. Pads with a blank line so the marker reads as a
- * distinct paragraph regardless of whether `stdout` ended with a newline.
+ * Append a "[…output saved to <path>]" marker to the captured stdout carried
+ * on a ShellError. Pads with a blank line so the marker reads as a distinct
+ * paragraph regardless of whether `stdout` ended with a newline.
+ *
+ * When the rolled output exceeded MAX_PERSISTED_SHELL_OUTPUT_SIZE the saved
+ * file is capped, so the marker says so rather than claiming the full failure
+ * body is on disk — otherwise the model trusts a truncated file and may miss a
+ * compiler/test error that appears past the cap.
  */
-function appendPersistedOutputHint(
+export function appendPersistedOutputHint(
   stdout: string,
   persistedPath: string,
   persistedSize: number,
+  truncated: boolean,
 ): string {
-  const hint = `[output truncated above — full output (${persistedSize} bytes) saved to ${persistedPath}; read with the Read tool]`;
+  const hint = truncated
+    ? `[output truncated above — first ${MAX_PERSISTED_SHELL_OUTPUT_SIZE} bytes of the ${persistedSize}-byte output saved to ${persistedPath} (capped, tail not saved); read with the Read tool]`
+    : `[output truncated above — full output (${persistedSize} bytes) saved to ${persistedPath}; read with the Read tool]`;
   if (!stdout) return hint;
   const trimmed = stdout.endsWith('\n') ? stdout.slice(0, -1) : stdout;
   return `${trimmed}\n\n${hint}`;
@@ -830,6 +843,7 @@ export const BashTool = buildTool({
               errorStdout,
               persistedForError.path,
               persistedForError.size,
+              persistedForError.truncated,
             )
           }
         }

--- a/src/tools/BashTool/BashTool.tsx
+++ b/src/tools/BashTool/BashTool.tsx
@@ -1,6 +1,8 @@
 import { feature } from 'bun:bundle';
 import type { ToolResultBlockParam } from '@anthropic-ai/sdk/resources/index.mjs';
-import { copyFile, stat as fsStat, truncate as fsTruncate, link } from 'fs/promises';
+import { copyFile, stat as fsStat, link, unlink } from 'fs/promises';
+import { createReadStream, createWriteStream } from 'fs';
+import { pipeline } from 'stream/promises';
 import * as React from 'react';
 import type { CanUseToolFn } from 'src/hooks/useCanUseTool.js';
 import type { AppState } from 'src/state/AppState.js';
@@ -343,13 +345,25 @@ export async function persistShellOutputFile(
     const dest = getToolResultPath(taskId, false);
     const truncated = size > maxSize;
     if (truncated) {
-      // Cap the destination copy, never the shell's rolled-output source: the
-      // error fallback and resizeShellImageOutput still read `sourcePath`, so
+      // Cap the destination, never the shell's rolled-output source: the error
+      // fallback and resizeShellImageOutput still read `sourcePath`, so
       // truncating it would drop the tail this persistence is meant to recover.
-      // A hardlink shares the inode, so the oversized path must copy first and
-      // truncate the copy.
-      await copyFile(sourcePath, dest);
-      await fsTruncate(dest, maxSize);
+      // Write only the first `maxSize` bytes into `dest` via a bounded read
+      // range — copying the whole (potentially multi-GB) source and truncating
+      // afterward would balloon session storage and, if the truncate failed,
+      // leave a full-size copy behind. `end` is inclusive, so [0, maxSize-1]
+      // yields exactly maxSize bytes.
+      try {
+        await pipeline(
+          createReadStream(sourcePath, { start: 0, end: maxSize - 1 }),
+          createWriteStream(dest),
+        );
+      } catch (e) {
+        // Remove any partial destination before falling through to the outer
+        // catch, so we never report a half-written capped file.
+        await unlink(dest).catch(() => {});
+        throw e;
+      }
     } else {
       try {
         await link(sourcePath, dest);

--- a/src/utils/toolResultStorage.test.ts
+++ b/src/utils/toolResultStorage.test.ts
@@ -3,8 +3,30 @@ import { expect, test } from 'bun:test'
 import { createUserMessage } from './messages.ts'
 import {
   applyToolResultReplacementsToMessages,
+  buildLargeToolResultMessage,
   filterContentReplacementsForMessages,
 } from './toolResultStorage.ts'
+
+const baseResult = {
+  filepath: '/tmp/tool-results/abc.txt',
+  originalSize: 100_000,
+  isJson: false,
+  preview: 'first chunk',
+  hasMore: true,
+}
+
+test('buildLargeToolResultMessage says "Full output" when the file is complete', () => {
+  const message = buildLargeToolResultMessage(baseResult)
+  expect(message).toContain('Full output saved to: /tmp/tool-results/abc.txt')
+  expect(message).not.toContain('capped')
+})
+
+test('buildLargeToolResultMessage avoids "Full output" wording when the file was capped', () => {
+  const message = buildLargeToolResultMessage({ ...baseResult, truncated: true })
+  expect(message).not.toContain('Full output')
+  expect(message).toContain('Partial output saved to: /tmp/tool-results/abc.txt')
+  expect(message).toContain('capped')
+})
 
 test('applyToolResultReplacementsToMessages replaces matching tool results and preserves unrelated messages', () => {
   const unrelated = createUserMessage({ content: 'keep me' })

--- a/src/utils/toolResultStorage.ts
+++ b/src/utils/toolResultStorage.ts
@@ -84,6 +84,10 @@ export type PersistedToolResult = {
   isJson: boolean
   preview: string
   hasMore: boolean
+  // When true, the persisted file is capped (only the first portion of the
+  // originalSize-byte output was written). The model-facing message must not
+  // claim the full output is available.
+  truncated?: boolean
 }
 
 // Error result when persistence fails
@@ -190,7 +194,10 @@ export function buildLargeToolResultMessage(
   result: PersistedToolResult,
 ): string {
   let message = `${PERSISTED_OUTPUT_TAG}\n`
-  message += `Output too large (${formatFileSize(result.originalSize)}). Full output saved to: ${result.filepath}\n\n`
+  const savedDescription = result.truncated
+    ? `Partial output saved to: ${result.filepath} (output was capped — the tail was not saved)`
+    : `Full output saved to: ${result.filepath}`
+  message += `Output too large (${formatFileSize(result.originalSize)}). ${savedDescription}\n\n`
   message += `Preview (first ${formatFileSize(PREVIEW_SIZE_BYTES)}):\n`
   message += result.preview
   message += result.hasMore ? '\n...\n' : '\n'


### PR DESCRIPTION
## Summary

When a Bash command produces more than `getMaxOutputLength()` bytes the shell rolls captured output to a file and leaves only the first chunk on `result.stdout`. The success path persists that file into the tool-results dir so the model can read it back via FileRead; the non-zero-exit path threw `ShellError` before reaching that block, so the captured-but-rolled output was effectively unreachable. The model saw the exit code and the truncated chunk and had no way to recover the failure body — the user had to re-run with explicit redirection.

Issue #1359 reads as "almost every command returns only the exit code on error" because the offenders (`bun run build`, test runners, language compilers) routinely emit more than 30k bytes before they fail.

## Implementation

- Extract the persist step into a shared `persistShellOutputFile(sourcePath, taskId)` helper. Returns `{ path, size }` on success, `null` if the roll file is missing or the link/copy itself fails. Both call sites — success path and the new error path — go through it.
- New `appendPersistedOutputHint(stdout, path, size)` produces a canonical `[output truncated above — full output (<bytes> bytes) saved to <path>; read with the Read tool]` marker. Pads with a blank line so it reads as a distinct paragraph regardless of whether the captured chunk ended with a newline.
- In the existing non-zero-exit branch in `BashTool.call`, if `result.outputFilePath` is set, persist the file and append the marker to the stdout we hand to `ShellError`. The exit-code-only and small-output-no-persist paths are unchanged.

## Test plan

- [x] `src/tools/BashTool/BashTool.errorOutput.test.ts` — new regression drives ~50k bytes into a command that exits 1 and asserts the canonical marker phrasing appears in `formatError(err)` along with the exit code.
- [x] Existing #1231 regressions (small-output exit-non-zero, command-not-found, merged-stream mapping, empty-output exit) still pass — 5/5 tests in the file pass locally.

Closes #1359

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Shell command results now include a clearer “output saved” marker when large output is persisted, with messaging that indicates whether the saved content was capped (tail not saved).

* **Bug Fixes**
  * Error and success cases now consistently report the correct persisted output location and accurate “full vs capped” wording.
  
* **Tests**
  * Added regression and unit tests to verify capped vs full persisted-output messaging and that persisted file contents match truncation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->