### PR TITLE
fix(repl): show permission prompts while draft input is present

### DIFF
--- a/src/components/PromptInput/PromptInput.tsx
+++ b/src/components/PromptInput/PromptInput.tsx
@@ -177,7 +177,6 @@ type Props = {
   isSideQuestionVisible?: boolean;
   helpOpen: boolean;
   setHelpOpen: React.Dispatch<React.SetStateAction<boolean>>;
-  hasSuppressedDialogs?: boolean;
   isLocalJSXCommandActive?: boolean;
   insertTextRef?: React.MutableRefObject<{
     insert: (text: string) => void;
@@ -232,7 +231,6 @@ function PromptInput({
   isSideQuestionVisible,
   helpOpen,
   setHelpOpen,
-  hasSuppressedDialogs,
   isLocalJSXCommandActive = false,
   insertTextRef,
   voiceInterimRange
@@ -2279,9 +2277,6 @@ function PromptInput({
   const textInputElement = isVimModeEnabled() ? <VimTextInput {...baseProps} initialMode={vimMode} onModeChange={setVimMode} /> : <TextInput {...baseProps} />;
   return <Box flexDirection="column" marginTop={briefOwnsGap ? 0 : 1}>
       {!isFullscreenEnvEnabled() && <PromptInputQueuedCommands />}
-      {hasSuppressedDialogs && <Box marginTop={1} marginLeft={2}>
-          <Text dimColor>Waiting for permission…</Text>
-        </Box>}
       <PromptInputStashNotice hasStash={stashedPrompt !== undefined} />
       {swarmBanner ? <>
           <Text color={swarmBanner.bgColor}>

--- a/src/screens/REPL.tsx
+++ b/src/screens/REPL.tsx
@@ -243,6 +243,7 @@ import { useOfficialMarketplaceNotification } from 'src/hooks/useOfficialMarketp
 import { usePromptsFromClaudeInChrome } from 'src/hooks/usePromptsFromClaudeInChrome.js';
 import { getTipToShowOnSpinner, recordShownTip } from 'src/services/tips/tipScheduler.js';
 import type { Theme } from 'src/utils/theme.js';
+import { resolveCriticalInputDialog } from './replFocusedInputDialog.js';
 import { isPromptTypingSuppressionActive } from './replInputSuppression.js';
 import { shouldRunStartupChecks } from './replStartupGates.js';
 import { checkAndDisableBypassPermissionsIfNeeded, checkAndDisableAutoModeIfNeeded, useKickOffCheckAndDisableBypassPermissionsIfNeeded, useKickOffCheckAndDisableAutoModeIfNeeded } from 'src/utils/permissions/bypassPermissionsKillswitch.js';
@@ -2100,18 +2101,20 @@ export function REPL({
     // High priority dialogs (always show regardless of typing)
     if (isMessageSelectorVisible) return 'message-selector';
 
-    // Suppress interrupt dialogs while user is actively typing
-    if (promptTypingSuppressionActive) return undefined;
-    if (sandboxPermissionRequestQueue[0]) return 'sandbox-permission';
-
-    // Permission/interactive dialogs (show unless blocked by toolJSX)
     const allowDialogsWithAnimation = !toolJSX || toolJSX.shouldContinueAnimation;
-    if (allowDialogsWithAnimation && toolUseConfirmQueue[0]) return 'tool-permission';
-    if (allowDialogsWithAnimation && promptQueue[0]) return 'prompt';
-    // Worker sandbox permission prompts (network access) from swarm workers
-    if (allowDialogsWithAnimation && workerSandboxPermissions.queue[0]) return 'worker-sandbox-permission';
-    if (allowDialogsWithAnimation && elicitation.queue[0]) return 'elicitation';
-    if (allowDialogsWithAnimation && showingCostDialog) return 'cost';
+    const criticalDialog = resolveCriticalInputDialog({
+      sandboxPermissionPending: !!sandboxPermissionRequestQueue[0],
+      toolUseConfirmPending: !!toolUseConfirmQueue[0],
+      promptPending: !!promptQueue[0],
+      workerSandboxPermissionPending: !!workerSandboxPermissions.queue[0],
+      elicitationPending: !!elicitation.queue[0],
+      showingCostDialog,
+      allowDialogsWithAnimation,
+    });
+    if (criticalDialog) return criticalDialog;
+
+    // Suppress lower-priority interrupt dialogs while user is actively typing
+    if (promptTypingSuppressionActive) return undefined;
     if (allowDialogsWithAnimation && idleReturnPending) return 'idle-return';
     if (feature('ULTRAPLAN') && allowDialogsWithAnimation && !isLoading && ultraplanPendingChoice) return 'ultraplan-choice';
     if (feature('ULTRAPLAN') && allowDialogsWithAnimation && !isLoading && ultraplanLaunchPending) return 'ultraplan-launch';
@@ -2143,9 +2146,6 @@ export function REPL({
     return undefined;
   }
   const focusedInputDialog = getFocusedInputDialog();
-
-  // True when permission prompts exist but are hidden because the user is typing
-  const hasSuppressedDialogs = promptTypingSuppressionActive && (sandboxPermissionRequestQueue[0] || toolUseConfirmQueue[0] || promptQueue[0] || workerSandboxPermissions.queue[0] || elicitation.queue[0] || showingCostDialog);
 
   // Keep ref in sync so timer callbacks can read the current value
   focusedInputDialogRef.current = focusedInputDialog;
@@ -5025,7 +5025,7 @@ export function REPL({
             {"external" === 'ant' && skillImprovementSurvey.suggestion && <SkillImprovementSurvey isOpen={skillImprovementSurvey.isOpen} skillName={skillImprovementSurvey.suggestion.skillName} updates={skillImprovementSurvey.suggestion.updates} handleSelect={skillImprovementSurvey.handleSelect} inputValue={inputValue} setInputValue={setInputValue} />}
             {showIssueFlagBanner && <IssueFlagBanner />}
             { }
-            <PromptInput debug={debug} ideSelection={ideSelection} hasSuppressedDialogs={!!hasSuppressedDialogs} isLocalJSXCommandActive={isShowingLocalJSXCommand} getToolUseContext={getToolUseContext} toolPermissionContext={toolPermissionContext} setToolPermissionContext={setToolPermissionContext} apiKeyStatus={apiKeyStatus} commands={renderCommands} agents={agentDefinitions.activeAgents} isLoading={isLoading} onExit={handleExit} verbose={verbose} messages={messages} onAutoUpdaterResult={setAutoUpdaterResult} autoUpdaterResult={autoUpdaterResult} input={inputValue} onInputChange={setInputValue} mode={inputMode} onModeChange={setInputMode} stashedPrompt={stashedPrompt} setStashedPrompt={setStashedPrompt} submitCount={submitCount} onShowMessageSelector={handleShowMessageSelector} onMessageActionsEnter={
+            <PromptInput debug={debug} ideSelection={ideSelection} isLocalJSXCommandActive={isShowingLocalJSXCommand} getToolUseContext={getToolUseContext} toolPermissionContext={toolPermissionContext} setToolPermissionContext={setToolPermissionContext} apiKeyStatus={apiKeyStatus} commands={renderCommands} agents={agentDefinitions.activeAgents} isLoading={isLoading} onExit={handleExit} verbose={verbose} messages={messages} onAutoUpdaterResult={setAutoUpdaterResult} autoUpdaterResult={autoUpdaterResult} input={inputValue} onInputChange={setInputValue} mode={inputMode} onModeChange={setInputMode} stashedPrompt={stashedPrompt} setStashedPrompt={setStashedPrompt} submitCount={submitCount} onShowMessageSelector={handleShowMessageSelector} onMessageActionsEnter={
               // Works during isLoading — edit cancels first; uuid selection survives appends.
               feature('MESSAGE_ACTIONS') && isFullscreenEnvEnabled() && !disableMessageActions ? enterMessageActions : undefined} mcpClients={mcpClients} pastedContents={pastedContents} setPastedContents={setPastedContents} vimMode={vimMode} setVimMode={setVimMode} showBashesDialog={showBashesDialog} setShowBashesDialog={setShowBashesDialog} onSubmit={onSubmit} onAgentSubmit={onAgentSubmit} isSearchingHistory={isSearchingHistory} setIsSearchingHistory={setIsSearchingHistory} helpOpen={isHelpOpen} setHelpOpen={setIsHelpOpen} insertTextRef={feature('VOICE_MODE') ? insertTextRef : undefined} voiceInterimRange={voice.interimRange} />
             <SessionBackgroundHint onBackgroundSession={handleBackgroundSession} isLoading={isLoading} />

--- a/src/screens/replFocusedInputDialog.test.ts
+++ b/src/screens/replFocusedInputDialog.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'bun:test';
+
+import { resolveCriticalInputDialog } from './replFocusedInputDialog.js';
+
+const idle = {
+  sandboxPermissionPending: false,
+  toolUseConfirmPending: false,
+  promptPending: false,
+  workerSandboxPermissionPending: false,
+  elicitationPending: false,
+  showingCostDialog: false,
+  allowDialogsWithAnimation: true,
+};
+
+describe('resolveCriticalInputDialog', () => {
+  it('returns tool-permission even when typing suppression would block lower dialogs', () => {
+    expect(
+      resolveCriticalInputDialog({
+        ...idle,
+        toolUseConfirmPending: true,
+      }),
+    ).toBe('tool-permission');
+  });
+
+  it('returns hook prompt when pending', () => {
+    expect(
+      resolveCriticalInputDialog({
+        ...idle,
+        promptPending: true,
+      }),
+    ).toBe('prompt');
+  });
+
+  it('respects allowDialogsWithAnimation for non-sandbox dialogs', () => {
+    expect(
+      resolveCriticalInputDialog({
+        ...idle,
+        toolUseConfirmPending: true,
+        allowDialogsWithAnimation: false,
+      }),
+    ).toBeUndefined();
+  });
+
+  it('always returns sandbox-permission regardless of animation gate', () => {
+    expect(
+      resolveCriticalInputDialog({
+        ...idle,
+        sandboxPermissionPending: true,
+        allowDialogsWithAnimation: false,
+      }),
+    ).toBe('sandbox-permission');
+  });
+
+  it('prioritizes sandbox permission over tool permission', () => {
+    expect(
+      resolveCriticalInputDialog({
+        ...idle,
+        sandboxPermissionPending: true,
+        toolUseConfirmPending: true,
+      }),
+    ).toBe('sandbox-permission');
+  });
+});

--- a/src/screens/replFocusedInputDialog.ts
+++ b/src/screens/replFocusedInputDialog.ts
@@ -1,0 +1,38 @@
+export type CriticalInputDialog =
+  | 'sandbox-permission'
+  | 'tool-permission'
+  | 'prompt'
+  | 'worker-sandbox-permission'
+  | 'elicitation'
+  | 'cost';
+
+/**
+ * Permission and hook prompts must take focus immediately. Suppressing them
+ * while the user has draft input only shows "Waiting for permission…" without
+ * the actual question until input is cleared (issue #651).
+ */
+export function resolveCriticalInputDialog(options: {
+  sandboxPermissionPending: boolean;
+  toolUseConfirmPending: boolean;
+  promptPending: boolean;
+  workerSandboxPermissionPending: boolean;
+  elicitationPending: boolean;
+  showingCostDialog: boolean;
+  allowDialogsWithAnimation: boolean;
+}): CriticalInputDialog | undefined {
+  if (options.sandboxPermissionPending) return 'sandbox-permission';
+  if (options.allowDialogsWithAnimation && options.toolUseConfirmPending) {
+    return 'tool-permission';
+  }
+  if (options.allowDialogsWithAnimation && options.promptPending) return 'prompt';
+  if (options.allowDialogsWithAnimation && options.workerSandboxPermissionPending) {
+    return 'worker-sandbox-permission';
+  }
+  if (options.allowDialogsWithAnimation && options.elicitationPending) {
+    return 'elicitation';
+  }
+  if (options.allowDialogsWithAnimation && options.showingCostDialog) {
+    return 'cost';
+  }
+  return undefined;
+}


### PR DESCRIPTION
## Summary

- Resolve permission, hook, elicitation, and cost dialogs before prompt typing suppression so they take focus immediately
- Remove the redundant "Waiting for permission…" placeholder in `PromptInput` that appeared while the real dialog was hidden
- Add `resolveCriticalInputDialog` helper with regression tests

Fixes #651

## Impact

- user-facing impact: Permission and interactive prompts are visible as soon as they are requested, even when the user has draft text in the input or was recently typing. Pressing Return is no longer required to reveal the question.
- developer/maintainer impact: Critical dialog priority is extracted to `replFocusedInputDialog.ts` for testability. Lower-priority startup/recommendation dialogs remain suppressed during typing (issue #363 behavior preserved).

## Testing

- [x] `bun run build`
- [x] `bun run smoke`
- [x] focused tests: `bun test src/screens/replFocusedInputDialog.test.ts src/screens/replInputSuppression.test.ts src/screens/replStartupGates.test.ts`

## Notes

- provider/model path tested: n/a (REPL UI focus logic only)
- Root cause: `getFocusedInputDialog()` returned `undefined` while `promptTypingSuppressionActive` was true (draft input or recent typing), so `PromptInput` stayed mounted with a placeholder instead of rendering the permission UI. Pressing Return cleared/submitted draft input and ended suppression.
- follow-up work or known limitations: Manual terminal verification across varied terminals would still be useful; the fix targets the confirmed focus/suppression logic rather than a low-level Ink refresh bug.
