### PR TITLE
fix(bash): show output for ! shell commands (#1265)

### DIFF
--- a/src/components/messages/UserBashOutputMessage.tsx
+++ b/src/components/messages/UserBashOutputMessage.tsx
@@ -2,6 +2,7 @@ import { c as _c } from "react-compiler-runtime";
 import * as React from 'react';
 import BashToolResultMessage from '../../tools/BashTool/BashToolResultMessage.js';
 import { extractTag } from '../../utils/messages.js';
+import { unescapeXml } from '../../utils/xml.js';
 export function UserBashOutputMessage(t0) {
   const $ = _c(10);
   const {
@@ -11,7 +12,7 @@ export function UserBashOutputMessage(t0) {
   let t1;
   if ($[0] !== content) {
     const rawStdout = extractTag(content, "bash-stdout") ?? "";
-    t1 = extractTag(rawStdout, "persisted-output") ?? rawStdout;
+    t1 = extractTag(rawStdout, "persisted-output") ?? unescapeXml(rawStdout);
     $[0] = content;
     $[1] = t1;
   } else {
@@ -20,7 +21,7 @@ export function UserBashOutputMessage(t0) {
   const stdout = t1;
   let t2;
   if ($[2] !== content) {
-    t2 = extractTag(content, "bash-stderr") ?? "";
+    t2 = unescapeXml(extractTag(content, "bash-stderr") ?? "");
     $[2] = content;
     $[3] = t2;
   } else {

--- a/src/utils/exportRenderer.tsx
+++ b/src/utils/exportRenderer.tsx
@@ -25,6 +25,7 @@ import {
 } from '../constants/xml.js';
 import type { ExportFormat } from './exportFormats.js';
 import { renderToAnsiString } from './staticRender.js';
+import { unescapeXml } from './xml.js';
 
 /**
  * Minimal keybinding provider for static/headless renders.
@@ -645,7 +646,7 @@ function parseWrappedOutputPrefix(text: string): { output: TerminalOutput; rest:
       output: {
         source,
         stream,
-        text: text.slice(openTagEnd + 1, closeIndex),
+        text: unescapeXml(text.slice(openTagEnd + 1, closeIndex)),
       },
       rest: text.slice(closeIndex + closeTag.length),
     }

--- a/src/utils/exportRenderer.tsx
+++ b/src/utils/exportRenderer.tsx
@@ -642,11 +642,16 @@ function parseWrappedOutputPrefix(text: string): { output: TerminalOutput; rest:
     if (openTagEnd === -1) return null
     const closeIndex = text.indexOf(closeTag, openTagEnd + 1)
     if (closeIndex === -1) return null
+    const rawText = text.slice(openTagEnd + 1, closeIndex)
+    const decodedText =
+      tag === BASH_STDOUT_TAG || tag === BASH_STDERR_TAG
+        ? unescapeXml(rawText)
+        : rawText
     return {
       output: {
         source,
         stream,
-        text: unescapeXml(text.slice(openTagEnd + 1, closeIndex)),
+        text: decodedText,
       },
       rest: text.slice(closeIndex + closeTag.length),
     }

--- a/src/utils/processUserInput/processBashCommand.test.tsx
+++ b/src/utils/processUserInput/processBashCommand.test.tsx
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, expect, test } from 'bun:test'
+import { afterEach, beforeEach, expect, mock, test } from 'bun:test'
 import { getEmptyToolPermissionContext } from '../../Tool.js'
 import { BashTool } from '../../tools/BashTool/BashTool.js'
 import {
@@ -6,6 +6,18 @@ import {
   releaseSharedMutationLock,
 } from '../../test/sharedMutationLock.js'
 import { getContentText } from '../messages.js'
+
+// Force bash routing regardless of platform/env — processBashCommand
+// consults isPowerShellToolEnabled() and resolveDefaultShell() at the
+// top, and may route to PowerShellTool on Windows which defeats our
+// BashTool.call stub.  mock.module is process-global in bun, so this
+// must run BEFORE the import of processBashCommand.
+mock.module('../shell/shellToolUtils.js', () => ({
+  isPowerShellToolEnabled: mock(() => false),
+}))
+mock.module('../shell/resolveDefaultShell.js', () => ({
+  resolveDefaultShell: mock((): 'bash' | 'powershell' => 'bash'),
+}))
 import { processBashCommand } from './processBashCommand.js'
 
 const originalCall = BashTool.call
@@ -14,9 +26,17 @@ beforeEach(async () => {
   await acquireSharedMutationLock('utils/processUserInput/processBashCommand.test.tsx')
 })
 
-afterEach(() => {
+afterEach(async () => {
   try {
     BashTool.call = originalCall
+    const realPowerShell = await import('../shell/shellToolUtils.js')
+    const realShell = await import('../shell/resolveDefaultShell.js')
+    mock.module('../shell/shellToolUtils.js', () => ({
+      isPowerShellToolEnabled: realPowerShell.isPowerShellToolEnabled,
+    }))
+    mock.module('../shell/resolveDefaultShell.js', () => ({
+      resolveDefaultShell: realShell.resolveDefaultShell,
+    }))
   } finally {
     releaseSharedMutationLock()
   }

--- a/src/utils/processUserInput/processBashCommand.test.tsx
+++ b/src/utils/processUserInput/processBashCommand.test.tsx
@@ -1,0 +1,97 @@
+import { afterEach, beforeEach, expect, test } from 'bun:test'
+import { getEmptyToolPermissionContext } from '../../Tool.js'
+import { BashTool } from '../../tools/BashTool/BashTool.js'
+import {
+  acquireSharedMutationLock,
+  releaseSharedMutationLock,
+} from '../../test/sharedMutationLock.js'
+import { getContentText } from '../messages.js'
+import { processBashCommand } from './processBashCommand.js'
+
+const originalCall = BashTool.call
+
+beforeEach(async () => {
+  await acquireSharedMutationLock('utils/processUserInput/processBashCommand.test.tsx')
+})
+
+afterEach(() => {
+  try {
+    BashTool.call = originalCall
+  } finally {
+    releaseSharedMutationLock()
+  }
+})
+
+function makeContext() {
+  return {
+    abortController: new AbortController(),
+    options: {
+      verbose: false,
+      isNonInteractiveSession: false,
+    },
+    getAppState() {
+      return {
+        toolPermissionContext: getEmptyToolPermissionContext(),
+      }
+    },
+  } as never
+}
+
+test('processBashCommand returns successful shell output as visible bash stdout', async () => {
+  BashTool.call = (async () => ({
+    data: {
+      stdout: 'visible-1265\n',
+      stderr: '',
+      interrupted: false,
+    },
+  })) as unknown as typeof BashTool.call
+
+  const result = await processBashCommand(
+    'printf visible-1265',
+    [],
+    [],
+    makeContext(),
+    () => {},
+  )
+
+  expect(result.shouldQuery).toBe(false)
+
+  const visibleText = result.messages
+    .filter(message => message.type === 'user' && !message.isMeta)
+    .map(message => getContentText(message.message.content))
+    .join('\n')
+
+  expect(visibleText).toContain('<bash-input>printf visible-1265</bash-input>')
+  expect(visibleText).toContain('<bash-stdout>visible-1265')
+})
+
+test('processBashCommand preserves background task metadata', async () => {
+  BashTool.call = (async () => ({
+    data: {
+      stdout: '',
+      stderr: '',
+      interrupted: false,
+      backgroundTaskId: 'bg-review-1',
+      backgroundedByUser: true,
+    },
+  })) as unknown as typeof BashTool.call
+
+  const result = await processBashCommand(
+    'sleep 60',
+    [],
+    [],
+    makeContext(),
+    () => {},
+  )
+
+  expect(result.shouldQuery).toBe(false)
+
+  const visibleText = result.messages
+    .filter(message => message.type === 'user' && !message.isMeta)
+    .map(message => getContentText(message.message.content))
+    .join('\n')
+
+  expect(visibleText).toContain('Command was manually backgrounded by user')
+  expect(visibleText).toContain('bg-review-1')
+  expect(visibleText).toContain('Output is being written to:')
+})

--- a/src/utils/processUserInput/processBashCommand.tsx
+++ b/src/utils/processUserInput/processBashCommand.tsx
@@ -94,19 +94,18 @@ export async function processBashCommand(inputString: string, precedingInputBloc
       throw new Error('No result received from shell command');
     }
     const stderr = data.stderr;
-    // Reuse the same formatting pipeline as inline !`cmd` bash (promptShellExecution)
-    // and model-initiated Bash. When BashTool.call() persists large output to disk,
-    // data.persistedOutputPath is set and the formatter wraps in <persisted-output>.
-    // Pass stderr:'' to keep it separate for the <bash-stderr> UI tag.
-    const mapped = await processToolResultBlock(shellTool, {
-      ...data,
-      stderr: ''
-    }, randomUUID());
-    // mapped.content may contain our own <persisted-output> wrapper (trusted
-    // XML from buildLargeToolResultMessage). Escaping it would turn structural
-    // tags into &lt;persisted-output&gt;, breaking the model's parse and
-    // UserBashOutputMessage's extractTag. Escape the raw fallback only.
-    const stdout = typeof mapped.content === 'string' ? mapped.content : escapeXml(data.stdout);
+    let stdout = escapeXml(data.stdout);
+    if (data.persistedOutputPath || data.backgroundTaskId) {
+      // Reuse the model-facing formatter when it adds metadata the user needs,
+      // such as persisted-output markers or background task IDs.
+      const mapped = await processToolResultBlock(shellTool, {
+        ...data,
+        stderr: ''
+      }, randomUUID());
+      if (typeof mapped.content === 'string') {
+        stdout = data.persistedOutputPath ? mapped.content : escapeXml(mapped.content);
+      }
+    }
     return {
       messages: [createSyntheticUserCaveatMessage(), userMessage, ...attachmentMessages, createUserMessage({
         content: `<bash-stdout>${stdout}</bash-stdout><bash-stderr>${escapeXml(stderr)}</bash-stderr>`

--- a/src/utils/processUserInput/processBashCommand.tsx
+++ b/src/utils/processUserInput/processBashCommand.tsx
@@ -103,7 +103,7 @@ export async function processBashCommand(inputString: string, precedingInputBloc
         stderr: ''
       }, randomUUID());
       if (typeof mapped.content === 'string') {
-        stdout = data.persistedOutputPath ? mapped.content : escapeXml(mapped.content);
+        stdout = mapped.content;
       }
     }
     return {

--- a/src/utils/processUserInput/processBashCommand.tsx
+++ b/src/utils/processUserInput/processBashCommand.tsx
@@ -102,6 +102,9 @@ export async function processBashCommand(inputString: string, precedingInputBloc
         ...data,
         stderr: ''
       }, randomUUID());
+      // Formatter output is trusted: persisted-output markers contain
+      // structural XML, background-task output is plain text with no
+      // user-supplied content that needs escaping.
       if (typeof mapped.content === 'string') {
         stdout = mapped.content;
       }

--- a/src/utils/xml.ts
+++ b/src/utils/xml.ts
@@ -21,3 +21,12 @@ export function escapeXml(s: string | null | undefined): string {
 export function escapeXmlAttr(s: string | null | undefined): string {
   return escapeXml(s).replace(/"/g, '&quot;').replace(/'/g, '&apos;')
 }
+
+/**
+ * Decode XML/HTML entities produced by `escapeXml` back to literal characters.
+ * Handles &amp; &lt; &gt;. Must decode &amp; first to avoid double-decoding.
+ */
+export function unescapeXml(s: string | null | undefined): string {
+  if (s == null) return ''
+  return s.replace(/&amp;/g, '&').replace(/&lt;/g, '<').replace(/&gt;/g, '>')
+}

--- a/src/utils/xml.ts
+++ b/src/utils/xml.ts
@@ -24,9 +24,11 @@ export function escapeXmlAttr(s: string | null | undefined): string {
 
 /**
  * Decode XML/HTML entities produced by `escapeXml` back to literal characters.
- * Handles &amp; &lt; &gt;. Must decode &amp; first to avoid double-decoding.
+ * Handles &amp; &lt; &gt;. Must decode &lt; and &gt; first, then &amp; last,
+ * so that literal entity text (e.g. &amp;lt;tag&amp;gt;&amp;amp;) round-trips
+ * correctly without premature double-decoding.
  */
 export function unescapeXml(s: string | null | undefined): string {
   if (s == null) return ''
-  return s.replace(/&amp;/g, '&').replace(/&lt;/g, '<').replace(/&gt;/g, '>')
+  return s.replace(/&lt;/g, '<').replace(/&gt;/g, '>').replace(/&amp;/g, '&')
 }


### PR DESCRIPTION
## Summary
- render successful ! shell command output directly from the shell tool result
- preserve the persisted-output formatter only for large persisted command output
- add a regression test for visible bash stdout from processBashCommand

## Root Cause
processBashCommand was calling processToolResultBlock for ALL commands, including normal (non-persisted) ones. The model-facing formatter could silently lose or transform stdout for simple ! commands. The fix uses escapeXml(data.stdout) directly for the normal case and only calls processToolResultBlock when output is persisted or backgrounded.

## Validation
- bun test src/utils/processUserInput/processBashCommand.test.tsx

Fixes #1265