### PR TITLE
fix(autocompact): replace permanent circuit-breaker latch with cooldown (#1373)

### DIFF
--- a/src/query.ts
+++ b/src/query.ts
@@ -507,7 +507,7 @@ async function* queryLoop(
     )
 
     queryCheckpoint('query_autocompact_start')
-    const { compactionResult, consecutiveFailures } = await deps.autocompact(
+    const { compactionResult, consecutiveFailures, lastFailureAt } = await deps.autocompact(
       messagesForQuery,
       toolUseContext,
       {
@@ -590,11 +590,14 @@ async function* queryLoop(
       // Continue on with the current query call using the post compact messages
       messagesForQuery = postCompactMessages
     } else if (consecutiveFailures !== undefined) {
-      // Autocompact failed — propagate failure count so the circuit breaker
-      // can stop retrying on the next iteration.
+      // Autocompact failed — propagate failure count + timestamp so the
+      // circuit breaker can stop retrying on the next iteration and then
+      // re-arm after the cooldown elapses (see CIRCUIT_BREAKER_COOLDOWN_MS
+      // in autoCompact.ts; #1373).
       tracking = {
         ...(tracking ?? { compacted: false, turnId: '', turnCounter: 0 }),
         consecutiveFailures,
+        lastFailureAt,
       }
     }
 

--- a/src/services/compact/autoCompact.test.ts
+++ b/src/services/compact/autoCompact.test.ts
@@ -135,6 +135,109 @@ describe('getEffectiveContextWindowSize', () => {
   })
 })
 
+describe('isAutoCompactBreakerHolding (circuit-breaker cooldown — #1373)', () => {
+  test('lets attempts through when no failures recorded', async () => {
+    const { isAutoCompactBreakerHolding } = await importAutoCompact()
+    expect(isAutoCompactBreakerHolding(undefined, Date.now())).toBe(false)
+    expect(isAutoCompactBreakerHolding({}, Date.now())).toBe(false)
+  })
+
+  test('lets attempts through below the failure threshold', async () => {
+    const { isAutoCompactBreakerHolding } = await importAutoCompact()
+    expect(
+      isAutoCompactBreakerHolding(
+        { consecutiveFailures: 1, lastFailureAt: Date.now() },
+        Date.now(),
+      ),
+    ).toBe(false)
+    expect(
+      isAutoCompactBreakerHolding(
+        { consecutiveFailures: 2, lastFailureAt: Date.now() },
+        Date.now(),
+      ),
+    ).toBe(false)
+  })
+
+  test('holds calls when at-or-above threshold AND cooldown not yet elapsed', async () => {
+    const { isAutoCompactBreakerHolding, CIRCUIT_BREAKER_COOLDOWN_MS } =
+      await importAutoCompact()
+    const now = 1_000_000_000
+    expect(
+      isAutoCompactBreakerHolding(
+        { consecutiveFailures: 3, lastFailureAt: now },
+        now,
+      ),
+    ).toBe(true)
+    // 1 minute later, still inside the 5-minute cooldown
+    expect(
+      isAutoCompactBreakerHolding(
+        { consecutiveFailures: 3, lastFailureAt: now },
+        now + 60_000,
+      ),
+    ).toBe(true)
+    // Right at the boundary — still holding (< not <=)
+    expect(
+      isAutoCompactBreakerHolding(
+        { consecutiveFailures: 3, lastFailureAt: now },
+        now + CIRCUIT_BREAKER_COOLDOWN_MS - 1,
+      ),
+    ).toBe(true)
+  })
+
+  test('releases after the cooldown elapses — fixes permanent-latch #1373', async () => {
+    const { isAutoCompactBreakerHolding, CIRCUIT_BREAKER_COOLDOWN_MS } =
+      await importAutoCompact()
+    const now = 1_000_000_000
+    expect(
+      isAutoCompactBreakerHolding(
+        { consecutiveFailures: 3, lastFailureAt: now },
+        now + CIRCUIT_BREAKER_COOLDOWN_MS,
+      ),
+    ).toBe(false)
+    // Hours later — definitely released. This is the case from #1373 where
+    // the previous implementation latched permanently for the rest of the
+    // session and let state.messages grow unbounded.
+    expect(
+      isAutoCompactBreakerHolding(
+        { consecutiveFailures: 3, lastFailureAt: now },
+        now + 3 * 60 * 60_000,
+      ),
+    ).toBe(false)
+  })
+
+  test('higher failure counts (5, 10, 50) follow the same cooldown rule', async () => {
+    const { isAutoCompactBreakerHolding, CIRCUIT_BREAKER_COOLDOWN_MS } =
+      await importAutoCompact()
+    const now = 1_000_000_000
+    for (const count of [5, 10, 50]) {
+      // Still holding inside cooldown
+      expect(
+        isAutoCompactBreakerHolding(
+          { consecutiveFailures: count, lastFailureAt: now },
+          now + 1000,
+        ),
+      ).toBe(true)
+      // Released after cooldown
+      expect(
+        isAutoCompactBreakerHolding(
+          { consecutiveFailures: count, lastFailureAt: now },
+          now + CIRCUIT_BREAKER_COOLDOWN_MS,
+        ),
+      ).toBe(false)
+    }
+  })
+
+  test('treats missing lastFailureAt as ancient (releases immediately)', async () => {
+    const { isAutoCompactBreakerHolding } = await importAutoCompact()
+    // Tracking from an older session/version without the timestamp field
+    // should release rather than latch — failing open here is safer than
+    // permanently disabling compaction over a missing field.
+    expect(
+      isAutoCompactBreakerHolding({ consecutiveFailures: 3 }, Date.now()),
+    ).toBe(false)
+  })
+})
+
 describe('getAutoCompactThreshold', () => {
   test('returns positive threshold for known models', async () => {
     const { getAutoCompactThreshold } = await importAutoCompact()

--- a/src/services/compact/autoCompact.ts
+++ b/src/services/compact/autoCompact.ts
@@ -64,6 +64,13 @@ export type AutoCompactTrackingState = {
   // Used as a circuit breaker to stop retrying when the context is
   // irrecoverably over the limit (e.g., prompt_too_long).
   consecutiveFailures?: number
+  // Timestamp (ms since epoch) of the most recent autocompact failure.
+  // Used by the circuit breaker to time the cooldown — after
+  // CIRCUIT_BREAKER_COOLDOWN_MS the failure counter resets and one more
+  // attempt is allowed, so transient summarization errors (e.g. provider
+  // 5xx during the spike that tripped the breaker) don't permanently
+  // disable compaction for the rest of the session (#1373).
+  lastFailureAt?: number
 }
 
 export const AUTOCOMPACT_BUFFER_TOKENS = 13_000
@@ -75,6 +82,39 @@ export const MANUAL_COMPACT_BUFFER_TOKENS = 3_000
 // BQ 2026-03-10: 1,279 sessions had 50+ consecutive failures (up to 3,272)
 // in a single session, wasting ~250K API calls/day globally.
 const MAX_CONSECUTIVE_AUTOCOMPACT_FAILURES = 3
+
+// How long the circuit breaker stays open after MAX_CONSECUTIVE failures
+// before allowing a retry. Fixes #1373: previously the breaker latched
+// for the whole session and `state.messages` grew unbounded for the
+// ~3 hours it took to OOM, even when the original failure was a transient
+// provider 5xx during the spike that tripped the breaker. Five minutes is
+// long enough to drain the failure burst, short enough that a normal-mode
+// session recovers compaction without the user noticing.
+export const CIRCUIT_BREAKER_COOLDOWN_MS = 5 * 60_000
+
+/**
+ * Decide whether the autocompact circuit breaker should hold this call.
+ *
+ * Returns true when the breaker has tripped (consecutive failures >= max)
+ * AND the cooldown has not yet elapsed. Caller should short-circuit and
+ * return `wasCompacted: false` without hitting the compaction API.
+ *
+ * Pure so the cooldown contract can be regression-tested without mocking
+ * the whole compaction stack — see autoCompact.test.ts (#1373).
+ */
+export function isAutoCompactBreakerHolding(
+  tracking: { consecutiveFailures?: number; lastFailureAt?: number } | undefined,
+  now: number,
+): boolean {
+  if (
+    tracking?.consecutiveFailures === undefined ||
+    tracking.consecutiveFailures < MAX_CONSECUTIVE_AUTOCOMPACT_FAILURES
+  ) {
+    return false
+  }
+  const lastFailureAt = tracking.lastFailureAt ?? 0
+  return now - lastFailureAt < CIRCUIT_BREAKER_COOLDOWN_MS
+}
 
 export function getAutoCompactThreshold(model: string): number {
   const effectiveContextWindow = getEffectiveContextWindowSize(model)
@@ -261,6 +301,7 @@ export async function autoCompactIfNeeded(
   wasCompacted: boolean
   compactionResult?: CompactionResult
   consecutiveFailures?: number
+  lastFailureAt?: number
 }> {
   if (isEnvTruthy(process.env.DISABLE_COMPACT)) {
     return { wasCompacted: false }
@@ -269,11 +310,25 @@ export async function autoCompactIfNeeded(
   // Circuit breaker: stop retrying after N consecutive failures.
   // Without this, sessions where context is irrecoverably over the limit
   // hammer the API with doomed compaction attempts on every turn.
+  //
+  // Once the cooldown elapses we let one attempt through (fall through to
+  // the compaction call below without resetting the counter). On success
+  // the counter is reset to 0; on failure it stays at MAX, lastFailureAt
+  // is bumped, and the breaker latches again for another CIRCUIT_BREAKER_COOLDOWN_MS.
+  // This keeps the original anti-API-spam guarantee while preventing the
+  // permanent latch from #1373.
+  const now = Date.now()
+  if (isAutoCompactBreakerHolding(tracking, now)) {
+    return { wasCompacted: false }
+  }
   if (
     tracking?.consecutiveFailures !== undefined &&
     tracking.consecutiveFailures >= MAX_CONSECUTIVE_AUTOCOMPACT_FAILURES
   ) {
-    return { wasCompacted: false }
+    const elapsed = now - (tracking.lastFailureAt ?? 0)
+    logForDebugging(
+      `autocompact: circuit breaker cooldown (${Math.round(elapsed / 1000)}s) elapsed — re-attempting`,
+    )
   }
 
   const model = toolUseContext.options.mainLoopModel
@@ -382,15 +437,23 @@ export async function autoCompactIfNeeded(
     }
     // Increment consecutive failure count for circuit breaker.
     // The caller threads this through autoCompactTracking so the
-    // next query loop iteration can skip futile retry attempts.
+    // next query loop iteration can skip futile retry attempts —
+    // until CIRCUIT_BREAKER_COOLDOWN_MS elapses and the guard above
+    // lets one through, at which point a success here resets the
+    // counter to 0 and a failure latches the breaker for another
+    // cooldown window (rather than the rest of the session, see #1373).
     const prevFailures = tracking?.consecutiveFailures ?? 0
     const nextFailures = prevFailures + 1
     if (nextFailures >= MAX_CONSECUTIVE_AUTOCOMPACT_FAILURES) {
       logForDebugging(
-        `autocompact: circuit breaker tripped after ${nextFailures} consecutive failures — skipping future attempts this session`,
+        `autocompact: circuit breaker tripped after ${nextFailures} consecutive failures — pausing for ${Math.round(CIRCUIT_BREAKER_COOLDOWN_MS / 60000)} min before retry`,
         { level: 'warn' },
       )
     }
-    return { wasCompacted: false, consecutiveFailures: nextFailures }
+    return {
+      wasCompacted: false,
+      consecutiveFailures: nextFailures,
+      lastFailureAt: Date.now(),
+    }
   }
 }


### PR DESCRIPTION
## Summary

Closes #1373.

The autocompact circuit breaker tripped after 3 consecutive failures and stayed open for the rest of the session. When the failures were transient (provider 5xx during the spike that hit the breaker), compaction never re-attempted and `state.messages` grew unbounded — ~3 hours later Node.js crashed with \`FATAL ERROR: Ineffective mark-compacts near heap limit\` at ~2GB.

Replace the permanent latch with a 5-minute cooldown.

## Behavior

1. Counter still increments on each failure and the breaker still holds the next attempt while `consecutiveFailures >= 3` AND the cooldown has not elapsed — preserves the BQ 2026-03-10 anti-API-spam guarantee that landed `MAX_CONSECUTIVE_AUTOCOMPACT_FAILURES`.
2. Once `CIRCUIT_BREAKER_COOLDOWN_MS` (5 min) elapses since the last failure, the guard releases and one attempt falls through. On success the counter resets to 0; on failure the breaker latches again for another cooldown window. Worst case ≈ one compaction attempt every 5 minutes, well under the original 3,272-failure pathological case, and recoverable from transient outages.
3. `autoCompactTracking` in `query.ts` now carries `lastFailureAt` alongside `consecutiveFailures` so the breaker state survives across turns.

## Implementation

- Extracted breaker check into `isAutoCompactBreakerHolding(tracking, now)` — pure / time-injectable so the cooldown contract is unit-testable without mocking the whole compaction stack.
- Added `lastFailureAt` to `AutoCompactTrackingState`.
- `autoCompactWithThreshold` returns `lastFailureAt` alongside `consecutiveFailures`; `query.ts` threads both into tracking.
- Missing `lastFailureAt` (older tracking shape from in-flight v0.14.x sessions) is treated as ancient — fail open rather than permanently latch on a missing field.

## Test plan

- [x] 5 new dedicated cases in `src/services/compact/autoCompact.test.ts`: under-threshold lets through, holding-inside-cooldown, released-at-boundary, released-after-hours, higher failure counts follow same rule, missing-`lastFailureAt` fails open. 11/11 green.

## Out of scope

The absolute cap on `state.messages` length called out in the issue. That cap belongs in the message-append path (`query.ts`) not the compaction circuit breaker; reasonable as a follow-up once this cooldown stops the unbounded-growth root cause.