### PR TITLE
fix(onboarding): bound preflight probe + recover from connectivity failure (#1017)

### DIFF
--- a/src/utils/preflightChecks.test.ts
+++ b/src/utils/preflightChecks.test.ts
@@ -1,0 +1,87 @@
+import { afterEach, describe, expect, mock, test } from 'bun:test'
+
+// MACRO is normally substituted at build time. The test runs without the
+// bundler, so stub the build-time globals before importing the module under
+// test (which transitively imports utils/http.ts -> MACRO.VERSION).
+;(globalThis as unknown as { MACRO?: unknown }).MACRO ??= {
+  VERSION: '0.0.0-test',
+  DISPLAY_VERSION: '0.0.0-test',
+  BUILD_TIME: 'test',
+  ISSUES_EXPLAINER: '',
+  PACKAGE_URL: '',
+  NATIVE_PACKAGE_URL: undefined,
+}
+
+describe('checkEndpoints (preflight)', () => {
+  afterEach(() => {
+    mock.restore()
+  })
+
+  test('passes a bounded timeout to axios so a hung probe cannot freeze onboarding (#1017)', async () => {
+    const calls: Array<{ url: string; options: { timeout?: number } }> = []
+    mock.module('axios', () => ({
+      default: {
+        get: async (
+          url: string,
+          options: { timeout?: number } = {},
+        ): Promise<{ status: number }> => {
+          calls.push({ url, options })
+          return { status: 200 }
+        },
+        isAxiosError: () => false,
+      },
+    }))
+
+    const { checkEndpoints, PREFLIGHT_REQUEST_TIMEOUT_MS } = await import(
+      './preflightChecks.js'
+    )
+
+    const result = await checkEndpoints()
+
+    expect(result.success).toBe(true)
+    expect(calls.length).toBeGreaterThan(0)
+    for (const call of calls) {
+      expect(call.options.timeout).toBe(PREFLIGHT_REQUEST_TIMEOUT_MS)
+    }
+    expect(PREFLIGHT_REQUEST_TIMEOUT_MS).toBeGreaterThan(0)
+    expect(PREFLIGHT_REQUEST_TIMEOUT_MS).toBeLessThanOrEqual(15_000)
+  })
+
+  test('returns a failure result (instead of throwing or hanging) when axios rejects with ECONNABORTED', async () => {
+    mock.module('axios', () => ({
+      default: {
+        get: async (): Promise<never> => {
+          const err = new Error('timeout of 5000ms exceeded') as Error & {
+            code?: string
+          }
+          err.code = 'ECONNABORTED'
+          throw err
+        },
+        isAxiosError: () => false,
+      },
+    }))
+
+    const { checkEndpoints } = await import('./preflightChecks.js')
+
+    const result = await checkEndpoints()
+
+    expect(result.success).toBe(false)
+    expect(result.error).toBeDefined()
+    expect(result.error).toContain('Failed to connect to')
+  })
+
+  test('returns success when all probes return 200', async () => {
+    mock.module('axios', () => ({
+      default: {
+        get: async (): Promise<{ status: number }> => ({ status: 200 }),
+        isAxiosError: () => false,
+      },
+    }))
+
+    const { checkEndpoints } = await import('./preflightChecks.js')
+
+    const result = await checkEndpoints()
+    expect(result.success).toBe(true)
+    expect(result.error).toBeUndefined()
+  })
+})

--- a/src/utils/preflightChecks.test.ts
+++ b/src/utils/preflightChecks.test.ts
@@ -1,4 +1,12 @@
-import { afterEach, describe, expect, mock, test } from 'bun:test'
+import { PassThrough } from 'node:stream'
+
+import { afterEach, beforeEach, describe, expect, jest, mock, test } from 'bun:test'
+import React from 'react'
+
+import {
+  acquireSharedMutationLock,
+  releaseSharedMutationLock,
+} from '../test/sharedMutationLock.js'
 
 // MACRO is normally substituted at build time. The test runs without the
 // bundler, so stub the build-time globals before importing the module under
@@ -12,11 +20,95 @@ import { afterEach, describe, expect, mock, test } from 'bun:test'
   NATIVE_PACKAGE_URL: undefined,
 }
 
-describe('checkEndpoints (preflight)', () => {
-  afterEach(() => {
-    mock.restore()
-  })
+type TestStdin = PassThrough & {
+  isTTY: boolean
+  setRawMode: (mode: boolean) => void
+  ref: () => void
+  unref: () => void
+}
 
+const originalProcessExit = process.exit
+
+function createTestStreams(): {
+  stdout: PassThrough
+  stdin: TestStdin
+} {
+  const stdout = new PassThrough()
+  const stdin = new PassThrough() as TestStdin
+
+  stdin.isTTY = true
+  stdin.setRawMode = () => {}
+  stdin.ref = () => {}
+  stdin.unref = () => {}
+  ;(stdout as unknown as { columns: number }).columns = 120
+
+  return {
+    stdout,
+    stdin,
+  }
+}
+
+async function flushFakeTimerWork(iterations = 10): Promise<void> {
+  for (let i = 0; i < iterations; i++) {
+    await Promise.resolve()
+    jest.advanceTimersByTime(0)
+    await new Promise<void>(resolve => setImmediate(resolve))
+  }
+}
+
+type TimerSpy = {
+  mock: {
+    calls: readonly unknown[][]
+  }
+}
+
+function hasPreflightHoldTimer(
+  setTimeoutSpy: TimerSpy,
+  onSuccess: () => void,
+  delay: number,
+): boolean {
+  return setTimeoutSpy.mock.calls.some(
+    call => call[0] === onSuccess && call[1] === delay,
+  )
+}
+
+async function waitForPreflightFailureEffect(
+  setTimeoutSpy: TimerSpy,
+  onSuccess: () => void,
+  delay: number,
+  exitCodes: readonly unknown[],
+  getOnSuccessCallCount: () => number,
+): Promise<void> {
+  for (let i = 0; i < 30; i++) {
+    await flushFakeTimerWork(1)
+    if (
+      exitCodes.length > 0 ||
+      getOnSuccessCallCount() > 0 ||
+      hasPreflightHoldTimer(setTimeoutSpy, onSuccess, delay)
+    ) {
+      return
+    }
+  }
+
+  throw new Error('Timed out waiting for failed preflight hold timer')
+}
+
+beforeEach(async () => {
+  await acquireSharedMutationLock('utils/preflightChecks.test.ts')
+})
+
+afterEach(() => {
+  try {
+    process.exit = originalProcessExit
+    jest.restoreAllMocks()
+    jest.useRealTimers()
+    mock.restore()
+  } finally {
+    releaseSharedMutationLock()
+  }
+})
+
+describe('checkEndpoints (preflight)', () => {
   test('passes a bounded timeout to axios so a hung probe cannot freeze onboarding (#1017)', async () => {
     const calls: Array<{ url: string; options: { timeout?: number } }> = []
     mock.module('axios', () => ({
@@ -83,5 +175,76 @@ describe('checkEndpoints (preflight)', () => {
     const result = await checkEndpoints()
     expect(result.success).toBe(true)
     expect(result.error).toBeUndefined()
+  })
+
+  test('advances onboarding after a failed probe hold without exiting', async () => {
+    const exitCodes: Array<string | number | null | undefined> = []
+    let probeCalls = 0
+    process.exit = ((code?: string | number | null | undefined) => {
+      exitCodes.push(code)
+      return undefined as never
+    }) as typeof process.exit
+
+    jest.useFakeTimers()
+    const setTimeoutSpy = jest.spyOn(globalThis, 'setTimeout')
+    mock.module('../hooks/useTimeout.js', () => ({
+      useTimeout: () => false,
+    }))
+    mock.module('axios', () => ({
+      default: {
+        get: async (): Promise<never> => {
+          probeCalls++
+          const err = new Error('timeout of 5000ms exceeded') as Error & {
+            code?: string
+          }
+          err.code = 'ECONNABORTED'
+          throw err
+        },
+        isAxiosError: () => false,
+      },
+    }))
+
+    const { createRoot } = await import('../ink.js')
+    const { PreflightStep, PREFLIGHT_ERROR_HOLD_MS } = await import(
+      `./preflightChecks.js?failed-component-${Date.now()}`
+    )
+    const onSuccess = mock(() => {})
+    const { stdout, stdin } = createTestStreams()
+    const root = await createRoot({
+      stdout: stdout as unknown as NodeJS.WriteStream,
+      stdin: stdin as unknown as NodeJS.ReadStream,
+      patchConsole: false,
+    })
+
+    try {
+      root.render(React.createElement(PreflightStep, { onSuccess }))
+
+      await waitForPreflightFailureEffect(
+        setTimeoutSpy,
+        onSuccess,
+        PREFLIGHT_ERROR_HOLD_MS,
+        exitCodes,
+        () => onSuccess.mock.calls.length,
+      )
+      expect(probeCalls).toBeGreaterThan(0)
+      expect(exitCodes).toEqual([])
+      expect(onSuccess).not.toHaveBeenCalled()
+      expect(
+        hasPreflightHoldTimer(
+          setTimeoutSpy,
+          onSuccess,
+          PREFLIGHT_ERROR_HOLD_MS,
+        ),
+      ).toBe(true)
+
+      jest.advanceTimersByTime(PREFLIGHT_ERROR_HOLD_MS)
+      await Promise.resolve()
+      expect(exitCodes).toEqual([])
+      expect(onSuccess).toHaveBeenCalledTimes(1)
+    } finally {
+      root.unmount()
+      stdin.end()
+      stdout.end()
+    }
   })
 })

--- a/src/utils/preflightChecks.tsx
+++ b/src/utils/preflightChecks.tsx
@@ -10,12 +10,19 @@ import { getSSLErrorHint } from '../services/api/errorUtils.js';
 import { getUserAgent } from './http.js';
 import { logError } from './log.js';
 import { getAPIProvider } from './model/providers.js';
+
+// Bound the connectivity probe so blocked networks cannot freeze onboarding.
+export const PREFLIGHT_REQUEST_TIMEOUT_MS = 5000;
+
+// Failed connectivity should be readable, but it should not block onboarding.
+export const PREFLIGHT_ERROR_HOLD_MS = 4000;
+
 export interface PreflightCheckResult {
   success: boolean;
   error?: string;
   sslHint?: string;
 }
-async function checkEndpoints(): Promise<PreflightCheckResult> {
+export async function checkEndpoints(): Promise<PreflightCheckResult> {
   try {
     const oauthConfig = getOauthConfig();
     const tokenUrl = new URL(oauthConfig.TOKEN_URL);
@@ -25,7 +32,8 @@ async function checkEndpoints(): Promise<PreflightCheckResult> {
         const response = await axios.get(url, {
           headers: {
             'User-Agent': getUserAgent()
-          }
+          },
+          timeout: PREFLIGHT_REQUEST_TIMEOUT_MS
         });
         if (response.status !== 200) {
           const hostname = new URL(url).hostname;
@@ -109,11 +117,9 @@ export function PreflightStep(t0) {
     t3 = () => {
       if (result?.success) {
         onSuccess();
-      } else {
-        if (result && !result.success) {
-          const timer = setTimeout(_temp, 100);
-          return () => clearTimeout(timer);
-        }
+      } else if (result && !result.success) {
+        const timer = setTimeout(onSuccess, PREFLIGHT_ERROR_HOLD_MS);
+        return () => clearTimeout(timer);
       }
     };
     t4 = [result, onSuccess];
@@ -128,7 +134,7 @@ export function PreflightStep(t0) {
   useEffect(t3, t4);
   let t5;
   if ($[6] !== isChecking || $[7] !== result || $[8] !== showSpinner) {
-    t5 = isChecking && showSpinner ? <Box paddingLeft={1}><Spinner /><Text>Checking connectivity...</Text></Box> : !result?.success && !isChecking && <Box flexDirection="column" gap={1}><Text color="error">Unable to connect to Anthropic services</Text><Text color="error">{result?.error}</Text>{result?.sslHint ? <Box flexDirection="column" gap={1}><Text>{result.sslHint}</Text><Text color="suggestion">See https://code.claude.com/docs/en/network-config</Text></Box> : <Box flexDirection="column" gap={1}><Text>Please check your internet connection and network settings.</Text>{getAPIProvider() === 'firstParty' && <Text>Note: Claude Code might not be available in your country. Check supported countries at{" "}<Text color="suggestion">https://anthropic.com/supported-countries</Text></Text>}</Box>}</Box>;
+    t5 = isChecking && showSpinner ? <Box paddingLeft={1}><Spinner /><Text>Checking connectivity...</Text></Box> : !result?.success && !isChecking && <Box flexDirection="column" gap={1}><Text color="error">Unable to connect to Anthropic services</Text><Text color="error">{result?.error}</Text>{result?.sslHint ? <Box flexDirection="column" gap={1}><Text>{result.sslHint}</Text><Text color="suggestion">See https://code.claude.com/docs/en/network-config</Text></Box> : <Box flexDirection="column" gap={1}><Text>Please check your internet connection and network settings.</Text>{getAPIProvider() === 'firstParty' && <Text>Note: Claude Code might not be available in your country. Check supported countries at{" "}<Text color="suggestion">https://anthropic.com/supported-countries</Text></Text>}</Box>}<Text dimColor>Continuing: you can configure a non-Anthropic provider later with /provider.</Text></Box>;
     $[6] = isChecking;
     $[7] = result;
     $[8] = showSpinner;
@@ -145,7 +151,4 @@ export function PreflightStep(t0) {
     t6 = $[11];
   }
   return t6;
-}
-function _temp() {
-  return process.exit(1);
 }


### PR DESCRIPTION
## Summary
- Bound onboarding connectivity preflight at 5s so blocked networks cannot hang forever on "Checking connectivity..."
- Replace `process.exit(1)` on probe failure with a 4s error display, then continue onboarding so non-Anthropic providers can still be configured
- Add regression coverage for the timeout, ECONNABORTED, success, and failed-probe onboarding advance paths

## Issue
Refs #1017. This PR addresses the first-run onboarding connectivity preflight path discussed there; other freeze paths in that thread may still need separate fixes.

## What Changed
- `src/utils/preflightChecks.tsx`: export `checkEndpoints`, add `PREFLIGHT_REQUEST_TIMEOUT_MS` / `PREFLIGHT_ERROR_HOLD_MS`, pass axios timeout, and advance onboarding after failed connectivity instead of exiting
- `src/utils/preflightChecks.test.ts`: add focused regression tests, including a component/fake-timer test that proves failed preflight advances onboarding without calling `process.exit(1)`

## Validation
- [x] `bun test src/utils/preflightChecks.test.ts` - 4 pass
- [x] `bun run security:pr-scan -- --base upstream/main` - no suspicious additions found
- [x] `git diff --check upstream/main...HEAD` - pass
- [x] `bun run build` - pass

## Risk
Low. This is scoped to first-run onboarding preflight only. Failed Anthropic connectivity now surfaces briefly, then onboarding continues so users can configure a non-Anthropic provider later with `/provider`.