### PR TITLE
fix(teammate-progress): keep cumulative token+tool counts across prompts (#475)

### DIFF
--- a/src/tasks/LocalAgentTask/progressTracker.test.ts
+++ b/src/tasks/LocalAgentTask/progressTracker.test.ts
@@ -1,0 +1,182 @@
+import { describe, expect, test } from 'bun:test'
+
+import type { Message } from '../../types/message.js'
+import {
+  createProgressTracker,
+  getProgressUpdate,
+  getTokenCountFromTracker,
+  updateProgressFromMessage,
+} from './LocalAgentTask.js'
+
+// Pin issue #475 — agent-team teammate pill in TeammateSpinnerLine reads
+// `teammate.progress?.tokenCount` and `teammate.progress?.toolUseCount`. Those
+// are populated by `getProgressUpdate(tracker)` in inProcessRunner.ts. Before
+// the fix the runner re-created the tracker on every prompt iteration, so
+// across multi-prompt teammate conversations the pill kept resetting to the
+// current prompt's per-call counts (often 0 between turns). These tests pin
+// the cumulative-across-iterations contract the runner now relies on.
+
+function assistantMessage(
+  inputTokens: number,
+  outputTokens: number,
+  options: {
+    toolUses?: Array<{ id: string; name: string; input?: Record<string, unknown> }>
+    cacheCreation?: number
+    cacheRead?: number
+  } = {},
+): Message {
+  const { toolUses = [], cacheCreation, cacheRead } = options
+  return {
+    type: 'assistant',
+    message: {
+      content: toolUses.map(({ id, name, input }) => ({
+        type: 'tool_use',
+        id,
+        name,
+        input: input ?? {},
+      })),
+      usage: {
+        input_tokens: inputTokens,
+        output_tokens: outputTokens,
+        ...(cacheCreation !== undefined
+          ? { cache_creation_input_tokens: cacheCreation }
+          : {}),
+        ...(cacheRead !== undefined
+          ? { cache_read_input_tokens: cacheRead }
+          : {}),
+      },
+    },
+  }
+}
+
+describe('progress tracker (issue #475)', () => {
+  test('output tokens accumulate across multiple assistant messages', () => {
+    const tracker = createProgressTracker()
+
+    updateProgressFromMessage(tracker, assistantMessage(100, 50))
+    updateProgressFromMessage(tracker, assistantMessage(120, 30))
+    updateProgressFromMessage(tracker, assistantMessage(140, 20))
+
+    expect(tracker.cumulativeOutputTokens).toBe(100)
+    expect(tracker.latestInputTokens).toBe(140)
+    expect(getTokenCountFromTracker(tracker)).toBe(240)
+  })
+
+  test('cumulative semantic survives a simulated multi-prompt teammate session', () => {
+    // Simulates inProcessRunner's loop: two leader prompts to the same
+    // teammate, each driving multiple assistant turns. The runner now
+    // reuses one tracker across both prompts so `task.progress.tokenCount`
+    // reflects the teammate's total spend, not just the latest prompt.
+    const tracker = createProgressTracker()
+
+    // First prompt — 3 assistant turns
+    updateProgressFromMessage(tracker, assistantMessage(500, 100))
+    updateProgressFromMessage(tracker, assistantMessage(800, 200))
+    updateProgressFromMessage(tracker, assistantMessage(1200, 150))
+
+    const afterFirstPrompt = getProgressUpdate(tracker)
+    expect(afterFirstPrompt.tokenCount).toBeGreaterThan(0)
+
+    // Second prompt — 2 assistant turns; `forkContextMessages` re-sends
+    // history so input_tokens is large but already cumulative-per-request.
+    updateProgressFromMessage(tracker, assistantMessage(2100, 80))
+    updateProgressFromMessage(tracker, assistantMessage(2400, 90))
+
+    const afterSecondPrompt = getProgressUpdate(tracker)
+
+    // tokenCount must monotonically increase across prompts. Before the
+    // fix the runner reset the tracker between prompts, so this value
+    // could drop or zero out between turns.
+    expect(afterSecondPrompt.tokenCount).toBeGreaterThan(
+      afterFirstPrompt.tokenCount,
+    )
+    // Cumulative outputs across both prompts: 100 + 200 + 150 + 80 + 90.
+    expect(tracker.cumulativeOutputTokens).toBe(620)
+    expect(tracker.latestInputTokens).toBe(2400)
+    expect(afterSecondPrompt.tokenCount).toBe(3020)
+  })
+
+  test('fresh tracker per prompt would drop prior outputs (regression repro)', () => {
+    // This pins the failure mode #475 was reporting: the leader's pill
+    // showed per-prompt counters instead of running totals. The runner
+    // used to behave like this — resetting the tracker between prompts
+    // erased all prior output tokens and tool-use counts.
+    const promptOne = createProgressTracker()
+    updateProgressFromMessage(
+      promptOne,
+      assistantMessage(500, 100, {
+        toolUses: [{ id: 'a', name: 'Read', input: {} }],
+      }),
+    )
+    updateProgressFromMessage(
+      promptOne,
+      assistantMessage(800, 200, {
+        toolUses: [{ id: 'b', name: 'Grep', input: {} }],
+      }),
+    )
+
+    const promptTwo = createProgressTracker()
+    updateProgressFromMessage(promptTwo, assistantMessage(2100, 80))
+
+    // Output tokens from prompt one (300) are gone in the reset world.
+    expect(promptTwo.cumulativeOutputTokens).toBe(80)
+    // Tool uses from prompt one (2) are gone too — leader's "0 tool uses"
+    // display is the visible symptom of this.
+    expect(promptTwo.toolUseCount).toBe(0)
+    expect(promptOne.toolUseCount).toBe(2)
+  })
+
+  test('tool use count accumulates across assistant messages', () => {
+    const tracker = createProgressTracker()
+
+    updateProgressFromMessage(
+      tracker,
+      assistantMessage(100, 10, {
+        toolUses: [
+          { id: 'tu-1', name: 'Read', input: { file_path: '/a' } },
+          { id: 'tu-2', name: 'Grep', input: { pattern: 'foo' } },
+        ],
+      }),
+    )
+    updateProgressFromMessage(
+      tracker,
+      assistantMessage(120, 10, {
+        toolUses: [{ id: 'tu-3', name: 'Bash', input: { command: 'ls' } }],
+      }),
+    )
+
+    expect(tracker.toolUseCount).toBe(3)
+    const progress = getProgressUpdate(tracker)
+    expect(progress.toolUseCount).toBe(3)
+  })
+
+  test('cache_creation and cache_read input tokens are added to latestInputTokens', () => {
+    const tracker = createProgressTracker()
+
+    updateProgressFromMessage(
+      tracker,
+      assistantMessage(1000, 50, { cacheCreation: 200, cacheRead: 800 }),
+    )
+
+    expect(tracker.latestInputTokens).toBe(2000)
+    expect(getTokenCountFromTracker(tracker)).toBe(2050)
+  })
+
+  test('recentActivities are capped while toolUseCount still accumulates', () => {
+    const tracker = createProgressTracker()
+
+    for (let i = 0; i < 10; i++) {
+      updateProgressFromMessage(
+        tracker,
+        assistantMessage(100, 5, {
+          toolUses: [{ id: `tu-${i}`, name: 'Read', input: { file_path: `/${i}` } }],
+        }),
+      )
+    }
+
+    expect(tracker.toolUseCount).toBe(10)
+    // MAX_RECENT_ACTIVITIES is 5; the array should stay bounded so the UI
+    // preview doesn't bloat over a long teammate session.
+    expect(tracker.recentActivities.length).toBeLessThanOrEqual(5)
+  })
+})

--- a/src/utils/swarm/inProcessRunner.ts
+++ b/src/utils/swarm/inProcessRunner.ts
@@ -1044,6 +1044,20 @@ export async function runInProcessTeammate(
       ? createContentReplacementState()
       : undefined
 
+    // Progress tracker spans the whole teammate lifetime (multiple prompts).
+    // Resetting per prompt iteration dropped prior prompts' output tokens and
+    // tool-use counts from `task.progress`, so the leader's pill + spinner
+    // aggregate read zero/low values between turns even after long sessions
+    // (#475). The Claude API returns `input_tokens` as cumulative for that
+    // request (includes prior history sent via `forkContextMessages`), so
+    // `latestInputTokens` already represents the running context cost — we
+    // just need `cumulativeOutputTokens` and `toolUseCount` to keep their
+    // running totals across iterations.
+    const tracker = createProgressTracker()
+    const resolveActivity = createActivityDescriptionResolver(
+      toolUseContext.options.tools,
+    )
+
     // Main teammate loop - runs until abort or shutdown approved
     while (!abortController.signal.aborted && !shouldExit) {
       logForDebugging(
@@ -1134,11 +1148,6 @@ export async function runInProcessTeammate(
       // This ensures the full conversation (user + assistant turns) is preserved
       allMessages.push(userMessage)
 
-      // Create fresh progress tracker for this prompt
-      const tracker = createProgressTracker()
-      const resolveActivity = createActivityDescriptionResolver(
-        toolUseContext.options.tools,
-      )
       const iterationMessages: Message[] = []
 
       // Read current permission mode from task state (may have been cycled by leader via Shift+Tab)


### PR DESCRIPTION
Closes #475.

### What broke

`TeammateSpinnerLine`, `InProcessTeammateDetailDialog`, and the leader's spinner aggregate (`Spinner.tsx:191-200`) all read `teammate.progress?.tokenCount` and `teammate.progress?.toolUseCount` straight from `AppState`. Those fields are populated by `getProgressUpdate(tracker)` from inside the in-process teammate runner's per-message loop. The runner used to do this:

```ts
while (!abortController.signal.aborted && !shouldExit) {
  // ...
  // Create fresh progress tracker for this prompt
  const tracker = createProgressTracker()
  // ...
}
```

A fresh tracker per prompt iteration meant that whenever the leader sent a second prompt to the same teammate (i.e. any multi-turn agent-team flow), the previous prompts' `cumulativeOutputTokens` and `toolUseCount` were dropped on the floor and the pill jumped back to (or near) zero.

The Claude API returns `input_tokens` as cumulative-per-request — `forkContextMessages` already re-sends the full history each turn — so `latestInputTokens` was always large and partially masked the bug. The visible symptom matched the report on #475: output tokens and tool-use counts repeatedly looked low / stale to leaders, even after long sessions.

### Fix

Hoist `createProgressTracker()` (and the resolver) out of the `while` loop so a single tracker spans the whole teammate lifetime. `cumulativeOutputTokens` and `toolUseCount` now keep running totals across every prompt; `latestInputTokens` continues to track the latest request's cumulative-per-request input (which is what we want for "running context cost"). `recentActivities` stays capped at `MAX_RECENT_ACTIVITIES = 5` so the preview doesn't bloat over long teammate sessions.

Behavior on a single-prompt teammate is unchanged.

### Tests

New `src/tasks/LocalAgentTask/progressTracker.test.ts` pins the contract the runner relies on. Six cases:

1. Output tokens accumulate across multiple assistant messages.
2. Cumulative semantic survives a simulated multi-prompt teammate session (3 turns prompt-1 + 2 turns prompt-2 → monotonically-increasing `tokenCount`).
3. Fresh-tracker-per-prompt regression repro — confirms that under the old behavior prompt-1's output tokens and tool uses are lost when a new tracker is created for prompt-2.
4. Tool use count accumulates across messages.
5. `cache_creation_input_tokens` + `cache_read_input_tokens` fold into `latestInputTokens`.
6. `recentActivities` stays capped at 5 while `toolUseCount` keeps climbing.

`bun test` (full): **2998/2998 pass**. `bun run build` clean (no React/Ink leakage in SDK bundle; external lists valid).

### Repro for reviewer

1. Start two teammates (e.g. `/team` with two agents).
2. Send a first prompt to one — note token + tool-use count growing on its pill.
3. Send a second prompt to the same teammate — pre-fix the count snaps back to the second prompt's per-call value (often visibly lower); post-fix it keeps climbing.
