### PR TITLE
fix: third-party provider compat — update, metrics, and refusal message

### DIFF
--- a/src/cli/update.ts
+++ b/src/cli/update.ts
@@ -29,11 +29,15 @@ import { gte } from 'src/utils/semver.js'
 import { getInitialSettings } from 'src/utils/settings/settings.js'
 
 export async function update() {
-  // Block updates for third-party providers. The update mechanism downloads
-  // from the first-party distribution bucket, which would silently replace the
-  // OpenClaude build (with the OpenAI shim) with the upstream Claude Code
-  // binary (without it).
-  if (getAPIProvider() !== 'firstParty') {
+  // Block updates for third-party providers using upstream Anthropic builds.
+  // The update mechanism downloads from the first-party distribution bucket,
+  // which would silently replace the OpenClaude build with the upstream
+  // Claude Code binary. However, builds with a custom PACKAGE_URL (like
+  // OpenClaude's @gitlawb/openclaude) are safe to self-update.
+  if (
+    getAPIProvider() !== 'firstParty' &&
+    MACRO.PACKAGE_URL === '@anthropic-ai/claude-code'
+  ) {
     writeToStdout(
       chalk.yellow(
         `Auto-update is not available for third-party provider builds.\n`,

--- a/src/services/api/errors.ts
+++ b/src/services/api/errors.ts
@@ -25,6 +25,7 @@ import {
   NO_RESPONSE_REQUESTED,
 } from 'src/utils/messages.js'
 import {
+  getDefaultMainLoopModel,
   getDefaultMainLoopModelSetting,
   isNonCustomOpusModel,
 } from 'src/utils/model/model.js'
@@ -1356,9 +1357,10 @@ export function getErrorMessageIfRefusal(
     ? `${API_ERROR_MESSAGE_PREFIX}: OpenClaude is unable to respond to this request, which appears to violate our Usage Policy (${usagePolicyUrl}). Try rephrasing the request or attempting a different approach.`
     : `${API_ERROR_MESSAGE_PREFIX}: OpenClaude is unable to respond to this request, which appears to violate our Usage Policy (${usagePolicyUrl}). Please double press esc to edit your last message or start a new session for OpenClaude to assist with a different task.`
 
+  const defaultModel = getDefaultMainLoopModel()
   const modelSuggestion =
-    model !== 'claude-sonnet-4-20250514'
-      ? ' If you are seeing this refusal repeatedly, try running /model claude-sonnet-4-20250514 to switch models.'
+    model !== defaultModel
+      ? ` If you are seeing this refusal repeatedly, try running /model ${defaultModel} to switch models.`
       : ''
 
   return createAssistantAPIErrorMessage({

--- a/src/services/api/metricsOptOut.ts
+++ b/src/services/api/metricsOptOut.ts
@@ -1,6 +1,7 @@
 import axios from 'axios'
 import { hasProfileScope, isClaudeAISubscriber } from '../../utils/auth.js'
 import { getGlobalConfig, saveGlobalConfig } from '../../utils/config.js'
+import { getAPIProvider } from '../../utils/model/providers.js'
 import { logForDebugging } from '../../utils/debug.js'
 import { errorMessage } from '../../utils/errors.js'
 import { getAuthHeaders, withOAuth401Retry } from '../../utils/http.js'
@@ -31,6 +32,11 @@ const DISK_CACHE_TTL_MS = 24 * 60 * 60 * 1000
  * This is wrapped by memoizeWithTTLAsync to add caching behavior
  */
 async function _fetchMetricsEnabled(): Promise<MetricsEnabledResponse> {
+  // Third-party providers should not call Anthropic's metrics endpoint.
+  if (getAPIProvider() !== 'firstParty') {
+    return { metrics_logging_enabled: false }
+  }
+
   const authResult = getAuthHeaders()
   if (authResult.error) {
     throw new Error(`Auth error: ${authResult.error}`)

--- a/src/services/api/metricsOptOut.ts
+++ b/src/services/api/metricsOptOut.ts
@@ -132,6 +132,12 @@ async function refreshMetricsStatus(): Promise<MetricsStatus> {
  * an extra one during the 24h window is acceptable.
  */
 export async function checkMetricsEnabled(): Promise<MetricsStatus> {
+  // Third-party providers never use Anthropic metrics. Short-circuit before
+  // disk cache so a stale first-party `enabled: true` entry cannot leak.
+  if (getAPIProvider() !== 'firstParty') {
+    return { enabled: false, hasError: false }
+  }
+
   // Service key OAuth sessions lack user:profile scope → would 403.
   // API key users (non-subscribers) fall through and use x-api-key auth.
   // This check runs before the disk read so we never persist auth-state-derived

--- a/src/utils/autoUpdater.ts
+++ b/src/utils/autoUpdater.ts
@@ -88,9 +88,13 @@ export async function assertMinVersion(): Promise<void> {
     return
   }
 
-  // Skip version check for third-party providers — the min version
-  // kill-switch is first-party-specific and should not block 3P users
-  if (getAPIProvider() !== 'firstParty') {
+  // Skip version check for third-party providers using upstream Anthropic
+  // builds — the min version kill-switch is first-party-specific. Builds
+  // with a custom PACKAGE_URL (like OpenClaude) should still be checked.
+  if (
+    getAPIProvider() !== 'firstParty' &&
+    MACRO.PACKAGE_URL === '@anthropic-ai/claude-code'
+  ) {
     return
   }
 


### PR DESCRIPTION
## Summary

Four fixes for third-party provider users:

### 1. `openclaude update` blocked for all 3P users
**`src/cli/update.ts`** — Changed gate from `getAPIProvider() !== 'firstParty'` to also check `MACRO.PACKAGE_URL === '@anthropic-ai/claude-code'`. OpenClaude builds (where `PACKAGE_URL` is `@gitlawb/openclaude`) can now self-update from npm.

**`src/utils/autoUpdater.ts`** — Same fix in `assertMinVersion()`.

### 2. Metrics endpoint called by 3P providers
**`src/services/api/metricsOptOut.ts`** — Added firstParty gate to `_fetchMetricsEnabled()`. Previously, 3P users with API keys would hit `api.anthropic.com/api/claude_code/organizations/metrics_enabled` and get auth errors.

### 3. Stale hardcoded model in refusal message
**`src/services/api/errors.ts`** — Replaced hardcoded `'claude-sonnet-4-20250514'` with `getDefaultMainLoopModel()` so the model suggestion is always current and provider-appropriate.

## Testing

- `openclaude update` should work for non-Anthropic builds
- Metrics check should return `{ metrics_logging_enabled: false }` for 3P without hitting Anthropic
- Refusal message should suggest the correct default model for the current provider