### PR TITLE
fix(update): allow auto-update for third-party provider builds (#1404)

### DIFF
--- a/src/cli/update.ts
+++ b/src/cli/update.ts
@@ -29,11 +29,11 @@ import { gte } from 'src/utils/semver.js'
 import { getInitialSettings } from 'src/utils/settings/settings.js'
 
 export async function update() {
-  // Block updates for third-party providers. The update mechanism downloads
-  // from the first-party distribution bucket, which would silently replace the
-  // OpenClaude build (with the OpenAI shim) with the upstream Claude Code
-  // binary (without it).
-  if (getAPIProvider() !== 'firstParty') {
+  // Block updates only for upstream Anthropic builds with third-party providers.
+  // Forked builds (e.g. OpenClaude) set their own PACKAGE_URL and have their own
+  // distribution — the update mechanism targets that package URL, not the Anthropic
+  // bucket, so the gate would permanently lock them out of auto-update (#1404).
+  if (getAPIProvider() !== 'firstParty' && MACRO.PACKAGE_URL.startsWith('@anthropic')) {
     writeToStdout(
       chalk.yellow(
         `Auto-update is not available for third-party provider builds.\n`,

--- a/src/cli/update.ts
+++ b/src/cli/update.ts
@@ -33,7 +33,7 @@ export async function update() {
   // Forked builds (e.g. OpenClaude) set their own PACKAGE_URL and have their own
   // distribution — the update mechanism targets that package URL, not the Anthropic
   // bucket, so the gate would permanently lock them out of auto-update (#1404).
-  if (getAPIProvider() !== 'firstParty' && MACRO.PACKAGE_URL.startsWith('@anthropic')) {
+  if (getAPIProvider() !== 'firstParty' && MACRO.PACKAGE_URL.startsWith('@anthropic-ai/')) {
     writeToStdout(
       chalk.yellow(
         `Auto-update is not available for third-party provider builds.\n`,

--- a/src/cli/update.ts
+++ b/src/cli/update.ts
@@ -33,7 +33,7 @@ export async function update() {
   // Forked builds (e.g. OpenClaude) set their own PACKAGE_URL and have their own
   // distribution — the update mechanism targets that package URL, not the Anthropic
   // bucket, so the gate would permanently lock them out of auto-update (#1404).
-  if (getAPIProvider() !== 'firstParty' && MACRO.PACKAGE_URL.startsWith('@anthropic-ai/')) {
+  if (getAPIProvider() !== 'firstParty' && MACRO.PACKAGE_URL?.startsWith('@anthropic-ai/')) {
     writeToStdout(
       chalk.yellow(
         `Auto-update is not available for third-party provider builds.\n`,

--- a/src/cli/update.ts
+++ b/src/cli/update.ts
@@ -33,7 +33,7 @@ export async function update() {
   // Forked builds (e.g. OpenClaude) set their own PACKAGE_URL and have their own
   // distribution — the update mechanism targets that package URL, not the Anthropic
   // bucket, so the gate would permanently lock them out of auto-update (#1404).
-  if (getAPIProvider() !== 'firstParty' && MACRO.PACKAGE_URL?.startsWith('@anthropic-ai/')) {
+  if (getAPIProvider() !== 'firstParty' && (!MACRO.PACKAGE_URL || MACRO.PACKAGE_URL.startsWith('@anthropic-ai/'))) {
     writeToStdout(
       chalk.yellow(
         `Auto-update is not available for third-party provider builds.\n`,


### PR DESCRIPTION
The update gate checked ``getAPIProvider() !== 'firstParty'`` unconditionally, locking out all OpenClaude users even though ``MACRO.PACKAGE_URL`` correctly points to ``@gitlawb/openclaude`` for npm updates.

The check was inherited from upstream Claude Code to prevent accidentally replacing a third-party-shimmed binary with the upstream Anthropic binary. But forked builds (OpenClaude, etc.) set their own ``MACRO.PACKAGE_URL`` and have their own distribution — the update mechanism already targets that URL, so the gate permanently blocks them.

## Fix

Add ``&& MACRO.PACKAGE_URL.startsWith('@anthropic-ai/')`` to the gate so it only fires for upstream builds using third-party providers. Forked builds with their own package URL are unaffected.

Uses ``startsWith('@anthropic-ai/')`` rather than ``startsWith('@anthropic')`` to avoid false matches on other ``@anthropic-*`` scopes.

Fixes #1404
