### PR TITLE
fix: strip image blocks for text-only providers to prevent DeepSeek crash (#1382)

### DIFF
--- a/src/services/api/openaiShim.ts
+++ b/src/services/api/openaiShim.ts
@@ -372,8 +372,27 @@ function convertToolResultContent(
   return parts
 }
 
+const VISION_SUPPORTING_MODEL_PREFIXES = [
+  'gpt-4', 'gpt-4o', 'gpt-4v',
+  'gemini', 'gemini-',
+  'claude-3', 'claude-3.',
+  'kimi', 'kimi-',
+  'qwen-vl', 'qwen2-vl',
+  'grok-vision',
+  'minimax-vl',
+  'xiaomi-mimo-vl',
+]
+
+function modelSupportsVision(modelName: string): boolean {
+  const normalized = modelName.toLowerCase().trim()
+  return VISION_SUPPORTING_MODEL_PREFIXES.some(prefix =>
+    normalized.startsWith(prefix.toLowerCase()),
+  )
+}
+
 function convertContentBlocks(
   content: unknown,
+  stripImages?: boolean,
 ): string | Array<{ type: string; text?: string; image_url?: { url: string } }> {
   if (typeof content === 'string') return content
   if (!Array.isArray(content)) return String(content ?? '')
@@ -385,6 +404,10 @@ function convertContentBlocks(
         parts.push({ type: 'text', text: block.text ?? '' })
         break
       case 'image': {
+        if (stripImages) {
+          parts.push({ type: 'text', text: '[Image]' })
+          break
+        }
         const src = block.source
         if (src?.type === 'base64') {
           parts.push({
@@ -494,6 +517,7 @@ function convertMessages(
     preserveReasoningContent?: boolean
     reasoningContentFallback?: '' | 'omit'
     preserveGeminiThoughtSignature?: boolean
+    stripImages?: boolean
   },
 ): OpenAIMessage[] {
   const preserveReasoningContent = options?.preserveReasoningContent === true
@@ -567,13 +591,13 @@ function convertMessages(
         if (otherContent.length > 0) {
           result.push({
             role: 'user',
-            content: convertContentBlocks(otherContent),
+            content: convertContentBlocks(otherContent, options?.stripImages),
           })
         }
       } else {
         result.push({
           role: 'user',
-          content: convertContentBlocks(content),
+          content: convertContentBlocks(content, options?.stripImages),
         })
       }
     } else if (role === 'assistant') {
@@ -1785,6 +1809,7 @@ class OpenAIShimMessages {
       treatAsLocal: isLocalProviderUrl(request.baseUrl),
     })
     const shimConfig = runtimeShimContext.openaiShimConfig
+    const stripImages = !modelSupportsVision(request.resolvedModel)
     const openaiMessages = convertMessages(compressedMessages, params.system, {
       preserveReasoningContent: shimConfig.preserveReasoningContent,
       reasoningContentFallback: shimConfig.reasoningContentFallback,
@@ -1792,6 +1817,7 @@ class OpenAIShimMessages {
         request.resolvedModel,
         request.baseUrl,
       ),
+      stripImages,
     })
 
     const body: Record<string, unknown> = {

--- a/src/services/api/openaiShim.ts
+++ b/src/services/api/openaiShim.ts
@@ -309,6 +309,7 @@ function convertSystemPrompt(
 function convertToolResultContent(
   content: unknown,
   isError?: boolean,
+  stripImages?: boolean,
 ): string | Array<{ type: string; text?: string; image_url?: { url: string } }> {
   if (typeof content === 'string') {
     return isError ? `Error: ${content}` : content
@@ -330,6 +331,10 @@ function convertToolResultContent(
     }
 
     if (block?.type === 'image') {
+      if (stripImages) {
+        parts.push({ type: 'text', text: '[Image]' })
+        continue
+      }
       const source = block.source
       if (source?.type === 'url' && source.url) {
         parts.push({ type: 'image_url', image_url: { url: source.url } })
@@ -578,7 +583,7 @@ function convertMessages(
             result.push({
               role: 'tool',
               tool_call_id: id,
-              content: convertToolResultContent(tr.content, tr.is_error),
+              content: convertToolResultContent(tr.content, tr.is_error, options?.stripImages),
             })
           } else {
             logForDebugging(
@@ -616,7 +621,7 @@ function convertMessages(
         const assistantMsg: OpenAIMessage = {
           role: 'assistant',
           content: (() => {
-            const c = convertContentBlocks(textContent)
+            const c = convertContentBlocks(textContent, options?.stripImages)
             return typeof c === 'string'
               ? c
               : Array.isArray(c)
@@ -719,7 +724,7 @@ function convertMessages(
         const assistantMsg: OpenAIMessage = {
           role: 'assistant',
           content: (() => {
-            const c = convertContentBlocks(content)
+            const c = convertContentBlocks(content, options?.stripImages)
             return typeof c === 'string'
               ? c
               : Array.isArray(c)


### PR DESCRIPTION
Fixes #1382

DeepSeek (and other text-only providers) crash when receiving image_url content blocks from multi-modal conversation history. Other text-only providers (Mistral, Llama, etc.) have the same issue.

## Changes
- Added modelSupportsVision() helper that checks model name prefixes against known vision-capable models
- Added stripImages option to the OpenAI shim convertMessages() - when enabled, image_url blocks are replaced with [Image] placeholder text
- Applied stripImages to user messages, tool result content, and assistant content paths
- Defaults to no stripping for providers that support vision, so existing behavior is unchanged