### PR TITLE
feat: set process.title to 'openclaude'

### DIFF
--- a/src/__tests__/process-title.test.ts
+++ b/src/__tests__/process-title.test.ts
@@ -1,0 +1,13 @@
+import { describe, test, expect } from 'bun:test'
+import { resolve } from 'path'
+
+const SRC = resolve(import.meta.dir, '..')
+const file = (relative: string) => Bun.file(resolve(SRC, relative))
+
+describe('process.title', () => {
+  test('should be set to openclaude in main.tsx', async () => {
+    const mainSource = await file('main.tsx').text()
+    expect(mainSource).toContain("process.title = 'openclaude'")
+    expect(mainSource).not.toContain("process.title = 'claude'")
+  })
+})

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -922,7 +922,7 @@ async function run(): Promise<CommanderCommand> {
     // terminal shell integration may mirror the process name to the tab.
     // After init() so settings.json env can also gate this (gh-4765).
     if (!isEnvTruthy(process.env.CLAUDE_CODE_DISABLE_TERMINAL_TITLE)) {
-      process.title = 'claude';
+      process.title = 'openclaude';
     }
 
     // Attach logging sinks so subcommand handlers can use logEvent/logError.


### PR DESCRIPTION
## Summary

Change `process.title` from `'claude'` to `'openclaude'` in `src/main.tsx` to match the project name after the rename from Claude Code to OpenClaude.

## Benefits

- **Observability:** `pgrep openclaude` / `ps aux | grep openclaude` now distinguishes the process from upstream Claude Code
- **Log identification:** `/proc/[pid]/comm` shows `openclaude`, making debugging and log correlation easier
- **nproxy consistency:** Base process title aligns with the OpenClaude identity before nproxy overwrites it

## Changes

- `src/main.tsx:925` — `process.title = 'claude'` → `process.title = 'openclaude'`
- `src/__tests__/process-title.test.ts` — New source-level test verifying the correct title is set

## Impact

- **With nproxy:** No functional change — nproxy overwrites `process.title`
- **Without nproxy:** Improved process discoverability
- **Windows:** `tasklist | findstr openclaude` works (improvement)
- **gracefulShutdown:** Unaffected (sets `process.title = ''`)
- **use-terminal-title.ts:** Unaffected (independent)

## Checks

- `bun test src/__tests__/process-title.test.ts` — 1 pass
- `bun run build` — Success

Ref: professional-slacker/status#13