### PR TITLE
fix(provider): add Use Anthropic option to switch back from third-party profiles

### DIFF
--- a/src/commands/provider/provider.tsx
+++ b/src/commands/provider/provider.tsx
@@ -57,8 +57,6 @@ import {
   type ProfileFile,
   type ProviderProfile,
 } from '../../utils/providerProfile.js'
-import { clearActiveProviderProfile } from '../../utils/providerProfiles.js'
-import { clearStartupProviderOverrides } from '../../utils/providerStartupOverrides.js'
 import {
   getGeminiProjectIdHint,
   mayHaveGeminiAdcCredentials,
@@ -138,7 +136,7 @@ function describeOllamaReadinessIssue(
   return ''
 }
 
-type ProviderChoice = 'auto' | ProviderProfile | 'codex-oauth' | 'clear' | 'anthropic'
+type ProviderChoice = 'auto' | ProviderProfile | 'codex-oauth' | 'clear'
 
 type Step =
   | { name: 'choose' }
@@ -722,15 +720,6 @@ function ProviderChooser({
         ]
       : []),
   ]
-
-  if (summary.providerLabel !== 'Anthropic') {
-    options.push({
-      label: 'Use Anthropic (built-in)',
-      value: 'anthropic',
-      description:
-        'Switch back to Claude now without a restart — saved profiles are kept',
-    })
-  }
 
   if (summary.savedProfileLabel !== 'none') {
     options.push({
@@ -1339,20 +1328,6 @@ export function ProviderWizard({
               })
             } else if (value === 'codex-oauth') {
               setStep({ name: 'codex-oauth' })
-            } else if (value === 'anthropic') {
-              clearActiveProviderProfile()
-              const settingsOverrideError = clearStartupProviderOverrides()
-              onDone(
-                settingsOverrideError
-                  ? `Switched back to Anthropic (built-in) for this session. Warning: could not clear startup provider override (${settingsOverrideError}).`
-                  : 'Switched back to Anthropic (built-in) for this session.',
-                {
-                  display: 'system',
-                  metaMessages: [
-                    '<system-reminder>Provider switched mid-session to Anthropic (built-in Claude). Use Anthropic for subsequent requests unless the user switches again.</system-reminder>',
-                  ],
-                },
-              )
             } else if (value === 'clear') {
               const filePath = deleteProfileFile()
               onDone(`Removed saved provider profile at ${filePath}. Restart OpenClaude to go back to normal startup.`, {

--- a/src/commands/provider/provider.tsx
+++ b/src/commands/provider/provider.tsx
@@ -58,6 +58,7 @@ import {
   type ProviderProfile,
 } from '../../utils/providerProfile.js'
 import { clearActiveProviderProfile } from '../../utils/providerProfiles.js'
+import { clearStartupProviderOverrides } from '../../utils/providerStartupOverrides.js'
 import {
   getGeminiProjectIdHint,
   mayHaveGeminiAdcCredentials,
@@ -1340,12 +1341,18 @@ export function ProviderWizard({
               setStep({ name: 'codex-oauth' })
             } else if (value === 'anthropic') {
               clearActiveProviderProfile()
-              onDone('Switched back to Anthropic (built-in) for this session.', {
-                display: 'system',
-                metaMessages: [
-                  '<system-reminder>Provider switched mid-session to Anthropic (built-in Claude). Use Anthropic for subsequent requests unless the user switches again.</system-reminder>',
-                ],
-              })
+              const settingsOverrideError = clearStartupProviderOverrides()
+              onDone(
+                settingsOverrideError
+                  ? `Switched back to Anthropic (built-in) for this session. Warning: could not clear startup provider override (${settingsOverrideError}).`
+                  : 'Switched back to Anthropic (built-in) for this session.',
+                {
+                  display: 'system',
+                  metaMessages: [
+                    '<system-reminder>Provider switched mid-session to Anthropic (built-in Claude). Use Anthropic for subsequent requests unless the user switches again.</system-reminder>',
+                  ],
+                },
+              )
             } else if (value === 'clear') {
               const filePath = deleteProfileFile()
               onDone(`Removed saved provider profile at ${filePath}. Restart OpenClaude to go back to normal startup.`, {

--- a/src/commands/provider/provider.tsx
+++ b/src/commands/provider/provider.tsx
@@ -57,6 +57,7 @@ import {
   type ProfileFile,
   type ProviderProfile,
 } from '../../utils/providerProfile.js'
+import { clearActiveProviderProfile } from '../../utils/providerProfiles.js'
 import {
   getGeminiProjectIdHint,
   mayHaveGeminiAdcCredentials,
@@ -136,7 +137,7 @@ function describeOllamaReadinessIssue(
   return ''
 }
 
-type ProviderChoice = 'auto' | ProviderProfile | 'codex-oauth' | 'clear'
+type ProviderChoice = 'auto' | ProviderProfile | 'codex-oauth' | 'clear' | 'anthropic'
 
 type Step =
   | { name: 'choose' }
@@ -720,6 +721,15 @@ function ProviderChooser({
         ]
       : []),
   ]
+
+  if (summary.providerLabel !== 'Anthropic') {
+    options.push({
+      label: 'Use Anthropic (built-in)',
+      value: 'anthropic',
+      description:
+        'Switch back to Claude now without a restart — saved profiles are kept',
+    })
+  }
 
   if (summary.savedProfileLabel !== 'none') {
     options.push({
@@ -1328,6 +1338,14 @@ export function ProviderWizard({
               })
             } else if (value === 'codex-oauth') {
               setStep({ name: 'codex-oauth' })
+            } else if (value === 'anthropic') {
+              clearActiveProviderProfile()
+              onDone('Switched back to Anthropic (built-in) for this session.', {
+                display: 'system',
+                metaMessages: [
+                  '<system-reminder>Provider switched mid-session to Anthropic (built-in Claude). Use Anthropic for subsequent requests unless the user switches again.</system-reminder>',
+                ],
+              })
             } else if (value === 'clear') {
               const filePath = deleteProfileFile()
               onDone(`Removed saved provider profile at ${filePath}. Restart OpenClaude to go back to normal startup.`, {

--- a/src/components/ProviderManager.test.tsx
+++ b/src/components/ProviderManager.test.tsx
@@ -2262,8 +2262,9 @@ test('ProviderManager switches back to Anthropic via the manager UI: resets the 
       readGithubModelsToken: () => storedToken,
       readGithubModelsTokenAsync: async () => storedToken,
     }))
+    const clearStartupProviderOverrides = mock(() => null)
     mock.module('../utils/providerStartupOverrides.js', () => ({
-      clearStartupProviderOverrides: () => null,
+      clearStartupProviderOverrides,
     }))
 
     const onDoneResults: Array<Record<string, unknown>> = []
@@ -2316,6 +2317,11 @@ test('ProviderManager switches back to Anthropic via the manager UI: resets the 
     // user-supplied GITHUB_TOKEN. Asserting the argument (not just the call)
     // means the test fails if the branch stops forwarding the stored token.
     expect(clearHydratedGithubModelsTokenFromEnv).toHaveBeenCalledWith(storedToken)
+    // The restart fix depends on clearing persisted startup provider overrides
+    // after clearActiveProviderProfile(); without this the next launch replays
+    // the third-party provider. Anchor on the mocked symbol so the test fails
+    // if the Anthropic branch stops calling it.
+    expect(clearStartupProviderOverrides).toHaveBeenCalled()
   } finally {
     if (mounted) {
       await mounted.dispose()

--- a/src/components/ProviderManager.test.tsx
+++ b/src/components/ProviderManager.test.tsx
@@ -2335,3 +2335,114 @@ test('ProviderManager switches back to Anthropic via the manager UI: resets the 
     }
   }
 })
+
+test('ProviderManager deleting the GitHub provider reverts the hydrated credential via the shared cleanup helper', async () => {
+  // Regression for the #1429 review: the GitHub Models delete path used to
+  // hand-roll its own cleanup that only dropped GITHUB_TOKEN, so a hydrated
+  // `copilot_key` (which hydrateGithubModelsTokenFromSecureStorage stores in
+  // GITHUB_COPILOT_KEY under the same marker) was left behind once the marker
+  // was removed. The delete flow must now delegate to the shared
+  // clearHydratedGithubModelsTokenFromEnv helper — the same one the switch-back
+  // path uses — so both GitHub Models removal paths revert the hydrated
+  // credential consistently. Asserting the helper is invoked with the stored
+  // token proves the delete path shares that cleanup rather than the old
+  // partial version.
+  const envKeys = [
+    'CLAUDE_CODE_USE_GITHUB',
+    'GITHUB_TOKEN',
+    'GITHUB_COPILOT_KEY',
+    'GH_TOKEN',
+    'CLAUDE_CODE_SIMPLE',
+  ]
+  const envSnapshot = new Map(envKeys.map(key => [key, process.env[key]] as const))
+  let mounted: Awaited<ReturnType<typeof mountProviderManager>> | undefined
+
+  try {
+    process.env.CLAUDE_CODE_USE_GITHUB = '1'
+    delete process.env.GITHUB_TOKEN
+    delete process.env.GITHUB_COPILOT_KEY
+    delete process.env.GH_TOKEN
+    delete process.env.CLAUDE_CODE_SIMPLE
+
+    const realProviderProfiles = await import('../utils/providerProfiles.js')
+
+    const githubSyncRead = mock(() => undefined)
+    const githubAsyncRead = mock(async () => undefined)
+    mockProviderManagerDependencies(githubSyncRead, githubAsyncRead, {
+      getProviderProfiles: () => [],
+      getActiveProviderProfile: () => null,
+    })
+
+    const clearHydratedGithubModelsTokenFromEnv = mock(() => {})
+    // Seed a stored GitHub Models token so the delete path forwards a real token
+    // into the cleanup helper (rather than `undefined`).
+    const storedToken = 'ghp_stored_secure_storage_token'
+
+    mock.module('../utils/providerProfiles.js', () => ({
+      ...realProviderProfiles,
+      applyActiveProviderProfileFromConfig: () => {},
+      getProviderProfiles: () => [],
+      getActiveProviderProfile: () => null,
+    }))
+    mock.module('../utils/githubModelsCredentials.js', () => ({
+      clearGithubModelsToken: () => ({ success: true }),
+      clearHydratedGithubModelsTokenFromEnv,
+      GITHUB_MODELS_HYDRATED_ENV_MARKER: 'CLAUDE_CODE_GITHUB_TOKEN_HYDRATED',
+      hydrateGithubModelsTokenFromSecureStorage: () => {},
+      readGithubModelsToken: () => storedToken,
+      readGithubModelsTokenAsync: async () => storedToken,
+    }))
+
+    const nonce = `${Date.now()}-${Math.random()}`
+    const { ProviderManager } = await import(`./ProviderManager.js?ts=${nonce}`)
+    mounted = await mountProviderManager(ProviderManager)
+
+    await waitForFrameOutput(
+      mounted.getOutput,
+      frame =>
+        frame.includes('Provider manager') &&
+        frame.includes('Delete provider'),
+    )
+
+    // Menu order is [Add, Set active, Edit, Delete, ...]; move to "Delete
+    // provider" and open it.
+    mounted.stdin.write('j')
+    await Bun.sleep(25)
+    mounted.stdin.write('j')
+    await Bun.sleep(25)
+    mounted.stdin.write('j')
+    await Bun.sleep(25)
+    mounted.stdin.write('\r')
+
+    // The active GitHub Models provider is the deletable entry; wait for the
+    // delete list to render before selecting it (avoid a render race).
+    await waitForFrameOutput(
+      mounted.getOutput,
+      frame => frame.includes('Delete provider') && frame.includes('GitHub Models'),
+    )
+    await Bun.sleep(40)
+    mounted.stdin.write('\r')
+
+    await waitForCondition(
+      () => clearHydratedGithubModelsTokenFromEnv.mock.calls.length > 0,
+    )
+
+    // The delete path must forward the stored token into the shared cleanup
+    // helper (which reverts both the GITHUB_TOKEN and GITHUB_COPILOT_KEY
+    // hydration modes). Asserting the argument — not just that it was called —
+    // fails the test if the delete path regresses to a partial hand-rolled
+    // cleanup that leaves the hydrated Copilot key behind.
+    expect(clearHydratedGithubModelsTokenFromEnv).toHaveBeenCalledWith(storedToken)
+  } finally {
+    if (mounted) {
+      await mounted.dispose()
+    }
+    for (const [key, value] of envSnapshot) {
+      if (value === undefined) {
+        delete process.env[key]
+      } else {
+        process.env[key] = value
+      }
+    }
+  }
+})

--- a/src/components/ProviderManager.test.tsx
+++ b/src/components/ProviderManager.test.tsx
@@ -2268,6 +2268,7 @@ test('ProviderManager switches back to Anthropic via the manager UI: resets the 
     }))
 
     const onDoneResults: Array<Record<string, unknown>> = []
+    const appStateChanges: Array<{ newState: any; oldState: any }> = []
     const nonce = `${Date.now()}-${Math.random()}`
     const { ProviderManager } = await import(`./ProviderManager.js?ts=${nonce}`)
     mounted = await mountProviderManager(ProviderManager, {
@@ -2275,6 +2276,9 @@ test('ProviderManager switches back to Anthropic via the manager UI: resets the 
         if (result && typeof result === 'object') {
           onDoneResults.push(result as Record<string, unknown>)
         }
+      },
+      onChangeAppState: args => {
+        appStateChanges.push(args as { newState: any; oldState: any })
       },
     })
 
@@ -2308,6 +2312,32 @@ test('ProviderManager switches back to Anthropic via the manager UI: resets the 
     expect(String(result.activeProviderName)).toMatch(/anthropic/i)
     expect(typeof result.activeProviderModel).toBe('string')
     expect((result.activeProviderModel as string).length).toBeGreaterThan(0)
+    // The switch-back must also refresh the live session AppState — that is the
+    // path onChangeAppState uses to update the runtime mainLoopModelOverride, so
+    // without it the running session could keep the previous provider model after
+    // selecting "Use Anthropic (built-in)". Mirror the active-provider tests:
+    // assert the AppState update sets mainLoopModel to the Anthropic model from
+    // the result and clears mainLoopModelForSession to null.
+    const anthropicModel = result.activeProviderModel as string
+    await waitForCondition(() =>
+      appStateChanges.some(
+        ({ newState }) => newState.mainLoopModel === anthropicModel,
+      ),
+    )
+    expect(
+      appStateChanges.some(
+        ({ newState, oldState }) =>
+          newState.mainLoopModel === anthropicModel &&
+          oldState.mainLoopModel !== newState.mainLoopModel,
+      ),
+    ).toBe(true)
+    expect(
+      appStateChanges.some(
+        ({ newState }) =>
+          newState.mainLoopModel === anthropicModel &&
+          newState.mainLoopModelForSession === null,
+      ),
+    ).toBe(true)
     expect(
       Object.keys(process.env).some(key => key.startsWith('CLAUDE_CODE_USE_')),
     ).toBe(false)

--- a/src/components/ProviderManager.test.tsx
+++ b/src/components/ProviderManager.test.tsx
@@ -2203,97 +2203,124 @@ test('ProviderManager switches back to Anthropic via the manager UI: resets the 
   // "Use Anthropic (built-in)" recovery option must reset the session model and
   // drop the managed CLAUDE_CODE_USE_* flags. This is the production switch-back
   // path; the existing util tests only cover the sentinel in isolation.
-  process.env.CLAUDE_CODE_USE_GITHUB = '1'
-  delete process.env.GITHUB_TOKEN
-  delete process.env.GH_TOKEN
-  delete process.env.CLAUDE_CODE_SIMPLE
+  //
+  // The test mutates process-wide env and mounts an Ink app, so both are
+  // snapshotted/restored in finally — a failed wait or assertion must not leak
+  // provider flags or a live mount into later tests.
+  const envKeys = [
+    'CLAUDE_CODE_USE_GITHUB',
+    'GITHUB_TOKEN',
+    'GH_TOKEN',
+    'CLAUDE_CODE_SIMPLE',
+  ]
+  const envSnapshot = new Map(envKeys.map(key => [key, process.env[key]] as const))
+  let mounted: Awaited<ReturnType<typeof mountProviderManager>> | undefined
 
-  // Capture the real providerProfiles module before any mock replaces it so the
-  // Anthropic sentinel id and preset helpers stay intact.
-  const realProviderProfiles = await import('../utils/providerProfiles.js')
+  try {
+    process.env.CLAUDE_CODE_USE_GITHUB = '1'
+    delete process.env.GITHUB_TOKEN
+    delete process.env.GH_TOKEN
+    delete process.env.CLAUDE_CODE_SIMPLE
 
-  const githubSyncRead = mock(() => undefined)
-  const githubAsyncRead = mock(async () => undefined)
-  mockProviderManagerDependencies(githubSyncRead, githubAsyncRead, {
-    getProviderProfiles: () => [],
-    getActiveProviderProfile: () => null,
-  })
+    // Capture the real providerProfiles module before any mock replaces it so the
+    // Anthropic sentinel id and preset helpers stay intact.
+    const realProviderProfiles = await import('../utils/providerProfiles.js')
 
-  const clearActiveProviderProfile = mock(() => {
-    for (const key of Object.keys(process.env)) {
-      if (key.startsWith('CLAUDE_CODE_USE_')) {
+    const githubSyncRead = mock(() => undefined)
+    const githubAsyncRead = mock(async () => undefined)
+    mockProviderManagerDependencies(githubSyncRead, githubAsyncRead, {
+      getProviderProfiles: () => [],
+      getActiveProviderProfile: () => null,
+    })
+
+    const clearActiveProviderProfile = mock(() => {
+      for (const key of Object.keys(process.env)) {
+        if (key.startsWith('CLAUDE_CODE_USE_')) {
+          delete process.env[key]
+        }
+      }
+      return true
+    })
+    const clearHydratedGithubModelsTokenFromEnv = mock(() => {})
+
+    mock.module('../utils/providerProfiles.js', () => ({
+      ...realProviderProfiles,
+      applyActiveProviderProfileFromConfig: () => {},
+      getProviderProfiles: () => [],
+      getActiveProviderProfile: () => null,
+      setActiveProviderProfile: mock(() => null),
+      clearActiveProviderProfile,
+    }))
+    mock.module('../utils/githubModelsCredentials.js', () => ({
+      clearGithubModelsToken: () => ({ success: true }),
+      clearHydratedGithubModelsTokenFromEnv,
+      GITHUB_MODELS_HYDRATED_ENV_MARKER: 'CLAUDE_CODE_GITHUB_TOKEN_HYDRATED',
+      hydrateGithubModelsTokenFromSecureStorage: () => {},
+      readGithubModelsToken: () => undefined,
+      readGithubModelsTokenAsync: async () => undefined,
+    }))
+    mock.module('../utils/providerStartupOverrides.js', () => ({
+      clearStartupProviderOverrides: () => null,
+    }))
+
+    const onDoneResults: Array<Record<string, unknown>> = []
+    const nonce = `${Date.now()}-${Math.random()}`
+    const { ProviderManager } = await import(`./ProviderManager.js?ts=${nonce}`)
+    mounted = await mountProviderManager(ProviderManager, {
+      onDone: result => {
+        if (result && typeof result === 'object') {
+          onDoneResults.push(result as Record<string, unknown>)
+        }
+      },
+    })
+
+    await waitForFrameOutput(
+      mounted.getOutput,
+      frame =>
+        frame.includes('Provider manager') &&
+        frame.includes('Set active provider'),
+    )
+
+    // Open "Set active provider" (second menu item).
+    mounted.stdin.write('j')
+    await Bun.sleep(25)
+    mounted.stdin.write('\r')
+
+    // Options here are [GitHub Models (active), Use Anthropic (built-in)]; move
+    // down to the switch-back option and select it.
+    await waitForFrameOutput(
+      mounted.getOutput,
+      frame => frame.includes('Use Anthropic (built-in)'),
+    )
+
+    mounted.stdin.write('j')
+    await Bun.sleep(25)
+    mounted.stdin.write('\r')
+
+    await waitForCondition(() => onDoneResults.length > 0)
+
+    const result = onDoneResults[0]
+    expect(result.action).toBe('activated')
+    expect(String(result.activeProviderName)).toMatch(/anthropic/i)
+    expect(typeof result.activeProviderModel).toBe('string')
+    expect((result.activeProviderModel as string).length).toBeGreaterThan(0)
+    expect(
+      Object.keys(process.env).some(key => key.startsWith('CLAUDE_CODE_USE_')),
+    ).toBe(false)
+    expect(clearActiveProviderProfile).toHaveBeenCalled()
+    // The switch-back must also drop a hydrated GitHub Models token; assert the
+    // cleanup is wired so removing that call cannot pass unnoticed.
+    expect(clearHydratedGithubModelsTokenFromEnv).toHaveBeenCalled()
+  } finally {
+    if (mounted) {
+      await mounted.dispose()
+    }
+    for (const [key, value] of envSnapshot) {
+      if (value === undefined) {
         delete process.env[key]
+      } else {
+        process.env[key] = value
       }
     }
-    return true
-  })
-  const clearHydratedGithubModelsTokenFromEnv = mock(() => {})
-
-  mock.module('../utils/providerProfiles.js', () => ({
-    ...realProviderProfiles,
-    applyActiveProviderProfileFromConfig: () => {},
-    getProviderProfiles: () => [],
-    getActiveProviderProfile: () => null,
-    setActiveProviderProfile: mock(() => null),
-    clearActiveProviderProfile,
-  }))
-  mock.module('../utils/githubModelsCredentials.js', () => ({
-    clearGithubModelsToken: () => ({ success: true }),
-    clearHydratedGithubModelsTokenFromEnv,
-    GITHUB_MODELS_HYDRATED_ENV_MARKER: 'CLAUDE_CODE_GITHUB_TOKEN_HYDRATED',
-    hydrateGithubModelsTokenFromSecureStorage: () => {},
-    readGithubModelsToken: () => undefined,
-    readGithubModelsTokenAsync: async () => undefined,
-  }))
-  mock.module('../utils/providerStartupOverrides.js', () => ({
-    clearStartupProviderOverrides: () => null,
-  }))
-
-  const onDoneResults: Array<Record<string, unknown>> = []
-  const nonce = `${Date.now()}-${Math.random()}`
-  const { ProviderManager } = await import(`./ProviderManager.js?ts=${nonce}`)
-  const mounted = await mountProviderManager(ProviderManager, {
-    onDone: result => {
-      if (result && typeof result === 'object') {
-        onDoneResults.push(result as Record<string, unknown>)
-      }
-    },
-  })
-
-  await waitForFrameOutput(
-    mounted.getOutput,
-    frame =>
-      frame.includes('Provider manager') &&
-      frame.includes('Set active provider'),
-  )
-
-  // Open "Set active provider" (second menu item).
-  mounted.stdin.write('j')
-  await Bun.sleep(25)
-  mounted.stdin.write('\r')
-
-  // Options here are [GitHub Models (active), Use Anthropic (built-in)]; move
-  // down to the switch-back option and select it.
-  await waitForFrameOutput(
-    mounted.getOutput,
-    frame => frame.includes('Use Anthropic (built-in)'),
-  )
-
-  mounted.stdin.write('j')
-  await Bun.sleep(25)
-  mounted.stdin.write('\r')
-
-  await waitForCondition(() => onDoneResults.length > 0)
-
-  const result = onDoneResults[0]
-  expect(result.action).toBe('activated')
-  expect(String(result.activeProviderName)).toMatch(/anthropic/i)
-  expect(typeof result.activeProviderModel).toBe('string')
-  expect((result.activeProviderModel as string).length).toBeGreaterThan(0)
-  expect(
-    Object.keys(process.env).some(key => key.startsWith('CLAUDE_CODE_USE_')),
-  ).toBe(false)
-  expect(clearActiveProviderProfile).toHaveBeenCalled()
-
-  await mounted.dispose()
+  }
 })

--- a/src/components/ProviderManager.test.tsx
+++ b/src/components/ProviderManager.test.tsx
@@ -2242,6 +2242,9 @@ test('ProviderManager switches back to Anthropic via the manager UI: resets the 
       return true
     })
     const clearHydratedGithubModelsTokenFromEnv = mock(() => {})
+    // Seed a stored GitHub Models token so the switch-back path has a real
+    // token to forward into the cleanup helper (rather than `undefined`).
+    const storedToken = 'ghp_stored_secure_storage_token'
 
     mock.module('../utils/providerProfiles.js', () => ({
       ...realProviderProfiles,
@@ -2256,8 +2259,8 @@ test('ProviderManager switches back to Anthropic via the manager UI: resets the 
       clearHydratedGithubModelsTokenFromEnv,
       GITHUB_MODELS_HYDRATED_ENV_MARKER: 'CLAUDE_CODE_GITHUB_TOKEN_HYDRATED',
       hydrateGithubModelsTokenFromSecureStorage: () => {},
-      readGithubModelsToken: () => undefined,
-      readGithubModelsTokenAsync: async () => undefined,
+      readGithubModelsToken: () => storedToken,
+      readGithubModelsTokenAsync: async () => storedToken,
     }))
     mock.module('../utils/providerStartupOverrides.js', () => ({
       clearStartupProviderOverrides: () => null,
@@ -2308,9 +2311,11 @@ test('ProviderManager switches back to Anthropic via the manager UI: resets the 
       Object.keys(process.env).some(key => key.startsWith('CLAUDE_CODE_USE_')),
     ).toBe(false)
     expect(clearActiveProviderProfile).toHaveBeenCalled()
-    // The switch-back must also drop a hydrated GitHub Models token; assert the
-    // cleanup is wired so removing that call cannot pass unnoticed.
-    expect(clearHydratedGithubModelsTokenFromEnv).toHaveBeenCalled()
+    // The switch-back must forward the stored token into the cleanup helper so
+    // it clears only the hydrated secure-storage token and preserves a
+    // user-supplied GITHUB_TOKEN. Asserting the argument (not just the call)
+    // means the test fails if the branch stops forwarding the stored token.
+    expect(clearHydratedGithubModelsTokenFromEnv).toHaveBeenCalledWith(storedToken)
   } finally {
     if (mounted) {
       await mounted.dispose()

--- a/src/components/ProviderManager.test.tsx
+++ b/src/components/ProviderManager.test.tsx
@@ -2197,3 +2197,103 @@ test('ProviderManager hides Codex OAuth setup in bare mode', async () => {
   expect(output).toContain('Set up provider')
   expect(output).not.toContain('Codex OAuth')
 })
+
+test('ProviderManager switches back to Anthropic via the manager UI: resets the model and clears managed env', async () => {
+  // GitHub Models is the active provider with no saved profiles. Selecting the
+  // "Use Anthropic (built-in)" recovery option must reset the session model and
+  // drop the managed CLAUDE_CODE_USE_* flags. This is the production switch-back
+  // path; the existing util tests only cover the sentinel in isolation.
+  process.env.CLAUDE_CODE_USE_GITHUB = '1'
+  delete process.env.GITHUB_TOKEN
+  delete process.env.GH_TOKEN
+  delete process.env.CLAUDE_CODE_SIMPLE
+
+  // Capture the real providerProfiles module before any mock replaces it so the
+  // Anthropic sentinel id and preset helpers stay intact.
+  const realProviderProfiles = await import('../utils/providerProfiles.js')
+
+  const githubSyncRead = mock(() => undefined)
+  const githubAsyncRead = mock(async () => undefined)
+  mockProviderManagerDependencies(githubSyncRead, githubAsyncRead, {
+    getProviderProfiles: () => [],
+    getActiveProviderProfile: () => null,
+  })
+
+  const clearActiveProviderProfile = mock(() => {
+    for (const key of Object.keys(process.env)) {
+      if (key.startsWith('CLAUDE_CODE_USE_')) {
+        delete process.env[key]
+      }
+    }
+    return true
+  })
+  const clearHydratedGithubModelsTokenFromEnv = mock(() => {})
+
+  mock.module('../utils/providerProfiles.js', () => ({
+    ...realProviderProfiles,
+    applyActiveProviderProfileFromConfig: () => {},
+    getProviderProfiles: () => [],
+    getActiveProviderProfile: () => null,
+    setActiveProviderProfile: mock(() => null),
+    clearActiveProviderProfile,
+  }))
+  mock.module('../utils/githubModelsCredentials.js', () => ({
+    clearGithubModelsToken: () => ({ success: true }),
+    clearHydratedGithubModelsTokenFromEnv,
+    GITHUB_MODELS_HYDRATED_ENV_MARKER: 'CLAUDE_CODE_GITHUB_TOKEN_HYDRATED',
+    hydrateGithubModelsTokenFromSecureStorage: () => {},
+    readGithubModelsToken: () => undefined,
+    readGithubModelsTokenAsync: async () => undefined,
+  }))
+  mock.module('../utils/providerStartupOverrides.js', () => ({
+    clearStartupProviderOverrides: () => null,
+  }))
+
+  const onDoneResults: Array<Record<string, unknown>> = []
+  const nonce = `${Date.now()}-${Math.random()}`
+  const { ProviderManager } = await import(`./ProviderManager.js?ts=${nonce}`)
+  const mounted = await mountProviderManager(ProviderManager, {
+    onDone: result => {
+      if (result && typeof result === 'object') {
+        onDoneResults.push(result as Record<string, unknown>)
+      }
+    },
+  })
+
+  await waitForFrameOutput(
+    mounted.getOutput,
+    frame =>
+      frame.includes('Provider manager') &&
+      frame.includes('Set active provider'),
+  )
+
+  // Open "Set active provider" (second menu item).
+  mounted.stdin.write('j')
+  await Bun.sleep(25)
+  mounted.stdin.write('\r')
+
+  // Options here are [GitHub Models (active), Use Anthropic (built-in)]; move
+  // down to the switch-back option and select it.
+  await waitForFrameOutput(
+    mounted.getOutput,
+    frame => frame.includes('Use Anthropic (built-in)'),
+  )
+
+  mounted.stdin.write('j')
+  await Bun.sleep(25)
+  mounted.stdin.write('\r')
+
+  await waitForCondition(() => onDoneResults.length > 0)
+
+  const result = onDoneResults[0]
+  expect(result.action).toBe('activated')
+  expect(String(result.activeProviderName)).toMatch(/anthropic/i)
+  expect(typeof result.activeProviderModel).toBe('string')
+  expect((result.activeProviderModel as string).length).toBeGreaterThan(0)
+  expect(
+    Object.keys(process.env).some(key => key.startsWith('CLAUDE_CODE_USE_')),
+  ).toBe(false)
+  expect(clearActiveProviderProfile).toHaveBeenCalled()
+
+  await mounted.dispose()
+})

--- a/src/components/ProviderManager.tsx
+++ b/src/components/ProviderManager.tsx
@@ -64,6 +64,7 @@ import {
 import { getDefaultMainLoopModelSetting } from '../utils/model/model.js'
 import {
   clearGithubModelsToken,
+  clearHydratedGithubModelsTokenFromEnv,
   GITHUB_MODELS_HYDRATED_ENV_MARKER,
   hydrateGithubModelsTokenFromSecureStorage,
   readGithubModelsToken,
@@ -1233,6 +1234,12 @@ export function ProviderManager({ mode, onDone }: Props): React.ReactNode {
         // startup no longer replays a third-party profile, and keeps saved
         // profiles for later re-selection (#1426).
         clearActiveProviderProfile()
+        // clearActiveProviderProfile clears the managed provider flags (e.g.
+        // CLAUDE_CODE_USE_GITHUB) but not a GitHub Models token hydrated into the
+        // session from secure storage. Drop that hydrated token + marker so the
+        // built-in Anthropic session does not keep a GitHub credential around,
+        // mirroring the GitHub delete path; a user-supplied token is preserved.
+        clearHydratedGithubModelsTokenFromEnv(readGithubModelsToken())
         // Clear any startup provider override persisted in user settings
         // (CLAUDE_CODE_USE_OPENAI, OPENAI_BASE_URL, provider API keys, ...) so a
         // restart does not replay the third-party provider. The saved-profile

--- a/src/components/ProviderManager.tsx
+++ b/src/components/ProviderManager.tsx
@@ -49,7 +49,9 @@ import { openAIShimSupportsApiFormatForModel } from '../integrations/runtimeMeta
 import { probeRouteReadiness } from '../integrations/discoveryService.js'
 import {
   addProviderProfile,
+  ANTHROPIC_DEFAULT_PROFILE_ID,
   applyActiveProviderProfileFromConfig,
+  clearActiveProviderProfile,
   deleteProviderProfile,
   getActiveProviderProfile,
   getProviderPresetDefaults,
@@ -59,6 +61,7 @@ import {
   type ProviderProfileInput,
   updateProviderProfile,
 } from '../utils/providerProfiles.js'
+import { getDefaultMainLoopModelSetting } from '../utils/model/model.js'
 import {
   clearGithubModelsToken,
   GITHUB_MODELS_HYDRATED_ENV_MARKER,
@@ -214,6 +217,7 @@ const FORM_STEPS: Array<{
 
 const GITHUB_PROVIDER_ID = '__github_models__'
 const GITHUB_PROVIDER_LABEL = 'GitHub Models'
+const ANTHROPIC_PROVIDER_LABEL = 'Anthropic (built-in)'
 const GITHUB_PROVIDER_DEFAULT_MODEL = 'github:copilot'
 const GITHUB_PROVIDER_DEFAULT_BASE_URL = 'https://models.github.ai/inference'
 const CODEX_OAUTH_PROVIDER_NAME = 'Codex OAuth'
@@ -1217,6 +1221,32 @@ export function ProviderManager({ mode, onDone }: Props): React.ReactNode {
           activeProviderName: GITHUB_PROVIDER_LABEL,
           activeProviderModel: GITHUB_PROVIDER_DEFAULT_MODEL,
           message: `Provider switched to ${GITHUB_PROVIDER_LABEL} (${GITHUB_PROVIDER_DEFAULT_MODEL})`,
+        })
+        returnToMenu()
+        return
+      }
+
+      if (profileId === ANTHROPIC_DEFAULT_PROFILE_ID) {
+        providerLabel = ANTHROPIC_PROVIDER_LABEL
+        // Switch back to built-in Anthropic: clears the managed provider env so
+        // it takes effect this session, records the Anthropic sentinel so
+        // startup no longer replays a third-party profile, and keeps saved
+        // profiles for later re-selection (#1426).
+        clearActiveProviderProfile()
+        const anthropicModel = getPrimaryModel(getDefaultMainLoopModelSetting())
+        setAppState(prev => ({
+          ...prev,
+          mainLoopModel: anthropicModel,
+          mainLoopModelForSession: null,
+        }))
+        refreshProfiles()
+        setStatusMessage(`Active provider: ${ANTHROPIC_PROVIDER_LABEL}`)
+        setIsActivating(false)
+        onDone({
+          action: 'activated',
+          activeProviderName: ANTHROPIC_PROVIDER_LABEL,
+          activeProviderModel: anthropicModel,
+          message: `Provider switched to ${ANTHROPIC_PROVIDER_LABEL} (${anthropicModel})`,
         })
         returnToMenu()
         return
@@ -2305,9 +2335,10 @@ export function ProviderManager({ mode, onDone }: Props): React.ReactNode {
     title: string,
     emptyMessage: string,
     onSelect: (profileId: string) => void,
-    options?: { includeGithub?: boolean },
+    options?: { includeGithub?: boolean; includeAnthropic?: boolean },
   ): React.ReactNode {
     const includeGithub = options?.includeGithub ?? false
+    const includeAnthropic = options?.includeAnthropic ?? false
     const selectOptions = profiles.map(profile => ({
       value: profile.id,
       label:
@@ -2324,6 +2355,18 @@ export function ProviderManager({ mode, onDone }: Props): React.ReactNode {
           ? `${GITHUB_PROVIDER_LABEL} (active)`
           : GITHUB_PROVIDER_LABEL,
         description: `github-models · ${GITHUB_PROVIDER_DEFAULT_BASE_URL} · ${getGithubProviderModel()}`,
+      })
+    }
+
+    // Offer a way back to built-in Anthropic only when a third-party provider
+    // (saved profile or GitHub Models) is currently active — otherwise the user
+    // is already on Anthropic and the option is a no-op (#1426).
+    if (includeAnthropic && (activeProfileId || isGithubActive)) {
+      selectOptions.push({
+        value: ANTHROPIC_DEFAULT_PROFILE_ID,
+        label: 'Use Anthropic (built-in)',
+        description:
+          'Switch back to Claude now without a restart — saved profiles are kept',
       })
     }
 
@@ -2565,7 +2608,7 @@ export function ProviderManager({ mode, onDone }: Props): React.ReactNode {
         profileId => {
           void activateSelectedProvider(profileId)
         },
-        { includeGithub: true },
+        { includeGithub: true, includeAnthropic: true },
       )
       break
     case 'select-edit':

--- a/src/components/ProviderManager.tsx
+++ b/src/components/ProviderManager.tsx
@@ -1443,17 +1443,14 @@ export function ProviderManager({ mode, onDone }: Props): React.ReactNode {
       return error.message
     }
 
-    const hydratedTokenInSession = process.env.GITHUB_TOKEN?.trim()
-    if (
-      process.env[GITHUB_MODELS_HYDRATED_ENV_MARKER] === '1' &&
-      hydratedTokenInSession &&
-      (!storedTokenBeforeClear || hydratedTokenInSession === storedTokenBeforeClear)
-    ) {
-      delete process.env.GITHUB_TOKEN
-    }
-
     delete process.env.CLAUDE_CODE_USE_GITHUB
-    delete process.env[GITHUB_MODELS_HYDRATED_ENV_MARKER]
+    // Undo any GitHub Models token hydrated into the session from secure
+    // storage and drop the marker. Use the shared helper so both hydration
+    // modes are reverted: GITHUB_TOKEN and the copilot_key blob's
+    // GITHUB_COPILOT_KEY. The old hand-rolled cleanup here only cleared
+    // GITHUB_TOKEN, leaving a hydrated Copilot key behind after the marker was
+    // removed. A user-supplied token is preserved.
+    clearHydratedGithubModelsTokenFromEnv(storedTokenBeforeClear)
     delete process.env.OPENAI_MODEL
     delete process.env.OPENAI_API_KEYS
     delete process.env.OPENAI_API_KEY

--- a/src/components/ProviderManager.tsx
+++ b/src/components/ProviderManager.tsx
@@ -1233,6 +1233,12 @@ export function ProviderManager({ mode, onDone }: Props): React.ReactNode {
         // startup no longer replays a third-party profile, and keeps saved
         // profiles for later re-selection (#1426).
         clearActiveProviderProfile()
+        // Clear any startup provider override persisted in user settings
+        // (CLAUDE_CODE_USE_OPENAI, OPENAI_BASE_URL, provider API keys, ...) so a
+        // restart does not replay the third-party provider. The saved-profile
+        // and GitHub activation paths perform the same cleanup; surface any
+        // failure as a warning the same way the saved-profile path does.
+        const settingsOverrideError = clearStartupProviderOverrideFromUserSettings()
         const anthropicModel = getPrimaryModel(getDefaultMainLoopModelSetting())
         setAppState(prev => ({
           ...prev,
@@ -1240,13 +1246,19 @@ export function ProviderManager({ mode, onDone }: Props): React.ReactNode {
           mainLoopModelForSession: null,
         }))
         refreshProfiles()
-        setStatusMessage(`Active provider: ${ANTHROPIC_PROVIDER_LABEL}`)
+        setStatusMessage(
+          settingsOverrideError
+            ? `Active provider: ${ANTHROPIC_PROVIDER_LABEL}. Warning: could not clear startup provider override (${settingsOverrideError}).`
+            : `Active provider: ${ANTHROPIC_PROVIDER_LABEL}`,
+        )
         setIsActivating(false)
         onDone({
           action: 'activated',
           activeProviderName: ANTHROPIC_PROVIDER_LABEL,
           activeProviderModel: anthropicModel,
-          message: `Provider switched to ${ANTHROPIC_PROVIDER_LABEL} (${anthropicModel})`,
+          message: settingsOverrideError
+            ? `Provider switched to ${ANTHROPIC_PROVIDER_LABEL} (${anthropicModel}). Warning: could not clear startup provider override (${settingsOverrideError}).`
+            : `Provider switched to ${ANTHROPIC_PROVIDER_LABEL} (${anthropicModel})`,
         })
         returnToMenu()
         return

--- a/src/components/ProviderManager.tsx
+++ b/src/components/ProviderManager.tsx
@@ -819,6 +819,15 @@ export function ProviderManager({ mode, onDone }: Props): React.ReactNode {
   // array reference, causing Select to re-render and feel sluggish.
   const hasProfiles = profiles.length > 0
   const hasSelectableProviders = hasProfiles || githubProviderAvailable
+  // A non-Anthropic provider (a saved profile or GitHub Models) is currently
+  // active. The switch-back-to-Anthropic recovery option must stay reachable
+  // in that case even when no profiles are saved and GitHub credentials have
+  // gone away (cleared storage / removed env token); otherwise the user is
+  // stranded on an unusable provider with no way back. Scoped to the activate
+  // path only — edit/delete still require an actual profile.
+  const isNonAnthropicProviderActive = isGithubActive || activeProfileId != null
+  const canSwitchActiveProvider =
+    hasSelectableProviders || isNonAnthropicProviderActive
   const menuOptions = React.useMemo(
     () => [
       {
@@ -830,7 +839,7 @@ export function ProviderManager({ mode, onDone }: Props): React.ReactNode {
         value: 'activate',
         label: 'Set active provider',
         description: 'Switch the active provider profile',
-        disabled: !hasSelectableProviders,
+        disabled: !canSwitchActiveProvider,
       },
       {
         value: 'edit',
@@ -870,6 +879,7 @@ export function ProviderManager({ mode, onDone }: Props): React.ReactNode {
     ],
     [
       hasSelectableProviders,
+      canSwitchActiveProvider,
       hasProfiles,
       hasStoredCodexOAuthCredentials,
       hasStoredXaiOAuthCredentials,
@@ -2196,6 +2206,8 @@ export function ProviderManager({ mode, onDone }: Props): React.ReactNode {
     // Use memoized menuOptions from component scope
     const hasProfiles = profiles.length > 0
     const hasSelectableProviders = hasProfiles || githubProviderAvailable
+    const canSwitchActiveProvider =
+      hasSelectableProviders || isGithubActive || activeProfileId != null
 
     return (
       <Box flexDirection="column" gap={1}>
@@ -2241,7 +2253,7 @@ export function ProviderManager({ mode, onDone }: Props): React.ReactNode {
                 setScreen('select-preset')
                 break
               case 'activate':
-                if (hasSelectableProviders) {
+                if (canSwitchActiveProvider) {
                   setScreen('select-active')
                 }
                 break

--- a/src/components/ProviderManager.tsx
+++ b/src/components/ProviderManager.tsx
@@ -2206,8 +2206,8 @@ export function ProviderManager({ mode, onDone }: Props): React.ReactNode {
     // Use memoized menuOptions from component scope
     const hasProfiles = profiles.length > 0
     const hasSelectableProviders = hasProfiles || githubProviderAvailable
-    const canSwitchActiveProvider =
-      hasSelectableProviders || isGithubActive || activeProfileId != null
+    // canSwitchActiveProvider is derived once in the component body; reuse it
+    // here rather than recomputing so the two sites cannot drift.
 
     return (
       <Box flexDirection="column" gap={1}>

--- a/src/utils/githubModelsCredentials.test.ts
+++ b/src/utils/githubModelsCredentials.test.ts
@@ -62,3 +62,67 @@ describe('saveGithubModelsToken / clearGithubModelsToken', () => {
     expect(clearGithubModelsToken().success).toBe(true)
   })
 })
+
+describe('clearHydratedGithubModelsTokenFromEnv', () => {
+  test('drops a hydrated token that matches secure storage, with its marker', async () => {
+    const { clearHydratedGithubModelsTokenFromEnv, GITHUB_MODELS_HYDRATED_ENV_MARKER } =
+      await importFreshGithubModelsCredentials('clear-hydrated-match')
+
+    process.env[GITHUB_MODELS_HYDRATED_ENV_MARKER] = '1'
+    process.env.GITHUB_TOKEN = 'stored-tok'
+    try {
+      clearHydratedGithubModelsTokenFromEnv('stored-tok')
+      expect(process.env.GITHUB_TOKEN).toBeUndefined()
+      expect(process.env[GITHUB_MODELS_HYDRATED_ENV_MARKER]).toBeUndefined()
+    } finally {
+      delete process.env.GITHUB_TOKEN
+      delete process.env[GITHUB_MODELS_HYDRATED_ENV_MARKER]
+    }
+  })
+
+  test('preserves a user-supplied token that differs from secure storage', async () => {
+    const { clearHydratedGithubModelsTokenFromEnv, GITHUB_MODELS_HYDRATED_ENV_MARKER } =
+      await importFreshGithubModelsCredentials('clear-hydrated-user')
+
+    process.env[GITHUB_MODELS_HYDRATED_ENV_MARKER] = '1'
+    process.env.GITHUB_TOKEN = 'user-supplied'
+    try {
+      clearHydratedGithubModelsTokenFromEnv('stored-tok')
+      expect(process.env.GITHUB_TOKEN).toBe('user-supplied')
+      expect(process.env[GITHUB_MODELS_HYDRATED_ENV_MARKER]).toBeUndefined()
+    } finally {
+      delete process.env.GITHUB_TOKEN
+      delete process.env[GITHUB_MODELS_HYDRATED_ENV_MARKER]
+    }
+  })
+
+  test('drops the token when secure storage is empty but the marker is set', async () => {
+    const { clearHydratedGithubModelsTokenFromEnv, GITHUB_MODELS_HYDRATED_ENV_MARKER } =
+      await importFreshGithubModelsCredentials('clear-hydrated-nostore')
+
+    process.env[GITHUB_MODELS_HYDRATED_ENV_MARKER] = '1'
+    process.env.GITHUB_TOKEN = 'hydrated-tok'
+    try {
+      clearHydratedGithubModelsTokenFromEnv(undefined)
+      expect(process.env.GITHUB_TOKEN).toBeUndefined()
+      expect(process.env[GITHUB_MODELS_HYDRATED_ENV_MARKER]).toBeUndefined()
+    } finally {
+      delete process.env.GITHUB_TOKEN
+      delete process.env[GITHUB_MODELS_HYDRATED_ENV_MARKER]
+    }
+  })
+
+  test('is a no-op when the hydration marker is absent', async () => {
+    const { clearHydratedGithubModelsTokenFromEnv, GITHUB_MODELS_HYDRATED_ENV_MARKER } =
+      await importFreshGithubModelsCredentials('clear-hydrated-nomarker')
+
+    delete process.env[GITHUB_MODELS_HYDRATED_ENV_MARKER]
+    process.env.GITHUB_TOKEN = 'untouched'
+    try {
+      clearHydratedGithubModelsTokenFromEnv('stored-tok')
+      expect(process.env.GITHUB_TOKEN).toBe('untouched')
+    } finally {
+      delete process.env.GITHUB_TOKEN
+    }
+  })
+})

--- a/src/utils/githubModelsCredentials.test.ts
+++ b/src/utils/githubModelsCredentials.test.ts
@@ -125,4 +125,36 @@ describe('clearHydratedGithubModelsTokenFromEnv', () => {
       delete process.env.GITHUB_TOKEN
     }
   })
+
+  test('drops a hydrated Copilot key that matches secure storage, with its marker', async () => {
+    const { clearHydratedGithubModelsTokenFromEnv, GITHUB_MODELS_HYDRATED_ENV_MARKER } =
+      await importFreshGithubModelsCredentials('clear-hydrated-copilot-match')
+
+    process.env[GITHUB_MODELS_HYDRATED_ENV_MARKER] = '1'
+    process.env.GITHUB_COPILOT_KEY = 'stored-key'
+    try {
+      clearHydratedGithubModelsTokenFromEnv('stored-key')
+      expect(process.env.GITHUB_COPILOT_KEY).toBeUndefined()
+      expect(process.env[GITHUB_MODELS_HYDRATED_ENV_MARKER]).toBeUndefined()
+    } finally {
+      delete process.env.GITHUB_COPILOT_KEY
+      delete process.env[GITHUB_MODELS_HYDRATED_ENV_MARKER]
+    }
+  })
+
+  test('preserves a user-supplied Copilot key that differs from secure storage', async () => {
+    const { clearHydratedGithubModelsTokenFromEnv, GITHUB_MODELS_HYDRATED_ENV_MARKER } =
+      await importFreshGithubModelsCredentials('clear-hydrated-copilot-user')
+
+    process.env[GITHUB_MODELS_HYDRATED_ENV_MARKER] = '1'
+    process.env.GITHUB_COPILOT_KEY = 'user-supplied'
+    try {
+      clearHydratedGithubModelsTokenFromEnv('stored-key')
+      expect(process.env.GITHUB_COPILOT_KEY).toBe('user-supplied')
+      expect(process.env[GITHUB_MODELS_HYDRATED_ENV_MARKER]).toBeUndefined()
+    } finally {
+      delete process.env.GITHUB_COPILOT_KEY
+      delete process.env[GITHUB_MODELS_HYDRATED_ENV_MARKER]
+    }
+  })
 })

--- a/src/utils/githubModelsCredentials.ts
+++ b/src/utils/githubModelsCredentials.ts
@@ -122,9 +122,10 @@ export function hydrateGithubModelsTokenFromSecureStorage(): void {
 
 /**
  * Undo {@link hydrateGithubModelsTokenFromSecureStorage} for the current
- * session: drop a `GITHUB_TOKEN` that was hydrated from secure storage along
- * with its marker. A user-supplied `GITHUB_TOKEN` — one that does not match the
- * stored credential — is preserved. No-op when the hydration marker is absent.
+ * session: drop a `GITHUB_TOKEN` (or, for a `copilot_key` blob, a
+ * `GITHUB_COPILOT_KEY`) that was hydrated from secure storage along with its
+ * marker. A user-supplied value — one that does not match the stored
+ * credential — is preserved. No-op when the hydration marker is absent.
  *
  * `storedToken` is the secure-storage credential, passed in so callers control
  * whether it is read before or after they clear it (the delete path reads it
@@ -138,6 +139,17 @@ export function clearHydratedGithubModelsTokenFromEnv(storedToken?: string): voi
   const sessionToken = process.env.GITHUB_TOKEN?.trim()
   if (sessionToken && (!normalizedStored || sessionToken === normalizedStored)) {
     delete process.env.GITHUB_TOKEN
+  }
+  // Hydration has two modes (see hydrateGithubModelsTokenFromSecureStorage): a
+  // `copilot_key` blob populates GITHUB_COPILOT_KEY instead of GITHUB_TOKEN.
+  // Undo that branch symmetrically, otherwise the marker is removed while the
+  // hydrated Copilot key is left behind in the session.
+  const sessionCopilotKey = process.env.GITHUB_COPILOT_KEY?.trim()
+  if (
+    sessionCopilotKey &&
+    (!normalizedStored || sessionCopilotKey === normalizedStored)
+  ) {
+    delete process.env.GITHUB_COPILOT_KEY
   }
   delete process.env[GITHUB_MODELS_HYDRATED_ENV_MARKER]
 }

--- a/src/utils/githubModelsCredentials.ts
+++ b/src/utils/githubModelsCredentials.ts
@@ -121,6 +121,28 @@ export function hydrateGithubModelsTokenFromSecureStorage(): void {
 }
 
 /**
+ * Undo {@link hydrateGithubModelsTokenFromSecureStorage} for the current
+ * session: drop a `GITHUB_TOKEN` that was hydrated from secure storage along
+ * with its marker. A user-supplied `GITHUB_TOKEN` — one that does not match the
+ * stored credential — is preserved. No-op when the hydration marker is absent.
+ *
+ * `storedToken` is the secure-storage credential, passed in so callers control
+ * whether it is read before or after they clear it (the delete path reads it
+ * before clearing; the switch-to-Anthropic path leaves it in place).
+ */
+export function clearHydratedGithubModelsTokenFromEnv(storedToken?: string): void {
+  if (process.env[GITHUB_MODELS_HYDRATED_ENV_MARKER] !== '1') {
+    return
+  }
+  const normalizedStored = storedToken?.trim()
+  const sessionToken = process.env.GITHUB_TOKEN?.trim()
+  if (sessionToken && (!normalizedStored || sessionToken === normalizedStored)) {
+    delete process.env.GITHUB_TOKEN
+  }
+  delete process.env[GITHUB_MODELS_HYDRATED_ENV_MARKER]
+}
+
+/**
  * Startup auto-refresh for GitHub Models mode.
  *
  * If a stored Copilot token is expired/invalid and an OAuth token is present,

--- a/src/utils/providerProfiles.test.ts
+++ b/src/utils/providerProfiles.test.ts
@@ -1194,6 +1194,61 @@ describe('getProviderProfiles', () => {
   })
 })
 
+describe('clearActiveProviderProfile', () => {
+  test('returns undefined active profile while preserving saved profiles (#1426)', async () => {
+    const {
+      getActiveProviderProfile,
+      clearActiveProviderProfile,
+      getProviderProfiles,
+      ANTHROPIC_DEFAULT_PROFILE_ID,
+    } = await importFreshProviderProfileModules()
+
+    saveMockGlobalConfig(current => ({
+      ...current,
+      providerProfiles: [
+        buildProfile({ id: 'saved_deepseek', name: 'DeepSeek' }),
+      ],
+      activeProviderProfileId: 'saved_deepseek',
+    }))
+
+    expect(getActiveProviderProfile()?.id).toBe('saved_deepseek')
+
+    const hadActive = clearActiveProviderProfile()
+
+    expect(hadActive).toBe(true)
+    expect(mockConfigState.activeProviderProfileId).toBe(
+      ANTHROPIC_DEFAULT_PROFILE_ID,
+    )
+    // Falls back to Anthropic, NOT to profiles[0].
+    expect(getActiveProviderProfile()).toBeUndefined()
+    // Saved profiles remain for later re-selection.
+    expect(getProviderProfiles()).toHaveLength(1)
+  })
+
+  test('clears managed provider env from the current session', async () => {
+    const { clearActiveProviderProfile } =
+      await importFreshProviderProfileModules()
+
+    process.env.CLAUDE_CODE_PROVIDER_PROFILE_ENV_APPLIED = '1'
+    process.env.CLAUDE_CODE_PROVIDER_PROFILE_ENV_APPLIED_ID = 'saved_deepseek'
+
+    saveMockGlobalConfig(current => ({
+      ...current,
+      providerProfiles: [buildProfile({ id: 'saved_deepseek' })],
+      activeProviderProfileId: 'saved_deepseek',
+    }))
+
+    clearActiveProviderProfile()
+
+    expect(
+      process.env.CLAUDE_CODE_PROVIDER_PROFILE_ENV_APPLIED,
+    ).toBeUndefined()
+    expect(
+      process.env.CLAUDE_CODE_PROVIDER_PROFILE_ENV_APPLIED_ID,
+    ).toBeUndefined()
+  })
+})
+
 describe('applyActiveProviderProfileFromConfig', () => {
   test('does not override explicit startup provider selection', async () => {
     const { applyActiveProviderProfileFromConfig } =

--- a/src/utils/providerProfiles.test.ts
+++ b/src/utils/providerProfiles.test.ts
@@ -1813,43 +1813,72 @@ describe('applyActiveProviderProfileFromConfig', () => {
     const { buildStartupEnvFromProfile, DEFAULT_STARTUP_PROVIDER_ENV_VAR } =
       await import(`./providerProfile.js?ts=${Date.now()}-${Math.random()}`)
 
-    // No explicit provider selection in the environment (cold start).
-    delete process.env.CLAUDE_CODE_USE_OPENAI
-    delete process.env.CLAUDE_CODE_USE_GITHUB
-    delete process.env.OPENAI_BASE_URL
-    delete process.env.OPENAI_MODEL
-    delete process.env.CLAUDE_CODE_PROVIDER_PROFILE_ENV_APPLIED
-    delete process.env.CLAUDE_CODE_PROVIDER_PROFILE_ENV_APPLIED_ID
-
-    const applied = applyActiveProviderProfileFromConfig({
-      providerProfiles: [
-        buildProfile({
-          id: 'saved_openai',
-          baseUrl: 'https://api.openai.com/v1',
-          model: 'gpt-4o',
-        }),
-      ],
-      activeProviderProfileId: ANTHROPIC_DEFAULT_PROFILE_ID,
-    } as any)
-
-    // Built-in Anthropic resolves to no profile, but env is now marked handled
-    // and carries no third-party provider selection.
-    expect(applied).toBeUndefined()
-    expect(String(process.env.CLAUDE_CODE_PROVIDER_PROFILE_ENV_APPLIED)).toBe('1')
-    expect(process.env.OPENAI_BASE_URL).toBeUndefined()
-    expect(process.env.CLAUDE_CODE_USE_OPENAI).toBeUndefined()
-
-    // The deleted profile mirror (persisted: null) must NOT be treated as a
-    // fresh install, so no OpenGateway default is synthesized.
-    const startupEnv = await buildStartupEnvFromProfile({
-      persisted: null,
-      processEnv: process.env,
-    })
-    expect(startupEnv[DEFAULT_STARTUP_PROVIDER_ENV_VAR]).not.toBe(
-      'gitlawb-opengateway',
+    // Cold start with a fully isolated env. applyActiveProviderProfileFromConfig
+    // and buildStartupEnvFromProfile treat ANY CLAUDE_CODE_USE_* flag (OpenAI,
+    // GitHub, Gemini, Mistral, Bedrock, Vertex, Foundry) as an explicit provider
+    // selection, so an inherited flag would route this case down a different
+    // path and hide the sentinel regression. Snapshot every provider key, clear
+    // them all, and restore in finally so the test neither leaks nor depends on
+    // ambient env.
+    const providerEnvKeys = [
+      'CLAUDE_CODE_USE_OPENAI',
+      'CLAUDE_CODE_USE_GITHUB',
+      'CLAUDE_CODE_USE_GEMINI',
+      'CLAUDE_CODE_USE_MISTRAL',
+      'CLAUDE_CODE_USE_BEDROCK',
+      'CLAUDE_CODE_USE_VERTEX',
+      'CLAUDE_CODE_USE_FOUNDRY',
+      'OPENAI_BASE_URL',
+      'OPENAI_MODEL',
+      'CLAUDE_CODE_PROVIDER_PROFILE_ENV_APPLIED',
+      'CLAUDE_CODE_PROVIDER_PROFILE_ENV_APPLIED_ID',
+    ]
+    const providerEnvSnapshot = new Map(
+      providerEnvKeys.map(key => [key, process.env[key]] as const),
     )
-    expect(startupEnv.CLAUDE_CODE_USE_OPENAI).toBeUndefined()
-    expect(startupEnv.OPENAI_BASE_URL).toBeUndefined()
+    for (const key of providerEnvKeys) {
+      delete process.env[key]
+    }
+
+    try {
+      const applied = applyActiveProviderProfileFromConfig({
+        providerProfiles: [
+          buildProfile({
+            id: 'saved_openai',
+            baseUrl: 'https://api.openai.com/v1',
+            model: 'gpt-4o',
+          }),
+        ],
+        activeProviderProfileId: ANTHROPIC_DEFAULT_PROFILE_ID,
+      } as any)
+
+      // Built-in Anthropic resolves to no profile, but env is now marked handled
+      // and carries no third-party provider selection.
+      expect(applied).toBeUndefined()
+      expect(String(process.env.CLAUDE_CODE_PROVIDER_PROFILE_ENV_APPLIED)).toBe('1')
+      expect(process.env.OPENAI_BASE_URL).toBeUndefined()
+      expect(process.env.CLAUDE_CODE_USE_OPENAI).toBeUndefined()
+
+      // The deleted profile mirror (persisted: null) must NOT be treated as a
+      // fresh install, so no OpenGateway default is synthesized.
+      const startupEnv = await buildStartupEnvFromProfile({
+        persisted: null,
+        processEnv: process.env,
+      })
+      expect(startupEnv[DEFAULT_STARTUP_PROVIDER_ENV_VAR]).not.toBe(
+        'gitlawb-opengateway',
+      )
+      expect(startupEnv.CLAUDE_CODE_USE_OPENAI).toBeUndefined()
+      expect(startupEnv.OPENAI_BASE_URL).toBeUndefined()
+    } finally {
+      for (const [key, value] of providerEnvSnapshot) {
+        if (value === undefined) {
+          delete process.env[key]
+        } else {
+          process.env[key] = value
+        }
+      }
+    }
   })
 })
 

--- a/src/utils/providerProfiles.test.ts
+++ b/src/utils/providerProfiles.test.ts
@@ -1314,6 +1314,33 @@ describe('Anthropic sentinel survives profile management (#1426)', () => {
     expect(getActiveProviderProfile()?.id).toBe('saved_one')
   })
 
+  test('addProviderProfile with makeActive:false keeps the resolved first profile active when the active id is stale', async () => {
+    const { addProviderProfile, getActiveProviderProfile } =
+      await importFreshProviderProfileModules()
+
+    // activeProviderProfileId points at a profile that no longer exists.
+    // getActiveProviderProfile resolves a stale id to the first profile, so
+    // adding another with makeActive:false must keep that first profile active
+    // rather than promoting the new one (#1426).
+    saveMockGlobalConfig(current => ({
+      ...current,
+      providerProfiles: [buildProfile({ id: 'saved_one', name: 'Saved One' })],
+      activeProviderProfileId: 'deleted_profile_id',
+    }))
+
+    addProviderProfile(
+      {
+        provider: 'openai',
+        name: 'Saved Two',
+        baseUrl: 'https://api.openai.com/v1',
+        model: 'gpt-4o',
+      },
+      { makeActive: false },
+    )
+
+    expect(getActiveProviderProfile()?.id).toBe('saved_one')
+  })
+
   test('updateProviderProfile of a non-active profile keeps the Anthropic sentinel active', async () => {
     const {
       updateProviderProfile,

--- a/src/utils/providerProfiles.test.ts
+++ b/src/utils/providerProfiles.test.ts
@@ -1799,6 +1799,58 @@ describe('applyActiveProviderProfileFromConfig', () => {
     } as any).find((profile: ProviderProfile) => profile.id === activeProfile.id)
     expect(saved?.model).toBe('glm-5.2')
   })
+
+  test('cold start on the Anthropic sentinel stays on built-in Anthropic and does not fall back to the OpenGateway default (#1429)', async () => {
+    // Regression: after clearActiveProviderProfile() records the Anthropic
+    // sentinel and deletes the startup profile mirror, a restart must keep the
+    // user on built-in Anthropic. Previously applyActiveProviderProfileFromConfig()
+    // returned without marking provider env as handled (the sentinel resolves to
+    // no profile), so buildStartupEnvFromProfile() saw the missing mirror as a
+    // fresh install and synthesized the default Gitlawb OpenGateway env —
+    // silently moving the user back onto a third-party provider.
+    const { applyActiveProviderProfileFromConfig, ANTHROPIC_DEFAULT_PROFILE_ID } =
+      await importFreshProviderProfileModules()
+    const { buildStartupEnvFromProfile, DEFAULT_STARTUP_PROVIDER_ENV_VAR } =
+      await import(`./providerProfile.js?ts=${Date.now()}-${Math.random()}`)
+
+    // No explicit provider selection in the environment (cold start).
+    delete process.env.CLAUDE_CODE_USE_OPENAI
+    delete process.env.CLAUDE_CODE_USE_GITHUB
+    delete process.env.OPENAI_BASE_URL
+    delete process.env.OPENAI_MODEL
+    delete process.env.CLAUDE_CODE_PROVIDER_PROFILE_ENV_APPLIED
+    delete process.env.CLAUDE_CODE_PROVIDER_PROFILE_ENV_APPLIED_ID
+
+    const applied = applyActiveProviderProfileFromConfig({
+      providerProfiles: [
+        buildProfile({
+          id: 'saved_openai',
+          baseUrl: 'https://api.openai.com/v1',
+          model: 'gpt-4o',
+        }),
+      ],
+      activeProviderProfileId: ANTHROPIC_DEFAULT_PROFILE_ID,
+    } as any)
+
+    // Built-in Anthropic resolves to no profile, but env is now marked handled
+    // and carries no third-party provider selection.
+    expect(applied).toBeUndefined()
+    expect(String(process.env.CLAUDE_CODE_PROVIDER_PROFILE_ENV_APPLIED)).toBe('1')
+    expect(process.env.OPENAI_BASE_URL).toBeUndefined()
+    expect(process.env.CLAUDE_CODE_USE_OPENAI).toBeUndefined()
+
+    // The deleted profile mirror (persisted: null) must NOT be treated as a
+    // fresh install, so no OpenGateway default is synthesized.
+    const startupEnv = await buildStartupEnvFromProfile({
+      persisted: null,
+      processEnv: process.env,
+    })
+    expect(startupEnv[DEFAULT_STARTUP_PROVIDER_ENV_VAR]).not.toBe(
+      'gitlawb-opengateway',
+    )
+    expect(startupEnv.CLAUDE_CODE_USE_OPENAI).toBeUndefined()
+    expect(startupEnv.OPENAI_BASE_URL).toBeUndefined()
+  })
 })
 
 describe('persistActiveProviderProfileModel', () => {

--- a/src/utils/providerProfiles.test.ts
+++ b/src/utils/providerProfiles.test.ts
@@ -1288,6 +1288,32 @@ describe('Anthropic sentinel survives profile management (#1426)', () => {
     expect(getActiveProviderProfile()).toBeUndefined()
   })
 
+  test('addProviderProfile with makeActive:false keeps the implicit first profile active when no active id is set', async () => {
+    const { addProviderProfile, getActiveProviderProfile } =
+      await importFreshProviderProfileModules()
+
+    // activeProviderProfileId unset, but a saved profile exists. getActiveProviderProfile
+    // implicitly resolves this to the first profile, so adding another with
+    // makeActive:false must not silently promote the new one.
+    saveMockGlobalConfig(current => ({
+      ...current,
+      providerProfiles: [buildProfile({ id: 'saved_one', name: 'Saved One' })],
+      activeProviderProfileId: undefined,
+    }))
+
+    addProviderProfile(
+      {
+        provider: 'openai',
+        name: 'Saved Two',
+        baseUrl: 'https://api.openai.com/v1',
+        model: 'gpt-4o',
+      },
+      { makeActive: false },
+    )
+
+    expect(getActiveProviderProfile()?.id).toBe('saved_one')
+  })
+
   test('updateProviderProfile of a non-active profile keeps the Anthropic sentinel active', async () => {
     const {
       updateProviderProfile,

--- a/src/utils/providerProfiles.test.ts
+++ b/src/utils/providerProfiles.test.ts
@@ -1249,6 +1249,90 @@ describe('clearActiveProviderProfile', () => {
   })
 })
 
+describe('Anthropic sentinel survives profile management (#1426)', () => {
+  test('addProviderProfile with makeActive:false keeps the Anthropic sentinel active', async () => {
+    const {
+      addProviderProfile,
+      getActiveProviderProfile,
+      ANTHROPIC_DEFAULT_PROFILE_ID,
+    } = await importFreshProviderProfileModules()
+
+    saveMockGlobalConfig(current => ({
+      ...current,
+      providerProfiles: [buildProfile({ id: 'saved_one', name: 'Saved One' })],
+      activeProviderProfileId: ANTHROPIC_DEFAULT_PROFILE_ID,
+    }))
+
+    addProviderProfile(
+      {
+        provider: 'openai',
+        name: 'Saved Two',
+        baseUrl: 'https://api.openai.com/v1',
+        model: 'gpt-4o',
+      },
+      { makeActive: false },
+    )
+
+    expect(mockConfigState.activeProviderProfileId).toBe(
+      ANTHROPIC_DEFAULT_PROFILE_ID,
+    )
+    expect(getActiveProviderProfile()).toBeUndefined()
+  })
+
+  test('updateProviderProfile of a non-active profile keeps the Anthropic sentinel active', async () => {
+    const {
+      updateProviderProfile,
+      getActiveProviderProfile,
+      ANTHROPIC_DEFAULT_PROFILE_ID,
+    } = await importFreshProviderProfileModules()
+
+    saveMockGlobalConfig(current => ({
+      ...current,
+      providerProfiles: [buildProfile({ id: 'saved_one', name: 'Saved One' })],
+      activeProviderProfileId: ANTHROPIC_DEFAULT_PROFILE_ID,
+    }))
+
+    updateProviderProfile('saved_one', {
+      provider: 'openai',
+      name: 'Saved One Renamed',
+      baseUrl: 'https://api.openai.com/v1',
+      model: 'gpt-4o',
+    })
+
+    expect(mockConfigState.activeProviderProfileId).toBe(
+      ANTHROPIC_DEFAULT_PROFILE_ID,
+    )
+    expect(getActiveProviderProfile()).toBeUndefined()
+  })
+
+  test('deleteProviderProfile of an inactive profile keeps the Anthropic sentinel active', async () => {
+    const {
+      deleteProviderProfile,
+      getActiveProviderProfile,
+      getProviderProfiles,
+      ANTHROPIC_DEFAULT_PROFILE_ID,
+    } = await importFreshProviderProfileModules()
+
+    saveMockGlobalConfig(current => ({
+      ...current,
+      providerProfiles: [
+        buildProfile({ id: 'saved_one', name: 'Saved One' }),
+        buildProfile({ id: 'saved_two', name: 'Saved Two' }),
+      ],
+      activeProviderProfileId: ANTHROPIC_DEFAULT_PROFILE_ID,
+    }))
+
+    const result = deleteProviderProfile('saved_one')
+
+    expect(result.removed).toBe(true)
+    expect(mockConfigState.activeProviderProfileId).toBe(
+      ANTHROPIC_DEFAULT_PROFILE_ID,
+    )
+    expect(getActiveProviderProfile()).toBeUndefined()
+    expect(getProviderProfiles()).toHaveLength(1)
+  })
+})
+
 describe('applyActiveProviderProfileFromConfig', () => {
   test('does not override explicit startup provider selection', async () => {
     const { applyActiveProviderProfileFromConfig } =

--- a/src/utils/providerProfiles.test.ts
+++ b/src/utils/providerProfiles.test.ts
@@ -1231,6 +1231,10 @@ describe('clearActiveProviderProfile', () => {
 
     process.env.CLAUDE_CODE_PROVIDER_PROFILE_ENV_APPLIED = '1'
     process.env.CLAUDE_CODE_PROVIDER_PROFILE_ENV_APPLIED_ID = 'saved_deepseek'
+    // Managed provider env that a third-party profile would have applied.
+    process.env.CLAUDE_CODE_USE_OPENAI = '1'
+    process.env.OPENAI_BASE_URL = 'https://api.deepseek.com'
+    process.env.OPENAI_API_KEY = 'sk-test'
 
     saveMockGlobalConfig(current => ({
       ...current,
@@ -1246,6 +1250,11 @@ describe('clearActiveProviderProfile', () => {
     expect(
       process.env.CLAUDE_CODE_PROVIDER_PROFILE_ENV_APPLIED_ID,
     ).toBeUndefined()
+    // The managed provider env itself must be gone too, otherwise the switch
+    // back to Anthropic would not take effect for the current session.
+    expect(process.env.CLAUDE_CODE_USE_OPENAI).toBeUndefined()
+    expect(process.env.OPENAI_BASE_URL).toBeUndefined()
+    expect(process.env.OPENAI_API_KEY).toBeUndefined()
   })
 })
 

--- a/src/utils/providerProfiles.ts
+++ b/src/utils/providerProfiles.ts
@@ -28,6 +28,7 @@ import {
   buildAtlasCloudProfileEnv,
   buildVertexProfileEnv,
   clearManagedProfileEnv,
+  deleteProfileFile,
   type ProfileFileLocation,
   type ProfileEnv,
   type ProviderProfile as ProviderProfileStartup,
@@ -717,6 +718,16 @@ function isProcessEnvAlignedWithProfile(
   )
 }
 
+/**
+ * Sentinel `activeProviderProfileId` meaning "use built-in Anthropic", kept
+ * distinct from `undefined`. Without it, clearing the active id falls through
+ * to `profiles[0]` (see below), so a user with any saved third-party profile
+ * could never return to Anthropic from `/provider` without hand-editing
+ * `~/.openclaude.json` and restarting (#1426). Storing the sentinel preserves
+ * the saved profiles for re-selection while expressing "no third-party active".
+ */
+export const ANTHROPIC_DEFAULT_PROFILE_ID = '__anthropic_default__'
+
 export function getActiveProviderProfile(
   config = getGlobalConfig(),
 ): ProviderProfile | undefined {
@@ -726,7 +737,35 @@ export function getActiveProviderProfile(
   }
 
   const activeId = trimOrUndefined(config.activeProviderProfileId)
+  // Explicit Anthropic selection: do not fall back to the first saved profile.
+  if (activeId === ANTHROPIC_DEFAULT_PROFILE_ID) {
+    return undefined
+  }
   return profiles.find(profile => profile.id === activeId) ?? profiles[0]
+}
+
+/**
+ * Switch back to built-in Anthropic while keeping saved provider profiles.
+ * Clears the managed env this session (so the switch takes effect without a
+ * restart), records the Anthropic sentinel as the active id (so startup no
+ * longer replays a third-party profile), and removes the startup profile
+ * mirror file. Returns false when there was nothing to clear.
+ */
+export function clearActiveProviderProfile(
+  options?: ProfileFileLocation,
+): boolean {
+  const hadActiveProfile = getActiveProviderProfile() !== undefined
+
+  saveGlobalConfig(config => ({
+    ...config,
+    activeProviderProfileId: ANTHROPIC_DEFAULT_PROFILE_ID,
+    openaiAdditionalModelOptionsCache: [],
+  }))
+
+  clearProviderProfileEnvFromProcessEnv()
+  deleteProfileFile(options)
+
+  return hadActiveProfile
 }
 
 export function clearProviderProfileEnvFromProcessEnv(

--- a/src/utils/providerProfiles.ts
+++ b/src/utils/providerProfiles.ts
@@ -1004,19 +1004,28 @@ export function addProviderProfile(
     const currentProfiles = getProviderProfiles(current)
     const nextProfiles = [...currentProfiles, profile]
     const currentActive = trimOrUndefined(current.activeProviderProfileId)
-    // Resolve the *effective* active state the same way getActiveProviderProfile
-    // does: an unset id with saved profiles implicitly means the first profile,
-    // not "no active profile". Adding a profile with makeActive:false must not
-    // silently switch a user — whether they are on built-in Anthropic (sentinel),
-    // an explicit profile, or the implicit first profile — over to the new one
-    // (#1426).
-    const hasEffectiveActive =
-      currentActive === ANTHROPIC_DEFAULT_PROFILE_ID ||
-      (currentActive
-        ? nextProfiles.some(p => p.id === currentActive)
-        : currentProfiles.length > 0)
+    // Resolve the *effective* active id the same way getActiveProviderProfile
+    // does, so adding a profile with makeActive:false preserves whatever is
+    // actually active now rather than silently switching the user (#1426):
+    //   - Anthropic sentinel               -> built-in Anthropic (keep sentinel)
+    //   - explicit id for a saved profile  -> that profile
+    //   - stale or unset id with profiles  -> implicit first profile
+    //   - no saved profiles                -> nothing active yet
+    // The stale-id case matters: getActiveProviderProfile() falls back to
+    // profiles[0] for an id whose profile was deleted, so makeActive:false must
+    // keep profiles[0] and not promote the newly added profile.
+    let effectiveActiveId: string | undefined
+    if (currentActive === ANTHROPIC_DEFAULT_PROFILE_ID) {
+      effectiveActiveId = ANTHROPIC_DEFAULT_PROFILE_ID
+    } else if (currentActive && currentProfiles.some(p => p.id === currentActive)) {
+      effectiveActiveId = currentActive
+    } else if (currentProfiles.length > 0) {
+      effectiveActiveId = currentProfiles[0].id
+    } else {
+      effectiveActiveId = undefined
+    }
     const nextActiveId =
-      makeActive || !hasEffectiveActive ? profile.id : currentActive
+      makeActive || effectiveActiveId === undefined ? profile.id : effectiveActiveId
 
     return {
       ...current,

--- a/src/utils/providerProfiles.ts
+++ b/src/utils/providerProfiles.ts
@@ -1004,16 +1004,19 @@ export function addProviderProfile(
     const currentProfiles = getProviderProfiles(current)
     const nextProfiles = [...currentProfiles, profile]
     const currentActive = trimOrUndefined(current.activeProviderProfileId)
-    // Keep the Anthropic sentinel as a valid active state: adding a profile with
-    // makeActive:false must not silently switch a user who is on built-in
-    // Anthropic over to the new third-party profile (#1426).
+    // Resolve the *effective* active state the same way getActiveProviderProfile
+    // does: an unset id with saved profiles implicitly means the first profile,
+    // not "no active profile". Adding a profile with makeActive:false must not
+    // silently switch a user — whether they are on built-in Anthropic (sentinel),
+    // an explicit profile, or the implicit first profile — over to the new one
+    // (#1426).
+    const hasEffectiveActive =
+      currentActive === ANTHROPIC_DEFAULT_PROFILE_ID ||
+      (currentActive
+        ? nextProfiles.some(p => p.id === currentActive)
+        : currentProfiles.length > 0)
     const nextActiveId =
-      makeActive ||
-      !currentActive ||
-      (currentActive !== ANTHROPIC_DEFAULT_PROFILE_ID &&
-        !nextProfiles.some(p => p.id === currentActive))
-        ? profile.id
-        : currentActive
+      makeActive || !hasEffectiveActive ? profile.id : currentActive
 
     return {
       ...current,

--- a/src/utils/providerProfiles.ts
+++ b/src/utils/providerProfiles.ts
@@ -946,6 +946,28 @@ export function applyActiveProviderProfileFromConfig(
   },
 ): ProviderProfile | undefined {
   const processEnv = options?.processEnv ?? process.env
+
+  // Built-in Anthropic is an explicit active state recorded as the sentinel,
+  // not "no active profile". getActiveProviderProfile() resolves the sentinel
+  // to undefined, so without this guard we would return below without marking
+  // provider env as handled; buildStartupEnvFromProfile() then treats the
+  // profile mirror that clearActiveProviderProfile() deleted as a fresh install
+  // and synthesizes the default Gitlawb OpenGateway env, bouncing the user off
+  // built-in Anthropic on the next launch (#1429). Clear any managed provider
+  // env and set the applied flag so the legacy/fresh-install fallback is
+  // suppressed. An explicit startup provider selection still wins for the
+  // current session, matching the saved-profile branch below.
+  if (
+    trimOrUndefined(config.activeProviderProfileId) === ANTHROPIC_DEFAULT_PROFILE_ID
+  ) {
+    if (!options?.force && hasCompleteProviderSelection(processEnv)) {
+      return undefined
+    }
+    clearProviderProfileEnvFromProcessEnv(processEnv)
+    processEnv[PROFILE_ENV_APPLIED_FLAG] = '1'
+    return undefined
+  }
+
   const activeProfile = getActiveProviderProfile(config)
   if (!activeProfile) {
     return undefined

--- a/src/utils/providerProfiles.ts
+++ b/src/utils/providerProfiles.ts
@@ -1004,8 +1004,14 @@ export function addProviderProfile(
     const currentProfiles = getProviderProfiles(current)
     const nextProfiles = [...currentProfiles, profile]
     const currentActive = trimOrUndefined(current.activeProviderProfileId)
+    // Keep the Anthropic sentinel as a valid active state: adding a profile with
+    // makeActive:false must not silently switch a user who is on built-in
+    // Anthropic over to the new third-party profile (#1426).
     const nextActiveId =
-      makeActive || !currentActive || !nextProfiles.some(p => p.id === currentActive)
+      makeActive ||
+      !currentActive ||
+      (currentActive !== ANTHROPIC_DEFAULT_PROFILE_ID &&
+        !nextProfiles.some(p => p.id === currentActive))
         ? profile.id
         : currentActive
 
@@ -1058,8 +1064,12 @@ export function updateProviderProfile(
     delete cacheByProfile[profileId]
 
     const currentActive = trimOrUndefined(current.activeProviderProfileId)
+    // Updating any profile must not reactivate profiles[0] when the user is on
+    // built-in Anthropic — the sentinel is a valid active state to preserve.
     const nextActiveId =
-      currentActive && nextProfiles.some(profile => profile.id === currentActive)
+      currentActive &&
+      (currentActive === ANTHROPIC_DEFAULT_PROFILE_ID ||
+        nextProfiles.some(profile => profile.id === currentActive))
         ? currentActive
         : nextProfiles[0]?.id
 
@@ -1503,13 +1513,18 @@ export function deleteProviderProfile(profileId: string): {
 
     const nextProfiles = currentProfiles.filter(profile => profile.id !== profileId)
     const currentActive = trimOrUndefined(current.activeProviderProfileId)
+    // The Anthropic sentinel survives deletion of any other profile — deleting
+    // an inactive saved profile must not knock a built-in-Anthropic user back
+    // onto profiles[0] (#1426).
     const activeWasDeleted =
-      !currentActive || currentActive === profileId ||
-      !nextProfiles.some(profile => profile.id === currentActive)
+      !currentActive ||
+      currentActive === profileId ||
+      (currentActive !== ANTHROPIC_DEFAULT_PROFILE_ID &&
+        !nextProfiles.some(profile => profile.id === currentActive))
 
     const nextActiveId = activeWasDeleted ? nextProfiles[0]?.id : currentActive
 
-    if (nextActiveId) {
+    if (nextActiveId && nextActiveId !== ANTHROPIC_DEFAULT_PROFILE_ID) {
       nextActiveProfile =
         nextProfiles.find(profile => profile.id === nextActiveId) ?? nextProfiles[0]
     }


### PR DESCRIPTION
Fixes #1426

## Problem

Once any third-party provider profile is active, `/provider` offers no way back to built-in Anthropic. `getActiveProviderProfile` falls back to `profiles[0]` whenever `activeProviderProfileId` is unset, so clearing the active id still re-selects a saved profile. The only escape was hand-editing `~/.openclaude.json` (null the active id, empty `providerProfiles`) and a full restart — and `auth status` kept reporting `third_party` until then due to stale session env.

## Fix

- Add an explicit `ANTHROPIC_DEFAULT_PROFILE_ID` sentinel. `getActiveProviderProfile` resolves it to `undefined` (built-in Anthropic) instead of falling through to `profiles[0]`.
- Add `clearActiveProviderProfile()`: records the sentinel as the active id, clears the managed provider env from the current session (so the switch is immediate, no restart), and removes the startup profile mirror file.
- Surface a `Use Anthropic (built-in)` choice in the `/provider` menu, shown whenever the current provider is not Anthropic. Selecting it switches mid-session and emits a provider-switch system reminder.

Saved profiles are preserved for re-selection — this only changes which one is *active*.

## Test plan

- `bun test src/utils/providerProfiles.test.ts` — added coverage: sentinel resolves to undefined while saved profiles persist; managed env cleared from session.
- `bun test src/commands/provider/provider.test.tsx`
- `bun run build`
- `node dist/cli.mjs --version` (smoke)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a “Use Anthropic (built-in)” option to the provider selection menu, and re-enabled the active-provider switch when appropriate—even with no selectable third-party profiles.

* **Bug Fixes**
  * Improved built-in Anthropic recovery to keep the correct active-provider state, prevent unintended provider fallback, and properly clear session/startup overrides.
  * Refined GitHub Models credential cleanup to remove only session-hydrated credentials while preserving user-supplied values.

* **Tests**
  * Added regression coverage for Anthropic built-in sentinel handling, cold-start behavior, and GitHub Models cleanup, including new ProviderManager UI switch-back/delete checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->