### PR TITLE
fix(test): prevent providerProfiles config mock from leaking across files

### DIFF
--- a/src/utils/providerProfiles.test.ts
+++ b/src/utils/providerProfiles.test.ts
@@ -129,7 +129,16 @@ async function importFreshProviderProfileModules() {
   const actualConfig = await import(`./config.js?ts=${Date.now()}-${Math.random()}`)
   mock.module('./config.js', () => ({
     ...actualConfig,
-    getGlobalConfig: () => mockConfigState,
+    // Spread the real config so the mock stays a COMPLETE GlobalConfig and only
+    // the provider-profile fields are overridden. bun's mock.restore() does NOT
+    // revert mock.module(), so this replacement leaks into later test files in
+    // the same process; returning a partial object (missing e.g.
+    // autoCompactEnabled) silently broke unrelated suites that read other config
+    // fields via getGlobalConfig().
+    getGlobalConfig: () => ({
+      ...actualConfig.getGlobalConfig(),
+      ...mockConfigState,
+    }),
     saveGlobalConfig: (
       updater: (current: MockConfigState) => MockConfigState,
     ) => {


### PR DESCRIPTION
The mock.module('./config.js') replacement in providerProfiles.test.ts returned a partial config object (mockConfigState) with no autoCompactEnabled field. Because bun's mock.restore() does not revert mock.module(), this incomplete config leaked into later test files in the same process, making getGlobalConfig().autoCompactEnabled undefined.

That caused isAutoCompactEnabled() to be falsy and the auto-compact cooldown safety-net block in query.ts to be skipped, failing 3 tests in src/query/autoCompactCooldown.test.ts — but only in the full suite, not in isolation.

Spread the real getGlobalConfig() into the mock so it stays a complete GlobalConfig and only the provider-profile fields are overridden.
