### PR TITLE
fix(diff): guard diff language detection against prototype-chain filenames

### DIFF
--- a/src/native-ts/color-diff/detectLanguage.test.ts
+++ b/src/native-ts/color-diff/detectLanguage.test.ts
@@ -3,13 +3,22 @@ import { __test } from './index.js'
 
 const { detectLanguage } = __test
 
+// A lightweight stand-in for highlight.js#getLanguage so this regression check
+// stays isolated: it must not lazy-load and cache the full highlight.js
+// registry into the shared Bun test process (per the module comment in
+// index.ts). detectLanguage takes the validator as an injectable third
+// argument exactly so this coverage can run without loading hljs.
+const KNOWN_LANGUAGES = new Set(['css', 'dockerfile', 'makefile', 'cmake', 'ts', 'py'])
+const isValidLanguage = (name: string) =>
+  KNOWN_LANGUAGES.has(name.toLowerCase())
+
 // Regression for #1430 — a file whose basename or stem collides with an
 // Object.prototype member used to resolve the inherited function from the
 // plain-object FILENAME_LANGS lookup, then crash highlight.js#getLanguage()
 // with "(name || '').toLowerCase is not a function" while rendering the diff.
 describe('detectLanguage prototype-key safety (#1430)', () => {
   test('does not crash and falls back to the extension for constructor.css', () => {
-    expect(detectLanguage('constructor.css', null)).toBe('css')
+    expect(detectLanguage('constructor.css', null, isValidLanguage)).toBe('css')
   })
 
   test.each([
@@ -19,18 +28,18 @@ describe('detectLanguage prototype-key safety (#1430)', () => {
     'hasOwnProperty',
     '__proto__',
   ])('basename %p resolves to a language or null, never a function', name => {
-    const lang = detectLanguage(name, null)
+    const lang = detectLanguage(name, null, isValidLanguage)
     expect(lang === null || typeof lang === 'string').toBe(true)
   })
 
   test('still detects known filename-based languages', () => {
-    expect(detectLanguage('Dockerfile', null)).toBe('dockerfile')
-    expect(detectLanguage('path/to/Makefile', null)).toBe('makefile')
-    expect(detectLanguage('CMakeLists.txt', null)).toBe('cmake')
+    expect(detectLanguage('Dockerfile', null, isValidLanguage)).toBe('dockerfile')
+    expect(detectLanguage('path/to/Makefile', null, isValidLanguage)).toBe('makefile')
+    expect(detectLanguage('CMakeLists.txt', null, isValidLanguage)).toBe('cmake')
   })
 
   test('still detects by extension', () => {
-    expect(detectLanguage('foo/bar.ts', null)).toBe('ts')
-    expect(detectLanguage('script.py', null)).toBe('py')
+    expect(detectLanguage('foo/bar.ts', null, isValidLanguage)).toBe('ts')
+    expect(detectLanguage('script.py', null, isValidLanguage)).toBe('py')
   })
 })

--- a/src/native-ts/color-diff/detectLanguage.test.ts
+++ b/src/native-ts/color-diff/detectLanguage.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, test } from 'bun:test'
+import { __test } from './index.js'
+
+const { detectLanguage } = __test
+
+// Regression for #1430 — a file whose basename or stem collides with an
+// Object.prototype member used to resolve the inherited function from the
+// plain-object FILENAME_LANGS lookup, then crash highlight.js#getLanguage()
+// with "(name || '').toLowerCase is not a function" while rendering the diff.
+describe('detectLanguage prototype-key safety (#1430)', () => {
+  test('does not crash and falls back to the extension for constructor.css', () => {
+    expect(detectLanguage('constructor.css', null)).toBe('css')
+  })
+
+  test.each([
+    'constructor',
+    'toString',
+    'valueOf',
+    'hasOwnProperty',
+    '__proto__',
+  ])('basename %p resolves to a language or null, never a function', name => {
+    const lang = detectLanguage(name, null)
+    expect(lang === null || typeof lang === 'string').toBe(true)
+  })
+
+  test('still detects known filename-based languages', () => {
+    expect(detectLanguage('Dockerfile', null)).toBe('dockerfile')
+    expect(detectLanguage('path/to/Makefile', null)).toBe('makefile')
+    expect(detectLanguage('CMakeLists.txt', null)).toBe('cmake')
+  })
+
+  test('still detects by extension', () => {
+    expect(detectLanguage('foo/bar.ts', null)).toBe('ts')
+    expect(detectLanguage('script.py', null)).toBe('py')
+  })
+})

--- a/src/native-ts/color-diff/index.ts
+++ b/src/native-ts/color-diff/index.ts
@@ -411,13 +411,19 @@ type HljsNode = {
 
 // Filename-based and extension-based language detection (approximates bat's
 // SyntaxMapping + syntect's find_syntax_by_extension)
-const FILENAME_LANGS: Record<string, string> = {
-  Dockerfile: 'dockerfile',
-  Makefile: 'makefile',
-  Rakefile: 'ruby',
-  Gemfile: 'ruby',
-  CMakeLists: 'cmake',
-}
+// Keyed lookup must be a Map, not a plain object: a file whose basename or
+// stem collides with an Object.prototype member (`constructor`, `toString`,
+// `valueOf`, `hasOwnProperty`, …) would otherwise resolve to the inherited
+// function instead of `undefined`, and highlight.js#getLanguage() crashes on
+// the non-string value with "(name || '').toLowerCase is not a function"
+// (issue #1430, e.g. editing `constructor.css`).
+const FILENAME_LANGS = new Map<string, string>([
+  ['Dockerfile', 'dockerfile'],
+  ['Makefile', 'makefile'],
+  ['Rakefile', 'ruby'],
+  ['Gemfile', 'ruby'],
+  ['CMakeLists', 'cmake'],
+])
 
 function detectLanguage(
   filePath: string,
@@ -428,7 +434,7 @@ function detectLanguage(
 
   // Filename-based lookup (handles Dockerfile, Makefile, CMakeLists.txt, etc.)
   const stem = base.split('.')[0] ?? ''
-  const byName = FILENAME_LANGS[base] ?? FILENAME_LANGS[stem]
+  const byName = FILENAME_LANGS.get(base) ?? FILENAME_LANGS.get(stem)
   if (byName && hljs().getLanguage(byName)) return byName
   if (ext) {
     const lang = hljs().getLanguage(ext)

--- a/src/native-ts/color-diff/index.ts
+++ b/src/native-ts/color-diff/index.ts
@@ -425,9 +425,15 @@ const FILENAME_LANGS = new Map<string, string>([
   ['CMakeLists', 'cmake'],
 ])
 
+// The language validator is injectable so unit tests (e.g. the #1430
+// prototype-key regression) can exercise detectLanguage without pulling the
+// full highlight.js registry into the shared Bun test process. Production
+// callers use the default, which lazy-loads hljs as before.
 function detectLanguage(
   filePath: string,
   firstLine: string | null,
+  isValidLanguage: (name: string) => boolean = name =>
+    Boolean(hljs().getLanguage(name)),
 ): string | null {
   const base = basename(filePath)
   const ext = extname(filePath).slice(1)
@@ -435,10 +441,9 @@ function detectLanguage(
   // Filename-based lookup (handles Dockerfile, Makefile, CMakeLists.txt, etc.)
   const stem = base.split('.')[0] ?? ''
   const byName = FILENAME_LANGS.get(base) ?? FILENAME_LANGS.get(stem)
-  if (byName && hljs().getLanguage(byName)) return byName
+  if (byName && isValidLanguage(byName)) return byName
   if (ext) {
-    const lang = hljs().getLanguage(ext)
-    if (lang) return ext
+    if (isValidLanguage(ext)) return ext
   }
   // Shebang / first-line detection (strip UTF-8 BOM)
   if (firstLine) {


### PR DESCRIPTION
## Summary

Editing a file whose basename collides with an `Object.prototype` member (e.g. `constructor.css`) crashes the whole diff render with:

```
(name || '').toLowerCase is not a function
  at Object.getLanguage (highlight.js)
  at detectLanguage (color-diff)
  at ColorDiff.render → renderColorDiff → StructuredDiff
```

Fixes #1430.

## Root cause

`detectLanguage()` (`src/native-ts/color-diff/index.ts`) looked up the filename basename/stem in a plain-object map:

```ts
const FILENAME_LANGS: Record<string, string> = { Dockerfile: 'dockerfile', ... }
const byName = FILENAME_LANGS[base] ?? FILENAME_LANGS[stem]
```

For `constructor.css`, `stem` is `"constructor"`, so `FILENAME_LANGS["constructor"]` resolves to the inherited `Object.prototype.constructor` **function** rather than `undefined`. That truthy non-string value passes the `if (byName && ...)` guard and is handed to `highlight.js#getLanguage()`, which does `(name || '').toLowerCase()` and throws. Same hazard for `toString`, `valueOf`, `hasOwnProperty`, `__proto__`, etc.

## Fix

Switch `FILENAME_LANGS` to a `Map`. `Map.get()` returns `undefined` for absent keys and never walks the prototype chain, so prototype-member filenames can't leak a function into the lookup.

## Tests

Added `detectLanguage.test.ts`:
- `constructor.css` → falls back to `css` (the reported repro)
- prototype-key basenames (`constructor`, `toString`, `valueOf`, `hasOwnProperty`, `__proto__`) return a string or `null`, never a function
- existing filename-based (`Dockerfile`/`Makefile`/`CMakeLists.txt`) and extension-based detection still work

All pass; full suite green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Added a language-detection regression test suite to ensure reliable handling when basenames/stems match built-in object property names.

* **Bug Fixes**
  * Improved filename-based language detection for common special files (e.g., Dockerfile/Makefile/Rakefile/Gemfile/CMakeLists) to avoid prototype-key collisions.
  * Updated language detection to be more robust and consistently return `null` or a valid language for edge cases, while preserving existing known filename and extension behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->