### PR TITLE
fix(update): allow auto-update for OpenClaude builds on third-party providers

### DIFF
--- a/src/cli/update.test.ts
+++ b/src/cli/update.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, test } from 'bun:test'
+import { isAutoUpdateBlockedForThirdParty } from './update.js'
+
+// Regression for #1404 — `openclaude update` was gated on
+// `getAPIProvider() !== 'firstParty'`, which blocked auto-update for every
+// OpenClaude user running any third-party provider, even though OpenClaude
+// builds reinstall their own `@gitlawb/openclaude` package (not the Anthropic
+// binary) and are therefore safe to update.
+describe('isAutoUpdateBlockedForThirdParty (#1404)', () => {
+  test('OpenClaude-packaged build is never blocked, regardless of provider', () => {
+    expect(isAutoUpdateBlockedForThirdParty('@gitlawb/openclaude', 'openai')).toBe(false)
+    expect(isAutoUpdateBlockedForThirdParty('@gitlawb/openclaude', 'mistral')).toBe(false)
+    expect(isAutoUpdateBlockedForThirdParty('@gitlawb/openclaude', 'firstParty')).toBe(false)
+  })
+
+  test('Anthropic-packaged build is blocked when a third-party provider is active', () => {
+    expect(isAutoUpdateBlockedForThirdParty('@anthropic-ai/claude-code', 'openai')).toBe(true)
+    expect(isAutoUpdateBlockedForThirdParty('@anthropic-ai/claude-code', 'gemini')).toBe(true)
+  })
+
+  test('Anthropic-packaged build is allowed on the first-party provider', () => {
+    expect(isAutoUpdateBlockedForThirdParty('@anthropic-ai/claude-code', 'firstParty')).toBe(false)
+  })
+
+  test('missing package URL is treated as the Anthropic build (conservative)', () => {
+    expect(isAutoUpdateBlockedForThirdParty(undefined, 'openai')).toBe(true)
+    expect(isAutoUpdateBlockedForThirdParty(undefined, 'firstParty')).toBe(false)
+  })
+})

--- a/src/cli/update.ts
+++ b/src/cli/update.ts
@@ -28,12 +28,32 @@ import { writeToStdout } from 'src/utils/process.js'
 import { gte } from 'src/utils/semver.js'
 import { getInitialSettings } from 'src/utils/settings/settings.js'
 
+/**
+ * Whether `openclaude update` must refuse to run.
+ *
+ * Auto-update reinstalls `${MACRO.PACKAGE_URL}@latest`. On the upstream
+ * first-party (Anthropic) build that URL is the Anthropic package, so a user
+ * running a third-party provider must NOT auto-update — it would silently
+ * replace their shim build with the upstream Claude Code binary.
+ *
+ * OpenClaude builds set `PACKAGE_URL` to `@gitlawb/openclaude`
+ * (scripts/build.ts), so `update` reinstalls the *same* OpenClaude package and
+ * is always safe, regardless of which provider happens to be active. Gating on
+ * the active provider alone wrongly blocked every OpenClaude user (issue #1404).
+ */
+export function isAutoUpdateBlockedForThirdParty(
+  packageUrl: string | undefined,
+  apiProvider: ReturnType<typeof getAPIProvider>,
+): boolean {
+  const isAnthropicPackage = !packageUrl || packageUrl.startsWith('@anthropic')
+  return isAnthropicPackage && apiProvider !== 'firstParty'
+}
+
 export async function update() {
-  // Block updates for third-party providers. The update mechanism downloads
-  // from the first-party distribution bucket, which would silently replace the
-  // OpenClaude build (with the OpenAI shim) with the upstream Claude Code
-  // binary (without it).
-  if (getAPIProvider() !== 'firstParty') {
+  // Block updates only when an Anthropic-packaged build is paired with a
+  // third-party provider — reinstalling would overwrite the shim build with
+  // the upstream Claude Code binary. OpenClaude-packaged builds are unaffected.
+  if (isAutoUpdateBlockedForThirdParty(MACRO.PACKAGE_URL, getAPIProvider())) {
     writeToStdout(
       chalk.yellow(
         `Auto-update is not available for third-party provider builds.\n`,


### PR DESCRIPTION
## Summary

`openclaude update` exits immediately for every user running a third-party provider, never checking for or installing an update. Fixes #1404.

## Root cause

`src/cli/update.ts` gated on the active runtime provider:

```ts
if (getAPIProvider() !== 'firstParty') {
  // "Auto-update is not available for third-party provider builds." → exit
}
```

The guard was inherited from upstream Claude Code, where auto-update reinstalls the **Anthropic** package — so a third-party user updating would overwrite their shim build with the upstream binary. But OpenClaude builds set `PACKAGE_URL` to `@gitlawb/openclaude` (`scripts/build.ts`), so `update` reinstalls the *same* OpenClaude package. Gating on the active provider therefore blocked all OpenClaude users for no reason.

## Fix

Gate on **package identity**, not the active provider: block only when an Anthropic-packaged build is paired with a third-party provider. OpenClaude-packaged builds always update; the original safety case (Anthropic package + third-party provider) is preserved.

Decision extracted into a pure, exported `isAutoUpdateBlockedForThirdParty(packageUrl, apiProvider)`:

| package | provider | blocked |
|---|---|---|
| `@gitlawb/openclaude` | any (incl. third-party) | ❌ no |
| `@anthropic-ai/claude-code` | third-party | ✅ yes |
| `@anthropic-ai/claude-code` | firstParty | ❌ no |
| missing | third-party | ✅ yes (conservative) |

## Tests

`src/cli/update.test.ts` covers all four rows. All pass; full suite green.