### PR TITLE
fix(bash): treat linter/test-runner exit code 1 as non-error (#1436)

### DIFF
--- a/src/tools/BashTool/commandSemantics.e2e.test.ts
+++ b/src/tools/BashTool/commandSemantics.e2e.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test, beforeAll, afterAll } from 'bun:test'
 import { spawnSync } from 'child_process'
-import { mkdtempSync, rmSync, writeFileSync } from 'fs'
+import { existsSync, mkdtempSync, rmSync, writeFileSync } from 'fs'
 import { tmpdir } from 'os'
 import { join } from 'path'
 import { interpretCommandResult } from './commandSemantics.js'
@@ -14,10 +14,17 @@ import { interpretCommandResult } from './commandSemantics.js'
 // Each suite is skipped when its binary is unavailable.
 // =============================================================================
 
-const TSC_BIN = join(
-  import.meta.dir,
-  '../../../node_modules/.bin/tsc',
-)
+// Resolve tsc shim cross-platform: Bun on Windows installs .bunx/.cmd, not
+// a bare extensionless script. Try each candidate so the e2e suite runs on
+// the same platform the issue was reported on.
+function findTscBin(): string {
+  const base = join(import.meta.dir, '../../../node_modules/.bin/tsc')
+  for (const p of [base, `${base}.bunx`, `${base}.cmd`, `${base}.exe`]) {
+    if (existsSync(p)) return p
+  }
+  return base // hasBinary will return false → tests skip gracefully
+}
+const TSC_BIN = findTscBin()
 
 function hasBinary(cmd: string, args: string[]): boolean {
   try {

--- a/src/tools/BashTool/commandSemantics.e2e.test.ts
+++ b/src/tools/BashTool/commandSemantics.e2e.test.ts
@@ -1,0 +1,161 @@
+import { describe, expect, test, beforeAll, afterAll } from 'bun:test'
+import { spawnSync } from 'child_process'
+import { mkdtempSync, rmSync, writeFileSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { interpretCommandResult } from './commandSemantics.js'
+
+// =============================================================================
+// End-to-end: run real tools, feed their REAL exit codes to
+// interpretCommandResult, and assert the error/non-error classification.
+//
+// Unlike the unit tests (which hardcode exit codes), these spawn the actual
+// binary so the exit-code assumptions are validated against real behavior.
+// Each suite is skipped when its binary is unavailable.
+// =============================================================================
+
+const TSC_BIN = join(
+  import.meta.dir,
+  '../../../node_modules/.bin/tsc',
+)
+
+function hasBinary(cmd: string, args: string[]): boolean {
+  try {
+    const r = spawnSync(cmd, args, { stdio: 'ignore', timeout: 60_000 })
+    return r.error === undefined && r.status !== null
+  } catch {
+    return false
+  }
+}
+
+describe('e2e: tsc real exit codes', () => {
+  const tscAvailable = hasBinary(TSC_BIN, ['--version'])
+  let dir: string
+
+  beforeAll(() => {
+    if (tscAvailable) dir = mkdtempSync(join(tmpdir(), 'semantics-tsc-'))
+  })
+
+  afterAll(() => {
+    if (dir) rmSync(dir, { recursive: true, force: true })
+  })
+
+  test.if(tscAvailable)(
+    'clean file → exit 0, not an error',
+    () => {
+      const f = join(dir, 'good.ts')
+      writeFileSync(f, 'const x: number = 1\nexport {}\n')
+      const r = spawnSync(TSC_BIN, ['--noEmit', f], { encoding: 'utf8' })
+      const cmd = `tsc --noEmit ${f}`
+      const result = interpretCommandResult(cmd, r.status ?? -1, r.stdout, r.stderr)
+      expect(r.status).toBe(0)
+      expect(result.isError).toBe(false)
+    },
+    60_000,
+  )
+
+  test.if(tscAvailable)(
+    'type error → exit 2, classified as non-error (read diagnostics)',
+    () => {
+      const f = join(dir, 'bad.ts')
+      writeFileSync(f, 'const x: number = "nope"\nexport {}\n')
+      const r = spawnSync(TSC_BIN, ['--noEmit', f], { encoding: 'utf8' })
+      const cmd = `tsc --noEmit ${f}`
+      const result = interpretCommandResult(cmd, r.status ?? -1, r.stdout, r.stderr)
+      // tsc reports type diagnostics with exit code 2 (verified TS 5.9)
+      expect(r.status).toBe(2)
+      expect(result.isError).toBe(false)
+      expect(result.message).toContain('Type errors found')
+    },
+    60_000,
+  )
+
+  test.if(tscAvailable)(
+    'unknown CLI flag → exit 1, classified as a real error',
+    () => {
+      const r = spawnSync(TSC_BIN, ['--definitelyNotAFlag'], { encoding: 'utf8' })
+      const result = interpretCommandResult(
+        'tsc --definitelyNotAFlag',
+        r.status ?? -1,
+        r.stdout,
+        r.stderr,
+      )
+      expect(r.status).toBe(1)
+      expect(result.isError).toBe(true)
+    },
+    60_000,
+  )
+})
+
+describe('e2e: ruff via uvx (real exit codes)', () => {
+  const uvxAvailable = hasBinary('uvx', ['--version'])
+  // Confirm ruff itself resolves through uvx before relying on it
+  const ruffAvailable =
+    uvxAvailable && hasBinary('uvx', ['ruff', '--version'])
+  let dir: string
+
+  beforeAll(() => {
+    if (ruffAvailable) dir = mkdtempSync(join(tmpdir(), 'semantics-ruff-'))
+  })
+
+  afterAll(() => {
+    if (dir) rmSync(dir, { recursive: true, force: true })
+  })
+
+  test.if(ruffAvailable)(
+    'clean file → exit 0, not an error',
+    () => {
+      const f = join(dir, 'clean.py')
+      writeFileSync(f, 'x = 1\n')
+      const r = spawnSync('uvx', ['ruff', 'check', f], { encoding: 'utf8' })
+      const result = interpretCommandResult(
+        `uvx ruff check ${f}`,
+        r.status ?? -1,
+        r.stdout,
+        r.stderr,
+      )
+      expect(r.status).toBe(0)
+      expect(result.isError).toBe(false)
+    },
+    120_000,
+  )
+
+  test.if(ruffAvailable)(
+    'violations → exit 1, classified as non-error (read findings)',
+    () => {
+      const f = join(dir, 'lint.py')
+      // unused import + bare statement → guaranteed violations
+      writeFileSync(f, 'import os\nx=1\n')
+      const r = spawnSync('uvx', ['ruff', 'check', f], { encoding: 'utf8' })
+      const result = interpretCommandResult(
+        `uvx ruff check ${f}`,
+        r.status ?? -1,
+        r.stdout,
+        r.stderr,
+      )
+      // The whole point of #1436: violations (exit 1) must NOT look like a crash,
+      // and the runner prefix (uvx) must resolve to ruff.
+      expect(r.status).toBe(1)
+      expect(result.isError).toBe(false)
+    },
+    120_000,
+  )
+
+  test.if(ruffAvailable)(
+    'unknown CLI flag → exit 2, classified as a real error',
+    () => {
+      const r = spawnSync('uvx', ['ruff', '--definitelyNotAFlag'], {
+        encoding: 'utf8',
+      })
+      const result = interpretCommandResult(
+        'uvx ruff --definitelyNotAFlag',
+        r.status ?? -1,
+        r.stdout,
+        r.stderr,
+      )
+      expect(r.status).toBe(2)
+      expect(result.isError).toBe(true)
+    },
+    120_000,
+  )
+})

--- a/src/tools/BashTool/commandSemantics.e2e.test.ts
+++ b/src/tools/BashTool/commandSemantics.e2e.test.ts
@@ -19,7 +19,7 @@ import { interpretCommandResult } from './commandSemantics.js'
 // the same platform the issue was reported on.
 function findTscBin(): string {
   const base = join(import.meta.dir, '../../../node_modules/.bin/tsc')
-  for (const p of [base, `${base}.bunx`, `${base}.cmd`, `${base}.exe`]) {
+  for (const p of [base, `${base}.exe`, `${base}.cmd`, `${base}.bunx`]) {
     if (existsSync(p)) return p
   }
   return base // hasBinary will return false → tests skip gracefully

--- a/src/tools/BashTool/commandSemantics.e2e.test.ts
+++ b/src/tools/BashTool/commandSemantics.e2e.test.ts
@@ -21,7 +21,7 @@ const TSC_BIN = join(
 
 function hasBinary(cmd: string, args: string[]): boolean {
   try {
-    const r = spawnSync(cmd, args, { stdio: 'ignore', timeout: 60_000 })
+    const r = spawnSync(cmd, args, { stdio: 'ignore', timeout: 5_000 })
     return r.error === undefined && r.status !== null
   } catch {
     return false

--- a/src/tools/BashTool/commandSemantics.e2e.test.ts
+++ b/src/tools/BashTool/commandSemantics.e2e.test.ts
@@ -87,11 +87,14 @@ describe('e2e: tsc real exit codes', () => {
   )
 })
 
-describe('e2e: ruff via uvx (real exit codes)', () => {
-  const uvxAvailable = hasBinary('uvx', ['--version'])
-  // Confirm ruff itself resolves through uvx before relying on it
-  const ruffAvailable =
-    uvxAvailable && hasBinary('uvx', ['ruff', '--version'])
+describe('e2e: ruff (real exit codes, validates uvx-prefix unwrapping)', () => {
+  // Gate on a locally-installed ruff binary. Using `uvx ruff --version` as
+  // a probe would trigger a uvx package-index resolution / network fetch on
+  // machines that don't have ruff cached, making the normal test suite depend
+  // on external network state. We run ruff directly but pass the uvx-prefixed
+  // command string to interpretCommandResult to exercise the runner-unwrapping
+  // logic without side-effects.
+  const ruffAvailable = hasBinary('ruff', ['--version'])
   let dir: string
 
   beforeAll(() => {
@@ -107,7 +110,7 @@ describe('e2e: ruff via uvx (real exit codes)', () => {
     () => {
       const f = join(dir, 'clean.py')
       writeFileSync(f, 'x = 1\n')
-      const r = spawnSync('uvx', ['ruff', 'check', f], { encoding: 'utf8' })
+      const r = spawnSync('ruff', ['check', f], { encoding: 'utf8' })
       const result = interpretCommandResult(
         `uvx ruff check ${f}`,
         r.status ?? -1,
@@ -117,7 +120,7 @@ describe('e2e: ruff via uvx (real exit codes)', () => {
       expect(r.status).toBe(0)
       expect(result.isError).toBe(false)
     },
-    120_000,
+    60_000,
   )
 
   test.if(ruffAvailable)(
@@ -126,27 +129,25 @@ describe('e2e: ruff via uvx (real exit codes)', () => {
       const f = join(dir, 'lint.py')
       // unused import + bare statement → guaranteed violations
       writeFileSync(f, 'import os\nx=1\n')
-      const r = spawnSync('uvx', ['ruff', 'check', f], { encoding: 'utf8' })
+      const r = spawnSync('ruff', ['check', f], { encoding: 'utf8' })
       const result = interpretCommandResult(
         `uvx ruff check ${f}`,
         r.status ?? -1,
         r.stdout,
         r.stderr,
       )
-      // The whole point of #1436: violations (exit 1) must NOT look like a crash,
+      // violations (exit 1) must NOT look like a crash,
       // and the runner prefix (uvx) must resolve to ruff.
       expect(r.status).toBe(1)
       expect(result.isError).toBe(false)
     },
-    120_000,
+    60_000,
   )
 
   test.if(ruffAvailable)(
     'unknown CLI flag → exit 2, classified as a real error',
     () => {
-      const r = spawnSync('uvx', ['ruff', '--definitelyNotAFlag'], {
-        encoding: 'utf8',
-      })
+      const r = spawnSync('ruff', ['--definitelyNotAFlag'], { encoding: 'utf8' })
       const result = interpretCommandResult(
         'uvx ruff --definitelyNotAFlag',
         r.status ?? -1,
@@ -156,6 +157,6 @@ describe('e2e: ruff via uvx (real exit codes)', () => {
       expect(r.status).toBe(2)
       expect(result.isError).toBe(true)
     },
-    120_000,
+    60_000,
   )
 })

--- a/src/tools/BashTool/commandSemantics.test.ts
+++ b/src/tools/BashTool/commandSemantics.test.ts
@@ -478,5 +478,31 @@ describe('interpretCommandResult', () => {
       const result = interpretCommandResult("'./node_modules/.bin/ruff' check app.py", 1, '', '')
       expect(result.isError).toBe(false)
     })
+
+    // env builtin prefix: `env [flags] [VAR=value...] command`
+    test('env VAR=value pytest exit 1 = test failures (not a crash)', () => {
+      const result = interpretCommandResult('env PYTHONPATH=. pytest tests/', 1, '', '')
+      expect(result.isError).toBe(false)
+    })
+
+    test('env VAR=value ruff exit 1 = findings (not a crash)', () => {
+      const result = interpretCommandResult('env RUFF_CACHE_DIR=. ruff check app.py', 1, '', '')
+      expect(result.isError).toBe(false)
+    })
+
+    test('env -u FLAG ruff exit 1 = findings (value-flag skipped)', () => {
+      const result = interpretCommandResult('env -u HOME ruff check app.py', 1, '', '')
+      expect(result.isError).toBe(false)
+    })
+
+    test('env -i pytest exit 1 = test failures (plain flag skipped)', () => {
+      const result = interpretCommandResult('env -i pytest tests/', 1, '', '')
+      expect(result.isError).toBe(false)
+    })
+
+    test('env VAR=value uvx ruff exit 1 = findings (runner unwrapping still works)', () => {
+      const result = interpretCommandResult('env RUFF_CACHE_DIR=. uvx ruff check app.py', 1, '', '')
+      expect(result.isError).toBe(false)
+    })
   })
 })

--- a/src/tools/BashTool/commandSemantics.test.ts
+++ b/src/tools/BashTool/commandSemantics.test.ts
@@ -448,5 +448,35 @@ describe('interpretCommandResult', () => {
       const result = interpretCommandResult('cd /project && npm test', 1, '', '')
       expect(result.isError).toBe(false)
     })
+
+    test('env-prefixed pytest (PYTHONPATH=.) exit 1 = test failures', () => {
+      const result = interpretCommandResult('PYTHONPATH=. pytest tests/', 1, '', '')
+      expect(result.isError).toBe(false)
+    })
+
+    test('env-prefixed npm test (CI=1 npm test) exit 1 = test failures', () => {
+      const result = interpretCommandResult('CI=1 npm test', 1, '', '')
+      expect(result.isError).toBe(false)
+    })
+
+    test('env-prefixed ruff (RUFF_CACHE_DIR=.ruff_cache uvx ruff check) exit 1 = findings', () => {
+      const result = interpretCommandResult('RUFF_CACHE_DIR=.ruff_cache uvx ruff check app.py', 1, '', '')
+      expect(result.isError).toBe(false)
+    })
+
+    test('multiple env vars prefixed (VAR1=x VAR2=y pytest tests/) exit 1 = test failures', () => {
+      const result = interpretCommandResult('VAR1=value1 VAR2=value2 pytest tests/', 1, '', '')
+      expect(result.isError).toBe(false)
+    })
+
+    test('quoted path-based eslint ("./node_modules/.bin/eslint" src/) exit 1 = findings', () => {
+      const result = interpretCommandResult('"./node_modules/.bin/eslint" src/', 1, '', '')
+      expect(result.isError).toBe(false)
+    })
+
+    test("single-quoted path-based command ('./node_modules/.bin/ruff' check) exit 1 = findings", () => {
+      const result = interpretCommandResult("'./node_modules/.bin/ruff' check app.py", 1, '', '')
+      expect(result.isError).toBe(false)
+    })
   })
 })

--- a/src/tools/BashTool/commandSemantics.test.ts
+++ b/src/tools/BashTool/commandSemantics.test.ts
@@ -269,6 +269,22 @@ describe('interpretCommandResult', () => {
       const result = interpretCommandResult('vitest run', 1, '', '')
       expect(result.isError).toBe(false)
     })
+
+    test('npm test exit code 1 = test failures (not error)', () => {
+      const result = interpretCommandResult('npm test', 1, '1 failed', '')
+      expect(result.isError).toBe(false)
+      expect(result.message).toContain('Test failures')
+    })
+
+    test('npm test exit code 0 = all passed', () => {
+      const result = interpretCommandResult('npm test', 0, '5 passed', '')
+      expect(result.isError).toBe(false)
+    })
+
+    test('npm test exit code 2 = runner error', () => {
+      const result = interpretCommandResult('npm test', 2, '', 'ENOENT')
+      expect(result.isError).toBe(true)
+    })
   })
 
   // --- pylint: OR-ed bitfield (1=fatal, 2=error, 4=warn, 8=refactor, 16=convention, 32=usage) ---
@@ -380,6 +396,11 @@ describe('interpretCommandResult', () => {
       // command stays python → default semantics → exit 1 is a real error
       const result = interpretCommandResult('python script.py -m ruff', 1, '', '')
       expect(result.isError).toBe(true)
+    })
+
+    test('npm test in compound command', () => {
+      const result = interpretCommandResult('cd /project && npm test', 1, '', '')
+      expect(result.isError).toBe(false)
     })
   })
 })

--- a/src/tools/BashTool/commandSemantics.test.ts
+++ b/src/tools/BashTool/commandSemantics.test.ts
@@ -368,5 +368,18 @@ describe('interpretCommandResult', () => {
       const result = interpretCommandResult('cd /tmp && uvx ruff check app.py', 1, '', '')
       expect(result.isError).toBe(false)
     })
+
+    test('npx -p <pkg> <cmd> unwraps to the command, not the package value', () => {
+      // tsc exit 2 = diagnostics found (not error); proves -p value was skipped
+      const result = interpretCommandResult('npx -p typescript tsc --noEmit', 2, '', '')
+      expect(result.isError).toBe(false)
+    })
+
+    test('-m as a script arg (not at position 1) does not mis-resolve', () => {
+      // `-m` here is an argument to script.py, not python's module flag;
+      // command stays python → default semantics → exit 1 is a real error
+      const result = interpretCommandResult('python script.py -m ruff', 1, '', '')
+      expect(result.isError).toBe(true)
+    })
   })
 })

--- a/src/tools/BashTool/commandSemantics.test.ts
+++ b/src/tools/BashTool/commandSemantics.test.ts
@@ -160,4 +160,195 @@ describe('interpretCommandResult', () => {
       expect(result.isError).toBe(true)
     })
   })
+
+  // --- linters: 0=clean, 1=violations (not error), 2+=tool error ---
+  describe('linters', () => {
+    test('ruff exit code 1 = violations found (not error)', () => {
+      const result = interpretCommandResult('ruff check app.py', 1, 'E501 Line too long', '')
+      expect(result.isError).toBe(false)
+      expect(result.message).toContain('Lint violations found')
+    })
+
+    test('ruff exit code 0 = clean', () => {
+      const result = interpretCommandResult('ruff check app.py', 0, '', '')
+      expect(result.isError).toBe(false)
+    })
+
+    test('ruff exit code 2 = internal error', () => {
+      const result = interpretCommandResult('ruff check app.py', 2, '', 'invalid config')
+      expect(result.isError).toBe(true)
+    })
+
+    test('eslint exit code 1 = violations (not error)', () => {
+      const result = interpretCommandResult('eslint src/', 1, '', '')
+      expect(result.isError).toBe(false)
+    })
+
+    test('eslint exit code 2 = fatal config error', () => {
+      const result = interpretCommandResult('eslint src/', 2, '', 'Cannot read config')
+      expect(result.isError).toBe(true)
+    })
+
+    test('flake8 exit code 1 = violations (not error)', () => {
+      const result = interpretCommandResult('flake8 app.py', 1, '', '')
+      expect(result.isError).toBe(false)
+    })
+
+    test('biome exit code 1 = violations (not error)', () => {
+      const result = interpretCommandResult('biome check .', 1, '', '')
+      expect(result.isError).toBe(false)
+    })
+  })
+
+  // --- type checkers: 0=clean, 1=type errors (not error), 2+=tool error ---
+  describe('type checkers', () => {
+    test('mypy exit code 1 = type errors found (not error)', () => {
+      const result = interpretCommandResult('mypy app.py', 1, 'error: incompatible type', '')
+      expect(result.isError).toBe(false)
+      expect(result.message).toContain('Type errors found')
+    })
+
+    test('mypy exit code 2 = tool error', () => {
+      const result = interpretCommandResult('mypy app.py', 2, '', 'cannot find module')
+      expect(result.isError).toBe(true)
+    })
+
+    test('pyright exit code 1 = errors found (not error)', () => {
+      const result = interpretCommandResult('pyright', 1, '', '')
+      expect(result.isError).toBe(false)
+    })
+
+    test('tsc exit code 1 = compile errors (not error)', () => {
+      const result = interpretCommandResult('tsc --noEmit', 1, 'TS2304: cannot find name', '')
+      expect(result.isError).toBe(false)
+    })
+  })
+
+  // --- test runners: 0=pass, 1=failures (not error), 2+=runner error ---
+  describe('test runners', () => {
+    test('pytest exit code 1 = test failures (not error)', () => {
+      const result = interpretCommandResult('pytest tests/', 1, '1 failed', '')
+      expect(result.isError).toBe(false)
+      expect(result.message).toContain('Test failures')
+    })
+
+    test('pytest exit code 0 = all passed', () => {
+      const result = interpretCommandResult('pytest tests/', 0, '5 passed', '')
+      expect(result.isError).toBe(false)
+    })
+
+    test('pytest exit code 2 = interrupted/internal error', () => {
+      const result = interpretCommandResult('pytest tests/', 2, '', 'INTERNALERROR')
+      expect(result.isError).toBe(true)
+    })
+
+    test('jest exit code 1 = failures (not error)', () => {
+      const result = interpretCommandResult('jest', 1, '', '')
+      expect(result.isError).toBe(false)
+    })
+
+    test('vitest exit code 1 = failures (not error)', () => {
+      const result = interpretCommandResult('vitest run', 1, '', '')
+      expect(result.isError).toBe(false)
+    })
+  })
+
+  // --- pylint: OR-ed bitfield (1=fatal, 2=error, 4=warn, 8=refactor, 16=convention, 32=usage) ---
+  describe('pylint bitfield', () => {
+    test('exit code 0 = clean', () => {
+      const result = interpretCommandResult('pylint app.py', 0, '', '')
+      expect(result.isError).toBe(false)
+    })
+
+    test('exit code 16 = convention only (not error)', () => {
+      const result = interpretCommandResult('pylint app.py', 16, 'C0114 missing docstring', '')
+      expect(result.isError).toBe(false)
+      expect(result.message).toContain('Lint messages found')
+    })
+
+    test('exit code 4 = warning only (not error)', () => {
+      const result = interpretCommandResult('pylint app.py', 4, '', '')
+      expect(result.isError).toBe(false)
+    })
+
+    test('exit code 2 = error-category message (not a crash)', () => {
+      const result = interpretCommandResult('pylint app.py', 2, 'E1101', '')
+      expect(result.isError).toBe(false)
+    })
+
+    test('exit code 1 = fatal pylint crash (error)', () => {
+      const result = interpretCommandResult('pylint app.py', 1, '', 'fatal')
+      expect(result.isError).toBe(true)
+    })
+
+    test('exit code 32 = usage error (error)', () => {
+      const result = interpretCommandResult('pylint --bogus', 32, '', 'usage error')
+      expect(result.isError).toBe(true)
+    })
+
+    test('exit code 20 = convention(16)+warning(4) only (not error)', () => {
+      const result = interpretCommandResult('pylint app.py', 20, '', '')
+      expect(result.isError).toBe(false)
+    })
+
+    test('exit code 17 = fatal(1)+convention(16) (error)', () => {
+      const result = interpretCommandResult('pylint app.py', 17, '', '')
+      expect(result.isError).toBe(true)
+    })
+  })
+
+  // --- package/module runners unwrap to the real tool ---
+  describe('runner unwrapping', () => {
+    test('uvx ruff check exit 1 = violations (not error)', () => {
+      const result = interpretCommandResult('uvx ruff check --fix app.py', 1, 'E501', '')
+      expect(result.isError).toBe(false)
+    })
+
+    test('npx eslint exit 1 = violations (not error)', () => {
+      const result = interpretCommandResult('npx eslint src/', 1, '', '')
+      expect(result.isError).toBe(false)
+    })
+
+    test('npx with --yes flag still unwraps to eslint', () => {
+      const result = interpretCommandResult('npx --yes eslint src/', 1, '', '')
+      expect(result.isError).toBe(false)
+    })
+
+    test('npx with version pin unwraps to eslint', () => {
+      const result = interpretCommandResult('npx eslint@8.0.0 src/', 1, '', '')
+      expect(result.isError).toBe(false)
+    })
+
+    test('python -m ruff exit 1 = violations (not error)', () => {
+      const result = interpretCommandResult('python -m ruff check app.py', 1, '', '')
+      expect(result.isError).toBe(false)
+    })
+
+    test('python3 -m pytest exit 1 = test failures (not error)', () => {
+      const result = interpretCommandResult('python3 -m pytest tests/', 1, '', '')
+      expect(result.isError).toBe(false)
+    })
+
+    test('pipx run black exit 1 falls back to default (black not in map)', () => {
+      // black exit 1 = files would be reformatted; not in the map, so default
+      // semantics apply. This documents current behaviour, not an endorsement.
+      const result = interpretCommandResult('pipx run black --check app.py', 1, '', '')
+      expect(result.isError).toBe(true)
+    })
+
+    test('path-based eslint invocation unwraps to eslint', () => {
+      const result = interpretCommandResult('./node_modules/.bin/eslint src/', 1, '', '')
+      expect(result.isError).toBe(false)
+    })
+
+    test('bare python script exit 1 stays a real error', () => {
+      const result = interpretCommandResult('python script.py', 1, '', 'Traceback')
+      expect(result.isError).toBe(true)
+    })
+
+    test('uvx ruff as last command in compound chain', () => {
+      const result = interpretCommandResult('cd /tmp && uvx ruff check app.py', 1, '', '')
+      expect(result.isError).toBe(false)
+    })
+  })
 })

--- a/src/tools/BashTool/commandSemantics.test.ts
+++ b/src/tools/BashTool/commandSemantics.test.ts
@@ -383,6 +383,36 @@ describe('interpretCommandResult', () => {
       expect(result.isError).toBe(false)
     })
 
+    test('uvx --with requests ruff check exit 1 = violations (not error)', () => {
+      const result = interpretCommandResult('uvx --with requests ruff check app.py', 1, 'E501', '')
+      expect(result.isError).toBe(false)
+    })
+
+    test('uvx --python 3.12 ruff check exit 1 = violations (not error)', () => {
+      const result = interpretCommandResult('uvx --python 3.12 ruff check app.py', 1, 'E501', '')
+      expect(result.isError).toBe(false)
+    })
+
+    test('uvx -p 3.12 ruff check exit 1 = violations (not error)', () => {
+      const result = interpretCommandResult('uvx -p 3.12 ruff check app.py', 1, 'E501', '')
+      expect(result.isError).toBe(false)
+    })
+
+    test('uvx --env-file .env ruff check exit 1 = violations (not error)', () => {
+      const result = interpretCommandResult('uvx --env-file .env ruff check app.py', 1, 'E501', '')
+      expect(result.isError).toBe(false)
+    })
+
+    test('uvx --with requests --python 3.12 ruff check exit 1 = violations (not error)', () => {
+      const result = interpretCommandResult('uvx --with requests --python 3.12 ruff check app.py', 1, 'E501', '')
+      expect(result.isError).toBe(false)
+    })
+
+    test('pipx run --python 3.12 ruff check exit 1 = violations (not error)', () => {
+      const result = interpretCommandResult('pipx run --python 3.12 ruff check .', 1, 'E501', '')
+      expect(result.isError).toBe(false)
+    })
+
     test('npx eslint exit 1 = violations (not error)', () => {
       const result = interpretCommandResult('npx eslint src/', 1, '', '')
       expect(result.isError).toBe(false)

--- a/src/tools/BashTool/commandSemantics.test.ts
+++ b/src/tools/BashTool/commandSemantics.test.ts
@@ -218,9 +218,27 @@ describe('interpretCommandResult', () => {
       expect(result.isError).toBe(false)
     })
 
-    test('tsc exit code 1 = compile errors (not error)', () => {
-      const result = interpretCommandResult('tsc --noEmit', 1, 'TS2304: cannot find name', '')
+    // tsc is inverted vs other linters (verified against TypeScript 5.9):
+    // exit 1 = CLI/usage error, exit 2 = diagnostics found.
+    test('tsc exit code 0 = clean', () => {
+      const result = interpretCommandResult('tsc --noEmit', 0, '', '')
       expect(result.isError).toBe(false)
+    })
+
+    test('tsc exit code 2 = type/syntax errors found (not error)', () => {
+      const result = interpretCommandResult('tsc --noEmit', 2, 'TS2322: Type mismatch', '')
+      expect(result.isError).toBe(false)
+      expect(result.message).toContain('Type errors found')
+    })
+
+    test('tsc exit code 1 = CLI/usage error (real failure)', () => {
+      const result = interpretCommandResult('tsc --bogusFlag', 1, '', 'Unknown compiler option')
+      expect(result.isError).toBe(true)
+    })
+
+    test('tsc exit code 3 = config/internal error', () => {
+      const result = interpretCommandResult('tsc -p bad.json', 3, '', '')
+      expect(result.isError).toBe(true)
     })
   })
 

--- a/src/tools/BashTool/commandSemantics.test.ts
+++ b/src/tools/BashTool/commandSemantics.test.ts
@@ -285,6 +285,26 @@ describe('interpretCommandResult', () => {
       const result = interpretCommandResult('npm test', 2, '', 'ENOENT')
       expect(result.isError).toBe(true)
     })
+
+    test('npm t shorthand exit code 1 = test failures (not error)', () => {
+      const result = interpretCommandResult('npm t', 1, '1 failed', '')
+      expect(result.isError).toBe(false)
+    })
+
+    test('npm run test exit code 1 = test failures (not error)', () => {
+      const result = interpretCommandResult('npm run test', 1, '1 failed', '')
+      expect(result.isError).toBe(false)
+    })
+
+    test('npm install exit code 1 = real failure', () => {
+      const result = interpretCommandResult('npm install', 1, '', 'ERR!')
+      expect(result.isError).toBe(true)
+    })
+
+    test('npm run build exit code 1 = real failure', () => {
+      const result = interpretCommandResult('npm run build', 1, '', 'Build failed')
+      expect(result.isError).toBe(true)
+    })
   })
 
   // --- pylint: OR-ed bitfield (1=fatal, 2=error, 4=warn, 8=refactor, 16=convention, 32=usage) ---

--- a/src/tools/BashTool/commandSemantics.test.ts
+++ b/src/tools/BashTool/commandSemantics.test.ts
@@ -305,6 +305,31 @@ describe('interpretCommandResult', () => {
       const result = interpretCommandResult('npm run build', 1, '', 'Build failed')
       expect(result.isError).toBe(true)
     })
+
+    test('yarn test exit code 1 = test failures (not error)', () => {
+      const result = interpretCommandResult('yarn test', 1, '1 failed', '')
+      expect(result.isError).toBe(false)
+    })
+
+    test('yarn install exit code 1 = real failure', () => {
+      const result = interpretCommandResult('yarn install', 1, '', 'ERR!')
+      expect(result.isError).toBe(true)
+    })
+
+    test('pnpm test exit code 1 = test failures (not error)', () => {
+      const result = interpretCommandResult('pnpm test', 1, '1 failed', '')
+      expect(result.isError).toBe(false)
+    })
+
+    test('bun test exit code 1 = test failures (not error)', () => {
+      const result = interpretCommandResult('bun test', 1, '1 failed', '')
+      expect(result.isError).toBe(false)
+    })
+
+    test('bun run build exit code 1 = real failure', () => {
+      const result = interpretCommandResult('bun run build', 1, '', 'Build failed')
+      expect(result.isError).toBe(true)
+    })
   })
 
   // --- pylint: OR-ed bitfield (1=fatal, 2=error, 4=warn, 8=refactor, 16=convention, 32=usage) ---
@@ -386,6 +411,7 @@ describe('interpretCommandResult', () => {
     test('pipx run black exit 1 falls back to default (black not in map)', () => {
       // black exit 1 = files would be reformatted; not in the map, so default
       // semantics apply. This documents current behaviour, not an endorsement.
+      // TODO: add black (and formatter exit-code semantics generally) to the map.
       const result = interpretCommandResult('pipx run black --check app.py', 1, '', '')
       expect(result.isError).toBe(true)
     })

--- a/src/tools/BashTool/commandSemantics.ts
+++ b/src/tools/BashTool/commandSemantics.ts
@@ -168,9 +168,24 @@ const COMMAND_SEMANTICS: Map<string, CommandSemantic> = new Map([
 const PACKAGE_RUNNERS = new Set(['uvx', 'npx', 'bunx', 'pipx'])
 const MODULE_RUNNERS = new Set(['python', 'python3'])
 const RUN_SUBCOMMANDS = new Set(['run'])
-// Runner flags that take a separate value (the next token is the flag's
-// argument, not the tool to run). e.g. `npx -p typescript tsc` runs tsc.
-const VALUE_FLAGS = new Set(['-p', '--package', '-c', '--call', '-w', '--workspace'])
+// Per-runner flags that take a separate value argument (the next token is the
+// flag's value, not the tool to run). e.g. `npx -p typescript tsc` runs tsc,
+// `uvx --with requests ruff check` runs ruff.
+const RUNNER_VALUE_FLAGS: Readonly<Record<string, ReadonlySet<string>>> = {
+  uvx: new Set([
+    '--with', '--with-editable', '--with-requirements',
+    '-p', '--python', '--managed-python', '--env-file', '--from',
+    '--index', '--index-url', '--default-index', '--extra-index-url', '--find-links',
+    '--constraints', '--overrides', '--resolution', '--prerelease',
+    '--exclude-newer', '--refresh-package', '--cache-dir',
+  ]),
+  pipx: new Set([
+    '--python', '--spec', '--index-url', '--extra-index-url', '--find-links', '--pip-args',
+  ]),
+  npx: new Set(['-p', '--package', '-c', '--call', '-w', '--workspace']),
+  bunx: new Set(['-p', '--package']),
+}
+const DEFAULT_RUNNER_VALUE_FLAGS = new Set<string>()
 
 /**
  * Resolve a raw token to a bare command name: strip any leading path and a
@@ -275,9 +290,10 @@ function extractBaseCommand(command: string): string {
   // flags, and a `run` subcommand, then take the first real argument as the
   // tool being executed.
   if (PACKAGE_RUNNERS.has(first)) {
+    const valueFlags = RUNNER_VALUE_FLAGS[first] ?? DEFAULT_RUNNER_VALUE_FLAGS
     for (let i = firstCmdIdx + 1; i < words.length; i++) {
       const w = words[i]
-      if (VALUE_FLAGS.has(w)) {
+      if (valueFlags.has(w)) {
         i++ // also skip the flag's value
         continue
       }

--- a/src/tools/BashTool/commandSemantics.ts
+++ b/src/tools/BashTool/commandSemantics.ts
@@ -174,14 +174,19 @@ const VALUE_FLAGS = new Set(['-p', '--package', '-c', '--call', '-w', '--workspa
 
 /**
  * Resolve a raw token to a bare command name: strip any leading path and a
- * trailing version pin or Windows extension.
+ * trailing version pin or Windows extension, and normalize quotes.
  *   ./node_modules/.bin/eslint → eslint
  *   /usr/bin/ruff              → ruff
  *   eslint@8.0.0               → eslint
  *   ruff.exe                   → ruff
+ *   "./path/to/cmd"            → cmd
  */
 function resolveToolName(token: string): string {
-  const base = token.split(/[/\\]/).pop() || token
+  // Remove surrounding quotes (both single and double)
+  let clean = token.replace(/^['"]|['"]$/g, '')
+  // Split by path separators and take the last component
+  const base = clean.split(/[/\\]/).pop() || clean
+  // Remove version pins (@8.0.0) and Windows extensions (.exe, .cmd, etc.)
   return base.replace(/@.*$/, '').replace(/\.(exe|cmd|bat|ps1)$/i, '')
 }
 
@@ -208,14 +213,23 @@ function extractBaseCommand(command: string): string {
   const words = command.trim().split(/\s+/).filter(Boolean)
   if (words.length === 0) return ''
 
-  const first = resolveToolName(words[0])
+  // Skip leading environment variable assignments (TOKEN=value)
+  let firstCmdIdx = 0
+  for (let i = 0; i < words.length; i++) {
+    if (!words[i].includes('=')) {
+      firstCmdIdx = i
+      break
+    }
+  }
+
+  const first = resolveToolName(words[firstCmdIdx])
 
   // `python -m <module>` / `python3 -m <module>`: the module is the real tool.
   // `-m` must immediately follow the interpreter — a later `-m` is a script arg.
   // A bare `python script.py` keeps default semantics (exit 1 = real error).
   if (MODULE_RUNNERS.has(first)) {
-    if (words[1] === '-m' && words[2]) {
-      return resolveToolName(words[2])
+    if (words[firstCmdIdx + 1] === '-m' && words[firstCmdIdx + 2]) {
+      return resolveToolName(words[firstCmdIdx + 2])
     }
     return first
   }
@@ -224,17 +238,17 @@ function extractBaseCommand(command: string): string {
   // Other subcommands (install/publish/build/run <non-test>) exit 1 on real
   // failures and must fall through to DEFAULT_SEMANTIC.
   if (first === 'npm' || first === 'yarn' || first === 'pnpm') {
-    const sub = words[1]
+    const sub = words[firstCmdIdx + 1]
     const key = `${first} test` as const
     if (sub === 'test' || sub === 't') return key
-    if (sub === 'run' && words[2] && /^test(:.+)?$/.test(words[2])) return key
+    if (sub === 'run' && words[firstCmdIdx + 2] && /^test(:.+)?$/.test(words[firstCmdIdx + 2])) return key
     return first
   }
 
   // bun test = bun's built-in runner (exit 1 = failures).
   // bun run <script> proxies to an arbitrary runner — keep default semantics.
   if (first === 'bun') {
-    if (words[1] === 'test') return 'bun test'
+    if (words[firstCmdIdx + 1] === 'test') return 'bun test'
     return first
   }
 
@@ -242,7 +256,7 @@ function extractBaseCommand(command: string): string {
   // flags, and a `run` subcommand, then take the first real argument as the
   // tool being executed.
   if (PACKAGE_RUNNERS.has(first)) {
-    for (let i = 1; i < words.length; i++) {
+    for (let i = firstCmdIdx + 1; i < words.length; i++) {
       const w = words[i]
       if (VALUE_FLAGS.has(w)) {
         i++ // also skip the flag's value

--- a/src/tools/BashTool/commandSemantics.ts
+++ b/src/tools/BashTool/commandSemantics.ts
@@ -108,7 +108,20 @@ const COMMAND_SEMANTICS: Map<string, CommandSemantic> = new Map([
   // Type checkers: 0=clean, 1=type errors found (informational), 2+=tool error
   ['mypy', exitOneInformational('Type errors found')],
   ['pyright', exitOneInformational('Type errors found')],
-  ['tsc', exitOneInformational('Type errors found')],
+
+  // tsc is inverted vs other linters (verified against TypeScript 5.9):
+  //   0=clean, 1=CLI/usage error (real failure), 2=diagnostics found,
+  //   3+=config/internal error. Exit 2 (type/syntax errors) is informational —
+  //   the model should read the diagnostics, not retry the command.
+  [
+    'tsc',
+    (exitCode, _stdout, _stderr) => {
+      if (exitCode === 0) return { isError: false }
+      if (exitCode === 2)
+        return { isError: false, message: 'Type errors found' }
+      return { isError: true }
+    },
+  ],
 
   // Test runners: 0=all passed, 1=test failures (informational), 2+=runner error
   ['pytest', exitOneInformational('Test failures')],

--- a/src/tools/BashTool/commandSemantics.ts
+++ b/src/tools/BashTool/commandSemantics.ts
@@ -3,9 +3,10 @@
  *
  * Many commands use exit codes to convey information other than just success/failure.
  * For example, grep returns 1 when no matches are found, which is not an error condition.
- * Linters and test runners follow the same pattern: exit code 1 means "issues found"
- * (something the model should read and act on), while exit code 2+ means the tool
- * itself failed (a real error worth retrying or surfacing).
+ * Most linters and test runners follow the same pattern: exit code 1 means "issues
+ * found" (something the model should read and act on, not retry), while exit code 2+
+ * means the tool itself failed. Exceptions exist — e.g. tsc inverts this — so the
+ * per-command semantics below are authoritative over the general rule.
  */
 
 import { splitCommand_DEPRECATED } from '../../utils/bash/commands.js'
@@ -34,10 +35,12 @@ const DEFAULT_SEMANTIC: CommandSemantic = (exitCode, _stdout, _stderr) => ({
  * linters, type checkers, and test runners.
  */
 function exitOneInformational(message: string): CommandSemantic {
-  return (exitCode, _stdout, _stderr) => ({
-    isError: exitCode >= 2,
-    message: exitCode === 1 ? message : undefined,
-  })
+  return (exitCode, _stdout, _stderr) => {
+    if (exitCode === 1) return { isError: false, message }
+    if (exitCode >= 2)
+      return { isError: true, message: `Command failed with exit code ${exitCode}` }
+    return { isError: false }
+  }
 }
 
 /**
@@ -157,6 +160,9 @@ const COMMAND_SEMANTICS: Map<string, CommandSemantic> = new Map([
 const PACKAGE_RUNNERS = new Set(['uvx', 'npx', 'bunx', 'pipx'])
 const MODULE_RUNNERS = new Set(['python', 'python3'])
 const RUN_SUBCOMMANDS = new Set(['run'])
+// Runner flags that take a separate value (the next token is the flag's
+// argument, not the tool to run). e.g. `npx -p typescript tsc` runs tsc.
+const VALUE_FLAGS = new Set(['-p', '--package', '-c', '--call', '-w', '--workspace'])
 
 /**
  * Resolve a raw token to a bare command name: strip any leading path and a
@@ -197,20 +203,25 @@ function extractBaseCommand(command: string): string {
   const first = resolveToolName(words[0])
 
   // `python -m <module>` / `python3 -m <module>`: the module is the real tool.
+  // `-m` must immediately follow the interpreter — a later `-m` is a script arg.
   // A bare `python script.py` keeps default semantics (exit 1 = real error).
   if (MODULE_RUNNERS.has(first)) {
-    const mIdx = words.indexOf('-m')
-    if (mIdx !== -1 && words[mIdx + 1]) {
-      return resolveToolName(words[mIdx + 1])
+    if (words[1] === '-m' && words[2]) {
+      return resolveToolName(words[2])
     }
     return first
   }
 
-  // Package runners: skip the runner, any flags, and a `run` subcommand, then
-  // take the first real argument as the tool being executed.
+  // Package runners: skip the runner, value-flags and their argument, plain
+  // flags, and a `run` subcommand, then take the first real argument as the
+  // tool being executed.
   if (PACKAGE_RUNNERS.has(first)) {
     for (let i = 1; i < words.length; i++) {
       const w = words[i]
+      if (VALUE_FLAGS.has(w)) {
+        i++ // also skip the flag's value
+        continue
+      }
       if (w.startsWith('-')) continue
       if (RUN_SUBCOMMANDS.has(w)) continue
       return resolveToolName(w)

--- a/src/tools/BashTool/commandSemantics.ts
+++ b/src/tools/BashTool/commandSemantics.ts
@@ -3,6 +3,9 @@
  *
  * Many commands use exit codes to convey information other than just success/failure.
  * For example, grep returns 1 when no matches are found, which is not an error condition.
+ * Linters and test runners follow the same pattern: exit code 1 means "issues found"
+ * (something the model should read and act on), while exit code 2+ means the tool
+ * itself failed (a real error worth retrying or surfacing).
  */
 
 import { splitCommand_DEPRECATED } from '../../utils/bash/commands.js'
@@ -24,6 +27,18 @@ const DEFAULT_SEMANTIC: CommandSemantic = (exitCode, _stdout, _stderr) => ({
   message:
     exitCode !== 0 ? `Command failed with exit code ${exitCode}` : undefined,
 })
+
+/**
+ * Semantic factory for tools where exit code 1 is informational (issues found,
+ * not a crash) and exit code 2+ means the tool itself failed. Covers most
+ * linters, type checkers, and test runners.
+ */
+function exitOneInformational(message: string): CommandSemantic {
+  return (exitCode, _stdout, _stderr) => ({
+    isError: exitCode >= 2,
+    message: exitCode === 1 ? message : undefined,
+  })
+}
 
 /**
  * Command-specific semantics
@@ -84,9 +99,64 @@ const COMMAND_SEMANTICS: Map<string, CommandSemantic> = new Map([
     }),
   ],
 
+  // Linters: 0=clean, 1=violations found (informational), 2+=tool error
+  ['ruff', exitOneInformational('Lint violations found')],
+  ['eslint', exitOneInformational('Lint violations found')],
+  ['flake8', exitOneInformational('Lint violations found')],
+  ['biome', exitOneInformational('Lint violations found')],
+
+  // Type checkers: 0=clean, 1=type errors found (informational), 2+=tool error
+  ['mypy', exitOneInformational('Type errors found')],
+  ['pyright', exitOneInformational('Type errors found')],
+  ['tsc', exitOneInformational('Type errors found')],
+
+  // Test runners: 0=all passed, 1=test failures (informational), 2+=runner error
+  ['pytest', exitOneInformational('Test failures')],
+  ['jest', exitOneInformational('Test failures')],
+  ['vitest', exitOneInformational('Test failures')],
+
+  // pylint uses an OR-ed bitfield exit code:
+  //   1=fatal, 2=error msg, 4=warning, 8=refactor, 16=convention, 32=usage error
+  // Only a fatal pylint crash (1) or a CLI usage error (32) is a real failure;
+  // the message bits (2/4/8/16) are lint findings the model should read.
+  [
+    'pylint',
+    (exitCode, _stdout, _stderr) => {
+      if (exitCode === 0) return { isError: false }
+      const fatal = (exitCode & 1) !== 0
+      const usageError = (exitCode & 32) !== 0
+      return {
+        isError: fatal || usageError,
+        message: fatal || usageError ? undefined : 'Lint messages found',
+      }
+    },
+  ],
+
   // wc, head, tail, cat, etc.: these typically only fail on real errors
   // so we use default semantics
 ])
+
+/**
+ * Package/module runners that invoke another tool as a subprocess and inherit
+ * its exit code. To interpret the exit code correctly we must look past the
+ * runner to the tool it actually runs (e.g. `uvx ruff check` → ruff).
+ */
+const PACKAGE_RUNNERS = new Set(['uvx', 'npx', 'bunx', 'pipx'])
+const MODULE_RUNNERS = new Set(['python', 'python3'])
+const RUN_SUBCOMMANDS = new Set(['run'])
+
+/**
+ * Resolve a raw token to a bare command name: strip any leading path and a
+ * trailing version pin or Windows extension.
+ *   ./node_modules/.bin/eslint → eslint
+ *   /usr/bin/ruff              → ruff
+ *   eslint@8.0.0               → eslint
+ *   ruff.exe                   → ruff
+ */
+function resolveToolName(token: string): string {
+  const base = token.split(/[/\\]/).pop() || token
+  return base.replace(/@.*$/, '').replace(/\.(exe|cmd|bat|ps1)$/i, '')
+}
 
 /**
  * Get the semantic interpretation for a command
@@ -99,10 +169,43 @@ function getCommandSemantic(command: string): CommandSemantic {
 }
 
 /**
- * Extract just the command name (first word) from a single command string.
+ * Extract the effective command name from a single command string, looking past
+ * package/module runners and resolving path/version-pinned invocations.
+ *   uvx ruff check --fix    → ruff
+ *   npx --yes eslint .      → eslint
+ *   python -m ruff check    → ruff
+ *   pipx run black          → black
+ *   ./node_modules/.bin/tsc → tsc
  */
 function extractBaseCommand(command: string): string {
-  return command.trim().split(/\s+/)[0] || ''
+  const words = command.trim().split(/\s+/).filter(Boolean)
+  if (words.length === 0) return ''
+
+  const first = resolveToolName(words[0])
+
+  // `python -m <module>` / `python3 -m <module>`: the module is the real tool.
+  // A bare `python script.py` keeps default semantics (exit 1 = real error).
+  if (MODULE_RUNNERS.has(first)) {
+    const mIdx = words.indexOf('-m')
+    if (mIdx !== -1 && words[mIdx + 1]) {
+      return resolveToolName(words[mIdx + 1])
+    }
+    return first
+  }
+
+  // Package runners: skip the runner, any flags, and a `run` subcommand, then
+  // take the first real argument as the tool being executed.
+  if (PACKAGE_RUNNERS.has(first)) {
+    for (let i = 1; i < words.length; i++) {
+      const w = words[i]
+      if (w.startsWith('-')) continue
+      if (RUN_SUBCOMMANDS.has(w)) continue
+      return resolveToolName(w)
+    }
+    return first
+  }
+
+  return first
 }
 
 /**

--- a/src/tools/BashTool/commandSemantics.ts
+++ b/src/tools/BashTool/commandSemantics.ts
@@ -252,6 +252,25 @@ function extractBaseCommand(command: string): string {
     return first
   }
 
+  // `env [flags] [VAR=value...] command args` — skip env, its flags/assignments,
+  // then recurse so that nested runners (e.g. `env CACHE=. uvx ruff check .`)
+  // continue through the PACKAGE_RUNNERS path and resolve to the inner tool.
+  if (first === 'env') {
+    // env value-flags whose next token is the flag's argument, not a command
+    const ENV_VALUE_FLAGS = new Set(['-u', '--unset', '-C', '--chdir', '-S', '--split-string'])
+    for (let i = firstCmdIdx + 1; i < words.length; i++) {
+      const w = words[i]
+      if (ENV_VALUE_FLAGS.has(w)) { i++; continue }
+      if (w.startsWith('-')) continue    // other env flags (-i, --ignore-environment, …)
+      if (w.includes('=')) continue      // VAR=value assignment
+      if (w === '-') continue            // env - clears environment
+      // Recurse on the remaining words so PACKAGE_RUNNERS / MODULE_RUNNERS
+      // and subcommand-aware logic all apply to the inner command.
+      return extractBaseCommand(words.slice(i).join(' '))
+    }
+    return first
+  }
+
   // Package runners: skip the runner, value-flags and their argument, plain
   // flags, and a `run` subcommand, then take the first real argument as the
   // tool being executed.

--- a/src/tools/BashTool/commandSemantics.ts
+++ b/src/tools/BashTool/commandSemantics.ts
@@ -130,7 +130,10 @@ const COMMAND_SEMANTICS: Map<string, CommandSemantic> = new Map([
   ['pytest', exitOneInformational('Test failures')],
   ['jest', exitOneInformational('Test failures')],
   ['vitest', exitOneInformational('Test failures')],
-  ['npm', exitOneInformational('Test failures')],
+  // Compound key: only npm test / npm t / npm run test[:<variant>] get
+  // informational semantics. npm install, npm publish, npm run build etc.
+  // all have exit 1 = real failure and must keep DEFAULT_SEMANTIC.
+  ['npm test', exitOneInformational('Test failures')],
 
   // pylint uses an OR-ed bitfield exit code:
   //   1=fatal, 2=error msg, 4=warning, 8=refactor, 16=convention, 32=usage error
@@ -210,6 +213,16 @@ function extractBaseCommand(command: string): string {
     if (words[1] === '-m' && words[2]) {
       return resolveToolName(words[2])
     }
+    return first
+  }
+
+  // npm: only `npm test` / `npm t` / `npm run test[:<variant>]` get
+  // informational semantics — other subcommands (install, publish, build…)
+  // exit 1 on real failures and must fall through to DEFAULT_SEMANTIC.
+  if (first === 'npm') {
+    const sub = words[1]
+    if (sub === 'test' || sub === 't') return 'npm test'
+    if (sub === 'run' && words[2] && /^test(:.+)?$/.test(words[2])) return 'npm test'
     return first
   }
 

--- a/src/tools/BashTool/commandSemantics.ts
+++ b/src/tools/BashTool/commandSemantics.ts
@@ -130,6 +130,7 @@ const COMMAND_SEMANTICS: Map<string, CommandSemantic> = new Map([
   ['pytest', exitOneInformational('Test failures')],
   ['jest', exitOneInformational('Test failures')],
   ['vitest', exitOneInformational('Test failures')],
+  ['npm', exitOneInformational('Test failures')],
 
   // pylint uses an OR-ed bitfield exit code:
   //   1=fatal, 2=error msg, 4=warning, 8=refactor, 16=convention, 32=usage error

--- a/src/tools/BashTool/commandSemantics.ts
+++ b/src/tools/BashTool/commandSemantics.ts
@@ -38,7 +38,7 @@ function exitOneInformational(message: string): CommandSemantic {
   return (exitCode, _stdout, _stderr) => {
     if (exitCode === 1) return { isError: false, message }
     if (exitCode >= 2)
-      return { isError: true, message: `Command failed with exit code ${exitCode}` }
+      return { isError: true }
     return { isError: false }
   }
 }
@@ -130,10 +130,14 @@ const COMMAND_SEMANTICS: Map<string, CommandSemantic> = new Map([
   ['pytest', exitOneInformational('Test failures')],
   ['jest', exitOneInformational('Test failures')],
   ['vitest', exitOneInformational('Test failures')],
-  // Compound key: only npm test / npm t / npm run test[:<variant>] get
-  // informational semantics. npm install, npm publish, npm run build etc.
-  // all have exit 1 = real failure and must keep DEFAULT_SEMANTIC.
+  // Compound keys: only the test subcommand gets informational semantics.
+  // install/publish/build/run <non-test> all have exit 1 = real failure.
   ['npm test', exitOneInformational('Test failures')],
+  ['yarn test', exitOneInformational('Test failures')],
+  ['pnpm test', exitOneInformational('Test failures')],
+  // bun test is bun's built-in runner (exit 1 = failures).
+  // bun run <script> delegates to an arbitrary runner — handled separately.
+  ['bun test', exitOneInformational('Test failures')],
 
   // pylint uses an OR-ed bitfield exit code:
   //   1=fatal, 2=error msg, 4=warning, 8=refactor, 16=convention, 32=usage error
@@ -216,13 +220,21 @@ function extractBaseCommand(command: string): string {
     return first
   }
 
-  // npm: only `npm test` / `npm t` / `npm run test[:<variant>]` get
-  // informational semantics — other subcommands (install, publish, build…)
-  // exit 1 on real failures and must fall through to DEFAULT_SEMANTIC.
-  if (first === 'npm') {
+  // Package managers: scope informational semantics to the test subcommand.
+  // Other subcommands (install/publish/build/run <non-test>) exit 1 on real
+  // failures and must fall through to DEFAULT_SEMANTIC.
+  if (first === 'npm' || first === 'yarn' || first === 'pnpm') {
     const sub = words[1]
-    if (sub === 'test' || sub === 't') return 'npm test'
-    if (sub === 'run' && words[2] && /^test(:.+)?$/.test(words[2])) return 'npm test'
+    const key = `${first} test` as const
+    if (sub === 'test' || sub === 't') return key
+    if (sub === 'run' && words[2] && /^test(:.+)?$/.test(words[2])) return key
+    return first
+  }
+
+  // bun test = bun's built-in runner (exit 1 = failures).
+  // bun run <script> proxies to an arbitrary runner — keep default semantics.
+  if (first === 'bun') {
+    if (words[1] === 'test') return 'bun test'
     return first
   }
 


### PR DESCRIPTION
Closes #1436

## Problem

**Concrete issue:** Linters and test runners use exit code 1 to mean "issues  not a command crash. `commandSemantics.ts` falls back to `DEFAULT_SEMANTIC` for unknown commands, which treats any non-zero exit as an error.found" 

Result: the model is told `isError: true`, the system prompt tells it to retry on tool errors, and it retries the same `ruff`/`eslint`/`pytest` command 2-3 times before giving  even though the lint output it needs is right there in the result.up 

Reported on v0.15.0 (Windows) with `uvx ruff check --fix`:
```
Bash(uvx ruff check --fix app/foo.py 2>&1)
  Error: Exit code 1  
E501 Line too long (105 > 100)
```

**Broader context:** This PR treats a symptom of a larger architectural issue: the system conflates *command execution failure* with *command output indicating findings*. A linter returning exit 1 with findings is a successful execution; a linter crashing is a failed execution. These are fundamentally different, yet both map to `isError: true` today.

## Fix

This PR corrects exit-code semantics for the most common developer tools currently affected. It does **not** solve the broader question of how agents should handle non-zero exit codes  that warrants a separate design discussion.generally 

`src/tools/BashTool/commandSemantics.ts`:

1. **Add tools to `COMMAND_ exit 1 = informational, 2+ = real error:SEMANTICS`** 
   - Linters: `ruff`, `eslint`, `flake8`, `biome`
   - Type checkers: `mypy`, `pyright`, `tsc`
   - Test runners: `pytest`, `jest`, `vitest`
2. **` uses an OR-ed bitfield (1=fatal, 2=error msg, 4=warn, 8=refactor, 16=convention, 32=usage). Only fatal (1) or usage error (32) is a real failure; message bits are findings the model should read.pylint`** 
3. **Runner-aware base command  `heuristicallyExtractBaseCommand` now looks past package/module runners and resolves path/version-pinned invocations:extraction** 
 `ruff`
 `eslint`
 `pytest`
 `tsc`

### Deliberately conservative

- `pnpm`/`yarn`/`poetry` are **not** unwrapped: their subcommand is usually a `package.json`/script name, not a tool, so exit-code semantics are ambiguous.
- `black --check` (exit 1 = would reformat) is **not**  it falls through to default semantics. Can follow up if wanted.added 
- Anything not in the list keeps today's exact behavior.

## Future work

The longer-term  "how should agents handle non-zero exit codes when the output contains meaningful  deserves its own design thread. This covers architectural decisions like:results?" question 
- Whether agents should inspect `stdout`/`stderr` before deciding a retry is warranted
- Whether the system prompt should guide command-result interpretation differently for different tool families
- Whether instrumentation should separately track "execution failed" vs "findings returned"

For now, this PR keeps the scope narrow: fix the tools that account for most daily developer interactions.agent

## Test plan

- [x] `bun test src/tools/BashTool/commandSemantics.test. 58/58 passts` 
- [x] `bun test src/tools/ 126/126 pass (no regressions)BashTool/` 
- [x] `tsc -- no new errors in changed filenoEmit` 

New tests cover each tool family, the pylint bitfield (including OR-ed codes like 17 and 20), runner unwrapping, version pins, path-based invocations, compound chains, and the negative case (`python script.py` exit 1 stays a real error).

