### PR TITLE
fix(repl): inject [INTERRUPTED] signal after user-cancel to break model momentum

### DIFF
--- a/src/__tests__/bugfixes.test.ts
+++ b/src/__tests__/bugfixes.test.ts
@@ -427,7 +427,9 @@ describe('Interrupt correction context injection (issue #1422)', () => {
 
   test('REPL snapshots ref into wasInterrupted before try block to prevent stale writes on throw', async () => {
     const content = await file('screens/REPL.tsx').text()
-    expect(content).toContain('const wasInterrupted = hadInterruptedTurnRef.current')
+    // shouldQuery gate ensures local/slash commands (shouldQuery=false) leave the
+    // flag intact for the next real model query.
+    expect(content).toContain('const wasInterrupted = shouldQuery && hadInterruptedTurnRef.current')
     // Reset must happen before try, not inside it
     const resetIdx = content.indexOf('hadInterruptedTurnRef.current = false')
     const tryIdx = content.indexOf('try {', content.indexOf('wasInterrupted'))

--- a/src/__tests__/bugfixes.test.ts
+++ b/src/__tests__/bugfixes.test.ts
@@ -6,6 +6,7 @@
  * 2. Session timeout / 500 error fix (stream idle timeout)
  * 3. Agent loop continuation nudge
  * 4. Web search result count improvements
+ * 5. [INTERRUPTED] correction context injection after user-cancel (issue #1422)
  */
 
 import { describe, test, expect } from 'bun:test'
@@ -408,5 +409,90 @@ describe('Project-scope MCP approval — third-party providers (issue #696)', ()
   test('issue #696 is referenced from the comment so future readers can find context', async () => {
     const content = await file('interactiveHelpers.tsx').text()
     expect(content).toContain('#696')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Fix 5: [INTERRUPTED] correction context injection after user-cancel (issue #1422)
+// When the model executes real tool calls before Escape, the auto-rewind is
+// skipped (messagesAfterAreOnlySynthetic returns false). The fix prepends a
+// meta user message with an [INTERRUPTED] signal so the model breaks momentum.
+// ---------------------------------------------------------------------------
+describe('Interrupt correction context injection (issue #1422)', () => {
+  test('REPL declares hadInterruptedTurnRef for cross-query interrupt tracking', async () => {
+    const content = await file('screens/REPL.tsx').text()
+    expect(content).toContain('hadInterruptedTurnRef')
+    expect(content).toContain('useRef(false)')
+  })
+
+  test('REPL snapshots ref into wasInterrupted before try block to prevent stale writes on throw', async () => {
+    const content = await file('screens/REPL.tsx').text()
+    expect(content).toContain('const wasInterrupted = hadInterruptedTurnRef.current')
+    // Reset must happen before try, not inside it
+    const resetIdx = content.indexOf('hadInterruptedTurnRef.current = false')
+    const tryIdx = content.indexOf('try {', content.indexOf('wasInterrupted'))
+    expect(resetIdx).toBeGreaterThan(-1)
+    expect(tryIdx).toBeGreaterThan(resetIdx)
+  })
+
+  test('REPL injects [INTERRUPTED] marker as isMeta user message', async () => {
+    const content = await file('screens/REPL.tsx').text()
+    expect(content).toContain('[INTERRUPTED]')
+    expect(content).toContain('Disregard prior tool calls')
+    // Marker must be sent as a meta message (hidden from REPL, visible to model)
+    const markerIdx = content.indexOf('[INTERRUPTED]')
+    const metaIdx = content.indexOf('isMeta: true', markerIdx - 200)
+    expect(metaIdx).toBeGreaterThan(-1)
+  })
+
+  test('REPL guards finally-block ref write with !queryGuard.isActive to prevent cancel+resubmit race corruption', async () => {
+    const content = await file('screens/REPL.tsx').text()
+    // The setter must check isActive so a racing new query does not get a
+    // spurious [INTERRUPTED] injected two turns later.
+    expect(content).toMatch(/user-cancel.*queryGuard\.isActive|queryGuard\.isActive.*user-cancel/)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Unit: messagesAfterAreOnlySynthetic gate (drives injection decision)
+// ---------------------------------------------------------------------------
+describe('messagesAfterAreOnlySynthetic — injection gate for #1422', () => {
+  test('returns false when assistant made tool calls — injection should fire', async () => {
+    const { messagesAfterAreOnlySynthetic } = await import('../utils/messageFilters.js')
+    const { createUserMessage, createAssistantMessage } = await import('../utils/messages.js')
+    const msgs = [
+      createUserMessage({ content: 'do X' }),
+      createAssistantMessage({ content: [{ type: 'tool_use', id: 'tu_1', name: 'Bash', input: {} }] as any }),
+    ]
+    expect(messagesAfterAreOnlySynthetic(msgs, 0)).toBe(false)
+  })
+
+  test('returns false when assistant produced text — injection should fire', async () => {
+    const { messagesAfterAreOnlySynthetic } = await import('../utils/messageFilters.js')
+    const { createUserMessage, createAssistantMessage } = await import('../utils/messages.js')
+    const msgs = [
+      createUserMessage({ content: 'do X' }),
+      createAssistantMessage({ content: [{ type: 'text', text: 'I will do X' }] as any }),
+    ]
+    expect(messagesAfterAreOnlySynthetic(msgs, 0)).toBe(false)
+  })
+
+  test('returns true when nothing meaningful after user message — injection skipped (auto-rewind path)', async () => {
+    const { messagesAfterAreOnlySynthetic } = await import('../utils/messageFilters.js')
+    const { createUserMessage } = await import('../utils/messages.js')
+    const msgs = [
+      createUserMessage({ content: 'do X' }),
+    ]
+    expect(messagesAfterAreOnlySynthetic(msgs, 0)).toBe(true)
+  })
+
+  test('isMeta user messages (e.g. the [INTERRUPTED] marker itself) are not meaningful', async () => {
+    const { messagesAfterAreOnlySynthetic } = await import('../utils/messageFilters.js')
+    const { createUserMessage } = await import('../utils/messages.js')
+    const msgs = [
+      createUserMessage({ content: 'do X' }),
+      createUserMessage({ content: '[INTERRUPTED] ...', isMeta: true }),
+    ]
+    expect(messagesAfterAreOnlySynthetic(msgs, 0)).toBe(true)
   })
 })

--- a/src/screens/REPL.tsx
+++ b/src/screens/REPL.tsx
@@ -920,6 +920,11 @@ export function REPL({
   // defined, read in the onQuery finally block for auto-restore on interrupt.
   const restoreMessageSyncRef = useRef<(m: UserMessage) => void>(() => { });
 
+  // Set when a query ends via user-cancel; cleared on next onQuery start.
+  // Causes the next query to prepend an [INTERRUPTED] signal so the model
+  // breaks momentum from the prior (still-visible) tool calls.
+  const hadInterruptedTurnRef = useRef(false);
+
   // Ref to the fullscreen layout's scroll box for keyboard scrolling.
   // Null when fullscreen mode is disabled (ref never attached).
   const scrollRef = useRef<ScrollBoxHandle>(null);
@@ -2990,6 +2995,11 @@ export function REPL({
       });
       return;
     }
+    // Snapshot and clear the interrupt flag atomically before entering the
+    // try block — prevents a throw from leaving a stale true that bleeds
+    // into the query after next.
+    const wasInterrupted = hadInterruptedTurnRef.current;
+    hadInterruptedTurnRef.current = false;
     try {
       // isLoading is derived from queryGuard — tryStart() above already
       // transitioned dispatching→running, so no setter call needed here.
@@ -3001,7 +3011,26 @@ export function REPL({
       // Idempotent with respect to the end-of-turn reset — double-reset
       // is a no-op.
       resetCurrentTurn();
-      setMessages(oldMessages => [...oldMessages, ...newMessages]);
+
+      // If the previous turn ended via user-cancel and the model had real
+      // progress (tool calls that weren't auto-rewound), prepend an explicit
+      // interrupt signal so the model doesn't re-execute the original task.
+      let messagesToQueue: MessageType[] = newMessages;
+      if (wasInterrupted) {
+        const currentMsgs = messagesRef.current;
+        const lastUserMsg = currentMsgs.findLast(selectableUserMessagesFilter);
+        if (lastUserMsg && !messagesAfterAreOnlySynthetic(currentMsgs, currentMsgs.lastIndexOf(lastUserMsg))) {
+          messagesToQueue = [
+            createUserMessage({
+              content: '[INTERRUPTED] Previous attempt was stopped by the user. Disregard prior tool calls. Follow only the next instruction.\n',
+              isMeta: true,
+            }),
+            ...newMessages,
+          ];
+        }
+      }
+
+      setMessages(oldMessages => [...oldMessages, ...messagesToQueue]);
       responseLengthRef.current = 0;
       if (feature('TOKEN_BUDGET')) {
         const parsedBudget = input ? parseTokenBudget(input) : null;
@@ -3136,6 +3165,14 @@ export function REPL({
         // controller makes ctrl+c fire onCancel() (aborting nothing) instead of
         // propagating to the double-press exit flow.
         setAbortController(null);
+      }
+
+      // Mark that the next query should inject an [INTERRUPTED] correction context.
+      // Guard with !queryGuard.isActive: in the cancel+resubmit race the new
+      // query has already started, so setting the ref here would corrupt the
+      // query after that one instead.
+      if (abortController.signal.reason === 'user-cancel' && !queryGuard.isActive) {
+        hadInterruptedTurnRef.current = true;
       }
 
       // Auto-restore: if the user interrupted before any meaningful response

--- a/src/screens/REPL.tsx
+++ b/src/screens/REPL.tsx
@@ -925,6 +925,10 @@ export function REPL({
   // breaks momentum from the prior (still-visible) tool calls.
   const hadInterruptedTurnRef = useRef(false);
 
+  // True while a model-bound query (shouldQuery=true) owns the queryGuard.
+  // Used by onCancel to avoid marking local-command cancels as interrupts.
+  const isModelTurnActiveRef = useRef(false);
+
   // Ref to the fullscreen layout's scroll box for keyboard scrolling.
   // Null when fullscreen mode is disabled (ref never attached).
   const scrollRef = useRef<ScrollBoxHandle>(null);
@@ -2207,7 +2211,9 @@ export function REPL({
     // Record user-cancel synchronously so the next onQuery sees it
     // immediately, even if the aborted turn's finally fires as a microtask
     // after onQuery has already started and snapshotted the flag.
-    if (wasQueryActive) {
+    // Only set for model-bound turns — local-command cancels must not leave
+    // a spurious [INTERRUPTED] marker for the next real model prompt.
+    if (wasQueryActive && isModelTurnActiveRef.current) {
       hadInterruptedTurnRef.current = true;
     }
 
@@ -3003,6 +3009,9 @@ export function REPL({
       });
       return;
     }
+    // Track whether the current guard owns a model turn so onCancel can
+    // distinguish model-bound cancels from local-command cancels.
+    isModelTurnActiveRef.current = shouldQuery;
     // Snapshot and clear the interrupt flag only for model queries — local
     // and slash commands (shouldQuery=false) must leave the flag so the next
     // real model query still sees it. Clear before the try block so a throw
@@ -3180,8 +3189,9 @@ export function REPL({
       // outside onCancel). The primary path is onCancel() setting the ref
       // synchronously above. Guard with !queryGuard.isActive so the
       // cancel+resubmit race (new query already started) doesn't set the flag
-      // after the new query has already consumed it.
-      if (abortController.signal.reason === 'user-cancel' && !queryGuard.isActive) {
+      // after the new query has already consumed it. Only applies to
+      // model-bound turns — local-command cancels must not mark an interrupt.
+      if (shouldQuery && abortController.signal.reason === 'user-cancel' && !queryGuard.isActive) {
         hadInterruptedTurnRef.current = true;
       }
 

--- a/src/screens/REPL.tsx
+++ b/src/screens/REPL.tsx
@@ -2200,8 +2200,16 @@ export function REPL({
     if (feature('PROACTIVE') || feature('KAIROS')) {
       proactiveModule?.pauseProactive();
     }
+    const wasQueryActive = queryGuard.isActive;
     queryGuard.forceEnd();
     skipIdleCheckRef.current = false;
+
+    // Record user-cancel synchronously so the next onQuery sees it
+    // immediately, even if the aborted turn's finally fires as a microtask
+    // after onQuery has already started and snapshotted the flag.
+    if (wasQueryActive) {
+      hadInterruptedTurnRef.current = true;
+    }
 
     // Preserve partially-streamed text so the user can read what was
     // generated before pressing Esc. Pushed before resetLoadingState clears
@@ -2995,11 +3003,12 @@ export function REPL({
       });
       return;
     }
-    // Snapshot and clear the interrupt flag atomically before entering the
-    // try block — prevents a throw from leaving a stale true that bleeds
-    // into the query after next.
-    const wasInterrupted = hadInterruptedTurnRef.current;
-    hadInterruptedTurnRef.current = false;
+    // Snapshot and clear the interrupt flag only for model queries — local
+    // and slash commands (shouldQuery=false) must leave the flag so the next
+    // real model query still sees it. Clear before the try block so a throw
+    // can't leave stale true bleeding into the query after next.
+    const wasInterrupted = shouldQuery && hadInterruptedTurnRef.current;
+    if (wasInterrupted) hadInterruptedTurnRef.current = false;
     try {
       // isLoading is derived from queryGuard — tryStart() above already
       // transitioned dispatching→running, so no setter call needed here.
@@ -3167,10 +3176,11 @@ export function REPL({
         setAbortController(null);
       }
 
-      // Mark that the next query should inject an [INTERRUPTED] correction context.
-      // Guard with !queryGuard.isActive: in the cancel+resubmit race the new
-      // query has already started, so setting the ref here would corrupt the
-      // query after that one instead.
+      // Belt-and-suspenders for edge cases (e.g. direct abort('user-cancel')
+      // outside onCancel). The primary path is onCancel() setting the ref
+      // synchronously above. Guard with !queryGuard.isActive so the
+      // cancel+resubmit race (new query already started) doesn't set the flag
+      // after the new query has already consumed it.
       if (abortController.signal.reason === 'user-cancel' && !queryGuard.isActive) {
         hadInterruptedTurnRef.current = true;
       }

--- a/src/screens/REPL.tsx
+++ b/src/screens/REPL.tsx
@@ -3209,6 +3209,10 @@ export function REPL({
             // otherwise Up-arrow shows the restored text twice.
             removeLastFromHistory();
             restoreMessageSyncRef.current(lastUserMsg);
+            // The canceled turn was fully rewound, so there is no
+            // tool-call momentum to break. Clear the flag so the next
+            // real model query doesn't receive a spurious [INTERRUPTED].
+            hadInterruptedTurnRef.current = false;
           }
         }
       }


### PR DESCRIPTION
## Summary

Fixes #1422.

When the model executes real tool calls before an Escape interrupt, `messagesAfterAreOnlySynthetic` returns `false` so the auto-rewind is skipped. The original instruction + all tool calls remain in conversation history, causing the model to ignore the user's correction and repeat the original behavior.

- Add `hadInterruptedTurnRef` to track user-cancel aborts across query boundaries
- On the next query submission, if history shows non-synthetic model progress (tool calls), prepend a meta user message with an `[INTERRUPTED]` signal before the correction
- Marker is `isMeta: true` — hidden in the REPL, but present in the API context to break model momentum

## Race safety

- Ref snapshotted into `wasInterrupted` and cleared **before** the `try` block — a throw can't leave a stale `true` that bleeds into the query after next
- Finally-block setter guarded with `&& !queryGuard.isActive` — in the cancel+resubmit race the new query has already started; writing the ref there would corrupt the query after that one

## Test plan

- [x] Reproduce #1422: give a task, interrupt mid-tool-call, type a correction → model should follow correction, not repeat original task
- [ ] Fast cancel (no tool calls): auto-rewind triggers as before, no `[INTERRUPTED]` injected (`messagesAfterAreOnlySynthetic` gate)
- [ ] Cancel+resubmit race: no spurious injection into unrelated follow-up queries

🤖 Generated with [Claude Code](https://claude.com/claude-code)