### PR TITLE
test(build): add WebFetch SSRF-guard bundle regression test (runtime fix landed via #1399)

### DIFF
--- a/scripts/missing-module-stub.test.ts
+++ b/scripts/missing-module-stub.test.ts
@@ -22,3 +22,26 @@ test('/dream command is present in the CLI bundle', () => {
     /missing-module-stub:.*commands\/dream\/dream\.js/,
   )
 })
+
+// Regression for the WebFetch SSRF guard. WebFetchTool passes the real
+// ssrfGuardedLookup (src/utils/hooks/ssrfGuard.ts) as its DNS `lookup`. A
+// string-literal import of that module inside
+// src/__tests__/security-hardening.test.ts previously registered the specifier
+// as missing, and the specifier-keyed resolver then replaced WebFetch's real
+// import with a noop in dist/cli.mjs — silently disabling SSRF protection. The
+// source-level test only reads src/tools/WebFetchTool/utils.ts, so it cannot
+// catch a bundle-only regression; assert against the shipped bundle instead.
+test('WebFetch binds the real ssrfGuardedLookup in the CLI bundle', () => {
+  if (!existsSync(DIST)) {
+    throw new Error(
+      'dist/cli.mjs not found — run `bun run build` before this test',
+    )
+  }
+
+  const bundle = readFileSync(DIST, 'utf-8')
+
+  // The real guard's distinctive blocked-address error must be bundled...
+  expect(bundle).toContain('private/link-local address')
+  // ...and ssrfGuard must not have been replaced by a missing-module stub.
+  expect(bundle).not.toMatch(/missing-module-stub:.*ssrfGuard/)
+})


### PR DESCRIPTION
## What this PR does

Adds a bundle-level regression test asserting that the shipped CLI bundle binds the **real** `ssrfGuardedLookup` for WebFetch, rather than a `missing-module-stub` noop.

The underlying runtime fix already landed on `main` via #1399, which switched the build's missing-import scanner to track unresolved relative imports **per importer** (so a missing specifier from one directory no longer poisons a real module of the same specifier elsewhere) and added `/dream` bundle regression coverage. This branch is now rebased on that and contains only the additional test.

## Background (already fixed on main)

The previous specifier-string-keyed scanner stubbed real modules when a test file referenced a same-named-but-missing specifier:

- **WebFetch SSRF guard** was noop-ed because `src/__tests__/security-hardening.test.ts` contained a string-literal `'../../utils/hooks/ssrfGuard.js'` that resolved to a nonexistent path, and the stub was keyed by specifier string for every importer.
- **`/dream`** was noop-ed by the same collision (`./dream.js` missing in `skills/bundled/`, real at `src/commands/dream/dream.ts`).

#1399's per-importer resolution fixed both.

## Why the extra test

The existing `src/__tests__/security-hardening.test.ts` assertion only reads the **source** file `src/tools/WebFetchTool/utils.ts`, so it stays green even if the shipped bundle stubbed the guard. This PR adds a bundle-inspection test (`scripts/missing-module-stub.test.ts`) that reads `dist/cli.mjs` and verifies WebFetch binds the real guard (asserts the guard's marker string is present and no `ssrfGuard` `missing-module-stub` marker remains), mirroring the `/dream` bundle test now on `main`.

## Verification

- `bun run build` then `bun test scripts/missing-module-stub.test.ts` → passes.
