### PR TITLE
fix(fork): render forked-worker messages, drop unmirrored /fork command

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -123,11 +123,6 @@ const peersCmd = feature('UDS_INBOX')
       require('./commands/peers/index.js') as typeof import('./commands/peers/index.js')
     ).default
   : null
-const forkCmd = feature('FORK_SUBAGENT')
-  ? (
-      require('./commands/fork/index.js') as typeof import('./commands/fork/index.js')
-    ).default
-  : null
 const buddy = isBuddyEnabled()
   ? (
       require('./commands/buddy/index.js') as typeof import('./commands/buddy/index.js')
@@ -348,7 +343,6 @@ const COMMANDS = memoize((): Command[] => [
   vim,
   wiki,
   ...(webCmd ? [webCmd] : []),
-  ...(forkCmd ? [forkCmd] : []),
   ...(buddy ? [buddy] : []),
   ...(proactive ? [proactive] : []),
   ...(briefCommand ? [briefCommand] : []),

--- a/src/commands/branch/index.ts
+++ b/src/commands/branch/index.ts
@@ -1,11 +1,12 @@
-import { feature } from 'bun:bundle'
 import type { Command } from '../../commands.js'
 
 const branch = {
   type: 'local-jsx',
   name: 'branch',
-  // 'fork' alias only when /fork doesn't exist as its own command
-  aliases: feature('FORK_SUBAGENT') ? [] : ['fork'],
+  // /branch always owns the 'fork' alias: the dedicated /fork slash command is
+  // not part of this build (unmirrored source), and FORK_SUBAGENT's forking is
+  // implicit (omitting subagent_type), not a slash command.
+  aliases: ['fork'],
   description: 'Create a branch of the current conversation at this point',
   argumentHint: '[name]',
   load: () => import('./branch.js'),

--- a/src/components/messages/UserForkBoilerplateMessage.test.tsx
+++ b/src/components/messages/UserForkBoilerplateMessage.test.tsx
@@ -1,0 +1,48 @@
+import { PassThrough } from 'node:stream'
+
+import { expect, test } from 'bun:test'
+import React from 'react'
+import stripAnsi from 'strip-ansi'
+
+import { render } from '../../ink.js'
+import { UserForkBoilerplateMessage } from './UserForkBoilerplateMessage.js'
+
+// Regression: FORK_SUBAGENT ships enabled, so UserTextMessage reaches this
+// branch whenever a user message contains <fork-boilerplate> (produced by
+// forkSubagent.buildChildMessage). No source file existed, so the build stubbed
+// the import to a noop default export and the named component was undefined,
+// crashing the render. Guard the named export and a compact render.
+test('exports a named UserForkBoilerplateMessage component (not a stub noop)', () => {
+  expect(typeof UserForkBoilerplateMessage).toBe('function')
+})
+
+const SAMPLE = `<fork-boilerplate>
+STOP. READ THIS FIRST.
+You are a forked worker process.
+RULES (non-negotiable):
+1. Do NOT spawn sub-agents.
+</fork-boilerplate>
+
+Your directive: investigate the auth refresh flow`
+
+test('renders the directive compactly and hides the boilerplate rules', async () => {
+  const stdout = new PassThrough()
+  let output = ''
+  stdout.on('data', chunk => {
+    output += chunk.toString()
+  })
+  ;(stdout as unknown as { columns: number }).columns = 120
+
+  const param = { type: 'text' as const, text: SAMPLE }
+  const instance = await render(
+    <UserForkBoilerplateMessage addMargin={true} param={param} />,
+    stdout as unknown as NodeJS.WriteStream,
+  )
+  await new Promise(resolve => setTimeout(resolve, 20))
+  instance.unmount()
+
+  const frame = stripAnsi(output)
+  expect(frame).toContain('investigate the auth refresh flow')
+  // The verbose worker rules must not be dumped into the transcript.
+  expect(frame).not.toContain('STOP. READ THIS FIRST')
+})

--- a/src/components/messages/UserForkBoilerplateMessage.tsx
+++ b/src/components/messages/UserForkBoilerplateMessage.tsx
@@ -1,0 +1,28 @@
+import type { TextBlockParam } from '@anthropic-ai/sdk/resources/index.mjs'
+import * as React from 'react'
+import { Box, Text } from '../../ink.js'
+import { FORK_DIRECTIVE_PREFIX } from '../../constants/xml.js'
+
+type Props = {
+  addMargin: boolean
+  param: TextBlockParam
+}
+
+// A fork-boilerplate user message carries the verbose forked-worker instruction
+// block (buildChildMessage in forkSubagent.ts) followed by `Your directive: …`.
+// Dumping the whole rules block into the transcript is noise; render a compact
+// marker with just the directive.
+export function UserForkBoilerplateMessage({ addMargin, param }: Props) {
+  const text = param.text ?? ''
+  const prefixIdx = text.indexOf(FORK_DIRECTIVE_PREFIX)
+  const directive =
+    prefixIdx === -1
+      ? ''
+      : text.slice(prefixIdx + FORK_DIRECTIVE_PREFIX.length).trim()
+  return (
+    <Box flexDirection="row" marginTop={addMargin ? 1 : 0}>
+      <Text dimColor={true}>⑂ forked worker</Text>
+      {directive ? <Text color="text">{`: ${directive}`}</Text> : null}
+    </Box>
+  )
+}

--- a/src/tools/AgentTool/forkSubagent.ts
+++ b/src/tools/AgentTool/forkSubagent.ts
@@ -24,7 +24,10 @@ import type { BuiltInAgentDefinition } from './loadAgentsDir.js'
  *   the parent's full conversation context and system prompt
  * - All agent spawns run in the background (async) for a unified
  *   `<task-notification>` interaction model
- * - `/fork <directive>` slash command is available
+ *
+ * (The `/fork <directive>` slash command is not part of this build — its source
+ * is unmirrored. Forking here is implicit, via omitting `subagent_type`; the
+ * `/fork` alias instead routes to `/branch`.)
  *
  * Mutually exclusive with coordinator mode — coordinator already owns the
  * orchestration role and has its own delegation model.


### PR DESCRIPTION
## Problem

`FORK_SUBAGENT` ships enabled, which makes two missing-module paths live in the bundle (same crash class as the recently-fixed `SnipBoundaryMessage`):

1. **`UserForkBoilerplateMessage` render crash.** `UserTextMessage` renders `<UserForkBoilerplateMessage>` whenever a user message contains `<fork-boilerplate>` — a marker that `forkSubagent.buildChildMessage` actually produces. No source file existed, so the build stubbed the import to a noop default export; the named component resolved to `undefined` and crashed the render of any forked-worker message.
2. **`/fork` noop command.** The slash command required `./commands/fork/index.js`, whose source was never mirrored. Its noop `.default` was truthy and spread into the command list, registering a command with no `name`/`description`/`call` — broken on enumeration.

Both were surfaced while auditing the bundle's missing-module stubs.

## Fix

- **Add `src/components/messages/UserForkBoilerplateMessage.tsx`.** Renders a compact dimmed marker with just the directive (parsed off `FORK_DIRECTIVE_PREFIX`) instead of dumping the verbose forked-worker rules block into the transcript.
- **Remove the `/fork` registration** from `commands.ts`. The implicit-fork machinery (`AgentTool` / `forkSubagent`, which is what `FORK_SUBAGENT` actually enables) is present and keeps working; only the unmirrored slash command is dropped. Same approach as the earlier `force-snip` removal.

## Verification

- Both stubs (`./UserForkBoilerplateMessage.js`, `./commands/fork/index.js`) are gone from `dist/cli.mjs`; the real component is bundled.
- `bun run smoke` passes.
- New component test (named export + compact render that hides the rules block) and `commands.test.ts` pass.

Note: this branch is cut from `main`, so the `ssrfGuard`/`dream` stubs are untouched here — those are fixed separately in the build-scanner PR.