### PR TITLE
fix(sandbox): guard annotateStderrWithSandboxFailures against missing runtime method (fixes Bash on builds without sandbox-runtime)

### DIFF
--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -850,10 +850,10 @@ export const Fragment = null;
           'instances': 'new Map()',
           'selectableUserMessagesFilter': '() => true',
           'messagesAfterAreOnlySynthetic': '() => false',
-          'SandboxManager': 'class { static isSupportedPlatform = () => false; static create = noop; static Version = \'\'; }',
+          'SandboxManager': 'class { static isSupportedPlatform = () => false; static create = noop; static Version = \'\'; static annotateStderrWithSandboxFailures = (_command, stderr) => stderr; }',
           'SandboxRuntimeConfigSchema': '{ parse: noop }',
           'SandboxViolationStore': 'null',
-          'BaseSandboxManager': 'class { static isSupportedPlatform = () => false; }',
+          'BaseSandboxManager': 'class { static isSupportedPlatform = () => false; static annotateStderrWithSandboxFailures = (_command, stderr) => stderr; }',
           'ExportResultCode': '{ SUCCESS: 0, FAILED: 1 }',
           'linkifyUrlsInText': '(s) => s',
         }

--- a/src/utils/sandbox/sandbox-adapter.ts
+++ b/src/utils/sandbox/sandbox-adapter.ts
@@ -968,7 +968,8 @@ export const SandboxManager: ISandboxManager = {
   waitForNetworkInitialization: BaseSandboxManager.waitForNetworkInitialization,
   getSandboxViolationStore: BaseSandboxManager.getSandboxViolationStore,
   annotateStderrWithSandboxFailures:
-    BaseSandboxManager.annotateStderrWithSandboxFailures,
+    BaseSandboxManager.annotateStderrWithSandboxFailures ??
+    ((_command: string, stderr: string): string => stderr),
   cleanupAfterCommand: (): void => {
     BaseSandboxManager.cleanupAfterCommand()
     scrubBareGitRepoFiles()


### PR DESCRIPTION
## Problem

On builds where the underlying `@anthropic-ai/sandbox-runtime` does **not** provide `annotateStderrWithSandboxFailures` (e.g. the published npm bundle, where the bundled sandbox-runtime stub omits the method), **every Bash command fails** with:

```
Error: SandboxManager2.annotateStderrWithSandboxFailures is not a function
```

### Why

`src/utils/sandbox/sandbox-adapter.ts` builds the `SandboxManager` adapter by forwarding the method straight through:

```ts
annotateStderrWithSandboxFailures:
  BaseSandboxManager.annotateStderrWithSandboxFailures,
```

When `BaseSandboxManager` lacks it, the property is `undefined`. `src/tools/BashTool/BashTool.tsx` then calls it **unconditionally** on the result of every command:

```ts
const outputWithSbFailures = SandboxManager.annotateStderrWithSandboxFailures(input.command, result.stdout || '');
```

→ `undefined(...)` → throws. The error is byte-for-byte identical on every command (even `ls`), because it fails before/instead of producing output. Sandboxing is already disabled in these environments (`isSupportedPlatform()` is false), but this call is not gated by `isSandboxingEnabled()`, so it runs regardless. Only the Bash result-annotation path is affected — other tools work.

## Fix

Fall back to a passthrough when the method is absent:

```ts
annotateStderrWithSandboxFailures:
  BaseSandboxManager.annotateStderrWithSandboxFailures ??
  ((_command: string, stderr: string): string => stderr),
```

With no sandbox there are no violations to annotate, so returning the output unchanged is semantically correct. One line, type-safe (matches the `ISandboxManager` signature), and **no behavior change when the real method is present**.

## Repro

Run any Bash command via the SDK on a build whose sandbox-runtime stub omits `annotateStderrWithSandboxFailures` (e.g. the current published `@gitlawb/openclaude` npm package) → every command throws the error above. With this patch, Bash works.