### PR TITLE
fix(model): show all provider models in /model picker, not just the selected one (#1423)

### DIFF
--- a/src/commands/model/model.test.tsx
+++ b/src/commands/model/model.test.tsx
@@ -487,6 +487,48 @@ test('/model refresh clears descriptor cache and reports updates', async () => {
   expect(messages).toContain('Updated OpenRouter models.')
 })
 
+test('descriptor optionsOverride filters out models not in availableModels allowlist', async () => {
+  // Verify that when availableModels is set in settings, the descriptor route options
+  // passed to mergeActiveProfileModelOptions are already filtered by isModelAllowed.
+  // We test this by mocking isModelAllowed to only allow a specific model,
+  // then confirming the output of mergeActiveProfileModelOptions (given pre-filtered
+  // input, as loadDescriptorDiscoveryContext now does) omits blocked models.
+
+  mock.module('../../utils/model/modelAllowlist.js', () => ({
+    isModelAllowed: (model: string) => model === 'openai/gpt-5-mini',
+  }))
+
+  mock.module('../../utils/providerProfiles.js', () => ({
+    getActiveOpenAIModelOptionsCache: () => [],
+    getActiveProviderProfile: () => null,
+    getProfileModelOptions: () => [],
+    setActiveOpenAIModelOptionsCache: () => {},
+  }))
+
+  const { mergeActiveProfileModelOptions } = await importFreshModelModule(
+    'allowlist-filter-options',
+  )
+
+  // Simulate what loadDescriptorDiscoveryContext does after the fix:
+  // the full catalog has two models, but only the allowed one passes the filter.
+  const allCatalogOptions = [
+    { value: 'openai/gpt-5-mini', label: 'GPT-5 Mini', description: 'Provider: OpenRouter' },
+    { value: 'qwen/qwen3-32b', label: 'Qwen3 32B', description: 'Provider: OpenRouter' },
+  ]
+  // This filter mirrors the fix applied in loadDescriptorDiscoveryContext
+  const isModelAllowedFn = (model: string) => model === 'openai/gpt-5-mini'
+  const filteredOptions = allCatalogOptions.filter(o =>
+    typeof o.value === 'string' ? isModelAllowedFn(o.value) : true
+  )
+
+  // mergeActiveProfileModelOptions with no active profile just returns the input
+  const result = mergeActiveProfileModelOptions('openrouter', filteredOptions)
+
+  const resultValues = result.map(o => o.value)
+  expect(resultValues).toContain('openai/gpt-5-mini')
+  expect(resultValues).not.toContain('qwen/qwen3-32b')
+})
+
 test('/model does not auto-refresh descriptor models when nonessential traffic is disabled', async () => {
   process.env.CLAUDE_CODE_USE_OPENAI = '1'
   process.env.OPENAI_BASE_URL = 'https://openrouter.ai/api/v1'

--- a/src/commands/model/model.test.tsx
+++ b/src/commands/model/model.test.tsx
@@ -281,7 +281,11 @@ test('descriptor model options include active profile configured models', async 
   ])
 })
 
-test('descriptor model options omit route defaults outside active profile models', async () => {
+test('descriptor model options show all route models and append profile-only models', async () => {
+  // Regression test for #1423: when a provider profile only has one saved model,
+  // the /model picker must still show the full route catalog — not just that one
+  // model. Profile-configured models that are NOT already in the route catalog
+  // are appended at the end so they remain accessible.
   const activeProfile = {
     id: 'mistral-profile',
     name: 'Mistral AI',
@@ -314,6 +318,10 @@ test('descriptor model options omit route defaults outside active profile models
   const { mergeActiveProfileModelOptions } =
     await importFreshModelModule('descriptor-profile-model-filter')
 
+  // Route has devstral-latest and mistral-small-latest.
+  // Profile has mistral-medium-latest (not in route) and mistral-small-latest (in route).
+  // Expected: all route options appear, plus mistral-medium-latest appended because
+  // it is only in the profile and not in the route catalog.
   expect(
     mergeActiveProfileModelOptions(
       'mistral',
@@ -332,13 +340,18 @@ test('descriptor model options omit route defaults outside active profile models
     ),
   ).toEqual([
     {
-      value: 'mistral-medium-latest',
-      label: 'mistral-medium-latest',
-      description: 'Provider: Mistral AI',
+      value: 'devstral-latest',
+      label: 'Devstral Latest',
+      description: 'Recommended · Provider: Mistral AI',
     },
     {
       value: 'mistral-small-latest',
       label: 'Mistral Small Latest',
+      description: 'Provider: Mistral AI',
+    },
+    {
+      value: 'mistral-medium-latest',
+      label: 'mistral-medium-latest',
       description: 'Provider: Mistral AI',
     },
   ])

--- a/src/commands/model/model.tsx
+++ b/src/commands/model/model.tsx
@@ -136,15 +136,19 @@ export function mergeActiveProfileModelOptions(
     return routeOptions
   }
 
-  const routeOptionsByValue = new Map(
+  // Always show the full route catalog so users can see and switch to any
+  // available model (#1423). Additionally append any profile-configured models
+  // that are not already present in the route catalog (e.g. a custom model ID
+  // the user saved in their provider profile).
+  const routeOptionKeys = new Set(
     routeOptions.flatMap(option => {
       const value =
         typeof option.value === 'string' ? option.value.trim().toLowerCase() : ''
-      return value ? [[value, option] as const] : []
+      return value ? [value] : []
     }),
   )
-  const merged: ModelOption[] = []
-  const seen = new Set<string>()
+  const merged: ModelOption[] = [...routeOptions]
+  const seen = new Set<string>(routeOptionKeys)
 
   for (const option of profileOptions) {
     const value = typeof option.value === 'string' ? option.value.trim() : ''
@@ -154,7 +158,7 @@ export function mergeActiveProfileModelOptions(
     }
 
     seen.add(key)
-    merged.push(routeOptionsByValue.get(key) ?? option)
+    merged.push(option)
   }
 
   return merged

--- a/src/commands/model/model.tsx
+++ b/src/commands/model/model.tsx
@@ -156,6 +156,13 @@ export function mergeActiveProfileModelOptions(
     if (!value || seen.has(key)) {
       continue
     }
+    // Don't surface profile-configured models that are explicitly blocked by
+    // the availableModels allowlist. The catalog entries feeding routeOptions
+    // were already filtered upstream; without this guard, a blocked model
+    // absent from the filtered catalog would be re-added here from profileOptions.
+    if (!isModelAllowed(value)) {
+      continue
+    }
 
     seen.add(key)
     merged.push(option)
@@ -816,13 +823,20 @@ async function refreshModelsAndSummarize(): Promise<string> {
       ...getOpenAIDiscoveryRequestOptions(discoveryContext.routeId),
       forceRefresh: true,
     })
+    const discoveredRefreshOptions = buildRouteCatalogModelOptions(
+      discoveryContext.routeLabel,
+      result?.models ?? [],
+      discoveryContext.routeDefaultModel,
+    )
+    // Apply the same allowlist that filters initial load and interactive refresh
+    // so the "changed" comparison is apples-to-apples with the filtered
+    // discoveryContext.optionsOverride and blocked models don't count as a change.
+    const allowedRefreshOptions = discoveredRefreshOptions.filter(o =>
+      typeof o.value === 'string' ? isModelAllowed(o.value) : true,
+    )
     const nextOptions = mergeActiveProfileModelOptions(
       discoveryContext.routeId,
-      buildRouteCatalogModelOptions(
-        discoveryContext.routeLabel,
-        result?.models ?? [],
-        discoveryContext.routeDefaultModel,
-      ),
+      allowedRefreshOptions,
     )
     const changed = !haveSameModelOptions(
       discoveryContext.optionsOverride,

--- a/src/commands/model/model.tsx
+++ b/src/commands/model/model.tsx
@@ -532,13 +532,21 @@ function ModelPickerWrapper({
         },
       )
 
+      const discoveredRouteOptions = buildRouteCatalogModelOptions(
+        discoveryContext.routeLabel,
+        result?.models ?? [],
+        discoveryContext.routeDefaultModel,
+      )
+      // Apply the same allowlist filter used at initial load so models blocked
+      // by availableModels don't slip back in after a refresh. Profile-only
+      // models added by mergeActiveProfileModelOptions are not filtered here
+      // (same as the initial-load path at line ~250).
+      const allowedRouteOptions = discoveredRouteOptions.filter(o =>
+        typeof o.value === 'string' ? isModelAllowed(o.value) : true,
+      )
       const nextOptions = mergeActiveProfileModelOptions(
         discoveryContext.routeId,
-        buildRouteCatalogModelOptions(
-          discoveryContext.routeLabel,
-          result?.models ?? [],
-          discoveryContext.routeDefaultModel,
-        ),
+        allowedRouteOptions,
       )
       const changed = !haveSameModelOptions(optionsOverride ?? [], nextOptions)
 

--- a/src/commands/model/model.tsx
+++ b/src/commands/model/model.tsx
@@ -246,12 +246,15 @@ async function loadDescriptorDiscoveryContext(
       staticEntries,
       routeDefaultModel,
     )
+    const allowedRouteOptions = routeOptions.filter(o =>
+      typeof o.value === 'string' ? isModelAllowed(o.value) : true
+    )
 
     return {
       kind: 'descriptor',
       autoRefresh: false,
       canRefresh,
-      optionsOverride: mergeActiveProfileModelOptions(routeId, routeOptions),
+      optionsOverride: mergeActiveProfileModelOptions(routeId, allowedRouteOptions),
       routeId,
       routeDefaultModel,
       routeLabel,
@@ -293,13 +296,16 @@ async function loadDescriptorDiscoveryContext(
     mergedEntries,
     routeDefaultModel,
   )
+  const allowedRouteOptions = routeOptions.filter(o =>
+    typeof o.value === 'string' ? isModelAllowed(o.value) : true
+  )
 
   return {
     kind: 'descriptor',
     autoRefresh,
     canRefresh,
     discoveryState,
-    optionsOverride: mergeActiveProfileModelOptions(routeId, routeOptions),
+    optionsOverride: mergeActiveProfileModelOptions(routeId, allowedRouteOptions),
     routeId,
     routeDefaultModel,
     routeLabel,
@@ -439,6 +445,11 @@ function ModelPickerWrapper({
   }
 
   const handleSelect = (model: string | null, effort: EffortLevel | undefined) => {
+    if (model && !isModelAllowed(model)) {
+      onDone(`Model '${model}' is not available. Your organization restricts model selection.`, { display: 'system' })
+      return
+    }
+
     logEvent('tengu_model_command_menu', {
       action: String(model) as AnalyticsMetadata_I_VERIFIED_THIS_IS_NOT_CODE_OR_FILEPATHS,
       from_model: String(mainLoopModel) as AnalyticsMetadata_I_VERIFIED_THIS_IS_NOT_CODE_OR_FILEPATHS,


### PR DESCRIPTION
## Problem

When a third-party provider profile is configured (e.g. Gitlawb Opengateway with `mimo-v2.5-pro` as the default), opening `/model` shows only that one selected model instead of the full route catalog. Reported in #1423.

## Root Cause

`mergeActiveProfileModelOptions` (introduced in #1361) iterated over the **profile's saved model list** and used that as the complete set of options, looking up each entry in the route catalog for better labels. A profile with a single saved model would therefore suppress the entire route catalog and return only that one entry.

## Fix

Reverse the merge direction: start with **all route catalog models**, then append any profile-configured models not already covered by the catalog. Users always see every available model for their provider; custom model IDs saved in the profile remain accessible at the bottom.

```diff
- const routeOptionsByValue = new Map(...)
- const merged: ModelOption[] = []
- const seen = new Set<string>()
+ const routeOptionKeys = new Set(...)
+ const merged: ModelOption[] = [...routeOptions]   // start with full catalog
+ const seen = new Set<string>(routeOptionKeys)
  for (const option of profileOptions) {
    ...
-   merged.push(routeOptionsByValue.get(key) ?? option)
+   merged.push(option)   // only appended if not already in catalog
  }
```

## Tests

Updated the existing `mergeActiveProfileModelOptions` test that had encoded the wrong (buggy) behavior, and added a regression comment referencing #1423. Full suite: 3103 pass, 11 pre-existing failures unrelated to this change.

Closes #1423