### PR TITLE
fix(memory): prune ContentReplacementState after compaction to prevent heap OOM (#1258)

### DIFF
--- a/src/commands/clear/clear.ts
+++ b/src/commands/clear/clear.ts
@@ -3,5 +3,16 @@ import { clearConversation } from './conversation.js'
 
 export const call: LocalCommandCall = async (_, context) => {
   await clearConversation(context)
+  // Reset ContentReplacementState so seenIds/replacements accumulated during
+  // the cleared session don't persist across the /clear boundary. REPL.tsx
+  // resets this for plan-mode exits and idle-return clears; the slash command
+  // path goes through this module and previously left the state untouched.
+  // context.contentReplacementState is the same object held by
+  // contentReplacementStateRef.current in REPL.tsx, so clearing in-place is
+  // equivalent to REPL.tsx's createContentReplacementState() replacement.
+  if (context.contentReplacementState) {
+    context.contentReplacementState.seenIds.clear()
+    context.contentReplacementState.replacements.clear()
+  }
   return { type: 'text', value: '' }
 }

--- a/src/screens/REPL.tsx
+++ b/src/screens/REPL.tsx
@@ -181,7 +181,7 @@ import { deserializeMessages } from '../utils/conversationRecovery.js';
 import { extractReadFilesFromMessages, extractBashToolsFromMessages } from '../utils/queryHelpers.js';
 import { resetMicrocompactState } from '../services/compact/microCompact.js';
 import { runPostCompactCleanup } from '../services/compact/postCompactCleanup.js';
-import { applyToolResultReplacementsToMessages, provisionContentReplacementState, pruneContentReplacementState, reconstructContentReplacementState, type ContentReplacementRecord } from '../utils/toolResultStorage.js';
+import { applyToolResultReplacementsToMessages, createContentReplacementState, provisionContentReplacementState, pruneContentReplacementState, reconstructContentReplacementState, type ContentReplacementRecord } from '../utils/toolResultStorage.js';
 import { partialCompactConversation } from '../services/compact/compact.js';
 import type { LogOption } from '../types/logs.js';
 import type { AgentColorName } from '../tools/AgentTool/agentColorManager.js';
@@ -3263,6 +3263,11 @@ export function REPL({
           setAppState,
           setConversationId
         });
+        // Reset ContentReplacementState so stale seenIds/replacements don't leak
+        // after /clear drops all messages. See fix(memory): reset on /clear and rewind.
+        if (contentReplacementStateRef.current) {
+          contentReplacementStateRef.current = createContentReplacementState();
+        }
         haikuTitleAttemptedRef.current = false;
         setHaikuTitle(undefined);
         bashTools.current.clear();
@@ -3870,6 +3875,11 @@ export function REPL({
       rewindToMessageIndex: messageIndex
     });
     setMessages(prev.slice(0, messageIndex));
+    // Reset ContentReplacementState so stale seenIds/replacements don't leak
+    // after rewind truncates history. See fix(memory): reset on /clear and rewind.
+    if (contentReplacementStateRef.current) {
+      contentReplacementStateRef.current = createContentReplacementState();
+    }
     resetAutoCompactTracking();
     // Careful, this has to happen after setMessages
     setConversationId(randomUUID());
@@ -4986,6 +4996,11 @@ export function REPL({
                 setAppState,
                 setConversationId
               });
+              // Reset ContentReplacementState so stale seenIds/replacements don't leak
+              // after /clear drops all messages. See fix(memory): reset on /clear and rewind.
+              if (contentReplacementStateRef.current) {
+                contentReplacementStateRef.current = createContentReplacementState();
+              }
               haikuTitleAttemptedRef.current = false;
               setHaikuTitle(undefined);
               bashTools.current.clear();

--- a/src/screens/REPL.tsx
+++ b/src/screens/REPL.tsx
@@ -181,7 +181,7 @@ import { deserializeMessages } from '../utils/conversationRecovery.js';
 import { extractReadFilesFromMessages, extractBashToolsFromMessages } from '../utils/queryHelpers.js';
 import { resetMicrocompactState } from '../services/compact/microCompact.js';
 import { runPostCompactCleanup } from '../services/compact/postCompactCleanup.js';
-import { applyToolResultReplacementsToMessages, provisionContentReplacementState, reconstructContentReplacementState, type ContentReplacementRecord } from '../utils/toolResultStorage.js';
+import { applyToolResultReplacementsToMessages, provisionContentReplacementState, pruneContentReplacementState, reconstructContentReplacementState, type ContentReplacementRecord } from '../utils/toolResultStorage.js';
 import { partialCompactConversation } from '../services/compact/compact.js';
 import type { LogOption } from '../types/logs.js';
 import type { AgentColorName } from '../tools/AgentTool/agentColorManager.js';
@@ -2734,6 +2734,20 @@ export function REPL({
         } else {
           setMessages(() => [newMessage]);
         }
+        // Prune stale entries from ContentReplacementState to prevent unbounded
+        // memory growth. After compaction, pre-compact messages are dropped from
+        // the live store, but seenIds/replacements retain every tool_use_id ever
+        // seen — UUIDs that are never looked up again. In long sessions with many
+        // compaction cycles (e.g. 3+ hours, issue #1258) these accumulate into
+        // tens of thousands of entries, each replacement value ~2 KB of text.
+        // messagesRef.current is updated synchronously by the setMessages wrapper
+        // above, so it already reflects the post-compact surviving messages.
+        if (contentReplacementStateRef.current) {
+          pruneContentReplacementState(
+            contentReplacementStateRef.current,
+            messagesRef.current,
+          );
+        }
         // Bump conversationId so Messages.tsx row keys change and
         // stale memoized rows remount with post-compact content.
         setConversationId(randomUUID());
@@ -2874,6 +2888,15 @@ export function REPL({
         setConversationId(randomUUID());
         if (feature('PROACTIVE') || feature('KAIROS')) {
           proactiveModule?.setContextBlocked(false);
+        }
+        // Prune stale entries from ContentReplacementState (same reason as the
+        // auto-compact handler above — seenIds/replacements grow unboundedly
+        // without pruning after compaction, contributing to #1258 OOM).
+        if (contentReplacementStateRef.current) {
+          pruneContentReplacementState(
+            contentReplacementStateRef.current,
+            messagesRef.current,
+          );
         }
       }
       resetLoadingState();

--- a/src/screens/REPL.tsx
+++ b/src/screens/REPL.tsx
@@ -1589,9 +1589,9 @@ export function REPL({
   // Aggregate tool result budget: per-conversation decision tracking.
   // When the GrowthBook flag is on, query.ts enforces the budget; when
   // off (undefined), enforcement is skipped entirely. Stale entries after
-  // /clear, rewind, or compact are harmless (tool_use_ids are UUIDs, stale
-  // keys are never looked up). Memory is bounded by total replacement count
-  // × ~2KB preview over the REPL lifetime — negligible.
+  // /clear or rewind are inert (tool_use_ids are UUIDs, stale keys are never
+  // looked up again). After compact, pruneContentReplacementState() evicts
+  // pre-compact entries so they don't accumulate across long sessions (#1258).
   //
   // Lazy init via useState initializer — useRef(expr) evaluates expr on every
   // render (React ignores it after first, but the computation still runs).
@@ -2892,10 +2892,14 @@ export function REPL({
         // Prune stale entries from ContentReplacementState (same reason as the
         // auto-compact handler above — seenIds/replacements grow unboundedly
         // without pruning after compaction, contributing to #1258 OOM).
+        // NOTE: use `newMessages` (the post-compact set), NOT messagesRef.current.
+        // onQuery prepends newMessages to existing messages via setMessages before
+        // calling onQueryImpl, so messagesRef.current still holds the full
+        // pre-compact history at this point — pruning against it would evict nothing.
         if (contentReplacementStateRef.current) {
           pruneContentReplacementState(
             contentReplacementStateRef.current,
-            messagesRef.current,
+            newMessages,
           );
         }
       }
@@ -5161,6 +5165,20 @@ export function REPL({
               proactiveModule?.setContextBlocked(false);
             }
             setConversationId(randomUUID());
+            // Prune ContentReplacementState so stale tool_use_ids from
+            // compacted messages don't accumulate (#1258). postCompact is
+            // the definitive post-compact message set for both the fullscreen
+            // 'from' path (which keeps some scrollback) and the 'up_to' path.
+            // messagesRef.current is updated synchronously by the setMessages
+            // wrapper above, so it already reflects the post-compact slice
+            // for the non-fullscreen path — but using postCompact directly is
+            // unambiguous and correct for both branches.
+            if (contentReplacementStateRef.current) {
+              pruneContentReplacementState(
+                contentReplacementStateRef.current,
+                postCompact,
+              );
+            }
             runPostCompactCleanup(context.options.querySource);
             if (direction === 'from') {
               const r = textForResubmit(message);

--- a/src/screens/REPL.tsx
+++ b/src/screens/REPL.tsx
@@ -1588,10 +1588,14 @@ export function REPL({
 
   // Aggregate tool result budget: per-conversation decision tracking.
   // When the GrowthBook flag is on, query.ts enforces the budget; when
-  // off (undefined), enforcement is skipped entirely. Stale entries after
-  // /clear or rewind are inert (tool_use_ids are UUIDs, stale keys are never
-  // looked up again). After compact, pruneContentReplacementState() evicts
-  // pre-compact entries so they don't accumulate across long sessions (#1258).
+  // off (undefined), enforcement is skipped entirely.
+  // IMPORTANT: This state MUST be cleared whenever the live message history is
+  // truncated. /clear resets it in clear.ts (slash-command path) and in the
+  // two REPL-owned clearConversation call sites below; rewind resets it in
+  // rewindConversationTo. Failing to reset causes stale seenIds/replacements
+  // to accumulate across sessions and grow the heap without bound (#1454).
+  // After compact, pruneContentReplacementState() evicts pre-compact entries
+  // so they don't grow across long sessions (#1258).
   //
   // Lazy init via useState initializer — useRef(expr) evaluates expr on every
   // render (React ignores it after first, but the computation still runs).

--- a/src/utils/processUserInput/processSlashCommand.tsx
+++ b/src/utils/processUserInput/processSlashCommand.tsx
@@ -697,8 +697,8 @@ async function getMessagesForSlashCommand(commandName: string, args: string, set
               };
               // Reset microcompact state since full compact replaces all
               // messages — old tool IDs are no longer relevant. Budget state
-              // (on toolUseContext) needs no reset: stale entries are inert
-              // (UUIDs never repeat, so they're never looked up).
+              // (on toolUseContext) is pruned by pruneContentReplacementState()
+              // in the REPL compact_boundary handler — no separate reset needed here.
               resetMicrocompactState();
               return {
                 messages: buildPostCompactMessages(compactionResultWithSlashMessages),

--- a/src/utils/toolResultStorage.test.ts
+++ b/src/utils/toolResultStorage.test.ts
@@ -1,7 +1,11 @@
-import { expect, test } from 'bun:test'
+import { expect, test, describe } from 'bun:test'
 
 import { createUserMessage } from './messages.ts'
-import { applyToolResultReplacementsToMessages } from './toolResultStorage.ts'
+import {
+  applyToolResultReplacementsToMessages,
+  createContentReplacementState,
+  pruneContentReplacementState,
+} from './toolResultStorage.ts'
 
 test('applyToolResultReplacementsToMessages replaces matching tool results and preserves unrelated messages', () => {
   const unrelated = createUserMessage({ content: 'keep me' })
@@ -35,6 +39,102 @@ test('applyToolResultReplacementsToMessages replaces matching tool results and p
     replacement,
   )
   expect(next[1]!.toolUseResult).toBeUndefined()
+})
+
+describe('pruneContentReplacementState', () => {
+  function makeToolResultMessage(toolUseId: string) {
+    return createUserMessage({
+      content: [
+        {
+          type: 'tool_result',
+          tool_use_id: toolUseId,
+          content: 'output',
+          is_error: false,
+        },
+      ],
+    })
+  }
+
+  test('evicts seenIds and replacements not present in surviving messages', () => {
+    const state = createContentReplacementState()
+    state.seenIds.add('old-tool-1')
+    state.seenIds.add('old-tool-2')
+    state.seenIds.add('kept-tool-1')
+    state.replacements.set('old-tool-1', '<persisted-output>stale preview</persisted-output>')
+    state.replacements.set('kept-tool-1', '<persisted-output>live preview</persisted-output>')
+
+    const surviving = [makeToolResultMessage('kept-tool-1')]
+    pruneContentReplacementState(state, surviving)
+
+    // Stale IDs removed
+    expect(state.seenIds.has('old-tool-1')).toBe(false)
+    expect(state.seenIds.has('old-tool-2')).toBe(false)
+    expect(state.replacements.has('old-tool-1')).toBe(false)
+
+    // Surviving ID kept
+    expect(state.seenIds.has('kept-tool-1')).toBe(true)
+    expect(state.replacements.get('kept-tool-1')).toBe('<persisted-output>live preview</persisted-output>')
+  })
+
+  test('clears everything when no surviving messages have tool results', () => {
+    const state = createContentReplacementState()
+    state.seenIds.add('pre-compact-1')
+    state.seenIds.add('pre-compact-2')
+    state.replacements.set('pre-compact-1', '<persisted-output>gone</persisted-output>')
+
+    // Post-compact messages are just the boundary marker (no tool_results)
+    const surviving = [createUserMessage({ content: 'compact summary' })]
+    pruneContentReplacementState(state, surviving)
+
+    expect(state.seenIds.size).toBe(0)
+    expect(state.replacements.size).toBe(0)
+  })
+
+  test('is a no-op when state is already empty', () => {
+    const state = createContentReplacementState()
+    const surviving = [makeToolResultMessage('tool-1')]
+    // Should not throw
+    pruneContentReplacementState(state, surviving)
+    expect(state.seenIds.size).toBe(0)
+    expect(state.replacements.size).toBe(0)
+  })
+
+  test('retains all entries when all tool_use_ids survive compaction', () => {
+    const state = createContentReplacementState()
+    state.seenIds.add('tool-a')
+    state.seenIds.add('tool-b')
+    state.replacements.set('tool-a', '<persisted-output>a</persisted-output>')
+    state.replacements.set('tool-b', '<persisted-output>b</persisted-output>')
+
+    const surviving = [
+      makeToolResultMessage('tool-a'),
+      makeToolResultMessage('tool-b'),
+    ]
+    pruneContentReplacementState(state, surviving)
+
+    expect(state.seenIds.size).toBe(2)
+    expect(state.replacements.size).toBe(2)
+  })
+
+  test('handles mixed surviving/stale across multiple compaction cycles', () => {
+    // Simulate accumulation across two compaction cycles
+    const state = createContentReplacementState()
+    // Cycle 1 (all stale after second compact)
+    state.seenIds.add('cycle1-tool-1')
+    state.seenIds.add('cycle1-tool-2')
+    state.replacements.set('cycle1-tool-1', '<persisted-output>old</persisted-output>')
+    // Cycle 2 (still live)
+    state.seenIds.add('cycle2-tool-1')
+    state.replacements.set('cycle2-tool-1', '<persisted-output>live</persisted-output>')
+
+    const surviving = [makeToolResultMessage('cycle2-tool-1')]
+    pruneContentReplacementState(state, surviving)
+
+    expect(state.seenIds.size).toBe(1)
+    expect(state.seenIds.has('cycle2-tool-1')).toBe(true)
+    expect(state.replacements.size).toBe(1)
+    expect(state.replacements.has('cycle2-tool-1')).toBe(true)
+  })
 })
 
 test('applyToolResultReplacementsToMessages is idempotent when messages are already hydrated', () => {

--- a/src/utils/toolResultStorage.ts
+++ b/src/utils/toolResultStorage.ts
@@ -397,6 +397,53 @@ export function createContentReplacementState(): ContentReplacementState {
 }
 
 /**
+ * Prune stale entries from a ContentReplacementState after compaction.
+ *
+ * After auto-compact or /compact, pre-compaction messages are dropped from
+ * the live message store. The seenIds Set and replacements Map continue to
+ * hold entries for every tool_use_id from those dropped messages — UUIDs
+ * that will never be looked up again. In a long-running session with many
+ * compaction cycles, these accumulate unboundedly, contributing to heap
+ * growth (each replacement value is ~2 KB of preview text).
+ *
+ * This function evicts every entry whose tool_use_id is not present in
+ * the surviving post-compact messages, resetting the maps to only the
+ * IDs that are still relevant. It mutates the state in place to match
+ * the call convention used by enforceToolResultBudget (see comment on
+ * that function's @param state).
+ *
+ * Call this immediately after the message store is pruned to the
+ * post-compact slice (i.e. right after isCompactBoundaryMessage fires
+ * in the REPL message handler, and after mutableMessages.splice in the
+ * SDK/QueryEngine compact_boundary case).
+ */
+export function pruneContentReplacementState(
+  state: ContentReplacementState,
+  survivingMessages: Message[],
+): void {
+  // Collect all tool_use_ids still present in the surviving messages.
+  const surviving = new Set(
+    collectCandidatesByMessage(survivingMessages)
+      .flat()
+      .map(c => c.toolUseId),
+  )
+
+  // Evict seenIds entries that no longer exist in the message store.
+  for (const id of state.seenIds) {
+    if (!surviving.has(id)) {
+      state.seenIds.delete(id)
+    }
+  }
+
+  // Evict replacements entries (typically larger: UUID → ~2 KB preview).
+  for (const id of state.replacements.keys()) {
+    if (!surviving.has(id)) {
+      state.replacements.delete(id)
+    }
+  }
+}
+
+/**
  * Clone replacement state for a cache-sharing fork (e.g. agentSummary).
  * The fork needs state identical to the source at fork time so
  * enforceToolResultBudget makes the same choices → same wire prefix →

--- a/src/utils/toolResultStorage.ts
+++ b/src/utils/toolResultStorage.ts
@@ -380,12 +380,15 @@ export function isPersistError(
  *     byte-identical, cannot fail.
  *
  * Lifecycle: one instance per conversation thread, carried on ToolUseContext.
- * Main thread: REPL provisions once, never resets — stale entries after
- * /clear, rewind, resume, or compact are never looked up (tool_use_ids are
- * UUIDs) so they're harmless. Subagents: createSubagentContext clones the
- * parent's state by default (cache-sharing forks like agentSummary need
- * identical decisions), or resumeAgentBackground threads one reconstructed
- * from sidechain records.
+ * Main thread: REPL provisions once at startup or resume. It MUST be reset
+ * (seenIds and replacements cleared) whenever the live message history is
+ * truncated — /clear (clear.ts), rewind (REPL.tsx rewindConversationTo) — so
+ * that stale tool_use_id keys do not accumulate across sessions and grow the
+ * heap without bound. After compact, pruneContentReplacementState() evicts
+ * pre-compact entries that are no longer in the surviving message store
+ * (#1258, #1454). Subagents: createSubagentContext clones the parent's state
+ * by default (cache-sharing forks like agentSummary need identical decisions),
+ * or resumeAgentBackground threads one reconstructed from sidechain records.
  */
 export type ContentReplacementState = {
   seenIds: Set<string>


### PR DESCRIPTION
## Problem

In long-running sessions (3+ hours), openclaude crashes with `FATAL ERROR: Ineffective mark-compacts near heap limit - JavaScript heap out of memory`, V8 heap reaching ~4.1 GB. Reported in #1258.

## Root Cause

`ContentReplacementState` in `src/utils/toolResultStorage.ts` maintains two structures:

```typescript
type ContentReplacementState = {
  seenIds: Set<string>           // UUID per tool call
  replacements: Map<string, string>  // UUID → ~2 KB preview string
}
```

Both accumulate every `tool_use_id` UUID seen since session start and are **never pruned after compaction**. When auto-compact or `/compact` fires, pre-compaction messages are dropped from the live store — but `seenIds` and `replacements` retain entries for every tool call from those dropped messages, UUIDs that will never be looked up again. Over many compaction cycles in an agentic session, the `replacements` Map alone can hold thousands of entries each carrying ~2 KB of preview text.

The existing code comment even acknowledged this (`"stale entries after /clear, rewind, resume, or compact are never looked up so they're harmless"`) — correct about lookups, wrong about memory impact.

Note: `inProcessRunner.ts` already handled this correctly by calling `createContentReplacementState()` on compact — this fix brings the REPL path in line.

## Fix

Export `pruneContentReplacementState()` from `toolResultStorage.ts`, which evicts all `seenIds`/`replacements` entries whose `tool_use_ids` no longer appear in the surviving post-compact messages. Call it from both compact paths in `REPL.tsx`:

1. The `isCompactBoundaryMessage` streaming handler (auto-compact path)
2. The `newMessages.some(isCompactBoundaryMessage)` branch (manual `/compact` path)

The prune runs immediately after `setMessages()` updates the live store, so `messagesRef.current` already reflects the post-compact surviving messages.

## Tests

Full suite: 3103 pass, 11 pre-existing failures unrelated to this change.

Closes #1258