### PR TITLE
Fix on prem keepalive

### DIFF
--- a/src/services/api/fetchWithProxyRetry.test.ts
+++ b/src/services/api/fetchWithProxyRetry.test.ts
@@ -91,14 +91,6 @@ test('fetchWithProxyRetry does not retry non-network errors', async () => {
   expect(attempts).toBe(1)
 })
 
-test('isRetryableFetchError matches Bun "socket is cooked" failures', () => {
-  expect(
-    isRetryableFetchError(
-      new Error('TypeError: The socket is cooked'),
-    ),
-  ).toBe(true)
-})
-
 test('fetchWithProxyRetry retries and disables keepalive after receiving a 504 response', async () => {
   const calls: Array<RequestInit | undefined> = []
   

--- a/src/services/api/fetchWithProxyRetry.test.ts
+++ b/src/services/api/fetchWithProxyRetry.test.ts
@@ -90,3 +90,29 @@ test('fetchWithProxyRetry does not retry non-network errors', async () => {
   )
   expect(attempts).toBe(1)
 })
+
+test('isRetryableFetchError matches Bun "socket is cooked" failures', () => {
+  expect(
+    isRetryableFetchError(
+      new Error('TypeError: The socket is cooked'),
+    ),
+  ).toBe(true)
+})
+
+test('fetchWithProxyRetry retries and disables keepalive after receiving a 504 response', async () => {
+  const calls: Array<RequestInit | undefined> = []
+  
+  globalThis.fetch = (async (_input, init) => {
+    calls.push(init)
+    if (calls.length === 1) {
+      return new Response('Gateway Timeout', { status: 504 })
+    }
+    return new Response('ok')
+  }) as FetchType
+
+  const response = await fetchWithProxyRetry('https://example.com/search')
+  expect(response.status).toBe(200)
+  expect(calls).toHaveLength(2)
+  expect((calls[0] as RequestInit).keepalive).toBeUndefined()
+  expect((calls[1] as RequestInit).keepalive).toBe(false)
+})

--- a/src/services/api/fetchWithProxyRetry.ts
+++ b/src/services/api/fetchWithProxyRetry.ts
@@ -1,7 +1,7 @@
 import { disableKeepAlive, getProxyFetchOptions } from '../../utils/proxy.js'
 
 const RETRYABLE_FETCH_ERROR_PATTERN =
-  /socket connection was closed unexpectedly|ECONNRESET|EPIPE|socket hang up|Connection reset by peer|fetch failed|cooked/i
+  /socket connection was closed unexpectedly|ECONNRESET|EPIPE|socket hang up|Connection reset by peer|fetch failed/i
 
 export function isRetryableFetchError(error: unknown): boolean {
   if (!(error instanceof Error)) {

--- a/src/services/api/fetchWithProxyRetry.ts
+++ b/src/services/api/fetchWithProxyRetry.ts
@@ -1,7 +1,7 @@
 import { disableKeepAlive, getProxyFetchOptions } from '../../utils/proxy.js'
 
 const RETRYABLE_FETCH_ERROR_PATTERN =
-  /socket connection was closed unexpectedly|ECONNRESET|EPIPE|socket hang up|Connection reset by peer|fetch failed/i
+  /socket connection was closed unexpectedly|ECONNRESET|EPIPE|socket hang up|Connection reset by peer|fetch failed|cooked/i
 
 export function isRetryableFetchError(error: unknown): boolean {
   if (!(error instanceof Error)) {
@@ -23,12 +23,25 @@ export async function fetchWithProxyRetry(
 
   for (let attempt = 1; attempt <= maxAttempts; attempt++) {
     try {
-      return await fetch(input, {
+      const response = await fetch(input, {
         ...init,
         ...getProxyFetchOptions({
           forAnthropicAPI: options?.forAnthropicAPI,
         }),
       })
+
+      // If an upstream proxy or local NAT silently dropped the keep-alive socket,
+      // it might result in a 502/504 response instead of a hard network exception.
+      // We automatically disable keep-alive and retry to force a clean handshake.
+      if (
+        (response.status === 502 || response.status === 504) &&
+        attempt < maxAttempts
+      ) {
+        disableKeepAlive()
+        continue
+      }
+
+      return response
     } catch (error) {
       lastError = error
       if (attempt >= maxAttempts || !isRetryableFetchError(error)) {

--- a/src/utils/proxy.ts
+++ b/src/utils/proxy.ts
@@ -24,14 +24,14 @@ import {
 // Works under Bun (native fetch respects keepalive:false for pooling).
 // Under Node/undici, keepalive is a no-op for pooling, but undici
 // naturally evicts dead sockets from the pool on ECONNRESET.
-let keepAliveDisabled = false
+let keepAliveDisabled = isEnvTruthy(process.env.CLAUDE_CODE_DISABLE_KEEPALIVE)
 
 export function disableKeepAlive(): void {
   keepAliveDisabled = true
 }
 
 export function _resetKeepAliveForTesting(): void {
-  keepAliveDisabled = false
+  keepAliveDisabled = isEnvTruthy(process.env.CLAUDE_CODE_DISABLE_KEEPALIVE)
 }
 
 /**


### PR DESCRIPTION
## Summary

- **what changed:** 
  - Modified `fetchWithProxyRetry.ts` to intercept `502 Bad Gateway` and `504 Gateway Timeout` HTTP responses. When detected on the first attempt, the client now automatically disables HTTP keep-alive (`keepalive: false`) and retries the request seamlessly on a fresh TCP connection.
  - Added a global escape hatch environment variable: `CLAUDE_CODE_DISABLE_KEEPALIVE=1` to permanently disable keep-alive if needed.

- **why it changed:** 
  - To prevent spurious connection failures for users querying on-premises models or working behind strict enterprise reverse proxies/NATs. These proxies often aggressively drop idle HTTP keep-alive sockets without sending a `TCP RST` packet. When Bun attempts to reuse the pooled socket for the next user message, it either results in a native socket error (`TypeError: The socket is cooked`) or an instantaneous `504 Gateway Timeout`. This change allows the SDK to silently recover and rebuild the connection.

## Impact

- **user-facing impact:** Increased stability and no more random 504s or connection errors when pausing between prompts in an interactive session, particularly when connecting to self-hosted models or through strict VPNs.
- **developer/maintainer impact:** Better resiliency for the network transport layer without affecting the standard retry logic of the Anthropic SDK.

## Testing

- [x] `bun run build`
- [x] `bun run smoke`
- [x] `bun run check`
- [x] **focused tests:** Wrote unit tests in `src/services/api/fetchWithProxyRetry.test.ts` ensuring that 504 responses trigger `disableKeepAlive()` and a retry.

## Notes

- **provider/model path tested:** OpenAI-compatible on-premises endpoints.
- **screenshots attached (if UI changed):** N/A
- **follow-up work or known limitations:** This mitigates *idle* connection drops. If a 504 is genuinely caused by a Time-To-First-Token (TTFT) that exceeds the proxy's active `read_timeout` due to an enormous context window, the retry will also time out. Users in that scenario are advised to use `/compact` to shrink the context.