### PR TITLE
fix(ci): build before unit tests in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,14 +59,14 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
+      - name: Build
+        run: bun run build
+
       - name: Run unit tests
         run: bun test --max-concurrency=1
 
       - name: Smoke test
         run: bun run smoke
-
-      - name: Build
-        run: bun run build
 
       - name: Dry-run package
         run: npm pack --dry-run


### PR DESCRIPTION
The release workflow ran `bun test` before `bun run build`, but the bundle regression tests in scripts/missing-module-stub.test.ts read the shipped dist/cli.mjs. On a fresh release-tag checkout dist/ (gitignored) does not exist yet, so both tests threw "dist/cli.mjs not found" and failed the npm publish job. pr-checks.yml already builds first (via `bun run smoke`); reorder release.yml to match.
