### PR TITLE
Fix OpenGateway provider flag API key routing

### DIFF
--- a/src/entrypoints/cli.test.ts
+++ b/src/entrypoints/cli.test.ts
@@ -67,3 +67,40 @@ describe('useMemoryUsage.ts — threshold constants (issue #402)', () => {
     expect(src).toContain('CRITICAL_MEMORY_THRESHOLD = 2.5 * 1024 * 1024 * 1024')
   })
 })
+
+describe('cli.tsx — --provider startup ordering', () => {
+  it('remembers --provider so settings.env reloads cannot clobber it', async () => {
+    const src = await Bun.file(`${import.meta.dir}/cli.tsx`).text()
+
+    const earlyProviderApplyIndex = src.indexOf('applyProviderFlagFromArgs(args')
+    const rememberOptionIndex = src.indexOf(
+      'rememberForSettingsEnv: true',
+      earlyProviderApplyIndex,
+    )
+    const settingsEnvApplyIndex = src.indexOf(
+      'applySafeConfigEnvironmentVariables()',
+    )
+
+    expect(earlyProviderApplyIndex).toBeGreaterThanOrEqual(0)
+    expect(rememberOptionIndex).toBeGreaterThan(earlyProviderApplyIndex)
+    expect(settingsEnvApplyIndex).toBeGreaterThan(earlyProviderApplyIndex)
+  })
+
+  it('reapplies remembered --provider after every managed settings env merge', async () => {
+    const src = await Bun.file(`${import.meta.dir}/../utils/managedEnv.ts`).text()
+    const safeApplyIndex = src.indexOf('export function applySafeConfigEnvironmentVariables')
+    const configApplyIndex = src.indexOf('export function applyConfigEnvironmentVariables')
+    const safeReapplyIndex = src.indexOf(
+      'reapplyRememberedProviderFlag()',
+      safeApplyIndex,
+    )
+    const configReapplyIndex = src.indexOf(
+      'reapplyRememberedProviderFlag()',
+      configApplyIndex,
+    )
+
+    expect(safeReapplyIndex).toBeGreaterThan(safeApplyIndex)
+    expect(safeReapplyIndex).toBeLessThan(configApplyIndex)
+    expect(configReapplyIndex).toBeGreaterThan(configApplyIndex)
+  })
+})

--- a/src/entrypoints/cli.tsx
+++ b/src/entrypoints/cli.tsx
@@ -91,7 +91,9 @@ async function main(): Promise<void> {
   // validation, and the startup banner all see the intended provider/model.
   if (args.includes('--provider')) {
     const { applyProviderFlagFromArgs } = await import('../utils/providerFlag.js');
-    const result = applyProviderFlagFromArgs(args);
+    const result = applyProviderFlagFromArgs(args, {
+      rememberForSettingsEnv: true,
+    });
     if (result?.error) {
       // biome-ignore lint/suspicious/noConsole:: intentional error output
       console.error(`Error: ${result.error}`);

--- a/src/services/api/openaiShim.test.ts
+++ b/src/services/api/openaiShim.test.ts
@@ -1,12 +1,15 @@
 import { afterEach, beforeEach, expect, test } from 'bun:test'
 import { acquireSharedMutationLock, releaseSharedMutationLock } from '../../test/sharedMutationLock.js'
 import { _clearRegistryForTesting, ensureIntegrationsLoaded, registerGateway } from '../../integrations/index.ts'
+import { applyProviderFlag } from '../../utils/providerFlag.ts'
+import { applyProviderProfileToProcessEnv } from '../../utils/providerProfiles.ts'
 import { createOpenAIShimClient } from './openaiShim.ts'
 
 type FetchType = typeof globalThis.fetch
 
 const originalEnv = {
   OPENAI_BASE_URL: process.env.OPENAI_BASE_URL,
+  OPENAI_API_BASE: process.env.OPENAI_API_BASE,
   OPENAI_API_KEY: process.env.OPENAI_API_KEY,
   OPENAI_MODEL: process.env.OPENAI_MODEL,
   OPENAI_API_FORMAT: process.env.OPENAI_API_FORMAT,
@@ -35,6 +38,10 @@ const originalEnv = {
   OPENROUTER_API_KEY: process.env.OPENROUTER_API_KEY,
   DEEPSEEK_API_KEY: process.env.DEEPSEEK_API_KEY,
   MIMO_API_KEY: process.env.MIMO_API_KEY,
+  OPENGATEWAY_API_KEY: process.env.OPENGATEWAY_API_KEY,
+  OPENGATEWAY_BASE_URL: process.env.OPENGATEWAY_BASE_URL,
+  CLAUDE_CODE_PROVIDER_PROFILE_ENV_APPLIED: process.env.CLAUDE_CODE_PROVIDER_PROFILE_ENV_APPLIED,
+  CLAUDE_CODE_PROVIDER_PROFILE_ENV_APPLIED_ID: process.env.CLAUDE_CODE_PROVIDER_PROFILE_ENV_APPLIED_ID,
 }
 
 const originalFetch = globalThis.fetch
@@ -86,9 +93,59 @@ function makeStreamChunks(chunks: unknown[]): string[] {
   ]
 }
 
+function makeChatCompletionResponse(model: string): Response {
+  return new Response(
+    JSON.stringify({
+      id: 'chatcmpl-test',
+      model,
+      choices: [
+        {
+          message: {
+            role: 'assistant',
+            content: 'ok',
+          },
+          finish_reason: 'stop',
+        },
+      ],
+    }),
+    {
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    },
+  )
+}
+
+async function captureChatCompletionRequest(
+  model = 'mimo-v2.5-pro',
+): Promise<{ authorization: string | null; url: string | null }> {
+  let authorization: string | null = null
+  let url: string | null = null
+
+  globalThis.fetch = (async (input, init) => {
+    url = String(input)
+    const headers = init?.headers as Record<string, string> | undefined
+    authorization = headers?.Authorization ?? headers?.authorization ?? null
+
+    return makeChatCompletionResponse(model)
+  }) as FetchType
+
+  const client = createOpenAIShimClient({}) as OpenAIShimClient
+
+  await client.beta.messages.create({
+    model,
+    messages: [{ role: 'user', content: 'hello' }],
+    max_tokens: 32,
+    stream: false,
+  })
+
+  return { authorization, url }
+}
+
 beforeEach(async () => {
   await acquireSharedMutationLock('openaiShim.test.ts')
   process.env.OPENAI_BASE_URL = 'http://example.test/v1'
+  delete process.env.OPENAI_API_BASE
   process.env.OPENAI_API_KEY = 'test-key'
   delete process.env.OPENAI_MODEL
   delete process.env.OPENAI_API_FORMAT
@@ -117,11 +174,16 @@ beforeEach(async () => {
   delete process.env.OPENROUTER_API_KEY
   delete process.env.DEEPSEEK_API_KEY
   delete process.env.MIMO_API_KEY
+  delete process.env.OPENGATEWAY_API_KEY
+  delete process.env.OPENGATEWAY_BASE_URL
+  delete process.env.CLAUDE_CODE_PROVIDER_PROFILE_ENV_APPLIED
+  delete process.env.CLAUDE_CODE_PROVIDER_PROFILE_ENV_APPLIED_ID
 })
 
 afterEach(() => {
   try {
     restoreEnv('OPENAI_BASE_URL', originalEnv.OPENAI_BASE_URL)
+    restoreEnv('OPENAI_API_BASE', originalEnv.OPENAI_API_BASE)
     restoreEnv('OPENAI_API_KEY', originalEnv.OPENAI_API_KEY)
     restoreEnv('OPENAI_MODEL', originalEnv.OPENAI_MODEL)
     restoreEnv('OPENAI_API_FORMAT', originalEnv.OPENAI_API_FORMAT)
@@ -150,6 +212,10 @@ afterEach(() => {
     restoreEnv('OPENROUTER_API_KEY', originalEnv.OPENROUTER_API_KEY)
     restoreEnv('DEEPSEEK_API_KEY', originalEnv.DEEPSEEK_API_KEY)
     restoreEnv('MIMO_API_KEY', originalEnv.MIMO_API_KEY)
+    restoreEnv('OPENGATEWAY_API_KEY', originalEnv.OPENGATEWAY_API_KEY)
+    restoreEnv('OPENGATEWAY_BASE_URL', originalEnv.OPENGATEWAY_BASE_URL)
+    restoreEnv('CLAUDE_CODE_PROVIDER_PROFILE_ENV_APPLIED', originalEnv.CLAUDE_CODE_PROVIDER_PROFILE_ENV_APPLIED)
+    restoreEnv('CLAUDE_CODE_PROVIDER_PROFILE_ENV_APPLIED_ID', originalEnv.CLAUDE_CODE_PROVIDER_PROFILE_ENV_APPLIED_ID)
     globalThis.fetch = originalFetch
     _clearRegistryForTesting()
     ensureIntegrationsLoaded()
@@ -2068,6 +2134,145 @@ test('xiaomi mimo route uses api-key auth header and max_completion_tokens', asy
   expect(capturedHeaders).not.toHaveProperty('Authorization')
   expect(capturedBody).toMatchObject({ max_completion_tokens: 32 })
   expect(capturedBody).not.toHaveProperty('max_tokens')
+})
+
+test('gitlawb opengateway provider flag sends OPENGATEWAY_API_KEY as bearer auth despite stale generic base URL', async () => {
+  process.env.OPENAI_BASE_URL = 'https://api.openai.com/v1'
+  process.env.OPENAI_MODEL = 'gpt-5.5'
+  process.env.OPENGATEWAY_API_KEY = 'fake-ogw-key'
+  delete process.env.OPENAI_API_KEY
+
+  const result = applyProviderFlag('gitlawb-opengateway', [])
+  expect(result.error).toBeUndefined()
+
+  const captured = await captureChatCompletionRequest()
+
+  expect(captured.url).toBe('https://opengateway.gitlawb.com/v1/chat/completions')
+  expect(captured.authorization).toBe('Bearer fake-ogw-key')
+})
+
+test('gitlawb opengateway provider flag accepts OPENAI_API_KEY compatibility fallback', async () => {
+  delete process.env.OPENAI_BASE_URL
+  delete process.env.OPENGATEWAY_API_KEY
+  process.env.OPENAI_API_KEY = 'fake-openai-fallback'
+
+  const result = applyProviderFlag('gitlawb-opengateway', [])
+  expect(result.error).toBeUndefined()
+
+  const captured = await captureChatCompletionRequest()
+
+  expect(captured.authorization).toBe('Bearer fake-openai-fallback')
+})
+
+test('gitlawb opengateway provider flag sends OPENAI_API_KEY fallback despite stale generic base URL', async () => {
+  process.env.OPENAI_BASE_URL = 'https://api.openai.com/v1'
+  process.env.OPENAI_API_KEY = 'fake-openai-fallback'
+  delete process.env.OPENGATEWAY_API_KEY
+
+  const result = applyProviderFlag('gitlawb-opengateway', [])
+  expect(result.error).toBeUndefined()
+
+  const captured = await captureChatCompletionRequest()
+
+  expect(captured.url).toBe('https://opengateway.gitlawb.com/v1/chat/completions')
+  expect(captured.authorization).toBe('Bearer fake-openai-fallback')
+})
+
+test('gitlawb opengateway provider flag trims OPENGATEWAY_API_KEY before bearer auth', async () => {
+  process.env.OPENGATEWAY_API_KEY = ' fake-ogw-key '
+  delete process.env.OPENAI_API_KEY
+
+  const result = applyProviderFlag('gitlawb-opengateway', [])
+  expect(result.error).toBeUndefined()
+
+  const captured = await captureChatCompletionRequest()
+
+  expect(captured.authorization).toBe('Bearer fake-ogw-key')
+})
+
+test('gitlawb opengateway provider flag ignores blank OPENGATEWAY_API_KEY and uses OPENAI_API_KEY fallback', async () => {
+  process.env.OPENGATEWAY_API_KEY = '   '
+  process.env.OPENAI_API_KEY = 'fake-openai-fallback'
+
+  const result = applyProviderFlag('gitlawb-opengateway', [])
+  expect(result.error).toBeUndefined()
+
+  const captured = await captureChatCompletionRequest()
+
+  expect(captured.authorization).toBe('Bearer fake-openai-fallback')
+})
+
+test('gitlawb opengateway provider flag sends OPENGATEWAY_API_KEY to OPENGATEWAY_BASE_URL override', async () => {
+  process.env.OPENGATEWAY_BASE_URL = 'http://localhost:8181/v1'
+  process.env.OPENGATEWAY_API_KEY = 'fake-ogw-key'
+  delete process.env.OPENAI_API_KEY
+
+  const result = applyProviderFlag('gitlawb-opengateway', [])
+  expect(result.error).toBeUndefined()
+
+  const captured = await captureChatCompletionRequest()
+
+  expect(captured.url).toBe('http://localhost:8181/v1/chat/completions')
+  expect(captured.authorization).toBe('Bearer fake-ogw-key')
+})
+
+test('gitlawb opengateway provider flag sends OPENGATEWAY_API_KEY to custom OPENAI_BASE_URL fallback', async () => {
+  process.env.OPENAI_BASE_URL = 'http://localhost:8181/v1'
+  process.env.OPENGATEWAY_API_KEY = 'fake-ogw-key'
+  delete process.env.OPENGATEWAY_BASE_URL
+  delete process.env.OPENAI_API_KEY
+
+  const result = applyProviderFlag('gitlawb-opengateway', [])
+  expect(result.error).toBeUndefined()
+
+  const captured = await captureChatCompletionRequest()
+
+  expect(captured.url).toBe('http://localhost:8181/v1/chat/completions')
+  expect(captured.authorization).toBe('Bearer fake-ogw-key')
+})
+
+test('gitlawb opengateway provider flag prefers OPENGATEWAY_API_KEY over generic OPENAI_API_KEY for custom base URL', async () => {
+  process.env.OPENGATEWAY_BASE_URL = 'http://localhost:8181/v1'
+  process.env.OPENGATEWAY_API_KEY = 'fake-ogw-key'
+  process.env.OPENAI_API_KEY = 'fake-generic-openai-key'
+
+  const result = applyProviderFlag('gitlawb-opengateway', [])
+  expect(result.error).toBeUndefined()
+
+  const captured = await captureChatCompletionRequest()
+
+  expect(captured.url).toBe('http://localhost:8181/v1/chat/completions')
+  expect(captured.authorization).toBe('Bearer fake-ogw-key')
+})
+
+test('gitlawb opengateway stored provider profile key becomes bearer auth', async () => {
+  delete process.env.OPENAI_API_KEY
+  delete process.env.OPENGATEWAY_API_KEY
+
+  applyProviderProfileToProcessEnv({
+    id: 'stored-opengateway',
+    provider: 'gitlawb-opengateway',
+    name: 'Gitlawb Opengateway',
+    baseUrl: 'https://opengateway.gitlawb.com/v1',
+    model: 'mimo-v2.5-pro',
+    apiKey: 'fake-profile-key',
+  })
+
+  const captured = await captureChatCompletionRequest()
+
+  expect(captured.authorization).toBe('Bearer fake-profile-key')
+})
+
+test('openai route still sends OPENAI_API_KEY as bearer auth', async () => {
+  process.env.CLAUDE_CODE_USE_OPENAI = '1'
+  process.env.OPENAI_BASE_URL = 'https://api.openai.com/v1'
+  process.env.OPENAI_MODEL = 'gpt-5.5'
+  process.env.OPENAI_API_KEY = 'fake-openai-key'
+  delete process.env.OPENGATEWAY_API_KEY
+
+  const captured = await captureChatCompletionRequest('gpt-5.5')
+
+  expect(captured.authorization).toBe('Bearer fake-openai-key')
 })
 
 test('does not use BNKR_API_KEY for non-Bankr OpenAI-compatible routes', async () => {

--- a/src/utils/apiPreconnect.test.ts
+++ b/src/utils/apiPreconnect.test.ts
@@ -3,6 +3,7 @@ import {
   acquireSharedMutationLock,
   releaseSharedMutationLock,
 } from '../test/sharedMutationLock.js'
+import * as actualProviders from './model/providers.js'
 
 const originalEnv = { ...process.env }
 const originalFetch = globalThis.fetch
@@ -17,6 +18,7 @@ function getMockApiProvider() {
 async function importFreshModule() {
   mock.restore()
   mock.module('./model/providers.js', () => ({
+    ...actualProviders,
     getAPIProvider: getMockApiProvider,
   }))
   return import(`./apiPreconnect.ts?ts=${Date.now()}-${Math.random()}`)
@@ -105,5 +107,13 @@ describe('preconnectAnthropicApi', () => {
     preconnectAnthropicApi()
 
     expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+
+  test('keeps non-mocked provider exports available to neighboring imports', async () => {
+    await importFreshModule()
+
+    const providers = await import('./model/providers.js')
+
+    expect(typeof providers.isFirstPartyAnthropicBaseUrl).toBe('function')
   })
 })

--- a/src/utils/apiPreconnect.test.ts
+++ b/src/utils/apiPreconnect.test.ts
@@ -7,8 +7,18 @@ import {
 const originalEnv = { ...process.env }
 const originalFetch = globalThis.fetch
 
+function getMockApiProvider() {
+  if (process.env.CLAUDE_CODE_USE_OPENAI === '1') return 'openai'
+  if (process.env.CLAUDE_CODE_USE_GEMINI === '1') return 'gemini'
+  if (process.env.CLAUDE_CODE_USE_GITHUB === '1') return 'github'
+  return 'firstParty'
+}
+
 async function importFreshModule() {
   mock.restore()
+  mock.module('./model/providers.js', () => ({
+    getAPIProvider: getMockApiProvider,
+  }))
   return import(`./apiPreconnect.ts?ts=${Date.now()}-${Math.random()}`)
 }
 

--- a/src/utils/attribution.test.ts
+++ b/src/utils/attribution.test.ts
@@ -8,10 +8,8 @@ import {
 } from '../bootstrap/state.js'
 import * as actualModel from './model/model.js'
 import * as actualProviders from './model/providers.js'
-import {
-  resetSettingsCache,
-  setSessionSettingsCache,
-} from './settings/settingsCache.js'
+import * as actualSettings from './settings/settings.js'
+import { resetSettingsCache } from './settings/settingsCache.js'
 import type { SettingsJson } from './settings/types.js'
 
 let getAttributionTexts: (typeof import('./attribution.js'))['getAttributionTexts']
@@ -70,8 +68,10 @@ const originalMainLoopModelOverride = getMainLoopModelOverride()
 const defaultPrAttribution =
   '🤖 Generated with [OpenClaude](https://github.com/Gitlawb/openclaude)'
 
+let activeSettings: SettingsJson = {}
+
 function useSettings(settings: SettingsJson): void {
-  setSessionSettingsCache({ settings, errors: [] })
+  activeSettings = settings
 }
 
 function restoreEnv(): void {
@@ -86,6 +86,7 @@ function restoreEnv(): void {
 
 beforeEach(async () => {
   mock.restore()
+  activeSettings = {}
   resetStateForTests()
   resetSettingsCache()
   setClientType('cli')
@@ -131,6 +132,10 @@ beforeEach(async () => {
     ...actualProviders,
     getAPIProvider: () => 'openai',
   }))
+  mock.module('./settings/settings.js', () => ({
+    ...actualSettings,
+    getInitialSettings: () => activeSettings,
+  }))
 
   const attribution = await import(
     `./attribution.ts?attributionTest=${Date.now()}-${Math.random()}`
@@ -143,6 +148,7 @@ beforeEach(async () => {
 
 afterEach(() => {
   mock.restore()
+  activeSettings = {}
   resetStateForTests()
   resetSettingsCache()
   setClientType(originalClientType)

--- a/src/utils/managedEnv.ts
+++ b/src/utils/managedEnv.ts
@@ -9,6 +9,7 @@ import {
 import { clearMTLSCache } from './mtls.js'
 import { clearProxyCache, configureGlobalAgents } from './proxy.js'
 import { applyActiveProviderProfileFromConfig } from './providerProfiles.js'
+import { reapplyRememberedProviderFlag } from './providerFlag.js'
 import { isSettingSourceEnabled } from './settings/constants.js'
 import {
   getSettings_DEPRECATED,
@@ -180,6 +181,11 @@ export function applySafeConfigEnvironmentVariables(): void {
   // Apply active provider profile only when startup did not explicitly
   // select a provider via flags/env. Explicit startup intent should win.
   applyActiveProviderProfileFromConfig()
+
+  // If the CLI parsed --provider before settings.env was loaded, restore
+  // that explicit routing after every settings merge so saved env cannot
+  // clobber the selected provider endpoint or compatibility key mapping.
+  reapplyRememberedProviderFlag()
 }
 
 /**
@@ -197,6 +203,7 @@ export function applyConfigEnvironmentVariables(): void {
   // Keep runtime provider/model env aligned with the active profile, except
   // when an explicit provider selection is already present in process.env.
   applyActiveProviderProfileFromConfig()
+  reapplyRememberedProviderFlag()
 
   // Clear caches so agents are rebuilt with the new env vars
   clearCACertsCache()

--- a/src/utils/providerFlag.test.ts
+++ b/src/utils/providerFlag.test.ts
@@ -8,6 +8,8 @@ import {
   parseModelFlag,
   applyProviderFlag,
   applyProviderFlagFromArgs,
+  reapplyRememberedProviderFlag,
+  clearRememberedProviderFlagForTests,
   applyModelFlagFromArgs,
   VALID_PROVIDERS,
 } from './providerFlag.js'
@@ -73,6 +75,7 @@ const RESET_KEYS = [
 ] as const
 
 beforeEach(() => {
+  clearRememberedProviderFlagForTests()
   for (const key of RESET_KEYS) {
     delete process.env[key]
   }
@@ -80,6 +83,7 @@ beforeEach(() => {
 
 afterEach(() => {
   try {
+    clearRememberedProviderFlagForTests()
     for (const key of ENV_KEYS) {
       if (originalEnv[key] === undefined) {
         delete process.env[key]
@@ -585,6 +589,60 @@ describe('applyProviderFlagFromArgs', () => {
 
   test('returns undefined when --provider is absent', () => {
     expect(applyProviderFlagFromArgs(['--model', 'gpt-4o'])).toBeUndefined()
+  })
+
+  test('reapplies remembered gitlawb-opengateway after settings env restores stale OpenAI routing', () => {
+    const args = ['--provider', 'gitlawb-opengateway']
+    delete process.env.OPENGATEWAY_API_KEY
+    delete process.env.OPENAI_API_KEY
+
+    const earlyResult = applyProviderFlagFromArgs(args, {
+      rememberForSettingsEnv: true,
+    })
+    expect(earlyResult?.error).toBeUndefined()
+    expect(process.env.OPENAI_BASE_URL).toBe(
+      'https://opengateway.gitlawb.com/v1',
+    )
+    expect(process.env.OPENAI_API_KEY).toBeUndefined()
+
+    process.env.OPENGATEWAY_API_KEY = 'settings-ogw-key'
+    process.env.OPENAI_BASE_URL = 'https://api.openai.com/v1'
+
+    const lateResult = reapplyRememberedProviderFlag()
+
+    expect(lateResult?.error).toBeUndefined()
+    expect(process.env.OPENAI_BASE_URL).toBe(
+      'https://opengateway.gitlawb.com/v1',
+    )
+    expect(process.env.OPENAI_API_KEY as string | undefined).toBe(
+      'settings-ogw-key',
+    )
+  })
+
+  test('remembered provider reapply preserves an explicit --model', () => {
+    const result = applyProviderFlagFromArgs(
+      [
+        '--print',
+        '--provider',
+        'gitlawb-opengateway',
+        '--model',
+        'custom-ogw-model',
+        'do not retain prompt text',
+      ],
+      { rememberForSettingsEnv: true },
+    )
+
+    expect(result?.error).toBeUndefined()
+    process.env.OPENAI_BASE_URL = 'https://api.openai.com/v1'
+    process.env.OPENAI_MODEL = 'stale-openai-model'
+
+    const lateResult = reapplyRememberedProviderFlag()
+
+    expect(lateResult?.error).toBeUndefined()
+    expect(process.env.OPENAI_BASE_URL).toBe(
+      'https://opengateway.gitlawb.com/v1',
+    )
+    expect(process.env.OPENAI_MODEL).toBe('custom-ogw-model')
   })
 })
 

--- a/src/utils/providerFlag.test.ts
+++ b/src/utils/providerFlag.test.ts
@@ -20,6 +20,7 @@ const ENV_KEYS = [
   'CLAUDE_CODE_USE_BEDROCK',
   'CLAUDE_CODE_USE_VERTEX',
   'OPENAI_BASE_URL',
+  'OPENAI_API_BASE',
   'OPENAI_API_KEY',
   'OPENAI_MODEL',
   'GEMINI_MODEL',
@@ -30,6 +31,8 @@ const ENV_KEYS = [
   'MINIMAX_API_KEY',
   'VENICE_API_KEY',
   'MIMO_API_KEY',
+  'OPENGATEWAY_API_KEY',
+  'OPENGATEWAY_BASE_URL',
   'MISTRAL_MODEL',
   'ANTHROPIC_MODEL',
 ]
@@ -52,6 +55,7 @@ const RESET_KEYS = [
   'CLAUDE_CODE_USE_BEDROCK',
   'CLAUDE_CODE_USE_VERTEX',
   'OPENAI_BASE_URL',
+  'OPENAI_API_BASE',
   'OPENAI_API_KEY',
   'OPENAI_MODEL',
   'GEMINI_MODEL',
@@ -62,6 +66,8 @@ const RESET_KEYS = [
   'MINIMAX_API_KEY',
   'VENICE_API_KEY',
   'MIMO_API_KEY',
+  'OPENGATEWAY_API_KEY',
+  'OPENGATEWAY_BASE_URL',
   'MISTRAL_MODEL',
   'ANTHROPIC_MODEL',
 ] as const
@@ -237,6 +243,119 @@ describe('applyProviderFlag - descriptor-backed openai-compatible routes', () =>
     expect(result.error).toBeUndefined()
     expect(process.env.CLAUDE_CODE_USE_OPENAI).toBe('1')
     expect(process.env.OPENAI_BASE_URL).toBe('https://openrouter.ai/api/v1')
+  })
+
+  test('descriptor-backed provider selection preserves custom OPENAI_BASE_URL', () => {
+    process.env.OPENAI_BASE_URL = 'http://proxy.local:8080/v1'
+
+    const result = applyProviderFlag('openrouter', [])
+
+    expect(result.error).toBeUndefined()
+    expect(process.env.CLAUDE_CODE_USE_OPENAI).toBe('1')
+    expect(process.env.OPENAI_BASE_URL).toBe('http://proxy.local:8080/v1')
+  })
+
+  test('gitlawb-opengateway explicit provider overrides stale generic base URL', () => {
+    process.env.OPENAI_BASE_URL = 'https://api.openai.com/v1'
+    process.env.OPENAI_MODEL = 'gpt-5.5'
+    process.env.OPENGATEWAY_API_KEY = 'fake-ogw-key'
+
+    const result = applyProviderFlag('gitlawb-opengateway', [])
+
+    expect(result.error).toBeUndefined()
+    expect(process.env.CLAUDE_CODE_USE_OPENAI).toBe('1')
+    expect(process.env.OPENAI_BASE_URL).toBe('https://opengateway.gitlawb.com/v1')
+    expect(process.env.OPENGATEWAY_API_KEY).toBe('fake-ogw-key')
+    expect(process.env.OPENAI_API_KEY).toBe('fake-ogw-key')
+  })
+
+  test('gitlawb-opengateway explicit provider respects OPENGATEWAY_BASE_URL override', () => {
+    process.env.OPENAI_BASE_URL = 'https://api.openai.com/v1'
+    process.env.OPENGATEWAY_BASE_URL = 'http://localhost:8181/v1'
+
+    const result = applyProviderFlag('gitlawb-opengateway', [])
+
+    expect(result.error).toBeUndefined()
+    expect(process.env.CLAUDE_CODE_USE_OPENAI).toBe('1')
+    expect(process.env.OPENAI_BASE_URL).toBe('http://localhost:8181/v1')
+  })
+
+  test('gitlawb-opengateway explicit provider preserves custom OPENAI_BASE_URL when no OPENGATEWAY_BASE_URL is set', () => {
+    process.env.OPENAI_BASE_URL = 'http://localhost:8181/v1'
+    process.env.OPENGATEWAY_API_KEY = 'fake-ogw-key'
+
+    const result = applyProviderFlag('gitlawb-opengateway', [])
+
+    expect(result.error).toBeUndefined()
+    expect(process.env.CLAUDE_CODE_USE_OPENAI).toBe('1')
+    expect(process.env.OPENAI_BASE_URL).toBe('http://localhost:8181/v1')
+    expect(process.env.OPENAI_API_KEY).toBe('fake-ogw-key')
+  })
+
+  test('gitlawb-opengateway explicit provider prefers OPENGATEWAY_API_KEY over generic OPENAI_API_KEY', () => {
+    process.env.OPENGATEWAY_BASE_URL = 'http://localhost:8181/v1'
+    process.env.OPENGATEWAY_API_KEY = 'fake-ogw-key'
+    process.env.OPENAI_API_KEY = 'fake-generic-openai-key'
+
+    const result = applyProviderFlag('gitlawb-opengateway', [])
+
+    expect(result.error).toBeUndefined()
+    expect(process.env.CLAUDE_CODE_USE_OPENAI).toBe('1')
+    expect(process.env.OPENAI_BASE_URL).toBe('http://localhost:8181/v1')
+    expect(process.env.OPENAI_API_KEY).toBe('fake-ogw-key')
+  })
+
+  test('gitlawb-opengateway explicit provider ignores blank OPENGATEWAY_API_KEY fallback', () => {
+    process.env.OPENGATEWAY_BASE_URL = 'http://localhost:8181/v1'
+    process.env.OPENGATEWAY_API_KEY = '   '
+    process.env.OPENAI_API_KEY = 'fake-openai-fallback'
+
+    const result = applyProviderFlag('gitlawb-opengateway', [])
+
+    expect(result.error).toBeUndefined()
+    expect(process.env.CLAUDE_CODE_USE_OPENAI).toBe('1')
+    expect(process.env.OPENAI_BASE_URL).toBe('http://localhost:8181/v1')
+    expect(process.env.OPENAI_API_KEY).toBe('fake-openai-fallback')
+  })
+
+  test('gitlawb-opengateway trims scoped API key and clears the copied key when switching routes', () => {
+    process.env.OPENGATEWAY_API_KEY = ' fake-ogw-key '
+
+    const opengatewayResult = applyProviderFlag('gitlawb-opengateway', [])
+    expect(opengatewayResult.error).toBeUndefined()
+    expect(process.env.OPENAI_API_KEY).toBe('fake-ogw-key')
+
+    const openrouterResult = applyProviderFlag('openrouter', [])
+
+    expect(openrouterResult.error).toBeUndefined()
+    expect(process.env.OPENAI_BASE_URL).toBe('https://openrouter.ai/api/v1')
+    expect(process.env.OPENAI_API_KEY).toBeUndefined()
+    expect(process.env.OPENGATEWAY_API_KEY).toBe(' fake-ogw-key ')
+  })
+
+  test('clears OPENGATEWAY_API_KEY copied into OPENAI_API_KEY when switching routes', () => {
+    process.env.OPENAI_API_KEY = 'fake-ogw-key'
+    process.env.OPENGATEWAY_API_KEY = 'fake-ogw-key'
+
+    const result = applyProviderFlag('openrouter', [])
+
+    expect(result.error).toBeUndefined()
+    expect(process.env.CLAUDE_CODE_USE_OPENAI).toBe('1')
+    expect(process.env.OPENAI_BASE_URL).toBe('https://openrouter.ai/api/v1')
+    expect(process.env.OPENAI_API_KEY).toBeUndefined()
+    expect(process.env.OPENGATEWAY_API_KEY).toBe('fake-ogw-key')
+  })
+
+  test('descriptor-backed provider selection does not keep stale OpenGateway route', () => {
+    process.env.OPENAI_BASE_URL = 'https://opengateway.gitlawb.com/v1'
+    process.env.OPENGATEWAY_API_KEY = 'fake-ogw-key'
+
+    const result = applyProviderFlag('openrouter', [])
+
+    expect(result.error).toBeUndefined()
+    expect(process.env.CLAUDE_CODE_USE_OPENAI).toBe('1')
+    expect(process.env.OPENAI_BASE_URL).toBe('https://openrouter.ai/api/v1')
+    expect(process.env.OPENGATEWAY_API_KEY).toBe('fake-ogw-key')
   })
 
   test('clears stale NVIDIA_NIM marker when switching to another OpenAI-compatible route', () => {

--- a/src/utils/providerFlag.test.ts
+++ b/src/utils/providerFlag.test.ts
@@ -259,6 +259,30 @@ describe('applyProviderFlag - descriptor-backed openai-compatible routes', () =>
     expect(process.env.OPENAI_BASE_URL).toBe('http://proxy.local:8080/v1')
   })
 
+  test('descriptor-backed provider selection preserves custom OPENAI_API_BASE alias', () => {
+    process.env.OPENAI_API_BASE = 'http://proxy.local:8080/v1'
+    process.env.OPENGATEWAY_API_KEY = 'fake-ogw-key'
+
+    const result = applyProviderFlag('gitlawb-opengateway', [])
+
+    expect(result.error).toBeUndefined()
+    expect(process.env.CLAUDE_CODE_USE_OPENAI).toBe('1')
+    expect(process.env.OPENAI_BASE_URL).toBeUndefined()
+    expect(process.env.OPENAI_API_BASE).toBe('http://proxy.local:8080/v1')
+    expect(process.env.OPENAI_API_KEY).toBe('fake-ogw-key')
+  })
+
+  test('descriptor-backed provider selection ignores placeholder OPENAI_API_BASE alias values', () => {
+    process.env.OPENAI_API_BASE = 'undefined'
+
+    const result = applyProviderFlag('gitlawb-opengateway', [])
+
+    expect(result.error).toBeUndefined()
+    expect(process.env.CLAUDE_CODE_USE_OPENAI).toBe('1')
+    expect(process.env.OPENAI_BASE_URL).toBe('https://opengateway.gitlawb.com/v1')
+    expect(process.env.OPENAI_API_BASE).toBe('undefined')
+  })
+
   test('gitlawb-opengateway explicit provider overrides stale generic base URL', () => {
     process.env.OPENAI_BASE_URL = 'https://api.openai.com/v1'
     process.env.OPENAI_MODEL = 'gpt-5.5'

--- a/src/utils/providerFlag.ts
+++ b/src/utils/providerFlag.ts
@@ -20,6 +20,7 @@ import {
   getGateway,
   getVendor,
   resolveProfileRoute,
+  resolveRouteIdFromBaseUrl,
 } from '../integrations/index.js'
 import { PRESET_VENDOR_MAP } from '../integrations/compatibility.js'
 
@@ -122,6 +123,35 @@ function getRouteDefaults(provider: string): {
   }
 }
 
+function shouldReplaceStaleKnownBaseUrl(provider: string): boolean {
+  const currentRouteId = resolveRouteIdFromBaseUrl(process.env.OPENAI_BASE_URL)
+  if (!currentRouteId) {
+    return false
+  }
+
+  const targetRouteId = resolveProfileRoute(provider).routeId
+  return (
+    targetRouteId !== 'openai' &&
+    targetRouteId !== 'custom' &&
+    targetRouteId !== 'unknown-fallback' &&
+    currentRouteId !== targetRouteId
+  )
+}
+
+function applyOpenAIBaseUrlDefault(provider: string, baseUrl?: string): void {
+  const normalizedBaseUrl = baseUrl?.trim()
+  if (!normalizedBaseUrl) {
+    return
+  }
+
+  if (
+    !process.env.OPENAI_BASE_URL ||
+    shouldReplaceStaleKnownBaseUrl(provider)
+  ) {
+    process.env.OPENAI_BASE_URL = normalizedBaseUrl
+  }
+}
+
 /**
  * Apply --model (without --provider) to process.env for the current process only.
  *
@@ -168,8 +198,10 @@ export function applyModelFlagFromArgs(args: string[]): void {
 /**
  * Apply a provider name to process.env.
  * Sets the required CLAUDE_CODE_USE_* flag and any provider-specific
- * defaults (Ollama base URL, model routing). Does NOT overwrite values
- * that are already set — explicit env vars always win.
+ * defaults (Ollama base URL, model routing). Preserves explicit custom
+ * endpoint env vars for descriptor-backed defaults, while replacing stale
+ * known provider endpoints when the user explicitly chooses a different
+ * descriptor-backed provider.
  *
  * Returns { error } if the provider name is not recognized.
  */
@@ -183,6 +215,7 @@ export function applyProviderFlag(
     }
   }
 
+  const opengatewayApiKey = process.env.OPENGATEWAY_API_KEY?.trim()
   const copiedOpenAIKeyProvider =
     process.env.OPENAI_API_KEY !== undefined &&
     process.env.OPENAI_API_KEY === process.env.NVIDIA_API_KEY &&
@@ -203,7 +236,12 @@ export function applyProviderFlag(
               : process.env.OPENAI_API_KEY !== undefined &&
                   process.env.OPENAI_API_KEY === process.env.MINIMAX_API_KEY
                 ? 'minimax'
-                : null
+                : process.env.OPENAI_API_KEY !== undefined &&
+                    opengatewayApiKey !== undefined &&
+                    opengatewayApiKey.length > 0 &&
+                    process.env.OPENAI_API_KEY === opengatewayApiKey
+                  ? 'gitlawb-opengateway'
+                  : null
 
   delete process.env.CLAUDE_CODE_USE_OPENAI
   delete process.env.CLAUDE_CODE_USE_GEMINI
@@ -301,11 +339,26 @@ export function applyProviderFlag(
       }
       break
 
+    case 'gitlawb-opengateway':
+      process.env.CLAUDE_CODE_USE_OPENAI = '1'
+      if (process.env.OPENGATEWAY_BASE_URL?.trim()) {
+        process.env.OPENAI_BASE_URL = process.env.OPENGATEWAY_BASE_URL.trim()
+      } else {
+        applyOpenAIBaseUrlDefault(
+          provider,
+          defaultBaseUrl ?? 'https://opengateway.gitlawb.com/v1',
+        )
+      }
+      process.env.OPENAI_MODEL ??= defaultModel ?? 'mimo-v2.5-pro'
+      if (model) process.env.OPENAI_MODEL = model
+      if (opengatewayApiKey) {
+        process.env.OPENAI_API_KEY = opengatewayApiKey
+      }
+      break
+
     default:
       process.env.CLAUDE_CODE_USE_OPENAI = '1'
-      if (defaultBaseUrl) {
-        process.env.OPENAI_BASE_URL ??= defaultBaseUrl
-      }
+      applyOpenAIBaseUrlDefault(provider, defaultBaseUrl)
       if (defaultModel) {
         process.env.OPENAI_MODEL ??= defaultModel
       }

--- a/src/utils/providerFlag.ts
+++ b/src/utils/providerFlag.ts
@@ -65,6 +65,13 @@ export const VALID_PROVIDERS = buildValidProviders()
 
 export type ProviderFlagName = string
 
+let rememberedProviderFlag:
+  | {
+      provider: string
+      model?: string
+    }
+  | null = null
+
 /**
  * Extract the value of --provider from argv.
  * Returns null if the flag is absent or has no value.
@@ -83,10 +90,35 @@ export function parseProviderFlag(args: string[]): string | null {
  */
 export function applyProviderFlagFromArgs(
   args: string[],
+  options?: {
+    rememberForSettingsEnv?: boolean
+  },
 ): { error?: string } | undefined {
   const provider = parseProviderFlag(args)
   if (!provider) return undefined
-  return applyProviderFlag(provider, args)
+  const result = applyProviderFlag(provider, args)
+  if (!result.error && options?.rememberForSettingsEnv) {
+    const model = parseModelFlag(args)
+    rememberedProviderFlag = model ? { provider, model } : { provider }
+  }
+  return result
+}
+
+export function reapplyRememberedProviderFlag():
+  | { error?: string }
+  | undefined {
+  if (!rememberedProviderFlag) return undefined
+
+  const args = ['--provider', rememberedProviderFlag.provider]
+  if (rememberedProviderFlag.model) {
+    args.push('--model', rememberedProviderFlag.model)
+  }
+
+  return applyProviderFlag(rememberedProviderFlag.provider, args)
+}
+
+export function clearRememberedProviderFlagForTests(): void {
+  rememberedProviderFlag = null
 }
 
 /**

--- a/src/utils/providerFlag.ts
+++ b/src/utils/providerFlag.ts
@@ -155,8 +155,24 @@ function getRouteDefaults(provider: string): {
   }
 }
 
+function normalizeBaseUrlEnv(value: string | undefined): string | undefined {
+  const trimmed = value?.trim()
+  return trimmed && trimmed !== 'undefined' ? trimmed : undefined
+}
+
+function getConfiguredOpenAIBaseUrl(): string | undefined {
+  const baseUrl = normalizeBaseUrlEnv(process.env.OPENAI_BASE_URL)
+  if (baseUrl) {
+    return baseUrl
+  }
+
+  return normalizeBaseUrlEnv(process.env.OPENAI_API_BASE)
+}
+
 function shouldReplaceStaleKnownBaseUrl(provider: string): boolean {
-  const currentRouteId = resolveRouteIdFromBaseUrl(process.env.OPENAI_BASE_URL)
+  const currentRouteId = resolveRouteIdFromBaseUrl(
+    getConfiguredOpenAIBaseUrl(),
+  )
   if (!currentRouteId) {
     return false
   }
@@ -177,7 +193,7 @@ function applyOpenAIBaseUrlDefault(provider: string, baseUrl?: string): void {
   }
 
   if (
-    !process.env.OPENAI_BASE_URL ||
+    !getConfiguredOpenAIBaseUrl() ||
     shouldReplaceStaleKnownBaseUrl(provider)
   ) {
     process.env.OPENAI_BASE_URL = normalizedBaseUrl


### PR DESCRIPTION
## Summary

Fixes #1455.

This makes explicit `--provider gitlawb-opengateway` route through the OpenGateway endpoint even when a stale known `OPENAI_BASE_URL` is already present. It also maps a trimmed `OPENGATEWAY_API_KEY` into the OpenAI-compatible shim auth path, keeps `OPENAI_API_KEY` as a compatibility fallback, and preserves custom endpoints instead of blindly overwriting them.

## Details

- Replace stale known OpenAI-compatible base URLs when the user explicitly selects a descriptor-backed provider, while preserving unknown/custom `OPENAI_BASE_URL` values.
- Add an explicit OpenGateway provider-flag path for default hosted routing, `OPENGATEWAY_BASE_URL`, scoped API-key precedence, blank key handling, and copied-key cleanup when switching providers.
- Add request-level regression coverage that verifies the actual outgoing URL and `Authorization: Bearer ...` header for stale base URLs, custom base URLs, scoped keys, fallback keys, blank/whitespace keys, stored profiles, and OpenAI non-regression.

## Testing

- `git diff --check`
- `bun test src/utils/providerFlag.test.ts` — 62 pass
- `bun test src/services/api/openaiShim.test.ts` — 113 pass
- `bun run test:provider` — 646 pass
- `bun run test:provider-recommendation` — 78 pass
- `bun run integrations:check`
- `bun run check` — build/smoke passed; full test suite currently fails outside this patch:
  - `src/utils/analyzeContext.messageBreakdown.test.ts` timeout in the full suite; passes in isolation
  - `src/utils/conversationRecovery.hooks.test.ts` existing thinking-block assertion failure
  - two `tests/sdk/query-lifecycle.test.ts` order-dependent failures through `axios.defaults.proxy`; both pass in isolation
