### PR TITLE
feat(minimax): add MiniMax M3 model with 1M context window

### DIFF
--- a/src/commands/model/model.test.tsx
+++ b/src/commands/model/model.test.tsx
@@ -344,6 +344,47 @@ test('descriptor model options omit route defaults outside active profile models
   ])
 })
 
+test('native vendor routes show the full catalog regardless of the profile model', async () => {
+  const activeProfile = {
+    id: 'minimax-profile',
+    name: 'MiniMax',
+    provider: 'minimax',
+    baseUrl: 'https://api.minimax.io/anthropic',
+    model: 'MiniMax-M2.7',
+    apiKey: 'sk-minimax',
+  }
+  process.env.CLAUDE_CODE_PROVIDER_PROFILE_ENV_APPLIED = '1'
+  process.env.CLAUDE_CODE_PROVIDER_PROFILE_ENV_APPLIED_ID = activeProfile.id
+
+  mock.module('../../utils/providerProfiles.js', () => ({
+    getActiveOpenAIModelOptionsCache: () => [],
+    getActiveProviderProfile: () => activeProfile,
+    getProfileModelOptions: () => [
+      {
+        value: 'MiniMax-M2.7',
+        label: 'MiniMax-M2.7',
+        description: 'Provider: MiniMax',
+      },
+    ],
+    setActiveOpenAIModelOptionsCache: () => {},
+  }))
+
+  const { mergeActiveProfileModelOptions } =
+    await importFreshModelModule('native-vendor-full-catalog')
+
+  const routeOptions = [
+    { value: 'MiniMax-M2.7', label: 'MiniMax M2.7', description: '256K context' },
+    { value: 'MiniMax-M3', label: 'MiniMax M3', description: '1M context' },
+  ]
+
+  const merged = mergeActiveProfileModelOptions('minimax', routeOptions)
+  const values = merged.map(option => option.value)
+
+  // The whole catalog stays selectable — not just the profile's pinned model.
+  expect(values).toContain('MiniMax-M2.7')
+  expect(values).toContain('MiniMax-M3')
+})
+
 test('descriptor model options skip saved profile models for env-selected routes', async () => {
   const savedProfile = {
     id: 'mistral-profile',

--- a/src/commands/model/model.tsx
+++ b/src/commands/model/model.tsx
@@ -19,6 +19,7 @@ import {
 } from '../../integrations/discoveryService.js'
 import {
   getRouteDescriptor,
+  isNativeVendorCatalogRoute,
   resolveRouteCredentialValue,
   resolveActiveRouteIdFromEnv,
   resolveRouteIdFromBaseUrl,
@@ -134,6 +135,26 @@ export function mergeActiveProfileModelOptions(
   const profileOptions = getProfileModelOptions(activeProfile)
   if (profileOptions.length === 0) {
     return routeOptions
+  }
+
+  // Native vendor routes ship a complete curated catalog, so show every
+  // catalogued model (e.g. all MiniMax models including M3) rather than
+  // collapsing to the single model pinned in the profile. Any profile-only
+  // models not present in the catalog are appended so custom entries survive.
+  if (isNativeVendorCatalogRoute(routeId)) {
+    const catalogKeys = new Set(
+      routeOptions.flatMap(option =>
+        typeof option.value === 'string'
+          ? [option.value.trim().toLowerCase()]
+          : [],
+      ),
+    )
+    const extraProfileModels = profileOptions.filter(option => {
+      const value =
+        typeof option.value === 'string' ? option.value.trim().toLowerCase() : ''
+      return value !== '' && !catalogKeys.has(value)
+    })
+    return [...routeOptions, ...extraProfileModels]
   }
 
   const routeOptionsByValue = new Map(

--- a/src/integrations/models/minimax.ts
+++ b/src/integrations/models/minimax.ts
@@ -88,6 +88,17 @@ export default [
     maxOutputTokens: 131_072,
   }),
   defineModel({
+    id: 'minimax-m3',
+    label: 'MiniMax M3',
+    brandId: 'minimax',
+    vendorId: 'minimax',
+    classification: ['chat', 'reasoning', 'coding'],
+    defaultModel: 'MiniMax-M3',
+    capabilities: minimaxM2Capabilities,
+    contextWindow: 1_048_576,
+    maxOutputTokens: 131_072,
+  }),
+  defineModel({
     id: 'minimax-text-01',
     label: 'MiniMax Text 01',
     brandId: 'minimax',

--- a/src/integrations/routeMetadata.ts
+++ b/src/integrations/routeMetadata.ts
@@ -144,6 +144,22 @@ export function getRouteDefaultModel(
   return defaultEntry?.apiName
 }
 
+/**
+ * True for native vendor routes (e.g. MiniMax, xAI) that ship a complete,
+ * curated static catalog. For these the catalog is authoritative, so the
+ * `/model` picker should surface every catalogued model — not collapse to the
+ * single model pinned in the active provider profile. Gateways, whose catalog
+ * is a user-curated subset, keep the profile model list as a whitelist.
+ */
+export function isNativeVendorCatalogRoute(routeId: string): boolean {
+  const vendor = getVendor(routeId)
+  return (
+    vendor?.classification === 'native' &&
+    vendor.catalog?.source === 'static' &&
+    (vendor.catalog?.models?.length ?? 0) > 0
+  )
+}
+
 function uniqueEnvVars(envVars: Iterable<string>): string[] {
   const seen = new Set<string>()
   const normalized: string[] = []

--- a/src/integrations/vendors/minimax.ts
+++ b/src/integrations/vendors/minimax.ts
@@ -5,7 +5,7 @@ export default defineVendor({
   label: 'MiniMax',
   classification: 'native',
   defaultBaseUrl: 'https://api.minimax.io/anthropic',
-  defaultModel: 'MiniMax-M2.7',
+  defaultModel: 'MiniMax-M3',
   requiredEnvVars: ['MINIMAX_API_KEY'],
   setup: {
     requiresAuth: true,

--- a/src/integrations/vendors/minimax.ts
+++ b/src/integrations/vendors/minimax.ts
@@ -40,6 +40,7 @@ export default defineVendor({
       { id: 'minimax-m2.5-highspeed', apiName: 'MiniMax-M2.5-highspeed', label: 'MiniMax M2.5 Highspeed', modelDescriptorId: 'minimax-m2.5-highspeed', contextWindow: 204_800 },
       { id: 'minimax-m2.7', apiName: 'MiniMax-M2.7', label: 'MiniMax M2.7', modelDescriptorId: 'minimax-m2.7', contextWindow: 204_800 },
       { id: 'minimax-m2.7-highspeed', apiName: 'MiniMax-M2.7-highspeed', label: 'MiniMax M2.7 Highspeed', modelDescriptorId: 'minimax-m2.7-highspeed', contextWindow: 204_800 },
+      { id: 'minimax-m3', apiName: 'MiniMax-M3', label: 'MiniMax M3', modelDescriptorId: 'minimax-m3', contextWindow: 1_048_576 },
       { id: 'minimax-text-01', apiName: 'MiniMax-Text-01', label: 'MiniMax Text 01', modelDescriptorId: 'minimax-text-01' },
       { id: 'minimax-text-01-preview', apiName: 'MiniMax-Text-01-Preview', label: 'MiniMax Text 01 Preview', modelDescriptorId: 'minimax-text-01-preview' },
       { id: 'minimax-vision-01', apiName: 'MiniMax-Vision-01', label: 'MiniMax Vision 01', modelDescriptorId: 'minimax-vision-01' },

--- a/src/utils/apiPreconnect.test.ts
+++ b/src/utils/apiPreconnect.test.ts
@@ -28,35 +28,36 @@ afterEach(() => {
 })
 
 describe('preconnectAnthropicApi', () => {
+  // The provider is injected directly rather than mocking getAPIProvider():
+  // bun does not unregister mock.module() overrides, so a leaked providers.js
+  // mock from another test file (e.g. fastMode) would otherwise force
+  // getAPIProvider() to 'firstParty' here and break these assertions.
   test('does not fetch when OpenAI mode is enabled', async () => {
-    process.env.CLAUDE_CODE_USE_OPENAI = '1'
     const fetchMock = mock(() => Promise.resolve(new Response(null, { status: 200 })))
     globalThis.fetch = fetchMock as typeof globalThis.fetch
 
     const { preconnectAnthropicApi } = await importFreshModule()
-    preconnectAnthropicApi()
+    preconnectAnthropicApi('openai')
 
     expect(fetchMock).not.toHaveBeenCalled()
   })
 
   test('does not fetch when Gemini mode is enabled', async () => {
-    process.env.CLAUDE_CODE_USE_GEMINI = '1'
     const fetchMock = mock(() => Promise.resolve(new Response(null, { status: 200 })))
     globalThis.fetch = fetchMock as typeof globalThis.fetch
 
     const { preconnectAnthropicApi } = await importFreshModule()
-    preconnectAnthropicApi()
+    preconnectAnthropicApi('gemini')
 
     expect(fetchMock).not.toHaveBeenCalled()
   })
 
   test('does not fetch when GitHub mode is enabled', async () => {
-    process.env.CLAUDE_CODE_USE_GITHUB = '1'
     const fetchMock = mock(() => Promise.resolve(new Response(null, { status: 200 })))
     globalThis.fetch = fetchMock as typeof globalThis.fetch
 
     const { preconnectAnthropicApi } = await importFreshModule()
-    preconnectAnthropicApi()
+    preconnectAnthropicApi('github')
 
     expect(fetchMock).not.toHaveBeenCalled()
   })
@@ -92,7 +93,7 @@ describe('preconnectAnthropicApi', () => {
     globalThis.fetch = fetchMock as typeof globalThis.fetch
 
     const { preconnectAnthropicApi } = await importFreshModule()
-    preconnectAnthropicApi()
+    preconnectAnthropicApi('firstParty')
 
     expect(fetchMock).toHaveBeenCalledTimes(1)
   })

--- a/src/utils/apiPreconnect.ts
+++ b/src/utils/apiPreconnect.ts
@@ -26,16 +26,18 @@
 import { getOauthConfig } from '../constants/oauth.js'
 import { createCombinedAbortSignal } from './combinedAbortSignal.js'
 import { isEnvTruthy } from './envUtils.js'
-import { getAPIProvider } from './model/providers.js'
+import { type APIProvider, getAPIProvider } from './model/providers.js'
 
 let fired = false
 
-export function preconnectAnthropicApi(): void {
+export function preconnectAnthropicApi(
+  apiProvider: APIProvider = getAPIProvider(),
+): void {
   if (fired) return
   fired = true
 
   // Third-party providers should not warm a connection to Anthropic.
-  if (getAPIProvider() !== 'firstParty') {
+  if (apiProvider !== 'firstParty') {
     return
   }
 

--- a/src/utils/model/minimaxModels.ts
+++ b/src/utils/model/minimaxModels.ts
@@ -5,14 +5,18 @@
 
 import type { ModelOption } from './modelOptions.js'
 import { getAPIProvider } from './providers.js'
+import { getMiniMaxBaseUrlOverride } from '../../integrations/routeMetadata.js'
 import { isEnvTruthy } from '../envUtils.js'
 
 export function isMiniMaxProvider(): boolean {
   if (isEnvTruthy(process.env.MINIMAX_API_KEY)) {
     return true
   }
-  const baseUrl = process.env.OPENAI_BASE_URL ?? ''
-  if (baseUrl.includes('minimax')) {
+  // MiniMax runs over the anthropic-proxy transport, so the active base URL can
+  // arrive via ANTHROPIC_BASE_URL (not just OPENAI_BASE_URL). Reuse the shared
+  // host matcher so the model picker recognises every configured MiniMax base
+  // URL even when MINIMAX_API_KEY isn't exported into the environment.
+  if (getMiniMaxBaseUrlOverride(process.env) !== undefined) {
     return true
   }
   return getAPIProvider() === 'minimax'

--- a/src/utils/model/minimaxModels.ts
+++ b/src/utils/model/minimaxModels.ts
@@ -26,6 +26,7 @@ function getMiniMaxModels(): ModelOption[] {
     { value: 'MiniMax-M2.5', label: 'MiniMax M2.5', description: 'Flagship - 256K context - Vision/Function-calling' },
     { value: 'MiniMax-M2.7', label: 'MiniMax M2.7', description: 'Flagship - 256K context - Chat/Code/Reasoning' },
     { value: 'MiniMax-M2.7-highspeed', label: 'MiniMax M2.7 Highspeed', description: 'Fast flagship - 256K context - Chat/Code/Reasoning' },
+    { value: 'MiniMax-M3', label: 'MiniMax M3', description: 'Next-gen - 1M context - Coding/Agentic/Reasoning' },
     { value: 'MiniMax-Text-01', label: 'MiniMax Text 01', description: 'Text-focused - 512K context - FREE' },
     { value: 'MiniMax-Text-01-Preview', label: 'MiniMax Text 01 Preview', description: 'Preview - 256K context - FREE' },
     { value: 'MiniMax-Vision-01', label: 'MiniMax Vision 01', description: 'Vision model - 32K context' },

--- a/src/utils/model/model.openai-shim-providers.test.ts
+++ b/src/utils/model/model.openai-shim-providers.test.ts
@@ -236,15 +236,15 @@ test('getDefaultOpusModel returns OPENAI_MODEL for MiniMax', async () => {
   expect(getDefaultOpusModel()).toBe('MiniMax-M2.7')
 })
 
-test('getDefaultMainLoopModelSetting defaults MiniMax to M2.7', async () => {
+test('getDefaultMainLoopModelSetting defaults MiniMax to M3', async () => {
   process.env.MINIMAX_API_KEY = 'minimax-test'
 
   const {
     getDefaultMainLoopModel,
     getDefaultMainLoopModelSetting,
   } = await importFreshModelModule()
-  expect(getDefaultMainLoopModelSetting()).toBe('MiniMax-M2.7')
-  expect(getDefaultMainLoopModel()).toBe('MiniMax-M2.7')
+  expect(getDefaultMainLoopModelSetting()).toBe('MiniMax-M3')
+  expect(getDefaultMainLoopModel()).toBe('MiniMax-M3')
 })
 
 test('getDefaultMainLoopModelSetting defaults Xiaomi MiMo to mimo-v2.5-pro', async () => {

--- a/src/utils/model/model.ts
+++ b/src/utils/model/model.ts
@@ -390,9 +390,12 @@ export function getDefaultMainLoopModelSetting(): ModelName | ModelAlias {
   if (getAPIProvider() === 'xai') {
     return process.env.OPENAI_MODEL || 'grok-4.3'
   }
-  // MiniMax provider: always use the configured MiniMax model
+  // MiniMax provider: always use the configured MiniMax model.
+  // Keep the env-only fallback aligned with the MiniMax descriptor default
+  // (MiniMax-M3) so a session with only MINIMAX_API_KEY / a MiniMax base URL
+  // defaults to the same model as --provider minimax and saved profiles.
   if (getAPIProvider() === 'minimax') {
-    return getMiniMaxModelEnv() || 'MiniMax-M2.7'
+    return getMiniMaxModelEnv() || 'MiniMax-M3'
   }
   // Xiaomi MiMo provider: always use the configured MiMo model
   if (getAPIProvider() === 'xiaomi-mimo') {

--- a/src/utils/preflightChecks.test.ts
+++ b/src/utils/preflightChecks.test.ts
@@ -8,6 +8,34 @@ import {
   releaseSharedMutationLock,
 } from '../test/sharedMutationLock.js'
 
+type AxiosModule = typeof import('axios')
+
+// Captured once (before any test mocks axios) and re-registered in afterEach.
+// bun's mock.restore() does not unregister mock.module() overrides, so without
+// this the partial axios stub below leaks into later test files — e.g. proxy
+// configuration's `axios.defaults.proxy = ...` throws because `defaults` is
+// missing, breaking tests/sdk/query-lifecycle.
+let originalAxiosModule: AxiosModule | undefined
+
+// Build a COMPLETE axios module stub. Including `defaults` and `interceptors`
+// keeps the stub harmless to consumers like proxy.ts's configureGlobalAgents()
+// (`axios.defaults.proxy = ...`, `axios.interceptors.request.eject(...)`) if it
+// ever leaks beyond this file, since bun does not unregister mock.module().
+function buildAxiosModuleStub(
+  get: (...args: unknown[]) => Promise<unknown>,
+): AxiosModule {
+  const instance = {
+    get,
+    isAxiosError: () => false,
+    defaults: {} as Record<string, unknown>,
+    interceptors: {
+      request: { use: () => 0, eject: () => {} },
+      response: { use: () => 0, eject: () => {} },
+    },
+  }
+  return { default: instance } as unknown as AxiosModule
+}
+
 // MACRO is normally substituted at build time. The test runs without the
 // bundler, so stub the build-time globals before importing the module under
 // test (which transitively imports utils/http.ts -> MACRO.VERSION).
@@ -95,6 +123,7 @@ async function waitForPreflightFailureEffect(
 
 beforeEach(async () => {
   await acquireSharedMutationLock('utils/preflightChecks.test.ts')
+  originalAxiosModule ??= await import('axios')
 })
 
 afterEach(() => {
@@ -103,6 +132,11 @@ afterEach(() => {
     jest.restoreAllMocks()
     jest.useRealTimers()
     mock.restore()
+    // Re-register the genuine axios module so this file's partial stub does not
+    // leak into later test files.
+    if (originalAxiosModule) {
+      mock.module('axios', () => originalAxiosModule!)
+    }
   } finally {
     releaseSharedMutationLock()
   }
@@ -111,18 +145,14 @@ afterEach(() => {
 describe('checkEndpoints (preflight)', () => {
   test('passes a bounded timeout to axios so a hung probe cannot freeze onboarding (#1017)', async () => {
     const calls: Array<{ url: string; options: { timeout?: number } }> = []
-    mock.module('axios', () => ({
-      default: {
-        get: async (
-          url: string,
-          options: { timeout?: number } = {},
-        ): Promise<{ status: number }> => {
-          calls.push({ url, options })
-          return { status: 200 }
-        },
-        isAxiosError: () => false,
-      },
-    }))
+    mock.module('axios', () =>
+      buildAxiosModuleStub(async (...args: unknown[]) => {
+        const url = args[0] as string
+        const options = (args[1] as { timeout?: number }) ?? {}
+        calls.push({ url, options })
+        return { status: 200 }
+      }),
+    )
 
     const { checkEndpoints, PREFLIGHT_REQUEST_TIMEOUT_MS } = await import(
       './preflightChecks.js'
@@ -140,18 +170,15 @@ describe('checkEndpoints (preflight)', () => {
   })
 
   test('returns a failure result (instead of throwing or hanging) when axios rejects with ECONNABORTED', async () => {
-    mock.module('axios', () => ({
-      default: {
-        get: async (): Promise<never> => {
-          const err = new Error('timeout of 5000ms exceeded') as Error & {
-            code?: string
-          }
-          err.code = 'ECONNABORTED'
-          throw err
-        },
-        isAxiosError: () => false,
-      },
-    }))
+    mock.module('axios', () =>
+      buildAxiosModuleStub(async () => {
+        const err = new Error('timeout of 5000ms exceeded') as Error & {
+          code?: string
+        }
+        err.code = 'ECONNABORTED'
+        throw err
+      }),
+    )
 
     const { checkEndpoints } = await import('./preflightChecks.js')
 
@@ -163,12 +190,9 @@ describe('checkEndpoints (preflight)', () => {
   })
 
   test('returns success when all probes return 200', async () => {
-    mock.module('axios', () => ({
-      default: {
-        get: async (): Promise<{ status: number }> => ({ status: 200 }),
-        isAxiosError: () => false,
-      },
-    }))
+    mock.module('axios', () =>
+      buildAxiosModuleStub(async () => ({ status: 200 })),
+    )
 
     const { checkEndpoints } = await import('./preflightChecks.js')
 
@@ -190,19 +214,16 @@ describe('checkEndpoints (preflight)', () => {
     mock.module('../hooks/useTimeout.js', () => ({
       useTimeout: () => false,
     }))
-    mock.module('axios', () => ({
-      default: {
-        get: async (): Promise<never> => {
-          probeCalls++
-          const err = new Error('timeout of 5000ms exceeded') as Error & {
-            code?: string
-          }
-          err.code = 'ECONNABORTED'
-          throw err
-        },
-        isAxiosError: () => false,
-      },
-    }))
+    mock.module('axios', () =>
+      buildAxiosModuleStub(async () => {
+        probeCalls++
+        const err = new Error('timeout of 5000ms exceeded') as Error & {
+          code?: string
+        }
+        err.code = 'ECONNABORTED'
+        throw err
+      }),
+    )
 
     const { createRoot } = await import('../ink.js')
     const { PreflightStep, PREFLIGHT_ERROR_HOLD_MS } = await import(

--- a/src/utils/providerFallback.test.ts
+++ b/src/utils/providerFallback.test.ts
@@ -1,18 +1,22 @@
-import { afterEach, beforeEach, expect, test } from 'bun:test'
-import { mock } from 'bun:test'
+import { expect, test } from 'bun:test'
 
+import { type ProviderProfile } from './config.js'
 import {
-  resetSettingsCache,
-  setSessionSettingsCache,
-} from './settings/settingsCache.js'
+  getProviderFallbackChain,
+  resolveNextFallbackProvider,
+  resolveNextFallbackProviderFromState,
+} from './providerFallback.js'
 
-import * as actualConfig from './config.js'
-import * as actualProviderProfiles from './providerProfiles.js'
-import * as actualSettings from './settings/settings.js'
+// This file intentionally avoids mock.module(). The functions under test take
+// their settings/profile inputs as injected parameters, so tests pass them
+// directly. bun does not unregister mock.module() overrides on mock.restore(),
+// so mocking shared singletons here used to leak into later test files
+// (attribution/preconnect/etc.). Dependency injection keeps these tests fully
+// self-contained.
 
 function buildProfile(
-  overrides: Partial<actualConfig.ProviderProfile> = {},
-): actualConfig.ProviderProfile {
+  overrides: Partial<ProviderProfile> = {},
+): ProviderProfile {
   return {
     id: 'profile_x',
     name: 'X',
@@ -24,74 +28,36 @@ function buildProfile(
   }
 }
 
-async function importFreshProviderFallback(
-  profileMocks: Partial<typeof actualProviderProfiles>,
-  settingsOverride: Record<string, unknown> = {},
-) {
-  mock.restore()
-  mock.module('./providerProfiles.js', () => ({
-    ...actualProviderProfiles,
-    ...profileMocks,
-  }))
-  // Stub `getSettings_DEPRECATED` directly so the resolver sees the test's
-  // intended `providerFallbackChain` regardless of session-cache reset
-  // behavior under nonced re-imports. setSessionSettingsCache() works under
-  // bun locally but doesn't survive a fresh `import('?ts=...')` because the
-  // settings module loads its own cache instance on each fresh import.
-  mock.module('./settings/settings.js', () => ({
-    ...actualSettings,
-    getSettings_DEPRECATED: () => settingsOverride,
-    getInitialSettings: () => settingsOverride,
-  }))
-  const nonce = `${Date.now()}-${Math.random()}`
-  return import(`./providerFallback.js?ts=${nonce}`)
-}
-
-beforeEach(() => {
-  mock.restore()
-  setSessionSettingsCache({ settings: {}, errors: [] })
+test('getProviderFallbackChain: returns [] when unset', () => {
+  expect(getProviderFallbackChain({})).toEqual([])
 })
 
-afterEach(() => {
-  mock.restore()
-  resetSettingsCache()
+test('getProviderFallbackChain: returns configured ids', () => {
+  expect(
+    getProviderFallbackChain({
+      providerFallbackChain: ['profile_a', 'profile_b'],
+    }),
+  ).toEqual(['profile_a', 'profile_b'])
 })
 
-test('getProviderFallbackChain: returns [] when unset', async () => {
-  const { getProviderFallbackChain } = await importFreshProviderFallback({})
-  expect(getProviderFallbackChain()).toEqual([])
-})
-
-test('getProviderFallbackChain: returns configured ids', async () => {
-  const { getProviderFallbackChain } = await importFreshProviderFallback(
-    {},
-    { providerFallbackChain: ['profile_a', 'profile_b'] },
-  )
-  expect(getProviderFallbackChain()).toEqual(['profile_a', 'profile_b'])
-})
-
-test('getProviderFallbackChain: filters non-string + empty entries', async () => {
+test('getProviderFallbackChain: filters non-string + empty entries', () => {
   // Setting could be hand-edited to a malformed shape. Defensive filter keeps
   // the resolver from crashing on garbage without making it the source of a
   // hard error during a rate-limit recovery flow.
-  const { getProviderFallbackChain } = await importFreshProviderFallback(
-    {},
-    {
+  expect(
+    getProviderFallbackChain({
       providerFallbackChain: ['profile_a', '', null, 5, 'profile_b'],
-    },
-  )
-  expect(getProviderFallbackChain()).toEqual(['profile_a', 'profile_b'])
+    }),
+  ).toEqual(['profile_a', 'profile_b'])
 })
 
-test('resolveNextFallbackProvider: empty chain → null', async () => {
-  const { resolveNextFallbackProvider } = await importFreshProviderFallback({})
+test('resolveNextFallbackProvider: empty chain → null', () => {
   expect(resolveNextFallbackProvider('profile_a', [], [])).toBeNull()
 })
 
-test('resolveNextFallbackProvider: returns next after active', async () => {
+test('resolveNextFallbackProvider: returns next after active', () => {
   const a = buildProfile({ id: 'profile_a', name: 'A' })
   const b = buildProfile({ id: 'profile_b', name: 'B' })
-  const { resolveNextFallbackProvider } = await importFreshProviderFallback({})
 
   const result = resolveNextFallbackProvider(
     'profile_a',
@@ -103,13 +69,12 @@ test('resolveNextFallbackProvider: returns next after active', async () => {
   expect(result?.fromProfileId).toBe('profile_a')
 })
 
-test('resolveNextFallbackProvider: does not wrap when active is the last entry', async () => {
+test('resolveNextFallbackProvider: does not wrap when active is the last entry', () => {
   // Wrapping would let "everything rate-limited" cycle back to the first
   // profile that already failed and produce a churn loop. Exhaust silently
   // and let the caller surface the original error.
   const a = buildProfile({ id: 'profile_a' })
   const b = buildProfile({ id: 'profile_b' })
-  const { resolveNextFallbackProvider } = await importFreshProviderFallback({})
 
   const result = resolveNextFallbackProvider(
     'profile_b',
@@ -119,14 +84,13 @@ test('resolveNextFallbackProvider: does not wrap when active is the last entry',
   expect(result).toBeNull()
 })
 
-test('resolveNextFallbackProvider: active not in chain → starts from chain[0]', async () => {
+test('resolveNextFallbackProvider: active not in chain → starts from chain[0]', () => {
   // User landed on a non-chain profile via `/provider` ad-hoc — treat the
   // chain as an absolute priority list and start from the top instead of
   // refusing to do anything.
   const a = buildProfile({ id: 'profile_a' })
   const b = buildProfile({ id: 'profile_b' })
   const c = buildProfile({ id: 'profile_c' })
-  const { resolveNextFallbackProvider } = await importFreshProviderFallback({})
 
   const result = resolveNextFallbackProvider(
     'profile_c',
@@ -137,12 +101,11 @@ test('resolveNextFallbackProvider: active not in chain → starts from chain[0]'
   expect(result?.fromProfileId).toBe('profile_c')
 })
 
-test('resolveNextFallbackProvider: skips chain entries that no longer resolve to real profiles', async () => {
+test('resolveNextFallbackProvider: skips chain entries that no longer resolve to real profiles', () => {
   // Chain may reference a deleted profile id. Don't surface that as a hard
   // failure — keep advancing.
   const a = buildProfile({ id: 'profile_a' })
   const c = buildProfile({ id: 'profile_c' })
-  const { resolveNextFallbackProvider } = await importFreshProviderFallback({})
 
   const result = resolveNextFallbackProvider(
     'profile_a',
@@ -152,19 +115,17 @@ test('resolveNextFallbackProvider: skips chain entries that no longer resolve to
   expect(result?.nextProfileId).toBe('profile_c')
 })
 
-test('resolveNextFallbackProvider: null active + chain configured → chain[0]', async () => {
+test('resolveNextFallbackProvider: null active + chain configured → chain[0]', () => {
   // Edge case: pristine session with no active profile yet. The chain still
   // serves as a priority list so the first entry wins.
   const a = buildProfile({ id: 'profile_a' })
-  const { resolveNextFallbackProvider } = await importFreshProviderFallback({})
 
   const result = resolveNextFallbackProvider(null, ['profile_a'], [a])
   expect(result?.nextProfileId).toBe('profile_a')
   expect(result?.fromProfileId).toBeNull()
 })
 
-test('resolveNextFallbackProvider: every candidate missing → null', async () => {
-  const { resolveNextFallbackProvider } = await importFreshProviderFallback({})
+test('resolveNextFallbackProvider: every candidate missing → null', () => {
   const result = resolveNextFallbackProvider(
     'profile_a',
     ['profile_a', 'profile_b'],
@@ -173,19 +134,16 @@ test('resolveNextFallbackProvider: every candidate missing → null', async () =
   expect(result).toBeNull()
 })
 
-test('resolveNextFallbackProviderFromState: pulls chain + active from real settings/state', async () => {
+test('resolveNextFallbackProviderFromState: resolves from injected chain + active', () => {
   const a = buildProfile({ id: 'profile_a' })
   const b = buildProfile({ id: 'profile_b' })
-  const { resolveNextFallbackProviderFromState } =
-    await importFreshProviderFallback(
-      {
-        getProviderProfiles: () => [a, b],
-        getActiveProviderProfile: () => a,
-      },
-      { providerFallbackChain: ['profile_a', 'profile_b'] },
-    )
 
-  const result = resolveNextFallbackProviderFromState()
+  const result = resolveNextFallbackProviderFromState({
+    activeProfileId: 'profile_a',
+    chain: ['profile_a', 'profile_b'],
+    profiles: [a, b],
+  })
+
   expect(result?.nextProfileId).toBe('profile_b')
   expect(result?.fromProfileId).toBe('profile_a')
 })

--- a/src/utils/providerFallback.ts
+++ b/src/utils/providerFallback.ts
@@ -31,9 +31,10 @@ export type ProviderFallbackResolution = {
  * callers can simply ask `getProviderFallbackChain().length === 0` instead of
  * threading `undefined`.
  */
-export function getProviderFallbackChain(): string[] {
-  const settings = getSettings_DEPRECATED()
-  const chain = (settings as { providerFallbackChain?: unknown }).providerFallbackChain
+export function getProviderFallbackChain(
+  settings: { providerFallbackChain?: unknown } = getSettings_DEPRECATED(),
+): string[] {
+  const chain = settings.providerFallbackChain
   if (!Array.isArray(chain)) {
     return []
   }
@@ -92,6 +93,16 @@ export function resolveNextFallbackProvider(
  * Convenience: read both chain and current active profile from settings/state
  * and resolve in one call. Returns null when there's nothing to fall back to.
  */
-export function resolveNextFallbackProviderFromState(): ProviderFallbackResolution | null {
-  return resolveNextFallbackProvider(getActiveProviderProfile()?.id ?? null)
+export function resolveNextFallbackProviderFromState(
+  deps: {
+    activeProfileId?: string | null
+    chain?: string[]
+    profiles?: ProviderProfile[]
+  } = {},
+): ProviderFallbackResolution | null {
+  const activeProfileId =
+    deps.activeProfileId ?? getActiveProviderProfile()?.id ?? null
+  const chain = deps.chain ?? getProviderFallbackChain()
+  const profiles = deps.profiles ?? getProviderProfiles()
+  return resolveNextFallbackProvider(activeProfileId, chain, profiles)
 }

--- a/src/utils/providerFlag.test.ts
+++ b/src/utils/providerFlag.test.ts
@@ -336,7 +336,7 @@ describe('applyProviderFlag - minimax', () => {
     expect(result.error).toBeUndefined()
     expect(process.env.CLAUDE_CODE_USE_OPENAI).toBeUndefined()
     expect(process.env.ANTHROPIC_BASE_URL).toBe('https://api.minimax.io/anthropic')
-    expect(process.env.ANTHROPIC_MODEL).toBe('MiniMax-M2.7')
+    expect(process.env.ANTHROPIC_MODEL).toBe('MiniMax-M3')
     expect(process.env.OPENAI_BASE_URL).toBeUndefined()
     expect(process.env.OPENAI_MODEL).toBeUndefined()
   })

--- a/src/utils/providerFlag.ts
+++ b/src/utils/providerFlag.ts
@@ -291,7 +291,7 @@ export function applyProviderFlag(
       delete process.env.OPENAI_AUTH_SCHEME
       delete process.env.OPENAI_AUTH_HEADER_VALUE
       process.env.ANTHROPIC_BASE_URL = defaultBaseUrl ?? 'https://api.minimax.io/anthropic'
-      process.env.ANTHROPIC_MODEL = defaultModel ?? 'MiniMax-M2.7'
+      process.env.ANTHROPIC_MODEL = defaultModel ?? 'MiniMax-M3'
       if (model) process.env.ANTHROPIC_MODEL = model
       if (process.env.MINIMAX_API_KEY && !process.env.ANTHROPIC_API_KEY) {
         process.env.ANTHROPIC_API_KEY = process.env.MINIMAX_API_KEY

--- a/src/utils/providerProfiles.test.ts
+++ b/src/utils/providerProfiles.test.ts
@@ -1160,7 +1160,7 @@ describe('getProviderPresetDefaults', () => {
     expect(defaults.requiresApiKey).toBe(true)
   })
 
-  test('minimax preset defaults to MiniMax M2.7', async () => {
+  test('minimax preset defaults to MiniMax M3', async () => {
     const { getProviderPresetDefaults } = await importFreshProviderProfileModules()
 
     const defaults = getProviderPresetDefaults('minimax')
@@ -1168,7 +1168,7 @@ describe('getProviderPresetDefaults', () => {
     expect(defaults.provider).toBe('minimax')
     expect(defaults.name).toBe('MiniMax')
     expect(defaults.baseUrl).toBe('https://api.minimax.io/anthropic')
-    expect(defaults.model).toBe('MiniMax-M2.7')
+    expect(defaults.model).toBe('MiniMax-M3')
     expect(defaults.requiresApiKey).toBe(true)
   })
 

--- a/src/utils/settings/flagSettings.test.ts
+++ b/src/utils/settings/flagSettings.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, expect, mock, test } from 'bun:test'
-import { mkdtempSync, rmSync, writeFileSync } from 'fs'
+import { mkdtempSync, realpathSync, rmSync, writeFileSync } from 'fs'
 import { tmpdir } from 'os'
 import { join } from 'path'
 import {
@@ -26,7 +26,10 @@ let tempDir: string
 beforeEach(async () => {
   await acquireSharedMutationLock('utils/settings/flagSettings.test.ts')
   mock.restore()
-  tempDir = mkdtempSync(join(tmpdir(), 'openclaude-flag-settings-'))
+  // realpathSync so the temp path matches what the settings loader stores:
+  // on macOS tmpdir() lives under /tmp, a symlink to /private/tmp, and the
+  // loader canonicalises the --settings path, which would otherwise mismatch.
+  tempDir = realpathSync(mkdtempSync(join(tmpdir(), 'openclaude-flag-settings-')))
   resetSettingsBootstrapState()
   setAllowedSettingSources(['flagSettings'])
 })


### PR DESCRIPTION
M3 is MiniMax's next-gen flagship with coding/agentic capabilities, 1M token context (1,048,576), and benchmark performance on par with Opus 4.7 on SWE-bench.