### PR TITLE
Add provider-profile model picker modes

### DIFF
--- a/docs/advanced-setup.md
+++ b/docs/advanced-setup.md
@@ -377,6 +377,27 @@ bun run dev:atomic-chat
 
 If no profile exists yet, `dev:profile` uses the same goal-aware defaults when picking the initial model.
 
+### Provider Profile Model Picker Mode
+
+When a saved provider profile is active, `/model` can either show the provider's
+catalog/discovered models or only the models explicitly listed in the profile.
+Configure this in `~/.openclaude.json`:
+
+```json
+{
+  "providerProfileModelPickerMode": "auto"
+}
+```
+
+Supported values:
+
+- `auto` (default): single-model profiles show the provider catalog; multi-model
+  profiles show the explicit profile list; native vendor routes keep their full
+  provider catalog.
+- `provider`: show the provider catalog/discovery list first and append
+  profile-only custom model IDs.
+- `profile`: show only explicitly configured profile models.
+
 Use `--provider ollama` when you want a local-only path. Auto mode falls back to OpenAI when no viable local chat model is installed.
 
 Use `--provider atomic-chat` when you want Atomic Chat as the local Apple Silicon provider.

--- a/src/commands/model/model.test.tsx
+++ b/src/commands/model/model.test.tsx
@@ -58,6 +58,36 @@ async function expectModelCommandDoesNotWaitForRefresh(
   return result
 }
 
+function mockProviderProfiles(
+  overrides: Partial<typeof import('../../utils/providerProfiles.js')> = {},
+): void {
+  const providerProfilesMock = {
+    addProviderProfile: () => null,
+    applyActiveProviderProfileFromConfig: () => undefined,
+    clearActiveOpenAIModelOptionsCache: () => {},
+    deleteProviderProfile: () => ({ removed: false }),
+    getActiveOpenAIModelOptionsCache: () => [],
+    getActiveProviderProfile: () => null,
+    getProfileModelOptions: () => [],
+    getProviderPresetDefaults: () => ({
+      provider: 'openai',
+      name: 'OpenAI',
+      baseUrl: 'https://api.openai.com/v1',
+      model: 'gpt-5',
+      requiresApiKey: true,
+    }),
+    getProviderProfiles: () => [],
+    setActiveOpenAIModelOptionsCache: () => {},
+    setActiveProviderProfile: () => null,
+    updateProviderProfile: () => null,
+  } satisfies Partial<typeof import('../../utils/providerProfiles.js')>
+
+  mock.module('../../utils/providerProfiles.js', () => ({
+    ...providerProfilesMock,
+    ...overrides,
+  }))
+}
+
 beforeEach(async () => {
   await acquireSharedMutationLock('commands/model/model.test.tsx')
 })
@@ -168,12 +198,12 @@ test('opens the model picker without awaiting descriptor-backed route refresh', 
     ),
   }))
 
-  mock.module('../../utils/providerProfiles.js', () => ({
+  mockProviderProfiles({
     getActiveOpenAIModelOptionsCache: () => [],
     getActiveProviderProfile: () => null,
     getProfileModelOptions: () => [],
     setActiveOpenAIModelOptionsCache: () => {},
-  }))
+  })
 
   const { call } = await importFreshModelModule('descriptor-refresh-open')
   await expectModelCommandDoesNotWaitForRefresh(call(() => {}, {} as never, ''))
@@ -235,7 +265,7 @@ test('descriptor model options include active profile configured models', async 
   process.env.CLAUDE_CODE_PROVIDER_PROFILE_ENV_APPLIED = '1'
   process.env.CLAUDE_CODE_PROVIDER_PROFILE_ENV_APPLIED_ID = activeProfile.id
 
-  mock.module('../../utils/providerProfiles.js', () => ({
+  mockProviderProfiles({
     getActiveOpenAIModelOptionsCache: () => [],
     getActiveProviderProfile: () => activeProfile,
     getProfileModelOptions: () => [
@@ -251,7 +281,7 @@ test('descriptor model options include active profile configured models', async 
       },
     ],
     setActiveOpenAIModelOptionsCache: () => {},
-  }))
+  })
 
   const { mergeActiveProfileModelOptions } =
     await importFreshModelModule('descriptor-profile-model-merge')
@@ -293,7 +323,7 @@ test('descriptor model options omit route defaults outside active profile models
   process.env.CLAUDE_CODE_PROVIDER_PROFILE_ENV_APPLIED = '1'
   process.env.CLAUDE_CODE_PROVIDER_PROFILE_ENV_APPLIED_ID = activeProfile.id
 
-  mock.module('../../utils/providerProfiles.js', () => ({
+  mockProviderProfiles({
     getActiveOpenAIModelOptionsCache: () => [],
     getActiveProviderProfile: () => activeProfile,
     getProfileModelOptions: () => [
@@ -309,7 +339,7 @@ test('descriptor model options omit route defaults outside active profile models
       },
     ],
     setActiveOpenAIModelOptionsCache: () => {},
-  }))
+  })
 
   const { mergeActiveProfileModelOptions } =
     await importFreshModelModule('descriptor-profile-model-filter')
@@ -344,6 +374,75 @@ test('descriptor model options omit route defaults outside active profile models
   ])
 })
 
+test('descriptor model options preserve discovered route models for discovery-backed active profiles', async () => {
+  const activeProfile = {
+    id: 'openrouter-profile',
+    name: 'OpenRouter',
+    provider: 'openrouter',
+    baseUrl: 'https://openrouter.ai/api/v1',
+    model: 'openai/gpt-oss-120b:free',
+    apiKey: 'sk-openrouter',
+  }
+  process.env.CLAUDE_CODE_PROVIDER_PROFILE_ENV_APPLIED = '1'
+  process.env.CLAUDE_CODE_PROVIDER_PROFILE_ENV_APPLIED_ID = activeProfile.id
+
+  mockProviderProfiles({
+    getActiveOpenAIModelOptionsCache: () => [],
+    getActiveProviderProfile: () => activeProfile,
+    getProfileModelOptions: () => [
+      {
+        value: 'openai/gpt-oss-120b:free',
+        label: 'openai/gpt-oss-120b:free',
+        description: 'Provider: OpenRouter',
+      },
+    ],
+    setActiveOpenAIModelOptionsCache: () => {},
+  })
+
+  const { mergeActiveProfileModelOptions } =
+    await importFreshModelModule('descriptor-profile-model-discovery-merge')
+
+  expect(
+    mergeActiveProfileModelOptions(
+      'openrouter',
+      [
+        {
+          value: 'openai/gpt-oss-120b:free',
+          label: 'GPT OSS 120B Free',
+          description: 'Provider: OpenRouter',
+        },
+        {
+          value: 'openai/gpt-5',
+          label: 'GPT-5',
+          description: 'Provider: OpenRouter',
+        },
+        {
+          value: 'anthropic/claude-sonnet-4',
+          label: 'Claude Sonnet 4',
+          description: 'Provider: OpenRouter',
+        },
+      ],
+      { preserveRouteOptions: true },
+    ),
+  ).toEqual([
+    {
+      value: 'openai/gpt-oss-120b:free',
+      label: 'GPT OSS 120B Free',
+      description: 'Provider: OpenRouter',
+    },
+    {
+      value: 'openai/gpt-5',
+      label: 'GPT-5',
+      description: 'Provider: OpenRouter',
+    },
+    {
+      value: 'anthropic/claude-sonnet-4',
+      label: 'Claude Sonnet 4',
+      description: 'Provider: OpenRouter',
+    },
+  ])
+})
+
 test('descriptor model options skip saved profile models for env-selected routes', async () => {
   const savedProfile = {
     id: 'mistral-profile',
@@ -356,7 +455,7 @@ test('descriptor model options skip saved profile models for env-selected routes
   delete process.env.CLAUDE_CODE_PROVIDER_PROFILE_ENV_APPLIED
   delete process.env.CLAUDE_CODE_PROVIDER_PROFILE_ENV_APPLIED_ID
 
-  mock.module('../../utils/providerProfiles.js', () => ({
+  mockProviderProfiles({
     getActiveOpenAIModelOptionsCache: () => [],
     getActiveProviderProfile: () => savedProfile,
     getProfileModelOptions: () => [
@@ -367,7 +466,7 @@ test('descriptor model options skip saved profile models for env-selected routes
       },
     ],
     setActiveOpenAIModelOptionsCache: () => {},
-  }))
+  })
 
   const { mergeActiveProfileModelOptions } =
     await importFreshModelModule('descriptor-profile-model-env-skip')
@@ -441,14 +540,15 @@ test('/model refresh clears descriptor cache and reports updates', async () => {
       error: null,
       source: 'network',
     })),
+    probeRouteReadiness: mock(async () => null),
   }))
 
-  mock.module('../../utils/providerProfiles.js', () => ({
+  mockProviderProfiles({
     getActiveOpenAIModelOptionsCache: () => [],
     getActiveProviderProfile: () => null,
     getProfileModelOptions: () => [],
     setActiveOpenAIModelOptionsCache: () => {},
-  }))
+  })
 
   const messages: string[] = []
   const { call } = await importFreshModelModule(
@@ -472,6 +572,90 @@ test('/model refresh clears descriptor cache and reports updates', async () => {
   expect(isCacheStale).toHaveBeenCalledWith(expectedCacheKey, 86_400_000)
   expect(clearDiscoveryCache).toHaveBeenCalledWith(expectedCacheKey)
   expect(messages).toContain('Updated OpenRouter models.')
+})
+
+test('/model refresh reports discovered model changes for dynamic active profiles', async () => {
+  const activeProfile = {
+    id: 'lmstudio-profile',
+    name: 'LM Studio',
+    provider: 'lmstudio',
+    baseUrl: 'http://localhost:1234/v1',
+    model: 'local-model-a',
+    apiKey: '',
+  }
+  process.env.CLAUDE_CODE_USE_OPENAI = '1'
+  process.env.OPENAI_BASE_URL = activeProfile.baseUrl
+  delete process.env.OPENAI_API_KEY
+  delete process.env.OPENROUTER_API_KEY
+  process.env.OPENAI_MODEL = activeProfile.model
+  process.env.CLAUDE_CODE_PROVIDER_PROFILE_ENV_APPLIED = '1'
+  process.env.CLAUDE_CODE_PROVIDER_PROFILE_ENV_APPLIED_ID = activeProfile.id
+  delete process.env.CLAUDE_CODE_USE_GEMINI
+  delete process.env.CLAUDE_CODE_USE_GITHUB
+  delete process.env.CLAUDE_CODE_USE_MISTRAL
+  delete process.env.CLAUDE_CODE_USE_BEDROCK
+  delete process.env.CLAUDE_CODE_USE_VERTEX
+  delete process.env.CLAUDE_CODE_USE_FOUNDRY
+  delete process.env.OPENAI_API_BASE
+
+  mock.module('../../integrations/discoveryCache.js', () => ({
+    clearDiscoveryCache: mock(async () => {}),
+    getCachedModels: mock(async () => ({
+      models: [{ id: 'profile-model', apiName: activeProfile.model }],
+      updatedAt: Date.now(),
+      error: null,
+    })),
+    isCacheStale: mock(async () => false),
+    parseDurationString: (value: number | string) =>
+      typeof value === 'number' ? value : 86_400_000,
+  }))
+
+  mock.module('../../integrations/discoveryService.js', () => ({
+    getDiscoveryCacheKey: (
+      routeId: string,
+      options?: { apiKey?: string; baseUrl?: string; headers?: Record<string, string> },
+    ) => `${routeId}|${options?.baseUrl ?? ''}|${options?.apiKey ?? ''}|${JSON.stringify(options?.headers ?? {})}`,
+    discoverModelsForRoute: mock(async () => ({
+      routeId: 'lmstudio',
+      models: [
+        { id: 'profile-model', apiName: activeProfile.model },
+        { id: 'local-model-b', apiName: 'local-model-b' },
+      ],
+      stale: false,
+      error: null,
+      source: 'network',
+    })),
+    probeRouteReadiness: mock(async () => null),
+  }))
+
+  mockProviderProfiles({
+    getActiveOpenAIModelOptionsCache: () => [],
+    getActiveProviderProfile: () => activeProfile,
+    getProfileModelOptions: () => [
+      {
+        value: activeProfile.model,
+        label: activeProfile.model,
+        description: 'Provider: LM Studio',
+      },
+    ],
+    setActiveOpenAIModelOptionsCache: () => {},
+  })
+
+  const messages: string[] = []
+  const { call } = await importFreshModelModule(
+    'descriptor-profile-refresh-manual',
+  )
+  await call(
+    (message?: string) => {
+      if (message) {
+        messages.push(message)
+      }
+    },
+    {} as never,
+    'refresh',
+  )
+
+  expect(messages).toContain('Updated LM Studio models.')
 })
 
 test('/model does not auto-refresh descriptor models when nonessential traffic is disabled', async () => {
@@ -509,12 +693,12 @@ test('/model does not auto-refresh descriptor models when nonessential traffic i
     discoverModelsForRoute,
   }))
 
-  mock.module('../../utils/providerProfiles.js', () => ({
+  mockProviderProfiles({
     getActiveOpenAIModelOptionsCache: () => [],
     getActiveProviderProfile: () => null,
     getProfileModelOptions: () => [],
     setActiveOpenAIModelOptionsCache: () => {},
-  }))
+  })
 
   const { call } = await importFreshModelModule('descriptor-privacy-open')
   const result = await call(() => {}, {} as never, '')

--- a/src/commands/model/model.test.tsx
+++ b/src/commands/model/model.test.tsx
@@ -1,10 +1,21 @@
+import { PassThrough } from 'node:stream'
+
 import { afterEach, beforeEach, expect, mock, test } from 'bun:test'
+import React from 'react'
 
 import { getAdditionalModelOptionsCacheScope } from '../../services/api/providerConfig.js'
 import {
   acquireSharedMutationLock,
   releaseSharedMutationLock,
 } from '../../test/sharedMutationLock.js'
+import {
+  resetSettingsCache,
+  setSessionSettingsCache,
+} from '../../utils/settings/settingsCache.js'
+import type { ModelOption } from '../../utils/model/modelOptions.js'
+import type { SettingsJson } from '../../utils/settings/types.js'
+
+type SettingsModule = typeof import('../../utils/settings/settings.js')
 
 const originalEnv = {
   CLAUDE_CODE_USE_OPENAI: process.env.CLAUDE_CODE_USE_OPENAI,
@@ -58,6 +69,71 @@ async function expectModelCommandDoesNotWaitForRefresh(
   return result
 }
 
+type ProviderProfileModelPickerModeForTest = 'auto' | 'profile' | 'provider'
+let actualSettingsModule: SettingsModule | undefined
+let settingsForTest: SettingsJson & {
+  providerProfileModelPickerMode?: ProviderProfileModelPickerModeForTest
+} = {}
+let scopedLocalOpenAIModelCacheState:
+  | {
+      additionalModelOptionsCache?: ModelOption[]
+      additionalModelOptionsCacheScope?: string
+    }
+  | undefined
+
+function useSettings(
+  settings: SettingsJson & {
+    providerProfileModelPickerMode?: ProviderProfileModelPickerModeForTest
+  },
+): void {
+  settingsForTest = settings
+  setSessionSettingsCache({ settings, errors: [] })
+}
+
+async function mockSettingsForTest(): Promise<void> {
+  actualSettingsModule ??= await import(
+    `../../utils/settings/settings.ts?modelCommandSettingsActual=${Date.now()}-${Math.random()}`
+  )
+  mock.module('../../utils/settings/settings.js', () => ({
+    ...actualSettingsModule!,
+    getInitialSettings: () => settingsForTest,
+    getSettings_DEPRECATED: () => settingsForTest,
+  }))
+  mock.module('../../utils/model/modelAllowlist.js', () => ({
+    isModelAllowed: isModelAllowedForTest,
+  }))
+}
+
+function isModelAllowedForTest(model: string): boolean {
+  const { availableModels } = settingsForTest
+  if (!availableModels) {
+    return true
+  }
+  if (availableModels.length === 0) {
+    return false
+  }
+
+  const normalizedModel = model.trim().toLowerCase()
+  return availableModels.some(
+    allowed => allowed.trim().toLowerCase() === normalizedModel,
+  )
+}
+
+function getConfiguredProfileModelOptionsForTest(profile: {
+  model: string
+  name: string
+}) {
+  return profile.model
+    .split(/[;,]/)
+    .map(model => model.trim())
+    .filter(Boolean)
+    .map(model => ({
+      value: model,
+      label: model,
+      description: `Provider: ${profile.name}`,
+    }))
+}
+
 function mockProviderProfiles(
   overrides: Partial<typeof import('../../utils/providerProfiles.js')> = {},
 ): void {
@@ -67,7 +143,16 @@ function mockProviderProfiles(
     clearActiveOpenAIModelOptionsCache: () => {},
     deleteProviderProfile: () => ({ removed: false }),
     getActiveOpenAIModelOptionsCache: () => [],
-    getActiveProviderProfile: () => null,
+    getActiveOpenAIRouteModelOptionsCache: () => {
+      const activeScope = getAdditionalModelOptionsCacheScope()
+      return activeScope?.startsWith('openai:') &&
+        scopedLocalOpenAIModelCacheState?.additionalModelOptionsCacheScope ===
+          activeScope
+        ? (scopedLocalOpenAIModelCacheState.additionalModelOptionsCache ?? [])
+        : []
+    },
+    getActiveProviderProfile: () => undefined,
+    getConfiguredProfileModelOptions: getConfiguredProfileModelOptionsForTest,
     getProfileModelOptions: () => [],
     getProviderPresetDefaults: () => ({
       provider: 'openai',
@@ -77,6 +162,17 @@ function mockProviderProfiles(
       requiresApiKey: true,
     }),
     getProviderProfiles: () => [],
+    setActiveOpenAIRouteModelOptionsCache: (options: ModelOption[]) => {
+      const activeScope = getAdditionalModelOptionsCacheScope()
+      if (!activeScope?.startsWith('openai:')) {
+        return
+      }
+      scopedLocalOpenAIModelCacheState = {
+        ...(scopedLocalOpenAIModelCacheState ?? {}),
+        additionalModelOptionsCache: options,
+        additionalModelOptionsCacheScope: activeScope,
+      }
+    },
     setActiveOpenAIModelOptionsCache: () => {},
     setActiveProviderProfile: () => null,
     updateProviderProfile: () => null,
@@ -90,11 +186,18 @@ function mockProviderProfiles(
 
 beforeEach(async () => {
   await acquireSharedMutationLock('commands/model/model.test.tsx')
+  mock.restore()
+  settingsForTest = {}
+  await mockSettingsForTest()
+  scopedLocalOpenAIModelCacheState = undefined
+  useSettings({} as SettingsJson)
 })
 
 afterEach(() => {
   try {
     mock.restore()
+    resetSettingsCache()
+    settingsForTest = {}
     restoreEnv('CLAUDE_CODE_USE_OPENAI', originalEnv.CLAUDE_CODE_USE_OPENAI)
     restoreEnv('CLAUDE_CODE_USE_GEMINI', originalEnv.CLAUDE_CODE_USE_GEMINI)
     restoreEnv('CLAUDE_CODE_USE_GITHUB', originalEnv.CLAUDE_CODE_USE_GITHUB)
@@ -124,6 +227,154 @@ afterEach(() => {
     releaseSharedMutationLock()
   }
 })
+
+async function waitForCondition(
+  predicate: () => boolean,
+  timeoutMs = 2000,
+): Promise<void> {
+  const startedAt = Date.now()
+
+  while (Date.now() - startedAt < timeoutMs) {
+    if (predicate()) {
+      return
+    }
+    await Bun.sleep(10)
+  }
+
+  throw new Error('Timed out waiting for condition')
+}
+
+type CapturedModelPickerPropsForTest = {
+  discoveryState?: { message?: string; tone?: string }
+  onRefresh?: () => void
+  optionsOverride?: unknown
+}
+
+type DiscoveryModelForTest = {
+  apiName: string
+  default?: boolean
+  id: string
+  label?: string
+}
+
+function mockDescriptorDiscovery(options: {
+  cachedModels: DiscoveryModelForTest[]
+  discoveredModels?: DiscoveryModelForTest[]
+  routeId?: string
+}): void {
+  mock.module('../../integrations/discoveryCache.js', () => ({
+    clearDiscoveryCache: mock(async () => {}),
+    getCachedModels: mock(async () => ({
+      models: options.cachedModels,
+      updatedAt: Date.now(),
+      error: null,
+    })),
+    isCacheStale: mock(async () => false),
+    parseDurationString: (value: number | string) =>
+      typeof value === 'number' ? value : 86_400_000,
+  }))
+  mock.module('../../integrations/discoveryService.js', () => ({
+    getDiscoveryCacheKey: (
+      routeId: string,
+      requestOptions?: {
+        apiKey?: string
+        baseUrl?: string
+        headers?: Record<string, string>
+      },
+    ) => `${routeId}|${requestOptions?.baseUrl ?? ''}|${requestOptions?.apiKey ?? ''}|${JSON.stringify(requestOptions?.headers ?? {})}`,
+    discoverModelsForRoute: mock(async () => ({
+      routeId: options.routeId ?? 'openrouter',
+      models: options.discoveredModels ?? options.cachedModels,
+      stale: false,
+      error: null,
+      source: 'network',
+    })),
+    probeRouteReadiness: mock(async () => null),
+  }))
+}
+
+async function mockScopedLocalOpenAIModelCache(
+  initialOptions: ModelOption[],
+): Promise<{
+  getState: () => {
+    additionalModelOptionsCache?: ModelOption[]
+    additionalModelOptionsCacheScope?: string
+  }
+}> {
+  const actualConfig = await import('../../utils/config.js')
+  const activeScope = getAdditionalModelOptionsCacheScope()
+  scopedLocalOpenAIModelCacheState = {
+    additionalModelOptionsCache: initialOptions,
+    additionalModelOptionsCacheScope: activeScope ?? undefined,
+  }
+  let state = {
+    ...actualConfig.getGlobalConfig(),
+    additionalModelOptionsCache: initialOptions,
+    additionalModelOptionsCacheScope: activeScope ?? undefined,
+  }
+
+  mock.module('../../utils/config.js', () => ({
+    ...actualConfig,
+    getGlobalConfig: () => state,
+    saveGlobalConfig: (
+      updater: (current: typeof state) => typeof state,
+    ) => {
+      state = updater(state)
+    },
+  }))
+
+  return {
+    getState: () => scopedLocalOpenAIModelCacheState ?? state,
+  }
+}
+
+async function renderModelCommandWithCapturedPicker(
+  suffix: string,
+  options?: {
+    initialState?: unknown
+    onDone?: (message?: string, options?: { display?: string }) => void
+  },
+): Promise<{
+  getCapturedProps: () => CapturedModelPickerPropsForTest
+  instance: Awaited<ReturnType<typeof import('../../ink.js')['render']>>
+  stdout: PassThrough
+}> {
+  let capturedProps: CapturedModelPickerPropsForTest | undefined
+  mock.module('../../components/ModelPicker.js', () => ({
+    ModelPicker: function MockModelPicker(
+      props: CapturedModelPickerPropsForTest,
+    ): React.ReactNode {
+      capturedProps = props
+      return null
+    },
+  }))
+
+  const { call } = await importFreshModelModule(suffix)
+  const element = await call(options?.onDone ?? (() => {}), {} as never, '')
+  const { AppStateProvider } = await import('../../state/AppState.js')
+  const { render } = await import('../../ink.js')
+  const stdout = new PassThrough()
+  ;(stdout as unknown as { columns: number }).columns = 120
+  const instance = await render(
+    <AppStateProvider initialState={options?.initialState as never}>
+      {element}
+    </AppStateProvider>,
+    stdout as unknown as NodeJS.WriteStream,
+  )
+
+  await waitForCondition(() => capturedProps !== undefined)
+
+  return {
+    getCapturedProps: () => {
+      if (!capturedProps) {
+        throw new Error('ModelPicker props were not captured')
+      }
+      return capturedProps
+    },
+    instance,
+    stdout,
+  }
+}
 
 test('opens the model picker without awaiting local model discovery refresh', async () => {
   process.env.CLAUDE_CODE_USE_OPENAI = '1'
@@ -200,7 +451,7 @@ test('opens the model picker without awaiting descriptor-backed route refresh', 
 
   mockProviderProfiles({
     getActiveOpenAIModelOptionsCache: () => [],
-    getActiveProviderProfile: () => null,
+    getActiveProviderProfile: () => undefined,
     getProfileModelOptions: () => [],
     setActiveOpenAIModelOptionsCache: () => {},
   })
@@ -422,7 +673,7 @@ test('descriptor model options preserve discovered route models for discovery-ba
           description: 'Provider: OpenRouter',
         },
       ],
-      { preserveRouteOptions: true },
+      { profileModelSurface: 'provider' },
     ),
   ).toEqual([
     {
@@ -438,6 +689,1152 @@ test('descriptor model options preserve discovered route models for discovery-ba
     {
       value: 'anthropic/claude-sonnet-4',
       label: 'Claude Sonnet 4',
+      description: 'Provider: OpenRouter',
+    },
+  ])
+})
+
+test('auto profile model picker mode uses explicit multi-model profiles as the picker surface', async () => {
+  const activeProfile = {
+    id: 'mistral-profile',
+    name: 'Mistral AI',
+    provider: 'mistral',
+    baseUrl: 'https://api.mistral.ai/v1',
+    model: 'mistral-medium-latest, mistral-small-latest',
+    apiKey: 'sk-mistral',
+  }
+  process.env.CLAUDE_CODE_PROVIDER_PROFILE_ENV_APPLIED = '1'
+  process.env.CLAUDE_CODE_PROVIDER_PROFILE_ENV_APPLIED_ID = activeProfile.id
+
+  mockProviderProfiles({
+    getActiveProviderProfile: () => activeProfile,
+    getProfileModelOptions: () => [
+      ...getConfiguredProfileModelOptionsForTest(activeProfile),
+      {
+        value: 'devstral-latest',
+        label: 'Devstral Latest',
+        description: 'Cached discovery result that is not explicitly configured',
+      },
+    ],
+  })
+
+  const { mergeActiveProfileModelOptions } = await importFreshModelModule(
+    'descriptor-profile-model-auto-profile',
+  )
+
+  expect(
+    mergeActiveProfileModelOptions(
+      'mistral',
+      [
+        {
+          value: 'devstral-latest',
+          label: 'Devstral Latest',
+          description: 'Recommended · Provider: Mistral AI',
+        },
+        {
+          value: 'mistral-small-latest',
+          label: 'Mistral Small Latest',
+          description: 'Provider: Mistral AI',
+        },
+      ],
+      { profileModelSurface: 'profile' },
+    ),
+  ).toEqual([
+    {
+      value: 'mistral-medium-latest',
+      label: 'mistral-medium-latest',
+      description: 'Provider: Mistral AI',
+    },
+    {
+      value: 'mistral-small-latest',
+      label: 'Mistral Small Latest',
+      description: 'Provider: Mistral AI',
+    },
+  ])
+})
+
+test('provider profile model picker surface keeps static route catalogs for single-default profiles', async () => {
+  const activeProfile = {
+    id: 'opengateway-profile',
+    name: 'Gitlawb Opengateway',
+    provider: 'gitlawb-opengateway',
+    baseUrl: 'https://opengateway.gitlawb.com/v1',
+    model: 'mimo-v2.5-pro',
+    apiKey: 'sk-opengateway',
+  }
+  process.env.CLAUDE_CODE_PROVIDER_PROFILE_ENV_APPLIED = '1'
+  process.env.CLAUDE_CODE_PROVIDER_PROFILE_ENV_APPLIED_ID = activeProfile.id
+
+  mockProviderProfiles({
+    getActiveProviderProfile: () => activeProfile,
+    getProfileModelOptions: () =>
+      getConfiguredProfileModelOptionsForTest(activeProfile),
+  })
+
+  const { mergeActiveProfileModelOptions } = await importFreshModelModule(
+    'descriptor-profile-model-provider-static',
+  )
+
+  expect(
+    mergeActiveProfileModelOptions(
+      'gitlawb-opengateway',
+      [
+        {
+          value: 'mimo-v2.5-pro',
+          label: 'MiMo v2.5 Pro',
+          description: 'Recommended · Provider: Gitlawb Opengateway',
+        },
+        {
+          value: 'mimo-v2-pro',
+          label: 'MiMo v2 Pro',
+          description: 'Provider: Gitlawb Opengateway',
+        },
+      ],
+      { profileModelSurface: 'provider' },
+    ),
+  ).toEqual([
+    {
+      value: 'mimo-v2.5-pro',
+      label: 'MiMo v2.5 Pro',
+      description: 'Recommended · Provider: Gitlawb Opengateway',
+    },
+    {
+      value: 'mimo-v2-pro',
+      label: 'MiMo v2 Pro',
+      description: 'Provider: Gitlawb Opengateway',
+    },
+  ])
+})
+
+test('provider profile model picker surface keeps discovered catalogs and appends profile-only custom models', async () => {
+  const activeProfile = {
+    id: 'openrouter-profile',
+    name: 'OpenRouter',
+    provider: 'openrouter',
+    baseUrl: 'https://openrouter.ai/api/v1',
+    model: 'custom/private-model',
+    apiKey: 'sk-openrouter',
+  }
+  process.env.CLAUDE_CODE_PROVIDER_PROFILE_ENV_APPLIED = '1'
+  process.env.CLAUDE_CODE_PROVIDER_PROFILE_ENV_APPLIED_ID = activeProfile.id
+
+  mockProviderProfiles({
+    getActiveProviderProfile: () => activeProfile,
+    getProfileModelOptions: () =>
+      getConfiguredProfileModelOptionsForTest(activeProfile),
+  })
+
+  const { mergeActiveProfileModelOptions } = await importFreshModelModule(
+    'descriptor-profile-model-provider-discovery',
+  )
+
+  expect(
+    mergeActiveProfileModelOptions(
+      'openrouter',
+      [
+        {
+          value: 'openai/gpt-oss-120b:free',
+          label: 'GPT OSS 120B Free',
+          description: 'Provider: OpenRouter',
+        },
+        {
+          value: 'openai/gpt-5',
+          label: 'GPT-5',
+          description: 'Provider: OpenRouter',
+        },
+      ],
+      { profileModelSurface: 'provider' },
+    ),
+  ).toEqual([
+    {
+      value: 'openai/gpt-oss-120b:free',
+      label: 'GPT OSS 120B Free',
+      description: 'Provider: OpenRouter',
+    },
+    {
+      value: 'openai/gpt-5',
+      label: 'GPT-5',
+      description: 'Provider: OpenRouter',
+    },
+    {
+      value: 'custom/private-model',
+      label: 'custom/private-model',
+      description: 'Provider: OpenRouter',
+    },
+  ])
+})
+
+test('resolveProviderProfileModelSurface honors explicit settings and auto mode', async () => {
+  const { resolveProviderProfileModelSurface } = await importFreshModelModule(
+    'descriptor-profile-model-surface-resolution',
+  )
+  const singleModelProfile = {
+    id: 'openrouter-profile',
+    name: 'OpenRouter',
+    provider: 'openrouter',
+    baseUrl: 'https://openrouter.ai/api/v1',
+    model: 'openai/gpt-oss-120b:free',
+    apiKey: 'sk-openrouter',
+  }
+  const multiModelProfile = {
+    ...singleModelProfile,
+    model: 'mistral-medium-latest, mistral-small-latest',
+  }
+
+  expect(
+    resolveProviderProfileModelSurface({
+      activeProfile: singleModelProfile,
+      settingsMode: 'auto',
+    }),
+  ).toBe('provider')
+  expect(
+    resolveProviderProfileModelSurface({
+      activeProfile: multiModelProfile,
+      settingsMode: 'auto',
+    }),
+  ).toBe('profile')
+  expect(
+    resolveProviderProfileModelSurface({
+      activeProfile: singleModelProfile,
+      settingsMode: 'profile',
+    }),
+  ).toBe('profile')
+  expect(
+    resolveProviderProfileModelSurface({
+      activeProfile: multiModelProfile,
+      settingsMode: 'provider',
+    }),
+  ).toBe('provider')
+})
+
+test('provider profile model picker mode override keeps catalog first for multi-model profiles', async () => {
+  const activeProfile = {
+    id: 'mistral-profile',
+    name: 'Mistral AI',
+    provider: 'mistral',
+    baseUrl: 'https://api.mistral.ai/v1',
+    model: 'mistral-medium-latest, mistral-small-latest',
+    apiKey: 'sk-mistral',
+  }
+  process.env.CLAUDE_CODE_PROVIDER_PROFILE_ENV_APPLIED = '1'
+  process.env.CLAUDE_CODE_PROVIDER_PROFILE_ENV_APPLIED_ID = activeProfile.id
+
+  mockProviderProfiles({
+    getActiveProviderProfile: () => activeProfile,
+  })
+
+  const {
+    mergeActiveProfileModelOptions,
+    resolveProviderProfileModelSurface,
+  } = await importFreshModelModule('descriptor-profile-model-provider-override')
+  const profileModelSurface = resolveProviderProfileModelSurface({
+    activeProfile,
+    settingsMode: 'provider',
+  })
+
+  expect(
+    mergeActiveProfileModelOptions(
+      'mistral',
+      [
+        {
+          value: 'devstral-latest',
+          label: 'Devstral Latest',
+          description: 'Recommended · Provider: Mistral AI',
+        },
+        {
+          value: 'mistral-small-latest',
+          label: 'Mistral Small Latest',
+          description: 'Provider: Mistral AI',
+        },
+      ],
+      { profileModelSurface },
+    ),
+  ).toEqual([
+    {
+      value: 'devstral-latest',
+      label: 'Devstral Latest',
+      description: 'Recommended · Provider: Mistral AI',
+    },
+    {
+      value: 'mistral-small-latest',
+      label: 'Mistral Small Latest',
+      description: 'Provider: Mistral AI',
+    },
+    {
+      value: 'mistral-medium-latest',
+      label: 'mistral-medium-latest',
+      description: 'Provider: Mistral AI',
+    },
+  ])
+})
+
+test('/model applies providerProfileModelPickerMode profile override on descriptor picker load', async () => {
+  useSettings({
+    providerProfileModelPickerMode: 'profile',
+  } as SettingsJson & {
+    providerProfileModelPickerMode: ProviderProfileModelPickerModeForTest
+  })
+  const activeProfile = {
+    id: 'openrouter-profile',
+    name: 'OpenRouter',
+    provider: 'openrouter',
+    baseUrl: 'https://openrouter.ai/api/v1',
+    model: 'openai/gpt-oss-120b:free',
+    apiKey: 'sk-openrouter',
+  }
+  process.env.CLAUDE_CODE_USE_OPENAI = '1'
+  process.env.OPENAI_BASE_URL = activeProfile.baseUrl
+  process.env.OPENAI_API_KEY = activeProfile.apiKey
+  delete process.env.OPENROUTER_API_KEY
+  process.env.OPENAI_MODEL = activeProfile.model
+  process.env.CLAUDE_CODE_PROVIDER_PROFILE_ENV_APPLIED = '1'
+  process.env.CLAUDE_CODE_PROVIDER_PROFILE_ENV_APPLIED_ID = activeProfile.id
+  delete process.env.CLAUDE_CODE_USE_GEMINI
+  delete process.env.CLAUDE_CODE_USE_GITHUB
+  delete process.env.CLAUDE_CODE_USE_MISTRAL
+  delete process.env.CLAUDE_CODE_USE_BEDROCK
+  delete process.env.CLAUDE_CODE_USE_VERTEX
+  delete process.env.CLAUDE_CODE_USE_FOUNDRY
+  delete process.env.OPENAI_API_BASE
+
+  mock.module('../../integrations/discoveryCache.js', () => ({
+    clearDiscoveryCache: mock(async () => {}),
+    getCachedModels: mock(async () => ({
+      models: [
+        { id: 'profile-model', apiName: activeProfile.model },
+        { id: 'other-model', apiName: 'openai/gpt-5' },
+      ],
+      updatedAt: Date.now(),
+      error: null,
+    })),
+    isCacheStale: mock(async () => false),
+    parseDurationString: (value: number | string) =>
+      typeof value === 'number' ? value : 86_400_000,
+  }))
+  mock.module('../../integrations/discoveryService.js', () => ({
+    getDiscoveryCacheKey: (
+      routeId: string,
+      options?: { apiKey?: string; baseUrl?: string; headers?: Record<string, string> },
+    ) => `${routeId}|${options?.baseUrl ?? ''}|${options?.apiKey ?? ''}|${JSON.stringify(options?.headers ?? {})}`,
+    discoverModelsForRoute: mock(async () => ({
+      routeId: 'openrouter',
+      models: [],
+      stale: false,
+      error: null,
+      source: 'network',
+    })),
+    probeRouteReadiness: mock(async () => null),
+  }))
+  mockProviderProfiles({
+    getActiveProviderProfile: () => activeProfile,
+  })
+
+  let capturedOptions: unknown
+  mock.module('../../components/ModelPicker.js', () => ({
+    ModelPicker: function MockModelPicker(props: {
+      optionsOverride?: unknown
+    }): React.ReactNode {
+      capturedOptions = props.optionsOverride
+      return null
+    },
+  }))
+
+  const { call } = await importFreshModelModule(
+    'descriptor-picker-settings-profile-mode',
+  )
+  const element = await call(() => {}, {} as never, '')
+  const { AppStateProvider } = await import('../../state/AppState.js')
+  const { render } = await import('../../ink.js')
+  const stdout = new PassThrough()
+  ;(stdout as unknown as { columns: number }).columns = 120
+  const instance = await render(
+    <AppStateProvider>{element}</AppStateProvider>,
+    stdout as unknown as NodeJS.WriteStream,
+  )
+
+  try {
+    await waitForCondition(() => capturedOptions !== undefined)
+  } finally {
+    instance.unmount()
+    stdout.end()
+  }
+
+  expect(capturedOptions).toEqual([
+    {
+      value: activeProfile.model,
+      label: activeProfile.model,
+      description: 'Provider: OpenRouter',
+      descriptionForModel: 'Provider: OpenRouter',
+    },
+  ])
+})
+
+test('/model applies auto profile surface for multi-model descriptor profiles', async () => {
+  const activeProfile = {
+    id: 'openrouter-profile',
+    name: 'OpenRouter',
+    provider: 'openrouter',
+    baseUrl: 'https://openrouter.ai/api/v1',
+    model: 'openai/gpt-oss-120b:free, custom/private-model',
+    apiKey: 'sk-openrouter',
+  }
+  process.env.CLAUDE_CODE_USE_OPENAI = '1'
+  process.env.OPENAI_BASE_URL = activeProfile.baseUrl
+  process.env.OPENAI_API_KEY = activeProfile.apiKey
+  delete process.env.OPENROUTER_API_KEY
+  process.env.OPENAI_MODEL = 'openai/gpt-oss-120b:free'
+  process.env.CLAUDE_CODE_PROVIDER_PROFILE_ENV_APPLIED = '1'
+  process.env.CLAUDE_CODE_PROVIDER_PROFILE_ENV_APPLIED_ID = activeProfile.id
+  delete process.env.CLAUDE_CODE_USE_GEMINI
+  delete process.env.CLAUDE_CODE_USE_GITHUB
+  delete process.env.CLAUDE_CODE_USE_MISTRAL
+  delete process.env.CLAUDE_CODE_USE_BEDROCK
+  delete process.env.CLAUDE_CODE_USE_VERTEX
+  delete process.env.CLAUDE_CODE_USE_FOUNDRY
+  delete process.env.OPENAI_API_BASE
+
+  mockDescriptorDiscovery({
+    cachedModels: [
+      { id: 'profile-model', apiName: 'openai/gpt-oss-120b:free' },
+      { id: 'other-model', apiName: 'openai/gpt-5' },
+    ],
+  })
+  mockProviderProfiles({
+    getActiveProviderProfile: () => activeProfile,
+  })
+
+  const rendered = await renderModelCommandWithCapturedPicker(
+    'descriptor-picker-auto-profile-mode',
+  )
+  try {
+    expect(rendered.getCapturedProps().optionsOverride).toEqual([
+      {
+        value: 'openai/gpt-oss-120b:free',
+        label: 'openai/gpt-oss-120b:free',
+        description: 'Provider: OpenRouter',
+        descriptionForModel: 'Provider: OpenRouter',
+      },
+      {
+        value: 'custom/private-model',
+        label: 'custom/private-model',
+        description: 'Provider: OpenRouter',
+      },
+    ])
+  } finally {
+    rendered.instance.unmount()
+    rendered.stdout.end()
+  }
+})
+
+test('/model applies auto provider surface for single-model descriptor profiles', async () => {
+  const activeProfile = {
+    id: 'openrouter-profile',
+    name: 'OpenRouter',
+    provider: 'openrouter',
+    baseUrl: 'https://openrouter.ai/api/v1',
+    model: 'openai/gpt-oss-120b:free',
+    apiKey: 'sk-openrouter',
+  }
+  process.env.CLAUDE_CODE_USE_OPENAI = '1'
+  process.env.OPENAI_BASE_URL = activeProfile.baseUrl
+  process.env.OPENAI_API_KEY = activeProfile.apiKey
+  delete process.env.OPENROUTER_API_KEY
+  process.env.OPENAI_MODEL = activeProfile.model
+  process.env.CLAUDE_CODE_PROVIDER_PROFILE_ENV_APPLIED = '1'
+  process.env.CLAUDE_CODE_PROVIDER_PROFILE_ENV_APPLIED_ID = activeProfile.id
+  delete process.env.CLAUDE_CODE_USE_GEMINI
+  delete process.env.CLAUDE_CODE_USE_GITHUB
+  delete process.env.CLAUDE_CODE_USE_MISTRAL
+  delete process.env.CLAUDE_CODE_USE_BEDROCK
+  delete process.env.CLAUDE_CODE_USE_VERTEX
+  delete process.env.CLAUDE_CODE_USE_FOUNDRY
+  delete process.env.OPENAI_API_BASE
+
+  mockDescriptorDiscovery({
+    cachedModels: [
+      { id: 'profile-model', apiName: activeProfile.model },
+      { id: 'other-model', apiName: 'openai/gpt-5' },
+    ],
+  })
+  mockProviderProfiles({
+    getActiveProviderProfile: () => activeProfile,
+  })
+
+  const rendered = await renderModelCommandWithCapturedPicker(
+    'descriptor-picker-auto-provider-mode',
+  )
+  try {
+    expect(rendered.getCapturedProps().optionsOverride).toEqual([
+      {
+        value: 'openai/gpt-5-mini',
+        label: 'GPT-5 Mini (via OpenRouter)',
+        description: 'Recommended · Provider: OpenRouter',
+        descriptionForModel:
+          'Recommended · Provider: OpenRouter (openai/gpt-5-mini)',
+      },
+      {
+        value: activeProfile.model,
+        label: activeProfile.model,
+        description: 'Provider: OpenRouter',
+        descriptionForModel: 'Provider: OpenRouter',
+      },
+      {
+        value: 'openai/gpt-5',
+        label: 'openai/gpt-5',
+        description: 'Provider: OpenRouter',
+        descriptionForModel: 'Provider: OpenRouter',
+      },
+    ])
+  } finally {
+    rendered.instance.unmount()
+    rendered.stdout.end()
+  }
+})
+
+test('/model applies auto provider surface for single-model static descriptor profiles', async () => {
+  const activeProfile = {
+    id: 'opengateway-profile',
+    name: 'Gitlawb Opengateway',
+    provider: 'gitlawb-opengateway',
+    baseUrl: 'https://opengateway.gitlawb.com/v1',
+    model: 'mimo-v2.5-pro',
+    apiKey: 'sk-opengateway',
+  }
+  process.env.CLAUDE_CODE_USE_OPENAI = '1'
+  process.env.OPENAI_BASE_URL = activeProfile.baseUrl
+  process.env.OPENAI_API_KEY = activeProfile.apiKey
+  process.env.OPENAI_MODEL = activeProfile.model
+  process.env.CLAUDE_CODE_PROVIDER_PROFILE_ENV_APPLIED = '1'
+  process.env.CLAUDE_CODE_PROVIDER_PROFILE_ENV_APPLIED_ID = activeProfile.id
+  delete process.env.OPENROUTER_API_KEY
+  delete process.env.CLAUDE_CODE_USE_GEMINI
+  delete process.env.CLAUDE_CODE_USE_GITHUB
+  delete process.env.CLAUDE_CODE_USE_MISTRAL
+  delete process.env.CLAUDE_CODE_USE_BEDROCK
+  delete process.env.CLAUDE_CODE_USE_VERTEX
+  delete process.env.CLAUDE_CODE_USE_FOUNDRY
+  delete process.env.OPENAI_API_BASE
+
+  mockProviderProfiles({
+    getActiveProviderProfile: () => activeProfile,
+  })
+
+  const rendered = await renderModelCommandWithCapturedPicker(
+    'descriptor-picker-auto-provider-static-mode',
+  )
+  try {
+    expect(
+      (rendered.getCapturedProps().optionsOverride as ModelOption[]).map(
+        option => option.value,
+      ),
+    ).toEqual([
+      'mimo-v2.5-pro',
+      'mimo-v2-pro',
+      'mimo-v2.5',
+      'mimo-v2-omni',
+      'mimo-v2-flash',
+      'google/gemini-3.1-flash-lite-preview',
+    ])
+  } finally {
+    rendered.instance.unmount()
+    rendered.stdout.end()
+  }
+})
+
+test('/model applies providerProfileModelPickerMode provider override on descriptor picker load', async () => {
+  useSettings({
+    providerProfileModelPickerMode: 'provider',
+  } as SettingsJson & {
+    providerProfileModelPickerMode: ProviderProfileModelPickerModeForTest
+  })
+  const activeProfile = {
+    id: 'openrouter-profile',
+    name: 'OpenRouter',
+    provider: 'openrouter',
+    baseUrl: 'https://openrouter.ai/api/v1',
+    model: 'custom/private-model, openai/gpt-oss-120b:free',
+    apiKey: 'sk-openrouter',
+  }
+  process.env.CLAUDE_CODE_USE_OPENAI = '1'
+  process.env.OPENAI_BASE_URL = activeProfile.baseUrl
+  process.env.OPENAI_API_KEY = activeProfile.apiKey
+  delete process.env.OPENROUTER_API_KEY
+  process.env.OPENAI_MODEL = 'openai/gpt-oss-120b:free'
+  process.env.CLAUDE_CODE_PROVIDER_PROFILE_ENV_APPLIED = '1'
+  process.env.CLAUDE_CODE_PROVIDER_PROFILE_ENV_APPLIED_ID = activeProfile.id
+  delete process.env.CLAUDE_CODE_USE_GEMINI
+  delete process.env.CLAUDE_CODE_USE_GITHUB
+  delete process.env.CLAUDE_CODE_USE_MISTRAL
+  delete process.env.CLAUDE_CODE_USE_BEDROCK
+  delete process.env.CLAUDE_CODE_USE_VERTEX
+  delete process.env.CLAUDE_CODE_USE_FOUNDRY
+  delete process.env.OPENAI_API_BASE
+
+  mockDescriptorDiscovery({
+    cachedModels: [
+      { id: 'profile-model', apiName: 'openai/gpt-oss-120b:free' },
+      { id: 'other-model', apiName: 'openai/gpt-5' },
+    ],
+  })
+  mockProviderProfiles({
+    getActiveProviderProfile: () => activeProfile,
+  })
+
+  const rendered = await renderModelCommandWithCapturedPicker(
+    'descriptor-picker-settings-provider-mode',
+  )
+  try {
+    expect(rendered.getCapturedProps().optionsOverride).toEqual([
+      {
+        value: 'openai/gpt-5-mini',
+        label: 'GPT-5 Mini (via OpenRouter)',
+        description: 'Recommended · Provider: OpenRouter',
+        descriptionForModel:
+          'Recommended · Provider: OpenRouter (openai/gpt-5-mini)',
+      },
+      {
+        value: 'openai/gpt-oss-120b:free',
+        label: 'openai/gpt-oss-120b:free',
+        description: 'Provider: OpenRouter',
+        descriptionForModel: 'Provider: OpenRouter',
+      },
+      {
+        value: 'openai/gpt-5',
+        label: 'openai/gpt-5',
+        description: 'Provider: OpenRouter',
+        descriptionForModel: 'Provider: OpenRouter',
+      },
+      {
+        value: 'custom/private-model',
+        label: 'custom/private-model',
+        description: 'Provider: OpenRouter',
+      },
+    ])
+  } finally {
+    rendered.instance.unmount()
+    rendered.stdout.end()
+  }
+})
+
+test('/model applies profile surface to legacy local OpenAI-compatible profiles', async () => {
+  useSettings({
+    providerProfileModelPickerMode: 'profile',
+  } as SettingsJson & {
+    providerProfileModelPickerMode: ProviderProfileModelPickerModeForTest
+  })
+  const activeProfile = {
+    id: 'custom-local-profile',
+    name: 'Custom Local',
+    provider: 'custom',
+    baseUrl: 'http://localhost:7777/v1',
+    model: 'local-model-a, local-model-b',
+    apiKey: '',
+  }
+  process.env.CLAUDE_CODE_USE_OPENAI = '1'
+  process.env.OPENAI_BASE_URL = activeProfile.baseUrl
+  delete process.env.OPENAI_API_KEY
+  delete process.env.OPENROUTER_API_KEY
+  process.env.OPENAI_MODEL = 'local-model-a'
+  process.env.CLAUDE_CODE_PROVIDER_PROFILE_ENV_APPLIED = '1'
+  process.env.CLAUDE_CODE_PROVIDER_PROFILE_ENV_APPLIED_ID = activeProfile.id
+  delete process.env.CLAUDE_CODE_USE_GEMINI
+  delete process.env.CLAUDE_CODE_USE_GITHUB
+  delete process.env.CLAUDE_CODE_USE_MISTRAL
+  delete process.env.CLAUDE_CODE_USE_BEDROCK
+  delete process.env.CLAUDE_CODE_USE_VERTEX
+  delete process.env.CLAUDE_CODE_USE_FOUNDRY
+  delete process.env.OPENAI_API_BASE
+
+  expect(getAdditionalModelOptionsCacheScope()?.startsWith('openai:')).toBe(
+    true,
+  )
+  await mockScopedLocalOpenAIModelCache([
+    {
+      value: 'local-model-a',
+      label: 'Local Model A',
+      description: 'Discovered from API',
+    },
+    {
+      value: 'local-model-c',
+      label: 'Local Model C',
+      description: 'Discovered from API',
+    },
+  ])
+  mockProviderProfiles({
+    getActiveOpenAIModelOptionsCache: () => [
+      {
+        value: 'local-model-a',
+        label: 'Local Model A',
+        description: 'Discovered from API',
+      },
+      {
+        value: 'local-model-c',
+        label: 'Local Model C',
+        description: 'Discovered from API',
+      },
+    ],
+    getActiveProviderProfile: () => activeProfile,
+  })
+
+  const rendered = await renderModelCommandWithCapturedPicker(
+    'legacy-openai-profile-mode',
+  )
+  try {
+    expect(rendered.getCapturedProps().optionsOverride).toEqual([
+      {
+        value: 'local-model-a',
+        label: 'Local Model A',
+        description: 'Discovered from API',
+      },
+      {
+        value: 'local-model-b',
+        label: 'local-model-b',
+        description: 'Provider: Custom Local',
+      },
+    ])
+  } finally {
+    rendered.instance.unmount()
+    rendered.stdout.end()
+  }
+})
+
+test('/model legacy local OpenAI route ignores inactive saved profile cache', async () => {
+  const savedProfile = {
+    id: 'saved-local-profile',
+    name: 'Saved Local',
+    provider: 'custom',
+    baseUrl: 'http://localhost:7777/v1',
+    model: 'saved-profile-model',
+    apiKey: '',
+  }
+  process.env.CLAUDE_CODE_USE_OPENAI = '1'
+  process.env.OPENAI_BASE_URL = 'http://localhost:7777/v1'
+  delete process.env.OPENAI_API_KEY
+  delete process.env.OPENROUTER_API_KEY
+  process.env.OPENAI_MODEL = 'route-model'
+  delete process.env.CLAUDE_CODE_PROVIDER_PROFILE_ENV_APPLIED
+  delete process.env.CLAUDE_CODE_PROVIDER_PROFILE_ENV_APPLIED_ID
+  delete process.env.CLAUDE_CODE_USE_GEMINI
+  delete process.env.CLAUDE_CODE_USE_GITHUB
+  delete process.env.CLAUDE_CODE_USE_MISTRAL
+  delete process.env.CLAUDE_CODE_USE_BEDROCK
+  delete process.env.CLAUDE_CODE_USE_VERTEX
+  delete process.env.CLAUDE_CODE_USE_FOUNDRY
+  delete process.env.OPENAI_API_BASE
+
+  expect(getAdditionalModelOptionsCacheScope()?.startsWith('openai:')).toBe(
+    true,
+  )
+  await mockScopedLocalOpenAIModelCache([
+    {
+      value: 'route-model',
+      label: 'Route Model',
+      description: 'Detected from route',
+    },
+  ])
+  mockProviderProfiles({
+    getActiveOpenAIModelOptionsCache: () => [
+      {
+        value: 'saved-profile-model',
+        label: 'Saved Profile Model',
+        description: 'Provider: Saved Local',
+      },
+    ],
+    getActiveProviderProfile: () => savedProfile,
+  })
+
+  const rendered = await renderModelCommandWithCapturedPicker(
+    'legacy-openai-inactive-profile-cache',
+  )
+  try {
+    expect(rendered.getCapturedProps().optionsOverride).toEqual([
+      expect.objectContaining({
+        value: null,
+        label: 'Default (recommended)',
+      }),
+      {
+        value: 'route-model',
+        label: 'Route Model',
+        description: 'Detected from route',
+      },
+    ])
+  } finally {
+    rendered.instance.unmount()
+    rendered.stdout.end()
+  }
+})
+
+test('/model legacy local OpenAI route filters scoped cache by availableModels', async () => {
+  useSettings({ availableModels: ['allowed-route'] } as SettingsJson)
+  process.env.CLAUDE_CODE_USE_OPENAI = '1'
+  process.env.OPENAI_BASE_URL = 'http://localhost:7777/v1'
+  delete process.env.OPENAI_API_KEY
+  delete process.env.OPENROUTER_API_KEY
+  process.env.OPENAI_MODEL = 'allowed-route'
+  delete process.env.CLAUDE_CODE_PROVIDER_PROFILE_ENV_APPLIED
+  delete process.env.CLAUDE_CODE_PROVIDER_PROFILE_ENV_APPLIED_ID
+  delete process.env.CLAUDE_CODE_USE_GEMINI
+  delete process.env.CLAUDE_CODE_USE_GITHUB
+  delete process.env.CLAUDE_CODE_USE_MISTRAL
+  delete process.env.CLAUDE_CODE_USE_BEDROCK
+  delete process.env.CLAUDE_CODE_USE_VERTEX
+  delete process.env.CLAUDE_CODE_USE_FOUNDRY
+  delete process.env.OPENAI_API_BASE
+
+  await mockScopedLocalOpenAIModelCache([
+    {
+      value: 'allowed-route',
+      label: 'Allowed Route',
+      description: 'Detected from route',
+    },
+    {
+      value: 'blocked-route',
+      label: 'Blocked Route',
+      description: 'Detected from route',
+    },
+  ])
+  mockProviderProfiles()
+
+  const rendered = await renderModelCommandWithCapturedPicker(
+    'legacy-openai-allowlist-initial',
+  )
+  try {
+    expect(rendered.getCapturedProps().optionsOverride).toEqual([
+      expect.objectContaining({
+        value: null,
+        label: 'Default (recommended)',
+      }),
+      {
+        value: 'allowed-route',
+        label: 'Allowed Route',
+        description: 'Detected from route',
+      },
+    ])
+  } finally {
+    rendered.instance.unmount()
+    rendered.stdout.end()
+  }
+})
+
+test('/model legacy local OpenAI refresh does not write inactive profile cache', async () => {
+  const savedProfile = {
+    id: 'saved-local-profile',
+    name: 'Saved Local',
+    provider: 'custom',
+    baseUrl: 'http://localhost:7777/v1',
+    model: 'saved-profile-model',
+    apiKey: '',
+  }
+  process.env.CLAUDE_CODE_USE_OPENAI = '1'
+  process.env.OPENAI_BASE_URL = 'http://localhost:7777/v1'
+  delete process.env.OPENAI_API_KEY
+  delete process.env.OPENROUTER_API_KEY
+  process.env.OPENAI_MODEL = 'route-model'
+  delete process.env.CLAUDE_CODE_PROVIDER_PROFILE_ENV_APPLIED
+  delete process.env.CLAUDE_CODE_PROVIDER_PROFILE_ENV_APPLIED_ID
+  delete process.env.CLAUDE_CODE_USE_GEMINI
+  delete process.env.CLAUDE_CODE_USE_GITHUB
+  delete process.env.CLAUDE_CODE_USE_MISTRAL
+  delete process.env.CLAUDE_CODE_USE_BEDROCK
+  delete process.env.CLAUDE_CODE_USE_VERTEX
+  delete process.env.CLAUDE_CODE_USE_FOUNDRY
+  delete process.env.OPENAI_API_BASE
+
+  const scopedCache = await mockScopedLocalOpenAIModelCache([
+    {
+      value: 'route-model',
+      label: 'Route Model',
+      description: 'Detected from route',
+    },
+  ])
+  const setActiveOpenAIModelOptionsCache = mock(() => {
+    throw new Error('inactive profile cache must not be written')
+  })
+  mockProviderProfiles({
+    getActiveOpenAIModelOptionsCache: () => [
+      {
+        value: 'saved-profile-model',
+        label: 'Saved Profile Model',
+        description: 'Provider: Saved Local',
+      },
+    ],
+    getActiveProviderProfile: () => savedProfile,
+    setActiveOpenAIModelOptionsCache,
+  })
+  mock.module('../../utils/model/openaiModelDiscovery.js', () => ({
+    discoverOpenAICompatibleModelOptions: mock(async () => [
+      {
+        value: 'route-model',
+        label: 'Route Model',
+        description: 'Detected from route',
+      },
+      {
+        value: 'route-model-b',
+        label: 'Route Model B',
+        description: 'Detected from route',
+      },
+    ]),
+  }))
+
+  const rendered = await renderModelCommandWithCapturedPicker(
+    'legacy-openai-inactive-profile-refresh',
+  )
+  try {
+    rendered.getCapturedProps().onRefresh?.()
+    await waitForCondition(
+      () =>
+        rendered.getCapturedProps().discoveryState?.message ===
+        'Updated Local OpenAI-compatible models.',
+    )
+
+    expect(setActiveOpenAIModelOptionsCache).not.toHaveBeenCalled()
+    expect(scopedCache.getState().additionalModelOptionsCache).toEqual([
+      {
+        value: 'route-model',
+        label: 'Route Model',
+        description: 'Detected from route',
+      },
+      {
+        value: 'route-model-b',
+        label: 'Route Model B',
+        description: 'Detected from route',
+      },
+    ])
+    expect(rendered.getCapturedProps().optionsOverride).toEqual([
+      expect.objectContaining({
+        value: null,
+        label: 'Default (recommended)',
+      }),
+      {
+        value: 'route-model',
+        label: 'Route Model',
+        description: 'Detected from route',
+      },
+      {
+        value: 'route-model-b',
+        label: 'Route Model B',
+        description: 'Detected from route',
+      },
+    ])
+  } finally {
+    rendered.instance.unmount()
+    rendered.stdout.end()
+  }
+})
+
+test('/model legacy local OpenAI refresh compares allowlist-filtered options', async () => {
+  useSettings({ availableModels: ['allowed-route'] } as SettingsJson)
+  process.env.CLAUDE_CODE_USE_OPENAI = '1'
+  process.env.OPENAI_BASE_URL = 'http://localhost:7777/v1'
+  delete process.env.OPENAI_API_KEY
+  delete process.env.OPENROUTER_API_KEY
+  process.env.OPENAI_MODEL = 'allowed-route'
+  delete process.env.CLAUDE_CODE_PROVIDER_PROFILE_ENV_APPLIED
+  delete process.env.CLAUDE_CODE_PROVIDER_PROFILE_ENV_APPLIED_ID
+  delete process.env.CLAUDE_CODE_USE_GEMINI
+  delete process.env.CLAUDE_CODE_USE_GITHUB
+  delete process.env.CLAUDE_CODE_USE_MISTRAL
+  delete process.env.CLAUDE_CODE_USE_BEDROCK
+  delete process.env.CLAUDE_CODE_USE_VERTEX
+  delete process.env.CLAUDE_CODE_USE_FOUNDRY
+  delete process.env.OPENAI_API_BASE
+
+  const scopedCache = await mockScopedLocalOpenAIModelCache([
+    {
+      value: 'allowed-route',
+      label: 'Allowed Route',
+      description: 'Detected from route',
+    },
+  ])
+  mockProviderProfiles()
+  mock.module('../../utils/model/openaiModelDiscovery.js', () => ({
+    discoverOpenAICompatibleModelOptions: mock(async () => [
+      {
+        value: 'allowed-route',
+        label: 'Allowed Route',
+        description: 'Detected from route',
+      },
+      {
+        value: 'blocked-route',
+        label: 'Blocked Route',
+        description: 'Detected from route',
+      },
+    ]),
+  }))
+
+  const rendered = await renderModelCommandWithCapturedPicker(
+    'legacy-openai-allowlist-refresh',
+  )
+  try {
+    rendered.getCapturedProps().onRefresh?.()
+    await waitForCondition(
+      () =>
+        rendered.getCapturedProps().discoveryState?.message ===
+        'No changes found for Local OpenAI-compatible.',
+    )
+
+    expect(scopedCache.getState().additionalModelOptionsCache).toEqual([
+      {
+        value: 'allowed-route',
+        label: 'Allowed Route',
+        description: 'Detected from route',
+      },
+      {
+        value: 'blocked-route',
+        label: 'Blocked Route',
+        description: 'Detected from route',
+      },
+    ])
+    expect(rendered.getCapturedProps().optionsOverride).toEqual([
+      expect.objectContaining({
+        value: null,
+        label: 'Default (recommended)',
+      }),
+      {
+        value: 'allowed-route',
+        label: 'Allowed Route',
+        description: 'Detected from route',
+      },
+    ])
+  } finally {
+    rendered.instance.unmount()
+    rendered.stdout.end()
+  }
+})
+
+test('/model legacy provider mode keeps raw local cache before profile-only models', async () => {
+  useSettings({
+    providerProfileModelPickerMode: 'provider',
+  } as SettingsJson & {
+    providerProfileModelPickerMode: ProviderProfileModelPickerModeForTest
+  })
+  const activeProfile = {
+    id: 'custom-local-profile',
+    name: 'Custom Local',
+    provider: 'custom',
+    baseUrl: 'http://localhost:7777/v1',
+    model: 'profile-only-model, route-model',
+    apiKey: '',
+  }
+  process.env.CLAUDE_CODE_USE_OPENAI = '1'
+  process.env.OPENAI_BASE_URL = activeProfile.baseUrl
+  delete process.env.OPENAI_API_KEY
+  delete process.env.OPENROUTER_API_KEY
+  process.env.OPENAI_MODEL = 'route-model'
+  process.env.CLAUDE_CODE_PROVIDER_PROFILE_ENV_APPLIED = '1'
+  process.env.CLAUDE_CODE_PROVIDER_PROFILE_ENV_APPLIED_ID = activeProfile.id
+  delete process.env.CLAUDE_CODE_USE_GEMINI
+  delete process.env.CLAUDE_CODE_USE_GITHUB
+  delete process.env.CLAUDE_CODE_USE_MISTRAL
+  delete process.env.CLAUDE_CODE_USE_BEDROCK
+  delete process.env.CLAUDE_CODE_USE_VERTEX
+  delete process.env.CLAUDE_CODE_USE_FOUNDRY
+  delete process.env.OPENAI_API_BASE
+
+  await mockScopedLocalOpenAIModelCache([
+    {
+      value: 'route-model',
+      label: 'Route Model',
+      description: 'Detected from route',
+    },
+    {
+      value: 'route-model-b',
+      label: 'Route Model B',
+      description: 'Detected from route',
+    },
+  ])
+  mockProviderProfiles({
+    getActiveOpenAIModelOptionsCache: () => [
+      {
+        value: 'profile-only-model',
+        label: 'profile-only-model',
+        description: 'Provider: Custom Local',
+      },
+      {
+        value: 'route-model',
+        label: 'Route Model',
+        description: 'Detected from route',
+      },
+      {
+        value: 'route-model-b',
+        label: 'Route Model B',
+        description: 'Detected from route',
+      },
+    ],
+    getActiveProviderProfile: () => activeProfile,
+  })
+
+  const rendered = await renderModelCommandWithCapturedPicker(
+    'legacy-openai-provider-mode-raw-cache',
+  )
+  try {
+    expect(rendered.getCapturedProps().optionsOverride).toEqual([
+      {
+        value: 'route-model',
+        label: 'Route Model',
+        description: 'Detected from route',
+      },
+      {
+        value: 'route-model-b',
+        label: 'Route Model B',
+        description: 'Detected from route',
+      },
+      {
+        value: 'profile-only-model',
+        label: 'profile-only-model',
+        description: 'Provider: Custom Local',
+      },
+    ])
+  } finally {
+    rendered.instance.unmount()
+    rendered.stdout.end()
+  }
+})
+
+test('descriptor model options filter route and profile-only entries by availableModels', async () => {
+  useSettings({ availableModels: ['allowed-route'] } as SettingsJson)
+  const activeProfile = {
+    id: 'openrouter-profile',
+    name: 'OpenRouter',
+    provider: 'openrouter',
+    baseUrl: 'https://openrouter.ai/api/v1',
+    model: 'blocked-profile-only',
+    apiKey: 'sk-openrouter',
+  }
+  process.env.CLAUDE_CODE_PROVIDER_PROFILE_ENV_APPLIED = '1'
+  process.env.CLAUDE_CODE_PROVIDER_PROFILE_ENV_APPLIED_ID = activeProfile.id
+
+  mockProviderProfiles({
+    getActiveProviderProfile: () => activeProfile,
+    getProfileModelOptions: () =>
+      getConfiguredProfileModelOptionsForTest(activeProfile),
+  })
+
+  const { mergeActiveProfileModelOptions } = await importFreshModelModule(
+    'descriptor-profile-model-allowlist',
+  )
+
+  expect(
+    mergeActiveProfileModelOptions(
+      'openrouter',
+      [
+        {
+          value: 'allowed-route',
+          label: 'Allowed Route',
+          description: 'Provider: OpenRouter',
+        },
+        {
+          value: 'blocked-route',
+          label: 'Blocked Route',
+          description: 'Provider: OpenRouter',
+        },
+      ],
+      { profileModelSurface: 'provider' },
+    ),
+  ).toEqual([
+    {
+      value: 'allowed-route',
+      label: 'Allowed Route',
       description: 'Provider: OpenRouter',
     },
   ])
@@ -470,6 +1867,86 @@ test('descriptor model options skip saved profile models for env-selected routes
 
   const { mergeActiveProfileModelOptions } =
     await importFreshModelModule('descriptor-profile-model-env-skip')
+
+  expect(
+    mergeActiveProfileModelOptions(
+      'openrouter',
+      [
+        {
+          value: 'openai/gpt-5-mini',
+          label: 'GPT-5 Mini',
+          description: 'Provider: OpenRouter',
+        },
+      ],
+    ),
+  ).toEqual([
+    {
+      value: 'openai/gpt-5-mini',
+      label: 'GPT-5 Mini',
+      description: 'Provider: OpenRouter',
+    },
+  ])
+})
+
+test('descriptor model options ignore active profile when applied profile id does not match', async () => {
+  const activeProfile = {
+    id: 'mistral-profile',
+    name: 'Mistral AI',
+    provider: 'mistral',
+    baseUrl: 'https://api.mistral.ai/v1',
+    model: 'mistral-medium-latest',
+    apiKey: 'sk-mistral',
+  }
+  process.env.CLAUDE_CODE_PROVIDER_PROFILE_ENV_APPLIED = '1'
+  process.env.CLAUDE_CODE_PROVIDER_PROFILE_ENV_APPLIED_ID = 'other-profile'
+
+  mockProviderProfiles({
+    getActiveProviderProfile: () => activeProfile,
+  })
+
+  const { mergeActiveProfileModelOptions } = await importFreshModelModule(
+    'descriptor-profile-model-id-mismatch',
+  )
+
+  expect(
+    mergeActiveProfileModelOptions(
+      'mistral',
+      [
+        {
+          value: 'devstral-latest',
+          label: 'Devstral Latest',
+          description: 'Recommended · Provider: Mistral AI',
+        },
+      ],
+    ),
+  ).toEqual([
+    {
+      value: 'devstral-latest',
+      label: 'Devstral Latest',
+      description: 'Recommended · Provider: Mistral AI',
+    },
+  ])
+})
+
+test('descriptor model options ignore active profile when route does not match', async () => {
+  const activeProfile = {
+    id: 'mistral-profile',
+    name: 'Mistral AI',
+    provider: 'mistral',
+    baseUrl: 'https://api.mistral.ai/v1',
+    model: 'mistral-medium-latest',
+    apiKey: 'sk-mistral',
+  }
+  process.env.CLAUDE_CODE_PROVIDER_PROFILE_ENV_APPLIED = '1'
+  process.env.CLAUDE_CODE_PROVIDER_PROFILE_ENV_APPLIED_ID = activeProfile.id
+
+  mockProviderProfiles({
+    getActiveProviderProfile: () => activeProfile,
+  })
+
+  const { mergeActiveProfileModelOptions } = await importFreshModelModule(
+    'descriptor-profile-model-route-mismatch',
+  )
 
   expect(
     mergeActiveProfileModelOptions(
@@ -545,7 +2022,7 @@ test('/model refresh clears descriptor cache and reports updates', async () => {
 
   mockProviderProfiles({
     getActiveOpenAIModelOptionsCache: () => [],
-    getActiveProviderProfile: () => null,
+    getActiveProviderProfile: () => undefined,
     getProfileModelOptions: () => [],
     setActiveOpenAIModelOptionsCache: () => {},
   })
@@ -658,6 +2135,210 @@ test('/model refresh reports discovered model changes for dynamic active profile
   expect(messages).toContain('Updated LM Studio models.')
 })
 
+test('/model refresh compares already allowlist-filtered descriptor options', async () => {
+  useSettings({ availableModels: ['local-model-a'] } as SettingsJson)
+  process.env.CLAUDE_CODE_USE_OPENAI = '1'
+  process.env.OPENAI_BASE_URL = 'http://localhost:1234/v1'
+  delete process.env.OPENAI_API_KEY
+  delete process.env.OPENROUTER_API_KEY
+  process.env.OPENAI_MODEL = 'local-model-a'
+  delete process.env.CLAUDE_CODE_USE_GEMINI
+  delete process.env.CLAUDE_CODE_USE_GITHUB
+  delete process.env.CLAUDE_CODE_USE_MISTRAL
+  delete process.env.CLAUDE_CODE_USE_BEDROCK
+  delete process.env.CLAUDE_CODE_USE_VERTEX
+  delete process.env.CLAUDE_CODE_USE_FOUNDRY
+  delete process.env.OPENAI_API_BASE
+
+  mock.module('../../integrations/discoveryCache.js', () => ({
+    clearDiscoveryCache: mock(async () => {}),
+    getCachedModels: mock(async () => ({
+      models: [{ id: 'local-model-a', apiName: 'local-model-a' }],
+      updatedAt: Date.now(),
+      error: null,
+    })),
+    isCacheStale: mock(async () => false),
+    parseDurationString: (value: number | string) =>
+      typeof value === 'number' ? value : 86_400_000,
+  }))
+
+  mock.module('../../integrations/discoveryService.js', () => ({
+    getDiscoveryCacheKey: (
+      routeId: string,
+      options?: { apiKey?: string; baseUrl?: string; headers?: Record<string, string> },
+    ) => `${routeId}|${options?.baseUrl ?? ''}|${options?.apiKey ?? ''}|${JSON.stringify(options?.headers ?? {})}`,
+    discoverModelsForRoute: mock(async () => ({
+      routeId: 'lmstudio',
+      models: [
+        { id: 'local-model-a', apiName: 'local-model-a' },
+        { id: 'blocked-model', apiName: 'blocked-model' },
+      ],
+      stale: false,
+      error: null,
+      source: 'network',
+    })),
+    probeRouteReadiness: mock(async () => null),
+  }))
+
+  mockProviderProfiles()
+
+  const messages: string[] = []
+  const { call } = await importFreshModelModule(
+    'descriptor-refresh-allowlist-summary',
+  )
+  await call(
+    (message?: string) => {
+      if (message) {
+        messages.push(message)
+      }
+    },
+    {} as never,
+    'refresh',
+  )
+
+  expect(messages).toContain('No changes found for LM Studio.')
+})
+
+test('interactive model picker refresh keeps descriptor options allowlist-filtered', async () => {
+  useSettings({ availableModels: ['allowed-route'] } as SettingsJson)
+  const activeProfile = {
+    id: 'openrouter-profile',
+    name: 'OpenRouter',
+    provider: 'openrouter',
+    baseUrl: 'https://openrouter.ai/api/v1',
+    model: 'blocked-profile-only',
+    apiKey: 'sk-openrouter',
+  }
+  process.env.CLAUDE_CODE_USE_OPENAI = '1'
+  process.env.OPENAI_BASE_URL = activeProfile.baseUrl
+  process.env.OPENAI_API_KEY = activeProfile.apiKey
+  delete process.env.OPENROUTER_API_KEY
+  process.env.OPENAI_MODEL = 'allowed-route'
+  process.env.CLAUDE_CODE_PROVIDER_PROFILE_ENV_APPLIED = '1'
+  process.env.CLAUDE_CODE_PROVIDER_PROFILE_ENV_APPLIED_ID = activeProfile.id
+  delete process.env.CLAUDE_CODE_USE_GEMINI
+  delete process.env.CLAUDE_CODE_USE_GITHUB
+  delete process.env.CLAUDE_CODE_USE_MISTRAL
+  delete process.env.CLAUDE_CODE_USE_BEDROCK
+  delete process.env.CLAUDE_CODE_USE_VERTEX
+  delete process.env.CLAUDE_CODE_USE_FOUNDRY
+  delete process.env.OPENAI_API_BASE
+
+  mockDescriptorDiscovery({
+    cachedModels: [{ id: 'allowed', apiName: 'allowed-route' }],
+    discoveredModels: [
+      { id: 'allowed', apiName: 'allowed-route' },
+      { id: 'blocked', apiName: 'blocked-route' },
+    ],
+  })
+  mockProviderProfiles({
+    getActiveProviderProfile: () => activeProfile,
+  })
+
+  const rendered = await renderModelCommandWithCapturedPicker(
+    'descriptor-picker-refresh-allowlist',
+  )
+  try {
+    expect(rendered.getCapturedProps().optionsOverride).toEqual([
+      {
+        value: 'allowed-route',
+        label: 'allowed-route',
+        description: 'Provider: OpenRouter',
+        descriptionForModel: 'Provider: OpenRouter',
+      },
+    ])
+
+    rendered.getCapturedProps().onRefresh?.()
+    await waitForCondition(
+      () =>
+        rendered.getCapturedProps().discoveryState?.message ===
+        'No changes found for OpenRouter.',
+    )
+
+    expect(rendered.getCapturedProps().optionsOverride).toEqual([
+      {
+        value: 'allowed-route',
+        label: 'allowed-route',
+        description: 'Provider: OpenRouter',
+        descriptionForModel: 'Provider: OpenRouter',
+      },
+    ])
+  } finally {
+    rendered.instance.unmount()
+    rendered.stdout.end()
+  }
+})
+
+test('interactive model picker rejects models blocked by availableModels before updating state', async () => {
+  useSettings({ availableModels: ['allowed-model'] } as SettingsJson)
+
+  mockProviderProfiles()
+  mock.module('../../components/ModelPicker.js', () => ({
+    ModelPicker: function MockModelPicker(props: {
+      onSelect: (model: string | null, effort: undefined) => void
+    }): React.ReactNode {
+      React.useEffect(() => {
+        props.onSelect('blocked-model', undefined)
+      }, [props])
+      return null
+    },
+  }))
+
+  const messages: Array<{
+    message?: string
+    options?: { display?: string }
+  }> = []
+  const { call } = await importFreshModelModule(
+    'descriptor-interactive-allowlist-guard',
+  )
+  const element = await call(
+    (message, options) => {
+      messages.push({ message, options })
+    },
+    {} as never,
+    '',
+  )
+  const { AppStateProvider, getDefaultAppState } = await import(
+    '../../state/AppState.js'
+  )
+  const { render } = await import('../../ink.js')
+
+  const stdout = new PassThrough()
+  ;(stdout as unknown as { columns: number }).columns = 120
+  const initialState = {
+    ...getDefaultAppState(),
+    mainLoopModel: 'allowed-model',
+  }
+  let latestMainLoopModel = initialState.mainLoopModel
+  const instance = await render(
+    <AppStateProvider
+      initialState={initialState}
+      onChangeAppState={({ newState }) => {
+        latestMainLoopModel = newState.mainLoopModel
+      }}
+    >
+      {element}
+    </AppStateProvider>,
+    stdout as unknown as NodeJS.WriteStream,
+  )
+
+  try {
+    await waitForCondition(() => messages.length > 0)
+  } finally {
+    instance.unmount()
+    stdout.end()
+  }
+
+  expect(messages).toEqual([
+    {
+      message:
+        "Model 'blocked-model' is not available. Your organization restricts model selection.",
+      options: { display: 'system' },
+    },
+  ])
+  expect(latestMainLoopModel).toBe('allowed-model')
+})
+
 test('/model does not auto-refresh descriptor models when nonessential traffic is disabled', async () => {
   process.env.CLAUDE_CODE_USE_OPENAI = '1'
   process.env.OPENAI_BASE_URL = 'https://openrouter.ai/api/v1'
@@ -695,7 +2376,7 @@ test('/model does not auto-refresh descriptor models when nonessential traffic i
 
   mockProviderProfiles({
     getActiveOpenAIModelOptionsCache: () => [],
-    getActiveProviderProfile: () => null,
+    getActiveProviderProfile: () => undefined,
     getProfileModelOptions: () => [],
     setActiveOpenAIModelOptionsCache: () => {},
   })

--- a/src/commands/model/model.test.tsx
+++ b/src/commands/model/model.test.tsx
@@ -1742,6 +1742,188 @@ test('/model legacy local OpenAI refresh compares allowlist-filtered options', a
   }
 })
 
+test('/model legacy local OpenAI refresh preserves cached options when discovery finds no models', async () => {
+  process.env.CLAUDE_CODE_USE_OPENAI = '1'
+  process.env.OPENAI_BASE_URL = 'http://localhost:7777/v1'
+  delete process.env.OPENAI_API_KEY
+  delete process.env.OPENROUTER_API_KEY
+  process.env.OPENAI_MODEL = 'route-model'
+  delete process.env.CLAUDE_CODE_PROVIDER_PROFILE_ENV_APPLIED
+  delete process.env.CLAUDE_CODE_PROVIDER_PROFILE_ENV_APPLIED_ID
+  delete process.env.CLAUDE_CODE_USE_GEMINI
+  delete process.env.CLAUDE_CODE_USE_GITHUB
+  delete process.env.CLAUDE_CODE_USE_MISTRAL
+  delete process.env.CLAUDE_CODE_USE_BEDROCK
+  delete process.env.CLAUDE_CODE_USE_VERTEX
+  delete process.env.CLAUDE_CODE_USE_FOUNDRY
+  delete process.env.OPENAI_API_BASE
+
+  const cachedOptions = [
+    {
+      value: 'route-model',
+      label: 'Route Model',
+      description: 'Detected from route',
+    },
+    {
+      value: 'route-model-b',
+      label: 'Route Model B',
+      description: 'Detected from route',
+    },
+  ]
+  const scopedCache = await mockScopedLocalOpenAIModelCache(cachedOptions)
+  mockProviderProfiles()
+  mock.module('../../utils/model/openaiModelDiscovery.js', () => ({
+    discoverOpenAICompatibleModelOptions: mock(async () => []),
+  }))
+
+  const rendered = await renderModelCommandWithCapturedPicker(
+    'legacy-openai-empty-refresh',
+  )
+  try {
+    const expectedPickerOptions = [
+      expect.objectContaining({
+        value: null,
+        label: 'Default (recommended)',
+      }),
+      ...cachedOptions,
+    ]
+    expect(rendered.getCapturedProps().optionsOverride).toEqual(
+      expectedPickerOptions,
+    )
+
+    rendered.getCapturedProps().onRefresh?.()
+    await waitForCondition(() => {
+      const message = rendered.getCapturedProps().discoveryState?.message
+      return (
+        message !== undefined &&
+        message !== 'Refreshing Local OpenAI-compatible models…'
+      )
+    })
+
+    expect(rendered.getCapturedProps().discoveryState).toEqual({
+      message: 'Could not refresh Local OpenAI-compatible models.',
+      tone: 'warning',
+    })
+    expect(scopedCache.getState().additionalModelOptionsCache).toEqual(
+      cachedOptions,
+    )
+    expect(rendered.getCapturedProps().optionsOverride).toEqual(
+      expectedPickerOptions,
+    )
+  } finally {
+    rendered.instance.unmount()
+    rendered.stdout.end()
+  }
+})
+
+test('/model legacy local OpenAI refresh preserves cached provider options for active profiles when discovery finds no models', async () => {
+  useSettings({
+    providerProfileModelPickerMode: 'provider',
+  } as SettingsJson & {
+    providerProfileModelPickerMode: ProviderProfileModelPickerModeForTest
+  })
+  const activeProfile = {
+    id: 'custom-local-profile',
+    name: 'Custom Local',
+    provider: 'custom',
+    baseUrl: 'http://localhost:7777/v1',
+    model: 'profile-only-model, route-model',
+    apiKey: '',
+  }
+  process.env.CLAUDE_CODE_USE_OPENAI = '1'
+  process.env.OPENAI_BASE_URL = activeProfile.baseUrl
+  delete process.env.OPENAI_API_KEY
+  delete process.env.OPENROUTER_API_KEY
+  process.env.OPENAI_MODEL = 'route-model'
+  process.env.CLAUDE_CODE_PROVIDER_PROFILE_ENV_APPLIED = '1'
+  process.env.CLAUDE_CODE_PROVIDER_PROFILE_ENV_APPLIED_ID = activeProfile.id
+  delete process.env.CLAUDE_CODE_USE_GEMINI
+  delete process.env.CLAUDE_CODE_USE_GITHUB
+  delete process.env.CLAUDE_CODE_USE_MISTRAL
+  delete process.env.CLAUDE_CODE_USE_BEDROCK
+  delete process.env.CLAUDE_CODE_USE_VERTEX
+  delete process.env.CLAUDE_CODE_USE_FOUNDRY
+  delete process.env.OPENAI_API_BASE
+
+  const cachedOptions = [
+    {
+      value: 'route-model',
+      label: 'Route Model',
+      description: 'Detected from route',
+    },
+    {
+      value: 'route-model-b',
+      label: 'Route Model B',
+      description: 'Detected from route',
+    },
+  ]
+  const scopedCache = await mockScopedLocalOpenAIModelCache(cachedOptions)
+  mockProviderProfiles({
+    getActiveOpenAIModelOptionsCache: () => [
+      {
+        value: 'profile-only-model',
+        label: 'profile-only-model',
+        description: 'Provider: Custom Local',
+      },
+      ...cachedOptions,
+    ],
+    getActiveProviderProfile: () => activeProfile,
+  })
+  const discoverOpenAICompatibleModelOptions = mock(async () => [])
+  mock.module('../../utils/model/openaiModelDiscovery.js', () => ({
+    discoverOpenAICompatibleModelOptions,
+  }))
+
+  const rendered = await renderModelCommandWithCapturedPicker(
+    'legacy-openai-active-profile-empty-refresh',
+  )
+  try {
+    const expectedPickerOptions = [
+      ...cachedOptions,
+      {
+        value: 'profile-only-model',
+        label: 'profile-only-model',
+        description: 'Provider: Custom Local',
+      },
+    ]
+    expect(rendered.getCapturedProps().optionsOverride).toEqual(
+      expectedPickerOptions,
+    )
+
+    await waitForCondition(
+      () =>
+        discoverOpenAICompatibleModelOptions.mock.calls.length >= 1 &&
+        rendered.getCapturedProps().discoveryState?.message ===
+          'Could not refresh Local OpenAI-compatible models.',
+    )
+    expect(rendered.getCapturedProps().optionsOverride).toEqual(
+      expectedPickerOptions,
+    )
+
+    rendered.getCapturedProps().onRefresh?.()
+    await waitForCondition(
+      () =>
+        discoverOpenAICompatibleModelOptions.mock.calls.length >= 2 &&
+        rendered.getCapturedProps().discoveryState?.message ===
+          'Could not refresh Local OpenAI-compatible models.',
+    )
+
+    expect(rendered.getCapturedProps().discoveryState).toEqual({
+      message: 'Could not refresh Local OpenAI-compatible models.',
+      tone: 'warning',
+    })
+    expect(scopedCache.getState().additionalModelOptionsCache).toEqual(
+      cachedOptions,
+    )
+    expect(rendered.getCapturedProps().optionsOverride).toEqual(
+      expectedPickerOptions,
+    )
+  } finally {
+    rendered.instance.unmount()
+    rendered.stdout.end()
+  }
+})
+
 test('/model legacy provider mode keeps raw local cache before profile-only models', async () => {
   useSettings({
     providerProfileModelPickerMode: 'provider',
@@ -2237,6 +2419,57 @@ test('/model refresh compares already allowlist-filtered descriptor options', as
   )
 
   expect(messages).toContain('No changes found for LM Studio.')
+})
+
+test('/model refresh treats empty legacy OpenAI-compatible discovery as failed no-op', async () => {
+  process.env.CLAUDE_CODE_USE_OPENAI = '1'
+  process.env.OPENAI_BASE_URL = 'http://localhost:7777/v1'
+  delete process.env.OPENAI_API_KEY
+  delete process.env.OPENROUTER_API_KEY
+  process.env.OPENAI_MODEL = 'route-model'
+  delete process.env.CLAUDE_CODE_PROVIDER_PROFILE_ENV_APPLIED
+  delete process.env.CLAUDE_CODE_PROVIDER_PROFILE_ENV_APPLIED_ID
+  delete process.env.CLAUDE_CODE_USE_GEMINI
+  delete process.env.CLAUDE_CODE_USE_GITHUB
+  delete process.env.CLAUDE_CODE_USE_MISTRAL
+  delete process.env.CLAUDE_CODE_USE_BEDROCK
+  delete process.env.CLAUDE_CODE_USE_VERTEX
+  delete process.env.CLAUDE_CODE_USE_FOUNDRY
+  delete process.env.OPENAI_API_BASE
+
+  const cachedOptions = [
+    {
+      value: 'route-model',
+      label: 'Route Model',
+      description: 'Detected from route',
+    },
+  ]
+  const scopedCache = await mockScopedLocalOpenAIModelCache(cachedOptions)
+  mockProviderProfiles()
+  mock.module('../../utils/model/openaiModelDiscovery.js', () => ({
+    discoverOpenAICompatibleModelOptions: mock(async () => []),
+  }))
+
+  const messages: string[] = []
+  const { call } = await importFreshModelModule(
+    'legacy-openai-empty-refresh-summary',
+  )
+  await call(
+    (message?: string) => {
+      if (message) {
+        messages.push(message)
+      }
+    },
+    {} as never,
+    'refresh',
+  )
+
+  expect(messages).toContain(
+    'Could not refresh Local OpenAI-compatible models.',
+  )
+  expect(scopedCache.getState().additionalModelOptionsCache).toEqual(
+    cachedOptions,
+  )
 })
 
 test('interactive model picker refresh keeps descriptor options allowlist-filtered', async () => {

--- a/src/commands/model/model.tsx
+++ b/src/commands/model/model.tsx
@@ -74,6 +74,7 @@ type ModelDiscoveryContext =
       autoRefresh: boolean
       canRefresh: boolean
       discoveryState?: ModelPickerDiscoveryState
+      preserveRouteOptions: boolean
       optionsOverride: ModelOption[]
       routeId: string
       routeDefaultModel?: string
@@ -114,6 +115,9 @@ function haveSameModelOptions(left: ModelOption[], right: ModelOption[]): boolea
 export function mergeActiveProfileModelOptions(
   routeId: string,
   routeOptions: ModelOption[],
+  options?: {
+    preserveRouteOptions?: boolean
+  },
 ): ModelOption[] {
   const activeProfile = getActiveProviderProfile()
   if (!activeProfile) {
@@ -155,6 +159,19 @@ export function mergeActiveProfileModelOptions(
 
     seen.add(key)
     merged.push(routeOptionsByValue.get(key) ?? option)
+  }
+
+  if (options?.preserveRouteOptions) {
+    for (const option of routeOptions) {
+      const value = typeof option.value === 'string' ? option.value.trim() : ''
+      const key = value.toLowerCase()
+      if (!value || seen.has(key)) {
+        continue
+      }
+
+      seen.add(key)
+      merged.push(option)
+    }
   }
 
   return merged
@@ -247,6 +264,7 @@ async function loadDescriptorDiscoveryContext(
       kind: 'descriptor',
       autoRefresh: false,
       canRefresh,
+      preserveRouteOptions: false,
       optionsOverride: mergeActiveProfileModelOptions(routeId, routeOptions),
       routeId,
       routeDefaultModel,
@@ -295,7 +313,10 @@ async function loadDescriptorDiscoveryContext(
     autoRefresh,
     canRefresh,
     discoveryState,
-    optionsOverride: mergeActiveProfileModelOptions(routeId, routeOptions),
+    preserveRouteOptions: true,
+    optionsOverride: mergeActiveProfileModelOptions(routeId, routeOptions, {
+      preserveRouteOptions: true,
+    }),
     routeId,
     routeDefaultModel,
     routeLabel,
@@ -524,6 +545,9 @@ function ModelPickerWrapper({
           result?.models ?? [],
           discoveryContext.routeDefaultModel,
         ),
+        {
+          preserveRouteOptions: discoveryContext.preserveRouteOptions,
+        },
       )
       const changed = !haveSameModelOptions(optionsOverride ?? [], nextOptions)
 
@@ -800,6 +824,9 @@ async function refreshModelsAndSummarize(): Promise<string> {
         result?.models ?? [],
         discoveryContext.routeDefaultModel,
       ),
+      {
+        preserveRouteOptions: discoveryContext.preserveRouteOptions,
+      },
     )
     const changed = !haveSameModelOptions(
       discoveryContext.optionsOverride,

--- a/src/commands/model/model.tsx
+++ b/src/commands/model/model.tsx
@@ -32,6 +32,7 @@ import {
   getAdditionalModelOptionsCacheScope,
   resolveProviderRequest,
 } from '../../services/api/providerConfig.js'
+import type { ProviderProfile } from '../../utils/config.js'
 import type { AppState } from '../../state/AppState.js'
 import { useAppState, useSetAppState } from '../../state/AppState.js'
 import type { LocalJSXCommandCall } from '../../types/command.js'
@@ -48,7 +49,10 @@ import {
   checkOpus1mAccess,
   checkSonnet1mAccess,
 } from '../../utils/model/check1mAccess.js'
-import type { ModelOption } from '../../utils/model/modelOptions.js'
+import {
+  getDefaultOptionForUser,
+  type ModelOption,
+} from '../../utils/model/modelOptions.js'
 import { buildRouteCatalogModelOptions, mergeRouteCatalogEntries } from '../../utils/model/routeCatalogOptions.js'
 import { discoverOpenAICompatibleModelOptions } from '../../utils/model/openaiModelDiscovery.js'
 import {
@@ -62,11 +66,17 @@ import { getLocalOpenAICompatibleProviderLabel } from '../../utils/providerDisco
 import { isEssentialTrafficOnly } from '../../utils/privacyLevel.js'
 import { parseCustomHeadersEnv } from '../../utils/providerCustomHeaders.js'
 import {
-  getActiveOpenAIModelOptionsCache,
+  getActiveOpenAIRouteModelOptionsCache,
   getActiveProviderProfile,
-  getProfileModelOptions,
+  getConfiguredProfileModelOptions,
+  setActiveOpenAIRouteModelOptionsCache,
   setActiveOpenAIModelOptionsCache,
 } from '../../utils/providerProfiles.js'
+import { parseModelList } from '../../utils/providerModels.js'
+import { getInitialSettings } from '../../utils/settings/settings.js'
+
+export type ProviderProfileModelPickerMode = 'auto' | 'profile' | 'provider'
+export type ResolvedProviderProfileModelSurface = 'profile' | 'provider'
 
 type ModelDiscoveryContext =
   | {
@@ -74,7 +84,7 @@ type ModelDiscoveryContext =
       autoRefresh: boolean
       canRefresh: boolean
       discoveryState?: ModelPickerDiscoveryState
-      preserveRouteOptions: boolean
+      profileModelSurface: ResolvedProviderProfileModelSurface
       optionsOverride: ModelOption[]
       routeId: string
       routeDefaultModel?: string
@@ -85,6 +95,9 @@ type ModelDiscoveryContext =
       autoRefresh: boolean
       canRefresh: boolean
       discoveryState?: ModelPickerDiscoveryState
+      optionsOverride: ModelOption[]
+      profileModelSurface: ResolvedProviderProfileModelSurface
+      routeId: string
       routeLabel: string
     }
 
@@ -112,48 +125,38 @@ function haveSameModelOptions(left: ModelOption[], right: ModelOption[]): boolea
   })
 }
 
-export function mergeActiveProfileModelOptions(
-  routeId: string,
+function filterModelOptionsByAllowlist(options: ModelOption[]): ModelOption[] {
+  return options.filter(option => {
+    if (option.value === null) {
+      return true
+    }
+    return typeof option.value === 'string'
+      ? isModelAllowed(option.value)
+      : true
+  })
+}
+
+function modelOptionKey(option: ModelOption): string | null {
+  const value = typeof option.value === 'string' ? option.value.trim() : ''
+  return value ? value.toLowerCase() : null
+}
+
+function mergeProfileListFirst(
   routeOptions: ModelOption[],
-  options?: {
-    preserveRouteOptions?: boolean
-  },
+  profileOptions: ModelOption[],
 ): ModelOption[] {
-  const activeProfile = getActiveProviderProfile()
-  if (!activeProfile) {
-    return routeOptions
-  }
-
-  const profileEnvApplied =
-    process.env.CLAUDE_CODE_PROVIDER_PROFILE_ENV_APPLIED === '1' &&
-    process.env.CLAUDE_CODE_PROVIDER_PROFILE_ENV_APPLIED_ID === activeProfile.id
-  const activeProfileRouteId =
-    resolveRouteIdFromBaseUrl(activeProfile.baseUrl) ??
-    resolveProfileRoute(activeProfile.provider).routeId
-
-  if (!profileEnvApplied || activeProfileRouteId !== routeId) {
-    return routeOptions
-  }
-
-  const profileOptions = getProfileModelOptions(activeProfile)
-  if (profileOptions.length === 0) {
-    return routeOptions
-  }
-
   const routeOptionsByValue = new Map(
     routeOptions.flatMap(option => {
-      const value =
-        typeof option.value === 'string' ? option.value.trim().toLowerCase() : ''
-      return value ? [[value, option] as const] : []
+      const key = modelOptionKey(option)
+      return key ? [[key, option] as const] : []
     }),
   )
   const merged: ModelOption[] = []
   const seen = new Set<string>()
 
   for (const option of profileOptions) {
-    const value = typeof option.value === 'string' ? option.value.trim() : ''
-    const key = value.toLowerCase()
-    if (!value || seen.has(key)) {
+    const key = modelOptionKey(option)
+    if (!key || seen.has(key)) {
       continue
     }
 
@@ -161,20 +164,117 @@ export function mergeActiveProfileModelOptions(
     merged.push(routeOptionsByValue.get(key) ?? option)
   }
 
-  if (options?.preserveRouteOptions) {
-    for (const option of routeOptions) {
-      const value = typeof option.value === 'string' ? option.value.trim() : ''
-      const key = value.toLowerCase()
-      if (!value || seen.has(key)) {
+  return merged
+}
+
+function mergeProviderCatalogFirst(
+  routeOptions: ModelOption[],
+  profileOptions: ModelOption[],
+): ModelOption[] {
+  const merged: ModelOption[] = []
+  const seen = new Set<string>()
+
+  for (const option of routeOptions) {
+    const key = modelOptionKey(option)
+    if (key) {
+      if (seen.has(key)) {
         continue
       }
-
       seen.add(key)
-      merged.push(option)
     }
+    merged.push(option)
+  }
+
+  for (const option of profileOptions) {
+    const key = modelOptionKey(option)
+    if (!key || seen.has(key)) {
+      continue
+    }
+
+    seen.add(key)
+    merged.push(option)
   }
 
   return merged
+}
+
+function getProviderProfileModelPickerMode(): ProviderProfileModelPickerMode {
+  const mode = getInitialSettings().providerProfileModelPickerMode
+  return mode === 'profile' || mode === 'provider' || mode === 'auto'
+    ? mode
+    : 'auto'
+}
+
+export function resolveProviderProfileModelSurface(options: {
+  activeProfile?: ProviderProfile | null
+  settingsMode?: ProviderProfileModelPickerMode
+}): ResolvedProviderProfileModelSurface {
+  if (options.settingsMode === 'profile') {
+    return 'profile'
+  }
+  if (options.settingsMode === 'provider') {
+    return 'provider'
+  }
+
+  const explicitProfileModelCount = options.activeProfile
+    ? parseModelList(options.activeProfile.model).length
+    : 0
+
+  return explicitProfileModelCount > 1 ? 'profile' : 'provider'
+}
+
+function getActiveProfileRouteId(activeProfile: ProviderProfile): string {
+  return (
+    resolveRouteIdFromBaseUrl(activeProfile.baseUrl) ??
+    resolveProfileRoute(activeProfile.provider).routeId
+  )
+}
+
+function isActiveProfileAppliedToRoute(
+  activeProfile: ProviderProfile,
+  routeId: string,
+): boolean {
+  return (
+    process.env.CLAUDE_CODE_PROVIDER_PROFILE_ENV_APPLIED === '1' &&
+    process.env.CLAUDE_CODE_PROVIDER_PROFILE_ENV_APPLIED_ID ===
+      activeProfile.id &&
+    getActiveProfileRouteId(activeProfile) === routeId
+  )
+}
+
+export function mergeActiveProfileModelOptions(
+  routeId: string,
+  routeOptions: ModelOption[],
+  options?: {
+    profileModelSurface?: ResolvedProviderProfileModelSurface
+  },
+): ModelOption[] {
+  const activeProfile = getActiveProviderProfile()
+  if (!activeProfile) {
+    return filterModelOptionsByAllowlist(routeOptions)
+  }
+
+  if (!isActiveProfileAppliedToRoute(activeProfile, routeId)) {
+    return filterModelOptionsByAllowlist(routeOptions)
+  }
+
+  const profileOptions = getConfiguredProfileModelOptions(activeProfile)
+  if (profileOptions.length === 0) {
+    return filterModelOptionsByAllowlist(routeOptions)
+  }
+
+  const surface =
+    options?.profileModelSurface ??
+    resolveProviderProfileModelSurface({
+      activeProfile,
+      settingsMode: getProviderProfileModelPickerMode(),
+    })
+  const merged =
+    surface === 'provider'
+      ? mergeProviderCatalogFirst(routeOptions, profileOptions)
+      : mergeProfileListFirst(routeOptions, profileOptions)
+
+  return filterModelOptionsByAllowlist(merged)
 }
 
 function getActiveRouteId(): string | null {
@@ -182,6 +282,31 @@ function getActiveRouteId(): string | null {
   return resolveActiveRouteIdFromEnv(process.env, {
     activeProfileProvider: activeProfile?.provider,
   })
+}
+
+function getLegacyOpenAIOptionsOverride(options: {
+  profileModelSurface: ResolvedProviderProfileModelSurface
+  routeId: string
+}): ModelOption[] {
+  const scopedOptions = getActiveOpenAIRouteModelOptionsCache()
+  const activeProfile = getActiveProviderProfile()
+  if (
+    !activeProfile ||
+    !isActiveProfileAppliedToRoute(activeProfile, options.routeId)
+  ) {
+    return filterModelOptionsByAllowlist([
+      getDefaultOptionForUser(),
+      ...scopedOptions,
+    ])
+  }
+
+  return mergeActiveProfileModelOptions(
+    options.routeId,
+    scopedOptions,
+    {
+      profileModelSurface: options.profileModelSurface,
+    },
+  )
 }
 
 function getOpenAIDiscoveryRequestOptions(routeId?: string | null): {
@@ -243,6 +368,11 @@ async function loadDescriptorDiscoveryContext(
   const routeLabel = descriptor.label
   const routeDefaultModel =
     'defaultModel' in descriptor ? descriptor.defaultModel : undefined
+  const activeProfile = getActiveProviderProfile()
+  const profileModelSurface = resolveProviderProfileModelSurface({
+    activeProfile,
+    settingsMode: getProviderProfileModelPickerMode(),
+  })
   const staticEntries = catalog.models ?? []
   const trafficRestricted = isEssentialTrafficOnly()
   const canRefresh = Boolean(
@@ -264,8 +394,10 @@ async function loadDescriptorDiscoveryContext(
       kind: 'descriptor',
       autoRefresh: false,
       canRefresh,
-      preserveRouteOptions: false,
-      optionsOverride: mergeActiveProfileModelOptions(routeId, routeOptions),
+      profileModelSurface,
+      optionsOverride: mergeActiveProfileModelOptions(routeId, routeOptions, {
+        profileModelSurface,
+      }),
       routeId,
       routeDefaultModel,
       routeLabel,
@@ -313,9 +445,9 @@ async function loadDescriptorDiscoveryContext(
     autoRefresh,
     canRefresh,
     discoveryState,
-    preserveRouteOptions: true,
+    profileModelSurface,
     optionsOverride: mergeActiveProfileModelOptions(routeId, routeOptions, {
-      preserveRouteOptions: true,
+      profileModelSurface,
     }),
     routeId,
     routeDefaultModel,
@@ -334,10 +466,22 @@ async function loadModelDiscoveryContext(): Promise<ModelDiscoveryContext | null
 
   if (getAdditionalModelOptionsCacheScope()?.startsWith('openai:')) {
     const { baseUrl } = getOpenAIDiscoveryRequestOptions()
+    const activeProfile = getActiveProviderProfile()
+    const profileModelSurface = resolveProviderProfileModelSurface({
+      activeProfile,
+      settingsMode: getProviderProfileModelPickerMode(),
+    })
+    const legacyRouteId = routeId ?? 'custom'
     return {
       kind: 'legacy-openai',
       autoRefresh: !isEssentialTrafficOnly(),
       canRefresh: !isEssentialTrafficOnly(),
+      optionsOverride: getLegacyOpenAIOptionsOverride({
+        profileModelSurface,
+        routeId: legacyRouteId,
+      }),
+      profileModelSurface,
+      routeId: legacyRouteId,
       routeLabel: getLocalOpenAICompatibleProviderLabel(baseUrl),
     }
   }
@@ -437,7 +581,7 @@ function ModelPickerWrapper({
   const isFastMode = useAppState((s: AppState) => s.fastMode)
   const setAppState = useSetAppState()
   const [optionsOverride, setOptionsOverride] = React.useState<ModelOption[] | undefined>(
-    discoveryContext?.kind === 'descriptor'
+    discoveryContext && 'optionsOverride' in discoveryContext
       ? discoveryContext.optionsOverride
       : undefined,
   )
@@ -456,6 +600,14 @@ function ModelPickerWrapper({
   }
 
   const handleSelect = (model: string | null, effort: EffortLevel | undefined) => {
+    if (model && !isModelAllowed(model)) {
+      onDone(
+        `Model '${model}' is not available. Your organization restricts model selection.`,
+        { display: 'system' },
+      )
+      return
+    }
+
     logEvent('tengu_model_command_menu', {
       action: String(model) as AnalyticsMetadata_I_VERIFIED_THIS_IS_NOT_CODE_OR_FILEPATHS,
       from_model: String(mainLoopModel) as AnalyticsMetadata_I_VERIFIED_THIS_IS_NOT_CODE_OR_FILEPATHS,
@@ -546,7 +698,7 @@ function ModelPickerWrapper({
           discoveryContext.routeDefaultModel,
         ),
         {
-          preserveRouteOptions: discoveryContext.preserveRouteOptions,
+          profileModelSurface: discoveryContext.profileModelSurface,
         },
       )
       const changed = !haveSameModelOptions(optionsOverride ?? [], nextOptions)
@@ -565,14 +717,44 @@ function ModelPickerWrapper({
 
     try {
       const discoveredOptions = await discoverOpenAICompatibleModelOptions()
-      const currentOptions = getActiveOpenAIModelOptionsCache()
+      const currentRawOptions = getActiveOpenAIRouteModelOptionsCache()
+      const activeProfile = getActiveProviderProfile()
+      const profileApplied = Boolean(
+        activeProfile &&
+          isActiveProfileAppliedToRoute(
+            activeProfile,
+            discoveryContext.routeId,
+          ),
+      )
+      const nextOptions = profileApplied
+        ? mergeActiveProfileModelOptions(
+            discoveryContext.routeId,
+            discoveredOptions,
+            {
+              profileModelSurface: discoveryContext.profileModelSurface,
+            },
+          )
+        : filterModelOptionsByAllowlist([
+            getDefaultOptionForUser(),
+            ...discoveredOptions,
+          ])
       const changed =
         discoveredOptions.length > 0 &&
-        !haveSameModelOptions(currentOptions, discoveredOptions)
+        !haveSameModelOptions(
+          optionsOverride ?? currentRawOptions,
+          nextOptions,
+        )
+      const rawChanged =
+        discoveredOptions.length > 0 &&
+        !haveSameModelOptions(currentRawOptions, discoveredOptions)
 
-      if (discoveredOptions.length > 0 && changed) {
-        setActiveOpenAIModelOptionsCache(discoveredOptions)
+      if (discoveredOptions.length > 0 && rawChanged) {
+        setActiveOpenAIRouteModelOptionsCache(discoveredOptions)
+        if (profileApplied) {
+          setActiveOpenAIModelOptionsCache(discoveredOptions)
+        }
       }
+      setOptionsOverride(nextOptions)
 
       setDiscoveryState(
         legacyDiscoveryStateForOptions({
@@ -825,7 +1007,7 @@ async function refreshModelsAndSummarize(): Promise<string> {
         discoveryContext.routeDefaultModel,
       ),
       {
-        preserveRouteOptions: discoveryContext.preserveRouteOptions,
+        profileModelSurface: discoveryContext.profileModelSurface,
       },
     )
     const changed = !haveSameModelOptions(
@@ -843,13 +1025,39 @@ async function refreshModelsAndSummarize(): Promise<string> {
 
   try {
     const discoveredOptions = await discoverOpenAICompatibleModelOptions()
-    const currentOptions = getActiveOpenAIModelOptionsCache()
+    const currentRawOptions = getActiveOpenAIRouteModelOptionsCache()
+    const activeProfile = getActiveProviderProfile()
+    const profileApplied = Boolean(
+      activeProfile &&
+        isActiveProfileAppliedToRoute(activeProfile, discoveryContext.routeId),
+    )
+    const nextOptions = profileApplied
+      ? mergeActiveProfileModelOptions(
+          discoveryContext.routeId,
+          discoveredOptions,
+          {
+            profileModelSurface: discoveryContext.profileModelSurface,
+          },
+        )
+      : filterModelOptionsByAllowlist([
+          getDefaultOptionForUser(),
+          ...discoveredOptions,
+        ])
     const changed =
       discoveredOptions.length > 0 &&
-      !haveSameModelOptions(currentOptions, discoveredOptions)
+      !haveSameModelOptions(
+        discoveryContext.optionsOverride ?? currentRawOptions,
+        nextOptions,
+      )
+    const rawChanged =
+      discoveredOptions.length > 0 &&
+      !haveSameModelOptions(currentRawOptions, discoveredOptions)
 
-    if (discoveredOptions.length > 0 && changed) {
-      setActiveOpenAIModelOptionsCache(discoveredOptions)
+    if (discoveredOptions.length > 0 && rawChanged) {
+      setActiveOpenAIRouteModelOptionsCache(discoveredOptions)
+      if (profileApplied) {
+        setActiveOpenAIModelOptionsCache(discoveredOptions)
+      }
     }
 
     return legacyDiscoveryStateForOptions({

--- a/src/commands/model/model.tsx
+++ b/src/commands/model/model.tsx
@@ -726,6 +726,18 @@ function ModelPickerWrapper({
 
     try {
       const discoveredOptions = await discoverOpenAICompatibleModelOptions()
+      if (discoveredOptions.length === 0) {
+        setDiscoveryState(
+          legacyDiscoveryStateForOptions({
+            changed: false,
+            failed: true,
+            manual,
+            routeLabel: discoveryContext.routeLabel,
+          }),
+        )
+        return
+      }
+
       const currentRawOptions = getActiveOpenAIRouteModelOptionsCache()
       const activeProfile = getActiveProviderProfile()
       const profileApplied = Boolean(
@@ -748,16 +760,11 @@ function ModelPickerWrapper({
             ...discoveredOptions,
           ])
       const changed =
-        discoveredOptions.length > 0 &&
-        !haveSameModelOptions(
-          optionsOverride ?? currentRawOptions,
-          nextOptions,
-        )
+        !haveSameModelOptions(optionsOverride ?? currentRawOptions, nextOptions)
       const rawChanged =
-        discoveredOptions.length > 0 &&
         !haveSameModelOptions(currentRawOptions, discoveredOptions)
 
-      if (discoveredOptions.length > 0 && rawChanged) {
+      if (rawChanged) {
         setActiveOpenAIRouteModelOptionsCache(discoveredOptions)
         if (profileApplied) {
           setActiveOpenAIModelOptionsCache(discoveredOptions)
@@ -1034,6 +1041,15 @@ async function refreshModelsAndSummarize(): Promise<string> {
 
   try {
     const discoveredOptions = await discoverOpenAICompatibleModelOptions()
+    if (discoveredOptions.length === 0) {
+      return legacyDiscoveryStateForOptions({
+        changed: false,
+        failed: true,
+        manual: true,
+        routeLabel: discoveryContext.routeLabel,
+      }).message
+    }
+
     const currentRawOptions = getActiveOpenAIRouteModelOptionsCache()
     const activeProfile = getActiveProviderProfile()
     const profileApplied = Boolean(
@@ -1053,16 +1069,14 @@ async function refreshModelsAndSummarize(): Promise<string> {
           ...discoveredOptions,
         ])
     const changed =
-      discoveredOptions.length > 0 &&
       !haveSameModelOptions(
         discoveryContext.optionsOverride ?? currentRawOptions,
         nextOptions,
       )
     const rawChanged =
-      discoveredOptions.length > 0 &&
       !haveSameModelOptions(currentRawOptions, discoveredOptions)
 
-    if (discoveredOptions.length > 0 && rawChanged) {
+    if (rawChanged) {
       setActiveOpenAIRouteModelOptionsCache(discoveredOptions)
       if (profileApplied) {
         setActiveOpenAIModelOptionsCache(discoveredOptions)

--- a/src/components/ModelPicker.test.tsx
+++ b/src/components/ModelPicker.test.tsx
@@ -1,0 +1,150 @@
+import { PassThrough } from 'node:stream'
+import { stripVTControlCharacters as stripAnsi } from 'node:util'
+
+import { afterEach, beforeEach, expect, mock, test } from 'bun:test'
+import React from 'react'
+
+import { render } from '../ink.js'
+import { AppStateProvider, getDefaultAppState } from '../state/AppState.js'
+import {
+  acquireSharedMutationLock,
+  releaseSharedMutationLock,
+} from '../test/sharedMutationLock.js'
+import {
+  resetSettingsCache,
+  setSessionSettingsCache,
+} from '../utils/settings/settingsCache.js'
+import type { SettingsJson } from '../utils/settings/types.js'
+
+type SettingsModule = typeof import('../utils/settings/settings.js')
+
+let actualSettingsModule: SettingsModule | undefined
+let settingsForTest: SettingsJson = {}
+
+function useSettings(settings: SettingsJson): void {
+  settingsForTest = settings
+  setSessionSettingsCache({ settings, errors: [] })
+}
+
+async function mockSettingsForTest(): Promise<void> {
+  actualSettingsModule ??= await import(
+    `../utils/settings/settings.ts?modelPickerSettingsActual=${Date.now()}-${Math.random()}`
+  )
+  mock.module('../utils/settings/settings.js', () => ({
+    ...actualSettingsModule!,
+    getInitialSettings: () => settingsForTest,
+    getSettings_DEPRECATED: () => settingsForTest,
+  }))
+  mock.module('../utils/model/modelAllowlist.js', () => ({
+    isModelAllowed: isModelAllowedForTest,
+  }))
+}
+
+function isModelAllowedForTest(model: string): boolean {
+  const { availableModels } = settingsForTest
+  if (!availableModels) {
+    return true
+  }
+  if (availableModels.length === 0) {
+    return false
+  }
+
+  const normalizedModel = model.trim().toLowerCase()
+  return availableModels.some(
+    allowed => allowed.trim().toLowerCase() === normalizedModel,
+  )
+}
+
+async function waitForCondition(
+  predicate: () => boolean,
+  timeoutMs = 2000,
+): Promise<void> {
+  const startedAt = Date.now()
+
+  while (Date.now() - startedAt < timeoutMs) {
+    if (predicate()) {
+      return
+    }
+    await Bun.sleep(10)
+  }
+
+  throw new Error('Timed out waiting for ModelPicker test condition')
+}
+
+beforeEach(async () => {
+  await acquireSharedMutationLock('components/ModelPicker.test.tsx')
+  mock.restore()
+  settingsForTest = {}
+  await mockSettingsForTest()
+  useSettings({} as SettingsJson)
+})
+
+afterEach(() => {
+  try {
+    mock.restore()
+    resetSettingsCache()
+    settingsForTest = {}
+  } finally {
+    releaseSharedMutationLock()
+  }
+})
+
+test('does not append a blocked current model to filtered override options', async () => {
+  useSettings({ availableModels: ['allowed-model'] } as SettingsJson)
+  const { ModelPicker } = await import(
+    `./ModelPicker.js?blocked-current-${Date.now()}`
+  )
+  let output = ''
+  const stdout = new PassThrough()
+  const stdin = new PassThrough() as PassThrough & {
+    isTTY: boolean
+    setRawMode: (mode: boolean) => void
+    ref: () => void
+    unref: () => void
+  }
+  stdin.isTTY = true
+  stdin.setRawMode = () => {}
+  stdin.ref = () => {}
+  stdin.unref = () => {}
+  ;(stdout as unknown as { columns: number }).columns = 120
+  stdout.on('data', chunk => {
+    output += chunk.toString()
+  })
+
+  const instance = await render(
+    <AppStateProvider
+      initialState={{
+        ...getDefaultAppState(),
+        mainLoopModel: 'blocked-model',
+      }}
+    >
+      <ModelPicker
+        initial="blocked-model"
+        onSelect={() => {}}
+        optionsOverride={[
+          {
+            value: 'allowed-model',
+            label: 'Allowed Model',
+            description: 'Allowed by policy',
+          },
+        ]}
+      />
+    </AppStateProvider>,
+    {
+      stdin: stdin as unknown as NodeJS.ReadStream,
+      stdout: stdout as unknown as NodeJS.WriteStream,
+      exitOnCtrlC: false,
+    },
+  )
+
+  try {
+    await waitForCondition(() => stripAnsi(output).includes('Allowed Model'))
+    const rendered = stripAnsi(output)
+    expect(rendered).toContain('Allowed Model')
+    expect(rendered).not.toContain('blocked-model')
+  } finally {
+    instance.unmount()
+    stdin.end()
+    stdout.end()
+  }
+})

--- a/src/components/ModelPicker.tsx
+++ b/src/components/ModelPicker.tsx
@@ -9,6 +9,7 @@ import { Box, Text } from '../ink.js';
 import { useKeybindings } from '../keybindings/useKeybinding.js';
 import { useAppState, useSetAppState } from '../state/AppState.js';
 import { convertEffortValueToLevel, type EffortLevel, getDefaultEffortForModel, modelSupportsEffort, modelSupportsMaxEffort, resolvePickerEffortPersistence, toPersistableEffort } from '../utils/effort.js';
+import { isModelAllowed } from '../utils/model/modelAllowlist.js';
 import { getDefaultMainLoopModel, type ModelSetting, modelDisplayString, parseUserSpecifiedModel } from '../utils/model/model.js';
 import { getModelOptions, type ModelOption } from '../utils/model/modelOptions.js';
 import { getSettingsForSource, updateSettingsForSource } from '../utils/settings/settings.js';
@@ -99,7 +100,7 @@ export function ModelPicker(t0) {
   const modelOptions = optionsOverride ?? t3;
   let t4;
   bb0: {
-    if (initial !== null && !modelOptions.some(opt => opt.value === initial)) {
+    if (initial !== null && isModelAllowed(initial) && !modelOptions.some(opt => opt.value === initial)) {
       let t5;
       if ($[4] !== initial) {
         t5 = modelDisplayString(initial);
@@ -243,6 +244,11 @@ export function ModelPicker(t0) {
   let t14;
   if ($[35] !== effort || $[36] !== hasToggledEffort || $[37] !== onSelect || $[38] !== setAppState || $[39] !== skipSettingsWrite) {
     t14 = function handleSelect(value_0) {
+      const selectedModel = resolveOptionModel(value_0);
+      if (value_0 !== NO_PREFERENCE && selectedModel && !isModelAllowed(selectedModel)) {
+        onSelect(value_0 === NO_PREFERENCE ? null : value_0, undefined);
+        return;
+      }
       logEvent("tengu_model_command_menu_effort", {
         effort: effort as AnalyticsMetadata_I_VERIFIED_THIS_IS_NOT_CODE_OR_FILEPATHS
       });
@@ -259,7 +265,6 @@ export function ModelPicker(t0) {
           effortValue: effortLevel
         }));
       }
-      const selectedModel = resolveOptionModel(value_0);
       const selectedEffort = hasToggledEffort && selectedModel && modelSupportsEffort(selectedModel) ? effort : undefined;
       if (value_0 === NO_PREFERENCE) {
         onSelect(null, selectedEffort);

--- a/src/utils/analyzeContext.messageBreakdown.test.ts
+++ b/src/utils/analyzeContext.messageBreakdown.test.ts
@@ -54,7 +54,7 @@ describe('approximateMessageTokens', () => {
       await rm(fixtureRoot, { recursive: true, force: true })
       releaseSharedMutationLock()
     }
-  })
+  }, 15_000)
 
   test('uses local message estimates when provider token counters are unavailable', async () => {
     await acquireSharedMutationLock('analyzeContext.messageBreakdown.test.ts')

--- a/src/utils/attribution.test.ts
+++ b/src/utils/attribution.test.ts
@@ -8,10 +8,7 @@ import {
 } from '../bootstrap/state.js'
 import * as actualModel from './model/model.js'
 import * as actualProviders from './model/providers.js'
-import {
-  resetSettingsCache,
-  setSessionSettingsCache,
-} from './settings/settingsCache.js'
+import { resetSettingsCache } from './settings/settingsCache.js'
 import type { SettingsJson } from './settings/types.js'
 
 let getAttributionTexts: (typeof import('./attribution.js'))['getAttributionTexts']
@@ -24,6 +21,7 @@ let getDefaultCommitCoAuthorName: (typeof import('./attribution.js'))[
 let getEnhancedPRAttribution: (typeof import('./attribution.js'))[
   'getEnhancedPRAttribution'
 ]
+let settingsForTest: SettingsJson = {}
 
 const originalEnv = {
   CLAUDE_CODE_USE_OPENAI: process.env.CLAUDE_CODE_USE_OPENAI,
@@ -71,7 +69,7 @@ const defaultPrAttribution =
   '🤖 Generated with [OpenClaude](https://github.com/Gitlawb/openclaude)'
 
 function useSettings(settings: SettingsJson): void {
-  setSessionSettingsCache({ settings, errors: [] })
+  settingsForTest = settings
 }
 
 function restoreEnv(): void {
@@ -88,6 +86,7 @@ beforeEach(async () => {
   mock.restore()
   resetStateForTests()
   resetSettingsCache()
+  settingsForTest = {}
   setClientType('cli')
   setMainLoopModelOverride(undefined)
   delete process.env.CLAUDE_CODE_USE_GEMINI
@@ -131,6 +130,14 @@ beforeEach(async () => {
     ...actualProviders,
     getAPIProvider: () => 'openai',
   }))
+  const actualSettings = await import(
+    `./settings/settings.ts?attributionSettingsActual=${Date.now()}-${Math.random()}`
+  )
+  mock.module('./settings/settings.js', () => ({
+    ...actualSettings,
+    getInitialSettings: () => settingsForTest,
+    getSettings_DEPRECATED: () => settingsForTest,
+  }))
 
   const attribution = await import(
     `./attribution.ts?attributionTest=${Date.now()}-${Math.random()}`
@@ -145,6 +152,7 @@ afterEach(() => {
   mock.restore()
   resetStateForTests()
   resetSettingsCache()
+  settingsForTest = {}
   setClientType(originalClientType)
   setMainLoopModelOverride(originalMainLoopModelOverride)
   mock.module('./model/model.js', () => actualModel)

--- a/src/utils/conversationRecovery.hooks.test.ts
+++ b/src/utils/conversationRecovery.hooks.test.ts
@@ -18,6 +18,7 @@ const tempDirs: string[] = []
 const originalEnv = { ...process.env }
 const sessionId = '00000000-0000-4000-8000-000000001999'
 const ts = '2026-04-02T00:00:00.000Z'
+let providerForTest: ReturnType<typeof realProviders.getAPIProvider> = 'firstParty'
 
 function id(n: number): string {
   return `00000000-0000-4000-8000-${String(n).padStart(12, '0')}`
@@ -52,9 +53,10 @@ async function writeJsonl(entry: unknown): Promise<string> {
 
 beforeEach(async () => {
   await acquireSharedMutationLock('utils/conversationRecovery.hooks.test.ts')
+  providerForTest = 'firstParty'
   mock.module('./model/providers.js', () => ({
     ...realProviders,
-    getAPIProvider: () => 'firstParty',
+    getAPIProvider: () => providerForTest,
   }))
 })
 
@@ -63,6 +65,7 @@ afterEach(async () => {
     mock.restore()
     mock.module('./model/providers.js', () => realProviders)
     mock.module('./sessionStart.js', () => realSessionStart)
+    providerForTest = 'firstParty'
     process.env = { ...originalEnv }
     await Promise.all(tempDirs.splice(0).map(dir => rm(dir, { recursive: true, force: true })))
   } finally {
@@ -126,10 +129,10 @@ test('deserializeMessagesWithInterruptDetection strips thinking blocks only for 
     user(id(13), 'follow up'),
   ]
 
-  mock.module('./model/providers.js', () => ({
-    ...realProviders,
-    getAPIProvider: () => 'openai',
-  }))
+  providerForTest = 'openai'
+  process.env.CLAUDE_CODE_USE_OPENAI = '1'
+  process.env.OPENAI_BASE_URL = 'https://api.openai.com/v1'
+  process.env.OPENAI_MODEL = 'gpt-5-mini'
 
   const openaiModule = await import(`./conversationRecovery.ts?provider=openai-${Date.now()}`)
   const thirdParty = openaiModule.deserializeMessagesWithInterruptDetection(serializedMessages as never[])
@@ -149,10 +152,6 @@ test('deserializeMessagesWithInterruptDetection strips thinking blocks only for 
   ).not.toContain('only hidden reasoning')
 
   process.env.OPENAI_MODEL = 'mimo-v2.5-pro'
-  mock.module('./model/providers.js', () => ({
-    ...realProviders,
-    getAPIProvider: () => 'openai',
-  }))
 
   const mimoModule = await import(`./conversationRecovery.ts?provider=mimo-${Date.now()}`)
   const mimo = mimoModule.deserializeMessagesWithInterruptDetection(serializedMessages as never[])
@@ -173,10 +172,10 @@ test('deserializeMessagesWithInterruptDetection strips thinking blocks only for 
   ).not.toContain('only hidden reasoning')
   delete process.env.OPENAI_MODEL
 
-  mock.module('./model/providers.js', () => ({
-    ...realProviders,
-    getAPIProvider: () => 'bedrock',
-  }))
+  providerForTest = 'bedrock'
+  delete process.env.CLAUDE_CODE_USE_OPENAI
+  delete process.env.OPENAI_BASE_URL
+  delete process.env.OPENAI_MODEL
 
   const bedrockModule = await import(`./conversationRecovery.ts?provider=bedrock-${Date.now()}`)
   const anthropicCompatible = bedrockModule.deserializeMessagesWithInterruptDetection(serializedMessages as never[])

--- a/src/utils/preflightChecks.test.ts
+++ b/src/utils/preflightChecks.test.ts
@@ -1,6 +1,7 @@
 import { PassThrough } from 'node:stream'
 
 import { afterEach, beforeEach, describe, expect, jest, mock, test } from 'bun:test'
+import axios from 'axios'
 import React from 'react'
 
 import {
@@ -28,6 +29,7 @@ type TestStdin = PassThrough & {
 }
 
 const originalProcessExit = process.exit
+const originalAxiosGet = axios.get
 
 function createTestStreams(): {
   stdout: PassThrough
@@ -100,6 +102,7 @@ beforeEach(async () => {
 afterEach(() => {
   try {
     process.exit = originalProcessExit
+    axios.get = originalAxiosGet
     jest.restoreAllMocks()
     jest.useRealTimers()
     mock.restore()
@@ -111,18 +114,13 @@ afterEach(() => {
 describe('checkEndpoints (preflight)', () => {
   test('passes a bounded timeout to axios so a hung probe cannot freeze onboarding (#1017)', async () => {
     const calls: Array<{ url: string; options: { timeout?: number } }> = []
-    mock.module('axios', () => ({
-      default: {
-        get: async (
-          url: string,
-          options: { timeout?: number } = {},
-        ): Promise<{ status: number }> => {
-          calls.push({ url, options })
-          return { status: 200 }
-        },
-        isAxiosError: () => false,
-      },
-    }))
+    axios.get = mock(async (
+      url: string,
+      options: { timeout?: number } = {},
+    ): Promise<{ status: number }> => {
+      calls.push({ url, options })
+      return { status: 200 }
+    }) as typeof axios.get
 
     const { checkEndpoints, PREFLIGHT_REQUEST_TIMEOUT_MS } = await import(
       './preflightChecks.js'
@@ -140,18 +138,13 @@ describe('checkEndpoints (preflight)', () => {
   })
 
   test('returns a failure result (instead of throwing or hanging) when axios rejects with ECONNABORTED', async () => {
-    mock.module('axios', () => ({
-      default: {
-        get: async (): Promise<never> => {
-          const err = new Error('timeout of 5000ms exceeded') as Error & {
-            code?: string
-          }
-          err.code = 'ECONNABORTED'
-          throw err
-        },
-        isAxiosError: () => false,
-      },
-    }))
+    axios.get = mock(async (): Promise<never> => {
+      const err = new Error('timeout of 5000ms exceeded') as Error & {
+        code?: string
+      }
+      err.code = 'ECONNABORTED'
+      throw err
+    }) as typeof axios.get
 
     const { checkEndpoints } = await import('./preflightChecks.js')
 
@@ -163,12 +156,9 @@ describe('checkEndpoints (preflight)', () => {
   })
 
   test('returns success when all probes return 200', async () => {
-    mock.module('axios', () => ({
-      default: {
-        get: async (): Promise<{ status: number }> => ({ status: 200 }),
-        isAxiosError: () => false,
-      },
-    }))
+    axios.get = mock(async (): Promise<{ status: number }> => ({
+      status: 200,
+    })) as typeof axios.get
 
     const { checkEndpoints } = await import('./preflightChecks.js')
 
@@ -190,19 +180,14 @@ describe('checkEndpoints (preflight)', () => {
     mock.module('../hooks/useTimeout.js', () => ({
       useTimeout: () => false,
     }))
-    mock.module('axios', () => ({
-      default: {
-        get: async (): Promise<never> => {
-          probeCalls++
-          const err = new Error('timeout of 5000ms exceeded') as Error & {
-            code?: string
-          }
-          err.code = 'ECONNABORTED'
-          throw err
-        },
-        isAxiosError: () => false,
-      },
-    }))
+    axios.get = mock(async (): Promise<never> => {
+      probeCalls++
+      const err = new Error('timeout of 5000ms exceeded') as Error & {
+        code?: string
+      }
+      err.code = 'ECONNABORTED'
+      throw err
+    }) as typeof axios.get
 
     const { createRoot } = await import('../ink.js')
     const { PreflightStep, PREFLIGHT_ERROR_HOLD_MS } = await import(

--- a/src/utils/providerProfiles.test.ts
+++ b/src/utils/providerProfiles.test.ts
@@ -1865,6 +1865,94 @@ describe('deleteProviderProfile', () => {
 })
 
 describe('getProfileModelOptions', () => {
+  test('getConfiguredProfileModelOptions ignores discovered cache entries', async () => {
+    const { getConfiguredProfileModelOptions } =
+      await importFreshProviderProfileModules()
+    const profile = buildProfile({
+      id: 'multi_provider',
+      name: 'Multi Provider',
+      model: 'glm-4.7, glm-4.7-flash',
+    })
+
+    mockConfigState = {
+      ...createMockConfigState(),
+      providerProfiles: [profile],
+      activeProviderProfileId: 'multi_provider',
+      openaiAdditionalModelOptionsCacheByProfile: {
+        multi_provider: [
+          {
+            value: 'glm-4.7-plus',
+            label: 'glm-4.7-plus',
+            description: 'Discovered from API',
+          },
+        ],
+      },
+    }
+
+    expect(getConfiguredProfileModelOptions(profile)).toEqual([
+      {
+        value: 'glm-4.7',
+        label: 'glm-4.7',
+        description: 'Provider: Multi Provider',
+      },
+      {
+        value: 'glm-4.7-flash',
+        label: 'glm-4.7-flash',
+        description: 'Provider: Multi Provider',
+      },
+    ])
+  })
+
+  test('route-scoped OpenAI cache ignores active profile cache entries', async () => {
+    process.env.CLAUDE_CODE_USE_OPENAI = '1'
+    process.env.OPENAI_BASE_URL = 'http://localhost:7777/v1'
+    process.env.OPENAI_MODEL = 'route-model'
+
+    const { getAdditionalModelOptionsCacheScope } = await import(
+      '../services/api/providerConfig.js'
+    )
+    const { getActiveOpenAIRouteModelOptionsCache } =
+      await importFreshProviderProfileModules()
+    const profile = buildProfile({
+      id: 'multi_provider',
+      name: 'Multi Provider',
+      baseUrl: 'http://localhost:7777/v1',
+      model: 'profile-model',
+    })
+
+    mockConfigState = {
+      ...createMockConfigState(),
+      providerProfiles: [profile],
+      activeProviderProfileId: 'multi_provider',
+      additionalModelOptionsCache: [
+        {
+          value: 'route-model',
+          label: 'Route Model',
+          description: 'Detected from route',
+        },
+      ],
+      additionalModelOptionsCacheScope:
+        getAdditionalModelOptionsCacheScope() ?? undefined,
+      openaiAdditionalModelOptionsCacheByProfile: {
+        multi_provider: [
+          {
+            value: 'profile-model',
+            label: 'profile-model',
+            description: 'Provider: Multi Provider',
+          },
+        ],
+      },
+    }
+
+    expect(getActiveOpenAIRouteModelOptionsCache()).toEqual([
+      {
+        value: 'route-model',
+        label: 'Route Model',
+        description: 'Detected from route',
+      },
+    ])
+  })
+
   test('generates options for multi-model profile', async () => {
     const { getProfileModelOptions } =
       await importFreshProviderProfileModules()

--- a/src/utils/providerProfiles.ts
+++ b/src/utils/providerProfiles.ts
@@ -1,5 +1,6 @@
 import { randomBytes } from 'crypto'
 import {
+  getAdditionalModelOptionsCacheScope,
   isCodexBaseUrl,
   parseOpenAICompatibleApiFormat,
 } from '../services/api/providerConfig.js'
@@ -910,6 +911,16 @@ export function persistActiveProviderProfileModel(
   return resolvedProfile
 }
 
+export function getConfiguredProfileModelOptions(
+  profile: ProviderProfile,
+): ModelOption[] {
+  return parseModelList(profile.model).map(model => ({
+    value: model,
+    label: model,
+    description: `Provider: ${profile.name}`,
+  }))
+}
+
 /**
  * Generate model options from a provider profile's model field.
  * Each parsed model becomes a separate option in the picker, then any
@@ -920,12 +931,7 @@ export function getProfileModelOptions(
   profile: ProviderProfile,
   config = getGlobalConfig(),
 ): ModelOption[] {
-  const configuredOptions = parseModelList(profile.model).map(model => ({
-    value: model,
-    label: model,
-    description: `Provider: ${profile.name}`,
-  }))
-
+  const configuredOptions = getConfiguredProfileModelOptions(profile)
   return mergeModelOptionsByValue(
     configuredOptions,
     getModelCacheByProfile(profile.id, config),
@@ -1345,6 +1351,32 @@ export function setActiveOpenAIModelOptionsCache(options: ModelOption[]): void {
       ...(current.openaiAdditionalModelOptionsCacheByProfile ?? {}),
       [activeProfile.id]: mergedOptions,
     },
+  }))
+}
+
+export function getActiveOpenAIRouteModelOptionsCache(
+  config = getGlobalConfig(),
+): ModelOption[] {
+  const activeScope = getAdditionalModelOptionsCacheScope()
+
+  return activeScope?.startsWith('openai:') &&
+    config.additionalModelOptionsCacheScope === activeScope
+    ? (config.additionalModelOptionsCache ?? [])
+    : []
+}
+
+export function setActiveOpenAIRouteModelOptionsCache(
+  options: ModelOption[],
+): void {
+  const activeScope = getAdditionalModelOptionsCacheScope()
+  if (!activeScope?.startsWith('openai:')) {
+    return
+  }
+
+  saveGlobalConfig(current => ({
+    ...current,
+    additionalModelOptionsCache: options,
+    additionalModelOptionsCacheScope: activeScope,
   }))
 }
 

--- a/src/utils/settings/providerProfileModelPickerMode.test.ts
+++ b/src/utils/settings/providerProfileModelPickerMode.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, test } from 'bun:test'
+
+describe('SettingsSchema providerProfileModelPickerMode', () => {
+  test('accepts explicit provider profile model picker modes', async () => {
+    const { SettingsSchema } = await import('./types.js')
+
+    for (const mode of ['auto', 'profile', 'provider'] as const) {
+      const result = SettingsSchema().safeParse({
+        providerProfileModelPickerMode: mode,
+      })
+
+      expect(result.success).toBe(true)
+      expect(result.data?.providerProfileModelPickerMode).toBe(mode)
+    }
+  })
+
+  test('treats invalid provider profile model picker modes as unset', async () => {
+    const { SettingsSchema } = await import('./types.js')
+    const result = SettingsSchema().safeParse({
+      providerProfileModelPickerMode: 'catalog',
+    })
+
+    expect(result.success).toBe(true)
+    expect(result.data?.providerProfileModelPickerMode).toBeUndefined()
+  })
+})

--- a/src/utils/settings/types.ts
+++ b/src/utils/settings/types.ts
@@ -395,6 +395,16 @@ export const SettingsSchema = lazySchema(() =>
             'If undefined, all models are available. If empty array, only the default model is available. ' +
             'Typically set in managed settings by enterprise administrators.',
         ),
+      providerProfileModelPickerMode: z
+        .enum(['auto', 'profile', 'provider'])
+        .optional()
+        .catch(undefined)
+        .describe(
+          'Controls /model options when an active provider profile is applied. ' +
+            '"profile" shows only explicitly configured profile models; ' +
+            '"provider" shows the provider catalog/discovery list plus explicit profile-only custom models; ' +
+            '"auto" uses profile mode when the profile has multiple explicitly configured models, otherwise provider mode.',
+        ),
       modelOverrides: z
         .record(z.string(), z.string())
         .optional()


### PR DESCRIPTION
## Summary

- Add `providerProfileModelPickerMode` with `auto`, `profile`, and `provider` picker surfaces for active provider profiles.
- Preserve curated multi-model profile behavior while keeping provider catalogs visible by default for single-default profiles such as OpenRouter and Gitlawb Opengateway.
- Keep native vendor routes on their full curated catalog in auto mode, so provider profiles do not hide newly catalogued vendor models.
- Apply `availableModels` filtering consistently to descriptor overrides, legacy local OpenAI-compatible overrides, refresh summaries, synthetic current-model rows, and interactive selection.
- Keep local OpenAI-compatible route cache ownership explicit so provider-catalog ordering is not polluted by profile-merged caches.
- Document the user-selectable provider profile model picker mode in the advanced setup guide.
- Tighten related test isolation for process-global mocks that affected full-suite SDK runs.

Fixes #1467

## Testing

- [x] `bun test src/utils/settings/providerProfileModelPickerMode.test.ts src/commands/model/model.test.tsx`
- [x] `bun test --max-concurrency=1 src/utils/preflightChecks.test.ts tests/sdk/query-lifecycle.test.ts src/utils/attribution.test.ts src/commands/model/model.test.tsx src/components/ModelPicker.test.tsx src/utils/providerProfiles.test.ts src/utils/settings/providerProfileModelPickerMode.test.ts`
- [x] `bun run check`
- [x] `python -m pytest -q python/tests`
- [x] `bun run security:pr-scan -- --base upstream/main --head HEAD`
- [x] `bun run test:provider`
- [x] `npm run test:provider-recommendation`
- [x] `bun run --cwd web typecheck`
- [x] `bun run --cwd web build`
- [x] `git diff --cached --check`
- [x] `git diff --check upstream/main...HEAD`

## Notes

- Reviewed the #1467 note referencing #1423, #1453, and #1361. This PR is scoped around that conflict by making the provider/profile picker behavior user-selectable instead of hard-coding either side.
- Merged current `upstream/main` into the branch and resolved conflicts in the provider profile picker, attribution, and preflight test areas.
- Covers profile-constrained and provider-catalog picker semantics for static, native-vendor, discovery-backed, and legacy local OpenAI-compatible routes.
- Screenshots not applicable; CLI picker behavior only.