### PR TITLE
fix: resolve tool getter double-invocation, dedup getMergedTools, fix openaiShim errors

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -271,6 +271,7 @@ if ("external" !== 'ant' && isBeingDebugged()) {
   // Use process.exit directly here since we're in the top-level code before imports
   // and gracefulShutdown is not yet available
   // eslint-disable-next-line custom-rules/no-top-level-side-effects
+  process.stderr.write('[openclaude] Debugger detected. Attach a debugger is not supported in external builds. Exiting.\n')
   process.exit(1);
 }
 

--- a/src/query.ts
+++ b/src/query.ts
@@ -1729,26 +1729,21 @@ async function* queryLoop(
 
       // Collect tool info for summary generation
       const toolUseIds = toolUseBlocks.map(block => block.id)
+
+      // Build a Map for O(1) tool result lookup instead of O(N*M) nested find()
+      const toolResultMap = new Map<string, ToolResultBlockParam>()
+      for (const result of toolResults) {
+        if (result.type === 'user' && Array.isArray(result.message.content)) {
+          for (const content of result.message.content) {
+            if (content.type === 'tool_result' && content.tool_use_id) {
+              toolResultMap.set(content.tool_use_id, content as ToolResultBlockParam)
+            }
+          }
+        }
+      }
+
       const toolInfoForSummary = toolUseBlocks.map(block => {
-        // Find the corresponding tool result
-        const toolResult = toolResults.find(
-          result =>
-            result.type === 'user' &&
-            Array.isArray(result.message.content) &&
-            result.message.content.some(
-              content =>
-                content.type === 'tool_result' &&
-                content.tool_use_id === block.id,
-            ),
-        )
-        const resultContent =
-          toolResult?.type === 'user' &&
-          Array.isArray(toolResult.message.content)
-            ? toolResult.message.content.find(
-                (c): c is ToolResultBlockParam =>
-                  c.type === 'tool_result' && c.tool_use_id === block.id,
-              )
-            : undefined
+        const resultContent = toolResultMap.get(block.id)
         return {
           name: block.name,
           input: block.input,

--- a/src/services/api/openaiShim.ts
+++ b/src/services/api/openaiShim.ts
@@ -233,9 +233,9 @@ function redactUrlForDiagnostics(url: string): string {
     }
 
     const serialized = parsed.toString()
-    return redactSecretValueForDisplay(serialized, process.env as SecretValueSource) ?? serialized
+    return redactSecretValueForDisplay(serialized, process.env as SecretValueSource) ?? '[redacted]'
   } catch {
-    return redactSecretValueForDisplay(url, process.env as SecretValueSource) ?? url
+    return redactSecretValueForDisplay(url, process.env as SecretValueSource) ?? '[redacted]'
   }
 }
 
@@ -1468,7 +1468,7 @@ async function* openaiStreamToAnthropic(
           },
         }
         throw APIError.generate(
-          (response.status ?? 200) as number,
+          (response.status || 500) as number,
           errorPayload,
           message,
           response.headers as unknown as Headers,
@@ -2679,12 +2679,18 @@ class OpenAIShimMessages {
     }
 
     let response: Response | undefined
-    const provider = request.baseUrl.includes('nvidia') ? 'nvidia-nim'
-      : request.baseUrl.includes('minimax') ? 'minimax'
-      : request.baseUrl.includes('xiaomimimo') || request.baseUrl.includes('mimo-v2') ? 'xiaomi-mimo'
-      : request.baseUrl.includes('localhost:11434') || request.baseUrl.includes('localhost:11435') ? 'ollama'
-      : request.baseUrl.includes('anthropic') ? 'anthropic'
-      : 'openai'
+    let provider = 'openai'
+    try {
+      const parsedUrl = new URL(request.baseUrl)
+      const hostname = parsedUrl.hostname.toLowerCase()
+      if (hostname.includes('nvidia')) provider = 'nvidia-nim'
+      else if (hostname.includes('minimax')) provider = 'minimax'
+      else if (hostname.includes('xiaomimimo') || hostname.includes('mimo-v2')) provider = 'xiaomi-mimo'
+      else if (hostname === 'localhost' && (parsedUrl.port === '11434' || parsedUrl.port === '11435')) provider = 'ollama'
+      else if (hostname.includes('anthropic')) provider = 'anthropic'
+    } catch {
+      // Keep default 'openai' if URL parsing fails
+    }
     const { correlationId, startTime } = logApiCallStart(provider, request.resolvedModel)
     for (let attempt = 0; attempt < maxAttempts; attempt++) {
       try {
@@ -2730,10 +2736,16 @@ class OpenAIShimMessages {
         // stream_options: { include_usage: true } and can be extracted from the stream.
         if (!params.stream) {
           try {
-            const clone = response.clone()
-            const data = await clone.json()
+            const bodyText = await response.text()
+            const data = JSON.parse(bodyText)
             tokensIn = data.usage?.prompt_tokens ?? 0
             tokensOut = data.usage?.completion_tokens ?? 0
+            // Recreate response with the consumed body so callers can still read it
+            response = new Response(bodyText, {
+              status: response.status,
+              statusText: response.statusText,
+              headers: response.headers,
+            })
           } catch { /* ignore */ }
         }
         logApiCallEnd(correlationId, startTime, request.resolvedModel, 'success', tokensIn, tokensOut, false)

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -210,11 +210,11 @@ export function getAllBaseTools(): Tools {
     ...(TerminalCaptureTool ? [TerminalCaptureTool] : []),
     LSPTool,
     ...(isWorktreeModeEnabled() ? [EnterWorktreeTool, ExitWorktreeTool] : []),
-    // Use filter(Boolean) to handle case where getter might return null/undefined
-    ...(getSendMessageTool() ? [getSendMessageTool()] : []),
+    // Cache getter results to avoid double-invocation of lazy require()
+    ...(() => { const smt = getSendMessageTool(); return smt ? [smt] : [] })(),
     ...(ListPeersTool ? [ListPeersTool] : []),
     ...(isAgentSwarmsEnabled()
-      ? [getTeamCreateTool(), getTeamDeleteTool()].filter(Boolean)
+      ? (() => { const tct = getTeamCreateTool(); const tdt = getTeamDeleteTool(); return [tct, tdt].filter(Boolean) })()
       : []),
     ...(VerifyPlanExecutionTool ? [VerifyPlanExecutionTool] : []),
     ...(process.env.USER_TYPE === 'ant' && REPLTool ? [REPLTool] : []),
@@ -227,7 +227,7 @@ export function getAllBaseTools(): Tools {
     ...(SendUserFileTool ? [SendUserFileTool] : []),
     ...(PushNotificationTool ? [PushNotificationTool] : []),
     ...(SubscribePRTool ? [SubscribePRTool] : []),
-    ...(getPowerShellTool() ? [getPowerShellTool()] : []),
+    ...(() => { const pst = getPowerShellTool(); return pst ? [pst] : [] })(),
     ...(SnipTool ? [SnipTool] : []),
     ...(process.env.NODE_ENV === 'test' ? [TestingPermissionTool] : []),
     ListMcpResourcesTool,
@@ -382,5 +382,5 @@ export function getMergedTools(
   mcpTools: Tools,
 ): Tools {
   const builtInTools = getTools(permissionContext)
-  return [...builtInTools, ...mcpTools]
+  return uniqBy([...builtInTools, ...mcpTools], 'name')
 }


### PR DESCRIPTION
## Summary

Fixes 5 bugs and adds 2 performance optimizations to existing code. No new features or tools.

## Bug Fixes

| File | Fix |
|------|-----|
| `src/tools.ts:214,217,230` | Cache lazy `require()` getter results to avoid double-invocation (`getSendMessageTool`, `getPowerShellTool`) |
| `src/tools.ts:380-386` | `getMergedTools()` now uses `uniqBy` to deduplicate, matching `assembleToolPool()` behavior |
| `src/services/api/openaiShim.ts:1471` | Error status defaults to 500 instead of 200 (`response.status || 500`) |
| `src/services/api/openaiShim.ts:236,238` | Redaction fallback returns `[redacted]` instead of unredacted URL when `redactSecretValueForDisplay` fails |
| `src/main.tsx:270` | Debugger detection writes error message to stderr before `process.exit(1)` |

## Optimizations

| File | Fix |
|------|-----|
| `src/query.ts:1734-1751` | Tool result lookup uses `Map<tool_use_id, result>` for O(N+M) instead of O(N×M×K) nested `find()` |
| `src/services/api/openaiShim.ts:2733` | Non-streaming path reads body once and recreates `Response` instead of `response.clone()` which doubles memory |
| `src/services/api/openaiShim.ts:2682` | Provider detection uses `new URL().hostname` parsing instead of fragile `baseUrl.includes()` substring matching |

## Testing

- Build passes: `bun run build` ✓
- Smoke test: `node dist/cli.mjs --version` → `0.15.0` ✓
