### PR TITLE
fix(security): SSRF validation, auth.json permission check, env var memory leak

### DIFF
--- a/src/services/api/providerConfig.ssrf.test.ts
+++ b/src/services/api/providerConfig.ssrf.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, test } from 'bun:test'
+import { resolveProviderRequest } from './providerConfig.js'
+
+describe('SSRF protection in resolveProviderRequest', () => {
+  test('blocks cloud metadata endpoint 169.254.169.254 and falls back to default', () => {
+    const result = resolveProviderRequest({
+      baseUrl: 'http://169.254.169.254/latest/meta-data/',
+    })
+    // Should NOT use the metadata URL — should fall back to a safe default
+    expect(result.baseUrl).not.toContain('169.254.169.254')
+    expect(result.baseUrl).toContain('api.openai.com')
+  })
+
+  test('blocks GCP metadata endpoint and falls back', () => {
+    const result = resolveProviderRequest({
+      baseUrl: 'http://metadata.google.internal/computeMetadata/v1/',
+    })
+    expect(result.baseUrl).not.toContain('metadata.google.internal')
+  })
+
+  test('blocks private IP 10.x.x.x and falls back', () => {
+    const result = resolveProviderRequest({
+      baseUrl: 'http://10.0.0.1:8080/v1',
+    })
+    expect(result.baseUrl).not.toContain('10.0.0.1')
+  })
+
+  test('blocks private IP 192.168.x.x and falls back', () => {
+    const result = resolveProviderRequest({
+      baseUrl: 'http://192.168.1.100:3000/v1',
+    })
+    expect(result.baseUrl).not.toContain('192.168.1.100')
+  })
+
+  test('allows localhost (for local providers like Ollama)', () => {
+    const result = resolveProviderRequest({
+      baseUrl: 'http://localhost:11434/v1',
+    })
+    expect(result.baseUrl).toContain('localhost:11434')
+  })
+
+  test('allows public URLs', () => {
+    const result = resolveProviderRequest({
+      baseUrl: 'https://api.example.com/v1',
+    })
+    expect(result.baseUrl).toContain('api.example.com')
+  })
+})

--- a/src/services/api/providerConfig.ts
+++ b/src/services/api/providerConfig.ts
@@ -1,4 +1,4 @@
-import { existsSync, readFileSync } from 'node:fs'
+import { existsSync, readFileSync, statSync } from 'node:fs'
 import { createHash } from 'node:crypto'
 import { isIP } from 'node:net'
 import { homedir } from 'node:os'
@@ -32,6 +32,19 @@ export const DEFAULT_OPENCODE_GO_BASE_URL = 'https://opencode.ai/zen/go/v1'
 /** Default GitHub Copilot API model when user selects copilot / github:copilot */
 export const DEFAULT_GITHUB_MODELS_API_MODEL = 'gpt-4o'
 const warnedUndefinedEnvNames = new Set<string>()
+// Clear periodically to prevent unbounded growth in long sessions
+let warnedEnvResetTimer: ReturnType<typeof setTimeout> | null = null
+function warnOnceUndefinedEnv(name: string): boolean {
+  if (warnedUndefinedEnvNames.has(name)) return false
+  warnedUndefinedEnvNames.add(name)
+  if (!warnedEnvResetTimer) {
+    warnedEnvResetTimer = setTimeout(() => {
+      warnedUndefinedEnvNames.clear()
+      warnedEnvResetTimer = null
+    }, 60_000)
+  }
+  return true
+}
 
 function normalizeGitlawbOpengatewayBaseUrl(baseUrl: string | undefined): string | undefined {
   if (!baseUrl) return undefined
@@ -200,8 +213,7 @@ function asNamedEnvUrl(
   if (!trimmed) return undefined
 
   if (trimmed === 'undefined') {
-    if (!warnedUndefinedEnvNames.has(envName)) {
-      warnedUndefinedEnvNames.add(envName)
+    if (warnOnceUndefinedEnv(envName)) {
       logForDebugging(
         `[provider-config] Environment variable ${envName} is the literal string "undefined"; ignoring it.`,
         { level: 'warn' },
@@ -609,6 +621,55 @@ export function getGithubEndpointType(
   }
 }
 
+/**
+ * Validates that a URL is not targeting internal/metadata endpoints (SSRF protection).
+ * Returns the URL if valid, or undefined if it targets a blocked internal host.
+ */
+function validateUrlNotSSRF(urlString: string): string | undefined {
+  try {
+    const parsed = new URL(urlString)
+    const hostname = parsed.hostname.toLowerCase()
+
+    // Block cloud metadata endpoints
+    const blockedHosts = [
+      '169.254.169.254',  // AWS/GCP/Azure metadata
+      'fd00:ec2::254',    // AWS IPv6 metadata
+      'metadata.google.internal',  // GCP metadata
+      'metadata.go.internal',      // GCP metadata alias
+    ]
+    if (blockedHosts.includes(hostname)) {
+      logForDebugging(
+        `[provider-config] Blocked SSRF attempt to internal host: ${hostname}`,
+        { level: 'warn' },
+      )
+      return undefined
+    }
+
+    // Block private/loopback IPs (except localhost for local providers)
+    if (hostname !== 'localhost' && hostname !== '127.0.0.1' && hostname !== '::1') {
+      const ipVersion = isIP(hostname)
+      if (ipVersion !== 0) {
+        // It's a raw IP address - check if it's private
+        const isPrivate = ipVersion === 4
+          ? /^(10\.|172\.(1[6-9]|2\d|3[01])\.|192\.168\.)/.test(hostname)
+          : hostname.startsWith('fc') || hostname.startsWith('fd')
+        if (isPrivate) {
+          logForDebugging(
+            `[provider-config] Blocked SSRF attempt to private IP: ${hostname}`,
+            { level: 'warn' },
+          )
+          return undefined
+        }
+      }
+    }
+
+    return urlString
+  } catch {
+    // If URL parsing fails, allow it through (will fail later with a clearer error)
+    return urlString
+  }
+}
+
 export function resolveProviderRequest(options?: {
   model?: string
   baseUrl?: string
@@ -695,6 +756,22 @@ export function resolveProviderRequest(options?: {
       : rawBaseUrl
   const finalBaseUrl = normalizeGitlawbOpengatewayBaseUrl(finalBaseUrlRaw)
 
+  // SSRF protection: reject user-configured URLs targeting internal/metadata endpoints.
+  // If the URL is blocked, fall back to the provider default so the request doesn't
+  // hit an internal service.
+  let safeBaseUrl = finalBaseUrl
+  if (finalBaseUrl) {
+    const validated = validateUrlNotSSRF(finalBaseUrl)
+    if (validated === undefined) {
+      // URL was blocked — fall back to the provider's default URL
+      safeBaseUrl = isMistralMode
+        ? DEFAULT_MISTRAL_BASE_URL
+        : isGeminiMode
+        ? DEFAULT_GEMINI_BASE_URL
+        : DEFAULT_OPENAI_BASE_URL
+    }
+  }
+
   const githubEndpointType = isGithubMode
     ? getGithubEndpointType(rawBaseUrl)
     : 'custom'
@@ -716,9 +793,9 @@ export function resolveProviderRequest(options?: {
     (() => {
       const runtimeShimContext = resolveOpenAIShimRuntimeContext({
         processEnv: process.env,
-        baseUrl: finalBaseUrl,
+        baseUrl: safeBaseUrl,
         model: descriptor.baseModel,
-        treatAsLocal: finalBaseUrl ? isLocalProviderUrl(finalBaseUrl) : false,
+        treatAsLocal: safeBaseUrl ? isLocalProviderUrl(safeBaseUrl) : false,
       })
 
       return openAIShimSupportsApiFormatForModel(
@@ -728,7 +805,7 @@ export function resolveProviderRequest(options?: {
       )
     })()
   const transport: ProviderTransport =
-    shouldUseCodexTransport(requestedModel, finalBaseUrl) ||
+    shouldUseCodexTransport(requestedModel, safeBaseUrl) ||
       (isGithubCopilot && shouldUseGithubResponsesApi(githubResolvedModel))
       ? 'codex_responses'
       : requestedApiFormat === 'responses' && supportsRequestedApiFormat
@@ -754,7 +831,7 @@ export function resolveProviderRequest(options?: {
     requestedModel,
     resolvedModel,
     baseUrl:
-      (finalBaseUrl ??
+      (safeBaseUrl ??
         (isGithubCopilot && transport === 'codex_responses'
           ? GITHUB_COPILOT_BASE_URL
           : (isGithubMode
@@ -815,6 +892,19 @@ function loadCodexAuthJson(
 ): Record<string, unknown> | undefined {
   if (!existsSync(authPath)) return undefined
   try {
+    // Warn if auth file has overly permissive permissions (world-readable)
+    try {
+      const stats = statSync(authPath)
+      const mode = stats.mode & 0o777
+      if (mode & 0o004) {
+        logForDebugging(
+          `[provider-config] Warning: ${authPath} is world-readable (mode ${mode.toString(8)}). Consider restricting permissions with: chmod 600 ${authPath}`,
+          { level: 'warn' },
+        )
+      }
+    } catch {
+      // Permission check is advisory only — don't block on stat failures
+    }
     const raw = readFileSync(authPath, 'utf8')
     const parsed = JSON.parse(raw)
     return parsed && typeof parsed === 'object'


### PR DESCRIPTION
## Summary

Security hardening for `providerConfig.ts` — SSRF protection, credential file permission checks, and memory leak fix. Includes focused tests.

## Changes

### SSRF validation (`providerConfig.ts:628-670`)
- `validateUrlNotSSRF()` blocks URLs targeting cloud metadata endpoints (`169.254.169.254`, `metadata.google.internal`, `fd00:ec2::254`) and private IPs (`10.x`, `172.16-31.x`, `192.168.x`)
- `resolveProviderRequest()` uses the validated URL — blocked URLs fall back to the provider's default URL instead of being passed through
- Localhost is explicitly allowed for local providers (Ollama, LM Studio)

### Auth.json permission check (`providerConfig.ts:829-840`)
- `loadCodexAuthJson()` checks file permissions via `statSync()` and logs a warning if the auth file is world-readable (`mode & 0o004`)
- Advisory only — does not block credential loading, just warns

### Memory leak fix (`providerConfig.ts:34-47`)
- `warnedUndefinedEnvNames` Set now clears periodically (every 60s) via `warnOnceUndefinedEnv()` helper to prevent unbounded growth in long sessions

## Tests

`providerConfig.ssrf.test.ts` — 6 tests:
- Blocks `169.254.169.254` metadata endpoint, falls back to default
- Blocks `metadata.google.internal`, falls back to default
- Blocks `10.x.x.x` private IP, falls back to default
- Blocks `192.168.x.x` private IP, falls back to default
- Allows `localhost:11434` (Ollama)
- Allows public URLs (`api.example.com`)
