### PR TITLE
fix: add error context to silent catches and debugger detection

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -225,6 +225,7 @@ function logManagedSettings(): void {
     }
   } catch {
     // Silently ignore errors - this is just for analytics
+    logForDebugging('[main] logManagedSettings failed', { level: 'debug' })
   }
 }
 
@@ -267,6 +268,7 @@ if ("external" !== 'ant' && isBeingDebugged()) {
   // Use process.exit directly here since we're in the top-level code before imports
   // and gracefulShutdown is not yet available
   // eslint-disable-next-line custom-rules/no-top-level-side-effects
+  process.stderr.write('[openclaude] Debugger detected. Attaching a debugger is not supported in external builds. Exiting.\n')
   process.exit(1);
 }
 
@@ -346,8 +348,12 @@ function runMigrations(): void {
     });
   }
   // Async migration - fire and forget since it's non-blocking
-  migrateChangelogFromConfig().catch(() => {
-    // Silently ignore migration errors - will retry on next startup
+  migrateChangelogFromConfig().catch(error => {
+    logError(
+      new Error('Changelog migration failed; will retry on next startup', {
+        cause: error,
+      }),
+    )
   });
 }
 
@@ -364,7 +370,7 @@ function prefetchSystemContextIfSafe(): void {
   // execution is considered trusted (as documented in help text)
   if (isNonInteractiveSession) {
     logForDiagnosticsNoPII('info', 'prefetch_system_context_non_interactive');
-    void getSystemContext();
+    void getSystemContext().catch(logError);
     return;
   }
 
@@ -372,7 +378,7 @@ function prefetchSystemContextIfSafe(): void {
   const hasTrust = checkHasTrustDialogAccepted();
   if (hasTrust) {
     logForDiagnosticsNoPII('info', 'prefetch_system_context_has_trust');
-    void getSystemContext();
+    void getSystemContext().catch(logError);
   } else {
     logForDiagnosticsNoPII('info', 'prefetch_system_context_skipped_no_trust');
   }
@@ -1904,7 +1910,7 @@ async function run(): Promise<CommanderCommand> {
       // a cache hit. The microtask from await getIsGit() drains at the
       // getCommands Promise.all await below. Trust is implicit in -p mode
       // (same gate as prefetchSystemContextIfSafe).
-      void getSystemContext();
+      void getSystemContext().catch(logError);
       // Kick getUserContext now too — its first await (fs.readFile in
       // getMemoryFiles) yields naturally, so the CLAUDE.md directory walk
       // runs during the ~280ms overlap window before the context

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -223,9 +223,9 @@ function logManagedSettings(): void {
         keys: allKeys.join(',') as unknown as AnalyticsMetadata_I_VERIFIED_THIS_IS_NOT_CODE_OR_FILEPATHS
       });
     }
-  } catch {
+  } catch (error) {
     // Silently ignore errors - this is just for analytics
-    logForDebugging('[main] logManagedSettings failed', { level: 'debug' })
+    logForDebugging(`[main] logManagedSettings failed: ${errorMessage(error)}`, { level: 'debug' })
   }
 }
 

--- a/src/utils/fileHistory.ts
+++ b/src/utils/fileHistory.ts
@@ -19,7 +19,6 @@ import {
 import { logEvent } from 'src/services/analytics/index.js'
 import { notifyVscodeFileUpdated } from 'src/services/mcp/vscodeSdkMcp.js'
 import type { LogOption } from 'src/types/logs.js'
-import { inspect } from 'util'
 import { getGlobalConfig } from './config.js'
 import { logForDebugging } from './debug.js'
 import { getClaudeConfigHomeDir, isEnvTruthy } from './envUtils.js'
@@ -166,7 +165,6 @@ export async function fileHistoryTrackEdit(
         })(),
         trackedFiles: updatedTrackedFiles,
       }
-      maybeDumpStateForDebug(updatedState)
 
       // Record a snapshot update since it has changed.
       void recordFileHistorySnapshot(
@@ -311,7 +309,6 @@ export async function fileHistoryMakeSnapshot(
             : allSnapshots,
         snapshotSequence: (state.snapshotSequence ?? 0) + 1,
       }
-      maybeDumpStateForDebug(updatedState)
 
       void notifyVscodeSnapshotFilesUpdated(state, updatedState).catch(logError)
 
@@ -1103,13 +1100,5 @@ async function readFileAsyncOrNull(path: string): Promise<string | null> {
     return await readFile(path, 'utf-8')
   } catch {
     return null
-  }
-}
-
-const ENABLE_DUMP_STATE = false
-function maybeDumpStateForDebug(state: FileHistoryState): void {
-  if (ENABLE_DUMP_STATE) {
-    // biome-ignore lint/suspicious/noConsole:: intentional console output
-    console.error(inspect(state, false, 5))
   }
 }

--- a/src/utils/worktree.ts
+++ b/src/utils/worktree.ts
@@ -1332,8 +1332,7 @@ export async function execIntoTmuxWorktree(args: string[]): Promise<{
       }
     }
     repoName = basename(findCanonicalGitRoot(getCwd()) ?? getCwd())
-    // biome-ignore lint/suspicious/noConsole: intentional console output
-    console.log(`Using worktree via hook: ${worktreeDir}`)
+    logForDebugging(`Using worktree via hook: ${worktreeDir}`)
   } else {
     // Get main git repo root (resolves through worktrees)
     const repoRoot = findCanonicalGitRoot(getCwd())
@@ -1355,8 +1354,7 @@ export async function execIntoTmuxWorktree(args: string[]): Promise<{
         prNumber !== null ? { prNumber } : undefined,
       )
       if (!result.existed) {
-        // biome-ignore lint/suspicious/noConsole: intentional console output
-        console.log(
+        logForDebugging(
           `Created worktree: ${worktreeDir} (based on ${result.baseBranch})`,
         )
         await performPostCreationSetup(repoRoot, worktreeDir)


### PR DESCRIPTION
Replace silent `catch` handlers and remove dead debug code so failures and stale instrumentation are no longer hidden.

**main.tsx**
- `migrateChangelogFromConfig().catch(() => {})` now logs the error via `logError` (with the original error as `cause`). Migration still retries on the next startup, but the failure is now visible.
- Debugger-detection branch now writes a stderr message before `process.exit(1)` so users see why the process exited.
- Silent catch block in `logManagedSettings` now calls `logForDebugging` instead of swallowing the error.
- Three `void getSystemContext()` calls now use `.catch(logError)` so git-hook/config failures are surfaced.

**src/utils/worktree.ts**
- Two diagnostic `console.log` call sites (`Using worktree via hook: ...` and `Created worktree: ... (based on ...)`) are converted to `logForDebugging`. They were diagnostic noise that polluted stdout in normal use; routing them through the debug log pipeline lets the matching `biome-ignore` comments go away.
- The iTerm2 tip `console.log` further down is intentionally user-facing guidance and is left untouched.

**src/utils/fileHistory.ts**
- Removed the dead `ENABLE_DUMP_STATE` flag (hard-coded to `false`) and its `maybeDumpStateForDebug` helper, both call sites in `fileHistoryTrackEdit` / `fileHistoryMakeSnapshot`, and the now-unused `inspect` import from `util`. State-dump debug output can be re-introduced with a real debug flag if it is ever needed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved startup error reporting and logging consistency so initialization failures are now surfaced and logged.
  * Removed optional debug state dumping functionality.
  * Updated logging output for worktree operations to use consistent debug-level logs.

* **Bug Fixes**
  * Ensured non-blocking startup tasks log failures instead of being silently ignored.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->