### PR TITLE
Add reasoned denial option to permission prompts

### DIFF
--- a/src/components/CustomSelect/select.tsx
+++ b/src/components/CustomSelect/select.tsx
@@ -169,6 +169,12 @@ export type SelectProps<T> = {
   readonly onInputModeToggle?: (value: T) => void;
 
   /**
+   * Callback when an input option is submitted while empty.
+   * If omitted, empty input submission falls back to onCancel.
+   */
+  readonly onEmptyInputSubmit?: (value: T) => void;
+
+  /**
    * Callback to open external editor for editing input option values.
    * When provided, ctrl+g will trigger this callback in input options
    * with the current value and a setter function to update the internal state.
@@ -191,7 +197,7 @@ export type SelectProps<T> = {
   readonly onRemoveImage?: (id: number) => void;
 };
 export function Select(t0) {
-  const $ = _c(72);
+  const $ = _c(73);
   const {
     isDisabled: t1,
     hideIndexes: t2,
@@ -209,6 +215,7 @@ export function Select(t0) {
     onUpFromFirstItem,
     onDownFromLastItem,
     onInputModeToggle,
+    onEmptyInputSubmit,
     onOpenEditor,
     onImagePaste,
     pastedContents,
@@ -351,7 +358,7 @@ export function Select(t0) {
   let t15;
   let t16;
   let t17;
-  if ($[28] !== hideIndexes || $[29] !== highlightText || $[30] !== imagesSelected || $[31] !== inlineDescriptions || $[32] !== inputValues || $[33] !== isDisabled || $[34] !== layout || $[35] !== onCancel || $[36] !== onChange || $[37] !== onImagePaste || $[38] !== onOpenEditor || $[39] !== onRemoveImage || $[40] !== options.length || $[41] !== pastedContents || $[42] !== selectedImageIndex || $[43] !== state.focusedValue || $[44] !== state.options || $[45] !== state.value || $[46] !== state.visibleFromIndex || $[47] !== state.visibleOptions || $[48] !== state.visibleToIndex) {
+  if ($[28] !== hideIndexes || $[29] !== highlightText || $[30] !== imagesSelected || $[31] !== inlineDescriptions || $[32] !== inputValues || $[33] !== isDisabled || $[34] !== layout || $[35] !== onCancel || $[36] !== onChange || $[37] !== onImagePaste || $[38] !== onOpenEditor || $[39] !== onRemoveImage || $[40] !== options.length || $[41] !== pastedContents || $[42] !== selectedImageIndex || $[43] !== state.focusedValue || $[44] !== state.options || $[45] !== state.value || $[46] !== state.visibleFromIndex || $[47] !== state.visibleOptions || $[48] !== state.visibleToIndex || $[72] !== onEmptyInputSubmit) {
     t17 = Symbol.for("react.early_return_sentinel");
     bb0: {
       const styles = {
@@ -388,6 +395,8 @@ export function Select(t0) {
                 const hasImageAttachments = pastedContents && Object.values(pastedContents).some(_temp5);
                 if (value_0.trim() || hasImageAttachments || option_1.allowEmptySubmitToCancel) {
                   onChange?.(option_1.value);
+                } else if (onEmptyInputSubmit) {
+                  onEmptyInputSubmit(option_1.value);
                 } else {
                   onCancel?.();
                 }
@@ -436,6 +445,8 @@ export function Select(t0) {
                 const hasImageAttachments_0 = pastedContents && Object.values(pastedContents).some(_temp6);
                 if (value_2.trim() || hasImageAttachments_0 || option_2.allowEmptySubmitToCancel) {
                   onChange?.(option_2.value);
+                } else if (onEmptyInputSubmit) {
+                  onEmptyInputSubmit(option_2.value);
                 } else {
                   onCancel?.();
                 }
@@ -556,6 +567,8 @@ export function Select(t0) {
             const hasImageAttachments_1 = pastedContents && Object.values(pastedContents).some(_temp9);
             if (value_4.trim() || hasImageAttachments_1 || option_4.allowEmptySubmitToCancel) {
               onChange?.(option_4.value);
+            } else if (onEmptyInputSubmit) {
+              onEmptyInputSubmit(option_4.value);
             } else {
               onCancel?.();
             }
@@ -600,6 +613,7 @@ export function Select(t0) {
     $[46] = state.visibleFromIndex;
     $[47] = state.visibleOptions;
     $[48] = state.visibleToIndex;
+    $[72] = onEmptyInputSubmit;
     $[49] = T0;
     $[50] = t15;
     $[51] = t16;

--- a/src/components/ShowInIDEPrompt.tsx
+++ b/src/components/ShowInIDEPrompt.tsx
@@ -23,7 +23,7 @@ type Props<A> = {
   noInputMode: boolean;
 };
 export function ShowInIDEPrompt(t0) {
-  const $ = _c(36);
+  const $ = _c(37);
   const {
     onChange,
     options,
@@ -79,12 +79,15 @@ export function ShowInIDEPrompt(t0) {
     t5 = $[8];
   }
   let t6;
-  if ($[9] !== acceptFeedback || $[10] !== input || $[11] !== onChange || $[12] !== options || $[13] !== rejectFeedback) {
+  if ($[9] !== acceptFeedback || $[10] !== input || $[11] !== onChange || $[12] !== options || $[13] !== rejectFeedback || $[36] !== noInputMode) {
     t6 = value => {
       const selected = options.find(opt => opt.value === value);
       if (selected) {
         if (selected.option.type === "reject") {
-          const trimmedFeedback = rejectFeedback.trim();
+          const trimmedFeedback = selected.option.withReason || noInputMode ? rejectFeedback.trim() : "";
+          if (selected.option.withReason && !trimmedFeedback) {
+            return;
+          }
           onChange(selected.option, input, trimmedFeedback || undefined);
           return;
         }
@@ -101,6 +104,7 @@ export function ShowInIDEPrompt(t0) {
     $[11] = onChange;
     $[12] = options;
     $[13] = rejectFeedback;
+    $[36] = noInputMode;
     $[14] = t6;
   } else {
     t6 = $[14];
@@ -126,7 +130,11 @@ export function ShowInIDEPrompt(t0) {
   }
   let t9;
   if ($[20] !== onInputModeToggle || $[21] !== options || $[22] !== t6 || $[23] !== t7 || $[24] !== t8) {
-    t9 = <Select options={options} inlineDescriptions={true} onChange={t6} onCancel={t7} onFocus={t8} onInputModeToggle={onInputModeToggle} />;
+    t9 = <Select options={options} inlineDescriptions={true} onChange={t6} onCancel={t7} onFocus={t8} onInputModeToggle={onInputModeToggle} onEmptyInputSubmit={value_1 => {
+      if (value_1 !== "no-with-reason") {
+        t7();
+      }
+    }} />;
     $[20] = onInputModeToggle;
     $[21] = options;
     $[22] = t6;

--- a/src/components/permissions/BashPermissionRequest/BashPermissionRequest.tsx
+++ b/src/components/permissions/BashPermissionRequest/BashPermissionRequest.tsx
@@ -292,7 +292,8 @@ function BashPermissionRequestInner({
       'yes-apply-suggestions': 2,
       'yes-prefix-edited': 2,
       'yes-full-access': 3,
-      no: 4,
+      'no-with-reason': 4,
+      no: 5,
     }
     logEvent('tengu_permission_request_option_selected', {
       option_index: optionIndex[value],
@@ -313,6 +314,7 @@ function BashPermissionRequestInner({
       rejectFeedback,
       yesFeedbackModeEntered,
       noFeedbackModeEntered,
+      noInputMode,
       editablePrefix,
       ruleToolName: BashTool.name,
       toolAnalyticsName: toolNameForAnalytics,

--- a/src/components/permissions/FilePermissionDialog/FilePermissionDialog.tsx
+++ b/src/components/permissions/FilePermissionDialog/FilePermissionDialog.tsx
@@ -190,7 +190,10 @@ export function FilePermissionDialog<T extends ToolInput = ToolInput>({
           if (selected) {
             // For reject option
             if (selected.option.type === 'reject') {
-              const trimmedFeedback = rejectFeedback.trim();
+              const trimmedFeedback = selected.option.withReason || noInputMode ? rejectFeedback.trim() : '';
+              if (selected.option.withReason && !trimmedFeedback) {
+                return;
+              }
               onChange(selected.option, trimmedFeedback || undefined);
               return;
             }
@@ -204,7 +207,13 @@ export function FilePermissionDialog<T extends ToolInput = ToolInput>({
           }
         }} onCancel={() => onChange({
           type: 'reject'
-        })} onFocus={value_0 => setFocusedOption(value_0)} onInputModeToggle={handleInputModeToggle} />
+        })} onFocus={value_0 => setFocusedOption(value_0)} onInputModeToggle={handleInputModeToggle} onEmptyInputSubmit={value_1 => {
+          if (value_1 !== 'no-with-reason') {
+            onChange({
+              type: 'reject'
+            });
+          }
+        }} />
         </Box>
       </PermissionScaffold>
       <Box paddingX={1} marginTop={1}>

--- a/src/components/permissions/FilePermissionDialog/permissionOptions.tsx
+++ b/src/components/permissions/FilePermissionDialog/permissionOptions.tsx
@@ -52,6 +52,7 @@ export type PermissionOption = {
   type: 'accept-full-access';
 } | {
   type: 'reject';
+  withReason?: boolean;
 };
 export type PermissionOptionWithLabel = OptionWithDescription<string> & {
   option: PermissionOption;
@@ -166,7 +167,19 @@ export function getFilePermissionOptions({
     });
   }
 
-  // When in input mode, show input field for reject
+  options.push({
+    type: 'input',
+    label: 'No, provide reason',
+    value: 'no-with-reason',
+    placeholder: `tell ${PRODUCT_DISPLAY_NAME} what to do differently`,
+    onChange: onRejectFeedbackChange,
+    option: {
+      type: 'reject',
+      withReason: true
+    }
+  });
+
+  // When in input mode, keep supporting the existing Tab-to-amend flow.
   if (noInputMode && onRejectFeedbackChange) {
     options.push({
       type: 'input',
@@ -180,7 +193,6 @@ export function getFilePermissionOptions({
       }
     });
   } else {
-    // Not in input mode - simple option
     options.push({
       label: 'No',
       value: 'no',

--- a/src/components/permissions/FilePermissionDialog/permissionOptions.tsx
+++ b/src/components/permissions/FilePermissionDialog/permissionOptions.tsx
@@ -70,7 +70,7 @@ export function getFilePermissionOptions({
   filePath: string;
   toolPermissionContext: ToolPermissionContext;
   operationType?: FileOperationType;
-  onRejectFeedbackChange?: (value: string) => void;
+  onRejectFeedbackChange: (value: string) => void;
   onAcceptFeedbackChange?: (value: string) => void;
   yesInputMode?: boolean;
   noInputMode?: boolean;

--- a/src/components/permissions/FilePermissionDialog/useFilePermissionDialog.ts
+++ b/src/components/permissions/FilePermissionDialog/useFilePermissionDialog.ts
@@ -145,7 +145,14 @@ export function useFilePermissionDialog<T extends ToolInput>({
       if (value !== 'yes' && yesInputMode && !acceptFeedback.trim()) {
         setYesInputMode(false)
       }
-      if (value !== 'no' && noInputMode && !rejectFeedback.trim()) {
+      if (value === 'no-with-reason' && noInputMode) {
+        setNoInputMode(false)
+      }
+      if (
+        value !== 'no' &&
+        noInputMode &&
+        !rejectFeedback.trim()
+      ) {
         setNoInputMode(false)
       }
       setFocusedOption(value)

--- a/src/components/permissions/PowerShellPermissionRequest/PowerShellPermissionRequest.tsx
+++ b/src/components/permissions/PowerShellPermissionRequest/PowerShellPermissionRequest.tsx
@@ -131,7 +131,8 @@ export function PowerShellPermissionRequest(
       'yes-apply-suggestions': 2,
       'yes-prefix-edited': 2,
       'yes-full-access': 3,
-      no: 4,
+      'no-with-reason': 4,
+      no: 5,
     }
     logEvent('tengu_permission_request_option_selected', {
       option_index: optionIndex[value],
@@ -151,6 +152,7 @@ export function PowerShellPermissionRequest(
       rejectFeedback,
       yesFeedbackModeEntered,
       noFeedbackModeEntered,
+      noInputMode,
       editablePrefix,
       ruleToolName: PowerShellTool.name,
       toolAnalyticsName: toolNameForAnalytics,

--- a/src/components/permissions/SharedShellPermissionRequest.tsx
+++ b/src/components/permissions/SharedShellPermissionRequest.tsx
@@ -136,6 +136,11 @@ export function SharedShellPermissionRequest<T extends string>({
               onCancel={onCancel}
               onFocus={onFocus}
               onInputModeToggle={onInputModeToggle}
+              onEmptyInputSubmit={value => {
+                if (value !== 'no-with-reason') {
+                  onCancel()
+                }
+              }}
             />
           </Box>
           <Box justifyContent="space-between" marginTop={1}>

--- a/src/components/permissions/baseShellToolUseOptions.tsx
+++ b/src/components/permissions/baseShellToolUseOptions.tsx
@@ -18,6 +18,7 @@ export type BaseShellToolUseOption =
   | 'yes-apply-suggestions'
   | 'yes-prefix-edited'
   | 'yes-full-access'
+  | 'no-with-reason'
   | 'no'
 
 function commandListDisplay(commands: string[]): ReactNode {
@@ -293,6 +294,14 @@ export function buildBaseShellToolUseOptions<T extends string>({
     }
   }
 
+  options.push({
+    type: 'input',
+    label: 'No, provide reason',
+    value: 'no-with-reason' as T,
+    placeholder: 'tell Claude what to do differently',
+    onChange: onRejectFeedbackChange,
+  })
+
   if (noInputMode) {
     options.push({
       type: 'input',
@@ -321,6 +330,7 @@ export function handleBaseShellSelection({
   rejectFeedback,
   yesFeedbackModeEntered,
   noFeedbackModeEntered,
+  noInputMode,
   editablePrefix,
   ruleToolName,
   toolAnalyticsName,
@@ -334,6 +344,7 @@ export function handleBaseShellSelection({
   rejectFeedback: string
   yesFeedbackModeEntered: boolean
   noFeedbackModeEntered: boolean
+  noInputMode: boolean
   editablePrefix?: string
   ruleToolName: string
   toolAnalyticsName: AnalyticsMetadata_I_VERIFIED_THIS_IS_NOT_CODE_OR_FILEPATHS
@@ -408,8 +419,23 @@ export function handleBaseShellSelection({
       onDone()
       return
     }
-    case 'no': {
+    case 'no-with-reason': {
       const trimmedFeedback = rejectFeedback.trim()
+      if (!trimmedFeedback) {
+        return
+      }
+      logEvent('tengu_reject_submitted', {
+        toolName: toolAnalyticsName,
+        isMcp: toolUseConfirm.tool.isMcp ?? false,
+        has_instructions: !!trimmedFeedback,
+        instructions_length: trimmedFeedback.length,
+        entered_feedback_mode: true,
+      })
+      onReject(trimmedFeedback || undefined)
+      return
+    }
+    case 'no': {
+      const trimmedFeedback = noInputMode ? rejectFeedback.trim() : ''
       logEvent('tengu_reject_submitted', {
         toolName: toolAnalyticsName,
         isMcp: toolUseConfirm.tool.isMcp ?? false,

--- a/src/components/permissions/useShellPermissionFeedback.ts
+++ b/src/components/permissions/useShellPermissionFeedback.ts
@@ -125,7 +125,14 @@ export function useShellPermissionFeedback({
     if (value !== 'yes' && yesInputMode && !acceptFeedback.trim()) {
       setYesInputMode(false)
     }
-    if (value !== 'no' && noInputMode && !rejectFeedback.trim()) {
+    if (value === 'no-with-reason' && noInputMode) {
+      setNoInputMode(false)
+    }
+    if (
+      value !== 'no' &&
+      noInputMode &&
+      !rejectFeedback.trim()
+    ) {
       setNoInputMode(false)
     }
     setFocusedOption(value)

--- a/src/utils/attribution.test.ts
+++ b/src/utils/attribution.test.ts
@@ -8,6 +8,7 @@ import {
 } from '../bootstrap/state.js'
 import * as actualModel from './model/model.js'
 import * as actualProviders from './model/providers.js'
+import * as actualSettings from './settings/settings.js'
 import {
   resetSettingsCache,
   setSessionSettingsCache,
@@ -24,6 +25,7 @@ let getDefaultCommitCoAuthorName: (typeof import('./attribution.js'))[
 let getEnhancedPRAttribution: (typeof import('./attribution.js'))[
   'getEnhancedPRAttribution'
 ]
+let testSettings: SettingsJson = {}
 
 const originalEnv = {
   CLAUDE_CODE_USE_OPENAI: process.env.CLAUDE_CODE_USE_OPENAI,
@@ -71,6 +73,7 @@ const defaultPrAttribution =
   '🤖 Generated with [OpenClaude](https://github.com/Gitlawb/openclaude)'
 
 function useSettings(settings: SettingsJson): void {
+  testSettings = settings
   setSessionSettingsCache({ settings, errors: [] })
 }
 
@@ -88,6 +91,7 @@ beforeEach(async () => {
   mock.restore()
   resetStateForTests()
   resetSettingsCache()
+  testSettings = {}
   setClientType('cli')
   setMainLoopModelOverride(undefined)
   delete process.env.CLAUDE_CODE_USE_GEMINI
@@ -131,6 +135,11 @@ beforeEach(async () => {
     ...actualProviders,
     getAPIProvider: () => 'openai',
   }))
+  mock.module('./settings/settings.js', () => ({
+    ...actualSettings,
+    getInitialSettings: () => testSettings,
+    getSettings_DEPRECATED: () => testSettings,
+  }))
 
   const attribution = await import(
     `./attribution.ts?attributionTest=${Date.now()}-${Math.random()}`
@@ -149,6 +158,7 @@ afterEach(() => {
   setMainLoopModelOverride(originalMainLoopModelOverride)
   mock.module('./model/model.js', () => actualModel)
   mock.module('./model/providers.js', () => actualProviders)
+  mock.module('./settings/settings.js', () => actualSettings)
   restoreEnv()
 })
 


### PR DESCRIPTION
## Summary
- Add an explicit `No, provide reason` option to file edit and IDE diff permission prompts.
- Add the same reasoned denial path to Bash and PowerShell permission prompts.
- Require non-empty feedback for the explicit reason option, while preserving the existing Tab-amended `No` feedback flow.
- Extend the shared select component so callers can intercept empty input submissions without accidentally cancelling or rejecting.
- Stabilize the attribution settings test so CI's nonced attribution import reads the intended test settings consistently.

Fixes #1468

## Validation
- `bun install` - passed, no dependency changes.
- `bun run build` - passed.
- `bun run smoke` - passed, printed `0.16.1 (OpenClaude)`.
- `bun test src/utils/attribution.test.ts --max-concurrency=1` - passed locally.
- GitHub Actions `smoke-and-tests` - passed.
- GitHub Actions `web` - passed.

## Notes
A local Windows `bun run check` still hits unrelated order-sensitive failures in this workspace, but the Linux CI suite for this PR is green after the attribution test isolation fix.
