### PR TITLE
fix(color-diff): guard FILENAME_LANGS lookup against prototype-property keys

### DIFF
--- a/src/native-ts/color-diff/index.test.ts
+++ b/src/native-ts/color-diff/index.test.ts
@@ -1,0 +1,18 @@
+import { expect, test } from 'bun:test'
+import { __test } from './index.js'
+
+const { detectLanguage } = __test
+
+test('detectLanguage returns css for constructor.css (no prototype-chain crash)', () => {
+  expect(detectLanguage('constructor.css', 'body {}')).toBe('css')
+})
+
+test('detectLanguage returns js for toString.js (no prototype-chain crash)', () => {
+  expect(detectLanguage('toString.js', 'console.log()')).toBe('js')
+})
+
+test('detectLanguage returns correct lang for normal filenames', () => {
+  expect(detectLanguage('app.ts', 'const x = 1')).toBe('ts')
+  expect(detectLanguage('Dockerfile', 'FROM node:20')).toBe('dockerfile')
+  expect(detectLanguage('Makefile', 'all: build')).toBe('makefile')
+})

--- a/src/native-ts/color-diff/index.ts
+++ b/src/native-ts/color-diff/index.ts
@@ -428,7 +428,10 @@ function detectLanguage(
 
   // Filename-based lookup (handles Dockerfile, Makefile, CMakeLists.txt, etc.)
   const stem = base.split('.')[0] ?? ''
-  const byName = FILENAME_LANGS[base] ?? FILENAME_LANGS[stem]
+  // Guard against prototype-property keys (e.g. "constructor", "toString")
+  // when the filename or stem matches a built-in Object.prototype name.
+  const byName = (Object.hasOwn(FILENAME_LANGS, base) ? FILENAME_LANGS[base] : undefined)
+    ?? (Object.hasOwn(FILENAME_LANGS, stem) ? FILENAME_LANGS[stem] : undefined)
   if (byName && hljs().getLanguage(byName)) return byName
   if (ext) {
     const lang = hljs().getLanguage(ext)


### PR DESCRIPTION
## Summary
- Fixes a crash in `detectLanguage` when a filename or its stem matches an `Object.prototype` property name (e.g. `constructor.css`, `toString.js`)
- The `FILENAME_LANGS` lookup object inherits prototype properties, so `FILENAME_LANGS["constructor"]` returns the `Object` constructor function instead of `undefined`
- Passing that function to `hljs().getLanguage()` triggers `toLowerCase is not a function`
- Fix: guard both lookups with `Object.hasOwn()` so only own keys match

## Test plan
- [x] Added unit tests for `constructor.css`, `toString.js`, and normal filenames (Dockerfile, Makefile, `.ts`)
- [x] `bun test src/native-ts/color-diff/index.test.ts` — 3 pass, 0 fail
- [x] `tsc --noEmit` — clean

Fixes #1430