### PR TITLE
feat: Make Gitlawb OpenGateway the fresh-install default provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ Advanced and source-build guides:
 | GitHub Models | `/onboard-github` | Interactive onboarding with saved credentials |
 | Codex OAuth | `/provider` | Opens ChatGPT sign-in in your browser and stores Codex credentials securely |
 | Codex | `/provider` | Uses existing Codex CLI auth, OpenClaude secure storage, or env credentials |
-| Gitlawb Opengateway | `/provider` or zero-config fallback | Free smart gateway at `https://opengateway.gitlawb.com/v1`; routes Xiaomi MiMo and GMI Cloud partner models by `OPENAI_MODEL` |
+| Gitlawb Opengateway | Startup default, `/provider`, or env vars | Smart gateway at `https://opengateway.gitlawb.com/v1`; requires an API key from https://gitlawb.com/opengateway/keys and routes Xiaomi MiMo and GMI Cloud partner models by `OPENAI_MODEL` |
 | OpenCode Zen | `/provider` or env vars | Pay-as-you-go AI gateway (41 models); uses `OPENCODE_API_KEY` via `https://opencode.ai/zen/v1`; shared key with OpenCode Go |
 | OpenCode Go | `/provider` or env vars | $10/mo subscription for open models (12 models); uses `OPENCODE_API_KEY` via `https://opencode.ai/zen/go/v1`; shared key with OpenCode Zen |
 | Xiaomi MiMo | `/provider` or env vars | OpenAI-compatible API at `https://mimo.mi.com`; uses `MIMO_API_KEY` and defaults to `mimo-v2.5-pro` |
@@ -186,7 +186,7 @@ OpenClaude supports multiple providers, but behavior is not identical across all
 - Tool quality depends heavily on the selected model
 - Smaller local models can struggle with long multi-step tool flows
 - Some providers impose lower output caps than the CLI defaults, and OpenClaude adapts where possible
-- Gitlawb Opengateway uses one OpenAI-compatible base URL. Switch between `mimo-*` and `google/gemini-3.1-flash-lite-preview` with `/model`; do not pin the base URL to `/v1/xiaomi-mimo`.
+- Gitlawb Opengateway is the fresh-install startup default and requires an API key from https://gitlawb.com/opengateway/keys. It uses one OpenAI-compatible base URL; switch between `mimo-*` and `google/gemini-3.1-flash-lite-preview` with `/model`, and do not pin the base URL to `/v1/xiaomi-mimo`.
 - Xiaomi MiMo uses `api-key` header auth on the direct OpenAI-compatible route and currently does not support `/usage` reporting in OpenClaude
 
 For best results, use models with strong tool/function calling support.

--- a/docs/advanced-setup.md
+++ b/docs/advanced-setup.md
@@ -217,12 +217,13 @@ MiMo, MiniMax, Qwen). Uses the same `OPENCODE_API_KEY` as OpenCode Zen.
 ```bash
 export CLAUDE_CODE_USE_OPENAI=1
 export OPENAI_BASE_URL=https://opengateway.gitlawb.com/v1
-export OPENAI_API_KEY=anything
+export OPENGATEWAY_API_KEY=ogw_live_...
 export OPENAI_MODEL=mimo-v2.5-pro
 ```
 
-The Opengateway route is a smart gateway. Keep the base URL at `/v1` and switch
-models with `/model` or `OPENAI_MODEL`. Current partner models include:
+The Opengateway route is the fresh-install startup default and requires an API
+key from https://gitlawb.com/opengateway/keys. Keep the base URL at `/v1` and
+switch models with `/model` or `OPENAI_MODEL`. Current partner models include:
 
 - `mimo-v2.5-pro`
 - `google/gemini-3.1-flash-lite-preview`

--- a/scripts/start-grpc.ts
+++ b/scripts/start-grpc.ts
@@ -24,12 +24,16 @@ async function main() {
   const { hydrateGithubModelsTokenFromSecureStorage } = await import('../src/utils/githubModelsCredentials.js')
   hydrateGithubModelsTokenFromSecureStorage()
 
-  const { buildStartupEnvFromProfile, applyProfileEnvToProcessEnv } = await import('../src/utils/providerProfile.js')
+  const {
+    buildStartupEnvFromProfile,
+    applyProfileEnvToProcessEnv,
+    isDefaultStartupProviderEnv,
+  } = await import('../src/utils/providerProfile.js')
   const { getProviderValidationError, validateProviderEnvOrExit } = await import('../src/utils/providerValidation.js')
   const startupEnv = await buildStartupEnvFromProfile({ processEnv: process.env })
   if (startupEnv !== process.env) {
     const startupProfileError = await getProviderValidationError(startupEnv)
-    if (startupProfileError) {
+    if (startupProfileError && !isDefaultStartupProviderEnv(startupEnv)) {
       console.warn(`Warning: ignoring saved provider profile. ${startupProfileError}`)
     } else {
       applyProfileEnvToProcessEnv(process.env, startupEnv)

--- a/src/components/ProviderManager.tsx
+++ b/src/components/ProviderManager.tsx
@@ -236,6 +236,15 @@ function toDraft(profile: ProviderProfile): ProviderDraft {
 
 function getPresetLabel(preset: ProviderPreset, label: string, metadata?: { badge?: { text: string; color?: string } }): React.ReactNode {
   if (metadata?.badge) {
+    if (metadata.badge.text.toLowerCase() === 'recommended') {
+      return (
+        <Text>
+          <Text>{label} </Text>
+          <Text color={metadata.badge.color ?? 'success'} bold>★ Recommended</Text>
+        </Text>
+      )
+    }
+
     return (
       <Text>
         <Text>{label} </Text>

--- a/src/entrypoints/cli.tsx
+++ b/src/entrypoints/cli.tsx
@@ -2,6 +2,7 @@ import { feature } from 'bun:bundle';
 import {
   applyProfileEnvToProcessEnv,
   buildStartupEnvFromProfile,
+  isDefaultStartupProviderEnv,
 } from '../utils/providerProfile.js'
 import {
   getProviderValidationError,
@@ -124,7 +125,7 @@ async function main(): Promise<void> {
   })
   if (startupEnv !== process.env) {
     const startupProfileError = await getProviderValidationError(startupEnv)
-    if (startupProfileError) {
+    if (startupProfileError && !isDefaultStartupProviderEnv(startupEnv)) {
       console.error(
         `Warning: ignoring saved provider profile. ${startupProfileError}`,
       )

--- a/src/integrations/artifactGenerator.ts
+++ b/src/integrations/artifactGenerator.ts
@@ -233,9 +233,8 @@ function compareProviderPresetEntries(
     return 0
   }
 
-  // Pin Gitlawb Opengateway first — the free zero-config default
-  // (Xiaomi partnership). Surfaces ahead of anthropic so users without
-  // their own provider credentials hit the working option immediately.
+  // Pin Gitlawb Opengateway first so the startup-default provider is also
+  // the first guided setup option when users need to add an API key.
   if (leftPreset === 'gitlawb-opengateway') {
     return -1
   }

--- a/src/integrations/gateways/gitlawb-opengateway.ts
+++ b/src/integrations/gateways/gitlawb-opengateway.ts
@@ -43,7 +43,7 @@ export default defineGateway({
   },
   preset: {
     id: 'gitlawb-opengateway',
-    description: 'Gitlawb Opengateway — free hosted Xiaomi MiMo + GMI Cloud partner models (API key required, mint at https://gitlawb.com/opengateway/keys)',
+    description: 'Gitlawb Opengateway - (API key required, signup at https://gitlawb.com/opengateway/keys)',
     apiKeyEnvVars: ['OPENGATEWAY_API_KEY'],
     label: 'Gitlawb Opengateway',
     name: 'Gitlawb Opengateway',
@@ -52,7 +52,7 @@ export default defineGateway({
     baseUrlEnvVars: ['OPENGATEWAY_BASE_URL', 'OPENAI_BASE_URL'],
     fallbackBaseUrl: 'https://opengateway.gitlawb.com/v1',
     fallbackModel: 'mimo-v2.5-pro',
-    badge: { text: 'FREE', color: 'success' },
+    badge: { text: 'Recommended', color: 'success' },
   },
   catalog: {
     source: 'static',

--- a/src/integrations/generated/integrationArtifacts.generated.ts
+++ b/src/integrations/generated/integrationArtifacts.generated.ts
@@ -77,7 +77,7 @@ export const PROVIDER_PRESET_MANIFEST = [
     "routeId": "gitlawb-opengateway",
     "vendorId": "openai",
     "gatewayId": "gitlawb-opengateway",
-    "description": "Gitlawb Opengateway — free hosted Xiaomi MiMo + GMI Cloud partner models (API key required, mint at https://gitlawb.com/opengateway/keys)",
+    "description": "Gitlawb Opengateway - (API key required, signup at https://gitlawb.com/opengateway/keys)",
     "label": "Gitlawb Opengateway",
     "name": "Gitlawb Opengateway",
     "apiKeyEnvVars": [
@@ -93,7 +93,7 @@ export const PROVIDER_PRESET_MANIFEST = [
     "fallbackBaseUrl": "https://opengateway.gitlawb.com/v1",
     "fallbackModel": "mimo-v2.5-pro",
     "badge": {
-      "text": "FREE",
+      "text": "Recommended",
       "color": "success"
     }
   },

--- a/src/utils/providerAutoDetect.ts
+++ b/src/utils/providerAutoDetect.ts
@@ -292,9 +292,9 @@ function normalizeOpengatewayBaseUrl(baseUrl: string): string {
 }
 
 /**
- * Fallback: the Gitlawb Opengateway exposes free partner inference through a
+ * Fallback: the Gitlawb Opengateway exposes partner inference through a
  * smart OpenAI-compatible route. As of 2026-05-22 it requires a per-user API
- * key (mint at https://gitlawb.com/opengateway/keys); without a key we return
+ * key (signup at https://gitlawb.com/opengateway/keys); without a key we return
  * null so the caller surfaces the missing-credential prompt instead of
  * silently routing to an endpoint that will 401.
  */
@@ -310,7 +310,7 @@ function defaultOpengatewayProvider(env: EnvLike): DetectedProvider | null {
   return {
     kind: 'gitlawb-opengateway',
     source:
-      'Gitlawb Opengateway (free partner models — API key required, mint at https://gitlawb.com/opengateway/keys)',
+      'Gitlawb Opengateway (API key required, signup at https://gitlawb.com/opengateway/keys)',
     baseUrl: normalizeOpengatewayBaseUrl(baseUrl),
     model: OPENGATEWAY_DEFAULT_MODEL,
   }

--- a/src/utils/providerProfile.test.ts
+++ b/src/utils/providerProfile.test.ts
@@ -19,6 +19,7 @@ import {
   createProfileFile,
   deleteProfileFile,
   getDefaultProfileFilePath,
+  isDefaultStartupProviderEnv,
   isPersistedCodexOAuthProfile,
   maskSecretForDisplay,
   loadProfileFile,
@@ -239,6 +240,18 @@ test('openai launch ignores codex persisted transport hints', async () => {
   assert.equal(env.OPENAI_BASE_URL, 'https://api.openai.com/v1')
   assert.equal(env.OPENAI_MODEL, 'gpt-5.5')
   assert.equal(env.OPENAI_API_KEY, 'sk-live')
+})
+
+test('buildStartupEnvFromProfile defaults fresh installs to Gitlawb Opengateway', async () => {
+  const env = await buildStartupEnvFromProfile({
+    persisted: null,
+    processEnv: {},
+  })
+
+  assert.equal(env.CLAUDE_CODE_USE_OPENAI, '1')
+  assert.equal(env.OPENAI_BASE_URL, 'https://opengateway.gitlawb.com/v1')
+  assert.equal(env.OPENAI_MODEL, 'mimo-v2.5-pro')
+  assert.equal(isDefaultStartupProviderEnv(env), true)
 })
 
 test('openai launch preserves shell responses format and custom auth overrides', async () => {

--- a/src/utils/providerProfile.ts
+++ b/src/utils/providerProfile.ts
@@ -46,6 +46,8 @@ export const DEFAULT_GEMINI_BASE_URL =
 export const DEFAULT_GEMINI_MODEL = 'gemini-3-flash-preview'
 export const DEFAULT_MISTRAL_BASE_URL = 'https://api.mistral.ai/v1'
 export const DEFAULT_MISTRAL_MODEL = 'mistral-vibe-cli-latest'
+export const DEFAULT_STARTUP_PROVIDER_ENV_VAR =
+  'CLAUDE_CODE_DEFAULT_STARTUP_PROVIDER'
 
 const PROFILE_ENV_KEYS = [
   'CLAUDE_CODE_USE_OPENAI',
@@ -96,6 +98,7 @@ const PROFILE_ENV_KEYS = [
   'VENICE_API_KEY',
   'MIMO_API_KEY',
   'OPENCODE_API_KEY',
+  DEFAULT_STARTUP_PROVIDER_ENV_VAR,
 ] as const
 
 export type CompatibilityProfileMode =
@@ -877,6 +880,10 @@ export function buildCompatibilityProcessEnv(options: {
   return env
 }
 
+export function isDefaultStartupProviderEnv(env: NodeJS.ProcessEnv): boolean {
+  return env[DEFAULT_STARTUP_PROVIDER_ENV_VAR] === 'gitlawb-opengateway'
+}
+
 export function buildCodexOAuthProfileEnv(
   tokens: {
     accessToken: string
@@ -1592,7 +1599,8 @@ export async function buildStartupEnvFromProfile(options?: {
   readGeminiAccessToken?: () => string | undefined
 }): Promise<NodeJS.ProcessEnv> {
   const processEnv = options?.processEnv ?? process.env
-  const persisted = options?.persisted ?? loadProfileFile()
+  const persisted =
+    options && 'persisted' in options ? options.persisted : loadProfileFile()
 
   const profileManagedEnv = processEnv.CLAUDE_CODE_PROVIDER_PROFILE_ENV_APPLIED === '1'
   const hasConfiguredProviderProfile =
@@ -1631,26 +1639,20 @@ export async function buildStartupEnvFromProfile(options?: {
   }
 
   if (!persisted) {
-    // No saved profile — default to Codex OAuth / GPT 5.5.
-    // If Codex credentials are available (OAuth or existing), use Codex.
-    // Otherwise inject the Codex env defaults so the provider picker
-    // shows GPT 5.5 as the default model when the user lands on it.
-    const codexEnv = buildCodexProfileEnv({})
-    if (codexEnv) {
-      return buildCompatibilityProcessEnv({
-        processEnv,
-        compatibilityMode: 'openai',
-        profileEnv: codexEnv,
-      })
-    }
-    return buildCompatibilityProcessEnv({
+    // No saved profile — default to Gitlawb Opengateway.
+    const env = buildCompatibilityProcessEnv({
       processEnv,
       compatibilityMode: 'openai',
       profileEnv: {
-        OPENAI_BASE_URL: DEFAULT_CODEX_BASE_URL,
-        OPENAI_MODEL: 'codexplan',
+        OPENAI_BASE_URL:
+          getRouteDefaultBaseUrl('gitlawb-opengateway') ??
+          'https://opengateway.gitlawb.com/v1',
+        OPENAI_MODEL:
+          getRouteDefaultModel('gitlawb-opengateway') ?? 'mimo-v2.5-pro',
       },
     })
+    env[DEFAULT_STARTUP_PROVIDER_ENV_VAR] = 'gitlawb-opengateway'
+    return env
   }
 
   return buildLaunchEnv({


### PR DESCRIPTION
# Make Gitlawb OpenGateway the fresh-install default provider

## Summary

Closes #1457

This PR changes the no-profile startup path so a fresh OpenClaude install defaults to Gitlawb OpenGateway instead of falling through to the Claude subscription/auth flow. When no saved provider profile exists, startup now applies the Gitlawb OpenGateway OpenAI-compatible route with:

- `CLAUDE_CODE_USE_OPENAI=1`
- `OPENAI_BASE_URL=https://opengateway.gitlawb.com/v1`
- `OPENAI_MODEL=mimo-v2.5-pro`

The provider is also marked as recommended in the provider picker, with the same `★ Recommended` presentation used for Codex OAuth. The Gitlawb OpenGateway provider description and setup docs now make the API-key requirement explicit and point users to https://gitlawb.com/opengateway/keys.

## Why

Fresh installs currently can land users in the Claude Code subscription/auth UI before they have selected a third-party provider. That is confusing for users expecting OpenClaude to start with an OpenClaude-supported default provider path.

Defaulting fresh installs to Gitlawb OpenGateway gives new users a first-run provider route inside the OpenClaude provider system while still allowing saved profiles, explicit environment variables, and provider opt-outs to take precedence.

## User Impact

- Fresh installs now start on the Gitlawb OpenGateway provider path.
- Users are guided toward an API-key-backed OpenGateway setup instead of a Claude subscription UI.
- `/provider` shows Gitlawb OpenGateway as recommended.
- The OpenGateway row and advanced setup docs now state that an API key is required and link to the key signup page.

## Developer Impact

- `buildStartupEnvFromProfile()` now has an explicit no-profile default for Gitlawb OpenGateway.
- A startup-default marker env var identifies the injected default provider so startup validation can treat the default differently from a broken saved profile.
- CLI and gRPC startup preserve validation for real saved profiles while allowing the fresh-install default to reach the normal provider validation/recovery flow.
- The generated integration artifacts were updated to match the gateway descriptor changes.
- Focused coverage was added for the fresh-install default provider environment.

## Provider Path Tested

Provider/model path changed and tested:

- Provider: Gitlawb OpenGateway
- Base URL: `https://opengateway.gitlawb.com/v1`
- Model: `mimo-v2.5-pro`
- Credential env: `OPENGATEWAY_API_KEY`
- Compatibility mode: OpenAI-compatible provider path via `CLAUDE_CODE_USE_OPENAI=1`

## Checks Run

```bash
bun run integrations:check
```

```bash
bun test src\utils\providerProfile.test.ts src\utils\providerValidation.test.ts src\components\ProviderManager.test.tsx --max-concurrency=1
```

Result: 127 tests passed, 0 failed.

```bash
bun run build
```

Result: build passed.

Earlier smoke validation also passed:

```bash
bun run smoke
```

Known local validation issue:

```bash
bun run security:pr-scan -- --base upstream/main --head HEAD
```

This failed with a script/runtime error before producing scan findings:

```text
PR intent scan failed: null is not an object (evaluating 'mergeBase.stderr.trim')
```

## Screenshots / Terminal Presentation

This PR changes CLI/provider-picker presentation only. No graphical screenshot is attached.

Expected provider-picker presentation for Gitlawb OpenGateway:

```text
Gitlawb Opengateway ★ Recommended
Gitlawb Opengateway - (API key required, signup at https://gitlawb.com/opengateway/keys)
```

## Notes and Follow-Ups

- This PR does not add a new provider or dependency.
- This PR does not change existing saved provider profiles.
- OpenGateway currently requires an API key. Users without `OPENGATEWAY_API_KEY` will still need to add one through the normal setup/validation flow.
- Open issues around OpenGateway auth, credits, and gateway reliability are being tracked separately and are not expanded in this PR.
