### PR TITLE
fix(typecheck): make session history cache variant-safe

### DIFF
--- a/src/assistant/sessionHistory.test.ts
+++ b/src/assistant/sessionHistory.test.ts
@@ -115,15 +115,15 @@ describe('session history cache serialization', () => {
 
     expect(serialized[0]).toEqual({
       ...resultMessage,
-      timestamp: expect.any(Number),
+      cachedAt: expect.any(Number),
     })
     expect(serialized[1]).toEqual({
       ...statusMessage,
-      timestamp: expect.any(Number),
+      cachedAt: expect.any(Number),
     })
     expect(serialized[2]).toEqual({
       ...toolProgressMessage,
-      timestamp: expect.any(Number),
+      cachedAt: expect.any(Number),
     })
 
     expect(deserializeFromCacheMessage(serialized)).toEqual([
@@ -168,5 +168,52 @@ describe('session history cache serialization', () => {
     const deserialized = deserializeFromCacheMessage(serialized)
 
     expect(deserialized).toEqual(messages)
+  })
+
+  test('preserves SDK user message timestamps across cache round trip', () => {
+    const userMessage = {
+      type: 'user',
+      message: {
+        role: 'user',
+        content: 'Hello with timestamp',
+      },
+      parent_tool_use_id: null,
+      timestamp: '2026-06-02T17:44:00.000Z',
+      uuid: 'timestamped-user-uuid',
+      session_id: 'session-1',
+    } satisfies SDKUserMessage
+
+    const [serialized] = serializeToCacheMessage([userMessage])
+
+    expect(serialized.timestamp).toBe(userMessage.timestamp)
+    expect(serialized.cachedAt).toEqual(expect.any(Number))
+
+    const [deserialized] = deserializeFromCacheMessage([serialized])
+
+    expect(deserialized).toEqual(userMessage)
+  })
+
+  test('parses legacy top-level cached array content', () => {
+    const legacyContent = [{ type: 'text', text: 'Hello' }]
+    const legacyRecord = {
+      type: 'assistant',
+      role: 'assistant',
+      content: JSON.stringify(legacyContent),
+      contentIsArray: true,
+      timestamp: 123456,
+      uuid: 'legacy-uuid',
+      session_id: 'session-1',
+    }
+
+    const [deserialized] = deserializeFromCacheMessage([legacyRecord])
+    const deserializedRecord = deserialized as unknown as Record<string, unknown>
+
+    expect(deserializedRecord).toEqual({
+      type: 'assistant',
+      role: 'assistant',
+      content: legacyContent,
+      uuid: 'legacy-uuid',
+      session_id: 'session-1',
+    })
   })
 })

--- a/src/assistant/sessionHistory.test.ts
+++ b/src/assistant/sessionHistory.test.ts
@@ -193,27 +193,52 @@ describe('session history cache serialization', () => {
     expect(deserialized).toEqual(userMessage)
   })
 
-  test('parses legacy top-level cached array content', () => {
+  test('normalizes legacy top-level cached user and assistant content', () => {
     const legacyContent = [{ type: 'text', text: 'Hello' }]
-    const legacyRecord = {
-      type: 'assistant',
-      role: 'assistant',
-      content: JSON.stringify(legacyContent),
-      contentIsArray: true,
-      timestamp: 123456,
-      uuid: 'legacy-uuid',
-      session_id: 'session-1',
-    }
+    const legacyRecords = [
+      {
+        type: 'assistant',
+        role: 'assistant',
+        content: JSON.stringify(legacyContent),
+        contentIsArray: true,
+        timestamp: 123456,
+        uuid: 'legacy-assistant-uuid',
+        session_id: 'session-1',
+      },
+      {
+        type: 'user',
+        role: 'user',
+        content: 'Legacy hello',
+        contentIsArray: false,
+        timestamp: 123456,
+        uuid: 'legacy-user-uuid',
+        session_id: 'session-1',
+      },
+    ]
 
-    const [deserialized] = deserializeFromCacheMessage([legacyRecord])
-    const deserializedRecord = deserialized as unknown as Record<string, unknown>
+    const deserialized = deserializeFromCacheMessage(legacyRecords)
 
-    expect(deserializedRecord).toEqual({
-      type: 'assistant',
-      role: 'assistant',
-      content: legacyContent,
-      uuid: 'legacy-uuid',
-      session_id: 'session-1',
-    })
+    expect(deserialized).toEqual([
+      {
+        type: 'assistant',
+        message: {
+          role: 'assistant',
+          content: legacyContent,
+        },
+        parent_tool_use_id: null,
+        uuid: 'legacy-assistant-uuid',
+        session_id: 'session-1',
+      },
+      {
+        type: 'user',
+        message: {
+          role: 'user',
+          content: 'Legacy hello',
+        },
+        parent_tool_use_id: null,
+        uuid: 'legacy-user-uuid',
+        session_id: 'session-1',
+      },
+    ])
   })
 })

--- a/src/assistant/sessionHistory.test.ts
+++ b/src/assistant/sessionHistory.test.ts
@@ -1,352 +1,172 @@
-import { describe, expect, it } from 'bun:test'
-import type { SDKMessage } from '../entrypoints/agentSdkTypes.js'
+import { describe, expect, test } from 'bun:test'
+import type {
+  SDKAssistantMessage,
+  SDKMessage,
+  SDKStatusMessage,
+  SDKToolProgressMessage,
+  SDKUserMessage,
+} from '../entrypoints/agentSdkTypes.js'
+import {
+  deserializeFromCacheMessage,
+  serializeToCacheMessage,
+} from './sessionHistorySerialization.js'
 
-// Test the serialization round-trip by importing the module functions
-// These are unexported, so we test via the exported cacheSession/loadCachedSession path
-// We also test the internal functions by re-implementing the round-trip inline
+const resultMessage = {
+  type: 'result',
+  subtype: 'success',
+  duration_ms: 3000,
+  duration_api_ms: 2500,
+  is_error: false,
+  num_turns: 2,
+  result: 'Task completed successfully',
+  stop_reason: 'end_turn',
+  total_cost_usd: 0.02,
+  usage: { input_tokens: 200, output_tokens: 100 },
+  modelUsage: {},
+  permission_denials: [],
+  uuid: 'result-uuid',
+  session_id: 'session-1',
+} satisfies SDKMessage
 
-function serializeToCacheMessage(events: SDKMessage[]): Record<string, unknown>[] {
-  return events.map((m) => {
-    const cacheMsg: Record<string, unknown> = {
-      role: m.role,
-      content: typeof m.content === 'string' ? m.content : JSON.stringify(m.content),
-      contentIsArray: Array.isArray(m.content),
-      timestamp: Date.now(),
-    }
-    if (m.tool_calls) cacheMsg.tool_calls = m.tool_calls
-    if (m.tool_use_id) cacheMsg.tool_use_id = m.tool_use_id
-    if ('id' in m && m.id) cacheMsg.id = m.id
-    if ('type' in m) cacheMsg.type = m.type
-    if ('message' in m) cacheMsg.message = m.message
-    if ('error' in m) cacheMsg.error = m.error
-    if ('uuid' in m) cacheMsg.uuid = m.uuid
-    if ('session_id' in m) cacheMsg.session_id = m.session_id
-    if ('parent_tool_use_id' in m) cacheMsg.parent_tool_use_id = m.parent_tool_use_id
-    if ('tool_use_result' in m) cacheMsg.tool_use_result = m.tool_use_result
-    if ('subtype' in m) cacheMsg.subtype = m.subtype
-    if ('result' in m) cacheMsg.result = m.result
-    if ('errors' in m) cacheMsg.errors = m.errors
-    if ('event' in m) cacheMsg.event = m.event
-    if ('status' in m && m.status) cacheMsg.status = m.status
-    if ('compact_metadata' in m) cacheMsg.compact_metadata = m.compact_metadata
-    if ('tool_name' in m) cacheMsg.tool_name = m.tool_name
-    if ('elapsed_time_seconds' in m) cacheMsg.elapsed_time_seconds = m.elapsed_time_seconds
-    return cacheMsg
-  })
-}
+const statusMessage = {
+  type: 'system',
+  subtype: 'status',
+  status: 'compacting',
+  uuid: 'status-uuid',
+  session_id: 'session-1',
+} satisfies SDKStatusMessage
 
-function deserializeFromCacheMessage(messages: Record<string, unknown>[]): Record<string, unknown>[] {
-  return messages.map((m) => {
-    let content: unknown = m.content
-    if (m.contentIsArray) {
-      try {
-        content = JSON.parse(m.content as string)
-      } catch {
-        content = m.content
-      }
-    }
-    const msg: Record<string, unknown> = {
-      role: m.role,
-      content,
-    }
-    if (m.tool_calls) msg.tool_calls = m.tool_calls
-    if (m.tool_use_id) msg.tool_use_id = m.tool_use_id
-    if (m.id) msg.id = m.id
-    if (m.type) msg.type = m.type
-    if (m.message) msg.message = m.message
-    if (m.error) msg.error = m.error
-    if (m.uuid) msg.uuid = m.uuid
-    if (m.session_id) msg.session_id = m.session_id
-    if (m.parent_tool_use_id) msg.parent_tool_use_id = m.parent_tool_use_id
-    if (m.tool_use_result) msg.tool_use_result = m.tool_use_result
-    if (m.subtype) msg.subtype = m.subtype
-    if (m.result) msg.result = m.result
-    if (m.errors) msg.errors = m.errors
-    if (m.event) msg.event = m.event
-    if (m.status) msg.status = m.status
-    if (m.compact_metadata) msg.compact_metadata = m.compact_metadata
-    if (m.tool_name) msg.tool_name = m.tool_name
-    if (m.elapsed_time_seconds !== undefined) msg.elapsed_time_seconds = m.elapsed_time_seconds
-    return msg
-  })
-}
+const toolProgressMessage = {
+  type: 'tool_progress',
+  tool_use_id: 'tool-use-1',
+  tool_name: 'Bash',
+  parent_tool_use_id: null,
+  elapsed_time_seconds: 0,
+  uuid: 'tool-progress-uuid',
+  session_id: 'session-1',
+} satisfies SDKToolProgressMessage
 
-describe('SDKMessage Serialization Round-Trip', () => {
-
-  it('round-trips assistant message with error', () => {
-    const message: SDKMessage = {
-      role: 'assistant',
+describe('session history cache serialization', () => {
+  test('preserves assistant message variants while encoding array content for cache storage', () => {
+    const assistantMessage = {
       type: 'assistant',
-      content: [{ type: 'text', text: 'Hello' }],
-      message: { role: 'assistant', content: [{ type: 'text', text: 'Hello' }] },
-      error: 'rate_limit',
-      uuid: 'uuid-1',
-      session_id: 'session-1',
-      model: 'claude-sonnet-4-20250514',
-      parent_tool_use_id: null,
-    } as unknown as SDKMessage
-
-    const serialized = serializeToCacheMessage([message])
-    const deserialized = deserializeFromCacheMessage(serialized)[0]
-
-    expect(deserialized.error).toBe('rate_limit')
-    expect(deserialized.uuid).toBe('uuid-1')
-    expect(deserialized.session_id).toBe('session-1')
-  })
-
-  it('round-trips result message with errors (error variant)', () => {
-    const message: SDKMessage = {
-      role: 'system',
-      type: 'result',
-      subtype: 'error_during_execution',
-      result: undefined,
-      errors: ['Connection timeout', 'Retry failed'],
-      is_error: true,
-      duration_ms: 5000,
-      duration_api_ms: 4000,
-      num_turns: 3,
-      stop_reason: null,
-      total_cost_usd: 0.05,
-      usage: { input_tokens: 100, output_tokens: 50 },
-      modelUsage: {},
-      permission_denials: [],
-      uuid: 'uuid-2',
-      session_id: 'session-1',
-    } as unknown as SDKMessage
-
-    const serialized = serializeToCacheMessage([message])
-    const deserialized = deserializeFromCacheMessage(serialized)[0]
-
-    expect(deserialized.errors).toEqual(['Connection timeout', 'Retry failed'])
-    expect(deserialized.subtype).toBe('error_during_execution')
-    expect(deserialized.uuid).toBe('uuid-2')
-    expect(deserialized.result).toBeUndefined()
-  })
-
-  it('round-trips result message with success result (success variant)', () => {
-    const message: SDKMessage = {
-      role: 'system',
-      type: 'result',
-      subtype: 'success',
-      result: 'Task completed successfully',
-      is_error: false,
-      duration_ms: 3000,
-      duration_api_ms: 2500,
-      num_turns: 2,
-      stop_reason: 'end_turn',
-      total_cost_usd: 0.02,
-      usage: { input_tokens: 200, output_tokens: 100 },
-      modelUsage: {},
-      permission_denials: [],
-      uuid: 'uuid-3',
-      session_id: 'session-1',
-    } as unknown as SDKMessage
-
-    const serialized = serializeToCacheMessage([message])
-    const deserialized = deserializeFromCacheMessage(serialized)[0]
-
-    expect(deserialized.result).toBe('Task completed successfully')
-    expect(deserialized.subtype).toBe('success')
-    expect(deserialized.errors).toBeUndefined()
-    expect(deserialized.uuid).toBe('uuid-3')
-  })
-
-  it('round-trips status message with compacting status', () => {
-    const message: SDKMessage = {
-      role: 'system',
-      type: 'system',
-      subtype: 'status',
-      status: 'compacting',
-      uuid: 'uuid-4',
-      session_id: 'session-1',
-    } as unknown as SDKMessage
-
-    const serialized = serializeToCacheMessage([message])
-    const deserialized = deserializeFromCacheMessage(serialized)[0]
-
-    expect(deserialized.status).toBe('compacting')
-    expect(deserialized.subtype).toBe('status')
-    expect(deserialized.uuid).toBe('uuid-4')
-  })
-
-  it('round-trips compact_boundary message with compact_metadata', () => {
-    const message: SDKMessage = {
-      role: 'system',
-      type: 'system',
-      subtype: 'compact_boundary',
-      compact_metadata: {
-        trigger: 'auto',
-        pre_tokens: 15000,
-        preserved_segment: {
-          head_uuid: 'head-uuid',
-          anchor_uuid: 'anchor-uuid',
-          tail_uuid: 'tail-uuid',
-        },
+      message: {
+        role: 'assistant',
+        content: [{ type: 'text', text: 'Hello' }],
       },
-      uuid: 'uuid-5',
-      session_id: 'session-1',
-    } as unknown as SDKMessage
-
-    const serialized = serializeToCacheMessage([message])
-    const deserialized = deserializeFromCacheMessage(serialized)[0]
-
-    expect(deserialized.compact_metadata).toBeDefined()
-    expect((deserialized.compact_metadata as Record<string, unknown>).trigger).toBe('auto')
-    expect((deserialized.compact_metadata as Record<string, unknown>).pre_tokens).toBe(15000)
-    expect(deserialized.subtype).toBe('compact_boundary')
-    expect(deserialized.uuid).toBe('uuid-5')
-  })
-
-  it('round-trips tool_progress message with tool_name and elapsed_time_seconds', () => {
-    const message: SDKMessage = {
-      role: 'system',
-      type: 'tool_progress',
-      tool_use_id: 'tool-use-1',
-      tool_name: 'Bash',
-      elapsed_time_seconds: 3.5,
       parent_tool_use_id: null,
-      uuid: 'uuid-6',
+      error: 'rate_limit',
+      uuid: 'assistant-uuid',
       session_id: 'session-1',
-    } as unknown as SDKMessage
+    } satisfies SDKAssistantMessage
 
-    const serialized = serializeToCacheMessage([message])
-    const deserialized = deserializeFromCacheMessage(serialized)[0]
+    const [serialized] = serializeToCacheMessage([assistantMessage])
 
-    expect(deserialized.tool_name).toBe('Bash')
-    expect(deserialized.elapsed_time_seconds).toBe(3.5)
-    expect(deserialized.tool_use_id).toBe('tool-use-1')
-    expect(deserialized.uuid).toBe('uuid-6')
-  })
-
-  it('round-trips tool_progress with elapsed_time_seconds=0', () => {
-    const message: SDKMessage = {
-      role: 'system',
-      type: 'tool_progress',
-      tool_use_id: 'tool-use-2',
-      tool_name: 'Read',
-      elapsed_time_seconds: 0,
-      parent_tool_use_id: null,
-      uuid: 'uuid-7',
-      session_id: 'session-1',
-    } as unknown as SDKMessage
-
-    const serialized = serializeToCacheMessage([message])
-    const deserialized = deserializeFromCacheMessage(serialized)[0]
-
-    expect(deserialized.tool_name).toBe('Read')
-    expect(deserialized.elapsed_time_seconds).toBe(0)
-  })
-
-  it('drops status: null (not compacting) during serialization', () => {
-    const message: SDKMessage = {
-      role: 'system',
-      type: 'system',
-      subtype: 'status',
-      status: null,
-      uuid: 'uuid-8',
-      session_id: 'session-1',
-    } as unknown as SDKMessage
-
-    const serialized = serializeToCacheMessage([message])
-
-    expect(serialized[0].status).toBeUndefined()
-  })
-
-  it('round-trips multiple message variants correctly', () => {
-    const messages: SDKMessage[] = [
-      {
-        role: 'assistant',
-        type: 'assistant',
-        content: 'Hello',
-        error: 'rate_limit',
-        uuid: 'uuid-a',
-        session_id: 'session-1',
-        parent_tool_use_id: null,
-      } as unknown as SDKMessage,
-      {
-        role: 'system',
-        type: 'result',
-        subtype: 'error_max_turns',
-        errors: ['Max turns reached'],
-        uuid: 'uuid-b',
-        session_id: 'session-1',
-      } as unknown as SDKMessage,
-      {
-        role: 'system',
-        type: 'system',
-        subtype: 'compact_boundary',
-        compact_metadata: { trigger: 'manual', pre_tokens: 5000 },
-        uuid: 'uuid-c',
-        session_id: 'session-1',
-      } as unknown as SDKMessage,
-      {
-        role: 'system',
-        type: 'tool_progress',
-        tool_use_id: 'tu-1',
-        tool_name: 'Edit',
-        elapsed_time_seconds: 1.2,
-        parent_tool_use_id: null,
-        uuid: 'uuid-d',
-        session_id: 'session-1',
-      } as unknown as SDKMessage,
-    ]
-
-    const serialized = serializeToCacheMessage(messages)
-    const deserialized = deserializeFromCacheMessage(serialized)
-
-    expect(deserialized).toHaveLength(4)
-    expect(deserialized[0].error).toBe('rate_limit')
-    expect(deserialized[1].errors).toEqual(['Max turns reached'])
-    expect((deserialized[2].compact_metadata as Record<string, unknown>).trigger).toBe('manual')
-    expect(deserialized[3].tool_name).toBe('Edit')
-    expect(deserialized[3].elapsed_time_seconds).toBe(1.2)
-  })
-
-  it('preserves message identity across full round-trip', () => {
-    const messages: SDKMessage[] = [
-      {
-        role: 'user',
-        type: 'user',
-        content: 'Hello world',
-        uuid: 'uuid-x',
-        session_id: 'session-1',
-      } as unknown as SDKMessage,
-      {
-        role: 'assistant',
-        type: 'assistant',
-        content: [{ type: 'text', text: 'Hi there' }],
-        message: { role: 'assistant', content: [{ type: 'text', text: 'Hi there' }] },
-        uuid: 'uuid-y',
-        session_id: 'session-1',
-        parent_tool_use_id: null,
-      } as unknown as SDKMessage,
-    ]
-
-    const serialized = serializeToCacheMessage(messages)
-    const deserialized = deserializeFromCacheMessage(serialized)
-
-    expect(deserialized).toHaveLength(2)
-    expect(deserialized[0].role).toBe('user')
-    expect(deserialized[0].uuid).toBe('uuid-x')
-    expect(deserialized[1].role).toBe('assistant')
-    expect(deserialized[1].uuid).toBe('uuid-y')
-  })
-
-  it('round-trips stream_event correctly', () => {
-    const message: SDKMessage = {
+    expect(serialized.type).toBe('assistant')
+    expect(serialized.contentIsArray).toBe(true)
+    expect(serialized.message).toEqual({
       role: 'assistant',
-      type: 'stream_event',
-      event: { type: 'content_block_delta', delta: { text: 'Hello' } },
-      parent_tool_use_id: 'parent-1',
-      uuid: 'uuid-z',
+      content: JSON.stringify([{ type: 'text', text: 'Hello' }]),
+    })
+    expect(serialized).not.toHaveProperty('role')
+    expect(serialized).not.toHaveProperty('content')
+
+    const [deserialized] = deserializeFromCacheMessage([serialized])
+
+    expect(deserialized).toEqual(assistantMessage)
+  })
+
+  test('preserves user message string content without marking it as an array', () => {
+    const userMessage = {
+      type: 'user',
+      message: {
+        role: 'user',
+        content: 'Hello world',
+      },
+      parent_tool_use_id: null,
+      uuid: 'user-uuid',
       session_id: 'session-1',
-    } as unknown as SDKMessage
+    } satisfies SDKUserMessage
 
-    const serialized = serializeToCacheMessage([message])
-    const deserialized = deserializeFromCacheMessage(serialized)[0]
+    const [serialized] = serializeToCacheMessage([userMessage])
 
-    expect(deserialized.type).toBe('stream_event')
-    expect(deserialized.parent_tool_use_id).toBe('parent-1')
-    expect(deserialized.uuid).toBe('uuid-z')
+    expect(serialized.contentIsArray).toBeUndefined()
+    expect(serialized.message).toEqual({
+      role: 'user',
+      content: 'Hello world',
+    })
+
+    const [deserialized] = deserializeFromCacheMessage([serialized])
+
+    expect(deserialized).toEqual(userMessage)
+  })
+
+  test('does not create legacy role or content fields for non-message variants', () => {
+    const serialized = serializeToCacheMessage([
+      resultMessage,
+      statusMessage,
+      toolProgressMessage,
+    ])
+
+    for (const record of serialized) {
+      expect(record).not.toHaveProperty('role')
+      expect(record).not.toHaveProperty('content')
+    }
+
+    expect(serialized[0]).toEqual({
+      ...resultMessage,
+      timestamp: expect.any(Number),
+    })
+    expect(serialized[1]).toEqual({
+      ...statusMessage,
+      timestamp: expect.any(Number),
+    })
+    expect(serialized[2]).toEqual({
+      ...toolProgressMessage,
+      timestamp: expect.any(Number),
+    })
+
+    expect(deserializeFromCacheMessage(serialized)).toEqual([
+      resultMessage,
+      statusMessage,
+      toolProgressMessage,
+    ])
+  })
+
+  test('preserves mixed SDK message variants across cache round trip', () => {
+    const assistantMessage = {
+      type: 'assistant',
+      message: {
+        role: 'assistant',
+        content: [{ type: 'text', text: 'Done' }],
+      },
+      parent_tool_use_id: null,
+      uuid: 'assistant-uuid',
+      session_id: 'session-1',
+    } satisfies SDKAssistantMessage
+
+    const userMessage = {
+      type: 'user',
+      message: {
+        role: 'user',
+        content: [{ type: 'tool_result', tool_use_id: 'tool-use-1' }],
+      },
+      parent_tool_use_id: 'tool-use-1',
+      uuid: 'user-uuid',
+      session_id: 'session-1',
+    } satisfies SDKUserMessage
+
+    const messages: SDKMessage[] = [
+      assistantMessage,
+      userMessage,
+      resultMessage,
+      statusMessage,
+      toolProgressMessage,
+    ]
+
+    const serialized = serializeToCacheMessage(messages)
+    const deserialized = deserializeFromCacheMessage(serialized)
+
+    expect(deserialized).toEqual(messages)
   })
 })

--- a/src/assistant/sessionHistory.ts
+++ b/src/assistant/sessionHistory.ts
@@ -6,8 +6,12 @@ import { getOAuthHeaders, prepareApiRequest } from '../utils/teleport/api.js'
 import {
   ConversationCache,
   createConversationCache,
-  type CacheMessage,
 } from '../utils/conversationCache.js'
+import {
+  deserializeFromCacheMessage,
+  serializeToCacheMessage,
+  type SDKMessageCacheRecord,
+} from './sessionHistorySerialization.js'
 import {
   saveSession,
   loadSession,
@@ -92,107 +96,6 @@ function extractSessionId(baseUrl: string): string {
   return match ? match[1] : 'default'
 }
 
-function serializeToCacheMessage(events: SDKMessage[]): CacheMessage[] {
-  return events.map((m): CacheMessage => {
-    const isArrayContent = Array.isArray(m.content)
-    const cacheMsg: CacheMessage = {
-      role: m.role,
-      content:
-        typeof m.content === 'string' ? m.content : JSON.stringify(m.content),
-      contentIsArray: isArrayContent,
-      tool_calls: m.tool_calls as CacheMessage['tool_calls'],
-      tool_use_id: m.tool_use_id,
-      timestamp: Date.now(),
-    }
-    // Core SDK fields (always present)
-    if ('id' in m && m.id) cacheMsg.id = m.id
-    if ('type' in m) cacheMsg.type = m.type
-    // Assistant message payload
-    if ('message' in m) cacheMsg.message = m.message as CacheMessage['message']
-    // Assistant error (SDKAssistantMessage only)
-    if ('error' in m) cacheMsg.error = m.error as string
-    // User message fields
-    if ('uuid' in m) cacheMsg.uuid = m.uuid
-    if ('session_id' in m) cacheMsg.session_id = m.session_id
-    if ('parent_tool_use_id' in m) cacheMsg.parent_tool_use_id = m.parent_tool_use_id
-    if ('tool_use_result' in m) cacheMsg.tool_use_result = m.tool_use_result as CacheMessage['tool_use_result']
-    // Assistant message metadata
-    if ('model' in m && m.model) cacheMsg.model = m.model
-    if ('created_at' in m && m.created_at) cacheMsg.created_at = m.created_at
-    if ('stop_reason' in m && m.stop_reason) cacheMsg.stop_reason = m.stop_reason
-    if ('usage' in m && m.usage) cacheMsg.usage = m.usage as CacheMessage['usage']
-    // Result/system fields
-    if ('subtype' in m) cacheMsg.subtype = m.subtype
-    if ('result' in m) cacheMsg.result = m.result as CacheMessage['result']
-    // Result errors (SDKResultMessage error variant only)
-    if ('errors' in m) cacheMsg.errors = m.errors as string[]
-    // Stream event payload
-    if ('event' in m) cacheMsg.event = m.event as CacheMessage['event']
-    // Generic metadata
-    if ('is_development' in m) cacheMsg.is_development = m.is_development
-    if ('index' in m && typeof m.index === 'number') cacheMsg.index = m.index
-    // System status (SDKStatusMessage only - persist 'compacting', skip null)
-    if ('status' in m && m.status) cacheMsg.status = m.status as string
-    // Compact boundary metadata (SDKCompactBoundaryMessage only)
-    if ('compact_metadata' in m) cacheMsg.compact_metadata = m.compact_metadata as unknown
-    // Tool progress fields (SDKToolProgressMessage only)
-    if ('tool_name' in m) cacheMsg.tool_name = m.tool_name as string
-    if ('elapsed_time_seconds' in m) cacheMsg.elapsed_time_seconds = m.elapsed_time_seconds as number
-    return cacheMsg
-  })
-}
-
-function deserializeFromCacheMessage(messages: CacheMessage[]): SDKMessage[] {
-  return messages.map((m): SDKMessage => {
-    let content: SDKMessage['content']
-    if (m.contentIsArray) {
-      try {
-        content = JSON.parse(m.content)
-      } catch {
-        content = m.content
-      }
-    } else {
-      content = m.content
-    }
-
-    const msg: SDKMessage = {
-      role: m.role,
-      content,
-      tool_calls: m.tool_calls as SDKMessage['tool_calls'],
-      tool_use_id: m.tool_use_id,
-    }
-    // Restore all SDK fields
-    if (m.id) msg.id = m.id
-    if (m.type) msg.type = m.type
-    if (m.message) msg.message = m.message as SDKMessage['message']
-    if (m.uuid) msg.uuid = m.uuid
-    if (m.session_id) msg.session_id = m.session_id
-    if (m.parent_tool_use_id) msg.parent_tool_use_id = m.parent_tool_use_id
-    if (m.tool_use_result) msg.tool_use_result = m.tool_use_result as SDKMessage['tool_use_result']
-    if (m.model) msg.model = m.model
-    if (m.created_at) msg.created_at = m.created_at
-    if (m.stop_reason) msg.stop_reason = m.stop_reason
-    if (m.usage) msg.usage = m.usage as SDKMessage['usage']
-    if (m.subtype) msg.subtype = m.subtype
-    if (m.result) msg.result = m.result as SDKMessage['result']
-    if (m.event) msg.event = m.event as SDKMessage['event']
-    if (typeof m.is_development === 'boolean') msg.is_development = m.is_development
-    if (typeof m.index === 'number') msg.index = m.index
-    // Assistant error (SDKAssistantMessage)
-    if (m.error) msg.error = m.error as SDKMessage['error']
-    // Result errors (SDKResultMessage error variant)
-    if (m.errors) msg.errors = m.errors as SDKMessage['errors']
-    // System status (SDKStatusMessage - only truthy values get serialized)
-    if (m.status) msg.status = m.status as SDKMessage['status']
-    // Compact boundary metadata (SDKCompactBoundaryMessage)
-    if (m.compact_metadata) msg.compact_metadata = m.compact_metadata as SDKMessage['compact_metadata']
-    // Tool progress fields (SDKToolProgressMessage)
-    if (m.tool_name) msg.tool_name = m.tool_name as SDKMessage['tool_name']
-    if (m.elapsed_time_seconds !== undefined) msg.elapsed_time_seconds = m.elapsed_time_seconds as SDKMessage['elapsed_time_seconds']
-    return msg
-  })
-}
-
 export async function fetchLatestEvents(
   ctx: HistoryAuthCtx,
   limit = HISTORY_PAGE_SIZE,
@@ -243,12 +146,18 @@ export async function cacheSession(
 
   sessionMetadataCache.set(sessionId, { hasMore, lastId })
 
-  const newUuids = new Set(events.map(e => e.uuid))
+  const newUuids = new Set(
+    events
+      .map(event => ('uuid' in event ? event.uuid : undefined))
+      .filter((uuid): uuid is string => typeof uuid === 'string'),
+  )
   const lastUuids = lastSavedIds.get(sessionId)
   const newCount = events.length
   const lastCount = lastSavedCounts.get(sessionId) ?? 0
 
-  const hasNewUuids = !lastUuids || [...newUuids].some(uuid => !lastUuids.has(uuid))
+  const hasNewUuids =
+    newUuids.size > 0 &&
+    (!lastUuids || [...newUuids].some(uuid => !lastUuids.has(uuid)))
   if (hasNewUuids || newCount !== lastCount) {
     lastSavedCounts.set(sessionId, newCount)
     lastSavedIds.set(sessionId, newUuids)
@@ -275,7 +184,7 @@ export async function loadCachedSession(
   try {
     const session = await loadSession(sessionId)
     if (session) {
-      const events = session.messages as CacheMessage[]
+      const events = session.messages as unknown as SDKMessageCacheRecord[]
       cache.set(sessionId, events)
 
       if (session.pagination) {

--- a/src/assistant/sessionHistorySerialization.ts
+++ b/src/assistant/sessionHistorySerialization.ts
@@ -1,13 +1,26 @@
 import type { SDKMessage } from '../entrypoints/agentSdkTypes.js'
 
 export type SDKMessageCacheRecord = Record<string, unknown> & {
+  cachedAt?: number
   contentIsArray?: boolean
   message?: Record<string, unknown>
-  timestamp?: number
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return value !== null && typeof value === 'object' && !Array.isArray(value)
+}
+
+function parseSerializedArrayContent(content: unknown): unknown {
+  if (typeof content !== 'string') {
+    return content
+  }
+
+  try {
+    const parsed = JSON.parse(content)
+    return Array.isArray(parsed) ? parsed : content
+  } catch {
+    return content
+  }
 }
 
 export function serializeToCacheMessage(
@@ -16,7 +29,7 @@ export function serializeToCacheMessage(
   return events.map(event => {
     const record: SDKMessageCacheRecord = {
       ...(event as unknown as Record<string, unknown>),
-      timestamp: Date.now(),
+      cachedAt: Date.now(),
     }
 
     if ('message' in event && isRecord(event.message)) {
@@ -39,21 +52,20 @@ export function deserializeFromCacheMessage(
 ): SDKMessage[] {
   return records.map(record => {
     const event = { ...record }
-    delete event.timestamp
+    delete event.cachedAt
 
     if (record.contentIsArray && isRecord(event.message)) {
       const message = event.message
-      const content = message.content
-      if (typeof content === 'string') {
-        try {
-          event.message = {
-            ...message,
-            content: JSON.parse(content),
-          }
-        } catch {
-          event.message = message
-        }
+      event.message = {
+        ...message,
+        content: parseSerializedArrayContent(message.content),
       }
+    } else if (record.contentIsArray) {
+      event.content = parseSerializedArrayContent(event.content)
+    }
+
+    if (!('cachedAt' in record) && typeof event.timestamp === 'number') {
+      delete event.timestamp
     }
 
     delete event.contentIsArray

--- a/src/assistant/sessionHistorySerialization.ts
+++ b/src/assistant/sessionHistorySerialization.ts
@@ -23,6 +23,44 @@ function parseSerializedArrayContent(content: unknown): unknown {
   }
 }
 
+function getLegacyMessageRole(
+  event: Record<string, unknown>,
+): 'assistant' | 'user' | null {
+  if (event.type === 'assistant' || event.type === 'user') {
+    return event.type
+  }
+  if (
+    event.type === undefined &&
+    (event.role === 'assistant' || event.role === 'user')
+  ) {
+    return event.role
+  }
+  return null
+}
+
+function normalizeLegacyTopLevelMessage(event: Record<string, unknown>): void {
+  const role = getLegacyMessageRole(event)
+  if (!role) {
+    return
+  }
+
+  if (!isRecord(event.message) && 'content' in event) {
+    event.message = {
+      role,
+      content: event.content,
+    }
+  }
+
+  if (isRecord(event.message)) {
+    event.type = role
+    if (!('parent_tool_use_id' in event)) {
+      event.parent_tool_use_id = null
+    }
+    delete event.role
+    delete event.content
+  }
+}
+
 export function serializeToCacheMessage(
   events: readonly SDKMessage[],
 ): SDKMessageCacheRecord[] {
@@ -60,9 +98,12 @@ export function deserializeFromCacheMessage(
         ...message,
         content: parseSerializedArrayContent(message.content),
       }
-    } else if (record.contentIsArray) {
+    }
+    if (record.contentIsArray && 'content' in event) {
       event.content = parseSerializedArrayContent(event.content)
     }
+
+    normalizeLegacyTopLevelMessage(event)
 
     if (!('cachedAt' in record) && typeof event.timestamp === 'number') {
       delete event.timestamp

--- a/src/assistant/sessionHistorySerialization.ts
+++ b/src/assistant/sessionHistorySerialization.ts
@@ -1,0 +1,62 @@
+import type { SDKMessage } from '../entrypoints/agentSdkTypes.js'
+
+export type SDKMessageCacheRecord = Record<string, unknown> & {
+  contentIsArray?: boolean
+  message?: Record<string, unknown>
+  timestamp?: number
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value)
+}
+
+export function serializeToCacheMessage(
+  events: readonly SDKMessage[],
+): SDKMessageCacheRecord[] {
+  return events.map(event => {
+    const record: SDKMessageCacheRecord = {
+      ...(event as unknown as Record<string, unknown>),
+      timestamp: Date.now(),
+    }
+
+    if ('message' in event && isRecord(event.message)) {
+      const content = event.message.content
+      if (Array.isArray(content)) {
+        record.message = {
+          ...event.message,
+          content: JSON.stringify(content),
+        }
+        record.contentIsArray = true
+      }
+    }
+
+    return record
+  })
+}
+
+export function deserializeFromCacheMessage(
+  records: readonly SDKMessageCacheRecord[],
+): SDKMessage[] {
+  return records.map(record => {
+    const event = { ...record }
+    delete event.timestamp
+
+    if (record.contentIsArray && isRecord(event.message)) {
+      const message = event.message
+      const content = message.content
+      if (typeof content === 'string') {
+        try {
+          event.message = {
+            ...message,
+            content: JSON.parse(content),
+          }
+        } catch {
+          event.message = message
+        }
+      }
+    }
+
+    delete event.contentIsArray
+    return event as unknown as SDKMessage
+  })
+}

--- a/src/utils/conversationCache.ts
+++ b/src/utils/conversationCache.ts
@@ -19,7 +19,7 @@ export interface ConversationCacheConfig {
 }
 
 export class ConversationCache {
-  private cache = new Map<string, CacheEntry<Message[]>>()
+  private cache = new Map<string, CacheEntry<CacheMessage[]>>()
   private accessOrder = new Map<string, number>()
   private evictions = 0
 
@@ -39,7 +39,7 @@ export class ConversationCache {
     return this.evictions
   }
 
-  set(key: string, messages: Message[]): void {
+  set(key: string, messages: CacheMessage[]): void {
     if (this.cache.size >= this.maxSize && !this.cache.has(key)) {
       this.evictLRU()
     }
@@ -52,7 +52,7 @@ export class ConversationCache {
     this.accessOrder.set(key, this.accessOrder.size)
   }
 
-  get(key: string): Message[] | undefined {
+  get(key: string): CacheMessage[] | undefined {
     const entry = this.cache.get(key)
     if (!entry) return undefined
 
@@ -137,39 +137,8 @@ export class ConversationCache {
   }
 }
 
-export interface Message {
-  role: 'user' | 'assistant' | 'system'
-  content: string
-  /** True if original message content was a structured array, not a string */
-  contentIsArray?: boolean
-  tool_calls?: unknown[]
-  tool_use_id?: string
-  timestamp?: number
-  id?: string
-  type?: string
-  model?: string
-  created_at?: number
-  stop_reason?: string
-  usage?: unknown
-  is_development?: boolean
-  index?: number
-  uuid?: string
-  session_id?: string
-  parent_tool_use_id?: string | null
-  tool_use_result?: unknown
-  message?: unknown
-  subtype?: string
-  result?: string
-  event?: unknown
-  error?: string
-  errors?: string[]
-  status?: string | null
-  compact_metadata?: unknown
-  tool_name?: string
-  elapsed_time_seconds?: number
-}
-
-export type CacheMessage = Message
+export type CacheMessage = Record<string, unknown>
+export type Message = CacheMessage
 
 export interface SessionCacheMetadata {
   hasMore: boolean


### PR DESCRIPTION
## Summary

Refs #1486.

Fixes a focused set of TypeScript errors in session history cache serialization.

## What changed

- Added a small session-history serialization helper that preserves SDK event variants and only stringifies nested `message.content` arrays for cache storage.
- Updated `sessionHistory.ts` to use the helper instead of constructing fake top-level `role`/`content` SDK messages.
- Replaced duplicated serializer tests with focused tests using valid SDK message variants.
- Loosened the conversation cache record type so it can store SDK cache records that do not have legacy `role`/`content` fields.

## Why

The generated `SDKMessage` union has variants that do not expose top-level `role`, `content`, `tool_calls`, or `tool_use_id`. Flattening every event into that shape caused type errors and risked losing variant-specific payloads during cache round trips.

## Validation

- [x] `bun test src/assistant/sessionHistory.test.ts src/utils/conversationCache.test.ts` — 12 pass, 0 fail
- [x] `git diff --check` — no whitespace errors
- [x] `bun run typecheck` — still fails globally due to the existing backlog, but targeted `src/assistant/sessionHistory*` errors were reduced from 55 lines before to 0 after