### PR TITLE
fix(typecheck): restore proactive module import surface

### DIFF
--- a/src/proactive/index.test.ts
+++ b/src/proactive/index.test.ts
@@ -1,0 +1,46 @@
+import { afterEach, describe, expect, test } from 'bun:test'
+import {
+  activateProactive,
+  deactivateProactive,
+  isProactivePaused,
+  setContextBlocked,
+  subscribeToProactiveChanges,
+} from './index.js'
+
+describe('proactive state', () => {
+  const unsubscribers: Array<() => void> = []
+
+  afterEach(() => {
+    for (const unsubscribe of unsubscribers.splice(0)) {
+      unsubscribe()
+    }
+    deactivateProactive()
+  })
+
+  test('activation clears a stale context block', () => {
+    setContextBlocked(true)
+
+    activateProactive()
+
+    expect(isProactivePaused()).toBe(false)
+  })
+
+  test('one failing listener does not block later listeners or state changes', () => {
+    let notified = false
+    unsubscribers.push(
+      subscribeToProactiveChanges(() => {
+        throw new Error('listener failed')
+      }),
+    )
+    unsubscribers.push(
+      subscribeToProactiveChanges(() => {
+        notified = true
+      }),
+    )
+
+    expect(() => activateProactive()).not.toThrow()
+
+    expect(notified).toBe(true)
+    expect(isProactivePaused()).toBe(false)
+  })
+})

--- a/src/proactive/index.test.ts
+++ b/src/proactive/index.test.ts
@@ -26,21 +26,33 @@ describe('proactive state', () => {
   })
 
   test('one failing listener does not block later listeners or state changes', () => {
-    let notified = false
-    unsubscribers.push(
-      subscribeToProactiveChanges(() => {
-        throw new Error('listener failed')
-      }),
-    )
-    unsubscribers.push(
-      subscribeToProactiveChanges(() => {
-        notified = true
-      }),
-    )
+    const consoleError = console.error
+    const consoleErrors: unknown[][] = []
+    console.error = (...args: unknown[]) => {
+      consoleErrors.push(args)
+    }
+    try {
+      let notified = false
+      unsubscribers.push(
+        subscribeToProactiveChanges(() => {
+          throw new Error('listener failed')
+        }),
+      )
+      unsubscribers.push(
+        subscribeToProactiveChanges(() => {
+          notified = true
+        }),
+      )
 
-    expect(() => activateProactive()).not.toThrow()
+      expect(() => activateProactive()).not.toThrow()
 
-    expect(notified).toBe(true)
-    expect(isProactivePaused()).toBe(false)
+      expect(notified).toBe(true)
+      expect(isProactivePaused()).toBe(false)
+      expect(consoleErrors).toEqual([
+        ['proactive listener error', expect.any(Error)],
+      ])
+    } finally {
+      console.error = consoleError
+    }
   })
 })

--- a/src/proactive/index.ts
+++ b/src/proactive/index.ts
@@ -1,0 +1,70 @@
+type ProactiveListener = () => void
+
+const listeners = new Set<ProactiveListener>()
+
+let proactiveActive = false
+let proactivePaused = false
+let contextBlocked = false
+let nextTickAt: number | null = null
+
+function notifyProactiveListeners(): void {
+  for (const listener of listeners) {
+    listener()
+  }
+}
+
+export function subscribeToProactiveChanges(
+  listener: ProactiveListener,
+): () => void {
+  listeners.add(listener)
+  return () => {
+    listeners.delete(listener)
+  }
+}
+
+export function isProactiveActive(): boolean {
+  return proactiveActive
+}
+
+export function isProactivePaused(): boolean {
+  return proactivePaused || contextBlocked
+}
+
+export function getNextTickAt(): number | null {
+  return isProactivePaused() ? null : nextTickAt
+}
+
+export function activateProactive(_source?: string): void {
+  proactiveActive = true
+  proactivePaused = false
+  notifyProactiveListeners()
+}
+
+export function deactivateProactive(): void {
+  proactiveActive = false
+  proactivePaused = false
+  contextBlocked = false
+  nextTickAt = null
+  notifyProactiveListeners()
+}
+
+export function pauseProactive(): void {
+  proactivePaused = true
+  notifyProactiveListeners()
+}
+
+export function resumeProactive(): void {
+  if (!proactiveActive) {
+    return
+  }
+  proactivePaused = false
+  notifyProactiveListeners()
+}
+
+export function setContextBlocked(blocked: boolean): void {
+  contextBlocked = blocked
+  if (blocked) {
+    nextTickAt = null
+  }
+  notifyProactiveListeners()
+}

--- a/src/proactive/index.ts
+++ b/src/proactive/index.ts
@@ -11,7 +11,8 @@ function notifyProactiveListeners(): void {
   for (const listener of [...listeners]) {
     try {
       listener()
-    } catch {
+    } catch (error) {
+      console.error('proactive listener error', error)
       // Listener failures must not prevent state transitions or later listeners.
     }
   }

--- a/src/proactive/index.ts
+++ b/src/proactive/index.ts
@@ -8,8 +8,12 @@ let contextBlocked = false
 let nextTickAt: number | null = null
 
 function notifyProactiveListeners(): void {
-  for (const listener of listeners) {
-    listener()
+  for (const listener of [...listeners]) {
+    try {
+      listener()
+    } catch {
+      // Listener failures must not prevent state transitions or later listeners.
+    }
   }
 }
 
@@ -37,6 +41,8 @@ export function getNextTickAt(): number | null {
 export function activateProactive(_source?: string): void {
   proactiveActive = true
   proactivePaused = false
+  contextBlocked = false
+  nextTickAt = null
   notifyProactiveListeners()
 }
 


### PR DESCRIPTION
## Summary

Refs #1486.

Restores the proactive module import surface expected by feature-gated consumers and hardens the new state helper against stale pause state and subscriber failures.

## What changed

- Added `src/proactive/index.ts` with the proactive active/paused state helpers used by CLI, REPL, prompt, and tool code.
- Exposed the subscription and context-blocking helpers that existing lazy imports already call.
- Made activation clear stale context blocking so enabling proactive mode cannot remain silently paused.
- Isolated proactive-change listener failures so one bad subscriber cannot abort later notifications or leak through state transitions.
- Added focused unit tests for stale context-block activation and failing-listener notification behavior.

## Why

Several consumers lazy-require `../proactive/index.js` behind feature gates, but `main` no longer has that module. This leaves focused typecheck errors for the proactive import path and would also fail at runtime if the feature-gated path is enabled.

The review pass found two edge cases in the initial shim: context blocking could survive activation, and notification callbacks were allowed to throw through the state transition. Both are fixed in the state module rather than making callers defend against broken global state.

## Validation

- [x] `bun test src/proactive/index.test.ts` - 2 pass, 0 fail
- [x] `git diff --check` - passed
- [x] `bun run build` - passed
- [x] `bun run typecheck 2>&1 | tee /tmp/openclaude-typecheck-after-proactive-review.txt` - still reports unrelated repository backlog errors, but targeted grep for `proactive/index` and `src/proactive` has no matches

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced proactive state management with activation, deactivation, pause/resume, and context-blocking behavior
  * Added a subscription API that notifies listeners on state changes and isolates listener errors so one failure doesn't block others
* **Tests**
  * Added tests covering state transitions, context-blocking behavior, subscription cleanup, and listener error isolation
<!-- end of auto-generated comment: release notes by coderabbit.ai -->