### PR TITLE
fix(typecheck): narrow hook event counts

### DIFF
--- a/src/components/hooks/HooksConfigMenu.tsx
+++ b/src/components/hooks/HooksConfigMenu.tsx
@@ -49,6 +49,10 @@ type ModeState = {
   event: HookEvent;
   hook: IndividualHookConfig;
 };
+type HooksByEventAndMatcher = Record<
+  HookEvent,
+  Record<string, IndividualHookConfig[]>
+>;
 export function HooksConfigMenu(t0) {
   const $ = _c(100);
   const {
@@ -106,7 +110,7 @@ export function HooksConfigMenu(t0) {
   } else {
     t4 = $[7];
   }
-  const hooksByEventAndMatcher = t4;
+  const hooksByEventAndMatcher: HooksByEventAndMatcher = t4;
   let t5;
   if ($[8] !== hooksByEventAndMatcher || $[9] !== selectedEvent) {
     t5 = getSortedMatchersForEvent(hooksByEventAndMatcher, selectedEvent);
@@ -259,7 +263,7 @@ export function HooksConfigMenu(t0) {
   const hooksDisabled_1 = settings_1?.disableAllHooks === true;
   let t20;
   if ($[33] !== hooksByEventAndMatcher) {
-    const byEvent = {};
+    const byEvent: Partial<Record<HookEvent, number>> = {};
     let total = 0;
     for (const [event_0, matchers] of Object.entries(hooksByEventAndMatcher)) {
       const eventCount = Object.values(matchers).reduce(_temp5, 0);
@@ -559,7 +563,7 @@ export function HooksConfigMenu(t0) {
 function _temp6() {
   return <Text>Esc to close</Text>;
 }
-function _temp5(sum, hooks) {
+function _temp5(sum: number, hooks: IndividualHookConfig[]): number {
   return sum + hooks.length;
 }
 function _temp4(tool) {


### PR DESCRIPTION
## Summary

Refs #1486.

Fixes a focused hook menu typecheck error by preserving the concrete hook grouping shape through the memoized count calculation.

## What changed

- Added a local `HooksByEventAndMatcher` type for the grouped hook config map.
- Typed the per-event count accumulator and reducer callback so `Object.values(matchers)` stays `IndividualHookConfig[]` instead of degrading to `unknown`.

## Why

The component already builds a `HookEvent -> matcher -> hooks[]` map, but the React compiler cache slot erased that shape before the reduce call. Restoring the explicit local type keeps the runtime behavior unchanged while removing the loose object-access error.

## Validation

- [x] `bun run typecheck 2>&1 | tee /tmp/openclaude-typecheck-after-hook-counts.txt` — still reports unrelated backlog errors, but `grep -n "HooksConfigMenu" /tmp/openclaude-typecheck-after-hook-counts.txt` has no matches
- [x] `git diff --check` — passed
- [x] `bun run build` — passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Improved code type safety and reliability.

---

*This release contains no user-facing changes.*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->