### PR TITLE
fix(typecheck): restore control protocol type exports

### DIFF
--- a/scripts/generate-sdk-types.ts
+++ b/scripts/generate-sdk-types.ts
@@ -268,8 +268,10 @@ function convert(schema: any, depth = 0): string {
         .map(v => JSON.stringify(v))
         .join(' | ')
     }
-    case 'array':
-      return `${convert(def.element, depth)}[]`
+    case 'array': {
+      const element = convert(def.element, depth)
+      return `${needsArrayElementParens(element) ? `(${element})` : element}[]`
+    }
     case 'tuple': {
       const items = (def.items as any[]).map(t => convert(t, depth))
       return `[${items.join(', ')}]`
@@ -352,6 +354,10 @@ function isOptional(schema: any): boolean {
 
 function needsParens(ts: string): boolean {
   return ts.includes('\n') || ts.includes(' & ')
+}
+
+function needsArrayElementParens(ts: string): boolean {
+  return ts.includes(' | ') || ts.includes(' & ')
 }
 
 // ---------------------------------------------------------------------------

--- a/src/cli/structuredIO.ts
+++ b/src/cli/structuredIO.ts
@@ -352,7 +352,9 @@ export class StructuredIO {
         // by the REPL process itself, not just child Bash commands.
         const keys = Object.keys(message.variables)
         for (const [key, value] of Object.entries(message.variables)) {
-          process.env[key] = value
+          if (typeof value === 'string') {
+            process.env[key] = value
+          }
         }
         logForDebugging(
           `[structuredIO] applied update_environment_variables: ${keys.join(', ')}`,

--- a/src/entrypoints/sdk.d.ts
+++ b/src/entrypoints/sdk.d.ts
@@ -187,16 +187,38 @@ export type SessionMessage = {
 // Re-export precise SDK message types from generated types
 // These use camelCase field names and discriminated unions for full IntelliSense
 import type {
+  AccountInfo,
+  AgentInfo,
+  FastModeState,
+  ModelInfo,
+  SlashCommand,
   SDKMessage,
   SDKUserMessage,
   SDKResultMessage,
 } from './sdk/coreTypes.generated.js'
 
 export type {
+  AccountInfo,
+  AgentInfo,
+  FastModeState,
+  ModelInfo,
+  SlashCommand,
   SDKMessage,
   SDKUserMessage,
   SDKResultMessage,
 } from './sdk/coreTypes.generated.js'
+
+export type SDKControlInitializeResponse = {
+  commands: SlashCommand[]
+  agents: AgentInfo[]
+  output_style: string
+  available_output_styles: string[]
+  models: ModelInfo[]
+  account: AccountInfo
+  /** @internal CLI process PID for tmux socket isolation. */
+  pid?: number
+  fast_mode_state?: FastModeState
+}
 
 // ============================================================================
 // Query types

--- a/src/entrypoints/sdk/controlTypes.ts
+++ b/src/entrypoints/sdk/controlTypes.ts
@@ -6,6 +6,7 @@ import type {
   SDKControlPermissionRequestSchema,
   SDKControlReloadPluginsResponseSchema,
 } from './controlSchemas.js'
+import type { SDKPartialAssistantMessageSchema } from './coreSchemas.js'
 
 /*
  * The control schema source does not yet cover every request subtype handled by
@@ -37,10 +38,6 @@ export type SDKControlResponse = any
 export type SDKControlCancelRequest = any
 export type StdinMessage = any
 export type StdoutMessage = any
-export type SDKPartialAssistantMessage = {
-  type: 'stream_event'
-  event: any
-  parent_tool_use_id: string | null
-  uuid: string
-  session_id: string
-}
+export type SDKPartialAssistantMessage = InferSchema<
+  typeof SDKPartialAssistantMessageSchema
+>

--- a/src/entrypoints/sdk/controlTypes.ts
+++ b/src/entrypoints/sdk/controlTypes.ts
@@ -1,10 +1,46 @@
-/**
- * Stub — control protocol types not included in source snapshot. See
- * src/types/message.ts for the same scoping caveat (issue #473).
- */
+import type { z } from 'zod/v4'
+import type {
+  SDKControlInitializeRequestSchema,
+  SDKControlInitializeResponseSchema,
+  SDKControlMcpSetServersResponseSchema,
+  SDKControlPermissionRequestSchema,
+  SDKControlReloadPluginsResponseSchema,
+} from './controlSchemas.js'
 
+/*
+ * The control schema source does not yet cover every request subtype handled by
+ * print.ts. Keep aggregate transport messages permissive while exporting the
+ * named payload contracts that do have canonical schemas.
+ */
 /* eslint-disable @typescript-eslint/no-explicit-any */
+
+type InferSchema<T extends () => z.ZodType> = z.infer<ReturnType<T>>
+
+export type SDKControlInitializeRequest = InferSchema<
+  typeof SDKControlInitializeRequestSchema
+>
+export type SDKControlInitializeResponse = InferSchema<
+  typeof SDKControlInitializeResponseSchema
+>
+export type SDKControlPermissionRequest = InferSchema<
+  typeof SDKControlPermissionRequestSchema
+>
+export type SDKControlMcpSetServersResponse = InferSchema<
+  typeof SDKControlMcpSetServersResponseSchema
+>
+export type SDKControlReloadPluginsResponse = InferSchema<
+  typeof SDKControlReloadPluginsResponseSchema
+>
+export type SDKControlRequestInner = any
 export type SDKControlRequest = any
 export type SDKControlResponse = any
-export type SDKControlPermissionRequest = any
+export type SDKControlCancelRequest = any
+export type StdinMessage = any
 export type StdoutMessage = any
+export type SDKPartialAssistantMessage = {
+  type: 'stream_event'
+  event: any
+  parent_tool_use_id: string | null
+  uuid: string
+  session_id: string
+}

--- a/src/entrypoints/sdk/coreSchemas.ts
+++ b/src/entrypoints/sdk/coreSchemas.ts
@@ -62,6 +62,22 @@ export const ConfigScopeSchema = lazySchema(() =>
   z.enum(['local', 'user', 'project']).describe('Config scope for settings.'),
 )
 
+const API_PROVIDER_VALUES = [
+  'firstParty',
+  'bedrock',
+  'vertex',
+  'foundry',
+  'openai',
+  'gemini',
+  'github',
+  'codex',
+  'nvidia-nim',
+  'minimax',
+  'mistral',
+  'xai',
+  'xiaomi-mimo',
+] as const
+
 export const SdkBetaSchema = lazySchema(() =>
   z.literal('context-1m-2025-08-07'),
 )
@@ -1095,7 +1111,7 @@ export const AccountInfoSchema = lazySchema(() =>
       tokenSource: z.string().optional(),
       apiKeySource: z.string().optional(),
       apiProvider: z
-        .enum(['firstParty', 'bedrock', 'vertex', 'foundry'])
+        .enum(API_PROVIDER_VALUES)
         .optional()
         .describe(
           'Active API backend. Anthropic OAuth login only applies when "firstParty"; for 3P providers the other fields are absent and auth is external (AWS creds, gcloud ADC, etc.).',

--- a/src/entrypoints/sdk/coreTypes.generated.ts
+++ b/src/entrypoints/sdk/coreTypes.generated.ts
@@ -238,7 +238,7 @@ export type PermissionDecisionClassification = "user_temporary" | "user_permanen
 export type PermissionResult = ({
   behavior: "allow"
   updatedInput?: Record<string, unknown>
-  updatedPermissions?: ({
+  updatedPermissions?: (({
     type: "addRules"
     rules: {
       toolName: string
@@ -274,7 +274,7 @@ export type PermissionResult = ({
     type: "removeDirectories"
     directories: string[]
     destination: "userSettings" | "projectSettings" | "localSettings" | "session" | "cliArg"
-  })[]
+  }))[]
   toolUseID?: string
   decisionClassification?: "user_temporary" | "user_permanent" | "user_reject"
 }) | ({
@@ -504,7 +504,7 @@ export type PermissionRequestHookInput = {
   hook_event_name: "PermissionRequest"
   tool_name: string
   tool_input: unknown
-  permission_suggestions?: ({
+  permission_suggestions?: (({
     type: "addRules"
     rules: {
       toolName: string
@@ -540,7 +540,7 @@ export type PermissionRequestHookInput = {
     type: "removeDirectories"
     directories: string[]
     destination: "userSettings" | "projectSettings" | "localSettings" | "session" | "cliArg"
-  })[]
+  }))[]
 }
 
 export type SetupHookInput = {
@@ -892,7 +892,7 @@ export type HookInput = ({
   hook_event_name: "PermissionRequest"
   tool_name: string
   tool_input: unknown
-  permission_suggestions?: ({
+  permission_suggestions?: (({
     type: "addRules"
     rules: {
       toolName: string
@@ -928,7 +928,7 @@ export type HookInput = ({
     type: "removeDirectories"
     directories: string[]
     destination: "userSettings" | "projectSettings" | "localSettings" | "session" | "cliArg"
-  })[]
+  }))[]
 }) | ({
   session_id: string
   transcript_path: string
@@ -1138,7 +1138,7 @@ export type PermissionRequestHookSpecificOutput = {
   decision: ({
     behavior: "allow"
     updatedInput?: Record<string, unknown>
-    updatedPermissions?: ({
+    updatedPermissions?: (({
       type: "addRules"
       rules: {
         toolName: string
@@ -1174,7 +1174,7 @@ export type PermissionRequestHookSpecificOutput = {
       type: "removeDirectories"
       directories: string[]
       destination: "userSettings" | "projectSettings" | "localSettings" | "session" | "cliArg"
-    })[]
+    }))[]
   }) | ({
     behavior: "deny"
     message?: string
@@ -1257,7 +1257,7 @@ export type SyncHookJSONOutput = {
     decision: ({
       behavior: "allow"
       updatedInput?: Record<string, unknown>
-      updatedPermissions?: ({
+      updatedPermissions?: (({
         type: "addRules"
         rules: {
           toolName: string
@@ -1293,7 +1293,7 @@ export type SyncHookJSONOutput = {
         type: "removeDirectories"
         directories: string[]
         destination: "userSettings" | "projectSettings" | "localSettings" | "session" | "cliArg"
-      })[]
+      }))[]
     }) | ({
       behavior: "deny"
       message?: string
@@ -1367,7 +1367,7 @@ export type HookJSONOutput = ({
     decision: ({
       behavior: "allow"
       updatedInput?: Record<string, unknown>
-      updatedPermissions?: ({
+      updatedPermissions?: (({
         type: "addRules"
         rules: {
           toolName: string
@@ -1403,7 +1403,7 @@ export type HookJSONOutput = ({
         type: "removeDirectories"
         directories: string[]
         destination: "userSettings" | "projectSettings" | "localSettings" | "session" | "cliArg"
-      })[]
+      }))[]
     }) | ({
       behavior: "deny"
       message?: string
@@ -1470,7 +1470,7 @@ export type ModelInfo = {
   displayName: string
   description: string
   supportsEffort?: boolean
-  supportedEffortLevels?: "low" | "medium" | "high" | "max"[]
+  supportedEffortLevels?: ("low" | "medium" | "high" | "max")[]
   supportsAdaptiveThinking?: boolean
   supportsFastMode?: boolean
   supportsAutoMode?: boolean
@@ -1483,7 +1483,7 @@ export type AccountInfo = {
   subscriptionType?: string
   tokenSource?: string
   apiKeySource?: string
-  apiProvider?: "firstParty" | "bedrock" | "vertex" | "foundry"
+  apiProvider?: "firstParty" | "bedrock" | "vertex" | "foundry" | "openai" | "gemini" | "github" | "codex" | "nvidia-nim" | "minimax" | "mistral" | "xai" | "xiaomi-mimo"
 }
 
 export type AgentMcpServerSpec = string | (Record<string, ({
@@ -1511,7 +1511,7 @@ export type AgentDefinition = {
   disallowedTools?: string[]
   prompt: string
   model?: string
-  mcpServers?: string | (Record<string, ({
+  mcpServers?: (string | (Record<string, ({
     type?: "stdio"
     command: string
     args?: string[]
@@ -1527,7 +1527,7 @@ export type AgentDefinition = {
   }) | ({
     type: "sdk"
     name: string
-  })>)[]
+  })>))[]
   criticalSystemReminder_EXPERIMENTAL?: string
   skills?: string[]
   initialPrompt?: string

--- a/src/entrypoints/sdk/index.ts
+++ b/src/entrypoints/sdk/index.ts
@@ -66,6 +66,14 @@ export type {
   SDKAgentLoadFailureMessage,
   QueryPermissionMode,
 } from './shared.js'
+export type {
+  AccountInfo,
+  AgentInfo,
+  FastModeState,
+  ModelInfo,
+  SlashCommand,
+} from './coreTypes.js'
+export type { SDKControlInitializeResponse } from './controlTypes.js'
 
 // ============================================================================
 // Re-exports from permissions

--- a/src/remote/SessionsWebSocket.ts
+++ b/src/remote/SessionsWebSocket.ts
@@ -210,13 +210,17 @@ export class SessionsWebSocket {
   private handleMessage(data: string): void {
     try {
       const message: unknown = jsonParse(data)
+      const messageType =
+        typeof message === 'object' && message !== null && 'type' in message
+          ? String(message.type)
+          : 'unknown'
 
       // Forward SDK messages to callback
       if (isSessionsMessage(message)) {
         this.callbacks.onMessage(message)
       } else {
         logForDebugging(
-          `[SessionsWebSocket] Ignoring message type: ${typeof message === 'object' && message !== null && 'type' in message ? String(message.type) : 'unknown'}`,
+          `[SessionsWebSocket] Ignoring message type: ${messageType}`,
         )
       }
     } catch (error) {

--- a/tests/sdk/generated-types.test.ts
+++ b/tests/sdk/generated-types.test.ts
@@ -1,5 +1,6 @@
 import { describe, test, expect } from 'bun:test'
 import {
+  AccountInfoSchema,
   SDKAssistantMessageSchema,
   SDKSystemMessageSchema,
   SDKCompactBoundaryMessageSchema,
@@ -14,6 +15,7 @@ import {
   AgentDefinitionSchema,
   McpServerStatusSchema,
   ModelUsageSchema,
+  ModelInfoSchema,
   FastModeStateSchema,
   HookInputSchema,
   ExitReasonSchema,
@@ -264,6 +266,43 @@ describe('SDK Zod schemas (type generation source)', () => {
       maxOutputTokens: 8192,
     })
     expect(result.success).toBe(true)
+  })
+
+  test('ModelInfoSchema accepts supported effort level arrays', () => {
+    const schema = ModelInfoSchema()
+    const result = schema.safeParse({
+      value: 'claude-opus-4-6',
+      displayName: 'Claude Opus 4.6',
+      description: 'Most capable model',
+      supportsEffort: true,
+      supportedEffortLevels: ['low', 'medium', 'high', 'max'],
+    })
+
+    expect(result.success).toBe(true)
+  })
+
+  test('AccountInfoSchema accepts all runtime API provider categories', () => {
+    const schema = AccountInfoSchema()
+    const providers = [
+      'firstParty',
+      'bedrock',
+      'vertex',
+      'foundry',
+      'openai',
+      'gemini',
+      'github',
+      'codex',
+      'nvidia-nim',
+      'minimax',
+      'mistral',
+      'xai',
+      'xiaomi-mimo',
+    ]
+
+    for (const apiProvider of providers) {
+      expect(schema.safeParse({ apiProvider }).success).toBe(true)
+    }
+    expect(schema.safeParse({ apiProvider: 'unknown' }).success).toBe(false)
   })
 
   test('AgentDefinitionSchema accepts valid data', () => {

--- a/tests/sdk/package-consumer-types.test.ts
+++ b/tests/sdk/package-consumer-types.test.ts
@@ -205,6 +205,40 @@ describe('package consumer types', () => {
 
     expect(tsc(tmpDir)).toBe('')
   }, 30_000)
+
+  test('control initialize response accepts generated model and account values', () => {
+    const tmpDir = setupConsumerProject('control-init')
+
+    writeFileSync(
+      join(tmpDir, 'consumer.ts'),
+      [
+        `import type { SDKControlInitializeResponse } from '../../src/entrypoints/sdk/controlTypes.js'`,
+        `import type { ModelInfo } from '../../src/entrypoints/sdk/coreTypes.generated.js'`,
+        ``,
+        `const models: ModelInfo[] = [{`,
+        `  value: 'claude-opus-4-6',`,
+        `  displayName: 'Claude Opus 4.6',`,
+        `  description: 'Most capable model',`,
+        `  supportsEffort: true,`,
+        `  supportedEffortLevels: ['low', 'medium', 'high', 'max'],`,
+        `}]`,
+        ``,
+        `const response: SDKControlInitializeResponse = {`,
+        `  commands: [],`,
+        `  agents: [],`,
+        `  output_style: 'default',`,
+        `  available_output_styles: ['default'],`,
+        `  models,`,
+        `  account: { apiProvider: 'openai' },`,
+        `  pid: 1234,`,
+        `}`,
+        ``,
+        `console.log(response)`,
+      ].join('\n'),
+    )
+
+    expect(tsc(tmpDir)).toBe('')
+  }, 30_000)
 })
 
 describe('package exports resolution', () => {

--- a/tests/sdk/package-consumer-types.test.ts
+++ b/tests/sdk/package-consumer-types.test.ts
@@ -212,8 +212,7 @@ describe('package consumer types', () => {
     writeFileSync(
       join(tmpDir, 'consumer.ts'),
       [
-        `import type { SDKControlInitializeResponse } from '../../src/entrypoints/sdk/controlTypes.js'`,
-        `import type { ModelInfo } from '../../src/entrypoints/sdk/coreTypes.generated.js'`,
+        `import type { SDKControlInitializeResponse, ModelInfo } from '@gitlawb/openclaude/sdk'`,
         ``,
         `const models: ModelInfo[] = [{`,
         `  value: 'claude-opus-4-6',`,


### PR DESCRIPTION
## Summary

Refs #1486.

Fixes a focused SDK control protocol typecheck cluster by restoring missing control type exports, keeping broad transport aliases compatible with current incomplete schema coverage, and aligning the schema/generated initialize-response contracts with the values emitted by `print.ts`.

## What changed

- Added schema-derived named payload types for initialize, permission, MCP set-servers, and reload-plugins control payloads.
- Restored missing aggregate/control exports used by CLI, remote session, and CCR transport code.
- Narrowed two directly exposed consumers: string-only environment variable updates and WebSocket ignored-message logging.
- Widened `AccountInfoSchema.apiProvider` to the full runtime `getAPIProvider()` category surface.
- Fixed SDK type generation for arrays whose element type is a union, so effort-level arrays generate as `("low" | "medium" | "high" | "max")[]` instead of the wrong precedence form.

## Why

`controlTypes.ts` still has to keep aggregate transport messages permissive because the canonical control schemas do not yet cover every request subtype handled by `print.ts`. The stale export surface was causing consumers to fail before they could typecheck their actual logic. This keeps the broad compatibility boundary intact while making the named payload contracts concrete where schemas already exist.

The stricter initialize-response export also exposed two older contract mismatches: the account schema did not include third-party provider categories that the CLI intentionally emits, and the generator emitted arrays of unions with incorrect TypeScript precedence. Those are fixed at the schema/generator source rather than papered over with casts at the call site.

## Validation

- [x] `git diff --check` - passed
- [x] `bun test tests/sdk/generated-types.test.ts` - 18 pass, 0 fail
- [x] `bun test tests/sdk/package-consumer-types.test.ts` - 7 pass, 0 fail
- [x] `bun run build` - passed, including SDK declaration sync
- [x] `bun run typecheck 2>&1 | tee /tmp/openclaude-typecheck-after-control-review-final.txt` - still reports unrelated repository backlog errors, but targeted grep for `print.ts`, `SDKControlInitializeResponse`, `ModelInfo`, `AccountInfo`, and changed SDK/control files has no matches

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded API provider support with additional provider identifiers.
  * Permission updates now support multiple permission-update objects.
  * Model configurations now support optional effort level arrays.
  * MCP servers configuration updated to support optional array format.
  * SDK now exposes additional core types and an SDKControlInitializeResponse type to consumers.

* **Bug Fixes**
  * Environment variable handling now validates string types before assignment.

* **Tests**
  * Added schema validation tests for API providers and effort levels.
  * Added consumer type-check tests for SDK control initialization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->