### PR TITLE
Fix(minimax-m3-free): Add MiniMax M3 Free model to opencode/zen

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ Advanced and source-build guides:
 | Codex OAuth | `/provider` | Opens ChatGPT sign-in in your browser and stores Codex credentials securely |
 | Codex | `/provider` | Uses existing Codex CLI auth, OpenClaude secure storage, or env credentials |
 | Gitlawb Opengateway | `/provider` or zero-config fallback | Free smart gateway at `https://opengateway.gitlawb.com/v1`; routes Xiaomi MiMo and GMI Cloud partner models by `OPENAI_MODEL` |
-| OpenCode Zen | `/provider` or env vars | Pay-as-you-go AI gateway (41 models); uses `OPENCODE_API_KEY` via `https://opencode.ai/zen/v1`; shared key with OpenCode Go |
+| OpenCode Zen | `/provider` or env vars | Pay-as-you-go AI gateway (42 models); uses `OPENCODE_API_KEY` via `https://opencode.ai/zen/v1`; shared key with OpenCode Go |
 | OpenCode Go | `/provider` or env vars | $10/mo subscription for open models (12 models); uses `OPENCODE_API_KEY` via `https://opencode.ai/zen/go/v1`; shared key with OpenCode Zen |
 | Xiaomi MiMo | `/provider` or env vars | OpenAI-compatible API at `https://mimo.mi.com`; uses `MIMO_API_KEY` and defaults to `mimo-v2.5-pro` |
 | Ollama | `/provider` or env vars | Local inference with no API key |

--- a/docs/advanced-setup.md
+++ b/docs/advanced-setup.md
@@ -194,7 +194,7 @@ export OPENAI_MODEL=gpt-5.4
 openclaude
 ```
 
-OpenCode Zen is a pay-as-you-go AI gateway with 41 models (GPT, Claude, Gemini,
+OpenCode Zen is a pay-as-you-go AI gateway with 42 models (GPT, Claude, Gemini,
 Qwen, MiniMax, GLM, Kimi, Grok, Big Pickle, DeepSeek, Nemotron). Uses the same
 `OPENCODE_API_KEY` as OpenCode Go. Get your key from https://opencode.ai.
 

--- a/src/integrations/gateways/opencode.test.ts
+++ b/src/integrations/gateways/opencode.test.ts
@@ -284,7 +284,7 @@ describe('OpenCode model catalog', () => {
 
   test('zen model count matches expected', () => {
     const models = getCatalogEntriesForRoute('opencode')
-    expect(models.length).toBe(41)
+    expect(models.length).toBe(42)
   })
 
   test('go model count matches expected', () => {

--- a/src/integrations/gateways/opencode.ts
+++ b/src/integrations/gateways/opencode.ts
@@ -20,7 +20,7 @@ export default defineGateway({
   preset: {
     id: 'opencode',
     vendorId: 'openai',
-    description: 'OpenCode Zen — pay-as-you-go AI gateway (41 models)',
+    description: 'OpenCode Zen — pay-as-you-go AI gateway (42 models)',
     apiKeyEnvVars: ['OPENCODE_API_KEY'],
     modelEnvVars: ['OPENAI_MODEL'],
   },
@@ -74,6 +74,7 @@ export default defineGateway({
       // OpenAI-compatible — /zen/v1/chat/completions (default, no override needed)
       { id: 'minimax-m2.7', apiName: 'minimax-m2.7', label: 'MiniMax M2.7', modelDescriptorId: 'opencode-minimax-m2.7' },
       { id: 'minimax-m2.5', apiName: 'minimax-m2.5', label: 'MiniMax M2.5', modelDescriptorId: 'opencode-minimax-m2.5' },
+      { id: 'minimax-m3-free', apiName: 'minimax-m3-free', label: 'MiniMax M3 Free', modelDescriptorId: 'opencode-minimax-m3-free' },
       { id: 'glm-5.1', apiName: 'glm-5.1', label: 'GLM 5.1', modelDescriptorId: 'opencode-glm-5.1' },
       { id: 'glm-5', apiName: 'glm-5', label: 'GLM 5', modelDescriptorId: 'opencode-glm-5' },
       { id: 'kimi-k2.5', apiName: 'kimi-k2.5', label: 'Kimi K2.5', modelDescriptorId: 'opencode-kimi-k2.5' },

--- a/src/integrations/generated/integrationArtifacts.generated.ts
+++ b/src/integrations/generated/integrationArtifacts.generated.ts
@@ -323,7 +323,7 @@ export const PROVIDER_PRESET_MANIFEST = [
     "routeId": "opencode",
     "vendorId": "openai",
     "gatewayId": "opencode",
-    "description": "OpenCode Zen — pay-as-you-go AI gateway (41 models)",
+    "description": "OpenCode Zen — pay-as-you-go AI gateway (42 models)",
     "apiKeyEnvVars": [
       "OPENCODE_API_KEY"
     ],

--- a/src/integrations/models/opencode.ts
+++ b/src/integrations/models/opencode.ts
@@ -609,6 +609,24 @@ export default [
     maxOutputTokens: 32_768,
   }),
   defineModel({
+    id: 'opencode-minimax-m3-free',
+    label: 'MiniMax M3 Free',
+
+    vendorId: 'openai',
+    classification: ['chat'],
+    defaultModel: 'opencode-minimax-m3-free',
+    capabilities: {
+      supportsVision: false,
+      supportsStreaming: true,
+      supportsFunctionCalling: true,
+      supportsJsonMode: true,
+      supportsReasoning: false,
+      supportsPreciseTokenCount: false,
+    },
+    contextWindow: 131_072,
+    maxOutputTokens: 32_768,
+  }),
+  defineModel({
     id: 'opencode-glm-5.1',
     label: 'GLM 5.1',
 


### PR DESCRIPTION
## Summary

Fixes for the rejected PR's findings:                                                                                 
   
  - Missing OpenCode model descriptor — src/integrations/models/opencode.ts:611-628                                
  Added opencode-minimax-m3-free with conservative free-tier metadata (chat-only, no vision, no reasoning,
  131_072/32_768 tokens), matching the existing *-free opencode descriptors. Resolves the dangling modelDescriptorId    
  reference from the catalog and unblocks getModelsForGateway('opencode') enrichment.
  - Zen model count in `opencode.ts:23` — bumped 41 models → 42 models.                                             
  - Zen model count in test `opencode.test.ts:287` — bumped expect(...).toBe(41) → 42. The cross-reference test at  
  line 327 (which was the actual failure mode in the rejected PR) will now also pass.                                   
  - User-facing docs — README.md:165 and docs/advanced-setup.md:197 bumped to 42 models.                          
  - Generated artifact — `src/integrations/generated/integrationArtifacts.generated.ts:326` hand-synced to 42 models.
                   
