### PR TITLE
fix(test): stop use-input test from leaking a global stdin mock

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -18,7 +18,6 @@
         "@modelcontextprotocol/sdk": "1.29.0",
         "@orama/orama": "^3.1.18",
         "@orama/plugin-data-persistence": "^3.1.18",
-        "@testing-library/react-hooks": "^8.0.1",
         "@vscode/ripgrep": "^1.17.1",
         "ajv": "8.18.0",
         "auto-bind": "5.0.1",
@@ -77,7 +76,6 @@
         "@types/bun": "1.3.11",
         "@types/node": "25.5.0",
         "@types/react": "19.2.14",
-        "react-test-renderer": "^19.2.6",
         "tsx": "^4.21.0",
         "typescript": "5.9.3",
       },
@@ -420,8 +418,6 @@
     "@smithy/util-uri-escape": ["@smithy/util-uri-escape@3.0.0", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-LqR7qYLgZTD7nWLBecUi4aqolw8Mhza9ArpNEQ881MJJIU2sE5iHCK6TdyqqzcDLy0OPe10IY4T8ctVdtynubg=="],
 
     "@smithy/util-utf8": ["@smithy/util-utf8@4.3.1", "", { "dependencies": { "@smithy/core": "^3.24.1", "tslib": "^2.6.2" } }, "sha512-FtRrSnriXtOs4+J8/y9SbQ1xmN71hrOsN/YJr5PQQj5nR1l7YNkGS/TEk4gr0WN7gyrUqw8/RFaYVjI18732ZA=="],
-
-    "@testing-library/react-hooks": ["@testing-library/react-hooks@8.0.1", "", { "dependencies": { "@babel/runtime": "^7.12.5", "react-error-boundary": "^3.1.0" }, "peerDependencies": { "@types/react": "^16.9.0 || ^17.0.0", "react": "^16.9.0 || ^17.0.0", "react-dom": "^16.9.0 || ^17.0.0", "react-test-renderer": "^16.9.0 || ^17.0.0" }, "optionalPeers": ["@types/react", "react-dom", "react-test-renderer"] }, "sha512-Aqhl2IVmLt8IovEVarNDFuJDVWVvhnr9/GCU6UUnrYXwgDFF9h2L2o2P9KBni1AST5sT6riAyoukFLyjQUgD/g=="],
 
     "@types/bun": ["@types/bun@1.3.11", "", { "dependencies": { "bun-types": "1.3.11" } }, "sha512-5vPne5QvtpjGpsGYXiFyycfpDF2ECyPcTSsFBMa0fraoxiQyMJ3SmuQIGhzPg2WJuWxVBoxWJ2kClYTcw/4fAg=="],
 
@@ -813,13 +809,7 @@
 
     "react-compiler-runtime": ["react-compiler-runtime@1.0.0", "", { "peerDependencies": { "react": "^17.0.0 || ^18.0.0 || ^19.0.0 || ^0.0.0-experimental" } }, "sha512-rRfjYv66HlG8896yPUDONgKzG5BxZD1nV9U6rkm+7VCuvQc903C4MjcoZR4zPw53IKSOX9wMQVpA1IAbRtzQ7w=="],
 
-    "react-error-boundary": ["react-error-boundary@3.1.4", "", { "dependencies": { "@babel/runtime": "^7.12.5" }, "peerDependencies": { "react": ">=16.13.1" } }, "sha512-uM9uPzZJTF6wRQORmSrvOIgt4lJ9MC1sNgEOj2XGsDTRE4kmpWxg7ENK9EWNKJRMAOY9z0MuF4yIfl6gp4sotA=="],
-
-    "react-is": ["react-is@19.2.6", "", {}, "sha512-XjBR15BhXuylgWGuslhDKqlSayuqvqBX91BP8pauG8kd1zY8kotkNWbXksTCNRarse4kuGbe2kIY05ARtwNIvw=="],
-
     "react-reconciler": ["react-reconciler@0.33.0", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.0" } }, "sha512-KetWRytFv1epdpJc3J4G75I4WrplZE5jOL7Yq0p34+OVOKF4Se7WrdIdVC45XsSSmUTlht2FM/fM1FZb1mfQeA=="],
-
-    "react-test-renderer": ["react-test-renderer@19.2.6", "", { "dependencies": { "react-is": "^19.2.6", "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.6" } }, "sha512-GbS6V23YduFTPiWJ5xICbKEjRcqx1Z90js/V5miqhz7qp/d6xSe9Dd6NjSQODFRdzdsqRMPW82E/sFpPRbY5Mw=="],
 
     "readdirp": ["readdirp@4.1.2", "", {}, "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg=="],
 

--- a/package.json
+++ b/package.json
@@ -139,11 +139,9 @@
     "zod": "3.25.76"
   },
   "devDependencies": {
-    "@testing-library/react-hooks": "^8.0.1",
     "@types/bun": "1.3.11",
     "@types/node": "25.5.0",
     "@types/react": "19.2.14",
-    "react-test-renderer": "^19.2.6",
     "tsx": "^4.21.0",
     "typescript": "5.9.3"
   },

--- a/src/ink/hooks/use-input.test.ts
+++ b/src/ink/hooks/use-input.test.ts
@@ -1,116 +1,166 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from 'bun:test'
+import { PassThrough } from 'node:stream'
 
-// Hoist the mock so it's available before module load
-const mockSetRawMode = vi.fn()
-const mockEventEmitter = { on: vi.fn(), removeListener: vi.fn(), emit: vi.fn() }
+import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test'
+import { createElement } from 'react'
 
-vi.mock('./use-stdin.js', () => ({
-  default: () => ({
-    setRawMode: mockSetRawMode,
+import { EventEmitter } from '../events/emitter.js'
+import StdinContext, { type Props } from '../components/StdinContext.js'
+import { createRoot, type Root } from '../root.js'
+import useInput from './use-input.js'
+
+// The hook reads its stdin handle from StdinContext, so we inject a fake
+// context value instead of mocking the module. A module-level mock.module()
+// would leak into every subsequent test file in the same `bun test` process
+// (use-stdin would stay replaced), silently breaking input handling in
+// unrelated component tests — so we deliberately avoid it here.
+function createStdinContextValue(setRawMode: (value: boolean) => void): Props {
+  return {
+    stdin: process.stdin,
+    setRawMode,
+    isRawModeSupported: true,
     internal_exitOnCtrlC: false,
-    internal_eventEmitter: mockEventEmitter,
-  }),
-}))
+    internal_eventEmitter: new EventEmitter(),
+    internal_querier: null,
+  }
+}
 
-// Dynamic import after mock is registered
-const { renderHook, act } = await import('@testing-library/react-hooks')
-const useInput = (await import('./use-input.js')).default
+function createTestStdout(): NodeJS.WriteStream {
+  const stdout = new PassThrough()
+  ;(stdout as unknown as { columns: number }).columns = 80
+  return stdout as unknown as NodeJS.WriteStream
+}
+
+// A probe that mounts the hook under test, with isActive driven by props so we
+// can exercise the mount / re-render / unmount transitions.
+function Probe({ isActive }: { isActive?: boolean }): null {
+  useInput(() => {}, { isActive })
+  return null
+}
+
+// Renders the probe inside an injected StdinContext so the hook's setRawMode
+// calls land on our spy. The deferred raw-mode reset uses a real setTimeout(0),
+// so tests await `tick()` to let it fire rather than using fake timers.
+async function renderProbe(
+  setRawMode: (value: boolean) => void,
+  initial: { isActive?: boolean } = {},
+): Promise<{
+  rerender: (props: { isActive?: boolean }) => void
+  unmount: () => void
+}> {
+  const stdout = createTestStdout()
+  const root: Root = await createRoot({ stdout, patchConsole: false })
+  const contextValue = createStdinContextValue(setRawMode)
+
+  const draw = (props: { isActive?: boolean }) =>
+    root.render(
+      createElement(
+        StdinContext.Provider,
+        { value: contextValue },
+        createElement(Probe, props),
+      ),
+    )
+
+  draw(initial)
+
+  return {
+    rerender: draw,
+    unmount: () => root.unmount(),
+  }
+}
+
+function tick(): Promise<void> {
+  return Bun.sleep(5)
+}
 
 describe('useInput — raw mode lifecycle', () => {
+  let setRawMode: ReturnType<typeof mock>
+
   beforeEach(() => {
-    vi.useFakeTimers()
-    mockSetRawMode.mockClear()
+    setRawMode = mock((_value: boolean) => {})
   })
 
   afterEach(() => {
-    vi.useRealTimers()
+    mock.restore()
   })
 
-  it('enables raw mode on mount when isActive is true (default)', () => {
-    const handler = vi.fn()
-    renderHook(() => useInput(handler))
-
-    expect(mockSetRawMode).toHaveBeenCalledWith(true)
+  test('enables raw mode on mount when isActive is true (default)', async () => {
+    const probe = await renderProbe(setRawMode)
+    try {
+      expect(setRawMode).toHaveBeenCalledWith(true)
+    } finally {
+      probe.unmount()
+    }
   })
 
-  it('does NOT enable raw mode when isActive is false', () => {
-    const handler = vi.fn()
-    renderHook(() => useInput(handler, { isActive: false }))
-
-    expect(mockSetRawMode).not.toHaveBeenCalled()
+  test('does NOT enable raw mode when isActive is false', async () => {
+    const probe = await renderProbe(setRawMode, { isActive: false })
+    try {
+      expect(setRawMode).not.toHaveBeenCalled()
+    } finally {
+      probe.unmount()
+    }
   })
 
-  it('defers setRawMode(false) on unmount — fires after one tick', () => {
-    const handler = vi.fn()
-    const { unmount } = renderHook(() => useInput(handler))
+  test('defers setRawMode(false) on unmount — fires after one tick', async () => {
+    const probe = await renderProbe(setRawMode)
 
-    unmount()
+    probe.unmount()
 
-    // Immediately after unmount, setRawMode(false) has NOT yet fired
-    expect(mockSetRawMode).toHaveBeenCalledTimes(1) // only the initial true
-    expect(mockSetRawMode).toHaveBeenCalledWith(true)
+    // Immediately after unmount, setRawMode(false) has NOT yet fired.
+    expect(setRawMode).toHaveBeenCalledTimes(1) // only the initial true
+    expect(setRawMode).toHaveBeenCalledWith(true)
 
-    // Advance timers — the deferred reset fires
-    vi.advanceTimersByTime(1)
+    // Let the deferred reset fire.
+    await tick()
 
-    expect(mockSetRawMode).toHaveBeenCalledTimes(2)
-    expect(mockSetRawMode).toHaveBeenLastCalledWith(false)
+    expect(setRawMode).toHaveBeenCalledTimes(2)
+    expect(setRawMode).toHaveBeenLastCalledWith(false)
   })
 
-  it('cancels deferred reset on isActive false→true transition (MCP re-render churn)', () => {
-    const handler = vi.fn()
-    const { rerender, unmount } = renderHook(
-      ({ isActive }: { isActive: boolean }) => useInput(handler, { isActive }),
-      { initialProps: { isActive: true } },
-    )
+  test('cancels deferred reset on isActive false→true transition (MCP re-render churn)', async () => {
+    const probe = await renderProbe(setRawMode, { isActive: true })
 
-    expect(mockSetRawMode).toHaveBeenCalledTimes(1)
-    expect(mockSetRawMode).toHaveBeenCalledWith(true)
+    expect(setRawMode).toHaveBeenCalledTimes(1)
+    expect(setRawMode).toHaveBeenCalledWith(true)
 
-    // Toggle to inactive — effect cleanup schedules deferred reset
-    rerender({ isActive: false })
+    // Toggle to inactive — effect cleanup schedules the deferred reset.
+    probe.rerender({ isActive: false })
 
-    // Cleanup ran: timer scheduled but hasn't fired yet
-    expect(mockSetRawMode).toHaveBeenCalledTimes(1)
+    // Cleanup ran: timer scheduled but hasn't fired yet.
+    expect(setRawMode).toHaveBeenCalledTimes(1)
 
-    // Toggle back to active before timer fires — setup cancels pending reset
-    rerender({ isActive: true })
+    // Toggle back to active before the timer fires — setup cancels the pending
+    // reset and does NOT call setRawMode(true) again, because the counter was
+    // never decremented by the deferred reset.
+    probe.rerender({ isActive: true })
 
-    // Setup cleared the pending timer but did NOT call setRawMode(true)
-    // because the counter was never decremented by the deferred reset.
-    expect(mockSetRawMode).toHaveBeenCalledTimes(1)
-    expect(mockSetRawMode).toHaveBeenLastCalledWith(true)
+    expect(setRawMode).toHaveBeenCalledTimes(1)
+    expect(setRawMode).toHaveBeenLastCalledWith(true)
 
-    // Advance timers — the cancelled reset should NOT fire
-    vi.advanceTimersByTime(100)
+    // The cancelled reset must not fire.
+    await tick()
+    expect(setRawMode).toHaveBeenCalledTimes(1)
 
-    // Still only 1 call (no setRawMode(false), no redundant setRawMode(true))
-    expect(mockSetRawMode).toHaveBeenCalledTimes(1)
+    // Final unmount fires the deferred reset.
+    probe.unmount()
+    await tick()
 
-    // Clean up: final unmount fires the deferred reset
-    unmount()
-    vi.advanceTimersByTime(1)
-
-    expect(mockSetRawMode).toHaveBeenCalledTimes(2)
-    expect(mockSetRawMode).toHaveBeenLastCalledWith(false)
+    expect(setRawMode).toHaveBeenCalledTimes(2)
+    expect(setRawMode).toHaveBeenLastCalledWith(false)
   })
 
-  it('handles isActive true → false transition: disables raw mode', () => {
-    const handler = vi.fn()
-    const { rerender } = renderHook(
-      ({ isActive }) => useInput(handler, { isActive }),
-      { initialProps: { isActive: true } },
-    )
+  test('handles isActive true → false transition: disables raw mode', async () => {
+    const probe = await renderProbe(setRawMode, { isActive: true })
 
-    expect(mockSetRawMode).toHaveBeenCalledWith(true)
+    expect(setRawMode).toHaveBeenCalledWith(true)
 
-    // Transition to inactive
-    rerender({ isActive: false })
+    // Transition to inactive — the cleanup from the isActive=true run schedules
+    // a deferred reset.
+    probe.rerender({ isActive: false })
+    await tick()
 
-    // The effect cleanup from the previous isActive=true run
-    // schedules a deferred reset
-    vi.advanceTimersByTime(1)
+    expect(setRawMode).toHaveBeenLastCalledWith(false)
 
-    expect(mockSetRawMode).toHaveBeenLastCalledWith(false)
+    probe.unmount()
   })
 })


### PR DESCRIPTION
The use-input.test.ts added in #1198 broke the full `bun test` run two ways:

1. It imported `@testing-library/react-hooks`, which was never installed and is React 16/17/18-only (incompatible with this repo's React 19), so the file errored on load.
2. Its top-level `vi.mock('./use-stdin.js', …)` registered a module mock that leaks across every later file in the same `bun test` process. The fake eventEmitter's `.on` was a no-op, so `useInput` silently registered no listener and dropped all keystrokes — surfacing as timeouts in MonitorPermissionRequest and the agent-menu/wizard TextInput tests (which passed in isolation but failed in the full suite).

Rewrite the test to inject the stdin handle via StdinContext.Provider (no leaking global mock) and render through the real ink root (no @testing-library/react-hooks). Drop the now-dead react-hooks and react-test-renderer devDependencies and reconcile the lockfile.

Full suite: 3429 pass, 0 fail (was 9 fail + 1 error).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development dependencies.

* **Tests**
  * Refactored test infrastructure for improved maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->