### PR TITLE
fix(typecheck): restore typed add-dir source

### DIFF
--- a/src/commands/add-dir/add-dir.tsx
+++ b/src/commands/add-dir/add-dir.tsx
@@ -1,4 +1,3 @@
-import { c as _c } from "react-compiler-runtime";
 import chalk from 'chalk';
 import figures from 'figures';
 import React, { useEffect } from 'react';
@@ -12,55 +11,27 @@ import { applyPermissionUpdate, persistPermissionUpdate } from '../../utils/perm
 import type { PermissionUpdateDestination } from '../../utils/permissions/PermissionUpdateSchema.js';
 import { SandboxManager } from '../../utils/sandbox/sandbox-adapter.js';
 import { addDirHelpMessage, validateDirectoryForWorkspace } from './validation.js';
-function AddDirError(t0) {
-  const $ = _c(10);
-  const {
-    message,
-    args,
-    onDone
-  } = t0;
-  let t1;
-  let t2;
-  if ($[0] !== onDone) {
-    t1 = () => {
-      const timer = setTimeout(onDone, 0);
-      return () => clearTimeout(timer);
-    };
-    t2 = [onDone];
-    $[0] = onDone;
-    $[1] = t1;
-    $[2] = t2;
-  } else {
-    t1 = $[1];
-    t2 = $[2];
-  }
-  useEffect(t1, t2);
-  let t3;
-  if ($[3] !== args) {
-    t3 = <Text dimColor={true}>{figures.pointer} /add-dir {args}</Text>;
-    $[3] = args;
-    $[4] = t3;
-  } else {
-    t3 = $[4];
-  }
-  let t4;
-  if ($[5] !== message) {
-    t4 = <MessageResponse><Text>{message}</Text></MessageResponse>;
-    $[5] = message;
-    $[6] = t4;
-  } else {
-    t4 = $[6];
-  }
-  let t5;
-  if ($[7] !== t3 || $[8] !== t4) {
-    t5 = <Box flexDirection="column">{t3}{t4}</Box>;
-    $[7] = t3;
-    $[8] = t4;
-    $[9] = t5;
-  } else {
-    t5 = $[9];
-  }
-  return t5;
+
+type AddDirErrorProps = {
+  message: string;
+  args: string;
+  onDone: () => void;
+};
+
+function AddDirError({ message, args, onDone }: AddDirErrorProps): React.ReactNode {
+  useEffect(() => {
+    const timer = setTimeout(onDone, 0);
+    return () => clearTimeout(timer);
+  }, [onDone]);
+
+  return (
+    <Box flexDirection="column">
+      <Text dimColor={true}>{figures.pointer} /add-dir {args}</Text>
+      <MessageResponse>
+        <Text>{message}</Text>
+      </MessageResponse>
+    </Box>
+  );
 }
 export async function call(onDone: LocalJSXCommandOnDone, context: LocalJSXCommandContext, args?: string): Promise<React.ReactNode> {
   const directoryPath = (args ?? '').trim();

--- a/src/components/permissions/rules/AddWorkspaceDirectory.tsx
+++ b/src/components/permissions/rules/AddWorkspaceDirectory.tsx
@@ -144,7 +144,7 @@ export function AddWorkspaceDirectory(t0) {
     directoryPath
   } = t0;
   const [directoryInput, setDirectoryInput] = useState("");
-  const [error, setError] = useState(null);
+  const [error, setError] = useState<string | null>(null);
   let t1;
   if ($[0] === Symbol.for("react.memo_cache_sentinel")) {
     t1 = [];


### PR DESCRIPTION
Refs #1486.

## Summary
- Restores `AddDirError` from compiler-cache output to typed React source.
- Types the add-workspace-directory validation error state as `string | null` so validation help messages can be assigned.

## Why
The add-dir command source had compiler-cache output checked in, and the current typecheck run reported a `SetStateAction<null>` diagnostic when `AddWorkspaceDirectory` stores validation help text.

## Validation
- `git diff --check`
- `bun run build`
- `bun test src/commands/add-dir` (no matching focused test files exist)
- `bun run typecheck` still exits 2 because of the unrelated existing backlog; normalized diagnostics for this branch go from 1,760 to 1,759, with 0 new diagnostics and 1 removed diagnostic. No diagnostics remain for `src/commands/add-dir/add-dir.tsx` or `src/components/permissions/rules/AddWorkspaceDirectory.tsx`.

## Review
- Exact open PR file-overlap check found no open PR touching either changed file.
- Diff reviewed before publishing; no issues found.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined add directory functionality with enhanced type safety and reduced code complexity.
  * Improved type definitions for workspace directory permissions handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->