### PR TITLE
Feat/gemma 4 models

### DIFF
--- a/src/integrations/brands/gemini.ts
+++ b/src/integrations/brands/gemini.ts
@@ -21,10 +21,7 @@ export default defineBrand({
     'google/gemini-3.1-flash-lite-preview',
     'google/gemini-2.5-pro',
     'google/gemini-2.0-flash',
-    'gemma-4-e2b',
-    'gemma-4-e4b',
-    'gemma-4-12b',
-    'gemma-4-26b-a4b',
-    'gemma-4-31b',
+    'gemma-4-26b-a4b-it',
+    'gemma-4-31b-it',
   ],
 })

--- a/src/integrations/brands/gemini.ts
+++ b/src/integrations/brands/gemini.ts
@@ -21,5 +21,10 @@ export default defineBrand({
     'google/gemini-3.1-flash-lite-preview',
     'google/gemini-2.5-pro',
     'google/gemini-2.0-flash',
+    'gemma-4-e2b',
+    'gemma-4-e4b',
+    'gemma-4-12b',
+    'gemma-4-26b-a4b',
+    'gemma-4-31b',
   ],
 })

--- a/src/integrations/models/gemini.ts
+++ b/src/integrations/models/gemini.ts
@@ -47,6 +47,6 @@ export default [
   geminiModel('google/gemini-2.5-pro', 'Google Gemini 2.5 Pro', 65_536),
   geminiModel('google/gemini-2.0-flash', 'Google Gemini 2.0 Flash', 8_192),
 
-  gemmaModel('gemma-4-26b-a4b-it', 'Gemma 4 26B A4B', 262_144, 8_192),
-  gemmaModel('gemma-4-31b-it', 'Gemma 4 31B', 262_144, 8_192),
+  gemmaModel('gemma-4-26b-a4b-it', 'Gemma 4 26B A4B', 262_144, 65_536),
+  gemmaModel('gemma-4-31b-it', 'Gemma 4 31B', 262_144, 65_536),
 ]

--- a/src/integrations/models/gemini.ts
+++ b/src/integrations/models/gemini.ts
@@ -29,7 +29,7 @@ function gemmaModel(id: string, label: string, contextWindow: number, maxOutputT
     label,
     brandId: 'gemini',
     vendorId: 'gemini',
-    classification: ['chat', 'reasoning', 'coding'],
+    classification: ['chat', 'reasoning', 'coding', 'vision'],
     defaultModel: id,
     capabilities: geminiCapabilities,
     contextWindow,
@@ -47,9 +47,6 @@ export default [
   geminiModel('google/gemini-2.5-pro', 'Google Gemini 2.5 Pro', 65_536),
   geminiModel('google/gemini-2.0-flash', 'Google Gemini 2.0 Flash', 8_192),
 
-  gemmaModel('gemma-4-e2b', 'Gemma 4 E2B', 131_072, 8_192),
-  gemmaModel('gemma-4-e4b', 'Gemma 4 E4B', 131_072, 8_192),
-  gemmaModel('gemma-4-12b', 'Gemma 4 12B', 262_144, 8_192),
-  gemmaModel('gemma-4-26b-a4b', 'Gemma 4 26B A4B', 262_144, 8_192),
-  gemmaModel('gemma-4-31b', 'Gemma 4 31B', 262_144, 8_192),
+  gemmaModel('gemma-4-26b-a4b-it', 'Gemma 4 26B A4B', 262_144, 8_192),
+  gemmaModel('gemma-4-31b-it', 'Gemma 4 31B', 262_144, 8_192),
 ]

--- a/src/integrations/models/gemini.ts
+++ b/src/integrations/models/gemini.ts
@@ -23,6 +23,20 @@ function geminiModel(id: string, label: string, maxOutputTokens: number) {
   })
 }
 
+function gemmaModel(id: string, label: string, contextWindow: number, maxOutputTokens: number) {
+  return defineModel({
+    id,
+    label,
+    brandId: 'gemini',
+    vendorId: 'gemini',
+    classification: ['chat', 'reasoning', 'coding'],
+    defaultModel: id,
+    capabilities: geminiCapabilities,
+    contextWindow,
+    maxOutputTokens,
+  })
+}
+
 export default [
   geminiModel('gemini-3.1-flash-lite-preview', 'Gemini 3.1 Flash Lite Preview', 65_536),
   geminiModel('gemini-3.1-pro', 'Gemini 3.1 Pro', 65_536),
@@ -32,4 +46,10 @@ export default [
   geminiModel('google/gemini-3.1-flash-lite-preview', 'Google Gemini 3.1 Flash Lite Preview', 65_536),
   geminiModel('google/gemini-2.5-pro', 'Google Gemini 2.5 Pro', 65_536),
   geminiModel('google/gemini-2.0-flash', 'Google Gemini 2.0 Flash', 8_192),
+
+  gemmaModel('gemma-4-e2b', 'Gemma 4 E2B', 131_072, 8_192),
+  gemmaModel('gemma-4-e4b', 'Gemma 4 E4B', 131_072, 8_192),
+  gemmaModel('gemma-4-12b', 'Gemma 4 12B', 262_144, 8_192),
+  gemmaModel('gemma-4-26b-a4b', 'Gemma 4 26B A4B', 262_144, 8_192),
+  gemmaModel('gemma-4-31b', 'Gemma 4 31B', 262_144, 8_192),
 ]

--- a/src/integrations/vendors/gemini.ts
+++ b/src/integrations/vendors/gemini.ts
@@ -36,11 +36,8 @@ export default defineVendor({
     models: [
       { id: 'gemini-3-flash-preview', apiName: 'gemini-3-flash-preview', label: 'Gemini 3 Flash Preview' },
       { id: 'gemini-2.5-pro', apiName: 'gemini-2.5-pro', label: 'Gemini 2.5 Pro' },
-      { id: 'gemma-4-e2b', apiName: 'gemma-4-e2b', label: 'Gemma 4 E2B' },
-      { id: 'gemma-4-e4b', apiName: 'gemma-4-e4b', label: 'Gemma 4 E4B' },
-      { id: 'gemma-4-12b', apiName: 'gemma-4-12b', label: 'Gemma 4 12B' },
-      { id: 'gemma-4-26b-a4b', apiName: 'gemma-4-26b-a4b', label: 'Gemma 4 26B A4B' },
-      { id: 'gemma-4-31b', apiName: 'gemma-4-31b', label: 'Gemma 4 31B' },
+      { id: 'gemma-4-26b-a4b-it', apiName: 'gemma-4-26b-a4b-it', label: 'Gemma 4 26B A4B' },
+      { id: 'gemma-4-31b-it', apiName: 'gemma-4-31b-it', label: 'Gemma 4 31B' },
     ],
   },
   usage: { supported: false },

--- a/src/integrations/vendors/gemini.ts
+++ b/src/integrations/vendors/gemini.ts
@@ -36,6 +36,11 @@ export default defineVendor({
     models: [
       { id: 'gemini-3-flash-preview', apiName: 'gemini-3-flash-preview', label: 'Gemini 3 Flash Preview' },
       { id: 'gemini-2.5-pro', apiName: 'gemini-2.5-pro', label: 'Gemini 2.5 Pro' },
+      { id: 'gemma-4-e2b', apiName: 'gemma-4-e2b', label: 'Gemma 4 E2B' },
+      { id: 'gemma-4-e4b', apiName: 'gemma-4-e4b', label: 'Gemma 4 E4B' },
+      { id: 'gemma-4-12b', apiName: 'gemma-4-12b', label: 'Gemma 4 12B' },
+      { id: 'gemma-4-26b-a4b', apiName: 'gemma-4-26b-a4b', label: 'Gemma 4 26B A4B' },
+      { id: 'gemma-4-31b', apiName: 'gemma-4-31b', label: 'Gemma 4 31B' },
     ],
   },
   usage: { supported: false },


### PR DESCRIPTION
Summary
- what changed: Added support for the newly released Google DeepMind Gemma 4 hosted models (gemma-4-26b-a4b-it and gemma-4-31b-it) under the Gemini provider.
- why it changed: To allow users to select, configure, and use the new state-of-the-art open-weights Gemma 4 models natively through the OpenClaude UI when setting up the Gemini integration.
Impact
- user-facing impact: Users will now see the supported Gemma 4 models populated in the default catalog list when selecting or adding a Gemini provider in the CLI. Context windows and reasoning capabilities are properly configured.
- developer/maintainer impact: Minimal. We introduced a gemmaModel helper in gemini.ts to manage the large 256K context windows specific to the Gemma 4 architecture while inheriting standard Gemini API capabilities.

Testing
 - bun run build
 - bun run smoke
 - bun run check
 - focused tests: Verified typechecks pass and that the catalog arrays correctly map the new model IDs.

Notes
- provider/model path tested: gemini provider -> gemma-4-* models
- screenshots attached (if UI changed): N/A
- follow-up work or known limitations: N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for two new Gemini Gemma 4 models: Gemma 4-26B and Gemma 4-31B, now available for use in the model catalog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->