### PR TITLE
fix(typecheck): add missing xai entry to deprecation retirement date maps

### DIFF
--- a/src/utils/model/deprecation.ts
+++ b/src/utils/model/deprecation.ts
@@ -46,6 +46,7 @@ const DEPRECATED_MODELS: Record<string, DeprecationEntry> = {
       minimax: null,
       'xiaomi-mimo': null,
       mistral: null,
+      xai: null,
     },
   },
   'claude-3-7-sonnet': {
@@ -63,6 +64,7 @@ const DEPRECATED_MODELS: Record<string, DeprecationEntry> = {
       minimax: null,
       'xiaomi-mimo': null,
       mistral: null,
+      xai: null,
     },
   },
   'claude-3-5-haiku': {
@@ -80,6 +82,7 @@ const DEPRECATED_MODELS: Record<string, DeprecationEntry> = {
       minimax: null,
       'xiaomi-mimo': null,
       mistral: null,
+      xai: null,
     },
   },
 }


### PR DESCRIPTION
## Summary

Refs #1486.

The `LegacyAPIProvider` type union includes `'xai'` but the three `DEPRECATED_MODELS` retirement date entries were missing the `xai` key, causing TS2741 "Property xai is missing" errors.

## What changed

- Added `xai: null` to each of the three `retirementDates` objects in `DEPRECATED_MODELS` (claude-3-opus, claude-3-7-sonnet, claude-3-5-haiku).

## Why

The `Record<LegacyAPIProvider, string | null>` type requires every key in the union to be present. When `xai` was added to `LegacyAPIProvider` (in `providers.ts`), the deprecation maps were not updated. This is a type-completeness fix with zero runtime behavior change — previously `getDeprecatedModelInfo()` would return `undefined` (treated as "not deprecated") for `xai`; now it returns `null` (also "not deprecated").

`perplexity` is intentionally not added because it is not yet in the `LegacyAPIProvider` union. It should be added in the PR that introduces perplexity as a provider.

## Validation

- [x] `git diff --check` — passed
- [x] `bun run typecheck` — zero errors in `deprecation.ts` (was 3 × TS2741)
- [x] All 13 `LegacyAPIProvider` keys present in every `retirementDates` entry

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated model deprecation metadata to ensure consistent provider configuration tracking across all entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->