### PR TITLE
fix(typecheck): add proper type parameters to useState(null) hooks

### DIFF
--- a/src/commands/btw/btw.tsx
+++ b/src/commands/btw/btw.tsx
@@ -40,8 +40,8 @@ function BtwSideQuestion(t0) {
     context,
     onDone
   } = t0;
-  const [response, setResponse] = useState(null);
-  const [error, setError] = useState(null);
+  const [response, setResponse] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
   const [frame, setFrame] = useState(0);
   const scrollRef = useRef(null);
   const {

--- a/src/commands/rate-limit-options/rate-limit-options.tsx
+++ b/src/commands/rate-limit-options/rate-limit-options.tsx
@@ -27,7 +27,7 @@ function RateLimitOptionsMenu(t0) {
     onDone,
     context
   } = t0;
-  const [subCommandJSX, setSubCommandJSX] = useState(null);
+  const [subCommandJSX, setSubCommandJSX] = useState<React.ReactNode | null>(null);
   const claudeAiLimits = useClaudeAiLimits();
   let t1;
   if ($[0] === Symbol.for("react.memo_cache_sentinel")) {

--- a/src/commands/tag/tag.tsx
+++ b/src/commands/tag/tag.tsx
@@ -76,7 +76,7 @@ function ToggleTagAndClose(t0) {
     onDone
   } = t0;
   const [showConfirm, setShowConfirm] = React.useState(false);
-  const [sessionId, setSessionId] = React.useState(null);
+  const [sessionId, setSessionId] = React.useState<string | null>(null);
   let t1;
   if ($[0] !== tagName) {
     t1 = recursivelySanitizeUnicode(tagName).trim();

--- a/src/commands/thinkback/thinkback.tsx
+++ b/src/commands/thinkback/thinkback.tsx
@@ -390,9 +390,9 @@ function ThinkbackFlow(t0) {
     onDone
   } = t0;
   const [installComplete, setInstallComplete] = useState(false);
-  const [installError, setInstallError] = useState(null);
-  const [skillDir, setSkillDir] = useState(null);
-  const [hasGenerated, setHasGenerated] = useState(null);
+  const [installError, setInstallError] = useState<string | null>(null);
+  const [skillDir, setSkillDir] = useState<string | null>(null);
+  const [hasGenerated, setHasGenerated] = useState<boolean | null>(null);
   let t1;
   if ($[0] === Symbol.for("react.memo_cache_sentinel")) {
     t1 = function handleReady() {

--- a/src/components/AutoUpdaterWrapper.tsx
+++ b/src/components/AutoUpdaterWrapper.tsx
@@ -26,8 +26,8 @@ export function AutoUpdaterWrapper(t0) {
     showSuccessMessage,
     verbose
   } = t0;
-  const [useNativeInstaller, setUseNativeInstaller] = React.useState(null);
-  const [isPackageManager, setIsPackageManager] = React.useState(null);
+  const [useNativeInstaller, setUseNativeInstaller] = React.useState<boolean | null>(null);
+  const [isPackageManager, setIsPackageManager] = React.useState<boolean | null>(null);
   let t1;
   let t2;
   if ($[0] === Symbol.for("react.memo_cache_sentinel")) {

--- a/src/components/DesktopHandoff.tsx
+++ b/src/components/DesktopHandoff.tsx
@@ -30,7 +30,7 @@ export function DesktopHandoff(t0) {
     onDone
   } = t0;
   const [state, setState] = useState("checking");
-  const [error, setError] = useState(null);
+  const [error, setError] = useState<string | null>(null);
   const [downloadMessage, setDownloadMessage] = useState("");
   let t1;
   if ($[0] !== error || $[1] !== onDone || $[2] !== state) {

--- a/src/components/PromptInput/PromptInputFooterLeftSide.tsx
+++ b/src/components/PromptInput/PromptInputFooterLeftSide.tsx
@@ -74,7 +74,7 @@ type Props = {
 function ProactiveCountdown() {
   const $ = _c(7);
   const nextTickAt = useSyncExternalStore(proactiveModule?.subscribeToProactiveChanges ?? NO_OP_SUBSCRIBE, proactiveModule?.getNextTickAt ?? NULL, NULL);
-  const [remainingSeconds, setRemainingSeconds] = useState(null);
+  const [remainingSeconds, setRemainingSeconds] = useState<number | null>(null);
   let t0;
   let t1;
   if ($[0] !== nextTickAt) {

--- a/src/components/TeleportError.tsx
+++ b/src/components/TeleportError.tsx
@@ -25,7 +25,7 @@ export function TeleportError(t0) {
     errorsToIgnore: t1
   } = t0;
   const errorsToIgnore = t1 === undefined ? EMPTY_ERRORS_TO_IGNORE : t1;
-  const [currentError, setCurrentError] = useState(null);
+  const [currentError, setCurrentError] = useState<TeleportLocalErrorType | null>(null);
   const [isLoggingIn, setIsLoggingIn] = useState(false);
   let t2;
   if ($[0] !== errorsToIgnore || $[1] !== onComplete) {

--- a/src/components/TeleportRepoMismatchDialog.tsx
+++ b/src/components/TeleportRepoMismatchDialog.tsx
@@ -21,7 +21,7 @@ export function TeleportRepoMismatchDialog(t0) {
     onCancel
   } = t0;
   const [availablePaths, setAvailablePaths] = useState(initialPaths);
-  const [errorMessage, setErrorMessage] = useState(null);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const [validating, setValidating] = useState(false);
   let t1;
   if ($[0] !== availablePaths || $[1] !== onCancel || $[2] !== onSelectPath || $[3] !== targetRepo) {

--- a/src/components/ThinkingToggle.tsx
+++ b/src/components/ThinkingToggle.tsx
@@ -25,7 +25,7 @@ export function ThinkingToggle(t0) {
     isMidConversation
   } = t0;
   const exitState = useExitOnCtrlCDWithKeybindings();
-  const [confirmationPending, setConfirmationPending] = useState(null);
+  const [confirmationPending, setConfirmationPending] = useState<boolean | null>(null);
   let t1;
   if ($[0] === Symbol.for("react.memo_cache_sentinel")) {
     t1 = [{

--- a/src/components/mcp/MCPReconnect.tsx
+++ b/src/components/mcp/MCPReconnect.tsx
@@ -22,7 +22,7 @@ export function MCPReconnect(t0) {
   const store = useAppStateStore();
   const reconnectMcpServer = useMcpReconnect();
   const [isReconnecting, setIsReconnecting] = useState(true);
-  const [error, setError] = useState(null);
+  const [error, setError] = useState<string | null>(null);
   let t1;
   let t2;
   if ($[0] !== onComplete || $[1] !== reconnectMcpServer || $[2] !== serverName || $[3] !== store) {


### PR DESCRIPTION
## Summary

Refs #1486.

Adds explicit type parameters to `useState(null)` calls where the setter later receives string, boolean, number, or known string-union values. TypeScript infers the state type as `null`, causing TS2345/TS2322 errors when passing non-null values to the setter.

## What changed

Each `useState(null)` was changed to `useState<Type | null>(null)` where `Type` matches the actual values passed to the setter:

| File | State variable | Type parameter |
|---|---|---|
| `commands/btw/btw.tsx` | `response`, `error` | `string \| null` |
| `commands/mcp/MCPReconnect.tsx` | `error` | `string \| null` |
| `commands/rate-limit-options/rate-limit-options.tsx` | `subCommandJSX` | `React.ReactNode \| null` |
| `commands/tag/tag.tsx` | `sessionId` | `string \| null` |
| `commands/thinkback/thinkback.tsx` | `installError`, `skillDir`, `hasGenerated` | `string \| null`, `string \| null`, `boolean \| null` |
| `components/AutoUpdaterWrapper.tsx` | `useNativeInstaller`, `isPackageManager` | `boolean \| null` |
| `components/DesktopHandoff.tsx` | `error` | `string \| null` |
| `components/PromptInput/PromptInputFooterLeftSide.tsx` | `remainingSeconds` | `number \| null` |
| `components/TeleportError.tsx` | `currentError` | `TeleportLocalErrorType \| null` |
| `components/TeleportRepoMismatchDialog.tsx` | `errorMessage` | `string \| null` |
| `components/ThinkingToggle.tsx` | `confirmationPending` | `boolean \| null` |

## Why

`useState(null)` infers the state type as `null`, making `setX(someString)` a type error. Adding the explicit type parameter is the canonical React fix. It does not change runtime behavior — the state still initializes as `null`.

Complex object types (`GroveConfig | null`, `EnvironmentResource | null`, `LogTreeNode | null`, etc.) and deeply multi-state components (`LogSelector.tsx`, `PluginSettings.tsx`, `Doctor.tsx`) are deferred to follow-up PRs to keep this review manageable.

## Validation

- [x] `git diff --check` — passed
- [x] `bun run typecheck` — zero `SetStateAction<null>` errors in modified files (was ~22)
- [x] All type parameters verified against actual setter usage in each file
- [x] `React` already imported in `rate-limit-options.tsx` (no new imports needed)
- [x] `TeleportLocalErrorType` already defined and exported in `TeleportError.tsx`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced TypeScript type annotations across the application to improve code stability, maintainability, and long-term reliability. No user-facing changes or behavioral modifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->