### PR TITLE
feat(opengateway): add MiniMax M3 and Qwen 3.7 Max to the model catalog

### DIFF
--- a/src/commands/model/model.test.tsx
+++ b/src/commands/model/model.test.tsx
@@ -1275,6 +1275,8 @@ test('/model applies auto provider surface for single-model static descriptor pr
       'mimo-v2-omni',
       'mimo-v2-flash',
       'google/gemini-3.1-flash-lite-preview',
+      'minimax/minimax-m3',
+      'qwen/qwen3.7-max',
     ])
   } finally {
     rendered.instance.unmount()

--- a/src/integrations/gateways/gitlawb-opengateway.ts
+++ b/src/integrations/gateways/gitlawb-opengateway.ts
@@ -100,6 +100,18 @@ export default defineGateway({
         label: 'Gemini 3.1 Flash Lite Preview (via Opengateway)',
         modelDescriptorId: 'gemini-3.1-flash-lite-preview',
       },
+      {
+        id: 'opengateway-minimax-m3',
+        apiName: 'minimax/minimax-m3',
+        label: 'MiniMax M3 (via Opengateway)',
+        modelDescriptorId: 'minimax-m3',
+      },
+      {
+        id: 'opengateway-qwen3.7-max',
+        apiName: 'qwen/qwen3.7-max',
+        label: 'Qwen 3.7 Max (via Opengateway)',
+        modelDescriptorId: 'qwen3.7-max',
+      },
     ],
   },
   usage: { supported: false },

--- a/src/integrations/models/qwen.ts
+++ b/src/integrations/models/qwen.ts
@@ -35,4 +35,20 @@ export default [
   qwenModel('qwen3-coder-next', 'Qwen 3 Coder Next', 262_144, 65_536),
   qwenModel('qwen3-max', 'Qwen 3 Max', 262_144, 32_768),
   qwenModel('Qwen/Qwen3.5-9B', 'Qwen 3.5 9B', 128_000, 32_768),
+  // Text-only (no vision per the OpenRouter catalog), so it skips the
+  // qwenModel helper's vision defaults.
+  defineModel({
+    id: 'qwen3.7-max',
+    label: 'Qwen 3.7 Max',
+    brandId: 'qwen',
+    vendorId: 'openai',
+    classification: ['chat', 'reasoning', 'coding'],
+    defaultModel: 'qwen3.7-max',
+    capabilities: {
+      ...qwenCapabilities,
+      supportsVision: false,
+    },
+    contextWindow: 1_000_000,
+    maxOutputTokens: 65_536,
+  }),
 ]


### PR DESCRIPTION
Two new models reachable through the Gitlawb Opengateway unified route, both served upstream via OpenRouter (gateway-side routing lands separately in the opengateway repo):

- MiniMax M3 (`minimax/minimax-m3`): reuses the existing minimax-m3 descriptor — 1M context, 131k output, reasoning/coding.
- Qwen 3.7 Max (`qwen/qwen3.7-max`): new descriptor — 1M context, 65k output, text-only per the OpenRouter catalog (no vision), so it skips the qwenModel helper's vision defaults.

The /model picker test's exact-list assertion gains both entries

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for Minimax M3 and Qwen 3.7 Max AI models in the model picker
  * Expanded available models accessible through the gateway

* **Tests**
  * Updated model selection tests to include newly available models

<!-- end of auto-generated comment: release notes by coderabbit.ai -->