### PR TITLE
fix(typecheck): type beta header accumulator

### DIFF
--- a/src/utils/betas.test.ts
+++ b/src/utils/betas.test.ts
@@ -1,0 +1,83 @@
+import { afterEach, beforeEach, expect, test } from 'bun:test'
+import {
+  CLAUDE_CODE_20250219_BETA_HEADER,
+} from '../constants/betas.js'
+import { setSdkBetas } from '../bootstrap/state.js'
+import {
+  acquireSharedMutationLock,
+  releaseSharedMutationLock,
+} from '../test/sharedMutationLock.js'
+
+const originalEnv = { ...process.env }
+
+beforeEach(async () => {
+  await acquireSharedMutationLock('utils/betas.test.ts')
+  process.env = { ...originalEnv }
+  useOpenAIProviderForTest()
+})
+
+afterEach(() => {
+  try {
+    process.env = { ...originalEnv }
+    setSdkBetas(undefined)
+  } finally {
+    releaseSharedMutationLock()
+  }
+})
+
+test('adds trimmed user-provided beta headers without empty entries', async () => {
+  process.env.ANTHROPIC_BETAS =
+    ' custom-beta-2026-01-01, ,second-beta-2026-02-02 '
+
+  const { getAllModelBetas } = await importFreshBetasModule()
+  const betas = getAllModelBetas('claude-3-haiku-20240307')
+
+  expect(betas.slice(-2)).toEqual([
+    'custom-beta-2026-01-01',
+    'second-beta-2026-02-02',
+  ])
+  expect(betas).not.toContain('')
+})
+
+test('does not duplicate an env-provided agentic beta for Haiku requests', async () => {
+  process.env.ANTHROPIC_BETAS = [
+    CLAUDE_CODE_20250219_BETA_HEADER,
+    'custom-beta-2026-01-01',
+  ].join(',')
+
+  const { getMergedBetas } = await importFreshBetasModule()
+  const mergedBetas = getMergedBetas('claude-3-haiku-20240307', {
+    isAgenticQuery: true,
+  })
+
+  expect(
+    mergedBetas.filter(beta => beta === CLAUDE_CODE_20250219_BETA_HEADER),
+  ).toHaveLength(1)
+  expect(mergedBetas).toContain('custom-beta-2026-01-01')
+})
+
+async function importFreshBetasModule() {
+  return import(`./betas.ts?betasTest=${Date.now()}-${Math.random()}`)
+}
+
+function useOpenAIProviderForTest(): void {
+  delete process.env.CLAUDE_CODE_USE_BEDROCK
+  delete process.env.CLAUDE_CODE_USE_VERTEX
+  delete process.env.CLAUDE_CODE_USE_FOUNDRY
+  delete process.env.CLAUDE_CODE_USE_GEMINI
+  delete process.env.CLAUDE_CODE_USE_MISTRAL
+  delete process.env.CLAUDE_CODE_USE_GITHUB
+  delete process.env.NVIDIA_NIM
+  delete process.env.USER_TYPE
+  delete process.env.CLAUDE_CODE_ENTRYPOINT
+  delete process.env.DISABLE_INTERLEAVED_THINKING
+  delete process.env.CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS
+  delete process.env.USE_API_CONTEXT_MANAGEMENT
+  delete process.env.USE_CONNECTOR_TEXT_SUMMARIZATION
+
+  process.env.CLAUDE_CODE_USE_OPENAI = '1'
+  process.env.OPENAI_MODEL = 'claude-3-haiku-20240307'
+  process.env.OPENAI_BASE_URL = 'http://localhost:11434/v1'
+  process.env.OPENAI_API_KEY = 'test'
+  setSdkBetas(undefined)
+}

--- a/src/utils/betas.ts
+++ b/src/utils/betas.ts
@@ -232,7 +232,7 @@ export function shouldUseGlobalCacheScope(): boolean {
 }
 
 export const getAllModelBetas = memoize((model: string): string[] => {
-  const betaHeaders = []
+  const betaHeaders: string[] = []
   const isHaiku = getCanonicalName(model).includes('haiku')
   const provider = getAPIProvider()
   const includeFirstPartyOnlyBetas = shouldIncludeFirstPartyOnlyBetas()


### PR DESCRIPTION
## Summary
- Type the beta header accumulator in `getAllModelBetas` so dynamic beta strings from `ANTHROPIC_BETAS` do not hit `never[]` inference.
- Add focused coverage for trimming user-provided beta headers, dropping empty entries, and avoiding duplicate agentic beta headers on Haiku requests.

## Validation
- `bun test src/utils/betas.test.ts`
- `bun test --max-concurrency=1 src/utils/betas.test.ts src/utils/effort.codex.test.ts src/utils/status.test.ts`
- `env -u CLAUDE_CODE_USE_OPENAI -u OPENAI_API_KEY -u OPENAI_BASE_URL -u OPENAI_MODEL bun run check`
- `bun run typecheck` still exits nonzero for the existing repo-wide #1486 baseline, but no diagnostics remain for `src/utils/betas.ts` or `src/utils/betas.test.ts`.

Contributes to #1486.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive tests for beta header behavior: trimming whitespace, removing empty entries, deduplicating and correctly merging user-provided betas with built-in defaults.

* **Code Quality**
  * Improved type safety with an explicit type annotation to make beta handling more robust.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->