### PR TITLE
fix(typecheck): type provider diagnostic tests

### DIFF
--- a/src/services/api/openaiShim.diagnostics.test.ts
+++ b/src/services/api/openaiShim.diagnostics.test.ts
@@ -1,5 +1,15 @@
 import { afterEach, beforeEach, expect, mock, test } from 'bun:test'
 import { acquireSharedMutationLock, releaseSharedMutationLock } from '../../test/sharedMutationLock.js'
+import type { DebugLogLevel } from '../../utils/debug.js'
+
+type DebugModule = typeof import('../../utils/debug.js')
+type DebugSpy = ReturnType<
+  typeof mock<(message: string, options?: { level?: DebugLogLevel }) => void>
+>
+type FetchMock = (
+  input: RequestInfo | URL,
+  init?: RequestInit,
+) => Promise<Response>
 
 const originalFetch = globalThis.fetch
 const originalEnv = {
@@ -7,6 +17,7 @@ const originalEnv = {
   OPENAI_API_KEY: process.env.OPENAI_API_KEY,
   OPENAI_MODEL: process.env.OPENAI_MODEL,
 }
+let actualDebugModule: DebugModule | undefined
 
 function restoreEnv(key: string, value: string | undefined): void {
   if (value === undefined) {
@@ -27,16 +38,14 @@ afterEach(() => {
     restoreEnv('OPENAI_API_KEY', originalEnv.OPENAI_API_KEY)
     restoreEnv('OPENAI_MODEL', originalEnv.OPENAI_MODEL)
     mock.restore()
+    restoreDebugModule()
   } finally {
     releaseSharedMutationLock()
   }
 })
 
 test('logs classified transport diagnostics with category and code', async () => {
-  const debugSpy = mock(() => {})
-  mock.module('../../utils/debug.js', () => ({
-    logForDebugging: debugSpy,
-  }))
+  const debugSpy = await mockDebugLogging()
 
   const nonce = `${Date.now()}-${Math.random()}`
   const { createOpenAIShimClient } = await import(`./openaiShim.ts?ts=${nonce}`)
@@ -48,9 +57,9 @@ test('logs classified transport diagnostics with category and code', async () =>
     code: 'ECONNREFUSED',
   })
 
-  globalThis.fetch = mock(async () => {
+  globalThis.fetch = mockFetch(async (): Promise<Response> => {
     throw transportError
-  }) as typeof globalThis.fetch
+  })
 
   const client = createOpenAIShimClient({}) as {
     beta: {
@@ -80,10 +89,7 @@ test('logs classified transport diagnostics with category and code', async () =>
 })
 
 test('redacts credentials in transport diagnostic URL logs', async () => {
-  const debugSpy = mock(() => {})
-  mock.module('../../utils/debug.js', () => ({
-    logForDebugging: debugSpy,
-  }))
+  const debugSpy = await mockDebugLogging()
 
   const nonce = `${Date.now()}-${Math.random()}`
   const { createOpenAIShimClient } = await import(`./openaiShim.ts?ts=${nonce}`)
@@ -95,9 +101,9 @@ test('redacts credentials in transport diagnostic URL logs', async () => {
     code: 'ECONNREFUSED',
   })
 
-  globalThis.fetch = mock(async () => {
+  globalThis.fetch = mockFetch(async (): Promise<Response> => {
     throw transportError
-  }) as typeof globalThis.fetch
+  })
 
   const client = createOpenAIShimClient({}) as {
     beta: {
@@ -127,10 +133,7 @@ test('redacts credentials in transport diagnostic URL logs', async () => {
   expect(logLine).not.toContain('supersecret@')
 })
 test('logs self-heal localhost fallback with redacted from/to URLs', async () => {
-  const debugSpy = mock(() => {})
-  mock.module('../../utils/debug.js', () => ({
-    logForDebugging: debugSpy,
-  }))
+  const debugSpy = await mockDebugLogging()
 
   const nonce = `${Date.now()}-${Math.random()}`
   const { createOpenAIShimClient } = await import(`./openaiShim.ts?ts=${nonce}`)
@@ -138,8 +141,8 @@ test('logs self-heal localhost fallback with redacted from/to URLs', async () =>
   process.env.OPENAI_BASE_URL = 'http://user:supersecret@localhost:11434/v1'
   process.env.OPENAI_API_KEY = 'supersecret'
 
-  globalThis.fetch = mock(async (input: string | Request) => {
-    const url = typeof input === 'string' ? input : input.url
+  globalThis.fetch = mockFetch(async (input: RequestInfo | URL) => {
+    const url = getFetchInputUrl(input)
     if (url.includes('localhost')) {
       throw Object.assign(new TypeError('fetch failed'), {
         code: 'ENOTFOUND',
@@ -172,7 +175,7 @@ test('logs self-heal localhost fallback with redacted from/to URLs', async () =>
         },
       },
     )
-  }) as typeof globalThis.fetch
+  })
 
   const client = createOpenAIShimClient({}) as {
     beta: {
@@ -204,10 +207,7 @@ test('logs self-heal localhost fallback with redacted from/to URLs', async () =>
 })
 
 test('logs self-heal toolless retry for local tool-call incompatibility', async () => {
-  const debugSpy = mock(() => {})
-  mock.module('../../utils/debug.js', () => ({
-    logForDebugging: debugSpy,
-  }))
+  const debugSpy = await mockDebugLogging()
 
   const nonce = `${Date.now()}-${Math.random()}`
   const { createOpenAIShimClient } = await import(`./openaiShim.ts?ts=${nonce}`)
@@ -216,7 +216,7 @@ test('logs self-heal toolless retry for local tool-call incompatibility', async 
   process.env.OPENAI_API_KEY = 'ollama'
 
   let callCount = 0
-  globalThis.fetch = mock(async () => {
+  globalThis.fetch = mockFetch(async () => {
     callCount += 1
     if (callCount === 1) {
       return new Response('tool_calls are not supported', {
@@ -253,7 +253,7 @@ test('logs self-heal toolless retry for local tool-call incompatibility', async 
         },
       },
     )
-  }) as typeof globalThis.fetch
+  })
 
   const client = createOpenAIShimClient({}) as {
     beta: {
@@ -293,3 +293,37 @@ test('logs self-heal toolless retry for local tool-call incompatibility', async 
   expect(fallbackLog).toBeDefined()
   expect(fallbackLog?.[1]).toEqual({ level: 'warn' })
 })
+
+async function mockDebugLogging(): Promise<DebugSpy> {
+  actualDebugModule ??= await import(
+    `../../utils/debug.ts?openaiShimDiagnosticsActual=${Date.now()}-${Math.random()}`
+  )
+  const debugSpy = mock(
+    (_message: string, _options?: { level?: DebugLogLevel }) => {},
+  )
+  mock.module('../../utils/debug.js', () => ({
+    ...actualDebugModule!,
+    logForDebugging: debugSpy,
+  }))
+  return debugSpy
+}
+
+function restoreDebugModule(): void {
+  if (actualDebugModule) {
+    mock.module('../../utils/debug.js', () => ({ ...actualDebugModule! }))
+  }
+}
+
+function mockFetch(fetchMock: FetchMock): typeof globalThis.fetch {
+  return mock(fetchMock) as unknown as typeof globalThis.fetch
+}
+
+function getFetchInputUrl(input: RequestInfo | URL): string {
+  if (typeof input === 'string') {
+    return input
+  }
+  if (input instanceof URL) {
+    return input.toString()
+  }
+  return input.url
+}

--- a/src/services/api/providerConfig.envDiagnostics.test.ts
+++ b/src/services/api/providerConfig.envDiagnostics.test.ts
@@ -1,5 +1,11 @@
 import { afterEach, beforeEach, expect, mock, test } from 'bun:test'
 import { acquireSharedMutationLock, releaseSharedMutationLock } from '../../test/sharedMutationLock.js'
+import type { DebugLogLevel } from '../../utils/debug.js'
+
+type DebugModule = typeof import('../../utils/debug.js')
+type DebugSpy = ReturnType<
+  typeof mock<(message: string, options?: { level?: DebugLogLevel }) => void>
+>
 
 const originalEnv = {
   CLAUDE_CODE_USE_OPENAI: process.env.CLAUDE_CODE_USE_OPENAI,
@@ -13,6 +19,7 @@ const originalEnv = {
   GEMINI_BASE_URL: process.env.GEMINI_BASE_URL,
   GEMINI_MODEL: process.env.GEMINI_MODEL,
 }
+let actualDebugModule: DebugModule | undefined
 
 function restoreEnv(key: string, value: string | undefined): void {
   if (value === undefined) {
@@ -39,16 +46,14 @@ afterEach(() => {
     restoreEnv('GEMINI_BASE_URL', originalEnv.GEMINI_BASE_URL)
     restoreEnv('GEMINI_MODEL', originalEnv.GEMINI_MODEL)
     mock.restore()
+    restoreDebugModule()
   } finally {
     releaseSharedMutationLock()
   }
 })
 
 test('logs a warning when OPENAI_BASE_URL is literal undefined', async () => {
-  const debugSpy = mock(() => {})
-  mock.module('../../utils/debug.js', () => ({
-    logForDebugging: debugSpy,
-  }))
+  const debugSpy = await mockDebugLogging()
 
   process.env.CLAUDE_CODE_USE_OPENAI = '1'
   process.env.OPENAI_BASE_URL = 'undefined'
@@ -73,10 +78,7 @@ test('logs a warning when OPENAI_BASE_URL is literal undefined', async () => {
 })
 
 test('does not warn for OPENAI_API_BASE when OPENAI_BASE_URL is active', async () => {
-  const debugSpy = mock(() => {})
-  mock.module('../../utils/debug.js', () => ({
-    logForDebugging: debugSpy,
-  }))
+  const debugSpy = await mockDebugLogging()
 
   process.env.CLAUDE_CODE_USE_OPENAI = '1'
   delete process.env.CLAUDE_CODE_USE_MISTRAL
@@ -101,10 +103,7 @@ test('does not warn for OPENAI_API_BASE when OPENAI_BASE_URL is active', async (
 })
 
 test('uses OPENAI_API_BASE as fallback in mistral mode when MISTRAL_BASE_URL is unset', async () => {
-  const debugSpy = mock(() => {})
-  mock.module('../../utils/debug.js', () => ({
-    logForDebugging: debugSpy,
-  }))
+  const debugSpy = await mockDebugLogging()
 
   delete process.env.CLAUDE_CODE_USE_OPENAI
   process.env.CLAUDE_CODE_USE_MISTRAL = '1'
@@ -122,10 +121,7 @@ test('uses OPENAI_API_BASE as fallback in mistral mode when MISTRAL_BASE_URL is 
 })
 
 test('uses descriptor-backed Gemini default model when GEMINI_MODEL is unset', async () => {
-  const debugSpy = mock(() => {})
-  mock.module('../../utils/debug.js', () => ({
-    logForDebugging: debugSpy,
-  }))
+  await mockDebugLogging()
 
   delete process.env.CLAUDE_CODE_USE_OPENAI
   delete process.env.CLAUDE_CODE_USE_MISTRAL
@@ -143,3 +139,23 @@ test('uses descriptor-backed Gemini default model when GEMINI_MODEL is unset', a
   expect(resolved.resolvedModel).toBe('gemini-3-flash-preview')
   expect(resolved.baseUrl).toBe('https://generativelanguage.googleapis.com/v1beta/openai')
 })
+
+async function mockDebugLogging(): Promise<DebugSpy> {
+  actualDebugModule ??= await import(
+    `../../utils/debug.ts?providerConfigEnvDiagnosticsActual=${Date.now()}-${Math.random()}`
+  )
+  const debugSpy = mock(
+    (_message: string, _options?: { level?: DebugLogLevel }) => {},
+  )
+  mock.module('../../utils/debug.js', () => ({
+    ...actualDebugModule!,
+    logForDebugging: debugSpy,
+  }))
+  return debugSpy
+}
+
+function restoreDebugModule(): void {
+  if (actualDebugModule) {
+    mock.module('../../utils/debug.js', () => ({ ...actualDebugModule! }))
+  }
+}

--- a/src/utils/providerAutoDetect.test.ts
+++ b/src/utils/providerAutoDetect.test.ts
@@ -6,6 +6,11 @@ import {
   detectProviderFromEnv,
 } from './providerAutoDetect.ts'
 
+type FetchImpl = (
+  input: RequestInfo | URL,
+  init?: RequestInit,
+) => Promise<Response>
+
 // Hermetic env scan: always report "no Codex auth on disk" so tests don't
 // depend on the dev machine's ~/.codex/auth.json state.
 function scan(env: Record<string, string | undefined>) {
@@ -136,13 +141,13 @@ describe('detectProviderFromEnv — priority order', () => {
 
 describe('detectLocalService', () => {
   test('returns Ollama when its /api/tags responds ok', async () => {
-    const fetchImpl = (async (input: URL | RequestInfo) => {
+    const fetchImpl = asFetch(async (input: RequestInfo | URL) => {
       const url = typeof input === 'string' ? input : (input as URL).toString()
       if (url.includes(':11434')) {
         return new Response('{"models":[]}', { status: 200 })
       }
       return new Response('', { status: 404 })
-    }) as typeof fetch
+    })
 
     const result = await detectLocalService({
       env: {},
@@ -154,7 +159,7 @@ describe('detectLocalService', () => {
   })
 
   test('Ollama wins over LM Studio even when both are reachable', async () => {
-    const fetchImpl = (async () => new Response('{}', { status: 200 })) as typeof fetch
+    const fetchImpl = asFetch(async () => new Response('{}', { status: 200 }))
     const result = await detectLocalService({
       env: {},
       fetchImpl,
@@ -164,13 +169,13 @@ describe('detectLocalService', () => {
   })
 
   test('falls back to LM Studio when Ollama is unreachable', async () => {
-    const fetchImpl = (async (input: URL | RequestInfo) => {
+    const fetchImpl = asFetch(async (input: RequestInfo | URL) => {
       const url = typeof input === 'string' ? input : (input as URL).toString()
       if (url.includes(':1234')) {
         return new Response('{"data":[]}', { status: 200 })
       }
       return new Response('', { status: 404 })
-    }) as typeof fetch
+    })
 
     const result = await detectLocalService({
       env: {},
@@ -182,8 +187,7 @@ describe('detectLocalService', () => {
   })
 
   test('returns null when no local services respond', async () => {
-    const fetchImpl = (async () =>
-      new Response('', { status: 500 })) as typeof fetch
+    const fetchImpl = asFetch(async () => new Response('', { status: 500 }))
     const result = await detectLocalService({
       env: {},
       fetchImpl,
@@ -194,11 +198,11 @@ describe('detectLocalService', () => {
 
   test('honors OLLAMA_BASE_URL override', async () => {
     const probedUrls: string[] = []
-    const fetchImpl = (async (input: URL | RequestInfo) => {
+    const fetchImpl = asFetch(async (input: RequestInfo | URL) => {
       const url = typeof input === 'string' ? input : (input as URL).toString()
       probedUrls.push(url)
       return new Response('{"models":[]}', { status: 200 })
-    }) as typeof fetch
+    })
 
     const result = await detectLocalService({
       env: { OLLAMA_BASE_URL: 'http://10.0.0.5:11434' },
@@ -210,7 +214,7 @@ describe('detectLocalService', () => {
   })
 
   test('probe timeout does not throw — returns null', async () => {
-    const fetchImpl = (async (_input: URL | RequestInfo, init?: RequestInit) => {
+    const fetchImpl = asFetch(async (_input: RequestInfo | URL, init?: RequestInit) => {
       // Respect the caller's abort signal so the race with timeoutMs is fair.
       return new Promise<Response>((_resolve, reject) => {
         const onAbort = () => reject(new Error('aborted'))
@@ -220,7 +224,7 @@ describe('detectLocalService', () => {
           _resolve(new Response('ok'))
         }, 500)
       })
-    }) as typeof fetch
+    })
 
     const result = await detectLocalService({
       env: {},
@@ -231,9 +235,9 @@ describe('detectLocalService', () => {
   })
 
   test('network errors do not throw', async () => {
-    const fetchImpl = (async () => {
+    const fetchImpl = asFetch(async (): Promise<Response> => {
       throw new Error('ECONNREFUSED')
-    }) as typeof fetch
+    })
 
     const result = await detectLocalService({
       env: {},
@@ -247,10 +251,10 @@ describe('detectLocalService', () => {
 describe('detectBestProvider — orchestrator', () => {
   test('env match short-circuits the local probe', async () => {
     let probeCalled = false
-    const fetchImpl = (async () => {
+    const fetchImpl = asFetch(async () => {
       probeCalled = true
       return new Response('{}', { status: 200 })
-    }) as typeof fetch
+    })
 
     const result = await detectBestProvider({
       env: { ANTHROPIC_API_KEY: 'sk-ant' },
@@ -263,7 +267,7 @@ describe('detectBestProvider — orchestrator', () => {
   })
 
   test('env miss falls through to local-service probe', async () => {
-    const fetchImpl = (async () => new Response('{}', { status: 200 })) as typeof fetch
+    const fetchImpl = asFetch(async () => new Response('{}', { status: 200 }))
     const result = await detectBestProvider({
       env: {},
       fetchImpl,
@@ -275,10 +279,10 @@ describe('detectBestProvider — orchestrator', () => {
 
   test('skipLocal + OPENGATEWAY_API_KEY falls back to opengateway without probing', async () => {
     let probeCalled = false
-    const fetchImpl = (async () => {
+    const fetchImpl = asFetch(async () => {
       probeCalled = true
       return new Response('{}', { status: 200 })
-    }) as typeof fetch
+    })
 
     const result = await detectBestProvider({
       env: { OPENGATEWAY_API_KEY: 'ogw_live_test_0000000000000000' },
@@ -292,9 +296,9 @@ describe('detectBestProvider — orchestrator', () => {
   })
 
   test('completely empty environment returns null (opengateway needs an API key)', async () => {
-    const fetchImpl = (async () => {
+    const fetchImpl = asFetch(async (): Promise<Response> => {
       throw new Error('nothing reachable')
-    }) as typeof fetch
+    })
 
     const result = await detectBestProvider({
       env: {},
@@ -308,9 +312,9 @@ describe('detectBestProvider — orchestrator', () => {
   })
 
   test('OPENGATEWAY_BASE_URL env overrides the opengateway fallback base URL', async () => {
-    const fetchImpl = (async () => {
+    const fetchImpl = asFetch(async (): Promise<Response> => {
       throw new Error('nothing reachable')
-    }) as typeof fetch
+    })
 
     const result = await detectBestProvider({
       env: {
@@ -326,9 +330,9 @@ describe('detectBestProvider — orchestrator', () => {
   })
 
   test('OPENGATEWAY_BASE_URL normalizes hosted legacy Xiaomi route to smart route', async () => {
-    const fetchImpl = (async () => {
+    const fetchImpl = asFetch(async (): Promise<Response> => {
       throw new Error('nothing reachable')
-    }) as typeof fetch
+    })
 
     const result = await detectBestProvider({
       env: {
@@ -344,9 +348,9 @@ describe('detectBestProvider — orchestrator', () => {
   })
 
   test('skipOpengatewayFallback returns null when nothing else is detected', async () => {
-    const fetchImpl = (async () => {
+    const fetchImpl = asFetch(async (): Promise<Response> => {
       throw new Error('nothing reachable')
-    }) as typeof fetch
+    })
 
     const result = await detectBestProvider({
       env: {},
@@ -358,3 +362,7 @@ describe('detectBestProvider — orchestrator', () => {
     expect(result).toBeNull()
   })
 })
+
+function asFetch(fetchImpl: FetchImpl): typeof fetch {
+  return fetchImpl as unknown as typeof fetch
+}


### PR DESCRIPTION
## Summary
- Type provider diagnostic debug spies so Bun mock call records are usable under `tsc --noEmit`.
- Preserve and restore real `debug.js` exports in diagnostic tests instead of replacing the module with a single export.
- Localize `typeof fetch` test casts behind helpers for provider auto-detection mocks.

This removes the typecheck diagnostics for:
- `src/services/api/openaiShim.diagnostics.test.ts`
- `src/services/api/providerConfig.envDiagnostics.test.ts`
- `src/utils/providerAutoDetect.test.ts`

I deliberately left `src/utils/providerDiscovery.test.ts` out because open PR #863 already touches that file.

## Validation
- `env -u CLAUDE_CODE_USE_OPENAI -u OPENAI_API_KEY -u OPENAI_BASE_URL -u OPENAI_MODEL bun test --max-concurrency=1 src/services/api/openaiShim.diagnostics.test.ts src/services/api/providerConfig.envDiagnostics.test.ts src/utils/providerAutoDetect.test.ts`
- `env -u CLAUDE_CODE_USE_OPENAI -u OPENAI_API_KEY -u OPENAI_BASE_URL -u OPENAI_MODEL bun test --max-concurrency=1 src/services/api/openaiShim.diagnostics.test.ts src/services/api/providerConfig.envDiagnostics.test.ts src/utils/providerAutoDetect.test.ts src/utils/status.test.ts src/utils/effort.codex.test.ts`
- `env -u CLAUDE_CODE_USE_OPENAI -u OPENAI_API_KEY -u OPENAI_BASE_URL -u OPENAI_MODEL bun run check`
- `bun run typecheck` still exits nonzero for the existing repo-wide #1486 baseline, but no diagnostics remain for the three files above.

Contributes to #1486.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test infrastructure with centralized helper utilities for mocking debug logging and fetch requests, enhancing test maintainability and consistency across test suites.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->