### PR TITLE
fix(typecheck): type tool test fixtures

### DIFF
--- a/src/services/tools/toolHooks.test.ts
+++ b/src/services/tools/toolHooks.test.ts
@@ -2,34 +2,39 @@ import { describe, expect, test, vi } from 'bun:test'
 import { z } from 'zod/v4'
 
 import type { CanUseToolFn } from '../../hooks/useCanUseTool.js'
-import { getEmptyToolPermissionContext, type Tool } from '../../Tool.js'
+import { getEmptyToolPermissionContext, type ToolUseContext } from '../../Tool.js'
+import { createToolFixture } from '../../test/toolFixtures.js'
 import { resolveHookPermissionDecision } from './toolHooks.js'
 
-const passthroughTool = {
+const emptyInputSchema = z.object({})
+const assistantMessage = {} as Parameters<CanUseToolFn>[3]
+
+const passthroughTool = createToolFixture(emptyInputSchema, {
   name: 'PassthroughTool',
-  inputSchema: z.object({}),
   async checkPermissions() {
     return {
       behavior: 'passthrough',
       message: '',
     }
   },
-} as Tool<Record<string, unknown>>
+})
 
-const denyTool = {
+const denyTool = createToolFixture(emptyInputSchema, {
   name: 'DenyTool',
-  inputSchema: z.object({}),
   async checkPermissions() {
     return {
       behavior: 'deny',
       message: 'Denied by tool',
+      decisionReason: {
+        type: 'other',
+        reason: 'Denied by tool',
+      },
     }
   },
-} as Tool<Record<string, unknown>>
+})
 
-const askWithUpdatedInputTool = {
+const askWithUpdatedInputTool = createToolFixture(emptyInputSchema, {
   name: 'AskWithUpdatedInputTool',
-  inputSchema: z.object({}),
   async checkPermissions() {
     return {
       behavior: 'ask',
@@ -37,9 +42,9 @@ const askWithUpdatedInputTool = {
       updatedInput: { normalized: true },
     }
   },
-} as Tool<Record<string, unknown>>
+})
 
-function contextForFullAccess() {
+function contextForFullAccess(): ToolUseContext {
   return {
     abortController: new AbortController(),
     getAppState: () => ({
@@ -50,7 +55,7 @@ function contextForFullAccess() {
       },
     }),
     options: {},
-  } as never
+  } as unknown as ToolUseContext
 }
 
 describe('resolveHookPermissionDecision', () => {
@@ -71,7 +76,7 @@ describe('resolveHookPermissionDecision', () => {
       {},
       contextForFullAccess(),
       canUseTool,
-      {} as never,
+      assistantMessage,
       'tool-use-id',
     )
 
@@ -103,7 +108,7 @@ describe('resolveHookPermissionDecision', () => {
       {},
       contextForFullAccess(),
       canUseTool,
-      {} as never,
+      assistantMessage,
       'tool-use-id',
     )
 
@@ -129,7 +134,7 @@ describe('resolveHookPermissionDecision', () => {
       { raw: true },
       contextForFullAccess(),
       canUseTool,
-      {} as never,
+      assistantMessage,
       'tool-use-id',
     )
 

--- a/src/test/toolFixtures.ts
+++ b/src/test/toolFixtures.ts
@@ -1,0 +1,61 @@
+import type { AnyObject, Tool } from '../Tool.js'
+
+type ToolFixtureOverrides<Input extends AnyObject, Output> = Pick<
+  Tool<Input, Output>,
+  'name'
+> &
+  Partial<Omit<Tool<Input, Output>, 'inputSchema' | 'name'>>
+
+export function createToolFixture<
+  Input extends AnyObject,
+  Output = unknown,
+>(
+  inputSchema: Input,
+  overrides: ToolFixtureOverrides<Input, Output>,
+): Tool<Input, Output> {
+  const { name, ...restOverrides } = overrides
+
+  return {
+    name,
+    inputSchema,
+    maxResultSizeChars: 0,
+    async call() {
+      return { data: undefined as Output }
+    },
+    async description() {
+      return name
+    },
+    async prompt() {
+      return ''
+    },
+    isConcurrencySafe() {
+      return false
+    },
+    isEnabled() {
+      return true
+    },
+    isReadOnly() {
+      return false
+    },
+    async checkPermissions(input) {
+      return { behavior: 'allow', updatedInput: input }
+    },
+    toAutoClassifierInput() {
+      return ''
+    },
+    userFacingName() {
+      return name
+    },
+    mapToolResultToToolResultBlockParam(content, toolUseID) {
+      return {
+        type: 'tool_result',
+        tool_use_id: toolUseID,
+        content: typeof content === 'string' ? content : '',
+      }
+    },
+    renderToolUseMessage() {
+      return null
+    },
+    ...restOverrides,
+  }
+}

--- a/src/tools/MCPTool/MCPTool.test.ts
+++ b/src/tools/MCPTool/MCPTool.test.ts
@@ -1,5 +1,27 @@
-import { describe, expect, test, beforeEach } from 'bun:test'
-import { MCPTool } from './MCPTool.js'
+import { describe, expect, test } from 'bun:test'
+import { MCPTool, type Output } from './MCPTool.js'
+
+type MCPToolWithValidator = typeof MCPTool & {
+  validateInput: NonNullable<typeof MCPTool.validateInput>
+}
+
+type MCPToolWithTruncationCheck = typeof MCPTool & {
+  isResultTruncated: NonNullable<typeof MCPTool.isResultTruncated>
+}
+
+function withValidator(tool: typeof MCPTool): MCPToolWithValidator {
+  if (!tool.validateInput) {
+    throw new Error('MCPTool.validateInput is required for these tests')
+  }
+  return tool as MCPToolWithValidator
+}
+
+function withTruncationCheck(tool: typeof MCPTool): MCPToolWithTruncationCheck {
+  if (!tool.isResultTruncated) {
+    throw new Error('MCPTool.isResultTruncated is required for these tests')
+  }
+  return tool as MCPToolWithTruncationCheck
+}
 
 // =============================================================================
 // MCPTool.validateInput — AJV schema validation
@@ -8,7 +30,10 @@ import { MCPTool } from './MCPTool.js'
 describe('MCPTool.validateInput', () => {
   test('passes when no inputJSONSchema is set', async () => {
     const tool = { ...MCPTool, inputJSONSchema: undefined }
-    const result = await tool.validateInput({ anything: 'goes' }, {} as never)
+    const result = await withValidator(tool).validateInput(
+      { anything: 'goes' },
+      {} as never,
+    )
     expect(result.result).toBe(true)
   })
 
@@ -24,11 +49,14 @@ describe('MCPTool.validateInput', () => {
     const tool = { ...MCPTool, inputJSONSchema: schema }
 
     // Valid input
-    const valid = await tool.validateInput({ name: 'test' }, {} as never)
+    const valid = await withValidator(tool).validateInput(
+      { name: 'test' },
+      {} as never,
+    )
     expect(valid.result).toBe(true)
 
     // Missing required field
-    const invalid = await tool.validateInput({}, {} as never)
+    const invalid = await withValidator(tool).validateInput({}, {} as never)
     expect(invalid.result).toBe(false)
     expect(invalid.result === false && invalid.message).toContain('name')
   })
@@ -43,7 +71,10 @@ describe('MCPTool.validateInput', () => {
     }
     const tool = { ...MCPTool, inputJSONSchema: schema }
 
-    const result = await tool.validateInput({ x: 1, extra: 'bad' }, {} as never)
+    const result = await withValidator(tool).validateInput(
+      { x: 1, extra: 'bad' },
+      {} as never,
+    )
     expect(result.result).toBe(false)
   })
 
@@ -52,7 +83,7 @@ describe('MCPTool.validateInput', () => {
     const schema = { type: 'invalid_type' } as any
     const tool = { ...MCPTool, inputJSONSchema: schema }
 
-    const result = await tool.validateInput({}, {} as never)
+    const result = await withValidator(tool).validateInput({}, {} as never)
     expect(result.result).toBe(false)
     expect(result.result === false && result.errorCode).toBe(500)
     expect(result.result === false && result.message).toContain('Failed to compile')
@@ -62,7 +93,7 @@ describe('MCPTool.validateInput', () => {
     const schema = { type: 'invalid_type' } as any
     const tool = { ...MCPTool, inputJSONSchema: schema }
 
-    const result = await tool.validateInput({}, {} as never)
+    const result = await withValidator(tool).validateInput({}, {} as never)
     expect(result.result).toBe(false)
     // Should NOT contain [object Object]
     expect(result.result === false && result.message).not.toContain('[object Object]')
@@ -82,8 +113,8 @@ describe('MCPTool.mapToolResultToToolResultBlockParam', () => {
   })
 
   test('handles array content', () => {
-    const blocks = [{ type: 'text', text: 'hello' }]
-    const result = MCPTool.mapToolResultToToolResultBlockParam(blocks as any, 'tool-2')
+    const blocks = [{ type: 'text' as const, text: 'hello' }] satisfies Output
+    const result = MCPTool.mapToolResultToToolResultBlockParam(blocks, 'tool-2')
     expect(result.content).toEqual(blocks)
   })
 
@@ -106,27 +137,42 @@ describe('MCPTool.mapToolResultToToolResultBlockParam', () => {
 
 describe('MCPTool.isResultTruncated', () => {
   test('returns false for short string', () => {
-    expect(MCPTool.isResultTruncated('short')).toBe(false)
+    expect(withTruncationCheck(MCPTool).isResultTruncated('short')).toBe(false)
   })
 
   test('returns false for empty array', () => {
-    expect(MCPTool.isResultTruncated([])).toBe(false)
+    expect(withTruncationCheck(MCPTool).isResultTruncated([])).toBe(false)
   })
 
   test('returns false for array with short text blocks', () => {
-    expect(MCPTool.isResultTruncated([{ type: 'text', text: 'short' }])).toBe(false)
+    expect(
+      withTruncationCheck(MCPTool).isResultTruncated([
+        { type: 'text', text: 'short' },
+      ]),
+    ).toBe(false)
   })
 
   test('handles null blocks in array', () => {
-    expect(MCPTool.isResultTruncated([null as any, { type: 'text', text: 'ok' }])).toBe(false)
+    expect(
+      withTruncationCheck(MCPTool).isResultTruncated([
+        null as any,
+        { type: 'text', text: 'ok' },
+      ]),
+    ).toBe(false)
   })
 
   test('handles undefined blocks in array', () => {
-    expect(MCPTool.isResultTruncated([undefined as any])).toBe(false)
+    expect(
+      withTruncationCheck(MCPTool).isResultTruncated([undefined as any]),
+    ).toBe(false)
   })
 
   test('returns false for non-string non-array', () => {
-    expect(MCPTool.isResultTruncated(42 as any)).toBe(false)
-    expect(MCPTool.isResultTruncated({} as any)).toBe(false)
+    expect(withTruncationCheck(MCPTool).isResultTruncated(42 as any)).toBe(
+      false,
+    )
+    expect(withTruncationCheck(MCPTool).isResultTruncated({} as any)).toBe(
+      false,
+    )
   })
 })

--- a/src/utils/permissions/filesystem.test.ts
+++ b/src/utils/permissions/filesystem.test.ts
@@ -2,17 +2,22 @@ import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
 import { mkdtemp, mkdir, rm } from 'fs/promises'
 import { tmpdir } from 'os'
 import { join } from 'path'
-import type { Tool } from '../../Tool.js'
+import { z } from 'zod/v4'
 import type { ToolPermissionContext } from '../../types/permissions.js'
 import { getOriginalCwd, setOriginalCwd } from '../../bootstrap/state.js'
+import { createToolFixture } from '../../test/toolFixtures.js'
 import { checkWritePermissionForTool } from './filesystem.js'
 
-const writeTool = {
+const writeInputSchema = z.object({
+  file_path: z.string(),
+})
+
+const writeTool = createToolFixture(writeInputSchema, {
   name: 'Write',
   getPath(input: { file_path: string }) {
     return input.file_path
   },
-} as Tool<{ file_path: string }>
+})
 
 function permissionContext(mode: ToolPermissionContext['mode']) {
   return {

--- a/src/utils/permissions/permissions.test.ts
+++ b/src/utils/permissions/permissions.test.ts
@@ -1,11 +1,14 @@
 import { describe, expect, test } from 'bun:test'
 import { z } from 'zod/v4'
-import type { Tool, ToolPermissionContext } from '../../Tool.js'
+import type { ToolPermissionContext, ToolUseContext } from '../../Tool.js'
+import { createToolFixture } from '../../test/toolFixtures.js'
 import { hasPermissionsToUseTool } from './permissions.js'
 
-const safetyCheckTool = {
+const emptyInputSchema = z.object({})
+const assistantMessage = {} as Parameters<typeof hasPermissionsToUseTool>[3]
+
+const safetyCheckTool = createToolFixture(emptyInputSchema, {
   name: 'SafetyCheckTool',
-  inputSchema: z.object({}),
   async checkPermissions() {
     return {
       behavior: 'ask',
@@ -17,11 +20,10 @@ const safetyCheckTool = {
       },
     }
   },
-} as Tool<Record<string, never>>
+})
 
-const userInteractionTool = {
+const userInteractionTool = createToolFixture(emptyInputSchema, {
   name: 'UserInteractionTool',
-  inputSchema: z.object({}),
   requiresUserInteraction() {
     return true
   },
@@ -31,22 +33,20 @@ const userInteractionTool = {
       message: 'User interaction requires approval',
     }
   },
-} as Tool<Record<string, never>>
+})
 
-const plainAskRuleTool = {
+const plainAskRuleTool = createToolFixture(emptyInputSchema, {
   name: 'PlainAskRuleTool',
-  inputSchema: z.object({}),
   async checkPermissions() {
     return {
       behavior: 'passthrough',
       message: '',
     }
   },
-} as Tool<Record<string, never>>
+})
 
-const contentAskTool = {
+const contentAskTool = createToolFixture(emptyInputSchema, {
   name: 'ContentAskTool',
-  inputSchema: z.object({}),
   async checkPermissions() {
     return {
       behavior: 'ask',
@@ -54,28 +54,35 @@ const contentAskTool = {
       decisionReason: {
         type: 'rule',
         rule: {
+          source: 'session',
           ruleBehavior: 'ask',
+          ruleValue: {
+            toolName: 'ContentAskTool',
+          },
         },
       },
     }
   },
-} as Tool<Record<string, never>>
+})
 
-const denyTool = {
+const denyTool = createToolFixture(emptyInputSchema, {
   name: 'DenyTool',
-  inputSchema: z.object({}),
   async checkPermissions() {
     return {
       behavior: 'deny',
       message: 'Denied by tool',
+      decisionReason: {
+        type: 'other',
+        reason: 'Denied by tool',
+      },
     }
   },
-} as Tool<Record<string, never>>
+})
 
 function contextFor(
   mode: ToolPermissionContext['mode'],
   overrides: Partial<ToolPermissionContext> = {},
-) {
+): ToolUseContext {
   const toolPermissionContext = {
     mode,
     additionalWorkingDirectories: new Map(),
@@ -92,7 +99,7 @@ function contextFor(
     getAppState: () => ({ toolPermissionContext }),
     setAppState: () => {},
     options: {},
-  }
+  } as unknown as ToolUseContext
 }
 
 describe('permission modes and safety checks', () => {
@@ -100,8 +107,8 @@ describe('permission modes and safety checks', () => {
     const result = await hasPermissionsToUseTool(
       safetyCheckTool,
       {},
-      contextFor('bypassPermissions') as never,
-      {} as never,
+      contextFor('bypassPermissions'),
+      assistantMessage,
       'tool-use-id',
     )
 
@@ -113,8 +120,8 @@ describe('permission modes and safety checks', () => {
     const result = await hasPermissionsToUseTool(
       safetyCheckTool,
       {},
-      contextFor('fullAccess') as never,
-      {} as never,
+      contextFor('fullAccess'),
+      assistantMessage,
       'tool-use-id',
     )
 
@@ -131,8 +138,8 @@ describe('permission modes and safety checks', () => {
       {},
       contextFor('fullAccess', {
         alwaysAskRules: { session: ['PlainAskRuleTool'] },
-      }) as never,
-      {} as never,
+      }),
+      assistantMessage,
       'tool-use-id',
     )
 
@@ -147,12 +154,15 @@ describe('permission modes and safety checks', () => {
     const result = await hasPermissionsToUseTool(
       userInteractionTool,
       {},
-      contextFor('fullAccess') as never,
-      {} as never,
+      contextFor('fullAccess'),
+      assistantMessage,
       'tool-use-id',
     )
 
     expect(result.behavior).toBe('ask')
+    if (result.behavior !== 'ask') {
+      throw new Error(`Expected ask decision, received ${result.behavior}`)
+    }
     expect(result.message).toBe('User interaction requires approval')
   })
 
@@ -160,8 +170,8 @@ describe('permission modes and safety checks', () => {
     const result = await hasPermissionsToUseTool(
       contentAskTool,
       {},
-      contextFor('fullAccess') as never,
-      {} as never,
+      contextFor('fullAccess'),
+      assistantMessage,
       'tool-use-id',
     )
 
@@ -176,12 +186,15 @@ describe('permission modes and safety checks', () => {
     const result = await hasPermissionsToUseTool(
       denyTool,
       {},
-      contextFor('fullAccess') as never,
-      {} as never,
+      contextFor('fullAccess'),
+      assistantMessage,
       'tool-use-id',
     )
 
     expect(result.behavior).toBe('deny')
+    if (result.behavior !== 'deny') {
+      throw new Error(`Expected deny decision, received ${result.behavior}`)
+    }
     expect(result.message).toBe('Denied by tool')
   })
 })


### PR DESCRIPTION
## Summary

- add a small typed test helper for inert `Tool` fixtures
- replace brittle `Tool<Record<...>>` casts in permission and hook tests with schema-backed fixtures
- guard optional MCP tool methods in tests before invoking them

## Validation

- `bun test src/utils/permissions/permissions.test.ts src/utils/permissions/filesystem.test.ts src/services/tools/toolHooks.test.ts src/tools/MCPTool/MCPTool.test.ts`
- `bun run typecheck` still exits 2 because of the existing repo-wide baseline, but reports no errors for the changed files
- `env -u CLAUDE_CODE_USE_OPENAI -u OPENAI_API_KEY -u OPENAI_BASE_URL -u OPENAI_MODEL bun run check`

Part of #1486.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Refactored test infrastructure to use shared fixture helpers for consistent tool object creation across test suites.
  * Updated test utilities with type guards and wrapper helpers for safer method validation.
  * Consolidated permission-context and message handling in permission-related tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->