### PR TITLE
fix(typecheck): import bun test helpers in truncate test

### DIFF
--- a/src/utils/truncate.test.ts
+++ b/src/utils/truncate.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, test } from 'bun:test'
 import { truncate, truncateToWidth, truncatePathMiddle } from './truncate.js'
 
 describe('truncate utilities', () => {
@@ -11,5 +12,15 @@ describe('truncate utilities', () => {
 
   test('truncatePathMiddle returns empty string for undefined path', () => {
     expect(truncatePathMiddle(undefined, 20)).toBe('')
+  })
+
+  test('truncate respects single-line mode and display width together', () => {
+    expect(truncate('abcdefghij\nrest', 5, true)).toBe('abcd\u2026')
+  })
+
+  test('truncateToWidth preserves CJK display width boundaries', () => {
+    expect(truncateToWidth('\u4f60\u597d\u4e16\u754c', 5)).toBe(
+      '\u4f60\u597d\u2026',
+    )
   })
 })


### PR DESCRIPTION
## Summary

- import Bun test helpers explicitly in `truncate.test.ts`
- add edge-case coverage for single-line width truncation and CJK display width handling

## Validation

- `bun test src/utils/truncate.test.ts`
- `bun run typecheck` still exits 2 because of the existing repo-wide baseline, but reports no errors for `src/utils/truncate.test.ts`
- `env -u CLAUDE_CODE_USE_OPENAI -u OPENAI_API_KEY -u OPENAI_BASE_URL -u OPENAI_MODEL bun run check`

Part of #1486.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded test suite with enhanced coverage for text truncation features. Added test cases to validate single-line mode behavior when handling newline characters and to ensure text width truncation properly respects character display width boundaries for CJK characters in multilingual applications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->