### PR TITLE
fix(typecheck): type Grove dialog state

### DIFF
--- a/src/components/grove/Grove.tsx
+++ b/src/components/grove/Grove.tsx
@@ -141,15 +141,15 @@ function PostGracePeriodContentBody() {
   }
   return t6;
 }
-export function GroveDialog(t0) {
+export function GroveDialog(t0: Props) {
   const $ = _c(34);
   const {
     showIfAlreadyViewed,
     location,
     onDone
   } = t0;
-  const [shouldShowDialog, setShouldShowDialog] = useState(null);
-  const [groveConfig, setGroveConfig] = useState(null);
+  const [shouldShowDialog, setShouldShowDialog] = useState<boolean | null>(null);
+  const [groveConfig, setGroveConfig] = useState<GroveConfig | null>(null);
   let t1;
   let t2;
   if ($[0] !== location || $[1] !== onDone || $[2] !== showIfAlreadyViewed) {
@@ -354,7 +354,7 @@ type PrivacySettingsDialogProps = {
   domainExcluded?: boolean;
   onDone(): void;
 };
-export function PrivacySettingsDialog(t0) {
+export function PrivacySettingsDialog(t0: PrivacySettingsDialogProps) {
   const $ = _c(17);
   const {
     settings,

--- a/src/services/api/grove.test.ts
+++ b/src/services/api/grove.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, test } from 'bun:test'
+import {
+  calculateShouldShowGrove,
+  type AccountSettings,
+  type ApiResult,
+  type GroveConfig,
+} from './grove.js'
+
+const DAY_MS = 24 * 60 * 60 * 1000
+
+function settings(
+  overrides: Partial<AccountSettings> = {},
+): ApiResult<AccountSettings> {
+  return {
+    success: true,
+    data: {
+      grove_enabled: null,
+      grove_notice_viewed_at: null,
+      ...overrides,
+    },
+  }
+}
+
+function config(overrides: Partial<GroveConfig> = {}): ApiResult<GroveConfig> {
+  return {
+    success: true,
+    data: {
+      grove_enabled: true,
+      domain_excluded: false,
+      notice_is_grace_period: true,
+      notice_reminder_frequency: null,
+      ...overrides,
+    },
+  }
+}
+
+describe('calculateShouldShowGrove', () => {
+  test('hides the dialog when either Grove API call failed', () => {
+    expect(calculateShouldShowGrove({ success: false }, config(), false)).toBe(
+      false,
+    )
+    expect(calculateShouldShowGrove(settings(), { success: false }, false)).toBe(
+      false,
+    )
+  })
+
+  test('hides the dialog after the user has already chosen either setting', () => {
+    expect(
+      calculateShouldShowGrove(
+        settings({ grove_enabled: true }),
+        config(),
+        false,
+      ),
+    ).toBe(false)
+
+    expect(
+      calculateShouldShowGrove(
+        settings({ grove_enabled: false }),
+        config(),
+        false,
+      ),
+    ).toBe(false)
+  })
+
+  test('uses reminder frequency during the grace period', () => {
+    const recentlyViewed = new Date(Date.now() - 6 * DAY_MS).toISOString()
+    const reminderExpired = new Date(Date.now() - 8 * DAY_MS).toISOString()
+    const weeklyReminderConfig = config({ notice_reminder_frequency: 7 })
+
+    expect(
+      calculateShouldShowGrove(
+        settings({ grove_notice_viewed_at: recentlyViewed }),
+        weeklyReminderConfig,
+        false,
+      ),
+    ).toBe(false)
+
+    expect(
+      calculateShouldShowGrove(
+        settings({ grove_notice_viewed_at: reminderExpired }),
+        weeklyReminderConfig,
+        false,
+      ),
+    ).toBe(true)
+  })
+
+  test('can force display for settings even after the notice was already viewed', () => {
+    expect(
+      calculateShouldShowGrove(
+        settings({ grove_notice_viewed_at: new Date().toISOString() }),
+        config(),
+        true,
+      ),
+    ).toBe(true)
+  })
+
+  test('shows the post-grace dialog until the user makes a choice', () => {
+    expect(
+      calculateShouldShowGrove(
+        settings({ grove_notice_viewed_at: new Date().toISOString() }),
+        config({ notice_is_grace_period: false }),
+        false,
+      ),
+    ).toBe(true)
+  })
+})


### PR DESCRIPTION
## Summary

- Type the Grove dialog props and nullable state so `GroveConfig` and `boolean` updates no longer collapse to `never`/`null` during typecheck.
- Type `PrivacySettingsDialog` with its existing props shape.
- Add focused Grove decision coverage for API failures, prior user choices, reminder cadence, forced display, and post-grace display.

## Impact

- user-facing impact: none expected; this is a type-surface cleanup with pure-function test coverage.
- developer/maintainer impact: removes the Grove component diagnostics from the repo-wide typecheck backlog tracked in #1486.

## Testing

- [x] `bun run build`
- [x] `bun run smoke`
- [x] `env -u CLAUDE_CODE_USE_OPENAI -u OPENAI_API_KEY -u OPENAI_BASE_URL -u OPENAI_MODEL -u CLAUDE_CODE_MAX_RETRIES -u CLAUDE_CODE_UNATTENDED_RETRY bun run check`
- [x] `bun test src/services/api/grove.test.ts`
- [x] `bun run test:provider`
- [x] `env -u CLAUDE_CODE_USE_OPENAI -u OPENAI_API_KEY -u OPENAI_BASE_URL -u OPENAI_MODEL -u CLAUDE_CODE_MAX_RETRIES -u CLAUDE_CODE_UNATTENDED_RETRY npm run test:provider-recommendation`
- [x] `bun run web:typecheck`
- [x] `git diff --check`

## Notes

- Part of #1486.
- `bun run typecheck` still exits 2 because of the existing repo-wide baseline; the checked log has 1701 TypeScript diagnostics and no `src/components/grove/Grove.tsx` diagnostics.
- provider/model path tested: neutral CI-style environment with local provider override variables unset.
- screenshots attached: n/a, no UI behavior change.
- follow-up work or known limitations: remaining unrelated typecheck backlog in #1486.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved type safety for component parameters with explicit type annotations

* **Tests**
  * Added comprehensive test coverage for dialog display logic across multiple scenarios, including API failure handling, user preferences, and grace-period reminder frequency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->