### PR TITLE
fix(typecheck): type GitHub app setup flow

### DIFF
--- a/src/commands/install-github-app/OAuthFlowStep.tsx
+++ b/src/commands/install-github-app/OAuthFlowStep.tsx
@@ -32,6 +32,7 @@ type OAuthStatus = {
   state: 'about_to_retry';
   nextState: OAuthStatus;
 };
+type TimerHandle = number | NodeJS.Timeout;
 const PASTE_HERE_MSG = 'Paste code here if prompted > ';
 export function OAuthFlowStep({
   onSuccess,
@@ -45,9 +46,9 @@ export function OAuthFlowStep({
   const [cursorOffset, setCursorOffset] = useState(0);
   const [showPastePrompt, setShowPastePrompt] = useState(false);
   const [urlCopied, setUrlCopied] = useState(false);
-  const timersRef = useRef<Set<NodeJS.Timeout>>(new Set());
+  const timersRef = useRef<Set<TimerHandle>>(new Set());
   // Separate ref so startOAuth's timer clear doesn't cancel the urlCopied reset
-  const urlCopiedTimerRef = useRef<NodeJS.Timeout | undefined>(undefined);
+  const urlCopiedTimerRef = useRef<TimerHandle | undefined>(undefined);
   const terminalSize = useTerminalSize();
   const textInputColumns = Math.max(50, terminalSize.columns - PASTE_HERE_MSG.length - 4);
   function handleKeyDown(e: KeyboardEvent): void {

--- a/src/commands/install-github-app/setupGitHubActions.test.ts
+++ b/src/commands/install-github-app/setupGitHubActions.test.ts
@@ -1,0 +1,282 @@
+import { afterEach, beforeEach, expect, mock, test } from 'bun:test'
+import { getGlobalConfig, saveGlobalConfig } from 'src/utils/config.js'
+import {
+  acquireSharedMutationLock,
+  releaseSharedMutationLock,
+} from '../../test/sharedMutationLock.js'
+
+type BrowserModule = typeof import('../../utils/browser.js')
+type ExecFileNoThrowModule = typeof import('../../utils/execFileNoThrow.js')
+
+type ExecCall = {
+  file: string
+  args: string[]
+}
+
+type RealModules = {
+  browser: BrowserModule
+  execFileNoThrow: ExecFileNoThrowModule
+}
+
+const CLAUDE_WORKFLOW_PATH =
+  'repos/owner/repo/contents/.github/workflows/claude.yml'
+const REVIEW_WORKFLOW_PATH =
+  'repos/owner/repo/contents/.github/workflows/claude-code-review.yml'
+
+const execCalls: ExecCall[] = []
+const openedUrls: string[] = []
+let initialSetupCount: number | undefined
+let realModules: RealModules | undefined
+
+function execResult(stdout = '', code = 0, stderr = '') {
+  return {
+    code,
+    stderr,
+    stdout,
+  }
+}
+
+async function importRealModules(): Promise<RealModules> {
+  if (realModules) return realModules
+
+  const cacheKey = `${Date.now()}-${Math.random()}`
+  realModules = {
+    browser: (await import(
+      `../../utils/browser.ts?setup-actions-real-${cacheKey}`
+    )) as BrowserModule,
+    execFileNoThrow: (await import(
+      `../../utils/execFileNoThrow.ts?setup-actions-real-${cacheKey}`
+    )) as ExecFileNoThrowModule,
+  }
+  return realModules
+}
+
+function getWorkflowMessage(path: string): string | null {
+  if (path === CLAUDE_WORKFLOW_PATH) return 'Claude PR Assistant workflow'
+  if (path === REVIEW_WORKFLOW_PATH) return 'Claude Code Review workflow'
+  return null
+}
+
+function isBranchName(value: string): boolean {
+  return /^add-claude-github-actions-\d+$/.test(value)
+}
+
+function workflowWritePaths(): string[] {
+  return execCalls
+    .filter(
+      call =>
+        call.args[0] === 'api' &&
+        call.args[1] === '--method' &&
+        call.args[2] === 'PUT' &&
+        call.args[3]?.startsWith(
+          'repos/owner/repo/contents/.github/workflows/',
+        ),
+    )
+    .map(call => call.args[3])
+}
+
+function handleGhCommand(args: string[]) {
+  if (args.join('\0') === ['api', 'repos/owner/repo', '--jq', '.id'].join('\0')) {
+    return execResult('123')
+  }
+  if (
+    args.join('\0') ===
+    ['api', 'repos/owner/repo', '--jq', '.default_branch'].join('\0')
+  ) {
+    return execResult('main')
+  }
+  if (
+    args.join('\0') ===
+    [
+      'api',
+      'repos/owner/repo/git/ref/heads/main',
+      '--jq',
+      '.object.sha',
+    ].join('\0')
+  ) {
+    return execResult('base-sha')
+  }
+
+  if (
+    args.length === 8 &&
+    args[0] === 'api' &&
+    args[1] === '--method' &&
+    args[2] === 'POST' &&
+    args[3] === 'repos/owner/repo/git/refs' &&
+    args[4] === '-f' &&
+    args[5]?.startsWith('ref=refs/heads/') &&
+    isBranchName(args[5].slice('ref=refs/heads/'.length)) &&
+    args[6] === '-f' &&
+    args[7] === 'sha=base-sha'
+  ) {
+    return execResult()
+  }
+
+  if (
+    args.length === 4 &&
+    args[0] === 'api' &&
+    args[1] === CLAUDE_WORKFLOW_PATH &&
+    args[2] === '--jq' &&
+    args[3] === '.sha'
+  ) {
+    return execResult('', 1, 'Not Found')
+  }
+
+  if (
+    args.length === 4 &&
+    args[0] === 'api' &&
+    args[1] === REVIEW_WORKFLOW_PATH &&
+    args[2] === '--jq' &&
+    args[3] === '.sha'
+  ) {
+    return execResult('', 1, 'Not Found')
+  }
+
+  if (
+    args.length === 10 &&
+    args[0] === 'api' &&
+    args[1] === '--method' &&
+    args[2] === 'PUT' &&
+    getWorkflowMessage(args[3]) &&
+    args[4] === '-f' &&
+    args[5] === `message="${getWorkflowMessage(args[3])}"` &&
+    args[6] === '-f' &&
+    args[7]?.startsWith('content=') &&
+    args[8] === '-f' &&
+    args[9]?.startsWith('branch=') &&
+    isBranchName(args[9].slice('branch='.length))
+  ) {
+    return execResult()
+  }
+
+  if (
+    args.length === 7 &&
+    args[0] === 'secret' &&
+    args[1] === 'set' &&
+    (args[2] === 'ANTHROPIC_API_KEY' || args[2] === 'CLAUDE_CODE_OAUTH_TOKEN') &&
+    args[3] === '--body' &&
+    typeof args[4] === 'string' &&
+    args[4].length > 0 &&
+    args[5] === '--repo' &&
+    args[6] === 'owner/repo'
+  ) {
+    return execResult()
+  }
+
+  throw new Error(`Unexpected gh call: ${args.join(' ')}`)
+}
+
+function installMocks(real: RealModules): void {
+  mock.module('../../utils/execFileNoThrow.js', () => ({
+    ...real.execFileNoThrow,
+    execFileNoThrow: mock(async (file: string, args: string[]) => {
+      execCalls.push({ file, args })
+
+      if (file === 'gh') {
+        return handleGhCommand(args)
+      }
+
+      throw new Error(`Unexpected executable: ${file}`)
+    }),
+  }))
+
+  mock.module('../../utils/browser.js', () => ({
+    ...real.browser,
+    openBrowser: mock(async (url: string) => {
+      openedUrls.push(url)
+    }),
+  }))
+}
+
+async function importSetupGitHubActions() {
+  return import(`./setupGitHubActions.ts?test-${Date.now()}-${Math.random()}`)
+}
+
+beforeEach(async () => {
+  await acquireSharedMutationLock(
+    'commands/install-github-app/setupGitHubActions.test.ts',
+  )
+  execCalls.length = 0
+  openedUrls.length = 0
+  initialSetupCount = getGlobalConfig().githubActionSetupCount
+  installMocks(await importRealModules())
+})
+
+afterEach(() => {
+  try {
+    saveGlobalConfig(current => ({
+      ...current,
+      githubActionSetupCount: initialSetupCount,
+    }))
+    initialSetupCount = undefined
+    mock.restore()
+    if (realModules) {
+      mock.module(
+        '../../utils/execFileNoThrow.js',
+        () => realModules!.execFileNoThrow,
+      )
+      mock.module('../../utils/browser.js', () => realModules!.browser)
+    }
+  } finally {
+    releaseSharedMutationLock()
+  }
+})
+
+test('setupGitHubActions creates only the selected review workflow', async () => {
+  const { setupGitHubActions } = await importSetupGitHubActions()
+
+  await setupGitHubActions(
+    'owner/repo',
+    'api-token',
+    'ANTHROPIC_API_KEY',
+    () => {},
+    false,
+    ['claude-review'],
+    'api_key',
+  )
+
+  const secretSet = execCalls.find(call =>
+    call.args.includes('secret') && call.args.includes('set'),
+  )
+
+  expect(workflowWritePaths()).toEqual([REVIEW_WORKFLOW_PATH])
+  expect(secretSet?.args).toContain('ANTHROPIC_API_KEY')
+  expect(secretSet?.args).toContain('api-token')
+  expect(openedUrls).toHaveLength(1)
+  expect(openedUrls[0]).toContain(
+    'https://github.com/owner/repo/compare/main...add-claude-github-actions-',
+  )
+  expect(getGlobalConfig().githubActionSetupCount).toBe(
+    (initialSetupCount ?? 0) + 1,
+  )
+})
+
+test('setupGitHubActions skip mode configures the secret without workflow writes', async () => {
+  const { setupGitHubActions } = await importSetupGitHubActions()
+
+  await setupGitHubActions(
+    'owner/repo',
+    'oauth-token',
+    'CLAUDE_CODE_OAUTH_TOKEN',
+    () => {},
+    true,
+    ['claude', 'claude-review'],
+    'oauth_token',
+  )
+
+  const branchCreates = execCalls.filter(call =>
+    call.args.includes('repos/owner/repo/git/refs'),
+  )
+  const secretSet = execCalls.find(call =>
+    call.args.includes('secret') && call.args.includes('set'),
+  )
+
+  expect(branchCreates).toHaveLength(0)
+  expect(workflowWritePaths()).toEqual([])
+  expect(openedUrls).toHaveLength(0)
+  expect(secretSet?.args).toContain('CLAUDE_CODE_OAUTH_TOKEN')
+  expect(secretSet?.args).toContain('oauth-token')
+  expect(getGlobalConfig().githubActionSetupCount).toBe(
+    (initialSetupCount ?? 0) + 1,
+  )
+})

--- a/src/commands/install-github-app/setupGitHubActions.ts
+++ b/src/commands/install-github-app/setupGitHubActions.ts
@@ -14,6 +14,12 @@ import { execFileNoThrow } from '../../utils/execFileNoThrow.js'
 import { logError } from '../../utils/log.js'
 import type { Workflow } from './types.js'
 
+type WorkflowFile = {
+  path: string
+  content: string
+  message: string
+}
+
 async function createWorkflowFile(
   repoName: string,
   branchName: string,
@@ -219,7 +225,7 @@ export async function setupGitHubActions(
 
       updateProgress()
       // Create selected workflow files
-      const workflows = []
+      const workflows: WorkflowFile[] = []
 
       if (selectedWorkflows.includes('claude')) {
         workflows.push({

--- a/src/commands/install-github-app/types.ts
+++ b/src/commands/install-github-app/types.ts
@@ -1,0 +1,49 @@
+export type Workflow = 'claude' | 'claude-review'
+
+export type Warning = {
+  title: string
+  message: string
+  instructions: string[]
+}
+
+export type ApiKeyOption = 'existing' | 'new' | 'oauth'
+
+export type AuthType = 'api_key' | 'oauth_token'
+
+export type WorkflowAction = 'update' | 'skip' | 'exit'
+
+export type InstallGitHubAppStep =
+  | 'check-gh'
+  | 'warnings'
+  | 'choose-repo'
+  | 'install-app'
+  | 'check-existing-workflow'
+  | 'select-workflows'
+  | 'check-existing-secret'
+  | 'api-key'
+  | 'creating'
+  | 'success'
+  | 'error'
+  | 'oauth-flow'
+
+export type State = {
+  step: InstallGitHubAppStep
+  selectedRepoName: string
+  currentRepo: string
+  useCurrentRepo: boolean
+  apiKeyOrOAuthToken: string
+  useExistingKey: boolean
+  currentWorkflowInstallStep: number
+  warnings: Warning[]
+  secretExists: boolean
+  secretName: string
+  useExistingSecret: boolean
+  workflowExists: boolean
+  selectedWorkflows: Workflow[]
+  selectedApiKeyOption: ApiKeyOption
+  authType: AuthType
+  workflowAction?: WorkflowAction
+  error?: string
+  errorReason?: string
+  errorInstructions?: string[]
+}


### PR DESCRIPTION
## Summary

- Restore the install-GitHub-app domain types used by the setup flow, workflow selector, warning, and progress steps.
- Type the selected workflow file queue in `setupGitHubActions` and use a timer handle type that works across the repo's mixed Node/DOM timer environment.
- Add setup coverage for installing only the review workflow and for skip-workflow mode configuring secrets without workflow writes.

## Impact

- User-facing impact: none expected; this is a type-surface cleanup with setup-helper regression coverage.
- Developer impact: removes the install-GitHub-app and workflow selector diagnostics from the repo-wide typecheck backlog tracked in #1486.

## Testing

- [x] `bun test src/commands/install-github-app/setupGitHubActions.test.ts src/commands/install-github-app/repoSlug.test.ts`
- [x] `bun test --max-concurrency=1 src/commands/install-github-app/setupGitHubActions.test.ts src/commands/knowledge/knowledge.test.ts`
- [x] `env -u CLAUDE_CODE_USE_OPENAI -u OPENAI_API_KEY -u OPENAI_BASE_URL -u OPENAI_MODEL -u CLAUDE_CODE_MAX_RETRIES -u CLAUDE_CODE_UNATTENDED_RETRY bun run check`
- [x] `bun run test:provider`
- [x] `env -u CLAUDE_CODE_USE_OPENAI -u OPENAI_API_KEY -u OPENAI_BASE_URL -u OPENAI_MODEL -u CLAUDE_CODE_MAX_RETRIES -u CLAUDE_CODE_UNATTENDED_RETRY npm run test:provider-recommendation`
- [x] `bun run web:typecheck`
- [x] `git diff --check`

## Notes

- Part of #1486.
- `bun run typecheck` still exits 2 because of the existing repo-wide baseline; the post-change log has 1708 TypeScript diagnostics and no diagnostics for `src/commands/install-github-app/*` or `src/components/WorkflowMultiselectDialog.tsx`.
- Screenshots attached: n/a, no intended UI behavior change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for GitHub Actions installation workflow behavior

* **Refactor**
  * Improved internal type definitions and timer handling for better code structure

<!-- end of auto-generated comment: release notes by coderabbit.ai -->