### PR TITLE
fix(typecheck): type MCP doctor test fixtures

### DIFF
--- a/src/services/mcp/doctor.test.ts
+++ b/src/services/mcp/doctor.test.ts
@@ -1,5 +1,7 @@
 import assert from 'node:assert/strict'
 import test from 'node:test'
+import { Client } from '@modelcontextprotocol/sdk/client/index.js'
+import memoize from 'lodash-es/memoize.js'
 
 import type { ValidationError } from '../../utils/settings/validation.js'
 
@@ -10,8 +12,26 @@ import {
   findingsFromValidationErrors,
   type McpDoctorDependencies,
 } from './doctor.js'
+import { getServerCacheKey } from './client.js'
+import type {
+  ConfigScope,
+  MCPServerConnection,
+  ScopedMcpServerConfig,
+} from './types.js'
 
-function stdioConfig(scope: 'local' | 'project' | 'user' | 'enterprise', command: string) {
+type AllConfigResult = Awaited<ReturnType<McpDoctorDependencies['getAllMcpConfigs']>>
+type ScopeConfigResult = ReturnType<McpDoctorDependencies['getMcpConfigsByScope']>
+type ConnectToServerHandler = (
+  ...args: Parameters<McpDoctorDependencies['connectToServer']>
+) => ReturnType<McpDoctorDependencies['connectToServer']>
+type ConfigFileScope = Extract<ConfigScope, 'enterprise' | 'local' | 'project' | 'user'>
+type McpDoctorDependencyOverrides = Partial<
+  Omit<McpDoctorDependencies, 'connectToServer'> & {
+    connectToServer: ConnectToServerHandler
+  }
+>
+
+function stdioConfig(scope: ConfigFileScope, command: string): ScopedMcpServerConfig {
   return {
     type: 'stdio' as const,
     command,
@@ -20,22 +40,71 @@ function stdioConfig(scope: 'local' | 'project' | 'user' | 'enterprise', command
   }
 }
 
-function makeDependencies(overrides: Partial<McpDoctorDependencies> = {}): McpDoctorDependencies {
+function allConfig(
+  servers: Record<string, ScopedMcpServerConfig> = {},
+  errors: AllConfigResult['errors'] = [],
+): AllConfigResult {
+  return { servers, errors }
+}
+
+function scopeConfig(
+  servers: Record<string, ScopedMcpServerConfig> = {},
+  errors: ValidationError[] = [],
+): ScopeConfigResult {
+  return { servers, errors }
+}
+
+function connectedServer(name: string, config: ScopedMcpServerConfig): MCPServerConnection {
   return {
-    getAllMcpConfigs: async () => ({ servers: {}, errors: [] }),
-    getMcpConfigsByScope: () => ({ servers: {}, errors: [] }),
+    name,
+    type: 'connected',
+    client: new Client({ name: 'test-client', version: '0.0.0' }),
+    capabilities: {},
+    config,
+    cleanup: async () => {},
+  }
+}
+
+function failedServer(
+  name: string,
+  config: ScopedMcpServerConfig,
+  error: string,
+): MCPServerConnection {
+  return {
+    name,
+    type: 'failed',
+    config,
+    error,
+  }
+}
+
+function needsAuthServer(name: string, config: ScopedMcpServerConfig): MCPServerConnection {
+  return {
+    name,
+    type: 'needs-auth',
+    config,
+  }
+}
+
+function connectMock(handler: ConnectToServerHandler): McpDoctorDependencies['connectToServer'] {
+  return memoize(handler, getServerCacheKey)
+}
+
+function makeDependencies(overrides: McpDoctorDependencyOverrides = {}): McpDoctorDependencies {
+  const {
+    connectToServer = async (name, config) => connectedServer(name, config),
+    ...rest
+  } = overrides
+
+  return {
+    getAllMcpConfigs: async () => allConfig(),
+    getMcpConfigsByScope: () => scopeConfig(),
     getProjectMcpServerStatus: () => 'approved',
     isMcpServerDisabled: () => false,
     describeMcpConfigFilePath: scope => `scope://${scope}`,
     clearServerCache: async () => {},
-    connectToServer: async (name, config) => ({
-      name,
-      type: 'connected',
-      capabilities: {},
-      config,
-      cleanup: async () => {},
-    }),
-    ...overrides,
+    connectToServer: connectMock(connectToServer),
+    ...rest,
   }
 }
 
@@ -139,15 +208,12 @@ test('findingsFromValidationErrors maps fatal parse errors into blocking finding
 test('doctorAllServers reports global validation findings once without duplicating them into every server', async () => {
   const localConfig = stdioConfig('local', 'node-local')
   const deps = makeDependencies({
-    getAllMcpConfigs: async () => ({
-      servers: { filesystem: localConfig },
-      errors: [],
-    }),
+    getAllMcpConfigs: async () => allConfig({ filesystem: localConfig }),
     getMcpConfigsByScope: scope =>
       scope === 'project'
-        ? {
-            servers: {},
-            errors: [
+        ? scopeConfig(
+            {},
+            [
               {
                 file: '.mcp.json',
                 path: '',
@@ -159,10 +225,10 @@ test('doctorAllServers reports global validation findings once without duplicati
                 },
               },
             ],
-          }
+          )
         : scope === 'local'
-          ? { servers: { filesystem: localConfig }, errors: [] }
-          : { servers: {}, errors: [] },
+          ? scopeConfig({ filesystem: localConfig })
+          : scopeConfig(),
   })
 
   const report = await doctorAllServers({ configOnly: true }, deps)
@@ -178,20 +244,15 @@ test('doctorServer explains same-name shadowing across scopes', async () => {
   const localConfig = stdioConfig('local', 'node-local')
   const userConfig = stdioConfig('user', 'node-user')
   const deps = makeDependencies({
-    getAllMcpConfigs: async () => ({
-      servers: {
-        filesystem: localConfig,
-      },
-      errors: [],
-    }),
+    getAllMcpConfigs: async () => allConfig({ filesystem: localConfig }),
     getMcpConfigsByScope: scope => {
       switch (scope) {
         case 'local':
-          return { servers: { filesystem: localConfig }, errors: [] }
+          return scopeConfig({ filesystem: localConfig })
         case 'user':
-          return { servers: { filesystem: userConfig }, errors: [] }
+          return scopeConfig({ filesystem: userConfig })
         default:
-          return { servers: {}, errors: [] }
+          return scopeConfig()
       }
     },
   })
@@ -212,8 +273,8 @@ test('doctorServer reports project servers pending approval', async () => {
   const deps = makeDependencies({
     getMcpConfigsByScope: scope =>
       scope === 'project'
-        ? { servers: { sentry: projectConfig }, errors: [] }
-        : { servers: {}, errors: [] },
+        ? scopeConfig({ sentry: projectConfig })
+        : scopeConfig(),
     getProjectMcpServerStatus: name => (name === 'sentry' ? 'pending' : 'approved'),
   })
 
@@ -232,23 +293,15 @@ test('doctorServer does not treat disabled servers as runtime-active or live-che
   let connectCalls = 0
   const localConfig = stdioConfig('local', 'node-local')
   const deps = makeDependencies({
-    getAllMcpConfigs: async () => ({
-      servers: { github: localConfig },
-      errors: [],
-    }),
+    getAllMcpConfigs: async () => allConfig({ github: localConfig }),
     getMcpConfigsByScope: scope =>
       scope === 'local'
-        ? { servers: { github: localConfig }, errors: [] }
-        : { servers: {}, errors: [] },
+        ? scopeConfig({ github: localConfig })
+        : scopeConfig(),
     isMcpServerDisabled: name => name === 'github',
     connectToServer: async (name, config) => {
       connectCalls += 1
-      return {
-        name,
-        type: 'failed',
-        config,
-        error: 'should not connect',
-      }
+      return failedServer(name, config, 'should not connect')
     },
   })
 
@@ -271,23 +324,14 @@ test('doctorAllServers skips live checks in config-only mode', async () => {
   let connectCalls = 0
   const localConfig = stdioConfig('local', 'node-local')
   const deps = makeDependencies({
-    getAllMcpConfigs: async () => ({
-      servers: { linear: localConfig },
-      errors: [],
-    }),
+    getAllMcpConfigs: async () => allConfig({ linear: localConfig }),
     getMcpConfigsByScope: scope =>
       scope === 'local'
-        ? { servers: { linear: localConfig }, errors: [] }
-        : { servers: {}, errors: [] },
+        ? scopeConfig({ linear: localConfig })
+        : scopeConfig(),
     connectToServer: async (name, config) => {
       connectCalls += 1
-      return {
-        name,
-        type: 'connected',
-        capabilities: {},
-        config,
-        cleanup: async () => {},
-      }
+      return connectedServer(name, config)
     },
   })
 
@@ -305,10 +349,7 @@ test('doctorAllServers honors scopeFilter when collecting names', async () => {
     pluginSource: 'plugin:github@official',
   }
   const deps = makeDependencies({
-    getAllMcpConfigs: async () => ({
-      servers: { 'plugin:github:github': pluginConfig },
-      errors: [],
-    }),
+    getAllMcpConfigs: async () => allConfig({ 'plugin:github:github': pluginConfig }),
   })
 
   const report = await doctorAllServers({ configOnly: true, scopeFilter: 'user' }, deps)
@@ -320,16 +361,13 @@ test('doctorAllServers honors scopeFilter when collecting names', async () => {
 test('doctorAllServers honors scopeFilter when collecting validation errors', async () => {
   const userConfig = stdioConfig('user', 'node-user')
   const deps = makeDependencies({
-    getAllMcpConfigs: async () => ({
-      servers: { filesystem: userConfig },
-      errors: [],
-    }),
+    getAllMcpConfigs: async () => allConfig({ filesystem: userConfig }),
     getMcpConfigsByScope: scope => {
       switch (scope) {
         case 'project':
-          return {
-            servers: {},
-            errors: [
+          return scopeConfig(
+            {},
+            [
               {
                 file: '.mcp.json',
                 path: '',
@@ -341,11 +379,11 @@ test('doctorAllServers honors scopeFilter when collecting validation errors', as
                 },
               },
             ],
-          }
+          )
         case 'user':
-          return { servers: { filesystem: userConfig }, errors: [] }
+          return scopeConfig({ filesystem: userConfig })
         default:
-          return { servers: {}, errors: [] }
+          return scopeConfig()
       }
     },
   })
@@ -366,10 +404,7 @@ test('doctorAllServers includes observed runtime definitions for plugin-only ser
     pluginSource: 'plugin:github@official',
   }
   const deps = makeDependencies({
-    getAllMcpConfigs: async () => ({
-      servers: { 'plugin:github:github': pluginConfig },
-      errors: [],
-    }),
+    getAllMcpConfigs: async () => allConfig({ 'plugin:github:github': pluginConfig }),
   })
 
   const report = await doctorAllServers({ configOnly: true }, deps)
@@ -388,10 +423,7 @@ test('doctorAllServers reports disabled plugin servers as disabled, not not-foun
     pluginSource: 'plugin:github@official',
   }
   const deps = makeDependencies({
-    getAllMcpConfigs: async () => ({
-      servers: { 'plugin:github:github': pluginConfig },
-      errors: [],
-    }),
+    getAllMcpConfigs: async () => allConfig({ 'plugin:github:github': pluginConfig }),
     isMcpServerDisabled: name => name === 'plugin:github:github',
   })
 
@@ -417,20 +449,13 @@ test('doctorAllServers reports disabled plugin servers as disabled, not not-foun
 test('doctorServer converts failed live checks into blocking findings', async () => {
   const localConfig = stdioConfig('local', 'node-local')
   const deps = makeDependencies({
-    getAllMcpConfigs: async () => ({
-      servers: { github: localConfig },
-      errors: [],
-    }),
+    getAllMcpConfigs: async () => allConfig({ github: localConfig }),
     getMcpConfigsByScope: scope =>
       scope === 'local'
-        ? { servers: { github: localConfig }, errors: [] }
-        : { servers: {}, errors: [] },
-    connectToServer: async (name, config) => ({
-      name,
-      type: 'failed',
-      config,
-      error: 'command not found: node-local',
-    }),
+        ? scopeConfig({ github: localConfig })
+        : scopeConfig(),
+    connectToServer: async (name, config) =>
+      failedServer(name, config, 'command not found: node-local'),
   })
 
   const report = await doctorServer('github', { configOnly: false }, deps)
@@ -448,19 +473,12 @@ test('doctorServer converts failed live checks into blocking findings', async ()
 test('doctorServer converts needs-auth live checks into warning findings', async () => {
   const localConfig = stdioConfig('local', 'node-local')
   const deps = makeDependencies({
-    getAllMcpConfigs: async () => ({
-      servers: { sentry: localConfig },
-      errors: [],
-    }),
+    getAllMcpConfigs: async () => allConfig({ sentry: localConfig }),
     getMcpConfigsByScope: scope =>
       scope === 'local'
-        ? { servers: { sentry: localConfig }, errors: [] }
-        : { servers: {}, errors: [] },
-    connectToServer: async (name, config) => ({
-      name,
-      type: 'needs-auth',
-      config,
-    }),
+        ? scopeConfig({ sentry: localConfig })
+        : scopeConfig(),
+    connectToServer: async (name, config) => needsAuthServer(name, config),
   })
 
   const report = await doctorServer('sentry', { configOnly: false }, deps)
@@ -481,10 +499,7 @@ test('doctorServer includes observed runtime definition for plugin-only targets'
     pluginSource: 'plugin:github@official',
   }
   const deps = makeDependencies({
-    getAllMcpConfigs: async () => ({
-      servers: { 'plugin:github:github': pluginConfig },
-      errors: [],
-    }),
+    getAllMcpConfigs: async () => allConfig({ 'plugin:github:github': pluginConfig }),
   })
 
   const report = await doctorServer('plugin:github:github', { configOnly: true }, deps)
@@ -499,23 +514,14 @@ test('doctorServer with scopeFilter does not leak runtime definition from anothe
   let connectCalls = 0
   const localConfig = stdioConfig('local', 'node-local')
   const deps = makeDependencies({
-    getAllMcpConfigs: async () => ({
-      servers: { github: localConfig },
-      errors: [],
-    }),
+    getAllMcpConfigs: async () => allConfig({ github: localConfig }),
     getMcpConfigsByScope: scope =>
       scope === 'local'
-        ? { servers: { github: localConfig }, errors: [] }
-        : { servers: {}, errors: [] },
+        ? scopeConfig({ github: localConfig })
+        : scopeConfig(),
     connectToServer: async (name, config) => {
       connectCalls += 1
-      return {
-        name,
-        type: 'connected',
-        capabilities: {},
-        config,
-        cleanup: async () => {},
-      }
+      return connectedServer(name, config)
     },
   })
 


### PR DESCRIPTION
Part of #1486.

## Summary
- Type MCP doctor config fixtures against the production `getAllMcpConfigs` / `getMcpConfigsByScope` return shapes.
- Wrap test `connectToServer` overrides with the same lodash memoized function shape and cache-key resolver expected by `McpDoctorDependencies`.
- Build connected, failed, and needs-auth MCP connection fixtures through typed helpers instead of repeating structurally incomplete inline objects.

## Validation
- `bun test src/services/mcp/doctor.test.ts src/commands/mcp/doctorCommand.test.ts src/entrypoints/mcp.test.ts` (21 pass)
- `env -u OPENAI_API_KEY -u OPENAI_BASE_URL -u OPENAI_MODEL -u CLAUDE_CODE_USE_OPENAI -u CLAUDE_CODE_USE_GEMINI -u CLAUDE_CODE_USE_MISTRAL -u CLAUDE_CODE_USE_GITHUB -u CLAUDE_CODE_USE_BEDROCK -u CLAUDE_CODE_USE_VERTEX -u CLAUDE_CODE_USE_FOUNDRY -u GEMINI_API_KEY -u GOOGLE_API_KEY -u GITHUB_TOKEN -u GH_TOKEN -u ANTHROPIC_MODEL -u ANTHROPIC_SMALL_FAST_MODEL bun run check` (3433 pass, 0 fail)
- `bun run test:provider` (650 pass)
- `env -u OPENAI_API_KEY -u OPENAI_BASE_URL -u OPENAI_MODEL -u CLAUDE_CODE_USE_OPENAI -u CLAUDE_CODE_USE_GEMINI -u CLAUDE_CODE_USE_MISTRAL -u CLAUDE_CODE_USE_GITHUB -u CLAUDE_CODE_USE_BEDROCK -u CLAUDE_CODE_USE_VERTEX -u CLAUDE_CODE_USE_FOUNDRY -u GEMINI_API_KEY -u GOOGLE_API_KEY -u GITHUB_TOKEN -u GH_TOKEN -u ANTHROPIC_MODEL -u ANTHROPIC_SMALL_FAST_MODEL npm run test:provider-recommendation` (79 pass)
- `bun install --cwd web --frozen-lockfile && bun run web:typecheck`
- `bun run typecheck` still exits on the repository baseline; no diagnostics remain for `src/services/mcp/doctor.test.ts` (1704 baseline error lines)
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Refactored test utilities to improve code reusability and maintainability with shared helper functions for mock server configurations and connection objects.

**Note:** This is an internal maintenance release with no user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->