### PR TITLE
fix(context): avoid noisy metadata fallback errors

### DIFF
--- a/src/utils/context.test.ts
+++ b/src/utils/context.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, expect, test } from 'bun:test'
+import { afterEach, beforeEach, expect, mock, test } from 'bun:test'
 import { acquireSharedMutationLock, releaseSharedMutationLock } from '../test/sharedMutationLock.js'
 
 import { getMaxOutputTokensForModel } from '../services/api/claude.ts'
@@ -431,6 +431,23 @@ test('unknown openai-compatible models use the 128k fallback window (not 8k, see
   delete process.env.OPENAI_MODEL
 
   expect(getContextWindowForModel('some-unknown-3p-model')).toBe(128_000)
+})
+
+test('unknown openai-compatible model fallback does not emit console errors', () => {
+  process.env.CLAUDE_CODE_USE_OPENAI = '1'
+  delete process.env.CLAUDE_CODE_MAX_OUTPUT_TOKENS
+  delete process.env.OPENAI_MODEL
+
+  const originalConsoleError = console.error
+  const consoleError = mock(() => {})
+  console.error = consoleError
+  try {
+    expect(getContextWindowForModel('another-unknown-3p-model')).toBe(128_000)
+    expect(getContextWindowForModel('another-unknown-3p-model')).toBe(128_000)
+    expect(consoleError).not.toHaveBeenCalled()
+  } finally {
+    console.error = originalConsoleError
+  }
 })
 
 test('prefixed OpenGateway Gemini Flash Lite uses integration metadata', () => {

--- a/src/utils/context.test.ts
+++ b/src/utils/context.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, expect, mock, test } from 'bun:test'
+import { afterEach, beforeEach, expect, mock, spyOn, test } from 'bun:test'
 import { acquireSharedMutationLock, releaseSharedMutationLock } from '../test/sharedMutationLock.js'
 
 import { getMaxOutputTokensForModel } from '../services/api/claude.ts'
@@ -438,14 +438,11 @@ test('unknown openai-compatible model fallback logs one debug warning and no con
   delete process.env.CLAUDE_CODE_MAX_OUTPUT_TOKENS
   delete process.env.OPENAI_MODEL
 
-  const actualDebugModule = await import(
-    `./debug.ts?contextDedupeActual=${Date.now()}-${Math.random()}`
-  )
-  const logForDebugging = mock(() => {})
-  mock.module('./debug.js', () => ({
-    ...actualDebugModule,
-    logForDebugging,
-  }))
+  const actualDebugModule = await import('./debug.js')
+  const logForDebugging = spyOn(
+    actualDebugModule,
+    'logForDebugging',
+  ).mockImplementation((_message, _options) => {})
 
   const originalConsoleError = console.error
   const consoleError = mock(() => {})

--- a/src/utils/context.test.ts
+++ b/src/utils/context.test.ts
@@ -433,20 +433,40 @@ test('unknown openai-compatible models use the 128k fallback window (not 8k, see
   expect(getContextWindowForModel('some-unknown-3p-model')).toBe(128_000)
 })
 
-test('unknown openai-compatible model fallback does not emit console errors', () => {
+test('unknown openai-compatible model fallback logs one debug warning and no console errors', async () => {
   process.env.CLAUDE_CODE_USE_OPENAI = '1'
   delete process.env.CLAUDE_CODE_MAX_OUTPUT_TOKENS
   delete process.env.OPENAI_MODEL
+
+  const actualDebugModule = await import(
+    `./debug.ts?contextDedupeActual=${Date.now()}-${Math.random()}`
+  )
+  const logForDebugging = mock(() => {})
+  mock.module('./debug.js', () => ({
+    ...actualDebugModule,
+    logForDebugging,
+  }))
 
   const originalConsoleError = console.error
   const consoleError = mock(() => {})
   console.error = consoleError
   try {
-    expect(getContextWindowForModel('another-unknown-3p-model')).toBe(128_000)
-    expect(getContextWindowForModel('another-unknown-3p-model')).toBe(128_000)
+    const contextModule = await import(
+      `./context.ts?contextDedupe=${Date.now()}-${Math.random()}`
+    )
+
+    expect(
+      contextModule.getContextWindowForModel('another-unknown-3p-model'),
+    ).toBe(128_000)
+    expect(
+      contextModule.getContextWindowForModel('another-unknown-3p-model'),
+    ).toBe(128_000)
     expect(consoleError).not.toHaveBeenCalled()
+    expect(logForDebugging).toHaveBeenCalledTimes(1)
+    expect(logForDebugging.mock.calls[0]?.[1]).toEqual({ level: 'warn' })
   } finally {
     console.error = originalConsoleError
+    mock.restore()
   }
 })
 

--- a/src/utils/context.ts
+++ b/src/utils/context.ts
@@ -80,6 +80,13 @@ function shouldUseIntegrationRuntimeLimits(
   )
 }
 
+/**
+ * Emit one debug-only metadata fallback warning per active route/model pair.
+ *
+ * Unknown runtime metadata is recoverable because the fallback context window
+ * keeps compaction budgets positive. Keep this out of console.error because
+ * the Ink runtime treats console errors as application errors.
+ */
 function warnUnknownIntegrationRuntimeLimits(model: string): void {
   const routeId = resolveActiveRouteIdFromEnv(process.env) ?? 'unknown-route'
   const warningKey = `${routeId}:${model}`

--- a/src/utils/context.ts
+++ b/src/utils/context.ts
@@ -1,6 +1,7 @@
 // biome-ignore-all assist/source/organizeImports: internal-only import markers must not be reordered
 import { CONTEXT_1M_BETA_HEADER } from '../constants/betas.js'
 import { getGlobalConfig } from './config.js'
+import { logForDebugging } from './debug.js'
 import { isEnvTruthy } from './envUtils.js'
 import { resolveModelRuntimeLimits } from '../integrations/runtimeMetadata.js'
 import {
@@ -38,6 +39,8 @@ const MAX_OUTPUT_TOKENS_UPPER_LIMIT = 64_000
 // import cycle.
 export const CAPPED_DEFAULT_MAX_TOKENS = 8_000
 export const ESCALATED_MAX_TOKENS = 64_000
+
+const warnedUnknownIntegrationRuntimeLimitKeys = new Set<string>()
 
 /**
  * Check if 1M context is disabled via environment variable.
@@ -77,6 +80,20 @@ function shouldUseIntegrationRuntimeLimits(
   )
 }
 
+function warnUnknownIntegrationRuntimeLimits(model: string): void {
+  const routeId = resolveActiveRouteIdFromEnv(process.env) ?? 'unknown-route'
+  const warningKey = `${routeId}:${model}`
+  if (warnedUnknownIntegrationRuntimeLimitKeys.has(warningKey)) return
+
+  warnedUnknownIntegrationRuntimeLimitKeys.add(warningKey)
+  logForDebugging(
+    `[context] Warning: model "${model}" not in integration model metadata for route "${routeId}" — ` +
+      `using fallback ${OPENAI_FALLBACK_CONTEXT_WINDOW} token context window. ` +
+      'Add it to src/integrations/models for accurate compaction.',
+    { level: 'warn' },
+  )
+}
+
 export function getContextWindowForModel(
   model: string,
   betas?: string[],
@@ -109,10 +126,7 @@ export function getContextWindowForModel(
     if (runtimeLimits.contextWindow !== undefined) {
       return runtimeLimits.contextWindow
     }
-    console.error(
-      `[context] Warning: model "${model}" not in integration model metadata — using conservative 128k default. ` +
-      'Add it to src/integrations/models for accurate compaction.',
-    )
+    warnUnknownIntegrationRuntimeLimits(model)
     return OPENAI_FALLBACK_CONTEXT_WINDOW
   }
 


### PR DESCRIPTION
## Summary
- move unknown integration model context-window diagnostics from `console.error` to debug logging
- dedupe the fallback warning per route/model
- keep the existing fallback context window behavior unchanged
- add regression coverage for warning dedupe and no terminal error output

## Impact
- User-facing: unknown OpenAI-compatible model metadata fallback no longer produces repeated terminal error noise during normal operation.
- Developer/maintainer: debug logs still capture one warning per route/model so missing integration metadata remains discoverable without polluting stderr.
- Behavior: context-window fallback remains unchanged at the configured OpenAI-compatible fallback size.

## Testing
- [x] `bun test src/utils/context.test.ts`
- [x] `env -u CLAUDE_CODE_USE_OPENAI -u OPENAI_BASE_URL -u OPENAI_MODEL -u OPENAI_API_KEY bun test src/integrations/runtimeMetadata.test.ts src/utils/context.test.ts src/services/compact/autoCompact.test.ts`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced noisy error output for unknown models by replacing repeated errors with a single deduplicated warning at the warn level, and ensuring the intended fallback context size is returned when model metadata is missing.

* **Tests**
  * Added a test confirming the fallback behavior for unknown models, verifying no console errors and exactly one warn-level debug message.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->