### PR TITLE
perf(attachments): skip skill listings for utility forks

### DIFF
--- a/src/utils/attachments.extractors.test.ts
+++ b/src/utils/attachments.extractors.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from 'bun:test'
 import {
   extractAtMentionedFiles,
   extractMcpResourceMentions,
+  shouldIncludeSkillListingAttachment,
 } from './attachments.js'
 
 // Contract tests for the two @-mention extractors.
@@ -82,4 +83,20 @@ describe('extractor contract', () => {
       expect(extractAtMentionedFiles(input)).toEqual(expected)
     })
   })
+})
+
+describe('skill listing attachment policy', () => {
+  test.each(['extract_memories', 'session_memory', 'compact'])(
+    'suppresses skill listings for %s utility forks',
+    querySource => {
+      expect(shouldIncludeSkillListingAttachment(querySource)).toBe(false)
+    },
+  )
+
+  test.each([undefined, 'repl_main_thread', 'agent:builtin:general-purpose', 'side_question'])(
+    'keeps skill listings available for %s',
+    querySource => {
+      expect(shouldIncludeSkillListingAttachment(querySource)).toBe(true)
+    },
+  )
 })

--- a/src/utils/attachments.ts
+++ b/src/utils/attachments.ts
@@ -88,9 +88,8 @@ import { getContextWindowForModel } from './context.js'
 import type { DiscoverySignal } from '../services/skillSearch/signals.js'
 // Conditional require for DCE. All skill-search string literals that would
 // otherwise leak into external builds live inside these modules. The only
-// surfaces in THIS file are: the maybe() call (gated via spread below) and
-// the skill_listing suppression check (uses the same skillSearchModules null
-// check). The type-only DiscoverySignal import above is erased at compile time.
+// direct surface in THIS file is the maybe() call gated via spread below. The
+// type-only DiscoverySignal import above is erased at compile time.
 /* eslint-disable @typescript-eslint/no-require-imports */
 const skillSearchModules = feature('EXPERIMENTAL_SKILL_SEARCH')
   ? {
@@ -266,6 +265,21 @@ export const AUTO_MODE_ATTACHMENT_CONFIG = {
   TURNS_BETWEEN_ATTACHMENTS: 5,
   FULL_REMINDER_EVERY_N_ATTACHMENTS: 5,
 } as const
+
+const SKILL_LISTING_SUPPRESSED_QUERY_SOURCES = new Set([
+  'compact',
+  'extract_memories',
+  'session_memory',
+])
+
+export function shouldIncludeSkillListingAttachment(
+  querySource?: QuerySource,
+): boolean {
+  return !(
+    typeof querySource === 'string' &&
+    SKILL_LISTING_SUPPRESSED_QUERY_SOURCES.has(querySource)
+  )
+}
 
 const MAX_MEMORY_LINES = 200
 // Line cap alone doesn't bound size (200 × 500-char lines = 100KB).  The
@@ -873,7 +887,9 @@ export async function getAttachments(
     maybe('nested_memory', () => getNestedMemoryAttachments(context)),
     // relevant_memories moved to async prefetch (startRelevantMemoryPrefetch)
     maybe('dynamic_skill', () => getDynamicSkillAttachments(context)),
-    maybe('skill_listing', () => getSkillListingAttachments(context)),
+    ...(shouldIncludeSkillListingAttachment(querySource)
+      ? [maybe('skill_listing', () => getSkillListingAttachments(context))]
+      : []),
     // Inter-turn skill discovery now runs via startSkillDiscoveryPrefetch
     // (query.ts, concurrent with the main turn). The blocking call that
     // previously lived here was the assistant_turn signal — 97% of those


### PR DESCRIPTION
## Summary
- suppress full skill-listing attachments for utility fork query sources: `extract_memories`, `session_memory`, and `compact`
- keep skill listings available for the main thread, normal agents, and side questions
- reduce repeated context overhead in internal worker calls

## Validation
- `bun test src/utils/attachments.extractors.test.ts src/services/compact/autoCompact.test.ts src/query/autoCompactCooldown.test.ts`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed attachment handling in specific query contexts (memory extraction and compact session modes) to improve context accuracy and efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->