### PR TITLE
fix(agent-routing): support API model aliases

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,6 +210,11 @@ Add to `~/.openclaude.json`:
       "base_url": "https://api.deepseek.com/v1",
       "api_key": "sk-your-key"
     },
+    "zai-default": {
+      "model": "glm-5.1",
+      "base_url": "https://api.z.ai/api/coding/paas/v4",
+      "api_key": "sk-your-key"
+    },
     "gpt-4o": {
       "base_url": "https://api.openai.com/v1",
       "api_key": "sk-your-key"
@@ -219,7 +224,7 @@ Add to `~/.openclaude.json`:
     "Explore": "deepseek-v4-flash",
     "Plan": "gpt-4o",
     "general-purpose": "gpt-4o",
-    "frontend-dev": "deepseek-v4-flash",
+    "frontend-dev": "zai-default",
     "default": "gpt-4o"
   }
 }
@@ -227,7 +232,7 @@ Add to `~/.openclaude.json`:
 
 When no routing match is found, the global provider remains the fallback.
 
-You can also explicitly pass a `model` argument to the Agent tool that exactly matches a configured key in `agentModels` to override the provider for a single subagent request.
+`agentRouting` values and explicit Agent tool `model` overrides match keys in `agentModels`. By default, that key is also the model string sent to the provider. Set `agentModels.<key>.model` when you want a local route key such as `zai-default` to call a different provider model name such as `glm-5.1`.
 
 > **Note:** `/provider` changes the global/parent provider for your current session. `agentModels` and `agentRouting` are specifically for configuring per-agent provider overrides while keeping the parent session unchanged.
 

--- a/src/services/api/agentRouting.test.ts
+++ b/src/services/api/agentRouting.test.ts
@@ -130,6 +130,42 @@ describe('resolveAgentProvider', () => {
     expect(result?.model).toBe('deepseek-chat')
   })
 
+  test('configured model key can alias a different API model name', () => {
+    const settings = {
+      agentModels: {
+        zai: {
+          model: 'glm-5.1',
+          base_url: 'https://api.z.ai/api/coding/paas/v4',
+          api_key: 'sk-zai',
+        },
+      },
+      agentRouting: { default: 'zai' },
+    } as unknown as SettingsJson
+
+    const result = resolveAgentProvider(undefined, undefined, settings)
+
+    expect(result).toEqual({
+      model: 'glm-5.1',
+      baseURL: 'https://api.z.ai/api/coding/paas/v4',
+      apiKey: 'sk-zai',
+    })
+  })
+
+  test('blank API keys do not create provider overrides', () => {
+    const settings = {
+      agentModels: {
+        zai: {
+          model: 'glm-5.1',
+          base_url: 'https://api.z.ai/api/coding/paas/v4',
+          api_key: '',
+        },
+      },
+      agentRouting: { default: 'zai' },
+    } as unknown as SettingsJson
+
+    expect(resolveAgentProvider(undefined, undefined, settings)).toBeNull()
+  })
+
 })
 
 describe('resolveAgentModelProvider', () => {
@@ -154,6 +190,24 @@ describe('resolveAgentModelProvider', () => {
   test('trims whitespace around requested model', () => {
     const result = resolveAgentModelProvider('  deepseek-chat  ', baseSettings)
     expect(result?.model).toBe('deepseek-chat')
+  })
+
+  test('exact match can resolve to a different API model name', () => {
+    const settings = {
+      agentModels: {
+        zai: {
+          model: 'glm-5.1',
+          base_url: 'https://api.z.ai/api/coding/paas/v4',
+          api_key: 'sk-zai',
+        },
+      },
+    } as unknown as SettingsJson
+
+    expect(resolveAgentModelProvider('zai', settings)).toEqual({
+      model: 'glm-5.1',
+      baseURL: 'https://api.z.ai/api/coding/paas/v4',
+      apiKey: 'sk-zai',
+    })
   })
 
   test('no fuzzy matching', () => {
@@ -233,6 +287,25 @@ describe('resolveAgentRunModelRouting', () => {
     })
 
     expect(result).toEqual({ mainLoopModel: 'default-model' })
+  })
+
+  test('falls back to resolved model when routed provider has a blank API key', () => {
+    const result = resolveAgentRunModelRouting({
+      resolvedAgentModel: 'parent-runtime-model',
+      subagentType: 'Explore',
+      settings: {
+        agentModels: {
+          zai: {
+            model: 'glm-5.1',
+            base_url: 'https://api.z.ai/api/coding/paas/v4',
+            api_key: '   ',
+          },
+        },
+        agentRouting: { Explore: 'zai' },
+      } as unknown as SettingsJson,
+    })
+
+    expect(result).toEqual({ mainLoopModel: 'parent-runtime-model' })
   })
 })
 

--- a/src/services/api/agentRouting.ts
+++ b/src/services/api/agentRouting.ts
@@ -18,6 +18,8 @@ export interface AgentRunModelRouting {
   providerOverride?: ProviderOverride
 }
 
+type AgentModelConfig = NonNullable<SettingsJson['agentModels']>[string]
+
 const PROVIDER_ENV_VARS_TO_CLEAR_FOR_OVERRIDE = [
   'CLAUDE_CODE_USE_OPENAI',
   'CLAUDE_CODE_USE_BEDROCK',
@@ -47,6 +49,22 @@ const PROVIDER_ENV_VARS_TO_CLEAR_FOR_OVERRIDE = [
  */
 function normalize(key: string): string {
   return key.toLowerCase().replace(/[-_]/g, '')
+}
+
+function toProviderOverride(
+  configuredModelKey: string,
+  modelConfig: AgentModelConfig | undefined,
+): ProviderOverride | null {
+  if (!modelConfig) return null
+
+  const apiKey = modelConfig.api_key.trim()
+  if (!apiKey) return null
+
+  return {
+    model: modelConfig.model?.trim() || configuredModelKey,
+    baseURL: modelConfig.base_url,
+    apiKey,
+  }
 }
 
 /**
@@ -95,14 +113,7 @@ export function resolveAgentProvider(
 
   if (!modelName) return null
 
-  const modelConfig = models[modelName]
-  if (!modelConfig) return null
-
-  return {
-    model: modelName,
-    baseURL: modelConfig.base_url,
-    apiKey: modelConfig.api_key,
-  }
+  return toProviderOverride(modelName, models[modelName])
 }
 
 /**
@@ -116,17 +127,7 @@ export function resolveAgentModelProvider(
   if (!settings || !settings.agentModels || !modelName) return null
 
   const trimmedModelName = modelName.trim()
-  const modelConfig = settings.agentModels[trimmedModelName]
-
-  if (modelConfig) {
-    return {
-      model: trimmedModelName,
-      baseURL: modelConfig.base_url,
-      apiKey: modelConfig.api_key,
-    }
-  }
-
-  return null
+  return toProviderOverride(trimmedModelName, settings.agentModels[trimmedModelName])
 }
 
 export function resolveAgentRunModelRouting({

--- a/src/utils/settings/types.ts
+++ b/src/utils/settings/types.ts
@@ -750,14 +750,19 @@ export const SettingsSchema = lazySchema(() =>
         .record(
           z.string(),
           z.object({
+            model: z
+              .string()
+              .optional()
+              .describe('Actual model name to send to the API. Defaults to the surrounding agentModels key.'),
             base_url: z.string().url().describe('OpenAI-compatible API endpoint (must be https:// or http://)'),
             api_key: z.string().describe('API key for this provider'),
           }),
         )
         .optional()
         .describe(
-          'Map of model name to provider connection info. ' +
-            'Example: { "deepseek-chat": { "base_url": "https://api.deepseek.com/v1", "api_key": "sk-xxx" } }',
+          'Map of route key to provider connection info. ' +
+            'Example: { "deepseek-chat": { "base_url": "https://api.deepseek.com/v1", "api_key": "sk-xxx" } }. ' +
+            'Use "model" when the route key is an alias for a different API model name.',
         ),
       agentRouting: z
         .record(z.string(), z.string())


### PR DESCRIPTION
## Summary
- allow `agentModels` entries to set an optional provider-facing `model` value
- keep existing configs working by defaulting the API model to the `agentModels` key
- ignore blank `api_key` entries so broken local aliases do not create provider overrides
- document the route-key vs API-model distinction

## Validation
- `bun test src/services/api/agentRouting.test.ts src/tools/AgentTool/runAgent.routing.test.ts src/tools/AgentTool/AgentTool.routing.test.ts src/tools/AgentTool/AgentTool.teammateModel.test.ts src/utils/model/agent.test.ts src/utils/settings/flagSettings.test.ts`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for model aliasing in agent routing—configure an optional `model` field in `agentModels` to map a route key to a different API model name.

* **Documentation**
  * Updated Agent Routing configuration examples with clarified guidance on route keys and model aliases.

* **Tests**
  * Added test coverage for model aliasing and agent provider resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->