### PR TITLE
fix(api): honor OpenAI-compatible retry classification

### DIFF
--- a/src/services/api/openaiErrorClassification.test.ts
+++ b/src/services/api/openaiErrorClassification.test.ts
@@ -8,6 +8,7 @@ import {
   extractOpenAICategoryMarker,
   formatOpenAICategoryMarker,
   isLocalhostLikeHost,
+  isRetryableOpenAICompatibilityFailureCategory,
 } from './openaiErrorClassification.js'
 
 test('classifies localhost ECONNREFUSED as connection_refused', () => {
@@ -177,6 +178,15 @@ test('marker without host stays backward-compatible', () => {
   expect(marker).toBe('[openai_category=endpoint_not_found]')
   expect(extractOpenAICategoryMarker(marker)).toBe('endpoint_not_found')
   expect(extractOpenAICategoryHost(marker)).toBeUndefined()
+})
+
+test('reports retryability for extracted category markers', () => {
+  expect(isRetryableOpenAICompatibilityFailureCategory('auth_invalid')).toBe(false)
+  expect(isRetryableOpenAICompatibilityFailureCategory('model_not_found')).toBe(false)
+  expect(isRetryableOpenAICompatibilityFailureCategory('context_overflow')).toBe(false)
+  expect(isRetryableOpenAICompatibilityFailureCategory('rate_limited')).toBe(true)
+  expect(isRetryableOpenAICompatibilityFailureCategory('provider_unavailable')).toBe(true)
+  expect(isRetryableOpenAICompatibilityFailureCategory('network_error')).toBe(true)
 })
 
 test('isLocalhostLikeHost matches loopback variants', () => {

--- a/src/services/api/openaiErrorClassification.ts
+++ b/src/services/api/openaiErrorClassification.ts
@@ -47,12 +47,28 @@ const OPENAI_COMPATIBILITY_FAILURE_CATEGORIES: ReadonlySet<OpenAICompatibilityFa
     'unknown',
   ])
 
+const RETRYABLE_OPENAI_COMPATIBILITY_FAILURE_CATEGORIES: ReadonlySet<OpenAICompatibilityFailureCategory> =
+  new Set<OpenAICompatibilityFailureCategory>([
+    'connection_refused',
+    'localhost_resolution_failed',
+    'request_timeout',
+    'network_error',
+    'rate_limited',
+    'provider_unavailable',
+  ])
+
 function isOpenAICompatibilityFailureCategory(
   value: string,
 ): value is OpenAICompatibilityFailureCategory {
   return OPENAI_COMPATIBILITY_FAILURE_CATEGORIES.has(
     value as OpenAICompatibilityFailureCategory,
   )
+}
+
+export function isRetryableOpenAICompatibilityFailureCategory(
+  category: OpenAICompatibilityFailureCategory,
+): boolean {
+  return RETRYABLE_OPENAI_COMPATIBILITY_FAILURE_CATEGORIES.has(category)
 }
 
 function getErrorCode(error: unknown): string | undefined {

--- a/src/services/api/withRetry.test.ts
+++ b/src/services/api/withRetry.test.ts
@@ -206,6 +206,93 @@ describe('OpenAI-compatible retry classification', () => {
 
     expect(attempts).toBe(1)
   })
+
+  test('keeps parseable 402 affordability errors on the max_tokens retry path', async () => {
+    process.env.OPENCLAUDE_RETRY_DELAY_MS = '1'
+    const { withRetry } = await importFreshWithRetryModule('openai')
+    const error = APIError.generate(
+      402,
+      undefined,
+      'OpenAI API error 402: Payment Required [openai_category=unknown,host=openrouter.ai] ' +
+        'This request requires more credits, or fewer max_tokens. ' +
+        'You requested up to 32000 tokens, but can only afford 27342. To increase, visit ...',
+      new Headers(),
+    )
+    const originalConsoleError = console.error
+    const consoleError = mock(() => {})
+    const observedMaxTokensOverrides: Array<number | undefined> = []
+    let attempts = 0
+
+    console.error = consoleError
+    try {
+      const result = await drainAsyncGenerator(
+        withRetry(
+          async () => ({} as Anthropic),
+          async (_client, _attempt, context) => {
+            attempts++
+            observedMaxTokensOverrides.push(context.maxTokensOverride)
+            if (attempts === 1) throw error
+            return { ok: true }
+          },
+          {
+            maxRetries: 2,
+            model: 'openrouter/test-model',
+            thinkingConfig: { type: 'disabled' },
+          },
+        ),
+      )
+
+      expect(result).toEqual({ ok: true })
+    } finally {
+      console.error = originalConsoleError
+    }
+
+    expect(attempts).toBe(2)
+    expect(observedMaxTokensOverrides).toEqual([undefined, 27342])
+    expect(consoleError).toHaveBeenCalledTimes(1)
+  })
+
+  test('does not keep retrying repeated 402 affordability errors after one max_tokens adjustment', async () => {
+    process.env.OPENCLAUDE_RETRY_DELAY_MS = '1'
+    const { CannotRetryError, withRetry } =
+      await importFreshWithRetryModule('openai')
+    const error = APIError.generate(
+      402,
+      undefined,
+      'OpenAI API error 402: Payment Required [openai_category=unknown,host=openrouter.ai] ' +
+        'This request requires more credits, or fewer max_tokens. ' +
+        'You requested up to 32000 tokens, but can only afford 27342. To increase, visit ...',
+      new Headers(),
+    )
+    const originalConsoleError = console.error
+    const consoleError = mock(() => {})
+    let attempts = 0
+
+    console.error = consoleError
+    try {
+      await expect(
+        drainAsyncGenerator(
+          withRetry(
+            async () => ({} as Anthropic),
+            async () => {
+              attempts++
+              throw error
+            },
+            {
+              maxRetries: 2,
+              model: 'openrouter/test-model',
+              thinkingConfig: { type: 'disabled' },
+            },
+          ),
+        ),
+      ).rejects.toBeInstanceOf(CannotRetryError)
+    } finally {
+      console.error = originalConsoleError
+    }
+
+    expect(attempts).toBe(2)
+    expect(consoleError).toHaveBeenCalledTimes(1)
+  })
 })
 
 // --- parseOpenAIDuration ---

--- a/src/services/api/withRetry.test.ts
+++ b/src/services/api/withRetry.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test'
+import type Anthropic from '@anthropic-ai/sdk'
 import { APIError } from '@anthropic-ai/sdk'
 import { acquireSharedMutationLock, releaseSharedMutationLock } from '../../test/sharedMutationLock.js'
 type ProvidersModule = typeof import('../../utils/model/providers.js')
@@ -86,6 +87,13 @@ async function importFreshWithRetryModule(
   return import(`./withRetry.js?ts=${Date.now()}-${Math.random()}`)
 }
 
+async function drainAsyncGenerator<T>(generator: AsyncGenerator<unknown, T>): Promise<T> {
+  while (true) {
+    const result = await generator.next()
+    if (result.done) return result.value
+  }
+}
+
 describe('retry configuration', () => {
   test('uses default retry attempts when env var is absent', async () => {
     const { getDefaultMaxRetries } = await importFreshWithRetryModule()
@@ -163,6 +171,40 @@ describe('retry configuration', () => {
     process.env.OPENCLAUDE_RETRY_DELAY_MS = '2000'
     const { getRetryDelay } = await importFreshWithRetryModule()
     expect(getRetryDelay(1, '3')).toBe(3000)
+  })
+})
+
+describe('OpenAI-compatible retry classification', () => {
+  test('does not retry marked non-retryable auth failures', async () => {
+    process.env.OPENCLAUDE_RETRY_DELAY_MS = '1'
+    const { CannotRetryError, withRetry } =
+      await importFreshWithRetryModule('openai')
+    const error = APIError.generate(
+      401,
+      undefined,
+      'OpenAI API error 401: Unauthorized [openai_category=auth_invalid,host=api.z.ai] Hint: Authentication failed.',
+      new Headers(),
+    )
+    let attempts = 0
+
+    await expect(
+      drainAsyncGenerator(
+        withRetry(
+          async () => ({} as Anthropic),
+          async () => {
+            attempts++
+            throw error
+          },
+          {
+            maxRetries: 2,
+            model: 'glm-5.1',
+            thinkingConfig: { type: 'disabled' },
+          },
+        ),
+      ),
+    ).rejects.toBeInstanceOf(CannotRetryError)
+
+    expect(attempts).toBe(1)
   })
 })
 

--- a/src/services/api/withRetry.test.ts
+++ b/src/services/api/withRetry.test.ts
@@ -293,6 +293,41 @@ describe('OpenAI-compatible retry classification', () => {
     expect(attempts).toBe(2)
     expect(consoleError).toHaveBeenCalledTimes(1)
   })
+
+  test('keeps parseable marked context-overflow errors on the max_tokens retry path', async () => {
+    process.env.OPENCLAUDE_RETRY_DELAY_MS = '1'
+    const { withRetry } = await importFreshWithRetryModule('openai')
+    const error = APIError.generate(
+      400,
+      undefined,
+      'OpenAI API error 400: Bad Request [openai_category=context_overflow,host=api.z.ai] ' +
+        'input length and `max_tokens` exceed context limit: 188059 + 20000 > 200000',
+      new Headers(),
+    )
+    const observedMaxTokensOverrides: Array<number | undefined> = []
+    let attempts = 0
+
+    const result = await drainAsyncGenerator(
+      withRetry(
+        async () => ({} as Anthropic),
+        async (_client, _attempt, context) => {
+          attempts++
+          observedMaxTokensOverrides.push(context.maxTokensOverride)
+          if (attempts === 1) throw error
+          return { ok: true }
+        },
+        {
+          maxRetries: 2,
+          model: 'glm-5.1',
+          thinkingConfig: { type: 'disabled' },
+        },
+      ),
+    )
+
+    expect(result).toEqual({ ok: true })
+    expect(attempts).toBe(2)
+    expect(observedMaxTokensOverrides).toEqual([undefined, 10941])
+  })
 })
 
 // --- parseOpenAIDuration ---

--- a/src/services/api/withRetry.ts
+++ b/src/services/api/withRetry.ts
@@ -401,19 +401,12 @@ export async function* withRetry<T>(
       // AWS/GCP errors aren't always APIError, but can be retried
       const handledCloudAuthError =
         handleAwsCredentialError(error) || handleGcpCredentialError(error)
-      if (
-        !handledCloudAuthError &&
-        (!(error instanceof APIError) || !shouldRetry(error))
-      ) {
-        throw new CannotRetryError(error, retryContext)
-      }
 
       // OpenRouter / OpenAI-compatible quota gateways: HTTP 402 with the
       // affordable max_tokens in the message. Retry once at the affordable
       // cap instead of failing on a credits-vs-max_tokens mismatch the user
       // can't see in their shell (#1125). One adjustment per chain — if 402
-      // recurs after this, the retry chain falls through to the normal error
-      // path.
+      // recurs after this, fail instead of spending the normal retry budget.
       if (error instanceof APIError) {
         const affordData = parseOpenRouterAffordableMaxTokensError(error)
         if (affordData && retryContext.maxTokensOverride === undefined) {
@@ -430,6 +423,16 @@ export async function* withRetry<T>(
           )
           continue
         }
+        if (affordData) {
+          throw new CannotRetryError(error, retryContext)
+        }
+      }
+
+      if (
+        !handledCloudAuthError &&
+        (!(error instanceof APIError) || !shouldRetry(error))
+      ) {
+        throw new CannotRetryError(error, retryContext)
       }
 
       // Handle max tokens context overflow errors by adjusting max_tokens for the next attempt

--- a/src/services/api/withRetry.ts
+++ b/src/services/api/withRetry.ts
@@ -795,6 +795,17 @@ function shouldRetry(error: APIError): boolean {
     return true
   }
 
+  // Local max_tokens recovery paths need to run even when an
+  // OpenAI-compatible shim classifies the underlying provider error as a
+  // non-retryable context or quota failure.
+  if (parseMaxTokensContextOverflowError(error)) {
+    return true
+  }
+
+  if (parseOpenRouterAffordableMaxTokensError(error)) {
+    return true
+  }
+
   const openAICategory = extractOpenAICategoryMarker(error.message ?? '')
   if (
     openAICategory &&
@@ -818,17 +829,6 @@ function shouldRetry(error: APIError): boolean {
   // The SDK sometimes fails to properly pass the 529 status code during streaming,
   // so we need to check the error message directly
   if (error.message?.includes('"type":"overloaded_error"')) {
-    return true
-  }
-
-  // Check for max tokens context overflow errors that we can handle
-  if (parseMaxTokensContextOverflowError(error)) {
-    return true
-  }
-
-  // OpenRouter-style 402 with an affordable max_tokens in the message — we
-  // can retry once at the lower cap (issue #1125).
-  if (parseOpenRouterAffordableMaxTokensError(error)) {
     return true
   }
 

--- a/src/services/api/withRetry.ts
+++ b/src/services/api/withRetry.ts
@@ -47,6 +47,10 @@ import {
 } from '../rateLimitMocking.js'
 import { REPEATED_529_ERROR_MESSAGE } from './errors.js'
 import { extractConnectionErrorDetails } from './errorUtils.js'
+import {
+  extractOpenAICategoryMarker,
+  isRetryableOpenAICompatibilityFailureCategory,
+} from './openaiErrorClassification.js'
 
 const abortError = () => new APIUserAbortError()
 
@@ -786,6 +790,14 @@ function shouldRetry(error: APIError): boolean {
   // x-should-retry header.
   if (isPersistentRetryEnabled() && isTransientCapacityError(error)) {
     return true
+  }
+
+  const openAICategory = extractOpenAICategoryMarker(error.message ?? '')
+  if (
+    openAICategory &&
+    !isRetryableOpenAICompatibilityFailureCategory(openAICategory)
+  ) {
+    return false
   }
 
   // CCR mode: auth is via infrastructure-provided JWTs, so a 401/403 is a


### PR DESCRIPTION
## Summary
- expose retryability for OpenAI-compatible diagnostic categories
- make `withRetry` stop retrying marked permanent OpenAI-compatible failures such as `auth_invalid`
- preserve existing retry behavior for unmarked first-party/OAuth 401s and retryable OpenAI-compatible categories

## Validation
- `bun test src/services/api/withRetry.test.ts src/services/api/openaiErrorClassification.test.ts src/services/api/errors.openaiCompatibility.test.ts`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved retry behavior for OpenAI-compatible responses: clearly classify which error categories are retryable so non-retryable categories fail fast; repeated affordability adjustments no longer cause endless retries.
  * Network, rate-limit and provider-availability issues still trigger automatic retries; auth/model-not-found errors do not.

* **Tests**
  * Expanded test coverage for error classification and retry scenarios, including affordability and context-overflow handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->