### PR TITLE
fix(provider): preserve explicit startup env

### DIFF
--- a/src/entrypoints/cli.tsx
+++ b/src/entrypoints/cli.tsx
@@ -114,14 +114,8 @@ async function main(): Promise<void> {
     applySafeConfigEnvironmentVariables()
   }
 
-  const hasConfiguredProviderProfile = await (async () => {
-    const { getActiveProviderProfile } = await import('../utils/providerProfiles.js')
-    return getActiveProviderProfile() !== undefined
-  })()
-
   const startupEnv = await buildStartupEnvFromProfile({
     processEnv: process.env,
-    hasConfiguredProviderProfile,
   })
   if (startupEnv !== process.env) {
     const startupProfileError = await getProviderValidationError(startupEnv)

--- a/src/utils/providerProfile.test.ts
+++ b/src/utils/providerProfile.test.ts
@@ -5,6 +5,7 @@ import { join } from 'node:path'
 import test, { afterEach, beforeEach } from 'node:test'
 
 import { acquireEnvMutex, releaseEnvMutex } from '../entrypoints/sdk/shared.js'
+import { resolveActiveRouteIdFromEnv } from '../integrations/routeMetadata.js'
 import { DEFAULT_CODEX_BASE_URL } from '../services/api/providerConfig.js'
 import {
   applySavedProfileToCurrentSession,
@@ -252,6 +253,25 @@ test('buildStartupEnvFromProfile defaults fresh installs to Gitlawb Opengateway'
   assert.equal(env.OPENAI_BASE_URL, 'https://opengateway.gitlawb.com/v1')
   assert.equal(env.OPENAI_MODEL, 'mimo-v2.5-pro')
   assert.equal(isDefaultStartupProviderEnv(env), true)
+})
+
+test('buildStartupEnvFromProfile preserves explicit OpenAI-compatible env without a saved profile', async () => {
+  const env = await buildStartupEnvFromProfile({
+    persisted: null,
+    processEnv: {
+      CLAUDE_CODE_USE_OPENAI: '1',
+      OPENAI_API_KEY: 'sk-live',
+      OPENAI_BASE_URL: 'http://common.example.com/v1',
+      OPENAI_MODEL: 'gemma-4-31B-it',
+    },
+  })
+
+  assert.equal(env.CLAUDE_CODE_USE_OPENAI, '1')
+  assert.equal(env.OPENAI_API_KEY, 'sk-live')
+  assert.equal(env.OPENAI_BASE_URL, 'http://common.example.com/v1')
+  assert.equal(env.OPENAI_MODEL, 'gemma-4-31B-it')
+  assert.equal(resolveActiveRouteIdFromEnv(env), 'custom')
+  assert.equal(isDefaultStartupProviderEnv(env), false)
 })
 
 test('openai launch preserves shell responses format and custom auth overrides', async () => {
@@ -1057,13 +1077,11 @@ test('buildStartupEnvFromProfile leaves explicit provider selections untouched',
     processEnv,
   })
 
-  // Remove the strict object equality check: assert.equal(env, processEnv)
   assert.equal(env.CLAUDE_CODE_USE_GEMINI, '1')
   assert.equal(env.GEMINI_API_KEY, 'gem-live')
   assert.equal(env.GEMINI_MODEL, 'gemini-2.0-flash')
-  // Add the new default fields injected by the function
-  assert.equal(env.GEMINI_BASE_URL, 'https://generativelanguage.googleapis.com/v1beta/openai')
-  assert.equal(env.GEMINI_AUTH_MODE, 'api-key')
+  assert.equal(env.GEMINI_BASE_URL, undefined)
+  assert.equal(env.GEMINI_AUTH_MODE, undefined)
   assert.equal(env.OPENAI_API_KEY, undefined)
 })
 
@@ -1275,7 +1293,7 @@ test('buildStartupEnvFromProfile preserves plural-profile env when the legacy fi
   assert.equal(env.CLAUDE_CODE_PROVIDER_PROFILE_ENV_APPLIED_ID, 'saved_moonshot')
 })
 
-test('buildStartupEnvFromProfile ignores the legacy file when a configured provider profile already selected a concrete env', async () => {
+test('buildStartupEnvFromProfile ignores the legacy file when startup already has concrete env', async () => {
   const processEnv: NodeJS.ProcessEnv = {
     CLAUDE_CODE_USE_OPENAI: '1',
     OPENAI_BASE_URL: 'https://api.moonshot.ai/v1',
@@ -1289,7 +1307,6 @@ test('buildStartupEnvFromProfile ignores the legacy file when a configured provi
       OPENAI_BASE_URL: 'https://api.sambanova.ai/v1',
     }),
     processEnv,
-    hasConfiguredProviderProfile: true,
   })
 
   assert.equal(env, processEnv)
@@ -1321,7 +1338,7 @@ test('buildStartupEnvFromProfile falls back to legacy file when plural system ha
   assert.equal(env.OPENAI_MODEL, 'gpt-4o')
 })
 
-test('buildStartupEnvFromProfile still falls back to the legacy file when configured profiles exist but startup env is incomplete', async () => {
+test('buildStartupEnvFromProfile falls back to the legacy file when startup env is incomplete', async () => {
   const processEnv = {
     CLAUDE_CODE_USE_OPENAI: '1',
   }
@@ -1333,7 +1350,6 @@ test('buildStartupEnvFromProfile still falls back to the legacy file when config
       OPENAI_BASE_URL: 'https://api.openai.com/v1',
     }),
     processEnv,
-    hasConfiguredProviderProfile: true,
   })
 
   assert.notEqual(env, processEnv)
@@ -1342,7 +1358,7 @@ test('buildStartupEnvFromProfile still falls back to the legacy file when config
   assert.equal(env.OPENAI_MODEL, 'gpt-4o')
 })
 
-test('buildStartupEnvFromProfile ignores falsey provider flags when deciding whether a configured profile already selected startup env', async () => {
+test('buildStartupEnvFromProfile ignores falsey provider flags when deciding whether startup env is concrete', async () => {
   const processEnv = {
     CLAUDE_CODE_USE_OPENAI: '0',
     OPENAI_BASE_URL: 'https://api.stale.example/v1',
@@ -1356,7 +1372,6 @@ test('buildStartupEnvFromProfile ignores falsey provider flags when deciding whe
       OPENAI_BASE_URL: 'https://api.openai.com/v1',
     }),
     processEnv,
-    hasConfiguredProviderProfile: true,
   })
 
   assert.notEqual(env, processEnv)

--- a/src/utils/providerProfile.ts
+++ b/src/utils/providerProfile.ts
@@ -1593,7 +1593,6 @@ export async function buildStartupEnvFromProfile(options?: {
   persisted?: ProfileFile | null
   goal?: RecommendationGoal
   processEnv?: NodeJS.ProcessEnv
-  hasConfiguredProviderProfile?: boolean
   getOllamaChatBaseUrl?: (baseUrl?: string) => string
   resolveOllamaDefaultModel?: (goal: RecommendationGoal) => Promise<string>
   readGeminiAccessToken?: () => string | undefined
@@ -1603,8 +1602,6 @@ export async function buildStartupEnvFromProfile(options?: {
     options && 'persisted' in options ? options.persisted : loadProfileFile()
 
   const profileManagedEnv = processEnv.CLAUDE_CODE_PROVIDER_PROFILE_ENV_APPLIED === '1'
-  const hasConfiguredProviderProfile =
-    options?.hasConfiguredProviderProfile ?? false
 
   // The single-profile file in the user config directory is a
   // first-run / fallback mechanism. The newer plural provider-profile
@@ -1622,15 +1619,10 @@ export async function buildStartupEnvFromProfile(options?: {
     return processEnv
   }
 
-  // If startup already has a concrete provider selection and the modern
-  // plural-profile system is configured, keep trusting that selection.
-  // This prevents the legacy single-profile file from becoming a silent
-  // third precedence layer when `/provider` profiles or explicit env/flags
-  // already chose a provider before startup fallback runs.
-  if (
-    hasConfiguredProviderProfile &&
-    hasConcreteProviderSelection(processEnv)
-  ) {
+  // If startup already has a concrete provider selection, keep trusting it.
+  // This prevents legacy profiles or the fresh-install default from becoming
+  // a silent third precedence layer over explicit env/flags.
+  if (hasConcreteProviderSelection(processEnv)) {
     return processEnv
   }
 


### PR DESCRIPTION
# Fix explicit OpenAI-compatible startup env being overridden

Fixes #1559

## Summary

This PR fixes a startup precedence regression where explicit OpenAI-compatible environment variables could be overwritten by the fresh-install Gitlawb Opengateway default when no saved provider profile existed.

When users start OpenClaude with explicit env such as:

```powershell
$env:CLAUDE_CODE_USE_OPENAI="1"
$env:OPENAI_API_KEY="..."
$env:OPENAI_BASE_URL="http://common.example.com/v1"
$env:OPENAI_MODEL="gemma-4-31B-it"
```

`buildStartupEnvFromProfile()` now preserves that concrete provider selection instead of applying the no-profile Opengateway fallback.

## What Changed

- Moved the concrete-provider-env guard so it runs before both legacy profile loading and the fresh-install default provider fallback.
- Removed the now-unused `hasConfiguredProviderProfile` startup plumbing from `cli.tsx` and `buildStartupEnvFromProfile()`.
- Added regression coverage for explicit OpenAI-compatible env with no saved profile.
- Updated related test names/assertions so they reflect the new precedence rule: concrete startup env wins; incomplete env still falls back to legacy profile data.

## Why

PR #1493 introduced Gitlawb Opengateway as the fresh-install default provider. That fallback was intended for users with no provider configuration, but it could also run when users had explicit shell env configured and no saved profile yet.

The result was that `OPENAI_BASE_URL` and `OPENAI_MODEL` from the shell could be replaced with:

```text
OPENAI_BASE_URL=https://opengateway.gitlawb.com/v1
OPENAI_MODEL=mimo-v2.5-pro
```

That matches the behavior reported in #1559.

## User Impact

- Users who configure OpenAI-compatible providers through env vars keep their configured endpoint/model on startup.
- Fresh installs with no concrete provider env still default to Gitlawb Opengateway.
- Legacy saved profile fallback still applies when startup env is incomplete, such as `CLAUDE_CODE_USE_OPENAI=1` without a base URL or model.

## Risk Surface

This PR intentionally changes startup provider precedence for provider/profile env handling.

Areas reviewed:

- Provider and endpoint selection: concrete startup env now wins before legacy profile fallback and fresh-install default fallback.
- Credential handling: explicit `OPENAI_API_KEY` is preserved with explicit OpenAI-compatible startup env; no new credential source is added.
- Default provider behavior: empty/no-profile startup env still uses the Gitlawb Opengateway fresh-install default.
- Legacy fallback behavior: incomplete startup env still falls back to the legacy saved profile.

No new network calls, telemetry, auth storage, or provider endpoints are introduced.

## Provider Path Tested

Provider path changed and tested:

- Compatibility mode: OpenAI-compatible provider path via `CLAUDE_CODE_USE_OPENAI=1`
- Explicit base URL: `http://common.example.com/v1`
- Explicit model: `gemma-4-31B-it`
- Expected route: `custom`

Additional behavior verified:

- Changing `OPENAI_BASE_URL` to `https://api.deepseek.com/v1` resolves to the `deepseek` route and uses that request base URL.
- Empty/no-profile startup env still applies the Gitlawb Opengateway default route.

## Checks Run

```bash
bun run build
```

Result: passed.

```bash
bun run smoke
```

Result: passed.

```bash
bun run test:provider-recommendation
```

Result: 80 passed, 0 failed.

```bash
bun run test:provider
```

Result: 664 passed, 0 failed.

```bash
python -m pytest -q python/tests
```

Result: 44 passed, 1 pytest cache warning.

```bash
bun run security:pr-scan
```

Result: passed when run outside the sandbox.

```bash
bun run check
```

Result: build, smoke, and focused typecheck passed, but `test:full` failed with 3 full-suite failures:

- `countMcpToolTokens > keeps deferred MCP schemas excluded from the outgoing request estimate when Tool Search is deferred`
- `setupGitHubActions creates only the selected review workflow`
- `setupGitHubActions skip mode configures the secret without workflow writes`

All 3 failing tests passed when rerun directly:

```bash
bun test src/utils/analyzeContext.mcp.test.ts --test-name-pattern "keeps deferred MCP schemas excluded"
bun test src/commands/install-github-app/setupGitHubActions.test.ts --test-name-pattern "creates only the selected review workflow|skip mode configures"
```

## Screenshots / Terminal Presentation

No screenshots. This changes startup provider precedence but does not intentionally change UI or terminal presentation.
