### PR TITLE
fix(typecheck): add MCP component view types

### DIFF
--- a/src/components/mcp/MCPAgentServerMenu.tsx
+++ b/src/components/mcp/MCPAgentServerMenu.tsx
@@ -6,7 +6,7 @@ import { useKeybinding } from '../../keybindings/useKeybinding.js';
 import { AuthenticationCancelledError, performMCPOAuthFlow } from '../../services/mcp/auth.js';
 import { capitalize } from '../../utils/stringUtils.js';
 import { ConfigurableShortcutHint } from '../ConfigurableShortcutHint.js';
-import { Select } from '../CustomSelect/index.js';
+import { Select, type OptionWithDescription } from '../CustomSelect/index.js';
 import { Byline } from '../design-system/Byline.js';
 import { Dialog } from '../design-system/Dialog.js';
 import { KeyboardShortcutHint } from '../design-system/KeyboardShortcutHint.js';
@@ -102,7 +102,7 @@ export function MCPAgentServerMenu({
         </Box>
       </Box>;
   }
-  const menuOptions = [];
+  const menuOptions: OptionWithDescription<string>[] = [];
 
   // Only show authenticate option for HTTP/SSE servers
   if (agentServer.needsAuth) {

--- a/src/components/mcp/MCPListPanel.tsx
+++ b/src/components/mcp/MCPListPanel.tsx
@@ -89,7 +89,7 @@ function groupServersByScope(serverList: ServerInfo[]): Map<ConfigScope, ServerI
   }
   return groups;
 }
-export function MCPListPanel(t0) {
+export function MCPListPanel(t0: Props): React.ReactNode {
   const $ = _c(78);
   const {
     servers,
@@ -106,7 +106,7 @@ export function MCPListPanel(t0) {
   } else {
     t2 = $[1];
   }
-  const agentServers = t2;
+  const agentServers = t2 as AgentMcpServerInfo[];
   const [theme] = useTheme();
   const [selectedIndex, setSelectedIndex] = useState(0);
   let t3;
@@ -483,7 +483,7 @@ export function MCPListPanel(t0) {
   }
   return t32;
 }
-function _temp6(s_2) {
+function _temp6(s_2: AgentMcpServerInfo) {
   return s_2.sourceAgents;
 }
 function _temp5(s_1) {

--- a/src/components/mcp/MCPRemoteServerMenu.tsx
+++ b/src/components/mcp/MCPRemoteServerMenu.tsx
@@ -20,7 +20,7 @@ import { errorMessage } from '../../utils/errors.js';
 import { logMCPDebug } from '../../utils/log.js';
 import { capitalize } from '../../utils/stringUtils.js';
 import { ConfigurableShortcutHint } from '../ConfigurableShortcutHint.js';
-import { Select } from '../CustomSelect/index.js';
+import { Select, type OptionWithDescription } from '../CustomSelect/index.js';
 import { Byline } from '../design-system/Byline.js';
 import { KeyboardShortcutHint } from '../design-system/KeyboardShortcutHint.js';
 import { Spinner } from '../Spinner.js';
@@ -467,7 +467,7 @@ export function MCPRemoteServerMenu({
         <Text dimColor>This may take a few moments.</Text>
       </Box>;
   }
-  const menuOptions = [];
+  const menuOptions: OptionWithDescription<string>[] = [];
 
   // If server is disabled, show Enable first as the primary action
   if (server.client.type === 'disabled') {

--- a/src/components/mcp/MCPSettings.tsx
+++ b/src/components/mcp/MCPSettings.tsx
@@ -18,7 +18,7 @@ type Props = {
     display?: CommandResultDisplay;
   }) => void;
 };
-export function MCPSettings(t0) {
+export function MCPSettings(t0: Props): React.ReactNode {
   const $ = _c(66);
   const {
     onComplete
@@ -35,7 +35,7 @@ export function MCPSettings(t0) {
   } else {
     t1 = $[0];
   }
-  const [viewState, setViewState] = React.useState(t1);
+  const [viewState, setViewState] = React.useState<MCPViewState>(t1);
   let t2;
   if ($[1] === Symbol.for("react.memo_cache_sentinel")) {
     t2 = [];
@@ -43,7 +43,7 @@ export function MCPSettings(t0) {
   } else {
     t2 = $[1];
   }
-  const [servers, setServers] = React.useState(t2);
+  const [servers, setServers] = React.useState<ServerInfo[]>(t2);
   let t3;
   if ($[2] !== agentDefinitions.allAgents) {
     t3 = extractAgentMcpServers(agentDefinitions.allAgents);
@@ -68,12 +68,12 @@ export function MCPSettings(t0) {
     t5 = () => {
       let cancelled = false;
       const prepareServers = async function prepareServers() {
-        const serverInfos = await Promise.all(filteredClients.map(async client_0 => {
+        const serverInfos: ServerInfo[] = await Promise.all(filteredClients.map(async client_0 => {
           const scope = client_0.config.scope;
           const isSSE = client_0.config.type === "sse";
           const isHTTP = client_0.config.type === "http";
           const isClaudeAIProxy = client_0.config.type === "claudeai-proxy";
-          let isAuthenticated = undefined;
+          let isAuthenticated: boolean | undefined = undefined;
           if (isSSE || isHTTP) {
             const authProvider = new ClaudeAuthProvider(client_0.name, client_0.config as McpSSEServerConfig | McpHTTPServerConfig);
             const tokens = await authProvider.tokens();
@@ -98,7 +98,7 @@ export function MCPSettings(t0) {
               return {
                 ...baseInfo,
                 transport: "sse" as const,
-                isAuthenticated,
+                isAuthenticated: isAuthenticated ?? false,
                 config: client_0.config as McpSSEServerConfig
               };
             } else {
@@ -106,7 +106,7 @@ export function MCPSettings(t0) {
                 return {
                   ...baseInfo,
                   transport: "http" as const,
-                  isAuthenticated,
+                  isAuthenticated: isAuthenticated ?? false,
                   config: client_0.config as McpHTTPServerConfig
                 };
               } else {

--- a/src/components/mcp/MCPStdioServerMenu.tsx
+++ b/src/components/mcp/MCPStdioServerMenu.tsx
@@ -10,7 +10,7 @@ import { useAppState } from '../../state/AppState.js';
 import { errorMessage } from '../../utils/errors.js';
 import { capitalize } from '../../utils/stringUtils.js';
 import { ConfigurableShortcutHint } from '../ConfigurableShortcutHint.js';
-import { Select } from '../CustomSelect/index.js';
+import { Select, type OptionWithDescription } from '../CustomSelect/index.js';
 import { Byline } from '../design-system/Byline.js';
 import { KeyboardShortcutHint } from '../design-system/KeyboardShortcutHint.js';
 import { Spinner } from '../Spinner.js';
@@ -56,7 +56,7 @@ export function MCPStdioServerMenu({
 
   // Count MCP prompts for this server (skills are shown in /skills, not here)
   const serverCommandsCount = filterMcpPromptsByServer(mcp.commands, server.name).length;
-  const menuOptions = [];
+  const menuOptions: OptionWithDescription<string>[] = [];
 
   // Only show "View tools" if server is not disabled and has tools
   if (server.client.type !== 'disabled' && serverToolsCount > 0) {

--- a/src/components/mcp/MCPToolDetailView.tsx
+++ b/src/components/mcp/MCPToolDetailView.tsx
@@ -11,7 +11,7 @@ type Props = {
   server: ServerInfo;
   onBack: () => void;
 };
-export function MCPToolDetailView(t0) {
+export function MCPToolDetailView(t0: Props): React.ReactNode {
   const $ = _c(44);
   const {
     tool,

--- a/src/components/mcp/MCPToolListView.tsx
+++ b/src/components/mcp/MCPToolListView.tsx
@@ -17,7 +17,7 @@ type Props = {
   onSelectTool: (tool: Tool, index: number) => void;
   onBack: () => void;
 };
-export function MCPToolListView(t0) {
+export function MCPToolListView(t0: Props): React.ReactNode {
   const $ = _c(21);
   const {
     server,
@@ -61,7 +61,7 @@ export function MCPToolListView(t0) {
         const isReadOnly = tool.isReadOnly?.({}) ?? false;
         const isDestructive = tool.isDestructive?.({}) ?? false;
         const isOpenWorld = tool.isOpenWorld?.({}) ?? false;
-        const annotations = [];
+        const annotations: string[] = [];
         if (isReadOnly) {
           annotations.push("read-only");
         }

--- a/src/components/mcp/types.ts
+++ b/src/components/mcp/types.ts
@@ -1,0 +1,76 @@
+import type {
+  ConfigScope,
+  MCPServerConnection,
+  McpClaudeAIProxyServerConfig,
+  McpHTTPServerConfig,
+  McpSSEServerConfig,
+  McpStdioServerConfig,
+} from '../../services/mcp/types.js'
+
+type BaseServerInfo = {
+  name: string
+  client: MCPServerConnection
+  scope: ConfigScope
+}
+
+export type StdioServerInfo = BaseServerInfo & {
+  transport: 'stdio'
+  config: McpStdioServerConfig
+}
+
+export type SSEServerInfo = BaseServerInfo & {
+  transport: 'sse'
+  config: McpSSEServerConfig
+  isAuthenticated?: boolean
+}
+
+export type HTTPServerInfo = BaseServerInfo & {
+  transport: 'http'
+  config: McpHTTPServerConfig
+  isAuthenticated?: boolean
+}
+
+export type ClaudeAIServerInfo = BaseServerInfo & {
+  transport: 'claudeai-proxy'
+  config: McpClaudeAIProxyServerConfig
+  isAuthenticated?: boolean
+}
+
+export type ServerInfo =
+  | StdioServerInfo
+  | SSEServerInfo
+  | HTTPServerInfo
+  | ClaudeAIServerInfo
+
+export type AgentMcpServerInfo = {
+  name: string
+  sourceAgents: string[]
+  transport: 'stdio' | 'sse' | 'http' | 'ws'
+  command?: string
+  url?: string
+  needsAuth: boolean
+  isAuthenticated?: boolean
+}
+
+export type MCPViewState =
+  | {
+      type: 'list'
+      defaultTab?: string
+    }
+  | {
+      type: 'server-menu'
+      server: ServerInfo
+    }
+  | {
+      type: 'server-tools'
+      server: ServerInfo
+    }
+  | {
+      type: 'server-tool-detail'
+      server: ServerInfo
+      toolIndex: number
+    }
+  | {
+      type: 'agent-server-menu'
+      agentServer: AgentMcpServerInfo
+    }


### PR DESCRIPTION
Refs #1486

## Summary
- add the missing shared MCP component types for server list/menu/detail view state
- type MCP settings/list/tool component entry points so existing React compiler caches do not collapse state and props to `unknown`/`never[]`
- annotate MCP menu option arrays with the existing `OptionWithDescription` type

## Why
The `/mcp` UI imports `./types.js`, but the source file was missing. That creates direct `TS2307` failures and masks follow-on `never[]` and `unknown` inference errors in the MCP list, server menus, and tool views.

## Duplicate check
I checked open PR file lists before opening this. The only overlap is broad feature PR #1257, which also adds an MCP types file while changing many unrelated areas. This PR is the focused #1486 cleanup: it adds the shared MCP component types and fixes the local menu/view-state inference errors without the unrelated feature changes.

## Validation
- `bun run typecheck` still reports unrelated pre-existing diagnostics, but this branch reduces diagnostic lines from 1043 to 1012.
- Focused MCP component/type diagnostics went from 31 to 0.
- Remaining nearby diagnostics are unrelated plugin command type files and existing `ElicitationDialog` hook arity errors.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced internal code structure and type safety for MCP components to improve maintainability and reduce potential runtime errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->