### PR TITLE
fix(typecheck): annotate diff rendering props

### DIFF
--- a/src/components/FileEditToolDiff.tsx
+++ b/src/components/FileEditToolDiff.tsx
@@ -20,7 +20,7 @@ type DiffData = {
   firstLine: string | null;
   fileContent: string | undefined;
 };
-export function FileEditToolDiff(props) {
+export function FileEditToolDiff(props: Props): React.ReactNode {
   const $ = _c(7);
   let t0;
   if ($[0] !== props.edits || $[1] !== props.file_path) {
@@ -50,7 +50,10 @@ export function FileEditToolDiff(props) {
   }
   return t2;
 }
-function DiffBody(t0) {
+function DiffBody(t0: {
+  promise: Promise<DiffData>;
+  file_path: string;
+}): React.ReactNode {
   const $ = _c(6);
   const {
     promise,
@@ -78,7 +81,10 @@ function DiffBody(t0) {
   }
   return t1;
 }
-function DiffFrame(t0) {
+function DiffFrame(t0: {
+  children?: React.ReactNode;
+  placeholder?: boolean;
+}): React.ReactNode {
   const $ = _c(5);
   const {
     children,

--- a/src/components/FileEditToolUseRejectedMessage.tsx
+++ b/src/components/FileEditToolUseRejectedMessage.tsx
@@ -21,7 +21,7 @@ type Props = {
   style?: 'condensed';
   verbose: boolean;
 };
-export function FileEditToolUseRejectedMessage(t0) {
+export function FileEditToolUseRejectedMessage(t0: Props): React.ReactNode {
   const $ = _c(38);
   const {
     file_path,

--- a/src/components/HighlightedCode.tsx
+++ b/src/components/HighlightedCode.tsx
@@ -15,7 +15,7 @@ type Props = {
   dim?: boolean;
 };
 const DEFAULT_WIDTH = 80;
-export const HighlightedCode = memo(function HighlightedCode(t0) {
+export const HighlightedCode = memo(function HighlightedCode(t0: Props): React.ReactNode {
   const $ = _c(21);
   const {
     code,
@@ -24,7 +24,7 @@ export const HighlightedCode = memo(function HighlightedCode(t0) {
     dim: t1
   } = t0;
   const dim = t1 === undefined ? false : t1;
-  const ref = useRef(null);
+  const ref = useRef<DOMElement | null>(null);
   const [measuredWidth, setMeasuredWidth] = useState(width || DEFAULT_WIDTH);
   const [theme] = useTheme();
   const settings = useSettings();
@@ -134,7 +134,10 @@ export const HighlightedCode = memo(function HighlightedCode(t0) {
   }
   return t7;
 });
-function CodeLine(t0) {
+function CodeLine(t0: {
+  line: string;
+  gutterWidth: number;
+}): React.ReactNode {
   const $ = _c(13);
   const {
     line,

--- a/src/components/HighlightedCode/Fallback.tsx
+++ b/src/components/HighlightedCode/Fallback.tsx
@@ -36,7 +36,7 @@ function cachedHighlight(hl: NonNullable<Awaited<ReturnType<typeof getCliHighlig
   hlCache.set(key, out);
   return out;
 }
-export function HighlightedCodeFallback(t0) {
+export function HighlightedCodeFallback(t0: Props): React.ReactNode {
   const $ = _c(20);
   const {
     code,
@@ -121,13 +121,16 @@ export function HighlightedCodeFallback(t0) {
   }
   return t8;
 }
-function Highlighted(t0) {
+function Highlighted(t0: {
+  codeWithSpaces: string;
+  language: string;
+}): React.ReactNode {
   const $ = _c(10);
   const {
     codeWithSpaces,
     language
   } = t0;
-  let t1;
+  let t1: ReturnType<typeof getCliHighlightPromise>;
   if ($[0] === Symbol.for("react.memo_cache_sentinel")) {
     t1 = getCliHighlightPromise();
     $[0] = t1;

--- a/src/components/StructuredDiff.tsx
+++ b/src/components/StructuredDiff.tsx
@@ -92,7 +92,7 @@ function renderColorDiff(patch: StructuredPatchHunk, firstLine: string | null, f
   perHunk.set(key, entry);
   return entry;
 }
-export const StructuredDiff = memo(function StructuredDiff(t0) {
+export const StructuredDiff = memo(function StructuredDiff(t0: Props): React.ReactNode {
   const $ = _c(26);
   const {
     patch,

--- a/src/components/diff/DiffDialog.tsx
+++ b/src/components/diff/DiffDialog.tsx
@@ -141,7 +141,7 @@ export function DiffDialog(t0) {
     t8 = $[15];
   }
   useEffect(t7, t8);
-  useRegisterOverlay("diff-dialog");
+  useRegisterOverlay("diff-dialog", true);
   let t10;
   let t9;
   if ($[16] !== sources.length || $[17] !== viewMode) {

--- a/src/components/permissions/FileWritePermissionRequest/FileWriteToolDiff.tsx
+++ b/src/components/permissions/FileWritePermissionRequest/FileWriteToolDiff.tsx
@@ -13,7 +13,7 @@ type Props = {
   fileExists: boolean;
   oldContent: string;
 };
-export function FileWriteToolDiff(t0) {
+export function FileWriteToolDiff(t0: Props): React.ReactNode {
   const $ = _c(15);
   const {
     file_path,

--- a/src/tools/FileEditTool/UI.tsx
+++ b/src/tools/FileEditTool/UI.tsx
@@ -157,7 +157,14 @@ type RejectionDiffData = {
   firstLine: string | null;
   fileContent: string | undefined;
 };
-function EditRejectionDiff(t0) {
+function EditRejectionDiff(t0: {
+  filePath: string;
+  oldString: string;
+  newString: string;
+  replaceAll: boolean;
+  style?: 'condensed';
+  verbose: boolean;
+}): React.ReactNode {
   const $ = _c(16);
   const {
     filePath,
@@ -210,7 +217,12 @@ function EditRejectionDiff(t0) {
   }
   return t4;
 }
-function EditRejectionBody(t0) {
+function EditRejectionBody(t0: {
+  promise: Promise<RejectionDiffData>;
+  filePath: string;
+  style?: 'condensed';
+  verbose: boolean;
+}): React.ReactNode {
   const $ = _c(7);
   const {
     promise,


### PR DESCRIPTION
Refs #1486

## Summary
- annotate `HighlightedCode`, `StructuredDiff`, and fallback renderer props
- annotate file edit/write diff wrapper props and Suspense body data shapes
- pass the required overlay enabled flag in `DiffDialog`

## Validation
- `bun run typecheck` still fails on unrelated baseline errors from #1486
- target diff/highlight diagnostics reduced from 26 to 0 on this branch
- total `src/*` diagnostics reduced from 1043 to 1010 versus the captured baseline

## Duplicate check
- Checked all open PRs for overlap on the touched diff/highlight rendering files before opening this PR; none were touching these files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced TypeScript type safety across React components with explicit parameter and return type annotations.
  * Updated overlay registration configuration in diff dialog component.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->