### PR TITLE
fix(typecheck): type MCP XAA auth storage

### DIFF
--- a/src/services/mcp/auth.ts
+++ b/src/services/mcp/auth.ts
@@ -267,7 +267,7 @@ export async function normalizeOAuthErrorBody(
 function createAuthFetch(): FetchLike {
   return async (url: string | URL, init?: RequestInit) => {
     const isPost = init?.method?.toUpperCase() === 'POST'
-    const { signal, cleanup } = createCombinedAbortSignal(init?.signal, {
+    const { signal, cleanup } = createCombinedAbortSignal(init?.signal ?? undefined, {
       timeoutMs: AUTH_REQUEST_TIMEOUT_MS,
     })
     try {
@@ -2091,10 +2091,6 @@ export class ClaudeAuthProvider implements OAuthClientProvider {
       return {
         authorizationServerUrl: cached.authorizationServerUrl,
         resourceMetadataUrl: cached.resourceMetadataUrl,
-        resourceMetadata:
-          cached.resourceMetadata as OAuthDiscoveryState['resourceMetadata'],
-        authorizationServerMetadata:
-          cached.authorizationServerMetadata as OAuthDiscoveryState['authorizationServerMetadata'],
       }
     }
 

--- a/src/services/mcp/xaa.ts
+++ b/src/services/mcp/xaa.ts
@@ -42,7 +42,7 @@ const ID_TOKEN_TYPE = 'urn:ietf:params:oauth:token-type:id_token'
  */
 function makeXaaFetch(abortSignal?: AbortSignal): FetchLike {
   return (url, init) => {
-    const { signal, cleanup } = createCombinedAbortSignal(init?.signal, {
+    const { signal, cleanup } = createCombinedAbortSignal(init?.signal ?? undefined, {
       signalB: abortSignal,
       timeoutMs: XAA_REQUEST_TIMEOUT_MS,
     })

--- a/src/services/mcp/xaaIdpLogin.ts
+++ b/src/services/mcp/xaaIdpLogin.ts
@@ -29,7 +29,6 @@ import { getSecureStorage } from '../../utils/secureStorage/index.js'
 import { getInitialSettings } from '../../utils/settings/settings.js'
 import { jsonParse } from '../../utils/slowOperations.js'
 import {
-  shouldCompleteXaaIdpCallback,
   validateXaaIdpCallbackParams,
 } from './xaaIdpCallback.js'
 import { buildRedirectUri, findAvailablePort } from './oauthPort.js'
@@ -346,7 +345,7 @@ function waitForCallback(
         expectedState,
       )
 
-      if (!shouldCompleteXaaIdpCallback(result)) {
+      if (result.type === 'state_mismatch') {
         res.writeHead(400, { 'Content-Type': 'text/html' })
         res.end('<html><body><h3>State mismatch</h3></body></html>')
         return
@@ -481,7 +480,7 @@ export async function acquireIdpIdToken(
     codeVerifier,
     redirectUri,
     fetchFn: (url, init) => {
-      const { signal, cleanup } = createCombinedAbortSignal(init?.signal, {
+      const { signal, cleanup } = createCombinedAbortSignal(init?.signal ?? undefined, {
         timeoutMs: IDP_REQUEST_TIMEOUT_MS,
       })
       // eslint-disable-next-line eslint-plugin-n/no-unsupported-features/node-builtins

--- a/src/utils/secureStorage/index.ts
+++ b/src/utils/secureStorage/index.ts
@@ -34,6 +34,8 @@ export interface SecureStorageData {
     }
   >
   mcpOAuthClientConfig?: Record<string, { clientSecret: string }>
+  mcpXaaIdp?: Record<string, { idToken: string; expiresAt: number }>
+  mcpXaaIdpConfig?: Record<string, { clientSecret: string }>
   trustedDeviceToken?: string
   pluginSecrets?: Record<string, Record<string, string>>
 }


### PR DESCRIPTION
## Summary

Addresses part of #1486 by tightening the MCP XAA auth/storage types.

- adds the existing XAA IdP token and client-secret slots to `SecureStorageData`
- normalizes nullable `RequestInit.signal` values before passing them to `createCombinedAbortSignal`
- stops returning cached OAuth metadata fields that the secure-storage schema intentionally does not persist
- narrows the IdP callback result with the explicit `state_mismatch` discriminant before resolving the authorization code

## Duplicate PR check

Checked all open PR files in `Gitlawb/openclaude` before opening this branch. No open PR currently touches:

- `src/services/mcp/auth.ts`
- `src/services/mcp/xaa.ts`
- `src/services/mcp/xaaIdpLogin.ts`
- `src/utils/secureStorage/index.ts`

## Validation

Ran `bun run typecheck` on this branch.

- targeted auth/XAA secure-storage diagnostics: 16 -> 0
- total `src/` diagnostics: 1043 -> 1027


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced authentication signal handling to ensure reliable timeout management across requests
  * Improved OAuth discovery state caching for consistency and better state management
  * Refined identity provider callback validation to handle edge cases properly

* **Chores**
  * Extended secure storage infrastructure to support additional identity provider authentication metadata

<!-- end of auto-generated comment: release notes by coderabbit.ai -->