### PR TITLE
fix(typecheck): declare Ink JSX intrinsics

### DIFF
--- a/src/ink/global.d.ts
+++ b/src/ink/global.d.ts
@@ -1,9 +1,56 @@
-// Stub — global types for Ink renderer
-declare namespace JSX {
-  interface IntrinsicElements {
-    'ink-box': Record<string, unknown>
-    'ink-text': Record<string, unknown>
-    'ink-root': Record<string, unknown>
-    'ink-virtual-text': Record<string, unknown>
+import type { ReactNode, Ref } from 'react'
+import type { DOMElement } from './dom.js'
+import type { ClickEvent } from './events/click-event.js'
+import type { FocusEvent } from './events/focus-event.js'
+import type { KeyboardEvent } from './events/keyboard-event.js'
+import type { Styles, TextStyles } from './styles.js'
+
+type InkBoxElementProps = {
+  ref?: Ref<DOMElement>
+  children?: ReactNode
+  style?: Styles
+  tabIndex?: number
+  autoFocus?: boolean
+  onClick?: (event: ClickEvent) => void
+  onFocus?: (event: FocusEvent) => void
+  onFocusCapture?: (event: FocusEvent) => void
+  onBlur?: (event: FocusEvent) => void
+  onBlurCapture?: (event: FocusEvent) => void
+  onKeyDown?: (event: KeyboardEvent) => void
+  onKeyDownCapture?: (event: KeyboardEvent) => void
+  onMouseEnter?: () => void
+  onMouseLeave?: () => void
+  stickyScroll?: boolean
+}
+
+type InkTextElementProps = {
+  children?: ReactNode
+  style?: Styles
+  textStyles?: TextStyles
+}
+
+type InkLinkElementProps = {
+  children?: ReactNode
+  href?: string
+}
+
+type InkRawAnsiElementProps = {
+  rawText: string
+  rawWidth: number
+  rawHeight: number
+}
+
+type InkIntrinsicElements = {
+  'ink-box': InkBoxElementProps
+  'ink-text': InkTextElementProps
+  'ink-root': Record<string, unknown>
+  'ink-virtual-text': Record<string, unknown>
+  'ink-link': InkLinkElementProps
+  'ink-raw-ansi': InkRawAnsiElementProps
+}
+
+declare module 'react' {
+  namespace JSX {
+    interface IntrinsicElements extends InkIntrinsicElements {}
   }
 }


### PR DESCRIPTION
## Summary

Addresses part of #1486 by declaring the custom Ink host elements used by the internal renderer.

- moves the Ink host element declarations into React's JSX namespace for the `react-jsx` runtime
- adds declarations for `ink-link` and `ink-raw-ansi` in addition to the existing Ink host nodes
- gives the commonly-used `ink-box`/`ink-text` props lightweight types based on the existing Ink DOM, style, and event types

## Duplicate PR check

Checked all open PR files in `Gitlawb/openclaude` before opening this branch. The only nearby overlap was #1562 on `src/global.d.ts`; this branch edits `src/ink/global.d.ts` and handles a separate Ink JSX intrinsic-element cluster.

## Validation

Ran `bun run typecheck` on this branch.

- Ink JSX intrinsic diagnostics: 11 -> 0
- total `src/` diagnostics: 1043 -> 1032


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced TypeScript type definitions for Ink UI components, providing improved IDE autocomplete and type checking for terminal user interface development.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->