### PR TITLE
fix(typecheck): type FileWrite rejection state

### DIFF
--- a/src/tools/FileWriteTool/UI.tsx
+++ b/src/tools/FileWriteTool/UI.tsx
@@ -36,7 +36,12 @@ export function countLines(content: string): number {
   const parts = content.split(EOL);
   return content.endsWith(EOL) ? parts.length - 1 : parts.length;
 }
-function FileWriteToolCreatedMessage(t0) {
+type FileWriteToolCreatedMessageProps = {
+  filePath: string;
+  content: string;
+  verbose: boolean;
+};
+function FileWriteToolCreatedMessage(t0: FileWriteToolCreatedMessageProps): React.ReactNode {
   const $ = _c(25);
   const {
     filePath,
@@ -205,7 +210,13 @@ type RejectionDiffData = {
 } | {
   type: 'error';
 };
-function WriteRejectionDiff(t0) {
+type WriteRejectionDiffProps = {
+  filePath: string;
+  content: string;
+  style?: 'condensed';
+  verbose: boolean;
+};
+function WriteRejectionDiff(t0: WriteRejectionDiffProps): React.ReactNode {
   const $ = _c(20);
   const {
     filePath,
@@ -213,7 +224,7 @@ function WriteRejectionDiff(t0) {
     style,
     verbose
   } = t0;
-  let t1;
+  let t1: () => Promise<RejectionDiffData>;
   if ($[0] !== content || $[1] !== filePath) {
     t1 = () => loadRejectionDiff(filePath, content);
     $[0] = content;
@@ -222,8 +233,8 @@ function WriteRejectionDiff(t0) {
   } else {
     t1 = $[2];
   }
-  const [dataPromise] = useState(t1);
-  let t2;
+  const [dataPromise] = useState<Promise<RejectionDiffData>>(t1);
+  let t2: string | null;
   if ($[3] !== content) {
     t2 = content.split("\n")[0] ?? null;
     $[3] = content;
@@ -268,7 +279,15 @@ function WriteRejectionDiff(t0) {
   }
   return t5;
 }
-function WriteRejectionBody(t0) {
+type WriteRejectionBodyProps = {
+  promise: Promise<RejectionDiffData>;
+  filePath: string;
+  firstLine: string | null;
+  createFallback: React.ReactNode;
+  style?: 'condensed';
+  verbose: boolean;
+};
+function WriteRejectionBody(t0: WriteRejectionBodyProps): React.ReactNode {
   const $ = _c(8);
   const {
     promise,
@@ -278,7 +297,7 @@ function WriteRejectionBody(t0) {
     style,
     verbose
   } = t0;
-  const data = use(promise);
+  const data: RejectionDiffData = use(promise);
   if (data.type === "create") {
     return createFallback;
   }


### PR DESCRIPTION
## Summary

Addresses part of #1486 by typing the FileWrite rejection-diff Suspense state.

- adds props types for the FileWrite created/rejection view components
- types the lazy rejection-diff promise state as `Promise<RejectionDiffData>`
- annotates the `use(promise)` result so create/update/error branches narrow correctly

## Duplicate PR check

Checked all open PRs in `Gitlawb/openclaude` before opening this branch. No open PR touches `src/tools/FileWriteTool/UI.tsx`.

This branch intentionally leaves the remaining `HighlightedCode` prop diagnostic alone because that adjacent component typing is already covered by #1568.

## Validation

Ran `bun run typecheck` on this branch.

- `src/tools/FileWriteTool/UI.tsx` diagnostics: 9 -> 1
- remaining diagnostic: `HighlightedCode` props, covered separately by #1568
- total `src/` diagnostics: 1043 -> 1035

The full command still exits nonzero because #1486 has unrelated remaining diagnostics outside this PR's scope.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved internal type safety and code stability through enhanced TypeScript type definitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->