### PR TITLE
fix(typecheck): recreate missing Spinner types

### DIFF
--- a/src/components/Spinner/types.ts
+++ b/src/components/Spinner/types.ts
@@ -1,0 +1,13 @@
+export type SpinnerMode =
+  | 'requesting'
+  | 'responding'
+  | 'thinking'
+  | 'tool-use'
+  | 'tool-input'
+  | string & {}
+
+export interface RGBColor {
+  r: number
+  g: number
+  b: number
+}


### PR DESCRIPTION
This PR addresses several `TS2307` module resolution errors by recreating the missing `types.ts` export for the Spinner component.

**Context:**
A previous refactoring or migration removed `src/components/Spinner/types.ts` without updating the dependent components, resulting in broken imports across the Spinner module.

**Changes:**
- Recreated `SpinnerMode` and `RGBColor` types in `src/components/Spinner/types.ts`
- This single isolated change satisfies the imports and cleans up 5 `Cannot find module` errors.

**Resolved Errors:**
```
src/components/Spinner/GlimmerMessage.tsx: Cannot find module './types.js'
src/components/Spinner/SpinnerAnimationRow.tsx: Cannot find module './types.js'
src/components/Spinner/index.ts: Cannot find module './types.js'
src/components/Spinner/useShimmerAnimation.ts: Cannot find module './types.js'
src/components/Spinner/utils.ts: Cannot find module './types.js'
```

**Validation:**
Ran `bun run typecheck` locally to confirm all Spinner-related type errors are eliminated.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced spinner component with support for multiple operation states (`requesting`, `responding`, `thinking`, `tool-use`, `tool-input`) and RGB color customization options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->