### PR TITLE
feat(opengateway): surface the gateway's "auto" smart-routing model in /model

### DIFF
--- a/src/commands/model/model.test.tsx
+++ b/src/commands/model/model.test.tsx
@@ -1269,6 +1269,7 @@ test('/model applies auto provider surface for single-model static descriptor pr
         option => option.value,
       ),
     ).toEqual([
+      'auto',
       'mimo-v2.5-pro',
       'mimo-v2.5',
       'mimo-v2-flash',

--- a/src/integrations/gateways/gitlawb-opengateway.ts
+++ b/src/integrations/gateways/gitlawb-opengateway.ts
@@ -60,6 +60,16 @@ export default defineGateway({
   catalog: {
     source: 'static',
     models: [
+      // Virtual model: the gateway's smart router picks the cheapest model
+      // expected to handle the request and escalates on upstream failure
+      // (see opengateway/src/routing/). Billed at the serving model's rate;
+      // the x-gateway-served-model response header names who answered.
+      {
+        id: 'opengateway-auto',
+        apiName: 'auto',
+        label: 'Auto — Smart Routing (via Opengateway)',
+        notes: 'Gateway picks the cheapest capable model and escalates on failure',
+      },
       {
         id: 'opengateway-mimo-v2.5-pro',
         apiName: 'mimo-v2.5-pro',

--- a/src/integrations/index.test.ts
+++ b/src/integrations/index.test.ts
@@ -63,6 +63,9 @@ describe('loaded registry validation', () => {
   test('static gateway catalog entries use shared model descriptors when known', () => {
     const descriptorOptionalEntries = new Set([
       'azure-openai:azure-deployment',
+      // Virtual model — the gateway's smart router resolves it server-side,
+      // so there is no concrete model descriptor to reference.
+      'gitlawb-opengateway:opengateway-auto',
     ])
     const missingDescriptors = getAllGateways().flatMap(gateway =>
       (gateway.catalog?.models ?? [])


### PR DESCRIPTION
Opengateway now supports a virtual model "auto": the gateway scores each request (context size, tools, code, reasoning) and routes it to the cheapest model expected to handle it, escalating on upstream failure. Add it to the static catalog so the /model picker offers it (listed first) when the opengateway provider is active.

- catalog entry only — defaultModel stays mimo-v2.5-pro until the routing heuristics are calibrated
- no MODEL_ALIASES change: "auto" validates through the normal live sideQuery path, which the gateway accepts
- exempt the virtual entry from the shared-descriptor test (no concrete model descriptor exists for a server-side router)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added "Auto" model option for intelligent routing. Automatically selects the most cost-effective capable model with automatic fallback on failure. Billing reflects the model that serves your request.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->