### PR TITLE
fix: rename "Claude" to "OpenClaude" in feedback survey prompt

### DIFF
--- a/src/components/FeedbackSurvey/FeedbackSurveyView.tsx
+++ b/src/components/FeedbackSurvey/FeedbackSurveyView.tsx
@@ -18,7 +18,7 @@ const inputToResponse: Record<ResponseInput, FeedbackSurveyResponse> = {
   '3': 'good'
 } as const;
 export const isValidResponseInput = (input: string): input is ResponseInput => (RESPONSE_INPUTS as readonly string[]).includes(input);
-const DEFAULT_MESSAGE = 'How is Claude doing this session? (optional)';
+const DEFAULT_MESSAGE = 'How is OpenClaude doing this session? (optional)';
 export function FeedbackSurveyView(t0) {
   const $ = _c(15);
   const {


### PR DESCRIPTION
## Summary
- Rename feedback survey prompt from "How is Claude doing this session?" to "How is OpenClaude doing this session?"
- One-line text change in `FeedbackSurveyView.tsx`

## Rationale
The survey prompt should reference the actual project name.