### PR TITLE
ci: split typecheck into its own PR-checks job

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -42,9 +42,6 @@ jobs:
       - name: Smoke and full unit test suite
         run: bun run check
 
-      - name: Typecheck
-        run: bun run typecheck
-
       - name: Install Python test dependencies
         run: python -m pip install -r python/requirements.txt
 
@@ -61,6 +58,29 @@ jobs:
 
       - name: Provider recommendation tests
         run: npm run test:provider-recommendation
+
+  typecheck:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        with:
+          bun-version-file: .bun-version
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Typecheck
+        run: bun run typecheck
+
+      - name: Type tests
+        run: bun run typecheck:type-tests
 
   web:
     runs-on: ubuntu-latest

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -165,6 +165,13 @@ Python tests:
 python -m pytest -q python/tests
 ```
 
+Typecheck (enforced by the dedicated `typecheck` CI job):
+
+```bash
+bun run typecheck
+bun run typecheck:type-tests
+```
+
 PR intent scan:
 
 ```bash
@@ -183,12 +190,6 @@ PRs that fail CI checks will not be merged.
 ### Recommended Local Checks
 
 These are not enforced by CI but are worth running locally before submitting.
-
-Typecheck:
-
-```bash
-bun run typecheck
-```
 
 Focused tests:
 

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "typecheck": "tsc --noEmit",
     "typecheck:type-tests": "bun run scripts/typecheck-type-tests.ts",
     "smoke": "bun run build && node dist/cli.mjs --version",
-    "check": "bun run smoke && bun run typecheck:type-tests && bun run test:full",
+    "check": "bun run smoke && bun run test:full",
     "verify:privacy": "bun run scripts/verify-no-phone-home.ts",
     "build:verified": "bun run build && bun run verify:privacy",
     "test:provider": "bun test --max-concurrency=1 src/services/api/*.test.ts src/utils/context.test.ts",


### PR DESCRIPTION
  ## Summary

  - **What changed:** TypeScript checking moves out of the `smoke-and-tests` job into its
    own dedicated `typecheck` job in PR Checks. The new job runs `bun run typecheck`
    (tsc --noEmit) and `bun run typecheck:type-tests` with a minimal setup (checkout →
    Bun → install — no Node/Python). The embedded `Typecheck` step is removed from
    `smoke-and-tests`, and the `check` script slims from
    `smoke && typecheck:type-tests && test:full` to `smoke && test:full` so the type
    tests don't run twice in CI. Local scripts (`typecheck`, `typecheck:type-tests`,
    `hardening:strict`) are unchanged.
  - **Why:** type errors were buried mid-way through the smoke job and serialized behind
    the build. As a separate parallel job, a type failure now surfaces as its own
    distinct status check (`typecheck`) with fast feedback, independent of whether the
    build/test pipeline succeeds — and the smoke job gets slightly faster.

  ## Impact

  - **user-facing impact:** none — CI/workflow configuration only, no runtime code changed.
  - **developer/maintainer impact:** PRs show three independent status checks
    (`smoke-and-tests`, `typecheck`, `web`); a type regression is identifiable at a
    glance and fails fast in parallel. Anyone relying on `bun run check` locally should
    note it no longer includes `typecheck:type-tests` — run `bun run typecheck` /
    `typecheck:type-tests` directly (or `hardening:strict`, which still includes
    typecheck).

  ## Testing

  - [x] `bun run build`
  - [x] `bun run smoke`
  - [x] `bun run check` (slimmed variant: smoke + full suite — 3698 tests, 0 fail)
  - [x] focused tests: `bun run typecheck` (exit 0) and `bun run typecheck:type-tests`
    (the new job's exact steps, run locally); workflow YAML parsed and verified to
    contain the three jobs with expected steps. The new job runs live on this PR's own
    checks as the end-to-end proof.

  ## Notes

  - provider/model path tested: N/A — no provider or runtime code touched.
  - screenshots attached (if UI changed): N/A — no UI change.
  - follow-up work or known limitations: branch-protection/required-checks settings (if
    any) may need the new `typecheck` check added to the required list once this merges;
    that's a repo-settings change only a maintainer can make.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Moved type checking into its own CI job to run separately from smoke/tests.
  * Simplified the main check script to exclude type-test steps and streamline checks.

* **Documentation**
  * CONTRIBUTING updated to document the enforced CI Typecheck job and related commands.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->