### PR TITLE
feat(gemini-vertex): native Gemini Vertex client and auth helpers (1/3)

### DIFF
--- a/src/services/api/geminiVertexClient.test.ts
+++ b/src/services/api/geminiVertexClient.test.ts
@@ -1,0 +1,551 @@
+import { expect, test } from 'bun:test'
+import { createGeminiVertexClient, type GeminiVertexStreamEvent } from './geminiVertexClient.js'
+
+function createJsonVertexResponse(text: string) {
+  return new Response(
+    JSON.stringify({
+      candidates: [
+        { content: { parts: [{ text }] } },
+      ],
+    }),
+    { headers: { 'Content-Type': 'application/json', 'x-request-id': 'vertex-request-123' } },
+  )
+}
+
+test('Gemini Vertex client uses root aiplatform host for global location', async () => {
+  let capturedUrl: string | undefined
+
+  const client = createGeminiVertexClient({
+    project: 'project-123',
+    location: 'global',
+    model: 'gemini-3.5-flash',
+    getAccessToken: async () => 'access-token-123',
+    fetch: (async (input) => {
+      capturedUrl = String(input)
+      return createJsonVertexResponse('Bonjour Global Vertex')
+    }) as typeof fetch,
+  })
+
+  await client.messages.create({
+    model: 'gemini-3.5-flash',
+    max_tokens: 1,
+    messages: [{ role: 'user', content: 'Salut' }],
+  })
+
+  expect(capturedUrl).toBe(
+    'https://aiplatform.googleapis.com/v1/projects/project-123/locations/global/publishers/google/models/gemini-3.5-flash:generateContent',
+  )
+})
+
+test('Gemini Vertex client sends Anthropic-style messages to Vertex generateContent', async () => {
+  let capturedUrl: string | undefined
+  let capturedHeaders: Headers | undefined
+  let capturedBody: Record<string, unknown> | undefined
+
+  const client = createGeminiVertexClient({
+    project: 'project-123',
+    location: 'us-central1',
+    model: 'gemini-3.5-flash',
+    getAccessToken: async () => 'access-token-123',
+    fetch: (async (input, init) => {
+      capturedUrl = String(input)
+      capturedHeaders = new Headers(init?.headers)
+      capturedBody = JSON.parse(String(init?.body)) as Record<string, unknown>
+
+      return createJsonVertexResponse('Bonjour Vertex')
+    }) as typeof fetch,
+  })
+
+  const response = await client.messages.create({
+    model: 'gemini-2.5-pro',
+    max_tokens: 321,
+    temperature: 0.25,
+    messages: [
+      { role: 'user', content: 'Salut' },
+      { role: 'assistant', content: [{ type: 'text', text: 'Ancienne rÃ©ponse' }] },
+      { role: 'user', content: [{ type: 'text', text: 'Suite' }] },
+    ],
+  })
+
+  expect(capturedUrl).toBe(
+    'https://us-central1-aiplatform.googleapis.com/v1/projects/project-123/locations/us-central1/publishers/google/models/gemini-3.5-flash:generateContent',
+  )
+  expect(capturedHeaders?.get('authorization')).toBe('Bearer access-token-123')
+  expect(capturedHeaders?.get('x-goog-user-project')).toBe('project-123')
+  expect(capturedBody).toEqual({
+    contents: [
+      { role: 'user', parts: [{ text: 'Salut' }] },
+      { role: 'model', parts: [{ text: 'Ancienne rÃ©ponse' }] },
+      { role: 'user', parts: [{ text: 'Suite' }] },
+    ],
+    generationConfig: {
+      // gemini-3.5-flash is a thinking model: we raise the floor so the
+      // model has room to think AND emit visible text. The caller asked
+      // for 321 but the floor wins.
+      maxOutputTokens: 8192,
+      // Thinking models degrade (looping / empty output) below temperature
+      // 1.0, so the caller's 0.25 is clamped up to the documented 1.0 floor.
+      temperature: 1,
+    },
+  })
+  expect(response).toMatchObject({
+    role: 'assistant',
+    model: 'gemini-3.5-flash',
+    content: [{ type: 'text', text: 'Bonjour Vertex' }],
+  })
+})
+
+test('Gemini Vertex client clamps thinking-model temperature to the 1.0 floor', async () => {
+  let capturedBody: Record<string, unknown> | undefined
+
+  const client = createGeminiVertexClient({
+    project: 'project-123',
+    location: 'global',
+    model: 'gemini-3.5-flash',
+    getAccessToken: async () => 'access-token-123',
+    fetch: (async (_input, init) => {
+      capturedBody = JSON.parse(String(init?.body)) as Record<string, unknown>
+      return createJsonVertexResponse('ok')
+    }) as typeof fetch,
+  })
+
+  await client.messages.create({
+    model: 'gemini-3.5-flash',
+    max_tokens: 100,
+    temperature: 0, // coding-agent determinism â€” must be lifted to 1.0
+    messages: [{ role: 'user', content: 'salut' }],
+  })
+
+  expect((capturedBody?.generationConfig as Record<string, unknown>).temperature).toBe(1)
+})
+
+test('Gemini Vertex client renders tool_reference blocks in tool results as readable text', async () => {
+  let capturedBody: Record<string, unknown> | undefined
+
+  const client = createGeminiVertexClient({
+    project: 'project-123',
+    location: 'global',
+    model: 'gemini-2.5-flash',
+    getAccessToken: async () => 'access-token-123',
+    fetch: (async (_input, init) => {
+      capturedBody = JSON.parse(String(init?.body)) as Record<string, unknown>
+      return createJsonVertexResponse('ok')
+    }) as typeof fetch,
+  })
+
+  await client.messages.create({
+    model: 'gemini-2.5-flash',
+    max_tokens: 100,
+    messages: [
+      {
+        role: 'assistant',
+        content: [
+          { type: 'tool_use', id: 'toolu_ts1', name: 'ToolSearch', input: { query: 'memory' } },
+        ],
+      },
+      {
+        role: 'user',
+        content: [
+          {
+            type: 'tool_result',
+            tool_use_id: 'toolu_ts1',
+            content: [
+              { type: 'tool_reference', tool_name: 'mcp__example__memory_search' },
+            ] as never,
+          },
+        ],
+      },
+    ],
+  })
+
+  const serialized = JSON.stringify(capturedBody?.contents)
+  expect(serialized).toContain('mcp__example__memory_search')
+})
+
+test('Gemini Vertex client preserves temperature for non-thinking models', async () => {
+  let capturedBody: Record<string, unknown> | undefined
+
+  const client = createGeminiVertexClient({
+    project: 'project-123',
+    location: 'global',
+    model: 'gemini-2.5-flash', // not a thinking model
+    getAccessToken: async () => 'access-token-123',
+    fetch: (async (_input, init) => {
+      capturedBody = JSON.parse(String(init?.body)) as Record<string, unknown>
+      return createJsonVertexResponse('ok')
+    }) as typeof fetch,
+  })
+
+  await client.messages.create({
+    model: 'gemini-2.5-flash',
+    max_tokens: 100,
+    temperature: 0.25,
+    messages: [{ role: 'user', content: 'salut' }],
+  })
+
+  expect((capturedBody?.generationConfig as Record<string, unknown>).temperature).toBe(0.25)
+})
+
+test('Gemini Vertex client supports Anthropic streaming withResponse contract', async () => {
+  const client = createGeminiVertexClient({
+    project: 'project-123',
+    location: 'us-central1',
+    model: 'gemini-3.5-flash',
+    getAccessToken: async () => 'access-token-123',
+    fetch: (async () => createJsonVertexResponse('Bonjour Vertex')) as unknown as typeof fetch,
+  })
+
+  const result = await client.beta.messages.create({
+    model: 'gemini-3.5-flash',
+    max_tokens: 1,
+    messages: [{ role: 'user', content: 'Salut' }],
+    stream: true,
+  }).withResponse()
+
+  const events: GeminiVertexStreamEvent[] = []
+  for await (const event of result.data) {
+    events.push(event)
+  }
+
+  expect(result.request_id).toBe('vertex-request-123')
+  expect(result.response).toBeInstanceOf(Response)
+  expect(events.map(event => event.type)).toEqual([
+    'message_start',
+    'content_block_start',
+    'content_block_delta',
+    'content_block_stop',
+    'message_delta',
+    'message_stop',
+  ])
+  expect(events[2]).toMatchObject({
+    type: 'content_block_delta',
+    index: 0,
+    delta: { type: 'text_delta', text: 'Bonjour Vertex' },
+  })
+})
+
+test('Gemini Vertex client forwards Anthropic tools as Vertex functionDeclarations', async () => {
+  let capturedBody: Record<string, unknown> | undefined
+
+  const client = createGeminiVertexClient({
+    project: 'project-123',
+    location: 'global',
+    model: 'gemini-2.5-flash',
+    getAccessToken: async () => 'access-token-123',
+    fetch: (async (_input, init) => {
+      capturedBody = JSON.parse(String(init?.body)) as Record<string, unknown>
+      return createJsonVertexResponse('ok')
+    }) as typeof fetch,
+  })
+
+  await client.messages.create({
+    model: 'gemini-2.5-flash',
+    max_tokens: 100,
+    messages: [{ role: 'user', content: 'list files' }],
+    tools: [
+      {
+        name: 'Read',
+        description: 'Read a file',
+        input_schema: {
+          type: 'object',
+          properties: {
+            file_path: { type: 'string', description: 'absolute path' },
+            limit: { type: 'integer' },
+          },
+          required: ['file_path'],
+          additionalProperties: false,
+        },
+      },
+    ],
+  })
+
+  expect(capturedBody?.tools).toEqual([
+    {
+      functionDeclarations: [
+        {
+          name: 'Read',
+          description: 'Read a file',
+          parameters: {
+            type: 'OBJECT',
+            properties: {
+              file_path: { type: 'STRING', description: 'absolute path' },
+              limit: { type: 'INTEGER' },
+            },
+            required: ['file_path'],
+          },
+        },
+      ],
+    },
+  ])
+})
+
+test('Gemini Vertex client strips JSON Schema keywords Vertex rejects', async () => {
+  let capturedBody: Record<string, unknown> | undefined
+
+  const client = createGeminiVertexClient({
+    project: 'project-123',
+    location: 'global',
+    model: 'gemini-2.5-flash',
+    getAccessToken: async () => 'access-token-123',
+    fetch: (async (_input, init) => {
+      capturedBody = JSON.parse(String(init?.body)) as Record<string, unknown>
+      return createJsonVertexResponse('ok')
+    }) as typeof fetch,
+  })
+
+  await client.messages.create({
+    model: 'gemini-2.5-flash',
+    max_tokens: 100,
+    messages: [{ role: 'user', content: 'go' }],
+    tools: [
+      {
+        name: 'Tricky',
+        description: 'Schema with keywords Vertex does not accept',
+        input_schema: {
+          type: 'object',
+          $schema: 'http://json-schema.org/draft-07/schema#',
+          additionalProperties: false,
+          propertyNames: { pattern: '^[a-z]+$' },
+          properties: {
+            count: { type: 'integer', exclusiveMinimum: 0 },
+            mode: { type: 'string', const: 'fast' },
+            tags: {
+              type: 'array',
+              items: { type: 'string' },
+              patternProperties: { '.*': { type: 'string' } },
+            },
+          },
+          required: ['count'],
+        },
+      },
+    ],
+  })
+
+  const tools = capturedBody?.tools as Array<{
+    functionDeclarations: Array<{ parameters: Record<string, unknown> }>
+  }>
+  const params = tools[0]!.functionDeclarations[0]!.parameters
+  expect(params).toEqual({
+    type: 'OBJECT',
+    properties: {
+      // exclusiveMinimum approximated as minimum, type uppercased
+      count: { type: 'INTEGER', minimum: 0 },
+      // const translated to single-value enum
+      mode: { type: 'STRING', enum: ['fast'] },
+      tags: { type: 'ARRAY', items: { type: 'STRING' } },
+    },
+    required: ['count'],
+  })
+})
+
+test('Gemini Vertex client surfaces functionCall responses as tool_use blocks', async () => {
+  const client = createGeminiVertexClient({
+    project: 'project-123',
+    location: 'global',
+    model: 'gemini-2.5-flash',
+    getAccessToken: async () => 'access-token-123',
+    fetch: (async () =>
+      new Response(
+        JSON.stringify({
+          candidates: [
+            {
+              content: {
+                parts: [
+                  {
+                    functionCall: {
+                      name: 'Read',
+                      args: { file_path: '/tmp/notes.md' },
+                    },
+                  },
+                ],
+              },
+              finishReason: 'STOP',
+            },
+          ],
+        }),
+        { headers: { 'Content-Type': 'application/json' } },
+      )) as unknown as typeof fetch,
+  })
+
+  const response = await client.messages.create({
+    model: 'gemini-2.5-flash',
+    max_tokens: 100,
+    messages: [{ role: 'user', content: 'list files' }],
+  })
+
+  expect(response.stop_reason).toBe('tool_use')
+  expect(response.content).toHaveLength(1)
+  const block = response.content[0]!
+  expect(block.type).toBe('tool_use')
+  expect(block).toMatchObject({
+    type: 'tool_use',
+    name: 'Read',
+    input: { file_path: '/tmp/notes.md' },
+  })
+})
+
+test('Gemini Vertex client round-trips functionCall thoughtSignature through history', async () => {
+  let capturedBody: Record<string, unknown> | undefined
+
+  const client = createGeminiVertexClient({
+    project: 'project-123',
+    location: 'global',
+    model: 'gemini-3.5-flash',
+    getAccessToken: async () => 'access-token-123',
+    fetch: (async (_input, init) => {
+      capturedBody = JSON.parse(String(init?.body)) as Record<string, unknown>
+      // The model emits a functionCall WITH a thoughtSignature (thinking model).
+      return new Response(
+        JSON.stringify({
+          candidates: [
+            {
+              content: {
+                parts: [
+                  {
+                    functionCall: { name: 'Skill', args: { skill: 'x' } },
+                    thoughtSignature: 'SIG_ABC_123',
+                  },
+                ],
+              },
+              finishReason: 'STOP',
+            },
+          ],
+        }),
+        { headers: { 'Content-Type': 'application/json' } },
+      )
+    }) as typeof fetch,
+  })
+
+  // First turn: capture the tool_use id the client synthesises.
+  const first = await client.messages.create({
+    model: 'gemini-3.5-flash',
+    max_tokens: 100,
+    messages: [{ role: 'user', content: 'salut' }],
+  })
+  const toolUse = first.content[0] as { type: string; id: string; name: string }
+  expect(toolUse.type).toBe('tool_use')
+
+  // Second turn: replay the assistant tool_use + a tool_result, exactly as the
+  // agent loop would. The functionCall part sent to Vertex MUST carry the
+  // original thoughtSignature, or Vertex 400s.
+  await client.messages.create({
+    model: 'gemini-3.5-flash',
+    max_tokens: 100,
+    messages: [
+      { role: 'user', content: 'salut' },
+      {
+        role: 'assistant',
+        content: [{ type: 'tool_use', id: toolUse.id, name: toolUse.name, input: { skill: 'x' } }],
+      },
+      {
+        role: 'user',
+        content: [{ type: 'tool_result', tool_use_id: toolUse.id, content: 'done' }],
+      },
+    ],
+  })
+
+  const contents = capturedBody?.contents as Array<{
+    role: string
+    parts: Array<Record<string, unknown>>
+  }>
+  const functionCallPart = contents
+    .flatMap(c => c.parts)
+    .find(p => 'functionCall' in p)
+  expect(functionCallPart).toEqual({
+    functionCall: { name: 'Skill', args: { skill: 'x' } },
+    thoughtSignature: 'SIG_ABC_123',
+  })
+})
+
+test('Gemini Vertex client keeps functionResponse turns pure (splits trailing text)', async () => {
+  let capturedBody: Record<string, unknown> | undefined
+
+  const client = createGeminiVertexClient({
+    project: 'project-123',
+    location: 'global',
+    model: 'gemini-2.5-flash',
+    getAccessToken: async () => 'access-token-123',
+    fetch: (async (_input, init) => {
+      capturedBody = JSON.parse(String(init?.body)) as Record<string, unknown>
+      return createJsonVertexResponse('Bonjour')
+    }) as typeof fetch,
+  })
+
+  await client.messages.create({
+    model: 'gemini-2.5-flash',
+    max_tokens: 100,
+    messages: [
+      { role: 'user', content: 'salut' },
+      {
+        role: 'assistant',
+        content: [{ type: 'tool_use', id: 'toolu_1', name: 'Skill', input: { skill: 'x' } }],
+      },
+      {
+        // openclaude appends a system-reminder text AFTER the tool_result in
+        // the SAME user message â€” this must not pollute the functionResponse turn.
+        role: 'user',
+        content: [
+          { type: 'tool_result', tool_use_id: 'toolu_1', content: 'loaded' },
+          { type: 'text', text: '<system-reminder>stay on task</system-reminder>' },
+        ],
+      },
+    ],
+  })
+
+  // The functionResponse turn is emitted pure, immediately after the model's
+  // functionCall; the reminder text is pushed to its own following user turn.
+  expect(capturedBody?.contents).toEqual([
+    { role: 'user', parts: [{ text: 'salut' }] },
+    { role: 'model', parts: [{ functionCall: { name: 'Skill', args: { skill: 'x' } } }] },
+    { role: 'user', parts: [{ functionResponse: { name: 'Skill', response: { result: 'loaded' } } }] },
+    { role: 'user', parts: [{ text: '<system-reminder>stay on task</system-reminder>' }] },
+  ])
+})
+
+test('Gemini Vertex client includes a response diagnostic on empty STOP responses', async () => {
+  const client = createGeminiVertexClient({
+    project: 'project-123',
+    location: 'global',
+    model: 'gemini-3.5-flash',
+    getAccessToken: async () => 'access-token-123',
+    fetch: (async () =>
+      new Response(
+        JSON.stringify({
+          // A "thought-only" turn: the model burned tokens thinking but emitted
+          // no visible parts. finishReason STOP, empty content.
+          candidates: [{ content: { role: 'model', parts: [] }, finishReason: 'STOP' }],
+          usageMetadata: {
+            promptTokenCount: 1200,
+            candidatesTokenCount: 0,
+            thoughtsTokenCount: 640,
+            totalTokenCount: 1840,
+          },
+        }),
+        { headers: { 'Content-Type': 'application/json' } },
+      )) as unknown as typeof fetch,
+  })
+
+  await expect(
+    client.messages.create({
+      model: 'gemini-3.5-flash',
+      max_tokens: 100,
+      messages: [{ role: 'user', content: 'salut' }],
+    }),
+  ).rejects.toThrow(/\[diag candidates=1 content:yes parts=\[\] \| usage prompt=1200 candidates=0 thoughts=640 total=1840 \| promptBlock:none\]/)
+})
+
+test('Gemini Vertex client propagates HTTP errors', async () => {
+  const client = createGeminiVertexClient({
+    project: 'project-123',
+    location: 'us-central1',
+    model: 'gemini-3.5-flash',
+    getAccessToken: async () => 'access-token-123',
+    fetch: (async () => new Response('permission denied', { status: 403 })) as NonNullable<import('@anthropic-ai/sdk').ClientOptions['fetch']>,
+  })
+
+  await expect(client.messages.create({
+    model: 'gemini-3.5-flash',
+    max_tokens: 1,
+    messages: [{ role: 'user', content: 'Salut' }],
+  })).rejects.toThrow('Gemini Vertex request failed: 403 permission denied')
+})

--- a/src/services/api/geminiVertexClient.ts
+++ b/src/services/api/geminiVertexClient.ts
@@ -1,0 +1,803 @@
+import type { ClientOptions } from '@anthropic-ai/sdk'
+import type { MessageCreateParamsBase } from '@anthropic-ai/sdk/resources/messages/messages'
+
+type AccessTokenProvider = () => Promise<string>
+
+type GeminiVertexClientOptions = {
+  project: string
+  location: string
+  model: string
+  getAccessToken: AccessTokenProvider
+  fetch?: NonNullable<ClientOptions['fetch']>
+}
+
+type GeminiVertexFunctionCallPart = {
+  functionCall: { name: string; args?: Record<string, unknown> }
+  // Gemini thinking models (gemini-3.x, 2.5-pro) attach an opaque
+  // thoughtSignature to each functionCall part. It MUST be echoed back when the
+  // call is replayed in history, or Vertex rejects the request with 400.
+  thoughtSignature?: string
+}
+type GeminiVertexFunctionResponsePart = {
+  functionResponse: { name: string; response: Record<string, unknown> }
+}
+type GeminiVertexPart =
+  | { text: string }
+  | GeminiVertexFunctionCallPart
+  | GeminiVertexFunctionResponsePart
+type GeminiVertexContent = { role: 'user' | 'model'; parts: GeminiVertexPart[] }
+type GeminiVertexSystemInstruction = { parts: Array<{ text: string }> }
+
+// Vertex AI uses an OpenAPI-style schema with UPPERCASE type names and a
+// restricted feature set. We translate Anthropic's lowercase JSON Schema and
+// drop fields Vertex doesn't accept ($schema, $ref, additionalProperties).
+type GeminiVertexSchema = Record<string, unknown>
+
+type GeminiVertexFunctionDeclaration = {
+  name: string
+  description?: string
+  parameters?: GeminiVertexSchema
+}
+type GeminiVertexTool = {
+  functionDeclarations: GeminiVertexFunctionDeclaration[]
+}
+type GeminiVertexFunctionCallingMode = 'AUTO' | 'ANY' | 'NONE'
+type GeminiVertexToolConfig = {
+  functionCallingConfig: {
+    mode: GeminiVertexFunctionCallingMode
+    allowedFunctionNames?: string[]
+  }
+}
+
+type GeminiVertexSafetyRating = {
+  category?: string
+  probability?: string
+  blocked?: boolean
+}
+
+type GeminiVertexResponsePart = {
+  text?: string
+  functionCall?: { name?: string; args?: Record<string, unknown> }
+  thoughtSignature?: string
+}
+
+type GeminiVertexResponse = {
+  candidates?: Array<{
+    content?: {
+      role?: string
+      parts?: GeminiVertexResponsePart[]
+    }
+    finishReason?: string
+    safetyRatings?: GeminiVertexSafetyRating[]
+  }>
+  promptFeedback?: {
+    blockReason?: string
+    blockReasonMessage?: string
+    safetyRatings?: GeminiVertexSafetyRating[]
+  }
+  usageMetadata?: {
+    promptTokenCount?: number
+    candidatesTokenCount?: number
+    totalTokenCount?: number
+    thoughtsTokenCount?: number
+  }
+}
+
+function summarizeBlockedSafetyRatings(
+  ratings: GeminiVertexSafetyRating[] | undefined,
+): string {
+  if (!ratings?.length) return ''
+  const blocked = ratings
+    .filter(r => r.blocked || r.probability === 'HIGH' || r.probability === 'MEDIUM')
+    .map(r => `${r.category ?? '?'}=${r.probability ?? '?'}`)
+  return blocked.length ? ` (${blocked.join(', ')})` : ''
+}
+
+// Compact, non-sensitive snapshot of a response that produced no usable
+// content. Surfaced in the empty-response error so a single real test reveals
+// the exact shape (parts present? thought-only? token split?) instead of us
+// guessing across round-trips. Reports part *keys* and text lengths, never the
+// text itself, so it can't leak prompt content.
+function diagnoseEmptyResponse(json: GeminiVertexResponse): string {
+  const candidate = json.candidates?.[0]
+  const parts = candidate?.content?.parts
+  let partsSummary: string
+  if (Array.isArray(parts)) {
+    partsSummary = parts.length === 0
+      ? 'parts=[]'
+      : parts
+          .map((p, i) => {
+            const rec = p as Record<string, unknown>
+            const keys = Object.keys(rec)
+            const textLen =
+              typeof rec.text === 'string' ? (rec.text as string).length : 0
+            return `#${i}{${keys.join(',') || 'empty'}${textLen ? ` textLen=${textLen}` : ''}}`
+          })
+          .join(' ')
+  } else {
+    partsSummary = parts === undefined ? 'parts=undefined' : 'parts=null'
+  }
+  const u = json.usageMetadata ?? {}
+  const usage = `prompt=${u.promptTokenCount ?? 0} candidates=${u.candidatesTokenCount ?? 0} thoughts=${u.thoughtsTokenCount ?? 0} total=${u.totalTokenCount ?? 0}`
+  const contentPresent = candidate?.content ? 'content:yes' : 'content:no'
+  const promptBlock = json.promptFeedback?.blockReason
+    ? `promptBlock=${json.promptFeedback.blockReason}`
+    : 'promptBlock:none'
+  return `[diag candidates=${json.candidates?.length ?? 0} ${contentPresent} ${partsSummary} | usage ${usage} | ${promptBlock}]`
+}
+
+// Role + part-kind sequence of the request we sent (no content, just shape).
+// Surfaced alongside the response diagnostic so a structural cause — a trailing
+// model turn, a missing functionResponse, an empty part — is visible directly.
+function summarizeRequestContents(contents: GeminiVertexContent[]): string {
+  const seq = contents
+    .map(c => {
+      const kinds = c.parts.map(p => {
+        if ('functionCall' in p) return 'fc'
+        if ('functionResponse' in p) return 'fr'
+        if ('text' in p) return (p as { text: string }).text ? 'text' : 'text:empty'
+        return '?'
+      })
+      return `${c.role}[${kinds.join(',')}]`
+    })
+    .join(' ')
+  return `[req n=${contents.length} ${seq}]`
+}
+
+// Thinking-capable Vertex Gemini models spend a chunk of maxOutputTokens on
+// internal reasoning (thoughtsTokenCount) before emitting any visible text.
+// If openclaude passes a tight budget — common for the first turn of a chat —
+// the model burns the entire allotment thinking and the response comes back
+// with finishReason=MAX_TOKENS and no `parts`. Boost the floor for these
+// families so a simple greeting actually produces a reply.
+const THINKING_MODEL_PREFIXES = ['gemini-3.', 'gemini-2.5-pro']
+const THINKING_MODEL_MIN_OUTPUT_TOKENS = 8192
+
+function isThinkingModel(model: string): boolean {
+  const lower = model.toLowerCase()
+  return THINKING_MODEL_PREFIXES.some(prefix => lower.startsWith(prefix))
+}
+
+type GeminiVertexTextBlock = { type: 'text'; text: string }
+type GeminiVertexToolUseBlock = {
+  type: 'tool_use'
+  id: string
+  name: string
+  input: Record<string, unknown>
+}
+type GeminiVertexContentBlock = GeminiVertexTextBlock | GeminiVertexToolUseBlock
+type GeminiVertexStopReason = 'end_turn' | 'tool_use'
+
+type GeminiVertexMessage = {
+  id: string
+  type: 'message'
+  role: 'assistant'
+  model: string
+  stop_reason: GeminiVertexStopReason
+  stop_sequence: null
+  usage: { input_tokens: number; output_tokens: number }
+  content: GeminiVertexContentBlock[]
+}
+
+export type GeminiVertexStreamEvent =
+  | { type: 'message_start'; message: GeminiVertexMessage }
+  | {
+      type: 'content_block_start'
+      index: number
+      content_block:
+        | GeminiVertexTextBlock
+        | { type: 'tool_use'; id: string; name: string; input: Record<string, unknown> }
+    }
+  | { type: 'content_block_delta'; index: number; delta: { type: 'text_delta'; text: string } }
+  | {
+      type: 'content_block_delta'
+      index: number
+      delta: { type: 'input_json_delta'; partial_json: string }
+    }
+  | { type: 'content_block_stop'; index: number }
+  | {
+      type: 'message_delta'
+      delta: { stop_reason: GeminiVertexStopReason; stop_sequence: null }
+      usage: { output_tokens: number }
+    }
+  | { type: 'message_stop' }
+
+type GeminiVertexWithResponseResult = {
+  data: AsyncGenerator<GeminiVertexStreamEvent>
+  response: Response
+  request_id: string
+}
+
+type GeminiVertexPromise = Promise<GeminiVertexMessage> & {
+  withResponse(): Promise<GeminiVertexWithResponseResult>
+}
+
+// JSON Schema → Vertex schema. Vertex's schema is an OpenAPI 3.0 subset: it
+// requires UPPERCASE type names and rejects ANY field it doesn't recognize
+// (e.g. propertyNames, exclusiveMinimum, const, $schema, additionalProperties).
+// We therefore use an ALLOWLIST: only fields Vertex documents are forwarded,
+// everything else is dropped. This is robust against future JSON Schema
+// keywords that a drop-list could never anticipate.
+//
+// Supported scalar fields are copied as-is; structural fields (properties,
+// items, anyOf, ...) are translated recursively.
+const VERTEX_SCHEMA_SCALAR_KEYS = new Set([
+  'format',
+  'title',
+  'description',
+  'nullable',
+  'default',
+  'minItems',
+  'maxItems',
+  'enum',
+  'required',
+  'minProperties',
+  'maxProperties',
+  'minimum',
+  'maximum',
+  'minLength',
+  'maxLength',
+  'pattern',
+  'example',
+  'propertyOrdering',
+])
+
+function toVertexSchema(schema: unknown): GeminiVertexSchema {
+  if (!schema || typeof schema !== 'object' || Array.isArray(schema)) {
+    return {} as GeminiVertexSchema
+  }
+  const out: GeminiVertexSchema = {}
+  for (const [key, value] of Object.entries(schema as Record<string, unknown>)) {
+    if (key === 'type' && typeof value === 'string') {
+      out.type = value.toUpperCase()
+    } else if (key === 'properties' && value && typeof value === 'object') {
+      const properties: Record<string, GeminiVertexSchema> = {}
+      for (const [propName, propSchema] of Object.entries(
+        value as Record<string, unknown>,
+      )) {
+        properties[propName] = toVertexSchema(propSchema)
+      }
+      out.properties = properties
+    } else if (key === 'items') {
+      out.items = toVertexSchema(value)
+    } else if (key === 'anyOf' || key === 'oneOf') {
+      if (Array.isArray(value)) {
+        out.anyOf = value.map(s => toVertexSchema(s))
+      }
+    } else if (key === 'allOf') {
+      // Vertex doesn't support allOf; collapse to anyOf as a best-effort.
+      if (Array.isArray(value)) {
+        out.anyOf = value.map(s => toVertexSchema(s))
+      }
+    } else if (key === 'const') {
+      // Vertex rejects `const` but supports `enum`; translate to preserve the
+      // single-value constraint.
+      out.enum = [value]
+    } else if (key === 'exclusiveMinimum' && typeof value === 'number') {
+      // No exclusive bounds in the Vertex subset; approximate with `minimum`.
+      out.minimum = value
+    } else if (key === 'exclusiveMaximum' && typeof value === 'number') {
+      out.maximum = value
+    } else if (VERTEX_SCHEMA_SCALAR_KEYS.has(key)) {
+      out[key] = value
+    }
+    // Any other key (propertyNames, additionalProperties, $schema, $ref, if,
+    // patternProperties, ...) is silently dropped — Vertex would 400 on it.
+  }
+  return out
+}
+
+// Anthropic tool definitions → Vertex `tools: [{ functionDeclarations }]`.
+// Drops tools without an input_schema (e.g. server-side connector tools the
+// Anthropic SDK exposes that aren't function-calls) so they don't pollute the
+// declaration list.
+function toGeminiTools(
+  tools: MessageCreateParamsBase['tools'],
+): GeminiVertexTool[] | undefined {
+  if (!tools?.length) return undefined
+  const functionDeclarations: GeminiVertexFunctionDeclaration[] = []
+  for (const tool of tools) {
+    const t = tool as { name?: string; description?: string; input_schema?: unknown }
+    if (!t.name || !t.input_schema) continue
+    const declaration: GeminiVertexFunctionDeclaration = { name: t.name }
+    if (t.description) declaration.description = t.description
+    const parameters = toVertexSchema(t.input_schema)
+    if (Object.keys(parameters).length > 0) declaration.parameters = parameters
+    functionDeclarations.push(declaration)
+  }
+  if (!functionDeclarations.length) return undefined
+  return [{ functionDeclarations }]
+}
+
+// Translate Anthropic tool_choice (auto / any / tool / none) into Vertex's
+// toolConfig. Vertex defaults to AUTO when omitted, so we only emit the
+// config when a non-default behaviour is requested.
+function toGeminiToolConfig(
+  toolChoice: MessageCreateParamsBase['tool_choice'],
+  hasTools: boolean,
+): GeminiVertexToolConfig | undefined {
+  if (!hasTools) return undefined
+  if (!toolChoice) return undefined
+  const choice = toolChoice as { type?: string; name?: string }
+  if (choice.type === 'auto') {
+    return { functionCallingConfig: { mode: 'AUTO' } }
+  }
+  if (choice.type === 'none') {
+    return { functionCallingConfig: { mode: 'NONE' } }
+  }
+  if (choice.type === 'any') {
+    return { functionCallingConfig: { mode: 'ANY' } }
+  }
+  if (choice.type === 'tool' && choice.name) {
+    return {
+      functionCallingConfig: {
+        mode: 'ANY',
+        allowedFunctionNames: [choice.name],
+      },
+    }
+  }
+  return undefined
+}
+
+function safeJsonParse(value: unknown): Record<string, unknown> {
+  if (value && typeof value === 'object' && !Array.isArray(value)) {
+    return value as Record<string, unknown>
+  }
+  if (typeof value === 'string' && value.trim()) {
+    try {
+      const parsed = JSON.parse(value)
+      if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+        return parsed as Record<string, unknown>
+      }
+    } catch {
+      /* fall through */
+    }
+  }
+  return {}
+}
+
+function stringifyToolResultContent(content: unknown): string {
+  if (typeof content === 'string') return content
+  if (Array.isArray(content)) {
+    return content
+      .map(block => {
+        if (block && typeof block === 'object' && 'text' in block) {
+          return String((block as { text?: unknown }).text ?? '')
+        }
+        // ToolSearch results are tool_reference blocks with no text payload —
+        // render them so the model learns which deferred tools were loaded
+        // (their schemas arrive in the next request's tools array).
+        if (
+          block &&
+          typeof block === 'object' &&
+          (block as { type?: unknown }).type === 'tool_reference' &&
+          typeof (block as { tool_name?: unknown }).tool_name === 'string'
+        ) {
+          return `Tool "${(block as { tool_name: string }).tool_name}" is now loaded and available to call.`
+        }
+        return ''
+      })
+      .filter(Boolean)
+      .join('\n')
+  }
+  return ''
+}
+
+// Translate Anthropic message history → Vertex `contents`. Handles:
+//   - plain text on user/assistant turns
+//   - assistant tool_use blocks → model functionCall parts (keeps a name map
+//     so the subsequent tool_result can be wired back to the right function)
+//   - user tool_result blocks → user functionResponse parts, looking up the
+//     function name from the most recent tool_use with the same id
+// Drops blocks we can't translate (e.g. images) instead of failing the whole
+// request — Vertex will respond from whatever it received.
+function toGeminiContents(
+  messages: MessageCreateParamsBase['messages'],
+): GeminiVertexContent[] {
+  const toolUseIdToName = new Map<string, string>()
+  const out: GeminiVertexContent[] = []
+
+  for (const message of messages) {
+    const role: 'user' | 'model' = message.role === 'assistant' ? 'model' : 'user'
+    // Gemini's function-calling protocol expects a turn carrying
+    // functionResponse parts to be PURE (no text mixed in) and to immediately
+    // follow the model's functionCall turn. openclaude, however, appends
+    // system-reminder text blocks to the same user message as a tool_result —
+    // which would emit `user[functionResponse, text]`. Vertex then silently
+    // produces an empty response (finishReason STOP, 0 tokens). So we collect
+    // functionResponse parts separately and emit them in their own clean turn,
+    // pushing any accompanying text into a following user turn.
+    const responseParts: GeminiVertexPart[] = []
+    const otherParts: GeminiVertexPart[] = []
+
+    if (typeof message.content === 'string') {
+      if (message.content) otherParts.push({ text: message.content })
+    } else {
+      for (const block of message.content) {
+        const b = block as {
+          type?: string
+          text?: string
+          name?: string
+          id?: string
+          input?: unknown
+          tool_use_id?: string
+          content?: unknown
+        }
+        if (b.type === 'text' && typeof b.text === 'string' && b.text) {
+          otherParts.push({ text: b.text })
+        } else if (b.type === 'tool_use' && b.name && b.id) {
+          toolUseIdToName.set(b.id, b.name)
+          const { thoughtSignature } = decodeToolUseId(b.id)
+          const functionCallPart: GeminiVertexFunctionCallPart = {
+            functionCall: {
+              name: b.name,
+              args: safeJsonParse(b.input),
+            },
+          }
+          // Replay the thinking model's thoughtSignature so Vertex accepts the
+          // call in history (it 400s on functionCall parts missing it).
+          if (thoughtSignature) functionCallPart.thoughtSignature = thoughtSignature
+          otherParts.push(functionCallPart)
+        } else if (b.type === 'tool_result' && b.tool_use_id) {
+          const name = toolUseIdToName.get(b.tool_use_id) ?? 'tool'
+          responseParts.push({
+            functionResponse: {
+              name,
+              response: { result: stringifyToolResultContent(b.content) },
+            },
+          })
+        }
+      }
+    }
+
+    // Emit the pure functionResponse turn first (immediately after the model's
+    // functionCall), then any remaining text/other parts as a separate turn.
+    if (responseParts.length > 0) out.push({ role, parts: responseParts })
+    if (otherParts.length > 0) out.push({ role, parts: otherParts })
+  }
+  return out
+}
+
+// openclaude ships a large coding-agent system prompt as params.system. Vertex
+// expects it in the top-level `systemInstruction` field — passing it inside
+// `contents` would lose its role and confuse the model. Returns undefined if
+// the caller didn't send one (so we don't emit an empty instruction object).
+function toGeminiSystemInstruction(
+  system: MessageCreateParamsBase['system'],
+): GeminiVertexSystemInstruction | undefined {
+  if (!system) {
+    return undefined
+  }
+  const text = typeof system === 'string'
+    ? system
+    : system
+        .map(block => ('text' in block && typeof block.text === 'string' ? block.text : ''))
+        .filter(Boolean)
+        .join('\n')
+  if (!text.trim()) {
+    return undefined
+  }
+  return { parts: [{ text }] }
+}
+
+// Pull every visible-text part out of a Vertex response and concatenate.
+// Used both to detect empty-text outcomes and to build the final content
+// blocks. Function-call parts are surfaced separately by extractContentBlocks.
+function extractText(response: GeminiVertexResponse): string {
+  return (
+    response.candidates?.[0]?.content?.parts
+      ?.map(part => part.text ?? '')
+      .join('') ?? ''
+  )
+}
+
+let toolUseCounter = 0
+function nextToolUseId(): string {
+  // Anthropic IDs look like `toolu_01XXXXXXXX...`. Vertex doesn't provide an
+  // id with its functionCall, so we synthesise one stable per-call so the
+  // assistant message and any follow-up tool_result can correlate.
+  toolUseCounter = (toolUseCounter + 1) % Number.MAX_SAFE_INTEGER
+  return `toolu_vertex_${Date.now().toString(36)}_${toolUseCounter}`
+}
+
+// Gemini thinking models require the functionCall's thoughtSignature to be
+// replayed on the next turn. The Anthropic message shape has no field for it,
+// so we smuggle it through the tool_use `id` (preserved verbatim by the agent
+// loop, even across session save/restore). The `~~sig~~` delimiter can't appear
+// in our synthesised ids nor in a base64 signature, so decoding is unambiguous.
+const TOOL_USE_SIG_DELIM = '~~sig~~'
+
+function encodeToolUseId(baseId: string, thoughtSignature: string | undefined): string {
+  if (!thoughtSignature) return baseId
+  return `${baseId}${TOOL_USE_SIG_DELIM}${thoughtSignature}`
+}
+
+function decodeToolUseId(id: string): { thoughtSignature?: string } {
+  const idx = id.indexOf(TOOL_USE_SIG_DELIM)
+  if (idx === -1) return {}
+  const sig = id.slice(idx + TOOL_USE_SIG_DELIM.length)
+  return sig ? { thoughtSignature: sig } : {}
+}
+
+// Build Anthropic-shaped content blocks (text + tool_use) from Vertex parts,
+// preserving the original ordering. A response that mixes text and function
+// calls is valid and is what the agent loop needs to actually call tools.
+function extractContentBlocks(
+  response: GeminiVertexResponse,
+): GeminiVertexContentBlock[] {
+  const parts = response.candidates?.[0]?.content?.parts ?? []
+  const blocks: GeminiVertexContentBlock[] = []
+  let textBuffer = ''
+  const flushText = (): void => {
+    if (textBuffer) {
+      blocks.push({ type: 'text', text: textBuffer })
+      textBuffer = ''
+    }
+  }
+  for (const part of parts) {
+    if (typeof part.text === 'string' && part.text) {
+      textBuffer += part.text
+    } else if (part.functionCall?.name) {
+      flushText()
+      blocks.push({
+        type: 'tool_use',
+        id: encodeToolUseId(nextToolUseId(), part.thoughtSignature),
+        name: part.functionCall.name,
+        input: part.functionCall.args ?? {},
+      })
+    }
+  }
+  flushText()
+  return blocks
+}
+
+// Adapt the completed Vertex response to the Anthropic streaming event
+// sequence the rest of openclaude consumes. Emits one content_block_start /
+// delta / stop trio per block so the streaming accumulator builds the right
+// shape for multi-block (text + tool_use) responses.
+async function* toAnthropicStream(
+  message: GeminiVertexMessage,
+): AsyncGenerator<GeminiVertexStreamEvent> {
+  yield { type: 'message_start', message }
+  for (let index = 0; index < message.content.length; index++) {
+    const block = message.content[index]!
+    if (block.type === 'text') {
+      yield {
+        type: 'content_block_start',
+        index,
+        content_block: { type: 'text', text: '' },
+      }
+      if (block.text) {
+        yield {
+          type: 'content_block_delta',
+          index,
+          delta: { type: 'text_delta', text: block.text },
+        }
+      }
+      yield { type: 'content_block_stop', index }
+    } else {
+      yield {
+        type: 'content_block_start',
+        index,
+        content_block: {
+          type: 'tool_use',
+          id: block.id,
+          name: block.name,
+          input: {},
+        },
+      }
+      yield {
+        type: 'content_block_delta',
+        index,
+        delta: {
+          type: 'input_json_delta',
+          partial_json: JSON.stringify(block.input ?? {}),
+        },
+      }
+      yield { type: 'content_block_stop', index }
+    }
+  }
+  yield {
+    type: 'message_delta',
+    delta: { stop_reason: message.stop_reason, stop_sequence: null },
+    usage: { output_tokens: message.usage.output_tokens },
+  }
+  yield { type: 'message_stop' }
+}
+
+export function createGeminiVertexClient(options: GeminiVertexClientOptions) {
+  const fetchImpl = options.fetch ?? fetch
+
+  const create = (params: MessageCreateParamsBase & { stream?: boolean }): GeminiVertexPromise => {
+    let capturedResponse: Response | undefined
+    const promise = (async (): Promise<GeminiVertexMessage> => {
+      const model = options.model
+      const token = await options.getAccessToken()
+      const host = options.location === 'global'
+        ? 'aiplatform.googleapis.com'
+        : `${options.location}-aiplatform.googleapis.com`
+      const url = `https://${host}/v1/projects/${options.project}/locations/${options.location}/publishers/google/models/${model}:generateContent`
+
+      const thinking = isThinkingModel(model)
+
+      // For thinking models, raise the floor so the model has room to think
+      // *and* still emit visible output. Honor the caller's value when it's
+      // already large enough — only boost when the requested budget would
+      // certainly be eaten by the thinking phase.
+      const requestedMaxTokens = params.max_tokens
+      const effectiveMaxTokens = thinking
+        ? Math.max(requestedMaxTokens ?? 0, THINKING_MODEL_MIN_OUTPUT_TOKENS)
+        : requestedMaxTokens
+
+      // Gemini 3 thinking models misbehave below temperature 1.0: Google warns
+      // it "may lead to unexpected behavior, such as looping or degraded
+      // performance". In practice the model burns its budget thinking and then
+      // emits ZERO text parts (finishReason STOP, empty response). openclaude,
+      // like most coding agents, sends a low temperature for determinism — so
+      // we clamp thinking models to the documented 1.0 floor. Non-thinking
+      // models keep the caller's temperature untouched.
+      const effectiveTemperature = thinking
+        ? Math.max(params.temperature ?? 1, 1)
+        : params.temperature
+
+      const systemInstruction = toGeminiSystemInstruction(params.system)
+      const tools = toGeminiTools(params.tools)
+      const toolConfig = toGeminiToolConfig(params.tool_choice, Boolean(tools))
+      const contents = toGeminiContents(params.messages)
+
+      const response = await fetchImpl(url, {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${token}`,
+          'Content-Type': 'application/json',
+          'x-goog-user-project': options.project,
+        },
+        body: JSON.stringify({
+          contents,
+          ...(systemInstruction ? { systemInstruction } : {}),
+          // Forward tool definitions so the model emits well-formed
+          // functionCall parts instead of inventing syntax that Vertex
+          // rejects with finishReason=MALFORMED_FUNCTION_CALL. Without
+          // this, any agentic prompt (which always declares tools) returns
+          // an empty, unusable response.
+          ...(tools ? { tools } : {}),
+          ...(toolConfig ? { toolConfig } : {}),
+          generationConfig: {
+            ...(effectiveMaxTokens !== undefined
+              ? { maxOutputTokens: effectiveMaxTokens }
+              : {}),
+            ...(effectiveTemperature !== undefined
+              ? { temperature: effectiveTemperature }
+              : {}),
+          },
+        }),
+      })
+      capturedResponse = response
+
+      if (!response.ok) {
+        const body = await response.text()
+        throw new Error(`Gemini Vertex request failed: ${response.status} ${body}`)
+      }
+
+      const json = (await response.json()) as GeminiVertexResponse
+      const contentBlocks = extractContentBlocks(json)
+      const text = extractText(json)
+      const candidate = json.candidates?.[0]
+      const finishReason = candidate?.finishReason
+      const thoughtsTokenCount = json.usageMetadata?.thoughtsTokenCount ?? 0
+      const hasToolCall = contentBlocks.some(b => b.type === 'tool_use')
+
+      // Surface every silent-empty-response path explicitly. We treat the
+      // response as empty only when the candidate produced neither text nor
+      // a function call — a function-call-only turn is a perfectly valid
+      // agent response and must be passed through to the orchestrator.
+      if (!text && !hasToolCall) {
+        // 1. Prompt-level block: Vertex refuses to process the input before
+        //    producing any candidate (safety filter at the prompt layer).
+        const promptBlock = json.promptFeedback?.blockReason
+        if (promptBlock) {
+          const detail =
+            json.promptFeedback?.blockReasonMessage ??
+            summarizeBlockedSafetyRatings(json.promptFeedback?.safetyRatings)
+          throw new Error(
+            `Gemini Vertex blocked the prompt (${promptBlock})${detail ? `: ${detail}` : ''}. ` +
+              `Try a less sensitive prompt or another Vertex model.`,
+          )
+        }
+
+        // 2. Thinking model exhausted its output budget on internal reasoning.
+        if (finishReason === 'MAX_TOKENS') {
+          const usedForThinking = thoughtsTokenCount > 0
+            ? ` (${thoughtsTokenCount} tokens consumed by internal thinking)`
+            : ''
+          throw new Error(
+            `Gemini Vertex returned no visible text: hit MAX_TOKENS${usedForThinking}. ` +
+              `Model "${model}" likely needs a larger maxOutputTokens budget. ` +
+              `Try a non-thinking model (e.g. gemini-2.5-flash) or raise the budget.`,
+          )
+        }
+
+        // 3. Candidate-level safety / recitation / blocklist refusal.
+        if (
+          finishReason === 'SAFETY' ||
+          finishReason === 'RECITATION' ||
+          finishReason === 'BLOCKLIST' ||
+          finishReason === 'PROHIBITED_CONTENT' ||
+          finishReason === 'SPII'
+        ) {
+          const detail = summarizeBlockedSafetyRatings(candidate?.safetyRatings)
+          throw new Error(
+            `Gemini Vertex refused to answer (${finishReason})${detail}. ` +
+              `Try rephrasing or another Vertex model.`,
+          )
+        }
+
+        // 4. Malformed function call: the model tried to emit a tool call
+        //    Vertex couldn't parse. Almost always means tools weren't passed
+        //    or the schema was unparseable. The toGeminiTools/toVertexSchema
+        //    pipeline above should prevent this, but surface a clear error
+        //    if it still happens (e.g. an unusual tool definition).
+        if (finishReason === 'MALFORMED_FUNCTION_CALL') {
+          throw new Error(
+            `Gemini Vertex emitted a malformed function call from "${model}". ` +
+              `This usually indicates a tool schema Vertex couldn't parse. ` +
+              `Try another model or remove a recently-added custom tool.`,
+          )
+        }
+
+        // 5. Catch-all: model finished normally (STOP / OTHER / undefined)
+        //    but produced no text or function call. Surface it — with a compact
+        //    diagnostic of the raw response — instead of silently dropping, so
+        //    the true cause (thought-only output, empty parts, blocked content)
+        //    is visible from one test rather than guessed at.
+        throw new Error(
+          `Gemini Vertex returned an empty response from "${model}"` +
+            `${finishReason ? ` (finishReason: ${finishReason})` : ''}. ` +
+            `This usually means the model couldn't generate output for this prompt — try another model or rephrase. ` +
+            diagnoseEmptyResponse(json) +
+            ' ' +
+            summarizeRequestContents(contents),
+        )
+      }
+
+      const finalBlocks: GeminiVertexContentBlock[] =
+        contentBlocks.length > 0
+          ? contentBlocks
+          : [{ type: 'text', text }]
+
+      return {
+        id: `gemini-vertex-${Date.now()}`,
+        type: 'message',
+        role: 'assistant',
+        model,
+        stop_reason: hasToolCall ? 'tool_use' : 'end_turn',
+        stop_sequence: null,
+        usage: {
+          input_tokens: json.usageMetadata?.promptTokenCount ?? 0,
+          output_tokens: json.usageMetadata?.candidatesTokenCount ?? 0,
+        },
+        content: finalBlocks,
+      }
+    })()
+
+    const typed = promise as GeminiVertexPromise
+    typed.withResponse = async () => {
+      const data = await promise
+      const response = capturedResponse ?? new Response()
+      return {
+        data: toAnthropicStream(data),
+        response,
+        request_id: response.headers.get('x-request-id') ?? data.id,
+      }
+    }
+
+    return typed
+  }
+
+  const messages = { create }
+
+  return {
+    messages,
+    beta: { messages },
+  }
+}

--- a/src/utils/geminiAuth.test.ts
+++ b/src/utils/geminiAuth.test.ts
@@ -239,6 +239,14 @@ describe('Gemini auth helpers', () => {
       'gcloud-project',
     )
 
+    // Leading/trailing whitespace is trimmed from real values.
+    expect(
+      getGeminiVertexLocation({ GEMINI_VERTEX_LOCATION: '  europe-west4  ' }),
+    ).toBe('europe-west4')
+    expect(
+      getGeminiVertexProjectId({ GEMINI_VERTEX_PROJECT: '  vertex-project  ' }),
+    ).toBe('vertex-project')
+
     // Blank / whitespace-only values are treated as unset, not as overrides.
     expect(getGeminiVertexLocation({ GEMINI_VERTEX_LOCATION: '  ' })).toBe('global')
     expect(

--- a/src/utils/geminiAuth.test.ts
+++ b/src/utils/geminiAuth.test.ts
@@ -7,6 +7,8 @@ import {
 } from '../test/sharedMutationLock.js'
 import {
   getGeminiProjectIdHint,
+  getGeminiVertexLocation,
+  getGeminiVertexModel,
   mayHaveGeminiAdcCredentials,
   resolveGeminiCredential,
 } from './geminiAuth.ts'
@@ -35,6 +37,14 @@ function restoreEnv(key: string, value: string | undefined): void {
 
 beforeEach(async () => {
   await acquireSharedMutationLock('utils/geminiAuth.test.ts')
+  delete process.env.GEMINI_API_KEY
+  delete process.env.GOOGLE_API_KEY
+  delete process.env.GEMINI_ACCESS_TOKEN
+  delete process.env.GEMINI_AUTH_MODE
+  delete process.env.GOOGLE_APPLICATION_CREDENTIALS
+  delete process.env.GOOGLE_CLOUD_PROJECT
+  delete process.env.GCLOUD_PROJECT
+  delete process.env.GOOGLE_PROJECT_ID
 })
 
 afterEach(() => {
@@ -121,7 +131,13 @@ describe('resolveGeminiCredential', () => {
       delete process.env.GEMINI_ACCESS_TOKEN
       delete process.env.GOOGLE_APPLICATION_CREDENTIALS
 
-      await expect(resolveGeminiCredential(process.env)).resolves.toEqual({
+      await expect(
+        resolveGeminiCredential(process.env, {
+          createGoogleAuth: async () => {
+            throw new Error('unexpected ADC lookup')
+          },
+        }),
+      ).resolves.toEqual({
         kind: 'none',
       })
     } finally {
@@ -188,6 +204,11 @@ describe('resolveGeminiCredential', () => {
 })
 
 describe('Gemini auth helpers', () => {
+  test('defaults Vertex to global endpoint and current flash model', () => {
+    expect(getGeminiVertexLocation({})).toBe('global')
+    expect(getGeminiVertexModel({})).toBe('gemini-2.5-flash')
+  })
+
   test('detects explicit project id hints', () => {
     process.env.GOOGLE_PROJECT_ID = 'project-a'
     expect(getGeminiProjectIdHint(process.env)).toBe('project-a')

--- a/src/utils/geminiAuth.test.ts
+++ b/src/utils/geminiAuth.test.ts
@@ -9,6 +9,7 @@ import {
   getGeminiProjectIdHint,
   getGeminiVertexLocation,
   getGeminiVertexModel,
+  getGeminiVertexProjectId,
   mayHaveGeminiAdcCredentials,
   resolveGeminiCredential,
 } from './geminiAuth.ts'
@@ -207,6 +208,45 @@ describe('Gemini auth helpers', () => {
   test('defaults Vertex to global endpoint and current flash model', () => {
     expect(getGeminiVertexLocation({})).toBe('global')
     expect(getGeminiVertexModel({})).toBe('gemini-2.5-flash')
+  })
+
+  test('explicit GEMINI_VERTEX_* overrides win over defaults and Google fallbacks', () => {
+    // Location and model: explicit override beats the default.
+    expect(
+      getGeminiVertexLocation({ GEMINI_VERTEX_LOCATION: 'europe-west4' }),
+    ).toBe('europe-west4')
+    expect(
+      getGeminiVertexModel({ GEMINI_VERTEX_MODEL: 'gemini-2.5-pro' }),
+    ).toBe('gemini-2.5-pro')
+
+    // Project precedence: GEMINI_VERTEX_PROJECT > GOOGLE_CLOUD_PROJECT >
+    // GCLOUD_PROJECT > GOOGLE_PROJECT_ID.
+    expect(
+      getGeminiVertexProjectId({
+        GEMINI_VERTEX_PROJECT: 'vertex-project',
+        GOOGLE_CLOUD_PROJECT: 'gcp-project',
+        GCLOUD_PROJECT: 'gcloud-project',
+        GOOGLE_PROJECT_ID: 'legacy-project',
+      }),
+    ).toBe('vertex-project')
+    expect(
+      getGeminiVertexProjectId({
+        GOOGLE_CLOUD_PROJECT: 'gcp-project',
+        GCLOUD_PROJECT: 'gcloud-project',
+      }),
+    ).toBe('gcp-project')
+    expect(getGeminiVertexProjectId({ GCLOUD_PROJECT: 'gcloud-project' })).toBe(
+      'gcloud-project',
+    )
+
+    // Blank / whitespace-only values are treated as unset, not as overrides.
+    expect(getGeminiVertexLocation({ GEMINI_VERTEX_LOCATION: '  ' })).toBe('global')
+    expect(
+      getGeminiVertexProjectId({
+        GEMINI_VERTEX_PROJECT: '',
+        GOOGLE_PROJECT_ID: 'legacy-project',
+      }),
+    ).toBe('legacy-project')
   })
 
   test('detects explicit project id hints', () => {

--- a/src/utils/geminiAuth.ts
+++ b/src/utils/geminiAuth.ts
@@ -59,6 +59,30 @@ export function getGeminiProjectIdHint(
   )
 }
 
+export function getGeminiVertexProjectId(
+  env: NodeJS.ProcessEnv = process.env,
+): string | undefined {
+  return (
+    sanitizeCredential(env.GEMINI_VERTEX_PROJECT) ??
+    getGeminiProjectIdHint(env)
+  )
+}
+
+const DEFAULT_GEMINI_VERTEX_LOCATION = 'global'
+export const DEFAULT_GEMINI_VERTEX_MODEL = 'gemini-2.5-flash'
+
+export function getGeminiVertexLocation(
+  env: NodeJS.ProcessEnv = process.env,
+): string {
+  return sanitizeCredential(env.GEMINI_VERTEX_LOCATION) ?? DEFAULT_GEMINI_VERTEX_LOCATION
+}
+
+export function getGeminiVertexModel(
+  env: NodeJS.ProcessEnv = process.env,
+): string | undefined {
+  return sanitizeCredential(env.GEMINI_VERTEX_MODEL) ?? DEFAULT_GEMINI_VERTEX_MODEL
+}
+
 export function getGeminiAuthMode(
   env: NodeJS.ProcessEnv = process.env,
 ): GeminiAuthMode | undefined {


### PR DESCRIPTION
## What & why

First of three focused PRs re-submitting the native Gemini-on-Vertex provider, following the review feedback on #1428 (closed: too large, provider reference-list drift). This PR is the standalone foundation — no call sites, no behavior change:

- `src/services/api/geminiVertexClient.ts`: Anthropic-shaped client for the Vertex AI `generateContent` API — message and tool conversion (`functionCall`/`functionResponse`, thought-signature replay required by Gemini thinking models), system-instruction mapping, streaming + non-streaming with the `withResponse` contract, thinking-model temperature/output floors, ToolSearch `tool_reference` rendering.
- `src/utils/geminiAuth.ts`: Vertex helpers — project/location/model resolution from `GEMINI_VERTEX_*` env with Google Cloud fallbacks, access-token / ADC credential resolution with injectable `GoogleAuth` for tests.

## Follow-up stack

- **2/3 — provider routing & selection**: wires `CLAUDE_CODE_USE_GEMINI_VERTEX` end-to-end and fixes both review findings from #1428 (P1 startup-selection precedence incl. `hasProviderSelectionFlags()`/`hasCompleteProviderSelection()`, P2 bootstrap cache scope), plus a single source of truth for provider-selection flags with a parity test so the list drift cannot recur.
- **3/3 — profiles & UI**: `/provider` integration, profile env shaping, launcher.

## Impact

None until the follow-up PRs land: these are new files plus unused auth helpers. Existing providers are untouched.

## Checks run

- `bun test src/services/api/geminiVertexClient.test.ts src/utils/geminiAuth.test.ts` → 22 pass / 0 fail
- `tsc --noEmit` → 0 errors
- `bun run test:provider` → 703 pass / 0 fail
- `bun run build` → clean (bundle guard OK)

## Provider paths tested

Gemini Vertex (unit-level against a mocked `generateContent` endpoint: global + regional hosts, ADC and access-token auth). End-to-end provider testing is covered in PR 2/3 where the routing lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for Google Gemini Vertex provider with streaming, tool/function calling, and default Vertex config (project, location: global, model: Gemini 2.5 Flash).

* **Behavior Changes / Bug Fixes**
  * Better handling and diagnostics for silent/empty responses, clamped thinking-model temperatures, preserved non-thinking behavior, and improved tool/parameter schema compatibility and function-call round-tripping.

* **Tests**
  * Expanded tests covering Vertex integration, auth resolution, streaming, tool handling, and error propagation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->