### PR TITLE
fix(tool-search): enable MCP tool deferral on converted-wire providers

### DIFF
--- a/src/services/api/codexShim.test.ts
+++ b/src/services/api/codexShim.test.ts
@@ -695,6 +695,46 @@ describe('Codex request translation', () => {
     ])
   })
 
+  test('renders tool_reference blocks from ToolSearch results as readable text', () => {
+    const items = convertAnthropicMessagesToResponsesInput([
+      {
+        role: 'assistant',
+        content: [
+          { type: 'tool_use', id: 'call_ts1', name: 'ToolSearch', input: { query: 'memory' } },
+        ],
+      },
+      {
+        role: 'user',
+        content: [
+          {
+            type: 'tool_result',
+            tool_use_id: 'call_ts1',
+            content: [
+              { type: 'tool_reference', tool_name: 'mcp__example__memory_search' },
+              { type: 'tool_reference', tool_name: 'mcp__example__memory_store' },
+            ],
+          },
+        ],
+      },
+    ])
+
+    const output = items.find(item => item.type === 'function_call_output') as
+      | { type: 'function_call_output'; output: string }
+      | undefined
+    expect(output).toBeDefined()
+    expect(output!.output).toContain('mcp__example__memory_search')
+    expect(output!.output).toContain('mcp__example__memory_store')
+  })
+
+  test('keeps the ToolSearch tool in the Responses tools list', () => {
+    const tools = convertToolsToResponsesTools([
+      { name: 'ToolSearch', description: 'Find deferred tools', input_schema: { type: 'object', properties: { query: { type: 'string' } }, required: ['query'] } },
+      { name: 'Read', description: 'Read a file', input_schema: { type: 'object', properties: {} } },
+    ])
+
+    expect(tools.map(t => t.name)).toEqual(['ToolSearch', 'Read'])
+  })
+
   test('converts completed Codex tool response into Anthropic message', () => {
     const message = convertCodexResponseToAnthropicMessage(
       {

--- a/src/services/api/codexShim.ts
+++ b/src/services/api/codexShim.ts
@@ -150,6 +150,15 @@ function convertToolResultToText(content: unknown): string {
       continue
     }
 
+    // ToolSearch results are tool_reference blocks with no text payload. On
+    // the Anthropic wire the API expands them server-side; here we render
+    // them as text — the full schema arrives in the next request's tools
+    // array (see the discovered-tools filter in claude.ts).
+    if (block?.type === 'tool_reference' && typeof block.tool_name === 'string') {
+      chunks.push(`Tool "${block.tool_name}" is now loaded and available to call.`)
+      continue
+    }
+
     if (block?.type === 'image') {
       const src = block.source
       if (src?.type === 'url' && src.url) {
@@ -457,8 +466,10 @@ function enforceStrictSchema(schema: unknown): Record<string, unknown> {
 export function convertToolsToResponsesTools(
   tools: Array<{ name?: string; description?: string; input_schema?: Record<string, unknown> }>,
 ): ResponsesTool[] {
+  // Note: ToolSearch (the deferral discovery tool) must reach the wire as a
+  // regular function — claude.ts already removes it when tool search is off.
   return tools
-    .filter(tool => tool.name && tool.name !== 'ToolSearchTool')
+    .filter(tool => tool.name)
     .map(tool => {
       const rawParameters = tool.input_schema ?? { type: 'object', properties: {} }
       // Codex requires strict schemas: all properties must be required

--- a/src/services/api/openaiShim.test.ts
+++ b/src/services/api/openaiShim.test.ts
@@ -6587,3 +6587,40 @@ test('DeepSeek: redacted_thinking block with non-empty data propagates data into
     'encrypted_chain_of_thought_payload_v1',
   )
 })
+
+test('renders tool_reference blocks as text on the chat/completions path', async () => {
+  const { __test } = await import('./openaiShim.ts')
+
+  const messages = __test.convertMessages(
+    [
+      {
+        role: 'assistant',
+        content: [
+          { type: 'tool_use', id: 'call_ts1', name: 'ToolSearch', input: { query: 'memory' } },
+        ],
+      },
+      {
+        role: 'user',
+        content: [
+          {
+            type: 'tool_result',
+            tool_use_id: 'call_ts1',
+            content: [
+              { type: 'tool_reference', tool_name: 'mcp__example__memory_search' },
+              { type: 'tool_reference', tool_name: 'mcp__example__memory_store' },
+            ],
+          },
+        ],
+      },
+    ],
+    undefined,
+  )
+
+  const toolMsg = messages.find(m => m.role === 'tool')
+  expect(toolMsg).toBeDefined()
+  const content = typeof toolMsg!.content === 'string'
+    ? toolMsg!.content
+    : JSON.stringify(toolMsg!.content)
+  expect(content).toContain('mcp__example__memory_search')
+  expect(content).toContain('mcp__example__memory_store')
+})

--- a/src/services/api/openaiShim.test.ts
+++ b/src/services/api/openaiShim.test.ts
@@ -6618,9 +6618,9 @@ test('renders tool_reference blocks as text on the chat/completions path', async
 
   const toolMsg = messages.find(m => m.role === 'tool')
   expect(toolMsg).toBeDefined()
-  const content = typeof toolMsg!.content === 'string'
-    ? toolMsg!.content
-    : JSON.stringify(toolMsg!.content)
+  // The rendering contract is plain text: text-only parts collapse to a string.
+  expect(typeof toolMsg!.content).toBe('string')
+  const content = toolMsg!.content as string
   expect(content).toContain('mcp__example__memory_search')
   expect(content).toContain('mcp__example__memory_store')
 })

--- a/src/services/api/openaiShim.ts
+++ b/src/services/api/openaiShim.ts
@@ -356,6 +356,17 @@ function convertToolResultContent(
       continue
     }
 
+    // ToolSearch results are tool_reference blocks with no text payload —
+    // render them so the model learns which deferred tools were loaded
+    // (their schemas arrive in the next request's tools array).
+    if (block?.type === 'tool_reference' && typeof block.tool_name === 'string') {
+      parts.push({
+        type: 'text',
+        text: `Tool "${block.tool_name}" is now loaded and available to call.`,
+      })
+      continue
+    }
+
     if (block?.type === 'image') {
       const source = block.source
       if (source?.type === 'url' && source.url) {

--- a/src/services/api/openaiShim.ts
+++ b/src/services/api/openaiShim.ts
@@ -3223,3 +3223,6 @@ export function createOpenAIShimClient(options: {
     messages: beta.messages,
   }
 }
+
+// Test-only surface (same pattern as WebSearchTool's __test export).
+export const __test = { convertMessages }

--- a/src/utils/toolSearch.test.ts
+++ b/src/utils/toolSearch.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, test } from 'bun:test'
+import { resolveToolSearchMode } from './toolSearch.js'
+
+describe('resolveToolSearchMode', () => {
+  test('defaults to tst when nothing is configured', () => {
+    expect(resolveToolSearchMode({}, 'firstParty')).toBe('tst')
+    expect(resolveToolSearchMode({}, 'codex')).toBe('tst')
+  })
+
+  test('kill switch forces standard mode on Anthropic-wire providers', () => {
+    const env = { CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS: 'true' }
+    expect(resolveToolSearchMode(env, 'firstParty')).toBe('standard')
+    expect(resolveToolSearchMode(env, 'bedrock')).toBe('standard')
+    expect(resolveToolSearchMode(env, 'vertex')).toBe('standard')
+    expect(resolveToolSearchMode(env, 'foundry')).toBe('standard')
+    expect(resolveToolSearchMode(env, 'minimax')).toBe('standard')
+  })
+
+  test('kill switch does not disable tool search on converted-wire providers', () => {
+    // The OpenAI shims and the Gemini Vertex client convert every message and
+    // tool definition client-side — no Anthropic beta shape reaches the wire,
+    // so the beta kill switch has nothing to protect there.
+    const env = { CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS: 'true' }
+    expect(resolveToolSearchMode(env, 'codex')).toBe('tst')
+    expect(resolveToolSearchMode(env, 'openai')).toBe('tst')
+    expect(resolveToolSearchMode(env, 'github')).toBe('tst')
+    expect(resolveToolSearchMode(env, 'gemini')).toBe('tst')
+    expect(resolveToolSearchMode(env, 'mistral')).toBe('tst')
+  })
+
+  test('explicit ENABLE_TOOL_SEARCH=false still disables everywhere', () => {
+    const env = { ENABLE_TOOL_SEARCH: 'false' }
+    expect(resolveToolSearchMode(env, 'codex')).toBe('standard')
+    expect(resolveToolSearchMode(env, 'firstParty')).toBe('standard')
+  })
+
+  test('auto mode is preserved on converted-wire providers despite kill switch', () => {
+    const env = {
+      CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS: 'true',
+      ENABLE_TOOL_SEARCH: 'auto',
+    }
+    expect(resolveToolSearchMode(env, 'codex')).toBe('tst-auto')
+    expect(resolveToolSearchMode(env, 'firstParty')).toBe('standard')
+  })
+})

--- a/src/utils/toolSearch.ts
+++ b/src/utils/toolSearch.ts
@@ -37,6 +37,7 @@ import { isEnvDefinedFalsy, isEnvTruthy } from './envUtils.js'
 import {
   getAPIProvider,
   isFirstPartyAnthropicBaseUrl,
+  type LegacyAPIProvider,
 } from './model/providers.js'
 import { jsonStringify } from './slowOperations.js'
 import { zodToJsonSchema } from './zodToJsonSchema.js'
@@ -169,20 +170,53 @@ export type ToolSearchMode = 'tst' | 'tst-auto' | 'standard'
  *   false / auto:100      standard
  *   (unset)               tst (default: always defer MCP and shouldDefer tools)
  */
-export function getToolSearchMode(): ToolSearchMode {
+/**
+ * Providers whose requests leave on the raw Anthropic wire format. Tool search
+ * emits beta API shapes there (defer_loading on tool definitions,
+ * tool_reference content blocks, the beta header), so the experimental-betas
+ * kill switch must be honoured. Every other provider goes through a converter
+ * (OpenAI shims, Gemini Vertex client) that re-renders those shapes into
+ * plain text / plain function schemas — no beta shape ever reaches the wire,
+ * so the kill switch has nothing to protect and must not disable deferral
+ * (sending hundreds of inline MCP tools crashes e.g. the Codex backend).
+ */
+const ANTHROPIC_WIRE_PROVIDERS: ReadonlySet<LegacyAPIProvider> = new Set([
+  'firstParty',
+  'bedrock',
+  'vertex',
+  'foundry',
+  'minimax',
+])
+
+/**
+ * Pure resolver for the tool search mode — injectable env/provider for tests.
+ */
+export function resolveToolSearchMode(
+  env: {
+    ENABLE_TOOL_SEARCH?: string
+    CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS?: string
+    [key: string]: string | undefined
+  },
+  provider: LegacyAPIProvider,
+): ToolSearchMode {
   // CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS is a kill switch for beta API
   // features. Tool search emits defer_loading on tool definitions and
   // tool_reference content blocks — both require the API to accept a beta
   // header. When the kill switch is set, force 'standard' so no beta shapes
   // reach the wire, even if ENABLE_TOOL_SEARCH is also set. This is the
   // explicit escape hatch for proxy gateways that the heuristic in
-  // isToolSearchEnabledOptimistic doesn't cover.
+  // isToolSearchEnabledOptimistic doesn't cover. Scoped to Anthropic-wire
+  // providers: converted wires (OpenAI shims, Gemini Vertex) never carry
+  // beta shapes, so deferral stays available there.
   // github.com/anthropics/claude-code/issues/20031
-  if (isEnvTruthy(process.env.CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS)) {
+  if (
+    isEnvTruthy(env.CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS) &&
+    ANTHROPIC_WIRE_PROVIDERS.has(provider)
+  ) {
     return 'standard'
   }
 
-  const value = process.env.ENABLE_TOOL_SEARCH
+  const value = env.ENABLE_TOOL_SEARCH
 
   // Handle auto:N syntax - check edge cases first
   const autoPercent = value ? parseAutoPercentage(value) : null
@@ -193,8 +227,12 @@ export function getToolSearchMode(): ToolSearchMode {
   }
 
   if (isEnvTruthy(value)) return 'tst'
-  if (isEnvDefinedFalsy(process.env.ENABLE_TOOL_SEARCH)) return 'standard'
+  if (isEnvDefinedFalsy(value)) return 'standard'
   return 'tst' // default: always defer MCP and shouldDefer tools
+}
+
+export function getToolSearchMode(): ToolSearchMode {
+  return resolveToolSearchMode(process.env, getAPIProvider())
 }
 
 /**


### PR DESCRIPTION
## What & why

`CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS` (defaulted on since #281) forces tool search to `standard` mode everywhere, so OpenAI-compatible providers receive **every MCP tool inline**. With a large MCP server (claude-flow exposes 293 tools, ~306 KB of JSON schemas per request) the ChatGPT Codex backend accepts the request (HTTP 200) and then crashes mid-stream at reasoning start with a generic `server_error` — surfaced to the user as a persistent, opaque `API Error: 500` that retries can never fix.

The kill switch exists to keep Anthropic beta shapes (`defer_loading`, `tool_reference` blocks, beta headers) off the wire for accounts without the betas. Converted wires never carry those shapes, so this PR:

- scopes the kill switch to Anthropic-wire providers only (`firstParty`/`bedrock`/`vertex`/`foundry`/`minimax`), via a pure, testable `resolveToolSearchMode(env, provider)` (`src/utils/toolSearch.ts`)
- renders ToolSearch `tool_reference` results as plain text in `codexShim.ts` (Responses path) and `openaiShim.ts` (chat/completions path) — previously these blocks were silently dropped and the model received an empty tool result; the full schemas already arrive in the next request's tools array via the existing discovered-tools filter
- removes a dead filter in `codexShim.ts` that targeted a tool name that does not exist

## Impact

Users with large MCP servers can use them on Codex / OpenAI-compatible providers instead of hitting a deterministic 500. Tool palettes shrink to native tools + ToolSearch (requests roughly 3x lighter in the 293-tool case). Anthropic-wire behavior is unchanged — the kill switch still applies there, matching the intent of #281.

## Checks run

- `bun test src/utils/toolSearch.test.ts src/services/api/codexShim.test.ts src/services/api/openaiShim.test.ts` → 168+ pass / 0 fail (new tests for the mode resolver and the tool_reference rendering on both paths)
- `tsc --noEmit` → 0 errors

## Provider paths tested

Codex OAuth end-to-end on a real session carrying 343 tools (293 from an MCP server): deterministic `API Error: 500` before, completes after — the model defers, searches, loads and calls MCP tools across multiple turns. chat/completions path covered by unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Tool-reference blocks now render as readable text and consistently indicate when referenced tools are loaded and callable.
  * Tool-list conversion no longer omits tool-search entries where they should remain available.

* **Refactor**
  * Provider-aware tool-search mode resolution introduced to ensure correct behavior across different API providers and environment settings.

* **Tests**
  * Added tests for tool-reference rendering and provider-aware tool-search mode.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->