### PR TITLE
perf(cli): restore --version fast path with dynamic provider imports

### DIFF
--- a/src/entrypoints/cli.tsx
+++ b/src/entrypoints/cli.tsx
@@ -1,13 +1,4 @@
 import { feature } from 'bun:bundle';
-import {
-  applyProfileEnvToProcessEnv,
-  buildStartupEnvFromProfile,
-  isDefaultStartupProviderEnv,
-} from '../utils/providerProfile.js'
-import {
-  getProviderValidationError,
-  validateProviderEnvForStartupOrExit,
-} from '../utils/providerValidation.js'
 
 // OpenClaude: polyfill globalThis.File for Node < 20.
 // undici v7 references `File` at module evaluation time (webidl type
@@ -113,10 +104,18 @@ async function main(): Promise<void> {
     applySafeConfigEnvironmentVariables()
   }
 
+  const {
+    applyProfileEnvToProcessEnv,
+    buildStartupEnvFromProfile,
+    isDefaultStartupProviderEnv,
+  } = await import('../utils/providerProfile.js')
   const startupEnv = await buildStartupEnvFromProfile({
     processEnv: process.env,
   })
   if (startupEnv !== process.env) {
+    const { getProviderValidationError } = await import(
+      '../utils/providerValidation.js'
+    )
     const startupProfileError = await getProviderValidationError(startupEnv)
     if (startupProfileError && !isDefaultStartupProviderEnv(startupEnv)) {
       console.error(
@@ -169,6 +168,9 @@ async function main(): Promise<void> {
     hydrateGithubModelsTokenFromSecureStorage()
   }
 
+  const { validateProviderEnvForStartupOrExit } = await import(
+    '../utils/providerValidation.js'
+  )
   await validateProviderEnvForStartupOrExit()
 
   // #808: --model alone (no --provider) — route to the env var matching the


### PR DESCRIPTION
Summary

  - What changed: Removed the static top-of-file imports of ../utils/providerProfile.js and ../utils/providerValidation.js in src/entrypoints/cli.tsx and converted them to dynamic await import() at their actual
  use sites (the startup-env block and the validateProviderEnvForStartupOrExit call).
  - Why it changed: providerValidation.js has a side-effect import of src/integrations/index.ts, which (before this stack) eagerly evaluated the entire integrations descriptor graph (~10k lines of
  vendor/gateway/model catalogs) at module load. Because these were static imports at the top of cli.tsx, every invocation — including the zero-import --version/-v fast path — paid that cost. Making them dynamic
  restores the fast path and matches the file's existing convention (40+ dynamic imports already).

  Impact

  - User-facing impact: openclaude --version / -v (and any fast-exit path that returns before provider validation) is noticeably quicker — measured ~0.47s median (0.35–0.60s) → steady ~0.26s. Normal interactive
  startup is unchanged: the same provider profile/validation logic runs at the same point, just imported on demand.
  - Developer/maintainer impact: cli.tsx no longer has any runtime static imports beyond the compile-time bun:bundle helper; the two provider util modules are evaluated only on paths that use them. No API or
  signature changes.

  Testing

  - [x] bun run build
  - [x] bun run smoke
  - [ ] bun run check
  - [x] focused tests: bun test src/utils/providerProfile.test.ts src/utils/providerProfiles.test.ts src/utils/providerFlag.test.ts src/utils/providerValidation.test.ts → 269 pass, 0 fail. Also bun run typecheck
  clean.

  Notes

  - Provider/model path tested: ran node dist/cli.mjs --provider not-a-real-provider against the built bundle — it correctly errors and lists the full provider registry (anthropic, openai, gemini, … all 35),
  confirming the now-dynamically-imported validation path still loads and resolves end to end. --version and --help verified through the built bundle.
  - Screenshots attached (if UI changed): none — no UI change.
  - Follow-up work or known limitations: This is PR 1 of a 5-PR stacked series; base it on main. bun run check (full test:full + the new knip gate) is intentionally exercised on the later branches — PR 2
  (chore/dead-code) is where knip/deadcode is wired into check. The two pre-existing full-suite flakes (/lsp recommend and an SDK-types timeout) are unrelated to this change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured CLI initialization process for improved efficiency. No user-facing behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->