### PR TITLE
Add dedicated /continue command

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -48,7 +48,7 @@ import {
   requestSize,
   requestSizeNonInteractive,
 } from './commands/request-size/index.js'
-import resume from './commands/resume/index.js'
+import resume, { continueCommand } from './commands/resume/index.js'
 import review, { ultrareview } from './commands/review.js'
 import session from './commands/session/index.js'
 import share from './commands/share/index.js'
@@ -283,6 +283,7 @@ const COMMANDS = memoize((): Command[] => [
   compact,
   commitMessage,
   config,
+  continueCommand,
   copy,
   desktop,
   context,

--- a/src/commands/resume/index.ts
+++ b/src/commands/resume/index.ts
@@ -4,9 +4,19 @@ const resume: Command = {
   type: 'local-jsx',
   name: 'resume',
   description: 'Resume a previous conversation',
-  aliases: ['continue'],
   argumentHint: '[conversation id or search term]',
   load: () => import('./resume.js'),
+}
+
+export const continueCommand: Command = {
+  type: 'local-jsx',
+  name: 'continue',
+  description: 'Continue the current task',
+  argumentHint: '[optional instruction]',
+  load: async () => {
+    const mod = await import('./resume.js')
+    return { call: mod.continueCall }
+  },
 }
 
 export default resume

--- a/src/commands/resume/resume.test.tsx
+++ b/src/commands/resume/resume.test.tsx
@@ -1,0 +1,307 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test'
+
+import {
+  achieveGoal,
+  createGoalState,
+  pauseGoal,
+} from '../../services/goal/state.js'
+import { getDefaultAppState, type AppState } from '../../state/AppStateStore.js'
+import type {
+  LocalJSXCommandContext,
+  LocalJSXCommandOnDone,
+} from '../../types/command.js'
+
+type OnDoneArgs = Parameters<LocalJSXCommandOnDone>
+
+let saveGoalStateMock: ReturnType<typeof mock>
+
+async function importFreshResumeModule(): Promise<
+  typeof import('./resume.js')
+> {
+  const unique = `${Date.now()}-${Math.random()}`
+  return import(`./resume.js?${unique}`) as Promise<
+    typeof import('./resume.js')
+  >
+}
+
+function makeContext(
+  opts: {
+    goal?: AppState['goal']
+    todos?: AppState['todos']
+  } = {},
+) {
+  let state: AppState = {
+    ...getDefaultAppState(),
+    goal: opts.goal ?? null,
+    todos: opts.todos ?? {},
+  }
+
+  return {
+    context: {
+      getAppState: () => state,
+      setAppState: (updater: (prev: AppState) => AppState) => {
+        state = updater(state)
+      },
+      agentId: 'agent-test-123',
+    } as unknown as LocalJSXCommandContext,
+    getState: () => state,
+  }
+}
+
+describe('/resume and /continue unified command', () => {
+  beforeEach(() => {
+    saveGoalStateMock = mock(() => Promise.resolve())
+    mock.module('../../services/goal/persistence.js', () => ({
+      saveGoalState: saveGoalStateMock,
+    }))
+    mock.module('../../utils/getWorktreePaths.js', () => ({
+      getWorktreePaths: () => Promise.resolve([]),
+    }))
+    mock.module('../../utils/sessionStorage.js', () => ({
+      getLastSessionLog: () => Promise.resolve(null),
+      getSessionIdFromLog: (log: { sessionId?: string }) => log.sessionId,
+      isCustomTitleEnabled: () => false,
+      isLiteLog: () => false,
+      loadAllProjectsMessageLogs: () => Promise.resolve([]),
+      loadFullLog: (log: unknown) => Promise.resolve(log),
+      loadSameRepoMessageLogs: () => Promise.resolve([]),
+      searchSessionsByCustomTitle: () => Promise.resolve([]),
+    }))
+  })
+
+  afterEach(() => {
+    mock.restore()
+  })
+
+  test('/continue continues an active goal', async () => {
+    const activeGoal = {
+      ...createGoalState('finish the feature'),
+      turnCount: 7,
+      lastEvaluatedMessageUuid: 'assistant-1',
+    }
+    const { context, getState } = makeContext({
+      goal: activeGoal,
+    })
+    const { continueCall } = await importFreshResumeModule()
+
+    let onDoneResult: OnDoneArgs | undefined
+    const onDone = (...args: OnDoneArgs) => {
+      onDoneResult = args
+    }
+
+    const element = await continueCall(onDone, context, '')
+
+    expect(element).toBeNull()
+    expect(onDoneResult).toBeDefined()
+    expect(onDoneResult![0]).toBe('Goal already active; continuing.')
+    expect(onDoneResult![1]?.shouldQuery).toBe(true)
+    expect(onDoneResult![1]?.metaMessages).toHaveLength(1)
+    expect(onDoneResult![1]?.metaMessages![0]).toContain('finish the feature')
+    expect(getState().goal?.status).toBe('active')
+    expect(getState().goal?.turnCount).toBe(7)
+    expect(getState().goal?.lastEvaluatedMessageUuid).toBe('assistant-1')
+  })
+
+  test('/continue resumes a paused goal and continues it', async () => {
+    const { context, getState } = makeContext({
+      goal: pauseGoal(createGoalState('finish the feature')),
+    })
+    const { continueCall } = await importFreshResumeModule()
+
+    let onDoneResult: OnDoneArgs | undefined
+    const onDone = (...args: OnDoneArgs) => {
+      onDoneResult = args
+    }
+
+    const element = await continueCall(onDone, context, '')
+
+    expect(element).toBeNull()
+    expect(onDoneResult![0]).toBe('Goal resumed.')
+    expect(onDoneResult![1]?.shouldQuery).toBe(true)
+    expect(onDoneResult![1]?.metaMessages![0]).toContain('finish the feature')
+    expect(getState().goal?.status).toBe('active')
+  })
+
+  test('/continue still resumes a paused goal when persistence fails', async () => {
+    saveGoalStateMock.mockImplementation(() =>
+      Promise.reject(new Error('disk full')),
+    )
+    const { context, getState } = makeContext({
+      goal: pauseGoal(createGoalState('finish the feature')),
+    })
+    const { continueCall } = await importFreshResumeModule()
+
+    let onDoneResult: OnDoneArgs | undefined
+    const onDone = (...args: OnDoneArgs) => {
+      onDoneResult = args
+    }
+
+    const element = await continueCall(onDone, context, '')
+
+    expect(element).toBeNull()
+    expect(onDoneResult![0]).toBe('Goal resumed.')
+    expect(onDoneResult![1]?.shouldQuery).toBe(true)
+    expect(onDoneResult![1]?.metaMessages![0]).toContain('finish the feature')
+    expect(getState().goal?.status).toBe('active')
+    expect(saveGoalStateMock).toHaveBeenCalled()
+  })
+
+  test('falls back to session picker when goal is achieved', async () => {
+    const { context } = makeContext({
+      goal: achieveGoal(createGoalState('finish the feature'), {
+        evaluatedMessageUuid: 'assistant-1',
+        reason: 'completed',
+      }),
+    })
+    const { call } = await importFreshResumeModule()
+
+    const onDone = mock(() => {})
+    const element = await call(onDone as unknown as LocalJSXCommandOnDone, context, '')
+
+    expect(element).toBeTruthy()
+    expect(onDone).not.toHaveBeenCalled()
+  })
+
+  test('/continue continues current todos when no goal is set', async () => {
+    const { context } = makeContext({
+      todos: {
+        'agent-test-123': [
+          { content: 'write tests', status: 'completed', activeForm: 'write tests' },
+          { content: 'run ci', status: 'in_progress', activeForm: 'run ci' },
+          { content: 'deploy', status: 'pending', activeForm: 'deploy' },
+        ],
+      },
+    })
+    const { continueCall } = await importFreshResumeModule()
+
+    let onDoneResult: OnDoneArgs | undefined
+    const onDone = (...args: OnDoneArgs) => {
+      onDoneResult = args
+    }
+
+    const element = await continueCall(onDone, context, '')
+
+    expect(element).toBeNull()
+    expect(onDoneResult![0]).toBe('Continuing current task.')
+    expect(onDoneResult![1]?.shouldQuery).toBe(true)
+    const metaMessage = onDoneResult![1]?.metaMessages![0]
+    expect(metaMessage).toContain('write tests')
+    expect(metaMessage).toContain('run ci')
+    expect(metaMessage).toContain('deploy')
+    expect(metaMessage).toContain('[done] write tests')
+    expect(metaMessage).toContain('[in progress] run ci')
+    expect(metaMessage).toContain('[pending] deploy')
+    expect(metaMessage).toContain('Resume the most recent task')
+  })
+
+  test('falls back to session picker when no goal or todos', async () => {
+    const { context } = makeContext()
+    const { call } = await importFreshResumeModule()
+
+    const onDone = mock(() => {})
+    const element = await call(onDone as unknown as LocalJSXCommandOnDone, context, '')
+
+    expect(element).toBeTruthy()
+    expect(onDone).not.toHaveBeenCalled()
+  })
+
+  test('/resume still shows picker when current task state exists', async () => {
+    const { context } = makeContext({
+      goal: createGoalState('finish the feature'),
+      todos: {
+        'agent-test-123': [
+          { content: 'run ci', status: 'in_progress', activeForm: 'run ci' },
+        ],
+      },
+    })
+    const { call } = await importFreshResumeModule()
+
+    const onDone = mock(() => {})
+    const element = await call(onDone as unknown as LocalJSXCommandOnDone, context, '')
+
+    expect(element).toBeTruthy()
+    expect(onDone).not.toHaveBeenCalled()
+  })
+
+  test('/continue continues from transcript when no goal or todos are tracked', async () => {
+    const { context } = makeContext()
+    const { continueCall } = await importFreshResumeModule()
+
+    let onDoneResult: OnDoneArgs | undefined
+    const onDone = (...args: OnDoneArgs) => {
+      onDoneResult = args
+    }
+
+    const element = await continueCall(onDone, context, '')
+
+    expect(element).toBeNull()
+    expect(onDoneResult![0]).toBe('Continuing current task.')
+    expect(onDoneResult![1]?.shouldQuery).toBe(true)
+    expect(onDoneResult![1]?.metaMessages![0]).toContain(
+      'The user asked you to continue.',
+    )
+    expect(onDoneResult![1]?.metaMessages![0]).toContain(
+      'Resume the most recent task based on the conversation transcript.',
+    )
+  })
+
+  test('/continue includes an optional user continuation hint', async () => {
+    const { context } = makeContext()
+    const { continueCall } = await importFreshResumeModule()
+
+    let onDoneResult: OnDoneArgs | undefined
+    const onDone = (...args: OnDoneArgs) => {
+      onDoneResult = args
+    }
+
+    const element = await continueCall(onDone, context, 'pick up at tests')
+
+    expect(element).toBeNull()
+    expect(onDoneResult![1]?.metaMessages![0]).toContain(
+      'User continuation hint:\npick up at tests',
+    )
+    expect(onDoneResult![1]?.metaMessages![0]).toContain(
+      'The user asked you to continue.',
+    )
+  })
+
+  test('/continue includes an optional hint with current todos', async () => {
+    const { context } = makeContext({
+      todos: {
+        'agent-test-123': [
+          { content: 'run ci', status: 'in_progress', activeForm: 'run ci' },
+        ],
+      },
+    })
+    const { continueCall } = await importFreshResumeModule()
+
+    let onDoneResult: OnDoneArgs | undefined
+    const onDone = (...args: OnDoneArgs) => {
+      onDoneResult = args
+    }
+
+    const element = await continueCall(onDone, context, 'focus on the failing tests')
+
+    expect(element).toBeNull()
+    expect(onDoneResult![1]?.metaMessages![0]).toContain('[in progress] run ci')
+    expect(onDoneResult![1]?.metaMessages![0]).toContain(
+      'User continuation hint:\nfocus on the failing tests',
+    )
+    expect(onDoneResult![1]?.metaMessages![0]).toContain(
+      'The user asked you to continue.',
+    )
+  })
+
+  test('with args bypasses current-task continuation and searches sessions', async () => {
+    const { context } = makeContext({
+      goal: createGoalState('finish the feature'),
+    })
+    const { call } = await importFreshResumeModule()
+
+    const onDone = mock(() => {})
+    const element = await call(onDone as unknown as LocalJSXCommandOnDone, context, 'feature')
+
+    expect(element).toBeTruthy()
+    expect(onDone).not.toHaveBeenCalled()
+  })
+})

--- a/src/commands/resume/resume.tsx
+++ b/src/commands/resume/resume.tsx
@@ -4,6 +4,10 @@ import type { UUID } from 'crypto';
 import figures from 'figures';
 import * as React from 'react';
 import { getOriginalCwd, getSessionId } from '../../bootstrap/state.js';
+import { buildGoalStartInstruction } from '../../services/goal/instructions.js';
+import { saveGoalState } from '../../services/goal/persistence.js';
+import { resumeGoal } from '../../services/goal/state.js';
+import type { GoalState } from '../../services/goal/types.js';
 import type { CommandResultDisplay, ResumeEntrypoint } from '../../commands.js';
 import { LogSelector } from '../../components/LogSelector.js';
 import { MessageResponse } from '../../components/MessageResponse.js';
@@ -14,6 +18,7 @@ import { setClipboard } from '../../ink/termio/osc.js';
 import { Box, Text } from '../../ink.js';
 import type { LocalJSXCommandCall } from '../../types/command.js';
 import type { LogOption } from '../../types/logs.js';
+import type { TodoItem, TodoList } from '../../utils/todo/types.js';
 import { agenticSessionSearch } from '../../utils/agenticSessionSearch.js';
 import { checkCrossProjectResume } from '../../utils/crossProjectResume.js';
 import { getWorktreePaths } from '../../utils/getWorktreePaths.js';
@@ -191,6 +196,117 @@ function ResumeCommand({
 export function filterResumableSessions(logs: LogOption[], currentSessionId: string): LogOption[] {
   return logs.filter(l => !l.isSidechain && getSessionIdFromLog(l) !== currentSessionId);
 }
+
+function isResumableGoal(goal: GoalState | null): goal is GoalState {
+  return goal != null && (goal.status === 'active' || goal.status === 'paused');
+}
+
+function formatTodoStatus(status: TodoItem['status']): string {
+  switch (status) {
+    case 'in_progress':
+      return 'in progress';
+    case 'completed':
+      return 'done';
+    default:
+      return status;
+  }
+}
+
+function formatTodosMessage(todos: TodoList): string {
+  const lines = todos.map(todo => `- [${formatTodoStatus(todo.status)}] ${todo.content}`);
+  return lines.length === 0
+    ? 'No todos are currently tracked.'
+    : ['Current todos:', ...lines].join('\n');
+}
+
+const CONTINUE_INSTRUCTION = `The user asked you to continue.
+
+Resume the most recent task based on the conversation transcript. Do not simply acknowledge the request. Pick up exactly where you left off and take the next concrete step. Only ask for clarification if the next action is genuinely ambiguous.`;
+
+function buildGenericContinueMessage(extraContext: string | null): string {
+  return extraContext
+    ? `${extraContext}\n\n${CONTINUE_INSTRUCTION}`
+    : CONTINUE_INSTRUCTION;
+}
+
+function formatContinuationHint(hint: string | null): string | null {
+  return hint ? `User continuation hint:\n${hint}` : null;
+}
+
+function appendContinuationHint(message: string, hint: string | null): string {
+  const formattedHint = formatContinuationHint(hint);
+  return formattedHint ? `${message}\n\n${formattedHint}` : message;
+}
+
+async function tryContinueCurrentTask(
+  context: Parameters<LocalJSXCommandCall>[1],
+  onDone: Parameters<LocalJSXCommandCall>[0],
+  continuationHint: string | null = null,
+): Promise<boolean> {
+  const appState = context.getAppState();
+  const currentGoal = appState.goal ?? null;
+
+  if (isResumableGoal(currentGoal)) {
+    const goal =
+      currentGoal.status === 'paused' ? resumeGoal(currentGoal) : currentGoal;
+    if (goal !== currentGoal) {
+      context.setAppState(prev => ({ ...prev, goal }));
+      try {
+        await saveGoalState(goal);
+      } catch (error) {
+        logError(error as Error);
+      }
+    }
+    onDone(
+      currentGoal.status === 'active'
+        ? 'Goal already active; continuing.'
+        : 'Goal resumed.',
+      {
+        shouldQuery: true,
+        metaMessages: [
+          appendContinuationHint(
+            buildGoalStartInstruction(goal),
+            continuationHint,
+          ),
+        ],
+      },
+    );
+    return true;
+  }
+
+  const sessionId = context.agentId ?? getSessionId();
+  const todos = appState.todos[sessionId];
+
+  if (todos && todos.length > 0) {
+    const todoContext = [
+      formatTodosMessage(todos),
+      formatContinuationHint(continuationHint),
+    ].filter(Boolean).join('\n\n');
+    onDone('Continuing current task.', {
+      shouldQuery: true,
+      metaMessages: [buildGenericContinueMessage(todoContext)],
+    });
+    return true;
+  }
+
+  return false;
+}
+
+export const continueCall: LocalJSXCommandCall = async (onDone, context, args) => {
+  const arg = args?.trim() || null;
+  if (await tryContinueCurrentTask(context, onDone, arg)) {
+    return null;
+  }
+
+  onDone('Continuing current task.', {
+    shouldQuery: true,
+    metaMessages: [
+      buildGenericContinueMessage(formatContinuationHint(arg)),
+    ],
+  });
+  return null;
+};
+
 export const call: LocalJSXCommandCall = async (onDone, context, args) => {
   const onResume = async (sessionId: UUID, log: LogOption, entrypoint: ResumeEntrypoint) => {
     try {

--- a/src/i18n/commandDescriptions.ts
+++ b/src/i18n/commandDescriptions.ts
@@ -12,6 +12,7 @@ const openClaudeCommandDescriptionKeys: Record<string, LocalizationKey> = {
   compact: 'commands.compact.description',
   'commit-message': 'commands.commit-message.description',
   config: 'commands.config.description',
+  continue: 'commands.continue.description',
   copy: 'commands.copy.description',
   context: 'commands.context.description',
   cost: 'commands.cost.description',

--- a/src/i18n/languages/en.ts
+++ b/src/i18n/languages/en.ts
@@ -17,6 +17,7 @@ export const en = {
   'commands.commit-message.description':
     'Configure commit attribution text',
   'commands.config.description': 'Open config panel',
+  'commands.continue.description': 'Continue the current task',
   'commands.copy.description':
     "Copy Claude's last response to clipboard (or /copy N for the Nth-latest)",
   'commands.context.description': 'Show current context usage',

--- a/src/i18n/languages/vi.ts
+++ b/src/i18n/languages/vi.ts
@@ -17,6 +17,7 @@ export const vi = {
   'commands.commit-message.description':
     'Cấu hình văn bản ghi công commit',
   'commands.config.description': 'Mở bảng cấu hình',
+  'commands.continue.description': 'Tiếp tục tác vụ hiện tại',
   'commands.copy.description':
     'Sao chép phản hồi gần nhất của Claude vào clipboard (hoặc /copy N cho phản hồi thứ N gần nhất)',
   'commands.context.description': 'Hiện mức sử dụng ngữ cảnh',


### PR DESCRIPTION
## Summary

- add a first-class `/continue` command for interrupted work recovery
- keep `/resume` focused on previous-conversation selection
- reuse goal/todo continuation context when available, and otherwise send a hidden transcript-based continuation instruction
- keep paused-goal continuation running even if goal persistence fails, while logging the persistence error
- preserve optional `/continue [hint]` instructions across goal, todo, and transcript-only continuation paths
- add focused coverage for active goals, paused goals, persistence failures, todos, transcript-only continuation, optional hints, and `/resume` picker behavior

Fixes #1613

## User / Developer Impact

Users can run `/continue` after an accidental interruption and OpenClaude will continue from the current transcript instead of only acknowledging the request. Optional hints such as `/continue focus on failing tests` are preserved even when an active goal or todo list already exists. Existing `/resume` behavior remains available for selecting a previous conversation.

## Checks Run

- `bun test src/commands/resume/resume.test.tsx` - passed, 11 tests / 50 assertions
- `bun test src/commands.test.ts` - passed
- `bun run build` - passed
- `bun run typecheck` - passed
- `bun run smoke` - passed outside sandbox
- `bun run typecheck:type-tests` - passed outside sandbox
- `bun run security:pr-scan` - passed outside sandbox
- `bun test src/commands/lsp/lsp.test.ts --max-concurrency=1` - passed outside sandbox

## Known Local Check Notes

- Raw `bun run check` outside sandbox still fails three existing `/export direct filename` tests when no auth token is present.
- With `ANTHROPIC_API_KEY=test-key`, those export failures disappear, leaving one unrelated full-suite-only timeout in `/lsp recommend > falls back to filesystem scanning when git cannot enumerate workspace files`.
- That exact LSP test passes in isolation in about 55 ms.
- Several commands needed to be rerun outside the Codex sandbox because sandboxed Bun/Git access hit dependency or merge-base read errors.

## Screenshots

Not applicable. This changes slash-command behavior and command metadata only.

## Provider Path Tested

Not applicable. This change does not touch provider behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a dedicated **/continue** command to resume active or paused goals, continue tracked todos, or fall back to a generic continuation (supports optional user-provided hints).
  * Added localized command descriptions for **English** and **Vietnamese** for **/continue**.
* **Behavior Changes**
  * Updated **/resume** to remove the previous **continue** alias, making **/continue** its own command.
  * Made paused-goal continuation resilient to goal persistence failures.
  * Preserved optional continuation hints when current goal or todo context exists.
* **Tests**
  * Expanded the command test suite to cover multiple continue/resume scenarios, persistence failures, optional hints, and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->