### PR TITLE
[codex] fix(mcp): demote successful stdio startup stderr

### DIFF
--- a/src/services/mcp/client.test.ts
+++ b/src/services/mcp/client.test.ts
@@ -1,7 +1,39 @@
 import assert from 'node:assert/strict'
 import test from 'node:test'
 
-import { cleanupFailedConnection, buildMcpStdioCommand } from './client.js'
+import {
+  cleanupFailedConnection,
+  buildMcpStdioCommand,
+  logMcpServerStderr,
+} from './client.js'
+import {
+  _resetErrorLogForTesting,
+  attachErrorLogSink,
+  type ErrorLogSink,
+} from '../../utils/log.js'
+
+function withCapturedMcpLogEvents(
+  fn: (events: Array<['debug' | 'error', string, unknown]>) => void,
+): void {
+  const events: Array<['debug' | 'error', string, unknown]> = []
+  const sink: ErrorLogSink = {
+    logError: error => events.push(['error', 'global', error]),
+    logMCPError: (serverName, error) =>
+      events.push(['error', serverName, error]),
+    logMCPDebug: (serverName, message) =>
+      events.push(['debug', serverName, message]),
+    getErrorsPath: () => '/tmp/errors.log',
+    getMCPLogsPath: serverName => `/tmp/${serverName}.log`,
+  }
+
+  _resetErrorLogForTesting()
+  try {
+    attachErrorLogSink(sink)
+    fn(events)
+  } finally {
+    _resetErrorLogForTesting()
+  }
+}
 
 test('cleanupFailedConnection awaits transport close before resolving', async () => {
   let closed = false
@@ -45,6 +77,34 @@ test('cleanupFailedConnection closes in-process server and transport', async () 
 
   assert.equal(inProcessClosed, true)
   assert.equal(transportClosed, true)
+})
+
+test('successful MCP startup stderr is logged as debug, not error', () => {
+  withCapturedMcpLogEvents(events => {
+    logMcpServerStderr(
+      'context7',
+      'Context7 Documentation MCP Server running on stdio',
+      true,
+    )
+
+    assert.deepEqual(events, [
+      [
+        'debug',
+        'context7',
+        'Server stderr: Context7 Documentation MCP Server running on stdio',
+      ],
+    ])
+  })
+})
+
+test('failed MCP startup stderr remains error-level', () => {
+  withCapturedMcpLogEvents(events => {
+    logMcpServerStderr('context7', 'startup failed', false)
+
+    assert.deepEqual(events, [
+      ['error', 'context7', 'Server stderr: startup failed'],
+    ])
+  })
 })
 
 test('buildMcpStdioCommand — no prefix passes command and args through unchanged', () => {

--- a/src/services/mcp/client.ts
+++ b/src/services/mcp/client.ts
@@ -580,6 +580,21 @@ export async function cleanupFailedConnection(
   await transport.close().catch(() => {})
 }
 
+export function logMcpServerStderr(
+  name: string,
+  stderrOutput: string,
+  connectedSuccessfully: boolean,
+): void {
+  if (!stderrOutput) return
+
+  const message = `Server stderr: ${stderrOutput}`
+  if (connectedSuccessfully) {
+    logMCPDebug(name, message)
+  } else {
+    logMCPError(name, message)
+  }
+}
+
 function isLocalMcpServer(config: ScopedMcpServerConfig): boolean {
   return !config.type || config.type === 'stdio' || config.type === 'sdk'
 }
@@ -1105,7 +1120,7 @@ export const connectToServer = memoize(
       try {
         await Promise.race([connectPromise, timeoutPromise])
         if (stderrOutput) {
-          logMCPError(name, `Server stderr: ${stderrOutput}`)
+          logMcpServerStderr(name, stderrOutput, true)
           stderrOutput = '' // Release accumulated string to prevent memory growth
         }
         const elapsed = Date.now() - connectStartTime
@@ -1176,7 +1191,7 @@ export const connectToServer = memoize(
           await cleanupFailedConnection(transport)
         }
         if (stderrOutput) {
-          logMCPError(name, `Server stderr: ${stderrOutput}`)
+          logMcpServerStderr(name, stderrOutput, false)
         }
         throw error
       }


### PR DESCRIPTION
## Summary

- Demote buffered stderr emitted during a successful stdio MCP startup from error-level logging to debug-level logging.
- Preserve error-level stderr logging when MCP connection setup fails.
- Add focused coverage for successful and failed startup stderr severity.

## Root Cause

The stdio transport buffers stderr during startup so connection failures can include useful diagnostics. The success path reused the same error-level logging as the failure path, so normal server banners printed to stderr were reported as MCP errors even when the server connected successfully.

## Impact

- Normal MCP startup banners no longer appear as errors after a successful connection.
- Failed MCP startup diagnostics remain error-level and visible.
- No provider or protocol behavior changes.

## Validation

- `bun test src/services/mcp/client.test.ts`
- `bun run typecheck`
- `bun run smoke`
- `bun run scripts/pr-intent-scan.ts --base upstream/main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * MCP server error logging now dynamically adjusts log severity based on connection outcome, utilizing debug level for successful startups and error level for failures.

* **Tests**
  * Added comprehensive test coverage for MCP server stderr logging to verify correct severity levels across various connection states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->