### PR TITLE
[codex] fix(query): abort active work on QueryGuard timeout

### DIFF
--- a/src/screens/REPL.tsx
+++ b/src/screens/REPL.tsx
@@ -1726,6 +1726,28 @@ export function REPL({
   const mrOnBeforeQuery = useCallback(async (_input: string, _allMessages: MessageType[], _newMessageCount: number) => true, []);
   const mrOnTurnComplete = useCallback(async (_allMessages: MessageType[], _aborted: boolean) => { }, []);
   const mrRender = useCallback(() => null, []);
+  const abortTimedOutQuery = useCallback(() => {
+    const activeAbortController = abortControllerRef.current;
+    if (activeAbortController && !activeAbortController.signal.aborted) {
+      activeAbortController.abort('query-timeout');
+    }
+    if (feature('TOKEN_BUDGET')) {
+      snapshotOutputTokensForTurn(null);
+    }
+
+    // QueryGuard calls this before forceEnd(); defer UI cleanup until after
+    // the guard has released so the normal stale-generation finally path skips.
+    queueMicrotask(() => {
+      resetLoadingState();
+      setAbortController(null);
+      void mrOnTurnComplete(messagesRef.current, true);
+    });
+  }, [mrOnTurnComplete, resetLoadingState]);
+
+  useEffect(() => {
+    return queryGuard.setTimeoutHandler(abortTimedOutQuery);
+  }, [abortTimedOutQuery, queryGuard]);
+
   const showSpinner = (!toolJSX || toolJSX.showSpinner === true) && toolUseConfirmQueue.length === 0 && promptQueue.length === 0 && (
     // Show spinner during input processing, API call, while teammates are running,
     // or while pending task notifications are queued (prevents spinner bounce between consecutive notifications)

--- a/src/utils/QueryGuard.test.ts
+++ b/src/utils/QueryGuard.test.ts
@@ -93,18 +93,20 @@ describe('QueryGuard', () => {
     const guard = new QueryGuard()
     const handlerError = new Error('handler failed')
     const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
-    guard.setTimeoutHandler(() => {
-      throw handlerError
-    })
+    try {
+      guard.setTimeoutHandler(() => {
+        throw handlerError
+      })
 
-    guard.tryStart()
+      guard.tryStart()
 
-    expect(() => vi.advanceTimersByTime(5 * 60 * 1000)).not.toThrow()
-    expect(guard.isActive).toBe(false)
-    expect(consoleError).toHaveBeenCalledWith('[QueryGuard] Timeout handler failed', handlerError)
-
-    consoleError.mockRestore()
-    vi.useRealTimers()
+      expect(() => vi.advanceTimersByTime(5 * 60 * 1000)).not.toThrow()
+      expect(guard.isActive).toBe(false)
+      expect(consoleError).toHaveBeenCalledWith('[QueryGuard] Timeout handler failed', handlerError)
+    } finally {
+      consoleError.mockRestore()
+      vi.useRealTimers()
+    }
   })
 
   test('timeout is cleared when end() is called normally', () => {

--- a/src/utils/QueryGuard.test.ts
+++ b/src/utils/QueryGuard.test.ts
@@ -88,6 +88,25 @@ describe('QueryGuard', () => {
     vi.useRealTimers()
   })
 
+  test('timeout handler errors do not escape the watchdog callback', () => {
+    vi.useFakeTimers()
+    const guard = new QueryGuard()
+    const handlerError = new Error('handler failed')
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+    guard.setTimeoutHandler(() => {
+      throw handlerError
+    })
+
+    guard.tryStart()
+
+    expect(() => vi.advanceTimersByTime(5 * 60 * 1000)).not.toThrow()
+    expect(guard.isActive).toBe(false)
+    expect(consoleError).toHaveBeenCalledWith('[QueryGuard] Timeout handler failed', handlerError)
+
+    consoleError.mockRestore()
+    vi.useRealTimers()
+  })
+
   test('timeout is cleared when end() is called normally', () => {
     vi.useFakeTimers()
     const guard = new QueryGuard()

--- a/src/utils/QueryGuard.test.ts
+++ b/src/utils/QueryGuard.test.ts
@@ -56,6 +56,38 @@ describe('QueryGuard', () => {
     vi.useRealTimers()
   })
 
+  test('timeout notifies owner with the timed-out generation', () => {
+    vi.useFakeTimers()
+    const guard = new QueryGuard()
+    const onTimeout = vi.fn()
+    guard.setTimeoutHandler(onTimeout)
+
+    const gen = guard.tryStart()!
+    vi.advanceTimersByTime(5 * 60 * 1000)
+
+    expect(onTimeout).toHaveBeenCalledTimes(1)
+    expect(onTimeout).toHaveBeenCalledWith(gen)
+    expect(guard.isActive).toBe(false)
+
+    vi.useRealTimers()
+  })
+
+  test('timeout handler cleanup prevents stale notification', () => {
+    vi.useFakeTimers()
+    const guard = new QueryGuard()
+    const onTimeout = vi.fn()
+    const cleanup = guard.setTimeoutHandler(onTimeout)
+    cleanup()
+
+    guard.tryStart()
+    vi.advanceTimersByTime(5 * 60 * 1000)
+
+    expect(onTimeout).not.toHaveBeenCalled()
+    expect(guard.isActive).toBe(false)
+
+    vi.useRealTimers()
+  })
+
   test('timeout is cleared when end() is called normally', () => {
     vi.useFakeTimers()
     const guard = new QueryGuard()

--- a/src/utils/QueryGuard.test.ts
+++ b/src/utils/QueryGuard.test.ts
@@ -1,7 +1,12 @@
-import { describe, test, expect, vi } from 'vitest'
+import { afterEach, describe, test, expect, vi } from 'vitest'
 import { QueryGuard } from './QueryGuard.js'
 
 describe('QueryGuard', () => {
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.restoreAllMocks()
+  })
+
   test('starts idle', () => {
     const guard = new QueryGuard()
     expect(guard.isActive).toBe(false)
@@ -52,8 +57,6 @@ describe('QueryGuard', () => {
     // At timeout
     vi.advanceTimersByTime(1)
     expect(guard.isActive).toBe(false)
-
-    vi.useRealTimers()
   })
 
   test('timeout notifies owner with the timed-out generation', () => {
@@ -68,8 +71,6 @@ describe('QueryGuard', () => {
     expect(onTimeout).toHaveBeenCalledTimes(1)
     expect(onTimeout).toHaveBeenCalledWith(gen)
     expect(guard.isActive).toBe(false)
-
-    vi.useRealTimers()
   })
 
   test('timeout handler cleanup prevents stale notification', () => {
@@ -84,8 +85,6 @@ describe('QueryGuard', () => {
 
     expect(onTimeout).not.toHaveBeenCalled()
     expect(guard.isActive).toBe(false)
-
-    vi.useRealTimers()
   })
 
   test('timeout handler errors do not escape the watchdog callback', () => {
@@ -93,20 +92,15 @@ describe('QueryGuard', () => {
     const guard = new QueryGuard()
     const handlerError = new Error('handler failed')
     const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
-    try {
-      guard.setTimeoutHandler(() => {
-        throw handlerError
-      })
+    guard.setTimeoutHandler(() => {
+      throw handlerError
+    })
 
-      guard.tryStart()
+    guard.tryStart()
 
-      expect(() => vi.advanceTimersByTime(5 * 60 * 1000)).not.toThrow()
-      expect(guard.isActive).toBe(false)
-      expect(consoleError).toHaveBeenCalledWith('[QueryGuard] Timeout handler failed', handlerError)
-    } finally {
-      consoleError.mockRestore()
-      vi.useRealTimers()
-    }
+    expect(() => vi.advanceTimersByTime(5 * 60 * 1000)).not.toThrow()
+    expect(guard.isActive).toBe(false)
+    expect(consoleError).toHaveBeenCalledWith('[QueryGuard] Timeout handler failed', handlerError)
   })
 
   test('timeout is cleared when end() is called normally', () => {
@@ -125,6 +119,5 @@ describe('QueryGuard', () => {
     expect(guard.isActive).toBe(true)
 
     guard.forceEnd()
-    vi.useRealTimers()
   })
 })

--- a/src/utils/QueryGuard.ts
+++ b/src/utils/QueryGuard.ts
@@ -156,6 +156,8 @@ export class QueryGuard {
         console.error(`[QueryGuard] Query timeout after ${QUERY_TIMEOUT_MS}ms — force-ending to prevent infinite spinner`)
         try {
           this._timeoutHandler?.(this._generation)
+        } catch (error) {
+          console.error('[QueryGuard] Timeout handler failed', error)
         } finally {
           this.forceEnd()
         }

--- a/src/utils/QueryGuard.ts
+++ b/src/utils/QueryGuard.ts
@@ -31,12 +31,14 @@
 import { createSignal } from './signal.js'
 
 const QUERY_TIMEOUT_MS = 5 * 60 * 1000 // 5 minutes
+type QueryTimeoutHandler = (generation: number) => void
 
 export class QueryGuard {
   private _status: 'idle' | 'dispatching' | 'running' = 'idle'
   private _generation = 0
   private _changed = createSignal()
   private _timeoutId: ReturnType<typeof setTimeout> | null = null
+  private _timeoutHandler: QueryTimeoutHandler | null = null
 
   /**
    * Reserve the guard for queue processing. Transitions idle → dispatching.
@@ -114,6 +116,20 @@ export class QueryGuard {
     return this._generation
   }
 
+  /**
+   * Register a single owner callback for watchdog timeouts. The callback runs
+   * before forceEnd(), so callers can abort in-flight work while the timed-out
+   * generation is still current.
+   */
+  setTimeoutHandler(handler: QueryTimeoutHandler | null): () => void {
+    this._timeoutHandler = handler
+    return () => {
+      if (this._timeoutHandler === handler) {
+        this._timeoutHandler = null
+      }
+    }
+  }
+
   // --
   // useSyncExternalStore interface
 
@@ -138,7 +154,11 @@ export class QueryGuard {
     this._timeoutId = setTimeout(() => {
       if (this._status === 'running') {
         console.error(`[QueryGuard] Query timeout after ${QUERY_TIMEOUT_MS}ms — force-ending to prevent infinite spinner`)
-        this.forceEnd()
+        try {
+          this._timeoutHandler?.(this._generation)
+        } finally {
+          this.forceEnd()
+        }
       }
     }, QUERY_TIMEOUT_MS)
   }


### PR DESCRIPTION
## Summary
- Add a `QueryGuard` timeout callback so the REPL owner is notified when the watchdog fires.
- Abort the active `AbortController` on timeout before `QueryGuard.forceEnd()` releases the guard.
- Reuse the existing aborted-turn cleanup path for loading state, token budget state, and turn completion notifications.

## Root Cause
`QueryGuard` force-ended its internal state after five minutes, which hid the spinner but did not abort the active query generator. If the provider stream or tool path remained stuck, the underlying work could continue after the UI appeared idle.

## Impact
A watchdog timeout now actively interrupts the running query instead of only resetting local guard state. This keeps stale provider/tool work from surviving behind an idle prompt and aligns timeout behavior with the existing abort semantics.

## Validation
- `bun test src/utils/QueryGuard.test.ts`
- `bun run typecheck`
- `bun run smoke`
- `bun run scripts/pr-intent-scan.ts --base upstream/main`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a watchdog-style query timeout for the REPL to prevent long-running queries from stalling.
  - When the timeout fires, the active request is aborted, REPL loading state is cleared, and turn completion is triggered (including token-budget cleanup when enabled).

- **Tests**
  - Added and expanded fake-timer coverage for timeout invocation, disposer cancellation behavior, and error handling (including guaranteed cleanup/transition to inactive and expected error logging).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->