### PR TITLE
[codex] fix(tokens): fallback when provider lacks countTokens

### DIFF
--- a/src/services/tokenEstimation.test.ts
+++ b/src/services/tokenEstimation.test.ts
@@ -1,119 +1,80 @@
-import { afterEach, beforeEach, expect, mock, test } from 'bun:test'
-import {
-  acquireSharedMutationLock,
-  releaseSharedMutationLock,
-} from '../test/sharedMutationLock.js'
-import * as realApiClient from './api/client.js'
-import * as realVcr from './vcr.js'
-import * as realBetas from '../utils/betas.js'
-import * as realLog from '../utils/log.js'
-import * as realModel from '../utils/model/model.js'
-import * as realProviders from '../utils/model/providers.js'
+import type { Anthropic } from '@anthropic-ai/sdk'
+import { expect, mock, test } from 'bun:test'
+import { jsonStringify } from '../utils/slowOperations.js'
+import { __test, roughTokenCountEstimation } from './tokenEstimation.js'
 
-let anthropicClient: unknown
-
-const getAnthropicClient = mock(async () => anthropicClient)
-
-function createShimClientWithoutCountTokens(): unknown {
+function createTextTool(): Anthropic.Beta.Messages.BetaToolUnion {
   return {
-    beta: {
-      messages: {
-        create: async () => ({
-          usage: { input_tokens: 1, output_tokens: 1 },
-        }),
+    name: 'lookup_docs',
+    description: 'Look up project documentation.',
+    input_schema: {
+      type: 'object',
+      properties: {
+        query: { type: 'string' },
       },
+      required: ['query'],
     },
   }
 }
 
-async function loadTokenEstimationForTesting() {
-  return import(`./tokenEstimation.js?ts=${Date.now()}-${Math.random()}`)
-}
-
-function applyMocks() {
-  mock.module('./api/client.js', () => ({
-    ...realApiClient,
-    getAnthropicClient,
-  }))
-  mock.module('./vcr.js', () => ({
-    ...realVcr,
-    withTokenCountVCR: async (
-      _messages: unknown,
-      _tools: unknown,
-      run: () => Promise<unknown>,
-    ) => run(),
-  }))
-  mock.module('../utils/betas.js', () => ({
-    ...realBetas,
-    getModelBetas: () => [],
-  }))
-  mock.module('../utils/log.js', () => ({
-    ...realLog,
-    logError: () => {},
-  }))
-  mock.module('../utils/model/model.js', () => ({
-    ...realModel,
-    getMainLoopModel: () => 'gpt-4o',
-    normalizeModelStringForAPI: (model: string) => model,
-  }))
-  mock.module('../utils/model/providers.js', () => ({
-    ...realProviders,
-    getAPIProvider: () => 'openai',
-  }))
-}
-
-function restoreMocks() {
-  mock.restore()
-  mock.module('./api/client.js', () => realApiClient)
-  mock.module('./vcr.js', () => realVcr)
-  mock.module('../utils/betas.js', () => realBetas)
-  mock.module('../utils/log.js', () => realLog)
-  mock.module('../utils/model/model.js', () => realModel)
-  mock.module('../utils/model/providers.js', () => realProviders)
-}
-
-beforeEach(async () => {
-  await acquireSharedMutationLock('tokenEstimation.test.ts')
-  anthropicClient = createShimClientWithoutCountTokens()
-  getAnthropicClient.mockClear()
-  applyMocks()
-})
-
-afterEach(() => {
-  restoreMocks()
-  releaseSharedMutationLock()
-})
-
-test('countMessagesTokensWithAPI falls back when shim client lacks countTokens', async () => {
-  const { countMessagesTokensWithAPI, roughTokenCountEstimation } =
-    await loadTokenEstimationForTesting()
+test('countMessagesTokensWithClient falls back when shim client lacks countTokens', async () => {
   const content = 'hello from an openai-compatible provider'
 
-  const result = await countMessagesTokensWithAPI(
-    [{ role: 'user', content }],
-    [],
-  )
+  const result = await __test.countMessagesTokensWithClient({
+    messagesClient: {},
+    model: 'gpt-4o',
+    messages: [{ role: 'user', content }],
+    tools: [],
+    filteredBetas: [],
+    containsThinking: false,
+  })
 
-  expect(getAnthropicClient).toHaveBeenCalledTimes(1)
   expect(result).toBe(roughTokenCountEstimation(content))
 })
 
-test('countMessagesTokensWithAPI uses countTokens when the client supports it', async () => {
-  const countTokens = mock(async () => ({ input_tokens: 42 }))
-  anthropicClient = {
-    beta: {
-      messages: {
-        countTokens,
-      },
-    },
-  }
-  const { countMessagesTokensWithAPI } = await loadTokenEstimationForTesting()
+test('countMessagesTokensWithClient includes tool overhead in fallback estimates', async () => {
+  const content = 'count this request with tool definitions'
+  const tools = [createTextTool()]
 
-  const result = await countMessagesTokensWithAPI(
-    [{ role: 'user', content: 'use exact count when available' }],
-    [],
+  const result = await __test.countMessagesTokensWithClient({
+    messagesClient: {},
+    model: 'gpt-4o',
+    messages: [{ role: 'user', content }],
+    tools,
+    filteredBetas: [],
+    containsThinking: false,
+  })
+
+  expect(result).toBe(
+    roughTokenCountEstimation(content) +
+      500 +
+      roughTokenCountEstimation(jsonStringify(tools)),
   )
+})
+
+test('countMessagesTokensWithClient uses countTokens when the client supports it', async () => {
+  const countTokens = mock(async (_params: unknown) => ({ input_tokens: 42 }))
+  const messages: Anthropic.Beta.Messages.BetaMessageParam[] = [
+    { role: 'user', content: 'use exact count when available' },
+  ]
+
+  const result = await __test.countMessagesTokensWithClient({
+    messagesClient: {
+      countTokens:
+        countTokens as unknown as Anthropic['beta']['messages']['countTokens'],
+    },
+    model: 'gpt-4o',
+    messages,
+    tools: [],
+    filteredBetas: [],
+    containsThinking: false,
+  })
 
   expect(countTokens).toHaveBeenCalledTimes(1)
+  expect(countTokens.mock.calls[0]?.[0]).toEqual({
+    model: 'gpt-4o',
+    messages,
+    tools: [],
+  })
   expect(result).toBe(42)
 })

--- a/src/services/tokenEstimation.test.ts
+++ b/src/services/tokenEstimation.test.ts
@@ -1,0 +1,119 @@
+import { afterEach, beforeEach, expect, mock, test } from 'bun:test'
+import {
+  acquireSharedMutationLock,
+  releaseSharedMutationLock,
+} from '../test/sharedMutationLock.js'
+import * as realApiClient from './api/client.js'
+import * as realVcr from './vcr.js'
+import * as realBetas from '../utils/betas.js'
+import * as realLog from '../utils/log.js'
+import * as realModel from '../utils/model/model.js'
+import * as realProviders from '../utils/model/providers.js'
+
+let anthropicClient: unknown
+
+const getAnthropicClient = mock(async () => anthropicClient)
+
+function createShimClientWithoutCountTokens(): unknown {
+  return {
+    beta: {
+      messages: {
+        create: async () => ({
+          usage: { input_tokens: 1, output_tokens: 1 },
+        }),
+      },
+    },
+  }
+}
+
+async function loadTokenEstimationForTesting() {
+  return import(`./tokenEstimation.js?ts=${Date.now()}-${Math.random()}`)
+}
+
+function applyMocks() {
+  mock.module('./api/client.js', () => ({
+    ...realApiClient,
+    getAnthropicClient,
+  }))
+  mock.module('./vcr.js', () => ({
+    ...realVcr,
+    withTokenCountVCR: async (
+      _messages: unknown,
+      _tools: unknown,
+      run: () => Promise<unknown>,
+    ) => run(),
+  }))
+  mock.module('../utils/betas.js', () => ({
+    ...realBetas,
+    getModelBetas: () => [],
+  }))
+  mock.module('../utils/log.js', () => ({
+    ...realLog,
+    logError: () => {},
+  }))
+  mock.module('../utils/model/model.js', () => ({
+    ...realModel,
+    getMainLoopModel: () => 'gpt-4o',
+    normalizeModelStringForAPI: (model: string) => model,
+  }))
+  mock.module('../utils/model/providers.js', () => ({
+    ...realProviders,
+    getAPIProvider: () => 'openai',
+  }))
+}
+
+function restoreMocks() {
+  mock.restore()
+  mock.module('./api/client.js', () => realApiClient)
+  mock.module('./vcr.js', () => realVcr)
+  mock.module('../utils/betas.js', () => realBetas)
+  mock.module('../utils/log.js', () => realLog)
+  mock.module('../utils/model/model.js', () => realModel)
+  mock.module('../utils/model/providers.js', () => realProviders)
+}
+
+beforeEach(async () => {
+  await acquireSharedMutationLock('tokenEstimation.test.ts')
+  anthropicClient = createShimClientWithoutCountTokens()
+  getAnthropicClient.mockClear()
+  applyMocks()
+})
+
+afterEach(() => {
+  restoreMocks()
+  releaseSharedMutationLock()
+})
+
+test('countMessagesTokensWithAPI falls back when shim client lacks countTokens', async () => {
+  const { countMessagesTokensWithAPI, roughTokenCountEstimation } =
+    await loadTokenEstimationForTesting()
+  const content = 'hello from an openai-compatible provider'
+
+  const result = await countMessagesTokensWithAPI(
+    [{ role: 'user', content }],
+    [],
+  )
+
+  expect(getAnthropicClient).toHaveBeenCalledTimes(1)
+  expect(result).toBe(roughTokenCountEstimation(content))
+})
+
+test('countMessagesTokensWithAPI uses countTokens when the client supports it', async () => {
+  const countTokens = mock(async () => ({ input_tokens: 42 }))
+  anthropicClient = {
+    beta: {
+      messages: {
+        countTokens,
+      },
+    },
+  }
+  const { countMessagesTokensWithAPI } = await loadTokenEstimationForTesting()
+
+  const result = await countMessagesTokensWithAPI(
+    [{ role: 'user', content: 'use exact count when available' }],
+    [],
+  )
+
+  expect(countTokens).toHaveBeenCalledTimes(1)
+  expect(result).toBe(42)
+})

--- a/src/services/tokenEstimation.ts
+++ b/src/services/tokenEstimation.ts
@@ -34,6 +34,10 @@ const TOKEN_COUNT_MAX_TOKENS = 2048
 // Keep this local to avoid importing analyzeContext.ts, which already depends on tokenEstimation.
 const ROUGH_TOOL_TOKEN_COUNT_OVERHEAD = 500
 
+type CountTokensMessagesClient = {
+  countTokens?: Anthropic['beta']['messages']['countTokens']
+}
+
 /**
  * Check if messages contain thinking blocks
  */
@@ -168,51 +172,74 @@ export async function countMessagesTokensWithAPI(
       const messagesClient = (
         anthropic as {
           beta?: {
-            messages?: {
-              countTokens?: Anthropic['beta']['messages']['countTokens']
-            }
+            messages?: CountTokensMessagesClient
           }
         }
       ).beta?.messages
-
-      if (typeof messagesClient?.countTokens !== 'function') {
-        return roughTokenCountEstimationForCountTokensFallback(messages, tools)
-      }
 
       const filteredBetas =
         getAPIProvider() === 'vertex'
           ? betas.filter(b => VERTEX_COUNT_TOKENS_ALLOWED_BETAS.has(b))
           : betas
 
-      const response = await messagesClient.countTokens({
-        model: normalizeModelStringForAPI(model),
-        messages:
-          // When we pass tools and no messages, we need to pass a dummy message
-          // to get an accurate tool token count.
-          messages.length > 0 ? messages : [{ role: 'user', content: 'foo' }],
+      return countMessagesTokensWithClient({
+        messagesClient,
+        model,
+        messages,
         tools,
-        ...(filteredBetas.length > 0 && { betas: filteredBetas }),
-        // Enable thinking if messages contain thinking blocks
-        ...(containsThinking && {
-          thinking: {
-            type: 'enabled',
-            budget_tokens: TOKEN_COUNT_THINKING_BUDGET,
-          },
-        }),
+        filteredBetas,
+        containsThinking,
       })
-
-      if (typeof response.input_tokens !== 'number') {
-        // Vertex client throws
-        // Bedrock client succeeds with { Output: { __type: 'com.amazon.coral.service#UnknownOperationException' }, Version: '1.0' }
-        return null
-      }
-
-      return response.input_tokens
     } catch (error) {
       logError(error)
       return null
     }
   })
+}
+
+async function countMessagesTokensWithClient({
+  messagesClient,
+  model,
+  messages,
+  tools,
+  filteredBetas,
+  containsThinking,
+}: {
+  messagesClient: CountTokensMessagesClient | undefined
+  model: string
+  messages: Anthropic.Beta.Messages.BetaMessageParam[]
+  tools: Anthropic.Beta.Messages.BetaToolUnion[]
+  filteredBetas: string[]
+  containsThinking: boolean
+}): Promise<number | null> {
+  if (typeof messagesClient?.countTokens !== 'function') {
+    return roughTokenCountEstimationForCountTokensFallback(messages, tools)
+  }
+
+  const response = await messagesClient.countTokens({
+    model: normalizeModelStringForAPI(model),
+    messages:
+      // When we pass tools and no messages, we need to pass a dummy message
+      // to get an accurate tool token count.
+      messages.length > 0 ? messages : [{ role: 'user', content: 'foo' }],
+    tools,
+    ...(filteredBetas.length > 0 && { betas: filteredBetas }),
+    // Enable thinking if messages contain thinking blocks
+    ...(containsThinking && {
+      thinking: {
+        type: 'enabled',
+        budget_tokens: TOKEN_COUNT_THINKING_BUDGET,
+      },
+    }),
+  })
+
+  if (typeof response.input_tokens !== 'number') {
+    // Vertex client throws
+    // Bedrock client succeeds with { Output: { __type: 'com.amazon.coral.service#UnknownOperationException' }, Version: '1.0' }
+    return null
+  }
+
+  return response.input_tokens
 }
 
 function roughTokenCountEstimationForCountTokensFallback(
@@ -239,6 +266,9 @@ function roughTokenCountEstimationForCountTokensFallback(
 
   return totalTokens
 }
+
+// Test-only surface for fallback dispatch without process-wide module mocks.
+export const __test = { countMessagesTokensWithClient }
 
 export function roughTokenCountEstimation(
   content: string,

--- a/src/services/tokenEstimation.ts
+++ b/src/services/tokenEstimation.ts
@@ -31,6 +31,8 @@ import { withTokenCountVCR } from './vcr.js'
 // API constraint: max_tokens must be greater than thinking.budget_tokens
 const TOKEN_COUNT_THINKING_BUDGET = 1024
 const TOKEN_COUNT_MAX_TOKENS = 2048
+// Keep this local to avoid importing analyzeContext.ts, which already depends on tokenEstimation.
+const ROUGH_TOOL_TOKEN_COUNT_OVERHEAD = 500
 
 /**
  * Check if messages contain thinking blocks
@@ -163,13 +165,26 @@ export async function countMessagesTokensWithAPI(
         model,
         source: 'count_tokens',
       })
+      const messagesClient = (
+        anthropic as {
+          beta?: {
+            messages?: {
+              countTokens?: Anthropic['beta']['messages']['countTokens']
+            }
+          }
+        }
+      ).beta?.messages
+
+      if (typeof messagesClient?.countTokens !== 'function') {
+        return roughTokenCountEstimationForCountTokensFallback(messages, tools)
+      }
 
       const filteredBetas =
         getAPIProvider() === 'vertex'
           ? betas.filter(b => VERTEX_COUNT_TOKENS_ALLOWED_BETAS.has(b))
           : betas
 
-      const response = await anthropic.beta.messages.countTokens({
+      const response = await messagesClient.countTokens({
         model: normalizeModelStringForAPI(model),
         messages:
           // When we pass tools and no messages, we need to pass a dummy message
@@ -198,6 +213,31 @@ export async function countMessagesTokensWithAPI(
       return null
     }
   })
+}
+
+function roughTokenCountEstimationForCountTokensFallback(
+  messages: Anthropic.Beta.Messages.BetaMessageParam[],
+  tools: Anthropic.Beta.Messages.BetaToolUnion[],
+): number {
+  let totalTokens = 0
+
+  for (const message of messages) {
+    totalTokens += roughTokenCountEstimationForContent(
+      message.content as
+        | string
+        | Array<Anthropic.ContentBlock>
+        | Array<Anthropic.ContentBlockParam>
+        | undefined,
+    )
+  }
+
+  if (tools.length > 0) {
+    totalTokens +=
+      ROUGH_TOOL_TOKEN_COUNT_OVERHEAD +
+      roughTokenCountEstimation(jsonStringify(tools))
+  }
+
+  return totalTokens
 }
 
 export function roughTokenCountEstimation(


### PR DESCRIPTION
## Summary
- Detect Anthropic-compatible clients whose `beta.messages` surface does not expose `countTokens`.
- Fall back to the local rough token estimator for those shim clients, including the existing tool-definition overhead.
- Preserve the exact API token-count path when the client supports `countTokens`.

## Root Cause
`countMessagesTokensWithAPI()` assumed every non-Bedrock Anthropic-shaped client exposes `beta.messages.countTokens()`. OpenAI-compatible shim clients expose `beta.messages.create()` but not `countTokens()`, so token estimation could crash before falling back to a usable local estimate.

## Impact And Risk
OpenAI-compatible providers can keep context and cost-estimation flows working even when their shim client lacks Anthropic's token-count endpoint. The fallback is intentionally narrow: normal `countTokens` API failures and malformed count responses still return `null` through the existing error path.

Risk surfaces: provider client capability detection and conditional outbound token-count calls. This PR does not change provider selection, authentication, model routing, or message sending behavior.

## Validation
- `bun test src/services/tokenEstimation.test.ts src/services/api/client.test.ts`
- `bun test src/services/tokenEstimation.test.ts src/services/api/client.test.ts src/services/tokenModelCompression.test.ts src/utils/mcpValidation.test.ts src/utils/analyzeContext.messageBreakdown.test.ts`
- `bun run typecheck`
- `bun run smoke`
- `bun run scripts/pr-intent-scan.ts --base upstream/main`
- `git diff --check`

GitHub Actions on the PR are passing: `smoke-and-tests`, `typecheck`, and `web`. CodeRabbit's latest review is approved with no actionable comments.

Note: I also ran `bun run test:full` locally after the follow-up test isolation change. It still fails in unrelated suites in this local environment (`AgentTool`, auto-compact, marketplace cache finalization, secure storage stdin, export/LSP timeout cases), while the PR-specific regression and CI suites pass.
