### PR TITLE
[codex] fix(read): improve oversized file guidance

### DIFF
--- a/src/tools/FileReadTool/FileReadTool.oversized.test.ts
+++ b/src/tools/FileReadTool/FileReadTool.oversized.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, test } from 'bun:test'
+
+import {
+  formatMaxFileReadTokenExceededMessage,
+  MaxFileReadTokenExceededError,
+} from './FileReadTool.js'
+
+describe('oversized FileReadTool guidance', () => {
+  test('includes token limit, total lines, and concrete Read ranges', () => {
+    const message = formatMaxFileReadTokenExceededMessage(12_345, 8_000, {
+      filePath: '/repo/src/big.ts',
+      source: 'estimate',
+      totalLines: 450,
+    })
+
+    expect(message).toContain('estimated 12,345 tokens')
+    expect(message).toContain('limit 8,000 tokens')
+    expect(message).toContain('450 total lines')
+    expect(message).toContain(
+      '{"file_path":"/repo/src/big.ts","offset":1,"limit":200}',
+    )
+    expect(message).toContain(
+      '{"file_path":"/repo/src/big.ts","offset":201,"limit":200}',
+    )
+    expect(message).toContain('Use Grep first')
+  })
+
+  test('marks API-counted token counts without calling them estimates', () => {
+    const message = formatMaxFileReadTokenExceededMessage(9_001, 9_000, {
+      source: 'api',
+    })
+
+    expect(message).toContain('9,001 tokens')
+    expect(message).not.toContain('estimated 9,001 tokens')
+  })
+
+  test('MaxFileReadTokenExceededError preserves metadata on the error object', () => {
+    const error = new MaxFileReadTokenExceededError(3_001, 3_000, {
+      filePath: '/repo/large.log',
+      source: 'estimate',
+      totalLines: 250,
+    })
+
+    expect(error.name).toBe('MaxFileReadTokenExceededError')
+    expect(error.tokenCount).toBe(3_001)
+    expect(error.maxTokens).toBe(3_000)
+    expect(error.details).toEqual({
+      filePath: '/repo/large.log',
+      source: 'estimate',
+      totalLines: 250,
+    })
+    expect(error.message).toContain('250 total lines')
+  })
+})

--- a/src/tools/FileReadTool/FileReadTool.ts
+++ b/src/tools/FileReadTool/FileReadTool.ts
@@ -172,14 +172,80 @@ export function registerFileReadListener(
   }
 }
 
+export type MaxFileReadTokenExceededDetails = {
+  filePath?: string
+  source?: 'api' | 'estimate'
+  totalLines?: number
+}
+
+function formatCount(value: number): string {
+  return value.toLocaleString('en-US')
+}
+
+function formatReadRangeExample(
+  filePath: string,
+  offset: number,
+  limit: number,
+): string {
+  return JSON.stringify({ file_path: filePath, offset, limit })
+}
+
+export function formatMaxFileReadTokenExceededMessage(
+  tokenCount: number,
+  maxTokens: number,
+  details: MaxFileReadTokenExceededDetails = {},
+): string {
+  const tokenCountText =
+    details.source === 'estimate'
+      ? `estimated ${formatCount(tokenCount)} tokens`
+      : `${formatCount(tokenCount)} tokens`
+
+  const lines = [
+    `File content is too large to read in one request (${tokenCountText}; limit ${formatCount(maxTokens)} tokens).`,
+  ]
+
+  if (details.totalLines !== undefined) {
+    lines.push(`The file has ${formatCount(details.totalLines)} total lines.`)
+  }
+
+  if (details.filePath) {
+    const firstLimit = Math.max(
+      1,
+      Math.min(200, details.totalLines ?? 200),
+    )
+    lines.push('Read smaller ranges with offset and limit, for example:')
+    lines.push(`  ${formatReadRangeExample(details.filePath, 1, firstLimit)}`)
+
+    if (details.totalLines === undefined || details.totalLines > firstLimit) {
+      const secondOffset = firstLimit + 1
+      const secondLimit = Math.max(
+        1,
+        Math.min(200, (details.totalLines ?? firstLimit + 200) - firstLimit),
+      )
+      lines.push(
+        `  ${formatReadRangeExample(details.filePath, secondOffset, secondLimit)}`,
+      )
+    }
+  } else {
+    lines.push(
+      'Read smaller ranges with offset and limit, for example offset: 1, limit: 200, then offset: 201, limit: 200.',
+    )
+  }
+
+  lines.push(
+    'Use Grep first if you are looking for specific text, then Read the relevant range.',
+  )
+
+  return lines.join('\n')
+}
+
 export class MaxFileReadTokenExceededError extends Error {
   constructor(
     public tokenCount: number,
     public maxTokens: number,
+    public details: MaxFileReadTokenExceededDetails = {},
   ) {
-    super(
-      `File content (${tokenCount} tokens) exceeds maximum allowed tokens (${maxTokens}). Use offset and limit parameters to read specific portions of the file, or search for specific content instead of reading the whole file.`,
-    )
+    super(formatMaxFileReadTokenExceededMessage(tokenCount, maxTokens, details))
     this.name = 'MaxFileReadTokenExceededError'
   }
 }
@@ -759,6 +825,7 @@ async function validateContentTokens(
   content: string,
   ext: string,
   maxTokens?: number,
+  details: Omit<MaxFileReadTokenExceededDetails, 'source'> = {},
 ): Promise<void> {
   const effectiveMaxTokens =
     maxTokens ?? getDefaultFileReadingLimits().maxTokens
@@ -770,7 +837,14 @@ async function validateContentTokens(
   const effectiveCount = tokenCount ?? tokenEstimate
 
   if (effectiveCount > effectiveMaxTokens) {
-    throw new MaxFileReadTokenExceededError(effectiveCount, effectiveMaxTokens)
+    throw new MaxFileReadTokenExceededError(
+      effectiveCount,
+      effectiveMaxTokens,
+      {
+        ...details,
+        source: tokenCount === null ? 'estimate' : 'api',
+      },
+    )
   }
 }
 
@@ -1030,7 +1104,10 @@ async function callInner(
       context.abortController.signal,
     )
 
-  await validateContentTokens(content, ext, maxTokens)
+  await validateContentTokens(content, ext, maxTokens, {
+    filePath: file_path,
+    totalLines,
+  })
 
   readFileState.set(fullFilePath, {
     content,


### PR DESCRIPTION
## Summary
- Replace the generic oversized `Read` token-limit error with actionable guidance.
- Include counted vs estimated token wording, the configured token limit, total line count when available, and concrete `Read` range examples.
- Preserve the existing oversized-read failure behavior while adding focused unit coverage for the formatter and error metadata.

## Risk
- Low: this changes only the model-visible error text for `Read` results that exceed the token budget.
- Normal successful reads, partial `offset`/`limit` reads, image handling, notebook handling, and PDF page handling are not changed.

## Validation
- `bun test src/tools/FileReadTool/FileReadTool.oversized.test.ts`
- `bun test src/tools/FileReadTool/FileReadTool.oversized.test.ts src/utils/mcpValidation.test.ts`
- `bun run typecheck`
- `bun run smoke`
- `bun run deadcode`
- `bun run scripts/pr-intent-scan.ts --base upstream/main`
- `git diff --check`

## Local full-suite note
- `bun run test:full` was run. The new `FileReadTool` test passed, but the local full suite still fails in unrelated existing areas reproduced on earlier clean PRs: agent routing/model fallback, auto-compact breaker, marketplace cache finalization, secure-storage stdin payload assertions, export filename timeouts, and LSP recommendation timeout.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced error messages when file read operations exceed token limits, including concrete suggested read ranges and total line counts for easier troubleshooting.
  * Clearer distinction between API-measured and estimated token counts in error information.

* **Tests**
  * Added comprehensive test suite validating file read token limit validation and error messaging behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->