### PR TITLE
[codex] perf(skills): cap skill listing budget

### DIFF
--- a/src/tools/SkillTool/prompt.test.ts
+++ b/src/tools/SkillTool/prompt.test.ts
@@ -1,0 +1,76 @@
+import { afterEach, describe, expect, test } from 'bun:test'
+
+import type { Command } from '../../types/command.js'
+import {
+  formatCommandsWithinBudget,
+  getCharBudget,
+  MAX_CHAR_BUDGET,
+} from './prompt.js'
+
+const originalBudgetOverride = process.env.SLASH_COMMAND_TOOL_CHAR_BUDGET
+
+afterEach(() => {
+  if (originalBudgetOverride === undefined) {
+    delete process.env.SLASH_COMMAND_TOOL_CHAR_BUDGET
+  } else {
+    process.env.SLASH_COMMAND_TOOL_CHAR_BUDGET = originalBudgetOverride
+  }
+})
+
+function createSkill(name: string, description: string): Command {
+  return {
+    type: 'prompt',
+    name,
+    description,
+    progressMessage: `${name} progress`,
+    contentLength: 0,
+    source: 'plugin',
+    loadedFrom: 'plugin',
+    async getPromptForCommand() {
+      return []
+    },
+  }
+}
+
+describe('SkillTool listing budget', () => {
+  test('caps provider-derived budget for very large context windows', () => {
+    expect(getCharBudget(2_000_000)).toBe(MAX_CHAR_BUDGET)
+  })
+
+  test('keeps smaller context windows below the hard cap proportional', () => {
+    expect(getCharBudget(50_000)).toBe(2_000)
+  })
+
+  test('preserves explicit budget override for local testing', () => {
+    process.env.SLASH_COMMAND_TOOL_CHAR_BUDGET = '12000'
+
+    expect(getCharBudget(2_000_000)).toBe(12_000)
+  })
+
+  test('does not allow huge context windows to keep every long description', () => {
+    const longDescription = 'x'.repeat(220)
+    const skills = Array.from({ length: 60 }, (_, i) =>
+      createSkill(`skill-${i}`, longDescription),
+    )
+
+    const content = formatCommandsWithinBudget(skills, 2_000_000)
+
+    expect(content).toContain('- skill-0')
+    expect(content).not.toContain(longDescription)
+  })
+
+  test('supports lower listing caps while preserving skill names', () => {
+    const skills = Array.from({ length: 24 }, (_, i) =>
+      createSkill(`worker-skill-${i}`, `worker details ${'x'.repeat(120)}`),
+    )
+
+    const defaultContent = formatCommandsWithinBudget(skills, 200_000)
+    const compactContent = formatCommandsWithinBudget(skills, 200_000, {
+      maxCharBudget: 1_000,
+    })
+
+    expect(compactContent.length).toBeLessThan(defaultContent.length)
+    expect(compactContent).toContain('- worker-skill-0')
+    expect(compactContent).toContain('- worker-skill-23')
+  })
+})

--- a/src/tools/SkillTool/prompt.ts
+++ b/src/tools/SkillTool/prompt.ts
@@ -30,7 +30,7 @@ export const SUBAGENT_SKILL_LISTING_CHAR_BUDGET = 4_000
 // since the cap is generous enough to preserve the core use case.
 export const MAX_LISTING_DESC_CHARS = 250
 
-type SkillListingBudgetOptions = {
+export type SkillListingBudgetOptions = {
   maxCharBudget?: number
 }
 

--- a/src/tools/SkillTool/prompt.ts
+++ b/src/tools/SkillTool/prompt.ts
@@ -21,6 +21,8 @@ import { logError } from '../../utils/log.js'
 export const SKILL_BUDGET_CONTEXT_PERCENT = 0.01
 export const CHARS_PER_TOKEN = 4
 export const DEFAULT_CHAR_BUDGET = 8_000 // Fallback: 1% of 200k × 4
+export const MAX_CHAR_BUDGET = DEFAULT_CHAR_BUDGET
+export const SUBAGENT_SKILL_LISTING_CHAR_BUDGET = 4_000
 
 // Per-entry hard cap. The listing is for discovery only — the Skill tool loads
 // full content on invoke, so verbose whenToUse strings waste turn-1 cache_creation
@@ -28,16 +30,27 @@ export const DEFAULT_CHAR_BUDGET = 8_000 // Fallback: 1% of 200k × 4
 // since the cap is generous enough to preserve the core use case.
 export const MAX_LISTING_DESC_CHARS = 250
 
-export function getCharBudget(contextWindowTokens?: number): number {
+type SkillListingBudgetOptions = {
+  maxCharBudget?: number
+}
+
+export function getCharBudget(
+  contextWindowTokens?: number,
+  options: SkillListingBudgetOptions = {},
+): number {
   if (Number(process.env.SLASH_COMMAND_TOOL_CHAR_BUDGET)) {
     return Number(process.env.SLASH_COMMAND_TOOL_CHAR_BUDGET)
   }
+  const maxBudget = options.maxCharBudget ?? MAX_CHAR_BUDGET
   if (contextWindowTokens) {
-    return Math.floor(
-      contextWindowTokens * CHARS_PER_TOKEN * SKILL_BUDGET_CONTEXT_PERCENT,
+    return Math.min(
+      maxBudget,
+      Math.floor(
+        contextWindowTokens * CHARS_PER_TOKEN * SKILL_BUDGET_CONTEXT_PERCENT,
+      ),
     )
   }
-  return DEFAULT_CHAR_BUDGET
+  return Math.min(DEFAULT_CHAR_BUDGET, maxBudget)
 }
 
 function getCommandDescription(cmd: Command): string {
@@ -70,10 +83,11 @@ const MIN_DESC_LENGTH = 20
 export function formatCommandsWithinBudget(
   commands: Command[],
   contextWindowTokens?: number,
+  options: SkillListingBudgetOptions = {},
 ): string {
   if (commands.length === 0) return ''
 
-  const budget = getCharBudget(contextWindowTokens)
+  const budget = getCharBudget(contextWindowTokens, options)
 
   // Try full descriptions first
   const fullEntries = commands.map(cmd => ({

--- a/src/utils/attachments.ts
+++ b/src/utils/attachments.ts
@@ -83,7 +83,10 @@ import { getSkillToolCommands, getMcpSkillCommands } from '../commands.js'
 import type { Command } from '../types/command.js'
 import uniqBy from 'lodash-es/uniqBy.js'
 import { getProjectRoot } from '../bootstrap/state.js'
-import { formatCommandsWithinBudget } from '../tools/SkillTool/prompt.js'
+import {
+  formatCommandsWithinBudget,
+  SUBAGENT_SKILL_LISTING_CHAR_BUDGET,
+} from '../tools/SkillTool/prompt.js'
 import { getContextWindowForModel } from './context.js'
 import type { DiscoverySignal } from '../services/skillSearch/signals.js'
 // Conditional require for DCE. All skill-search string literals that would
@@ -2750,12 +2753,19 @@ async function getSkillListingAttachments(
     `Sending ${newSkills.length} skills via attachment (${isInitial ? 'initial' : 'dynamic'}, ${sent.size} total sent)`,
   )
 
-  // Format within budget using existing logic
+  // Subagents can each receive their own initial listing. Keep those
+  // discoverability hints compact; the Skill tool still loads full content.
   const contextWindowTokens = getContextWindowForModel(
     toolUseContext.options.mainLoopModel,
     getSdkBetas(),
   )
-  const content = formatCommandsWithinBudget(newSkills, contextWindowTokens)
+  const content = formatCommandsWithinBudget(
+    newSkills,
+    contextWindowTokens,
+    toolUseContext.agentId
+      ? { maxCharBudget: SUBAGENT_SKILL_LISTING_CHAR_BUDGET }
+      : undefined,
+  )
 
   return [
     {


### PR DESCRIPTION
## Summary
- Add a hard cap to provider-derived Skill listing budgets so very large context windows do not inflate turn-0 skill-listing attachments.
- Keep explicit `SLASH_COMMAND_TOOL_CHAR_BUDGET` overrides for local/debug testing.
- Use a smaller listing cap for subagent skill-listing attachments while preserving skill names; full skill content still loads through the Skill tool when invoked.

## Problem
Skill listing text was sized as 1% of the model context window. That is reasonable for common windows, but it scales up to tens of thousands of characters for huge or provider-reported context windows. Subagents can also receive their own initial listings, multiplying the same discoverability cost.

## Root cause
`getCharBudget()` trusted the context-window-derived budget directly, and `getSkillListingAttachments()` used the same budget for main-thread and subagent listings.

## What changed
- `getCharBudget()` now clamps provider-derived budgets to `MAX_CHAR_BUDGET` (8,000 chars).
- `formatCommandsWithinBudget()` accepts an optional `maxCharBudget` for constrained callers.
- Subagent listings use `SUBAGENT_SKILL_LISTING_CHAR_BUDGET` (4,000 chars).
- Exported the `SkillListingBudgetOptions` type so callers can reference the options contract directly.
- Added focused tests for huge context windows, proportional smaller windows, env override behavior, long-description truncation, and compact listings preserving names.

## Risk surface
- Subagent behavior changes only in initial listing length. Skills remain discoverable by name in the listing and full skill content still loads through the Skill tool on demand.
- No provider routing, auth, permission, MCP, sandbox, or trust-boundary behavior changes are introduced.
- Explicit `SLASH_COMMAND_TOOL_CHAR_BUDGET` overrides continue to win, preserving local/debug workflows.
- Main-thread listings are capped at the previous fallback budget, avoiding growth on oversized provider context windows without reducing ordinary smaller-window budgets.

## Why this approach is safe
- This does not enable ToolSearch for OpenAI-compatible providers or change provider-specific tool_reference behavior.
- It does not hide skills from subagents; it only shortens discoverability descriptions when the listing is over budget.
- Skill invocation behavior remains unchanged: the Skill tool still loads full skill content on demand.

## Validation
- `bun test src/tools/SkillTool/prompt.test.ts src/tools/SkillTool/SkillTool.test.ts src/utils/attachments.extractors.test.ts`
- `bun run typecheck`
- `bun run smoke`
- `bun run deadcode`
- `bun run scripts/pr-intent-scan.ts --base upstream/main`
- `git diff --check`

## Local full-suite note
- `bun run test:full` was run. The new SkillTool prompt tests passed, but the local full suite still fails in unrelated existing areas reproduced on earlier clean PRs: agent routing/model fallback, auto-compact breaker, marketplace cache finalization, secure-storage stdin payload assertions, export filename timeouts, and LSP recommendation timeout.

## Follow-up
- A future, larger PR could add a richer provider-neutral skill index with stable hashes and source/plugin metadata. This PR intentionally keeps the behavior change small and reviewable.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a Bun test suite covering skill listing budget calculations and formatting, including truncation behavior under tight context limits and support for explicit budget overrides.

* **Improvements**
  * Skill listing formatting now supports a configurable character budget cap, refining how much detail is included for each skill.
  * Subagent skill listings now apply a dedicated character budget constraint to improve context usage consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
