### PR TITLE
feat(config): add compactModel option to use a separate model for compaction (#1445)

### DIFF
--- a/src/components/Settings/Config.tsx
+++ b/src/components/Settings/Config.tsx
@@ -1613,6 +1613,9 @@ export function Config({
           <ModelPicker initial={globalConfig.compactModel ?? null} skipSettingsWrite headerText="Model used for conversation compaction. Defaults to the main model when unset." onSelect={(model_2, _effort_1) => {
         setShowSubmenu(null);
         setTabsHidden(false);
+        if (globalConfig.compactModel === undefined && model_2 === null) {
+          return;
+        }
         isDirty.current = true;
         saveGlobalConfig(current_24 => {
           if (model_2 === null) {

--- a/src/components/Settings/Config.tsx
+++ b/src/components/Settings/Config.tsx
@@ -1613,7 +1613,7 @@ export function Config({
           <ModelPicker initial={globalConfig.compactModel ?? null} skipSettingsWrite headerText="Model used for conversation compaction. Defaults to the main model when unset." onSelect={(model_2, _effort_1) => {
         setShowSubmenu(null);
         setTabsHidden(false);
-        if (globalConfig.compactModel === undefined && model_2 === null) {
+        if ((globalConfig.compactModel ?? null) === model_2) {
           return;
         }
         isDirty.current = true;

--- a/src/components/Settings/Config.tsx
+++ b/src/components/Settings/Config.tsx
@@ -82,7 +82,7 @@ type Setting = (SettingBase & {
   onChange(value: string): void;
   type: 'managedEnum';
 });
-type SubMenu = 'Theme' | 'Model' | 'TeammateModel' | 'ExternalIncludes' | 'OutputStyle' | 'ChannelDowngrade' | 'Language' | 'EnableAutoUpdates';
+type SubMenu = 'Theme' | 'Model' | 'TeammateModel' | 'CompactModel' | 'ExternalIncludes' | 'OutputStyle' | 'ChannelDowngrade' | 'Language' | 'EnableAutoUpdates';
 export function Config({
   onClose,
   context,
@@ -888,6 +888,12 @@ export function Config({
     value: mainLoopModel === null ? 'Default (recommended)' : mainLoopModel,
     type: 'managedEnum' as const,
     onChange: onChangeMainModelConfig
+  }, {
+    id: 'compactModel',
+    label: 'Compaction model',
+    value: compactModelDisplayString(globalConfig.compactModel),
+    type: 'managedEnum' as const,
+    onChange() {}
   }, ...(isConnectedToIde ? [{
     id: 'diffTool',
     label: 'Diff tool',
@@ -1378,7 +1384,7 @@ export function Config({
       }
       return;
     }
-    if (setting_0.id === 'theme' || setting_0.id === 'model' || setting_0.id === 'teammateDefaultModel' || setting_0.id === 'showExternalIncludesDialog' || setting_0.id === 'outputStyle' || setting_0.id === 'language') {
+    if (setting_0.id === 'theme' || setting_0.id === 'model' || setting_0.id === 'compactModel' || setting_0.id === 'teammateDefaultModel' || setting_0.id === 'showExternalIncludesDialog' || setting_0.id === 'outputStyle' || setting_0.id === 'language') {
       // managedEnum items open a submenu — isDirty is set by the submenu's
       // completion callback, not here (submenu may be cancelled).
       switch (setting_0.id) {
@@ -1388,6 +1394,10 @@ export function Config({
           return;
         case 'model':
           setShowSubmenu('Model');
+          setTabsHidden(true);
+          return;
+        case 'compactModel':
+          setShowSubmenu('CompactModel');
           setTabsHidden(true);
           return;
         case 'teammateDefaultModel':
@@ -1588,6 +1598,42 @@ export function Config({
         }));
         logEvent('tengu_teammate_default_model_changed', {
           model: model_1 as AnalyticsMetadata_I_VERIFIED_THIS_IS_NOT_CODE_OR_FILEPATHS
+        });
+      }} onCancel={() => {
+        setShowSubmenu(null);
+        setTabsHidden(false);
+      }} />
+          <Text dimColor>
+            <Byline>
+              <KeyboardShortcutHint shortcut="Enter" action="confirm" />
+              <ConfigurableShortcutHint action="confirm:no" context="Confirmation" fallback="Esc" description="cancel" />
+            </Byline>
+          </Text>
+        </> : showSubmenu === 'CompactModel' ? <>
+          <ModelPicker initial={globalConfig.compactModel ?? null} skipSettingsWrite headerText="Model used for conversation compaction. Defaults to the main model when unset." onSelect={(model_2, _effort_1) => {
+        setShowSubmenu(null);
+        setTabsHidden(false);
+        isDirty.current = true;
+        saveGlobalConfig(current_24 => {
+          if (model_2 === null) {
+            const {
+              compactModel,
+              ...rest
+            } = current_24;
+            return rest;
+          }
+          return {
+            ...current_24,
+            compactModel: model_2
+          };
+        });
+        setGlobalConfig(getGlobalConfig());
+        setChanges(prev_26 => ({
+          ...prev_26,
+          compactModel: compactModelDisplayString(model_2 ?? undefined)
+        }));
+        logEvent('tengu_compact_model_changed', {
+          model: model_2 as AnalyticsMetadata_I_VERIFIED_THIS_IS_NOT_CODE_OR_FILEPATHS
         });
       }} onCancel={() => {
         setShowSubmenu(null);
@@ -1821,6 +1867,10 @@ function teammateModelDisplayString(value: string | null | undefined): string {
     return modelDisplayString(getHardcodedTeammateModelFallback());
   }
   if (value === null) return "Default (leader's model)";
+  return modelDisplayString(value);
+}
+function compactModelDisplayString(value: string | undefined): string {
+  if (value === undefined) return 'Default (main model)';
   return modelDisplayString(value);
 }
 const THEME_LABELS: Record<string, string> = {

--- a/src/services/compact/compact.test.ts
+++ b/src/services/compact/compact.test.ts
@@ -200,6 +200,12 @@ export type CompactMockOptions = {
   growthBookDefault?: boolean
   /** Mock for executePreCompactHooks. */
   executePreCompactHooks?: ReturnType<typeof mock>
+  /** Override for getGlobalConfig(), e.g. to set compactModel. */
+  getGlobalConfig?: ReturnType<typeof mock>
+  /** Override for queryModelWithStreaming(), to inspect the model/options passed in. */
+  queryModelWithStreaming?: ReturnType<typeof mock>
+  /** Override for getMaxOutputTokensForModel(). */
+  getMaxOutputTokensForModel?: ReturnType<typeof mock>
 }
 
 /**
@@ -318,18 +324,21 @@ function registerCommonCompactStubs(options: CompactMockOptions = {}) {
 
   // --- API / streaming (DEFENSIVE) ---
   mock.module('../api/claude.js', () => ({
-    queryModelWithStreaming: mock(async function* () {
-      yield {
-        type: 'assistant' as const,
-        message: {
-          role: 'assistant' as const,
-          content: [{ type: 'text' as const, text: 'Streamed summary.' }],
-        },
-        uuid: `stream-${Math.random()}`,
-        timestamp: new Date().toISOString(),
-      }
-    }),
-    getMaxOutputTokensForModel: mock(() => 8192),
+    queryModelWithStreaming:
+      options.queryModelWithStreaming ??
+      mock(async function* () {
+        yield {
+          type: 'assistant' as const,
+          message: {
+            role: 'assistant' as const,
+            content: [{ type: 'text' as const, text: 'Streamed summary.' }],
+          },
+          uuid: `stream-${Math.random()}`,
+          timestamp: new Date().toISOString(),
+        }
+      }),
+    getMaxOutputTokensForModel:
+      options.getMaxOutputTokensForModel ?? mock(() => 8192),
   }))
 
   mock.module('../api/errors.js', () => ({
@@ -374,6 +383,9 @@ function registerCommonCompactStubs(options: CompactMockOptions = {}) {
   mock.module('../../utils/config.js', () => ({
     ..._realConfigModule,
     getMemoryPath: mock(() => '/tmp/memory'),
+    ...(options.getGlobalConfig
+      ? { getGlobalConfig: options.getGlobalConfig }
+      : {}),
   }))
 
   // --- File state cache (DEFENSIVE) ---
@@ -661,5 +673,55 @@ describe('compactConversation provider gate', () => {
     await compactConversation(messages, ctx, csp, false)
 
     expect(runForkedAgent).toHaveBeenCalled()
+  })
+})
+
+describe('compactConversation compactModel override', () => {
+  test('skips cache-sharing and routes streaming compaction to compactModel when it differs from mainLoopModel', async () => {
+    // All provider env vars are cleared by beforeEach, so this would normally
+    // be eligible for forked-agent cache-sharing (Anthropic provider). Setting
+    // compactModel to a different model than mainLoopModel must override that.
+    const compactModel = 'claude-opus-4-1'
+    const getMaxOutputTokensForModel = mock((model: string) =>
+      model === compactModel ? 4096 : 8192,
+    )
+    const queryModelWithStreaming = mock(async function* () {
+      yield {
+        type: 'assistant' as const,
+        message: {
+          role: 'assistant' as const,
+          content: [{ type: 'text' as const, text: 'Streamed summary.' }],
+        },
+        uuid: `stream-${Math.random()}`,
+        timestamp: new Date().toISOString(),
+      }
+    })
+
+    const { compactConversation, runForkedAgent } = await importCompact({
+      getGlobalConfig: mock(() => ({
+        ..._realConfigModule.getGlobalConfig(),
+        compactModel,
+      })),
+      getMaxOutputTokensForModel,
+      queryModelWithStreaming,
+    })
+
+    const messages = [userMessage('Hello'), assistantMessage('Hi there!')]
+    const ctx = toolUseContext()
+    const csp = cacheSafeParams(messages)
+
+    await compactConversation(messages, ctx, csp, false)
+
+    // modelChangesForCompaction forces promptCacheSharingEnabled to false,
+    // even though the default (Anthropic) provider would normally allow
+    // forked-agent cache-sharing.
+    expect(runForkedAgent).not.toHaveBeenCalled()
+
+    expect(queryModelWithStreaming).toHaveBeenCalled()
+    const [{ options: streamOptions }] = queryModelWithStreaming.mock.calls[0] as unknown as [
+      { options: { model: string; maxOutputTokensOverride: number } },
+    ]
+    expect(streamOptions.model).toBe(compactModel)
+    expect(streamOptions.maxOutputTokensOverride).toBe(4096)
   })
 })

--- a/src/services/compact/compact.test.ts
+++ b/src/services/compact/compact.test.ts
@@ -677,13 +677,57 @@ describe('compactConversation provider gate', () => {
 })
 
 describe('compactConversation compactModel override', () => {
+  test('resolves a compact model alias to full model ID before comparing and sending', async () => {
+    // The ModelPicker stores alias values like 'sonnet' directly; compact must
+    // resolve them with parseUserSpecifiedModel before comparing to mainLoopModel
+    // or passing to the API, so 'sonnet' → 'claude-sonnet-4-6-20251001' etc.
+    const compactModelAlias = 'sonnet'
+    const resolvedModel = _realModelModule.parseUserSpecifiedModel(compactModelAlias)
+    const queryModelWithStreaming = mock(async function* () {
+      yield {
+        type: 'assistant' as const,
+        message: {
+          role: 'assistant' as const,
+          content: [{ type: 'text' as const, text: 'Alias summary.' }],
+        },
+        uuid: `alias-${Math.random()}`,
+        timestamp: new Date().toISOString(),
+      }
+    })
+
+    const { compactConversation } = await importCompact({
+      getGlobalConfig: mock(() => ({
+        ..._realConfigModule.getGlobalConfig(),
+        compactModel: compactModelAlias,
+      })),
+      queryModelWithStreaming,
+    })
+
+    const messages = [userMessage('Hello'), assistantMessage('Hi there!')]
+    const ctx = toolUseContext()
+    const csp = cacheSafeParams(messages)
+
+    await compactConversation(messages, ctx, csp, false)
+
+    expect(queryModelWithStreaming).toHaveBeenCalled()
+    const [{ options: streamOptions }] = queryModelWithStreaming.mock.calls[0] as unknown as [
+      { options: { model: string } },
+    ]
+    // The alias must be expanded — never sent verbatim to the API.
+    expect(streamOptions.model).toBe(resolvedModel)
+    expect(streamOptions.model).not.toBe(compactModelAlias)
+  })
+
   test('skips cache-sharing and routes streaming compaction to compactModel when it differs from mainLoopModel', async () => {
     // All provider env vars are cleared by beforeEach, so this would normally
     // be eligible for forked-agent cache-sharing (Anthropic provider). Setting
     // compactModel to a different model than mainLoopModel must override that.
     const compactModel = 'claude-opus-4-1'
+    // parseUserSpecifiedModel remaps legacy opus IDs to the current default —
+    // the resolved form is what compact.ts sends to the API.
+    const resolvedCompactModel = _realModelModule.parseUserSpecifiedModel(compactModel)
     const getMaxOutputTokensForModel = mock((model: string) =>
-      model === compactModel ? 4096 : 8192,
+      model === resolvedCompactModel ? 4096 : 8192,
     )
     const queryModelWithStreaming = mock(async function* () {
       yield {
@@ -721,7 +765,7 @@ describe('compactConversation compactModel override', () => {
     const [{ options: streamOptions }] = queryModelWithStreaming.mock.calls[0] as unknown as [
       { options: { model: string; maxOutputTokensOverride: number } },
     ]
-    expect(streamOptions.model).toBe(compactModel)
+    expect(streamOptions.model).toBe(resolvedCompactModel)
     expect(streamOptions.maxOutputTokensOverride).toBe(4096)
   })
 })

--- a/src/services/compact/compact.ts
+++ b/src/services/compact/compact.ts
@@ -98,6 +98,7 @@ import {
 } from '../../utils/toolSearch.js'
 import { getFeatureValue_CACHED_MAY_BE_STALE } from '../analytics/growthbook.js'
 import { isAnthropicProvider } from '../../utils/betas.js'
+import { parseUserSpecifiedModel } from '../../utils/model/model.js'
 import { isGithubNativeAnthropicMode } from '../../utils/model/providers.js'
 import {
   type AnalyticsMetadata_I_VERIFIED_THIS_IS_NOT_CODE_OR_FILEPATHS,
@@ -459,7 +460,11 @@ export async function compactConversation(
     // The GB flag is kept as a kill-switch.
     // streamCompactSummary() (below) follows the same gate; see also the
     // provider-gate tests in src/services/compact/compact.test.ts.
-    const compactModel = getGlobalConfig().compactModel
+    const rawCompactModel = getGlobalConfig().compactModel
+    const compactModel =
+      rawCompactModel !== undefined
+        ? parseUserSpecifiedModel(rawCompactModel)
+        : undefined
     const modelChangesForCompaction =
       compactModel !== undefined && compactModel !== context.options.mainLoopModel
     const promptCacheSharingEnabled =
@@ -1190,7 +1195,11 @@ async function streamCompactSummary({
   // prompt cache; other 3P providers are incompatible and would send
   // Anthropic-only params that they reject. The shared predicate makes this
   // safe to call from 3P provider paths.
-  const compactModel = getGlobalConfig().compactModel
+  const rawCompactModel = getGlobalConfig().compactModel
+  const compactModel =
+    rawCompactModel !== undefined
+      ? parseUserSpecifiedModel(rawCompactModel)
+      : undefined
   const modelChangesForCompaction =
     compactModel !== undefined && compactModel !== context.options.mainLoopModel
   const cacheSharingAvailable = isCompactionCacheSharingCompatible(

--- a/src/services/compact/compact.ts
+++ b/src/services/compact/compact.ts
@@ -1360,10 +1360,10 @@ async function streamCompactSummary({
       let response: AssistantMessage | undefined
       context.setResponseLength?.(() => 0)
 
-      // Check if tool search is enabled using the main loop's tools list.
-      // context.options.tools includes MCP tools merged via useMergedTools.
+      // Check if tool search is enabled for the model actually used for
+      // compaction (compactModel when set, otherwise mainLoopModel).
       const useToolSearch = await isToolSearchEnabled(
-        context.options.mainLoopModel,
+        compactModel ?? context.options.mainLoopModel,
         context.options.tools,
         async () => appState.toolPermissionContext,
         context.options.agentDefinitions.activeAgents,

--- a/src/services/compact/compact.ts
+++ b/src/services/compact/compact.ts
@@ -41,7 +41,7 @@ import {
   getDeferredToolsDeltaAttachment,
   getMcpInstructionsDeltaAttachment,
 } from '../../utils/attachments.js'
-import { getMemoryPath } from '../../utils/config.js'
+import { getGlobalConfig, getMemoryPath } from '../../utils/config.js'
 import { COMPACT_MAX_OUTPUT_TOKENS } from '../../utils/context.js'
 import { createChildAbortController } from '../../utils/abortController.js'
 import {
@@ -459,7 +459,11 @@ export async function compactConversation(
     // The GB flag is kept as a kill-switch.
     // streamCompactSummary() (below) follows the same gate; see also the
     // provider-gate tests in src/services/compact/compact.test.ts.
+    const compactModel = getGlobalConfig().compactModel
+    const modelChangesForCompaction =
+      compactModel !== undefined && compactModel !== context.options.mainLoopModel
     const promptCacheSharingEnabled =
+      !modelChangesForCompaction &&
       isCompactionCacheSharingCompatible(context.options.mainLoopModel) &&
       getFeatureValue_CACHED_MAY_BE_STALE(
         'tengu_compact_cache_prefix',
@@ -1186,10 +1190,14 @@ async function streamCompactSummary({
   // prompt cache; other 3P providers are incompatible and would send
   // Anthropic-only params that they reject. The shared predicate makes this
   // safe to call from 3P provider paths.
+  const compactModel = getGlobalConfig().compactModel
+  const modelChangesForCompaction =
+    compactModel !== undefined && compactModel !== context.options.mainLoopModel
   const cacheSharingAvailable = isCompactionCacheSharingCompatible(
     context.options.mainLoopModel,
   )
   const promptCacheSharingEnabled =
+    !modelChangesForCompaction &&
     cacheSharingAvailable &&
     getFeatureValue_CACHED_MAY_BE_STALE(
       'tengu_compact_cache_prefix',
@@ -1402,13 +1410,13 @@ async function streamCompactSummary({
             const appState = context.getAppState()
             return appState.toolPermissionContext
           },
-          model: context.options.mainLoopModel,
+          model: compactModel ?? context.options.mainLoopModel,
           toolChoice: undefined,
           isNonInteractiveSession: context.options.isNonInteractiveSession,
           hasAppendSystemPrompt: !!context.options.appendSystemPrompt,
           maxOutputTokensOverride: Math.min(
             COMPACT_MAX_OUTPUT_TOKENS,
-            getMaxOutputTokensForModel(context.options.mainLoopModel),
+            getMaxOutputTokensForModel(compactModel ?? context.options.mainLoopModel),
           ),
           querySource: 'compact',
           agents: context.options.agentDefinitions.activeAgents,

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -670,6 +670,10 @@ export type GlobalConfig = {
   // When enabled, triggers forced compaction if the message count exceeds the
   // chosen threshold, regardless of token usage.
   maxMessagesCompactionThreshold?: MaxMessagesCompactionThreshold
+
+  // Use a different (e.g. cheaper/faster) model for compaction.
+  // Defaults to mainLoopModel when unset.
+  compactModel?: string
 }
 
 /**
@@ -774,6 +778,7 @@ export const GLOBAL_CONFIG_KEYS = [
   'knowledgeGraphEnabled',
   'logoColor',
   'maxMessagesCompactionThreshold',
+  'compactModel',
 ] as const
 
 export type GlobalConfigKey = (typeof GLOBAL_CONFIG_KEYS)[number]


### PR DESCRIPTION
Adds a `compactModel` config key so compaction can use a different
(e.g. cheaper or faster) model than `mainLoopModel`.

## What changed

- `src/utils/config.ts`: added `compactModel?: string` to `GlobalConfig`
  and `GLOBAL_CONFIG_KEYS`.
- `src/services/compact/compact.ts`:
  - Read `compactModel` directly from `getGlobalConfig()` (no threading
    through `ToolUseContext.options` — minimal footprint).
  - Added `modelChangesForCompaction` guard in both `compactConversation()`
    and `streamCompactSummary()`: when `compactModel` is set and differs
    from `mainLoopModel`, bypass the forked-agent cache-sharing path
    (guaranteed miss with a different model anyway).
  - Pass `compactModel` (falling back to `mainLoopModel` when unset) to
    `queryModelWithStreaming()`, including the `maxOutputTokensOverride`
    guard.

## Behaviour

- `compactModel` unset → no behaviour change (existing path preserved).
- `compactModel === mainLoopModel` → no behaviour change.
- `compactModel` set and different → cache-sharing bypassed; streaming
  fallback runs with `compactModel`.

Closes #1445

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new **Compact Model** setting, including a dedicated picker submenu, to control the model used for message compaction.
* **Improvements**
  * Compaction now supports an optional compact-model override and disables prompt-cache sharing when the compact model differs from the main loop model.
  * Streaming compaction now derives tool-search behavior and output token limits from the effective compact model.
* **Tests**
  * Expanded compaction test coverage to validate compact-model alias resolution, cache-handling behavior, and overridden max output token limits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->