### PR TITLE
feat: add ultrathink keyword detection and ultracode effort level (#1551)

### DIFF
--- a/src/commands/effort/effort.test.tsx
+++ b/src/commands/effort/effort.test.tsx
@@ -1,0 +1,177 @@
+import { PassThrough } from 'node:stream'
+
+import { afterEach, beforeEach, expect, mock, test } from 'bun:test'
+import React from 'react'
+
+import { render } from '../../ink.js'
+import { AppStateProvider, getDefaultAppState } from '../../state/AppState.js'
+import {
+  acquireSharedMutationLock,
+  releaseSharedMutationLock,
+} from '../../test/sharedMutationLock.js'
+import * as actualAuth from '../../utils/auth.js'
+import * as actualModelSupportOverrides from '../../utils/model/modelSupportOverrides.js'
+import * as actualProviders from '../../utils/model/providers.js'
+import * as actualSettings from '../../utils/settings/settings.js'
+import * as actualThinking from '../../utils/thinking.js'
+import * as actualGrowthbook from '../../services/analytics/growthbook.js'
+
+beforeEach(async () => {
+  await acquireSharedMutationLock('commands/effort/effort.test.tsx')
+})
+
+afterEach(() => {
+  try {
+    mock.restore()
+  } finally {
+    releaseSharedMutationLock()
+  }
+})
+
+async function importFreshEffortCommandModule(): Promise<
+  typeof import('./effort.js')
+> {
+  mock.module('../../utils/model/providers.js', () => ({
+    ...actualProviders,
+    getAPIProvider: () => 'firstParty',
+  }))
+  mock.module('../../utils/model/modelSupportOverrides.js', () => ({
+    ...actualModelSupportOverrides,
+    get3PModelCapabilityOverride: () => undefined,
+  }))
+  mock.module('../../utils/settings/settings.js', () => ({
+    ...actualSettings,
+    updateSettingsForSource: () => ({ error: null }),
+  }))
+  mock.module('../../utils/auth.js', () => ({
+    ...actualAuth,
+    isProSubscriber: () => false,
+    isMaxSubscriber: () => false,
+    isTeamSubscriber: () => false,
+  }))
+  mock.module('../../utils/thinking.js', () => ({
+    ...actualThinking,
+    isUltrathinkEnabled: () => false,
+  }))
+  mock.module('../../services/analytics/growthbook.js', () => ({
+    ...actualGrowthbook,
+    getFeatureValue_CACHED_MAY_BE_STALE: (_key: string, fallback: unknown) =>
+      fallback,
+  }))
+
+  return import(`./effort.js?ts=${Date.now()}-${Math.random()}`) as Promise<
+    typeof import('./effort.js')
+  >
+}
+
+function createTestStreams(): {
+  stdout: PassThrough
+  stdin: PassThrough & {
+    isTTY: boolean
+    setRawMode: (mode: boolean) => void
+    ref: () => void
+    unref: () => void
+  }
+  getOutput: () => string
+} {
+  let output = ''
+  const stdout = new PassThrough()
+  const stdin = new PassThrough() as PassThrough & {
+    isTTY: boolean
+    setRawMode: (mode: boolean) => void
+    ref: () => void
+    unref: () => void
+  }
+  stdin.isTTY = true
+  stdin.setRawMode = () => {}
+  stdin.ref = () => {}
+  stdin.unref = () => {}
+  ;(stdout as unknown as { columns: number }).columns = 120
+  stdout.on('data', chunk => {
+    output += chunk.toString()
+  })
+
+  return {
+    stdout,
+    stdin,
+    getOutput: () => output,
+  }
+}
+
+test('/effort ultracode reports unavailable for a model without ultracode support', async () => {
+  const { call } = await importFreshEffortCommandModule()
+  const messages: (string | undefined)[] = []
+  const onDone = (result?: string) => {
+    messages.push(result)
+  }
+
+  const element = await call(onDone, {}, 'ultracode')
+  const { stdout, stdin } = createTestStreams()
+
+  const instance = await render(
+    <AppStateProvider
+      initialState={{
+        ...getDefaultAppState(),
+        mainLoopModelForSession: 'claude-sonnet-4-6',
+      }}
+    >
+      {element}
+    </AppStateProvider>,
+    {
+      stdout: stdout as unknown as NodeJS.WriteStream,
+      stdin: stdin as unknown as NodeJS.ReadStream,
+      patchConsole: false,
+    },
+  )
+
+  // Let the mount effect that calls onDone() flush before asserting.
+  await Bun.sleep(10)
+  instance.unmount()
+  stdin.end()
+  stdout.end()
+
+  expect(messages).toEqual([
+    'ultracode is not available for your current model and provider. Use /effort without arguments to see available options.',
+  ])
+})
+
+test('/effort ultracode applies the ultracode session effort when available', async () => {
+  const { call } = await importFreshEffortCommandModule()
+  const messages: (string | undefined)[] = []
+  const onDone = (result?: string) => {
+    messages.push(result)
+  }
+
+  const element = await call(onDone, {}, 'ultracode')
+  const { stdout, stdin } = createTestStreams()
+
+  let finalEffortValue: string | number | undefined
+  const instance = await render(
+    <AppStateProvider
+      initialState={{
+        ...getDefaultAppState(),
+        mainLoopModelForSession: 'claude-opus-4-8',
+      }}
+      onChangeAppState={({ newState }) => {
+        finalEffortValue = newState.effortValue
+      }}
+    >
+      {element}
+    </AppStateProvider>,
+    {
+      stdout: stdout as unknown as NodeJS.WriteStream,
+      stdin: stdin as unknown as NodeJS.ReadStream,
+      patchConsole: false,
+    },
+  )
+
+  // Let the mount effect that calls onDone() flush before asserting.
+  await Bun.sleep(10)
+  instance.unmount()
+  stdin.end()
+  stdout.end()
+
+  expect(messages).toHaveLength(1)
+  expect(messages[0]).toMatch(/^Set effort level to ultracode/)
+  expect(finalEffortValue).toBe('ultracode')
+})

--- a/src/commands/effort/effort.test.tsx
+++ b/src/commands/effort/effort.test.tsx
@@ -16,13 +16,21 @@ import * as actualSettings from '../../utils/settings/settings.js'
 import * as actualThinking from '../../utils/thinking.js'
 import * as actualGrowthbook from '../../services/analytics/growthbook.js'
 
+const originalEffortEnv = process.env.CLAUDE_CODE_EFFORT_LEVEL
+
 beforeEach(async () => {
   await acquireSharedMutationLock('commands/effort/effort.test.tsx')
+  delete process.env.CLAUDE_CODE_EFFORT_LEVEL
 })
 
 afterEach(() => {
   try {
     mock.restore()
+    if (originalEffortEnv === undefined) {
+      delete process.env.CLAUDE_CODE_EFFORT_LEVEL
+    } else {
+      process.env.CLAUDE_CODE_EFFORT_LEVEL = originalEffortEnv
+    }
   } finally {
     releaseSharedMutationLock()
   }
@@ -173,5 +181,56 @@ test('/effort ultracode applies the ultracode session effort when available', as
 
   expect(messages).toHaveLength(1)
   expect(messages[0]).toMatch(/^Set effort level to ultracode/)
+  expect(finalEffortValue).toBe('ultracode')
+})
+
+test('/effort picker reports env override when selecting ultracode', async () => {
+  mock.module('../../components/EffortPicker.js', () => ({
+    EffortPicker: ({ onSelect }: { onSelect: (effort: string) => void }) => {
+      React.useEffect(() => {
+        onSelect('ultracode')
+      }, [onSelect])
+      return null
+    },
+  }))
+
+  const { call } = await importFreshEffortCommandModule()
+  const messages: (string | undefined)[] = []
+  const onDone = (result?: string) => {
+    messages.push(result)
+  }
+
+  process.env.CLAUDE_CODE_EFFORT_LEVEL = 'high'
+  const element = await call(onDone, {}, '')
+  const { stdout, stdin } = createTestStreams()
+
+  let finalEffortValue: string | number | undefined
+  const instance = await render(
+    <AppStateProvider
+      initialState={{
+        ...getDefaultAppState(),
+        mainLoopModelForSession: 'claude-opus-4-8',
+      }}
+      onChangeAppState={({ newState }) => {
+        finalEffortValue = newState.effortValue
+      }}
+    >
+      {element}
+    </AppStateProvider>,
+    {
+      stdout: stdout as unknown as NodeJS.WriteStream,
+      stdin: stdin as unknown as NodeJS.ReadStream,
+      patchConsole: false,
+    },
+  )
+
+  await Bun.sleep(10)
+  instance.unmount()
+  stdin.end()
+  stdout.end()
+
+  expect(messages).toEqual([
+    'Not applied: CLAUDE_CODE_EFFORT_LEVEL=high overrides effort this session, and ultracode is session-only (nothing saved)',
+  ])
   expect(finalEffortValue).toBe('ultracode')
 })

--- a/src/commands/effort/effort.tsx
+++ b/src/commands/effort/effort.tsx
@@ -210,22 +210,14 @@ function EffortPickerWrapper({ onDone }: { onDone: LocalJSXCommandOnDone }) {
   const usesOpenAIEffort = modelUsesOpenAIEffort(model);
 
   function handleSelect(effort: EffortValue | undefined) {
-    const persistable = toPersistableEffort(effort);
-    if (persistable !== undefined) {
-      updateSettingsForSource('userSettings', {
-        effortLevel: persistable
-      });
+    const result = effort === undefined ? unsetEffortLevel() : setEffortValue(effort);
+    if (result.effortUpdate) {
+      setAppState(prev => ({
+        ...prev,
+        effortValue: result.effortUpdate?.value
+      }));
     }
-    logEvent('tengu_effort_command', {
-      effort: (effort ?? 'auto') as AnalyticsMetadata_I_VERIFIED_THIS_IS_NOT_CODE_OR_FILEPATHS
-    });
-    setAppState(prev => ({
-      ...prev,
-      effortValue: effort
-    }));
-    const description = effort ? getEffortValueDescription(effort) : 'Use default effort level for your model';
-    const suffix = persistable !== undefined ? '' : ' (this session only)';
-    onDone(`Set effort level to ${effort ?? 'auto'}${suffix}: ${description}`);
+    onDone(result.message);
   }
 
   function handleCancel() {

--- a/src/commands/effort/effort.tsx
+++ b/src/commands/effort/effort.tsx
@@ -4,7 +4,7 @@ import { useMainLoopModel } from '../../hooks/useMainLoopModel.js';
 import { type AnalyticsMetadata_I_VERIFIED_THIS_IS_NOT_CODE_OR_FILEPATHS, logEvent } from '../../services/analytics/index.js';
 import { useAppState, useSetAppState } from '../../state/AppState.js';
 import type { LocalJSXCommandOnDone } from '../../types/command.js';
-import { type EffortValue, getDisplayedEffortLevel, getEffortEnvOverride, getEffortValueDescription, isEffortLevel, isOpenAIEffortLevel, modelUsesOpenAIEffort, openAIEffortToStandard, toPersistableEffort } from '../../utils/effort.js';
+import { type EffortValue, clampUltracodeEffort, getAvailableEffortLevels, getDisplayedEffortLevel, getEffortEnvOverride, getEffortValueDescription, isEffortLevel, isOpenAIEffortLevel, modelUsesOpenAIEffort, openAIEffortToStandard, toPersistableEffort } from '../../utils/effort.js';
 import { EffortPicker } from '../../components/EffortPicker.js';
 import { updateSettingsForSource } from '../../utils/settings/settings.js';
 const COMMON_HELP_ARGS = ['help', '-h', '--help'];
@@ -62,7 +62,8 @@ function setEffortValue(effortValue: EffortValue): EffortCommandResult {
 }
 export function showCurrentEffort(appStateEffort: EffortValue | undefined, model: string): EffortCommandResult {
   const envOverride = getEffortEnvOverride();
-  const effectiveValue = envOverride === null ? undefined : envOverride ?? appStateEffort;
+  const rawEffectiveValue = envOverride === null ? undefined : envOverride ?? appStateEffort;
+  const effectiveValue = rawEffectiveValue !== undefined ? clampUltracodeEffort(rawEffectiveValue, model) : undefined;
   if (effectiveValue === undefined) {
     const level = getDisplayedEffortLevel(model, appStateEffort);
     return {
@@ -118,7 +119,7 @@ export function executeEffort(args: string): EffortCommandResult {
     return setEffortValue(openAIEffortToStandard(normalized));
   }
   return {
-    message: `Invalid argument: ${args}. Valid options are: low, medium, high, max, xhigh, auto`
+    message: `Invalid argument: ${args}. Valid options are: low, medium, high, max, xhigh, ultracode, auto`
   };
 }
 function ShowCurrentEffort(t0) {
@@ -173,10 +174,20 @@ function ApplyEffortAndClose(t0) {
   React.useEffect(t1, t2);
   return null;
 }
+function UltracodeCommand({ onDone }: { onDone: LocalJSXCommandOnDone }) {
+  const model = useMainLoopModel();
+  const result = React.useMemo(() => {
+    if (!getAvailableEffortLevels(model).includes('ultracode')) {
+      return { message: 'ultracode is not available for your current model and provider. Use /effort without arguments to see available options.' };
+    }
+    return setEffortValue('ultracode' as EffortValue);
+  }, [model]);
+  return <ApplyEffortAndClose result={result} onDone={onDone} />;
+}
 export async function call(onDone: LocalJSXCommandOnDone, _context: unknown, args?: string): Promise<React.ReactNode> {
   args = args?.trim() || '';
   if (COMMON_HELP_ARGS.includes(args)) {
-    onDone('Usage: /effort [low|medium|high|max|xhigh|auto]\n\nEffort levels:\n- low: Quick, straightforward implementation\n- medium: Balanced approach with standard testing\n- high: Comprehensive implementation with extensive testing\n- max: Maximum capability with deepest reasoning (Opus 4.8+)\n- xhigh: Extra-high reasoning (OpenAI/Codex and Opus 4.7+)\n- auto: Use the default effort level for your model');
+    onDone('Usage: /effort [low|medium|high|max|xhigh|ultracode|auto]\n\nEffort levels:\n- low: Quick, straightforward implementation\n- medium: Balanced approach with standard testing\n- high: Comprehensive implementation with extensive testing\n- max: Maximum capability with deepest reasoning (Opus 4.8+)\n- xhigh: Extra-high reasoning (OpenAI/Codex and Opus 4.7+)\n- ultracode: Ultracode session-only mode with multi-agent orchestration permission (Anthropic first-party + xhigh-capable models only)\n- auto: Use the default effort level for your model');
     return;
   }
   if (args === 'current' || args === 'status') {
@@ -184,6 +195,10 @@ export async function call(onDone: LocalJSXCommandOnDone, _context: unknown, arg
   }
   if (!args) {
     return <EffortPickerWrapper onDone={onDone} />;
+  }
+  // ultracode is gated to the same provider/model check as the picker
+  if (args.toLowerCase() === 'ultracode') {
+    return <UltracodeCommand onDone={onDone} />;
   }
   const result = executeEffort(args);
   return <ApplyEffortAndClose result={result} onDone={onDone} />;

--- a/src/commands/effort/index.ts
+++ b/src/commands/effort/index.ts
@@ -5,7 +5,7 @@ export default {
   type: 'local-jsx',
   name: 'effort',
   description: 'Set effort level for model usage',
-  argumentHint: '[low|medium|high|max|auto]',
+  argumentHint: '[low|medium|high|xhigh|max|ultracode|auto]',
   get immediate() {
     return shouldInferenceConfigCommandBeImmediate()
   },

--- a/src/commands/model/model.test.tsx
+++ b/src/commands/model/model.test.tsx
@@ -453,6 +453,48 @@ test('/model current reports the effective effort when env overrides session ult
   expect(messages[0]).not.toContain('(effort: ultracode)')
 })
 
+test('/model current resolves effort against the active session model', async () => {
+  const { call } = await importFreshModelModule('current-session-model-effort')
+  const { AppStateProvider, getDefaultAppState } = await import('../../state/AppState.js')
+  const { render } = await import('../../ink.js')
+  const messages: string[] = []
+  const stdout = new PassThrough()
+  ;(stdout as unknown as { columns: number }).columns = 120
+
+  delete process.env.CLAUDE_CODE_EFFORT_LEVEL
+  const element = await call(
+    result => {
+      if (result) messages.push(result)
+    },
+    {} as never,
+    'current',
+  )
+
+  const instance = await render(
+    <AppStateProvider
+      initialState={{
+        ...getDefaultAppState(),
+        mainLoopModel: 'claude-opus-4-8',
+        mainLoopModelForSession: 'claude-sonnet-4-6',
+        effortValue: 'ultracode',
+      }}
+    >
+      {element}
+    </AppStateProvider>,
+    stdout as unknown as NodeJS.WriteStream,
+  )
+
+  await waitForCondition(() => messages.length > 0)
+  instance.unmount()
+  stdout.end()
+
+  expect(messages[0]).toContain('Current model:')
+  expect(messages[0]).toContain('session override from plan mode')
+  expect(messages[0]).toContain('Base model:')
+  expect(messages[0]).toContain('(effort: high)')
+  expect(messages[0]).not.toContain('(effort: xhigh)')
+})
+
 test('opens the model picker without awaiting descriptor-backed route refresh', async () => {
   process.env.CLAUDE_CODE_USE_OPENAI = '1'
   process.env.OPENAI_BASE_URL = 'https://openrouter.ai/api/v1'

--- a/src/commands/model/model.test.tsx
+++ b/src/commands/model/model.test.tsx
@@ -449,7 +449,8 @@ test('/model current reports the effective effort when env overrides session ult
   instance.unmount()
   stdout.end()
 
-  expect(messages[0]).toBe('Current model: Opus 4.8 (effort: high)')
+  expect(messages[0]).toContain('(effort: high)')
+  expect(messages[0]).not.toContain('(effort: ultracode)')
 })
 
 test('opens the model picker without awaiting descriptor-backed route refresh', async () => {

--- a/src/commands/model/model.test.tsx
+++ b/src/commands/model/model.test.tsx
@@ -33,6 +33,7 @@ const originalEnv = {
   OPENROUTER_API_KEY: process.env.OPENROUTER_API_KEY,
   OPENAI_MODEL: process.env.OPENAI_MODEL,
   ANTHROPIC_CUSTOM_HEADERS: process.env.ANTHROPIC_CUSTOM_HEADERS,
+  CLAUDE_CODE_EFFORT_LEVEL: process.env.CLAUDE_CODE_EFFORT_LEVEL,
   CLAUDE_CODE_PROVIDER_PROFILE_ENV_APPLIED:
     process.env.CLAUDE_CODE_PROVIDER_PROFILE_ENV_APPLIED,
   CLAUDE_CODE_PROVIDER_PROFILE_ENV_APPLIED_ID:
@@ -214,6 +215,7 @@ afterEach(() => {
     restoreEnv('OPENROUTER_API_KEY', originalEnv.OPENROUTER_API_KEY)
     restoreEnv('OPENAI_MODEL', originalEnv.OPENAI_MODEL)
     restoreEnv('ANTHROPIC_CUSTOM_HEADERS', originalEnv.ANTHROPIC_CUSTOM_HEADERS)
+    restoreEnv('CLAUDE_CODE_EFFORT_LEVEL', originalEnv.CLAUDE_CODE_EFFORT_LEVEL)
     restoreEnv(
       'CLAUDE_CODE_PROVIDER_PROFILE_ENV_APPLIED',
       originalEnv.CLAUDE_CODE_PROVIDER_PROFILE_ENV_APPLIED,
@@ -411,6 +413,43 @@ test('opens the model picker without awaiting local model discovery refresh', as
   // Use a fresh module instance so per-test mocks stay local to this test.
   const { call } = await importFreshModelModule('local-discovery')
   await expectModelCommandDoesNotWaitForRefresh(call(() => {}, {} as never, ''))
+})
+
+test('/model current reports the effective effort when env overrides session ultracode', async () => {
+  const { call } = await importFreshModelModule('current-effective-effort')
+  const { AppStateProvider, getDefaultAppState } = await import('../../state/AppState.js')
+  const { render } = await import('../../ink.js')
+  const messages: string[] = []
+  const stdout = new PassThrough()
+  ;(stdout as unknown as { columns: number }).columns = 120
+
+  process.env.CLAUDE_CODE_EFFORT_LEVEL = 'high'
+  const element = await call(
+    result => {
+      if (result) messages.push(result)
+    },
+    {} as never,
+    'current',
+  )
+
+  const instance = await render(
+    <AppStateProvider
+      initialState={{
+        ...getDefaultAppState(),
+        mainLoopModel: 'claude-opus-4-8',
+        effortValue: 'ultracode',
+      }}
+    >
+      {element}
+    </AppStateProvider>,
+    stdout as unknown as NodeJS.WriteStream,
+  )
+
+  await waitForCondition(() => messages.length > 0)
+  instance.unmount()
+  stdout.end()
+
+  expect(messages[0]).toBe('Current model: Opus 4.8 (effort: high)')
 })
 
 test('opens the model picker without awaiting descriptor-backed route refresh', async () => {

--- a/src/commands/model/model.tsx
+++ b/src/commands/model/model.tsx
@@ -984,8 +984,10 @@ function ShowModelAndClose({
   )
   const effortValue = useAppState((s: AppState) => s.effortValue)
   const displayModel = renderModelLabel(mainLoopModel)
+  const activeModel =
+    mainLoopModelForSession ?? mainLoopModel ?? getDefaultMainLoopModelSetting()
   const effectiveEffort = resolveAppliedEffort(
-    mainLoopModel ?? getDefaultMainLoopModelSetting(),
+    activeModel,
     effortValue,
   )
   const effortEnvOverride = getEffortEnvOverride()

--- a/src/commands/model/model.tsx
+++ b/src/commands/model/model.tsx
@@ -38,7 +38,11 @@ import type { ProviderProfile } from '../../utils/config.js'
 import type { AppState } from '../../state/AppState.js'
 import { useAppState, useSetAppState } from '../../state/AppState.js'
 import type { LocalJSXCommandCall } from '../../types/command.js'
-import type { EffortLevel } from '../../utils/effort.js'
+import {
+  type EffortLevel,
+  getEffortEnvOverride,
+  resolveAppliedEffort,
+} from '../../utils/effort.js'
 import { isBilledAsExtraUsage } from '../../utils/extraUsage.js'
 import {
   clearFastModeCooldown,
@@ -980,8 +984,17 @@ function ShowModelAndClose({
   )
   const effortValue = useAppState((s: AppState) => s.effortValue)
   const displayModel = renderModelLabel(mainLoopModel)
+  const effectiveEffort = resolveAppliedEffort(
+    mainLoopModel ?? getDefaultMainLoopModelSetting(),
+    effortValue,
+  )
+  const effortEnvOverride = getEffortEnvOverride()
   const effortInfo =
-    effortValue !== undefined ? ` (effort: ${effortValue})` : ''
+    effectiveEffort !== undefined
+      ? ` (effort: ${effectiveEffort})`
+      : effortEnvOverride === null
+        ? ' (effort: auto)'
+        : ''
 
   if (mainLoopModelForSession) {
     onDone(

--- a/src/components/Spinner.tsx
+++ b/src/components/Spinner.tsx
@@ -28,7 +28,7 @@ import { isInProcessTeammateTask } from '../tasks/InProcessTeammateTask/types.js
 import { isBackgroundTask } from '../tasks/types.js';
 import { getAllInProcessTeammateTasks } from '../tasks/InProcessTeammateTask/InProcessTeammateTask.js';
 import { getEffortSuffix } from '../utils/effort.js';
-import { getMainLoopModel } from '../utils/model/model.js';
+import { useMainLoopModel } from '../hooks/useMainLoopModel.js';
 import { getViewedTeammateTask } from '../state/selectors.js';
 import { TEARDROP_ASTERISK } from '../constants/figures.js';
 import figures from 'figures';
@@ -178,8 +178,9 @@ function SpinnerWithVerbInner({
       activityManager.endCLIActivity(operationId);
     };
   }, [mode]);
+  const mainLoopModel = useMainLoopModel();
   const effortValue = useAppState(s_4 => s_4.effortValue);
-  const effortSuffix = getEffortSuffix(getMainLoopModel(), effortValue);
+  const effortSuffix = getEffortSuffix(mainLoopModel, effortValue);
 
   // Check if any running in-process teammates exist (needed for both modes)
   const runningTeammates = getAllInProcessTeammateTasks(tasks).filter(t => t.status === 'running');

--- a/src/components/messages/nullRenderingAttachments.ts
+++ b/src/components/messages/nullRenderingAttachments.ts
@@ -42,6 +42,7 @@ const NULL_RENDERING_TYPES = [
   'companion_intro',
   'token_usage',
   'ultrathink_effort',
+  'ultracode_mode',
   'max_turns_reached',
   'task_reminder',
   'auto_mode',

--- a/src/entrypoints/sdk/coreSchemas.ts
+++ b/src/entrypoints/sdk/coreSchemas.ts
@@ -1081,7 +1081,7 @@ export const ModelInfoSchema = lazySchema(() =>
         .optional()
         .describe('Whether this model supports effort levels'),
       supportedEffortLevels: z
-        .array(z.enum(['low', 'medium', 'high', 'xhigh', 'max']))
+        .array(z.enum(['low', 'medium', 'high', 'xhigh', 'max', 'ultracode']))
         .optional()
         .describe('Available effort levels for this model'),
       supportsAdaptiveThinking: z

--- a/src/entrypoints/sdk/coreTypes.generated.ts
+++ b/src/entrypoints/sdk/coreTypes.generated.ts
@@ -1470,7 +1470,7 @@ export type ModelInfo = {
   displayName: string
   description: string
   supportsEffort?: boolean
-  supportedEffortLevels?: ("low" | "medium" | "high" | "xhigh" | "max")[]
+  supportedEffortLevels?: ("low" | "medium" | "high" | "xhigh" | "max" | "ultracode")[]
   supportsAdaptiveThinking?: boolean
   supportsFastMode?: boolean
   supportsAutoMode?: boolean

--- a/src/entrypoints/sdk/runtimeTypes.ts
+++ b/src/entrypoints/sdk/runtimeTypes.ts
@@ -10,7 +10,7 @@
 import type { z } from 'zod/v4'
 import type { Query, QueryOptions } from './query.js'
 
-export type EffortLevel = 'low' | 'medium' | 'high' | 'max' | 'xhigh'
+export type EffortLevel = 'low' | 'medium' | 'high' | 'max' | 'xhigh' | 'ultracode'
 
 // ============================================================================
 // Zod helpers for tool() input schemas

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -52,7 +52,7 @@ import { count, uniq } from './utils/array.js';
 import { getSubscriptionType, isClaudeAISubscriber, prefetchAwsCredentialsAndBedRockInfoIfSafe, prefetchGcpCredentialsIfSafe, validateForceLoginOrg } from './utils/auth.js';
 import { checkHasTrustDialogAccepted, getGlobalConfig, getRemoteControlAtStartup, isAutoUpdaterDisabled, saveGlobalConfig } from './utils/config.js';
 import { seedEarlyInput, stopCapturingEarlyInput } from './utils/earlyInput.js';
-import { getInitialEffortSetting, parseEffortValue } from './utils/effort.js';
+import { clampUltracodeEffort, getInitialEffortSetting, parseEffortValue } from './utils/effort.js';
 import { getInitialFastModeSetting, isFastModeEnabled, prefetchFastModeStatus, resolveFastModeStatusFromCache } from './utils/fastMode.js';
 import { applyConfigEnvironmentVariables } from './utils/managedEnv.js';
 import { createSystemMessage, createUserMessage } from './utils/messages.js';
@@ -963,9 +963,9 @@ async function run(): Promise<CommanderCommand> {
     return Number.isFinite(n) ? n : undefined;
   }).hideHelp()).option('--from-pr [value]', 'Resume a session linked to a PR by PR number/URL, or open interactive picker with optional search term', value => value || true).option('--no-session-persistence', 'Disable session persistence - sessions will not be saved to disk and cannot be resumed (only works with --print)').addOption(new Option('--resume-session-at <message id>', 'When resuming, only messages up to and including the assistant message with <message.id> (use with --resume in print mode)').argParser(String).hideHelp()).addOption(new Option('--rewind-files <user-message-id>', 'Restore files to state at the specified user message and exit (requires --resume)').hideHelp())
   // @[MODEL LAUNCH]: Update the example model ID in the --model help text.
-  .option('--model <model>', `Model for the current session. Provide an alias for the latest model (e.g. 'sonnet' or 'opus') or a model's full name (e.g. 'claude-sonnet-4-6').`).option('--provider <provider>', `AI provider to use (anthropic, openai, gemini, github, bedrock, vertex, ollama). Reads API keys from environment variables.`).addOption(new Option('--effort <level>', `Effort level for the current session (low, medium, high, xhigh, max)`).argParser((rawValue: string) => {
+  .option('--model <model>', `Model for the current session. Provide an alias for the latest model (e.g. 'sonnet' or 'opus') or a model's full name (e.g. 'claude-sonnet-4-6').`).option('--provider <provider>', `AI provider to use (anthropic, openai, gemini, github, bedrock, vertex, ollama). Reads API keys from environment variables.`).addOption(new Option('--effort <level>', `Effort level for the current session (low, medium, high, xhigh, max, ultracode)`).argParser((rawValue: string) => {
     const value = rawValue.toLowerCase();
-    const allowed = ['low', 'medium', 'high', 'xhigh', 'max'];
+    const allowed = ['low', 'medium', 'high', 'xhigh', 'max', 'ultracode'];
     if (!allowed.includes(value)) {
       throw new InvalidArgumentError(`It must be one of: ${allowed.join(', ')}`);
     }
@@ -2578,7 +2578,7 @@ async function run(): Promise<CommanderCommand> {
           tools: mcpTools
         },
         toolPermissionContext,
-        effortValue: parseEffortValue(options.effort) ?? getInitialEffortSetting(),
+        effortValue: clampUltracodeEffort(parseEffortValue(options.effort) ?? getInitialEffortSetting(), effectiveModel ?? resolvedInitialModel),
         ...(isFastModeEnabled() && {
           fastMode: getInitialFastModeSetting(effectiveModel ?? null)
         }),
@@ -2991,7 +2991,7 @@ async function run(): Promise<CommanderCommand> {
           content: String(inputPrompt)
         })
       } : null,
-      effortValue: parseEffortValue(options.effort) ?? getInitialEffortSetting(),
+      effortValue: clampUltracodeEffort(parseEffortValue(options.effort) ?? getInitialEffortSetting(), effectiveModel ?? resolvedInitialModel),
       activeOverlays: new Set<string>(),
       fastMode: getInitialFastModeSetting(resolvedInitialModel),
       ...(isAdvisorEnabled() && advisorModel && {

--- a/src/services/api/claude.ts
+++ b/src/services/api/claude.ts
@@ -450,7 +450,7 @@ function should1hCacheTTL(querySource?: QuerySource): boolean {
  *
  */
 function configureEffortParams(
-  effortValue: EffortValue | undefined,
+  effortValue: Exclude<EffortValue, 'ultracode'> | undefined,
   outputConfig: BetaOutputConfig,
   extraBodyParams: Record<string, unknown>,
   betas: string[],

--- a/src/skills/loadSkillsDir.ts
+++ b/src/skills/loadSkillsDir.ts
@@ -27,7 +27,7 @@ import { logForDebugging } from '../utils/debug.js'
 import {
   EFFORT_LEVELS,
   type EffortValue,
-  parseEffortValue,
+  parseFrontmatterEffortValue,
 } from '../utils/effort.js'
 import {
   getClaudeConfigHomeDir,
@@ -227,10 +227,12 @@ export function parseSkillFrontmatterFields(
 
   const effortRaw = frontmatter['effort']
   const effort =
-    effortRaw !== undefined ? parseEffortValue(effortRaw) : undefined
+    effortRaw !== undefined ? parseFrontmatterEffortValue(effortRaw) : undefined
   if (effortRaw !== undefined && effort === undefined) {
     logForDebugging(
-      `Skill ${resolvedName} has invalid effort '${effortRaw}'. Valid options: ${EFFORT_LEVELS.join(', ')} or an integer`,
+      String(effortRaw).toLowerCase() === 'ultracode'
+        ? `Skill ${resolvedName} requested effort 'ultracode', a session-only mode not supported in frontmatter; ignoring.`
+        : `Skill ${resolvedName} has invalid effort '${effortRaw}'. Valid options: ${EFFORT_LEVELS.filter(l => l !== 'ultracode').join(', ')} or an integer`,
     )
   }
 

--- a/src/tools/AgentTool/loadAgentsDir.test.ts
+++ b/src/tools/AgentTool/loadAgentsDir.test.ts
@@ -5,6 +5,7 @@ import { dirname, join } from 'path'
 import {
   clearAgentDefinitionsCache,
   getAgentDefinitionsWithOverrides,
+  parseAgentFromJson,
 } from './loadAgentsDir.js'
 import { loadMarkdownFilesForSubdir } from '../../utils/markdownConfigLoader.js'
 import {
@@ -156,5 +157,38 @@ describe('agent definition loading', () => {
 
     expect(agent).toBeDefined()
     expect(agent?.isolation).toBeUndefined()
+  })
+})
+
+describe('parseAgentFromJson effort handling', () => {
+  // ultracode is a session-only meta-mode and must not be settable from an agent
+  // definition, so the JSON schema drops it (like the markdown/skill/plugin
+  // frontmatter and SDK paths) while preserving every other effort value.
+  test('drops ultracode from a JSON agent definition', () => {
+    const agent = parseAgentFromJson('my-agent', {
+      description: 'desc',
+      prompt: 'sys',
+      effort: 'ultracode',
+    })
+    expect(agent).not.toBeNull()
+    expect(agent?.effort).toBeUndefined()
+  })
+
+  test('preserves a non-ultracode effort level', () => {
+    const agent = parseAgentFromJson('my-agent', {
+      description: 'desc',
+      prompt: 'sys',
+      effort: 'high',
+    })
+    expect(agent?.effort).toBe('high')
+  })
+
+  test('preserves a numeric effort value', () => {
+    const agent = parseAgentFromJson('my-agent', {
+      description: 'desc',
+      prompt: 'sys',
+      effort: 2,
+    })
+    expect(agent?.effort).toBe(2)
   })
 })

--- a/src/tools/AgentTool/loadAgentsDir.ts
+++ b/src/tools/AgentTool/loadAgentsDir.ts
@@ -17,7 +17,7 @@ import { logForDebugging } from '../../utils/debug.js'
 import {
   EFFORT_LEVELS,
   type EffortValue,
-  parseEffortValue,
+  parseFrontmatterEffortValue,
 } from '../../utils/effort.js'
 import { parsePositiveIntFromFrontmatter } from '../../utils/frontmatterParser.js'
 import { lazySchema } from '../../utils/lazySchema.js'
@@ -81,7 +81,14 @@ const AgentJsonSchema = lazySchema(() =>
       .min(1, 'Model cannot be empty')
       .transform(m => (m.toLowerCase() === 'inherit' ? 'inherit' : m))
       .optional(),
-    effort: z.union([z.enum(EFFORT_LEVELS), z.number().int()]).optional(),
+    // ultracode is a session-only meta-mode and must not be settable from an
+    // agent definition, so route the value through parseFrontmatterEffortValue
+    // (which drops ultracode) — same as the markdown/skill/plugin frontmatter
+    // and SDK schema paths, so every agent-definition input agrees.
+    effort: z
+      .union([z.enum(EFFORT_LEVELS), z.number().int()])
+      .optional()
+      .transform(parseFrontmatterEffortValue),
     permissionMode: z.enum(PERMISSION_MODES).optional(),
     mcpServers: z.array(AgentMcpServerSpecSchema()).optional(),
     hooks: HooksSchema().optional(),
@@ -606,14 +613,17 @@ export function parseAgentFromMarkdown(
       }
     }
 
-    // Parse effort from frontmatter (supports string levels and integers)
+    // Parse effort from frontmatter (supports string levels and integers).
+    // ultracode is rejected here — see parseFrontmatterEffortValue.
     const effortRaw = frontmatter['effort']
     const parsedEffort =
-      effortRaw !== undefined ? parseEffortValue(effortRaw) : undefined
+      effortRaw !== undefined ? parseFrontmatterEffortValue(effortRaw) : undefined
 
     if (effortRaw !== undefined && parsedEffort === undefined) {
       logForDebugging(
-        `Agent file ${filePath} has invalid effort '${effortRaw}'. Valid options: ${EFFORT_LEVELS.join(', ')} or an integer`,
+        String(effortRaw).toLowerCase() === 'ultracode'
+          ? `Agent file ${filePath} requested effort 'ultracode', a session-only mode not supported in frontmatter; ignoring.`
+          : `Agent file ${filePath} has invalid effort '${effortRaw}'. Valid options: ${EFFORT_LEVELS.filter(l => l !== 'ultracode').join(', ')} or an integer`,
       )
     }
 

--- a/src/utils/attachments.ts
+++ b/src/utils/attachments.ts
@@ -64,6 +64,8 @@ import {
 } from 'src/types/textInputTypes.js'
 import { randomUUID, type UUID } from 'crypto'
 import { getSettings_DEPRECATED } from './settings/settings.js'
+import { getAPIProvider } from './model/providers.js'
+import { getEffortEnvOverride, modelSupportsXHighEffort } from './effort.js'
 import { getSnippetForTwoFileDiff } from 'src/tools/FileEditTool/utils.js'
 import type {
   ContentBlockParam,
@@ -701,6 +703,9 @@ export type Attachment =
       level: 'high'
     }
   | {
+      type: 'ultracode_mode'
+    }
+  | {
       type: 'deferred_tools_delta'
       addedNames: string[]
       addedLines: string[]
@@ -850,6 +855,9 @@ export async function getAttachments(
     ),
     maybe('ultrathink_effort', () =>
       Promise.resolve(getUltrathinkEffortAttachment(input)),
+    ),
+    maybe('ultracode_mode', () =>
+      Promise.resolve(getUltracodePermissionAttachment(toolUseContext)),
     ),
     maybe('deferred_tools_delta', () =>
       Promise.resolve(
@@ -1464,11 +1472,43 @@ export function getDateChangeAttachments(
 }
 
 function getUltrathinkEffortAttachment(input: string | null): Attachment[] {
-  if (!isUltrathinkEnabled() || !input || !hasUltrathinkKeyword(input)) {
+  // Gate the model-facing attachment behind the same rollout flag as the UI.
+  // Without this, the hidden `ultrathink_effort` attachment would still raise
+  // the turn to high effort even when the ULTRATHINK build flag / GrowthBook
+  // rollout is disabled.
+  if (!input || !isUltrathinkEnabled() || !hasUltrathinkKeyword(input)) {
     return []
   }
   logEvent('tengu_ultrathink', {})
   return [{ type: 'ultrathink_effort', level: 'high' }]
+}
+
+// Exported for focused testing of the first-party / provider-override gating.
+export function getUltracodePermissionAttachment(toolUseContext: ToolUseContext): Attachment[] {
+  const effortValue = toolUseContext.getAppState().effortValue
+  const envOverride = getEffortEnvOverride()
+  // Mirror resolveAppliedEffort's precedence so the permission tracks the effort
+  // the API actually runs with: a set CLAUDE_CODE_EFFORT_LEVEL wins over app
+  // state, and `null` (auto/unset) clears it. Otherwise `/effort ultracode` with
+  // CLAUDE_CODE_EFFORT_LEVEL=high would still leak ultracode_mode for a turn the
+  // API runs at high.
+  const effectiveEffort =
+    envOverride === null ? undefined : (envOverride ?? effortValue)
+  const isUltracode = effectiveEffort === 'ultracode'
+  if (
+    !isUltracode ||
+    getAPIProvider() !== 'firstParty' ||
+    // A per-agent providerOverride routes the actual request through a
+    // third-party shim (runAgent.ts sets it; query.ts forwards it to
+    // getAnthropicClient()), so the process-wide first-party check above is not
+    // enough. Suppress the first-party-only ultracode permission reminder
+    // whenever an override is in effect so it cannot leak into routed calls.
+    Boolean(toolUseContext.options.providerOverride) ||
+    !modelSupportsXHighEffort(toolUseContext.options.mainLoopModel)
+  ) {
+    return []
+  }
+  return [{ type: 'ultracode_mode' }]
 }
 
 // Exported for compact.ts — the gate must be identical at both call sites.

--- a/src/utils/attachments.ultracode.test.ts
+++ b/src/utils/attachments.ultracode.test.ts
@@ -1,0 +1,112 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import { getUltracodePermissionAttachment } from './attachments.js'
+import type { ToolUseContext } from '../Tool.js'
+
+// The standing `ultracode` multi-agent permission reminder is first-party only
+// and must never leak into a routed third-party agent call. These tests pin that
+// gating directly on the attachment builder, which is the security-sensitive
+// behavior that previously leaked a first-party permission into provider-routed
+// subagent requests. @see #1551
+//
+// Routing env vars are cleared so getAPIProvider() resolves to 'firstParty'
+// (its default), isolating the gating decisions to the tool-use context.
+const ROUTING_ENV_VARS = [
+  'CLAUDE_CODE_USE_GEMINI',
+  'CLAUDE_CODE_USE_GITHUB',
+  'CLAUDE_CODE_USE_MISTRAL',
+  'CLAUDE_CODE_USE_BEDROCK',
+  'CLAUDE_CODE_USE_VERTEX',
+  'CLAUDE_CODE_USE_FOUNDRY',
+  'CLAUDE_CODE_USE_OPENAI',
+  'CLAUDE_CODE_PROVIDER_PROFILE_ENV_APPLIED',
+  'CLAUDE_CODE_PROVIDER_PROFILE_ENV_APPLIED_ID',
+  'NVIDIA_NIM',
+  'CLAUDE_CODE_EFFORT_LEVEL',
+]
+
+const savedEnv: Record<string, string | undefined> = {}
+
+beforeEach(() => {
+  for (const key of ROUTING_ENV_VARS) {
+    savedEnv[key] = process.env[key]
+    delete process.env[key]
+  }
+})
+
+afterEach(() => {
+  for (const key of ROUTING_ENV_VARS) {
+    if (savedEnv[key] === undefined) {
+      delete process.env[key]
+    } else {
+      process.env[key] = savedEnv[key]
+    }
+  }
+})
+
+function makeContext(opts: {
+  effortValue?: string
+  mainLoopModel?: string
+  providerOverride?: { model: string; baseURL: string; apiKey: string }
+}): ToolUseContext {
+  return {
+    getAppState: () => ({ effortValue: opts.effortValue ?? 'ultracode' }),
+    options: {
+      mainLoopModel: opts.mainLoopModel ?? 'claude-opus-4-8',
+      providerOverride: opts.providerOverride,
+    },
+  } as unknown as ToolUseContext
+}
+
+describe('getUltracodePermissionAttachment', () => {
+  test('emits ultracode_mode for a first-party, xhigh-capable ultracode request', () => {
+    expect(getUltracodePermissionAttachment(makeContext({}))).toEqual([
+      { type: 'ultracode_mode' },
+    ])
+  })
+
+  test('omits the reminder when a per-agent providerOverride routes to a third party', () => {
+    // Same first-party ultracode parent state as above, but the request is routed
+    // through a provider override — the first-party-only reminder must be dropped.
+    const result = getUltracodePermissionAttachment(
+      makeContext({
+        providerOverride: {
+          model: 'gpt-5.5',
+          baseURL: 'https://api.openai.com/v1',
+          apiKey: 'sk-test',
+        },
+      }),
+    )
+    expect(result).toEqual([])
+  })
+
+  test('omits the reminder when the model does not support xhigh', () => {
+    expect(
+      getUltracodePermissionAttachment(makeContext({ mainLoopModel: 'claude-haiku-4-5' })),
+    ).toEqual([])
+  })
+
+  test('omits the reminder when effort is not ultracode', () => {
+    expect(
+      getUltracodePermissionAttachment(makeContext({ effortValue: 'high' })),
+    ).toEqual([])
+  })
+
+  test('omits when CLAUDE_CODE_EFFORT_LEVEL overrides session ultracode with a different value', () => {
+    // env override wins over app state for the API effort, so the permission
+    // must not fire for a turn the API actually runs at high.
+    process.env.CLAUDE_CODE_EFFORT_LEVEL = 'high'
+    expect(getUltracodePermissionAttachment(makeContext({}))).toEqual([])
+  })
+
+  test('omits when CLAUDE_CODE_EFFORT_LEVEL=auto clears the session ultracode', () => {
+    process.env.CLAUDE_CODE_EFFORT_LEVEL = 'auto'
+    expect(getUltracodePermissionAttachment(makeContext({}))).toEqual([])
+  })
+
+  test('emits when CLAUDE_CODE_EFFORT_LEVEL=ultracode even if app state differs', () => {
+    process.env.CLAUDE_CODE_EFFORT_LEVEL = 'ultracode'
+    expect(
+      getUltracodePermissionAttachment(makeContext({ effortValue: 'high' })),
+    ).toEqual([{ type: 'ultracode_mode' }])
+  })
+})

--- a/src/utils/effort.codex.test.ts
+++ b/src/utils/effort.codex.test.ts
@@ -98,6 +98,8 @@ async function importFreshEffortModule(options: {
       effort.getDefaultEffortForModel(model, reasoningContext),
     resolveAppliedEffort: (model: string, appStateEffortValue: unknown) =>
       effort.resolveAppliedEffort(model, appStateEffortValue, reasoningContext),
+    clampUltracodeEffort: (appStateEffortValue: unknown, model: string) =>
+      effort.clampUltracodeEffort(appStateEffortValue, model, reasoningContext),
     modelSupportsShimReasoningEffort: (
       model: string,
       thinkingRequestFormat?: unknown,
@@ -245,9 +247,9 @@ test('xhigh does not appear in available levels for non-supporting models', asyn
   ])
   expect(getAvailableEffortLevels('claude-haiku-4-5')).toEqual([])
 
-  // Has xhigh AND max (opus-4-8)
+  // Has xhigh AND max AND ultracode (opus-4-8 on firstParty)
   const opusLevels = getAvailableEffortLevels('claude-opus-4-8')
-  expect(opusLevels).toEqual(['low', 'medium', 'high', 'xhigh', 'max'])
+  expect(opusLevels).toEqual(['low', 'medium', 'high', 'xhigh', 'max', 'ultracode'])
 })
 
 test('effort allowlist is narrowed to the shim isAdaptive||isOpus45 set', async () => {
@@ -297,12 +299,74 @@ test('xhigh clamps to high on non-supporting models so stale settings.json value
   expect(resolveAppliedEffort('claude-opus-4-8', 'xhigh')).toBe('xhigh')
 })
 
+test('clampUltracodeEffort: clamps to xhigh on non-firstParty xhigh-capable model', async () => {
+  const { clampUltracodeEffort, resolveAppliedEffort } = await importFreshEffortModule({
+    provider: 'openai',
+    supportsCodexReasoningEffort: true,
+  })
+
+  // ultracode isn't selectable off firstParty, so it clamps — but to xhigh
+  // (the model is xhigh-capable), matching resolveAppliedEffort's mapping
+  // rather than the old hardcoded 'max'.
+  expect(clampUltracodeEffort('ultracode', 'claude-opus-4-8')).toBe('xhigh')
+  expect(clampUltracodeEffort('ultracode', 'claude-opus-4-8')).toBe(
+    resolveAppliedEffort('claude-opus-4-8', 'ultracode'),
+  )
+  expect(clampUltracodeEffort('max', 'claude-opus-4-8')).toBe('max')
+  expect(clampUltracodeEffort('high', 'claude-opus-4-8')).toBe('high')
+  expect(clampUltracodeEffort(undefined, 'claude-opus-4-8')).toBeUndefined()
+})
+
+test('clampUltracodeEffort: clamps to high on firstParty non-xhigh model', async () => {
+  const { clampUltracodeEffort, resolveAppliedEffort } = await importFreshEffortModule({
+    provider: 'firstParty' as unknown as 'openai',
+    supportsCodexReasoningEffort: false,
+  })
+
+  // Not xhigh-capable -> clamp to high, the same level the env/app-state path
+  // (resolveAppliedEffort) sends for ultracode. Previously this returned 'max',
+  // so the two paths disagreed on max-capable-but-not-xhigh models.
+  expect(clampUltracodeEffort('ultracode', 'claude-sonnet-4-6')).toBe('high')
+  expect(clampUltracodeEffort('ultracode', 'claude-sonnet-4-6')).toBe(
+    resolveAppliedEffort('claude-sonnet-4-6', 'ultracode'),
+  )
+})
+
+test('clampUltracodeEffort: preserves ultracode on firstParty + xhigh-capable model', async () => {
+  const { clampUltracodeEffort } = await importFreshEffortModule({
+    provider: 'firstParty' as unknown as 'openai',
+    supportsCodexReasoningEffort: false,
+  })
+
+  expect(clampUltracodeEffort('ultracode', 'claude-opus-4-8')).toBe('ultracode')
+})
+
+test('parseFrontmatterEffortValue: rejects ultracode but passes other levels/integers through', async () => {
+  const { parseFrontmatterEffortValue } = await importFreshEffortModule({
+    provider: 'openai',
+    supportsCodexReasoningEffort: true,
+  })
+
+  // ultracode is session-only; frontmatter cannot grant its permission, so reject it
+  expect(parseFrontmatterEffortValue('ultracode')).toBeUndefined()
+  expect(parseFrontmatterEffortValue('ULTRACODE')).toBeUndefined()
+  // every other valid level still parses
+  expect(parseFrontmatterEffortValue('low')).toBe('low')
+  expect(parseFrontmatterEffortValue('medium')).toBe('medium')
+  expect(parseFrontmatterEffortValue('high')).toBe('high')
+  expect(parseFrontmatterEffortValue('xhigh')).toBe('xhigh')
+  expect(parseFrontmatterEffortValue('max')).toBe('max')
+  expect(parseFrontmatterEffortValue(42)).toBe(42)
+  // genuinely invalid values still return undefined
+  expect(parseFrontmatterEffortValue('nonsense')).toBeUndefined()
+  expect(parseFrontmatterEffortValue(undefined)).toBeUndefined()
+})
+
 test('modelUsesOpenAIEffort: Claude/Gemini are excluded even on the openai provider (OpenCode native route)', async () => {
-  const { modelUsesOpenAIEffort, getAvailableEffortLevels } =
-    await importFreshEffortModule({
-      provider: 'openai',
-      supportsCodexReasoningEffort: true,
-    })
+  const { modelUsesOpenAIEffort } = await importFreshEffortModule({
+    provider: 'openai',
+    supportsCodexReasoningEffort: true,
+  })
 
   // Native Claude/Gemini on OpenCode use Anthropic/Google format, not OpenAI
   expect(modelUsesOpenAIEffort('claude-opus-4-8')).toBe(false)
@@ -310,11 +374,6 @@ test('modelUsesOpenAIEffort: Claude/Gemini are excluded even on the openai provi
   expect(modelUsesOpenAIEffort('gemini-3-flash')).toBe(false)
   // Real OpenAI-shaped models still classify as OpenAI
   expect(modelUsesOpenAIEffort('gpt-5.4')).toBe(true)
-
-  // And the picker excludes xhigh for OpenCode Claude on openai provider
-  const opusLevels = getAvailableEffortLevels('claude-opus-4-8')
-  // Standard branch: no OPENAI_EFFORT_LEVELS, just the supported standard levels
-  expect(opusLevels).toEqual(['low', 'medium', 'high', 'xhigh', 'max'])
 })
 
 test('supportsReasoning-only catalog entries do not enable effort or wire mutation', async () => {

--- a/src/utils/effort.ts
+++ b/src/utils/effort.ts
@@ -33,6 +33,7 @@ export const EFFORT_LEVELS = [
   'high',
   'xhigh',
   'max',
+  'ultracode',
 ] as const satisfies readonly EffortLevel[]
 
 export const OPENAI_EFFORT_LEVELS = [
@@ -732,6 +733,26 @@ function getLegacyAvailableEffortLevels(
   if (legacyModelSupportsMaxEffort(model)) {
     levels.push('max')
   }
+  if (
+    getReasoningApiProvider(context) === 'firstParty' &&
+    legacyModelSupportsXHighEffort(model, context)
+  ) {
+    levels.push('ultracode')
+  }
+  return levels
+}
+
+function appendUltracodeLevel(
+  levels: EffortLevel[],
+  context?: ReasoningControlContext,
+): EffortLevel[] {
+  if (
+    getReasoningApiProvider(context) === 'firstParty' &&
+    levels.includes('xhigh') &&
+    !levels.includes('ultracode')
+  ) {
+    return [...levels, 'ultracode']
+  }
   return levels
 }
 
@@ -754,11 +775,12 @@ export function modelSupportsXHighEffort(model: string, context?: ReasoningContr
 export function getAvailableEffortLevels(model: string, context?: ReasoningControlContext): EffortLevel[] {
   const control = resolveModelReasoningControl(model, context)
   if (control.source === 'metadata' || control.source === 'capability' || control.source === 'compat') {
-    return [...control.levels]
+    return appendUltracodeLevel([...control.levels], context)
   }
   return getLegacyAvailableEffortLevels(model, context)
 }
 export function getEffortLevelLabel(level: EffortLevel | OpenAIEffortLevel): string {
+  if (level === 'ultracode') return 'Ultracode'
   if (level === 'xhigh') return 'Extra High'
   if (level === 'max') return 'Max'
   return capitalize(level)
@@ -769,7 +791,7 @@ export function openAIEffortToStandard(level: OpenAIEffortLevel): EffortLevel {
 }
 
 export function standardEffortToOpenAI(level: EffortLevel): OpenAIEffortLevel {
-  if (level === 'max') return 'xhigh'
+  if (level === 'max' || level === 'ultracode') return 'xhigh'
   return level as OpenAIEffortLevel
 }
 
@@ -796,6 +818,30 @@ export function parseEffortValue(value: unknown): EffortValue | undefined {
 }
 
 /**
+ * Frontmatter (skill / agent / plugin command) effort parser. Identical to
+ * parseEffortValue except it rejects 'ultracode'.
+ *
+ * ultracode is a session-only mode whose defining trait — the standing
+ * multi-agent permission — is granted by getUltracodePermissionAttachment(),
+ * which gates on AppState.effortValue / the env override, NOT on a
+ * command-level effort. A command/skill turn carrying `effort: ultracode`
+ * would therefore send xhigh API effort WITHOUT that permission attachment,
+ * making it indistinguishable from plain xhigh while claiming to be
+ * ultracode. Until command-level effort is threaded into attachment
+ * generation, keep ultracode out of frontmatter — callers fall back to
+ * undefined (model/session default) just as they do for any invalid value.
+ */
+export function parseFrontmatterEffortValue(
+  value: unknown,
+): Exclude<EffortValue, 'ultracode'> | undefined {
+  const parsed = parseEffortValue(value)
+  if (parsed === 'ultracode') {
+    return undefined
+  }
+  return parsed
+}
+
+/**
  * Numeric values are model-default only and not persisted.
  * 'max' can now be persisted by all users.
  * 'xhigh' is a first-class EffortLevel (supported by OpenCode Claude 4.7+)
@@ -805,7 +851,7 @@ export function parseEffortValue(value: unknown): EffortValue | undefined {
  */
 export function toPersistableEffort(
   value: EffortValue | undefined,
-): EffortLevel | undefined {
+): Exclude<EffortLevel, 'ultracode'> | undefined {
   if (
     value === 'low' ||
     value === 'medium' ||
@@ -847,6 +893,22 @@ export function resolvePickerEffortPersistence(
   return hadExplicit || picked !== modelDefault ? picked : undefined
 }
 
+export function clampUltracodeEffort(
+  effort: EffortValue | undefined,
+  model: string,
+  context?: ReasoningControlContext,
+): EffortValue | undefined {
+  if (effort === 'ultracode' && !getAvailableEffortLevels(model, context).includes('ultracode')) {
+    // Mirror resolveAppliedEffort's ultracode mapping (xhigh when supported,
+    // else high) so the startup/display clamp and the env/app-state resolution
+    // send the SAME effort to the API. Hardcoding 'max' here meant
+    // `--effort ultracode` (clamped to app state) and `CLAUDE_CODE_EFFORT_LEVEL=ultracode`
+    // (resolved live) diverged on max-capable-but-not-xhigh models like opus-4-6.
+    return modelSupportsXHighEffort(model, context) ? 'xhigh' : 'high'
+  }
+  return effort
+}
+
 export function getEffortEnvOverride(): EffortValue | null | undefined {
   const envOverride = process.env.CLAUDE_CODE_EFFORT_LEVEL
   return envOverride?.toLowerCase() === 'unset' ||
@@ -867,7 +929,7 @@ export function resolveAppliedEffort(
   model: string,
   appStateEffortValue: EffortValue | undefined,
   context?: ReasoningControlContext,
-): EffortValue | undefined {
+): Exclude<EffortValue, 'ultracode'> | undefined {
   const envOverride = getEffortEnvOverride()
   if (envOverride === null) {
     return undefined
@@ -885,7 +947,12 @@ export function resolveAppliedEffort(
     control.levels.length > 0 &&
     !control.levels.includes(resolved)
   ) {
-    return control.levels.includes('high') ? 'high' : (control.defaultLevel ?? control.levels[0])
+    const fallback = control.levels.includes('high')
+      ? 'high'
+      : (control.defaultLevel ?? control.levels[0])
+    return fallback === 'ultracode'
+      ? modelSupportsXHighEffort(model, context) ? 'xhigh' : 'high'
+      : fallback
   }
   // API rejects 'max' on non-Opus-4.6 Anthropic models — downgrade to 'high'.
   // OpenAI/Codex models use 'max' as the standard form of 'xhigh'; the client
@@ -903,6 +970,10 @@ export function resolveAppliedEffort(
   if (resolved === 'xhigh' && !modelSupportsXHighEffort(model, context)) {
     return 'high'
   }
+  // ultracode is a meta-level: map it to xhigh (or high if unsupported).
+  if (resolved === 'ultracode') {
+    return modelSupportsXHighEffort(model, context) ? 'xhigh' : 'high'
+  }
   return resolved
 }
 
@@ -915,6 +986,19 @@ export function getDisplayedEffortLevel(
   model: string,
   appStateEffort: EffortValue | undefined,
 ): EffortLevel {
+  // `ultracode` is a meta-mode (the standing multi-agent permission), not just
+  // an API effort alias, so surface it as the current level rather than the
+  // `xhigh`/`high` it maps to at the API boundary — but only when it is the
+  // EFFECTIVE effort. CLAUDE_CODE_EFFORT_LEVEL takes precedence over app state
+  // (see resolveAppliedEffort), so `--effort ultracode` with
+  // CLAUDE_CODE_EFFORT_LEVEL=high must show high, matching the API and the
+  // permission gate rather than the stale session value.
+  const envOverride = getEffortEnvOverride()
+  const effectiveEffort =
+    envOverride === null ? undefined : (envOverride ?? appStateEffort)
+  if (effectiveEffort === 'ultracode') {
+    return 'ultracode'
+  }
   const resolved = resolveAppliedEffort(model, appStateEffort) ?? 'high'
   return convertEffortValueToLevel(resolved)
 }
@@ -930,6 +1014,16 @@ export function getEffortSuffix(
   effortValue: EffortValue | undefined,
 ): string {
   if (effortValue === undefined) return ''
+  // Surface the ultracode meta-mode here too (Logo/Spinner), consistent with
+  // getDisplayedEffortLevel — but only when it is the EFFECTIVE effort, so a
+  // CLAUDE_CODE_EFFORT_LEVEL override wins over the session value rather than
+  // showing ultracode for a turn the API runs at a different effort.
+  const envOverride = getEffortEnvOverride()
+  const effectiveEffort =
+    envOverride === null ? undefined : (envOverride ?? effortValue)
+  if (effectiveEffort === 'ultracode') {
+    return ' with ultracode effort'
+  }
   const resolved = resolveAppliedEffort(model, effortValue)
   if (resolved === undefined) return ''
   return ` with ${convertEffortValueToLevel(resolved)} effort`
@@ -983,6 +1077,8 @@ export function getEffortLevelDescription(level: EffortLevel | OpenAIEffortLevel
       return 'Maximum capability with deepest reasoning (Opus 4.8+)'
     case 'xhigh':
       return 'Extra high reasoning effort for complex tasks'
+    case 'ultracode':
+      return 'xhigh effort + standing permission for multi-agent orchestration'
   }
 }
 

--- a/src/utils/effort.ts
+++ b/src/utils/effort.ts
@@ -977,6 +977,17 @@ export function resolveAppliedEffort(
   return resolved
 }
 
+function isEffectiveUltracodeDisplay(
+  model: string,
+  effort: EffortValue | undefined,
+  context?: ReasoningControlContext,
+): boolean {
+  return (
+    effort === 'ultracode' &&
+    getAvailableEffortLevels(model, context).includes('ultracode')
+  )
+}
+
 /**
  * Resolve the effort level to show the user. Wraps resolveAppliedEffort
  * with the 'high' fallback (what the API uses when no effort param is sent).
@@ -985,6 +996,7 @@ export function resolveAppliedEffort(
 export function getDisplayedEffortLevel(
   model: string,
   appStateEffort: EffortValue | undefined,
+  context?: ReasoningControlContext,
 ): EffortLevel {
   // `ultracode` is a meta-mode (the standing multi-agent permission), not just
   // an API effort alias, so surface it as the current level rather than the
@@ -996,10 +1008,10 @@ export function getDisplayedEffortLevel(
   const envOverride = getEffortEnvOverride()
   const effectiveEffort =
     envOverride === null ? undefined : (envOverride ?? appStateEffort)
-  if (effectiveEffort === 'ultracode') {
+  if (isEffectiveUltracodeDisplay(model, effectiveEffort, context)) {
     return 'ultracode'
   }
-  const resolved = resolveAppliedEffort(model, appStateEffort) ?? 'high'
+  const resolved = resolveAppliedEffort(model, appStateEffort, context) ?? 'high'
   return convertEffortValueToLevel(resolved)
 }
 
@@ -1012,6 +1024,7 @@ export function getDisplayedEffortLevel(
 export function getEffortSuffix(
   model: string,
   effortValue: EffortValue | undefined,
+  context?: ReasoningControlContext,
 ): string {
   if (effortValue === undefined) return ''
   // Surface the ultracode meta-mode here too (Logo/Spinner), consistent with
@@ -1021,10 +1034,10 @@ export function getEffortSuffix(
   const envOverride = getEffortEnvOverride()
   const effectiveEffort =
     envOverride === null ? undefined : (envOverride ?? effortValue)
-  if (effectiveEffort === 'ultracode') {
+  if (isEffectiveUltracodeDisplay(model, effectiveEffort, context)) {
     return ' with ultracode effort'
   }
-  const resolved = resolveAppliedEffort(model, effortValue)
+  const resolved = resolveAppliedEffort(model, effortValue, context)
   if (resolved === undefined) return ''
   return ` with ${convertEffortValueToLevel(resolved)} effort`
 }

--- a/src/utils/effort.ultracode-display.test.ts
+++ b/src/utils/effort.ultracode-display.test.ts
@@ -1,0 +1,45 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import { getDisplayedEffortLevel, getEffortSuffix } from './effort.js'
+
+// ultracode is a meta-mode (the standing multi-agent permission). The display
+// surfaces show it as the current level when it is the EFFECTIVE effort —
+// CLAUDE_CODE_EFFORT_LEVEL takes precedence over the session value (matching the
+// API and the permission gate), so the display follows that precedence too.
+// @see #1551
+const MODEL = 'claude-opus-4-8'
+let savedEnv: string | undefined
+
+beforeEach(() => {
+  savedEnv = process.env.CLAUDE_CODE_EFFORT_LEVEL
+  delete process.env.CLAUDE_CODE_EFFORT_LEVEL
+})
+
+afterEach(() => {
+  if (savedEnv === undefined) {
+    delete process.env.CLAUDE_CODE_EFFORT_LEVEL
+  } else {
+    process.env.CLAUDE_CODE_EFFORT_LEVEL = savedEnv
+  }
+})
+
+describe('ultracode display surfaces', () => {
+  test('getDisplayedEffortLevel surfaces ultracode (not its xhigh mapping)', () => {
+    expect(getDisplayedEffortLevel(MODEL, 'ultracode')).toBe('ultracode')
+  })
+
+  test('getEffortSuffix surfaces ultracode while it is active', () => {
+    expect(getEffortSuffix(MODEL, 'ultracode')).toBe(' with ultracode effort')
+  })
+
+  test('a conflicting CLAUDE_CODE_EFFORT_LEVEL override wins over session ultracode', () => {
+    process.env.CLAUDE_CODE_EFFORT_LEVEL = 'high'
+    expect(getDisplayedEffortLevel(MODEL, 'ultracode')).toBe('high')
+    expect(getEffortSuffix(MODEL, 'ultracode')).toBe(' with high effort')
+  })
+
+  test('CLAUDE_CODE_EFFORT_LEVEL=ultracode surfaces ultracode even if the session differs', () => {
+    process.env.CLAUDE_CODE_EFFORT_LEVEL = 'ultracode'
+    expect(getDisplayedEffortLevel(MODEL, 'high')).toBe('ultracode')
+    expect(getEffortSuffix(MODEL, 'high')).toBe(' with ultracode effort')
+  })
+})

--- a/src/utils/effort.ultracode-display.test.ts
+++ b/src/utils/effort.ultracode-display.test.ts
@@ -7,39 +7,116 @@ import { getDisplayedEffortLevel, getEffortSuffix } from './effort.js'
 // API and the permission gate), so the display follows that precedence too.
 // @see #1551
 const MODEL = 'claude-opus-4-8'
-let savedEnv: string | undefined
+const FIRST_PARTY_CONTEXT = { apiProvider: 'firstParty' as const }
+const OPENAI_CONTEXT = {
+  apiProvider: 'openai' as const,
+  supportsCodexReasoningEffort: () => true,
+}
+const ENV_VARS = [
+  'CLAUDE_CODE_EFFORT_LEVEL',
+  'CLAUDE_CODE_USE_GEMINI',
+  'CLAUDE_CODE_USE_GITHUB',
+  'CLAUDE_CODE_USE_MISTRAL',
+  'CLAUDE_CODE_USE_OPENAI',
+  'CLAUDE_CODE_USE_BEDROCK',
+  'CLAUDE_CODE_USE_VERTEX',
+  'CLAUDE_CODE_USE_FOUNDRY',
+  'CLAUDE_CODE_PROVIDER_PROFILE_ENV_APPLIED',
+  'CLAUDE_CODE_PROVIDER_PROFILE_ENV_APPLIED_ID',
+  'ANTHROPIC_BASE_URL',
+  'ANTHROPIC_API_KEY',
+  'ANTHROPIC_MODEL',
+  'OPENAI_MODEL',
+  'OPENAI_BASE_URL',
+  'OPENAI_API_BASE',
+  'OPENAI_API_KEY',
+  'OPENAI_API_KEYS',
+  'GEMINI_API_KEY',
+  'MISTRAL_API_KEY',
+  'MINIMAX_API_KEY',
+  'NVIDIA_NIM',
+  'NVIDIA_API_KEY',
+  'XAI_API_KEY',
+  'VENICE_API_KEY',
+  'MIMO_API_KEY',
+  'OPENGATEWAY_API_KEY',
+  'OPENCODE_API_KEY',
+  'HICAP_API_KEY',
+  'NEARAI_API_KEY',
+]
+const savedEnv: Record<string, string | undefined> = {}
 
 beforeEach(() => {
-  savedEnv = process.env.CLAUDE_CODE_EFFORT_LEVEL
-  delete process.env.CLAUDE_CODE_EFFORT_LEVEL
+  for (const key of ENV_VARS) {
+    savedEnv[key] = process.env[key]
+    delete process.env[key]
+  }
 })
 
 afterEach(() => {
-  if (savedEnv === undefined) {
-    delete process.env.CLAUDE_CODE_EFFORT_LEVEL
-  } else {
-    process.env.CLAUDE_CODE_EFFORT_LEVEL = savedEnv
+  for (const key of ENV_VARS) {
+    if (savedEnv[key] === undefined) {
+      delete process.env[key]
+    } else {
+      process.env[key] = savedEnv[key]
+    }
   }
 })
 
 describe('ultracode display surfaces', () => {
   test('getDisplayedEffortLevel surfaces ultracode (not its xhigh mapping)', () => {
-    expect(getDisplayedEffortLevel(MODEL, 'ultracode')).toBe('ultracode')
+    expect(getDisplayedEffortLevel(MODEL, 'ultracode', FIRST_PARTY_CONTEXT)).toBe(
+      'ultracode',
+    )
   })
 
   test('getEffortSuffix surfaces ultracode while it is active', () => {
-    expect(getEffortSuffix(MODEL, 'ultracode')).toBe(' with ultracode effort')
+    expect(getEffortSuffix(MODEL, 'ultracode', FIRST_PARTY_CONTEXT)).toBe(
+      ' with ultracode effort',
+    )
   })
 
   test('a conflicting CLAUDE_CODE_EFFORT_LEVEL override wins over session ultracode', () => {
     process.env.CLAUDE_CODE_EFFORT_LEVEL = 'high'
-    expect(getDisplayedEffortLevel(MODEL, 'ultracode')).toBe('high')
-    expect(getEffortSuffix(MODEL, 'ultracode')).toBe(' with high effort')
+    expect(getDisplayedEffortLevel(MODEL, 'ultracode', FIRST_PARTY_CONTEXT)).toBe(
+      'high',
+    )
+    expect(getEffortSuffix(MODEL, 'ultracode', FIRST_PARTY_CONTEXT)).toBe(
+      ' with high effort',
+    )
   })
 
   test('CLAUDE_CODE_EFFORT_LEVEL=ultracode surfaces ultracode even if the session differs', () => {
     process.env.CLAUDE_CODE_EFFORT_LEVEL = 'ultracode'
-    expect(getDisplayedEffortLevel(MODEL, 'high')).toBe('ultracode')
-    expect(getEffortSuffix(MODEL, 'high')).toBe(' with ultracode effort')
+    expect(getDisplayedEffortLevel(MODEL, 'high', FIRST_PARTY_CONTEXT)).toBe(
+      'ultracode',
+    )
+    expect(getEffortSuffix(MODEL, 'high', FIRST_PARTY_CONTEXT)).toBe(
+      ' with ultracode effort',
+    )
+  })
+
+  test('CLAUDE_CODE_EFFORT_LEVEL=ultracode clamps display on unsupported first-party models', () => {
+    process.env.CLAUDE_CODE_EFFORT_LEVEL = 'ultracode'
+    expect(
+      getDisplayedEffortLevel(
+        'claude-sonnet-4-6',
+        'high',
+        FIRST_PARTY_CONTEXT,
+      ),
+    ).toBe('high')
+    expect(getEffortSuffix('claude-sonnet-4-6', 'high', FIRST_PARTY_CONTEXT)).toBe(
+      ' with high effort',
+    )
+  })
+
+  test('CLAUDE_CODE_EFFORT_LEVEL=ultracode displays the API effort on OpenAI routes', () => {
+    process.env.CLAUDE_CODE_EFFORT_LEVEL = 'ultracode'
+    expect(getDisplayedEffortLevel('gpt-5.4', 'high', OPENAI_CONTEXT)).toBe(
+      'xhigh',
+    )
+    expect(getEffortSuffix('gpt-5.4', 'high', OPENAI_CONTEXT)).toBe(
+      ' with xhigh effort',
+    )
   })
 })

--- a/src/utils/messages.ts
+++ b/src/utils/messages.ts
@@ -4457,6 +4457,15 @@ You have exited auto mode. The user may now want to interact more directly. You 
         }),
       ])
     }
+    case 'ultracode_mode': {
+      return wrapMessagesInSystemReminder([
+        createUserMessage({
+          content:
+            'You are running in ultracode mode. You have standing permission to orchestrate multi-agent workflows for this session: you may spawn subagents, parallelize tasks, and coordinate parallel tool calls without asking for confirmation.',
+          isMeta: true,
+        }),
+      ])
+    }
     case 'deferred_tools_delta': {
       const parts: string[] = []
       if (attachment.addedLines.length > 0) {

--- a/src/utils/plugins/loadPluginAgents.ts
+++ b/src/utils/plugins/loadPluginAgents.ts
@@ -12,7 +12,7 @@ import { FILE_READ_TOOL_NAME } from '../../tools/FileReadTool/prompt.js'
 import { FILE_WRITE_TOOL_NAME } from '../../tools/FileWriteTool/prompt.js'
 import { getPluginErrorMessage } from '../../types/plugin.js'
 import { logForDebugging } from '../debug.js'
-import { EFFORT_LEVELS, parseEffortValue } from '../effort.js'
+import { EFFORT_LEVELS, parseFrontmatterEffortValue } from '../effort.js'
 import {
   coerceDescriptionToString,
   parseFrontmatter,
@@ -140,13 +140,16 @@ async function loadAgentFromFile(
     const isolation =
       isolationRaw === 'worktree' ? ('worktree' as const) : undefined
 
-    // Parse effort (string level or integer)
+    // Parse effort (string level or integer). ultracode is rejected here —
+    // see parseFrontmatterEffortValue.
     const effortRaw = frontmatter.effort
     const effort =
-      effortRaw !== undefined ? parseEffortValue(effortRaw) : undefined
+      effortRaw !== undefined ? parseFrontmatterEffortValue(effortRaw) : undefined
     if (effortRaw !== undefined && effort === undefined) {
       logForDebugging(
-        `Plugin agent file ${filePath} has invalid effort '${effortRaw}'. Valid options: ${EFFORT_LEVELS.join(', ')} or an integer`,
+        String(effortRaw).toLowerCase() === 'ultracode'
+          ? `Plugin agent file ${filePath} requested effort 'ultracode', a session-only mode not supported in frontmatter; ignoring.`
+          : `Plugin agent file ${filePath} has invalid effort '${effortRaw}'. Valid options: ${EFFORT_LEVELS.filter(l => l !== 'ultracode').join(', ')} or an integer`,
       )
     }
 

--- a/src/utils/plugins/loadPluginCommands.ts
+++ b/src/utils/plugins/loadPluginCommands.ts
@@ -8,7 +8,7 @@ import {
   substituteArguments,
 } from '../argumentSubstitution.js'
 import { logForDebugging } from '../debug.js'
-import { EFFORT_LEVELS, parseEffortValue } from '../effort.js'
+import { EFFORT_LEVELS, parseFrontmatterEffortValue } from '../effort.js'
 import { isBareMode } from '../envUtils.js'
 import { isENOENT } from '../errors.js'
 import {
@@ -281,10 +281,12 @@ function createPluginCommand(
 
     const effortRaw = frontmatter['effort']
     const effort =
-      effortRaw !== undefined ? parseEffortValue(effortRaw) : undefined
+      effortRaw !== undefined ? parseFrontmatterEffortValue(effortRaw) : undefined
     if (effortRaw !== undefined && effort === undefined) {
       logForDebugging(
-        `Plugin command ${commandName} has invalid effort '${effortRaw}'. Valid options: ${EFFORT_LEVELS.join(', ')} or an integer`,
+        String(effortRaw).toLowerCase() === 'ultracode'
+          ? `Plugin command ${commandName} requested effort 'ultracode', a session-only mode not supported in frontmatter; ignoring.`
+          : `Plugin command ${commandName} has invalid effort '${effortRaw}'. Valid options: ${EFFORT_LEVELS.filter(l => l !== 'ultracode').join(', ')} or an integer`,
       )
     }
 


### PR DESCRIPTION
Closes #1551

## Summary

This PR adds two Claude Code CLI parity improvements around effort handling:

**ultrathink keyword detection**
- Keeps the hidden `ultrathink_effort` attachment behind the same `isUltrathinkEnabled()` rollout gate (`feature('ULTRATHINK')` + GrowthBook `tengu_turtle_carbon`) that controls UI highlighting/notification.
- When the rollout is enabled, a `\bultrathink\b/i` keyword in the user prompt injects a per-turn system reminder requesting high reasoning effort.
- Preserves the existing `isUltrathinkEnabled()` use in `effort.ts` for Opus medium defaults, so disabled rollouts do not change API behavior.

**`ultracode` effort level**
- Adds `'ultracode'` to the public `EffortLevel` / SDK model metadata surface and `/effort` / `--effort` input paths.
- Treats `ultracode` as a session-only meta-mode: it maps to `xhigh` on the wire when supported, otherwise `high`, and is not persisted to settings.
- Makes `/effort ultracode` available only on the first-party Anthropic path for xhigh-capable models.
- Injects the `ultracode_mode` system reminder only when the **effective** effort is ultracode after `CLAUDE_CODE_EFFORT_LEVEL` precedence, only on the first-party provider path, only for xhigh-capable models, and never for per-agent `providerOverride` calls.
- Keeps user-facing display surfaces aligned with the effective effort: `/effort`, `/model current`, status/picker display, Logo/Spinner suffixes, startup `--effort`, and env overrides all resolve through the same xhigh/high clamp behavior.
- Rejects `effort: ultracode` from persisted agent/skill/plugin definitions, including markdown frontmatter, plugin commands/agents, SDK agent definitions, and JSON agent files.

## Files changed

| Area | Files | Change |
|---|---|---|
| Effort core | `src/utils/effort.ts`, `src/services/api/claude.ts` | Add `ultracode`, wire mapping, availability, effective-effort resolution, env precedence, display helpers, and non-persistence rules |
| Attachments/messages | `src/utils/attachments.ts`, `src/utils/messages.ts`, `src/components/messages/nullRenderingAttachments.ts` | Keep ultrathink gated; add first-party `ultracode_mode` attachment and API normalization |
| CLI/UI | `src/commands/effort/effort.tsx`, `src/commands/effort/index.ts`, `src/commands/model/model.tsx`, `src/components/Spinner.tsx`, `src/main.tsx` | Add `/effort ultracode`, update help/argument hints, clamp startup effort, and show effective effort for model/status/spinner surfaces |
| SDK schemas | `src/entrypoints/sdk/runtimeTypes.ts`, `src/entrypoints/sdk/coreTypes.generated.ts`, `src/entrypoints/sdk/coreSchemas.ts` | Add `ultracode` to SDK effort metadata |
| Agent/plugin loaders | `src/skills/loadSkillsDir.ts`, `src/tools/AgentTool/loadAgentsDir.ts`, `src/utils/plugins/loadPluginAgents.ts`, `src/utils/plugins/loadPluginCommands.ts` | Reject session-only `ultracode` from frontmatter / JSON agent definitions |
| Tests | `src/utils/effort.codex.test.ts`, `src/utils/effort.ultracode-display.test.ts`, `src/utils/attachments.ultracode.test.ts`, `src/commands/effort/effort.test.tsx`, `src/commands/model/model.test.tsx`, `src/tools/AgentTool/loadAgentsDir.test.ts` | Add coverage for availability, env precedence, display consistency, providerOverride gating, startup/session-model behavior, and JSON agent rejection |

## Testing

- `bun install --frozen-lockfile`
- `bun test --feature=UNATTENDED_RETRY src/utils/effort.codex.test.ts src/utils/effort.ultracode-display.test.ts src/utils/attachments.ultracode.test.ts src/commands/effort/effort.test.tsx src/commands/model/model.test.tsx src/tools/AgentTool/loadAgentsDir.test.ts`
- `bun test --feature=UNATTENDED_RETRY src/utils/effort.test.ts src/utils/attachments.extractors.test.ts src/tools/AgentTool/loadAgentsDir.test.ts src/commands/model/model.test.tsx src/commands/effort/effort.test.tsx src/utils/attachments.ultracode.test.ts src/utils/effort.ultracode-display.test.ts src/utils/effort.codex.test.ts`
- `bun test --feature=UNATTENDED_RETRY src/services/api/client.test.ts src/services/api/client.oauthRouting.test.ts src/services/api/claude.lifecycle.test.ts src/utils/effort.ultracode-display.test.ts src/utils/attachments.ultracode.test.ts`
- `bun run typecheck`
- `bun run smoke`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added **ultracode** as a supported advanced effort level for **/effort** and **--effort**, including updated **/effort** help and argument validation.
* **SDK / Compatibility**
  * Expanded SDK effort typing and model schema validation to recognize **ultracode**.
* **Command UX**
  * Improved **/effort ultracode** handling with availability messaging and automatic clamping when the model doesn’t support it.
* **Messaging / Attachments**
  * Added **ultracode mode** signaling so the system can grant permission for multi-agent orchestration behavior in supported scenarios.
* **Behavior Updates**
  * Treat **ultracode** in agent/skill/plugin frontmatter as **unsupported session-only** and ignore it.
* **Tests**
  * Added/updated tests covering availability, display behavior, and app state updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
