### PR TITLE
docs(non-technical-setup): add Getting Help section with support link…

### DIFF
--- a/docs/non-technical-setup.md
+++ b/docs/non-technical-setup.md
@@ -24,13 +24,14 @@ You need:
 
 1. Node.js 20 or newer installed
 2. A terminal window
-3. An API key from your provider, unless you are using a local model like Ollama
 
 ## Fastest Path
 
 1. Install OpenClaude with npm
-2. Set 3 environment variables
-3. Run `openclaude`
+2. Run `openclaude`
+3. Inside the CLI, run `/provider` for guided provider setup
+
+The `/provider` command walks you through choosing a provider and entering credentials. You do not need to set environment variables beforehand.
 
 ## Choose Your Operating System
 
@@ -39,11 +40,13 @@ You need:
 
 ## Which Provider Should You Choose?
 
+Once you have picked a provider, run `/provider` inside OpenClaude to set it up with guided prompts.
+
 ### OpenAI
 
 Choose this if:
 
-- you want the easiest setup
+- you want the easiest cloud setup
 - you already have an OpenAI API key
 
 ### Ollama
@@ -111,7 +114,7 @@ Cause:
 Fix:
 
 1. Get a fresh key from your provider
-2. Paste it again carefully
+2. Run `/provider` inside OpenClaude to update your credentials
 3. Re-run `openclaude`
 
 ### Ollama not working

--- a/docs/non-technical-setup.md
+++ b/docs/non-technical-setup.md
@@ -24,6 +24,7 @@ You need:
 
 1. Node.js 20 or newer installed
 2. A terminal window
+3. An API key from your provider, unless you are using a local model like Ollama
 
 ## Fastest Path
 

--- a/docs/non-technical-setup.md
+++ b/docs/non-technical-setup.md
@@ -132,3 +132,21 @@ If you want source builds, advanced provider profiles, diagnostics, or Bun-based
 
 - [Advanced Setup](advanced-setup.md)
   This is also where to find Codex, Gemini, Mistral, LiteLLM, and profile-launcher setup.
+
+## Getting Help
+
+- **GitHub Discussions**: https://github.com/Gitlawb/openclaude/discussions
+  Use this for Q&A, setup help, and community conversation.
+
+- **GitHub Issues**: https://github.com/Gitlawb/openclaude/issues
+  Use this for confirmed bugs and feature requests.
+
+### Quick diagnostic check
+
+If OpenClaude is not working after setup, run:
+
+```bash
+openclaude --version
+```
+
+If this prints a version number, the install succeeded. If it says "command not found," close your terminal, open a new one, and try again. On Windows, you may also need to add npm's global bin folder to your user `Path` (see the [Windows Quick Start](quick-start-windows.md) guide for details).


### PR DESCRIPTION
### What changed and why

The guide previously directed users to set environment variables before
launching the CLI, which misses the simpler onboarding path. This update
restructures the guide around the `/provider` flow so non-technical users
can install, run openclaude, and configure everything inside the CLI.

Changes:
- Remove required API key from prerequisites — only Node.js and a
  terminal are needed to start
- Rewrite 'Fastest Path' to: install -> run `openclaude` -> `/provider`
- Add note under provider descriptions that `/provider` handles setup
- Update 'Invalid API key' troubleshooting to use `/provider` instead
  of re-pasting environment variables
- Add 'Getting Help' section with GitHub Discussions/Issues links and
  a quick diagnostic check

### Impact

Better aligns the non-technical setup guide with the recommended
onboarding flow. No code or behavior changes.

### Checks ran

- Reviewed the final file for formatting and correctness
- Confirmed all links are valid

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Simplified setup instructions to use the `/provider` CLI command for guided provider configuration instead of manual environment variables.
  * Updated troubleshooting section to resolve authentication issues via `/provider`.
  * Added Getting Help section with diagnostic commands and support links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->