### PR TITLE
feat(agent-routing): assign a per-agent model from the /agents menu

### DIFF
--- a/src/components/agents/AgentDetail.test.tsx
+++ b/src/components/agents/AgentDetail.test.tsx
@@ -1,0 +1,139 @@
+import { PassThrough } from 'node:stream'
+
+import { afterEach, beforeEach, expect, test } from 'bun:test'
+import React from 'react'
+import stripAnsi from 'strip-ansi'
+
+import { createRoot } from '../../ink.js'
+import { KeybindingSetup } from '../../keybindings/KeybindingProviderSetup.js'
+import { AppStateProvider } from '../../state/AppState.js'
+import {
+  acquireSharedMutationLock,
+  releaseSharedMutationLock,
+} from '../../test/sharedMutationLock.js'
+import type { AgentDefinition } from '../../tools/AgentTool/loadAgentsDir.js'
+import { AgentDetail } from './AgentDetail.js'
+
+const SYNC_START = '\x1B[?2026h'
+const SYNC_END = '\x1B[?2026l'
+
+function extractLastFrame(output: string): string {
+  let lastFrame: string | null = null
+  let cursor = 0
+  while (cursor < output.length) {
+    const start = output.indexOf(SYNC_START, cursor)
+    if (start === -1) break
+    const contentStart = start + SYNC_START.length
+    const end = output.indexOf(SYNC_END, contentStart)
+    if (end === -1) break
+    const frame = output.slice(contentStart, end)
+    if (frame.trim().length > 0) lastFrame = frame
+    cursor = end + SYNC_END.length
+  }
+  return lastFrame ?? output
+}
+
+function createTestStreams() {
+  let output = ''
+  const stdout = new PassThrough()
+  const stdin = new PassThrough() as PassThrough & {
+    isTTY: boolean
+    setRawMode: () => void
+    ref: () => void
+    unref: () => void
+  }
+  stdin.isTTY = true
+  stdin.setRawMode = () => {}
+  stdin.ref = () => {}
+  stdin.unref = () => {}
+  ;(stdout as unknown as { columns: number }).columns = 120
+  stdout.on('data', chunk => {
+    output += chunk.toString()
+  })
+  return { stdout, stdin, getOutput: () => output }
+}
+
+async function waitForOutput(
+  getOutput: () => string,
+  predicate: (frame: string) => boolean,
+): Promise<string> {
+  const startedAt = Date.now()
+  let frame = ''
+  while (Date.now() - startedAt < 2500) {
+    frame = stripAnsi(extractLastFrame(getOutput()))
+    if (predicate(frame)) return frame
+    await Bun.sleep(10)
+  }
+  throw new Error(`Timed out waiting for agent detail output:\n${frame}`)
+}
+
+function createAgent(agentType: string): AgentDefinition {
+  return {
+    agentType,
+    whenToUse: `Use ${agentType}`,
+    source: 'userSettings',
+    getSystemPrompt: () => `You are ${agentType}`,
+  }
+}
+
+beforeEach(async () => {
+  await acquireSharedMutationLock('components/agents/AgentDetail.test.tsx')
+})
+
+afterEach(() => {
+  releaseSharedMutationLock()
+})
+
+// Regression: while the route picker is open, AgentDetail kept its parent
+// `confirm:no` (Esc -> onBack) handler active. Because Confirmation was the
+// first-registered context, a bare Esc resolved to confirm:no and exited the
+// detail view instead of resolving to the nested select's select:cancel. The
+// fix gates confirm:no with isActive=!routing so the picker owns Esc and a
+// single Esc only closes the picker, returning to the detail view.
+test('Esc closes the route picker without leaving the detail view', async () => {
+  // Unique agentType so getAgentRoute does not pick up a host-configured route.
+  const agent = createAgent('regression-esc-agent')
+  const { stdout, stdin, getOutput } = createTestStreams()
+  const root = await createRoot({
+    stdout: stdout as unknown as NodeJS.WriteStream,
+    stdin: stdin as unknown as NodeJS.ReadStream,
+    patchConsole: false,
+  })
+  let backCalls = 0
+
+  try {
+    root.render(
+      <AppStateProvider>
+        <KeybindingSetup>
+          <AgentDetail
+            agent={agent}
+            tools={[]}
+            onBack={() => {
+              backCalls += 1
+            }}
+          />
+        </KeybindingSetup>
+      </AppStateProvider>,
+    )
+
+    // Detail view is up.
+    await waitForOutput(getOutput, f => f.includes('press "m" to change'))
+    // Open the route picker.
+    stdin.write('m')
+    await waitForOutput(getOutput, f => f.includes('Set model route'))
+    // A single Esc should close the picker, not fire onBack.
+    stdin.write('\u001B')
+    await Bun.sleep(150)
+    // Back at the detail view, picker dismissed.
+    const frame = await waitForOutput(getOutput, f =>
+      f.includes('press "m" to change'),
+    )
+    expect(frame).not.toContain('Set model route')
+    expect(backCalls).toBe(0)
+  } finally {
+    root.unmount()
+    stdin.end()
+    stdout.end()
+    await Bun.sleep(0)
+  }
+})

--- a/src/components/agents/AgentDetail.tsx
+++ b/src/components/agents/AgentDetail.tsx
@@ -20,13 +20,17 @@ type Props = {
   tools: Tools;
   allAgents?: AgentDefinition[];
   onBack: () => void;
+  /** Notifies the parent when the route picker opens/closes so an enclosing
+   *  Dialog can deactivate its own Esc handler while the picker owns Esc. */
+  onRoutingChange?: (routing: boolean) => void;
 };
 export function AgentDetail(t0) {
   const $ = _c(48);
   const {
     agent,
     tools,
-    onBack
+    onBack,
+    onRoutingChange
   } = t0;
   const resolvedTools = resolveAgentTools(agent, tools, false);
   const [routing, setRouting] = React.useState(false);
@@ -34,6 +38,7 @@ export function AgentDetail(t0) {
   useInput((input) => {
     if (!routing && (input === 'm' || input === 'M')) {
       setRouting(true);
+      onRoutingChange?.(true);
     }
   }, { isActive: !routing });
   let t1;
@@ -225,7 +230,10 @@ export function AgentDetail(t0) {
     t24 = $[47];
   }
   if (routing) {
-    return <AgentRouteSelector agentType={agent.agentType} current={currentRoute} onClose={() => setRouting(false)} />;
+    return <AgentRouteSelector agentType={agent.agentType} current={currentRoute} onClose={() => {
+      setRouting(false);
+      onRoutingChange?.(false);
+    }} />;
   }
   return <Box flexDirection="column">{t24}<Text dimColor={true}>{describeRouteLine(currentRoute)}  (press "m" to change)</Text></Box>;
 }

--- a/src/components/agents/AgentDetail.tsx
+++ b/src/components/agents/AgentDetail.tsx
@@ -3,8 +3,10 @@ import figures from 'figures';
 import * as React from 'react';
 import { PRODUCT_DISPLAY_NAME } from '../../constants/product.js';
 import type { KeyboardEvent } from '../../ink/events/keyboard-event.js';
-import { Box, Text } from '../../ink.js';
+import { Box, Text, useInput } from '../../ink.js';
 import { useKeybinding } from '../../keybindings/useKeybinding.js';
+import { AgentRouteSelector } from './AgentRouteSelector.js';
+import { describeRouteLine, getAgentRoute } from '../../services/api/agentRouteSettings.js';
 import type { Tools } from '../../Tool.js';
 import { getAgentColor } from '../../tools/AgentTool/agentColorManager.js';
 import { getMemoryScopeDisplay } from '../../tools/AgentTool/agentMemory.js';
@@ -27,6 +29,13 @@ export function AgentDetail(t0) {
     onBack
   } = t0;
   const resolvedTools = resolveAgentTools(agent, tools, false);
+  const [routing, setRouting] = React.useState(false);
+  const currentRoute = getAgentRoute(agent.agentType);
+  useInput((input) => {
+    if (!routing && (input === 'm' || input === 'M')) {
+      setRouting(true);
+    }
+  }, { isActive: !routing });
   let t1;
   if ($[0] !== agent) {
     t1 = getActualRelativeAgentFilePath(agent);
@@ -216,5 +225,8 @@ export function AgentDetail(t0) {
   } else {
     t24 = $[47];
   }
-  return t24;
+  if (routing) {
+    return <AgentRouteSelector agentType={agent.agentType} current={currentRoute} onClose={() => setRouting(false)} />;
+  }
+  return <Box flexDirection="column">{t24}<Text dimColor={true}>{describeRouteLine(currentRoute)}  (press "m" to change)</Text></Box>;
 }

--- a/src/components/agents/AgentDetail.tsx
+++ b/src/components/agents/AgentDetail.tsx
@@ -54,16 +54,15 @@ export function AgentDetail(t0) {
     t2 = $[3];
   }
   const backgroundColor = t2;
-  let t3;
-  if ($[4] === Symbol.for("react.memo_cache_sentinel")) {
-    t3 = {
-      context: "Confirmation"
-    };
-    $[4] = t3;
-  } else {
-    t3 = $[4];
-  }
-  useKeybinding("confirm:no", onBack, t3);
+  // While the route picker is open it owns Esc (its Select registers
+  // select:cancel via onClose). Deactivate the detail-level back handler so a
+  // bare Esc only closes the picker instead of exiting the detail view.
+  // Passed inline rather than memoized: useKeybinding keys its effect on the
+  // destructured values, not the options object identity.
+  useKeybinding("confirm:no", onBack, {
+    context: "Confirmation",
+    isActive: !routing
+  });
   let t4;
   if ($[5] !== onBack) {
     t4 = e => {

--- a/src/components/agents/AgentDetailDialog.test.tsx
+++ b/src/components/agents/AgentDetailDialog.test.tsx
@@ -1,0 +1,141 @@
+import { PassThrough } from 'node:stream'
+
+import { afterEach, beforeEach, expect, test } from 'bun:test'
+import React from 'react'
+import stripAnsi from 'strip-ansi'
+
+import { createRoot } from '../../ink.js'
+import { KeybindingSetup } from '../../keybindings/KeybindingProviderSetup.js'
+import { AppStateProvider } from '../../state/AppState.js'
+import {
+  acquireSharedMutationLock,
+  releaseSharedMutationLock,
+} from '../../test/sharedMutationLock.js'
+import type { AgentDefinition } from '../../tools/AgentTool/loadAgentsDir.js'
+import { AgentDetailDialog } from './AgentDetailDialog.js'
+
+const SYNC_START = '\x1B[?2026h'
+const SYNC_END = '\x1B[?2026l'
+
+function extractLastFrame(output: string): string {
+  let lastFrame: string | null = null
+  let cursor = 0
+  while (cursor < output.length) {
+    const start = output.indexOf(SYNC_START, cursor)
+    if (start === -1) break
+    const contentStart = start + SYNC_START.length
+    const end = output.indexOf(SYNC_END, contentStart)
+    if (end === -1) break
+    const frame = output.slice(contentStart, end)
+    if (frame.trim().length > 0) lastFrame = frame
+    cursor = end + SYNC_END.length
+  }
+  return lastFrame ?? output
+}
+
+function createTestStreams() {
+  let output = ''
+  const stdout = new PassThrough()
+  const stdin = new PassThrough() as PassThrough & {
+    isTTY: boolean
+    setRawMode: () => void
+    ref: () => void
+    unref: () => void
+  }
+  stdin.isTTY = true
+  stdin.setRawMode = () => {}
+  stdin.ref = () => {}
+  stdin.unref = () => {}
+  ;(stdout as unknown as { columns: number }).columns = 120
+  stdout.on('data', chunk => {
+    output += chunk.toString()
+  })
+  return { stdout, stdin, getOutput: () => output }
+}
+
+async function waitForOutput(
+  getOutput: () => string,
+  predicate: (frame: string) => boolean,
+): Promise<string> {
+  const startedAt = Date.now()
+  let frame = ''
+  while (Date.now() - startedAt < 2500) {
+    frame = stripAnsi(extractLastFrame(getOutput()))
+    if (predicate(frame)) return frame
+    await Bun.sleep(10)
+  }
+  throw new Error(`Timed out waiting for agent detail dialog output:\n${frame}`)
+}
+
+function createAgent(agentType: string): AgentDefinition {
+  return {
+    agentType,
+    whenToUse: `Use ${agentType}`,
+    source: 'userSettings',
+    getSystemPrompt: () => `You are ${agentType}`,
+  }
+}
+
+beforeEach(async () => {
+  await acquireSharedMutationLock('components/agents/AgentDetailDialog.test.tsx')
+})
+
+afterEach(() => {
+  releaseSharedMutationLock()
+})
+
+// Regression (jatmn P2): the full /agents view wraps AgentDetail in a Dialog
+// whose own confirm:no (onCancel) stayed active while the route picker was open,
+// so a bare Esc jumped back to the agent list instead of closing the picker.
+// AgentDetailDialog mirrors the picker state to the Dialog's isCancelActive, so
+// while the picker is open only its Select owns Esc.
+test('Esc closes the route picker without firing the Dialog onCancel', async () => {
+  const agent = createAgent('regression-dialog-esc-agent')
+  const { stdout, stdin, getOutput } = createTestStreams()
+  const root = await createRoot({
+    stdout: stdout as unknown as NodeJS.WriteStream,
+    stdin: stdin as unknown as NodeJS.ReadStream,
+    patchConsole: false,
+  })
+  let cancelCalls = 0
+  let backCalls = 0
+
+  try {
+    root.render(
+      <AppStateProvider>
+        <KeybindingSetup>
+          <AgentDetailDialog
+            agent={agent}
+            tools={[]}
+            title={agent.agentType}
+            hideInputGuide={true}
+            onBack={() => {
+              backCalls += 1
+            }}
+            onCancel={() => {
+              cancelCalls += 1
+            }}
+          />
+        </KeybindingSetup>
+      </AppStateProvider>,
+    )
+
+    await waitForOutput(getOutput, f => f.includes('press "m" to change'))
+    stdin.write('m')
+    await waitForOutput(getOutput, f => f.includes('Set model route'))
+    // A single Esc must close the picker only, not the enclosing Dialog.
+    stdin.write('\u001B')
+    await Bun.sleep(150)
+    const frame = await waitForOutput(getOutput, f =>
+      f.includes('press "m" to change'),
+    )
+    expect(frame).not.toContain('Set model route')
+    expect(cancelCalls).toBe(0)
+    expect(backCalls).toBe(0)
+  } finally {
+    root.unmount()
+    stdin.end()
+    stdout.end()
+    await Bun.sleep(0)
+  }
+})

--- a/src/components/agents/AgentDetailDialog.tsx
+++ b/src/components/agents/AgentDetailDialog.tsx
@@ -1,0 +1,49 @@
+import * as React from 'react'
+
+import type { Tools } from '../../Tool.js'
+import type { AgentDefinition } from '../../tools/AgentTool/loadAgentsDir.js'
+import { Dialog } from '../design-system/Dialog.js'
+import { AgentDetail } from './AgentDetail.js'
+
+type Props = {
+  agent: AgentDefinition
+  tools: Tools
+  allAgents?: AgentDefinition[]
+  onBack: () => void
+  title: React.ReactNode
+  onCancel: () => void
+  hideInputGuide?: boolean
+}
+
+// Wraps AgentDetail in its Dialog while mirroring the detail view's route-picker
+// state up to the Dialog. While the picker is open its Select owns Esc (via
+// select:cancel -> onClose). Without deactivating the Dialog's own confirm:no,
+// the Dialog is the first-registered Confirmation context, so a bare Esc would
+// fire its onCancel and leave the detail view instead of just closing the picker.
+export function AgentDetailDialog({
+  agent,
+  tools,
+  allAgents,
+  onBack,
+  title,
+  onCancel,
+  hideInputGuide,
+}: Props): React.ReactNode {
+  const [routing, setRouting] = React.useState(false)
+  return (
+    <Dialog
+      title={title}
+      onCancel={onCancel}
+      hideInputGuide={hideInputGuide}
+      isCancelActive={!routing}
+    >
+      <AgentDetail
+        agent={agent}
+        tools={tools}
+        allAgents={allAgents}
+        onBack={onBack}
+        onRoutingChange={setRouting}
+      />
+    </Dialog>
+  )
+}

--- a/src/components/agents/AgentRouteSelector.test.tsx
+++ b/src/components/agents/AgentRouteSelector.test.tsx
@@ -5,6 +5,7 @@ import React from 'react'
 import stripAnsi from 'strip-ansi'
 
 import { createRoot } from '../../ink.js'
+import { AppStateProvider } from '../../state/AppState.js'
 import {
   acquireSharedMutationLock,
   releaseSharedMutationLock,
@@ -137,7 +138,11 @@ async function renderSelector(props: {
     stdin: stdin as unknown as NodeJS.ReadStream,
     patchConsole: false,
   })
-  root.render(<AgentRouteSelector {...props} />)
+  root.render(
+    <AppStateProvider>
+      <AgentRouteSelector {...props} />
+    </AppStateProvider>,
+  )
   return { root, stdin, getOutput }
 }
 
@@ -228,6 +233,56 @@ test('a failed save is surfaced and keeps the dialog open', async () => {
     const frame = await waitForOutput(getOutput, f => f.includes('Could not save'))
     expect(frame).toContain('disk full')
     expect(closed).toBe(false)
+  } finally {
+    root.unmount()
+    stdin.end()
+  }
+})
+
+test('typing a custom model id persists the full id on submit', async () => {
+  // Regression: the custom-input option once committed on its first keystroke,
+  // so typing "gpt-5-mini" saved only "g". The component now buffers the typed
+  // value in customIdRef and only calls setAgentRoute on submit. Type the id one
+  // character at a time (so a per-keystroke commit would surface as an early or
+  // truncated call) and assert exactly one save with the full id.
+  shadowSource = null
+  let closed = false
+  const { root, stdin, getOutput } = await renderSelector({
+    agentType: 'verification',
+    current: { kind: 'none' },
+    onClose: () => {
+      closed = true
+    },
+  })
+  try {
+    // The custom-input option is appended last; its index depends on how many
+    // model aliases the host's settings produce, so read it from the frame
+    // instead of hardcoding. Pressing its digit focuses the empty input (the
+    // useInput digit handler focuses, rather than submits, an empty input option).
+    const listed = await waitForOutput(
+      getOutput,
+      f => f.includes('Set model route') && f.includes('gpt-5-mini'),
+    )
+    const inputLine = listed.split('\n').find(l => l.includes('e.g. gpt-5-mini'))!
+    const inputIndex = inputLine.trim().match(/^(\d+)\./)?.[1]
+    expect(inputIndex).toBeDefined()
+    stdin.write(inputIndex!)
+    await waitForOutput(getOutput, f =>
+      f.split('\n').some(line => line.includes('❯') && line.includes('gpt-5-mini')),
+    )
+    for (const ch of 'gpt-5-mini') {
+      stdin.write(ch)
+      await Bun.sleep(5)
+    }
+    // The typed value replaces the "e.g. gpt-5-mini" placeholder once non-empty.
+    await waitForOutput(getOutput, f =>
+      f.split('\n').some(line => line.includes('gpt-5-mini') && !line.includes('e.g.')),
+    )
+    stdin.write('\r')
+    await waitForOutput(getOutput, () => setCalls.length > 0 || closed)
+    expect(setCalls.length).toBe(1)
+    expect(setCalls[0]).toEqual(['verification', 'gpt-5-mini'])
+    expect(closed).toBe(true)
   } finally {
     root.unmount()
     stdin.end()

--- a/src/components/agents/AgentRouteSelector.test.tsx
+++ b/src/components/agents/AgentRouteSelector.test.tsx
@@ -1,0 +1,214 @@
+import { PassThrough } from 'node:stream'
+
+import { afterEach, beforeEach, expect, mock, test } from 'bun:test'
+import React from 'react'
+import stripAnsi from 'strip-ansi'
+
+import { createRoot } from '../../ink.js'
+import {
+  acquireSharedMutationLock,
+  releaseSharedMutationLock,
+} from '../../test/sharedMutationLock.js'
+import type { CurrentAgentRoute } from '../../services/api/agentRouteSettings.js'
+
+const SYNC_START = '\x1B[?2026h'
+const SYNC_END = '\x1B[?2026l'
+
+function extractLastFrame(output: string): string {
+  let lastFrame: string | null = null
+  let cursor = 0
+  while (cursor < output.length) {
+    const start = output.indexOf(SYNC_START, cursor)
+    if (start === -1) break
+    const contentStart = start + SYNC_START.length
+    const end = output.indexOf(SYNC_END, contentStart)
+    if (end === -1) break
+    const frame = output.slice(contentStart, end)
+    if (frame.trim().length > 0) lastFrame = frame
+    cursor = end + SYNC_END.length
+  }
+  return lastFrame ?? output
+}
+
+function createTestStreams() {
+  let output = ''
+  const stdout = new PassThrough()
+  const stdin = new PassThrough() as PassThrough & {
+    isTTY: boolean
+    setRawMode: () => void
+    ref: () => void
+    unref: () => void
+  }
+  stdin.isTTY = true
+  stdin.setRawMode = () => {}
+  stdin.ref = () => {}
+  stdin.unref = () => {}
+  ;(stdout as unknown as { columns: number }).columns = 120
+  stdout.on('data', chunk => {
+    output += chunk.toString()
+  })
+  return { stdout, stdin, getOutput: () => output }
+}
+
+async function waitForOutput(
+  getOutput: () => string,
+  predicate: (frame: string) => boolean,
+): Promise<string> {
+  const startedAt = Date.now()
+  let frame = ''
+  while (Date.now() - startedAt < 2500) {
+    frame = stripAnsi(extractLastFrame(getOutput()))
+    if (predicate(frame)) return frame
+    await Bun.sleep(10)
+  }
+  throw new Error(`Timed out waiting for route selector output:\n${frame}`)
+}
+
+// Controls for the mocked service I/O, reset per test.
+let shadowSource: string | null = null
+let setCalls: Array<[string, string]> = []
+let clearCalls: string[] = []
+let setResult: { error: Error | null } = { error: null }
+
+beforeEach(async () => {
+  await acquireSharedMutationLock('components/agents/AgentRouteSelector.test.tsx')
+  shadowSource = null
+  setCalls = []
+  clearCalls = []
+  setResult = { error: null }
+  const real = await import('../../services/api/agentRouteSettings.js')
+  mock.module('../../services/api/agentRouteSettings.js', () => ({
+    ...real,
+    getRouteShadowSource: () => shadowSource,
+    setAgentRoute: (agentType: string, modelKey: string) => {
+      setCalls.push([agentType, modelKey])
+      return setResult
+    },
+    clearAgentRoute: (agentType: string) => {
+      clearCalls.push(agentType)
+      return { error: null }
+    },
+  }))
+})
+
+afterEach(() => {
+  try {
+    mock.restore()
+  } finally {
+    releaseSharedMutationLock()
+  }
+})
+
+async function importSelector() {
+  const nonce = `${Date.now()}-${Math.random()}`
+  return (await import(`./AgentRouteSelector.js?route-selector-test=${nonce}`))
+    .AgentRouteSelector
+}
+
+async function renderSelector(props: {
+  agentType: string
+  current: CurrentAgentRoute
+  onClose: () => void
+}) {
+  const AgentRouteSelector = await importSelector()
+  const { stdout, stdin, getOutput } = createTestStreams()
+  const root = await createRoot({
+    stdout: stdout as unknown as NodeJS.WriteStream,
+    stdin: stdin as unknown as NodeJS.ReadStream,
+    patchConsole: false,
+  })
+  root.render(<AgentRouteSelector {...props} />)
+  return { root, stdin, getOutput }
+}
+
+test('shadow mode shows a read-only notice naming the overriding source', async () => {
+  shadowSource = 'projectSettings'
+  let closed = false
+  const { root, stdin, getOutput } = await renderSelector({
+    agentType: 'verification',
+    current: { kind: 'none' },
+    onClose: () => {
+      closed = true
+    },
+  })
+  try {
+    const frame = await waitForOutput(getOutput, f =>
+      f.includes('override your user settings'),
+    )
+    expect(frame).toContain('verification')
+    expect(frame).toContain('projectSettings')
+    expect(frame).toContain('Edit the projectSettings settings')
+    // The picker (which would let you save an ignored route) must not render.
+    expect(frame).not.toContain('Set model route')
+    expect(closed).toBe(false)
+  } finally {
+    root.unmount()
+    stdin.end()
+  }
+})
+
+test('shadow mode uses flag-specific guidance for flagSettings (no file to edit)', async () => {
+  shadowSource = 'flagSettings'
+  const { root, stdin, getOutput } = await renderSelector({
+    agentType: 'Explore',
+    current: { kind: 'none' },
+    onClose: () => {},
+  })
+  try {
+    const frame = await waitForOutput(getOutput, f =>
+      f.includes('override your user settings'),
+    )
+    expect(frame).toContain('--settings flag or SDK inline settings')
+    expect(frame).not.toContain('Edit the flagSettings settings')
+  } finally {
+    root.unmount()
+    stdin.end()
+  }
+})
+
+test('normal mode renders the picker and persists a selected model', async () => {
+  shadowSource = null
+  let closed = false
+  const { root, stdin, getOutput } = await renderSelector({
+    agentType: 'verification',
+    current: { kind: 'none' },
+    onClose: () => {
+      closed = true
+    },
+  })
+  try {
+    await waitForOutput(getOutput, f => f.includes('Set model route'))
+    // Select the first numbered option.
+    stdin.write('1')
+    await waitForOutput(getOutput, () => setCalls.length > 0 || closed)
+    expect(setCalls.length).toBe(1)
+    expect(setCalls[0]![0]).toBe('verification')
+    expect(closed).toBe(true)
+  } finally {
+    root.unmount()
+    stdin.end()
+  }
+})
+
+test('a failed save is surfaced and keeps the dialog open', async () => {
+  shadowSource = null
+  setResult = { error: new Error('disk full') }
+  let closed = false
+  const { root, stdin, getOutput } = await renderSelector({
+    agentType: 'verification',
+    current: { kind: 'none' },
+    onClose: () => {
+      closed = true
+    },
+  })
+  try {
+    await waitForOutput(getOutput, f => f.includes('Set model route'))
+    stdin.write('1')
+    const frame = await waitForOutput(getOutput, f => f.includes('Could not save'))
+    expect(frame).toContain('disk full')
+    expect(closed).toBe(false)
+  } finally {
+    root.unmount()
+    stdin.end()
+  }
+})

--- a/src/components/agents/AgentRouteSelector.test.tsx
+++ b/src/components/agents/AgentRouteSelector.test.tsx
@@ -10,6 +10,9 @@ import {
   releaseSharedMutationLock,
 } from '../../test/sharedMutationLock.js'
 import type { CurrentAgentRoute } from '../../services/api/agentRouteSettings.js'
+import * as realRouteSettings from '../../services/api/agentRouteSettings.js'
+
+const ROUTE_SETTINGS_MODULE = '../../services/api/agentRouteSettings.js'
 
 const SYNC_START = '\x1B[?2026h'
 const SYNC_END = '\x1B[?2026l'
@@ -76,9 +79,8 @@ beforeEach(async () => {
   setCalls = []
   clearCalls = []
   setResult = { error: null }
-  const real = await import('../../services/api/agentRouteSettings.js')
-  mock.module('../../services/api/agentRouteSettings.js', () => ({
-    ...real,
+  mock.module(ROUTE_SETTINGS_MODULE, () => ({
+    ...realRouteSettings,
     getRouteShadowSource: () => shadowSource,
     // Deterministic option list so selecting index 1 picks a known model key.
     buildRouteOptions: () => [
@@ -98,6 +100,11 @@ beforeEach(async () => {
 afterEach(() => {
   try {
     mock.restore()
+    // Re-point the module at the real implementation. bun's mock.module
+    // persists across files in the same process, and mock.restore() alone does
+    // not undo it, so without this the mocked buildRouteOptions/etc. leak into
+    // agentRouteSettings.test.ts and fail its assertions.
+    mock.module(ROUTE_SETTINGS_MODULE, () => realRouteSettings)
   } finally {
     releaseSharedMutationLock()
   }

--- a/src/components/agents/AgentRouteSelector.test.tsx
+++ b/src/components/agents/AgentRouteSelector.test.tsx
@@ -79,13 +79,16 @@ beforeEach(async () => {
   setCalls = []
   clearCalls = []
   setResult = { error: null }
+  // Override only the I/O wrappers the component calls. buildRouteOptions is
+  // left as the REAL implementation on purpose: faking it here would persist in
+  // bun's module registry (mock.module live-updates the namespace, so the
+  // afterEach re-mock re-installs the fake) and leak into agentRouteSettings.test.ts,
+  // which unit-tests the real buildRouteOptions. The real one is deterministic:
+  // getAgentModelOptions always lists sonnet/opus/haiku first, so option 1 is
+  // 'sonnet' regardless of the host's settings.
   mock.module(ROUTE_SETTINGS_MODULE, () => ({
     ...realRouteSettings,
     getRouteShadowSource: () => shadowSource,
-    // Deterministic option list so selecting index 1 picks a known model key.
-    buildRouteOptions: () => [
-      { value: 'gpt-5-mini', label: 'gpt-5-mini', description: '' },
-    ],
     setAgentRoute: (agentType: string, modelKey: string) => {
       setCalls.push([agentType, modelKey])
       return setResult
@@ -189,11 +192,12 @@ test('normal mode renders the picker and persists a selected model', async () =>
   })
   try {
     await waitForOutput(getOutput, f => f.includes('Set model route'))
-    // Select the first numbered option.
+    // Select the first numbered option. buildRouteOptions always lists the
+    // built-in aliases first, so option 1 is 'sonnet'.
     stdin.write('1')
     await waitForOutput(getOutput, () => setCalls.length > 0 || closed)
     expect(setCalls.length).toBe(1)
-    expect(setCalls[0]).toEqual(['verification', 'gpt-5-mini'])
+    expect(setCalls[0]).toEqual(['verification', 'sonnet'])
     expect(closed).toBe(true)
   } finally {
     root.unmount()

--- a/src/components/agents/AgentRouteSelector.test.tsx
+++ b/src/components/agents/AgentRouteSelector.test.tsx
@@ -80,6 +80,10 @@ beforeEach(async () => {
   mock.module('../../services/api/agentRouteSettings.js', () => ({
     ...real,
     getRouteShadowSource: () => shadowSource,
+    // Deterministic option list so selecting index 1 picks a known model key.
+    buildRouteOptions: () => [
+      { value: 'gpt-5-mini', label: 'gpt-5-mini', description: '' },
+    ],
     setAgentRoute: (agentType: string, modelKey: string) => {
       setCalls.push([agentType, modelKey])
       return setResult
@@ -182,7 +186,7 @@ test('normal mode renders the picker and persists a selected model', async () =>
     stdin.write('1')
     await waitForOutput(getOutput, () => setCalls.length > 0 || closed)
     expect(setCalls.length).toBe(1)
-    expect(setCalls[0]![0]).toBe('verification')
+    expect(setCalls[0]).toEqual(['verification', 'gpt-5-mini'])
     expect(closed).toBe(true)
   } finally {
     root.unmount()

--- a/src/components/agents/AgentRouteSelector.test.tsx
+++ b/src/components/agents/AgentRouteSelector.test.tsx
@@ -13,6 +13,12 @@ import type { CurrentAgentRoute } from '../../services/api/agentRouteSettings.js
 import * as realRouteSettings from '../../services/api/agentRouteSettings.js'
 
 const ROUTE_SETTINGS_MODULE = '../../services/api/agentRouteSettings.js'
+// Snapshot the real exports before any mock.module call. bun live-updates the
+// `realRouteSettings` namespace when the module is mocked, so spreading it
+// directly (or restoring from it in afterEach) can pull in the mocked values;
+// this frozen copy keeps both the mock spread and the restore pinned to the
+// genuine implementation.
+const actualRouteSettings = { ...realRouteSettings }
 
 const SYNC_START = '\x1B[?2026h'
 const SYNC_END = '\x1B[?2026l'
@@ -87,7 +93,7 @@ beforeEach(async () => {
   // getAgentModelOptions always lists sonnet/opus/haiku first, so option 1 is
   // 'sonnet' regardless of the host's settings.
   mock.module(ROUTE_SETTINGS_MODULE, () => ({
-    ...realRouteSettings,
+    ...actualRouteSettings,
     getRouteShadowSource: () => shadowSource,
     setAgentRoute: (agentType: string, modelKey: string) => {
       setCalls.push([agentType, modelKey])
@@ -107,7 +113,7 @@ afterEach(() => {
     // persists across files in the same process, and mock.restore() alone does
     // not undo it, so without this the mocked buildRouteOptions/etc. leak into
     // agentRouteSettings.test.ts and fail its assertions.
-    mock.module(ROUTE_SETTINGS_MODULE, () => realRouteSettings)
+    mock.module(ROUTE_SETTINGS_MODULE, () => actualRouteSettings)
   } finally {
     releaseSharedMutationLock()
   }

--- a/src/components/agents/AgentRouteSelector.test.tsx
+++ b/src/components/agents/AgentRouteSelector.test.tsx
@@ -1,6 +1,7 @@
 import { PassThrough } from 'node:stream'
 
 import { afterEach, beforeEach, expect, mock, test } from 'bun:test'
+import figures from 'figures'
 import React from 'react'
 import stripAnsi from 'strip-ansi'
 
@@ -267,8 +268,15 @@ test('typing a custom model id persists the full id on submit', async () => {
     const inputIndex = inputLine.trim().match(/^(\d+)\./)?.[1]
     expect(inputIndex).toBeDefined()
     stdin.write(inputIndex!)
+    // The focus indicator is figures.pointer, which renders as ❯ on Unix but as
+    // ">" on Windows. Match the actual glyph the renderer uses on this platform
+    // so the wait does not time out in a Windows checkout.
     await waitForOutput(getOutput, f =>
-      f.split('\n').some(line => line.includes('❯') && line.includes('gpt-5-mini')),
+      f
+        .split('\n')
+        .some(
+          line => line.includes(figures.pointer) && line.includes('gpt-5-mini'),
+        ),
     )
     for (const ch of 'gpt-5-mini') {
       stdin.write(ch)

--- a/src/components/agents/AgentRouteSelector.tsx
+++ b/src/components/agents/AgentRouteSelector.tsx
@@ -7,6 +7,7 @@ import {
   buildRouteOptions,
   clearAgentRoute,
   currentRouteValue,
+  getRouteShadowSource,
   setAgentRoute,
   type CurrentAgentRoute,
 } from '../../services/api/agentRouteSettings.js'
@@ -34,6 +35,28 @@ export function AgentRouteSelector({ agentType, current, onClose }: Props): Reac
       return
     }
     onClose()
+  }
+
+  // A higher-priority settings source (project/local/policy) can override the
+  // user file the picker writes to. Saving there would be a silent no-op, so
+  // explain it as read-only instead of offering an ineffective edit.
+  const shadowSource = getRouteShadowSource(agentType)
+  if (shadowSource) {
+    return (
+      <Box flexDirection="column" gap={1}>
+        <Text>
+          <Text bold>{agentType}</Text> is routed by <Text bold>{shadowSource}</Text> settings, which override your user settings.
+        </Text>
+        <Text dimColor>
+          A user-level change won't take effect. Edit the {shadowSource} settings file to change this route. Press Esc to go back.
+        </Text>
+        <Select
+          options={[{ value: '__back__', label: 'Back' }]}
+          onChange={onClose}
+          onCancel={onClose}
+        />
+      </Box>
+    )
   }
 
   // Build options from the same scope we persist to (user settings), so a key

--- a/src/components/agents/AgentRouteSelector.tsx
+++ b/src/components/agents/AgentRouteSelector.tsx
@@ -8,13 +8,14 @@ import {
   clearAgentRoute,
   currentRouteValue,
   getRouteShadowSource,
+  getShadowedModelKeys,
   setAgentRoute,
   shadowRemediation,
   type CurrentAgentRoute,
 } from '../../services/api/agentRouteSettings.js'
 import type { OptionWithDescription } from '../CustomSelect/select.js'
 import { Select } from '../CustomSelect/select.js'
-import { getSettingsForSource } from '../../utils/settings/settings.js'
+import { getInitialSettings, getSettingsForSource } from '../../utils/settings/settings.js'
 
 type Props = {
   agentType: string
@@ -60,11 +61,16 @@ export function AgentRouteSelector({ agentType, current, onClose }: Props): Reac
     )
   }
 
-  // Build options from the same scope we persist to (user settings), so a key
-  // shown here can never create a shadow agentModels entry on a different scope.
+  // Options are built from userSettings (the scope we persist to), but a key
+  // here can still collide with a higher-priority agentModels entry that wins on
+  // merge, so flag those as shadowed. A `default` route also changes what
+  // clearing means, so surface that in the clear label.
   const settings = getSettingsForSource('userSettings')
   const options: OptionWithDescription<string>[] = [
-    ...buildRouteOptions(settings, current),
+    ...buildRouteOptions(settings, current, {
+      shadowedModelKeys: getShadowedModelKeys(),
+      defaultRouteApplies: Boolean(getInitialSettings()?.agentRouting?.default),
+    }),
     {
       type: 'input',
       value: CUSTOM_MODEL_VALUE,

--- a/src/components/agents/AgentRouteSelector.tsx
+++ b/src/components/agents/AgentRouteSelector.tsx
@@ -9,6 +9,7 @@ import {
   currentRouteValue,
   getRouteShadowSource,
   setAgentRoute,
+  shadowRemediation,
   type CurrentAgentRoute,
 } from '../../services/api/agentRouteSettings.js'
 import type { OptionWithDescription } from '../CustomSelect/select.js'
@@ -48,7 +49,7 @@ export function AgentRouteSelector({ agentType, current, onClose }: Props): Reac
           <Text bold>{agentType}</Text> is routed by <Text bold>{shadowSource}</Text> settings, which override your user settings.
         </Text>
         <Text dimColor>
-          A user-level change won't take effect. Edit the {shadowSource} settings file to change this route. Press Esc to go back.
+          A user-level change won't take effect. {shadowRemediation(shadowSource)} Press Esc to go back.
         </Text>
         <Select
           options={[{ value: '__back__', label: 'Back' }]}

--- a/src/components/agents/AgentRouteSelector.tsx
+++ b/src/components/agents/AgentRouteSelector.tsx
@@ -1,0 +1,74 @@
+import * as React from 'react'
+import { useState } from 'react'
+import { Box, Text } from '../../ink.js'
+import {
+  CUSTOM_MODEL_VALUE,
+  CLEAR_ROUTE_VALUE,
+  buildRouteOptions,
+  clearAgentRoute,
+  currentRouteValue,
+  setAgentRoute,
+  type CurrentAgentRoute,
+} from '../../services/api/agentRouteSettings.js'
+import type { OptionWithDescription } from '../CustomSelect/select.js'
+import { Select } from '../CustomSelect/select.js'
+import { getInitialSettings } from '../../utils/settings/settings.js'
+
+type Props = {
+  agentType: string
+  current: CurrentAgentRoute
+  onClose: () => void
+}
+
+export function AgentRouteSelector({ agentType, current, onClose }: Props): React.ReactNode {
+  const [error, setError] = useState<string | null>(null)
+
+  const apply = (run: () => { error: Error | null }): void => {
+    const { error: writeError } = run()
+    if (writeError) {
+      setError(writeError.message)
+      return
+    }
+    onClose()
+  }
+
+  const settings = getInitialSettings()
+  const options: OptionWithDescription<string>[] = [
+    ...buildRouteOptions(settings, current),
+    {
+      type: 'input',
+      value: CUSTOM_MODEL_VALUE,
+      label: 'Enter a custom model id',
+      placeholder: 'e.g. gpt-5-mini',
+      onChange: (value: string) => {
+        const id = value.trim()
+        if (id.length === 0) return
+        apply(() => setAgentRoute(agentType, id))
+      },
+    },
+  ]
+
+  const onChange = (value: string): void => {
+    if (value === CUSTOM_MODEL_VALUE) return
+    if (value === CLEAR_ROUTE_VALUE) {
+      apply(() => clearAgentRoute(agentType))
+      return
+    }
+    apply(() => setAgentRoute(agentType, value))
+  }
+
+  return (
+    <Box flexDirection="column" gap={1}>
+      <Text>
+        Set model route for <Text bold>{agentType}</Text> (saved to your user settings, applies next time this agent runs):
+      </Text>
+      <Select
+        options={options}
+        defaultValue={currentRouteValue(current)}
+        onChange={onChange}
+        onCancel={onClose}
+      />
+      {error && <Text color="error">Could not save: {error}</Text>}
+    </Box>
+  )
+}

--- a/src/components/agents/AgentRouteSelector.tsx
+++ b/src/components/agents/AgentRouteSelector.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { useState } from 'react'
+import { useRef, useState } from 'react'
 import { Box, Text } from '../../ink.js'
 import {
   CUSTOM_MODEL_VALUE,
@@ -22,6 +22,10 @@ type Props = {
 
 export function AgentRouteSelector({ agentType, current, onClose }: Props): React.ReactNode {
   const [error, setError] = useState<string | null>(null)
+  // The input option's onChange fires on every keystroke; track the value here
+  // and only persist on submit (handled below via the sentinel), so typing
+  // "gpt-5-mini" saves the full id instead of "g" on the first character.
+  const customIdRef = useRef('')
 
   const apply = (run: () => { error: Error | null }): void => {
     const { error: writeError } = run()
@@ -43,15 +47,21 @@ export function AgentRouteSelector({ agentType, current, onClose }: Props): Reac
       label: 'Enter a custom model id',
       placeholder: 'e.g. gpt-5-mini',
       onChange: (value: string) => {
-        const id = value.trim()
-        if (id.length === 0) return
-        apply(() => setAgentRoute(agentType, id))
+        customIdRef.current = value
       },
     },
   ]
 
   const onChange = (value: string): void => {
-    if (value === CUSTOM_MODEL_VALUE) return
+    if (value === CUSTOM_MODEL_VALUE) {
+      const id = customIdRef.current.trim()
+      if (id.length === 0) {
+        onClose()
+        return
+      }
+      apply(() => setAgentRoute(agentType, id))
+      return
+    }
     if (value === CLEAR_ROUTE_VALUE) {
       apply(() => clearAgentRoute(agentType))
       return

--- a/src/components/agents/AgentRouteSelector.tsx
+++ b/src/components/agents/AgentRouteSelector.tsx
@@ -12,7 +12,7 @@ import {
 } from '../../services/api/agentRouteSettings.js'
 import type { OptionWithDescription } from '../CustomSelect/select.js'
 import { Select } from '../CustomSelect/select.js'
-import { getInitialSettings } from '../../utils/settings/settings.js'
+import { getSettingsForSource } from '../../utils/settings/settings.js'
 
 type Props = {
   agentType: string
@@ -32,7 +32,9 @@ export function AgentRouteSelector({ agentType, current, onClose }: Props): Reac
     onClose()
   }
 
-  const settings = getInitialSettings()
+  // Build options from the same scope we persist to (user settings), so a key
+  // shown here can never create a shadow agentModels entry on a different scope.
+  const settings = getSettingsForSource('userSettings')
   const options: OptionWithDescription<string>[] = [
     ...buildRouteOptions(settings, current),
     {

--- a/src/components/agents/AgentsMenu.tsx
+++ b/src/components/agents/AgentsMenu.tsx
@@ -16,6 +16,7 @@ import { logError } from '../../utils/log.js';
 import { Select } from '../CustomSelect/select.js';
 import { Dialog } from '../design-system/Dialog.js';
 import { AgentDetail } from './AgentDetail.js';
+import { AgentDetailDialog } from './AgentDetailDialog.js';
 import { AgentEditor } from './AgentEditor.js';
 import { AgentNavigationFooter } from './AgentNavigationFooter.js';
 import { AgentsList } from './AgentsList.js';
@@ -507,26 +508,19 @@ export function AgentsMenu(t0) {
           t15 = $[99];
         }
         let t16;
-        if ($[100] !== agentToDisplay || $[101] !== allAgents || $[102] !== mergedTools || $[103] !== t15) {
-          t16 = <AgentDetail agent={agentToDisplay} tools={mergedTools} allAgents={allAgents} onBack={t15} />;
+        if ($[100] !== agentToDisplay || $[101] !== allAgents || $[102] !== mergedTools || $[103] !== t15 || $[105] !== t14 || $[106] !== agentToDisplay.agentType) {
+          t16 = <AgentDetailDialog title={agentToDisplay.agentType} onCancel={t14} hideInputGuide={true} agent={agentToDisplay} tools={mergedTools} allAgents={allAgents} onBack={t15} />;
           $[100] = agentToDisplay;
           $[101] = allAgents;
           $[102] = mergedTools;
           $[103] = t15;
+          $[105] = t14;
+          $[106] = agentToDisplay.agentType;
           $[104] = t16;
         } else {
           t16 = $[104];
         }
-        let t17;
-        if ($[105] !== agentToDisplay.agentType || $[106] !== t14 || $[107] !== t16) {
-          t17 = <Dialog title={agentToDisplay.agentType} onCancel={t14} hideInputGuide={true}>{t16}</Dialog>;
-          $[105] = agentToDisplay.agentType;
-          $[106] = t14;
-          $[107] = t16;
-          $[108] = t17;
-        } else {
-          t17 = $[108];
-        }
+        const t17 = t16;
         let t18;
         if ($[109] === Symbol.for("react.memo_cache_sentinel")) {
           t18 = <AgentNavigationFooter instructions="Press Enter or Esc to go back" />;

--- a/src/services/api/agentRouteSettings.test.ts
+++ b/src/services/api/agentRouteSettings.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, test } from 'bun:test'
+import type { SettingsJson } from '../../utils/settings/types.js'
+import {
+  CLEAR_ROUTE_VALUE,
+  buildRouteOptions,
+  computeClearRouteUpdate,
+  computeSetRouteUpdate,
+  currentRouteValue,
+  describeRouteLine,
+  readAgentRoute,
+} from './agentRouteSettings.js'
+
+const modelOnly: SettingsJson = {
+  agentModels: { mini: { model: 'gpt-5-mini' } },
+  agentRouting: { verification: 'mini' },
+} as unknown as SettingsJson
+
+const crossProvider: SettingsJson = {
+  agentModels: { ds: { base_url: 'https://api.deepseek.com/v1', api_key: 'sk-x', model: 'deepseek-chat' } },
+  agentRouting: { Explore: 'ds' },
+} as unknown as SettingsJson
+
+const dangling: SettingsJson = {
+  agentRouting: { Plan: 'ghost' },
+} as unknown as SettingsJson
+
+describe('readAgentRoute', () => {
+  test('none when no agentRouting entry', () => {
+    expect(readAgentRoute({} as SettingsJson, 'verification')).toEqual({ kind: 'none' })
+    expect(readAgentRoute(null, 'verification')).toEqual({ kind: 'none' })
+  })
+
+  test('model-only entry', () => {
+    expect(readAgentRoute(modelOnly, 'verification')).toEqual({
+      kind: 'model-only',
+      routeKey: 'mini',
+      model: 'gpt-5-mini',
+    })
+  })
+
+  test('cross-provider entry', () => {
+    expect(readAgentRoute(crossProvider, 'Explore')).toEqual({
+      kind: 'cross-provider',
+      routeKey: 'ds',
+      model: 'deepseek-chat',
+      baseURL: 'https://api.deepseek.com/v1',
+    })
+  })
+
+  test('dangling when routing points at a missing agentModels key', () => {
+    expect(readAgentRoute(dangling, 'Plan')).toEqual({ kind: 'dangling', routeKey: 'ghost' })
+  })
+
+  test('model defaults to the route key when entry has no model', () => {
+    const s = { agentModels: { haiku: {} }, agentRouting: { verification: 'haiku' } } as unknown as SettingsJson
+    expect(readAgentRoute(s, 'verification')).toEqual({ kind: 'model-only', routeKey: 'haiku', model: 'haiku' })
+  })
+})
+
+describe('computeSetRouteUpdate', () => {
+  test('creates a model-only entry and points routing at it', () => {
+    const next = computeSetRouteUpdate({} as SettingsJson, 'verification', 'haiku')
+    expect(next.agentModels).toEqual({ haiku: { model: 'haiku' } })
+    expect(next.agentRouting).toEqual({ verification: 'haiku' })
+  })
+
+  test('does NOT clobber an existing agentModels entry (e.g. cross-provider)', () => {
+    const next = computeSetRouteUpdate(crossProvider, 'verification', 'ds')
+    expect(next.agentModels).toEqual({
+      ds: { base_url: 'https://api.deepseek.com/v1', api_key: 'sk-x', model: 'deepseek-chat' },
+    })
+    expect(next.agentRouting).toEqual({ Explore: 'ds', verification: 'ds' })
+  })
+
+  test('preserves unrelated routing entries', () => {
+    const next = computeSetRouteUpdate(modelOnly, 'Explore', 'mini')
+    expect(next.agentRouting).toEqual({ verification: 'mini', Explore: 'mini' })
+  })
+})
+
+describe('computeClearRouteUpdate', () => {
+  test('marks the routing key as undefined for deletion', () => {
+    const next = computeClearRouteUpdate('verification') as unknown as {
+      agentRouting: Record<string, string | undefined>
+    }
+    expect('verification' in next.agentRouting).toBe(true)
+    expect(next.agentRouting.verification).toBeUndefined()
+  })
+})
+
+describe('buildRouteOptions', () => {
+  test('includes built-in model aliases, excludes inherit, no clear when route is none', () => {
+    const opts = buildRouteOptions({} as SettingsJson, { kind: 'none' })
+    const values = opts.map(o => o.value)
+    expect(values).toContain('sonnet')
+    expect(values).toContain('opus')
+    expect(values).toContain('haiku')
+    expect(values).not.toContain('inherit')
+    expect(values).not.toContain(CLEAR_ROUTE_VALUE)
+  })
+
+  test('adds a clear option when a route is set, and labels cross-provider keys', () => {
+    const opts = buildRouteOptions(crossProvider, { kind: 'cross-provider', routeKey: 'ds', model: 'deepseek-chat', baseURL: 'x' })
+    const clear = opts.find(o => o.value === CLEAR_ROUTE_VALUE)
+    expect(clear).toBeDefined()
+    const ds = opts.find(o => o.value === 'ds')
+    expect(ds?.label).toContain('cross-provider')
+  })
+})
+
+describe('currentRouteValue', () => {
+  test('returns the route key, or undefined for none/dangling', () => {
+    expect(currentRouteValue({ kind: 'model-only', routeKey: 'mini', model: 'gpt-5-mini' })).toBe('mini')
+    expect(currentRouteValue({ kind: 'none' })).toBeUndefined()
+  })
+})
+
+describe('describeRouteLine', () => {
+  test('produces a readable line per kind', () => {
+    expect(describeRouteLine({ kind: 'none' })).toContain('inherits')
+    expect(describeRouteLine({ kind: 'model-only', routeKey: 'm', model: 'gpt-5-mini' })).toContain('gpt-5-mini')
+    expect(describeRouteLine({ kind: 'cross-provider', routeKey: 'ds', model: 'deepseek-chat', baseURL: 'x' })).toContain('cross-provider')
+    expect(describeRouteLine({ kind: 'dangling', routeKey: 'ghost' })).toContain('ghost')
+  })
+})

--- a/src/services/api/agentRouteSettings.test.ts
+++ b/src/services/api/agentRouteSettings.test.ts
@@ -7,8 +7,10 @@ import {
   computeSetRouteUpdate,
   currentRouteValue,
   describeRouteLine,
+  findShadowingSource,
   readAgentRoute,
 } from './agentRouteSettings.js'
+import type { SettingsWithSources } from '../../utils/settings/settings.js'
 
 const modelOnly: SettingsJson = {
   agentModels: { mini: { model: 'gpt-5-mini' } },
@@ -215,5 +217,45 @@ describe('describeRouteLine', () => {
     expect(
       describeRouteLine({ kind: 'model-only', routeKey: 'm', model: 'gpt-5-mini', viaDefault: true }),
     ).toContain('via default')
+  })
+})
+
+describe('findShadowingSource', () => {
+  const src = (
+    source: string,
+    agentRouting: Record<string, string>,
+  ): SettingsWithSources['sources'][number] =>
+    ({ source, settings: { agentRouting } } as unknown as SettingsWithSources['sources'][number])
+
+  test('null when only userSettings defines the route', () => {
+    expect(findShadowingSource([src('userSettings', { verification: 'mini' })], 'verification')).toBeNull()
+  })
+
+  test('null when a higher source has no matching key', () => {
+    const sources = [src('userSettings', { verification: 'mini' }), src('projectSettings', { Explore: 'haiku' })]
+    expect(findShadowingSource(sources, 'verification')).toBeNull()
+  })
+
+  test('returns a higher-priority source that overrides the user route', () => {
+    const sources = [src('userSettings', { verification: 'mini' }), src('projectSettings', { verification: 'proj' })]
+    expect(findShadowingSource(sources, 'verification')).toBe('projectSettings')
+  })
+
+  test('matches by runtime normalization, not exact key', () => {
+    const sources = [src('userSettings', {}), src('localSettings', { general_purpose: 'x' })]
+    expect(findShadowingSource(sources, 'general-purpose')).toBe('localSettings')
+  })
+
+  test('shadows even when userSettings is absent', () => {
+    expect(findShadowingSource([src('projectSettings', { verification: 'proj' })], 'verification')).toBe('projectSettings')
+  })
+
+  test('returns the highest-priority shadowing source', () => {
+    const sources = [
+      src('userSettings', { verification: 'mini' }),
+      src('projectSettings', { verification: 'proj' }),
+      src('policySettings', { verification: 'pol' }),
+    ]
+    expect(findShadowingSource(sources, 'verification')).toBe('policySettings')
   })
 })

--- a/src/services/api/agentRouteSettings.test.ts
+++ b/src/services/api/agentRouteSettings.test.ts
@@ -51,6 +51,22 @@ describe('readAgentRoute', () => {
     expect(readAgentRoute(dangling, 'Plan')).toEqual({ kind: 'dangling', routeKey: 'ghost' })
   })
 
+  test('partial cross-provider entry (one cred) is unconfigured like the runtime', () => {
+    // toAgentRoute skips an entry with only base_url or only api_key, so it
+    // inherits at runtime; the UI must not present it as a working route.
+    const halfBase = {
+      agentModels: { half: { base_url: 'https://api.example.com/v1' } },
+      agentRouting: { verification: 'half' },
+    } as unknown as SettingsJson
+    expect(readAgentRoute(halfBase, 'verification')).toEqual({ kind: 'dangling', routeKey: 'half' })
+
+    const halfKey = {
+      agentModels: { half: { api_key: 'sk-only' } },
+      agentRouting: { verification: 'half' },
+    } as unknown as SettingsJson
+    expect(readAgentRoute(halfKey, 'verification')).toEqual({ kind: 'dangling', routeKey: 'half' })
+  })
+
   test('model defaults to the route key when entry has no model', () => {
     const s = { agentModels: { haiku: {} }, agentRouting: { verification: 'haiku' } } as unknown as SettingsJson
     expect(readAgentRoute(s, 'verification')).toEqual({ kind: 'model-only', routeKey: 'haiku', model: 'haiku' })
@@ -105,6 +121,17 @@ describe('buildRouteOptions', () => {
     expect(clear).toBeDefined()
     const ds = opts.find(o => o.value === 'ds')
     expect(ds?.label).toContain('cross-provider')
+  })
+
+  test('labels a partial cross-provider key as unconfigured, not cross-provider', () => {
+    const half = {
+      agentModels: { half: { base_url: 'https://api.example.com/v1' } },
+      agentRouting: { verification: 'half' },
+    } as unknown as SettingsJson
+    const opts = buildRouteOptions(half, { kind: 'dangling', routeKey: 'half' })
+    const entry = opts.find(o => o.value === 'half')
+    expect(String(entry?.label)).toContain('unconfigured')
+    expect(String(entry?.label)).not.toContain('cross-provider')
   })
 })
 

--- a/src/services/api/agentRouteSettings.test.ts
+++ b/src/services/api/agentRouteSettings.test.ts
@@ -109,8 +109,9 @@ describe('buildRouteOptions', () => {
 })
 
 describe('currentRouteValue', () => {
-  test('returns the route key, or undefined for none/dangling', () => {
+  test('returns the route key for any assigned route, undefined only for none', () => {
     expect(currentRouteValue({ kind: 'model-only', routeKey: 'mini', model: 'gpt-5-mini' })).toBe('mini')
+    expect(currentRouteValue({ kind: 'dangling', routeKey: 'ghost' })).toBe('ghost')
     expect(currentRouteValue({ kind: 'none' })).toBeUndefined()
   })
 })

--- a/src/services/api/agentRouteSettings.test.ts
+++ b/src/services/api/agentRouteSettings.test.ts
@@ -1,5 +1,6 @@
-import { afterEach, describe, expect, test } from 'bun:test'
+import { afterEach, describe, expect, spyOn, test } from 'bun:test'
 import type { SettingsJson } from '../../utils/settings/types.js'
+import * as settingsModule from '../../utils/settings/settings.js'
 import {
   CLEAR_ROUTE_VALUE,
   buildRouteOptions,
@@ -378,6 +379,68 @@ describe('shadowRemediation', () => {
     const msg = shadowRemediation('flagSettings')
     expect(msg).not.toContain('Edit the')
     expect(msg).toContain('--settings flag')
+  })
+})
+
+describe('setAgentRoute model-key shadow guard', () => {
+  const sourcesWith = (
+    entries: Array<[string, Record<string, unknown>]>,
+  ): SettingsWithSources =>
+    ({
+      effective: {} as SettingsJson,
+      sources: entries.map(([source, agentModels]) => ({
+        source,
+        settings: { agentModels },
+      })),
+    } as unknown as SettingsWithSources)
+
+  let withSources: ReturnType<typeof spyOn> | undefined
+  let update: ReturnType<typeof spyOn> | undefined
+  let forSource: ReturnType<typeof spyOn> | undefined
+
+  afterEach(() => {
+    withSources?.mockRestore()
+    update?.mockRestore()
+    forSource?.mockRestore()
+    withSources = update = forSource = undefined
+  })
+
+  test('rejects a key shadowed by a higher-priority source', () => {
+    // projectSettings defines agentModels.mini, which wins on merge, so a
+    // user-level route to "mini" would resolve to the project entry, not the
+    // current-provider model the option promised. The save must be refused.
+    withSources = spyOn(settingsModule, 'getSettingsWithSources').mockReturnValue(
+      sourcesWith([
+        ['userSettings', { mini: { model: 'gpt-5-mini' } }],
+        ['projectSettings', { mini: { model: 'project-model' } }],
+      ]),
+    )
+    update = spyOn(settingsModule, 'updateSettingsForSource')
+
+    const { error } = setAgentRoute('verification', 'mini')
+    expect(error).toBeInstanceOf(Error)
+    expect(error!.message).toContain('projectSettings')
+    // The guard must short-circuit before any write lands.
+    expect(update).not.toHaveBeenCalled()
+  })
+
+  test('saves a user-only key that nothing higher shadows', () => {
+    withSources = spyOn(settingsModule, 'getSettingsWithSources').mockReturnValue(
+      sourcesWith([['userSettings', { mine: { model: 'gpt-5-mini' } }]]),
+    )
+    forSource = spyOn(settingsModule, 'getSettingsForSource').mockReturnValue(
+      { agentModels: { mine: { model: 'gpt-5-mini' } } } as unknown as SettingsJson,
+    )
+    update = spyOn(settingsModule, 'updateSettingsForSource').mockReturnValue({
+      error: null,
+    })
+
+    const { error } = setAgentRoute('verification', 'mine')
+    expect(error).toBeNull()
+    expect(update).toHaveBeenCalledTimes(1)
+    const [source, next] = update.mock.calls[0] as [string, SettingsJson]
+    expect(source).toBe('userSettings')
+    expect((next.agentRouting as Record<string, string>).verification).toBe('mine')
   })
 })
 

--- a/src/services/api/agentRouteSettings.test.ts
+++ b/src/services/api/agentRouteSettings.test.ts
@@ -8,6 +8,7 @@ import {
   computeSetRouteUpdate,
   currentRouteValue,
   describeRouteLine,
+  findModelKeyShadowingSource,
   findShadowingSource,
   readAgentRoute,
   setAgentRoute,
@@ -202,6 +203,40 @@ describe('buildRouteOptions', () => {
     expect(String(entry?.label)).toContain('unconfigured')
     expect(String(entry?.label)).not.toContain('cross-provider')
   })
+
+  test('clear label promises default route, not parent, when a default applies', () => {
+    const opts = buildRouteOptions(
+      modelOnly,
+      { kind: 'model-only', routeKey: 'mini', model: 'gpt-5-mini' },
+      { defaultRouteApplies: true },
+    )
+    const clear = opts.find(o => o.value === CLEAR_ROUTE_VALUE)
+    expect(String(clear?.label)).toContain('default route')
+    expect(String(clear?.label)).not.toContain('inherit from parent')
+  })
+
+  test('clear label promises parent inheritance when no default applies', () => {
+    const opts = buildRouteOptions(
+      modelOnly,
+      { kind: 'model-only', routeKey: 'mini', model: 'gpt-5-mini' },
+      { defaultRouteApplies: false },
+    )
+    const clear = opts.find(o => o.value === CLEAR_ROUTE_VALUE)
+    expect(String(clear?.label)).toContain('inherit from parent')
+  })
+
+  test('flags a model key shadowed by a higher source', () => {
+    const opts = buildRouteOptions(
+      {} as SettingsJson,
+      { kind: 'none' },
+      { shadowedModelKeys: new Set(['sonnet']) },
+    )
+    const sonnet = opts.find(o => o.value === 'sonnet')
+    expect(String(sonnet?.label)).toContain('shadowed by higher settings')
+    // Non-shadowed built-ins are unaffected.
+    const opus = opts.find(o => o.value === 'opus')
+    expect(String(opus?.label)).not.toContain('shadowed')
+  })
 })
 
 describe('currentRouteValue', () => {
@@ -264,6 +299,44 @@ describe('findShadowingSource', () => {
       src('policySettings', { verification: 'pol' }),
     ]
     expect(findShadowingSource(sources, 'verification')).toBe('policySettings')
+  })
+})
+
+describe('findModelKeyShadowingSource', () => {
+  const src = (
+    source: string,
+    agentModels: Record<string, unknown>,
+  ): SettingsWithSources['sources'][number] =>
+    ({ source, settings: { agentModels } } as unknown as SettingsWithSources['sources'][number])
+
+  test('null when only userSettings defines the model key', () => {
+    expect(findModelKeyShadowingSource([src('userSettings', { sonnet: { model: 'sonnet' } })], 'sonnet')).toBeNull()
+  })
+
+  test('returns a higher source that defines the same agentModels key', () => {
+    const sources = [
+      src('userSettings', {}),
+      src('projectSettings', { sonnet: { base_url: 'x', api_key: 'k', model: 'team-sonnet' } }),
+    ]
+    expect(findModelKeyShadowingSource(sources, 'sonnet')).toBe('projectSettings')
+  })
+
+  test('uses exact key match (not normalized), mirroring the resolver', () => {
+    const sources = [src('userSettings', {}), src('projectSettings', { 'gpt_5': {} })]
+    expect(findModelKeyShadowingSource(sources, 'gpt-5')).toBeNull()
+  })
+
+  test('shadows even when userSettings is absent', () => {
+    expect(findModelKeyShadowingSource([src('policySettings', { sonnet: {} })], 'sonnet')).toBe('policySettings')
+  })
+
+  test('returns the highest-priority shadowing source', () => {
+    const sources = [
+      src('userSettings', { sonnet: { model: 'sonnet' } }),
+      src('projectSettings', { sonnet: {} }),
+      src('policySettings', { sonnet: {} }),
+    ]
+    expect(findModelKeyShadowingSource(sources, 'sonnet')).toBe('policySettings')
   })
 })
 

--- a/src/services/api/agentRouteSettings.test.ts
+++ b/src/services/api/agentRouteSettings.test.ts
@@ -9,6 +9,7 @@ import {
   describeRouteLine,
   findShadowingSource,
   readAgentRoute,
+  shadowRemediation,
 } from './agentRouteSettings.js'
 import type { SettingsWithSources } from '../../utils/settings/settings.js'
 
@@ -257,5 +258,18 @@ describe('findShadowingSource', () => {
       src('policySettings', { verification: 'pol' }),
     ]
     expect(findShadowingSource(sources, 'verification')).toBe('policySettings')
+  })
+})
+
+describe('shadowRemediation', () => {
+  test('points file-backed sources at their settings file', () => {
+    expect(shadowRemediation('projectSettings')).toContain('Edit the projectSettings settings')
+    expect(shadowRemediation('policySettings')).toContain('Edit the policySettings settings')
+  })
+
+  test('flagSettings has no file to edit', () => {
+    const msg = shadowRemediation('flagSettings')
+    expect(msg).not.toContain('Edit the')
+    expect(msg).toContain('--settings flag')
   })
 })

--- a/src/services/api/agentRouteSettings.test.ts
+++ b/src/services/api/agentRouteSettings.test.ts
@@ -1,17 +1,23 @@
-import { describe, expect, test } from 'bun:test'
+import { afterEach, describe, expect, test } from 'bun:test'
 import type { SettingsJson } from '../../utils/settings/types.js'
 import {
   CLEAR_ROUTE_VALUE,
   buildRouteOptions,
+  clearAgentRoute,
   computeClearRouteUpdate,
   computeSetRouteUpdate,
   currentRouteValue,
   describeRouteLine,
   findShadowingSource,
   readAgentRoute,
+  setAgentRoute,
   shadowRemediation,
 } from './agentRouteSettings.js'
 import type { SettingsWithSources } from '../../utils/settings/settings.js'
+import {
+  getAllowedSettingSources,
+  setAllowedSettingSources,
+} from '../../bootstrap/state.js'
 
 const modelOnly: SettingsJson = {
   agentModels: { mini: { model: 'gpt-5-mini' } },
@@ -271,5 +277,37 @@ describe('shadowRemediation', () => {
     const msg = shadowRemediation('flagSettings')
     expect(msg).not.toContain('Edit the')
     expect(msg).toContain('--settings flag')
+  })
+})
+
+describe('write guard when user settings are disabled', () => {
+  afterEach(() => {
+    // Restore the full default source set for other tests.
+    setAllowedSettingSources([
+      'userSettings',
+      'projectSettings',
+      'localSettings',
+      'flagSettings',
+      'policySettings',
+    ])
+  })
+
+  test('setAgentRoute refuses and explains when userSettings is not enabled', () => {
+    const before = getAllowedSettingSources()
+    expect(before).toContain('userSettings')
+    // Simulate `--setting-sources project`: user settings excluded.
+    setAllowedSettingSources(['projectSettings'])
+
+    const { error } = setAgentRoute('verification', 'gpt-5-mini')
+    expect(error).toBeInstanceOf(Error)
+    expect(error!.message).toContain('User settings are disabled')
+    expect(error!.message).toContain('--setting-sources')
+  })
+
+  test('clearAgentRoute refuses when userSettings is not enabled', () => {
+    setAllowedSettingSources(['projectSettings'])
+    const { error } = clearAgentRoute('verification')
+    expect(error).toBeInstanceOf(Error)
+    expect(error!.message).toContain('User settings are disabled')
   })
 })

--- a/src/services/api/agentRouteSettings.test.ts
+++ b/src/services/api/agentRouteSettings.test.ts
@@ -71,6 +71,37 @@ describe('readAgentRoute', () => {
     const s = { agentModels: { haiku: {} }, agentRouting: { verification: 'haiku' } } as unknown as SettingsJson
     expect(readAgentRoute(s, 'verification')).toEqual({ kind: 'model-only', routeKey: 'haiku', model: 'haiku' })
   })
+
+  test('matches a normalized routing key the runtime would resolve (hyphen vs underscore)', () => {
+    // Runtime normalizes "general_purpose" and "general-purpose" to the same key,
+    // so an exact-key read would wrongly report this agent as inheriting.
+    const s = {
+      agentModels: { mini: { model: 'gpt-5-mini' } },
+      agentRouting: { general_purpose: 'mini' },
+    } as unknown as SettingsJson
+    expect(readAgentRoute(s, 'general-purpose')).toEqual({ kind: 'model-only', routeKey: 'mini', model: 'gpt-5-mini' })
+  })
+
+  test('surfaces a default-fallback route with viaDefault', () => {
+    const s = {
+      agentModels: { mini: { model: 'gpt-5-mini' } },
+      agentRouting: { default: 'mini' },
+    } as unknown as SettingsJson
+    expect(readAgentRoute(s, 'Explore')).toEqual({
+      kind: 'model-only',
+      routeKey: 'mini',
+      model: 'gpt-5-mini',
+      viaDefault: true,
+    })
+  })
+
+  test('an own route key wins over the default fallback', () => {
+    const s = {
+      agentModels: { mini: { model: 'gpt-5-mini' }, haiku: {} },
+      agentRouting: { default: 'mini', Explore: 'haiku' },
+    } as unknown as SettingsJson
+    expect(readAgentRoute(s, 'Explore')).toEqual({ kind: 'model-only', routeKey: 'haiku', model: 'haiku' })
+  })
 })
 
 describe('computeSetRouteUpdate', () => {
@@ -92,15 +123,35 @@ describe('computeSetRouteUpdate', () => {
     const next = computeSetRouteUpdate(modelOnly, 'Explore', 'mini')
     expect(next.agentRouting).toEqual({ verification: 'mini', Explore: 'mini' })
   })
+
+  test('overwrites the existing normalized key in place instead of adding a sibling', () => {
+    const s = {
+      agentModels: { mini: { model: 'gpt-5-mini' }, haiku: {} },
+      agentRouting: { general_purpose: 'mini' },
+    } as unknown as SettingsJson
+    const next = computeSetRouteUpdate(s, 'general-purpose', 'haiku')
+    // The runtime first-wins lookup would ignore a "general-purpose" sibling, so
+    // we must reuse the existing "general_purpose" spelling.
+    expect(next.agentRouting).toEqual({ general_purpose: 'haiku' })
+  })
 })
 
 describe('computeClearRouteUpdate', () => {
   test('marks the routing key as undefined for deletion', () => {
-    const next = computeClearRouteUpdate('verification') as unknown as {
+    const next = computeClearRouteUpdate(modelOnly, 'verification') as unknown as {
       agentRouting: Record<string, string | undefined>
     }
     expect('verification' in next.agentRouting).toBe(true)
     expect(next.agentRouting.verification).toBeUndefined()
+  })
+
+  test('clears the existing normalized key spelling', () => {
+    const s = { agentRouting: { general_purpose: 'mini' } } as unknown as SettingsJson
+    const next = computeClearRouteUpdate(s, 'general-purpose') as unknown as {
+      agentRouting: Record<string, string | undefined>
+    }
+    expect('general_purpose' in next.agentRouting).toBe(true)
+    expect(next.agentRouting.general_purpose).toBeUndefined()
   })
 })
 
@@ -121,6 +172,15 @@ describe('buildRouteOptions', () => {
     expect(clear).toBeDefined()
     const ds = opts.find(o => o.value === 'ds')
     expect(ds?.label).toContain('cross-provider')
+  })
+
+  test('omits the clear option for a default-inherited route (nothing own to clear)', () => {
+    const s = {
+      agentModels: { mini: { model: 'gpt-5-mini' } },
+      agentRouting: { default: 'mini' },
+    } as unknown as SettingsJson
+    const opts = buildRouteOptions(s, { kind: 'model-only', routeKey: 'mini', model: 'gpt-5-mini', viaDefault: true })
+    expect(opts.map(o => o.value)).not.toContain(CLEAR_ROUTE_VALUE)
   })
 
   test('labels a partial cross-provider key as unconfigured, not cross-provider', () => {
@@ -149,5 +209,11 @@ describe('describeRouteLine', () => {
     expect(describeRouteLine({ kind: 'model-only', routeKey: 'm', model: 'gpt-5-mini' })).toContain('gpt-5-mini')
     expect(describeRouteLine({ kind: 'cross-provider', routeKey: 'ds', model: 'deepseek-chat', baseURL: 'x' })).toContain('cross-provider')
     expect(describeRouteLine({ kind: 'dangling', routeKey: 'ghost' })).toContain('ghost')
+  })
+
+  test('marks a default-inherited route', () => {
+    expect(
+      describeRouteLine({ kind: 'model-only', routeKey: 'm', model: 'gpt-5-mini', viaDefault: true }),
+    ).toContain('via default')
   })
 })

--- a/src/services/api/agentRouteSettings.test.ts
+++ b/src/services/api/agentRouteSettings.test.ts
@@ -6,6 +6,7 @@ import {
   clearAgentRoute,
   computeClearRouteUpdate,
   computeSetRouteUpdate,
+  collectShadowedModelKeys,
   currentRouteValue,
   describeRouteLine,
   findModelKeyShadowingSource,
@@ -337,6 +338,33 @@ describe('findModelKeyShadowingSource', () => {
       src('policySettings', { sonnet: {} }),
     ]
     expect(findModelKeyShadowingSource(sources, 'sonnet')).toBe('policySettings')
+  })
+
+  test('shadows a key the user also defines (the user entry is the one shadowed)', () => {
+    const sources = [
+      src('userSettings', { sonnet: { model: 'sonnet' } }),
+      src('projectSettings', { sonnet: { base_url: 'x', api_key: 'k', model: 'team' } }),
+    ]
+    // Owning the key in userSettings does not save it from being shadowed.
+    expect(findModelKeyShadowingSource(sources, 'sonnet')).toBe('projectSettings')
+  })
+
+  test('collectShadowedModelKeys agrees with findModelKeyShadowingSource', () => {
+    // The offer path (this set) and the save guard (find...) must never disagree
+    // on what is shadowed, or the picker flags a key it still lets you save.
+    const sources = [
+      src('userSettings', { sonnet: { model: 'sonnet' }, mine: {} }),
+      src('projectSettings', { sonnet: {}, teamModel: {} }),
+      src('policySettings', { locked: {} }),
+    ]
+    const set = collectShadowedModelKeys(sources)
+    expect(set).toEqual(new Set(['sonnet', 'teamModel', 'locked']))
+    for (const key of set) {
+      expect(findModelKeyShadowingSource(sources, key)).not.toBeNull()
+    }
+    // A user-only key is not in the set and is not shadowed.
+    expect(set.has('mine')).toBe(false)
+    expect(findModelKeyShadowingSource(sources, 'mine')).toBeNull()
   })
 })
 

--- a/src/services/api/agentRouteSettings.ts
+++ b/src/services/api/agentRouteSettings.ts
@@ -11,33 +11,77 @@ export const CUSTOM_MODEL_VALUE = '__custom_model__'
 /** Sentinel Select value: clear the route so the agent inherits the parent model. */
 export const CLEAR_ROUTE_VALUE = '__clear_route__'
 
-/** The route currently assigned to an agent type in user settings. */
+/**
+ * The route currently assigned to an agent type in user settings. `viaDefault`
+ * marks a route the agent only gets through the `default` fallback (it has no
+ * own routing key), so the menu can show it without claiming it as the agent's
+ * own assignment.
+ */
 export type CurrentAgentRoute =
   | { kind: 'none' }
-  | { kind: 'model-only'; routeKey: string; model: string }
-  | { kind: 'cross-provider'; routeKey: string; model: string; baseURL: string }
-  | { kind: 'dangling'; routeKey: string }
+  | { kind: 'model-only'; routeKey: string; model: string; viaDefault?: boolean }
+  | { kind: 'cross-provider'; routeKey: string; model: string; baseURL: string; viaDefault?: boolean }
+  | { kind: 'dangling'; routeKey: string; viaDefault?: boolean }
 
-/** Read the route assigned to `agentType` from a settings value. Pure. */
-export function readAgentRoute(
-  settings: SettingsJson | null,
+/** Normalize a routing key the same way the runtime resolver does. */
+function normalizeAgentKey(key: string): string {
+  return key.toLowerCase().replace(/[-_]/g, '')
+}
+
+/**
+ * The existing `agentRouting` key (original spelling) that the runtime resolver
+ * would match for `agentType`, or undefined if none. Mirrors
+ * resolveAgentProvider's case-insensitive, hyphen/underscore-insensitive,
+ * first-wins lookup. Pure.
+ */
+function findOwnRouteKey(
+  routing: Record<string, string> | undefined,
   agentType: string,
+): string | undefined {
+  if (!routing) return undefined
+  const target = normalizeAgentKey(agentType)
+  for (const key of Object.keys(routing)) {
+    if (normalizeAgentKey(key) === target) return key
+  }
+  return undefined
+}
+
+/** Build the route descriptor for a resolved model key. Pure. */
+function describeModelKey(
+  settings: SettingsJson | null,
+  modelKey: string,
+  viaDefault: boolean,
 ): CurrentAgentRoute {
-  const routeKey = settings?.agentRouting?.[agentType]
-  if (!routeKey) return { kind: 'none' }
-  const entry = settings?.agentModels?.[routeKey]
-  if (!entry) return { kind: 'dangling', routeKey }
-  const model = entry.model?.trim() || routeKey
+  const entry = settings?.agentModels?.[modelKey]
+  if (!entry) return { kind: 'dangling', routeKey: modelKey, ...(viaDefault ? { viaDefault } : {}) }
+  const model = entry.model?.trim() || modelKey
   // Mirror the runtime resolver (toAgentRoute): cross-provider needs BOTH
   // base_url and api_key. A partial entry is skipped at runtime and inherits,
   // so surface it as unconfigured rather than claiming a route that won't run.
   const baseURL = entry.base_url?.trim()
   const apiKey = entry.api_key?.trim()
-  if (!baseURL && !apiKey) return { kind: 'model-only', routeKey, model }
+  if (!baseURL && !apiKey) return { kind: 'model-only', routeKey: modelKey, model, ...(viaDefault ? { viaDefault } : {}) }
   if (baseURL && apiKey) {
-    return { kind: 'cross-provider', routeKey, model, baseURL }
+    return { kind: 'cross-provider', routeKey: modelKey, model, baseURL, ...(viaDefault ? { viaDefault } : {}) }
   }
-  return { kind: 'dangling', routeKey }
+  return { kind: 'dangling', routeKey: modelKey, ...(viaDefault ? { viaDefault } : {}) }
+}
+
+/**
+ * Read the route assigned to `agentType` from a settings value, mirroring the
+ * runtime resolver: a normalized per-agent key wins, otherwise the `default`
+ * fallback applies (surfaced with `viaDefault`). Pure.
+ */
+export function readAgentRoute(
+  settings: SettingsJson | null,
+  agentType: string,
+): CurrentAgentRoute {
+  const routing = settings?.agentRouting
+  const ownKey = findOwnRouteKey(routing, agentType)
+  if (ownKey) return describeModelKey(settings, routing![ownKey], false)
+  const defaultModelKey = routing?.default
+  if (defaultModelKey) return describeModelKey(settings, defaultModelKey, true)
+  return { kind: 'none' }
 }
 
 /** The Select value representing the current route, if any. Pure. */
@@ -59,29 +103,39 @@ export function computeSetRouteUpdate(
   if (!agentModels[modelKey]) {
     agentModels[modelKey] = { model: modelKey }
   }
-  const agentRouting = { ...(settings?.agentRouting ?? {}), [agentType]: modelKey }
+  // Reuse the existing routing key the runtime would match so we overwrite it
+  // in place instead of writing a normalized sibling the resolver's first-wins
+  // lookup would ignore (e.g. "general-purpose" beside "general_purpose").
+  const routingKey = findOwnRouteKey(settings?.agentRouting, agentType) ?? agentType
+  const agentRouting = { ...(settings?.agentRouting ?? {}), [routingKey]: modelKey }
   return { agentModels, agentRouting } as unknown as SettingsJson
 }
 
 /**
- * Next settings to clear `agentType`'s route. The explicit `undefined` is what
- * makes updateSettingsForSource delete the key on merge. Pure.
+ * Next settings to clear `agentType`'s route. Clears the effective routing key
+ * the runtime would match (not a normalized sibling). The explicit `undefined`
+ * is what makes updateSettingsForSource delete the key on merge. Pure.
  */
-export function computeClearRouteUpdate(agentType: string): SettingsJson {
-  return { agentRouting: { [agentType]: undefined } } as unknown as SettingsJson
+export function computeClearRouteUpdate(
+  settings: SettingsJson | null,
+  agentType: string,
+): SettingsJson {
+  const routingKey = findOwnRouteKey(settings?.agentRouting, agentType) ?? agentType
+  return { agentRouting: { [routingKey]: undefined } } as unknown as SettingsJson
 }
 
 /** Human-readable one-line route summary for the AgentDetail view. Pure. */
 export function describeRouteLine(current: CurrentAgentRoute): string {
+  const viaDefault = current.kind !== 'none' && current.viaDefault ? ' (via default)' : ''
   switch (current.kind) {
     case 'none':
       return 'Route: inherits parent model'
     case 'model-only':
-      return `Route: ${current.model} (current provider)`
+      return `Route: ${current.model} (current provider)${viaDefault}`
     case 'cross-provider':
-      return `Route: ${current.model} (cross-provider)`
+      return `Route: ${current.model} (cross-provider)${viaDefault}`
     case 'dangling':
-      return `Route: ${current.routeKey} (unconfigured, inherits)`
+      return `Route: ${current.routeKey} (unconfigured, inherits)${viaDefault}`
   }
 }
 
@@ -111,7 +165,11 @@ export function buildRouteOptions(
       }
     })
 
-  if (current.kind !== 'none') {
+  // Only offer "clear" when the agent has its OWN routing key. A route inherited
+  // via `default` has nothing agent-specific to remove, and clearing wouldn't
+  // make it inherit the parent (default would still apply), so the option would
+  // claim a change the runtime ignores.
+  if (current.kind !== 'none' && !current.viaDefault) {
     modelOptions.push({
       value: CLEAR_ROUTE_VALUE,
       label: 'Clear route (inherit from parent)',
@@ -139,5 +197,8 @@ export function setAgentRoute(
 
 /** Remove `agentType`'s route in user-global settings. */
 export function clearAgentRoute(agentType: string): { error: Error | null } {
-  return updateSettingsForSource('userSettings', computeClearRouteUpdate(agentType))
+  return updateSettingsForSource(
+    'userSettings',
+    computeClearRouteUpdate(getSettingsForSource('userSettings'), agentType),
+  )
 }

--- a/src/services/api/agentRouteSettings.ts
+++ b/src/services/api/agentRouteSettings.ts
@@ -249,9 +249,20 @@ export function clearAgentRoute(agentType: string): { error: Error | null } {
   )
 }
 
+/**
+ * Per-source guidance for a route the user cannot change from user settings.
+ * flagSettings has no file to edit (it comes from the --settings flag or SDK
+ * inline settings), so point elsewhere for that source.
+ */
+export function shadowRemediation(source: SettingSource): string {
+  return source === 'flagSettings'
+    ? 'It comes from the --settings flag or SDK inline settings, not a file you can edit here.'
+    : `Edit the ${source} settings to change this route.`
+}
+
 function shadowError(agentType: string, source: SettingSource): Error {
   return new Error(
     `${agentType} is routed by ${source} settings, which override your user settings. ` +
-      `A user-level change won't take effect; edit the ${source} settings instead.`,
+      `A user-level change won't take effect. ${shadowRemediation(source)}`,
   )
 }

--- a/src/services/api/agentRouteSettings.ts
+++ b/src/services/api/agentRouteSettings.ts
@@ -91,7 +91,7 @@ export function buildRouteOptions(
     .filter(o => o.value !== 'inherit')
     .map(o => {
       const entry = settings?.agentModels?.[o.value]
-      const isCross = Boolean(entry && entry.base_url && entry.api_key)
+      const isCross = Boolean(entry && (entry.base_url || entry.api_key))
       return {
         value: o.value,
         label: isCross ? `${o.label} (cross-provider)` : o.label,

--- a/src/services/api/agentRouteSettings.ts
+++ b/src/services/api/agentRouteSettings.ts
@@ -100,6 +100,24 @@ export function findModelKeyShadowingSource(
   return null
 }
 
+/**
+ * Every agentModels key defined ABOVE userSettings in the effective chain.
+ * The offer path (buildRouteOptions shadow flag) and the save guard
+ * (setAgentRoute via findModelKeyShadowingSource) must agree on what counts as
+ * shadowed; both derive from this same set so they cannot drift. Pure.
+ */
+export function collectShadowedModelKeys(
+  sources: SettingsWithSources['sources'],
+): Set<string> {
+  const userIdx = sources.findIndex(s => s.source === 'userSettings')
+  const keys = new Set<string>()
+  for (let i = sources.length - 1; i > userIdx; i--) {
+    const models = sources[i]!.settings.agentModels
+    if (models) for (const k of Object.keys(models)) keys.add(k)
+  }
+  return keys
+}
+
 /** Build the route descriptor for a resolved model key. Pure. */
 function describeModelKey(
   settings: SettingsJson | null,
@@ -284,14 +302,7 @@ export function getModelKeyShadowSource(modelKey: string): SettingSource | null 
 
 /** agentModels keys defined above userSettings in the effective chain. */
 export function getShadowedModelKeys(): Set<string> {
-  const { sources } = getSettingsWithSources()
-  const userIdx = sources.findIndex(s => s.source === 'userSettings')
-  const keys = new Set<string>()
-  for (let i = sources.length - 1; i > userIdx; i--) {
-    const models = sources[i]!.settings.agentModels
-    if (models) for (const k of Object.keys(models)) keys.add(k)
-  }
-  return keys
+  return collectShadowedModelKeys(getSettingsWithSources().sources)
 }
 
 /**
@@ -318,17 +329,14 @@ export function setAgentRoute(
   const shadow = getRouteShadowSource(agentType)
   if (shadow) return { error: shadowError(agentType, shadow) }
   // A higher-priority source defining agentModels[modelKey] wins on merge, so a
-  // user-level route to it would resolve to that entry, not the model the
-  // option promised. Refuse rather than silently save a misleading route. Skip
-  // when the user already owns this key in userSettings (selecting their own
-  // pre-defined entry is intentional).
-  const userSettings = getSettingsForSource('userSettings')
-  const ownsKey = Boolean(userSettings?.agentModels?.[modelKey])
-  if (!ownsKey) {
-    const modelShadow = getModelKeyShadowSource(modelKey)
-    if (modelShadow) return { error: modelKeyShadowError(modelKey, modelShadow) }
-  }
-  const next = computeSetRouteUpdate(userSettings, agentType, modelKey)
+  // user-level route to it resolves to that entry, not the model the option
+  // promised. Refuse rather than silently save a misleading route. This holds
+  // even when userSettings also defines the key: the user's entry is the one
+  // being shadowed, so the save still would not take effect. Mirrors the
+  // shadow flag buildRouteOptions shows for the same keys.
+  const modelShadow = getModelKeyShadowSource(modelKey)
+  if (modelShadow) return { error: modelKeyShadowError(modelKey, modelShadow) }
+  const next = computeSetRouteUpdate(getSettingsForSource('userSettings'), agentType, modelKey)
   return updateSettingsForSource('userSettings', next)
 }
 

--- a/src/services/api/agentRouteSettings.ts
+++ b/src/services/api/agentRouteSettings.ts
@@ -7,6 +7,7 @@ import {
   updateSettingsForSource,
   type SettingsWithSources,
 } from '../../utils/settings/settings.js'
+import { isSettingSourceEnabled } from '../../utils/settings/constants.js'
 import type { SettingSource } from '../../utils/settings/constants.js'
 import type { SettingsJson } from '../../utils/settings/types.js'
 
@@ -228,11 +229,27 @@ export function getRouteShadowSource(agentType: string): SettingSource | null {
   return findShadowingSource(getSettingsWithSources().sources, agentType)
 }
 
+/**
+ * Error for when user settings are not an enabled setting source this session
+ * (e.g. launched with `--setting-sources project`). The picker reads and writes
+ * userSettings, but the runtime resolves from the enabled chain only, so a write
+ * here would be saved to a file that is never loaded — report it instead of
+ * claiming a save that does nothing.
+ */
+function userSettingsDisabledError(): Error {
+  return new Error(
+    'User settings are disabled in this session (--setting-sources excludes them), ' +
+      'so a route saved here would never load. Enable user settings or set the route ' +
+      'in an active settings source.',
+  )
+}
+
 /** Persist a route from `agentType` to `modelKey` in user-global settings. */
 export function setAgentRoute(
   agentType: string,
   modelKey: string,
 ): { error: Error | null } {
+  if (!isSettingSourceEnabled('userSettings')) return { error: userSettingsDisabledError() }
   const shadow = getRouteShadowSource(agentType)
   if (shadow) return { error: shadowError(agentType, shadow) }
   const next = computeSetRouteUpdate(getSettingsForSource('userSettings'), agentType, modelKey)
@@ -241,6 +258,7 @@ export function setAgentRoute(
 
 /** Remove `agentType`'s route in user-global settings. */
 export function clearAgentRoute(agentType: string): { error: Error | null } {
+  if (!isSettingSourceEnabled('userSettings')) return { error: userSettingsDisabledError() }
   const shadow = getRouteShadowSource(agentType)
   if (shadow) return { error: shadowError(agentType, shadow) }
   return updateSettingsForSource(

--- a/src/services/api/agentRouteSettings.ts
+++ b/src/services/api/agentRouteSettings.ts
@@ -1,9 +1,13 @@
 import type { OptionWithDescription } from '../../components/CustomSelect/select.js'
 import { getAgentModelOptions } from '../../utils/model/agent.js'
 import {
+  getInitialSettings,
   getSettingsForSource,
+  getSettingsWithSources,
   updateSettingsForSource,
+  type SettingsWithSources,
 } from '../../utils/settings/settings.js'
+import type { SettingSource } from '../../utils/settings/constants.js'
 import type { SettingsJson } from '../../utils/settings/types.js'
 
 /** Sentinel Select value: open inline input for a custom model id. */
@@ -44,6 +48,31 @@ function findOwnRouteKey(
     if (normalizeAgentKey(key) === target) return key
   }
   return undefined
+}
+
+/**
+ * The highest-priority settings source ranked ABOVE userSettings that defines a
+ * routing key normalizing to `agentType`, or null. Such a source overrides the
+ * user file in the merged settings the runtime resolves from, so a user-level
+ * write would be silently shadowed. `sources` is the low-to-high priority list
+ * from getSettingsWithSources. Pure.
+ */
+export function findShadowingSource(
+  sources: SettingsWithSources['sources'],
+  agentType: string,
+): SettingSource | null {
+  const target = normalizeAgentKey(agentType)
+  // userSettings is the write target; anything after it in the list outranks it.
+  // When userSettings is absent (empty file), userIdx is -1 and every source
+  // that defines the key still outranks the user write we would create.
+  const userIdx = sources.findIndex(s => s.source === 'userSettings')
+  for (let i = sources.length - 1; i > userIdx; i--) {
+    const routing = sources[i]!.settings.agentRouting
+    if (routing && Object.keys(routing).some(k => normalizeAgentKey(k) === target)) {
+      return sources[i]!.source
+    }
+  }
+  return null
 }
 
 /** Build the route descriptor for a resolved model key. Pure. */
@@ -181,9 +210,22 @@ export function buildRouteOptions(
 
 // --- Thin I/O wrappers over user-global settings (not unit-tested; covered by build + manual) ---
 
-/** Read the user-settings route for `agentType`. */
+/**
+ * Read the EFFECTIVE route for `agentType` from the merged settings chain, the
+ * same view the runtime resolver uses. Reading only userSettings would hide a
+ * project/local/policy route and wrongly report the agent as inheriting.
+ */
 export function getAgentRoute(agentType: string): CurrentAgentRoute {
-  return readAgentRoute(getSettingsForSource('userSettings'), agentType)
+  return readAgentRoute(getInitialSettings(), agentType)
+}
+
+/**
+ * The settings source that overrides a user-level route for `agentType`, or
+ * null when a user write would take effect. The picker uses this to explain why
+ * an edit is read-only instead of silently saving an ignored route.
+ */
+export function getRouteShadowSource(agentType: string): SettingSource | null {
+  return findShadowingSource(getSettingsWithSources().sources, agentType)
 }
 
 /** Persist a route from `agentType` to `modelKey` in user-global settings. */
@@ -191,14 +233,25 @@ export function setAgentRoute(
   agentType: string,
   modelKey: string,
 ): { error: Error | null } {
+  const shadow = getRouteShadowSource(agentType)
+  if (shadow) return { error: shadowError(agentType, shadow) }
   const next = computeSetRouteUpdate(getSettingsForSource('userSettings'), agentType, modelKey)
   return updateSettingsForSource('userSettings', next)
 }
 
 /** Remove `agentType`'s route in user-global settings. */
 export function clearAgentRoute(agentType: string): { error: Error | null } {
+  const shadow = getRouteShadowSource(agentType)
+  if (shadow) return { error: shadowError(agentType, shadow) }
   return updateSettingsForSource(
     'userSettings',
     computeClearRouteUpdate(getSettingsForSource('userSettings'), agentType),
+  )
+}
+
+function shadowError(agentType: string, source: SettingSource): Error {
+  return new Error(
+    `${agentType} is routed by ${source} settings, which override your user settings. ` +
+      `A user-level change won't take effect; edit the ${source} settings instead.`,
   )
 }

--- a/src/services/api/agentRouteSettings.ts
+++ b/src/services/api/agentRouteSettings.ts
@@ -1,0 +1,131 @@
+import type { OptionWithDescription } from '../../components/CustomSelect/select.js'
+import { getAgentModelOptions } from '../../utils/model/agent.js'
+import {
+  getSettingsForSource,
+  updateSettingsForSource,
+} from '../../utils/settings/settings.js'
+import type { SettingsJson } from '../../utils/settings/types.js'
+
+/** Sentinel Select value: open inline input for a custom model id. */
+export const CUSTOM_MODEL_VALUE = '__custom_model__'
+/** Sentinel Select value: clear the route so the agent inherits the parent model. */
+export const CLEAR_ROUTE_VALUE = '__clear_route__'
+
+/** The route currently assigned to an agent type in user settings. */
+export type CurrentAgentRoute =
+  | { kind: 'none' }
+  | { kind: 'model-only'; routeKey: string; model: string }
+  | { kind: 'cross-provider'; routeKey: string; model: string; baseURL: string }
+  | { kind: 'dangling'; routeKey: string }
+
+/** Read the route assigned to `agentType` from a settings value. Pure. */
+export function readAgentRoute(
+  settings: SettingsJson | null,
+  agentType: string,
+): CurrentAgentRoute {
+  const routeKey = settings?.agentRouting?.[agentType]
+  if (!routeKey) return { kind: 'none' }
+  const entry = settings?.agentModels?.[routeKey]
+  if (!entry) return { kind: 'dangling', routeKey }
+  const model = entry.model?.trim() || routeKey
+  if (entry.base_url || entry.api_key) {
+    return { kind: 'cross-provider', routeKey, model, baseURL: entry.base_url ?? '' }
+  }
+  return { kind: 'model-only', routeKey, model }
+}
+
+/** The Select value representing the current route, if any. Pure. */
+export function currentRouteValue(current: CurrentAgentRoute): string | undefined {
+  return current.kind === 'none' ? undefined : current.routeKey
+}
+
+/**
+ * Next settings to point `agentType` at `modelKey`. Creates a model-only
+ * `agentModels[modelKey]` only when absent (never clobbers an existing entry,
+ * so selecting a pre-defined cross-provider key just sets routing). Pure.
+ */
+export function computeSetRouteUpdate(
+  settings: SettingsJson | null,
+  agentType: string,
+  modelKey: string,
+): SettingsJson {
+  const agentModels = { ...(settings?.agentModels ?? {}) }
+  if (!agentModels[modelKey]) {
+    agentModels[modelKey] = { model: modelKey }
+  }
+  const agentRouting = { ...(settings?.agentRouting ?? {}), [agentType]: modelKey }
+  return { agentModels, agentRouting } as unknown as SettingsJson
+}
+
+/**
+ * Next settings to clear `agentType`'s route. The explicit `undefined` is what
+ * makes updateSettingsForSource delete the key on merge. Pure.
+ */
+export function computeClearRouteUpdate(agentType: string): SettingsJson {
+  return { agentRouting: { [agentType]: undefined } } as unknown as SettingsJson
+}
+
+/** Human-readable one-line route summary for the AgentDetail view. Pure. */
+export function describeRouteLine(current: CurrentAgentRoute): string {
+  switch (current.kind) {
+    case 'none':
+      return 'Route: inherits parent model'
+    case 'model-only':
+      return `Route: ${current.model} (current provider)`
+    case 'cross-provider':
+      return `Route: ${current.model} (cross-provider)`
+    case 'dangling':
+      return `Route: ${current.routeKey} (unconfigured, inherits)`
+  }
+}
+
+/**
+ * Build the Select options for the route picker (excluding the inline custom
+ * input option, which the component appends with its own onChange). Pure.
+ */
+export function buildRouteOptions(
+  settings: SettingsJson | null,
+  current: CurrentAgentRoute,
+): OptionWithDescription<string>[] {
+  const modelOptions: OptionWithDescription<string>[] = getAgentModelOptions(settings)
+    .filter(o => o.value !== 'inherit')
+    .map(o => {
+      const entry = settings?.agentModels?.[o.value]
+      const isCross = Boolean(entry && entry.base_url && entry.api_key)
+      return {
+        value: o.value,
+        label: isCross ? `${o.label} (cross-provider)` : o.label,
+        description: o.description,
+      }
+    })
+
+  if (current.kind !== 'none') {
+    modelOptions.push({
+      value: CLEAR_ROUTE_VALUE,
+      label: 'Clear route (inherit from parent)',
+      description: "Remove this agent's model assignment",
+    })
+  }
+  return modelOptions
+}
+
+// --- Thin I/O wrappers over user-global settings (not unit-tested; covered by build + manual) ---
+
+/** Read the user-settings route for `agentType`. */
+export function getAgentRoute(agentType: string): CurrentAgentRoute {
+  return readAgentRoute(getSettingsForSource('userSettings'), agentType)
+}
+
+/** Persist a route from `agentType` to `modelKey` in user-global settings. */
+export function setAgentRoute(
+  agentType: string,
+  modelKey: string,
+): { error: Error | null } {
+  const next = computeSetRouteUpdate(getSettingsForSource('userSettings'), agentType, modelKey)
+  return updateSettingsForSource('userSettings', next)
+}
+
+/** Remove `agentType`'s route in user-global settings. */
+export function clearAgentRoute(agentType: string): { error: Error | null } {
+  return updateSettingsForSource('userSettings', computeClearRouteUpdate(agentType))
+}

--- a/src/services/api/agentRouteSettings.ts
+++ b/src/services/api/agentRouteSettings.ts
@@ -28,10 +28,16 @@ export function readAgentRoute(
   const entry = settings?.agentModels?.[routeKey]
   if (!entry) return { kind: 'dangling', routeKey }
   const model = entry.model?.trim() || routeKey
-  if (entry.base_url || entry.api_key) {
-    return { kind: 'cross-provider', routeKey, model, baseURL: entry.base_url ?? '' }
+  // Mirror the runtime resolver (toAgentRoute): cross-provider needs BOTH
+  // base_url and api_key. A partial entry is skipped at runtime and inherits,
+  // so surface it as unconfigured rather than claiming a route that won't run.
+  const baseURL = entry.base_url?.trim()
+  const apiKey = entry.api_key?.trim()
+  if (!baseURL && !apiKey) return { kind: 'model-only', routeKey, model }
+  if (baseURL && apiKey) {
+    return { kind: 'cross-provider', routeKey, model, baseURL }
   }
-  return { kind: 'model-only', routeKey, model }
+  return { kind: 'dangling', routeKey }
 }
 
 /** The Select value representing the current route, if any. Pure. */
@@ -91,10 +97,16 @@ export function buildRouteOptions(
     .filter(o => o.value !== 'inherit')
     .map(o => {
       const entry = settings?.agentModels?.[o.value]
-      const isCross = Boolean(entry && (entry.base_url || entry.api_key))
+      // Same validity rule as the runtime resolver: both creds = cross-provider,
+      // exactly one = unconfigured (skipped at runtime), neither = model-only.
+      const hasBase = Boolean(entry?.base_url?.trim())
+      const hasKey = Boolean(entry?.api_key?.trim())
+      let label = o.label
+      if (hasBase && hasKey) label = `${o.label} (cross-provider)`
+      else if (hasBase || hasKey) label = `${o.label} (unconfigured, inherits)`
       return {
         value: o.value,
-        label: isCross ? `${o.label} (cross-provider)` : o.label,
+        label,
         description: o.description,
       }
     })

--- a/src/services/api/agentRouteSettings.ts
+++ b/src/services/api/agentRouteSettings.ts
@@ -76,6 +76,30 @@ export function findShadowingSource(
   return null
 }
 
+/**
+ * The highest-priority settings source ranked ABOVE userSettings that defines
+ * `agentModels[modelKey]`, or null. A route saved here points an agent at
+ * `modelKey`, but `agentModels` merges by source priority, so a higher source's
+ * entry for the same key wins — the user's model-only entry (e.g. the
+ * synthesized `{ model: "sonnet" }` for the built-in Sonnet option) is shadowed
+ * and the agent resolves to the higher source's (often cross-provider) route
+ * instead of the current-provider model the picker promised. `agentModels` keys
+ * are exact (not normalized) to match the runtime resolver. Pure.
+ */
+export function findModelKeyShadowingSource(
+  sources: SettingsWithSources['sources'],
+  modelKey: string,
+): SettingSource | null {
+  const userIdx = sources.findIndex(s => s.source === 'userSettings')
+  for (let i = sources.length - 1; i > userIdx; i--) {
+    const models = sources[i]!.settings.agentModels
+    if (models && Object.prototype.hasOwnProperty.call(models, modelKey)) {
+      return sources[i]!.source
+    }
+  }
+  return null
+}
+
 /** Build the route descriptor for a resolved model key. Pure. */
 function describeModelKey(
   settings: SettingsJson | null,
@@ -172,11 +196,23 @@ export function describeRouteLine(current: CurrentAgentRoute): string {
 /**
  * Build the Select options for the route picker (excluding the inline custom
  * input option, which the component appends with its own onChange). Pure.
+ *
+ * opts.shadowedModelKeys: agentModels keys defined by a higher-priority source
+ * than userSettings. A user-level route to such a key resolves to the higher
+ * source's entry (see findModelKeyShadowingSource), so they are flagged here
+ * and rejected on save rather than presented as a current-provider model.
+ *
+ * opts.defaultRouteApplies: whether a `default` agentRouting entry is in effect.
+ * When it is, clearing an agent's own key does not inherit the parent model; the
+ * default route still applies. The clear label reflects that instead of
+ * promising parent inheritance.
  */
 export function buildRouteOptions(
   settings: SettingsJson | null,
   current: CurrentAgentRoute,
+  opts?: { shadowedModelKeys?: ReadonlySet<string>; defaultRouteApplies?: boolean },
 ): OptionWithDescription<string>[] {
+  const shadowed = opts?.shadowedModelKeys
   const modelOptions: OptionWithDescription<string>[] = getAgentModelOptions(settings)
     .filter(o => o.value !== 'inherit')
     .map(o => {
@@ -186,7 +222,8 @@ export function buildRouteOptions(
       const hasBase = Boolean(entry?.base_url?.trim())
       const hasKey = Boolean(entry?.api_key?.trim())
       let label = o.label
-      if (hasBase && hasKey) label = `${o.label} (cross-provider)`
+      if (shadowed?.has(o.value)) label = `${o.label} (shadowed by higher settings)`
+      else if (hasBase && hasKey) label = `${o.label} (cross-provider)`
       else if (hasBase || hasKey) label = `${o.label} (unconfigured, inherits)`
       return {
         value: o.value,
@@ -196,14 +233,20 @@ export function buildRouteOptions(
     })
 
   // Only offer "clear" when the agent has its OWN routing key. A route inherited
-  // via `default` has nothing agent-specific to remove, and clearing wouldn't
-  // make it inherit the parent (default would still apply), so the option would
-  // claim a change the runtime ignores.
+  // via `default` has nothing agent-specific to remove.
   if (current.kind !== 'none' && !current.viaDefault) {
+    // Clearing only removes the agent's own key. If a `default` route is still
+    // in effect the agent falls back to it, not the parent model, so don't
+    // promise parent inheritance the runtime won't deliver.
+    const defaultApplies = opts?.defaultRouteApplies ?? false
     modelOptions.push({
       value: CLEAR_ROUTE_VALUE,
-      label: 'Clear route (inherit from parent)',
-      description: "Remove this agent's model assignment",
+      label: defaultApplies
+        ? 'Clear route (use default route)'
+        : 'Clear route (inherit from parent)',
+      description: defaultApplies
+        ? "Remove this agent's own route; the default route still applies"
+        : "Remove this agent's model assignment",
     })
   }
   return modelOptions
@@ -230,6 +273,28 @@ export function getRouteShadowSource(agentType: string): SettingSource | null {
 }
 
 /**
+ * The settings source whose `agentModels[modelKey]` would shadow a user-level
+ * route to `modelKey`, or null. The picker uses this to refuse saving (and to
+ * flag) a route that would resolve to a higher source's entry rather than the
+ * current-provider model the option promised.
+ */
+export function getModelKeyShadowSource(modelKey: string): SettingSource | null {
+  return findModelKeyShadowingSource(getSettingsWithSources().sources, modelKey)
+}
+
+/** agentModels keys defined above userSettings in the effective chain. */
+export function getShadowedModelKeys(): Set<string> {
+  const { sources } = getSettingsWithSources()
+  const userIdx = sources.findIndex(s => s.source === 'userSettings')
+  const keys = new Set<string>()
+  for (let i = sources.length - 1; i > userIdx; i--) {
+    const models = sources[i]!.settings.agentModels
+    if (models) for (const k of Object.keys(models)) keys.add(k)
+  }
+  return keys
+}
+
+/**
  * Error for when user settings are not an enabled setting source this session
  * (e.g. launched with `--setting-sources project`). The picker reads and writes
  * userSettings, but the runtime resolves from the enabled chain only, so a write
@@ -252,7 +317,18 @@ export function setAgentRoute(
   if (!isSettingSourceEnabled('userSettings')) return { error: userSettingsDisabledError() }
   const shadow = getRouteShadowSource(agentType)
   if (shadow) return { error: shadowError(agentType, shadow) }
-  const next = computeSetRouteUpdate(getSettingsForSource('userSettings'), agentType, modelKey)
+  // A higher-priority source defining agentModels[modelKey] wins on merge, so a
+  // user-level route to it would resolve to that entry, not the model the
+  // option promised. Refuse rather than silently save a misleading route. Skip
+  // when the user already owns this key in userSettings (selecting their own
+  // pre-defined entry is intentional).
+  const userSettings = getSettingsForSource('userSettings')
+  const ownsKey = Boolean(userSettings?.agentModels?.[modelKey])
+  if (!ownsKey) {
+    const modelShadow = getModelKeyShadowSource(modelKey)
+    if (modelShadow) return { error: modelKeyShadowError(modelKey, modelShadow) }
+  }
+  const next = computeSetRouteUpdate(userSettings, agentType, modelKey)
   return updateSettingsForSource('userSettings', next)
 }
 
@@ -282,5 +358,13 @@ function shadowError(agentType: string, source: SettingSource): Error {
   return new Error(
     `${agentType} is routed by ${source} settings, which override your user settings. ` +
       `A user-level change won't take effect. ${shadowRemediation(source)}`,
+  )
+}
+
+function modelKeyShadowError(modelKey: string, source: SettingSource): Error {
+  return new Error(
+    `"${modelKey}" is defined in ${source} settings, which override your user settings. ` +
+      `A user-level route to it would resolve to that entry, not a current-provider model. ` +
+      `${shadowRemediation(source)}`,
   )
 }

--- a/src/services/api/agentRouting.test.ts
+++ b/src/services/api/agentRouting.test.ts
@@ -5,11 +5,13 @@ import {
   resolveAgentModelProvider,
   resolveAgentProvider,
   resolveAgentRunModelRouting,
+  resolveOutOfProcessTeammateModelOnly,
   resolveOutOfProcessTeammateProvider,
   resolveOutOfProcessTeammateProviderFromCliArgs,
   shouldEnforceModelAllowlist,
 } from './agentRouting.js'
 import { getAgentModel } from '../../utils/model/agent.js'
+import * as agentModelModule from '../../utils/model/agent.js'
 import type { SettingsJson } from '../../utils/settings/types.js'
 
 const baseSettings = {
@@ -440,6 +442,39 @@ describe('resolveAgentRunModelRouting', () => {
     })
     expect(result).toEqual({ mainLoopModel: 'gpt-5-mini' })
   })
+
+  test('permissionMode is threaded into alias resolution, not dropped', () => {
+    // The plan-mode-sensitive paths in getAgentModel (inherit, opusplan, haiku)
+    // all key off global model state, so a value comparison cannot prove the mode
+    // reached getAgentModel. Spy on the resolver dependency and assert the exact
+    // permissionMode is forwarded as the 4th arg, locking the contract threaded
+    // through AgentTool/runAgent/resolveModelOnlyModel.
+    const spy = spyOn(agentModelModule, 'getAgentModel').mockReturnValue(
+      'effective-from-getAgentModel',
+    )
+    try {
+      const settings = {
+        agentModels: { sonnet: { model: 'sonnet' } },
+        agentRouting: { verification: 'sonnet' },
+      } as unknown as SettingsJson
+      const result = resolveAgentRunModelRouting({
+        resolvedAgentModel: 'should-not-be-used',
+        parentModel: 'claude-sonnet-4-5',
+        subagentType: 'verification',
+        settings,
+        permissionMode: 'plan',
+      })
+      expect(result.mainLoopModel).toBe('effective-from-getAgentModel')
+      expect(spy).toHaveBeenCalledWith(
+        'sonnet',
+        'claude-sonnet-4-5',
+        undefined,
+        'plan',
+      )
+    } finally {
+      spy.mockRestore()
+    }
+  })
 })
 
 describe('resolveOutOfProcessTeammateProvider', () => {
@@ -507,6 +542,76 @@ describe('resolveOutOfProcessTeammateProvider', () => {
     })
 
     expect(result?.model).toBe('deepseek-chat')
+  })
+})
+
+describe('resolveOutOfProcessTeammateModelOnly', () => {
+  const modelOnlySettings = {
+    agentModels: {
+      'gpt-5-mini': { model: 'gpt-5-mini' },
+      'deepseek-chat': { base_url: 'https://api.deepseek.com/v1', api_key: 'sk-ds' },
+    },
+    agentRouting: {
+      verification: 'gpt-5-mini',
+      'frontend-dev': 'deepseek-chat',
+    },
+  } as unknown as SettingsJson
+
+  test('returns the model-only route model for a routed teammate type', () => {
+    expect(
+      resolveOutOfProcessTeammateModelOnly({
+        agentType: 'verification',
+        parentModel: 'claude-sonnet-4-5',
+        settings: modelOnlySettings,
+      }),
+    ).toBe('gpt-5-mini')
+  })
+
+  test('returns undefined when the route is cross-provider (handled by the provider resolver)', () => {
+    expect(
+      resolveOutOfProcessTeammateModelOnly({
+        agentType: 'frontend-dev',
+        parentModel: 'claude-sonnet-4-5',
+        settings: modelOnlySettings,
+      }),
+    ).toBeUndefined()
+  })
+
+  test('returns undefined when there is no route', () => {
+    expect(
+      resolveOutOfProcessTeammateModelOnly({
+        agentType: 'unrouted-type',
+        parentModel: 'claude-sonnet-4-5',
+        settings: modelOnlySettings,
+      }),
+    ).toBeUndefined()
+  })
+
+  test('built-in alias route resolves through getAgentModel, not literally', () => {
+    const aliasSettings = {
+      agentModels: { sonnet: { model: 'sonnet' } },
+      agentRouting: { verification: 'sonnet' },
+    } as unknown as SettingsJson
+    const result = resolveOutOfProcessTeammateModelOnly({
+      agentType: 'verification',
+      parentModel: 'claude-sonnet-4-5',
+      settings: aliasSettings,
+    })
+    expect(result).toBe(
+      getAgentModel('sonnet', 'claude-sonnet-4-5', undefined, undefined),
+    )
+    expect(result).not.toBe('sonnet')
+  })
+
+  test('an explicit configured cli model takes precedence and is not treated as model-only when cross-provider', () => {
+    expect(
+      resolveOutOfProcessTeammateModelOnly({
+        cliModel: 'deepseek-chat',
+        agentType: 'verification',
+        parentModel: 'claude-sonnet-4-5',
+        settings: modelOnlySettings,
+      }),
+    ).toBeUndefined()
   })
 })
 

--- a/src/services/api/agentRouting.test.ts
+++ b/src/services/api/agentRouting.test.ts
@@ -742,3 +742,50 @@ describe('shouldEnforceModelAllowlist', () => {
     expect(shouldEnforceModelAllowlist('m', 'm', false)).toBe(false)
   })
 })
+
+describe('resolveAgentRunModelRouting: in-process teammate route identity', () => {
+  // In-process teammates run runAgent() with a synthetic agentDefinition whose
+  // agentType is the teammate's display name. Routing must use the original
+  // subagent_type instead, or the configured cross-provider route is missed and
+  // the teammate runs on the parent provider.
+  const settings = {
+    agentModels: {
+      'deepseek-chat': {
+        base_url: 'https://api.deepseek.com/v1',
+        api_key: 'sk-ds',
+      },
+    },
+    agentRouting: {
+      verification: 'deepseek-chat',
+    },
+  } as unknown as SettingsJson
+
+  test('teammate display name misses the configured route', () => {
+    const result = resolveAgentRunModelRouting({
+      resolvedAgentModel: 'parent-model',
+      parentModel: 'parent-model',
+      agentName: 'worker-a',
+      subagentType: 'worker-a',
+      settings,
+    })
+    expect(result).toEqual({ mainLoopModel: 'parent-model' })
+  })
+
+  test('original subagent_type resolves the cross-provider override', () => {
+    const result = resolveAgentRunModelRouting({
+      resolvedAgentModel: 'parent-model',
+      parentModel: 'parent-model',
+      agentName: 'worker-a',
+      subagentType: 'verification',
+      settings,
+    })
+    expect(result).toEqual({
+      mainLoopModel: 'deepseek-chat',
+      providerOverride: {
+        model: 'deepseek-chat',
+        baseURL: 'https://api.deepseek.com/v1',
+        apiKey: 'sk-ds',
+      },
+    })
+  })
+})

--- a/src/services/api/agentRouting.test.ts
+++ b/src/services/api/agentRouting.test.ts
@@ -9,6 +9,7 @@ import {
   resolveOutOfProcessTeammateProviderFromCliArgs,
   shouldEnforceModelAllowlist,
 } from './agentRouting.js'
+import { getAgentModel } from '../../utils/model/agent.js'
 import type { SettingsJson } from '../../utils/settings/types.js'
 
 const baseSettings = {
@@ -225,6 +226,7 @@ describe('model-only routes', () => {
   test('resolveAgentRunModelRouting: model-only sets mainLoopModel, no providerOverride', () => {
     const result = resolveAgentRunModelRouting({
       resolvedAgentModel: 'parent-model',
+      parentModel: 'parent-model',
       subagentType: 'verification',
       settings: modelOnlySettings,
     })
@@ -235,6 +237,7 @@ describe('model-only routes', () => {
   test('resolveAgentRunModelRouting: no route falls back to resolvedAgentModel', () => {
     const result = resolveAgentRunModelRouting({
       resolvedAgentModel: 'parent-model',
+      parentModel: 'parent-model',
       subagentType: 'unconfigured',
       settings: modelOnlySettings,
     })
@@ -302,6 +305,7 @@ describe('resolveAgentRunModelRouting', () => {
   test('explicit configured model wins over agentRouting', () => {
     const result = resolveAgentRunModelRouting({
       resolvedAgentModel: 'parent-model',
+      parentModel: 'parent-model',
       toolSpecifiedModel: 'deepseek-chat',
       agentName: 'frontend-dev',
       subagentType: 'Explore',
@@ -321,6 +325,7 @@ describe('resolveAgentRunModelRouting', () => {
   test('explicit non-configured model keeps resolved model behavior', () => {
     const result = resolveAgentRunModelRouting({
       resolvedAgentModel: 'haiku-model',
+      parentModel: 'parent-model',
       toolSpecifiedModel: 'haiku',
       agentName: 'frontend-dev',
       subagentType: 'Explore',
@@ -333,6 +338,7 @@ describe('resolveAgentRunModelRouting', () => {
   test('explicit inherit keeps resolved parent model despite default routing', () => {
     const result = resolveAgentRunModelRouting({
       resolvedAgentModel: 'parent-runtime-model',
+      parentModel: 'parent-model',
       toolSpecifiedModel: ' InHerit ',
       subagentType: 'unknown-type',
       settings: baseSettings,
@@ -344,6 +350,7 @@ describe('resolveAgentRunModelRouting', () => {
   test('agent definition model key is used after routing misses', () => {
     const result = resolveAgentRunModelRouting({
       resolvedAgentModel: 'default-model',
+      parentModel: 'parent-model',
       subagentType: 'unknown-type',
       agentDefinitionModel: 'deepseek-chat',
       settings: {
@@ -359,6 +366,7 @@ describe('resolveAgentRunModelRouting', () => {
   test('falls back to resolved model when no provider override matches', () => {
     const result = resolveAgentRunModelRouting({
       resolvedAgentModel: 'default-model',
+      parentModel: 'parent-model',
       toolSpecifiedModel: 'haiku',
       subagentType: 'unknown-type',
       agentDefinitionModel: 'sonnet',
@@ -374,6 +382,7 @@ describe('resolveAgentRunModelRouting', () => {
   test('falls back to resolved model when routed provider has a blank API key', () => {
     const result = resolveAgentRunModelRouting({
       resolvedAgentModel: 'parent-runtime-model',
+      parentModel: 'parent-model',
       subagentType: 'Explore',
       settings: {
         agentModels: {
@@ -391,6 +400,45 @@ describe('resolveAgentRunModelRouting', () => {
     expect(errorSpy).toHaveBeenCalledWith(
       '[agentRouting] Warning: agentModels entry "zai" has only one of base_url/api_key; both are required for cross-provider routing. Skipping this route.',
     )
+  })
+
+  test('model-only built-in alias route resolves through getAgentModel, not literally', () => {
+    // A picker route like { sonnet: { model: 'sonnet' } } must not send the
+    // literal alias as mainLoopModel — it has to go through the same
+    // provider-aware path as the agent model selector, so e.g. on a non-Claude
+    // provider it inherits the parent instead of 404ing. We assert parity with
+    // getAgentModel rather than a fixed string so the test holds across the
+    // provider env the suite happens to run under.
+    const settings = {
+      agentModels: { sonnet: { model: 'sonnet' } },
+      agentRouting: { verification: 'sonnet' },
+    } as unknown as SettingsJson
+    const result = resolveAgentRunModelRouting({
+      resolvedAgentModel: 'should-not-be-used',
+      parentModel: 'claude-sonnet-4-5',
+      subagentType: 'verification',
+      settings,
+    })
+    expect('providerOverride' in result).toBe(false)
+    expect(result.mainLoopModel).toBe(
+      getAgentModel('sonnet', 'claude-sonnet-4-5', undefined, undefined),
+    )
+    // And it is NOT the bare alias that the old code would have sent.
+    expect(result.mainLoopModel).not.toBe('sonnet')
+  })
+
+  test('model-only real model id passes through unchanged', () => {
+    const settings = {
+      agentModels: { 'gpt-5-mini': { model: 'gpt-5-mini' } },
+      agentRouting: { verification: 'gpt-5-mini' },
+    } as unknown as SettingsJson
+    const result = resolveAgentRunModelRouting({
+      resolvedAgentModel: 'parent-model',
+      parentModel: 'parent-model',
+      subagentType: 'verification',
+      settings,
+    })
+    expect(result).toEqual({ mainLoopModel: 'gpt-5-mini' })
   })
 })
 

--- a/src/services/api/agentRouting.ts
+++ b/src/services/api/agentRouting.ts
@@ -263,6 +263,49 @@ export function resolveOutOfProcessTeammateProvider({
   return route && isProviderOverride(route) ? route : null
 }
 
+/**
+ * Resolve the model a pane/window teammate should run when its configured route
+ * is model-only (no cross-provider override). The provider twin above filters to
+ * ProviderOverride, so model-only routes the menu writes (e.g. agentRouting set
+ * to a plain agentModels key) are dropped and the teammate inherits the parent.
+ * This returns that route's provider-aware model so the spawn path can apply it.
+ * Mirrors resolveAgentRunModelRouting's lookup order (tool model, then agent
+ * name/type, then agent-definition model). Returns undefined when there is no
+ * model-only route, so the caller keeps the inherit-parent default.
+ */
+export function resolveOutOfProcessTeammateModelOnly({
+  cliModel,
+  agentName,
+  agentType,
+  agentDefinitionModel,
+  parentModel,
+  permissionMode,
+  settings,
+}: {
+  cliModel?: string
+  agentName?: string
+  agentType?: string
+  agentDefinitionModel?: string
+  parentModel: string
+  permissionMode?: PermissionMode
+  settings: SettingsJson | null
+}): string | undefined {
+  const requestedModel = cliModel?.trim()
+  if (requestedModel) {
+    const route = resolveAgentModelProvider(requestedModel, settings)
+    return route && !isProviderOverride(route)
+      ? resolveModelOnlyModel(route.model, parentModel, permissionMode)
+      : undefined
+  }
+
+  const route =
+    resolveAgentProvider(agentName, agentType, settings) ??
+    resolveAgentModelProvider(agentDefinitionModel, settings)
+  return route && !isProviderOverride(route)
+    ? resolveModelOnlyModel(route.model, parentModel, permissionMode)
+    : undefined
+}
+
 export function resolveOutOfProcessTeammateProviderFromCliArgs(
   args: readonly string[],
   settings: SettingsJson | null,

--- a/src/services/api/agentRouting.ts
+++ b/src/services/api/agentRouting.ts
@@ -1,4 +1,7 @@
 import type { SettingsJson } from '../../utils/settings/types.js'
+import type { PermissionMode } from '../../utils/permissions/PermissionMode.js'
+import { getAgentModel } from '../../utils/model/agent.js'
+import { isModelAlias } from '../../utils/model/aliases.js'
 
 /**
  * Provider override resolved from agent routing config.
@@ -149,20 +152,43 @@ export function resolveAgentModelProvider(
   return toAgentRoute(trimmedModelName, settings.agentModels[trimmedModelName])
 }
 
+/**
+ * Resolve a model-only route's model to what should actually run. A bare
+ * built-in alias ("sonnet"/"haiku"/"opus"/"inherit") is sent through the same
+ * provider-aware path as the agent model selector (getAgentModel), so on
+ * non-Claude-native providers it inherits the parent model instead of being
+ * sent literally and failing with a provider "model not found". A real model id
+ * (a configured agentModels key for the active provider) passes through as-is.
+ */
+function resolveModelOnlyModel(
+  model: string,
+  parentModel: string,
+  permissionMode?: PermissionMode,
+): string {
+  if (model === 'inherit' || isModelAlias(model)) {
+    return getAgentModel(model, parentModel, undefined, permissionMode)
+  }
+  return model
+}
+
 export function resolveAgentRunModelRouting({
   resolvedAgentModel,
+  parentModel,
   toolSpecifiedModel,
   agentName,
   subagentType,
   agentDefinitionModel,
   settings,
+  permissionMode,
 }: {
   resolvedAgentModel: string
+  parentModel: string
   toolSpecifiedModel?: string
   agentName?: string
   subagentType?: string
   agentDefinitionModel?: string
   settings: SettingsJson | null
+  permissionMode?: PermissionMode
 }): AgentRunModelRouting {
   const toolRequestedModel = toolSpecifiedModel?.trim()
   if (toolRequestedModel) {
@@ -174,7 +200,9 @@ export function resolveAgentRunModelRouting({
     if (isProviderOverride(route)) {
       return { mainLoopModel: route.model, providerOverride: route }
     }
-    return { mainLoopModel: route.model }
+    return {
+      mainLoopModel: resolveModelOnlyModel(route.model, parentModel, permissionMode),
+    }
   }
 
   const route =
@@ -184,7 +212,9 @@ export function resolveAgentRunModelRouting({
   if (isProviderOverride(route)) {
     return { mainLoopModel: route.model, providerOverride: route }
   }
-  return { mainLoopModel: route.model }
+  return {
+    mainLoopModel: resolveModelOnlyModel(route.model, parentModel, permissionMode),
+  }
 }
 
 /**

--- a/src/tools/AgentTool/AgentTool.teammateModel.test.ts
+++ b/src/tools/AgentTool/AgentTool.teammateModel.test.ts
@@ -288,6 +288,34 @@ test('passes routed agentModels keys to teammate spawns by subagent type', async
   expect(getSpawnConfig(spawnTeammate).modelWasToolSpecified).toBe(false)
 })
 
+test('applies a model-only route to a teammate spawn without a cross-provider override', async () => {
+  // Regression: the model-only teammate fix is otherwise only covered at the
+  // resolveOutOfProcessTeammateModelOnly() helper level. If AgentTool stops
+  // passing routedTeammateModelOnly into spawnTeammate(), pane/window teammates
+  // silently fall back to inheriting the parent model. A model-only route
+  // resolves to the model VALUE (gpt-5-mini), not the agentModels key (mini),
+  // which is how this differs from the cross-provider key-passing path above.
+  settingsForTest = {
+    agentModels: {
+      mini: { model: 'gpt-5-mini' },
+    },
+    agentRouting: {
+      verification: 'mini',
+    },
+  } as unknown as SettingsJson
+  allowedModelsForTest = new Set(['gpt-5-mini'])
+  const { AgentTool, spawnTeammate } = await importAgentToolWithSpawnMock()
+
+  await callTeammateAgentTool(
+    AgentTool,
+    { subagent_type: 'verification' },
+    { activeAgents: [createAgentDefinition('verification')] },
+  )
+
+  expect(getSpawnConfig(spawnTeammate).model).toBe('gpt-5-mini')
+  expect(getSpawnConfig(spawnTeammate).modelWasToolSpecified).toBe(false)
+})
+
 test('uses default agentRouting only when no explicit teammate model is provided', async () => {
   settingsForTest = {
     agentModels: {

--- a/src/tools/AgentTool/AgentTool.tsx
+++ b/src/tools/AgentTool/AgentTool.tsx
@@ -502,11 +502,13 @@ export const AgentTool = buildTool({
     const resolvedAgentModel = getAgentModel(selectedAgent.model, toolUseContext.options.mainLoopModel, isForkPath ? undefined : model, permissionMode);
     const { mainLoopModel: effectiveAgentModel } = resolveAgentRunModelRouting({
       resolvedAgentModel,
+      parentModel: toolUseContext.options.mainLoopModel,
       toolSpecifiedModel: isForkPath ? undefined : model,
       agentName: name,
       subagentType: selectedAgent.agentType,
       agentDefinitionModel: selectedAgent.model,
       settings: getInitialSettings(),
+      permissionMode,
     });
     logEvent('tengu_agent_tool_selected', {
       agent_type: selectedAgent.agentType as AnalyticsMetadata_I_VERIFIED_THIS_IS_NOT_CODE_OR_FILEPATHS,

--- a/src/tools/AgentTool/AgentTool.tsx
+++ b/src/tools/AgentTool/AgentTool.tsx
@@ -11,7 +11,7 @@ import { startAgentSummarization } from '../../services/AgentSummary/agentSummar
 import { getFeatureValue_CACHED_MAY_BE_STALE } from '../../services/analytics/growthbook.js';
 import { type AnalyticsMetadata_I_VERIFIED_THIS_IS_NOT_CODE_OR_FILEPATHS, logEvent } from '../../services/analytics/index.js';
 import { clearDumpState } from '../../services/api/dumpPrompts.js';
-import { resolveAgentRunModelRouting, resolveOutOfProcessTeammateProvider } from '../../services/api/agentRouting.js';
+import { resolveAgentRunModelRouting, resolveOutOfProcessTeammateProvider, resolveOutOfProcessTeammateModelOnly } from '../../services/api/agentRouting.js';
 import { completeAgentTask as completeAsyncAgent, createActivityDescriptionResolver, createProgressTracker, enqueueAgentNotification, failAgentTask as failAsyncAgent, getProgressUpdate, getTokenCountFromTracker, isLocalAgentTask, killAsyncAgent, registerAgentForeground, registerAsyncAgent, unregisterAgentForeground, updateAgentProgress as updateAsyncAgentProgress, updateProgressFromMessage } from '../../tasks/LocalAgentTask/LocalAgentTask.js';
 import { assembleToolPool } from '../../tools.js';
 import { asAgentId } from '../../types/ids.js';
@@ -335,6 +335,28 @@ export const AgentTool = buildTool({
       if (routedTeammateProvider && !isModelAllowed(routedTeammateProvider.model)) {
         throw new Error(`Model '${routedTeammateProvider.model}' is not available. Your organization restricts model selection.`);
       }
+      // A model-only agentRouting route (no cross-provider creds) is dropped by the
+      // provider resolver above, so resolve it separately and apply it on the next
+      // spawn. The child inherits the parent provider env, so passing the model is
+      // enough. Only consulted when there is no cross-provider override.
+      const routedTeammateModelOnly = routedTeammateProvider
+        ? undefined
+        : resolveOutOfProcessTeammateModelOnly({
+            cliModel: model,
+            agentName: name,
+            agentType: subagent_type,
+            agentDefinitionModel: agentDef?.model,
+            parentModel: toolUseContext.options.mainLoopModel,
+            permissionMode,
+            settings: getInitialSettings()
+          });
+      if (
+        routedTeammateModelOnly &&
+        routedTeammateModelOnly !== toolUseContext.options.mainLoopModel &&
+        !isModelAllowed(routedTeammateModelOnly)
+      ) {
+        throw new Error(`Model '${routedTeammateModelOnly}' is not available. Your organization restricts model selection.`);
+      }
       const result = await spawnTeammate({
         name,
         prompt,
@@ -342,7 +364,7 @@ export const AgentTool = buildTool({
         team_name: teamName,
         use_splitpane: true,
         plan_mode_required: spawnMode === 'plan',
-        model: routedTeammateProvider?.model ?? resolvedTeammateModel,
+        model: routedTeammateProvider?.model ?? routedTeammateModelOnly ?? resolvedTeammateModel,
         modelWasToolSpecified: model !== undefined,
         agent_type: subagent_type,
         invokingRequestId: assistantMessage?.requestId

--- a/src/tools/AgentTool/runAgent.ts
+++ b/src/tools/AgentTool/runAgent.ts
@@ -265,6 +265,7 @@ export async function* runAgent({
   transcriptSubdir,
   onQueryProgress,
   agentName,
+  routingSubagentType,
 }: {
   agentDefinition: AgentDefinition
   promptMessages: Message[]
@@ -326,6 +327,11 @@ export async function* runAgent({
   onQueryProgress?: () => void
   /** Agent name (team member name) for routing resolution */
   agentName?: string
+  /** Routing key for per-agent provider resolution. In-process teammates build a
+   *  synthetic agentDefinition whose agentType is the teammate's display name,
+   *  which drops the original subagent_type that agentRouting is keyed on. Pass
+   *  the original subagent_type here so the configured route still resolves. */
+  routingSubagentType?: string
 }): AsyncGenerator<Message, void> {
   // Track subagent usage for feature discovery
 
@@ -353,7 +359,7 @@ export async function* runAgent({
       parentModel: toolUseContext.options.mainLoopModel,
       toolSpecifiedModel: model,
       agentName,
-      subagentType: agentDefinition.agentType,
+      subagentType: routingSubagentType ?? agentDefinition.agentType,
       agentDefinitionModel: agentDefinition.model,
       settings,
       permissionMode,

--- a/src/tools/AgentTool/runAgent.ts
+++ b/src/tools/AgentTool/runAgent.ts
@@ -350,11 +350,13 @@ export async function* runAgent({
   const { mainLoopModel: effectiveModel, providerOverride } =
     resolveAgentRunModelRouting({
       resolvedAgentModel,
+      parentModel: toolUseContext.options.mainLoopModel,
       toolSpecifiedModel: model,
       agentName,
       subagentType: agentDefinition.agentType,
       agentDefinitionModel: agentDefinition.model,
       settings,
+      permissionMode,
     })
 
   if (

--- a/src/tools/shared/spawnMultiAgent.ts
+++ b/src/tools/shared/spawnMultiAgent.ts
@@ -997,6 +997,7 @@ async function handleSpawnInProcess(
       description: input.description,
       model,
       modelWasToolSpecified,
+      subagentType: agent_type,
       agentDefinition,
       teammateContext: result.teammateContext,
       // Strip messages: the teammate never reads toolUseContext.messages

--- a/src/utils/swarm/inProcessRunner.ts
+++ b/src/utils/swarm/inProcessRunner.ts
@@ -491,6 +491,10 @@ export type InProcessRunnerConfig = {
   model?: string
   /** True when model came from an explicit Agent tool model argument. */
   modelWasToolSpecified?: boolean
+  /** Original subagent_type for provider-routing resolution. The synthetic agent
+   *  definition overwrites agentType with the teammate name, so the route key
+   *  must be carried separately for runAgent to resolve the configured route. */
+  subagentType?: string
   /** Optional system prompt override for this teammate */
   systemPrompt?: string
   /** How to apply the system prompt: 'replace' or 'append' to default */
@@ -900,6 +904,7 @@ export async function runInProcessTeammate(
     abortController,
     model,
     modelWasToolSpecified,
+    subagentType,
     systemPrompt,
     systemPromptMode,
     allowedTools,
@@ -1218,6 +1223,7 @@ export async function runInProcessTeammate(
               ? (model as ModelAlias | undefined)
               : undefined,
             agentName: identity.agentName,
+            routingSubagentType: subagentType,
             preserveToolUseResults: true,
             availableTools: toolUseContext.options.tools,
             allowedTools,


### PR DESCRIPTION
## What and why

Per-agent model routing already works through settings (`agentModels` + `agentRouting`), but the only way to set it was hand-editing `~/.openclaude.json`, and the built-in agents' route keys (`verification`, `Explore`, `Plan`) were undiscoverable. This adds a way to do it from the `/agents` menu.

Open any agent in `/agents`, press `m`, and pick a model. You can choose a model on your current provider (typing a custom id for OpenAI-compatible providers), point at an already-defined cross-provider entry, or clear the route to remove the agent's own assignment (it then falls back to the `default` route if one is configured, otherwise inherits the main-loop model). It writes to user-global settings and takes effect on the next spawn of that agent type. Built-in agents are routable the same way, since routing is keyed by agent type.

## Impact

- New: a model-route picker in the `/agents` detail view (press `m`).
- Writes `agentModels` / `agentRouting` under user settings.
- Resolution path changed (review note): model-only routes naming a built-in alias (`sonnet`/`opus`/`haiku`/`inherit`) now resolve through `getAgentModel` with the active permission mode, so on non-Claude-native providers they inherit the parent model instead of sending a literal alias that 404s. Real model ids still pass through unchanged. The same model-only resolution now also applies to pane/window teammate spawns, which previously honored only cross-provider routes and otherwise inherited the parent.
- Writes are guarded when user settings are not an enabled setting source (e.g. launched with `--setting-sources` excluding them): the picker reports an error instead of saving a route to a file the runtime would never load.

## Design notes

The settings-shaping logic lives in a pure module (`agentRouteSettings.ts`) with thin I/O wrappers, unit-tested with plain objects. The selector is a small standalone component. The route resolver (`agentRouting.ts`) was extended so model-only alias routes go through `getAgentModel` and receive `permissionMode`, threaded from `AgentTool`/`runAgent`; the cross-provider override path is unchanged. The touch to the (React-Compiler-output) `AgentDetail` is minimal and does not alter existing memo slots. Creating new cross-provider credentials from the TUI is intentionally out of scope; those stay JSON-managed.

## Checks

- `bun test src/services/api/agentRouting.test.ts` — 54 pass
- `bun test src/services/api/agentRouteSettings.test.ts src/services/api/agentRouting.test.ts src/utils/settings/` — pass
- `bun test src/tools/AgentTool/` — 46 pass
- `bun run typecheck` — clean
- `bun run build && bun run smoke` — pass (`0.18.0`)
- Full `bun test` — only pre-existing sandbox-only failures (3 `/export`, 1 `/lsp recommend`, 1 `usage` child-process error) that pass on CI; unrelated to this change.

## Provider path

The model-only resolution that this now routes through `getAgentModel` is provider-aware: built-in aliases inherit the parent on non-Claude-native providers, and OpenAI-compatible custom model ids pass through as-is. Cross-provider routes (full `agentModels` entries with `base_url`+`api_key`) are unchanged and still apply across providers.

## UI

This adds terminal UI. From `/agents`, opening an agent shows a `Route:` line and `(press "m" to change)`; pressing `m` opens a select with the model options plus a custom-id input and a clear option. Happy to add an asciinema/screenshot if useful.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a keyboard-driven per-agent routing view in agent details (toggle with **m**) showing current route context and enabling save/clear/custom selection with shadowing-aware read-only behavior.
  * Improved model-only routing to resolve aliases with provider-aware logic, and ensured routing resolution honors `permissionMode` during agent runs and teammate spawning.

* **Bug Fixes**
  * Prevented **Esc** from canceling/backing out while the route picker is open, both in the embedded view and dialog flow.

* **Tests**
  * Added/expanded Bun/React and API tests covering routing selection, shadowing rules, save/clear error handling, Esc behavior regressions, and model-only teammate routing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

