### PR TITLE
feat: add fastCRW provider

### DIFF
--- a/src/__tests__/providerCounts.test.ts
+++ b/src/__tests__/providerCounts.test.ts
@@ -14,6 +14,7 @@ describe('Provider result counts', () => {
     'tavily.ts',
     'exa.ts',
     'firecrawl.ts',
+    'crw.ts',
     'mojeek.ts',
     'you.ts',
     'jina.ts',

--- a/src/tools/WebSearchTool/README_SEARCH_PROVIDERS.md
+++ b/src/tools/WebSearchTool/README_SEARCH_PROVIDERS.md
@@ -13,6 +13,7 @@ OpenClaude supports multiple search backends through a provider adapter system.
 | Brave (adapter) | `BRAVE_API_KEY` | `X-Subscription-Token` | GET |
 | SerpAPI | `WEB_PROVIDER=serpapi` | `Authorization: Bearer` | GET |
 | Firecrawl | `FIRECRAWL_API_KEY` | Internal | SDK |
+| fastCRW | `CRW_API_KEY` / `CRW_API_URL` | `Authorization: Bearer` | POST |
 | Tavily | `TAVILY_API_KEY` | `Authorization: Bearer` | POST |
 | Exa | `EXA_API_KEY` | `x-api-key` | POST |
 | You.com | `YOU_API_KEY` | `X-API-Key` | GET |
@@ -54,10 +55,11 @@ export WEB_SEARCH_API=https://search.example.com/search
 | `brave` | Brave only — throws on failure |
 | `custom` | Custom API only — throws on failure. **Not in the auto chain** — must be explicitly selected |
 | `firecrawl` | Firecrawl only — throws on failure |
+| `crw` | fastCRW only — throws on failure |
 | `ddg` | DuckDuckGo only — throws on failure |
 | `native` | Anthropic native / Codex only |
 
-**Auto mode priority:** firecrawl → tavily → exa → you → jina → brave → bing → mojeek → linkup → ddg
+**Auto mode priority:** firecrawl → crw → tavily → exa → you → jina → brave → bing → mojeek → linkup → ddg
 
 > **Note:** The `custom` provider is excluded from the `auto` chain. It is only used when `WEB_SEARCH_PROVIDER=custom` is explicitly set. This prevents the generic outbound provider from silently becoming the default backend.
 

--- a/src/tools/WebSearchTool/providers/crw.test.ts
+++ b/src/tools/WebSearchTool/providers/crw.test.ts
@@ -1,0 +1,59 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import {
+  acquireSharedMutationLock,
+  releaseSharedMutationLock,
+} from '../../../test/sharedMutationLock.js'
+
+import { crwProvider } from './crw.ts'
+
+const originalEnv = {
+  CRW_API_KEY: process.env.CRW_API_KEY,
+  CRW_API_URL: process.env.CRW_API_URL,
+}
+
+function restoreEnv(key: string, value: string | undefined): void {
+  if (value === undefined) {
+    delete process.env[key]
+  } else {
+    process.env[key] = value
+  }
+}
+
+beforeEach(async () => {
+  await acquireSharedMutationLock('WebSearchTool/providers/crw.test.ts')
+})
+
+afterEach(() => {
+  try {
+    restoreEnv('CRW_API_KEY', originalEnv.CRW_API_KEY)
+    restoreEnv('CRW_API_URL', originalEnv.CRW_API_URL)
+  } finally {
+    releaseSharedMutationLock()
+  }
+})
+
+describe('crwProvider isConfigured', () => {
+  test('true when CRW_API_KEY is set only', () => {
+    process.env.CRW_API_KEY = 'crw-test-key'
+    delete process.env.CRW_API_URL
+    expect(crwProvider.isConfigured()).toBe(true)
+  })
+
+  test('true when CRW_API_URL is set only', () => {
+    delete process.env.CRW_API_KEY
+    process.env.CRW_API_URL = 'http://localhost:3000'
+    expect(crwProvider.isConfigured()).toBe(true)
+  })
+
+  test('true when both CRW_API_KEY and CRW_API_URL are set', () => {
+    process.env.CRW_API_KEY = 'crw-test-key'
+    process.env.CRW_API_URL = 'http://localhost:3000'
+    expect(crwProvider.isConfigured()).toBe(true)
+  })
+
+  test('false when neither CRW_API_KEY nor CRW_API_URL is set', () => {
+    delete process.env.CRW_API_KEY
+    delete process.env.CRW_API_URL
+    expect(crwProvider.isConfigured()).toBe(false)
+  })
+})

--- a/src/tools/WebSearchTool/providers/crw.ts
+++ b/src/tools/WebSearchTool/providers/crw.ts
@@ -1,0 +1,45 @@
+import type { SearchInput, SearchProvider } from './types.js'
+import { applyDomainFilters, type ProviderOutput } from './types.js'
+import { crwSearch } from '../../crw/client.js'
+
+// fastCRW: Firecrawl-compatible web scraper; single binary; self-host or cloud.
+export const crwProvider: SearchProvider = {
+  name: 'crw',
+
+  isConfigured() {
+    return Boolean(process.env.CRW_API_KEY) || Boolean(process.env.CRW_API_URL)
+  },
+
+  async search(input: SearchInput, signal?: AbortSignal): Promise<ProviderOutput> {
+    const start = performance.now()
+    if (signal?.aborted) throw new DOMException('Aborted', 'AbortError')
+
+    let query = input.query
+    if (input.blocked_domains?.length) {
+      const exclusions = input.blocked_domains.map(d => `-site:${d}`).join(' ')
+      query = `${query} ${exclusions}`
+    }
+
+    const data = await crwSearch(query, {
+      apiKey: process.env.CRW_API_KEY,
+      apiUrl: process.env.CRW_API_URL,
+      limit: 15,
+      signal,
+    })
+
+    const hits = applyDomainFilters(
+      (data ?? []).map(r => ({
+        title: r.title ?? r.url,
+        url: r.url,
+        description: r.description,
+      })),
+      input,
+    )
+
+    return {
+      hits,
+      providerName: 'crw',
+      durationSeconds: (performance.now() - start) / 1000,
+    }
+  },
+}

--- a/src/tools/WebSearchTool/providers/index.ts
+++ b/src/tools/WebSearchTool/providers/index.ts
@@ -6,6 +6,7 @@
  *   "auto"      (default) — try providers in priority order, fall through on failure
  *   "custom"    — use WEB_SEARCH_API / WEB_PROVIDER preset only (fail loudly)
  *   "firecrawl" — use Firecrawl only (fail loudly)
+ *   "crw"       — use fastCRW only (fail loudly)
  *   "tavily"    — use Tavily only (fail loudly)
  *   "exa"       — use Exa only (fail loudly)
  *   "you"       — use You.com only (fail loudly)
@@ -30,6 +31,7 @@ import type { ProviderOutput } from './types.js'
 import { customProvider } from './custom.js'
 import { duckduckgoProvider } from './duckduckgo.js'
 import { firecrawlProvider } from './firecrawl.js'
+import { crwProvider } from './crw.js'
 import { tavilyProvider } from './tavily.js'
 import { exaProvider } from './exa.js'
 import { youProvider } from './you.js'
@@ -57,6 +59,7 @@ export { extractHits } from './custom.js'
 
 const ALL_PROVIDERS: SearchProvider[] = [
   firecrawlProvider,
+  crwProvider,
   tavilyProvider,
   exaProvider,
   youProvider,
@@ -80,6 +83,7 @@ export type ProviderMode =
   | 'auto'
   | 'custom'
   | 'firecrawl'
+  | 'crw'
   | 'ddg'
   | 'tavily'
   | 'exa'
@@ -94,6 +98,7 @@ export type ProviderMode =
 const PROVIDER_BY_NAME: Record<string, SearchProvider> = {
   custom: customProvider,
   firecrawl: firecrawlProvider,
+  crw: crwProvider,
   ddg: duckduckgoProvider,
   tavily: tavilyProvider,
   exa: exaProvider,

--- a/src/tools/crw/client.test.ts
+++ b/src/tools/crw/client.test.ts
@@ -1,0 +1,181 @@
+import { afterEach, describe, expect, mock, test } from 'bun:test'
+
+import { asMockFetch } from '../../test/typedMocks.js'
+import { crwScrape, crwSearch } from './client.js'
+
+const originalFetch = globalThis.fetch
+const originalEnv = {
+  CRW_API_KEY: process.env.CRW_API_KEY,
+  CRW_API_URL: process.env.CRW_API_URL,
+}
+
+function restoreEnv(key: string, value: string | undefined): void {
+  if (value === undefined) {
+    delete process.env[key]
+  } else {
+    process.env[key] = value
+  }
+}
+
+afterEach(() => {
+  globalThis.fetch = originalFetch
+  restoreEnv('CRW_API_KEY', originalEnv.CRW_API_KEY)
+  restoreEnv('CRW_API_URL', originalEnv.CRW_API_URL)
+})
+
+describe('crw client', () => {
+  test('search posts to the v1 API with bearer auth', async () => {
+    process.env.CRW_API_KEY = 'crw-test-key'
+    delete process.env.CRW_API_URL
+
+    globalThis.fetch = asMockFetch(mock(async (input, init) => {
+      expect(String(input)).toBe('https://fastcrw.com/api/v1/search')
+      expect(init?.method).toBe('POST')
+      expect((init?.headers as Record<string, string>).Authorization).toBe('Bearer crw-test-key')
+
+      const body = JSON.parse(String(init?.body)) as Record<string, unknown>
+      expect(body).toMatchObject({
+        query: 'openclaude',
+        limit: 7,
+        origin: 'openclaude',
+      })
+
+      return new Response(
+        JSON.stringify({
+          success: true,
+          data: [{ url: 'https://example.com', title: 'Example', description: 'desc' }],
+        }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } },
+      )
+    }))
+
+    await expect(crwSearch('openclaude', { limit: 7 })).resolves.toEqual([
+      { url: 'https://example.com', title: 'Example', description: 'desc' },
+    ])
+  })
+
+  test('scrape allows self-hosted api urls without an api key', async () => {
+    delete process.env.CRW_API_KEY
+    process.env.CRW_API_URL = 'http://localhost:3000'
+
+    globalThis.fetch = asMockFetch(mock(async (input, init) => {
+      expect(String(input)).toBe('http://localhost:3000/v1/scrape')
+      expect((init?.headers as Record<string, string>).Authorization).toBeUndefined()
+
+      const body = JSON.parse(String(init?.body)) as Record<string, unknown>
+      expect(body).toMatchObject({
+        url: 'https://example.com',
+        formats: ['markdown'],
+        origin: 'openclaude',
+      })
+
+      return new Response(
+        JSON.stringify({
+          success: true,
+          data: {
+            markdown: '# Example',
+          },
+        }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } },
+      )
+    }))
+
+    await expect(crwScrape('https://example.com')).resolves.toEqual({
+      markdown: '# Example',
+    })
+  })
+
+  test('cloud api requires an api key', async () => {
+    delete process.env.CRW_API_KEY
+    delete process.env.CRW_API_URL
+
+    await expect(crwSearch('openclaude')).rejects.toThrow(
+      'fastCRW API key is required for the cloud API.',
+    )
+  })
+
+  test('retries transient 502 responses before succeeding', async () => {
+    process.env.CRW_API_KEY = 'crw-test-key'
+    delete process.env.CRW_API_URL
+
+    let attempts = 0
+    globalThis.fetch = asMockFetch(mock(async () => {
+      attempts += 1
+      if (attempts < 3) {
+        return new Response(
+          JSON.stringify({
+            success: false,
+            error: 'temporary upstream failure',
+          }),
+          { status: 502, headers: { 'Content-Type': 'application/json' } },
+        )
+      }
+
+      return new Response(
+        JSON.stringify({
+          success: true,
+          data: [{ url: 'https://example.com/retried' }],
+        }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } },
+      )
+    }))
+
+    await expect(
+      crwSearch('openclaude', { maxRetries: 3, backoffFactorSeconds: 0 }),
+    ).resolves.toEqual([{ url: 'https://example.com/retried' }])
+    expect(attempts).toBe(3)
+  })
+
+  test('aborts in-flight requests when the request timeout elapses', async () => {
+    process.env.CRW_API_KEY = 'crw-test-key'
+    delete process.env.CRW_API_URL
+
+    globalThis.fetch = asMockFetch(mock(async (_input, init) => {
+      const signal = init?.signal
+      expect(signal).toBeInstanceOf(AbortSignal)
+
+      return new Promise<Response>((_resolve, reject) => {
+        signal?.addEventListener('abort', () => reject(signal.reason), {
+          once: true,
+        })
+      })
+    }))
+
+    await expect(
+      Promise.race([
+        crwSearch('openclaude', { maxRetries: 1, timeoutMs: 1 }),
+        new Promise((_resolve, reject) =>
+          setTimeout(
+            reject,
+            100,
+            new Error('fastCRW request timeout did not abort'),
+          ),
+        ),
+      ]),
+    ).rejects.toThrow('The operation timed out.')
+  })
+
+  test('cleans up request timeout after a successful response', async () => {
+    process.env.CRW_API_KEY = 'crw-test-key'
+    delete process.env.CRW_API_URL
+
+    let requestSignal: AbortSignal | undefined
+    globalThis.fetch = asMockFetch(mock(async (_input, init) => {
+      requestSignal = init?.signal
+      return new Response(
+        JSON.stringify({
+          success: true,
+          data: [{ url: 'https://example.com/cleanup' }],
+        }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } },
+      )
+    }))
+
+    await expect(
+      crwSearch('openclaude', { maxRetries: 1, timeoutMs: 20 }),
+    ).resolves.toEqual([{ url: 'https://example.com/cleanup' }])
+
+    await new Promise(resolve => setTimeout(resolve, 40))
+    expect(requestSignal?.aborted).toBe(false)
+  })
+})

--- a/src/tools/crw/client.ts
+++ b/src/tools/crw/client.ts
@@ -1,0 +1,175 @@
+import { createCombinedAbortSignal } from '../../utils/combinedAbortSignal.js'
+
+// fastCRW: Firecrawl-compatible web scraper; single binary; self-host or cloud.
+// Cloud base URL carries the `/api` suffix; self-host points CRW_API_URL at the
+// local engine (which may require no auth key).
+const DEFAULT_CRW_API_URL = 'https://fastcrw.com/api'
+const DEFAULT_TIMEOUT_MS = 300_000
+const DEFAULT_MAX_RETRIES = 3
+const DEFAULT_BACKOFF_FACTOR_SECONDS = 0.5
+
+interface CrwEnvelope<T> {
+  success?: boolean
+  data?: T
+  error?: string
+}
+
+interface CrwWebResult {
+  url: string
+  title?: string
+  description?: string
+}
+
+// fastCRW /v1/search returns a flat array of results under `data`.
+type CrwSearchData = CrwWebResult[]
+
+interface CrwScrapeData {
+  markdown?: string
+}
+
+interface CrwRequestOptions {
+  apiKey?: string | null
+  apiUrl?: string | null
+  signal?: AbortSignal
+  timeoutMs?: number
+  maxRetries?: number
+  backoffFactorSeconds?: number
+}
+
+interface CrwSearchOptions extends CrwRequestOptions {
+  limit?: number
+}
+
+interface CrwScrapeOptions extends CrwRequestOptions {
+  formats?: string[]
+}
+
+function getCrwConfig(options: CrwRequestOptions) {
+  const apiKey = options.apiKey ?? process.env.CRW_API_KEY ?? ''
+  const apiUrl = (options.apiUrl ?? process.env.CRW_API_URL ?? DEFAULT_CRW_API_URL).replace(/\/$/, '')
+
+  if (apiUrl.includes('fastcrw.com') && !apiKey) {
+    throw new Error(
+      'fastCRW API key is required for the cloud API. Set CRW_API_KEY or use CRW_API_URL for a self-hosted instance.',
+    )
+  }
+
+  return { apiKey, apiUrl }
+}
+
+function sleep(seconds: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, seconds * 1000))
+}
+
+async function parseCrwResponse<T>(
+  response: Response,
+  action: string,
+): Promise<CrwEnvelope<T>> {
+  const text = await response.text()
+  let payload: CrwEnvelope<T> | undefined
+
+  if (text) {
+    try {
+      payload = JSON.parse(text) as CrwEnvelope<T>
+    } catch {
+      if (!response.ok) {
+        throw new Error(`fastCRW ${action} error ${response.status}: ${text}`)
+      }
+      throw new Error(`fastCRW ${action} returned invalid JSON`)
+    }
+  }
+
+  if (!response.ok || !payload?.success) {
+    const detail = payload?.error ?? text
+    const suffix = detail ? `: ${detail}` : ''
+    throw new Error(`fastCRW ${action} error ${response.status}${suffix}`)
+  }
+
+  return payload
+}
+
+async function postToCrw<T>(
+  path: string,
+  body: Record<string, unknown>,
+  action: string,
+  options: CrwRequestOptions,
+): Promise<T> {
+  const { apiKey, apiUrl } = getCrwConfig(options)
+  const headers: Record<string, string> = {
+    Accept: 'application/json',
+    'Content-Type': 'application/json',
+  }
+  const maxRetries = options.maxRetries ?? DEFAULT_MAX_RETRIES
+  const backoffFactorSeconds = options.backoffFactorSeconds ?? DEFAULT_BACKOFF_FACTOR_SECONDS
+
+  if (apiKey) {
+    headers.Authorization = `Bearer ${apiKey}`
+  }
+
+  for (let attempt = 0; attempt < maxRetries; attempt++) {
+    const { signal, cleanup } = createCombinedAbortSignal(options.signal, {
+      timeoutMs: options.timeoutMs ?? DEFAULT_TIMEOUT_MS,
+    })
+
+    try {
+      const response = await fetch(`${apiUrl}${path}`, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({
+          ...body,
+          origin: 'openclaude',
+        }),
+        signal,
+      })
+
+      if (response.status !== 502 || attempt === maxRetries - 1) {
+        const payload = await parseCrwResponse<T>(response, action)
+        return (payload.data ?? {}) as T
+      }
+    } finally {
+      cleanup()
+    }
+
+    await sleep(backoffFactorSeconds * Math.pow(2, attempt))
+  }
+
+  throw new Error(`fastCRW ${action} failed before receiving a response`)
+}
+
+export async function crwSearch(
+  query: string,
+  options: CrwSearchOptions = {},
+): Promise<CrwSearchData> {
+  if (!query.trim()) {
+    throw new Error('fastCRW query cannot be empty')
+  }
+
+  return postToCrw<CrwSearchData>(
+    '/v1/search',
+    {
+      query,
+      limit: options.limit ?? 15,
+    },
+    'search',
+    options,
+  )
+}
+
+export async function crwScrape(
+  url: string,
+  options: CrwScrapeOptions = {},
+): Promise<CrwScrapeData> {
+  if (!url.trim()) {
+    throw new Error('fastCRW URL cannot be empty')
+  }
+
+  return postToCrw<CrwScrapeData>(
+    '/v1/scrape',
+    {
+      url,
+      formats: options.formats ?? ['markdown'],
+    },
+    'scrape',
+    options,
+  )
+}


### PR DESCRIPTION
Fixes #1636

## What changed and why
Adds **fastCRW** as a web search/scrape provider alongside the existing providers (firecrawl, tavily, …), via the existing `SearchProvider` abstraction. Purely additive — no existing provider is modified.

[fastCRW](https://fastcrw.com) is a **faster, more-open** web engine — not just another backend:
- **Fully open-source (AGPL), runs 100% locally:** anti-bot/stealth, BYO-proxy + rotation, and JS rendering all ship in the open core. (Firecrawl's OSS gates its stealth engine behind a cloud-only flag, so its self-host can't reach protected/JS-heavy sites.)
- **Higher quality + faster on Firecrawl's own benchmark dataset:** truth-recall 63.74% vs 56.04%, and faster median latency (p50 ~1.9s vs ~2.3s). Single ~8MB Rust binary, ~6MB RAM idle.
- **Search is an optimized SearXNG:** SearXNG-backed with added reranking + multi-round retrieval.
- It also happens to be Firecrawl-API-compatible, which is what keeps this integration a tiny additive diff.

Implementation:
- `src/tools/crw/client.ts` — HTTP client (Bearer auth, 502 retry w/ exponential backoff, combined caller+timeout `AbortSignal`, envelope parsing) + `crwSearch`/`crwScrape`.
- `src/tools/WebSearchTool/providers/` — `crwProvider` adapter, registered in `ALL_PROVIDERS` (after `firecrawl`) + `ProviderMode`.
- Docs + unit tests.

## User / developer impact
- An additional web backend that works fully self-hosted (real anti-bot + JS rendering in the open core) with flat pricing (1 credit = 1 page). Opt-in via `CRW_API_KEY` (+ optional `CRW_API_URL` for self-host); unset = behavior unchanged.
- Developers: one more registry entry; no change to existing provider behavior beyond inserting `crw` after `firecrawl` in the fallback chain.

## Checks run
- Unit tests `src/tools/crw/client.test.ts` (auth header, 502 retry/backoff, timeout/abort, success/error envelope, input validation) — run in this PR's CI.
- Addressed the CodeRabbit review (incl. updating the provider-priority comment in `providers/index.ts` to reflect `crw` after `firecrawl`).

## Provider path tested
fastCRW **search** and **scrape** via the `SearchProvider` adapter (unit tests, mocked HTTP). Existing providers untouched.

---
Read CONTRIBUTING and opened #1636 first to align on scope. Happy to adjust before review — I maintain the integration and can provide a free test key/credits.
