### PR TITLE
docs(test): clarify work secret localhost regression

### DIFF
--- a/src/bridge/workSecret.test.ts
+++ b/src/bridge/workSecret.test.ts
@@ -1,8 +1,8 @@
 import { expect, test } from 'bun:test'
 import { buildSdkUrl } from './workSecret.ts'
 
-// Finding #42-5: buildSdkUrl uses string.includes() on the full URL,
-// so a remote URL containing "localhost" in its path gets ws:// (unencrypted).
+// Regression coverage: buildSdkUrl must decide localhost from the parsed
+// hostname only, not from "localhost" appearing elsewhere in the URL.
 
 test('buildSdkUrl uses wss for remote URL that contains localhost in path', () => {
   const url = buildSdkUrl('https://remote.example.com/proxy/localhost/api', 'sess-1')


### PR DESCRIPTION
## Summary

- Reword the stale `workSecret.test.ts` comment so it describes the current regression coverage.
- Remove obsolete wording that implied `buildSdkUrl` still used full-URL string matching for localhost detection.

## Impact

- user-facing impact: none; test/documentation comment only.
- developer/maintainer impact: avoids sending maintainers toward a security issue that the implementation and tests already cover.

## Testing

- [ ] `bun run build` - not run; comment-only test file change.
- [ ] `bun run smoke` - not run; comment-only test file change.
- [ ] `bun run check` - not run; focused test run instead.
- [x] focused tests: `bun test src/bridge/workSecret.test.ts` (6 pass, 0 fail)

## Notes

- provider/model path tested: N/A
- screenshots attached (if UI changed): N/A
- follow-up work or known limitations: Closes #1633


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added regression coverage documentation to enhance test clarity and prevent future regressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->