### PR TITLE
feat(api): update reasoning structure in responses API

### DIFF
--- a/src/services/api/openaiShim.test.ts
+++ b/src/services/api/openaiShim.test.ts
@@ -345,6 +345,51 @@ test('uses OpenAI-compatible responses endpoint when OPENAI_API_FORMAT=responses
   ])
 })
 
+test('emits nested reasoning object on responses API when reasoningEffort is passed', async () => {
+  process.env.OPENAI_API_FORMAT = 'responses'
+  let capturedBody: Record<string, unknown> | undefined
+
+  globalThis.fetch = (async (_input, init) => {
+    capturedBody = JSON.parse(String(init?.body)) as Record<string, unknown>
+
+    return new Response(
+      JSON.stringify({
+        id: 'resp-1',
+        model: 'gpt-5.5',
+        output: [
+          {
+            type: 'message',
+            role: 'assistant',
+            content: [{ type: 'output_text', text: 'ok' }],
+          },
+        ],
+      }),
+      {
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      },
+    )
+  }) as unknown as FetchType
+
+  const client = createOpenAIShimClient({
+    defaultHeaders: {},
+    reasoningEffort: 'high',
+  }) as OpenAIShimClient
+
+  await client.beta.messages.create({
+    model: 'gpt-5.5',
+    messages: [{ role: 'user', content: 'hello' }],
+    max_tokens: 64,
+    stream: false,
+  })
+
+  expect(capturedBody?.reasoning).toEqual({ effort: 'high', summary: 'auto' })
+  expect(capturedBody).not.toHaveProperty('reasoning_effort')
+  expect(capturedBody).not.toHaveProperty('reasoning_summary')
+  expect(capturedBody?.include).toEqual(['reasoning.encrypted_content'])
+})
+
 test('uses OpenAI-compatible responses endpoint with text chunk types when OPENAI_API_FORMAT=responses_compat', async () => {
   process.env.OPENAI_API_FORMAT = 'responses_compat'
   let capturedUrl = ''

--- a/src/services/api/openaiShim.ts
+++ b/src/services/api/openaiShim.ts
@@ -2572,8 +2572,10 @@ class OpenAIShimMessages {
       if (params.temperature !== undefined) responsesBody.temperature = params.temperature
       if (params.top_p !== undefined) responsesBody.top_p = params.top_p
       if (request.reasoning?.effort) {
-        responsesBody.reasoning_effort = request.reasoning.effort
-        responsesBody.reasoning_summary = 'auto'
+        responsesBody.reasoning = {
+          effort: request.reasoning.effort,
+          summary: 'auto',
+        }
         responsesBody.include = ['reasoning.encrypted_content']
       }
 


### PR DESCRIPTION
## Summary

- what changed: Responses API requests now send reasoning as `reasoning: { effort, summary: 'auto' }` instead of top-level `reasoning_effort` / `reasoning_summary`.
- why it changed: OpenAI-compatible Responses API rejects the old top-level fields.

## Impact

- user-facing impact: OpenAI-compatible providers using `OPENAI_API_FORMAT=responses` can answer with reasoning effort enabled instead of failing with “Unsupported parameter: 'reasoning_effort'”.
- developer/maintainer impact: n/a

## Testing

- [x] `bun run build` passed
- [x] `bun run smoke` passed
- [ ] `bun run check` failures were outside the OpenAI path.
- [x] focused tests passed

## Notes

- provider/model path tested: OpenAI
- screenshots attached (if UI changed):
- follow-up work or known limitations:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated the request format for reasoning parameters in API integration.

* **Tests**
  * Added test coverage for reasoning functionality validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->