### PR TITLE
fix(security): bundle real sandbox runtime in open CLI

### DIFF
--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -225,7 +225,6 @@ export async function handleBgFlag() { throw new Error("Background sessions are 
           'color-diff-napi',
           '@anthropic-ai/mcpb',
           '@ant/claude-for-chrome-mcp',
-          '@anthropic-ai/sandbox-runtime',
           'asciichart',
           'plist',
           'cacache',

--- a/scripts/missing-module-stub.test.ts
+++ b/scripts/missing-module-stub.test.ts
@@ -55,8 +55,6 @@ test('CLI bundle includes the real sandbox runtime instead of the native stub', 
 
   const bundle = readFileSync(DIST, 'utf-8')
 
-  expect(bundle.includes('native-stub:@anthropic-ai/sandbox-runtime')).toBe(
-    false,
-  )
+  expect(bundle).not.toContain('native-stub:@anthropic-ai/sandbox-runtime')
   expect(bundle).toContain('bubblewrap (bwrap) not installed')
 })

--- a/scripts/missing-module-stub.test.ts
+++ b/scripts/missing-module-stub.test.ts
@@ -45,3 +45,18 @@ test('WebFetch binds the real ssrfGuardedLookup in the CLI bundle', () => {
   // ...and ssrfGuard must not have been replaced by a missing-module stub.
   expect(bundle).not.toMatch(/missing-module-stub:.*ssrfGuard/)
 })
+
+test('CLI bundle includes the real sandbox runtime instead of the native stub', () => {
+  if (!existsSync(DIST)) {
+    throw new Error(
+      'dist/cli.mjs not found — run `bun run build` before this test',
+    )
+  }
+
+  const bundle = readFileSync(DIST, 'utf-8')
+
+  expect(bundle.includes('native-stub:@anthropic-ai/sandbox-runtime')).toBe(
+    false,
+  )
+  expect(bundle).toContain('bubblewrap (bwrap) not installed')
+})

--- a/scripts/system-check.test.ts
+++ b/scripts/system-check.test.ts
@@ -123,6 +123,31 @@ describe('checkNodeVersion', () => {
 })
 
 describe('sandbox runtime diagnostics', () => {
+  test('fails when sandbox runtime inspection throws an Error', () => {
+    const result = buildSandboxRuntimeCheck({
+      inspectionError: new Error('EACCES: permission denied, open dist/cli.mjs'),
+    })
+
+    expect(result).toEqual({
+      ok: false,
+      label: 'Sandbox runtime',
+      detail:
+        'Unable to inspect CLI sandbox runtime: EACCES: permission denied, open dist/cli.mjs',
+    })
+  })
+
+  test('fails when sandbox runtime inspection throws a non-Error value', () => {
+    const result = buildSandboxRuntimeCheck({
+      inspectionError: 'bundle read failed',
+    })
+
+    expect(result).toEqual({
+      ok: false,
+      label: 'Sandbox runtime',
+      detail: 'Unable to inspect CLI sandbox runtime: bundle read failed',
+    })
+  })
+
   test('detects sandbox-runtime native stubs in the CLI bundle', () => {
     expect(
       isCliSandboxRuntimeStubbed(

--- a/scripts/system-check.test.ts
+++ b/scripts/system-check.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, test } from 'bun:test'
 
 import {
+  buildSandboxRuntimeCheck,
   checkNodeVersion,
   formatReachabilityFailureDetail,
+  isCliSandboxRuntimeStubbed,
   readNodeExecutableVersion,
 } from './system-check.ts'
 
@@ -117,5 +119,108 @@ describe('checkNodeVersion', () => {
       label: 'Node.js version',
       detail: '22.0.0',
     })
+  })
+})
+
+describe('sandbox runtime diagnostics', () => {
+  test('detects sandbox-runtime native stubs in the CLI bundle', () => {
+    expect(
+      isCliSandboxRuntimeStubbed(
+        '// native-stub:@anthropic-ai/sandbox-runtime\nconst noop = () => null',
+      ),
+    ).toBe(true)
+    expect(isCliSandboxRuntimeStubbed('bubblewrap (bwrap) not installed')).toBe(
+      false,
+    )
+  })
+
+  test('fails when the CLI bundle contains a sandbox runtime stub', () => {
+    const result = buildSandboxRuntimeCheck({
+      cliRuntimeStubbed: true,
+      sandboxEnabled: true,
+      failIfUnavailable: true,
+      sandboxingEnabled: false,
+      unavailableReason: 'sandbox.enabled is set but the runtime is stubbed',
+    })
+
+    expect(result.ok).toBe(false)
+    expect(result.label).toBe('Sandbox runtime')
+    expect(result.detail).toContain('CLI bundle: stubbed')
+    expect(result.detail).toContain('effective behavior: fail-closed')
+    expect(result.detail).toContain(
+      'reason: sandbox.enabled is set but the runtime is stubbed',
+    )
+  })
+
+  test('reports warning-only behavior when sandbox is enabled but unavailable', () => {
+    const result = buildSandboxRuntimeCheck({
+      cliRuntimeStubbed: false,
+      sandboxEnabled: true,
+      failIfUnavailable: false,
+      sandboxingEnabled: false,
+      unavailableReason: 'bubblewrap (bwrap) not installed',
+    })
+
+    expect(result.ok).toBe(true)
+    expect(result.detail).toContain('CLI bundle: real runtime')
+    expect(result.detail).toContain('effective behavior: warning-only')
+    expect(result.detail).toContain('reason: bubblewrap (bwrap) not installed')
+  })
+
+  test('flags fail-closed behavior when sandbox is required but unavailable', () => {
+    const result = buildSandboxRuntimeCheck({
+      cliRuntimeStubbed: false,
+      sandboxEnabled: true,
+      failIfUnavailable: true,
+      sandboxingEnabled: false,
+      unavailableReason: 'bubblewrap (bwrap) not installed',
+    })
+
+    expect(result.ok).toBe(false)
+    expect(result.detail).toContain('CLI bundle: real runtime')
+    expect(result.detail).toContain('effective behavior: fail-closed')
+    expect(result.detail).toContain('reason: bubblewrap (bwrap) not installed')
+  })
+
+  test('reports enforcing behavior when sandboxing is active', () => {
+    const result = buildSandboxRuntimeCheck({
+      cliRuntimeStubbed: false,
+      sandboxEnabled: true,
+      failIfUnavailable: true,
+      sandboxingEnabled: true,
+    })
+
+    expect(result.ok).toBe(true)
+    expect(result.detail).toBe(
+      'CLI bundle: real runtime; sandbox.enabled: true; failIfUnavailable: true; effective behavior: enforcing',
+    )
+  })
+
+  test('reports disabled behavior without failing when sandbox is not enabled', () => {
+    const result = buildSandboxRuntimeCheck({
+      cliRuntimeStubbed: false,
+      sandboxEnabled: false,
+      failIfUnavailable: false,
+      sandboxingEnabled: false,
+    })
+
+    expect(result.ok).toBe(true)
+    expect(result.detail).toBe(
+      'CLI bundle: real runtime; sandbox.enabled: false; failIfUnavailable: false; effective behavior: disabled',
+    )
+  })
+
+  test('reports disabled behavior without failing when sandbox is off and the CLI runtime is stubbed', () => {
+    const result = buildSandboxRuntimeCheck({
+      cliRuntimeStubbed: true,
+      sandboxEnabled: false,
+      failIfUnavailable: false,
+      sandboxingEnabled: false,
+    })
+
+    expect(result.ok).toBe(true)
+    expect(result.detail).toBe(
+      'CLI bundle: stubbed; sandbox.enabled: false; failIfUnavailable: false; effective behavior: disabled',
+    )
   })
 })

--- a/scripts/system-check.ts
+++ b/scripts/system-check.ts
@@ -178,13 +178,32 @@ export function isCliSandboxRuntimeStubbed(bundleText: string): boolean {
   return bundleText.includes('native-stub:@anthropic-ai/sandbox-runtime')
 }
 
-export function buildSandboxRuntimeCheck(input: {
-  cliRuntimeStubbed: boolean
-  sandboxEnabled: boolean
-  failIfUnavailable: boolean
-  sandboxingEnabled: boolean
-  unavailableReason?: string
-}): CheckResult {
+type SandboxRuntimeCheckInput =
+  | {
+      inspectionError: unknown
+    }
+  | {
+      cliRuntimeStubbed: boolean
+      sandboxEnabled: boolean
+      failIfUnavailable: boolean
+      sandboxingEnabled: boolean
+      unavailableReason?: string
+    }
+
+function formatUnknownError(error: unknown): string {
+  return error instanceof Error ? error.message : String(error)
+}
+
+export function buildSandboxRuntimeCheck(
+  input: SandboxRuntimeCheckInput,
+): CheckResult {
+  if ('inspectionError' in input) {
+    return fail(
+      'Sandbox runtime',
+      `Unable to inspect CLI sandbox runtime: ${formatUnknownError(input.inspectionError)}`,
+    )
+  }
+
   const effectiveBehavior = input.sandboxingEnabled
     ? 'enforcing'
     : input.sandboxEnabled
@@ -227,14 +246,18 @@ function checkSandboxRuntime(): CheckResult {
     )
   }
 
-  const bundle = readFileSync(distCli, 'utf8')
-  return buildSandboxRuntimeCheck({
-    cliRuntimeStubbed: isCliSandboxRuntimeStubbed(bundle),
-    sandboxEnabled: SandboxManager.isSandboxEnabledInSettings(),
-    failIfUnavailable: SandboxManager.isSandboxRequired(),
-    sandboxingEnabled: SandboxManager.isSandboxingEnabled(),
-    unavailableReason: SandboxManager.getSandboxUnavailableReason(),
-  })
+  try {
+    const bundle = readFileSync(distCli, 'utf8')
+    return buildSandboxRuntimeCheck({
+      cliRuntimeStubbed: isCliSandboxRuntimeStubbed(bundle),
+      sandboxEnabled: SandboxManager.isSandboxEnabledInSettings(),
+      failIfUnavailable: SandboxManager.isSandboxRequired(),
+      sandboxingEnabled: SandboxManager.isSandboxingEnabled(),
+      unavailableReason: SandboxManager.getSandboxUnavailableReason(),
+    })
+  } catch (error) {
+    return buildSandboxRuntimeCheck({ inspectionError: error })
+  }
 }
 
 function isLocalBaseUrl(baseUrl: string): boolean {

--- a/scripts/system-check.ts
+++ b/scripts/system-check.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-import { existsSync, mkdirSync, writeFileSync } from 'node:fs'
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
 import { dirname, join, resolve } from 'node:path'
 import { spawnSync } from 'node:child_process'
 import {
@@ -17,6 +17,7 @@ import {
   MIN_NODE_ENGINE_RANGE,
   checkSupportedNodeVersion,
 } from '../src/utils/nodeRuntime.js'
+import { SandboxManager } from '../src/utils/sandbox/sandbox-adapter.js'
 
 type CheckResult = {
   ok: boolean
@@ -171,6 +172,69 @@ function checkBuildArtifacts(): CheckResult {
     return fail('Build artifacts', `Missing ${distCli}. Run: bun run build`)
   }
   return pass('Build artifacts', distCli)
+}
+
+export function isCliSandboxRuntimeStubbed(bundleText: string): boolean {
+  return bundleText.includes('native-stub:@anthropic-ai/sandbox-runtime')
+}
+
+export function buildSandboxRuntimeCheck(input: {
+  cliRuntimeStubbed: boolean
+  sandboxEnabled: boolean
+  failIfUnavailable: boolean
+  sandboxingEnabled: boolean
+  unavailableReason?: string
+}): CheckResult {
+  const effectiveBehavior = input.sandboxingEnabled
+    ? 'enforcing'
+    : input.sandboxEnabled
+      ? input.failIfUnavailable
+        ? 'fail-closed'
+        : 'warning-only'
+      : 'disabled'
+
+  const detailParts = [
+    `CLI bundle: ${input.cliRuntimeStubbed ? 'stubbed' : 'real runtime'}`,
+    `sandbox.enabled: ${input.sandboxEnabled}`,
+    `failIfUnavailable: ${input.failIfUnavailable}`,
+    `effective behavior: ${effectiveBehavior}`,
+  ]
+  const reason =
+    input.unavailableReason ??
+    (input.cliRuntimeStubbed && input.sandboxEnabled
+      ? 'CLI bundle contains a no-op sandbox runtime stub'
+      : undefined)
+  if (reason) {
+    detailParts.push(`reason: ${reason}`)
+  }
+
+  const ok = !(
+    input.sandboxEnabled &&
+    input.failIfUnavailable &&
+    Boolean(reason)
+  )
+  return ok
+    ? pass('Sandbox runtime', detailParts.join('; '))
+    : fail('Sandbox runtime', detailParts.join('; '))
+}
+
+function checkSandboxRuntime(): CheckResult {
+  const distCli = resolve(process.cwd(), 'dist', 'cli.mjs')
+  if (!existsSync(distCli)) {
+    return fail(
+      'Sandbox runtime',
+      `CLI bundle missing at ${distCli}. Run: bun run build`,
+    )
+  }
+
+  const bundle = readFileSync(distCli, 'utf8')
+  return buildSandboxRuntimeCheck({
+    cliRuntimeStubbed: isCliSandboxRuntimeStubbed(bundle),
+    sandboxEnabled: SandboxManager.isSandboxEnabledInSettings(),
+    failIfUnavailable: SandboxManager.isSandboxRequired(),
+    sandboxingEnabled: SandboxManager.isSandboxingEnabled(),
+    unavailableReason: SandboxManager.getSandboxUnavailableReason(),
+  })
 }
 
 function isLocalBaseUrl(baseUrl: string): boolean {
@@ -717,6 +781,7 @@ async function main(): Promise<void> {
   results.push(checkNodeVersion())
   results.push(checkBunRuntime())
   results.push(checkBuildArtifacts())
+  results.push(checkSandboxRuntime())
   results.push(...checkOpenAIEnv())
   results.push(await checkBaseUrlReachability())
   results.push(await checkProviderGenerationReadiness())


### PR DESCRIPTION
## Summary
- Bundle the real `@anthropic-ai/sandbox-runtime` into the open CLI build instead of routing it through the native-stub shim.
- Add a CLI bundle guard that fails if the sandbox runtime is stubbed again.
- Add runtime doctor diagnostics for CLI bundle status, sandbox settings, and effective behavior.

## Problem Discovered
The open CLI build was replacing `@anthropic-ai/sandbox-runtime` with a no-op native stub. That made the bundled CLI unable to use the real sandbox runtime even though sandbox settings and dependency checks existed.

## Effective Behavior
Before:
- `dist/cli.mjs` contained `native-stub:@anthropic-ai/sandbox-runtime`.
- Sandbox checks saw a no-op runtime and treated sandboxing as unavailable.

After:
- `dist/cli.mjs` contains the real runtime path.
- Runtime doctor reports whether the CLI bundle has the real runtime, whether sandboxing is enabled, whether `failIfUnavailable` is set, and the effective behavior.

## Security Implications
Users who enable sandboxing now get the real runtime in the CLI bundle. If platform dependencies are missing, the existing warning or fail-closed behavior applies according to settings.

## Tests
- `git diff --check`
- `bun test scripts/missing-module-stub.test.ts scripts/system-check.test.ts`
- `bun run typecheck`
- `bun test`
- `bun run smoke`
- `bun run doctor:runtime`
- Temp config smoke with `sandbox.enabled=true` and `sandbox.failIfUnavailable=true`
- Static bundle check for sandbox-runtime stub markers


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a Bun regression test to ensure the shipped CLI bundle includes the real sandbox runtime (not the native stub marker).
  * Expanded sandbox runtime diagnostics coverage to validate expected pass/warn/fail outcomes across multiple configuration scenarios.
* **Chores**
  * Adjusted the CLI bundling process so the sandbox runtime is included correctly.
  * Enhanced system checks to inspect the shipped CLI artifact, report effective sandbox behavior, and influence the overall exit code when sandbox availability is required.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->