### PR TITLE
feat(cli): add local background sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,31 @@ Inside OpenClaude:
 - run `/provider` for guided provider setup and saved profiles
 - run `/onboard-github` for GitHub Models onboarding
 
+### Background sessions
+
+Run long non-interactive prompts detached from the current terminal:
+
+```bash
+openclaude --bg "fix failing tests"
+openclaude --bg --name auth-refactor "refactor auth middleware"
+openclaude ps
+openclaude logs auth-refactor
+openclaude logs auth-refactor -f
+openclaude kill auth-refactor
+```
+
+Background sessions are local child processes. OpenClaude does not start a daemon
+or network service, and permission/provider/model/settings flags are passed to
+the child process the same way they are for a foreground `--print` run. Session
+metadata and logs are stored under the resolved OpenClaude config directory,
+usually `~/.openclaude/bg-sessions/`; `CLAUDE_CONFIG_DIR` can point OpenClaude
+somewhere else. Session names can be reused after older sessions reach a
+terminal state; use the session ID to inspect older logs with the same name.
+
+`openclaude attach <id-or-name>` currently reports the matching session and
+points to `openclaude logs <id> -f`; full terminal reattach is not implemented
+for local background sessions yet.
+
 ### Fastest OpenAI setup
 
 macOS / Linux:

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -31,7 +31,7 @@ const featureFlags: Record<string, boolean> = {
   COMMIT_ATTRIBUTION: false,      // Co-Authored-By metadata in git commits
   HISTORY_SNIP: true,             // Model-callable snip tool for context management
   UDS_INBOX: false,               // Unix Domain Socket inter-session messaging
-  BG_SESSIONS: false,             // Background sessions via tmux (stubbed)
+  BG_SESSIONS: true,              // Local detached background sessions
   WEB_BROWSER_TOOL: false,        // Built-in browser automation (source not mirrored)
   CHICAGO_MCP: false,             // Computer-use MCP (native Swift modules stubbed)
   COWORKER_TYPE_TELEMETRY: false, // Telemetry for agent/coworker type classification
@@ -154,16 +154,6 @@ result = await Bun.build({
             'export async function daemonMain() { throw new Error("Daemon mode is unavailable in the open build."); }',
           ],
           [
-            '../cli/bg.js',
-            `
-export async function psHandler() { throw new Error("Background sessions are unavailable in the open build."); }
-export async function logsHandler() { throw new Error("Background sessions are unavailable in the open build."); }
-export async function attachHandler() { throw new Error("Background sessions are unavailable in the open build."); }
-export async function killHandler() { throw new Error("Background sessions are unavailable in the open build."); }
-export async function handleBgFlag() { throw new Error("Background sessions are unavailable in the open build."); }
-`,
-          ],
-          [
             '../cli/handlers/templateJobs.js',
             'export async function templatesMain() { throw new Error("Template jobs are unavailable in the open build."); }',
           ],
@@ -183,7 +173,7 @@ export async function handleBgFlag() { throw new Error("Background sessions are 
         // before the JS plugin phase runs.
 
         build.onResolve(
-          { filter: /^\.\.\/(daemon\/workerRegistry|daemon\/main|cli\/bg|cli\/handlers\/templateJobs|environment-runner\/main|self-hosted-runner\/main)\.js$/ },
+          { filter: /^\.\.\/(daemon\/workerRegistry|daemon\/main|cli\/handlers\/templateJobs|environment-runner\/main|self-hosted-runner\/main)\.js$/ },
           args => {
             if (!internalFeatureStubModules.has(args.path)) return null
             return {

--- a/src/cli/bg.test.ts
+++ b/src/cli/bg.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it } from 'bun:test'
+import {
+  buildBackgroundChildProcessConfig,
+  terminateBackgroundProcessTree,
+  parseBackgroundInvocation,
+  parseLogsInvocation,
+} from './bg.js'
+
+describe('background session CLI parsing', () => {
+  it('builds a print-mode child command and preserves provider/model flags', () => {
+    const parsed = parseBackgroundInvocation([
+      '--provider',
+      'openai',
+      '--model',
+      'gpt-5',
+      '--bg',
+      '--name',
+      'auth-refactor',
+      'refactor auth middleware',
+    ])
+
+    expect(parsed.name).toBe('auth-refactor')
+    expect(parsed.prompt).toBe('refactor auth middleware')
+    expect(parsed.childArgs).toEqual([
+      '--provider',
+      'openai',
+      '--model',
+      'gpt-5',
+      '--name',
+      'auth-refactor',
+      '--print',
+      'refactor auth middleware',
+    ])
+  })
+
+  it('does not duplicate --print when the user already passed it', () => {
+    const parsed = parseBackgroundInvocation([
+      '--background',
+      '--print',
+      '--max-turns',
+      '2',
+      'fix failing tests',
+    ])
+
+    expect(parsed.childArgs).toEqual([
+      '--print',
+      '--max-turns',
+      '2',
+      'fix failing tests',
+    ])
+  })
+
+  it('inserts generated flags before -- so dash-prefixed prompts stay positional', () => {
+    const parsed = parseBackgroundInvocation(['--bg', '--', '--fix-tests'])
+
+    expect(parsed.prompt).toBe('--fix-tests')
+    expect(parsed.childArgs).toEqual(['--print', '--', '--fix-tests'])
+  })
+
+  it('does not strip --bg when it appears after -- as the prompt', () => {
+    const parsed = parseBackgroundInvocation(['--bg', '--', '--bg'])
+
+    expect(parsed.prompt).toBe('--bg')
+    expect(parsed.childArgs).toEqual(['--print', '--', '--bg'])
+  })
+
+  it('parses log follow mode', () => {
+    expect(parseLogsInvocation(['auth-refactor', '-f'])).toEqual({
+      target: 'auth-refactor',
+      follow: true,
+      stream: 'stdout',
+    })
+    expect(parseLogsInvocation(['auth-refactor', '--stderr'])).toEqual({
+      target: 'auth-refactor',
+      follow: false,
+      stream: 'stderr',
+    })
+  })
+
+  it('preserves Node exec flags and lets the launcher manage heap relaunch state', () => {
+    const config = buildBackgroundChildProcessConfig({
+      execPath: '/usr/bin/node',
+      execArgv: ['--max-old-space-size=8192', '--expose-gc'],
+      entrypoint: '/repo/bin/openclaude',
+      childArgs: ['--print', 'fix failing tests'],
+      processEnv: {
+        OPENCLAUDE_HEAP_RELAUNCHED: '1',
+        OPENCLAUDE_NODE_MAX_OLD_SPACE_SIZE_MB: '8192',
+      },
+      sessionName: 'tests',
+      stdoutLogPath: '/tmp/bg.out.log',
+    })
+
+    expect(config.command).toBe('/usr/bin/node')
+    expect(config.args).toEqual([
+      '--max-old-space-size=8192',
+      '--expose-gc',
+      '/repo/bin/openclaude',
+      '--print',
+      'fix failing tests',
+    ])
+    expect(config.env.OPENCLAUDE_HEAP_RELAUNCHED).toBeUndefined()
+    expect(config.env.OPENCLAUDE_NODE_MAX_OLD_SPACE_SIZE_MB).toBe('8192')
+    expect(config.env.CLAUDE_CODE_SESSION_KIND).toBe('bg')
+    expect(config.env.CLAUDE_CODE_SESSION_LOG).toBe('/tmp/bg.out.log')
+    expect(config.env.CLAUDE_CODE_SESSION_NAME).toBe('tests')
+  })
+
+  it('escalates process-tree termination and waits for exit before returning', async () => {
+    const signals: Array<string | number | undefined> = []
+    let aliveChecks = 0
+
+    await terminateBackgroundProcessTree(123, {
+      isProcessAlive: () => {
+        aliveChecks++
+        return aliveChecks < 4
+      },
+      killTree: async (_pid, signal) => {
+        signals.push(signal)
+      },
+      sleep: async () => {},
+      termGraceMs: 1,
+      killGraceMs: 1,
+      pollIntervalMs: 1,
+    })
+
+    expect(signals).toEqual(['SIGTERM', 'SIGKILL'])
+  })
+})

--- a/src/cli/bg.test.ts
+++ b/src/cli/bg.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'bun:test'
 import {
+  buildBackgroundSessionLaunch,
   buildBackgroundChildProcessConfig,
   terminateBackgroundProcessTree,
   parseBackgroundInvocation,
@@ -131,6 +132,39 @@ describe('background session CLI parsing', () => {
       sessionId,
       '--print',
       'continue the fix',
+    ])
+  })
+
+  it('does not inject a generated session id when resuming without forking', () => {
+    const resumeSessionId = '550e8400-e29b-41d4-a716-446655440000'
+    const generatedSessionId = '00000000-0000-4000-8000-000000000001'
+
+    const launch = buildBackgroundSessionLaunch(
+      ['--resume', resumeSessionId, '--print'],
+      generatedSessionId,
+    )
+
+    expect(launch.sessionId).toBe(resumeSessionId)
+    expect(launch.childArgs).toEqual(['--resume', resumeSessionId, '--print'])
+  })
+
+  it('uses a generated session id for forked background resumes', () => {
+    const resumeSessionId = '550e8400-e29b-41d4-a716-446655440000'
+    const generatedSessionId = '00000000-0000-4000-8000-000000000001'
+
+    const launch = buildBackgroundSessionLaunch(
+      ['--resume', resumeSessionId, '--fork-session', '--print'],
+      generatedSessionId,
+    )
+
+    expect(launch.sessionId).toBe(generatedSessionId)
+    expect(launch.childArgs).toEqual([
+      '--resume',
+      resumeSessionId,
+      '--fork-session',
+      '--print',
+      '--session-id',
+      generatedSessionId,
     ])
   })
 

--- a/src/cli/bg.test.ts
+++ b/src/cli/bg.test.ts
@@ -207,6 +207,18 @@ describe('background session CLI parsing', () => {
     expect(launch.childArgs).toEqual(['--from-pr', '1642', '--print'])
   })
 
+  it('fails when a non-forked PR resume selector cannot be resolved', async () => {
+    await expect(
+      buildBackgroundSessionLaunch(
+        ['--from-pr', '1642', '--print'],
+        '00000000-0000-4000-8000-000000000001',
+        {
+          resolvePrResumeSessionId: async () => null,
+        },
+      ),
+    ).rejects.toThrow('No conversation found linked to PR selector: 1642')
+  })
+
   it('inserts generated flags before -- so dash-prefixed prompts stay positional', () => {
     const parsed = parseBackgroundInvocation(['--bg', '--', '--fix-tests'])
 

--- a/src/cli/bg.test.ts
+++ b/src/cli/bg.test.ts
@@ -148,6 +148,24 @@ describe('background session CLI parsing', () => {
     expect(launch.childArgs).toEqual(['--resume', resumeSessionId, '--print'])
   })
 
+  it('preserves an explicit session id without injecting a generated one', () => {
+    const explicitSessionId = '550e8400-e29b-41d4-a716-446655440000'
+    const generatedSessionId = '00000000-0000-4000-8000-000000000001'
+
+    const launch = buildBackgroundSessionLaunch(
+      ['--session-id', explicitSessionId, '--print', 'fix failing tests'],
+      generatedSessionId,
+    )
+
+    expect(launch.sessionId).toBe(explicitSessionId)
+    expect(launch.childArgs).toEqual([
+      '--session-id',
+      explicitSessionId,
+      '--print',
+      'fix failing tests',
+    ])
+  })
+
   it('uses a generated session id for forked background resumes', () => {
     const resumeSessionId = '550e8400-e29b-41d4-a716-446655440000'
     const generatedSessionId = '00000000-0000-4000-8000-000000000001'

--- a/src/cli/bg.test.ts
+++ b/src/cli/bg.test.ts
@@ -76,36 +76,62 @@ describe('background session CLI parsing', () => {
     ])
   })
 
-  it('treats optional resume and PR values as prompts unless supplied inline', () => {
+  it('preserves space-separated resume and PR option values', () => {
+    const sessionId = '550e8400-e29b-41d4-a716-446655440000'
     const resumeParsed = parseBackgroundInvocation([
       '--bg',
       '--resume',
-      'continue work',
+      sessionId,
     ])
     const fromPrParsed = parseBackgroundInvocation([
       '--bg',
       '--from-pr',
-      'review 123',
+      '1642',
+    ])
+    const shortResumeParsed = parseBackgroundInvocation([
+      '--bg',
+      '-r',
+      sessionId,
     ])
     const inlineResumeParsed = parseBackgroundInvocation([
       '--bg',
       '--resume=auth',
     ])
 
-    expect(resumeParsed.prompt).toBe('continue work')
+    expect(resumeParsed.prompt).toBeUndefined()
     expect(resumeParsed.childArgs).toEqual([
       '--resume',
+      sessionId,
       '--print',
-      'continue work',
     ])
-    expect(fromPrParsed.prompt).toBe('review 123')
+    expect(fromPrParsed.prompt).toBeUndefined()
     expect(fromPrParsed.childArgs).toEqual([
       '--from-pr',
+      '1642',
       '--print',
-      'review 123',
     ])
+    expect(shortResumeParsed.prompt).toBeUndefined()
+    expect(shortResumeParsed.childArgs).toEqual(['-r', sessionId, '--print'])
     expect(inlineResumeParsed.prompt).toBeUndefined()
     expect(inlineResumeParsed.childArgs).toEqual(['--resume=auth', '--print'])
+  })
+
+  it('finds the prompt after a space-separated resume option value', () => {
+    const sessionId = '550e8400-e29b-41d4-a716-446655440000'
+    const parsed = parseBackgroundInvocation([
+      '--bg',
+      '--resume',
+      sessionId,
+      'continue the fix',
+    ])
+
+    expect(parsed.prompt).toBe('continue the fix')
+    expect(parsed.childArgs).toEqual([
+      '--resume',
+      sessionId,
+      '--print',
+      'continue the fix',
+    ])
   })
 
   it('inserts generated flags before -- so dash-prefixed prompts stay positional', () => {

--- a/src/cli/bg.test.ts
+++ b/src/cli/bg.test.ts
@@ -50,6 +50,32 @@ describe('background session CLI parsing', () => {
     ])
   })
 
+  it('preserves the prompt when --debug has no inline filter', () => {
+    const parsed = parseBackgroundInvocation([
+      '--bg',
+      '--debug',
+      'fix failing tests',
+    ])
+
+    expect(parsed.prompt).toBe('fix failing tests')
+    expect(parsed.childArgs).toEqual(['--debug', '--print', 'fix failing tests'])
+  })
+
+  it('preserves inline --debug filters while finding the prompt', () => {
+    const parsed = parseBackgroundInvocation([
+      '--bg',
+      '--debug=api,hooks',
+      'fix failing tests',
+    ])
+
+    expect(parsed.prompt).toBe('fix failing tests')
+    expect(parsed.childArgs).toEqual([
+      '--debug=api,hooks',
+      '--print',
+      'fix failing tests',
+    ])
+  })
+
   it('inserts generated flags before -- so dash-prefixed prompts stay positional', () => {
     const parsed = parseBackgroundInvocation(['--bg', '--', '--fix-tests'])
 

--- a/src/cli/bg.test.ts
+++ b/src/cli/bg.test.ts
@@ -135,11 +135,11 @@ describe('background session CLI parsing', () => {
     ])
   })
 
-  it('does not inject a generated session id when resuming without forking', () => {
+  it('does not inject a generated session id when resuming without forking', async () => {
     const resumeSessionId = '550e8400-e29b-41d4-a716-446655440000'
     const generatedSessionId = '00000000-0000-4000-8000-000000000001'
 
-    const launch = buildBackgroundSessionLaunch(
+    const launch = await buildBackgroundSessionLaunch(
       ['--resume', resumeSessionId, '--print'],
       generatedSessionId,
     )
@@ -148,11 +148,11 @@ describe('background session CLI parsing', () => {
     expect(launch.childArgs).toEqual(['--resume', resumeSessionId, '--print'])
   })
 
-  it('preserves an explicit session id without injecting a generated one', () => {
+  it('preserves an explicit session id without injecting a generated one', async () => {
     const explicitSessionId = '550e8400-e29b-41d4-a716-446655440000'
     const generatedSessionId = '00000000-0000-4000-8000-000000000001'
 
-    const launch = buildBackgroundSessionLaunch(
+    const launch = await buildBackgroundSessionLaunch(
       ['--session-id', explicitSessionId, '--print', 'fix failing tests'],
       generatedSessionId,
     )
@@ -166,11 +166,11 @@ describe('background session CLI parsing', () => {
     ])
   })
 
-  it('uses a generated session id for forked background resumes', () => {
+  it('uses a generated session id for forked background resumes', async () => {
     const resumeSessionId = '550e8400-e29b-41d4-a716-446655440000'
     const generatedSessionId = '00000000-0000-4000-8000-000000000001'
 
-    const launch = buildBackgroundSessionLaunch(
+    const launch = await buildBackgroundSessionLaunch(
       ['--resume', resumeSessionId, '--fork-session', '--print'],
       generatedSessionId,
     )
@@ -184,6 +184,27 @@ describe('background session CLI parsing', () => {
       '--session-id',
       generatedSessionId,
     ])
+  })
+
+  it('registers non-forked PR resumes under the selected transcript id', async () => {
+    const generatedSessionId = '00000000-0000-4000-8000-000000000001'
+    const prSessionId = '550e8400-e29b-41d4-a716-446655440000'
+    const seenSelectors: unknown[] = []
+
+    const launch = await buildBackgroundSessionLaunch(
+      ['--from-pr', '1642', '--print'],
+      generatedSessionId,
+      {
+        resolvePrResumeSessionId: async selector => {
+          seenSelectors.push(selector)
+          return prSessionId
+        },
+      },
+    )
+
+    expect(seenSelectors).toEqual(['1642'])
+    expect(launch.sessionId).toBe(prSessionId)
+    expect(launch.childArgs).toEqual(['--from-pr', '1642', '--print'])
   })
 
   it('inserts generated flags before -- so dash-prefixed prompts stay positional', () => {

--- a/src/cli/bg.test.ts
+++ b/src/cli/bg.test.ts
@@ -76,11 +76,53 @@ describe('background session CLI parsing', () => {
     ])
   })
 
+  it('treats optional resume and PR values as prompts unless supplied inline', () => {
+    const resumeParsed = parseBackgroundInvocation([
+      '--bg',
+      '--resume',
+      'continue work',
+    ])
+    const fromPrParsed = parseBackgroundInvocation([
+      '--bg',
+      '--from-pr',
+      'review 123',
+    ])
+    const inlineResumeParsed = parseBackgroundInvocation([
+      '--bg',
+      '--resume=auth',
+    ])
+
+    expect(resumeParsed.prompt).toBe('continue work')
+    expect(resumeParsed.childArgs).toEqual([
+      '--resume',
+      '--print',
+      'continue work',
+    ])
+    expect(fromPrParsed.prompt).toBe('review 123')
+    expect(fromPrParsed.childArgs).toEqual([
+      '--from-pr',
+      '--print',
+      'review 123',
+    ])
+    expect(inlineResumeParsed.prompt).toBeUndefined()
+    expect(inlineResumeParsed.childArgs).toEqual(['--resume=auth', '--print'])
+  })
+
   it('inserts generated flags before -- so dash-prefixed prompts stay positional', () => {
     const parsed = parseBackgroundInvocation(['--bg', '--', '--fix-tests'])
 
     expect(parsed.prompt).toBe('--fix-tests')
     expect(parsed.childArgs).toEqual(['--print', '--', '--fix-tests'])
+  })
+
+  it('injects print mode when the prompt after -- looks like a print flag', () => {
+    const longFlagParsed = parseBackgroundInvocation(['--bg', '--', '--print'])
+    const shortFlagParsed = parseBackgroundInvocation(['--bg', '--', '-p'])
+
+    expect(longFlagParsed.prompt).toBe('--print')
+    expect(longFlagParsed.childArgs).toEqual(['--print', '--', '--print'])
+    expect(shortFlagParsed.prompt).toBe('-p')
+    expect(shortFlagParsed.childArgs).toEqual(['--print', '--', '-p'])
   })
 
   it('does not strip --bg when it appears after -- as the prompt', () => {

--- a/src/cli/bg.ts
+++ b/src/cli/bg.ts
@@ -1,27 +1,608 @@
-/**
- * Inert stub for background-session management
- * (`claude ps|logs|attach|kill` and `--bg`/`--background`).
- *
- * The bundler noop-stubs this specifier in current builds; this module
- * mirrors that behavior for the typechecker. Every handler resolves
- * immediately without touching the ~/.claude/sessions/ registry, so the
- * commands exit quietly — the same observable behavior as the `() => null`
- * bundler stubs. The call site in entrypoints/cli.tsx does not catch errors
- * (`void main()`), so no-ops are preferred over throwing. No import-time
- * side effects.
- */
+import { spawn } from 'node:child_process'
+import { randomUUID } from 'node:crypto'
+import { closeSync, openSync } from 'node:fs'
+import { open, readFile, unlink } from 'node:fs/promises'
+import { basename } from 'node:path'
+import treeKill from 'tree-kill'
+import { isProcessRunning } from '../utils/genericProcessUtils.js'
+import {
+  assertBackgroundSessionNameAvailable,
+  backgroundSessionLogExists,
+  createBackgroundSession,
+  ensureBackgroundSessionDirs,
+  getBackgroundSessionLogPaths,
+  isTerminalBackgroundSession,
+  listBackgroundSessions,
+  markBackgroundSessionKilled,
+  refreshBackgroundSessionStatuses,
+  resolveBackgroundSession,
+} from './bgRegistry.js'
 
-/** `claude ps [...]` — list background sessions. Stub: no registry, no output. */
-export async function psHandler(_args: string[]): Promise<void> {}
+export type ParsedBackgroundInvocation = {
+  name?: string
+  prompt?: string
+  childArgs: string[]
+}
 
-/** `claude logs <id>` — tail a session log. Stub: no-op. */
-export async function logsHandler(_sessionId: string | undefined): Promise<void> {}
+export type ParsedLogsInvocation = {
+  target?: string
+  follow: boolean
+  stream: 'stdout' | 'stderr'
+}
 
-/** `claude attach <id>` — attach to a session. Stub: no-op. */
-export async function attachHandler(_sessionId: string | undefined): Promise<void> {}
+export type BackgroundChildProcessConfig = {
+  command: string
+  args: string[]
+  env: NodeJS.ProcessEnv
+}
 
-/** `claude kill <id>` — terminate a session. Stub: no-op. */
-export async function killHandler(_sessionId: string | undefined): Promise<void> {}
+export type BuildBackgroundChildProcessConfigInput = {
+  execPath: string
+  execArgv: string[]
+  entrypoint: string
+  childArgs: string[]
+  processEnv: NodeJS.ProcessEnv
+  sessionName?: string
+  stdoutLogPath: string
+}
 
-/** `claude --bg/--background ...` — spawn a detached session. Stub: no-op. */
-export async function handleBgFlag(_args: string[]): Promise<void> {}
+const HEAP_RELAUNCHED_ENV = 'OPENCLAUDE_HEAP_RELAUNCHED'
+const DEFAULT_TERM_GRACE_MS = 2_000
+const DEFAULT_KILL_GRACE_MS = 2_000
+const DEFAULT_KILL_POLL_INTERVAL_MS = 100
+
+// This must stay in sync with value-consuming CLI flags in main.tsx and
+// related handlers. If the CLI flag definitions become centralized, move this
+// parser metadata there instead of maintaining a second hand-written list.
+const OPTION_VALUE_FLAGS = new Set([
+  '--add-dir',
+  '--agent',
+  '--agents',
+  '--allowed-tools',
+  '--allowedTools',
+  '--append-system-prompt',
+  '--append-system-prompt-file',
+  '--betas',
+  '--debug',
+  '--debug-file',
+  '--disallowed-tools',
+  '--disallowedTools',
+  '--effort',
+  '--fallback-model',
+  '--file',
+  '--from-pr',
+  '--input-format',
+  '--json-schema',
+  '--max-budget-usd',
+  '--max-turns',
+  '--mcp-config',
+  '--model',
+  '--name',
+  '--output-format',
+  '--permission-mode',
+  '--permission-prompt-tool',
+  '--plugin-dir',
+  '--prefill',
+  '--provider',
+  '--resume',
+  '--resume-session-at',
+  '--rewind-files',
+  '--session-id',
+  '--setting-sources',
+  '--settings',
+  '--system-prompt',
+  '--system-prompt-file',
+  '--task-budget',
+  '--tools',
+  '--workload',
+  '-n',
+  '-r',
+])
+
+function safeNodeExecArgvForBackground(execArgv: string[]): string[] {
+  return execArgv.filter(
+    arg =>
+      arg === '--expose-gc' ||
+      arg.startsWith('--max-old-space-size') ||
+      arg.startsWith('--heapsnapshot-near-heap-limit'),
+  )
+}
+
+export function buildBackgroundChildProcessConfig(
+  input: BuildBackgroundChildProcessConfigInput,
+): BackgroundChildProcessConfig {
+  const env: NodeJS.ProcessEnv = {
+    ...input.processEnv,
+    CLAUDE_CODE_ENTRYPOINT: 'bg',
+    CLAUDE_CODE_SESSION_KIND: 'bg',
+    CLAUDE_CODE_SESSION_LOG: input.stdoutLogPath,
+    ...(input.sessionName
+      ? { CLAUDE_CODE_SESSION_NAME: input.sessionName }
+      : {}),
+  }
+  delete env[HEAP_RELAUNCHED_ENV]
+
+  return {
+    command: input.execPath,
+    args: [
+      ...safeNodeExecArgvForBackground(input.execArgv),
+      input.entrypoint,
+      ...input.childArgs,
+    ],
+    env,
+  }
+}
+
+function fail(message: string): never {
+  console.error(`Error: ${message}`)
+  process.exit(1)
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error)
+}
+
+async function resolveSessionOrExit(target: string) {
+  try {
+    return await resolveBackgroundSession(target)
+  } catch (error) {
+    fail(errorMessage(error))
+  }
+}
+
+function stripBackgroundFlag(args: string[]): string[] {
+  const delimiterIndex = args.indexOf('--')
+  const head = delimiterIndex === -1 ? args : args.slice(0, delimiterIndex)
+  const tail = delimiterIndex === -1 ? [] : args.slice(delimiterIndex)
+  return [
+    ...head.filter(arg => arg !== '--bg' && arg !== '--background'),
+    ...tail,
+  ]
+}
+
+function argsBeforeDelimiter(args: string[]): string[] {
+  const delimiterIndex = args.indexOf('--')
+  return delimiterIndex === -1 ? args : args.slice(0, delimiterIndex)
+}
+
+function findPromptIndex(args: string[]): number {
+  const dashDash = args.indexOf('--')
+  if (dashDash !== -1) {
+    return dashDash + 1 < args.length ? dashDash + 1 : -1
+  }
+
+  const consumedValues = new Set<number>()
+  for (let i = 0; i < args.length - 1; i++) {
+    const arg = args[i]
+    if (OPTION_VALUE_FLAGS.has(arg)) {
+      consumedValues.add(i + 1)
+      i++
+    }
+  }
+
+  for (let i = args.length - 1; i >= 0; i--) {
+    if (consumedValues.has(i)) continue
+    const arg = args[i]
+    if (arg === '--') continue
+    if (!arg.startsWith('-')) return i
+  }
+  return -1
+}
+
+function findFlagValue(args: string[], flag: string): string | undefined {
+  const inlinePrefix = `${flag}=`
+  const searchable = argsBeforeDelimiter(args)
+  for (let i = 0; i < searchable.length; i++) {
+    const arg = searchable[i]
+    if (arg.startsWith(inlinePrefix)) return arg.slice(inlinePrefix.length)
+    if (arg === flag && i + 1 < searchable.length) return searchable[i + 1]
+  }
+  return undefined
+}
+
+function findSessionName(args: string[]): string | undefined {
+  return findFlagValue(args, '--name') ?? findFlagValue(args, '-n')
+}
+
+function hasPrintMode(args: string[]): boolean {
+  return args.includes('--print') || args.includes('-p')
+}
+
+function insertBeforePrompt(args: string[], values: string[]): string[] {
+  const next = [...args]
+  const delimiterIndex = next.indexOf('--')
+  const insertionIndex =
+    delimiterIndex === -1
+      ? findPromptIndex(next)
+      : delimiterIndex
+  next.splice(insertionIndex === -1 ? next.length : insertionIndex, 0, ...values)
+  return next
+}
+
+function withGeneratedSessionId(args: string[], sessionId: string): string[] {
+  if (findFlagValue(args, '--session-id')) return args
+  return insertBeforePrompt(args, ['--session-id', sessionId])
+}
+
+export function parseBackgroundInvocation(
+  args: string[],
+): ParsedBackgroundInvocation {
+  let childArgs = stripBackgroundFlag(args)
+  const name = findSessionName(childArgs)?.trim() || undefined
+  const promptIndex = findPromptIndex(childArgs)
+  const prompt = promptIndex === -1 ? undefined : childArgs[promptIndex]
+
+  if (!hasPrintMode(childArgs)) {
+    childArgs = insertBeforePrompt(childArgs, ['--print'])
+  }
+
+  return {
+    ...(name ? { name } : {}),
+    ...(prompt ? { prompt } : {}),
+    childArgs,
+  }
+}
+
+export function parseLogsInvocation(args: string[]): ParsedLogsInvocation {
+  let follow = false
+  let stream: ParsedLogsInvocation['stream'] = 'stdout'
+  let target: string | undefined
+
+  for (const arg of args) {
+    if (arg === '-f' || arg === '--follow') {
+      follow = true
+      continue
+    }
+    if (arg === '--stderr') {
+      stream = 'stderr'
+      continue
+    }
+    if (arg === '--stdout') {
+      stream = 'stdout'
+      continue
+    }
+    target ??= arg
+  }
+
+  return { target, follow, stream }
+}
+
+function backgroundSessionId(): string {
+  return `bg-${randomUUID().slice(0, 8)}`
+}
+
+function formatCommand(command: string[]): string {
+  return command
+    .map(part => (/\s/.test(part) ? JSON.stringify(part) : part))
+    .join(' ')
+}
+
+function printSessionTable(
+  sessions: Awaited<ReturnType<typeof listBackgroundSessions>>,
+): void {
+  if (sessions.length === 0) {
+    console.log('No background sessions.')
+    return
+  }
+
+  const rows = [
+    ['ID', 'STATUS', 'PID', 'NAME', 'STARTED', 'CWD'],
+    ...sessions.map(session => [
+      session.id,
+      session.status,
+      String(session.pid),
+      session.name ?? '-',
+      session.startedAt,
+      session.cwd,
+    ]),
+  ]
+  const widths = rows[0].map((_, col) =>
+    Math.max(...rows.map(row => row[col].length)),
+  )
+
+  for (const row of rows) {
+    console.log(row.map((cell, i) => cell.padEnd(widths[i])).join('  '))
+  }
+}
+
+async function printExistingLog(path: string): Promise<number> {
+  try {
+    const contents = await readFile(path)
+    if (contents.length > 0) process.stdout.write(contents)
+    return contents.length
+  } catch {
+    return 0
+  }
+}
+
+async function followLogFile(path: string, offset: number): Promise<void> {
+  let position = offset
+  let reading = false
+
+  await new Promise<void>(resolve => {
+    const cleanup = () => {
+      clearInterval(timer)
+      process.off('SIGINT', cleanup)
+      process.off('SIGTERM', cleanup)
+      resolve()
+    }
+
+    const timer = setInterval(() => {
+      if (reading) return
+      reading = true
+      void (async () => {
+        try {
+          const handle = await open(path, 'r')
+          try {
+            const { size } = await handle.stat()
+            if (size < position) position = 0
+            if (size > position) {
+              const buffer = Buffer.alloc(size - position)
+              await handle.read(buffer, 0, buffer.length, position)
+              position = size
+              process.stdout.write(buffer)
+            }
+          } finally {
+            await handle.close()
+          }
+        } catch {
+          // Keep following; the child may create or rotate the file later.
+        } finally {
+          reading = false
+        }
+      })()
+    }, 500)
+
+    process.once('SIGINT', cleanup)
+    process.once('SIGTERM', cleanup)
+  })
+}
+
+function normalizeArgs(args: string[] | string | undefined): string[] {
+  if (Array.isArray(args)) return args
+  return args ? [args] : []
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms))
+}
+
+async function treeKillAsync(pid: number, signal: string | number): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    treeKill(pid, signal, error => {
+      if (error && isProcessRunning(pid)) {
+        reject(error)
+        return
+      }
+      resolve()
+    })
+  })
+}
+
+async function waitForProcessExit(
+  pid: number,
+  options: {
+    isProcessAlive: (pid: number) => boolean
+    sleep: (ms: number) => Promise<void>
+    graceMs: number
+    pollIntervalMs: number
+  },
+): Promise<boolean> {
+  const attempts = Math.max(
+    1,
+    Math.ceil(options.graceMs / options.pollIntervalMs),
+  )
+  for (let i = 0; i < attempts; i++) {
+    if (!options.isProcessAlive(pid)) return true
+    await options.sleep(options.pollIntervalMs)
+  }
+  return !options.isProcessAlive(pid)
+}
+
+export async function terminateBackgroundProcessTree(
+  pid: number,
+  options?: {
+    isProcessAlive?: (pid: number) => boolean
+    killTree?: (pid: number, signal: string | number) => Promise<void>
+    sleep?: (ms: number) => Promise<void>
+    termGraceMs?: number
+    killGraceMs?: number
+    pollIntervalMs?: number
+  },
+): Promise<void> {
+  const isProcessAlive = options?.isProcessAlive ?? isProcessRunning
+  const killTree = options?.killTree ?? treeKillAsync
+  const sleepFn = options?.sleep ?? sleep
+  const pollIntervalMs =
+    options?.pollIntervalMs ?? DEFAULT_KILL_POLL_INTERVAL_MS
+
+  if (!isProcessAlive(pid)) return
+  await killTree(pid, 'SIGTERM')
+  if (
+    await waitForProcessExit(pid, {
+      isProcessAlive,
+      sleep: sleepFn,
+      graceMs: options?.termGraceMs ?? DEFAULT_TERM_GRACE_MS,
+      pollIntervalMs,
+    })
+  ) {
+    return
+  }
+
+  await killTree(pid, 'SIGKILL')
+  if (
+    await waitForProcessExit(pid, {
+      isProcessAlive,
+      sleep: sleepFn,
+      graceMs: options?.killGraceMs ?? DEFAULT_KILL_GRACE_MS,
+      pollIntervalMs,
+    })
+  ) {
+    return
+  }
+
+  throw new Error(`Process ${pid} did not exit after SIGKILL`)
+}
+
+export async function psHandler(_args: string[]): Promise<void> {
+  const sessions = await refreshBackgroundSessionStatuses()
+  printSessionTable(sessions)
+}
+
+export async function logsHandler(
+  args: string[] | string | undefined,
+): Promise<void> {
+  const parsed = parseLogsInvocation(normalizeArgs(args))
+  if (!parsed.target) fail('Usage: openclaude logs <id-or-name> [-f]')
+
+  await refreshBackgroundSessionStatuses()
+  const session = await resolveSessionOrExit(parsed.target)
+  const logPath =
+    parsed.stream === 'stderr' ? session.stderrLogPath : session.stdoutLogPath
+
+  if (!(await backgroundSessionLogExists(logPath))) {
+    fail(`Log file does not exist: ${logPath}`)
+  }
+
+  const offset = await printExistingLog(logPath)
+  if (parsed.follow) {
+    await followLogFile(logPath, offset)
+  }
+}
+
+export async function attachHandler(
+  args: string[] | string | undefined,
+): Promise<void> {
+  const target = normalizeArgs(args)[0]
+  if (!target) fail('Usage: openclaude attach <id-or-name>')
+
+  await refreshBackgroundSessionStatuses()
+  const session = await resolveSessionOrExit(target)
+  console.error(
+    `Attach is not implemented for local background sessions yet. Use \`openclaude logs ${session.id} -f\` to follow output.`,
+  )
+  process.exitCode = 1
+}
+
+export async function killHandler(
+  args: string[] | string | undefined,
+): Promise<void> {
+  const target = normalizeArgs(args)[0]
+  if (!target) fail('Usage: openclaude kill <id-or-name>')
+
+  await refreshBackgroundSessionStatuses()
+  const session = await resolveSessionOrExit(target)
+  if (!isTerminalBackgroundSession(session) && isProcessRunning(session.pid)) {
+    await terminateBackgroundProcessTree(session.pid).catch(error => {
+      fail(
+        `Failed to kill background session ${session.id}: ${errorMessage(error)}`,
+      )
+    })
+  }
+
+  const killed = await markBackgroundSessionKilled(session.id)
+  console.log(`Killed background session ${killed.id}.`)
+}
+
+export async function handleBgFlag(args: string[]): Promise<void> {
+  const parsed = parseBackgroundInvocation(args)
+  if (!parsed.prompt) {
+    fail('Usage: openclaude --bg [--name <name>] "<prompt>"')
+  }
+
+  try {
+    await assertBackgroundSessionNameAvailable(parsed.name)
+  } catch (error) {
+    fail(errorMessage(error))
+  }
+
+  const id = backgroundSessionId()
+  const sessionId =
+    findFlagValue(parsed.childArgs, '--session-id') ?? randomUUID()
+  const childArgs = withGeneratedSessionId(parsed.childArgs, sessionId)
+  const logPaths = getBackgroundSessionLogPaths(id)
+  await ensureBackgroundSessionDirs()
+  const entrypoint = process.argv[1]
+  if (!entrypoint) {
+    fail('Cannot determine OpenClaude entrypoint for background session')
+  }
+  const childConfig = buildBackgroundChildProcessConfig({
+    execPath: process.execPath,
+    execArgv: process.execArgv,
+    entrypoint,
+    childArgs,
+    processEnv: process.env,
+    sessionName: parsed.name,
+    stdoutLogPath: logPaths.stdoutLogPath,
+  })
+
+  let stdoutFd: number | undefined
+  let stderrFd: number | undefined
+  let createdStdoutLog = false
+  let createdStderrLog = false
+  const cleanupCreatedLogs = async () => {
+    if (createdStdoutLog) await unlink(logPaths.stdoutLogPath).catch(() => {})
+    if (createdStderrLog) await unlink(logPaths.stderrLogPath).catch(() => {})
+  }
+  let child
+  try {
+    stdoutFd = openSync(logPaths.stdoutLogPath, 'wx')
+    createdStdoutLog = true
+    stderrFd = openSync(logPaths.stderrLogPath, 'wx')
+    createdStderrLog = true
+    child = spawn(childConfig.command, childConfig.args, {
+      cwd: process.cwd(),
+      detached: true,
+      env: childConfig.env,
+      stdio: ['ignore', stdoutFd, stderrFd],
+    })
+    child.unref()
+  } catch (error) {
+    if (stdoutFd !== undefined) {
+      closeSync(stdoutFd)
+      stdoutFd = undefined
+    }
+    if (stderrFd !== undefined) {
+      closeSync(stderrFd)
+      stderrFd = undefined
+    }
+    await cleanupCreatedLogs()
+    fail(`Failed to start background session: ${errorMessage(error)}`)
+  } finally {
+    if (stdoutFd !== undefined) closeSync(stdoutFd)
+    if (stderrFd !== undefined) closeSync(stderrFd)
+  }
+
+  if (!child.pid) {
+    await cleanupCreatedLogs()
+    fail('Failed to start background session')
+  }
+
+  const command = [childConfig.command, ...childConfig.args]
+  const session = await createBackgroundSession({
+    id,
+    name: parsed.name,
+    pid: child.pid,
+    cwd: process.cwd(),
+    command,
+    provider: findFlagValue(childArgs, '--provider'),
+    model: findFlagValue(childArgs, '--model'),
+    sessionId,
+    stdoutLogPath: logPaths.stdoutLogPath,
+    stderrLogPath: logPaths.stderrLogPath,
+    logFilesPrecreated: true,
+  }).catch(async error => {
+    await terminateBackgroundProcessTree(child.pid!).catch(() => {})
+    await cleanupCreatedLogs()
+    fail(errorMessage(error))
+  })
+
+  console.log(`Started background session ${session.id}.`)
+  if (session.name) console.log(`Name: ${session.name}`)
+  console.log(`PID: ${session.pid}`)
+  console.log(`Logs: ${session.stdoutLogPath}`)
+  console.log(`Follow: openclaude logs ${session.id} -f`)
+  console.log(
+    `Command: ${formatCommand([basename(childConfig.command), ...childConfig.args])}`,
+  )
+}

--- a/src/cli/bg.ts
+++ b/src/cli/bg.ts
@@ -69,7 +69,6 @@ const REQUIRED_OPTION_VALUE_FLAGS = new Set([
   '--effort',
   '--fallback-model',
   '--file',
-  '--from-pr',
   '--input-format',
   '--json-schema',
   '--max-budget-usd',
@@ -83,7 +82,6 @@ const REQUIRED_OPTION_VALUE_FLAGS = new Set([
   '--plugin-dir',
   '--prefill',
   '--provider',
-  '--resume',
   '--resume-session-at',
   '--rewind-files',
   '--session-id',
@@ -217,7 +215,8 @@ function findSessionName(args: string[]): string | undefined {
 }
 
 function hasPrintMode(args: string[]): boolean {
-  return args.includes('--print') || args.includes('-p')
+  const searchable = argsBeforeDelimiter(args)
+  return searchable.includes('--print') || searchable.includes('-p')
 }
 
 function insertBeforePrompt(args: string[], values: string[]): string[] {

--- a/src/cli/bg.ts
+++ b/src/cli/bg.ts
@@ -46,6 +46,14 @@ export type BuildBackgroundChildProcessConfigInput = {
   stdoutLogPath: string
 }
 
+type PrResumeSelector = true | string
+
+export type BuildBackgroundSessionLaunchDeps = {
+  resolvePrResumeSessionId?: (
+    selector: PrResumeSelector,
+  ) => Promise<string | null | undefined>
+}
+
 const HEAP_RELAUNCHED_ENV = 'OPENCLAUDE_HEAP_RELAUNCHED'
 const DEFAULT_TERM_GRACE_MS = 2_000
 const DEFAULT_KILL_GRACE_MS = 2_000
@@ -251,18 +259,48 @@ function hasForkSession(args: string[]): boolean {
   return argsBeforeDelimiter(args).includes('--fork-session')
 }
 
+function findFromPrSelector(args: string[]): PrResumeSelector | undefined {
+  const searchable = argsBeforeDelimiter(args)
+  const inlinePrefix = '--from-pr='
+  for (let i = 0; i < searchable.length; i++) {
+    const arg = searchable[i]
+    if (arg.startsWith(inlinePrefix)) {
+      return arg.slice(inlinePrefix.length) || true
+    }
+    if (arg === '--from-pr') {
+      const next = searchable[i + 1]
+      return next && !next.startsWith('-') ? next : true
+    }
+  }
+  return undefined
+}
+
 function hasResumeSource(args: string[]): boolean {
   return Boolean(
     findFlagValue(args, '--resume') ??
       findFlagValue(args, '-r') ??
-      findFlagValue(args, '--from-pr'),
+      findFromPrSelector(args),
   )
 }
 
-export function buildBackgroundSessionLaunch(
+async function resolvePrResumeSessionId(
+  selector: PrResumeSelector,
+  deps: BuildBackgroundSessionLaunchDeps,
+): Promise<string | null | undefined> {
+  if (deps.resolvePrResumeSessionId) {
+    return deps.resolvePrResumeSessionId(selector)
+  }
+  const { findResumeSessionIdByPrSelector } = await import(
+    '../utils/conversationRecovery.js'
+  )
+  return findResumeSessionIdByPrSelector(selector)
+}
+
+export async function buildBackgroundSessionLaunch(
   childArgs: string[],
   generatedSessionId: string,
-): { childArgs: string[]; sessionId: string } {
+  deps: BuildBackgroundSessionLaunchDeps = {},
+): Promise<{ childArgs: string[]; sessionId: string }> {
   const explicitSessionId = findFlagValue(childArgs, '--session-id')
   if (explicitSessionId) {
     return { childArgs, sessionId: explicitSessionId }
@@ -272,6 +310,17 @@ export function buildBackgroundSessionLaunch(
     findFlagValue(childArgs, '--resume') ?? findFlagValue(childArgs, '-r')
   if (resumeSessionId && !hasForkSession(childArgs)) {
     return { childArgs, sessionId: resumeSessionId }
+  }
+
+  const fromPrSelector = findFromPrSelector(childArgs)
+  if (fromPrSelector !== undefined && !hasForkSession(childArgs)) {
+    const sessionId = await resolvePrResumeSessionId(fromPrSelector, deps)
+    if (!sessionId) {
+      const description =
+        fromPrSelector === true ? 'any PR' : `PR selector: ${fromPrSelector}`
+      throw new Error(`No conversation found linked to ${description}`)
+    }
+    return { childArgs, sessionId }
   }
 
   return {
@@ -580,10 +629,12 @@ export async function handleBgFlag(args: string[]): Promise<void> {
   }
 
   const id = backgroundSessionId()
-  const { childArgs, sessionId } = buildBackgroundSessionLaunch(
+  const { childArgs, sessionId } = await buildBackgroundSessionLaunch(
     parsed.childArgs,
     randomUUID(),
-  )
+  ).catch(error => {
+    fail(errorMessage(error))
+  })
   const logPaths = getBackgroundSessionLogPaths(id)
   await ensureBackgroundSessionDirs()
   const entrypoint = process.argv[1]

--- a/src/cli/bg.ts
+++ b/src/cli/bg.ts
@@ -247,12 +247,37 @@ function withGeneratedSessionId(args: string[], sessionId: string): string[] {
   return insertBeforePrompt(args, ['--session-id', sessionId])
 }
 
+function hasForkSession(args: string[]): boolean {
+  return argsBeforeDelimiter(args).includes('--fork-session')
+}
+
 function hasResumeSource(args: string[]): boolean {
   return Boolean(
     findFlagValue(args, '--resume') ??
       findFlagValue(args, '-r') ??
       findFlagValue(args, '--from-pr'),
   )
+}
+
+export function buildBackgroundSessionLaunch(
+  childArgs: string[],
+  generatedSessionId: string,
+): { childArgs: string[]; sessionId: string } {
+  const explicitSessionId = findFlagValue(childArgs, '--session-id')
+  if (explicitSessionId) {
+    return { childArgs, sessionId: explicitSessionId }
+  }
+
+  const resumeSessionId =
+    findFlagValue(childArgs, '--resume') ?? findFlagValue(childArgs, '-r')
+  if (resumeSessionId && !hasForkSession(childArgs)) {
+    return { childArgs, sessionId: resumeSessionId }
+  }
+
+  return {
+    childArgs: withGeneratedSessionId(childArgs, generatedSessionId),
+    sessionId: generatedSessionId,
+  }
 }
 
 export function parseBackgroundInvocation(
@@ -555,9 +580,10 @@ export async function handleBgFlag(args: string[]): Promise<void> {
   }
 
   const id = backgroundSessionId()
-  const sessionId =
-    findFlagValue(parsed.childArgs, '--session-id') ?? randomUUID()
-  const childArgs = withGeneratedSessionId(parsed.childArgs, sessionId)
+  const { childArgs, sessionId } = buildBackgroundSessionLaunch(
+    parsed.childArgs,
+    randomUUID(),
+  )
   const logPaths = getBackgroundSessionLogPaths(id)
   await ensureBackgroundSessionDirs()
   const entrypoint = process.argv[1]

--- a/src/cli/bg.ts
+++ b/src/cli/bg.ts
@@ -96,11 +96,14 @@ const REQUIRED_OPTION_VALUE_FLAGS = new Set([
   '-n',
 ])
 
-const OPTIONAL_OPTION_VALUE_FLAGS = new Set([
+const INLINE_OPTIONAL_VALUE_FLAGS = new Set([
   '--debug',
+  '-d',
+])
+
+const SPACE_OPTIONAL_VALUE_FLAGS = new Set([
   '--from-pr',
   '--resume',
-  '-d',
   '-r',
 ])
 
@@ -179,9 +182,17 @@ function findPromptIndex(args: string[]): number {
       i++
       continue
     }
-    if (OPTIONAL_OPTION_VALUE_FLAGS.has(arg)) {
-      // Commander only accepts optional option values inline (`--debug=api`),
-      // so the following token remains eligible to be the positional prompt.
+    if (SPACE_OPTIONAL_VALUE_FLAGS.has(arg)) {
+      const next = args[i + 1]
+      if (next && !next.startsWith('-')) {
+        consumedValues.add(i + 1)
+        i++
+      }
+      continue
+    }
+    if (INLINE_OPTIONAL_VALUE_FLAGS.has(arg)) {
+      // Keep debug filters inline-only here so `--debug "prompt"` remains a
+      // background prompt instead of being consumed as a logging filter.
       continue
     }
   }
@@ -201,7 +212,13 @@ function findFlagValue(args: string[], flag: string): string | undefined {
   for (let i = 0; i < searchable.length; i++) {
     const arg = searchable[i]
     if (arg.startsWith(inlinePrefix)) return arg.slice(inlinePrefix.length)
-    if (arg === flag && i + 1 < searchable.length) return searchable[i + 1]
+    if (
+      arg === flag &&
+      i + 1 < searchable.length &&
+      !searchable[i + 1]?.startsWith('-')
+    ) {
+      return searchable[i + 1]
+    }
   }
   return undefined
 }
@@ -229,6 +246,14 @@ function insertBeforePrompt(args: string[], values: string[]): string[] {
 function withGeneratedSessionId(args: string[], sessionId: string): string[] {
   if (findFlagValue(args, '--session-id')) return args
   return insertBeforePrompt(args, ['--session-id', sessionId])
+}
+
+function hasResumeSource(args: string[]): boolean {
+  return Boolean(
+    findFlagValue(args, '--resume') ??
+      findFlagValue(args, '-r') ??
+      findFlagValue(args, '--from-pr'),
+  )
 }
 
 export function parseBackgroundInvocation(
@@ -515,7 +540,7 @@ export async function killHandler(
 
 export async function handleBgFlag(args: string[]): Promise<void> {
   const parsed = parseBackgroundInvocation(args)
-  if (!parsed.prompt) {
+  if (!parsed.prompt && !hasResumeSource(parsed.childArgs)) {
     fail('Usage: openclaude --bg [--name <name>] "<prompt>"')
   }
 

--- a/src/cli/bg.ts
+++ b/src/cli/bg.ts
@@ -374,6 +374,8 @@ async function treeKillAsync(pid: number, signal: string | number): Promise<void
         reject(error)
         return
       }
+      // The process may exit naturally after the liveness check but before
+      // tree-kill reaches it; that race is already the requested outcome.
       resolve()
     })
   })

--- a/src/cli/bg.ts
+++ b/src/cli/bg.ts
@@ -4,6 +4,7 @@ import { closeSync, openSync } from 'node:fs'
 import { open, readFile, unlink } from 'node:fs/promises'
 import { basename } from 'node:path'
 import treeKill from 'tree-kill'
+import { argsBeforeDelimiter } from '../utils/cliArgs.js'
 import { isProcessRunning } from '../utils/genericProcessUtils.js'
 import {
   assertBackgroundSessionNameAvailable,
@@ -162,11 +163,6 @@ function stripBackgroundFlag(args: string[]): string[] {
     ...head.filter(arg => arg !== '--bg' && arg !== '--background'),
     ...tail,
   ]
-}
-
-function argsBeforeDelimiter(args: string[]): string[] {
-  const delimiterIndex = args.indexOf('--')
-  return delimiterIndex === -1 ? args : args.slice(0, delimiterIndex)
 }
 
 function findPromptIndex(args: string[]): number {

--- a/src/cli/bg.ts
+++ b/src/cli/bg.ts
@@ -12,7 +12,6 @@ import {
   createBackgroundSession,
   ensureBackgroundSessionDirs,
   getBackgroundSessionLogPaths,
-  isTerminalBackgroundSession,
   listBackgroundSessions,
   markBackgroundSessionKilled,
   refreshBackgroundSessionStatuses,
@@ -526,7 +525,12 @@ export async function killHandler(
 
   await refreshBackgroundSessionStatuses()
   const session = await resolveSessionOrExit(target)
-  if (!isTerminalBackgroundSession(session) && isProcessRunning(session.pid)) {
+  if (session.status === 'unknown' && isProcessRunning(session.pid)) {
+    fail(
+      `Cannot safely kill background session ${session.id}: process identity could not be verified`,
+    )
+  }
+  if (session.status === 'running' && isProcessRunning(session.pid)) {
     await terminateBackgroundProcessTree(session.pid).catch(error => {
       fail(
         `Failed to kill background session ${session.id}: ${errorMessage(error)}`,

--- a/src/cli/bg.ts
+++ b/src/cli/bg.ts
@@ -51,10 +51,10 @@ const DEFAULT_TERM_GRACE_MS = 2_000
 const DEFAULT_KILL_GRACE_MS = 2_000
 const DEFAULT_KILL_POLL_INTERVAL_MS = 100
 
-// This must stay in sync with value-consuming CLI flags in main.tsx and
-// related handlers. If the CLI flag definitions become centralized, move this
-// parser metadata there instead of maintaining a second hand-written list.
-const OPTION_VALUE_FLAGS = new Set([
+// This must stay in sync with value-consuming CLI flags in main.tsx and related
+// handlers. If the CLI flag definitions become centralized, move this parser
+// metadata there instead of maintaining a second hand-written list.
+const REQUIRED_OPTION_VALUE_FLAGS = new Set([
   '--add-dir',
   '--agent',
   '--agents',
@@ -63,7 +63,6 @@ const OPTION_VALUE_FLAGS = new Set([
   '--append-system-prompt',
   '--append-system-prompt-file',
   '--betas',
-  '--debug',
   '--debug-file',
   '--disallowed-tools',
   '--disallowedTools',
@@ -96,6 +95,13 @@ const OPTION_VALUE_FLAGS = new Set([
   '--tools',
   '--workload',
   '-n',
+])
+
+const OPTIONAL_OPTION_VALUE_FLAGS = new Set([
+  '--debug',
+  '--from-pr',
+  '--resume',
+  '-d',
   '-r',
 ])
 
@@ -174,9 +180,15 @@ function findPromptIndex(args: string[]): number {
   const consumedValues = new Set<number>()
   for (let i = 0; i < args.length - 1; i++) {
     const arg = args[i]
-    if (OPTION_VALUE_FLAGS.has(arg)) {
+    if (REQUIRED_OPTION_VALUE_FLAGS.has(arg)) {
       consumedValues.add(i + 1)
       i++
+      continue
+    }
+    if (OPTIONAL_OPTION_VALUE_FLAGS.has(arg)) {
+      // Commander only accepts optional option values inline (`--debug=api`),
+      // so the following token remains eligible to be the positional prompt.
+      continue
     }
   }
 

--- a/src/cli/bgRegistry.test.ts
+++ b/src/cli/bgRegistry.test.ts
@@ -2,7 +2,14 @@ import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
 import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { setClaudeConfigHomeDirForTesting } from '../utils/envUtils.js'
+import {
+  getClaudeConfigHomeDir,
+  setClaudeConfigHomeDirForTesting,
+} from '../utils/envUtils.js'
+import {
+  acquireSharedMutationLock,
+  releaseSharedMutationLock,
+} from '../test/sharedMutationLock.js'
 import {
   createBackgroundSession,
   listBackgroundSessions,
@@ -13,15 +20,35 @@ import {
 
 describe('background session registry', () => {
   let configDir: string
+  let previousConfigDir: string | undefined
+  let hasSharedMutationLock = false
 
   beforeEach(async () => {
+    await acquireSharedMutationLock('bgRegistry.test')
+    hasSharedMutationLock = true
+    previousConfigDir = process.env.CLAUDE_CONFIG_DIR
     configDir = await mkdtemp(join(tmpdir(), 'openclaude-bg-registry-'))
+    process.env.CLAUDE_CONFIG_DIR = configDir
     setClaudeConfigHomeDirForTesting(configDir)
+    getClaudeConfigHomeDir.cache?.clear?.()
   })
 
   afterEach(async () => {
-    setClaudeConfigHomeDirForTesting(undefined)
-    await rm(configDir, { force: true, recursive: true })
+    try {
+      setClaudeConfigHomeDirForTesting(undefined)
+      if (previousConfigDir === undefined) {
+        delete process.env.CLAUDE_CONFIG_DIR
+      } else {
+        process.env.CLAUDE_CONFIG_DIR = previousConfigDir
+      }
+      getClaudeConfigHomeDir.cache?.clear?.()
+      await rm(configDir, { force: true, recursive: true })
+    } finally {
+      if (hasSharedMutationLock) {
+        hasSharedMutationLock = false
+        releaseSharedMutationLock()
+      }
+    }
   })
 
   it('creates session metadata and log files under the OpenClaude config dir', async () => {

--- a/src/cli/bgRegistry.test.ts
+++ b/src/cli/bgRegistry.test.ts
@@ -6,6 +6,7 @@ import { join } from 'node:path'
 import {
   _setBackgroundSessionsRootForTesting,
   createBackgroundSession,
+  isTerminalBackgroundSession,
   listBackgroundSessions,
   markBackgroundSessionKilled,
   refreshBackgroundSessionStatuses,
@@ -547,7 +548,7 @@ describe('background session registry', () => {
     })
   })
 
-  it('marks sessions stale when a live PID command identity cannot be read', async () => {
+  it('marks sessions unknown when a live PID command identity cannot be read', async () => {
     await createBackgroundSession({
       id: 'bg-unreadable-pid',
       pid: 333,
@@ -565,9 +566,10 @@ describe('background session registry', () => {
 
     expect(refreshed[0]).toMatchObject({
       id: 'bg-unreadable-pid',
-      status: 'stale',
+      status: 'unknown',
       updatedAt: '2026-06-15T08:05:00.000Z',
     })
+    expect(isTerminalBackgroundSession(refreshed[0]!)).toBe(false)
   })
 
   it('marks a session killed without deleting its logs or metadata', async () => {

--- a/src/cli/bgRegistry.test.ts
+++ b/src/cli/bgRegistry.test.ts
@@ -124,6 +124,43 @@ describe('background session registry', () => {
     ).rejects.toThrow('already exists')
   })
 
+  it('rejects concurrent duplicate live names atomically', async () => {
+    const attempts = await Promise.allSettled([
+      createBackgroundSession({
+        id: 'bg-race-one',
+        name: 'shared-race',
+        pid: 111,
+        cwd: '/repo',
+        command: ['openclaude', '--print', 'one'],
+        sessionId: 'conversation-1',
+      }),
+      createBackgroundSession({
+        id: 'bg-race-two',
+        name: 'shared-race',
+        pid: 222,
+        cwd: '/repo',
+        command: ['openclaude', '--print', 'two'],
+        sessionId: 'conversation-2',
+      }),
+    ])
+    const fulfilled = attempts.filter(result => result.status === 'fulfilled')
+    const rejected = attempts.find(result => result.status === 'rejected')
+
+    expect(fulfilled).toHaveLength(1)
+    expect(rejected?.status).toBe('rejected')
+    if (!rejected || rejected.status !== 'rejected') {
+      throw new Error('Expected one duplicate-name registration to fail')
+    }
+    expect(String(rejected.reason?.message ?? rejected.reason)).toContain(
+      'already exists',
+    )
+    expect(
+      (await listBackgroundSessions()).filter(
+        session => session.name === 'shared-race',
+      ),
+    ).toHaveLength(1)
+  })
+
   it('allows terminal session names to be reused and resolves the active match', async () => {
     await createBackgroundSession({
       id: 'bg-old',
@@ -168,6 +205,30 @@ describe('background session registry', () => {
       }),
     ).rejects.toThrow('already exists')
     expect((await resolveBackgroundSession('bg-collision')).name).toBe('first')
+  })
+
+  it('rejects non-positive pids at creation', async () => {
+    await expect(
+      createBackgroundSession({
+        id: 'bg-zero-pid',
+        pid: 0,
+        cwd: '/repo',
+        command: ['openclaude', '--print', 'zero'],
+        sessionId: 'conversation-zero',
+      }),
+    ).rejects.toThrow('Invalid background session pid')
+
+    await expect(
+      createBackgroundSession({
+        id: 'bg-negative-pid',
+        pid: -1,
+        cwd: '/repo',
+        command: ['openclaude', '--print', 'negative'],
+        sessionId: 'conversation-negative',
+      }),
+    ).rejects.toThrow('Invalid background session pid')
+
+    expect(await listBackgroundSessions()).toEqual([])
   })
 
   it('registers a session whose log files were created before spawn', async () => {
@@ -410,6 +471,29 @@ describe('background session registry', () => {
         id: 'bg-bad',
         pid: 123,
         status: 'running',
+      }),
+    )
+
+    expect(await listBackgroundSessions()).toEqual([])
+  })
+
+  it('ignores metadata with a non-positive pid', async () => {
+    await mkdir(join(configDir, 'bg-sessions', 'sessions'), {
+      recursive: true,
+    })
+    await writeFile(
+      join(configDir, 'bg-sessions', 'sessions', 'bg-zero-pid.json'),
+      JSON.stringify({
+        id: 'bg-zero-pid',
+        pid: 0,
+        cwd: '/repo',
+        status: 'running',
+        sessionId: 'conversation-1',
+        startedAt: '2026-06-15T08:00:00.000Z',
+        updatedAt: '2026-06-15T08:00:00.000Z',
+        command: ['openclaude', '--print', 'work'],
+        stdoutLogPath: '/tmp/stdout.log',
+        stderrLogPath: '/tmp/stderr.log',
       }),
     )
 

--- a/src/cli/bgRegistry.test.ts
+++ b/src/cli/bgRegistry.test.ts
@@ -547,6 +547,29 @@ describe('background session registry', () => {
     })
   })
 
+  it('marks sessions stale when a live PID command identity cannot be read', async () => {
+    await createBackgroundSession({
+      id: 'bg-unreadable-pid',
+      pid: 333,
+      cwd: '/repo',
+      command: ['openclaude', '--session-id', 'conversation-1', '--print', 'work'],
+      sessionId: 'conversation-1',
+      now: new Date('2026-06-15T08:00:00.000Z'),
+    })
+
+    const refreshed = await refreshBackgroundSessionStatuses({
+      isProcessAlive: () => true,
+      getProcessCommand: () => null,
+      now: new Date('2026-06-15T08:05:00.000Z'),
+    })
+
+    expect(refreshed[0]).toMatchObject({
+      id: 'bg-unreadable-pid',
+      status: 'stale',
+      updatedAt: '2026-06-15T08:05:00.000Z',
+    })
+  })
+
   it('marks a session killed without deleting its logs or metadata', async () => {
     await createBackgroundSession({
       id: 'bg-kill',

--- a/src/cli/bgRegistry.test.ts
+++ b/src/cli/bgRegistry.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
+import { createHash } from 'node:crypto'
 import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
@@ -13,6 +14,26 @@ import {
 
 describe('background session registry', () => {
   let configDir: string
+
+  function nameReservationPath(name: string): string {
+    const digest = createHash('sha256').update(name).digest('hex')
+    return join(configDir, 'bg-sessions', 'names', `${digest}.json`)
+  }
+
+  async function writeNameReservation(
+    name: string,
+    reservation: {
+      id: string
+      creatorPid?: number
+      createdAt?: string
+    },
+  ): Promise<void> {
+    await mkdir(join(configDir, 'bg-sessions', 'names'), { recursive: true })
+    await writeFile(
+      nameReservationPath(name),
+      JSON.stringify({ name, ...reservation }),
+    )
+  }
 
   beforeEach(async () => {
     configDir = await mkdtemp(join(tmpdir(), 'openclaude-bg-registry-'))
@@ -159,6 +180,89 @@ describe('background session registry', () => {
         session => session.name === 'shared-race',
       ),
     ).toHaveLength(1)
+  })
+
+  it('does not steal an in-flight name reservation from a live creator', async () => {
+    await writeNameReservation('in-flight', {
+      id: 'bg-in-flight',
+      creatorPid: process.pid,
+      createdAt: '2026-06-15T08:00:00.000Z',
+    })
+
+    await expect(
+      createBackgroundSession({
+        id: 'bg-contender',
+        name: 'in-flight',
+        pid: 222,
+        cwd: '/repo',
+        command: ['openclaude', '--print', 'contender'],
+        sessionId: 'conversation-contender',
+      }),
+    ).rejects.toThrow('already exists')
+    expect(await listBackgroundSessions()).toEqual([])
+  })
+
+  it('recovers orphaned name reservations whose owner metadata is missing', async () => {
+    await writeNameReservation('orphaned', {
+      id: 'bg-missing-owner',
+      creatorPid: Number.MAX_SAFE_INTEGER,
+      createdAt: '2026-06-15T08:00:00.000Z',
+    })
+
+    const session = await createBackgroundSession({
+      id: 'bg-recovered',
+      name: 'orphaned',
+      pid: 222,
+      cwd: '/repo',
+      command: ['openclaude', '--print', 'recovered'],
+      sessionId: 'conversation-recovered',
+    })
+
+    expect(session.name).toBe('orphaned')
+    expect((await listBackgroundSessions()).map(s => s.id)).toEqual([
+      'bg-recovered',
+    ])
+  })
+
+  it('recovers name reservations owned by terminal sessions', async () => {
+    await mkdir(join(configDir, 'bg-sessions', 'sessions'), {
+      recursive: true,
+    })
+    await writeFile(
+      join(configDir, 'bg-sessions', 'sessions', 'bg-terminal-owner.json'),
+      JSON.stringify({
+        id: 'bg-terminal-owner',
+        name: 'terminal-name',
+        pid: 111,
+        cwd: '/repo',
+        status: 'killed',
+        sessionId: 'conversation-terminal',
+        startedAt: '2026-06-15T08:00:00.000Z',
+        updatedAt: '2026-06-15T08:05:00.000Z',
+        command: ['openclaude', '--print', 'old'],
+        stdoutLogPath: '/tmp/old-out.log',
+        stderrLogPath: '/tmp/old-err.log',
+      }),
+    )
+    await writeNameReservation('terminal-name', {
+      id: 'bg-terminal-owner',
+      creatorPid: process.pid,
+      createdAt: '2026-06-15T08:00:00.000Z',
+    })
+
+    const session = await createBackgroundSession({
+      id: 'bg-new-owner',
+      name: 'terminal-name',
+      pid: 222,
+      cwd: '/repo',
+      command: ['openclaude', '--print', 'new'],
+      sessionId: 'conversation-new',
+    })
+
+    expect(session.name).toBe('terminal-name')
+    expect((await resolveBackgroundSession('terminal-name')).id).toBe(
+      'bg-new-owner',
+    )
   })
 
   it('allows terminal session names to be reused and resolves the active match', async () => {

--- a/src/cli/bgRegistry.test.ts
+++ b/src/cli/bgRegistry.test.ts
@@ -1,0 +1,441 @@
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { setClaudeConfigHomeDirForTesting } from '../utils/envUtils.js'
+import {
+  createBackgroundSession,
+  listBackgroundSessions,
+  markBackgroundSessionKilled,
+  refreshBackgroundSessionStatuses,
+  resolveBackgroundSession,
+} from './bgRegistry.js'
+
+describe('background session registry', () => {
+  let configDir: string
+
+  beforeEach(async () => {
+    configDir = await mkdtemp(join(tmpdir(), 'openclaude-bg-registry-'))
+    setClaudeConfigHomeDirForTesting(configDir)
+  })
+
+  afterEach(async () => {
+    setClaudeConfigHomeDirForTesting(undefined)
+    await rm(configDir, { force: true, recursive: true })
+  })
+
+  it('creates session metadata and log files under the OpenClaude config dir', async () => {
+    const session = await createBackgroundSession({
+      id: 'bg-test-1',
+      name: 'auth-refactor',
+      pid: 12345,
+      cwd: '/repo',
+      command: ['openclaude', '--print', 'refactor auth'],
+      provider: 'openai',
+      model: 'gpt-5',
+      sessionId: 'conversation-1',
+      now: new Date('2026-06-15T08:00:00.000Z'),
+    })
+
+    expect(session).toMatchObject({
+      id: 'bg-test-1',
+      name: 'auth-refactor',
+      pid: 12345,
+      cwd: '/repo',
+      status: 'running',
+      provider: 'openai',
+      model: 'gpt-5',
+      sessionId: 'conversation-1',
+      startedAt: '2026-06-15T08:00:00.000Z',
+      updatedAt: '2026-06-15T08:00:00.000Z',
+      command: ['openclaude', '--print', 'refactor auth'],
+    })
+    expect(session.stdoutLogPath).toBe(
+      join(configDir, 'bg-sessions', 'logs', 'bg-test-1.out.log'),
+    )
+    expect(session.stderrLogPath).toBe(
+      join(configDir, 'bg-sessions', 'logs', 'bg-test-1.err.log'),
+    )
+
+    const sessions = await listBackgroundSessions()
+    expect(sessions.map(s => s.id)).toEqual(['bg-test-1'])
+  })
+
+  it('resolves sessions by id, id prefix, and name', async () => {
+    await createBackgroundSession({
+      id: 'bg-abcdef',
+      name: 'named-session',
+      pid: 111,
+      cwd: '/repo',
+      command: ['openclaude', '--print', 'work'],
+      sessionId: 'conversation-1',
+    })
+
+    expect((await resolveBackgroundSession('bg-abcdef')).id).toBe('bg-abcdef')
+    expect((await resolveBackgroundSession('bg-abc')).id).toBe('bg-abcdef')
+    expect((await resolveBackgroundSession('named-session')).id).toBe(
+      'bg-abcdef',
+    )
+  })
+
+  it('rejects missing and ambiguous session targets', async () => {
+    await createBackgroundSession({
+      id: 'bg-prefix-one',
+      pid: 111,
+      cwd: '/repo',
+      command: ['openclaude', '--print', 'one'],
+      sessionId: 'conversation-1',
+    })
+    await createBackgroundSession({
+      id: 'bg-prefix-two',
+      pid: 222,
+      cwd: '/repo',
+      command: ['openclaude', '--print', 'two'],
+      sessionId: 'conversation-2',
+    })
+
+    await expect(resolveBackgroundSession('missing')).rejects.toThrow(
+      'No background session found',
+    )
+    await expect(resolveBackgroundSession('bg-prefix')).rejects.toThrow(
+      'ambiguous',
+    )
+  })
+
+  it('rejects duplicate names and reports ambiguous names', async () => {
+    await createBackgroundSession({
+      id: 'bg-one',
+      name: 'shared',
+      pid: 111,
+      cwd: '/repo',
+      command: ['openclaude', '--print', 'one'],
+      sessionId: 'conversation-1',
+    })
+
+    await expect(
+      createBackgroundSession({
+        id: 'bg-two',
+        name: 'shared',
+        pid: 222,
+        cwd: '/repo',
+        command: ['openclaude', '--print', 'two'],
+        sessionId: 'conversation-2',
+      }),
+    ).rejects.toThrow('already exists')
+  })
+
+  it('allows terminal session names to be reused and resolves the active match', async () => {
+    await createBackgroundSession({
+      id: 'bg-old',
+      name: 'reuse-me',
+      pid: 111,
+      cwd: '/repo',
+      command: ['openclaude', '--print', 'old'],
+      sessionId: 'conversation-old',
+    })
+    await markBackgroundSessionKilled('bg-old')
+
+    await createBackgroundSession({
+      id: 'bg-new',
+      name: 'reuse-me',
+      pid: 222,
+      cwd: '/repo',
+      command: ['openclaude', '--print', 'new'],
+      sessionId: 'conversation-new',
+    })
+
+    expect((await resolveBackgroundSession('reuse-me')).id).toBe('bg-new')
+  })
+
+  it('does not overwrite existing metadata on id collision', async () => {
+    await createBackgroundSession({
+      id: 'bg-collision',
+      name: 'first',
+      pid: 111,
+      cwd: '/repo',
+      command: ['openclaude', '--print', 'one'],
+      sessionId: 'conversation-1',
+    })
+
+    await expect(
+      createBackgroundSession({
+        id: 'bg-collision',
+        name: 'second',
+        pid: 222,
+        cwd: '/repo',
+        command: ['openclaude', '--print', 'two'],
+        sessionId: 'conversation-2',
+      }),
+    ).rejects.toThrow('already exists')
+    expect((await resolveBackgroundSession('bg-collision')).name).toBe('first')
+  })
+
+  it('registers a session whose log files were created before spawn', async () => {
+    const stdoutLogPath = join(
+      configDir,
+      'bg-sessions',
+      'logs',
+      'bg-precreated.out.log',
+    )
+    const stderrLogPath = join(
+      configDir,
+      'bg-sessions',
+      'logs',
+      'bg-precreated.err.log',
+    )
+    await mkdir(join(configDir, 'bg-sessions', 'logs'), {
+      recursive: true,
+    })
+    await writeFile(stdoutLogPath, '')
+    await writeFile(stderrLogPath, '')
+
+    const session = await createBackgroundSession({
+      id: 'bg-precreated',
+      pid: 222,
+      cwd: '/repo',
+      command: ['openclaude', '--print', 'work'],
+      sessionId: 'conversation-1',
+      stdoutLogPath,
+      stderrLogPath,
+      logFilesPrecreated: true,
+    })
+
+    expect(session.stdoutLogPath).toBe(stdoutLogPath)
+    expect(session.stderrLogPath).toBe(stderrLogPath)
+    expect((await resolveBackgroundSession('bg-precreated')).id).toBe(
+      'bg-precreated',
+    )
+  })
+
+  it('preserves caller-owned precreated logs when metadata registration fails', async () => {
+    const stdoutLogPath = join(
+      configDir,
+      'bg-sessions',
+      'logs',
+      'bg-precreated-collision.out.log',
+    )
+    const stderrLogPath = join(
+      configDir,
+      'bg-sessions',
+      'logs',
+      'bg-precreated-collision.err.log',
+    )
+    await mkdir(join(configDir, 'bg-sessions', 'logs'), {
+      recursive: true,
+    })
+    await mkdir(join(configDir, 'bg-sessions', 'sessions'), {
+      recursive: true,
+    })
+    await writeFile(stdoutLogPath, 'stdout already belongs to caller')
+    await writeFile(stderrLogPath, 'stderr already belongs to caller')
+    await writeFile(
+      join(
+        configDir,
+        'bg-sessions',
+        'sessions',
+        'bg-precreated-collision.json',
+      ),
+      JSON.stringify({
+        id: 'bg-precreated-collision',
+        pid: 111,
+        cwd: '/repo',
+        status: 'running',
+        sessionId: 'conversation-1',
+        startedAt: '2026-06-15T08:00:00.000Z',
+        updatedAt: '2026-06-15T08:00:00.000Z',
+        command: ['openclaude', '--print', 'one'],
+        stdoutLogPath: '/tmp/existing-out.log',
+        stderrLogPath: '/tmp/existing-err.log',
+      }),
+    )
+
+    await expect(
+      createBackgroundSession({
+        id: 'bg-precreated-collision',
+        pid: 222,
+        cwd: '/repo',
+        command: ['openclaude', '--print', 'two'],
+        sessionId: 'conversation-2',
+        stdoutLogPath,
+        stderrLogPath,
+        logFilesPrecreated: true,
+      }),
+    ).rejects.toThrow('already exists')
+
+    expect(await Bun.file(stdoutLogPath).text()).toBe(
+      'stdout already belongs to caller',
+    )
+    expect(await Bun.file(stderrLogPath).text()).toBe(
+      'stderr already belongs to caller',
+    )
+  })
+
+  it('cleans up logs created before detecting a metadata id collision', async () => {
+    await mkdir(join(configDir, 'bg-sessions', 'sessions'), {
+      recursive: true,
+    })
+    await writeFile(
+      join(configDir, 'bg-sessions', 'sessions', 'bg-log-cleanup.json'),
+      JSON.stringify({
+        id: 'bg-log-cleanup',
+        pid: 111,
+        cwd: '/repo',
+        status: 'running',
+        sessionId: 'conversation-1',
+        startedAt: '2026-06-15T08:00:00.000Z',
+        updatedAt: '2026-06-15T08:00:00.000Z',
+        command: ['openclaude', '--print', 'one'],
+        stdoutLogPath: '/tmp/existing-out.log',
+        stderrLogPath: '/tmp/existing-err.log',
+      }),
+    )
+
+    await expect(
+      createBackgroundSession({
+        id: 'bg-log-cleanup',
+        pid: 222,
+        cwd: '/repo',
+        command: ['openclaude', '--print', 'two'],
+        sessionId: 'conversation-2',
+      }),
+    ).rejects.toThrow('already exists')
+
+    expect(
+      await Bun.file(
+        join(configDir, 'bg-sessions', 'logs', 'bg-log-cleanup.out.log'),
+      ).exists(),
+    ).toBe(false)
+    expect(
+      await Bun.file(
+        join(configDir, 'bg-sessions', 'logs', 'bg-log-cleanup.err.log'),
+      ).exists(),
+    ).toBe(false)
+  })
+
+  it('marks running sessions stale when their process is gone', async () => {
+    await createBackgroundSession({
+      id: 'bg-stale',
+      pid: 333,
+      cwd: '/repo',
+      command: ['openclaude', '--print', 'work'],
+      sessionId: 'conversation-1',
+      now: new Date('2026-06-15T08:00:00.000Z'),
+    })
+
+    const refreshed = await refreshBackgroundSessionStatuses({
+      isProcessAlive: () => false,
+      now: new Date('2026-06-15T08:05:00.000Z'),
+    })
+
+    expect(refreshed).toHaveLength(1)
+    expect(refreshed[0]).toMatchObject({
+      id: 'bg-stale',
+      status: 'stale',
+      updatedAt: '2026-06-15T08:05:00.000Z',
+    })
+  })
+
+  it('keeps running sessions fresh when their process identity still matches', async () => {
+    await createBackgroundSession({
+      id: 'bg-running',
+      pid: 333,
+      cwd: '/repo',
+      command: ['openclaude', '--session-id', 'conversation-1', '--print', 'work'],
+      sessionId: 'conversation-1',
+      now: new Date('2026-06-15T08:00:00.000Z'),
+    })
+
+    const refreshed = await refreshBackgroundSessionStatuses({
+      isProcessAlive: () => true,
+      getProcessCommand: () =>
+        'node openclaude --session-id conversation-1 --print work',
+      now: new Date('2026-06-15T08:05:00.000Z'),
+    })
+
+    expect(refreshed[0]).toMatchObject({
+      id: 'bg-running',
+      status: 'running',
+      updatedAt: '2026-06-15T08:00:00.000Z',
+    })
+  })
+
+  it('marks sessions stale when a live PID no longer matches the session command', async () => {
+    await createBackgroundSession({
+      id: 'bg-reused-pid',
+      pid: 333,
+      cwd: '/repo',
+      command: ['openclaude', '--session-id', 'conversation-1', '--print', 'work'],
+      sessionId: 'conversation-1',
+      now: new Date('2026-06-15T08:00:00.000Z'),
+    })
+
+    const refreshed = await refreshBackgroundSessionStatuses({
+      isProcessAlive: () => true,
+      getProcessCommand: () => 'unrelated-process',
+      now: new Date('2026-06-15T08:05:00.000Z'),
+    })
+
+    expect(refreshed[0]).toMatchObject({
+      id: 'bg-reused-pid',
+      status: 'stale',
+      updatedAt: '2026-06-15T08:05:00.000Z',
+    })
+  })
+
+  it('marks a session killed without deleting its logs or metadata', async () => {
+    await createBackgroundSession({
+      id: 'bg-kill',
+      pid: 444,
+      cwd: '/repo',
+      command: ['openclaude', '--print', 'work'],
+      sessionId: 'conversation-1',
+    })
+
+    const killed = await markBackgroundSessionKilled('bg-kill', {
+      now: new Date('2026-06-15T08:10:00.000Z'),
+    })
+
+    expect(killed.status).toBe('killed')
+    expect(killed.updatedAt).toBe('2026-06-15T08:10:00.000Z')
+    expect((await listBackgroundSessions()).map(s => s.id)).toEqual(['bg-kill'])
+  })
+
+  it('ignores malformed metadata files instead of returning unsafe sessions', async () => {
+    await mkdir(join(configDir, 'bg-sessions', 'sessions'), {
+      recursive: true,
+    })
+    await writeFile(
+      join(configDir, 'bg-sessions', 'sessions', 'bad.json'),
+      JSON.stringify({
+        id: 'bg-bad',
+        pid: 123,
+        status: 'running',
+      }),
+    )
+
+    expect(await listBackgroundSessions()).toEqual([])
+  })
+
+  it('ignores metadata whose id does not match its filename', async () => {
+    await mkdir(join(configDir, 'bg-sessions', 'sessions'), {
+      recursive: true,
+    })
+    await writeFile(
+      join(configDir, 'bg-sessions', 'sessions', 'bg-file.json'),
+      JSON.stringify({
+        id: 'bg-other',
+        pid: 123,
+        cwd: '/repo',
+        status: 'running',
+        sessionId: 'conversation-1',
+        startedAt: '2026-06-15T08:00:00.000Z',
+        updatedAt: '2026-06-15T08:00:00.000Z',
+        command: ['openclaude', '--print', 'work'],
+        stdoutLogPath: '/tmp/stdout.log',
+        stderrLogPath: '/tmp/stderr.log',
+      }),
+    )
+
+    expect(await listBackgroundSessions()).toEqual([])
+  })
+})

--- a/src/cli/bgRegistry.test.ts
+++ b/src/cli/bgRegistry.test.ts
@@ -525,6 +525,29 @@ describe('background session registry', () => {
     })
   })
 
+  it('keeps PR-resume sessions fresh when the live command matches the stored invocation', async () => {
+    await createBackgroundSession({
+      id: 'bg-from-pr',
+      pid: 333,
+      cwd: '/repo',
+      command: ['openclaude', '--from-pr', '1642', '--print'],
+      sessionId: '550e8400-e29b-41d4-a716-446655440000',
+      now: new Date('2026-06-15T08:00:00.000Z'),
+    })
+
+    const refreshed = await refreshBackgroundSessionStatuses({
+      isProcessAlive: () => true,
+      getProcessCommand: () => 'node openclaude --from-pr 1642 --print',
+      now: new Date('2026-06-15T08:05:00.000Z'),
+    })
+
+    expect(refreshed[0]).toMatchObject({
+      id: 'bg-from-pr',
+      status: 'running',
+      updatedAt: '2026-06-15T08:00:00.000Z',
+    })
+  })
+
   it('marks sessions stale when a live PID no longer matches the session command', async () => {
     await createBackgroundSession({
       id: 'bg-reused-pid',

--- a/src/cli/bgRegistry.test.ts
+++ b/src/cli/bgRegistry.test.ts
@@ -3,14 +3,7 @@ import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import {
-  getClaudeConfigHomeDir,
-  setClaudeConfigHomeDirForTesting,
-} from '../utils/envUtils.js'
-import {
-  acquireSharedMutationLock,
-  releaseSharedMutationLock,
-} from '../test/sharedMutationLock.js'
-import {
+  _setBackgroundSessionsRootForTesting,
   createBackgroundSession,
   listBackgroundSessions,
   markBackgroundSessionKilled,
@@ -20,35 +13,15 @@ import {
 
 describe('background session registry', () => {
   let configDir: string
-  let previousConfigDir: string | undefined
-  let hasSharedMutationLock = false
 
   beforeEach(async () => {
-    await acquireSharedMutationLock('bgRegistry.test')
-    hasSharedMutationLock = true
-    previousConfigDir = process.env.CLAUDE_CONFIG_DIR
     configDir = await mkdtemp(join(tmpdir(), 'openclaude-bg-registry-'))
-    process.env.CLAUDE_CONFIG_DIR = configDir
-    setClaudeConfigHomeDirForTesting(configDir)
-    getClaudeConfigHomeDir.cache?.clear?.()
+    _setBackgroundSessionsRootForTesting(join(configDir, 'bg-sessions'))
   })
 
   afterEach(async () => {
-    try {
-      setClaudeConfigHomeDirForTesting(undefined)
-      if (previousConfigDir === undefined) {
-        delete process.env.CLAUDE_CONFIG_DIR
-      } else {
-        process.env.CLAUDE_CONFIG_DIR = previousConfigDir
-      }
-      getClaudeConfigHomeDir.cache?.clear?.()
-      await rm(configDir, { force: true, recursive: true })
-    } finally {
-      if (hasSharedMutationLock) {
-        hasSharedMutationLock = false
-        releaseSharedMutationLock()
-      }
-    }
+    _setBackgroundSessionsRootForTesting(undefined)
+    await rm(configDir, { force: true, recursive: true })
   })
 
   it('creates session metadata and log files under the OpenClaude config dir', async () => {

--- a/src/cli/bgRegistry.ts
+++ b/src/cli/bgRegistry.ts
@@ -501,8 +501,7 @@ export function isBackgroundSessionProcessAlive(
 
   const readCommand = options?.getProcessCommand ?? getProcessCommand
   const command = readCommand(session.pid)
-  if (command == null) return true
-  return command.includes(session.sessionId)
+  return command != null && command.includes(session.sessionId)
 }
 
 export async function markBackgroundSessionKilled(

--- a/src/cli/bgRegistry.ts
+++ b/src/cli/bgRegistry.ts
@@ -1,0 +1,384 @@
+import {
+  mkdir,
+  readFile,
+  readdir,
+  rename,
+  stat,
+  unlink,
+  writeFile,
+} from 'node:fs/promises'
+import { randomUUID } from 'node:crypto'
+import { basename, join } from 'node:path'
+import { getClaudeConfigHomeDir } from '../utils/envUtils.js'
+import {
+  getProcessCommand,
+  isProcessRunning,
+} from '../utils/genericProcessUtils.js'
+import { jsonParse, jsonStringify } from '../utils/slowOperations.js'
+
+export type BackgroundSessionStatus =
+  | 'running'
+  | 'exited'
+  | 'failed'
+  | 'stale'
+  | 'killed'
+
+export type BackgroundSession = {
+  id: string
+  name?: string
+  pid: number
+  cwd: string
+  status: BackgroundSessionStatus
+  provider?: string
+  model?: string
+  sessionId: string
+  startedAt: string
+  updatedAt: string
+  command: string[]
+  stdoutLogPath: string
+  stderrLogPath: string
+}
+
+export type CreateBackgroundSessionInput = {
+  id: string
+  name?: string
+  pid: number
+  cwd: string
+  command: string[]
+  provider?: string
+  model?: string
+  sessionId: string
+  now?: Date
+  stdoutLogPath?: string
+  stderrLogPath?: string
+  logFilesPrecreated?: boolean
+}
+
+const TERMINAL_STATUSES = new Set<BackgroundSessionStatus>([
+  'exited',
+  'failed',
+  'stale',
+  'killed',
+])
+const ALL_STATUSES = new Set<BackgroundSessionStatus>([
+  'running',
+  ...TERMINAL_STATUSES,
+])
+const SAFE_ID_RE = /^[A-Za-z0-9._-]+$/
+
+function getBackgroundSessionsRoot(): string {
+  return join(getClaudeConfigHomeDir(), 'bg-sessions')
+}
+
+function getBackgroundSessionMetadataDir(): string {
+  return join(getBackgroundSessionsRoot(), 'sessions')
+}
+
+function getBackgroundSessionLogsDir(): string {
+  return join(getBackgroundSessionsRoot(), 'logs')
+}
+
+function metadataPathForId(id: string): string {
+  assertSafeId(id)
+  return join(getBackgroundSessionMetadataDir(), `${id}.json`)
+}
+
+function assertSafeId(id: string): void {
+  if (!SAFE_ID_RE.test(id)) {
+    throw new Error(`Invalid background session id: ${id}`)
+  }
+}
+
+function isErrno(error: unknown, code: string): boolean {
+  return (
+    !!error &&
+    typeof error === 'object' &&
+    'code' in error &&
+    error.code === code
+  )
+}
+
+function iso(now: Date | undefined): string {
+  return (now ?? new Date()).toISOString()
+}
+
+export function getBackgroundSessionLogPaths(id: string): {
+  stdoutLogPath: string
+  stderrLogPath: string
+} {
+  assertSafeId(id)
+  const logsDir = getBackgroundSessionLogsDir()
+  return {
+    stdoutLogPath: join(logsDir, `${id}.out.log`),
+    stderrLogPath: join(logsDir, `${id}.err.log`),
+  }
+}
+
+export async function ensureBackgroundSessionDirs(): Promise<void> {
+  await mkdir(getBackgroundSessionMetadataDir(), {
+    recursive: true,
+    mode: 0o700,
+  })
+  await mkdir(getBackgroundSessionLogsDir(), { recursive: true, mode: 0o700 })
+}
+
+async function writeSession(session: BackgroundSession): Promise<void> {
+  await ensureBackgroundSessionDirs()
+  const target = metadataPathForId(session.id)
+  const tmp = join(
+    getBackgroundSessionMetadataDir(),
+    `${session.id}.${process.pid}.${randomUUID()}.tmp`,
+  )
+  try {
+    await writeFile(tmp, jsonStringify(session), { flag: 'wx' })
+    await rename(tmp, target)
+  } catch (error) {
+    await unlink(tmp).catch(() => {})
+    throw error
+  }
+}
+
+async function writeNewSession(session: BackgroundSession): Promise<void> {
+  await ensureBackgroundSessionDirs()
+  try {
+    await writeFile(metadataPathForId(session.id), jsonStringify(session), {
+      flag: 'wx',
+    })
+  } catch (error) {
+    if (isErrno(error, 'EEXIST')) {
+      throw new Error(`Background session id "${session.id}" already exists`)
+    }
+    throw error
+  }
+}
+
+async function readSessionFile(path: string): Promise<BackgroundSession | null> {
+  try {
+    const parsed = jsonParse(await readFile(path, 'utf8'))
+    return isBackgroundSession(parsed, basename(path, '.json')) ? parsed : null
+  } catch {
+    return null
+  }
+}
+
+function isStringArray(value: unknown): value is string[] {
+  return Array.isArray(value) && value.every(item => typeof item === 'string')
+}
+
+function isBackgroundSession(
+  value: unknown,
+  expectedId: string,
+): value is BackgroundSession {
+  if (!value || typeof value !== 'object') return false
+  const candidate = value as Partial<BackgroundSession>
+
+  return (
+    typeof candidate.id === 'string' &&
+    SAFE_ID_RE.test(candidate.id) &&
+    candidate.id === expectedId &&
+    typeof candidate.pid === 'number' &&
+    Number.isInteger(candidate.pid) &&
+    typeof candidate.cwd === 'string' &&
+    typeof candidate.status === 'string' &&
+    ALL_STATUSES.has(candidate.status as BackgroundSessionStatus) &&
+    (candidate.name === undefined || typeof candidate.name === 'string') &&
+    (candidate.provider === undefined ||
+      typeof candidate.provider === 'string') &&
+    (candidate.model === undefined || typeof candidate.model === 'string') &&
+    typeof candidate.sessionId === 'string' &&
+    typeof candidate.startedAt === 'string' &&
+    typeof candidate.updatedAt === 'string' &&
+    isStringArray(candidate.command) &&
+    typeof candidate.stdoutLogPath === 'string' &&
+    typeof candidate.stderrLogPath === 'string'
+  )
+}
+
+export async function listBackgroundSessions(): Promise<BackgroundSession[]> {
+  let entries: string[]
+  try {
+    entries = await readdir(getBackgroundSessionMetadataDir())
+  } catch {
+    return []
+  }
+
+  const sessions: BackgroundSession[] = []
+  for (const entry of entries) {
+    if (!entry.endsWith('.json')) continue
+    const session = await readSessionFile(
+      join(getBackgroundSessionMetadataDir(), entry),
+    )
+    if (session) sessions.push(session)
+  }
+
+  return sessions.sort((a, b) => a.startedAt.localeCompare(b.startedAt))
+}
+
+export async function assertBackgroundSessionNameAvailable(
+  name: string | undefined,
+): Promise<void> {
+  if (!name) return
+  const existing = (await listBackgroundSessions()).find(
+    s => s.name === name && !isTerminalBackgroundSession(s),
+  )
+  if (existing) {
+    throw new Error(
+      `Background session name "${name}" already exists (${existing.id})`,
+    )
+  }
+}
+
+export async function createBackgroundSession(
+  input: CreateBackgroundSessionInput,
+): Promise<BackgroundSession> {
+  await assertBackgroundSessionNameAvailable(input.name)
+  const timestamp = iso(input.now)
+  const logPaths = getBackgroundSessionLogPaths(input.id)
+  const session: BackgroundSession = {
+    id: input.id,
+    ...(input.name ? { name: input.name } : {}),
+    pid: input.pid,
+    cwd: input.cwd,
+    status: 'running',
+    ...(input.provider ? { provider: input.provider } : {}),
+    ...(input.model ? { model: input.model } : {}),
+    sessionId: input.sessionId,
+    startedAt: timestamp,
+    updatedAt: timestamp,
+    command: input.command,
+    stdoutLogPath: input.stdoutLogPath ?? logPaths.stdoutLogPath,
+    stderrLogPath: input.stderrLogPath ?? logPaths.stderrLogPath,
+  }
+
+  await ensureBackgroundSessionDirs()
+  let createdStdoutLog = false
+  let createdStderrLog = false
+  try {
+    if (input.logFilesPrecreated) {
+      if (!(await backgroundSessionLogExists(session.stdoutLogPath))) {
+        throw new Error(
+          `Background session log file does not exist: ${session.stdoutLogPath}`,
+        )
+      }
+      if (!(await backgroundSessionLogExists(session.stderrLogPath))) {
+        throw new Error(
+          `Background session log file does not exist: ${session.stderrLogPath}`,
+        )
+      }
+    } else {
+      await writeFile(session.stdoutLogPath, '', { flag: 'wx' })
+      createdStdoutLog = true
+      await writeFile(session.stderrLogPath, '', { flag: 'wx' })
+      createdStderrLog = true
+    }
+    await writeNewSession(session)
+  } catch (error) {
+    if (createdStdoutLog) await unlink(session.stdoutLogPath).catch(() => {})
+    if (createdStderrLog) await unlink(session.stderrLogPath).catch(() => {})
+    if (isErrno(error, 'EEXIST')) {
+      throw new Error(`Background session id "${session.id}" already exists`)
+    }
+    throw error
+  }
+  return session
+}
+
+export async function resolveBackgroundSession(
+  target: string,
+): Promise<BackgroundSession> {
+  const sessions = await listBackgroundSessions()
+  const exactId = sessions.filter(s => s.id === target)
+  if (exactId.length === 1) return exactId[0]
+
+  const idPrefix = sessions.filter(s => s.id.startsWith(target))
+  if (idPrefix.length === 1) return idPrefix[0]
+  if (idPrefix.length > 1) {
+    throw new Error(`Background session id "${target}" is ambiguous`)
+  }
+
+  const byName = sessions.filter(s => s.name === target)
+  const liveByName = byName.filter(s => !isTerminalBackgroundSession(s))
+  if (liveByName.length === 1) return liveByName[0]
+  if (liveByName.length > 1) {
+    throw new Error(`Background session name "${target}" is ambiguous`)
+  }
+  if (byName.length === 1) return byName[0]
+  if (byName.length > 1) {
+    throw new Error(`Background session name "${target}" is ambiguous`)
+  }
+
+  throw new Error(`No background session found for "${target}"`)
+}
+
+export async function refreshBackgroundSessionStatuses(options?: {
+  isProcessAlive?: (pid: number) => boolean
+  getProcessCommand?: (pid: number) => string | null
+  now?: Date
+}): Promise<BackgroundSession[]> {
+  const timestamp = iso(options?.now)
+  const sessions = await listBackgroundSessions()
+  const refreshed: BackgroundSession[] = []
+
+  for (const session of sessions) {
+    if (
+      session.status === 'running' &&
+      !isBackgroundSessionProcessAlive(session, options)
+    ) {
+      const updated = {
+        ...session,
+        status: 'stale' as const,
+        updatedAt: timestamp,
+      }
+      await writeSession(updated)
+      refreshed.push(updated)
+      continue
+    }
+    refreshed.push(session)
+  }
+
+  return refreshed
+}
+
+export function isBackgroundSessionProcessAlive(
+  session: BackgroundSession,
+  options?: {
+    isProcessAlive?: (pid: number) => boolean
+    getProcessCommand?: (pid: number) => string | null
+  },
+): boolean {
+  const isAlive = options?.isProcessAlive ?? isProcessRunning
+  if (!isAlive(session.pid)) return false
+
+  const readCommand = options?.getProcessCommand ?? getProcessCommand
+  const command = readCommand(session.pid)
+  if (command == null) return true
+  return command.includes(session.sessionId)
+}
+
+export async function markBackgroundSessionKilled(
+  target: string,
+  options?: { now?: Date },
+): Promise<BackgroundSession> {
+  const session = await resolveBackgroundSession(target)
+  const updated: BackgroundSession = {
+    ...session,
+    status: 'killed',
+    updatedAt: iso(options?.now),
+  }
+  await writeSession(updated)
+  return updated
+}
+
+export async function backgroundSessionLogExists(path: string): Promise<boolean> {
+  try {
+    return (await stat(path)).isFile()
+  } catch {
+    return false
+  }
+}
+
+export function isTerminalBackgroundSession(
+  session: BackgroundSession,
+): boolean {
+  return TERMINAL_STATUSES.has(session.status)
+}

--- a/src/cli/bgRegistry.ts
+++ b/src/cli/bgRegistry.ts
@@ -18,6 +18,7 @@ import { jsonParse, jsonStringify } from '../utils/slowOperations.js'
 
 export type BackgroundSessionStatus =
   | 'running'
+  | 'unknown'
   | 'exited'
   | 'failed'
   | 'stale'
@@ -69,6 +70,7 @@ const TERMINAL_STATUSES = new Set<BackgroundSessionStatus>([
 ])
 const ALL_STATUSES = new Set<BackgroundSessionStatus>([
   'running',
+  'unknown',
   ...TERMINAL_STATUSES,
 ])
 const SAFE_ID_RE = /^[A-Za-z0-9._-]+$/
@@ -470,23 +472,52 @@ export async function refreshBackgroundSessionStatuses(options?: {
   const refreshed: BackgroundSession[] = []
 
   for (const session of sessions) {
-    if (
-      session.status === 'running' &&
-      !isBackgroundSessionProcessAlive(session, options)
-    ) {
+    if (session.status !== 'running' && session.status !== 'unknown') {
+      refreshed.push(session)
+      continue
+    }
+
+    const processState = getBackgroundSessionProcessState(session, options)
+    const nextStatus: BackgroundSessionStatus =
+      processState === 'alive'
+        ? 'running'
+        : processState === 'unknown'
+          ? 'unknown'
+          : 'stale'
+
+    if (session.status !== nextStatus) {
       const updated = {
         ...session,
-        status: 'stale' as const,
+        status: nextStatus,
         updatedAt: timestamp,
       }
       await writeSession(updated)
       refreshed.push(updated)
       continue
     }
+
     refreshed.push(session)
   }
 
   return refreshed
+}
+
+type BackgroundSessionProcessState = 'alive' | 'dead' | 'unknown'
+
+function getBackgroundSessionProcessState(
+  session: BackgroundSession,
+  options?: {
+    isProcessAlive?: (pid: number) => boolean
+    getProcessCommand?: (pid: number) => string | null
+  },
+): BackgroundSessionProcessState {
+  const isAlive = options?.isProcessAlive ?? isProcessRunning
+  if (!isAlive(session.pid)) return 'dead'
+
+  const readCommand = options?.getProcessCommand ?? getProcessCommand
+  const command = readCommand(session.pid)
+  if (command == null) return 'unknown'
+  return command.includes(session.sessionId) ? 'alive' : 'dead'
 }
 
 export function isBackgroundSessionProcessAlive(
@@ -496,12 +527,7 @@ export function isBackgroundSessionProcessAlive(
     getProcessCommand?: (pid: number) => string | null
   },
 ): boolean {
-  const isAlive = options?.isProcessAlive ?? isProcessRunning
-  if (!isAlive(session.pid)) return false
-
-  const readCommand = options?.getProcessCommand ?? getProcessCommand
-  const command = readCommand(session.pid)
-  return command != null && command.includes(session.sessionId)
+  return getBackgroundSessionProcessState(session, options) === 'alive'
 }
 
 export async function markBackgroundSessionKilled(

--- a/src/cli/bgRegistry.ts
+++ b/src/cli/bgRegistry.ts
@@ -7,7 +7,7 @@ import {
   unlink,
   writeFile,
 } from 'node:fs/promises'
-import { randomUUID } from 'node:crypto'
+import { createHash, randomUUID } from 'node:crypto'
 import { basename, join } from 'node:path'
 import { getClaudeConfigHomeDir } from '../utils/envUtils.js'
 import {
@@ -54,6 +54,11 @@ export type CreateBackgroundSessionInput = {
   logFilesPrecreated?: boolean
 }
 
+type BackgroundSessionNameReservation = {
+  name: string
+  id: string
+}
+
 const TERMINAL_STATUSES = new Set<BackgroundSessionStatus>([
   'exited',
   'failed',
@@ -88,9 +93,18 @@ function getBackgroundSessionLogsDir(): string {
   return join(getBackgroundSessionsRoot(), 'logs')
 }
 
+function getBackgroundSessionNamesDir(): string {
+  return join(getBackgroundSessionsRoot(), 'names')
+}
+
 function metadataPathForId(id: string): string {
   assertSafeId(id)
   return join(getBackgroundSessionMetadataDir(), `${id}.json`)
+}
+
+function nameReservationPathForName(name: string): string {
+  const digest = createHash('sha256').update(name).digest('hex')
+  return join(getBackgroundSessionNamesDir(), `${digest}.json`)
 }
 
 function assertSafeId(id: string): void {
@@ -130,6 +144,7 @@ export async function ensureBackgroundSessionDirs(): Promise<void> {
     mode: 0o700,
   })
   await mkdir(getBackgroundSessionLogsDir(), { recursive: true, mode: 0o700 })
+  await mkdir(getBackgroundSessionNamesDir(), { recursive: true, mode: 0o700 })
 }
 
 async function writeSession(session: BackgroundSession): Promise<void> {
@@ -142,6 +157,9 @@ async function writeSession(session: BackgroundSession): Promise<void> {
   try {
     await writeFile(tmp, jsonStringify(session), { flag: 'wx' })
     await rename(tmp, target)
+    if (session.name && isTerminalBackgroundSession(session)) {
+      await releaseNameReservation(session.name, session.id)
+    }
   } catch (error) {
     await unlink(tmp).catch(() => {})
     throw error
@@ -171,6 +189,57 @@ async function readSessionFile(path: string): Promise<BackgroundSession | null> 
   }
 }
 
+async function readNameReservation(
+  path: string,
+): Promise<BackgroundSessionNameReservation | null> {
+  try {
+    const parsed = jsonParse(await readFile(path, 'utf8'))
+    if (
+      parsed &&
+      typeof parsed === 'object' &&
+      typeof (parsed as Partial<BackgroundSessionNameReservation>).name ===
+        'string' &&
+      typeof (parsed as Partial<BackgroundSessionNameReservation>).id ===
+        'string' &&
+      SAFE_ID_RE.test((parsed as BackgroundSessionNameReservation).id)
+    ) {
+      return parsed as BackgroundSessionNameReservation
+    }
+  } catch {
+    // Malformed reservations are treated as occupied below.
+  }
+  return null
+}
+
+async function releaseNameReservation(
+  name: string,
+  id: string,
+): Promise<void> {
+  const path = nameReservationPathForName(name)
+  const existing = await readNameReservation(path)
+  if (existing?.id !== id) return
+  await unlink(path).catch(() => {})
+}
+
+async function reserveBackgroundSessionName(
+  name: string,
+  id: string,
+): Promise<() => Promise<void>> {
+  const path = nameReservationPathForName(name)
+  const reservation = jsonStringify({ name, id })
+
+  try {
+    await writeFile(path, reservation, { flag: 'wx' })
+    return () => releaseNameReservation(name, id)
+  } catch (error) {
+    if (!isErrno(error, 'EEXIST')) throw error
+
+    const existing = await readNameReservation(path)
+    const suffix = existing && existing.name === name ? ` (${existing.id})` : ''
+    throw new Error(`Background session name "${name}" already exists${suffix}`)
+  }
+}
+
 function isStringArray(value: unknown): value is string[] {
   return Array.isArray(value) && value.every(item => typeof item === 'string')
 }
@@ -188,6 +257,7 @@ function isBackgroundSession(
     candidate.id === expectedId &&
     typeof candidate.pid === 'number' &&
     Number.isInteger(candidate.pid) &&
+    candidate.pid > 0 &&
     typeof candidate.cwd === 'string' &&
     typeof candidate.status === 'string' &&
     ALL_STATUSES.has(candidate.status as BackgroundSessionStatus) &&
@@ -241,6 +311,9 @@ export async function assertBackgroundSessionNameAvailable(
 export async function createBackgroundSession(
   input: CreateBackgroundSessionInput,
 ): Promise<BackgroundSession> {
+  if (!Number.isInteger(input.pid) || input.pid <= 0) {
+    throw new Error(`Invalid background session pid: ${input.pid}`)
+  }
   await assertBackgroundSessionNameAvailable(input.name)
   const timestamp = iso(input.now)
   const logPaths = getBackgroundSessionLogPaths(input.id)
@@ -263,7 +336,11 @@ export async function createBackgroundSession(
   await ensureBackgroundSessionDirs()
   let createdStdoutLog = false
   let createdStderrLog = false
+  let releaseReservedName: (() => Promise<void>) | undefined
   try {
+    releaseReservedName = input.name
+      ? await reserveBackgroundSessionName(input.name, input.id)
+      : undefined
     if (input.logFilesPrecreated) {
       if (!(await backgroundSessionLogExists(session.stdoutLogPath))) {
         throw new Error(
@@ -285,6 +362,7 @@ export async function createBackgroundSession(
   } catch (error) {
     if (createdStdoutLog) await unlink(session.stdoutLogPath).catch(() => {})
     if (createdStderrLog) await unlink(session.stderrLogPath).catch(() => {})
+    await releaseReservedName?.()
     if (isErrno(error, 'EEXIST')) {
       throw new Error(`Background session id "${session.id}" already exists`)
     }

--- a/src/cli/bgRegistry.ts
+++ b/src/cli/bgRegistry.ts
@@ -504,6 +504,27 @@ export async function refreshBackgroundSessionStatuses(options?: {
 
 type BackgroundSessionProcessState = 'alive' | 'dead' | 'unknown'
 
+function commandLineContainsArgs(commandLine: string, args: string[]): boolean {
+  if (args.length === 0) return false
+  let offset = 0
+  for (const arg of args) {
+    const index = commandLine.indexOf(arg, offset)
+    if (index === -1) return false
+    offset = index + arg.length
+  }
+  return true
+}
+
+function commandLineMatchesBackgroundSession(
+  commandLine: string,
+  session: BackgroundSession,
+): boolean {
+  if (commandLine.includes(session.sessionId)) return true
+  // PR resume launches write to the resumed transcript id without carrying
+  // that id on argv, so use the stored launch invocation as the PID guard.
+  return commandLineContainsArgs(commandLine, session.command)
+}
+
 function getBackgroundSessionProcessState(
   session: BackgroundSession,
   options?: {
@@ -517,7 +538,7 @@ function getBackgroundSessionProcessState(
   const readCommand = options?.getProcessCommand ?? getProcessCommand
   const command = readCommand(session.pid)
   if (command == null) return 'unknown'
-  return command.includes(session.sessionId) ? 'alive' : 'dead'
+  return commandLineMatchesBackgroundSession(command, session) ? 'alive' : 'dead'
 }
 
 export function isBackgroundSessionProcessAlive(

--- a/src/cli/bgRegistry.ts
+++ b/src/cli/bgRegistry.ts
@@ -57,6 +57,8 @@ export type CreateBackgroundSessionInput = {
 type BackgroundSessionNameReservation = {
   name: string
   id: string
+  creatorPid?: number
+  createdAt?: string
 }
 
 const TERMINAL_STATUSES = new Set<BackgroundSessionStatus>([
@@ -194,19 +196,24 @@ async function readNameReservation(
 ): Promise<BackgroundSessionNameReservation | null> {
   try {
     const parsed = jsonParse(await readFile(path, 'utf8'))
+    const candidate = parsed as Partial<BackgroundSessionNameReservation>
     if (
       parsed &&
       typeof parsed === 'object' &&
-      typeof (parsed as Partial<BackgroundSessionNameReservation>).name ===
-        'string' &&
-      typeof (parsed as Partial<BackgroundSessionNameReservation>).id ===
-        'string' &&
-      SAFE_ID_RE.test((parsed as BackgroundSessionNameReservation).id)
+      typeof candidate.name === 'string' &&
+      typeof candidate.id === 'string' &&
+      SAFE_ID_RE.test(candidate.id) &&
+      (candidate.creatorPid === undefined ||
+        (typeof candidate.creatorPid === 'number' &&
+          Number.isInteger(candidate.creatorPid) &&
+          candidate.creatorPid > 1)) &&
+      (candidate.createdAt === undefined ||
+        typeof candidate.createdAt === 'string')
     ) {
       return parsed as BackgroundSessionNameReservation
     }
   } catch {
-    // Malformed reservations are treated as occupied below.
+    // Malformed reservations are treated as recoverable orphans below.
   }
   return null
 }
@@ -221,22 +228,77 @@ async function releaseNameReservation(
   await unlink(path).catch(() => {})
 }
 
+async function unlinkStaleNameReservation(path: string): Promise<void> {
+  try {
+    await unlink(path)
+  } catch (error) {
+    if (!isErrno(error, 'ENOENT')) throw error
+  }
+}
+
+async function releaseStaleNameReservation(
+  name: string,
+  id: string,
+): Promise<void> {
+  const path = nameReservationPathForName(name)
+  const existing = await readNameReservation(path)
+  if (existing?.id !== id) return
+  await unlinkStaleNameReservation(path)
+}
+
+async function isLiveNameReservation(
+  name: string,
+  reservation: BackgroundSessionNameReservation | null,
+): Promise<boolean> {
+  if (!reservation) return false
+  if (reservation.name !== name) return false
+
+  const owner = await readSessionFile(metadataPathForId(reservation.id))
+  if (owner) {
+    return owner.name === name && !isTerminalBackgroundSession(owner)
+  }
+
+  return (
+    typeof reservation.creatorPid === 'number' &&
+    isProcessRunning(reservation.creatorPid)
+  )
+}
+
 async function reserveBackgroundSessionName(
   name: string,
   id: string,
 ): Promise<() => Promise<void>> {
   const path = nameReservationPathForName(name)
-  const reservation = jsonStringify({ name, id })
+  const reservation = jsonStringify({
+    name,
+    id,
+    creatorPid: process.pid,
+    createdAt: iso(undefined),
+  })
 
-  try {
-    await writeFile(path, reservation, { flag: 'wx' })
-    return () => releaseNameReservation(name, id)
-  } catch (error) {
-    if (!isErrno(error, 'EEXIST')) throw error
+  while (true) {
+    try {
+      await writeFile(path, reservation, { flag: 'wx' })
+      return () => releaseNameReservation(name, id)
+    } catch (error) {
+      if (!isErrno(error, 'EEXIST')) throw error
 
-    const existing = await readNameReservation(path)
-    const suffix = existing && existing.name === name ? ` (${existing.id})` : ''
-    throw new Error(`Background session name "${name}" already exists${suffix}`)
+      const existing = await readNameReservation(path)
+      if (!(await isLiveNameReservation(name, existing))) {
+        if (existing) {
+          await releaseStaleNameReservation(name, existing.id)
+        } else {
+          await unlinkStaleNameReservation(path)
+        }
+        continue
+      }
+
+      const suffix =
+        existing && existing.name === name ? ` (${existing.id})` : ''
+      throw new Error(
+        `Background session name "${name}" already exists${suffix}`,
+      )
+    }
   }
 }
 

--- a/src/cli/bgRegistry.ts
+++ b/src/cli/bgRegistry.ts
@@ -65,8 +65,18 @@ const ALL_STATUSES = new Set<BackgroundSessionStatus>([
   ...TERMINAL_STATUSES,
 ])
 const SAFE_ID_RE = /^[A-Za-z0-9._-]+$/
+let backgroundSessionsRootForTesting: string | undefined
+
+export function _setBackgroundSessionsRootForTesting(
+  root: string | undefined,
+): void {
+  backgroundSessionsRootForTesting = root?.normalize('NFC')
+}
 
 function getBackgroundSessionsRoot(): string {
+  if (backgroundSessionsRootForTesting) {
+    return backgroundSessionsRootForTesting
+  }
   return join(getClaudeConfigHomeDir(), 'bg-sessions')
 }
 

--- a/src/cli/print.ts
+++ b/src/cli/print.ts
@@ -68,6 +68,7 @@ import type { Stream } from 'src/utils/stream.js'
 import { EMPTY_USAGE } from 'src/services/api/logging.js'
 import {
   loadConversationForResume,
+  loadConversationForResumeFromPr,
   type TurnInterruptionState,
 } from 'src/utils/conversationRecovery.js'
 import type {
@@ -455,6 +456,7 @@ export async function runHeadless(
   options: {
     continue: boolean | undefined
     resume: string | boolean | undefined
+    fromPr: string | boolean | undefined
     resumeSessionAt: string | undefined
     verbose: boolean | undefined
     outputFormat: string | undefined
@@ -687,6 +689,7 @@ export async function runHeadless(
     continue: options.continue,
     teleport: options.teleport,
     resume: options.resume,
+    fromPr: options.fromPr,
     resumeSessionAt: options.resumeSessionAt,
     forkSession: options.forkSession,
     outputFormat: options.outputFormat,
@@ -4909,6 +4912,7 @@ async function loadInitialMessages(
     continue: boolean | undefined
     teleport: string | true | null | undefined
     resume: string | boolean | undefined
+    fromPr: string | boolean | undefined
     resumeSessionAt: string | undefined
     forkSession: boolean | undefined
     outputFormat: string | undefined
@@ -5037,62 +5041,82 @@ async function loadInitialMessages(
     }
   }
 
-  // Handle resume in print mode (accepts session ID or URL)
+  // Handle resume in print mode (accepts session ID, URL, or PR selector)
   // URLs are [internal-only]
-  if (options.resume) {
+  if (options.resume || options.fromPr) {
     try {
-      logEvent('tengu_resume_print', {})
+      let result: Awaited<ReturnType<typeof loadConversationForResume>> = null
+      let parsedSessionId: ReturnType<typeof parseSessionIdentifier> = null
 
-      // In print mode - we require a valid session ID, JSONL file or URL
-      const parsedSessionId = parseSessionIdentifier(
-        typeof options.resume === 'string' ? options.resume : '',
-      )
-      if (!parsedSessionId) {
-        let errorMessage =
-          'Error: --resume requires a valid session ID when used with --print. Usage: openclaude -p --resume <session-id>'
-        if (typeof options.resume === 'string') {
-          errorMessage += `. Session IDs must be in UUID format (e.g., 550e8400-e29b-41d4-a716-446655440000). Provided value "${options.resume}" is not a valid UUID`
-        }
-        emitLoadError(errorMessage, options.outputFormat)
-        gracefulShutdownSync(1)
-        return { messages: [] }
-      }
+      if (options.resume) {
+        logEvent('tengu_resume_print', {})
 
-      // Hydrate local transcript from remote before loading
-      if (isEnvTruthy(process.env.CLAUDE_CODE_USE_CCR_V2)) {
-        // Await restore alongside hydration so SSE catchup lands on
-        // restored state, not a fresh default.
-        const [, metadata] = await Promise.all([
-          hydrateFromCCRv2InternalEvents(parsedSessionId.sessionId),
-          options.restoredWorkerState,
-        ])
-        if (metadata) {
-          const sanitizedMetadata = await sanitizeResumedExternalMetadata(
-            metadata,
-            options.getAppState().toolPermissionContext,
-          )
-          setAppState(externalMetadataToAppState(sanitizedMetadata))
-          if (typeof metadata.model === 'string') {
-            setMainLoopModelOverride(metadata.model)
-          }
-        }
-      } else if (
-        parsedSessionId.isUrl &&
-        parsedSessionId.ingressUrl &&
-        isEnvTruthy(process.env.ENABLE_SESSION_PERSISTENCE)
-      ) {
-        // v1: fetch session logs from Session Ingress
-        await hydrateRemoteSession(
-          parsedSessionId.sessionId,
-          parsedSessionId.ingressUrl,
+        // In print mode - we require a valid session ID, JSONL file or URL
+        parsedSessionId = parseSessionIdentifier(
+          typeof options.resume === 'string' ? options.resume : '',
         )
-      }
+        if (!parsedSessionId) {
+          let errorMessage =
+            'Error: --resume requires a valid session ID when used with --print. Usage: openclaude -p --resume <session-id>'
+          if (typeof options.resume === 'string') {
+            errorMessage += `. Session IDs must be in UUID format (e.g., 550e8400-e29b-41d4-a716-446655440000). Provided value "${options.resume}" is not a valid UUID`
+          }
+          emitLoadError(errorMessage, options.outputFormat)
+          gracefulShutdownSync(1)
+          return { messages: [] }
+        }
 
-      // Load the conversation with the specified session ID
-      const result = await loadConversationForResume(
-        parsedSessionId.sessionId,
-        parsedSessionId.jsonlFile || undefined,
-      )
+        // Hydrate local transcript from remote before loading
+        if (isEnvTruthy(process.env.CLAUDE_CODE_USE_CCR_V2)) {
+          // Await restore alongside hydration so SSE catchup lands on
+          // restored state, not a fresh default.
+          const [, metadata] = await Promise.all([
+            hydrateFromCCRv2InternalEvents(parsedSessionId.sessionId),
+            options.restoredWorkerState,
+          ])
+          if (metadata) {
+            const sanitizedMetadata = await sanitizeResumedExternalMetadata(
+              metadata,
+              options.getAppState().toolPermissionContext,
+            )
+            setAppState(externalMetadataToAppState(sanitizedMetadata))
+            if (typeof metadata.model === 'string') {
+              setMainLoopModelOverride(metadata.model)
+            }
+          }
+        } else if (
+          parsedSessionId.isUrl &&
+          parsedSessionId.ingressUrl &&
+          isEnvTruthy(process.env.ENABLE_SESSION_PERSISTENCE)
+        ) {
+          // v1: fetch session logs from Session Ingress
+          await hydrateRemoteSession(
+            parsedSessionId.sessionId,
+            parsedSessionId.ingressUrl,
+          )
+        }
+
+        // Load the conversation with the specified session ID
+        result = await loadConversationForResume(
+          parsedSessionId.sessionId,
+          parsedSessionId.jsonlFile || undefined,
+        )
+      } else if (options.fromPr) {
+        logEvent('tengu_resume_from_pr_print', {})
+        const selector =
+          options.fromPr === true ? true : String(options.fromPr)
+        result = await loadConversationForResumeFromPr(selector)
+        if (!result || result.messages.length === 0) {
+          const description =
+            selector === true ? 'any PR' : `PR selector: ${selector}`
+          emitLoadError(
+            `No conversation found linked to ${description}`,
+            options.outputFormat,
+          )
+          gracefulShutdownSync(1)
+          return { messages: [] }
+        }
+      }
 
       // hydrateFromCCRv2InternalEvents writes an empty transcript file for
       // fresh sessions (writeFile(sessionFile, '') with zero events), so
@@ -5101,7 +5125,7 @@ async function loadInitialMessages(
       if (!result || result.messages.length === 0) {
         // For URL-based or CCR v2 resume, start with empty session (it was hydrated but empty)
         if (
-          parsedSessionId.isUrl ||
+          parsedSessionId?.isUrl ||
           isEnvTruthy(process.env.CLAUDE_CODE_USE_CCR_V2)
         ) {
           // Execute SessionStart hooks for startup since we're starting a new session
@@ -5111,7 +5135,9 @@ async function loadInitialMessages(
           }
         } else {
           emitLoadError(
-            `No conversation found with session ID: ${parsedSessionId.sessionId}`,
+            parsedSessionId
+              ? `No conversation found with session ID: ${parsedSessionId.sessionId}`
+              : 'No conversation found for selected PR-linked session',
             options.outputFormat,
           )
           gracefulShutdownSync(1)

--- a/src/cli/print.ts
+++ b/src/cli/print.ts
@@ -565,14 +565,20 @@ export async function runHeadless(
   // Without this, the disk cache is empty and all flags fall back to defaults.
   void initializeGrowthBook()
 
-  if (options.resumeSessionAt && !options.resume) {
-    process.stderr.write(`Error: --resume-session-at requires --resume\n`)
+  const hasRequestedResumeSource = Boolean(options.resume || options.fromPr)
+
+  if (options.resumeSessionAt && !hasRequestedResumeSource) {
+    process.stderr.write(
+      `Error: --resume-session-at requires --resume or --from-pr\n`,
+    )
     gracefulShutdownSync(1)
     return
   }
 
-  if (options.rewindFiles && !options.resume) {
-    process.stderr.write(`Error: --rewind-files requires --resume\n`)
+  if (options.rewindFiles && !hasRequestedResumeSource) {
+    process.stderr.write(
+      `Error: --rewind-files requires --resume or --from-pr\n`,
+    )
     gracefulShutdownSync(1)
     return
   }
@@ -777,9 +783,11 @@ export async function runHeadless(
   const hasValidResumeSessionId =
     typeof options.resume === 'string' &&
     (Boolean(validateUuid(options.resume)) || options.resume.endsWith('.jsonl'))
+  const hasValidResumeSource =
+    hasValidResumeSessionId || Boolean(options.fromPr)
   const isUsingSdkUrl = Boolean(options.sdkUrl)
 
-  if (!inputPrompt && !hasValidResumeSessionId && !isUsingSdkUrl) {
+  if (!inputPrompt && !hasValidResumeSource && !isUsingSdkUrl) {
     process.stderr.write(
       `Error: Input must be provided either through stdin or as a prompt argument when using --print\n`,
     )

--- a/src/entrypoints/cli.test.ts
+++ b/src/entrypoints/cli.test.ts
@@ -86,15 +86,35 @@ describe('cli.tsx — --provider startup ordering', () => {
     expect(configReapplyIndex).toBeGreaterThan(configApplyIndex)
   })
 
-  it('dispatches background session management before provider validation', async () => {
+  it('dispatches background session management before config and provider validation', async () => {
     const src = await Bun.file(`${import.meta.dir}/cli.tsx`).text()
-    const bgFastPathIndex = src.indexOf("await import('../cli/bg.js')")
+    const bgManagementIndex = src.indexOf("args[0] === 'ps'")
+    const configEnableIndex = src.indexOf('enableConfigs()')
     const providerValidationIndex = src.indexOf(
       'await validateProviderEnvForStartupOrExit()',
     )
 
-    expect(bgFastPathIndex).toBeGreaterThanOrEqual(0)
+    expect(bgManagementIndex).toBeGreaterThanOrEqual(0)
+    expect(configEnableIndex).toBeGreaterThanOrEqual(0)
     expect(providerValidationIndex).toBeGreaterThanOrEqual(0)
-    expect(bgFastPathIndex).toBeLessThan(providerValidationIndex)
+    expect(bgManagementIndex).toBeLessThan(configEnableIndex)
+    expect(bgManagementIndex).toBeLessThan(providerValidationIndex)
+  })
+
+  it('keeps background spawn after profile routing but before provider validation', async () => {
+    const src = await Bun.file(`${import.meta.dir}/cli.tsx`).text()
+    const profileApplyIndex = src.indexOf(
+      'applyProfileEnvToProcessEnv(process.env, startupEnv)',
+    )
+    const bgFlagIndex = src.indexOf("args.includes('--bg')")
+    const providerValidationIndex = src.indexOf(
+      'await validateProviderEnvForStartupOrExit()',
+    )
+
+    expect(profileApplyIndex).toBeGreaterThanOrEqual(0)
+    expect(bgFlagIndex).toBeGreaterThanOrEqual(0)
+    expect(providerValidationIndex).toBeGreaterThanOrEqual(0)
+    expect(bgFlagIndex).toBeGreaterThan(profileApplyIndex)
+    expect(bgFlagIndex).toBeLessThan(providerValidationIndex)
   })
 })

--- a/src/entrypoints/cli.test.ts
+++ b/src/entrypoints/cli.test.ts
@@ -106,7 +106,7 @@ describe('cli.tsx — --provider startup ordering', () => {
     const profileApplyIndex = src.indexOf(
       'applyProfileEnvToProcessEnv(process.env, startupEnv)',
     )
-    const bgFlagIndex = src.indexOf("args.includes('--bg')")
+    const bgFlagIndex = src.indexOf("optionArgs.includes('--bg')")
     const providerValidationIndex = src.indexOf(
       'await validateProviderEnvForStartupOrExit()',
     )
@@ -116,5 +116,24 @@ describe('cli.tsx — --provider startup ordering', () => {
     expect(providerValidationIndex).toBeGreaterThanOrEqual(0)
     expect(bgFlagIndex).toBeGreaterThan(profileApplyIndex)
     expect(bgFlagIndex).toBeLessThan(providerValidationIndex)
+  })
+
+  it('checks background spawn flags only before the -- delimiter', async () => {
+    const src = await Bun.file(`${import.meta.dir}/cli.tsx`).text()
+    const helperIndex = src.indexOf('function argsBeforeDelimiter')
+    const optionArgsIndex = src.indexOf(
+      'const optionArgs = argsBeforeDelimiter(args)',
+    )
+    const bgFlagIndex = src.indexOf("optionArgs.includes('--bg')")
+    const backgroundFlagIndex = src.indexOf(
+      "optionArgs.includes('--background')",
+    )
+
+    expect(helperIndex).toBeGreaterThanOrEqual(0)
+    expect(optionArgsIndex).toBeGreaterThan(helperIndex)
+    expect(bgFlagIndex).toBeGreaterThan(optionArgsIndex)
+    expect(backgroundFlagIndex).toBeGreaterThan(optionArgsIndex)
+    expect(src).not.toContain("args.includes('--bg')")
+    expect(src).not.toContain("args.includes('--background')")
   })
 })

--- a/src/entrypoints/cli.test.ts
+++ b/src/entrypoints/cli.test.ts
@@ -3,7 +3,84 @@
  * Closes: Gitlawb/openclaude#402 — JavaScript heap OOM during large tasks
  */
 
-import { describe, it, expect, beforeEach, afterEach } from 'bun:test'
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  mock,
+} from 'bun:test'
+
+type CliMain = typeof import('./cli.js')['main']
+
+let runCliEntrypoint: CliMain
+
+const mockProfileCheckpoint = mock((_checkpoint: string) => {})
+const mockPsHandler = mock(async (_args: string[]) => {})
+const mockLogsHandler = mock(async (_args: string[]) => {})
+const mockAttachHandler = mock(async (_args: string[]) => {})
+const mockKillHandler = mock(async (_args: string[]) => {})
+const mockHandleBgFlag = mock(async (_args: string[]) => {})
+const mockEnableConfigs = mock(() => {})
+const mockApplySafeConfigEnvironmentVariables = mock(() => {})
+const mockBuildStartupEnvFromProfile = mock(
+  async (_input: { processEnv: NodeJS.ProcessEnv }) => process.env,
+)
+const mockIsDefaultStartupProviderEnv = mock(
+  (_env: NodeJS.ProcessEnv) => true,
+)
+const mockApplyProfileEnvToProcessEnv = mock(
+  (_target: NodeJS.ProcessEnv, _source: NodeJS.ProcessEnv) => {},
+)
+const mockGetProviderValidationError = mock(
+  async (_env: NodeJS.ProcessEnv) => undefined,
+)
+const mockEagerLoadSettingsFromArgs = mock((_args: string[]) => ({ ok: true }))
+const mockResolveOutOfProcessTeammateProviderFromCliArgs = mock(
+  (_args: string[], _settings: unknown) => undefined,
+)
+const mockApplyAgentProviderOverrideToEnv = mock((_override: unknown) => {})
+const mockGetInitialSettings = mock(() => ({}))
+const mockRefreshGithubModelsTokenIfNeeded = mock(async () => {})
+const mockHydrateGithubModelsTokenFromSecureStorage = mock(() => {})
+const mockValidateProviderEnvForStartupOrExit = mock(async () => {})
+const mockPrintStartupScreen = mock((_model: string | undefined) => {})
+const mockStartCapturingEarlyInput = mock(() => {})
+const mockCliMain = mock(async () => {})
+
+const runtimeMocks = [
+  mockProfileCheckpoint,
+  mockPsHandler,
+  mockLogsHandler,
+  mockAttachHandler,
+  mockKillHandler,
+  mockHandleBgFlag,
+  mockEnableConfigs,
+  mockApplySafeConfigEnvironmentVariables,
+  mockBuildStartupEnvFromProfile,
+  mockIsDefaultStartupProviderEnv,
+  mockApplyProfileEnvToProcessEnv,
+  mockGetProviderValidationError,
+  mockEagerLoadSettingsFromArgs,
+  mockResolveOutOfProcessTeammateProviderFromCliArgs,
+  mockApplyAgentProviderOverrideToEnv,
+  mockGetInitialSettings,
+  mockRefreshGithubModelsTokenIfNeeded,
+  mockHydrateGithubModelsTokenFromSecureStorage,
+  mockValidateProviderEnvForStartupOrExit,
+  mockPrintStartupScreen,
+  mockStartCapturingEarlyInput,
+  mockCliMain,
+]
+
+function clearRuntimeMocks() {
+  for (const fn of runtimeMocks) {
+    fn.mockClear()
+  }
+}
 
 describe('cli.tsx — NODE_OPTIONS --max-old-space-size (issue #402)', () => {
   const originalNodeOptions = process.env.NODE_OPTIONS
@@ -118,26 +195,158 @@ describe('cli.tsx — --provider startup ordering', () => {
     expect(bgFlagIndex).toBeLessThan(providerValidationIndex)
   })
 
-  it('checks background spawn flags only before the -- delimiter', async () => {
-    const src = await Bun.file(`${import.meta.dir}/cli.tsx`).text()
-    const optionArgsIndex = src.indexOf(
-      'const optionArgs = argsBeforeDelimiter(args)',
-    )
-    const helperImportIndex = src.lastIndexOf(
-      "await import('../utils/cliArgs.js')",
-      optionArgsIndex,
-    )
-    const bgFlagIndex = src.indexOf("optionArgs.includes('--bg')")
-    const backgroundFlagIndex = src.indexOf(
-      "optionArgs.includes('--background')",
-    )
+})
 
-    expect(helperImportIndex).toBeGreaterThanOrEqual(0)
-    expect(optionArgsIndex).toBeGreaterThan(helperImportIndex)
-    expect(bgFlagIndex).toBeGreaterThan(optionArgsIndex)
-    expect(backgroundFlagIndex).toBeGreaterThan(optionArgsIndex)
-    expect(src).not.toContain('function argsBeforeDelimiter')
-    expect(src).not.toContain("args.includes('--bg')")
-    expect(src).not.toContain("args.includes('--background')")
+describe('cli.tsx — background routing behavior', () => {
+  const bgOptions = {
+    bgSessionsEnabled: true,
+    importers: {
+      startupProfiler: async () => ({
+        profileCheckpoint: mockProfileCheckpoint,
+      }),
+      bg: async () => ({
+        psHandler: mockPsHandler,
+        logsHandler: mockLogsHandler,
+        attachHandler: mockAttachHandler,
+        killHandler: mockKillHandler,
+        handleBgFlag: mockHandleBgFlag,
+      }),
+      config: async () => ({
+        enableConfigs: mockEnableConfigs,
+      }),
+      managedEnv: async () => ({
+        applySafeConfigEnvironmentVariables:
+          mockApplySafeConfigEnvironmentVariables,
+      }),
+      providerProfile: async () => ({
+        applyProfileEnvToProcessEnv: mockApplyProfileEnvToProcessEnv,
+        buildStartupEnvFromProfile: mockBuildStartupEnvFromProfile,
+        isDefaultStartupProviderEnv: mockIsDefaultStartupProviderEnv,
+      }),
+      providerValidation: async () => ({
+        getProviderValidationError: mockGetProviderValidationError,
+        validateProviderEnvForStartupOrExit:
+          mockValidateProviderEnvForStartupOrExit,
+      }),
+      flagSettings: async () => ({
+        eagerLoadSettingsFromArgs: mockEagerLoadSettingsFromArgs,
+      }),
+      agentRouting: async () => ({
+        applyAgentProviderOverrideToEnv: mockApplyAgentProviderOverrideToEnv,
+        resolveOutOfProcessTeammateProviderFromCliArgs:
+          mockResolveOutOfProcessTeammateProviderFromCliArgs,
+      }),
+      settings: async () => ({
+        getInitialSettings: mockGetInitialSettings,
+      }),
+      githubModelsCredentials: async () => ({
+        hydrateGithubModelsTokenFromSecureStorage:
+          mockHydrateGithubModelsTokenFromSecureStorage,
+        refreshGithubModelsTokenIfNeeded: mockRefreshGithubModelsTokenIfNeeded,
+      }),
+      startupScreen: async () => ({
+        printStartupScreen: mockPrintStartupScreen,
+      }),
+      earlyInput: async () => ({
+        startCapturingEarlyInput: mockStartCapturingEarlyInput,
+      }),
+      main: async () => ({
+        main: mockCliMain,
+      }),
+    },
+  } as unknown as Parameters<CliMain>[1]
+  const originalAutoRunGuard =
+    process.env.OPENCLAUDE_DISABLE_CLI_ENTRYPOINT_AUTO_RUN
+
+  beforeAll(async () => {
+    process.env.OPENCLAUDE_DISABLE_CLI_ENTRYPOINT_AUTO_RUN = '1'
+
+    const entrypoint = await import('./cli.js')
+    runCliEntrypoint = entrypoint.main
+  })
+
+  afterAll(() => {
+    if (originalAutoRunGuard === undefined) {
+      delete process.env.OPENCLAUDE_DISABLE_CLI_ENTRYPOINT_AUTO_RUN
+    } else {
+      process.env.OPENCLAUDE_DISABLE_CLI_ENTRYPOINT_AUTO_RUN =
+        originalAutoRunGuard
+    }
+  })
+
+  beforeEach(() => {
+    clearRuntimeMocks()
+  })
+
+  it('dispatches background management commands before startup work', async () => {
+    const cases: Array<[string, typeof mockPsHandler, string[]]> = [
+      ['ps', mockPsHandler, ['--json']],
+      ['logs', mockLogsHandler, ['session-1', '-f']],
+      ['attach', mockAttachHandler, ['session-1']],
+      ['kill', mockKillHandler, ['session-1']],
+    ]
+
+    for (const [command, handler, tail] of cases) {
+      clearRuntimeMocks()
+
+      await runCliEntrypoint([command, ...tail], bgOptions)
+
+      expect(handler.mock.calls).toEqual([[tail]])
+      expect(mockHandleBgFlag).not.toHaveBeenCalled()
+      expect(mockEnableConfigs).not.toHaveBeenCalled()
+      expect(mockValidateProviderEnvForStartupOrExit).not.toHaveBeenCalled()
+      expect(mockCliMain).not.toHaveBeenCalled()
+    }
+  })
+
+  it('keeps management commands on the management path even with --bg arguments', async () => {
+    const cases: Array<[string, typeof mockPsHandler]> = [
+      ['ps', mockPsHandler],
+      ['logs', mockLogsHandler],
+      ['attach', mockAttachHandler],
+      ['kill', mockKillHandler],
+    ]
+
+    for (const [command, handler] of cases) {
+      clearRuntimeMocks()
+
+      await runCliEntrypoint([command, '--bg', 'session-1'], bgOptions)
+
+      expect(handler.mock.calls).toEqual([[['--bg', 'session-1']]])
+      expect(mockHandleBgFlag).not.toHaveBeenCalled()
+      expect(mockEnableConfigs).not.toHaveBeenCalled()
+      expect(mockValidateProviderEnvForStartupOrExit).not.toHaveBeenCalled()
+      expect(mockCliMain).not.toHaveBeenCalled()
+    }
+  })
+
+  it('routes real background flags after profile routing without provider validation', async () => {
+    const args = ['--background', '--', '--print']
+
+    await runCliEntrypoint(args, bgOptions)
+
+    expect(mockEnableConfigs).toHaveBeenCalledTimes(1)
+    expect(mockApplySafeConfigEnvironmentVariables).toHaveBeenCalledTimes(1)
+    expect(mockBuildStartupEnvFromProfile).toHaveBeenCalledTimes(1)
+    expect(mockEagerLoadSettingsFromArgs.mock.calls).toEqual([[args]])
+    expect(mockHandleBgFlag.mock.calls).toEqual([[args]])
+    expect(mockRefreshGithubModelsTokenIfNeeded).not.toHaveBeenCalled()
+    expect(mockValidateProviderEnvForStartupOrExit).not.toHaveBeenCalled()
+    expect(mockCliMain).not.toHaveBeenCalled()
+  })
+
+  it('treats --bg after -- as positional text, not a background flag', async () => {
+    const args = ['--', '--bg']
+
+    await runCliEntrypoint(args, bgOptions)
+
+    expect(mockHandleBgFlag).not.toHaveBeenCalled()
+    expect(mockRefreshGithubModelsTokenIfNeeded).toHaveBeenCalledTimes(1)
+    expect(mockHydrateGithubModelsTokenFromSecureStorage).toHaveBeenCalledTimes(
+      1,
+    )
+    expect(mockValidateProviderEnvForStartupOrExit).toHaveBeenCalledTimes(1)
+    expect(mockPrintStartupScreen).toHaveBeenCalledTimes(1)
+    expect(mockCliMain).toHaveBeenCalledTimes(1)
   })
 })

--- a/src/entrypoints/cli.test.ts
+++ b/src/entrypoints/cli.test.ts
@@ -120,19 +120,23 @@ describe('cli.tsx — --provider startup ordering', () => {
 
   it('checks background spawn flags only before the -- delimiter', async () => {
     const src = await Bun.file(`${import.meta.dir}/cli.tsx`).text()
-    const helperIndex = src.indexOf('function argsBeforeDelimiter')
     const optionArgsIndex = src.indexOf(
       'const optionArgs = argsBeforeDelimiter(args)',
+    )
+    const helperImportIndex = src.lastIndexOf(
+      "await import('../utils/cliArgs.js')",
+      optionArgsIndex,
     )
     const bgFlagIndex = src.indexOf("optionArgs.includes('--bg')")
     const backgroundFlagIndex = src.indexOf(
       "optionArgs.includes('--background')",
     )
 
-    expect(helperIndex).toBeGreaterThanOrEqual(0)
-    expect(optionArgsIndex).toBeGreaterThan(helperIndex)
+    expect(helperImportIndex).toBeGreaterThanOrEqual(0)
+    expect(optionArgsIndex).toBeGreaterThan(helperImportIndex)
     expect(bgFlagIndex).toBeGreaterThan(optionArgsIndex)
     expect(backgroundFlagIndex).toBeGreaterThan(optionArgsIndex)
+    expect(src).not.toContain('function argsBeforeDelimiter')
     expect(src).not.toContain("args.includes('--bg')")
     expect(src).not.toContain("args.includes('--background')")
   })

--- a/src/entrypoints/cli.test.ts
+++ b/src/entrypoints/cli.test.ts
@@ -85,4 +85,16 @@ describe('cli.tsx — --provider startup ordering', () => {
     expect(safeReapplyIndex).toBeLessThan(configApplyIndex)
     expect(configReapplyIndex).toBeGreaterThan(configApplyIndex)
   })
+
+  it('dispatches background session management before provider validation', async () => {
+    const src = await Bun.file(`${import.meta.dir}/cli.tsx`).text()
+    const bgFastPathIndex = src.indexOf("await import('../cli/bg.js')")
+    const providerValidationIndex = src.indexOf(
+      'await validateProviderEnvForStartupOrExit()',
+    )
+
+    expect(bgFastPathIndex).toBeGreaterThanOrEqual(0)
+    expect(providerValidationIndex).toBeGreaterThanOrEqual(0)
+    expect(bgFastPathIndex).toBeLessThan(providerValidationIndex)
+  })
 })

--- a/src/entrypoints/cli.tsx
+++ b/src/entrypoints/cli.tsx
@@ -78,6 +78,32 @@ async function main(): Promise<void> {
     return;
   }
 
+  // Fast-path for `openclaude ps|logs|attach|kill`.
+  // Session management is entirely local, so it should not require config,
+  // profile, credential, provider-validation, or startup-screen work.
+  if (feature('BG_SESSIONS') && (args[0] === 'ps' || args[0] === 'logs' || args[0] === 'attach' || args[0] === 'kill')) {
+    const {
+      profileCheckpoint
+    } = await import('../utils/startupProfiler.js');
+    profileCheckpoint('cli_bg_path');
+    const bg = await import('../cli/bg.js');
+    switch (args[0]) {
+      case 'ps':
+        await bg.psHandler(args.slice(1));
+        break;
+      case 'logs':
+        await bg.logsHandler(args.slice(1));
+        break;
+      case 'attach':
+        await bg.attachHandler(args.slice(1));
+        break;
+      case 'kill':
+        await bg.killHandler(args.slice(1));
+        break;
+    }
+    return;
+  }
+
   // --provider: set provider env vars early so saved-profile resolution,
   // validation, and the startup banner all see the intended provider/model.
   if (args.includes('--provider')) {
@@ -158,32 +184,15 @@ async function main(): Promise<void> {
     }
   }
 
-  // Fast-path for `claude ps|logs|attach|kill` and `--bg`/`--background`.
-  // Session management is local and must not depend on provider validation or
-  // startup-screen rendering. Flag literals are inlined so bg.js only loads
-  // when actually dispatching.
-  if (feature('BG_SESSIONS') && (args[0] === 'ps' || args[0] === 'logs' || args[0] === 'attach' || args[0] === 'kill' || args.includes('--bg') || args.includes('--background'))) {
+  // Fast-path for `--bg`/`--background` after profile routing has been applied
+  // so the spawned child inherits the selected provider/model environment.
+  if (feature('BG_SESSIONS') && (args.includes('--bg') || args.includes('--background'))) {
     const {
       profileCheckpoint
     } = await import('../utils/startupProfiler.js');
     profileCheckpoint('cli_bg_path');
     const bg = await import('../cli/bg.js');
-    switch (args[0]) {
-      case 'ps':
-        await bg.psHandler(args.slice(1));
-        break;
-      case 'logs':
-        await bg.logsHandler(args.slice(1));
-        break;
-      case 'attach':
-        await bg.attachHandler(args.slice(1));
-        break;
-      case 'kill':
-        await bg.killHandler(args.slice(1));
-        break;
-      default:
-        await bg.handleBgFlag(args);
-    }
+    await bg.handleBgFlag(args);
     return;
   }
 

--- a/src/entrypoints/cli.tsx
+++ b/src/entrypoints/cli.tsx
@@ -67,6 +67,11 @@ if (feature('ABLATION_BASELINE') && process.env.CLAUDE_CODE_ABLATION_BASELINE) {
  * All imports are dynamic to minimize module evaluation for fast paths.
  * Fast-path for --version has zero imports beyond this file.
  */
+function argsBeforeDelimiter(args: string[]): string[] {
+  const delimiterIndex = args.indexOf('--')
+  return delimiterIndex === -1 ? args : args.slice(0, delimiterIndex)
+}
+
 async function main(): Promise<void> {
   const args = process.argv.slice(2);
 
@@ -186,7 +191,11 @@ async function main(): Promise<void> {
 
   // Fast-path for `--bg`/`--background` after profile routing has been applied
   // so the spawned child inherits the selected provider/model environment.
-  if (feature('BG_SESSIONS') && (args.includes('--bg') || args.includes('--background'))) {
+  const optionArgs = argsBeforeDelimiter(args)
+  if (
+    feature('BG_SESSIONS') &&
+    (optionArgs.includes('--bg') || optionArgs.includes('--background'))
+  ) {
     const {
       profileCheckpoint
     } = await import('../utils/startupProfiler.js');

--- a/src/entrypoints/cli.tsx
+++ b/src/entrypoints/cli.tsx
@@ -67,8 +67,77 @@ if (feature('ABLATION_BASELINE') && process.env.CLAUDE_CODE_ABLATION_BASELINE) {
  * All imports are dynamic to minimize module evaluation for fast paths.
  * Fast-path for --version has zero imports beyond this file.
  */
-async function main(): Promise<void> {
-  const args = process.argv.slice(2);
+type CliEntrypointOptions = {
+  bgSessionsEnabled?: boolean
+  importers?: Partial<CliEntrypointImporters>
+}
+
+type CliEntrypointImporters = {
+  startupProfiler: () => Promise<typeof import('../utils/startupProfiler.js')>
+  bg: () => Promise<typeof import('../cli/bg.js')>
+  providerFlag: () => Promise<typeof import('../utils/providerFlag.js')>
+  config: () => Promise<typeof import('../utils/config.js')>
+  managedEnv: () => Promise<typeof import('../utils/managedEnv.js')>
+  providerProfile: () => Promise<typeof import('../utils/providerProfile.js')>
+  providerValidation: () => Promise<
+    typeof import('../utils/providerValidation.js')
+  >
+  flagSettings: () => Promise<
+    typeof import('../utils/settings/flagSettings.js')
+  >
+  agentRouting: () => Promise<
+    typeof import('../services/api/agentRouting.js')
+  >
+  settings: () => Promise<typeof import('../utils/settings/settings.js')>
+  cliArgs: () => Promise<typeof import('../utils/cliArgs.js')>
+  githubModelsCredentials: () => Promise<
+    typeof import('../utils/githubModelsCredentials.js')
+  >
+  startupScreen: () => Promise<typeof import('../components/StartupScreen.js')>
+  earlyInput: () => Promise<typeof import('../utils/earlyInput.js')>
+  main: () => Promise<typeof import('../main.js')>
+}
+
+const defaultCliEntrypointImporters: CliEntrypointImporters = {
+  startupProfiler: () => import('../utils/startupProfiler.js'),
+  bg: () => import('../cli/bg.js'),
+  providerFlag: () => import('../utils/providerFlag.js'),
+  config: () => import('../utils/config.js'),
+  managedEnv: () => import('../utils/managedEnv.js'),
+  providerProfile: () => import('../utils/providerProfile.js'),
+  providerValidation: () => import('../utils/providerValidation.js'),
+  flagSettings: () => import('../utils/settings/flagSettings.js'),
+  agentRouting: () => import('../services/api/agentRouting.js'),
+  settings: () => import('../utils/settings/settings.js'),
+  cliArgs: () => import('../utils/cliArgs.js'),
+  githubModelsCredentials: () =>
+    import('../utils/githubModelsCredentials.js'),
+  startupScreen: () => import('../components/StartupScreen.js'),
+  earlyInput: () => import('../utils/earlyInput.js'),
+  main: () => import('../main.js'),
+}
+
+function getCliEntrypointImporters(
+  overrides: Partial<CliEntrypointImporters> | undefined,
+): CliEntrypointImporters {
+  return {
+    ...defaultCliEntrypointImporters,
+    ...overrides,
+  }
+}
+
+function isBgSessionsEnabled(options: CliEntrypointOptions): boolean {
+  if (options.bgSessionsEnabled !== undefined) return options.bgSessionsEnabled
+  if (feature('BG_SESSIONS')) return true
+  return false
+}
+
+export async function main(
+  args: string[] = process.argv.slice(2),
+  options: CliEntrypointOptions = {},
+): Promise<void> {
+  const bgSessionsEnabled = isBgSessionsEnabled(options)
+  const importers = getCliEntrypointImporters(options.importers)
 
   // Fast-path for --version/-v: zero module loading needed
   if (args.length === 1 && (args[0] === '--version' || args[0] === '-v' || args[0] === '-V')) {
@@ -81,12 +150,12 @@ async function main(): Promise<void> {
   // Fast-path for `openclaude ps|logs|attach|kill`.
   // Session management is entirely local, so it should not require config,
   // profile, credential, provider-validation, or startup-screen work.
-  if (feature('BG_SESSIONS') && (args[0] === 'ps' || args[0] === 'logs' || args[0] === 'attach' || args[0] === 'kill')) {
+  if (bgSessionsEnabled && (args[0] === 'ps' || args[0] === 'logs' || args[0] === 'attach' || args[0] === 'kill')) {
     const {
       profileCheckpoint
-    } = await import('../utils/startupProfiler.js');
+    } = await importers.startupProfiler();
     profileCheckpoint('cli_bg_path');
-    const bg = await import('../cli/bg.js');
+    const bg = await importers.bg();
     switch (args[0]) {
       case 'ps':
         await bg.psHandler(args.slice(1));
@@ -107,7 +176,7 @@ async function main(): Promise<void> {
   // --provider: set provider env vars early so saved-profile resolution,
   // validation, and the startup banner all see the intended provider/model.
   if (args.includes('--provider')) {
-    const { applyProviderFlagFromArgs } = await import('../utils/providerFlag.js');
+    const { applyProviderFlagFromArgs } = await importers.providerFlag();
     const result = applyProviderFlagFromArgs(args, {
       rememberForSettingsEnv: true,
     });
@@ -120,13 +189,14 @@ async function main(): Promise<void> {
 
   // Enable configs first so we can read settings
   {
-    const { enableConfigs } = await import('../utils/config.js')
+    const { enableConfigs } = await importers.config()
     enableConfigs()
   }
 
   // Apply settings.env from user settings (includes GitHub provider settings from /onboard-github)
   {
-    const { applySafeConfigEnvironmentVariables } = await import('../utils/managedEnv.js')
+    const { applySafeConfigEnvironmentVariables } =
+      await importers.managedEnv()
     applySafeConfigEnvironmentVariables()
   }
 
@@ -134,14 +204,13 @@ async function main(): Promise<void> {
     applyProfileEnvToProcessEnv,
     buildStartupEnvFromProfile,
     isDefaultStartupProviderEnv,
-  } = await import('../utils/providerProfile.js')
+  } = await importers.providerProfile()
   const startupEnv = await buildStartupEnvFromProfile({
     processEnv: process.env,
   })
   if (startupEnv !== process.env) {
-    const { getProviderValidationError } = await import(
-      '../utils/providerValidation.js'
-    )
+    const { getProviderValidationError } =
+      await importers.providerValidation()
     const startupProfileError = await getProviderValidationError(startupEnv)
     if (startupProfileError && !isDefaultStartupProviderEnv(startupEnv)) {
       console.error(
@@ -156,9 +225,7 @@ async function main(): Promise<void> {
   // selected a configured agentModels key, apply that route before provider
   // validation and --model env routing run in this child process.
   {
-    const { eagerLoadSettingsFromArgs } = await import(
-      '../utils/settings/flagSettings.js'
-    )
+    const { eagerLoadSettingsFromArgs } = await importers.flagSettings()
     const settingsLoadResult = eagerLoadSettingsFromArgs(args)
     if (!settingsLoadResult.ok) {
       if (settingsLoadResult.cause instanceof Error) {
@@ -173,8 +240,8 @@ async function main(): Promise<void> {
     const {
       applyAgentProviderOverrideToEnv,
       resolveOutOfProcessTeammateProviderFromCliArgs,
-    } = await import('../services/api/agentRouting.js')
-    const { getInitialSettings } = await import('../utils/settings/settings.js')
+    } = await importers.agentRouting()
+    const { getInitialSettings } = await importers.settings()
     const providerOverride = resolveOutOfProcessTeammateProviderFromCliArgs(
       args,
       getInitialSettings(),
@@ -186,15 +253,15 @@ async function main(): Promise<void> {
 
   // Fast-path for `--bg`/`--background` after profile routing has been applied
   // so the spawned child inherits the selected provider/model environment.
-  if (feature('BG_SESSIONS')) {
-    const { argsBeforeDelimiter } = await import('../utils/cliArgs.js')
+  if (bgSessionsEnabled) {
+    const { argsBeforeDelimiter } = await importers.cliArgs()
     const optionArgs = argsBeforeDelimiter(args)
     if (optionArgs.includes('--bg') || optionArgs.includes('--background')) {
       const {
         profileCheckpoint
-      } = await import('../utils/startupProfiler.js');
+      } = await importers.startupProfiler();
       profileCheckpoint('cli_bg_path');
-      const bg = await import('../cli/bg.js');
+      const bg = await importers.bg();
       await bg.handleBgFlag(args);
       return;
     }
@@ -205,35 +272,34 @@ async function main(): Promise<void> {
     const {
       hydrateGithubModelsTokenFromSecureStorage,
       refreshGithubModelsTokenIfNeeded,
-    } = await import('../utils/githubModelsCredentials.js')
+    } = await importers.githubModelsCredentials()
     await refreshGithubModelsTokenIfNeeded()
     hydrateGithubModelsTokenFromSecureStorage()
   }
 
-  const { validateProviderEnvForStartupOrExit } = await import(
-    '../utils/providerValidation.js'
-  )
+  const { validateProviderEnvForStartupOrExit } =
+    await importers.providerValidation()
   await validateProviderEnvForStartupOrExit()
 
   // #808: --model alone (no --provider) — route to the env var matching the
   // active provider before the banner prints so the override is visible.
   if (args.includes('--model')) {
-    const { applyModelFlagFromArgs } = await import('../utils/providerFlag.js')
+    const { applyModelFlagFromArgs } = await importers.providerFlag()
     applyModelFlagFromArgs(args)
   }
 
   // Parse --model early so the startup screen can display the override
-  const { eagerParseCliFlag } = await import('../utils/cliArgs.js')
+  const { eagerParseCliFlag } = await importers.cliArgs()
   const earlyModelFlag = eagerParseCliFlag('--model')
 
   // Print the gradient startup screen before the Ink UI loads
-  const { printStartupScreen } = await import('../components/StartupScreen.js')
+  const { printStartupScreen } = await importers.startupScreen()
   printStartupScreen(earlyModelFlag)
 
   // For all other paths, load the startup profiler
   const {
     profileCheckpoint
-  } = await import('../utils/startupProfiler.js');
+  } = await importers.startupProfiler();
   profileCheckpoint('cli_entry');
 
   // Fast-path for --dump-system-prompt: output the rendered system prompt and exit.
@@ -448,17 +514,19 @@ async function main(): Promise<void> {
   if (process.env.OPENCLAUDE_DISABLE_EARLY_INPUT !== '1') {
     const {
       startCapturingEarlyInput
-    } = await import('../utils/earlyInput.js');
+    } = await importers.earlyInput();
     startCapturingEarlyInput();
   }
   profileCheckpoint('cli_before_main_import');
   const {
     main: cliMain
-  } = await import('../main.js');
+  } = await importers.main();
   profileCheckpoint('cli_after_main_import');
   await cliMain();
   profileCheckpoint('cli_after_main_complete');
 }
 
-// eslint-disable-next-line custom-rules/no-top-level-side-effects
-void main();
+// eslint-disable-next-line custom-rules/no-top-level-side-effects, custom-rules/no-process-env-top-level
+if (process.env.OPENCLAUDE_DISABLE_CLI_ENTRYPOINT_AUTO_RUN !== '1') {
+  void main();
+}

--- a/src/entrypoints/cli.tsx
+++ b/src/entrypoints/cli.tsx
@@ -158,6 +158,35 @@ async function main(): Promise<void> {
     }
   }
 
+  // Fast-path for `claude ps|logs|attach|kill` and `--bg`/`--background`.
+  // Session management is local and must not depend on provider validation or
+  // startup-screen rendering. Flag literals are inlined so bg.js only loads
+  // when actually dispatching.
+  if (feature('BG_SESSIONS') && (args[0] === 'ps' || args[0] === 'logs' || args[0] === 'attach' || args[0] === 'kill' || args.includes('--bg') || args.includes('--background'))) {
+    const {
+      profileCheckpoint
+    } = await import('../utils/startupProfiler.js');
+    profileCheckpoint('cli_bg_path');
+    const bg = await import('../cli/bg.js');
+    switch (args[0]) {
+      case 'ps':
+        await bg.psHandler(args.slice(1));
+        break;
+      case 'logs':
+        await bg.logsHandler(args.slice(1));
+        break;
+      case 'attach':
+        await bg.attachHandler(args.slice(1));
+        break;
+      case 'kill':
+        await bg.killHandler(args.slice(1));
+        break;
+      default:
+        await bg.handleBgFlag(args);
+    }
+    return;
+  }
+
   // Hydrate GitHub credentials after profile is applied so CLAUDE_CODE_USE_GITHUB from profile is available
   {
     const {
@@ -323,35 +352,6 @@ async function main(): Promise<void> {
       daemonMain
     } = await import('../daemon/main.js');
     await daemonMain(args.slice(1));
-    return;
-  }
-
-  // Fast-path for `claude ps|logs|attach|kill` and `--bg`/`--background`.
-  // Session management against the ~/.claude/sessions/ registry. Flag
-  // literals are inlined so bg.js only loads when actually dispatching.
-  if (feature('BG_SESSIONS') && (args[0] === 'ps' || args[0] === 'logs' || args[0] === 'attach' || args[0] === 'kill' || args.includes('--bg') || args.includes('--background'))) {
-    profileCheckpoint('cli_bg_path');
-    const {
-      enableConfigs
-    } = await import('../utils/config.js');
-    enableConfigs();
-    const bg = await import('../cli/bg.js');
-    switch (args[0]) {
-      case 'ps':
-        await bg.psHandler(args.slice(1));
-        break;
-      case 'logs':
-        await bg.logsHandler(args[1]);
-        break;
-      case 'attach':
-        await bg.attachHandler(args[1]);
-        break;
-      case 'kill':
-        await bg.killHandler(args[1]);
-        break;
-      default:
-        await bg.handleBgFlag(args);
-    }
     return;
   }
 

--- a/src/entrypoints/cli.tsx
+++ b/src/entrypoints/cli.tsx
@@ -67,11 +67,6 @@ if (feature('ABLATION_BASELINE') && process.env.CLAUDE_CODE_ABLATION_BASELINE) {
  * All imports are dynamic to minimize module evaluation for fast paths.
  * Fast-path for --version has zero imports beyond this file.
  */
-function argsBeforeDelimiter(args: string[]): string[] {
-  const delimiterIndex = args.indexOf('--')
-  return delimiterIndex === -1 ? args : args.slice(0, delimiterIndex)
-}
-
 async function main(): Promise<void> {
   const args = process.argv.slice(2);
 
@@ -191,18 +186,18 @@ async function main(): Promise<void> {
 
   // Fast-path for `--bg`/`--background` after profile routing has been applied
   // so the spawned child inherits the selected provider/model environment.
-  const optionArgs = argsBeforeDelimiter(args)
-  if (
-    feature('BG_SESSIONS') &&
-    (optionArgs.includes('--bg') || optionArgs.includes('--background'))
-  ) {
-    const {
-      profileCheckpoint
-    } = await import('../utils/startupProfiler.js');
-    profileCheckpoint('cli_bg_path');
-    const bg = await import('../cli/bg.js');
-    await bg.handleBgFlag(args);
-    return;
+  if (feature('BG_SESSIONS')) {
+    const { argsBeforeDelimiter } = await import('../utils/cliArgs.js')
+    const optionArgs = argsBeforeDelimiter(args)
+    if (optionArgs.includes('--bg') || optionArgs.includes('--background')) {
+      const {
+        profileCheckpoint
+      } = await import('../utils/startupProfiler.js');
+      profileCheckpoint('cli_bg_path');
+      const bg = await import('../cli/bg.js');
+      await bg.handleBgFlag(args);
+      return;
+    }
   }
 
   // Hydrate GitHub credentials after profile is applied so CLAUDE_CODE_USE_GITHUB from profile is available

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2743,6 +2743,7 @@ async function run(): Promise<CommanderCommand> {
       void runHeadless(inputPrompt, () => headlessStore.getState(), headlessStore.setState, commandsHeadless, tools, sdkMcpConfigs, agentDefinitions.activeAgents, {
         continue: options.continue,
         resume: options.resume,
+        fromPr: options.fromPr,
         verbose: verbose,
         outputFormat: outputFormat,
         jsonSchema,

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2516,7 +2516,7 @@ async function run(): Promise<CommanderCommand> {
       // undefined and the ?? fallback runs). Also skip when setupTrigger is
       // set — those paths run setup hooks first (print.ts:544), and session
       // start hooks must wait until setup completes.
-      const sessionStartHooksPromise = options.continue || options.resume || teleport || setupTrigger ? undefined : processSessionStartHooks('startup');
+      const sessionStartHooksPromise = options.continue || options.resume || options.fromPr || teleport || setupTrigger ? undefined : processSessionStartHooks('startup');
       // Suppress transient unhandledRejection if this rejects before
       // loadInitialMessages awaits it. Downstream await still observes the
       // rejection — this just prevents the spurious global handler fire.

--- a/src/utils/cliArgs.ts
+++ b/src/utils/cliArgs.ts
@@ -28,6 +28,11 @@ export function eagerParseCliFlag(
   return undefined
 }
 
+export function argsBeforeDelimiter(args: string[]): string[] {
+  const delimiterIndex = args.indexOf('--')
+  return delimiterIndex === -1 ? args : args.slice(0, delimiterIndex)
+}
+
 /**
  * Handle the standard Unix `--` separator convention in CLI arguments.
  *

--- a/src/utils/conversationRecovery.test.ts
+++ b/src/utils/conversationRecovery.test.ts
@@ -1,5 +1,4 @@
 import { afterEach, beforeEach, expect, mock, test } from 'bun:test'
-import { spawn, type ChildProcess } from 'node:child_process'
 import { mkdtemp, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
@@ -7,13 +6,10 @@ import {
   acquireSharedMutationLock,
   releaseSharedMutationLock,
 } from '../test/sharedMutationLock.js'
-import * as realBgRegistry from '../cli/bgRegistry.js'
-import * as realEnvUtils from './envUtils.js'
 import * as realUdsClient from './udsClient.js'
 import * as realProviders from './model/providers.js'
 
 const tempDirs: string[] = []
-const childProcesses: ChildProcess[] = []
 const originalSimple = process.env.CLAUDE_CODE_SIMPLE
 const providerEnvKeys = [
   'CLAUDE_CODE_USE_GEMINI',
@@ -99,8 +95,6 @@ afterEach(async () => {
     mock.restore()
     mock.module('./udsClient.js', () => realUdsClient)
     mock.module('./model/providers.js', () => realProviders)
-    realEnvUtils.setClaudeConfigHomeDirForTesting(undefined)
-    realEnvUtils.getClaudeConfigHomeDir.cache?.clear?.()
     if (originalSimple === undefined) {
       delete process.env.CLAUDE_CODE_SIMPLE
     } else {
@@ -117,49 +111,10 @@ afterEach(async () => {
     await Promise.all(
       tempDirs.splice(0).map(dir => rm(dir, { recursive: true, force: true })),
     )
-    await Promise.all(childProcesses.splice(0).map(stopChildProcess))
   } finally {
     releaseSharedMutationLock()
   }
 })
-
-async function spawnLiveSessionProcess(sessionId: string): Promise<number> {
-  const child = spawn(
-    process.execPath,
-    ['-e', 'setTimeout(() => {}, 30000)', sessionId],
-    {
-      stdio: 'ignore',
-    },
-  )
-  childProcesses.push(child)
-
-  await new Promise<void>((resolve, reject) => {
-    child.once('spawn', resolve)
-    child.once('error', reject)
-  })
-  if (!child.pid) {
-    throw new Error('Failed to start background session test process')
-  }
-  return child.pid
-}
-
-async function stopChildProcess(child: ChildProcess): Promise<void> {
-  if (!child.pid || child.exitCode !== null || child.signalCode !== null) {
-    return
-  }
-
-  await new Promise<void>(resolve => {
-    const timeout = setTimeout(() => {
-      child.kill('SIGKILL')
-      resolve()
-    }, 500)
-    child.once('exit', () => {
-      clearTimeout(timeout)
-      resolve()
-    })
-    child.kill('SIGTERM')
-  })
-}
 
 async function importFreshConversationRecovery() {
   mock.restore()
@@ -261,44 +216,27 @@ test('loadConversationForResume rejects oversized reconstructed transcripts', as
 
 test('collectLiveBackgroundSessionIds includes local registry sessions when UDS is empty', async () => {
   process.env.CLAUDE_CODE_SIMPLE = '1'
-  const configDir = await mkdtemp(join(tmpdir(), 'openclaude-bg-registry-'))
-  tempDirs.push(configDir)
-  realEnvUtils.setClaudeConfigHomeDirForTesting(configDir)
-  realEnvUtils.getClaudeConfigHomeDir.cache?.clear?.()
-
   const liveSessionId = '00000000-0000-4000-8000-000000000111'
   const staleSessionId = '00000000-0000-4000-8000-000000000222'
-  const livePid = await spawnLiveSessionProcess(liveSessionId)
-  await realBgRegistry.createBackgroundSession({
-    id: 'bg-live',
-    pid: livePid,
-    cwd: '/tmp',
-    command: [
-      process.execPath,
-      '-e',
-      'setTimeout(() => {}, 30000)',
-      liveSessionId,
-    ],
-    sessionId: liveSessionId,
-  })
-  await realBgRegistry.createBackgroundSession({
-    id: 'bg-stale',
-    pid: 1,
-    cwd: '/tmp',
-    command: ['openclaude', '--print', 'stale'],
-    sessionId: staleSessionId,
-  })
-
   const { collectLiveBackgroundSessionIds } =
     await importFreshConversationRecovery()
-  mock.module('./udsClient.js', () => ({
-    ...realUdsClient,
-    listAllLiveSessions: async () => [],
-  }))
 
-  expect(await collectLiveBackgroundSessionIds()).toEqual(
-    new Set([liveSessionId]),
-  )
+  expect(
+    await collectLiveBackgroundSessionIds({
+      listAllLiveSessions: async () => [],
+      refreshBackgroundSessionStatuses: async () => [
+        {
+          sessionId: liveSessionId,
+          status: 'running',
+        },
+        {
+          sessionId: staleSessionId,
+          status: 'stale',
+        },
+      ],
+      isTerminalBackgroundSession: session => session.status !== 'running',
+    }),
+  ).toEqual(new Set([liveSessionId]))
 })
 
 test('deserializeMessages preserves thinking blocks for GitHub native Claude transport', async () => {

--- a/src/utils/conversationRecovery.test.ts
+++ b/src/utils/conversationRecovery.test.ts
@@ -93,6 +93,8 @@ beforeEach(async () => {
 afterEach(async () => {
   try {
     mock.restore()
+    // Bun 1.3.13 can leave restored module instances visible to later test
+    // files, so re-register full exports after using partial module mocks.
     mock.module('./udsClient.js', () => realUdsClient)
     mock.module('./model/providers.js', () => realProviders)
     if (originalSimple === undefined) {

--- a/src/utils/conversationRecovery.test.ts
+++ b/src/utils/conversationRecovery.test.ts
@@ -212,6 +212,34 @@ test('loadConversationForResume rejects oversized reconstructed transcripts', as
   )
 })
 
+test('collectLiveBackgroundSessionIds includes local registry sessions when UDS is empty', async () => {
+  process.env.CLAUDE_CODE_SIMPLE = '1'
+  mock.module('./udsClient.js', () => ({
+    listAllLiveSessions: async () => [],
+  }))
+  mock.module('../cli/bgRegistry.js', () => ({
+    refreshBackgroundSessionStatuses: async () => [
+      {
+        sessionId: '00000000-0000-4000-8000-000000000111',
+        status: 'running',
+      },
+      {
+        sessionId: '00000000-0000-4000-8000-000000000222',
+        status: 'stale',
+      },
+    ],
+    isTerminalBackgroundSession: (session: { status: string }) =>
+      session.status !== 'running',
+  }))
+
+  const { collectLiveBackgroundSessionIds } =
+    await importFreshConversationRecovery()
+
+  expect(await collectLiveBackgroundSessionIds()).toEqual(
+    new Set(['00000000-0000-4000-8000-000000000111']),
+  )
+})
+
 test('deserializeMessages preserves thinking blocks for GitHub native Claude transport', async () => {
   clearProviderEnv()
   process.env.CLAUDE_CODE_USE_GITHUB = '1'

--- a/src/utils/conversationRecovery.test.ts
+++ b/src/utils/conversationRecovery.test.ts
@@ -6,6 +6,8 @@ import {
   acquireSharedMutationLock,
   releaseSharedMutationLock,
 } from '../test/sharedMutationLock.js'
+import * as realBgRegistry from '../cli/bgRegistry.js'
+import * as realUdsClient from './udsClient.js'
 import * as realProviders from './model/providers.js'
 
 const tempDirs: string[] = []
@@ -92,6 +94,8 @@ beforeEach(async () => {
 afterEach(async () => {
   try {
     mock.restore()
+    mock.module('../cli/bgRegistry.js', () => realBgRegistry)
+    mock.module('./udsClient.js', () => realUdsClient)
     mock.module('./model/providers.js', () => realProviders)
     if (originalSimple === undefined) {
       delete process.env.CLAUDE_CODE_SIMPLE
@@ -215,9 +219,11 @@ test('loadConversationForResume rejects oversized reconstructed transcripts', as
 test('collectLiveBackgroundSessionIds includes local registry sessions when UDS is empty', async () => {
   process.env.CLAUDE_CODE_SIMPLE = '1'
   mock.module('./udsClient.js', () => ({
+    ...realUdsClient,
     listAllLiveSessions: async () => [],
   }))
   mock.module('../cli/bgRegistry.js', () => ({
+    ...realBgRegistry,
     refreshBackgroundSessionStatuses: async () => [
       {
         sessionId: '00000000-0000-4000-8000-000000000111',

--- a/src/utils/conversationRecovery.test.ts
+++ b/src/utils/conversationRecovery.test.ts
@@ -241,6 +241,55 @@ test('collectLiveBackgroundSessionIds includes local registry sessions when UDS 
   ).toEqual(new Set([liveSessionId]))
 })
 
+test('collectLiveBackgroundSessionIds falls back to registry sessions when UDS fails', async () => {
+  process.env.CLAUDE_CODE_SIMPLE = '1'
+  const liveSessionId = '00000000-0000-4000-8000-000000000333'
+  const { collectLiveBackgroundSessionIds } =
+    await importFreshConversationRecovery()
+
+  expect(
+    await collectLiveBackgroundSessionIds({
+      listAllLiveSessions: async () => {
+        throw new Error('UDS unavailable')
+      },
+      refreshBackgroundSessionStatuses: async () => [
+        {
+          sessionId: liveSessionId,
+          status: 'running',
+        },
+      ],
+      isTerminalBackgroundSession: session => session.status !== 'running',
+    }),
+  ).toEqual(new Set([liveSessionId]))
+})
+
+test('collectLiveBackgroundSessionIds falls back to UDS sessions when registry refresh fails', async () => {
+  process.env.CLAUDE_CODE_SIMPLE = '1'
+  const liveSessionId = '00000000-0000-4000-8000-000000000444'
+  const interactiveSessionId = '00000000-0000-4000-8000-000000000555'
+  const { collectLiveBackgroundSessionIds } =
+    await importFreshConversationRecovery()
+
+  expect(
+    await collectLiveBackgroundSessionIds({
+      listAllLiveSessions: async () => [
+        {
+          kind: 'background',
+          sessionId: liveSessionId,
+        },
+        {
+          kind: 'interactive',
+          sessionId: interactiveSessionId,
+        },
+      ],
+      refreshBackgroundSessionStatuses: async () => {
+        throw new Error('Registry unavailable')
+      },
+      isTerminalBackgroundSession: session => session.status !== 'running',
+    }),
+  ).toEqual(new Set([liveSessionId]))
+})
+
 test('deserializeMessages preserves thinking blocks for GitHub native Claude transport', async () => {
   clearProviderEnv()
   process.env.CLAUDE_CODE_USE_GITHUB = '1'

--- a/src/utils/conversationRecovery.test.ts
+++ b/src/utils/conversationRecovery.test.ts
@@ -194,6 +194,51 @@ test('loadConversationForResume preserves goal metadata from jsonl transcript pa
   expect(result?.goal).toEqual(goal)
 })
 
+test('findResumeLogByPrSelector selects the first non-sidechain PR match', async () => {
+  const { findResumeLogByPrSelector } = await importFreshConversationRecovery()
+  const linked = {
+    date: ts,
+    messages: [user(id(12), 'linked')],
+    value: 0,
+    created: new Date(ts),
+    modified: new Date(ts),
+    firstPrompt: 'linked',
+    messageCount: 1,
+    isSidechain: false,
+    sessionId: id(12),
+    prNumber: 1642,
+    prUrl: 'https://github.com/Gitlawb/openclaude/pull/1642',
+    prRepository: 'Gitlawb/openclaude',
+  } as any
+  const sidechain = {
+    ...linked,
+    isSidechain: true,
+    sessionId: id(13),
+  } as any
+  const unrelated = {
+    ...linked,
+    sessionId: id(14),
+    prNumber: 17,
+    prUrl: 'https://github.com/Gitlawb/openclaude/pull/17',
+  } as any
+
+  expect(findResumeLogByPrSelector([sidechain, linked, unrelated], true)).toBe(
+    linked,
+  )
+  expect(
+    findResumeLogByPrSelector([sidechain, linked, unrelated], '1642'),
+  ).toBe(linked)
+  expect(
+    findResumeLogByPrSelector(
+      [sidechain, linked, unrelated],
+      'https://github.com/Gitlawb/openclaude/pull/1642',
+    ),
+  ).toBe(linked)
+  expect(
+    findResumeLogByPrSelector([sidechain, linked, unrelated], 'missing'),
+  ).toBeNull()
+})
+
 test('loadConversationForResume rejects oversized reconstructed transcripts', async () => {
   process.env.CLAUDE_CODE_SIMPLE = '1'
   const hugeContent = 'x'.repeat(8 * 1024 * 1024 + 32 * 1024)

--- a/src/utils/conversationRecovery.test.ts
+++ b/src/utils/conversationRecovery.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, expect, mock, test } from 'bun:test'
+import { spawn, type ChildProcess } from 'node:child_process'
 import { mkdtemp, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
@@ -7,10 +8,12 @@ import {
   releaseSharedMutationLock,
 } from '../test/sharedMutationLock.js'
 import * as realBgRegistry from '../cli/bgRegistry.js'
+import * as realEnvUtils from './envUtils.js'
 import * as realUdsClient from './udsClient.js'
 import * as realProviders from './model/providers.js'
 
 const tempDirs: string[] = []
+const childProcesses: ChildProcess[] = []
 const originalSimple = process.env.CLAUDE_CODE_SIMPLE
 const providerEnvKeys = [
   'CLAUDE_CODE_USE_GEMINI',
@@ -94,9 +97,10 @@ beforeEach(async () => {
 afterEach(async () => {
   try {
     mock.restore()
-    mock.module('../cli/bgRegistry.js', () => realBgRegistry)
     mock.module('./udsClient.js', () => realUdsClient)
     mock.module('./model/providers.js', () => realProviders)
+    realEnvUtils.setClaudeConfigHomeDirForTesting(undefined)
+    realEnvUtils.getClaudeConfigHomeDir.cache?.clear?.()
     if (originalSimple === undefined) {
       delete process.env.CLAUDE_CODE_SIMPLE
     } else {
@@ -113,10 +117,49 @@ afterEach(async () => {
     await Promise.all(
       tempDirs.splice(0).map(dir => rm(dir, { recursive: true, force: true })),
     )
+    await Promise.all(childProcesses.splice(0).map(stopChildProcess))
   } finally {
     releaseSharedMutationLock()
   }
 })
+
+async function spawnLiveSessionProcess(sessionId: string): Promise<number> {
+  const child = spawn(
+    process.execPath,
+    ['-e', 'setTimeout(() => {}, 30000)', sessionId],
+    {
+      stdio: 'ignore',
+    },
+  )
+  childProcesses.push(child)
+
+  await new Promise<void>((resolve, reject) => {
+    child.once('spawn', resolve)
+    child.once('error', reject)
+  })
+  if (!child.pid) {
+    throw new Error('Failed to start background session test process')
+  }
+  return child.pid
+}
+
+async function stopChildProcess(child: ChildProcess): Promise<void> {
+  if (!child.pid || child.exitCode !== null || child.signalCode !== null) {
+    return
+  }
+
+  await new Promise<void>(resolve => {
+    const timeout = setTimeout(() => {
+      child.kill('SIGKILL')
+      resolve()
+    }, 500)
+    child.once('exit', () => {
+      clearTimeout(timeout)
+      resolve()
+    })
+    child.kill('SIGTERM')
+  })
+}
 
 async function importFreshConversationRecovery() {
   mock.restore()
@@ -218,31 +261,43 @@ test('loadConversationForResume rejects oversized reconstructed transcripts', as
 
 test('collectLiveBackgroundSessionIds includes local registry sessions when UDS is empty', async () => {
   process.env.CLAUDE_CODE_SIMPLE = '1'
+  const configDir = await mkdtemp(join(tmpdir(), 'openclaude-bg-registry-'))
+  tempDirs.push(configDir)
+  realEnvUtils.setClaudeConfigHomeDirForTesting(configDir)
+  realEnvUtils.getClaudeConfigHomeDir.cache?.clear?.()
+
+  const liveSessionId = '00000000-0000-4000-8000-000000000111'
+  const staleSessionId = '00000000-0000-4000-8000-000000000222'
+  const livePid = await spawnLiveSessionProcess(liveSessionId)
+  await realBgRegistry.createBackgroundSession({
+    id: 'bg-live',
+    pid: livePid,
+    cwd: '/tmp',
+    command: [
+      process.execPath,
+      '-e',
+      'setTimeout(() => {}, 30000)',
+      liveSessionId,
+    ],
+    sessionId: liveSessionId,
+  })
+  await realBgRegistry.createBackgroundSession({
+    id: 'bg-stale',
+    pid: 1,
+    cwd: '/tmp',
+    command: ['openclaude', '--print', 'stale'],
+    sessionId: staleSessionId,
+  })
+
+  const { collectLiveBackgroundSessionIds } =
+    await importFreshConversationRecovery()
   mock.module('./udsClient.js', () => ({
     ...realUdsClient,
     listAllLiveSessions: async () => [],
   }))
-  mock.module('../cli/bgRegistry.js', () => ({
-    ...realBgRegistry,
-    refreshBackgroundSessionStatuses: async () => [
-      {
-        sessionId: '00000000-0000-4000-8000-000000000111',
-        status: 'running',
-      },
-      {
-        sessionId: '00000000-0000-4000-8000-000000000222',
-        status: 'stale',
-      },
-    ],
-    isTerminalBackgroundSession: (session: { status: string }) =>
-      session.status !== 'running',
-  }))
-
-  const { collectLiveBackgroundSessionIds } =
-    await importFreshConversationRecovery()
 
   expect(await collectLiveBackgroundSessionIds()).toEqual(
-    new Set(['00000000-0000-4000-8000-000000000111']),
+    new Set([liveSessionId]),
   )
 })
 

--- a/src/utils/conversationRecovery.ts
+++ b/src/utils/conversationRecovery.ts
@@ -83,6 +83,8 @@ const SEND_USER_FILE_TOOL_NAME: string | null = feature('KAIROS')
 // enough room for normal compacted sessions plus resume hook context.
 const MAX_RESUME_MESSAGE_BYTES = 8 * 1024 * 1024
 
+type PrResumeSelector = true | number | string
+
 export class ResumeTranscriptTooLargeError extends Error {
   constructor(
     readonly bytes: number,
@@ -221,6 +223,38 @@ function shouldPreserveThinkingBlocksForProviderReplay(): boolean {
       model: process.env.OPENAI_MODEL,
     }).openaiShimConfig.preserveReasoningContent === true
   )
+}
+
+function parsePrIdentifier(value: string): number | null {
+  const directNumber = parseInt(value, 10)
+  if (!isNaN(directNumber) && directNumber > 0) {
+    return directNumber
+  }
+  const urlMatch = value.match(/github\.com\/[^/]+\/[^/]+\/pull\/(\d+)/)
+  if (urlMatch?.[1]) {
+    return parseInt(urlMatch[1], 10)
+  }
+  return null
+}
+
+export function findResumeLogByPrSelector(
+  logs: LogOption[],
+  selector: PrResumeSelector,
+): LogOption | null {
+  const candidates = logs.filter(log => !log.isSidechain)
+  if (selector === true) {
+    return candidates.find(log => log.prNumber !== undefined) ?? null
+  }
+  if (typeof selector === 'number') {
+    return candidates.find(log => log.prNumber === selector) ?? null
+  }
+
+  const prNumber = parsePrIdentifier(selector)
+  if (prNumber !== null) {
+    return candidates.find(log => log.prNumber === prNumber) ?? null
+  }
+
+  return null
 }
 
 /**
@@ -756,4 +790,12 @@ export async function loadConversationForResume(
     logError(error as Error)
     throw error
   }
+}
+
+export async function loadConversationForResumeFromPr(
+  selector: true | string,
+): ReturnType<typeof loadConversationForResume> {
+  const log = findResumeLogByPrSelector(await loadMessageLogs(), selector)
+  if (!log) return null
+  return loadConversationForResume(log, undefined)
 }

--- a/src/utils/conversationRecovery.ts
+++ b/src/utils/conversationRecovery.ts
@@ -799,3 +799,11 @@ export async function loadConversationForResumeFromPr(
   if (!log) return null
   return loadConversationForResume(log, undefined)
 }
+
+export async function findResumeSessionIdByPrSelector(
+  selector: true | string,
+): Promise<UUID | null> {
+  const log = findResumeLogByPrSelector(await loadMessageLogs(), selector)
+  if (!log) return null
+  return getSessionIdFromLog(log) ?? null
+}

--- a/src/utils/conversationRecovery.ts
+++ b/src/utils/conversationRecovery.ts
@@ -358,6 +358,38 @@ export function deserializeMessagesWithInterruptDetection(
   }
 }
 
+export async function collectLiveBackgroundSessionIds(): Promise<Set<string>> {
+  const skip = new Set<string>()
+  try {
+    const { listAllLiveSessions } = await import('./udsClient.js')
+    const live = await listAllLiveSessions()
+    for (const session of live) {
+      if (session.kind && session.kind !== 'interactive' && session.sessionId) {
+        skip.add(session.sessionId)
+      }
+    }
+  } catch {
+    // UDS unavailable — local registry below still protects local bg sessions.
+  }
+
+  try {
+    const {
+      refreshBackgroundSessionStatuses,
+      isTerminalBackgroundSession,
+    } = await import('../cli/bgRegistry.js')
+    const sessions = await refreshBackgroundSessionStatuses()
+    for (const session of sessions) {
+      if (!isTerminalBackgroundSession(session)) {
+        skip.add(session.sessionId)
+      }
+    }
+  } catch {
+    // Registry unavailable or unreadable — fall back to UDS-only results.
+  }
+
+  return skip
+}
+
 /**
  * Internal 3-way result from detection, before transforming interrupted_turn
  * into interrupted_prompt with a synthetic continuation message.
@@ -606,19 +638,7 @@ export async function loadConversationForResume(
       const logsPromise = loadMessageLogs()
       let skip = new Set<string>()
       if (feature('BG_SESSIONS')) {
-        try {
-          const { listAllLiveSessions } = await import('./udsClient.js')
-          const live = await listAllLiveSessions()
-          skip = new Set(
-            live.flatMap(s =>
-              s.kind && s.kind !== 'interactive' && s.sessionId
-                ? [s.sessionId]
-                : [],
-            ),
-          )
-        } catch {
-          // UDS unavailable — treat all sessions as continuable
-        }
+        skip = await collectLiveBackgroundSessionIds()
       }
       const logs = await logsPromise
       log =

--- a/src/utils/conversationRecovery.ts
+++ b/src/utils/conversationRecovery.ts
@@ -358,10 +358,23 @@ export function deserializeMessagesWithInterruptDetection(
   }
 }
 
-export async function collectLiveBackgroundSessionIds(): Promise<Set<string>> {
+type UdsClientModule = typeof import('./udsClient.js')
+type BgRegistryModule = typeof import('../cli/bgRegistry.js')
+
+type CollectLiveBackgroundSessionIdsDeps = {
+  listAllLiveSessions?: UdsClientModule['listAllLiveSessions']
+  refreshBackgroundSessionStatuses?: BgRegistryModule['refreshBackgroundSessionStatuses']
+  isTerminalBackgroundSession?: BgRegistryModule['isTerminalBackgroundSession']
+}
+
+export async function collectLiveBackgroundSessionIds(
+  deps: CollectLiveBackgroundSessionIdsDeps = {},
+): Promise<Set<string>> {
   const skip = new Set<string>()
   try {
-    const { listAllLiveSessions } = await import('./udsClient.js')
+    const listAllLiveSessions =
+      deps.listAllLiveSessions ??
+      (await import('./udsClient.js')).listAllLiveSessions
     const live = await listAllLiveSessions()
     for (const session of live) {
       if (session.kind && session.kind !== 'interactive' && session.sessionId) {
@@ -373,10 +386,15 @@ export async function collectLiveBackgroundSessionIds(): Promise<Set<string>> {
   }
 
   try {
-    const {
-      refreshBackgroundSessionStatuses,
-      isTerminalBackgroundSession,
-    } = await import('../cli/bgRegistry.js')
+    let refreshBackgroundSessionStatuses =
+      deps.refreshBackgroundSessionStatuses
+    let isTerminalBackgroundSession = deps.isTerminalBackgroundSession
+    if (!refreshBackgroundSessionStatuses || !isTerminalBackgroundSession) {
+      const bgRegistry = await import('../cli/bgRegistry.js')
+      refreshBackgroundSessionStatuses ??=
+        bgRegistry.refreshBackgroundSessionStatuses
+      isTerminalBackgroundSession ??= bgRegistry.isTerminalBackgroundSession
+    }
     const sessions = await refreshBackgroundSessionStatuses()
     for (const session of sessions) {
       if (!isTerminalBackgroundSession(session)) {


### PR DESCRIPTION
## Summary
- Add local detached `openclaude --bg` sessions with `ps`, `logs`, `logs -f`, `kill`, and an explicit `attach` limitation.
- Store session metadata and stdout/stderr logs under the resolved OpenClaude config directory without starting a daemon or network service.
- Integrate live local background sessions with `--continue` transcript selection so active detached work is not resumed accidentally.
- Harden registry validation, atomic metadata writes, ID/name collision handling, terminal-name reuse, PID validation, and PID/session identity refresh.
- Address review feedback for optional-value flag parsing, background resume/from-PR selectors, orphaned name-reservation recovery, delimiter-safe background/print flag detection, shared delimiter helper reuse, runtime entrypoint routing coverage, and conservative PID identity refresh.

## Design and safety
- Local management commands dispatch before provider/config/profile startup, avoiding unrelated startup warnings and wasted work for `ps`, `logs`, `attach`, and `kill`.
- Background spawning still runs after profile routing so detached child processes inherit the selected provider/model environment.
- Named live sessions use an atomic reservation file; terminal session updates release the reservation so names can be reused safely.
- Reservation recovery validates live owner metadata and live creator processes before reclaiming stale reservation files.
- `--bg --debug "prompt"` preserves the prompt while still supporting inline debug filters such as `--debug=api,hooks`.
- `--bg --resume <id>`, `--bg -r <id>`, and `--bg --from-pr <selector>` keep their space-separated selector values attached to the option instead of treating them as prompts.
- Flag-shaped prompt text after `--`, including `--print`, `-p`, and `--bg`, remains positional and does not change background routing or child print-mode detection.
- The delimiter helper lives in the dependency-free CLI args utility and is dynamically imported by the entrypoint to preserve fast-path startup behavior.
- Entrypoint routing now has execution-level tests with isolated dependency injection instead of global module mocks.
- Registry reads ignore malformed or unsafe metadata, including non-positive process IDs.
- Running sessions with unreadable live PID command lines move to a non-terminal `unknown` state, keeping resume filtering conservative while avoiding unsafe termination of a reused unrelated PID.
- Failed registration cleans up only files owned by the attempted session, while preserving caller-owned precreated logs.
- `kill` waits for verified running process-tree exit and escalates to `SIGKILL` before marking a session killed; live `unknown` sessions are not terminated because their PID identity cannot be verified.

## Validation
- `bunx bun@1.3.13 test --max-concurrency=1 src/entrypoints/cli.test.ts src/cli/bg.test.ts` (23 pass, 0 fail)
- `bunx bun@1.3.13 test --max-concurrency=1 src/commands/provider/provider.test.tsx src/utils/providerProfile.test.ts src/services/api/providerValidation.test.ts` (101 pass, 0 fail)
- `bunx bun@1.3.13 run typecheck`
- `git diff --check`
- `bunx bun@1.3.13 test --max-concurrency=1 src/cli/bg.test.ts src/cli/bgRegistry.test.ts` (34 pass, 0 fail)
- `bunx bun@1.3.13 run check` (4067 pass, 0 fail)
- Merge conflict resolution on `0996e7d7`: preserved upstream provider-profile startup handling behind the local CLI importer seam.
- GitHub Actions on `0996e7d7`: `smoke-and-tests`, `typecheck`, and `web` passed
- CodeRabbit on `0996e7d7`: approved, no actionable comments in the latest review
- Reviewer follow-up on `953aabc2`: preserved background resume/from-PR selector values and added conservative PID identity handling.
- CodeRabbit follow-up on `03ecd3ed`: represented unreadable live PID identity as non-terminal `unknown` and blocked unsafe `kill` termination for unverified live PIDs.
- GitHub Actions on `03ecd3ed`: `smoke-and-tests`, `typecheck`, and `web` passed
- CodeRabbit on `03ecd3ed`: approved, no unresolved review threads

## Known limitation
- `attach` currently points users to `openclaude logs <id> -f`; full terminal reattach is not implemented in this change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added full background-session support (`--bg/--background`) with persistent session tracking and dedicated commands: `ps`, `logs` (supports `-f` for follow; stdout/stderr), `kill`, and `attach` (redirects to `logs -f`).
  * Print mode now supports PR-based resume via `--from-pr`.

* **Documentation**
  * Updated Quick Start with background session usage, session naming, and log/metadata location details.

* **Bug Fixes**
  * Improved CLI routing to ensure background commands receive the correct arguments and run in the appropriate startup phase.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
