### PR TITLE
fix(openai-shim): nest reasoning under reasoning.effort for the Responses API

### DIFF
--- a/src/services/api/openaiShim.test.ts
+++ b/src/services/api/openaiShim.test.ts
@@ -345,6 +345,46 @@ test('uses OpenAI-compatible responses endpoint when OPENAI_API_FORMAT=responses
   ])
 })
 
+test('nests reasoning under a reasoning object for the responses API (#1638)', async () => {
+  process.env.OPENAI_API_FORMAT = 'responses'
+  let capturedBody: Record<string, unknown> | undefined
+
+  globalThis.fetch = (async (_input, init) => {
+    capturedBody = JSON.parse(String(init?.body)) as Record<string, unknown>
+
+    return new Response(
+      JSON.stringify({
+        id: 'resp-1',
+        model: 'gpt-5.5',
+        output: [
+          {
+            type: 'message',
+            role: 'assistant',
+            content: [{ type: 'output_text', text: 'ok' }],
+          },
+        ],
+        usage: { input_tokens: 8, output_tokens: 3, total_tokens: 11 },
+      }),
+      { headers: { 'Content-Type': 'application/json' } },
+    )
+  }) as unknown as FetchType
+
+  const client = createOpenAIShimClient({
+    reasoningEffort: 'high',
+  }) as OpenAIShimClient
+
+  await client.beta.messages.create({
+    model: 'gpt-5.5',
+    messages: [{ role: 'user', content: 'hello' }],
+    max_tokens: 64,
+    stream: false,
+  })
+
+  // The Responses API rejects the flat `reasoning_effort`; it must be nested.
+  expect(capturedBody?.reasoning).toEqual({ effort: 'high', summary: 'auto' })
+  expect('reasoning_effort' in (capturedBody ?? {})).toBe(false)
+})
+
 test('uses OpenAI-compatible responses endpoint with text chunk types when OPENAI_API_FORMAT=responses_compat', async () => {
   process.env.OPENAI_API_FORMAT = 'responses_compat'
   let capturedUrl = ''

--- a/src/services/api/openaiShim.ts
+++ b/src/services/api/openaiShim.ts
@@ -2572,8 +2572,14 @@ class OpenAIShimMessages {
       if (params.temperature !== undefined) responsesBody.temperature = params.temperature
       if (params.top_p !== undefined) responsesBody.top_p = params.top_p
       if (request.reasoning?.effort) {
-        responsesBody.reasoning_effort = request.reasoning.effort
-        responsesBody.reasoning_summary = 'auto'
+        // The Responses API nests reasoning controls under a `reasoning` object
+        // (`reasoning.effort` / `reasoning.summary`); the flat `reasoning_effort`
+        // form is Chat Completions only and is rejected here with
+        // "Unsupported parameter: 'reasoning_effort'" (#1638).
+        responsesBody.reasoning = {
+          effort: request.reasoning.effort,
+          summary: 'auto',
+        }
         responsesBody.include = ['reasoning.encrypted_content']
       }
 


### PR DESCRIPTION
## What

Adding an OpenAI-compatible provider on the Responses API (e.g. GPT-5.5 via `/provider`) failed on the first request with:

```
API Error: 400 Unsupported parameter: 'reasoning_effort'. In the Responses API,
this parameter has moved to 'reasoning.effort'.
```

## Why

In `src/services/api/openaiShim.ts`, the responses body set the flat `reasoning_effort` / `reasoning_summary` fields. Those belong to Chat Completions — the Responses API nests them under a `reasoning` object (`reasoning.effort` / `reasoning.summary`) and rejects the flat form.

## Change

Emit `reasoning: { effort, summary }` when building the responses body. The chat-completions path is untouched (the flat `reasoning_effort` is correct there).

## Test

Added a responses-API test asserting the nested `reasoning` object is sent and the flat `reasoning_effort` is absent. `bun test src/services/api/openaiShim.test.ts` (122 pass) and `tsc --noEmit` clean.

Closes #1638

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed how reasoning effort settings are formatted and transmitted in API requests, ensuring proper handling and configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->