### PR TITLE
fix(gitDiff): keep hunk content lines beginning with -- or ++

### DIFF
--- a/src/utils/gitDiff.test.ts
+++ b/src/utils/gitDiff.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'bun:test'
+import { parseGitDiff } from './gitDiff.js'
+
+describe('parseGitDiff', () => {
+  it('keeps hunk content lines whose text starts with -- or ++', () => {
+    // A removed line whose content is "--legacy-peer-deps" appears in the diff
+    // as "---legacy-peer-deps"; an added line "++quiet-flag" appears as
+    // "+++quiet-flag". Both must be retained as hunk content, not mistaken for
+    // the "---"/"+++" file-header lines.
+    const diff = [
+      'diff --git a/run.sh b/run.sh',
+      'index abc1234..def5678 100644',
+      '--- a/run.sh',
+      '+++ b/run.sh',
+      '@@ -1,3 +1,3 @@',
+      ' npm install \\',
+      '---legacy-peer-deps',
+      '+++quiet-flag',
+      ' echo done',
+      '',
+    ].join('\n')
+
+    const hunks = parseGitDiff(diff).get('run.sh')
+    expect(hunks).toBeDefined()
+    const lines = hunks![0]!.lines
+    expect(lines).toContain('---legacy-peer-deps')
+    expect(lines).toContain('+++quiet-flag')
+    expect(lines).toContain(' npm install \\')
+    expect(lines).toContain(' echo done')
+  })
+
+  it('still drops the file-header --- / +++ / index lines from hunk content', () => {
+    const diff = [
+      'diff --git a/a.txt b/a.txt',
+      'index 1111111..2222222 100644',
+      '--- a/a.txt',
+      '+++ b/a.txt',
+      '@@ -1 +1 @@',
+      '-old',
+      '+new',
+      '',
+    ].join('\n')
+
+    const lines = parseGitDiff(diff).get('a.txt')![0]!.lines
+    expect(lines).toContain('-old')
+    expect(lines).toContain('+new')
+    expect(lines).not.toContain('--- a/a.txt')
+    expect(lines).not.toContain('+++ b/a.txt')
+    expect(lines).not.toContain('index 1111111..2222222 100644')
+  })
+
+  it('parses a normal hunk with added, removed and context lines', () => {
+    const diff = [
+      'diff --git a/src/x.ts b/src/x.ts',
+      'index 1111111..2222222 100644',
+      '--- a/src/x.ts',
+      '+++ b/src/x.ts',
+      '@@ -1,3 +1,3 @@',
+      ' const a = 1',
+      '-const b = 2',
+      '+const b = 3',
+      ' const c = 4',
+      '',
+    ].join('\n')
+
+    const hunks = parseGitDiff(diff).get('src/x.ts')
+    expect(hunks).toBeDefined()
+    expect(hunks![0]!.oldStart).toBe(1)
+    expect(hunks![0]!.newStart).toBe(1)
+    const lines = hunks![0]!.lines
+    expect(lines).toContain('-const b = 2')
+    expect(lines).toContain('+const b = 3')
+    expect(lines).toContain(' const a = 1')
+  })
+})

--- a/src/utils/gitDiff.ts
+++ b/src/utils/gitDiff.ts
@@ -248,16 +248,22 @@ export function parseGitDiff(
         continue
       }
 
-      // Skip binary file markers and other metadata
+      // Skip binary file markers and other metadata. These only appear in the
+      // file preamble before the first @@ hunk header, so only match them when
+      // we are not yet inside a hunk. Once inside a hunk, a line such as
+      // "---legacy-peer-deps" (a removed line whose content starts with "--")
+      // or "+++count" (an added line whose content starts with "++") is real
+      // diff content and must not be dropped as a "+++"/"---" header.
       if (
-        line.startsWith('index ') ||
-        line.startsWith('---') ||
-        line.startsWith('+++') ||
-        line.startsWith('new file') ||
-        line.startsWith('deleted file') ||
-        line.startsWith('old mode') ||
-        line.startsWith('new mode') ||
-        line.startsWith('Binary files')
+        !currentHunk &&
+        (line.startsWith('index ') ||
+          line.startsWith('---') ||
+          line.startsWith('+++') ||
+          line.startsWith('new file') ||
+          line.startsWith('deleted file') ||
+          line.startsWith('old mode') ||
+          line.startsWith('new mode') ||
+          line.startsWith('Binary files'))
       ) {
         continue
       }


### PR DESCRIPTION
## What

`parseGitDiff` was dropping hunk content lines whose text begins with `--` or `++`.

A removed line whose content starts with `--` (e.g. `--legacy-peer-deps`) appears in a unified diff as `---legacy-peer-deps`, and an added line whose content starts with `++` (e.g. `++count`) appears as `+++count`. The per-line loop's metadata-skip block matched `line.startsWith('---')` and `line.startsWith('+++')` on every line, so these were mistaken for the `---`/`+++` file-header lines and silently discarded — the rendered diff lost real changes.

## Why

Those `---`/`+++`/`index `/`new file`/`mode`/`Binary files` markers only appear in the file preamble, before the first `@@` hunk header. The skip block was running unconditionally, including inside hunks where `+`/`-`/` ` lines are content.

## Fix

Gate the metadata-skip block on `!currentHunk`. Outside a hunk it still skips the header/preamble lines exactly as before; inside a hunk those lines are treated as content. This is more robust than matching a trailing space (`'--- '`), which would still mis-handle content like `-- foo` -> `--- foo`.

## Tests

Adds `src/utils/gitDiff.test.ts`:
- a hunk with a removed `--`-prefixed line and an added `++`-prefixed line — both retained (fails before this change)
- a regression check that the file-header `---`/`+++`/`index` lines are still excluded from hunk content
- a normal add/remove/context hunk still parses (start lines + content)

`bun test src/utils/gitDiff.test.ts` passes; `tsc --noEmit` and `bun run build` are clean.

Closes #1645


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed git diff parsing to correctly preserve content lines that resemble diff headers when they appear within the actual diff content.

* **Tests**
  * Added comprehensive test coverage for git diff parsing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->