### PR TITLE
fix(diff): stop dropping in-hunk lines starting with -- or ++

### DIFF
--- a/src/utils/gitDiff.test.ts
+++ b/src/utils/gitDiff.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from 'bun:test'
+import { parseGitDiff } from './gitDiff.js'
+
+// Regression for #1645 — parseGitDiff dropped in-hunk content lines whose text
+// starts with `--` or `++`. A removed source line `--legacy-peer-deps` appears
+// in the unified diff as `---legacy-peer-deps`, and an added source line
+// `++count` appears as `+++count`. The metadata-skip block (meant only for the
+// per-file header: `--- a/file`, `+++ b/file`, `index ...`) ran for every line,
+// so those real changes were silently discarded.
+
+describe('parseGitDiff (#1645)', () => {
+  it('keeps a removed line whose content starts with --', () => {
+    const diff = [
+      'diff --git a/install.sh b/install.sh',
+      'index 1111111..2222222 100644',
+      '--- a/install.sh',
+      '+++ b/install.sh',
+      '@@ -1,3 +1,3 @@',
+      ' npm install \\',
+      '---legacy-peer-deps',
+      '+--legacy-peer-deps --force',
+      ' echo done',
+      '',
+    ].join('\n')
+
+    const hunks = parseGitDiff(diff).get('install.sh')
+    expect(hunks).toBeDefined()
+    const lines = hunks!.flatMap(h => h.lines)
+    expect(lines).toContain('---legacy-peer-deps')
+    expect(lines).toContain('+--legacy-peer-deps --force')
+  })
+
+  it('keeps an added line whose content starts with ++', () => {
+    const diff = [
+      'diff --git a/counter.c b/counter.c',
+      'index 3333333..4444444 100644',
+      '--- a/counter.c',
+      '+++ b/counter.c',
+      '@@ -1,2 +1,2 @@',
+      ' int main() {',
+      '-  count++;',
+      '+++count;',
+      '',
+    ].join('\n')
+
+    const hunks = parseGitDiff(diff).get('counter.c')
+    expect(hunks).toBeDefined()
+    const lines = hunks!.flatMap(h => h.lines)
+    expect(lines).toContain('+++count;')
+    expect(lines).toContain('-  count++;')
+  })
+
+  it('still strips the per-file header lines (--- / +++ / index) from hunks', () => {
+    const diff = [
+      'diff --git a/file.txt b/file.txt',
+      'index 5555555..6666666 100644',
+      '--- a/file.txt',
+      '+++ b/file.txt',
+      '@@ -1 +1 @@',
+      '-old',
+      '+new',
+      '',
+    ].join('\n')
+
+    const hunks = parseGitDiff(diff).get('file.txt')
+    expect(hunks).toBeDefined()
+    const lines = hunks!.flatMap(h => h.lines)
+    // Header lines must not leak into hunk content.
+    expect(lines).not.toContain('--- a/file.txt')
+    expect(lines).not.toContain('+++ b/file.txt')
+    expect(lines).not.toContain('index 5555555..6666666 100644')
+    expect(lines.filter(line => line !== '')).toEqual(['-old', '+new'])
+  })
+})

--- a/src/utils/gitDiff.ts
+++ b/src/utils/gitDiff.ts
@@ -248,16 +248,23 @@ export function parseGitDiff(
         continue
       }
 
-      // Skip binary file markers and other metadata
+      // Skip binary file markers and other file-header metadata. These only
+      // appear in the per-file preamble, before the first @@ hunk header, so
+      // only treat them as metadata while we're not yet inside a hunk.
+      // Otherwise an in-hunk line whose content starts with `--`/`++` (e.g. a
+      // removed `--legacy-peer-deps` → `---legacy-peer-deps`, or an added
+      // `++count` → `+++count`) would be misread as a `---`/`+++` file header
+      // and silently dropped from the parsed diff.
       if (
-        line.startsWith('index ') ||
-        line.startsWith('---') ||
-        line.startsWith('+++') ||
-        line.startsWith('new file') ||
-        line.startsWith('deleted file') ||
-        line.startsWith('old mode') ||
-        line.startsWith('new mode') ||
-        line.startsWith('Binary files')
+        !currentHunk &&
+        (line.startsWith('index ') ||
+          line.startsWith('---') ||
+          line.startsWith('+++') ||
+          line.startsWith('new file') ||
+          line.startsWith('deleted file') ||
+          line.startsWith('old mode') ||
+          line.startsWith('new mode') ||
+          line.startsWith('Binary files'))
       ) {
         continue
       }


### PR DESCRIPTION
## Summary

`parseGitDiff` (`src/utils/gitDiff.ts`) silently drops in-hunk content lines whose text starts with `--` or `++`:

- a removed source line `--legacy-peer-deps` renders in the diff as `---legacy-peer-deps`
- an added source line `++count` renders as `+++count`

Both were discarded, so the rendered diff was missing real changes.

## Root cause

The per-line loop has a metadata-skip block meant to strip the unified-diff **file header** (`--- a/file`, `+++ b/file`, `index ...`, `new file`, …). Those lines only appear in the per-file preamble, before the first `@@` hunk header — but the block ran for **every** line, including lines inside a hunk:

```ts
if (
  line.startsWith('index ') ||
  line.startsWith('---') ||   // also matches a removed line "---legacy-peer-deps"
  line.startsWith('+++') ||   // also matches an added line "+++count"
  ...
) {
  continue
}
```

So any in-hunk line beginning with `---`/`+++` was treated as a header and skipped.

## Fix

Gate the metadata-skip on not yet being inside a hunk (`!currentHunk`). Header stripping stays preamble-only; in-hunk `--`/`++` content lines reach the line-collection block and are preserved.

## Tests

Added `src/utils/gitDiff.test.ts`:
- removed line whose content starts with `--` is kept
- added line whose content starts with `++` is kept
- the per-file header (`---`/`+++`/`index`) is still stripped from hunk content

All pass; `tsc --noEmit` clean.

Fixes #1645

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Git diff parsing to correctly preserve diff content lines that start with `---` or `+++` characters, which were previously being incorrectly discarded during parsing. This ensures accurate display of diff files containing such content patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->