### PR TITLE
fix(claude-desktop): add native Windows support for MCP server import

### DIFF
--- a/src/components/MCPServerDesktopImportDialog.tsx
+++ b/src/components/MCPServerDesktopImportDialog.tsx
@@ -163,7 +163,7 @@ export function MCPServerDesktopImportDialog(t0) {
   }
   let t15;
   if ($[23] !== handleEscCancel || $[24] !== onSubmit || $[25] !== t13 || $[26] !== t14) {
-    t15 = <SelectMulti options={t13} defaultValue={t14} onSubmit={onSubmit} onCancel={handleEscCancel} hideIndexes={true} />;
+    t15 = <SelectMulti options={t13} defaultValue={[]} onSubmit={onSubmit} onCancel={handleEscCancel} hideIndexes={true} />;
     $[23] = handleEscCancel;
     $[24] = onSubmit;
     $[25] = t13;

--- a/src/components/MCPServerDesktopImportDialog.tsx
+++ b/src/components/MCPServerDesktopImportDialog.tsx
@@ -163,7 +163,7 @@ export function MCPServerDesktopImportDialog(t0) {
   }
   let t15;
   if ($[23] !== handleEscCancel || $[24] !== onSubmit || $[25] !== t13 || $[26] !== t14) {
-    t15 = <SelectMulti options={t13} defaultValue={[]} onSubmit={onSubmit} onCancel={handleEscCancel} hideIndexes={true} />;
+    t15 = <SelectMulti options={t13} defaultValue={t14} onSubmit={onSubmit} onCancel={handleEscCancel} hideIndexes={true} />;
     $[23] = handleEscCancel;
     $[24] = onSubmit;
     $[25] = t13;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3744,7 +3744,7 @@ async function run(): Promise<CommanderCommand> {
     } = await import('./cli/handlers/mcp.js');
     await mcpAddJsonHandler(name, json, options);
   });
-  mcp.command('add-from-claude-desktop').description('Import MCP servers from Claude Desktop (Mac and WSL only)').option('-s, --scope <scope>', 'Configuration scope (local, user, or project)', 'local').action(async (options: {
+  mcp.command('add-from-claude-desktop').description('Import MCP servers from Claude Desktop (macOS, Windows, and WSL)').option('-s, --scope <scope>', 'Configuration scope (local, user, or project)', 'local').action(async (options: {
     scope?: string;
   }) => {
     const {

--- a/src/utils/claudeDesktop.test.ts
+++ b/src/utils/claudeDesktop.test.ts
@@ -6,20 +6,28 @@ const isWindows = process.platform === 'win32'
 test('getClaudeDesktopConfigPath returns APPDATA path on Windows when APPDATA is set', async () => {
   if (!isWindows) return
 
-  const appData = process.env.APPDATA
-  const result = await getClaudeDesktopConfigPath()
-  expect(result).toBe(`${appData}\\Claude\\claude_desktop_config.json`)
+  const original = process.env.APPDATA
+  process.env.APPDATA = 'C:\\Users\\test\\AppData\\Roaming'
+  try {
+    const result = await getClaudeDesktopConfigPath()
+    expect(result).toBe(
+      'C:\\Users\\test\\AppData\\Roaming\\Claude\\claude_desktop_config.json',
+    )
+  } finally {
+    process.env.APPDATA = original
+  }
 })
 
 test('getClaudeDesktopConfigPath throws when APPDATA is unset on Windows', async () => {
   if (!isWindows) return
 
   const original = process.env.APPDATA
-  delete process.env.APPDATA
-
-  await expect(getClaudeDesktopConfigPath()).rejects.toThrow(
-    'APPDATA environment variable is not set.',
-  )
-
-  process.env.APPDATA = original
+  try {
+    delete process.env.APPDATA
+    await expect(getClaudeDesktopConfigPath()).rejects.toThrow(
+      'APPDATA environment variable is not set.',
+    )
+  } finally {
+    process.env.APPDATA = original
+  }
 })

--- a/src/utils/claudeDesktop.test.ts
+++ b/src/utils/claudeDesktop.test.ts
@@ -1,0 +1,25 @@
+import { expect, test } from 'bun:test'
+import { getClaudeDesktopConfigPath } from './claudeDesktop.js'
+
+const isWindows = process.platform === 'win32'
+
+test('getClaudeDesktopConfigPath returns APPDATA path on Windows when APPDATA is set', async () => {
+  if (!isWindows) return
+
+  const appData = process.env.APPDATA
+  const result = await getClaudeDesktopConfigPath()
+  expect(result).toBe(`${appData}\\Claude\\claude_desktop_config.json`)
+})
+
+test('getClaudeDesktopConfigPath throws when APPDATA is unset on Windows', async () => {
+  if (!isWindows) return
+
+  const original = process.env.APPDATA
+  delete process.env.APPDATA
+
+  await expect(getClaudeDesktopConfigPath()).rejects.toThrow(
+    'APPDATA environment variable is not set.',
+  )
+
+  process.env.APPDATA = original
+})

--- a/src/utils/claudeDesktop.test.ts
+++ b/src/utils/claudeDesktop.test.ts
@@ -1,4 +1,5 @@
 import { afterAll, expect, mock, test } from 'bun:test'
+import { win32 } from 'path'
 
 // force the windows code path on any host os so ci exercises these branches.
 // mock.module is process-global, so save the real module first and restore
@@ -22,7 +23,7 @@ test('getClaudeDesktopConfigPath returns APPDATA path on Windows when APPDATA is
   try {
     const result = await getClaudeDesktopConfigPath()
     expect(result).toBe(
-      'C:\\Users\\test\\AppData\\Roaming\\Claude\\claude_desktop_config.json',
+      win32.join('C:\\Users\\test\\AppData\\Roaming', 'Claude', 'claude_desktop_config.json'),
     )
   } finally {
     process.env.APPDATA = original

--- a/src/utils/claudeDesktop.test.ts
+++ b/src/utils/claudeDesktop.test.ts
@@ -1,11 +1,16 @@
-import { expect, test } from 'bun:test'
+import { expect, mock, test } from 'bun:test'
+
+// force windows code path regardless of host os so ci (linux) covers it too.
+// mock.module is process-global in bun - this file controls the mock for the
+// lifetime of the process, so it must not re-export tested helpers.
+mock.module('./platform.js', () => ({
+  getPlatform: () => 'windows' as const,
+  SUPPORTED_PLATFORMS: ['macos', 'wsl', 'windows'],
+}))
+
 import { getClaudeDesktopConfigPath } from './claudeDesktop.js'
 
-const isWindows = process.platform === 'win32'
-
 test('getClaudeDesktopConfigPath returns APPDATA path on Windows when APPDATA is set', async () => {
-  if (!isWindows) return
-
   const original = process.env.APPDATA
   process.env.APPDATA = 'C:\\Users\\test\\AppData\\Roaming'
   try {
@@ -19,8 +24,6 @@ test('getClaudeDesktopConfigPath returns APPDATA path on Windows when APPDATA is
 })
 
 test('getClaudeDesktopConfigPath throws when APPDATA is unset on Windows', async () => {
-  if (!isWindows) return
-
   const original = process.env.APPDATA
   try {
     delete process.env.APPDATA

--- a/src/utils/claudeDesktop.test.ts
+++ b/src/utils/claudeDesktop.test.ts
@@ -1,14 +1,20 @@
-import { expect, mock, test } from 'bun:test'
+import { afterAll, expect, mock, test } from 'bun:test'
 
-// force windows code path regardless of host os so ci (linux) covers it too.
-// mock.module is process-global in bun - this file controls the mock for the
-// lifetime of the process, so it must not re-export tested helpers.
+// force the windows code path on any host os so ci exercises these branches.
+// mock.module is process-global, so save the real module first and restore
+// it in afterAll to avoid breaking other test files.
+const realPlatform = await import('./platform.js')
+
 mock.module('./platform.js', () => ({
   getPlatform: () => 'windows' as const,
   SUPPORTED_PLATFORMS: ['macos', 'wsl', 'windows'],
 }))
 
 import { getClaudeDesktopConfigPath } from './claudeDesktop.js'
+
+afterAll(() => {
+  mock.module('./platform.js', () => realPlatform)
+})
 
 test('getClaudeDesktopConfigPath returns APPDATA path on Windows when APPDATA is set', async () => {
   const original = process.env.APPDATA

--- a/src/utils/claudeDesktop.test.ts
+++ b/src/utils/claudeDesktop.test.ts
@@ -11,7 +11,15 @@ mock.module('./platform.js', () => ({
   SUPPORTED_PLATFORMS: ['macos', 'wsl', 'windows'],
 }))
 
-import { getClaudeDesktopConfigPath } from './claudeDesktop.js'
+import { getClaudeDesktopConfigPath, readClaudeDesktopMcpServers } from './claudeDesktop.js'
+
+function restoreAppData(original: string | undefined): void {
+  if (original === undefined) {
+    delete process.env.APPDATA
+  } else {
+    process.env.APPDATA = original
+  }
+}
 
 afterAll(() => {
   mock.module('./platform.js', () => realPlatform)
@@ -26,7 +34,7 @@ test('getClaudeDesktopConfigPath returns APPDATA path on Windows when APPDATA is
       win32.join('C:\\Users\\test\\AppData\\Roaming', 'Claude', 'claude_desktop_config.json'),
     )
   } finally {
-    process.env.APPDATA = original
+    restoreAppData(original)
   }
 })
 
@@ -38,6 +46,18 @@ test('getClaudeDesktopConfigPath throws when APPDATA is unset on Windows', async
       'APPDATA environment variable is not set.',
     )
   } finally {
-    process.env.APPDATA = original
+    restoreAppData(original)
+  }
+})
+
+test('readClaudeDesktopMcpServers rethrows APPDATA error instead of swallowing it', async () => {
+  const original = process.env.APPDATA
+  try {
+    delete process.env.APPDATA
+    await expect(readClaudeDesktopMcpServers()).rejects.toThrow(
+      'APPDATA environment variable is not set.',
+    )
+  } finally {
+    restoreAppData(original)
   }
 })

--- a/src/utils/claudeDesktop.test.ts
+++ b/src/utils/claudeDesktop.test.ts
@@ -1,17 +1,7 @@
-import { afterAll, expect, mock, test } from 'bun:test'
+import { expect, test } from 'bun:test'
 import { win32 } from 'path'
 
-// force the windows code path on any host os so ci exercises these branches.
-// mock.module is process-global, so save the real module first and restore
-// it in afterAll to avoid breaking other test files.
-const realPlatform = await import('./platform.js')
-
-mock.module('./platform.js', () => ({
-  getPlatform: () => 'windows' as const,
-  SUPPORTED_PLATFORMS: ['macos', 'wsl', 'windows'],
-}))
-
-import { getClaudeDesktopConfigPath, readClaudeDesktopMcpServers } from './claudeDesktop.js'
+const isWindows = process.platform === 'win32'
 
 function restoreAppData(original: string | undefined): void {
   if (original === undefined) {
@@ -21,43 +11,49 @@ function restoreAppData(original: string | undefined): void {
   }
 }
 
-afterAll(() => {
-  mock.module('./platform.js', () => realPlatform)
+test('win32.join constructs correct Windows APPDATA path for Claude Desktop config', () => {
+  const appData = 'C:\\Users\\test\\AppData\\Roaming'
+  const result = win32.join(appData, 'Claude', 'claude_desktop_config.json')
+  expect(result).toBe('C:\\Users\\test\\AppData\\Roaming\\Claude\\claude_desktop_config.json')
 })
 
-test('getClaudeDesktopConfigPath returns APPDATA path on Windows when APPDATA is set', async () => {
-  const original = process.env.APPDATA
-  process.env.APPDATA = 'C:\\Users\\test\\AppData\\Roaming'
-  try {
-    const result = await getClaudeDesktopConfigPath()
-    expect(result).toBe(
-      win32.join('C:\\Users\\test\\AppData\\Roaming', 'Claude', 'claude_desktop_config.json'),
-    )
-  } finally {
-    restoreAppData(original)
-  }
-})
+if (isWindows) {
+  const { getClaudeDesktopConfigPath, readClaudeDesktopMcpServers } = await import('./claudeDesktop.js')
 
-test('getClaudeDesktopConfigPath throws when APPDATA is unset on Windows', async () => {
-  const original = process.env.APPDATA
-  try {
-    delete process.env.APPDATA
-    await expect(getClaudeDesktopConfigPath()).rejects.toThrow(
-      'APPDATA environment variable is not set.',
-    )
-  } finally {
-    restoreAppData(original)
-  }
-})
+  test('getClaudeDesktopConfigPath returns APPDATA path on Windows when APPDATA is set', async () => {
+    const original = process.env.APPDATA
+    process.env.APPDATA = 'C:\\Users\\test\\AppData\\Roaming'
+    try {
+      const result = await getClaudeDesktopConfigPath()
+      expect(result).toBe(
+        win32.join('C:\\Users\\test\\AppData\\Roaming', 'Claude', 'claude_desktop_config.json'),
+      )
+    } finally {
+      restoreAppData(original)
+    }
+  })
 
-test('readClaudeDesktopMcpServers rethrows APPDATA error instead of swallowing it', async () => {
-  const original = process.env.APPDATA
-  try {
-    delete process.env.APPDATA
-    await expect(readClaudeDesktopMcpServers()).rejects.toThrow(
-      'APPDATA environment variable is not set.',
-    )
-  } finally {
-    restoreAppData(original)
-  }
-})
+  test('getClaudeDesktopConfigPath throws when APPDATA is unset on Windows', async () => {
+    const original = process.env.APPDATA
+    try {
+      delete process.env.APPDATA
+      await expect(getClaudeDesktopConfigPath()).rejects.toThrow(
+        'APPDATA environment variable is not set.',
+      )
+    } finally {
+      restoreAppData(original)
+    }
+  })
+
+  test('readClaudeDesktopMcpServers rethrows APPDATA error instead of swallowing it', async () => {
+    const original = process.env.APPDATA
+    try {
+      delete process.env.APPDATA
+      await expect(readClaudeDesktopMcpServers()).rejects.toThrow(
+        'APPDATA environment variable is not set.',
+      )
+    } finally {
+      restoreAppData(original)
+    }
+  })
+}

--- a/src/utils/claudeDesktop.test.ts
+++ b/src/utils/claudeDesktop.test.ts
@@ -1,5 +1,6 @@
 import { expect, test } from 'bun:test'
 import { win32 } from 'path'
+import { getWindowsClaudeDesktopConfigPath } from './claudeDesktop.js'
 
 const isWindows = process.platform === 'win32'
 
@@ -11,16 +12,21 @@ function restoreAppData(original: string | undefined): void {
   }
 }
 
-test('win32.join constructs correct Windows APPDATA path for Claude Desktop config', () => {
-  const appData = 'C:\\Users\\test\\AppData\\Roaming'
-  const result = win32.join(appData, 'Claude', 'claude_desktop_config.json')
+test('getWindowsClaudeDesktopConfigPath constructs correct APPDATA path', () => {
+  const result = getWindowsClaudeDesktopConfigPath('C:\\Users\\test\\AppData\\Roaming')
   expect(result).toBe('C:\\Users\\test\\AppData\\Roaming\\Claude\\claude_desktop_config.json')
+})
+
+test('getWindowsClaudeDesktopConfigPath throws when APPDATA is not set', () => {
+  expect(() => getWindowsClaudeDesktopConfigPath(undefined)).toThrow(
+    'APPDATA environment variable is not set.',
+  )
 })
 
 if (isWindows) {
   const { getClaudeDesktopConfigPath, readClaudeDesktopMcpServers } = await import('./claudeDesktop.js')
 
-  test('getClaudeDesktopConfigPath returns APPDATA path on Windows when APPDATA is set', async () => {
+  test('getClaudeDesktopConfigPath delegates to helper when APPDATA is set', async () => {
     const original = process.env.APPDATA
     process.env.APPDATA = 'C:\\Users\\test\\AppData\\Roaming'
     try {
@@ -33,7 +39,7 @@ if (isWindows) {
     }
   })
 
-  test('getClaudeDesktopConfigPath throws when APPDATA is unset on Windows', async () => {
+  test('getClaudeDesktopConfigPath throws via helper when APPDATA is unset', async () => {
     const original = process.env.APPDATA
     try {
       delete process.env.APPDATA

--- a/src/utils/claudeDesktop.ts
+++ b/src/utils/claudeDesktop.ts
@@ -10,6 +10,15 @@ import { safeParseJSON } from './json.js'
 import { logError } from './log.js'
 import { getPlatform, SUPPORTED_PLATFORMS } from './platform.js'
 
+/**
+ * Resolves the path to the Claude Desktop configuration file based on the
+ * current platform. Supports macOS (~/Library/Application Support/Claude),
+ * native Windows (%APPDATA%/Claude), and WSL (/mnt/c/Users/...).
+ *
+ * Throws if the platform is not supported or if the required environment
+ * variable (%APPDATA%) is unset on Windows. The caller should handle these
+ * errors gracefully, as an absent config file is a normal state.
+ */
 export async function getClaudeDesktopConfigPath(): Promise<string> {
   const platform = getPlatform()
 
@@ -103,6 +112,11 @@ export async function getClaudeDesktopConfigPath(): Promise<string> {
   )
 }
 
+/**
+ * Reads MCP server configurations from the Claude Desktop config file.
+ * Returns an empty record if the config file does not exist or cannot be
+ * parsed, making it safe to call without error handling at the call site.
+ */
 export async function readClaudeDesktopMcpServers(): Promise<
   Record<string, McpServerConfig>
 > {

--- a/src/utils/claudeDesktop.ts
+++ b/src/utils/claudeDesktop.ts
@@ -1,6 +1,6 @@
 import { readdir, readFile, stat } from 'fs/promises'
 import { homedir } from 'os'
-import { join } from 'path'
+import { join, win32 } from 'path'
 import {
   type McpServerConfig,
   McpStdioServerConfigSchema,
@@ -43,7 +43,7 @@ export async function getClaudeDesktopConfigPath(): Promise<string> {
     if (!appData) {
       throw new Error('APPDATA environment variable is not set.')
     }
-    return join(appData, 'Claude', 'claude_desktop_config.json')
+    return win32.join(appData, 'Claude', 'claude_desktop_config.json')
   }
 
   // WSL — try using USERPROFILE environment variable if available

--- a/src/utils/claudeDesktop.ts
+++ b/src/utils/claudeDesktop.ts
@@ -168,6 +168,9 @@ export async function readClaudeDesktopMcpServers(): Promise<
 
     return servers
   } catch (error) {
+    if (error instanceof Error && error.message.includes('APPDATA environment variable is not set.')) {
+      throw error
+    }
     logError(error)
     return {}
   }

--- a/src/utils/claudeDesktop.ts
+++ b/src/utils/claudeDesktop.ts
@@ -15,7 +15,7 @@ export async function getClaudeDesktopConfigPath(): Promise<string> {
 
   if (!SUPPORTED_PLATFORMS.includes(platform)) {
     throw new Error(
-      `Unsupported platform: ${platform} - Claude Desktop integration only works on macOS and WSL.`,
+      `Unsupported platform: ${platform} - Claude Desktop integration only works on macOS, Windows, and WSL.`,
     )
   }
 
@@ -29,7 +29,15 @@ export async function getClaudeDesktopConfigPath(): Promise<string> {
     )
   }
 
-  // First, try using USERPROFILE environment variable if available
+  if (platform === 'windows') {
+    const appData = process.env.APPDATA
+    if (!appData) {
+      throw new Error('APPDATA environment variable is not set.')
+    }
+    return join(appData, 'Claude', 'claude_desktop_config.json')
+  }
+
+  // WSL — try using USERPROFILE environment variable if available
   const windowsHome = process.env.USERPROFILE
     ? process.env.USERPROFILE.replace(/\\/g, '/') // Convert Windows backslashes to forward slashes
     : null
@@ -100,7 +108,7 @@ export async function readClaudeDesktopMcpServers(): Promise<
 > {
   if (!SUPPORTED_PLATFORMS.includes(getPlatform())) {
     throw new Error(
-      'Unsupported platform - Claude Desktop integration only works on macOS and WSL.',
+      'Unsupported platform - Claude Desktop integration only works on macOS, Windows, and WSL.',
     )
   }
   try {

--- a/src/utils/claudeDesktop.ts
+++ b/src/utils/claudeDesktop.ts
@@ -11,6 +11,17 @@ import { logError } from './log.js'
 import { getPlatform, SUPPORTED_PLATFORMS } from './platform.js'
 
 /**
+ * Constructs the Claude Desktop config path on Windows from the APPDATA
+ * environment variable value. Throws if appData is undefined or empty.
+ */
+export function getWindowsClaudeDesktopConfigPath(appData: string | undefined): string {
+  if (!appData) {
+    throw new Error('APPDATA environment variable is not set.')
+  }
+  return win32.join(appData, 'Claude', 'claude_desktop_config.json')
+}
+
+/**
  * Resolves the path to the Claude Desktop configuration file based on the
  * current platform. Supports macOS (~/Library/Application Support/Claude),
  * native Windows (%APPDATA%/Claude), and WSL (/mnt/c/Users/...).
@@ -39,11 +50,7 @@ export async function getClaudeDesktopConfigPath(): Promise<string> {
   }
 
   if (platform === 'windows') {
-    const appData = process.env.APPDATA
-    if (!appData) {
-      throw new Error('APPDATA environment variable is not set.')
-    }
-    return win32.join(appData, 'Claude', 'claude_desktop_config.json')
+    return getWindowsClaudeDesktopConfigPath(process.env.APPDATA)
   }
 
   // WSL — try using USERPROFILE environment variable if available

--- a/src/utils/claudeDesktop.ts
+++ b/src/utils/claudeDesktop.ts
@@ -122,7 +122,9 @@ export async function getClaudeDesktopConfigPath(): Promise<string> {
 /**
  * Reads MCP server configurations from the Claude Desktop config file.
  * Returns an empty record if the config file does not exist or cannot be
- * parsed, making it safe to call without error handling at the call site.
+ * parsed, making it safe to call without error handling at the call site
+ * on macOS and WSL. On Windows, may throw if the APPDATA environment
+ * variable is not set.
  */
 export async function readClaudeDesktopMcpServers(): Promise<
   Record<string, McpServerConfig>

--- a/src/utils/platform.ts
+++ b/src/utils/platform.ts
@@ -6,7 +6,7 @@ import { logError } from './log.js'
 
 export type Platform = 'macos' | 'windows' | 'wsl' | 'linux' | 'unknown'
 
-export const SUPPORTED_PLATFORMS: Platform[] = ['macos', 'wsl']
+export const SUPPORTED_PLATFORMS: Platform[] = ['macos', 'wsl', 'windows']
 
 export const getPlatform = memoize((): Platform => {
   try {


### PR DESCRIPTION
### What changed and why

The `SUPPORTED_PLATFORMS` constant in `src/utils/platform.ts` only included `['macos', 'wsl']`, which caused both `getClaudeDesktopConfigPath()` and `readClaudeDesktopMcpServers()` in `src/utils/claudeDesktop.ts` to throw an "Unsupported platform" error on native Windows, despite the `Platform` type and `getPlatform()` both recognizing `'windows'` as a valid platform.

Additionally, `getClaudeDesktopConfigPath()` had no path resolution logic for native Windows. It handled macOS via `~/Library/Application Support/Claude/claude_desktop_config.json` and then fell through to WSL-specific logic that searches `/mnt/c/Users/...` paths. On native Windows, the correct config path is `%APPDATA%\Claude\claude_desktop_config.json` (typically `C:\Users\<user>\AppData\Roaming\Claude\claude_desktop_config.json`), matching where the Claude Desktop app stores its configuration on Windows.

### Changes

1. **`src/utils/platform.ts:9`** - Added `'windows'` to `SUPPORTED_PLATFORMS` so the platform guard in `claudeDesktop.ts` allows native Windows through.

2. **`src/utils/claudeDesktop.ts:32-38`** - Added a `'windows'` branch in `getClaudeDesktopConfigPath()` that resolves the config path using the `%APPDATA%` environment variable (`process.env.APPDATA`), which is the standard Windows environment variable pointing to `C:\Users\<user>\AppData\Roaming`.

3. **`src/utils/claudeDesktop.ts:18,111`** - Updated error messages from "only works on macOS and WSL" to "only works on macOS, Windows, and WSL".

### Impact

Unblocks the Claude Desktop MCP server import feature for users running OpenClaude on native Windows (non-WSL). Previously, any attempt to import MCP servers from Claude Desktop would fail immediately with an "Unsupported platform" error. Existing macOS and WSL code paths are completely unchanged.

### Checks ran

- Verified the `%APPDATA%` environment variable resolves to the correct path on Windows
- Existing macOS and WSL path resolution logic is untouched
- No existing tests cover this module

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Extended support to Windows platform for Claude Desktop configuration synchronization, joining macOS and WSL

* **Tests**
  * Added Windows platform test coverage to ensure reliability

* **Documentation**
  * Updated CLI help documentation to reflect Windows as a supported platform option
<!-- end of auto-generated comment: release notes by coderabbit.ai -->