### PR TITLE
Feat/system prompt immediate tools

### DIFF
--- a/src/constants/promptIdentity.test.ts
+++ b/src/constants/promptIdentity.test.ts
@@ -124,14 +124,23 @@ test('system prompt includes immediate-tool-use directive in non-REPL mode', asy
     const text = prompt.join('\n')
     expect(text).toContain('If you intend to use a tool to accomplish a task or analyze a file, use the tool IMMEDIATELY. Do not output a message explaining what you are going to do and then stop to wait for the user to prompt you again. Always call the tool in the same response.')
   } finally {
-    process.env.CLAUDE_REPL_MODE = originalReplMode
-    process.env.CLAUDE_CODE_REPL = originalCodeRepl
+    if (originalReplMode === undefined) {
+      delete process.env.CLAUDE_REPL_MODE
+    } else {
+      process.env.CLAUDE_REPL_MODE = originalReplMode
+    }
+    if (originalCodeRepl === undefined) {
+      delete process.env.CLAUDE_CODE_REPL
+    } else {
+      process.env.CLAUDE_CODE_REPL = originalCodeRepl
+    }
   }
 })
 
 test('system prompt includes immediate-tool-use directive in REPL mode', async () => {
   const originalReplMode = process.env.CLAUDE_REPL_MODE
   const originalCodeRepl = process.env.CLAUDE_CODE_REPL
+  delete process.env.CLAUDE_CODE_REPL
   process.env.CLAUDE_REPL_MODE = '1'
 
   try {
@@ -139,8 +148,16 @@ test('system prompt includes immediate-tool-use directive in REPL mode', async (
     const text = prompt.join('\n')
     expect(text).toContain('If you intend to use a tool to accomplish a task or analyze a file, use the tool IMMEDIATELY. Do not output a message explaining what you are going to do and then stop to wait for the user to prompt you again. Always call the tool in the same response.')
   } finally {
-    process.env.CLAUDE_REPL_MODE = originalReplMode
-    process.env.CLAUDE_CODE_REPL = originalCodeRepl
+    if (originalReplMode === undefined) {
+      delete process.env.CLAUDE_REPL_MODE
+    } else {
+      process.env.CLAUDE_REPL_MODE = originalReplMode
+    }
+    if (originalCodeRepl === undefined) {
+      delete process.env.CLAUDE_CODE_REPL
+    } else {
+      process.env.CLAUDE_CODE_REPL = originalCodeRepl
+    }
   }
 })
 

--- a/src/constants/promptIdentity.test.ts
+++ b/src/constants/promptIdentity.test.ts
@@ -114,6 +114,36 @@ test('system prompt model identity updates when model changes mid-session', asyn
   expect(secondText).not.toContain('You are powered by the model old-test-model.')
 })
 
+test('system prompt includes immediate-tool-use directive in non-REPL mode', async () => {
+  const originalReplMode = process.env.CLAUDE_REPL_MODE
+  const originalCodeRepl = process.env.CLAUDE_CODE_REPL
+  process.env.CLAUDE_CODE_REPL = '0'
+
+  try {
+    const prompt = await getSystemPrompt([], 'gpt-4o')
+    const text = prompt.join('\n')
+    expect(text).toContain('If you intend to use a tool to accomplish a task or analyze a file, use the tool IMMEDIATELY. Do not output a message explaining what you are going to do and then stop to wait for the user to prompt you again. Always call the tool in the same response.')
+  } finally {
+    process.env.CLAUDE_REPL_MODE = originalReplMode
+    process.env.CLAUDE_CODE_REPL = originalCodeRepl
+  }
+})
+
+test('system prompt includes immediate-tool-use directive in REPL mode', async () => {
+  const originalReplMode = process.env.CLAUDE_REPL_MODE
+  const originalCodeRepl = process.env.CLAUDE_CODE_REPL
+  process.env.CLAUDE_REPL_MODE = '1'
+
+  try {
+    const prompt = await getSystemPrompt([], 'gpt-4o')
+    const text = prompt.join('\n')
+    expect(text).toContain('If you intend to use a tool to accomplish a task or analyze a file, use the tool IMMEDIATELY. Do not output a message explaining what you are going to do and then stop to wait for the user to prompt you again. Always call the tool in the same response.')
+  } finally {
+    process.env.CLAUDE_REPL_MODE = originalReplMode
+    process.env.CLAUDE_CODE_REPL = originalCodeRepl
+  }
+})
+
 test('built-in agent prompts describe OpenClaude instead of Claude Code', () => {
   expect(DEFAULT_AGENT_PROMPT).toContain('OpenClaude')
   expect(DEFAULT_AGENT_PROMPT).not.toContain('Claude Code')

--- a/src/constants/prompts.ts
+++ b/src/constants/prompts.ts
@@ -272,6 +272,7 @@ function getUsingYourToolsSection(enabledTools: Set<string>): string {
       taskToolName
         ? `Break down and manage your work with the ${taskToolName} tool. These tools are helpful for planning your work and helping the user track your progress. Mark each task as completed as soon as you are done with the task. Do not batch up multiple tasks before marking them as completed.`
         : null,
+      `If you intend to use a tool to accomplish a task or analyze a file, use the tool IMMEDIATELY. Do not output a message explaining what you are going to do and then stop to wait for the user to prompt you again. Always call the tool in the same response.`,
     ].filter(item => item !== null)
     if (items.length === 0) return ''
     return [`# Using your tools`, ...prependBullets(items)].join(`\n`)
@@ -301,6 +302,7 @@ function getUsingYourToolsSection(enabledTools: Set<string>): string {
       ? `Break down and manage your work with the ${taskToolName} tool. These tools are helpful for planning your work and helping the user track your progress. Mark each task as completed as soon as you are done with the task. Do not batch up multiple tasks before marking them as completed.`
       : null,
     `You can call multiple tools in a single response. If you intend to call multiple tools and there are no dependencies between them, make all independent tool calls in parallel. Maximize use of parallel tool calls where possible to increase efficiency. However, if some tool calls depend on previous calls to inform dependent values, do NOT call these tools in parallel and instead call them sequentially. For instance, if one operation must complete before another starts, run these operations sequentially instead.`,
+    `If you intend to use a tool to accomplish a task or analyze a file, use the tool IMMEDIATELY. Do not output a message explaining what you are going to do and then stop to wait for the user to prompt you again. Always call the tool in the same response.`,
   ].filter(item => item !== null)
 
   return [`# Using your tools`, ...prependBullets(items)].join(`\n`)


### PR DESCRIPTION
## Summary

- **what changed**: Added an explicit directive in the `getUsingYourToolsSection` (both standard and REPL modes) of the system prompt instructing the model to invoke tools immediately in the same response.
- **why it changed**: To fix the "lazy agent" syndrome. The model frequently outputted text like *"I'll analyze this file to see what's wrong"* but then stopped generating without actually calling the tool, forcing the user to manually send another message (e.g. "go ahead") to trigger the execution.

## Impact

- **user-facing impact**: Much smoother, highly autonomous agentic loops. The model now chains tool executions (reading files, searching, etc.) in a continuous flow without unnecessarily pausing for user permission on intermediate research steps.
- **developer/maintainer impact**: Minimal. Modifies only the static text portion of the system prompt.

## Testing

- [ ] `bun run build`
- [ ] `bun run smoke`
- [x] `bun run check` (typecheck passes)
- [ ] focused tests: N/A (system prompt text modification)

## Notes

- **provider/model path tested**: Standard and REPL modes
- **screenshots attached (if UI changed)**: N/A
- **follow-up work or known limitations**: N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated AI assistant guidance to immediately execute tools in the same response when needed for task completion or file analysis, instead of outputting a message and waiting for user confirmation (applies to both standard and REPL modes).
* **Tests**
  * Added coverage to ensure the “immediate tool use” directive is included in the system prompt for both REPL-disabled and REPL-enabled configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->