### PR TITLE
fix: startup provider validation fallback

### DIFF
--- a/scripts/start-grpc.ts
+++ b/scripts/start-grpc.ts
@@ -27,13 +27,12 @@ async function main() {
   const {
     buildStartupEnvFromProfile,
     applyProfileEnvToProcessEnv,
-    isDefaultStartupProviderEnv,
   } = await import('../src/utils/providerProfile.js')
   const { getProviderValidationError, validateProviderEnvOrExit } = await import('../src/utils/providerValidation.js')
   const startupEnv = await buildStartupEnvFromProfile({ processEnv: process.env })
   if (startupEnv !== process.env) {
     const startupProfileError = await getProviderValidationError(startupEnv)
-    if (startupProfileError && !isDefaultStartupProviderEnv(startupEnv)) {
+    if (startupProfileError) {
       console.warn(`Warning: ignoring saved provider profile. ${startupProfileError}`)
     } else {
       applyProfileEnvToProcessEnv(process.env, startupEnv)

--- a/scripts/start-grpc.ts
+++ b/scripts/start-grpc.ts
@@ -24,20 +24,14 @@ async function main() {
   const { hydrateGithubModelsTokenFromSecureStorage } = await import('../src/utils/githubModelsCredentials.js')
   hydrateGithubModelsTokenFromSecureStorage()
 
-  const {
-    buildStartupEnvFromProfile,
-    applyProfileEnvToProcessEnv,
-  } = await import('../src/utils/providerProfile.js')
-  const { getProviderValidationError, validateProviderEnvOrExit } = await import('../src/utils/providerValidation.js')
-  const startupEnv = await buildStartupEnvFromProfile({ processEnv: process.env })
-  if (startupEnv !== process.env) {
-    const startupProfileError = await getProviderValidationError(startupEnv)
-    if (startupProfileError) {
-      console.warn(`Warning: ignoring saved provider profile. ${startupProfileError}`)
-    } else {
-      applyProfileEnvToProcessEnv(process.env, startupEnv)
-    }
-  }
+  const { applyStartupEnvFromProfile } = await import('../src/utils/providerProfile.js')
+  const { validateProviderEnvOrExit } = await import('../src/utils/providerValidation.js')
+  await applyStartupEnvFromProfile({
+    processEnv: process.env,
+    onValidationError: message => {
+      console.warn(message)
+    },
+  })
   await validateProviderEnvOrExit()
 
   const port = process.env.GRPC_PORT ? parseInt(process.env.GRPC_PORT, 10) : 50051

--- a/src/entrypoints/cli.test.ts
+++ b/src/entrypoints/cli.test.ts
@@ -85,38 +85,4 @@ describe('cli.tsx — --provider startup ordering', () => {
     expect(safeReapplyIndex).toBeLessThan(configApplyIndex)
     expect(configReapplyIndex).toBeGreaterThan(configApplyIndex)
   })
-
-  it('does not apply the startup env when validation fails (issue #1651)', async () => {
-    const src = await Bun.file(`${import.meta.dir}/cli.tsx`).text()
-
-    const validationIndex = src.indexOf('getProviderValidationError(startupEnv)')
-    const applyIndex = src.indexOf(
-      'applyProfileEnvToProcessEnv(process.env, startupEnv)',
-    )
-    const defaultProviderCarveOutIndex = src.indexOf(
-      'isDefaultStartupProviderEnv(startupEnv)',
-    )
-
-    expect(validationIndex).toBeGreaterThanOrEqual(0)
-    expect(applyIndex).toBeGreaterThanOrEqual(0)
-    expect(validationIndex).toBeLessThan(applyIndex)
-    expect(defaultProviderCarveOutIndex).toBe(-1)
-  })
-
-  it('keeps the gRPC bootstrap aligned when startup env validation fails (issue #1651)', async () => {
-    const src = await Bun.file(`${import.meta.dir}/../../scripts/start-grpc.ts`).text()
-
-    const validationIndex = src.indexOf('getProviderValidationError(startupEnv)')
-    const applyIndex = src.indexOf(
-      'applyProfileEnvToProcessEnv(process.env, startupEnv)',
-    )
-    const defaultProviderCarveOutIndex = src.indexOf(
-      'isDefaultStartupProviderEnv(startupEnv)',
-    )
-
-    expect(validationIndex).toBeGreaterThanOrEqual(0)
-    expect(applyIndex).toBeGreaterThanOrEqual(0)
-    expect(validationIndex).toBeLessThan(applyIndex)
-    expect(defaultProviderCarveOutIndex).toBe(-1)
-  })
 })

--- a/src/entrypoints/cli.test.ts
+++ b/src/entrypoints/cli.test.ts
@@ -85,4 +85,38 @@ describe('cli.tsx — --provider startup ordering', () => {
     expect(safeReapplyIndex).toBeLessThan(configApplyIndex)
     expect(configReapplyIndex).toBeGreaterThan(configApplyIndex)
   })
+
+  it('does not apply the startup env when validation fails (issue #1651)', async () => {
+    const src = await Bun.file(`${import.meta.dir}/cli.tsx`).text()
+
+    const validationIndex = src.indexOf('getProviderValidationError(startupEnv)')
+    const applyIndex = src.indexOf(
+      'applyProfileEnvToProcessEnv(process.env, startupEnv)',
+    )
+    const defaultProviderCarveOutIndex = src.indexOf(
+      'isDefaultStartupProviderEnv(startupEnv)',
+    )
+
+    expect(validationIndex).toBeGreaterThanOrEqual(0)
+    expect(applyIndex).toBeGreaterThanOrEqual(0)
+    expect(validationIndex).toBeLessThan(applyIndex)
+    expect(defaultProviderCarveOutIndex).toBe(-1)
+  })
+
+  it('keeps the gRPC bootstrap aligned when startup env validation fails (issue #1651)', async () => {
+    const src = await Bun.file(`${import.meta.dir}/../../scripts/start-grpc.ts`).text()
+
+    const validationIndex = src.indexOf('getProviderValidationError(startupEnv)')
+    const applyIndex = src.indexOf(
+      'applyProfileEnvToProcessEnv(process.env, startupEnv)',
+    )
+    const defaultProviderCarveOutIndex = src.indexOf(
+      'isDefaultStartupProviderEnv(startupEnv)',
+    )
+
+    expect(validationIndex).toBeGreaterThanOrEqual(0)
+    expect(applyIndex).toBeGreaterThanOrEqual(0)
+    expect(validationIndex).toBeLessThan(applyIndex)
+    expect(defaultProviderCarveOutIndex).toBe(-1)
+  })
 })

--- a/src/entrypoints/cli.tsx
+++ b/src/entrypoints/cli.tsx
@@ -104,26 +104,15 @@ async function main(): Promise<void> {
     applySafeConfigEnvironmentVariables()
   }
 
-  const {
-    applyProfileEnvToProcessEnv,
-    buildStartupEnvFromProfile,
-  } = await import('../utils/providerProfile.js')
-  const startupEnv = await buildStartupEnvFromProfile({
+  const { applyStartupEnvFromProfile } = await import(
+    '../utils/providerProfile.js'
+  )
+  await applyStartupEnvFromProfile({
     processEnv: process.env,
+    onValidationError: message => {
+      console.error(message)
+    },
   })
-  if (startupEnv !== process.env) {
-    const { getProviderValidationError } = await import(
-      '../utils/providerValidation.js'
-    )
-    const startupProfileError = await getProviderValidationError(startupEnv)
-    if (startupProfileError) {
-      console.error(
-        `Warning: ignoring saved provider profile. ${startupProfileError}`,
-      )
-    } else {
-      applyProfileEnvToProcessEnv(process.env, startupEnv)
-    }
-  }
 
   // Pane/window teammates are launched as fresh CLI processes. If the parent
   // selected a configured agentModels key, apply that route before provider

--- a/src/entrypoints/cli.tsx
+++ b/src/entrypoints/cli.tsx
@@ -107,7 +107,6 @@ async function main(): Promise<void> {
   const {
     applyProfileEnvToProcessEnv,
     buildStartupEnvFromProfile,
-    isDefaultStartupProviderEnv,
   } = await import('../utils/providerProfile.js')
   const startupEnv = await buildStartupEnvFromProfile({
     processEnv: process.env,
@@ -117,7 +116,7 @@ async function main(): Promise<void> {
       '../utils/providerValidation.js'
     )
     const startupProfileError = await getProviderValidationError(startupEnv)
-    if (startupProfileError && !isDefaultStartupProviderEnv(startupEnv)) {
+    if (startupProfileError) {
       console.error(
         `Warning: ignoring saved provider profile. ${startupProfileError}`,
       )

--- a/src/utils/providerProfile.test.ts
+++ b/src/utils/providerProfile.test.ts
@@ -7,6 +7,7 @@ import test, { afterEach, beforeEach } from 'node:test'
 import { acquireEnvMutex, releaseEnvMutex } from '../entrypoints/sdk/shared.js'
 import { resolveActiveRouteIdFromEnv } from '../integrations/routeMetadata.js'
 import { DEFAULT_CODEX_BASE_URL } from '../services/api/providerConfig.js'
+import { getProviderValidationError } from './providerValidation.js'
 import {
   applySavedProfileToCurrentSession,
   buildStartupEnvFromProfile,
@@ -290,6 +291,18 @@ test('buildStartupEnvFromProfile defaults fresh installs to Gitlawb Opengateway'
   assert.equal(env.OPENAI_BASE_URL, 'https://opengateway.gitlawb.com/v1')
   assert.equal(env.OPENAI_MODEL, 'mimo-v2.5-pro')
   assert.equal(isDefaultStartupProviderEnv(env), true)
+})
+
+test('buildStartupEnvFromProfile fresh-install OpenGateway env is invalid without an API key (issue #1651)', async () => {
+  const env = await buildStartupEnvFromProfile({
+    persisted: null,
+    processEnv: {},
+  })
+
+  assert.equal(isDefaultStartupProviderEnv(env), true)
+  const error = await getProviderValidationError(env)
+  assert.notEqual(error, null)
+  assert.ok(error!.includes('OPENGATEWAY_API_KEY'))
 })
 
 test('buildStartupEnvFromProfile preserves explicit OpenAI-compatible env without a saved profile', async () => {

--- a/src/utils/providerProfile.test.ts
+++ b/src/utils/providerProfile.test.ts
@@ -10,6 +10,7 @@ import { DEFAULT_CODEX_BASE_URL } from '../services/api/providerConfig.js'
 import { getProviderValidationError } from './providerValidation.js'
 import {
   applySavedProfileToCurrentSession,
+  applyStartupEnvFromProfile,
   buildStartupEnvFromProfile,
   buildAtomicChatProfileEnv,
   buildCodexProfileEnv,
@@ -303,6 +304,44 @@ test('buildStartupEnvFromProfile fresh-install OpenGateway env is invalid withou
   const error = await getProviderValidationError(env)
   assert.notEqual(error, null)
   assert.ok(error!.includes('OPENGATEWAY_API_KEY'))
+})
+
+test('applyStartupEnvFromProfile ignores invalid startup env and warns (issue #1651)', async () => {
+  const processEnv: NodeJS.ProcessEnv = {}
+  const warnings: string[] = []
+
+  const error = await applyStartupEnvFromProfile({
+    persisted: null,
+    processEnv,
+    onValidationError: message => warnings.push(message),
+  })
+
+  assert.notEqual(error, null)
+  assert.ok(error!.includes('OPENGATEWAY_API_KEY'))
+  assert.deepEqual(warnings, [
+    `Warning: ignoring saved provider profile. ${error}`,
+  ])
+  assert.deepEqual(processEnv, {})
+})
+
+test('applyStartupEnvFromProfile applies valid startup env (issue #1651)', async () => {
+  const processEnv: NodeJS.ProcessEnv = {
+    OPENGATEWAY_API_KEY: 'test-key',
+  }
+  const warnings: string[] = []
+
+  const error = await applyStartupEnvFromProfile({
+    persisted: null,
+    processEnv,
+    onValidationError: message => warnings.push(message),
+  })
+
+  assert.equal(error, null)
+  assert.deepEqual(warnings, [])
+  assert.equal(processEnv.CLAUDE_CODE_USE_OPENAI, '1')
+  assert.equal(processEnv.OPENAI_BASE_URL, 'https://opengateway.gitlawb.com/v1')
+  assert.equal(processEnv.OPENAI_MODEL, 'mimo-v2.5-pro')
+  assert.equal(processEnv.OPENGATEWAY_API_KEY, 'test-key')
 })
 
 test('buildStartupEnvFromProfile preserves explicit OpenAI-compatible env without a saved profile', async () => {

--- a/src/utils/providerProfile.ts
+++ b/src/utils/providerProfile.ts
@@ -1768,6 +1768,33 @@ export function applyProfileEnvToProcessEnv(
   Object.assign(targetEnv, nextEnv)
 }
 
+type StartupEnvOptions = NonNullable<Parameters<typeof buildStartupEnvFromProfile>[0]>
+
+export async function applyStartupEnvFromProfile(options?: StartupEnvOptions & {
+  onValidationError?: (message: string) => void
+}): Promise<string | null> {
+  const processEnv = options?.processEnv ?? process.env
+  const { onValidationError, ...startupOptions } = options ?? {}
+  const startupEnv = await buildStartupEnvFromProfile({
+    ...startupOptions,
+    processEnv,
+  })
+  if (startupEnv === processEnv) {
+    return null
+  }
+
+  const validationError = await getProviderValidationError(startupEnv)
+  if (validationError) {
+    onValidationError?.(
+      `Warning: ignoring saved provider profile. ${validationError}`,
+    )
+    return validationError
+  }
+
+  applyProfileEnvToProcessEnv(processEnv, startupEnv)
+  return null
+}
+
 export async function applySavedProfileToCurrentSession(options: {
   profileFile: ProfileFile
   processEnv?: NodeJS.ProcessEnv


### PR DESCRIPTION
## Summary

- Stop applying a saved/default startup provider env when startup validation fails.
- Keep the CLI and gRPC bootstrap paths aligned for invalid startup provider profiles.
- Add regression coverage for the fresh-install OpenGateway default and both startup call sites.

## Why

Fixes #1651.

Fresh installs can synthesize the Gitlawb OpenGateway startup provider without an `OPENGATEWAY_API_KEY`. The previous default-provider carve-out still applied that invalid env, which left startup on a broken provider path instead of ignoring the invalid profile/default and allowing normal repair flows.

## Impact

- Invalid startup provider profiles/defaults are ignored before mutating `process.env`.
- Users should see the existing warning and can repair provider settings through `/provider`.
- Provider paths affected: startup provider profile/default resolution for the CLI and gRPC server. The direct provider runtime/shim paths are unchanged.

## Validation

- `bun run build` - passed
- `bun run smoke` - passed
- `bun run typecheck` - passed
- `bun run typecheck:type-tests` - passed
- `bun run test:provider` - passed
- `bun run test:provider-recommendation` - passed
- `bun run security:pr-scan` - passed when rerun unsandboxed
- `python -m pytest -q python/tests` - 44 passed, with one pytest cache permission warning in the local sandbox
- `bun test src/entrypoints/cli.test.ts src/utils/providerProfile.test.ts` - 85 passed

## Known Local Check Notes

- `bun run check` initially failed because `knip` was listed but missing from `node_modules`; `bun install` restored the missing dev dependency without tracked file changes.
- `bun run check` / `bun run test:full` still fails in this local Windows workspace with order/environment-sensitive failures outside this change:
  - `/export` text filename tests render an auth error unless run with a dummy Anthropic key.
  - One `/lsp recommend` test timed out in the full serial suite but passed when rerun individually.
  - Marketplace cache finalization and secure-storage platform tests failed in the full serial suite but passed when rerun individually.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Unified startup provider environment application logic across the codebase by consolidating separate implementations into a shared utility function, simplifying maintenance and ensuring consistent validation behavior.

* **Tests**
  * Extended test coverage for provider profile validation scenarios, including handling of missing required environment variables and successful profile application during startup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->