### PR TITLE
fix: Ollama max output token override

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,9 @@ CLAUDE.md
 package-lock.json
 /.claude
 coverage/
+__pycache__/
+*.py[cod]
+pytest-cache-files-*/
 agent.log
 plan/
 .tmp

--- a/.gitignore
+++ b/.gitignore
@@ -17,7 +17,7 @@ package-lock.json
 coverage/
 __pycache__/
 *.py[cod]
-pytest-cache-files-*/
+.pytest_cache/
 agent.log
 plan/
 .tmp

--- a/src/services/api/claude.ts
+++ b/src/services/api/claude.ts
@@ -67,6 +67,7 @@ import {
   CAPPED_DEFAULT_MAX_TOKENS,
   getModelMaxOutputTokens,
   getSonnet1mExpTreatmentEnabled,
+  shouldUseIntegrationRuntimeLimits,
 } from '../../utils/context.js'
 import { resolveAppliedEffort } from '../../utils/effort.js'
 import { isEnvTruthy } from '../../utils/envUtils.js'
@@ -2301,8 +2302,10 @@ async function* queryModel(
               logEvent('tengu_max_tokens_reached', {
                 max_tokens: maxOutputTokens,
               })
+              const is3pProvider = shouldUseIntegrationRuntimeLimits()
+              const providerNoun = is3pProvider ? "Model's" : "OpenClaude's"
               yield createAssistantAPIErrorMessage({
-                content: `${API_ERROR_MESSAGE_PREFIX}: Claude's response exceeded the ${
+                content: `${API_ERROR_MESSAGE_PREFIX}: ${providerNoun} response exceeded the ${
                   maxOutputTokens
                 } output token maximum. To configure this behavior, set the CLAUDE_CODE_MAX_OUTPUT_TOKENS environment variable.`,
                 apiError: 'max_output_tokens',

--- a/src/utils/context.test.ts
+++ b/src/utils/context.test.ts
@@ -766,3 +766,69 @@ test('DashScope models clamp oversized max output overrides to the provider limi
   expect(getMaxOutputTokensForModel('glm-5')).toBe(16_384)
   expect(getMaxOutputTokensForModel('glm-5.1')).toBe(16_384)
 })
+
+test('Ollama model with no runtime metadata uses permissive upper limit (#1604)', () => {
+  // gemma4:e4b is not in the Ollama catalog — no runtime maxOutputTokens
+  // available. Previously the fallback Anthropic 64k upper limit silently
+  // capped the user's CLAUDE_CODE_MAX_OUTPUT_TOKENS override.
+  process.env.CLAUDE_CODE_USE_OPENAI = '1'
+  process.env.OPENAI_BASE_URL = 'http://localhost:11434/v1'
+  process.env.OPENAI_MODEL = 'gemma4:e4b'
+  delete process.env.CLAUDE_CODE_MAX_OUTPUT_TOKENS
+  delete process.env.CLAUDE_CODE_OPENAI_MAX_OUTPUT_TOKENS
+
+  expect(getModelMaxOutputTokens('gemma4:e4b')).toEqual({
+    default: 32_000,
+    upperLimit: 128_000,
+  })
+  expect(getMaxOutputTokensForModel('gemma4:e4b')).toBe(32_000)
+})
+
+test('Ollama model with no runtime metadata honors CLAUDE_CODE_MAX_OUTPUT_TOKENS above 64k (#1604)', () => {
+  process.env.CLAUDE_CODE_USE_OPENAI = '1'
+  process.env.OPENAI_BASE_URL = 'http://localhost:11434/v1'
+  process.env.OPENAI_MODEL = 'gemma4:e4b'
+  process.env.CLAUDE_CODE_MAX_OUTPUT_TOKENS = '128000'
+  delete process.env.CLAUDE_CODE_OPENAI_MAX_OUTPUT_TOKENS
+
+  // Previously this returned 64000 because the unknown-model fallback used
+  // MAX_OUTPUT_TOKENS_UPPER_LIMIT (64k) as the upper limit, silently capping
+  // the user's 128000 override.
+  expect(getMaxOutputTokensForModel('gemma4:e4b')).toBe(128_000)
+})
+
+test('Ollama model with no runtime metadata caps absurd overrides at the context window (#1604)', () => {
+  process.env.CLAUDE_CODE_USE_OPENAI = '1'
+  process.env.OPENAI_BASE_URL = 'http://localhost:11434/v1'
+  process.env.OPENAI_MODEL = 'gemma4:e4b'
+  process.env.CLAUDE_CODE_OPENAI_CONTEXT_WINDOWS = JSON.stringify({
+    'gemma4:e4b': 32_000,
+  })
+  process.env.CLAUDE_CODE_MAX_OUTPUT_TOKENS = '999999999'
+  delete process.env.CLAUDE_CODE_OPENAI_MAX_OUTPUT_TOKENS
+
+  expect(getMaxOutputTokensForModel('gemma4:e4b')).toBe(32_000)
+})
+
+test('Ollama model with no runtime metadata caps at fallback context window when context window is also unknown (#1604)', () => {
+  process.env.CLAUDE_CODE_USE_OPENAI = '1'
+  process.env.OPENAI_BASE_URL = 'http://localhost:11434/v1'
+  process.env.OPENAI_MODEL = 'gemma4:e4b'
+  process.env.CLAUDE_CODE_MAX_OUTPUT_TOKENS = '999999999'
+  delete process.env.CLAUDE_CODE_OPENAI_MAX_OUTPUT_TOKENS
+  delete process.env.CLAUDE_CODE_OPENAI_CONTEXT_WINDOWS
+
+  expect(getMaxOutputTokensForModel('gemma4:e4b')).toBe(128_000)
+})
+
+test('Anthropic model with high CLAUDE_CODE_MAX_OUTPUT_TOKENS still caps at model upper limit (#1604)', () => {
+  // Regression guard: the fix for #1604 must not relax the cap for Anthropic
+  // models where the API itself rejects values above the model's real limit.
+  delete process.env.CLAUDE_CODE_USE_OPENAI
+  delete process.env.OPENAI_BASE_URL
+  process.env.CLAUDE_CODE_MAX_OUTPUT_TOKENS = '128000'
+
+  expect(getMaxOutputTokensForModel('sonnet-4-6')).toBe(128_000)
+  expect(getMaxOutputTokensForModel('opus-4-1')).toBe(32_000)
+  expect(getMaxOutputTokensForModel('claude-3-opus')).toBe(4_096)
+})

--- a/src/utils/context.ts
+++ b/src/utils/context.ts
@@ -67,7 +67,7 @@ export function modelSupports1M(model: string): boolean {
   return canonical.includes('claude-sonnet-4') || canonical.includes('opus-4-6')
 }
 
-function shouldUseIntegrationRuntimeLimits(
+export function shouldUseIntegrationRuntimeLimits(
   processEnv: NodeJS.ProcessEnv = process.env,
 ): boolean {
   const routeId = resolveActiveRouteIdFromEnv(processEnv)
@@ -237,6 +237,16 @@ export function getModelMaxOutputTokens(model: string): {
         default: runtimeLimits.maxOutputTokens,
         upperLimit: runtimeLimits.maxOutputTokens,
       }
+    }
+    // 3P provider with no runtime maxOutputTokens (e.g. ad-hoc Ollama models
+    // like `gemma4:e4b` not in the route catalog) — fall through to a
+    // permissive upper limit so CLAUDE_CODE_MAX_OUTPUT_TOKENS isn't silently
+    // capped to the Anthropic 64k fallback below (issue #1604). Bound by the
+    // runtime context window when known; otherwise use the same fallback as
+    // context budgeting so output reservation cannot exceed the window.
+    return {
+      default: MAX_OUTPUT_TOKENS_DEFAULT,
+      upperLimit: runtimeLimits.contextWindow ?? OPENAI_FALLBACK_CONTEXT_WINDOW,
     }
   }
 


### PR DESCRIPTION
## Summary

- Fix unknown OpenAI-compatible/Ollama models without runtime `maxOutputTokens` metadata so `CLAUDE_CODE_MAX_OUTPUT_TOKENS` can raise the cap above the Anthropic-style 64k fallback.
- Keep the permissive override bounded by the known runtime context window, or by the existing OpenAI-compatible fallback context window when metadata is absent.
- Update the max-output error wording for third-party providers and ignore generated Python/pytest cache artifacts.

Fixes #1604

## User / Developer Impact

Users running uncatalogued Ollama models such as `Gemma4:e4b` can now set `CLAUDE_CODE_MAX_OUTPUT_TOKENS=128000` and have OpenClaude actually use that 128k output-token cap instead of silently staying at 64k. Known Anthropic/model-specific caps remain unchanged.

## Provider Path Tested

- Ollama through the OpenAI-compatible local route:
  - `CLAUDE_CODE_USE_OPENAI=1`
  - `OPENAI_BASE_URL=http://localhost:11434/v1`
  - `OPENAI_MODEL=Gemma4:e4b`
  - `CLAUDE_CODE_MAX_OUTPUT_TOKENS=128000`
- Smoke checked `getMaxOutputTokensForModel('Gemma4:e4b')` returns `128000`.

## Validation

Passed:

- `bun install` - no dependency changes
- `bun run build`
- `bun run smoke`
- `bun run typecheck`
- `bun run typecheck:type-tests`
- `bun run test:provider`
- `bun run test:provider-recommendation`
- `python -m pytest -q python/tests` - 44 passed, with one pytest cache permission warning
- `bun run security:pr-scan` - passed when rerun outside the managed sandbox
- `bun test src/utils/context.test.ts` - 51 passed
- `bun -e "process.env.CLAUDE_CODE_USE_OPENAI='1'; process.env.OPENAI_BASE_URL='http://localhost:11434/v1'; process.env.OPENAI_MODEL='Gemma4:e4b'; process.env.CLAUDE_CODE_MAX_OUTPUT_TOKENS='128000'; const { getMaxOutputTokensForModel } = await import('./src/services/api/claude.ts'); console.log(getMaxOutputTokensForModel('Gemma4:e4b'))"` - printed `128000`

`bun run check` status:

- `bun run check` passes build, smoke, deadcode, and most tests, but the full all-files `test:full` run still reports `3980 pass`, `11 fail`, `1 error` in unrelated areas.
- Reported failing groups: `src/commands/export/export.test.ts`, `src/commands/lsp/lsp.test.ts`, `src/utils/plugins/marketplaceManager.test.ts`, and `src/utils/secureStorage/platformStorage.test.ts`.
- Isolated reruns passed for `lsp`, `marketplaceManager`, and `secureStorage`.
- `export.test.ts` passed in isolation when run with a dummy `ANTHROPIC_API_KEY`; without it, the reproducible failure is the existing app render path requiring `ANTHROPIC_API_KEY` or `CLAUDE_CODE_OAUTH_TOKEN`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved API error messaging for token limit stop-reasons, including clearer context about provider-specific runtime limits.
  * Corrected max output token handling for OpenAI-compatible/route-based scenarios to avoid unintentionally applying Anthropic 64k fallback caps.
* **Tests**
  * Added regression coverage for model max-output token behavior, including Ollama defaults, environment overrides, and safety capping for extreme values.
* **Chores**
  * Updated gitignore to exclude Python runtime/build artifacts and test caches.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->