### PR TITLE
docs(readme): add social links and clarify license line

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ Use OpenAI-compatible APIs, Gemini, GitHub Models, Codex OAuth, Codex, Ollama, A
 [![PR Checks](https://github.com/Gitlawb/openclaude/actions/workflows/pr-checks.yml/badge.svg?branch=main)](https://github.com/Gitlawb/openclaude/actions/workflows/pr-checks.yml)
 [![Release](https://img.shields.io/github/v/tag/Gitlawb/openclaude?label=release&color=0ea5e9)](https://github.com/Gitlawb/openclaude/tags)
 [![Discussions](https://img.shields.io/badge/discussions-open-7c3aed)](https://github.com/Gitlawb/openclaude/discussions)
+[![Discord](https://img.shields.io/badge/Discord-join-5865F2?logo=discord&logoColor=white)](https://discord.gg/k68zFR6AcB)
+[![X](https://img.shields.io/badge/X-@gitlawb-000000?logo=x&logoColor=white)](https://x.com/gitlawb)
 [![Security Policy](https://img.shields.io/badge/security-policy-0f766e)](SECURITY.md)
 [![License](https://img.shields.io/badge/license-MIT-2563eb)](LICENSE)
 
@@ -416,6 +418,8 @@ If you believe you found a security issue, see [SECURITY.md](SECURITY.md).
 
 - Use [GitHub Discussions](https://github.com/Gitlawb/openclaude/discussions) for Q&A, ideas, and community conversation
 - Use [GitHub Issues](https://github.com/Gitlawb/openclaude/issues) for confirmed bugs and actionable feature work
+- Join the [Discord](https://discord.gg/k68zFR6AcB) to chat with the community in real time
+- Follow [@gitlawb on X](https://x.com/gitlawb) for updates and announcements
 
 ## Contributing
 
@@ -437,4 +441,4 @@ OpenClaude originated from the Claude Code codebase and has since been substanti
 
 ## License
 
-See [LICENSE](LICENSE).
+MIT for OpenClaude contributors' modifications; the derived Claude Code remains Anthropic's. [See more](LICENSE).


### PR DESCRIPTION
- Add Discord (discord.gg/k68zFR6AcB) and X (x.com/gitlawb) as shields.io badges in the top badge row and as descriptive links in the Community section.
- License section now notes contributor modifications are MIT while the derived Claude Code remains Anthropic's, with a "See more" link to LICENSE.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added social community badges for Discord and X to the top of the README.
  * Extended the Community section with new links to join Discord and follow the project on X.
  * Updated License section to clarify MIT licensing terms and applicable licensing for derived code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->