### PR TITLE
fix: sandbox temp dir fallback

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -8,7 +8,7 @@
         "@alcalzone/ansi-tokenize": "0.3.0",
         "@anthropic-ai/bedrock-sdk": "0.29.1",
         "@anthropic-ai/foundry-sdk": "0.2.3",
-        "@anthropic-ai/sandbox-runtime": "0.0.46",
+        "@anthropic-ai/sandbox-runtime": "0.0.55",
         "@anthropic-ai/sdk": "0.94.0",
         "@anthropic-ai/vertex-sdk": "0.16.0",
         "@commander-js/extra-typings": "12.1.0",
@@ -89,7 +89,7 @@
 
     "@anthropic-ai/foundry-sdk": ["@anthropic-ai/foundry-sdk@0.2.3", "", { "dependencies": { "@anthropic-ai/sdk": ">=0.50.3 <1" } }, "sha512-pD5yYnAeem5s8wDLbdf8/N8CejF/edRd9TJV+0PrT9tLKv6ggQimnr7d05pQn6FrIYACPmty9hekCo2JgepP0w=="],
 
-    "@anthropic-ai/sandbox-runtime": ["@anthropic-ai/sandbox-runtime@0.0.46", "", { "dependencies": { "@pondwader/socks5-server": "^1.0.10", "@types/lodash-es": "^4.17.12", "commander": "^12.1.0", "lodash-es": "^4.17.23", "shell-quote": "^1.8.3", "zod": "^3.24.1" }, "bin": { "srt": "dist/cli.js" } }, "sha512-FeVZ4rbdiHNPiMtf70xkiwogDGXYcCKCPmYjrED2HGNlk5jOabgrlvUROz0SsVksIh24SVRuTwNTK/yGBFm/5w=="],
+    "@anthropic-ai/sandbox-runtime": ["@anthropic-ai/sandbox-runtime@0.0.55", "", { "dependencies": { "@pondwader/socks5-server": "^1.0.10", "commander": "^12.1.0", "node-forge": "^1.4.0", "shell-quote": "^1.8.4", "zod": "^3.24.1" }, "bin": { "srt": "dist/cli.js" } }, "sha512-XGTLbzitn0y6OCdmqP5aYrBR0HlNi87ue++m9vMPxcNwaQeOj9i3f9CSWmXua8mv+Q8E55k4ZGlzJmpDHzQFBw=="],
 
     "@anthropic-ai/sdk": ["@anthropic-ai/sdk@0.94.0", "", { "dependencies": { "json-schema-to-ts": "^3.1.1" }, "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" }, "optionalPeers": ["zod"], "bin": { "anthropic-ai-sdk": "bin/cli" } }, "sha512-OVlCttk5MyeTGtrWX5+F3MJOfEMDuEjK8+rm9aQMDfRPWndVMbhk37QG8WLnVbcc7huyUGngVMjT7iMN2llySA=="],
 
@@ -419,10 +419,6 @@
 
     "@types/bun": ["@types/bun@1.3.11", "", { "dependencies": { "bun-types": "1.3.11" } }, "sha512-5vPne5QvtpjGpsGYXiFyycfpDF2ECyPcTSsFBMa0fraoxiQyMJ3SmuQIGhzPg2WJuWxVBoxWJ2kClYTcw/4fAg=="],
 
-    "@types/lodash": ["@types/lodash@4.17.24", "", {}, "sha512-gIW7lQLZbue7lRSWEFql49QJJWThrTFFeIMJdp3eH4tKoxm1OvEPg02rm4wCCSHS0cL3/Fizimb35b7k8atwsQ=="],
-
-    "@types/lodash-es": ["@types/lodash-es@4.17.12", "", { "dependencies": { "@types/lodash": "*" } }, "sha512-0NgftHUcV4v34VhXm8QBSftKVXtbkBG3ViCjs6+eJ5a6y6Mi/jiFGPc1sC7QK+9BFhWrURE3EOggmWaSxL9OzQ=="],
-
     "@types/node": ["@types/node@25.5.0", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw=="],
 
     "@types/react": ["@types/react@19.2.14", "", { "dependencies": { "csstype": "^3.2.2" } }, "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w=="],
@@ -742,6 +738,8 @@
     "negotiator": ["negotiator@1.0.0", "", {}, "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg=="],
 
     "node-fetch": ["node-fetch@2.7.0", "", { "dependencies": { "whatwg-url": "^5.0.0" }, "peerDependencies": { "encoding": "^0.1.0" }, "optionalPeers": ["encoding"] }, "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A=="],
+
+    "node-forge": ["node-forge@1.4.0", "", {}, "sha512-LarFH0+6VfriEhqMMcLX2F7SwSXeWwnEAJEsYm5QKWchiVYVvJyV9v7UDvUv+w5HO23ZpQTXDv/GxdDdMyOuoQ=="],
 
     "npm-run-path": ["npm-run-path@6.0.0", "", { "dependencies": { "path-key": "^4.0.0", "unicorn-magic": "^0.3.0" } }, "sha512-9qny7Z9DsQU8Ou39ERsPU4OZQlSTP47ShQzuKZ6PRXpYLtIFgl/DEBYEXKlvcEa+9tHVcK8CF81Y2V72qaZhWA=="],
 

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "@alcalzone/ansi-tokenize": "0.3.0",
     "@anthropic-ai/bedrock-sdk": "0.29.1",
     "@anthropic-ai/foundry-sdk": "0.2.3",
-    "@anthropic-ai/sandbox-runtime": "0.0.46",
+    "@anthropic-ai/sandbox-runtime": "0.0.55",
     "@anthropic-ai/sdk": "0.94.0",
     "@anthropic-ai/vertex-sdk": "0.16.0",
     "@commander-js/extra-typings": "12.1.0",

--- a/src/commands/plugin/BrowseMarketplace.tsx
+++ b/src/commands/plugin/BrowseMarketplace.tsx
@@ -18,6 +18,7 @@ import { getMarketplace, loadKnownMarketplacesConfig } from '../../utils/plugins
 import { OFFICIAL_MARKETPLACE_NAME } from '../../utils/plugins/officialMarketplace.js';
 import { installPluginFromMarketplace } from '../../utils/plugins/pluginInstallationHelpers.js';
 import { isPluginBlockedByPolicy } from '../../utils/plugins/pluginPolicy.js';
+import type { PluginMarketplaceEntry } from '../../utils/plugins/schemas.js';
 import { plural } from '../../utils/stringUtils.js';
 import { truncateToWidth } from '../../utils/truncate.js';
 import { findPluginOptionsTarget, PluginOptionsFlow } from './PluginOptionsFlow.js';
@@ -139,11 +140,12 @@ export function BrowseMarketplace({
           data: marketplace
         } of marketplaces_0) {
           if (marketplace) {
+            const plugins = marketplace.plugins as PluginMarketplaceEntry[];
             // Count how many plugins from this marketplace are installed
-            const installedFromThisMarketplace = count(marketplace.plugins, plugin => isPluginInstalled(createPluginId(plugin.name, name)));
+            const installedFromThisMarketplace = count(plugins, plugin => isPluginInstalled(createPluginId(plugin.name, name)));
             marketplaceInfos.push({
               name,
-              totalPlugins: marketplace.plugins.length,
+              totalPlugins: plugins.length,
               installedCount: installedFromThisMarketplace,
               source: getMarketplaceSourceDisplay(marketplaceConfig.source)
             });

--- a/src/components/Settings/Config.tsx
+++ b/src/components/Settings/Config.tsx
@@ -27,7 +27,7 @@ import { Dialog } from '../design-system/Dialog.js';
 import { Select } from '../CustomSelect/index.js';
 import { OutputStylePicker } from '../OutputStylePicker.js';
 import { LanguagePicker } from '../LanguagePicker.js';
-import { getExternalClaudeMdIncludes, getMemoryFiles, hasExternalClaudeMdIncludes } from 'src/utils/claudemd.js';
+import { getExternalClaudeMdIncludes, getMemoryFiles, hasExternalClaudeMdIncludes, type MemoryFileInfo } from 'src/utils/claudemd.js';
 import { KeyboardShortcutHint } from '../design-system/KeyboardShortcutHint.js';
 import { ConfigurableShortcutHint } from '../ConfigurableShortcutHint.js';
 import { Byline } from '../design-system/Byline.js';
@@ -198,7 +198,7 @@ export function Config({
   }, [ownsEsc, onIsSearchModeChange]);
   const isConnectedToIde = hasAccessToIDEExtensionDiffFeature(context.options.mcpClients);
   const isFileCheckpointingAvailable = !isEnvTruthy(process.env.CLAUDE_CODE_DISABLE_FILE_CHECKPOINTING);
-  const memoryFiles = React.use(getMemoryFiles(true));
+  const memoryFiles = React.use(getMemoryFiles(true)) as MemoryFileInfo[];
   function getPendingExternalIncludesScope(): 'User' | 'Project' | null {
     const cfg = getCurrentProjectConfig();
     // Project/Local first (mirrors startup priority in shouldShowClaudeMdExternalIncludesWarning)

--- a/src/components/StatusNotices.tsx
+++ b/src/components/StatusNotices.tsx
@@ -20,12 +20,13 @@ async function loadMemoryFiles(): Promise<void> {
   if (memoryFilesPromise) {
     return memoryFilesPromise;
   }
-  memoryFilesPromise = getMemoryFiles().then(files => {
+  const promise = getMemoryFiles().then(files => {
     cachedMemoryFiles = files;
   }).finally(() => {
     memoryFilesPromise = null;
   });
-  return memoryFilesPromise;
+  memoryFilesPromise = promise;
+  return promise;
 }
 
 /**

--- a/src/components/memory/MemoryFileSelector.tsx
+++ b/src/components/memory/MemoryFileSelector.tsx
@@ -48,7 +48,7 @@ export function MemoryFileSelector(t0) {
     onSelect,
     onCancel
   } = t0;
-  const existingMemoryFiles = use(getMemoryFiles());
+  const existingMemoryFiles = use(getMemoryFiles()) as MemoryFileInfo[];
   const originalCwd = getOriginalCwd();
   const userMemoryPath = join(getClaudeConfigHomeDir(), "CLAUDE.md");
   const projectMemoryPath = getProjectMemoryPathForSelector(existingMemoryFiles, originalCwd);

--- a/src/constants/outputStyles.ts
+++ b/src/constants/outputStyles.ts
@@ -182,7 +182,7 @@ export async function getOutputStyleConfig(): Promise<OutputStyleConfig | null> 
   const allStyles = await getAllOutputStyles(getCwd())
 
   // Check for forced plugin output styles
-  const forcedStyles = Object.values(allStyles).filter(
+  const forcedStyles = (Object.values(allStyles) as Array<OutputStyleConfig | null>).filter(
     (style): style is OutputStyleConfig =>
       style !== null &&
       style.source === 'plugin' &&

--- a/src/hooks/useManagePlugins.ts
+++ b/src/hooks/useManagePlugins.ts
@@ -13,6 +13,7 @@ import {
   subscribePluginCommands,
 } from '../state/pluginCommandsStore.js'
 import type { AgentDefinition } from '../tools/AgentTool/loadAgentsDir.js'
+import type { LoadedPlugin } from '../types/plugin.js'
 import { count } from '../utils/array.js'
 import { logForDebugging } from '../utils/debug.js'
 import { logForDiagnosticsNoPII } from '../utils/diagLogs.js'
@@ -26,6 +27,7 @@ import { loadPluginMcpServers } from '../utils/plugins/mcpPluginIntegration.js'
 import { detectAndUninstallDelistedPlugins } from '../utils/plugins/pluginBlocklist.js'
 import { getFlaggedPlugins } from '../utils/plugins/pluginFlagging.js'
 import { loadAllPlugins } from '../utils/plugins/pluginLoader.js'
+import type { HookMatcher, HooksSettings } from '../utils/settings/types.js'
 
 /**
  * Hook to manage plugin state and synchronize with AppState.
@@ -62,6 +64,7 @@ export function useManagePlugins({
     try {
       // Load all plugins - capture errors array
       const { enabled, disabled, errors } = await loadAllPlugins()
+      const enabledPlugins = enabled as LoadedPlugin[]
 
       // Detect delisted plugins, auto-uninstall them, and record as flagged.
       await detectAndUninstallDelistedPlugins()
@@ -130,7 +133,7 @@ export function useManagePlugins({
       // Runs BEFORE setAppState so any errors pushed by these loaders make it
       // into AppState.plugins.errors (Doctor UI), not just telemetry.
       const mcpServerCounts = await Promise.all(
-        enabled.map(async p => {
+        enabledPlugins.map(async p => {
           if (p.mcpServers) return Object.keys(p.mcpServers).length
           const servers = await loadPluginMcpServers(p, errors)
           if (servers) p.mcpServers = servers
@@ -146,7 +149,7 @@ export function useManagePlugins({
       // invalidation happened between main.tsx:3203 and REPL mount (e.g.
       // seed marketplace registration or policySettings hot-reload).
       const lspServerCounts = await Promise.all(
-        enabled.map(async p => {
+        enabledPlugins.map(async p => {
           if (p.lspServers) return Object.keys(p.lspServers).length
           const servers = await loadPluginLspServers(p, errors)
           if (servers) p.lspServers = servers
@@ -183,7 +186,7 @@ export function useManagePlugins({
           ...prevState,
           plugins: {
             ...prevState.plugins,
-            enabled,
+            enabled: enabledPlugins,
             disabled,
             commands: [],
             errors: mergedErrors,
@@ -192,15 +195,17 @@ export function useManagePlugins({
       })
 
       logForDebugging(
-        `Loaded plugins - Enabled: ${enabled.length}, Disabled: ${disabled.length}, Commands: ${commands.length}, Agents: ${agents.length}, Errors: ${errors.length}`,
+        `Loaded plugins - Enabled: ${enabledPlugins.length}, Disabled: ${disabled.length}, Commands: ${commands.length}, Agents: ${agents.length}, Errors: ${errors.length}`,
       )
 
       // Count component types across enabled plugins
-      const hook_count = enabled.reduce((sum, p) => {
+      const hook_count = enabledPlugins.reduce((sum, p) => {
         if (!p.hooksConfig) return sum
         return (
           sum +
-          Object.values(p.hooksConfig).reduce(
+          (Object.values(p.hooksConfig as HooksSettings) as Array<
+            HookMatcher[] | undefined
+          >).reduce(
             (s, matchers) =>
               s + (matchers?.reduce((h, m) => h + m.hooks.length, 0) ?? 0),
             0,
@@ -209,10 +214,10 @@ export function useManagePlugins({
       }, 0)
 
       return {
-        enabled_count: enabled.length,
+        enabled_count: enabledPlugins.length,
         disabled_count: disabled.length,
-        inline_count: count(enabled, p => p.source.endsWith('@inline')),
-        marketplace_count: count(enabled, p => !p.source.endsWith('@inline')),
+        inline_count: count(enabledPlugins, p => p.source.endsWith('@inline')),
+        marketplace_count: count(enabledPlugins, p => !p.source.endsWith('@inline')),
         error_count: errors.length,
         skill_count: commands.length,
         agent_count: agents.length,

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1454,7 +1454,7 @@ async function run(): Promise<CommanderCommand> {
         const {
           allowed,
           blocked
-        } = filterMcpServersByPolicy(scopedConfigs);
+        } = filterMcpServersByPolicy(scopedConfigs as Record<string, ScopedMcpServerConfig>);
         if (blocked.length > 0) {
           process.stderr.write(`Warning: MCP ${plural(blocked.length, 'server')} blocked by enterprise policy: ${blocked.join(', ')}\n`);
         }

--- a/src/services/api/grove.ts
+++ b/src/services/api/grove.ts
@@ -204,7 +204,8 @@ async function fetchAndStoreGroveConfig(accountId: string): Promise<void> {
     const groveEnabled = result.data.grove_enabled
     const cachedEntry = getGlobalConfig().groveConfigCache?.[accountId]
     if (
-      cachedEntry?.grove_enabled === groveEnabled &&
+      cachedEntry !== undefined &&
+      cachedEntry.grove_enabled === groveEnabled &&
       Date.now() - cachedEntry.timestamp <= GROVE_CACHE_EXPIRATION_MS
     ) {
       return

--- a/src/services/mcp/config.ts
+++ b/src/services/mcp/config.ts
@@ -1272,7 +1272,7 @@ export async function getAllMcpConfigs(): Promise<{
     claudeaiPromise,
   )
   const { allowed: claudeaiMcpServers } = filterMcpServersByPolicy(
-    await claudeaiPromise,
+    (await claudeaiPromise) as Record<string, ScopedMcpServerConfig>,
   )
 
   // Suppress claude.ai connectors that duplicate an enabled manual server.

--- a/src/services/mcp/doctor.ts
+++ b/src/services/mcp/doctor.ts
@@ -467,6 +467,7 @@ async function getLiveCheck(
           error: connection.error,
         }
     }
+    return { attempted: true, result: 'failed', durationMs }
   } finally {
     await deps.clearServerCache(name, activeConfig).catch(() => {
       // Best-effort cleanup for diagnostic connections.

--- a/src/utils/Shell.ts
+++ b/src/utils/Shell.ts
@@ -3,7 +3,6 @@ import { constants as fsConstants, readFileSync, unlinkSync } from 'fs'
 import { type FileHandle, mkdir, open, stat } from 'fs/promises'
 import memoize from 'lodash-es/memoize.js'
 import { isAbsolute, resolve } from 'path'
-import { join as posixJoin } from 'path/posix'
 import { logEvent } from 'src/services/analytics/index.js'
 import {
   getOriginalCwd,
@@ -30,7 +29,7 @@ export type { ExecResult } from './ShellCommand.js'
 
 import { accessSync } from 'fs'
 import { onCwdChangedForHooks } from './hooks/fileChangedWatcher.js'
-import { getClaudeTempDirName } from './permissions/filesystem.js'
+import { getClaudeTempDir } from './permissions/filesystem.js'
 import { getPlatform } from './platform.js'
 import { SandboxManager } from './sandbox/sandbox-adapter.js'
 import { invalidateSessionEnvCache } from './sessionEnvironment.js'
@@ -221,11 +220,8 @@ export async function exec(
     .toString(16)
     .padStart(4, '0')
 
-  // Sandbox temp directory - use per-user directory name to prevent multi-user permission conflicts
-  const sandboxTmpDir = posixJoin(
-    process.env.CLAUDE_CODE_TMPDIR || '/tmp',
-    getClaudeTempDirName(),
-  )
+  // Use the same probed temp directory that the sandbox allowlist exposes.
+  const sandboxTmpDir = getClaudeTempDir()
 
   const { commandString: builtCommand, cwdFilePath } =
     await provider.buildExecCommand(command, {

--- a/src/utils/analyzeContext.ts
+++ b/src/utils/analyzeContext.ts
@@ -307,7 +307,7 @@ async function countSystemTokens(
           content.length > 0 && content !== SYSTEM_PROMPT_DYNAMIC_BOUNDARY,
       )
       .map(content => ({ name: extractSectionName(content), content })),
-    ...Object.entries(systemContext)
+    ...(Object.entries(systemContext) as Array<[string, string]>)
       .filter(([, content]) => content.length > 0)
       .map(([name, content]) => ({ name, content })),
   ]

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -179,6 +179,7 @@ export function shortErrorStack(e: unknown, maxFrames = 5): string {
  *  ENOENT    — path does not exist
  *  EACCES    — permission denied
  *  EPERM     — operation not permitted
+ *  EROFS     — read-only filesystem
  *  ENOTDIR   — a path component is not a directory (e.g. a file named
  *              `.claude` exists where a directory is expected)
  *  ELOOP     — too many symlink levels (circular symlinks)
@@ -189,6 +190,7 @@ export function isFsInaccessible(e: unknown): e is NodeJS.ErrnoException {
     code === 'ENOENT' ||
     code === 'EACCES' ||
     code === 'EPERM' ||
+    code === 'EROFS' ||
     code === 'ENOTDIR' ||
     code === 'ELOOP'
   )

--- a/src/utils/fsOperations.ts
+++ b/src/utils/fsOperations.ts
@@ -422,12 +422,20 @@ export const NodeFsOperations: FsOperations = {
     try {
       await mkdirPromise(dirPath, { recursive: true, ...options })
     } catch (e) {
+      const code = getErrnoCode(e)
       // Bun/Windows: recursive:true throws EEXIST on directories with the
       // FILE_ATTRIBUTE_READONLY bit set (Group Policy, OneDrive, desktop.ini).
       // Bun's directoryExistsAt misclassifies DIRECTORY+READONLY as not-a-dir
       // (bun-internal src/sys.zig existsAtType). The dir exists; ignore.
       // https://github.com/anthropics/claude-code/issues/30924
-      if (getErrnoCode(e) !== 'EEXIST') throw e
+      if (code === 'EEXIST') return
+      // Permission denied on recursive:true — the parent dir may exist but
+      // refuse writes (e.g. /tmp in container environments with restricted
+      // permissions, systemd private tmp namespaces). If the directory
+      // already exists via a prior mkdir call, treat it as a no-op. This
+      // prevents the error from propagating to callers that don't catch it.
+      if (code === 'EACCES' && fs.existsSync(dirPath)) return
+      throw e
     }
   },
 
@@ -547,12 +555,19 @@ export const NodeFsOperations: FsOperations = {
     try {
       fs.mkdirSync(dirPath, mkdirOptions)
     } catch (e) {
+      const code = getErrnoCode(e)
       // Bun/Windows: recursive:true throws EEXIST on directories with the
       // FILE_ATTRIBUTE_READONLY bit set (Group Policy, OneDrive, desktop.ini).
       // Bun's directoryExistsAt misclassifies DIRECTORY+READONLY as not-a-dir
       // (bun-internal src/sys.zig existsAtType). The dir exists; ignore.
       // https://github.com/anthropics/claude-code/issues/30924
-      if (getErrnoCode(e) !== 'EEXIST') throw e
+      if (code === 'EEXIST') return
+      // Permission denied on recursive:true — the parent dir may exist but
+      // refuse writes (e.g. /tmp in container environments with restricted
+      // permissions, systemd private tmp namespaces). If the directory
+      // already exists via a prior mkdir call, treat it as a no-op.
+      if (code === 'EACCES' && fs.existsSync(dirPath)) return
+      throw e
     }
   },
 

--- a/src/utils/permissions/filesystem.ts
+++ b/src/utils/permissions/filesystem.ts
@@ -19,7 +19,9 @@ import { checkStatsigFeatureGate_CACHED_MAY_BE_STALE } from '../../services/anal
 import type { AnyObject, Tool, ToolPermissionContext } from '../../Tool.js'
 import { FILE_READ_TOOL_NAME } from '../../tools/FileReadTool/prompt.js'
 import { getCwd } from '../cwd.js'
+import { logForDebugging } from '../debug.js'
 import { getClaudeConfigHomeDir } from '../envUtils.js'
+import { isFsInaccessible } from '../errors.js'
 import {
   getFsImplementation,
   getPathsForPermissionCheck,
@@ -332,6 +334,21 @@ export function getClaudeTempDirName(): string {
   return `claude-${uid}`
 }
 
+function ensureUsableTempDir(
+  fs: ReturnType<typeof getFsImplementation>,
+  dirPath: string,
+): void {
+  fs.mkdirSync(dirPath, { mode: 0o700 })
+  const probeDir = join(
+    dirPath,
+    `.write-probe-${process.pid}-${Date.now()}-${Math.random()
+      .toString(36)
+      .slice(2)}`,
+  )
+  fs.mkdirSync(probeDir, { mode: 0o700 })
+  fs.rmdirSync(probeDir)
+}
+
 /**
  * Returns the Claude temp directory path with symlinks resolved.
  * Uses TMPDIR env var if set, otherwise:
@@ -361,7 +378,36 @@ export const getClaudeTempDir = memoize(function getClaudeTempDir(): string {
     // If resolution fails, use the original path
   }
 
-  return join(resolvedBaseTmpDir, getClaudeTempDirName()) + sep
+  const fullPath = join(resolvedBaseTmpDir, getClaudeTempDirName()) + sep
+
+  // Verify the directory is actually usable - on systems with restricted /tmp
+  // (container environments, systemd private tmp namespaces), the base temp dir
+  // may exist but reject mkdir/writes with EACCES.
+  try {
+    ensureUsableTempDir(fs, fullPath)
+  } catch (e: unknown) {
+    if (isFsInaccessible(e)) {
+      const fallbackDirs = [
+        join(tmpdir(), 'claude-code', getClaudeTempDirName()) + sep,
+        join(getClaudeConfigHomeDir(), 'tmp', getClaudeTempDirName()) + sep,
+      ]
+      for (const fallbackDir of fallbackDirs) {
+        try {
+          ensureUsableTempDir(fs, fallbackDir)
+          logForDebugging(
+            `Claude temp directory ${fullPath} is not writable; ` +
+              `falling back to ${fallbackDir}`,
+          )
+          return fallbackDir
+        } catch (fallbackError: unknown) {
+          if (!isFsInaccessible(fallbackError)) throw fallbackError
+        }
+      }
+    }
+    throw e
+  }
+
+  return fullPath
 })
 
 /**

--- a/src/utils/permissions/pathValidation.ts
+++ b/src/utils/permissions/pathValidation.ts
@@ -112,8 +112,8 @@ export function isPathInSandboxWriteAllowlist(resolvedPath: string): boolean {
   // their resolution to avoid N × config.length redundant syscalls per
   // command with N write targets (matching getResolvedWorkingDirPaths).
   const pathsToCheck = getPathsForPermissionCheck(resolvedPath)
-  const resolvedAllow = allowOnly.flatMap(getResolvedSandboxConfigPath)
-  const resolvedDeny = denyWithinAllow.flatMap(getResolvedSandboxConfigPath)
+  const resolvedAllow = allowOnly.flatMap(path => getResolvedSandboxConfigPath(path))
+  const resolvedDeny = denyWithinAllow.flatMap(path => getResolvedSandboxConfigPath(path))
   return pathsToCheck.every(p => {
     for (const denyPath of resolvedDeny) {
       if (pathInWorkingPath(p, denyPath)) return false

--- a/src/utils/plugins/loadPluginCommands.ts
+++ b/src/utils/plugins/loadPluginCommands.ts
@@ -525,7 +525,7 @@ export const getPluginCommands = memoize(async (): Promise<Command[]> => {
                   // Convert metadata.source (relative to plugin root) to absolute path for comparison
                   for (const [name, metadata] of Object.entries(
                     plugin.commandsMetadata,
-                  )) {
+                  ) as [string, CommandMetadata][]) {
                     if (metadata.source) {
                       const fullMetadataPath = join(
                         plugin.path,
@@ -610,7 +610,7 @@ export const getPluginCommands = memoize(async (): Promise<Command[]> => {
       if (plugin.commandsMetadata) {
         for (const [name, metadata] of Object.entries(
           plugin.commandsMetadata,
-        )) {
+        ) as [string, CommandMetadata][]) {
           // Only process entries with inline content (no source)
           if (metadata.content && !metadata.source) {
             try {

--- a/src/utils/plugins/refresh.ts
+++ b/src/utils/plugins/refresh.ts
@@ -35,6 +35,7 @@ import { loadPluginLspServers } from './lspPluginIntegration.js'
 import { loadPluginMcpServers } from './mcpPluginIntegration.js'
 import { clearPluginCacheExclusions } from './orphanedPluginFilter.js'
 import { loadAllPlugins } from './pluginLoader.js'
+import type { HookMatcher, HooksSettings } from '../settings/types.js'
 
 type SetAppState = (updater: (prev: AppState) => AppState) => void
 
@@ -166,7 +167,9 @@ export async function refreshActivePlugins(
     if (!p.hooksConfig) return sum
     return (
       sum +
-      Object.values(p.hooksConfig).reduce(
+      (Object.values(p.hooksConfig as HooksSettings) as Array<
+        HookMatcher[] | undefined
+      >).reduce(
         (s, matchers) =>
           s + (matchers?.reduce((h, m) => h + m.hooks.length, 0) ?? 0),
         0,

--- a/src/utils/sessionStorage.ts
+++ b/src/utils/sessionStorage.ts
@@ -104,8 +104,9 @@ function getBuiltInCommandNames(): Set<string> {
   if (builtInCommandNamesCache) return builtInCommandNamesCache
   const commands =
     require('../commands.js') as typeof import('../commands.js')
-  builtInCommandNamesCache = commands.builtInCommandNames()
-  return builtInCommandNamesCache
+  const names = commands.builtInCommandNames()
+  builtInCommandNamesCache = names
+  return names
 }
 
 type Transcript = (

--- a/src/utils/shell/bashProvider.ts
+++ b/src/utils/shell/bashProvider.ts
@@ -239,6 +239,7 @@ export async function createBashShellProvider(
         }
         env.TMPDIR = posixTmpDir
         env.CLAUDE_CODE_TMPDIR = posixTmpDir
+        env.CLAUDE_TMPDIR = posixTmpDir
         // Zsh uses TMPPREFIX (default /tmp/zsh) for heredoc temp files,
         // not TMPDIR. Set it to a path inside the sandbox tmp dir so
         // heredocs work in sandboxed zsh commands.

--- a/src/utils/shell/powershellProvider.ts
+++ b/src/utils/shell/powershellProvider.ts
@@ -116,6 +116,7 @@ export function createPowerShellProvider(shellPath: string): ShellProvider {
         // PowerShell on Linux/macOS honors TMPDIR for [System.IO.Path]::GetTempPath()
         env.TMPDIR = currentSandboxTmpDir
         env.CLAUDE_CODE_TMPDIR = currentSandboxTmpDir
+        env.CLAUDE_TMPDIR = currentSandboxTmpDir
       }
       return env
     },


### PR DESCRIPTION
## Summary
- Probe the Claude temp directory before returning it, and fall back to verified writable temp locations when the primary base is inaccessible or read-only.
- Use the resolved Claude temp dir for sandboxed shell cwd tracking and TMPDIR/CLAUDE_CODE_TMPDIR/CLAUDE_TMPDIR propagation so the sandbox allowlist and shell providers agree.
- Update @anthropic-ai/sandbox-runtime to 0.0.55 and refresh bun.lock.
- Fix the PR typecheck failures with narrow type annotations and inference hints.

## Impact
- Sandboxed Bash and PowerShell commands can continue to use writable temp storage in restricted /tmp, private tmp, or read-only tmp environments.
- Temp directory permission decisions are validated up front instead of memoizing an unusable path.

## Permission policy notes
- Sandboxed processes now receive CLAUDE_TMPDIR alongside TMPDIR and CLAUDE_CODE_TMPDIR.
- Fallback temp roots are still under policy-controlled temp/config locations:
  - `{tmpdir()}/claude-code/{claude temp dir name}/`
  - `{getClaudeConfigHomeDir()}/tmp/{claude temp dir name}/`

Fixes #1649

## Checks run
- bun install (passed after network/filesystem escalation; initial sandboxed run hit EPERM copying packages)
- bun run build (passed)
- python -m pytest -q python/tests (passed: 44 passed; pytest cache warning due access denied writing .pytest_cache)
- bun run typecheck (passed)
- bun run typecheck:type-tests (passed)
- git diff --check (passed; CRLF warnings only)
- bun run check (build/smoke/deadcode ran, but test:full still reports 11 full-suite failures that pass in focused reruns)
- ANTHROPIC_API_KEY=test-key bun test --max-concurrency=1 src/commands/export/export.test.ts (passed)
- Focused rerun of the other reported failing files passed: src/commands/lsp/lsp.test.ts, src/utils/plugins/marketplaceManager.test.ts, src/utils/secureStorage/platformStorage.test.ts
- bun run security:pr-scan (fails before scanning: null is not an object evaluating mergeBase.stderr.trim)

## Notes
- No UI or provider behavior changed; screenshots not applicable.
- Full-suite test failures appear order/global-state related in this local environment because the same reported files pass when run directly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sandbox temporary directory resolution with added usability probing and safer fallback locations.
  * Updated environment overrides so the sandbox temp directory is consistently honored in shell providers.
  * Strengthened recursive directory creation error handling (e.g., existing directory and access cases).
  * Refined caching and health-check failure output to reduce ambiguous/over-detailed results.
* **Chores**
  * Updated the sandbox runtime dependency to a newer compatible version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
