### PR TITLE
test(file-suggestions): stop cross-spawn mock leaking into later suites

### DIFF
--- a/src/hooks/fileSuggestions.test.ts
+++ b/src/hooks/fileSuggestions.test.ts
@@ -11,6 +11,7 @@ import * as path from 'node:path'
 type FakeChildProcess = EventEmitter & {
   stdout: EventEmitter
   stderr: EventEmitter
+  kill: (signal?: NodeJS.Signals | number) => boolean
 }
 
 type LoadModuleOptions = {
@@ -27,6 +28,14 @@ let actualCrossSpawnModule:
   | typeof import('cross-spawn')
   | undefined
 let actualRipgrepModule: typeof import('../utils/ripgrep.js') | undefined
+
+// The `cross-spawn` mock is installed via `mock.module`, which bun does NOT
+// undo on `mock.restore()` — it persists process-wide. To keep it from
+// hijacking real `git` spawns in later test files (which run sequentially),
+// the interception is gated on this module-level scenario, set only while one
+// of this suite's spawn-scenario tests is active and cleared in afterEach. Once
+// cleared, the persisted mock falls through to the real spawn.
+let activeSpawnScenario: LoadModuleOptions['spawnScenario'] | undefined
 let actualMarkdownConfigLoaderModule:
   | typeof import('../utils/markdownConfigLoader.js')
   | undefined
@@ -35,6 +44,9 @@ let defaultFileSuggestionsModule:
   | undefined
 
 afterEach(() => {
+  // Clear the spawn scenario so the persisted cross-spawn mock falls through to
+  // the real spawn for any later test file's git commands.
+  activeSpawnScenario = undefined
   mock.restore()
 })
 
@@ -55,6 +67,14 @@ function createFakeChildProcess(): FakeChildProcess {
   const child = new EventEmitter() as FakeChildProcess
   child.stdout = new EventEmitter()
   child.stderr = new EventEmitter()
+  // A real ChildProcess exposes kill(); callers (e.g. execFileNoThrow's
+  // timeout path) call it. Provide it so a foreign caller that ever reaches
+  // this fake child terminates cleanly instead of throwing
+  // "child.kill is not a function". Emit close so the caller stops waiting.
+  child.kill = (() => {
+    queueMicrotask(() => child.emit('close', null, 'SIGTERM'))
+    return true
+  }) as FakeChildProcess['kill']
   return child
 }
 
@@ -107,11 +127,11 @@ function installFileSuggestionsDependencyMocks(options: LoadModuleOptions = {}):
       args: string[],
       spawnOptions: { signal?: AbortSignal },
     ) => {
-      if (!options.spawnScenario || !isGitCommand(command)) {
+      if (!activeSpawnScenario || !isGitCommand(command)) {
         return realSpawn(command, args, spawnOptions)
       }
       const child = createFakeChildProcess()
-      options.spawnScenario?.(child, spawnOptions.signal)
+      activeSpawnScenario(child, spawnOptions.signal)
       return child
     },
     spawn: (
@@ -119,11 +139,11 @@ function installFileSuggestionsDependencyMocks(options: LoadModuleOptions = {}):
       args: string[],
       spawnOptions: { signal?: AbortSignal },
     ) => {
-      if (!options.spawnScenario || !isGitCommand(command)) {
+      if (!activeSpawnScenario || !isGitCommand(command)) {
         return realSpawn(command, args, spawnOptions)
       }
       const child = createFakeChildProcess()
-      options.spawnScenario?.(child, spawnOptions.signal)
+      activeSpawnScenario(child, spawnOptions.signal)
       return child
     },
   }))
@@ -151,6 +171,7 @@ function installFileSuggestionsDependencyMocks(options: LoadModuleOptions = {}):
 }
 
 async function loadFileSuggestionsModule(options: LoadModuleOptions = {}) {
+  activeSpawnScenario = options.spawnScenario
   actualCrossSpawnModule ??= await import('cross-spawn')
   actualRipgrepModule ??= await import('../utils/ripgrep.js')
   actualMarkdownConfigLoaderModule ??= await import(


### PR DESCRIPTION
## Problem

`src/commands/lsp/lsp.test.ts` → `/lsp recommend > falls back to filesystem scanning when git cannot enumerate workspace files` fails intermittently in `smoke-and-tests` with:

```
TypeError: child.kill is not a function. (In 'child.kill()', 'child.kill' is undefined)
  at .../src/commands/lsp/lsp.ts (discoverWorkspaceExtensions → execFileNoThrow timeout path)
```

It reproduces locally on a full `bun test src/` run (and on `main`), but passes in isolation — a classic order-dependent test-isolation bug.

## Root cause

`src/hooks/fileSuggestions.test.ts` mocks `cross-spawn` via `mock.module(...)`. bun's `mock.restore()` resets spies but does **not** undo `mock.module` — the module mock persists process-wide for the rest of the run. Its interception was gated on `options.spawnScenario`, captured in the factory closure at install time, so after this suite finished the persisted mock kept returning a fake child (a bare `EventEmitter`, no `kill()`) for **any** `git` command.

bun runs test files sequentially in one process, so a later suite's real `git ls-files` (the `/lsp recommend` filesystem-scan fallback) hit the leaked fake child, which never emits `close`. `execFileNoThrow` waited out its 5s timeout, then called `child.kill()` → `TypeError`, and the 5s wait also blew the test's own timeout.

## Fix

- Gate the cross-spawn interception on a module-level `activeSpawnScenario`, set only while one of this suite's spawn-scenario tests runs and cleared in `afterEach`. Once cleared, the persisted mock falls through to the real `spawn`, so later suites' git commands are untouched.
- Give the fake child a `kill()` that emits `close`, so any stray caller terminates cleanly instead of throwing.

## Verification

- `fileSuggestions.test.ts` in isolation: 9/9 pass.
- Full `bun test src/` green across repeated runs (previously intermittently red on the `/lsp` test).
- `tsc --noEmit` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test infrastructure for file suggestion mocking to ensure consistent behavior and proper cleanup across test scenarios.

---

**No user-facing changes in this release.**

<!-- end of auto-generated comment: release notes by coderabbit.ai -->