### PR TITLE
fix(provider): match xAI base URL by hostname, not 'x.ai' substring

### DIFF
--- a/src/utils/providerProfiles.test.ts
+++ b/src/utils/providerProfiles.test.ts
@@ -780,6 +780,30 @@ describe('applyProviderProfileToProcessEnv', () => {
     expect(getFreshAPIProvider()).toBe('xai')
   })
 
+  test('does not mirror XAI_API_KEY for a lookalike host containing "x.ai"', async () => {
+    const { applyProviderProfileToProcessEnv } =
+      await importFreshProviderProfileModules()
+
+    // `vertex.ai` contains the substring "x.ai"; a raw includes() check would
+    // wrongly treat this OpenAI-compatible profile as xAI and mirror the key
+    // into XAI_API_KEY. Host matching must be by hostname (api.x.ai), not
+    // substring.
+    applyProviderProfileToProcessEnv(
+      buildProfile({
+        provider: 'openai',
+        baseUrl: 'https://vertex.ai/v1',
+        model: 'some-model',
+        apiKey: 'not-an-xai-key',
+      }),
+    )
+    const { getAPIProvider: getFreshAPIProvider } =
+      await importFreshProvidersModule()
+
+    expect(process.env.XAI_API_KEY).toBeUndefined()
+    expect(process.env.OPENAI_API_KEY).toBe('not-an-xai-key')
+    expect(getFreshAPIProvider()).not.toBe('xai')
+  })
+
   test('openai-compatible profile applies maxContextLength env override', async () => {
     const { applyProviderProfileToProcessEnv } =
       await importFreshProviderProfileModules()

--- a/src/utils/providerProfiles.ts
+++ b/src/utils/providerProfiles.ts
@@ -44,7 +44,7 @@ import {
   type ResolvedProfileRoute,
   type ProviderPreset,
 } from '../integrations/index.js'
-import { isFireworksBaseUrl, isNearaiBaseUrl, resolveEnvOnlyProviderRouteId } from '../integrations/routeMetadata.js'
+import { isFireworksBaseUrl, isNearaiBaseUrl, isXaiBaseUrl, resolveEnvOnlyProviderRouteId } from '../integrations/routeMetadata.js'
 import { logForDebugging } from './debug.js'
 import {
   sanitizeProfileCustomHeaders,
@@ -560,7 +560,7 @@ function isProcessEnvAlignedWithProfile(
       ? !includeApiKey ||
         sameOptionalEnvValue(processEnv.BNKR_API_KEY, profile.apiKey)
       : true) &&
-    (profile.baseUrl?.toLowerCase().includes('x.ai')
+    (isXaiBaseUrl(profile.baseUrl)
       ? !includeApiKey ||
         sameOptionalEnvValue(processEnv.XAI_API_KEY, profile.apiKey)
       : true) &&
@@ -710,7 +710,7 @@ export function applyProviderProfileToProcessEnv(profile: ProviderProfile): void
       if (route.routeId === 'bankr' || profile.baseUrl.toLowerCase().includes('bankr')) {
         openAIProfileEnv.BNKR_API_KEY = profile.apiKey
       }
-      if (route.routeId === 'xai' || profile.baseUrl.toLowerCase().includes('x.ai')) {
+      if (route.routeId === 'xai' || isXaiBaseUrl(profile.baseUrl)) {
         openAIProfileEnv.XAI_API_KEY = profile.apiKey
       }
       if (route.routeId === 'venice' || profile.baseUrl.toLowerCase().includes('api.venice.ai')) {
@@ -1010,7 +1010,7 @@ function buildOpenAICompatibleStartupEnv(
     if (activeProfile.baseUrl?.toLowerCase().includes('bankr')) {
       env.BNKR_API_KEY = activeProfile.apiKey
     }
-    if (activeProfile.baseUrl?.toLowerCase().includes('x.ai')) {
+    if (isXaiBaseUrl(activeProfile.baseUrl)) {
       env.XAI_API_KEY = activeProfile.apiKey
     }
     if (activeProfile.baseUrl?.toLowerCase().includes('api.venice.ai')) {


### PR DESCRIPTION
## Problem

The xAI credential-mirroring checks in `src/utils/providerProfiles.ts` matched the base URL with a raw substring:

```ts
profile.baseUrl?.toLowerCase().includes('x.ai')
```

`x.ai` is a substring of unrelated hostnames — `vertex.ai`, `essex.ai`, `max.ai`, `prox.ai` all contain it. So an OpenAI-compatible profile pointed at such a host was wrongly treated as xAI:

- its api key was mirrored into `XAI_API_KEY`, and
- provider detection (`getAPIProvider`) flipped to `xai`,

which breaks model routing for that profile.

This file already imports `isFireworksBaseUrl` / `isNearaiBaseUrl` from `routeMetadata` and uses them for exactly this kind of check; the xAI sites were just inconsistent leftovers. A matching `isXaiBaseUrl` helper already exists and matches `hostname === 'api.x.ai'`.

## Fix

Route the three xAI sites through `isXaiBaseUrl`:

- `profileSecretsAreComplete`
- the OpenAI profile-env builder (`openAIProfileEnv.XAI_API_KEY`)
- the active-profile env builder (`env.XAI_API_KEY`)

No behavior change for real xAI profiles (`https://api.x.ai/v1`); lookalike hosts are no longer misrouted.

## Test

Added a regression test in `providerProfiles.test.ts`: a profile with `baseUrl: https://vertex.ai/v1` does not set `XAI_API_KEY` and is not detected as the `xai` provider. Verified it fails before the fix and passes after. `tsc --noEmit` clean; full `providerProfiles.test.ts` suite green (91 tests).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of XAI-compatible API endpoints to accurately distinguish from services with similar domain names (e.g., Vertex AI).

* **Tests**
  * Added regression test to verify correct API key handling for lookalike service URLs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->