### PR TITLE
fix(context): recognize Opus 4.7 as 1M-context capable in modelSupports1M

### DIFF
--- a/src/utils/context.test.ts
+++ b/src/utils/context.test.ts
@@ -6,6 +6,7 @@ import { resolveOpenAIShimRuntimeContext } from '../integrations/runtimeMetadata
 import {
   getContextWindowForModel,
   getModelMaxOutputTokens,
+  modelSupports1M,
 } from './context.ts'
 
 const originalEnv = {
@@ -831,4 +832,45 @@ test('Anthropic model with high CLAUDE_CODE_MAX_OUTPUT_TOKENS still caps at mode
   expect(getMaxOutputTokensForModel('sonnet-4-6')).toBe(128_000)
   expect(getMaxOutputTokensForModel('opus-4-1')).toBe(32_000)
   expect(getMaxOutputTokensForModel('claude-3-opus')).toBe(4_096)
+})
+
+test('modelSupports1M recognizes the current default Opus (4.7) as 1M-capable', () => {
+  const original = process.env.CLAUDE_CODE_DISABLE_1M_CONTEXT
+  delete process.env.CLAUDE_CODE_DISABLE_1M_CONTEXT
+  try {
+    // Regression: the firstParty default session model is claude-opus-4-7[1m]
+    // (getDefaultMainLoopModelSetting), so dropping 4.7 here downgrades a 1M
+    // session to 200K and trips a spurious "Context limit reached" — exactly
+    // what resolveSkillModelOverride relies on this predicate to prevent.
+    expect(modelSupports1M('claude-opus-4-7')).toBe(true)
+    expect(modelSupports1M('claude-opus-4-7[1m]')).toBe(true)
+    // Existing 1M models must keep working.
+    expect(modelSupports1M('claude-opus-4-6')).toBe(true)
+    expect(modelSupports1M('claude-sonnet-4-6')).toBe(true)
+    expect(modelSupports1M('claude-sonnet-4-5')).toBe(true)
+    // Models without a 1M variant must stay false.
+    expect(modelSupports1M('claude-opus-4-1')).toBe(false)
+    expect(modelSupports1M('claude-opus-4-0')).toBe(false)
+    expect(modelSupports1M('claude-3-5-haiku')).toBe(false)
+  } finally {
+    if (original === undefined) {
+      delete process.env.CLAUDE_CODE_DISABLE_1M_CONTEXT
+    } else {
+      process.env.CLAUDE_CODE_DISABLE_1M_CONTEXT = original
+    }
+  }
+})
+
+test('modelSupports1M honors the 1M disable switch even for Opus 4.7', () => {
+  const original = process.env.CLAUDE_CODE_DISABLE_1M_CONTEXT
+  process.env.CLAUDE_CODE_DISABLE_1M_CONTEXT = '1'
+  try {
+    expect(modelSupports1M('claude-opus-4-7')).toBe(false)
+  } finally {
+    if (original === undefined) {
+      delete process.env.CLAUDE_CODE_DISABLE_1M_CONTEXT
+    } else {
+      process.env.CLAUDE_CODE_DISABLE_1M_CONTEXT = original
+    }
+  }
 })

--- a/src/utils/context.ts
+++ b/src/utils/context.ts
@@ -64,7 +64,11 @@ export function modelSupports1M(model: string): boolean {
     return false
   }
   const canonical = getCanonicalName(model)
-  return canonical.includes('claude-sonnet-4') || canonical.includes('opus-4-6')
+  return (
+    canonical.includes('claude-sonnet-4') ||
+    canonical.includes('opus-4-6') ||
+    canonical.includes('opus-4-7')
+  )
 }
 
 export function shouldUseIntegrationRuntimeLimits(


### PR DESCRIPTION
## Summary

- `modelSupports1M` (`src/utils/context.ts`) matched only `claude-sonnet-4` and `opus-4-6`, so the current default Opus, `claude-opus-4-7`, is treated as **not** 1M-capable.
- The firstParty default session model is `claude-opus-4-7[1m]` (`getDefaultMainLoopModelSetting` -> `getDefaultOpusModel()` returns `getModelStrings().opus47` + `[1m]`), so 4.7 plainly supports 1M; the predicate was simply not updated at the 4.6 -> 4.7 default bump (the function carries an `@[MODEL LAUNCH]: Update this pattern...` reminder for exactly this).

## Impact

- user-facing impact: On a firstParty Opus 4.7 (`[1m]`) session, invoking a skill whose frontmatter says `model: opus` runs `resolveSkillModelOverride('opus', 'claude-opus-4-7[1m]')`. Because `modelSupports1M('claude-opus-4-7')` returned `false`, the `[1m]` suffix was dropped and the effective context window collapsed from 1M to 200K. That trips auto-compact at ~23% apparent usage and surfaces a spurious "Context limit reached" even though nothing overflowed — the exact failure `resolveSkillModelOverride`'s docstring says it exists to prevent. The same predicate also gates the beta-based 1M window path in `getContextWindowForModel`.
- developer/maintainer impact: none beyond the predicate. 3P providers stay on Opus 4.6 (`getDefaultOpusModel` keeps them there until 4.7 rolls out), and `opus-4-6` matching is unchanged.

## Testing

- [x] `bun run build`
- [x] `bun run smoke`
- [ ] `bun run check` (full suite runs in CI)
- [x] focused tests: `bun test src/utils/context.test.ts` (53 pass) + `tsc --noEmit` clean

## Notes

- provider/model path tested: `modelSupports1M` across `claude-opus-4-7`, `claude-opus-4-7[1m]`, `claude-opus-4-6`, `claude-sonnet-4-6/4-5` (all true), legacy `claude-opus-4-1/4-0` and `claude-3-5-haiku` (false), and the `CLAUDE_CODE_DISABLE_1M_CONTEXT` switch (forces false even for 4.7).
- follow-up work or known limitations: scoped strictly to the 1M-context predicate. Other `@[MODEL LAUNCH]` allowlists keyed on model capabilities (structured outputs / auto-mode in `betas.ts`) are left untouched, since whether 4.7 supports those is a capability question rather than the contract-defined suffix carry-over fixed here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extended model support to recognize Claude Opus 4.7 variants as supporting 1M token context windows.

* **Tests**
  * Added tests verifying Opus 4.7 model recognition and context capability behavior, including environment-based configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->