### PR TITLE
fix(model): preserve [1m] tag for the 'best' alias

### DIFF
--- a/src/utils/model/model.ts
+++ b/src/utils/model/model.ts
@@ -760,7 +760,7 @@ export function parseUserSpecifiedModel(
       case 'opus':
         return getDefaultOpusModel() + (has1mTag ? '[1m]' : '')
       case 'best':
-        return getBestModel()
+        return getBestModel() + (has1mTag ? '[1m]' : '')
       default:
     }
   }

--- a/src/utils/model/parseUserSpecifiedModel.bestTag.test.ts
+++ b/src/utils/model/parseUserSpecifiedModel.bestTag.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, test } from 'bun:test'
+import { parseUserSpecifiedModel } from './model.js'
+
+// Regression: the `best` alias dropped the `[1m]` (1M-context) tag while the
+// other aliases (opus/sonnet/haiku) preserved it. `best` resolves to the same
+// model as `opus`, so `best[1m]` should behave exactly like `opus[1m]` and keep
+// the 1M tag. Assertions are relational so they don't pin a specific model id.
+describe('parseUserSpecifiedModel — best alias 1M tag', () => {
+  test('best[1m] preserves the [1m] tag, matching the opus alias', () => {
+    const best = parseUserSpecifiedModel('best')
+    const best1m = parseUserSpecifiedModel('best[1m]')
+
+    expect(best1m).toBe(`${best}[1m]`)
+    expect(best1m.endsWith('[1m]')).toBe(true)
+  })
+
+  test('best and best[1m] track the opus alias exactly', () => {
+    expect(parseUserSpecifiedModel('best')).toBe(parseUserSpecifiedModel('opus'))
+    expect(parseUserSpecifiedModel('best[1m]')).toBe(
+      parseUserSpecifiedModel('opus[1m]'),
+    )
+  })
+
+  test('the tag is case-insensitive and not duplicated', () => {
+    const best1m = parseUserSpecifiedModel('best[1m]')
+    expect(parseUserSpecifiedModel('BEST[1M]')).toBe(best1m)
+    // exactly one trailing [1m], no doubling
+    expect(best1m.match(/\[1m]/gi)?.length).toBe(1)
+  })
+})


### PR DESCRIPTION
## Problem

`parseUserSpecifiedModel` appends the `[1m]` (1M-context) tag for the `opus`, `sonnet`, and `haiku` aliases, but not for `best`:

```ts
case 'sonnet':
  return getDefaultSonnetModel() + (has1mTag ? '[1m]' : '')
case 'opus':
  return getDefaultOpusModel() + (has1mTag ? '[1m]' : '')
case 'best':
  return getBestModel()   // <- drops the tag
```

`getBestModel()` returns `getDefaultOpusModel()` — the same model as the `opus` alias — so the two should behave identically. They don't:

```
opus[1m]  -> claude-opus-4-7[1m]
best[1m]  -> claude-opus-4-7      # 1M tag silently dropped
```

A user pinning `best[1m]` (best model, 1M context) silently loses the larger context window.

## Fix

Append the tag for `best` as well, matching the other aliases:

```ts
case 'best':
  return getBestModel() + (has1mTag ? '[1m]' : '')
```

## Test

Added `parseUserSpecifiedModel.bestTag.test.ts` with relational assertions (no hardcoded model id):
- `best[1m]` === `best` + `[1m]`
- `best`/`best[1m]` track `opus`/`opus[1m]` exactly
- tag is case-insensitive and not duplicated

Verified it fails before the fix and passes after. `tsc --noEmit` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The "best" model alias now correctly preserves variant specifications when applied.

* **Tests**
  * Added regression test coverage for model alias variant tag handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->