### PR TITLE
fix(openai): nest reasoning under reasoning.effort on Responses API

### DIFF
--- a/src/services/api/openaiShim.test.ts
+++ b/src/services/api/openaiShim.test.ts
@@ -345,6 +345,51 @@ test('uses OpenAI-compatible responses endpoint when OPENAI_API_FORMAT=responses
   ])
 })
 
+test('nests reasoning under reasoning.effort (not flat reasoning_effort) on the responses endpoint (#1638)', async () => {
+  process.env.OPENAI_API_FORMAT = 'responses'
+  let capturedBody: Record<string, unknown> | undefined
+
+  globalThis.fetch = (async (_input, init) => {
+    capturedBody = JSON.parse(String(init?.body)) as Record<string, unknown>
+
+    return new Response(
+      JSON.stringify({
+        id: 'resp-1',
+        model: 'gpt-5.4',
+        output: [
+          {
+            type: 'message',
+            role: 'assistant',
+            content: [{ type: 'output_text', text: 'ok' }],
+          },
+        ],
+        usage: { input_tokens: 8, output_tokens: 3, total_tokens: 11 },
+      }),
+      { headers: { 'Content-Type': 'application/json' } },
+    )
+  }) as unknown as FetchType
+
+  const client = createOpenAIShimClient({
+    defaultHeaders: {},
+    reasoningEffort: 'high',
+  }) as OpenAIShimClient
+
+  await client.beta.messages.create({
+    model: 'gpt-5.4',
+    system: 'test system',
+    messages: [{ role: 'user', content: 'hello' }],
+    max_tokens: 64,
+    stream: false,
+  })
+
+  // The Responses API rejects the flat chat_completions fields with
+  // `Unsupported parameter: 'reasoning_effort'`; reasoning must be nested.
+  expect(capturedBody?.reasoning).toEqual({ effort: 'high', summary: 'auto' })
+  expect(capturedBody && 'reasoning_effort' in capturedBody).toBe(false)
+  expect(capturedBody && 'reasoning_summary' in capturedBody).toBe(false)
+  expect(capturedBody?.include).toEqual(['reasoning.encrypted_content'])
+})
+
 test('uses OpenAI-compatible responses endpoint with text chunk types when OPENAI_API_FORMAT=responses_compat', async () => {
   process.env.OPENAI_API_FORMAT = 'responses_compat'
   let capturedUrl = ''

--- a/src/services/api/openaiShim.ts
+++ b/src/services/api/openaiShim.ts
@@ -2577,8 +2577,16 @@ class OpenAIShimMessages {
       if (params.temperature !== undefined) responsesBody.temperature = params.temperature
       if (params.top_p !== undefined) responsesBody.top_p = params.top_p
       if (request.reasoning?.effort) {
-        responsesBody.reasoning_effort = request.reasoning.effort
-        responsesBody.reasoning_summary = 'auto'
+        // The Responses API nests reasoning controls under a `reasoning`
+        // object ({ effort, summary }). The flat `reasoning_effort` /
+        // `reasoning_summary` fields are chat_completions-only; the Responses
+        // API rejects them with `Unsupported parameter: 'reasoning_effort'.
+        // In the Responses API, this parameter has moved to 'reasoning.effort'`
+        // (#1638).
+        responsesBody.reasoning = {
+          effort: request.reasoning.effort,
+          summary: 'auto',
+        }
         responsesBody.include = ['reasoning.encrypted_content']
       }
 


### PR DESCRIPTION
## Problem

Fixes #1638.

The OpenAI shim's Responses API transport was sending reasoning configuration as flat top-level fields (`reasoning_effort` / `reasoning_summary`), which is the shape the Chat Completions endpoint expects. The Responses API rejects those flat fields — it expects reasoning nested under a `reasoning` object (`reasoning: { effort, summary }`) and the encrypted reasoning content requested via `include`.

## Fix

In the Responses path, when `request.reasoning?.effort` is set, build:

```ts
responsesBody.reasoning = { effort: request.reasoning.effort, summary: 'auto' }
responsesBody.include = ['reasoning.encrypted_content']
```

The Chat Completions path (flat `reasoning_effort`) is left unchanged.

## Tests

Added a test asserting the Responses endpoint sends `reasoning: { effort: 'high', summary: 'auto' }` and `include: ['reasoning.encrypted_content']`, and does **not** send flat `reasoning_effort` / `reasoning_summary`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated reasoning parameter structure in OpenAI API requests to align with the Responses API format, ensuring proper parameter nesting when reasoning effort is specified.

* **Tests**
  * Added test coverage for reasoning parameter handling with the Responses API format configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->