### PR TITLE
fix: guard against Object.prototype properties in FILENAME_LANGS lookup

### DIFF
--- a/src/native-ts/color-diff/index.ts
+++ b/src/native-ts/color-diff/index.ts
@@ -429,7 +429,7 @@ function detectLanguage(
   // Filename-based lookup (handles Dockerfile, Makefile, CMakeLists.txt, etc.)
   const stem = base.split('.')[0] ?? ''
   const byName = FILENAME_LANGS[base] ?? FILENAME_LANGS[stem]
-  if (byName && hljs().getLanguage(byName)) return byName
+  if (typeof byName === 'string' && hljs().getLanguage(byName)) return byName
   if (ext) {
     const lang = hljs().getLanguage(ext)
     if (lang) return ext


### PR DESCRIPTION
Fixes #1430

When a file is named `constructor.css`, the stem `constructor` matches `Object.prototype.constructor` (a function) via the plain-object lookup in `FILENAME_LANGS`. `highlight.js`'s `getLanguage()` then receives a function instead of a string and crashes on `.toLowerCase()`.

**Fix:** Added `typeof byName === 'string'` guard so only string values are passed to `getLanguage()`.

```ts
// Before
if (byName && hljs().getLanguage(byName)) return byName

// After
if (typeof byName === 'string' && hljs().getLanguage(byName)) return byName
```

This is a one-line fix. Files named `constructor`, `toString`, `valueOf`, `hasOwnProperty`, etc. no longer crash the diff renderer.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved language detection reliability by adding stricter validation when looking up language names, preventing potential issues with invalid inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->