### PR TITLE
fix: WSL stdin handling

### DIFF
--- a/src/commands/lsp/lsp.test.ts
+++ b/src/commands/lsp/lsp.test.ts
@@ -375,23 +375,30 @@ describe('/lsp recommend', () => {
     )
   })
 
-  test('falls back to filesystem scanning when git cannot enumerate workspace files', async () => {
-    const tempDir = await mkdtemp(join(tmpdir(), 'openclaude-lsp-'))
-    try {
-      await mkdir(join(tempDir, 'src'), { recursive: true })
-      await writeFile(join(tempDir, 'src', 'main.ts'), 'export const x = 1\n')
-      await writeFile(join(tempDir, 'src', 'style.css'), '.root {}\n')
-      await writeFile(join(tempDir, 'logo.png'), '')
+  test(
+    'falls back to filesystem scanning when git cannot enumerate workspace files',
+    async () => {
+      const tempDir = await mkdtemp(join(tmpdir(), 'openclaude-lsp-'))
+      try {
+        await mkdir(join(tempDir, 'src'), { recursive: true })
+        await writeFile(join(tempDir, 'src', 'main.ts'), 'export const x = 1\n')
+        await writeFile(join(tempDir, 'src', 'style.css'), '.root {}\n')
+        await writeFile(join(tempDir, 'logo.png'), '')
 
-      const extensions = await discoverRealWorkspaceExtensions(undefined, tempDir)
+        const extensions = await discoverRealWorkspaceExtensions(
+          undefined,
+          tempDir,
+        )
 
-      expect(extensions).toContain('.ts')
-      expect(extensions).toContain('.css')
-      expect(extensions).not.toContain('.png')
-    } finally {
-      await rm(tempDir, { recursive: true, force: true })
-    }
-  })
+        expect(extensions).toContain('.ts')
+        expect(extensions).toContain('.css')
+        expect(extensions).not.toContain('.png')
+      } finally {
+        await rm(tempDir, { recursive: true, force: true })
+      }
+    },
+    10_000,
+  )
 
   test('installs missing official marketplace and retries candidate lookup', async () => {
     const typescriptCandidate = {

--- a/src/hooks/fileSuggestions.test.ts
+++ b/src/hooks/fileSuggestions.test.ts
@@ -48,6 +48,7 @@ afterEach(() => {
   // the real spawn for any later test file's git commands.
   activeSpawnScenario = undefined
   mock.restore()
+  restoreFileSuggestionsDependencyMocks()
 })
 
 beforeAll(
@@ -76,6 +77,15 @@ function createFakeChildProcess(): FakeChildProcess {
     return true
   }) as FakeChildProcess['kill']
   return child
+}
+
+function restoreFileSuggestionsDependencyMocks(): void {
+  if (actualCrossSpawnModule) {
+    mock.module('cross-spawn', () => actualCrossSpawnModule!)
+  }
+  if (actualRipgrepModule) {
+    mock.module('../utils/ripgrep.js', () => actualRipgrepModule!)
+  }
 }
 
 function createIgnoreModuleMock() {
@@ -180,7 +190,7 @@ async function loadFileSuggestionsModule(options: LoadModuleOptions = {}) {
   installFileSuggestionsDependencyMocks(options)
   const nonce = `${Date.now()}-${Math.random()}`
   const module = await import(`./fileSuggestions.ts?ts=${nonce}`)
-  mock.restore()
+  restoreFileSuggestionsDependencyMocks()
   return module
 }
 

--- a/src/hooks/fileSuggestions.test.ts
+++ b/src/hooks/fileSuggestions.test.ts
@@ -36,6 +36,9 @@ let actualRipgrepModule: typeof import('../utils/ripgrep.js') | undefined
 // of this suite's spawn-scenario tests is active and cleared in afterEach. Once
 // cleared, the persisted mock falls through to the real spawn.
 let activeSpawnScenario: LoadModuleOptions['spawnScenario'] | undefined
+let actualFileIndexModule:
+  | typeof import('../native-ts/file-index/index.js')
+  | undefined
 let actualMarkdownConfigLoaderModule:
   | typeof import('../utils/markdownConfigLoader.js')
   | undefined
@@ -85,6 +88,9 @@ function restoreFileSuggestionsDependencyMocks(): void {
   }
   if (actualRipgrepModule) {
     mock.module('../utils/ripgrep.js', () => actualRipgrepModule!)
+  }
+  if (actualFileIndexModule) {
+    mock.module('../native-ts/file-index/index.js', () => actualFileIndexModule!)
   }
 }
 
@@ -184,6 +190,7 @@ async function loadFileSuggestionsModule(options: LoadModuleOptions = {}) {
   activeSpawnScenario = options.spawnScenario
   actualCrossSpawnModule ??= await import('cross-spawn')
   actualRipgrepModule ??= await import('../utils/ripgrep.js')
+  actualFileIndexModule ??= await import('../native-ts/file-index/index.js')
   actualMarkdownConfigLoaderModule ??= await import(
     '../utils/markdownConfigLoader.js'
   )

--- a/src/ink/components/App.test.tsx
+++ b/src/ink/components/App.test.tsx
@@ -101,4 +101,19 @@ describe('App stdin mode setup', () => {
 
     app.handleSetRawMode(false)
   })
+
+  test('uses data mode when OPENCLAUDE_USE_READABLE_STDIN=0', () => {
+    delete process.env.OPENCLAUDE_USE_DATA_STDIN
+    process.env.OPENCLAUDE_USE_READABLE_STDIN = '0'
+    const stdin = createFakeStdin()
+    const app = createApp(stdin)
+
+    app.handleSetRawMode(true)
+
+    expect(stdin.listeners('data')).toContain(app.handleDataChunk)
+    expect(stdin.listeners('readable')).not.toContain(app.handleReadable)
+    expect(stdin.resume).toHaveBeenCalledTimes(1)
+
+    app.handleSetRawMode(false)
+  })
 })

--- a/src/ink/components/App.test.tsx
+++ b/src/ink/components/App.test.tsx
@@ -1,0 +1,104 @@
+import { EventEmitter } from 'node:events'
+import { PassThrough } from 'node:stream'
+
+import { afterEach, describe, expect, mock, test } from 'bun:test'
+
+import { createSelectionState } from '../selection.js'
+import App from './App.js'
+
+type FakeStdin = NodeJS.ReadStream & {
+  setRawMode: ReturnType<typeof mock>
+  ref: ReturnType<typeof mock>
+  unref: ReturnType<typeof mock>
+  resume: ReturnType<typeof mock>
+  pause: ReturnType<typeof mock>
+}
+
+function createFakeStdin(): FakeStdin {
+  const stdin = new EventEmitter() as unknown as FakeStdin
+  stdin.isTTY = true
+  stdin.ref = mock(() => stdin)
+  stdin.unref = mock(() => stdin)
+  stdin.resume = mock(() => stdin)
+  stdin.pause = mock(() => stdin)
+  stdin.setEncoding = mock(() => stdin) as unknown as FakeStdin['setEncoding']
+  stdin.setRawMode = mock(() => stdin)
+  return stdin
+}
+
+function createFakeStdout(): NodeJS.WriteStream {
+  const stdout = new PassThrough() as unknown as NodeJS.WriteStream
+  stdout.isTTY = true
+  stdout.write = mock(() => true) as unknown as NodeJS.WriteStream['write']
+  return stdout
+}
+
+function createApp(stdin: NodeJS.ReadStream): App {
+  return new App({
+    children: null,
+    stdin,
+    stdout: createFakeStdout(),
+    stderr: createFakeStdout(),
+    exitOnCtrlC: true,
+    onExit: () => {},
+    terminalColumns: 80,
+    terminalRows: 24,
+    selection: createSelectionState(),
+    onSelectionChange: () => {},
+    onClickAt: () => false,
+    onHoverAt: () => {},
+    getHyperlinkAt: () => undefined,
+    onOpenHyperlink: () => {},
+    onMultiClick: () => {},
+    onSelectionDrag: () => {},
+    dispatchKeyboardEvent: () => {},
+  })
+}
+
+describe('App stdin mode setup', () => {
+  const originalDataMode = process.env.OPENCLAUDE_USE_DATA_STDIN
+  const originalReadableMode = process.env.OPENCLAUDE_USE_READABLE_STDIN
+
+  afterEach(() => {
+    if (originalDataMode === undefined) {
+      delete process.env.OPENCLAUDE_USE_DATA_STDIN
+    } else {
+      process.env.OPENCLAUDE_USE_DATA_STDIN = originalDataMode
+    }
+    if (originalReadableMode === undefined) {
+      delete process.env.OPENCLAUDE_USE_READABLE_STDIN
+    } else {
+      process.env.OPENCLAUDE_USE_READABLE_STDIN = originalReadableMode
+    }
+  })
+
+  test('uses readable stdin by default without switching the stream to flowing mode', () => {
+    delete process.env.OPENCLAUDE_USE_DATA_STDIN
+    delete process.env.OPENCLAUDE_USE_READABLE_STDIN
+    const stdin = createFakeStdin()
+    const app = createApp(stdin)
+
+    app.handleSetRawMode(true)
+
+    expect(stdin.listeners('readable')).toContain(app.handleReadable)
+    expect(stdin.listeners('data')).not.toContain(app.handleDataChunk)
+    expect(stdin.resume).not.toHaveBeenCalled()
+
+    app.handleSetRawMode(false)
+  })
+
+  test('resumes stdin only for opt-in data mode', () => {
+    process.env.OPENCLAUDE_USE_DATA_STDIN = '1'
+    delete process.env.OPENCLAUDE_USE_READABLE_STDIN
+    const stdin = createFakeStdin()
+    const app = createApp(stdin)
+
+    app.handleSetRawMode(true)
+
+    expect(stdin.listeners('data')).toContain(app.handleDataChunk)
+    expect(stdin.listeners('readable')).not.toContain(app.handleReadable)
+    expect(stdin.resume).toHaveBeenCalledTimes(1)
+
+    app.handleSetRawMode(false)
+  })
+})

--- a/src/ink/components/App.tsx
+++ b/src/ink/components/App.tsx
@@ -242,10 +242,10 @@ export default class App extends PureComponent<Props, State> {
         stdin.setRawMode(true);
         if (this.stdinMode === 'data') {
           stdin.addListener('data', this.handleDataChunk);
+          stdin.resume();
         } else {
           stdin.addListener('readable', this.handleReadable);
         }
-        stdin.resume();
         // Enable bracketed paste mode
         this.props.stdout.write(EBP);
         // Enable terminal focus reporting (DECSET 1004)

--- a/src/services/compact/compact.test.ts
+++ b/src/services/compact/compact.test.ts
@@ -45,6 +45,9 @@ const _realDiskOutputModule = await import(
 const _realMessagesModule = await import(
   `../../utils/messages.js?real=${Date.now()}-${Math.random()}`
 )
+const _realSlowOperationsModule = await import(
+  `../../utils/slowOperations.js?real=${Date.now()}-${Math.random()}`
+)
 const _realBootstrapStateModule = await import(
   `../../bootstrap/state.js?real=${Date.now()}-${Math.random()}`
 )
@@ -604,6 +607,9 @@ afterAll(async () => {
     MAX_TASK_OUTPUT_BYTES_DISPLAY: _realDiskOutputModule.MAX_TASK_OUTPUT_BYTES_DISPLAY,
   }))
   mock.module('../../utils/messages.js', () => ({ ..._realMessagesModule }))
+  mock.module('../../utils/slowOperations.js', () => ({
+    ..._realSlowOperationsModule,
+  }))
   mock.module('../../bootstrap/state.js', () => ({ ..._realBootstrapStateModule }))
   mock.module('../../utils/settings/settings.js', () => ({ ..._realSettingsModule }))
   mock.module('../../utils/model/model.js', () => ({ ..._realModelModule }))

--- a/src/utils/execFileNoThrow.ts
+++ b/src/utils/execFileNoThrow.ts
@@ -286,7 +286,13 @@ export function execFileNoThrowWithCwd(
       finalTimeout > 0
         ? setTimeout(() => {
             timedOut = true
-            child.kill()
+            child.kill?.()
+            finish({
+              stdout: finalPreserveOutput ? stdout : '',
+              stderr: finalPreserveOutput ? stderr : '',
+              code: 1,
+              error: `Command timed out after ${finalTimeout}ms`,
+            })
           }, finalTimeout)
         : undefined
 

--- a/src/utils/plugins/marketplaceManager.test.ts
+++ b/src/utils/plugins/marketplaceManager.test.ts
@@ -9,6 +9,7 @@ import {
   type Mock,
   test,
 } from 'bun:test'
+import * as realAxios from 'axios'
 import { existsSync, mkdirSync, mkdtempSync, readdirSync, rmSync } from 'fs'
 import { tmpdir } from 'os'
 import { join } from 'path'
@@ -296,7 +297,7 @@ describe('loadAndCacheMarketplace — rename failure fallback (EXDEV)', () => {
   })
 
   afterAll(() => {
-    mock.restore()
+    mock.module('axios', () => realAxios)
   })
 
   beforeEach(() => {

--- a/src/utils/secureStorage/platformStorage.test.ts
+++ b/src/utils/secureStorage/platformStorage.test.ts
@@ -101,7 +101,6 @@ describe("Secure Storage Platform Implementations", () => {
 
   afterAll(() => {
     try {
-      mock.restore();
       mock.module("execa", () => realExeca);
     } finally {
       releaseSharedMutationLock();

--- a/src/utils/statusNoticeDefinitions.tsx
+++ b/src/utils/statusNoticeDefinitions.tsx
@@ -16,6 +16,7 @@ import type { LocalModelContextWarning } from './statusNoticeLocalModel.js';
 import type { PermissionMode } from './permissions/PermissionMode.js';
 import { modelSupportsAutoMode } from './betas.js';
 import { getAPIProvider } from './model/providers.js';
+import { logForDebugging } from './debug.js';
 
 // Types
 export type StatusNoticeType = 'warning' | 'info';
@@ -318,7 +319,10 @@ export function getActiveNotices(context: StatusNoticeContext): StatusNoticeDefi
   return statusNoticeDefinitions.filter(notice => {
     try {
       return notice.isActive(context);
-    } catch {
+    } catch (error) {
+      logForDebugging(
+        `status_notice_isActive_failed noticeId=${notice.id} error=${error instanceof Error ? error.message : String(error)}`,
+      );
       return false;
     }
   });

--- a/src/utils/statusNoticeDefinitions.tsx
+++ b/src/utils/statusNoticeDefinitions.tsx
@@ -315,5 +315,11 @@ export const statusNoticeDefinitions: StatusNoticeDefinition[] = [largeMemoryFil
 
 // Helper functions for external use
 export function getActiveNotices(context: StatusNoticeContext): StatusNoticeDefinition[] {
-  return statusNoticeDefinitions.filter(notice => notice.isActive(context));
+  return statusNoticeDefinitions.filter(notice => {
+    try {
+      return notice.isActive(context);
+    } catch {
+      return false;
+    }
+  });
 }


### PR DESCRIPTION
## What changed and why

Fixes #843.

This keeps the default Ink App stdin path in readable mode without calling `stdin.resume()`. Under WSL PTYs, resuming the stream can switch stdin into flowing `data` mode even though the app is wired for `readable`, which matches the reported freeze after typing a prompt or slash command. The opt-in data-mode path still calls `resume()` so the fallback behavior is preserved.

The PR also adds focused App stdin-mode tests and includes small support fixes needed for a clean local validation pass: timeout resolution for `execFileNoThrow`, defensive status notice filtering, and test mock isolation cleanup.

## User/developer impact

WSL users should be able to type prompts and slash commands without the terminal freezing. The fallback `OPENCLAUDE_USE_DATA_STDIN=1` path remains available for environments that need data-mode stdin.

## Validation

- `bun run build`
- `bun run typecheck`
- `bun run typecheck:type-tests`
- `bun run security:pr-scan`
- `bun run check`
- Focused tests: `bun test src\hooks\fileSuggestions.test.ts src\commands\lsp\lsp.test.ts --max-concurrency=1`
- Focused test: `bun test src\commands\lsp\lsp.test.ts --max-concurrency=1`
- WSL2 PTY smoke test using `node dist/cli.mjs --bare --setting-sources user` with `OPENCLAUDE_USE_DATA_STDIN` and `OPENCLAUDE_USE_READABLE_STDIN` unset. After first-run prompts, `/help` was sent through a pseudo-terminal, rendered the help dialog, dismissed cleanly, and returned to the prompt without freezing.

## Screenshots / terminal presentation

This touches terminal input behavior, not visual layout. No screenshot is attached; the WSL PTY smoke above verifies the affected terminal interaction path.

## Provider path tested

No provider path changed. I did not send a model-backed prompt in WSL because this fix is in terminal stdin handling, independent of provider execution.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented a single failing status notice from breaking active-notice evaluation.
  * Improved command timeout behavior to reliably terminate the process and return a clearer timeout error.
  * Refined stdin raw-mode enablement to resume immediately for data-mode selection.
* **Tests**
  * Added App stdin raw-mode tests covering default, data-mode, and readable-override environment behaviors.
  * Updated and hardened multiple test suites with better timeouts and restored real dependencies/mocks during cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->