### PR TITLE
chore(gitignore): ignore local worktree directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,8 @@ GEMINI.md
 CLAUDE.md
 package-lock.json
 /.claude
+# Local git worktrees created by agent/developer tooling.
+/.worktrees/
 coverage/
 __pycache__/
 *.py[cod]


### PR DESCRIPTION
Adds a root-anchored `.gitignore` rule for `.worktrees/`, which is used by local agent/developer workflows such as Superpowers v6 for project-local git worktrees. OpenClaude's built-in `.claude/worktrees` path is already covered by `/.claude`; this rule covers external tooling without ignoring broader project content.

Validation:
- `git diff -- .gitignore`
- `git status --ignored --short`
- temporary `.worktrees/test/example` status probe
- `git diff --check origin/main...HEAD`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated git configuration to improve local development environment management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->