### PR TITLE
feat(query): add lifecycle identity and terminal reasons

### DIFF
--- a/src/Tool.ts
+++ b/src/Tool.ts
@@ -64,6 +64,7 @@ import type { FileStateCache } from './utils/fileStateCache.js'
 import type { DenialTrackingState } from './utils/permissions/denialTracking.js'
 import type { SystemPrompt } from './utils/systemPromptType.js'
 import type { ContentReplacementState } from './utils/toolResultStorage.js'
+import type { QueryLifecycleOperationTracker } from './utils/queryLifecycle.js'
 
 // Re-export progress types for backwards compatibility
 export type {
@@ -291,6 +292,7 @@ export type ToolUseContext = {
     toolInputSummary?: string | null,
   ) => (request: PromptRequest) => Promise<PromptResponse>
   toolUseId?: string
+  queryLifecycle?: QueryLifecycleOperationTracker
   criticalSystemReminder_EXPERIMENTAL?: string
   /** When true, preserve toolUseResult on messages even for subagents.
    * Used by in-process teammates whose transcripts are viewable by the user. */

--- a/src/query.ts
+++ b/src/query.ts
@@ -909,6 +909,7 @@ async function* queryLoop(
                 c => c.type === 'pending',
               ),
               queryTracking,
+              queryLifecycle: toolUseContext.queryLifecycle,
               effortValue: appState.effortValue,
               advisorModel: appState.advisorModel,
               skipCacheWrite,

--- a/src/screens/REPL.queryLifecycle.test.ts
+++ b/src/screens/REPL.queryLifecycle.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, test } from 'bun:test'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+const source = readFileSync(join(import.meta.dirname, 'REPL.tsx'), 'utf8')
+
+function getAbortTimedOutQueryBody(): string {
+  const start = source.indexOf('const abortTimedOutQuery = useCallback')
+  expect(start).toBeGreaterThan(-1)
+  const end = source.indexOf('}, [mrOnTurnComplete, resetLoadingState])', start)
+  expect(end).toBeGreaterThan(start)
+  return source.slice(start, end)
+}
+
+describe('REPL query lifecycle timeout logging', () => {
+  test('logs timeout end only after abort acknowledgement', () => {
+    const body = getAbortTimedOutQueryBody()
+    const queueMicrotaskIndex = body.indexOf('queueMicrotask(() => {')
+    expect(queueMicrotaskIndex).toBeGreaterThan(-1)
+    const beforeAcknowledgement = body.slice(0, queueMicrotaskIndex)
+    expect(beforeAcknowledgement).not.toContain("logQueryLifecycle('end'")
+
+    const abortAcknowledgedIndex = body.indexOf(
+      "logQueryLifecycle('abort_acknowledged'",
+      queueMicrotaskIndex,
+    )
+    const endIndex = body.indexOf(
+      "logQueryLifecycle('end'",
+      queueMicrotaskIndex,
+    )
+
+    expect(abortAcknowledgedIndex).toBeGreaterThan(queueMicrotaskIndex)
+    expect(endIndex).toBeGreaterThan(abortAcknowledgedIndex)
+  })
+})

--- a/src/screens/REPL.queryLifecycle.test.ts
+++ b/src/screens/REPL.queryLifecycle.test.ts
@@ -12,24 +12,38 @@ function getAbortTimedOutQueryBody(): string {
   return source.slice(start, end)
 }
 
+function getQueryFinallyBody(): string {
+  const queryStart = source.indexOf('await onQueryImpl(')
+  expect(queryStart).toBeGreaterThan(-1)
+  const finallyStart = source.indexOf('} finally {', queryStart)
+  expect(finallyStart).toBeGreaterThan(queryStart)
+  const finallyEnd = source.indexOf('// Auto-restore:', finallyStart)
+  expect(finallyEnd).toBeGreaterThan(finallyStart)
+  return source.slice(finallyStart, finallyEnd)
+}
+
 describe('REPL query lifecycle timeout logging', () => {
-  test('logs timeout end only after abort acknowledgement', () => {
+  test('does not emit terminal timeout end from timeout handler', () => {
     const body = getAbortTimedOutQueryBody()
     const queueMicrotaskIndex = body.indexOf('queueMicrotask(() => {')
     expect(queueMicrotaskIndex).toBeGreaterThan(-1)
-    const beforeAcknowledgement = body.slice(0, queueMicrotaskIndex)
-    expect(beforeAcknowledgement).not.toContain("logQueryLifecycle('end'")
 
     const abortAcknowledgedIndex = body.indexOf(
       "logQueryLifecycle('abort_acknowledged'",
       queueMicrotaskIndex,
     )
-    const endIndex = body.indexOf(
-      "logQueryLifecycle('end'",
-      queueMicrotaskIndex,
-    )
 
     expect(abortAcknowledgedIndex).toBeGreaterThan(queueMicrotaskIndex)
-    expect(endIndex).toBeGreaterThan(abortAcknowledgedIndex)
+    expect(body).not.toContain("logQueryLifecycle('end'")
+  })
+
+  test('emits timeout end from the query finally cleanup path', () => {
+    const body = getQueryFinallyBody()
+
+    expect(body).toContain('const guardCompletedContext = queryGuard.lastContext')
+    expect(body).toContain("guardCompletedContext?.terminalReason === 'query-timeout'")
+    expect(body).toContain("guardCompletedContext?.terminalReason === 'hard-max-query-timeout'")
+    expect(body).toContain('guardCompletedContext.queryGeneration === thisGeneration')
+    expect(body).toContain('logCompletedLifecycle(guardCompletedContext)')
   })
 })

--- a/src/screens/REPL.tsx
+++ b/src/screens/REPL.tsx
@@ -1767,7 +1767,6 @@ export function REPL({
     if (timeout.activeOperations.apiCalls.length > 0) {
       logForDebugging(`api.call.active_on_abort queryId=${timeout.context.queryId} generation=${timeout.generation} ${timeoutOperations}`);
     }
-    logQueryLifecycle('end', timeout.context, timeoutOperations);
     if (feature('TOKEN_BUDGET')) {
       snapshotOutputTokensForTurn(null);
     }
@@ -1776,6 +1775,7 @@ export function REPL({
     // the guard has released so the normal stale-generation finally path skips.
     queueMicrotask(() => {
       logQueryLifecycle('abort_acknowledged', timeout.context, formatQueryLifecycleAbortSignalReason('query-timeout'));
+      logQueryLifecycle('end', timeout.context, summarizeActiveOperations(queryLifecycleTrackerRef.current.snapshot()));
       resetLoadingState();
       setAbortController(null);
       void mrOnTurnComplete(messagesRef.current, true);

--- a/src/screens/REPL.tsx
+++ b/src/screens/REPL.tsx
@@ -36,7 +36,7 @@ import { updateLastInteractionTime, getLastInteractionTime, getOriginalCwd, getP
 import { asSessionId, asAgentId } from '../types/ids.js';
 import { logForDebugging } from '../utils/debug.js';
 import { QueryGuard } from '../utils/QueryGuard.js';
-import { QueryLifecycleOperationTracker, type QueryActiveOperationSnapshot, type QueryGuardTimeoutInfo, type QueryLifecycleContext, type QueryTerminalReason } from '../utils/queryLifecycle.js';
+import { QueryLifecycleOperationTracker, formatQueryLifecycleAbortSignalReason, formatQueryLifecycleLogMessage, type QueryActiveOperationSnapshot, type QueryGuardTimeoutInfo, type QueryLifecycleContext, type QueryTerminalReason } from '../utils/queryLifecycle.js';
 import { createCombinedAbortSignal } from '../utils/combinedAbortSignal.js';
 import { isEnvTruthy } from '../utils/envUtils.js';
 import { formatTokens, truncateToWidth } from '../utils/format.js';
@@ -578,11 +578,7 @@ function summarizeActiveOperations(snapshot: QueryActiveOperationSnapshot): stri
   return `activeApiCalls=${snapshot.apiCalls.length} activeToolUses=${snapshot.toolUses.length}` + (apiIds ? ` apiIds=${apiIds}` : '') + (toolIds ? ` toolIds=${toolIds}` : '');
 }
 function logQueryLifecycle(event: string, context: QueryLifecycleContext, extras = ''): void {
-  const parent = context.parentQueryId ? ` parentQueryId=${context.parentQueryId}` : '';
-  const subagent = context.subagentId ? ` subagentId=${context.subagentId}` : '';
-  const terminal = context.terminalReason ? ` terminalReason=${context.terminalReason}` : '';
-  const abort = context.abortReason ? ` abortReason=${context.abortReason}` : '';
-  logForDebugging(`query.${event} queryId=${context.queryId} generation=${context.queryGeneration} source=${context.querySource}${parent}${subagent}${terminal}${abort}${extras ? ` ${extras}` : ''}`);
+  logForDebugging(formatQueryLifecycleLogMessage(event, context, extras));
 }
 export type Props = {
   commands: Command[];
@@ -1765,7 +1761,7 @@ export function REPL({
     logQueryLifecycle('timeout', timeout.context, timeoutOperations);
     const activeAbortController = abortControllerRef.current;
     if (activeAbortController && !activeAbortController.signal.aborted) {
-      logQueryLifecycle('abort_requested', timeout.context, 'abortReason=query-timeout');
+      logQueryLifecycle('abort_requested', timeout.context, formatQueryLifecycleAbortSignalReason('query-timeout'));
       activeAbortController.abort('query-timeout');
     }
     if (timeout.activeOperations.apiCalls.length > 0) {
@@ -1779,7 +1775,7 @@ export function REPL({
     // QueryGuard calls this before forceEnd(); defer UI cleanup until after
     // the guard has released so the normal stale-generation finally path skips.
     queueMicrotask(() => {
-      logQueryLifecycle('abort_acknowledged', timeout.context, 'abortReason=query-timeout');
+      logQueryLifecycle('abort_acknowledged', timeout.context, formatQueryLifecycleAbortSignalReason('query-timeout'));
       resetLoadingState();
       setAbortController(null);
       void mrOnTurnComplete(messagesRef.current, true);
@@ -2279,7 +2275,7 @@ export function REPL({
       abortReason: 'user-cancel'
     } : null;
     if (cancelContext) {
-      logQueryLifecycle('abort_requested', cancelContext, 'abortReason=user-cancel');
+      logQueryLifecycle('abort_requested', cancelContext, formatQueryLifecycleAbortSignalReason('user-cancel'));
     }
     queryGuard.forceEnd('user-abort', 'user-cancel');
     skipIdleCheckRef.current = false;
@@ -2318,7 +2314,7 @@ export function REPL({
       abortController?.abort('user-cancel');
     }
     if (cancelContext) {
-      logQueryLifecycle('abort_acknowledged', cancelContext, 'abortReason=user-cancel');
+      logQueryLifecycle('abort_acknowledged', cancelContext, formatQueryLifecycleAbortSignalReason('user-cancel'));
     }
     if (completedCancelContext) {
       const cancelOperationSummary = summarizeActiveOperations(cancelOperations);

--- a/src/screens/REPL.tsx
+++ b/src/screens/REPL.tsx
@@ -1769,9 +1769,7 @@ export function REPL({
       activeAbortController.abort('query-timeout');
     }
     if (timeout.activeOperations.apiCalls.length > 0) {
-      logForDebugging(`api.call.orphaned_on_query_end queryId=${timeout.context.queryId} generation=${timeout.generation} ${timeoutOperations}`, {
-        level: 'warn'
-      });
+      logForDebugging(`api.call.active_on_abort queryId=${timeout.context.queryId} generation=${timeout.generation} ${timeoutOperations}`);
     }
     logQueryLifecycle('end', timeout.context, timeoutOperations);
     if (feature('TOKEN_BUDGET')) {
@@ -2325,9 +2323,7 @@ export function REPL({
     if (completedCancelContext) {
       const cancelOperationSummary = summarizeActiveOperations(cancelOperations);
       if (cancelOperations.apiCalls.length > 0) {
-        logForDebugging(`api.call.orphaned_on_query_end queryId=${completedCancelContext.queryId} generation=${completedCancelContext.queryGeneration} ${cancelOperationSummary}`, {
-          level: 'warn'
-        });
+        logForDebugging(`api.call.active_on_abort queryId=${completedCancelContext.queryId} generation=${completedCancelContext.queryGeneration} ${cancelOperationSummary}`);
       }
       logQueryLifecycle('end', completedCancelContext, cancelOperationSummary);
     }
@@ -2569,7 +2565,7 @@ export function REPL({
       reject
     }]);
   }), []);
-  const getToolUseContext = useCallback((messages: MessageType[], newMessages: MessageType[], abortController: AbortController, mainLoopModel: string, queryGeneration?: number): ProcessUserInputContext => {
+  const getToolUseContext = useCallback((messages: MessageType[], newMessages: MessageType[], abortController: AbortController, mainLoopModel: string, queryGeneration?: number, queryLifecycle?: QueryLifecycleOperationTracker): ProcessUserInputContext => {
     // Read mutable values fresh from the store rather than closure-capturing
     // useAppState() snapshots. Same values today (closure is refreshed by the
     // render between turns); decouples freshness from React's render cycle for
@@ -2596,7 +2592,7 @@ export function REPL({
     } satisfies ProcessUserInputContext['queryActivity'];
     return {
       abortController,
-      queryLifecycle: queryLifecycleTrackerRef.current,
+      ...(queryLifecycle ? { queryLifecycle } : {}),
       options: {
         commands,
         tools: computeTools(),
@@ -2860,7 +2856,7 @@ export function REPL({
       void removeTranscriptMessage(tombstonedMessage.uuid);
     }, setStreamingThinking, undefined, onStreamingText);
   }, [setMessages, setResponseLength, setStreamMode, setStreamingToolUses, setStreamingThinking, onStreamingText]);
-  const onQueryImpl = useCallback(async (messagesIncludingNewMessages: MessageType[], newMessages: MessageType[], abortController: AbortController, shouldQuery: boolean, additionalAllowedTools: string[], mainLoopModelParam: string, queryGeneration: number, effort?: EffortValue) => {
+  const onQueryImpl = useCallback(async (messagesIncludingNewMessages: MessageType[], newMessages: MessageType[], abortController: AbortController, shouldQuery: boolean, additionalAllowedTools: string[], mainLoopModelParam: string, queryGeneration: number, effort?: EffortValue, queryLifecycle?: QueryLifecycleOperationTracker) => {
     // Prepare IDE integration for new prompt. Read mcpClients fresh from
     // store — useManageMCPConnections may have populated it since the
     // render that captured this closure (same pattern as computeTools).
@@ -2947,7 +2943,7 @@ export function REPL({
       setAbortController(null);
       return;
     }
-    const toolUseContext = getToolUseContext(messagesIncludingNewMessages, newMessages, abortController, mainLoopModelParam, queryGeneration);
+    const toolUseContext = getToolUseContext(messagesIncludingNewMessages, newMessages, abortController, mainLoopModelParam, queryGeneration, queryLifecycle);
     const querySessionId = getSessionId();
     const queryAutoCompactTracking = getAutoCompactTrackingForSession(querySessionId);
     // getToolUseContext reads tools/mcpClients fresh from store.getState()
@@ -3114,7 +3110,7 @@ export function REPL({
           return;
         }
       }
-      await onQueryImpl(latestMessages, newMessages, abortController, shouldQuery, additionalAllowedTools, mainLoopModelParam, thisGeneration, effort);
+      await onQueryImpl(latestMessages, newMessages, abortController, shouldQuery, additionalAllowedTools, mainLoopModelParam, thisGeneration, effort, lifecycleTracker);
     } catch (error) {
       didThrow = true;
       throw error;

--- a/src/screens/REPL.tsx
+++ b/src/screens/REPL.tsx
@@ -36,6 +36,7 @@ import { updateLastInteractionTime, getLastInteractionTime, getOriginalCwd, getP
 import { asSessionId, asAgentId } from '../types/ids.js';
 import { logForDebugging } from '../utils/debug.js';
 import { QueryGuard } from '../utils/QueryGuard.js';
+import { QueryLifecycleOperationTracker, type QueryActiveOperationSnapshot, type QueryGuardTimeoutInfo, type QueryLifecycleContext, type QueryTerminalReason } from '../utils/queryLifecycle.js';
 import { createCombinedAbortSignal } from '../utils/combinedAbortSignal.js';
 import { isEnvTruthy } from '../utils/envUtils.js';
 import { formatTokens, truncateToWidth } from '../utils/format.js';
@@ -550,6 +551,38 @@ function _temp2(setFrame_0) {
 }
 function _temp(f) {
   return (f + 1) % TITLE_ANIMATION_FRAMES.length;
+}
+function getAbortReasonLabel(reason: unknown): string | undefined {
+  if (reason === undefined) return undefined;
+  if (typeof reason === 'string') return reason;
+  if (reason instanceof Error) return reason.name;
+  return String(reason);
+}
+function getQueryTerminalReason(signal: AbortSignal, didThrow: boolean): QueryTerminalReason {
+  if (!signal.aborted) return didThrow ? 'unknown' : 'ok';
+  switch (getAbortReasonLabel(signal.reason)) {
+    case 'query-timeout':
+      return 'query-timeout';
+    case 'user-cancel':
+    case 'interrupt':
+      return 'user-abort';
+    case 'background':
+      return 'parent-ended';
+    default:
+      return 'unknown';
+  }
+}
+function summarizeActiveOperations(snapshot: QueryActiveOperationSnapshot): string {
+  const apiIds = snapshot.apiCalls.map(call => call.requestId ?? call.clientRequestId ?? 'unknown').join(',');
+  const toolIds = snapshot.toolUses.map(tool => `${tool.toolName}:${tool.toolUseId}`).join(',');
+  return `activeApiCalls=${snapshot.apiCalls.length} activeToolUses=${snapshot.toolUses.length}` + (apiIds ? ` apiIds=${apiIds}` : '') + (toolIds ? ` toolIds=${toolIds}` : '');
+}
+function logQueryLifecycle(event: string, context: QueryLifecycleContext, extras = ''): void {
+  const parent = context.parentQueryId ? ` parentQueryId=${context.parentQueryId}` : '';
+  const subagent = context.subagentId ? ` subagentId=${context.subagentId}` : '';
+  const terminal = context.terminalReason ? ` terminalReason=${context.terminalReason}` : '';
+  const abort = context.abortReason ? ` abortReason=${context.abortReason}` : '';
+  logForDebugging(`query.${event} queryId=${context.queryId} generation=${context.queryGeneration} source=${context.querySource}${parent}${subagent}${terminal}${abort}${extras ? ` ${extras}` : ''}`);
 }
 export type Props = {
   commands: Command[];
@@ -1449,6 +1482,7 @@ export function REPL({
   }, [setLocalCommands]);
   const [inProgressToolUseIDs, setInProgressToolUseIDs] = useState<Set<string>>(new Set());
   const hasInterruptibleToolInProgressRef = useRef(false);
+  const queryLifecycleTrackerRef = useRef(new QueryLifecycleOperationTracker());
 
   // Remote session hook - manages WebSocket connection and message handling for --remote mode
   const remoteSession = useRemoteSession({
@@ -1726,11 +1760,20 @@ export function REPL({
   const mrOnBeforeQuery = useCallback(async (_input: string, _allMessages: MessageType[], _newMessageCount: number) => true, []);
   const mrOnTurnComplete = useCallback(async (_allMessages: MessageType[], _aborted: boolean) => { }, []);
   const mrRender = useCallback(() => null, []);
-  const abortTimedOutQuery = useCallback(() => {
+  const abortTimedOutQuery = useCallback((timeout: QueryGuardTimeoutInfo) => {
+    const timeoutOperations = summarizeActiveOperations(timeout.activeOperations);
+    logQueryLifecycle('timeout', timeout.context, timeoutOperations);
     const activeAbortController = abortControllerRef.current;
     if (activeAbortController && !activeAbortController.signal.aborted) {
+      logQueryLifecycle('abort_requested', timeout.context, 'abortReason=query-timeout');
       activeAbortController.abort('query-timeout');
     }
+    if (timeout.activeOperations.apiCalls.length > 0) {
+      logForDebugging(`api.call.orphaned_on_query_end queryId=${timeout.context.queryId} generation=${timeout.generation} ${timeoutOperations}`, {
+        level: 'warn'
+      });
+    }
+    logQueryLifecycle('end', timeout.context, timeoutOperations);
     if (feature('TOKEN_BUDGET')) {
       snapshotOutputTokensForTurn(null);
     }
@@ -1738,6 +1781,7 @@ export function REPL({
     // QueryGuard calls this before forceEnd(); defer UI cleanup until after
     // the guard has released so the normal stale-generation finally path skips.
     queueMicrotask(() => {
+      logQueryLifecycle('abort_acknowledged', timeout.context, 'abortReason=query-timeout');
       resetLoadingState();
       setAbortController(null);
       void mrOnTurnComplete(messagesRef.current, true);
@@ -2229,7 +2273,17 @@ export function REPL({
     if (feature('PROACTIVE') || feature('KAIROS')) {
       proactiveModule?.pauseProactive();
     }
-    queryGuard.forceEnd();
+    const cancelContext = queryGuard.activeContext;
+    const cancelOperations = queryLifecycleTrackerRef.current.snapshot();
+    const completedCancelContext = cancelContext ? {
+      ...cancelContext,
+      terminalReason: 'user-abort' as const,
+      abortReason: 'user-cancel'
+    } : null;
+    if (cancelContext) {
+      logQueryLifecycle('abort_requested', cancelContext, 'abortReason=user-cancel');
+    }
+    queryGuard.forceEnd('user-abort', 'user-cancel');
     skipIdleCheckRef.current = false;
 
     // Preserve partially-streamed text so the user can read what was
@@ -2264,6 +2318,18 @@ export function REPL({
       activeRemote.cancelRequest();
     } else {
       abortController?.abort('user-cancel');
+    }
+    if (cancelContext) {
+      logQueryLifecycle('abort_acknowledged', cancelContext, 'abortReason=user-cancel');
+    }
+    if (completedCancelContext) {
+      const cancelOperationSummary = summarizeActiveOperations(cancelOperations);
+      if (cancelOperations.apiCalls.length > 0) {
+        logForDebugging(`api.call.orphaned_on_query_end queryId=${completedCancelContext.queryId} generation=${completedCancelContext.queryGeneration} ${cancelOperationSummary}`, {
+          level: 'warn'
+        });
+      }
+      logQueryLifecycle('end', completedCancelContext, cancelOperationSummary);
     }
 
     // Clear the controller so subsequent Escape presses don't see a stale
@@ -2530,6 +2596,7 @@ export function REPL({
     } satisfies ProcessUserInputContext['queryActivity'];
     return {
       abortController,
+      queryLifecycle: queryLifecycleTrackerRef.current,
       options: {
         commands,
         tools: computeTools(),
@@ -2977,10 +3044,17 @@ export function REPL({
     }
 
     // Concurrent guard via state machine. tryStart() atomically checks
-    // and transitions idle→running, returning the generation number.
+    // and transitions idle→running, returning lifecycle context.
     // Returns null if already running — no separate check-then-set.
-    const thisGeneration = queryGuard.tryStart();
-    if (thisGeneration === null) {
+    const lifecycleTracker = queryLifecycleTrackerRef.current;
+    const querySource = getQuerySourceForREPL();
+    const startResult = queryGuard.tryStart({
+      queryId: randomUUID(),
+      querySource,
+      startedAt: Date.now(),
+      getActiveOperations: () => lifecycleTracker.snapshot()
+    });
+    if (startResult === null) {
       logEvent('tengu_concurrent_onquery_detected', {});
 
       // Extract and enqueue user message text, skipping meta messages
@@ -2997,6 +3071,12 @@ export function REPL({
       });
       return;
     }
+    lifecycleTracker.clear();
+    const thisGeneration = startResult.generation;
+    const queryContext = startResult.context;
+    logQueryLifecycle('start', queryContext);
+    logQueryLifecycle('guard_start', queryContext);
+    let didThrow = false;
     try {
       // isLoading is derived from queryGuard — tryStart() above already
       // transitioned dispatching→running, so no setter call needed here.
@@ -3035,11 +3115,31 @@ export function REPL({
         }
       }
       await onQueryImpl(latestMessages, newMessages, abortController, shouldQuery, additionalAllowedTools, mainLoopModelParam, thisGeneration, effort);
+    } catch (error) {
+      didThrow = true;
+      throw error;
     } finally {
+      const terminalReason = getQueryTerminalReason(abortController.signal, didThrow);
+      const abortReason = getAbortReasonLabel(abortController.signal.reason);
+      const activeOperations = lifecycleTracker.snapshot();
+      const completedContext = {
+        ...queryContext,
+        terminalReason,
+        ...(abortReason !== undefined && {
+          abortReason
+        })
+      };
       // queryGuard.end() atomically checks generation and transitions
       // running→idle. Returns false if a newer query owns the guard
       // (cancel+resubmit race where the stale finally fires as a microtask).
-      if (queryGuard.end(thisGeneration)) {
+      if (queryGuard.end(thisGeneration, terminalReason, abortReason)) {
+        logQueryLifecycle('end', completedContext, summarizeActiveOperations(activeOperations));
+        if (activeOperations.apiCalls.length > 0) {
+          logForDebugging(`api.call.orphaned_on_query_end queryId=${queryContext.queryId} generation=${thisGeneration} ${summarizeActiveOperations(activeOperations)}`, {
+            level: 'warn'
+          });
+        }
+        lifecycleTracker.clear();
         setLastQueryCompletionTime(Date.now());
         skipIdleCheckRef.current = false;
         // Always reset loading state in finally - this ensures cleanup even
@@ -3125,6 +3225,8 @@ export function REPL({
         // controller makes ctrl+c fire onCancel() (aborting nothing) instead of
         // propagating to the double-press exit flow.
         setAbortController(null);
+      } else if (!queryGuard.isActive) {
+        lifecycleTracker.clear();
       }
 
       // Auto-restore: if the user interrupted before any meaningful response

--- a/src/screens/REPL.tsx
+++ b/src/screens/REPL.tsx
@@ -1775,7 +1775,6 @@ export function REPL({
     // the guard has released so the normal stale-generation finally path skips.
     queueMicrotask(() => {
       logQueryLifecycle('abort_acknowledged', timeout.context, formatQueryLifecycleAbortSignalReason('query-timeout'));
-      logQueryLifecycle('end', timeout.context, summarizeActiveOperations(queryLifecycleTrackerRef.current.snapshot()));
       resetLoadingState();
       setAbortController(null);
       void mrOnTurnComplete(messagesRef.current, true);
@@ -3121,16 +3120,20 @@ export function REPL({
           abortReason
         })
       };
+      const activeOperationSummary = summarizeActiveOperations(activeOperations);
+      const logCompletedLifecycle = (context: QueryLifecycleContext) => {
+        logQueryLifecycle('end', context, activeOperationSummary);
+        if (activeOperations.apiCalls.length > 0) {
+          logForDebugging(`api.call.orphaned_on_query_end queryId=${queryContext.queryId} generation=${thisGeneration} ${activeOperationSummary}`, {
+            level: 'warn'
+          });
+        }
+      };
       // queryGuard.end() atomically checks generation and transitions
       // running→idle. Returns false if a newer query owns the guard
       // (cancel+resubmit race where the stale finally fires as a microtask).
       if (queryGuard.end(thisGeneration, terminalReason, abortReason)) {
-        logQueryLifecycle('end', completedContext, summarizeActiveOperations(activeOperations));
-        if (activeOperations.apiCalls.length > 0) {
-          logForDebugging(`api.call.orphaned_on_query_end queryId=${queryContext.queryId} generation=${thisGeneration} ${summarizeActiveOperations(activeOperations)}`, {
-            level: 'warn'
-          });
-        }
+        logCompletedLifecycle(completedContext);
         lifecycleTracker.clear();
         setLastQueryCompletionTime(Date.now());
         skipIdleCheckRef.current = false;
@@ -3217,8 +3220,15 @@ export function REPL({
         // controller makes ctrl+c fire onCancel() (aborting nothing) instead of
         // propagating to the double-press exit flow.
         setAbortController(null);
-      } else if (!queryGuard.isActive) {
-        lifecycleTracker.clear();
+      } else {
+        const guardCompletedContext = queryGuard.lastContext;
+        if ((guardCompletedContext?.terminalReason === 'query-timeout' || guardCompletedContext?.terminalReason === 'hard-max-query-timeout') && guardCompletedContext.queryGeneration === thisGeneration) {
+          logCompletedLifecycle(guardCompletedContext);
+          setLastQueryCompletionTime(Date.now());
+          lifecycleTracker.clear();
+        } else if (!queryGuard.isActive) {
+          lifecycleTracker.clear();
+        }
       }
 
       // Auto-restore: if the user interrupted before any meaningful response

--- a/src/services/api/claude.lifecycle.test.ts
+++ b/src/services/api/claude.lifecycle.test.ts
@@ -1,0 +1,409 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import type {
+  BetaMessage,
+  BetaMessageStreamParams,
+} from '@anthropic-ai/sdk/resources/beta/messages/messages.mjs'
+import { mkdtempSync, rmSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import {
+  acquireSharedMutationLock,
+  releaseSharedMutationLock,
+} from '../../test/sharedMutationLock.js'
+import { getEmptyToolPermissionContext } from '../../Tool.js'
+import type { Message } from '../../types/message.js'
+import { QueryLifecycleOperationTracker } from '../../utils/queryLifecycle.js'
+import { asSystemPrompt } from '../../utils/systemPromptType.js'
+import {
+  executeNonStreamingRequest,
+  type Options,
+  queryModelWithStreaming,
+} from './claude.js'
+import { EMPTY_USAGE } from './emptyUsage.js'
+
+const envKeys = [
+  'ANTHROPIC_AUTH_TOKEN',
+  'ANTHROPIC_API_KEY',
+  'ANTHROPIC_BASE_URL',
+  'ANTHROPIC_MODEL',
+  'CLAUDE_CODE_TEST_FIXTURES_ROOT',
+  'CLAUDE_CODE_PROVIDER_PROFILE_ENV_APPLIED',
+  'CLAUDE_CODE_PROVIDER_PROFILE_ENV_APPLIED_ID',
+  'CLAUDE_CODE_USE_BEDROCK',
+  'CLAUDE_CODE_USE_FOUNDRY',
+  'CLAUDE_CODE_USE_GEMINI',
+  'CLAUDE_CODE_USE_GITHUB',
+  'CLAUDE_CODE_USE_MISTRAL',
+  'CLAUDE_CODE_USE_OPENAI',
+  'CLAUDE_CODE_USE_VERTEX',
+  'GEMINI_API_KEY',
+  'OPENAI_API_KEY',
+  'OPENAI_BASE_URL',
+  'OPENAI_MODEL',
+  'OPENCLAUDE_MAX_RETRIES',
+  'VCR_RECORD',
+] as const
+const originalEnv = { ...process.env }
+const originalFetch = globalThis.fetch
+const hadSavedMacro = Object.hasOwn(globalThis, 'MACRO')
+const savedMacro = (globalThis as Record<string, unknown>).MACRO
+let fixturesRoot: string | undefined
+
+type FetchOverride = NonNullable<Options['fetchOverride']>
+type LifecycleSnapshot = ReturnType<QueryLifecycleOperationTracker['snapshot']>
+
+function makeJsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: {
+      'content-type': 'application/json',
+      'request-id': `req-${status}`,
+    },
+  })
+}
+
+function makeErrorResponse(status: number, message: string): Response {
+  return makeJsonResponse(
+    {
+      type: 'error',
+      error: {
+        type: 'api_error',
+        message,
+      },
+    },
+    status,
+  )
+}
+
+function makeBetaMessage(): BetaMessage {
+  return {
+    id: 'msg-lifecycle-test',
+    type: 'message',
+    role: 'assistant',
+    model: 'claude-lifecycle-test',
+    content: [],
+    container: null,
+    context_management: null,
+    stop_details: null,
+    stop_reason: 'end_turn',
+    stop_sequence: null,
+    usage: {
+      ...EMPTY_USAGE,
+      input_tokens: 1,
+      output_tokens: 1,
+    },
+  }
+}
+
+function makeOpenAIChatCompletionResponse(): Response {
+  return makeJsonResponse({
+    id: 'chatcmpl-lifecycle-fallback',
+    object: 'chat.completion',
+    created: 1_771_264_800,
+    model: 'gpt-override',
+    choices: [
+      {
+        index: 0,
+        message: {
+          role: 'assistant',
+          content: 'fallback ok',
+        },
+        finish_reason: 'stop',
+      },
+    ],
+    usage: {
+      prompt_tokens: 1,
+      completion_tokens: 1,
+      total_tokens: 2,
+    },
+  })
+}
+
+function parseRequestBody(init: RequestInit | undefined): Record<string, unknown> {
+  if (typeof init?.body !== 'string') return {}
+  const parsed = JSON.parse(init.body) as unknown
+  return parsed && typeof parsed === 'object'
+    ? (parsed as Record<string, unknown>)
+    : {}
+}
+
+async function drainGenerator<T>(
+  generator: AsyncGenerator<unknown, T>,
+): Promise<T> {
+  while (true) {
+    const result = await generator.next()
+    if (result.done) return result.value
+  }
+}
+
+function makeParams(context: { model: string }): BetaMessageStreamParams {
+  return {
+    model: context.model,
+    max_tokens: 64,
+    messages: [{ role: 'user', content: 'hello' }],
+  } as BetaMessageStreamParams
+}
+
+function makeOptions(
+  queryLifecycle: QueryLifecycleOperationTracker,
+): Options {
+  return {
+    getToolPermissionContext: async () => getEmptyToolPermissionContext(),
+    model: 'claude-lifecycle-test',
+    isNonInteractiveSession: false,
+    querySource: 'sdk',
+    agents: [],
+    hasAppendSystemPrompt: false,
+    mcpTools: [],
+    queryLifecycle,
+  }
+}
+
+function setTestMacro(): void {
+  ;(globalThis as Record<string, unknown>).MACRO = {
+    VERSION: '0.0.0-test',
+    DISPLAY_VERSION: '0.0.0-test',
+    BUILD_TIME: 'test',
+    ISSUES_EXPLAINER: 'test',
+    PACKAGE_URL: 'test',
+    NATIVE_PACKAGE_URL: undefined,
+  }
+}
+
+function setClientTestEnv(): void {
+  setTestMacro()
+  fixturesRoot = mkdtempSync(join(tmpdir(), 'claude-lifecycle-vcr-'))
+  for (const key of envKeys) {
+    delete process.env[key]
+  }
+  process.env.ANTHROPIC_API_KEY = 'sk-test-lifecycle'
+  process.env.CLAUDE_CODE_TEST_FIXTURES_ROOT = fixturesRoot
+  process.env.VCR_RECORD = '1'
+}
+
+beforeEach(async () => {
+  await acquireSharedMutationLock('claude.lifecycle.test.ts')
+})
+
+afterEach(() => {
+  try {
+    for (const key of envKeys) {
+      if (originalEnv[key] === undefined) {
+        delete process.env[key]
+      } else {
+        process.env[key] = originalEnv[key]
+      }
+    }
+    if (hadSavedMacro) {
+      ;(globalThis as Record<string, unknown>).MACRO = savedMacro
+    } else {
+      delete (globalThis as Record<string, unknown>).MACRO
+    }
+    globalThis.fetch = originalFetch
+    if (fixturesRoot) {
+      rmSync(fixturesRoot, { force: true, recursive: true })
+      fixturesRoot = undefined
+    }
+  } finally {
+    releaseSharedMutationLock()
+  }
+})
+
+describe('Claude API lifecycle tracking', () => {
+  test('ends a failed streaming dispatch before retry backoff is reported', async () => {
+    setClientTestEnv()
+    process.env.OPENCLAUDE_MAX_RETRIES = '1'
+    const queryLifecycle = new QueryLifecycleOperationTracker()
+    const dispatchSnapshots: ReturnType<
+      QueryLifecycleOperationTracker['snapshot']
+    >[] = []
+    const fetchOverride: FetchOverride = async () => {
+      dispatchSnapshots.push(queryLifecycle.snapshot())
+      return makeErrorResponse(500, 'stream dispatch failed')
+    }
+
+    const generator = queryModelWithStreaming({
+      messages: [
+        {
+          type: 'user',
+          uuid: '00000000-0000-0000-0000-000000000001',
+          timestamp: '2026-06-17T00:00:00.000Z',
+          message: { role: 'user', content: 'hello' },
+        } as Message,
+      ],
+      systemPrompt: asSystemPrompt([]),
+      thinkingConfig: { type: 'disabled' },
+      tools: [],
+      signal: new AbortController().signal,
+      options: {
+        ...makeOptions(queryLifecycle),
+        fetchOverride,
+      },
+    })
+
+    const first = await generator.next()
+    expect(first.done).toBe(false)
+    expect(first.value).toMatchObject({
+      type: 'system',
+      subtype: 'api_error',
+    })
+    expect(dispatchSnapshots.length).toBeGreaterThanOrEqual(1)
+    expect(dispatchSnapshots.some(snapshot => snapshot.apiCalls.length === 1)).toBe(
+      true,
+    )
+    expect(queryLifecycle.snapshot().apiCalls).toEqual([])
+
+    await generator.return(undefined)
+  })
+
+  test('preserves provider override and query source during 404 non-streaming fallback', async () => {
+    setClientTestEnv()
+    process.env.OPENCLAUDE_MAX_RETRIES = '0'
+    const queryLifecycle = new QueryLifecycleOperationTracker()
+    const providerBaseURL = 'https://provider.example/v1'
+    const requests: {
+      authorization: string | null
+      snapshot: LifecycleSnapshot
+      stream: unknown
+      url: string
+    }[] = []
+
+    globalThis.fetch = (async (input, init) => {
+      const body = parseRequestBody(init)
+      requests.push({
+        authorization: new Headers(init?.headers).get('authorization'),
+        snapshot: queryLifecycle.snapshot(),
+        stream: body.stream,
+        url: input instanceof Request ? input.url : String(input),
+      })
+
+      if (body.stream === true) {
+        return makeErrorResponse(404, 'streaming unavailable')
+      }
+
+      return makeOpenAIChatCompletionResponse()
+    }) as typeof fetch
+
+    const messages: unknown[] = []
+    const generator = queryModelWithStreaming({
+      messages: [
+        {
+          type: 'user',
+          uuid: '00000000-0000-0000-0000-000000000002',
+          timestamp: '2026-06-17T00:00:00.000Z',
+          message: { role: 'user', content: 'hello' },
+        } as Message,
+      ],
+      systemPrompt: asSystemPrompt([]),
+      thinkingConfig: { type: 'disabled' },
+      tools: [],
+      signal: new AbortController().signal,
+      options: {
+        ...makeOptions(queryLifecycle),
+        providerOverride: {
+          model: 'gpt-override',
+          baseURL: providerBaseURL,
+          apiKey: 'provider-test-key',
+        },
+      },
+    })
+
+    for await (const message of generator) {
+      messages.push(message)
+    }
+
+    const streamingRequest = requests.find(request => request.stream === true)
+    const fallbackRequest = requests.find(request => request.stream === false)
+
+    expect(
+      messages.some(
+        message =>
+          typeof message === 'object' &&
+          message !== null &&
+          (message as { type?: unknown }).type === 'assistant',
+      ),
+    ).toBe(true)
+    expect(streamingRequest?.url.startsWith(providerBaseURL)).toBe(true)
+    expect(fallbackRequest?.url.startsWith(providerBaseURL)).toBe(true)
+    expect(fallbackRequest?.authorization).toBe('Bearer provider-test-key')
+    expect(fallbackRequest?.snapshot.apiCalls).toHaveLength(1)
+    expect(fallbackRequest?.snapshot.apiCalls[0]).toMatchObject({
+      querySource: 'sdk',
+    })
+    expect(queryLifecycle.snapshot().apiCalls).toEqual([])
+  })
+
+  test('tracks each non-streaming fallback request and clears it on success', async () => {
+    const queryLifecycle = new QueryLifecycleOperationTracker()
+    const requestSnapshots: ReturnType<
+      QueryLifecycleOperationTracker['snapshot']
+    >[] = []
+    setClientTestEnv()
+    const fetchOverride: FetchOverride = async () => {
+      requestSnapshots.push(queryLifecycle.snapshot())
+      return makeJsonResponse(makeBetaMessage())
+    }
+
+    const result = await drainGenerator(
+      executeNonStreamingRequest(
+        { model: 'claude-lifecycle-test', source: 'sdk', fetchOverride },
+        {
+          model: 'claude-lifecycle-test',
+          thinkingConfig: { type: 'disabled' },
+          signal: new AbortController().signal,
+          querySource: 'sdk',
+        },
+        makeParams,
+        () => {},
+        () => {},
+        null,
+        queryLifecycle,
+      ),
+    )
+
+    expect(result.id).toBe('msg-lifecycle-test')
+    expect(requestSnapshots).toHaveLength(1)
+    expect(requestSnapshots[0]?.apiCalls).toHaveLength(1)
+    expect(requestSnapshots[0]?.apiCalls[0]).toMatchObject({
+      model: 'claude-lifecycle-test',
+      querySource: 'sdk',
+    })
+    expect(queryLifecycle.snapshot().apiCalls).toEqual([])
+  })
+
+  test('clears non-streaming fallback lifecycle entries after request errors', async () => {
+    setClientTestEnv()
+    process.env.OPENCLAUDE_MAX_RETRIES = '0'
+    const queryLifecycle = new QueryLifecycleOperationTracker()
+    const requestSnapshots: ReturnType<
+      QueryLifecycleOperationTracker['snapshot']
+    >[] = []
+    const fetchOverride: FetchOverride = async () => {
+      requestSnapshots.push(queryLifecycle.snapshot())
+      return makeErrorResponse(400, 'fallback failed')
+    }
+
+    await expect(
+      drainGenerator(
+        executeNonStreamingRequest(
+          { model: 'claude-lifecycle-test', source: 'sdk', fetchOverride },
+          {
+            model: 'claude-lifecycle-test',
+            thinkingConfig: { type: 'disabled' },
+            signal: new AbortController().signal,
+            querySource: 'sdk',
+          },
+          makeParams,
+          () => {},
+          () => {},
+          null,
+          queryLifecycle,
+        ),
+      ),
+    ).rejects.toThrow('fallback failed')
+
+    expect(requestSnapshots).toHaveLength(1)
+    expect(requestSnapshots[0]?.apiCalls).toHaveLength(1)
+    expect(queryLifecycle.snapshot().apiCalls).toEqual([])
+  })
+})

--- a/src/services/api/claude.ts
+++ b/src/services/api/claude.ts
@@ -854,6 +854,7 @@ export async function* executeNonStreamingRequest(
    * from. Emitted in tengu_nonstreaming_fallback_error for funnel correlation.
    */
   originatingRequestId?: string | null,
+  queryLifecycle?: QueryLifecycleOperationTracker,
 ): AsyncGenerator<SystemAPIErrorMessage, BetaMessage> {
   const fallbackTimeoutMs = getNonstreamingFallbackTimeoutMs()
   const generator = withRetry(
@@ -876,6 +877,12 @@ export async function* executeNonStreamingRequest(
         retryParams,
         MAX_NON_STREAMING_TOKENS,
       )
+      const activeApiCallKey =
+        queryLifecycle?.startApiCall({
+          model: context.model,
+          querySource: retryOptions.querySource,
+          startedAt: start,
+        }) ?? null
 
       try {
         // biome-ignore lint/plugin: non-streaming API call
@@ -910,6 +917,10 @@ export async function* executeNonStreamingRequest(
             'unknown') as AnalyticsMetadata_I_VERIFIED_THIS_IS_NOT_CODE_OR_FILEPATHS,
         })
         throw err
+      } finally {
+        if (activeApiCallKey) {
+          queryLifecycle?.endApiCall(activeApiCallKey)
+        }
       }
     },
     {
@@ -1543,6 +1554,20 @@ async function* queryModel(
   // eslint-disable-next-line eslint-plugin-n/no-unsupported-features/node-builtins -- Response is available in supported Node runtimes and is used by the SDK
   let streamResponse: Response | undefined = undefined
 
+  function endActiveApiCall(key = activeApiCallKey): void {
+    if (!key) return
+    options.queryLifecycle?.endApiCall(key)
+    if (activeApiCallKey === key) {
+      activeApiCallKey = null
+    }
+  }
+
+  function startActiveApiCall(call: Parameters<QueryLifecycleOperationTracker['startApiCall']>[0]): string | null {
+    endActiveApiCall()
+    activeApiCallKey = options.queryLifecycle?.startApiCall(call) ?? null
+    return activeApiCallKey
+  }
+
   // Release all stream resources to prevent native memory leaks.
   // The Response object holds native TLS/socket buffers that live outside the
   // V8 heap (observed on the Node.js/npm path; see GH #32920), so we must
@@ -1852,42 +1877,42 @@ async function* queryModel(
           getAPIProvider() === 'firstParty' && isFirstPartyAnthropicBaseUrl()
             ? randomUUID()
             : undefined
-        if (activeApiCallKey) {
-          options.queryLifecycle?.endApiCall(activeApiCallKey)
-          activeApiCallKey = null
-        }
-        activeApiCallKey =
-          options.queryLifecycle?.startApiCall({
-            clientRequestId,
-            model: options.model,
-            querySource: options.querySource,
-            startedAt: start,
-          }) ?? null
+        const attemptApiCallKey = startActiveApiCall({
+          clientRequestId,
+          model: options.model,
+          querySource: options.querySource,
+          startedAt: start,
+        })
 
         // Use raw stream instead of BetaMessageStream to avoid O(n²) partial JSON parsing
         // BetaMessageStream calls partialParse() on every input_json_delta, which we don't need
         // since we handle tool input accumulation ourselves
         // biome-ignore lint/plugin: main conversation loop handles attribution separately
-        const result = await anthropic.beta.messages
-          .create(
-            { ...params, stream: true },
-            {
-              signal,
-              ...(clientRequestId && {
-                headers: { [CLIENT_REQUEST_ID_HEADER]: clientRequestId },
-              }),
-            },
-          )
-          .withResponse()
-        queryCheckpoint('query_response_headers_received')
-        streamRequestId = result.request_id
-        if (activeApiCallKey) {
-          options.queryLifecycle?.updateApiCall(activeApiCallKey, {
-            requestId: streamRequestId,
-          })
+        try {
+          const result = await anthropic.beta.messages
+            .create(
+              { ...params, stream: true },
+              {
+                signal,
+                ...(clientRequestId && {
+                  headers: { [CLIENT_REQUEST_ID_HEADER]: clientRequestId },
+                }),
+              },
+            )
+            .withResponse()
+          queryCheckpoint('query_response_headers_received')
+          streamRequestId = result.request_id
+          if (attemptApiCallKey) {
+            options.queryLifecycle?.updateApiCall(attemptApiCallKey, {
+              requestId: streamRequestId,
+            })
+          }
+          streamResponse = result.response
+          return result.data
+        } catch (err) {
+          endActiveApiCall(attemptApiCallKey)
+          throw err
         }
-        streamResponse = result.response
-        return result.data
       },
       {
         model: options.model,
@@ -2604,6 +2629,7 @@ async function* queryModel(
           ? 'watchdog'
           : 'other') as AnalyticsMetadata_I_VERIFIED_THIS_IS_NOT_CODE_OR_FILEPATHS,
       })
+      endActiveApiCall()
       const result = yield* executeNonStreamingRequest(
         { model: options.model, source: options.querySource, providerOverride: options.providerOverride, effortValue: effort },
         {
@@ -2622,6 +2648,7 @@ async function* queryModel(
         },
         params => captureAPIRequest(params, options.querySource),
         streamRequestId,
+        options.queryLifecycle,
       )
 
       const m: AssistantMessage = {
@@ -2703,14 +2730,21 @@ async function* queryModel(
 
       try {
         // Fall back to non-streaming mode
+        endActiveApiCall()
         const result = yield* executeNonStreamingRequest(
-          { model: options.model, source: options.querySource, effortValue: effort },
+          {
+            model: options.model,
+            source: options.querySource,
+            providerOverride: options.providerOverride,
+            effortValue: effort,
+          },
           {
             model: options.model,
             fallbackModel: options.fallbackModel,
             thinkingConfig,
             ...(isFastModeEnabled() && { fastMode: isFastMode }),
             signal,
+            querySource: options.querySource,
           },
           paramsFromContext,
           (attempt, _startTime, tokens) => {
@@ -2719,6 +2753,7 @@ async function* queryModel(
           },
           params => captureAPIRequest(params, options.querySource),
           failedRequestId,
+          options.queryLifecycle,
         )
 
         const m: AssistantMessage = {
@@ -2860,10 +2895,7 @@ async function* queryModel(
       return
     }
   } finally {
-    if (activeApiCallKey) {
-      options.queryLifecycle?.endApiCall(activeApiCallKey)
-      activeApiCallKey = null
-    }
+    endActiveApiCall()
     stopSessionActivity('api_call')
     // Must be in the finally block: if the generator is terminated early
     // via .return() (e.g. consumer breaks out of for-await-of, or query.ts

--- a/src/services/api/claude.ts
+++ b/src/services/api/claude.ts
@@ -170,6 +170,7 @@ import { COMPACT_MAX_OUTPUT_TOKENS, getContextWindowForModel, getMaxThinkingToke
 import { logForDebugging } from 'src/utils/debug.js'
 import { logForDiagnosticsNoPII } from 'src/utils/diagLogs.js'
 import { type EffortValue, modelSupportsEffort } from 'src/utils/effort.js'
+import type { QueryLifecycleOperationTracker } from 'src/utils/queryLifecycle.js'
 import {
   isFastModeAvailable,
   isFastModeCooldown,
@@ -716,6 +717,7 @@ export type Options = {
   // (query.ts decrements across the agentic loop).
   taskBudget?: { total: number; remaining?: number }
   providerOverride?: { model: string; baseURL: string; apiKey: string }
+  queryLifecycle?: QueryLifecycleOperationTracker
 }
 
 export async function queryModelWithoutStreaming({
@@ -1537,6 +1539,7 @@ async function* queryModel(
   let stream: Stream<BetaRawMessageStreamEvent> | undefined = undefined
   let streamRequestId: string | null | undefined = undefined
   let clientRequestId: string | undefined = undefined
+  let activeApiCallKey: string | null = null
   // eslint-disable-next-line eslint-plugin-n/no-unsupported-features/node-builtins -- Response is available in supported Node runtimes and is used by the SDK
   let streamResponse: Response | undefined = undefined
 
@@ -1849,6 +1852,17 @@ async function* queryModel(
           getAPIProvider() === 'firstParty' && isFirstPartyAnthropicBaseUrl()
             ? randomUUID()
             : undefined
+        if (activeApiCallKey) {
+          options.queryLifecycle?.endApiCall(activeApiCallKey)
+          activeApiCallKey = null
+        }
+        activeApiCallKey =
+          options.queryLifecycle?.startApiCall({
+            clientRequestId,
+            model: options.model,
+            querySource: options.querySource,
+            startedAt: start,
+          }) ?? null
 
         // Use raw stream instead of BetaMessageStream to avoid O(n²) partial JSON parsing
         // BetaMessageStream calls partialParse() on every input_json_delta, which we don't need
@@ -1867,6 +1881,11 @@ async function* queryModel(
           .withResponse()
         queryCheckpoint('query_response_headers_received')
         streamRequestId = result.request_id
+        if (activeApiCallKey) {
+          options.queryLifecycle?.updateApiCall(activeApiCallKey, {
+            requestId: streamRequestId,
+          })
+        }
         streamResponse = result.response
         return result.data
       },
@@ -2841,6 +2860,10 @@ async function* queryModel(
       return
     }
   } finally {
+    if (activeApiCallKey) {
+      options.queryLifecycle?.endApiCall(activeApiCallKey)
+      activeApiCallKey = null
+    }
     stopSessionActivity('api_call')
     // Must be in the finally block: if the generator is terminated early
     // via .return() (e.g. consumer breaks out of for-await-of, or query.ts

--- a/src/services/tools/StreamingToolExecutor.test.ts
+++ b/src/services/tools/StreamingToolExecutor.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, test } from 'bun:test'
+import type { ToolUseBlock } from '@anthropic-ai/sdk/resources/index.mjs'
+import { z } from 'zod/v4'
+
+import type { CanUseToolFn } from '../../hooks/useCanUseTool.js'
+import { createToolFixture } from '../../test/toolFixtures.js'
+import {
+  getEmptyToolPermissionContext,
+  type Tool,
+  type ToolUseContext,
+} from '../../Tool.js'
+import type { AssistantMessage } from '../../types/message.js'
+import { QueryLifecycleOperationTracker } from '../../utils/queryLifecycle.js'
+import { StreamingToolExecutor } from './StreamingToolExecutor.js'
+
+const assistantMessage = {
+  uuid: 'assistant-message-1',
+  requestId: 'request-1',
+  message: {
+    id: 'assistant-api-message-1',
+    content: [],
+  },
+} as unknown as AssistantMessage
+
+function makeToolUseContext(
+  tools: readonly Tool[],
+  queryLifecycle: QueryLifecycleOperationTracker,
+  inProgressToolUseIds: { current: Set<string> },
+  hasInterruptibleToolInProgress: { current: boolean },
+): ToolUseContext {
+  return {
+    abortController: new AbortController(),
+    messages: [],
+    queryLifecycle,
+    options: {
+      tools,
+      commands: [],
+      debug: false,
+      verbose: false,
+      mainLoopModel: 'test-model',
+      mcpClients: [],
+      mcpResources: {},
+      isNonInteractiveSession: false,
+    },
+    getAppState: () => ({
+      toolPermissionContext: getEmptyToolPermissionContext(),
+      sessionHooks: new Map(),
+    }),
+    setAppState: () => {},
+    setInProgressToolUseIDs: updater => {
+      inProgressToolUseIds.current = updater(inProgressToolUseIds.current)
+    },
+    setHasInterruptibleToolInProgress: value => {
+      hasInterruptibleToolInProgress.current = value
+    },
+    setResponseLength: () => {},
+    updateFileHistoryState: () => {},
+    updateAttributionState: () => {},
+  } as unknown as ToolUseContext
+}
+
+describe('StreamingToolExecutor lifecycle tracking', () => {
+  test('discard aborts in-flight tools and clears lifecycle tracking immediately', async () => {
+    const queryLifecycle = new QueryLifecycleOperationTracker()
+    const inProgressToolUseIds = { current: new Set<string>() }
+    const hasInterruptibleToolInProgress = { current: false }
+    let resolveStarted!: () => void
+    const started = new Promise<void>(resolve => {
+      resolveStarted = resolve
+    })
+    let observedAbortReason: unknown
+    let resolveAborted!: () => void
+    const aborted = new Promise<void>(resolve => {
+      resolveAborted = resolve
+    })
+    const tool = createToolFixture(z.object({}), {
+      name: 'SlowLifecycleTool',
+      interruptBehavior: () => 'cancel',
+      async call(_input, context) {
+        resolveStarted()
+        await new Promise<void>(resolve => {
+          if (context.abortController.signal.aborted) {
+            observedAbortReason = context.abortController.signal.reason
+            resolveAborted()
+            resolve()
+            return
+          }
+          context.abortController.signal.addEventListener(
+            'abort',
+            () => {
+              observedAbortReason = context.abortController.signal.reason
+              resolveAborted()
+              resolve()
+            },
+            { once: true },
+          )
+        })
+        return { data: 'aborted' }
+      },
+    })
+    const toolUseContext = makeToolUseContext(
+      [tool],
+      queryLifecycle,
+      inProgressToolUseIds,
+      hasInterruptibleToolInProgress,
+    )
+    const executor = new StreamingToolExecutor(
+      [tool],
+      (async () => ({ behavior: 'allow' })) as CanUseToolFn,
+      toolUseContext,
+    )
+
+    executor.addTool(
+      {
+        type: 'tool_use',
+        id: 'tool-use-1',
+        name: tool.name,
+        input: {},
+      } as ToolUseBlock,
+      assistantMessage,
+    )
+    await started
+
+    expect(queryLifecycle.snapshot().toolUses).toMatchObject([
+      {
+        toolUseId: 'tool-use-1',
+        toolName: tool.name,
+      },
+    ])
+    expect(inProgressToolUseIds.current.has('tool-use-1')).toBe(true)
+    expect(hasInterruptibleToolInProgress.current).toBe(true)
+
+    executor.discard()
+
+    expect(queryLifecycle.snapshot()).toEqual({ apiCalls: [], toolUses: [] })
+    expect(inProgressToolUseIds.current.has('tool-use-1')).toBe(false)
+    expect(hasInterruptibleToolInProgress.current).toBe(false)
+    await aborted
+    expect(observedAbortReason).toBe('streaming_fallback')
+    expect([...executor.getCompletedResults()]).toEqual([])
+  })
+})

--- a/src/services/tools/StreamingToolExecutor.ts
+++ b/src/services/tools/StreamingToolExecutor.ts
@@ -67,7 +67,21 @@ export class StreamingToolExecutor {
    * Queued tools won't start, and in-progress tools will receive synthetic errors.
    */
   discard(): void {
+    if (this.discarded) return
     this.discarded = true
+    this.siblingAbortController.abort('streaming_fallback')
+    for (const tool of this.tools) {
+      if (tool.status === 'yielded') continue
+      this.toolUseContext.queryLifecycle?.endToolUse(tool.id)
+      markToolUseAsComplete(this.toolUseContext, tool.id)
+      tool.pendingProgress.length = 0
+      tool.status = 'yielded'
+    }
+    this.updateInterruptibleState()
+    if (this.progressAvailableResolve) {
+      this.progressAvailableResolve()
+      this.progressAvailableResolve = undefined
+    }
   }
 
   /**

--- a/src/services/tools/toolExecution.test.ts
+++ b/src/services/tools/toolExecution.test.ts
@@ -3,6 +3,7 @@ import { z } from 'zod/v4'
 
 import { SkillTool } from '../../tools/SkillTool/SkillTool.js'
 import { AskUserQuestionTool } from '../../tools/AskUserQuestionTool/AskUserQuestionTool.js'
+import { BASH_TOOL_NAME } from '../../tools/BashTool/toolName.js'
 import type { CanUseToolFn } from '../../hooks/useCanUseTool.js'
 import { createToolFixture } from '../../test/toolFixtures.js'
 import {
@@ -152,6 +153,47 @@ describe('runToolUse lifecycle tracking', () => {
       toolName: 'LifecycleTestTool',
     })
     expect(typeof snapshots[0]?.toolUses[0]?.startedAt).toBe('number')
+    expect(queryLifecycle.snapshot()).toEqual({ apiCalls: [], toolUses: [] })
+  })
+
+  test('tracks Bash timeout metadata while async input validation is pending', async () => {
+    const queryLifecycle = new QueryLifecycleOperationTracker()
+    const snapshots: ReturnType<QueryLifecycleOperationTracker['snapshot']>[] =
+      []
+    const tool = createToolFixture(lifecycleToolInputSchema, {
+      name: BASH_TOOL_NAME,
+      async validateInput() {
+        snapshots.push(queryLifecycle.snapshot())
+        return {
+          result: false,
+          message: 'blocked by validation',
+          errorCode: 123,
+        }
+      },
+      async call() {
+        throw new Error('call should not run after validation failure')
+      },
+    })
+    const toolUseContext = makeToolUseContext([tool], queryLifecycle)
+    const canUseTool = (async () => ({
+      behavior: 'allow',
+    })) as CanUseToolFn
+
+    await collectToolUseUpdates(
+      tool,
+      { command: 'sleep 1', timeout: 4321 },
+      canUseTool,
+      toolUseContext,
+    )
+
+    expect(snapshots).toHaveLength(1)
+    expect(snapshots[0]?.toolUses).toHaveLength(1)
+    expect(snapshots[0]?.toolUses[0]).toMatchObject({
+      toolUseId: 'tool-use-1',
+      toolName: BASH_TOOL_NAME,
+      isBash: true,
+      timeoutMs: 4321,
+    })
     expect(queryLifecycle.snapshot()).toEqual({ apiCalls: [], toolUses: [] })
   })
 

--- a/src/services/tools/toolExecution.test.ts
+++ b/src/services/tools/toolExecution.test.ts
@@ -1,12 +1,90 @@
 import { describe, expect, test } from 'bun:test'
+import { z } from 'zod/v4'
 
 import { SkillTool } from '../../tools/SkillTool/SkillTool.js'
 import { AskUserQuestionTool } from '../../tools/AskUserQuestionTool/AskUserQuestionTool.js'
+import type { CanUseToolFn } from '../../hooks/useCanUseTool.js'
+import { createToolFixture } from '../../test/toolFixtures.js'
+import {
+  getEmptyToolPermissionContext,
+  type Tool,
+  type ToolUseContext,
+} from '../../Tool.js'
+import type { AssistantMessage } from '../../types/message.js'
+import { QueryLifecycleOperationTracker } from '../../utils/queryLifecycle.js'
 import {
   getSchemaValidationErrorOverride,
   getSchemaValidationToolUseResult,
+  type MessageUpdateLazy,
   normalizeToolInputForValidation,
+  runToolUse,
 } from './toolExecution.js'
+
+const lifecycleToolInputSchema = z.object({
+  command: z.string(),
+  timeout: z.number().optional(),
+})
+
+const assistantMessage = {
+  uuid: 'assistant-message-1',
+  requestId: 'request-1',
+  message: {
+    id: 'assistant-api-message-1',
+  },
+} as unknown as AssistantMessage
+
+function makeToolUseContext(
+  tools: readonly Tool[],
+  queryLifecycle: QueryLifecycleOperationTracker,
+): ToolUseContext {
+  return {
+    abortController: new AbortController(),
+    messages: [],
+    queryLifecycle,
+    options: {
+      tools,
+      commands: [],
+      debug: false,
+      verbose: false,
+      mainLoopModel: 'test-model',
+      mcpClients: [],
+      mcpResources: {},
+      isNonInteractiveSession: false,
+    },
+    getAppState: () => ({
+      toolPermissionContext: getEmptyToolPermissionContext(),
+      sessionHooks: new Map(),
+    }),
+    setAppState: () => {},
+    setInProgressToolUseIDs: () => {},
+    setResponseLength: () => {},
+    updateFileHistoryState: () => {},
+    updateAttributionState: () => {},
+  } as unknown as ToolUseContext
+}
+
+async function collectToolUseUpdates(
+  tool: Tool,
+  input: Record<string, unknown>,
+  canUseTool: CanUseToolFn,
+  toolUseContext: ToolUseContext,
+) {
+  const updates: MessageUpdateLazy[] = []
+  for await (const update of runToolUse(
+    {
+      type: 'tool_use',
+      id: 'tool-use-1',
+      name: tool.name,
+      input,
+    } as Parameters<typeof runToolUse>[0],
+    assistantMessage,
+    canUseTool,
+    toolUseContext,
+  )) {
+    updates.push(update)
+  }
+  return updates
+}
 
 describe('getSchemaValidationErrorOverride', () => {
   test('returns actionable missing-skill error for SkillTool', () => {
@@ -31,6 +109,106 @@ describe('getSchemaValidationErrorOverride', () => {
     expect(getSchemaValidationToolUseResult(SkillTool, {} as never)).toBe(
       'InputValidationError: Missing skill name. Pass the slash command name as the skill parameter (e.g., skill: "commit" for /commit, skill: "review-pr" for /review-pr).',
     )
+  })
+})
+
+describe('runToolUse lifecycle tracking', () => {
+  test('tracks the tool use while async input validation is pending and clears it on validation failure', async () => {
+    const queryLifecycle = new QueryLifecycleOperationTracker()
+    const snapshots: ReturnType<QueryLifecycleOperationTracker['snapshot']>[] =
+      []
+    const tool = createToolFixture(lifecycleToolInputSchema, {
+      name: 'LifecycleTestTool',
+      async validateInput() {
+        snapshots.push(queryLifecycle.snapshot())
+        return {
+          result: false,
+          message: 'blocked by validation',
+          errorCode: 123,
+        }
+      },
+      async call() {
+        throw new Error('call should not run after validation failure')
+      },
+    })
+    const toolUseContext = makeToolUseContext([tool], queryLifecycle)
+    const canUseTool = (async () => ({
+      behavior: 'allow',
+    })) as CanUseToolFn
+
+    const updates = await collectToolUseUpdates(
+      tool,
+      { command: 'echo hi', timeout: 1234 },
+      canUseTool,
+      toolUseContext,
+    )
+
+    expect(updates).toHaveLength(1)
+    expect(snapshots).toHaveLength(1)
+    expect(snapshots[0]?.apiCalls).toEqual([])
+    expect(snapshots[0]?.toolUses).toHaveLength(1)
+    expect(snapshots[0]?.toolUses[0]).toMatchObject({
+      toolUseId: 'tool-use-1',
+      toolName: 'LifecycleTestTool',
+    })
+    expect(typeof snapshots[0]?.toolUses[0]?.startedAt).toBe('number')
+    expect(queryLifecycle.snapshot()).toEqual({ apiCalls: [], toolUses: [] })
+  })
+
+  test('tracks the tool use while permission resolution is pending and clears it on denial', async () => {
+    const queryLifecycle = new QueryLifecycleOperationTracker()
+    const snapshots: ReturnType<QueryLifecycleOperationTracker['snapshot']>[] =
+      []
+    const tool = createToolFixture(lifecycleToolInputSchema, {
+      name: 'LifecyclePermissionTool',
+      async validateInput() {
+        return { result: true }
+      },
+      async call() {
+        throw new Error('call should not run after permission denial')
+      },
+    })
+    const toolUseContext = makeToolUseContext([tool], queryLifecycle)
+    const canUseTool = (async () => {
+      snapshots.push(queryLifecycle.snapshot())
+      return {
+        behavior: 'deny',
+        message: 'denied by test',
+        decisionReason: {
+          type: 'other',
+          reason: 'denied by test',
+        },
+      }
+    }) as CanUseToolFn
+
+    const previousSimpleMode = process.env.CLAUDE_CODE_SIMPLE
+    process.env.CLAUDE_CODE_SIMPLE = '1'
+    let updates: Awaited<ReturnType<typeof collectToolUseUpdates>>
+    try {
+      updates = await collectToolUseUpdates(
+        tool,
+        { command: 'echo hi' },
+        canUseTool,
+        toolUseContext,
+      )
+    } finally {
+      if (previousSimpleMode === undefined) {
+        delete process.env.CLAUDE_CODE_SIMPLE
+      } else {
+        process.env.CLAUDE_CODE_SIMPLE = previousSimpleMode
+      }
+    }
+
+    expect(updates).toHaveLength(1)
+    expect(snapshots).toHaveLength(1)
+    expect(snapshots[0]?.apiCalls).toEqual([])
+    expect(snapshots[0]?.toolUses).toHaveLength(1)
+    expect(snapshots[0]?.toolUses[0]).toMatchObject({
+      toolUseId: 'tool-use-1',
+      toolName: 'LifecyclePermissionTool',
+    })
+    expect(typeof snapshots[0]?.toolUses[0]?.startedAt).toBe('number')
+    expect(queryLifecycle.snapshot()).toEqual({ apiCalls: [], toolUses: [] })
   })
 })
 

--- a/src/services/tools/toolExecution.test.ts
+++ b/src/services/tools/toolExecution.test.ts
@@ -252,6 +252,64 @@ describe('runToolUse lifecycle tracking', () => {
     expect(typeof snapshots[0]?.toolUses[0]?.startedAt).toBe('number')
     expect(queryLifecycle.snapshot()).toEqual({ apiCalls: [], toolUses: [] })
   })
+
+  test('refreshes Bash timeout metadata after permission input rewrites', async () => {
+    const queryLifecycle = new QueryLifecycleOperationTracker()
+    const permissionSnapshots: ReturnType<
+      QueryLifecycleOperationTracker['snapshot']
+    >[] = []
+    const callSnapshots: ReturnType<QueryLifecycleOperationTracker['snapshot']>[] =
+      []
+    const tool = createToolFixture(lifecycleToolInputSchema, {
+      name: BASH_TOOL_NAME,
+      async validateInput() {
+        return { result: true }
+      },
+      async call(input) {
+        callSnapshots.push(queryLifecycle.snapshot())
+        expect(input).toMatchObject({
+          command: 'sleep 2',
+          timeout: 2222,
+        })
+        return { data: 'ok' }
+      },
+    })
+    const toolUseContext = makeToolUseContext([tool], queryLifecycle)
+    const canUseTool = (async () => {
+      permissionSnapshots.push(queryLifecycle.snapshot())
+      return {
+        behavior: 'allow',
+        updatedInput: { command: 'sleep 2', timeout: 2222 },
+        decisionReason: {
+          type: 'other',
+          reason: 'allowed by test',
+        },
+      }
+    }) as CanUseToolFn
+
+    await collectToolUseUpdates(
+      tool,
+      { command: 'sleep 1', timeout: 1111 },
+      canUseTool,
+      toolUseContext,
+    )
+
+    expect(permissionSnapshots).toHaveLength(1)
+    expect(permissionSnapshots[0]?.toolUses[0]).toMatchObject({
+      toolUseId: 'tool-use-1',
+      toolName: BASH_TOOL_NAME,
+      isBash: true,
+      timeoutMs: 1111,
+    })
+    expect(callSnapshots).toHaveLength(1)
+    expect(callSnapshots[0]?.toolUses[0]).toMatchObject({
+      toolUseId: 'tool-use-1',
+      toolName: BASH_TOOL_NAME,
+      isBash: true,
+      timeoutMs: 2222,
+    })
+    expect(queryLifecycle.snapshot()).toEqual({ apiCalls: [], toolUses: [] })
+  })
 })
 
 describe('normalizeToolInputForValidation', () => {

--- a/src/services/tools/toolExecution.ts
+++ b/src/services/tools/toolExecution.ts
@@ -756,893 +756,50 @@ async function checkPermissionsAndCallTool(
     ]
   }
 
-  // Validate input values. Each tool has its own validation logic
-  const isValidCall = await tool.validateInput?.(
-    parsedInput.data,
-    toolUseContext,
-  )
-  if (isValidCall?.result === false) {
-    logForDebugging(
-      `${tool.name} tool validation error: ${isValidCall.message?.slice(0, 200)}`,
-    )
-    logEvent('tengu_tool_use_error', {
-      messageID:
-        messageId as AnalyticsMetadata_I_VERIFIED_THIS_IS_NOT_CODE_OR_FILEPATHS,
-      toolName: sanitizeToolNameForAnalytics(tool.name),
-      error:
-        isValidCall.message as AnalyticsMetadata_I_VERIFIED_THIS_IS_NOT_CODE_OR_FILEPATHS,
-      errorCode: isValidCall.errorCode,
-      isMcp: tool.isMcp ?? false,
-
-      queryChainId: toolUseContext.queryTracking
-        ?.chainId as AnalyticsMetadata_I_VERIFIED_THIS_IS_NOT_CODE_OR_FILEPATHS,
-      queryDepth: toolUseContext.queryTracking?.depth,
-      ...(mcpServerType && {
-        mcpServerType:
-          mcpServerType as AnalyticsMetadata_I_VERIFIED_THIS_IS_NOT_CODE_OR_FILEPATHS,
-      }),
-      ...(mcpServerBaseUrl && {
-        mcpServerBaseUrl:
-          mcpServerBaseUrl as AnalyticsMetadata_I_VERIFIED_THIS_IS_NOT_CODE_OR_FILEPATHS,
-      }),
-      ...(requestId && {
-        requestId:
-          requestId as AnalyticsMetadata_I_VERIFIED_THIS_IS_NOT_CODE_OR_FILEPATHS,
-      }),
-      ...mcpToolDetailsForAnalytics(tool.name, mcpServerType, mcpServerBaseUrl),
-    })
-    return [
-      {
-        message: createUserMessage({
-          content: [
-            {
-              type: 'tool_result',
-              content: `<tool_use_error>${isValidCall.message}</tool_use_error>`,
-              is_error: true,
-              tool_use_id: toolUseID,
-            },
-          ],
-          toolUseResult: `Error: ${isValidCall.message}`,
-          sourceToolAssistantUUID: assistantMessage.uuid,
-        }),
-      },
-    ]
-  }
-  // Speculatively start the bash allow classifier check early so it runs in
-  // parallel with pre-tool hooks, deny/ask classifiers, and permission dialog
-  // setup. The UI indicator (setClassifierChecking) is NOT set here — it's
-  // set in interactiveHandler.ts only when the permission check returns `ask`
-  // with a pendingClassifierCheck. This avoids flashing "classifier running"
-  // for commands that auto-allow via prefix rules.
-  if (
-    tool.name === BASH_TOOL_NAME &&
-    parsedInput.data &&
-    'command' in parsedInput.data
-  ) {
-    const appState = toolUseContext.getAppState()
-    startSpeculativeClassifierCheck(
-      (parsedInput.data as BashToolInput).command,
-      appState.toolPermissionContext,
-      toolUseContext.abortController.signal,
-      toolUseContext.options.isNonInteractiveSession,
-    )
-  }
-
-  const resultingMessages: MessageUpdateLazy[] = []
-
-  // Defense-in-depth: strip _simulatedSedEdit from model-provided Bash input.
-  // This field is internal-only — it must only be injected by the permission
-  // system (SedEditPermissionRequest) after user approval. If the model supplies
-  // it, the schema's strictObject should already reject it, but we strip here
-  // as a safeguard against future regressions.
-  let processedInput = parsedInput.data
-  if (
-    tool.name === BASH_TOOL_NAME &&
-    processedInput &&
-    typeof processedInput === 'object' &&
-    '_simulatedSedEdit' in processedInput
-  ) {
-    const { _simulatedSedEdit: _, ...rest } =
-      processedInput as typeof processedInput & {
-        _simulatedSedEdit: unknown
-      }
-    processedInput = rest as typeof processedInput
-  }
-
-  // Backfill legacy/derived fields on a shallow clone so hooks/canUseTool see
-  // them without affecting tool.call(). SendMessageTool adds fields; file
-  // tools overwrite file_path with expandPath — that mutation must not reach
-  // call() because tool results embed the input path verbatim (e.g. "File
-  // created successfully at: {path}"), and changing it alters the serialized
-  // transcript and VCR fixture hashes. If a hook/permission later returns a
-  // fresh updatedInput, callInput converges on it below — that replacement
-  // is intentional and should reach call().
-  let callInput = processedInput
-  const backfilledClone =
-    tool.backfillObservableInput &&
-    typeof processedInput === 'object' &&
-    processedInput !== null
-      ? ({ ...processedInput } as typeof processedInput)
-      : null
-  if (backfilledClone) {
-    tool.backfillObservableInput!(backfilledClone as Record<string, unknown>)
-    processedInput = backfilledClone
-  }
-
-  let shouldPreventContinuation = false
-  let stopReason: string | undefined
-  let hookPermissionResult: PermissionResult | undefined
-  const preToolHookInfos: StopHookInfo[] = []
-  const preToolHookStart = Date.now()
-  for await (const result of runPreToolUseHooks(
-    toolUseContext,
-    tool,
-    processedInput,
-    toolUseID,
-    assistantMessage.message.id,
-    requestId,
-    mcpServerType,
-    mcpServerBaseUrl,
-  )) {
-    switch (result.type) {
-      case 'message':
-        if (result.message.message.type === 'progress') {
-          onToolProgress(result.message.message)
-        } else {
-          resultingMessages.push(result.message)
-          const att = result.message.message.attachment
-          if (
-            att &&
-            'command' in att &&
-            att.command !== undefined &&
-            'durationMs' in att &&
-            att.durationMs !== undefined
-          ) {
-            preToolHookInfos.push({
-              command: att.command,
-              durationMs: att.durationMs,
-            })
-          }
-        }
-        break
-      case 'hookPermissionResult':
-        hookPermissionResult = result.hookPermissionResult
-        break
-      case 'hookUpdatedInput':
-        // Hook provided updatedInput without making a permission decision (passthrough)
-        // Update processedInput so it's used in the normal permission flow
-        processedInput = result.updatedInput
-        break
-      case 'preventContinuation':
-        shouldPreventContinuation = result.shouldPreventContinuation
-        break
-      case 'stopReason':
-        stopReason = result.stopReason
-        break
-      case 'additionalContext':
-        resultingMessages.push(result.message)
-        break
-      case 'stop':
-        getStatsStore()?.observe(
-          'pre_tool_hook_duration_ms',
-          Date.now() - preToolHookStart,
-        )
-        resultingMessages.push({
-          message: createUserMessage({
-            content: [createToolResultStopMessage(toolUseID)],
-            toolUseResult: `Error: ${stopReason}`,
-            sourceToolAssistantUUID: assistantMessage.uuid,
-          }),
-        })
-        return resultingMessages
-    }
-  }
-  const preToolHookDurationMs = Date.now() - preToolHookStart
-  getStatsStore()?.observe('pre_tool_hook_duration_ms', preToolHookDurationMs)
-  if (preToolHookDurationMs >= SLOW_PHASE_LOG_THRESHOLD_MS) {
-    logForDebugging(
-      `Slow PreToolUse hooks: ${preToolHookDurationMs}ms for ${tool.name} (${preToolHookInfos.length} hooks)`,
-      { level: 'info' },
-    )
-  }
-
-  // Emit PreToolUse summary immediately so it's visible while the tool executes.
-  // Use wall-clock time (not sum of individual durations) since hooks run in parallel.
-  if (process.env.USER_TYPE === 'ant' && preToolHookInfos.length > 0) {
-    if (preToolHookDurationMs > HOOK_TIMING_DISPLAY_THRESHOLD_MS) {
-      resultingMessages.push({
-        message: createStopHookSummaryMessage(
-          preToolHookInfos.length,
-          preToolHookInfos,
-          [],
-          false,
-          undefined,
-          false,
-          'suggestion',
-          undefined,
-          'PreToolUse',
-          preToolHookDurationMs,
-        ),
-      })
-    }
-  }
-
-  const toolAttributes: Record<string, string | number | boolean> = {}
-  if (processedInput && typeof processedInput === 'object') {
-    if (tool.name === FILE_READ_TOOL_NAME && 'file_path' in processedInput) {
-      toolAttributes.file_path = String(processedInput.file_path)
-    } else if (
-      (tool.name === FILE_EDIT_TOOL_NAME ||
-        tool.name === FILE_WRITE_TOOL_NAME) &&
-      'file_path' in processedInput
-    ) {
-      toolAttributes.file_path = String(processedInput.file_path)
-    } else if (tool.name === BASH_TOOL_NAME && 'command' in processedInput) {
-      const bashInput = processedInput as BashToolInput
-      toolAttributes.full_command = bashInput.command
-    }
-  }
-
-  // Check whether we have permission to use the tool,
-  // and ask the user for permission if we don't
-  const permissionMode = toolUseContext.getAppState().toolPermissionContext.mode
-  const permissionStart = Date.now()
-
-  const resolved = await resolveHookPermissionDecision(
-    hookPermissionResult,
-    tool,
-    processedInput,
-    toolUseContext,
-    canUseTool,
-    assistantMessage,
-    toolUseID,
-  )
-  const permissionDecision = resolved.decision
-  processedInput = resolved.input
-  const permissionDurationMs = Date.now() - permissionStart
-  // In auto mode, canUseTool awaits the classifier (side_query) — if that's
-  // slow the collapsed view shows "Running…" with no (Ns) tick since
-  // bash_progress hasn't started yet. Auto-only: in default mode this timer
-  // includes interactive-dialog wait (user think time), which is just noise.
-  if (
-    permissionDurationMs >= SLOW_PHASE_LOG_THRESHOLD_MS &&
-    permissionMode === 'auto'
-  ) {
-    logForDebugging(
-      `Slow permission decision: ${permissionDurationMs}ms for ${tool.name} ` +
-        `(mode=${permissionMode}, behavior=${permissionDecision.behavior})`,
-      { level: 'info' },
-    )
-  }
-
-  // Emit tool_decision OTel event and code-edit counter if the interactive
-  // permission path didn't already log it (headless mode bypasses permission
-  // logging, so we need to emit both the generic event and the code-edit
-  // counter here)
-  if (
-    permissionDecision.behavior !== 'ask' &&
-    !toolUseContext.toolDecisions?.has(toolUseID)
-  ) {
-    const decision =
-      permissionDecision.behavior === 'allow' ? 'accept' : 'reject'
-    const source = decisionReasonToOTelSource(
-      permissionDecision.decisionReason,
-      permissionDecision.behavior,
-    )
-  }
-
-  // Add message if permission was granted/denied by PermissionRequest hook
-  if (
-    permissionDecision.decisionReason?.type === 'hook' &&
-    permissionDecision.decisionReason.hookName === 'PermissionRequest' &&
-    permissionDecision.behavior !== 'ask'
-  ) {
-    resultingMessages.push({
-      message: createAttachmentMessage({
-        type: 'hook_permission_decision',
-        decision: permissionDecision.behavior,
-        toolUseID,
-        hookEvent: 'PermissionRequest',
-      }),
-    })
-  }
-
-  if (permissionDecision.behavior !== 'allow') {
-    logForDebugging(`${tool.name} tool permission denied`)
-    const decisionInfo = toolUseContext.toolDecisions?.get(toolUseID)
-
-    logEvent('tengu_tool_use_can_use_tool_rejected', {
-      messageID:
-        messageId as AnalyticsMetadata_I_VERIFIED_THIS_IS_NOT_CODE_OR_FILEPATHS,
-      toolName: sanitizeToolNameForAnalytics(tool.name),
-
-      queryChainId: toolUseContext.queryTracking
-        ?.chainId as AnalyticsMetadata_I_VERIFIED_THIS_IS_NOT_CODE_OR_FILEPATHS,
-      queryDepth: toolUseContext.queryTracking?.depth,
-      ...(mcpServerType && {
-        mcpServerType:
-          mcpServerType as AnalyticsMetadata_I_VERIFIED_THIS_IS_NOT_CODE_OR_FILEPATHS,
-      }),
-      ...(mcpServerBaseUrl && {
-        mcpServerBaseUrl:
-          mcpServerBaseUrl as AnalyticsMetadata_I_VERIFIED_THIS_IS_NOT_CODE_OR_FILEPATHS,
-      }),
-      ...(requestId && {
-        requestId:
-          requestId as AnalyticsMetadata_I_VERIFIED_THIS_IS_NOT_CODE_OR_FILEPATHS,
-      }),
-      ...mcpToolDetailsForAnalytics(tool.name, mcpServerType, mcpServerBaseUrl),
-    })
-    let errorMessage = permissionDecision.message
-    // Only use generic "Execution stopped" message if we don't have a detailed hook message
-    if (shouldPreventContinuation && !errorMessage) {
-      errorMessage = `Execution stopped by PreToolUse hook${stopReason ? `: ${stopReason}` : ''}`
-    }
-
-    // Build top-level content: tool_result (text-only for is_error compatibility) + images alongside
-    const messageContent: ContentBlockParam[] = [
-      {
-        type: 'tool_result',
-        content: errorMessage,
-        is_error: true,
-        tool_use_id: toolUseID,
-      },
-    ]
-
-    // Add image blocks at top level (not inside tool_result, which rejects non-text with is_error)
-    const rejectContentBlocks =
-      permissionDecision.behavior === 'ask'
-        ? permissionDecision.contentBlocks
-        : undefined
-    if (rejectContentBlocks?.length) {
-      messageContent.push(...rejectContentBlocks)
-    }
-
-    // Generate sequential imagePasteIds so each image renders with a distinct label
-    let rejectImageIds: number[] | undefined
-    if (rejectContentBlocks?.length) {
-      const imageCount = count(
-        rejectContentBlocks,
-        (b: ContentBlockParam) => b.type === 'image',
-      )
-      if (imageCount > 0) {
-        const startId = getNextImagePasteId(toolUseContext.messages)
-        rejectImageIds = Array.from(
-          { length: imageCount },
-          (_, i) => startId + i,
-        )
-      }
-    }
-
-    resultingMessages.push({
-      message: createUserMessage({
-        content: messageContent,
-        imagePasteIds: rejectImageIds,
-        toolUseResult: `Error: ${errorMessage}`,
-        sourceToolAssistantUUID: assistantMessage.uuid,
-      }),
-    })
-
-    // Run PermissionDenied hooks for auto mode classifier denials.
-    // If a hook returns {retry: true}, tell the model it may retry.
+  const lifecycleStartTime = Date.now()
+  function getLifecycleBashTimeoutMs(input: unknown): number | undefined {
     if (
-      feature('TRANSCRIPT_CLASSIFIER') &&
-      permissionDecision.decisionReason?.type === 'classifier' &&
-      permissionDecision.decisionReason.classifier === 'auto-mode'
+      tool.name !== BASH_TOOL_NAME ||
+      !input ||
+      typeof input !== 'object' ||
+      !('timeout' in input)
     ) {
-      let hookSaysRetry = false
-      for await (const result of executePermissionDeniedHooks(
-        tool.name,
-        toolUseID,
-        processedInput,
-        permissionDecision.decisionReason.reason ?? 'Permission denied',
-        toolUseContext,
-        permissionMode,
-        toolUseContext.abortController.signal,
-      )) {
-        if (result.retry) hookSaysRetry = true
-      }
-      if (hookSaysRetry) {
-        resultingMessages.push({
-          message: createUserMessage({
-            content:
-              'The PermissionDenied hook indicated this command is now approved. You may retry it if you would like.',
-            isMeta: true,
-          }),
-        })
-      }
+      return undefined
     }
-
-    return resultingMessages
-  }
-  logEvent('tengu_tool_use_can_use_tool_allowed', {
-    messageID:
-      messageId as AnalyticsMetadata_I_VERIFIED_THIS_IS_NOT_CODE_OR_FILEPATHS,
-    toolName: sanitizeToolNameForAnalytics(tool.name),
-
-    queryChainId: toolUseContext.queryTracking
-      ?.chainId as AnalyticsMetadata_I_VERIFIED_THIS_IS_NOT_CODE_OR_FILEPATHS,
-    queryDepth: toolUseContext.queryTracking?.depth,
-    ...(mcpServerType && {
-      mcpServerType:
-        mcpServerType as AnalyticsMetadata_I_VERIFIED_THIS_IS_NOT_CODE_OR_FILEPATHS,
-    }),
-    ...(mcpServerBaseUrl && {
-      mcpServerBaseUrl:
-        mcpServerBaseUrl as AnalyticsMetadata_I_VERIFIED_THIS_IS_NOT_CODE_OR_FILEPATHS,
-    }),
-    ...(requestId && {
-      requestId:
-        requestId as AnalyticsMetadata_I_VERIFIED_THIS_IS_NOT_CODE_OR_FILEPATHS,
-    }),
-    ...mcpToolDetailsForAnalytics(tool.name, mcpServerType, mcpServerBaseUrl),
-  })
-
-  // Use the updated input from permissions if provided
-  // (Don't overwrite if undefined - processedInput may have been modified by passthrough hooks)
-  if (permissionDecision.updatedInput !== undefined) {
-    processedInput = permissionDecision.updatedInput
+    return (input as BashToolInput).timeout
   }
 
-  // Prepare tool parameters for logging in tool_result event.
-  // Gated by OTEL_LOG_TOOL_DETAILS — tool parameters can contain sensitive
-  // content (bash commands, MCP server names, etc.) so they're opt-in only.
-  const telemetryToolInput = extractToolInputForTelemetry(processedInput)
-  let toolParameters: Record<string, unknown> = {}
-  if (isToolDetailsLoggingEnabled()) {
-    if (tool.name === BASH_TOOL_NAME && 'command' in processedInput) {
-      const bashInput = processedInput as BashToolInput
-      const commandParts = bashInput.command.trim().split(/\s+/)
-      const bashCommand = commandParts[0] || ''
-
-      toolParameters = {
-        bash_command: bashCommand,
-        full_command: bashInput.command,
-        ...(bashInput.timeout !== undefined && {
-          timeout: bashInput.timeout,
-        }),
-        ...(bashInput.description !== undefined && {
-          description: bashInput.description,
-        }),
-        ...('dangerouslyDisableSandbox' in bashInput && {
-          dangerouslyDisableSandbox: bashInput.dangerouslyDisableSandbox,
-        }),
-      }
-    }
-
-    const mcpDetails = extractMcpToolDetails(tool.name)
-    if (mcpDetails) {
-      toolParameters.mcp_server_name = mcpDetails.serverName
-      toolParameters.mcp_tool_name = mcpDetails.mcpToolName
-    }
-    const skillName = extractSkillName(tool.name, processedInput)
-    if (skillName) {
-      toolParameters.skill_name = skillName
-    }
+  function trackLifecycleToolUse(input: unknown): void {
+    const lifecycleBashTimeoutMs = getLifecycleBashTimeoutMs(input)
+    toolUseContext.queryLifecycle?.startToolUse({
+      toolUseId: toolUseID,
+      toolName: tool.name,
+      startedAt: lifecycleStartTime,
+      ...(tool.name === BASH_TOOL_NAME && { isBash: true }),
+      ...(lifecycleBashTimeoutMs !== undefined && {
+        timeoutMs: lifecycleBashTimeoutMs,
+      }),
+    })
   }
 
-  const decisionInfo = toolUseContext.toolDecisions?.get(toolUseID)
-
-  const startTime = Date.now()
-  const bashTimeoutMs =
-    tool.name === BASH_TOOL_NAME && 'timeout' in processedInput
-      ? (processedInput as BashToolInput).timeout
-      : undefined
-  toolUseContext.queryLifecycle?.startToolUse({
-    toolUseId: toolUseID,
-    toolName: tool.name,
-    startedAt: startTime,
-    ...(tool.name === BASH_TOOL_NAME && { isBash: true }),
-    ...(bashTimeoutMs !== undefined && { timeoutMs: bashTimeoutMs }),
-  })
-
-  startSessionActivity('tool_exec')
-  // If processedInput still points at the backfill clone, no hook/permission
-  // replaced it — pass the pre-backfill callInput so call() sees the model's
-  // original field values. Otherwise converge on the hook-supplied input.
-  // Permission/hook flows may return a fresh object derived from the
-  // backfilled clone (e.g. via inputSchema.parse). If its file_path matches
-  // the backfill-expanded value, restore the model's original so the tool
-  // result string embeds the path the model emitted — keeps transcript/VCR
-  // hashes stable. Other hook modifications flow through unchanged.
-  if (
-    backfilledClone &&
-    processedInput !== callInput &&
-    typeof processedInput === 'object' &&
-    processedInput !== null &&
-    'file_path' in processedInput &&
-    'file_path' in (callInput as Record<string, unknown>) &&
-    (processedInput as Record<string, unknown>).file_path ===
-      (backfilledClone as Record<string, unknown>).file_path
-  ) {
-    callInput = {
-      ...processedInput,
-      file_path: (callInput as Record<string, unknown>).file_path,
-    } as typeof processedInput
-  } else if (processedInput !== backfilledClone) {
-    callInput = processedInput
-  }
-  let queryActivityLease: { release(): void } | undefined
+  trackLifecycleToolUse(parsedInput.data)
   try {
-    const queryActivityLeaseInput = createToolQueryLeaseInput(
-      tool.name,
-      toolUseID,
-      callInput,
-    )
-    queryActivityLease = queryActivityLeaseInput
-      ? toolUseContext.queryActivity?.acquireLease(queryActivityLeaseInput)
-      : undefined
-    toolUseContext.queryActivity?.registerActivity(`tool:${tool.name}:start`)
-
-    const result = await tool.call(
-      callInput,
-      {
-        ...toolUseContext,
-        toolUseId: toolUseID,
-        hookChainsCanUseTool: canUseTool,
-        userModified: permissionDecision.userModified ?? false,
-      },
-      canUseTool,
-      assistantMessage,
-      progress => {
-        toolUseContext.queryActivity?.registerActivity(
-          `tool:${tool.name}:progress`,
-        )
-        onToolProgress({
-          toolUseID: progress.toolUseID,
-          data: progress.data,
-        })
-      },
-    )
-    const durationMs = Date.now() - startTime
-    addToToolDuration(durationMs)
-
-    // Capture structured output from tool result if present
-    if (typeof result === 'object' && 'structured_output' in result) {
-      // Store the structured output in an attachment message
-      resultingMessages.push({
-        message: createAttachmentMessage({
-          type: 'structured_output',
-          data: result.structured_output,
-        }),
-      })
-    }
-
-    // Map the tool result to API format once and cache it. This block is reused
-    // by addToolResult (skipping the remap) and measured here for analytics.
-    const mappedToolResultBlock = tool.mapToolResultToToolResultBlockParam(
-      result.data,
-      toolUseID,
-    )
-    const mappedContent = mappedToolResultBlock.content
-    const toolResultSizeBytes = !mappedContent
-      ? 0
-      : typeof mappedContent === 'string'
-        ? mappedContent.length
-        : jsonStringify(mappedContent).length
-
-    // Extract file extension for file-related tools
-    let fileExtension: ReturnType<typeof getFileExtensionForAnalytics>
-    if (processedInput && typeof processedInput === 'object') {
-      if (
-        (tool.name === FILE_READ_TOOL_NAME ||
-          tool.name === FILE_EDIT_TOOL_NAME ||
-          tool.name === FILE_WRITE_TOOL_NAME) &&
-        'file_path' in processedInput
-      ) {
-        fileExtension = getFileExtensionForAnalytics(
-          String(processedInput.file_path),
-        )
-      } else if (
-        tool.name === NOTEBOOK_EDIT_TOOL_NAME &&
-        'notebook_path' in processedInput
-      ) {
-        fileExtension = getFileExtensionForAnalytics(
-          String(processedInput.notebook_path),
-        )
-      } else if (tool.name === BASH_TOOL_NAME && 'command' in processedInput) {
-        const bashInput = processedInput as BashToolInput
-        fileExtension = getFileExtensionsFromBashCommand(
-          bashInput.command,
-          bashInput._simulatedSedEdit?.filePath,
-        )
-      }
-    }
-
-    logEvent('tengu_tool_use_success', {
-      messageID:
-        messageId as AnalyticsMetadata_I_VERIFIED_THIS_IS_NOT_CODE_OR_FILEPATHS,
-      toolName: sanitizeToolNameForAnalytics(tool.name),
-      isMcp: tool.isMcp ?? false,
-      durationMs,
-      preToolHookDurationMs,
-      toolResultSizeBytes,
-      ...(fileExtension !== undefined && { fileExtension }),
-
-      queryChainId: toolUseContext.queryTracking
-        ?.chainId as AnalyticsMetadata_I_VERIFIED_THIS_IS_NOT_CODE_OR_FILEPATHS,
-      queryDepth: toolUseContext.queryTracking?.depth,
-      ...(mcpServerType && {
-        mcpServerType:
-          mcpServerType as AnalyticsMetadata_I_VERIFIED_THIS_IS_NOT_CODE_OR_FILEPATHS,
-      }),
-      ...(mcpServerBaseUrl && {
-        mcpServerBaseUrl:
-          mcpServerBaseUrl as AnalyticsMetadata_I_VERIFIED_THIS_IS_NOT_CODE_OR_FILEPATHS,
-      }),
-      ...(requestId && {
-        requestId:
-          requestId as AnalyticsMetadata_I_VERIFIED_THIS_IS_NOT_CODE_OR_FILEPATHS,
-      }),
-      ...mcpToolDetailsForAnalytics(tool.name, mcpServerType, mcpServerBaseUrl),
-    })
-
-    // Enrich tool parameters with git commit ID from successful git commit output
-    if (
-      isToolDetailsLoggingEnabled() &&
-      (tool.name === BASH_TOOL_NAME || tool.name === POWERSHELL_TOOL_NAME) &&
-      'command' in processedInput &&
-      typeof processedInput.command === 'string' &&
-      processedInput.command.match(/\bgit\s+commit\b/) &&
-      result.data &&
-      typeof result.data === 'object' &&
-      'stdout' in result.data
-    ) {
-      const gitCommitId = parseGitCommitId(String(result.data.stdout))
-      if (gitCommitId) {
-        toolParameters.git_commit_id = gitCommitId
-      }
-    }
-
-    // Log tool result event for OTLP with tool parameters and decision context
-    const mcpServerScope = isMcpTool(tool)
-      ? getMcpServerScopeFromToolName(tool.name)
-      : null
-
-
-    // Run PostToolUse hooks
-    let toolOutput = result.data
-    const hookResults: MessageUpdateLazy<HookResultMessage>[] = []
-    const toolContextModifier = result.contextModifier
-    const mcpMeta = result.mcpMeta
-
-    async function addToolResult(
-      toolUseResult: unknown,
-      preMappedBlock?: ToolResultBlockParam,
-    ) {
-      // Use the pre-mapped block when available (non-MCP tools where hooks
-      // don't modify the output), otherwise map from scratch.
-      const toolResultBlock = preMappedBlock
-        ? await processPreMappedToolResultBlock(
-            preMappedBlock,
-            tool.name,
-            tool.maxResultSizeChars,
-          )
-        : await processToolResultBlock(tool, toolUseResult, toolUseID)
-
-      // Build content blocks - tool result first, then optional feedback
-      const contentBlocks: ContentBlockParam[] = [toolResultBlock]
-      // Add accept feedback if user provided feedback when approving
-      // (acceptFeedback only exists on PermissionAllowDecision, which is guaranteed here)
-      if (
-        'acceptFeedback' in permissionDecision &&
-        permissionDecision.acceptFeedback
-      ) {
-        contentBlocks.push({
-          type: 'text',
-          text: permissionDecision.acceptFeedback,
-        })
-      }
-
-      // Add content blocks (e.g., pasted images) from the permission decision
-      const allowContentBlocks =
-        'contentBlocks' in permissionDecision
-          ? permissionDecision.contentBlocks
-          : undefined
-      if (allowContentBlocks?.length) {
-        contentBlocks.push(...allowContentBlocks)
-      }
-
-      // Generate sequential imagePasteIds so each image renders with a distinct label
-      let allowImageIds: number[] | undefined
-      if (allowContentBlocks?.length) {
-        const imageCount = count(
-          allowContentBlocks,
-          (b: ContentBlockParam) => b.type === 'image',
-        )
-        if (imageCount > 0) {
-          const startId = getNextImagePasteId(toolUseContext.messages)
-          allowImageIds = Array.from(
-            { length: imageCount },
-            (_, i) => startId + i,
-          )
-        }
-      }
-
-      resultingMessages.push({
-        message: createUserMessage({
-          content: contentBlocks,
-          imagePasteIds: allowImageIds,
-          toolUseResult:
-            toolUseContext.agentId && !toolUseContext.preserveToolUseResults
-              ? undefined
-              : toolUseResult,
-          mcpMeta: toolUseContext.agentId ? undefined : mcpMeta,
-          sourceToolAssistantUUID: assistantMessage.uuid,
-        }),
-        contextModifier: toolContextModifier
-          ? {
-              toolUseID: toolUseID,
-              modifyContext: toolContextModifier,
-            }
-          : undefined,
-      })
-    }
-
-    // TOOD(hackyon): refactor so we don't have different experiences for MCP tools
-    if (!isMcpTool(tool)) {
-      await addToolResult(toolOutput, mappedToolResultBlock)
-    }
-
-    const postToolHookInfos: StopHookInfo[] = []
-    const postToolHookStart = Date.now()
-    for await (const hookResult of runPostToolUseHooks(
+    // Validate input values. Each tool has its own validation logic
+    const isValidCall = await tool.validateInput?.(
+      parsedInput.data,
       toolUseContext,
-      tool,
-      toolUseID,
-      assistantMessage.message.id,
-      processedInput,
-      toolOutput,
-      requestId,
-      mcpServerType,
-      mcpServerBaseUrl,
-    )) {
-      if ('updatedMCPToolOutput' in hookResult) {
-        if (isMcpTool(tool)) {
-          toolOutput = hookResult.updatedMCPToolOutput
-        }
-      } else if (isMcpTool(tool)) {
-        hookResults.push(hookResult)
-        if (hookResult.message.type === 'attachment') {
-          const att = hookResult.message.attachment
-          if (
-            'command' in att &&
-            att.command !== undefined &&
-            'durationMs' in att &&
-            att.durationMs !== undefined
-          ) {
-            postToolHookInfos.push({
-              command: att.command,
-              durationMs: att.durationMs,
-            })
-          }
-        }
-      } else {
-        resultingMessages.push(hookResult)
-        if (hookResult.message.type === 'attachment') {
-          const att = hookResult.message.attachment
-          if (
-            'command' in att &&
-            att.command !== undefined &&
-            'durationMs' in att &&
-            att.durationMs !== undefined
-          ) {
-            postToolHookInfos.push({
-              command: att.command,
-              durationMs: att.durationMs,
-            })
-          }
-        }
-      }
-    }
-    const postToolHookDurationMs = Date.now() - postToolHookStart
-    if (postToolHookDurationMs >= SLOW_PHASE_LOG_THRESHOLD_MS) {
+    )
+    if (isValidCall?.result === false) {
       logForDebugging(
-        `Slow PostToolUse hooks: ${postToolHookDurationMs}ms for ${tool.name} (${postToolHookInfos.length} hooks)`,
-        { level: 'info' },
+        `${tool.name} tool validation error: ${isValidCall.message?.slice(0, 200)}`,
       )
-    }
-
-    if (isMcpTool(tool)) {
-      await addToolResult(toolOutput)
-    }
-
-    // Show PostToolUse hook timing inline below tool result when > 500ms.
-    // Use wall-clock time (not sum of individual durations) since hooks run in parallel.
-    if (process.env.USER_TYPE === 'ant' && postToolHookInfos.length > 0) {
-      if (postToolHookDurationMs > HOOK_TIMING_DISPLAY_THRESHOLD_MS) {
-        resultingMessages.push({
-          message: createStopHookSummaryMessage(
-            postToolHookInfos.length,
-            postToolHookInfos,
-            [],
-            false,
-            undefined,
-            false,
-            'suggestion',
-            undefined,
-            'PostToolUse',
-            postToolHookDurationMs,
-          ),
-        })
-      }
-    }
-
-    // If the tool provided new messages, add them to the list to return.
-    if (result.newMessages && result.newMessages.length > 0) {
-      for (const message of result.newMessages) {
-        resultingMessages.push({ message })
-      }
-    }
-    // If hook indicated to prevent continuation after successful execution, yield a stop reason message
-    if (shouldPreventContinuation) {
-      resultingMessages.push({
-        message: createAttachmentMessage({
-          type: 'hook_stopped_continuation',
-          message: stopReason || 'Execution stopped by hook',
-          hookName: `PreToolUse:${tool.name}`,
-          toolUseID: toolUseID,
-          hookEvent: 'PreToolUse',
-        }),
-      })
-    }
-
-    // Yield the remaining hook results after the other messages are sent
-    for (const hookResult of hookResults) {
-      resultingMessages.push(hookResult)
-    }
-    return resultingMessages
-  } catch (error) {
-    const durationMs = Date.now() - startTime
-    addToToolDuration(durationMs)
-
-    // Handle MCP auth errors by updating the client status to 'needs-auth'
-    // This updates the /mcp display to show the server needs re-authorization
-    if (error instanceof McpAuthError) {
-      toolUseContext.setAppState(prevState => {
-        const serverName = error.serverName
-        const existingClientIndex = prevState.mcp.clients.findIndex(
-          c => c.name === serverName,
-        )
-        if (existingClientIndex === -1) {
-          return prevState
-        }
-        const existingClient = prevState.mcp.clients[existingClientIndex]
-        // Only update if client was connected (don't overwrite other states)
-        if (!existingClient || existingClient.type !== 'connected') {
-          return prevState
-        }
-        const updatedClients = [...prevState.mcp.clients]
-        updatedClients[existingClientIndex] = {
-          name: serverName,
-          type: 'needs-auth' as const,
-          config: existingClient.config,
-        }
-        return {
-          ...prevState,
-          mcp: {
-            ...prevState.mcp,
-            clients: updatedClients,
-          },
-        }
-      })
-    }
-
-    if (!(error instanceof AbortError)) {
-      const errorMsg = errorMessage(error)
-      logForDebugging(
-        `${tool.name} tool error (${durationMs}ms): ${errorMsg.slice(0, 200)}`,
-      )
-      if (!(error instanceof ShellError)) {
-        logError(error)
-      }
       logEvent('tengu_tool_use_error', {
         messageID:
           messageId as AnalyticsMetadata_I_VERIFIED_THIS_IS_NOT_CODE_OR_FILEPATHS,
         toolName: sanitizeToolNameForAnalytics(tool.name),
-        error: classifyToolError(
-          error,
-        ) as AnalyticsMetadata_I_VERIFIED_THIS_IS_NOT_CODE_OR_FILEPATHS,
+        error:
+          isValidCall.message as AnalyticsMetadata_I_VERIFIED_THIS_IS_NOT_CODE_OR_FILEPATHS,
+        errorCode: isValidCall.errorCode,
         isMcp: tool.isMcp ?? false,
 
         queryChainId: toolUseContext.queryTracking
@@ -1660,86 +817,951 @@ async function checkPermissionsAndCallTool(
           requestId:
             requestId as AnalyticsMetadata_I_VERIFIED_THIS_IS_NOT_CODE_OR_FILEPATHS,
         }),
-        ...mcpToolDetailsForAnalytics(
-          tool.name,
-          mcpServerType,
-          mcpServerBaseUrl,
-        ),
+        ...mcpToolDetailsForAnalytics(tool.name, mcpServerType, mcpServerBaseUrl),
       })
-      // Log tool result error event for OTLP with tool parameters and decision context
+      return [
+        {
+          message: createUserMessage({
+            content: [
+              {
+                type: 'tool_result',
+                content: `<tool_use_error>${isValidCall.message}</tool_use_error>`,
+                is_error: true,
+                tool_use_id: toolUseID,
+              },
+            ],
+            toolUseResult: `Error: ${isValidCall.message}`,
+            sourceToolAssistantUUID: assistantMessage.uuid,
+          }),
+        },
+      ]
+    }
+    // Speculatively start the bash allow classifier check early so it runs in
+    // parallel with pre-tool hooks, deny/ask classifiers, and permission dialog
+    // setup. The UI indicator (setClassifierChecking) is NOT set here — it's
+    // set in interactiveHandler.ts only when the permission check returns `ask`
+    // with a pendingClassifierCheck. This avoids flashing "classifier running"
+    // for commands that auto-allow via prefix rules.
+    if (
+      tool.name === BASH_TOOL_NAME &&
+      parsedInput.data &&
+      'command' in parsedInput.data
+    ) {
+      const appState = toolUseContext.getAppState()
+      startSpeculativeClassifierCheck(
+        (parsedInput.data as BashToolInput).command,
+        appState.toolPermissionContext,
+        toolUseContext.abortController.signal,
+        toolUseContext.options.isNonInteractiveSession,
+      )
+    }
+
+    const resultingMessages: MessageUpdateLazy[] = []
+
+    // Defense-in-depth: strip _simulatedSedEdit from model-provided Bash input.
+    // This field is internal-only — it must only be injected by the permission
+    // system (SedEditPermissionRequest) after user approval. If the model supplies
+    // it, the schema's strictObject should already reject it, but we strip here
+    // as a safeguard against future regressions.
+    let processedInput = parsedInput.data
+    if (
+      tool.name === BASH_TOOL_NAME &&
+      processedInput &&
+      typeof processedInput === 'object' &&
+      '_simulatedSedEdit' in processedInput
+    ) {
+      const { _simulatedSedEdit: _, ...rest } =
+        processedInput as typeof processedInput & {
+          _simulatedSedEdit: unknown
+        }
+      processedInput = rest as typeof processedInput
+    }
+
+    // Backfill legacy/derived fields on a shallow clone so hooks/canUseTool see
+    // them without affecting tool.call(). SendMessageTool adds fields; file
+    // tools overwrite file_path with expandPath — that mutation must not reach
+    // call() because tool results embed the input path verbatim (e.g. "File
+    // created successfully at: {path}"), and changing it alters the serialized
+    // transcript and VCR fixture hashes. If a hook/permission later returns a
+    // fresh updatedInput, callInput converges on it below — that replacement
+    // is intentional and should reach call().
+    let callInput = processedInput
+    const backfilledClone =
+      tool.backfillObservableInput &&
+      typeof processedInput === 'object' &&
+      processedInput !== null
+        ? ({ ...processedInput } as typeof processedInput)
+        : null
+    if (backfilledClone) {
+      tool.backfillObservableInput!(backfilledClone as Record<string, unknown>)
+      processedInput = backfilledClone
+    }
+
+    let shouldPreventContinuation = false
+    let stopReason: string | undefined
+    let hookPermissionResult: PermissionResult | undefined
+    const preToolHookInfos: StopHookInfo[] = []
+    const preToolHookStart = Date.now()
+    for await (const result of runPreToolUseHooks(
+      toolUseContext,
+      tool,
+      processedInput,
+      toolUseID,
+      assistantMessage.message.id,
+      requestId,
+      mcpServerType,
+      mcpServerBaseUrl,
+    )) {
+      switch (result.type) {
+        case 'message':
+          if (result.message.message.type === 'progress') {
+            onToolProgress(result.message.message)
+          } else {
+            resultingMessages.push(result.message)
+            const att = result.message.message.attachment
+            if (
+              att &&
+              'command' in att &&
+              att.command !== undefined &&
+              'durationMs' in att &&
+              att.durationMs !== undefined
+            ) {
+              preToolHookInfos.push({
+                command: att.command,
+                durationMs: att.durationMs,
+              })
+            }
+          }
+          break
+        case 'hookPermissionResult':
+          hookPermissionResult = result.hookPermissionResult
+          break
+        case 'hookUpdatedInput':
+          // Hook provided updatedInput without making a permission decision (passthrough)
+          // Update processedInput so it's used in the normal permission flow
+          processedInput = result.updatedInput
+          trackLifecycleToolUse(processedInput)
+          break
+        case 'preventContinuation':
+          shouldPreventContinuation = result.shouldPreventContinuation
+          break
+        case 'stopReason':
+          stopReason = result.stopReason
+          break
+        case 'additionalContext':
+          resultingMessages.push(result.message)
+          break
+        case 'stop':
+          getStatsStore()?.observe(
+            'pre_tool_hook_duration_ms',
+            Date.now() - preToolHookStart,
+          )
+          resultingMessages.push({
+            message: createUserMessage({
+              content: [createToolResultStopMessage(toolUseID)],
+              toolUseResult: `Error: ${stopReason}`,
+              sourceToolAssistantUUID: assistantMessage.uuid,
+            }),
+          })
+          return resultingMessages
+      }
+    }
+    const preToolHookDurationMs = Date.now() - preToolHookStart
+    getStatsStore()?.observe('pre_tool_hook_duration_ms', preToolHookDurationMs)
+    if (preToolHookDurationMs >= SLOW_PHASE_LOG_THRESHOLD_MS) {
+      logForDebugging(
+        `Slow PreToolUse hooks: ${preToolHookDurationMs}ms for ${tool.name} (${preToolHookInfos.length} hooks)`,
+        { level: 'info' },
+      )
+    }
+
+    // Emit PreToolUse summary immediately so it's visible while the tool executes.
+    // Use wall-clock time (not sum of individual durations) since hooks run in parallel.
+    if (process.env.USER_TYPE === 'ant' && preToolHookInfos.length > 0) {
+      if (preToolHookDurationMs > HOOK_TIMING_DISPLAY_THRESHOLD_MS) {
+        resultingMessages.push({
+          message: createStopHookSummaryMessage(
+            preToolHookInfos.length,
+            preToolHookInfos,
+            [],
+            false,
+            undefined,
+            false,
+            'suggestion',
+            undefined,
+            'PreToolUse',
+            preToolHookDurationMs,
+          ),
+        })
+      }
+    }
+
+    const toolAttributes: Record<string, string | number | boolean> = {}
+    if (processedInput && typeof processedInput === 'object') {
+      if (tool.name === FILE_READ_TOOL_NAME && 'file_path' in processedInput) {
+        toolAttributes.file_path = String(processedInput.file_path)
+      } else if (
+        (tool.name === FILE_EDIT_TOOL_NAME ||
+          tool.name === FILE_WRITE_TOOL_NAME) &&
+        'file_path' in processedInput
+      ) {
+        toolAttributes.file_path = String(processedInput.file_path)
+      } else if (tool.name === BASH_TOOL_NAME && 'command' in processedInput) {
+        const bashInput = processedInput as BashToolInput
+        toolAttributes.full_command = bashInput.command
+      }
+    }
+
+    // Check whether we have permission to use the tool,
+    // and ask the user for permission if we don't
+    const permissionMode = toolUseContext.getAppState().toolPermissionContext.mode
+    const permissionStart = Date.now()
+
+    const resolved = await resolveHookPermissionDecision(
+      hookPermissionResult,
+      tool,
+      processedInput,
+      toolUseContext,
+      canUseTool,
+      assistantMessage,
+      toolUseID,
+    )
+    const permissionDecision = resolved.decision
+    processedInput = resolved.input
+    trackLifecycleToolUse(processedInput)
+    const permissionDurationMs = Date.now() - permissionStart
+    // In auto mode, canUseTool awaits the classifier (side_query) — if that's
+    // slow the collapsed view shows "Running…" with no (Ns) tick since
+    // bash_progress hasn't started yet. Auto-only: in default mode this timer
+    // includes interactive-dialog wait (user think time), which is just noise.
+    if (
+      permissionDurationMs >= SLOW_PHASE_LOG_THRESHOLD_MS &&
+      permissionMode === 'auto'
+    ) {
+      logForDebugging(
+        `Slow permission decision: ${permissionDurationMs}ms for ${tool.name} ` +
+          `(mode=${permissionMode}, behavior=${permissionDecision.behavior})`,
+        { level: 'info' },
+      )
+    }
+
+    // Emit tool_decision OTel event and code-edit counter if the interactive
+    // permission path didn't already log it (headless mode bypasses permission
+    // logging, so we need to emit both the generic event and the code-edit
+    // counter here)
+    if (
+      permissionDecision.behavior !== 'ask' &&
+      !toolUseContext.toolDecisions?.has(toolUseID)
+    ) {
+      const decision =
+        permissionDecision.behavior === 'allow' ? 'accept' : 'reject'
+      const source = decisionReasonToOTelSource(
+        permissionDecision.decisionReason,
+        permissionDecision.behavior,
+      )
+    }
+
+    // Add message if permission was granted/denied by PermissionRequest hook
+    if (
+      permissionDecision.decisionReason?.type === 'hook' &&
+      permissionDecision.decisionReason.hookName === 'PermissionRequest' &&
+      permissionDecision.behavior !== 'ask'
+    ) {
+      resultingMessages.push({
+        message: createAttachmentMessage({
+          type: 'hook_permission_decision',
+          decision: permissionDecision.behavior,
+          toolUseID,
+          hookEvent: 'PermissionRequest',
+        }),
+      })
+    }
+
+    if (permissionDecision.behavior !== 'allow') {
+      logForDebugging(`${tool.name} tool permission denied`)
+      const decisionInfo = toolUseContext.toolDecisions?.get(toolUseID)
+
+      logEvent('tengu_tool_use_can_use_tool_rejected', {
+        messageID:
+          messageId as AnalyticsMetadata_I_VERIFIED_THIS_IS_NOT_CODE_OR_FILEPATHS,
+        toolName: sanitizeToolNameForAnalytics(tool.name),
+
+        queryChainId: toolUseContext.queryTracking
+          ?.chainId as AnalyticsMetadata_I_VERIFIED_THIS_IS_NOT_CODE_OR_FILEPATHS,
+        queryDepth: toolUseContext.queryTracking?.depth,
+        ...(mcpServerType && {
+          mcpServerType:
+            mcpServerType as AnalyticsMetadata_I_VERIFIED_THIS_IS_NOT_CODE_OR_FILEPATHS,
+        }),
+        ...(mcpServerBaseUrl && {
+          mcpServerBaseUrl:
+            mcpServerBaseUrl as AnalyticsMetadata_I_VERIFIED_THIS_IS_NOT_CODE_OR_FILEPATHS,
+        }),
+        ...(requestId && {
+          requestId:
+            requestId as AnalyticsMetadata_I_VERIFIED_THIS_IS_NOT_CODE_OR_FILEPATHS,
+        }),
+        ...mcpToolDetailsForAnalytics(tool.name, mcpServerType, mcpServerBaseUrl),
+      })
+      let errorMessage = permissionDecision.message
+      // Only use generic "Execution stopped" message if we don't have a detailed hook message
+      if (shouldPreventContinuation && !errorMessage) {
+        errorMessage = `Execution stopped by PreToolUse hook${stopReason ? `: ${stopReason}` : ''}`
+      }
+
+      // Build top-level content: tool_result (text-only for is_error compatibility) + images alongside
+      const messageContent: ContentBlockParam[] = [
+        {
+          type: 'tool_result',
+          content: errorMessage,
+          is_error: true,
+          tool_use_id: toolUseID,
+        },
+      ]
+
+      // Add image blocks at top level (not inside tool_result, which rejects non-text with is_error)
+      const rejectContentBlocks =
+        permissionDecision.behavior === 'ask'
+          ? permissionDecision.contentBlocks
+          : undefined
+      if (rejectContentBlocks?.length) {
+        messageContent.push(...rejectContentBlocks)
+      }
+
+      // Generate sequential imagePasteIds so each image renders with a distinct label
+      let rejectImageIds: number[] | undefined
+      if (rejectContentBlocks?.length) {
+        const imageCount = count(
+          rejectContentBlocks,
+          (b: ContentBlockParam) => b.type === 'image',
+        )
+        if (imageCount > 0) {
+          const startId = getNextImagePasteId(toolUseContext.messages)
+          rejectImageIds = Array.from(
+            { length: imageCount },
+            (_, i) => startId + i,
+          )
+        }
+      }
+
+      resultingMessages.push({
+        message: createUserMessage({
+          content: messageContent,
+          imagePasteIds: rejectImageIds,
+          toolUseResult: `Error: ${errorMessage}`,
+          sourceToolAssistantUUID: assistantMessage.uuid,
+        }),
+      })
+
+      // Run PermissionDenied hooks for auto mode classifier denials.
+      // If a hook returns {retry: true}, tell the model it may retry.
+      if (
+        feature('TRANSCRIPT_CLASSIFIER') &&
+        permissionDecision.decisionReason?.type === 'classifier' &&
+        permissionDecision.decisionReason.classifier === 'auto-mode'
+      ) {
+        let hookSaysRetry = false
+        for await (const result of executePermissionDeniedHooks(
+          tool.name,
+          toolUseID,
+          processedInput,
+          permissionDecision.decisionReason.reason ?? 'Permission denied',
+          toolUseContext,
+          permissionMode,
+          toolUseContext.abortController.signal,
+        )) {
+          if (result.retry) hookSaysRetry = true
+        }
+        if (hookSaysRetry) {
+          resultingMessages.push({
+            message: createUserMessage({
+              content:
+                'The PermissionDenied hook indicated this command is now approved. You may retry it if you would like.',
+              isMeta: true,
+            }),
+          })
+        }
+      }
+
+      return resultingMessages
+    }
+    logEvent('tengu_tool_use_can_use_tool_allowed', {
+      messageID:
+        messageId as AnalyticsMetadata_I_VERIFIED_THIS_IS_NOT_CODE_OR_FILEPATHS,
+      toolName: sanitizeToolNameForAnalytics(tool.name),
+
+      queryChainId: toolUseContext.queryTracking
+        ?.chainId as AnalyticsMetadata_I_VERIFIED_THIS_IS_NOT_CODE_OR_FILEPATHS,
+      queryDepth: toolUseContext.queryTracking?.depth,
+      ...(mcpServerType && {
+        mcpServerType:
+          mcpServerType as AnalyticsMetadata_I_VERIFIED_THIS_IS_NOT_CODE_OR_FILEPATHS,
+      }),
+      ...(mcpServerBaseUrl && {
+        mcpServerBaseUrl:
+          mcpServerBaseUrl as AnalyticsMetadata_I_VERIFIED_THIS_IS_NOT_CODE_OR_FILEPATHS,
+      }),
+      ...(requestId && {
+        requestId:
+          requestId as AnalyticsMetadata_I_VERIFIED_THIS_IS_NOT_CODE_OR_FILEPATHS,
+      }),
+      ...mcpToolDetailsForAnalytics(tool.name, mcpServerType, mcpServerBaseUrl),
+    })
+
+    // Use the updated input from permissions if provided
+    // (Don't overwrite if undefined - processedInput may have been modified by passthrough hooks)
+    if (permissionDecision.updatedInput !== undefined) {
+      processedInput = permissionDecision.updatedInput
+      trackLifecycleToolUse(processedInput)
+    }
+
+    // Prepare tool parameters for logging in tool_result event.
+    // Gated by OTEL_LOG_TOOL_DETAILS — tool parameters can contain sensitive
+    // content (bash commands, MCP server names, etc.) so they're opt-in only.
+    const telemetryToolInput = extractToolInputForTelemetry(processedInput)
+    let toolParameters: Record<string, unknown> = {}
+    if (isToolDetailsLoggingEnabled()) {
+      if (tool.name === BASH_TOOL_NAME && 'command' in processedInput) {
+        const bashInput = processedInput as BashToolInput
+        const commandParts = bashInput.command.trim().split(/\s+/)
+        const bashCommand = commandParts[0] || ''
+
+        toolParameters = {
+          bash_command: bashCommand,
+          full_command: bashInput.command,
+          ...(bashInput.timeout !== undefined && {
+            timeout: bashInput.timeout,
+          }),
+          ...(bashInput.description !== undefined && {
+            description: bashInput.description,
+          }),
+          ...('dangerouslyDisableSandbox' in bashInput && {
+            dangerouslyDisableSandbox: bashInput.dangerouslyDisableSandbox,
+          }),
+        }
+      }
+
+      const mcpDetails = extractMcpToolDetails(tool.name)
+      if (mcpDetails) {
+        toolParameters.mcp_server_name = mcpDetails.serverName
+        toolParameters.mcp_tool_name = mcpDetails.mcpToolName
+      }
+      const skillName = extractSkillName(tool.name, processedInput)
+      if (skillName) {
+        toolParameters.skill_name = skillName
+      }
+    }
+
+    const decisionInfo = toolUseContext.toolDecisions?.get(toolUseID)
+
+    const startTime = Date.now()
+
+    startSessionActivity('tool_exec')
+    // If processedInput still points at the backfill clone, no hook/permission
+    // replaced it — pass the pre-backfill callInput so call() sees the model's
+    // original field values. Otherwise converge on the hook-supplied input.
+    // Permission/hook flows may return a fresh object derived from the
+    // backfilled clone (e.g. via inputSchema.parse). If its file_path matches
+    // the backfill-expanded value, restore the model's original so the tool
+    // result string embeds the path the model emitted — keeps transcript/VCR
+    // hashes stable. Other hook modifications flow through unchanged.
+    if (
+      backfilledClone &&
+      processedInput !== callInput &&
+      typeof processedInput === 'object' &&
+      processedInput !== null &&
+      'file_path' in processedInput &&
+      'file_path' in (callInput as Record<string, unknown>) &&
+      (processedInput as Record<string, unknown>).file_path ===
+        (backfilledClone as Record<string, unknown>).file_path
+    ) {
+      callInput = {
+        ...processedInput,
+        file_path: (callInput as Record<string, unknown>).file_path,
+      } as typeof processedInput
+    } else if (processedInput !== backfilledClone) {
+      callInput = processedInput
+    }
+    let queryActivityLease: { release(): void } | undefined
+    try {
+      const queryActivityLeaseInput = createToolQueryLeaseInput(
+        tool.name,
+        toolUseID,
+        callInput,
+      )
+      queryActivityLease = queryActivityLeaseInput
+        ? toolUseContext.queryActivity?.acquireLease(queryActivityLeaseInput)
+        : undefined
+      toolUseContext.queryActivity?.registerActivity(`tool:${tool.name}:start`)
+
+      const result = await tool.call(
+        callInput,
+        {
+          ...toolUseContext,
+          toolUseId: toolUseID,
+          hookChainsCanUseTool: canUseTool,
+          userModified: permissionDecision.userModified ?? false,
+        },
+        canUseTool,
+        assistantMessage,
+        progress => {
+          toolUseContext.queryActivity?.registerActivity(
+            `tool:${tool.name}:progress`,
+          )
+          onToolProgress({
+            toolUseID: progress.toolUseID,
+            data: progress.data,
+          })
+        },
+      )
+      const durationMs = Date.now() - startTime
+      addToToolDuration(durationMs)
+
+      // Capture structured output from tool result if present
+      if (typeof result === 'object' && 'structured_output' in result) {
+        // Store the structured output in an attachment message
+        resultingMessages.push({
+          message: createAttachmentMessage({
+            type: 'structured_output',
+            data: result.structured_output,
+          }),
+        })
+      }
+
+      // Map the tool result to API format once and cache it. This block is reused
+      // by addToolResult (skipping the remap) and measured here for analytics.
+      const mappedToolResultBlock = tool.mapToolResultToToolResultBlockParam(
+        result.data,
+        toolUseID,
+      )
+      const mappedContent = mappedToolResultBlock.content
+      const toolResultSizeBytes = !mappedContent
+        ? 0
+        : typeof mappedContent === 'string'
+          ? mappedContent.length
+          : jsonStringify(mappedContent).length
+
+      // Extract file extension for file-related tools
+      let fileExtension: ReturnType<typeof getFileExtensionForAnalytics>
+      if (processedInput && typeof processedInput === 'object') {
+        if (
+          (tool.name === FILE_READ_TOOL_NAME ||
+            tool.name === FILE_EDIT_TOOL_NAME ||
+            tool.name === FILE_WRITE_TOOL_NAME) &&
+          'file_path' in processedInput
+        ) {
+          fileExtension = getFileExtensionForAnalytics(
+            String(processedInput.file_path),
+          )
+        } else if (
+          tool.name === NOTEBOOK_EDIT_TOOL_NAME &&
+          'notebook_path' in processedInput
+        ) {
+          fileExtension = getFileExtensionForAnalytics(
+            String(processedInput.notebook_path),
+          )
+        } else if (tool.name === BASH_TOOL_NAME && 'command' in processedInput) {
+          const bashInput = processedInput as BashToolInput
+          fileExtension = getFileExtensionsFromBashCommand(
+            bashInput.command,
+            bashInput._simulatedSedEdit?.filePath,
+          )
+        }
+      }
+
+      logEvent('tengu_tool_use_success', {
+        messageID:
+          messageId as AnalyticsMetadata_I_VERIFIED_THIS_IS_NOT_CODE_OR_FILEPATHS,
+        toolName: sanitizeToolNameForAnalytics(tool.name),
+        isMcp: tool.isMcp ?? false,
+        durationMs,
+        preToolHookDurationMs,
+        toolResultSizeBytes,
+        ...(fileExtension !== undefined && { fileExtension }),
+
+        queryChainId: toolUseContext.queryTracking
+          ?.chainId as AnalyticsMetadata_I_VERIFIED_THIS_IS_NOT_CODE_OR_FILEPATHS,
+        queryDepth: toolUseContext.queryTracking?.depth,
+        ...(mcpServerType && {
+          mcpServerType:
+            mcpServerType as AnalyticsMetadata_I_VERIFIED_THIS_IS_NOT_CODE_OR_FILEPATHS,
+        }),
+        ...(mcpServerBaseUrl && {
+          mcpServerBaseUrl:
+            mcpServerBaseUrl as AnalyticsMetadata_I_VERIFIED_THIS_IS_NOT_CODE_OR_FILEPATHS,
+        }),
+        ...(requestId && {
+          requestId:
+            requestId as AnalyticsMetadata_I_VERIFIED_THIS_IS_NOT_CODE_OR_FILEPATHS,
+        }),
+        ...mcpToolDetailsForAnalytics(tool.name, mcpServerType, mcpServerBaseUrl),
+      })
+
+      // Enrich tool parameters with git commit ID from successful git commit output
+      if (
+        isToolDetailsLoggingEnabled() &&
+        (tool.name === BASH_TOOL_NAME || tool.name === POWERSHELL_TOOL_NAME) &&
+        'command' in processedInput &&
+        typeof processedInput.command === 'string' &&
+        processedInput.command.match(/\bgit\s+commit\b/) &&
+        result.data &&
+        typeof result.data === 'object' &&
+        'stdout' in result.data
+      ) {
+        const gitCommitId = parseGitCommitId(String(result.data.stdout))
+        if (gitCommitId) {
+          toolParameters.git_commit_id = gitCommitId
+        }
+      }
+
+      // Log tool result event for OTLP with tool parameters and decision context
       const mcpServerScope = isMcpTool(tool)
         ? getMcpServerScopeFromToolName(tool.name)
         : null
 
+
+      // Run PostToolUse hooks
+      let toolOutput = result.data
+      const hookResults: MessageUpdateLazy<HookResultMessage>[] = []
+      const toolContextModifier = result.contextModifier
+      const mcpMeta = result.mcpMeta
+
+      async function addToolResult(
+        toolUseResult: unknown,
+        preMappedBlock?: ToolResultBlockParam,
+      ) {
+        // Use the pre-mapped block when available (non-MCP tools where hooks
+        // don't modify the output), otherwise map from scratch.
+        const toolResultBlock = preMappedBlock
+          ? await processPreMappedToolResultBlock(
+              preMappedBlock,
+              tool.name,
+              tool.maxResultSizeChars,
+            )
+          : await processToolResultBlock(tool, toolUseResult, toolUseID)
+
+        // Build content blocks - tool result first, then optional feedback
+        const contentBlocks: ContentBlockParam[] = [toolResultBlock]
+        // Add accept feedback if user provided feedback when approving
+        // (acceptFeedback only exists on PermissionAllowDecision, which is guaranteed here)
+        if (
+          'acceptFeedback' in permissionDecision &&
+          permissionDecision.acceptFeedback
+        ) {
+          contentBlocks.push({
+            type: 'text',
+            text: permissionDecision.acceptFeedback,
+          })
+        }
+
+        // Add content blocks (e.g., pasted images) from the permission decision
+        const allowContentBlocks =
+          'contentBlocks' in permissionDecision
+            ? permissionDecision.contentBlocks
+            : undefined
+        if (allowContentBlocks?.length) {
+          contentBlocks.push(...allowContentBlocks)
+        }
+
+        // Generate sequential imagePasteIds so each image renders with a distinct label
+        let allowImageIds: number[] | undefined
+        if (allowContentBlocks?.length) {
+          const imageCount = count(
+            allowContentBlocks,
+            (b: ContentBlockParam) => b.type === 'image',
+          )
+          if (imageCount > 0) {
+            const startId = getNextImagePasteId(toolUseContext.messages)
+            allowImageIds = Array.from(
+              { length: imageCount },
+              (_, i) => startId + i,
+            )
           }
-    const content = formatError(error)
+        }
 
-    // Determine if this was a user interrupt
-    const isInterrupt = error instanceof AbortError
+        resultingMessages.push({
+          message: createUserMessage({
+            content: contentBlocks,
+            imagePasteIds: allowImageIds,
+            toolUseResult:
+              toolUseContext.agentId && !toolUseContext.preserveToolUseResults
+                ? undefined
+                : toolUseResult,
+            mcpMeta: toolUseContext.agentId ? undefined : mcpMeta,
+            sourceToolAssistantUUID: assistantMessage.uuid,
+          }),
+          contextModifier: toolContextModifier
+            ? {
+                toolUseID: toolUseID,
+                modifyContext: toolContextModifier,
+              }
+            : undefined,
+        })
+      }
 
-    // Run PostToolUseFailure hooks
-    const hookMessages: MessageUpdateLazy<
-      AttachmentMessage | ProgressMessage<HookProgress>
-    >[] = []
-    const hookChainsContext = toolUseContext as ToolUseContext & {
-      hookChainsCanUseTool?: CanUseToolFn
-    }
-    hookChainsContext.hookChainsCanUseTool = canUseTool
-    try {
-      for await (const hookResult of runPostToolUseFailureHooks(
+      // TOOD(hackyon): refactor so we don't have different experiences for MCP tools
+      if (!isMcpTool(tool)) {
+        await addToolResult(toolOutput, mappedToolResultBlock)
+      }
+
+      const postToolHookInfos: StopHookInfo[] = []
+      const postToolHookStart = Date.now()
+      for await (const hookResult of runPostToolUseHooks(
         toolUseContext,
         tool,
         toolUseID,
-        messageId,
+        assistantMessage.message.id,
         processedInput,
-        content,
-        isInterrupt,
+        toolOutput,
         requestId,
         mcpServerType,
         mcpServerBaseUrl,
       )) {
-        hookMessages.push(hookResult)
+        if ('updatedMCPToolOutput' in hookResult) {
+          if (isMcpTool(tool)) {
+            toolOutput = hookResult.updatedMCPToolOutput
+          }
+        } else if (isMcpTool(tool)) {
+          hookResults.push(hookResult)
+          if (hookResult.message.type === 'attachment') {
+            const att = hookResult.message.attachment
+            if (
+              'command' in att &&
+              att.command !== undefined &&
+              'durationMs' in att &&
+              att.durationMs !== undefined
+            ) {
+              postToolHookInfos.push({
+                command: att.command,
+                durationMs: att.durationMs,
+              })
+            }
+          }
+        } else {
+          resultingMessages.push(hookResult)
+          if (hookResult.message.type === 'attachment') {
+            const att = hookResult.message.attachment
+            if (
+              'command' in att &&
+              att.command !== undefined &&
+              'durationMs' in att &&
+              att.durationMs !== undefined
+            ) {
+              postToolHookInfos.push({
+                command: att.command,
+                durationMs: att.durationMs,
+              })
+            }
+          }
+        }
       }
-    } finally {
-      if (hookChainsContext.hookChainsCanUseTool === canUseTool) {
-        delete hookChainsContext.hookChainsCanUseTool
+      const postToolHookDurationMs = Date.now() - postToolHookStart
+      if (postToolHookDurationMs >= SLOW_PHASE_LOG_THRESHOLD_MS) {
+        logForDebugging(
+          `Slow PostToolUse hooks: ${postToolHookDurationMs}ms for ${tool.name} (${postToolHookInfos.length} hooks)`,
+          { level: 'info' },
+        )
       }
-    }
 
-    return [
-      {
-        message: createUserMessage({
-          content: [
-            {
-              type: 'tool_result',
-              content,
-              is_error: true,
-              tool_use_id: toolUseID,
+      if (isMcpTool(tool)) {
+        await addToolResult(toolOutput)
+      }
+
+      // Show PostToolUse hook timing inline below tool result when > 500ms.
+      // Use wall-clock time (not sum of individual durations) since hooks run in parallel.
+      if (process.env.USER_TYPE === 'ant' && postToolHookInfos.length > 0) {
+        if (postToolHookDurationMs > HOOK_TIMING_DISPLAY_THRESHOLD_MS) {
+          resultingMessages.push({
+            message: createStopHookSummaryMessage(
+              postToolHookInfos.length,
+              postToolHookInfos,
+              [],
+              false,
+              undefined,
+              false,
+              'suggestion',
+              undefined,
+              'PostToolUse',
+              postToolHookDurationMs,
+            ),
+          })
+        }
+      }
+
+      // If the tool provided new messages, add them to the list to return.
+      if (result.newMessages && result.newMessages.length > 0) {
+        for (const message of result.newMessages) {
+          resultingMessages.push({ message })
+        }
+      }
+      // If hook indicated to prevent continuation after successful execution, yield a stop reason message
+      if (shouldPreventContinuation) {
+        resultingMessages.push({
+          message: createAttachmentMessage({
+            type: 'hook_stopped_continuation',
+            message: stopReason || 'Execution stopped by hook',
+            hookName: `PreToolUse:${tool.name}`,
+            toolUseID: toolUseID,
+            hookEvent: 'PreToolUse',
+          }),
+        })
+      }
+
+      // Yield the remaining hook results after the other messages are sent
+      for (const hookResult of hookResults) {
+        resultingMessages.push(hookResult)
+      }
+      return resultingMessages
+    } catch (error) {
+      const durationMs = Date.now() - startTime
+      addToToolDuration(durationMs)
+
+      // Handle MCP auth errors by updating the client status to 'needs-auth'
+      // This updates the /mcp display to show the server needs re-authorization
+      if (error instanceof McpAuthError) {
+        toolUseContext.setAppState(prevState => {
+          const serverName = error.serverName
+          const existingClientIndex = prevState.mcp.clients.findIndex(
+            c => c.name === serverName,
+          )
+          if (existingClientIndex === -1) {
+            return prevState
+          }
+          const existingClient = prevState.mcp.clients[existingClientIndex]
+          // Only update if client was connected (don't overwrite other states)
+          if (!existingClient || existingClient.type !== 'connected') {
+            return prevState
+          }
+          const updatedClients = [...prevState.mcp.clients]
+          updatedClients[existingClientIndex] = {
+            name: serverName,
+            type: 'needs-auth' as const,
+            config: existingClient.config,
+          }
+          return {
+            ...prevState,
+            mcp: {
+              ...prevState.mcp,
+              clients: updatedClients,
             },
-          ],
-          toolUseResult: `Error: ${content}`,
-          mcpMeta: toolUseContext.agentId
-            ? undefined
-            : error instanceof
-                McpToolCallError_I_VERIFIED_THIS_IS_NOT_CODE_OR_FILEPATHS
-              ? error.mcpMeta
-              : undefined,
-          sourceToolAssistantUUID: assistantMessage.uuid,
-        }),
-      },
-      ...hookMessages,
-    ]
-  } finally {
-    try {
-      queryActivityLease?.release()
-      toolUseContext.queryActivity?.registerActivity(`tool:${tool.name}:end`)
+          }
+        })
+      }
+
+      if (!(error instanceof AbortError)) {
+        const errorMsg = errorMessage(error)
+        logForDebugging(
+          `${tool.name} tool error (${durationMs}ms): ${errorMsg.slice(0, 200)}`,
+        )
+        if (!(error instanceof ShellError)) {
+          logError(error)
+        }
+        logEvent('tengu_tool_use_error', {
+          messageID:
+            messageId as AnalyticsMetadata_I_VERIFIED_THIS_IS_NOT_CODE_OR_FILEPATHS,
+          toolName: sanitizeToolNameForAnalytics(tool.name),
+          error: classifyToolError(
+            error,
+          ) as AnalyticsMetadata_I_VERIFIED_THIS_IS_NOT_CODE_OR_FILEPATHS,
+          isMcp: tool.isMcp ?? false,
+
+          queryChainId: toolUseContext.queryTracking
+            ?.chainId as AnalyticsMetadata_I_VERIFIED_THIS_IS_NOT_CODE_OR_FILEPATHS,
+          queryDepth: toolUseContext.queryTracking?.depth,
+          ...(mcpServerType && {
+            mcpServerType:
+              mcpServerType as AnalyticsMetadata_I_VERIFIED_THIS_IS_NOT_CODE_OR_FILEPATHS,
+          }),
+          ...(mcpServerBaseUrl && {
+            mcpServerBaseUrl:
+              mcpServerBaseUrl as AnalyticsMetadata_I_VERIFIED_THIS_IS_NOT_CODE_OR_FILEPATHS,
+          }),
+          ...(requestId && {
+            requestId:
+              requestId as AnalyticsMetadata_I_VERIFIED_THIS_IS_NOT_CODE_OR_FILEPATHS,
+          }),
+          ...mcpToolDetailsForAnalytics(
+            tool.name,
+            mcpServerType,
+            mcpServerBaseUrl,
+          ),
+        })
+        // Log tool result error event for OTLP with tool parameters and decision context
+        const mcpServerScope = isMcpTool(tool)
+          ? getMcpServerScopeFromToolName(tool.name)
+          : null
+
+            }
+      const content = formatError(error)
+
+      // Determine if this was a user interrupt
+      const isInterrupt = error instanceof AbortError
+
+      // Run PostToolUseFailure hooks
+      const hookMessages: MessageUpdateLazy<
+        AttachmentMessage | ProgressMessage<HookProgress>
+      >[] = []
+      const hookChainsContext = toolUseContext as ToolUseContext & {
+        hookChainsCanUseTool?: CanUseToolFn
+      }
+      hookChainsContext.hookChainsCanUseTool = canUseTool
+      try {
+        for await (const hookResult of runPostToolUseFailureHooks(
+          toolUseContext,
+          tool,
+          toolUseID,
+          messageId,
+          processedInput,
+          content,
+          isInterrupt,
+          requestId,
+          mcpServerType,
+          mcpServerBaseUrl,
+        )) {
+          hookMessages.push(hookResult)
+        }
+      } finally {
+        if (hookChainsContext.hookChainsCanUseTool === canUseTool) {
+          delete hookChainsContext.hookChainsCanUseTool
+        }
+      }
+
+      return [
+        {
+          message: createUserMessage({
+            content: [
+              {
+                type: 'tool_result',
+                content,
+                is_error: true,
+                tool_use_id: toolUseID,
+              },
+            ],
+            toolUseResult: `Error: ${content}`,
+            mcpMeta: toolUseContext.agentId
+              ? undefined
+              : error instanceof
+                  McpToolCallError_I_VERIFIED_THIS_IS_NOT_CODE_OR_FILEPATHS
+                ? error.mcpMeta
+                : undefined,
+            sourceToolAssistantUUID: assistantMessage.uuid,
+          }),
+        },
+        ...hookMessages,
+      ]
     } finally {
-      toolUseContext.queryLifecycle?.endToolUse(toolUseID)
-      stopSessionActivity('tool_exec')
-      // Clean up decision info after logging
-      if (decisionInfo) {
-        toolUseContext.toolDecisions?.delete(toolUseID)
+      try {
+        queryActivityLease?.release()
+        toolUseContext.queryActivity?.registerActivity(`tool:${tool.name}:end`)
+      } finally {
+        stopSessionActivity('tool_exec')
+        // Clean up decision info after logging
+        if (decisionInfo) {
+          toolUseContext.toolDecisions?.delete(toolUseID)
+        }
       }
     }
+  } finally {
+    toolUseContext.queryLifecycle?.endToolUse(toolUseID)
   }
 }

--- a/src/services/tools/toolExecution.ts
+++ b/src/services/tools/toolExecution.ts
@@ -1224,6 +1224,17 @@ async function checkPermissionsAndCallTool(
   const decisionInfo = toolUseContext.toolDecisions?.get(toolUseID)
 
   const startTime = Date.now()
+  const bashTimeoutMs =
+    tool.name === BASH_TOOL_NAME && 'timeout' in processedInput
+      ? (processedInput as BashToolInput).timeout
+      : undefined
+  toolUseContext.queryLifecycle?.startToolUse({
+    toolUseId: toolUseID,
+    toolName: tool.name,
+    startedAt: startTime,
+    ...(tool.name === BASH_TOOL_NAME && { isBash: true }),
+    ...(bashTimeoutMs !== undefined && { timeoutMs: bashTimeoutMs }),
+  })
 
   startSessionActivity('tool_exec')
   // If processedInput still points at the backfill clone, no hook/permission
@@ -1723,6 +1734,7 @@ async function checkPermissionsAndCallTool(
       queryActivityLease?.release()
       toolUseContext.queryActivity?.registerActivity(`tool:${tool.name}:end`)
     } finally {
+      toolUseContext.queryLifecycle?.endToolUse(toolUseID)
       stopSessionActivity('tool_exec')
       // Clean up decision info after logging
       if (decisionInfo) {

--- a/src/tools/AgentTool/runAgent.routing.test.ts
+++ b/src/tools/AgentTool/runAgent.routing.test.ts
@@ -12,6 +12,7 @@ import { createUserMessage } from '../../utils/messages.js'
 import {
   resetSettingsCache,
 } from '../../utils/settings/settingsCache.js'
+import { QueryLifecycleOperationTracker } from '../../utils/queryLifecycle.js'
 import type { SettingsJson } from '../../utils/settings/types.js'
 import type { AgentDefinition } from './loadAgentsDir.js'
 import type { runAgent as runAgentFn } from './runAgent.js'
@@ -167,6 +168,71 @@ describe('runAgent provider routing', () => {
     await expect(generator.next()).rejects.toBe(stop)
     expect(capturedContext?.options.providerOverride).toBeUndefined()
   })
+
+  test('preserves query lifecycle tracking for synchronous child contexts', async () => {
+    const queryLifecycle = new QueryLifecycleOperationTracker()
+    const parentContext = createToolUseContext('parent-model', queryLifecycle)
+    const stop = new Error('stop after cache-safe params')
+    let capturedContext: ToolUseContext | undefined
+    const runAgent = await importRunAgent()
+
+    const generator = runAgent({
+      agentDefinition: createAgentDefinition(),
+      promptMessages: [createUserMessage({ content: 'inspect this' })],
+      toolUseContext: parentContext,
+      canUseTool: async () => ({ behavior: 'allow' }),
+      isAsync: false,
+      querySource: 'agent:builtin:general-purpose',
+      availableTools: [],
+      onCacheSafeParams: params => {
+        capturedContext = params.toolUseContext
+        throw stop
+      },
+    })
+
+    await expect(generator.next()).rejects.toBe(stop)
+
+    expect(capturedContext?.queryLifecycle).toBe(queryLifecycle)
+    capturedContext?.queryLifecycle?.startToolUse({
+      toolUseId: 'child-tool-use',
+      toolName: 'Read',
+      startedAt: 1,
+    })
+    expect(queryLifecycle.snapshot().toolUses).toEqual([
+      {
+        toolUseId: 'child-tool-use',
+        toolName: 'Read',
+        startedAt: 1,
+      },
+    ])
+  })
+
+  test('keeps query lifecycle tracking out of asynchronous child contexts', async () => {
+    const queryLifecycle = new QueryLifecycleOperationTracker()
+    const parentContext = createToolUseContext('parent-model', queryLifecycle)
+    const stop = new Error('stop after cache-safe params')
+    let capturedContext: ToolUseContext | undefined
+    const runAgent = await importRunAgent()
+
+    const generator = runAgent({
+      agentDefinition: createAgentDefinition(),
+      promptMessages: [createUserMessage({ content: 'inspect this' })],
+      toolUseContext: parentContext,
+      canUseTool: async () => ({ behavior: 'allow' }),
+      isAsync: true,
+      querySource: 'agent:builtin:general-purpose',
+      availableTools: [],
+      onCacheSafeParams: params => {
+        capturedContext = params.toolUseContext
+        throw stop
+      },
+    })
+
+    await expect(generator.next()).rejects.toBe(stop)
+
+    expect(capturedContext?.queryLifecycle).toBeUndefined()
+    expect(queryLifecycle.snapshot()).toEqual({ apiCalls: [], toolUses: [] })
+  })
 })
 
 function createAgentDefinition(): AgentDefinition {
@@ -185,7 +251,10 @@ async function importRunAgent(): Promise<typeof runAgentFn> {
   return module.runAgent
 }
 
-function createToolUseContext(mainLoopModel: string): ToolUseContext {
+function createToolUseContext(
+  mainLoopModel: string,
+  queryLifecycle?: QueryLifecycleOperationTracker,
+): ToolUseContext {
   const appState = {
     mainLoopModel,
     mainLoopModelForSession: mainLoopModel,
@@ -220,6 +289,7 @@ function createToolUseContext(mainLoopModel: string): ToolUseContext {
       },
     },
     abortController: new AbortController(),
+    ...(queryLifecycle ? { queryLifecycle } : {}),
     readFileState: createFileStateCacheWithSizeLimit(
       READ_FILE_STATE_CACHE_SIZE,
     ),

--- a/src/tools/AgentTool/runAgent.ts
+++ b/src/tools/AgentTool/runAgent.ts
@@ -743,6 +743,9 @@ export async function* runAgent({
     readFileState: agentReadFileState,
     abortController: agentAbortController,
     getAppState: agentGetAppState,
+    ...(!isAsync && toolUseContext.queryLifecycle
+      ? { queryLifecycle: toolUseContext.queryLifecycle }
+      : {}),
     // Sync agents share these callbacks with parent
     shareSetAppState: !isAsync,
     shareSetResponseLength: true, // Both sync and async contribute to response metrics

--- a/src/utils/QueryGuard.test.ts
+++ b/src/utils/QueryGuard.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, test, expect, vi } from 'vitest'
 import { QueryGuard } from './QueryGuard.js'
+import { QueryLifecycleOperationTracker } from './queryLifecycle.js'
 
 describe('QueryGuard', () => {
   afterEach(() => {
@@ -51,16 +52,14 @@ describe('QueryGuard', () => {
     guard.tryStart()
     expect(guard.isActive).toBe(true)
 
-    // Just before timeout
     vi.advanceTimersByTime(5 * 60 * 1000 - 1)
     expect(guard.isActive).toBe(true)
 
-    // At timeout
     vi.advanceTimersByTime(1)
     expect(guard.isActive).toBe(false)
   })
 
-  test('timeout notifies owner with the timed-out generation and reason', () => {
+  test('timeout notifies owner with lifecycle context and timeout reason', () => {
     vi.useFakeTimers()
     vi.spyOn(console, 'error').mockImplementation(() => {})
     const guard = new QueryGuard()
@@ -71,8 +70,110 @@ describe('QueryGuard', () => {
     vi.advanceTimersByTime(5 * 60 * 1000)
 
     expect(onTimeout).toHaveBeenCalledTimes(1)
-    expect(onTimeout).toHaveBeenCalledWith(gen, 'idle')
+    expect(onTimeout).toHaveBeenCalledWith(
+      expect.objectContaining({
+        generation: gen,
+        reason: 'idle',
+        timeoutMs: 5 * 60 * 1000,
+        context: expect.objectContaining({
+          queryGeneration: gen,
+          terminalReason: 'query-timeout',
+          abortReason: 'idle',
+        }),
+      }),
+    )
     expect(guard.isActive).toBe(false)
+  })
+
+  test('tryStart accepts explicit query identity and returns lifecycle context', () => {
+    const guard = new QueryGuard()
+    const start = guard.tryStart({
+      queryId: 'query-1',
+      querySource: 'repl_main_thread',
+      parentQueryId: 'parent-query',
+      subagentId: 'agent-1',
+      startedAt: 1234,
+    })
+
+    expect(start).toEqual({
+      generation: 1,
+      context: {
+        queryId: 'query-1',
+        queryGeneration: 1,
+        querySource: 'repl_main_thread',
+        parentQueryId: 'parent-query',
+        subagentId: 'agent-1',
+        startedAt: 1234,
+      },
+    })
+    expect(guard.activeContext).toEqual(start!.context)
+  })
+
+  test('timeout callback receives explicit query identity and active operation snapshot', () => {
+    vi.useFakeTimers()
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+    const tracker = new QueryLifecycleOperationTracker()
+    tracker.startApiCall({
+      clientRequestId: 'client-request-1',
+      requestId: 'server-request-1',
+      model: 'model-name',
+      querySource: 'repl_main_thread',
+      startedAt: 10,
+    })
+    tracker.startToolUse({
+      toolUseId: 'tool-use-1',
+      toolName: 'Bash',
+      startedAt: 20,
+      isBash: true,
+      timeoutMs: 120_000,
+    })
+
+    const guard = new QueryGuard()
+    const onTimeout = vi.fn()
+    guard.setTimeoutHandler(onTimeout)
+    const start = guard.tryStart({
+      queryId: 'query-1',
+      querySource: 'repl_main_thread',
+      startedAt: 1,
+      getActiveOperations: () => tracker.snapshot(),
+    })!
+
+    vi.advanceTimersByTime(5 * 60 * 1000)
+
+    expect(onTimeout).toHaveBeenCalledTimes(1)
+    expect(onTimeout).toHaveBeenCalledWith({
+      generation: start.generation,
+      reason: 'idle',
+      timeoutMs: 5 * 60 * 1000,
+      elapsedMs: expect.any(Number),
+      context: {
+        ...start.context,
+        terminalReason: 'query-timeout',
+        abortReason: 'idle',
+      },
+      activeOperations: {
+        apiCalls: [
+          {
+            clientRequestId: 'client-request-1',
+            requestId: 'server-request-1',
+            model: 'model-name',
+            querySource: 'repl_main_thread',
+            startedAt: 10,
+          },
+        ],
+        toolUses: [
+          {
+            toolUseId: 'tool-use-1',
+            toolName: 'Bash',
+            startedAt: 20,
+            isBash: true,
+            timeoutMs: 120_000,
+          },
+        ],
+      },
+    })
+    expect(guard.lastContext?.terminalReason).toBe('query-timeout')
+    expect(guard.lastContext?.abortReason).toBe('idle')
   })
 
   test('timeout handler cleanup prevents stale notification', () => {
@@ -103,7 +204,10 @@ describe('QueryGuard', () => {
 
     expect(() => vi.advanceTimersByTime(5 * 60 * 1000)).not.toThrow()
     expect(guard.isActive).toBe(false)
-    expect(consoleError).toHaveBeenCalledWith('[QueryGuard] Timeout handler failed', handlerError)
+    expect(consoleError).toHaveBeenCalledWith(
+      '[QueryGuard] Timeout handler failed',
+      handlerError,
+    )
   })
 
   test('API stream activity extends the idle deadline only while progress continues', () => {
@@ -147,11 +251,14 @@ describe('QueryGuard', () => {
       toolLeaseGraceMs: 10,
     })
     const gen = guard.tryStart()!
-    const lease = guard.acquireLease({
-      owner: 'bash',
-      id: 'toolu_1',
-      timeoutMs: 500,
-    }, gen)
+    const lease = guard.acquireLease(
+      {
+        owner: 'bash',
+        id: 'toolu_1',
+        timeoutMs: 500,
+      },
+      gen,
+    )
 
     vi.advanceTimersByTime(500)
 
@@ -171,18 +278,31 @@ describe('QueryGuard', () => {
     const onTimeout = vi.fn()
     guard.setTimeoutHandler(onTimeout)
     const gen = guard.tryStart()!
-    guard.acquireLease({
-      owner: 'bash',
-      id: 'toolu_1',
-      timeoutMs: 500,
-    }, gen)
+    guard.acquireLease(
+      {
+        owner: 'bash',
+        id: 'toolu_1',
+        timeoutMs: 500,
+      },
+      gen,
+    )
 
     vi.advanceTimersByTime(509)
     expect(guard.isActive).toBe(true)
     vi.advanceTimersByTime(1)
 
     expect(guard.isActive).toBe(false)
-    expect(onTimeout).toHaveBeenCalledWith(gen, 'lease_expired')
+    expect(onTimeout).toHaveBeenCalledWith(
+      expect.objectContaining({
+        generation: gen,
+        reason: 'lease_expired',
+        timeoutMs: 510,
+        context: expect.objectContaining({
+          terminalReason: 'query-timeout',
+          abortReason: 'lease_expired',
+        }),
+      }),
+    )
   })
 
   test('hard maximum aborts even with active leases and activity', () => {
@@ -196,11 +316,14 @@ describe('QueryGuard', () => {
     const onTimeout = vi.fn()
     guard.setTimeoutHandler(onTimeout)
     const gen = guard.tryStart()!
-    guard.acquireLease({
-      owner: 'bash',
-      id: 'toolu_1',
-      timeoutMs: 5_000,
-    }, gen)
+    guard.acquireLease(
+      {
+        owner: 'bash',
+        id: 'toolu_1',
+        timeoutMs: 5_000,
+      },
+      gen,
+    )
 
     for (let elapsed = 0; elapsed < 900; elapsed += 90) {
       vi.advanceTimersByTime(90)
@@ -211,7 +334,17 @@ describe('QueryGuard', () => {
     vi.advanceTimersByTime(100)
 
     expect(guard.isActive).toBe(false)
-    expect(onTimeout).toHaveBeenCalledWith(gen, 'hard_max')
+    expect(onTimeout).toHaveBeenCalledWith(
+      expect.objectContaining({
+        generation: gen,
+        reason: 'hard_max',
+        timeoutMs: 1_000,
+        context: expect.objectContaining({
+          terminalReason: 'hard-max-query-timeout',
+          abortReason: 'hard_max',
+        }),
+      }),
+    )
   })
 
   test('lease hard cap is relative to acquisition and capped by query remaining budget', () => {
@@ -227,19 +360,28 @@ describe('QueryGuard', () => {
     const gen = guard.tryStart()!
 
     vi.advanceTimersByTime(400)
-    guard.acquireLease({
-      owner: 'tool',
-      id: 'toolu_late',
-      timeoutMs: 500,
-      hardCapMs: 300,
-    }, gen)
+    guard.acquireLease(
+      {
+        owner: 'tool',
+        id: 'toolu_late',
+        timeoutMs: 500,
+        hardCapMs: 300,
+      },
+      gen,
+    )
 
     vi.advanceTimersByTime(299)
     expect(guard.isActive).toBe(true)
     vi.advanceTimersByTime(1)
 
     expect(guard.isActive).toBe(false)
-    expect(onTimeout).toHaveBeenCalledWith(gen, 'lease_expired')
+    expect(onTimeout).toHaveBeenCalledWith(
+      expect.objectContaining({
+        generation: gen,
+        reason: 'lease_expired',
+        timeoutMs: 300,
+      }),
+    )
   })
 
   test('stale generations cannot extend or release a newer query', () => {
@@ -254,19 +396,25 @@ describe('QueryGuard', () => {
     guard.setTimeoutHandler(onTimeout)
 
     const gen1 = guard.tryStart()!
-    const staleLease = guard.acquireLease({
-      owner: 'bash',
-      id: 'toolu_stale',
-      timeoutMs: 500,
-    }, gen1)
+    const staleLease = guard.acquireLease(
+      {
+        owner: 'bash',
+        id: 'toolu_stale',
+        timeoutMs: 500,
+      },
+      gen1,
+    )
     guard.forceEnd()
 
     const gen2 = guard.tryStart()!
-    const liveLease = guard.acquireLease({
-      owner: 'bash',
-      id: 'toolu_live',
-      timeoutMs: 500,
-    }, gen2)
+    const liveLease = guard.acquireLease(
+      {
+        owner: 'bash',
+        id: 'toolu_live',
+        timeoutMs: 500,
+      },
+      gen2,
+    )
 
     staleLease.release()
     vi.advanceTimersByTime(100)
@@ -276,7 +424,46 @@ describe('QueryGuard', () => {
     guard.registerActivity('stale_api_stream', gen1)
     vi.advanceTimersByTime(100)
     expect(guard.isActive).toBe(false)
-    expect(onTimeout).toHaveBeenCalledWith(gen2, 'idle')
+    expect(onTimeout).toHaveBeenCalledWith(
+      expect.objectContaining({
+        generation: gen2,
+        reason: 'idle',
+      }),
+    )
+  })
+
+  test('end stamps terminal reason on the completed lifecycle context', () => {
+    const guard = new QueryGuard()
+    const start = guard.tryStart({
+      queryId: 'query-1',
+      querySource: 'repl_main_thread',
+    })!
+
+    expect(guard.end(start.generation, 'user-abort')).toBe(true)
+    expect(guard.lastContext).toEqual({
+      ...start.context,
+      terminalReason: 'user-abort',
+    })
+  })
+
+  test('query metadata from one start does not leak into the next start', () => {
+    const guard = new QueryGuard()
+    const child = guard.tryStart({
+      queryId: 'child-query',
+      querySource: 'agent:general-purpose',
+      parentQueryId: 'parent-query',
+      subagentId: 'agent-1',
+    })!
+    expect(guard.end(child.generation, 'ok')).toBe(true)
+
+    const parent = guard.tryStart({
+      queryId: 'parent-query',
+      querySource: 'repl_main_thread',
+    })!
+
+    expect(parent.context.parentQueryId).toBeUndefined()
+    expect(parent.context.subagentId).toBeUndefined()
+    expect(parent.context.queryId).toBe('parent-query')
   })
 
   test('timeout is cleared when end() is called normally', () => {
@@ -285,15 +472,113 @@ describe('QueryGuard', () => {
     const gen = guard.tryStart()!
     guard.end(gen)
 
-    // Advance past timeout — should not affect anything
     vi.advanceTimersByTime(10 * 60 * 1000)
     expect(guard.isActive).toBe(false)
 
-    // Should be able to start a new query
     const gen2 = guard.tryStart()
     expect(gen2).not.toBeNull()
     expect(guard.isActive).toBe(true)
 
     guard.forceEnd()
+  })
+})
+
+describe('QueryLifecycleOperationTracker', () => {
+  test('tracks and cleans up active API and tool operations', () => {
+    const tracker = new QueryLifecycleOperationTracker()
+    const apiKey = tracker.startApiCall({
+      clientRequestId: 'client-request-1',
+      model: 'model-name',
+      querySource: 'repl_main_thread',
+      startedAt: 100,
+    })
+    tracker.updateApiCall(apiKey, { requestId: 'server-request-1' })
+    tracker.startToolUse({
+      toolUseId: 'tool-use-1',
+      toolName: 'Bash',
+      startedAt: 200,
+      isBash: true,
+      timeoutMs: 300_000,
+    })
+
+    expect(tracker.snapshot()).toEqual({
+      apiCalls: [
+        {
+          clientRequestId: 'client-request-1',
+          requestId: 'server-request-1',
+          model: 'model-name',
+          querySource: 'repl_main_thread',
+          startedAt: 100,
+        },
+      ],
+      toolUses: [
+        {
+          toolUseId: 'tool-use-1',
+          toolName: 'Bash',
+          startedAt: 200,
+          isBash: true,
+          timeoutMs: 300_000,
+        },
+      ],
+    })
+
+    tracker.endApiCall(apiKey)
+    tracker.endToolUse('tool-use-1')
+
+    expect(tracker.snapshot()).toEqual({ apiCalls: [], toolUses: [] })
+  })
+
+  test('snapshots contain only safe operation metadata', () => {
+    const tracker = new QueryLifecycleOperationTracker()
+    const apiKey = tracker.startApiCall({
+      clientRequestId: 'client-request-1',
+      model: 'model-name',
+      querySource: 'repl_main_thread',
+      startedAt: 1,
+      prompt: 'tool output',
+      apiKey: 'ANTHROPIC_API_KEY=secret',
+    } as Parameters<QueryLifecycleOperationTracker['startApiCall']>[0])
+    tracker.updateApiCall(apiKey, {
+      requestId: 'server-request-1',
+      cwd: '/home/user/project',
+    } as Partial<Parameters<QueryLifecycleOperationTracker['startApiCall']>[0]>)
+    tracker.updateApiCall(apiKey, {
+      requestId: undefined,
+      model: undefined,
+      querySource: undefined,
+      startedAt: undefined,
+      cwd: '/home/user/project',
+    } as Partial<Parameters<QueryLifecycleOperationTracker['startApiCall']>[0]>)
+    tracker.startToolUse({
+      toolUseId: 'tool-use-1',
+      toolName: 'Bash',
+      startedAt: 1,
+      isBash: true,
+      timeoutMs: 300_000,
+      command: 'cat /home/user/project/.env',
+      output: 'tool output',
+    } as Parameters<QueryLifecycleOperationTracker['startToolUse']>[0])
+
+    const snapshot = tracker.snapshot()
+
+    expect(snapshot.apiCalls).toEqual([
+      {
+        clientRequestId: 'client-request-1',
+        requestId: 'server-request-1',
+        model: 'model-name',
+        querySource: 'repl_main_thread',
+        startedAt: 1,
+      },
+    ])
+    expect(Object.keys(snapshot.toolUses[0]!)).toEqual([
+      'toolUseId',
+      'toolName',
+      'startedAt',
+      'isBash',
+      'timeoutMs',
+    ])
+    expect(JSON.stringify(snapshot)).not.toContain('/home/')
+    expect(JSON.stringify(snapshot)).not.toContain('ANTHROPIC_API_KEY')
+    expect(JSON.stringify(snapshot)).not.toContain('tool output')
   })
 })

--- a/src/utils/QueryGuard.ts
+++ b/src/utils/QueryGuard.ts
@@ -3,16 +3,16 @@
  * React's `useSyncExternalStore`.
  *
  * Three states:
- *   idle        → no query, safe to dequeue and process
- *   dispatching → an item was dequeued, async chain hasn't reached onQuery yet
- *   running     → onQuery called tryStart(), query is executing
+ *   idle        -> no query, safe to dequeue and process
+ *   dispatching -> an item was dequeued, async chain hasn't reached onQuery yet
+ *   running     -> onQuery called tryStart(), query is executing
  *
  * Transitions:
- *   idle → dispatching  (reserve)
- *   dispatching → running  (tryStart)
- *   idle → running  (tryStart, for direct user submissions)
- *   running → idle  (end / forceEnd / timeout)
- *   dispatching → idle  (cancelReservation, when processQueueIfReady fails)
+ *   idle -> dispatching  (reserve)
+ *   dispatching -> running  (tryStart)
+ *   idle -> running  (tryStart, for direct user submissions)
+ *   running -> idle  (end / forceEnd / timeout)
+ *   dispatching -> idle  (cancelReservation, when processQueueIfReady fails)
  *
  * `isActive` returns true for both dispatching and running, preventing
  * re-entry from the queue processor during the async gap.
@@ -29,18 +29,21 @@
  *   )
  */
 import { createSignal } from './signal.js'
+import type {
+  QueryActiveOperationSnapshot,
+  QueryGuardMetadata,
+  QueryGuardStart,
+  QueryGuardTimeoutInfo,
+  QueryGuardTimeoutReason,
+  QueryLifecycleContext,
+  QueryTerminalReason,
+} from './queryLifecycle.js'
+
+export type { QueryGuardTimeoutReason } from './queryLifecycle.js'
 
 export const DEFAULT_QUERY_IDLE_TIMEOUT_MS = 5 * 60 * 1000 // 5 minutes
 export const DEFAULT_QUERY_HARD_MAX_MS = 30 * 60 * 1000 // 30 minutes
 export const DEFAULT_TOOL_LEASE_GRACE_MS = 5_000
-
-/**
- * Why QueryGuard force-ended the current query.
- * - `idle`: no progress and no valid lease existed for the idle timeout.
- * - `hard_max`: the query reached its absolute maximum lifetime.
- * - `lease_expired`: bounded active work exceeded its own lease deadline.
- */
-export type QueryGuardTimeoutReason = 'idle' | 'hard_max' | 'lease_expired'
 
 /**
  * Input for a bounded unit of active work.
@@ -73,10 +76,7 @@ export type QueryGuardLease = {
   release(): void
 }
 
-type QueryTimeoutHandler = (
-  generation: number,
-  reason: QueryGuardTimeoutReason,
-) => void
+type QueryTimeoutHandler = (timeout: QueryGuardTimeoutInfo) => void
 
 type QueryGuardOptions = {
   idleTimeoutMs?: number
@@ -94,10 +94,23 @@ type LeaseRecord = {
   description?: string
 }
 
+const EMPTY_ACTIVE_OPERATIONS: QueryActiveOperationSnapshot = {
+  apiCalls: [],
+  toolUses: [],
+}
+
 function positiveOrDefault(value: number | undefined, fallback: number): number {
   return typeof value === 'number' && Number.isFinite(value) && value > 0
     ? value
     : fallback
+}
+
+function terminalReasonForTimeout(
+  reason: QueryGuardTimeoutReason,
+): QueryTerminalReason {
+  return reason === 'hard_max'
+    ? 'hard-max-query-timeout'
+    : 'query-timeout'
 }
 
 export class QueryGuard {
@@ -110,6 +123,10 @@ export class QueryGuard {
   private _lastActivityAt = 0
   private _leaseCounter = 0
   private _activeLeases = new Map<string, LeaseRecord>()
+  private _context: QueryLifecycleContext | null = null
+  private _lastContext: QueryLifecycleContext | null = null
+  private _getActiveOperations: (() => QueryActiveOperationSnapshot) | null =
+    null
   private readonly _idleTimeoutMs: number
   private readonly _hardMaxQueryMs: number
   private readonly _toolLeaseGraceMs: number
@@ -130,7 +147,7 @@ export class QueryGuard {
   }
 
   /**
-   * Reserve the guard for queue processing. Transitions idle → dispatching.
+   * Reserve the guard for queue processing. Transitions idle -> dispatching.
    * Returns false if not idle (another query or dispatch in progress).
    */
   reserve(): boolean {
@@ -142,7 +159,7 @@ export class QueryGuard {
 
   /**
    * Cancel a reservation when processQueueIfReady had nothing to process.
-   * Transitions dispatching → idle.
+   * Transitions dispatching -> idle.
    */
   cancelReservation(): void {
     if (this._status !== 'dispatching') return
@@ -156,15 +173,26 @@ export class QueryGuard {
    * Accepts transitions from both idle (direct user submit)
    * and dispatching (queue processor path).
    */
-  tryStart(): number | null {
+  tryStart(): number | null
+  tryStart(metadata: QueryGuardMetadata): QueryGuardStart | null
+  tryStart(metadata?: QueryGuardMetadata): number | QueryGuardStart | null {
     if (this._status === 'running') return null
     this._status = 'running'
     ++this._generation
     this._activeLeases.clear()
+    this._lastContext = null
     this._queryStartedAt = Date.now()
     this._lastActivityAt = this._queryStartedAt
+    this._context = this._createContext(metadata)
+    this._getActiveOperations = metadata?.getActiveOperations ?? null
     this._startTimeout()
     this._notify()
+    if (metadata) {
+      return {
+        generation: this._generation,
+        context: this._context,
+      }
+    }
     return this._generation
   }
 
@@ -173,12 +201,18 @@ export class QueryGuard {
    * (meaning the caller should perform cleanup). Returns false if a
    * newer query has started (stale finally block from a cancelled query).
    */
-  end(generation: number): boolean {
+  end(
+    generation: number,
+    terminalReason: QueryTerminalReason = 'ok',
+    abortReason?: string,
+  ): boolean {
     if (this._generation !== generation) return false
     if (this._status !== 'running') return false
     this._clearTimeout()
     this._activeLeases.clear()
+    this._completeContext(terminalReason, abortReason)
     this._status = 'idle'
+    this._getActiveOperations = null
     this._notify()
     return true
   }
@@ -189,11 +223,16 @@ export class QueryGuard {
    * Increments generation so stale finally blocks from the cancelled
    * query's promise rejection will see a mismatch and skip cleanup.
    */
-  forceEnd(): void {
+  forceEnd(
+    terminalReason: QueryTerminalReason = 'unknown',
+    abortReason?: string,
+  ): void {
     if (this._status === 'idle') return
     this._clearTimeout()
     this._activeLeases.clear()
+    this._completeContext(terminalReason, abortReason)
     this._status = 'idle'
+    this._getActiveOperations = null
     ++this._generation
     this._notify()
   }
@@ -283,7 +322,7 @@ export class QueryGuard {
 
   /**
    * Is the guard active (dispatching or running)?
-   * Always synchronous — not subject to React state batching delays.
+   * Always synchronous - not subject to React state batching delays.
    */
   get isActive(): boolean {
     return this._status !== 'idle'
@@ -291,6 +330,14 @@ export class QueryGuard {
 
   get generation(): number {
     return this._generation
+  }
+
+  get activeContext(): QueryLifecycleContext | null {
+    return this._context ? { ...this._context } : null
+  }
+
+  get lastContext(): QueryLifecycleContext | null {
+    return this._lastContext ? { ...this._lastContext } : null
   }
 
   /**
@@ -310,7 +357,7 @@ export class QueryGuard {
   // --
   // useSyncExternalStore interface
 
-  /** Subscribe to state changes. Stable reference — safe as useEffect dep. */
+  /** Subscribe to state changes. Stable reference - safe as useEffect dep. */
   subscribe = this._changed.subscribe
 
   /** Snapshot for useSyncExternalStore. Returns `isActive`. */
@@ -320,6 +367,55 @@ export class QueryGuard {
 
   private _notify(): void {
     this._changed.emit()
+  }
+
+  private _createContext(
+    metadata: QueryGuardMetadata | undefined,
+  ): QueryLifecycleContext {
+    return {
+      queryId: metadata?.queryId ?? `generation-${this._generation}`,
+      queryGeneration: this._generation,
+      querySource: metadata?.querySource ?? 'unknown',
+      ...(metadata?.parentQueryId && { parentQueryId: metadata.parentQueryId }),
+      ...(metadata?.subagentId && { subagentId: metadata.subagentId }),
+      startedAt: metadata?.startedAt ?? Date.now(),
+    }
+  }
+
+  private _completeContext(
+    terminalReason: QueryTerminalReason,
+    abortReason?: string,
+  ): void {
+    if (!this._context) return
+    const completed = {
+      ...this._context,
+      terminalReason,
+      ...(abortReason !== undefined && { abortReason }),
+    }
+    this._context = null
+    this._lastContext = completed
+  }
+
+  private _activeContextWithTerminalReason(
+    terminalReason: QueryTerminalReason,
+    abortReason?: string,
+  ): QueryLifecycleContext {
+    const context = this._context ?? this._createContext(undefined)
+    return {
+      ...context,
+      terminalReason,
+      ...(abortReason !== undefined && { abortReason }),
+    }
+  }
+
+  private _snapshotActiveOperations(): QueryActiveOperationSnapshot {
+    if (!this._getActiveOperations) return EMPTY_ACTIVE_OPERATIONS
+    try {
+      return this._getActiveOperations()
+    } catch (error) {
+      console.error('[QueryGuard] Active operation snapshot failed', error)
+      return EMPTY_ACTIVE_OPERATIONS
+    }
   }
 
   /**
@@ -354,21 +450,36 @@ export class QueryGuard {
     this._timeoutId = null
     if (this._status !== 'running') return
 
-    const reason = this._getTimeoutReason(Date.now())
+    const now = Date.now()
+    const reason = this._getTimeoutReason(now)
     if (!reason) {
       this._scheduleTimeout()
       return
     }
 
+    const terminalReason = terminalReasonForTimeout(reason)
+    const context = this._activeContextWithTerminalReason(
+      terminalReason,
+      reason,
+    )
+    const timeout: QueryGuardTimeoutInfo = {
+      generation: this._generation,
+      reason,
+      timeoutMs: this._getTimeoutMsForReason(reason, now),
+      elapsedMs: now - context.startedAt,
+      context,
+      activeOperations: this._snapshotActiveOperations(),
+    }
+
     console.error(
-      `[QueryGuard] Query ${reason} timeout — force-ending to prevent infinite spinner`,
+      `[QueryGuard] Query ${reason} timeout - force-ending to prevent infinite spinner`,
     )
     try {
-      this._timeoutHandler?.(this._generation, reason)
+      this._timeoutHandler?.(timeout)
     } catch (error) {
       console.error('[QueryGuard] Timeout handler failed', error)
     } finally {
-      this.forceEnd()
+      this.forceEnd(terminalReason, reason)
     }
   }
 
@@ -385,14 +496,25 @@ export class QueryGuard {
       hasValidLease = true
     }
 
-    if (
-      !hasValidLease &&
-      now >= this._lastActivityAt + this._idleTimeoutMs
-    ) {
+    if (!hasValidLease && now >= this._lastActivityAt + this._idleTimeoutMs) {
       return 'idle'
     }
 
     return null
+  }
+
+  private _getTimeoutMsForReason(
+    reason: QueryGuardTimeoutReason,
+    now: number,
+  ): number {
+    if (reason === 'hard_max') return this._hardMaxQueryMs
+    if (reason === 'idle') return this._idleTimeoutMs
+
+    const expiredLease = [...this._activeLeases.values()].find(
+      lease => lease.deadlineAt <= now,
+    )
+    if (!expiredLease) return this._idleTimeoutMs
+    return Math.max(0, expiredLease.deadlineAt - expiredLease.startedAt)
   }
 
   private _getNextDeadlineAt(now: number): number | null {

--- a/src/utils/forkedAgent.ts
+++ b/src/utils/forkedAgent.ts
@@ -277,6 +277,8 @@ export type SubagentContextOverrides = {
   abortController?: AbortController
   /** Override the getAppState function */
   getAppState?: ToolUseContext['getAppState']
+  /** Explicitly opt in to sharing a lifecycle tracker with this subagent. */
+  queryLifecycle?: ToolUseContext['queryLifecycle']
 
   /**
    * Explicit opt-in to share parent's setAppState callback.
@@ -452,6 +454,9 @@ export function createSubagentContext(
     // Generate new agentId for subagents (each subagent should have its own ID)
     agentId: overrides?.agentId ?? createAgentId(),
     agentType: overrides?.agentType,
+    ...(overrides?.queryLifecycle
+      ? { queryLifecycle: overrides.queryLifecycle }
+      : {}),
 
     // Create new query tracking chain for subagent with incremented depth
     queryTracking: {

--- a/src/utils/queryLifecycle.test.ts
+++ b/src/utils/queryLifecycle.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, test } from 'vitest'
+import {
+  formatQueryLifecycleAbortSignalReason,
+  formatQueryLifecycleLogMessage,
+  type QueryLifecycleContext,
+} from './queryLifecycle.js'
+
+describe('query lifecycle log formatting', () => {
+  test('keeps timeout context abort reason distinct from abort signal reason', () => {
+    const context: QueryLifecycleContext = {
+      queryId: 'query-1',
+      queryGeneration: 1,
+      querySource: 'repl_main_thread',
+      startedAt: 1,
+      terminalReason: 'query-timeout',
+      abortReason: 'idle',
+    }
+
+    const line = formatQueryLifecycleLogMessage(
+      'abort_requested',
+      context,
+      formatQueryLifecycleAbortSignalReason('query-timeout'),
+    )
+
+    expect(line).toContain('abortReason=idle')
+    expect(line).toContain('abortSignalReason=query-timeout')
+    expect(line).not.toContain('abortReason=query-timeout')
+    expect(line.match(/\babortReason=/g)).toHaveLength(1)
+  })
+})

--- a/src/utils/queryLifecycle.ts
+++ b/src/utils/queryLifecycle.ts
@@ -1,0 +1,109 @@
+export type QueryTerminalReason =
+  | 'ok'
+  | 'query-timeout'
+  | 'hard-max-query-timeout'
+  | 'user-abort'
+  | 'api-error'
+  | 'tool-error'
+  | 'budget-exhausted'
+  | 'parent-ended'
+  | 'unknown'
+
+export type QueryGuardTimeoutReason = 'idle' | 'hard_max' | 'lease_expired'
+
+export type QueryActiveApiCall = {
+  clientRequestId?: string
+  requestId?: string | null
+  model?: string
+  querySource?: string
+  startedAt: number
+}
+
+export type QueryActiveToolUse = {
+  toolUseId: string
+  toolName: string
+  startedAt: number
+  isBash?: boolean
+  timeoutMs?: number
+}
+
+export type QueryActiveOperationSnapshot = {
+  apiCalls: QueryActiveApiCall[]
+  toolUses: QueryActiveToolUse[]
+}
+
+export type QueryLifecycleContext = {
+  queryId: string
+  queryGeneration: number
+  querySource: string
+  parentQueryId?: string
+  subagentId?: string
+  startedAt: number
+  terminalReason?: QueryTerminalReason
+  abortReason?: string
+}
+
+export type QueryGuardMetadata = {
+  queryId: string
+  querySource: string
+  parentQueryId?: string
+  subagentId?: string
+  startedAt?: number
+  getActiveOperations?: () => QueryActiveOperationSnapshot
+}
+
+export type QueryGuardStart = {
+  generation: number
+  context: QueryLifecycleContext
+}
+
+export type QueryGuardTimeoutInfo = {
+  generation: number
+  reason: QueryGuardTimeoutReason
+  timeoutMs: number
+  elapsedMs: number
+  context: QueryLifecycleContext
+  activeOperations: QueryActiveOperationSnapshot
+}
+
+export class QueryLifecycleOperationTracker {
+  private apiCalls = new Map<string, QueryActiveApiCall>()
+  private toolUses = new Map<string, QueryActiveToolUse>()
+  private apiCallSeq = 0
+
+  startApiCall(call: QueryActiveApiCall): string {
+    const key = call.clientRequestId ?? call.requestId ?? `api-call-${++this.apiCallSeq}`
+    this.apiCalls.set(key, { ...call })
+    return key
+  }
+
+  updateApiCall(key: string, update: Partial<QueryActiveApiCall>): void {
+    const current = this.apiCalls.get(key)
+    if (!current) return
+    this.apiCalls.set(key, { ...current, ...update })
+  }
+
+  endApiCall(key: string): void {
+    this.apiCalls.delete(key)
+  }
+
+  startToolUse(toolUse: QueryActiveToolUse): void {
+    this.toolUses.set(toolUse.toolUseId, { ...toolUse })
+  }
+
+  endToolUse(toolUseId: string): void {
+    this.toolUses.delete(toolUseId)
+  }
+
+  clear(): void {
+    this.apiCalls.clear()
+    this.toolUses.clear()
+  }
+
+  snapshot(): QueryActiveOperationSnapshot {
+    return {
+      apiCalls: [...this.apiCalls.values()].map(call => ({ ...call })),
+      toolUses: [...this.toolUses.values()].map(toolUse => ({ ...toolUse })),
+    }
+  }
+}

--- a/src/utils/queryLifecycle.ts
+++ b/src/utils/queryLifecycle.ts
@@ -66,6 +66,26 @@ export type QueryGuardTimeoutInfo = {
   activeOperations: QueryActiveOperationSnapshot
 }
 
+function toSafeApiCallSnapshot(call: QueryActiveApiCall): QueryActiveApiCall {
+  return {
+    ...(call.clientRequestId !== undefined ? { clientRequestId: call.clientRequestId } : {}),
+    ...(call.requestId !== undefined ? { requestId: call.requestId } : {}),
+    ...(call.model !== undefined ? { model: call.model } : {}),
+    ...(call.querySource !== undefined ? { querySource: call.querySource } : {}),
+    startedAt: call.startedAt,
+  }
+}
+
+function toSafeToolUseSnapshot(toolUse: QueryActiveToolUse): QueryActiveToolUse {
+  return {
+    toolUseId: toolUse.toolUseId,
+    toolName: toolUse.toolName,
+    startedAt: toolUse.startedAt,
+    ...(toolUse.isBash !== undefined ? { isBash: toolUse.isBash } : {}),
+    ...(toolUse.timeoutMs !== undefined ? { timeoutMs: toolUse.timeoutMs } : {}),
+  }
+}
+
 export class QueryLifecycleOperationTracker {
   private apiCalls = new Map<string, QueryActiveApiCall>()
   private toolUses = new Map<string, QueryActiveToolUse>()
@@ -73,14 +93,14 @@ export class QueryLifecycleOperationTracker {
 
   startApiCall(call: QueryActiveApiCall): string {
     const key = call.clientRequestId ?? call.requestId ?? `api-call-${++this.apiCallSeq}`
-    this.apiCalls.set(key, { ...call })
+    this.apiCalls.set(key, toSafeApiCallSnapshot(call))
     return key
   }
 
   updateApiCall(key: string, update: Partial<QueryActiveApiCall>): void {
     const current = this.apiCalls.get(key)
     if (!current) return
-    this.apiCalls.set(key, { ...current, ...update })
+    this.apiCalls.set(key, toSafeApiCallSnapshot({ ...current, ...update }))
   }
 
   endApiCall(key: string): void {
@@ -88,7 +108,7 @@ export class QueryLifecycleOperationTracker {
   }
 
   startToolUse(toolUse: QueryActiveToolUse): void {
-    this.toolUses.set(toolUse.toolUseId, { ...toolUse })
+    this.toolUses.set(toolUse.toolUseId, toSafeToolUseSnapshot(toolUse))
   }
 
   endToolUse(toolUseId: string): void {
@@ -102,8 +122,8 @@ export class QueryLifecycleOperationTracker {
 
   snapshot(): QueryActiveOperationSnapshot {
     return {
-      apiCalls: [...this.apiCalls.values()].map(call => ({ ...call })),
-      toolUses: [...this.toolUses.values()].map(toolUse => ({ ...toolUse })),
+      apiCalls: [...this.apiCalls.values()].map(toSafeApiCallSnapshot),
+      toolUses: [...this.toolUses.values()].map(toSafeToolUseSnapshot),
     }
   }
 }

--- a/src/utils/queryLifecycle.ts
+++ b/src/utils/queryLifecycle.ts
@@ -66,6 +66,22 @@ export type QueryGuardTimeoutInfo = {
   activeOperations: QueryActiveOperationSnapshot
 }
 
+export function formatQueryLifecycleAbortSignalReason(reason: string): string {
+  return `abortSignalReason=${reason}`
+}
+
+export function formatQueryLifecycleLogMessage(
+  event: string,
+  context: QueryLifecycleContext,
+  extras = '',
+): string {
+  const parent = context.parentQueryId ? ` parentQueryId=${context.parentQueryId}` : ''
+  const subagent = context.subagentId ? ` subagentId=${context.subagentId}` : ''
+  const terminal = context.terminalReason ? ` terminalReason=${context.terminalReason}` : ''
+  const abort = context.abortReason ? ` abortReason=${context.abortReason}` : ''
+  return `query.${event} queryId=${context.queryId} generation=${context.queryGeneration} source=${context.querySource}${parent}${subagent}${terminal}${abort}${extras ? ` ${extras}` : ''}`
+}
+
 // Rebuild snapshots from an allowlist so debug logging cannot leak runtime extras.
 function toSafeApiCallSnapshot(call: QueryActiveApiCall): QueryActiveApiCall {
   return {

--- a/src/utils/queryLifecycle.ts
+++ b/src/utils/queryLifecycle.ts
@@ -66,6 +66,7 @@ export type QueryGuardTimeoutInfo = {
   activeOperations: QueryActiveOperationSnapshot
 }
 
+// Rebuild snapshots from an allowlist so debug logging cannot leak runtime extras.
 function toSafeApiCallSnapshot(call: QueryActiveApiCall): QueryActiveApiCall {
   return {
     ...(call.clientRequestId !== undefined ? { clientRequestId: call.clientRequestId } : {}),
@@ -76,6 +77,17 @@ function toSafeApiCallSnapshot(call: QueryActiveApiCall): QueryActiveApiCall {
   }
 }
 
+function toDefinedApiCallUpdate(update: Partial<QueryActiveApiCall>): Partial<QueryActiveApiCall> {
+  return {
+    ...(update.clientRequestId !== undefined ? { clientRequestId: update.clientRequestId } : {}),
+    ...(update.requestId !== undefined ? { requestId: update.requestId } : {}),
+    ...(update.model !== undefined ? { model: update.model } : {}),
+    ...(update.querySource !== undefined ? { querySource: update.querySource } : {}),
+    ...(update.startedAt !== undefined ? { startedAt: update.startedAt } : {}),
+  }
+}
+
+// Keep tool snapshots on the same explicit allowlist boundary as API calls.
 function toSafeToolUseSnapshot(toolUse: QueryActiveToolUse): QueryActiveToolUse {
   return {
     toolUseId: toolUse.toolUseId,
@@ -100,7 +112,7 @@ export class QueryLifecycleOperationTracker {
   updateApiCall(key: string, update: Partial<QueryActiveApiCall>): void {
     const current = this.apiCalls.get(key)
     if (!current) return
-    this.apiCalls.set(key, toSafeApiCallSnapshot({ ...current, ...update }))
+    this.apiCalls.set(key, toSafeApiCallSnapshot({ ...current, ...toDefinedApiCallUpdate(update) }))
   }
 
   endApiCall(key: string): void {


### PR DESCRIPTION
## Summary

- add explicit query lifecycle identity, source, terminal reason, and timeout context to QueryGuard
- track active API calls and tool uses with safe metadata for timeout/debug correlation
- emit query lifecycle debug events for start, guard start, timeout, abort, and end paths

## Validation

- `bun run typecheck`
- `bun test src/utils/QueryGuard.test.ts`
- `bun test tests/sdk/query-methods.test.ts tests/sdk/query-lifecycle.test.ts tests/sdk/query-concurrency.test.ts tests/sdk/query-happy-path.test.ts src/queryEngine.goal.test.ts src/query/autoCompactCooldown.test.ts src/query/stopHooks.goal.test.ts src/query/goalContinuation.test.ts src/query/providerMaxTokensCapRetry.test.ts src/query/toolFailureLoopGuard.test.ts`
- `bun test src/services/tools/toolExecution.test.ts src/services/tools/toolHooks.test.ts`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * End-to-end query lifecycle tracking for active API calls and tool executions, including richer terminal reasons and safe active-operation snapshots.
  * Improved timeout and user-cancellation lifecycle reporting with more detailed debug context.

* **Refactor**
  * Updated query guarding to expose current/previous lifecycle context and ensure lifecycle state is started, finalized, and cleaned up consistently.
  * Wired lifecycle tracking through tool execution and both streaming and fallback request paths.

* **Tests**
  * Expanded QueryGuard and query-lifecycle tracker test coverage, with stricter snapshot-safety and richer timeout payload assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->