### PR TITLE
Add GitHub Enterprise Copilot support

### DIFF
--- a/src/commands/onboard-github/onboard-github.test.ts
+++ b/src/commands/onboard-github/onboard-github.test.ts
@@ -5,6 +5,7 @@ import {
   applyGithubOnboardingProcessEnv,
   buildGithubOnboardingSettingsEnv,
   hasExistingGithubModelsLoginToken,
+  normalizeGithubEnterpriseInputUrl,
   shouldForceGithubRelogin,
 } from './onboard-github.js'
 
@@ -52,6 +53,14 @@ describe('hasExistingGithubModelsLoginToken', () => {
 })
 
 describe('onboarding auth precedence cleanup', () => {
+  test('normalizes Enterprise input URL to the instance origin', () => {
+    expect(
+      normalizeGithubEnterpriseInputUrl(
+        'https://github.mycompany.com/api/copilot/',
+      ),
+    ).toBe('https://github.mycompany.com')
+  })
+
   test('clears preexisting OpenAI auth when switching to GitHub', () => {
     const env: NodeJS.ProcessEnv = {
       CLAUDE_CODE_USE_OPENAI: '1',
@@ -62,11 +71,13 @@ describe('onboarding auth precedence cleanup', () => {
       OPENAI_ORGANIZATION: 'org-legacy',
       OPENAI_BASE_URL: 'https://api.openai.com/v1',
       OPENAI_API_BASE: 'https://api.openai.com/v1',
+      GITHUB_COPILOT_KEY: 'stale-copilot-key',
+      GITHUB_ENTERPRISE_URL: 'https://github.old.example.com',
       CLAUDE_CODE_PROVIDER_PROFILE_ENV_APPLIED: '1',
       CLAUDE_CODE_PROVIDER_PROFILE_ENV_APPLIED_ID: 'profile_old',
     }
 
-    applyGithubOnboardingProcessEnv('github:copilot', env)
+    applyGithubOnboardingProcessEnv('github:copilot', undefined, env)
 
     expect(env.CLAUDE_CODE_USE_GITHUB).toBe('1')
     expect(env.OPENAI_MODEL).toBe('github:copilot')
@@ -77,6 +88,8 @@ describe('onboarding auth precedence cleanup', () => {
     expect(env.OPENAI_ORGANIZATION).toBeUndefined()
     expect(env.OPENAI_BASE_URL).toBeUndefined()
     expect(env.OPENAI_API_BASE).toBeUndefined()
+    expect(env.GITHUB_COPILOT_KEY).toBeUndefined()
+    expect(env.GITHUB_ENTERPRISE_URL).toBeUndefined()
 
     expect(env.CLAUDE_CODE_USE_OPENAI).toBeUndefined()
     expect(env.CLAUDE_CODE_PROVIDER_PROFILE_ENV_APPLIED).toBeUndefined()
@@ -89,6 +102,31 @@ describe('onboarding auth precedence cleanup', () => {
     expect(settingsEnv.OPENAI_ORG).toBeUndefined()
     expect(settingsEnv.OPENAI_PROJECT).toBeUndefined()
     expect(settingsEnv.OPENAI_ORGANIZATION).toBeUndefined()
+    expect(settingsEnv.GITHUB_ENTERPRISE_URL).toBeUndefined()
+  })
+
+  test('persists Enterprise URL when switching to GitHub Enterprise', () => {
+    const env: NodeJS.ProcessEnv = {
+      CLAUDE_CODE_USE_OPENAI: '1',
+      GITHUB_ENTERPRISE_URL: 'https://github.old.example.com',
+    }
+
+    applyGithubOnboardingProcessEnv(
+      'github:copilot',
+      'https://github.mycompany.com',
+      env,
+    )
+
+    expect(env.CLAUDE_CODE_USE_GITHUB).toBe('1')
+    expect(env.GITHUB_ENTERPRISE_URL).toBe('https://github.mycompany.com')
+
+    const settingsEnv = buildGithubOnboardingSettingsEnv(
+      'github:copilot',
+      'https://github.mycompany.com',
+    )
+    expect(settingsEnv.GITHUB_ENTERPRISE_URL).toBe(
+      'https://github.mycompany.com',
+    )
   })
 })
 
@@ -97,12 +135,13 @@ describe('activateGithubOnboardingMode', () => {
     const calls: string[] = []
 
     const result = activateGithubOnboardingMode('  github:copilot  ', {
-      mergeSettingsEnv: model => {
-        calls.push(`merge:${model}`)
+      gheUrl: 'https://github.mycompany.com',
+      mergeSettingsEnv: (model, gheUrl) => {
+        calls.push(`merge:${model}:${gheUrl}`)
         return { ok: true }
       },
-      applyProcessEnv: model => {
-        calls.push(`apply:${model}`)
+      applyProcessEnv: (model, gheUrl) => {
+        calls.push(`apply:${model}:${gheUrl}`)
       },
       hydrateToken: () => {
         calls.push('hydrate')
@@ -114,8 +153,8 @@ describe('activateGithubOnboardingMode', () => {
 
     expect(result).toEqual({ ok: true })
     expect(calls).toEqual([
-      'merge:github:copilot',
-      'apply:github:copilot',
+      'merge:github:copilot:https://github.mycompany.com',
+      'apply:github:copilot:https://github.mycompany.com',
       'hydrate',
       'onChangeAPIKey',
     ])

--- a/src/commands/onboard-github/onboard-github.test.ts
+++ b/src/commands/onboard-github/onboard-github.test.ts
@@ -4,6 +4,7 @@ import {
   activateGithubOnboardingMode,
   applyGithubOnboardingProcessEnv,
   buildGithubOnboardingSettingsEnv,
+  getExistingGithubEnterpriseUrl,
   hasExistingGithubModelsLoginToken,
   normalizeGithubEnterpriseInputUrl,
   shouldForceGithubRelogin,
@@ -59,6 +60,26 @@ describe('onboarding auth precedence cleanup', () => {
         'https://github.mycompany.com/api/copilot/',
       ),
     ).toBe('https://github.mycompany.com')
+  })
+
+  test('rejects invalid Enterprise input URL', () => {
+    expect(() => normalizeGithubEnterpriseInputUrl('not-a-url')).toThrow()
+  })
+
+  test('reads existing Enterprise URL from env or user settings', () => {
+    expect(
+      getExistingGithubEnterpriseUrl(
+        { GITHUB_ENTERPRISE_URL: ' https://github.env.example.com/path ' },
+        { GITHUB_ENTERPRISE_URL: 'https://github.settings.example.com' },
+      ),
+    ).toBe('https://github.env.example.com')
+
+    expect(
+      getExistingGithubEnterpriseUrl(
+        { GITHUB_ENTERPRISE_URL: 'undefined' },
+        { GITHUB_ENTERPRISE_URL: 'https://github.settings.example.com/api' },
+      ),
+    ).toBe('https://github.settings.example.com')
   })
 
   test('clears preexisting OpenAI auth when switching to GitHub', () => {

--- a/src/commands/onboard-github/onboard-github.tsx
+++ b/src/commands/onboard-github/onboard-github.tsx
@@ -168,6 +168,36 @@ function mergeUserSettingsEnv(
   return { ok: true }
 }
 
+function normalizeOptionalGithubEnterpriseUrl(
+  value: unknown,
+): string | undefined {
+  if (typeof value !== 'string') {
+    return undefined
+  }
+  const trimmed = value.trim()
+  if (!trimmed || trimmed.toLowerCase() === 'undefined') {
+    return undefined
+  }
+  try {
+    return normalizeGithubEnterpriseInputUrl(trimmed)
+  } catch {
+    return undefined
+  }
+}
+
+export function getExistingGithubEnterpriseUrl(
+  env: NodeJS.ProcessEnv = process.env,
+  settingsEnv?: Record<string, unknown>,
+): string | undefined {
+  return (
+    normalizeOptionalGithubEnterpriseUrl(env.GITHUB_ENTERPRISE_URL) ??
+    normalizeOptionalGithubEnterpriseUrl(
+      settingsEnv?.GITHUB_ENTERPRISE_URL ??
+        getSettingsForSource('userSettings')?.env?.GITHUB_ENTERPRISE_URL,
+    )
+  )
+}
+
 export function activateGithubOnboardingMode(
   model: string = DEFAULT_MODEL,
   options?: {
@@ -348,8 +378,8 @@ function OnboardGithub(props: {
       // Clear stale provider-specific env vars from the current session
       // so resolveProviderRequest() doesn't pick up a previous provider's
       // base URL or key after onboarding completes.
-      for (const key of PROVIDER_SPECIFIC_KEYS) {
-        delete process.env[key]
+      for (const envKey of PROVIDER_SPECIFIC_KEYS) {
+        delete process.env[envKey]
       }
       process.env.CLAUDE_CODE_USE_GITHUB = '1'
       process.env.OPENAI_MODEL = model.trim() || DEFAULT_MODEL
@@ -583,7 +613,9 @@ function OnboardGithub(props: {
 export const call: LocalJSXCommandCall = async (onDone, context, args) => {
   const forceRelogin = shouldForceGithubRelogin(args)
   if (hasExistingGithubModelsLoginToken() && !forceRelogin) {
+    const existingGheUrl = getExistingGithubEnterpriseUrl()
     const activated = activateGithubOnboardingMode(DEFAULT_MODEL, {
+      gheUrl: existingGheUrl,
       onChangeAPIKey: context.onChangeAPIKey,
     })
     if (!activated.ok) {
@@ -596,7 +628,9 @@ export const call: LocalJSXCommandCall = async (onDone, context, args) => {
     }
 
     onDone(
-      'GitHub Models already authorized. Activated GitHub Models mode using your existing token. Use /onboard-github --force to re-authenticate.',
+      existingGheUrl
+        ? `GitHub Copilot Enterprise already authorized for ${existingGheUrl}. Activated GitHub mode using your existing token. Use /onboard-github --force to re-authenticate.`
+        : 'GitHub Models already authorized. Activated GitHub Models mode using your existing token. Use /onboard-github --force to re-authenticate.',
       { display: 'user' },
     )
     return null

--- a/src/commands/onboard-github/onboard-github.tsx
+++ b/src/commands/onboard-github/onboard-github.tsx
@@ -2,6 +2,8 @@ import * as React from 'react'
 import { useCallback, useState } from 'react'
 import { Select } from '../../components/CustomSelect/select.js'
 import { Spinner } from '../../components/Spinner.js'
+import TextInput from '../../components/TextInput.js'
+import { useTerminalSize } from '../../hooks/useTerminalSize.js'
 import { Box, Text } from '../../ink.js'
 import {
   exchangeForCopilotToken,
@@ -27,7 +29,7 @@ const FORCE_RELOGIN_ARGS = new Set([
   '--reauth',
 ])
 
-type Step = 'menu' | 'device-busy' | 'error'
+type Step = 'menu' | 'ghe-url' | 'copilot-key' | 'device-busy' | 'error'
 
 const PROVIDER_SPECIFIC_KEYS = new Set([
   'CLAUDE_CODE_USE_OPENAI',
@@ -39,6 +41,8 @@ const PROVIDER_SPECIFIC_KEYS = new Set([
   'OPENAI_API_BASE',
   'OPENAI_API_KEY',
   'OPENAI_MODEL',
+  'GITHUB_COPILOT_KEY',
+  'GITHUB_ENTERPRISE_URL',
   'GEMINI_API_KEY',
   'GOOGLE_API_KEY',
   'GEMINI_BASE_URL',
@@ -83,10 +87,12 @@ export function hasExistingGithubModelsLoginToken(
 
 export function buildGithubOnboardingSettingsEnv(
   model: string,
+  gheUrl?: string,
 ): Record<string, string | undefined> {
   return {
     CLAUDE_CODE_USE_GITHUB: '1',
     OPENAI_MODEL: model,
+    GITHUB_ENTERPRISE_URL: gheUrl,
     OPENAI_API_KEY: undefined,
     OPENAI_ORG: undefined,
     OPENAI_PROJECT: undefined,
@@ -103,10 +109,16 @@ export function buildGithubOnboardingSettingsEnv(
 
 export function applyGithubOnboardingProcessEnv(
   model: string,
+  gheUrl?: string,
   env: NodeJS.ProcessEnv = process.env,
 ): void {
   env.CLAUDE_CODE_USE_GITHUB = '1'
   env.OPENAI_MODEL = model
+  if (gheUrl) {
+    env.GITHUB_ENTERPRISE_URL = gheUrl
+  } else {
+    delete env.GITHUB_ENTERPRISE_URL
+  }
 
   delete env.OPENAI_API_KEY
   delete env.OPENAI_ORG
@@ -114,6 +126,7 @@ export function applyGithubOnboardingProcessEnv(
   delete env.OPENAI_ORGANIZATION
   delete env.OPENAI_BASE_URL
   delete env.OPENAI_API_BASE
+  delete env.GITHUB_COPILOT_KEY
 
   delete env.CLAUDE_CODE_USE_OPENAI
   delete env.CLAUDE_CODE_USE_GEMINI
@@ -124,7 +137,10 @@ export function applyGithubOnboardingProcessEnv(
   delete env.CLAUDE_CODE_PROVIDER_PROFILE_ENV_APPLIED_ID
 }
 
-function mergeUserSettingsEnv(model: string): { ok: boolean; detail?: string } {
+function mergeUserSettingsEnv(
+  model: string,
+  gheUrl?: string,
+): { ok: boolean; detail?: string } {
   const currentSettings = getSettingsForSource('userSettings')
   const currentEnv = currentSettings?.env ?? {}
 
@@ -137,6 +153,11 @@ function mergeUserSettingsEnv(model: string): { ok: boolean; detail?: string } {
 
   newEnv.CLAUDE_CODE_USE_GITHUB = '1'
   newEnv.OPENAI_MODEL = model
+  if (gheUrl) {
+    newEnv.GITHUB_ENTERPRISE_URL = gheUrl
+  } else {
+    delete newEnv.GITHUB_ENTERPRISE_URL
+  }
 
   const { error } = updateSettingsForSource('userSettings', {
     env: newEnv,
@@ -150,8 +171,12 @@ function mergeUserSettingsEnv(model: string): { ok: boolean; detail?: string } {
 export function activateGithubOnboardingMode(
   model: string = DEFAULT_MODEL,
   options?: {
-    mergeSettingsEnv?: (model: string) => { ok: boolean; detail?: string }
-    applyProcessEnv?: (model: string) => void
+    gheUrl?: string
+    mergeSettingsEnv?: (
+      model: string,
+      gheUrl?: string,
+    ) => { ok: boolean; detail?: string }
+    applyProcessEnv?: (model: string, gheUrl?: string) => void
     hydrateToken?: () => void
     onChangeAPIKey?: () => void
   },
@@ -162,15 +187,125 @@ export function activateGithubOnboardingMode(
   const hydrateToken =
     options?.hydrateToken ?? hydrateGithubModelsTokenFromSecureStorage
 
-  const merged = mergeSettingsEnv(normalizedModel)
+  const merged = mergeSettingsEnv(normalizedModel, options?.gheUrl)
   if (!merged.ok) {
     return merged
   }
 
-  applyProcessEnv(normalizedModel)
+  applyProcessEnv(normalizedModel, options?.gheUrl)
   hydrateToken()
   options?.onChangeAPIKey?.()
   return { ok: true }
+}
+
+export function normalizeGithubEnterpriseInputUrl(value: string): string {
+  const parsed = new URL(value.trim())
+  if (!parsed.hostname) {
+    throw new Error('Invalid URL: must include a hostname.')
+  }
+  return parsed.origin
+}
+
+function GheUrlInput(props: {
+  onSubmit: (url: string) => void
+  onCancel: () => void
+}): React.ReactNode {
+  const { onSubmit, onCancel } = props
+  const [input, setInput] = useState('')
+  const [cursorOffset, setCursorOffset] = useState(0)
+  const [error, setError] = useState<string | null>(null)
+  const { columns } = useTerminalSize()
+
+  const handleSubmit = useCallback((value: string = input) => {
+    const trimmed = value.trim()
+    if (!trimmed) {
+      setError('URL cannot be empty.')
+      return
+    }
+    // Validate URL format
+    try {
+      onSubmit(normalizeGithubEnterpriseInputUrl(trimmed))
+    } catch {
+      setError('Invalid URL format. Enter the full URL (e.g. https://github.mycompany.com)')
+    }
+  }, [input, onSubmit])
+
+  return (
+    <Box flexDirection="column" gap={1}>
+      <Text bold>GitHub Enterprise URL</Text>
+      <Text dimColor>
+        Enter your GitHub Enterprise Server URL (e.g. https://github.mycompany.com)
+      </Text>
+      {error && <Text color="red">{error}</Text>}
+      <Box>
+        <Text>URL: </Text>
+        <TextInput
+          value={input}
+          onChange={(value) => {
+            setInput(value)
+            setError(null)
+          }}
+          onSubmit={handleSubmit}
+          onExit={onCancel}
+          placeholder="https://github.mycompany.com"
+          columns={Math.max(20, columns - 6)}
+          cursorOffset={cursorOffset}
+          onChangeCursorOffset={setCursorOffset}
+          focus
+          showCursor
+        />
+      </Box>
+    </Box>
+  )
+}
+
+function CopilotKeyInput(props: {
+  onSubmit: (key: string) => void
+  onCancel: () => void
+}): React.ReactNode {
+  const { onSubmit, onCancel } = props
+  const [input, setInput] = useState('')
+  const [cursorOffset, setCursorOffset] = useState(0)
+  const [error, setError] = useState<string | null>(null)
+  const { columns } = useTerminalSize()
+
+  const handleSubmit = useCallback((value: string = input) => {
+    const trimmed = value.trim()
+    if (!trimmed) {
+      setError('API key cannot be empty.')
+      return
+    }
+    onSubmit(trimmed)
+  }, [input, onSubmit])
+
+  return (
+    <Box flexDirection="column" gap={1}>
+      <Text bold>GitHub Copilot API Key</Text>
+      <Text dimColor>
+        Enter your GitHub Copilot API key for direct authentication.
+      </Text>
+      {error && <Text color="red">{error}</Text>}
+      <Box>
+        <Text>Key: </Text>
+        <TextInput
+          value={input}
+          onChange={(value) => {
+            setInput(value)
+            setError(null)
+          }}
+          onSubmit={handleSubmit}
+          onExit={onCancel}
+          placeholder="Copilot API key"
+          mask="*"
+          columns={Math.max(20, columns - 6)}
+          cursorOffset={cursorOffset}
+          onChangeCursorOffset={setCursorOffset}
+          focus
+          showCursor
+        />
+      </Box>
+    </Box>
+  )
 }
 
 function OnboardGithub(props: {
@@ -180,6 +315,7 @@ function OnboardGithub(props: {
   const { onDone, onChangeAPIKey } = props
   const [step, setStep] = useState<Step>('menu')
   const [errorMsg, setErrorMsg] = useState<string | null>(null)
+  const [gheUrl, setGheUrl] = useState<string | null>(null)
   const [deviceHint, setDeviceHint] = useState<{
     user_code: string
     verification_uri: string
@@ -198,6 +334,7 @@ function OnboardGithub(props: {
         return
       }
       const activated = activateGithubOnboardingMode(model, {
+        gheUrl: gheUrl ?? undefined,
         onChangeAPIKey,
       })
       if (!activated.ok) {
@@ -216,14 +353,22 @@ function OnboardGithub(props: {
       }
       process.env.CLAUDE_CODE_USE_GITHUB = '1'
       process.env.OPENAI_MODEL = model.trim() || DEFAULT_MODEL
+      // Set GITHUB_ENTERPRISE_URL if provided
+      if (gheUrl) {
+        process.env.GITHUB_ENTERPRISE_URL = gheUrl
+      }
       hydrateGithubModelsTokenFromSecureStorage()
       onChangeAPIKey()
+      const successMsg = gheUrl
+        ? `GitHub Copilot Enterprise onboard complete for ${gheUrl}. `
+        : 'GitHub Copilot onboard complete. '
       onDone(
-        'GitHub Copilot onboard complete. Copilot token and OAuth token stored in secure storage (Windows/Linux: ~/.claude/.credentials.json, macOS: Keychain fallback to ~/.claude/.credentials.json); user settings updated. Restart if the model does not switch.',
+        successMsg +
+          'Copilot token and OAuth token stored in secure storage (Windows/Linux: ~/.claude/.credentials.json, macOS: Keychain fallback to ~/.claude/.credentials.json); user settings updated. Restart if the model does not switch.',
         { display: 'user' },
       )
     },
-    [onChangeAPIKey, onDone],
+    [gheUrl, onChangeAPIKey, onDone],
   )
 
   const runDeviceFlow = useCallback(async () => {
@@ -231,7 +376,7 @@ function OnboardGithub(props: {
     setErrorMsg(null)
     setDeviceHint(null)
     try {
-      const device = await requestDeviceCode()
+      const device = await requestDeviceCode({ gheUrl: gheUrl ?? undefined })
       setDeviceHint({
         user_code: device.user_code,
         verification_uri: device.verification_uri,
@@ -240,14 +385,70 @@ function OnboardGithub(props: {
       const oauthToken = await pollAccessToken(device.device_code, {
         initialInterval: device.interval,
         timeoutSeconds: device.expires_in,
+        gheUrl: gheUrl ?? undefined,
       })
-      const copilotToken = await exchangeForCopilotToken(oauthToken)
+      const copilotToken = await exchangeForCopilotToken(
+        oauthToken,
+        undefined,
+        gheUrl ?? undefined,
+      )
       await finalize(copilotToken.token, DEFAULT_MODEL, oauthToken)
     } catch (e) {
       setErrorMsg(e instanceof Error ? e.message : String(e))
       setStep('error')
     }
-  }, [finalize])
+  }, [finalize, gheUrl])
+
+  const handleCopilotKeySubmit = useCallback(
+    async (key: string) => {
+      const trimmed = key.trim()
+      if (!trimmed) {
+        setErrorMsg('Copilot key cannot be empty.')
+        setStep('error')
+        return
+      }
+      // Store the Copilot key directly
+      const saved = saveGithubModelsToken(trimmed, undefined, {
+        credentialType: 'copilot_key',
+      })
+      if (!saved.success) {
+        setErrorMsg(saved.warning ?? 'Could not save key to secure storage.')
+        setStep('error')
+        return
+      }
+      const activated = activateGithubOnboardingMode(DEFAULT_MODEL, {
+        gheUrl: gheUrl ?? undefined,
+        onChangeAPIKey,
+      })
+      if (!activated.ok) {
+        setErrorMsg(
+          `Key saved, but settings were not updated: ${activated.detail ?? 'unknown error'}. ` +
+            `Add env CLAUDE_CODE_USE_GITHUB=1 and OPENAI_MODEL to ~/.claude/settings.json manually.`,
+        )
+        setStep('error')
+        return
+      }
+      for (const key of PROVIDER_SPECIFIC_KEYS) {
+        delete process.env[key]
+      }
+      process.env.CLAUDE_CODE_USE_GITHUB = '1'
+      process.env.OPENAI_MODEL = DEFAULT_MODEL
+      process.env.GITHUB_COPILOT_KEY = trimmed
+      if (gheUrl) {
+        process.env.GITHUB_ENTERPRISE_URL = gheUrl
+      }
+      hydrateGithubModelsTokenFromSecureStorage()
+      onChangeAPIKey()
+      const successMsg = gheUrl
+        ? `GitHub Copilot Enterprise onboard complete for ${gheUrl}. `
+        : 'GitHub Copilot onboard complete. '
+      onDone(
+        successMsg + 'Copilot key stored in secure storage; user settings updated.',
+        { display: 'user' },
+      )
+    },
+    [gheUrl, onChangeAPIKey, onDone],
+  )
 
   if (step === 'error' && errorMsg) {
     const options = [
@@ -281,7 +482,7 @@ function OnboardGithub(props: {
   if (step === 'device-busy') {
     return (
       <Box flexDirection="column" gap={1}>
-        <Text>GitHub Copilot sign-in</Text>
+        <Text>GitHub Copilot{gheUrl ? ' Enterprise' : ''} sign-in</Text>
         {deviceHint ? (
           <>
             <Text>
@@ -300,10 +501,43 @@ function OnboardGithub(props: {
     )
   }
 
+  if (step === 'ghe-url') {
+    return (
+      <GheUrlInput
+        onSubmit={(url) => {
+          setGheUrl(url)
+          setStep('menu')
+        }}
+        onCancel={() => setStep('menu')}
+      />
+    )
+  }
+
+  if (step === 'copilot-key') {
+    return (
+      <CopilotKeyInput
+        onSubmit={handleCopilotKeySubmit}
+        onCancel={() => setStep('menu')}
+      />
+    )
+  }
+
   const menuOptions = [
     {
       label: 'Sign in with browser',
       value: 'device' as const,
+    },
+    ...(gheUrl
+      ? [
+          {
+            label: 'Use Copilot API key instead',
+            value: 'copilot-key' as const,
+          },
+        ]
+      : []),
+    {
+      label: gheUrl ? 'Change Enterprise URL' : 'Use GitHub Enterprise',
+      value: 'ghe-url' as const,
     },
     {
       label: 'Cancel',
@@ -313,7 +547,12 @@ function OnboardGithub(props: {
 
   return (
     <Box flexDirection="column" gap={1}>
-      <Text bold>GitHub Copilot setup</Text>
+      <Text bold>GitHub Copilot{gheUrl ? ' Enterprise' : ''} setup</Text>
+      {gheUrl && (
+        <Text dimColor>
+          Enterprise URL: {gheUrl}
+        </Text>
+      )}
       <Text dimColor>
         Stores your token in the OS credential store (macOS Keychain when available)
         and enables CLAUDE_CODE_USE_GITHUB in your user settings - no export
@@ -324,6 +563,14 @@ function OnboardGithub(props: {
         onChange={(v: string) => {
           if (v === 'cancel') {
             onDone('GitHub onboard cancelled', { display: 'system' })
+            return
+          }
+          if (v === 'ghe-url') {
+            setStep('ghe-url')
+            return
+          }
+          if (v === 'copilot-key') {
+            setStep('copilot-key')
             return
           }
           void runDeviceFlow()

--- a/src/integrations/gateways/github-enterprise.ts
+++ b/src/integrations/gateways/github-enterprise.ts
@@ -1,0 +1,197 @@
+import { defineGateway } from '../define.js'
+
+/**
+ * GitHub Copilot Enterprise gateway.
+ *
+ * Supports GitHub Enterprise Server (GHE) instances that host Copilot
+ * behind a custom URL (e.g. *.ghe.com or self-hosted GHE).
+ *
+ * Configuration:
+ *   GITHUB_ENTERPRISE_URL  — The base URL of the GHE instance
+ *                            (e.g. https://github.mycompany.com)
+ *   GITHUB_COPILOT_KEY     — Optional. Direct Copilot API key for auth.
+ *                            If not set, uses GITHUB_TOKEN/GH_TOKEN with
+ *                            OAuth device flow against the GHE instance.
+ *
+ * When GITHUB_ENTERPRISE_URL is set, the gateway:
+ *   - Routes Copilot API requests to {GITHUB_ENTERPRISE_URL}/api/copilot
+ *   - Uses GHE-specific OAuth device flow endpoints
+ *   - Falls back to github.com if GITHUB_ENTERPRISE_URL is not set
+ */
+export default defineGateway({
+  id: 'github-enterprise',
+  label: 'GitHub Copilot Enterprise',
+  vendorId: 'openai',
+  category: 'hosted',
+  defaultBaseUrl: 'https://api.githubcopilot.com',
+  supportsModelRouting: true,
+  setup: {
+    requiresAuth: true,
+    authMode: 'token',
+    credentialEnvVars: ['GITHUB_COPILOT_KEY', 'GITHUB_TOKEN', 'GH_TOKEN'],
+  },
+  transportConfig: {
+    kind: 'openai-compatible',
+    openaiShim: {
+      supportsAuthHeaders: true,
+      maxTokensField: 'max_tokens',
+    },
+  },
+  validation: {
+    kind: 'github-token',
+    routing: {
+      enablementEnvVar: 'CLAUDE_CODE_USE_GITHUB',
+      skipWhenUseOpenAI: true,
+    },
+    missingCredentialMessage:
+      'GitHub Copilot Enterprise authentication required.\n' +
+      'Set GITHUB_ENTERPRISE_URL to your GHE instance URL (e.g. https://github.mycompany.com).\n' +
+      'Then run /onboard-github to sign in, or set GITHUB_COPILOT_KEY for direct API key auth.',
+    expiredCredentialMessage:
+      'GitHub Copilot Enterprise token has expired.\nRun /onboard-github to sign in again.',
+    invalidCredentialMessage:
+      'GitHub Copilot Enterprise token is invalid or corrupted.\nRun /onboard-github to sign in again.',
+  },
+  catalog: {
+    source: 'static',
+    models: [
+      {
+        id: 'github-gpt-5.5',
+        apiName: 'gpt-5.5',
+        label: 'GPT-5.5 (GitHub Enterprise)',
+        modelDescriptorId: 'github:copilot:gpt-5.5',
+        contextWindow: 272_000,
+        maxOutputTokens: 128_000,
+      },
+      {
+        id: 'github-gpt-5.5-mini',
+        apiName: 'gpt-5.5-mini',
+        label: 'GPT-5.5 mini (GitHub Enterprise)',
+        modelDescriptorId: 'github:copilot:gpt-5.5-mini',
+        contextWindow: 400_000,
+        maxOutputTokens: 128_000,
+      },
+      {
+        id: 'github-gpt-5.4',
+        apiName: 'gpt-5.4',
+        label: 'GPT-5.4 (GitHub Enterprise)',
+        modelDescriptorId: 'github:copilot:gpt-5.4',
+        contextWindow: 1_050_000,
+        maxOutputTokens: 32_768,
+      },
+      {
+        id: 'github-gpt-5.4-mini',
+        apiName: 'gpt-5.4-mini',
+        label: 'GPT-5.4 mini (GitHub Enterprise)',
+        modelDescriptorId: 'github:copilot:gpt-5.4-mini',
+        contextWindow: 400_000,
+        maxOutputTokens: 128_000,
+      },
+      {
+        id: 'github-gpt-5.3-codex',
+        apiName: 'gpt-5.3-codex',
+        label: 'GPT-5.3-Codex (GitHub Enterprise)',
+        modelDescriptorId: 'github:copilot:gpt-5.3-codex',
+        contextWindow: 400_000,
+        maxOutputTokens: 32_768,
+      },
+      {
+        id: 'github-gpt-5.2-codex',
+        apiName: 'gpt-5.2-codex',
+        label: 'GPT-5.2-Codex (GitHub Enterprise)',
+        modelDescriptorId: 'github:copilot:gpt-5.2-codex',
+        contextWindow: 400_000,
+        maxOutputTokens: 32_768,
+      },
+      {
+        id: 'github-gpt-5.2',
+        apiName: 'gpt-5.2',
+        label: 'GPT-5.2 (GitHub Enterprise)',
+        modelDescriptorId: 'github:copilot:gpt-5.2',
+        contextWindow: 400_000,
+        maxOutputTokens: 32_768,
+      },
+      {
+        id: 'github-gpt-5.1-codex',
+        apiName: 'gpt-5.1-codex',
+        label: 'GPT-5.1-Codex (GitHub Enterprise)',
+        modelDescriptorId: 'github:copilot:gpt-5.1-codex',
+        contextWindow: 400_000,
+        maxOutputTokens: 32_768,
+      },
+      {
+        id: 'github-gpt-4.1',
+        apiName: 'gpt-4.1',
+        label: 'GPT-4.1 (GitHub Enterprise)',
+        modelDescriptorId: 'github:copilot:gpt-4.1',
+        contextWindow: 1_047_576,
+        maxOutputTokens: 32_768,
+      },
+      {
+        id: 'github-gpt-4o',
+        apiName: 'gpt-4o',
+        label: 'GPT-4o (GitHub Enterprise)',
+        modelDescriptorId: 'github:copilot:gpt-4o',
+        contextWindow: 128_000,
+        maxOutputTokens: 16_384,
+      },
+      {
+        id: 'github-claude-sonnet-4.6',
+        apiName: 'claude-sonnet-4-6',
+        label: 'Claude Sonnet 4.6 (GitHub Enterprise)',
+        modelDescriptorId: 'github:copilot:claude-sonnet-4.6',
+        contextWindow: 200_000,
+        maxOutputTokens: 8_192,
+      },
+      {
+        id: 'github-claude-sonnet-4.5',
+        apiName: 'claude-sonnet-4-5',
+        label: 'Claude Sonnet 4.5 (GitHub Enterprise)',
+        modelDescriptorId: 'github:copilot:claude-sonnet-4.5',
+        contextWindow: 200_000,
+        maxOutputTokens: 8_192,
+      },
+      {
+        id: 'github-claude-opus-4.6',
+        apiName: 'claude-opus-4-6',
+        label: 'Claude Opus 4.6 (GitHub Enterprise)',
+        modelDescriptorId: 'github:copilot:claude-opus-4.6',
+        contextWindow: 200_000,
+        maxOutputTokens: 8_192,
+      },
+      {
+        id: 'github-claude-opus-4.5',
+        apiName: 'claude-opus-4-5',
+        label: 'Claude Opus 4.5 (GitHub Enterprise)',
+        modelDescriptorId: 'github:copilot:claude-opus-4.5',
+        contextWindow: 200_000,
+        maxOutputTokens: 8_192,
+      },
+      {
+        id: 'github-claude-haiku-4.5',
+        apiName: 'claude-haiku-4-5',
+        label: 'Claude Haiku 4.5 (GitHub Enterprise)',
+        modelDescriptorId: 'github:copilot:claude-haiku-4.5',
+        contextWindow: 144_000,
+        maxOutputTokens: 8_192,
+      },
+      {
+        id: 'github-gemini-2.5-pro',
+        apiName: 'gemini-2.5-pro',
+        label: 'Gemini 2.5 Pro (GitHub Enterprise)',
+        modelDescriptorId: 'github:copilot:gemini-2.5-pro',
+        contextWindow: 1_048_576,
+        maxOutputTokens: 65_536,
+      },
+      {
+        id: 'github-grok-code-fast-1',
+        apiName: 'grok-code-fast-1',
+        label: 'Grok Code Fast 1 (GitHub Enterprise)',
+        modelDescriptorId: 'github:copilot:grok-code-fast-1',
+        contextWindow: 256_000,
+        maxOutputTokens: 32_768,
+      },
+    ],
+  },
+  usage: { supported: false },
+})

--- a/src/integrations/generated/integrationArtifacts.generated.ts
+++ b/src/integrations/generated/integrationArtifacts.generated.ts
@@ -22,6 +22,7 @@ import gatewayBedrock from '../gateways/bedrock.js'
 import gatewayCustom from '../gateways/custom.js'
 import gatewayDashscopeCn from '../gateways/dashscope-cn.js'
 import gatewayDashscopeIntl from '../gateways/dashscope-intl.js'
+import gatewayGithubEnterprise from '../gateways/github-enterprise.js'
 import gatewayGithub from '../gateways/github.js'
 import gatewayGitlawbOpengateway from '../gateways/gitlawb-opengateway.js'
 import gatewayGroq from '../gateways/groq.js'
@@ -71,7 +72,7 @@ import modelXai from '../models/xai.js'
 import modelXiaomiMimo from '../models/xiaomi-mimo.js'
 
 export const VENDOR_DESCRIPTORS = [vendorAnthropic, vendorAtlasCloud, vendorBankr, vendorDeepseek, vendorFireworks, vendorGemini, vendorMinimax, vendorMoonshot, vendorNearai, vendorOpenai, vendorVenice, vendorXai, vendorXiaomiMimo, vendorZai] as const satisfies readonly VendorDescriptor[]
-export const GATEWAY_DESCRIPTORS = [gatewayAtomicChat, gatewayAzureOpenai, gatewayBedrock, gatewayCustom, gatewayDashscopeCn, gatewayDashscopeIntl, gatewayGithub, gatewayGitlawbOpengateway, gatewayGroq, gatewayHicap, gatewayKimiCode, gatewayLmstudio, gatewayMistral, gatewayNvidiaNim, gatewayOllama, gatewayOpencodeGo, gatewayOpencode, gatewayOpenrouter, gatewayTogether, gatewayVertex] as const satisfies readonly GatewayDescriptor[]
+export const GATEWAY_DESCRIPTORS = [gatewayAtomicChat, gatewayAzureOpenai, gatewayBedrock, gatewayCustom, gatewayDashscopeCn, gatewayDashscopeIntl, gatewayGithubEnterprise, gatewayGithub, gatewayGitlawbOpengateway, gatewayGroq, gatewayHicap, gatewayKimiCode, gatewayLmstudio, gatewayMistral, gatewayNvidiaNim, gatewayOllama, gatewayOpencodeGo, gatewayOpencode, gatewayOpenrouter, gatewayTogether, gatewayVertex] as const satisfies readonly GatewayDescriptor[]
 export const ANTHROPIC_PROXY_DESCRIPTORS = [] as const satisfies readonly AnthropicProxyDescriptor[]
 export const BRAND_DESCRIPTORS = [brandClaude, brandDeepseek, brandFireworks, brandGemini, brandGlm, brandGpt, brandKimi, brandLlama, brandMinimax, brandMistral, brandNearai, brandNemotron, brandOpenaiCompatibleAlias, brandQwen, brandXai, brandXiaomiMimo] as const satisfies readonly BrandDescriptor[]
 export const MODEL_DESCRIPTOR_GROUPS = [modelClaude, modelDeepseek, modelFireworksMerged, modelGemini, modelGlm, modelGpt, modelKimi, modelLlama, modelMinimax, modelMistral, modelNearai, modelNemotron, modelOpenaiCompatibleAlias, modelOpencode, modelQwen, modelXai, modelXiaomiMimo] as const satisfies readonly (readonly ModelDescriptor[])[]

--- a/src/services/api/openaiShim.test.ts
+++ b/src/services/api/openaiShim.test.ts
@@ -18,6 +18,8 @@ const originalEnv = {
   OPENAI_AUTH_SCHEME: process.env.OPENAI_AUTH_SCHEME,
   OPENAI_AUTH_HEADER_VALUE: process.env.OPENAI_AUTH_HEADER_VALUE,
   CLAUDE_CODE_USE_GITHUB: process.env.CLAUDE_CODE_USE_GITHUB,
+  GITHUB_COPILOT_KEY: process.env.GITHUB_COPILOT_KEY,
+  GITHUB_ENTERPRISE_URL: process.env.GITHUB_ENTERPRISE_URL,
   GITHUB_TOKEN: process.env.GITHUB_TOKEN,
   GH_TOKEN: process.env.GH_TOKEN,
   CLAUDE_CODE_USE_OPENAI: process.env.CLAUDE_CODE_USE_OPENAI,
@@ -154,6 +156,8 @@ beforeEach(async () => {
   delete process.env.OPENAI_AUTH_SCHEME
   delete process.env.OPENAI_AUTH_HEADER_VALUE
   delete process.env.CLAUDE_CODE_USE_GITHUB
+  delete process.env.GITHUB_COPILOT_KEY
+  delete process.env.GITHUB_ENTERPRISE_URL
   delete process.env.GITHUB_TOKEN
   delete process.env.GH_TOKEN
   delete process.env.CLAUDE_CODE_USE_OPENAI
@@ -192,6 +196,8 @@ afterEach(() => {
     restoreEnv('OPENAI_AUTH_SCHEME', originalEnv.OPENAI_AUTH_SCHEME)
     restoreEnv('OPENAI_AUTH_HEADER_VALUE', originalEnv.OPENAI_AUTH_HEADER_VALUE)
     restoreEnv('CLAUDE_CODE_USE_GITHUB', originalEnv.CLAUDE_CODE_USE_GITHUB)
+    restoreEnv('GITHUB_COPILOT_KEY', originalEnv.GITHUB_COPILOT_KEY)
+    restoreEnv('GITHUB_ENTERPRISE_URL', originalEnv.GITHUB_ENTERPRISE_URL)
     restoreEnv('GITHUB_TOKEN', originalEnv.GITHUB_TOKEN)
     restoreEnv('GH_TOKEN', originalEnv.GH_TOKEN)
     restoreEnv('CLAUDE_CODE_USE_OPENAI', originalEnv.CLAUDE_CODE_USE_OPENAI)
@@ -1003,6 +1009,35 @@ test('strips Anthropic-specific headers on GitHub Codex transport requests', asy
   expect(capturedHeaders?.get('x-safe-header')).toBe('keep-me')
   expect(capturedHeaders?.get('authorization')).toBe('Bearer github-test-key')
   expect(capturedHeaders?.get('editor-plugin-version')).toBe('copilot-chat/0.26.7')
+})
+
+test('uses direct GitHub Copilot Enterprise key for shim authentication', async () => {
+  process.env.CLAUDE_CODE_USE_GITHUB = '1'
+  process.env.GITHUB_COPILOT_KEY = 'enterprise-direct-key'
+  process.env.GITHUB_ENTERPRISE_URL = 'https://github.mycompany.com'
+  delete process.env.OPENAI_API_KEY
+  delete process.env.OPENAI_BASE_URL
+
+  const { authorization, url } = await captureChatCompletionRequest(
+    'github:gpt-4o',
+  )
+
+  expect(authorization).toBe('Bearer enterprise-direct-key')
+  expect(url).toBe('https://github.mycompany.com/api/copilot/chat/completions')
+})
+
+test('direct GitHub Copilot key wins over stale OpenAI key', async () => {
+  process.env.CLAUDE_CODE_USE_GITHUB = '1'
+  process.env.GITHUB_COPILOT_KEY = 'enterprise-direct-key'
+  process.env.GITHUB_ENTERPRISE_URL = 'https://github.mycompany.com'
+  process.env.OPENAI_API_KEY = 'stale-openai-key'
+  delete process.env.OPENAI_BASE_URL
+
+  const { authorization } = await captureChatCompletionRequest(
+    'github:gpt-4o',
+  )
+
+  expect(authorization).toBe('Bearer enterprise-direct-key')
 })
 
 test('strips Anthropic-specific headers on GitHub Codex transport with providerOverride API key', async () => {

--- a/src/services/api/openaiShim.test.ts
+++ b/src/services/api/openaiShim.test.ts
@@ -969,6 +969,8 @@ test('strips Anthropic-specific headers on GitHub Codex transport requests', asy
 
   process.env.CLAUDE_CODE_USE_GITHUB = '1'
   process.env.OPENAI_API_KEY = 'github-test-key'
+  process.env.GITHUB_TOKEN = 'stored-secret'
+  delete process.env.GITHUB_COPILOT_KEY
   delete process.env.OPENAI_BASE_URL
   delete process.env.OPENAI_MODEL
 

--- a/src/services/api/openaiShim.ts
+++ b/src/services/api/openaiShim.ts
@@ -508,9 +508,9 @@ function hydrateOpenAIShimCompatibilityEnv(
   if (isEnvTruthy(processEnv.CLAUDE_CODE_USE_GITHUB)) {
     processEnv.OPENAI_API_KEY =
       processEnv.GITHUB_COPILOT_KEY ??
+      processEnv.OPENAI_API_KEY ??
       processEnv.GITHUB_TOKEN ??
       processEnv.GH_TOKEN ??
-      processEnv.OPENAI_API_KEY ??
       ''
     return
   }

--- a/src/services/api/openaiShim.ts
+++ b/src/services/api/openaiShim.ts
@@ -506,8 +506,12 @@ function hydrateOpenAIShimCompatibilityEnv(
   }
 
   if (isEnvTruthy(processEnv.CLAUDE_CODE_USE_GITHUB)) {
-    processEnv.OPENAI_API_KEY ??=
-      processEnv.GITHUB_TOKEN ?? processEnv.GH_TOKEN ?? ''
+    processEnv.OPENAI_API_KEY =
+      processEnv.GITHUB_COPILOT_KEY ??
+      processEnv.GITHUB_TOKEN ??
+      processEnv.GH_TOKEN ??
+      processEnv.OPENAI_API_KEY ??
+      ''
     return
   }
 
@@ -2455,7 +2459,7 @@ class OpenAIShimMessages {
     const isLocal = isLocalProviderUrl(request.baseUrl)
 
     const githubEndpointType = getGithubEndpointType(request.baseUrl)
-    const isGithubCopilot = isGithub && githubEndpointType === 'copilot'
+    const isGithubCopilot = isGithub && (githubEndpointType === 'copilot' || githubEndpointType === 'ghe')
     const isGithubModels = isGithub && (githubEndpointType === 'models' || githubEndpointType === 'custom')
     const shouldStripResponsesStore =
       (shimConfig.removeBodyFields ?? []).includes('store') ||

--- a/src/services/api/providerConfig.github.test.ts
+++ b/src/services/api/providerConfig.github.test.ts
@@ -14,6 +14,7 @@ const ENV_KEYS = [
   'OPENAI_BASE_URL',
   'OPENAI_API_BASE',
   'OPENAI_API_FORMAT',
+  'GITHUB_ENTERPRISE_URL',
 ] as const
 
 const originalEnv: Record<string, string | undefined> = {}
@@ -45,6 +46,7 @@ test.each([
   ['github:copilot', DEFAULT_GITHUB_MODELS_API_MODEL],
   ['', DEFAULT_GITHUB_MODELS_API_MODEL],
   ['github:gpt-4o', 'gpt-4o'],
+  ['github:copilot:gpt-5.3-codex', 'gpt-5.3-codex'],
   ['gpt-4o', 'gpt-4o'],
   ['github:copilot?reasoning=high', DEFAULT_GITHUB_MODELS_API_MODEL],
   // normalizeGithubModelsApiModel preserves provider prefix for models.github.ai compatibility
@@ -73,6 +75,47 @@ test('resolveProviderRequest keeps gpt-5-mini on chat_completions for GitHub', (
   const r = resolveProviderRequest({ model: 'gpt-5-mini' })
   expect(r.resolvedModel).toBe('gpt-5-mini')
   expect(r.transport).toBe('chat_completions')
+})
+
+test('resolveProviderRequest routes GitHub Enterprise to Enterprise Copilot API', () => {
+  process.env.CLAUDE_CODE_USE_GITHUB = '1'
+  process.env.GITHUB_ENTERPRISE_URL = 'https://github.mycompany.com/'
+
+  const r = resolveProviderRequest({ model: 'github:copilot:gpt-5.3-codex' })
+
+  expect(r.baseUrl).toBe('https://github.mycompany.com/api/copilot')
+  expect(r.resolvedModel).toBe('gpt-5.3-codex')
+  expect(r.transport).toBe('codex_responses')
+})
+
+test('resolveProviderRequest uses injected Enterprise env for endpoint detection', () => {
+  const r = resolveProviderRequest({
+    model: 'github:copilot:gpt-5.3-codex',
+    processEnv: {
+      CLAUDE_CODE_USE_GITHUB: '1',
+      GITHUB_ENTERPRISE_URL: 'https://github.mycompany.com',
+      OPENAI_BASE_URL: 'https://github.mycompany.com/api/copilot',
+    },
+  })
+
+  expect(r.baseUrl).toBe('https://github.mycompany.com/api/copilot')
+  expect(r.resolvedModel).toBe('gpt-5.3-codex')
+  expect(r.transport).toBe('codex_responses')
+})
+
+test('resolveProviderRequest expands Enterprise origin base URL to Copilot API path', () => {
+  const r = resolveProviderRequest({
+    model: 'github:copilot:gpt-5.3-codex',
+    processEnv: {
+      CLAUDE_CODE_USE_GITHUB: '1',
+      GITHUB_ENTERPRISE_URL: 'https://github.mycompany.com',
+      OPENAI_BASE_URL: 'https://github.mycompany.com',
+    },
+  })
+
+  expect(r.baseUrl).toBe('https://github.mycompany.com/api/copilot')
+  expect(r.resolvedModel).toBe('gpt-5.3-codex')
+  expect(r.transport).toBe('codex_responses')
 })
 
 test('resolveProviderRequest leaves model unchanged without GitHub flag', () => {

--- a/src/services/api/providerConfig.ts
+++ b/src/services/api/providerConfig.ts
@@ -556,14 +556,28 @@ export function isCodexBaseUrl(baseUrl: string | undefined): boolean {
   }
 }
 
+function normalizeGithubModelSegment(requestedModel: string): string {
+  const noQuery = requestedModel.split('?', 1)[0] ?? requestedModel
+  const trimmed = noQuery.trim()
+  const lower = trimmed.toLowerCase()
+  if (lower.startsWith('github:copilot:')) {
+    return trimmed.slice('github:copilot:'.length).trim()
+  }
+  if (lower.startsWith('github:')) {
+    return trimmed.slice('github:'.length).trim()
+  }
+  if (lower.startsWith('copilot:')) {
+    return trimmed.slice('copilot:'.length).trim()
+  }
+  return trimmed
+}
+
 /**
  * Normalize user model string for GitHub Copilot API inference.
  * Mirrors how Copilot resolves model IDs internally.
  */
 export function normalizeGithubCopilotModel(requestedModel: string): string {
-  const noQuery = requestedModel.split('?', 1)[0] ?? requestedModel
-  const segment =
-    noQuery.includes(':') ? noQuery.split(':', 2)[1]!.trim() : noQuery.trim()
+  const segment = normalizeGithubModelSegment(requestedModel)
   if (!segment || segment.toLowerCase() === 'copilot') {
     return DEFAULT_GITHUB_MODELS_API_MODEL
   }
@@ -580,9 +594,7 @@ export function normalizeGithubCopilotModel(requestedModel: string): string {
  * Only normalizes the default alias, preserves provider-qualified models.
  */
 export function normalizeGithubModelsApiModel(requestedModel: string): string {
-  const noQuery = requestedModel.split('?', 1)[0] ?? requestedModel
-  const segment =
-    noQuery.includes(':') ? noQuery.split(':', 2)[1]!.trim() : noQuery.trim()
+  const segment = normalizeGithubModelSegment(requestedModel)
   // Only normalize the default alias for GitHub Models
   if (!segment || segment.toLowerCase() === 'copilot') {
     return DEFAULT_GITHUB_MODELS_API_MODEL
@@ -594,9 +606,18 @@ export function normalizeGithubModelsApiModel(requestedModel: string): string {
 export const GITHUB_COPILOT_BASE_URL = 'https://api.githubcopilot.com'
 export const GITHUB_MODELS_BASE_URL = 'https://models.github.ai/inference'
 
+/**
+ * Returns the GitHub endpoint type for a given base URL.
+ *
+ * - 'copilot': standard GitHub Copilot API (api.githubcopilot.com)
+ * - 'models': GitHub Models API (models.github.ai)
+ * - 'ghe': GitHub Enterprise Server instance (*.ghe.com or custom GHE URL)
+ * - 'custom': any other custom URL
+ */
 export function getGithubEndpointType(
   baseUrl: string | undefined,
-): 'copilot' | 'models' | 'custom' {
+  options?: { githubEnterpriseUrl?: string },
+): 'copilot' | 'models' | 'ghe' | 'custom' {
   if (!baseUrl) return 'copilot'
   try {
     const hostname = new URL(baseUrl).hostname.toLowerCase()
@@ -606,9 +627,75 @@ export function getGithubEndpointType(
     if (hostname === 'models.github.ai' || hostname.endsWith('.github.ai')) {
       return 'models'
     }
+    // Detect GitHub Enterprise Server instances:
+    // - *.ghe.com (GitHub's hosted GHE domains)
+    // - *.github.com (but not api.github.com or models.github.ai)
+    // - Any host when GITHUB_ENTERPRISE_URL is set
+    if (
+      hostname.endsWith('.ghe.com') ||
+      (hostname.endsWith('.github.com') &&
+        hostname !== 'api.github.com' &&
+        hostname !== 'models.github.com')
+    ) {
+      return 'ghe'
+    }
+    // Check if GITHUB_ENTERPRISE_URL env var points to this host
+    const gheUrl = options?.githubEnterpriseUrl ?? process.env.GITHUB_ENTERPRISE_URL
+    if (gheUrl) {
+      try {
+        const gheHostname = new URL(gheUrl).hostname.toLowerCase()
+        if (hostname === gheHostname) {
+          return 'ghe'
+        }
+      } catch {
+        // Ignore invalid GITHUB_ENTERPRISE_URL
+      }
+    }
     return 'custom'
   } catch {
     return 'copilot'
+  }
+}
+
+/**
+ * Get the GitHub Enterprise URL from environment or base URL.
+ * Returns undefined if not in GHE mode.
+ */
+export function getGithubEnterpriseUrl(
+  baseUrl?: string,
+): string | undefined {
+  // Explicit env var takes precedence
+  const envUrl = process.env.GITHUB_ENTERPRISE_URL?.trim()
+  if (envUrl) return envUrl
+
+  // If base URL indicates GHE, derive the enterprise URL from it
+  if (baseUrl) {
+    const endpointType = getGithubEndpointType(baseUrl)
+    if (endpointType === 'ghe') {
+      try {
+        const parsed = new URL(baseUrl)
+        return parsed.origin
+      } catch {
+        // Ignore invalid URL
+      }
+    }
+  }
+
+  return undefined
+}
+
+/**
+ * Build the Copilot API base URL for a GitHub Enterprise instance.
+ * For GHE, the Copilot API is at {ghe_url}/api/copilot
+ */
+export function buildGithubEnterpriseCopilotBaseUrl(
+  gheUrl: string,
+): string {
+  try {
+    return `${new URL(gheUrl.trim()).origin}/api/copilot`
+  } catch {
+    const normalized = gheUrl.replace(/\/+$/, '')
+    return `${normalized}/api/copilot`
   }
 }
 
@@ -676,7 +763,11 @@ export function resolveProviderRequest(options?: {
 
   const isCodexModelForGithub = isGithubMode && isCodexAlias(requestedModel)
   const envBaseUrl =
-    isCodexModelForGithub && envBaseUrlRaw && getGithubEndpointType(envBaseUrlRaw) === 'custom'
+    isCodexModelForGithub &&
+    envBaseUrlRaw &&
+    getGithubEndpointType(envBaseUrlRaw, {
+      githubEnterpriseUrl: processEnv.GITHUB_ENTERPRISE_URL,
+    }) === 'custom'
       ? undefined
       : envBaseUrlRaw
 
@@ -700,16 +791,26 @@ export function resolveProviderRequest(options?: {
       : rawBaseUrl
   const finalBaseUrl = normalizeGitlawbOpengatewayBaseUrl(finalBaseUrlRaw)
 
+  const gheUrl = processEnv.GITHUB_ENTERPRISE_URL?.trim()
   const githubEndpointType = isGithubMode
-    ? getGithubEndpointType(rawBaseUrl)
+    ? (gheUrl && !rawBaseUrl
+      ? 'ghe'
+      : getGithubEndpointType(rawBaseUrl, { githubEnterpriseUrl: gheUrl }))
     : 'custom'
   const isGithubCopilot = isGithubMode && githubEndpointType === 'copilot'
   const isGithubModels = isGithubMode && githubEndpointType === 'models'
+  const isGithubGhe = isGithubMode && githubEndpointType === 'ghe'
   const isGithubCustom = isGithubMode && githubEndpointType === 'custom'
+  const isGithubCopilotLike = isGithubCopilot || isGithubGhe
 
   const githubResolvedModel = isGithubMode
     ? normalizeGithubModelsApiModel(requestedModel)
     : requestedModel
+
+  // For GHE instances, build the Copilot API base URL from GITHUB_ENTERPRISE_URL
+  const gheCopilotBaseUrl = gheUrl
+    ? buildGithubEnterpriseCopilotBaseUrl(gheUrl)
+    : undefined
 
   const requestedApiFormat =
     isGithubMode
@@ -734,7 +835,7 @@ export function resolveProviderRequest(options?: {
     })()
   const transport: ProviderTransport =
     shouldUseCodexTransport(requestedModel, finalBaseUrl) ||
-      (isGithubCopilot && shouldUseGithubResponsesApi(githubResolvedModel))
+      (isGithubCopilotLike && shouldUseGithubResponsesApi(githubResolvedModel))
       ? 'codex_responses'
       : (requestedApiFormat === 'responses' || requestedApiFormat === 'responses_compat') && supportsRequestedApiFormat
         ? requestedApiFormat
@@ -744,9 +845,9 @@ export function resolveProviderRequest(options?: {
   // For GitHub Models/custom endpoints:
   //   - Normalize default alias (github:copilot -> gpt-4o)
   //   - Preserve provider-qualified models (openai/gpt-4.1 stays as-is)
-  const resolvedModel = isGithubCopilot
+  const resolvedModel = isGithubCopilotLike
     ? normalizeGithubCopilotModel(descriptor.baseModel)
-    : (isGithubModels || isGithubCustom
+    : (isGithubModels || isGithubCustom || isGithubGhe
       ? normalizeGithubModelsApiModel(descriptor.baseModel)
       : descriptor.baseModel)
 
@@ -759,12 +860,16 @@ export function resolveProviderRequest(options?: {
     requestedModel,
     resolvedModel,
     baseUrl:
-      (finalBaseUrl ??
-        (isGithubCopilot && transport === 'codex_responses'
-          ? GITHUB_COPILOT_BASE_URL
-          : (isGithubMode
+      // For GHE instances, use the GHE Copilot API URL even when a profile
+      // stores the Enterprise origin as OPENAI_BASE_URL.
+      ((isGithubGhe && gheCopilotBaseUrl
+        ? gheCopilotBaseUrl
+        : (finalBaseUrl ??
+          (isGithubCopilot && transport === 'codex_responses'
             ? GITHUB_COPILOT_BASE_URL
-            : DEFAULT_OPENAI_BASE_URL))
+            : (isGithubMode
+              ? GITHUB_COPILOT_BASE_URL
+              : DEFAULT_OPENAI_BASE_URL))))
       ).replace(/\/+$/, ''),
     reasoning,
   }

--- a/src/services/api/providerConfig.ts
+++ b/src/services/api/providerConfig.ts
@@ -33,6 +33,14 @@ export const DEFAULT_OPENCODE_GO_BASE_URL = 'https://opencode.ai/zen/go/v1'
 export const DEFAULT_GITHUB_MODELS_API_MODEL = 'gpt-4o'
 const warnedUndefinedEnvNames = new Set<string>()
 
+function asGithubEnterpriseEnvUrl(value: string | undefined): string | undefined {
+  const trimmed = value?.trim()
+  if (!trimmed || trimmed.toLowerCase() === 'undefined') {
+    return undefined
+  }
+  return trimmed
+}
+
 function normalizeGitlawbOpengatewayBaseUrl(baseUrl: string | undefined): string | undefined {
   if (!baseUrl) return undefined
   try {
@@ -665,7 +673,7 @@ export function getGithubEnterpriseUrl(
   baseUrl?: string,
 ): string | undefined {
   // Explicit env var takes precedence
-  const envUrl = process.env.GITHUB_ENTERPRISE_URL?.trim()
+  const envUrl = asGithubEnterpriseEnvUrl(process.env.GITHUB_ENTERPRISE_URL)
   if (envUrl) return envUrl
 
   // If base URL indicates GHE, derive the enterprise URL from it
@@ -761,12 +769,15 @@ export function resolveProviderRequest(options?: {
     primaryEnvBaseUrl ??
     fallbackEnvBaseUrl
 
+  const githubEnterpriseEnvUrl = asGithubEnterpriseEnvUrl(
+    processEnv.GITHUB_ENTERPRISE_URL,
+  )
   const isCodexModelForGithub = isGithubMode && isCodexAlias(requestedModel)
   const envBaseUrl =
     isCodexModelForGithub &&
     envBaseUrlRaw &&
     getGithubEndpointType(envBaseUrlRaw, {
-      githubEnterpriseUrl: processEnv.GITHUB_ENTERPRISE_URL,
+      githubEnterpriseUrl: githubEnterpriseEnvUrl,
     }) === 'custom'
       ? undefined
       : envBaseUrlRaw
@@ -791,7 +802,7 @@ export function resolveProviderRequest(options?: {
       : rawBaseUrl
   const finalBaseUrl = normalizeGitlawbOpengatewayBaseUrl(finalBaseUrlRaw)
 
-  const gheUrl = processEnv.GITHUB_ENTERPRISE_URL?.trim()
+  const gheUrl = githubEnterpriseEnvUrl
   const githubEndpointType = isGithubMode
     ? (gheUrl && !rawBaseUrl
       ? 'ghe'

--- a/src/services/github/deviceFlow.test.ts
+++ b/src/services/github/deviceFlow.test.ts
@@ -79,6 +79,34 @@ describe('requestDeviceCode', () => {
     expect(r.interval).toBe(5)
   })
 
+  test('uses normalized Enterprise endpoint when gheUrl is provided', async () => {
+    const { requestDeviceCode } = await importFreshModule()
+    let capturedUrl = ''
+    const fetchImpl = mock((url: RequestInfo | URL) => {
+      capturedUrl = String(url)
+      return Promise.resolve(
+        new Response(
+          JSON.stringify({
+            device_code: 'abc',
+            user_code: 'ABCD-1234',
+            verification_uri: 'https://github.mycompany.com/login/device',
+          }),
+          { status: 200 },
+        ),
+      )
+    })
+
+    await requestDeviceCode({
+      clientId: 'test-client',
+      fetchImpl,
+      gheUrl: 'https://github.mycompany.com/api/copilot/',
+    })
+
+    expect(capturedUrl).toBe(
+      'https://github.mycompany.com/login/device/code',
+    )
+  })
+
   test('throws on HTTP error', async () => {
     const { requestDeviceCode, GitHubDeviceFlowError } =
       await importFreshModule()

--- a/src/services/github/deviceFlow.test.ts
+++ b/src/services/github/deviceFlow.test.ts
@@ -28,6 +28,27 @@ afterEach(() => {
   }
 })
 
+describe('GitHub Enterprise auth endpoints', () => {
+  test('normalize path-bearing Enterprise URLs to the instance origin', async () => {
+    const {
+      getGithubEnterpriseAccessTokenUrl,
+      getGithubEnterpriseCopilotTokenUrl,
+      getGithubEnterpriseDeviceCodeUrl,
+    } = await importFreshModule()
+    const gheUrl = 'https://github.mycompany.com/api/copilot/'
+
+    expect(getGithubEnterpriseDeviceCodeUrl(gheUrl)).toBe(
+      'https://github.mycompany.com/login/device/code',
+    )
+    expect(getGithubEnterpriseAccessTokenUrl(gheUrl)).toBe(
+      'https://github.mycompany.com/login/oauth/access_token',
+    )
+    expect(getGithubEnterpriseCopilotTokenUrl(gheUrl)).toBe(
+      'https://github.mycompany.com/api/copilot_internal/v2/token',
+    )
+  })
+})
+
 describe('requestDeviceCode', () => {
   test('parses successful device code response', async () => {
     const { requestDeviceCode } = await importFreshModule()

--- a/src/services/github/deviceFlow.ts
+++ b/src/services/github/deviceFlow.ts
@@ -30,16 +30,27 @@ export const COPILOT_HEADERS: Record<string, string> = {
  * Build auth endpoint URLs for GitHub Enterprise Server.
  * GHE instances host OAuth endpoints at {ghe_url}/login/...
  */
+export function normalizeGithubEnterpriseAuthBaseUrl(
+  gheUrl: string,
+): string {
+  const trimmed = gheUrl.trim()
+  try {
+    return new URL(trimmed).origin
+  } catch {
+    return trimmed.replace(/\/+$/, '')
+  }
+}
+
 export function getGithubEnterpriseDeviceCodeUrl(gheUrl: string): string {
-  return `${gheUrl.replace(/\/+$/, '')}/login/device/code`
+  return `${normalizeGithubEnterpriseAuthBaseUrl(gheUrl)}/login/device/code`
 }
 
 export function getGithubEnterpriseAccessTokenUrl(gheUrl: string): string {
-  return `${gheUrl.replace(/\/+$/, '')}/login/oauth/access_token`
+  return `${normalizeGithubEnterpriseAuthBaseUrl(gheUrl)}/login/oauth/access_token`
 }
 
 export function getGithubEnterpriseCopilotTokenUrl(gheUrl: string): string {
-  return `${gheUrl.replace(/\/+$/, '')}/api/copilot_internal/v2/token`
+  return `${normalizeGithubEnterpriseAuthBaseUrl(gheUrl)}/api/copilot_internal/v2/token`
 }
 
 /**
@@ -48,7 +59,7 @@ export function getGithubEnterpriseCopilotTokenUrl(gheUrl: string): string {
  */
 export function getEffectiveGithubAuthBaseUrl(): string | undefined {
   const gheUrl = process.env.GITHUB_ENTERPRISE_URL?.trim()
-  return gheUrl || undefined
+  return gheUrl ? normalizeGithubEnterpriseAuthBaseUrl(gheUrl) : undefined
 }
 
 export type CopilotTokenResponse = {

--- a/src/services/github/deviceFlow.ts
+++ b/src/services/github/deviceFlow.ts
@@ -1,6 +1,10 @@
 /**
  * GitHub OAuth device flow for CLI login (https://docs.github.com/en/apps/oauth-apps/building-oauth-apps/authorizing-oauth-apps#device-flow).
  * Uses GitHub Copilot's official OAuth app for device authentication.
+ *
+ * Supports GitHub Enterprise Server (GHE) instances via GITHUB_ENTERPRISE_URL.
+ * When GITHUB_ENTERPRISE_URL is set, auth endpoints are routed through the
+ * GHE instance instead of github.com.
  */
 
 import { execFileNoThrow } from '../../utils/execFileNoThrow.js'
@@ -20,6 +24,31 @@ export const COPILOT_HEADERS: Record<string, string> = {
   'Editor-Version': 'vscode/1.99.3',
   'Editor-Plugin-Version': 'copilot-chat/0.26.7',
   'Copilot-Integration-Id': 'vscode-chat',
+}
+
+/**
+ * Build auth endpoint URLs for GitHub Enterprise Server.
+ * GHE instances host OAuth endpoints at {ghe_url}/login/...
+ */
+export function getGithubEnterpriseDeviceCodeUrl(gheUrl: string): string {
+  return `${gheUrl.replace(/\/+$/, '')}/login/device/code`
+}
+
+export function getGithubEnterpriseAccessTokenUrl(gheUrl: string): string {
+  return `${gheUrl.replace(/\/+$/, '')}/login/oauth/access_token`
+}
+
+export function getGithubEnterpriseCopilotTokenUrl(gheUrl: string): string {
+  return `${gheUrl.replace(/\/+$/, '')}/api/copilot_internal/v2/token`
+}
+
+/**
+ * Get the effective GitHub base URL for auth operations.
+ * Returns the GHE URL if GITHUB_ENTERPRISE_URL is set, otherwise undefined.
+ */
+export function getEffectiveGithubAuthBaseUrl(): string | undefined {
+  const gheUrl = process.env.GITHUB_ENTERPRISE_URL?.trim()
+  return gheUrl || undefined
 }
 
 export type CopilotTokenResponse = {
@@ -63,6 +92,7 @@ export async function requestDeviceCode(options?: {
   clientId?: string
   scope?: string
   fetchImpl?: FetchLike
+  gheUrl?: string
 }): Promise<DeviceCodeResult> {
   const clientId = options?.clientId ?? getGithubDeviceFlowClientId()
   if (!clientId) {
@@ -78,10 +108,15 @@ export async function requestDeviceCode(options?: {
       ? [requestedScope]
       : [requestedScope, DEFAULT_GITHUB_DEVICE_SCOPE]
 
+  // Use GHE endpoint if GHE URL is provided
+  const deviceCodeUrl = options?.gheUrl
+    ? getGithubEnterpriseDeviceCodeUrl(options.gheUrl)
+    : GITHUB_DEVICE_CODE_URL
+
   let lastError = 'Device code request failed.'
 
   for (const scope of scopesToTry) {
-    const res = await fetchFn(GITHUB_DEVICE_CODE_URL, {
+    const res = await fetchFn(deviceCodeUrl, {
       method: 'POST',
       headers: { Accept: 'application/json' },
       body: new URLSearchParams({
@@ -133,6 +168,7 @@ export type PollOptions = {
   initialInterval?: number
   timeoutSeconds?: number
   fetchImpl?: FetchLike
+  gheUrl?: string
 }
 
 export async function pollAccessToken(
@@ -148,8 +184,13 @@ export async function pollAccessToken(
   const fetchFn = options?.fetchImpl ?? fetch
   const start = Date.now()
 
+  // Use GHE endpoint if GHE URL is provided
+  const accessTokenUrl = options?.gheUrl
+    ? getGithubEnterpriseAccessTokenUrl(options.gheUrl)
+    : GITHUB_DEVICE_ACCESS_TOKEN_URL
+
   while ((Date.now() - start) / 1000 < timeoutSeconds) {
-    const res = await fetchFn(GITHUB_DEVICE_ACCESS_TOKEN_URL, {
+    const res = await fetchFn(accessTokenUrl, {
       method: 'POST',
       headers: { Accept: 'application/json' },
       body: new URLSearchParams({
@@ -219,13 +260,22 @@ export async function openVerificationUri(uri: string): Promise<void> {
 /**
  * Exchange an OAuth access token for a Copilot API token.
  * The OAuth token alone cannot be used with the Copilot API endpoint.
+ *
+ * For GHE instances, the token exchange endpoint is at {ghe_url}/api/copilot_internal/v2/token
  */
 export async function exchangeForCopilotToken(
   oauthToken: string,
   fetchImpl?: FetchLike,
+  gheUrl?: string,
 ): Promise<CopilotTokenResponse> {
   const fetchFn = fetchImpl ?? fetch
-  const res = await fetchFn(COPILOT_TOKEN_URL, {
+
+  // Use GHE endpoint if provided
+  const copilotTokenUrl = gheUrl
+    ? getGithubEnterpriseCopilotTokenUrl(gheUrl)
+    : COPILOT_TOKEN_URL
+
+  const res = await fetchFn(copilotTokenUrl, {
     method: 'GET',
     headers: {
       Accept: 'application/json',

--- a/src/utils/githubModelsCredentials.hydrate.test.ts
+++ b/src/utils/githubModelsCredentials.hydrate.test.ts
@@ -27,6 +27,7 @@ function getEnvValue(name: string): string | undefined {
 describe('hydrateGithubModelsTokenFromSecureStorage', () => {
   const orig = {
     CLAUDE_CODE_USE_GITHUB: process.env.CLAUDE_CODE_USE_GITHUB,
+    GITHUB_COPILOT_KEY: process.env.GITHUB_COPILOT_KEY,
     GITHUB_TOKEN: process.env.GITHUB_TOKEN,
     GH_TOKEN: process.env.GH_TOKEN,
     CLAUDE_CODE_GITHUB_TOKEN_HYDRATED:
@@ -71,6 +72,32 @@ describe('hydrateGithubModelsTokenFromSecureStorage', () => {
       await importFreshGithubModelsCredentials('hydrate=sets-token')
     hydrateGithubModelsTokenFromSecureStorage()
     expect(getEnvValue('GITHUB_TOKEN')).toBe('stored-secret')
+    expect(getEnvValue('CLAUDE_CODE_GITHUB_TOKEN_HYDRATED')).toBe('1')
+  })
+
+  test('sets GITHUB_COPILOT_KEY when secure storage contains a direct Copilot key', async () => {
+    process.env.CLAUDE_CODE_USE_GITHUB = '1'
+    process.env.GITHUB_TOKEN = 'shell-token'
+    delete process.env.GITHUB_COPILOT_KEY
+    delete process.env.GH_TOKEN
+    delete process.env.CLAUDE_CODE_SIMPLE
+
+    mock.module('./secureStorage/index.js', () => ({
+      getSecureStorage: () => ({
+        read: () => ({
+          githubModels: {
+            accessToken: 'stored-enterprise-key',
+            credentialType: 'copilot_key',
+          },
+        }),
+      }),
+    }))
+
+    const { hydrateGithubModelsTokenFromSecureStorage } =
+      await importFreshGithubModelsCredentials('hydrate=sets-copilot-key')
+    hydrateGithubModelsTokenFromSecureStorage()
+    expect(getEnvValue('GITHUB_COPILOT_KEY')).toBe('stored-enterprise-key')
+    expect(getEnvValue('GITHUB_TOKEN')).toBe('shell-token')
     expect(getEnvValue('CLAUDE_CODE_GITHUB_TOKEN_HYDRATED')).toBe('1')
   })
 

--- a/src/utils/githubModelsCredentials.ts
+++ b/src/utils/githubModelsCredentials.ts
@@ -10,6 +10,7 @@ export const GITHUB_MODELS_HYDRATED_ENV_MARKER =
 export type GithubModelsCredentialBlob = {
   accessToken: string
   oauthAccessToken?: string
+  credentialType?: 'copilot_token' | 'copilot_key'
 }
 
 type GithubTokenStatus = 'valid' | 'expired' | 'invalid_format'
@@ -44,13 +45,23 @@ function checkGithubTokenStatus(token: string): GithubTokenStatus {
 }
 
 export function readGithubModelsToken(): string | undefined {
+  return readGithubModelsCredentialBlob()?.accessToken
+}
+
+function readGithubModelsCredentialBlob(): GithubModelsCredentialBlob | undefined {
   if (isBareMode()) return undefined
   try {
     const data = getSecureStorage().read() as
       | ({ githubModels?: GithubModelsCredentialBlob } & Record<string, unknown>)
       | null
-    const t = data?.githubModels?.accessToken?.trim()
-    return t || undefined
+    const blob = data?.githubModels
+    const accessToken = blob?.accessToken?.trim()
+    if (!accessToken) return undefined
+    return {
+      ...blob,
+      accessToken,
+      oauthAccessToken: blob?.oauthAccessToken?.trim() || undefined,
+    }
   } catch {
     return undefined
   }
@@ -78,6 +89,20 @@ export function hydrateGithubModelsTokenFromSecureStorage(): void {
     delete process.env[GITHUB_MODELS_HYDRATED_ENV_MARKER]
     return
   }
+  if (process.env.GITHUB_COPILOT_KEY?.trim()) {
+    delete process.env[GITHUB_MODELS_HYDRATED_ENV_MARKER]
+    return
+  }
+  if (isBareMode()) {
+    delete process.env[GITHUB_MODELS_HYDRATED_ENV_MARKER]
+    return
+  }
+  const stored = readGithubModelsCredentialBlob()
+  if (stored?.credentialType === 'copilot_key') {
+    process.env.GITHUB_COPILOT_KEY = stored.accessToken
+    process.env[GITHUB_MODELS_HYDRATED_ENV_MARKER] = '1'
+    return
+  }
   if (process.env.GH_TOKEN?.trim()) {
     delete process.env[GITHUB_MODELS_HYDRATED_ENV_MARKER]
     return
@@ -86,13 +111,8 @@ export function hydrateGithubModelsTokenFromSecureStorage(): void {
     delete process.env[GITHUB_MODELS_HYDRATED_ENV_MARKER]
     return
   }
-  if (isBareMode()) {
-    delete process.env[GITHUB_MODELS_HYDRATED_ENV_MARKER]
-    return
-  }
-  const t = readGithubModelsToken()
-  if (t) {
-    process.env.GITHUB_TOKEN = t
+  if (stored?.accessToken) {
+    process.env.GITHUB_TOKEN = stored.accessToken
     process.env[GITHUB_MODELS_HYDRATED_ENV_MARKER] = '1'
     return
   }
@@ -104,12 +124,19 @@ export function hydrateGithubModelsTokenFromSecureStorage(): void {
  *
  * If a stored Copilot token is expired/invalid and an OAuth token is present,
  * exchange the OAuth token for a fresh Copilot token and persist it.
+ *
+ * For GHE instances, the token exchange is routed through the GHE endpoint.
  */
 export async function refreshGithubModelsTokenIfNeeded(): Promise<boolean> {
   if (!isEnvTruthy(process.env.CLAUDE_CODE_USE_GITHUB)) {
     return false
   }
   if (isBareMode()) {
+    return false
+  }
+
+  // GITHUB_COPILOT_KEY is a direct API key, no refresh needed
+  if (process.env.GITHUB_COPILOT_KEY?.trim()) {
     return false
   }
 
@@ -121,6 +148,13 @@ export async function refreshGithubModelsTokenIfNeeded(): Promise<boolean> {
     const blob = data?.githubModels
     const accessToken = blob?.accessToken?.trim() || ''
     const oauthToken = blob?.oauthAccessToken?.trim() || ''
+
+    if (blob?.credentialType === 'copilot_key') {
+      if (accessToken && !process.env.GITHUB_COPILOT_KEY?.trim()) {
+        process.env.GITHUB_COPILOT_KEY = accessToken
+      }
+      return false
+    }
 
     if (!accessToken && !oauthToken) {
       return false
@@ -138,7 +172,10 @@ export async function refreshGithubModelsTokenIfNeeded(): Promise<boolean> {
       return false
     }
 
-    const refreshed = await exchangeForCopilotToken(oauthToken)
+    // Get GHE URL for token exchange if in enterprise mode
+    const gheUrl = process.env.GITHUB_ENTERPRISE_URL?.trim() || undefined
+
+    const refreshed = await exchangeForCopilotToken(oauthToken, undefined, gheUrl)
     const saved = saveGithubModelsToken(refreshed.token, oauthToken)
     if (!saved.success) {
       return false
@@ -154,6 +191,7 @@ export async function refreshGithubModelsTokenIfNeeded(): Promise<boolean> {
 export function saveGithubModelsToken(
   token: string,
   oauthToken?: string,
+  options?: { credentialType?: GithubModelsCredentialBlob['credentialType'] },
 ): {
   success: boolean
   warning?: string
@@ -173,6 +211,7 @@ export function saveGithubModelsToken(
   const oauthTrimmed = oauthToken?.trim()
   const mergedBlob: GithubModelsCredentialBlob = {
     accessToken: trimmed,
+    credentialType: options?.credentialType ?? 'copilot_token',
   }
   if (oauthTrimmed) {
     mergedBlob.oauthAccessToken = oauthTrimmed

--- a/src/utils/providerProfile.test.ts
+++ b/src/utils/providerProfile.test.ts
@@ -172,6 +172,39 @@ test('openai launch omits api key when no key is resolved', async () => {
   assert.equal(Object.hasOwn(env, 'OPENAI_API_KEY'), false)
 })
 
+test('github-enterprise launch does not derive Enterprise URL from public Copilot default', async () => {
+  const env = await buildLaunchEnv({
+    profile: 'github-enterprise',
+    persisted: profile('github-enterprise', {
+      OPENAI_BASE_URL: 'https://api.githubcopilot.com',
+      OPENAI_MODEL: 'github:copilot:gpt-5.3-codex',
+    }),
+    goal: 'coding',
+    processEnv: {},
+  })
+
+  assert.equal(env.CLAUDE_CODE_USE_GITHUB, '1')
+  assert.equal(env.OPENAI_BASE_URL, 'https://api.githubcopilot.com')
+  assert.equal(env.GITHUB_ENTERPRISE_URL, undefined)
+})
+
+test('github-enterprise launch preserves persisted direct Copilot key', async () => {
+  const env = await buildLaunchEnv({
+    profile: 'github-enterprise',
+    persisted: profile('github-enterprise', {
+      OPENAI_BASE_URL: 'https://github.mycompany.com/api/copilot',
+      OPENAI_MODEL: 'github:copilot:gpt-5.3-codex',
+      GITHUB_COPILOT_KEY: 'enterprise-profile-key',
+    }),
+    goal: 'coding',
+    processEnv: {},
+  })
+
+  assert.equal(env.CLAUDE_CODE_USE_GITHUB, '1')
+  assert.equal(env.GITHUB_ENTERPRISE_URL, 'https://github.mycompany.com')
+  assert.equal(env.GITHUB_COPILOT_KEY, 'enterprise-profile-key')
+})
+
 test('openai launch preserves persisted dedicated vendor credentials across restart', async () => {
   const env = await buildLaunchEnv({
     profile: 'openai',

--- a/src/utils/providerProfile.ts
+++ b/src/utils/providerProfile.ts
@@ -113,6 +113,7 @@ export type CompatibilityProfileMode =
   | 'gemini'
   | 'mistral'
   | 'github'
+  | 'github-enterprise'
   | 'bedrock'
   | 'vertex'
 
@@ -923,6 +924,7 @@ function getCompatibilityProfileFlag(
     case 'openai':
       return 'CLAUDE_CODE_USE_OPENAI'
     case 'github':
+    case 'github-enterprise':
       return 'CLAUDE_CODE_USE_GITHUB'
     case 'gemini':
       return 'CLAUDE_CODE_USE_GEMINI'

--- a/src/utils/providerProfile.ts
+++ b/src/utils/providerProfile.ts
@@ -71,6 +71,8 @@ const PROFILE_ENV_KEYS = [
   'OPENAI_AUTH_SCHEME',
   'OPENAI_AUTH_HEADER_VALUE',
   'OPENAI_API_KEY',
+  'GITHUB_COPILOT_KEY',
+  'GITHUB_ENTERPRISE_URL',
   'CLAUDE_CODE_OPENAI_CONTEXT_WINDOWS',
   'CODEX_API_KEY',
   'CODEX_CREDENTIAL_SOURCE',
@@ -144,6 +146,7 @@ export type ProviderProfile =
   | 'minimax'
   | 'mistral'
   | 'github'
+  | 'github-enterprise'
   | 'bedrock'
   | 'vertex'
   | 'xai'
@@ -164,6 +167,8 @@ export type ProfileEnv = {
   OPENAI_AUTH_SCHEME?: 'bearer' | 'raw'
   OPENAI_AUTH_HEADER_VALUE?: string
   OPENAI_API_KEY?: string
+  GITHUB_COPILOT_KEY?: string
+  GITHUB_ENTERPRISE_URL?: string
   CODEX_API_KEY?: string
   CODEX_CREDENTIAL_SOURCE?: 'oauth' | 'existing'
   CHATGPT_ACCOUNT_ID?: string
@@ -332,6 +337,7 @@ export function isProviderProfile(value: unknown): value is ProviderProfile {
     value === 'minimax' ||
     value === 'mistral' ||
     value === 'github' ||
+    value === 'github-enterprise' ||
     value === 'bedrock' ||
     value === 'vertex' ||
     value === 'xai' ||
@@ -356,6 +362,19 @@ export function buildGithubProfileEnv(options: {
   }
 
   return env
+}
+
+function deriveGithubEnterpriseUrl(baseUrl: string | undefined): string | undefined {
+  if (!baseUrl?.trim()) return undefined
+  try {
+    const parsed = new URL(baseUrl)
+    if (parsed.origin === 'https://api.githubcopilot.com') {
+      return undefined
+    }
+    return parsed.origin
+  } catch {
+    return undefined
+  }
 }
 
 export function buildOllamaProfileEnv(
@@ -1179,8 +1198,9 @@ export async function buildLaunchEnv(options: {
   readGeminiAccessToken?: () => string | undefined
 }): Promise<NodeJS.ProcessEnv> {
   const processEnv = options.processEnv ?? process.env
+  let selectedProfile = options.profile
   const persistedEnv =
-    options.persisted?.profile === options.profile
+    options.persisted?.profile === selectedProfile
       ? options.persisted.env ?? {}
       : {}
   const persistedOpenAIModel = normalizeProfileModel(
@@ -1255,29 +1275,43 @@ export async function buildLaunchEnv(options: {
     for (const [envKey, provider] of explicitProfileOverrides) {
       if (isEnvTruthy(processEnv[envKey])) {
         const isCodexOAuthProfile =
-          options.profile === 'codex' &&
+          selectedProfile === 'codex' &&
           provider === 'openai' &&
           persistedEnv.CODEX_CREDENTIAL_SOURCE === 'oauth'
         if (!isCodexOAuthProfile) {
-          options.profile = provider
+          selectedProfile = provider
         }
         break
       }
     }
   }
 
-  if (options.profile === 'github') {
+  if (selectedProfile === 'github' || selectedProfile === 'github-enterprise') {
+    const baseUrl = shellOpenAIBaseUrl || persistedOpenAIBaseUrl
+    const profileEnv = buildGithubProfileEnv({
+      model: shellOpenAIModel || persistedOpenAIModel || 'github:copilot',
+      baseUrl,
+    })
+    if (selectedProfile === 'github-enterprise') {
+      const enterpriseUrl = deriveGithubEnterpriseUrl(baseUrl)
+      if (enterpriseUrl) {
+        profileEnv.GITHUB_ENTERPRISE_URL = enterpriseUrl
+      }
+      const copilotKey =
+        sanitizeApiKey(processEnv.GITHUB_COPILOT_KEY) ||
+        sanitizeApiKey(persistedEnv.GITHUB_COPILOT_KEY)
+      if (copilotKey) {
+        profileEnv.GITHUB_COPILOT_KEY = copilotKey
+      }
+    }
     return buildCompatibilityProcessEnv({
       processEnv,
       compatibilityMode: 'github',
-      profileEnv: buildGithubProfileEnv({
-        model: shellOpenAIModel || persistedOpenAIModel || 'github:copilot',
-        baseUrl: shellOpenAIBaseUrl || persistedOpenAIBaseUrl,
-      }),
+      profileEnv,
     })
   }
 
-  if (options.profile === 'anthropic') {
+  if (selectedProfile === 'anthropic') {
     const anthropicBaseUrl =
       sanitizeProviderConfigValue(processEnv.ANTHROPIC_BASE_URL) ||
       sanitizeProviderConfigValue(persistedEnv.ANTHROPIC_BASE_URL)
@@ -1307,7 +1341,7 @@ export async function buildLaunchEnv(options: {
     })
   }
 
-  if (options.profile === 'bedrock') {
+  if (selectedProfile === 'bedrock') {
     const bedrockBaseUrl =
       sanitizeProviderConfigValue(processEnv.ANTHROPIC_BEDROCK_BASE_URL) ||
       sanitizeProviderConfigValue(persistedEnv.ANTHROPIC_BEDROCK_BASE_URL)
@@ -1329,7 +1363,7 @@ export async function buildLaunchEnv(options: {
     })
   }
 
-  if (options.profile === 'vertex') {
+  if (selectedProfile === 'vertex') {
     const vertexBaseUrl =
       sanitizeProviderConfigValue(processEnv.ANTHROPIC_VERTEX_BASE_URL) ||
       sanitizeProviderConfigValue(persistedEnv.ANTHROPIC_VERTEX_BASE_URL)
@@ -1351,7 +1385,7 @@ export async function buildLaunchEnv(options: {
     })
   }
 
-  if (options.profile === 'gemini') {
+  if (selectedProfile === 'gemini') {
     const env: ProfileEnv = {
       GEMINI_MODEL:
         shellGeminiModel ||
@@ -1388,7 +1422,7 @@ export async function buildLaunchEnv(options: {
     })
   }
 
-  if (options.profile === 'mistral') {
+  if (selectedProfile === 'mistral') {
     const shellMistralModel = normalizeProfileModel(
       sanitizeProviderConfigValue(
         processEnv.MISTRAL_MODEL,
@@ -1432,7 +1466,7 @@ export async function buildLaunchEnv(options: {
     })
   }
 
-  if (options.profile === 'xai') {
+  if (selectedProfile === 'xai') {
     // For OAuth-tagged profiles, do not fall back to OPENAI_API_KEY /
     // persisted OPENAI_API_KEY. The user's shell OpenAI key is for
     // api.openai.com — sending it as a bearer to api.x.ai/v1 just
@@ -1490,7 +1524,7 @@ export async function buildLaunchEnv(options: {
     return result
   }
 
-  if (options.profile === 'opencode') {
+  if (selectedProfile === 'opencode') {
     const opencodeKey =
       sanitizeApiKey(processEnv.OPENCODE_API_KEY) ||
       sanitizeApiKey(persistedEnv.OPENCODE_API_KEY)
@@ -1512,7 +1546,7 @@ export async function buildLaunchEnv(options: {
     })
   }
 
-  if (options.profile === 'ollama') {
+  if (selectedProfile === 'ollama') {
     const getOllamaBaseUrl =
       options.getOllamaChatBaseUrl ?? (() => 'http://localhost:11434/v1')
     const resolveOllamaModel =
@@ -1530,7 +1564,7 @@ export async function buildLaunchEnv(options: {
     })
   }
 
-  if (options.profile === 'atomic-chat') {
+  if (selectedProfile === 'atomic-chat') {
     const getAtomicChatBaseUrl =
       options.getAtomicChatChatBaseUrl ?? (() => 'http://127.0.0.1:1337/v1')
     const resolveModel =
@@ -1549,7 +1583,7 @@ export async function buildLaunchEnv(options: {
     })
   }
 
-  if (options.profile === 'codex') {
+  if (selectedProfile === 'codex') {
     const isCodexOAuthProfile = persistedEnv.CODEX_CREDENTIAL_SOURCE === 'oauth'
     const codexKey = isCodexOAuthProfile
       ? undefined

--- a/src/utils/providerProfiles.test.ts
+++ b/src/utils/providerProfiles.test.ts
@@ -397,6 +397,87 @@ describe('applyProviderProfileToProcessEnv', () => {
     expect(process.env.GITHUB_ENTERPRISE_URL).toBeUndefined()
   })
 
+  test('github-enterprise profile remains aligned only with Enterprise env', async () => {
+    const {
+      applyActiveProviderProfileFromConfig,
+      applyProviderProfileToProcessEnv,
+    } = await importFreshProviderProfileModules()
+    const activeProfile = buildProfile({
+      id: 'github_enterprise_prof',
+      provider: 'github-enterprise',
+      baseUrl: 'https://github.mycompany.com/api/copilot',
+      model: 'github:copilot:gpt-5.3-codex',
+      apiKey: 'enterprise-profile-key',
+    })
+
+    applyProviderProfileToProcessEnv(activeProfile)
+    const unchanged = applyActiveProviderProfileFromConfig({
+      providerProfiles: [activeProfile],
+      activeProviderProfileId: activeProfile.id,
+    } as any)
+
+    expect(unchanged?.id).toBe(activeProfile.id)
+    expect(process.env.GITHUB_ENTERPRISE_URL).toBe(
+      'https://github.mycompany.com',
+    )
+
+    delete process.env.GITHUB_ENTERPRISE_URL
+    const updated = applyActiveProviderProfileFromConfig({
+      providerProfiles: [activeProfile],
+      activeProviderProfileId: activeProfile.id,
+    } as any)
+
+    expect(updated?.id).toBe(activeProfile.id)
+    expect(String(process.env.GITHUB_ENTERPRISE_URL)).toBe(
+      'https://github.mycompany.com',
+    )
+  })
+
+  test('github-enterprise profile persists and relaunches with Enterprise env', async () => {
+    const tempDir = mkdtempSync(join(tmpdir(), 'openclaude-provider-'))
+    const configDir = mkdtempSync(join(tmpdir(), 'openclaude-provider-config-'))
+    process.chdir(tempDir)
+    process.env.CLAUDE_CONFIG_DIR = configDir
+
+    try {
+      const { setActiveProviderProfile } =
+        await importFreshProviderProfileModules()
+      const enterpriseProfile = buildProfile({
+        id: 'github_enterprise_persisted',
+        name: 'GitHub Enterprise',
+        provider: 'github-enterprise',
+        baseUrl: 'https://github.mycompany.com/api/copilot',
+        model: 'github:copilot:gpt-5.3-codex',
+        apiKey: 'enterprise-profile-key',
+      })
+
+      saveMockGlobalConfig(current => ({
+        ...current,
+        providerProfiles: [enterpriseProfile],
+      }))
+
+      const result = setActiveProviderProfile('github_enterprise_persisted', {
+        configDir,
+      })
+      const persisted = JSON.parse(
+        readFileSync(join(configDir, '.openclaude-profile.json'), 'utf8'),
+      )
+
+      expect(result?.id).toBe('github_enterprise_persisted')
+      expect(persisted.profile).toBe('github-enterprise')
+      expect(persisted.env).toMatchObject({
+        GITHUB_ENTERPRISE_URL: 'https://github.mycompany.com',
+        GITHUB_COPILOT_KEY: 'enterprise-profile-key',
+        OPENAI_BASE_URL: 'https://github.mycompany.com/api/copilot',
+        OPENAI_MODEL: 'github:copilot:gpt-5.3-codex',
+      })
+    } finally {
+      process.chdir(originalCwd)
+      rmSync(tempDir, { recursive: true, force: true })
+      rmSync(configDir, { recursive: true, force: true })
+    }
+  })
+
   test('nvidia-nim profile keeps openai-compatible routing but stamps NVIDIA_NIM', async () => {
     const { applyProviderProfileToProcessEnv } =
       await importFreshProviderProfileModules()

--- a/src/utils/providerProfiles.test.ts
+++ b/src/utils/providerProfiles.test.ts
@@ -1163,6 +1163,36 @@ describe('applyActiveProviderProfileFromConfig', () => {
     expect(process.env.OPENAI_MODEL).toBe('gpt-4o-mini')
   })
 
+  test('respects env-only GitHub Enterprise startup selection', async () => {
+    const { applyActiveProviderProfileFromConfig } =
+      await importFreshProviderProfileModules()
+    process.env.CLAUDE_CODE_USE_GITHUB = '1'
+    process.env.GITHUB_ENTERPRISE_URL = 'https://github.mycompany.com/api/copilot'
+    process.env.GITHUB_COPILOT_KEY = 'enterprise-direct-key'
+    delete process.env.OPENAI_MODEL
+
+    const applied = applyActiveProviderProfileFromConfig({
+      providerProfiles: [
+        buildProfile({
+          id: 'saved_openai',
+          baseUrl: 'https://api.openai.com/v1',
+          model: 'gpt-4o',
+        }),
+      ],
+      activeProviderProfileId: 'saved_openai',
+    } as any)
+
+    expect(applied).toBeUndefined()
+    expect(process.env.CLAUDE_CODE_USE_GITHUB).toBe('1')
+    expect(process.env.GITHUB_ENTERPRISE_URL).toBe(
+      'https://github.mycompany.com/api/copilot',
+    )
+    expect(process.env.GITHUB_COPILOT_KEY).toBe('enterprise-direct-key')
+    expect(process.env.CLAUDE_CODE_USE_OPENAI).toBeUndefined()
+    expect(process.env.OPENAI_BASE_URL).toBeUndefined()
+    expect(process.env.OPENAI_MODEL).toBeUndefined()
+  })
+
   test('does not override explicit env-only MiniMax selection with saved profile', async () => {
     const { applyActiveProviderProfileFromConfig } =
       await importFreshProviderProfileModules()

--- a/src/utils/providerProfiles.test.ts
+++ b/src/utils/providerProfiles.test.ts
@@ -33,6 +33,8 @@ const RESTORED_KEYS = [
   'OPENAI_AUTH_SCHEME',
   'OPENAI_AUTH_HEADER_VALUE',
   'OPENAI_API_KEY',
+  'GITHUB_COPILOT_KEY',
+  'GITHUB_ENTERPRISE_URL',
   'CODEX_API_KEY',
   'CODEX_CREDENTIAL_SOURCE',
   'CHATGPT_ACCOUNT_ID',
@@ -339,6 +341,60 @@ describe('applyProviderProfileToProcessEnv', () => {
     )
     expect(process.env.OPENAI_MODEL).toBe('github:copilot')
     expect(getFreshAPIProvider()).toBe('github')
+  })
+
+  test('github-enterprise profile uses GitHub compatibility env', async () => {
+    const { applyProviderProfileToProcessEnv } =
+      await importFreshProviderProfileModules()
+    process.env.CLAUDE_CODE_USE_OPENAI = '1'
+
+    applyProviderProfileToProcessEnv(
+      buildProfile({
+        provider: 'github-enterprise',
+        baseUrl: 'https://github.mycompany.com/api/copilot',
+        model: 'github:copilot:gpt-5.3-codex',
+        apiKey: 'enterprise-profile-key',
+      }),
+    )
+    const { getAPIProvider: getFreshAPIProvider } =
+      await importFreshProvidersModule()
+    const { resolveProviderRequest } = await import(
+      `../services/api/providerConfig.ts?ts=${Date.now()}-${Math.random()}`
+    )
+
+    expect(process.env.CLAUDE_CODE_USE_GITHUB).toBe('1')
+    expect(process.env.CLAUDE_CODE_USE_OPENAI).toBeUndefined()
+    expect(process.env.OPENAI_BASE_URL).toBe(
+      'https://github.mycompany.com/api/copilot',
+    )
+    expect(process.env.GITHUB_ENTERPRISE_URL).toBe(
+      'https://github.mycompany.com',
+    )
+    expect(process.env.GITHUB_COPILOT_KEY).toBe('enterprise-profile-key')
+    expect(process.env.OPENAI_MODEL).toBe('github:copilot:gpt-5.3-codex')
+    expect(getFreshAPIProvider()).toBe('github')
+    expect(resolveProviderRequest()).toMatchObject({
+      baseUrl: 'https://github.mycompany.com/api/copilot',
+      resolvedModel: 'gpt-5.3-codex',
+      transport: 'codex_responses',
+    })
+  })
+
+  test('github-enterprise profile does not derive Enterprise URL from public Copilot default', async () => {
+    const { applyProviderProfileToProcessEnv } =
+      await importFreshProviderProfileModules()
+
+    applyProviderProfileToProcessEnv(
+      buildProfile({
+        provider: 'github-enterprise',
+        baseUrl: 'https://api.githubcopilot.com',
+        model: 'github:copilot:gpt-5.3-codex',
+      }),
+    )
+
+    expect(process.env.CLAUDE_CODE_USE_GITHUB).toBe('1')
+    expect(process.env.OPENAI_BASE_URL).toBe('https://api.githubcopilot.com')
+    expect(process.env.GITHUB_ENTERPRISE_URL).toBeUndefined()
   })
 
   test('nvidia-nim profile keeps openai-compatible routing but stamps NVIDIA_NIM', async () => {

--- a/src/utils/providerProfiles.ts
+++ b/src/utils/providerProfiles.ts
@@ -440,6 +440,8 @@ function hasCompleteProviderSelection(
   }
   if (processEnv.CLAUDE_CODE_USE_GITHUB !== undefined) {
     return (
+      trimOrUndefined(processEnv.GITHUB_ENTERPRISE_URL) !== undefined ||
+      trimOrUndefined(processEnv.GITHUB_COPILOT_KEY) !== undefined ||
       trimOrUndefined(processEnv.GITHUB_TOKEN) !== undefined ||
       trimOrUndefined(processEnv.GH_TOKEN) !== undefined ||
       trimOrUndefined(processEnv.OPENAI_MODEL) !== undefined

--- a/src/utils/providerProfiles.ts
+++ b/src/utils/providerProfiles.ts
@@ -80,9 +80,19 @@ type ProfileCompatibilityMode =
   | 'gemini'
   | 'mistral'
   | 'github'
+  | 'github-enterprise'
   | 'bedrock'
   | 'vertex'
   | 'openai'
+
+function isGithubCompatibilityMode(
+  compatibilityMode: ProfileCompatibilityMode,
+): boolean {
+  return (
+    compatibilityMode === 'github' ||
+    compatibilityMode === 'github-enterprise'
+  )
+}
 
 function resolveProfileCompatibility(provider: string): {
   route: ResolvedProfileRoute
@@ -90,7 +100,10 @@ function resolveProfileCompatibility(provider: string): {
 } {
   const route = resolveProfileRoute(provider)
 
-  if (route.gatewayId === 'github' || route.gatewayId === 'github-enterprise') {
+  if (provider === 'github-enterprise' || route.gatewayId === 'github-enterprise') {
+    return { route, compatibilityMode: 'github-enterprise' }
+  }
+  if (provider === 'github' || route.gatewayId === 'github') {
     return { route, compatibilityMode: 'github' }
   }
   if (route.gatewayId === 'bedrock') {
@@ -451,7 +464,8 @@ function hasConflictingProviderFlagsForProfile(
     (compatibilityMode !== 'openai' && processEnv.CLAUDE_CODE_USE_OPENAI !== undefined) ||
     (compatibilityMode !== 'gemini' && processEnv.CLAUDE_CODE_USE_GEMINI !== undefined) ||
     (compatibilityMode !== 'mistral' && processEnv.CLAUDE_CODE_USE_MISTRAL !== undefined) ||
-    (compatibilityMode !== 'github' && processEnv.CLAUDE_CODE_USE_GITHUB !== undefined) ||
+    (!isGithubCompatibilityMode(compatibilityMode) &&
+      processEnv.CLAUDE_CODE_USE_GITHUB !== undefined) ||
     (compatibilityMode !== 'bedrock' && processEnv.CLAUDE_CODE_USE_BEDROCK !== undefined) ||
     (compatibilityMode !== 'vertex' && processEnv.CLAUDE_CODE_USE_VERTEX !== undefined) ||
     processEnv.CLAUDE_CODE_USE_FOUNDRY !== undefined
@@ -525,7 +539,11 @@ function isProcessEnvAlignedWithProfile(
     )
   }
 
-  if (compatibilityMode === 'github') {
+  if (isGithubCompatibilityMode(compatibilityMode)) {
+    const expectedGheUrl =
+      profile.provider === 'github-enterprise'
+        ? deriveGithubEnterpriseUrl(profile.baseUrl)
+        : undefined
     return (
       processEnv.CLAUDE_CODE_USE_GITHUB !== undefined &&
       processEnv.CLAUDE_CODE_USE_OPENAI === undefined &&
@@ -535,7 +553,11 @@ function isProcessEnvAlignedWithProfile(
       processEnv.CLAUDE_CODE_USE_VERTEX === undefined &&
       processEnv.CLAUDE_CODE_USE_FOUNDRY === undefined &&
       sameOptionalEnvValue(processEnv.OPENAI_BASE_URL, profile.baseUrl) &&
-      sameOptionalEnvValue(processEnv.OPENAI_MODEL, getPrimaryModel(profile.model))
+      sameOptionalEnvValue(processEnv.OPENAI_MODEL, getPrimaryModel(profile.model)) &&
+      sameOptionalEnvValue(processEnv.GITHUB_ENTERPRISE_URL, expectedGheUrl) &&
+      (profile.provider !== 'github-enterprise' ||
+        !includeApiKey ||
+        sameOptionalEnvValue(processEnv.GITHUB_COPILOT_KEY, profile.apiKey))
     )
   }
 
@@ -687,11 +709,14 @@ export function applyProviderProfileToProcessEnv(profile: ProviderProfile): void
       GEMINI_MODEL: primaryModel,
       ...(profile.apiKey ? { GEMINI_API_KEY: profile.apiKey } : {}),
     }
-  } else if (compatibilityMode === 'github') {
+  } else if (isGithubCompatibilityMode(compatibilityMode)) {
     profileEnv = buildGithubCompatibleProfileEnv({
       model: primaryModel,
       baseUrl: profile.baseUrl,
-      gatewayId: route.gatewayId,
+      gatewayId:
+        profile.provider === 'github-enterprise'
+          ? 'github-enterprise'
+          : route.gatewayId,
       apiKey: profile.apiKey,
     })
   } else if (compatibilityMode === 'bedrock') {
@@ -1133,9 +1158,13 @@ function buildStartupProfileFromActiveProfile(
         ? { profile: 'mistral', env: applySupportedProfileCustomHeaders(activeProfile, env) }
         : null
     }
-    case 'github': {
+    case 'github':
+    case 'github-enterprise': {
       return {
-        profile: 'github',
+        profile:
+          activeProfile.provider === 'github-enterprise'
+            ? 'github-enterprise'
+            : 'github',
         env: applySupportedProfileCustomHeaders(
           activeProfile,
           buildGithubCompatibleProfileEnv({

--- a/src/utils/providerProfiles.ts
+++ b/src/utils/providerProfiles.ts
@@ -90,7 +90,7 @@ function resolveProfileCompatibility(provider: string): {
 } {
   const route = resolveProfileRoute(provider)
 
-  if (route.gatewayId === 'github') {
+  if (route.gatewayId === 'github' || route.gatewayId === 'github-enterprise') {
     return { route, compatibilityMode: 'github' }
   }
   if (route.gatewayId === 'bedrock') {
@@ -113,6 +113,43 @@ function resolveProfileCompatibility(provider: string): {
   }
 
   return { route, compatibilityMode: 'openai' }
+}
+
+function deriveGithubEnterpriseUrl(baseUrl: string | undefined): string | undefined {
+  if (!baseUrl?.trim()) return undefined
+  try {
+    const parsed = new URL(baseUrl)
+    if (parsed.origin === 'https://api.githubcopilot.com') {
+      return undefined
+    }
+    return parsed.origin
+  } catch {
+    return undefined
+  }
+}
+
+function buildGithubCompatibleProfileEnv(options: {
+  model: string
+  baseUrl?: string
+  gatewayId?: string
+  apiKey?: string
+}): ProfileEnv {
+  const env = buildGithubProfileEnv({
+    model: options.model,
+    baseUrl: options.baseUrl,
+  })
+
+  if (options.gatewayId === 'github-enterprise') {
+    const enterpriseUrl = deriveGithubEnterpriseUrl(options.baseUrl)
+    if (enterpriseUrl) {
+      env.GITHUB_ENTERPRISE_URL = enterpriseUrl
+    }
+    if (options.apiKey?.trim()) {
+      env.GITHUB_COPILOT_KEY = options.apiKey.trim()
+    }
+  }
+
+  return env
 }
 
 function trimValue(value: string | undefined): string {
@@ -651,9 +688,11 @@ export function applyProviderProfileToProcessEnv(profile: ProviderProfile): void
       ...(profile.apiKey ? { GEMINI_API_KEY: profile.apiKey } : {}),
     }
   } else if (compatibilityMode === 'github') {
-    profileEnv = buildGithubProfileEnv({
+    profileEnv = buildGithubCompatibleProfileEnv({
       model: primaryModel,
       baseUrl: profile.baseUrl,
+      gatewayId: route.gatewayId,
+      apiKey: profile.apiKey,
     })
   } else if (compatibilityMode === 'bedrock') {
     profileEnv = buildBedrockProfileEnv({
@@ -1094,14 +1133,23 @@ function buildStartupProfileFromActiveProfile(
         ? { profile: 'mistral', env: applySupportedProfileCustomHeaders(activeProfile, env) }
         : null
     }
-    case 'github':
+    case 'github': {
       return {
         profile: 'github',
-        env: applySupportedProfileCustomHeaders(activeProfile, buildGithubProfileEnv({
-          model: getPrimaryModel(activeProfile.model),
-          baseUrl: activeProfile.baseUrl,
-        })),
+        env: applySupportedProfileCustomHeaders(
+          activeProfile,
+          buildGithubCompatibleProfileEnv({
+            model: getPrimaryModel(activeProfile.model),
+            baseUrl: activeProfile.baseUrl,
+            apiKey: activeProfile.apiKey,
+            gatewayId:
+              activeProfile.provider === 'github-enterprise'
+                ? 'github-enterprise'
+                : 'github',
+          }),
+        ),
       }
+    }
     case 'bedrock':
       return {
         profile: 'bedrock',

--- a/src/utils/providerValidation.test.ts
+++ b/src/utils/providerValidation.test.ts
@@ -19,6 +19,8 @@ const ENV_KEYS = [
   'CHATGPT_ACCOUNT_ID',
   'CODEX_ACCOUNT_ID',
   'CLAUDE_CODE_USE_GITHUB',
+  'GITHUB_COPILOT_KEY',
+  'GITHUB_ENTERPRISE_URL',
   'GITHUB_TOKEN',
   'GH_TOKEN',
   'CLAUDE_CODE_USE_GEMINI',
@@ -380,6 +382,8 @@ test('opengateway validation still requires a key on the model-specific path', a
 test('github validation stays descriptor-selected and reports missing auth', async () => {
   process.env.CLAUDE_CODE_USE_GITHUB = '1'
   delete process.env.CLAUDE_CODE_USE_OPENAI
+  delete process.env.GITHUB_ENTERPRISE_URL
+  delete process.env.OPENAI_BASE_URL
   delete process.env.GITHUB_TOKEN
   delete process.env.GH_TOKEN
 
@@ -388,6 +392,32 @@ test('github validation stays descriptor-selected and reports missing auth', asy
       'Run /onboard-github in the CLI to sign in with your GitHub account.\n' +
       'This will store your OAuth token securely and enable Copilot models.',
   )
+})
+
+test('github enterprise validation reports Enterprise auth guidance when Enterprise URL is set', async () => {
+  process.env.CLAUDE_CODE_USE_GITHUB = '1'
+  process.env.GITHUB_ENTERPRISE_URL = 'https://github.mycompany.com'
+  delete process.env.CLAUDE_CODE_USE_OPENAI
+  delete process.env.GITHUB_COPILOT_KEY
+  delete process.env.GITHUB_TOKEN
+  delete process.env.GH_TOKEN
+
+  await expect(getProviderValidationError(process.env)).resolves.toBe(
+    'GitHub Copilot Enterprise authentication required.\n' +
+      'Set GITHUB_ENTERPRISE_URL to your GHE instance URL (e.g. https://github.mycompany.com).\n' +
+      'Then run /onboard-github to sign in, or set GITHUB_COPILOT_KEY for direct API key auth.',
+  )
+})
+
+test('github enterprise validation accepts PAT when Enterprise URL is set without OPENAI_BASE_URL', async () => {
+  process.env.CLAUDE_CODE_USE_GITHUB = '1'
+  process.env.GITHUB_ENTERPRISE_URL = 'https://github.mycompany.com'
+  process.env.GITHUB_TOKEN = 'ghp_enterprisepat'
+  delete process.env.CLAUDE_CODE_USE_OPENAI
+  delete process.env.OPENAI_BASE_URL
+  delete process.env.GH_TOKEN
+
+  await expect(getProviderValidationError(process.env)).resolves.toBeNull()
 })
 
 test('github validation is skipped when openai mode is also active', async () => {

--- a/src/utils/providerValidation.test.ts
+++ b/src/utils/providerValidation.test.ts
@@ -420,6 +420,17 @@ test('github enterprise validation accepts PAT when Enterprise URL is set withou
   await expect(getProviderValidationError(process.env)).resolves.toBeNull()
 })
 
+test('github enterprise validation accepts a direct Copilot key without token validation', async () => {
+  process.env.CLAUDE_CODE_USE_GITHUB = '1'
+  process.env.GITHUB_ENTERPRISE_URL = 'https://github.mycompany.com'
+  process.env.GITHUB_COPILOT_KEY = 'enterprise-direct-key'
+  delete process.env.CLAUDE_CODE_USE_OPENAI
+  delete process.env.GITHUB_TOKEN
+  delete process.env.GH_TOKEN
+
+  await expect(getProviderValidationError(process.env)).resolves.toBeNull()
+})
+
 test('github validation is skipped when openai mode is also active', async () => {
   process.env.CLAUDE_CODE_USE_GITHUB = '1'
   process.env.CLAUDE_CODE_USE_OPENAI = '1'

--- a/src/utils/providerValidation.ts
+++ b/src/utils/providerValidation.ts
@@ -61,9 +61,10 @@ const GITHUB_PAT_PREFIXES = ['ghp_', 'gho_', 'ghs_', 'ghr_', 'github_pat_']
 
 function checkGithubTokenStatus(
   token: string,
-  endpointType: 'copilot' | 'models' | 'custom' = 'copilot',
+  endpointType: 'copilot' | 'models' | 'ghe' | 'custom' = 'copilot',
 ): GithubTokenStatus {
   // PATs work with GitHub Models but not with Copilot API
+  // For GHE, PATs work if they have the right scopes
   if (GITHUB_PAT_PREFIXES.some(prefix => token.startsWith(prefix))) {
     if (endpointType === 'copilot') {
       return 'expired'
@@ -177,6 +178,13 @@ function getValidationRouting(target: ValidationTarget) {
   return target.descriptor.validation?.routing
 }
 
+function isGithubEnterpriseValidationEnv(env: NodeJS.ProcessEnv): boolean {
+  if (env.GITHUB_ENTERPRISE_URL?.trim()) {
+    return true
+  }
+  return getGithubEndpointType(env.OPENAI_BASE_URL) === 'ghe'
+}
+
 function getValidationTargetBaseUrl(
   target: ValidationTarget,
 ): string | undefined {
@@ -197,6 +205,18 @@ function getRuntimeValidationTarget(
 
     if (useOpenAI && routing.skipWhenUseOpenAI) {
       return false
+    }
+
+    if (target.kind === 'gateway') {
+      if (target.descriptor.id === 'github-enterprise') {
+        return isGithubEnterpriseValidationEnv(env)
+      }
+      if (
+        target.descriptor.id === 'github' &&
+        isGithubEnterpriseValidationEnv(env)
+      ) {
+        return false
+      }
     }
 
     return true
@@ -308,12 +328,25 @@ async function getDescriptorValidationError(
     }
 
     case 'github-token': {
+      // GITHUB_COPILOT_KEY is a direct API key for GitHub Copilot Enterprise
+      // It doesn't need token status validation as it's used directly
+      if (env.GITHUB_COPILOT_KEY?.trim()) {
+        return null
+      }
+
       const token = (env.GITHUB_TOKEN?.trim() || env.GH_TOKEN?.trim()) ?? ''
       if (!token) {
         return validation.missingCredentialMessage
       }
 
-      const endpointType = getGithubEndpointType(env.OPENAI_BASE_URL)
+      const githubEnterpriseUrl = env.GITHUB_ENTERPRISE_URL?.trim()
+      const endpointType = githubEnterpriseUrl
+        ? (env.OPENAI_BASE_URL?.trim()
+          ? getGithubEndpointType(env.OPENAI_BASE_URL, {
+            githubEnterpriseUrl,
+          })
+          : 'ghe')
+        : getGithubEndpointType(env.OPENAI_BASE_URL)
       const status = checkGithubTokenStatus(token, endpointType)
       if (status === 'expired') {
         return validation.expiredCredentialMessage


### PR DESCRIPTION
## What changed

- Added GitHub Copilot Enterprise as a descriptor-backed gateway and registered it in the generated integration artifacts.
- Extended `/onboard-github` with GitHub Enterprise URL entry and direct Copilot API key entry.
- Routed GitHub Enterprise requests through `{GITHUB_ENTERPRISE_URL}/api/copilot`, including origin normalization for pasted `/api/copilot` URLs.
- Added GitHub Enterprise device-flow endpoints and token refresh support.
- Preserved Enterprise profile/startup env (`GITHUB_ENTERPRISE_URL`, `GITHUB_COPILOT_KEY`) and mapped Enterprise profile API keys to direct Copilot key auth.
- Updated GitHub validation so public GitHub still gets the public Copilot auth guidance, while Enterprise env gets Enterprise guidance and Enterprise PAT support.

## Why

GitHub Enterprise Server deployments need Copilot traffic, auth, onboarding, saved profiles, and validation to target the Enterprise instance instead of the public Copilot endpoint. Without these changes, Enterprise URL/key setup could be persisted but runtime requests or validation still used public GitHub/Copilot assumptions.

## User / developer impact

- Users can onboard GitHub Enterprise via `/onboard-github`, either through browser/device flow or direct Copilot key entry.
- Saved `github-enterprise` profiles survive restart and keep the correct Enterprise URL and Copilot key env.
- Public GitHub Copilot behavior remains the default when Enterprise env is absent.
- Provider authors get a descriptor-backed `github-enterprise` gateway path consistent with the integration system.

## Provider path tested

- GitHub Copilot public compatibility path
- GitHub Copilot Enterprise with `GITHUB_ENTERPRISE_URL`
- GitHub Copilot Enterprise direct key via `GITHUB_COPILOT_KEY`
- `github-enterprise` saved profile/startup env paths

## Checks run

- `bun run build`
- `bun run typecheck`
- `bun run typecheck:type-tests`
- `bun run integrations:check`
- `bun run test:provider`
- `bun run test:provider-recommendation`
- `bun run security:pr-scan`
- `python -m pytest -q python\tests` (`44 passed`, with a pytest cache warning on Windows)
- Focused GitHub Enterprise/provider tests during development:
  - `bun test src\services\api\providerConfig.github.test.ts src\services\api\openaiShim.test.ts --test-name-pattern "Enterprise|direct GitHub Copilot"`
  - `bun test src\utils\providerValidation.test.ts --test-name-pattern "github validation|github enterprise validation"`
  - `bun test src\utils\providerProfiles.test.ts --test-name-pattern "github-enterprise" --timeout 15000`
  - `bun test src\utils\providerProfile.test.ts --test-name-pattern "github-enterprise"`

## Known unrelated local failures

`bun run check` still fails in unrelated full-suite areas on this Windows workspace:

- `src/commands/export/export.test.ts`: 3 `/export direct filename` tests write an auth error (`ANTHROPIC_API_KEY or CLAUDE_CODE_OAUTH_TOKEN env var is required`) instead of the fake transcript.
- `src/utils/plugins/marketplaceManager.test.ts`: 4 cache-finalization/EXDEV tests fail in the full suite but pass when run alone.
- `src/utils/secureStorage/platformStorage.test.ts`: 3 platform-storage tests fail in the full suite but pass when run alone.

The GitHub Enterprise/provider-focused checks above pass.

Fixes #820

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added GitHub Enterprise support, including a dedicated enterprise gateway and Enterprise Copilot routing.
  * Extended onboarding to accept an optional Enterprise URL and added a Copilot API key sign-in path.
  * Introduced a `github-enterprise` compatibility/profile mode that persists Enterprise URL and Copilot key handling.

* **Improvements**
  * Refined credential/env precedence and synchronization across onboarding, profile activation, and request routing.
  * Improved Enterprise URL normalization and provider/model routing selection.

* **Tests**
  * Expanded coverage for Enterprise onboarding, validation, OAuth/device flow endpoints, and shim authentication behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->