### PR TITLE
fix(provider): honor explicit CLAUDE_CODE_USE_OPENAI=0 on fresh startup

### DIFF
--- a/src/utils/providerProfile.test.ts
+++ b/src/utils/providerProfile.test.ts
@@ -363,6 +363,26 @@ test('buildStartupEnvFromProfile preserves explicit OpenAI-compatible env withou
   assert.equal(isDefaultStartupProviderEnv(env), false)
 })
 
+test('buildStartupEnvFromProfile respects an explicit CLAUDE_CODE_USE_OPENAI=0 opt-out (issue #1245)', async () => {
+  const env = await buildStartupEnvFromProfile({
+    persisted: null,
+    processEnv: {
+      CLAUDE_CODE_USE_OPENAI: '0',
+    },
+  })
+
+  // The explicit opt-out must be preserved and the default Opengateway
+  // profile must NOT be injected over it.
+  assert.equal(env.CLAUDE_CODE_USE_OPENAI, '0')
+  assert.equal(env.OPENAI_BASE_URL, undefined)
+  assert.equal(env.OPENAI_MODEL, undefined)
+  assert.equal(isDefaultStartupProviderEnv(env), false)
+
+  // With OpenAI disabled and no provider configured, startup must not emit a
+  // spurious "OPENAI_API_KEY is required" warning.
+  assert.equal(await getProviderValidationError(env), null)
+})
+
 test('buildStartupEnvFromProfile preserves env-only Fireworks setup without a saved profile', async () => {
   const env = await buildStartupEnvFromProfile({
     persisted: null,

--- a/src/utils/providerProfile.ts
+++ b/src/utils/providerProfile.ts
@@ -1695,6 +1695,18 @@ export async function buildStartupEnvFromProfile(options?: {
   }
 
   if (!persisted) {
+    // No saved profile. If the user explicitly disabled the OpenAI-compatible
+    // provider (CLAUDE_CODE_USE_OPENAI=0), honor that opt-out instead of
+    // injecting the default Opengateway profile — otherwise the fallback
+    // re-enables OpenAI and the startup validator reports a spurious missing
+    // OPENAI_API_KEY warning (#1245).
+    if (
+      processEnv.CLAUDE_CODE_USE_OPENAI !== undefined &&
+      !isEnvTruthy(processEnv.CLAUDE_CODE_USE_OPENAI)
+    ) {
+      return processEnv
+    }
+
     // No saved profile — default to Gitlawb Opengateway.
     const env = buildCompatibilityProcessEnv({
       processEnv,


### PR DESCRIPTION
## Summary

Fixes the spurious `OPENAI_API_KEY is required` warning that appears on startup when a user has explicitly set `CLAUDE_CODE_USE_OPENAI=0` but has no saved provider profile (reproduces even under `env -i`).

## Root cause

`buildStartupEnvFromProfile` falls back to the default **Gitlawb Opengateway** profile in the no-saved-profile branch. That fallback injects `OPENAI_BASE_URL` / `OPENAI_MODEL` and re-enables the OpenAI-compatible route, overriding the user's explicit `CLAUDE_CODE_USE_OPENAI=0` opt-out. The startup validator then sees an OpenAI route with no key and emits the missing-key warning.

## Fix

In the `!persisted` branch, if `CLAUDE_CODE_USE_OPENAI` is defined and falsey, return the process env unchanged instead of injecting the default profile. Saved non-OpenAI profiles are untouched and still applied — only the implicit default injection is skipped when the user opted out.

## Tests

- New: `buildStartupEnvFromProfile respects an explicit CLAUDE_CODE_USE_OPENAI=0 opt-out` — asserts the default Opengateway env is not injected and `getProviderValidationError` returns null.
- Full `providerProfile.test.ts` suite green (80 pass), including the existing falsey-flag-with-persisted-profile tests which remain unaffected.
- `bun run smoke` (build + `--version`) passes; `tsc --noEmit` clean.

Closes #1245

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced provider configuration handling to properly respect explicit opt-out preferences for OpenAI-compatible providers, preventing automatic injection of default provider settings when users disable this integration.

* **Tests**
  * Added regression tests validating that explicit provider opt-out preferences are correctly honored and provider validation succeeds without errors when opt-outs are configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->