### PR TITLE
fix(session-title): harden generated title handling

### DIFF
--- a/src/bridge/initReplBridge.ts
+++ b/src/bridge/initReplBridge.ts
@@ -47,6 +47,7 @@ import { getCurrentSessionTitle } from '../utils/sessionStorage.js'
 import {
   extractConversationText,
   generateSessionTitle,
+  titleOrNullForPromptFallback,
 } from '../utils/sessionTitle.js'
 import { generateShortWordSlug } from '../utils/words.js'
 import {
@@ -342,13 +343,14 @@ export async function initReplBridge(
     })
     void generateSessionTitle(input, signal)
       .then(generated => {
+        const titleToPatch = titleOrNullForPromptFallback(generated)
         if (
-          generated &&
+          titleToPatch &&
           gen === genSeq &&
           lastBridgeSessionId === bridgeSessionId &&
           !getCurrentSessionTitle(getSessionId())
         ) {
-          patch(generated, bridgeSessionId, atCount)
+          patch(titleToPatch, bridgeSessionId, atCount)
         }
       })
       .finally(cleanup)

--- a/src/cli/print.ts
+++ b/src/cli/print.ts
@@ -3794,7 +3794,7 @@ function runHeadlessStreaming(
           const { description, persist } = message.request
           // Reuse the live controller only if it has not already been aborted
           // (e.g. by interrupt()); an aborted signal would cause queryHaiku to
-          // immediately throw APIUserAbortError → {title: null}.
+          // immediately throw APIUserAbortError and return the default title.
           const titleSignal = (
             abortController && !abortController.signal.aborted
               ? abortController
@@ -3813,7 +3813,7 @@ function runHeadlessStreaming(
               sendControlResponseSuccess(message, { title })
             } catch (e) {
               // Unreachable in practice — generateSessionTitle wraps its
-              // own body and returns null, saveAiGeneratedTitle is wrapped
+              // own body and returns a default title, saveAiGeneratedTitle is wrapped
               // above. Propagate (not swallow) so unexpected failures are
               // visible to the SDK caller (hostComms.ts catches and logs).
               sendControlResponseError(message, errorMessage(e))

--- a/src/cli/print.ts
+++ b/src/cli/print.ts
@@ -149,7 +149,10 @@ import {
 } from 'src/utils/permissions/PermissionPromptToolResultSchema.js'
 import { createAbortController } from 'src/utils/abortController.js'
 import { createCombinedAbortSignal } from 'src/utils/combinedAbortSignal.js'
-import { generateSessionTitle } from 'src/utils/sessionTitle.js'
+import {
+  generateSessionTitle,
+  titleOrNullForPromptFallback,
+} from 'src/utils/sessionTitle.js'
 import { buildSideQuestionFallbackParams } from 'src/utils/queryContext.js'
 import { runSideQuestion } from 'src/utils/sideQuestion.js'
 import {
@@ -3803,9 +3806,10 @@ function runHeadlessStreaming(
           void (async () => {
             try {
               const title = await generateSessionTitle(description, titleSignal)
-              if (title && persist) {
+              const titleToPersist = titleOrNullForPromptFallback(title)
+              if (titleToPersist && persist) {
                 try {
-                  saveAiGeneratedTitle(getSessionId() as UUID, title)
+                  saveAiGeneratedTitle(getSessionId() as UUID, titleToPersist)
                 } catch (e) {
                   logError(e)
                 }

--- a/src/hooks/useRemoteSession.ts
+++ b/src/hooks/useRemoteSession.ts
@@ -28,7 +28,10 @@ import {
   handleMessageFromStream,
   type StreamingToolUse,
 } from '../utils/messages.js'
-import { generateSessionTitle } from '../utils/sessionTitle.js'
+import {
+  generateSessionTitle,
+  titleOrNullForPromptFallback,
+} from '../utils/sessionTitle.js'
 import type { RemoteMessageContent } from '../utils/teleport/api.js'
 import { updateSessionTitle } from '../utils/teleport/api.js'
 
@@ -483,9 +486,10 @@ export function useRemoteSession({
             description,
             new AbortController().signal,
           ).then(title => {
+            const generatedTitle = titleOrNullForPromptFallback(title)
             void updateSessionTitle(
               sessionId,
-              title ?? truncateToWidth(description, 75),
+              generatedTitle ?? truncateToWidth(description, 75),
             )
           })
         }

--- a/src/hooks/useRemoteSession.ts
+++ b/src/hooks/useRemoteSession.ts
@@ -477,8 +477,8 @@ export function useRemoteSession({
             ? content
             : extractTextContent(content, ' ')
         if (description) {
-          // generateSessionTitle never rejects (wraps body in try/catch,
-          // returns null on failure), so no .catch needed on this chain.
+          // generateSessionTitle never rejects (wraps body in try/catch),
+          // so no .catch needed on this chain.
           void generateSessionTitle(
             description,
             new AbortController().signal,

--- a/src/screens/REPL.tsx
+++ b/src/screens/REPL.tsx
@@ -128,7 +128,7 @@ import { getFeatureValue_CACHED_MAY_BE_STALE } from 'src/services/analytics/grow
 import { textForResubmit, handleMessageFromStream, type StreamingToolUse, type StreamingThinking, isCompactBoundaryMessage, getMessagesAfterCompactBoundary, getContentText, createUserMessage, createAssistantMessage, createTurnDurationMessage, createAgentsKilledMessage, createSystemMessage, createCommandInputMessage, formatCommandInputTags } from '../utils/messages.js';
 import { getCurrentTurnCacheMetrics, resetCurrentTurn } from '../services/api/cacheStatsTracker.js';
 import { formatCacheMetricsCompact, formatCacheMetricsFull } from '../services/api/cacheMetrics.js';
-import { generateSessionTitle } from '../utils/sessionTitle.js';
+import { generateSessionTitle, titleOrNullForPromptFallback } from '../utils/sessionTitle.js';
 import { BASH_INPUT_TAG, COMMAND_MESSAGE_TAG, COMMAND_NAME_TAG, LOCAL_COMMAND_STDOUT_TAG } from '../constants/xml.js';
 import { escapeXml } from '../utils/xml.js';
 import type { ThinkingConfig } from '../utils/thinking.js';
@@ -2819,7 +2819,8 @@ export function REPL({
       if (text && !text.startsWith(`<${LOCAL_COMMAND_STDOUT_TAG}>`) && !text.startsWith(`<${COMMAND_MESSAGE_TAG}>`) && !text.startsWith(`<${COMMAND_NAME_TAG}>`) && !text.startsWith(`<${BASH_INPUT_TAG}>`)) {
         haikuTitleAttemptedRef.current = true;
         void generateSessionTitle(text, new AbortController().signal).then(title => {
-          if (title) setHaikuTitle(title); else haikuTitleAttemptedRef.current = false;
+          const generatedTitle = titleOrNullForPromptFallback(title);
+          if (generatedTitle) setHaikuTitle(generatedTitle); else haikuTitleAttemptedRef.current = false;
         }, () => {
           haikuTitleAttemptedRef.current = false;
         });

--- a/src/utils/sessionTitle.test.ts
+++ b/src/utils/sessionTitle.test.ts
@@ -25,6 +25,7 @@ let analyticsEvents: Array<{ name: string; metadata: Record<string, unknown> }> 
 let debugMessages: Array<{ message: string; level?: string }> = []
 let combinedAbortTimeouts: Array<number | undefined> = []
 let forcedCombinedTimeoutMs: number | null = null
+const COLD_MODULE_IMPORT_TEST_TIMEOUT_MS = 15_000
 
 function assistantText(text: string): unknown {
   return {
@@ -183,7 +184,7 @@ describe('generateSessionTitle', () => {
       name: 'tengu_session_title_generated',
       metadata: { success: true },
     })
-  })
+  }, COLD_MODULE_IMPORT_TEST_TIMEOUT_MS)
 
   test('falls back when title generation times out', async () => {
     forcedCombinedTimeoutMs = 1
@@ -298,6 +299,20 @@ describe('generateSessionTitle', () => {
     expect(title).toBe('Fix login button on mobile')
   })
 
+  test('skips provider intro lines before short-line title candidates', async () => {
+    structuredOutputsSupported = false
+    queryHaikuText =
+      'Here are some title ideas:\nFix login button on mobile\nPossible titles:'
+
+    const { generateSessionTitle } = await importSubject()
+    const title = await generateSessionTitle(
+      'The login button is broken on mobile',
+      new AbortController().signal,
+    )
+
+    expect(title).toBe('Fix login button on mobile')
+  })
+
   test('cleans title labels from short-line fallback output', async () => {
     structuredOutputsSupported = false
     queryHaikuText = 'Title: Debug failing CI tests'
@@ -374,6 +389,22 @@ describe('generateSessionTitle', () => {
 
     expect(title).toBe('OpenClaude')
     expect(titleOrNullForPromptFallback(title)).toBeNull()
+  })
+
+  test('lets persistence callers skip the generic default title', async () => {
+    forcedCombinedTimeoutMs = 1
+    queryHaikuImpl = async ({ signal }) => rejectWhenAborted(signal)
+
+    const { generateSessionTitle, titleOrNullForPromptFallback } =
+      await importSubject()
+    const title = await generateSessionTitle(
+      'Name a slow SDK title request',
+      new AbortController().signal,
+    )
+
+    const persistedTitle = titleOrNullForPromptFallback(title)
+    expect(title).toBe('OpenClaude')
+    expect(persistedTitle).toBeNull()
   })
 
   test('falls back when terminal sequence stripping leaves no title text', async () => {

--- a/src/utils/sessionTitle.test.ts
+++ b/src/utils/sessionTitle.test.ts
@@ -1,0 +1,266 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test'
+
+type QueryHaikuArgs = {
+  outputFormat?: unknown
+  signal: AbortSignal
+  options: {
+    querySource: string
+    agents: unknown[]
+    mcpTools: unknown[]
+    maxOutputTokensOverride?: number
+    temperatureOverride?: number
+    enablePromptCaching?: boolean
+    skipCacheWrite?: boolean
+  }
+}
+
+let queryHaikuCalls: QueryHaikuArgs[] = []
+let queryHaikuText = ''
+let queryHaikuImpl: (args: QueryHaikuArgs) => Promise<unknown>
+let structuredOutputsSupported = true
+let apiProvider = 'firstParty'
+let smallFastModel = 'claude-haiku-4-5'
+let analyticsEvents: Array<{ name: string; metadata: Record<string, unknown> }> =
+  []
+let debugMessages: Array<{ message: string; level?: string }> = []
+
+function assistantText(text: string): unknown {
+  return {
+    message: {
+      content: [{ type: 'text', text }],
+    },
+  }
+}
+
+async function importSubject() {
+  const nonce = `${Date.now()}-${Math.random()}`
+  const [actualAnalytics, actualBetas, actualDebug, actualModel, actualProviders] =
+    await Promise.all([
+      import(`../services/analytics/index.ts?actual=${nonce}`),
+      import(`./betas.ts?actual=${nonce}`),
+      import(`./debug.ts?actual=${nonce}`),
+      import(`./model/model.ts?actual=${nonce}`),
+      import(`./model/providers.ts?actual=${nonce}`),
+    ])
+
+  mock.module('../services/analytics/index.js', () => ({
+    ...actualAnalytics,
+    logEvent: (name: string, metadata: Record<string, unknown>) => {
+      analyticsEvents.push({ name, metadata })
+    },
+  }))
+  mock.module('../services/api/claude.js', () => ({
+    queryHaiku: async (args: QueryHaikuArgs) => {
+      queryHaikuCalls.push(args)
+      return queryHaikuImpl(args)
+    },
+  }))
+  mock.module('./betas.js', () => ({
+    ...actualBetas,
+    modelSupportsStructuredOutputs: () => structuredOutputsSupported,
+  }))
+  mock.module('./debug.js', () => ({
+    ...actualDebug,
+    logForDebugging: (
+      message: string,
+      options?: { level?: string },
+    ) => {
+      debugMessages.push({ message, level: options?.level })
+    },
+  }))
+  mock.module('./model/model.js', () => ({
+    ...actualModel,
+    getSmallFastModel: () => smallFastModel,
+  }))
+  mock.module('./model/providers.js', () => ({
+    ...actualProviders,
+    getAPIProvider: () => apiProvider,
+  }))
+
+  return import(`./sessionTitle.js?test=${nonce}`)
+}
+
+beforeEach(() => {
+  mock.restore()
+  queryHaikuCalls = []
+  queryHaikuText = '{"title":"Fix login button on mobile"}'
+  queryHaikuImpl = async () => assistantText(queryHaikuText)
+  structuredOutputsSupported = true
+  apiProvider = 'firstParty'
+  smallFastModel = 'claude-haiku-4-5'
+  analyticsEvents = []
+  debugMessages = []
+})
+
+afterEach(() => {
+  mock.restore()
+})
+
+describe('generateSessionTitle', () => {
+  test('uses a bounded internal-task profile for title generation', async () => {
+    const { generateSessionTitle } = await importSubject()
+    const callerAbort = new AbortController()
+
+    const title = await generateSessionTitle(
+      'Please fix the mobile login button',
+      callerAbort.signal,
+    )
+
+    expect(title).toBe('Fix login button on mobile')
+    expect(queryHaikuCalls).toHaveLength(1)
+    const call = queryHaikuCalls[0]!
+    expect(call.outputFormat).toEqual(
+      expect.objectContaining({ type: 'json_schema' }),
+    )
+    expect(call.signal).not.toBe(callerAbort.signal)
+    expect(call.options.querySource).toBe('generate_session_title')
+    expect(call.options.agents).toEqual([])
+    expect(call.options.mcpTools).toEqual([])
+    expect(call.options.maxOutputTokensOverride).toBe(64)
+    expect(call.options.maxOutputTokensOverride).toBeLessThanOrEqual(128)
+    expect(call.options.temperatureOverride).toBe(0)
+    expect(call.options.enablePromptCaching).toBe(false)
+    expect(call.options.skipCacheWrite).toBe(true)
+    expect(analyticsEvents).toContainEqual({
+      name: 'tengu_session_title_generated',
+      metadata: { success: true },
+    })
+  })
+
+  test('does not request schema mode for OpenAI-compatible routes without structured outputs', async () => {
+    structuredOutputsSupported = false
+    apiProvider = 'openai'
+    smallFastModel = 'glm-5.1'
+    queryHaikuText = ''
+
+    const { generateSessionTitle } = await importSubject()
+    const title = await generateSessionTitle(
+      'Summarize this session',
+      new AbortController().signal,
+    )
+
+    expect(title).toBe('OpenClaude')
+    expect(queryHaikuCalls[0]!.outputFormat).toBeUndefined()
+    expect(debugMessages).toContainEqual({
+      message:
+        'generateSessionTitle task=generate_session_title provider=openai model=glm-5.1 response_length=0 parse_failure=empty_response fallback=default',
+      level: 'warn',
+    })
+    expect(analyticsEvents).toContainEqual({
+      name: 'tengu_session_title_generated',
+      metadata: { success: false },
+    })
+  })
+
+  test('extracts an embedded JSON title from provider prose', async () => {
+    structuredOutputsSupported = false
+    queryHaikuText =
+      'Here is the title:\n{"title":"Refactor API client errors"}\nDone.'
+
+    const { generateSessionTitle } = await importSubject()
+    const title = await generateSessionTitle(
+      'Refactor the API error handling code',
+      new AbortController().signal,
+    )
+
+    expect(title).toBe('Refactor API client errors')
+    expect(analyticsEvents.at(-1)).toEqual({
+      name: 'tengu_session_title_generated',
+      metadata: { success: true },
+    })
+  })
+
+  test('falls back from malformed JSON to a short clean line', async () => {
+    structuredOutputsSupported = false
+    queryHaikuText = 'Fix login button on mobile\n\nThis is the concise title.'
+
+    const { generateSessionTitle } = await importSubject()
+    const title = await generateSessionTitle(
+      'The login button is broken on mobile',
+      new AbortController().signal,
+    )
+
+    expect(title).toBe('Fix login button on mobile')
+  })
+
+  test('cleans title labels from short-line fallback output', async () => {
+    structuredOutputsSupported = false
+    queryHaikuText = 'Title: Debug failing CI tests'
+
+    const { generateSessionTitle } = await importSubject()
+    const title = await generateSessionTitle(
+      'CI has a failing provider test',
+      new AbortController().signal,
+    )
+
+    expect(title).toBe('Debug failing CI tests')
+  })
+
+  test('extracts a quoted title-like string', async () => {
+    structuredOutputsSupported = false
+    queryHaikuText = 'The title should be "Debug failing CI tests".'
+
+    const { generateSessionTitle } = await importSubject()
+    const title = await generateSessionTitle(
+      'CI has a failing provider test',
+      new AbortController().signal,
+    )
+
+    expect(title).toBe('Debug failing CI tests')
+  })
+
+  test('rejects huge unusable responses safely', async () => {
+    structuredOutputsSupported = false
+    queryHaikuText = 'word '.repeat(5_000)
+
+    const { generateSessionTitle } = await importSubject()
+    const title = await generateSessionTitle(
+      'Name this session',
+      new AbortController().signal,
+    )
+
+    expect(title).toBe('OpenClaude')
+    expect(debugMessages.at(-1)?.message).toContain(
+      'parse_failure=unusable_response',
+    )
+    expect(debugMessages.at(-1)?.message).not.toContain('word word word word')
+  })
+
+  test('rejects obvious assistant prose', async () => {
+    structuredOutputsSupported = false
+    queryHaikuText = "I'll start by looking through the codebase."
+
+    const { generateSessionTitle } = await importSubject()
+    const title = await generateSessionTitle(
+      'Start the task',
+      new AbortController().signal,
+    )
+
+    expect(title).toBe('OpenClaude')
+  })
+
+  test('logs actual provider and model metadata when the title query throws', async () => {
+    apiProvider = 'openai'
+    smallFastModel = 'glm-5.1'
+    queryHaikuImpl = async () => {
+      throw new Error('provider rejected schema')
+    }
+
+    const { generateSessionTitle } = await importSubject()
+    const title = await generateSessionTitle(
+      'Name this session',
+      new AbortController().signal,
+    )
+
+    expect(title).toBe('OpenClaude')
+    expect(debugMessages).toContainEqual({
+      message:
+        'generateSessionTitle task=generate_session_title provider=openai model=glm-5.1 response_length=0 parse_failure=query_error fallback=default error_name=Error',
+      level: 'warn',
+    })
+    expect(analyticsEvents).toContainEqual({
+      name: 'tengu_session_title_generated',
+      metadata: { success: false },
+    })
+  })
+})

--- a/src/utils/sessionTitle.test.ts
+++ b/src/utils/sessionTitle.test.ts
@@ -23,6 +23,8 @@ let smallFastModel = 'claude-haiku-4-5'
 let analyticsEvents: Array<{ name: string; metadata: Record<string, unknown> }> =
   []
 let debugMessages: Array<{ message: string; level?: string }> = []
+let combinedAbortTimeouts: Array<number | undefined> = []
+let forcedCombinedTimeoutMs: number | null = null
 
 function assistantText(text: string): unknown {
   return {
@@ -32,12 +34,29 @@ function assistantText(text: string): unknown {
   }
 }
 
+function rejectWhenAborted(signal: AbortSignal): Promise<never> {
+  if (signal.aborted) return Promise.reject(signal.reason)
+  return new Promise((_resolve, reject) => {
+    signal.addEventListener('abort', () => reject(signal.reason), {
+      once: true,
+    })
+  })
+}
+
 async function importSubject() {
+  // Force Bun to load fresh module instances so each test sees current mocks.
   const nonce = `${Date.now()}-${Math.random()}`
-  const [actualAnalytics, actualBetas, actualDebug, actualModel, actualProviders] =
-    await Promise.all([
+  const [
+    actualAnalytics,
+    actualBetas,
+    actualCombinedAbortSignal,
+    actualDebug,
+    actualModel,
+    actualProviders,
+  ] = await Promise.all([
       import(`../services/analytics/index.ts?actual=${nonce}`),
       import(`./betas.ts?actual=${nonce}`),
+      import(`./combinedAbortSignal.ts?actual=${nonce}`),
       import(`./debug.ts?actual=${nonce}`),
       import(`./model/model.ts?actual=${nonce}`),
       import(`./model/providers.ts?actual=${nonce}`),
@@ -58,6 +77,44 @@ async function importSubject() {
   mock.module('./betas.js', () => ({
     ...actualBetas,
     modelSupportsStructuredOutputs: () => structuredOutputsSupported,
+  }))
+  mock.module('./combinedAbortSignal.js', () => ({
+    ...actualCombinedAbortSignal,
+    createCombinedAbortSignal: (
+      signal: AbortSignal | undefined,
+      opts?: { signalB?: AbortSignal; timeoutMs?: number },
+    ) => {
+      combinedAbortTimeouts.push(opts?.timeoutMs)
+      if (forcedCombinedTimeoutMs === null) {
+        return actualCombinedAbortSignal.createCombinedAbortSignal(signal, opts)
+      }
+
+      const combined = new AbortController()
+      if (signal?.aborted) {
+        combined.abort(signal.reason)
+        return { signal: combined.signal, cleanup: () => {} }
+      }
+
+      let timer: ReturnType<typeof setTimeout> | undefined
+      const cleanup = () => {
+        if (timer !== undefined) clearTimeout(timer)
+        signal?.removeEventListener('abort', abortFromSignal)
+      }
+      const abortFromSignal = () => {
+        cleanup()
+        combined.abort(signal?.reason)
+      }
+
+      signal?.addEventListener('abort', abortFromSignal)
+      timer = setTimeout(() => {
+        cleanup()
+        combined.abort(
+          new DOMException('The operation timed out.', 'TimeoutError'),
+        )
+      }, forcedCombinedTimeoutMs)
+
+      return { signal: combined.signal, cleanup }
+    },
   }))
   mock.module('./debug.js', () => ({
     ...actualDebug,
@@ -90,6 +147,8 @@ beforeEach(() => {
   smallFastModel = 'claude-haiku-4-5'
   analyticsEvents = []
   debugMessages = []
+  combinedAbortTimeouts = []
+  forcedCombinedTimeoutMs = null
 })
 
 afterEach(() => {
@@ -117,13 +176,68 @@ describe('generateSessionTitle', () => {
     expect(call.options.agents).toEqual([])
     expect(call.options.mcpTools).toEqual([])
     expect(call.options.maxOutputTokensOverride).toBe(64)
-    expect(call.options.maxOutputTokensOverride).toBeLessThanOrEqual(128)
     expect(call.options.temperatureOverride).toBe(0)
     expect(call.options.enablePromptCaching).toBe(false)
     expect(call.options.skipCacheWrite).toBe(true)
     expect(analyticsEvents).toContainEqual({
       name: 'tengu_session_title_generated',
       metadata: { success: true },
+    })
+  })
+
+  test('falls back when title generation times out', async () => {
+    forcedCombinedTimeoutMs = 1
+    queryHaikuImpl = async ({ signal }) => rejectWhenAborted(signal)
+
+    const { generateSessionTitle } = await importSubject()
+    const title = await generateSessionTitle(
+      'Name a slow provider response',
+      new AbortController().signal,
+    )
+
+    expect(title).toBe('OpenClaude')
+    expect(combinedAbortTimeouts).toEqual([12_000])
+    expect(queryHaikuCalls).toHaveLength(1)
+    expect(queryHaikuCalls[0]!.signal.aborted).toBe(true)
+    expect((queryHaikuCalls[0]!.signal.reason as DOMException).name).toBe(
+      'TimeoutError',
+    )
+    expect(debugMessages.at(-1)?.message).toContain(
+      'parse_failure=query_error',
+    )
+    expect(debugMessages.at(-1)?.message).toContain('error_name=TimeoutError')
+    expect(analyticsEvents).toContainEqual({
+      name: 'tengu_session_title_generated',
+      metadata: { success: false },
+    })
+  })
+
+  test('propagates caller aborts to the internal title signal', async () => {
+    queryHaikuImpl = async ({ signal }) => rejectWhenAborted(signal)
+
+    const { generateSessionTitle } = await importSubject()
+    const callerAbort = new AbortController()
+    const titlePromise = generateSessionTitle(
+      'Name an aborted session',
+      callerAbort.signal,
+    )
+
+    expect(queryHaikuCalls).toHaveLength(1)
+    expect(queryHaikuCalls[0]!.signal).not.toBe(callerAbort.signal)
+
+    const reason = new Error('caller cancelled')
+    callerAbort.abort(reason)
+
+    await expect(titlePromise).resolves.toBe('OpenClaude')
+    expect(queryHaikuCalls[0]!.signal.aborted).toBe(true)
+    expect(queryHaikuCalls[0]!.signal.reason).toBe(reason)
+    expect(debugMessages.at(-1)?.message).toContain(
+      'parse_failure=query_error',
+    )
+    expect(debugMessages.at(-1)?.message).toContain('error_name=Error')
+    expect(analyticsEvents).toContainEqual({
+      name: 'tengu_session_title_generated',
+      metadata: { success: false },
     })
   })
 
@@ -140,6 +254,7 @@ describe('generateSessionTitle', () => {
     )
 
     expect(title).toBe('OpenClaude')
+    expect(queryHaikuCalls).toHaveLength(1)
     expect(queryHaikuCalls[0]!.outputFormat).toBeUndefined()
     expect(debugMessages).toContainEqual({
       message:
@@ -207,6 +322,72 @@ describe('generateSessionTitle', () => {
     )
 
     expect(title).toBe('Debug failing CI tests')
+  })
+
+  test('strips terminal control sequences from structured titles', async () => {
+    queryHaikuText = JSON.stringify({
+      title: '\x1b]8;;https://example.invalid\x07Click\x1b]8;;\x07',
+    })
+
+    const { generateSessionTitle } = await importSubject()
+    const title = await generateSessionTitle(
+      'Open the linked issue',
+      new AbortController().signal,
+    )
+
+    expect(title).toBe('Click')
+  })
+
+  test('strips ANSI escape sequences from short-line fallback output', async () => {
+    structuredOutputsSupported = false
+    queryHaikuText = '\x1b[31mDebug failing CI tests\x1b[0m'
+
+    const { generateSessionTitle } = await importSubject()
+    const title = await generateSessionTitle(
+      'CI has a failing provider test',
+      new AbortController().signal,
+    )
+
+    expect(title).toBe('Debug failing CI tests')
+  })
+
+  test('lets prompt-fallback callers ignore the generic default title', async () => {
+    const { titleOrNullForPromptFallback } = await importSubject()
+
+    expect(titleOrNullForPromptFallback('Refactor API client errors')).toBe(
+      'Refactor API client errors',
+    )
+    expect(titleOrNullForPromptFallback('OpenClaude')).toBeNull()
+    expect(titleOrNullForPromptFallback(null)).toBeNull()
+  })
+
+  test('preserves prompt-fallback signal for empty provider output', async () => {
+    structuredOutputsSupported = false
+    queryHaikuText = ''
+
+    const { generateSessionTitle, titleOrNullForPromptFallback } =
+      await importSubject()
+    const title = await generateSessionTitle(
+      'Investigate remote session startup failure',
+      new AbortController().signal,
+    )
+
+    expect(title).toBe('OpenClaude')
+    expect(titleOrNullForPromptFallback(title)).toBeNull()
+  })
+
+  test('falls back when terminal sequence stripping leaves no title text', async () => {
+    queryHaikuText = JSON.stringify({
+      title: '\x1b]8;;https://example.invalid\x07\x1b]8;;\x07',
+    })
+
+    const { generateSessionTitle } = await importSubject()
+    const title = await generateSessionTitle(
+      'Open the linked issue',
+      new AbortController().signal,
+    )
+
+    expect(title).toBe('OpenClaude')
   })
 
   test('rejects huge unusable responses safely', async () => {

--- a/src/utils/sessionTitle.ts
+++ b/src/utils/sessionTitle.ts
@@ -36,6 +36,11 @@ const MAX_TITLE_WORDS = 10
 const MAX_CANDIDATE_CHARS = 200
 const MAX_CANDIDATE_WORDS = 20
 const FALLBACK_SESSION_TITLE = 'OpenClaude'
+const TERMINAL_CONTROL_SEQUENCE_PATTERN =
+  /\x1B(?:\][\s\S]*?(?:\x07|\x1B\\)|[PX^_][\s\S]*?\x1B\\|\[[0-?]*[ -/]*[@-~]|[@-_])|\x9B[0-?]*[ -/]*[@-~]/g
+const CONTROL_CHARACTER_PATTERN = /[\x00-\x08\x0B\x0C\x0E-\x1F\x7F-\x9F]/g
+const ESCAPED_CONTROL_CHARACTER_PATTERN =
+  /\\(?:x(?:0[0-8BCEFbcef]|1[0-9A-Fa-f]|7[Ff]|[89][0-9A-Fa-f])|u00(?:0[0-8BCEFbcef]|1[0-9A-Fa-f]|7[Ff]|[89][0-9A-Fa-f]))/
 
 /**
  * Flatten a message array into a single text string for Haiku title input.
@@ -114,10 +119,32 @@ type SessionTitleParseResult = {
   parseFailure: SessionTitleParseFailure
 }
 
+function stripTerminalControlSequences(value: string): string {
+  return value
+    .replace(TERMINAL_CONTROL_SEQUENCE_PATTERN, '')
+    .replace(CONTROL_CHARACTER_PATTERN, '')
+}
+
+function hasStringTitleField(value: unknown): boolean {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    !Array.isArray(value) &&
+    typeof (value as { title?: unknown }).title === 'string'
+  )
+}
+
+export function titleOrNullForPromptFallback(
+  title: string | null,
+): string | null {
+  return title === FALLBACK_SESSION_TITLE ? null : title
+}
+
 function sanitizeTitleCandidate(candidate: unknown): string | null {
   if (typeof candidate !== 'string') return null
+  if (ESCAPED_CONTROL_CHARACTER_PATTERN.test(candidate)) return null
 
-  let title = candidate
+  let title = stripTerminalControlSequences(candidate)
     .replace(/\r\n?/g, '\n')
     .replace(/^```[a-z0-9_-]*\s*/i, '')
     .replace(/```\s*$/i, '')
@@ -251,13 +278,22 @@ function parseSessionTitleResponse(text: string): SessionTitleParseResult {
     }
   }
 
-  const strictTitle = parseTitleFromJSON(safeParseJSON(response, false))
+  const strictJSON = safeParseJSON(response, false)
+  const strictTitle = parseTitleFromJSON(strictJSON)
   if (strictTitle) {
     return {
       title: strictTitle,
       success: true,
       fallback: 'strict_json',
       parseFailure: 'none',
+    }
+  }
+  if (hasStringTitleField(strictJSON)) {
+    return {
+      title: FALLBACK_SESSION_TITLE,
+      success: false,
+      fallback: 'default',
+      parseFailure: 'unusable_response',
     }
   }
 

--- a/src/utils/sessionTitle.ts
+++ b/src/utils/sessionTitle.ts
@@ -175,7 +175,7 @@ function sanitizeTitleCandidate(candidate: unknown): string | null {
   if (/^title$/i.test(title)) return null
 
   const assistantProse =
-    /^(?:i['\u2019]?ll|i will|i can|i would|let me|here['\u2019]?s|here is|sure[, ]|certainly[, ]|of course[, ]|the title (?:is|should be)|this (?:session|title)|based on)\b/i
+    /^(?:i['\u2019]?ll|i will|i can|i would|let me|here['\u2019]?s|here is|here are|sure[, ]|certainly[, ]|of course[, ]|the title (?:is|should be)|this (?:session|title)|based on|possible (?:session )?titles?|(?:title )?(?:ideas|options|suggestions))\b/i
   if (assistantProse.test(title)) return null
 
   const words = title.split(/\s+/).filter(Boolean)

--- a/src/utils/sessionTitle.ts
+++ b/src/utils/sessionTitle.ts
@@ -17,13 +17,25 @@ import { getIsNonInteractiveSession } from '../bootstrap/state.js'
 import { logEvent } from '../services/analytics/index.js'
 import { queryHaiku } from '../services/api/claude.js'
 import type { Message } from '../types/message.js'
+import { modelSupportsStructuredOutputs } from './betas.js'
+import { createCombinedAbortSignal } from './combinedAbortSignal.js'
 import { logForDebugging } from './debug.js'
 import { safeParseJSON } from './json.js'
 import { lazySchema } from './lazySchema.js'
 import { extractTextContent } from './messages.js'
+import { getSmallFastModel } from './model/model.js'
+import { getAPIProvider } from './model/providers.js'
 import { asSystemPrompt } from './systemPromptType.js'
 
 const MAX_CONVERSATION_TEXT = 1000
+const SESSION_TITLE_MAX_OUTPUT_TOKENS = 64
+const SESSION_TITLE_TIMEOUT_MS = 12_000
+const MAX_TITLE_RESPONSE_TEXT = 4096
+const MAX_TITLE_CHARS = 60
+const MAX_TITLE_WORDS = 10
+const MAX_CANDIDATE_CHARS = 200
+const MAX_CANDIDATE_WORDS = 20
+const FALLBACK_SESSION_TITLE = 'OpenClaude'
 
 /**
  * Flatten a message array into a single text string for Haiku title input.
@@ -69,9 +81,270 @@ Bad (wrong case): {"title": "Fix Login Button On Mobile"}`
 
 const titleSchema = lazySchema(() => z.object({ title: z.string() }))
 
+const SESSION_TITLE_OUTPUT_FORMAT = {
+  type: 'json_schema',
+  schema: {
+    type: 'object',
+    properties: {
+      title: { type: 'string' },
+    },
+    required: ['title'],
+    additionalProperties: false,
+  },
+} as const
+
+type SessionTitleFallback =
+  | 'strict_json'
+  | 'embedded_json'
+  | 'quoted_string'
+  | 'short_line'
+  | 'default'
+
+type SessionTitleParseFailure =
+  | 'none'
+  | 'empty_response'
+  | 'strict_json_parse_failed'
+  | 'unusable_response'
+  | 'query_error'
+
+type SessionTitleParseResult = {
+  title: string
+  success: boolean
+  fallback: SessionTitleFallback
+  parseFailure: SessionTitleParseFailure
+}
+
+function sanitizeTitleCandidate(candidate: unknown): string | null {
+  if (typeof candidate !== 'string') return null
+
+  let title = candidate
+    .replace(/\r\n?/g, '\n')
+    .replace(/^```[a-z0-9_-]*\s*/i, '')
+    .replace(/```\s*$/i, '')
+    .trim()
+
+  const firstLine = title
+    .split('\n')
+    .map(line => line.trim())
+    .find(Boolean)
+  if (!firstLine) return null
+
+  title = firstLine
+    .replace(/^(?:[-*+\u2022]\s+|\d+[.)]\s+|#+\s+|>\s+)/, '')
+    .replace(/^`+|`+$/g, '')
+    .replace(/^\*\*(.+)\*\*$/, '$1')
+    .replace(/^__(.+)__$/, '$1')
+    .replace(/^_(.+)_$/, '$1')
+    .replace(/^\*(.+)\*$/, '$1')
+    .replace(/^["'\u201c\u201d\u2018\u2019]+|["'\u201c\u201d\u2018\u2019]+$/g, '')
+    .replace(/^(?:title|session title)\s*:\s*/i, '')
+    .replace(/\s+/g, ' ')
+    .trim()
+
+  if (!title) return null
+  if (/^[{}\[\],:"'\u201c\u201d\u2018\u2019\s]+$/.test(title)) return null
+  if (/^\{.*\}$/.test(title) || /^\[.*\]$/.test(title)) return null
+  if (/"title"\s*:/.test(title)) return null
+  if (/^title$/i.test(title)) return null
+
+  const assistantProse =
+    /^(?:i['\u2019]?ll|i will|i can|i would|let me|here['\u2019]?s|here is|sure[, ]|certainly[, ]|of course[, ]|the title (?:is|should be)|this (?:session|title)|based on)\b/i
+  if (assistantProse.test(title)) return null
+
+  const words = title.split(/\s+/).filter(Boolean)
+  if (title.length > MAX_CANDIDATE_CHARS || words.length > MAX_CANDIDATE_WORDS) {
+    return null
+  }
+
+  if (words.length > MAX_TITLE_WORDS) {
+    title = words.slice(0, MAX_TITLE_WORDS).join(' ')
+  }
+
+  if (title.length > MAX_TITLE_CHARS) {
+    const truncated = title.slice(0, MAX_TITLE_CHARS).trim()
+    title = truncated.replace(/\s+\S*$/, '').trim() || truncated
+  }
+
+  title = title.replace(/[.?!]+$/g, '').trim()
+  return title || null
+}
+
+function parseTitleFromJSON(value: unknown): string | null {
+  const parsed = titleSchema().safeParse(value)
+  if (!parsed.success) return null
+  return sanitizeTitleCandidate(parsed.data.title)
+}
+
+function extractFirstJSONObject(text: string): string | null {
+  let start = -1
+  let depth = 0
+  let inString = false
+  let escaped = false
+
+  for (let i = 0; i < text.length; i++) {
+    const char = text[i]
+
+    if (start === -1) {
+      if (char === '{') {
+        start = i
+        depth = 1
+      }
+      continue
+    }
+
+    if (inString) {
+      if (escaped) {
+        escaped = false
+      } else if (char === '\\') {
+        escaped = true
+      } else if (char === '"') {
+        inString = false
+      }
+      continue
+    }
+
+    if (char === '"') {
+      inString = true
+      continue
+    }
+    if (char === '{') {
+      depth++
+      continue
+    }
+    if (char === '}') {
+      depth--
+      if (depth === 0) {
+        return text.slice(start, i + 1)
+      }
+    }
+  }
+
+  return null
+}
+
+function extractQuotedTitle(text: string): string | null {
+  const titled =
+    /\btitle\b[^"'\u201c\u201d\u2018\u2019\n]{0,32}["'\u201c\u201d\u2018\u2019]([^"'\u201c\u201d\u2018\u2019\n]{1,160})["'\u201c\u201d\u2018\u2019]/i.exec(
+      text,
+    )
+  const titledCandidate = sanitizeTitleCandidate(titled?.[1])
+  if (titledCandidate) return titledCandidate
+
+  const quoted =
+    /["'\u201c\u201d\u2018\u2019]([^"'\u201c\u201d\u2018\u2019\n]{1,160})["'\u201c\u201d\u2018\u2019]/g
+  for (const match of text.matchAll(quoted)) {
+    const candidate = sanitizeTitleCandidate(match[1])
+    if (candidate) return candidate
+  }
+
+  return null
+}
+
+function parseSessionTitleResponse(text: string): SessionTitleParseResult {
+  const response = text.trim()
+  if (!response) {
+    return {
+      title: FALLBACK_SESSION_TITLE,
+      success: false,
+      fallback: 'default',
+      parseFailure: 'empty_response',
+    }
+  }
+
+  const strictTitle = parseTitleFromJSON(safeParseJSON(response, false))
+  if (strictTitle) {
+    return {
+      title: strictTitle,
+      success: true,
+      fallback: 'strict_json',
+      parseFailure: 'none',
+    }
+  }
+
+  const inspectable = response.slice(0, MAX_TITLE_RESPONSE_TEXT)
+  const embedded = extractFirstJSONObject(inspectable)
+  if (embedded) {
+    const embeddedTitle = parseTitleFromJSON(safeParseJSON(embedded, false))
+    if (embeddedTitle) {
+      return {
+        title: embeddedTitle,
+        success: true,
+        fallback: 'embedded_json',
+        parseFailure: 'strict_json_parse_failed',
+      }
+    }
+  }
+
+  const quotedTitle = extractQuotedTitle(inspectable)
+  if (quotedTitle) {
+    return {
+      title: quotedTitle,
+      success: true,
+      fallback: 'quoted_string',
+      parseFailure: 'strict_json_parse_failed',
+    }
+  }
+
+  for (const line of inspectable.split('\n')) {
+    const title = sanitizeTitleCandidate(line)
+    if (title) {
+      return {
+        title,
+        success: true,
+        fallback: 'short_line',
+        parseFailure: 'strict_json_parse_failed',
+      }
+    }
+  }
+
+  return {
+    title: FALLBACK_SESSION_TITLE,
+    success: false,
+    fallback: 'default',
+    parseFailure: 'unusable_response',
+  }
+}
+
+function logSessionTitleDiagnostic({
+  provider,
+  model,
+  responseLength,
+  parseFailure,
+  fallback,
+  level,
+  error,
+}: {
+  provider: string
+  model: string
+  responseLength: number
+  parseFailure: SessionTitleParseFailure
+  fallback: SessionTitleFallback
+  level: 'debug' | 'warn'
+  error?: unknown
+}): void {
+  const parts = [
+    'generateSessionTitle',
+    'task=generate_session_title',
+    `provider=${provider}`,
+    `model=${model}`,
+    `response_length=${responseLength}`,
+    `parse_failure=${parseFailure}`,
+    `fallback=${fallback}`,
+  ]
+
+  if (error !== undefined) {
+    parts.push(
+      `error_name=${error instanceof Error ? error.name : typeof error}`,
+    )
+  }
+
+  logForDebugging(parts.join(' '), { level })
+}
+
 /**
  * Generate a sentence-case session title from a description or first message.
- * Returns null on error or if Haiku returns an unparseable response.
+ * Returns null for empty input and otherwise falls back to OpenClaude when
+ * provider output cannot be turned into a safe short title.
  *
  * @param description - The user's first message or a description of the session
  * @param signal - Abort signal for cancellation
@@ -83,22 +356,21 @@ export async function generateSessionTitle(
   const trimmed = description.trim()
   if (!trimmed) return null
 
+  const model = getSmallFastModel()
+  const provider = getAPIProvider()
+  const outputFormat = modelSupportsStructuredOutputs(model)
+    ? SESSION_TITLE_OUTPUT_FORMAT
+    : undefined
+  const titleSignal = createCombinedAbortSignal(signal, {
+    timeoutMs: SESSION_TITLE_TIMEOUT_MS,
+  })
+
   try {
     const result = await queryHaiku({
       systemPrompt: asSystemPrompt([SESSION_TITLE_PROMPT]),
       userPrompt: trimmed,
-      outputFormat: {
-        type: 'json_schema',
-        schema: {
-          type: 'object',
-          properties: {
-            title: { type: 'string' },
-          },
-          required: ['title'],
-          additionalProperties: false,
-        },
-      },
-      signal,
+      outputFormat,
+      signal: titleSignal.signal,
       options: {
         querySource: 'generate_session_title',
         agents: [],
@@ -107,27 +379,47 @@ export async function generateSessionTitle(
         // session path via useRemoteSession (interactive).
         isNonInteractiveSession: getIsNonInteractiveSession(),
         hasAppendSystemPrompt: false,
+        maxOutputTokensOverride: SESSION_TITLE_MAX_OUTPUT_TOKENS,
+        temperatureOverride: 0,
+        enablePromptCaching: false,
+        skipCacheWrite: true,
         mcpTools: [],
       },
     })
 
     const text = extractTextContent(result.message.content)
+    const parsed = parseSessionTitleResponse(text)
 
-    const parsed = titleSchema().safeParse(safeParseJSON(text))
-    const title = parsed.success ? parsed.data.title.trim() || null : null
+    if (parsed.fallback !== 'strict_json') {
+      logSessionTitleDiagnostic({
+        provider,
+        model,
+        responseLength: text.length,
+        parseFailure: parsed.parseFailure,
+        fallback: parsed.fallback,
+        level: parsed.success ? 'debug' : 'warn',
+      })
+    }
 
-    logEvent('tengu_session_title_generated', { success: title !== null })
+    logEvent('tengu_session_title_generated', { success: parsed.success })
 
-    return title
+    return parsed.title
   } catch (error) {
-    logForDebugging(`generateSessionTitle failed: ${error}`, {
-      level: 'error',
+    logSessionTitleDiagnostic({
+      provider,
+      model,
+      responseLength: 0,
+      parseFailure: 'query_error',
+      fallback: 'default',
+      level: 'warn',
+      error,
     })
     logEvent('tengu_session_title_generated', { success: false })
 
     // Fallback: When using 3P providers without a compatible schema,
     // default to the application name.
-    return 'OpenClaude'
+    return FALLBACK_SESSION_TITLE
+  } finally {
+    titleSignal.cleanup()
   }
 }
-


### PR DESCRIPTION
## Summary

- Bound session-title generation with a small internal-task profile: non-streaming path, 64 output tokens, temperature 0, short timeout, no tools, and no cache writes.
- Gate JSON schema mode to routes that support structured output, while treating all provider output as best effort.
- Harden generated-title parsing and sanitization for malformed JSON, embedded JSON, quoted titles, prose, empty responses, oversized unusable responses, and terminal control sequences.
- Preserve prompt-derived fallback titles in remote, bridge, and REPL callers when generation falls back to the generic app name.
- Log compact title-generation diagnostics with the actual provider route and model without logging raw model output.

## Why

Session title generation is metadata work. It should be cheap, bounded, safe to render, and resilient when OpenAI-compatible or custom providers ignore structured-output instructions and return verbose prose instead of strict JSON.

## Impact

- User-facing: session titles remain useful when provider title generation fails, instead of being overwritten with a generic app name where a prompt-derived fallback exists.
- Safety: generated titles strip terminal control sequences before they can be persisted, synced, logged, or rendered.
- Risk surface: provider routing and structured-output gating remain defensive and best-effort; no new provider selection path or external endpoint is introduced.

## Testing

- [x] `bun test ./src/utils/sessionTitle.test.ts`
- [x] `bun run typecheck`
- [x] `bun run smoke`
- [x] `git diff --check`
- [x] GitHub Actions: `web`, `typecheck`, `smoke-and-tests`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved session title generation with enhanced multi-stage parsing and comprehensive fallback mechanisms.

* **Bug Fixes**
  * Enhanced error handling and timeout management for session title generation operations.

* **Tests**
  * Added comprehensive test coverage for title generation and fallback logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->