### PR TITLE
fix(messages): make projections tool-pair safe

### DIFF
--- a/src/services/awaySummary.test.ts
+++ b/src/services/awaySummary.test.ts
@@ -1,0 +1,131 @@
+import { beforeEach, expect, mock, test } from 'bun:test'
+import type {
+  AssistantMessage,
+  Message,
+  UserMessage,
+} from '../types/message.js'
+import {
+  createAssistantMessage,
+  createUserMessage,
+  validateToolResultPairing,
+} from '../utils/messages.js'
+
+let capturedMessages: Message[] | null = null
+
+const queryModelWithoutStreamingMock = mock(
+  async (params: { messages: Message[] }) => {
+    capturedMessages = params.messages
+    return createAssistantMessage({
+      content: [
+        {
+          type: 'text',
+          text: 'Back to the implementation.',
+          citations: [],
+        },
+      ],
+    })
+  },
+)
+
+mock.module('./api/claude.js', () => ({
+  queryModelWithoutStreaming: queryModelWithoutStreamingMock,
+}))
+
+mock.module('./SessionMemory/sessionMemoryUtils.js', () => ({
+  getSessionMemoryContent: mock(async () => null),
+}))
+
+const { generateAwaySummary } = await import('./awaySummary.js')
+
+const RECENT_WINDOW_FOR_TEST = 30
+
+function assistantWithToolUse(id: string): Message {
+  return createAssistantMessage({
+    content: [
+      {
+        type: 'tool_use',
+        id,
+        name: 'Read',
+        input: { file_path: '/tmp/example.txt' },
+      },
+    ],
+  })
+}
+
+function userWithToolResult(id: string): Message {
+  return createUserMessage({
+    content: [
+      {
+        type: 'tool_result',
+        tool_use_id: id,
+        content: 'file contents',
+      },
+    ],
+  })
+}
+
+function isPairableMessage(
+  message: Message,
+): message is UserMessage | AssistantMessage {
+  return message.type === 'user' || message.type === 'assistant'
+}
+
+function capturedConversationBeforeRecapPrompt(): (UserMessage | AssistantMessage)[] {
+  // The last captured message is the recap prompt added by generateAwaySummary.
+  return capturedMessages!.slice(0, -1).filter(isPairableMessage)
+}
+
+beforeEach(() => {
+  capturedMessages = null
+  queryModelWithoutStreamingMock.mockClear()
+})
+
+test('generateAwaySummary does not start its recent projection with an orphan tool_result', async () => {
+  const toolUseId = 'toolu_away_summary'
+  const messages: Message[] = [
+    assistantWithToolUse(toolUseId),
+    userWithToolResult(toolUseId),
+  ]
+
+  for (let i = 0; i < RECENT_WINDOW_FOR_TEST - 1; i++) {
+    messages.push(createUserMessage({ content: `recent turn ${i}` }))
+  }
+
+  const summary = await generateAwaySummary(
+    messages,
+    new AbortController().signal,
+  )
+
+  expect(summary).toBe('Back to the implementation.')
+  expect(capturedMessages).not.toBeNull()
+  expect(capturedMessages?.[0]?.type).toBe('assistant')
+  expect(capturedMessages?.[1]?.type).toBe('user')
+
+  expect(
+    validateToolResultPairing(capturedConversationBeforeRecapPrompt()).valid,
+  ).toBe(true)
+})
+
+test('generateAwaySummary drops an orphaned tool_result instead of expanding beyond the recent window', async () => {
+  const toolUseId = 'toolu_away_summary_old'
+  const messages: Message[] = [assistantWithToolUse(toolUseId)]
+
+  // Push the matching tool_use beyond the allowed expansion budget.
+  for (let i = 0; i < RECENT_WINDOW_FOR_TEST + 5; i++) {
+    messages.push(createUserMessage({ content: `older filler ${i}` }))
+  }
+  messages.push(userWithToolResult(toolUseId))
+  for (let i = 0; i < RECENT_WINDOW_FOR_TEST - 1; i++) {
+    messages.push(createUserMessage({ content: `recent turn ${i}` }))
+  }
+
+  await generateAwaySummary(messages, new AbortController().signal)
+
+  expect(capturedMessages).not.toBeNull()
+  expect(capturedMessages?.[0]?.type).toBe('user')
+  expect(capturedMessages?.[0]?.message.content).toBe('recent turn 0')
+
+  expect(
+    validateToolResultPairing(capturedConversationBeforeRecapPrompt()).valid,
+  ).toBe(true)
+})

--- a/src/services/awaySummary.ts
+++ b/src/services/awaySummary.ts
@@ -5,6 +5,7 @@ import { logForDebugging } from '../utils/debug.js'
 import {
   createUserMessage,
   getAssistantMessageText,
+  selectToolPairSafeMessageRange,
 } from '../utils/messages.js'
 import { getSmallFastModel } from '../utils/model/model.js'
 import { asSystemPrompt } from '../utils/systemPromptType.js'
@@ -36,7 +37,20 @@ export async function generateAwaySummary(
 
   try {
     const memory = await getSessionMemoryContent()
-    const recent = messages.slice(-RECENT_MESSAGE_WINDOW)
+    const requestedStart = Math.max(0, messages.length - RECENT_MESSAGE_WINDOW)
+    const recentRange = selectToolPairSafeMessageRange(
+      messages,
+      requestedStart,
+      messages.length,
+      {
+        projectionName: 'away_summary',
+        querySource: 'away_summary',
+        // Keep recaps bounded: if a matching pair is farther back than one
+        // recent window, drop the partial pair instead of expanding indefinitely.
+        maxExtraMessages: RECENT_MESSAGE_WINDOW,
+      },
+    )
+    const recent = [...recentRange.messages]
     recent.push(createUserMessage({ content: buildAwaySummaryPrompt(memory) }))
     const response = await queryModelWithoutStreaming({
       messages: recent,

--- a/src/services/compact/compact.test.ts
+++ b/src/services/compact/compact.test.ts
@@ -95,6 +95,60 @@ function assistantMessage(text: string): Message {
   }
 }
 
+function assistantToolUseMessage(toolUseId: string): Message {
+  return {
+    type: 'assistant',
+    message: {
+      role: 'assistant',
+      id: `msg-${toolUseId}`,
+      model: 'claude-sonnet-4-5',
+      usage: {
+        input_tokens: 0,
+        output_tokens: 0,
+        cache_creation_input_tokens: 0,
+        cache_read_input_tokens: 0,
+      },
+      content: [
+        {
+          type: 'tool_use',
+          id: toolUseId,
+          name: 'Read',
+          input: { file_path: '/tmp/example.txt' },
+        },
+      ],
+    } as never,
+    uuid: randomUUID(),
+    timestamp: new Date().toISOString(),
+  }
+}
+
+function toolResultMessage(toolUseId: string): Message {
+  return {
+    type: 'user',
+    message: {
+      role: 'user',
+      content: [
+        {
+          type: 'tool_result',
+          tool_use_id: toolUseId,
+          content: 'file contents',
+        },
+      ],
+    },
+    uuid: randomUUID(),
+    timestamp: new Date().toISOString(),
+  } as Message
+}
+
+function hasToolResultBlock(message: Message): boolean {
+  const content =
+    message.type === 'user' ? message.message.content : undefined
+  return (
+    Array.isArray(content) &&
+    content.some(block => block.type === 'tool_result')
+  )
+}
+
 function toolUseContext() {
   return {
     agentId: 'test-agent',
@@ -320,6 +374,8 @@ function registerCommonCompactStubs(options: CompactMockOptions = {}) {
     getMessagesAfterCompactBoundary: mock((msgs: Message[]) => msgs),
     isCompactBoundaryMessage: mock(() => false),
     normalizeMessagesForAPI: mock((msgs: Message[]) => msgs),
+    selectToolPairSafeMessageRange:
+      _realMessagesModule.selectToolPairSafeMessageRange,
   }))
 
   // --- API / streaming (DEFENSIVE) ---
@@ -767,5 +823,51 @@ describe('compactConversation compactModel override', () => {
     ]
     expect(streamOptions.model).toBe(resolvedCompactModel)
     expect(streamOptions.maxOutputTokensOverride).toBe(4096)
+  })
+})
+
+describe('partialCompactConversation tool-pair-safe boundaries', () => {
+  test('up_to pivot on a tool_result keeps the dangling result out of the kept side', async () => {
+    const { partialCompactConversation } = await importCompact({})
+    const toolUseId = 'toolu_partial_up_to'
+    const head = userMessage('older context')
+    const assistant = assistantToolUseMessage(toolUseId)
+    const result = toolResultMessage(toolUseId)
+    const tail = userMessage('current context')
+    const messages = [head, assistant, result, tail]
+
+    const compacted = await partialCompactConversation(
+      messages,
+      2,
+      toolUseContext(),
+      cacheSafeParams(messages),
+      undefined,
+      'up_to',
+    )
+
+    expect(compacted.messagesToKeep.map(m => m.uuid)).toEqual([tail.uuid])
+    expect(compacted.messagesToKeep.some(hasToolResultBlock)).toBe(false)
+  })
+
+  test('from pivot on a tool_result expands the summarized side backward to include the tool_use', async () => {
+    const { partialCompactConversation } = await importCompact({})
+    const toolUseId = 'toolu_partial_from'
+    const head = userMessage('older context')
+    const assistant = assistantToolUseMessage(toolUseId)
+    const result = toolResultMessage(toolUseId)
+    const tail = userMessage('current context')
+    const messages = [head, assistant, result, tail]
+
+    const compacted = await partialCompactConversation(
+      messages,
+      2,
+      toolUseContext(),
+      cacheSafeParams(messages),
+      undefined,
+      'from',
+    )
+
+    expect(compacted.messagesToKeep.map(m => m.uuid)).toEqual([head.uuid])
+    expect(compacted.messagesToKeep.some(hasToolResultBlock)).toBe(false)
   })
 })

--- a/src/services/compact/compact.ts
+++ b/src/services/compact/compact.ts
@@ -69,6 +69,7 @@ import {
   getMessagesAfterCompactBoundary,
   isCompactBoundaryMessage,
   normalizeMessagesForAPI,
+  selectToolPairSafeMessageRange,
 } from '../../utils/messages.js'
 import { expandPath } from '../../utils/path.js'
 import { getPlan, getPlanFilePath } from '../../utils/plans.js'
@@ -816,10 +817,19 @@ export async function partialCompactConversation(
   direction: PartialCompactDirection = 'from',
 ): Promise<CompactionResult> {
   try {
-    const messagesToSummarize =
-      direction === 'up_to'
-        ? allMessages.slice(0, pivotIndex)
-        : allMessages.slice(pivotIndex)
+    const requestedStart = direction === 'up_to' ? 0 : pivotIndex
+    const requestedEnd =
+      direction === 'up_to' ? pivotIndex : allMessages.length
+    const summarizeRange = selectToolPairSafeMessageRange(
+      allMessages,
+      requestedStart,
+      requestedEnd,
+      {
+        projectionName: 'partial_compact',
+        querySource: 'compact',
+      },
+    )
+    const messagesToSummarize = summarizeRange.messages
     // 'up_to' must strip old compact boundaries/summaries: for 'up_to',
     // summary_B sits BEFORE kept, so a stale boundary_A in kept wins
     // findLastCompactBoundaryIndex's backward scan and drops summary_B.
@@ -828,14 +838,16 @@ export async function partialCompactConversation(
     const messagesToKeep =
       direction === 'up_to'
         ? allMessages
-            .slice(pivotIndex)
+            .slice(summarizeRange.end)
             .filter(
               m =>
                 m.type !== 'progress' &&
                 !isCompactBoundaryMessage(m) &&
                 !(m.type === 'user' && m.isCompactSummary),
             )
-        : allMessages.slice(0, pivotIndex).filter(m => m.type !== 'progress')
+        : allMessages
+            .slice(0, summarizeRange.start)
+            .filter(m => m.type !== 'progress')
 
     if (messagesToSummarize.length === 0) {
       throw new Error(
@@ -1046,8 +1058,9 @@ export async function partialCompactConversation(
     // a logicalParentUuid pointing at one. Both directions skip them.
     const lastPreCompactUuid =
       direction === 'up_to'
-        ? allMessages.slice(0, pivotIndex).findLast(m => m.type !== 'progress')
-            ?.uuid
+        ? allMessages
+            .slice(0, summarizeRange.end)
+            .findLast(m => m.type !== 'progress')?.uuid
         : messagesToKeep.at(-1)?.uuid
     const boundaryMarker = createCompactBoundaryMessage(
       'manual',

--- a/src/utils/messages.toolPairingDiagnostics.test.ts
+++ b/src/utils/messages.toolPairingDiagnostics.test.ts
@@ -4,6 +4,7 @@ import {
   createAssistantMessage,
   createUserMessage,
   ensureToolResultPairing,
+  selectToolPairSafeMessageRange,
   validateToolResultPairing,
 } from './messages.js'
 
@@ -171,4 +172,188 @@ test('ensureToolResultPairing keeps repairing legacy mismatches', () => {
     tool_use_id: 'toolu_missing',
     is_error: true,
   })
+})
+
+test('selectToolPairSafeMessageRange expands a tool_result start boundary backward', () => {
+  const preamble = createUserMessage({ content: 'older context' })
+  const assistant = assistantWithToolUses('toolu_window_start')
+  const result = userWithToolResults('toolu_window_start')
+  const tail = createUserMessage({ content: 'current request' })
+
+  const selected = selectToolPairSafeMessageRange(
+    [preamble, assistant, result, tail],
+    2,
+    4,
+    { projectionName: 'away_summary', querySource: 'away_summary' },
+  )
+
+  expect(selected.start).toBe(1)
+  expect(selected.end).toBe(4)
+  expect(selected.messages).toEqual([assistant, result, tail])
+  expect(selected.diagnostics.requestedStartedWithToolResult).toBe(true)
+  expect(selected.diagnostics.issueKinds).toContain('orphaned_tool_result')
+  expect(validateToolResultPairing(selected.messages).valid).toBe(true)
+})
+
+test('selectToolPairSafeMessageRange expands an assistant tool_use end boundary forward', () => {
+  const head = createUserMessage({ content: 'older context' })
+  const assistant = assistantWithToolUses('toolu_window_end')
+  const result = userWithToolResults('toolu_window_end')
+  const tail = createUserMessage({ content: 'current request' })
+
+  const selected = selectToolPairSafeMessageRange(
+    [head, assistant, result, tail],
+    0,
+    2,
+    { projectionName: 'partial_compact', querySource: 'compact' },
+  )
+
+  expect(selected.start).toBe(0)
+  expect(selected.end).toBe(3)
+  expect(selected.messages).toEqual([head, assistant, result])
+  expect(selected.diagnostics.issueKinds).toContain('missing_tool_result')
+  expect(validateToolResultPairing(selected.messages).valid).toBe(true)
+})
+
+test('selectToolPairSafeMessageRange keeps multi-tool assistant messages with their results', () => {
+  const assistant = assistantWithToolUses('toolu_multi_a', 'toolu_multi_b')
+  const result = userWithToolResults('toolu_multi_a', 'toolu_multi_b')
+  const tail = createUserMessage({ content: 'current request' })
+
+  const selected = selectToolPairSafeMessageRange(
+    [assistant, result, tail],
+    0,
+    1,
+    { projectionName: 'summary_window', querySource: 'away_summary' },
+  )
+
+  expect(selected.messages).toEqual([assistant, result])
+  expect(selected.diagnostics.issueKinds).toContain('missing_tool_result')
+  expect(validateToolResultPairing(selected.messages).valid).toBe(true)
+})
+
+test('selectToolPairSafeMessageRange diagnostics omit raw message content', () => {
+  const assistant = assistantWithToolUses('toolu_secret')
+  const result = userWithToolResults('toolu_secret')
+
+  const selected = selectToolPairSafeMessageRange([assistant, result], 1, 2, {
+    projectionName: 'away_summary',
+    querySource: 'away_summary',
+  })
+
+  expect(selected.diagnostics.projectionName).toBe('away_summary')
+  expect(selected.diagnostics.querySource).toBe('away_summary')
+  expect(selected.diagnostics.requestedRange).toEqual({ start: 1, end: 2 })
+  expect(selected.diagnostics.adjustedRange).toEqual({ start: 0, end: 2 })
+  expect(JSON.stringify(selected.diagnostics)).not.toContain('result for')
+})
+
+test('selectToolPairSafeMessageRange does not re-expand across a dropped orphaned tool_result', () => {
+  const earlierAssistantPart = createAssistantMessage({
+    content: [{ type: 'text', text: 'thinking', citations: [] }],
+  })
+  const laterAssistantPart = createAssistantMessage({
+    content: [{ type: 'text', text: 'continuing', citations: [] }],
+  })
+  laterAssistantPart.message.id = earlierAssistantPart.message.id
+  const orphanedResult = userWithToolResults('toolu_unavailable')
+  const tail = createUserMessage({ content: 'current request' })
+
+  const selected = selectToolPairSafeMessageRange(
+    [earlierAssistantPart, orphanedResult, laterAssistantPart, tail],
+    1,
+    4,
+    { projectionName: 'away_summary', querySource: 'away_summary' },
+  )
+
+  expect(selected.start).toBe(3)
+  expect(selected.messages).toEqual([tail])
+  expect(validateToolResultPairing(selected.messages).valid).toBe(true)
+})
+
+test('selectToolPairSafeMessageRange still expands available results when pending tool uses are allowed', () => {
+  const head = createUserMessage({ content: 'older context' })
+  const assistant = assistantWithToolUses('toolu_pending_allowed')
+  const result = userWithToolResults('toolu_pending_allowed')
+
+  const selected = selectToolPairSafeMessageRange([head, assistant, result], 0, 2, {
+    projectionName: 'live_turn',
+    querySource: 'repl_main_thread',
+    allowPendingToolUse: true,
+  })
+
+  expect(selected.messages).toEqual([head, assistant, result])
+  expect(validateToolResultPairing(selected.messages).valid).toBe(true)
+})
+
+test('selectToolPairSafeMessageRange does not treat out-of-range results as pending tool uses', () => {
+  const head = createUserMessage({ content: 'older context' })
+  const assistant = assistantWithToolUses('toolu_not_pending')
+  const filler = createUserMessage({ content: 'filler' })
+  const result = userWithToolResults('toolu_not_pending')
+
+  const selected = selectToolPairSafeMessageRange(
+    [head, assistant, filler, result],
+    0,
+    2,
+    {
+      projectionName: 'live_turn',
+      querySource: 'repl_main_thread',
+      allowPendingToolUse: true,
+      maxExtraMessages: 0,
+    },
+  )
+
+  expect(selected.messages).toEqual([head])
+  expect(validateToolResultPairing(selected.messages).valid).toBe(true)
+})
+
+test('selectToolPairSafeMessageRange drops a partial assistant group when the earlier sibling is outside the expansion budget', () => {
+  const earlierAssistantPart = createAssistantMessage({
+    content: [{ type: 'text', text: 'thinking', citations: [] }],
+  })
+  const filler = createUserMessage({ content: 'filler' })
+  const laterAssistantPart = createAssistantMessage({
+    content: [{ type: 'text', text: 'continuing', citations: [] }],
+  })
+  laterAssistantPart.message.id = earlierAssistantPart.message.id
+  const tail = createUserMessage({ content: 'current request' })
+
+  const selected = selectToolPairSafeMessageRange(
+    [earlierAssistantPart, filler, laterAssistantPart, tail],
+    2,
+    4,
+    {
+      projectionName: 'away_summary',
+      querySource: 'away_summary',
+      maxExtraMessages: 0,
+    },
+  )
+
+  expect(selected.messages).toEqual([tail])
+})
+
+test('selectToolPairSafeMessageRange drops a partial assistant group when the later sibling is outside the expansion budget', () => {
+  const head = createUserMessage({ content: 'older context' })
+  const earlierAssistantPart = createAssistantMessage({
+    content: [{ type: 'text', text: 'thinking', citations: [] }],
+  })
+  const filler = createUserMessage({ content: 'filler' })
+  const laterAssistantPart = createAssistantMessage({
+    content: [{ type: 'text', text: 'continuing', citations: [] }],
+  })
+  laterAssistantPart.message.id = earlierAssistantPart.message.id
+
+  const selected = selectToolPairSafeMessageRange(
+    [head, earlierAssistantPart, filler, laterAssistantPart],
+    0,
+    2,
+    {
+      projectionName: 'partial_compact',
+      querySource: 'compact',
+      maxExtraMessages: 0,
+    },
+  )
+
+  expect(selected.messages).toEqual([head])
 })

--- a/src/utils/messages.ts
+++ b/src/utils/messages.ts
@@ -5328,6 +5328,34 @@ export type ToolResultPairingValidationResult = {
   issues: ToolResultPairingIssue[]
 }
 
+export type ToolPairSafeMessageRangeOptions = {
+  projectionName: string
+  querySource?: string
+  allowPendingToolUse?: boolean
+  minStart?: number
+  maxEnd?: number
+  maxExtraMessages?: number
+}
+
+export type ToolPairSafeMessageRangeDiagnostics = {
+  projectionName: string
+  querySource?: string
+  messageCountBefore: number
+  messageCountAfter: number
+  requestedRange: { start: number; end: number }
+  adjustedRange: { start: number; end: number }
+  issueKinds: ToolResultPairingIssueKind[]
+  requestedStartedWithToolResult: boolean
+  adjusted: boolean
+}
+
+export type ToolPairSafeMessageRangeResult<T extends Message> = {
+  messages: T[]
+  start: number
+  end: number
+  diagnostics: ToolPairSafeMessageRangeDiagnostics
+}
+
 function getToolUseId(block: unknown): string | null {
   if (
     typeof block === 'object' &&
@@ -5389,6 +5417,328 @@ function getToolResultIdsFromUserMessage(message: UserMessage): string[] {
   return message.message.content
     .map(block => getToolResultId(block))
     .filter((id): id is string => id !== null)
+}
+
+function isUserOrAssistantMessage(
+  message: Message,
+): message is UserMessage | AssistantMessage {
+  return message.type === 'user' || message.type === 'assistant'
+}
+
+function getToolUseIdsFromAssistantMessage(message: Message): string[] {
+  if (message.type !== 'assistant') {
+    return []
+  }
+  return message.message.content
+    .map(block => getToolUseId(block))
+    .filter((id): id is string => id !== null)
+}
+
+function getToolResultIdsFromMessage(message: Message): string[] {
+  if (message.type !== 'user') {
+    return []
+  }
+  const content = message.message.content
+  if (!Array.isArray(content)) {
+    return []
+  }
+  return content
+    .map(block => getToolResultId(block))
+    .filter((id): id is string => id !== null)
+}
+
+function collectToolUseIdsInRange(
+  messages: Message[],
+  start: number,
+  end: number,
+): Set<string> {
+  const ids = new Set<string>()
+  for (let i = start; i < end; i++) {
+    for (const id of getToolUseIdsFromAssistantMessage(messages[i]!)) {
+      ids.add(id)
+    }
+  }
+  return ids
+}
+
+function collectToolResultIdsInRange(
+  messages: Message[],
+  start: number,
+  end: number,
+): Set<string> {
+  const ids = new Set<string>()
+  for (let i = start; i < end; i++) {
+    for (const id of getToolResultIdsFromMessage(messages[i]!)) {
+      ids.add(id)
+    }
+  }
+  return ids
+}
+
+function clampRangeIndex(index: number, min: number, max: number): number {
+  if (!Number.isFinite(index)) return min
+  return Math.max(min, Math.min(max, Math.trunc(index)))
+}
+
+function findToolUseMessageIndex(
+  messages: Message[],
+  toolUseId: string,
+  fromInclusive: number,
+  toExclusive: number,
+): number {
+  for (let i = toExclusive - 1; i >= fromInclusive; i--) {
+    if (getToolUseIdsFromAssistantMessage(messages[i]!).includes(toolUseId)) {
+      return i
+    }
+  }
+  return -1
+}
+
+function findToolResultMessageIndex(
+  messages: Message[],
+  toolUseId: string,
+  fromInclusive: number,
+  toExclusive: number,
+): number {
+  for (let i = fromInclusive; i < toExclusive; i++) {
+    if (getToolResultIdsFromMessage(messages[i]!).includes(toolUseId)) {
+      return i
+    }
+  }
+  return -1
+}
+
+function findEarliestAssistantWithSameMessageId(
+  messages: Message[],
+  messageId: string,
+  fromInclusive: number,
+  toExclusive: number,
+): number {
+  let result = -1
+  for (let i = fromInclusive; i < toExclusive; i++) {
+    const message = messages[i]!
+    if (message.type === 'assistant' && message.message.id === messageId) {
+      result = i
+      break
+    }
+  }
+  return result
+}
+
+function findLatestAssistantWithSameMessageId(
+  messages: Message[],
+  messageId: string,
+  fromInclusive: number,
+  toExclusive: number,
+): number {
+  let result = -1
+  for (let i = fromInclusive; i < toExclusive; i++) {
+    const message = messages[i]!
+    if (message.type === 'assistant' && message.message.id === messageId) {
+      result = i
+    }
+  }
+  return result
+}
+
+function getPairingIssueKinds(messages: Message[]): ToolResultPairingIssueKind[] {
+  const pairable = messages.filter(isUserOrAssistantMessage)
+  if (pairable.length === 0) return []
+  const validation = validateToolResultPairing(pairable)
+  return [...new Set(validation.issues.map(issue => issue.kind))]
+}
+
+function messageHasToolResult(message: Message | undefined): boolean {
+  return message ? getToolResultIdsFromMessage(message).length > 0 : false
+}
+
+/**
+ * Selects a contiguous message range without cutting through tool_use/tool_result
+ * pairs. Projection producers should call this before slicing history for
+ * summary, compaction, or forked-query contexts.
+ */
+export function selectToolPairSafeMessageRange<T extends Message>(
+  messages: readonly T[],
+  requestedStart: number,
+  requestedEnd: number,
+  options: ToolPairSafeMessageRangeOptions,
+): ToolPairSafeMessageRangeResult<T> {
+  const messageList = [...messages]
+  const minStart = clampRangeIndex(options.minStart ?? 0, 0, messageList.length)
+  const maxEnd = clampRangeIndex(
+    options.maxEnd ?? messageList.length,
+    minStart,
+    messageList.length,
+  )
+  const clampedStart = clampRangeIndex(requestedStart, minStart, maxEnd)
+  const clampedEnd = clampRangeIndex(requestedEnd, clampedStart, maxEnd)
+  const maxExtraMessages =
+    options.maxExtraMessages === undefined
+      ? messageList.length
+      : Math.max(0, Math.trunc(options.maxExtraMessages))
+  let expansionMinStart = Math.max(minStart, clampedStart - maxExtraMessages)
+  let expansionMaxEnd = Math.min(maxEnd, clampedEnd + maxExtraMessages)
+
+  let start = clampedStart
+  let end = clampedEnd
+  const requestedMessages = messageList.slice(clampedStart, clampedEnd)
+  const issueKinds = getPairingIssueKinds(requestedMessages)
+  const requestedStartedWithToolResult = messageHasToolResult(
+    messageList[clampedStart],
+  )
+
+  for (let guard = 0; guard < messageList.length * 2 + 2; guard++) {
+    let changed = false
+
+    for (let i = start; i < end; i++) {
+      const message = messageList[i]!
+      if (message.type !== 'assistant') continue
+      const messageId = message.message.id
+      if (!messageId) continue
+
+      const earlier = findEarliestAssistantWithSameMessageId(
+        messageList,
+        messageId,
+        0,
+        start,
+      )
+      if (earlier !== -1) {
+        if (earlier >= expansionMinStart) {
+          start = earlier
+        } else {
+          const lastInRange = findLatestAssistantWithSameMessageId(
+            messageList,
+            messageId,
+            start,
+            end,
+          )
+          start = lastInRange + 1
+          expansionMinStart = Math.max(expansionMinStart, start)
+        }
+        changed = true
+        break
+      }
+
+      const later = findLatestAssistantWithSameMessageId(
+        messageList,
+        messageId,
+        end,
+        messageList.length,
+      )
+      if (later !== -1) {
+        if (later < expansionMaxEnd) {
+          end = later + 1
+        } else {
+          const firstInRange = findEarliestAssistantWithSameMessageId(
+            messageList,
+            messageId,
+            start,
+            end,
+          )
+          end = firstInRange
+          expansionMaxEnd = Math.min(expansionMaxEnd, end)
+        }
+        changed = true
+        break
+      }
+    }
+    if (changed) continue
+
+    const toolUseIds = collectToolUseIdsInRange(messageList, start, end)
+    const toolResultIds = collectToolResultIdsInRange(messageList, start, end)
+
+    for (let i = start; i < end; i++) {
+      const resultIds = getToolResultIdsFromMessage(messageList[i]!)
+      const orphanedResultId = resultIds.find(id => !toolUseIds.has(id))
+      if (!orphanedResultId) continue
+
+      const toolUseIndex = findToolUseMessageIndex(
+        messageList,
+        orphanedResultId,
+        expansionMinStart,
+        start,
+      )
+      if (toolUseIndex !== -1) {
+        start = toolUseIndex
+        changed = true
+        break
+      }
+
+      start = i + 1
+      expansionMinStart = Math.max(expansionMinStart, start)
+      changed = true
+      break
+    }
+    if (changed) continue
+
+    for (let i = start; i < end; i++) {
+      const toolUseIdsForMessage = getToolUseIdsFromAssistantMessage(
+        messageList[i]!,
+      )
+      const missingToolUseId = toolUseIdsForMessage.find(
+        id => !toolResultIds.has(id),
+      )
+      if (!missingToolUseId) continue
+
+      const toolResultIndex = findToolResultMessageIndex(
+        messageList,
+        missingToolUseId,
+        end,
+        expansionMaxEnd,
+      )
+      if (toolResultIndex !== -1) {
+        end = toolResultIndex + 1
+        changed = true
+        break
+      }
+
+      const hasResultOutsideRange =
+        findToolResultMessageIndex(
+          messageList,
+          missingToolUseId,
+          0,
+          messageList.length,
+        ) !== -1
+      if (options.allowPendingToolUse && !hasResultOutsideRange) continue
+
+      end = i
+      expansionMaxEnd = Math.min(expansionMaxEnd, end)
+      changed = true
+      break
+    }
+    if (!changed) break
+  }
+
+  const selectedMessages = messageList.slice(start, end)
+  const diagnostics: ToolPairSafeMessageRangeDiagnostics = {
+    projectionName: options.projectionName,
+    querySource: options.querySource,
+    messageCountBefore: clampedEnd - clampedStart,
+    messageCountAfter: selectedMessages.length,
+    requestedRange: { start: clampedStart, end: clampedEnd },
+    adjustedRange: { start, end },
+    issueKinds,
+    requestedStartedWithToolResult,
+    adjusted: start !== clampedStart || end !== clampedEnd,
+  }
+
+  if (diagnostics.adjusted || issueKinds.length > 0) {
+    logForDebugging(
+      `[messageProjection] tool-pair-safe range projection=${options.projectionName} ` +
+        `querySource=${options.querySource ?? 'unknown'} ` +
+        `before=${diagnostics.messageCountBefore} after=${diagnostics.messageCountAfter} ` +
+        `requested=${clampedStart}:${clampedEnd} adjusted=${start}:${end} ` +
+        `issueKinds=${issueKinds.join(',') || 'none'} ` +
+        `requestedStartedWithToolResult=${requestedStartedWithToolResult}`,
+    )
+  }
+
+  return {
+    messages: selectedMessages as T[],
+    start,
+    end,
+    diagnostics,
+  }
 }
 
 export function validateToolResultPairing(


### PR DESCRIPTION
## Summary
- add a shared tool-pair-safe message range selector with sanitized projection diagnostics
- use the selector for away-summary and partial-compaction boundaries
- keep the existing before-send pairing repair as a final defense while preventing confirmed projection producers from creating broken slices

## Root cause
Some projection paths sliced message arrays without preserving `tool_use` / `tool_result` adjacency. In active sessions, that could produce orphaned `tool_result` messages or assistant `tool_use` messages missing their result before the final API repair layer compensated.

## Impact
- `away_summary` now keeps recent context bounded while avoiding orphaned tool results.
- partial compaction now chooses safe summarized/kept boundaries around tool pairs.
- diagnostics identify the projection and issue kinds without logging message text or tool output.
- legacy malformed transcripts still rely on the existing repair path rather than becoming unrecoverable.

## Validation
- [x] `bun test src/utils/messages.toolPairingDiagnostics.test.ts`
- [x] `bun test src/services/awaySummary.test.ts src/utils/messages.toolPairingDiagnostics.test.ts src/services/compact/compact.test.ts`
- [x] `bash -lc 'shopt -s globstar nullglob; bun test src/utils/messages*.test.ts src/**/summary*.test.ts src/**/compact*.test.ts src/**/resume*.test.ts'`
- [x] `bun run typecheck`
- [x] `git diff --check`
- [x] local CodeRabbit review completed with 0 issues
- [x] PR checks passed: `smoke-and-tests`, `typecheck`, `web`, and `CodeRabbit`
