### PR TITLE
fix(frontmatter): expand nested brace globs in paths: correctly

### DIFF
--- a/src/utils/frontmatterParser.test.ts
+++ b/src/utils/frontmatterParser.test.ts
@@ -1,0 +1,42 @@
+import { expect, test } from 'bun:test'
+import { splitPathInFrontmatter } from './frontmatterParser.ts'
+
+// splitPathInFrontmatter is the public entry that flatMaps each comma-separated
+// part through the (private) expandBraces helper, so it exercises the brace
+// expansion that loadSkillsDir.ts and claudemd.ts depend on for path-scoped
+// activation. These cover the regression where the old `[^}]+` regex stopped at
+// the first '}' and corrupted nested groups (leaving stray '}' in globs).
+
+test('passes through a pattern with no braces unchanged', () => {
+  expect(splitPathInFrontmatter('src/index.ts')).toEqual(['src/index.ts'])
+})
+
+test('expands a single-level brace group', () => {
+  expect(splitPathInFrontmatter('a.{js,ts}')).toEqual(['a.js', 'a.ts'])
+})
+
+test('expands a nested brace group without leaking braces', () => {
+  expect(splitPathInFrontmatter('{a,{b,c}}')).toEqual(['a', 'b', 'c'])
+})
+
+test('expands a nested glob group into valid globs', () => {
+  expect(splitPathInFrontmatter('src/**/*.{js,{ts,tsx}}')).toEqual([
+    'src/**/*.js',
+    'src/**/*.ts',
+    'src/**/*.tsx',
+  ])
+})
+
+test('expands sibling brace groups as a cartesian product', () => {
+  expect(splitPathInFrontmatter('{a,b}/{c,d}')).toEqual([
+    'a/c',
+    'a/d',
+    'b/c',
+    'b/d',
+  ])
+})
+
+test('returns unbalanced braces unchanged rather than throwing', () => {
+  // No matching close brace: treat as literal text, do not corrupt or throw.
+  expect(splitPathInFrontmatter('src/{a,b')).toEqual(['src/{a,b'])
+})

--- a/src/utils/frontmatterParser.test.ts
+++ b/src/utils/frontmatterParser.test.ts
@@ -40,3 +40,16 @@ test('returns unbalanced braces unchanged rather than throwing', () => {
   // No matching close brace: treat as literal text, do not corrupt or throw.
   expect(splitPathInFrontmatter('src/{a,b')).toEqual(['src/{a,b'])
 })
+
+test('keeps an empty brace group literal instead of yielding an empty path', () => {
+  // `{}` is not an alternation. Expanding it to '' would make parseSkillPaths
+  // and the CLAUDE.md path parser drop the empty string and treat the file as
+  // having NO path restriction (activating everywhere). Keep it literal so the
+  // pattern matches a literal `{}` (i.e. effectively nothing) instead.
+  expect(splitPathInFrontmatter('{}')).toEqual(['{}'])
+  expect(splitPathInFrontmatter('src/{}/file.ts')).toEqual(['src/{}/file.ts'])
+})
+
+test('keeps a literal empty group while still expanding later groups', () => {
+  expect(splitPathInFrontmatter('{}/{a,b}')).toEqual(['{}/a', '{}/b'])
+})

--- a/src/utils/frontmatterParser.ts
+++ b/src/utils/frontmatterParser.ts
@@ -233,33 +233,77 @@ export function splitPathInFrontmatter(input: string | string[]): string[] {
 
 /**
  * Expands brace patterns in a glob string.
+ *
+ * Uses a balance-aware scan to locate the first brace group's matching close
+ * brace, so nested groups expand correctly. Alternatives are split on
+ * top-level commas only — commas nested inside deeper groups belong to those
+ * sub-groups and are preserved until the recursion reaches them.
+ *
+ * Unmatched/unbalanced braces are treated as literal text: the input is
+ * returned unchanged rather than throwing.
+ *
  * @example
  * expandBraces("src/*.{ts,tsx}") // returns ["src/*.ts", "src/*.tsx"]
  * expandBraces("{a,b}/{c,d}") // returns ["a/c", "a/d", "b/c", "b/d"]
+ * expandBraces("{a,{b,c}}") // returns ["a", "b", "c"]
+ * expandBraces("src/**\/*.{js,{ts,tsx}}") // returns ["src/**\/*.js", "src/**\/*.ts", "src/**\/*.tsx"]
  */
 function expandBraces(pattern: string): string[] {
-  // Find the first brace group
-  const braceMatch = pattern.match(/^([^{]*)\{([^}]+)\}(.*)$/)
-
-  if (!braceMatch) {
-    // No braces found, return pattern as-is
+  // Find the first opening brace.
+  const open = pattern.indexOf('{')
+  if (open === -1) {
+    // No braces found, return pattern as-is.
     return [pattern]
   }
 
-  const prefix = braceMatch[1] || ''
-  const alternatives = braceMatch[2] || ''
-  const suffix = braceMatch[3] || ''
+  // Scan forward from the first '{' tracking brace depth to find its matching
+  // '}' (the point where depth returns to 0). Record the top-level comma
+  // positions (depth === 1) so we split alternatives on those only — commas
+  // nested deeper belong to sub-groups and are left for the recursion.
+  let depth = 0
+  let close = -1
+  const topLevelCommas: number[] = []
+  for (let i = open; i < pattern.length; i++) {
+    const char = pattern[i]
+    if (char === '{') {
+      depth++
+    } else if (char === '}') {
+      depth--
+      if (depth === 0) {
+        close = i
+        break
+      }
+    } else if (char === ',' && depth === 1) {
+      topLevelCommas.push(i)
+    }
+  }
 
-  // Split alternatives by comma and expand each one
-  const parts = alternatives.split(',').map(alt => alt.trim())
+  if (close === -1) {
+    // Unbalanced braces (no matching '}'): treat as literal, return unchanged.
+    return [pattern]
+  }
 
-  // Recursively expand remaining braces in suffix
+  const prefix = pattern.slice(0, open)
+  const inner = pattern.slice(open + 1, close)
+  const suffix = pattern.slice(close + 1)
+
+  // Split the inner content on top-level commas (relative to `inner`, whose
+  // indices are offset by open + 1 from the recorded positions).
+  const alternatives: string[] = []
+  let start = 0
+  for (const commaIndex of topLevelCommas) {
+    const rel = commaIndex - (open + 1)
+    alternatives.push(inner.slice(start, rel))
+    start = rel + 1
+  }
+  alternatives.push(inner.slice(start))
+
+  // Recursively expand each option combined with the surrounding prefix/suffix,
+  // which also handles any further brace groups in the suffix.
   const expanded: string[] = []
-  for (const part of parts) {
-    const combined = prefix + part + suffix
-    // Recursively handle additional brace groups
-    const furtherExpanded = expandBraces(combined)
-    expanded.push(...furtherExpanded)
+  for (const alternative of alternatives) {
+    const combined = prefix + alternative.trim() + suffix
+    expanded.push(...expandBraces(combined))
   }
 
   return expanded

--- a/src/utils/frontmatterParser.ts
+++ b/src/utils/frontmatterParser.ts
@@ -283,6 +283,18 @@ function expandBraces(pattern: string): string[] {
     return [pattern]
   }
 
+  if (close === open + 1) {
+    // Empty brace group `{}` is not an alternation. The previous regex required
+    // at least one inner character, so `{}` stayed literal; expanding it to an
+    // empty alternative would collapse `paths: "{}"` to `[""]`, and both
+    // parseSkillPaths and the CLAUDE.md path parser filter that empty string and
+    // treat the file as having NO path restriction (applying everywhere).
+    // Keep the `{}` literal, but still expand any later groups in the suffix.
+    return expandBraces(pattern.slice(close + 1)).map(
+      rest => pattern.slice(0, close + 1) + rest,
+    )
+  }
+
   const prefix = pattern.slice(0, open)
   const inner = pattern.slice(open + 1, close)
   const suffix = pattern.slice(close + 1)


### PR DESCRIPTION
## What & why

`expandBraces` used the regex `^([^{]*)\{([^}]+)\}(.*)$`, whose `[^}]+` stops at the first `}`, so nested brace groups in a `paths:` frontmatter glob were corrupted: `{a,{b,c}}` became `["a}","b","c}"]` and `src/**/*.{js,{ts,tsx}}` produced stray `}` and broken globs — silently breaking path-scoped skill / CLAUDE.md activation.

## Changes

Replaced the regex extraction with a depth-aware scan that finds the matching close brace and splits on top-level commas only, recursing as before. Unbalanced braces fall back to the literal input.

## Checks

Added `src/utils/frontmatterParser.test.ts` covering no-braces, single group, nested groups, nested globs, sibling groups, and the unbalanced-brace fallback.

(Small self-contained bug fix with no existing issue.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved frontmatter path brace expansion to correctly handle nested brace groups, multiple sibling groups (cartesian-product expansion), unbalanced brace patterns (left unchanged), and literal `{}` preservation for accurate glob generation.

* **Tests**
  * Added a Bun test suite covering brace-expansion behavior, including nested groups, edge cases (escaped and unbalanced inputs), and scenarios that previously risked producing invalid or stray brace output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->