### PR TITLE
fix(swarm): bound in-process teammate message history to avoid OOM

### DIFF
--- a/src/utils/swarm/inProcessRunner.ts
+++ b/src/utils/swarm/inProcessRunner.ts
@@ -108,6 +108,7 @@ import {
   sendPermissionRequestViaMailbox,
 } from './permissionSync.js'
 import { TEAMMATE_SYSTEM_PROMPT_ADDENDUM } from './teammatePromptAddendum.js'
+import { capTeammateMessages } from './teammateRetention.js'
 
 type SetAppStateFn = (updater: (prev: AppState) => AppState) => void
 
@@ -1297,6 +1298,18 @@ export async function runInProcessTeammate(
           return { success: true, messages: iterationMessages }
         })
       })
+
+      // Hard cap on the accumulated context buffer. Token-based auto-compaction
+      // above is the primary bound, but it only fires at the token threshold;
+      // a long session of many small messages can grow allMessages unbounded
+      // and contribute to JS-heap OOM (#1379). Prune to the most recent
+      // messages here (cheap, every turn), preserving tool_use/tool_result
+      // pairing so the next iteration's forkContextMessages stays API-valid.
+      const cappedMessages = capTeammateMessages(allMessages)
+      if (cappedMessages !== allMessages) {
+        allMessages.length = 0
+        allMessages.push(...cappedMessages)
+      }
 
       // Clear the work controller from state (it's no longer valid)
       updateTaskState(

--- a/src/utils/swarm/teammateRetention.test.ts
+++ b/src/utils/swarm/teammateRetention.test.ts
@@ -1,0 +1,185 @@
+import { describe, expect, it } from 'bun:test'
+import type { Message } from '../../types/message.js'
+import {
+  capTeammateMessages,
+  TEAMMATE_CONTEXT_MESSAGES_CAP,
+} from './teammateRetention.js'
+
+function userText(text: string): Message {
+  return {
+    type: 'user',
+    uuid: crypto.randomUUID(),
+    timestamp: new Date().toISOString(),
+    message: { role: 'user', content: text },
+  } as Message
+}
+
+function assistantToolUse(id: string): Message {
+  return {
+    type: 'assistant',
+    uuid: crypto.randomUUID(),
+    timestamp: new Date().toISOString(),
+    message: {
+      role: 'assistant',
+      content: [{ type: 'tool_use', id, name: 'Read', input: {} }],
+      id: `msg-${id}`,
+      model: 'test',
+      usage: {},
+    },
+  } as Message
+}
+
+function userToolResult(toolUseId: string): Message {
+  return {
+    type: 'user',
+    uuid: crypto.randomUUID(),
+    timestamp: new Date().toISOString(),
+    message: {
+      role: 'user',
+      content: [
+        { type: 'tool_result', tool_use_id: toolUseId, content: 'result' },
+      ],
+    },
+  } as Message
+}
+
+/** Collect every tool_result's tool_use_id referenced in the messages. */
+function referencedToolUseIds(messages: readonly Message[]): string[] {
+  const ids: string[] = []
+  for (const m of messages) {
+    const content = (m as any).message?.content
+    if (!Array.isArray(content)) continue
+    for (const block of content) {
+      if (block.type === 'tool_result') ids.push(block.tool_use_id)
+    }
+  }
+  return ids
+}
+
+/** Collect every tool_use id present in the messages. */
+function presentToolUseIds(messages: readonly Message[]): Set<string> {
+  const ids = new Set<string>()
+  for (const m of messages) {
+    if (m.type !== 'assistant') continue
+    const content = (m as any).message?.content
+    if (!Array.isArray(content)) continue
+    for (const block of content) {
+      if (block.type === 'tool_use') ids.add(block.id)
+    }
+  }
+  return ids
+}
+
+describe('capTeammateMessages', () => {
+  it('returns the same reference (no-op) when within the cap', () => {
+    const messages = [userText('a'), userText('b'), userText('c')]
+    expect(capTeammateMessages(messages, 10)).toBe(messages)
+  })
+
+  it('caps to the most recent N messages', () => {
+    const messages = Array.from({ length: 200 }, (_, i) => userText(`m${i}`))
+    const result = capTeammateMessages(messages, 50)
+    expect(result.length).toBeLessThanOrEqual(50)
+    // Keeps the most recent ones (sliding window from the end).
+    const lastText = (result.at(-1) as any).message.content
+    expect(lastText).toBe('m199')
+  })
+
+  it('uses TEAMMATE_CONTEXT_MESSAGES_CAP by default', () => {
+    const messages = Array.from(
+      { length: TEAMMATE_CONTEXT_MESSAGES_CAP + 100 },
+      (_, i) => userText(`m${i}`),
+    )
+    const result = capTeammateMessages(messages)
+    expect(result.length).toBeLessThanOrEqual(TEAMMATE_CONTEXT_MESSAGES_CAP)
+  })
+
+  it('never retains a tool_result whose tool_use was pruned (no orphans)', () => {
+    // Build pairs: [tool_use(i), tool_result(i)] repeated. A naive slice that
+    // cut between a tool_use and its tool_result would orphan the result.
+    const messages: Message[] = []
+    for (let i = 0; i < 100; i++) {
+      messages.push(assistantToolUse(`tu${i}`))
+      messages.push(userToolResult(`tu${i}`))
+    }
+
+    // Odd cap forces the slice boundary to land mid-pair for some pair.
+    const result = capTeammateMessages(messages, 51)
+
+    const present = presentToolUseIds(result)
+    for (const referenced of referencedToolUseIds(result)) {
+      // Every retained tool_result must have its tool_use retained too.
+      expect(present.has(referenced)).toBe(true)
+    }
+  })
+
+  it('drops a leading orphaned tool_result message at the cut boundary', () => {
+    // Window slice will start on the tool_result, orphaning it from its
+    // tool_use which sits just before the boundary.
+    const messages: Message[] = [
+      assistantToolUse('orphan'), // index 0 — will be sliced off
+      userToolResult('orphan'), // index 1 — becomes a leading orphan
+      userText('keep-1'),
+      userText('keep-2'),
+    ]
+
+    const result = capTeammateMessages(messages, 3)
+
+    // The orphaned tool_result message must be dropped, not retained.
+    expect(referencedToolUseIds(result)).not.toContain('orphan')
+    // The plain user messages survive.
+    expect(result.length).toBeGreaterThanOrEqual(2)
+  })
+
+  it('keeps a tool_result whose tool_use survives the cut', () => {
+    const messages: Message[] = [
+      userText('old'), // sliced off
+      assistantToolUse('tu-keep'),
+      userToolResult('tu-keep'),
+      userText('newest'),
+    ]
+
+    const result = capTeammateMessages(messages, 3)
+
+    const present = presentToolUseIds(result)
+    expect(present.has('tu-keep')).toBe(true)
+    expect(referencedToolUseIds(result)).toContain('tu-keep')
+  })
+
+  it('strips only orphaned tool_result blocks from a mixed-content message', () => {
+    // A user message that carries one orphaned and one valid tool_result.
+    const mixed: Message = {
+      type: 'user',
+      uuid: crypto.randomUUID(),
+      timestamp: new Date().toISOString(),
+      message: {
+        role: 'user',
+        content: [
+          { type: 'tool_result', tool_use_id: 'gone', content: 'x' },
+          { type: 'tool_result', tool_use_id: 'tu-keep', content: 'y' },
+        ],
+      },
+    } as Message
+
+    const messages: Message[] = [
+      assistantToolUse('gone'), // sliced off
+      assistantToolUse('tu-keep'),
+      mixed,
+      userText('newest'),
+    ]
+
+    const result = capTeammateMessages(messages, 3)
+
+    const referenced = referencedToolUseIds(result)
+    expect(referenced).toContain('tu-keep')
+    expect(referenced).not.toContain('gone')
+  })
+
+  it('leaves string-content user messages untouched', () => {
+    const messages = Array.from({ length: 100 }, (_, i) => userText(`m${i}`))
+    const result = capTeammateMessages(messages, 10)
+    for (const m of result) {
+      expect(typeof (m as any).message.content).toBe('string')
+    }
+  })
+})

--- a/src/utils/swarm/teammateRetention.ts
+++ b/src/utils/swarm/teammateRetention.ts
@@ -1,0 +1,123 @@
+/**
+ * Bounded retention for the in-process teammate `allMessages` buffer.
+ *
+ * The in-process teammate runner (inProcessRunner.ts) accumulates every
+ * user/assistant message it ever sees into a local `allMessages` array so the
+ * full conversation can be replayed as context on each iteration. Token-based
+ * auto-compaction (getAutoCompactThreshold) is the primary bound, but it is an
+ * expensive async LLM round-trip that only fires at the token threshold. In
+ * long-lived teammate sessions the array can still grow large between
+ * compactions and is a documented contributor to JS-heap OOM (#1379, and the
+ * BQ analysis cited on TEAMMATE_MESSAGES_UI_CAP showing ~20MB RSS per agent at
+ * 500+ turns). This module adds a cheap, synchronous hard cap as a safety net
+ * that runs every iteration regardless of token count.
+ *
+ * Unlike the UI mirror cap (TEAMMATE_MESSAGES_UI_CAP, a naive slice on
+ * task.messages which is display-only), this buffer is the actual LLM context,
+ * so the window must preserve tool_use <-> tool_result pairing: the API rejects
+ * a tool_result whose originating tool_use is missing. We keep the most recent
+ * messages (the relevant context) and, after slicing, strip any leading
+ * tool_result blocks orphaned by the cut so no retained tool_result dangles.
+ */
+
+import type { Message } from '../../types/message.js'
+
+/**
+ * Hard cap on the number of messages retained in the teammate `allMessages`
+ * buffer. Far larger than TEAMMATE_MESSAGES_UI_CAP (50, display-only) because
+ * this buffer carries the conversation context the agent actually needs;
+ * token-based auto-compaction handles normal-sized histories well before this.
+ * This is purely a heap safety net for pathological long sessions where many
+ * small messages accumulate without crossing the token threshold.
+ */
+export const TEAMMATE_CONTEXT_MESSAGES_CAP = 1000
+
+type ContentBlock = { type?: string; tool_use_id?: string; id?: string }
+
+function getBlocks(message: Message): ContentBlock[] {
+  const content = (message as { message?: { content?: unknown } }).message
+    ?.content
+  return Array.isArray(content) ? (content as ContentBlock[]) : []
+}
+
+/** Collect the set of tool_use ids that appear in the given messages. */
+function collectToolUseIds(messages: readonly Message[]): Set<string> {
+  const ids = new Set<string>()
+  for (const message of messages) {
+    if (message.type !== 'assistant') continue
+    for (const block of getBlocks(message)) {
+      if (block.type === 'tool_use' && typeof block.id === 'string') {
+        ids.add(block.id)
+      }
+    }
+  }
+  return ids
+}
+
+/**
+ * Cap `messages` to the most recent TEAMMATE_CONTEXT_MESSAGES_CAP entries while
+ * preserving tool_use <-> tool_result pairing.
+ *
+ * Returns the input unchanged (same reference) when already within the cap, so
+ * callers can cheaply detect a no-op. When over the cap we keep the trailing
+ * window (most recent context) and then drop any tool_result blocks whose
+ * matching tool_use was sliced off the front — never the reverse, which the
+ * window's contiguity already guarantees. A user message left with no content
+ * after stripping orphaned tool_results is dropped entirely.
+ */
+export function capTeammateMessages(
+  messages: readonly Message[],
+  cap: number = TEAMMATE_CONTEXT_MESSAGES_CAP,
+): Message[] | readonly Message[] {
+  if (messages.length <= cap) return messages
+
+  const window = messages.slice(-cap)
+  const retainedToolUseIds = collectToolUseIds(window)
+
+  const result: Message[] = []
+  for (const message of window) {
+    if (message.type !== 'user') {
+      result.push(message)
+      continue
+    }
+
+    const blocks = getBlocks(message)
+    // String content or non-array content carries no tool_result — keep as is.
+    if (blocks.length === 0) {
+      result.push(message)
+      continue
+    }
+
+    const hasToolResult = blocks.some(b => b.type === 'tool_result')
+    if (!hasToolResult) {
+      result.push(message)
+      continue
+    }
+
+    // Keep only tool_result blocks whose tool_use survived the slice, plus any
+    // non-tool_result content. Drop orphaned tool_results.
+    const kept = blocks.filter(
+      b =>
+        b.type !== 'tool_result' ||
+        (typeof b.tool_use_id === 'string' &&
+          retainedToolUseIds.has(b.tool_use_id)),
+    )
+
+    if (kept.length === 0) {
+      // Message was nothing but orphaned tool_results — drop it.
+      continue
+    }
+    if (kept.length === blocks.length) {
+      result.push(message)
+      continue
+    }
+
+    // Some (but not all) blocks were orphaned — rebuild with the kept blocks.
+    result.push({
+      ...message,
+      message: { ...message.message, content: kept },
+    } as Message)
+  }
+
+  return result
+}


### PR DESCRIPTION
## What & why

The in-process teammate runner accumulated `allMessages` unbounded across loop iterations; only token-based auto-compaction bounded it, so long sessions of many small messages grew the buffer without limit, contributing to the JS-heap OOM tracked in #1379.

## Changes

Added a synchronous message-count cap (`teammateRetention`) applied once per turn that keeps the most recent window and preserves `tool_use`/`tool_result` pairing (never leaves a dangling `tool_result`). Scoped to the in-process teammate path only — the broader `state.messages` cap is untouched.

## Checks

Added `src/utils/swarm/teammateRetention.test.ts`: no-op within cap, caps to most-recent N, orphaned `tool_result` stripped at the window boundary, valid pairs retained.

Fixes #1379

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed unbounded message history accumulation during extended conversations by implementing message retention capping, preventing memory issues and improving system stability over long sessions.

* **Tests**
  * Added comprehensive tests to verify message retention behavior, including proper handling of tool use and tool result pairings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->