### PR TITLE
fix(format): roll formatFileSize over to the next unit at the 1024 boundary

### DIFF
--- a/src/utils/format.test.ts
+++ b/src/utils/format.test.ts
@@ -1,0 +1,32 @@
+import { expect, test } from 'bun:test'
+import { formatFileSize } from './format.js'
+
+test('formats sub-KB sizes as raw bytes', () => {
+  expect(formatFileSize(0)).toBe('0 bytes')
+  expect(formatFileSize(512)).toBe('512 bytes')
+  expect(formatFileSize(1023)).toBe('1KB')
+})
+
+test('formats KB sizes with a stripped trailing .0', () => {
+  expect(formatFileSize(1024)).toBe('1KB')
+  expect(formatFileSize(1536)).toBe('1.5KB')
+})
+
+test('rolls KB over to MB when the rounded value reaches 1024', () => {
+  // 1048575 bytes is 1023.999...KB, which rounds up to 1024.0 — must
+  // promote to "1MB" rather than render the impossible "1024KB".
+  expect(formatFileSize(1048575)).toBe('1MB')
+  expect(formatFileSize(1048576)).toBe('1MB')
+})
+
+test('rolls MB over to GB when the rounded value reaches 1024', () => {
+  // 1073741823 bytes is 1023.999...MB, which rounds up to 1024.0 — must
+  // promote to "1GB" rather than render the impossible "1024MB".
+  expect(formatFileSize(1073741823)).toBe('1GB')
+  expect(formatFileSize(1073741824)).toBe('1GB')
+})
+
+test('formats normal MB and GB sizes', () => {
+  expect(formatFileSize(1024 * 1024 * 2.5)).toBe('2.5MB')
+  expect(formatFileSize(1024 * 1024 * 1024 * 3)).toBe('3GB')
+})

--- a/src/utils/format.test.ts
+++ b/src/utils/format.test.ts
@@ -4,7 +4,7 @@ import { formatFileSize } from './format.js'
 test('formats sub-KB sizes as raw bytes', () => {
   expect(formatFileSize(0)).toBe('0 bytes')
   expect(formatFileSize(512)).toBe('512 bytes')
-  expect(formatFileSize(1023)).toBe('1KB')
+  expect(formatFileSize(1023)).toBe('1023 bytes')
 })
 
 test('formats KB sizes with a stripped trailing .0', () => {

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -11,11 +11,13 @@ export function formatFileSize(sizeInBytes: number): string {
   if (kb < 1) {
     return `${sizeInBytes} bytes`
   }
-  if (kb < 1024) {
+  // Compare the rounded magnitude so values that round up to 1024 roll over
+  // to the next unit (e.g. 1048575 bytes → "1MB", not "1024KB").
+  if (Number(kb.toFixed(1)) < 1024) {
     return `${kb.toFixed(1).replace(/\.0$/, '')}KB`
   }
   const mb = kb / 1024
-  if (mb < 1024) {
+  if (Number(mb.toFixed(1)) < 1024) {
     return `${mb.toFixed(1).replace(/\.0$/, '')}MB`
   }
   const gb = mb / 1024


### PR DESCRIPTION
## What & why

`formatFileSize` picked the unit from the unrounded magnitude (`kb < 1024`) but displayed the rounded value, so sizes just under a boundary rendered as "1024KB"/"1024MB" instead of "1MB"/"1GB" (e.g. `formatFileSize(1048575)` → "1024KB"). This also makes size-limit error strings self-contradictory.

## Changes

Compare the rounded magnitude when selecting the unit so it promotes correctly at the KB→MB and MB→GB boundaries. Output format (the `.0` stripping, suffixes) is unchanged for all currently-correct inputs.

## Checks

Added `src/utils/format.test.ts` covering sub-KB bytes, 1.5KB, both boundary bands, and normal MB/GB values.

(Small self-contained bug fix with no existing issue.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected file size formatting at KB/MB/GB boundaries so values that round up now roll over to the next unit instead of displaying at the current unit.

* **Tests**
  * Added new automated coverage to verify formatting behavior across byte, KB, MB, and GB ranges, including edge cases around the rounding and unit rollover points.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->