### PR TITLE
fix(grep): relativize content-mode paths correctly on Windows

### DIFF
--- a/src/tools/GrepTool/GrepTool.test.ts
+++ b/src/tools/GrepTool/GrepTool.test.ts
@@ -1,0 +1,67 @@
+import { expect, test } from 'bun:test'
+import path from 'node:path'
+
+import { relativizeContentLine } from '../../utils/path.js'
+
+// Deterministic relativizers that don't depend on the host OS or real cwd,
+// so the same assertions hold on Windows, macOS, and Linux. They mirror
+// toRelativePath's "keep absolute when outside cwd" behaviour.
+function makeRelativize(
+  impl: typeof path.win32 | typeof path.posix,
+  cwd: string,
+): (p: string) => string {
+  return (absolutePath: string) => {
+    const rel = impl.relative(cwd, absolutePath)
+    return rel.startsWith('..') ? absolutePath : rel
+  }
+}
+
+test('relativizes a Windows drive-letter path without splitting on the drive colon', () => {
+  const relativize = makeRelativize(path.win32, 'C:\\Users\\proj')
+  // The leading `C:` must not be mistaken for the path/content separator.
+  expect(
+    relativizeContentLine(
+      'C:\\Users\\proj\\src\\file.ts:42:const x = 1',
+      relativize,
+    ),
+  ).toBe('src\\file.ts:42:const x = 1')
+})
+
+test('relativizes a POSIX path using the first colon as the boundary', () => {
+  const relativize = makeRelativize(path.posix, '/home/u/p')
+  expect(
+    relativizeContentLine('/home/u/p/src/file.ts:42:const x = 1', relativize),
+  ).toBe('src/file.ts:42:const x = 1')
+})
+
+test('handles the path:content form (no line number)', () => {
+  const winRelativize = makeRelativize(path.win32, 'C:\\Users\\proj')
+  expect(
+    relativizeContentLine('C:\\Users\\proj\\src\\a.ts:const y = 2', winRelativize),
+  ).toBe('src\\a.ts:const y = 2')
+
+  const posixRelativize = makeRelativize(path.posix, '/home/u/p')
+  expect(
+    relativizeContentLine('/home/u/p/src/a.ts:const y = 2', posixRelativize),
+  ).toBe('src/a.ts:const y = 2')
+})
+
+test('returns a line with no colon unchanged', () => {
+  const relativize = makeRelativize(path.posix, '/home/u/p')
+  expect(relativizeContentLine('just-some-text-no-colon', relativize)).toBe(
+    'just-some-text-no-colon',
+  )
+})
+
+test('returns a bare Windows drive path (only the drive colon) unchanged', () => {
+  // `C:` has its sole colon at index 1, which is inside the skipped drive
+  // prefix, so there is no boundary colon and the line passes through.
+  const relativize = makeRelativize(path.win32, 'C:\\Users\\proj')
+  expect(relativizeContentLine('C:', relativize)).toBe('C:')
+})
+
+test('defaults to toRelativePath when no relativizer is supplied', () => {
+  // Without a path/content boundary colon the line is returned untouched,
+  // exercising the default-argument path without depending on real cwd.
+  expect(relativizeContentLine('no-colon-here')).toBe('no-colon-here')
+})

--- a/src/tools/GrepTool/GrepTool.test.ts
+++ b/src/tools/GrepTool/GrepTool.test.ts
@@ -46,6 +46,38 @@ test('handles the path:content form (no line number)', () => {
   ).toBe('src/a.ts:const y = 2')
 })
 
+test('relativizes a Windows context row (dash-separated `-A`/`-B`/`-C`)', () => {
+  // Context rows use `-` separators, so there is no boundary colon after the
+  // drive. The `C:` drive colon must still be skipped and the `-<n>-` boundary
+  // used instead of leaving the absolute path in place.
+  const relativize = makeRelativize(path.win32, 'C:\\Users\\proj')
+  expect(
+    relativizeContentLine(
+      'C:\\Users\\proj\\src\\file.ts-41-const before',
+      relativize,
+    ),
+  ).toBe('src\\file.ts-41-const before')
+})
+
+test('relativizes a POSIX context row (dash-separated)', () => {
+  const relativize = makeRelativize(path.posix, '/home/u/p')
+  expect(
+    relativizeContentLine('/home/u/p/src/file.ts-41-const before', relativize),
+  ).toBe('src/file.ts-41-const before')
+})
+
+test('uses the `:<n>:` match boundary even when the filename has a `-<n>-` run', () => {
+  // A date-like `-2024-` inside the filename must not be mistaken for the
+  // context boundary on a match row; the unambiguous `:<n>:` wins.
+  const relativize = makeRelativize(path.win32, 'C:\\Users\\proj')
+  expect(
+    relativizeContentLine(
+      'C:\\Users\\proj\\report-2024-01-15.ts:7:hit',
+      relativize,
+    ),
+  ).toBe('report-2024-01-15.ts:7:hit')
+})
+
 test('returns a line with no colon unchanged', () => {
   const relativize = makeRelativize(path.posix, '/home/u/p')
   expect(relativizeContentLine('just-some-text-no-colon', relativize)).toBe(

--- a/src/tools/GrepTool/GrepTool.test.ts
+++ b/src/tools/GrepTool/GrepTool.test.ts
@@ -1,99 +1,87 @@
 import { expect, test } from 'bun:test'
-import path from 'node:path'
 
 import { relativizeContentLine } from '../../utils/path.js'
 
-// Deterministic relativizers that don't depend on the host OS or real cwd,
-// so the same assertions hold on Windows, macOS, and Linux. They mirror
-// toRelativePath's "keep absolute when outside cwd" behaviour.
-function makeRelativize(
-  impl: typeof path.win32 | typeof path.posix,
-  cwd: string,
-): (p: string) => string {
-  return (absolutePath: string) => {
-    const rel = impl.relative(cwd, absolutePath)
-    return rel.startsWith('..') ? absolutePath : rel
-  }
-}
+// relativizeContentLine strips the known absolute search root from a ripgrep
+// content row, so the relative path plus the original ripgrep delimiter and
+// content survive verbatim. Passing the root explicitly keeps these assertions
+// deterministic across Windows, macOS, and Linux.
 
-test('relativizes a Windows drive-letter path without splitting on the drive colon', () => {
-  const relativize = makeRelativize(path.win32, 'C:\\Users\\proj')
-  // The leading `C:` must not be mistaken for the path/content separator.
+test('relativizes a Windows match row without splitting on the drive colon', () => {
   expect(
     relativizeContentLine(
       'C:\\Users\\proj\\src\\file.ts:42:const x = 1',
-      relativize,
+      'C:\\Users\\proj',
     ),
   ).toBe('src\\file.ts:42:const x = 1')
 })
 
-test('relativizes a POSIX path using the first colon as the boundary', () => {
-  const relativize = makeRelativize(path.posix, '/home/u/p')
+test('relativizes a POSIX match row', () => {
   expect(
-    relativizeContentLine('/home/u/p/src/file.ts:42:const x = 1', relativize),
+    relativizeContentLine('/home/u/p/src/file.ts:42:const x = 1', '/home/u/p'),
   ).toBe('src/file.ts:42:const x = 1')
 })
 
-test('handles the path:content form (no line number)', () => {
-  const winRelativize = makeRelativize(path.win32, 'C:\\Users\\proj')
+test('relativizes the path:content form (no line number)', () => {
   expect(
-    relativizeContentLine('C:\\Users\\proj\\src\\a.ts:const y = 2', winRelativize),
+    relativizeContentLine('C:\\Users\\proj\\src\\a.ts:const y = 2', 'C:\\Users\\proj'),
   ).toBe('src\\a.ts:const y = 2')
-
-  const posixRelativize = makeRelativize(path.posix, '/home/u/p')
-  expect(
-    relativizeContentLine('/home/u/p/src/a.ts:const y = 2', posixRelativize),
-  ).toBe('src/a.ts:const y = 2')
 })
 
-test('relativizes a Windows context row (dash-separated `-A`/`-B`/`-C`)', () => {
-  // Context rows use `-` separators, so there is no boundary colon after the
-  // drive. The `C:` drive colon must still be skipped and the `-<n>-` boundary
-  // used instead of leaving the absolute path in place.
-  const relativize = makeRelativize(path.win32, 'C:\\Users\\proj')
+test('relativizes a Windows context row (dash-separated -A/-B/-C)', () => {
   expect(
     relativizeContentLine(
       'C:\\Users\\proj\\src\\file.ts-41-const before',
-      relativize,
+      'C:\\Users\\proj',
     ),
   ).toBe('src\\file.ts-41-const before')
 })
 
-test('relativizes a POSIX context row (dash-separated)', () => {
-  const relativize = makeRelativize(path.posix, '/home/u/p')
-  expect(
-    relativizeContentLine('/home/u/p/src/file.ts-41-const before', relativize),
-  ).toBe('src/file.ts-41-const before')
-})
-
-test('uses the `:<n>:` match boundary even when the filename has a `-<n>-` run', () => {
-  // A date-like `-2024-` inside the filename must not be mistaken for the
-  // context boundary on a match row; the unambiguous `:<n>:` wins.
-  const relativize = makeRelativize(path.win32, 'C:\\Users\\proj')
+test('relativizes a context row with line numbers disabled (path-content)', () => {
+  // With show_line_numbers: false, rg omits the `-<n>-` and emits `path-content`.
+  // Prefix stripping still works where delimiter parsing could not.
   expect(
     relativizeContentLine(
-      'C:\\Users\\proj\\report-2024-01-15.ts:7:hit',
-      relativize,
+      'C:\\Users\\proj\\src\\file.ts-const before',
+      'C:\\Users\\proj',
     ),
-  ).toBe('report-2024-01-15.ts:7:hit')
+  ).toBe('src\\file.ts-const before')
 })
 
-test('returns a line with no colon unchanged', () => {
-  const relativize = makeRelativize(path.posix, '/home/u/p')
-  expect(relativizeContentLine('just-some-text-no-colon', relativize)).toBe(
-    'just-some-text-no-colon',
+test('relativizes when the cwd itself contains a date-like -<digits>- segment', () => {
+  // Regression: a delimiter heuristic would split this row at `-2024-`. Prefix
+  // stripping against the known root handles it correctly.
+  expect(
+    relativizeContentLine(
+      'C:\\Users\\proj-2024-01-15\\src\\file.ts-41-context',
+      'C:\\Users\\proj-2024-01-15',
+    ),
+  ).toBe('src\\file.ts-41-context')
+})
+
+test('keeps a path outside the root absolute', () => {
+  expect(relativizeContentLine('D:\\other\\file.ts:1:x', 'C:\\Users\\proj')).toBe(
+    'D:\\other\\file.ts:1:x',
   )
 })
 
-test('returns a bare Windows drive path (only the drive colon) unchanged', () => {
-  // `C:` has its sole colon at index 1, which is inside the skipped drive
-  // prefix, so there is no boundary colon and the line passes through.
-  const relativize = makeRelativize(path.win32, 'C:\\Users\\proj')
-  expect(relativizeContentLine('C:', relativize)).toBe('C:')
+test('does not treat a sibling dir with a shared prefix as under the root', () => {
+  // `C:\proj2` is not under `C:\proj`; the required trailing separator guards it.
+  expect(relativizeContentLine('C:\\proj2\\file.ts:1:x', 'C:\\proj')).toBe(
+    'C:\\proj2\\file.ts:1:x',
+  )
 })
 
-test('defaults to toRelativePath when no relativizer is supplied', () => {
-  // Without a path/content boundary colon the line is returned untouched,
-  // exercising the default-argument path without depending on real cwd.
-  expect(relativizeContentLine('no-colon-here')).toBe('no-colon-here')
+test('handles a drive-root cwd that already ends with a separator', () => {
+  expect(relativizeContentLine('C:\\file.ts:1:x', 'C:\\')).toBe('file.ts:1:x')
+})
+
+test('returns an unrelated line unchanged', () => {
+  expect(relativizeContentLine('just-some-text', '/home/u/p')).toBe('just-some-text')
+})
+
+test('defaults root to the cwd when not supplied', () => {
+  // A line that is not under the real cwd is returned untouched, exercising the
+  // default-argument path without depending on the cwd's exact value.
+  expect(relativizeContentLine('Z:\\nowhere\\x.ts:1:y')).toBe('Z:\\nowhere\\x.ts:1:y')
 })

--- a/src/tools/GrepTool/GrepTool.test.ts
+++ b/src/tools/GrepTool/GrepTool.test.ts
@@ -76,6 +76,20 @@ test('handles a drive-root cwd that already ends with a separator', () => {
   expect(relativizeContentLine('C:\\file.ts:1:x', 'C:\\')).toBe('file.ts:1:x')
 })
 
+test('relativizes a Windows root spelled with different casing', () => {
+  // getCwd() and ripgrep can spell the same root with different casing; Windows
+  // paths are case-insensitive, so this must still strip rather than leak.
+  expect(
+    relativizeContentLine('C:\\Users\\proj\\src\\file.ts:1:x', 'C:\\USERS\\PROJ'),
+  ).toBe('src\\file.ts:1:x')
+})
+
+test('relativizes a forward-slash root against a backslash line', () => {
+  expect(
+    relativizeContentLine('C:\\Users\\proj\\src\\file.ts:1:x', 'C:/Users/proj'),
+  ).toBe('src\\file.ts:1:x')
+})
+
 test('returns an unrelated line unchanged', () => {
   expect(relativizeContentLine('just-some-text', '/home/u/p')).toBe('just-some-text')
 })

--- a/src/tools/GrepTool/GrepTool.ts
+++ b/src/tools/GrepTool/GrepTool.ts
@@ -9,7 +9,11 @@ import {
 } from '../../utils/file.js'
 import { getFsImplementation } from '../../utils/fsOperations.js'
 import { lazySchema } from '../../utils/lazySchema.js'
-import { expandPath, toRelativePath } from '../../utils/path.js'
+import {
+  expandPath,
+  relativizeContentLine,
+  toRelativePath,
+} from '../../utils/path.js'
 import {
   checkReadPermissionForTool,
   getFileReadIgnorePatterns,
@@ -453,16 +457,12 @@ export const GrepTool = buildTool({
         offset,
       )
 
-      const finalLines = limitedResults.map(line => {
-        // Lines have format: /absolute/path:line_content or /absolute/path:num:content
-        const colonIndex = line.indexOf(':')
-        if (colonIndex > 0) {
-          const filePath = line.substring(0, colonIndex)
-          const rest = line.substring(colonIndex)
-          return toRelativePath(filePath) + rest
-        }
-        return line
-      })
+      // Lines have format: /absolute/path:line_content or /absolute/path:num:content.
+      // relativizeContentLine handles the path/content boundary, including the
+      // Windows drive-letter colon (`C:\...`) which must not be split on.
+      const finalLines = limitedResults.map(line =>
+        relativizeContentLine(line, toRelativePath),
+      )
       const output = {
         mode: 'content' as const,
         numFiles: 0, // Not applicable for content mode

--- a/src/tools/GrepTool/GrepTool.ts
+++ b/src/tools/GrepTool/GrepTool.ts
@@ -457,12 +457,11 @@ export const GrepTool = buildTool({
         offset,
       )
 
-      // Lines have format: /absolute/path:line_content or /absolute/path:num:content.
-      // relativizeContentLine handles the path/content boundary, including the
-      // Windows drive-letter colon (`C:\...`) which must not be split on.
-      const finalLines = limitedResults.map(line =>
-        relativizeContentLine(line, toRelativePath),
-      )
+      // Lines are match rows (`path:content` / `path:num:content`) or context
+      // rows (`path-content` / `path-num-content` for -A/-B/-C). relativizeContentLine
+      // strips the known cwd prefix, so the delimiter and Windows drive colons /
+      // dashes in path names never need to be parsed.
+      const finalLines = limitedResults.map(line => relativizeContentLine(line))
       const output = {
         mode: 'content' as const,
         numFiles: 0, // Not applicable for content mode

--- a/src/utils/path.ts
+++ b/src/utils/path.ts
@@ -125,13 +125,22 @@ export function relativizeContentLine(
   line: string,
   root: string = getCwd(),
 ): string {
+  // Windows roots (drive-letter or backslash) compare case-insensitively and
+  // treat `/` and `\` as equivalent — mirroring toRelativePath's path.win32
+  // behavior — so `getCwd()` and ripgrep spelling the same root with different
+  // casing/slashes still relativizes. POSIX roots compare exactly. We normalize
+  // only for the comparison and slice the ORIGINAL line by the prefix length
+  // (case/slash normalization preserves length), so content is returned verbatim.
+  const isWindowsRoot = /^[A-Za-z]:[\\/]/.test(root) || root.includes('\\')
+  const norm = (s: string): string =>
+    isWindowsRoot ? s.toLowerCase().replace(/\//g, '\\') : s
   // Try both separators so the same logic works for Windows (`\`) and POSIX
   // (`/`) roots regardless of the host OS the tests run on. The trailing
   // separator is required so a sibling like `C:\proj2` is not treated as being
   // under `C:\proj`.
   for (const sep of ['/', '\\']) {
     const prefix = root.endsWith(sep) ? root : root + sep
-    if (line.startsWith(prefix)) {
+    if (norm(line).startsWith(norm(prefix))) {
       return line.slice(prefix.length)
     }
   }

--- a/src/utils/path.ts
+++ b/src/utils/path.ts
@@ -101,31 +101,46 @@ export function toRelativePath(absolutePath: string): string {
 /**
  * Relativizes the file-path portion of a ripgrep content-mode line.
  *
- * Lines have the form `path:content` or `path:line:content`. To find the
- * boundary between the path and the rest we look for the FIRST colon — but on
- * Windows an absolute path begins with a drive-letter colon (e.g. `C:\...`),
- * so the first colon is part of the path, not the separator. We detect a
- * leading `^[A-Za-z]:` drive letter and start searching for the boundary colon
- * AFTER it, leaving POSIX paths (no drive letter) unchanged.
+ * ripgrep separates the path from the rest with `:` on a MATCH row and with `-`
+ * on a CONTEXT row (`-A`/`-B`/`-C`/`context`). With line numbers (rg `-n`, the
+ * default in GrepTool) the boundary is `<sep><line><sep>` — `:<n>:` for matches
+ * and `-<n>-` for context rows. Finding that boundary is complicated on Windows
+ * because an absolute path both begins with a drive-letter colon (`C:\...`) and
+ * may contain `-` inside file/dir names, so neither the first `:` nor the first
+ * `-` is reliable on its own.
  *
- * @param line - A single ripgrep content line (`path:content` / `path:n:content`)
+ * We therefore look (after any drive prefix) for the first `:<digits>:`, which a
+ * Windows path can never contain since it has no non-drive colon — so this is
+ * unambiguous for match rows even when the filename holds date-like `-2024-`
+ * runs. Only if that is absent do we fall back to the first `-<digits>-` for
+ * context rows, then to the first colon for line-number-less match rows
+ * (`path:content`). POSIX paths (no drive letter) are handled the same way.
+ *
+ * @param line - A single ripgrep content line (match or context row)
  * @param relativize - Function that converts an absolute path to a relative one
  *   (defaults to {@link toRelativePath}; injectable for deterministic tests)
  * @returns The line with its leading path made relative, or unchanged when no
- *   path/content boundary colon is present
+ *   path/content boundary can be located
  */
 export function relativizeContentLine(
   line: string,
   relativize: (p: string) => string = toRelativePath,
 ): string {
   // Skip a leading Windows drive-letter colon (`C:`) so it is not mistaken for
-  // the path/content separator. searchStart stays 0 for POSIX paths.
-  const searchStart = /^[A-Za-z]:/.test(line) ? 2 : 0
-  const colonIndex = line.indexOf(':', searchStart)
-  if (colonIndex > 0) {
-    const filePath = line.substring(0, colonIndex)
-    const rest = line.substring(colonIndex)
-    return relativize(filePath) + rest
+  // the path/content separator. driveOffset stays 0 for POSIX paths.
+  const driveOffset = /^[A-Za-z]:/.test(line) ? 2 : 0
+  const afterDrive = line.slice(driveOffset)
+
+  // Prefer the `:<digits>:` match boundary (unambiguous: paths have no non-drive
+  // colon), then the `-<digits>-` context boundary.
+  const numbered = afterDrive.match(/:\d+:/) ?? afterDrive.match(/-\d+-/)
+  const boundary =
+    numbered?.index !== undefined
+      ? driveOffset + numbered.index
+      : // Line-number-less match row (`path:content`): fall back to first colon.
+        line.indexOf(':', driveOffset)
+  if (boundary > 0) {
+    return relativize(line.slice(0, boundary)) + line.slice(boundary)
   }
   return line
 }

--- a/src/utils/path.ts
+++ b/src/utils/path.ts
@@ -99,6 +99,38 @@ export function toRelativePath(absolutePath: string): string {
 }
 
 /**
+ * Relativizes the file-path portion of a ripgrep content-mode line.
+ *
+ * Lines have the form `path:content` or `path:line:content`. To find the
+ * boundary between the path and the rest we look for the FIRST colon — but on
+ * Windows an absolute path begins with a drive-letter colon (e.g. `C:\...`),
+ * so the first colon is part of the path, not the separator. We detect a
+ * leading `^[A-Za-z]:` drive letter and start searching for the boundary colon
+ * AFTER it, leaving POSIX paths (no drive letter) unchanged.
+ *
+ * @param line - A single ripgrep content line (`path:content` / `path:n:content`)
+ * @param relativize - Function that converts an absolute path to a relative one
+ *   (defaults to {@link toRelativePath}; injectable for deterministic tests)
+ * @returns The line with its leading path made relative, or unchanged when no
+ *   path/content boundary colon is present
+ */
+export function relativizeContentLine(
+  line: string,
+  relativize: (p: string) => string = toRelativePath,
+): string {
+  // Skip a leading Windows drive-letter colon (`C:`) so it is not mistaken for
+  // the path/content separator. searchStart stays 0 for POSIX paths.
+  const searchStart = /^[A-Za-z]:/.test(line) ? 2 : 0
+  const colonIndex = line.indexOf(':', searchStart)
+  if (colonIndex > 0) {
+    const filePath = line.substring(0, colonIndex)
+    const rest = line.substring(colonIndex)
+    return relativize(filePath) + rest
+  }
+  return line
+}
+
+/**
  * Gets the directory path for a given file or directory path.
  * If the path is a directory, returns the path itself.
  * If the path is a file or doesn't exist, returns the parent directory.

--- a/src/utils/path.ts
+++ b/src/utils/path.ts
@@ -101,46 +101,39 @@ export function toRelativePath(absolutePath: string): string {
 /**
  * Relativizes the file-path portion of a ripgrep content-mode line.
  *
- * ripgrep separates the path from the rest with `:` on a MATCH row and with `-`
- * on a CONTEXT row (`-A`/`-B`/`-C`/`context`). With line numbers (rg `-n`, the
- * default in GrepTool) the boundary is `<sep><line><sep>` — `:<n>:` for matches
- * and `-<n>-` for context rows. Finding that boundary is complicated on Windows
- * because an absolute path both begins with a drive-letter colon (`C:\...`) and
- * may contain `-` inside file/dir names, so neither the first `:` nor the first
- * `-` is reliable on its own.
+ * A content row is `<absolute path><delimiter><rest>`, where the delimiter is
+ * `:` / `:<n>:` for match rows and `-` / `-<n>-` for context rows (`-A`/`-B`/
+ * `-C`). Locating that delimiter by inspection is unreliable on Windows: drive
+ * colons, dashes inside directory/file names (e.g. a `proj-2024-01-15` cwd), and
+ * line-number-less context rows (`path-content`, emitted when line numbers are
+ * disabled) all defeat a delimiter heuristic.
  *
- * We therefore look (after any drive prefix) for the first `:<digits>:`, which a
- * Windows path can never contain since it has no non-drive colon — so this is
- * unambiguous for match rows even when the filename holds date-like `-2024-`
- * runs. Only if that is absent do we fall back to the first `-<digits>-` for
- * context rows, then to the first colon for line-number-less match rows
- * (`path:content`). POSIX paths (no drive letter) are handled the same way.
+ * Instead we strip the known absolute search root. Every path ripgrep emits for
+ * a search under the root begins with `<root><sep>`, so removing exactly that
+ * prefix yields the relative path plus the original delimiter and content
+ * verbatim — independent of the delimiter and of whether line numbers are on.
+ * Paths not under the root keep their absolute form, matching {@link
+ * toRelativePath}.
  *
  * @param line - A single ripgrep content line (match or context row)
- * @param relativize - Function that converts an absolute path to a relative one
- *   (defaults to {@link toRelativePath}; injectable for deterministic tests)
- * @returns The line with its leading path made relative, or unchanged when no
- *   path/content boundary can be located
+ * @param root - The absolute search root to relativize against (defaults to the
+ *   current working directory; injectable for deterministic tests)
+ * @returns The line with its leading path made relative, or unchanged when the
+ *   path is not under `root`
  */
 export function relativizeContentLine(
   line: string,
-  relativize: (p: string) => string = toRelativePath,
+  root: string = getCwd(),
 ): string {
-  // Skip a leading Windows drive-letter colon (`C:`) so it is not mistaken for
-  // the path/content separator. driveOffset stays 0 for POSIX paths.
-  const driveOffset = /^[A-Za-z]:/.test(line) ? 2 : 0
-  const afterDrive = line.slice(driveOffset)
-
-  // Prefer the `:<digits>:` match boundary (unambiguous: paths have no non-drive
-  // colon), then the `-<digits>-` context boundary.
-  const numbered = afterDrive.match(/:\d+:/) ?? afterDrive.match(/-\d+-/)
-  const boundary =
-    numbered?.index !== undefined
-      ? driveOffset + numbered.index
-      : // Line-number-less match row (`path:content`): fall back to first colon.
-        line.indexOf(':', driveOffset)
-  if (boundary > 0) {
-    return relativize(line.slice(0, boundary)) + line.slice(boundary)
+  // Try both separators so the same logic works for Windows (`\`) and POSIX
+  // (`/`) roots regardless of the host OS the tests run on. The trailing
+  // separator is required so a sibling like `C:\proj2` is not treated as being
+  // under `C:\proj`.
+  for (const sep of ['/', '\\']) {
+    const prefix = root.endsWith(sep) ? root : root + sep
+    if (line.startsWith(prefix)) {
+      return line.slice(prefix.length)
+    }
   }
   return line
 }


### PR DESCRIPTION
## What & why

Grep `output_mode: "content"` split each result line at the first colon to separate path from content, but a Windows absolute path begins with a drive-letter colon (`C:`), so it split at "C", `toRelativePath("C")` returned "C" unchanged, and the original absolute path was reassembled — defeating relativization. The `count` and `files_with_matches` modes were already correct.

## Changes

Skip a leading drive-letter colon (`^[A-Za-z]:`) when locating the path/content boundary. Extracted the logic into a pure `relativizeContentLine(line, cwd)` helper.

## Checks

Added `src/tools/GrepTool/GrepTool.test.ts` using `path.win32`/`path.posix` so it's deterministic on any OS: Windows drive-letter path relativizes, POSIX path relativizes, no-colon line unchanged.

(Small self-contained bug fix with no existing issue; affects all Windows users of grep content mode.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added Bun coverage for ripgrep “content” line relativization across Windows and POSIX, including drive-letter paths, `path:content` rows, dash/context formats, date-like dash segments, root normalization (case, separator styles, trailing separators), and verified that non-matching lines remain unchanged.

* **Refactor**
  * Updated grep “content” output processing to use a dedicated relativization helper, reliably stripping the absolute search-root prefix while preserving ripgrep’s original delimiters and row format.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->