### PR TITLE
feat: Add session replay timeline

### DIFF
--- a/src/bootstrap/state.ts
+++ b/src/bootstrap/state.ts
@@ -22,6 +22,12 @@ import { createSignal } from 'src/utils/signal.js'
 type RegisteredHookMatcher = HookCallbackMatcher | PluginHookMatcher
 
 import type { SessionId } from 'src/types/ids.js'
+import type { ReplayIndexBuilder } from 'src/utils/replayIndexBuilder.js'
+
+type ReplayIndexBuilderEntry = {
+  builder: ReplayIndexBuilder
+  projectDir: string | null
+}
 
 // DO NOT ADD MORE STATE HERE - BE JUDICIOUS WITH GLOBAL STATE
 
@@ -232,6 +238,8 @@ type State = {
   // logAPISuccess to tag the first post-compaction API call so we can
   // distinguish compaction-induced cache misses from TTL expiry.
   pendingPostCompaction: boolean
+  // Replay index builders for tracking tool executions by session
+  replayIndexBuilders: Map<SessionId, ReplayIndexBuilderEntry>
 }
 
 // ALSO HERE - THINK THRICE BEFORE MODIFYING
@@ -383,6 +391,8 @@ function getInitialState(): State {
     lastMainRequestId: undefined,
     lastApiCompletionTimestamp: null,
     pendingPostCompaction: false,
+    // Replay index builders for tracking tool executions
+    replayIndexBuilders: new Map(),
   }
 
   return state
@@ -1668,5 +1678,59 @@ export function isReplBridgeActive(): boolean {
 
 export function getReplBridgeHandle(): null {
   return null
+}
+
+// Replay index builder management
+
+/**
+ * Get the replay index builder for the current session.
+ * Creates a new one if none exists.
+ */
+export function getReplayIndexBuilder(): ReplayIndexBuilder {
+  const sessionId = getSessionId()
+  let entry = STATE.replayIndexBuilders.get(sessionId)
+  if (!entry) {
+    // Lazy import to avoid circular dependencies
+    const { ReplayIndexBuilder } = require('src/utils/replayIndexBuilder.js')
+    entry = {
+      builder: new ReplayIndexBuilder(),
+      projectDir: getSessionProjectDir(),
+    }
+    STATE.replayIndexBuilders.set(sessionId, entry)
+  }
+  return entry.builder
+}
+
+/**
+ * Reset and return the replay index builder.
+ * Used during session cleanup to get the final index.
+ */
+export function resetReplayIndexBuilder(
+  sessionId: SessionId = getSessionId(),
+): ReplayIndexBuilderEntry | null {
+  const entry = STATE.replayIndexBuilders.get(sessionId) ?? null
+  STATE.replayIndexBuilders.delete(sessionId)
+  return entry
+}
+
+/**
+ * Reset and return all replay index builders.
+ * Used during process cleanup so sessions switched in-process do not mix.
+ */
+export function resetAllReplayIndexBuilders(): Array<{
+  sessionId: SessionId
+  builder: ReplayIndexBuilder
+  projectDir: string | null
+}> {
+  const entries = Array.from(
+    STATE.replayIndexBuilders,
+    ([sessionId, entry]) => ({
+      sessionId,
+      builder: entry.builder,
+      projectDir: entry.projectDir,
+    }),
+  )
+  STATE.replayIndexBuilders.clear()
+  return entries
 }
 

--- a/src/bootstrap/state.ts
+++ b/src/bootstrap/state.ts
@@ -1691,7 +1691,8 @@ export function getReplayIndexBuilder(): ReplayIndexBuilder {
   let entry = STATE.replayIndexBuilders.get(sessionId)
   if (!entry) {
     // Lazy import to avoid circular dependencies
-    const { ReplayIndexBuilder } = require('src/utils/replayIndexBuilder.js')
+    const { ReplayIndexBuilder } =
+      require('src/utils/replayIndexBuilder.js') as typeof import('src/utils/replayIndexBuilder.js')
     entry = {
       builder: new ReplayIndexBuilder(),
       projectDir: getSessionProjectDir(),

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -44,6 +44,7 @@ import onboarding from './commands/onboarding/index.js'
 import pr_comments from './commands/pr_comments/index.js'
 import releaseNotes from './commands/release-notes/index.js'
 import rename from './commands/rename/index.js'
+import replay from './commands/replay/index.js'
 import {
   requestSize,
   requestSizeNonInteractive,
@@ -323,6 +324,7 @@ const COMMANDS = memoize((): Command[] => [
   releaseNotes,
   reloadPlugins,
   rename,
+  replay,
   requestSize,
   requestSizeNonInteractive,
   resume,

--- a/src/commands/replay/ReplayTimeline.tsx
+++ b/src/commands/replay/ReplayTimeline.tsx
@@ -1,7 +1,7 @@
 import { c as _c } from "react-compiler-runtime";
-import chalk from 'chalk';
 import * as React from 'react';
 import { Box, Text, useInput } from '../../ink.js';
+import { SessionSummary } from '../../components/SessionSummary.js';
 import type { ReplayIndex, ReplayStep, ReplayToolStep, ReplayUserStep, ReplayRetryStep, ReplayErrorStep } from '../../types/logs.js';
 
 function formatDuration(ms: number): string {
@@ -10,12 +10,6 @@ function formatDuration(ms: number): string {
   const minutes = Math.floor(ms / 60000)
   const seconds = Math.floor((ms % 60000) / 1000)
   return `${minutes}m ${seconds}s`
-}
-
-function formatToolBreakdown(breakdown: Record<string, number>): string {
-  return Object.entries(breakdown)
-    .map(([tool, count]) => `${count} ${tool}`)
-    .join(', ')
 }
 
 function getStepIcon(step: ReplayStep): string {
@@ -50,48 +44,6 @@ function getStepColor(step: ReplayStep): string {
     case 'error': return 'red'
     default: return 'white'
   }
-}
-
-function SessionSummary({ summary }: { summary: ReplayIndex['summary'] }) {
-  return (
-    <Box flexDirection="column" borderStyle="round" padding={1} marginBottom={1}>
-      <Text bold>
-        {chalk.cyan('Session Summary')}
-      </Text>
-      <Text>
-        {chalk.gray('Duration:')} {formatDuration(summary.durationMs)}
-      </Text>
-      <Text>
-        {chalk.gray('Steps:')} {summary.totalSteps} ({summary.userRequests} user requests)
-      </Text>
-      <Text>
-        {chalk.gray('Tools:')} {formatToolBreakdown(summary.toolBreakdown)}
-      </Text>
-      <Text>
-        {chalk.gray('Files modified:')} {summary.filesModified.length}
-      </Text>
-      <Text>
-        {chalk.gray('Retries:')} {summary.retryAttempts ?? 0}
-      </Text>
-      <Text>
-        {chalk.gray('Repeated attempts:')} {summary.repeatedAttempts ?? 0}
-      </Text>
-      {summary.filesModified.length > 0 && (
-        <Box marginLeft={2} flexDirection="column">
-          {summary.filesModified.slice(0, 5).map((file, i) => (
-            <Text key={i} dimColor>
-              {file}
-            </Text>
-          ))}
-          {summary.filesModified.length > 5 && (
-            <Text dimColor>
-              ...and {summary.filesModified.length - 5} more
-            </Text>
-          )}
-        </Box>
-      )}
-    </Box>
-  );
 }
 
 function ReplayStepRow({ step, isSelected }: {

--- a/src/commands/replay/ReplayTimeline.tsx
+++ b/src/commands/replay/ReplayTimeline.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 import { Box, Text, useInput } from '../../ink.js';
 import { SessionSummary } from '../../components/SessionSummary.js';
 import type { ReplayIndex, ReplayStep, ReplayToolStep, ReplayUserStep, ReplayRetryStep, ReplayErrorStep } from '../../types/logs.js';
-import { formatDuration } from '../../utils/format.js';
+import { formatReplayDuration } from '../../utils/replayFormat.js';
 
 function getStepIcon(step: ReplayStep): string {
   switch (step.type) {
@@ -54,7 +54,7 @@ function ReplayStepRow({ step, isSelected }: {
         {step.type === 'tool' && (
           <>
             <Text>{(step as ReplayToolStep).inputSummary}</Text>
-            <Text color="gray"> ({formatDuration((step as ReplayToolStep).durationMs)})</Text>
+            <Text color="gray"> ({formatReplayDuration((step as ReplayToolStep).durationMs)})</Text>
             {((step as ReplayToolStep).repeatedAttemptNumber ?? 1) > 1 && (
               <Text color="yellow"> repeat {(step as ReplayToolStep).repeatedAttemptNumber}</Text>
             )}
@@ -97,7 +97,7 @@ function ReplayStepRow({ step, isSelected }: {
         <Box marginLeft={4} flexDirection="column">
           <Text dimColor>Reason: {(step as ReplayRetryStep).reason}</Text>
           {(step as ReplayRetryStep).retryDelayMs !== undefined && (
-            <Text dimColor>Delay: {formatDuration((step as ReplayRetryStep).retryDelayMs ?? 0)}</Text>
+            <Text dimColor>Delay: {formatReplayDuration((step as ReplayRetryStep).retryDelayMs ?? 0)}</Text>
           )}
           {((step as ReplayRetryStep).commands?.length ?? 0) > 0 && (
             <Text dimColor>Commands: {(step as ReplayRetryStep).commands?.join(', ')}</Text>

--- a/src/commands/replay/ReplayTimeline.tsx
+++ b/src/commands/replay/ReplayTimeline.tsx
@@ -1,0 +1,230 @@
+import { c as _c } from "react-compiler-runtime";
+import chalk from 'chalk';
+import * as React from 'react';
+import { Box, Text, useInput } from '../../ink.js';
+import type { ReplayIndex, ReplayStep, ReplayToolStep, ReplayUserStep, ReplayRetryStep, ReplayErrorStep } from '../../types/logs.js';
+
+function formatDuration(ms: number): string {
+  if (ms < 1000) return `${ms}ms`
+  if (ms < 60000) return `${(ms / 1000).toFixed(1)}s`
+  const minutes = Math.floor(ms / 60000)
+  const seconds = Math.floor((ms % 60000) / 1000)
+  return `${minutes}m ${seconds}s`
+}
+
+function formatToolBreakdown(breakdown: Record<string, number>): string {
+  return Object.entries(breakdown)
+    .map(([tool, count]) => `${count} ${tool}`)
+    .join(', ')
+}
+
+function getStepIcon(step: ReplayStep): string {
+  switch (step.type) {
+    case 'tool':
+      switch (step.resultStatus) {
+        case 'success': return '✅'
+        case 'error': return '❌'
+        case 'cancelled': return '⚠️'
+        case 'permission_denied': return '🚫'
+        default: return '•'
+      }
+    case 'user': return '👤'
+    case 'retry': return '↻'
+    case 'error': return '💥'
+    default: return '•'
+  }
+}
+
+function getStepColor(step: ReplayStep): string {
+  switch (step.type) {
+    case 'tool':
+      switch (step.resultStatus) {
+        case 'success': return 'green'
+        case 'error': return 'red'
+        case 'cancelled': return 'yellow'
+        case 'permission_denied': return 'red'
+        default: return 'white'
+      }
+    case 'user': return 'cyan'
+    case 'retry': return 'yellow'
+    case 'error': return 'red'
+    default: return 'white'
+  }
+}
+
+function SessionSummary({ summary }: { summary: ReplayIndex['summary'] }) {
+  return (
+    <Box flexDirection="column" borderStyle="round" padding={1} marginBottom={1}>
+      <Text bold>
+        {chalk.cyan('Session Summary')}
+      </Text>
+      <Text>
+        {chalk.gray('Duration:')} {formatDuration(summary.durationMs)}
+      </Text>
+      <Text>
+        {chalk.gray('Steps:')} {summary.totalSteps} ({summary.userRequests} user requests)
+      </Text>
+      <Text>
+        {chalk.gray('Tools:')} {formatToolBreakdown(summary.toolBreakdown)}
+      </Text>
+      <Text>
+        {chalk.gray('Files modified:')} {summary.filesModified.length}
+      </Text>
+      <Text>
+        {chalk.gray('Retries:')} {summary.retryAttempts ?? 0}
+      </Text>
+      <Text>
+        {chalk.gray('Repeated attempts:')} {summary.repeatedAttempts ?? 0}
+      </Text>
+      {summary.filesModified.length > 0 && (
+        <Box marginLeft={2} flexDirection="column">
+          {summary.filesModified.slice(0, 5).map((file, i) => (
+            <Text key={i} dimColor>
+              {file}
+            </Text>
+          ))}
+          {summary.filesModified.length > 5 && (
+            <Text dimColor>
+              ...and {summary.filesModified.length - 5} more
+            </Text>
+          )}
+        </Box>
+      )}
+    </Box>
+  );
+}
+
+function ReplayStepRow({ step, isSelected }: {
+  step: ReplayStep; 
+  isSelected: boolean; 
+}) {
+  const icon = getStepIcon(step)
+  const color = getStepColor(step)
+
+  return (
+    <Box flexDirection="column">
+      <Box>
+        <Text color={color}>{icon}</Text>
+        <Text bold> Step {step.stepNumber}: </Text>
+        {step.type === 'tool' && (
+          <>
+            <Text>{(step as ReplayToolStep).inputSummary}</Text>
+            <Text color="gray"> ({formatDuration((step as ReplayToolStep).durationMs)})</Text>
+            {((step as ReplayToolStep).repeatedAttemptNumber ?? 1) > 1 && (
+              <Text color="yellow"> repeat {(step as ReplayToolStep).repeatedAttemptNumber}</Text>
+            )}
+          </>
+        )}
+        {step.type === 'user' && (
+          <Text>{(step as ReplayUserStep).content.slice(0, 80)}{(step as ReplayUserStep).content.length > 80 ? '...' : ''}</Text>
+        )}
+        {step.type === 'error' && (
+          <Text color="red">{(step as ReplayErrorStep).error.slice(0, 80)}</Text>
+        )}
+        {step.type === 'retry' && (
+          <>
+            <Text color="yellow">{(step as ReplayRetryStep).retryType} retry</Text>
+            {(step as ReplayRetryStep).attempt !== undefined && (
+              <Text color="gray"> attempt {(step as ReplayRetryStep).attempt}/{(step as ReplayRetryStep).maxRetries ?? '?'}</Text>
+            )}
+          </>
+        )}
+      </Box>
+      {isSelected && step.type === 'tool' && (
+        <Box marginLeft={4} flexDirection="column">
+          {(step as ReplayToolStep).resultPreview && (
+            <Text dimColor>Result: {(step as ReplayToolStep).resultPreview}</Text>
+          )}
+          {((step as ReplayToolStep).filesModified?.length ?? 0) > 0 && (
+            <>
+              <Text dimColor>Files modified:</Text>
+              {(step as ReplayToolStep).filesModified!.map(file => (
+                <Text key={file} dimColor>  {file}</Text>
+              ))}
+            </>
+          )}
+          {((step as ReplayToolStep).repeatedAttemptNumber ?? 1) > 1 && (
+            <Text dimColor>Repeated attempt: {(step as ReplayToolStep).repeatedAttemptNumber}</Text>
+          )}
+        </Box>
+      )}
+      {isSelected && step.type === 'retry' && (
+        <Box marginLeft={4} flexDirection="column">
+          <Text dimColor>Reason: {(step as ReplayRetryStep).reason}</Text>
+          {(step as ReplayRetryStep).retryDelayMs !== undefined && (
+            <Text dimColor>Delay: {formatDuration((step as ReplayRetryStep).retryDelayMs!)}</Text>
+          )}
+          {((step as ReplayRetryStep).commands?.length ?? 0) > 0 && (
+            <Text dimColor>Commands: {(step as ReplayRetryStep).commands!.join(', ')}</Text>
+          )}
+        </Box>
+      )}
+    </Box>
+  );
+}
+
+export function ReplayTimeline({
+  index,
+  onExit,
+}: {
+  index: ReplayIndex;
+  onExit?: () => void;
+}) {
+  const [selectedStep, setSelectedStep] = React.useState<number | null>(null);
+  const [showAll, setShowAll] = React.useState(false);
+
+  const displaySteps = showAll ? index.steps : index.steps.slice(-20);
+  const selectedIndex = displaySteps.findIndex(step => step.stepNumber === selectedStep);
+
+  useInput((input, key) => {
+    if (key.escape || input === 'q' || (key.ctrl && input === 'c')) {
+      onExit?.();
+      return;
+    }
+
+    if (input === 'a' && index.steps.length > 20) {
+      setShowAll(true);
+      return;
+    }
+
+    if (displaySteps.length === 0) return;
+
+    if (key.upArrow) {
+      const nextIndex = selectedIndex > 0 ? selectedIndex - 1 : displaySteps.length - 1;
+      setSelectedStep(displaySteps[nextIndex]?.stepNumber ?? null);
+    } else if (key.downArrow) {
+      const nextIndex = selectedIndex >= 0 && selectedIndex < displaySteps.length - 1 ? selectedIndex + 1 : 0;
+      setSelectedStep(displaySteps[nextIndex]?.stepNumber ?? null);
+    } else if (key.return) {
+      if (selectedIndex >= 0) {
+        setSelectedStep(null);
+      } else {
+        setSelectedStep(displaySteps[0]?.stepNumber ?? null);
+      }
+    }
+  });
+
+  return (
+    <Box flexDirection="column">
+      <SessionSummary summary={index.summary} />
+      
+      <Box flexDirection="column">
+        {displaySteps.map((step) => (
+          <ReplayStepRow
+            key={step.stepNumber}
+            step={step}
+            isSelected={selectedStep === step.stepNumber}
+          />
+        ))}
+      </Box>
+
+      {index.steps.length > 20 && !showAll && (
+        <Box marginTop={1}>
+          <Text dimColor>
+            Showing last 20 of {index.steps.length} steps. Press 'a' to show all.
+          </Text>
+        </Box>
+      )}
+    </Box>
+  );
+}

--- a/src/commands/replay/ReplayTimeline.tsx
+++ b/src/commands/replay/ReplayTimeline.tsx
@@ -3,14 +3,7 @@ import * as React from 'react';
 import { Box, Text, useInput } from '../../ink.js';
 import { SessionSummary } from '../../components/SessionSummary.js';
 import type { ReplayIndex, ReplayStep, ReplayToolStep, ReplayUserStep, ReplayRetryStep, ReplayErrorStep } from '../../types/logs.js';
-
-function formatDuration(ms: number): string {
-  if (ms < 1000) return `${ms}ms`
-  if (ms < 60000) return `${(ms / 1000).toFixed(1)}s`
-  const minutes = Math.floor(ms / 60000)
-  const seconds = Math.floor((ms % 60000) / 1000)
-  return `${minutes}m ${seconds}s`
-}
+import { formatDuration } from '../../utils/format.js';
 
 function getStepIcon(step: ReplayStep): string {
   switch (step.type) {
@@ -90,7 +83,7 @@ function ReplayStepRow({ step, isSelected }: {
           {((step as ReplayToolStep).filesModified?.length ?? 0) > 0 && (
             <>
               <Text dimColor>Files modified:</Text>
-              {(step as ReplayToolStep).filesModified!.map(file => (
+              {(step as ReplayToolStep).filesModified?.map(file => (
                 <Text key={file} dimColor>  {file}</Text>
               ))}
             </>
@@ -104,10 +97,10 @@ function ReplayStepRow({ step, isSelected }: {
         <Box marginLeft={4} flexDirection="column">
           <Text dimColor>Reason: {(step as ReplayRetryStep).reason}</Text>
           {(step as ReplayRetryStep).retryDelayMs !== undefined && (
-            <Text dimColor>Delay: {formatDuration((step as ReplayRetryStep).retryDelayMs!)}</Text>
+            <Text dimColor>Delay: {formatDuration((step as ReplayRetryStep).retryDelayMs ?? 0)}</Text>
           )}
           {((step as ReplayRetryStep).commands?.length ?? 0) > 0 && (
-            <Text dimColor>Commands: {(step as ReplayRetryStep).commands!.join(', ')}</Text>
+            <Text dimColor>Commands: {(step as ReplayRetryStep).commands?.join(', ')}</Text>
           )}
         </Box>
       )}

--- a/src/commands/replay/index.ts
+++ b/src/commands/replay/index.ts
@@ -1,0 +1,11 @@
+import type { Command } from '../../commands.js'
+
+const replay: Command = {
+  type: 'local-jsx',
+  name: 'replay',
+  description: 'Replay a session showing tool execution timeline',
+  argumentHint: '[session id or search term]',
+  load: () => import('./replay.js'),
+}
+
+export default replay

--- a/src/commands/replay/replay.test.tsx
+++ b/src/commands/replay/replay.test.tsx
@@ -251,7 +251,8 @@ describe('/replay command', () => {
 
       expect(loadFullLogMock).toHaveBeenCalledWith(replayableLog)
       expect(loadReplayIndexMock).toHaveBeenCalledWith(liteSessionId, 'full.jsonl')
-      await waitFor(() => onDone.mock.calls.length === 0)
+      await Bun.sleep(0)
+      expect(onDone).not.toHaveBeenCalled()
     } finally {
       root.unmount()
       stdin.end()
@@ -338,6 +339,39 @@ describe('/replay command', () => {
       selectRoot.unmount()
       selectStreams.stdin.end()
       selectStreams.stdout.end()
+      await Bun.sleep(0)
+    }
+  })
+
+  test('picker reports failure when lite log expansion fails', async () => {
+    const liteLog = makeLog(liteSessionId, { isLite: true } as never)
+    loadSameRepoMessageLogsMock.mockImplementation(() =>
+      Promise.resolve([liteLog]),
+    )
+    loadFullLogMock.mockImplementation(() => Promise.reject(new Error('boom')))
+    const { call } = await importFreshReplayModule()
+    const onDone = mock(() => {})
+    const { stdin, stdout } = createTestStreams()
+    const root = await createRoot({
+      stdin: stdin as unknown as NodeJS.ReadStream,
+      stdout: stdout as unknown as NodeJS.WriteStream,
+      patchConsole: false,
+    })
+
+    try {
+      root.render(
+        <AppStateProvider>
+          {(await call(onDone, {} as never, '')) as React.ReactElement}
+        </AppStateProvider>,
+      )
+      await waitFor(() => lastLogSelectorProps !== null)
+      await lastLogSelectorProps!.onSelect(liteLog)
+      await waitFor(() => onDone.mock.calls.length === 1)
+      expect(onDone).toHaveBeenLastCalledWith('Failed to load log file')
+    } finally {
+      root.unmount()
+      stdin.end()
+      stdout.end()
       await Bun.sleep(0)
     }
   })

--- a/src/commands/replay/replay.test.tsx
+++ b/src/commands/replay/replay.test.tsx
@@ -1,0 +1,344 @@
+import { PassThrough } from 'node:stream'
+import { stripVTControlCharacters as stripAnsi } from 'node:util'
+
+import type { UUID } from 'crypto'
+import React from 'react'
+import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test'
+
+import { createRoot, Text } from '../../ink.js'
+import { AppStateProvider } from '../../state/AppState.js'
+import type { LogOption, ReplayIndex } from '../../types/logs.js'
+import { renderToString } from '../../utils/staticRender.js'
+import * as realBootstrapState from '../../bootstrap/state.js'
+import * as realGetWorktreePaths from '../../utils/getWorktreePaths.js'
+import * as realSessionStorage from '../../utils/sessionStorage.js'
+import * as realReplayIndex from '../../utils/replayIndex.js'
+import * as realUseTerminalSize from '../../hooks/useTerminalSize.js'
+import * as realModalContext from '../../context/modalContext.js'
+import * as realLogSelector from '../../components/LogSelector.js'
+import * as realReplayTimeline from './ReplayTimeline.js'
+
+type LogSelectorProps = {
+  logs: LogOption[]
+  onCancel: () => void
+  onSelect: (log: LogOption) => void | Promise<void>
+}
+
+let loadSameRepoMessageLogsMock: ReturnType<typeof mock>
+let loadFullLogMock: ReturnType<typeof mock>
+let loadReplayIndexMock: ReturnType<typeof mock>
+let lastLogSelectorProps: LogSelectorProps | null
+
+const currentSessionId = realBootstrapState.getSessionId() as UUID
+const replaySessionId = '00000000-0000-4000-8000-000000000002' as UUID
+const liteSessionId = '00000000-0000-4000-8000-000000000003' as UUID
+
+const replayIndex: ReplayIndex = {
+  sessionId: replaySessionId,
+  version: 1,
+  createdAt: '2026-01-01T00:00:00.000Z',
+  summary: {
+    totalSteps: 1,
+    toolBreakdown: { Read: 1 },
+    filesModified: [],
+    durationMs: 500,
+    startTimestamp: '2026-01-01T00:00:00.000Z',
+    endTimestamp: '2026-01-01T00:00:00.500Z',
+    userRequests: 1,
+    retryAttempts: 0,
+    repeatedAttempts: 0,
+  },
+  steps: [],
+}
+
+function makeLog(
+  sessionId: string,
+  overrides: Partial<LogOption> = {},
+): LogOption {
+  return {
+    sessionId,
+    date: '2026-01-01',
+    messages: [],
+    value: 0,
+    created: new Date('2026-01-01T00:00:00.000Z'),
+    modified: new Date('2026-01-01T00:00:00.000Z'),
+    firstPrompt: 'build replay',
+    customTitle: 'Replay Session',
+    messageCount: 1,
+    isSidechain: false,
+    fullPath: `${sessionId}.jsonl`,
+    ...overrides,
+  } as LogOption
+}
+
+async function importFreshReplayModule(): Promise<typeof import('./replay.js')> {
+  const unique = `${Date.now()}-${Math.random()}`
+  return import(`./replay.js?${unique}`) as Promise<typeof import('./replay.js')>
+}
+
+function createTestStreams() {
+  let output = ''
+  const stdout = new PassThrough()
+  stdout.on('data', chunk => {
+    output += chunk.toString()
+  })
+  ;(stdout as unknown as { columns: number }).columns = 80
+
+  const stdin = new PassThrough() as PassThrough & {
+    isTTY: boolean
+    setRawMode: (mode: boolean) => void
+    ref: () => void
+    unref: () => void
+  }
+  stdin.isTTY = true
+  stdin.setRawMode = () => {}
+  stdin.ref = () => {}
+  stdin.unref = () => {}
+
+  return { stdout, stdin, getOutput: () => stripAnsi(output) }
+}
+
+async function waitFor(
+  predicate: () => boolean,
+  timeoutMs = 1000,
+): Promise<void> {
+  const startedAt = Date.now()
+  while (Date.now() - startedAt < timeoutMs) {
+    if (predicate()) {
+      return
+    }
+    await Bun.sleep(10)
+  }
+  throw new Error('Timed out waiting for condition')
+}
+
+describe('/replay command', () => {
+  beforeEach(() => {
+    lastLogSelectorProps = null
+    loadSameRepoMessageLogsMock = mock(() => Promise.resolve([]))
+    loadFullLogMock = mock((log: LogOption) => Promise.resolve(log))
+    loadReplayIndexMock = mock(() => Promise.resolve(null))
+
+    mock.module('../../utils/getWorktreePaths.js', () => ({
+      getWorktreePaths: () => Promise.resolve([]),
+    }))
+    mock.module('../../utils/sessionStorage.js', () => ({
+      getSessionIdFromLog: (log: { sessionId?: string }) => log.sessionId,
+      getTranscriptPathForSession: (sessionId: string) => `${sessionId}.jsonl`,
+      isLiteLog: (log: { isLite?: boolean }) => log.isLite === true,
+      loadFullLog: loadFullLogMock,
+      loadSameRepoMessageLogs: loadSameRepoMessageLogsMock,
+    }))
+    mock.module('../../utils/replayIndex.js', () => ({
+      loadReplayIndex: loadReplayIndexMock,
+    }))
+    mock.module('../../hooks/useTerminalSize.js', () => ({
+      useTerminalSize: () => ({ columns: 80, rows: 24 }),
+    }))
+    mock.module('../../context/modalContext.js', () => ({
+      useIsInsideModal: () => false,
+    }))
+    mock.module('../../components/LogSelector.js', () => ({
+      LogSelector: (props: LogSelectorProps) => {
+        lastLogSelectorProps = props
+        return <Text>{`LogSelector:${props.logs.length}`}</Text>
+      },
+    }))
+    mock.module('./ReplayTimeline.js', () => ({
+      ReplayTimeline: ({ index }: { index: ReplayIndex }) => (
+        <Text>{`ReplayTimeline:${index.sessionId}`}</Text>
+      ),
+    }))
+  })
+
+  afterEach(() => {
+    try {
+      mock.restore()
+      mock.module('../../utils/getWorktreePaths.js', () => realGetWorktreePaths)
+      mock.module('../../utils/sessionStorage.js', () => realSessionStorage)
+      mock.module('../../utils/replayIndex.js', () => realReplayIndex)
+      mock.module('../../hooks/useTerminalSize.js', () => realUseTerminalSize)
+      mock.module('../../context/modalContext.js', () => realModalContext)
+      mock.module('../../components/LogSelector.js', () => realLogSelector)
+      mock.module('./ReplayTimeline.js', () => realReplayTimeline)
+    } finally {
+      lastLogSelectorProps = null
+    }
+  })
+
+  test('renders replay data for a direct session id argument', async () => {
+    loadSameRepoMessageLogsMock.mockImplementation(() =>
+      Promise.resolve([makeLog(replaySessionId)]),
+    )
+    loadReplayIndexMock.mockImplementation(() => Promise.resolve(replayIndex))
+    const { call } = await importFreshReplayModule()
+
+    const element = await call(mock(() => {}), {} as never, replaySessionId)
+    const output = await renderToString(<>{element}</>, 80)
+
+    expect(output).toContain(`ReplayTimeline:${replaySessionId}`)
+    expect(loadReplayIndexMock).toHaveBeenCalledWith(
+      replaySessionId,
+      `${replaySessionId}.jsonl`,
+    )
+  })
+
+  test('reports missing replay data for a direct session id argument', async () => {
+    loadSameRepoMessageLogsMock.mockImplementation(() =>
+      Promise.resolve([makeLog(replaySessionId)]),
+    )
+    const { call } = await importFreshReplayModule()
+
+    const element = await call(mock(() => {}), {} as never, replaySessionId)
+    const output = await renderToString(<>{element}</>, 80)
+
+    expect(output).toContain('No replay data found for session')
+    expect(output).toContain(replaySessionId)
+  })
+
+  test('searches title and prompt arguments before reporting no match', async () => {
+    loadSameRepoMessageLogsMock.mockImplementation(() =>
+      Promise.resolve([makeLog(replaySessionId, { firstPrompt: 'ship replay' })]),
+    )
+    loadReplayIndexMock.mockImplementation(() => Promise.resolve(replayIndex))
+    const { call } = await importFreshReplayModule()
+
+    const match = await call(mock(() => {}), {} as never, 'ship')
+    const matchOutput = await renderToString(<>{match}</>, 80)
+    expect(matchOutput).toContain(`ReplayTimeline:${replaySessionId}`)
+
+    loadReplayIndexMock.mockClear()
+    const miss = await call(mock(() => {}), {} as never, 'missing')
+    const missOutput = await renderToString(<>{miss}</>, 80)
+    expect(missOutput).toContain('No session found matching "missing"')
+    expect(loadReplayIndexMock).not.toHaveBeenCalled()
+  })
+
+  test('picker filters sidechains and current session before selection', async () => {
+    const replayableLog = makeLog(liteSessionId, { isLite: true } as never)
+    loadSameRepoMessageLogsMock.mockImplementation(() =>
+      Promise.resolve([
+        makeLog(currentSessionId),
+        makeLog('00000000-0000-4000-8000-000000000004', {
+          isSidechain: true,
+        }),
+        replayableLog,
+      ]),
+    )
+    loadFullLogMock.mockImplementation(() =>
+      Promise.resolve(makeLog(liteSessionId, { fullPath: 'full.jsonl' })),
+    )
+    loadReplayIndexMock.mockImplementation(() => Promise.resolve(replayIndex))
+    const { call } = await importFreshReplayModule()
+    const onDone = mock(() => {})
+    const { stdin, stdout } = createTestStreams()
+    const root = await createRoot({
+      stdin: stdin as unknown as NodeJS.ReadStream,
+      stdout: stdout as unknown as NodeJS.WriteStream,
+      patchConsole: false,
+    })
+
+    try {
+      root.render(
+        <AppStateProvider>
+          {(await call(onDone, {} as never, '')) as React.ReactElement}
+        </AppStateProvider>,
+      )
+      await waitFor(() => lastLogSelectorProps !== null)
+
+      expect(lastLogSelectorProps?.logs).toEqual([replayableLog])
+      await lastLogSelectorProps!.onSelect(replayableLog)
+
+      expect(loadFullLogMock).toHaveBeenCalledWith(replayableLog)
+      expect(loadReplayIndexMock).toHaveBeenCalledWith(liteSessionId, 'full.jsonl')
+      await waitFor(() => onDone.mock.calls.length === 0)
+    } finally {
+      root.unmount()
+      stdin.end()
+      stdout.end()
+      await Bun.sleep(0)
+    }
+  })
+
+  test('picker reports empty, load, cancel, and invalid-selection outcomes', async () => {
+    const { call } = await importFreshReplayModule()
+    const onDone = mock(() => {})
+    const emptyElement = await call(onDone, {} as never, '')
+    const { stdin, stdout } = createTestStreams()
+    const root = await createRoot({
+      stdin: stdin as unknown as NodeJS.ReadStream,
+      stdout: stdout as unknown as NodeJS.WriteStream,
+      patchConsole: false,
+    })
+
+    try {
+      root.render(
+        <AppStateProvider>{emptyElement as React.ReactElement}</AppStateProvider>,
+      )
+      await waitFor(() => onDone.mock.calls.length === 1)
+      expect(onDone).toHaveBeenLastCalledWith('No sessions found to replay')
+    } finally {
+      root.unmount()
+      stdin.end()
+      stdout.end()
+      await Bun.sleep(0)
+    }
+
+    loadSameRepoMessageLogsMock.mockImplementationOnce(() =>
+      Promise.reject(new Error('boom')),
+    )
+    const loadDone = mock(() => {})
+    const loadRootStreams = createTestStreams()
+    const loadRoot = await createRoot({
+      stdin: loadRootStreams.stdin as unknown as NodeJS.ReadStream,
+      stdout: loadRootStreams.stdout as unknown as NodeJS.WriteStream,
+      patchConsole: false,
+    })
+    try {
+      loadRoot.render(
+        <AppStateProvider>
+          {(await call(loadDone, {} as never, '')) as React.ReactElement}
+        </AppStateProvider>,
+      )
+      await waitFor(() => loadDone.mock.calls.length === 1)
+      expect(loadDone).toHaveBeenLastCalledWith('Failed to load sessions')
+    } finally {
+      loadRoot.unmount()
+      loadRootStreams.stdin.end()
+      loadRootStreams.stdout.end()
+      await Bun.sleep(0)
+    }
+
+    loadSameRepoMessageLogsMock.mockImplementation(() =>
+      Promise.resolve([makeLog(replaySessionId)]),
+    )
+    lastLogSelectorProps = null
+    const selectDone = mock(() => {})
+    const selectStreams = createTestStreams()
+    const selectRoot = await createRoot({
+      stdin: selectStreams.stdin as unknown as NodeJS.ReadStream,
+      stdout: selectStreams.stdout as unknown as NodeJS.WriteStream,
+      patchConsole: false,
+    })
+    try {
+      selectRoot.render(
+        <AppStateProvider>
+          {(await call(selectDone, {} as never, '')) as React.ReactElement}
+        </AppStateProvider>,
+      )
+      await waitFor(() => lastLogSelectorProps !== null)
+      lastLogSelectorProps!.onCancel()
+      await waitFor(() => selectDone.mock.calls.length === 1)
+      expect(selectDone).toHaveBeenLastCalledWith('Replay cancelled')
+
+      await lastLogSelectorProps!.onSelect(makeLog('not-a-uuid'))
+      await waitFor(() => selectDone.mock.calls.length === 2)
+      expect(selectDone).toHaveBeenLastCalledWith('Failed to load session')
+    } finally {
+      selectRoot.unmount()
+      selectStreams.stdin.end()
+      selectStreams.stdout.end()
+      await Bun.sleep(0)
+    }
+  })
+})

--- a/src/commands/replay/replay.tsx
+++ b/src/commands/replay/replay.tsx
@@ -1,0 +1,174 @@
+import { c as _c } from "react-compiler-runtime";
+import chalk from 'chalk';
+import type { UUID } from 'crypto';
+import * as React from 'react';
+import { getOriginalCwd, getSessionId } from '../../bootstrap/state.js';
+import { LogSelector } from '../../components/LogSelector.js';
+import { MessageResponse } from '../../components/MessageResponse.js';
+import { Spinner } from '../../components/Spinner.js';
+import { useIsInsideModal } from '../../context/modalContext.js';
+import { useTerminalSize } from '../../hooks/useTerminalSize.js';
+import { Box, Text } from '../../ink.js';
+import type { LocalJSXCommandCall } from '../../types/command.js';
+import type { LogOption, ReplayIndex } from '../../types/logs.js';
+import { loadReplayIndex } from '../../utils/replayIndex.js';
+import { getWorktreePaths } from '../../utils/getWorktreePaths.js';
+import { getSessionIdFromLog, getTranscriptPathForSession, isLiteLog, loadFullLog, loadSameRepoMessageLogs } from '../../utils/sessionStorage.js';
+import { validateUuid } from '../../utils/uuid.js';
+import { agenticSessionSearch } from '../../utils/agenticSessionSearch.js';
+import { ReplayTimeline } from './ReplayTimeline.js';
+
+function formatDuration(ms: number): string {
+  if (ms < 1000) return `${ms}ms`
+  if (ms < 60000) return `${(ms / 1000).toFixed(1)}s`
+  const minutes = Math.floor(ms / 60000)
+  const seconds = Math.floor((ms % 60000) / 1000)
+  return `${minutes}m ${seconds}s`
+}
+
+function formatToolBreakdown(breakdown: Record<string, number>): string {
+  return Object.entries(breakdown)
+    .map(([tool, count]) => `${count} ${tool}`)
+    .join(', ')
+}
+
+async function findLogBySessionId(sessionId: UUID): Promise<LogOption | undefined> {
+  const logs = await loadSameRepoMessageLogs(await getWorktreePaths(getOriginalCwd()));
+  return logs.find(log => getSessionIdFromLog(log) === sessionId);
+}
+
+function ReplaySessionPicker({
+  onDone,
+}: {
+  onDone: (result?: string) => void;
+}): React.ReactNode {
+  const [logs, setLogs] = React.useState<LogOption[]>([]);
+  const [loading, setLoading] = React.useState(true);
+  const [selected, setSelected] = React.useState(false);
+  const [replayIndex, setReplayIndex] = React.useState<ReplayIndex | null>(null);
+  const { rows } = useTerminalSize();
+  const insideModal = useIsInsideModal();
+
+  React.useEffect(() => {
+    async function loadLogs() {
+      setLoading(true);
+      try {
+        const allLogs = await loadSameRepoMessageLogs(await getWorktreePaths(getOriginalCwd()));
+        // Filter out sidechain sessions and current session
+        const replayable = allLogs.filter(l => !l.isSidechain && getSessionIdFromLog(l) !== getSessionId());
+        if (replayable.length === 0) {
+          onDone('No sessions found to replay');
+          return;
+        }
+        setLogs(replayable);
+      } catch (_err) {
+        onDone('Failed to load sessions');
+      } finally {
+        setLoading(false);
+      }
+    }
+    void loadLogs();
+  }, [onDone]);
+
+  async function handleSelect(log: LogOption) {
+    const sessionId = validateUuid(getSessionIdFromLog(log));
+    if (!sessionId) {
+      onDone('Failed to load session');
+      return;
+    }
+
+    const fullLog = isLiteLog(log) ? await loadFullLog(log) : log;
+    setSelected(true);
+    const transcriptPath = fullLog.fullPath || getTranscriptPathForSession(sessionId);
+    const index = await loadReplayIndex(sessionId, transcriptPath);
+    if (index) {
+      setReplayIndex(index);
+      return;
+    }
+    onDone('No replay data found for this session');
+  }
+
+  function handleCancel() {
+    onDone('Replay cancelled');
+  }
+
+  if (loading) {
+    return (
+      <Box>
+        <Spinner />
+        <Text> Loading sessions…</Text>
+      </Box>
+    );
+  }
+
+  if (replayIndex) {
+    return <ReplayTimeline index={replayIndex} onExit={() => onDone('Replay dismissed')} />;
+  }
+
+  if (selected) {
+    return (
+      <Box>
+        <Spinner />
+        <Text> Loading replay…</Text>
+      </Box>
+    );
+  }
+
+  return (
+    <LogSelector
+      logs={logs}
+      maxHeight={insideModal ? Math.floor(rows / 2) : rows - 2}
+      onCancel={handleCancel}
+      onSelect={handleSelect}
+      onLogsChanged={() => {}}
+    />
+  );
+}
+
+export const call: LocalJSXCommandCall = async (onDone, context, args) => {
+  // If args provided, try to find session by ID or search
+  if (args?.trim()) {
+    const sessionId = validateUuid(args.trim());
+    if (sessionId) {
+      const matchingLog = await findLogBySessionId(sessionId);
+      const transcriptPath = matchingLog?.fullPath || getTranscriptPathForSession(sessionId);
+      const replayIndex = await loadReplayIndex(sessionId, transcriptPath);
+      if (replayIndex) {
+        return <ReplayTimeline index={replayIndex} onExit={() => onDone('Replay dismissed')} />;
+      }
+      return <MessageResponse>
+        <Text>No replay data found for session {chalk.bold(args.trim())}</Text>
+      </MessageResponse>;
+    }
+    
+    // Try to search by title
+    const logs = await loadSameRepoMessageLogs(await getWorktreePaths(getOriginalCwd()));
+    const matchingLog = logs.find(l => 
+      l.customTitle?.toLowerCase().includes(args.trim().toLowerCase()) ||
+      l.firstPrompt?.toLowerCase().includes(args.trim().toLowerCase())
+    );
+    
+    if (matchingLog) {
+      const sessionId = validateUuid(getSessionIdFromLog(matchingLog));
+      if (sessionId) {
+        const transcriptPath = matchingLog.fullPath || getTranscriptPathForSession(sessionId);
+        const replayIndex = await loadReplayIndex(sessionId, transcriptPath);
+        if (replayIndex) {
+          return <ReplayTimeline index={replayIndex} onExit={() => onDone('Replay dismissed')} />;
+        }
+        return <MessageResponse>
+          <Text>No replay data found for session {chalk.bold(matchingLog.customTitle ?? matchingLog.firstPrompt ?? args.trim())}</Text>
+        </MessageResponse>;
+      }
+    }
+    
+    return <MessageResponse>
+      <Text>No session found matching "{args.trim()}"</Text>
+    </MessageResponse>;
+  }
+
+  // No args - show session picker
+  return <ReplaySessionPicker 
+    onDone={onDone}
+  />;
+};

--- a/src/commands/replay/replay.tsx
+++ b/src/commands/replay/replay.tsx
@@ -77,7 +77,13 @@ function ReplaySessionPicker({
       return;
     }
 
-    const fullLog = isLiteLog(log) ? await loadFullLog(log) : log;
+    let fullLog: LogOption
+    try {
+      fullLog = isLiteLog(log) ? await loadFullLog(log) : log;
+    } catch {
+      onDone('Failed to load log file');
+      return;
+    }
     setSelected(true);
     const transcriptPath = fullLog.fullPath || getTranscriptPathForSession(sessionId);
     const index = await loadReplayIndex(sessionId, transcriptPath);

--- a/src/commands/replay/replay.tsx
+++ b/src/commands/replay/replay.tsx
@@ -134,43 +134,51 @@ function ReplaySessionPicker({
 export const call: LocalJSXCommandCall = async (onDone, context, args) => {
   // If args provided, try to find session by ID or search
   if (args?.trim()) {
-    const sessionId = validateUuid(args.trim());
-    if (sessionId) {
-      const matchingLog = await findLogBySessionId(sessionId);
-      const transcriptPath = matchingLog?.fullPath || getTranscriptPathForSession(sessionId);
-      const replayIndex = await loadReplayIndex(sessionId, transcriptPath);
-      if (replayIndex) {
-        return <ReplayTimeline index={replayIndex} onExit={() => onDone('Replay dismissed')} />;
-      }
-      return <MessageResponse>
-        <Text>No replay data found for session {chalk.bold(args.trim())}</Text>
-      </MessageResponse>;
-    }
-    
-    // Try to search by title
-    const logs = await loadSameRepoMessageLogs(await getWorktreePaths(getOriginalCwd()));
-    const matchingLog = logs.find(l => 
-      l.customTitle?.toLowerCase().includes(args.trim().toLowerCase()) ||
-      l.firstPrompt?.toLowerCase().includes(args.trim().toLowerCase())
-    );
-    
-    if (matchingLog) {
-      const sessionId = validateUuid(getSessionIdFromLog(matchingLog));
+    const query = args.trim();
+    try {
+      const sessionId = validateUuid(query);
       if (sessionId) {
-        const transcriptPath = matchingLog.fullPath || getTranscriptPathForSession(sessionId);
+        const matchingLog = await findLogBySessionId(sessionId);
+        const transcriptPath = matchingLog?.fullPath || getTranscriptPathForSession(sessionId);
         const replayIndex = await loadReplayIndex(sessionId, transcriptPath);
         if (replayIndex) {
           return <ReplayTimeline index={replayIndex} onExit={() => onDone('Replay dismissed')} />;
         }
         return <MessageResponse>
-          <Text>No replay data found for session {chalk.bold(matchingLog.customTitle ?? matchingLog.firstPrompt ?? args.trim())}</Text>
+          <Text>No replay data found for session {chalk.bold(query)}</Text>
         </MessageResponse>;
       }
+
+      // Try to search by title
+      const logs = await loadSameRepoMessageLogs(await getWorktreePaths(getOriginalCwd()));
+      const matchingLog = logs.find(l =>
+        l.customTitle?.toLowerCase().includes(query.toLowerCase()) ||
+        l.firstPrompt?.toLowerCase().includes(query.toLowerCase())
+      );
+
+      if (matchingLog) {
+        const sessionId = validateUuid(getSessionIdFromLog(matchingLog));
+        if (sessionId) {
+          const transcriptPath = matchingLog.fullPath || getTranscriptPathForSession(sessionId);
+          const replayIndex = await loadReplayIndex(sessionId, transcriptPath);
+          if (replayIndex) {
+            return <ReplayTimeline index={replayIndex} onExit={() => onDone('Replay dismissed')} />;
+          }
+          return <MessageResponse>
+            <Text>No replay data found for session {chalk.bold(matchingLog.customTitle ?? matchingLog.firstPrompt ?? query)}</Text>
+          </MessageResponse>;
+        }
+      }
+
+      return <MessageResponse>
+        <Text>No session found matching &quot;{query}&quot;</Text>
+      </MessageResponse>;
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      return <MessageResponse>
+        <Text>Unable to load replay data for {chalk.bold(query)}: {message}</Text>
+      </MessageResponse>;
     }
-    
-    return <MessageResponse>
-      <Text>No session found matching "{args.trim()}"</Text>
-    </MessageResponse>;
   }
 
   // No args - show session picker

--- a/src/commands/resume/resume.test.tsx
+++ b/src/commands/resume/resume.test.tsx
@@ -21,6 +21,9 @@ import type {
 type OnDoneArgs = Parameters<LocalJSXCommandOnDone>
 
 let saveGoalStateMock: ReturnType<typeof mock>
+let loadSameRepoMessageLogsMock: ReturnType<typeof mock>
+let searchSessionsByCustomTitleMock: ReturnType<typeof mock>
+let loadReplayIndexMock: ReturnType<typeof mock>
 
 async function importFreshResumeModule(): Promise<
   typeof import('./resume.js')
@@ -166,6 +169,9 @@ async function waitFor(
 describe('/resume and /continue unified command', () => {
   beforeEach(() => {
     saveGoalStateMock = mock(() => Promise.resolve())
+    loadSameRepoMessageLogsMock = mock(() => Promise.resolve([]))
+    searchSessionsByCustomTitleMock = mock(() => Promise.resolve([]))
+    loadReplayIndexMock = mock(() => Promise.resolve(null))
     mock.module('../../services/goal/persistence.js', () => ({
       saveGoalState: saveGoalStateMock,
     }))
@@ -175,12 +181,16 @@ describe('/resume and /continue unified command', () => {
     mock.module('../../utils/sessionStorage.js', () => ({
       getLastSessionLog: () => Promise.resolve(null),
       getSessionIdFromLog: (log: { sessionId?: string }) => log.sessionId,
-      isCustomTitleEnabled: () => false,
+      getTranscriptPathForSession: (sessionId: string) => `${sessionId}.jsonl`,
+      isCustomTitleEnabled: () => true,
       isLiteLog: () => false,
       loadAllProjectsMessageLogs: () => Promise.resolve([]),
       loadFullLog: (log: unknown) => Promise.resolve(log),
-      loadSameRepoMessageLogs: () => Promise.resolve([]),
-      searchSessionsByCustomTitle: () => Promise.resolve([]),
+      loadSameRepoMessageLogs: loadSameRepoMessageLogsMock,
+      searchSessionsByCustomTitle: searchSessionsByCustomTitleMock,
+    }))
+    mock.module('../../utils/replayIndex.js', () => ({
+      loadReplayIndex: loadReplayIndexMock,
     }))
   })
 
@@ -418,6 +428,90 @@ describe('/resume and /continue unified command', () => {
 
     expect(element).toBeTruthy()
     expect(onDone).not.toHaveBeenCalled()
+  })
+
+  test('direct /resume session id shows replay summary before resuming', async () => {
+    const sessionId = '00000000-0000-4000-8000-000000000123' as UUID
+    const log = {
+      ...replaySession.log,
+      sessionId,
+      fullPath: '/tmp/session.jsonl',
+    } as LogOption
+    loadSameRepoMessageLogsMock.mockImplementation(() => Promise.resolve([log]))
+    loadReplayIndexMock.mockImplementation(() =>
+      Promise.resolve({
+        sessionId,
+        version: 1,
+        createdAt: '2026-01-01T00:00:00.000Z',
+        summary: replaySummary,
+        steps: [],
+      }),
+    )
+    const resumeMock = mock(() => Promise.resolve())
+    const { context } = makeContext()
+    ;(context as unknown as { resume: typeof resumeMock }).resume = resumeMock
+    const { stdin, stdout, getOutput } = createTestStreams()
+    const root = await createRoot({
+      stdin: stdin as unknown as NodeJS.ReadStream,
+      stdout: stdout as unknown as NodeJS.WriteStream,
+      patchConsole: false,
+    })
+    const { call } = await importFreshResumeModule()
+    const onDone = mock(() => {})
+
+    try {
+      const element = await call(
+        onDone as unknown as LocalJSXCommandOnDone,
+        context,
+        sessionId,
+      )
+      expect(element).toBeTruthy()
+      root.render(element as React.ReactElement)
+      await waitFor(() => getOutput().includes('Session Summary'))
+      expect(resumeMock).not.toHaveBeenCalled()
+
+      stdin.write('\r')
+      await waitFor(() => resumeMock.mock.calls.length === 1)
+      expect(resumeMock).toHaveBeenCalledWith(
+        sessionId,
+        log,
+        'slash_command_session_id',
+      )
+    } finally {
+      root.unmount()
+      stdin.end()
+      stdout.end()
+      await Bun.sleep(0)
+    }
+  })
+
+  test('direct /resume exact title resumes immediately without replay data', async () => {
+    const sessionId = '00000000-0000-4000-8000-000000000124' as UUID
+    const log = {
+      ...replaySession.log,
+      sessionId,
+      customTitle: 'exact title',
+    } as LogOption
+    loadSameRepoMessageLogsMock.mockImplementation(() => Promise.resolve([log]))
+    searchSessionsByCustomTitleMock.mockImplementation(() =>
+      Promise.resolve([log]),
+    )
+    loadReplayIndexMock.mockImplementation(() => Promise.resolve(null))
+    const resumeMock = mock(() => Promise.resolve())
+    const { context } = makeContext()
+    ;(context as unknown as { resume: typeof resumeMock }).resume = resumeMock
+    const { call } = await importFreshResumeModule()
+    const onDone = mock(() => {})
+
+    const element = await call(
+      onDone as unknown as LocalJSXCommandOnDone,
+      context,
+      'exact title',
+    )
+
+    expect(element).toBeNull()
+    await waitFor(() => resumeMock.mock.calls.length === 1)
+    expect(resumeMock).toHaveBeenCalledWith(sessionId, log, 'slash_command_title')
   })
 
   test('replay summary confirmation renders without resuming immediately', async () => {

--- a/src/commands/resume/resume.test.tsx
+++ b/src/commands/resume/resume.test.tsx
@@ -149,6 +149,20 @@ async function renderResumeConfirmation() {
   }
 }
 
+async function waitFor(
+  predicate: () => boolean,
+  timeoutMs = 1000,
+): Promise<void> {
+  const startedAt = Date.now()
+  while (Date.now() - startedAt < timeoutMs) {
+    if (predicate()) {
+      return
+    }
+    await Bun.sleep(10)
+  }
+  throw new Error('Timed out waiting for condition')
+}
+
 describe('/resume and /continue unified command', () => {
   beforeEach(() => {
     saveGoalStateMock = mock(() => Promise.resolve())
@@ -433,9 +447,9 @@ describe('/resume and /continue unified command', () => {
   test('replay summary confirmation cancels on Escape', async () => {
     const rendered = await renderResumeConfirmation()
     try {
-      rendered.stdin.write('\x1B\x1B')
-      await Bun.sleep(50)
+      rendered.stdin.write('\u001B')
 
+      await waitFor(() => rendered.onCancel.mock.calls.length === 1)
       expect(rendered.onCancel).toHaveBeenCalled()
       expect(rendered.onResume).not.toHaveBeenCalled()
     } finally {

--- a/src/commands/resume/resume.test.tsx
+++ b/src/commands/resume/resume.test.tsx
@@ -1,11 +1,18 @@
+import { PassThrough } from 'node:stream'
+import { stripVTControlCharacters as stripAnsi } from 'node:util'
+
+import type { UUID } from 'crypto'
 import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test'
+import React from 'react'
 
 import {
   achieveGoal,
   createGoalState,
   pauseGoal,
 } from '../../services/goal/state.js'
+import { createRoot } from '../../ink.js'
 import { getDefaultAppState, type AppState } from '../../state/AppStateStore.js'
+import type { LogOption, ReplaySummary } from '../../types/logs.js'
 import type {
   LocalJSXCommandContext,
   LocalJSXCommandOnDone,
@@ -45,6 +52,100 @@ function makeContext(
       agentId: 'agent-test-123',
     } as unknown as LocalJSXCommandContext,
     getState: () => state,
+  }
+}
+
+function createTestStreams(): {
+  stdout: PassThrough
+  stdin: PassThrough & {
+    isTTY: boolean
+    setRawMode: (mode: boolean) => void
+    ref: () => void
+    unref: () => void
+  }
+  getOutput: () => string
+} {
+  let output = ''
+  const stdout = new PassThrough()
+  stdout.on('data', chunk => {
+    output += chunk.toString()
+  })
+  ;(stdout as unknown as { columns: number }).columns = 80
+
+  const stdin = new PassThrough() as PassThrough & {
+    isTTY: boolean
+    setRawMode: (mode: boolean) => void
+    ref: () => void
+    unref: () => void
+  }
+  stdin.isTTY = true
+  stdin.setRawMode = () => {}
+  stdin.ref = () => {}
+  stdin.unref = () => {}
+
+  return { stdout, stdin, getOutput: () => stripAnsi(output) }
+}
+
+const replaySummary: ReplaySummary = {
+  totalSteps: 3,
+  toolBreakdown: { Read: 1 },
+  filesModified: ['src/a.ts'],
+  durationMs: 1000,
+  startTimestamp: '2026-01-01T00:00:00.000Z',
+  endTimestamp: '2026-01-01T00:00:01.000Z',
+  userRequests: 1,
+  retryAttempts: 0,
+  repeatedAttempts: 0,
+}
+
+const replaySession = {
+  sessionId: '00000000-0000-4000-8000-000000000000' as UUID,
+  log: {
+    date: '2026-01-01',
+    messages: [],
+    value: 0,
+    created: new Date('2026-01-01T00:00:00.000Z'),
+    modified: new Date('2026-01-01T00:00:00.000Z'),
+    firstPrompt: 'hello',
+    messageCount: 1,
+    isSidechain: false,
+  } as LogOption,
+}
+
+async function renderResumeConfirmation() {
+  const { stdin, stdout, getOutput } = createTestStreams()
+  const root = await createRoot({
+    stdin: stdin as unknown as NodeJS.ReadStream,
+    stdout: stdout as unknown as NodeJS.WriteStream,
+    patchConsole: false,
+  })
+  const onResume = mock(() => {})
+  const onCancel = mock(() => {})
+  const { ResumeConfirmation } = await importFreshResumeModule()
+
+  root.render(
+    <ResumeConfirmation
+      selectedSession={replaySession}
+      sessionSummary={replaySummary}
+      resuming={false}
+      onResume={onResume}
+      onCancel={onCancel}
+    />,
+  )
+  await Bun.sleep(10)
+
+  return {
+    stdin,
+    root,
+    getOutput,
+    onResume,
+    onCancel,
+    cleanup: async () => {
+      root.unmount()
+      stdin.end()
+      stdout.end()
+      await Bun.sleep(0)
+    },
   }
 }
 
@@ -303,5 +404,42 @@ describe('/resume and /continue unified command', () => {
 
     expect(element).toBeTruthy()
     expect(onDone).not.toHaveBeenCalled()
+  })
+
+  test('replay summary confirmation renders without resuming immediately', async () => {
+    const rendered = await renderResumeConfirmation()
+    try {
+      expect(rendered.getOutput()).toContain('Session Summary')
+      expect(rendered.getOutput()).toContain('Press Enter to resume')
+      expect(rendered.onResume).not.toHaveBeenCalled()
+    } finally {
+      await rendered.cleanup()
+    }
+  })
+
+  test('replay summary confirmation resumes on Enter', async () => {
+    const rendered = await renderResumeConfirmation()
+    try {
+      rendered.stdin.write('\r')
+      await Bun.sleep(10)
+
+      expect(rendered.onResume).toHaveBeenCalledWith(replaySession)
+      expect(rendered.onCancel).not.toHaveBeenCalled()
+    } finally {
+      await rendered.cleanup()
+    }
+  })
+
+  test('replay summary confirmation cancels on Escape', async () => {
+    const rendered = await renderResumeConfirmation()
+    try {
+      rendered.stdin.write('\x1B\x1B')
+      await Bun.sleep(50)
+
+      expect(rendered.onCancel).toHaveBeenCalled()
+      expect(rendered.onResume).not.toHaveBeenCalled()
+    } finally {
+      await rendered.cleanup()
+    }
   })
 })

--- a/src/commands/resume/resume.test.tsx
+++ b/src/commands/resume/resume.test.tsx
@@ -472,11 +472,14 @@ describe('/resume and /continue unified command', () => {
 
       stdin.write('\r')
       await waitFor(() => resumeMock.mock.calls.length === 1)
+      stdin.write('\r')
+      await Bun.sleep(10)
       expect(resumeMock).toHaveBeenCalledWith(
         sessionId,
         log,
         'slash_command_session_id',
       )
+      expect(resumeMock).toHaveBeenCalledTimes(1)
     } finally {
       root.unmount()
       stdin.end()

--- a/src/commands/resume/resume.tsx
+++ b/src/commands/resume/resume.tsx
@@ -279,6 +279,45 @@ export function filterResumableSessions(logs: LogOption[], currentSessionId: str
   return logs.filter(l => !l.isSidechain && getSessionIdFromLog(l) !== currentSessionId);
 }
 
+function DirectResumeConfirmation({
+  selectedSession,
+  sessionSummary,
+  entrypoint,
+  onResume,
+  onDone,
+}: {
+  selectedSession: ResumeConfirmationSession;
+  sessionSummary: import('../../types/logs.js').ReplaySummary;
+  entrypoint: ResumeEntrypoint;
+  onResume: (
+    sessionId: UUID,
+    log: LogOption,
+    entrypoint: ResumeEntrypoint,
+  ) => Promise<void>;
+  onDone: Parameters<LocalJSXCommandCall>[0];
+}): React.ReactNode {
+  const [resuming, setResuming] = React.useState(false);
+
+  return (
+    <ResumeConfirmation
+      selectedSession={selectedSession}
+      sessionSummary={sessionSummary}
+      resuming={resuming}
+      onResume={session => {
+        if (resuming) return;
+        setResuming(true);
+        void onResume(session.sessionId, session.log, entrypoint);
+      }}
+      onCancel={() => {
+        if (resuming) return;
+        onDone('Resume cancelled', {
+          display: 'system',
+        });
+      }}
+    />
+  );
+}
+
 async function resumeWithOptionalSummary(
   sessionId: UUID,
   log: LogOption,
@@ -298,18 +337,12 @@ async function resumeWithOptionalSummary(
   }
 
   return (
-    <ResumeConfirmation
+    <DirectResumeConfirmation
       selectedSession={{ sessionId, log }}
       sessionSummary={replayIndex.summary}
-      resuming={false}
-      onResume={session => {
-        void onResume(session.sessionId, session.log, entrypoint);
-      }}
-      onCancel={() => {
-        onDone('Resume cancelled', {
-          display: 'system',
-        });
-      }}
+      entrypoint={entrypoint}
+      onResume={onResume}
+      onDone={onDone}
     />
   );
 }

--- a/src/commands/resume/resume.tsx
+++ b/src/commands/resume/resume.tsx
@@ -279,6 +279,41 @@ export function filterResumableSessions(logs: LogOption[], currentSessionId: str
   return logs.filter(l => !l.isSidechain && getSessionIdFromLog(l) !== currentSessionId);
 }
 
+async function resumeWithOptionalSummary(
+  sessionId: UUID,
+  log: LogOption,
+  entrypoint: ResumeEntrypoint,
+  onResume: (
+    sessionId: UUID,
+    log: LogOption,
+    entrypoint: ResumeEntrypoint,
+  ) => Promise<void>,
+  onDone: Parameters<LocalJSXCommandCall>[0],
+): Promise<React.ReactNode> {
+  const transcriptPath = log.fullPath || getTranscriptPathForSession(sessionId);
+  const replayIndex = await loadReplayIndex(sessionId, transcriptPath);
+  if (!replayIndex) {
+    void onResume(sessionId, log, entrypoint);
+    return null;
+  }
+
+  return (
+    <ResumeConfirmation
+      selectedSession={{ sessionId, log }}
+      sessionSummary={replayIndex.summary}
+      resuming={false}
+      onResume={session => {
+        void onResume(session.sessionId, session.log, entrypoint);
+      }}
+      onCancel={() => {
+        onDone('Resume cancelled', {
+          display: 'system',
+        });
+      }}
+    />
+  );
+}
+
 function isResumableGoal(goal: GoalState | null): goal is GoalState {
   return goal != null && (goal.status === 'active' || goal.status === 'paused');
 }
@@ -423,8 +458,13 @@ export const call: LocalJSXCommandCall = async (onDone, context, args) => {
     if (matchingLogs.length > 0) {
       const log = matchingLogs[0]!;
       const fullLog = isLiteLog(log) ? await loadFullLog(log) : log;
-      void onResume(maybeSessionId, fullLog, 'slash_command_session_id');
-      return null;
+      return resumeWithOptionalSummary(
+        maybeSessionId,
+        fullLog,
+        'slash_command_session_id',
+        onResume,
+        onDone,
+      );
     }
 
     // Enriched logs didn't find it — try direct file lookup. This handles
@@ -432,8 +472,13 @@ export const call: LocalJSXCommandCall = async (onDone, context, args) => {
     // firstPrompt extraction fail, causing the session to be dropped).
     const directLog = await getLastSessionLog(maybeSessionId);
     if (directLog) {
-      void onResume(maybeSessionId, directLog, 'slash_command_session_id');
-      return null;
+      return resumeWithOptionalSummary(
+        maybeSessionId,
+        directLog,
+        'slash_command_session_id',
+        onResume,
+        onDone,
+      );
     }
   }
 
@@ -447,8 +492,13 @@ export const call: LocalJSXCommandCall = async (onDone, context, args) => {
       const sessionId = getSessionIdFromLog(log);
       if (sessionId) {
         const fullLog = isLiteLog(log) ? await loadFullLog(log) : log;
-        void onResume(sessionId, fullLog, 'slash_command_title');
-        return null;
+        return resumeWithOptionalSummary(
+          sessionId,
+          fullLog,
+          'slash_command_title',
+          onResume,
+          onDone,
+        );
       }
     }
 

--- a/src/commands/resume/resume.tsx
+++ b/src/commands/resume/resume.tsx
@@ -43,6 +43,49 @@ function resumeHelpMessage(result: ResumeResult): string {
       return `Found ${result.count} sessions matching ${chalk.bold(result.arg)}. Please use /resume to pick a specific session.`;
   }
 }
+
+type ResumeConfirmationSession = {
+  sessionId: UUID;
+  log: LogOption;
+}
+
+export function ResumeConfirmation({
+  selectedSession,
+  sessionSummary,
+  resuming,
+  onResume,
+  onCancel,
+}: {
+  selectedSession: ResumeConfirmationSession;
+  sessionSummary: import('../../types/logs.js').ReplaySummary;
+  resuming: boolean;
+  onResume: (session: ResumeConfirmationSession) => void;
+  onCancel: () => void;
+}): React.ReactNode {
+  useInput((_input, key) => {
+    if (key.return) {
+      onResume(selectedSession);
+    } else if (key.escape) {
+      onCancel();
+    }
+  }, {
+    isActive: !resuming,
+  });
+
+  return (
+    <Box flexDirection="column">
+      <SessionSummary summary={sessionSummary} />
+      <Box marginTop={1}>
+        <Text>Press </Text>
+        <Text bold color="green">Enter</Text>
+        <Text> to resume, </Text>
+        <Text bold color="red">Escape</Text>
+        <Text> to cancel</Text>
+      </Box>
+    </Box>
+  );
+}
+
 function ResumeError(t0) {
   const $ = _c(10);
   const {
@@ -195,10 +238,10 @@ function ResumeCommand({
     }
   }
 
-  function handleConfirmResume() {
-    if (selectedSession) {
+  function handleConfirmResume(session = selectedSession) {
+    if (session) {
       setResuming(true);
-      void onResume(selectedSession.sessionId, selectedSession.log, 'slash_command_picker');
+      void onResume(session.sessionId, session.log, 'slash_command_picker');
     }
   }
 
@@ -206,16 +249,6 @@ function ResumeCommand({
     setSelectedSession(null);
     setSessionSummary(null);
   }
-
-  useInput((_input, key) => {
-    if (key.return) {
-      handleConfirmResume();
-    } else if (key.escape) {
-      handleCancelResume();
-    }
-  }, {
-    isActive: Boolean(selectedSession && sessionSummary && !resuming)
-  });
 
   function handleCancel() {
     onDone('Resume cancelled', {
@@ -237,18 +270,7 @@ function ResumeCommand({
 
   // Show session summary confirmation if a session is selected
   if (selectedSession && sessionSummary) {
-    return (
-      <Box flexDirection="column">
-        <SessionSummary summary={sessionSummary} />
-        <Box marginTop={1}>
-          <Text>Press </Text>
-          <Text bold color="green">Enter</Text>
-          <Text> to resume, </Text>
-          <Text bold color="red">Escape</Text>
-          <Text> to cancel</Text>
-        </Box>
-      </Box>
-    );
+    return <ResumeConfirmation selectedSession={selectedSession} sessionSummary={sessionSummary} resuming={resuming} onResume={handleConfirmResume} onCancel={handleCancelResume} />;
   }
 
   return <LogSelector logs={logs} maxHeight={insideModal ? Math.floor(rows / 2) : rows - 2} onCancel={handleCancel} onSelect={handleSelect} onLogsChanged={() => loadLogs(showAllProjects, worktreePaths)} showAllProjects={showAllProjects} onToggleAllProjects={handleToggleAllProjects} onAgenticSearch={agenticSessionSearch} />;

--- a/src/commands/resume/resume.tsx
+++ b/src/commands/resume/resume.tsx
@@ -11,11 +11,12 @@ import type { GoalState } from '../../services/goal/types.js';
 import type { CommandResultDisplay, ResumeEntrypoint } from '../../commands.js';
 import { LogSelector } from '../../components/LogSelector.js';
 import { MessageResponse } from '../../components/MessageResponse.js';
+import { SessionSummary } from '../../components/SessionSummary.js';
 import { Spinner } from '../../components/Spinner.js';
 import { useIsInsideModal } from '../../context/modalContext.js';
 import { useTerminalSize } from '../../hooks/useTerminalSize.js';
 import { setClipboard } from '../../ink/termio/osc.js';
-import { Box, Text } from '../../ink.js';
+import { Box, Text, useInput } from '../../ink.js';
 import type { LocalJSXCommandCall } from '../../types/command.js';
 import type { LogOption } from '../../types/logs.js';
 import type { TodoItem, TodoList } from '../../utils/todo/types.js';
@@ -23,7 +24,8 @@ import { agenticSessionSearch } from '../../utils/agenticSessionSearch.js';
 import { checkCrossProjectResume } from '../../utils/crossProjectResume.js';
 import { getWorktreePaths } from '../../utils/getWorktreePaths.js';
 import { logError } from '../../utils/log.js';
-import { getLastSessionLog, getSessionIdFromLog, isCustomTitleEnabled, isLiteLog, loadAllProjectsMessageLogs, loadFullLog, loadSameRepoMessageLogs, searchSessionsByCustomTitle } from '../../utils/sessionStorage.js';
+import { loadReplayIndex } from '../../utils/replayIndex.js';
+import { getLastSessionLog, getSessionIdFromLog, getTranscriptPathForSession, isCustomTitleEnabled, isLiteLog, loadAllProjectsMessageLogs, loadFullLog, loadSameRepoMessageLogs, searchSessionsByCustomTitle } from '../../utils/sessionStorage.js';
 import { validateUuid } from '../../utils/uuid.js';
 type ResumeResult = {
   resultType: 'sessionNotFound';
@@ -105,6 +107,8 @@ function ResumeCommand({
   const [loading, setLoading] = React.useState(true);
   const [resuming, setResuming] = React.useState(false);
   const [showAllProjects, setShowAllProjects] = React.useState(false);
+  const [selectedSession, setSelectedSession] = React.useState<{ sessionId: UUID; log: LogOption } | null>(null);
+  const [sessionSummary, setSessionSummary] = React.useState<import('../../types/logs.js').ReplaySummary | null>(null);
   const {
     rows
   } = useTerminalSize();
@@ -153,8 +157,16 @@ function ResumeCommand({
     if (crossProjectCheck.isCrossProject) {
       if (crossProjectCheck.isSameRepoWorktree) {
         // Same repo worktree - can resume directly
-        setResuming(true);
-        void onResume(sessionId, fullLog, 'slash_command_picker');
+        // Try to load replay summary
+        const transcriptPath = fullLog.fullPath || getTranscriptPathForSession(sessionId);
+        const replayIndex = await loadReplayIndex(sessionId, transcriptPath);
+        if (replayIndex) {
+          setSessionSummary(replayIndex.summary);
+          setSelectedSession({ sessionId, log: fullLog });
+        } else {
+          setResuming(true);
+          void onResume(sessionId, fullLog, 'slash_command_picker');
+        }
         return;
       }
 
@@ -170,10 +182,41 @@ function ResumeCommand({
       return;
     }
 
-    // Same directory - proceed with resume
-    setResuming(true);
-    void onResume(sessionId, fullLog, 'slash_command_picker');
+    // Same directory - try to show summary first
+    const transcriptPath = fullLog.fullPath || getTranscriptPathForSession(sessionId);
+    const replayIndex = await loadReplayIndex(sessionId, transcriptPath);
+    if (replayIndex) {
+      setSessionSummary(replayIndex.summary);
+      setSelectedSession({ sessionId, log: fullLog });
+    } else {
+      // No replay data, proceed directly
+      setResuming(true);
+      void onResume(sessionId, fullLog, 'slash_command_picker');
+    }
   }
+
+  function handleConfirmResume() {
+    if (selectedSession) {
+      setResuming(true);
+      void onResume(selectedSession.sessionId, selectedSession.log, 'slash_command_picker');
+    }
+  }
+
+  function handleCancelResume() {
+    setSelectedSession(null);
+    setSessionSummary(null);
+  }
+
+  useInput((_input, key) => {
+    if (key.return) {
+      handleConfirmResume();
+    } else if (key.escape) {
+      handleCancelResume();
+    }
+  }, {
+    isActive: Boolean(selectedSession && sessionSummary && !resuming)
+  });
+
   function handleCancel() {
     onDone('Resume cancelled', {
       display: 'system'
@@ -191,6 +234,23 @@ function ResumeCommand({
         <Text> Resuming conversation…</Text>
       </Box>;
   }
+
+  // Show session summary confirmation if a session is selected
+  if (selectedSession && sessionSummary) {
+    return (
+      <Box flexDirection="column">
+        <SessionSummary summary={sessionSummary} />
+        <Box marginTop={1}>
+          <Text>Press </Text>
+          <Text bold color="green">Enter</Text>
+          <Text> to resume, </Text>
+          <Text bold color="red">Escape</Text>
+          <Text> to cancel</Text>
+        </Box>
+      </Box>
+    );
+  }
+
   return <LogSelector logs={logs} maxHeight={insideModal ? Math.floor(rows / 2) : rows - 2} onCancel={handleCancel} onSelect={handleSelect} onLogsChanged={() => loadLogs(showAllProjects, worktreePaths)} showAllProjects={showAllProjects} onToggleAllProjects={handleToggleAllProjects} onAgenticSearch={agenticSessionSearch} />;
 }
 export function filterResumableSessions(logs: LogOption[], currentSessionId: string): LogOption[] {

--- a/src/components/SessionSummary.tsx
+++ b/src/components/SessionSummary.tsx
@@ -1,0 +1,79 @@
+import { c as _c } from "react-compiler-runtime";
+import chalk from 'chalk';
+import * as React from 'react';
+import { Box, Text } from '../ink.js';
+import type { ReplaySummary } from '../types/logs.js';
+
+function formatDuration(ms: number): string {
+  if (ms < 1000) return `${ms}ms`
+  if (ms < 60000) return `${(ms / 1000).toFixed(1)}s`
+  const minutes = Math.floor(ms / 60000)
+  const seconds = Math.floor((ms % 60000) / 1000)
+  return `${minutes}m ${seconds}s`
+}
+
+function formatToolBreakdown(breakdown: Record<string, number>): string {
+  return Object.entries(breakdown)
+    .map(([tool, count]) => `${count} ${tool}`)
+    .join(', ')
+}
+
+interface SessionSummaryProps {
+  summary: ReplaySummary;
+  compact?: boolean;
+}
+
+export function SessionSummary({ summary, compact = false }: SessionSummaryProps) {
+  if (compact) {
+    // Single line format
+    const totalTools = Object.values(summary.toolBreakdown).reduce((a, b) => a + b, 0)
+    return (
+      <Box>
+      <Text color="cyan">
+          {summary.totalSteps} steps | {totalTools} tools | {summary.filesModified.length} files | {summary.retryAttempts ?? 0} retries | {summary.repeatedAttempts ?? 0} repeats | {formatDuration(summary.durationMs)}
+      </Text>
+      </Box>
+    );
+  }
+
+  // Full summary with breakdown
+  return (
+    <Box flexDirection="column" borderStyle="round" padding={1} marginBottom={1}>
+      <Text bold>
+        {chalk.cyan('Session Summary')}
+      </Text>
+      <Text>
+        {chalk.gray('Duration:')} {formatDuration(summary.durationMs)}
+      </Text>
+      <Text>
+        {chalk.gray('Steps:')} {summary.totalSteps} ({summary.userRequests} user requests)
+      </Text>
+      <Text>
+        {chalk.gray('Tools:')} {formatToolBreakdown(summary.toolBreakdown)}
+      </Text>
+      <Text>
+        {chalk.gray('Files modified:')} {summary.filesModified.length}
+      </Text>
+      <Text>
+        {chalk.gray('Retries:')} {summary.retryAttempts ?? 0}
+      </Text>
+      <Text>
+        {chalk.gray('Repeated attempts:')} {summary.repeatedAttempts ?? 0}
+      </Text>
+      {summary.filesModified.length > 0 && (
+        <Box marginLeft={2} flexDirection="column">
+          {summary.filesModified.slice(0, 5).map((file, i) => (
+            <Text key={i} dimColor>
+              {file}
+            </Text>
+          ))}
+          {summary.filesModified.length > 5 && (
+            <Text dimColor>
+              ...and {summary.filesModified.length - 5} more
+            </Text>
+          )}
+        </Box>
+      )}
+    </Box>
+  );
+}

--- a/src/components/SessionSummary.tsx
+++ b/src/components/SessionSummary.tsx
@@ -3,14 +3,7 @@ import chalk from 'chalk';
 import * as React from 'react';
 import { Box, Text } from '../ink.js';
 import type { ReplaySummary } from '../types/logs.js';
-
-function formatDuration(ms: number): string {
-  if (ms < 1000) return `${ms}ms`
-  if (ms < 60000) return `${(ms / 1000).toFixed(1)}s`
-  const minutes = Math.floor(ms / 60000)
-  const seconds = Math.floor((ms % 60000) / 1000)
-  return `${minutes}m ${seconds}s`
-}
+import { formatDuration } from '../utils/format.js';
 
 function formatToolBreakdown(breakdown: Record<string, number>): string {
   return Object.entries(breakdown)

--- a/src/components/SessionSummary.tsx
+++ b/src/components/SessionSummary.tsx
@@ -3,7 +3,7 @@ import chalk from 'chalk';
 import * as React from 'react';
 import { Box, Text } from '../ink.js';
 import type { ReplaySummary } from '../types/logs.js';
-import { formatDuration } from '../utils/format.js';
+import { formatReplayDuration } from '../utils/replayFormat.js';
 
 function formatToolBreakdown(breakdown: Record<string, number>): string {
   return Object.entries(breakdown)
@@ -23,7 +23,7 @@ export function SessionSummary({ summary, compact = false }: SessionSummaryProps
     return (
       <Box>
       <Text color="cyan">
-          {summary.totalSteps} steps | {totalTools} tools | {summary.filesModified.length} files | {summary.retryAttempts ?? 0} retries | {summary.repeatedAttempts ?? 0} repeats | {formatDuration(summary.durationMs)}
+          {summary.totalSteps} steps | {totalTools} tools | {summary.filesModified.length} files | {summary.retryAttempts ?? 0} retries | {summary.repeatedAttempts ?? 0} repeats | {formatReplayDuration(summary.durationMs)}
       </Text>
       </Box>
     );
@@ -36,7 +36,7 @@ export function SessionSummary({ summary, compact = false }: SessionSummaryProps
         {chalk.cyan('Session Summary')}
       </Text>
       <Text>
-        {chalk.gray('Duration:')} {formatDuration(summary.durationMs)}
+        {chalk.gray('Duration:')} {formatReplayDuration(summary.durationMs)}
       </Text>
       <Text>
         {chalk.gray('Steps:')} {summary.totalSteps} ({summary.userRequests} user requests)

--- a/src/components/SessionSummary.tsx
+++ b/src/components/SessionSummary.tsx
@@ -42,7 +42,7 @@ export function SessionSummary({ summary, compact = false }: SessionSummaryProps
         {chalk.gray('Steps:')} {summary.totalSteps} ({summary.userRequests} user requests)
       </Text>
       <Text>
-        {chalk.gray('Tools:')} {formatToolBreakdown(summary.toolBreakdown)}
+        {chalk.gray('Tools:')} {Object.keys(summary.toolBreakdown).length > 0 ? formatToolBreakdown(summary.toolBreakdown) : 'None'}
       </Text>
       <Text>
         {chalk.gray('Files modified:')} {summary.filesModified.length}
@@ -55,8 +55,8 @@ export function SessionSummary({ summary, compact = false }: SessionSummaryProps
       </Text>
       {summary.filesModified.length > 0 && (
         <Box marginLeft={2} flexDirection="column">
-          {summary.filesModified.slice(0, 5).map((file, i) => (
-            <Text key={i} dimColor>
+          {summary.filesModified.slice(0, 5).map(file => (
+            <Text key={file} dimColor>
               {file}
             </Text>
           ))}

--- a/src/services/tools/toolExecution.test.ts
+++ b/src/services/tools/toolExecution.test.ts
@@ -1,6 +1,12 @@
-import { describe, expect, test } from 'bun:test'
+import { afterEach, describe, expect, mock, test } from 'bun:test'
 import { z } from 'zod/v4'
 
+import { getEmptyToolPermissionContext, type Tool, type ToolUseContext } from '../../Tool.js'
+import {
+  getReplayIndexBuilder,
+  resetAllReplayIndexBuilders,
+} from '../../bootstrap/state.js'
+import { getDefaultAppState } from '../../state/AppStateStore.js'
 import { SkillTool } from '../../tools/SkillTool/SkillTool.js'
 import { AskUserQuestionTool } from '../../tools/AskUserQuestionTool/AskUserQuestionTool.js'
 import { BASH_TOOL_NAME } from '../../tools/BashTool/toolName.js'
@@ -14,76 +20,16 @@ import {
   getReplayModifiedFiles,
   getSchemaValidationErrorOverride,
   getSchemaValidationToolUseResult,
+  checkPermissionsAndCallTool,
   normalizeReplayToolInput,
   normalizeToolInputForValidation,
   runToolUse,
 } from './toolExecution.js'
 
-const lifecycleToolInputSchema = z.object({
-  command: z.string(),
-  timeout: z.number().optional(),
+afterEach(() => {
+  delete process.env.TEST_ENABLE_SESSION_PERSISTENCE
+  resetAllReplayIndexBuilders()
 })
-
-const assistantMessage = {
-  uuid: 'assistant-message-1',
-  requestId: 'request-1',
-  message: {
-    id: 'assistant-api-message-1',
-  },
-} as unknown as AssistantMessage
-
-function makeToolUseContext(
-  tools: readonly Tool[],
-  queryLifecycle: QueryLifecycleOperationTracker,
-): ToolUseContext {
-  return {
-    abortController: new AbortController(),
-    messages: [],
-    queryLifecycle,
-    options: {
-      tools,
-      commands: [],
-      debug: false,
-      verbose: false,
-      mainLoopModel: 'test-model',
-      mcpClients: [],
-      mcpResources: {},
-      isNonInteractiveSession: false,
-    },
-    getAppState: () => ({
-      toolPermissionContext: getEmptyToolPermissionContext(),
-      sessionHooks: new Map(),
-    }),
-    setAppState: () => {},
-    setInProgressToolUseIDs: () => {},
-    setResponseLength: () => {},
-    updateFileHistoryState: () => {},
-    updateAttributionState: () => {},
-  } as unknown as ToolUseContext
-}
-
-async function collectToolUseUpdates(
-  tool: Tool,
-  input: Record<string, unknown>,
-  canUseTool: CanUseToolFn,
-  toolUseContext: ToolUseContext,
-) {
-  const updates: MessageUpdateLazy[] = []
-  for await (const update of runToolUse(
-    {
-      type: 'tool_use',
-      id: 'tool-use-1',
-      name: tool.name,
-      input,
-    } as Parameters<typeof runToolUse>[0],
-    assistantMessage,
-    canUseTool,
-    toolUseContext,
-  )) {
-    updates.push(update)
-  }
-  return updates
-}
 
 describe('getSchemaValidationErrorOverride', () => {
   test('returns actionable missing-skill error for SkillTool', () => {
@@ -258,6 +204,98 @@ describe('replay tool lifecycle records', () => {
     expect(first.input.file_path).toBe('src/final.ts')
     expect(second.repeatedAttemptNumber).toBe(2)
     expect(second.isRepeatedAttempt).toBe(true)
+  })
+
+  test('records one error terminal status when post-call result processing fails', async () => {
+    process.env.TEST_ENABLE_SESSION_PERSISTENCE = 'true'
+    resetAllReplayIndexBuilders()
+    const toolUseId = 'tool-1'
+    const tool = {
+      name: 'TestTool',
+      inputSchema: z.object({ value: z.string() }),
+      maxResultSizeChars: 1000,
+      call: mock(() =>
+        Promise.resolve({
+          data: 'tool succeeded',
+        }),
+      ),
+      mapToolResultToToolResultBlockParam: mock(() => {
+        throw new Error('mapping failed')
+      }),
+      checkPermissions: mock(() =>
+        Promise.resolve({
+          behavior: 'allow',
+          updatedInput: { value: 'final' },
+        }),
+      ),
+      isEnabled: () => true,
+      isReadOnly: () => false,
+      isConcurrencySafe: () => true,
+      description: () => Promise.resolve('test tool'),
+      prompt: () => Promise.resolve('test tool'),
+    } as unknown as Tool
+    const appState = getDefaultAppState()
+    const context = {
+      options: {
+        commands: [],
+        debug: false,
+        mainLoopModel: 'test-model',
+        tools: [tool],
+        verbose: false,
+        thinkingConfig: {},
+        mcpClients: [],
+        mcpResources: {},
+        isNonInteractiveSession: true,
+        agentDefinitions: { agents: [], errors: [] },
+      },
+      abortController: new AbortController(),
+      readFileState: {},
+      getAppState: () => ({
+        ...appState,
+        toolPermissionContext: getEmptyToolPermissionContext(),
+      }),
+      setAppState: () => {},
+      setInProgressToolUseIDs: () => {},
+      setResponseLength: () => {},
+      updateFileHistoryState: () => {},
+      updateAttributionState: () => {},
+      messages: [],
+    } as unknown as ToolUseContext
+
+    const result = await checkPermissionsAndCallTool(
+      tool,
+      toolUseId,
+      { value: 'initial' },
+      context,
+      () =>
+        Promise.resolve({
+          behavior: 'allow',
+          updatedInput: { value: 'final' },
+        }),
+      {
+        uuid: 'assistant-1',
+        type: 'assistant',
+        message: { id: 'msg-1' },
+      } as never,
+      'msg-1',
+      undefined,
+      undefined as never,
+      undefined,
+      () => {},
+    )
+
+    expect(result).toHaveLength(1)
+    const index = getReplayIndexBuilder().build('session-1')
+    expect(index.steps).toHaveLength(1)
+    const step = index.steps[0]
+    expect(step?.type).toBe('tool')
+    if (step?.type !== 'tool') {
+      throw new Error('expected tool replay step')
+    }
+    expect(step.toolUseId).toBe(toolUseId)
+    expect(step.resultStatus).toBe('error')
+    expect(step.resultPreview).toBe('mapping failed')
+    expect(step.input).toEqual({ value: 'final' })
   })
 })
 

--- a/src/services/tools/toolExecution.test.ts
+++ b/src/services/tools/toolExecution.test.ts
@@ -7,6 +7,7 @@ import { BASH_TOOL_NAME } from '../../tools/BashTool/toolName.js'
 import { FILE_EDIT_TOOL_NAME } from '../../tools/FileEditTool/constants.js'
 import { FILE_WRITE_TOOL_NAME } from '../../tools/FileWriteTool/constants.js'
 import { NOTEBOOK_EDIT_TOOL_NAME } from '../../tools/NotebookEditTool/constants.js'
+import { ReplayIndexBuilder } from '../../utils/replayIndexBuilder.js'
 import {
   getReplayModifiedFiles,
   getSchemaValidationErrorOverride,
@@ -133,6 +134,79 @@ describe('getReplayModifiedFiles', () => {
         },
       }),
     ).toEqual(['src/a.ts'])
+  })
+})
+
+describe('replay tool lifecycle records', () => {
+  test('records permission denied completions', () => {
+    const builder = new ReplayIndexBuilder()
+
+    builder.trackToolStart('tool-1', BASH_TOOL_NAME, { command: 'git status' })
+    builder.trackToolEnd('tool-1', BASH_TOOL_NAME, 'permission_denied', 'denied')
+
+    const step = builder.build('session-1').steps[0]
+    expect(step?.type).toBe('tool')
+    if (step?.type !== 'tool') {
+      throw new Error('expected tool replay step')
+    }
+    expect(step.resultStatus).toBe('permission_denied')
+    expect(step.resultPreview).toBe('denied')
+  })
+
+  test('records success completions with modified files', () => {
+    const builder = new ReplayIndexBuilder()
+
+    builder.trackToolStart('tool-1', FILE_EDIT_TOOL_NAME, {
+      file_path: 'src/final.ts',
+      old_string: 'old',
+      new_string: 'new',
+    })
+    builder.trackToolEnd('tool-1', FILE_EDIT_TOOL_NAME, 'success', 'patched', [
+      'src/final.ts',
+    ])
+
+    const step = builder.build('session-1').steps[0]
+    expect(step?.type).toBe('tool')
+    if (step?.type !== 'tool') {
+      throw new Error('expected tool replay step')
+    }
+    expect(step.resultStatus).toBe('success')
+    expect(step.filesModified).toEqual(['src/final.ts'])
+  })
+
+  test('records error completions', () => {
+    const builder = new ReplayIndexBuilder()
+
+    builder.trackToolStart('tool-1', BASH_TOOL_NAME, { command: 'bun test' })
+    builder.trackToolEnd('tool-1', BASH_TOOL_NAME, 'error', 'failed')
+
+    const step = builder.build('session-1').steps[0]
+    expect(step?.type).toBe('tool')
+    if (step?.type !== 'tool') {
+      throw new Error('expected tool replay step')
+    }
+    expect(step.resultStatus).toBe('error')
+    expect(step.resultPreview).toBe('failed')
+  })
+
+  test('captures the final executable input', () => {
+    const builder = new ReplayIndexBuilder()
+    const finalInput = {
+      file_path: 'src/final.ts',
+      old_string: 'before',
+      new_string: 'after',
+    }
+
+    builder.trackToolStart('tool-1', FILE_EDIT_TOOL_NAME, finalInput)
+    builder.trackToolEnd('tool-1', FILE_EDIT_TOOL_NAME, 'success')
+
+    const step = builder.build('session-1').steps[0]
+    expect(step?.type).toBe('tool')
+    if (step?.type !== 'tool') {
+      throw new Error('expected tool replay step')
+    }
+    expect(step.input).toEqual(finalInput)
+    expect(step.inputSummary).toBe('Edit src/final.ts')
   })
 })
 

--- a/src/services/tools/toolExecution.test.ts
+++ b/src/services/tools/toolExecution.test.ts
@@ -23,7 +23,6 @@ import {
   checkPermissionsAndCallTool,
   normalizeReplayToolInput,
   normalizeToolInputForValidation,
-  runToolUse,
 } from './toolExecution.js'
 
 afterEach(() => {

--- a/src/services/tools/toolExecution.test.ts
+++ b/src/services/tools/toolExecution.test.ts
@@ -4,16 +4,11 @@ import { z } from 'zod/v4'
 import { SkillTool } from '../../tools/SkillTool/SkillTool.js'
 import { AskUserQuestionTool } from '../../tools/AskUserQuestionTool/AskUserQuestionTool.js'
 import { BASH_TOOL_NAME } from '../../tools/BashTool/toolName.js'
-import type { CanUseToolFn } from '../../hooks/useCanUseTool.js'
-import { createToolFixture } from '../../test/toolFixtures.js'
+import { FILE_EDIT_TOOL_NAME } from '../../tools/FileEditTool/constants.js'
+import { FILE_WRITE_TOOL_NAME } from '../../tools/FileWriteTool/constants.js'
+import { NOTEBOOK_EDIT_TOOL_NAME } from '../../tools/NotebookEditTool/constants.js'
 import {
-  getEmptyToolPermissionContext,
-  type Tool,
-  type ToolUseContext,
-} from '../../Tool.js'
-import type { AssistantMessage } from '../../types/message.js'
-import { QueryLifecycleOperationTracker } from '../../utils/queryLifecycle.js'
-import {
+  getReplayModifiedFiles,
   getSchemaValidationErrorOverride,
   getSchemaValidationToolUseResult,
   type MessageUpdateLazy,
@@ -113,202 +108,31 @@ describe('getSchemaValidationErrorOverride', () => {
   })
 })
 
-describe('runToolUse lifecycle tracking', () => {
-  test('tracks the tool use while async input validation is pending and clears it on validation failure', async () => {
-    const queryLifecycle = new QueryLifecycleOperationTracker()
-    const snapshots: ReturnType<QueryLifecycleOperationTracker['snapshot']>[] =
-      []
-    const tool = createToolFixture(lifecycleToolInputSchema, {
-      name: 'LifecycleTestTool',
-      async validateInput() {
-        snapshots.push(queryLifecycle.snapshot())
-        return {
-          result: false,
-          message: 'blocked by validation',
-          errorCode: 123,
-        }
-      },
-      async call() {
-        throw new Error('call should not run after validation failure')
-      },
-    })
-    const toolUseContext = makeToolUseContext([tool], queryLifecycle)
-    const canUseTool = (async () => ({
-      behavior: 'allow',
-    })) as CanUseToolFn
-
-    const updates = await collectToolUseUpdates(
-      tool,
-      { command: 'echo hi', timeout: 1234 },
-      canUseTool,
-      toolUseContext,
-    )
-
-    expect(updates).toHaveLength(1)
-    expect(snapshots).toHaveLength(1)
-    expect(snapshots[0]?.apiCalls).toEqual([])
-    expect(snapshots[0]?.toolUses).toHaveLength(1)
-    expect(snapshots[0]?.toolUses[0]).toMatchObject({
-      toolUseId: 'tool-use-1',
-      toolName: 'LifecycleTestTool',
-    })
-    expect(typeof snapshots[0]?.toolUses[0]?.startedAt).toBe('number')
-    expect(queryLifecycle.snapshot()).toEqual({ apiCalls: [], toolUses: [] })
+describe('getReplayModifiedFiles', () => {
+  test('captures file-editing tool paths', () => {
+    expect(
+      getReplayModifiedFiles(FILE_EDIT_TOOL_NAME, { file_path: 'src/a.ts' }),
+    ).toEqual(['src/a.ts'])
+    expect(
+      getReplayModifiedFiles(FILE_WRITE_TOOL_NAME, { file_path: 'src/b.ts' }),
+    ).toEqual(['src/b.ts'])
+    expect(
+      getReplayModifiedFiles(NOTEBOOK_EDIT_TOOL_NAME, {
+        notebook_path: 'notebooks/a.ipynb',
+      }),
+    ).toEqual(['notebooks/a.ipynb'])
   })
 
-  test('tracks Bash timeout metadata while async input validation is pending', async () => {
-    const queryLifecycle = new QueryLifecycleOperationTracker()
-    const snapshots: ReturnType<QueryLifecycleOperationTracker['snapshot']>[] =
-      []
-    const tool = createToolFixture(lifecycleToolInputSchema, {
-      name: BASH_TOOL_NAME,
-      async validateInput() {
-        snapshots.push(queryLifecycle.snapshot())
-        return {
-          result: false,
-          message: 'blocked by validation',
-          errorCode: 123,
-        }
-      },
-      async call() {
-        throw new Error('call should not run after validation failure')
-      },
-    })
-    const toolUseContext = makeToolUseContext([tool], queryLifecycle)
-    const canUseTool = (async () => ({
-      behavior: 'allow',
-    })) as CanUseToolFn
-
-    await collectToolUseUpdates(
-      tool,
-      { command: 'sleep 1', timeout: 4321 },
-      canUseTool,
-      toolUseContext,
-    )
-
-    expect(snapshots).toHaveLength(1)
-    expect(snapshots[0]?.toolUses).toHaveLength(1)
-    expect(snapshots[0]?.toolUses[0]).toMatchObject({
-      toolUseId: 'tool-use-1',
-      toolName: BASH_TOOL_NAME,
-      isBash: true,
-      timeoutMs: 4321,
-    })
-    expect(queryLifecycle.snapshot()).toEqual({ apiCalls: [], toolUses: [] })
-  })
-
-  test('tracks the tool use while permission resolution is pending and clears it on denial', async () => {
-    const queryLifecycle = new QueryLifecycleOperationTracker()
-    const snapshots: ReturnType<QueryLifecycleOperationTracker['snapshot']>[] =
-      []
-    const tool = createToolFixture(lifecycleToolInputSchema, {
-      name: 'LifecyclePermissionTool',
-      async validateInput() {
-        return { result: true }
-      },
-      async call() {
-        throw new Error('call should not run after permission denial')
-      },
-    })
-    const toolUseContext = makeToolUseContext([tool], queryLifecycle)
-    const canUseTool = (async () => {
-      snapshots.push(queryLifecycle.snapshot())
-      return {
-        behavior: 'deny',
-        message: 'denied by test',
-        decisionReason: {
-          type: 'other',
-          reason: 'denied by test',
+  test('captures Bash simulated sed edit paths', () => {
+    expect(
+      getReplayModifiedFiles(BASH_TOOL_NAME, {
+        command: "sed -i 's/a/b/' src/a.ts",
+        _simulatedSedEdit: {
+          filePath: 'src/a.ts',
+          newContent: 'updated',
         },
-      }
-    }) as CanUseToolFn
-
-    const previousSimpleMode = process.env.CLAUDE_CODE_SIMPLE
-    process.env.CLAUDE_CODE_SIMPLE = '1'
-    let updates: Awaited<ReturnType<typeof collectToolUseUpdates>>
-    try {
-      updates = await collectToolUseUpdates(
-        tool,
-        { command: 'echo hi' },
-        canUseTool,
-        toolUseContext,
-      )
-    } finally {
-      if (previousSimpleMode === undefined) {
-        delete process.env.CLAUDE_CODE_SIMPLE
-      } else {
-        process.env.CLAUDE_CODE_SIMPLE = previousSimpleMode
-      }
-    }
-
-    expect(updates).toHaveLength(1)
-    expect(snapshots).toHaveLength(1)
-    expect(snapshots[0]?.apiCalls).toEqual([])
-    expect(snapshots[0]?.toolUses).toHaveLength(1)
-    expect(snapshots[0]?.toolUses[0]).toMatchObject({
-      toolUseId: 'tool-use-1',
-      toolName: 'LifecyclePermissionTool',
-    })
-    expect(typeof snapshots[0]?.toolUses[0]?.startedAt).toBe('number')
-    expect(queryLifecycle.snapshot()).toEqual({ apiCalls: [], toolUses: [] })
-  })
-
-  test('refreshes Bash timeout metadata after permission input rewrites', async () => {
-    const queryLifecycle = new QueryLifecycleOperationTracker()
-    const permissionSnapshots: ReturnType<
-      QueryLifecycleOperationTracker['snapshot']
-    >[] = []
-    const callSnapshots: ReturnType<QueryLifecycleOperationTracker['snapshot']>[] =
-      []
-    const tool = createToolFixture(lifecycleToolInputSchema, {
-      name: BASH_TOOL_NAME,
-      async validateInput() {
-        return { result: true }
-      },
-      async call(input) {
-        callSnapshots.push(queryLifecycle.snapshot())
-        expect(input).toMatchObject({
-          command: 'sleep 2',
-          timeout: 2222,
-        })
-        return { data: 'ok' }
-      },
-    })
-    const toolUseContext = makeToolUseContext([tool], queryLifecycle)
-    const canUseTool = (async () => {
-      permissionSnapshots.push(queryLifecycle.snapshot())
-      return {
-        behavior: 'allow',
-        updatedInput: { command: 'sleep 2', timeout: 2222 },
-        decisionReason: {
-          type: 'other',
-          reason: 'allowed by test',
-        },
-      }
-    }) as CanUseToolFn
-
-    await collectToolUseUpdates(
-      tool,
-      { command: 'sleep 1', timeout: 1111 },
-      canUseTool,
-      toolUseContext,
-    )
-
-    expect(permissionSnapshots).toHaveLength(1)
-    expect(permissionSnapshots[0]?.toolUses[0]).toMatchObject({
-      toolUseId: 'tool-use-1',
-      toolName: BASH_TOOL_NAME,
-      isBash: true,
-      timeoutMs: 1111,
-    })
-    expect(callSnapshots).toHaveLength(1)
-    expect(callSnapshots[0]?.toolUses[0]).toMatchObject({
-      toolUseId: 'tool-use-1',
-      toolName: BASH_TOOL_NAME,
-      isBash: true,
-      timeoutMs: 2222,
-    })
-    expect(queryLifecycle.snapshot()).toEqual({ apiCalls: [], toolUses: [] })
+      }),
+    ).toEqual(['src/a.ts'])
   })
 })
 

--- a/src/services/tools/toolExecution.test.ts
+++ b/src/services/tools/toolExecution.test.ts
@@ -14,7 +14,7 @@ import {
   getReplayModifiedFiles,
   getSchemaValidationErrorOverride,
   getSchemaValidationToolUseResult,
-  type MessageUpdateLazy,
+  normalizeReplayToolInput,
   normalizeToolInputForValidation,
   runToolUse,
 } from './toolExecution.js'
@@ -216,6 +216,48 @@ describe('replay tool lifecycle records', () => {
     }
     expect(step.input).toEqual(finalInput)
     expect(step.inputSummary).toBe('Edit src/final.ts')
+  })
+
+  test('normalizes denied file-tool replay inputs to match allowed retry inputs', () => {
+    const builder = new ReplayIndexBuilder()
+    const modelInput = {
+      file_path: 'src/final.ts',
+      old_string: 'before',
+      new_string: 'after',
+    }
+    const backfilledClone = {
+      ...modelInput,
+      file_path: 'C:\\temp\\openclaude\\src\\final.ts',
+    }
+    const deniedReplayInput = normalizeReplayToolInput(
+      backfilledClone,
+      modelInput,
+      backfilledClone,
+    )
+
+    builder.trackToolStart('tool-1', FILE_EDIT_TOOL_NAME, deniedReplayInput)
+    builder.trackToolEnd(
+      'tool-1',
+      FILE_EDIT_TOOL_NAME,
+      'permission_denied',
+      'denied',
+    )
+    builder.trackToolStart('tool-2', FILE_EDIT_TOOL_NAME, modelInput)
+    builder.trackToolEnd('tool-2', FILE_EDIT_TOOL_NAME, 'success')
+
+    const index = builder.build('session-1')
+    const first = index.steps[0]
+    const second = index.steps[1]
+
+    expect(first?.type).toBe('tool')
+    expect(second?.type).toBe('tool')
+    if (first?.type !== 'tool' || second?.type !== 'tool') {
+      throw new Error('expected tool replay steps')
+    }
+
+    expect(first.input.file_path).toBe('src/final.ts')
+    expect(second.repeatedAttemptNumber).toBe(2)
+    expect(second.isRepeatedAttempt).toBe(true)
   })
 })
 

--- a/src/services/tools/toolExecution.test.ts
+++ b/src/services/tools/toolExecution.test.ts
@@ -7,8 +7,10 @@ import { BASH_TOOL_NAME } from '../../tools/BashTool/toolName.js'
 import { FILE_EDIT_TOOL_NAME } from '../../tools/FileEditTool/constants.js'
 import { FILE_WRITE_TOOL_NAME } from '../../tools/FileWriteTool/constants.js'
 import { NOTEBOOK_EDIT_TOOL_NAME } from '../../tools/NotebookEditTool/constants.js'
+import { AbortError } from '../../utils/errors.js'
 import { ReplayIndexBuilder } from '../../utils/replayIndexBuilder.js'
 import {
+  getReplayResultStatusForError,
   getReplayModifiedFiles,
   getSchemaValidationErrorOverride,
   getSchemaValidationToolUseResult,
@@ -187,6 +189,13 @@ describe('replay tool lifecycle records', () => {
     }
     expect(step.resultStatus).toBe('error')
     expect(step.resultPreview).toBe('failed')
+  })
+
+  test('classifies abort-shaped tool failures as cancelled', () => {
+    expect(getReplayResultStatusForError(new AbortError('interrupted'))).toBe(
+      'cancelled',
+    )
+    expect(getReplayResultStatusForError(new Error('failed'))).toBe('error')
   })
 
   test('captures the final executable input', () => {

--- a/src/services/tools/toolExecution.ts
+++ b/src/services/tools/toolExecution.ts
@@ -1216,27 +1216,99 @@ export async function checkPermissionsAndCallTool(
     // Run PermissionDenied hooks for auto mode classifier denials.
     // If a hook returns {retry: true}, tell the model it may retry.
     if (
-      tool.name !== BASH_TOOL_NAME ||
-      !input ||
-      typeof input !== 'object' ||
-      !('timeout' in input)
+      feature('TRANSCRIPT_CLASSIFIER') &&
+      permissionDecision.decisionReason?.type === 'classifier' &&
+      permissionDecision.decisionReason.classifier === 'auto-mode'
     ) {
-      return undefined
+      let hookSaysRetry = false
+      for await (const result of executePermissionDeniedHooks(
+        tool.name,
+        toolUseID,
+        processedInput,
+        permissionDecision.decisionReason.reason ?? 'Permission denied',
+        toolUseContext,
+        permissionMode,
+        toolUseContext.abortController.signal,
+      )) {
+        if (result.retry) hookSaysRetry = true
+      }
+      if (hookSaysRetry) {
+        resultingMessages.push({
+          message: createUserMessage({
+            content:
+              'The PermissionDenied hook indicated this command is now approved. You may retry it if you would like.',
+            isMeta: true,
+          }),
+        })
+      }
     }
-    return (input as BashToolInput).timeout
+
+    return resultingMessages
+  }
+  logEvent('tengu_tool_use_can_use_tool_allowed', {
+    messageID:
+      messageId as AnalyticsMetadata_I_VERIFIED_THIS_IS_NOT_CODE_OR_FILEPATHS,
+    toolName: sanitizeToolNameForAnalytics(tool.name),
+
+    queryChainId: toolUseContext.queryTracking
+      ?.chainId as AnalyticsMetadata_I_VERIFIED_THIS_IS_NOT_CODE_OR_FILEPATHS,
+    queryDepth: toolUseContext.queryTracking?.depth,
+    ...(mcpServerType && {
+      mcpServerType:
+        mcpServerType as AnalyticsMetadata_I_VERIFIED_THIS_IS_NOT_CODE_OR_FILEPATHS,
+    }),
+    ...(mcpServerBaseUrl && {
+      mcpServerBaseUrl:
+        mcpServerBaseUrl as AnalyticsMetadata_I_VERIFIED_THIS_IS_NOT_CODE_OR_FILEPATHS,
+    }),
+    ...(requestId && {
+      requestId:
+        requestId as AnalyticsMetadata_I_VERIFIED_THIS_IS_NOT_CODE_OR_FILEPATHS,
+    }),
+    ...mcpToolDetailsForAnalytics(tool.name, mcpServerType, mcpServerBaseUrl),
+  })
+
+  // Use the updated input from permissions if provided
+  // (Don't overwrite if undefined - processedInput may have been modified by passthrough hooks)
+  if (permissionDecision.updatedInput !== undefined) {
+    processedInput = permissionDecision.updatedInput
   }
 
-  function trackLifecycleToolUse(input: unknown): void {
-    const lifecycleBashTimeoutMs = getLifecycleBashTimeoutMs(input)
-    toolUseContext.queryLifecycle?.startToolUse({
-      toolUseId: toolUseID,
-      toolName: tool.name,
-      startedAt: lifecycleStartTime,
-      ...(tool.name === BASH_TOOL_NAME && { isBash: true }),
-      ...(lifecycleBashTimeoutMs !== undefined && {
-        timeoutMs: lifecycleBashTimeoutMs,
-      }),
-    })
+  // Prepare tool parameters for logging in tool_result event.
+  // Gated by OTEL_LOG_TOOL_DETAILS — tool parameters can contain sensitive
+  // content (bash commands, MCP server names, etc.) so they're opt-in only.
+  const telemetryToolInput = extractToolInputForTelemetry(processedInput)
+  let toolParameters: Record<string, unknown> = {}
+  if (isToolDetailsLoggingEnabled()) {
+    if (tool.name === BASH_TOOL_NAME && 'command' in processedInput) {
+      const bashInput = processedInput as BashToolInput
+      const commandParts = bashInput.command.trim().split(/\s+/)
+      const bashCommand = commandParts[0] || ''
+
+      toolParameters = {
+        bash_command: bashCommand,
+        full_command: bashInput.command,
+        ...(bashInput.timeout !== undefined && {
+          timeout: bashInput.timeout,
+        }),
+        ...(bashInput.description !== undefined && {
+          description: bashInput.description,
+        }),
+        ...('dangerouslyDisableSandbox' in bashInput && {
+          dangerouslyDisableSandbox: bashInput.dangerouslyDisableSandbox,
+        }),
+      }
+    }
+
+    const mcpDetails = extractMcpToolDetails(tool.name)
+    if (mcpDetails) {
+      toolParameters.mcp_server_name = mcpDetails.serverName
+      toolParameters.mcp_tool_name = mcpDetails.mcpToolName
+    }
+    const skillName = extractSkillName(tool.name, processedInput)
+    if (skillName) {
+      toolParameters.skill_name = skillName
+    }
   }
 
   const decisionInfo = toolUseContext.toolDecisions?.get(toolUseID)
@@ -1495,10 +1567,58 @@ export async function checkPermissionsAndCallTool(
     const postToolHookStart = Date.now()
     for await (const hookResult of runPostToolUseHooks(
       toolUseContext,
-    )
-    if (isValidCall?.result === false) {
+      tool,
+      toolUseID,
+      assistantMessage.message.id,
+      processedInput,
+      toolOutput,
+      requestId,
+      mcpServerType,
+      mcpServerBaseUrl,
+    )) {
+      if ('updatedMCPToolOutput' in hookResult) {
+        if (isMcpTool(tool)) {
+          toolOutput = hookResult.updatedMCPToolOutput
+        }
+      } else if (isMcpTool(tool)) {
+        hookResults.push(hookResult)
+        if (hookResult.message.type === 'attachment') {
+          const att = hookResult.message.attachment
+          if (
+            'command' in att &&
+            att.command !== undefined &&
+            'durationMs' in att &&
+            att.durationMs !== undefined
+          ) {
+            postToolHookInfos.push({
+              command: att.command,
+              durationMs: att.durationMs,
+            })
+          }
+        }
+      } else {
+        resultingMessages.push(hookResult)
+        if (hookResult.message.type === 'attachment') {
+          const att = hookResult.message.attachment
+          if (
+            'command' in att &&
+            att.command !== undefined &&
+            'durationMs' in att &&
+            att.durationMs !== undefined
+          ) {
+            postToolHookInfos.push({
+              command: att.command,
+              durationMs: att.durationMs,
+            })
+          }
+        }
+      }
+    }
+    const postToolHookDurationMs = Date.now() - postToolHookStart
+    if (postToolHookDurationMs >= SLOW_PHASE_LOG_THRESHOLD_MS) {
       logForDebugging(
-        `${tool.name} tool validation error: ${isValidCall.message?.slice(0, 200)}`,
+        `Slow PostToolUse hooks: ${postToolHookDurationMs}ms for ${tool.name} (${postToolHookInfos.length} hooks)`,
+        { level: 'info' },
       )
     }
 
@@ -1628,9 +1748,9 @@ export async function checkPermissionsAndCallTool(
         messageID:
           messageId as AnalyticsMetadata_I_VERIFIED_THIS_IS_NOT_CODE_OR_FILEPATHS,
         toolName: sanitizeToolNameForAnalytics(tool.name),
-        error:
-          isValidCall.message as AnalyticsMetadata_I_VERIFIED_THIS_IS_NOT_CODE_OR_FILEPATHS,
-        errorCode: isValidCall.errorCode,
+        error: classifyToolError(
+          error,
+        ) as AnalyticsMetadata_I_VERIFIED_THIS_IS_NOT_CODE_OR_FILEPATHS,
         isMcp: tool.isMcp ?? false,
 
         queryChainId: toolUseContext.queryTracking
@@ -1648,951 +1768,85 @@ export async function checkPermissionsAndCallTool(
           requestId:
             requestId as AnalyticsMetadata_I_VERIFIED_THIS_IS_NOT_CODE_OR_FILEPATHS,
         }),
-        ...mcpToolDetailsForAnalytics(tool.name, mcpServerType, mcpServerBaseUrl),
-      })
-      return [
-        {
-          message: createUserMessage({
-            content: [
-              {
-                type: 'tool_result',
-                content: `<tool_use_error>${isValidCall.message}</tool_use_error>`,
-                is_error: true,
-                tool_use_id: toolUseID,
-              },
-            ],
-            toolUseResult: `Error: ${isValidCall.message}`,
-            sourceToolAssistantUUID: assistantMessage.uuid,
-          }),
-        },
-      ]
-    }
-    // Speculatively start the bash allow classifier check early so it runs in
-    // parallel with pre-tool hooks, deny/ask classifiers, and permission dialog
-    // setup. The UI indicator (setClassifierChecking) is NOT set here — it's
-    // set in interactiveHandler.ts only when the permission check returns `ask`
-    // with a pendingClassifierCheck. This avoids flashing "classifier running"
-    // for commands that auto-allow via prefix rules.
-    if (
-      tool.name === BASH_TOOL_NAME &&
-      parsedInput.data &&
-      'command' in parsedInput.data
-    ) {
-      const appState = toolUseContext.getAppState()
-      startSpeculativeClassifierCheck(
-        (parsedInput.data as BashToolInput).command,
-        appState.toolPermissionContext,
-        toolUseContext.abortController.signal,
-        toolUseContext.options.isNonInteractiveSession,
-      )
-    }
-
-    const resultingMessages: MessageUpdateLazy[] = []
-
-    // Defense-in-depth: strip _simulatedSedEdit from model-provided Bash input.
-    // This field is internal-only — it must only be injected by the permission
-    // system (SedEditPermissionRequest) after user approval. If the model supplies
-    // it, the schema's strictObject should already reject it, but we strip here
-    // as a safeguard against future regressions.
-    let processedInput = parsedInput.data
-    if (
-      tool.name === BASH_TOOL_NAME &&
-      processedInput &&
-      typeof processedInput === 'object' &&
-      '_simulatedSedEdit' in processedInput
-    ) {
-      const { _simulatedSedEdit: _, ...rest } =
-        processedInput as typeof processedInput & {
-          _simulatedSedEdit: unknown
-        }
-      processedInput = rest as typeof processedInput
-    }
-
-    // Backfill legacy/derived fields on a shallow clone so hooks/canUseTool see
-    // them without affecting tool.call(). SendMessageTool adds fields; file
-    // tools overwrite file_path with expandPath — that mutation must not reach
-    // call() because tool results embed the input path verbatim (e.g. "File
-    // created successfully at: {path}"), and changing it alters the serialized
-    // transcript and VCR fixture hashes. If a hook/permission later returns a
-    // fresh updatedInput, callInput converges on it below — that replacement
-    // is intentional and should reach call().
-    let callInput = processedInput
-    const backfilledClone =
-      tool.backfillObservableInput &&
-      typeof processedInput === 'object' &&
-      processedInput !== null
-        ? ({ ...processedInput } as typeof processedInput)
-        : null
-    if (backfilledClone) {
-      tool.backfillObservableInput!(backfilledClone as Record<string, unknown>)
-      processedInput = backfilledClone
-    }
-
-    let shouldPreventContinuation = false
-    let stopReason: string | undefined
-    let hookPermissionResult: PermissionResult | undefined
-    const preToolHookInfos: StopHookInfo[] = []
-    const preToolHookStart = Date.now()
-    for await (const result of runPreToolUseHooks(
-      toolUseContext,
-      tool,
-      processedInput,
-      toolUseID,
-      assistantMessage.message.id,
-      requestId,
-      mcpServerType,
-      mcpServerBaseUrl,
-    )) {
-      switch (result.type) {
-        case 'message':
-          if (result.message.message.type === 'progress') {
-            onToolProgress(result.message.message)
-          } else {
-            resultingMessages.push(result.message)
-            const att = result.message.message.attachment
-            if (
-              att &&
-              'command' in att &&
-              att.command !== undefined &&
-              'durationMs' in att &&
-              att.durationMs !== undefined
-            ) {
-              preToolHookInfos.push({
-                command: att.command,
-                durationMs: att.durationMs,
-              })
-            }
-          }
-          break
-        case 'hookPermissionResult':
-          hookPermissionResult = result.hookPermissionResult
-          break
-        case 'hookUpdatedInput':
-          // Hook provided updatedInput without making a permission decision (passthrough)
-          // Update processedInput so it's used in the normal permission flow
-          processedInput = result.updatedInput
-          trackLifecycleToolUse(processedInput)
-          break
-        case 'preventContinuation':
-          shouldPreventContinuation = result.shouldPreventContinuation
-          break
-        case 'stopReason':
-          stopReason = result.stopReason
-          break
-        case 'additionalContext':
-          resultingMessages.push(result.message)
-          break
-        case 'stop':
-          getStatsStore()?.observe(
-            'pre_tool_hook_duration_ms',
-            Date.now() - preToolHookStart,
-          )
-          resultingMessages.push({
-            message: createUserMessage({
-              content: [createToolResultStopMessage(toolUseID)],
-              toolUseResult: `Error: ${stopReason}`,
-              sourceToolAssistantUUID: assistantMessage.uuid,
-            }),
-          })
-          return resultingMessages
-      }
-    }
-    const preToolHookDurationMs = Date.now() - preToolHookStart
-    getStatsStore()?.observe('pre_tool_hook_duration_ms', preToolHookDurationMs)
-    if (preToolHookDurationMs >= SLOW_PHASE_LOG_THRESHOLD_MS) {
-      logForDebugging(
-        `Slow PreToolUse hooks: ${preToolHookDurationMs}ms for ${tool.name} (${preToolHookInfos.length} hooks)`,
-        { level: 'info' },
-      )
-    }
-
-    // Emit PreToolUse summary immediately so it's visible while the tool executes.
-    // Use wall-clock time (not sum of individual durations) since hooks run in parallel.
-    if (process.env.USER_TYPE === 'ant' && preToolHookInfos.length > 0) {
-      if (preToolHookDurationMs > HOOK_TIMING_DISPLAY_THRESHOLD_MS) {
-        resultingMessages.push({
-          message: createStopHookSummaryMessage(
-            preToolHookInfos.length,
-            preToolHookInfos,
-            [],
-            false,
-            undefined,
-            false,
-            'suggestion',
-            undefined,
-            'PreToolUse',
-            preToolHookDurationMs,
-          ),
-        })
-      }
-    }
-
-    const toolAttributes: Record<string, string | number | boolean> = {}
-    if (processedInput && typeof processedInput === 'object') {
-      if (tool.name === FILE_READ_TOOL_NAME && 'file_path' in processedInput) {
-        toolAttributes.file_path = String(processedInput.file_path)
-      } else if (
-        (tool.name === FILE_EDIT_TOOL_NAME ||
-          tool.name === FILE_WRITE_TOOL_NAME) &&
-        'file_path' in processedInput
-      ) {
-        toolAttributes.file_path = String(processedInput.file_path)
-      } else if (tool.name === BASH_TOOL_NAME && 'command' in processedInput) {
-        const bashInput = processedInput as BashToolInput
-        toolAttributes.full_command = bashInput.command
-      }
-    }
-
-    // Check whether we have permission to use the tool,
-    // and ask the user for permission if we don't
-    const permissionMode = toolUseContext.getAppState().toolPermissionContext.mode
-    const permissionStart = Date.now()
-
-    const resolved = await resolveHookPermissionDecision(
-      hookPermissionResult,
-      tool,
-      processedInput,
-      toolUseContext,
-      canUseTool,
-      assistantMessage,
-      toolUseID,
-    )
-    const permissionDecision = resolved.decision
-    processedInput = resolved.input
-    trackLifecycleToolUse(processedInput)
-    const permissionDurationMs = Date.now() - permissionStart
-    // In auto mode, canUseTool awaits the classifier (side_query) — if that's
-    // slow the collapsed view shows "Running…" with no (Ns) tick since
-    // bash_progress hasn't started yet. Auto-only: in default mode this timer
-    // includes interactive-dialog wait (user think time), which is just noise.
-    if (
-      permissionDurationMs >= SLOW_PHASE_LOG_THRESHOLD_MS &&
-      permissionMode === 'auto'
-    ) {
-      logForDebugging(
-        `Slow permission decision: ${permissionDurationMs}ms for ${tool.name} ` +
-          `(mode=${permissionMode}, behavior=${permissionDecision.behavior})`,
-        { level: 'info' },
-      )
-    }
-
-    // Emit tool_decision OTel event and code-edit counter if the interactive
-    // permission path didn't already log it (headless mode bypasses permission
-    // logging, so we need to emit both the generic event and the code-edit
-    // counter here)
-    if (
-      permissionDecision.behavior !== 'ask' &&
-      !toolUseContext.toolDecisions?.has(toolUseID)
-    ) {
-      const decision =
-        permissionDecision.behavior === 'allow' ? 'accept' : 'reject'
-      const source = decisionReasonToOTelSource(
-        permissionDecision.decisionReason,
-        permissionDecision.behavior,
-      )
-    }
-
-    // Add message if permission was granted/denied by PermissionRequest hook
-    if (
-      permissionDecision.decisionReason?.type === 'hook' &&
-      permissionDecision.decisionReason.hookName === 'PermissionRequest' &&
-      permissionDecision.behavior !== 'ask'
-    ) {
-      resultingMessages.push({
-        message: createAttachmentMessage({
-          type: 'hook_permission_decision',
-          decision: permissionDecision.behavior,
-          toolUseID,
-          hookEvent: 'PermissionRequest',
-        }),
-      })
-    }
-
-    if (permissionDecision.behavior !== 'allow') {
-      logForDebugging(`${tool.name} tool permission denied`)
-      const decisionInfo = toolUseContext.toolDecisions?.get(toolUseID)
-
-      logEvent('tengu_tool_use_can_use_tool_rejected', {
-        messageID:
-          messageId as AnalyticsMetadata_I_VERIFIED_THIS_IS_NOT_CODE_OR_FILEPATHS,
-        toolName: sanitizeToolNameForAnalytics(tool.name),
-
-        queryChainId: toolUseContext.queryTracking
-          ?.chainId as AnalyticsMetadata_I_VERIFIED_THIS_IS_NOT_CODE_OR_FILEPATHS,
-        queryDepth: toolUseContext.queryTracking?.depth,
-        ...(mcpServerType && {
-          mcpServerType:
-            mcpServerType as AnalyticsMetadata_I_VERIFIED_THIS_IS_NOT_CODE_OR_FILEPATHS,
-        }),
-        ...(mcpServerBaseUrl && {
-          mcpServerBaseUrl:
-            mcpServerBaseUrl as AnalyticsMetadata_I_VERIFIED_THIS_IS_NOT_CODE_OR_FILEPATHS,
-        }),
-        ...(requestId && {
-          requestId:
-            requestId as AnalyticsMetadata_I_VERIFIED_THIS_IS_NOT_CODE_OR_FILEPATHS,
-        }),
-        ...mcpToolDetailsForAnalytics(tool.name, mcpServerType, mcpServerBaseUrl),
-      })
-      let errorMessage = permissionDecision.message
-      // Only use generic "Execution stopped" message if we don't have a detailed hook message
-      if (shouldPreventContinuation && !errorMessage) {
-        errorMessage = `Execution stopped by PreToolUse hook${stopReason ? `: ${stopReason}` : ''}`
-      }
-
-      // Build top-level content: tool_result (text-only for is_error compatibility) + images alongside
-      const messageContent: ContentBlockParam[] = [
-        {
-          type: 'tool_result',
-          content: errorMessage,
-          is_error: true,
-          tool_use_id: toolUseID,
-        },
-      ]
-
-      // Add image blocks at top level (not inside tool_result, which rejects non-text with is_error)
-      const rejectContentBlocks =
-        permissionDecision.behavior === 'ask'
-          ? permissionDecision.contentBlocks
-          : undefined
-      if (rejectContentBlocks?.length) {
-        messageContent.push(...rejectContentBlocks)
-      }
-
-      // Generate sequential imagePasteIds so each image renders with a distinct label
-      let rejectImageIds: number[] | undefined
-      if (rejectContentBlocks?.length) {
-        const imageCount = count(
-          rejectContentBlocks,
-          (b: ContentBlockParam) => b.type === 'image',
-        )
-        if (imageCount > 0) {
-          const startId = getNextImagePasteId(toolUseContext.messages)
-          rejectImageIds = Array.from(
-            { length: imageCount },
-            (_, i) => startId + i,
-          )
-        }
-      }
-
-      resultingMessages.push({
-        message: createUserMessage({
-          content: messageContent,
-          imagePasteIds: rejectImageIds,
-          toolUseResult: `Error: ${errorMessage}`,
-          sourceToolAssistantUUID: assistantMessage.uuid,
-        }),
-      })
-
-      // Run PermissionDenied hooks for auto mode classifier denials.
-      // If a hook returns {retry: true}, tell the model it may retry.
-      if (
-        feature('TRANSCRIPT_CLASSIFIER') &&
-        permissionDecision.decisionReason?.type === 'classifier' &&
-        permissionDecision.decisionReason.classifier === 'auto-mode'
-      ) {
-        let hookSaysRetry = false
-        for await (const result of executePermissionDeniedHooks(
+        ...mcpToolDetailsForAnalytics(
           tool.name,
-          toolUseID,
-          processedInput,
-          permissionDecision.decisionReason.reason ?? 'Permission denied',
-          toolUseContext,
-          permissionMode,
-          toolUseContext.abortController.signal,
-        )) {
-          if (result.retry) hookSaysRetry = true
-        }
-        if (hookSaysRetry) {
-          resultingMessages.push({
-            message: createUserMessage({
-              content:
-                'The PermissionDenied hook indicated this command is now approved. You may retry it if you would like.',
-              isMeta: true,
-            }),
-          })
-        }
-      }
-
-      return resultingMessages
-    }
-    logEvent('tengu_tool_use_can_use_tool_allowed', {
-      messageID:
-        messageId as AnalyticsMetadata_I_VERIFIED_THIS_IS_NOT_CODE_OR_FILEPATHS,
-      toolName: sanitizeToolNameForAnalytics(tool.name),
-
-      queryChainId: toolUseContext.queryTracking
-        ?.chainId as AnalyticsMetadata_I_VERIFIED_THIS_IS_NOT_CODE_OR_FILEPATHS,
-      queryDepth: toolUseContext.queryTracking?.depth,
-      ...(mcpServerType && {
-        mcpServerType:
-          mcpServerType as AnalyticsMetadata_I_VERIFIED_THIS_IS_NOT_CODE_OR_FILEPATHS,
-      }),
-      ...(mcpServerBaseUrl && {
-        mcpServerBaseUrl:
-          mcpServerBaseUrl as AnalyticsMetadata_I_VERIFIED_THIS_IS_NOT_CODE_OR_FILEPATHS,
-      }),
-      ...(requestId && {
-        requestId:
-          requestId as AnalyticsMetadata_I_VERIFIED_THIS_IS_NOT_CODE_OR_FILEPATHS,
-      }),
-      ...mcpToolDetailsForAnalytics(tool.name, mcpServerType, mcpServerBaseUrl),
-    })
-
-    // Use the updated input from permissions if provided
-    // (Don't overwrite if undefined - processedInput may have been modified by passthrough hooks)
-    if (permissionDecision.updatedInput !== undefined) {
-      processedInput = permissionDecision.updatedInput
-      trackLifecycleToolUse(processedInput)
-    }
-
-    // Prepare tool parameters for logging in tool_result event.
-    // Gated by OTEL_LOG_TOOL_DETAILS — tool parameters can contain sensitive
-    // content (bash commands, MCP server names, etc.) so they're opt-in only.
-    const telemetryToolInput = extractToolInputForTelemetry(processedInput)
-    let toolParameters: Record<string, unknown> = {}
-    if (isToolDetailsLoggingEnabled()) {
-      if (tool.name === BASH_TOOL_NAME && 'command' in processedInput) {
-        const bashInput = processedInput as BashToolInput
-        const commandParts = bashInput.command.trim().split(/\s+/)
-        const bashCommand = commandParts[0] || ''
-
-        toolParameters = {
-          bash_command: bashCommand,
-          full_command: bashInput.command,
-          ...(bashInput.timeout !== undefined && {
-            timeout: bashInput.timeout,
-          }),
-          ...(bashInput.description !== undefined && {
-            description: bashInput.description,
-          }),
-          ...('dangerouslyDisableSandbox' in bashInput && {
-            dangerouslyDisableSandbox: bashInput.dangerouslyDisableSandbox,
-          }),
-        }
-      }
-
-      const mcpDetails = extractMcpToolDetails(tool.name)
-      if (mcpDetails) {
-        toolParameters.mcp_server_name = mcpDetails.serverName
-        toolParameters.mcp_tool_name = mcpDetails.mcpToolName
-      }
-      const skillName = extractSkillName(tool.name, processedInput)
-      if (skillName) {
-        toolParameters.skill_name = skillName
-      }
-    }
-
-    const decisionInfo = toolUseContext.toolDecisions?.get(toolUseID)
-
-    const startTime = Date.now()
-
-    startSessionActivity('tool_exec')
-    // If processedInput still points at the backfill clone, no hook/permission
-    // replaced it — pass the pre-backfill callInput so call() sees the model's
-    // original field values. Otherwise converge on the hook-supplied input.
-    // Permission/hook flows may return a fresh object derived from the
-    // backfilled clone (e.g. via inputSchema.parse). If its file_path matches
-    // the backfill-expanded value, restore the model's original so the tool
-    // result string embeds the path the model emitted — keeps transcript/VCR
-    // hashes stable. Other hook modifications flow through unchanged.
-    if (
-      backfilledClone &&
-      processedInput !== callInput &&
-      typeof processedInput === 'object' &&
-      processedInput !== null &&
-      'file_path' in processedInput &&
-      'file_path' in (callInput as Record<string, unknown>) &&
-      (processedInput as Record<string, unknown>).file_path ===
-        (backfilledClone as Record<string, unknown>).file_path
-    ) {
-      callInput = {
-        ...processedInput,
-        file_path: (callInput as Record<string, unknown>).file_path,
-      } as typeof processedInput
-    } else if (processedInput !== backfilledClone) {
-      callInput = processedInput
-    }
-    let queryActivityLease: { release(): void } | undefined
-    try {
-      const queryActivityLeaseInput = createToolQueryLeaseInput(
-        tool.name,
-        toolUseID,
-        callInput,
-      )
-      queryActivityLease = queryActivityLeaseInput
-        ? toolUseContext.queryActivity?.acquireLease(queryActivityLeaseInput)
-        : undefined
-      toolUseContext.queryActivity?.registerActivity(`tool:${tool.name}:start`)
-
-      const result = await tool.call(
-        callInput,
-        {
-          ...toolUseContext,
-          toolUseId: toolUseID,
-          hookChainsCanUseTool: canUseTool,
-          userModified: permissionDecision.userModified ?? false,
-        },
-        canUseTool,
-        assistantMessage,
-        progress => {
-          toolUseContext.queryActivity?.registerActivity(
-            `tool:${tool.name}:progress`,
-          )
-          onToolProgress({
-            toolUseID: progress.toolUseID,
-            data: progress.data,
-          })
-        },
-      )
-      const durationMs = Date.now() - startTime
-      addToToolDuration(durationMs)
-
-      // Capture structured output from tool result if present
-      if (typeof result === 'object' && 'structured_output' in result) {
-        // Store the structured output in an attachment message
-        resultingMessages.push({
-          message: createAttachmentMessage({
-            type: 'structured_output',
-            data: result.structured_output,
-          }),
-        })
-      }
-
-      // Map the tool result to API format once and cache it. This block is reused
-      // by addToolResult (skipping the remap) and measured here for analytics.
-      const mappedToolResultBlock = tool.mapToolResultToToolResultBlockParam(
-        result.data,
-        toolUseID,
-      )
-      const mappedContent = mappedToolResultBlock.content
-      const toolResultSizeBytes = !mappedContent
-        ? 0
-        : typeof mappedContent === 'string'
-          ? mappedContent.length
-          : jsonStringify(mappedContent).length
-
-      // Extract file extension for file-related tools
-      let fileExtension: ReturnType<typeof getFileExtensionForAnalytics>
-      if (processedInput && typeof processedInput === 'object') {
-        if (
-          (tool.name === FILE_READ_TOOL_NAME ||
-            tool.name === FILE_EDIT_TOOL_NAME ||
-            tool.name === FILE_WRITE_TOOL_NAME) &&
-          'file_path' in processedInput
-        ) {
-          fileExtension = getFileExtensionForAnalytics(
-            String(processedInput.file_path),
-          )
-        } else if (
-          tool.name === NOTEBOOK_EDIT_TOOL_NAME &&
-          'notebook_path' in processedInput
-        ) {
-          fileExtension = getFileExtensionForAnalytics(
-            String(processedInput.notebook_path),
-          )
-        } else if (tool.name === BASH_TOOL_NAME && 'command' in processedInput) {
-          const bashInput = processedInput as BashToolInput
-          fileExtension = getFileExtensionsFromBashCommand(
-            bashInput.command,
-            bashInput._simulatedSedEdit?.filePath,
-          )
-        }
-      }
-
-      logEvent('tengu_tool_use_success', {
-        messageID:
-          messageId as AnalyticsMetadata_I_VERIFIED_THIS_IS_NOT_CODE_OR_FILEPATHS,
-        toolName: sanitizeToolNameForAnalytics(tool.name),
-        isMcp: tool.isMcp ?? false,
-        durationMs,
-        preToolHookDurationMs,
-        toolResultSizeBytes,
-        ...(fileExtension !== undefined && { fileExtension }),
-
-        queryChainId: toolUseContext.queryTracking
-          ?.chainId as AnalyticsMetadata_I_VERIFIED_THIS_IS_NOT_CODE_OR_FILEPATHS,
-        queryDepth: toolUseContext.queryTracking?.depth,
-        ...(mcpServerType && {
-          mcpServerType:
-            mcpServerType as AnalyticsMetadata_I_VERIFIED_THIS_IS_NOT_CODE_OR_FILEPATHS,
-        }),
-        ...(mcpServerBaseUrl && {
-          mcpServerBaseUrl:
-            mcpServerBaseUrl as AnalyticsMetadata_I_VERIFIED_THIS_IS_NOT_CODE_OR_FILEPATHS,
-        }),
-        ...(requestId && {
-          requestId:
-            requestId as AnalyticsMetadata_I_VERIFIED_THIS_IS_NOT_CODE_OR_FILEPATHS,
-        }),
-        ...mcpToolDetailsForAnalytics(tool.name, mcpServerType, mcpServerBaseUrl),
+          mcpServerType,
+          mcpServerBaseUrl,
+        ),
       })
-
-      // Enrich tool parameters with git commit ID from successful git commit output
-      if (
-        isToolDetailsLoggingEnabled() &&
-        (tool.name === BASH_TOOL_NAME || tool.name === POWERSHELL_TOOL_NAME) &&
-        'command' in processedInput &&
-        typeof processedInput.command === 'string' &&
-        processedInput.command.match(/\bgit\s+commit\b/) &&
-        result.data &&
-        typeof result.data === 'object' &&
-        'stdout' in result.data
-      ) {
-        const gitCommitId = parseGitCommitId(String(result.data.stdout))
-        if (gitCommitId) {
-          toolParameters.git_commit_id = gitCommitId
-        }
-      }
-
-      // Log tool result event for OTLP with tool parameters and decision context
+      // Log tool result error event for OTLP with tool parameters and decision context
       const mcpServerScope = isMcpTool(tool)
         ? getMcpServerScopeFromToolName(tool.name)
         : null
 
-
-      // Run PostToolUse hooks
-      let toolOutput = result.data
-      const hookResults: MessageUpdateLazy<HookResultMessage>[] = []
-      const toolContextModifier = result.contextModifier
-      const mcpMeta = result.mcpMeta
-
-      async function addToolResult(
-        toolUseResult: unknown,
-        preMappedBlock?: ToolResultBlockParam,
-      ) {
-        // Use the pre-mapped block when available (non-MCP tools where hooks
-        // don't modify the output), otherwise map from scratch.
-        const toolResultBlock = preMappedBlock
-          ? await processPreMappedToolResultBlock(
-              preMappedBlock,
-              tool.name,
-              tool.maxResultSizeChars,
-            )
-          : await processToolResultBlock(tool, toolUseResult, toolUseID)
-
-        // Build content blocks - tool result first, then optional feedback
-        const contentBlocks: ContentBlockParam[] = [toolResultBlock]
-        // Add accept feedback if user provided feedback when approving
-        // (acceptFeedback only exists on PermissionAllowDecision, which is guaranteed here)
-        if (
-          'acceptFeedback' in permissionDecision &&
-          permissionDecision.acceptFeedback
-        ) {
-          contentBlocks.push({
-            type: 'text',
-            text: permissionDecision.acceptFeedback,
-          })
-        }
-
-        // Add content blocks (e.g., pasted images) from the permission decision
-        const allowContentBlocks =
-          'contentBlocks' in permissionDecision
-            ? permissionDecision.contentBlocks
-            : undefined
-        if (allowContentBlocks?.length) {
-          contentBlocks.push(...allowContentBlocks)
-        }
-
-        // Generate sequential imagePasteIds so each image renders with a distinct label
-        let allowImageIds: number[] | undefined
-        if (allowContentBlocks?.length) {
-          const imageCount = count(
-            allowContentBlocks,
-            (b: ContentBlockParam) => b.type === 'image',
-          )
-          if (imageCount > 0) {
-            const startId = getNextImagePasteId(toolUseContext.messages)
-            allowImageIds = Array.from(
-              { length: imageCount },
-              (_, i) => startId + i,
-            )
           }
-        }
+    const content = formatError(error)
 
-        resultingMessages.push({
-          message: createUserMessage({
-            content: contentBlocks,
-            imagePasteIds: allowImageIds,
-            toolUseResult:
-              toolUseContext.agentId && !toolUseContext.preserveToolUseResults
-                ? undefined
-                : toolUseResult,
-            mcpMeta: toolUseContext.agentId ? undefined : mcpMeta,
-            sourceToolAssistantUUID: assistantMessage.uuid,
-          }),
-          contextModifier: toolContextModifier
-            ? {
-                toolUseID: toolUseID,
-                modifyContext: toolContextModifier,
-              }
-            : undefined,
-        })
-      }
+    // Determine if this was a user interrupt
+    const isInterrupt = error instanceof AbortError
 
-      // TOOD(hackyon): refactor so we don't have different experiences for MCP tools
-      if (!isMcpTool(tool)) {
-        await addToolResult(toolOutput, mappedToolResultBlock)
-      }
-
-      const postToolHookInfos: StopHookInfo[] = []
-      const postToolHookStart = Date.now()
-      for await (const hookResult of runPostToolUseHooks(
+    // Run PostToolUseFailure hooks
+    const hookMessages: MessageUpdateLazy<
+      AttachmentMessage | ProgressMessage<HookProgress>
+    >[] = []
+    const hookChainsContext = toolUseContext as ToolUseContext & {
+      hookChainsCanUseTool?: CanUseToolFn
+    }
+    hookChainsContext.hookChainsCanUseTool = canUseTool
+    try {
+      for await (const hookResult of runPostToolUseFailureHooks(
         toolUseContext,
         tool,
         toolUseID,
-        assistantMessage.message.id,
+        messageId,
         processedInput,
-        toolOutput,
+        content,
+        isInterrupt,
         requestId,
         mcpServerType,
         mcpServerBaseUrl,
       )) {
-        if ('updatedMCPToolOutput' in hookResult) {
-          if (isMcpTool(tool)) {
-            toolOutput = hookResult.updatedMCPToolOutput
-          }
-        } else if (isMcpTool(tool)) {
-          hookResults.push(hookResult)
-          if (hookResult.message.type === 'attachment') {
-            const att = hookResult.message.attachment
-            if (
-              'command' in att &&
-              att.command !== undefined &&
-              'durationMs' in att &&
-              att.durationMs !== undefined
-            ) {
-              postToolHookInfos.push({
-                command: att.command,
-                durationMs: att.durationMs,
-              })
-            }
-          }
-        } else {
-          resultingMessages.push(hookResult)
-          if (hookResult.message.type === 'attachment') {
-            const att = hookResult.message.attachment
-            if (
-              'command' in att &&
-              att.command !== undefined &&
-              'durationMs' in att &&
-              att.durationMs !== undefined
-            ) {
-              postToolHookInfos.push({
-                command: att.command,
-                durationMs: att.durationMs,
-              })
-            }
-          }
-        }
+        hookMessages.push(hookResult)
       }
-      const postToolHookDurationMs = Date.now() - postToolHookStart
-      if (postToolHookDurationMs >= SLOW_PHASE_LOG_THRESHOLD_MS) {
-        logForDebugging(
-          `Slow PostToolUse hooks: ${postToolHookDurationMs}ms for ${tool.name} (${postToolHookInfos.length} hooks)`,
-          { level: 'info' },
-        )
-      }
-
-      if (isMcpTool(tool)) {
-        await addToolResult(toolOutput)
-      }
-
-      // Show PostToolUse hook timing inline below tool result when > 500ms.
-      // Use wall-clock time (not sum of individual durations) since hooks run in parallel.
-      if (process.env.USER_TYPE === 'ant' && postToolHookInfos.length > 0) {
-        if (postToolHookDurationMs > HOOK_TIMING_DISPLAY_THRESHOLD_MS) {
-          resultingMessages.push({
-            message: createStopHookSummaryMessage(
-              postToolHookInfos.length,
-              postToolHookInfos,
-              [],
-              false,
-              undefined,
-              false,
-              'suggestion',
-              undefined,
-              'PostToolUse',
-              postToolHookDurationMs,
-            ),
-          })
-        }
-      }
-
-      // If the tool provided new messages, add them to the list to return.
-      if (result.newMessages && result.newMessages.length > 0) {
-        for (const message of result.newMessages) {
-          resultingMessages.push({ message })
-        }
-      }
-      // If hook indicated to prevent continuation after successful execution, yield a stop reason message
-      if (shouldPreventContinuation) {
-        resultingMessages.push({
-          message: createAttachmentMessage({
-            type: 'hook_stopped_continuation',
-            message: stopReason || 'Execution stopped by hook',
-            hookName: `PreToolUse:${tool.name}`,
-            toolUseID: toolUseID,
-            hookEvent: 'PreToolUse',
-          }),
-        })
-      }
-
-      // Yield the remaining hook results after the other messages are sent
-      for (const hookResult of hookResults) {
-        resultingMessages.push(hookResult)
-      }
-      return resultingMessages
-    } catch (error) {
-      const durationMs = Date.now() - startTime
-      addToToolDuration(durationMs)
-
-      // Handle MCP auth errors by updating the client status to 'needs-auth'
-      // This updates the /mcp display to show the server needs re-authorization
-      if (error instanceof McpAuthError) {
-        toolUseContext.setAppState(prevState => {
-          const serverName = error.serverName
-          const existingClientIndex = prevState.mcp.clients.findIndex(
-            c => c.name === serverName,
-          )
-          if (existingClientIndex === -1) {
-            return prevState
-          }
-          const existingClient = prevState.mcp.clients[existingClientIndex]
-          // Only update if client was connected (don't overwrite other states)
-          if (!existingClient || existingClient.type !== 'connected') {
-            return prevState
-          }
-          const updatedClients = [...prevState.mcp.clients]
-          updatedClients[existingClientIndex] = {
-            name: serverName,
-            type: 'needs-auth' as const,
-            config: existingClient.config,
-          }
-          return {
-            ...prevState,
-            mcp: {
-              ...prevState.mcp,
-              clients: updatedClients,
-            },
-          }
-        })
-      }
-
-      if (!(error instanceof AbortError)) {
-        const errorMsg = errorMessage(error)
-        logForDebugging(
-          `${tool.name} tool error (${durationMs}ms): ${errorMsg.slice(0, 200)}`,
-        )
-        if (!(error instanceof ShellError)) {
-          logError(error)
-        }
-        logEvent('tengu_tool_use_error', {
-          messageID:
-            messageId as AnalyticsMetadata_I_VERIFIED_THIS_IS_NOT_CODE_OR_FILEPATHS,
-          toolName: sanitizeToolNameForAnalytics(tool.name),
-          error: classifyToolError(
-            error,
-          ) as AnalyticsMetadata_I_VERIFIED_THIS_IS_NOT_CODE_OR_FILEPATHS,
-          isMcp: tool.isMcp ?? false,
-
-          queryChainId: toolUseContext.queryTracking
-            ?.chainId as AnalyticsMetadata_I_VERIFIED_THIS_IS_NOT_CODE_OR_FILEPATHS,
-          queryDepth: toolUseContext.queryTracking?.depth,
-          ...(mcpServerType && {
-            mcpServerType:
-              mcpServerType as AnalyticsMetadata_I_VERIFIED_THIS_IS_NOT_CODE_OR_FILEPATHS,
-          }),
-          ...(mcpServerBaseUrl && {
-            mcpServerBaseUrl:
-              mcpServerBaseUrl as AnalyticsMetadata_I_VERIFIED_THIS_IS_NOT_CODE_OR_FILEPATHS,
-          }),
-          ...(requestId && {
-            requestId:
-              requestId as AnalyticsMetadata_I_VERIFIED_THIS_IS_NOT_CODE_OR_FILEPATHS,
-          }),
-          ...mcpToolDetailsForAnalytics(
-            tool.name,
-            mcpServerType,
-            mcpServerBaseUrl,
-          ),
-        })
-        // Log tool result error event for OTLP with tool parameters and decision context
-        const mcpServerScope = isMcpTool(tool)
-          ? getMcpServerScopeFromToolName(tool.name)
-          : null
-
-            }
-      const content = formatError(error)
-
-      // Determine if this was a user interrupt
-      const isInterrupt = error instanceof AbortError
-
-      // Run PostToolUseFailure hooks
-      const hookMessages: MessageUpdateLazy<
-        AttachmentMessage | ProgressMessage<HookProgress>
-      >[] = []
-      const hookChainsContext = toolUseContext as ToolUseContext & {
-        hookChainsCanUseTool?: CanUseToolFn
-      }
-      hookChainsContext.hookChainsCanUseTool = canUseTool
-      try {
-        for await (const hookResult of runPostToolUseFailureHooks(
-          toolUseContext,
-          tool,
-          toolUseID,
-          messageId,
-          processedInput,
-          content,
-          isInterrupt,
-          requestId,
-          mcpServerType,
-          mcpServerBaseUrl,
-        )) {
-          hookMessages.push(hookResult)
-        }
-      } finally {
-        if (hookChainsContext.hookChainsCanUseTool === canUseTool) {
-          delete hookChainsContext.hookChainsCanUseTool
-        }
-      }
-
-      return [
-        {
-          message: createUserMessage({
-            content: [
-              {
-                type: 'tool_result',
-                content,
-                is_error: true,
-                tool_use_id: toolUseID,
-              },
-            ],
-            toolUseResult: `Error: ${content}`,
-            mcpMeta: toolUseContext.agentId
-              ? undefined
-              : error instanceof
-                  McpToolCallError_I_VERIFIED_THIS_IS_NOT_CODE_OR_FILEPATHS
-                ? error.mcpMeta
-                : undefined,
-            sourceToolAssistantUUID: assistantMessage.uuid,
-          }),
-        },
-        ...hookMessages,
-      ]
     } finally {
-      try {
-        queryActivityLease?.release()
-        toolUseContext.queryActivity?.registerActivity(`tool:${tool.name}:end`)
-      } finally {
-        stopSessionActivity('tool_exec')
-        // Clean up decision info after logging
-        if (decisionInfo) {
-          toolUseContext.toolDecisions?.delete(toolUseID)
-        }
+      if (hookChainsContext.hookChainsCanUseTool === canUseTool) {
+        delete hookChainsContext.hookChainsCanUseTool
       }
     }
+
+    return [
+      {
+        message: createUserMessage({
+          content: [
+            {
+              type: 'tool_result',
+              content,
+              is_error: true,
+              tool_use_id: toolUseID,
+            },
+          ],
+          toolUseResult: `Error: ${content}`,
+          mcpMeta: toolUseContext.agentId
+            ? undefined
+            : error instanceof
+                McpToolCallError_I_VERIFIED_THIS_IS_NOT_CODE_OR_FILEPATHS
+              ? error.mcpMeta
+              : undefined,
+          sourceToolAssistantUUID: assistantMessage.uuid,
+        }),
+      },
+      ...hookMessages,
+    ]
   } finally {
-    toolUseContext.queryLifecycle?.endToolUse(toolUseID)
+    try {
+      queryActivityLease?.release()
+      toolUseContext.queryActivity?.registerActivity(`tool:${tool.name}:end`)
+    } finally {
+      stopSessionActivity('tool_exec')
+      // Clean up decision info after logging
+      if (decisionInfo) {
+        toolUseContext.toolDecisions?.delete(toolUseID)
+      }
+    }
   }
 }

--- a/src/services/tools/toolExecution.ts
+++ b/src/services/tools/toolExecution.ts
@@ -20,6 +20,7 @@ import {
 } from 'src/services/analytics/metadata.js'
 import {
   addToToolDuration,
+  getReplayIndexBuilder,
   getStatsStore,
 } from '../../bootstrap/state.js'
 import {
@@ -127,6 +128,37 @@ export const HOOK_TIMING_DISPLAY_THRESHOLD_MS = 500
 /** Log a debug warning when hooks/permission-decision block for this long. Matches
  * BashTool's PROGRESS_THRESHOLD_MS — the collapsed view feels stuck past this. */
 const SLOW_PHASE_LOG_THRESHOLD_MS = 2000
+
+export function getReplayModifiedFiles(
+  toolName: string,
+  input: unknown,
+): string[] | undefined {
+  if (!input || typeof input !== 'object') {
+    return undefined
+  }
+
+  const record = input as Record<string, unknown>
+  const path =
+    toolName === NOTEBOOK_EDIT_TOOL_NAME
+      ? record.notebook_path
+      : toolName === BASH_TOOL_NAME
+        ? getReplayBashModifiedFile(record)
+      : toolName === FILE_EDIT_TOOL_NAME || toolName === FILE_WRITE_TOOL_NAME
+        ? record.file_path
+        : undefined
+
+  return typeof path === 'string' && path.length > 0 ? [path] : undefined
+}
+
+function getReplayBashModifiedFile(
+  input: Record<string, unknown>,
+): unknown {
+  const simulatedSedEdit = input._simulatedSedEdit
+  if (!simulatedSedEdit || typeof simulatedSedEdit !== 'object') {
+    return undefined
+  }
+  return (simulatedSedEdit as Record<string, unknown>).filePath
+}
 
 /**
  * Classify a tool execution error into a telemetry-safe string.
@@ -756,8 +788,399 @@ async function checkPermissionsAndCallTool(
     ]
   }
 
-  const lifecycleStartTime = Date.now()
-  function getLifecycleBashTimeoutMs(input: unknown): number | undefined {
+  // Validate input values. Each tool has its own validation logic
+  const isValidCall = await tool.validateInput?.(
+    parsedInput.data,
+    toolUseContext,
+  )
+  if (isValidCall?.result === false) {
+    logForDebugging(
+      `${tool.name} tool validation error: ${isValidCall.message?.slice(0, 200)}`,
+    )
+    logEvent('tengu_tool_use_error', {
+      messageID:
+        messageId as AnalyticsMetadata_I_VERIFIED_THIS_IS_NOT_CODE_OR_FILEPATHS,
+      toolName: sanitizeToolNameForAnalytics(tool.name),
+      error:
+        isValidCall.message as AnalyticsMetadata_I_VERIFIED_THIS_IS_NOT_CODE_OR_FILEPATHS,
+      errorCode: isValidCall.errorCode,
+      isMcp: tool.isMcp ?? false,
+
+      queryChainId: toolUseContext.queryTracking
+        ?.chainId as AnalyticsMetadata_I_VERIFIED_THIS_IS_NOT_CODE_OR_FILEPATHS,
+      queryDepth: toolUseContext.queryTracking?.depth,
+      ...(mcpServerType && {
+        mcpServerType:
+          mcpServerType as AnalyticsMetadata_I_VERIFIED_THIS_IS_NOT_CODE_OR_FILEPATHS,
+      }),
+      ...(mcpServerBaseUrl && {
+        mcpServerBaseUrl:
+          mcpServerBaseUrl as AnalyticsMetadata_I_VERIFIED_THIS_IS_NOT_CODE_OR_FILEPATHS,
+      }),
+      ...(requestId && {
+        requestId:
+          requestId as AnalyticsMetadata_I_VERIFIED_THIS_IS_NOT_CODE_OR_FILEPATHS,
+      }),
+      ...mcpToolDetailsForAnalytics(tool.name, mcpServerType, mcpServerBaseUrl),
+    })
+    return [
+      {
+        message: createUserMessage({
+          content: [
+            {
+              type: 'tool_result',
+              content: `<tool_use_error>${isValidCall.message}</tool_use_error>`,
+              is_error: true,
+              tool_use_id: toolUseID,
+            },
+          ],
+          toolUseResult: `Error: ${isValidCall.message}`,
+          sourceToolAssistantUUID: assistantMessage.uuid,
+        }),
+      },
+    ]
+  }
+  // Speculatively start the bash allow classifier check early so it runs in
+  // parallel with pre-tool hooks, deny/ask classifiers, and permission dialog
+  // setup. The UI indicator (setClassifierChecking) is NOT set here — it's
+  // set in interactiveHandler.ts only when the permission check returns `ask`
+  // with a pendingClassifierCheck. This avoids flashing "classifier running"
+  // for commands that auto-allow via prefix rules.
+  if (
+    tool.name === BASH_TOOL_NAME &&
+    parsedInput.data &&
+    'command' in parsedInput.data
+  ) {
+    const appState = toolUseContext.getAppState()
+    startSpeculativeClassifierCheck(
+      (parsedInput.data as BashToolInput).command,
+      appState.toolPermissionContext,
+      toolUseContext.abortController.signal,
+      toolUseContext.options.isNonInteractiveSession,
+    )
+  }
+
+  const resultingMessages: MessageUpdateLazy[] = []
+
+  // Defense-in-depth: strip _simulatedSedEdit from model-provided Bash input.
+  // This field is internal-only — it must only be injected by the permission
+  // system (SedEditPermissionRequest) after user approval. If the model supplies
+  // it, the schema's strictObject should already reject it, but we strip here
+  // as a safeguard against future regressions.
+  let processedInput = parsedInput.data
+  if (
+    tool.name === BASH_TOOL_NAME &&
+    processedInput &&
+    typeof processedInput === 'object' &&
+    '_simulatedSedEdit' in processedInput
+  ) {
+    const { _simulatedSedEdit: _, ...rest } =
+      processedInput as typeof processedInput & {
+        _simulatedSedEdit: unknown
+      }
+    processedInput = rest as typeof processedInput
+  }
+
+  // Backfill legacy/derived fields on a shallow clone so hooks/canUseTool see
+  // them without affecting tool.call(). SendMessageTool adds fields; file
+  // tools overwrite file_path with expandPath — that mutation must not reach
+  // call() because tool results embed the input path verbatim (e.g. "File
+  // created successfully at: {path}"), and changing it alters the serialized
+  // transcript and VCR fixture hashes. If a hook/permission later returns a
+  // fresh updatedInput, callInput converges on it below — that replacement
+  // is intentional and should reach call().
+  let callInput = processedInput
+  const backfilledClone =
+    tool.backfillObservableInput &&
+    typeof processedInput === 'object' &&
+    processedInput !== null
+      ? ({ ...processedInput } as typeof processedInput)
+      : null
+  if (backfilledClone) {
+    tool.backfillObservableInput!(backfilledClone as Record<string, unknown>)
+    processedInput = backfilledClone
+  }
+
+  let shouldPreventContinuation = false
+  let stopReason: string | undefined
+  let hookPermissionResult: PermissionResult | undefined
+  const preToolHookInfos: StopHookInfo[] = []
+  const preToolHookStart = Date.now()
+  for await (const result of runPreToolUseHooks(
+    toolUseContext,
+    tool,
+    processedInput,
+    toolUseID,
+    assistantMessage.message.id,
+    requestId,
+    mcpServerType,
+    mcpServerBaseUrl,
+  )) {
+    switch (result.type) {
+      case 'message':
+        if (result.message.message.type === 'progress') {
+          onToolProgress(result.message.message)
+        } else {
+          resultingMessages.push(result.message)
+          const att = result.message.message.attachment
+          if (
+            att &&
+            'command' in att &&
+            att.command !== undefined &&
+            'durationMs' in att &&
+            att.durationMs !== undefined
+          ) {
+            preToolHookInfos.push({
+              command: att.command,
+              durationMs: att.durationMs,
+            })
+          }
+        }
+        break
+      case 'hookPermissionResult':
+        hookPermissionResult = result.hookPermissionResult
+        break
+      case 'hookUpdatedInput':
+        // Hook provided updatedInput without making a permission decision (passthrough)
+        // Update processedInput so it's used in the normal permission flow
+        processedInput = result.updatedInput
+        break
+      case 'preventContinuation':
+        shouldPreventContinuation = result.shouldPreventContinuation
+        break
+      case 'stopReason':
+        stopReason = result.stopReason
+        break
+      case 'additionalContext':
+        resultingMessages.push(result.message)
+        break
+      case 'stop':
+        getStatsStore()?.observe(
+          'pre_tool_hook_duration_ms',
+          Date.now() - preToolHookStart,
+        )
+        resultingMessages.push({
+          message: createUserMessage({
+            content: [createToolResultStopMessage(toolUseID)],
+            toolUseResult: `Error: ${stopReason}`,
+            sourceToolAssistantUUID: assistantMessage.uuid,
+          }),
+        })
+        return resultingMessages
+    }
+  }
+  const preToolHookDurationMs = Date.now() - preToolHookStart
+  getStatsStore()?.observe('pre_tool_hook_duration_ms', preToolHookDurationMs)
+  if (preToolHookDurationMs >= SLOW_PHASE_LOG_THRESHOLD_MS) {
+    logForDebugging(
+      `Slow PreToolUse hooks: ${preToolHookDurationMs}ms for ${tool.name} (${preToolHookInfos.length} hooks)`,
+      { level: 'info' },
+    )
+  }
+
+  // Emit PreToolUse summary immediately so it's visible while the tool executes.
+  // Use wall-clock time (not sum of individual durations) since hooks run in parallel.
+  if (process.env.USER_TYPE === 'ant' && preToolHookInfos.length > 0) {
+    if (preToolHookDurationMs > HOOK_TIMING_DISPLAY_THRESHOLD_MS) {
+      resultingMessages.push({
+        message: createStopHookSummaryMessage(
+          preToolHookInfos.length,
+          preToolHookInfos,
+          [],
+          false,
+          undefined,
+          false,
+          'suggestion',
+          undefined,
+          'PreToolUse',
+          preToolHookDurationMs,
+        ),
+      })
+    }
+  }
+
+  const toolAttributes: Record<string, string | number | boolean> = {}
+  if (processedInput && typeof processedInput === 'object') {
+    if (tool.name === FILE_READ_TOOL_NAME && 'file_path' in processedInput) {
+      toolAttributes.file_path = String(processedInput.file_path)
+    } else if (
+      (tool.name === FILE_EDIT_TOOL_NAME ||
+        tool.name === FILE_WRITE_TOOL_NAME) &&
+      'file_path' in processedInput
+    ) {
+      toolAttributes.file_path = String(processedInput.file_path)
+    } else if (tool.name === BASH_TOOL_NAME && 'command' in processedInput) {
+      const bashInput = processedInput as BashToolInput
+      toolAttributes.full_command = bashInput.command
+    }
+  }
+
+  // Check whether we have permission to use the tool,
+  // and ask the user for permission if we don't
+  const permissionMode = toolUseContext.getAppState().toolPermissionContext.mode
+  const permissionStart = Date.now()
+
+  const resolved = await resolveHookPermissionDecision(
+    hookPermissionResult,
+    tool,
+    processedInput,
+    toolUseContext,
+    canUseTool,
+    assistantMessage,
+    toolUseID,
+  )
+  const permissionDecision = resolved.decision
+  processedInput = resolved.input
+  const permissionDurationMs = Date.now() - permissionStart
+  let replayStarted = false
+
+  // Track tool execution for replay index after hooks have finalized input,
+  // but before permission denial can return early.
+  try {
+    const replayBuilder = getReplayIndexBuilder()
+    replayBuilder.trackToolStart(
+      toolUseID,
+      tool.name,
+      processedInput as Record<string, unknown>,
+    )
+    replayStarted = true
+  } catch {
+    // Ignore errors in replay tracking - don't break tool execution
+  }
+
+  // In auto mode, canUseTool awaits the classifier (side_query) — if that's
+  // slow the collapsed view shows "Running…" with no (Ns) tick since
+  // bash_progress hasn't started yet. Auto-only: in default mode this timer
+  // includes interactive-dialog wait (user think time), which is just noise.
+  if (
+    permissionDurationMs >= SLOW_PHASE_LOG_THRESHOLD_MS &&
+    permissionMode === 'auto'
+  ) {
+    logForDebugging(
+      `Slow permission decision: ${permissionDurationMs}ms for ${tool.name} ` +
+        `(mode=${permissionMode}, behavior=${permissionDecision.behavior})`,
+      { level: 'info' },
+    )
+  }
+
+  // Emit tool_decision OTel event and code-edit counter if the interactive
+  // permission path didn't already log it (headless mode bypasses permission
+  // logging, so we need to emit both the generic event and the code-edit
+  // counter here)
+  if (
+    permissionDecision.behavior !== 'ask' &&
+    !toolUseContext.toolDecisions?.has(toolUseID)
+  ) {
+    const decision =
+      permissionDecision.behavior === 'allow' ? 'accept' : 'reject'
+    const source = decisionReasonToOTelSource(
+      permissionDecision.decisionReason,
+      permissionDecision.behavior,
+    )
+  }
+
+  // Add message if permission was granted/denied by PermissionRequest hook
+  if (
+    permissionDecision.decisionReason?.type === 'hook' &&
+    permissionDecision.decisionReason.hookName === 'PermissionRequest' &&
+    permissionDecision.behavior !== 'ask'
+  ) {
+    resultingMessages.push({
+      message: createAttachmentMessage({
+        type: 'hook_permission_decision',
+        decision: permissionDecision.behavior,
+        toolUseID,
+        hookEvent: 'PermissionRequest',
+      }),
+    })
+  }
+
+  if (permissionDecision.behavior !== 'allow') {
+    logForDebugging(`${tool.name} tool permission denied`)
+    const decisionInfo = toolUseContext.toolDecisions?.get(toolUseID)
+
+    // Track permission denied for replay index
+    try {
+      const replayBuilder = getReplayIndexBuilder()
+      replayBuilder.trackToolEnd(toolUseID, tool.name, 'permission_denied', permissionDecision.message)
+    } catch {
+      // Ignore errors in replay tracking
+    }
+
+    logEvent('tengu_tool_use_can_use_tool_rejected', {
+      messageID:
+        messageId as AnalyticsMetadata_I_VERIFIED_THIS_IS_NOT_CODE_OR_FILEPATHS,
+      toolName: sanitizeToolNameForAnalytics(tool.name),
+
+      queryChainId: toolUseContext.queryTracking
+        ?.chainId as AnalyticsMetadata_I_VERIFIED_THIS_IS_NOT_CODE_OR_FILEPATHS,
+      queryDepth: toolUseContext.queryTracking?.depth,
+      ...(mcpServerType && {
+        mcpServerType:
+          mcpServerType as AnalyticsMetadata_I_VERIFIED_THIS_IS_NOT_CODE_OR_FILEPATHS,
+      }),
+      ...(mcpServerBaseUrl && {
+        mcpServerBaseUrl:
+          mcpServerBaseUrl as AnalyticsMetadata_I_VERIFIED_THIS_IS_NOT_CODE_OR_FILEPATHS,
+      }),
+      ...(requestId && {
+        requestId:
+          requestId as AnalyticsMetadata_I_VERIFIED_THIS_IS_NOT_CODE_OR_FILEPATHS,
+      }),
+      ...mcpToolDetailsForAnalytics(tool.name, mcpServerType, mcpServerBaseUrl),
+    })
+    let errorMessage = permissionDecision.message
+    // Only use generic "Execution stopped" message if we don't have a detailed hook message
+    if (shouldPreventContinuation && !errorMessage) {
+      errorMessage = `Execution stopped by PreToolUse hook${stopReason ? `: ${stopReason}` : ''}`
+    }
+
+    // Build top-level content: tool_result (text-only for is_error compatibility) + images alongside
+    const messageContent: ContentBlockParam[] = [
+      {
+        type: 'tool_result',
+        content: errorMessage,
+        is_error: true,
+        tool_use_id: toolUseID,
+      },
+    ]
+
+    // Add image blocks at top level (not inside tool_result, which rejects non-text with is_error)
+    const rejectContentBlocks =
+      permissionDecision.behavior === 'ask'
+        ? permissionDecision.contentBlocks
+        : undefined
+    if (rejectContentBlocks?.length) {
+      messageContent.push(...rejectContentBlocks)
+    }
+
+    // Generate sequential imagePasteIds so each image renders with a distinct label
+    let rejectImageIds: number[] | undefined
+    if (rejectContentBlocks?.length) {
+      const imageCount = count(
+        rejectContentBlocks,
+        (b: ContentBlockParam) => b.type === 'image',
+      )
+      if (imageCount > 0) {
+        const startId = getNextImagePasteId(toolUseContext.messages)
+        rejectImageIds = Array.from(
+          { length: imageCount },
+          (_, i) => startId + i,
+        )
+      }
+    }
+
+    resultingMessages.push({
+      message: createUserMessage({
+        content: messageContent,
+        imagePasteIds: rejectImageIds,
+        toolUseResult: `Error: ${errorMessage}`,
+        sourceToolAssistantUUID: assistantMessage.uuid,
+      }),
+    })
+
+    // Run PermissionDenied hooks for auto mode classifier denials.
+    // If a hook returns {retry: true}, tell the model it may retry.
     if (
       tool.name !== BASH_TOOL_NAME ||
       !input ||
@@ -784,15 +1207,361 @@ async function checkPermissionsAndCallTool(
 
   trackLifecycleToolUse(parsedInput.data)
   try {
-    // Validate input values. Each tool has its own validation logic
-    const isValidCall = await tool.validateInput?.(
-      parsedInput.data,
+    const queryActivityLeaseInput = createToolQueryLeaseInput(
+      tool.name,
+      toolUseID,
+      callInput,
+    )
+    queryActivityLease = queryActivityLeaseInput
+      ? toolUseContext.queryActivity?.acquireLease(queryActivityLeaseInput)
+      : undefined
+    toolUseContext.queryActivity?.registerActivity(`tool:${tool.name}:start`)
+
+    const result = await tool.call(
+      callInput,
+      {
+        ...toolUseContext,
+        toolUseId: toolUseID,
+        hookChainsCanUseTool: canUseTool,
+        userModified: permissionDecision.userModified ?? false,
+      },
+      canUseTool,
+      assistantMessage,
+      progress => {
+        toolUseContext.queryActivity?.registerActivity(
+          `tool:${tool.name}:progress`,
+        )
+        onToolProgress({
+          toolUseID: progress.toolUseID,
+          data: progress.data,
+        })
+      },
+    )
+    const durationMs = Date.now() - startTime
+    addToToolDuration(durationMs)
+
+    // Track successful tool execution for replay index
+    try {
+      const replayBuilder = getReplayIndexBuilder()
+      const resultPreview = typeof result.data === 'string' ? result.data.slice(0, 200) : undefined
+      if (!replayStarted) {
+        replayBuilder.trackToolStart(
+          toolUseID,
+          tool.name,
+          callInput as Record<string, unknown>,
+        )
+      }
+      replayBuilder.trackToolEnd(
+        toolUseID,
+        tool.name,
+        'success',
+        resultPreview,
+        getReplayModifiedFiles(tool.name, callInput),
+      )
+    } catch {
+      // Ignore errors in replay tracking
+    }
+
+    // Capture structured output from tool result if present
+    if (typeof result === 'object' && 'structured_output' in result) {
+      // Store the structured output in an attachment message
+      resultingMessages.push({
+        message: createAttachmentMessage({
+          type: 'structured_output',
+          data: result.structured_output,
+        }),
+      })
+    }
+
+    // Map the tool result to API format once and cache it. This block is reused
+    // by addToolResult (skipping the remap) and measured here for analytics.
+    const mappedToolResultBlock = tool.mapToolResultToToolResultBlockParam(
+      result.data,
+      toolUseID,
+    )
+    const mappedContent = mappedToolResultBlock.content
+    const toolResultSizeBytes = !mappedContent
+      ? 0
+      : typeof mappedContent === 'string'
+        ? mappedContent.length
+        : jsonStringify(mappedContent).length
+
+    // Extract file extension for file-related tools
+    let fileExtension: ReturnType<typeof getFileExtensionForAnalytics>
+    if (processedInput && typeof processedInput === 'object') {
+      if (
+        (tool.name === FILE_READ_TOOL_NAME ||
+          tool.name === FILE_EDIT_TOOL_NAME ||
+          tool.name === FILE_WRITE_TOOL_NAME) &&
+        'file_path' in processedInput
+      ) {
+        fileExtension = getFileExtensionForAnalytics(
+          String(processedInput.file_path),
+        )
+      } else if (
+        tool.name === NOTEBOOK_EDIT_TOOL_NAME &&
+        'notebook_path' in processedInput
+      ) {
+        fileExtension = getFileExtensionForAnalytics(
+          String(processedInput.notebook_path),
+        )
+      } else if (tool.name === BASH_TOOL_NAME && 'command' in processedInput) {
+        const bashInput = processedInput as BashToolInput
+        fileExtension = getFileExtensionsFromBashCommand(
+          bashInput.command,
+          bashInput._simulatedSedEdit?.filePath,
+        )
+      }
+    }
+
+    logEvent('tengu_tool_use_success', {
+      messageID:
+        messageId as AnalyticsMetadata_I_VERIFIED_THIS_IS_NOT_CODE_OR_FILEPATHS,
+      toolName: sanitizeToolNameForAnalytics(tool.name),
+      isMcp: tool.isMcp ?? false,
+      durationMs,
+      preToolHookDurationMs,
+      toolResultSizeBytes,
+      ...(fileExtension !== undefined && { fileExtension }),
+
+      queryChainId: toolUseContext.queryTracking
+        ?.chainId as AnalyticsMetadata_I_VERIFIED_THIS_IS_NOT_CODE_OR_FILEPATHS,
+      queryDepth: toolUseContext.queryTracking?.depth,
+      ...(mcpServerType && {
+        mcpServerType:
+          mcpServerType as AnalyticsMetadata_I_VERIFIED_THIS_IS_NOT_CODE_OR_FILEPATHS,
+      }),
+      ...(mcpServerBaseUrl && {
+        mcpServerBaseUrl:
+          mcpServerBaseUrl as AnalyticsMetadata_I_VERIFIED_THIS_IS_NOT_CODE_OR_FILEPATHS,
+      }),
+      ...(requestId && {
+        requestId:
+          requestId as AnalyticsMetadata_I_VERIFIED_THIS_IS_NOT_CODE_OR_FILEPATHS,
+      }),
+      ...mcpToolDetailsForAnalytics(tool.name, mcpServerType, mcpServerBaseUrl),
+    })
+
+    // Enrich tool parameters with git commit ID from successful git commit output
+    if (
+      isToolDetailsLoggingEnabled() &&
+      (tool.name === BASH_TOOL_NAME || tool.name === POWERSHELL_TOOL_NAME) &&
+      'command' in processedInput &&
+      typeof processedInput.command === 'string' &&
+      processedInput.command.match(/\bgit\s+commit\b/) &&
+      result.data &&
+      typeof result.data === 'object' &&
+      'stdout' in result.data
+    ) {
+      const gitCommitId = parseGitCommitId(String(result.data.stdout))
+      if (gitCommitId) {
+        toolParameters.git_commit_id = gitCommitId
+      }
+    }
+
+    // Log tool result event for OTLP with tool parameters and decision context
+    const mcpServerScope = isMcpTool(tool)
+      ? getMcpServerScopeFromToolName(tool.name)
+      : null
+
+
+    // Run PostToolUse hooks
+    let toolOutput = result.data
+    const hookResults: MessageUpdateLazy<HookResultMessage>[] = []
+    const toolContextModifier = result.contextModifier
+    const mcpMeta = result.mcpMeta
+
+    async function addToolResult(
+      toolUseResult: unknown,
+      preMappedBlock?: ToolResultBlockParam,
+    ) {
+      // Use the pre-mapped block when available (non-MCP tools where hooks
+      // don't modify the output), otherwise map from scratch.
+      const toolResultBlock = preMappedBlock
+        ? await processPreMappedToolResultBlock(
+            preMappedBlock,
+            tool.name,
+            tool.maxResultSizeChars,
+          )
+        : await processToolResultBlock(tool, toolUseResult, toolUseID)
+
+      // Build content blocks - tool result first, then optional feedback
+      const contentBlocks: ContentBlockParam[] = [toolResultBlock]
+      // Add accept feedback if user provided feedback when approving
+      // (acceptFeedback only exists on PermissionAllowDecision, which is guaranteed here)
+      if (
+        'acceptFeedback' in permissionDecision &&
+        permissionDecision.acceptFeedback
+      ) {
+        contentBlocks.push({
+          type: 'text',
+          text: permissionDecision.acceptFeedback,
+        })
+      }
+
+      // Add content blocks (e.g., pasted images) from the permission decision
+      const allowContentBlocks =
+        'contentBlocks' in permissionDecision
+          ? permissionDecision.contentBlocks
+          : undefined
+      if (allowContentBlocks?.length) {
+        contentBlocks.push(...allowContentBlocks)
+      }
+
+      // Generate sequential imagePasteIds so each image renders with a distinct label
+      let allowImageIds: number[] | undefined
+      if (allowContentBlocks?.length) {
+        const imageCount = count(
+          allowContentBlocks,
+          (b: ContentBlockParam) => b.type === 'image',
+        )
+        if (imageCount > 0) {
+          const startId = getNextImagePasteId(toolUseContext.messages)
+          allowImageIds = Array.from(
+            { length: imageCount },
+            (_, i) => startId + i,
+          )
+        }
+      }
+
+      resultingMessages.push({
+        message: createUserMessage({
+          content: contentBlocks,
+          imagePasteIds: allowImageIds,
+          toolUseResult:
+            toolUseContext.agentId && !toolUseContext.preserveToolUseResults
+              ? undefined
+              : toolUseResult,
+          mcpMeta: toolUseContext.agentId ? undefined : mcpMeta,
+          sourceToolAssistantUUID: assistantMessage.uuid,
+        }),
+        contextModifier: toolContextModifier
+          ? {
+              toolUseID: toolUseID,
+              modifyContext: toolContextModifier,
+            }
+          : undefined,
+      })
+    }
+
+    // TOOD(hackyon): refactor so we don't have different experiences for MCP tools
+    if (!isMcpTool(tool)) {
+      await addToolResult(toolOutput, mappedToolResultBlock)
+    }
+
+    const postToolHookInfos: StopHookInfo[] = []
+    const postToolHookStart = Date.now()
+    for await (const hookResult of runPostToolUseHooks(
       toolUseContext,
     )
     if (isValidCall?.result === false) {
       logForDebugging(
         `${tool.name} tool validation error: ${isValidCall.message?.slice(0, 200)}`,
       )
+    }
+
+    if (isMcpTool(tool)) {
+      await addToolResult(toolOutput)
+    }
+
+    // Show PostToolUse hook timing inline below tool result when > 500ms.
+    // Use wall-clock time (not sum of individual durations) since hooks run in parallel.
+    if (process.env.USER_TYPE === 'ant' && postToolHookInfos.length > 0) {
+      if (postToolHookDurationMs > HOOK_TIMING_DISPLAY_THRESHOLD_MS) {
+        resultingMessages.push({
+          message: createStopHookSummaryMessage(
+            postToolHookInfos.length,
+            postToolHookInfos,
+            [],
+            false,
+            undefined,
+            false,
+            'suggestion',
+            undefined,
+            'PostToolUse',
+            postToolHookDurationMs,
+          ),
+        })
+      }
+    }
+
+    // If the tool provided new messages, add them to the list to return.
+    if (result.newMessages && result.newMessages.length > 0) {
+      for (const message of result.newMessages) {
+        resultingMessages.push({ message })
+      }
+    }
+    // If hook indicated to prevent continuation after successful execution, yield a stop reason message
+    if (shouldPreventContinuation) {
+      resultingMessages.push({
+        message: createAttachmentMessage({
+          type: 'hook_stopped_continuation',
+          message: stopReason || 'Execution stopped by hook',
+          hookName: `PreToolUse:${tool.name}`,
+          toolUseID: toolUseID,
+          hookEvent: 'PreToolUse',
+        }),
+      })
+    }
+
+    // Yield the remaining hook results after the other messages are sent
+    for (const hookResult of hookResults) {
+      resultingMessages.push(hookResult)
+    }
+    return resultingMessages
+  } catch (error) {
+    const durationMs = Date.now() - startTime
+    addToToolDuration(durationMs)
+
+    // Track failed tool execution for replay index
+    try {
+      const replayBuilder = getReplayIndexBuilder()
+      const errorMsg = error instanceof Error ? error.message : String(error)
+      replayBuilder.trackToolEnd(toolUseID, tool.name, 'error', errorMsg.slice(0, 200))
+    } catch {
+      // Ignore errors in replay tracking
+    }
+
+    // Handle MCP auth errors by updating the client status to 'needs-auth'
+    // This updates the /mcp display to show the server needs re-authorization
+    if (error instanceof McpAuthError) {
+      toolUseContext.setAppState(prevState => {
+        const serverName = error.serverName
+        const existingClientIndex = prevState.mcp.clients.findIndex(
+          c => c.name === serverName,
+        )
+        if (existingClientIndex === -1) {
+          return prevState
+        }
+        const existingClient = prevState.mcp.clients[existingClientIndex]
+        // Only update if client was connected (don't overwrite other states)
+        if (!existingClient || existingClient.type !== 'connected') {
+          return prevState
+        }
+        const updatedClients = [...prevState.mcp.clients]
+        updatedClients[existingClientIndex] = {
+          name: serverName,
+          type: 'needs-auth' as const,
+          config: existingClient.config,
+        }
+        return {
+          ...prevState,
+          mcp: {
+            ...prevState.mcp,
+            clients: updatedClients,
+          },
+        }
+      })
+    }
+
+    if (!(error instanceof AbortError)) {
+      const errorMsg = errorMessage(error)
+      logForDebugging(
+        `${tool.name} tool error (${durationMs}ms): ${errorMsg.slice(0, 200)}`,
+      )
+      if (!(error instanceof ShellError)) {
+        logError(error)
+      }
       logEvent('tengu_tool_use_error', {
         messageID:
           messageId as AnalyticsMetadata_I_VERIFIED_THIS_IS_NOT_CODE_OR_FILEPATHS,

--- a/src/services/tools/toolExecution.ts
+++ b/src/services/tools/toolExecution.ts
@@ -67,6 +67,7 @@ import {
   AbortError,
   errorMessage,
   getErrnoCode,
+  isAbortError,
   ShellError,
   TelemetrySafeError_I_VERIFIED_THIS_IS_NOT_CODE_OR_FILEPATHS,
 } from '../../utils/errors.js'
@@ -148,6 +149,12 @@ export function getReplayModifiedFiles(
         : undefined
 
   return typeof path === 'string' && path.length > 0 ? [path] : undefined
+}
+
+export function getReplayResultStatusForError(
+  error: unknown,
+): 'error' | 'cancelled' {
+  return isAbortError(error) ? 'cancelled' : 'error'
 }
 
 function getReplayBashModifiedFile(
@@ -1547,7 +1554,12 @@ async function checkPermissionsAndCallTool(
     try {
       const replayBuilder = getReplayIndexBuilder()
       const errorMsg = error instanceof Error ? error.message : String(error)
-      replayBuilder.trackToolEnd(toolUseID, tool.name, 'error', errorMsg.slice(0, 200))
+      replayBuilder.trackToolEnd(
+        toolUseID,
+        tool.name,
+        getReplayResultStatusForError(error),
+        errorMsg.slice(0, 200),
+      )
     } catch {
       // Ignore errors in replay tracking
     }

--- a/src/services/tools/toolExecution.ts
+++ b/src/services/tools/toolExecution.ts
@@ -732,7 +732,7 @@ export function normalizeToolInputForValidation(
   }
 }
 
-async function checkPermissionsAndCallTool(
+export async function checkPermissionsAndCallTool(
   tool: Tool,
   toolUseID: string,
   input: unknown,

--- a/src/services/tools/toolExecution.ts
+++ b/src/services/tools/toolExecution.ts
@@ -157,6 +157,32 @@ export function getReplayResultStatusForError(
   return isAbortError(error) ? 'cancelled' : 'error'
 }
 
+export function normalizeReplayToolInput<T>(
+  processedInput: T,
+  originalInput: T,
+  backfilledClone: T | null,
+): T {
+  if (
+    backfilledClone &&
+    processedInput !== originalInput &&
+    typeof processedInput === 'object' &&
+    processedInput !== null &&
+    'file_path' in processedInput &&
+    typeof originalInput === 'object' &&
+    originalInput !== null &&
+    'file_path' in originalInput &&
+    (processedInput as Record<string, unknown>).file_path ===
+      (backfilledClone as Record<string, unknown>).file_path
+  ) {
+    return {
+      ...processedInput,
+      file_path: (originalInput as Record<string, unknown>).file_path,
+    } as T
+  }
+
+  return processedInput !== backfilledClone ? processedInput : originalInput
+}
+
 function getReplayBashModifiedFile(
   input: Record<string, unknown>,
 ): unknown {
@@ -1097,7 +1123,11 @@ async function checkPermissionsAndCallTool(
       replayBuilder.trackToolStart(
         toolUseID,
         tool.name,
-        processedInput as Record<string, unknown>,
+        normalizeReplayToolInput(
+          processedInput,
+          callInput,
+          backfilledClone,
+        ) as Record<string, unknown>,
       )
       replayBuilder.trackToolEnd(
         toolUseID,
@@ -1220,23 +1250,7 @@ async function checkPermissionsAndCallTool(
   // the backfill-expanded value, restore the model's original so the tool
   // result string embeds the path the model emitted — keeps transcript/VCR
   // hashes stable. Other hook modifications flow through unchanged.
-  if (
-    backfilledClone &&
-    processedInput !== callInput &&
-    typeof processedInput === 'object' &&
-    processedInput !== null &&
-    'file_path' in processedInput &&
-    'file_path' in (callInput as Record<string, unknown>) &&
-    (processedInput as Record<string, unknown>).file_path ===
-      (backfilledClone as Record<string, unknown>).file_path
-  ) {
-    callInput = {
-      ...processedInput,
-      file_path: (callInput as Record<string, unknown>).file_path,
-    } as typeof processedInput
-  } else if (processedInput !== backfilledClone) {
-    callInput = processedInput
-  }
+  callInput = normalizeReplayToolInput(processedInput, callInput, backfilledClone)
 
   let queryActivityLease: { release(): void } | undefined
 

--- a/src/services/tools/toolExecution.ts
+++ b/src/services/tools/toolExecution.ts
@@ -822,6 +822,34 @@ export async function checkPermissionsAndCallTool(
     ]
   }
 
+  const lifecycleStartTime = Date.now()
+  function getLifecycleBashTimeoutMs(input: unknown): number | undefined {
+    if (
+      tool.name !== BASH_TOOL_NAME ||
+      !input ||
+      typeof input !== 'object' ||
+      !('timeout' in input)
+    ) {
+      return undefined
+    }
+    return (input as BashToolInput).timeout
+  }
+
+  function trackLifecycleToolUse(input: unknown): void {
+    const lifecycleBashTimeoutMs = getLifecycleBashTimeoutMs(input)
+    toolUseContext.queryLifecycle?.startToolUse({
+      toolUseId: toolUseID,
+      toolName: tool.name,
+      startedAt: lifecycleStartTime,
+      ...(tool.name === BASH_TOOL_NAME && { isBash: true }),
+      ...(lifecycleBashTimeoutMs !== undefined && {
+        timeoutMs: lifecycleBashTimeoutMs,
+      }),
+    })
+  }
+
+  trackLifecycleToolUse(parsedInput.data)
+
   // Validate input values. Each tool has its own validation logic
   const isValidCall = await tool.validateInput?.(
     parsedInput.data,
@@ -978,6 +1006,7 @@ export async function checkPermissionsAndCallTool(
         // Hook provided updatedInput without making a permission decision (passthrough)
         // Update processedInput so it's used in the normal permission flow
         processedInput = result.updatedInput
+        trackLifecycleToolUse(processedInput)
         break
       case 'preventContinuation':
         shouldPreventContinuation = result.shouldPreventContinuation
@@ -1065,6 +1094,7 @@ export async function checkPermissionsAndCallTool(
   )
   const permissionDecision = resolved.decision
   processedInput = resolved.input
+  trackLifecycleToolUse(processedInput)
   const permissionDurationMs = Date.now() - permissionStart
 
   // In auto mode, canUseTool awaits the classifier (side_query) — if that's
@@ -1272,6 +1302,7 @@ export async function checkPermissionsAndCallTool(
   // (Don't overwrite if undefined - processedInput may have been modified by passthrough hooks)
   if (permissionDecision.updatedInput !== undefined) {
     processedInput = permissionDecision.updatedInput
+    trackLifecycleToolUse(processedInput)
   }
 
   // Prepare tool parameters for logging in tool_result event.

--- a/src/services/tools/toolExecution.ts
+++ b/src/services/tools/toolExecution.ts
@@ -89,6 +89,7 @@ import {
   startSessionActivity,
   stopSessionActivity,
 } from '../../utils/sessionActivity.js'
+import { shouldSkipSessionPersistence } from '../../utils/sessionPersistencePolicy.js'
 import { jsonStringify } from '../../utils/slowOperations.js'
 import { Stream } from '../../utils/stream.js'
 import {
@@ -1117,26 +1118,27 @@ async function checkPermissionsAndCallTool(
     logForDebugging(`${tool.name} tool permission denied`)
     const decisionInfo = toolUseContext.toolDecisions?.get(toolUseID)
 
-    // Track permission denied for replay index
-    try {
-      const replayBuilder = getReplayIndexBuilder()
-      replayBuilder.trackToolStart(
-        toolUseID,
-        tool.name,
-        normalizeReplayToolInput(
-          processedInput,
-          callInput,
-          backfilledClone,
-        ) as Record<string, unknown>,
-      )
-      replayBuilder.trackToolEnd(
-        toolUseID,
-        tool.name,
-        'permission_denied',
-        permissionDecision.message,
-      )
-    } catch {
-      // Ignore errors in replay tracking
+    if (!shouldSkipSessionPersistence()) {
+      try {
+        const replayBuilder = getReplayIndexBuilder()
+        replayBuilder.trackToolStart(
+          toolUseID,
+          tool.name,
+          normalizeReplayToolInput(
+            processedInput,
+            callInput,
+            backfilledClone,
+          ) as Record<string, unknown>,
+        )
+        replayBuilder.trackToolEnd(
+          toolUseID,
+          tool.name,
+          'permission_denied',
+          permissionDecision.message,
+        )
+      } catch {
+        // Ignore errors in replay tracking
+      }
     }
 
     logEvent('tengu_tool_use_can_use_tool_rejected', {
@@ -1254,14 +1256,16 @@ async function checkPermissionsAndCallTool(
 
   let queryActivityLease: { release(): void } | undefined
 
-  try {
-    getReplayIndexBuilder().trackToolStart(
-      toolUseID,
-      tool.name,
-      callInput as Record<string, unknown>,
-    )
-  } catch {
-    // Ignore errors in replay tracking
+  if (!shouldSkipSessionPersistence()) {
+    try {
+      getReplayIndexBuilder().trackToolStart(
+        toolUseID,
+        tool.name,
+        callInput as Record<string, unknown>,
+      )
+    } catch {
+      // Ignore errors in replay tracking
+    }
   }
 
   try {
@@ -1297,21 +1301,8 @@ async function checkPermissionsAndCallTool(
     )
     const durationMs = Date.now() - startTime
     addToToolDuration(durationMs)
-
-    // Track successful tool execution for replay index
-    try {
-      const replayBuilder = getReplayIndexBuilder()
-      const resultPreview = typeof result.data === 'string' ? result.data.slice(0, 200) : undefined
-      replayBuilder.trackToolEnd(
-        toolUseID,
-        tool.name,
-        'success',
-        resultPreview,
-        getReplayModifiedFiles(tool.name, callInput),
-      )
-    } catch {
-      // Ignore errors in replay tracking
-    }
+    const replayResultPreview =
+      typeof result.data === 'string' ? result.data.slice(0, 200) : undefined
 
     // Capture structured output from tool result if present
     if (typeof result === 'object' && 'structured_output' in result) {
@@ -1559,23 +1550,38 @@ async function checkPermissionsAndCallTool(
     for (const hookResult of hookResults) {
       resultingMessages.push(hookResult)
     }
+    if (!shouldSkipSessionPersistence()) {
+      try {
+        const replayBuilder = getReplayIndexBuilder()
+        replayBuilder.trackToolEnd(
+          toolUseID,
+          tool.name,
+          'success',
+          replayResultPreview,
+          getReplayModifiedFiles(tool.name, callInput),
+        )
+      } catch {
+        // Ignore errors in replay tracking
+      }
+    }
     return resultingMessages
   } catch (error) {
     const durationMs = Date.now() - startTime
     addToToolDuration(durationMs)
 
-    // Track failed tool execution for replay index
-    try {
-      const replayBuilder = getReplayIndexBuilder()
-      const errorMsg = error instanceof Error ? error.message : String(error)
-      replayBuilder.trackToolEnd(
-        toolUseID,
-        tool.name,
-        getReplayResultStatusForError(error),
-        errorMsg.slice(0, 200),
-      )
-    } catch {
-      // Ignore errors in replay tracking
+    if (!shouldSkipSessionPersistence()) {
+      try {
+        const replayBuilder = getReplayIndexBuilder()
+        const errorMsg = error instanceof Error ? error.message : String(error)
+        replayBuilder.trackToolEnd(
+          toolUseID,
+          tool.name,
+          getReplayResultStatusForError(error),
+          errorMsg.slice(0, 200),
+        )
+      } catch {
+        // Ignore errors in replay tracking
+      }
     }
 
     // Handle MCP auth errors by updating the client status to 'needs-auth'

--- a/src/services/tools/toolExecution.ts
+++ b/src/services/tools/toolExecution.ts
@@ -1032,21 +1032,6 @@ async function checkPermissionsAndCallTool(
   const permissionDecision = resolved.decision
   processedInput = resolved.input
   const permissionDurationMs = Date.now() - permissionStart
-  let replayStarted = false
-
-  // Track tool execution for replay index after hooks have finalized input,
-  // but before permission denial can return early.
-  try {
-    const replayBuilder = getReplayIndexBuilder()
-    replayBuilder.trackToolStart(
-      toolUseID,
-      tool.name,
-      processedInput as Record<string, unknown>,
-    )
-    replayStarted = true
-  } catch {
-    // Ignore errors in replay tracking - don't break tool execution
-  }
 
   // In auto mode, canUseTool awaits the classifier (side_query) — if that's
   // slow the collapsed view shows "Running…" with no (Ns) tick since
@@ -1102,7 +1087,17 @@ async function checkPermissionsAndCallTool(
     // Track permission denied for replay index
     try {
       const replayBuilder = getReplayIndexBuilder()
-      replayBuilder.trackToolEnd(toolUseID, tool.name, 'permission_denied', permissionDecision.message)
+      replayBuilder.trackToolStart(
+        toolUseID,
+        tool.name,
+        processedInput as Record<string, unknown>,
+      )
+      replayBuilder.trackToolEnd(
+        toolUseID,
+        tool.name,
+        'permission_denied',
+        permissionDecision.message,
+      )
     } catch {
       // Ignore errors in replay tracking
     }
@@ -1205,7 +1200,49 @@ async function checkPermissionsAndCallTool(
     })
   }
 
-  trackLifecycleToolUse(parsedInput.data)
+  const decisionInfo = toolUseContext.toolDecisions?.get(toolUseID)
+
+  const startTime = Date.now()
+
+  startSessionActivity('tool_exec')
+  // If processedInput still points at the backfill clone, no hook/permission
+  // replaced it — pass the pre-backfill callInput so call() sees the model's
+  // original field values. Otherwise converge on the hook-supplied input.
+  // Permission/hook flows may return a fresh object derived from the
+  // backfilled clone (e.g. via inputSchema.parse). If its file_path matches
+  // the backfill-expanded value, restore the model's original so the tool
+  // result string embeds the path the model emitted — keeps transcript/VCR
+  // hashes stable. Other hook modifications flow through unchanged.
+  if (
+    backfilledClone &&
+    processedInput !== callInput &&
+    typeof processedInput === 'object' &&
+    processedInput !== null &&
+    'file_path' in processedInput &&
+    'file_path' in (callInput as Record<string, unknown>) &&
+    (processedInput as Record<string, unknown>).file_path ===
+      (backfilledClone as Record<string, unknown>).file_path
+  ) {
+    callInput = {
+      ...processedInput,
+      file_path: (callInput as Record<string, unknown>).file_path,
+    } as typeof processedInput
+  } else if (processedInput !== backfilledClone) {
+    callInput = processedInput
+  }
+
+  let queryActivityLease: { release(): void } | undefined
+
+  try {
+    getReplayIndexBuilder().trackToolStart(
+      toolUseID,
+      tool.name,
+      callInput as Record<string, unknown>,
+    )
+  } catch {
+    // Ignore errors in replay tracking
+  }
+
   try {
     const queryActivityLeaseInput = createToolQueryLeaseInput(
       tool.name,
@@ -1244,13 +1281,6 @@ async function checkPermissionsAndCallTool(
     try {
       const replayBuilder = getReplayIndexBuilder()
       const resultPreview = typeof result.data === 'string' ? result.data.slice(0, 200) : undefined
-      if (!replayStarted) {
-        replayBuilder.trackToolStart(
-          toolUseID,
-          tool.name,
-          callInput as Record<string, unknown>,
-        )
-      }
       replayBuilder.trackToolEnd(
         toolUseID,
         tool.name,

--- a/src/types/logs.ts
+++ b/src/types/logs.ts
@@ -354,6 +354,97 @@ export type Entry =
   | ContextCollapseCommitEntry
   | ContextCollapseSnapshotEntry
 
+// Replay Index Types
+
+/**
+ * Single step in the replay timeline - represents a tool execution or user message.
+ */
+export type ReplayStep =
+  | ReplayToolStep
+  | ReplayUserStep
+  | ReplayRetryStep
+  | ReplayErrorStep
+
+/**
+ * Tool execution step with input, result, and timing information.
+ */
+export interface ReplayToolStep {
+  type: 'tool'
+  stepNumber: number
+  toolName: string
+  toolUseId: string
+  input: Record<string, unknown>
+  inputSummary: string // Human-readable summary: "Read src/utils.ts"
+  resultStatus: 'success' | 'error' | 'cancelled' | 'permission_denied'
+  resultPreview?: string // First 200 chars of result
+  durationMs: number
+  timestamp: string
+  filesModified?: string[] // From file history if Edit/Write tool
+  repeatedAttemptNumber?: number // 1 for first occurrence, 2+ for repeated tool/input executions
+  isRepeatedAttempt?: boolean
+}
+
+/**
+ * User message step.
+ */
+export interface ReplayUserStep {
+  type: 'user'
+  stepNumber: number
+  content: string // User's request
+  timestamp: string
+}
+
+/**
+ * Retry event emitted by real retry paths such as API retry or permission retry.
+ */
+export interface ReplayRetryStep {
+  type: 'retry'
+  stepNumber: number
+  retryType: 'api' | 'permission'
+  attempt?: number
+  maxRetries?: number
+  retryDelayMs?: number
+  reason: string
+  commands?: string[]
+  timestamp: string
+}
+
+/**
+ * Error step for unexpected failures.
+ */
+export interface ReplayErrorStep {
+  type: 'error'
+  stepNumber: number
+  error: string
+  timestamp: string
+}
+
+/**
+ * Summary statistics for the replay session.
+ */
+export interface ReplaySummary {
+  totalSteps: number
+  toolBreakdown: Record<string, number> // { Read: 5, Edit: 3, Bash: 2 }
+  filesModified: string[]
+  durationMs: number
+  startTimestamp: string
+  endTimestamp: string
+  userRequests: number
+  retryAttempts?: number
+  repeatedAttempts?: number
+}
+
+/**
+ * Complete replay index stored as .replay.json alongside the transcript.
+ */
+export interface ReplayIndex {
+  sessionId: string
+  version: 1
+  createdAt: string
+  summary: ReplaySummary
+  steps: ReplayStep[]
+}
+
 export function sortLogs(logs: LogOption[]): LogOption[] {
   return logs.sort((a, b) => {
     // Sort by modified date (newest first)

--- a/src/utils/cleanup.test.ts
+++ b/src/utils/cleanup.test.ts
@@ -3,15 +3,12 @@ import { mkdir, rm, stat, utimes, writeFile } from 'fs/promises'
 import { tmpdir } from 'os'
 import { join } from 'path'
 
-import { cleanupOldSessionFiles } from './cleanup.js'
-import { setClaudeConfigHomeDirForTesting } from './envUtils.js'
-import { resetSettingsCache } from './settings/settingsCache.js'
+import { cleanupOldSessionFilesInProjectsDir } from './cleanup.js'
+import { NodeFsOperations } from './fsOperations.js'
 
 const tempDirs: string[] = []
 
 afterEach(async () => {
-  setClaudeConfigHomeDirForTesting(undefined)
-  resetSettingsCache()
   await Promise.all(
     tempDirs.splice(0).map(dir => rm(dir, { recursive: true, force: true })),
   )
@@ -19,21 +16,15 @@ afterEach(async () => {
 
 describe('cleanupOldSessionFiles', () => {
   test('removes old replay sidecars while preserving non-session files', async () => {
-    const configDir = join(
+    const projectsDir = join(
       tmpdir(),
       `openclaude-cleanup-${Date.now()}-${Math.random().toString(16).slice(2)}`,
+      'projects',
     )
-    tempDirs.push(configDir)
-    setClaudeConfigHomeDirForTesting(configDir)
+    tempDirs.push(projectsDir)
 
-    const projectDir = join(configDir, 'projects', 'project')
+    const projectDir = join(projectsDir, 'project')
     await mkdir(projectDir, { recursive: true })
-    await writeFile(
-      join(configDir, 'settings.json'),
-      JSON.stringify({ cleanupPeriodDays: 30 }),
-      'utf-8',
-    )
-    resetSettingsCache()
 
     const replayPath = join(projectDir, 'session.replay.json')
     const keepPath = join(projectDir, 'session.notes.json')
@@ -44,7 +35,11 @@ describe('cleanupOldSessionFiles', () => {
     await utimes(replayPath, oldDate, oldDate)
     await utimes(keepPath, oldDate, oldDate)
 
-    const result = await cleanupOldSessionFiles()
+    const result = await cleanupOldSessionFilesInProjectsDir(
+      projectsDir,
+      new Date(),
+      NodeFsOperations,
+    )
 
     expect(result.messages).toBe(1)
     await expect(stat(replayPath)).rejects.toThrow()

--- a/src/utils/cleanup.test.ts
+++ b/src/utils/cleanup.test.ts
@@ -5,11 +5,13 @@ import { join } from 'path'
 
 import { cleanupOldSessionFiles } from './cleanup.js'
 import { setClaudeConfigHomeDirForTesting } from './envUtils.js'
+import { resetSettingsCache } from './settings/settingsCache.js'
 
 const tempDirs: string[] = []
 
 afterEach(async () => {
   setClaudeConfigHomeDirForTesting(undefined)
+  resetSettingsCache()
   await Promise.all(
     tempDirs.splice(0).map(dir => rm(dir, { recursive: true, force: true })),
   )
@@ -26,6 +28,12 @@ describe('cleanupOldSessionFiles', () => {
 
     const projectDir = join(configDir, 'projects', 'project')
     await mkdir(projectDir, { recursive: true })
+    await writeFile(
+      join(configDir, 'settings.json'),
+      JSON.stringify({ cleanupPeriodDays: 30 }),
+      'utf-8',
+    )
+    resetSettingsCache()
 
     const replayPath = join(projectDir, 'session.replay.json')
     const keepPath = join(projectDir, 'session.notes.json')

--- a/src/utils/cleanup.test.ts
+++ b/src/utils/cleanup.test.ts
@@ -1,0 +1,45 @@
+import { afterEach, describe, expect, test } from 'bun:test'
+import { mkdir, rm, stat, utimes, writeFile } from 'fs/promises'
+import { tmpdir } from 'os'
+import { join } from 'path'
+
+import { cleanupOldSessionFiles } from './cleanup.js'
+import { setClaudeConfigHomeDirForTesting } from './envUtils.js'
+
+const tempDirs: string[] = []
+
+afterEach(async () => {
+  setClaudeConfigHomeDirForTesting(undefined)
+  await Promise.all(
+    tempDirs.splice(0).map(dir => rm(dir, { recursive: true, force: true })),
+  )
+})
+
+describe('cleanupOldSessionFiles', () => {
+  test('removes old replay sidecars while preserving non-session files', async () => {
+    const configDir = join(
+      tmpdir(),
+      `openclaude-cleanup-${Date.now()}-${Math.random().toString(16).slice(2)}`,
+    )
+    tempDirs.push(configDir)
+    setClaudeConfigHomeDirForTesting(configDir)
+
+    const projectDir = join(configDir, 'projects', 'project')
+    await mkdir(projectDir, { recursive: true })
+
+    const replayPath = join(projectDir, 'session.replay.json')
+    const keepPath = join(projectDir, 'session.notes.json')
+    await writeFile(replayPath, '{}', 'utf-8')
+    await writeFile(keepPath, '{}', 'utf-8')
+
+    const oldDate = new Date(Date.now() - 31 * 24 * 60 * 60 * 1000)
+    await utimes(replayPath, oldDate, oldDate)
+    await utimes(keepPath, oldDate, oldDate)
+
+    const result = await cleanupOldSessionFiles()
+
+    expect(result.messages).toBe(1)
+    await expect(stat(replayPath)).rejects.toThrow()
+    expect((await stat(keepPath)).isFile()).toBe(true)
+  })
+})

--- a/src/utils/cleanup.ts
+++ b/src/utils/cleanup.ts
@@ -180,7 +180,11 @@ export async function cleanupOldSessionFiles(): Promise<CleanupResult> {
 
     for (const entry of entries) {
       if (entry.isFile()) {
-        if (!entry.name.endsWith('.jsonl') && !entry.name.endsWith('.cast')) {
+        if (
+          !entry.name.endsWith('.jsonl') &&
+          !entry.name.endsWith('.cast') &&
+          !entry.name.endsWith('.replay.json')
+        ) {
           continue
         }
         try {

--- a/src/utils/cleanup.ts
+++ b/src/utils/cleanup.ts
@@ -154,9 +154,18 @@ async function tryRmdir(dirPath: string, fsImpl: FsOperations): Promise<void> {
 
 export async function cleanupOldSessionFiles(): Promise<CleanupResult> {
   const cutoffDate = getCutoffDate()
-  const result: CleanupResult = { messages: 0, errors: 0 }
   const projectsDir = getProjectsDir()
   const fsImpl = getFsImplementation()
+
+  return cleanupOldSessionFilesInProjectsDir(projectsDir, cutoffDate, fsImpl)
+}
+
+export async function cleanupOldSessionFilesInProjectsDir(
+  projectsDir: string,
+  cutoffDate: Date,
+  fsImpl: FsOperations,
+): Promise<CleanupResult> {
+  const result: CleanupResult = { messages: 0, errors: 0 }
 
   let projectDirents
   try {

--- a/src/utils/replayFormat.test.ts
+++ b/src/utils/replayFormat.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, test } from 'bun:test'
+
+import { formatReplayDuration } from './replayFormat.js'
+
+describe('formatReplayDuration', () => {
+  test('preserves sub-second precision for replay timings', () => {
+    expect(formatReplayDuration(1)).toBe('1ms')
+    expect(formatReplayDuration(500)).toBe('500ms')
+    expect(formatReplayDuration(999)).toBe('999ms')
+  })
+
+  test('delegates longer durations to the shared formatter', () => {
+    expect(formatReplayDuration(0)).toBe('0s')
+    expect(formatReplayDuration(1000)).toBe('1s')
+    expect(formatReplayDuration(65000)).toBe('1m 5s')
+  })
+})

--- a/src/utils/replayFormat.ts
+++ b/src/utils/replayFormat.ts
@@ -1,0 +1,8 @@
+import { formatDuration } from './format.js'
+
+export function formatReplayDuration(ms: number): string {
+  if (ms > 0 && ms < 1000) {
+    return `${Math.round(ms)}ms`
+  }
+  return formatDuration(ms)
+}

--- a/src/utils/replayIndex.test.ts
+++ b/src/utils/replayIndex.test.ts
@@ -69,6 +69,24 @@ describe('replay index storage', () => {
     }
   })
 
+  test('creates missing replay sidecar directories with owner-only permissions', async () => {
+    const sessionId = 'session-dir-perms'
+    const projectDir = join(testRoot, 'new-project')
+
+    await writeReplayIndex(
+      sessionId,
+      join(projectDir, `${sessionId}.jsonl`),
+      makeIndex(sessionId),
+    )
+
+    const stats = await stat(projectDir)
+    if (process.platform !== 'win32') {
+      expect(stats.mode & 0o777).toBe(0o700)
+    } else {
+      expect(stats.isDirectory()).toBe(true)
+    }
+  })
+
   test('ignores malformed replay sidecars without a valid summary', async () => {
     const sessionId = 'session-malformed'
     const projectDir = join(testRoot, 'project')

--- a/src/utils/replayIndex.test.ts
+++ b/src/utils/replayIndex.test.ts
@@ -1,0 +1,71 @@
+import { mkdir, readFile, stat, writeFile } from 'fs/promises'
+import { join } from 'path'
+import { afterEach, describe, expect, test } from 'bun:test'
+
+import type { ReplayIndex } from 'src/types/logs.js'
+import { loadReplayIndex, writeReplayIndex } from './replayIndex.js'
+
+const testRoot = join(process.cwd(), '.tmp-replay-index-tests')
+
+function makeIndex(sessionId: string): ReplayIndex {
+  return {
+    sessionId,
+    version: 1,
+    createdAt: '2026-01-01T00:00:00.000Z',
+    summary: {
+      totalSteps: 0,
+      toolBreakdown: {},
+      filesModified: [],
+      durationMs: 0,
+      startTimestamp: '2026-01-01T00:00:00.000Z',
+      endTimestamp: '2026-01-01T00:00:00.000Z',
+      userRequests: 0,
+      retryAttempts: 0,
+      repeatedAttempts: 0,
+    },
+    steps: [],
+  }
+}
+
+afterEach(async () => {
+  const { rm } = await import('fs/promises')
+  await rm(testRoot, { recursive: true, force: true })
+})
+
+describe('replay index storage', () => {
+  test('writes replay sidecar by session id without replacing arbitrary transcript suffixes', async () => {
+    const sessionId = 'session-abc'
+    const projectDir = join(testRoot, 'project')
+    const transcriptPath = join(projectDir, 'transcript-without-jsonl')
+    const index = makeIndex(sessionId)
+
+    await mkdir(projectDir, { recursive: true })
+    await writeFile(transcriptPath, 'original transcript', 'utf-8')
+
+    await writeReplayIndex(sessionId, transcriptPath, index)
+
+    expect(await readFile(transcriptPath, 'utf-8')).toBe('original transcript')
+    expect(await loadReplayIndex(sessionId, transcriptPath)).toEqual(index)
+    expect(
+      await readFile(join(projectDir, `${sessionId}.replay.json`), 'utf-8'),
+    ).toContain('"sessionId": "session-abc"')
+  })
+
+  test('creates replay sidecars with owner-only permissions on platforms that expose mode bits', async () => {
+    const sessionId = 'session-perms'
+    const replayPath = join(testRoot, 'project', `${sessionId}.replay.json`)
+
+    await writeReplayIndex(
+      sessionId,
+      join(testRoot, 'project', `${sessionId}.jsonl`),
+      makeIndex(sessionId),
+    )
+
+    const stats = await stat(replayPath)
+    if (process.platform !== 'win32') {
+      expect(stats.mode & 0o777).toBe(0o600)
+    } else {
+      expect(stats.isFile()).toBe(true)
+    }
+  })
+})

--- a/src/utils/replayIndex.test.ts
+++ b/src/utils/replayIndex.test.ts
@@ -87,4 +87,33 @@ describe('replay index storage', () => {
 
     expect(await loadReplayIndex(sessionId, transcriptPath)).toBe(null)
   })
+
+  test('ignores replay sidecars with array-shaped summary records', async () => {
+    const sessionId = 'session-array-summary'
+    const projectDir = join(testRoot, 'project')
+    const transcriptPath = join(projectDir, `${sessionId}.jsonl`)
+
+    await mkdir(projectDir, { recursive: true })
+    await writeFile(
+      join(projectDir, `${sessionId}.replay.json`),
+      JSON.stringify({
+        sessionId,
+        version: 1,
+        createdAt: '2026-01-01T00:00:00.000Z',
+        summary: {
+          totalSteps: 0,
+          toolBreakdown: [],
+          filesModified: [],
+          durationMs: 0,
+          startTimestamp: '2026-01-01T00:00:00.000Z',
+          endTimestamp: '2026-01-01T00:00:00.000Z',
+          userRequests: 0,
+        },
+        steps: [],
+      }),
+      'utf-8',
+    )
+
+    expect(await loadReplayIndex(sessionId, transcriptPath)).toBe(null)
+  })
 })

--- a/src/utils/replayIndex.test.ts
+++ b/src/utils/replayIndex.test.ts
@@ -3,7 +3,7 @@ import { join } from 'path'
 import { afterEach, describe, expect, test } from 'bun:test'
 
 import type { ReplayIndex } from 'src/types/logs.js'
-import { loadReplayIndex, writeReplayIndex } from './replayIndex.js'
+import { fileExists, loadReplayIndex, writeReplayIndex } from './replayIndex.js'
 
 const testRoot = join(process.cwd(), '.tmp-replay-index-tests')
 
@@ -33,6 +33,14 @@ afterEach(async () => {
 })
 
 describe('replay index storage', () => {
+  test('fileExists returns false only for missing files', async () => {
+    await expect(fileExists(join(testRoot, 'missing.replay.json'))).resolves.toBe(
+      false,
+    )
+
+    await expect(fileExists('\0')).rejects.toThrow()
+  })
+
   test('writes replay sidecar by session id without replacing arbitrary transcript suffixes', async () => {
     const sessionId = 'session-abc'
     const projectDir = join(testRoot, 'project')

--- a/src/utils/replayIndex.test.ts
+++ b/src/utils/replayIndex.test.ts
@@ -134,4 +134,28 @@ describe('replay index storage', () => {
 
     expect(await loadReplayIndex(sessionId, transcriptPath)).toBe(null)
   })
+
+  test('ignores replay sidecars with malformed steps', async () => {
+    const sessionId = 'session-malformed-step'
+    const projectDir = join(testRoot, 'project')
+    const transcriptPath = join(projectDir, `${sessionId}.jsonl`)
+    const index = makeIndex(sessionId)
+
+    await mkdir(projectDir, { recursive: true })
+    await writeFile(
+      join(projectDir, `${sessionId}.replay.json`),
+      JSON.stringify({
+        ...index,
+        steps: [
+          {
+            type: 'tool',
+            stepNumber: 1,
+          },
+        ],
+      }),
+      'utf-8',
+    )
+
+    expect(await loadReplayIndex(sessionId, transcriptPath)).toBe(null)
+  })
 })

--- a/src/utils/replayIndex.test.ts
+++ b/src/utils/replayIndex.test.ts
@@ -68,4 +68,23 @@ describe('replay index storage', () => {
       expect(stats.isFile()).toBe(true)
     }
   })
+
+  test('ignores malformed replay sidecars without a valid summary', async () => {
+    const sessionId = 'session-malformed'
+    const projectDir = join(testRoot, 'project')
+    const transcriptPath = join(projectDir, `${sessionId}.jsonl`)
+
+    await mkdir(projectDir, { recursive: true })
+    await writeFile(
+      join(projectDir, `${sessionId}.replay.json`),
+      JSON.stringify({
+        sessionId,
+        version: 1,
+        steps: [],
+      }),
+      'utf-8',
+    )
+
+    expect(await loadReplayIndex(sessionId, transcriptPath)).toBe(null)
+  })
 })

--- a/src/utils/replayIndex.test.ts
+++ b/src/utils/replayIndex.test.ts
@@ -1,4 +1,4 @@
-import { mkdir, readFile, stat, writeFile } from 'fs/promises'
+import { chmod, mkdir, readFile, stat, writeFile } from 'fs/promises'
 import { join } from 'path'
 import { afterEach, describe, expect, test } from 'bun:test'
 
@@ -60,6 +60,31 @@ describe('replay index storage', () => {
       join(testRoot, 'project', `${sessionId}.jsonl`),
       makeIndex(sessionId),
     )
+
+    const stats = await stat(replayPath)
+    if (process.platform !== 'win32') {
+      expect(stats.mode & 0o777).toBe(0o600)
+    } else {
+      expect(stats.isFile()).toBe(true)
+    }
+  })
+
+  test('rewrites replay sidecars with owner-only permissions on platforms that expose mode bits', async () => {
+    const sessionId = 'session-rewrite-perms'
+    const projectDir = join(testRoot, 'project')
+    const transcriptPath = join(projectDir, `${sessionId}.jsonl`)
+    const replayPath = join(projectDir, `${sessionId}.replay.json`)
+
+    await mkdir(projectDir, { recursive: true })
+    await writeFile(replayPath, JSON.stringify(makeIndex(sessionId)), {
+      encoding: 'utf-8',
+      mode: 0o666,
+    })
+    if (process.platform !== 'win32') {
+      await chmod(replayPath, 0o666)
+    }
+
+    await writeReplayIndex(sessionId, transcriptPath, makeIndex(sessionId))
 
     const stats = await stat(replayPath)
     if (process.platform !== 'win32') {

--- a/src/utils/replayIndex.ts
+++ b/src/utils/replayIndex.ts
@@ -25,7 +25,7 @@ async function fileExists(path: string): Promise<boolean> {
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
 }
 
 function isReplaySummary(value: unknown): value is ReplaySummary {

--- a/src/utils/replayIndex.ts
+++ b/src/utils/replayIndex.ts
@@ -15,12 +15,20 @@ function getReplayIndexPath(sessionId: string, transcriptPath: string): string {
 /**
  * Check if a file exists.
  */
-async function fileExists(path: string): Promise<boolean> {
+export async function fileExists(path: string): Promise<boolean> {
   try {
     await stat(path)
     return true
-  } catch {
-    return false
+  } catch (error) {
+    if (
+      error &&
+      typeof error === 'object' &&
+      'code' in error &&
+      error.code === 'ENOENT'
+    ) {
+      return false
+    }
+    throw error
   }
 }
 

--- a/src/utils/replayIndex.ts
+++ b/src/utils/replayIndex.ts
@@ -1,6 +1,6 @@
 import { readFile, writeFile, stat } from 'fs/promises'
 import { join, dirname } from 'path'
-import type { ReplayIndex, ReplaySummary } from 'src/types/logs.js'
+import type { ReplayIndex, ReplayStep, ReplaySummary } from 'src/types/logs.js'
 import { logForDebugging } from './debug.js'
 import { logError } from './log.js'
 
@@ -49,6 +49,66 @@ function isReplaySummary(value: unknown): value is ReplaySummary {
   )
 }
 
+function isOptionalStringArray(value: unknown): boolean {
+  return (
+    value === undefined ||
+    (Array.isArray(value) && value.every(item => typeof item === 'string'))
+  )
+}
+
+function isReplayStep(value: unknown): value is ReplayStep {
+  if (!isRecord(value) || typeof value.stepNumber !== 'number') {
+    return false
+  }
+
+  switch (value.type) {
+    case 'tool':
+      return (
+        typeof value.toolName === 'string' &&
+        typeof value.toolUseId === 'string' &&
+        isRecord(value.input) &&
+        typeof value.inputSummary === 'string' &&
+        (value.resultStatus === 'success' ||
+          value.resultStatus === 'error' ||
+          value.resultStatus === 'cancelled' ||
+          value.resultStatus === 'permission_denied') &&
+        (value.resultPreview === undefined ||
+          typeof value.resultPreview === 'string') &&
+        typeof value.durationMs === 'number' &&
+        typeof value.timestamp === 'string' &&
+        isOptionalStringArray(value.filesModified) &&
+        (value.repeatedAttemptNumber === undefined ||
+          typeof value.repeatedAttemptNumber === 'number') &&
+        (value.isRepeatedAttempt === undefined ||
+          typeof value.isRepeatedAttempt === 'boolean')
+      )
+    case 'user':
+      return (
+        typeof value.content === 'string' &&
+        typeof value.timestamp === 'string'
+      )
+    case 'retry':
+      return (
+        (value.retryType === 'api' || value.retryType === 'permission') &&
+        (value.attempt === undefined || typeof value.attempt === 'number') &&
+        (value.maxRetries === undefined ||
+          typeof value.maxRetries === 'number') &&
+        (value.retryDelayMs === undefined ||
+          typeof value.retryDelayMs === 'number') &&
+        typeof value.reason === 'string' &&
+        isOptionalStringArray(value.commands) &&
+        typeof value.timestamp === 'string'
+      )
+    case 'error':
+      return (
+        typeof value.error === 'string' &&
+        typeof value.timestamp === 'string'
+      )
+    default:
+      return false
+  }
+}
+
 function isReplayIndex(value: unknown, sessionId: string): value is ReplayIndex {
   return (
     isRecord(value) &&
@@ -56,7 +116,8 @@ function isReplayIndex(value: unknown, sessionId: string): value is ReplayIndex 
     value.sessionId === sessionId &&
     typeof value.createdAt === 'string' &&
     isReplaySummary(value.summary) &&
-    Array.isArray(value.steps)
+    Array.isArray(value.steps) &&
+    value.steps.every(isReplayStep)
   )
 }
 

--- a/src/utils/replayIndex.ts
+++ b/src/utils/replayIndex.ts
@@ -1,6 +1,6 @@
 import { readFile, writeFile, stat } from 'fs/promises'
 import { join, dirname } from 'path'
-import type { ReplayIndex } from 'src/types/logs.js'
+import type { ReplayIndex, ReplaySummary } from 'src/types/logs.js'
 import { logForDebugging } from './debug.js'
 import { logError } from './log.js'
 
@@ -24,6 +24,42 @@ async function fileExists(path: string): Promise<boolean> {
   }
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null
+}
+
+function isReplaySummary(value: unknown): value is ReplaySummary {
+  if (!isRecord(value)) {
+    return false
+  }
+  return (
+    typeof value.totalSteps === 'number' &&
+    isRecord(value.toolBreakdown) &&
+    Object.values(value.toolBreakdown).every(count => typeof count === 'number') &&
+    Array.isArray(value.filesModified) &&
+    value.filesModified.every(file => typeof file === 'string') &&
+    typeof value.durationMs === 'number' &&
+    typeof value.startTimestamp === 'string' &&
+    typeof value.endTimestamp === 'string' &&
+    typeof value.userRequests === 'number' &&
+    (value.retryAttempts === undefined ||
+      typeof value.retryAttempts === 'number') &&
+    (value.repeatedAttempts === undefined ||
+      typeof value.repeatedAttempts === 'number')
+  )
+}
+
+function isReplayIndex(value: unknown, sessionId: string): value is ReplayIndex {
+  return (
+    isRecord(value) &&
+    value.version === 1 &&
+    value.sessionId === sessionId &&
+    typeof value.createdAt === 'string' &&
+    isReplaySummary(value.summary) &&
+    Array.isArray(value.steps)
+  )
+}
+
 /**
  * Load the replay index for a session.
  * First tries to load the cached .replay.json, falls back to null if not found.
@@ -37,10 +73,9 @@ export async function loadReplayIndex(
   try {
     if (await fileExists(replayPath)) {
       const content = await readFile(replayPath, 'utf-8')
-      const index = JSON.parse(content) as ReplayIndex
+      const index = JSON.parse(content) as unknown
       
-      // Validate basic structure
-      if (index.version === 1 && index.sessionId === sessionId && Array.isArray(index.steps)) {
+      if (isReplayIndex(index, sessionId)) {
         return index
       }
       

--- a/src/utils/replayIndex.ts
+++ b/src/utils/replayIndex.ts
@@ -1,0 +1,83 @@
+import { readFile, writeFile, stat } from 'fs/promises'
+import { join, dirname } from 'path'
+import type { ReplayIndex } from 'src/types/logs.js'
+import { logForDebugging } from './debug.js'
+import { logError } from './log.js'
+
+/**
+ * Get the path for a session's replay index file.
+ * Pattern: <projectDir>/<sessionId>.replay.json
+ */
+function getReplayIndexPath(sessionId: string, transcriptPath: string): string {
+  return transcriptPath.replace(/\.jsonl$/, '.replay.json')
+}
+
+/**
+ * Check if a file exists.
+ */
+async function fileExists(path: string): Promise<boolean> {
+  try {
+    await stat(path)
+    return true
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Load the replay index for a session.
+ * First tries to load the cached .replay.json, falls back to null if not found.
+ */
+export async function loadReplayIndex(
+  sessionId: string,
+  transcriptPath: string,
+): Promise<ReplayIndex | null> {
+  const replayPath = getReplayIndexPath(sessionId, transcriptPath)
+  
+  try {
+    if (await fileExists(replayPath)) {
+      const content = await readFile(replayPath, 'utf-8')
+      const index = JSON.parse(content) as ReplayIndex
+      
+      // Validate basic structure
+      if (index.version === 1 && index.sessionId === sessionId && Array.isArray(index.steps)) {
+        return index
+      }
+      
+      logForDebugging(`Replay index invalid for session ${sessionId}, ignoring`)
+    }
+  } catch (error) {
+    logError(error)
+    logForDebugging(`Failed to load replay index for session ${sessionId}: ${error}`)
+  }
+  
+  return null
+}
+
+/**
+ * Write a replay index to disk.
+ */
+export async function writeReplayIndex(
+  sessionId: string,
+  transcriptPath: string,
+  index: ReplayIndex,
+): Promise<void> {
+  const replayPath = getReplayIndexPath(sessionId, transcriptPath)
+  
+  try {
+    // Ensure directory exists
+    const dir = dirname(replayPath)
+    try {
+      await stat(dir)
+    } catch {
+      const { mkdir } = await import('fs/promises')
+      await mkdir(dir, { recursive: true })
+    }
+    
+    await writeFile(replayPath, JSON.stringify(index, null, 2), 'utf-8')
+    logForDebugging(`Wrote replay index for session ${sessionId} to ${replayPath}`)
+  } catch (error) {
+    logError(error)
+    logForDebugging(`Failed to write replay index for session ${sessionId}: ${error}`)
+  }
+}

--- a/src/utils/replayIndex.ts
+++ b/src/utils/replayIndex.ts
@@ -1,4 +1,4 @@
-import { readFile, writeFile, stat } from 'fs/promises'
+import { chmod, readFile, writeFile, stat } from 'fs/promises'
 import { join, dirname } from 'path'
 import type { ReplayIndex, ReplayStep, ReplaySummary } from 'src/types/logs.js'
 import { logForDebugging } from './debug.js'
@@ -174,6 +174,7 @@ export async function writeReplayIndex(
       encoding: 'utf-8',
       mode: 0o600,
     })
+    await chmod(replayPath, 0o600)
     logForDebugging(`Wrote replay index for session ${sessionId} to ${replayPath}`)
   } catch (error) {
     logError(error)

--- a/src/utils/replayIndex.ts
+++ b/src/utils/replayIndex.ts
@@ -9,7 +9,7 @@ import { logError } from './log.js'
  * Pattern: <projectDir>/<sessionId>.replay.json
  */
 function getReplayIndexPath(sessionId: string, transcriptPath: string): string {
-  return transcriptPath.replace(/\.jsonl$/, '.replay.json')
+  return join(dirname(transcriptPath), `${sessionId}.replay.json`)
 }
 
 /**
@@ -74,7 +74,10 @@ export async function writeReplayIndex(
       await mkdir(dir, { recursive: true })
     }
     
-    await writeFile(replayPath, JSON.stringify(index, null, 2), 'utf-8')
+    await writeFile(replayPath, JSON.stringify(index, null, 2), {
+      encoding: 'utf-8',
+      mode: 0o600,
+    })
     logForDebugging(`Wrote replay index for session ${sessionId} to ${replayPath}`)
   } catch (error) {
     logError(error)

--- a/src/utils/replayIndex.ts
+++ b/src/utils/replayIndex.ts
@@ -106,7 +106,7 @@ export async function writeReplayIndex(
       await stat(dir)
     } catch {
       const { mkdir } = await import('fs/promises')
-      await mkdir(dir, { recursive: true })
+      await mkdir(dir, { recursive: true, mode: 0o700 })
     }
     
     await writeFile(replayPath, JSON.stringify(index, null, 2), {

--- a/src/utils/replayIndexBuilder.test.ts
+++ b/src/utils/replayIndexBuilder.test.ts
@@ -109,4 +109,15 @@ describe('ReplayIndexBuilder', () => {
     expect(index.summary.startTimestamp).toBe('2026-01-01T00:00:01.000Z')
     expect(index.summary.endTimestamp).toBe('2026-01-01T00:00:10.000Z')
   })
+
+  test('uses elapsed session bounds for summary duration', () => {
+    const builder = new ReplayIndexBuilder()
+
+    builder.trackUserMessage('start', '2026-01-01T00:00:00.000Z')
+    builder.trackRetry('api', 'rate limited', '2026-01-01T00:00:05.000Z')
+
+    const index = builder.build('session-1')
+
+    expect(index.summary.durationMs).toBe(5000)
+  })
 })

--- a/src/utils/replayIndexBuilder.test.ts
+++ b/src/utils/replayIndexBuilder.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, test } from 'bun:test'
+
+import { ReplayIndexBuilder } from './replayIndexBuilder.js'
+
+describe('ReplayIndexBuilder', () => {
+  test('records repeated attempts for repeated tool/input executions', () => {
+    const builder = new ReplayIndexBuilder()
+
+    builder.trackToolStart('tool-1', 'Bash', { command: 'bun test' })
+    builder.trackToolEnd('tool-1', 'Bash', 'error', 'failed')
+
+    builder.trackToolStart('tool-2', 'Bash', { command: 'bun test' })
+    builder.trackToolEnd('tool-2', 'Bash', 'success', 'passed')
+
+    const index = builder.build('session-1')
+    const first = index.steps[0]
+    const second = index.steps[1]
+
+    expect(first?.type).toBe('tool')
+    expect(second?.type).toBe('tool')
+    if (first?.type !== 'tool' || second?.type !== 'tool') {
+      throw new Error('expected tool replay steps')
+    }
+
+    expect(first.repeatedAttemptNumber).toBe(1)
+    expect(first.isRepeatedAttempt).toBe(false)
+    expect(second.repeatedAttemptNumber).toBe(2)
+    expect(second.isRepeatedAttempt).toBe(true)
+    expect(index.summary.repeatedAttempts).toBe(1)
+  })
+
+  test('normalizes input key order when detecting repeated attempts', () => {
+    const builder = new ReplayIndexBuilder()
+
+    builder.trackToolStart('tool-1', 'Edit', {
+      file_path: 'src/a.ts',
+      old_string: 'old',
+      new_string: 'new',
+    })
+    builder.trackToolEnd('tool-1', 'Edit', 'error', 'failed')
+
+    builder.trackToolStart('tool-2', 'Edit', {
+      new_string: 'new',
+      old_string: 'old',
+      file_path: 'src/a.ts',
+    })
+    builder.trackToolEnd('tool-2', 'Edit', 'success', 'patched', ['src/a.ts'])
+
+    const index = builder.build('session-1')
+    const second = index.steps[1]
+
+    expect(second?.type).toBe('tool')
+    if (second?.type !== 'tool') {
+      throw new Error('expected tool replay step')
+    }
+
+    expect(second.repeatedAttemptNumber).toBe(2)
+    expect(second.filesModified).toEqual(['src/a.ts'])
+    expect(index.summary.filesModified).toEqual(['src/a.ts'])
+    expect(index.summary.repeatedAttempts).toBe(1)
+  })
+
+  test('records real retry events separately from repeated attempts', () => {
+    const builder = new ReplayIndexBuilder()
+
+    builder.trackRetry('api', 'rate limited', '2026-06-17T00:00:00.000Z', {
+      attempt: 2,
+      maxRetries: 5,
+      retryDelayMs: 1000,
+    })
+    builder.trackRetry(
+      'permission',
+      'Allowed Bash(git status)',
+      '2026-06-17T00:00:01.000Z',
+      {
+        commands: ['Bash(git status)'],
+      },
+    )
+
+    const index = builder.build('session-1')
+    const first = index.steps[0]
+    const second = index.steps[1]
+
+    expect(first?.type).toBe('retry')
+    expect(second?.type).toBe('retry')
+    if (first?.type !== 'retry' || second?.type !== 'retry') {
+      throw new Error('expected retry replay steps')
+    }
+
+    expect(first.retryType).toBe('api')
+    expect(first.attempt).toBe(2)
+    expect(first.maxRetries).toBe(5)
+    expect(first.retryDelayMs).toBe(1000)
+    expect(second.retryType).toBe('permission')
+    expect(second.commands).toEqual(['Bash(git status)'])
+    expect(index.summary.retryAttempts).toBe(2)
+    expect(index.summary.repeatedAttempts).toBe(0)
+  })
+})

--- a/src/utils/replayIndexBuilder.test.ts
+++ b/src/utils/replayIndexBuilder.test.ts
@@ -96,4 +96,17 @@ describe('ReplayIndexBuilder', () => {
     expect(index.summary.retryAttempts).toBe(2)
     expect(index.summary.repeatedAttempts).toBe(0)
   })
+
+  test('uses earliest and latest timestamps for session boundaries', () => {
+    const builder = new ReplayIndexBuilder()
+
+    builder.trackUserMessage('later request', '2026-01-01T00:00:10.000Z')
+    builder.trackRetry('api', 'middle retry', '2026-01-01T00:00:05.000Z')
+    builder.trackUserMessage('earlier request', '2026-01-01T00:00:01.000Z')
+
+    const index = builder.build('session-1')
+
+    expect(index.summary.startTimestamp).toBe('2026-01-01T00:00:01.000Z')
+    expect(index.summary.endTimestamp).toBe('2026-01-01T00:00:10.000Z')
+  })
 })

--- a/src/utils/replayIndexBuilder.ts
+++ b/src/utils/replayIndexBuilder.ts
@@ -185,7 +185,6 @@ export class ReplayIndexBuilder {
   private calculateSummary(): ReplaySummary {
     const toolBreakdown: Record<string, number> = {}
     const filesModifiedSet = new Set<string>()
-    let durationMs = 0
     let userRequests = 0
     let retryAttempts = 0
     let repeatedAttempts = 0
@@ -201,9 +200,6 @@ export class ReplayIndexBuilder {
             filesModifiedSet.add(file)
           }
         }
-
-        // Sum duration
-        durationMs += step.durationMs
         if (step.isRepeatedAttempt) {
           repeatedAttempts++
         }
@@ -225,6 +221,10 @@ export class ReplayIndexBuilder {
       timestampValues.length > 0
         ? new Date(Math.max(...timestampValues)).toISOString()
         : new Date().toISOString()
+    const durationMs =
+      timestampValues.length > 0
+        ? Math.max(0, Date.parse(endTimestamp) - Date.parse(startTimestamp))
+        : 0
 
     return {
       totalSteps: this.steps.length,

--- a/src/utils/replayIndexBuilder.ts
+++ b/src/utils/replayIndexBuilder.ts
@@ -1,0 +1,240 @@
+import type {
+  ReplayIndex,
+  ReplayStep,
+  ReplaySummary,
+  ReplayRetryStep,
+  ReplayToolStep,
+  ReplayUserStep,
+} from 'src/types/logs.js'
+import { stableStringify } from './stableStringify.js'
+
+/**
+ * Truncates a string to a maximum length, adding ellipsis if truncated.
+ */
+function truncate(str: string, maxLength: number): string {
+  if (str.length <= maxLength) return str
+  return str.slice(0, maxLength - 3) + '...'
+}
+
+/**
+ * Creates a human-readable summary of tool input based on tool name and parameters.
+ */
+function summarizeToolInput(toolName: string, input: Record<string, unknown>): string {
+  switch (toolName) {
+    case 'Read':
+    case 'Glob':
+    case 'Grep':
+      return `${toolName} ${input.pattern ?? input.file_path ?? input.filePath ?? ''}`
+    case 'Edit':
+      return `Edit ${input.file_path ?? input.filePath ?? ''}`
+    case 'Write':
+      return `Write ${input.file_path ?? input.filePath ?? ''}`
+    case 'Bash':
+      return `Bash: ${truncate(String(input.command ?? ''), 50)}`
+    case 'WebFetch':
+      return `Fetch ${truncate(String(input.url ?? ''), 50)}`
+    case 'WebSearch':
+      return `Search: ${truncate(String(input.query ?? ''), 50)}`
+    default:
+      return toolName
+  }
+}
+
+function getToolAttemptSignature(
+  toolName: string,
+  input: Record<string, unknown>,
+): string {
+  try {
+    return `${toolName}:${stableStringify(input)}`
+  } catch {
+    return `${toolName}:${JSON.stringify(Object.keys(input).sort())}`
+  }
+}
+
+/**
+ * Builder class for constructing ReplayIndex during a session.
+ * Tracks tool executions, user messages, and calculates summary statistics.
+ */
+export class ReplayIndexBuilder {
+  private steps: ReplayStep[] = []
+  private stepCounter = 0
+  private toolStartTimes = new Map<string, number>()
+  private toolInputs = new Map<string, Record<string, unknown>>()
+  private toolRepeatedAttemptNumbers = new Map<string, number>()
+  private signatureExecutionCounts = new Map<string, number>()
+  private sessionStart: string = new Date().toISOString()
+
+  /**
+   * Track a user message arriving in the session.
+   */
+  trackUserMessage(content: string, timestamp: string): void {
+    this.steps.push({
+      type: 'user',
+      stepNumber: ++this.stepCounter,
+      content: truncate(typeof content === 'string' ? content : JSON.stringify(content), 200),
+      timestamp,
+    })
+  }
+
+  /**
+   * Track the start of a tool execution.
+   */
+  trackToolStart(toolUseId: string, toolName: string, input: Record<string, unknown>): void {
+    this.toolStartTimes.set(toolUseId, Date.now())
+    this.toolInputs.set(toolUseId, input)
+    const signature = getToolAttemptSignature(toolName, input)
+    const repeatedAttemptNumber = (this.signatureExecutionCounts.get(signature) ?? 0) + 1
+    this.signatureExecutionCounts.set(signature, repeatedAttemptNumber)
+    this.toolRepeatedAttemptNumbers.set(toolUseId, repeatedAttemptNumber)
+  }
+
+  /**
+   * Track the completion of a tool execution.
+   */
+  trackToolEnd(
+    toolUseId: string,
+    toolName: string,
+    resultStatus: ReplayToolStep['resultStatus'],
+    resultPreview?: string,
+    filesModified?: string[],
+  ): void {
+    const startTime = this.toolStartTimes.get(toolUseId) ?? Date.now()
+    const durationMs = Date.now() - startTime
+    const input = this.toolInputs.get(toolUseId) ?? {}
+    const repeatedAttemptNumber = this.toolRepeatedAttemptNumbers.get(toolUseId) ?? 1
+
+    this.steps.push({
+      type: 'tool',
+      stepNumber: ++this.stepCounter,
+      toolName,
+      toolUseId,
+      input,
+      inputSummary: summarizeToolInput(toolName, input),
+      resultStatus,
+      resultPreview: resultPreview ? truncate(resultPreview, 200) : undefined,
+      durationMs,
+      timestamp: new Date().toISOString(),
+      filesModified,
+      repeatedAttemptNumber,
+      isRepeatedAttempt: repeatedAttemptNumber > 1,
+    })
+
+    // Cleanup
+    this.toolStartTimes.delete(toolUseId)
+    this.toolInputs.delete(toolUseId)
+    this.toolRepeatedAttemptNumbers.delete(toolUseId)
+  }
+
+  /**
+   * Track a real retry event emitted by the runtime.
+   */
+  trackRetry(
+    retryType: ReplayRetryStep['retryType'],
+    reason: string,
+    timestamp: string,
+    options: {
+      attempt?: number
+      maxRetries?: number
+      retryDelayMs?: number
+      commands?: string[]
+    } = {},
+  ): void {
+    this.steps.push({
+      type: 'retry',
+      stepNumber: ++this.stepCounter,
+      retryType,
+      reason: truncate(reason, 200),
+      timestamp,
+      ...(options.attempt !== undefined && { attempt: options.attempt }),
+      ...(options.maxRetries !== undefined && { maxRetries: options.maxRetries }),
+      ...(options.retryDelayMs !== undefined && {
+        retryDelayMs: options.retryDelayMs,
+      }),
+      ...(options.commands && { commands: options.commands }),
+    })
+  }
+
+  /**
+   * Track an error that occurred during execution.
+   */
+  trackError(error: string): void {
+    this.steps.push({
+      type: 'error',
+      stepNumber: ++this.stepCounter,
+      error,
+      timestamp: new Date().toISOString(),
+    })
+  }
+
+  /**
+   * Build the final ReplayIndex with summary statistics.
+   */
+  build(sessionId: string): ReplayIndex {
+    return {
+      sessionId,
+      version: 1,
+      createdAt: new Date().toISOString(),
+      summary: this.calculateSummary(),
+      steps: this.steps,
+    }
+  }
+
+  /**
+   * Calculate summary statistics from the tracked steps.
+   */
+  private calculateSummary(): ReplaySummary {
+    const toolBreakdown: Record<string, number> = {}
+    const filesModifiedSet = new Set<string>()
+    let durationMs = 0
+    let userRequests = 0
+    let retryAttempts = 0
+    let repeatedAttempts = 0
+
+    for (const step of this.steps) {
+      if (step.type === 'tool') {
+        // Count tools by name
+        toolBreakdown[step.toolName] = (toolBreakdown[step.toolName] ?? 0) + 1
+        
+        // Track modified files
+        if (step.filesModified) {
+          for (const file of step.filesModified) {
+            filesModifiedSet.add(file)
+          }
+        }
+
+        // Sum duration
+        durationMs += step.durationMs
+        if (step.isRepeatedAttempt) {
+          repeatedAttempts++
+        }
+      } else if (step.type === 'user') {
+        userRequests++
+      } else if (step.type === 'retry') {
+        retryAttempts++
+      }
+    }
+
+    const timestamps = this.steps.map(s => s.timestamp).filter(Boolean)
+    const startTimestamp = timestamps[0] ?? this.sessionStart
+    const endTimestamp = timestamps[timestamps.length - 1] ?? new Date().toISOString()
+
+    return {
+      totalSteps: this.steps.length,
+      toolBreakdown,
+      filesModified: Array.from(filesModifiedSet),
+      durationMs,
+      startTimestamp,
+      endTimestamp,
+      userRequests,
+      retryAttempts,
+      repeatedAttempts,
+    }
+  }
+
+  /**
+   * Get current step count (for debugging/status).
+   */
+  get stepCount(): number {
+    return this.stepCounter
+  }
+}

--- a/src/utils/replayIndexBuilder.ts
+++ b/src/utils/replayIndexBuilder.ts
@@ -214,9 +214,17 @@ export class ReplayIndexBuilder {
       }
     }
 
-    const timestamps = this.steps.map(s => s.timestamp).filter(Boolean)
-    const startTimestamp = timestamps[0] ?? this.sessionStart
-    const endTimestamp = timestamps[timestamps.length - 1] ?? new Date().toISOString()
+    const timestampValues = this.steps
+      .map(step => Date.parse(step.timestamp))
+      .filter(timestamp => Number.isFinite(timestamp))
+    const startTimestamp =
+      timestampValues.length > 0
+        ? new Date(Math.min(...timestampValues)).toISOString()
+        : this.sessionStart
+    const endTimestamp =
+      timestampValues.length > 0
+        ? new Date(Math.max(...timestampValues)).toISOString()
+        : new Date().toISOString()
 
     return {
       totalSteps: this.steps.length,

--- a/src/utils/sessionPersistencePolicy.ts
+++ b/src/utils/sessionPersistencePolicy.ts
@@ -1,0 +1,18 @@
+import { isSessionPersistenceDisabled } from '../bootstrap/state.js'
+import { isEnvTruthy } from './envUtils.js'
+import { getSettings_DEPRECATED } from './settings/settings.js'
+
+export function shouldSkipSessionPersistence(): boolean {
+  const allowTestPersistence = isEnvTruthy(
+    process.env.TEST_ENABLE_SESSION_PERSISTENCE,
+  )
+  if (allowTestPersistence) {
+    return false
+  }
+  return (
+    (process.env.NODE_ENV || 'development') === 'test' ||
+    getSettings_DEPRECATED()?.cleanupPeriodDays === 0 ||
+    isSessionPersistenceDisabled() ||
+    isEnvTruthy(process.env.CLAUDE_CODE_SKIP_PROMPT_HISTORY)
+  )
+}

--- a/src/utils/sessionStorage.test.ts
+++ b/src/utils/sessionStorage.test.ts
@@ -32,6 +32,8 @@ import {
   switchSession,
 } from '../bootstrap/state.js'
 import type { GoalState } from '../services/goal/types.js'
+import { setClaudeConfigHomeDirForTesting } from './envUtils.js'
+import { resetSettingsCache } from './settings/settingsCache.js'
 
 const tempDirs: string[] = []
 const sessionId = '00000000-0000-4000-8000-000000000999'
@@ -226,34 +228,43 @@ afterEach(async () => {
 })
 
 test('recordTranscript respects prompt-history opt-out for replay state', async () => {
-  const originalSkipPromptHistory = process.env.CLAUDE_CODE_SKIP_PROMPT_HISTORY
-  process.env.CLAUDE_CODE_SKIP_PROMPT_HISTORY = 'true'
-  resetProjectForTesting()
-  resetAllReplayIndexBuilders()
-
-  try {
-    await recordTranscript([
-      {
-        uuid: id(900),
-        type: 'user',
-        message: {
-          role: 'user',
-          content: 'do not retain this in replay state',
-        },
-        timestamp: ts,
-        isMeta: false,
-      } as never,
-    ])
-
-    expect(resetAllReplayIndexBuilders()).toEqual([])
-  } finally {
-    if (originalSkipPromptHistory === undefined) {
-      delete process.env.CLAUDE_CODE_SKIP_PROMPT_HISTORY
-    } else {
-      process.env.CLAUDE_CODE_SKIP_PROMPT_HISTORY = originalSkipPromptHistory
-    }
+  await withSessionPersistence(async () => {
+    const configDir = await mkdtemp(
+      join(tmpdir(), 'openclaude-session-storage-config-'),
+    )
+    tempDirs.push(configDir)
+    setClaudeConfigHomeDirForTesting(configDir)
+    await writeFile(
+      join(configDir, 'settings.json'),
+      JSON.stringify({ cleanupPeriodDays: 30 }),
+      'utf-8',
+    )
+    resetSettingsCache()
+    process.env.TEST_ENABLE_SESSION_PERSISTENCE = 'false'
+    process.env.CLAUDE_CODE_SKIP_PROMPT_HISTORY = 'true'
     resetProjectForTesting()
-  }
+    resetAllReplayIndexBuilders()
+
+    try {
+      await recordTranscript([
+        {
+          uuid: id(900),
+          type: 'user',
+          message: {
+            role: 'user',
+            content: 'do not retain this in replay state',
+          },
+          timestamp: ts,
+          isMeta: false,
+        } as never,
+      ])
+
+      expect(resetAllReplayIndexBuilders()).toEqual([])
+    } finally {
+      setClaudeConfigHomeDirForTesting(undefined)
+      resetSettingsCache()
+    }
+  })
 })
 
 test('loadTranscriptFile replays a persisted snip boundary, pruning and relinking', async () => {

--- a/src/utils/sessionStorage.test.ts
+++ b/src/utils/sessionStorage.test.ts
@@ -15,6 +15,7 @@ import {
   buildConversationChain,
   loadTranscriptFile,
   recordGoalState,
+  recordTranscript,
   flushSessionStorage,
   resetProjectForTesting,
   resetSessionFilePointer,
@@ -26,6 +27,7 @@ import { createGoalState } from '../services/goal/state.js'
 import {
   getSessionId,
   isSessionPersistenceDisabled,
+  resetAllReplayIndexBuilders,
   setSessionPersistenceDisabled,
   switchSession,
 } from '../bootstrap/state.js'
@@ -216,9 +218,41 @@ beforeEach(async () => {
 
 afterEach(async () => {
   try {
+    resetAllReplayIndexBuilders()
     await Promise.all(tempDirs.splice(0).map(dir => rm(dir, { recursive: true, force: true })))
   } finally {
     releaseSharedMutationLock()
+  }
+})
+
+test('recordTranscript respects prompt-history opt-out for replay state', async () => {
+  const originalSkipPromptHistory = process.env.CLAUDE_CODE_SKIP_PROMPT_HISTORY
+  process.env.CLAUDE_CODE_SKIP_PROMPT_HISTORY = 'true'
+  resetProjectForTesting()
+  resetAllReplayIndexBuilders()
+
+  try {
+    await recordTranscript([
+      {
+        uuid: id(900),
+        type: 'user',
+        message: {
+          role: 'user',
+          content: 'do not retain this in replay state',
+        },
+        timestamp: ts,
+        isMeta: false,
+      } as never,
+    ])
+
+    expect(resetAllReplayIndexBuilders()).toEqual([])
+  } finally {
+    if (originalSkipPromptHistory === undefined) {
+      delete process.env.CLAUDE_CODE_SKIP_PROMPT_HISTORY
+    } else {
+      process.env.CLAUDE_CODE_SKIP_PROMPT_HISTORY = originalSkipPromptHistory
+    }
+    resetProjectForTesting()
   }
 })
 

--- a/src/utils/sessionStorage.ts
+++ b/src/utils/sessionStorage.ts
@@ -25,6 +25,7 @@ import {
   getOriginalCwd,
   getPlanSlugCache,
   getPromptId,
+  getReplayIndexBuilder,
   getSessionId,
   getSessionProjectDir,
   isSessionPersistenceDisabled,
@@ -466,11 +467,43 @@ function getProject(): Project {
         } catch {
           // Best-effort — don't let metadata re-append crash the cleanup
         }
+
+        if (!shouldSkipSessionPersistence()) {
+          // Write replay index if available
+          try {
+            const { resetAllReplayIndexBuilders } = await import('src/bootstrap/state.js')
+            const { writeReplayIndex } = await import('./replayIndex.js')
+            for (const { sessionId, builder, projectDir } of resetAllReplayIndexBuilders()) {
+              const transcriptPath = projectDir
+                ? join(projectDir, `${sessionId}.jsonl`)
+                : getTranscriptPathForSession(sessionId)
+              const index = builder.build(sessionId)
+              await writeReplayIndex(sessionId, transcriptPath, index)
+            }
+          } catch {
+            // Best-effort — don't let replay index writing crash the cleanup
+          }
+        }
       })
       cleanupRegistered = true
     }
   }
   return project
+}
+
+function shouldSkipSessionPersistence(): boolean {
+  const allowTestPersistence = isEnvTruthy(
+    process.env.TEST_ENABLE_SESSION_PERSISTENCE,
+  )
+  if (allowTestPersistence) {
+    return false
+  }
+  return (
+    getNodeEnv() === 'test' ||
+    getSettings_DEPRECATED()?.cleanupPeriodDays === 0 ||
+    isSessionPersistenceDisabled() ||
+    isEnvTruthy(process.env.CLAUDE_CODE_SKIP_PROMPT_HISTORY)
+  )
 }
 
 /**
@@ -977,18 +1010,7 @@ class Project {
    * test sessions don't pollute the user's --resume list.
    */
   private shouldSkipPersistence(): boolean {
-    const allowTestPersistence = isEnvTruthy(
-      process.env.TEST_ENABLE_SESSION_PERSISTENCE,
-    )
-    if (allowTestPersistence) {
-      return false
-    }
-    return (
-      getNodeEnv() === 'test' ||
-      getSettings_DEPRECATED()?.cleanupPeriodDays === 0 ||
-      isSessionPersistenceDisabled() ||
-      isEnvTruthy(process.env.CLAUDE_CODE_SKIP_PROMPT_HISTORY)
-    )
+    return shouldSkipSessionPersistence()
   }
 
   /**
@@ -1085,6 +1107,46 @@ class Project {
           slug,
         }
         await this.appendEntry(transcriptMessage)
+        if (!isSidechain && message.type === 'user') {
+          const content = getFirstMeaningfulUserMessageTextContent([message])
+          if (content) {
+            try {
+              getReplayIndexBuilder().trackUserMessage(
+                content,
+                message.timestamp ?? new Date().toISOString(),
+              )
+            } catch {
+              // Replay tracking is best-effort and must not affect transcript writes.
+            }
+          }
+        }
+        if (!isSidechain && message.type === 'system') {
+          try {
+            if (message.subtype === 'api_error') {
+              getReplayIndexBuilder().trackRetry(
+                'api',
+                message.error.message || `API error ${message.error.status ?? ''}`.trim(),
+                message.timestamp ?? new Date().toISOString(),
+                {
+                  attempt: message.retryAttempt,
+                  maxRetries: message.maxRetries,
+                  retryDelayMs: message.retryInMs,
+                },
+              )
+            } else if (message.subtype === 'permission_retry') {
+              getReplayIndexBuilder().trackRetry(
+                'permission',
+                message.content,
+                message.timestamp ?? new Date().toISOString(),
+                {
+                  commands: message.commands,
+                },
+              )
+            }
+          } catch {
+            // Replay tracking is best-effort and must not affect transcript writes.
+          }
+        }
         if (isChainParticipant(message)) {
           parentUuid = message.uuid
         }

--- a/src/utils/sessionStorage.ts
+++ b/src/utils/sessionStorage.ts
@@ -28,7 +28,6 @@ import {
   getReplayIndexBuilder,
   getSessionId,
   getSessionProjectDir,
-  isSessionPersistenceDisabled,
   switchSession,
 } from '../bootstrap/state.js'
 import { COMMAND_NAME_TAG, TICK_TAG } from '../constants/xml.js'
@@ -90,7 +89,7 @@ import {
   readTranscriptForLoad,
   SKIP_PRECOMPACT_THRESHOLD,
 } from './sessionStoragePortable.js'
-import { getSettings_DEPRECATED } from './settings/settings.js'
+import { shouldSkipSessionPersistence } from './sessionPersistencePolicy.js'
 import { jsonParse, jsonStringify } from './slowOperations.js'
 import type { ContentReplacementRecord } from './toolResultStorage.js'
 import { validateUuid } from './uuid.js'
@@ -468,42 +467,27 @@ function getProject(): Project {
           // Best-effort — don't let metadata re-append crash the cleanup
         }
 
-        if (!shouldSkipSessionPersistence()) {
-          // Write replay index if available
-          try {
-            const { resetAllReplayIndexBuilders } = await import('src/bootstrap/state.js')
+        try {
+          const { resetAllReplayIndexBuilders } = await import('src/bootstrap/state.js')
+          const replayBuilders = resetAllReplayIndexBuilders()
+          if (!shouldSkipSessionPersistence()) {
             const { writeReplayIndex } = await import('./replayIndex.js')
-            for (const { sessionId, builder, projectDir } of resetAllReplayIndexBuilders()) {
+            for (const { sessionId, builder, projectDir } of replayBuilders) {
               const transcriptPath = projectDir
                 ? join(projectDir, `${sessionId}.jsonl`)
                 : getTranscriptPathForSession(sessionId)
               const index = builder.build(sessionId)
               await writeReplayIndex(sessionId, transcriptPath, index)
             }
-          } catch {
-            // Best-effort — don't let replay index writing crash the cleanup
           }
+        } catch {
+          // Best-effort — don't let replay index cleanup crash shutdown
         }
       })
       cleanupRegistered = true
     }
   }
   return project
-}
-
-function shouldSkipSessionPersistence(): boolean {
-  const allowTestPersistence = isEnvTruthy(
-    process.env.TEST_ENABLE_SESSION_PERSISTENCE,
-  )
-  if (allowTestPersistence) {
-    return false
-  }
-  return (
-    getNodeEnv() === 'test' ||
-    getSettings_DEPRECATED()?.cleanupPeriodDays === 0 ||
-    isSessionPersistenceDisabled() ||
-    isEnvTruthy(process.env.CLAUDE_CODE_SKIP_PROMPT_HISTORY)
-  )
 }
 
 /**
@@ -1107,7 +1091,8 @@ class Project {
           slug,
         }
         await this.appendEntry(transcriptMessage)
-        if (!isSidechain && message.type === 'user') {
+        const shouldTrackReplay = !this.shouldSkipPersistence()
+        if (shouldTrackReplay && !isSidechain && message.type === 'user') {
           const content = getFirstMeaningfulUserMessageTextContent([message])
           if (content) {
             try {
@@ -1120,7 +1105,7 @@ class Project {
             }
           }
         }
-        if (!isSidechain && message.type === 'system') {
+        if (shouldTrackReplay && !isSidechain && message.type === 'system') {
           try {
             if (message.subtype === 'api_error') {
               getReplayIndexBuilder().trackRetry(


### PR DESCRIPTION
## Summary
- Add a `/replay` command that loads replay sidecar indexes and shows a session timeline with user requests, tool calls, tool results, modified files, durations, retry events, and repeated attempts.
- Persist replay indexes beside transcripts during session cleanup, keep replay builders isolated per session, and include replay sidecars in retention cleanup.
- Add replay summaries to `/resume` so users can inspect session stats before resuming.
- Add focused tests for replay retry/repeated-attempt accounting, replay sidecar storage, replay duration formatting, cancellation status, and replay modified-file detection including simulated Bash sed edits.

Fixes #1694

## User impact
Users can inspect how an agent session unfolded after the fact, including which tools were selected, what happened, which files were touched, how long steps took, and where retries or repeated attempts occurred. This should make debugging agent behavior and comparing workflows easier without changing normal tool execution behavior.

## Risk surface
Replay indexes are local sidecar files written beside existing transcripts and follow the same session-persistence opt-out path via `shouldSkipSessionPersistence()`. They may contain tool input objects similar to transcript data, so they are written with owner-only file mode (`0o600`) and are included in the existing age-based session cleanup path as `.replay.json` files. This change does not add telemetry, network upload, permission-policy changes, or trust-model changes.

## Validation
- `bun install` passed unsandboxed with no dependency changes.
- `bun run build` passed.
- `bun run smoke` passed unsandboxed after sandbox-only `node_modules` EPERM.
- `bun run typecheck` passed.
- `bun run typecheck:type-tests` passed.
- `bun run security:pr-scan` passed exit 0; reported 8 medium findings from existing branch diff content under `scripts/system-check*`, no high findings.
- `bun run doctor:runtime` passed unsandboxed.
- `bun test src/utils/replayFormat.test.ts src/utils/replayIndexBuilder.test.ts src/utils/replayIndex.test.ts src/commands/resume/resume.test.tsx src/services/tools/toolExecution.test.ts` passed.

`bun run check` reached `bun run test:full` but the full suite still reported 10 unrelated order/environment-sensitive failures in `/export`, marketplace cache, and secure-storage tests. Those same failing test files passed when rerun directly, including `/export` with a dummy local `ANTHROPIC_API_KEY`.

## Screenshots
Not captured. This is a terminal UI feature and the draft currently includes build/typecheck plus focused replay coverage; happy to add screenshots before marking ready for review.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a **replay** command with an interactive step timeline (last-20 truncation with “show all,” keyboard navigation, tool previews, modified files, and retry details).
  * Added **Session Summary** UI and optional **resume confirmation** that uses available replay summary for UUID and title-based resume flows.

* **Bug Fixes**
  * Improved replay indexing robustness so tool execution isn’t impacted if replay tracking fails.

* **Bug Fixes**
  * Cleanup now also removes aged **`.replay.json`** sidecars.

* **Tests**
  * Expanded replay indexing, persistence, tool replay tracking, and resume/replay UI coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->