### PR TITLE
test(install-surfaces): stop execFileNoThrow mock leaking into later suites

### DIFF
--- a/src/utils/openclaudeInstallSurfaces.test.ts
+++ b/src/utils/openclaudeInstallSurfaces.test.ts
@@ -13,6 +13,33 @@ import * as realExecFileNoThrow from './execFileNoThrow.js'
 const originalEnv = { ...process.env }
 const originalMacro = (globalThis as Record<string, unknown>).MACRO
 
+// Snapshot the real execFileNoThrow module BEFORE installing the mock below.
+// bun live-updates the `realExecFileNoThrow` namespace to point at the mock once
+// mock.module runs, so delegating through the namespace inside the override
+// would call the override itself and recurse infinitely. A plain-object copy
+// taken now captures the genuine implementations.
+const realExecFileNoThrowModule = { ...realExecFileNoThrow }
+
+// The `cleanupNpmInstallations` test needs execFileNoThrowWithCwd to simulate a
+// failed `npm uninstall` (E404). bun's mock.module is process-wide and
+// re-mocking the module back to the real implementation in afterEach does NOT
+// reliably undo it, so a naive `mock.module(...)` set inside the test can leak
+// into later test files that shell out for real (e.g. `git worktree add`),
+// making them fail with a bogus "npm ERR! code E404". Install the override once
+// at module load and gate it on this flag so the persisted mock transparently
+// falls through to the real implementation whenever the flag is off.
+let simulateNpmUninstallFailure = false
+
+mock.module('./execFileNoThrow.js', () => ({
+  ...realExecFileNoThrowModule,
+  execFileNoThrowWithCwd: (
+    ...args: Parameters<typeof realExecFileNoThrow.execFileNoThrowWithCwd>
+  ) =>
+    simulateNpmUninstallFailure
+      ? Promise.resolve({ stdout: '', stderr: 'npm ERR! code E404', code: 1 })
+      : realExecFileNoThrowModule.execFileNoThrowWithCwd(...args),
+}))
+
 beforeEach(async () => {
   await acquireSharedMutationLock('utils/openclaudeInstallSurfaces.test.ts')
 })
@@ -25,10 +52,10 @@ afterEach(() => {
     } else {
       ;(globalThis as Record<string, unknown>).MACRO = originalMacro
     }
+    simulateNpmUninstallFailure = false
     mock.restore()
     mock.module('../utils/env.js', () => realEnv)
     mock.module('./envUtils.js', () => realEnvUtils)
-    mock.module('./execFileNoThrow.js', () => realExecFileNoThrow)
   } finally {
     releaseSharedMutationLock()
   }
@@ -85,13 +112,7 @@ test('cleanupNpmInstallations removes both openclaude and legacy claude local in
     },
   }))
 
-  mock.module('./execFileNoThrow.js', () => ({
-    ...realExecFileNoThrow,
-    execFileNoThrowWithCwd: async () => ({
-      code: 1,
-      stderr: 'npm ERR! code E404',
-    }),
-  }))
+  simulateNpmUninstallFailure = true
 
   mock.module('./envUtils.js', () => ({
     ...realEnvUtils,


### PR DESCRIPTION
## Problem

`smoke-and-tests` fails intermittently with a worktree creation error whose stderr is `npm ERR! code E404`:

```
error: Failed to create worktree: npm ERR! code E404
      at src/utils/worktree.ts:400
      at async withGitWorktreeMutationLock (src/utils/worktree.ts:212)
```

`git worktree add` does not emit npm output. The string comes from `src/utils/openclaudeInstallSurfaces.test.ts`, where the `cleanupNpmInstallations` test replaces `execFileNoThrowWithCwd` with a stub returning `stderr: 'npm ERR! code E404'` to simulate a failed `npm uninstall`.

`bun`'s `mock.module` is process-wide and runs test files sequentially in one process. Re-mocking the module back to the real implementation in `afterEach` does **not** reliably undo a `mock.module` override, so the stub leaks into later files that shell out for real — here `worktree.ts` calling `git worktree add` through the same `execFileNoThrowWithCwd`. The leak is order-dependent, which is why it surfaces only in the full CI run and not when the file is run alone.

This is the same leak class fixed in #1667 for the `cross-spawn` mock.

## Fix

Install the `execFileNoThrow` override **once** at module load and gate the stub on a module-level flag (`simulateNpmUninstallFailure`) that is cleared in `afterEach`. When the flag is off, the persisted mock transparently delegates to the real `execFileNoThrowWithCwd`, so nothing leaks into later suites.

## Validation

- `bun test src/utils/openclaudeInstallSurfaces.test.ts` — 3 pass
- `bun test src/utils/openclaudeInstallSurfaces.test.ts src/utils/worktree.agentBase.test.ts` — 4 pass (no leak)
- `tsc --noEmit` clean

No production code changed — test isolation only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved test reliability by strengthening mock setup and cleanup to prevent leakage between test runs.
  * Added a controlled way to simulate an `npm uninstall` E404 failure scenario, while avoiding unintended recursive behavior during mocking.
  * Streamlined failure simulation so tests can toggle the scenario without re-mocking core execution behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->