### PR TITLE
fix(model): preserve [1m] tag for the codex aliases

### DIFF
--- a/src/utils/model/model.ts
+++ b/src/utils/model/model.ts
@@ -765,12 +765,16 @@ export function parseUserSpecifiedModel(
     }
   }
 
-  // Handle Codex aliases - map to actual model names
+  // Handle Codex aliases - map to actual model names. Preserve the [1m] tag the
+  // same way the Claude aliases above do: it is an explicit client-side opt-in
+  // to the 1M context window (see has1mContext), so dropping it here would
+  // silently shrink a `codexplan[1m]`/`codexspark[1m]` session back to the
+  // model default.
   if (modelString === 'codexplan') {
-    return 'gpt-5.5'
+    return 'gpt-5.5' + (has1mTag ? '[1m]' : '')
   }
   if (modelString === 'codexspark') {
-    return 'gpt-5.3-codex-spark'
+    return 'gpt-5.3-codex-spark' + (has1mTag ? '[1m]' : '')
   }
 
   // Opus 4/4.1 are no longer available on the first-party API (same as

--- a/src/utils/model/parseUserSpecifiedModel.codexTag.test.ts
+++ b/src/utils/model/parseUserSpecifiedModel.codexTag.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, test } from 'bun:test'
+import { has1mContext } from '../context.js'
+import { parseUserSpecifiedModel } from './model.js'
+
+// Regression: the Codex aliases (codexplan/codexspark) dropped the `[1m]`
+// (1M-context) tag while every Claude alias (opus/sonnet/haiku/best) preserved
+// it. The `[1m]` suffix is an explicit client-side opt-in to the 1M context
+// window (see has1mContext), so dropping it silently shrinks a
+// `codexplan[1m]`/`codexspark[1m]` session back to the model default. The base
+// mapping (no tag) must stay unchanged. Assertions are relational so they don't
+// pin a specific gpt model id.
+describe('parseUserSpecifiedModel — codex alias 1M tag', () => {
+  test('codexplan[1m] keeps the [1m] tag on top of the base mapping', () => {
+    const base = parseUserSpecifiedModel('codexplan')
+    const tagged = parseUserSpecifiedModel('codexplan[1m]')
+
+    expect(tagged).toBe(`${base}[1m]`)
+    expect(has1mContext(tagged)).toBe(true)
+  })
+
+  test('codexspark[1m] keeps the [1m] tag on top of the base mapping', () => {
+    const base = parseUserSpecifiedModel('codexspark')
+    const tagged = parseUserSpecifiedModel('codexspark[1m]')
+
+    expect(tagged).toBe(`${base}[1m]`)
+    expect(has1mContext(tagged)).toBe(true)
+  })
+
+  test('the bare codex aliases are unchanged and carry no 1M tag', () => {
+    expect(parseUserSpecifiedModel('codexplan')).toBe('gpt-5.5')
+    expect(parseUserSpecifiedModel('codexspark')).toBe('gpt-5.3-codex-spark')
+    expect(has1mContext(parseUserSpecifiedModel('codexplan'))).toBe(false)
+    expect(has1mContext(parseUserSpecifiedModel('codexspark'))).toBe(false)
+  })
+
+  test('the tag is case-insensitive and not duplicated', () => {
+    const tagged = parseUserSpecifiedModel('codexplan[1m]')
+    expect(parseUserSpecifiedModel('CODEXPLAN[1M]')).toBe(tagged)
+    expect(tagged.match(/\[1m]/gi)?.length).toBe(1)
+  })
+})


### PR DESCRIPTION
## Problem

`parseUserSpecifiedModel` maps the Codex aliases to their gpt ids but drops the trailing `[1m]` tag, unlike every Claude alias:

```ts
case 'best':
  return getBestModel() + (has1mTag ? '[1m]' : '')   // tag preserved
...
if (modelString === 'codexplan') {
  return 'gpt-5.5'                                    // tag dropped
}
if (modelString === 'codexspark') {
  return 'gpt-5.3-codex-spark'                        // tag dropped
}
```

The `[1m]` suffix is an explicit client-side opt-in to the 1M context window — `has1mContext` reports 1M whenever it is present, regardless of model family (`src/utils/context.ts`):

```ts
// [1m] suffix — explicit client-side opt-in, respected over all detection
if (has1mContext(model)) {
  return 1_000_000
}
```

So `codexplan[1m]` / `codexspark[1m]` silently resolve to a non-1M model and the session falls back to the model default window instead of the 1M the user asked for.

Observed:

```
codexplan[1m]   -> gpt-5.5               has1m=false   (tag lost)
codexspark[1m]  -> gpt-5.3-codex-spark   has1m=false   (tag lost)
best[1m]        -> claude-opus-4-7[1m]   has1m=true    (correct)
opus[1m]        -> claude-opus-4-7[1m]   has1m=true    (correct)
```

## Fix

Append the `[1m]` tag on the Codex alias returns the same way the Claude aliases do. The bare aliases are unchanged.

## Validation

- New `parseUserSpecifiedModel.codexTag.test.ts` — 4 pass; 3 fail on the unpatched mapping (the bare-alias test passes both ways).
- `tsc --noEmit` clean.

Sibling to the `best`-alias tag fix (#1671).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed model alias handling to ensure expanded context options are properly preserved when selected.

* **Tests**
  * Added test coverage for model alias context window functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->