### PR TITLE
fix(code-indexing): guard command detection against prototype-chain names

### DIFF
--- a/src/utils/codeIndexing.proto.test.ts
+++ b/src/utils/codeIndexing.proto.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, test } from 'bun:test'
+import { detectCodeIndexingFromCommand } from './codeIndexing.js'
+
+// Regression: CLI_COMMAND_MAPPING was a plain object, so a command whose first
+// word collided with an inherited Object.prototype member (`constructor`,
+// `__proto__`) resolved to the prototype value instead of `undefined`. The bare
+// lookup `CLI_COMMAND_MAPPING[firstWord]` then returned the `Object` constructor
+// function, and the npx/bunx branch used `in` (which walks the prototype chain),
+// both falsely reporting a code-indexing tool and emitting a bogus telemetry
+// event with a function as the `tool` field.
+describe('detectCodeIndexingFromCommand — prototype-chain command names', () => {
+  test('inherited Object.prototype member names do not resolve to a tool', () => {
+    for (const name of ['constructor', '__proto__', 'toString', 'valueOf']) {
+      expect(detectCodeIndexingFromCommand(name)).toBeUndefined()
+      expect(detectCodeIndexingFromCommand(`${name} search "x"`)).toBeUndefined()
+    }
+  })
+
+  test('npx/bunx with a prototype-chain second word does not resolve', () => {
+    expect(detectCodeIndexingFromCommand('npx constructor')).toBeUndefined()
+    expect(detectCodeIndexingFromCommand('bunx __proto__ run')).toBeUndefined()
+  })
+
+  test('real mappings still resolve', () => {
+    expect(detectCodeIndexingFromCommand('src search "pattern"')).toBe(
+      'sourcegraph',
+    )
+    expect(detectCodeIndexingFromCommand('cody chat')).toBe('cody')
+    expect(detectCodeIndexingFromCommand('q chat')).toBe('amazon-q')
+    expect(detectCodeIndexingFromCommand('npx aider')).toBe('aider')
+  })
+
+  test('unknown commands return undefined', () => {
+    expect(detectCodeIndexingFromCommand('ls -la')).toBeUndefined()
+    expect(detectCodeIndexingFromCommand('')).toBeUndefined()
+  })
+})

--- a/src/utils/codeIndexing.ts
+++ b/src/utils/codeIndexing.ts
@@ -43,28 +43,34 @@ export type CodeIndexingTool =
 /**
  * Mapping of CLI command prefixes to code indexing tools.
  * The key is the command name (first word of the command).
+ *
+ * A Map (rather than a plain object) is used so that a command whose first word
+ * collides with an inherited Object.prototype member — e.g. `constructor` or
+ * `__proto__` — looks up to `undefined` instead of the prototype value. A plain
+ * object would return the `Object` constructor for `constructor`, falsely
+ * reporting a code-indexing tool.
  */
-const CLI_COMMAND_MAPPING: Record<string, CodeIndexingTool> = {
+const CLI_COMMAND_MAPPING: ReadonlyMap<string, CodeIndexingTool> = new Map([
   // Sourcegraph ecosystem
-  src: 'sourcegraph',
-  cody: 'cody',
+  ['src', 'sourcegraph'],
+  ['cody', 'cody'],
   // AI coding assistants
-  aider: 'aider',
-  tabby: 'tabby',
-  tabnine: 'tabnine',
-  augment: 'augment',
-  pieces: 'pieces',
-  qodo: 'qodo',
-  aide: 'aide',
+  ['aider', 'aider'],
+  ['tabby', 'tabby'],
+  ['tabnine', 'tabnine'],
+  ['augment', 'augment'],
+  ['pieces', 'pieces'],
+  ['qodo', 'qodo'],
+  ['aide', 'aide'],
   // Code search tools
-  hound: 'hound',
-  seagoat: 'seagoat',
-  bloop: 'bloop',
-  gitloop: 'gitloop',
+  ['hound', 'hound'],
+  ['seagoat', 'seagoat'],
+  ['bloop', 'bloop'],
+  ['gitloop', 'gitloop'],
   // Cloud provider AI assistants
-  q: 'amazon-q',
-  gemini: 'gemini',
-}
+  ['q', 'amazon-q'],
+  ['gemini', 'gemini'],
+])
 
 /**
  * Mapping of MCP server name patterns to code indexing tools.
@@ -137,12 +143,13 @@ export function detectCodeIndexingFromCommand(
   // Check for npx/bunx prefixed commands
   if (firstWord === 'npx' || firstWord === 'bunx') {
     const secondWord = trimmed.split(/\s+/)[1]?.toLowerCase()
-    if (secondWord && secondWord in CLI_COMMAND_MAPPING) {
-      return CLI_COMMAND_MAPPING[secondWord]
+    const secondTool = secondWord && CLI_COMMAND_MAPPING.get(secondWord)
+    if (secondTool) {
+      return secondTool
     }
   }
 
-  return CLI_COMMAND_MAPPING[firstWord]
+  return CLI_COMMAND_MAPPING.get(firstWord)
 }
 
 /**


### PR DESCRIPTION
## Problem

`detectCodeIndexingFromCommand` resolves a command's first word against `CLI_COMMAND_MAPPING`, a plain object. Plain-object lookups expose `Object.prototype` members, so a command whose first word collides with an inherited member resolves to the prototype value instead of `undefined`:

```ts
if (secondWord && secondWord in CLI_COMMAND_MAPPING) {   // `in` walks the prototype chain
  return CLI_COMMAND_MAPPING[secondWord]
}
return CLI_COMMAND_MAPPING[firstWord]                     // bare lookup, no own-key guard
```

Observed (before fix):

```
detectCodeIndexingFromCommand('constructor')      -> function Object() { [native code] }
detectCodeIndexingFromCommand('npx constructor')  -> function Object() { [native code] }
```

(`__proto__` behaves the same; camelCase members like `toString` happen to escape only because the input is lower-cased first.)

The single consumer treats the result as truthy and forwards it to telemetry (`src/tools/BashTool/BashTool.tsx`):

```ts
const codeIndexingTool = detectCodeIndexingFromCommand(input.command);
if (codeIndexingTool) {
  logEvent('tengu_code_indexing_tool_used', {
    tool: codeIndexingTool as AnalyticsMetadata_I_VERIFIED_THIS_IS_NOT_CODE_OR_FILEPATHS,
    ...
  });
}
```

So running a bash command beginning with `constructor` (or `__proto__`) falsely reports a code-indexing tool and emits a bogus `tengu_code_indexing_tool_used` event whose `tool` field is a JS function — exactly what the `_I_VERIFIED_THIS_IS_NOT_CODE_OR_FILEPATHS` cast claims it is not.

## Fix

Switch `CLI_COMMAND_MAPPING` to a `Map` and look up via `.get()`. Maps don't carry `Object.prototype`, so unknown and inherited keys both return `undefined`. Same hardening as the diff language-detection lookup.

## Validation

- New `codeIndexing.proto.test.ts` — 4 pass; the two prototype-chain cases fail on the unpatched code; real mappings (`src`, `cody`, `q`, `npx aider`) and unknown commands keep working.
- `tsc --noEmit` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for CLI command detection to ensure correct behavior across various input patterns.

* **Refactor**
  * Improved the internal implementation of command detection for enhanced performance and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->