### PR TITLE
fix(continuation): detect non-Claude continuation intent; scope completion guard to final sentence

### DIFF
--- a/src/__tests__/bugfixes.test.ts
+++ b/src/__tests__/bugfixes.test.ts
@@ -135,6 +135,27 @@ describe('Agent loop continuation nudge', () => {
     expect(analyzeContinuationIntent("Here is the code:\n```typescript\nfunction test() {").shouldNudge).toBe(true)
   })
 
+  test('non-Claude continuation verbs and mid-text completion markers (issue #1707)', async () => {
+    const { analyzeContinuationIntent } = await import('../utils/continuation.js')
+
+    // Mid-text completion marker must NOT suppress a later continuation intent.
+    // The completion-marker guard now only inspects the final sentence.
+    expect(analyzeContinuationIntent("The download is complete. Now I will install the dependencies").shouldNudge).toBe(true)
+    expect(analyzeContinuationIntent("Step one finished. I will now deploy the service").shouldNudge).toBe(true)
+
+    // Action verbs common to non-Claude models, gated behind intent framing.
+    expect(analyzeContinuationIntent("Let me compile the project").shouldNudge).toBe(true)
+    expect(analyzeContinuationIntent("I will now train the model").shouldNudge).toBe(true)
+
+    // Unpunctuated present-progressive action reads as in-progress work.
+    expect(analyzeContinuationIntent("Now downloading the dataset").shouldNudge).toBe(true)
+
+    // A genuinely completed message whose LAST sentence is a completion marker
+    // must still be suppressed, even if an action gerund appears earlier.
+    expect(analyzeContinuationIntent("Finished installing the packages. All set.").shouldNudge).toBe(false)
+    expect(analyzeContinuationIntent("Downloaded the files and the migration is complete.").shouldNudge).toBe(false)
+  })
+
   test('nudge creates a meta user message to continue', async () => {
     const content = await file('query.ts').text()
 

--- a/src/utils/continuation.ts
+++ b/src/utils/continuation.ts
@@ -13,6 +13,15 @@ export const CONTINUATION_SIGNALS = [
   /\blet me (go ahead and |now )?(do|create|write|edit|update|fix|implement|add|run|check|make|build|set up|proceed|start|begin|apply|update|create|identify|inspect|analyze|review|search|summarize)\b/i,
   /\btime to (do|create|write|edit|update|fix|implement|add|run|check|make|build|get started|begin|start|inspect|analyze|review|search)\b/i,
   /\b(moving on to|next step is to|starting to|proceeding to|applying (the|these) changes|inspecting|analyzing|reviewing|searching)\b/i,
+  // English: Action verbs common to non-Claude models, gated behind explicit
+  // first-person intent framing so they only fire as a continuation signal
+  // (e.g. "I will now deploy the service", "Let me install the deps").
+  /\b(i (will|'ll|shall|need to|have to|must|should|am going to|am about to)( now)?|let me( now)?|now i('ll| will)?)\s+(process|download|upload|compile|train|evaluate|extract|merge|deploy|install|configure|optimize|refactor|generate|fetch|validate|parse|scan|test)\b/i,
+  // English: Present-progressive action statements signal in-progress work.
+  // These intentionally do NOT override terminal punctuation downstream, so a
+  // punctuated completion ("Finished installing.") is still caught by the
+  // completion-marker guard; only an unpunctuated/truncated action nudges.
+  /\b(processing|downloading|uploading|compiling|training|evaluating|extracting|merging|deploying|installing|configuring|optimizing|refactoring|generating|fetching|validating|parsing|scanning)\b/i,
   // French: Support for common continuation phrasing (relaxed boundaries for accents and apostrophes)
   /(^|\s)(je passe (à|au)|ensuite|l'étape suivante est de|je continue avec|au suivant|passons à|je reviens vers vous|je suis en train d'|je vais maintenant)(\s|$|[a-zà-ÿ])/i,
   /(^|\s)(je (vais|dois|dois maintenant|vais maintenant) (faire|créer|écrire|modifier|ajouter|tester|vérifier|lancer|exécuter|procéder|démarrer|commencer|identifier|analyser|inspecter|revoir|chercher))(\s|$|[a-zà-ÿ])/i,
@@ -111,7 +120,12 @@ export function analyzeContinuationIntent(
   }
 
   // 3. Completion Marker Guard (Final check for sound, completed messages)
-  if (COMPLETION_MARKERS.test(lowerText)) {
+  // Only treat a completion marker as terminal when it appears in the LAST
+  // sentence. A marker buried mid-text ("The download is complete. Now
+  // installing the deps") must not suppress a later continuation intent —
+  // this is the common failure mode for non-Claude models (#1707).
+  const lastSentence = lowerText.split(/(?<=[.!?])\s+/).pop() ?? lowerText
+  if (COMPLETION_MARKERS.test(lastSentence)) {
     return { shouldNudge: false }
   }
 


### PR DESCRIPTION
Closes #1707.

### Problem

`analyzeContinuationIntent` (`src/utils/continuation.ts`) is biased toward Claude-style output, so non-Claude models (OpenAI/Gemini/local) frequently stop after a turn instead of continuing. Two concrete causes:

1. **Completion marker matched anywhere.** The `COMPLETION_MARKERS` guard tested the entire response, so a marker buried mid-text — e.g. `The download is complete. Now installing the deps` — suppressed an obvious later continuation intent.
2. **Continuation verb list too narrow.** Common non-Claude verbs (process, download, compile, deploy, install, train, refactor, …) were absent, so the model's continuation intent went undetected.

### Fix

- **Scope the completion guard to the final sentence.** A genuinely completed last sentence is still suppressed; a marker earlier in the message no longer is. This can only *reduce* false suppression — a sound, completed message still falls through to `shouldNudge: false`.
- **Add the missing action verbs**, gated behind explicit first-person intent framing (`I will … deploy`, `Let me … install`, `Now I'll … compile`) so they only fire as a continuation signal, plus present-progressive action statements (`Now downloading the dataset`) for the unpunctuated/truncated case. These do **not** override terminal punctuation, so a punctuated completion like `Finished installing.` stays suppressed by the marker guard.

### Out of scope (deliberately)

The issue also suggests raising `MAX_CONTINUATION_NUDGES` (3 → 20) and inverting the default `shouldNudge` to `true`. Those are product/tuning decisions with broader blast radius, so they're left for a maintainer call rather than bundled here.

### Tests

Extended `src/__tests__/bugfixes.test.ts` with mid-text-marker, intent-gated-verb, gerund, and still-suppressed-completion cases. Full file: 32 pass / 0 fail. `tsc --noEmit` clean; `bun run smoke` green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of user intent to continue working on tasks. The system now recognizes additional natural language patterns indicating ongoing work.
  * Fixed completion marker detection to only consider the final sentence, preventing mid-text completion phrases from incorrectly blocking continuation recognition.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->