### PR TITLE
fix: guard convertToLogOption against empty transcript

### DIFF
--- a/src/utils/sessionStorage.test.ts
+++ b/src/utils/sessionStorage.test.ts
@@ -16,6 +16,7 @@ import {
   getProjectDir,
   loadSameRepoMessageLogsProgressive,
   loadTranscriptFile,
+  loadTranscriptFromFile,
   recordGoalState,
   recordTranscript,
   flushSessionStorage,
@@ -876,4 +877,15 @@ test('loadSameRepoMessageLogsProgressive ignores branch metadata outside lite re
     setClaudeConfigHomeDirForTesting(undefined)
     getClaudeConfigHomeDir.cache?.clear?.()
   }
+})
+
+test('convertToLogOption throws for empty transcript', async () => {
+  const dir = await mkdtemp(join(tmpdir(), 'openclaude-session-storage-'))
+  tempDirs.push(dir)
+  const filePath = join(dir, 'session.json')
+  await writeFile(filePath, '[]')
+
+  await expect(loadTranscriptFromFile(filePath)).rejects.toThrow(
+    'convertToLogOption: cannot convert empty transcript',
+  )
 })

--- a/src/utils/sessionStorage.ts
+++ b/src/utils/sessionStorage.ts
@@ -2854,6 +2854,9 @@ function convertToLogOption(
   agentSetting?: string,
   contentReplacements?: ContentReplacementRecord[],
 ): LogOption {
+  if (transcript.length === 0) {
+    throw new Error('convertToLogOption: cannot convert empty transcript')
+  }
   const lastMessage = transcript.at(-1)!
   const firstMessage = transcript[0]!
 


### PR DESCRIPTION
## Summary

`convertToLogOption` in `src/utils/sessionStorage.ts` accesses `transcript.at(-1)!` and `transcript[0]!` without first checking that the transcript is non-empty. When `loadTranscriptFromFile` is called on a session file that contains `[]` (empty array), both indexed accesses return `undefined` and the non-null assertion throws a cryptic `TypeError: cannot read properties of undefined`.

## Root cause

`loadTranscriptFromFile` -> `convertToLogOption` is called for every resumed or adopted session file. If the file was written out as `[]` (e.g. an interrupted session that never recorded a message), the function crashes inside the indexing expression rather than producing a clear error.

## Fix

Add an explicit empty-array guard at the top of `convertToLogOption` that throws a descriptive error:

```ts
if (transcript.length === 0) {
  throw new Error('convertToLogOption: cannot convert empty transcript')
}
```

## Impact

Long-running sessions and session-resume paths now fail with an actionable message instead of a stack trace rooted in `undefined` property access. Callers can catch the error and present a clear "session file is empty" message.

## Test plan

- [x] Added regression test in `src/utils/sessionStorage.test.ts` asserting that loading a file containing `[]` rejects with `convertToLogOption: cannot convert empty transcript`
- [x] `bun run build` - covered by `bun run smoke` locally and by the passing `smoke-and-tests` CI job
- [x] `bun run smoke` - passed locally
- [x] `bun run check` - passed in the current `smoke-and-tests` CI job
- [x] `bun run typecheck` - passed locally and in the current `typecheck` CI job
