### PR TITLE
fix(permissions): bound the speculativeChecks cache with FIFO eviction

### DIFF
--- a/src/tools/BashTool/bashPermissions.test.ts
+++ b/src/tools/BashTool/bashPermissions.test.ts
@@ -7,8 +7,12 @@ import {
 } from '../../test/sharedMutationLock.js'
 import { SandboxManager } from '../../utils/sandbox/sandbox-adapter.js'
 import {
+  _test,
   bashToolHasPermission,
   checkSandboxAutoAllow,
+  clearSpeculativeChecks,
+  consumeSpeculativeClassifierCheck,
+  peekSpeculativeClassifierCheck,
   stripAllLeadingEnvVars,
 } from './bashPermissions.js'
 
@@ -206,5 +210,110 @@ describe('stripAllLeadingEnvVars — SEC-02 subscript expansion guard', () => {
 
   test('still strips a safe identifier array subscript', () => {
     expect(stripAllLeadingEnvVars('ARR[idx]=x ls')).toBe('ls')
+  })
+})
+
+describe('speculative cache eviction', () => {
+  beforeEach(() => {
+    clearSpeculativeChecks()
+  })
+
+  test('evictSpeculativeChecks removes oldest entries when over cap', () => {
+    const { speculativeChecks, evictSpeculativeChecks, MAX_SPECULATIVE_CHECKS_SIZE } = _test
+
+    // Fill just under the cap
+    for (let i = 0; i < MAX_SPECULATIVE_CHECKS_SIZE; i++) {
+      speculativeChecks.set(`cmd-${i}`, Promise.resolve('allow' as never))
+    }
+    expect(speculativeChecks.size).toBe(MAX_SPECULATIVE_CHECKS_SIZE)
+
+    // Add one more and evict
+    speculativeChecks.set('overflow', Promise.resolve('allow' as never))
+    evictSpeculativeChecks()
+    expect(speculativeChecks.size).toBe(MAX_SPECULATIVE_CHECKS_SIZE)
+    expect(speculativeChecks.has('cmd-0')).toBe(false)
+    expect(speculativeChecks.has('overflow')).toBe(true)
+  })
+
+  test('FIFO eviction removes entries in insertion order', () => {
+    const { speculativeChecks, evictSpeculativeChecks, MAX_SPECULATIVE_CHECKS_SIZE } = _test
+
+    for (let i = 0; i < MAX_SPECULATIVE_CHECKS_SIZE; i++) {
+      speculativeChecks.set(`cmd-${i}`, Promise.resolve('allow' as never))
+    }
+
+    // Add 3 more - should evict cmd-0, cmd-1, cmd-2
+    speculativeChecks.set('extra-1', Promise.resolve('allow' as never))
+    speculativeChecks.set('extra-2', Promise.resolve('allow' as never))
+    speculativeChecks.set('extra-3', Promise.resolve('allow' as never))
+    evictSpeculativeChecks()
+
+    expect(speculativeChecks.has('cmd-0')).toBe(false)
+    expect(speculativeChecks.has('cmd-1')).toBe(false)
+    expect(speculativeChecks.has('cmd-2')).toBe(false)
+    expect(speculativeChecks.has('cmd-3')).toBe(true)
+    expect(speculativeChecks.has('cmd-999')).toBe(true)
+    expect(speculativeChecks.has('extra-1')).toBe(true)
+    expect(speculativeChecks.has('extra-2')).toBe(true)
+    expect(speculativeChecks.has('extra-3')).toBe(true)
+  })
+
+  test('peek and consume return undefined for evicted entries', () => {
+    const { speculativeChecks, evictSpeculativeChecks, MAX_SPECULATIVE_CHECKS_SIZE } = _test
+
+    for (let i = 0; i < MAX_SPECULATIVE_CHECKS_SIZE; i++) {
+      speculativeChecks.set(`cmd-${i}`, Promise.resolve('allow' as never))
+    }
+
+    speculativeChecks.set('survivor', Promise.resolve('allow' as never))
+    evictSpeculativeChecks()
+
+    expect(peekSpeculativeClassifierCheck('cmd-0')).toBeUndefined()
+    expect(consumeSpeculativeClassifierCheck('cmd-0')).toBeUndefined()
+    expect(peekSpeculativeClassifierCheck('survivor')).toBeDefined()
+  })
+
+  test('eviction handles exact boundary without removing entries', () => {
+    const { speculativeChecks, evictSpeculativeChecks, MAX_SPECULATIVE_CHECKS_SIZE } = _test
+
+    for (let i = 0; i < MAX_SPECULATIVE_CHECKS_SIZE; i++) {
+      speculativeChecks.set(`cmd-${i}`, Promise.resolve('allow' as never))
+    }
+
+    evictSpeculativeChecks()
+    expect(speculativeChecks.size).toBe(MAX_SPECULATIVE_CHECKS_SIZE)
+    expect(speculativeChecks.has('cmd-0')).toBe(true)
+    expect(speculativeChecks.has('cmd-999')).toBe(true)
+  })
+
+  test('empty map survives eviction without error', () => {
+    const { evictSpeculativeChecks } = _test
+    expect(() => evictSpeculativeChecks()).not.toThrow()
+  })
+
+  test('peeking and consuming still works at boundary conditions', () => {
+    const { speculativeChecks, evictSpeculativeChecks, MAX_SPECULATIVE_CHECKS_SIZE } = _test
+
+    for (let i = 0; i < MAX_SPECULATIVE_CHECKS_SIZE; i++) {
+      speculativeChecks.set(`cmd-${i}`, Promise.resolve('allow' as never))
+    }
+
+    expect(peekSpeculativeClassifierCheck('cmd-0')).toBeDefined()
+    expect(peekSpeculativeClassifierCheck(`cmd-${MAX_SPECULATIVE_CHECKS_SIZE - 1}`)).toBeDefined()
+
+    speculativeChecks.set('overflow', Promise.resolve('allow' as never))
+    evictSpeculativeChecks()
+
+    expect(peekSpeculativeClassifierCheck('cmd-0')).toBeUndefined()
+    expect(peekSpeculativeClassifierCheck('cmd-1')).toBeDefined()
+    expect(peekSpeculativeClassifierCheck('overflow')).toBeDefined()
+
+    const consumed1 = consumeSpeculativeClassifierCheck('cmd-1')
+    expect(consumed1).toBeDefined()
+    expect(peekSpeculativeClassifierCheck('cmd-1')).toBeUndefined()
+
+    const consumedOverflow = consumeSpeculativeClassifierCheck('overflow')
+    expect(consumedOverflow).toBeDefined()
+    expect(peekSpeculativeClassifierCheck('overflow')).toBeUndefined()
   })
 })

--- a/src/tools/BashTool/bashPermissions.ts
+++ b/src/tools/BashTool/bashPermissions.ts
@@ -1494,7 +1494,22 @@ function buildPendingClassifierCheck(
   }
 }
 
+/** Maximum number of speculative classifier results to cache. */
+const MAX_SPECULATIVE_CHECKS_SIZE = 1000
 const speculativeChecks = new Map<string, Promise<ClassifierResult>>()
+
+/**
+ * Remove the oldest entries from speculativeChecks until the map is within
+ * the MAX_SPECULATIVE_CHECKS_SIZE cap. Eviction is FIFO based on insertion
+ * order (Map preserves insertion order for keys).
+ */
+function evictSpeculativeChecks(): void {
+  while (speculativeChecks.size > MAX_SPECULATIVE_CHECKS_SIZE) {
+    const oldestKey = speculativeChecks.keys().next().value
+    if (oldestKey === undefined) break
+    speculativeChecks.delete(oldestKey)
+  }
+}
 
 /**
  * Start a speculative bash allow classifier check early, so it runs in
@@ -1541,6 +1556,7 @@ export function startSpeculativeClassifierCheck(
   // The original promise (which may reject) is still stored in the Map for consumers to await.
   promise.catch(() => {})
   speculativeChecks.set(command, promise)
+  evictSpeculativeChecks()
   return true
 }
 
@@ -1560,6 +1576,13 @@ export function consumeSpeculativeClassifierCheck(
 
 export function clearSpeculativeChecks(): void {
   speculativeChecks.clear()
+}
+
+// Test-only surface for speculative cache eviction assertions.
+export const _test = {
+  speculativeChecks,
+  evictSpeculativeChecks,
+  MAX_SPECULATIVE_CHECKS_SIZE,
 }
 
 /**


### PR DESCRIPTION
## Summary

Internal/upstream defensive maintenance: cap the bash-classifier `speculativeChecks` Map and FIFO-evict the oldest entries so it can't grow unbounded when the speculative-classifier path is active.

- `src/tools/BashTool/bashPermissions.ts`: add `MAX_SPECULATIVE_CHECKS_SIZE = 1000` and an `evictSpeculativeChecks()` (FIFO, insertion-order) called after each insert in `startSpeculativeClassifierCheck`; expose a small `_test` surface for eviction assertions.

## Scope / honesty note

`classifyBashCommand` is a **stub in the open-source build**, so `speculativeChecks` is not populated here — this change does **not** fix a user-visible memory issue in OSS. It is upstream cache-bounding that takes effect where the classifier path is reachable. This PR was **rescoped** from an earlier version that also flipped `isClassifierPermissionsEnabled()` to read env vars (a security-sensitive permission-behavior change) and added `TEST_`-prefixed env-var reads; **all of that is removed** — this is now pure cache-bounding with **no runtime/permission behavior change and no new env vars**.

## Impact

- No behavior change in any build configuration; the only effect is bounding an in-memory Map when it is populated.
- No env vars introduced; nothing to document in `.env.example`.

## Testing

- `bun test src/tools/BashTool/bashPermissions.test.ts` — 15 pass (6 new FIFO-eviction cases; mutation-checked: neutering eviction fails them)
- `bun run typecheck` — clean

## Notes

Rebased onto current `main` (the earlier branch was ~900 commits behind).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added a limit to cached pending Bash approval checks to prevent the cache from growing indefinitely.
  * Older cached checks are now removed first when the limit is exceeded, keeping recent checks available.
  * Improved validation coverage for cache behavior, including boundary cases and safe handling when no entries exist.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->