### PR TITLE
fix: surface swallowed error in plan file write

### DIFF
--- a/src/components/permissions/ExitPlanModePermissionRequest/ExitPlanModePermissionRequest.render.test.tsx
+++ b/src/components/permissions/ExitPlanModePermissionRequest/ExitPlanModePermissionRequest.render.test.tsx
@@ -18,6 +18,7 @@ import type {
   KeybindingContextName,
   ParsedKeystroke,
 } from '../../../keybindings/types.js'
+import type { Notification } from '../../../context/notifications.js'
 import { getDefaultAppState } from '../../../state/AppStateStore.js'
 import { EXIT_PLAN_MODE_V2_TOOL_NAME } from '../../../tools/ExitPlanModeTool/constants.js'
 
@@ -29,7 +30,7 @@ const unwritablePlanPath = join(
   'plan.md',
 )
 
-const addNotification = mock(() => {})
+const addNotification = mock((_notification: Notification) => {})
 
 function createTestStreams() {
   let output = ''
@@ -211,7 +212,7 @@ describe('ExitPlanModePermissionRequest write guard (rendered)', () => {
       // The write-failure guard must queue the plan-save-error notification…
       await waitFor(() =>
         addNotification.mock.calls.some(
-          call => (call[0] as { key?: string } | undefined)?.key === 'plan-save-error',
+          call => call[0]?.key === 'plan-save-error',
         ),
       )
 

--- a/src/components/permissions/ExitPlanModePermissionRequest/ExitPlanModePermissionRequest.render.test.tsx
+++ b/src/components/permissions/ExitPlanModePermissionRequest/ExitPlanModePermissionRequest.render.test.tsx
@@ -1,0 +1,228 @@
+import { PassThrough } from 'node:stream'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+
+import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test'
+import React from 'react'
+import { stripVTControlCharacters as stripAnsi } from 'node:util'
+
+import { createRoot } from '../../../ink.js'
+import { DEFAULT_BINDINGS } from '../../../keybindings/defaultBindings.js'
+import { KeybindingProvider } from '../../../keybindings/KeybindingContext.js'
+import { parseBindings } from '../../../keybindings/parser.js'
+import {
+  acquireSharedMutationLock,
+  releaseSharedMutationLock,
+} from '../../../test/sharedMutationLock.js'
+import type {
+  KeybindingContextName,
+  ParsedKeystroke,
+} from '../../../keybindings/types.js'
+import { getDefaultAppState } from '../../../state/AppStateStore.js'
+import { EXIT_PLAN_MODE_V2_TOOL_NAME } from '../../../tools/ExitPlanModeTool/constants.js'
+
+// A real path whose parent directory does not exist, so writeFile rejects with
+// a genuine ENOENT — no fs/promises mock needed.
+const unwritablePlanPath = join(
+  tmpdir(),
+  `oc-plan-render-missing-${Date.now()}-${Math.random()}`,
+  'plan.md',
+)
+
+const addNotification = mock(() => {})
+
+function createTestStreams() {
+  let output = ''
+  const stdout = new PassThrough()
+  const stdin = new PassThrough() as PassThrough & {
+    isTTY: boolean
+    setRawMode: (mode: boolean) => void
+    ref: () => void
+    unref: () => void
+  }
+  stdin.isTTY = true
+  stdin.setRawMode = () => {}
+  stdin.ref = () => {}
+  stdin.unref = () => {}
+  ;(stdout as unknown as { columns: number }).columns = 120
+  stdout.on('data', chunk => {
+    output += chunk.toString()
+  })
+  return { stdout, stdin, getOutput: () => output }
+}
+
+async function waitFor(predicate: () => boolean, timeoutMs = 2000): Promise<void> {
+  const startedAt = Date.now()
+  while (Date.now() - startedAt < timeoutMs) {
+    if (predicate()) return
+    await Bun.sleep(10)
+  }
+  throw new Error('Timed out waiting for ExitPlanMode render test condition')
+}
+
+function TestKeybindingProvider({ children }: { children: React.ReactNode }): React.ReactNode {
+  const bindings = React.useMemo(() => parseBindings(DEFAULT_BINDINGS), [])
+  const pendingChordRef = React.useRef<ParsedKeystroke[] | null>(null)
+  const [pendingChord, setPendingChordState] = React.useState<ParsedKeystroke[] | null>(null)
+  const activeContextsRef = React.useRef<Set<KeybindingContextName>>(new Set())
+  const handlerRegistryRef = React.useRef(
+    new Map<string, Set<{ action: string; context: KeybindingContextName; handler: () => void }>>(),
+  )
+  const setPendingChord = React.useCallback((pending: ParsedKeystroke[] | null) => {
+    pendingChordRef.current = pending
+    setPendingChordState(pending)
+  }, [])
+  const registerActiveContext = React.useCallback((context: KeybindingContextName) => {
+    activeContextsRef.current.add(context)
+  }, [])
+  const unregisterActiveContext = React.useCallback((context: KeybindingContextName) => {
+    activeContextsRef.current.delete(context)
+  }, [])
+  return (
+    <KeybindingProvider
+      bindings={bindings}
+      pendingChordRef={pendingChordRef}
+      pendingChord={pendingChord}
+      setPendingChord={setPendingChord}
+      activeContexts={activeContextsRef.current}
+      registerActiveContext={registerActiveContext}
+      unregisterActiveContext={unregisterActiveContext}
+      handlerRegistryRef={handlerRegistryRef}
+    >
+      {children}
+    </KeybindingProvider>
+  )
+}
+
+function createToolUseConfirm() {
+  return {
+    assistantMessage: {
+      type: 'assistant',
+      uuid: 'assistant-uuid',
+      message: {
+        id: 'msg_123',
+        type: 'message',
+        role: 'assistant',
+        content: [],
+        model: 'test-model',
+        stop_reason: null,
+        stop_sequence: null,
+        usage: { input_tokens: 0, output_tokens: 0 },
+      },
+    },
+    tool: { name: EXIT_PLAN_MODE_V2_TOOL_NAME },
+    description: 'exit plan mode',
+    input: {},
+    toolUseContext: {},
+    toolUseID: 'toolu_exitplan',
+    permissionResult: { behavior: 'ask', message: 'Exit plan mode?' },
+    permissionPromptStartTimeMs: Date.now(),
+    onUserInteraction: mock(() => {}),
+    onAbort: mock(() => {}),
+    onAllow: mock(() => {}),
+    onReject: mock(() => {}),
+    recheckPermission: mock(async () => {}),
+  }
+}
+
+beforeEach(async () => {
+  await acquireSharedMutationLock(
+    'components/permissions/ExitPlanModePermissionRequest.render.test.tsx',
+  )
+  addNotification.mockClear()
+  mock.module('../PermissionRuleExplanation.js', () => ({
+    PermissionRuleExplanation: () => null,
+  }))
+  mock.module('../../Markdown.js', () => ({
+    Markdown: ({ children }: { children: string }) => children,
+  }))
+  // Capture notifications without a provider.
+  mock.module('src/context/notifications.js', () => ({
+    useNotifications: () => ({ addNotification, removeNotification: () => {} }),
+  }))
+  // V2 plan-file path points at a missing parent dir → real ENOENT on write.
+  const realPlans = await import('../../../utils/plans.ts')
+  mock.module('../../../utils/plans.js', () => ({
+    ...realPlans,
+    getPlanFilePath: () => unwritablePlanPath,
+    getPlan: () => '# A plan\n- step one',
+    persistFileSnapshotIfRemote: () => Promise.resolve(),
+  }))
+})
+
+afterEach(() => {
+  try {
+    mock.restore()
+  } finally {
+    releaseSharedMutationLock()
+  }
+})
+
+describe('ExitPlanModePermissionRequest write guard (rendered)', () => {
+  test('aborts the plan-exit and does not call onAllow/onReject when the plan write fails', async () => {
+    const { stdout, stdin, getOutput } = createTestStreams()
+    const { AppStateProvider } = await import('../../../state/AppState.js')
+    const { ExitPlanModePermissionRequest } = await import(
+      './ExitPlanModePermissionRequest.tsx'
+    )
+
+    const toolUseConfirm = createToolUseConfirm()
+    const onDone = mock(() => {})
+    const onReject = mock(() => {})
+
+    const base = getDefaultAppState()
+    const initialState = {
+      ...base,
+      toolPermissionContext: {
+        ...base.toolPermissionContext,
+        mode: 'plan',
+      },
+    }
+
+    const root = await createRoot({
+      stdout: stdout as unknown as NodeJS.WriteStream,
+      stdin: stdin as unknown as NodeJS.ReadStream,
+      patchConsole: false,
+    })
+
+    root.render(
+      <AppStateProvider initialState={initialState as never}>
+        <TestKeybindingProvider>
+          <ExitPlanModePermissionRequest
+            toolUseConfirm={toolUseConfirm as never}
+            toolUseContext={{} as never}
+            onDone={onDone}
+            onReject={onReject}
+            verbose={false}
+            workerBadge={undefined}
+            setStickyFooter={undefined as never}
+          />
+        </TestKeybindingProvider>
+      </AppStateProvider>,
+    )
+
+    try {
+      await waitFor(() => stripAnsi(getOutput()).includes('Would you like to proceed?'))
+
+      // Confirm the first (accept) option; its handler tries to persist the
+      // plan file, which fails (missing parent dir).
+      stdin.write('\r')
+
+      // The write-failure guard must queue the plan-save-error notification…
+      await waitFor(() =>
+        addNotification.mock.calls.some(
+          call => (call[0] as { key?: string } | undefined)?.key === 'plan-save-error',
+        ),
+      )
+
+      // …and must NOT advance the plan exit.
+      expect(toolUseConfirm.onAllow).not.toHaveBeenCalled()
+      expect(toolUseConfirm.onReject).not.toHaveBeenCalled()
+      expect(onDone).not.toHaveBeenCalled()
+    } finally {
+      root.unmount()
+      stdin.end()
+      stdout.end()
+    }
+  })
+})

--- a/src/components/permissions/ExitPlanModePermissionRequest/ExitPlanModePermissionRequest.test.ts
+++ b/src/components/permissions/ExitPlanModePermissionRequest/ExitPlanModePermissionRequest.test.ts
@@ -1,9 +1,13 @@
 import { describe, expect, test } from 'bun:test'
+import { mkdtemp, readFile, rm } from 'fs/promises'
+import { tmpdir } from 'os'
+import { join } from 'path'
 
 import {
   buildPermissionUpdates,
   buildPlanApprovalOptions,
   getDangerousPlanExitMode,
+  persistPlanFileBeforeExit,
 } from './ExitPlanModePermissionRequest.tsx'
 
 describe('getDangerousPlanExitMode', () => {
@@ -88,5 +92,52 @@ describe('buildPermissionUpdates', () => {
         destination: 'session',
       },
     ])
+  })
+})
+
+// Covers the write-before-permission guard that keeps the user in plan mode
+// when the plan file can't be persisted (#1725). Uses real filesystem paths
+// instead of a global fs/promises mock so it stays isolated from other tests.
+describe('persistPlanFileBeforeExit', () => {
+  test('writes the plan and returns true without notifying on success', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'oc-plan-ok-'))
+    const planFilePath = join(dir, 'plan.md')
+    const notifications: Array<{ key: string }> = []
+    try {
+      const ok = await persistPlanFileBeforeExit({
+        planFilePath,
+        currentPlan: '# my plan',
+        addNotification: n => notifications.push(n as { key: string }),
+      })
+
+      expect(ok).toBe(true)
+      expect(notifications).toHaveLength(0)
+      expect(await readFile(planFilePath, 'utf-8')).toBe('# my plan')
+    } finally {
+      await rm(dir, { recursive: true, force: true })
+    }
+  })
+
+  test('returns false and queues a plan-save-error notification on write failure', async () => {
+    // Parent directory does not exist → writeFile rejects with ENOENT.
+    const planFilePath = join(
+      tmpdir(),
+      `oc-plan-missing-${Date.now()}-${Math.random()}`,
+      'nested',
+      'plan.md',
+    )
+    const notifications: Array<{ key: string; color?: string; priority?: string }> = []
+
+    const ok = await persistPlanFileBeforeExit({
+      planFilePath,
+      currentPlan: '# my plan',
+      addNotification: n => notifications.push(n as { key: string }),
+    })
+
+    expect(ok).toBe(false)
+    expect(notifications).toHaveLength(1)
+    expect(notifications[0]?.key).toBe('plan-save-error')
+    expect(notifications[0]?.color).toBe('warning')
+    expect(notifications[0]?.priority).toBe('high')
   })
 })

--- a/src/components/permissions/ExitPlanModePermissionRequest/ExitPlanModePermissionRequest.tsx
+++ b/src/components/permissions/ExitPlanModePermissionRequest/ExitPlanModePermissionRequest.tsx
@@ -3,6 +3,7 @@ import type { UUID } from 'crypto';
 import figures from 'figures';
 import React, { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { useNotifications } from 'src/context/notifications.js';
+import type { Notification } from 'src/context/notifications.js';
 import { PRODUCT_DISPLAY_NAME } from '../../../constants/product.js';
 import { type AnalyticsMetadata_I_VERIFIED_THIS_IS_NOT_CODE_OR_FILEPATHS, logEvent } from 'src/services/analytics/index.js';
 import { useAppState, useAppStateStore, useSetAppState } from 'src/state/AppState.js';
@@ -149,6 +150,36 @@ export function autoNameSessionFromPlan(plan: string, setAppState: (updater: (pr
       };
     });
   }).catch(logError);
+}
+/**
+ * @internal Exported for testing. Persists the plan file before exiting plan
+ * mode. Returns true on success. On write failure it logs, queues a
+ * 'plan-save-error' notification, and returns false so the caller stays in
+ * plan mode (does not grant permissions or resolve the tool use).
+ */
+export async function persistPlanFileBeforeExit({
+  planFilePath,
+  currentPlan,
+  addNotification
+}: {
+  planFilePath: string;
+  currentPlan: string;
+  addNotification: (content: Notification) => void;
+}): Promise<boolean> {
+  try {
+    await writeFile(planFilePath, currentPlan, 'utf-8');
+    void persistFileSnapshotIfRemote();
+    return true;
+  } catch (e) {
+    logError(`Failed to save plan file to ${planFilePath}: ${e}`);
+    addNotification({
+      key: 'plan-save-error',
+      text: `Failed to save plan file: ${e instanceof Error ? e.message : String(e)}`,
+      color: 'warning',
+      priority: 'high'
+    });
+    return false;
+  }
 }
 export function ExitPlanModePermissionRequest({
   toolUseConfirm,
@@ -339,19 +370,10 @@ export function ExitPlanModePermissionRequest({
   };
   async function handleResponse(value: ResponseValue): Promise<void> {
     if (value !== 'no' && value !== 'ultraplan' && isV2 && planFilePath) {
-      try {
-        await writeFile(planFilePath, currentPlan, 'utf-8');
-        void persistFileSnapshotIfRemote();
-      } catch (e) {
-        logError(`Failed to save plan file to ${planFilePath}: ${e}`);
-        addNotification({
-          key: 'plan-save-error',
-          text: `Failed to save plan file: ${e instanceof Error ? e.message : String(e)}`,
-          color: 'warning',
-          priority: 'high'
-        });
-        return;
-      }
+      const saved = await persistPlanFileBeforeExit({ planFilePath, currentPlan, addNotification });
+      // Write failed — stay in plan mode rather than granting permissions on a
+      // plan that was never persisted to disk.
+      if (!saved) return;
     }
 
     const trimmedFeedback = planFeedback.trim();

--- a/src/components/permissions/ExitPlanModePermissionRequest/ExitPlanModePermissionRequest.tsx
+++ b/src/components/permissions/ExitPlanModePermissionRequest/ExitPlanModePermissionRequest.tsx
@@ -30,7 +30,8 @@ import { type PermissionMode, toExternalPermissionMode } from '../../../utils/pe
 import type { PermissionUpdate } from '../../../utils/permissions/PermissionUpdateSchema.js';
 import { isAutoModeGateEnabled, restoreDangerousPermissions, stripDangerousPermissionsForAutoMode } from '../../../utils/permissions/permissionSetup.js';
 import { getPewterLedgerVariant, isPlanModeInterviewPhaseEnabled } from '../../../utils/planModeV2.js';
-import { getPlan, getPlanFilePath } from '../../../utils/plans.js';
+import { writeFile } from 'fs/promises';
+import { getPlan, getPlanFilePath, persistFileSnapshotIfRemote } from '../../../utils/plans.js';
 import { editFileInEditor, editPromptInEditor } from '../../../utils/promptEditor.js';
 import { getCurrentSessionTitle, getTranscriptPath, saveAgentName, saveCustomTitle } from '../../../utils/sessionStorage.js';
 import { getSettings_DEPRECATED } from '../../../utils/settings/settings.js';
@@ -337,6 +338,22 @@ export function ExitPlanModePermissionRequest({
     }
   };
   async function handleResponse(value: ResponseValue): Promise<void> {
+    if (value !== 'no' && value !== 'ultraplan' && isV2 && planFilePath) {
+      try {
+        await writeFile(planFilePath, currentPlan, 'utf-8');
+        void persistFileSnapshotIfRemote();
+      } catch (e) {
+        logError(`Failed to save plan file to ${planFilePath}: ${e}`);
+        addNotification({
+          key: 'plan-save-error',
+          text: `Failed to save plan file: ${e instanceof Error ? e.message : String(e)}`,
+          color: 'warning',
+          priority: 'high'
+        });
+        return;
+      }
+    }
+
     const trimmedFeedback = planFeedback.trim();
     const acceptFeedback = trimmedFeedback || undefined;
 

--- a/src/tools/ExitPlanModeTool/ExitPlanModeV2Tool.test.ts
+++ b/src/tools/ExitPlanModeTool/ExitPlanModeV2Tool.test.ts
@@ -1,8 +1,18 @@
 import { afterAll, beforeAll, expect, mock, test } from 'bun:test'
+import { tmpdir } from 'os'
+import { join } from 'path'
 import {
   acquireSharedMutationLock,
   releaseSharedMutationLock,
 } from '../../test/sharedMutationLock.js'
+
+// A real path whose parent directory does not exist, so the tool's writeFile()
+// rejects with a genuine ENOENT. Using this instead of mocking the core
+// fs/promises module keeps the write-failure tests isolated — mock.module() on
+// a core module is process-global and can leak into other files.
+function makeUnwritablePlanPath(): string {
+  return join(tmpdir(), `oc-exitplan-missing-${Date.now()}-${Math.random()}`, 'plan.md')
+}
 import { getEmptyToolPermissionContext } from '../../Tool.js'
 import {
   setDynamicTeamContext,
@@ -44,7 +54,6 @@ afterAll(async () => {
     // Restore mock modules back to their actual implementations
     mock.module('../../utils/plans.js', () => actualPlans)
     mock.module('../../utils/teammateMailbox.js', () => actualTeammateMailbox)
-    mock.module('fs/promises', () => require('fs/promises'))
   } finally {
     releaseSharedMutationLock()
   }
@@ -65,19 +74,10 @@ function makeCtx() {
 }
 
 test('surfaces write error when plan file write fails and asserts no side effects (standard)', async () => {
-  const simulatedError = new Error('Simulated write failure')
-  const writeFileMock = mock(async () => {
-    throw simulatedError
-  })
-
-  mock.module('fs/promises', () => ({
-    writeFile: writeFileMock,
-  }))
-
   const persistFileSnapshotIfRemoteMock = mock(() => Promise.resolve())
   mock.module('../../utils/plans.js', () => ({
     ...actualPlans,
-    getPlanFilePath: () => '/tmp/test-plan.md',
+    getPlanFilePath: () => makeUnwritablePlanPath(),
     getPlan: () => 'plan content',
     persistFileSnapshotIfRemote: persistFileSnapshotIfRemoteMock,
   }))
@@ -102,6 +102,8 @@ test('surfaces write error when plan file write fails and asserts no side effect
   )
 
   try {
+    // The real writeFile rejects (ENOENT — parent dir is missing). The tool
+    // must surface that error and run none of the post-write side effects.
     await expect(
       mod.ExitPlanModeV2Tool.call(
         { plan: 'edited plan content' } as never,
@@ -109,33 +111,22 @@ test('surfaces write error when plan file write fails and asserts no side effect
         (() => Promise.resolve({ behavior: 'allow' })) as never,
         {} as never,
       ),
-    ).rejects.toThrow(simulatedError)
+    ).rejects.toThrow()
 
-    expect(writeFileMock).toHaveBeenCalled()
     expect(persistFileSnapshotIfRemoteMock).not.toHaveBeenCalled()
     expect(setAppStateMock).not.toHaveBeenCalled()
   } finally {
     mock.restore()
     clearDynamicTeamContext()
     mock.module('../../utils/plans.js', () => actualPlans)
-    mock.module('fs/promises', () => require('fs/promises'))
   }
 })
 
 test('surfaces write error when plan file write fails and asserts no teammate approval side effects', async () => {
-  const simulatedError = new Error('Simulated write failure')
-  const writeFileMock = mock(async () => {
-    throw simulatedError
-  })
-
-  mock.module('fs/promises', () => ({
-    writeFile: writeFileMock,
-  }))
-
   const persistFileSnapshotIfRemoteMock = mock(() => Promise.resolve())
   mock.module('../../utils/plans.js', () => ({
     ...actualPlans,
-    getPlanFilePath: () => '/tmp/test-plan.md',
+    getPlanFilePath: () => makeUnwritablePlanPath(),
     getPlan: () => 'plan content',
     persistFileSnapshotIfRemote: persistFileSnapshotIfRemoteMock,
   }))
@@ -170,6 +161,8 @@ test('surfaces write error when plan file write fails and asserts no teammate ap
   )
 
   try {
+    // The real writeFile rejects (ENOENT — parent dir is missing). The tool
+    // must surface that error before sending any teammate approval request.
     await expect(
       mod.ExitPlanModeV2Tool.call(
         { plan: 'edited plan content' } as never,
@@ -177,9 +170,8 @@ test('surfaces write error when plan file write fails and asserts no teammate ap
         (() => Promise.resolve({ behavior: 'allow' })) as never,
         {} as never,
       ),
-    ).rejects.toThrow(simulatedError)
+    ).rejects.toThrow()
 
-    expect(writeFileMock).toHaveBeenCalled()
     expect(persistFileSnapshotIfRemoteMock).not.toHaveBeenCalled()
     expect(writeToMailboxMock).not.toHaveBeenCalled()
     expect(setAppStateMock).not.toHaveBeenCalled()
@@ -188,6 +180,5 @@ test('surfaces write error when plan file write fails and asserts no teammate ap
     clearDynamicTeamContext()
     mock.module('../../utils/plans.js', () => actualPlans)
     mock.module('../../utils/teammateMailbox.js', () => actualTeammateMailbox)
-    mock.module('fs/promises', () => require('fs/promises'))
   }
 })

--- a/src/tools/ExitPlanModeTool/ExitPlanModeV2Tool.test.ts
+++ b/src/tools/ExitPlanModeTool/ExitPlanModeV2Tool.test.ts
@@ -1,4 +1,4 @@
-import { afterAll, beforeAll, expect, mock, test } from 'bun:test'
+import { afterAll, afterEach, beforeAll, expect, mock, test } from 'bun:test'
 import {
   acquireSharedMutationLock,
   releaseSharedMutationLock,
@@ -9,6 +9,7 @@ type ExitPlanModeModule = typeof import('./ExitPlanModeV2Tool.js')
 type ExitPlanModeTool = ExitPlanModeModule['ExitPlanModeV2Tool']
 
 let ExitPlanModeV2Tool: ExitPlanModeTool | undefined
+let realWriteFile: typeof import('fs/promises')['writeFile'] | undefined
 
 beforeAll(async () => {
   await acquireSharedMutationLock(
@@ -18,6 +19,8 @@ beforeAll(async () => {
   const actualPlans = await import(
     `../../utils/plans.ts?exitPlanModeWriteTest=${Date.now()}-${Math.random()}`
   )
+  const realFs = await import('fs/promises')
+  realWriteFile = realFs.writeFile
 
   mock.module('../../utils/plans.js', () => ({
     ...actualPlans,
@@ -40,6 +43,17 @@ afterAll(() => {
   }
 })
 
+// Restore fs/promises mock after each test so it cannot leak into
+// loadAgentsDir.test.ts on Linux CI. Addresses jatmn's P2 on #1725.
+afterEach(() => {
+  mock.restore()
+  // Re-apply the plans mock that afterAll's mock.restore() cleared,
+  // so subsequent tests in this file still see the mocked plans module.
+  if (realWriteFile) {
+    // No-op: plans mock is re-established per test below if needed.
+  }
+})
+
 function makeCtx() {
   const toolPermissionContext = getEmptyToolPermissionContext()
   return {
@@ -55,21 +69,22 @@ function makeCtx() {
 }
 
 test('surfaces write error when plan file write fails', async () => {
+  // Mock fs/promises.writeFile to throw. The afterEach restores this so
+  // it cannot leak into loadAgentsDir.test.ts on Linux CI.
+  const realFs = await import('fs/promises')
   mock.module('fs/promises', () => ({
+    ...realFs,
     writeFile: async () => {
       throw Object.assign(new Error('write failed'), { code: 'ENOSPC' })
     },
   }))
-  try {
-    await expect(
-      ExitPlanModeV2Tool!.call(
-        { plan: 'edited plan content' } as never,
-        makeCtx(),
-        (() => Promise.resolve({ behavior: 'allow' })) as never,
-        {} as never,
-      ),
-    ).rejects.toThrow('write failed')
-  } finally {
-    mock.restore()
-  }
+
+  await expect(
+    ExitPlanModeV2Tool!.call(
+      { plan: 'edited plan content' } as never,
+      makeCtx(),
+      (() => Promise.resolve({ behavior: 'allow' })) as never,
+      {} as never,
+    ),
+  ).rejects.toThrow('write failed')
 })

--- a/src/tools/ExitPlanModeTool/ExitPlanModeV2Tool.test.ts
+++ b/src/tools/ExitPlanModeTool/ExitPlanModeV2Tool.test.ts
@@ -45,7 +45,7 @@ function makeCtx() {
   return {
     abortController: new AbortController(),
     agentId: undefined,
-    options: { isNonInteractiveSession: false },
+    options: { isNonInteractiveSession: false, tools: [] },
     getAppState: () => ({ toolPermissionContext } as never),
     setAppState: () => undefined,
     setToolJSX: undefined,
@@ -54,32 +54,140 @@ function makeCtx() {
   } as never
 }
 
-test('surfaces write error when plan file write fails', async () => {
-  // Re-mock plans.js to point getPlanFilePath at a directory that doesn't
-  // exist, so the REAL fs/promises.writeFile rejects with ENOENT. This
-  // avoids mocking fs/promises globally, which leaked into
-  // loadAgentsDir.test.ts on Linux CI even with afterEach(mock.restore()).
-  // The fresh tool import picks up the new mock.
+test('surfaces write error when plan file write fails and asserts no side effects (standard)', async () => {
+  const simulatedError = new Error('Simulated write failure')
+  const writeFileMock = mock(async () => {
+    throw simulatedError
+  })
+
+  mock.module('fs/promises', () => ({
+    writeFile: writeFileMock,
+  }))
+
+  const persistFileSnapshotIfRemoteMock = mock(() => Promise.resolve())
   const actualPlans = await import(
-    `../../utils/plans.ts?failCase=${Date.now()}-${Math.random()}`
+    `../../utils/plans.ts?test1=${Date.now()}-${Math.random()}`
   )
   mock.module('../../utils/plans.js', () => ({
     ...actualPlans,
-    getPlanFilePath: () =>
-      '/nonexistent-dir-for-test/test-plan.md',
+    getPlanFilePath: () => '/tmp/test-plan.md',
     getPlan: () => 'plan content',
-    persistFileSnapshotIfRemote: () => Promise.resolve(),
+    persistFileSnapshotIfRemote: persistFileSnapshotIfRemoteMock,
   }))
 
-  const mod = await import(
-    `./ExitPlanModeV2Tool.ts?failCase=${Date.now()}-${Math.random()}`
+  const actualTeammate = await import(
+    `../../utils/teammate.ts?test1=${Date.now()}-${Math.random()}`
   )
-  await expect(
-    mod.ExitPlanModeV2Tool.call(
-      { plan: 'edited plan content' } as never,
-      makeCtx(),
-      (() => Promise.resolve({ behavior: 'allow' })) as never,
-      {} as never,
-    ),
-  ).rejects.toThrow()
+  mock.module('../../utils/teammate.js', () => ({
+    ...actualTeammate,
+    isTeammate: () => false,
+    isPlanModeRequired: () => false,
+  }))
+
+  const setAppStateMock = mock(() => undefined)
+  const toolPermissionContext = getEmptyToolPermissionContext()
+  const ctx = {
+    abortController: new AbortController(),
+    agentId: undefined,
+    options: { isNonInteractiveSession: false, tools: [] },
+    getAppState: () => ({ toolPermissionContext } as never),
+    setAppState: setAppStateMock,
+    setToolJSX: undefined,
+    toolUseId: 'test-exit-plan-mode',
+    addNotification: undefined,
+  } as never
+
+  const mod = await import(
+    `./ExitPlanModeV2Tool.ts?test1=${Date.now()}-${Math.random()}`
+  )
+
+  try {
+    await expect(
+      mod.ExitPlanModeV2Tool.call(
+        { plan: 'edited plan content' } as never,
+        ctx,
+        (() => Promise.resolve({ behavior: 'allow' })) as never,
+        {} as never,
+      ),
+    ).rejects.toThrow(simulatedError)
+
+    expect(writeFileMock).toHaveBeenCalled()
+    expect(persistFileSnapshotIfRemoteMock).not.toHaveBeenCalled()
+    expect(setAppStateMock).not.toHaveBeenCalled()
+  } finally {
+    mock.restore()
+  }
+})
+
+test('surfaces write error when plan file write fails and asserts no teammate approval side effects', async () => {
+  const simulatedError = new Error('Simulated write failure')
+  const writeFileMock = mock(async () => {
+    throw simulatedError
+  })
+
+  mock.module('fs/promises', () => ({
+    writeFile: writeFileMock,
+  }))
+
+  const persistFileSnapshotIfRemoteMock = mock(() => Promise.resolve())
+  const actualPlans = await import(
+    `../../utils/plans.ts?test2=${Date.now()}-${Math.random()}`
+  )
+  mock.module('../../utils/plans.js', () => ({
+    ...actualPlans,
+    getPlanFilePath: () => '/tmp/test-plan.md',
+    getPlan: () => 'plan content',
+    persistFileSnapshotIfRemote: persistFileSnapshotIfRemoteMock,
+  }))
+
+  const actualTeammate = await import(
+    `../../utils/teammate.ts?test2=${Date.now()}-${Math.random()}`
+  )
+  mock.module('../../utils/teammate.js', () => ({
+    ...actualTeammate,
+    isTeammate: () => true,
+    isPlanModeRequired: () => true,
+    getAgentName: () => 'test-agent',
+    getTeamName: () => 'test-team',
+  }))
+
+  const writeToMailboxMock = mock(() => Promise.resolve())
+  mock.module('../../utils/teammateMailbox.js', () => ({
+    writeToMailbox: writeToMailboxMock,
+  }))
+
+  const setAppStateMock = mock(() => undefined)
+  const toolPermissionContext = getEmptyToolPermissionContext()
+  const ctx = {
+    abortController: new AbortController(),
+    agentId: undefined,
+    options: { isNonInteractiveSession: false, tools: [] },
+    getAppState: () => ({ toolPermissionContext } as never),
+    setAppState: setAppStateMock,
+    setToolJSX: undefined,
+    toolUseId: 'test-exit-plan-mode',
+    addNotification: undefined,
+  } as never
+
+  const mod = await import(
+    `./ExitPlanModeV2Tool.ts?test2=${Date.now()}-${Math.random()}`
+  )
+
+  try {
+    await expect(
+      mod.ExitPlanModeV2Tool.call(
+        { plan: 'edited plan content' } as never,
+        ctx,
+        (() => Promise.resolve({ behavior: 'allow' })) as never,
+        {} as never,
+      ),
+    ).rejects.toThrow(simulatedError)
+
+    expect(writeFileMock).toHaveBeenCalled()
+    expect(persistFileSnapshotIfRemoteMock).not.toHaveBeenCalled()
+    expect(writeToMailboxMock).not.toHaveBeenCalled()
+    expect(setAppStateMock).not.toHaveBeenCalled()
+  } finally {
+    mock.restore()
+  }
 })

--- a/src/tools/ExitPlanModeTool/ExitPlanModeV2Tool.test.ts
+++ b/src/tools/ExitPlanModeTool/ExitPlanModeV2Tool.test.ts
@@ -26,12 +26,6 @@ beforeAll(async () => {
     persistFileSnapshotIfRemote: () => Promise.resolve(),
   }))
 
-  mock.module('fs/promises', () => ({
-    writeFile: async () => {
-      throw Object.assign(new Error('write failed'), { code: 'ENOSPC' })
-    },
-  }))
-
   const mod = await import(
     `./ExitPlanModeV2Tool.ts?exitPlanModeWriteTest=${Date.now()}-${Math.random()}`
   )
@@ -61,10 +55,21 @@ function makeCtx() {
 }
 
 test('surfaces write error when plan file write fails', async () => {
-  await expect(
-    ExitPlanModeV2Tool!.call(
-      { plan: 'edited plan content' } as never,
-      makeCtx(),
-    ),
-  ).rejects.toThrow('write failed')
+  mock.module('fs/promises', () => ({
+    writeFile: async () => {
+      throw Object.assign(new Error('write failed'), { code: 'ENOSPC' })
+    },
+  }))
+  try {
+    await expect(
+      ExitPlanModeV2Tool!.call(
+        { plan: 'edited plan content' } as never,
+        makeCtx(),
+        (() => Promise.resolve({ behavior: 'allow' })) as never,
+        {} as never,
+      ),
+    ).rejects.toThrow('write failed')
+  } finally {
+    mock.restore()
+  }
 })

--- a/src/tools/ExitPlanModeTool/ExitPlanModeV2Tool.test.ts
+++ b/src/tools/ExitPlanModeTool/ExitPlanModeV2Tool.test.ts
@@ -111,7 +111,9 @@ test('surfaces write error when plan file write fails and asserts no side effect
         (() => Promise.resolve({ behavior: 'allow' })) as never,
         {} as never,
       ),
-    ).rejects.toThrow()
+      // Assert the specific ENOENT write failure (missing parent dir) rather
+      // than any error, so the test locks in the intended failure behavior.
+    ).rejects.toThrow(/ENOENT/)
 
     expect(persistFileSnapshotIfRemoteMock).not.toHaveBeenCalled()
     expect(setAppStateMock).not.toHaveBeenCalled()
@@ -170,7 +172,9 @@ test('surfaces write error when plan file write fails and asserts no teammate ap
         (() => Promise.resolve({ behavior: 'allow' })) as never,
         {} as never,
       ),
-    ).rejects.toThrow()
+      // Assert the specific ENOENT write failure (missing parent dir) rather
+      // than any error, so the test locks in the intended failure behavior.
+    ).rejects.toThrow(/ENOENT/)
 
     expect(persistFileSnapshotIfRemoteMock).not.toHaveBeenCalled()
     expect(writeToMailboxMock).not.toHaveBeenCalled()

--- a/src/tools/ExitPlanModeTool/ExitPlanModeV2Tool.test.ts
+++ b/src/tools/ExitPlanModeTool/ExitPlanModeV2Tool.test.ts
@@ -1,0 +1,70 @@
+import { afterAll, beforeAll, expect, mock, test } from 'bun:test'
+import {
+  acquireSharedMutationLock,
+  releaseSharedMutationLock,
+} from '../../test/sharedMutationLock.js'
+import { getEmptyToolPermissionContext } from '../../Tool.js'
+
+type ExitPlanModeModule = typeof import('./ExitPlanModeV2Tool.js')
+type ExitPlanModeTool = ExitPlanModeModule['ExitPlanModeV2Tool']
+
+let ExitPlanModeV2Tool: ExitPlanModeTool | undefined
+
+beforeAll(async () => {
+  await acquireSharedMutationLock(
+    'tools/ExitPlanModeTool/ExitPlanModeV2Tool.test.ts',
+  )
+
+  const actualPlans = await import(
+    `../../utils/plans.ts?exitPlanModeWriteTest=${Date.now()}-${Math.random()}`
+  )
+
+  mock.module('../../utils/plans.js', () => ({
+    ...actualPlans,
+    getPlanFilePath: () => '/tmp/test-plan.md',
+    getPlan: () => 'plan content',
+    persistFileSnapshotIfRemote: () => Promise.resolve(),
+  }))
+
+  mock.module('fs/promises', () => ({
+    writeFile: async () => {
+      throw Object.assign(new Error('write failed'), { code: 'ENOSPC' })
+    },
+  }))
+
+  const mod = await import(
+    `./ExitPlanModeV2Tool.ts?exitPlanModeWriteTest=${Date.now()}-${Math.random()}`
+  )
+  ExitPlanModeV2Tool = mod.ExitPlanModeV2Tool
+})
+
+afterAll(() => {
+  try {
+    mock.restore()
+  } finally {
+    releaseSharedMutationLock()
+  }
+})
+
+function makeCtx() {
+  const toolPermissionContext = getEmptyToolPermissionContext()
+  return {
+    abortController: new AbortController(),
+    agentId: undefined,
+    options: { isNonInteractiveSession: false },
+    getAppState: () => ({ toolPermissionContext } as never),
+    setAppState: () => undefined,
+    setToolJSX: undefined,
+    toolUseId: 'test-exit-plan-mode',
+    addNotification: undefined,
+  } as never
+}
+
+test('surfaces write error when plan file write fails', async () => {
+  await expect(
+    ExitPlanModeV2Tool!.call(
+      { plan: 'edited plan content' } as never,
+      makeCtx(),
+    ),
+  ).rejects.toThrow('write failed')
+})

--- a/src/tools/ExitPlanModeTool/ExitPlanModeV2Tool.test.ts
+++ b/src/tools/ExitPlanModeTool/ExitPlanModeV2Tool.test.ts
@@ -4,20 +4,25 @@ import {
   releaseSharedMutationLock,
 } from '../../test/sharedMutationLock.js'
 import { getEmptyToolPermissionContext } from '../../Tool.js'
+import {
+  setDynamicTeamContext,
+  clearDynamicTeamContext,
+} from '../../utils/teammate.js'
 
 type ExitPlanModeModule = typeof import('./ExitPlanModeV2Tool.js')
 type ExitPlanModeTool = ExitPlanModeModule['ExitPlanModeV2Tool']
 
 let ExitPlanModeV2Tool: ExitPlanModeTool | undefined
+let actualPlans: any
+let actualTeammateMailbox: any
 
 beforeAll(async () => {
   await acquireSharedMutationLock(
     'tools/ExitPlanModeTool/ExitPlanModeV2Tool.test.ts',
   )
 
-  const actualPlans = await import(
-    `../../utils/plans.ts?exitPlanModeWriteTest=${Date.now()}-${Math.random()}`
-  )
+  actualPlans = await import('../../utils/plans.ts')
+  actualTeammateMailbox = await import('../../utils/teammateMailbox.ts')
 
   mock.module('../../utils/plans.js', () => ({
     ...actualPlans,
@@ -32,9 +37,14 @@ beforeAll(async () => {
   ExitPlanModeV2Tool = mod.ExitPlanModeV2Tool
 })
 
-afterAll(() => {
+afterAll(async () => {
   try {
     mock.restore()
+    clearDynamicTeamContext()
+    // Restore mock modules back to their actual implementations
+    mock.module('../../utils/plans.js', () => actualPlans)
+    mock.module('../../utils/teammateMailbox.js', () => actualTeammateMailbox)
+    mock.module('fs/promises', () => require('fs/promises'))
   } finally {
     releaseSharedMutationLock()
   }
@@ -65,9 +75,6 @@ test('surfaces write error when plan file write fails and asserts no side effect
   }))
 
   const persistFileSnapshotIfRemoteMock = mock(() => Promise.resolve())
-  const actualPlans = await import(
-    `../../utils/plans.ts?test1=${Date.now()}-${Math.random()}`
-  )
   mock.module('../../utils/plans.js', () => ({
     ...actualPlans,
     getPlanFilePath: () => '/tmp/test-plan.md',
@@ -75,14 +82,7 @@ test('surfaces write error when plan file write fails and asserts no side effect
     persistFileSnapshotIfRemote: persistFileSnapshotIfRemoteMock,
   }))
 
-  const actualTeammate = await import(
-    `../../utils/teammate.ts?test1=${Date.now()}-${Math.random()}`
-  )
-  mock.module('../../utils/teammate.js', () => ({
-    ...actualTeammate,
-    isTeammate: () => false,
-    isPlanModeRequired: () => false,
-  }))
+  clearDynamicTeamContext()
 
   const setAppStateMock = mock(() => undefined)
   const toolPermissionContext = getEmptyToolPermissionContext()
@@ -116,6 +116,9 @@ test('surfaces write error when plan file write fails and asserts no side effect
     expect(setAppStateMock).not.toHaveBeenCalled()
   } finally {
     mock.restore()
+    clearDynamicTeamContext()
+    mock.module('../../utils/plans.js', () => actualPlans)
+    mock.module('fs/promises', () => require('fs/promises'))
   }
 })
 
@@ -130,9 +133,6 @@ test('surfaces write error when plan file write fails and asserts no teammate ap
   }))
 
   const persistFileSnapshotIfRemoteMock = mock(() => Promise.resolve())
-  const actualPlans = await import(
-    `../../utils/plans.ts?test2=${Date.now()}-${Math.random()}`
-  )
   mock.module('../../utils/plans.js', () => ({
     ...actualPlans,
     getPlanFilePath: () => '/tmp/test-plan.md',
@@ -140,16 +140,12 @@ test('surfaces write error when plan file write fails and asserts no teammate ap
     persistFileSnapshotIfRemote: persistFileSnapshotIfRemoteMock,
   }))
 
-  const actualTeammate = await import(
-    `../../utils/teammate.ts?test2=${Date.now()}-${Math.random()}`
-  )
-  mock.module('../../utils/teammate.js', () => ({
-    ...actualTeammate,
-    isTeammate: () => true,
-    isPlanModeRequired: () => true,
-    getAgentName: () => 'test-agent',
-    getTeamName: () => 'test-team',
-  }))
+  setDynamicTeamContext({
+    agentId: 'test-agent',
+    agentName: 'test-agent',
+    teamName: 'test-team',
+    planModeRequired: true,
+  })
 
   const writeToMailboxMock = mock(() => Promise.resolve())
   mock.module('../../utils/teammateMailbox.js', () => ({
@@ -189,5 +185,9 @@ test('surfaces write error when plan file write fails and asserts no teammate ap
     expect(setAppStateMock).not.toHaveBeenCalled()
   } finally {
     mock.restore()
+    clearDynamicTeamContext()
+    mock.module('../../utils/plans.js', () => actualPlans)
+    mock.module('../../utils/teammateMailbox.js', () => actualTeammateMailbox)
+    mock.module('fs/promises', () => require('fs/promises'))
   }
 })

--- a/src/tools/ExitPlanModeTool/ExitPlanModeV2Tool.test.ts
+++ b/src/tools/ExitPlanModeTool/ExitPlanModeV2Tool.test.ts
@@ -1,4 +1,4 @@
-import { afterAll, afterEach, beforeAll, expect, mock, test } from 'bun:test'
+import { afterAll, beforeAll, expect, mock, test } from 'bun:test'
 import {
   acquireSharedMutationLock,
   releaseSharedMutationLock,
@@ -9,7 +9,6 @@ type ExitPlanModeModule = typeof import('./ExitPlanModeV2Tool.js')
 type ExitPlanModeTool = ExitPlanModeModule['ExitPlanModeV2Tool']
 
 let ExitPlanModeV2Tool: ExitPlanModeTool | undefined
-let realWriteFile: typeof import('fs/promises')['writeFile'] | undefined
 
 beforeAll(async () => {
   await acquireSharedMutationLock(
@@ -19,8 +18,6 @@ beforeAll(async () => {
   const actualPlans = await import(
     `../../utils/plans.ts?exitPlanModeWriteTest=${Date.now()}-${Math.random()}`
   )
-  const realFs = await import('fs/promises')
-  realWriteFile = realFs.writeFile
 
   mock.module('../../utils/plans.js', () => ({
     ...actualPlans,
@@ -43,17 +40,6 @@ afterAll(() => {
   }
 })
 
-// Restore fs/promises mock after each test so it cannot leak into
-// loadAgentsDir.test.ts on Linux CI. Addresses jatmn's P2 on #1725.
-afterEach(() => {
-  mock.restore()
-  // Re-apply the plans mock that afterAll's mock.restore() cleared,
-  // so subsequent tests in this file still see the mocked plans module.
-  if (realWriteFile) {
-    // No-op: plans mock is re-established per test below if needed.
-  }
-})
-
 function makeCtx() {
   const toolPermissionContext = getEmptyToolPermissionContext()
   return {
@@ -69,22 +55,31 @@ function makeCtx() {
 }
 
 test('surfaces write error when plan file write fails', async () => {
-  // Mock fs/promises.writeFile to throw. The afterEach restores this so
-  // it cannot leak into loadAgentsDir.test.ts on Linux CI.
-  const realFs = await import('fs/promises')
-  mock.module('fs/promises', () => ({
-    ...realFs,
-    writeFile: async () => {
-      throw Object.assign(new Error('write failed'), { code: 'ENOSPC' })
-    },
+  // Re-mock plans.js to point getPlanFilePath at a directory that doesn't
+  // exist, so the REAL fs/promises.writeFile rejects with ENOENT. This
+  // avoids mocking fs/promises globally, which leaked into
+  // loadAgentsDir.test.ts on Linux CI even with afterEach(mock.restore()).
+  // The fresh tool import picks up the new mock.
+  const actualPlans = await import(
+    `../../utils/plans.ts?failCase=${Date.now()}-${Math.random()}`
+  )
+  mock.module('../../utils/plans.js', () => ({
+    ...actualPlans,
+    getPlanFilePath: () =>
+      '/nonexistent-dir-for-test/test-plan.md',
+    getPlan: () => 'plan content',
+    persistFileSnapshotIfRemote: () => Promise.resolve(),
   }))
 
+  const mod = await import(
+    `./ExitPlanModeV2Tool.ts?failCase=${Date.now()}-${Math.random()}`
+  )
   await expect(
-    ExitPlanModeV2Tool!.call(
+    mod.ExitPlanModeV2Tool.call(
       { plan: 'edited plan content' } as never,
       makeCtx(),
       (() => Promise.resolve({ behavior: 'allow' })) as never,
       {} as never,
     ),
-  ).rejects.toThrow('write failed')
+  ).rejects.toThrow()
 })

--- a/src/tools/ExitPlanModeTool/ExitPlanModeV2Tool.ts
+++ b/src/tools/ExitPlanModeTool/ExitPlanModeV2Tool.ts
@@ -256,7 +256,12 @@ export const ExitPlanModeV2Tool: Tool<InputSchema, Output> = buildTool({
     // after: the only other persistFileSnapshotIfRemote call (api.ts) runs
     // in normalizeToolInput, pre-permission — it captured the old plan.
     if (inputPlan !== undefined && filePath) {
-      await writeFile(filePath, inputPlan, 'utf-8').catch(e => logError(e))
+      try {
+        await writeFile(filePath, inputPlan, 'utf-8')
+      } catch (e) {
+        logError(`Failed to write plan to ${filePath}: ${e}`)
+        throw e
+      }
       void persistFileSnapshotIfRemote()
     }
 


### PR DESCRIPTION
## Summary

`ExitPlanModeV2Tool.call()` previously swallowed plan-file write failures with `logError()` and continued, causing user-edited plans to silently vanish from disk while the session proceeded as if the write succeeded. This PR surfaces the error by re-throwing it from `call()` so the model (and user) see the failure. Additionally, it ensures that live permission updates (like leaving plan mode) in the React permission request dialog are only applied *after* the edited plan file is successfully saved to disk.

## Root cause

- `src/tools/ExitPlanModeTool/ExitPlanModeV2Tool.ts:258-264` — the `try { writeFile } catch { logError }` pattern swallowed the error. The `persistFileSnapshotIfRemote()` call and subsequent teammate-approval / plan-exit bookkeeping ran even when the write failed, so the session continued with an unsaved edited plan.
- In `ExitPlanModePermissionRequest.tsx`, the permission mode transition and state updates occurred before the tool execution actually wrote the plan to disk, meaning a failed write would still advance the user out of plan mode.

## Changes

- `src/tools/ExitPlanModeTool/ExitPlanModeV2Tool.ts`: re-throw the write error after logging, so `call()` rejects and the failure surfaces to the query loop.
- `src/components/permissions/ExitPlanModePermissionRequest/ExitPlanModePermissionRequest.tsx`: extract the plan-file write into an exported `persistPlanFileBeforeExit()` helper, called from `handleResponse` *before* any state transitions or `onAllow`/`onReject`. On write failure it queues a `plan-save-error` warning and returns `false`, and `handleResponse` aborts (returns early) to keep the user in plan mode.
- `src/components/permissions/ExitPlanModePermissionRequest/ExitPlanModePermissionRequest.test.ts`: tests for `persistPlanFileBeforeExit` covering the success path and the write-failure path (returns `false` + queues the `plan-save-error` notification).
- `src/tools/ExitPlanModeTool/ExitPlanModeV2Tool.test.ts`: regression tests that force the write to fail by pointing `getPlanFilePath()` at a real path whose parent directory does not exist (a genuine `ENOENT`) — no process-global `fs/promises` mock — asserting `call()` rejects with the ENOENT and that no plan-exit side effects (`persistFileSnapshotIfRemote`, `setAppState`, teammate mailbox) run.

## Test plan

- [x] `bun test src/tools/ExitPlanModeTool/ExitPlanModeV2Tool.test.ts` — 2 pass (real-path ENOENT failure; standard + teammate modes; asserts no side effects)
- [x] `bun test src/components/permissions/ExitPlanModePermissionRequest/ExitPlanModePermissionRequest.test.ts` — 8 pass (`persistPlanFileBeforeExit` success + write-failure)
- [x] `bun run typecheck` — clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Exit Plan Mode V2 now automatically saves your edited plan to disk after eligible permission responses (excluding `'no'` and `'ultraplan'`).

* **Bug Fixes**
  * Plan save/write failures no longer proceed silently: the app logs the error, shows a high-priority `plan-save-error` warning, and stops the exit flow to prevent inconsistent state.
  * Write errors now correctly surface instead of being swallowed.

* **Tests**
  * Added/expanded ENOENT write-failure coverage, including teammate-approval scenarios, ensuring errors surface and no post-write side effects occur.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->