### PR TITLE
fix(zen): allow keyless access for free models (big-pickle, etc.)

### DIFF
--- a/src/integrations/gateways/opencode.test.ts
+++ b/src/integrations/gateways/opencode.test.ts
@@ -59,9 +59,9 @@ describe('OpenCode Zen gateway descriptor', () => {
     expect(gateway!.defaultModel).toBe('gpt-5.4')
   })
 
-  test('requires auth', () => {
+  test('does not require auth (free models like big-pickle work without a key)', () => {
     const gateway = getGateway('opencode')
-    expect(gateway!.setup.requiresAuth).toBe(true)
+    expect(gateway!.setup.requiresAuth).toBe(false)
   })
 
   test('uses api-key auth mode', () => {
@@ -87,10 +87,9 @@ describe('OpenCode Zen gateway descriptor', () => {
     expect(gateway!.preset!.apiKeyEnvVars).toContain('OPENCODE_API_KEY')
   })
 
-  test('has validation metadata', () => {
+  test('has no validation metadata (keyless access for free models)', () => {
     const gateway = getGateway('opencode')
-    expect(gateway!.validation).toBeDefined()
-    expect(gateway!.validation!.kind).toBe('credential-env')
+    expect(gateway!.validation).toBeUndefined()
   })
 
   test('has catalog with static source', () => {
@@ -444,13 +443,9 @@ describe('OpenCode edge cases', () => {
     }
   })
 
-  test('zen gateway validation message mentions OPENCODE_API_KEY', () => {
+  test('zen gateway allows keyless access for free models', () => {
     const gateway = getGateway('opencode')
-    expect(gateway!.validation!.missingCredentialMessage).toContain('OPENCODE_API_KEY')
-  })
-
-  test('zen gateway validation message mentions opencode.ai', () => {
-    const gateway = getGateway('opencode')
-    expect(gateway!.validation!.missingCredentialMessage).toContain('opencode.ai')
+    expect(gateway!.setup.requiresAuth).toBe(false)
+    expect(gateway!.validation).toBeUndefined()
   })
 })

--- a/src/integrations/gateways/opencode.ts
+++ b/src/integrations/gateways/opencode.ts
@@ -7,7 +7,7 @@ export default defineGateway({
   defaultBaseUrl: 'https://opencode.ai/zen/v1',
   defaultModel: 'gpt-5.4',
   setup: {
-    requiresAuth: true,
+    requiresAuth: false,
     authMode: 'api-key',
     credentialEnvVars: ['OPENCODE_API_KEY'],
   },
@@ -20,18 +20,9 @@ export default defineGateway({
   preset: {
     id: 'opencode',
     vendorId: 'openai',
-    description: 'OpenCode Zen — pay-as-you-go AI gateway (43 models)',
+    description: 'OpenCode Zen — pay-as-you-go AI gateway (43 models; free models work without a key)',
     apiKeyEnvVars: ['OPENCODE_API_KEY'],
     modelEnvVars: ['OPENAI_MODEL'],
-  },
-  validation: {
-    kind: 'credential-env',
-    routing: {
-      matchDefaultBaseUrl: true,
-    },
-    credentialEnvVars: ['OPENCODE_API_KEY', 'OPENAI_API_KEY'],
-    missingCredentialMessage:
-      'OPENCODE_API_KEY is required. Get your API key from https://opencode.ai',
   },
   catalog: {
     source: 'static',


### PR DESCRIPTION
## Summary

The OpenCode Zen gateway required OPENCODE_API_KEY even for free models (big-pickle, deepseek-v4-flash-free, nemotron-3-super-free, mimo-v2.5-free). Changed \equiresAuth\ to \alse\ and removed the \credential-env\ validation block so the provider is selectable without a key. Users who need paid models can still set OPENCODE_API_KEY.

## Impact

Low — removes a credential gate that shouldn't apply to free-tier models. The key is still forwarded in the HTTP request if set.

## Testing

Updated opencode gateway tests to reflect the new auth-free expectation.

## Notes

The actual API call to Zen will fail at runtime if a paid model is selected without a key, but model selection is now unblocked.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Updated the OpenCode Zen gateway to enable keyless access for free models.

* **Documentation**
  * Clarified the gateway description to state that free models work without an API key.

* **Tests**
  * Adjusted gateway descriptor expectations to reflect optional authentication and the absence of validation metadata for missing credentials.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->