### PR TITLE
feat(fireworks): add GLM-5.2 model support

### DIFF
--- a/src/integrations/brands/fireworks.ts
+++ b/src/integrations/brands/fireworks.ts
@@ -92,6 +92,7 @@ export default defineBrand({
     'accounts/fireworks/models/glm-4p7-flash',
     'accounts/fireworks/models/glm-5',
     'accounts/fireworks/models/glm-5p1',
+    'accounts/fireworks/models/glm-5p2',
     'accounts/fireworks/models/gpt-oss-120b',
     'accounts/fireworks/models/gpt-oss-20b',
     'accounts/fireworks/models/gpt-oss-safeguard-120b',

--- a/src/integrations/models/fireworks-merged.ts
+++ b/src/integrations/models/fireworks-merged.ts
@@ -866,6 +866,17 @@ export default [
 
   // ── GLM Family ────────────────────────────────────────────────────
   defineModel({
+    id: 'accounts/fireworks/models/glm-5p2',
+    defaultModel: 'accounts/fireworks/models/glm-5p2',
+    label: 'GLM 5.2',
+    brandId: 'fireworks',
+    vendorId: 'fireworks',
+    classification: ['chat', 'coding'],
+    capabilities: { supportsVision: false, supportsStreaming: true, supportsFunctionCalling: true, supportsJsonMode: true, supportsReasoning: false, supportsPreciseTokenCount: false },
+    contextWindow: 1_000_000,
+    maxOutputTokens: 32_768,
+  }),
+  defineModel({
     id: 'accounts/fireworks/models/glm-5p1',
     defaultModel: 'accounts/fireworks/models/glm-5p1',
     label: 'GLM 5.1',

--- a/src/integrations/models/fireworks-merged.ts
+++ b/src/integrations/models/fireworks-merged.ts
@@ -873,7 +873,7 @@ export default [
     vendorId: 'fireworks',
     classification: ['chat', 'coding'],
     capabilities: { supportsVision: false, supportsStreaming: true, supportsFunctionCalling: true, supportsJsonMode: true, supportsReasoning: false, supportsPreciseTokenCount: false },
-    contextWindow: 1_000_000,
+    contextWindow: 1_040_000,
     maxOutputTokens: 32_768,
   }),
   defineModel({

--- a/src/integrations/vendors/fireworks.ts
+++ b/src/integrations/vendors/fireworks.ts
@@ -508,6 +508,12 @@ export default defineVendor({
         modelDescriptorId: 'accounts/fireworks/models/glm-5',
       },
       {
+        id: 'accounts/fireworks/models/glm-5p2',
+        apiName: 'accounts/fireworks/models/glm-5p2',
+        label: 'GLM 5.2',
+        modelDescriptorId: 'accounts/fireworks/models/glm-5p2',
+      },
+      {
         id: 'accounts/fireworks/models/glm-5p1',
         apiName: 'accounts/fireworks/models/glm-5p1',
         label: 'GLM 5.1',


### PR DESCRIPTION
Add the Fireworks-hosted glm-5p2 model to both the vendor catalog and the merged model descriptor with 1M context window.

<https://fireworks.ai/models/fireworks/glm-5p2>

## Summary

- A new model was added to the provider

## Impact

- none - users can choose the new model

## Testing

- [x] `bun run build`
- [x] `bun run smoke`
- [x] `bun run check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the Fireworks GLM 5.2 (`glm-5p2`) model to the available AI model options, with its updated context window and output token limits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->