### PR TITLE
[codex] Enable Windows long paths for worktrees

### DIFF
--- a/src/utils/settings/types.ts
+++ b/src/utils/settings/types.ts
@@ -475,7 +475,7 @@ export const SettingsSchema = lazySchema(() =>
               'Directories to include when creating worktrees, via git sparse-checkout (cone mode). ' +
                 'Dramatically faster in large monorepos — only the listed paths are written to disk.',
             ),
-          enableGitLongPaths: z
+          autoConfigureLongPaths: z
             .boolean()
             .optional()
             .describe(

--- a/src/utils/settings/types.ts
+++ b/src/utils/settings/types.ts
@@ -475,6 +475,13 @@ export const SettingsSchema = lazySchema(() =>
               'Directories to include when creating worktrees, via git sparse-checkout (cone mode). ' +
                 'Dramatically faster in large monorepos — only the listed paths are written to disk.',
             ),
+          enableGitLongPaths: z
+            .boolean()
+            .optional()
+            .describe(
+              'On Windows, enable Git long-path support (core.longpaths=true) before ' +
+                'creating worktrees. Defaults to true when unset.',
+            ),
         })
         .optional()
         .describe('Git worktree configuration for --worktree flag.'),

--- a/src/utils/settings/types.ts
+++ b/src/utils/settings/types.ts
@@ -459,7 +459,16 @@ export const SettingsSchema = lazySchema(() =>
           'and feed errors back for self-repair.',
         ),
       worktree: z
-        .object({
+        .preprocess((val: any) => {
+          if (val && typeof val === 'object') {
+            const copy = { ...val }
+            if ('enableGitLongPaths' in val && !('autoConfigureLongPaths' in val)) {
+              copy.autoConfigureLongPaths = val.enableGitLongPaths
+            }
+            return copy
+          }
+          return val
+        }, z.object({
           symlinkDirectories: z
             .array(z.string())
             .optional()
@@ -482,7 +491,11 @@ export const SettingsSchema = lazySchema(() =>
               'On Windows, enable Git long-path support (core.longpaths=true) before ' +
                 'creating worktrees. Defaults to true when unset.',
             ),
-        })
+          enableGitLongPaths: z
+            .boolean()
+            .optional()
+            .describe('Deprecated alias for autoConfigureLongPaths.'),
+        }))
         .optional()
         .describe('Git worktree configuration for --worktree flag.'),
       // Whether to disable all hooks and statusLine

--- a/src/utils/settings/worktreeSettings.test.ts
+++ b/src/utils/settings/worktreeSettings.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, test } from 'bun:test'
+
+describe('SettingsSchema worktree settings', () => {
+  test('accepts autoConfigureLongPaths setting', async () => {
+    const { SettingsSchema } = await import('./types.js')
+
+    const result = SettingsSchema().safeParse({
+      worktree: {
+        autoConfigureLongPaths: false,
+      },
+    })
+
+    expect(result.success).toBe(true)
+    expect(result.data?.worktree?.autoConfigureLongPaths).toBe(false)
+  })
+
+  test('normalizes legacy enableGitLongPaths to autoConfigureLongPaths', async () => {
+    const { SettingsSchema } = await import('./types.js')
+
+    const result = SettingsSchema().safeParse({
+      worktree: {
+        enableGitLongPaths: false,
+      },
+    })
+
+    expect(result.success).toBe(true)
+    expect(result.data?.worktree?.autoConfigureLongPaths).toBe(false)
+    expect(result.data?.worktree?.enableGitLongPaths).toBe(false)
+  })
+
+  test('gives precedence to autoConfigureLongPaths when both are defined', async () => {
+    const { SettingsSchema } = await import('./types.js')
+
+    const result = SettingsSchema().safeParse({
+      worktree: {
+        autoConfigureLongPaths: true,
+        enableGitLongPaths: false,
+      },
+    })
+
+    expect(result.success).toBe(true)
+    expect(result.data?.worktree?.autoConfigureLongPaths).toBe(true)
+  })
+})

--- a/src/utils/worktree.git.test.ts
+++ b/src/utils/worktree.git.test.ts
@@ -1,10 +1,51 @@
-import { expect, mock, test } from 'bun:test'
+import { expect, mock, test, afterEach } from 'bun:test'
+
+import * as realPlatform from './platform.js'
+import * as realSettings from './settings/settings.js'
+import * as realExecFileNoThrow from './execFileNoThrow.js'
+import * as realGitFilesystem from './git/gitFilesystem.js'
+import * as realGit from './git.js'
+import * as realDebug from './debug.js'
+import * as realConfig from './config.js'
+import * as realErrors from './errors.js'
+import * as realCwd from './cwd.js'
+import * as realPath from './path.js'
+import * as realSleep from './sleep.js'
+import * as realHooks from './hooks.js'
+import * as realSwarmBackendsDetection from './swarm/backends/detection.js'
+import * as realFsPromises from 'fs/promises'
+import * as realIgnore from 'ignore'
+import * as realChildProcess from 'child_process'
+import * as realChalk from 'chalk'
+
 
 /**
  * Each test in this file sets up mock.module mocks before dynamically importing
  * `./worktree.js` with a unique cache-busting query param. This keeps mocks
  * isolated per test even though mock.module is process-global in Bun.
  */
+
+afterEach(() => {
+  mock.restore()
+  mock.module('./platform.js', () => realPlatform)
+  mock.module('./settings/settings.js', () => realSettings)
+  mock.module('./execFileNoThrow.js', () => realExecFileNoThrow)
+  mock.module('./git/gitFilesystem.js', () => realGitFilesystem)
+  mock.module('./git.js', () => realGit)
+  mock.module('./debug.js', () => realDebug)
+  mock.module('./config.js', () => realConfig)
+  mock.module('./errors.js', () => realErrors)
+  mock.module('./cwd.js', () => realCwd)
+  mock.module('./path.js', () => realPath)
+  mock.module('./sleep.js', () => realSleep)
+  mock.module('./hooks.js', () => realHooks)
+  mock.module('./swarm/backends/detection.js', () => realSwarmBackendsDetection)
+  mock.module('fs/promises', () => realFsPromises)
+  mock.module('ignore', () => realIgnore)
+  mock.module('child_process', () => realChildProcess)
+  mock.module('chalk', () => realChalk)
+})
+
 let importCounter = 0
 
 async function importTestModule(mocks: Record<string, () => object>) {
@@ -58,10 +99,10 @@ function makeExecNoThrowMock(custom: object) {
 }
 
 // ---------------------------------------------------------------------------
-// enableGitLongPathsForWorktrees — setting gating
+// autoConfigureLongPathsForWorktrees — setting gating
 // ---------------------------------------------------------------------------
 
-test('enableGitLongPaths applies core.longpaths on Windows when setting is unset (default on)', async () => {
+test('autoConfigureLongPaths applies core.longpaths on Windows when setting is unset (default on)', async () => {
   const execMock = mock(
     async (_exe: string, _args: string[], _opts?: object) => ({
       code: 0,
@@ -82,7 +123,7 @@ test('enableGitLongPaths applies core.longpaths on Windows when setting is unset
     './execFileNoThrow.js': () => makeExecNoThrowMock({ execFileNoThrowWithCwd: execMock }),
   })
 
-  await _test.enableGitLongPathsForWorktrees('/repo')
+  await _test.autoConfigureLongPathsForWorktrees('/repo')
 
   expect(execMock).toHaveBeenCalledTimes(1)
   expect(execMock).toHaveBeenCalledWith(
@@ -92,7 +133,7 @@ test('enableGitLongPaths applies core.longpaths on Windows when setting is unset
   )
 })
 
-test('enableGitLongPaths skips core.longpaths on Windows when setting is false', async () => {
+test('autoConfigureLongPaths skips core.longpaths on Windows when setting is false', async () => {
   const execMock = mock(
     async (_exe: string, _args: string[], _opts?: object) => ({
       code: 0,
@@ -112,17 +153,17 @@ test('enableGitLongPaths skips core.longpaths on Windows when setting is false',
     './settings/settings.js': () =>
       makeSettingsMock({
         getInitialSettings: () => ({
-          worktree: { enableGitLongPaths: false },
+          worktree: { autoConfigureLongPaths: false },
         }),
       }),
     './execFileNoThrow.js': () => makeExecNoThrowMock({ execFileNoThrowWithCwd: execMock }),
   })
 
-  await _test.enableGitLongPathsForWorktrees('/repo')
+  await _test.autoConfigureLongPathsForWorktrees('/repo')
   expect(execMock).not.toHaveBeenCalled()
 })
 
-test('enableGitLongPaths skips core.longpaths on non-Windows', async () => {
+test('autoConfigureLongPaths skips core.longpaths on non-Windows', async () => {
   const execMock = mock(
     async (_exe: string, _args: string[], _opts?: object) => ({
       code: 0,
@@ -143,7 +184,7 @@ test('enableGitLongPaths skips core.longpaths on non-Windows', async () => {
     './execFileNoThrow.js': () => makeExecNoThrowMock({ execFileNoThrowWithCwd: execMock }),
   })
 
-  await _test.enableGitLongPathsForWorktrees('/repo')
+  await _test.autoConfigureLongPathsForWorktrees('/repo')
   expect(execMock).not.toHaveBeenCalled()
 })
 

--- a/src/utils/worktree.git.test.ts
+++ b/src/utils/worktree.git.test.ts
@@ -1,0 +1,447 @@
+import { expect, mock, test } from 'bun:test'
+
+/**
+ * Each test in this file sets up mock.module mocks before dynamically importing
+ * `./worktree.js` with a unique cache-busting query param. This keeps mocks
+ * isolated per test even though mock.module is process-global in Bun.
+ */
+let importCounter = 0
+
+async function importTestModule(mocks: Record<string, () => object>) {
+  importCounter++
+  const suffix = `${Date.now()}.${importCounter}.${Math.random().toString(36).slice(2, 8)}`
+  for (const [modPath, factory] of Object.entries(mocks)) {
+    mock.module(modPath, factory)
+  }
+  return await import(`./worktree.js?cachebust=${suffix}`)
+}
+
+// Bun's mock.module validates that the mock factory provides ALL exports that
+// the real module exposes (including re-exports). These helpers enumerate the
+// full export set so we don't hit SyntaxError at import time.
+
+function makeSettingsMock(custom: object) {
+  return {
+    getInitialSettings: () => ({}),
+    getRelativeSettingsFilePathForSource: () => undefined,
+    getSettingsForSource: () => null,
+    loadManagedFileSettings: () => ({}),
+    getManagedFileSettingsPresence: () => ({}),
+    parseSettingsFile: () => ({}),
+    getSettingsRootPathForSource: () => '',
+    getSettingsFilePathForSource: () => '',
+    updateSettingsForSource: async () => {},
+    settingsMergeCustomizer: () => ({}),
+    getManagedSettingsKeysForLogging: () => [],
+    getSettings_DEPRECATED: () => ({}),
+    getSettingsWithSources: () => ({}),
+    getSettingsWithErrors: () => ({}),
+    hasSkipDangerousModePermissionPrompt: () => false,
+    hasSkipFullAccessModePermissionPrompt: () => false,
+    hasAllowBypassPermissionsMode: () => false,
+    hasAutoModeOptIn: () => false,
+    getUseAutoModeDuringPlan: () => false,
+    getAutoModeConfig: () => ({}),
+    rawSettingsContainsKey: () => false,
+    getPolicySettingsOrigin: () => null,
+    ...custom,
+  }
+}
+
+function makeExecNoThrowMock(custom: object) {
+  return {
+    execFileNoThrow: async () => ({ code: 0, stdout: '', stderr: '' }),
+    execFileNoThrowWithCwd: async () => ({ code: 0, stdout: '', stderr: '' }),
+    execSyncWithDefaults_DEPRECATED: () => ({ status: 0, stdout: '', stderr: '' }),
+    ...custom,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// enableGitLongPathsForWorktrees — setting gating
+// ---------------------------------------------------------------------------
+
+test('enableGitLongPaths applies core.longpaths on Windows when setting is unset (default on)', async () => {
+  const execMock = mock(
+    async (_exe: string, _args: string[], _opts?: object) => ({
+      code: 0,
+      stdout: '',
+      stderr: '',
+    }),
+  )
+
+  const { _test } = await importTestModule({
+    './platform.js': () => ({
+      SUPPORTED_PLATFORMS: ['windows'],
+      getPlatform: () => 'windows',
+      getWslVersion: () => undefined,
+      getLinuxDistroInfo: () => undefined,
+      detectVcs: async () => [],
+    }),
+    './settings/settings.js': () => makeSettingsMock({}),
+    './execFileNoThrow.js': () => makeExecNoThrowMock({ execFileNoThrowWithCwd: execMock }),
+  })
+
+  await _test.enableGitLongPathsForWorktrees('/repo')
+
+  expect(execMock).toHaveBeenCalledTimes(1)
+  expect(execMock).toHaveBeenCalledWith(
+    expect.any(String),
+    ['config', '--local', 'core.longpaths', 'true'],
+    expect.objectContaining({ cwd: '/repo' }),
+  )
+})
+
+test('enableGitLongPaths skips core.longpaths on Windows when setting is false', async () => {
+  const execMock = mock(
+    async (_exe: string, _args: string[], _opts?: object) => ({
+      code: 0,
+      stdout: '',
+      stderr: '',
+    }),
+  )
+
+  const { _test } = await importTestModule({
+    './platform.js': () => ({
+      SUPPORTED_PLATFORMS: ['windows'],
+      getPlatform: () => 'windows',
+      getWslVersion: () => undefined,
+      getLinuxDistroInfo: () => undefined,
+      detectVcs: async () => [],
+    }),
+    './settings/settings.js': () =>
+      makeSettingsMock({
+        getInitialSettings: () => ({
+          worktree: { enableGitLongPaths: false },
+        }),
+      }),
+    './execFileNoThrow.js': () => makeExecNoThrowMock({ execFileNoThrowWithCwd: execMock }),
+  })
+
+  await _test.enableGitLongPathsForWorktrees('/repo')
+  expect(execMock).not.toHaveBeenCalled()
+})
+
+test('enableGitLongPaths skips core.longpaths on non-Windows', async () => {
+  const execMock = mock(
+    async (_exe: string, _args: string[], _opts?: object) => ({
+      code: 0,
+      stdout: '',
+      stderr: '',
+    }),
+  )
+
+  const { _test } = await importTestModule({
+    './platform.js': () => ({
+      SUPPORTED_PLATFORMS: ['linux'],
+      getPlatform: () => 'linux',
+      getWslVersion: () => undefined,
+      getLinuxDistroInfo: () => undefined,
+      detectVcs: async () => [],
+    }),
+    './settings/settings.js': () => makeSettingsMock({}),
+    './execFileNoThrow.js': () => makeExecNoThrowMock({ execFileNoThrowWithCwd: execMock }),
+  })
+
+  await _test.enableGitLongPathsForWorktrees('/repo')
+  expect(execMock).not.toHaveBeenCalled()
+})
+
+// ---------------------------------------------------------------------------
+// getOrCreateWorktree — git invocation ordering and error recovery
+// ---------------------------------------------------------------------------
+
+const GIT_SHA = 'abc123def456abc123def456abc123def4567890\n'
+
+function makeBaseMocks(execMock: ReturnType<typeof mock>) {
+  return {
+    './platform.js': () => ({
+      SUPPORTED_PLATFORMS: ['windows'],
+      getPlatform: () => 'windows',
+      getWslVersion: () => undefined,
+      getLinuxDistroInfo: () => undefined,
+      detectVcs: async () => [],
+    }),
+    './settings/settings.js': () => makeSettingsMock({}),
+    './git/gitFilesystem.js': () => ({
+      clearResolveGitDirCache: () => {},
+      resolveGitDir: () => '/repo/.git',
+      isSafeRefName: () => true,
+      isValidGitSha: () => true,
+      readGitHead: async () => null,
+      resolveRef: () => null,
+      getCommonDir: () => '/repo',
+      readRawSymref: async () => null,
+      getCachedBranch: async () => 'main',
+      getCachedHead: async () => '',
+      getCachedRemoteUrl: async () => null,
+      getCachedDefaultBranch: async () => 'main',
+      resetGitFileWatcher: () => {},
+      getHeadForDir: async () => null,
+      readWorktreeHeadSha: () => null,
+      getRemoteUrlForDir: async () => null,
+      isShallowClone: async () => false,
+      getWorktreeCountFromFs: async () => 0,
+    }),
+    './git.js': () => ({
+      findGitRoot: () => '/repo',
+      findCanonicalGitRoot: () => '/repo',
+      gitExe: () => 'git',
+      getIsGit: async () => true,
+      getGitDir: async () => '/repo/.git',
+      isAtGitRoot: async () => true,
+      dirIsInGitRepo: async () => true,
+      getHead: async () => 'abc123',
+      getBranch: () => 'main',
+      getDefaultBranch: () => 'main',
+      getRemoteUrl: async () => null,
+      normalizeGitRemoteUrl: () => null,
+      getRepoRemoteHash: async () => null,
+      getIsHeadOnRemote: async () => true,
+      hasUnpushedCommits: async () => false,
+      getIsClean: async () => true,
+      getChangedFiles: async () => [],
+      getFileStatus: async () => ({}),
+      getWorktreeCount: async () => 0,
+      stashToCleanState: async () => true,
+      getGitState: async () => null,
+      getGithubRepo: async () => null,
+      findRemoteBase: async () => null,
+      preserveGitStateForIssue: async () => null,
+      isCurrentDirectoryBareGitRepo: () => false,
+    }),
+    './debug.js': () => ({
+      getMinDebugLogLevel: () => 0,
+      isDebugMode: () => false,
+      enableDebugLogging: () => {},
+      getDebugFilter: () => '',
+      isDebugToStdErr: () => false,
+      getDebugFilePath: () => '',
+      setHasFormattedOutput: () => {},
+      getHasFormattedOutput: () => false,
+      flushDebugLogs: async () => {},
+      logForDebugging: () => {},
+      getDebugLogPath: () => '',
+      logAntError: () => {},
+    }),
+    './config.js': () => ({
+      SHOW_CACHE_STATS_MODES: [],
+      MAX_MESSAGES_COMPACTION_THRESHOLDS: [],
+      normalizeMaxMessagesCompactionThreshold: () => 0,
+      DEFAULT_GLOBAL_CONFIG: {},
+      GLOBAL_CONFIG_KEYS: [],
+      isGlobalConfigKey: () => false,
+      PROJECT_CONFIG_KEYS: [],
+      resetTrustDialogAcceptedCacheForTesting: () => {},
+      checkHasTrustDialogAccepted: () => false,
+      isPathTrusted: () => true,
+      isProjectConfigKey: () => false,
+      saveGlobalConfig: async () => {},
+      getGlobalConfigWriteCount: () => 0,
+      CONFIG_WRITE_DISPLAY_THRESHOLD: 0,
+      getGlobalConfig: () => ({}),
+      getRemoteControlAtStartup: () => null,
+      getCustomApiKeyStatus: () => null,
+      enableConfigs: () => true,
+      getProjectPathForConfig: () => '',
+      getCurrentProjectConfig: () => ({}),
+      saveCurrentProjectConfig: async () => {},
+      isAutoUpdaterDisabled: () => false,
+      shouldSkipPluginAutoupdate: () => false,
+      formatAutoUpdaterDisabledReason: () => '',
+      getAutoUpdaterDisabledReason: () => '',
+      getOrCreateUserID: async () => '',
+      recordFirstStartTime: async () => {},
+      getMemoryPath: () => '',
+      getManagedClaudeRulesDir: () => '',
+      getUserClaudeRulesDir: () => '',
+      _getConfigForTesting: () => ({}),
+      _wouldLoseAuthStateForTesting: () => false,
+      _setGlobalConfigCacheForTesting: () => {},
+    }),
+    './errors.js': () => ({
+      isAbortError: () => false,
+      hasExactErrorMessage: () => false,
+      toError: (e: unknown) => e instanceof Error ? e : new Error(String(e)),
+      errorMessage: (e: unknown) => String(e),
+      getErrnoCode: () => 'TEST',
+      isENOENT: () => false,
+      getErrnoPath: () => '',
+      shortErrorStack: () => '',
+      isFsInaccessible: () => false,
+      sdkErrorFromType: () => ({} as Error),
+      classifyAxiosError: () => null,
+    }),
+    './cwd.js': () => ({
+      runWithCwdOverride: async () => {},
+      pwd: () => '/repo',
+      getCwd: () => '/repo',
+    }),
+    './path.js': () => ({
+      expandPath: (p: string) => p,
+      toRelativePath: (p: string) => p,
+      getDirectoryForPath: (p: string) => p,
+      containsPathTraversal: () => false,
+      normalizePathForConfigKey: (p: string) => p,
+    }),
+    './sleep.js': () => ({
+      sleep: async () => {},
+      withTimeout: async <T>(p: Promise<T>) => p,
+    }),
+    './hooks.js': () => ({
+      isFallbackAgentLaunchSuccessStatus: () => false,
+      getSessionEndHookTimeoutMs: () => 5000,
+      shouldSkipHookDueToTrust: () => false,
+      createBaseHookInput: () => ({}),
+      getMatchingHooks: async () => [],
+      getPreToolHookBlockingMessage: () => null,
+      getStopHookMessage: () => '',
+      getTeammateIdleHookMessage: () => null,
+      getTaskCreatedHookMessage: () => null,
+      getTaskCompletedHookMessage: () => null,
+      getUserPromptSubmitHookBlockingMessage: () => null,
+      hasBlockingResult: () => false,
+      executeNotificationHooks: async () => {},
+      executeStopFailureHooks: async () => {},
+      executePreCompactHooks: async () => {},
+      executePostCompactHooks: async () => {},
+      executeSessionEndHooks: async () => {},
+      executeConfigChangeHooks: async () => {},
+      executeCwdChangedHooks: async () => {},
+      executeFileChangedHooks: async () => {},
+      hasInstructionsLoadedHook: () => false,
+      executeInstructionsLoadedHooks: async () => {},
+      executeElicitationHooks: async () => {},
+      executeElicitationResultHooks: async () => {},
+      executeStatusLineCommand: async () => '',
+      executeFileSuggestionCommand: async () => '',
+      hasWorktreeCreateHook: () => false,
+      executeWorktreeCreateHook: async () => {},
+      executeWorktreeRemoveHook: async () => {},
+    }),
+    './swarm/backends/detection.js': () => ({
+      isInsideTmuxSync: () => false,
+      isInsideTmux: () => false,
+      getLeaderPaneId: () => null,
+      isTmuxAvailable: () => false,
+      isInITerm2: () => false,
+      IT2_COMMAND: '',
+      isIt2CliAvailable: () => false,
+      resetDetectionCache: () => {},
+    }),
+    './execFileNoThrow.js': () =>
+      makeExecNoThrowMock({ execFileNoThrowWithCwd: execMock }),
+    'fs/promises': () => ({
+      mkdir: async () => {},
+      copyFile: async () => {},
+      readdir: async () => [],
+      readFile: async () => '',
+      stat: async () => ({}),
+      symlink: async () => {},
+      utimes: async () => {},
+    }),
+    ignore: () => ({
+      default: () => ({ add: () => {}, ignores: () => false }),
+    }),
+    child_process: () => ({
+      spawnSync: () => ({ status: 0, stdout: '', stderr: '' }),
+    }),
+    chalk: () => ({
+      default: { red: (s: string) => s },
+    }),
+  }
+}
+
+test('getOrCreateWorktree calls core.longpaths before worktree add on Windows', async () => {
+  const gitCalls: string[] = []
+  const execMock = mock(
+    async (_exe: string, args: string[], _opts?: object) => {
+      const joined = args.join(' ')
+      gitCalls.push(joined)
+      if (joined.includes('rev-parse')) {
+        return { code: 0, stdout: GIT_SHA, stderr: '' }
+      }
+      return { code: 0, stdout: '', stderr: '' }
+    },
+  )
+
+  const mocks = makeBaseMocks(execMock)
+  const { _test } = await importTestModule(mocks)
+
+  await _test.getOrCreateWorktree('/repo', 'my-slug')
+
+  const longpathsIdx = gitCalls.findIndex((c: string) =>
+    c.includes('config --local core.longpaths'),
+  )
+  const addIdx = gitCalls.findIndex((c: string) =>
+    c.includes('worktree add'),
+  )
+
+  expect(longpathsIdx).toBeGreaterThanOrEqual(0)
+  expect(addIdx).toBeGreaterThanOrEqual(0)
+  expect(longpathsIdx).toBeLessThan(addIdx)
+})
+
+test('getOrCreateWorktree cleans up with worktree remove --force on failure', async () => {
+  const execMock = mock(
+    async (_exe: string, args: string[], _opts?: object) => {
+      const joined = args.join(' ')
+      if (joined.includes('rev-parse')) {
+        return { code: 0, stdout: GIT_SHA, stderr: '' }
+      }
+      if (joined.includes('worktree add')) {
+        return { code: 1, stdout: '', stderr: 'checkout failed' }
+      }
+      if (joined.includes('worktree remove')) {
+        return { code: 0, stdout: '', stderr: '' }
+      }
+      return { code: 0, stdout: '', stderr: '' }
+    },
+  )
+
+  const mocks = makeBaseMocks(execMock)
+  const { _test } = await importTestModule(mocks)
+
+  await expect(_test.getOrCreateWorktree('/repo', 'my-slug')).rejects.toThrow(
+    'Failed to create worktree',
+  )
+
+  const removeCall = execMock.mock.calls.find(
+    (c: [_exe: string, args: string[], _opts?: object]) =>
+      c[1].join(' ').includes('worktree remove'),
+  )
+  expect(removeCall).toBeDefined()
+  expect(removeCall![1]).toContain('--force')
+})
+
+test('getOrCreateWorktree does not call core.longpaths on non-Windows', async () => {
+  const gitCalls: string[] = []
+  const execMock = mock(
+    async (_exe: string, args: string[], _opts?: object) => {
+      const joined = args.join(' ')
+      gitCalls.push(joined)
+      if (joined.includes('rev-parse')) {
+        return { code: 0, stdout: GIT_SHA, stderr: '' }
+      }
+      return { code: 0, stdout: '', stderr: '' }
+    },
+  )
+
+  const mocks = makeBaseMocks(execMock)
+  mocks['./platform.js'] = () => ({
+    SUPPORTED_PLATFORMS: ['linux'],
+    getPlatform: () => 'linux',
+    getWslVersion: () => undefined,
+    getLinuxDistroInfo: () => undefined,
+    detectVcs: async () => [],
+  })
+
+  const { _test } = await importTestModule(mocks)
+
+  await _test.getOrCreateWorktree('/repo', 'my-slug')
+
+  const longpathsCalls = gitCalls.filter((c: string) =>
+    c.includes('config --local core.longpaths'),
+  )
+  expect(longpathsCalls).toHaveLength(0)
+})

--- a/src/utils/worktree.git.test.ts
+++ b/src/utils/worktree.git.test.ts
@@ -1,102 +1,12 @@
 import { expect, mock, test, afterEach } from 'bun:test'
+import { _test, _testDeps } from './worktree.js'
 
-import * as realPlatform from './platform.js'
-import * as realSettings from './settings/settings.js'
-import * as realExecFileNoThrow from './execFileNoThrow.js'
-import * as realGitFilesystem from './git/gitFilesystem.js'
-import * as realGit from './git.js'
-import * as realDebug from './debug.js'
-import * as realConfig from './config.js'
-import * as realErrors from './errors.js'
-import * as realCwd from './cwd.js'
-import * as realPath from './path.js'
-import * as realSleep from './sleep.js'
-import * as realHooks from './hooks.js'
-import * as realSwarmBackendsDetection from './swarm/backends/detection.js'
-import * as realFsPromises from 'fs/promises'
-import * as realIgnore from 'ignore'
-import * as realChildProcess from 'child_process'
-import * as realChalk from 'chalk'
-
-
-/**
- * Each test in this file sets up mock.module mocks before dynamically importing
- * `./worktree.js` with a unique cache-busting query param. This keeps mocks
- * isolated per test even though mock.module is process-global in Bun.
- */
+const originalDeps = { ..._testDeps }
 
 afterEach(() => {
   mock.restore()
-  mock.module('./platform.js', () => realPlatform)
-  mock.module('./settings/settings.js', () => realSettings)
-  mock.module('./execFileNoThrow.js', () => realExecFileNoThrow)
-  mock.module('./git/gitFilesystem.js', () => realGitFilesystem)
-  mock.module('./git.js', () => realGit)
-  mock.module('./debug.js', () => realDebug)
-  mock.module('./config.js', () => realConfig)
-  mock.module('./errors.js', () => realErrors)
-  mock.module('./cwd.js', () => realCwd)
-  mock.module('./path.js', () => realPath)
-  mock.module('./sleep.js', () => realSleep)
-  mock.module('./hooks.js', () => realHooks)
-  mock.module('./swarm/backends/detection.js', () => realSwarmBackendsDetection)
-  mock.module('fs/promises', () => realFsPromises)
-  mock.module('ignore', () => realIgnore)
-  mock.module('child_process', () => realChildProcess)
-  mock.module('chalk', () => realChalk)
+  Object.assign(_testDeps, originalDeps)
 })
-
-let importCounter = 0
-
-async function importTestModule(mocks: Record<string, () => object>) {
-  importCounter++
-  const suffix = `${Date.now()}.${importCounter}.${Math.random().toString(36).slice(2, 8)}`
-  for (const [modPath, factory] of Object.entries(mocks)) {
-    mock.module(modPath, factory)
-  }
-  return await import(`./worktree.js?cachebust=${suffix}`)
-}
-
-// Bun's mock.module validates that the mock factory provides ALL exports that
-// the real module exposes (including re-exports). These helpers enumerate the
-// full export set so we don't hit SyntaxError at import time.
-
-function makeSettingsMock(custom: object) {
-  return {
-    getInitialSettings: () => ({}),
-    getRelativeSettingsFilePathForSource: () => undefined,
-    getSettingsForSource: () => null,
-    loadManagedFileSettings: () => ({}),
-    getManagedFileSettingsPresence: () => ({}),
-    parseSettingsFile: () => ({}),
-    getSettingsRootPathForSource: () => '',
-    getSettingsFilePathForSource: () => '',
-    updateSettingsForSource: async () => {},
-    settingsMergeCustomizer: () => ({}),
-    getManagedSettingsKeysForLogging: () => [],
-    getSettings_DEPRECATED: () => ({}),
-    getSettingsWithSources: () => ({}),
-    getSettingsWithErrors: () => ({}),
-    hasSkipDangerousModePermissionPrompt: () => false,
-    hasSkipFullAccessModePermissionPrompt: () => false,
-    hasAllowBypassPermissionsMode: () => false,
-    hasAutoModeOptIn: () => false,
-    getUseAutoModeDuringPlan: () => false,
-    getAutoModeConfig: () => ({}),
-    rawSettingsContainsKey: () => false,
-    getPolicySettingsOrigin: () => null,
-    ...custom,
-  }
-}
-
-function makeExecNoThrowMock(custom: object) {
-  return {
-    execFileNoThrow: async () => ({ code: 0, stdout: '', stderr: '' }),
-    execFileNoThrowWithCwd: async () => ({ code: 0, stdout: '', stderr: '' }),
-    execSyncWithDefaults_DEPRECATED: () => ({ status: 0, stdout: '', stderr: '' }),
-    ...custom,
-  }
-}
 
 // ---------------------------------------------------------------------------
 // autoConfigureLongPathsForWorktrees — setting gating
@@ -111,17 +21,9 @@ test('autoConfigureLongPaths applies core.longpaths on Windows when setting is u
     }),
   )
 
-  const { _test } = await importTestModule({
-    './platform.js': () => ({
-      SUPPORTED_PLATFORMS: ['windows'],
-      getPlatform: () => 'windows',
-      getWslVersion: () => undefined,
-      getLinuxDistroInfo: () => undefined,
-      detectVcs: async () => [],
-    }),
-    './settings/settings.js': () => makeSettingsMock({}),
-    './execFileNoThrow.js': () => makeExecNoThrowMock({ execFileNoThrowWithCwd: execMock }),
-  })
+  _testDeps.getPlatform = () => 'windows'
+  _testDeps.getInitialSettings = () => ({})
+  _testDeps.execFileNoThrowWithCwd = execMock
 
   await _test.autoConfigureLongPathsForWorktrees('/repo')
 
@@ -142,22 +44,11 @@ test('autoConfigureLongPaths skips core.longpaths on Windows when setting is fal
     }),
   )
 
-  const { _test } = await importTestModule({
-    './platform.js': () => ({
-      SUPPORTED_PLATFORMS: ['windows'],
-      getPlatform: () => 'windows',
-      getWslVersion: () => undefined,
-      getLinuxDistroInfo: () => undefined,
-      detectVcs: async () => [],
-    }),
-    './settings/settings.js': () =>
-      makeSettingsMock({
-        getInitialSettings: () => ({
-          worktree: { autoConfigureLongPaths: false },
-        }),
-      }),
-    './execFileNoThrow.js': () => makeExecNoThrowMock({ execFileNoThrowWithCwd: execMock }),
+  _testDeps.getPlatform = () => 'windows'
+  _testDeps.getInitialSettings = () => ({
+    worktree: { autoConfigureLongPaths: false },
   })
+  _testDeps.execFileNoThrowWithCwd = execMock
 
   await _test.autoConfigureLongPathsForWorktrees('/repo')
   expect(execMock).not.toHaveBeenCalled()
@@ -172,17 +63,9 @@ test('autoConfigureLongPaths skips core.longpaths on non-Windows', async () => {
     }),
   )
 
-  const { _test } = await importTestModule({
-    './platform.js': () => ({
-      SUPPORTED_PLATFORMS: ['linux'],
-      getPlatform: () => 'linux',
-      getWslVersion: () => undefined,
-      getLinuxDistroInfo: () => undefined,
-      detectVcs: async () => [],
-    }),
-    './settings/settings.js': () => makeSettingsMock({}),
-    './execFileNoThrow.js': () => makeExecNoThrowMock({ execFileNoThrowWithCwd: execMock }),
-  })
+  _testDeps.getPlatform = () => 'linux'
+  _testDeps.getInitialSettings = () => ({})
+  _testDeps.execFileNoThrowWithCwd = execMock
 
   await _test.autoConfigureLongPathsForWorktrees('/repo')
   expect(execMock).not.toHaveBeenCalled()
@@ -193,205 +76,6 @@ test('autoConfigureLongPaths skips core.longpaths on non-Windows', async () => {
 // ---------------------------------------------------------------------------
 
 const GIT_SHA = 'abc123def456abc123def456abc123def4567890\n'
-
-function makeBaseMocks(execMock: ReturnType<typeof mock>) {
-  return {
-    './platform.js': () => ({
-      SUPPORTED_PLATFORMS: ['windows'],
-      getPlatform: () => 'windows',
-      getWslVersion: () => undefined,
-      getLinuxDistroInfo: () => undefined,
-      detectVcs: async () => [],
-    }),
-    './settings/settings.js': () => makeSettingsMock({}),
-    './git/gitFilesystem.js': () => ({
-      clearResolveGitDirCache: () => {},
-      resolveGitDir: () => '/repo/.git',
-      isSafeRefName: () => true,
-      isValidGitSha: () => true,
-      readGitHead: async () => null,
-      resolveRef: () => null,
-      getCommonDir: () => '/repo',
-      readRawSymref: async () => null,
-      getCachedBranch: async () => 'main',
-      getCachedHead: async () => '',
-      getCachedRemoteUrl: async () => null,
-      getCachedDefaultBranch: async () => 'main',
-      resetGitFileWatcher: () => {},
-      getHeadForDir: async () => null,
-      readWorktreeHeadSha: () => null,
-      getRemoteUrlForDir: async () => null,
-      isShallowClone: async () => false,
-      getWorktreeCountFromFs: async () => 0,
-    }),
-    './git.js': () => ({
-      findGitRoot: () => '/repo',
-      findCanonicalGitRoot: () => '/repo',
-      gitExe: () => 'git',
-      getIsGit: async () => true,
-      getGitDir: async () => '/repo/.git',
-      isAtGitRoot: async () => true,
-      dirIsInGitRepo: async () => true,
-      getHead: async () => 'abc123',
-      getBranch: () => 'main',
-      getDefaultBranch: () => 'main',
-      getRemoteUrl: async () => null,
-      normalizeGitRemoteUrl: () => null,
-      getRepoRemoteHash: async () => null,
-      getIsHeadOnRemote: async () => true,
-      hasUnpushedCommits: async () => false,
-      getIsClean: async () => true,
-      getChangedFiles: async () => [],
-      getFileStatus: async () => ({}),
-      getWorktreeCount: async () => 0,
-      stashToCleanState: async () => true,
-      getGitState: async () => null,
-      getGithubRepo: async () => null,
-      findRemoteBase: async () => null,
-      preserveGitStateForIssue: async () => null,
-      isCurrentDirectoryBareGitRepo: () => false,
-    }),
-    './debug.js': () => ({
-      getMinDebugLogLevel: () => 0,
-      isDebugMode: () => false,
-      enableDebugLogging: () => {},
-      getDebugFilter: () => '',
-      isDebugToStdErr: () => false,
-      getDebugFilePath: () => '',
-      setHasFormattedOutput: () => {},
-      getHasFormattedOutput: () => false,
-      flushDebugLogs: async () => {},
-      logForDebugging: () => {},
-      getDebugLogPath: () => '',
-      logAntError: () => {},
-    }),
-    './config.js': () => ({
-      SHOW_CACHE_STATS_MODES: [],
-      MAX_MESSAGES_COMPACTION_THRESHOLDS: [],
-      normalizeMaxMessagesCompactionThreshold: () => 0,
-      DEFAULT_GLOBAL_CONFIG: {},
-      GLOBAL_CONFIG_KEYS: [],
-      isGlobalConfigKey: () => false,
-      PROJECT_CONFIG_KEYS: [],
-      resetTrustDialogAcceptedCacheForTesting: () => {},
-      checkHasTrustDialogAccepted: () => false,
-      isPathTrusted: () => true,
-      isProjectConfigKey: () => false,
-      saveGlobalConfig: async () => {},
-      getGlobalConfigWriteCount: () => 0,
-      CONFIG_WRITE_DISPLAY_THRESHOLD: 0,
-      getGlobalConfig: () => ({}),
-      getRemoteControlAtStartup: () => null,
-      getCustomApiKeyStatus: () => null,
-      enableConfigs: () => true,
-      getProjectPathForConfig: () => '',
-      getCurrentProjectConfig: () => ({}),
-      saveCurrentProjectConfig: async () => {},
-      isAutoUpdaterDisabled: () => false,
-      shouldSkipPluginAutoupdate: () => false,
-      formatAutoUpdaterDisabledReason: () => '',
-      getAutoUpdaterDisabledReason: () => '',
-      getOrCreateUserID: async () => '',
-      recordFirstStartTime: async () => {},
-      getMemoryPath: () => '',
-      getManagedClaudeRulesDir: () => '',
-      getUserClaudeRulesDir: () => '',
-      _getConfigForTesting: () => ({}),
-      _wouldLoseAuthStateForTesting: () => false,
-      _setGlobalConfigCacheForTesting: () => {},
-    }),
-    './errors.js': () => ({
-      isAbortError: () => false,
-      hasExactErrorMessage: () => false,
-      toError: (e: unknown) => e instanceof Error ? e : new Error(String(e)),
-      errorMessage: (e: unknown) => String(e),
-      getErrnoCode: () => 'TEST',
-      isENOENT: () => false,
-      getErrnoPath: () => '',
-      shortErrorStack: () => '',
-      isFsInaccessible: () => false,
-      sdkErrorFromType: () => ({} as Error),
-      classifyAxiosError: () => null,
-    }),
-    './cwd.js': () => ({
-      runWithCwdOverride: async () => {},
-      pwd: () => '/repo',
-      getCwd: () => '/repo',
-    }),
-    './path.js': () => ({
-      expandPath: (p: string) => p,
-      toRelativePath: (p: string) => p,
-      getDirectoryForPath: (p: string) => p,
-      containsPathTraversal: () => false,
-      normalizePathForConfigKey: (p: string) => p,
-    }),
-    './sleep.js': () => ({
-      sleep: async () => {},
-      withTimeout: async <T>(p: Promise<T>) => p,
-    }),
-    './hooks.js': () => ({
-      isFallbackAgentLaunchSuccessStatus: () => false,
-      getSessionEndHookTimeoutMs: () => 5000,
-      shouldSkipHookDueToTrust: () => false,
-      createBaseHookInput: () => ({}),
-      getMatchingHooks: async () => [],
-      getPreToolHookBlockingMessage: () => null,
-      getStopHookMessage: () => '',
-      getTeammateIdleHookMessage: () => null,
-      getTaskCreatedHookMessage: () => null,
-      getTaskCompletedHookMessage: () => null,
-      getUserPromptSubmitHookBlockingMessage: () => null,
-      hasBlockingResult: () => false,
-      executeNotificationHooks: async () => {},
-      executeStopFailureHooks: async () => {},
-      executePreCompactHooks: async () => {},
-      executePostCompactHooks: async () => {},
-      executeSessionEndHooks: async () => {},
-      executeConfigChangeHooks: async () => {},
-      executeCwdChangedHooks: async () => {},
-      executeFileChangedHooks: async () => {},
-      hasInstructionsLoadedHook: () => false,
-      executeInstructionsLoadedHooks: async () => {},
-      executeElicitationHooks: async () => {},
-      executeElicitationResultHooks: async () => {},
-      executeStatusLineCommand: async () => '',
-      executeFileSuggestionCommand: async () => '',
-      hasWorktreeCreateHook: () => false,
-      executeWorktreeCreateHook: async () => {},
-      executeWorktreeRemoveHook: async () => {},
-    }),
-    './swarm/backends/detection.js': () => ({
-      isInsideTmuxSync: () => false,
-      isInsideTmux: () => false,
-      getLeaderPaneId: () => null,
-      isTmuxAvailable: () => false,
-      isInITerm2: () => false,
-      IT2_COMMAND: '',
-      isIt2CliAvailable: () => false,
-      resetDetectionCache: () => {},
-    }),
-    './execFileNoThrow.js': () =>
-      makeExecNoThrowMock({ execFileNoThrowWithCwd: execMock }),
-    'fs/promises': () => ({
-      mkdir: async () => {},
-      copyFile: async () => {},
-      readdir: async () => [],
-      readFile: async () => '',
-      stat: async () => ({}),
-      symlink: async () => {},
-      utimes: async () => {},
-    }),
-    ignore: () => ({
-      default: () => ({ add: () => {}, ignores: () => false }),
-    }),
-    child_process: () => ({
-      spawnSync: () => ({ status: 0, stdout: '', stderr: '' }),
-    }),
-    chalk: () => ({
-      default: { red: (s: string) => s },
-    }),
-  }
-}
 
 test('getOrCreateWorktree calls core.longpaths before worktree add on Windows', async () => {
   const gitCalls: string[] = []
@@ -406,8 +90,14 @@ test('getOrCreateWorktree calls core.longpaths before worktree add on Windows', 
     },
   )
 
-  const mocks = makeBaseMocks(execMock)
-  const { _test } = await importTestModule(mocks)
+  _testDeps.getPlatform = () => 'windows'
+  _testDeps.getInitialSettings = () => ({})
+  _testDeps.readWorktreeHeadSha = async () => null
+  _testDeps.resolveGitDir = async () => '/repo/.git'
+  _testDeps.resolveRef = async () => null
+  _testDeps.getDefaultBranch = async () => 'main'
+  _testDeps.mkdir = async () => undefined
+  _testDeps.execFileNoThrowWithCwd = execMock
 
   await _test.getOrCreateWorktree('/repo', 'my-slug')
 
@@ -440,8 +130,14 @@ test('getOrCreateWorktree cleans up with worktree remove --force on failure', as
     },
   )
 
-  const mocks = makeBaseMocks(execMock)
-  const { _test } = await importTestModule(mocks)
+  _testDeps.getPlatform = () => 'windows'
+  _testDeps.getInitialSettings = () => ({})
+  _testDeps.readWorktreeHeadSha = async () => null
+  _testDeps.resolveGitDir = async () => '/repo/.git'
+  _testDeps.resolveRef = async () => null
+  _testDeps.getDefaultBranch = async () => 'main'
+  _testDeps.mkdir = async () => undefined
+  _testDeps.execFileNoThrowWithCwd = execMock
 
   await expect(_test.getOrCreateWorktree('/repo', 'my-slug')).rejects.toThrow(
     'Failed to create worktree',
@@ -468,16 +164,14 @@ test('getOrCreateWorktree does not call core.longpaths on non-Windows', async ()
     },
   )
 
-  const mocks = makeBaseMocks(execMock)
-  mocks['./platform.js'] = () => ({
-    SUPPORTED_PLATFORMS: ['linux'],
-    getPlatform: () => 'linux',
-    getWslVersion: () => undefined,
-    getLinuxDistroInfo: () => undefined,
-    detectVcs: async () => [],
-  })
-
-  const { _test } = await importTestModule(mocks)
+  _testDeps.getPlatform = () => 'linux'
+  _testDeps.getInitialSettings = () => ({})
+  _testDeps.readWorktreeHeadSha = async () => null
+  _testDeps.resolveGitDir = async () => '/repo/.git'
+  _testDeps.resolveRef = async () => null
+  _testDeps.getDefaultBranch = async () => 'main'
+  _testDeps.mkdir = async () => undefined
+  _testDeps.execFileNoThrowWithCwd = execMock
 
   await _test.getOrCreateWorktree('/repo', 'my-slug')
 

--- a/src/utils/worktree.test.ts
+++ b/src/utils/worktree.test.ts
@@ -3,6 +3,7 @@ import { afterEach, expect, test } from 'bun:test'
 import {
   _resetGitWorktreeMutationLocksForTesting,
   buildRevParseFailureMessage,
+  buildWorktreeCreationFailureMessage,
   withGitWorktreeMutationLock,
 } from './worktree.js'
 
@@ -98,4 +99,18 @@ test('buildRevParseFailureMessage skips HEAD-specific hint for branch refs', () 
 test('buildRevParseFailureMessage trims trailing whitespace from stderr', () => {
   const msg = buildRevParseFailureMessage('HEAD', '  some error\n\n', 128)
   expect(msg).toContain(': some error (HEAD')
+})
+
+test('buildWorktreeCreationFailureMessage provides a Windows long-path recovery hint', () => {
+  const msg = buildWorktreeCreationFailureMessage(
+    'error: unable to create file src/components/example.tsx: Filename too long\n',
+  )
+  expect(msg).toContain('Failed to create worktree')
+  expect(msg).toContain('Filename too long')
+
+  if (process.platform === 'win32') {
+    expect(msg).toContain('core.longpaths true')
+  } else {
+    expect(msg).not.toContain('core.longpaths true')
+  }
 })

--- a/src/utils/worktree.test.ts
+++ b/src/utils/worktree.test.ts
@@ -2,6 +2,7 @@ import { afterEach, expect, test } from 'bun:test'
 
 import {
   _resetGitWorktreeMutationLocksForTesting,
+  _testDeps,
   buildRevParseFailureMessage,
   buildWorktreeCreationFailureMessage,
   withGitWorktreeMutationLock,
@@ -101,16 +102,32 @@ test('buildRevParseFailureMessage trims trailing whitespace from stderr', () => 
   expect(msg).toContain(': some error (HEAD')
 })
 
-test('buildWorktreeCreationFailureMessage provides a Windows long-path recovery hint', () => {
-  const msg = buildWorktreeCreationFailureMessage(
-    'error: unable to create file src/components/example.tsx: Filename too long\n',
-  )
-  expect(msg).toContain('Failed to create worktree')
-  expect(msg).toContain('Filename too long')
-
-  if (process.platform === 'win32') {
+test('buildWorktreeCreationFailureMessage provides a Windows long-path recovery hint on Windows', () => {
+  const originalGetPlatform = _testDeps.getPlatform
+  _testDeps.getPlatform = () => 'windows'
+  try {
+    const msg = buildWorktreeCreationFailureMessage(
+      'error: unable to create file src/components/example.tsx: Filename too long\n',
+    )
+    expect(msg).toContain('Failed to create worktree')
+    expect(msg).toContain('Filename too long')
     expect(msg).toContain('core.longpaths true')
-  } else {
+  } finally {
+    _testDeps.getPlatform = originalGetPlatform
+  }
+})
+
+test('buildWorktreeCreationFailureMessage does not provide a Windows long-path recovery hint on non-Windows', () => {
+  const originalGetPlatform = _testDeps.getPlatform
+  _testDeps.getPlatform = () => 'linux'
+  try {
+    const msg = buildWorktreeCreationFailureMessage(
+      'error: unable to create file src/components/example.tsx: Filename too long\n',
+    )
+    expect(msg).toContain('Failed to create worktree')
+    expect(msg).toContain('Filename too long')
     expect(msg).not.toContain('core.longpaths true')
+  } finally {
+    _testDeps.getPlatform = originalGetPlatform
   }
 })

--- a/src/utils/worktree.ts
+++ b/src/utils/worktree.ts
@@ -49,8 +49,12 @@ import { isInITerm2 } from './swarm/backends/detection.js'
 export const _testDeps = {
   getPlatform: () => getPlatform(),
   getInitialSettings: () => getInitialSettings(),
-  execFileNoThrowWithCwd: (exe: string, args: string[], opts?: any) => execFileNoThrowWithCwd(exe, args, opts),
-  mkdir: (path: string, opts?: any) => mkdir(path, opts),
+  execFileNoThrowWithCwd: (
+    exe: string,
+    args: string[],
+    opts?: Parameters<typeof execFileNoThrowWithCwd>[2],
+  ) => execFileNoThrowWithCwd(exe, args, opts),
+  mkdir: (path: string, opts?: Parameters<typeof mkdir>[1]) => mkdir(path, opts),
   readWorktreeHeadSha: (path: string) => readWorktreeHeadSha(path),
   resolveGitDir: (path: string) => resolveGitDir(path),
   resolveRef: (gitDir: string, ref: string) => resolveRef(gitDir, ref),
@@ -485,7 +489,11 @@ async function getOrCreateWorktree(
           { cwd: worktreePath },
         )
       if (sparseCode !== 0) {
-        await tearDown(`Failed to configure sparse-checkout: ${sparseErr}`)
+        await tearDown(
+          buildWorktreeCreationFailureMessage(
+            `Failed to configure sparse-checkout: ${sparseErr}`,
+          ),
+        )
       }
       const { code: coCode, stderr: coErr } = await _testDeps.execFileNoThrowWithCwd(
         gitExe(),
@@ -493,7 +501,11 @@ async function getOrCreateWorktree(
         { cwd: worktreePath },
       )
       if (coCode !== 0) {
-        await tearDown(`Failed to checkout sparse worktree: ${coErr}`)
+        await tearDown(
+          buildWorktreeCreationFailureMessage(
+            `Failed to checkout sparse worktree: ${coErr}`,
+          ),
+        )
       }
     }
 

--- a/src/utils/worktree.ts
+++ b/src/utils/worktree.ts
@@ -45,6 +45,18 @@ import {
 import { sleep } from './sleep.js'
 import { isInITerm2 } from './swarm/backends/detection.js'
 
+/** @private exported for testing only */
+export const _testDeps = {
+  getPlatform: () => getPlatform(),
+  getInitialSettings: () => getInitialSettings(),
+  execFileNoThrowWithCwd: (exe: string, args: string[], opts?: any) => execFileNoThrowWithCwd(exe, args, opts),
+  mkdir: (path: string, opts?: any) => mkdir(path, opts),
+  readWorktreeHeadSha: (path: string) => readWorktreeHeadSha(path),
+  resolveGitDir: (path: string) => resolveGitDir(path),
+  resolveRef: (gitDir: string, ref: string) => resolveRef(gitDir, ref),
+  getDefaultBranch: () => getDefaultBranch(),
+}
+
 const VALID_WORKTREE_SLUG_SEGMENT = /^[a-zA-Z0-9._-]+$/
 const MAX_WORKTREE_SLUG_LENGTH = 64
 
@@ -287,16 +299,16 @@ function worktreePathFor(repoRoot: string, slug: string): string {
  * already attempted the checkout.
  */
 async function autoConfigureLongPathsForWorktrees(repoRoot: string): Promise<void> {
-  if (getPlatform() !== 'windows') {
+  if (_testDeps.getPlatform() !== 'windows') {
     return
   }
 
-  const settings = getInitialSettings().worktree
+  const settings = _testDeps.getInitialSettings().worktree
   if (settings?.autoConfigureLongPaths === false) {
     return
   }
 
-  const { code, stderr } = await execFileNoThrowWithCwd(
+  const { code, stderr } = await _testDeps.execFileNoThrowWithCwd(
     gitExe(),
     ['config', '--local', 'core.longpaths', 'true'],
     { cwd: repoRoot },
@@ -312,7 +324,7 @@ async function autoConfigureLongPathsForWorktrees(repoRoot: string): Promise<voi
 export function buildWorktreeCreationFailureMessage(stderr: string): string {
   const detail = stderr.trim() || 'no error detail'
   const longPathHint =
-    getPlatform() === 'windows' && /filename too long/i.test(stderr)
+    _testDeps.getPlatform() === 'windows' && /filename too long/i.test(stderr)
       ? ' Git rejected a long path; run `git config --local core.longpaths true` in the main repository and retry.'
       : ''
   return `Failed to create worktree: ${detail}${longPathHint}`
@@ -336,7 +348,7 @@ async function getOrCreateWorktree(
   // Read the .git pointer file directly (no subprocess, no upward walk) — a
   // subprocess `rev-parse HEAD` burns ~15ms on spawn overhead even for a 2ms
   // task, and the await yield lets background spawnSyncs pile on (seen at 55ms).
-  const existingHead = await readWorktreeHeadSha(worktreePath)
+  const existingHead = await _testDeps.readWorktreeHeadSha(worktreePath)
   if (existingHead) {
     return {
       worktreePath,
@@ -347,7 +359,7 @@ async function getOrCreateWorktree(
   }
 
   return withGitWorktreeMutationLock(repoRoot, async () => {
-    const lockedExistingHead = await readWorktreeHeadSha(worktreePath)
+    const lockedExistingHead = await _testDeps.readWorktreeHeadSha(worktreePath)
     if (lockedExistingHead) {
       return {
         worktreePath,
@@ -358,7 +370,7 @@ async function getOrCreateWorktree(
     }
 
     // New worktree: fetch base branch then add
-    await mkdir(worktreesDir(repoRoot), { recursive: true })
+    await _testDeps.mkdir(worktreesDir(repoRoot), { recursive: true })
     await autoConfigureLongPathsForWorktrees(repoRoot)
 
     const fetchEnv = { ...process.env, ...GIT_NO_PROMPT_ENV }
@@ -367,7 +379,7 @@ async function getOrCreateWorktree(
     let baseSha: string | null = null
     if (options?.prNumber) {
       const { code: prFetchCode, stderr: prFetchStderr } =
-        await execFileNoThrowWithCwd(
+        await _testDeps.execFileNoThrowWithCwd(
           gitExe(),
           ['fetch', 'origin', `pull/${options.prNumber}/head`],
           { cwd: repoRoot, stdin: 'ignore', env: fetchEnv },
@@ -386,18 +398,18 @@ async function getOrCreateWorktree(
       // resolveRef reads the loose/packed ref directly; when it succeeds we
       // already have the SHA, so the later rev-parse is skipped entirely.
       const [defaultBranch, gitDir] = await Promise.all([
-        getDefaultBranch(),
-        resolveGitDir(repoRoot),
+        _testDeps.getDefaultBranch(),
+        _testDeps.resolveGitDir(repoRoot),
       ])
       const originRef = `origin/${defaultBranch}`
       const originSha = gitDir
-        ? await resolveRef(gitDir, `refs/remotes/origin/${defaultBranch}`)
+        ? await _testDeps.resolveRef(gitDir, `refs/remotes/origin/${defaultBranch}`)
         : null
       if (originSha) {
         baseBranch = originRef
         baseSha = originSha
       } else {
-        const { code: fetchCode } = await execFileNoThrowWithCwd(
+        const { code: fetchCode } = await _testDeps.execFileNoThrowWithCwd(
           gitExe(),
           ['fetch', 'origin', defaultBranch],
           { cwd: repoRoot, stdin: 'ignore', env: fetchEnv },
@@ -409,7 +421,7 @@ async function getOrCreateWorktree(
     // For the fetch/PR-fetch paths we still need the SHA — the fs-only resolveRef
     // above only covers the "origin/<branch> already exists locally" case.
     if (!baseSha) {
-      const { stdout, stderr, code: shaCode } = await execFileNoThrowWithCwd(
+      const { stdout, stderr, code: shaCode } = await _testDeps.execFileNoThrowWithCwd(
         gitExe(),
         ['rev-parse', baseBranch],
         { cwd: repoRoot },
@@ -422,7 +434,7 @@ async function getOrCreateWorktree(
       baseSha = stdout.trim()
     }
 
-    const sparsePaths = getInitialSettings().worktree?.sparsePaths
+    const sparsePaths = _testDeps.getInitialSettings().worktree?.sparsePaths
     const addArgs = ['worktree', 'add']
     if (sparsePaths?.length) {
       addArgs.push('--no-checkout')
@@ -432,14 +444,14 @@ async function getOrCreateWorktree(
     addArgs.push('-B', worktreeBranch, worktreePath, baseBranch)
 
     const { code: createCode, stderr: createStderr } =
-      await execFileNoThrowWithCwd(gitExe(), addArgs, { cwd: repoRoot })
+      await _testDeps.execFileNoThrowWithCwd(gitExe(), addArgs, { cwd: repoRoot })
     if (createCode !== 0) {
       // `git worktree add` creates and registers the worktree before checking
       // out its files. If checkout fails (for example, due to a Windows path
       // limit), leaving it in place makes the fast-resume path treat the
       // incomplete worktree as healthy on the next attempt.
       const { code: cleanupCode, stderr: cleanupStderr } =
-        await execFileNoThrowWithCwd(
+        await _testDeps.execFileNoThrowWithCwd(
           gitExe(),
           ['worktree', 'remove', '--force', worktreePath],
           { cwd: repoRoot },
@@ -459,7 +471,7 @@ async function getOrCreateWorktree(
       // fast-resume (rev-parse HEAD) would succeed and present a broken worktree
       // as "resumed". Tear it down before propagating the error.
       const tearDown = async (msg: string): Promise<never> => {
-        await execFileNoThrowWithCwd(
+        await _testDeps.execFileNoThrowWithCwd(
           gitExe(),
           ['worktree', 'remove', '--force', worktreePath],
           { cwd: repoRoot },
@@ -467,7 +479,7 @@ async function getOrCreateWorktree(
         throw new Error(msg)
       }
       const { code: sparseCode, stderr: sparseErr } =
-        await execFileNoThrowWithCwd(
+        await _testDeps.execFileNoThrowWithCwd(
           gitExe(),
           ['sparse-checkout', 'set', '--cone', '--', ...sparsePaths],
           { cwd: worktreePath },
@@ -475,7 +487,7 @@ async function getOrCreateWorktree(
       if (sparseCode !== 0) {
         await tearDown(`Failed to configure sparse-checkout: ${sparseErr}`)
       }
-      const { code: coCode, stderr: coErr } = await execFileNoThrowWithCwd(
+      const { code: coCode, stderr: coErr } = await _testDeps.execFileNoThrowWithCwd(
         gitExe(),
         ['checkout', 'HEAD'],
         { cwd: worktreePath },

--- a/src/utils/worktree.ts
+++ b/src/utils/worktree.ts
@@ -277,6 +277,43 @@ function worktreePathFor(repoRoot: string, slug: string): string {
 }
 
 /**
+ * Git for Windows keeps long-path support opt-in, even on Windows versions
+ * that support extended-length paths. Worktrees add a few directory segments
+ * to every checked-out file, so a repository that works at its root can still
+ * fail while `git worktree add` is checking it out.
+ *
+ * This is a repository-local setting: it affects only Git operations in this
+ * repository and is required before creating the worktree, not after Git has
+ * already attempted the checkout.
+ */
+async function enableGitLongPathsForWorktrees(repoRoot: string): Promise<void> {
+  if (getPlatform() !== 'windows') {
+    return
+  }
+
+  const { code, stderr } = await execFileNoThrowWithCwd(
+    gitExe(),
+    ['config', '--local', 'core.longpaths', 'true'],
+    { cwd: repoRoot },
+  )
+  if (code !== 0) {
+    logForDebugging(
+      `Could not enable Git long-path support before creating worktree: ${stderr.trim() || `exit code ${code}`}`,
+      { level: 'warn' },
+    )
+  }
+}
+
+export function buildWorktreeCreationFailureMessage(stderr: string): string {
+  const detail = stderr.trim() || 'no error detail'
+  const longPathHint =
+    getPlatform() === 'windows' && /filename too long/i.test(stderr)
+      ? ' Git rejected a long path; run `git config --local core.longpaths true` in the main repository and retry.'
+      : ''
+  return `Failed to create worktree: ${detail}${longPathHint}`
+}
+
+/**
  * Creates a new git worktree for the given slug, or resumes it if it already exists.
  * Named worktrees reuse the same path across invocations, so the existence check
  * prevents unconditionally running `git fetch` (which can hang waiting for credentials)
@@ -317,6 +354,7 @@ async function getOrCreateWorktree(
 
     // New worktree: fetch base branch then add
     await mkdir(worktreesDir(repoRoot), { recursive: true })
+    await enableGitLongPathsForWorktrees(repoRoot)
 
     const fetchEnv = { ...process.env, ...GIT_NO_PROMPT_ENV }
 
@@ -391,7 +429,23 @@ async function getOrCreateWorktree(
     const { code: createCode, stderr: createStderr } =
       await execFileNoThrowWithCwd(gitExe(), addArgs, { cwd: repoRoot })
     if (createCode !== 0) {
-      throw new Error(`Failed to create worktree: ${createStderr}`)
+      // `git worktree add` creates and registers the worktree before checking
+      // out its files. If checkout fails (for example, due to a Windows path
+      // limit), leaving it in place makes the fast-resume path treat the
+      // incomplete worktree as healthy on the next attempt.
+      const { code: cleanupCode, stderr: cleanupStderr } =
+        await execFileNoThrowWithCwd(
+          gitExe(),
+          ['worktree', 'remove', '--force', worktreePath],
+          { cwd: repoRoot },
+        )
+      if (cleanupCode !== 0) {
+        logForDebugging(
+          `Could not remove incomplete worktree after creation failure: ${cleanupStderr.trim() || `exit code ${cleanupCode}`}`,
+          { level: 'warn' },
+        )
+      }
+      throw new Error(buildWorktreeCreationFailureMessage(createStderr))
     }
 
     if (sparsePaths?.length) {

--- a/src/utils/worktree.ts
+++ b/src/utils/worktree.ts
@@ -286,13 +286,13 @@ function worktreePathFor(repoRoot: string, slug: string): string {
  * repository and is required before creating the worktree, not after Git has
  * already attempted the checkout.
  */
-async function enableGitLongPathsForWorktrees(repoRoot: string): Promise<void> {
+async function autoConfigureLongPathsForWorktrees(repoRoot: string): Promise<void> {
   if (getPlatform() !== 'windows') {
     return
   }
 
   const settings = getInitialSettings().worktree
-  if (settings?.enableGitLongPaths === false) {
+  if (settings?.autoConfigureLongPaths === false) {
     return
   }
 
@@ -359,7 +359,7 @@ async function getOrCreateWorktree(
 
     // New worktree: fetch base branch then add
     await mkdir(worktreesDir(repoRoot), { recursive: true })
-    await enableGitLongPathsForWorktrees(repoRoot)
+    await autoConfigureLongPathsForWorktrees(repoRoot)
 
     const fetchEnv = { ...process.env, ...GIT_NO_PROMPT_ENV }
 
@@ -1642,5 +1642,5 @@ export async function execIntoTmuxWorktree(args: string[]): Promise<{
 /** @private exported for testing only */
 export const _test = {
   getOrCreateWorktree,
-  enableGitLongPathsForWorktrees,
+  autoConfigureLongPathsForWorktrees,
 }

--- a/src/utils/worktree.ts
+++ b/src/utils/worktree.ts
@@ -291,6 +291,11 @@ async function enableGitLongPathsForWorktrees(repoRoot: string): Promise<void> {
     return
   }
 
+  const settings = getInitialSettings().worktree
+  if (settings?.enableGitLongPaths === false) {
+    return
+  }
+
   const { code, stderr } = await execFileNoThrowWithCwd(
     gitExe(),
     ['config', '--local', 'core.longpaths', 'true'],
@@ -1632,4 +1637,10 @@ export async function execIntoTmuxWorktree(args: string[]): Promise<{
   }
 
   return { handled: true }
+}
+
+/** @private exported for testing only */
+export const _test = {
+  getOrCreateWorktree,
+  enableGitLongPathsForWorktrees,
 }


### PR DESCRIPTION
## Summary

- Enable Git long-path support locally before Windows worktree creation.
- Remove a partially created worktree when checkout fails so a retry does not resume invalid state.
- Add an actionable long-path recovery hint and focused coverage.

## Root cause

Git for Windows leaves `core.longpaths` disabled by default. Creating a worktree adds directory segments to each checked-out file, which can push otherwise valid repository paths beyond the legacy Windows limit. Git registers the worktree before checkout, so a failed checkout could also leave a partial worktree that later appeared resumable.

## Impact

Windows users can create agent and session worktrees in repositories with long source paths, and failed checkouts no longer leave stale worktrees that block clean retries.

## Validation

- `bun test src/utils/worktree.test.ts` (7 passing)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional Windows setting `worktree.autoConfigureLongPaths` (enabled by default) to automatically apply Git `core.longpaths` before creating worktrees.
  * Legacy `worktree.enableGitLongPaths` is now mapped to `worktree.autoConfigureLongPaths` (with `autoConfigureLongPaths` taking precedence when both are set).
* **Bug Fixes**
  * Improved worktree creation error handling: attempts to force-remove partially created worktrees on `worktree add` failures and enhances Windows “filename too long” remediation messaging.
* **Tests**
  * Added/expanded Bun unit tests covering Windows vs non-Windows long-path behavior, command ordering, failure recovery cleanup, and settings normalization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->