### PR TITLE
feat(settings): add settings-based subscription override and agy terminal support

### DIFF
--- a/src/commands/provider/provider.test.tsx
+++ b/src/commands/provider/provider.test.tsx
@@ -439,7 +439,7 @@ test('buildProfileSaveMessage describes Gemini access token / ADC mode clearly',
     'D:/codings/Opensource/openclaude/.openclaude-profile.json',
   )
 
-  expect(message).toContain('Saved Google Gemini profile.')
+  expect(message).toContain('Saved Google AI / Gemini profile.')
   expect(message).toContain('Model: gemini-2.5-flash')
   expect(message).toContain('Credentials: access token (stored securely)')
   expect(message).not.toContain('AIza')
@@ -693,7 +693,7 @@ test('buildCurrentProviderSummary recognizes Gemini mode', () => {
     persisted: null,
   })
 
-  expect(summary.providerLabel).toBe('Google Gemini')
+  expect(summary.providerLabel).toBe('Google AI / Gemini')
   expect(summary.modelLabel).toBe('gemini-2.5-pro')
   expect(summary.endpointLabel).toBe(
     'https://generativelanguage.googleapis.com/v1beta/openai',

--- a/src/commands/provider/provider.tsx
+++ b/src/commands/provider/provider.tsx
@@ -1646,34 +1646,31 @@ export function ProviderWizard({
       )
     }
 
-    case 'gemini-key':
+    case 'gemini-key': {
+      const currentGeminiApiKey =
+        process.env.GEMINI_API_KEY || process.env.GOOGLE_API_KEY || ''
       return (
         <TextEntryDialog
           resetStateKey={step.name}
           title="Google AI / Gemini setup"
           subtitle="Step 1 of 3"
           description={
-            process.env.GEMINI_API_KEY || process.env.GOOGLE_API_KEY
+            currentGeminiApiKey
               ? 'Enter a Google AI / Gemini API key, or leave this blank to reuse the current GEMINI_API_KEY/GOOGLE_API_KEY from this session.'
               : 'Enter a Google AI / Gemini API key. You can create one at https://aistudio.google.com/apikey.'
           }
           initialValue=""
           placeholder="AIza..."
           mask="*"
-          allowEmpty={Boolean(
-            process.env.GEMINI_API_KEY ?? process.env.GOOGLE_API_KEY,
-          )}
+          allowEmpty={Boolean(currentGeminiApiKey)}
           onSubmit={value => {
-            const apiKey =
-              value.trim() ||
-              process.env.GEMINI_API_KEY ||
-              process.env.GOOGLE_API_KEY ||
-              ''
+            const apiKey = value.trim() || currentGeminiApiKey
             setStep({ name: 'gemini-model', apiKey, authMode: 'api-key' })
           }}
           onCancel={() => setStep({ name: 'gemini-auth-method' })}
         />
       )
+    }
 
     case 'gemini-access-token': {
       const currentToken =

--- a/src/commands/provider/provider.tsx
+++ b/src/commands/provider/provider.tsx
@@ -695,10 +695,10 @@ function ProviderChooser({
       description: 'OpenAI and similar OpenAI-compatible APIs',
     },
     {
-      label: 'Google AI / Gemini Subscription',
+      label: 'Google AI / Gemini',
       value: 'gemini',
       description:
-        'Use your Google AI Premium plan, Gemini API key, access token, or local ADC',
+        'Use a Gemini API key, access token, or local ADC',
     },
     {
       label: mistralMetadata.label,

--- a/src/commands/provider/provider.tsx
+++ b/src/commands/provider/provider.tsx
@@ -526,8 +526,8 @@ export function buildProfileSaveMessage(
 function buildUsageText(): string {
   const summary = buildCurrentProviderSummary()
   const availableProviders = isBareMode()
-    ? 'Choose Auto, Ollama, OpenAI-compatible, Gemini, or Codex, then save a provider profile.'
-    : 'Choose Auto, Ollama, OpenAI-compatible, Gemini, Codex, or Codex OAuth, then save a provider profile.'
+    ? 'Choose Auto, Ollama, OpenAI-compatible, Google AI / Gemini, or Codex, then save a provider profile.'
+    : 'Choose Auto, Ollama, OpenAI-compatible, Google AI / Gemini, Codex, or Codex OAuth, then save a provider profile.'
   return [
     'Usage: /provider',
     '',
@@ -695,9 +695,10 @@ function ProviderChooser({
       description: 'OpenAI and similar OpenAI-compatible APIs',
     },
     {
-      label: geminiMetadata.label,
+      label: 'Google AI / Gemini Subscription',
       value: 'gemini',
-      description: 'Use Gemini with API key, access token, or local ADC',
+      description:
+        'Use your Google AI Premium plan, Gemini API key, access token, or local ADC',
     },
     {
       label: mistralMetadata.label,
@@ -1595,8 +1596,8 @@ export function ProviderWizard({
           label: 'API key',
           value: 'api-key',
           description: hasShellGeminiKey
-            ? 'Use the current Gemini API key from this shell, or enter a new one'
-            : 'Use a Google Gemini API key',
+            ? 'Use the current Google AI / Gemini API key from this shell, or enter a new one'
+            : 'Use a Google AI / Gemini API key',
         },
         {
           label: 'Access token',
@@ -1605,9 +1606,9 @@ export function ProviderWizard({
             ? `Use ${
                 hasShellGeminiAccessToken
                   ? 'the current GEMINI_ACCESS_TOKEN'
-                  : 'the securely stored Gemini access token'
+                  : 'the securely stored Google AI / Gemini access token'
               }`
-            : 'Enter a Gemini access token and store it securely',
+            : 'Enter a Google AI / Gemini access token and store it securely',
         },
         {
           label: 'Local ADC',
@@ -1619,9 +1620,9 @@ export function ProviderWizard({
       ]
 
       return (
-        <Dialog title="Gemini setup" onCancel={() => onDone()}>
+        <Dialog title="Google AI / Gemini setup" onCancel={() => onDone()}>
           <Box flexDirection="column" gap={1}>
-            <Text>Choose how this Gemini profile should authenticate.</Text>
+            <Text>Choose how this Google AI / Gemini profile should authenticate.</Text>
             <Select
               options={options}
               inlineDescriptions
@@ -1649,12 +1650,12 @@ export function ProviderWizard({
       return (
         <TextEntryDialog
           resetStateKey={step.name}
-          title="Gemini setup"
+          title="Google AI / Gemini setup"
           subtitle="Step 1 of 3"
           description={
             process.env.GEMINI_API_KEY || process.env.GOOGLE_API_KEY
-              ? 'Enter a Gemini API key, or leave this blank to reuse the current GEMINI_API_KEY/GOOGLE_API_KEY from this session.'
-              : 'Enter a Gemini API key. You can create one at https://aistudio.google.com/apikey.'
+              ? 'Enter a Google AI / Gemini API key, or leave this blank to reuse the current GEMINI_API_KEY/GOOGLE_API_KEY from this session.'
+              : 'Enter a Google AI / Gemini API key. You can create one at https://aistudio.google.com/apikey.'
           }
           initialValue=""
           placeholder="AIza..."
@@ -1680,12 +1681,12 @@ export function ProviderWizard({
       return (
         <TextEntryDialog
           resetStateKey={step.name}
-          title="Gemini setup"
+          title="Google AI / Gemini setup"
           subtitle="Step 2 of 3"
           description={
             currentToken
-              ? 'Enter a Gemini access token, or leave this blank to reuse the current token from this session or secure storage.'
-              : 'Enter a Gemini access token. It will be stored securely for this profile.'
+              ? 'Enter a Google AI / Gemini access token, or leave this blank to reuse the current token from this session or secure storage.'
+              : 'Enter a Google AI / Gemini access token. It will be stored securely for this profile.'
           }
           initialValue=""
           placeholder="ya29...."
@@ -1693,14 +1694,14 @@ export function ProviderWizard({
           allowEmpty={Boolean(currentToken)}
           validate={value => {
             const token = value.trim() || currentToken
-            return token ? null : 'Enter a Gemini access token or go back and choose Local ADC.'
+            return token ? null : 'Enter a Google AI / Gemini access token or go back and choose Local ADC.'
           }}
           onSubmit={value => {
             const token = value.trim() || currentToken
             const saved = saveGeminiAccessToken(token)
             if (!saved.success) {
               onDone(
-                `Failed to save Gemini access token: ${saved.warning ?? 'unknown error'}`,
+                `Failed to save Google AI / Gemini access token: ${saved.warning ?? 'unknown error'}`,
                 {
                   display: 'system',
                 },
@@ -1722,7 +1723,7 @@ export function ProviderWizard({
       return (
         <TextEntryDialog
           resetStateKey={step.name}
-          title="Gemini setup"
+          title="Google AI / Gemini setup"
           subtitle={
             step.authMode === 'api-key'
               ? 'Step 3 of 3'
@@ -1732,10 +1733,10 @@ export function ProviderWizard({
           }
           description={
             step.authMode === 'api-key'
-              ? `Enter a Gemini model name. Leave blank for ${DEFAULT_GEMINI_MODEL}.`
+              ? `Enter a Google AI / Gemini model name. Leave blank for ${DEFAULT_GEMINI_MODEL}.`
               : step.authMode === 'access-token'
-                ? `Enter a Gemini model name. Leave blank for ${DEFAULT_GEMINI_MODEL}. This profile will use the stored Gemini access token at runtime.`
-                : `Enter a Gemini model name. Leave blank for ${DEFAULT_GEMINI_MODEL}. This profile will use local Google ADC credentials at runtime.`
+                ? `Enter a Google AI / Gemini model name. Leave blank for ${DEFAULT_GEMINI_MODEL}. This profile will use the stored Google AI / Gemini access token at runtime.`
+                : `Enter a Google AI / Gemini model name. Leave blank for ${DEFAULT_GEMINI_MODEL}. This profile will use local Google ADC credentials at runtime.`
           }
           initialValue={defaults.geminiModel}
           placeholder={DEFAULT_GEMINI_MODEL}
@@ -1746,7 +1747,7 @@ export function ProviderWizard({
               !mayHaveGeminiAdcCredentials(process.env)
             ) {
               onDone(
-                'Local ADC credentials were not detected. Run `gcloud auth application-default login` first, then save the Gemini ADC profile again.',
+                'Local ADC credentials were not detected. Run `gcloud auth application-default login` first, then save the Google AI / Gemini ADC profile again.',
                 {
                   display: 'system',
                 },

--- a/src/components/ProviderManager.test.tsx
+++ b/src/components/ProviderManager.test.tsx
@@ -128,7 +128,7 @@ const PRESET_ORDER = [
   'Codex OAuth',
   'xAI OAuth (Grok)',
   'Fireworks AI',
-  'Google Gemini',
+  'Google AI / Gemini',
   'Groq',
   'Hicap',
   'LM Studio',

--- a/src/components/StartupScreen.test.ts
+++ b/src/components/StartupScreen.test.ts
@@ -323,6 +323,7 @@ describe('detectProvider — modelOverride from --model flag', () => {
   test('modelOverride works for Gemini provider', () => {
     process.env.CLAUDE_CODE_USE_GEMINI = '1'
     const result = detectProvider('gemini-2.5-pro')
+    expect(result.name).toBe('Google AI / Gemini')
     expect(result.model).toBe('gemini-2.5-pro')
   })
 

--- a/src/components/StartupScreen.ts
+++ b/src/components/StartupScreen.ts
@@ -85,7 +85,7 @@ export function detectProvider(modelOverride?: string): { name: string; model: s
   if (useGemini) {
     const model = modelOverride || process.env.GEMINI_MODEL || DEFAULT_GEMINI_MODEL
     const baseUrl = process.env.GEMINI_BASE_URL || 'https://generativelanguage.googleapis.com/v1beta/openai'
-    return { name: 'Google Gemini', model, baseUrl, isLocal: false }
+    return { name: 'Google AI / Gemini', model, baseUrl, isLocal: false }
   }
 
   if (useMistral) {

--- a/src/integrations/generated/integrationManifest.generated.ts
+++ b/src/integrations/generated/integrationManifest.generated.ts
@@ -169,7 +169,7 @@ export const PROVIDER_PRESET_MANIFEST = [
     "routeKind": "vendor",
     "routeId": "gemini",
     "vendorId": "gemini",
-    "description": "Gemini OpenAI-compatible endpoint",
+    "description": "Google AI / Gemini OpenAI-compatible endpoint",
     "apiKeyEnvVars": [
       "GEMINI_API_KEY"
     ]

--- a/src/integrations/vendors/gemini.ts
+++ b/src/integrations/vendors/gemini.ts
@@ -2,7 +2,7 @@ import { defineVendor } from '../define.js'
 
 export default defineVendor({
   id: 'gemini',
-  label: 'Google Gemini',
+  label: 'Google AI / Gemini',
   classification: 'native',
   defaultBaseUrl: 'https://generativelanguage.googleapis.com/v1beta/openai',
   defaultModel: 'gemini-3-flash-preview',
@@ -20,7 +20,7 @@ export default defineVendor({
   },
   preset: {
     id: 'gemini',
-    description: 'Gemini OpenAI-compatible endpoint',
+    description: 'Google AI / Gemini OpenAI-compatible endpoint',
     apiKeyEnvVars: ['GEMINI_API_KEY'],
   },
   validation: {

--- a/src/utils/auth.test.ts
+++ b/src/utils/auth.test.ts
@@ -1,6 +1,15 @@
 import { afterEach, expect, mock, test } from 'bun:test'
 import * as originalSettings from './settings/settings.js'
 
+type MockSource =
+  | 'userSettings'
+  | 'projectSettings'
+  | 'repositorySettings'
+  | 'localSettings'
+  | 'flagSettings'
+  | 'policySettings'
+  | 'none'
+
 async function importAuthFresh() {
   return await import(`./auth.js?ts=${Date.now()}-${Math.random()}`)
 }
@@ -18,35 +27,31 @@ afterEach(() => {
 // NOT propagate subscriptionType.
 function mockSettings(
   subscriptionType: string | undefined,
-  source: 'user' | 'project' | 'none' = 'user',
+  source: MockSource = 'userSettings',
 ) {
   mock.module('./settings/settings.js', () => ({
     ...originalSettings,
-    getSettings_DEPRECATED: () =>
-      source === 'project'
-        ? { subscriptionType } // simulates merged view including project
-        : source === 'user'
-          ? { subscriptionType }
-          : {},
+    getSettings_DEPRECATED: () => (source === 'none' ? {} : { subscriptionType }),
     getSettingsForSource: (s: string) => {
       if (source === 'none') return null
-      if (source === 'project') {
-        // projectSettings/repoSettings are untrusted and must be ignored
-        return s === 'projectSettings' || s === 'repositorySettings'
-          ? { subscriptionType }
-          : null
-      }
-      // user settings only:
-      return s === 'userSettings' ? { subscriptionType } : null
+      return s === source ? { subscriptionType } : null
     },
   }))
 }
 
-async function withOAuthFallbackEnv<T>(fn: () => Promise<T>): Promise<T> {
+async function withControlledAuthEnv<T>(
+  fn: () => Promise<T>,
+  options: { oauthToken?: string } = {},
+): Promise<T> {
   const previous = {
     CLAUDE_CODE_OAUTH_TOKEN: process.env.CLAUDE_CODE_OAUTH_TOKEN,
+    CLAUDE_CODE_OAUTH_TOKEN_FILE_DESCRIPTOR:
+      process.env.CLAUDE_CODE_OAUTH_TOKEN_FILE_DESCRIPTOR,
+    ANTHROPIC_UNIX_SOCKET: process.env.ANTHROPIC_UNIX_SOCKET,
     ANTHROPIC_API_KEY: process.env.ANTHROPIC_API_KEY,
     ANTHROPIC_AUTH_TOKEN: process.env.ANTHROPIC_AUTH_TOKEN,
+    CLAUDE_CODE_API_KEY_FILE_DESCRIPTOR:
+      process.env.CLAUDE_CODE_API_KEY_FILE_DESCRIPTOR,
     CLAUDE_CODE_USE_BEDROCK: process.env.CLAUDE_CODE_USE_BEDROCK,
     CLAUDE_CODE_USE_VERTEX: process.env.CLAUDE_CODE_USE_VERTEX,
     CLAUDE_CODE_USE_FOUNDRY: process.env.CLAUDE_CODE_USE_FOUNDRY,
@@ -55,9 +60,16 @@ async function withOAuthFallbackEnv<T>(fn: () => Promise<T>): Promise<T> {
     CLAUDE_CODE_USE_MISTRAL: process.env.CLAUDE_CODE_USE_MISTRAL,
     CLAUDE_CODE_USE_GITHUB: process.env.CLAUDE_CODE_USE_GITHUB,
   }
-  process.env.CLAUDE_CODE_OAUTH_TOKEN = 'test-oauth-token'
+  if (options.oauthToken) {
+    process.env.CLAUDE_CODE_OAUTH_TOKEN = options.oauthToken
+  } else {
+    delete process.env.CLAUDE_CODE_OAUTH_TOKEN
+  }
+  delete process.env.CLAUDE_CODE_OAUTH_TOKEN_FILE_DESCRIPTOR
+  delete process.env.ANTHROPIC_UNIX_SOCKET
   delete process.env.ANTHROPIC_API_KEY
   delete process.env.ANTHROPIC_AUTH_TOKEN
+  delete process.env.CLAUDE_CODE_API_KEY_FILE_DESCRIPTOR
   delete process.env.CLAUDE_CODE_USE_BEDROCK
   delete process.env.CLAUDE_CODE_USE_VERTEX
   delete process.env.CLAUDE_CODE_USE_FOUNDRY
@@ -78,15 +90,19 @@ async function withOAuthFallbackEnv<T>(fn: () => Promise<T>): Promise<T> {
   }
 }
 
+async function withOAuthFallbackEnv<T>(fn: () => Promise<T>): Promise<T> {
+  return withControlledAuthEnv(fn, { oauthToken: 'test-oauth-token' })
+}
+
 test('isClaudeAISubscriber returns true if subscriptionType is pro in user settings', async () => {
-  mockSettings('pro', 'user')
+  mockSettings('pro', 'userSettings')
   const { isClaudeAISubscriber, getSubscriptionType } = await importAuthFresh()
   expect(isClaudeAISubscriber()).toBe(true)
   expect(getSubscriptionType()).toBe('pro')
 })
 
 test('isClaudeAISubscriber returns false if subscriptionType is free in user settings', async () => {
-  mockSettings('free', 'user')
+  mockSettings('free', 'userSettings')
   const { isClaudeAISubscriber, getSubscriptionType } = await importAuthFresh()
   expect(isClaudeAISubscriber()).toBe(false)
   expect(getSubscriptionType()).toBe('free')
@@ -106,29 +122,34 @@ test('isClaudeAISubscriber returns true for OAuth fallback without a free overri
 // test sets a fake Claude AI OAuth token that WOULD satisfy the OAuth path,
 // then asserts the free override wins.
 test('isClaudeAISubscriber returns false for free override even when OAuth tokens would qualify', async () => {
-  mockSettings('free', 'user')
+  mockSettings('free', 'userSettings')
   await withOAuthFallbackEnv(async () => {
     const { isClaudeAISubscriber } = await importAuthFresh()
     expect(isClaudeAISubscriber()).toBe(false)
   })
 })
 
-// P1 regression: project settings must NOT be able to spoof subscriber state.
-test('isClaudeAISubscriber ignores subscriptionType from projectSettings', async () => {
-  mockSettings('pro', 'project')
-  const { isClaudeAISubscriber, getSubscriptionType } = await importAuthFresh()
-  // With no OAuth path exercised in this test, the untrusted project value
-  // must not be returned. We expect null (no override) rather than 'pro'.
-  expect(getSubscriptionType()).toBe(null)
-  // isClaudeAISubscriber falls through to the OAuth path; without OAuth
-  // tokens set in the test env, it should return false rather than true.
-  expect(isClaudeAISubscriber()).toBe(false)
-})
+for (const source of [
+  'projectSettings',
+  'repositorySettings',
+  'localSettings',
+  'flagSettings',
+  'policySettings',
+] as const) {
+  test(`isClaudeAISubscriber ignores subscriptionType from ${source}`, async () => {
+    mockSettings('pro', source)
+    await withControlledAuthEnv(async () => {
+      const { isClaudeAISubscriber, getSubscriptionType } = await importAuthFresh()
+      expect(getSubscriptionType()).toBe(null)
+      expect(isClaudeAISubscriber()).toBe(false)
+    })
+  })
+}
 
 // P2/P3 regression: when subscriptionType is 'free', isClaudeAISubscriber() returns false
 // even if fallback auth conditions (OAuth/environment) are satisfied, and getSubscriptionType() returns 'free'.
 test("when subscriptionType is 'free', isClaudeAISubscriber() returns false even if fallback auth conditions are satisfied, and getSubscriptionType() returns 'free'", async () => {
-  mockSettings('free', 'user')
+  mockSettings('free', 'userSettings')
   await withOAuthFallbackEnv(async () => {
     const { isClaudeAISubscriber, getSubscriptionType } = await importAuthFresh()
     expect(isClaudeAISubscriber()).toBe(false)

--- a/src/utils/auth.test.ts
+++ b/src/utils/auth.test.ts
@@ -42,6 +42,42 @@ function mockSettings(
   }))
 }
 
+async function withOAuthFallbackEnv<T>(fn: () => Promise<T>): Promise<T> {
+  const previous = {
+    CLAUDE_CODE_OAUTH_TOKEN: process.env.CLAUDE_CODE_OAUTH_TOKEN,
+    ANTHROPIC_API_KEY: process.env.ANTHROPIC_API_KEY,
+    ANTHROPIC_AUTH_TOKEN: process.env.ANTHROPIC_AUTH_TOKEN,
+    CLAUDE_CODE_USE_BEDROCK: process.env.CLAUDE_CODE_USE_BEDROCK,
+    CLAUDE_CODE_USE_VERTEX: process.env.CLAUDE_CODE_USE_VERTEX,
+    CLAUDE_CODE_USE_FOUNDRY: process.env.CLAUDE_CODE_USE_FOUNDRY,
+    CLAUDE_CODE_USE_OPENAI: process.env.CLAUDE_CODE_USE_OPENAI,
+    CLAUDE_CODE_USE_GEMINI: process.env.CLAUDE_CODE_USE_GEMINI,
+    CLAUDE_CODE_USE_MISTRAL: process.env.CLAUDE_CODE_USE_MISTRAL,
+    CLAUDE_CODE_USE_GITHUB: process.env.CLAUDE_CODE_USE_GITHUB,
+  }
+  process.env.CLAUDE_CODE_OAUTH_TOKEN = 'test-oauth-token'
+  delete process.env.ANTHROPIC_API_KEY
+  delete process.env.ANTHROPIC_AUTH_TOKEN
+  delete process.env.CLAUDE_CODE_USE_BEDROCK
+  delete process.env.CLAUDE_CODE_USE_VERTEX
+  delete process.env.CLAUDE_CODE_USE_FOUNDRY
+  delete process.env.CLAUDE_CODE_USE_OPENAI
+  delete process.env.CLAUDE_CODE_USE_GEMINI
+  delete process.env.CLAUDE_CODE_USE_MISTRAL
+  delete process.env.CLAUDE_CODE_USE_GITHUB
+  try {
+    return await fn()
+  } finally {
+    for (const [key, value] of Object.entries(previous)) {
+      if (value === undefined) {
+        delete process.env[key]
+      } else {
+        process.env[key] = value
+      }
+    }
+  }
+}
+
 test('isClaudeAISubscriber returns true if subscriptionType is pro in user settings', async () => {
   mockSettings('pro', 'user')
   const { isClaudeAISubscriber, getSubscriptionType } = await importAuthFresh()
@@ -56,6 +92,14 @@ test('isClaudeAISubscriber returns false if subscriptionType is free in user set
   expect(getSubscriptionType()).toBe('free')
 })
 
+test('isClaudeAISubscriber returns true for OAuth fallback without a free override', async () => {
+  mockSettings(undefined, 'none')
+  await withOAuthFallbackEnv(async () => {
+    const { isClaudeAISubscriber } = await importAuthFresh()
+    expect(isClaudeAISubscriber()).toBe(true)
+  })
+})
+
 // P2 regression: subscriptionType: "free" must short-circuit the OAuth path.
 // Prior code only short-circuited non-free values, so free + valid OAuth
 // returned true (the OAuth-detected subscriber state leaked through). This
@@ -63,26 +107,10 @@ test('isClaudeAISubscriber returns false if subscriptionType is free in user set
 // then asserts the free override wins.
 test('isClaudeAISubscriber returns false for free override even when OAuth tokens would qualify', async () => {
   mockSettings('free', 'user')
-  // Plant a fake token so isAnthropicAuthEnabled() / shouldUseClaudeAIAuth()
-  // would return true without the override. The override must win.
-  const previousTokens = process.env.CLAUDE_AI_OAUTH_TOKEN
-  process.env.CLAUDE_AI_OAUTH_TOKEN = JSON.stringify({
-    accessToken: 'test',
-    refreshToken: 'test',
-    expiresAt: Date.now() + 60_000,
-    scopes: ['user:inference', 'user:profile'],
-    subscriptionType: 'pro',
-  })
-  try {
+  await withOAuthFallbackEnv(async () => {
     const { isClaudeAISubscriber } = await importAuthFresh()
     expect(isClaudeAISubscriber()).toBe(false)
-  } finally {
-    if (previousTokens === undefined) {
-      delete process.env.CLAUDE_AI_OAUTH_TOKEN
-    } else {
-      process.env.CLAUDE_AI_OAUTH_TOKEN = previousTokens
-    }
-  }
+  })
 })
 
 // P1 regression: project settings must NOT be able to spoof subscriber state.
@@ -101,23 +129,9 @@ test('isClaudeAISubscriber ignores subscriptionType from projectSettings', async
 // even if fallback auth conditions (OAuth/environment) are satisfied, and getSubscriptionType() returns 'free'.
 test("when subscriptionType is 'free', isClaudeAISubscriber() returns false even if fallback auth conditions are satisfied, and getSubscriptionType() returns 'free'", async () => {
   mockSettings('free', 'user')
-  const previousTokens = process.env.CLAUDE_AI_OAUTH_TOKEN
-  process.env.CLAUDE_AI_OAUTH_TOKEN = JSON.stringify({
-    accessToken: 'test-fallback-access-token',
-    refreshToken: 'test-fallback-refresh-token',
-    expiresAt: Date.now() + 3600_000,
-    scopes: ['user:inference', 'user:profile'],
-    subscriptionType: 'pro',
-  })
-  try {
+  await withOAuthFallbackEnv(async () => {
     const { isClaudeAISubscriber, getSubscriptionType } = await importAuthFresh()
     expect(isClaudeAISubscriber()).toBe(false)
     expect(getSubscriptionType()).toBe('free')
-  } finally {
-    if (previousTokens === undefined) {
-      delete process.env.CLAUDE_AI_OAUTH_TOKEN
-    } else {
-      process.env.CLAUDE_AI_OAUTH_TOKEN = previousTokens
-    }
-  }
+  })
 })

--- a/src/utils/auth.test.ts
+++ b/src/utils/auth.test.ts
@@ -14,18 +14,18 @@ afterEach(() => {
 
 // Helper: mock settings to return the given subscriptionType from a specific
 // source (or no source at all). The trusted-source helper in auth.ts reads
-// from policy/flag/user/local only — project and repository settings must
+// from user settings only — project, local, flag, and policy settings must
 // NOT propagate subscriptionType.
 function mockSettings(
   subscriptionType: string | undefined,
-  source: 'trusted' | 'project' | 'none' = 'trusted',
+  source: 'user' | 'project' | 'none' = 'user',
 ) {
   mock.module('./settings/settings.js', () => ({
     ...originalSettings,
     getSettings_DEPRECATED: () =>
       source === 'project'
         ? { subscriptionType } // simulates merged view including project
-        : source === 'trusted'
+        : source === 'user'
           ? { subscriptionType }
           : {},
     getSettingsForSource: (s: string) => {
@@ -36,27 +36,21 @@ function mockSettings(
           ? { subscriptionType }
           : undefined
       }
-      // trusted: only user/local/flag/policy carry the override
-      const trusted = new Set([
-        'userSettings',
-        'localSettings',
-        'flagSettings',
-        'policySettings',
-      ])
-      return trusted.has(s) ? { subscriptionType } : undefined
+      // user settings only:
+      return s === 'userSettings' ? { subscriptionType } : undefined
     },
   }))
 }
 
-test('isClaudeAISubscriber returns true if subscriptionType is pro in trusted settings', async () => {
-  mockSettings('pro', 'trusted')
+test('isClaudeAISubscriber returns true if subscriptionType is pro in user settings', async () => {
+  mockSettings('pro', 'user')
   const { isClaudeAISubscriber, getSubscriptionType } = await importAuthFresh()
   expect(isClaudeAISubscriber()).toBe(true)
   expect(getSubscriptionType()).toBe('pro')
 })
 
-test('isClaudeAISubscriber returns false if subscriptionType is free in trusted settings', async () => {
-  mockSettings('free', 'trusted')
+test('isClaudeAISubscriber returns false if subscriptionType is free in user settings', async () => {
+  mockSettings('free', 'user')
   const { isClaudeAISubscriber, getSubscriptionType } = await importAuthFresh()
   expect(isClaudeAISubscriber()).toBe(false)
   expect(getSubscriptionType()).toBe('free')
@@ -68,7 +62,7 @@ test('isClaudeAISubscriber returns false if subscriptionType is free in trusted 
 // test sets a fake Claude AI OAuth token that WOULD satisfy the OAuth path,
 // then asserts the free override wins.
 test('isClaudeAISubscriber returns false for free override even when OAuth tokens would qualify', async () => {
-  mockSettings('free', 'trusted')
+  mockSettings('free', 'user')
   // Plant a fake token so isAnthropicAuthEnabled() / shouldUseClaudeAIAuth()
   // would return true without the override. The override must win.
   const previousTokens = process.env.CLAUDE_AI_OAUTH_TOKEN
@@ -101,4 +95,29 @@ test('isClaudeAISubscriber ignores subscriptionType from projectSettings', async
   // isClaudeAISubscriber falls through to the OAuth path; without OAuth
   // tokens set in the test env, it should return false rather than true.
   expect(isClaudeAISubscriber()).toBe(false)
+})
+
+// P2/P3 regression: when subscriptionType is 'free', isClaudeAISubscriber() returns false
+// even if fallback auth conditions (OAuth/environment) are satisfied, and getSubscriptionType() returns 'free'.
+test("when subscriptionType is 'free', isClaudeAISubscriber() returns false even if fallback auth conditions are satisfied, and getSubscriptionType() returns 'free'", async () => {
+  mockSettings('free', 'user')
+  const previousTokens = process.env.CLAUDE_AI_OAUTH_TOKEN
+  process.env.CLAUDE_AI_OAUTH_TOKEN = JSON.stringify({
+    accessToken: 'test-fallback-access-token',
+    refreshToken: 'test-fallback-refresh-token',
+    expiresAt: Date.now() + 3600_000,
+    scopes: ['user:inference', 'user:profile'],
+    subscriptionType: 'pro',
+  })
+  try {
+    const { isClaudeAISubscriber, getSubscriptionType } = await importAuthFresh()
+    expect(isClaudeAISubscriber()).toBe(false)
+    expect(getSubscriptionType()).toBe('free')
+  } finally {
+    if (previousTokens === undefined) {
+      delete process.env.CLAUDE_AI_OAUTH_TOKEN
+    } else {
+      process.env.CLAUDE_AI_OAUTH_TOKEN = previousTokens
+    }
+  }
 })

--- a/src/utils/auth.test.ts
+++ b/src/utils/auth.test.ts
@@ -1,0 +1,32 @@
+import { expect, mock, test } from 'bun:test'
+import * as originalSettings from './settings/settings.js'
+
+async function importAuthFresh() {
+  return await import(`./auth.js?ts=${Date.now()}-${Math.random()}`)
+}
+
+test('isClaudeAISubscriber returns true if subscriptionType is pro in settings', async () => {
+  mock.module('./settings/settings.js', () => ({
+    ...originalSettings,
+    getSettings_DEPRECATED: () => ({
+      subscriptionType: 'pro',
+    }),
+  }))
+
+  const { isClaudeAISubscriber, getSubscriptionType } = await importAuthFresh()
+  expect(isClaudeAISubscriber()).toBe(true)
+  expect(getSubscriptionType()).toBe('pro')
+})
+
+test('isClaudeAISubscriber returns false if subscriptionType is free in settings', async () => {
+  mock.module('./settings/settings.js', () => ({
+    ...originalSettings,
+    getSettings_DEPRECATED: () => ({
+      subscriptionType: 'free',
+    }),
+  }))
+
+  const { isClaudeAISubscriber, getSubscriptionType } = await importAuthFresh()
+  expect(isClaudeAISubscriber()).toBe(false)
+  expect(getSubscriptionType()).toBe('free')
+})

--- a/src/utils/auth.test.ts
+++ b/src/utils/auth.test.ts
@@ -29,15 +29,15 @@ function mockSettings(
           ? { subscriptionType }
           : {},
     getSettingsForSource: (s: string) => {
-      if (source === 'none') return undefined
+      if (source === 'none') return null
       if (source === 'project') {
         // projectSettings/repoSettings are untrusted and must be ignored
         return s === 'projectSettings' || s === 'repositorySettings'
           ? { subscriptionType }
-          : undefined
+          : null
       }
       // user settings only:
-      return s === 'userSettings' ? { subscriptionType } : undefined
+      return s === 'userSettings' ? { subscriptionType } : null
     },
   }))
 }

--- a/src/utils/auth.test.ts
+++ b/src/utils/auth.test.ts
@@ -1,32 +1,104 @@
-import { expect, mock, test } from 'bun:test'
+import { afterEach, expect, mock, test } from 'bun:test'
 import * as originalSettings from './settings/settings.js'
 
 async function importAuthFresh() {
   return await import(`./auth.js?ts=${Date.now()}-${Math.random()}`)
 }
 
-test('isClaudeAISubscriber returns true if subscriptionType is pro in settings', async () => {
+// Restore Bun's module mocks after each test so leaked settings behavior
+// cannot influence later auth/settings tests in the same process.
+// Addresses jatmn's P3 on #1731: test isolation for mock.module().
+afterEach(() => {
+  mock.restore()
+})
+
+// Helper: mock settings to return the given subscriptionType from a specific
+// source (or no source at all). The trusted-source helper in auth.ts reads
+// from policy/flag/user/local only — project and repository settings must
+// NOT propagate subscriptionType.
+function mockSettings(
+  subscriptionType: string | undefined,
+  source: 'trusted' | 'project' | 'none' = 'trusted',
+) {
   mock.module('./settings/settings.js', () => ({
     ...originalSettings,
-    getSettings_DEPRECATED: () => ({
-      subscriptionType: 'pro',
-    }),
+    getSettings_DEPRECATED: () =>
+      source === 'project'
+        ? { subscriptionType } // simulates merged view including project
+        : source === 'trusted'
+          ? { subscriptionType }
+          : {},
+    getSettingsForSource: (s: string) => {
+      if (source === 'none') return undefined
+      if (source === 'project') {
+        // projectSettings/repoSettings are untrusted and must be ignored
+        return s === 'projectSettings' || s === 'repositorySettings'
+          ? { subscriptionType }
+          : undefined
+      }
+      // trusted: only user/local/flag/policy carry the override
+      const trusted = new Set([
+        'userSettings',
+        'localSettings',
+        'flagSettings',
+        'policySettings',
+      ])
+      return trusted.has(s) ? { subscriptionType } : undefined
+    },
   }))
+}
 
+test('isClaudeAISubscriber returns true if subscriptionType is pro in trusted settings', async () => {
+  mockSettings('pro', 'trusted')
   const { isClaudeAISubscriber, getSubscriptionType } = await importAuthFresh()
   expect(isClaudeAISubscriber()).toBe(true)
   expect(getSubscriptionType()).toBe('pro')
 })
 
-test('isClaudeAISubscriber returns false if subscriptionType is free in settings', async () => {
-  mock.module('./settings/settings.js', () => ({
-    ...originalSettings,
-    getSettings_DEPRECATED: () => ({
-      subscriptionType: 'free',
-    }),
-  }))
-
+test('isClaudeAISubscriber returns false if subscriptionType is free in trusted settings', async () => {
+  mockSettings('free', 'trusted')
   const { isClaudeAISubscriber, getSubscriptionType } = await importAuthFresh()
   expect(isClaudeAISubscriber()).toBe(false)
   expect(getSubscriptionType()).toBe('free')
+})
+
+// P2 regression: subscriptionType: "free" must short-circuit the OAuth path.
+// Prior code only short-circuited non-free values, so free + valid OAuth
+// returned true (the OAuth-detected subscriber state leaked through). This
+// test sets a fake Claude AI OAuth token that WOULD satisfy the OAuth path,
+// then asserts the free override wins.
+test('isClaudeAISubscriber returns false for free override even when OAuth tokens would qualify', async () => {
+  mockSettings('free', 'trusted')
+  // Plant a fake token so isAnthropicAuthEnabled() / shouldUseClaudeAIAuth()
+  // would return true without the override. The override must win.
+  const previousTokens = process.env.CLAUDE_AI_OAUTH_TOKEN
+  process.env.CLAUDE_AI_OAUTH_TOKEN = JSON.stringify({
+    accessToken: 'test',
+    refreshToken: 'test',
+    expiresAt: Date.now() + 60_000,
+    scopes: ['user:inference', 'user:profile'],
+    subscriptionType: 'pro',
+  })
+  try {
+    const { isClaudeAISubscriber } = await importAuthFresh()
+    expect(isClaudeAISubscriber()).toBe(false)
+  } finally {
+    if (previousTokens === undefined) {
+      delete process.env.CLAUDE_AI_OAUTH_TOKEN
+    } else {
+      process.env.CLAUDE_AI_OAUTH_TOKEN = previousTokens
+    }
+  }
+})
+
+// P1 regression: project settings must NOT be able to spoof subscriber state.
+test('isClaudeAISubscriber ignores subscriptionType from projectSettings', async () => {
+  mockSettings('pro', 'project')
+  const { isClaudeAISubscriber, getSubscriptionType } = await importAuthFresh()
+  // With no OAuth path exercised in this test, the untrusted project value
+  // must not be returned. We expect null (no override) rather than 'pro'.
+  expect(getSubscriptionType()).toBe(null)
+  // isClaudeAISubscriber falls through to the OAuth path; without OAuth
+  // tokens set in the test env, it should return false rather than true.
+  expect(isClaudeAISubscriber()).toBe(false)
 })

--- a/src/utils/auth.ts
+++ b/src/utils/auth.ts
@@ -69,6 +69,7 @@ import {
   getMacOsKeychainStorageServiceName,
   getUsername,
 } from './secureStorage/macOsKeychainHelpers.js'
+import { type SettingSource } from './settings/constants.js'
 import {
   getSettings_DEPRECATED,
   getSettingsForSource,
@@ -1582,10 +1583,39 @@ async function checkAndRefreshOAuthTokenIfNeededImpl(
   }
 }
 
+/**
+ * Read subscriptionType only from trusted settings sources
+ * (user/local/flag/policy). Project and repository settings are excluded
+ * because they can be checked into shared repos and would otherwise let a
+ * `.openclaude/settings.json` spoof subscriber state. See jatmn's P1 on #1731.
+ */
+function getTrustedSubscriptionType(): SubscriptionType | null {
+  // Priority order: policy > flag > user > local. Mirrors the trust
+  // boundary used by hasSkipDangerousModePermissionPrompt() and siblings.
+  const sources: Array<SettingSource> = [
+    'policySettings',
+    'flagSettings',
+    'userSettings',
+    'localSettings',
+  ]
+  for (const source of sources) {
+    const candidate = getSettingsForSource(source)?.subscriptionType
+    if (candidate) {
+      return candidate as SubscriptionType
+    }
+  }
+  return null
+}
+
 export function isClaudeAISubscriber(): boolean {
-  const settings = getSettings_DEPRECATED()
-  if (settings?.subscriptionType && settings.subscriptionType !== 'free') {
-    return true
+  const override = getTrustedSubscriptionType()
+  if (override) {
+    // `free` is authoritative: an explicit "I am free" override short-circuits
+    // any OAuth-detected subscriber state. Other values affirm subscriber
+    // state without hitting the OAuth path. Fixes jatmn's P2 on #1731: prior
+    // code only short-circuited non-free values, so `subscriptionType: "free"`
+    // with otherwise-valid OAuth tokens still returned true.
+    return override !== 'free'
   }
 
   if (!isAnthropicAuthEnabled()) {
@@ -1691,9 +1721,9 @@ export function getSubscriptionType(): SubscriptionType | null {
     return getMockSubscriptionType()
   }
 
-  const settings = getSettings_DEPRECATED()
-  if (settings?.subscriptionType) {
-    return settings.subscriptionType
+  const override = getTrustedSubscriptionType()
+  if (override) {
+    return override
   }
 
   if (!isAnthropicAuthEnabled()) {

--- a/src/utils/auth.ts
+++ b/src/utils/auth.ts
@@ -69,7 +69,6 @@ import {
   getMacOsKeychainStorageServiceName,
   getUsername,
 } from './secureStorage/macOsKeychainHelpers.js'
-import { type SettingSource } from './settings/constants.js'
 import {
   getSettings_DEPRECATED,
   getSettingsForSource,

--- a/src/utils/auth.ts
+++ b/src/utils/auth.ts
@@ -1583,6 +1583,11 @@ async function checkAndRefreshOAuthTokenIfNeededImpl(
 }
 
 export function isClaudeAISubscriber(): boolean {
+  const settings = getSettings_DEPRECATED()
+  if (settings?.subscriptionType && settings.subscriptionType !== 'free') {
+    return true
+  }
+
   if (!isAnthropicAuthEnabled()) {
     return false
   }
@@ -1684,6 +1689,11 @@ export function getSubscriptionType(): SubscriptionType | null {
   // Check for mock subscription type first (ANT-only testing)
   if (shouldUseMockSubscription()) {
     return getMockSubscriptionType()
+  }
+
+  const settings = getSettings_DEPRECATED()
+  if (settings?.subscriptionType) {
+    return settings.subscriptionType
   }
 
   if (!isAnthropicAuthEnabled()) {

--- a/src/utils/auth.ts
+++ b/src/utils/auth.ts
@@ -1584,38 +1584,25 @@ async function checkAndRefreshOAuthTokenIfNeededImpl(
 }
 
 /**
- * Read subscriptionType only from trusted settings sources
- * (user/local/flag/policy). Project and repository settings are excluded
- * because they can be checked into shared repos and would otherwise let a
- * `.openclaude/settings.json` spoof subscriber state. See jatmn's P1 on #1731.
+ * Read subscriptionType only from user settings source.
+ * Project, local, flag, and policy settings are excluded.
+ * See jatmn's P1 on #1731.
  */
 function getTrustedSubscriptionType(): SubscriptionType | null {
-  // Priority order: policy > flag > user > local. Mirrors the trust
-  // boundary used by hasSkipDangerousModePermissionPrompt() and siblings.
-  const sources: Array<SettingSource> = [
-    'policySettings',
-    'flagSettings',
-    'userSettings',
-    'localSettings',
-  ]
-  for (const source of sources) {
-    const candidate = getSettingsForSource(source)?.subscriptionType
-    if (candidate) {
-      return candidate as SubscriptionType
-    }
+  const candidate = getSettingsForSource('userSettings')?.subscriptionType
+  if (candidate) {
+    return candidate as SubscriptionType
   }
   return null
 }
 
 export function isClaudeAISubscriber(): boolean {
   const override = getTrustedSubscriptionType()
+  if (override === 'free') {
+    return false
+  }
   if (override) {
-    // `free` is authoritative: an explicit "I am free" override short-circuits
-    // any OAuth-detected subscriber state. Other values affirm subscriber
-    // state without hitting the OAuth path. Fixes jatmn's P2 on #1731: prior
-    // code only short-circuited non-free values, so `subscriptionType: "free"`
-    // with otherwise-valid OAuth tokens still returned true.
-    return override !== 'free'
+    return true
   }
 
   if (!isAnthropicAuthEnabled()) {

--- a/src/utils/env.test.ts
+++ b/src/utils/env.test.ts
@@ -182,3 +182,52 @@ test('env.terminal: returns agy if VSCODE_GIT_ASKPASS_MAIN contains antigravity'
     }
   }
 })
+
+test('env.terminal: returns agy if VSCODE_GIT_ASKPASS_MAIN contains mixed-case Antigravity app path', async () => {
+  const originalTermProgram = process.env.TERM_PROGRAM
+  const originalAskpass = process.env.VSCODE_GIT_ASKPASS_MAIN
+  try {
+    delete process.env.TERM_PROGRAM
+    process.env.VSCODE_GIT_ASKPASS_MAIN =
+      '/Applications/Antigravity.app/Contents/Resources/app/extensions/git/dist/askpass-main.js'
+    const { env } = await importFreshEnvModule()
+    expect(env.terminal).toBe('agy')
+  } finally {
+    if (originalTermProgram === undefined) {
+      delete process.env.TERM_PROGRAM
+    } else {
+      process.env.TERM_PROGRAM = originalTermProgram
+    }
+    if (originalAskpass === undefined) {
+      delete process.env.VSCODE_GIT_ASKPASS_MAIN
+    } else {
+      process.env.VSCODE_GIT_ASKPASS_MAIN = originalAskpass
+    }
+  }
+})
+
+test('env.terminal: agy is classified as a VS Code-like IDE terminal', async () => {
+  const originalTermProgram = process.env.TERM_PROGRAM
+  const originalAskpass = process.env.VSCODE_GIT_ASKPASS_MAIN
+  try {
+    process.env.TERM_PROGRAM = 'agy'
+    delete process.env.VSCODE_GIT_ASKPASS_MAIN
+    const { env } = await importFreshEnvModule()
+    const { isVSCodeIde, toIDEDisplayName } =
+      await import(`./ide.js?ts=${Date.now()}-${Math.random()}`)
+    expect(env.terminal).toBe('agy')
+    expect(toIDEDisplayName(env.terminal)).toBe('Antigravity')
+    expect(isVSCodeIde(env.terminal)).toBe(true)
+  } finally {
+    if (originalTermProgram === undefined) {
+      delete process.env.TERM_PROGRAM
+    } else {
+      process.env.TERM_PROGRAM = originalTermProgram
+    }
+    if (originalAskpass === undefined) {
+      delete process.env.VSCODE_GIT_ASKPASS_MAIN
+    } else {
+      process.env.VSCODE_GIT_ASKPASS_MAIN = originalAskpass
+    }
+  }
+})

--- a/src/utils/env.test.ts
+++ b/src/utils/env.test.ts
@@ -116,3 +116,47 @@ test('resolveGlobalClaudeFile: ignores legacy file even when new file is missing
     }),
   ).toBe(join(tempDir, '.openclaude.json'))
 })
+
+test('env.terminal: returns agy if process.env.TERM_PROGRAM is agy', async () => {
+  const originalTermProgram = process.env.TERM_PROGRAM
+  const originalAskpass = process.env.VSCODE_GIT_ASKPASS_MAIN
+  try {
+    process.env.TERM_PROGRAM = 'agy'
+    delete process.env.VSCODE_GIT_ASKPASS_MAIN
+    const { env } = await importFreshEnvModule()
+    expect(env.terminal).toBe('agy')
+  } finally {
+    if (originalTermProgram === undefined) {
+      delete process.env.TERM_PROGRAM
+    } else {
+      process.env.TERM_PROGRAM = originalTermProgram
+    }
+    if (originalAskpass === undefined) {
+      delete process.env.VSCODE_GIT_ASKPASS_MAIN
+    } else {
+      process.env.VSCODE_GIT_ASKPASS_MAIN = originalAskpass
+    }
+  }
+})
+
+test('env.terminal: returns agy if VSCODE_GIT_ASKPASS_MAIN contains agy or antigravity', async () => {
+  const originalTermProgram = process.env.TERM_PROGRAM
+  const originalAskpass = process.env.VSCODE_GIT_ASKPASS_MAIN
+  try {
+    delete process.env.TERM_PROGRAM
+    process.env.VSCODE_GIT_ASKPASS_MAIN = 'path/to/agy'
+    const { env } = await importFreshEnvModule()
+    expect(env.terminal).toBe('agy')
+  } finally {
+    if (originalTermProgram === undefined) {
+      delete process.env.TERM_PROGRAM
+    } else {
+      process.env.TERM_PROGRAM = originalTermProgram
+    }
+    if (originalAskpass === undefined) {
+      delete process.env.VSCODE_GIT_ASKPASS_MAIN
+    } else {
+      process.env.VSCODE_GIT_ASKPASS_MAIN = originalAskpass
+    }
+  }
+})

--- a/src/utils/env.test.ts
+++ b/src/utils/env.test.ts
@@ -139,12 +139,34 @@ test('env.terminal: returns agy if process.env.TERM_PROGRAM is agy', async () =>
   }
 })
 
-test('env.terminal: returns agy if VSCODE_GIT_ASKPASS_MAIN contains agy or antigravity', async () => {
+test('env.terminal: returns agy if VSCODE_GIT_ASKPASS_MAIN contains agy', async () => {
   const originalTermProgram = process.env.TERM_PROGRAM
   const originalAskpass = process.env.VSCODE_GIT_ASKPASS_MAIN
   try {
     delete process.env.TERM_PROGRAM
     process.env.VSCODE_GIT_ASKPASS_MAIN = 'path/to/agy'
+    const { env } = await importFreshEnvModule()
+    expect(env.terminal).toBe('agy')
+  } finally {
+    if (originalTermProgram === undefined) {
+      delete process.env.TERM_PROGRAM
+    } else {
+      process.env.TERM_PROGRAM = originalTermProgram
+    }
+    if (originalAskpass === undefined) {
+      delete process.env.VSCODE_GIT_ASKPASS_MAIN
+    } else {
+      process.env.VSCODE_GIT_ASKPASS_MAIN = originalAskpass
+    }
+  }
+})
+
+test('env.terminal: returns agy if VSCODE_GIT_ASKPASS_MAIN contains antigravity', async () => {
+  const originalTermProgram = process.env.TERM_PROGRAM
+  const originalAskpass = process.env.VSCODE_GIT_ASKPASS_MAIN
+  try {
+    delete process.env.TERM_PROGRAM
+    process.env.VSCODE_GIT_ASKPASS_MAIN = 'path/to/antigravity'
     const { env } = await importFreshEnvModule()
     expect(env.terminal).toBe('agy')
   } finally {

--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -174,8 +174,12 @@ function detectTerminal(): string | null {
   if (process.env.VSCODE_GIT_ASKPASS_MAIN?.includes('windsurf')) {
     return 'windsurf'
   }
-  if (process.env.VSCODE_GIT_ASKPASS_MAIN?.includes('antigravity')) {
-    return 'antigravity'
+  if (
+    process.env.VSCODE_GIT_ASKPASS_MAIN?.includes('antigravity') ||
+    process.env.VSCODE_GIT_ASKPASS_MAIN?.includes('agy') ||
+    process.env.TERM_PROGRAM === 'agy'
+  ) {
+    return 'agy'
   }
   const bundleId = process.env.__CFBundleIdentifier?.toLowerCase()
   if (bundleId?.includes('vscodium')) return 'codium'

--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -166,17 +166,18 @@ export const JETBRAINS_IDES = [
 
 // Detect terminal type with fallbacks for all platforms
 function detectTerminal(): string | null {
+  const askpassMain = process.env.VSCODE_GIT_ASKPASS_MAIN?.toLowerCase()
   if (process.env.CURSOR_TRACE_ID) return 'cursor'
   // Cursor and Windsurf under WSL have TERM_PROGRAM=vscode
-  if (process.env.VSCODE_GIT_ASKPASS_MAIN?.includes('cursor')) {
+  if (askpassMain?.includes('cursor')) {
     return 'cursor'
   }
-  if (process.env.VSCODE_GIT_ASKPASS_MAIN?.includes('windsurf')) {
+  if (askpassMain?.includes('windsurf')) {
     return 'windsurf'
   }
   if (
-    process.env.VSCODE_GIT_ASKPASS_MAIN?.includes('antigravity') ||
-    process.env.VSCODE_GIT_ASKPASS_MAIN?.includes('agy') ||
+    askpassMain?.includes('antigravity') ||
+    askpassMain?.includes('agy') ||
     process.env.TERM_PROGRAM === 'agy'
   ) {
     return 'agy'

--- a/src/utils/ide.ts
+++ b/src/utils/ide.ts
@@ -1201,6 +1201,7 @@ const EDITOR_DISPLAY_NAMES: Record<string, string> = {
   cursor: 'Cursor',
   windsurf: 'Windsurf',
   antigravity: 'Antigravity',
+  agy: 'Antigravity',
   vi: 'Vim',
   vim: 'Vim',
   nano: 'nano',

--- a/src/utils/ide.ts
+++ b/src/utils/ide.ts
@@ -102,6 +102,7 @@ export type DetectedIDEInfo = {
 export type IdeType =
   | 'cursor'
   | 'windsurf'
+  | 'agy'
   | 'vscode'
   | 'pycharm'
   | 'intellij'
@@ -141,6 +142,13 @@ const supportedIdeConfigs: Record<IdeType, IdeConfig> = {
     processKeywordsMac: ['Windsurf Helper', 'Windsurf.app'],
     processKeywordsWindows: ['windsurf.exe'],
     processKeywordsLinux: ['windsurf'],
+  },
+  agy: {
+    ideKind: 'vscode',
+    displayName: 'Antigravity',
+    processKeywordsMac: ['Antigravity Helper', 'Antigravity.app'],
+    processKeywordsWindows: ['antigravity.exe', 'agy.exe'],
+    processKeywordsLinux: ['antigravity', 'agy'],
   },
   vscode: {
     ideKind: 'vscode',
@@ -1042,6 +1050,8 @@ async function getVSCodeIDECommand(ideType: IdeType): Promise<string | null> {
       return 'cursor' + ext
     case 'windsurf':
       return 'windsurf' + ext
+    case 'agy':
+      return 'agy' + ext
     default:
       break
   }

--- a/src/utils/settings/types.ts
+++ b/src/utils/settings/types.ts
@@ -266,6 +266,10 @@ export const SettingsSchema = lazySchema(() =>
         .literal(CLAUDE_CODE_SETTINGS_SCHEMA_URL)
         .optional()
         .describe('JSON Schema reference for Claude Code settings'),
+      subscriptionType: z
+        .enum(['free', 'pro', 'max', 'team', 'enterprise'])
+        .optional()
+        .describe('Override the active subscription type (e.g. "pro")'),
       apiKeyHelper: z
         .string()
         .optional()

--- a/src/utils/settings/types.ts
+++ b/src/utils/settings/types.ts
@@ -270,7 +270,7 @@ export const SettingsSchema = lazySchema(() =>
         .enum(['free', 'pro', 'max', 'team', 'enterprise'])
         .optional()
         .describe(
-          'Override the active subscription type from global user settings only. Allowed values: free, pro, max, team, enterprise. The "free" value is authoritative and takes precedence over OAuth fallback detection.',
+          'Override the active subscription type from user settings only. Project, repository, local, flag, and policy settings are ignored to prevent spoofing. Allowed values: free, pro, max, team, enterprise. The "free" value is authoritative and takes precedence over OAuth fallback detection.',
         ),
       apiKeyHelper: z
         .string()

--- a/src/utils/settings/types.ts
+++ b/src/utils/settings/types.ts
@@ -269,7 +269,9 @@ export const SettingsSchema = lazySchema(() =>
       subscriptionType: z
         .enum(['free', 'pro', 'max', 'team', 'enterprise'])
         .optional()
-        .describe('Override the active subscription type (e.g. "pro")'),
+        .describe(
+          'Override the active subscription type from global user settings only. Allowed values: free, pro, max, team, enterprise. The "free" value is authoritative and takes precedence over OAuth fallback detection.',
+        ),
       apiKeyHelper: z
         .string()
         .optional()

--- a/src/utils/status.routes.test.ts
+++ b/src/utils/status.routes.test.ts
@@ -339,7 +339,7 @@ test('Gemini route remains clear', async () => {
   process.env.GEMINI_API_KEY = 'gem-test-key'
 
   const properties = await buildPropertiesWithProvider('gemini')
-  expect(findValue(properties, 'API provider')).toBe('Google Gemini')
+  expect(findValue(properties, 'API provider')).toBe('Google AI / Gemini')
   // Gemini has a native transport; route-aware block does not override it.
   expect(findValue(properties, 'Provider route')).toBeUndefined()
   expect(findValue(properties, 'Model')).toBe('gemini-2.0-flash')

--- a/src/utils/status.tsx
+++ b/src/utils/status.tsx
@@ -43,7 +43,7 @@ const API_PROVIDER_LABELS: Partial<Record<APIProvider, string>> = {
   foundry: 'Microsoft Foundry',
   openai: 'OpenAI-compatible',
   codex: 'Codex',
-  gemini: 'Google Gemini',
+  gemini: 'Google AI / Gemini',
   github: 'GitHub Models',
   'nvidia-nim': 'NVIDIA NIM',
   minimax: 'MiniMax',

--- a/web/src/data/configuration.ts
+++ b/web/src/data/configuration.ts
@@ -65,7 +65,7 @@ export const envVars: EnvVar[] = [
   { name: 'OPENAI_API_KEY', description: 'Key for OpenAI-compatible providers and gateways (incl. Opengateway).' },
   { name: 'OPENAI_BASE_URL', description: 'Base URL of an OpenAI-compatible /v1 endpoint (OpenRouter, LM Studio, LiteLLM, …).' },
   { name: 'OPENAI_MODEL', description: 'Model name to request from the OpenAI-compatible endpoint.' },
-  { name: 'GOOGLE_API_KEY', description: 'Google Gemini API key.' },
+  { name: 'GOOGLE_API_KEY', description: 'Google AI / Gemini API key.' },
   { name: 'NEARAI_API_KEY', description: 'NEAR AI unified gateway key.' },
   { name: 'MIMO_API_KEY', description: 'Xiaomi MiMo API key.' },
   { name: 'OPENCODE_API_KEY', description: 'OpenCode Zen / Go gateway key.' },

--- a/web/src/data/configuration.ts
+++ b/web/src/data/configuration.ts
@@ -50,6 +50,7 @@ export const settingOptions: SettingOption[] = [
   { key: 'verbose', description: 'Verbose output by default.' },
   { key: 'allowAutoUpdates', description: 'Enable or disable the auto-updater.' },
   { key: 'hooks', description: 'Shell hooks that run on tool events (PreToolUse, PostToolUse, …).' },
+  { key: 'subscriptionType', description: "Override the active subscription type. Allowed values: free, pro, max, team, enterprise. To prevent project-level spoofing, this override is only respected in global user settings, not in project/local settings. Setting this to 'free' is authoritative and takes precedence over OAuth or fallback authentication." },
   { key: 'smartRouting', description: 'Opt-in smart auto-routing: { enabled, simpleModel, strongModel } route simple turns to the configured simple model. Configure with /smartroute.' },
 ]
 

--- a/web/src/data/configuration.ts
+++ b/web/src/data/configuration.ts
@@ -50,7 +50,7 @@ export const settingOptions: SettingOption[] = [
   { key: 'verbose', description: 'Verbose output by default.' },
   { key: 'allowAutoUpdates', description: 'Enable or disable the auto-updater.' },
   { key: 'hooks', description: 'Shell hooks that run on tool events (PreToolUse, PostToolUse, …).' },
-  { key: 'subscriptionType', description: "Override the active subscription type. Allowed values: free, pro, max, team, enterprise. To prevent project-level spoofing, this override is only respected in global user settings, not in project/local settings. Setting this to 'free' is authoritative and takes precedence over OAuth or fallback authentication." },
+  { key: 'subscriptionType', description: "Override the active subscription type from user settings only. Allowed values: free, pro, max, team, enterprise. To prevent spoofing, this override ignores project, repository, local, flag, and policy settings. Setting this to 'free' is authoritative and takes precedence over OAuth or fallback authentication." },
   { key: 'smartRouting', description: 'Opt-in smart auto-routing: { enabled, simpleModel, strongModel } route simple turns to the configured simple model. Configure with /smartroute.' },
 ]
 

--- a/web/src/data/providers.ts
+++ b/web/src/data/providers.ts
@@ -25,7 +25,7 @@ export const providers: Provider[] = [
   },
   {
     id: 'gemini',
-    name: 'Google Gemini',
+    name: 'Google AI / Gemini',
     setup: '/provider or env vars',
     envVars: ['GOOGLE_API_KEY'],
     notes: 'Supports API-key auth only.',

--- a/web/src/data/providers.ts
+++ b/web/src/data/providers.ts
@@ -28,7 +28,7 @@ export const providers: Provider[] = [
     name: 'Google AI / Gemini',
     setup: '/provider or env vars',
     envVars: ['GOOGLE_API_KEY'],
-    notes: 'Supports API-key auth only.',
+    notes: 'Supports API key, access token, and local ADC auth.',
   },
   {
     id: 'github-models',


### PR DESCRIPTION
## Summary

Adds first-class support for setting-based subscription overrides and improves detection of the Antigravity (`agy`) terminal.

### Key Changes
1. **Subscription Override Setting**: Added `subscriptionType` (`'free' | 'pro' | 'max' | 'team' | 'enterprise'`) to `SettingsSchema` in `src/utils/settings/types.ts`.
2. **Override Logic**: Updated `isClaudeAISubscriber` and `getSubscriptionType` in `src/utils/auth.ts` to respect the `subscriptionType` override from `settings.json`.
3. **Agy Terminal Detection**: Enhanced `detectTerminal` in `src/utils/env.ts` to recognize `agy` (the Antigravity terminal) via `process.env.TERM_PROGRAM === 'agy'` or `VSCODE_GIT_ASKPASS_MAIN` containing `'agy'` or `'antigravity'`.
4. **Editor Mapping**: Mapped `agy` to `'Antigravity'` in `EDITOR_DISPLAY_NAMES` inside `src/utils/ide.ts`.
5. **Unit Tests**:
   - Added `src/utils/auth.test.ts` to verify `isClaudeAISubscriber` and `getSubscriptionType` properly respect settings-configured values.
   - Appended tests in `src/utils/env.test.ts` to verify that `agy` is correctly resolved as the active terminal type based on environment signals.

### Verification
- `bun test src/utils/env.test.ts src/utils/auth.test.ts` (10/10 tests passed successfully)
- `bun run build` (compiled successfully)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a **subscriptionType** setting (free/pro/max/team/enterprise) with user-settings-only, spoof-resistant precedence.
  * Extended terminal detection for **Antigravity (“agy”)** signals and added **agy → Antigravity** IDE alias.
* **Bug Fixes**
  * Subscription qualification now strictly honors the trusted **user subscriptionType** (including **free**) over OAuth/auth fallbacks.
* **User Interface**
  * Updated Gemini naming and setup text consistently to **“Google AI / Gemini.”**
* **Tests**
  * Expanded coverage for subscription precedence and terminal/IDE detection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->