### PR TITLE
fix(query): prevent spurious Windows interruption prompt by passing 'interrupt' reason

### DIFF
--- a/src/cli/print.ts
+++ b/src/cli/print.ts
@@ -2849,7 +2849,7 @@ function runHeadlessStreaming(
             }))
           }
           if (abortController) {
-            abortController.abort()
+            abortController.abort('interrupt')
           }
           suggestionState.abortController?.abort()
           suggestionState.abortController = null

--- a/src/cli/print.ts
+++ b/src/cli/print.ts
@@ -3946,7 +3946,7 @@ function runHeadlessStreaming(
                     structuredIO.injectControlResponse(response)
                   },
                   onInterrupt() {
-                    abortController?.abort()
+                    abortController?.abort('interrupt')
                   },
                   onSetModel(model) {
                     const resolved =

--- a/src/hooks/useReplBridge.tsx
+++ b/src/hooks/useReplBridge.tsx
@@ -391,7 +391,7 @@ export function useReplBridge(messages: Message[], setMessages: (action: React.S
             onInboundMessage: handleInboundMessage,
             onPermissionResponse: handlePermissionResponse,
             onInterrupt() {
-              abortControllerRef.current?.abort();
+              abortControllerRef.current?.abort('interrupt');
             },
             onSetModel(model) {
               const resolved = model === 'default' ? null : model ?? null;

--- a/src/query/stopHooks.goal.test.ts
+++ b/src/query/stopHooks.goal.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, test } from 'bun:test'
 import { getDefaultAppState, type AppState } from '../state/AppStateStore.js'
 import { createGoalState } from '../services/goal/state.js'
 import { asSystemPrompt } from '../utils/systemPromptType.js'
+import { INTERRUPT_MESSAGE } from '../utils/messages.js'
 import { handleStopHooks } from './stopHooks.js'
 import type { GoalEvaluationDeps } from '../services/goal/controller.js'
 
@@ -229,5 +230,79 @@ describe('goal continuation stop-hook precedence', () => {
     expect(yieldedUserMessages).toHaveLength(1)
     expect(yieldedUserMessages[0]).toBe(returned.blockingErrors[0])
     expect(yieldedUserMessages[0].message.content).toContain('Run tests.')
+  })
+})
+
+function interruptionMessages(yielded: any[]) {
+  return yielded.filter(
+    message =>
+      message.type === 'user' &&
+      Array.isArray(message.message.content) &&
+      message.message.content.some(
+        (part: any) => part.type === 'text' && part.text === INTERRUPT_MESSAGE,
+      ),
+  )
+}
+
+describe('handleStopHooks abort-reason handling', () => {
+  test('abort reason "interrupt" suppresses the synthetic interruption message', async () => {
+    const appStateRef = { current: getDefaultAppState() }
+    const toolUseContext = makeToolUseContext(appStateRef)
+
+    const { yielded, returned } = await drain(
+      handleStopHooks(
+        [],
+        [assistant('assistant-1', 'Done.') as any],
+        asSystemPrompt([]),
+        {},
+        {},
+        toolUseContext,
+        'sdk',
+        false,
+        undefined,
+        {
+          // Abort while the Stop-hook generator is being consumed so the
+          // abort branch in handleStopHooks runs with reason 'interrupt'.
+          executeStopHooks: async function* () {
+            toolUseContext.abortController.abort('interrupt')
+            yield {} as any
+          },
+          isTeammate: () => false,
+        },
+      ),
+    )
+
+    expect(interruptionMessages(yielded)).toHaveLength(0)
+    expect(returned.preventContinuation).toBe(true)
+  })
+
+  test('default abort still yields the synthetic interruption message', async () => {
+    const appStateRef = { current: getDefaultAppState() }
+    const toolUseContext = makeToolUseContext(appStateRef)
+
+    const { yielded, returned } = await drain(
+      handleStopHooks(
+        [],
+        [assistant('assistant-1', 'Done.') as any],
+        asSystemPrompt([]),
+        {},
+        {},
+        toolUseContext,
+        'sdk',
+        false,
+        undefined,
+        {
+          // Default abort (user cancel) must still emit the interruption.
+          executeStopHooks: async function* () {
+            toolUseContext.abortController.abort()
+            yield {} as any
+          },
+          isTeammate: () => false,
+        },
+      ),
+    )
+
+    expect(interruptionMessages(yielded)).toHaveLength(1)
+    expect(returned.preventContinuation).toBe(true)
   })
 })

--- a/src/query/stopHooks.ts
+++ b/src/query/stopHooks.ts
@@ -322,9 +322,11 @@ export async function* handleStopHooks(
 
           queryDepth: toolUseContext.queryTracking?.depth,
         })
-        yield createUserInterruptionMessage({
-          toolUse: false,
-        })
+        if (toolUseContext.abortController.signal.reason !== 'interrupt') {
+          yield createUserInterruptionMessage({
+            toolUse: false,
+          })
+        }
         return {
           blockingErrors: [],
           preventContinuation: true,

--- a/tests/sdk/query-lifecycle.test.ts
+++ b/tests/sdk/query-lifecycle.test.ts
@@ -219,6 +219,53 @@ describe('Query interrupt lifecycle', () => {
     const messages = await drainQuery(q)
     expect(Array.isArray(messages)).toBe(true)
   }, 10_000)
+
+  test('interrupt() with reason "interrupt" does not yield synthetic user cancellation message', async () => {
+    const ac = new AbortController()
+    const q = query({
+      prompt: 'test interrupt reason',
+      options: { cwd: process.cwd(), abortController: ac },
+    })
+    ac.abort('interrupt')
+    const messages = await drainQuery(q)
+    expect(Array.isArray(messages)).toBe(true)
+    const userCancelMsg = messages.find((m: any) => 
+      m.type === 'user' && 
+      Array.isArray(m.message?.content) && 
+      m.message.content[0]?.text === '[Request interrupted by user]'
+    )
+    expect(userCancelMsg).toBeUndefined()
+  }, 10_000)
+
+  test('interrupt() with reason undefined yields synthetic user cancellation message', async () => {
+    const q = query({
+      prompt: 'test undefined reason',
+      options: { cwd: process.cwd() },
+    })
+    const iterator = q[Symbol.asyncIterator]()
+    const firstPromise = iterator.next()
+    
+    // Interrupt during execution
+    q.interrupt()
+
+    const messages: any[] = []
+    try {
+      let result = await firstPromise
+      while (!result.done) {
+        messages.push(result.value)
+        result = await iterator.next()
+      }
+    } catch (err) {
+      if (!isExpectedDrainAbort(err)) throw err
+    }
+
+    const userCancelMsg = messages.find((m: any) => 
+      m.type === 'user' && 
+      Array.isArray(m.message?.content) && 
+      m.message.content[0]?.text === '[Request interrupted by user]'
+    )
+    expect(userCancelMsg).toBeDefined()
+  }, 10_000)
 })
 
 describe('Query resume lifecycle', () => {

--- a/tests/sdk/query-lifecycle.test.ts
+++ b/tests/sdk/query-lifecycle.test.ts
@@ -15,6 +15,7 @@ import {
   createMinimalConversation,
   createMultiTurnConversation,
   UUID_REGEX,
+  isExpectedDrainAbort,
 } from './helpers/query-test-doubles.js'
 import {
   acquireSharedMutationLock,
@@ -263,6 +264,238 @@ describe('Query interrupt lifecycle', () => {
       m.type === 'user' && 
       Array.isArray(m.message?.content) && 
       m.message.content[0]?.text === '[Request interrupted by user]'
+    )
+    expect(userCancelMsg).toBeDefined()
+  }, 10_000)
+
+  test('Stop hook regression test - aborting with reason interrupt suppresses cancellation message', async () => {
+    const { query: queryLoop } = await import('../../src/query.js')
+    const { getDefaultAppState } = await import('../../src/state/AppStateStore.js')
+    const { asSystemPrompt } = await import('../../src/utils/systemPromptType.js')
+
+    const abortController = new AbortController()
+    const appStateRef = {
+      current: {
+        ...getDefaultAppState(),
+      },
+    }
+
+    const toolUseContext: any = {
+      options: {
+        commands: [],
+        debug: false,
+        mainLoopModel: 'sonnet',
+        tools: [],
+        verbose: false,
+        thinkingConfig: { type: 'disabled' },
+        mcpClients: [],
+        mcpResources: {},
+        isNonInteractiveSession: true,
+        agentDefinitions: { activeAgents: [], allAgents: [], allowedAgentTypes: [] },
+      },
+      abortController,
+      getAppState: () => appStateRef.current,
+      setAppState: (updater: any) => {
+        appStateRef.current = updater(appStateRef.current)
+      },
+    }
+
+    const mockExecuteStopHooks = async function* () {
+      yield {
+        message: {
+          type: 'progress' as const,
+          toolUseID: 'mock-tool-use-id',
+          data: {
+            command: 'mock-command',
+            promptText: 'mock-prompt',
+          },
+        },
+      }
+      abortController.abort('interrupt')
+      yield {
+        message: {
+          type: 'progress' as const,
+          toolUseID: 'mock-tool-use-id-2',
+          data: {
+            command: 'mock-command-2',
+            promptText: 'mock-prompt-2',
+          },
+        },
+      }
+    }
+
+    const mockCallModel = async function* () {
+      yield {
+        type: 'assistant' as const,
+        uuid: 'assistant-1',
+        message: {
+          id: 'assistant-1',
+          type: 'message' as const,
+          role: 'assistant' as const,
+          model: 'test-model',
+          stop_reason: 'end_turn' as const,
+          usage: {
+            input_tokens: 1,
+            output_tokens: 1,
+            cache_creation_input_tokens: 0,
+            cache_read_input_tokens: 0,
+          },
+          content: [{ type: 'text' as const, text: 'Hello' }],
+        },
+      }
+    }
+
+    const q = queryLoop({
+      messages: [],
+      systemPrompt: asSystemPrompt([]),
+      userContext: {},
+      systemContext: {},
+      canUseTool: async () => ({ behavior: 'allow' }),
+      toolUseContext,
+      querySource: 'sdk',
+      deps: {
+        callModel: mockCallModel as any,
+        microcompact: async (messages) => ({ messages }),
+        autocompact: async () => ({ wasCompacted: false }),
+        uuid: () => 'uuid-1',
+        stopHookExecutionDeps: {
+          executeStopHooks: mockExecuteStopHooks as any,
+          isTeammate: () => false,
+          getStopHookMessage: () => 'stop hook blocked',
+        },
+      },
+    })
+
+    const messages: any[] = []
+    try {
+      for await (const msg of q) {
+        messages.push(msg)
+      }
+    } catch (err) {
+      if (!isExpectedDrainAbort(err)) throw err
+    }
+
+    const userCancelMsg = messages.find(
+      (m: any) =>
+        m.type === 'user' &&
+        Array.isArray(m.message?.content) &&
+        m.message.content[0]?.text === '[Request interrupted by user]',
+    )
+    expect(userCancelMsg).toBeUndefined()
+  }, 10_000)
+
+  test('Stop hook regression test - default abort still yields cancellation message', async () => {
+    const { query: queryLoop } = await import('../../src/query.js')
+    const { getDefaultAppState } = await import('../../src/state/AppStateStore.js')
+    const { asSystemPrompt } = await import('../../src/utils/systemPromptType.js')
+
+    const abortController = new AbortController()
+    const appStateRef = {
+      current: {
+        ...getDefaultAppState(),
+      },
+    }
+
+    const toolUseContext: any = {
+      options: {
+        commands: [],
+        debug: false,
+        mainLoopModel: 'sonnet',
+        tools: [],
+        verbose: false,
+        thinkingConfig: { type: 'disabled' },
+        mcpClients: [],
+        mcpResources: {},
+        isNonInteractiveSession: true,
+        agentDefinitions: { activeAgents: [], allAgents: [], allowedAgentTypes: [] },
+      },
+      abortController,
+      getAppState: () => appStateRef.current,
+      setAppState: (updater: any) => {
+        appStateRef.current = updater(appStateRef.current)
+      },
+    }
+
+    const mockExecuteStopHooks = async function* () {
+      yield {
+        message: {
+          type: 'progress' as const,
+          toolUseID: 'mock-tool-use-id',
+          data: {
+            command: 'mock-command',
+            promptText: 'mock-prompt',
+          },
+        },
+      }
+      abortController.abort()
+      yield {
+        message: {
+          type: 'progress' as const,
+          toolUseID: 'mock-tool-use-id-2',
+          data: {
+            command: 'mock-command-2',
+            promptText: 'mock-prompt-2',
+          },
+        },
+      }
+    }
+
+    const mockCallModel = async function* () {
+      yield {
+        type: 'assistant' as const,
+        uuid: 'assistant-1',
+        message: {
+          id: 'assistant-1',
+          type: 'message' as const,
+          role: 'assistant' as const,
+          model: 'test-model',
+          stop_reason: 'end_turn' as const,
+          usage: {
+            input_tokens: 1,
+            output_tokens: 1,
+            cache_creation_input_tokens: 0,
+            cache_read_input_tokens: 0,
+          },
+          content: [{ type: 'text' as const, text: 'Hello' }],
+        },
+      }
+    }
+
+    const q = queryLoop({
+      messages: [],
+      systemPrompt: asSystemPrompt([]),
+      userContext: {},
+      systemContext: {},
+      canUseTool: async () => ({ behavior: 'allow' }),
+      toolUseContext,
+      querySource: 'sdk',
+      deps: {
+        callModel: mockCallModel as any,
+        microcompact: async (messages) => ({ messages }),
+        autocompact: async () => ({ wasCompacted: false }),
+        uuid: () => 'uuid-1',
+        stopHookExecutionDeps: {
+          executeStopHooks: mockExecuteStopHooks as any,
+          isTeammate: () => false,
+          getStopHookMessage: () => 'stop hook blocked',
+        },
+      },
+    })
+
+    const messages: any[] = []
+    try {
+      for await (const msg of q) {
+        messages.push(msg)
+      }
+    } catch (err) {
+      if (!isExpectedDrainAbort(err)) throw err
+    }
+
+    const userCancelMsg = messages.find(
+      (m: any) =>
+        m.type === 'user' &&
+        Array.isArray(m.message?.content) &&
+        m.message.content[0]?.text === '[Request interrupted by user]',
     )
     expect(userCancelMsg).toBeDefined()
   }, 10_000)


### PR DESCRIPTION
## Summary

This PR fixes the spurious Windows interruption prompt bug where OpenClaude displays "Interrupted · What should Claude do instead?" even when the user didn't press Ctrl+C.

## Root Cause

When the REPL bridge or terminal host interrupts an active command execution, it calls `abortController.abort()` with no reason (defaulting to `undefined`). Inside `src/query.ts` and `src/query/stopHooks.ts`, when the abort controller is triggered, the code checks if `abortController.signal.reason !== 'interrupt'`. If it is not `'interrupt'`, the system assumes it was a local user cancellation (Ctrl+C keypress) and yields the synthetic `INTERRUPT_MESSAGE` rendering `InterruptedByUser`.

## Solution

1. Changed REPL bridge interrupt calls in `useReplBridge.tsx` and `print.ts` to pass `'interrupt'` reason explicitly: `abortController.abort('interrupt')`.
2. Added the reason check to `stopHooks.ts` to conditionally suppress the user cancellation message when aborted with `'interrupt'`.
3. Added unit tests in `query-lifecycle.test.ts` to assert that aborting with `'interrupt'` reason correctly suppresses the user cancellation message, while aborting with no reason (or `undefined`) still correctly yields it.

## Test plan

- [x] `bun test` for the new `query-lifecycle.test.ts` cases
- [ ] `bun run build`
- [ ] `bun run smoke`
- [ ] `bun run check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated interruption handling so that aborts specifically marked as `interrupt` no longer surface the synthetic user cancellation message, while default/unspecified aborts continue to do so.
  * Applied consistent behavior across both local and bridge interrupt pathways, including stop-hook interruption flows.
* **Tests**
  * Added and expanded coverage to verify stream output for `q.interrupt()` and stop-hook abort scenarios, including cases with explicit vs unspecified abort reasons.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->