### PR TITLE
Fix runtime metadata precedence for context limits

### DIFF
--- a/src/integrations/runtimeMetadata.test.ts
+++ b/src/integrations/runtimeMetadata.test.ts
@@ -71,6 +71,39 @@ describe('resolveModelRuntimeLimits', () => {
     })
   })
 
+  it('prefers the model descriptor over a smaller discovered context window', async () => {
+    await withTempConfigDir(async () => {
+      const baseUrl = 'http://localhost:4000/v1'
+      await setCachedModels(
+        getDiscoveryCacheKey('custom', {
+          baseUrl,
+        }),
+        {
+          models: [
+            {
+              id: 'gpt-5.4',
+              apiName: 'gpt-5.4',
+              label: 'gpt-5.4',
+              contextWindow: 400_000,
+            },
+          ],
+        },
+      )
+
+      expect(
+        resolveModelRuntimeLimits({
+          model: 'gpt-5.4',
+          processEnv: {
+            CLAUDE_CODE_USE_OPENAI: '1',
+            OPENAI_BASE_URL: baseUrl,
+          },
+        }),
+      ).toMatchObject({
+        contextWindow: 1_050_000,
+      })
+    })
+  })
+
   it('uses built-in Z.AI GLM-5.2 runtime limits', () => {
     const limits = resolveModelRuntimeLimits({
       model: 'glm-5.2',

--- a/src/integrations/runtimeMetadata.test.ts
+++ b/src/integrations/runtimeMetadata.test.ts
@@ -85,6 +85,7 @@ describe('resolveModelRuntimeLimits', () => {
               apiName: 'gpt-5.4',
               label: 'gpt-5.4',
               contextWindow: 400_000,
+              maxOutputTokens: 32_000,
             },
           ],
         },
@@ -100,6 +101,7 @@ describe('resolveModelRuntimeLimits', () => {
         }),
       ).toMatchObject({
         contextWindow: 1_050_000,
+        maxOutputTokens: 128_000,
       })
     })
   })

--- a/src/integrations/runtimeMetadata.ts
+++ b/src/integrations/runtimeMetadata.ts
@@ -106,6 +106,16 @@ function mergeRemoveBodyFields(
   return merged.size > 0 ? [...merged] : undefined
 }
 
+function pickLargestDefinedValue(
+  ...values: Array<number | undefined>
+): number | undefined {
+  const defined = values.filter(
+    (value): value is number => value !== undefined,
+  )
+
+  return defined.length > 0 ? Math.max(...defined) : undefined
+}
+
 function mergeOpenAIShimConfig(
   baseConfig: OpenAIShimTransportConfig | undefined,
   entryConfig: Partial<OpenAIShimTransportConfig> | undefined,
@@ -420,15 +430,19 @@ export function resolveModelRuntimeLimits(options: {
   return {
     contextWindow:
       externalContextWindow.exact ??
-      catalogEntry?.contextWindow ??
-      modelDescriptor?.contextWindow ??
-      cachedCatalogEntry?.contextWindow ??
+      pickLargestDefinedValue(
+        modelDescriptor?.contextWindow,
+        catalogEntry?.contextWindow,
+        cachedCatalogEntry?.contextWindow,
+      ) ??
       externalContextWindow.prefix,
     maxOutputTokens:
       externalMaxOutputTokens.exact ??
-      catalogEntry?.maxOutputTokens ??
-      modelDescriptor?.maxOutputTokens ??
-      cachedCatalogEntry?.maxOutputTokens ??
+      pickLargestDefinedValue(
+        modelDescriptor?.maxOutputTokens,
+        catalogEntry?.maxOutputTokens,
+        cachedCatalogEntry?.maxOutputTokens,
+      ) ??
       externalMaxOutputTokens.prefix,
   }
 }

--- a/src/integrations/runtimeMetadata.ts
+++ b/src/integrations/runtimeMetadata.ts
@@ -421,15 +421,15 @@ export function resolveModelRuntimeLimits(options: {
     contextWindow:
       externalContextWindow.exact ??
       catalogEntry?.contextWindow ??
+      modelDescriptor?.contextWindow ??
       cachedCatalogEntry?.contextWindow ??
-      externalContextWindow.prefix ??
-      modelDescriptor?.contextWindow,
+      externalContextWindow.prefix,
     maxOutputTokens:
       externalMaxOutputTokens.exact ??
       catalogEntry?.maxOutputTokens ??
+      modelDescriptor?.maxOutputTokens ??
       cachedCatalogEntry?.maxOutputTokens ??
-      externalMaxOutputTokens.prefix ??
-      modelDescriptor?.maxOutputTokens,
+      externalMaxOutputTokens.prefix,
   }
 }
 


### PR DESCRIPTION
## Summary
Fixes incorrect context-window detection by preferring canonical model descriptors over smaller discovered/catalog values when resolving runtime limits.

## Related issue
Fixes #1732

## Verification
- `npx -y bun test ./src/utils/context.test.ts`
- `npx -y bun test ./src/integrations/runtimeMetadata.test.ts`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added coverage to ensure model runtime limits prioritize the resolved model descriptor over cached discovered values for matching base URLs.

* **Improvements**
  * Improved context window and max output token limit resolution by selecting the largest defined candidate across available model/cached/catalog sources, with fallback to external prefix-based values when needed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->