### PR TITLE
fix(mcp): support draft 2020-12 tool schemas

### DIFF
--- a/src/tools/MCPTool/MCPTool.test.ts
+++ b/src/tools/MCPTool/MCPTool.test.ts
@@ -78,6 +78,89 @@ describe('MCPTool.validateInput', () => {
     expect(result.result).toBe(false)
   })
 
+  test('validates JSON Schema Draft 2020-12 MCP input schemas', async () => {
+    const schema = {
+      $schema: 'https://json-schema.org/draft/2020-12/schema',
+      type: 'object' as const,
+      properties: {
+        action: {
+          type: 'string' as const,
+          enum: ['list', 'new', 'close', 'select'],
+        },
+        index: { type: 'number' as const },
+        url: { type: 'string' as const },
+      },
+      required: ['action'],
+      additionalProperties: false,
+    }
+    const tool = { ...MCPTool, inputJSONSchema: schema }
+
+    const valid = await withValidator(tool).validateInput(
+      { action: 'list' },
+      {} as never,
+    )
+    expect(valid.result).toBe(true)
+
+    const invalid = await withValidator(tool).validateInput(
+      { action: 'list', bad: true },
+      {} as never,
+    )
+    expect(invalid.result).toBe(false)
+    expect(invalid.result === false && invalid.message).toContain(
+      'additional properties',
+    )
+  })
+
+  test('defaults omitted-schema MCP input schemas to JSON Schema Draft 2020-12', async () => {
+    const schema = {
+      type: 'object' as const,
+      properties: {
+        tuple: {
+          type: 'array' as const,
+          prefixItems: [
+            { type: 'string' as const },
+            { type: 'number' as const },
+          ],
+          items: false,
+        },
+      },
+      required: ['tuple'],
+      additionalProperties: false,
+    }
+    const tool = { ...MCPTool, inputJSONSchema: schema }
+
+    const valid = await withValidator(tool).validateInput(
+      { tuple: ['ok', 1] },
+      {} as never,
+    )
+    expect(valid.result).toBe(true)
+
+    const invalid = await withValidator(tool).validateInput(
+      { tuple: ['ok', 1, true] },
+      {} as never,
+    )
+    expect(invalid.result).toBe(false)
+  })
+
+  test('continues to support explicit JSON Schema Draft-07 schemas', async () => {
+    const schema = {
+      $schema: 'http://json-schema.org/draft-07/schema#',
+      type: 'object' as const,
+      properties: {
+        name: { type: 'string' as const },
+      },
+      required: ['name'],
+      additionalProperties: false,
+    }
+    const tool = { ...MCPTool, inputJSONSchema: schema }
+
+    const result = await withValidator(tool).validateInput(
+      { name: 'test' },
+      {} as never,
+    )
+    expect(result.result).toBe(true)
+  })
+
   test('handles invalid schema gracefully', async () => {
     // Schema that will cause ajv.compile to throw
     const schema = { type: 'invalid_type' } as any

--- a/src/tools/MCPTool/MCPTool.ts
+++ b/src/tools/MCPTool/MCPTool.ts
@@ -1,5 +1,7 @@
 import type { ToolResultBlockParam } from '@anthropic-ai/sdk/resources/index.mjs'
 import { Ajv } from 'ajv'
+import Ajv2020 from 'ajv/dist/2020.js'
+import type { ValidateFunction } from 'ajv'
 import { z } from 'zod/v4'
 import { buildTool, type ToolDef, type ValidationResult } from '../../Tool.js'
 import { lazySchema } from '../../utils/lazySchema.js'
@@ -39,21 +41,42 @@ export type Output = z.infer<OutputSchema>
 // Re-export MCPProgress from centralized types to break import cycles
 export type { MCPProgress } from '../../types/tools.js'
 
-const ajv = new Ajv({ strict: false })
+const draft7Ajv = new Ajv({ strict: false })
+const draft202012Ajv = new Ajv2020({ strict: false })
+
+type CompiledValidator = {
+  validate: ValidateFunction
+  errorsText: (errors?: ValidateFunction['errors']) => string
+}
 
 // Cache compiled validators to avoid recompiling on every validateInput call.
 // AJV compilation is expensive — schemas don't change between calls.
 // Uses WeakMap to allow garbage collection of schemas from disconnected/refreshed
 // MCP tools, preventing memory leaks from accumulating strong references.
-const compiledValidatorCache = new WeakMap<object, ReturnType<typeof ajv.compile>>()
+const compiledValidatorCache = new WeakMap<object, CompiledValidator>()
+
+function selectAjv(schema: object) {
+  const schemaUri = (schema as Record<string, unknown>)['$schema']
+  if (
+    typeof schemaUri === 'string' &&
+    schemaUri.includes('json-schema.org/draft-07')
+  ) {
+    return draft7Ajv
+  }
+  return draft202012Ajv
+}
 
 function getCompiledValidator(schema: object) {
-  let validator = compiledValidatorCache.get(schema)
-  if (!validator) {
-    validator = ajv.compile(schema)
-    compiledValidatorCache.set(schema, validator)
+  let compiled = compiledValidatorCache.get(schema)
+  if (!compiled) {
+    const ajv = selectAjv(schema)
+    compiled = {
+      validate: ajv.compile(schema),
+      errorsText: errors => ajv.errorsText(errors),
+    }
+    compiledValidatorCache.set(schema, compiled)
   }
-  return validator
+  return compiled
 }
 
 export const MCPTool = buildTool({
@@ -94,11 +117,13 @@ export const MCPTool = buildTool({
   async validateInput(input, context): Promise<ValidationResult> {
     if (this.inputJSONSchema) {
       try {
-        const validate = getCompiledValidator(this.inputJSONSchema)
+        const { validate, errorsText } = getCompiledValidator(
+          this.inputJSONSchema,
+        )
         if (!validate(input)) {
           return {
             result: false,
-            message: ajv.errorsText(validate.errors),
+            message: errorsText(validate.errors),
             errorCode: 400,
           }
         }


### PR DESCRIPTION
## Summary

Fixes #1739.

OpenClaude's MCP input validator compiled MCP tool schemas with the wrong JSON Schema dialect for modern MCP inputs. MCP tool `inputSchema` defaults to JSON Schema Draft 2020-12, and Playwright MCP advertises Draft 2020-12 schemas explicitly. Using tools like `browser_tabs` could fail before execution with:

`Failed to compile JSON schema for validation: no schema with key or ref "https://json-schema.org/draft/2020-12/schema"`

This PR makes MCP tool validation select the AJV dialect from the schema declaration while following the MCP default:

- default omitted-`$schema` MCP input schemas to Draft 2020-12
- use `ajv/dist/2020.js` for Draft 2020-12 schemas
- keep explicit Draft-07 schemas on the legacy AJV validator
- keep compiled validator caching per schema object
- add regression coverage for Playwright-style Draft 2020-12 schemas, omitted-`$schema` Draft 2020-12 tuple keywords, and explicit Draft-07 compatibility

## Impact

Users can use modern MCP servers that advertise or imply Draft 2020-12 input schemas, including Playwright MCP, without OpenClaude rejecting the schema before the tool call runs. Existing explicit Draft-07 MCP schemas continue to use the previous validation path.

## Validation

- `bun test src/tools/MCPTool/MCPTool.test.ts`
- `bun run typecheck`
- `bun run build`
- `git diff --check`
- Live verification against `@playwright/mcp@latest`: fetched the actual `browser_tabs` schema (`https://json-schema.org/draft/2020-12/schema`) and confirmed `{ "action": "list" }` validates successfully while an extra property is still rejected.

## Notes

- No UI, terminal presentation, or VS Code extension changes; screenshots are not applicable.
- No provider path changes; provider-specific testing is not applicable.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * MCPTool now supports multiple JSON Schema draft versions (Draft 2020-12 and Draft-07) with automatic version detection and improved validation error messages.

* **Tests**
  * Expanded validation test coverage for multiple JSON Schema versions and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->