### PR TITLE
perf(repl): batch streaming text, cache normalize, coalesce config writes

### DIFF
--- a/src/components/Messages.tsx
+++ b/src/components/Messages.tsx
@@ -28,7 +28,7 @@ import { getGlobalConfig } from '../utils/config.js';
 import { isEnvTruthy } from '../utils/envUtils.js';
 import { isFullscreenEnvEnabled } from '../utils/fullscreen.js';
 import { applyGrouping } from '../utils/groupToolUses.js';
-import { buildMessageLookups, createAssistantMessage, deriveUUID, getMessagesAfterCompactBoundary, getToolUseID, getToolUseIDs, hasUnresolvedHooksFromLookup, isNotEmptyMessage, normalizeMessages, reorderMessagesInUI, type StreamingThinking, type StreamingToolUse, shouldShowUserMessage } from '../utils/messages.js';
+import { buildMessageLookups, createAssistantMessage, deriveUUID, getMessagesAfterCompactBoundary, getToolUseID, getToolUseIDs, hasUnresolvedHooksFromLookup, isNotEmptyMessage, normalizeMessages, normalizeMessagesCached, reorderMessagesInUI, type StreamingThinking, type StreamingToolUse, shouldShowUserMessage } from '../utils/messages.js';
 import { plural } from '../utils/stringUtils.js';
 import { renderableSearchText } from '../utils/transcriptSearch.js';
 import { Divider } from './design-system/Divider.js';
@@ -378,7 +378,10 @@ const MessagesImpl = ({
     columns
   } = useTerminalSize();
   const toggleShowAllShortcut = useShortcutDisplay('transcript:toggleShowAll', 'Transcript', 'Ctrl+E');
-  const normalizedMessages = useMemo(() => normalizeMessages(messages).filter(isNotEmptyMessage), [messages]);
+  // normalizeMessagesCached reuses per-message normalized output across
+  // renders, so a single append no longer re-normalizes the whole transcript
+  // and unchanged rows keep their object identity for memo/WeakMap reuse.
+  const normalizedMessages = useMemo(() => normalizeMessagesCached(messages).filter(isNotEmptyMessage), [messages]);
 
   // Check if streaming thinking should be visible (streaming or within 30s timeout)
   const isStreamingThinkingVisible = useMemo(() => {

--- a/src/screens/REPL.tsx
+++ b/src/screens/REPL.tsx
@@ -122,7 +122,7 @@ import { WEB_FETCH_TOOL_NAME } from '../tools/WebFetchTool/prompt.js';
 import { SLEEP_TOOL_NAME } from '../tools/SleepTool/prompt.js';
 import { clearSpeculativeChecks } from '../tools/BashTool/bashPermissions.js';
 import type { AutoUpdaterResult } from '../utils/autoUpdater.js';
-import { getGlobalConfig, saveGlobalConfig } from '../utils/config.js';
+import { getGlobalConfig, saveGlobalConfig, saveGlobalConfigDeferred } from '../utils/config.js';
 import { hasConsoleBillingAccess } from '../utils/billing.js';
 import { logEvent, type AnalyticsMetadata_I_VERIFIED_THIS_IS_NOT_CODE_OR_FILEPATHS } from 'src/services/analytics/index.js';
 import { getFeatureValue_CACHED_MAY_BE_STALE } from 'src/services/analytics/growthbook.js';
@@ -198,6 +198,7 @@ const SUGGEST_BG_PR_NOOP = (_p: string, _n: string): boolean => false;
 const useScheduledTasks = require('../hooks/useScheduledTasks.js').useScheduledTasks;
 /* eslint-enable @typescript-eslint/no-require-imports */
 import { isAgentSwarmsEnabled } from '../utils/agentSwarmsEnabled.js';
+import { decideStreamingTextUpdate } from './streamingTextPublish.js';
 import type { SandboxAskCallback, NetworkHostPattern } from '../utils/sandbox/sandbox-adapter.js';
 import { type IDEExtensionInstallationStatus, closeOpenDiffs, getConnectedIdeClient, type IdeType } from '../utils/ide.js';
 import { useIDEIntegration } from '../hooks/useIDEIntegration.js';
@@ -1543,15 +1544,37 @@ export function REPL({
     responseLengthRef.current = f(responseLengthRef.current);
   }, []);
 
-  // Streaming text display: set state directly per delta (Ink's 16ms render
-  // throttle batches rapid updates). Cleared on message arrival (messages.ts)
-  // so displayedMessages switches from deferredMessages to messages atomically.
+  // Streaming text display. streamingTextRef holds the full accumulated text
+  // (eager, per delta); streamingText state is only published when the visible
+  // (newline-truncated) preview actually changes. The Ink root is a LegacyRoot,
+  // so every setState from a stream event commits a synchronous REPL render —
+  // and because the preview hides the in-progress trailing line, deltas between
+  // newlines never change anything on screen. Publishing only on newline (and
+  // on clear) drops those no-op renders entirely under fast streams
+  // (100-300 deltas/sec) while keeping the displayed text byte-identical.
+  // Cleared on message arrival (messages.ts) so displayedMessages switches from
+  // deferredMessages to messages atomically.
   const [streamingText, setStreamingText] = useState<string | null>(null);
+  const streamingTextRef = useRef<string | null>(null);
+  const lastFlushedStreamingVisibleRef = useRef<string | null>(null);
   const reducedMotion = useAppState(s => s.settings.prefersReducedMotion) ?? false;
   const showStreamingText = !reducedMotion && !hasCursorUpViewportYankBug();
   const onStreamingText = useCallback((f: (current: string | null) => string | null) => {
-    if (!showStreamingText) return;
-    setStreamingText(f);
+    // decideStreamingTextUpdate keeps the ref current even when the live preview
+    // is disabled (reduced-motion / cursor-up yank bug) — the Esc handler
+    // recovers partial assistant output from it — and publishes to state only
+    // when the newline-truncated visible preview changes.
+    const decision = decideStreamingTextUpdate(
+      streamingTextRef.current,
+      f,
+      showStreamingText,
+      lastFlushedStreamingVisibleRef.current,
+    );
+    streamingTextRef.current = decision.nextText;
+    if (decision.publish) {
+      lastFlushedStreamingVisibleRef.current = decision.nextVisible;
+      setStreamingText(decision.nextText);
+    }
   }, [showStreamingText]);
 
   // Hide the in-progress source line so text streams line-by-line, not
@@ -1675,6 +1698,8 @@ export function REPL({
     // does not leave the progress bar rendered in the idle UI.
     setCompactProgressRatio(null);
     responseLengthRef.current = 0;
+    streamingTextRef.current = null;
+    lastFlushedStreamingVisibleRef.current = null;
     setStreamingText(null);
     setStreamingToolUses([]);
     setSpinnerMessage(null);
@@ -1725,7 +1750,9 @@ export function REPL({
       if (count >= 3) return;
       const timer = setTimeout((ref, setMessages) => {
         ref.current = true;
-        saveGlobalConfig(prev => {
+        // Loss-tolerant notification counter — coalesce the write so it can't
+        // contend on the config lock with other writers.
+        saveGlobalConfigDeferred(prev => {
           const prevCount = prev.autoPermissionsNotificationCount ?? 0;
           if (prevCount >= 3) return prev;
           return {
@@ -2299,12 +2326,16 @@ export function REPL({
     skipIdleCheckRef.current = false;
 
     // Preserve partially-streamed text so the user can read what was
-    // generated before pressing Esc. Pushed before resetLoadingState clears
-    // streamingText, and before query.ts yields the async interrupt marker,
-    // giving final order [user, partial-assistant, [Request interrupted by user]].
-    if (streamingText?.trim()) {
+    // generated before pressing Esc. Read the ref, not streamingText state:
+    // state only holds up to the last published newline, while the ref has the
+    // full text including the in-progress trailing line. Pushed before
+    // resetLoadingState clears streamingText, and before query.ts yields the
+    // async interrupt marker, giving final order
+    // [user, partial-assistant, [Request interrupted by user]].
+    const partialStreamedText = streamingTextRef.current;
+    if (partialStreamedText?.trim()) {
       setMessages(prev => [...prev, createAssistantMessage({
-        content: streamingText
+        content: partialStreamedText
       })]);
     }
     resetLoadingState();
@@ -3105,6 +3136,8 @@ export function REPL({
         snapshotOutputTokensForTurn(parsedBudget ?? getCurrentTurnTokenBudget());
       }
       setStreamingToolUses([]);
+      streamingTextRef.current = null;
+      lastFlushedStreamingVisibleRef.current = null;
       setStreamingText(null);
 
       // messagesRef is updated synchronously by the setMessages wrapper
@@ -4093,7 +4126,10 @@ export function REPL({
     }
     if (hasCountedQueueUseRef.current) return;
     hasCountedQueueUseRef.current = true;
-    saveGlobalConfig(current => ({
+    // Loss-tolerant analytics counter. Deferring it coalesces the write so a
+    // render loop (see comment above) can no longer drive the lock contention
+    // that triggers GH #3117.
+    saveGlobalConfigDeferred(current => ({
       ...current,
       promptQueueUseCount: (current.promptQueueUseCount ?? 0) + 1
     }));

--- a/src/screens/replStreamingTextClear.test.ts
+++ b/src/screens/replStreamingTextClear.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, test } from 'bun:test'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+// Source-scan regression (same approach as REPL.queryLifecycle.test.ts) for the
+// turn-boundary clearing of the streaming-text refs. The streaming optimization
+// keeps the full accumulated text in streamingTextRef and the last published
+// preview in lastFlushedStreamingVisibleRef. If a reset / next-turn path nulls
+// one but not the other, cancelling a later turn before any new delta arrives
+// could re-append the previous answer's text (Esc reads streamingTextRef) or
+// fail to re-publish (lastFlushedStreamingVisibleRef stays non-null). A unit
+// test of the extracted helper cannot catch that wiring regression, so assert
+// the clears directly against the component source.
+const source = readFileSync(join(import.meta.dirname, 'REPL.tsx'), 'utf8')
+
+describe('REPL streaming-text clear wiring', () => {
+  test('every streamingTextRef clear also clears the preview ref and publishes null', () => {
+    // The full reset that each turn-boundary path must perform, in order.
+    const fullClear =
+      /streamingTextRef\.current = null;\s*lastFlushedStreamingVisibleRef\.current = null;\s*setStreamingText\(null\);/g
+    const fullClears = source.match(fullClear) ?? []
+
+    // Both the cancel/reset path and the next-turn start must perform it.
+    expect(fullClears.length).toBeGreaterThanOrEqual(2)
+
+    // No partial clear may exist: every streamingTextRef null-assignment must be
+    // part of the full trio above (so a stale ref can never survive a turn).
+    const bareTextClears = (
+      source.match(/streamingTextRef\.current = null/g) ?? []
+    ).length
+    expect(bareTextClears).toBe(fullClears.length)
+  })
+})

--- a/src/screens/streamingTextPublish.test.ts
+++ b/src/screens/streamingTextPublish.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, test } from 'bun:test'
+
+import {
+  decideStreamingTextUpdate,
+  visibleStreamingPreview,
+} from './streamingTextPublish.js'
+
+const append = (delta: string) => (current: string | null) =>
+  (current ?? '') + delta
+
+// Drive a sequence of deltas through the decision the way REPL's onStreamingText
+// does: keep `ref` (full accumulated text) and `lastVisible` (last published
+// preview), recording each publish. Mirrors the component's side effects.
+function runDeltas(
+  deltas: Array<(current: string | null) => string | null>,
+  showPreview: boolean,
+) {
+  let ref: string | null = null
+  let lastVisible: string | null = null
+  const published: Array<string | null> = []
+  for (const apply of deltas) {
+    const d = decideStreamingTextUpdate(ref, apply, showPreview, lastVisible)
+    ref = d.nextText
+    if (d.publish) {
+      lastVisible = d.nextVisible
+      published.push(d.nextText)
+    }
+  }
+  return { ref, published }
+}
+
+describe('visibleStreamingPreview', () => {
+  test('hides the in-progress trailing line (only newline-terminated text shows)', () => {
+    expect(visibleStreamingPreview(null)).toBeNull()
+    expect(visibleStreamingPreview('partial line')).toBeNull()
+    expect(visibleStreamingPreview('line1\npart')).toBe('line1\n')
+    expect(visibleStreamingPreview('a\nb\nc\n')).toBe('a\nb\nc\n')
+  })
+})
+
+describe('decideStreamingTextUpdate', () => {
+  test('preview disabled: deltas still accumulate in the ref but never publish', () => {
+    const { ref, published } = runDeltas(
+      [append('Hello '), append('world'), append('!\n')],
+      /* showPreview */ false,
+    )
+    // Full text is preserved for the Esc handler...
+    expect(ref).toBe('Hello world!\n')
+    // ...but nothing was ever published (no renders while the preview is hidden).
+    expect(published).toEqual([])
+  })
+
+  test('preview enabled: only newline-completing deltas publish', () => {
+    const { ref, published } = runDeltas(
+      [
+        append('Hel'), // no newline -> no publish
+        append('lo'), // no newline -> no publish
+        append(' world\n'), // newline -> publish
+        append('next part'), // no newline -> no publish
+        append(' done\n'), // newline -> publish
+      ],
+      /* showPreview */ true,
+    )
+    expect(ref).toBe('Hello world\nnext part done\n')
+    // Two publishes, each the full accumulated text at the newline boundary.
+    expect(published).toEqual(['Hello world\n', 'Hello world\nnext part done\n'])
+  })
+
+  test('the ref holds the full accumulated text the Esc handler would restore', () => {
+    // Reduced-motion users (preview off) press Esc mid-stream: the recovered
+    // text is the ref, which must equal everything streamed so far.
+    const { ref } = runDeltas(
+      [append('partial answer with no trailing newline yet')],
+      /* showPreview */ false,
+    )
+    expect(ref).toBe('partial answer with no trailing newline yet')
+  })
+
+  test('a clear (updater -> null) publishes to drop the visible preview', () => {
+    let lastVisible: string | null = 'line1\n'
+    const clear = decideStreamingTextUpdate(
+      'line1\nin progress',
+      () => null,
+      /* showPreview */ true,
+      lastVisible,
+    )
+    expect(clear.nextText).toBeNull()
+    expect(clear.publish).toBe(true)
+    expect(clear.nextVisible).toBeNull()
+  })
+
+  test('preview enabled but visible unchanged does not publish (idempotent ref write)', () => {
+    const d = decideStreamingTextUpdate(
+      'done\n',
+      append('more'),
+      /* showPreview */ true,
+      'done\n',
+    )
+    expect(d.nextText).toBe('done\nmore')
+    expect(d.publish).toBe(false) // visible preview still "done\n"
+  })
+})

--- a/src/screens/streamingTextPublish.ts
+++ b/src/screens/streamingTextPublish.ts
@@ -1,0 +1,45 @@
+// Pure streaming-text publish decision, factored out of REPL's onStreamingText
+// so the hot-path behavior can be unit-tested without rendering the REPL:
+// deltas always accumulate (so the Esc handler can recover partial output even
+// when the live preview is off), but a React state publish — which commits a
+// synchronous LegacyRoot render — only happens when the newline-truncated
+// visible preview actually changes.
+
+// The streaming preview hides the in-progress trailing line (everything after
+// the last newline), so it only changes when a newline is appended.
+export function visibleStreamingPreview(text: string | null): string | null {
+  return text ? text.substring(0, text.lastIndexOf('\n') + 1) || null : null
+}
+
+export type StreamingTextDecision = {
+  // Full accumulated text. Always written to streamingTextRef, even when the
+  // preview is disabled, so the Esc handler can append partial assistant output.
+  nextText: string | null
+  // Whether to publish nextText to React state (drives a render).
+  publish: boolean
+  // New last-published visible preview; only advances when publish is true.
+  nextVisible: string | null
+}
+
+// Decide the effect of one streaming-text delta. `apply` is the incoming
+// updater (current -> next); `lastVisible` is the previously published preview.
+export function decideStreamingTextUpdate(
+  currentText: string | null,
+  apply: (current: string | null) => string | null,
+  showPreview: boolean,
+  lastVisible: string | null,
+): StreamingTextDecision {
+  const nextText = apply(currentText)
+  if (!showPreview) {
+    // Accumulate into the ref but never render while the preview is hidden.
+    return { nextText, publish: false, nextVisible: lastVisible }
+  }
+  const nextVisible = visibleStreamingPreview(nextText)
+  if (nextVisible !== lastVisible) {
+    // Publish only when the visible preview changes. A clear (nextText === null)
+    // always wins this check because the live preview was non-null, keeping the
+    // streaming -> final swap atomic with the onMessage setMessages.
+    return { nextText, publish: true, nextVisible }
+  }
+  return { nextText, publish: false, nextVisible: lastVisible }
+}

--- a/src/utils/config.deferredWrite.test.ts
+++ b/src/utils/config.deferredWrite.test.ts
@@ -1,0 +1,70 @@
+import { afterEach, beforeAll, describe, expect, test } from 'bun:test'
+import type * as ConfigModule from './config.js'
+
+// In NODE_ENV=test saveGlobalConfigDeferred delegates synchronously to
+// saveGlobalConfig (the in-memory test config), so these assertions exercise
+// the public contract — apply-in-order and a safe flush — without touching the
+// real ~/.openclaude.json or lockfiles. The actual queue/debounce/write-through/
+// batch-drain branch (skipped here by the NODE_ENV bypass) is covered against
+// injected storage/scheduler in deferredConfigWrites.test.ts.
+//
+// Load config through a unique URL specifier rather than the bare './config.js'.
+// mock.module() is process-global in bun:test and is NOT reliably undone by
+// afterEach (a documented trap — see user.test.ts), so a leaked
+// mock.module('./config.js') from another file used to drop promptQueueUseCount
+// and silently turn these assertions into no-ops. A query-suffixed specifier is
+// a different module key that mock.module never replaces, so this file always
+// loads the real module and exercises the real path — never skipping coverage,
+// never flaking on another file's leak. It is also a private instance, so these
+// tests neither read nor mutate the config the rest of the suite shares.
+let config: typeof ConfigModule
+beforeAll(async () => {
+  config = (await import(
+    `./config.js?deferredWriteTest=${Date.now()}-${Math.random()}`
+  )) as typeof ConfigModule
+})
+
+describe('saveGlobalConfigDeferred', () => {
+  // Reset the private test config after each case so ordering within this file
+  // can't carry a value between tests.
+  afterEach(() => {
+    config.saveGlobalConfig(c => ({ ...c, promptQueueUseCount: 0 }))
+  })
+
+  test('applies the updater (visible via getGlobalConfig)', () => {
+    const before = config.getGlobalConfig().promptQueueUseCount ?? 0
+    config.saveGlobalConfigDeferred(c => ({
+      ...c,
+      promptQueueUseCount: (c.promptQueueUseCount ?? 0) + 1,
+    }))
+    config.flushGlobalConfigWrites()
+    expect(config.getGlobalConfig().promptQueueUseCount).toBe(before + 1)
+  })
+
+  test('composes multiple queued updaters in call order', () => {
+    config.saveGlobalConfig(c => ({ ...c, promptQueueUseCount: 10 }))
+    // Order matters: +1 then *2 => 22, the other order would give 21.
+    config.saveGlobalConfigDeferred(c => ({
+      ...c,
+      promptQueueUseCount: (c.promptQueueUseCount ?? 0) + 1,
+    }))
+    config.saveGlobalConfigDeferred(c => ({
+      ...c,
+      promptQueueUseCount: (c.promptQueueUseCount ?? 0) * 2,
+    }))
+    config.flushGlobalConfigWrites()
+    expect(config.getGlobalConfig().promptQueueUseCount).toBe(22)
+  })
+
+  test('flushGlobalConfigWrites is a safe no-op when nothing is queued', () => {
+    expect(() => config.flushGlobalConfigWrites()).not.toThrow()
+    expect(() => config.flushGlobalConfigWrites()).not.toThrow()
+  })
+
+  test('a no-op updater (same reference) does not change config', () => {
+    config.saveGlobalConfig(c => ({ ...c, promptQueueUseCount: 5 }))
+    config.saveGlobalConfigDeferred(c => c)
+    config.flushGlobalConfigWrites()
+    expect(config.getGlobalConfig().promptQueueUseCount).toBe(5)
+  })
+})

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -14,6 +14,7 @@ import type {
 } from '../services/oauth/types.js'
 import { getCwd } from '../utils/cwd.js'
 import { registerCleanup } from './cleanupRegistry.js'
+import { createDeferredWriter } from './deferredConfigWrites.js'
 import { logForDebugging } from './debug.js'
 import { logForDiagnosticsNoPII } from './diagLogs.js'
 import { getGlobalClaudeFile } from './env.js'
@@ -957,6 +958,15 @@ export function saveGlobalConfig(
     return
   }
 
+  // Apply any queued deferred writes first. A direct save re-reads the on-disk
+  // config and write-throughs that snapshot into globalConfigCache; without
+  // draining the deferred queue first, that snapshot would drop the pending
+  // counter deltas the cache is holding and same-process readers would observe
+  // stale values until the debounce fires. flushGlobalConfigWrites() is a no-op
+  // when nothing is queued, and the drain empties the queue before its own
+  // saveGlobalConfig runs, so this recurses at most one level.
+  flushGlobalConfigWrites()
+
   let written: GlobalConfig | null = null
   try {
     const didWrite = saveConfigWithLock(
@@ -1022,6 +1032,78 @@ export function saveGlobalConfig(
     writeThroughGlobalConfigCache(written)
   }
 }
+
+// Coalesced (debounced) global-config writer.
+//
+// saveGlobalConfig does a synchronous lockfile acquire + full re-read + backup
+// copy + fsync on every call, which stalls the event loop (and drops frames)
+// when several low-stakes writes land back-to-back. saveGlobalConfigDeferred
+// queues the updater, write-throughs the in-memory cache immediately so
+// same-process reads stay coherent, and folds all pending updaters into a
+// single locked saveGlobalConfig on a trailing debounce. The auth-loss guard,
+// lockfile and backup all remain on saveGlobalConfig's disk path — this only
+// batches WHEN the disk write happens, never how. Do NOT route auth, onboarding
+// or migration writes through it (see GH #3117); it is for idempotent,
+// loss-tolerant counters/flags only.
+const CONFIG_FLUSH_DEBOUNCE_MS = 500
+
+// The queue/debounce/write-through/batch-drain logic lives in a generic,
+// disk-free engine (see deferredConfigWrites.ts) so it can be unit-tested with
+// injected storage/scheduler. Here we wire the real saveGlobalConfig, in-memory
+// cache, and timers into it.
+const globalConfigDeferredWriter = createDeferredWriter<
+  GlobalConfig,
+  ReturnType<typeof setTimeout>
+>({
+  debounceMs: CONFIG_FLUSH_DEBOUNCE_MS,
+  save: updater => saveGlobalConfig(updater),
+  readCache: () => globalConfigCache.config,
+  writeThrough: next => writeThroughGlobalConfigCache(next),
+  setTimer: (fn, ms) => {
+    const timer = setTimeout(fn, ms)
+    // A pending config flush must never hold the process open on its own.
+    timer.unref?.()
+    return timer
+  },
+  clearTimer: timer => clearTimeout(timer),
+})
+
+export function saveGlobalConfigDeferred(
+  updater: (currentConfig: GlobalConfig) => GlobalConfig,
+): void {
+  // Keep tests synchronous and observable, matching saveGlobalConfig.
+  if (process.env.NODE_ENV === 'test') {
+    saveGlobalConfig(updater)
+    return
+  }
+  // Prime the cache before enqueueing. The deferred writer only write-throughs
+  // the pending updater when there is a cached config to apply it to; on a cold
+  // cache (no prior read) it would skip the write-through and the first deferred
+  // counter update would be invisible to getGlobalConfig() until the debounce
+  // flush — breaking same-process read coherence.
+  if (globalConfigCache.config === null) {
+    getGlobalConfig()
+  }
+  globalConfigDeferredWriter.defer(updater)
+}
+
+// Force any queued deferred writes to disk now. Safe to call repeatedly; a
+// no-op when nothing is pending. Call before reading the config from disk in
+// another process, or before spawning a subprocess that reads it.
+export function flushGlobalConfigWrites(): void {
+  globalConfigDeferredWriter.flush()
+}
+
+// Flush queued writes on shutdown. registerCleanup covers graceful exits; the
+// sync 'exit' handler is the hard-exit backstop (flush is fully synchronous).
+// eslint-disable-next-line custom-rules/no-top-level-side-effects
+registerCleanup(async () => {
+  flushGlobalConfigWrites()
+})
+// eslint-disable-next-line custom-rules/no-top-level-side-effects
+process.on('exit', () => {
+  flushGlobalConfigWrites()
+})
 
 // Cache for global config
 let globalConfigCache: { config: GlobalConfig | null; mtime: number } = {

--- a/src/utils/deferredConfigWrites.test.ts
+++ b/src/utils/deferredConfigWrites.test.ts
@@ -1,0 +1,207 @@
+import { describe, expect, test } from 'bun:test'
+
+import { createDeferredWriter } from './deferredConfigWrites.js'
+
+type Cfg = { n: number }
+
+// A fake scheduler + storage so the real queue/debounce/write-through/drain
+// logic runs without NODE_ENV bypass, timers, or disk. Each handle is an id we
+// can fire on demand to simulate the debounce elapsing.
+//
+// The persisted store and the in-memory cache are kept SEPARATE, matching
+// production: save() (saveGlobalConfig) applies to the authoritative store,
+// while readCache()/writeThrough() touch the same-process cache. They start
+// equal and the composed batch must bring the store back in line.
+function makeHarness(
+  initialCache: Cfg | null = { n: 0 },
+  initialPersisted: Cfg = initialCache ?? { n: 0 },
+) {
+  let cache: Cfg | null = initialCache
+  let persisted: Cfg = initialPersisted
+  const saves: Array<Cfg> = []
+  const writeThroughs: Array<Cfg> = []
+  let nextId = 1
+  const timers = new Map<number, () => void>()
+
+  const writer = createDeferredWriter<Cfg, number>({
+    debounceMs: 500,
+    save: updater => {
+      persisted = updater(persisted)
+      saves.push(persisted)
+    },
+    readCache: () => cache,
+    writeThrough: next => {
+      cache = next
+      writeThroughs.push(next)
+    },
+    setTimer: fn => {
+      const id = nextId++
+      timers.set(id, fn)
+      return id
+    },
+    clearTimer: id => {
+      timers.delete(id)
+    },
+  })
+
+  return {
+    writer,
+    saves,
+    writeThroughs,
+    getCache: () => cache,
+    scheduledCount: () => timers.size,
+    fireTimers: () => {
+      // Fire every scheduled timer (the engine only ever schedules one).
+      for (const fn of [...timers.values()]) fn()
+    },
+    // Models config.ts saveGlobalConfig: it re-reads the persisted store, applies
+    // its own updater, and write-throughs the result to the cache. When
+    // flushFirst is true it drains the deferred queue first (the fix), so a
+    // pending delta is not clobbered.
+    directSave: (updater: (c: Cfg) => Cfg, flushFirst: boolean) => {
+      if (flushFirst) writer.flush()
+      persisted = updater(persisted)
+      cache = persisted
+    },
+  }
+}
+
+describe('createDeferredWriter (the non-bypassed deferred path)', () => {
+  test('write-throughs immediately but defers the persisted save to the debounce', () => {
+    const h = makeHarness({ n: 0 })
+
+    h.writer.defer(c => ({ n: c.n + 1 }))
+
+    // Visible to same-process reads at once...
+    expect(h.getCache()).toEqual({ n: 1 })
+    expect(h.writeThroughs).toHaveLength(1)
+    // ...but not yet persisted, and exactly one flush is scheduled.
+    expect(h.saves).toHaveLength(0)
+    expect(h.writer.pendingCount()).toBe(1)
+    expect(h.scheduledCount()).toBe(1)
+  })
+
+  test('coalesces several writes into a single composed save in call order', () => {
+    const h = makeHarness({ n: 0 })
+
+    h.writer.defer(c => ({ n: c.n + 1 })) // +1
+    h.writer.defer(c => ({ n: c.n * 2 })) // *2
+    h.writer.defer(c => ({ n: c.n + 3 })) // +3
+
+    // Still one debounce window, nothing persisted yet.
+    expect(h.scheduledCount()).toBe(1)
+    expect(h.saves).toHaveLength(0)
+    expect(h.writer.pendingCount()).toBe(3)
+
+    h.fireTimers()
+
+    // ((0+1)*2)+3 = 5 — a single batched save applied in order.
+    expect(h.saves).toEqual([{ n: 5 }])
+    expect(h.writer.pendingCount()).toBe(0)
+    expect(h.scheduledCount()).toBe(0)
+  })
+
+  test('the trailing timer drains the batch', () => {
+    const h = makeHarness({ n: 10 })
+    h.writer.defer(c => ({ n: c.n + 5 }))
+
+    expect(h.saves).toHaveLength(0)
+    h.fireTimers()
+    expect(h.saves).toEqual([{ n: 15 }])
+  })
+
+  test('flush() drains synchronously and cancels the scheduled timer', () => {
+    const h = makeHarness({ n: 0 })
+    h.writer.defer(c => ({ n: c.n + 7 }))
+    expect(h.scheduledCount()).toBe(1)
+
+    h.writer.flush()
+
+    expect(h.saves).toEqual([{ n: 7 }])
+    expect(h.scheduledCount()).toBe(0)
+    // A second flush is a no-op (nothing queued).
+    h.writer.flush()
+    expect(h.saves).toHaveLength(1)
+  })
+
+  test('flush() is a safe no-op when nothing is queued', () => {
+    const h = makeHarness({ n: 0 })
+    expect(() => h.writer.flush()).not.toThrow()
+    expect(h.saves).toHaveLength(0)
+  })
+
+  test('a no-op updater (same reference) skips the write-through', () => {
+    const h = makeHarness({ n: 3 })
+
+    h.writer.defer(c => c) // returns same ref
+
+    expect(h.writeThroughs).toHaveLength(0)
+    expect(h.getCache()).toEqual({ n: 3 })
+    // It is still queued, so the persisted apply runs on flush.
+    h.writer.flush()
+    expect(h.saves).toEqual([{ n: 3 }])
+  })
+
+  test('defers persistence even when the cache is empty (no write-through possible)', () => {
+    const h = makeHarness(null)
+
+    h.writer.defer(() => ({ n: 99 }))
+
+    expect(h.writeThroughs).toHaveLength(0) // nothing to write through yet
+    expect(h.writer.pendingCount()).toBe(1)
+    h.writer.flush()
+    expect(h.saves).toEqual([{ n: 99 }])
+  })
+
+  // Regression for the CodeRabbit cold-cache finding. On a null cache the
+  // engine cannot write through, so the first deferred update is invisible to
+  // same-process reads until the flush — which is why saveGlobalConfigDeferred
+  // primes the cache (via getGlobalConfig) before enqueueing.
+  test('first deferred write is invisible on a cold cache but visible once primed', () => {
+    // Cold cache: defer skips the write-through, so a same-process read sees
+    // nothing until the debounce.
+    const cold = makeHarness(null)
+    cold.writer.defer(c => ({ n: (c?.n ?? 0) + 1 }))
+    expect(cold.writeThroughs).toHaveLength(0)
+    expect(cold.getCache()).toBeNull()
+
+    // Primed cache (what the wrapper now guarantees): the first deferred update
+    // write-throughs immediately and is visible before any flush.
+    const primed = makeHarness({ n: 0 })
+    primed.writer.defer(c => ({ n: c.n + 1 }))
+    expect(primed.writeThroughs).toHaveLength(1)
+    expect(primed.getCache()).toEqual({ n: 1 })
+  })
+
+  test('schedules a fresh timer for the next batch after a flush', () => {
+    const h = makeHarness({ n: 0 })
+    h.writer.defer(c => ({ n: c.n + 1 }))
+    h.fireTimers()
+    expect(h.saves).toEqual([{ n: 1 }])
+
+    // A new write after draining must schedule again, not silently drop.
+    h.writer.defer(c => ({ n: c.n + 1 }))
+    expect(h.scheduledCount()).toBe(1)
+    h.fireTimers()
+    expect(h.saves).toEqual([{ n: 1 }, { n: 2 }])
+  })
+
+  // Regression for the CodeRabbit finding: a direct save landing before the
+  // debounce fires must not strand the pending deferred delta out of the cache.
+  test('a direct save flushes pending deferred writes first to stay coherent', () => {
+    // Without the flush, the direct save reads the persisted store (which has
+    // not seen the deferred delta yet) and overwrites the cache, dropping it.
+    const buggy = makeHarness({ n: 0 })
+    buggy.writer.defer(c => ({ n: c.n + 1 })) // cache -> 1, pending = [+1]
+    buggy.directSave(c => ({ n: c.n + 100 }), /* flushFirst */ false)
+    expect(buggy.getCache()).toEqual({ n: 100 }) // stale: the +1 was clobbered
+
+    // With the fix (flush first), the deferred delta is applied before the
+    // direct save, so the cache stays coherent: +1 then +100.
+    const fixed = makeHarness({ n: 0 })
+    fixed.writer.defer(c => ({ n: c.n + 1 }))
+    fixed.directSave(c => ({ n: c.n + 100 }), /* flushFirst */ true)
+    expect(fixed.getCache()).toEqual({ n: 101 })
+    expect(fixed.writer.pendingCount()).toBe(0)
+  })
+})

--- a/src/utils/deferredConfigWrites.ts
+++ b/src/utils/deferredConfigWrites.ts
@@ -1,0 +1,82 @@
+// Coalesced (debounced) write engine, factored out of config.ts so the queue,
+// debounce timer, write-through, and batch-drain logic can be unit-tested with
+// injected storage/scheduler instead of through the NODE_ENV=test bypass (which
+// delegates straight to the synchronous writer and never exercises this path).
+//
+// The engine is intentionally generic over the config type and free of any
+// global/process/disk access — config.ts wires the real saveGlobalConfig,
+// in-memory cache, and setTimeout/clearTimeout into it.
+
+export type Updater<C> = (current: C) => C
+
+export interface DeferredWriterDeps<C, H> {
+  /** Trailing-debounce window before a queued batch is flushed. */
+  debounceMs: number
+  /** Persist one composed updater for the whole batch (the locked disk write). */
+  save: (updater: Updater<C>) => void
+  /** Current in-process cache value, or null when nothing is cached yet. */
+  readCache: () => C | null
+  /** Apply an immediate in-memory write-through so same-process reads stay coherent. */
+  writeThrough: (next: C) => void
+  /** Schedule the trailing flush. Returns a handle passed back to clearTimer. */
+  setTimer: (fn: () => void, ms: number) => H
+  /** Cancel a scheduled flush. */
+  clearTimer: (handle: H) => void
+}
+
+export interface DeferredWriter<C> {
+  /** Queue an updater; write-through immediately, flush to disk on the debounce. */
+  defer: (updater: Updater<C>) => void
+  /** Force any queued writes now. Safe to call repeatedly; no-op when idle. */
+  flush: () => void
+  /** Number of updaters currently queued (diagnostics/tests). */
+  pendingCount: () => number
+}
+
+export function createDeferredWriter<C, H>(
+  deps: DeferredWriterDeps<C, H>,
+): DeferredWriter<C> {
+  let pending: Array<Updater<C>> = []
+  let timer: H | null = null
+
+  function flush(): void {
+    if (timer !== null) {
+      deps.clearTimer(timer)
+      timer = null
+    }
+    if (pending.length === 0) {
+      return
+    }
+    const updaters = pending
+    pending = []
+    // One locked read-modify-write for the whole batch. Compose in call order
+    // so the result matches applying each save in sequence.
+    //
+    // The queue is drained before save() intentionally: this writer is for
+    // loss-tolerant counters/flags only, the in-memory cache was already
+    // write-through-updated in defer(), and save() (saveGlobalConfig) catches
+    // its own lock/permission errors. Re-queuing on a throw would risk
+    // double-applying updaters that already landed in the cache.
+    deps.save(config => updaters.reduce((acc, fn) => fn(acc), config))
+  }
+
+  function defer(updater: Updater<C>): void {
+    // Apply to the in-memory cache now so reads in this process see the pending
+    // change before it is flushed. The authoritative apply still happens against
+    // the persisted config inside the flushed save().
+    const cached = deps.readCache()
+    if (cached !== null) {
+      const next = updater(cached)
+      if (next !== cached) {
+        deps.writeThrough(next)
+      }
+    }
+
+    pending.push(updater)
+    if (timer === null) {
+      timer = deps.setTimer(flush, deps.debounceMs)
+    }
+  }
+
+  return { defer, flush, pendingCount: () => pending.length }
+}

--- a/src/utils/messages.normalizeCached.test.ts
+++ b/src/utils/messages.normalizeCached.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, test } from 'bun:test'
+import {
+  createAssistantMessage,
+  createUserMessage,
+  normalizeMessages,
+  normalizeMessagesCached,
+} from './messages.js'
+import type { Message } from '../types/message.js'
+
+// normalizeMessagesCached must be observably identical to normalizeMessages
+// for every mutation pattern the REPL produces (append, replace-last, filter,
+// slice/rewind), while additionally preserving object identity for unchanged
+// messages so downstream memo/WeakMap caches survive.
+
+let uuidCounter = 0
+function withUuid<T extends Message>(message: T): T {
+  uuidCounter += 1
+  const hex = uuidCounter.toString(16).padStart(12, '0')
+  return { ...message, uuid: `a1b2c3d4-0000-0000-0000-${hex}` as Message['uuid'] }
+}
+
+function assistant(...texts: string[]): Message {
+  return withUuid(
+    createAssistantMessage({
+      content: texts.map(
+        text => ({ type: 'text' as const, text, citations: null }) as never,
+      ),
+    }),
+  )
+}
+
+function user(text: string): Message {
+  return withUuid(createUserMessage({ content: text })) as Message
+}
+
+function expectEquivalent(messages: Message[]): void {
+  expect(normalizeMessagesCached(messages)).toEqual(normalizeMessages(messages))
+}
+
+describe('normalizeMessagesCached', () => {
+  test('matches normalizeMessages for single-block messages', () => {
+    expectEquivalent([user('hi'), assistant('hello'), user('bye')])
+  })
+
+  test('matches across an isNewChain transition (multi-block message)', () => {
+    expectEquivalent([
+      user('q'),
+      assistant('part one', 'part two'),
+      user('follow up'),
+      assistant('answer'),
+    ])
+  })
+
+  test('matches when the chain flag is already set before a later message', () => {
+    // The multi-block assistant sets isNewChain; every later message must get
+    // derived UUIDs in both implementations.
+    expectEquivalent([
+      assistant('a', 'b', 'c'),
+      user('next'),
+      assistant('single'),
+      user('again'),
+    ])
+  })
+
+  test('matches after an append (incremental growth)', () => {
+    const base = [user('1'), assistant('one'), user('2')]
+    expectEquivalent(base)
+    expectEquivalent([...base, assistant('two')])
+    expectEquivalent([...base, assistant('two'), user('3')])
+  })
+
+  test('matches after replacing the last message', () => {
+    const base = [user('1'), assistant('streaming...')]
+    expectEquivalent(base)
+    expectEquivalent([base[0]!, assistant('final answer')])
+  })
+
+  test('matches after filtering out a middle message', () => {
+    const a = user('1')
+    const b = assistant('two')
+    const c = user('3')
+    expectEquivalent([a, b, c])
+    expectEquivalent([a, c])
+  })
+
+  test('matches after a rewind slice', () => {
+    const full = [user('1'), assistant('two', 'three'), user('4'), assistant('5')]
+    expectEquivalent(full)
+    expectEquivalent(full.slice(0, 2))
+    expectEquivalent(full.slice(0, 1))
+  })
+
+  test('preserves object identity for unchanged messages on pure append', () => {
+    const a = user('1')
+    const b = assistant('two')
+    const first = normalizeMessagesCached([a, b])
+    const second = normalizeMessagesCached([a, b, user('3')])
+    // The normalized outputs for a and b must be the very same objects.
+    expect(second[0]).toBe(first[0])
+    expect(second[1]).toBe(first[1])
+  })
+
+  test('preserves identity for messages before a newly multi-block tail', () => {
+    const a = user('1')
+    const b = assistant('two')
+    const first = normalizeMessagesCached([a, b])
+    // Appending a multi-block message after b does not change b's entry flag
+    // (still false), so b's normalized output identity is retained.
+    const second = normalizeMessagesCached([a, b, assistant('x', 'y')])
+    expect(second[0]).toBe(first[0])
+    expect(second[1]).toBe(first[1])
+  })
+
+  // The cache is keyed by (message identity, entryFlag). The dangerous path is
+  // reusing the SAME trailing message object across both flag states: a rewind
+  // that removes an earlier multi-block message flips a later message's entry
+  // flag true -> false, which must drop its derived UUIDs and recompute rather
+  // than return the stale true-flag entry.
+  test('recomputes a reused trailing message when its entry flag flips true -> false', () => {
+    const q = user('q')
+    const multi = assistant('a', 'b') // sets isNewChain = true
+    const tail = assistant('tail')
+
+    // Warm the cache: `tail` follows a multi-block message, so entryFlag = true.
+    const withMulti = normalizeMessagesCached([q, multi, tail])
+    expect(withMulti).toEqual(normalizeMessages([q, multi, tail]))
+
+    // Rewind: drop the multi-block message. `tail` (same object) now has
+    // entryFlag = false. The cache must recompute, not reuse the true-flag entry.
+    expectEquivalent([q, tail])
+
+    // And the false-flag tail output must differ from the cached true-flag one.
+    const withoutMulti = normalizeMessagesCached([q, tail])
+    expect(withoutMulti[withoutMulti.length - 1]).not.toBe(
+      withMulti[withMulti.length - 1],
+    )
+  })
+
+  // The reverse transition (false -> true) on a reused object must also recompute.
+  test('recomputes a reused trailing message when its entry flag flips false -> true', () => {
+    const q = user('q')
+    const multi = assistant('a', 'b')
+    const tail = assistant('tail')
+
+    // Warm the cache with entryFlag = false (no preceding multi-block message).
+    normalizeMessagesCached([q, tail])
+    // Insert a multi-block message before `tail`: entryFlag becomes true.
+    expectEquivalent([q, multi, tail])
+  })
+})

--- a/src/utils/messages.streamingToolUses.test.ts
+++ b/src/utils/messages.streamingToolUses.test.ts
@@ -1,0 +1,78 @@
+import { expect, test } from 'bun:test'
+
+import { handleMessageFromStream, type StreamingToolUse } from './messages.js'
+import type { StreamEvent } from '../types/message.js'
+
+// Regression for the PR #1744 change that switched input_json_delta handling
+// from filter-then-append to an in-place update. Concurrently-streaming tool
+// uses must keep a stable array order (the Messages memo comparator aligns
+// streamingToolUses by index), and a delta must only touch its matching entry.
+
+function toolStart(index: number, id: string, name: string): StreamEvent {
+  return {
+    type: 'stream_event',
+    event: {
+      type: 'content_block_start',
+      index,
+      content_block: { type: 'tool_use', id, name, input: {} },
+    },
+  } as unknown as StreamEvent
+}
+
+function inputJsonDelta(index: number, partialJson: string): StreamEvent {
+  return {
+    type: 'stream_event',
+    event: {
+      type: 'content_block_delta',
+      index,
+      delta: { type: 'input_json_delta', partial_json: partialJson },
+    },
+  } as unknown as StreamEvent
+}
+
+function makeHarness() {
+  let toolUses: StreamingToolUse[] = []
+  const noop = (): void => {}
+  const feed = (event: StreamEvent): void =>
+    handleMessageFromStream(event, noop, noop, noop, f => {
+      toolUses = f(toolUses)
+    })
+  return { feed, get: () => toolUses }
+}
+
+test('interleaved input_json_delta preserves tool order and updates only the matching index', () => {
+  const { feed, get } = makeHarness()
+
+  // Three concurrent tool uses start in order 0, 1, 2.
+  feed(toolStart(0, 'a', 'toolA'))
+  feed(toolStart(1, 'b', 'toolB'))
+  feed(toolStart(2, 'c', 'toolC'))
+
+  // Deltas arrive interleaved and out of index order.
+  feed(inputJsonDelta(1, '{"x":'))
+  feed(inputJsonDelta(0, '{"a":'))
+  feed(inputJsonDelta(2, '{"c":'))
+  feed(inputJsonDelta(1, '1}'))
+  feed(inputJsonDelta(0, '2}'))
+
+  // Order stays start-order, not most-recently-updated order.
+  expect(get().map(t => t.index)).toEqual([0, 1, 2])
+  expect(get().map(t => t.contentBlock.id)).toEqual(['a', 'b', 'c'])
+
+  // Each entry accumulated only its own deltas.
+  expect(get()[0]!.unparsedToolInput).toBe('{"a":2}')
+  expect(get()[1]!.unparsedToolInput).toBe('{"x":1}')
+  expect(get()[2]!.unparsedToolInput).toBe('{"c":')
+})
+
+test('input_json_delta for an unknown index returns the same array reference', () => {
+  const { feed, get } = makeHarness()
+  feed(toolStart(0, 'a', 'toolA'))
+
+  const before = get()
+  feed(inputJsonDelta(7, 'ignored'))
+
+  // found === false → the updater returns the original array unchanged.
+  expect(get()).toBe(before)
+  expect(get()[0]!.unparsedToolInput).toBe('')
+})

--- a/src/utils/messages.ts
+++ b/src/utils/messages.ts
@@ -836,6 +836,101 @@ export function normalizeMessages(messages: Message[]): NormalizedMessage[] {
   })
 }
 
+// Per-element cache for normalizeMessages. The only cross-message state in
+// normalizeMessages is the monotonic isNewChain flag, so each message's
+// normalized output is fully determined by (message identity, entry flag).
+// Caching on the message object keeps output identity stable across calls,
+// which preserves downstream WeakMap caches and React.memo bailouts, and
+// reduces each unchanged message to an O(1) cache hit (reused blocks, no
+// re-splitting or re-allocation) instead of a full renormalization. The call
+// itself still scans the message list and reassembles the output array, so it
+// stays O(n) per render — this is an allocation/object-identity optimization,
+// not an O(1) append. Entries GC together with their messages.
+type NormalizedCacheEntry = {
+  entryFlag: boolean
+  exitFlag: boolean
+  out: NormalizedMessage[]
+}
+const normalizedMessageCache = new WeakMap<Message, NormalizedCacheEntry>()
+
+// Drop-in replacement for normalizeMessages on render hot paths. Reuses each
+// message's previously normalized blocks (preserving object identity) when the
+// incoming isNewChain flag matches the cached run; recomputes only changed or
+// new messages. Messages are treated as immutable, matching the assumptions of
+// the React.memo comparators downstream.
+export function normalizeMessagesCached(
+  messages: Message[],
+): NormalizedMessage[] {
+  const out: NormalizedMessage[] = []
+  let flag = false
+  for (const message of messages) {
+    const cached = normalizedMessageCache.get(message)
+    if (cached && cached.entryFlag === flag) {
+      for (const m of cached.out) {
+        out.push(m)
+      }
+      flag = cached.exitFlag
+      continue
+    }
+    const entryFlag = flag
+    // Reuse normalizeMessages for the actual block-splitting logic so the two
+    // implementations cannot drift. isNewChain only transitions false -> true,
+    // so seeding the single-element run with the current flag is equivalent to
+    // running the whole list: pass a synthetic multi-block predecessor when the
+    // flag is already set.
+    const normalized = normalizeSingleMessageWithFlag(message, entryFlag)
+    normalizedMessageCache.set(message, {
+      entryFlag,
+      exitFlag: normalized.exitFlag,
+      out: normalized.out,
+    })
+    for (const m of normalized.out) {
+      out.push(m)
+    }
+    flag = normalized.exitFlag
+  }
+  return out
+}
+
+function normalizeSingleMessageWithFlag(
+  message: Message,
+  entryFlag: boolean,
+): { out: NormalizedMessage[]; exitFlag: boolean } {
+  const exitFlag =
+    entryFlag ||
+    ((message.type === 'assistant' ||
+      (message.type === 'user' && typeof message.message.content !== 'string')) &&
+      message.message.content.length > 1)
+
+  if (!entryFlag) {
+    return { out: normalizeMessages([message]), exitFlag }
+  }
+
+  // normalizeMessages keys UUID derivation off its internal isNewChain flag;
+  // when the chain flag is already set for this position, every produced block
+  // must get a derived UUID. Recreate that by normalizing the single message
+  // and re-deriving UUIDs the same way the full pass would.
+  switch (message.type) {
+    case 'attachment':
+    case 'progress':
+    case 'system':
+      return { out: [message], exitFlag }
+    default: {
+      const normalized = normalizeMessages([message])
+      return {
+        out: normalized.map(
+          (m, index) =>
+            ({
+              ...m,
+              uuid: deriveUUID(message.uuid, index),
+            }) as NormalizedMessage,
+        ),
+        exitFlag,
+      }
+    }
+  }
+}
+
 type ToolUseRequestMessage = NormalizedAssistantMessage & {
   message: { content: [ToolUseBlock] }
 }
@@ -3234,17 +3329,22 @@ export function handleMessageFromStream(
           const index = message.event.index
           onUpdateLength(delta)
           onStreamingToolUses(_ => {
-            const element = _.find(_ => _.index === index)
-            if (!element) {
-              return _
-            }
-            return [
-              ..._.filter(_ => _ !== element),
-              {
+            // Update in place (preserve array order). The previous
+            // filter-then-append moved the updated tool to the end, which
+            // shuffled concurrently-streaming tools and broke the index-aligned
+            // contentBlock check in the Messages memo comparator.
+            let found = false
+            const next = _.map(element => {
+              if (element.index !== index) {
+                return element
+              }
+              found = true
+              return {
                 ...element,
                 unparsedToolInput: element.unparsedToolInput + delta,
-              },
-            ]
+              }
+            })
+            return found ? next : _
           })
           return
         }


### PR DESCRIPTION
 Summary

  - What changed: Three runtime hot-path optimizations: (1) streaming text in REPL.tsx holds the full text in a ref and only publishes to state when the newline-truncated preview changes (drops per-token synchronous LegacyRoot re-renders); (2) normalizeMessagesCached
  (messages.ts) memoizes per-message normalized output in a WeakMap keyed on message identity + chain flag, making transcript appends O(1) instead of O(n); (3) saveGlobalConfigDeferred (config.ts) coalesces loss-tolerant counter writes onto a 500ms debounce. Also fixes
  handleMessageFromStream's input_json_delta to update tool input in place instead of reordering it to the array tail.
  - Why it changed: Fast streams re-rendered the REPL per delta; long sessions re-normalized the whole transcript per append; saveGlobalConfig did a sync lock+reread+backup+fsync per call (the write-storm behind GH #3117).

  Impact

  - User-facing impact: Smoother streaming and scrolling in long sessions; fewer frame drops around config-write bursts. Displayed streaming text is byte-identical.
  - Developer/maintainer impact: No react-compiler _c component bodies touched (edits are plain React / plain functions). Auth/onboarding/migration writes stay on the immediate saveGlobalConfig path; only promptQueueUseCount and autoPermissionsNotificationCount are
  deferred. Esc-interrupt reads the streaming ref so no trailing partial line is lost.

  Testing

  - [x] bun run build
  - [x] bun run smoke
  - [ ] bun run check
  - [x] focused tests: bun test src/utils/messages.normalizeCached.test.ts src/utils/config.deferredWrite.test.ts src/utils/messages.snipTag.test.ts → 21 pass, 0 fail. bun run typecheck clean.

  Notes

  - Provider/model path tested: Ran a live multi-line -p turn (haiku) through the rebuilt bundle — line-by-line streaming and atomic finalization verified.
  - Screenshots: none (no static UI change; streaming cadence verified live).
  - Follow-up/limitations: Streaming tool-use delta batching was deliberately left out (its setter is shared with useRemoteSession and multiple reset sites — higher risk, smaller benefit); the order-preserving input_json_delta fix it depended on is included. Rebased onto
  current main; REPL/messages auto-merged cleanly and were re-verified by typecheck + live streaming.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added deferred, coalesced global configuration writes with manual `flush` and automatic shutdown flushing.
  * Introduced streaming-text preview publishing logic (newline-truncated updates).
* **Bug Fixes**
  * Improved streaming cancellation to preserve full in-progress streamed text for partial outputs.
  * Fixed interleaved tool-use streaming deltas to update the correct in-flight entry by index.
* **Performance**
  * Added cached message normalization to reduce repeated processing.
  * Reduced streaming preview re-renders by publishing only when the visible preview changes.
* **Tests**
  * Expanded Bun test coverage for deferred writes, cached normalization, tool-use delta handling, and streaming preview behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->