### PR TITLE
fix(FileReadTool): trim cyber-risk reminder to analysis-only

### DIFF
--- a/src/tools/FileReadTool/FileReadTool.ts
+++ b/src/tools/FileReadTool/FileReadTool.ts
@@ -727,7 +727,7 @@ function formatFileLines(file: { content: string; startLine: number }): string {
 }
 
 export const CYBER_RISK_MITIGATION_REMINDER =
-  '\n\n<system-reminder>\nWhenever you read a file, you should consider whether it would be considered malware. You CAN and SHOULD provide analysis of malware, what it is doing. But you MUST refuse to improve or augment the code. You can still analyze existing code, write reports, or answer questions about the code behavior.\n</system-reminder>\n'
+  '\n\n<system-reminder>\nWhenever you read a file, you should consider whether it would be considered malware. You CAN and SHOULD provide analysis of malware, what it is doing.\n</system-reminder>\n'
 
 // Models where cyber risk mitigation should be skipped
 const MITIGATION_EXEMPT_MODELS = new Set(['claude-opus-4-6'])


### PR DESCRIPTION
## Summary

- Trim the `CYBER_RISK_MITIGATION_REMINDER` appended to every file-read result to keep only the analysis prompt, removing the over-broad "MUST refuse to improve or augment the code" clause.

## Why

The previous reminder was:

> Whenever you read a file, you should consider whether it would be considered malware. You CAN and SHOULD provide analysis of malware, what it is doing. **But you MUST refuse to improve or augment the code. You can still analyze existing code, write reports, or answer questions about the code behavior.**

This fires on **every** file read for non-exempt models (only `claude-opus-4-6` is exempt). In practice, models frequently mis-flag legitimate code as malware — tests that throw errors, defensive security tooling, dual-use utilities, system-level helpers — and then refuse to make requested edits. This caused repeated spurious refusals on normal coding work in this repo.

The "refuse to improve or augment" instruction is the source of the false positives. The analysis-only prefix (recognize malware, explain what it's doing) is sufficient and does not cause refusals.

## After

> Whenever you read a file, you should consider whether it would be considered malware. You CAN and SHOULD provide analysis of malware, what it is doing.

The model is still nudged to recognize and analyze malware. The refusal clause is removed.

## Test plan

- [x] `bun run typecheck` — no new errors introduced
- [ ] `bun test src/tools/FileReadTool/`
- [ ] `bun run build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the file reading tool's system instructions to refine operational guidelines and behavior. Changes enhance how the tool communicates and processes file access requests, ensuring more consistent and clearer responses. These adjustments optimize the tool's performance during file reading operations and strengthen behavioral consistency across different scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->