### PR TITLE
fix(opencode-go): surface clear error on subscription quota exhaustion

### DIFF
--- a/src/services/api/errors.opencodeGo.test.ts
+++ b/src/services/api/errors.opencodeGo.test.ts
@@ -1,0 +1,158 @@
+import { APIError } from '@anthropic-ai/sdk'
+import { afterEach, expect, test } from 'bun:test'
+
+import {
+  classifyAPIError,
+  getAssistantMessageFromError,
+  OPENCODE_GO_FREE_LIMIT_ERROR_MESSAGE,
+  OPENCODE_GO_USAGE_LIMIT_ERROR_MESSAGE,
+} from './errors.js'
+
+function getFirstText(message: ReturnType<typeof getAssistantMessageFromError>): string {
+  const first = message.message.content[0]
+  if (!first || typeof first !== 'object' || !('text' in first)) {
+    return ''
+  }
+  return typeof first.text === 'string' ? first.text : ''
+}
+
+const originalBaseUrl = process.env.OPENAI_BASE_URL
+
+afterEach(() => {
+  if (originalBaseUrl === undefined) {
+    delete process.env.OPENAI_BASE_URL
+  } else {
+    process.env.OPENAI_BASE_URL = originalBaseUrl
+  }
+})
+
+function makeGoError(body: string, headers?: Record<string, string>): APIError {
+  const h = new Headers({
+    'x-opencode-request-url': 'https://opencode.ai/zen/go/v1/messages',
+    ...(headers ?? {}),
+  })
+  return APIError.generate(429, undefined, body, h)
+}
+
+test('FreeUsageLimitError surfaces the free-tier upgrade message', () => {
+  const error = makeGoError(
+    JSON.stringify({
+      error: {
+        type: 'FreeUsageLimitError',
+        message: 'free usage limit reached',
+      },
+    }),
+  )
+  const message = getAssistantMessageFromError(error, 'glm-4.6')
+  const text = getFirstText(message)
+
+  expect(message.isApiErrorMessage).toBe(true)
+  expect(text).toBe(OPENCODE_GO_FREE_LIMIT_ERROR_MESSAGE)
+  expect(text).toContain('Subscribe at https://opencode.ai/go')
+})
+
+test('GoUsageLimitError surfaces the subscription message with reset and workspace', () => {
+  const error = makeGoError(
+    JSON.stringify({
+      error: {
+        type: 'GoUsageLimitError',
+        message: 'go subscription limit reached',
+        limitName: 'weekly',
+        workspace: 'euxaristia-personal',
+      },
+    }),
+    { 'retry-after': '172800' }, // 2 days
+  )
+  const message = getAssistantMessageFromError(error, 'glm-4.6')
+  const text = getFirstText(message)
+
+  expect(message.isApiErrorMessage).toBe(true)
+  expect(text).toContain(OPENCODE_GO_USAGE_LIMIT_ERROR_MESSAGE)
+  expect(text).toContain('Resets in 2d')
+  expect(text).toContain('Workspace: euxaristia-personal')
+  expect(text).toContain('Limit: weekly')
+})
+
+test('GoUsageLimitError without retry-after omits reset hint', () => {
+  const error = makeGoError(
+    JSON.stringify({
+      error: {
+        type: 'GoUsageLimitError',
+        limitName: 'rolling',
+        workspace: 'default',
+      },
+    }),
+  )
+  const text = getFirstText(getAssistantMessageFromError(error, 'glm-4.6'))
+
+  expect(text).toContain(OPENCODE_GO_USAGE_LIMIT_ERROR_MESSAGE)
+  expect(text).not.toContain('Resets in')
+  // default workspace is not surfaced to reduce noise
+  expect(text).not.toContain('Workspace:')
+})
+
+test('GoUsageLimitError reset duration formats hours and minutes', () => {
+  const error = makeGoError(
+    JSON.stringify({
+      error: { type: 'GoUsageLimitError', limitName: 'daily', workspace: 'default' },
+    }),
+    { 'retry-after': '7560' }, // 2h 6m
+  )
+  const text = getFirstText(getAssistantMessageFromError(error, 'glm-4.6'))
+  expect(text).toContain('Resets in 2h 6m')
+})
+
+test('falls back to OPENAI_BASE_URL env check when header is missing', () => {
+  process.env.OPENAI_BASE_URL = 'https://opencode.ai/zen/go/v1'
+  const error = APIError.generate(
+    429,
+    undefined,
+    JSON.stringify({
+      error: { type: 'FreeUsageLimitError', message: 'free exhausted' },
+    }),
+    new Headers(),
+  )
+  const text = getFirstText(getAssistantMessageFromError(error, 'glm-4.6'))
+  expect(text).toBe(OPENCODE_GO_FREE_LIMIT_ERROR_MESSAGE)
+})
+
+test('non-opencode-go 429 with similar body is NOT mapped to opencode-go message', () => {
+  // Same error body shape but no opencode.ai/zen/go URL anywhere
+  const savedBaseUrl = process.env.OPENAI_BASE_URL
+  delete process.env.OPENAI_BASE_URL
+  try {
+    const error = APIError.generate(
+      429,
+      undefined,
+      JSON.stringify({
+        error: { type: 'FreeUsageLimitError', message: 'free exhausted' },
+      }),
+      new Headers({ 'x-opencode-request-url': 'https://api.openai.com/v1/messages' }),
+    )
+    const text = getFirstText(getAssistantMessageFromError(error, 'glm-4.6'))
+    expect(text).not.toContain('OpenCode Go')
+  } finally {
+    if (savedBaseUrl !== undefined) {
+      process.env.OPENAI_BASE_URL = savedBaseUrl
+    }
+  }
+})
+
+test('classifyAPIError returns opencode_go_quota_exhausted for GoUsageLimitError', () => {
+  const error = makeGoError(
+    JSON.stringify({ error: { type: 'GoUsageLimitError' } }),
+  )
+  expect(classifyAPIError(error)).toBe('opencode_go_quota_exhausted')
+})
+
+test('classifyAPIError returns opencode_go_quota_exhausted for FreeUsageLimitError', () => {
+  const error = makeGoError(
+    JSON.stringify({ error: { type: 'FreeUsageLimitError' } }),
+  )
+  expect(classifyAPIError(error)).toBe('opencode_go_quota_exhausted')
+})
+
+test('classifyAPIError returns rate_limit for generic opencode-go 429', () => {
+  const error = makeGoError(JSON.stringify({ error: { message: 'slow down' } }))
+  expect(classifyAPIError(error)).toBe('rate_limit')
+})

--- a/src/services/api/errors.opencodeGo.test.ts
+++ b/src/services/api/errors.opencodeGo.test.ts
@@ -7,6 +7,7 @@ import {
   OPENCODE_GO_FREE_LIMIT_ERROR_MESSAGE,
   OPENCODE_GO_USAGE_LIMIT_ERROR_MESSAGE,
 } from './errors.js'
+import { shouldRetry } from './withRetry.js'
 
 function getFirstText(message: ReturnType<typeof getAssistantMessageFromError>): string {
   const first = message.message.content[0]
@@ -155,4 +156,55 @@ test('classifyAPIError returns opencode_go_quota_exhausted for FreeUsageLimitErr
 test('classifyAPIError returns rate_limit for generic opencode-go 429', () => {
   const error = makeGoError(JSON.stringify({ error: { message: 'slow down' } }))
   expect(classifyAPIError(error)).toBe('rate_limit')
+})
+
+test('shouldRetry returns false for OpenCode Go usage limits', () => {
+  const freeError = makeGoError(
+    JSON.stringify({ error: { type: 'FreeUsageLimitError' } }),
+  )
+  expect(shouldRetry(freeError, false)).toBe(false)
+
+  const goError = makeGoError(
+    JSON.stringify({ error: { type: 'GoUsageLimitError' } }),
+  )
+  expect(shouldRetry(goError, false)).toBe(false)
+})
+
+test('shouldRetry returns true for similar body on non-OpenCode 429', () => {
+  const savedBaseUrl = process.env.OPENAI_BASE_URL
+  delete process.env.OPENAI_BASE_URL
+  try {
+    const error = APIError.generate(
+      429,
+      undefined,
+      JSON.stringify({ error: { type: 'FreeUsageLimitError' } }),
+      new Headers({ 'x-opencode-request-url': 'https://api.openai.com/v1/messages' }),
+    )
+    expect(shouldRetry(error, false)).toBe(true)
+  } finally {
+    if (savedBaseUrl !== undefined) {
+      process.env.OPENAI_BASE_URL = savedBaseUrl
+    }
+  }
+})
+
+test('precedence: when request header points to non-OpenCode, environment variable is ignored', () => {
+  // Set env var to OpenCode Go url (simulating stale config)
+  process.env.OPENAI_BASE_URL = 'https://opencode.ai/zen/go/v1'
+
+  const error = APIError.generate(
+    429,
+    undefined,
+    JSON.stringify({
+      error: { type: 'FreeUsageLimitError', message: 'free exhausted' },
+    }),
+    new Headers({ 'x-opencode-request-url': 'https://api.openai.com/v1/messages' }),
+  )
+
+  // Message should NOT be OpenCode Go message
+  const text = getFirstText(getAssistantMessageFromError(error, 'glm-4.6'))
+  expect(text).not.toContain('OpenCode Go')
+
+  // Retry gate should allow retry
+  expect(shouldRetry(error, false)).toBe(true)
 })

--- a/src/services/api/errors.opencodeGo.test.ts
+++ b/src/services/api/errors.opencodeGo.test.ts
@@ -117,6 +117,18 @@ test('falls back to OPENAI_BASE_URL env check when header is missing', () => {
   expect(text).toBe(OPENCODE_GO_FREE_LIMIT_ERROR_MESSAGE)
 })
 
+test('OpenAI compatibility quota marker does not hide OpenCode Go message', () => {
+  const error = APIError.generate(
+    429,
+    undefined,
+    'OpenAI API error 429: {"type":"FreeUsageLimitError","message":"free usage limit reached"} [openai_category=quota_exhausted,host=opencode.ai] Hint: Provider quota or usage allotment has run out.',
+    new Headers({ 'x-opencode-request-url': 'https://opencode.ai/zen/go/v1/messages' }),
+  )
+  const text = getFirstText(getAssistantMessageFromError(error, 'glm-4.6'))
+
+  expect(text).toBe(OPENCODE_GO_FREE_LIMIT_ERROR_MESSAGE)
+})
+
 test('non-opencode-go 429 with similar body is NOT mapped to opencode-go message', () => {
   // Same error body shape but no opencode.ai/zen/go URL anywhere
   const savedBaseUrl = process.env.OPENAI_BASE_URL
@@ -231,7 +243,7 @@ test('retry regression: FreeUsageLimitError and GoUsageLimitError are not retrie
   const originalEnv = process.env.OPENAI_BASE_URL
   try {
     process.env.OPENAI_BASE_URL = 'https://opencode.ai/zen/go/v1'
-    
+
     const errorEnvFree = APIError.generate(
       429,
       undefined,
@@ -274,7 +286,7 @@ test('retry regression: non-OpenCode 429 errors with similar body markers are re
   const originalEnv = process.env.OPENAI_BASE_URL
   try {
     process.env.OPENAI_BASE_URL = 'https://api.openai.com/v1'
-    
+
     const errorEnvFree = APIError.generate(
       429,
       undefined,

--- a/src/services/api/errors.opencodeGo.test.ts
+++ b/src/services/api/errors.opencodeGo.test.ts
@@ -208,3 +208,89 @@ test('precedence: when request header points to non-OpenCode, environment variab
   // Retry gate should allow retry
   expect(shouldRetry(error, false)).toBe(true)
 })
+
+test('retry regression: FreeUsageLimitError and GoUsageLimitError are not retried on OpenCode Go', () => {
+  // 1. With authoritative header pointing to OpenCode Go
+  const errorHeaderFree = APIError.generate(
+    429,
+    undefined,
+    JSON.stringify({ error: { type: 'FreeUsageLimitError' } }),
+    new Headers({ 'x-opencode-request-url': 'https://opencode.ai/zen/go/v1/messages' }),
+  )
+  expect(shouldRetry(errorHeaderFree, false)).toBe(false)
+
+  const errorHeaderGo = APIError.generate(
+    429,
+    undefined,
+    JSON.stringify({ error: { type: 'GoUsageLimitError' } }),
+    new Headers({ 'x-opencode-request-url': 'https://opencode.ai/zen/go/v1/messages' }),
+  )
+  expect(shouldRetry(errorHeaderGo, false)).toBe(false)
+
+  // 2. With header absent, falling back to environment variable pointing to OpenCode Go
+  const originalEnv = process.env.OPENAI_BASE_URL
+  try {
+    process.env.OPENAI_BASE_URL = 'https://opencode.ai/zen/go/v1'
+    
+    const errorEnvFree = APIError.generate(
+      429,
+      undefined,
+      JSON.stringify({ error: { type: 'FreeUsageLimitError' } }),
+      new Headers(),
+    )
+    expect(shouldRetry(errorEnvFree, false)).toBe(false)
+
+    const errorEnvGo = APIError.generate(
+      429,
+      undefined,
+      JSON.stringify({ error: { type: 'GoUsageLimitError' } }),
+      new Headers(),
+    )
+    expect(shouldRetry(errorEnvGo, false)).toBe(false)
+  } finally {
+    process.env.OPENAI_BASE_URL = originalEnv
+  }
+})
+
+test('retry regression: non-OpenCode 429 errors with similar body markers are retried', () => {
+  // 1. Header is present but points to non-OpenCode
+  const errorHeaderFree = APIError.generate(
+    429,
+    undefined,
+    JSON.stringify({ error: { type: 'FreeUsageLimitError' } }),
+    new Headers({ 'x-opencode-request-url': 'https://api.openai.com/v1/messages' }),
+  )
+  expect(shouldRetry(errorHeaderFree, false)).toBe(true)
+
+  const errorHeaderGo = APIError.generate(
+    429,
+    undefined,
+    JSON.stringify({ error: { type: 'GoUsageLimitError' } }),
+    new Headers({ 'x-opencode-request-url': 'https://api.openai.com/v1/messages' }),
+  )
+  expect(shouldRetry(errorHeaderGo, false)).toBe(true)
+
+  // 2. Header is absent, and environment variable does not point to OpenCode Go
+  const originalEnv = process.env.OPENAI_BASE_URL
+  try {
+    process.env.OPENAI_BASE_URL = 'https://api.openai.com/v1'
+    
+    const errorEnvFree = APIError.generate(
+      429,
+      undefined,
+      JSON.stringify({ error: { type: 'FreeUsageLimitError' } }),
+      new Headers(),
+    )
+    expect(shouldRetry(errorEnvFree, false)).toBe(true)
+
+    const errorEnvGo = APIError.generate(
+      429,
+      undefined,
+      JSON.stringify({ error: { type: 'GoUsageLimitError' } }),
+      new Headers(),
+    )
+    expect(shouldRetry(errorEnvGo, false)).toBe(true)
+  } finally {
+    process.env.OPENAI_BASE_URL = originalEnv
+  }
+})

--- a/src/services/api/errors.ts
+++ b/src/services/api/errors.ts
@@ -448,6 +448,32 @@ export const OPENCODE_GO_FREE_LIMIT_ERROR_MESSAGE =
 export const OPENCODE_GO_USAGE_LIMIT_ERROR_MESSAGE =
   'OpenCode Go subscription limit reached · See https://opencode.ai/workspace/go'
 
+function getOpenCodeGoAssistantMessage(error: APIError): AssistantMessage | null {
+  const goLimit = parseOpenCodeGoLimitError(error)
+  if (!goLimit) return null
+
+  if (goLimit.kind === 'free') {
+    return createAssistantAPIErrorMessage({
+      content: OPENCODE_GO_FREE_LIMIT_ERROR_MESSAGE,
+      error: 'rate_limit',
+    })
+  }
+
+  const reset =
+    goLimit.retryAfterSeconds !== undefined
+      ? ` · Resets in ${formatResetDuration(goLimit.retryAfterSeconds)}`
+      : ''
+  const workspace =
+    goLimit.workspace && goLimit.workspace !== 'default'
+      ? ` · Workspace: ${goLimit.workspace}`
+      : ''
+  const limit = goLimit.limitName ? ` · Limit: ${goLimit.limitName}` : ''
+  return createAssistantAPIErrorMessage({
+    content: `${OPENCODE_GO_USAGE_LIMIT_ERROR_MESSAGE}${limit}${workspace}${reset}`,
+    error: 'rate_limit',
+  })
+}
+
 function parseOpenCodeGoLimitError(
   error: APIError,
 ): {
@@ -773,6 +799,15 @@ export function getAssistantMessageFromError(
     }
   }
 
+  // OpenCode Go subscription quota exhaustion (429 with FreeUsageLimitError
+  // or GoUsageLimitError in the body). Check this before generic
+  // OpenAI-compatible markers so shim-shaped quota errors keep the
+  // provider-specific subscribe/reset guidance.
+  if (error instanceof APIError) {
+    const goMessage = getOpenCodeGoAssistantMessage(error)
+    if (goMessage) return goMessage
+  }
+
   // OpenAI-compatible transport and HTTP failures include structured category
   // markers from openaiShim.ts for actionable end-user remediation.
   if (error instanceof APIError) {
@@ -783,33 +818,6 @@ export function getAssistantMessageFromError(
         model,
         rawMessage: error.message,
         host: extractOpenAICategoryHost(error.message),
-      })
-    }
-  }
-
-  // OpenCode Go subscription quota exhaustion (429 with FreeUsageLimitError
-  // or GoUsageLimitError in the body). Terminal — must not be retried.
-  if (error instanceof APIError) {
-    const goLimit = parseOpenCodeGoLimitError(error)
-    if (goLimit) {
-      if (goLimit.kind === 'free') {
-        return createAssistantAPIErrorMessage({
-          content: OPENCODE_GO_FREE_LIMIT_ERROR_MESSAGE,
-          error: 'rate_limit',
-        })
-      }
-      const reset =
-        goLimit.retryAfterSeconds !== undefined
-          ? ` · Resets in ${formatResetDuration(goLimit.retryAfterSeconds)}`
-          : ''
-      const workspace =
-        goLimit.workspace && goLimit.workspace !== 'default'
-          ? ` · Workspace: ${goLimit.workspace}`
-          : ''
-      const limit = goLimit.limitName ? ` · Limit: ${goLimit.limitName}` : ''
-      return createAssistantAPIErrorMessage({
-        content: `${OPENCODE_GO_USAGE_LIMIT_ERROR_MESSAGE}${limit}${workspace}${reset}`,
-        error: 'rate_limit',
       })
     }
   }

--- a/src/services/api/errors.ts
+++ b/src/services/api/errors.ts
@@ -430,6 +430,69 @@ export function getVisionNotSupportedErrorMessage(): string {
 export const OAUTH_ORG_NOT_ALLOWED_ERROR_MESSAGE =
   'Your account does not have access to OpenClaude. Please run /login.'
 
+// OpenCode Go subscription quota exhaustion. The opencode.ai gateway returns
+// 429 with one of these error types in the response body:
+//   - FreeUsageLimitError: free tier exhausted, upgrade required
+//   - GoUsageLimitError: paid Go subscription limit hit (rolling/weekly/monthly)
+// The `retry-after` header (seconds) indicates when the paid limit resets.
+// See https://github.com/anomalyco/opencode packages/opencode/src/session/retry.ts
+// for the canonical implementation we're mirroring.
+export const OPENCODE_GO_FREE_LIMIT_ERROR_MESSAGE =
+  'OpenCode Go free usage exhausted · Subscribe at https://opencode.ai/go'
+export const OPENCODE_GO_USAGE_LIMIT_ERROR_MESSAGE =
+  'OpenCode Go subscription limit reached · See https://opencode.ai/workspace/go'
+
+function parseOpenCodeGoLimitError(
+  error: APIError,
+): {
+  kind: 'free' | 'go'
+  limitName?: string
+  workspace?: string
+  retryAfterSeconds?: number
+} | null {
+  // Only relevant for the opencode-go gateway. Check the base URL on the
+  // error's request or fall back to an env-var check for direct-mode usage.
+  const url = error.headers?.get?.('x-opencode-request-url') ?? ''
+  const envBaseUrl = process.env.OPENAI_BASE_URL ?? ''
+  const isOpencodeGo =
+    url.includes('opencode.ai/zen/go') ||
+    envBaseUrl.includes('opencode.ai/zen/go')
+  if (!isOpencodeGo) return null
+
+  const body = error.message ?? ''
+  const retryAfter = error.headers?.get?.('retry-after')
+  const retryAfterSeconds = retryAfter ? Number(retryAfter) : undefined
+
+  if (body.includes('FreeUsageLimitError')) {
+    return { kind: 'free' }
+  }
+  if (body.includes('GoUsageLimitError')) {
+    const limitNameMatch = body.match(/"limitName"\s*:\s*"([^"]+)"/)
+    const workspaceMatch = body.match(/"workspace"\s*:\s*"([^"]+)"/)
+    return {
+      kind: 'go',
+      limitName: limitNameMatch?.[1],
+      workspace: workspaceMatch?.[1],
+      retryAfterSeconds:
+        typeof retryAfterSeconds === 'number' && !isNaN(retryAfterSeconds)
+          ? retryAfterSeconds
+          : undefined,
+    }
+  }
+  return null
+}
+
+function formatResetDuration(seconds: number): string {
+  const days = Math.floor(seconds / 86400)
+  const hours = Math.floor((seconds % 86400) / 3600)
+  const minutes = Math.floor((seconds % 3600) / 60)
+  const parts: string[] = []
+  if (days > 0) parts.push(`${days}d`)
+  if (hours > 0) parts.push(`${hours}h`)
+  if (minutes > 0 && days === 0) parts.push(`${minutes}m`)
+  return parts.join(' ') || 'soon'
+}
+
 export function getTokenRevokedErrorMessage(): string {
   return getIsNonInteractiveSession()
     ? 'Your account does not have access to Claude. Please login again or contact your administrator.'
@@ -706,6 +769,33 @@ export function getAssistantMessageFromError(
         model,
         rawMessage: error.message,
         host: extractOpenAICategoryHost(error.message),
+      })
+    }
+  }
+
+  // OpenCode Go subscription quota exhaustion (429 with FreeUsageLimitError
+  // or GoUsageLimitError in the body). Terminal — must not be retried.
+  if (error instanceof APIError) {
+    const goLimit = parseOpenCodeGoLimitError(error)
+    if (goLimit) {
+      if (goLimit.kind === 'free') {
+        return createAssistantAPIErrorMessage({
+          content: OPENCODE_GO_FREE_LIMIT_ERROR_MESSAGE,
+          error: 'rate_limit',
+        })
+      }
+      const reset =
+        goLimit.retryAfterSeconds !== undefined
+          ? ` · Resets in ${formatResetDuration(goLimit.retryAfterSeconds)}`
+          : ''
+      const workspace =
+        goLimit.workspace && goLimit.workspace !== 'default'
+          ? ` · Workspace: ${goLimit.workspace}`
+          : ''
+      const limit = goLimit.limitName ? ` · Limit: ${goLimit.limitName}` : ''
+      return createAssistantAPIErrorMessage({
+        content: `${OPENCODE_GO_USAGE_LIMIT_ERROR_MESSAGE}${limit}${workspace}${reset}`,
+        error: 'rate_limit',
       })
     }
   }
@@ -1300,6 +1390,11 @@ export function classifyAPIError(error: unknown): string {
     error.message.includes(CUSTOM_OFF_SWITCH_MESSAGE)
   ) {
     return 'capacity_off_switch'
+  }
+
+  // OpenCode Go subscription quota exhaustion (distinct from generic 429)
+  if (error instanceof APIError && parseOpenCodeGoLimitError(error)) {
+    return 'opencode_go_quota_exhausted'
   }
 
   // Rate limiting

--- a/src/services/api/errors.ts
+++ b/src/services/api/errors.ts
@@ -122,6 +122,12 @@ function mapOpenAICompatibilityFailureToAssistantMessage(options: {
         error: 'rate_limit',
       })
 
+    case 'quota_exhausted':
+      return createAssistantAPIErrorMessage({
+        content: `${API_ERROR_MESSAGE_PREFIX}: Provider quota or usage allotment has run out. Please enable billing for your provider or switch provider via /provider.`,
+        error: 'rate_limit',
+      })
+
     case 'request_timeout':
       return createAssistantAPIErrorMessage({
         content: `${API_ERROR_MESSAGE_PREFIX}: Provider request timed out. Local models may be loading or overloaded; retry shortly or increase API_TIMEOUT_MS.`,

--- a/src/services/api/errors.ts
+++ b/src/services/api/errors.ts
@@ -457,10 +457,12 @@ function parseOpenCodeGoLimitError(
   retryAfterSeconds?: number
 } | null {
   const requestUrl = error.headers?.get?.('x-opencode-request-url')
-  const baseUrl = requestUrl !== null && requestUrl !== undefined
-    ? requestUrl
-    : (process.env.OPENAI_BASE_URL ?? '')
-  const isOpencodeGo = baseUrl.includes('opencode.ai/zen/go')
+  let isOpencodeGo = false
+  if (typeof requestUrl === 'string') {
+    isOpencodeGo = requestUrl.includes('opencode.ai/zen/go')
+  } else {
+    isOpencodeGo = (process.env.OPENAI_BASE_URL ?? '').includes('opencode.ai/zen/go')
+  }
   if (!isOpencodeGo) return null
 
   const body = error.message ?? ''

--- a/src/services/api/errors.ts
+++ b/src/services/api/errors.ts
@@ -456,13 +456,11 @@ function parseOpenCodeGoLimitError(
   workspace?: string
   retryAfterSeconds?: number
 } | null {
-  // Only relevant for the opencode-go gateway. Check the base URL on the
-  // error's request or fall back to an env-var check for direct-mode usage.
-  const url = error.headers?.get?.('x-opencode-request-url') ?? ''
-  const envBaseUrl = process.env.OPENAI_BASE_URL ?? ''
-  const isOpencodeGo =
-    url.includes('opencode.ai/zen/go') ||
-    envBaseUrl.includes('opencode.ai/zen/go')
+  const requestUrl = error.headers?.get?.('x-opencode-request-url')
+  const baseUrl = requestUrl !== null && requestUrl !== undefined
+    ? requestUrl
+    : (process.env.OPENAI_BASE_URL ?? '')
+  const isOpencodeGo = baseUrl.includes('opencode.ai/zen/go')
   if (!isOpencodeGo) return null
 
   const body = error.message ?? ''

--- a/src/services/api/errors.ts
+++ b/src/services/api/errors.ts
@@ -488,6 +488,14 @@ function parseOpenCodeGoLimitError(
   return null
 }
 
+// True when the error is an OpenCode Go subscription/free quota exhaustion
+// (429 with FreeUsageLimitError / GoUsageLimitError from the opencode.ai Go
+// gateway). Callers use this to keep the specific OpenCode Go assistant
+// message intact instead of clobbering it with the generic quota guard.
+export function isOpenCodeGoQuotaError(error: unknown): boolean {
+  return error instanceof APIError && parseOpenCodeGoLimitError(error) !== null
+}
+
 function formatResetDuration(seconds: number): string {
   const days = Math.floor(seconds / 86400)
   const hours = Math.floor((seconds % 86400) / 3600)

--- a/src/services/api/openaiErrorClassification.test.ts
+++ b/src/services/api/openaiErrorClassification.test.ts
@@ -298,3 +298,12 @@ test('classifies 403 with allotment messages as quota_exhausted', () => {
   expect(failure.retryable).toBe(false)
 })
 
+test('does not classify generic billing 400 errors as quota_exhausted', () => {
+  const failure = classifyOpenAIHttpFailure({
+    status: 400,
+    body: 'Invalid billing header: x-anthropic-billing-header is malformed',
+  })
+
+  expect(failure.category).toBe('malformed_provider_response')
+  expect(failure.retryable).toBe(false)
+})

--- a/src/services/api/openaiErrorClassification.test.ts
+++ b/src/services/api/openaiErrorClassification.test.ts
@@ -266,3 +266,35 @@ test('isLocalhostLikeHost matches loopback variants', () => {
   expect(isLocalhostLikeHost('integrate.api.nvidia.com')).toBe(false)
   expect(isLocalhostLikeHost(undefined)).toBe(false)
 })
+
+test('classifies 402 Payment Required as quota_exhausted', () => {
+  const failure = classifyOpenAIHttpFailure({
+    status: 402,
+    body: 'Billing limit reached',
+  })
+
+  expect(failure.category).toBe('quota_exhausted')
+  expect(failure.retryable).toBe(false)
+  expect(failure.hint).toContain('quota or usage allotment')
+})
+
+test('classifies 429 with credit messages as quota_exhausted', () => {
+  const failure = classifyOpenAIHttpFailure({
+    status: 429,
+    body: 'You exceeded your current quota, please check your plan and billing details.',
+  })
+
+  expect(failure.category).toBe('quota_exhausted')
+  expect(failure.retryable).toBe(false)
+})
+
+test('classifies 403 with allotment messages as quota_exhausted', () => {
+  const failure = classifyOpenAIHttpFailure({
+    status: 403,
+    body: 'OpenCode Go usage allotment has run out.',
+  })
+
+  expect(failure.category).toBe('quota_exhausted')
+  expect(failure.retryable).toBe(false)
+})
+

--- a/src/services/api/openaiErrorClassification.ts
+++ b/src/services/api/openaiErrorClassification.ts
@@ -214,7 +214,9 @@ function isQuotaExhaustedMessage(body: string): boolean {
     lower.includes('quota exceeded') ||
     lower.includes('allotment') ||
     lower.includes('insufficient funds') ||
-    lower.includes('billing')
+    lower.includes('billing limit') ||
+    lower.includes('billing quota') ||
+    lower.includes('billing credits')
   )
 }
 

--- a/src/services/api/openaiErrorClassification.ts
+++ b/src/services/api/openaiErrorClassification.ts
@@ -5,6 +5,7 @@ export type OpenAICompatibilityFailureCategory =
   | 'network_error'
   | 'auth_invalid'
   | 'rate_limited'
+  | 'quota_exhausted'
   | 'model_not_found'
   | 'endpoint_not_found'
   | 'vision_not_supported'
@@ -37,6 +38,7 @@ const OPENAI_COMPATIBILITY_FAILURE_CATEGORIES: ReadonlySet<OpenAICompatibilityFa
     'network_error',
     'auth_invalid',
     'rate_limited',
+    'quota_exhausted',
     'model_not_found',
     'endpoint_not_found',
     'vision_not_supported',
@@ -199,6 +201,23 @@ function isModelNotFoundMessage(body: string): boolean {
   )
 }
 
+function isQuotaExhaustedMessage(body: string): boolean {
+  const lower = body.toLowerCase()
+  return (
+    lower.includes('limit: 0') ||
+    lower.includes('exceeded your current quota') ||
+    lower.includes('insufficient credit') ||
+    lower.includes('credit limit') ||
+    lower.includes('out of credits') ||
+    lower.includes('payment required') ||
+    lower.includes('usage limit') ||
+    lower.includes('quota exceeded') ||
+    lower.includes('allotment') ||
+    lower.includes('insufficient funds') ||
+    lower.includes('billing')
+  )
+}
+
 export function formatOpenAICategoryMarker(
   category: OpenAICompatibilityFailureCategory,
   host?: string,
@@ -315,6 +334,21 @@ export function classifyOpenAIHttpFailure(options: {
   const body = options.body ?? ''
   const hostname = options.url ? getHostname(options.url) : null
   const isLocalHost = isLocalhostLikeHostname(hostname)
+
+  if (
+    options.status === 402 ||
+    ((options.status === 400 || options.status === 403 || options.status === 429) &&
+      isQuotaExhaustedMessage(body))
+  ) {
+    return {
+      source: 'http',
+      category: 'quota_exhausted',
+      retryable: false,
+      status: options.status,
+      message: body,
+      hint: 'Provider quota or usage allotment has run out. Enable billing or switch provider.',
+    }
+  }
 
   if (options.status === 401 || options.status === 403) {
     // OAuth-issued tokens (GitHub Models via /onboard-github, Codex) expire

--- a/src/services/api/openaiShim.test.ts
+++ b/src/services/api/openaiShim.test.ts
@@ -9716,4 +9716,187 @@ test('GitHub Copilot 401 chat_completions with providerOverride does not trigger
   } finally {
     mock.module('../../utils/githubModelsCredentials.js', () => realGithubModule)
   }
+// --- JSON fallback regression tests (#1749) -------------------------------
+// Some OpenAI-compatible providers ignore `stream: true` and return a full
+// `application/json` chat completion. The fallback inside
+// openaiStreamToAnthropic must route that response through the same
+// non-streaming converter so tool_calls, Anthropic stop reasons, array
+// content, and <think> stripping are all preserved (jatmn CHANGES_REQUESTED).
+
+function makeJsonChatCompletion(body: Record<string, unknown>): Response {
+  return new Response(JSON.stringify(body), {
+    headers: { 'Content-Type': 'application/json' },
+  })
+}
+
+async function collectFallbackEvents(
+  body: Record<string, unknown>,
+): Promise<Array<Record<string, unknown>>> {
+  globalThis.fetch = (async () => makeJsonChatCompletion(body)) as unknown as FetchType
+  const client = createOpenAIShimClient({}) as OpenAIShimClient
+  const result = await client.beta.messages
+    .create({
+      model: 'fake-model',
+      messages: [{ role: 'user', content: 'hi' }],
+      max_tokens: 64,
+      stream: true,
+    })
+    .withResponse()
+  const events: Array<Record<string, unknown>> = []
+  for await (const event of result.data) {
+    events.push(event)
+  }
+  return events
+}
+
+test('JSON fallback: preserves tool_calls as a tool_use block', async () => {
+  const events = await collectFallbackEvents({
+    id: 'chatcmpl-json-tool',
+    model: 'fake-model',
+    choices: [
+      {
+        message: {
+          role: 'assistant',
+          content: null,
+          tool_calls: [
+            {
+              id: 'call_1',
+              type: 'function',
+              function: { name: 'Bash', arguments: '{"command":"pwd"}' },
+            },
+          ],
+        },
+        finish_reason: 'tool_calls',
+      },
+    ],
+  })
+
+  const toolStart = events.find(
+    event =>
+      event.type === 'content_block_start' &&
+      typeof event.content_block === 'object' &&
+      event.content_block !== null &&
+      (event.content_block as Record<string, unknown>).type === 'tool_use',
+  ) as { content_block?: Record<string, unknown> } | undefined
+  expect(toolStart?.content_block).toMatchObject({
+    type: 'tool_use',
+    id: 'call_1',
+    name: 'Bash',
+  })
+
+  const inputDelta = events.find(
+    event =>
+      event.type === 'content_block_delta' &&
+      typeof event.delta === 'object' &&
+      event.delta !== null &&
+      (event.delta as Record<string, unknown>).type === 'input_json_delta',
+  ) as { delta?: { partial_json?: string } } | undefined
+  expect(JSON.parse(inputDelta?.delta?.partial_json ?? '{}')).toEqual({
+    command: 'pwd',
+  })
+
+  const stopEvent = events.find(e => e.type === 'message_delta') as
+    | { delta?: { stop_reason?: string } }
+    | undefined
+  expect(stopEvent?.delta?.stop_reason).toBe('tool_use')
+})
+
+test('JSON fallback: maps finish_reason=length to max_tokens', async () => {
+  const events = await collectFallbackEvents({
+    id: 'chatcmpl-json-len',
+    model: 'fake-model',
+    choices: [
+      { message: { role: 'assistant', content: 'partial' }, finish_reason: 'length' },
+    ],
+  })
+  const stopEvent = events.find(e => e.type === 'message_delta') as
+    | { delta?: { stop_reason?: string } }
+    | undefined
+  expect(stopEvent?.delta?.stop_reason).toBe('max_tokens')
+})
+
+test('JSON fallback: strips <think> tags from emitted text', async () => {
+  const events = await collectFallbackEvents({
+    id: 'chatcmpl-json-think',
+    model: 'fake-model',
+    choices: [
+      {
+        message: { role: 'assistant', content: '<think>private plan</think>visible answer' },
+        finish_reason: 'stop',
+      },
+    ],
+  })
+  const textDelta = events.find(
+    event =>
+      event.type === 'content_block_delta' &&
+      typeof event.delta === 'object' &&
+      event.delta !== null &&
+      (event.delta as Record<string, unknown>).type === 'text_delta',
+  ) as { delta?: { text?: string } } | undefined
+  expect(textDelta?.delta?.text).toBe('visible answer')
+  expect(textDelta?.delta?.text).not.toContain('private plan')
+})
+
+test('JSON fallback: normalizes array content into a text string', async () => {
+  const events = await collectFallbackEvents({
+    id: 'chatcmpl-json-array',
+    model: 'fake-model',
+    choices: [
+      {
+        message: {
+          role: 'assistant',
+          content: [
+            { type: 'text', text: 'line one' },
+            { type: 'text', text: 'line two' },
+          ],
+        },
+        finish_reason: 'stop',
+      },
+    ],
+  })
+  const textDelta = events.find(
+    event =>
+      event.type === 'content_block_delta' &&
+      typeof event.delta === 'object' &&
+      event.delta !== null &&
+      (event.delta as Record<string, unknown>).type === 'text_delta',
+  ) as { delta?: { text?: unknown } } | undefined
+  expect(typeof textDelta?.delta?.text).toBe('string')
+  expect(textDelta?.delta?.text).toBe('line one\nline two')
+})
+
+test('JSON fallback: recovers raw-text tool call into tool_use block', async () => {
+  const events = await collectFallbackEvents({
+    id: 'chatcmpl-json-raw',
+    model: 'fake-model',
+    choices: [
+      {
+        message: {
+          role: 'assistant',
+          // Same "Tool calls requested:" recovery format the non-streaming
+          // converter already handles (parseRawToolCallsRequestedText).
+          content:
+            'Tool calls requested:\n- Bash({"command":"ls"}) [id: call_raw_1]',
+        },
+        finish_reason: 'stop',
+      },
+    ],
+  })
+  const toolStart = events.find(
+    event =>
+      event.type === 'content_block_start' &&
+      typeof event.content_block === 'object' &&
+      event.content_block !== null &&
+      (event.content_block as Record<string, unknown>).type === 'tool_use',
+  ) as { content_block?: Record<string, unknown> } | undefined
+  expect(toolStart?.content_block).toMatchObject({
+    type: 'tool_use',
+    id: 'call_raw_1',
+    name: 'Bash',
+  })
+  const stopEvent = events.find(e => e.type === 'message_delta') as
+    | { delta?: { stop_reason?: string } }
+    | undefined
+  expect(stopEvent?.delta?.stop_reason).toBe('tool_use')
+
 })

--- a/src/services/api/openaiShim.test.ts
+++ b/src/services/api/openaiShim.test.ts
@@ -9732,21 +9732,27 @@ function makeJsonChatCompletion(body: Record<string, unknown>): Response {
 async function collectFallbackEvents(
   body: Record<string, unknown>,
 ): Promise<Array<Record<string, unknown>>> {
+  const previousFetch = globalThis.fetch
   globalThis.fetch = (async () => makeJsonChatCompletion(body)) as unknown as FetchType
-  const client = createOpenAIShimClient({}) as OpenAIShimClient
-  const result = await client.beta.messages
-    .create({
-      model: 'fake-model',
-      messages: [{ role: 'user', content: 'hi' }],
-      max_tokens: 64,
-      stream: true,
-    })
-    .withResponse()
-  const events: Array<Record<string, unknown>> = []
-  for await (const event of result.data) {
-    events.push(event)
+  try {
+    const client = createOpenAIShimClient({}) as OpenAIShimClient
+    const result = await client.beta.messages
+      .create({
+        model: 'fake-model',
+        messages: [{ role: 'user', content: 'hi' }],
+        max_tokens: 64,
+        stream: true,
+      })
+      .withResponse()
+    const events: Array<Record<string, unknown>> = []
+    for await (const event of result.data) {
+      events.push(event)
+    }
+    return events
+  } finally {
+    // Restore so the global fetch stub does not leak past this helper.
+    globalThis.fetch = previousFetch
   }
-  return events
 }
 
 test('JSON fallback: preserves tool_calls as a tool_use block', async () => {
@@ -9899,4 +9905,36 @@ test('JSON fallback: recovers raw-text tool call into tool_use block', async () 
     | undefined
   expect(stopEvent?.delta?.stop_reason).toBe('tool_use')
 
+})
+
+test('JSON fallback: empty tool_calls array does not block raw-text recovery', async () => {
+  // tool_calls: [] is truthy; it must be treated as "no structured tool calls"
+  // so the raw "Tool calls requested" recovery still runs.
+  const events = await collectFallbackEvents({
+    id: 'chatcmpl-json-empty-tc',
+    model: 'fake-model',
+    choices: [
+      {
+        message: {
+          role: 'assistant',
+          tool_calls: [],
+          content:
+            'Tool calls requested:\n- Bash({"command":"ls"}) [id: call_empty_tc]',
+        },
+        finish_reason: 'stop',
+      },
+    ],
+  })
+  const toolStart = events.find(
+    event =>
+      event.type === 'content_block_start' &&
+      typeof event.content_block === 'object' &&
+      event.content_block !== null &&
+      (event.content_block as Record<string, unknown>).type === 'tool_use',
+  ) as { content_block?: Record<string, unknown> } | undefined
+  expect(toolStart?.content_block).toMatchObject({
+    type: 'tool_use',
+    id: 'call_empty_tc',
+    name: 'Bash',
+  })
 })

--- a/src/services/api/openaiShim.test.ts
+++ b/src/services/api/openaiShim.test.ts
@@ -5,6 +5,10 @@ import { asMockFetch } from '../../test/typedMocks.js'
 import { _clearRegistryForTesting, ensureIntegrationsLoaded, registerGateway } from '../../integrations/index.ts'
 import { applyProviderFlag } from '../../utils/providerFlag.ts'
 import { applyProviderProfileToProcessEnv } from '../../utils/providerProfiles.ts'
+import {
+  getAssistantMessageFromError,
+  OPENCODE_GO_FREE_LIMIT_ERROR_MESSAGE,
+} from './errors.ts'
 import { createOpenAIShimClient, hasMistralApiHost } from './openaiShim.ts'
 import * as realCodexShim from './codexShim.js'
 import * as realGithubModelsCredentials from '../../utils/githubModelsCredentials.js'
@@ -9821,6 +9825,55 @@ test('JSON fallback: maps finish_reason=length to max_tokens', async () => {
     | { delta?: { stop_reason?: string } }
     | undefined
   expect(stopEvent?.delta?.stop_reason).toBe('max_tokens')
+})
+
+test('JSON fallback: preserves OpenCode Go quota error guidance', async () => {
+  process.env.OPENAI_BASE_URL = 'https://opencode.ai/zen/go/v1'
+  const previousFetch = globalThis.fetch
+  globalThis.fetch = (async () =>
+    withResponseUrl(
+      makeJsonChatCompletion({
+        error: {
+          type: 'FreeUsageLimitError',
+          message: 'free usage limit reached',
+        },
+      }),
+      'https://opencode.ai/zen/go/v1/chat/completions',
+    )) as unknown as FetchType
+
+  try {
+    const client = createOpenAIShimClient({}) as OpenAIShimClient
+    const result = await client.beta.messages
+      .create({
+        model: 'fake-model',
+        messages: [{ role: 'user', content: 'hi' }],
+        max_tokens: 64,
+        stream: true,
+      })
+      .withResponse()
+
+    let caught: unknown
+    try {
+      for await (const _event of result.data) {
+        // Consume until the JSON error is surfaced.
+      }
+    } catch (error) {
+      caught = error
+    }
+
+    expect(caught).toBeInstanceOf(APIError)
+    const apiError = caught as APIError
+    expect(apiError.headers?.get('x-opencode-request-url')).toBe(
+      'https://opencode.ai/zen/go/v1/chat/completions',
+    )
+    const message = getAssistantMessageFromError(apiError, 'glm-5.1')
+    const first = message.message.content[0]
+    expect(typeof first === 'object' && first && 'text' in first ? first.text : '').toBe(
+      OPENCODE_GO_FREE_LIMIT_ERROR_MESSAGE,
+    )
+  } finally {
+    globalThis.fetch = previousFetch
+  }
 })
 
 test('JSON fallback: strips <think> tags from emitted text', async () => {

--- a/src/services/api/openaiShim.test.ts
+++ b/src/services/api/openaiShim.test.ts
@@ -9716,6 +9716,8 @@ test('GitHub Copilot 401 chat_completions with providerOverride does not trigger
   } finally {
     mock.module('../../utils/githubModelsCredentials.js', () => realGithubModule)
   }
+})
+
 // --- JSON fallback regression tests (#1749) -------------------------------
 // Some OpenAI-compatible providers ignore `stream: true` and return a full
 // `application/json` chat completion. The fallback inside
@@ -9935,6 +9937,40 @@ test('JSON fallback: empty tool_calls array does not block raw-text recovery', a
   expect(toolStart?.content_block).toMatchObject({
     type: 'tool_use',
     id: 'call_empty_tc',
+    name: 'Bash',
+  })
+})
+
+test('JSON fallback: empty tool_calls does not block raw-text recovery on array content', async () => {
+  // Companion to the string-content case above: the array-content branch must
+  // also treat tool_calls: [] as "no structured tool calls" so raw recovery runs.
+  const events = await collectFallbackEvents({
+    id: 'chatcmpl-json-empty-tc-array',
+    model: 'fake-model',
+    choices: [
+      {
+        message: {
+          role: 'assistant',
+          tool_calls: [],
+          content: [
+            { type: 'text', text: 'Tool calls requested:' },
+            { type: 'text', text: '- Bash({"command":"ls"}) [id: call_empty_tc_arr]' },
+          ],
+        },
+        finish_reason: 'stop',
+      },
+    ],
+  })
+  const toolStart = events.find(
+    event =>
+      event.type === 'content_block_start' &&
+      typeof event.content_block === 'object' &&
+      event.content_block !== null &&
+      (event.content_block as Record<string, unknown>).type === 'tool_use',
+  ) as { content_block?: Record<string, unknown> } | undefined
+  expect(toolStart?.content_block).toMatchObject({
+    type: 'tool_use',
+    id: 'call_empty_tc_arr',
     name: 'Bash',
   })
 })

--- a/src/services/api/openaiShim.ts
+++ b/src/services/api/openaiShim.ts
@@ -2197,6 +2197,167 @@ async function* geminiSseToAnthropic(
   }
 }
 
+type NonStreamingOpenAIResponse = {
+  id?: string
+  model?: string
+  choices?: Array<{
+    message?: {
+      role?: string
+      content?: string | null | Array<{ type?: string; text?: string }>
+      reasoning_content?: string | null
+      extra_content?: Record<string, unknown>
+      tool_calls?: Array<{
+        id: string
+        function: { name: string; arguments: string }
+        extra_content?: Record<string, unknown>
+      }>
+    }
+    finish_reason?: string
+  }>
+  usage?: {
+    prompt_tokens?: number
+    completion_tokens?: number
+    prompt_tokens_details?: {
+      cached_tokens?: number
+    }
+  }
+}
+
+/**
+ * Convert an OpenAI-compatible non-streaming chat completion into an
+ * Anthropic-shaped message. Shared by the `OpenAIShimMessages` non-stream path
+ * and the `application/json` fallback inside `openaiStreamToAnthropic` so both
+ * apply the same tool-call extraction, stop-reason mapping, array-content
+ * normalization, <think>-tag stripping, and raw text tool-call recovery.
+ */
+function convertNonStreamingResponseToAnthropicMessage(
+  data: NonStreamingOpenAIResponse,
+  model: string,
+) {
+  const choice = data.choices?.[0]
+  const content: Array<Record<string, unknown>> = []
+
+  // Some reasoning models (e.g. GLM-5) put their chain-of-thought in
+  // reasoning_content while content stays null. Preserve it as a thinking
+  // block, but do not surface it as visible assistant text.
+  const reasoningText = choice?.message?.reasoning_content
+  if (typeof reasoningText === 'string' && reasoningText) {
+    content.push({ type: 'thinking', thinking: reasoningText })
+  }
+  const rawContent =
+    choice?.message?.content !== '' && choice?.message?.content != null
+      ? choice?.message?.content
+      : null
+  if (typeof rawContent === 'string' && rawContent) {
+    const strippedContent = stripThinkTags(rawContent)
+    const rawToolCalls = choice?.message?.tool_calls
+      ? null
+      : parseRawToolCallsRequestedText(strippedContent)
+    if (rawToolCalls) {
+      for (const toolCall of rawToolCalls) {
+        content.push({
+          type: 'tool_use',
+          id: toolCall.id,
+          name: toolCall.name,
+          input: JSON.parse(toolCall.argumentsJson),
+        })
+      }
+    } else {
+      content.push({
+        type: 'text',
+        text: strippedContent,
+      })
+    }
+  } else if (Array.isArray(rawContent) && rawContent.length > 0) {
+    const parts: string[] = []
+    for (const part of rawContent) {
+      if (
+        part &&
+        typeof part === 'object' &&
+        part.type === 'text' &&
+        typeof part.text === 'string'
+      ) {
+        parts.push(part.text)
+      }
+    }
+    const joined = parts.join('\n')
+    if (joined) {
+      const strippedContent = stripThinkTags(joined)
+      const rawToolCalls = choice?.message?.tool_calls
+        ? null
+        : parseRawToolCallsRequestedText(strippedContent)
+      if (rawToolCalls) {
+        for (const toolCall of rawToolCalls) {
+          content.push({
+            type: 'tool_use',
+            id: toolCall.id,
+            name: toolCall.name,
+            input: JSON.parse(toolCall.argumentsJson),
+          })
+        }
+      } else {
+        content.push({
+          type: 'text',
+          text: strippedContent,
+        })
+      }
+    }
+  }
+
+  if (choice?.message?.tool_calls) {
+    for (const tc of choice.message.tool_calls) {
+      const input = normalizeToolArguments(
+        tc.function.name,
+        tc.function.arguments,
+      )
+      const toolExtraContent = tc.extra_content ?? choice.message.extra_content
+      const toolSignature =
+        geminiThoughtSignatureFromExtraContent(tc.extra_content) ??
+        geminiThoughtSignatureFromExtraContent(choice.message.extra_content)
+      const mergedToolExtraContent = mergeGeminiThoughtSignature(
+        toolExtraContent,
+        toolSignature,
+      )
+      content.push({
+        type: 'tool_use',
+        id: tc.id,
+        name: tc.function.name,
+        input,
+        ...(mergedToolExtraContent ? { extra_content: mergedToolExtraContent } : {}),
+        ...(toolSignature ? { signature: toolSignature } : {}),
+      })
+    }
+  }
+
+  const stopReason =
+    choice?.finish_reason === 'tool_calls' ||
+    content.some(block => block.type === 'tool_use')
+      ? 'tool_use'
+      : choice?.finish_reason === 'length'
+        ? 'max_tokens'
+        : 'end_turn'
+
+  if (choice?.finish_reason === 'content_filter' || choice?.finish_reason === 'safety') {
+    content.push({
+      type: 'text',
+      text: '\n\n[Content blocked by provider safety filter]',
+    })
+  }
+
+  return {
+    id: data.id ?? makeMessageId(),
+    type: 'message',
+    role: 'assistant',
+    content,
+    model: data.model ?? model,
+    stop_reason: stopReason,
+    stop_sequence: null,
+    usage: buildAnthropicUsageFromRawUsage(
+      data.usage as unknown as Record<string, unknown> | undefined,
+    ),
+  }
+}
+
 async function* openaiStreamToAnthropic(
   response: Response,
   model: string,
@@ -2292,57 +2453,64 @@ async function* openaiStreamToAnthropic(
       )
     }
 
-    // Convert non-streaming response into stream events
-    const choice = parsed.choices?.[0]
-    const content = choice?.message?.content || ''
-    const reasoning = choice?.message?.reasoning_content || ''
+    // Some providers ignore `stream: true` and return a normal JSON chat
+    // completion. Route it through the shared non-streaming converter so this
+    // fallback preserves tool_calls, Anthropic stop-reason mapping, array
+    // content normalization, <think>-tag stripping, and raw text tool-call
+    // recovery — then re-emit the resulting message as stream events.
+    const message = convertNonStreamingResponseToAnthropicMessage(parsed, model)
 
-    if (reasoning) {
-      yield {
-        type: 'content_block_start',
-        index: contentBlockIndex,
-        content_block: { type: 'thinking', thinking: '' },
+    for (const block of message.content) {
+      if (block.type === 'thinking') {
+        yield {
+          type: 'content_block_start',
+          index: contentBlockIndex,
+          content_block: { type: 'thinking', thinking: '' },
+        }
+        yield {
+          type: 'content_block_delta',
+          index: contentBlockIndex,
+          delta: { type: 'thinking_delta', thinking: block.thinking as string },
+        }
+        yield { type: 'content_block_stop', index: contentBlockIndex }
+        contentBlockIndex++
+      } else if (block.type === 'tool_use') {
+        const { type: _t, input, ...rest } = block
+        yield {
+          type: 'content_block_start',
+          index: contentBlockIndex,
+          content_block: { type: 'tool_use', input: {}, ...rest },
+        }
+        yield {
+          type: 'content_block_delta',
+          index: contentBlockIndex,
+          delta: { type: 'input_json_delta', partial_json: JSON.stringify(input ?? {}) },
+        }
+        yield { type: 'content_block_stop', index: contentBlockIndex }
+        contentBlockIndex++
+      } else {
+        yield {
+          type: 'content_block_start',
+          index: contentBlockIndex,
+          content_block: { type: 'text', text: '' },
+        }
+        yield {
+          type: 'content_block_delta',
+          index: contentBlockIndex,
+          delta: { type: 'text_delta', text: block.text as string },
+        }
+        yield { type: 'content_block_stop', index: contentBlockIndex }
+        contentBlockIndex++
       }
-      yield {
-        type: 'content_block_delta',
-        index: contentBlockIndex,
-        delta: { type: 'thinking_delta', thinking: reasoning },
-      }
-      yield {
-        type: 'content_block_stop',
-        index: contentBlockIndex,
-      }
-      contentBlockIndex++
-    }
-
-    if (content) {
-      yield {
-        type: 'content_block_start',
-        index: contentBlockIndex,
-        content_block: { type: 'text', text: '' },
-      }
-      yield {
-        type: 'content_block_delta',
-        index: contentBlockIndex,
-        delta: { type: 'text_delta', text: content },
-      }
-      yield {
-        type: 'content_block_stop',
-        index: contentBlockIndex,
-      }
-      contentBlockIndex++
     }
 
     yield {
       type: 'message_delta',
       delta: {
-        stop_reason: choice?.finish_reason || 'end_turn',
+        stop_reason: message.stop_reason,
         stop_sequence: null,
       },
-      usage: {
-        output_tokens: parsed.usage?.completion_tokens ?? 0,
-        input_tokens: parsed.usage?.prompt_tokens ?? 0,
-      },
+      usage: message.usage,
     }
     yield { type: 'message_stop' }
     return
@@ -4618,159 +4786,10 @@ class OpenAIShimMessages {
   }
 
   private _convertNonStreamingResponse(
-    data: {
-      id?: string
-      model?: string
-      choices?: Array<{
-        message?: {
-          role?: string
-          content?:
-            | string
-            | null
-            | Array<{ type?: string; text?: string }>
-          reasoning_content?: string | null
-          extra_content?: Record<string, unknown>
-          tool_calls?: Array<{
-            id: string
-            function: { name: string; arguments: string }
-            extra_content?: Record<string, unknown>
-          }>
-        }
-        finish_reason?: string
-      }>
-      usage?: {
-        prompt_tokens?: number
-        completion_tokens?: number
-        prompt_tokens_details?: {
-          cached_tokens?: number
-        }
-      }
-    },
+    data: NonStreamingOpenAIResponse,
     model: string,
   ) {
-    const choice = data.choices?.[0]
-    const content: Array<Record<string, unknown>> = []
-
-    // Recover tool calls that the model emitted as text (no structured
-    // tool_calls field): first the "Tool calls requested:" prefix format, then
-    // XML dialects (GLM/Qwen `<tool_call>…`). Falls back to plain text.
-    const pushParsedTextContent = (strippedContent: string) => {
-      if (choice?.message?.tool_calls) {
-        content.push({ type: 'text', text: strippedContent })
-        return
-      }
-      const rawToolCalls = parseRawToolCallsRequestedText(strippedContent)
-      if (rawToolCalls) {
-        for (const toolCall of rawToolCalls) {
-          content.push({
-            type: 'tool_use',
-            id: toolCall.id,
-            name: toolCall.name,
-            input: JSON.parse(toolCall.argumentsJson),
-          })
-        }
-        return
-      }
-      const { calls, toolCallRanges } = parseXmlToolCalls(strippedContent)
-      if (calls.length > 0) {
-        const remaining = stripRanges(strippedContent, toolCallRanges).trim()
-        if (remaining) content.push({ type: 'text', text: remaining })
-        for (const tc of calls) {
-          content.push({
-            type: 'tool_use',
-            id: tc.id,
-            name: tc.name,
-            input: tc.arguments,
-          })
-        }
-        return
-      }
-      content.push({ type: 'text', text: strippedContent })
-    }
-
-    // Some reasoning models (e.g. GLM-5) put their chain-of-thought in
-    // reasoning_content while content stays null. Preserve it as a thinking
-    // block, but do not surface it as visible assistant text.
-    const reasoningText = choice?.message?.reasoning_content
-    if (typeof reasoningText === 'string' && reasoningText) {
-      content.push({ type: 'thinking', thinking: reasoningText })
-    }
-    const rawContent =
-      choice?.message?.content !== '' && choice?.message?.content != null
-        ? choice?.message?.content
-        : null
-    if (typeof rawContent === 'string' && rawContent) {
-      pushParsedTextContent(stripThinkTags(rawContent))
-    } else if (Array.isArray(rawContent) && rawContent.length > 0) {
-      const parts: string[] = []
-      for (const part of rawContent) {
-        if (
-          part &&
-          typeof part === 'object' &&
-          part.type === 'text' &&
-          typeof part.text === 'string'
-        ) {
-          parts.push(part.text)
-        }
-      }
-      const joined = parts.join('\n')
-      if (joined) {
-        pushParsedTextContent(stripThinkTags(joined))
-      }
-    }
-
-    if (choice?.message?.tool_calls) {
-      for (const tc of choice.message.tool_calls) {
-        const input = normalizeToolArguments(
-          tc.function.name,
-          tc.function.arguments,
-        )
-        const toolExtraContent = tc.extra_content ?? choice.message.extra_content
-        const toolSignature =
-          geminiThoughtSignatureFromExtraContent(tc.extra_content) ??
-          geminiThoughtSignatureFromExtraContent(choice.message.extra_content)
-        const mergedToolExtraContent = mergeGeminiThoughtSignature(
-          toolExtraContent,
-          toolSignature,
-        )
-        content.push({
-          type: 'tool_use',
-          id: tc.id,
-          name: tc.function.name,
-          input,
-          ...(mergedToolExtraContent ? { extra_content: mergedToolExtraContent } : {}),
-          ...(toolSignature ? { signature: toolSignature } : {}),
-        })
-      }
-    }
-
-    const stopReason =
-      choice?.finish_reason === 'tool_calls' ||
-      content.some(block => block.type === 'tool_use')
-        ? 'tool_use'
-        : choice?.finish_reason === 'length'
-          ? 'max_tokens'
-          : 'end_turn'
-
-    if (choice?.finish_reason === 'content_filter' || choice?.finish_reason === 'safety') {
-      content.push({
-        type: 'text',
-        text: '\n\n[Content blocked by provider safety filter]',
-      })
-    }
-
-    return {
-      id: data.id ?? makeMessageId(),
-      type: 'message',
-      role: 'assistant',
-      content,
-      model: data.model ?? model,
-      stop_reason: stopReason,
-      stop_sequence: null,
-      usage: buildAnthropicUsageFromRawUsage(
-        data.usage as unknown as Record<string, unknown> | undefined,
-      ),
-    }
+    return convertNonStreamingResponseToAnthropicMessage(data, model)
   }
 
   private _convertGeminiToAnthropicResponse(

--- a/src/services/api/openaiShim.ts
+++ b/src/services/api/openaiShim.ts
@@ -2236,6 +2236,10 @@ function convertNonStreamingResponseToAnthropicMessage(
 ) {
   const choice = data.choices?.[0]
   const content: Array<Record<string, unknown>> = []
+  // An empty tool_calls array is still truthy; treat it as "no structured tool
+  // calls" so raw "Tool calls requested" text recovery is not skipped.
+  const hasStructuredToolCalls =
+    (choice?.message?.tool_calls?.length ?? 0) > 0
 
   // Some reasoning models (e.g. GLM-5) put their chain-of-thought in
   // reasoning_content while content stays null. Preserve it as a thinking
@@ -2250,7 +2254,7 @@ function convertNonStreamingResponseToAnthropicMessage(
       : null
   if (typeof rawContent === 'string' && rawContent) {
     const strippedContent = stripThinkTags(rawContent)
-    const rawToolCalls = choice?.message?.tool_calls
+    const rawToolCalls = hasStructuredToolCalls
       ? null
       : parseRawToolCallsRequestedText(strippedContent)
     if (rawToolCalls) {
@@ -2283,7 +2287,7 @@ function convertNonStreamingResponseToAnthropicMessage(
     const joined = parts.join('\n')
     if (joined) {
       const strippedContent = stripThinkTags(joined)
-      const rawToolCalls = choice?.message?.tool_calls
+      const rawToolCalls = hasStructuredToolCalls
         ? null
         : parseRawToolCallsRequestedText(strippedContent)
       if (rawToolCalls) {
@@ -2304,7 +2308,7 @@ function convertNonStreamingResponseToAnthropicMessage(
     }
   }
 
-  if (choice?.message?.tool_calls) {
+  if (hasStructuredToolCalls && choice?.message?.tool_calls) {
     for (const tc of choice.message.tool_calls) {
       const input = normalizeToolArguments(
         tc.function.name,

--- a/src/services/api/openaiShim.ts
+++ b/src/services/api/openaiShim.ts
@@ -2362,11 +2362,20 @@ function convertNonStreamingResponseToAnthropicMessage(
   }
 }
 
+function headersWithRequestUrl(headers: Headers, requestUrl?: string): Headers {
+  const next = new Headers(headers)
+  if (requestUrl) {
+    next.set('x-opencode-request-url', requestUrl)
+  }
+  return next
+}
+
 async function* openaiStreamToAnthropic(
   response: Response,
   model: string,
   signal?: AbortSignal,
   isOllama = false,
+  requestUrl?: string,
 ): AsyncGenerator<AnthropicStreamEvent> {
   const messageId = makeMessageId()
   let contentBlockIndex = 0
@@ -2404,26 +2413,6 @@ async function* openaiStreamToAnthropic(
   let xmlToolCallText: string | null = null
   let xmlHoldback = ''
 
-  // Emit message_start
-  yield {
-    type: 'message_start',
-    message: {
-      id: messageId,
-      type: 'message',
-      role: 'assistant',
-      content: [],
-      model,
-      stop_reason: null,
-      stop_sequence: null,
-      usage: {
-        input_tokens: 0,
-        output_tokens: 0,
-        cache_creation_input_tokens: 0,
-        cache_read_input_tokens: 0,
-      },
-    },
-  }
-
   const contentType = response.headers.get('content-type') ?? ''
   if (contentType.includes('application/json')) {
     const text = await response.text().catch(() => '')
@@ -2440,20 +2429,23 @@ async function* openaiStreamToAnthropic(
     }
 
     if (parsed && typeof parsed === 'object' && parsed.error) {
-      const errorMsg = parsed.error.message || JSON.stringify(parsed.error)
+      const errorMsg =
+        parsed.error && typeof parsed.error === 'object' && 'type' in parsed.error
+          ? JSON.stringify(parsed.error)
+          : parsed.error.message || JSON.stringify(parsed.error)
       const failure = classifyOpenAIHttpFailure({
         status: response.status,
         body: text,
-        url: response.url,
+        url: requestUrl ?? response.url,
       })
       throw APIError.generate(
         response.status,
         parsed,
         buildOpenAICompatibilityErrorMessage(
           `OpenAI API error ${response.status}: ${errorMsg}`,
-          { ...failure, requestUrl: response.url },
+          { ...failure, requestUrl: requestUrl ?? response.url },
         ),
-        response.headers as unknown as Headers,
+        headersWithRequestUrl(response.headers, requestUrl ?? response.url),
       )
     }
 
@@ -2463,6 +2455,25 @@ async function* openaiStreamToAnthropic(
     // content normalization, <think>-tag stripping, and raw text tool-call
     // recovery — then re-emit the resulting message as stream events.
     const message = convertNonStreamingResponseToAnthropicMessage(parsed, model)
+
+    yield {
+      type: 'message_start',
+      message: {
+        id: messageId,
+        type: 'message',
+        role: 'assistant',
+        content: [],
+        model,
+        stop_reason: null,
+        stop_sequence: null,
+        usage: {
+          input_tokens: 0,
+          output_tokens: 0,
+          cache_creation_input_tokens: 0,
+          cache_read_input_tokens: 0,
+        },
+      },
+    }
 
     for (const block of message.content) {
       if (block.type === 'thinking') {
@@ -3413,7 +3424,7 @@ class OpenAIShimMessages {
                 ? anthropicSsePassthrough(response, request.resolvedModel, streamSignal)
                 : isGeminiStream
                   ? geminiSseToAnthropic(response, request.resolvedModel, streamSignal)
-                  : openaiStreamToAnthropic(response, request.resolvedModel, streamSignal, isLikelyOllamaEndpoint(request.baseUrl)),
+                  : openaiStreamToAnthropic(response, request.resolvedModel, streamSignal, isLikelyOllamaEndpoint(request.baseUrl), response.url || undefined),
           options?.signal,
           cancelBeforeIteration,
         )
@@ -4490,7 +4501,7 @@ class OpenAIShimMessages {
           `OpenAI API error ${status}: ${errorBody}${rateHint}`,
           failureWithUrl,
         ),
-        responseHeaders,
+        headersWithRequestUrl(responseHeaders, requestUrl),
       )
     }
 

--- a/src/services/api/openaiShim.ts
+++ b/src/services/api/openaiShim.ts
@@ -2239,6 +2239,115 @@ async function* openaiStreamToAnthropic(
   let xmlToolCallText: string | null = null
   let xmlHoldback = ''
 
+  // Emit message_start
+  yield {
+    type: 'message_start',
+    message: {
+      id: messageId,
+      type: 'message',
+      role: 'assistant',
+      content: [],
+      model,
+      stop_reason: null,
+      stop_sequence: null,
+      usage: {
+        input_tokens: 0,
+        output_tokens: 0,
+        cache_creation_input_tokens: 0,
+        cache_read_input_tokens: 0,
+      },
+    },
+  }
+
+  const contentType = response.headers.get('content-type') ?? ''
+  if (contentType.includes('application/json')) {
+    const text = await response.text().catch(() => '')
+    let parsed: any
+    try {
+      parsed = JSON.parse(text)
+    } catch {
+      throw APIError.generate(
+        response.status,
+        undefined,
+        `Unexpected JSON response from provider: ${text}`,
+        response.headers as unknown as Headers,
+      )
+    }
+
+    if (parsed && typeof parsed === 'object' && parsed.error) {
+      const errorMsg = parsed.error.message || JSON.stringify(parsed.error)
+      const failure = classifyOpenAIHttpFailure({
+        status: response.status,
+        body: text,
+        url: response.url,
+      })
+      throw APIError.generate(
+        response.status,
+        parsed,
+        buildOpenAICompatibilityErrorMessage(
+          `OpenAI API error ${response.status}: ${errorMsg}`,
+          { ...failure, requestUrl: response.url },
+        ),
+        response.headers as unknown as Headers,
+      )
+    }
+
+    // Convert non-streaming response into stream events
+    const choice = parsed.choices?.[0]
+    const content = choice?.message?.content || ''
+    const reasoning = choice?.message?.reasoning_content || ''
+
+    if (reasoning) {
+      yield {
+        type: 'content_block_start',
+        index: contentBlockIndex,
+        content_block: { type: 'thinking', thinking: '' },
+      }
+      yield {
+        type: 'content_block_delta',
+        index: contentBlockIndex,
+        delta: { type: 'thinking_delta', thinking: reasoning },
+      }
+      yield {
+        type: 'content_block_stop',
+        index: contentBlockIndex,
+      }
+      contentBlockIndex++
+    }
+
+    if (content) {
+      yield {
+        type: 'content_block_start',
+        index: contentBlockIndex,
+        content_block: { type: 'text', text: '' },
+      }
+      yield {
+        type: 'content_block_delta',
+        index: contentBlockIndex,
+        delta: { type: 'text_delta', text: content },
+      }
+      yield {
+        type: 'content_block_stop',
+        index: contentBlockIndex,
+      }
+      contentBlockIndex++
+    }
+
+    yield {
+      type: 'message_delta',
+      delta: {
+        stop_reason: choice?.finish_reason || 'end_turn',
+        stop_sequence: null,
+      },
+      usage: {
+        output_tokens: parsed.usage?.completion_tokens ?? 0,
+        input_tokens: parsed.usage?.prompt_tokens ?? 0,
+      },
+    }
+    yield { type: 'message_stop' }
+    return
+  }
+
   const readerOrNull = response.body?.getReader()
   if (!readerOrNull) throw new Error('Response body is not readable')
   const reader: ReadableStreamDefaultReader<Uint8Array> = readerOrNull

--- a/src/services/api/withRetry.test.ts
+++ b/src/services/api/withRetry.test.ts
@@ -343,8 +343,9 @@ describe('OpenAI-compatible retry classification', () => {
     )
     let attempts = 0
 
-    await expect(
-      drainAsyncGenerator(
+    let caught: unknown
+    try {
+      await drainAsyncGenerator(
         withRetry(
           async () => ({} as Anthropic),
           async () => {
@@ -357,9 +358,13 @@ describe('OpenAI-compatible retry classification', () => {
             thinkingConfig: { type: 'disabled' },
           },
         ),
-      ),
-    ).rejects.toBeInstanceOf(CannotRetryError)
+      )
+    } catch (error) {
+      caught = error
+    }
 
+    expect(caught).toBeInstanceOf(CannotRetryError)
+    expect((caught as { originalError?: unknown }).originalError).toBe(error)
     expect(attempts).toBe(1)
   })
 

--- a/src/services/api/withRetry.test.ts
+++ b/src/services/api/withRetry.test.ts
@@ -76,9 +76,10 @@ async function importFreshWithRetryModule(
     | 'gemini'
     | 'codex'
     | 'foundry' = 'firstParty',
-  options?: {
+  options: {
     logForDebugging?: ReturnType<typeof mock>
-  },
+    forceFastMode?: boolean
+  } = {},
 ) {
   mock.restore()
   originalProvidersModule ??= await importActualProviders()
@@ -99,6 +100,13 @@ async function importFreshWithRetryModule(
     isGithubNativeAnthropicMode: () => false,
     usesAnthropicAccountFlow: () => false,
   }))
+  if (options.forceFastMode) {
+    const realFastMode = await import('../../utils/fastMode.js')
+    mock.module('src/utils/fastMode.js', () => ({
+      ...realFastMode,
+      isFastModeEnabled: () => true,
+    }))
+  }
   return import(`./withRetry.js?ts=${Date.now()}-${Math.random()}`)
 }
 
@@ -411,6 +419,52 @@ describe('OpenAI-compatible retry classification', () => {
     expect((caught as Error).message).not.toContain(
       'API quota exhausted or not enabled',
     )
+  })
+
+  test('terminates OpenCode Go quota 429 immediately in fast mode (no fast-mode retry/cooldown)', async () => {
+    // Regression for #1749 (CodeRabbit): the OpenCode Go terminal throw must run
+    // BEFORE the fast-mode 429 fallback, otherwise fast mode retries/cooldowns a
+    // quota-exhausted subscription instead of surfacing the quota message.
+    process.env.OPENCLAUDE_RETRY_DELAY_MS = '1'
+    const { CannotRetryError, withRetry } =
+      await importFreshWithRetryModule('openai', { forceFastMode: true })
+    const error = APIError.generate(
+      429,
+      undefined,
+      JSON.stringify({
+        error: { type: 'GoUsageLimitError', message: 'subscription limit reached' },
+      }),
+      new Headers({
+        'x-opencode-request-url': 'https://opencode.ai/zen/go/v1/messages',
+      }),
+    )
+    let attempts = 0
+
+    let caught: unknown
+    try {
+      await drainAsyncGenerator(
+        withRetry(
+          async () => ({} as Anthropic),
+          async () => {
+            attempts++
+            throw error
+          },
+          {
+            maxRetries: 2,
+            model: 'glm-5.1',
+            thinkingConfig: { type: 'disabled' },
+            fastMode: true,
+          },
+        ),
+      )
+    } catch (e) {
+      caught = e
+    }
+
+    expect(caught).toBeInstanceOf(CannotRetryError)
+    // Fired exactly once — fast mode did not retry or enter cooldown.
+    expect(attempts).toBe(1)
+    expect((caught as { originalError?: unknown }).originalError).toBe(error)
   })
 
   test('keeps parseable 402 affordability errors on the max_tokens retry path', async () => {

--- a/src/services/api/withRetry.test.ts
+++ b/src/services/api/withRetry.test.ts
@@ -323,6 +323,38 @@ describe('OpenAI-compatible retry classification', () => {
     expect(attempts).toBe(1)
   })
 
+  test('does not retry quota/allotment exhaustion failures', async () => {
+    process.env.OPENCLAUDE_RETRY_DELAY_MS = '1'
+    const { CannotRetryError, withRetry } =
+      await importFreshWithRetryModule('openai')
+    const error = APIError.generate(
+      402,
+      undefined,
+      'OpenAI API error 402: Payment Required [openai_category=quota_exhausted,host=opencode.ai] Hint: Provider quota or usage allotment has run out.',
+      new Headers(),
+    )
+    let attempts = 0
+
+    await expect(
+      drainAsyncGenerator(
+        withRetry(
+          async () => ({} as Anthropic),
+          async () => {
+            attempts++
+            throw error
+          },
+          {
+            maxRetries: 2,
+            model: 'glm-5.1',
+            thinkingConfig: { type: 'disabled' },
+          },
+        ),
+      ),
+    ).rejects.toBeInstanceOf(CannotRetryError)
+
+    expect(attempts).toBe(1)
+  })
+
   test('keeps parseable 402 affordability errors on the max_tokens retry path', async () => {
     process.env.OPENCLAUDE_RETRY_DELAY_MS = '1'
     const { withRetry } = await importFreshWithRetryModule('openai')

--- a/src/services/api/withRetry.test.ts
+++ b/src/services/api/withRetry.test.ts
@@ -355,6 +355,64 @@ describe('OpenAI-compatible retry classification', () => {
     expect(attempts).toBe(1)
   })
 
+  test('preserves the OpenCode Go quota message through the retry loop instead of the generic guard', async () => {
+    // Regression for #1749: the early isQuotaExhausted guard used to wrap an
+    // OpenCode Go FreeUsageLimitError in the generic "API quota exhausted or
+    // not enabled" message, clobbering the actionable subscribe guidance.
+    process.env.OPENCLAUDE_RETRY_DELAY_MS = '1'
+    const { CannotRetryError, withRetry } =
+      await importFreshWithRetryModule('openai')
+    const { getAssistantMessageFromError, OPENCODE_GO_FREE_LIMIT_ERROR_MESSAGE } =
+      await import('./errors.js')
+    const error = APIError.generate(
+      429,
+      undefined,
+      JSON.stringify({
+        error: { type: 'FreeUsageLimitError', message: 'free usage limit reached' },
+      }),
+      new Headers({
+        'x-opencode-request-url': 'https://opencode.ai/zen/go/v1/messages',
+      }),
+    )
+    let attempts = 0
+
+    let caught: unknown
+    try {
+      await drainAsyncGenerator(
+        withRetry(
+          async () => ({} as Anthropic),
+          async () => {
+            attempts++
+            throw error
+          },
+          {
+            maxRetries: 2,
+            model: 'glm-5.1',
+            thinkingConfig: { type: 'disabled' },
+          },
+        ),
+      )
+    } catch (e) {
+      caught = e
+    }
+
+    expect(caught).toBeInstanceOf(CannotRetryError)
+    // Terminal — no wasteful retries against an exhausted quota.
+    expect(attempts).toBe(1)
+    // The original APIError survives so the specific OpenCode Go assistant
+    // message is recoverable, not the generic billing guidance.
+    const original = (caught as { originalError?: unknown }).originalError
+    expect(original).toBe(error)
+    const message = getAssistantMessageFromError(original as APIError, 'glm-5.1')
+    const text = message.message.content[0]
+    expect(
+      typeof text === 'object' && text && 'text' in text ? text.text : '',
+    ).toBe(OPENCODE_GO_FREE_LIMIT_ERROR_MESSAGE)
+    expect((caught as Error).message).not.toContain(
+      'API quota exhausted or not enabled',
+    )
+  })
+
   test('keeps parseable 402 affordability errors on the max_tokens retry path', async () => {
     process.env.OPENCLAUDE_RETRY_DELAY_MS = '1'
     const { withRetry } = await importFreshWithRetryModule('openai')

--- a/src/services/api/withRetry.ts
+++ b/src/services/api/withRetry.ts
@@ -826,6 +826,22 @@ function shouldRetry(error: APIError, persistentRetryEnabled: boolean): boolean 
     return false
   }
 
+  // OpenCode Go subscription quota exhaustion is terminal — retrying burns
+  // the same 429 and confuses the user with repeated "mysterious stop"
+  // failures. getAssistantMessageFromError surfaces the actionable message.
+  if (
+    error.status === 429 &&
+    typeof error.message === 'string' &&
+    (error.message.includes('GoUsageLimitError') ||
+      error.message.includes('FreeUsageLimitError')) &&
+    ((error.headers?.get?.('x-opencode-request-url') ?? '').includes(
+      'opencode.ai/zen/go',
+    ) ||
+      process.env.OPENAI_BASE_URL?.includes('opencode.ai/zen/go'))
+  ) {
+    return false
+  }
+
   // Persistent mode: 429/529 always retryable, bypass subscriber gates and
   // x-should-retry header.
   if (persistentRetryEnabled && isTransientCapacityError(error)) {

--- a/src/services/api/withRetry.ts
+++ b/src/services/api/withRetry.ts
@@ -49,7 +49,7 @@ import {
   checkMockRateLimitError,
   isMockRateLimitError,
 } from '../rateLimitMocking.js'
-import { REPEATED_529_ERROR_MESSAGE } from './errors.js'
+import { REPEATED_529_ERROR_MESSAGE, isOpenCodeGoQuotaError } from './errors.js'
 import { extractConnectionErrorDetails } from './errorUtils.js'
 import {
   extractOpenAICategoryMarker,
@@ -310,7 +310,12 @@ export async function* withRetry<T>(
         `API error (attempt ${attempt}/${maxRetries + 1}): ${error instanceof APIError ? `${error.status} ${error.message}` : errorMessage(error)}`,
         { level: 'error' },
       )
-        if (isQuotaExhausted(error)) {
+        // OpenCode Go quota exhaustion is also "quota exhausted", but it has a
+        // specific, actionable assistant message (subscribe / reset timing).
+        // Let it fall through to the standard shouldRetry=false terminal path,
+        // which rethrows the original APIError so getAssistantMessageFromError
+        // can surface that message instead of this generic guidance.
+        if (isQuotaExhausted(error) && !isOpenCodeGoQuotaError(error)) {
           throw new CannotRetryError(
             new Error(
               'API quota exhausted or not enabled.\n' +
@@ -844,20 +849,7 @@ function shouldRetry(error: APIError, persistentRetryEnabled: boolean): boolean 
   // OpenCode Go subscription quota exhaustion is terminal — retrying burns
   // the same 429 and confuses the user with repeated "mysterious stop"
   // failures. getAssistantMessageFromError surfaces the actionable message.
-  const requestUrl = error.headers?.get?.('x-opencode-request-url')
-  let isOpencodeGo = false
-  if (typeof requestUrl === 'string') {
-    isOpencodeGo = requestUrl.includes('opencode.ai/zen/go')
-  } else {
-    isOpencodeGo = (process.env.OPENAI_BASE_URL ?? '').includes('opencode.ai/zen/go')
-  }
-  if (
-    error.status === 429 &&
-    typeof error.message === 'string' &&
-    (error.message.includes('GoUsageLimitError') ||
-      error.message.includes('FreeUsageLimitError')) &&
-    isOpencodeGo
-  ) {
+  if (isOpenCodeGoQuotaError(error)) {
     return false
   }
 

--- a/src/services/api/withRetry.ts
+++ b/src/services/api/withRetry.ts
@@ -845,15 +845,18 @@ function shouldRetry(error: APIError, persistentRetryEnabled: boolean): boolean 
   // the same 429 and confuses the user with repeated "mysterious stop"
   // failures. getAssistantMessageFromError surfaces the actionable message.
   const requestUrl = error.headers?.get?.('x-opencode-request-url')
-  const baseUrl = requestUrl !== null && requestUrl !== undefined
-    ? requestUrl
-    : (process.env.OPENAI_BASE_URL ?? '')
+  let isOpencodeGo = false
+  if (typeof requestUrl === 'string') {
+    isOpencodeGo = requestUrl.includes('opencode.ai/zen/go')
+  } else {
+    isOpencodeGo = (process.env.OPENAI_BASE_URL ?? '').includes('opencode.ai/zen/go')
+  }
   if (
     error.status === 429 &&
     typeof error.message === 'string' &&
     (error.message.includes('GoUsageLimitError') ||
       error.message.includes('FreeUsageLimitError')) &&
-    baseUrl.includes('opencode.ai/zen/go')
+    isOpencodeGo
   ) {
     return false
   }

--- a/src/services/api/withRetry.ts
+++ b/src/services/api/withRetry.ts
@@ -310,12 +310,16 @@ export async function* withRetry<T>(
         `API error (attempt ${attempt}/${maxRetries + 1}): ${error instanceof APIError ? `${error.status} ${error.message}` : errorMessage(error)}`,
         { level: 'error' },
       )
-        // OpenCode Go quota exhaustion is also "quota exhausted", but it has a
-        // specific, actionable assistant message (subscribe / reset timing).
-        // Let it fall through to the standard shouldRetry=false terminal path,
-        // which rethrows the original APIError so getAssistantMessageFromError
-        // can surface that message instead of this generic guidance.
-        if (isQuotaExhausted(error) && !isOpenCodeGoQuotaError(error)) {
+        // OpenCode Go quota exhaustion is terminal and carries a specific,
+        // actionable assistant message (subscribe / reset timing). Throw here —
+        // before the fast-mode 429 fallback below — so fast mode can't retry or
+        // cooldown a quota-exhausted subscription. Wrapping the original
+        // APIError preserves the OpenCode Go message via
+        // getAssistantMessageFromError instead of the generic guidance.
+        if (isOpenCodeGoQuotaError(error)) {
+          throw new CannotRetryError(error, retryContext);
+        }
+        if (isQuotaExhausted(error)) {
           throw new CannotRetryError(
             new Error(
               'API quota exhausted or not enabled.\n' +

--- a/src/services/api/withRetry.ts
+++ b/src/services/api/withRetry.ts
@@ -124,9 +124,24 @@ function isPersistentRetryEnabled(): boolean {
 function isQuotaExhausted(error: any): boolean {
   const msg = (error?.message || '').toLowerCase()
 
+  // OpenRouter (and other gateways) return 402 with instructions to adjust max_tokens.
+  // If the 402 is retryable via token adjustment, do not treat it as exhausted.
+  if (error?.status === 402 && error instanceof APIError && parseOpenRouterAffordableMaxTokensError(error) !== undefined) {
+    return false
+  }
+
   return (
-    error?.status === 429 &&
-    (msg.includes('limit: 0') || msg.includes('exceeded your current quota'))
+    error?.status === 402 ||
+    msg.includes('quota_exhausted') ||
+    ((error?.status === 429 || error?.status === 403 || error?.status === 400) &&
+      (msg.includes('limit: 0') ||
+        msg.includes('exceeded your current quota') ||
+        msg.includes('credit') ||
+        msg.includes('billing') ||
+        msg.includes('payment required') ||
+        msg.includes('usage limit') ||
+        msg.includes('allotment') ||
+        msg.includes('quota')))
   )
 }
 

--- a/src/services/api/withRetry.ts
+++ b/src/services/api/withRetry.ts
@@ -310,25 +310,31 @@ export async function* withRetry<T>(
         `API error (attempt ${attempt}/${maxRetries + 1}): ${error instanceof APIError ? `${error.status} ${error.message}` : errorMessage(error)}`,
         { level: 'error' },
       )
-        // OpenCode Go quota exhaustion is terminal and carries a specific,
-        // actionable assistant message (subscribe / reset timing). Throw here —
-        // before the fast-mode 429 fallback below — so fast mode can't retry or
-        // cooldown a quota-exhausted subscription. Wrapping the original
-        // APIError preserves the OpenCode Go message via
-        // getAssistantMessageFromError instead of the generic guidance.
-        if (isOpenCodeGoQuotaError(error)) {
-          throw new CannotRetryError(error, retryContext);
-        }
-        if (isQuotaExhausted(error)) {
-          throw new CannotRetryError(
-            new Error(
-              'API quota exhausted or not enabled.\n' +
-              'Fix:\n' +
-              '- Enable billing for your provider\n' +
-              '- Or switch provider via /provider',
-            ),
-            retryContext,
-          );
+      // OpenCode Go quota exhaustion is terminal and carries a specific,
+      // actionable assistant message (subscribe / reset timing). Throw here -
+      // before the fast-mode 429 fallback below - so fast mode can't retry or
+      // cooldown a quota-exhausted subscription. Wrapping the original
+      // APIError preserves the OpenCode Go message via
+      // getAssistantMessageFromError instead of the generic guidance.
+      if (isOpenCodeGoQuotaError(error)) {
+        throw new CannotRetryError(error, retryContext)
+      }
+      if (
+        error instanceof APIError &&
+        extractOpenAICategoryMarker(error.message) === 'quota_exhausted'
+      ) {
+        throw new CannotRetryError(error, retryContext)
+      }
+      if (isQuotaExhausted(error)) {
+        throw new CannotRetryError(
+          new Error(
+            'API quota exhausted or not enabled.\n' +
+            'Fix:\n' +
+            '- Enable billing for your provider\n' +
+            '- Or switch provider via /provider',
+          ),
+          retryContext,
+        )
       }
       // Fast mode fallback: on 429/529, either wait and retry (short delays)
       // or fall back to standard speed (long delays) to avoid cache thrashing.

--- a/src/services/api/withRetry.ts
+++ b/src/services/api/withRetry.ts
@@ -844,15 +844,16 @@ function shouldRetry(error: APIError, persistentRetryEnabled: boolean): boolean 
   // OpenCode Go subscription quota exhaustion is terminal — retrying burns
   // the same 429 and confuses the user with repeated "mysterious stop"
   // failures. getAssistantMessageFromError surfaces the actionable message.
+  const requestUrl = error.headers?.get?.('x-opencode-request-url')
+  const baseUrl = requestUrl !== null && requestUrl !== undefined
+    ? requestUrl
+    : (process.env.OPENAI_BASE_URL ?? '')
   if (
     error.status === 429 &&
     typeof error.message === 'string' &&
     (error.message.includes('GoUsageLimitError') ||
       error.message.includes('FreeUsageLimitError')) &&
-    ((error.headers?.get?.('x-opencode-request-url') ?? '').includes(
-      'opencode.ai/zen/go',
-    ) ||
-      process.env.OPENAI_BASE_URL?.includes('opencode.ai/zen/go'))
+    baseUrl.includes('opencode.ai/zen/go')
   ) {
     return false
   }
@@ -1078,3 +1079,5 @@ export function getRateLimitResetDelayMs(error: APIError): number | null {
   // bedrock, vertex, foundry, gemini — no standard reset header
   return null
 }
+
+export { shouldRetry }


### PR DESCRIPTION
## Summary

The opencode.ai/zen/go gateway returns `429` with `GoUsageLimitError` in the response body when a user's Go subscription quota runs out. Previously these fell through to the generic `Request rejected (429)` path, causing the CLI to "mysteriously stop working" with no actionable hint for the user.

This PR adds detection for the opencode-go-specific error markers and surfaces a clear, actionable message. It also fixes an endless "thinking..." hang by intercepting JSON error payloads returned on streaming paths and throwing them cleanly instead of silently ending the stream.

## What an opencode-go user now sees

**OpenCode Go subscription limit hit:**
```
OpenCode Go subscription limit reached · See https://opencode.ai/workspace/go · Limit: weekly · Workspace: euxaristia-personal · Resets in 2d
```

## Changes

- `src/services/api/openaiShim.ts`
  - Intercepts `application/json` responses at the beginning of `openaiStreamToAnthropic` streaming reader loop. If it's a JSON error, it parses it and throws it cleanly, preventing endless thinking spinner hangs when the stream ends empty.

- `src/services/api/errors.ts`
  - `parseOpenCodeGoLimitError()` — detects `GoUsageLimitError` in the error body, scoped to the opencode-go gateway via the `x-opencode-request-url` header (with `OPENAI_BASE_URL` env fallback for direct-mode usage). Extracts `limitName`, `workspace`, and `retry-after` seconds.
  - `formatResetDuration()` — formats seconds as `2d`, `2d 3h`, `2h 6m`, etc.
  - `OPENCODE_GO_USAGE_LIMIT_ERROR_MESSAGE` exported constant.
  - `getAssistantMessageFromError()` — new branch that calls `parseOpenCodeGoLimitError()` before the generic 429 handler, returns the clear message with reset time, workspace, and limit name.
  - `classifyAPIError()` — new `opencode_go_quota_exhausted` analytics bucket (distinct from generic `rate_limit`).

- `src/services/api/openaiErrorClassification.ts`
  - Introduces `quota_exhausted` category mapping for `402` status codes and client errors with billing/credit/quota keywords.

- `src/services/api/withRetry.ts`
  - `shouldRetry()` — treats opencode-go quota errors as terminal. Retrying burns the same 429 and hides the actionable message behind repeated retries.
  - `isQuotaExhausted()` — updated to abort retries for `402` and quota-related errors.

- `src/services/api/errors.opencodeGo.test.ts` (new)
  - Tests covering paid branches, reset duration formatting, env-var fallback, and non-opencode-go 429s that must NOT be mapped.

- `src/services/api/openaiErrorClassification.test.ts` and `src/services/api/withRetry.test.ts`
  - Added coverage for `quota_exhausted` classification and retry loop termination.

## Why this approach

- Mirrors the canonical implementation in `anomalyco/opencode` `packages/opencode/src/session/retry.ts`.
- Gated on `opencode.ai/zen/go` in the request URL or `OPENAI_BASE_URL`, so it cannot misfire on other OpenAI-compatible providers.
- Avoids infinite thinking spinner hangs when streaming endpoints return JSON errors.

## Test plan

- [x] `bun test src/services/api/errors.opencodeGo.test.ts` — pass
- [x] `bun test src/services/api/openaiErrorClassification.test.ts src/services/api/withRetry.test.ts` — pass
- [x] `bun run typecheck` — clean
- [ ] `bun run smoke` (will run in CI)
- [ ] `bun run check` (will run in CI)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `quota_exhausted` classification for OpenAI-compatible HTTP errors (402/403/429) as non-retryable guidance.
  * Added Opencode Go quota-exhaustion assistant messaging (free vs subscription), including optional reset/workspace/limit details.
  * Improved non-streaming `application/json` handling by converting it into consistent Anthropic-style streaming events.

* **Bug Fixes**
  * Ensured Opencode Go quota errors are detected early and treated as terminal (retry/guidance precedence fixed).
  * Updated OpenAI shim error/header handling for better request-url context.

* **Tests**
  * Expanded Bun regression coverage for quota classification, Opencode Go parsing/precedence, retry behavior, and JSON fallback mappings (tool use, stop reasons, `<think>` stripping).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
