### PR TITLE
fix: treat 5xx HTML overload pages as retryable provider_unavailable

### DIFF
--- a/src/services/api/openaiErrorClassification.test.ts
+++ b/src/services/api/openaiErrorClassification.test.ts
@@ -222,6 +222,42 @@ test('reports retryability for extracted category markers', () => {
   expect(isRetryableOpenAICompatibilityFailureCategory('network_error')).toBe(true)
 })
 
+test('classifies 5xx with HTML body as provider_unavailable, not malformed_provider_response', () => {
+  // Regression: gateways return HTML 502/504 pages during overload. The old
+  // ordering matched isMalformedProviderResponse first, marking the error
+  // non-retryable and surfacing "Provider returned a malformed response"
+  // even though a manual retry would succeed.
+  const failure = classifyOpenAIHttpFailure({
+    status: 502,
+    body: '<!doctype html><html><body>Bad Gateway</body></html>',
+  })
+
+  expect(failure.category).toBe('provider_unavailable')
+  expect(failure.retryable).toBe(true)
+})
+
+test('classifies 504 gateway timeout HTML as provider_unavailable', () => {
+  const failure = classifyOpenAIHttpFailure({
+    status: 504,
+    body: '<html><head><title>504 Gateway Time-out</title></head></html>',
+  })
+
+  expect(failure.category).toBe('provider_unavailable')
+  expect(failure.retryable).toBe(true)
+})
+
+test('classifies 4xx with HTML body as malformed_provider_response (unchanged)', () => {
+  // Non-5xx HTML bodies are still genuine malformed responses — the provider
+  // returned something we can't parse when it should have returned JSON.
+  const failure = classifyOpenAIHttpFailure({
+    status: 400,
+    body: '<!doctype html><html><body>Bad Request</body></html>',
+  })
+
+  expect(failure.category).toBe('malformed_provider_response')
+  expect(failure.retryable).toBe(false)
+})
+
 test('isLocalhostLikeHost matches loopback variants', () => {
   expect(isLocalhostLikeHost('localhost')).toBe(true)
   expect(isLocalhostLikeHost('127.0.0.1')).toBe(true)

--- a/src/services/api/openaiErrorClassification.ts
+++ b/src/services/api/openaiErrorClassification.ts
@@ -433,17 +433,13 @@ export function classifyOpenAIHttpFailure(options: {
     }
   }
 
-  if (options.status >= 400 && isMalformedProviderResponse(body)) {
-    return {
-      source: 'http',
-      category: 'malformed_provider_response',
-      retryable: false,
-      status: options.status,
-      message: body,
-      hint: 'Provider returned malformed or non-JSON response where JSON was expected.',
-    }
-  }
-
+  // 5xx errors are always server-side failures and should be retryable,
+  // even when the body is HTML (common for gateway 502/504 overload pages
+  // that would otherwise classify as malformed_provider_response below).
+  // This must run before the malformed-provider-response check so a 5xx
+  // HTML page is treated as a transient provider_unavailable rather than
+  // a dead-end malformed response. Issue: users see "Provider returned a
+  // malformed response" on overload and have to retry manually.
   if (options.status >= 500) {
     return {
       source: 'http',
@@ -452,6 +448,17 @@ export function classifyOpenAIHttpFailure(options: {
       status: options.status,
       message: body,
       hint: 'Provider reported a server-side failure. Retry after a short delay.',
+    }
+  }
+
+  if (options.status >= 400 && isMalformedProviderResponse(body)) {
+    return {
+      source: 'http',
+      category: 'malformed_provider_response',
+      retryable: false,
+      status: options.status,
+      message: body,
+      hint: 'Provider returned malformed or non-JSON response where JSON was expected.',
     }
   }
 


### PR DESCRIPTION
## Summary
- Reorders `classifyOpenAIHttpFailure` so the `status >= 500` branch runs **before** the `isMalformedProviderResponse` check. Gateway 502/504 overload pages have HTML bodies (`<!doctype html>`, `<html>`) that previously matched the malformed-provider-response path, marking the error non-retryable and surfacing `"Provider returned a malformed response. Confirm endpoint compatibility and check local proxy/network middleware."` — even though the failure was transient and a manual retry would succeed.
- Any 5xx now classifies as `provider_unavailable` (retryable) regardless of body shape, matching the actual semantics. 4xx HTML responses still classify as `malformed_provider_response` since those are genuine protocol failures worth surfacing.
- Adds three regression tests: 502 HTML, 504 HTML, and the unchanged 400 HTML path.

## Root cause
Users intermittently see `API Error: Provider returned a malformed response...` during provider overload. The error usually succeeds on manual retry, which points at a transient 5xx being misclassified as a dead-end protocol failure. The classifier's ordering was the culprit: `isMalformedProviderResponse(body)` ran first and matched HTML gateway pages before the `status >= 500` branch could claim them as retryable.

## Test plan
- [x] `bun test ./src/services/api/openaiErrorClassification.test.ts` — 23 pass (20 existing + 3 new)
- [x] `bun test ./src/services/api/` — 817 pass, 0 fail
- [x] `bun run typecheck` — exit 0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error classification for API provider responses to correctly identify temporary service failures and overload conditions as retryable errors instead of malformed responses, ensuring the application properly handles transient server issues and automatically recovers when the service becomes available again.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->