### PR TITLE
fix(provider): Add Xiaomi MiMo token plan provider

### DIFF
--- a/src/components/ProviderManager.test.tsx
+++ b/src/components/ProviderManager.test.tsx
@@ -140,6 +140,7 @@ const PRESET_ORDER = [
   'Venice',
   'xAI',
   'Xiaomi MiMo',
+  'Xiaomi MiMo (Token Plan)',
   'Z.AI - GLM Coding Plan',
   'Custom',
 ] as const

--- a/src/integrations/compatibility.test.ts
+++ b/src/integrations/compatibility.test.ts
@@ -38,6 +38,7 @@ const EXPECTED_PRESETS = [
   'xai',
   'venice',
   'xiaomi-mimo',
+  'xiaomi-mimo-token',
   'zai',
   'bankr',
   'atomic-chat',

--- a/src/integrations/gateways/xiaomi-mimo-token.test.ts
+++ b/src/integrations/gateways/xiaomi-mimo-token.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, test } from 'bun:test'
+
+import '../index.js'
+import {
+  getRouteDefaultBaseUrl,
+  getRouteDefaultModel,
+  resolveRouteIdFromBaseUrl,
+} from '../routeMetadata.js'
+
+describe('xiaomi-mimo-token gateway', () => {
+  test('default base URL is the token-plan SGP endpoint', () => {
+    expect(getRouteDefaultBaseUrl('xiaomi-mimo-token')).toBe(
+      'https://token-plan-sgp.xiaomimimo.com/v1',
+    )
+  })
+
+  test('default model is mimo-v2.5-pro', () => {
+    expect(getRouteDefaultModel('xiaomi-mimo-token')).toBe('mimo-v2.5-pro')
+  })
+
+  test('resolves token-plan SGP base URL', () => {
+    expect(
+      resolveRouteIdFromBaseUrl('https://token-plan-sgp.xiaomimimo.com/v1'),
+    ).toBe('xiaomi-mimo-token')
+  })
+
+  test('resolves token-plan CN base URL', () => {
+    expect(
+      resolveRouteIdFromBaseUrl('https://token-plan-cn.xiaomimimo.com/v1'),
+    ).toBe('xiaomi-mimo-token')
+  })
+
+  test('resolves token-plan chat completions path', () => {
+    expect(
+      resolveRouteIdFromBaseUrl(
+        'https://token-plan-sgp.xiaomimimo.com/v1/chat/completions',
+      ),
+    ).toBe('xiaomi-mimo-token')
+  })
+})

--- a/src/integrations/gateways/xiaomi-mimo-token.ts
+++ b/src/integrations/gateways/xiaomi-mimo-token.ts
@@ -1,0 +1,78 @@
+import { defineCatalog, defineGateway } from '../define.js'
+
+const catalog = defineCatalog({
+  source: 'static',
+  models: [
+    {
+      id: 'mimo-v2.5-pro',
+      apiName: 'mimo-v2.5-pro',
+      label: 'MiMo V2.5 Pro',
+      modelDescriptorId: 'mimo-v2.5-pro',
+    },
+    {
+      id: 'mimo-v2.5',
+      apiName: 'mimo-v2.5',
+      label: 'MiMo V2.5',
+      modelDescriptorId: 'mimo-v2.5',
+    },
+    {
+      id: 'mimo-v2-flash',
+      apiName: 'mimo-v2-flash',
+      label: 'MiMo V2 Flash',
+      modelDescriptorId: 'mimo-v2-flash',
+    },
+  ],
+})
+
+export default defineGateway({
+  id: 'xiaomi-mimo-token',
+  label: 'Xiaomi MiMo (Token Plan)',
+  category: 'hosted',
+  defaultBaseUrl: 'https://token-plan-sgp.xiaomimimo.com/v1',
+  defaultModel: 'mimo-v2.5-pro',
+  setup: {
+    requiresAuth: true,
+    authMode: 'api-key',
+    credentialEnvVars: ['MIMO_API_KEY'],
+  },
+  transportConfig: {
+    kind: 'openai-compatible',
+    openaiShim: {
+      defaultAuthHeader: {
+        name: 'api-key',
+        scheme: 'raw',
+      },
+      preserveReasoningContent: true,
+      requireReasoningContentOnAssistantMessages: true,
+      maxTokensField: 'max_completion_tokens',
+      removeBodyFields: ['store', 'stream_options'],
+      supportsApiFormatSelection: false,
+      supportsAuthHeaders: false,
+    },
+  },
+  preset: {
+    id: 'xiaomi-mimo-token',
+    vendorId: 'xiaomi-mimo',
+    description: 'Xiaomi MiMo Token Plan subscription endpoint',
+    label: 'Xiaomi MiMo (Token Plan)',
+    name: 'Xiaomi MiMo (Token Plan)',
+    apiKeyEnvVars: ['MIMO_API_KEY'],
+    modelEnvVars: ['OPENAI_MODEL'],
+    badge: { text: 'Sponsor', color: 'success' },
+  },
+  validation: {
+    kind: 'credential-env',
+    routing: {
+      matchDefaultBaseUrl: true,
+      matchBaseUrlHosts: [
+        'token-plan-sgp.xiaomimimo.com',
+        'token-plan-cn.xiaomimimo.com',
+      ],
+    },
+    credentialEnvVars: ['MIMO_API_KEY', 'OPENAI_API_KEY'],
+    missingCredentialMessage:
+      'Xiaomi MiMo Token Plan auth is required. Set MIMO_API_KEY or OPENAI_API_KEY.',
+  },
+  catalog,
+  usage: { supported: false },
+})

--- a/src/integrations/generated/integrationArtifacts.generated.ts
+++ b/src/integrations/generated/integrationArtifacts.generated.ts
@@ -37,6 +37,7 @@ import gatewayOpencode from '../gateways/opencode.js'
 import gatewayOpenrouter from '../gateways/openrouter.js'
 import gatewayTogether from '../gateways/together.js'
 import gatewayVertex from '../gateways/vertex.js'
+import gatewayXiaomiMimoToken from '../gateways/xiaomi-mimo-token.js'
 import brandClaude from '../brands/claude.js'
 import brandDeepseek from '../brands/deepseek.js'
 import brandFireworks from '../brands/fireworks.js'
@@ -72,7 +73,7 @@ import modelXai from '../models/xai.js'
 import modelXiaomiMimo from '../models/xiaomi-mimo.js'
 
 export const VENDOR_DESCRIPTORS = [vendorAnthropic, vendorAtlasCloud, vendorBankr, vendorDeepseek, vendorFireworks, vendorGemini, vendorMinimax, vendorMoonshot, vendorNearai, vendorOpenai, vendorVenice, vendorXai, vendorXiaomiMimo, vendorZai] as const satisfies readonly VendorDescriptor[]
-export const GATEWAY_DESCRIPTORS = [gatewayAtomicChat, gatewayAzureOpenai, gatewayBedrock, gatewayCustom, gatewayDashscopeCn, gatewayDashscopeIntl, gatewayGithubEnterprise, gatewayGithub, gatewayGitlawbOpengateway, gatewayGroq, gatewayHicap, gatewayKimiCode, gatewayLmstudio, gatewayMistral, gatewayNvidiaNim, gatewayOllama, gatewayOpencodeGo, gatewayOpencode, gatewayOpenrouter, gatewayTogether, gatewayVertex] as const satisfies readonly GatewayDescriptor[]
+export const GATEWAY_DESCRIPTORS = [gatewayAtomicChat, gatewayAzureOpenai, gatewayBedrock, gatewayCustom, gatewayDashscopeCn, gatewayDashscopeIntl, gatewayGithubEnterprise, gatewayGithub, gatewayGitlawbOpengateway, gatewayGroq, gatewayHicap, gatewayKimiCode, gatewayLmstudio, gatewayMistral, gatewayNvidiaNim, gatewayOllama, gatewayOpencodeGo, gatewayOpencode, gatewayOpenrouter, gatewayTogether, gatewayVertex, gatewayXiaomiMimoToken] as const satisfies readonly GatewayDescriptor[]
 export const ANTHROPIC_PROXY_DESCRIPTORS = [] as const satisfies readonly AnthropicProxyDescriptor[]
 export const BRAND_DESCRIPTORS = [brandClaude, brandDeepseek, brandFireworks, brandGemini, brandGlm, brandGpt, brandKimi, brandLlama, brandMinimax, brandMistral, brandNearai, brandNemotron, brandOpenaiCompatibleAlias, brandQwen, brandXai, brandXiaomiMimo] as const satisfies readonly BrandDescriptor[]
 export const MODEL_DESCRIPTOR_GROUPS = [modelClaude, modelDeepseek, modelFireworksMerged, modelGemini, modelGlm, modelGpt, modelKimi, modelLlama, modelMinimax, modelMistral, modelNearai, modelNemotron, modelOpenaiCompatibleAlias, modelOpencode, modelQwen, modelXai, modelXiaomiMimo] as const satisfies readonly (readonly ModelDescriptor[])[]
@@ -447,6 +448,26 @@ export const PROVIDER_PRESET_MANIFEST = [
     }
   },
   {
+    "preset": "xiaomi-mimo-token",
+    "routeKind": "gateway",
+    "routeId": "xiaomi-mimo-token",
+    "vendorId": "xiaomi-mimo",
+    "gatewayId": "xiaomi-mimo-token",
+    "description": "Xiaomi MiMo Token Plan subscription endpoint",
+    "label": "Xiaomi MiMo (Token Plan)",
+    "name": "Xiaomi MiMo (Token Plan)",
+    "apiKeyEnvVars": [
+      "MIMO_API_KEY"
+    ],
+    "modelEnvVars": [
+      "OPENAI_MODEL"
+    ],
+    "badge": {
+      "text": "Sponsor",
+      "color": "success"
+    }
+  },
+  {
     "preset": "zai",
     "routeKind": "vendor",
     "routeId": "zai",
@@ -514,6 +535,7 @@ export const ORDERED_PROVIDER_PRESETS = [
   "venice",
   "xai",
   "xiaomi-mimo",
+  "xiaomi-mimo-token",
   "zai",
   "custom"
 ] as const

--- a/src/integrations/routeMetadata.ts
+++ b/src/integrations/routeMetadata.ts
@@ -30,6 +30,10 @@ const TRANSPORT_KIND_PROVIDER_TYPE_LABELS: Partial<
 
 const XIAOMI_MIMO_PRIMARY_HOST = 'api.xiaomimimo.com'
 const XIAOMI_MIMO_STALE_DOCS_HOST = 'api.mimo-v2.com'
+const XIAOMI_MIMO_TOKEN_PLAN_HOSTS = [
+  'token-plan-sgp.xiaomimimo.com',
+  'token-plan-cn.xiaomimimo.com',
+]
 export const XIAOMI_MIMO_PRIMARY_BASE_URL = `https://${XIAOMI_MIMO_PRIMARY_HOST}/v1`
 
 function getValidationRoutingHosts(
@@ -247,7 +251,8 @@ export function isXiaomiMimoBaseUrl(value: string | undefined): boolean {
     const hostname = new URL(trimmed).hostname.toLowerCase()
     return (
       hostname === XIAOMI_MIMO_PRIMARY_HOST ||
-      hostname === XIAOMI_MIMO_STALE_DOCS_HOST
+      hostname === XIAOMI_MIMO_STALE_DOCS_HOST ||
+      XIAOMI_MIMO_TOKEN_PLAN_HOSTS.includes(hostname)
     )
   } catch {
     return false

--- a/src/utils/model/providers.ts
+++ b/src/utils/model/providers.ts
@@ -51,6 +51,7 @@ export function getAPIProvider(): LegacyAPIProvider {
     case 'minimax':
       return 'minimax'
     case 'xiaomi-mimo':
+    case 'xiaomi-mimo-token':
       return 'xiaomi-mimo'
     case 'xai':
       return 'xai'

--- a/src/utils/providerFlag.test.ts
+++ b/src/utils/providerFlag.test.ts
@@ -146,6 +146,7 @@ describe('VALID_PROVIDERS', () => {
     expect(VALID_PROVIDERS).toContain('zai')
     expect(VALID_PROVIDERS).toContain('venice')
     expect(VALID_PROVIDERS).toContain('xiaomi-mimo')
+    expect(VALID_PROVIDERS).toContain('xiaomi-mimo-token')
   })
 })
 
@@ -531,6 +532,28 @@ describe('applyProviderFlag - xiaomi-mimo', () => {
 
   test('sets Xiaomi MiMo OPENAI_MODEL when --model is provided', () => {
     applyProviderFlag('xiaomi-mimo', ['--model', 'mimo-v2-flash'])
+
+    expect(process.env.OPENAI_MODEL).toBe('mimo-v2-flash')
+  })
+})
+
+describe('applyProviderFlag - xiaomi-mimo-token', () => {
+  test('sets Xiaomi MiMo Token Plan OpenAI-compatible defaults and mirrors MIMO_API_KEY', () => {
+    process.env.MIMO_API_KEY = 'tp-token-plan-key'
+
+    const result = applyProviderFlag('xiaomi-mimo-token', [])
+
+    expect(result.error).toBeUndefined()
+    expect(process.env.CLAUDE_CODE_USE_OPENAI).toBe('1')
+    expect(process.env.OPENAI_BASE_URL).toBe(
+      'https://token-plan-sgp.xiaomimimo.com/v1',
+    )
+    expect(process.env.OPENAI_MODEL).toBe('mimo-v2.5-pro')
+    expect(process.env.OPENAI_API_KEY).toBe('tp-token-plan-key')
+  })
+
+  test('sets Xiaomi MiMo Token Plan OPENAI_MODEL when --model is provided', () => {
+    applyProviderFlag('xiaomi-mimo-token', ['--model', 'mimo-v2-flash'])
 
     expect(process.env.OPENAI_MODEL).toBe('mimo-v2-flash')
   })

--- a/src/utils/providerFlag.test.ts
+++ b/src/utils/providerFlag.test.ts
@@ -552,6 +552,18 @@ describe('applyProviderFlag - xiaomi-mimo-token', () => {
     expect(process.env.OPENAI_API_KEY).toBe('tp-token-plan-key')
   })
 
+  test('replaces stale known provider base URL with the token-plan default', () => {
+    process.env.OPENAI_BASE_URL = 'https://openrouter.ai/api/v1'
+
+    const result = applyProviderFlag('xiaomi-mimo-token', [])
+
+    expect(result.error).toBeUndefined()
+    expect(process.env.CLAUDE_CODE_USE_OPENAI).toBe('1')
+    expect(process.env.OPENAI_BASE_URL).toBe(
+      'https://token-plan-sgp.xiaomimimo.com/v1',
+    )
+  })
+
   test('sets Xiaomi MiMo Token Plan OPENAI_MODEL when --model is provided', () => {
     applyProviderFlag('xiaomi-mimo-token', ['--model', 'mimo-v2-flash'])
 

--- a/src/utils/providerFlag.ts
+++ b/src/utils/providerFlag.ts
@@ -452,7 +452,10 @@ export function applyProviderFlag(
 
     case 'xiaomi-mimo-token':
       process.env.CLAUDE_CODE_USE_OPENAI = '1'
-      process.env.OPENAI_BASE_URL ??= defaultBaseUrl ?? 'https://token-plan-sgp.xiaomimimo.com/v1'
+      applyOpenAIBaseUrlDefault(
+        provider,
+        defaultBaseUrl ?? 'https://token-plan-sgp.xiaomimimo.com/v1',
+      )
       process.env.OPENAI_MODEL ??= defaultModel ?? 'mimo-v2.5-pro'
       if (model) process.env.OPENAI_MODEL = model
       if (process.env.MIMO_API_KEY && !process.env.OPENAI_API_KEY) {

--- a/src/utils/providerFlag.ts
+++ b/src/utils/providerFlag.ts
@@ -450,6 +450,16 @@ export function applyProviderFlag(
       }
       break
 
+    case 'xiaomi-mimo-token':
+      process.env.CLAUDE_CODE_USE_OPENAI = '1'
+      process.env.OPENAI_BASE_URL ??= defaultBaseUrl ?? 'https://token-plan-sgp.xiaomimimo.com/v1'
+      process.env.OPENAI_MODEL ??= defaultModel ?? 'mimo-v2.5-pro'
+      if (model) process.env.OPENAI_MODEL = model
+      if (process.env.MIMO_API_KEY && !process.env.OPENAI_API_KEY) {
+        process.env.OPENAI_API_KEY = process.env.MIMO_API_KEY
+      }
+      break
+
     case 'venice':
       process.env.CLAUDE_CODE_USE_OPENAI = '1'
       process.env.OPENAI_BASE_URL ??= defaultBaseUrl ?? 'https://api.venice.ai/api/v1'

--- a/src/utils/providerProfiles.test.ts
+++ b/src/utils/providerProfiles.test.ts
@@ -223,6 +223,17 @@ function buildXiaomiMimoProfile(overrides: Partial<ProviderProfile> = {}): Provi
   })
 }
 
+function buildXiaomiMimoTokenProfile(overrides: Partial<ProviderProfile> = {}): ProviderProfile {
+  return buildProfile({
+    provider: 'xiaomi-mimo-token',
+    name: 'Xiaomi MiMo Token Plan',
+    baseUrl: 'https://token-plan-sgp.xiaomimimo.com/v1',
+    model: 'mimo-v2.5-pro',
+    apiKey: 'tp-test-key',
+    ...overrides,
+  })
+}
+
 function buildFireworksProfile(overrides: Partial<ProviderProfile> = {}): ProviderProfile {
   return buildProfile({
     provider: 'fireworks',
@@ -749,6 +760,26 @@ describe('applyProviderProfileToProcessEnv', () => {
 
     expect(process.env.OPENAI_BASE_URL).toBe('https://api.xiaomimimo.com/v1')
     expect(process.env.MIMO_API_KEY).toBe('mimo-test-key')
+    expect(getFreshAPIProvider()).toBe('xiaomi-mimo')
+  })
+
+  test('xiaomi mimo token plan profile applies OpenAI-compatible env with MIMO_API_KEY mirror', async () => {
+    const { applyProviderProfileToProcessEnv } =
+      await importFreshProviderProfileModules()
+    process.env.CLAUDE_CODE_USE_GEMINI = '1'
+
+    applyProviderProfileToProcessEnv(buildXiaomiMimoTokenProfile())
+    const { getAPIProvider: getFreshAPIProvider } =
+      await importFreshProvidersModule()
+
+    expect(process.env.CLAUDE_CODE_USE_GEMINI).toBeUndefined()
+    expect(String(process.env.CLAUDE_CODE_USE_OPENAI)).toBe('1')
+    expect(process.env.OPENAI_BASE_URL).toBe(
+      'https://token-plan-sgp.xiaomimimo.com/v1',
+    )
+    expect(process.env.OPENAI_MODEL).toBe('mimo-v2.5-pro')
+    expect(process.env.OPENAI_API_KEY).toBe('tp-test-key')
+    expect(process.env.MIMO_API_KEY).toBe('tp-test-key')
     expect(getFreshAPIProvider()).toBe('xiaomi-mimo')
   })
 
@@ -1662,6 +1693,22 @@ describe('getProviderPresetDefaults', () => {
     expect(defaults.baseUrl).toBe('https://api.xiaomimimo.com/v1')
     expect(defaults.model).toBe('mimo-v2.5-pro')
     expect(defaults.apiKey).toBe('mimo-live-key')
+    expect(defaults.requiresApiKey).toBe(true)
+  })
+
+  test('xiaomi mimo token plan preset defaults to the token-plan SGP endpoint', async () => {
+    const { getProviderPresetDefaults } = await importFreshProviderProfileModules()
+    process.env.MIMO_API_KEY = 'tp-live-key'
+
+    const defaults = getProviderPresetDefaults('xiaomi-mimo-token')
+
+    expect(defaults.provider).toBe('xiaomi-mimo-token')
+    expect(defaults.name).toBe('Xiaomi MiMo (Token Plan)')
+    expect(defaults.baseUrl).toBe(
+      'https://token-plan-sgp.xiaomimimo.com/v1',
+    )
+    expect(defaults.model).toBe('mimo-v2.5-pro')
+    expect(defaults.apiKey).toBe('tp-live-key')
     expect(defaults.requiresApiKey).toBe(true)
   })
 

--- a/src/utils/providerProfiles.test.ts
+++ b/src/utils/providerProfiles.test.ts
@@ -783,6 +783,28 @@ describe('applyProviderProfileToProcessEnv', () => {
     expect(getFreshAPIProvider()).toBe('xiaomi-mimo')
   })
 
+  test('xiaomi mimo token plan CN profile applies OpenAI-compatible env with MIMO_API_KEY mirror', async () => {
+    const { applyProviderProfileToProcessEnv } =
+      await importFreshProviderProfileModules()
+    process.env.CLAUDE_CODE_USE_GEMINI = '1'
+
+    applyProviderProfileToProcessEnv(buildXiaomiMimoTokenProfile({
+      baseUrl: 'https://token-plan-cn.xiaomimimo.com/v1',
+    }))
+    const { getAPIProvider: getFreshAPIProvider } =
+      await importFreshProvidersModule()
+
+    expect(process.env.CLAUDE_CODE_USE_GEMINI).toBeUndefined()
+    expect(String(process.env.CLAUDE_CODE_USE_OPENAI)).toBe('1')
+    expect(process.env.OPENAI_BASE_URL).toBe(
+      'https://token-plan-cn.xiaomimimo.com/v1',
+    )
+    expect(process.env.OPENAI_MODEL).toBe('mimo-v2.5-pro')
+    expect(process.env.OPENAI_API_KEY).toBe('tp-test-key')
+    expect(process.env.MIMO_API_KEY).toBe('tp-test-key')
+    expect(getFreshAPIProvider()).toBe('xiaomi-mimo')
+  })
+
   test('fireworks profile applies OpenAI-compatible env with FIREWORKS_API_KEY mirror', async () => {
     const { applyProviderProfileToProcessEnv } =
       await importFreshProviderProfileModules()

--- a/src/utils/providerProfiles.ts
+++ b/src/utils/providerProfiles.ts
@@ -44,7 +44,13 @@ import {
   type ResolvedProfileRoute,
   type ProviderPreset,
 } from '../integrations/index.js'
-import { isFireworksBaseUrl, isNearaiBaseUrl, isXaiBaseUrl, resolveEnvOnlyProviderRouteId } from '../integrations/routeMetadata.js'
+import {
+  isFireworksBaseUrl,
+  isNearaiBaseUrl,
+  isXaiBaseUrl,
+  isXiaomiMimoBaseUrl,
+  resolveEnvOnlyProviderRouteId,
+} from '../integrations/routeMetadata.js'
 import { logForDebugging } from './debug.js'
 import {
   sanitizeProfileCustomHeaders,
@@ -785,10 +791,7 @@ export function applyProviderProfileToProcessEnv(profile: ProviderProfile): void
       if (
         route.routeId === 'xiaomi-mimo' ||
         route.routeId === 'xiaomi-mimo-token' ||
-        profile.baseUrl.toLowerCase().includes('api.xiaomimimo.com') ||
-        profile.baseUrl.toLowerCase().includes('api.mimo-v2.com') ||
-        profile.baseUrl.toLowerCase().includes('token-plan-sgp.xiaomimimo.com') ||
-        profile.baseUrl.toLowerCase().includes('token-plan-cn.xiaomimimo.com')
+        isXiaomiMimoBaseUrl(profile.baseUrl)
       ) {
         openAIProfileEnv.MIMO_API_KEY = profile.apiKey
       }

--- a/src/utils/providerProfiles.ts
+++ b/src/utils/providerProfiles.ts
@@ -739,7 +739,7 @@ export function applyProviderProfileToProcessEnv(profile: ProviderProfile): void
     const supportsApiFormat = routeSupportsApiFormatSelection(capabilityRouteId)
     const supportsAuthHeaders = routeSupportsAuthHeaders(capabilityRouteId)
     const normalizedProfileBaseUrl =
-      route.routeId === 'xiaomi-mimo'
+      route.routeId === 'xiaomi-mimo' || route.routeId === 'xiaomi-mimo-token'
         ? normalizeXiaomiMimoBaseUrl(profile.baseUrl) ?? profile.baseUrl
         : profile.baseUrl
     const openAIProfileEnv: ProfileEnv = {
@@ -782,7 +782,14 @@ export function applyProviderProfileToProcessEnv(profile: ProviderProfile): void
       if (route.routeId === 'venice' || profile.baseUrl.toLowerCase().includes('api.venice.ai')) {
         openAIProfileEnv.VENICE_API_KEY = profile.apiKey
       }
-      if (route.routeId === 'xiaomi-mimo' || profile.baseUrl.toLowerCase().includes('api.xiaomimimo.com') || profile.baseUrl.toLowerCase().includes('api.mimo-v2.com')) {
+      if (
+        route.routeId === 'xiaomi-mimo' ||
+        route.routeId === 'xiaomi-mimo-token' ||
+        profile.baseUrl.toLowerCase().includes('api.xiaomimimo.com') ||
+        profile.baseUrl.toLowerCase().includes('api.mimo-v2.com') ||
+        profile.baseUrl.toLowerCase().includes('token-plan-sgp.xiaomimimo.com') ||
+        profile.baseUrl.toLowerCase().includes('token-plan-cn.xiaomimimo.com')
+      ) {
         openAIProfileEnv.MIMO_API_KEY = profile.apiKey
       }
       if (route.routeId === 'atlas-cloud' || profile.baseUrl.toLowerCase().includes('atlascloud')) {


### PR DESCRIPTION
## Summary

- Add a descriptor-backed Xiaomi MiMo Token Plan provider preset for the token-plan SGP/CN endpoints.
- Expose Xiaomi MiMo (Token Plan) as a selectable preset in `/provider`.
- Wire the preset through generated integration artifacts, provider flag handling, saved provider profiles, route metadata, and legacy provider detection.
- Add focused coverage for the gateway metadata, provider flag defaults, provider profile env mirroring, compatibility mapping, and ProviderManager preset ordering.

Fixes #1339

## User / Developer Impact

Users with Xiaomi MiMo Token Plan credentials can select Xiaomi MiMo (Token Plan) from `/provider` or use `--provider xiaomi-mimo-token`, then route through `https://token-plan-sgp.xiaomimimo.com/v1` by default while preserving the existing standard Xiaomi MiMo provider path. The new route keeps the Xiaomi MiMo-specific raw `api-key` auth header behavior and MiMo model defaults.

## Provider Path Tested

- Provider preset: `xiaomi-mimo-token`
- `/provider` label: `Xiaomi MiMo (Token Plan)`
- Default endpoint: `https://token-plan-sgp.xiaomimimo.com/v1`
- Alternate matched host: `https://token-plan-cn.xiaomimimo.com/v1`
- Default model: `mimo-v2.5-pro`
- Credential env: `MIMO_API_KEY`, mirrored to `OPENAI_API_KEY` for OpenAI-compatible runtime paths

## Risk Surface

This PR touches provider routing and credential/env handling for the new Xiaomi MiMo Token Plan route.

- Credential handling: mirrors `MIMO_API_KEY` into the OpenAI-compatible `OPENAI_API_KEY` path for this provider, matching the existing Xiaomi MiMo pattern.
- Routing: adds `xiaomi-mimo-token` as a descriptor-backed route and maps it to the existing Xiaomi MiMo legacy provider category.
- External endpoints: adds token-plan SGP and CN hosts: `token-plan-sgp.xiaomimimo.com` and `token-plan-cn.xiaomimimo.com`.
- Blockers: no known blockers; smoke, typecheck, focused provider tests, and provider isolation tests pass.

## Checks Run

```bash
bun run build
bun run smoke
bun run check
bun run typecheck
bun run typecheck:type-tests
bun run test:provider
bun run test:provider-recommendation
bun run integrations:check
bun run security:pr-scan -- --base upstream/main
bun run doctor:runtime
bun test src/integrations/gateways/xiaomi-mimo-token.test.ts src/integrations/routeMetadata.test.ts src/utils/providerFlag.test.ts src/utils/providerProfiles.test.ts src/integrations/compatibility.test.ts src/components/ProviderManager.test.tsx
```

Notes:

- `bun run check` passed unsandboxed with `4773 pass, 0 fail`.
- `doctor:runtime` passed unsandboxed with Node `24.16.0`, Bun `1.3.14`, build artifacts present, and Xiaomi endpoint reachability.
- Earlier sandboxed runs failed only because subprocess/network probes were blocked; rerunning those checks outside the sandbox passed.

## Screenshots

Not applicable; this is provider routing/setup behavior with automated coverage and no visual UI changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added **Xiaomi MiMo (Token Plan)** as a selectable provider option, including OpenAI-compatible base URL routing for token-plan hosts, a default model (**mimo-v2.5-pro**) with variant mapping, and API key handling via environment variable fallbacks.
  * Updated provider/preset logic so the new token-plan preset is included in preset coverage and selection ordering.

* **Tests**
  * Expanded test coverage for the new token-plan gateway, route/base URL resolution, provider flag behavior, provider profiles, preset defaults, and related ordering/expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
