### PR TITLE
feat(atlas-cloud): add GLM 5.2 to vendor catalog

### DIFF
--- a/src/integrations/vendors/atlas-cloud.ts
+++ b/src/integrations/vendors/atlas-cloud.ts
@@ -55,6 +55,7 @@ export default defineVendor({
       { id: 'moonshotai/Kimi-K2-Thinking', apiName: 'moonshotai/Kimi-K2-Thinking', label: 'Kimi K2 Thinking', contextWindow: 262_144 },
       { id: 'moonshotai/Kimi-K2-Instruct-0905', apiName: 'moonshotai/Kimi-K2-Instruct-0905', label: 'Kimi K2 Instruct 0905', contextWindow: 262_144 },
       { id: 'moonshotai/Kimi-K2-Instruct', apiName: 'moonshotai/Kimi-K2-Instruct', label: 'Kimi K2 Instruct', contextWindow: 131_072 },
+      { id: 'zai-org/glm-5.2', apiName: 'zai-org/glm-5.2', label: 'GLM 5.2', contextWindow: 202_752 },
       { id: 'zai-org/glm-5.1', apiName: 'zai-org/glm-5.1', label: 'GLM 5.1', contextWindow: 202_752 },
       { id: 'zai-org/glm-5', apiName: 'zai-org/glm-5', label: 'GLM 5', contextWindow: 202_752 },
       { id: 'zai-org/glm-5-turbo', apiName: 'zai-org/glm-5-turbo', label: 'GLM 5 Turbo', contextWindow: 262_144 },


### PR DESCRIPTION
## Summary
  - **what changed:** Added `zai-org/glm-5.2` ("GLM 5.2") to the Atlas Cloud vendor model list in `src/integrations/vendors/atlas-cloud.ts` with a 202,752-token context window, matching the existing GLM 5.1 / GLM 5 entries.
  - **why it changed:** GLM 5.2 is now available through the Atlas Cloud provider; registering it makes the model selectable through the OpenClaude Atlas Cloud integration.

  ## Impact
  - **user-facing impact:** Users on the Atlas Cloud provider can now select "GLM 5.2" from the model picker.
  - **developer/maintainer impact:** One-line addition to the vendor's model array; no schema, auth, or default-model changes. Follows the existing `zai-org/glm-*` pattern.

  ## Testing
  - [ ] `bun run build`
  - [ ] `bun run smoke`
  - [ ] focused tests: `bun test ./src/integrations/vendors` (if a vendor catalog test exists)
  - [ ] manual: `/provider atlas` → confirm GLM 5.2 appears in model list

  ## Notes
  - **provider/model path tested:** Atlas Cloud / `zai-org/glm-5.2` (catalog entry only; live API call not yet exercised).
  - **screenshots attached (if UI changed):** N/A (CLI-only, no UI screenshot).
  - **follow-up work or known limitations:** Context window set to 202,752 to match GLM 5.1; update if the upstream Atlas Cloud model card specifies a different limit. No alias/default-model changes made.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the zai-org/glm-5.2 model in Atlas Cloud integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->