### PR TITLE
feat(ux): long-turn visibility + default-on stream hang safety net

### DIFF
--- a/src/components/Spinner/SpinnerAnimationRow.tsx
+++ b/src/components/Spinner/SpinnerAnimationRow.tsx
@@ -17,6 +17,10 @@ import { useStalledAnimation } from './useStalledAnimation.js';
 import { interpolateColor, toRGBColor } from './utils.js';
 const SEP_WIDTH = stringWidth(' · ');
 const THINKING_BARE_WIDTH = stringWidth('thinking');
+// Show the elapsed-time counter early (reassurance that work is in flight,
+// especially during long tool calls where no tokens stream) but hold the token
+// count back until the turn is clearly long-running.
+const SHOW_TIMER_AFTER_MS = 5_000;
 const SHOW_TOKENS_AFTER_MS = 30_000;
 
 // Thinking shimmer constants. Previously lived in a separate ThinkingShimmerText
@@ -183,7 +187,8 @@ export function SpinnerAnimationRow({
   // the status parts, so reserve that space in the gating math too.
   const parensWidth = hasRunningTeammates ? 4 : 4 + 2 + SEP_WIDTH;
   const wantsThinking = thinkingStatus !== null;
-  const wantsTimerAndTokens = verbose || hasRunningTeammates || effectiveElapsedMs > SHOW_TOKENS_AFTER_MS;
+  const wantsTimer = verbose || hasRunningTeammates || effectiveElapsedMs > SHOW_TIMER_AFTER_MS;
+  const wantsTokens = verbose || hasRunningTeammates || effectiveElapsedMs > SHOW_TOKENS_AFTER_MS;
   const availableSpace = columns - messageWidth - parensWidth;
   let showThinking = wantsThinking && availableSpace > thinkingWidthValue;
   if (!showThinking && wantsThinking && thinkingStatus === 'thinking' && effortSuffix) {
@@ -194,9 +199,9 @@ export function SpinnerAnimationRow({
     }
   }
   const usedAfterThinking = showThinking ? thinkingWidthValue + sep : 0;
-  const showTimer = wantsTimerAndTokens && availableSpace > usedAfterThinking + timerWidth;
+  const showTimer = wantsTimer && availableSpace > usedAfterThinking + timerWidth;
   const usedAfterTimer = usedAfterThinking + (showTimer ? timerWidth + sep : 0);
-  const showTokens = wantsTimerAndTokens && totalTokens > 0 && availableSpace > usedAfterTimer + tokensWidth;
+  const showTokens = wantsTokens && totalTokens > 0 && availableSpace > usedAfterTimer + tokensWidth;
   // Second chance for narrow terminals: the gating above reserves space for
   // the mode glyph + separator, but a would-be thinking-only spin renders
   // neither the glyph nor the wrapping parens beyond "( )". When nothing

--- a/src/screens/REPL.tsx
+++ b/src/screens/REPL.tsx
@@ -1753,6 +1753,19 @@ export function REPL({
     const inProgressToolUses = lastAssistant.message.content.filter(b => b.type === 'tool_use' && inProgressToolUseIDs.has(b.id));
     return inProgressToolUses.length > 0 && inProgressToolUses.every(b => b.type === 'tool_use' && b.name === SLEEP_TOOL_NAME);
   }, [messages, inProgressToolUseIDs]);
+  // Surface the currently-executing tool in the spinner so long-running tools
+  // (subagents, typecheck, installs) don't look frozen during the elapsed
+  // crunch. Reuses the spinnerSuffix channel; stop-hook progress takes
+  // precedence when both apply (stop hooks run after the turn's tools).
+  const activeToolSpinnerSuffix = useMemo(() => {
+    if (!isLoading || inProgressToolUseIDs.size === 0) return null;
+    const lastAssistant = messages.findLast(m => m.type === 'assistant');
+    if (lastAssistant?.type !== 'assistant') return null;
+    const active = lastAssistant.message.content.filter(b => b.type === 'tool_use' && inProgressToolUseIDs.has(b.id));
+    const first = active[0];
+    if (!first || first.type !== 'tool_use') return null;
+    return active.length > 1 ? `${first.name} +${active.length - 1}` : first.name;
+  }, [messages, inProgressToolUseIDs, isLoading]);
   const mrOnBeforeQuery = useCallback(async (_input: string, _allMessages: MessageType[], _newMessageCount: number) => true, []);
   const mrOnTurnComplete = useCallback(async (_allMessages: MessageType[], _aborted: boolean) => { }, []);
   const mrRender = useCallback(() => null, []);
@@ -4762,7 +4775,7 @@ export function REPL({
         </Box>}
         {feature('WEB_BROWSER_TOOL') ? WebBrowserPanelModule && <WebBrowserPanelModule.WebBrowserPanel /> : null}
         <Box flexGrow={1} />
-        {showSpinner && <SpinnerWithVerb mode={streamMode} spinnerTip={spinnerTip} responseLengthRef={responseLengthRef} overrideMessage={spinnerMessage} spinnerSuffix={stopHookSpinnerSuffix} verbose={verbose} loadingStartTimeRef={loadingStartTimeRef} totalPausedMsRef={totalPausedMsRef} pauseStartTimeRef={pauseStartTimeRef} overrideColor={spinnerColor} overrideShimmerColor={spinnerShimmerColor} hasActiveTools={inProgressToolUseIDs.size > 0} leaderIsIdle={!isLoading} />}
+        {showSpinner && <SpinnerWithVerb mode={streamMode} spinnerTip={spinnerTip} responseLengthRef={responseLengthRef} overrideMessage={spinnerMessage} spinnerSuffix={stopHookSpinnerSuffix ?? activeToolSpinnerSuffix} verbose={verbose} loadingStartTimeRef={loadingStartTimeRef} totalPausedMsRef={totalPausedMsRef} pauseStartTimeRef={pauseStartTimeRef} overrideColor={spinnerColor} overrideShimmerColor={spinnerShimmerColor} hasActiveTools={inProgressToolUseIDs.size > 0} leaderIsIdle={!isLoading} />}
         {/* Permanently mounted: it observes the isLoading transition to flash
             `✓ Done` for ~1.5s. Suppressed wherever another element owns the
             row or the user's attention. */}

--- a/src/services/api/claude.ts
+++ b/src/services/api/claude.ts
@@ -70,7 +70,7 @@ import {
   shouldUseIntegrationRuntimeLimits,
 } from '../../utils/context.js'
 import { resolveAppliedEffort } from '../../utils/effort.js'
-import { isEnvTruthy } from '../../utils/envUtils.js'
+import { isEnvDefinedFalsy, isEnvTruthy } from '../../utils/envUtils.js'
 import { errorMessage } from '../../utils/errors.js'
 import { computeFingerprintFromMessages } from '../../utils/fingerprint.js'
 import { captureAPIRequest, logError } from '../../utils/log.js'
@@ -1950,9 +1950,15 @@ async function* queryModel(
     // kill hung streams. Without this, a silently dropped connection can hang
     // the session indefinitely since the SDK's request timeout only covers the
     // initial fetch(), not the streaming body.
-    const streamWatchdogEnabled = isEnvTruthy(
-      process.env.CLAUDE_ENABLE_STREAM_WATCHDOG,
-    )
+    // Enabled by default, matching the always-on idle timeout already used by
+    // the OpenAI/Codex shims (readWithTimeout). A silently dropped Anthropic
+    // stream now aborts and falls back to a non-streaming retry within
+    // STREAM_IDLE_TIMEOUT_MS, instead of hanging until QueryGuard's 5-minute
+    // idle timeout. Opt out with CLAUDE_DISABLE_STREAM_WATCHDOG=1 (or by
+    // explicitly setting CLAUDE_ENABLE_STREAM_WATCHDOG to a falsy value).
+    const streamWatchdogEnabled =
+      !isEnvTruthy(process.env.CLAUDE_DISABLE_STREAM_WATCHDOG) &&
+      !isEnvDefinedFalsy(process.env.CLAUDE_ENABLE_STREAM_WATCHDOG)
     const STREAM_IDLE_TIMEOUT_MS =
       parseInt(process.env.CLAUDE_STREAM_IDLE_TIMEOUT_MS || '', 10) || 90_000
     const STREAM_IDLE_WARNING_MS = STREAM_IDLE_TIMEOUT_MS / 2


### PR DESCRIPTION
## Summary
  Long-running turns looked frozen — a multi-minute turn (e.g. a long subagent or
  typecheck) showed a bare spinner, prompting "are you still working?" — and a
  silently dropped network stream could hang for the full 5-minute QueryGuard idle
  timeout. Three focused changes close those gaps.

  - **Elapsed timer at 5s, not 30s** (`SpinnerAnimationRow.tsx`): split the single
    `wantsTimerAndTokens` gate into `wantsTimer` (`SHOW_TIMER_AFTER_MS = 5_000`) and
    `wantsTokens` (`SHOW_TOKENS_AFTER_MS = 30_000`). The timer is wall-clock derived,
    so it keeps ticking during long tool calls where no tokens stream — proof of life.
  - **Active tool name in the spinner** (`REPL.tsx`): new `activeToolSpinnerSuffix`
    memo derives the first in-progress tool from the last assistant message ∩
    `inProgressToolUseIDs` and surfaces it via the existing `spinnerSuffix` channel
    (stop-hook progress still takes precedence). A long tool now reads
    `(↓ Bash · 1m 20s)` instead of a bare spinner. No new prop plumbing.
  - **Stream idle watchdog on by default** (`claude.ts`): the watchdog already
    existed but was gated behind `CLAUDE_ENABLE_STREAM_WATCHDOG`. Flipped to default-on
    (matching the always-on `readWithTimeout` in the OpenAI/Codex shims). A dropped
    Anthropic-family stream now aborts and falls back to a non-streaming retry within
    `STREAM_IDLE_TIMEOUT_MS` instead of hanging to 5 minutes.

  ## Impact
  - No new dependencies; +32/−8 across 3 files.
  - Behaviour change: the Anthropic-family stream watchdog is now active for all
    users. Default timeout kept conservative at **90s** (covers Anthropic/Bedrock/
    Vertex, which send SSE pings). On fire it throws → existing non-streaming retry
    fallback. Opt out with `CLAUDE_DISABLE_STREAM_WATCHDOG=1`; tune with
    `CLAUDE_STREAM_IDLE_TIMEOUT_MS`.
  - Spinner changes are display-only.

  ## Testing
  - [x] `bun run typecheck` (tsc --noEmit) — clean
  - [x] `bun test src/__tests__/bugfixes.test.ts` — 31 pass (incl. stream-idle assertions)
  - [x] `bun test src/services/api` — 835 pass
  - [x] `bun run smoke` — bundle builds + `--version` runs
  - [ ] Manual TUI check of the new spinner suffix / 5s timer (not yet captured)

  ## Notes
  Follow-ups deliberately deferred:
  - Surface the watchdog's 45s warning as a UI "reconnecting…" line (needs event
    plumbing from the API layer to the REPL). Token-streaming stalls already show a
    red spinner at 3s via `useStalledAnimation`, but it's suppressed while tools run.
  - Un-blank streaming text under reduced-motion (`REPL.tsx` `showStreamingText`).
  - Optionally tighten the 90s watchdog default toward ~30s.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Tool names now displayed in loading spinners when tools execute, with counts shown for multiple simultaneous tool operations.
  * Timer and token count display behavior improved with separate visibility logic for better rendering in narrow terminal layouts.

* **Chores**
  * Stream watchdog functionality enabled by default; can be disabled via environment configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->