### PR TITLE
feat(permissions): allow npm/bun/tsc --version as read-only

### DIFF
--- a/src/tools/BashTool/readOnlyValidation.test.ts
+++ b/src/tools/BashTool/readOnlyValidation.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, test } from 'bun:test'
+
+import { checkReadOnlyConstraints } from './readOnlyValidation.js'
+
+const isReadOnly = (command: string): boolean =>
+  checkReadOnlyConstraints({ command }, false).behavior === 'allow'
+
+// Package-manager / compiler version queries are read-only. node/python were
+// already covered; npm/bun/tsc were not, so they fell through to a permission
+// prompt. They must be allowed in exact-anchored form only — never with a
+// trailing argument, which could smuggle a script-running flag past the check.
+describe('read-only version queries (npm/bun/tsc)', () => {
+  test.each([
+    'npm --version',
+    'npm -v',
+    'bun --version',
+    'bun -v',
+    'tsc --version',
+    'tsc -v',
+    // Pre-existing coverage — guards against regressions in the same block.
+    'node --version',
+    'node -v',
+    'python --version',
+  ])('allows %j', cmd => {
+    expect(isReadOnly(cmd)).toBe(true)
+  })
+
+  test.each([
+    'npm install',
+    'npm i left-pad',
+    'npm run build',
+    'npm --version --run build', // suffix must not be permitted
+    'npm -v foo',
+    'bun add left-pad',
+    'tsc -p .',
+    'tsc --build',
+    'npm', // bare command is not a version query
+  ])('does not allow %j', cmd => {
+    expect(isReadOnly(cmd)).toBe(false)
+  })
+})

--- a/src/tools/BashTool/readOnlyValidation.ts
+++ b/src/tools/BashTool/readOnlyValidation.ts
@@ -1472,6 +1472,13 @@ const READONLY_COMMAND_REGEXES = new Set([
   /^node --version$/,
   /^python --version$/,
   /^python3 --version$/,
+  // Package-manager / compiler version queries. Exact-anchored (no trailing
+  // args) for the same defense-in-depth reason as node above: a bare version
+  // flag is read-only, but permitting suffixes could let a tool that parses
+  // flags in an unexpected order run a task (e.g. `npm <flag> run <script>`).
+  /^npm (?:-v|--version)$/,
+  /^bun (?:-v|--version)$/,
+  /^tsc (?:-v|--version)$/,
 
   // Misc. safe commands
   // tree command moved to COMMAND_ALLOWLIST for proper flag validation (blocks -o/--output)


### PR DESCRIPTION
## Summary
  `node --version` and `python --version` are auto-approved as read-only Bash via
  `readOnlyValidation.ts`, but `npm`, `bun`, and `tsc` version queries were absent
  from the allowlist — so they fell through to a permission prompt. This adds them
  in the same exact-anchored form already used for `node`.

  ```diff
    /^node --version$/,
    /^python --version$/,
    /^python3 --version$/,
  + /^npm (?:-v|--version)$/,
  + /^bun (?:-v|--version)$/,
  + /^tsc (?:-v|--version)$/,

  Impact

  - Removes a permission prompt for three extremely common, harmless commands.
  - Security: exact-anchored (no trailing args), matching the existing node
  entries. This is deliberate — permitting suffixes could let a tool that parses
  flags in an unexpected order run a task (the node -v --run <script> class of
  bypass). npm install, npm --version --run x, tsc -p ., bun add … all
  still prompt.

  Testing

  - [x] New readOnlyValidation.test.ts — 18 cases: allows -v/--version for
  npm/bun/tsc (+ node/python regression guards); rejects install/build/suffixed forms.
  - [x] tsc --noEmit clean
  - [x] bun test src/tools/BashTool/ — 117 pass (no regressions)
  - [x] knip clean

  Notes

  Supersedes the read-only gap covered by the now-closed #787 (pattern-based Bash
  classifier). The rest of #787's allowlist (ls, cat, grep, git status, …)
  is already auto-approved by readOnlyValidation.ts, so this ~3-line change
  closes the only real delta without a 1,342-line parallel classifier. Scoped to
  npm/bun/tsc — the ones actually observed prompting; cargo/go/deno/pnpm/yarn
  can follow individually if wanted (go uses the go version subcommand, not a flag).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved command validation to properly recognize version-only queries for npm, bun, and tsc as read-only safe operations.

* **Tests**
  * Added comprehensive test coverage for read-only command constraint validation, ensuring version queries are allowed while related commands are properly restricted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->