### PR TITLE
fix(bg): stream session logs with bounded memory

### DIFF
--- a/src/cli/bg.test.ts
+++ b/src/cli/bg.test.ts
@@ -569,6 +569,7 @@ describe('background session log streaming', () => {
       },
     }
 
+    let resolved = false
     const following = followLogFile('/tmp/stdout.log', 0, {
       output,
       chunkSize: 4,
@@ -576,19 +577,61 @@ describe('background session log streaming', () => {
       setInterval: scheduler.setInterval,
       clearInterval: scheduler.clearInterval,
       openFile: async () => handle,
+    }).then(() => {
+      resolved = true
     })
 
     scheduler.tick()
     await readStarted.promise
     abort.abort()
+    await new Promise(resolve => setTimeout(resolve, 0))
+    expect(resolved).toBe(false)
     releaseRead.resolve()
     await following
-    await waitFor(() => closed)
     scheduler.tick()
     await new Promise(resolve => setTimeout(resolve, 0))
 
     expect(scheduler.cleared).toBe(true)
+    expect(closed).toBe(true)
     expect(output.bytes().length).toBe(0)
+  })
+
+  it('preserves streamed progress when a later close failure occurs', async () => {
+    const output = new TestOutput()
+    const scheduler = createManualScheduler()
+    const abort = new AbortController()
+    let openCount = 0
+
+    const following = followLogFile('/tmp/stdout.log', 0, {
+      output,
+      chunkSize: 4,
+      signal: abort.signal,
+      setInterval: scheduler.setInterval,
+      clearInterval: scheduler.clearInterval,
+      openFile: async () => {
+        openCount++
+        return {
+          stat: async () => ({ size: 4 }),
+          read: async (buffer: Buffer) => {
+            buffer.write('once')
+            return { bytesRead: 4 }
+          },
+          close: async () => {
+            if (openCount === 1) throw new Error('close failed')
+          },
+        }
+      },
+    })
+
+    scheduler.tick()
+    await waitFor(() => output.bytes().toString() === 'once')
+    scheduler.tick()
+    await waitFor(() => openCount === 2)
+    await new Promise(resolve => setTimeout(resolve, 0))
+    abort.abort()
+    await following
+
+    expect(output.bytes().toString()).toBe('once')
   })
 
   it('handles EPIPE and destroyed stdout without throwing', async () => {

--- a/src/cli/bg.test.ts
+++ b/src/cli/bg.test.ts
@@ -2,7 +2,7 @@ import { EventEmitter } from 'node:events'
 import { mkdtemp, rm, unlink, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { afterEach, describe, expect, it } from 'bun:test'
+import { describe, expect, it } from 'bun:test'
 import {
   buildBackgroundSessionLaunch,
   buildBackgroundChildProcessConfig,
@@ -74,17 +74,17 @@ async function waitFor(condition: () => boolean): Promise<void> {
   throw new Error('condition was not met')
 }
 
-const tempDirs: string[] = []
-
-async function tempFile(name: string): Promise<string> {
+async function withTempFile<T>(
+  name: string,
+  run: (path: string) => Promise<T>,
+): Promise<T> {
   const dir = await mkdtemp(join(tmpdir(), 'openclaude-bg-test-'))
-  tempDirs.push(dir)
-  return join(dir, name)
+  try {
+    return await run(join(dir, name))
+  } finally {
+    await rm(dir, { recursive: true, force: true })
+  }
 }
-
-afterEach(async () => {
-  await Promise.all(tempDirs.splice(0).map(dir => rm(dir, { recursive: true })))
-})
 
 describe('background session CLI parsing', () => {
   it('builds a print-mode child command and preserves provider/model flags', () => {
@@ -398,154 +398,160 @@ describe('background session CLI parsing', () => {
 
 describe('background session log streaming', () => {
   it('emits a multi-megabyte existing log exactly with bounded allocations', async () => {
-    const path = await tempFile('stdout.log')
-    const chunkSize = LOG_STREAM_CHUNK_SIZE
-    const contents = Buffer.alloc(chunkSize * 32 + 123)
-    for (let i = 0; i < contents.length; i++) contents[i] = i % 251
-    await writeFile(path, contents)
+    await withTempFile('stdout.log', async path => {
+      const chunkSize = LOG_STREAM_CHUNK_SIZE
+      const contents = Buffer.alloc(chunkSize * 32 + 123)
+      for (let i = 0; i < contents.length; i++) contents[i] = i % 251
+      await writeFile(path, contents)
 
-    const allocations: number[] = []
-    const output = new TestOutput()
-    const offset = await printExistingLog(path, {
-      output,
-      chunkSize,
-      createBuffer: size => {
-        allocations.push(size)
-        return Buffer.alloc(size)
-      },
+      const allocations: number[] = []
+      const output = new TestOutput()
+      const offset = await printExistingLog(path, {
+        output,
+        chunkSize,
+        createBuffer: size => {
+          allocations.push(size)
+          return Buffer.alloc(size)
+        },
+      })
+
+      expect(offset).toBe(contents.length)
+      expect(output.bytes()).toEqual(contents)
+      expect(Math.max(...allocations)).toBeLessThanOrEqual(chunkSize)
+      expect(allocations.length).toBeGreaterThan(1)
     })
-
-    expect(offset).toBe(contents.length)
-    expect(output.bytes()).toEqual(contents)
-    expect(Math.max(...allocations)).toBeLessThanOrEqual(chunkSize)
-    expect(allocations.length).toBeGreaterThan(1)
   })
 
   it('follow mode emits existing and appended content exactly once in order', async () => {
-    const path = await tempFile('stdout.log')
-    const output = new TestOutput()
-    await writeFile(path, Buffer.from('existing-'))
+    await withTempFile('stdout.log', async path => {
+      const output = new TestOutput()
+      await writeFile(path, Buffer.from('existing-'))
 
-    const offset = await printExistingLog(path, { output, chunkSize: 4 })
-    const scheduler = createManualScheduler()
-    const abort = new AbortController()
-    const following = followLogFile(path, offset, {
-      output,
-      chunkSize: 4,
-      signal: abort.signal,
-      setInterval: scheduler.setInterval,
-      clearInterval: scheduler.clearInterval,
+      const offset = await printExistingLog(path, { output, chunkSize: 4 })
+      const scheduler = createManualScheduler()
+      const abort = new AbortController()
+      const following = followLogFile(path, offset, {
+        output,
+        chunkSize: 4,
+        signal: abort.signal,
+        setInterval: scheduler.setInterval,
+        clearInterval: scheduler.clearInterval,
+      })
+
+      await writeFile(path, Buffer.from('existing-appended'))
+      scheduler.tick()
+      await waitFor(() => output.bytes().toString() === 'existing-appended')
+      abort.abort()
+      await following
+
+      expect(output.bytes().toString()).toBe('existing-appended')
     })
-
-    await writeFile(path, Buffer.from('existing-appended'))
-    scheduler.tick()
-    await waitFor(() => output.bytes().toString() === 'existing-appended')
-    abort.abort()
-    await following
-
-    expect(output.bytes().toString()).toBe('existing-appended')
   })
 
   it('splits a large appended range into bounded chunks', async () => {
-    const path = await tempFile('stdout.log')
-    const chunkSize = 16
-    await writeFile(path, Buffer.from('seed'))
-    const appended = Buffer.alloc(chunkSize * 2 + 5, 7)
-    await writeFile(path, Buffer.concat([Buffer.from('seed'), appended]))
+    await withTempFile('stdout.log', async path => {
+      const chunkSize = 16
+      await writeFile(path, Buffer.from('seed'))
+      const appended = Buffer.alloc(chunkSize * 2 + 5, 7)
+      await writeFile(path, Buffer.concat([Buffer.from('seed'), appended]))
 
-    const output = new TestOutput()
-    const scheduler = createManualScheduler()
-    const abort = new AbortController()
-    const following = followLogFile(path, 4, {
-      output,
-      chunkSize,
-      signal: abort.signal,
-      setInterval: scheduler.setInterval,
-      clearInterval: scheduler.clearInterval,
+      const output = new TestOutput()
+      const scheduler = createManualScheduler()
+      const abort = new AbortController()
+      const following = followLogFile(path, 4, {
+        output,
+        chunkSize,
+        signal: abort.signal,
+        setInterval: scheduler.setInterval,
+        clearInterval: scheduler.clearInterval,
+      })
+
+      scheduler.tick()
+      await waitFor(() => output.bytes().length === appended.length)
+      abort.abort()
+      await following
+
+      expect(output.bytes()).toEqual(appended)
+      expect(output.chunks.map(chunk => chunk.length)).toEqual([16, 16, 5])
     })
-
-    scheduler.tick()
-    await waitFor(() => output.bytes().length === appended.length)
-    abort.abort()
-    await following
-
-    expect(output.bytes()).toEqual(appended)
-    expect(output.chunks.map(chunk => chunk.length)).toEqual([16, 16, 5])
   })
 
   it('waits for drain before reading or writing more when stdout applies backpressure', async () => {
-    const path = await tempFile('stdout.log')
-    await writeFile(path, Buffer.from('abcdef'))
-    const output = new TestOutput()
-    output.writeResults.push(false)
+    await withTempFile('stdout.log', async path => {
+      await writeFile(path, Buffer.from('abcdef'))
+      const output = new TestOutput()
+      output.writeResults.push(false)
 
-    let settled = false
-    const printing = printExistingLog(path, { output, chunkSize: 3 }).then(
-      offset => {
-        settled = true
-        return offset
-      },
-    )
+      let settled = false
+      const printing = printExistingLog(path, { output, chunkSize: 3 }).then(
+        offset => {
+          settled = true
+          return offset
+        },
+      )
 
-    await waitFor(() => output.chunks.length === 1)
-    expect(output.bytes().toString()).toBe('abc')
-    expect(settled).toBe(false)
+      await waitFor(() => output.chunks.length === 1)
+      expect(output.bytes().toString()).toBe('abc')
+      expect(settled).toBe(false)
 
-    output.emit('drain')
-    await expect(printing).resolves.toBe(6)
-    expect(output.bytes().toString()).toBe('abcdef')
-    expect(output.chunks.map(chunk => chunk.length)).toEqual([3, 3])
+      output.emit('drain')
+      await expect(printing).resolves.toBe(6)
+      expect(output.bytes().toString()).toBe('abcdef')
+      expect(output.chunks.map(chunk => chunk.length)).toEqual([3, 3])
+    })
   })
 
   it('resets the follow read position when the log is truncated', async () => {
-    const path = await tempFile('stdout.log')
-    await writeFile(path, Buffer.from('abcdef'))
-    const output = new TestOutput()
-    const scheduler = createManualScheduler()
-    const abort = new AbortController()
-    const following = followLogFile(path, 6, {
-      output,
-      chunkSize: 8,
-      signal: abort.signal,
-      setInterval: scheduler.setInterval,
-      clearInterval: scheduler.clearInterval,
+    await withTempFile('stdout.log', async path => {
+      await writeFile(path, Buffer.from('abcdef'))
+      const output = new TestOutput()
+      const scheduler = createManualScheduler()
+      const abort = new AbortController()
+      const following = followLogFile(path, 6, {
+        output,
+        chunkSize: 8,
+        signal: abort.signal,
+        setInterval: scheduler.setInterval,
+        clearInterval: scheduler.clearInterval,
+      })
+
+      await writeFile(path, Buffer.from('xy'))
+      scheduler.tick()
+      await waitFor(() => output.bytes().toString() === 'xy')
+      abort.abort()
+      await following
+
+      expect(output.bytes().toString()).toBe('xy')
     })
-
-    await writeFile(path, Buffer.from('xy'))
-    scheduler.tick()
-    await waitFor(() => output.bytes().toString() === 'xy')
-    abort.abort()
-    await following
-
-    expect(output.bytes().toString()).toBe('xy')
   })
 
   it('tolerates temporary file disappearance while following', async () => {
-    const path = await tempFile('stdout.log')
-    await writeFile(path, Buffer.from('seed'))
-    const output = new TestOutput()
-    const scheduler = createManualScheduler()
-    const abort = new AbortController()
-    const following = followLogFile(path, 4, {
-      output,
-      chunkSize: 8,
-      signal: abort.signal,
-      setInterval: scheduler.setInterval,
-      clearInterval: scheduler.clearInterval,
+    await withTempFile('stdout.log', async path => {
+      await writeFile(path, Buffer.from('seed'))
+      const output = new TestOutput()
+      const scheduler = createManualScheduler()
+      const abort = new AbortController()
+      const following = followLogFile(path, 4, {
+        output,
+        chunkSize: 8,
+        signal: abort.signal,
+        setInterval: scheduler.setInterval,
+        clearInterval: scheduler.clearInterval,
+      })
+
+      await unlink(path)
+      scheduler.tick()
+      await new Promise(resolve => setTimeout(resolve, 0))
+      expect(output.bytes().length).toBe(0)
+
+      await writeFile(path, Buffer.from('new'))
+      scheduler.tick()
+      await waitFor(() => output.bytes().toString() === 'new')
+      abort.abort()
+      await following
+
+      expect(output.bytes().toString()).toBe('new')
     })
-
-    await unlink(path)
-    scheduler.tick()
-    await new Promise(resolve => setTimeout(resolve, 0))
-    expect(output.bytes().length).toBe(0)
-
-    await writeFile(path, Buffer.from('new'))
-    scheduler.tick()
-    await waitFor(() => output.bytes().toString() === 'new')
-    abort.abort()
-    await following
-
-    expect(output.bytes().toString()).toBe('new')
   })
 
   it('prevents writes after signal cleanup during an in-flight poll', async () => {
@@ -658,22 +664,23 @@ describe('background session log streaming', () => {
   })
 
   it('handles EPIPE and destroyed stdout without throwing', async () => {
-    const path = await tempFile('stdout.log')
-    await writeFile(path, Buffer.from('closed-pipe'))
+    await withTempFile('stdout.log', async path => {
+      await writeFile(path, Buffer.from('closed-pipe'))
 
-    const epipeOutput = new TestOutput()
-    epipeOutput.writeError = Object.assign(new Error('broken pipe'), {
-      code: 'EPIPE',
+      const epipeOutput = new TestOutput()
+      epipeOutput.writeError = Object.assign(new Error('broken pipe'), {
+        code: 'EPIPE',
+      })
+      await expect(
+        printExistingLog(path, { output: epipeOutput, chunkSize: 4 }),
+      ).resolves.toBe(0)
+
+      const destroyedOutput = new TestOutput()
+      destroyedOutput.destroyed = true
+      await expect(
+        printExistingLog(path, { output: destroyedOutput, chunkSize: 4 }),
+      ).resolves.toBe(0)
+      expect(destroyedOutput.bytes().length).toBe(0)
     })
-    await expect(
-      printExistingLog(path, { output: epipeOutput, chunkSize: 4 }),
-    ).resolves.toBe(0)
-
-    const destroyedOutput = new TestOutput()
-    destroyedOutput.destroyed = true
-    await expect(
-      printExistingLog(path, { output: destroyedOutput, chunkSize: 4 }),
-    ).resolves.toBe(0)
-    expect(destroyedOutput.bytes().length).toBe(0)
   })
 })

--- a/src/cli/bg.test.ts
+++ b/src/cli/bg.test.ts
@@ -634,6 +634,29 @@ describe('background session log streaming', () => {
     expect(output.bytes().toString()).toBe('once')
   })
 
+  it('surfaces non-follow file read failures', async () => {
+    let closed = false
+    const readError = Object.assign(new Error('read failed'), {
+      code: 'EIO',
+    })
+
+    await expect(
+      printExistingLog('/tmp/stdout.log', {
+        chunkSize: 4,
+        openFile: async () => ({
+          stat: async () => ({ size: 4 }),
+          read: async () => {
+            throw readError
+          },
+          close: async () => {
+            closed = true
+          },
+        }),
+      }),
+    ).rejects.toThrow('read failed')
+    expect(closed).toBe(true)
+  })
+
   it('handles EPIPE and destroyed stdout without throwing', async () => {
     const path = await tempFile('stdout.log')
     await writeFile(path, Buffer.from('closed-pipe'))

--- a/src/cli/bg.test.ts
+++ b/src/cli/bg.test.ts
@@ -1,11 +1,90 @@
-import { describe, expect, it } from 'bun:test'
+import { EventEmitter } from 'node:events'
+import { mkdtemp, rm, unlink, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it } from 'bun:test'
 import {
   buildBackgroundSessionLaunch,
   buildBackgroundChildProcessConfig,
+  followLogFile,
+  printExistingLog,
   terminateBackgroundProcessTree,
+  LOG_STREAM_CHUNK_SIZE,
   parseBackgroundInvocation,
   parseLogsInvocation,
 } from './bg.js'
+
+class TestOutput extends EventEmitter {
+  chunks: Buffer[] = []
+  destroyed = false
+  writableDestroyed = false
+  writeResults: boolean[] = []
+  writeError: unknown
+
+  write(chunk: Uint8Array): boolean {
+    if (this.writeError) throw this.writeError
+    if (this.destroyed || this.writableDestroyed) {
+      throw Object.assign(new Error('stdout closed'), { code: 'EPIPE' })
+    }
+    this.chunks.push(Buffer.from(chunk))
+    return this.writeResults.shift() ?? true
+  }
+
+  bytes(): Buffer {
+    return Buffer.concat(this.chunks)
+  }
+}
+
+function createManualScheduler() {
+  let intervalCallback: (() => void) | undefined
+  let cleared = false
+
+  return {
+    setInterval(callback: () => void): ReturnType<typeof setInterval> {
+      intervalCallback = callback
+      return 1 as unknown as ReturnType<typeof setInterval>
+    },
+    clearInterval(): void {
+      cleared = true
+    },
+    tick(): void {
+      intervalCallback?.()
+    },
+    get cleared(): boolean {
+      return cleared
+    },
+  }
+}
+
+function deferred<T = void>() {
+  let resolve!: (value: T | PromiseLike<T>) => void
+  let reject!: (reason?: unknown) => void
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise
+    reject = rejectPromise
+  })
+  return { promise, resolve, reject }
+}
+
+async function waitFor(condition: () => boolean): Promise<void> {
+  for (let i = 0; i < 50; i++) {
+    if (condition()) return
+    await new Promise(resolve => setTimeout(resolve, 0))
+  }
+  throw new Error('condition was not met')
+}
+
+const tempDirs: string[] = []
+
+async function tempFile(name: string): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), 'openclaude-bg-test-'))
+  tempDirs.push(dir)
+  return join(dir, name)
+}
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map(dir => rm(dir, { recursive: true })))
+})
 
 describe('background session CLI parsing', () => {
   it('builds a print-mode child command and preserves provider/model flags', () => {
@@ -254,6 +333,16 @@ describe('background session CLI parsing', () => {
       follow: false,
       stream: 'stderr',
     })
+    expect(parseLogsInvocation(['auth-refactor', '--stdout', '-f'])).toEqual({
+      target: 'auth-refactor',
+      follow: true,
+      stream: 'stdout',
+    })
+    expect(parseLogsInvocation(['auth-refactor', '-f', '--stderr'])).toEqual({
+      target: 'auth-refactor',
+      follow: true,
+      stream: 'stderr',
+    })
   })
 
   it('preserves Node exec flags and lets the launcher manage heap relaunch state', () => {
@@ -304,5 +393,221 @@ describe('background session CLI parsing', () => {
     })
 
     expect(signals).toEqual(['SIGTERM', 'SIGKILL'])
+  })
+})
+
+describe('background session log streaming', () => {
+  it('emits a multi-megabyte existing log exactly with bounded allocations', async () => {
+    const path = await tempFile('stdout.log')
+    const chunkSize = LOG_STREAM_CHUNK_SIZE
+    const contents = Buffer.alloc(chunkSize * 32 + 123)
+    for (let i = 0; i < contents.length; i++) contents[i] = i % 251
+    await writeFile(path, contents)
+
+    const allocations: number[] = []
+    const output = new TestOutput()
+    const offset = await printExistingLog(path, {
+      output,
+      chunkSize,
+      createBuffer: size => {
+        allocations.push(size)
+        return Buffer.alloc(size)
+      },
+    })
+
+    expect(offset).toBe(contents.length)
+    expect(output.bytes()).toEqual(contents)
+    expect(Math.max(...allocations)).toBeLessThanOrEqual(chunkSize)
+    expect(allocations.length).toBeGreaterThan(1)
+  })
+
+  it('follow mode emits existing and appended content exactly once in order', async () => {
+    const path = await tempFile('stdout.log')
+    const output = new TestOutput()
+    await writeFile(path, Buffer.from('existing-'))
+
+    const offset = await printExistingLog(path, { output, chunkSize: 4 })
+    const scheduler = createManualScheduler()
+    const abort = new AbortController()
+    const following = followLogFile(path, offset, {
+      output,
+      chunkSize: 4,
+      signal: abort.signal,
+      setInterval: scheduler.setInterval,
+      clearInterval: scheduler.clearInterval,
+    })
+
+    await writeFile(path, Buffer.from('existing-appended'))
+    scheduler.tick()
+    await waitFor(() => output.bytes().toString() === 'existing-appended')
+    abort.abort()
+    await following
+
+    expect(output.bytes().toString()).toBe('existing-appended')
+  })
+
+  it('splits a large appended range into bounded chunks', async () => {
+    const path = await tempFile('stdout.log')
+    const chunkSize = 16
+    await writeFile(path, Buffer.from('seed'))
+    const appended = Buffer.alloc(chunkSize * 2 + 5, 7)
+    await writeFile(path, Buffer.concat([Buffer.from('seed'), appended]))
+
+    const output = new TestOutput()
+    const scheduler = createManualScheduler()
+    const abort = new AbortController()
+    const following = followLogFile(path, 4, {
+      output,
+      chunkSize,
+      signal: abort.signal,
+      setInterval: scheduler.setInterval,
+      clearInterval: scheduler.clearInterval,
+    })
+
+    scheduler.tick()
+    await waitFor(() => output.bytes().length === appended.length)
+    abort.abort()
+    await following
+
+    expect(output.bytes()).toEqual(appended)
+    expect(output.chunks.map(chunk => chunk.length)).toEqual([16, 16, 5])
+  })
+
+  it('waits for drain before reading or writing more when stdout applies backpressure', async () => {
+    const path = await tempFile('stdout.log')
+    await writeFile(path, Buffer.from('abcdef'))
+    const output = new TestOutput()
+    output.writeResults.push(false)
+
+    let settled = false
+    const printing = printExistingLog(path, { output, chunkSize: 3 }).then(
+      offset => {
+        settled = true
+        return offset
+      },
+    )
+
+    await waitFor(() => output.chunks.length === 1)
+    expect(output.bytes().toString()).toBe('abc')
+    expect(settled).toBe(false)
+
+    output.emit('drain')
+    await expect(printing).resolves.toBe(6)
+    expect(output.bytes().toString()).toBe('abcdef')
+    expect(output.chunks.map(chunk => chunk.length)).toEqual([3, 3])
+  })
+
+  it('resets the follow read position when the log is truncated', async () => {
+    const path = await tempFile('stdout.log')
+    await writeFile(path, Buffer.from('abcdef'))
+    const output = new TestOutput()
+    const scheduler = createManualScheduler()
+    const abort = new AbortController()
+    const following = followLogFile(path, 6, {
+      output,
+      chunkSize: 8,
+      signal: abort.signal,
+      setInterval: scheduler.setInterval,
+      clearInterval: scheduler.clearInterval,
+    })
+
+    await writeFile(path, Buffer.from('xy'))
+    scheduler.tick()
+    await waitFor(() => output.bytes().toString() === 'xy')
+    abort.abort()
+    await following
+
+    expect(output.bytes().toString()).toBe('xy')
+  })
+
+  it('tolerates temporary file disappearance while following', async () => {
+    const path = await tempFile('stdout.log')
+    await writeFile(path, Buffer.from('seed'))
+    const output = new TestOutput()
+    const scheduler = createManualScheduler()
+    const abort = new AbortController()
+    const following = followLogFile(path, 4, {
+      output,
+      chunkSize: 8,
+      signal: abort.signal,
+      setInterval: scheduler.setInterval,
+      clearInterval: scheduler.clearInterval,
+    })
+
+    await unlink(path)
+    scheduler.tick()
+    await new Promise(resolve => setTimeout(resolve, 0))
+    expect(output.bytes().length).toBe(0)
+
+    await writeFile(path, Buffer.from('new'))
+    scheduler.tick()
+    await waitFor(() => output.bytes().toString() === 'new')
+    abort.abort()
+    await following
+
+    expect(output.bytes().toString()).toBe('new')
+  })
+
+  it('prevents writes after signal cleanup during an in-flight poll', async () => {
+    const output = new TestOutput()
+    const scheduler = createManualScheduler()
+    const abort = new AbortController()
+    const readStarted = deferred()
+    const releaseRead = deferred()
+    let closed = false
+
+    const handle = {
+      stat: async () => ({ size: 4 }),
+      read: async (buffer: Buffer) => {
+        readStarted.resolve()
+        await releaseRead.promise
+        buffer.write('late')
+        return { bytesRead: 4, buffer }
+      },
+      close: async () => {
+        closed = true
+      },
+    }
+
+    const following = followLogFile('/tmp/stdout.log', 0, {
+      output,
+      chunkSize: 4,
+      signal: abort.signal,
+      setInterval: scheduler.setInterval,
+      clearInterval: scheduler.clearInterval,
+      openFile: async () => handle,
+    })
+
+    scheduler.tick()
+    await readStarted.promise
+    abort.abort()
+    releaseRead.resolve()
+    await following
+    await waitFor(() => closed)
+    scheduler.tick()
+    await new Promise(resolve => setTimeout(resolve, 0))
+
+    expect(scheduler.cleared).toBe(true)
+    expect(output.bytes().length).toBe(0)
+  })
+
+  it('handles EPIPE and destroyed stdout without throwing', async () => {
+    const path = await tempFile('stdout.log')
+    await writeFile(path, Buffer.from('closed-pipe'))
+
+    const epipeOutput = new TestOutput()
+    epipeOutput.writeError = Object.assign(new Error('broken pipe'), {
+      code: 'EPIPE',
+    })
+    await expect(
+      printExistingLog(path, { output: epipeOutput, chunkSize: 4 }),
+    ).resolves.toBe(0)
+
+    const destroyedOutput = new TestOutput()
+    destroyedOutput.destroyed = true
+    await expect(
+      printExistingLog(path, { output: destroyedOutput, chunkSize: 4 }),
+    ).resolves.toBe(0)
+    expect(destroyedOutput.bytes().length).toBe(0)
   })
 })

--- a/src/cli/bg.ts
+++ b/src/cli/bg.ts
@@ -534,12 +534,13 @@ async function streamLogRange(
       throw new Error('Log stream buffer factory returned a short buffer')
     }
 
-    const { bytesRead } = await handle.read(
-      buffer,
-      0,
-      bytesToRead,
-      position,
-    )
+    let bytesRead: number
+    try {
+      const readResult = await handle.read(buffer, 0, bytesToRead, position)
+      bytesRead = readResult.bytesRead
+    } catch {
+      return { position, outputOpen: true }
+    }
     if (bytesRead <= 0) break
     if (options.signal?.aborted) return { position, outputOpen: false }
 
@@ -559,19 +560,27 @@ async function streamLogSnapshot(
   offset: number,
   options: StreamLogOptions,
 ): Promise<StreamLogResult> {
+  let handle: LogFileHandle
   try {
-    const handle = await (options.openFile ?? open)(path, 'r')
-    try {
-      const { size } = await handle.stat()
-      const start = size < offset ? 0 : offset
-      if (size <= start) return { position: start, outputOpen: true }
-      return await streamLogRange(handle, start, size, options)
-    } finally {
-      await handle.close()
-    }
+    handle = await (options.openFile ?? open)(path, 'r')
   } catch {
     // Keep following; the child may create or rotate the file later.
     return { position: offset, outputOpen: true }
+  }
+
+  let result: StreamLogResult = { position: offset, outputOpen: true }
+  try {
+    const { size } = await handle.stat()
+    const start = size < offset ? 0 : offset
+    result =
+      size <= start
+        ? { position: start, outputOpen: true }
+        : await streamLogRange(handle, start, size, options)
+    return result
+  } catch {
+    return result
+  } finally {
+    await handle.close().catch(() => undefined)
   }
 }
 
@@ -594,6 +603,7 @@ export async function followLogFile(
   let reading = false
   let stopped = false
   let timer: LogFollowTimer | undefined
+  let activePoll: Promise<void> | undefined
 
   await new Promise<void>(resolve => {
     const cleanup = () => {
@@ -604,13 +614,18 @@ export async function followLogFile(
       process.off('SIGINT', cleanup)
       process.off('SIGTERM', cleanup)
       options.signal?.removeEventListener('abort', cleanup)
-      resolve()
+      const pendingPoll = activePoll
+      if (pendingPoll) {
+        void pendingPoll.finally(resolve)
+      } else {
+        resolve()
+      }
     }
 
     const poll = () => {
       if (stopped || reading) return
       reading = true
-      void (async () => {
+      const pollPromise = (async () => {
         try {
           const result = await streamLogSnapshot(path, position, {
             ...options,
@@ -623,6 +638,10 @@ export async function followLogFile(
           reading = false
         }
       })()
+      activePoll = pollPromise
+      void pollPromise.finally(() => {
+        if (activePoll === pollPromise) activePoll = undefined
+      })
     }
 
     process.once('SIGINT', cleanup)

--- a/src/cli/bg.ts
+++ b/src/cli/bg.ts
@@ -89,6 +89,7 @@ type StreamLogOptions = {
   createBuffer?: (size: number) => Buffer
   signal?: AbortSignal
   openFile?: (path: string, flags: 'r') => Promise<LogFileHandle>
+  continueOnFileError?: boolean
 }
 
 type FollowLogOptions = StreamLogOptions & {
@@ -538,7 +539,8 @@ async function streamLogRange(
     try {
       const readResult = await handle.read(buffer, 0, bytesToRead, position)
       bytesRead = readResult.bytesRead
-    } catch {
+    } catch (error) {
+      if (!options.continueOnFileError) throw error
       return { position, outputOpen: true }
     }
     if (bytesRead <= 0) break
@@ -563,7 +565,8 @@ async function streamLogSnapshot(
   let handle: LogFileHandle
   try {
     handle = await (options.openFile ?? open)(path, 'r')
-  } catch {
+  } catch (error) {
+    if (!options.continueOnFileError) throw error
     // Keep following; the child may create or rotate the file later.
     return { position: offset, outputOpen: true }
   }
@@ -577,10 +580,15 @@ async function streamLogSnapshot(
         ? { position: start, outputOpen: true }
         : await streamLogRange(handle, start, size, options)
     return result
-  } catch {
+  } catch (error) {
+    if (!options.continueOnFileError) throw error
     return result
   } finally {
-    await handle.close().catch(() => undefined)
+    if (options.continueOnFileError) {
+      await handle.close().catch(() => undefined)
+    } else {
+      await handle.close()
+    }
   }
 }
 
@@ -631,6 +639,7 @@ export async function followLogFile(
             ...options,
             output,
             signal: cleanupController.signal,
+            continueOnFileError: true,
           })
           position = result.position
           if (!result.outputOpen) cleanup()
@@ -766,7 +775,14 @@ export async function logsHandler(
     fail(`Log file does not exist: ${logPath}`)
   }
 
-  const offset = await printExistingLog(logPath)
+  let offset: number
+  try {
+    offset = await printExistingLog(logPath, {
+      continueOnFileError: parsed.follow,
+    })
+  } catch (error) {
+    fail(`Failed to read log file: ${errorMessage(error)}`)
+  }
   if (parsed.follow) {
     await followLogFile(logPath, offset)
   }

--- a/src/cli/bg.ts
+++ b/src/cli/bg.ts
@@ -1,7 +1,7 @@
 import { spawn } from 'node:child_process'
 import { randomUUID } from 'node:crypto'
 import { closeSync, openSync } from 'node:fs'
-import { open, readFile, unlink } from 'node:fs/promises'
+import { open, unlink } from 'node:fs/promises'
 import { basename } from 'node:path'
 import treeKill from 'tree-kill'
 import { argsBeforeDelimiter } from '../utils/cliArgs.js'
@@ -58,6 +58,49 @@ const HEAP_RELAUNCHED_ENV = 'OPENCLAUDE_HEAP_RELAUNCHED'
 const DEFAULT_TERM_GRACE_MS = 2_000
 const DEFAULT_KILL_GRACE_MS = 2_000
 const DEFAULT_KILL_POLL_INTERVAL_MS = 100
+// Each background-log read buffer is capped at 64 KiB to avoid whole-log allocations.
+export const LOG_STREAM_CHUNK_SIZE = 64 * 1024
+const LOG_FOLLOW_POLL_INTERVAL_MS = 500
+
+type LogOutput = {
+  destroyed?: boolean
+  writableDestroyed?: boolean
+  write(chunk: Uint8Array): boolean
+  once(event: string, listener: (...args: unknown[]) => void): unknown
+  off(event: string, listener: (...args: unknown[]) => void): unknown
+}
+
+type LogFileHandle = {
+  close(): Promise<void>
+  stat(): Promise<{ size: number }>
+  read(
+    buffer: Buffer,
+    offset: number,
+    length: number,
+    position: number,
+  ): Promise<{ bytesRead: number }>
+}
+
+type LogFollowTimer = ReturnType<typeof setInterval> | number
+
+type StreamLogOptions = {
+  output?: LogOutput
+  chunkSize?: number
+  createBuffer?: (size: number) => Buffer
+  signal?: AbortSignal
+  openFile?: (path: string, flags: 'r') => Promise<LogFileHandle>
+}
+
+type FollowLogOptions = StreamLogOptions & {
+  pollIntervalMs?: number
+  setInterval?: (callback: () => void, ms: number) => LogFollowTimer
+  clearInterval?: (timer: LogFollowTimer) => void
+}
+
+type StreamLogResult = {
+  position: number
+  outputOpen: boolean
+}
 
 // This must stay in sync with value-consuming CLI flags in main.tsx and related
 // handlers. If the CLI flag definitions become centralized, move this parser
@@ -410,56 +453,189 @@ function printSessionTable(
   }
 }
 
-async function printExistingLog(path: string): Promise<number> {
+function isOutputClosed(output: LogOutput): boolean {
+  return output.destroyed === true || output.writableDestroyed === true
+}
+
+function normalizeChunkSize(chunkSize: number | undefined): number {
+  if (!Number.isFinite(chunkSize) || !chunkSize || chunkSize < 1) {
+    return LOG_STREAM_CHUNK_SIZE
+  }
+  return Math.floor(chunkSize)
+}
+
+async function waitForDrain(
+  output: LogOutput,
+  signal: AbortSignal | undefined,
+): Promise<boolean> {
+  if (signal?.aborted || isOutputClosed(output)) return false
+
+  return await new Promise<boolean>(resolve => {
+    let settled = false
+
+    const cleanup = () => {
+      output.off('drain', onDrain)
+      output.off('error', onError)
+      output.off('close', onClose)
+      signal?.removeEventListener('abort', onAbort)
+    }
+    const finish = (open: boolean) => {
+      if (settled) return
+      settled = true
+      cleanup()
+      resolve(open)
+    }
+
+    const onDrain = () => finish(!isOutputClosed(output))
+    const onError = () => finish(false)
+    const onClose = () => finish(false)
+    const onAbort = () => finish(false)
+
+    output.once('drain', onDrain)
+    output.once('error', onError)
+    output.once('close', onClose)
+    signal?.addEventListener('abort', onAbort, { once: true })
+  })
+}
+
+async function writeLogBuffer(
+  output: LogOutput,
+  buffer: Buffer,
+  signal: AbortSignal | undefined,
+): Promise<boolean> {
+  if (buffer.length === 0) return true
+  if (signal?.aborted || isOutputClosed(output)) return false
+
   try {
-    const contents = await readFile(path)
-    if (contents.length > 0) process.stdout.write(contents)
-    return contents.length
+    if (output.write(buffer)) return !isOutputClosed(output)
   } catch {
-    return 0
+    return false
+  }
+
+  return await waitForDrain(output, signal)
+}
+
+async function streamLogRange(
+  handle: LogFileHandle,
+  start: number,
+  endExclusive: number,
+  options: StreamLogOptions,
+): Promise<StreamLogResult> {
+  const output = options.output ?? process.stdout
+  const chunkSize = normalizeChunkSize(options.chunkSize)
+  const createBuffer = options.createBuffer ?? Buffer.allocUnsafe
+  let position = start
+
+  while (position < endExclusive) {
+    if (options.signal?.aborted) return { position, outputOpen: false }
+    const bytesToRead = Math.min(chunkSize, endExclusive - position)
+    const buffer = createBuffer(bytesToRead)
+    if (buffer.length < bytesToRead) {
+      throw new Error('Log stream buffer factory returned a short buffer')
+    }
+
+    const { bytesRead } = await handle.read(
+      buffer,
+      0,
+      bytesToRead,
+      position,
+    )
+    if (bytesRead <= 0) break
+    if (options.signal?.aborted) return { position, outputOpen: false }
+
+    const chunk =
+      bytesRead === buffer.length ? buffer : buffer.subarray(0, bytesRead)
+    if (!(await writeLogBuffer(output, chunk, options.signal))) {
+      return { position, outputOpen: false }
+    }
+    position += bytesRead
+  }
+
+  return { position, outputOpen: true }
+}
+
+async function streamLogSnapshot(
+  path: string,
+  offset: number,
+  options: StreamLogOptions,
+): Promise<StreamLogResult> {
+  try {
+    const handle = await (options.openFile ?? open)(path, 'r')
+    try {
+      const { size } = await handle.stat()
+      const start = size < offset ? 0 : offset
+      if (size <= start) return { position: start, outputOpen: true }
+      return await streamLogRange(handle, start, size, options)
+    } finally {
+      await handle.close()
+    }
+  } catch {
+    // Keep following; the child may create or rotate the file later.
+    return { position: offset, outputOpen: true }
   }
 }
 
-async function followLogFile(path: string, offset: number): Promise<void> {
+export async function printExistingLog(
+  path: string,
+  options: StreamLogOptions = {},
+): Promise<number> {
+  const result = await streamLogSnapshot(path, 0, options)
+  return result.position
+}
+
+export async function followLogFile(
+  path: string,
+  offset: number,
+  options: FollowLogOptions = {},
+): Promise<void> {
+  const output = options.output ?? process.stdout
+  const cleanupController = new AbortController()
   let position = offset
   let reading = false
+  let stopped = false
+  let timer: LogFollowTimer | undefined
 
   await new Promise<void>(resolve => {
     const cleanup = () => {
-      clearInterval(timer)
+      if (stopped) return
+      stopped = true
+      if (timer) (options.clearInterval ?? clearInterval)(timer)
+      cleanupController.abort()
       process.off('SIGINT', cleanup)
       process.off('SIGTERM', cleanup)
+      options.signal?.removeEventListener('abort', cleanup)
       resolve()
     }
 
-    const timer = setInterval(() => {
-      if (reading) return
+    const poll = () => {
+      if (stopped || reading) return
       reading = true
       void (async () => {
         try {
-          const handle = await open(path, 'r')
-          try {
-            const { size } = await handle.stat()
-            if (size < position) position = 0
-            if (size > position) {
-              const buffer = Buffer.alloc(size - position)
-              await handle.read(buffer, 0, buffer.length, position)
-              position = size
-              process.stdout.write(buffer)
-            }
-          } finally {
-            await handle.close()
-          }
-        } catch {
-          // Keep following; the child may create or rotate the file later.
+          const result = await streamLogSnapshot(path, position, {
+            ...options,
+            output,
+            signal: cleanupController.signal,
+          })
+          position = result.position
+          if (!result.outputOpen) cleanup()
         } finally {
           reading = false
         }
       })()
-    }, 500)
+    }
 
     process.once('SIGINT', cleanup)
     process.once('SIGTERM', cleanup)
+    if (options.signal?.aborted) {
+      cleanup()
+      return
+    }
+    options.signal?.addEventListener('abort', cleanup, { once: true })
+    timer = (options.setInterval ?? setInterval)(
+      poll,
+      options.pollIntervalMs ?? LOG_FOLLOW_POLL_INTERVAL_MS,
+    )
   })
 }
 


### PR DESCRIPTION
## Summary

- Replace `openclaude logs` whole-file output with bounded byte streaming.
- Replace `openclaude logs -f` whole-unread-range allocation with bounded appended-range streaming.
- Add focused coverage for large logs, follow ordering, backpressure, truncation, temporary disappearance, cleanup, broken stdout, and parsing.

Previously, non-follow mode used `readFile(path)` for the selected log, and follow mode allocated `Buffer.alloc(size - position)` for all unread data in one poll. Both allocations scaled directly with log size or growth since the last poll.

The new path snapshots file size per read pass and streams with `FileHandle.read` in chunks capped at `LOG_STREAM_CHUNK_SIZE` (`64 KiB`). If `stdout.write()` returns `false`, streaming waits for `drain` before reading or writing more. Destroyed stdout or write-side failures such as EPIPE are treated as closed output so follow mode stops cleanly instead of retrying.

## Impact

- user-facing impact: users can inspect or follow very large background-session stdout/stderr logs without avoidable memory spikes while debugging long-running tasks.
- developer/maintainer impact: behavior remains scoped to the background-session CLI and is covered by deterministic tests without new dependencies or CLI flags.

## Risk Surface

- signal handling: follow mode uses signal-triggered cleanup to clear polling, abort in-flight work, and prevent writes after cleanup.
- resource cleanup: file handles are closed after each snapshot; follow-mode rotation/disappearance paths tolerate transient file errors without retry loops.
- stream errors: stdout backpressure waits for drain, and destroyed output or EPIPE is treated as closed output.
- regression coverage: focused tests cover cleanup, backpressure, truncation, temporary disappearance, EPIPE/destroyed stdout, and non-follow file I/O failures.

## Testing

- [x] `bun run build`
- [x] `bun run smoke`
- [ ] `bun run check` (not run; the requested focused and PR-hygiene checks below were run)
- [x] focused tests: `bun test src/cli/bg.test.ts`
- [x] `bun run typecheck`
- [x] `bun run security:pr-scan`
- [x] `git diff --check`

## Notes

- provider/model path tested: not applicable.
- screenshots attached: not applicable; CLI log output behavior only.
- follow-up work or known limitations: none.
- Contribution guidance reviewed: `AGENTS.md` and `CONTRIBUTING.md`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Background log streaming now outputs logs via bounded chunk reads with configurable chunk sizing, improving responsiveness for large log files.

* **Bug Fixes**
  * Follow mode is more robust: it streams “existing + appended” exactly once and in order, correctly handles truncation/rotation, tolerates temporary missing log files, coordinates shutdown to stop cleanly, and avoids writing after stream closure or abort (including backpressure/broken-pipe cases).

* **Tests**
  * Expanded end-to-end coverage for log streaming and follow behavior, plus improved CLI parsing checks for `follow`/`stream` interactions with `--stdout`/`--stderr`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
