### PR TITLE
fix: register JSON Schema draft 2020-12 support for MCP tool validation

### DIFF
--- a/src/tools/MCPTool/MCPTool.ts
+++ b/src/tools/MCPTool/MCPTool.ts
@@ -41,8 +41,8 @@ export type Output = z.infer<OutputSchema>
 // Re-export MCPProgress from centralized types to break import cycles
 export type { MCPProgress } from '../../types/tools.js'
 
-const draft7Ajv = new Ajv({ strict: false })
-const draft202012Ajv = new Ajv2020({ strict: false })
+const draft7Ajv = new Ajv({ strict: false, validateSchema: false })
+const draft202012Ajv = new Ajv2020({ strict: false, validateSchema: false })
 
 type CompiledValidator = {
   validate: ValidateFunction

--- a/src/tools/SyntheticOutputTool/SyntheticOutputTool.ts
+++ b/src/tools/SyntheticOutputTool/SyntheticOutputTool.ts
@@ -1,4 +1,4 @@
-import { Ajv } from 'ajv'
+import Ajv2020 from 'ajv/dist/2020.js'
 import { z } from 'zod/v4'
 import type { Tool, ToolInputJSONSchema } from '../../Tool.js'
 import { buildTool, type ToolDef } from '../../Tool.js'
@@ -155,7 +155,7 @@ function buildSyntheticOutputTool(
   jsonSchema: Record<string, unknown>,
 ): CreateResult {
   try {
-    const ajv = new Ajv({ allErrors: true })
+    const ajv = new Ajv2020({ allErrors: true })
     const isValidSchema = ajv.validateSchema(jsonSchema)
     if (!isValidSchema) {
       return { error: ajv.errorsText(ajv.errors) }


### PR DESCRIPTION
## Summary

MCP plugin tools with typed parameters (numbers, enums, objects) fail with:

> Failed to compile JSON schema for validation: no schema with key or ref \https://json-schema.org/draft/2020-12/schema\

AJV's `compile()` internally calls `validateSchema()` which checks the schema against its meta-schema. When the 2020-12 meta-schema can't be resolved — due to Bun bundler not including AJV's meta-schema JSON files, URI scheme variants (`http` vs `https`), or `$schema` references in sub-schemas — it throws `MissingRefError`.

### Fix

- **`src/tools/MCPTool/MCPTool.ts`**: Set `validateSchema: false` on both `Ajv` (draft-07) and `Ajv2020` instances. This skips the unnecessary meta-schema conformance check — MCP tool schemas come from the server and only need data validation, not schema-against-meta-schema validation.
- **`src/tools/SyntheticOutputTool/SyntheticOutputTool.ts`**: Switch from base `Ajv` (draft-07 only) to `Ajv2020` for consistent draft-2020-12 support.

### Verification

- `bun test src/tools/MCPTool/MCPTool.test.ts` — 18/18 pass
- `bun test src/tools/SyntheticOutputTool/SyntheticOutputTool.test.ts` — 5/5 pass
- `bun run build` ✓
- `bun run typecheck` ✓

Closes #1756

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated JSON schema validation configuration for internal tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->