### PR TITLE
fix(copilot): auto-refresh Copilot token on 401 instead of only showing re-auth hint

### DIFF
--- a/src/services/api/openaiShim.test.ts
+++ b/src/services/api/openaiShim.test.ts
@@ -8126,3 +8126,53 @@ test('GitHub Copilot 401 codex_responses with providerOverride does not trigger 
     mock.module('../../utils/githubModelsCredentials.js', () => realGithubModule)
   }
 })
+
+test('GitHub Copilot 401 chat_completions with providerOverride does not trigger refresh', async () => {
+  const realGithubModule = realGithubModelsCredentials
+  try {
+    const refreshSpy = mock(async () => {
+      process.env.GITHUB_TOKEN = 'refreshed-token'
+      process.env.OPENAI_API_KEY = 'refreshed-token'
+      return true
+    })
+
+    mock.module('../../utils/githubModelsCredentials.js', () => ({
+      ...realGithubModule,
+      refreshCopilotTokenOn401: refreshSpy,
+    }))
+
+    process.env.CLAUDE_CODE_USE_GITHUB = '1'
+    process.env.OPENAI_BASE_URL = 'https://api.githubcopilot.com'
+    process.env.OPENAI_API_KEY = 'stored-copilot-token'
+    process.env.GITHUB_TOKEN = 'stored-copilot-token'
+
+    globalThis.fetch = (() =>
+      Promise.resolve(
+        new Response(
+          JSON.stringify({ error: { message: 'token expired' } }),
+          { status: 401, headers: { 'Content-Type': 'application/json' } },
+        ),
+      )) as unknown as typeof globalThis.fetch
+
+    const { createOpenAIShimClient: createClient } =
+      await importFreshOpenAIShim('copilot-401-override-chat')
+
+    // providerOverride.apiKey differs from OPENAI_API_KEY → credential source gate blocks refresh
+    const client = createClient({
+      providerOverride: { model: 'gpt-4', baseURL: 'https://api.githubcopilot.com', apiKey: 'override-token' },
+    }) as OpenAIShimClient
+
+    await expect(
+      client.beta.messages.create({
+        model: 'gpt-4',
+        messages: [{ role: 'user', content: 'hello' }],
+        max_tokens: 32,
+        stream: false,
+      }),
+    ).rejects.toThrow()
+
+    expect(refreshSpy).toHaveBeenCalledTimes(0)
+  } finally {
+    mock.module('../../utils/githubModelsCredentials.js', () => realGithubModule)
+  }
+})

--- a/src/services/api/openaiShim.test.ts
+++ b/src/services/api/openaiShim.test.ts
@@ -5,6 +5,7 @@ import { _clearRegistryForTesting, ensureIntegrationsLoaded, registerGateway } f
 import { applyProviderFlag } from '../../utils/providerFlag.ts'
 import { applyProviderProfileToProcessEnv } from '../../utils/providerProfiles.ts'
 import { createOpenAIShimClient } from './openaiShim.ts'
+import * as realGithubModelsCredentials from '../../utils/githubModelsCredentials.js'
 
 type FetchType = typeof globalThis.fetch
 
@@ -96,6 +97,12 @@ function makeStreamChunks(chunks: unknown[]): string[] {
     ...chunks.map(chunk => `data: ${JSON.stringify(chunk)}\n\n`),
     'data: [DONE]\n\n',
   ]
+}
+
+function importFreshOpenAIShim(
+  cacheKey: string,
+): Promise<typeof import('./openaiShim.ts')> {
+  return import(`./openaiShim.ts?${cacheKey}`)
 }
 
 function makeChatCompletionResponse(model: string): Response {
@@ -7690,4 +7697,74 @@ test('renders tool_reference blocks as text on the chat/completions path', async
   const content = toolMsg!.content as string
   expect(content).toContain('mcp__example__memory_search')
   expect(content).toContain('mcp__example__memory_store')
+})
+
+test('GitHub Copilot 401 chat_completions retries with refreshed token', async () => {
+  const realModule = realGithubModelsCredentials
+  try {
+    const refreshSpy = mock(async () => {
+      process.env.GITHUB_TOKEN = 'refreshed-token'
+      process.env.OPENAI_API_KEY = 'refreshed-token'
+      return true
+    })
+
+    mock.module('../../utils/githubModelsCredentials.js', () => ({
+      ...realModule,
+      refreshCopilotTokenOn401: refreshSpy,
+    }))
+
+    process.env.CLAUDE_CODE_USE_GITHUB = '1'
+    process.env.OPENAI_BASE_URL = 'https://api.githubcopilot.com'
+    process.env.OPENAI_API_KEY = 'initial-token'
+    process.env.GITHUB_TOKEN = 'initial-token'
+
+    let fetchCallCount = 0
+    let firstAuth: string | undefined
+    let secondAuth: string | undefined
+
+    globalThis.fetch = ((_input, init) => {
+      fetchCallCount++
+      const headers = init?.headers as Record<string, string> | undefined
+      const auth = headers?.Authorization
+
+      if (fetchCallCount === 1) {
+        firstAuth = auth
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({ error: { message: 'token expired' } }),
+            { status: 401, headers: { 'Content-Type': 'application/json' } },
+          ),
+        )
+      }
+
+      if (fetchCallCount === 2) {
+        secondAuth = auth
+        return Promise.resolve(makeChatCompletionResponse('gpt-4'))
+      }
+
+      throw new Error(`unexpected fetch call #${fetchCallCount}`)
+    }) as unknown as typeof globalThis.fetch
+
+    const { createOpenAIShimClient: createClient } =
+      await importFreshOpenAIShim('copilot-401-retry')
+
+    const client = createClient({}) as OpenAIShimClient
+
+    const response = await client.beta.messages.create({
+      model: 'gpt-4',
+      messages: [{ role: 'user', content: 'hello' }],
+      max_tokens: 32,
+      stream: false,
+    })
+
+    expect(refreshSpy).toHaveBeenCalledTimes(1)
+    expect(process.env.GITHUB_TOKEN).toBe('refreshed-token')
+    expect(process.env.OPENAI_API_KEY).toBe('refreshed-token')
+    expect(fetchCallCount).toBe(2)
+    expect(firstAuth).toBe('Bearer initial-token')
+    expect(secondAuth).toBe('Bearer refreshed-token')
+    expect(response).toBeDefined()
+  } finally {
+    mock.module('../../utils/githubModelsCredentials.js', () => realModule)
+  }
 })

--- a/src/services/api/openaiShim.test.ts
+++ b/src/services/api/openaiShim.test.ts
@@ -7852,3 +7852,226 @@ test('GitHub Copilot 401 codex_responses retries with refreshed token', async ()
     mock.module('./codexShim.js', () => realCodexModule)
   }
 })
+
+test('GitHub Copilot 401 with credential pool uses refreshed token not pool key', async () => {
+  const realGithubModule = realGithubModelsCredentials
+  try {
+    const refreshSpy = mock(async () => {
+      process.env.GITHUB_TOKEN = 'refreshed-token'
+      process.env.OPENAI_API_KEY = 'refreshed-token'
+      return true
+    })
+
+    mock.module('../../utils/githubModelsCredentials.js', () => ({
+      ...realGithubModule,
+      refreshCopilotTokenOn401: refreshSpy,
+    }))
+
+    process.env.CLAUDE_CODE_USE_GITHUB = '1'
+    process.env.OPENAI_BASE_URL = 'https://api.githubcopilot.com'
+    delete process.env.OPENAI_API_KEY
+    process.env.OPENAI_API_KEYS = 'initial-token,second-key'
+    process.env.GITHUB_TOKEN = 'initial-token'
+
+    let fetchCallCount = 0
+    let usedAuthHeaders: string[] = []
+
+    globalThis.fetch = ((_input, init) => {
+      fetchCallCount++
+      const headers = init?.headers as Record<string, string> | undefined
+      usedAuthHeaders.push(headers?.Authorization ?? '')
+
+      if (fetchCallCount === 1) {
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({ error: { message: 'token expired' } }),
+            { status: 401, headers: { 'Content-Type': 'application/json' } },
+          ),
+        )
+      }
+
+      return Promise.resolve(makeChatCompletionResponse('gpt-4'))
+    }) as unknown as typeof globalThis.fetch
+
+    const { createOpenAIShimClient: createClient } =
+      await importFreshOpenAIShim('copilot-401-pool')
+
+    const client = createClient({}) as OpenAIShimClient
+
+    const response = await client.beta.messages.create({
+      model: 'gpt-4',
+      messages: [{ role: 'user', content: 'hello' }],
+      max_tokens: 32,
+      stream: false,
+    })
+
+    expect(refreshSpy).toHaveBeenCalledTimes(1)
+    expect(fetchCallCount).toBe(2)
+    expect(usedAuthHeaders[0]).toBe('Bearer initial-token')
+    expect(usedAuthHeaders[1]).toBe('Bearer refreshed-token')
+    expect(response).toBeDefined()
+  } finally {
+    mock.module('../../utils/githubModelsCredentials.js', () => realGithubModule)
+  }
+})
+
+test('GitHub Copilot 401 with "token has expired" triggers refresh', async () => {
+  const realGithubModule = realGithubModelsCredentials
+  try {
+    const refreshSpy = mock(async () => {
+      process.env.GITHUB_TOKEN = 'refreshed-token'
+      process.env.OPENAI_API_KEY = 'refreshed-token'
+      return true
+    })
+
+    mock.module('../../utils/githubModelsCredentials.js', () => ({
+      ...realGithubModule,
+      refreshCopilotTokenOn401: refreshSpy,
+    }))
+
+    process.env.CLAUDE_CODE_USE_GITHUB = '1'
+    process.env.OPENAI_BASE_URL = 'https://api.githubcopilot.com'
+    process.env.OPENAI_API_KEY = 'initial-token'
+    process.env.GITHUB_TOKEN = 'initial-token'
+
+    let fetchCallCount = 0
+
+    globalThis.fetch = ((_input, init) => {
+      fetchCallCount++
+
+      if (fetchCallCount === 1) {
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({ error: { message: 'token has expired' } }),
+            { status: 401, headers: { 'Content-Type': 'application/json' } },
+          ),
+        )
+      }
+
+      return Promise.resolve(makeChatCompletionResponse('gpt-4'))
+    }) as unknown as typeof globalThis.fetch
+
+    const { createOpenAIShimClient: createClient } =
+      await importFreshOpenAIShim('copilot-401-has-expired')
+
+    const client = createClient({}) as OpenAIShimClient
+
+    const response = await client.beta.messages.create({
+      model: 'gpt-4',
+      messages: [{ role: 'user', content: 'hello' }],
+      max_tokens: 32,
+      stream: false,
+    })
+
+    expect(refreshSpy).toHaveBeenCalledTimes(1)
+    expect(fetchCallCount).toBe(2)
+    expect(response).toBeDefined()
+  } finally {
+    mock.module('../../utils/githubModelsCredentials.js', () => realGithubModule)
+  }
+})
+
+test('GitHub Copilot 401 without expired-token message does not trigger refresh', async () => {
+  const realGithubModule = realGithubModelsCredentials
+  try {
+    const refreshSpy = mock(async () => true)
+
+    mock.module('../../utils/githubModelsCredentials.js', () => ({
+      ...realGithubModule,
+      refreshCopilotTokenOn401: refreshSpy,
+    }))
+
+    process.env.CLAUDE_CODE_USE_GITHUB = '1'
+    process.env.OPENAI_BASE_URL = 'https://api.githubcopilot.com'
+    process.env.OPENAI_API_KEY = 'initial-token'
+    process.env.GITHUB_TOKEN = 'initial-token'
+
+    let fetchCallCount = 0
+
+    globalThis.fetch = ((_input) => {
+      fetchCallCount++
+      return Promise.resolve(
+        new Response(
+          JSON.stringify({ error: { message: 'invalid token' } }),
+          { status: 401, headers: { 'Content-Type': 'application/json' } },
+        ),
+      )
+    }) as unknown as typeof globalThis.fetch
+
+    const { createOpenAIShimClient: createClient } =
+      await importFreshOpenAIShim('copilot-401-no-refresh')
+
+    const client = createClient({}) as OpenAIShimClient
+
+    await expect(
+      client.beta.messages.create({
+        model: 'gpt-4',
+        messages: [{ role: 'user', content: 'hello' }],
+        max_tokens: 32,
+        stream: false,
+      }),
+    ).rejects.toThrow()
+
+    expect(refreshSpy).toHaveBeenCalledTimes(0)
+    expect(fetchCallCount).toBe(1)
+  } finally {
+    mock.module('../../utils/githubModelsCredentials.js', () => realGithubModule)
+  }
+})
+
+test('GitHub Copilot 401 refresh returning same token does not update auth', async () => {
+  const realGithubModule = realGithubModelsCredentials
+  try {
+    const refreshSpy = mock(async () => {
+      process.env.GITHUB_TOKEN = 'initial-token'
+      process.env.OPENAI_API_KEY = 'initial-token'
+      return true
+    })
+
+    mock.module('../../utils/githubModelsCredentials.js', () => ({
+      ...realGithubModule,
+      refreshCopilotTokenOn401: refreshSpy,
+    }))
+
+    process.env.CLAUDE_CODE_USE_GITHUB = '1'
+    process.env.OPENAI_BASE_URL = 'https://api.githubcopilot.com'
+    process.env.OPENAI_API_KEY = 'initial-token'
+    process.env.GITHUB_TOKEN = 'initial-token'
+
+    let fetchCallCount = 0
+    let usedAuthHeaders: string[] = []
+
+    globalThis.fetch = ((_input, init) => {
+      fetchCallCount++
+      const headers = init?.headers as Record<string, string> | undefined
+      usedAuthHeaders.push(headers?.Authorization ?? '')
+
+      return Promise.resolve(
+        new Response(
+          JSON.stringify({ error: { message: 'token expired' } }),
+          { status: 401, headers: { 'Content-Type': 'application/json' } },
+        ),
+      )
+    }) as unknown as typeof globalThis.fetch
+
+    const { createOpenAIShimClient: createClient } =
+      await importFreshOpenAIShim('copilot-401-same-token')
+
+    const client = createClient({}) as OpenAIShimClient
+
+    await expect(
+      client.beta.messages.create({
+        model: 'gpt-4',
+        messages: [{ role: 'user', content: 'hello' }],
+        max_tokens: 32,
+        stream: false,
+      }),
+    ).rejects.toThrow()
+
+    expect(refreshSpy).toHaveBeenCalledTimes(1)
+    expect(fetchCallCount).toBeGreaterThanOrEqual(2)
+    expect(usedAuthHeaders.every(h => h === 'Bearer initial-token')).toBe(true)
+  } finally {
+    mock.module('../../utils/githubModelsCredentials.js', () => realGithubModule)
+  }
+})

--- a/src/services/api/openaiShim.test.ts
+++ b/src/services/api/openaiShim.test.ts
@@ -1,3 +1,4 @@
+import { APIError } from '@anthropic-ai/sdk'
 import { afterEach, beforeEach, expect, mock, test } from 'bun:test'
 import { acquireSharedMutationLock, releaseSharedMutationLock } from '../../test/sharedMutationLock.js'
 import { asMockFetch } from '../../test/typedMocks.js'
@@ -5,6 +6,7 @@ import { _clearRegistryForTesting, ensureIntegrationsLoaded, registerGateway } f
 import { applyProviderFlag } from '../../utils/providerFlag.ts'
 import { applyProviderProfileToProcessEnv } from '../../utils/providerProfiles.ts'
 import { createOpenAIShimClient } from './openaiShim.ts'
+import * as realCodexShim from './codexShim.js'
 import * as realGithubModelsCredentials from '../../utils/githubModelsCredentials.js'
 
 type FetchType = typeof globalThis.fetch
@@ -7699,6 +7701,11 @@ test('renders tool_reference blocks as text on the chat/completions path', async
   expect(content).toContain('mcp__example__memory_store')
 })
 
+function makeCodexSseResponse(responseData: Record<string, unknown>): Response {
+  const data = JSON.stringify(responseData)
+  return makeSseResponse([`event: response.completed\ndata: ${data}\n\n`])
+}
+
 test('GitHub Copilot 401 chat_completions retries with refreshed token', async () => {
   const realModule = realGithubModelsCredentials
   try {
@@ -7766,5 +7773,82 @@ test('GitHub Copilot 401 chat_completions retries with refreshed token', async (
     expect(response).toBeDefined()
   } finally {
     mock.module('../../utils/githubModelsCredentials.js', () => realModule)
+  }
+})
+
+test('GitHub Copilot 401 codex_responses retries with refreshed token', async () => {
+  const realGithubModule = realGithubModelsCredentials
+  const realCodexModule = realCodexShim
+  try {
+    const refreshSpy = mock(async () => {
+      process.env.GITHUB_TOKEN = 'refreshed-token'
+      process.env.OPENAI_API_KEY = 'refreshed-token'
+      return true
+    })
+
+    mock.module('../../utils/githubModelsCredentials.js', () => ({
+      ...realGithubModule,
+      refreshCopilotTokenOn401: refreshSpy,
+    }))
+
+    let codexCallCount = 0
+    let firstAuth: string | undefined
+    let secondAuth: string | undefined
+
+    mock.module('./codexShim.js', () => ({
+      ...realCodexModule,
+      performCodexRequest: mock(async (opts: { credentials: { apiKey: string } }) => {
+        codexCallCount++
+        const apiKey = opts.credentials?.apiKey
+
+        if (codexCallCount === 1) {
+          firstAuth = apiKey
+          throw APIError.generate(401, undefined, 'token expired', new Headers())
+        }
+
+        if (codexCallCount === 2) {
+          secondAuth = apiKey
+          return makeCodexSseResponse({
+            response: {
+              id: 'resp_test',
+              output: [{ type: 'message', content: [{ type: 'output_text', text: 'ok' }] }],
+              model: 'gpt-5',
+              usage: { input_tokens: 10, output_tokens: 5 },
+            },
+          })
+        }
+
+        throw new Error(`unexpected codex call #${codexCallCount}`)
+      }),
+    }))
+
+    process.env.CLAUDE_CODE_USE_GITHUB = '1'
+    process.env.OPENAI_BASE_URL = 'https://api.githubcopilot.com'
+    process.env.OPENAI_API_KEY = 'initial-token'
+    process.env.GITHUB_TOKEN = 'initial-token'
+
+    const { createOpenAIShimClient: createClient } =
+      await importFreshOpenAIShim('copilot-401-retry-codex')
+
+    const client = createClient({}) as OpenAIShimClient
+
+    const response = await client.beta.messages.create({
+      model: 'gpt-5',
+      messages: [{ role: 'user', content: 'hello' }],
+      max_tokens: 32,
+      stream: false,
+    })
+
+    expect(refreshSpy).toHaveBeenCalledTimes(1)
+    expect(process.env.GITHUB_TOKEN).toBe('refreshed-token')
+    expect(process.env.OPENAI_API_KEY).toBe('refreshed-token')
+    expect(codexCallCount).toBe(2)
+    expect(firstAuth).toBe('initial-token')
+    expect(secondAuth).toBe('refreshed-token')
+    expect(response).toBeDefined()
+    expect((response as Record<string, unknown>).content).toBeDefined()
+  } finally {
+    mock.module('../../utils/githubModelsCredentials.js', () => realGithubModule)
+    mock.module('./codexShim.js', () => realCodexModule)
   }
 })

--- a/src/services/api/openaiShim.test.ts
+++ b/src/services/api/openaiShim.test.ts
@@ -8075,3 +8075,54 @@ test('GitHub Copilot 401 refresh returning same token does not update auth', asy
     mock.module('../../utils/githubModelsCredentials.js', () => realGithubModule)
   }
 })
+
+test('GitHub Copilot 401 codex_responses with providerOverride does not trigger refresh', async () => {
+  const realGithubModule = realGithubModelsCredentials
+  try {
+    const refreshSpy = mock(async () => {
+      process.env.GITHUB_TOKEN = 'refreshed-token'
+      process.env.OPENAI_API_KEY = 'refreshed-token'
+      return true
+    })
+
+    mock.module('../../utils/githubModelsCredentials.js', () => ({
+      ...realGithubModule,
+      refreshCopilotTokenOn401: refreshSpy,
+    }))
+
+    process.env.CLAUDE_CODE_USE_GITHUB = '1'
+    process.env.OPENAI_BASE_URL = 'https://api.githubcopilot.com'
+    process.env.OPENAI_API_KEY = 'stored-copilot-token'
+    process.env.GITHUB_TOKEN = 'stored-copilot-token'
+
+    // Mock fetch so performCodexRequest gets a 401 response (no codexShim mock needed)
+    globalThis.fetch = (() =>
+      Promise.resolve(
+        new Response(
+          JSON.stringify({ error: { message: 'token expired' } }),
+          { status: 401, headers: { 'Content-Type': 'application/json' } },
+        ),
+      )) as unknown as typeof globalThis.fetch
+
+    const { createOpenAIShimClient: createClient } =
+      await importFreshOpenAIShim('copilot-401-override-codex')
+
+    // providerOverride.apiKey differs from OPENAI_API_KEY → credential source gate blocks refresh
+    const client = createClient({
+      providerOverride: { model: 'gpt-5', baseURL: 'https://api.githubcopilot.com', apiKey: 'override-token' },
+    }) as OpenAIShimClient
+
+    await expect(
+      client.beta.messages.create({
+        model: 'gpt-5',
+        messages: [{ role: 'user', content: 'hello' }],
+        max_tokens: 32,
+        stream: false,
+      }),
+    ).rejects.toThrow()
+
+    expect(refreshSpy).toHaveBeenCalledTimes(0)
+  } finally {
+    mock.module('../../utils/githubModelsCredentials.js', () => realGithubModule)
+  }
+})

--- a/src/services/api/openaiShim.ts
+++ b/src/services/api/openaiShim.ts
@@ -2348,7 +2348,8 @@ class OpenAIShimMessages {
   ): Promise<Response> {
     const githubEndpointType = getGithubEndpointType(request.baseUrl)
     const isGithubMode = isGithubModelsMode()
-    const isGithubWithCodexTransport = isGithubMode && request.transport === 'codex_responses'
+    const isGithubCopilotEndpoint = isGithubMode && (githubEndpointType === 'copilot' || githubEndpointType === 'ghe')
+    const isGithubWithCodexTransport = isGithubCopilotEndpoint && request.transport === 'codex_responses'
 
     if (isGithubWithCodexTransport) {
       let didRefreshCopilotCodexToken = false

--- a/src/services/api/openaiShim.ts
+++ b/src/services/api/openaiShim.ts
@@ -40,7 +40,10 @@ import { logForDebugging } from '../../utils/debug.js'
 import { isBareMode, isEnvTruthy } from '../../utils/envUtils.js'
 import { resolveGeminiCredential } from '../../utils/geminiAuth.js'
 import { hydrateGeminiAccessTokenFromSecureStorage } from '../../utils/geminiCredentials.js'
-import { hydrateGithubModelsTokenFromSecureStorage } from '../../utils/githubModelsCredentials.js'
+import {
+  hydrateGithubModelsTokenFromSecureStorage,
+  refreshCopilotTokenOn401,
+} from '../../utils/githubModelsCredentials.js'
 import { resolveXaiAccessToken } from '../../utils/xaiCredentials.js'
 import { resolveOpenAIShimRuntimeContext } from '../../integrations/runtimeMetadata.js'
 import {
@@ -3002,7 +3005,7 @@ class OpenAIShimMessages {
       const authValue =
         explicitCustomAuthHeaderValue ||
         credentialLease?.value ||
-        (credentialPool ? '' : singleAuthValue)
+        (credentialPool ? '' : refreshedCopilotToken || singleAuthValue)
 
       if (authValue) {
         if (hasCustomAuthHeader && customAuthHeader) {
@@ -3100,6 +3103,8 @@ class OpenAIShimMessages {
     let requestUrl = buildRequestUrl(activeBaseUrl)
     const attemptedLocalBaseUrls = new Set<string>([activeBaseUrl])
     let didRetryWithoutTools = false
+    let didRefreshCopilotToken = false
+    let refreshedCopilotToken: string | undefined
 
     const promoteNextLocalBaseUrl = (
       reason: 'endpoint_not_found' | 'localhost_resolution_failed',
@@ -3443,6 +3448,29 @@ class OpenAIShimMessages {
         body: errorBody,
         hasImages: bodyContainsImages(),
       })
+
+      // GitHub Copilot 401 with expired token: force-refresh and retry once.
+      // Only applies to the Copilot endpoint, not GitHub Models API or custom
+      // routes, and only when the failing credential is the stored Copilot
+      // token (not a provider override, route credential, or custom auth).
+      // The refreshed token is stored in refreshedCopilotToken so the next
+      // iteration's buildHeadersForAttempt picks it up instead of the stale
+      // singleAuthValue captured before the loop.
+      if (isGithubCopilot && response.status === 401 && !didRefreshCopilotToken) {
+        const lowerBody = errorBody.toLowerCase()
+        if (lowerBody.includes('token expired') || lowerBody.includes('token has expired')) {
+          didRefreshCopilotToken = true
+          const oldToken = headers.Authorization?.replace(/^Bearer\s+/i, '') || ''
+          const refreshed = await refreshCopilotTokenOn401()
+          if (refreshed) {
+            const newApiKey = process.env.OPENAI_API_KEY?.trim() || ''
+            if (newApiKey && newApiKey !== oldToken) {
+              refreshedCopilotToken = newApiKey
+            }
+            continue
+          }
+        }
+      }
 
       const credentialFailureKind =
         failure.category === 'auth_invalid' && !failure.retryable

--- a/src/services/api/openaiShim.ts
+++ b/src/services/api/openaiShim.ts
@@ -3494,7 +3494,7 @@ class OpenAIShimMessages {
       if (isGithubCopilot && response.status === 401 && !didRefreshCopilotToken) {
         if (isCopilotTokenExpiredError(errorBody)) {
           const oldToken = headers.Authorization?.replace(/^Bearer\s+/i, '') || ''
-          if (oldToken === (process.env.OPENAI_API_KEY ?? '')) {
+          if (oldToken && oldToken === (process.env.OPENAI_API_KEY ?? '')) {
             didRefreshCopilotToken = true
             const refreshed = await refreshCopilotTokenOn401()
             if (refreshed) {

--- a/src/services/api/openaiShim.ts
+++ b/src/services/api/openaiShim.ts
@@ -2352,8 +2352,9 @@ class OpenAIShimMessages {
 
     if (isGithubWithCodexTransport) {
       let didRefreshCopilotCodexToken = false
+      let refreshedCopilotCodexToken: string | undefined
       for (let attempt = 0; attempt < 2; attempt++) {
-        const apiKey = this.providerOverride?.apiKey ?? process.env.OPENAI_API_KEY ?? ''
+        const apiKey = refreshedCopilotCodexToken ?? this.providerOverride?.apiKey ?? process.env.OPENAI_API_KEY ?? ''
         if (!apiKey) {
           throw new Error(
             'GitHub Copilot auth is required. Run /onboard-github to sign in.',
@@ -2390,6 +2391,7 @@ class OpenAIShimMessages {
               if (refreshed) {
                 const newApiKey = process.env.OPENAI_API_KEY?.trim() || ''
                 if (newApiKey && newApiKey !== apiKey) {
+                  refreshedCopilotCodexToken = newApiKey
                   continue
                 }
               }
@@ -3498,7 +3500,9 @@ class OpenAIShimMessages {
             if (newApiKey && newApiKey !== oldToken) {
               refreshedCopilotToken = newApiKey
             }
-            continue
+            if (attempt < maxAttempts - 1) {
+              continue
+            }
           }
         }
       }

--- a/src/services/api/openaiShim.ts
+++ b/src/services/api/openaiShim.ts
@@ -3494,14 +3494,16 @@ class OpenAIShimMessages {
         if (isCopilotTokenExpiredError(errorBody)) {
           didRefreshCopilotToken = true
           const oldToken = headers.Authorization?.replace(/^Bearer\s+/i, '') || ''
-          const refreshed = await refreshCopilotTokenOn401()
-          if (refreshed) {
-            const newApiKey = process.env.OPENAI_API_KEY?.trim() || ''
-            if (newApiKey && newApiKey !== oldToken) {
-              refreshedCopilotToken = newApiKey
-            }
-            if (attempt < maxAttempts - 1) {
-              continue
+          if (oldToken === (process.env.OPENAI_API_KEY ?? '')) {
+            const refreshed = await refreshCopilotTokenOn401()
+            if (refreshed) {
+              const newApiKey = process.env.OPENAI_API_KEY?.trim() || ''
+              if (newApiKey && newApiKey !== oldToken) {
+                refreshedCopilotToken = newApiKey
+              }
+              if (attempt < maxAttempts - 1) {
+                continue
+              }
             }
           }
         }

--- a/src/services/api/openaiShim.ts
+++ b/src/services/api/openaiShim.ts
@@ -2381,11 +2381,17 @@ class OpenAIShimMessages {
             error instanceof APIError &&
             error.status === 401
           ) {
-            if (isCopilotTokenExpiredError(error.message)) {
+            if (
+              apiKey === (process.env.OPENAI_API_KEY ?? '') &&
+              isCopilotTokenExpiredError(error.message)
+            ) {
               didRefreshCopilotCodexToken = true
               const refreshed = await refreshCopilotTokenOn401()
-              if (refreshed && process.env.OPENAI_API_KEY?.trim()) {
-                continue
+              if (refreshed) {
+                const newApiKey = process.env.OPENAI_API_KEY?.trim() || ''
+                if (newApiKey && newApiKey !== apiKey) {
+                  continue
+                }
               }
             }
           }

--- a/src/services/api/openaiShim.ts
+++ b/src/services/api/openaiShim.ts
@@ -3493,9 +3493,9 @@ class OpenAIShimMessages {
       // singleAuthValue captured before the loop.
       if (isGithubCopilot && response.status === 401 && !didRefreshCopilotToken) {
         if (isCopilotTokenExpiredError(errorBody)) {
-          didRefreshCopilotToken = true
           const oldToken = headers.Authorization?.replace(/^Bearer\s+/i, '') || ''
           if (oldToken === (process.env.OPENAI_API_KEY ?? '')) {
+            didRefreshCopilotToken = true
             const refreshed = await refreshCopilotTokenOn401()
             if (refreshed) {
               const newApiKey = process.env.OPENAI_API_KEY?.trim() || ''

--- a/src/services/api/openaiShim.ts
+++ b/src/services/api/openaiShim.ts
@@ -118,6 +118,11 @@ const COPILOT_HEADERS: Record<string, string> = {
   'Copilot-Integration-Id': 'vscode-chat',
 }
 
+function isCopilotTokenExpiredError(text: string): boolean {
+  const lower = text.toLowerCase()
+  return lower.includes('token expired') || lower.includes('token has expired')
+}
+
 function isGithubModelsMode(): boolean {
   return isEnvTruthy(process.env.CLAUDE_CODE_USE_GITHUB)
 }
@@ -2376,8 +2381,7 @@ class OpenAIShimMessages {
             error instanceof APIError &&
             error.status === 401
           ) {
-            const lowerMsg = error.message.toLowerCase()
-            if (lowerMsg.includes('token expired') || lowerMsg.includes('token has expired')) {
+            if (isCopilotTokenExpiredError(error.message)) {
               didRefreshCopilotCodexToken = true
               const refreshed = await refreshCopilotTokenOn401()
               if (refreshed && process.env.OPENAI_API_KEY?.trim()) {
@@ -3479,8 +3483,7 @@ class OpenAIShimMessages {
       // iteration's buildHeadersForAttempt picks it up instead of the stale
       // singleAuthValue captured before the loop.
       if (isGithubCopilot && response.status === 401 && !didRefreshCopilotToken) {
-        const lowerBody = errorBody.toLowerCase()
-        if (lowerBody.includes('token expired') || lowerBody.includes('token has expired')) {
+        if (isCopilotTokenExpiredError(errorBody)) {
           didRefreshCopilotToken = true
           const oldToken = headers.Authorization?.replace(/^Bearer\s+/i, '') || ''
           const refreshed = await refreshCopilotTokenOn401()

--- a/src/services/api/openaiShim.ts
+++ b/src/services/api/openaiShim.ts
@@ -2346,27 +2346,48 @@ class OpenAIShimMessages {
     const isGithubWithCodexTransport = isGithubMode && request.transport === 'codex_responses'
 
     if (isGithubWithCodexTransport) {
-      const apiKey = this.providerOverride?.apiKey ?? process.env.OPENAI_API_KEY ?? ''
-      if (!apiKey) {
-        throw new Error(
-          'GitHub Copilot auth is required. Run /onboard-github to sign in.',
-        )
-      }
+      let didRefreshCopilotCodexToken = false
+      for (let attempt = 0; attempt < 2; attempt++) {
+        const apiKey = this.providerOverride?.apiKey ?? process.env.OPENAI_API_KEY ?? ''
+        if (!apiKey) {
+          throw new Error(
+            'GitHub Copilot auth is required. Run /onboard-github to sign in.',
+          )
+        }
 
-      return performCodexRequest({
-        request,
-        credentials: {
-          apiKey,
-          source: 'env',
-        },
-        params,
-        defaultHeaders: {
-          ...this.defaultHeaders,
-          ...filterAnthropicHeaders(options?.headers),
-          ...COPILOT_HEADERS,
-        },
-        signal: options?.signal,
-      })
+        try {
+          return await performCodexRequest({
+            request,
+            credentials: {
+              apiKey,
+              source: 'env',
+            },
+            params,
+            defaultHeaders: {
+              ...this.defaultHeaders,
+              ...filterAnthropicHeaders(options?.headers),
+              ...COPILOT_HEADERS,
+            },
+            signal: options?.signal,
+          })
+        } catch (error) {
+          if (
+            !didRefreshCopilotCodexToken &&
+            error instanceof APIError &&
+            error.status === 401
+          ) {
+            const lowerMsg = error.message.toLowerCase()
+            if (lowerMsg.includes('token expired') || lowerMsg.includes('token has expired')) {
+              didRefreshCopilotCodexToken = true
+              const refreshed = await refreshCopilotTokenOn401()
+              if (refreshed && process.env.OPENAI_API_KEY?.trim()) {
+                continue
+              }
+            }
+          }
+          throw error
+        }
+      }
     }
 
     if (request.transport === 'codex_responses' && !isGithubMode) {
@@ -3004,8 +3025,9 @@ class OpenAIShimMessages {
       const headers: Record<string, string> = { ...baseHeaders }
       const authValue =
         explicitCustomAuthHeaderValue ||
+        refreshedCopilotToken ||
         credentialLease?.value ||
-        (credentialPool ? '' : refreshedCopilotToken || singleAuthValue)
+        (credentialPool ? '' : singleAuthValue)
 
       if (authValue) {
         if (hasCustomAuthHeader && customAuthHeader) {

--- a/src/utils/githubModelsCredentials.refresh.test.ts
+++ b/src/utils/githubModelsCredentials.refresh.test.ts
@@ -138,3 +138,285 @@ describe('refreshGithubModelsTokenIfNeeded', () => {
     )
   })
 })
+
+type GithubModelsCredentialsModule =
+  typeof import('./githubModelsCredentials.js')
+
+function importFreshGithubModelsCredentials(
+  cacheKey: string,
+): Promise<GithubModelsCredentialsModule> {
+  return import(
+    `./githubModelsCredentials.js?${cacheKey}`
+  ) as Promise<GithubModelsCredentialsModule>
+}
+
+const STORED_OAUTH_TOKEN = 'gho_stored_oauth_token_xyz'
+const STORED_COPILOT_TOKEN = 'stored-copilot-token-abc'
+const FRESH_COPILOT_TOKEN = 'fresh-copilot-token-def'
+
+describe('refreshCopilotTokenOn401', () => {
+  const orig = {
+    GITHUB_COPILOT_KEY: process.env.GITHUB_COPILOT_KEY,
+    GITHUB_TOKEN: process.env.GITHUB_TOKEN,
+    GITHUB_ENTERPRISE_URL: process.env.GITHUB_ENTERPRISE_URL,
+    OPENAI_API_KEY: process.env.OPENAI_API_KEY,
+    CLAUDE_CODE_SIMPLE: process.env.CLAUDE_CODE_SIMPLE,
+  }
+
+  beforeEach(async () => {
+    await acquireSharedMutationLock('utils/githubModelsCredentials.refresh.test.ts')
+    // Clear early-exit guards so each test starts from a clean baseline
+    // regardless of prior test failures or CI environment.
+    delete process.env.GITHUB_COPILOT_KEY
+    delete process.env.CLAUDE_CODE_SIMPLE
+  })
+
+  afterEach(() => {
+    try {
+      mock.restore()
+      for (const [k, v] of Object.entries(orig)) {
+        if (v === undefined) {
+          delete process.env[k as keyof typeof orig]
+        } else {
+          process.env[k as keyof typeof orig] = v
+        }
+      }
+    } finally {
+      releaseSharedMutationLock()
+    }
+  })
+
+  test('returns false in bare mode', async () => {
+    process.env.CLAUDE_CODE_SIMPLE = '1'
+
+    const { refreshCopilotTokenOn401 } =
+      await importFreshGithubModelsCredentials('refresh=bare-mode')
+    const result = await refreshCopilotTokenOn401()
+    expect(result).toBe(false)
+  })
+
+  test('returns false when GITHUB_COPILOT_KEY is set', async () => {
+    process.env.GITHUB_COPILOT_KEY = 'direct-key'
+
+    const { refreshCopilotTokenOn401 } =
+      await importFreshGithubModelsCredentials('refresh=direct-key-env')
+    const result = await refreshCopilotTokenOn401()
+    expect(result).toBe(false)
+  })
+
+  test('returns false when no stored credential blob exists', async () => {
+    process.env.OPENAI_API_KEY = STORED_COPILOT_TOKEN
+
+    mock.module('./secureStorage/index.js', () => ({
+      getSecureStorage: () => ({
+        read: () => null,
+      }),
+    }))
+
+    const { refreshCopilotTokenOn401 } =
+      await importFreshGithubModelsCredentials('refresh=no-blob')
+    const result = await refreshCopilotTokenOn401()
+    expect(result).toBe(false)
+  })
+
+  test('returns false when stored credential type is copilot_key', async () => {
+    process.env.OPENAI_API_KEY = STORED_COPILOT_TOKEN
+
+    mock.module('./secureStorage/index.js', () => ({
+      getSecureStorage: () => ({
+        read: () => ({
+          githubModels: {
+            accessToken: STORED_COPILOT_TOKEN,
+            credentialType: 'copilot_key' as const,
+          },
+        }),
+      }),
+    }))
+
+    const { refreshCopilotTokenOn401 } =
+      await importFreshGithubModelsCredentials('refresh=copilot-key-type')
+    const result = await refreshCopilotTokenOn401()
+    expect(result).toBe(false)
+  })
+
+  test('returns false when current credential does not match stored token', async () => {
+    process.env.OPENAI_API_KEY = 'some-other-token'
+
+    mock.module('./secureStorage/index.js', () => ({
+      getSecureStorage: () => ({
+        read: () => ({
+          githubModels: {
+            accessToken: STORED_COPILOT_TOKEN,
+            oauthAccessToken: STORED_OAUTH_TOKEN,
+          },
+        }),
+      }),
+    }))
+
+    const { refreshCopilotTokenOn401 } =
+      await importFreshGithubModelsCredentials('refresh=cred-mismatch')
+    const result = await refreshCopilotTokenOn401()
+    expect(result).toBe(false)
+  })
+
+  test('returns false when current credential is empty', async () => {
+    delete process.env.OPENAI_API_KEY
+
+    mock.module('./secureStorage/index.js', () => ({
+      getSecureStorage: () => ({
+        read: () => ({
+          githubModels: {
+            accessToken: STORED_COPILOT_TOKEN,
+            oauthAccessToken: STORED_OAUTH_TOKEN,
+          },
+        }),
+      }),
+    }))
+
+    const { refreshCopilotTokenOn401 } =
+      await importFreshGithubModelsCredentials('refresh=empty-cred')
+    const result = await refreshCopilotTokenOn401()
+    expect(result).toBe(false)
+  })
+
+  test('returns false when no OAuth token is stored', async () => {
+    process.env.OPENAI_API_KEY = STORED_COPILOT_TOKEN
+
+    mock.module('./secureStorage/index.js', () => ({
+      getSecureStorage: () => ({
+        read: () => ({
+          githubModels: {
+            accessToken: STORED_COPILOT_TOKEN,
+          },
+        }),
+      }),
+    }))
+
+    const { refreshCopilotTokenOn401 } =
+      await importFreshGithubModelsCredentials('refresh=no-oauth')
+    const result = await refreshCopilotTokenOn401()
+    expect(result).toBe(false)
+  })
+
+  test('returns false when exchange fails', async () => {
+    process.env.OPENAI_API_KEY = STORED_COPILOT_TOKEN
+
+    mock.module('./secureStorage/index.js', () => ({
+      getSecureStorage: () => ({
+        read: () => ({
+          githubModels: {
+            accessToken: STORED_COPILOT_TOKEN,
+            oauthAccessToken: STORED_OAUTH_TOKEN,
+          },
+        }),
+        readAsync: () =>
+          Promise.resolve({
+            githubModels: {
+              accessToken: STORED_COPILOT_TOKEN,
+              oauthAccessToken: STORED_OAUTH_TOKEN,
+            },
+          }),
+        update: () => ({ success: true }),
+      }),
+    }))
+
+    mock.module('../services/github/deviceFlow.js', () => ({
+      exchangeForCopilotToken: () =>
+        Promise.reject(new Error('Exchange failed')),
+    }))
+
+    const { refreshCopilotTokenOn401 } =
+      await importFreshGithubModelsCredentials('refresh=exchange-fail')
+    const result = await refreshCopilotTokenOn401()
+    expect(result).toBe(false)
+  })
+
+  test('returns false when save fails', async () => {
+    process.env.OPENAI_API_KEY = STORED_COPILOT_TOKEN
+
+    mock.module('./secureStorage/index.js', () => ({
+      getSecureStorage: () => ({
+        read: () => ({
+          githubModels: {
+            accessToken: STORED_COPILOT_TOKEN,
+            oauthAccessToken: STORED_OAUTH_TOKEN,
+          },
+        }),
+        update: () => ({ success: false, warning: 'Storage full' }),
+      }),
+    }))
+
+    mock.module('../services/github/deviceFlow.js', () => ({
+      exchangeForCopilotToken: () =>
+        Promise.resolve({ token: FRESH_COPILOT_TOKEN, expires_at: 9999999999, refresh_in: 1800, endpoints: { api: 'https://api.githubcopilot.com' } }),
+    }))
+
+    const { refreshCopilotTokenOn401 } =
+      await importFreshGithubModelsCredentials('refresh=save-fail')
+    const result = await refreshCopilotTokenOn401()
+    expect(result).toBe(false)
+  })
+
+  test('successfully refreshes and updates env vars', async () => {
+    process.env.OPENAI_API_KEY = STORED_COPILOT_TOKEN
+
+    mock.module('./secureStorage/index.js', () => ({
+      getSecureStorage: () => ({
+        read: () => ({
+          githubModels: {
+            accessToken: STORED_COPILOT_TOKEN,
+            oauthAccessToken: STORED_OAUTH_TOKEN,
+          },
+        }),
+        update: () => ({ success: true }),
+      }),
+    }))
+
+    mock.module('../services/github/deviceFlow.js', () => ({
+      exchangeForCopilotToken: () =>
+        Promise.resolve({ token: FRESH_COPILOT_TOKEN, expires_at: 9999999999, refresh_in: 1800, endpoints: { api: 'https://api.githubcopilot.com' } }),
+    }))
+
+    const { refreshCopilotTokenOn401 } =
+      await importFreshGithubModelsCredentials('refresh=success')
+    const result = await refreshCopilotTokenOn401()
+    expect(result).toBe(true)
+    expect(process.env.GITHUB_TOKEN).toBe(FRESH_COPILOT_TOKEN)
+    expect(process.env.OPENAI_API_KEY).toBe(FRESH_COPILOT_TOKEN)
+  })
+
+  test('supports GHE URL when GITHUB_ENTERPRISE_URL is set', async () => {
+    process.env.OPENAI_API_KEY = STORED_COPILOT_TOKEN
+    process.env.GITHUB_ENTERPRISE_URL = 'https://github.mycompany.com'
+
+    let capturedGheUrl: string | undefined
+    mock.module('./secureStorage/index.js', () => ({
+      getSecureStorage: () => ({
+        read: () => ({
+          githubModels: {
+            accessToken: STORED_COPILOT_TOKEN,
+            oauthAccessToken: STORED_OAUTH_TOKEN,
+          },
+        }),
+        update: () => ({ success: true }),
+      }),
+    }))
+
+    mock.module('../services/github/deviceFlow.js', () => ({
+      exchangeForCopilotToken: (
+        _token: string,
+        _fetchImpl: unknown,
+        gheUrl?: string,
+      ) => {
+        capturedGheUrl = gheUrl
+        return Promise.resolve({ token: FRESH_COPILOT_TOKEN, expires_at: 9999999999, refresh_in: 1800, endpoints: { api: 'https://github.mycompany.com/api/copilot' } })
+      },
+    }))
+
+    const { refreshCopilotTokenOn401 } =
+      await importFreshGithubModelsCredentials('refresh=ghe')
+    const result = await refreshCopilotTokenOn401()
+    expect(result).toBe(true)
+    expect(capturedGheUrl).toBe('https://github.mycompany.com')
+  })
+})

--- a/src/utils/githubModelsCredentials.ts
+++ b/src/utils/githubModelsCredentials.ts
@@ -1,6 +1,7 @@
 import { isBareMode, isEnvTruthy } from './envUtils.js'
 import { getSecureStorage } from './secureStorage/index.js'
 import { exchangeForCopilotToken } from '../services/github/deviceFlow.js'
+import { logForDebugging } from './debug.js'
 
 /** JSON key in the shared OpenClaude secure storage blob. */
 export const GITHUB_MODELS_STORAGE_KEY = 'githubModels' as const
@@ -262,7 +263,11 @@ export async function refreshCopilotTokenOn401(): Promise<boolean> {
     process.env.GITHUB_TOKEN = refreshed.token
     process.env.OPENAI_API_KEY = refreshed.token
     return true
-  } catch {
+  } catch (error) {
+    logForDebugging(
+      `[refreshCopilotTokenOn401] failed: ${error instanceof Error ? error.message : String(error)}`,
+      { level: 'warn' },
+    )
     return false
   }
 }

--- a/src/utils/githubModelsCredentials.ts
+++ b/src/utils/githubModelsCredentials.ts
@@ -225,6 +225,48 @@ export function saveGithubModelsToken(
   return secureStorage.update(merged as typeof prev)
 }
 
+/**
+ * Force-refresh the Copilot token on 401.
+ *
+ * Only refreshes when the failing credential matches the stored Copilot
+ * token — silently skipping when a provider override, route credential,
+ * or custom auth header is in use, preventing credential substitution.
+ *
+ * Returns true if the refresh succeeded.
+ */
+export async function refreshCopilotTokenOn401(): Promise<boolean> {
+  if (isBareMode()) return false
+
+  // Direct API key users cannot refresh — they need to update the key manually
+  if (process.env.GITHUB_COPILOT_KEY?.trim()) return false
+
+  try {
+    const blob = readGithubModelsCredentialBlob()
+    if (!blob) return false
+    if (blob.credentialType === 'copilot_key') return false
+
+    // Only refresh when the failing credential IS the stored Copilot token.
+    // A provider override, route credential, or manually-set GITHUB_TOKEN
+    // will not match, preventing silent credential substitution.
+    const currentCredential = process.env.OPENAI_API_KEY?.trim()
+    if (!currentCredential || currentCredential !== blob.accessToken) return false
+
+    const oauthToken = blob.oauthAccessToken
+    if (!oauthToken) return false
+
+    const gheUrl = process.env.GITHUB_ENTERPRISE_URL?.trim() || undefined
+    const refreshed = await exchangeForCopilotToken(oauthToken, undefined, gheUrl)
+    const saved = saveGithubModelsToken(refreshed.token, oauthToken)
+    if (!saved.success) return false
+
+    process.env.GITHUB_TOKEN = refreshed.token
+    process.env.OPENAI_API_KEY = refreshed.token
+    return true
+  } catch {
+    return false
+  }
+}
+
 export function clearGithubModelsToken(): { success: boolean; warning?: string } {
   if (isBareMode()) {
     return { success: true }


### PR DESCRIPTION
Fixes #1746

## Problem
When GitHub Copilot returns 401 "token expired", the previous fix (#1042) only improved the error message hint to say "Run /onboard-github" — but never actually refreshed the token. Users had to manually notice the hint and re-authenticate, and even then the re-auth might not stick.

## Solution
Added  in  that reads the stored OAuth token and exchanges it for a fresh Copilot token, then updates `process.env`.

Hooked this into `openaiShim.ts:_doRequest()` retry loop: when GitHub mode is active, a 401 is returned, and the body contains "token expired", the token is refreshed and the request retried automatically.

## Changes
- **src/utils/githubModelsCredentials.ts**: Added  — reads stored OAuth token, calls `exchangeForCopilotToken()`, persists the new token, updates env vars
- **src/services/api/openaiShim.ts**: Added 401 detect-and-refresh in the retry loop with a `didRefreshCopilotToken` guard to prevent infinite loops

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved GitHub Copilot reliability by detecting `401` “token expired”/“token has expired” (case-insensitive), refreshing credentials when eligible, and retrying once with rotated authorization—covering both chat and Codex-style requests, including credential-pool scenarios. Refresh is skipped for bare/direct key usage, mismatched tokens, provider overrides, and non-matching `401` messages, with at-most-once refresh per retry cycle.

* **Tests**
  * Added/expanded coverage for Copilot token refresh and the `openaiShim` retry flow, including `refreshCopilotTokenOn401` success/failure cases, refresh trigger/skip conditions, same-token behavior, authorization header rotation, credential-pool handling, and enterprise/GHE refresh support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->