### PR TITLE
fix(bg): preserve provider env-file values during prompt detection

### DIFF
--- a/src/cli/bg.test.ts
+++ b/src/cli/bg.test.ts
@@ -34,6 +34,108 @@ describe('background session CLI parsing', () => {
     ])
   })
 
+  it('preserves provider env-file values before the prompt', () => {
+    const parsed = parseBackgroundInvocation([
+      '--bg',
+      '--provider-env-file',
+      '.env',
+      'fix failing tests',
+    ])
+
+    expect(parsed.prompt).toBe('fix failing tests')
+    expect(parsed.childArgs).toEqual([
+      '--provider-env-file',
+      '.env',
+      '--print',
+      'fix failing tests',
+    ])
+  })
+
+  it('preserves provider env-file values after the prompt', () => {
+    const parsed = parseBackgroundInvocation([
+      '--bg',
+      'fix failing tests',
+      '--provider-env-file',
+      '.env',
+    ])
+
+    expect(parsed.prompt).toBe('fix failing tests')
+    expect(parsed.childArgs).toEqual([
+      '--print',
+      'fix failing tests',
+      '--provider-env-file',
+      '.env',
+    ])
+  })
+
+  it('preserves repeated provider env-file values while finding the prompt', () => {
+    const parsed = parseBackgroundInvocation([
+      '--bg',
+      '--provider-env-file',
+      '.env.local',
+      'fix failing tests',
+      '--provider-env-file',
+      '.env.ci',
+    ])
+
+    expect(parsed.prompt).toBe('fix failing tests')
+    expect(parsed.childArgs).toEqual([
+      '--provider-env-file',
+      '.env.local',
+      '--print',
+      'fix failing tests',
+      '--provider-env-file',
+      '.env.ci',
+    ])
+  })
+
+  it('preserves inline provider env-file values', () => {
+    const parsed = parseBackgroundInvocation([
+      '--bg',
+      'fix failing tests',
+      '--provider-env-file=.env',
+    ])
+
+    expect(parsed.prompt).toBe('fix failing tests')
+    expect(parsed.childArgs).toEqual([
+      '--print',
+      'fix failing tests',
+      '--provider-env-file=.env',
+    ])
+  })
+
+  it('preserves provider env-file paths containing spaces', () => {
+    const parsed = parseBackgroundInvocation([
+      '--bg',
+      'fix failing tests',
+      '--provider-env-file',
+      'config files/provider.env',
+    ])
+
+    expect(parsed.prompt).toBe('fix failing tests')
+    expect(parsed.childArgs).toEqual([
+      '--print',
+      'fix failing tests',
+      '--provider-env-file',
+      'config files/provider.env',
+    ])
+  })
+
+  it('keeps provider env-file-looking prompts after -- positional', () => {
+    const parsed = parseBackgroundInvocation([
+      '--bg',
+      '--',
+      '--provider-env-file=.env',
+    ])
+
+    expect(parsed.prompt).toBe('--provider-env-file=.env')
+    expect(parsed.childArgs).toEqual([
+      '--print',
+      '--',
+      '--provider-env-file=.env',
+    ])
+  })
+
   it('does not duplicate --print when the user already passed it', () => {
     const parsed = parseBackgroundInvocation([
       '--background',

--- a/src/cli/bg.ts
+++ b/src/cli/bg.ts
@@ -90,6 +90,7 @@ const REQUIRED_OPTION_VALUE_FLAGS = new Set([
   '--plugin-dir',
   '--prefill',
   '--provider',
+  '--provider-env-file',
   '--resume-session-at',
   '--rewind-files',
   '--session-id',


### PR DESCRIPTION
## Summary
- Fix background prompt detection for this argv shape:

```bash
openclaude --bg "fix the tests" --provider-env-file .env
```

- Add `--provider-env-file` to the background parser's value-consuming option metadata so `.env` is preserved as the option value instead of being selected as the prompt.
- Add focused regression coverage for before/after prompt placement, repeated env files, inline env-file syntax, paths containing spaces, and `--` positional handling.

## Root cause
`src/main.tsx` registers `--provider-env-file <path>`, but `src/cli/bg.ts` uses a hand-maintained `REQUIRED_OPTION_VALUE_FLAGS` list while reverse-detecting the positional background prompt. Because `--provider-env-file` was missing from that metadata, a space-separated path such as `.env` could be mistaken for the prompt, causing `--print` to be inserted before the path instead of before the real prompt.

## Scope
This stays narrowly focused on the background parser metadata mismatch. It does not rewrite Commander registration, introduce a general command-line parser, add dependencies, or claim to solve ambiguous variadic-option grammar. Inline `--provider-env-file=.env` remains a single argv element and is not treated as consuming a separate prompt token.

I also checked the neighboring registered single-value options in the provider/model/settings/plugin-dir registration block; those were already represented in the background parser metadata except for `--provider-env-file`.

## Risk surface
- Background execution: only prompt detection and `--print` insertion placement change; process spawning and background session lifecycle behavior are unchanged.
- Provider env loading: this PR does not add new env-file loading semantics or file reads; it preserves the existing `--provider-env-file` argv value for the already-registered option.
- Provider routing/startup: no provider selection, validation, routing, credential, or startup environment behavior is changed beyond keeping the env-file argument attached to its flag.

## Validation
- `bun test src/cli/bg.test.ts`
- `bun run typecheck`
- `bun run build`
- `bun run smoke`
- `bun run security:pr-scan`
- `git diff --check`

I reviewed `AGENTS.md` and `CONTRIBUTING.md`, updated from latest upstream `main`, and searched open/closed PRs for `REQUIRED_OPTION_VALUE_FLAGS`, `--provider-env-file`, `parseBackgroundInvocation`, and background prompt parsing before opening this PR.
