### PR TITLE
fix(resume): tolerate malformed legacy attachment records

### DIFF
--- a/src/utils/conversationRecovery.test.ts
+++ b/src/utils/conversationRecovery.test.ts
@@ -622,9 +622,18 @@ test('loadConversationForResume keeps valid messages around a malformed attachme
 
   const result = await loadConversationForResume('fixture', path)
   const messages = result?.messages ?? []
+  const recoveredTranscriptMessages = messages.filter(
+    message => message.uuid === id(60) || message.uuid === id(62),
+  )
 
-  expect(messages.map(message => message.type)).toEqual(['user', 'assistant'])
-  expect((messages[1] as any).message.content[0].text).toBe('after')
+  expect(messages.some(message => message.uuid === id(61))).toBe(false)
+  expect(recoveredTranscriptMessages.map(message => message.type)).toEqual([
+    'user',
+    'assistant',
+  ])
+  expect((recoveredTranscriptMessages[1] as any).message.content[0].text).toBe(
+    'after',
+  )
 })
 
 test('deserializeMessages drops malformed attachments before sentinel normalization', async () => {

--- a/src/utils/conversationRecovery.test.ts
+++ b/src/utils/conversationRecovery.test.ts
@@ -3,6 +3,10 @@ import { mkdtemp, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import {
+  clearInvokedSkills,
+  getInvokedSkills,
+} from '../bootstrap/state.js'
+import {
   acquireSharedMutationLock,
   releaseSharedMutationLock,
 } from '../test/sharedMutationLock.js'
@@ -37,11 +41,11 @@ function id(n: number): string {
   return `00000000-0000-4000-8000-${String(n).padStart(12, '0')}`
 }
 
-function user(uuid: string, content: string) {
+function user(uuid: string, content: string, parentUuid: string | null = null) {
   return {
     type: 'user',
     uuid,
-    parentUuid: null,
+    parentUuid,
     timestamp: ts,
     cwd: '/tmp',
     userType: 'external',
@@ -53,6 +57,42 @@ function user(uuid: string, content: string) {
       role: 'user',
       content,
     },
+  }
+}
+
+function assistant(
+  uuid: string,
+  content: string,
+  parentUuid: string | null = null,
+) {
+  return {
+    type: 'assistant',
+    uuid,
+    parentUuid,
+    timestamp: ts,
+    sessionId,
+    version: 'test',
+    isSidechain: false,
+    isMeta: false,
+    message: {
+      role: 'assistant',
+      content: [{ type: 'text', text: content }],
+    },
+  }
+}
+
+function attachment(
+  uuid: string,
+  value: unknown,
+  parentUuid: string | null = null,
+) {
+  return {
+    type: 'attachment',
+    uuid,
+    parentUuid,
+    timestamp: ts,
+    sessionId,
+    attachment: value,
   }
 }
 
@@ -93,6 +133,7 @@ beforeEach(async () => {
 afterEach(async () => {
   try {
     mock.restore()
+    clearInvokedSkills()
     // Bun 1.3.13 can leave restored module instances visible to later test
     // files, so re-register full exports after using partial module mocks.
     mock.module('./udsClient.js', () => realUdsClient)
@@ -372,6 +413,236 @@ test('deserializeMessages strips dangerous permission modes from rewindable user
   ])
 
   expect((deserialized[0] as any)?.permissionMode).toBeUndefined()
+})
+
+test('deserializeMessages drops an attachment message with missing attachment payload', async () => {
+  clearProviderEnv()
+  const { deserializeMessages } = await importFreshConversationRecovery()
+
+  const deserialized = deserializeMessages([
+    user(id(20), 'before'),
+    {
+      type: 'attachment',
+      uuid: id(21),
+      parentUuid: id(20),
+      timestamp: ts,
+      sessionId,
+    } as any,
+    assistant(id(22), 'after') as any,
+  ])
+
+  expect(deserialized.map(message => message.type)).toEqual([
+    'user',
+    'assistant',
+  ])
+  expect((deserialized[1] as any).message.content[0].text).toBe('after')
+})
+
+test('deserializeMessages drops an attachment message with null attachment payload', async () => {
+  clearProviderEnv()
+  const { deserializeMessages } = await importFreshConversationRecovery()
+
+  const deserialized = deserializeMessages([
+    user(id(23), 'before'),
+    attachment(id(24), null, id(23)) as any,
+    assistant(id(25), 'after', id(24)) as any,
+  ])
+
+  expect(deserialized.map(message => message.type)).toEqual([
+    'user',
+    'assistant',
+  ])
+  expect((deserialized[1] as any).message.content[0].text).toBe('after')
+})
+
+const invalidLegacyPathValues: Array<[string, unknown]> = [
+  ['missing', undefined],
+  ['null', null],
+  ['numeric', 42],
+  ['object', { path: '/tmp/file.txt' }],
+  ['empty', ''],
+]
+
+for (const [label, filename] of invalidLegacyPathValues) {
+  test(`deserializeMessages drops legacy new_file attachment with ${label} filename`, async () => {
+    clearProviderEnv()
+    const { deserializeMessages } = await importFreshConversationRecovery()
+    const legacyAttachment =
+      filename === undefined
+        ? { type: 'new_file', content: { type: 'text', text: 'legacy' } }
+        : {
+            type: 'new_file',
+            filename,
+            content: { type: 'text', text: 'legacy' },
+          }
+
+    const deserialized = deserializeMessages([
+      user(id(30), 'before'),
+      attachment(id(31), legacyAttachment, id(30)) as any,
+      assistant(id(32), 'after', id(31)) as any,
+    ])
+
+    expect(deserialized.map(message => message.type)).toEqual([
+      'user',
+      'assistant',
+    ])
+  })
+}
+
+for (const [label, directoryPath] of invalidLegacyPathValues) {
+  test(`deserializeMessages drops legacy new_directory attachment with ${label} path`, async () => {
+    clearProviderEnv()
+    const { deserializeMessages } = await importFreshConversationRecovery()
+    const legacyAttachment =
+      directoryPath === undefined
+        ? { type: 'new_directory', content: 'legacy directory' }
+        : {
+            type: 'new_directory',
+            path: directoryPath,
+            content: 'legacy directory',
+          }
+
+    const deserialized = deserializeMessages([
+      user(id(33), 'before'),
+      attachment(id(34), legacyAttachment, id(33)) as any,
+      assistant(id(35), 'after', id(34)) as any,
+    ])
+
+    expect(deserialized.map(message => message.type)).toEqual([
+      'user',
+      'assistant',
+    ])
+  })
+}
+
+test('deserializeMessages preserves valid legacy file and directory displayPath migration', async () => {
+  clearProviderEnv()
+  const { deserializeMessages } = await importFreshConversationRecovery()
+  const legacyFilePath = join(process.cwd(), 'src', 'legacy-file.txt')
+  const legacyDirectoryPath = join(process.cwd(), 'src', 'legacy-directory')
+
+  const deserialized = deserializeMessages([
+    user(id(40), 'before'),
+    attachment(
+      id(41),
+      {
+        type: 'new_file',
+        filename: legacyFilePath,
+        content: { type: 'text', text: 'legacy file' },
+      },
+      id(40),
+    ) as any,
+    attachment(
+      id(42),
+      {
+        type: 'new_directory',
+        path: legacyDirectoryPath,
+        content: 'legacy directory',
+      },
+      id(41),
+    ) as any,
+    assistant(id(43), 'after', id(42)) as any,
+  ])
+
+  const attachments = deserialized.filter(
+    message => message.type === 'attachment',
+  ) as any[]
+
+  expect(attachments).toHaveLength(2)
+  expect(attachments[0].attachment).toMatchObject({
+    type: 'file',
+    filename: legacyFilePath,
+    displayPath: join('src', 'legacy-file.txt'),
+  })
+  expect(attachments[1].attachment).toMatchObject({
+    type: 'directory',
+    path: legacyDirectoryPath,
+    displayPath: join('src', 'legacy-directory'),
+  })
+})
+
+test('restoreSkillStateFromMessages ignores invoked_skills attachments with missing or non-array skills', async () => {
+  const { restoreSkillStateFromMessages } =
+    await importFreshConversationRecovery()
+
+  expect(() =>
+    restoreSkillStateFromMessages([
+      attachment(id(50), { type: 'invoked_skills' }) as any,
+      attachment(id(51), {
+        type: 'invoked_skills',
+        skills: 'not an array',
+      }) as any,
+    ]),
+  ).not.toThrow()
+  expect(getInvokedSkills().size).toBe(0)
+})
+
+test('restoreSkillStateFromMessages restores only complete valid invoked skill records', async () => {
+  const { restoreSkillStateFromMessages } =
+    await importFreshConversationRecovery()
+
+  restoreSkillStateFromMessages([
+    attachment(id(52), {
+      type: 'invoked_skills',
+      skills: [
+        { name: 'valid-skill', path: '/skills/valid', content: 'follow this' },
+        null,
+        { name: 123, path: '/skills/bad', content: 'bad name' },
+        { name: 'missing-path', content: 'bad path' },
+        { name: 'missing-content', path: '/skills/missing-content' },
+        { name: '', path: '/skills/empty-name', content: 'empty name' },
+      ],
+    }) as any,
+  ])
+
+  expect([...getInvokedSkills().values()]).toMatchObject([
+    {
+      skillName: 'valid-skill',
+      skillPath: '/skills/valid',
+      content: 'follow this',
+      agentId: null,
+    },
+  ])
+})
+
+test('loadConversationForResume keeps valid messages around a malformed attachment record', async () => {
+  process.env.CLAUDE_CODE_SIMPLE = '1'
+  const path = await writeJsonlEntries([
+    user(id(60), 'before'),
+    {
+      type: 'attachment',
+      uuid: id(61),
+      parentUuid: id(60),
+      timestamp: ts,
+      sessionId,
+    },
+    assistant(id(62), 'after', id(61)),
+  ])
+  const { loadConversationForResume } = await importFreshConversationRecovery()
+
+  const result = await loadConversationForResume('fixture', path)
+  const messages = result?.messages ?? []
+
+  expect(messages.map(message => message.type)).toEqual(['user', 'assistant'])
+  expect((messages[1] as any).message.content[0].text).toBe('after')
+})
+
+test('deserializeMessages drops malformed attachments before sentinel normalization', async () => {
+  clearProviderEnv()
+  const { deserializeMessages } = await importFreshConversationRecovery()
+
+  const deserialized = deserializeMessages([
+    user(id(63), 'before'),
+    attachment(id(64), { type: 42 }, id(63)) as any,
+  ])
+
+  expect(deserialized.map(message => message.type)).toEqual([
+    'user',
+    'assistant',
+  ])
+  expect((deserialized[1] as any).message.content[0].text).toBe(
+    'No response requested.',
+  )
 })
 
 test('deserializeMessages preserves thinking blocks for DeepSeek 3P provider (#957)', async () => {

--- a/src/utils/conversationRecovery.ts
+++ b/src/utils/conversationRecovery.ts
@@ -627,7 +627,7 @@ export function restoreSkillStateFromMessages(messages: Message[]): void {
     // in the transcript the model is about to see. sentSkillNames is
     // process-local, so without this every resume re-announces the same
     // ~600 tokens. Fire-once latch; consumed on the first attachment pass.
-    if (message.attachment.type === 'skill_listing') {
+    if (attachment.type === 'skill_listing') {
       suppressNextSkillListing()
     }
   }

--- a/src/utils/conversationRecovery.ts
+++ b/src/utils/conversationRecovery.ts
@@ -114,35 +114,62 @@ function assertResumeMessageSize(messages: Message[]): void {
 /**
  * Transforms legacy attachment types to current types for backward compatibility
  */
-function migrateLegacyAttachmentTypes(message: Message): Message {
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null
+}
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === 'string' && value.length > 0
+}
+
+function getAttachmentRecord(
+  message: Message,
+): Record<string, unknown> | null {
+  if (message.type !== 'attachment') {
+    return null
+  }
+  const attachment = (message as { attachment?: unknown }).attachment
+  if (!isRecord(attachment) || typeof attachment.type !== 'string') {
+    return null
+  }
+  return attachment
+}
+
+function migrateLegacyAttachmentTypes(message: Message): Message | null {
   if (message.type !== 'attachment') {
     return message
   }
 
-  const attachment = message.attachment as {
-    type: string
-    [key: string]: unknown
-  } // Handle legacy types not in current type system
+  const attachment = getAttachmentRecord(message)
+  if (!attachment) {
+    return null
+  }
 
   // Transform legacy attachment types
   if (attachment.type === 'new_file') {
+    if (!isNonEmptyString(attachment.filename)) {
+      return null
+    }
     return {
       ...message,
       attachment: {
         ...attachment,
         type: 'file',
-        displayPath: relative(getCwd(), attachment.filename as string),
+        displayPath: relative(getCwd(), attachment.filename),
       },
     } as SerializedMessage // Cast entire message since we know the structure is correct
   }
 
   if (attachment.type === 'new_directory') {
+    if (!isNonEmptyString(attachment.path)) {
+      return null
+    }
     return {
       ...message,
       attachment: {
         ...attachment,
         type: 'directory',
-        displayPath: relative(getCwd(), attachment.path as string),
+        displayPath: relative(getCwd(), attachment.path),
       },
     } as SerializedMessage // Cast entire message since we know the structure is correct
   }
@@ -150,12 +177,12 @@ function migrateLegacyAttachmentTypes(message: Message): Message {
   // Backfill displayPath for attachments from old sessions
   if (!('displayPath' in attachment)) {
     const path =
-      'filename' in attachment
-        ? (attachment.filename as string)
-        : 'path' in attachment
-          ? (attachment.path as string)
-          : 'skillDir' in attachment
-            ? (attachment.skillDir as string)
+      isNonEmptyString(attachment.filename)
+        ? attachment.filename
+        : isNonEmptyString(attachment.path)
+          ? attachment.path
+          : isNonEmptyString(attachment.skillDir)
+            ? attachment.skillDir
             : undefined
     if (path) {
       return {
@@ -278,9 +305,10 @@ export function deserializeMessagesWithInterruptDetection(
 ): DeserializeResult {
   try {
     // Transform legacy attachment types before processing
-    const migratedMessages = serializedMessages.map(
-      migrateLegacyAttachmentTypes,
-    )
+    const migratedMessages = serializedMessages.flatMap(message => {
+      const migratedMessage = migrateLegacyAttachmentTypes(message)
+      return migratedMessage ? [migratedMessage] : []
+    })
 
     // Strip invalid or dangerous permissionMode values from deserialized user
     // messages. The field is unvalidated JSON from disk and only
@@ -575,9 +603,21 @@ export function restoreSkillStateFromMessages(messages: Message[]): void {
     if (message.type !== 'attachment') {
       continue
     }
-    if (message.attachment.type === 'invoked_skills') {
-      for (const skill of message.attachment.skills) {
-        if (skill.name && skill.path && skill.content) {
+    const attachment = getAttachmentRecord(message)
+    if (!attachment) {
+      continue
+    }
+    if (attachment.type === 'invoked_skills') {
+      if (!Array.isArray(attachment.skills)) {
+        continue
+      }
+      for (const skill of attachment.skills) {
+        if (
+          isRecord(skill) &&
+          isNonEmptyString(skill.name) &&
+          isNonEmptyString(skill.path) &&
+          isNonEmptyString(skill.content)
+        ) {
           // Resume only happens for the main session, so agentId is null
           addInvokedSkill(skill.name, skill.path, skill.content, null)
         }


### PR DESCRIPTION
## Summary
- harden resume recovery so malformed attachment records from persisted JSONL are dropped instead of crashing the whole resume
- validate legacy `new_file`/`new_directory` path fields before migration and before calling `path.relative()`
- validate `invoked_skills` payloads so only complete skill records are restored

## Root cause
Persisted transcript JSONL is historical, untrusted data, but `conversationRecovery.ts` trusted TypeScript casts at runtime. A legacy or partially written attachment could leave `message.attachment` missing, null, or structurally invalid, and recovery would still dereference `attachment.type`, pass non-strings into `path.relative()`, or iterate a non-array `invoked_skills.skills` value.

## Recovery policy
Malformed attachment messages whose payload is absent, null, non-object, or lacks a string `type` are dropped during resume deserialization. Legacy `new_file` and `new_directory` records are migrated only when their path field is a non-empty string; invalid legacy entries are dropped. Display-path backfill ignores invalid path-like fields instead of casting them. `invoked_skills` restore now requires an array and restores only records with non-empty string `name`, `path`, and `content`.

Valid user, assistant, system, and valid attachment messages are preserved. Valid legacy file and directory records still migrate to the current attachment types and keep the existing `displayPath` behavior. No new logging was added, so transcript, attachment, skill, or credential contents are not emitted.

## Risk surface
This touches resume-time attachment handling and `invoked_skills` restoration only. The skills/plugin risk surface is defensive: malformed or partial skill records are ignored instead of being restored. This PR does not change MCP registration, provider routing, credential pooling, placeholder detection, permission-mode validation, or provider-specific thinking replay behavior.

## Tests
- `bun test src/utils/conversationRecovery.test.ts`
- `bun run typecheck`
- `bun run build`
- `bun run smoke`
- `bun run security:pr-scan`
- `git diff --check`

`AGENTS.md` and `CONTRIBUTING.md` were reviewed before implementation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved conversation recovery so malformed attachment messages are safely skipped while valid messages continue to load.
  * Legacy file and directory attachments are now preserved only when their path information is valid, helping avoid broken message recovery.
  * Resuming conversations now handles incomplete attachment data more reliably and falls back consistently when needed.
  * Invoked skills are restored only from valid records, preventing incorrect or partial skill data from appearing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->