### PR TITLE
feat(integrations): add GLM 5.2 as an Opengateway-routed model

### DIFF
--- a/src/commands/model/model.test.tsx
+++ b/src/commands/model/model.test.tsx
@@ -1278,6 +1278,7 @@ test('/model applies auto provider surface for single-model static descriptor pr
       'google/gemini-3.1-flash-lite',
       'minimax/minimax-m3',
       'qwen/qwen3.7-max',
+      'z-ai/glm-5.2',
       'nvidia/nemotron-3-ultra-550b-a55b:free',
     ])
   } finally {

--- a/src/integrations/gateways/gitlawb-opengateway.ts
+++ b/src/integrations/gateways/gitlawb-opengateway.ts
@@ -110,6 +110,12 @@ export default defineGateway({
         label: 'Qwen 3.7 Max (via Opengateway)',
         modelDescriptorId: 'qwen3.7-max',
       },
+      {
+        id: 'opengateway-glm-5.2',
+        apiName: 'z-ai/glm-5.2',
+        label: 'GLM 5.2 (via Opengateway)',
+        modelDescriptorId: 'glm-5.2',
+      },
       // OpenRouter :free endpoint — bills $0 and bypasses the gateway credit
       // gate, so it works even with an empty credit balance.
       {


### PR DESCRIPTION
## Summary
  Add GLM 5.2 as an Opengateway-routed model — a new `opengateway-glm-5.2` catalog
  entry (apiName `z-ai/glm-5.2`) on the gitlawb-opengateway gateway, reusing the
  existing `glm-5.2` model descriptor. Exposes GLM 5.2 through the credit-billed
  Opengateway (OpenRouter upstream) alongside the existing direct Z.AI vendor path.

  ## Impact
  - New model selectable via the Opengateway preset: `z-ai/glm-5.2`.
  - No change to existing models; generated artifacts unchanged.

  ## Testing
  - [x] `bun run integrations:check` — artifacts up to date
  - [x] `tsc --noEmit` — clean
  - [x] `bun test src/integrations` — 207 pass / 0 fail


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for the new **GLM 5.2** model through the **Opengateway** integration.
  * The GLM 5.2 option is now available in the model picker with a clearer display label for easier selection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->