### PR TITLE
fix(env-file): collapse escaped backslashes in quoted values

### DIFF
--- a/src/utils/envFile.test.ts
+++ b/src/utils/envFile.test.ts
@@ -149,6 +149,21 @@ BAZ=qux
     })
   })
 
+  it('collapses escaped backslashes inside quoted values', () => {
+    // The value content is C:\\Users\\me — escaped backslashes that the
+    // closing-quote scanner already treats as single backslashes, so the
+    // unescaper must collapse them too.
+    const result = parseEnvFile('FOO="C:\\\\Users\\\\me"')
+    expect(result).toEqual({ FOO: 'C:\\Users\\me' })
+  })
+
+  it('keeps lone backslashes in quoted values intact', () => {
+    // A single backslash before an ordinary character is not an escape and
+    // must survive verbatim (e.g. a Windows path written without doubling).
+    const result = parseEnvFile('FOO="C:\\Users\\me"')
+    expect(result).toEqual({ FOO: 'C:\\Users\\me' })
+  })
+
   it('strips inline comments from unquoted values', () => {
     const result = parseEnvFile('FOO=bar # comment\nBAZ=qux')
     expect(result).toEqual({ FOO: 'bar', BAZ: 'qux' })

--- a/src/utils/envFile.test.ts
+++ b/src/utils/envFile.test.ts
@@ -164,6 +164,15 @@ BAZ=qux
     expect(result).toEqual({ FOO: 'C:\\Users\\me' })
   })
 
+  it('collapses an escaped backslash adjacent to the closing quote', () => {
+    // The value content is a\\ — the escaped backslash sits right before the
+    // terminator, the trickiest interaction between findClosingQuote (which
+    // counts the even backslash run and keeps scanning) and unescapeQuotedValue
+    // (which must collapse the pair to one trailing backslash).
+    const result = parseEnvFile('FOO="a\\\\"')
+    expect(result).toEqual({ FOO: 'a\\' })
+  })
+
   it('strips inline comments from unquoted values', () => {
     const result = parseEnvFile('FOO=bar # comment\nBAZ=qux')
     expect(result).toEqual({ FOO: 'bar', BAZ: 'qux' })

--- a/src/utils/envFile.ts
+++ b/src/utils/envFile.ts
@@ -165,13 +165,19 @@ function findClosingQuote(value: string, quote: string): number {
 
 /**
  * Unescapes the active quote delimiter in a quoted env value.
+ *
+ * findClosingQuote/isEscapedQuote treat the value as backslash-escaped: an
+ * odd-length backslash run escapes the following quote, so `\\` is already
+ * consumed as a single escaped backslash when locating the closing quote.
+ * Collapse `\\` to `\` here too, otherwise the two stages disagree and a
+ * value like "a\\b" round-trips to the doubled "a\\b" instead of "a\b".
  */
 function unescapeQuotedValue(raw: string, quote: string): string {
   let result = ''
 
   for (let i = 0; i < raw.length; i++) {
-    if (raw[i] === '\\' && raw[i + 1] === quote) {
-      result += quote
+    if (raw[i] === '\\' && (raw[i + 1] === quote || raw[i + 1] === '\\')) {
+      result += raw[i + 1]
       i++
       continue
     }


### PR DESCRIPTION
### Problem

`parseEnvFile` parses quoted values in two stages, and the stages encode contradictory backslash rules:

- **Finding the closing quote** — `findClosingQuote` / `isEscapedQuote` use *odd/even backslash-run* semantics: an odd-length run of backslashes escapes the following quote. This means a `\\` pair is interpreted as a single escaped backslash while scanning, so the scanner correctly walks past it to find the real closing quote.
- **Unescaping the value** — `unescapeQuotedValue` only ever rewrote `\"` → `"`. It left `\\` completely untouched.

So the closing-quote scanner says "`\\` is one escaped backslash" but the unescaper says "`\\` is two literal characters". A value like `"a\\b"` round-trips to the doubled `a\\b` instead of `a\b`. The most common way to hit this is a Windows path written with the documented doubled-backslash form, e.g. `KEY="C:\\Users\\me"` yields `C:\\Users\\me`.

### Fix

Collapse `\\` → `\` in `unescapeQuotedValue` so both stages share a single escaping rule. Lone backslashes before ordinary characters (`C:\Users\me` written without doubling) are still preserved verbatim, and the existing escaped-quote behavior is unchanged.

### Tests

`src/utils/envFile.test.ts`:
- `collapses escaped backslashes inside quoted values` — `"C:\\Users\\me"` → `C:\Users\me` (fails before the fix).
- `keeps lone backslashes in quoted values intact` — single backslashes survive (guards against over-collapsing).

Full `envFile` suite: 33 pass, 0 fail.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved unescaping for quoted environment values to correctly preserve and normalize backslashes.
  * Collapses doubled backslashes inside quotes into single backslashes.
  * Ensures lone/non-escape backslashes and trailing escaped backslashes remain correct.
* **Tests**
  * Added cases covering quoted-value backslash parsing, including escaped, non-escaped, and trailing scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->