### PR TITLE
fix(update): stop false "development build" block on npm installs with NODE_ENV=development 

### DIFF
--- a/bin/openclaude
+++ b/bin/openclaude
@@ -75,9 +75,19 @@ function relaunchWithLongSessionHeapIfNeeded() {
     arg => !arg.startsWith('--max-memory=') && arg !== '--max-memory',
   )
 
+  // Preserve the original argv[1] (which may be a symlink like
+  // /usr/local/bin/openclaude) instead of resolving it via import.meta.url.
+  // Resolving symlinks here defeats install-type detection downstream: a real
+  // npm global install (symlink → node_modules/@gitlawb/openclaude/bin) would
+  // resolve to the package's real path inside node_modules, which is fine, but
+  // a `npm install -g .` dev symlink resolves back to the repo and looks like
+  // a source-tree dev run. Using argv[1] keeps the invocation path stable so
+  // doctorDiagnostic's npm-global path markers can match correctly.
+  const launcherPath = process.argv[1] || fileURLToPath(import.meta.url)
+
   const result = spawnSync(process.execPath, [
     ...execArgv,
-    fileURLToPath(import.meta.url),
+    launcherPath,
     ...childArgs,
   ], {
     stdio: 'inherit',

--- a/src/utils/doctorDiagnostic.ts
+++ b/src/utils/doctorDiagnostic.ts
@@ -99,10 +99,6 @@ function getNormalizedPaths(): [invokedPath: string, execPath: string] {
 }
 
 export async function getCurrentInstallationType(): Promise<InstallationType> {
-  if (process.env.NODE_ENV === 'development') {
-    return 'development'
-  }
-
   const [invokedPath] = getNormalizedPaths()
 
   // Check if running in bundled mode first
@@ -156,6 +152,15 @@ export async function getCurrentInstallationType(): Promise<InstallationType> {
 
   if (globalPrefix && invokedPath.startsWith(globalPrefix)) {
     return 'npm-global'
+  }
+
+  // Development build: running from a source tree (e.g. `bun run dev`) with
+  // NODE_ENV=development. Checked AFTER all real-install path markers so that
+  // a user shell exporting NODE_ENV=development can't downgrade a real npm
+  // install to 'development' (which would block /update). A source-tree run
+  // matches none of the path markers above, so it lands here.
+  if (process.env.NODE_ENV === 'development') {
+    return 'development'
   }
 
   // If we can't determine, return unknown


### PR DESCRIPTION
Summary

  - /update and openclaude update reported "Auto-update is unavailable for a development build." even when OpenClaude was correctly installed from npm (@gitlawb/openclaude), as long as the launching shell had
  NODE_ENV=development exported.
  - Root cause: getCurrentInstallationType() checked NODE_ENV === 'development' as its first branch, before any path-based detection — so a user's shell env var downgraded a real npm install to 'development',
  routing resolveUpdateStrategy() to { action: 'blocked', reason: 'development' }.
  - Two-part fix: (1) move the NODE_ENV check to a fallback after all real-install path markers; (2) preserve process.argv[1] in the bin/openclaude heap-relaunch instead of resolving symlinks via import.meta.url,
  so path detection sees the original invocation path.

  Impact

  - Before: any user with NODE_ENV=development in their shell (common in dev environments, .zshrc, or parent Node processes) could not use /update or openclaude update on a real npm install — it was blocked with a
  misleading "development build" message.
  - After: real npm installs (global or local) are detected by path markers first; NODE_ENV=development only classifies as 'development' when no install path matches (i.e. an actual source-tree bun run dev run).
  The bin/openclaude change also fixes a latent issue where symlinked global installs had their Invoked: path resolved back to the package's real location, defeating path detection.
  - No behavior change for actual development runs (bun run dev) — they still correctly report development.

  Testing

  - bun run typecheck passes (exit 0)
  - bun run build passes
  - Manual: npm install -g . + export NODE_ENV=development + openclaude doctor from /tmp → now reports npm-global (was development)
  - Logic verified: nvm symlink path (/Users/kevin/.nvm/versions/node/v22.13.0/bin/openclaude) matches /.nvm/versions/node/ marker → npm-global
  - No regression test added — getCurrentInstallationType() shells out to npm config get prefix and reads process.argv[1] directly, making it hard to mock cleanly without brittle fixtures. Open to adding one if
  maintainers prefer.

  Notes

  - First attempted fix (checking for absence of /node_modules/ in invokedPath) was rejected because PATH-installed symlinks like /usr/local/bin/openclaude do not contain /node_modules/ and would have been wrongly
  classified as development.
  - npm link and npm install -g . (folder argument) both create symlinks to the repo; before fix #2, bin/openclaude's symlink-resolving relaunch made process.argv[1] resolve back to the repo path, matching no
  npm-global marker. Fix #2 makes npm install -g . a valid test method. The most reliable test remains npm pack + npm install -g openclaude-<ver>.tgz (real file copy).
  - Clean up test installs with npm uninstall -g @gitlawb/openclaude.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved app relaunch behavior so restarts more reliably use the originally launched app path.
  * Fixed installation detection so a development environment setting no longer causes a real installation to be misidentified as development.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->