### PR TITLE
chore(deps): clean npm install — fix CVEs, silence warnings

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -59,11 +59,11 @@
         "tree-kill": "1.2.2",
         "turndown": "7.2.2",
         "type-fest": "4.41.0",
-        "undici": "7.24.6",
+        "undici": "7.28.0",
         "usehooks-ts": "3.1.1",
         "vscode-languageserver-protocol": "3.17.5",
         "wrap-ansi": "9.0.2",
-        "ws": "8.20.0",
+        "ws": "8.21.0",
         "xss": "1.0.15",
         "yaml": "2.8.3",
         "zod": "3.25.76",
@@ -81,6 +81,7 @@
     "google-auth-library": "10.6.2",
     "ip-address": "10.2.0",
     "lodash-es": "4.18.1",
+    "node-domexception": "file:vendor/node-domexception-shim",
   },
   "packages": {
     "@alcalzone/ansi-tokenize": ["@alcalzone/ansi-tokenize@0.3.0", "", { "dependencies": { "ansi-styles": "^6.2.1", "is-fullwidth-code-point": "^5.0.0" } }, "sha512-p+CMKJ93HFmLkjXKlXiVGlMQEuRb6H0MokBSwUsX+S6BRX8eV5naFZpQJFfJHjRZY0Hmnqy1/r6UWl3x+19zYA=="],
@@ -739,8 +740,6 @@
 
     "negotiator": ["negotiator@1.0.0", "", {}, "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg=="],
 
-    "node-domexception": ["node-domexception@1.0.0", "", {}, "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ=="],
-
     "node-fetch": ["node-fetch@3.3.2", "", { "dependencies": { "data-uri-to-buffer": "^4.0.0", "fetch-blob": "^3.1.4", "formdata-polyfill": "^4.0.10" } }, "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA=="],
 
     "node-forge": ["node-forge@1.4.0", "", {}, "sha512-LarFH0+6VfriEhqMMcLX2F7SwSXeWwnEAJEsYm5QKWchiVYVvJyV9v7UDvUv+w5HO23ZpQTXDv/GxdDdMyOuoQ=="],
@@ -907,7 +906,7 @@
 
     "unbash": ["unbash@3.0.0", "", {}, "sha512-FeFPZ/WFT0mbRCuydiZzpPFlrYN8ZUpphQKoq4EeElVIYjYyGzPMxQR/simUwCOJIyVhpFk4RbtyO7RuMpMnHA=="],
 
-    "undici": ["undici@7.24.6", "", {}, "sha512-Xi4agocCbRzt0yYMZGMA6ApD7gvtUFaxm4ZmeacWI4cZxaF6C+8I8QfofC20NAePiB/IcvZmzkJ7XPa471AEtA=="],
+    "undici": ["undici@7.28.0", "", {}, "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA=="],
 
     "undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
 
@@ -937,7 +936,7 @@
 
     "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
 
-    "ws": ["ws@8.20.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA=="],
+    "ws": ["ws@8.21.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g=="],
 
     "xml-naming": ["xml-naming@0.1.0", "", {}, "sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw=="],
 
@@ -1214,6 +1213,8 @@
     "cliui/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
     "cliui/wrap-ansi": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
+
+    "fetch-blob/node-domexception": ["node-domexception@file:vendor/node-domexception-shim", {}],
 
     "form-data/mime-types": ["mime-types@2.1.35", "", { "dependencies": { "mime-db": "1.52.0" } }, "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw=="],
 

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "src/entrypoints/sdk.d.ts",
     "src/entrypoints/sdk/coreTypes.generated.ts",
     "scripts/windows/openclaude-aliases.ps1",
+    "vendor/node-domexception-shim/",
     "docs/windows-aliases-and-launchers.md",
     "README.md"
   ],

--- a/package.json
+++ b/package.json
@@ -128,11 +128,11 @@
     "tree-kill": "1.2.2",
     "turndown": "7.2.2",
     "type-fest": "4.41.0",
-    "undici": "7.24.6",
+    "undici": "7.28.0",
     "usehooks-ts": "3.1.1",
     "vscode-languageserver-protocol": "3.17.5",
     "wrap-ansi": "9.0.2",
-    "ws": "8.20.0",
+    "ws": "8.21.0",
     "xss": "1.0.15",
     "yaml": "2.8.3",
     "zod": "3.25.76"
@@ -168,6 +168,11 @@
   "overrides": {
     "ip-address": "10.2.0",
     "google-auth-library": "10.6.2",
-    "lodash-es": "4.18.1"
+    "lodash-es": "4.18.1",
+    "node-domexception": "file:vendor/node-domexception-shim"
+  },
+  "allowScripts": {
+    "protobufjs@7.6.4": true,
+    "sharp@0.34.5": true
   }
 }

--- a/vendor/node-domexception-shim/index.js
+++ b/vendor/node-domexception-shim/index.js
@@ -1,0 +1,3 @@
+/*! node-domexception shim. Re-exports the platform-native DOMException. */
+
+module.exports = globalThis.DOMException

--- a/vendor/node-domexception-shim/package.json
+++ b/vendor/node-domexception-shim/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "node-domexception",
+  "version": "1.0.0",
+  "description": "Stub shim: re-exports the platform-native DOMException. Replaces the deprecated node-domexception polyfill.",
+  "main": "index.js",
+  "type": "commonjs",
+  "license": "MIT"
+}


### PR DESCRIPTION
Summary

  - npm install previously reported 7 high-severity vulnerabilities, a deprecation warning (node-domexception@1.0.0), and 2 install-script warnings (sharp, protobufjs). This PR makes npm install fully clean: 0 vulnerabilities, 0 warnings.

  Impact

  - Security: Bumped undici 7.24.6 → 7.28.0 (7 high CVEs: TLS certificate validation bypass via SOCKS5, HTTP header injection via Set-Cookie, WebSocket DoS, cross-origin request routing, HTTP response queue poisoning, SameSite downgrade, cross-user info disclosure) and ws
   8.20.0 → 8.21.0 (2 high CVEs: uninitialized memory disclosure, memory exhaustion DoS).
  - DX: allowScripts field approves sharp@0.34.5 and protobufjs@7.6.4 install scripts, silencing the npm warn allow-scripts noise on every install.
  - DX: Vendored a 1-line node-domexception shim that re-exports Node's native DOMException, overriding the deprecated polyfill pulled transitively by google-auth-library → gaxios → node-fetch@3 → fetch-blob. All published versions of node-domexception are deprecated, so
  a version bump couldn't fix this.

  Testing

  - rm -rf node_modules package-lock.json && npm install → added 499 packages, audited 501 packages in 5s. found 0 vulnerabilities (no warnings)
  - npm audit → 0 vulnerabilities
  - bun install — not yet verified (bun.lock is source of truth; bun's handling of file: overrides should match npm's but worth a confirm)
  - bun run typecheck / bun run build — not yet run

  Notes

  - The node-domexception shim is vendored under vendor/node-domexception-shim/ (2 files, ~10 lines). It's a CommonJS module that does module.exports = globalThis.DOMException — functionally identical to the original on Node 18+, which is well below the project's engines:
   node >=22.0.0 floor.
  - allowScripts was written by npm approve-scripts sharp protobufjs (npm 11 mechanism). The field uses pkg@version keys, not bare package names.
  - No runtime behavior change — node-domexception was only consumed as a polyfill fallback by fetch-blob, which checks globalThis.DOMException first on modern Node.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated bundled dependency versions to newer releases for improved stability and compatibility.
  * Improved runtime compatibility by ensuring `DOMException` is available in more environments via a bundled shim.
  * Adjusted installation behavior to allow install scripts for select packages, improving setup reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->