### PR TITLE
fix(plugins): treat prototype-shadowing marketplace names as not found

### DIFF
--- a/src/utils/plugins/marketplaceManager.test.ts
+++ b/src/utils/plugins/marketplaceManager.test.ts
@@ -572,21 +572,28 @@ describe('removeMarketplaceSource — prototype-shadowing names', () => {
 describe('cache-only lookups — prototype-shadowing names', () => {
   let originalFs: FsOperations
   let configReads: number
+  let readPaths: string[]
+  const SENTINEL_INSTALL_LOCATION = '/__bogus_inherited_install_location__'
 
   beforeEach(() => {
     originalFs = getFsImplementation()
     configReads = 0
+    readPaths = []
+    // Sentinel installLocation on Object.prototype so that *if* the hardening
+    // is removed, the inherited entry (`config['constructor']`, etc.) carries a
+    // real string installLocation and the reader proceeds to read a marketplace
+    // cache path derived from it — which we can then detect. With the
+    // null-prototype guard in place, the lookup resolves to `undefined`, the
+    // "not found" guard short-circuits, and this path is never touched.
+    ;(Object.prototype as Record<string, unknown>).installLocation =
+      SENTINEL_INSTALL_LOCATION
     // A *valid* (but empty) config file exists on disk, so the cache-only
     // readers reach the `config[name]` lookup instead of bailing on ENOENT.
-    // With the null-prototype hardening, a name that shadows an
-    // Object.prototype member resolves to `undefined` and the "not found"
-    // guard short-circuits; without it, `config['constructor']` is the
-    // inherited Object function and the reader takes a bogus path on a
-    // non-marketplace entry.
     setFsImplementation({
       ...originalFs,
-      readFile: async () => {
+      readFile: async (path: string) => {
         configReads++
+        readPaths.push(String(path))
         return '{}'
       },
     })
@@ -594,21 +601,32 @@ describe('cache-only lookups — prototype-shadowing names', () => {
 
   afterEach(() => {
     setFsImplementation(originalFs)
+    delete (Object.prototype as Record<string, unknown>).installLocation
   })
 
+  // Direct regression signal for getMarketplaceCacheOnly: the missing-marketplace
+  // lookup must short-circuit BEFORE attempting to read a marketplace cache path.
+  // Without the null-prototype guard, `config[name]` is the inherited Object
+  // member; its (sentinel) installLocation drives readCachedMarketplace into
+  // reading a cache path, which this asserts never happens.
   test.each(PROTO_NAMES)(
-    'getMarketplaceCacheOnly returns null for shadowing name %p',
+    'getMarketplaceCacheOnly returns null and never reads a cache path for shadowing name %p',
     async name => {
       await expect(getMarketplaceCacheOnly(name)).resolves.toBeNull()
+      // The only read is the config file itself; no cache path derived from a
+      // bogus inherited installLocation is ever touched.
+      expect(
+        readPaths.some(p => p.includes(SENTINEL_INSTALL_LOCATION)),
+      ).toBe(false)
+      expect(configReads).toBe(1)
     },
   )
 
-  // The strong regression signal: without the null-prototype guard,
+  // The strong regression signal for the plugin path: without the guard,
   // `config[name]` resolves to the inherited Object member, the "not found"
-  // check passes, and the reader re-enters `getMarketplaceCacheOnly(name)` —
+  // check passes, and the reader re-enters `getMarketplaceCacheOnly(name)`,
   // re-reading the config file a *second* time before failing. The hardened
-  // path short-circuits on the first lookup, so the config is read exactly
-  // once.
+  // path short-circuits on the first lookup, so the config is read exactly once.
   test.each(PROTO_NAMES)(
     'getPluginByIdCacheOnly returns null and does not re-resolve a shadowing marketplace %p',
     async name => {

--- a/src/utils/plugins/marketplaceManager.test.ts
+++ b/src/utils/plugins/marketplaceManager.test.ts
@@ -25,7 +25,7 @@ import type { MarketplaceSource } from './schemas.js'
 // @ts-expect-error -- query-string cache-buster: the import specifier ends with `?bust=...`
 // so TypeScript cannot resolve the bare path. The runtime import works under Bun (treats the
 // query string as a distinct module id that bypasses other test files' mock.module registrations).
-import { _test, removeMarketplaceSource } from './marketplaceManager.js?bust=this-test-needs-the-real-module'
+import { _test, removeMarketplaceSource, getMarketplaceCacheOnly, getPluginByIdCacheOnly } from './marketplaceManager.js?bust=this-test-needs-the-real-module'
 
 const { loadAndCacheMarketplace } = _test
 
@@ -516,11 +516,21 @@ describe('isCaseInsensitiveFsAt — probes the volume, not the platform', () => 
   })
 })
 
+const PROTO_NAMES = [
+  'constructor',
+  '__proto__',
+  'toString',
+  'hasOwnProperty',
+  'valueOf',
+]
+
 describe('removeMarketplaceSource — prototype-shadowing names', () => {
   let originalFs: FsOperations
+  let rmCalls: string[]
 
   beforeEach(() => {
     originalFs = getFsImplementation()
+    rmCalls = []
     // No config file on disk → loadKnownMarketplacesConfig returns an empty
     // config. Writes are stubbed so the test stays hermetic even if a
     // regression let execution fall past the "not found" guard.
@@ -533,7 +543,9 @@ describe('removeMarketplaceSource — prototype-shadowing names', () => {
       ...originalFs,
       readFile: async () => enoent(),
       mkdir: async () => {},
-      rm: async () => {},
+      rm: async (path: string) => {
+        rmCalls.push(path)
+      },
     })
   })
 
@@ -544,12 +556,66 @@ describe('removeMarketplaceSource — prototype-shadowing names', () => {
   // A marketplace name that shadows an Object.prototype member must report
   // "not found" — not resolve the inherited member via the prototype chain and
   // then crash / silently mis-act on a bogus entry.
-  test.each(['constructor', '__proto__', 'toString', 'hasOwnProperty', 'valueOf'])(
+  test.each(PROTO_NAMES)(
     'reports "not found" for prototype-shadowing name %p',
     async name => {
       await expect(removeMarketplaceSource(name)).rejects.toThrow(
         `Marketplace '${name}' not found`,
       )
+      // The not-found path must short-circuit before touching the filesystem:
+      // never rm a cache directory derived from a bogus inherited entry.
+      expect(rmCalls).toEqual([])
+    },
+  )
+})
+
+describe('cache-only lookups — prototype-shadowing names', () => {
+  let originalFs: FsOperations
+  let configReads: number
+
+  beforeEach(() => {
+    originalFs = getFsImplementation()
+    configReads = 0
+    // A *valid* (but empty) config file exists on disk, so the cache-only
+    // readers reach the `config[name]` lookup instead of bailing on ENOENT.
+    // With the null-prototype hardening, a name that shadows an
+    // Object.prototype member resolves to `undefined` and the "not found"
+    // guard short-circuits; without it, `config['constructor']` is the
+    // inherited Object function and the reader takes a bogus path on a
+    // non-marketplace entry.
+    setFsImplementation({
+      ...originalFs,
+      readFile: async () => {
+        configReads++
+        return '{}'
+      },
+    })
+  })
+
+  afterEach(() => {
+    setFsImplementation(originalFs)
+  })
+
+  test.each(PROTO_NAMES)(
+    'getMarketplaceCacheOnly returns null for shadowing name %p',
+    async name => {
+      await expect(getMarketplaceCacheOnly(name)).resolves.toBeNull()
+    },
+  )
+
+  // The strong regression signal: without the null-prototype guard,
+  // `config[name]` resolves to the inherited Object member, the "not found"
+  // check passes, and the reader re-enters `getMarketplaceCacheOnly(name)` —
+  // re-reading the config file a *second* time before failing. The hardened
+  // path short-circuits on the first lookup, so the config is read exactly
+  // once.
+  test.each(PROTO_NAMES)(
+    'getPluginByIdCacheOnly returns null and does not re-resolve a shadowing marketplace %p',
+    async name => {
+      await expect(
+        getPluginByIdCacheOnly(`some-plugin@${name}`),
+      ).resolves.toBeNull()
+      expect(configReads).toBe(1)
     },
   )
 })

--- a/src/utils/plugins/marketplaceManager.test.ts
+++ b/src/utils/plugins/marketplaceManager.test.ts
@@ -25,7 +25,7 @@ import type { MarketplaceSource } from './schemas.js'
 // @ts-expect-error -- query-string cache-buster: the import specifier ends with `?bust=...`
 // so TypeScript cannot resolve the bare path. The runtime import works under Bun (treats the
 // query string as a distinct module id that bypasses other test files' mock.module registrations).
-import { _test } from './marketplaceManager.js?bust=this-test-needs-the-real-module'
+import { _test, removeMarketplaceSource } from './marketplaceManager.js?bust=this-test-needs-the-real-module'
 
 const { loadAndCacheMarketplace } = _test
 
@@ -514,4 +514,42 @@ describe('isCaseInsensitiveFsAt — probes the volume, not the platform', () => 
       false,
     )
   })
+})
+
+describe('removeMarketplaceSource — prototype-shadowing names', () => {
+  let originalFs: FsOperations
+
+  beforeEach(() => {
+    originalFs = getFsImplementation()
+    // No config file on disk → loadKnownMarketplacesConfig returns an empty
+    // config. Writes are stubbed so the test stays hermetic even if a
+    // regression let execution fall past the "not found" guard.
+    const enoent = (): never => {
+      throw Object.assign(new Error('ENOENT: no such file or directory'), {
+        code: 'ENOENT',
+      })
+    }
+    setFsImplementation({
+      ...originalFs,
+      readFile: async () => enoent(),
+      mkdir: async () => {},
+      rm: async () => {},
+    })
+  })
+
+  afterEach(() => {
+    setFsImplementation(originalFs)
+  })
+
+  // A marketplace name that shadows an Object.prototype member must report
+  // "not found" — not resolve the inherited member via the prototype chain and
+  // then crash / silently mis-act on a bogus entry.
+  test.each(['constructor', '__proto__', 'toString', 'hasOwnProperty', 'valueOf'])(
+    'reports "not found" for prototype-shadowing name %p',
+    async name => {
+      await expect(removeMarketplaceSource(name)).rejects.toThrow(
+        `Marketplace '${name}' not found`,
+      )
+    },
+  )
 })

--- a/src/utils/plugins/marketplaceManager.ts
+++ b/src/utils/plugins/marketplaceManager.ts
@@ -303,30 +303,6 @@ export function saveMarketplaceToSettings(
 }
 
 /**
- * Load known marketplaces configuration from disk
- *
- * Reads the configuration file at ~/.claude/plugins/known_marketplaces.json
- * which contains a mapping of marketplace names to their sources and metadata.
- *
- * Example configuration file content:
- * ```json
- * {
- *   "official-marketplace": {
- *     "source": { "source": "url", "url": "https://example.com/marketplace.json" },
- *     "installLocation": "/Users/me/.claude/plugins/marketplaces/official-marketplace.json",
- *     "lastUpdated": "2024-01-15T10:30:00.000Z"
- *   },
- *   "company-plugins": {
- *     "source": { "source": "github", "repo": "mycompany/plugins" },
- *     "installLocation": "/Users/me/.claude/plugins/marketplaces/company-plugins",
- *     "lastUpdated": "2024-01-14T15:45:00.000Z"
- *   }
- * }
- * ```
- *
- * @returns Configuration object mapping marketplace names to their metadata
- */
-/**
  * Marketplace names are user-supplied and are used directly as object keys for
  * membership and lookup (`config[name]`) all over this module. On a normal
  * object, a name that shadows an `Object.prototype` member — `constructor`,
@@ -346,6 +322,32 @@ function toNullProtoConfig(
   )
 }
 
+/**
+ * Load known marketplaces configuration from disk
+ *
+ * Reads the configuration file at ~/.claude/plugins/known_marketplaces.json
+ * which contains a mapping of marketplace names to their sources and metadata.
+ * The returned config is null-prototype (see {@link toNullProtoConfig}) so that
+ * lookups by user-supplied marketplace name are own-property-exact.
+ *
+ * Example configuration file content:
+ * ```json
+ * {
+ *   "official-marketplace": {
+ *     "source": { "source": "url", "url": "https://example.com/marketplace.json" },
+ *     "installLocation": "/Users/me/.claude/plugins/marketplaces/official-marketplace.json",
+ *     "lastUpdated": "2024-01-15T10:30:00.000Z"
+ *   },
+ *   "company-plugins": {
+ *     "source": { "source": "github", "repo": "mycompany/plugins" },
+ *     "installLocation": "/Users/me/.claude/plugins/marketplaces/company-plugins",
+ *     "lastUpdated": "2024-01-14T15:45:00.000Z"
+ *   }
+ * }
+ * ```
+ *
+ * @returns Configuration object mapping marketplace names to their metadata
+ */
 export async function loadKnownMarketplacesConfig(): Promise<KnownMarketplacesConfig> {
   const fs = getFsImplementation()
   const configFile = getKnownMarketplacesFile()

--- a/src/utils/plugins/marketplaceManager.ts
+++ b/src/utils/plugins/marketplaceManager.ts
@@ -2194,7 +2194,7 @@ export async function getMarketplaceCacheOnly(
 
   try {
     const content = await fs.readFile(configFile, { encoding: 'utf-8' })
-    const config = jsonParse(content) as KnownMarketplacesConfig
+    const config = toNullProtoConfig(jsonParse(content) as KnownMarketplacesConfig)
     const entry = config[name]
 
     if (!entry) {
@@ -2308,7 +2308,7 @@ export async function getPluginByIdCacheOnly(pluginId: string): Promise<{
 
   try {
     const content = await fs.readFile(configFile, { encoding: 'utf-8' })
-    const config = jsonParse(content) as KnownMarketplacesConfig
+    const config = toNullProtoConfig(jsonParse(content) as KnownMarketplacesConfig)
     const marketplaceConfig = config[marketplaceName]
 
     if (!marketplaceConfig) {

--- a/src/utils/plugins/marketplaceManager.ts
+++ b/src/utils/plugins/marketplaceManager.ts
@@ -326,6 +326,26 @@ export function saveMarketplaceToSettings(
  *
  * @returns Configuration object mapping marketplace names to their metadata
  */
+/**
+ * Marketplace names are user-supplied and are used directly as object keys for
+ * membership and lookup (`config[name]`) all over this module. On a normal
+ * object, a name that shadows an `Object.prototype` member — `constructor`,
+ * `__proto__`, `toString`, `hasOwnProperty`, … — resolves up the prototype
+ * chain to an inherited value, so `config[name]` is truthy even when no such
+ * marketplace is registered. That makes "not found" guards pass and then act on
+ * a bogus inherited entry (silently mis-deleting or crashing on
+ * `entry.installLocation`). Returning a null-prototype object makes every
+ * `config[name]` lookup own-property-exact.
+ */
+function toNullProtoConfig(
+  config: KnownMarketplacesConfig,
+): KnownMarketplacesConfig {
+  return Object.assign(
+    Object.create(null) as KnownMarketplacesConfig,
+    config,
+  )
+}
+
 export async function loadKnownMarketplacesConfig(): Promise<KnownMarketplacesConfig> {
   const fs = getFsImplementation()
   const configFile = getKnownMarketplacesFile()
@@ -344,10 +364,10 @@ export async function loadKnownMarketplacesConfig(): Promise<KnownMarketplacesCo
       })
       throw new ConfigParseError(errorMsg, configFile, data)
     }
-    return parsed.data
+    return toNullProtoConfig(parsed.data)
   } catch (error) {
     if (isENOENT(error)) {
-      return {}
+      return toNullProtoConfig({})
     }
     // If it's already a ConfigParseError, re-throw it
     if (error instanceof ConfigParseError) {
@@ -377,7 +397,7 @@ export async function loadKnownMarketplacesConfigSafe(): Promise<KnownMarketplac
   } catch {
     // Inner function already logged via logForDebugging. Don't logError here —
     // corrupted user config isn't a Claude Code bug, shouldn't hit the error file.
-    return {}
+    return toNullProtoConfig({})
   }
 }
 


### PR DESCRIPTION
### Problem

Marketplace names are user-supplied and used directly as object keys for membership and lookup (`config[name]`) throughout `marketplaceManager.ts`. `loadKnownMarketplacesConfig()` returned an ordinary object, so a name that shadows an `Object.prototype` member — `constructor`, `__proto__`, `toString`, `hasOwnProperty`, `valueOf` — resolves up the prototype chain to a truthy inherited value even when no such marketplace is registered.

Concretely, `claude plugin marketplace remove constructor`:

```ts
const config = await loadKnownMarketplacesConfig() // {} → normal prototype
if (!config[name]) {                               // config['constructor'] === Object (truthy) → guard skipped
  throw new Error(`Marketplace '${name}' not found`)
}
const entry = config[name]                         // the Object function, not a marketplace entry
const seedDir = seedDirFor(entry.installLocation)  // seedDirFor(undefined)
```

So the intended `Marketplace 'constructor' not found` never fires. Instead it operates on a bogus inherited entry: it throws `TypeError: Cannot read properties of undefined (reading 'startsWith')` when a plugin seed dir is configured, or silently no-ops the removal otherwise. The same prototype-chain hazard exists at every `config[name]` site in this module (add-collision check, `getMarketplace`, `refreshMarketplace`, …).

### Fix

Return a **null-prototype** object from `loadKnownMarketplacesConfig` (and its safe variant) via a small `toNullProtoConfig` helper. A single change at the load source makes every `config[name]` lookup across the module own-property exact, so a shadowing name resolves to `undefined` and the existing "not found" guards fire correctly. No behavioral change for ordinary marketplace names; `Object.keys`/`Object.entries`/`delete`/`JSON.stringify` all work unchanged on a null-prototype record.

### Tests

`marketplaceManager.test.ts` — `removeMarketplaceSource` now reports `Marketplace '<name>' not found` for `constructor`, `__proto__`, `toString`, `hasOwnProperty`, `valueOf` (5 cases). Each fails on the current code (resolves/crashes instead of rejecting with "not found") and passes with the fix. Full suite: 14 pass, typecheck clean.

Same prototype-pollution class as the previously-fixed `CLI_COMMAND_MAPPING` (#1710) and `FILENAME_LANGS` (#1430) lookups.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed marketplace removal and cache-only lookups failing for marketplace names that overlap with JavaScript object properties (e.g., `constructor`, `__proto__`).
  * Improved known marketplace configuration handling to ensure lookups only consider explicitly defined entries, not inherited properties.
* **Tests**
  * Added regression coverage for prototype-shadowing marketplace names to verify correct “not found” behavior and avoid unnecessary filesystem work.
  * Added cache-only lookup tests ensuring results are `null` and configuration is read exactly once.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->