### PR TITLE
fix(xiaomi): Update Xiaomi MiMo v2.5 catalog reasoning

### DIFF
--- a/src/integrations/gateways/xiaomi-mimo-token.test.ts
+++ b/src/integrations/gateways/xiaomi-mimo-token.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'bun:test'
 
-import '../index.js'
+import { getCatalogEntriesForRoute } from '../index.js'
 import {
   getRouteDefaultBaseUrl,
   getRouteDefaultModel,
@@ -16,6 +16,22 @@ describe('xiaomi-mimo-token gateway', () => {
 
   test('default model is mimo-v2.5-pro', () => {
     expect(getRouteDefaultModel('xiaomi-mimo-token')).toBe('mimo-v2.5-pro')
+  })
+
+  test('catalog is limited to supported v2.5 chat models with OpenAI-compatible reasoning effort', () => {
+    const entries = getCatalogEntriesForRoute('xiaomi-mimo-token')
+    expect(entries.map(model => model.apiName)).toEqual([
+      'mimo-v2.5-pro',
+      'mimo-v2.5',
+    ])
+    for (const entry of entries) {
+      expect(entry.reasoning).toEqual({
+        mode: 'levels',
+        levels: ['low', 'medium', 'high'],
+        defaultLevel: 'medium',
+        wireFormat: 'reasoning_effort',
+      })
+    }
   })
 
   test('resolves token-plan SGP base URL', () => {

--- a/src/integrations/gateways/xiaomi-mimo-token.ts
+++ b/src/integrations/gateways/xiaomi-mimo-token.ts
@@ -1,28 +1,4 @@
-import { defineCatalog, defineGateway } from '../define.js'
-
-const catalog = defineCatalog({
-  source: 'static',
-  models: [
-    {
-      id: 'mimo-v2.5-pro',
-      apiName: 'mimo-v2.5-pro',
-      label: 'MiMo V2.5 Pro',
-      modelDescriptorId: 'mimo-v2.5-pro',
-    },
-    {
-      id: 'mimo-v2.5',
-      apiName: 'mimo-v2.5',
-      label: 'MiMo V2.5',
-      modelDescriptorId: 'mimo-v2.5',
-    },
-    {
-      id: 'mimo-v2-flash',
-      apiName: 'mimo-v2-flash',
-      label: 'MiMo V2 Flash',
-      modelDescriptorId: 'mimo-v2-flash',
-    },
-  ],
-})
+import { defineGateway } from '../define.js'
 
 export default defineGateway({
   id: 'xiaomi-mimo-token',
@@ -73,6 +49,12 @@ export default defineGateway({
     missingCredentialMessage:
       'Xiaomi MiMo Token Plan auth is required. Set MIMO_API_KEY or OPENAI_API_KEY.',
   },
-  catalog,
+  catalog: {
+    source: 'static',
+    models: [
+      { id: 'mimo-v2.5-pro', apiName: 'mimo-v2.5-pro', label: 'MiMo V2.5 Pro', modelDescriptorId: 'mimo-v2.5-pro', reasoning: { mode: 'levels', levels: ['low', 'medium', 'high'], defaultLevel: 'medium', wireFormat: 'reasoning_effort' } },
+      { id: 'mimo-v2.5', apiName: 'mimo-v2.5', label: 'MiMo V2.5', modelDescriptorId: 'mimo-v2.5', reasoning: { mode: 'levels', levels: ['low', 'medium', 'high'], defaultLevel: 'medium', wireFormat: 'reasoning_effort' } },
+    ],
+  },
   usage: { supported: false },
 })

--- a/src/integrations/vendors/xiaomi-mimo.ts
+++ b/src/integrations/vendors/xiaomi-mimo.ts
@@ -1,28 +1,4 @@
-import { defineCatalog, defineVendor } from '../define.js'
-
-const catalog = defineCatalog({
-  source: 'static',
-  models: [
-    {
-      id: 'mimo-v2.5-pro',
-      apiName: 'mimo-v2.5-pro',
-      label: 'MiMo V2.5 Pro',
-      modelDescriptorId: 'mimo-v2.5-pro',
-    },
-    {
-      id: 'mimo-v2.5',
-      apiName: 'mimo-v2.5',
-      label: 'MiMo V2.5',
-      modelDescriptorId: 'mimo-v2.5',
-    },
-    {
-      id: 'mimo-v2-flash',
-      apiName: 'mimo-v2-flash',
-      label: 'MiMo V2 Flash',
-      modelDescriptorId: 'mimo-v2-flash',
-    },
-  ],
-})
+import { defineVendor } from '../define.js'
 
 export default defineVendor({
   id: 'xiaomi-mimo',
@@ -70,6 +46,12 @@ export default defineVendor({
     missingCredentialMessage:
       'Xiaomi MiMo auth is required. Set MIMO_API_KEY or OPENAI_API_KEYS / OPENAI_API_KEY.',
   },
-  catalog,
+  catalog: {
+    source: 'static',
+    models: [
+      { id: 'mimo-v2.5-pro', apiName: 'mimo-v2.5-pro', label: 'MiMo V2.5 Pro', modelDescriptorId: 'mimo-v2.5-pro', reasoning: { mode: 'levels', levels: ['low', 'medium', 'high'], defaultLevel: 'medium', wireFormat: 'reasoning_effort' } },
+      { id: 'mimo-v2.5', apiName: 'mimo-v2.5', label: 'MiMo V2.5', modelDescriptorId: 'mimo-v2.5', reasoning: { mode: 'levels', levels: ['low', 'medium', 'high'], defaultLevel: 'medium', wireFormat: 'reasoning_effort' } },
+    ],
+  },
   usage: { supported: false },
 })

--- a/src/services/api/openaiShim.test.ts
+++ b/src/services/api/openaiShim.test.ts
@@ -2493,6 +2493,44 @@ test('xiaomi mimo route uses api-key auth header and max_completion_tokens', asy
   expect(capturedBody).toMatchObject({ max_completion_tokens: 32 })
   expect(capturedBody).not.toHaveProperty('max_tokens')
 })
+test('xiaomi mimo token plan uses raw api-key and OpenAI-compatible reasoning_effort', async () => {
+  let capturedHeaders: Record<string, string> | undefined
+  let capturedBody: Record<string, unknown> | undefined
+
+  process.env.CLAUDE_CODE_USE_OPENAI = '1'
+  process.env.OPENAI_BASE_URL = 'https://token-plan-sgp.xiaomimimo.com/v1'
+  process.env.OPENAI_MODEL = 'mimo-v2.5-pro'
+  process.env.MIMO_API_KEY = 'mimo-token-key'
+  delete process.env.OPENAI_API_KEY
+
+  globalThis.fetch = (async (_input, init) => {
+    capturedHeaders = init?.headers as Record<string, string>
+    capturedBody = JSON.parse(String(init?.body)) as Record<string, unknown>
+
+    return makeChatCompletionResponse('mimo-v2.5-pro')
+  }) as unknown as FetchType
+
+  const client = createOpenAIShimClient({
+    reasoningEffort: 'high',
+  }) as OpenAIShimClient
+
+  await client.beta.messages.create({
+    model: 'mimo-v2.5-pro',
+    messages: [{ role: 'user', content: 'hello' }],
+    max_tokens: 32,
+    stream: false,
+  })
+
+  expect(capturedHeaders).toMatchObject({ 'api-key': 'mimo-token-key' })
+  expect(capturedHeaders).not.toHaveProperty('Authorization')
+  expect(capturedBody).toMatchObject({
+    max_completion_tokens: 32,
+    reasoning_effort: 'high',
+  })
+  expect(capturedBody).not.toHaveProperty('max_tokens')
+  expect(capturedBody).not.toHaveProperty('store')
+  expect(capturedBody).not.toHaveProperty('stream_options')
+})
 
 test.each([
   'minimax-m3',


### PR DESCRIPTION
## Summary

- Limit the direct Xiaomi MiMo and Xiaomi MiMo Token Plan catalogs to the currently supported `mimo-v2.5-pro` and `mimo-v2.5` chat models.
- Remove the unsupported/deprecated `mimo-v2-flash` catalog entry from those Xiaomi routes.
- Add catalog reasoning metadata for OpenAI-compatible `reasoning_effort` levels `low`, `medium`, and `high`.
- Add tests for the token-plan catalog shape and the existing OpenAI-compatible shim request path, including raw `api-key` auth and `reasoning_effort` serialization.

## Impact

This keeps Xiaomi MiMo model selection aligned with the currently available v2.5 model set and exposes supported reasoning-effort choices without adding Xiaomi-specific shim serialization. Requests continue through the existing OpenAI-compatible provider path.

## Provider Path Tested

- Xiaomi MiMo Token Plan: `https://token-plan-sgp.xiaomimimo.com/v1`
- Model path: `mimo-v2.5-pro`
- Auth path: `MIMO_API_KEY` sent as raw `api-key`
- Reasoning path: OpenAI-compatible `reasoning_effort`

## Checks Run

- `bun run build`
- `bun run smoke`
- `bun run check`
- `bun run test:full`
- `bun run test:provider`
- `bun run test:provider-recommendation`
- `bun run typecheck`
- `bun run typecheck:type-tests`
- `python -m pytest -q python/tests`
- `bun run integrations:check`
- `bun test src/integrations/gateways/xiaomi-mimo-token.test.ts src/services/api/openaiShim.test.ts --feature=UNATTENDED_RETRY --max-concurrency=1`
- `git diff --check`
- `bun run scripts/pr-intent-scan.ts --base upstream/main`

## Screenshots

Not applicable; this changes provider catalog metadata and tests only.

## Issue

No linked issue.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated Xiaomi MiMo support to surface only the supported models and include configurable reasoning levels in requests.
* **Bug Fixes**
  * Improved request handling for the Xiaomi MiMo token plan so it uses the expected API key header and sends compatible completion settings.
* **Tests**
  * Added coverage for supported model selection and request payload formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->