### PR TITLE
feat(cli): add headless heartbeat for print mode

### DIFF
--- a/scripts/generate-sdk-types.ts
+++ b/scripts/generate-sdk-types.ts
@@ -13,7 +13,7 @@
  * are replaced via TypeOverrideMap with real TS type references.
  */
 
-import { writeFileSync } from 'fs'
+import { realpathSync, writeFileSync } from 'fs'
 import { resolve, dirname } from 'path'
 import { fileURLToPath } from 'url'
 import * as schemas from '../src/entrypoints/sdk/coreSchemas.js'
@@ -450,6 +450,16 @@ function writeGeneratedSdkTypes(): void {
   console.log(`✓ Written to ${outPath}`)
 }
 
-if (process.argv[1] && resolve(process.argv[1]) === scriptPath) {
+function isDirectExecution(): boolean {
+  if (!process.argv[1]) {
+    return false
+  }
+  return (
+    realpathSync.native(resolve(process.argv[1])) ===
+    realpathSync.native(scriptPath)
+  )
+}
+
+if (isDirectExecution()) {
   writeGeneratedSdkTypes()
 }

--- a/scripts/generate-sdk-types.ts
+++ b/scripts/generate-sdk-types.ts
@@ -454,10 +454,19 @@ function isDirectExecution(): boolean {
   if (!process.argv[1]) {
     return false
   }
-  return (
-    realpathSync.native(resolve(process.argv[1])) ===
-    realpathSync.native(scriptPath)
+  const invokedPath = realpathOrUndefined(resolve(process.argv[1]))
+  const currentScriptPath = realpathOrUndefined(scriptPath)
+  return Boolean(
+    invokedPath && currentScriptPath && invokedPath === currentScriptPath,
   )
+}
+
+function realpathOrUndefined(path: string): string | undefined {
+  try {
+    return realpathSync.native(path)
+  } catch {
+    return undefined
+  }
 }
 
 if (isDirectExecution()) {

--- a/scripts/generate-sdk-types.ts
+++ b/scripts/generate-sdk-types.ts
@@ -18,7 +18,8 @@ import { resolve, dirname } from 'path'
 import { fileURLToPath } from 'url'
 import * as schemas from '../src/entrypoints/sdk/coreSchemas.js'
 
-const __dirname = dirname(fileURLToPath(import.meta.url))
+const scriptPath = fileURLToPath(import.meta.url)
+const __dirname = dirname(scriptPath)
 const outPath = resolve(
   __dirname, '..', 'src', 'entrypoints', 'sdk', 'coreTypes.generated.ts',
 )
@@ -375,7 +376,7 @@ function needsArrayElementParens(ts: string): boolean {
 // Generation
 // ---------------------------------------------------------------------------
 
-function generate(): string {
+export function generateSdkTypes(): string {
   const lines: string[] = [
     '// AUTO-GENERATED — do not edit manually.',
     '// Regenerate with: bun scripts/generate-sdk-types.ts',
@@ -442,7 +443,13 @@ function generate(): string {
 // Main
 // ---------------------------------------------------------------------------
 
-console.log('Generating SDK types from Zod schemas...')
-const output = generate()
-writeFileSync(outPath, output, 'utf-8')
-console.log(`✓ Written to ${outPath}`)
+function writeGeneratedSdkTypes(): void {
+  console.log('Generating SDK types from Zod schemas...')
+  const output = generateSdkTypes()
+  writeFileSync(outPath, output, 'utf-8')
+  console.log(`✓ Written to ${outPath}`)
+}
+
+if (process.argv[1] && resolve(process.argv[1]) === scriptPath) {
+  writeGeneratedSdkTypes()
+}

--- a/scripts/generate-sdk-types.ts
+++ b/scripts/generate-sdk-types.ts
@@ -208,6 +208,7 @@ const EXPORT_ORDER = [
   'SDKTaskStartedMessageSchema',
   'SDKTaskProgressMessageSchema',
   'SDKSessionStateChangedMessageSchema',
+  'SDKHeartbeatMessageSchema',
   'SDKToolUseSummaryMessageSchema',
   'SDKElicitationCompleteMessageSchema',
   'SDKPromptSuggestionMessageSchema',

--- a/src/cli/headlessHeartbeat.test.ts
+++ b/src/cli/headlessHeartbeat.test.ts
@@ -467,15 +467,27 @@ test('heartbeat events are excluded from final-result and verbose JSON selection
     permission_denials: [],
     uuid: 'result-uuid',
   }
+  const filesPersistedMessage = {
+    type: 'system',
+    subtype: 'files_persisted',
+    files: [],
+    failed: [],
+    processed_at: '2026-06-25T12:00:31.000Z',
+    uuid: 'files-uuid',
+    session_id: 'session-id',
+  }
 
   expect(shouldSelectHeadlessFinalMessage(heartbeatMessage)).toBe(false)
+  expect(shouldSelectHeadlessFinalMessage(filesPersistedMessage)).toBe(false)
   expect(isHeadlessHeartbeatMessage(heartbeatMessage)).toBe(true)
   expect(isHeadlessHeartbeatMessage('partial output')).toBe(false)
   expect(shouldSelectHeadlessFinalMessage(resultMessage)).toBe(true)
   expect(shouldSelectHeadlessFinalMessage(null)).toBe(false)
   expect(shouldSelectHeadlessFinalMessage('partial output')).toBe(false)
   expect(shouldSelectHeadlessFinalMessage({})).toBe(false)
-  expect([heartbeatMessage, resultMessage].filter(shouldSelectHeadlessFinalMessage)).toEqual([
-    resultMessage,
-  ])
+  expect(
+    [heartbeatMessage, resultMessage, filesPersistedMessage].filter(
+      shouldSelectHeadlessFinalMessage,
+    ),
+  ).toEqual([resultMessage])
 })

--- a/src/cli/headlessHeartbeat.test.ts
+++ b/src/cli/headlessHeartbeat.test.ts
@@ -203,6 +203,33 @@ describe('createHeadlessHeartbeat', () => {
     expect(JSON.stringify(structured[0])).not.toContain('cwd')
   })
 
+  test('clamps emitted durations when the system clock moves backward', () => {
+    const clock = createFakeClock(10_000)
+    const structured: Array<Record<string, unknown>> = []
+    const heartbeat = createHeadlessHeartbeat({
+      intervalMs: HEADLESS_HEARTBEAT_MIN_INTERVAL_MS,
+      outputFormat: 'stream-json',
+      emitStructured: event => {
+        structured.push(event)
+      },
+      now: clock.now,
+      setInterval: clock.setInterval,
+      clearInterval: clock.clearInterval,
+    })
+
+    heartbeat.start()
+    clock.setNow(0)
+    heartbeat.markActivity()
+    clock.advance(HEADLESS_HEARTBEAT_MIN_INTERVAL_MS)
+    clock.tick()
+
+    expect(structured).toHaveLength(1)
+    expect(structured[0]).toMatchObject({
+      elapsed_ms: 0,
+      since_last_activity_ms: HEADLESS_HEARTBEAT_MIN_INTERVAL_MS,
+    })
+  })
+
   test('falls back to safe metadata defaults when heartbeat getters throw', () => {
     const clock = createFakeClock(0)
     const structured: Array<Record<string, unknown>> = []

--- a/src/cli/headlessHeartbeat.test.ts
+++ b/src/cli/headlessHeartbeat.test.ts
@@ -1,0 +1,451 @@
+import { describe, expect, mock, test } from 'bun:test'
+import {
+  createHeadlessHeartbeat,
+  HEADLESS_HEARTBEAT_MAX_INTERVAL_MS,
+  HEADLESS_HEARTBEAT_MIN_INTERVAL_MS,
+  parseHeadlessHeartbeatDuration,
+  shouldSelectHeadlessFinalMessage,
+  validateHeadlessHeartbeatPrintMode,
+} from './headlessHeartbeat.js'
+
+type FakeTimer = {
+  active: boolean
+  callback: () => void
+  intervalMs: number
+  unref: ReturnType<typeof mock>
+}
+
+function createFakeClock(startMs = 0) {
+  let nowMs = startMs
+  const timers: FakeTimer[] = []
+  const cleared: FakeTimer[] = []
+
+  return {
+    now: () => nowMs,
+    setNow: (nextMs: number) => {
+      nowMs = nextMs
+    },
+    advance: (deltaMs: number) => {
+      nowMs += deltaMs
+    },
+    setInterval: (callback: () => void, intervalMs: number) => {
+      const timer: FakeTimer = {
+        active: true,
+        callback,
+        intervalMs,
+        unref: mock(() => {}),
+      }
+      timers.push(timer)
+      return timer
+    },
+    clearInterval: (timer: unknown) => {
+      const fakeTimer = timer as FakeTimer
+      fakeTimer.active = false
+      cleared.push(fakeTimer)
+    },
+    tick: () => {
+      for (const timer of timers) {
+        if (timer.active) {
+          timer.callback()
+        }
+      }
+    },
+    timers,
+    cleared,
+  }
+}
+
+describe('parseHeadlessHeartbeatDuration', () => {
+  test('accepts explicit millisecond, second, and minute durations', () => {
+    expect(parseHeadlessHeartbeatDuration('5000ms')).toBe(5_000)
+    expect(parseHeadlessHeartbeatDuration('5s')).toBe(5_000)
+    expect(parseHeadlessHeartbeatDuration('30s')).toBe(30_000)
+    expect(parseHeadlessHeartbeatDuration('2m')).toBe(120_000)
+  })
+
+  test('rejects invalid, zero, negative, sub-minimum, and oversized durations', () => {
+    for (const value of ['abc', '', '5000', '1h', '-1s']) {
+      expect(() => parseHeadlessHeartbeatDuration(value)).toThrow(
+        '--heartbeat must be a duration like 30s, 2m, or 5000ms.',
+      )
+    }
+
+    for (const value of ['0', '0s', '1s', '4999ms']) {
+      expect(() => parseHeadlessHeartbeatDuration(value)).toThrow(
+        '--heartbeat must be at least 5s.',
+      )
+    }
+
+    expect(() =>
+      parseHeadlessHeartbeatDuration(`${HEADLESS_HEARTBEAT_MAX_INTERVAL_MS + 1}ms`),
+    ).toThrow(
+      `--heartbeat must be no more than ${HEADLESS_HEARTBEAT_MAX_INTERVAL_MS}ms.`,
+    )
+    expect(() => parseHeadlessHeartbeatDuration('9999999999999999s')).toThrow(
+      `--heartbeat must be no more than ${HEADLESS_HEARTBEAT_MAX_INTERVAL_MS}ms.`,
+    )
+  })
+})
+
+describe('createHeadlessHeartbeat', () => {
+  test('emits a quiet-based stderr heartbeat and uses unref', () => {
+    const clock = createFakeClock(1_000)
+    const stderrLines: string[] = []
+
+    const heartbeat = createHeadlessHeartbeat({
+      intervalMs: HEADLESS_HEARTBEAT_MIN_INTERVAL_MS,
+      outputFormat: 'text',
+      getSessionId: () => 'session-1',
+      getState: () => 'running',
+      initialPhase: 'in_turn',
+      emitStderr: line => stderrLines.push(line),
+      now: clock.now,
+      setInterval: clock.setInterval,
+      clearInterval: clock.clearInterval,
+    })
+
+    heartbeat.start()
+    expect(clock.timers).toHaveLength(1)
+    expect(clock.timers[0]!.intervalMs).toBe(HEADLESS_HEARTBEAT_MIN_INTERVAL_MS)
+    expect(clock.timers[0]!.unref).toHaveBeenCalledTimes(1)
+
+    clock.advance(4_999)
+    clock.tick()
+    expect(stderrLines).toEqual([])
+
+    clock.advance(1)
+    clock.tick()
+    expect(stderrLines).toHaveLength(1)
+    expect(stderrLines[0]).toContain('openclaude: heartbeat')
+    expect(stderrLines[0]).toContain('elapsed=5s')
+    expect(stderrLines[0]).toContain('quiet=5s')
+    expect(stderrLines[0]).toContain('state=running')
+    expect(stderrLines[0]).toContain('phase=in_turn')
+    expect(stderrLines[0]).toContain('session=session-1')
+  })
+
+  test('suppresses heartbeats while normal activity is flowing', () => {
+    const clock = createFakeClock(0)
+    const stderrLines: string[] = []
+    const heartbeat = createHeadlessHeartbeat({
+      intervalMs: HEADLESS_HEARTBEAT_MIN_INTERVAL_MS,
+      outputFormat: 'json',
+      emitStderr: line => stderrLines.push(line),
+      now: clock.now,
+      setInterval: clock.setInterval,
+      clearInterval: clock.clearInterval,
+    })
+
+    heartbeat.start()
+    clock.advance(4_000)
+    heartbeat.markActivity()
+    expect(clock.cleared).toHaveLength(1)
+    expect(clock.timers).toHaveLength(2)
+    expect(clock.timers[0]!.active).toBe(false)
+    expect(clock.timers[1]!.active).toBe(true)
+
+    clock.advance(1_000)
+    clock.tick()
+    expect(stderrLines).toEqual([])
+
+    clock.advance(3_999)
+    clock.tick()
+    expect(stderrLines).toEqual([])
+
+    clock.advance(1)
+    clock.tick()
+    expect(stderrLines).toHaveLength(1)
+    expect(stderrLines[0]).toContain('quiet=5s')
+  })
+
+  test('emits structured stream-json heartbeat events with safe metadata only', () => {
+    const clock = createFakeClock(10_000)
+    const structured: Array<Record<string, unknown>> = []
+    const heartbeat = createHeadlessHeartbeat({
+      intervalMs: HEADLESS_HEARTBEAT_MIN_INTERVAL_MS,
+      outputFormat: 'stream-json',
+      getSessionId: () => 'session-2',
+      getState: () => 'requires_action',
+      initialPhase: 'waiting_for_permission',
+      getPendingPermissionRequests: () => ['request-1'],
+      getBackgroundTaskCounts: () => ({ local_agent: 2, local_workflow: 1 }),
+      emitStructured: event => {
+        structured.push(event)
+      },
+      now: clock.now,
+      setInterval: clock.setInterval,
+      clearInterval: clock.clearInterval,
+      createUuid: () => 'uuid-1',
+    })
+
+    heartbeat.start()
+    clock.advance(5_000)
+    clock.tick()
+
+    expect(structured).toEqual([
+      {
+        type: 'system',
+        subtype: 'heartbeat',
+        timestamp: '1970-01-01T00:00:15.000Z',
+        elapsed_ms: 5_000,
+        since_last_activity_ms: 5_000,
+        state: 'requires_action',
+        phase: 'waiting_for_permission',
+        heartbeat_index: 1,
+        pending_permission_requests: 1,
+        background_tasks: { local_agent: 2, local_workflow: 1 },
+        uuid: 'uuid-1',
+        session_id: 'session-2',
+      },
+    ])
+    expect(JSON.stringify(structured[0])).not.toContain('prompt')
+    expect(JSON.stringify(structured[0])).not.toContain('cwd')
+  })
+
+  test('falls back to safe metadata defaults when heartbeat getters throw', () => {
+    const clock = createFakeClock(0)
+    const structured: Array<Record<string, unknown>> = []
+    const throwMetadataError = () => {
+      throw new Error('metadata unavailable')
+    }
+    const heartbeat = createHeadlessHeartbeat({
+      intervalMs: HEADLESS_HEARTBEAT_MIN_INTERVAL_MS,
+      outputFormat: 'stream-json',
+      getSessionId: throwMetadataError,
+      getState: throwMetadataError,
+      getPendingPermissionRequests: throwMetadataError,
+      getBackgroundTaskCounts: throwMetadataError,
+      emitStructured: event => {
+        structured.push(event)
+      },
+      now: clock.now,
+      setInterval: clock.setInterval,
+      clearInterval: clock.clearInterval,
+      createUuid: throwMetadataError,
+    })
+
+    heartbeat.start()
+    clock.advance(HEADLESS_HEARTBEAT_MIN_INTERVAL_MS)
+
+    expect(() => clock.tick()).not.toThrow()
+    expect(structured).toHaveLength(1)
+    expect(structured[0]).toMatchObject({
+      state: 'running',
+      pending_permission_requests: 0,
+      background_tasks: {},
+      uuid: '',
+      session_id: '',
+    })
+  })
+
+  test('updates phase and heartbeat index across emissions', () => {
+    const clock = createFakeClock(0)
+    const structured: Array<Record<string, unknown>> = []
+    const heartbeat = createHeadlessHeartbeat({
+      intervalMs: HEADLESS_HEARTBEAT_MIN_INTERVAL_MS,
+      outputFormat: 'stream-json',
+      initialPhase: 'startup',
+      emitStructured: event => {
+        structured.push(event)
+      },
+      now: clock.now,
+      setInterval: clock.setInterval,
+      clearInterval: clock.clearInterval,
+      createUuid: () => `uuid-${structured.length + 1}`,
+    })
+
+    heartbeat.start()
+    clock.advance(5_000)
+    clock.tick()
+    heartbeat.setPhase('flushing')
+    clock.advance(5_000)
+    clock.tick()
+
+    expect(structured.map(event => event.phase)).toEqual(['startup', 'flushing'])
+    expect(structured.map(event => event.heartbeat_index)).toEqual([1, 2])
+  })
+
+  test('stop is idempotent and clears the active timer', () => {
+    const clock = createFakeClock()
+    const heartbeat = createHeadlessHeartbeat({
+      intervalMs: HEADLESS_HEARTBEAT_MIN_INTERVAL_MS,
+      outputFormat: 'text',
+      emitStderr: () => {},
+      now: clock.now,
+      setInterval: clock.setInterval,
+      clearInterval: clock.clearInterval,
+    })
+
+    heartbeat.start()
+    heartbeat.stop()
+    heartbeat.stop()
+
+    expect(clock.cleared).toHaveLength(1)
+    expect(clock.timers[0]!.active).toBe(false)
+  })
+
+  test('treats a zero timer handle as active', () => {
+    const setIntervalMock = mock(() => 0)
+    const clearIntervalMock = mock(() => {})
+    const heartbeat = createHeadlessHeartbeat({
+      intervalMs: HEADLESS_HEARTBEAT_MIN_INTERVAL_MS,
+      outputFormat: 'text',
+      now: () => 0,
+      setInterval: setIntervalMock,
+      clearInterval: clearIntervalMock,
+    })
+
+    heartbeat.start()
+    heartbeat.start()
+    expect(setIntervalMock).toHaveBeenCalledTimes(1)
+
+    heartbeat.markActivity()
+    expect(clearIntervalMock).toHaveBeenCalledWith(0)
+    expect(setIntervalMock).toHaveBeenCalledTimes(2)
+
+    heartbeat.stop()
+    heartbeat.stop()
+    expect(clearIntervalMock).toHaveBeenCalledTimes(2)
+  })
+
+  test('restart resets the heartbeat index and phase for the next run', () => {
+    const clock = createFakeClock()
+    const structured: Array<Record<string, unknown>> = []
+    const heartbeat = createHeadlessHeartbeat({
+      intervalMs: HEADLESS_HEARTBEAT_MIN_INTERVAL_MS,
+      outputFormat: 'stream-json',
+      initialPhase: 'startup',
+      emitStructured: event => {
+        structured.push(event)
+      },
+      now: clock.now,
+      setInterval: clock.setInterval,
+      clearInterval: clock.clearInterval,
+    })
+
+    heartbeat.start()
+    clock.advance(HEADLESS_HEARTBEAT_MIN_INTERVAL_MS)
+    clock.tick()
+    heartbeat.setPhase('flushing')
+    heartbeat.stop()
+    heartbeat.start()
+    clock.advance(HEADLESS_HEARTBEAT_MIN_INTERVAL_MS)
+    clock.tick()
+
+    expect(structured.map(event => event.heartbeat_index)).toEqual([1, 1])
+    expect(structured.map(event => event.phase)).toEqual(['startup', 'startup'])
+  })
+
+  test('ignores heartbeat write failures from closed outputs', () => {
+    const clock = createFakeClock()
+    const heartbeat = createHeadlessHeartbeat({
+      intervalMs: HEADLESS_HEARTBEAT_MIN_INTERVAL_MS,
+      outputFormat: 'text',
+      emitStderr: () => {
+        throw Object.assign(new Error('stderr closed'), { code: 'EPIPE' })
+      },
+      now: clock.now,
+      setInterval: clock.setInterval,
+      clearInterval: clock.clearInterval,
+    })
+
+    heartbeat.start()
+    clock.advance(5_000)
+
+    expect(() => clock.tick()).not.toThrow()
+  })
+
+  test('rejects oversized intervals before scheduling', () => {
+    expect(() =>
+      createHeadlessHeartbeat({
+        intervalMs: HEADLESS_HEARTBEAT_MAX_INTERVAL_MS + 1,
+      }),
+    ).toThrow(
+      `--heartbeat must be no more than ${HEADLESS_HEARTBEAT_MAX_INTERVAL_MS}ms.`,
+    )
+  })
+
+  test('rejects stream-json heartbeat output without a structured sink', () => {
+    expect(() =>
+      createHeadlessHeartbeat({
+        intervalMs: HEADLESS_HEARTBEAT_MIN_INTERVAL_MS,
+        outputFormat: 'stream-json',
+      }),
+    ).toThrow('stream-json heartbeat output requires a structured sink.')
+  })
+
+  test('text and json heartbeats use stderr, not structured stdout', () => {
+    for (const outputFormat of ['text', 'json']) {
+      const clock = createFakeClock()
+      const stderrLines: string[] = []
+      const structured: unknown[] = []
+      const heartbeat = createHeadlessHeartbeat({
+        intervalMs: HEADLESS_HEARTBEAT_MIN_INTERVAL_MS,
+        outputFormat,
+        emitStderr: line => stderrLines.push(line),
+        emitStructured: event => {
+          structured.push(event)
+        },
+        now: clock.now,
+        setInterval: clock.setInterval,
+        clearInterval: clock.clearInterval,
+      })
+
+      heartbeat.start()
+      clock.advance(HEADLESS_HEARTBEAT_MIN_INTERVAL_MS)
+      clock.tick()
+
+      expect(stderrLines).toHaveLength(1)
+      expect(structured).toEqual([])
+    }
+  })
+})
+
+test('validateHeadlessHeartbeatPrintMode rejects heartbeat without --print', () => {
+  expect(() => validateHeadlessHeartbeatPrintMode(undefined, false)).not.toThrow()
+  expect(() => validateHeadlessHeartbeatPrintMode(5_000, true)).not.toThrow()
+  expect(() => validateHeadlessHeartbeatPrintMode(5_000, false)).toThrow(
+    '--heartbeat can only be used with --print.',
+  )
+})
+
+test('heartbeat events are excluded from final-result and verbose JSON selection', () => {
+  const heartbeatMessage = {
+    type: 'system',
+    subtype: 'heartbeat',
+    timestamp: '2026-06-25T12:00:30.000Z',
+    elapsed_ms: 30_000,
+    since_last_activity_ms: 30_000,
+    state: 'running',
+    phase: 'in_turn',
+    heartbeat_index: 1,
+    pending_permission_requests: 0,
+    background_tasks: {},
+    uuid: 'heartbeat-uuid',
+    session_id: 'session-id',
+  }
+  const resultMessage = {
+    type: 'result',
+    subtype: 'success',
+    duration_ms: 1,
+    duration_api_ms: 1,
+    is_error: false,
+    num_turns: 1,
+    result: 'done',
+    session_id: 'session-id',
+    total_cost_usd: 0,
+    usage: {},
+    modelUsage: {},
+    permission_denials: [],
+    uuid: 'result-uuid',
+  }
+
+  expect(shouldSelectHeadlessFinalMessage(heartbeatMessage)).toBe(false)
+  expect(shouldSelectHeadlessFinalMessage(resultMessage)).toBe(true)
+  expect(shouldSelectHeadlessFinalMessage(null)).toBe(false)
+  expect(shouldSelectHeadlessFinalMessage('partial output')).toBe(false)
+  expect(shouldSelectHeadlessFinalMessage({})).toBe(false)
+  expect([heartbeatMessage, resultMessage].filter(shouldSelectHeadlessFinalMessage)).toEqual([
+    resultMessage,
+  ])
+})

--- a/src/cli/headlessHeartbeat.test.ts
+++ b/src/cli/headlessHeartbeat.test.ts
@@ -169,7 +169,11 @@ describe('createHeadlessHeartbeat', () => {
       getState: () => 'requires_action',
       initialPhase: 'waiting_for_permission',
       getPendingPermissionRequests: () => ['request-1'],
-      getBackgroundTaskCounts: () => ({ local_agent: 2, local_workflow: 1 }),
+      getBackgroundTaskCounts: () => ({
+        local_agent: 2.9,
+        local_workflow: 1,
+        fractional_agent: 0.5,
+      }),
       emitStructured: event => {
         structured.push(event)
       },
@@ -220,6 +224,32 @@ describe('createHeadlessHeartbeat', () => {
     heartbeat.start()
     clock.setNow(0)
     heartbeat.markActivity()
+    clock.advance(HEADLESS_HEARTBEAT_MIN_INTERVAL_MS)
+    clock.tick()
+
+    expect(structured).toHaveLength(1)
+    expect(structured[0]).toMatchObject({
+      elapsed_ms: 0,
+      since_last_activity_ms: HEADLESS_HEARTBEAT_MIN_INTERVAL_MS,
+    })
+  })
+
+  test('emits after a backward clock jump without waiting for wall time to catch up', () => {
+    const clock = createFakeClock(10_000)
+    const structured: Array<Record<string, unknown>> = []
+    const heartbeat = createHeadlessHeartbeat({
+      intervalMs: HEADLESS_HEARTBEAT_MIN_INTERVAL_MS,
+      outputFormat: 'stream-json',
+      emitStructured: event => {
+        structured.push(event)
+      },
+      now: clock.now,
+      setInterval: clock.setInterval,
+      clearInterval: clock.clearInterval,
+    })
+
+    heartbeat.start()
+    clock.setNow(0)
     clock.advance(HEADLESS_HEARTBEAT_MIN_INTERVAL_MS)
     clock.tick()
 

--- a/src/cli/headlessHeartbeat.test.ts
+++ b/src/cli/headlessHeartbeat.test.ts
@@ -234,7 +234,7 @@ describe('createHeadlessHeartbeat', () => {
       state: 'running',
       pending_permission_requests: 0,
       background_tasks: {},
-      uuid: '',
+      uuid: '00000000-0000-4000-8000-000000000000',
       session_id: '',
     })
   })

--- a/src/cli/headlessHeartbeat.test.ts
+++ b/src/cli/headlessHeartbeat.test.ts
@@ -3,6 +3,7 @@ import {
   createHeadlessHeartbeat,
   HEADLESS_HEARTBEAT_MAX_INTERVAL_MS,
   HEADLESS_HEARTBEAT_MIN_INTERVAL_MS,
+  isHeadlessHeartbeatMessage,
   parseHeadlessHeartbeatDuration,
   shouldSelectHeadlessFinalMessage,
   validateHeadlessHeartbeatPrintMode,
@@ -441,6 +442,8 @@ test('heartbeat events are excluded from final-result and verbose JSON selection
   }
 
   expect(shouldSelectHeadlessFinalMessage(heartbeatMessage)).toBe(false)
+  expect(isHeadlessHeartbeatMessage(heartbeatMessage)).toBe(true)
+  expect(isHeadlessHeartbeatMessage('partial output')).toBe(false)
   expect(shouldSelectHeadlessFinalMessage(resultMessage)).toBe(true)
   expect(shouldSelectHeadlessFinalMessage(null)).toBe(false)
   expect(shouldSelectHeadlessFinalMessage('partial output')).toBe(false)

--- a/src/cli/headlessHeartbeat.test.ts
+++ b/src/cli/headlessHeartbeat.test.ts
@@ -476,8 +476,13 @@ test('heartbeat events are excluded from final-result and verbose JSON selection
     uuid: 'files-uuid',
     session_id: 'session-id',
   }
+  const postTurnSummaryMessage = {
+    type: 'system',
+    subtype: 'post_turn_summary',
+  }
 
   expect(shouldSelectHeadlessFinalMessage(heartbeatMessage)).toBe(false)
+  expect(shouldSelectHeadlessFinalMessage(postTurnSummaryMessage)).toBe(false)
   expect(shouldSelectHeadlessFinalMessage(filesPersistedMessage)).toBe(false)
   expect(isHeadlessHeartbeatMessage(heartbeatMessage)).toBe(true)
   expect(isHeadlessHeartbeatMessage('partial output')).toBe(false)
@@ -486,8 +491,11 @@ test('heartbeat events are excluded from final-result and verbose JSON selection
   expect(shouldSelectHeadlessFinalMessage('partial output')).toBe(false)
   expect(shouldSelectHeadlessFinalMessage({})).toBe(false)
   expect(
-    [heartbeatMessage, resultMessage, filesPersistedMessage].filter(
-      shouldSelectHeadlessFinalMessage,
-    ),
+    [
+      heartbeatMessage,
+      postTurnSummaryMessage,
+      resultMessage,
+      filesPersistedMessage,
+    ].filter(shouldSelectHeadlessFinalMessage),
   ).toEqual([resultMessage])
 })

--- a/src/cli/headlessHeartbeat.ts
+++ b/src/cli/headlessHeartbeat.ts
@@ -1,0 +1,345 @@
+import { randomUUID } from 'crypto'
+import type { StdoutMessage } from 'src/entrypoints/sdk/controlTypes.js'
+import { writeToStderr } from 'src/utils/process.js'
+
+export const HEADLESS_HEARTBEAT_MIN_INTERVAL_MS = 5_000
+export const HEADLESS_HEARTBEAT_MAX_INTERVAL_MS = 2_147_483_647
+
+export type HeadlessHeartbeatPhase =
+  | 'startup'
+  | 'loading_session'
+  | 'connecting_mcp'
+  | 'draining_commands'
+  | 'in_turn'
+  | 'waiting_for_permission'
+  | 'waiting_for_agents'
+  | 'flushing'
+  | 'shutting_down'
+
+export type HeadlessHeartbeatState =
+  | 'starting'
+  | 'running'
+  | 'requires_action'
+  | 'idle'
+  | 'shutting_down'
+
+type TimerHandle = unknown
+
+export type HeadlessHeartbeatEvent = {
+  type: 'system'
+  subtype: 'heartbeat'
+  timestamp: string
+  elapsed_ms: number
+  since_last_activity_ms: number
+  state: HeadlessHeartbeatState
+  phase: HeadlessHeartbeatPhase
+  heartbeat_index: number
+  pending_permission_requests: number
+  background_tasks: Record<string, number>
+  uuid: string
+  session_id: string
+}
+
+type HeadlessHeartbeatOptions = {
+  intervalMs: number
+  outputFormat?: string
+  getSessionId?: () => string | undefined
+  getState?: () => HeadlessHeartbeatState
+  initialPhase?: HeadlessHeartbeatPhase
+  getPendingPermissionRequests?: () => number | readonly unknown[]
+  getBackgroundTaskCounts?: () => Record<string, number>
+  emitStructured?: (message: HeadlessHeartbeatEvent) => void | Promise<void>
+  emitStderr?: (line: string) => void
+  now?: () => number
+  setInterval?: (callback: () => void, intervalMs: number) => TimerHandle
+  clearInterval?: (timer: TimerHandle) => void
+  createUuid?: () => string
+}
+
+export type HeadlessHeartbeat = {
+  start: () => void
+  stop: () => void
+  markActivity: () => void
+  setPhase: (phase: HeadlessHeartbeatPhase) => void
+}
+
+export function parseHeadlessHeartbeatDuration(rawValue: string): number {
+  const value = rawValue.trim()
+  if (/^0+$/.test(value)) {
+    throw new Error('--heartbeat must be at least 5s.')
+  }
+  const match = /^(\d+)(ms|s|m)$/.exec(value)
+  if (!match) {
+    throw new Error(
+      '--heartbeat must be a duration like 30s, 2m, or 5000ms.',
+    )
+  }
+
+  const unit = match[2]
+  const multiplier = unit === 'ms' ? 1n : unit === 's' ? 1_000n : 60_000n
+  const intervalMsBigInt = BigInt(match[1]) * multiplier
+  if (intervalMsBigInt > BigInt(HEADLESS_HEARTBEAT_MAX_INTERVAL_MS)) {
+    throw new Error(
+      `--heartbeat must be no more than ${HEADLESS_HEARTBEAT_MAX_INTERVAL_MS}ms.`,
+    )
+  }
+
+  const intervalMs = Number(intervalMsBigInt)
+
+  assertValidHeadlessHeartbeatInterval(intervalMs)
+
+  return intervalMs
+}
+
+export function createHeadlessHeartbeat(
+  options: HeadlessHeartbeatOptions,
+): HeadlessHeartbeat {
+  assertValidHeadlessHeartbeatInterval(options.intervalMs)
+  if (options.outputFormat === 'stream-json' && !options.emitStructured) {
+    throw new Error('stream-json heartbeat output requires a structured sink.')
+  }
+
+  const now = options.now ?? Date.now
+  const scheduleInterval = options.setInterval ?? setInterval
+  const clearScheduledInterval =
+    options.clearInterval ??
+    ((timerHandle: TimerHandle) =>
+      clearInterval(timerHandle as ReturnType<typeof setInterval>))
+  const createUuid = options.createUuid ?? randomUUID
+  const emitStderr =
+    options.emitStderr ?? ((line: string) => writeToStderr(`${line}\n`))
+  const emitStructured = options.emitStructured
+  const initialPhase = options.initialPhase ?? 'startup'
+
+  let timer: TimerHandle | undefined
+  let startedAt = now()
+  let lastActivityAt = startedAt
+  let lastHeartbeatAt = startedAt
+  let heartbeatIndex = 0
+  let phase = initialPhase
+
+  const armTimer = () => {
+    timer = scheduleInterval(emit, options.intervalMs)
+    unrefTimer(timer)
+  }
+
+  const clearTimer = () => {
+    if (timer === undefined) {
+      return
+    }
+    clearScheduledInterval(timer)
+    timer = undefined
+  }
+
+  const emit = () => {
+    const currentTime = now()
+    const sinceLastActivityMs = currentTime - lastActivityAt
+    if (sinceLastActivityMs < options.intervalMs) {
+      return
+    }
+    if (currentTime - lastHeartbeatAt < options.intervalMs) {
+      return
+    }
+
+    heartbeatIndex += 1
+    lastHeartbeatAt = currentTime
+
+    const state = safelyGet(options.getState, 'running')
+    const event: HeadlessHeartbeatEvent = {
+      type: 'system',
+      subtype: 'heartbeat',
+      timestamp: new Date(currentTime).toISOString(),
+      elapsed_ms: currentTime - startedAt,
+      since_last_activity_ms: sinceLastActivityMs,
+      state,
+      phase,
+      heartbeat_index: heartbeatIndex,
+      pending_permission_requests: getPendingPermissionRequestCount(
+        safelyGet(options.getPendingPermissionRequests, undefined),
+      ),
+      background_tasks: sanitizeBackgroundTaskCounts(
+        safelyGet(options.getBackgroundTaskCounts, {}),
+      ),
+      uuid: safelyGet(createUuid, ''),
+      session_id: safelyGet(options.getSessionId, '') ?? '',
+    }
+
+    if (options.outputFormat === 'stream-json') {
+      try {
+        void Promise.resolve(emitStructured?.(event)).catch(() => {})
+      } catch {
+        // Broken pipes or closed transports should not keep the process alive.
+      }
+      return
+    }
+
+    try {
+      emitStderr(formatStderrHeartbeat(event))
+    } catch {
+      // Broken pipes or closed stderr should not keep the process alive.
+    }
+  }
+
+  return {
+    start() {
+      if (timer !== undefined) {
+        return
+      }
+      startedAt = now()
+      lastActivityAt = startedAt
+      lastHeartbeatAt = startedAt
+      heartbeatIndex = 0
+      phase = initialPhase
+      armTimer()
+    },
+    stop() {
+      clearTimer()
+    },
+    markActivity() {
+      const currentTime = now()
+      lastActivityAt = currentTime
+      lastHeartbeatAt = currentTime
+      if (timer !== undefined) {
+        clearTimer()
+        armTimer()
+      }
+    },
+    setPhase(nextPhase: HeadlessHeartbeatPhase) {
+      phase = nextPhase
+    },
+  }
+}
+
+function unrefTimer(timer: TimerHandle): void {
+  if (
+    timer !== undefined &&
+    timer !== null &&
+    typeof timer === 'object' &&
+    'unref' in timer &&
+    typeof timer.unref === 'function'
+  ) {
+    timer.unref()
+  }
+}
+
+function safelyGet<T>(getter: (() => T) | undefined, fallback: T): T {
+  if (!getter) {
+    return fallback
+  }
+  try {
+    return getter()
+  } catch {
+    return fallback
+  }
+}
+
+export function isHeadlessHeartbeatMessage(message: StdoutMessage): boolean {
+  return message?.type === 'system' && message.subtype === 'heartbeat'
+}
+
+export function validateHeadlessHeartbeatPrintMode(
+  intervalMs: number | undefined,
+  hasPrintFlag: boolean,
+): void {
+  if (intervalMs !== undefined && !hasPrintFlag) {
+    throw new Error('--heartbeat can only be used with --print.')
+  }
+}
+
+export function shouldSelectHeadlessFinalMessage(
+  message: StdoutMessage,
+): boolean {
+  if (
+    !message ||
+    typeof message !== 'object' ||
+    typeof (message as { type?: unknown }).type !== 'string'
+  ) {
+    return false
+  }
+
+  return (
+    message.type !== 'control_response' &&
+    message.type !== 'control_request' &&
+    message.type !== 'control_cancel_request' &&
+    !(
+      message.type === 'system' &&
+      (message.subtype === 'session_state_changed' ||
+        message.subtype === 'task_notification' ||
+        message.subtype === 'task_started' ||
+        message.subtype === 'task_progress' ||
+        message.subtype === 'heartbeat' ||
+        message.subtype === 'post_turn_summary')
+    ) &&
+    message.type !== 'stream_event' &&
+    message.type !== 'keep_alive' &&
+    message.type !== 'streamlined_text' &&
+    message.type !== 'streamlined_tool_use_summary' &&
+    message.type !== 'prompt_suggestion'
+  )
+}
+
+function assertValidHeadlessHeartbeatInterval(intervalMs: number): void {
+  if (!Number.isFinite(intervalMs) || !Number.isInteger(intervalMs)) {
+    throw new Error('--heartbeat must be at least 5s.')
+  }
+  if (intervalMs < HEADLESS_HEARTBEAT_MIN_INTERVAL_MS) {
+    throw new Error('--heartbeat must be at least 5s.')
+  }
+  if (!Number.isSafeInteger(intervalMs)) {
+    throw new Error(
+      `--heartbeat must be no more than ${HEADLESS_HEARTBEAT_MAX_INTERVAL_MS}ms.`,
+    )
+  }
+  if (intervalMs > HEADLESS_HEARTBEAT_MAX_INTERVAL_MS) {
+    throw new Error(
+      `--heartbeat must be no more than ${HEADLESS_HEARTBEAT_MAX_INTERVAL_MS}ms.`,
+    )
+  }
+}
+
+function getPendingPermissionRequestCount(
+  value: number | readonly unknown[] | undefined,
+): number {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return Math.max(0, Math.trunc(value))
+  }
+  return Array.isArray(value) ? value.length : 0
+}
+
+function sanitizeBackgroundTaskCounts(
+  counts: Record<string, number>,
+): Record<string, number> {
+  const sanitized: Record<string, number> = {}
+  for (const [type, count] of Object.entries(counts)) {
+    if (!Number.isFinite(count) || count <= 0) {
+      continue
+    }
+    sanitized[type] = Math.trunc(count)
+  }
+  return sanitized
+}
+
+function formatStderrHeartbeat(event: {
+  elapsed_ms: number
+  since_last_activity_ms: number
+  state: HeadlessHeartbeatState
+  phase: HeadlessHeartbeatPhase
+  session_id: string
+}): string {
+  const parts = [
+    'openclaude: heartbeat',
+    `elapsed=${formatSeconds(event.elapsed_ms)}`,
+    `quiet=${formatSeconds(event.since_last_activity_ms)}`,
+    `state=${event.state}`,
+    `phase=${event.phase}`,
+  ]
+  if (event.session_id) {
+    parts.push(`session=${event.session_id}`)
+  }
+  return parts.join(' ')
+}
+
+function formatSeconds(ms: number): string {
+  const seconds = ms / 1_000
+  return `${Number.isInteger(seconds) ? seconds : seconds.toFixed(1)}s`
+}

--- a/src/cli/headlessHeartbeat.ts
+++ b/src/cli/headlessHeartbeat.ts
@@ -133,6 +133,16 @@ export function createHeadlessHeartbeat(
 
   const emit = () => {
     const currentTime = now()
+    if (currentTime < startedAt) {
+      startedAt = currentTime
+    }
+    if (currentTime < lastActivityAt) {
+      lastActivityAt = currentTime - options.intervalMs
+    }
+    if (currentTime < lastHeartbeatAt) {
+      lastHeartbeatAt = currentTime - options.intervalMs
+    }
+
     const sinceLastActivityMs = currentTime - lastActivityAt
     if (sinceLastActivityMs < options.intervalMs) {
       return
@@ -319,10 +329,14 @@ function sanitizeBackgroundTaskCounts(
 ): Record<string, number> {
   const sanitized: Record<string, number> = {}
   for (const [type, count] of Object.entries(counts)) {
-    if (!Number.isFinite(count) || count <= 0) {
+    if (!Number.isFinite(count)) {
       continue
     }
-    sanitized[type] = Math.trunc(count)
+    const normalizedCount = Math.trunc(count)
+    if (normalizedCount <= 0) {
+      continue
+    }
+    sanitized[type] = normalizedCount
   }
   return sanitized
 }

--- a/src/cli/headlessHeartbeat.ts
+++ b/src/cli/headlessHeartbeat.ts
@@ -1,5 +1,4 @@
 import { randomUUID } from 'crypto'
-import type { StdoutMessage } from 'src/entrypoints/sdk/controlTypes.js'
 import { writeToStderr } from 'src/utils/process.js'
 
 export const HEADLESS_HEARTBEAT_MIN_INTERVAL_MS = 5_000
@@ -233,8 +232,12 @@ function safelyGet<T>(getter: (() => T) | undefined, fallback: T): T {
   }
 }
 
-export function isHeadlessHeartbeatMessage(message: StdoutMessage): boolean {
-  return message?.type === 'system' && message.subtype === 'heartbeat'
+export function isHeadlessHeartbeatMessage(message: unknown): boolean {
+  if (!message || typeof message !== 'object') {
+    return false
+  }
+  const candidate = message as { type?: unknown; subtype?: unknown }
+  return candidate.type === 'system' && candidate.subtype === 'heartbeat'
 }
 
 export function validateHeadlessHeartbeatPrintMode(
@@ -247,7 +250,7 @@ export function validateHeadlessHeartbeatPrintMode(
 }
 
 export function shouldSelectHeadlessFinalMessage(
-  message: StdoutMessage,
+  message: unknown,
 ): boolean {
   if (
     !message ||
@@ -257,24 +260,25 @@ export function shouldSelectHeadlessFinalMessage(
     return false
   }
 
+  const candidate = message as { type: string; subtype?: unknown }
   return (
-    message.type !== 'control_response' &&
-    message.type !== 'control_request' &&
-    message.type !== 'control_cancel_request' &&
+    candidate.type !== 'control_response' &&
+    candidate.type !== 'control_request' &&
+    candidate.type !== 'control_cancel_request' &&
     !(
-      message.type === 'system' &&
-      (message.subtype === 'session_state_changed' ||
-        message.subtype === 'task_notification' ||
-        message.subtype === 'task_started' ||
-        message.subtype === 'task_progress' ||
-        message.subtype === 'heartbeat' ||
-        message.subtype === 'post_turn_summary')
+      candidate.type === 'system' &&
+      (candidate.subtype === 'session_state_changed' ||
+        candidate.subtype === 'task_notification' ||
+        candidate.subtype === 'task_started' ||
+        candidate.subtype === 'task_progress' ||
+        candidate.subtype === 'heartbeat' ||
+        candidate.subtype === 'post_turn_summary')
     ) &&
-    message.type !== 'stream_event' &&
-    message.type !== 'keep_alive' &&
-    message.type !== 'streamlined_text' &&
-    message.type !== 'streamlined_tool_use_summary' &&
-    message.type !== 'prompt_suggestion'
+    candidate.type !== 'stream_event' &&
+    candidate.type !== 'keep_alive' &&
+    candidate.type !== 'streamlined_text' &&
+    candidate.type !== 'streamlined_tool_use_summary' &&
+    candidate.type !== 'prompt_suggestion'
   )
 }
 

--- a/src/cli/headlessHeartbeat.ts
+++ b/src/cli/headlessHeartbeat.ts
@@ -3,6 +3,7 @@ import { writeToStderr } from 'src/utils/process.js'
 
 export const HEADLESS_HEARTBEAT_MIN_INTERVAL_MS = 5_000
 export const HEADLESS_HEARTBEAT_MAX_INTERVAL_MS = 2_147_483_647
+const FALLBACK_HEARTBEAT_UUID = '00000000-0000-4000-8000-000000000000'
 
 export type HeadlessHeartbeatPhase =
   | 'startup'
@@ -159,7 +160,7 @@ export function createHeadlessHeartbeat(
       background_tasks: sanitizeBackgroundTaskCounts(
         safelyGet(options.getBackgroundTaskCounts, {}),
       ),
-      uuid: safelyGet(createUuid, ''),
+      uuid: safelyGet(createUuid, FALLBACK_HEARTBEAT_UUID),
       session_id: safelyGet(options.getSessionId, '') ?? '',
     }
 

--- a/src/cli/headlessHeartbeat.ts
+++ b/src/cli/headlessHeartbeat.ts
@@ -275,7 +275,8 @@ export function shouldSelectHeadlessFinalMessage(
         candidate.subtype === 'task_started' ||
         candidate.subtype === 'task_progress' ||
         candidate.subtype === 'heartbeat' ||
-        candidate.subtype === 'post_turn_summary')
+        candidate.subtype === 'post_turn_summary' ||
+        candidate.subtype === 'files_persisted')
     ) &&
     candidate.type !== 'stream_event' &&
     candidate.type !== 'keep_alive' &&

--- a/src/cli/headlessHeartbeat.ts
+++ b/src/cli/headlessHeartbeat.ts
@@ -144,13 +144,15 @@ export function createHeadlessHeartbeat(
     heartbeatIndex += 1
     lastHeartbeatAt = currentTime
 
+    const elapsedMs = Math.max(0, currentTime - startedAt)
+    const emittedSinceLastActivityMs = Math.max(0, sinceLastActivityMs)
     const state = safelyGet(options.getState, 'running')
     const event: HeadlessHeartbeatEvent = {
       type: 'system',
       subtype: 'heartbeat',
       timestamp: new Date(currentTime).toISOString(),
-      elapsed_ms: currentTime - startedAt,
-      since_last_activity_ms: sinceLastActivityMs,
+      elapsed_ms: elapsedMs,
+      since_last_activity_ms: emittedSinceLastActivityMs,
       state,
       phase,
       heartbeat_index: heartbeatIndex,

--- a/src/cli/print.ts
+++ b/src/cli/print.ts
@@ -339,6 +339,7 @@ import {
   shouldSelectHeadlessFinalMessage,
   type HeadlessHeartbeat,
   type HeadlessHeartbeatEvent,
+  type HeadlessHeartbeatState,
 } from './headlessHeartbeat.js'
 import {
   isTeamLead,
@@ -619,15 +620,12 @@ export async function runHeadless(
     () => streamJsonDrainStarted,
   )
   const heartbeat = options.heartbeatIntervalMs
-    ? createHeadlessHeartbeat({
+    ? createRunHeadlessHeartbeat({
         intervalMs: options.heartbeatIntervalMs,
-        outputFormat:
-          options.outputFormat === 'stream-json' && !options.verbose
-            ? 'text'
-            : options.outputFormat,
+        outputFormat: options.outputFormat,
+        verbose: options.verbose,
         getSessionId,
         getState: () => (isShuttingDown() ? 'shutting_down' : getSessionState()),
-        initialPhase: 'loading_session',
         getPendingPermissionRequests: () =>
           structuredIO.getPendingPermissionRequests(),
         getBackgroundTaskCounts: () => getBackgroundTaskCounts(getAppState()),
@@ -1037,6 +1035,21 @@ type HeadlessHeartbeatStructuredTarget = {
   }
 }
 
+type RunHeadlessHeartbeatOptions = {
+  intervalMs: number | undefined
+  outputFormat: string | undefined
+  verbose: boolean | undefined
+  getSessionId: () => string | undefined
+  getState: () => HeadlessHeartbeatState
+  getPendingPermissionRequests: () => number | readonly unknown[]
+  getBackgroundTaskCounts: () => Record<string, number>
+  emitStructured: (message: HeadlessHeartbeatEvent) => void | Promise<void>
+  now?: () => number
+  setInterval?: (callback: () => void, intervalMs: number) => unknown
+  clearInterval?: (timer: unknown) => void
+  createUuid?: () => string
+}
+
 /** @internal */
 export function createHeadlessHeartbeatStructuredEmitter(
   structuredIO: HeadlessHeartbeatStructuredTarget,
@@ -1049,6 +1062,33 @@ export function createHeadlessHeartbeatStructuredEmitter(
     }
     return structuredIO.write(message)
   }
+}
+
+/** @internal */
+export function createRunHeadlessHeartbeat(
+  options: RunHeadlessHeartbeatOptions,
+): HeadlessHeartbeat | undefined {
+  if (options.intervalMs === undefined) {
+    return undefined
+  }
+
+  return createHeadlessHeartbeat({
+    intervalMs: options.intervalMs,
+    outputFormat:
+      options.outputFormat === 'stream-json' && !options.verbose
+        ? 'text'
+        : options.outputFormat,
+    getSessionId: options.getSessionId,
+    getState: options.getState,
+    initialPhase: 'startup',
+    getPendingPermissionRequests: options.getPendingPermissionRequests,
+    getBackgroundTaskCounts: options.getBackgroundTaskCounts,
+    emitStructured: options.emitStructured,
+    now: options.now,
+    setInterval: options.setInterval,
+    clearInterval: options.clearInterval,
+    createUuid: options.createUuid,
+  })
 }
 
 function getBackgroundTaskCounts(appState: AppState): Record<string, number> {

--- a/src/cli/print.ts
+++ b/src/cli/print.ts
@@ -334,6 +334,13 @@ import { installPluginsForHeadless } from '../utils/plugins/headlessPluginInstal
 import { refreshActivePlugins } from '../utils/plugins/refresh.js'
 import { loadAllPluginsCacheOnly } from '../utils/plugins/pluginLoader.js'
 import {
+  createHeadlessHeartbeat,
+  isHeadlessHeartbeatMessage,
+  shouldSelectHeadlessFinalMessage,
+  type HeadlessHeartbeat,
+  type HeadlessHeartbeatEvent,
+} from './headlessHeartbeat.js'
+import {
   isTeamLead,
   hasActiveInProcessTeammates,
   hasWorkingInProcessTeammates,
@@ -486,6 +493,7 @@ export async function runHeadless(
     setupTrigger?: 'init' | 'maintenance' | undefined
     sessionStartHooksPromise?: ReturnType<typeof processSessionStartHooks>
     setSDKStatus?: (status: SDKStatus) => void
+    heartbeatIntervalMs?: number | undefined
   },
 ): Promise<void> {
   if (
@@ -605,6 +613,30 @@ export async function runHeadless(
     installStreamJsonStdoutGuard()
   }
 
+  let streamJsonDrainStarted = false
+  const emitStructuredHeartbeat = createHeadlessHeartbeatStructuredEmitter(
+    structuredIO,
+    () => streamJsonDrainStarted,
+  )
+  const heartbeat = options.heartbeatIntervalMs
+    ? createHeadlessHeartbeat({
+        intervalMs: options.heartbeatIntervalMs,
+        outputFormat:
+          options.outputFormat === 'stream-json' && !options.verbose
+            ? 'text'
+            : options.outputFormat,
+        getSessionId,
+        getState: () => (isShuttingDown() ? 'shutting_down' : getSessionState()),
+        initialPhase: 'loading_session',
+        getPendingPermissionRequests: () =>
+          structuredIO.getPendingPermissionRequests(),
+        getBackgroundTaskCounts: () => getBackgroundTaskCounts(getAppState()),
+        emitStructured: emitStructuredHeartbeat,
+      })
+    : undefined
+  heartbeat?.start()
+  registerCleanup(async () => heartbeat?.stop())
+
   // #34044: if user explicitly set sandbox.enabled=true but deps are missing,
   // isSandboxingEnabled() returns false silently. Surface the reason so users
   // know their security config isn't being enforced.
@@ -615,6 +647,7 @@ export async function runHeadless(
         `\nError: sandbox required but unavailable: ${sandboxUnavailableReason}\n` +
           `  sandbox.failIfUnavailable is set — refusing to start without a working sandbox.\n\n`,
       )
+      heartbeat?.stop()
       gracefulShutdownSync(1)
       return
     }
@@ -630,6 +663,7 @@ export async function runHeadless(
       await SandboxManager.initialize(structuredIO.createSandboxAskCallback())
     } catch (err) {
       process.stderr.write(`\n❌ Sandbox Error: ${errorMessage(err)}\n`)
+      heartbeat?.stop()
       gracefulShutdownSync(1, 'other')
       return
     }
@@ -679,15 +713,20 @@ export async function runHeadless(
             }
         }
       })()
-      void structuredIO.write(message)
+      void structuredIO
+        .write(message)
+        .then(() => heartbeat?.markActivity())
+        .catch(() => {})
     })
   }
 
   if (options.setupTrigger) {
+    heartbeat?.setPhase('startup')
     await processSetupHooks(options.setupTrigger)
   }
 
   headlessProfilerCheckpoint('before_loadInitialMessages')
+  heartbeat?.setPhase('loading_session')
   const appState = getAppState()
   const {
     messages: initialMessages,
@@ -742,6 +781,7 @@ export async function runHeadless(
   // If a loadInitialMessages error path triggered it, bail early to avoid
   // unnecessary work while the process winds down.
   if (initialMessages.length === 0 && process.exitCode !== undefined) {
+    heartbeat?.stop()
     return
   }
 
@@ -757,6 +797,7 @@ export async function runHeadless(
       process.stderr.write(
         `Error: --rewind-files requires a user message UUID, but ${options.rewindFiles} is not a user message in this session\n`,
       )
+      heartbeat?.stop()
       gracefulShutdownSync(1)
       return
     }
@@ -770,6 +811,7 @@ export async function runHeadless(
     )
     if (!result.canRewind) {
       process.stderr.write(`Error: ${result.error || 'Unexpected error'}\n`)
+      heartbeat?.stop()
       gracefulShutdownSync(1)
       return
     }
@@ -778,6 +820,7 @@ export async function runHeadless(
     process.stdout.write(
       `Files rewound to state at message ${options.rewindFiles}\n`,
     )
+    heartbeat?.stop()
     gracefulShutdownSync(0)
     return
   }
@@ -794,6 +837,7 @@ export async function runHeadless(
     process.stderr.write(
       `Error: Input must be provided either through stdin or as a prompt argument when using --print\n`,
     )
+    heartbeat?.stop()
     gracefulShutdownSync(1)
     return
   }
@@ -802,6 +846,7 @@ export async function runHeadless(
     process.stderr.write(
       'Error: When using --print, --output-format=stream-json requires --verbose\n',
     )
+    heartbeat?.stop()
     gracefulShutdownSync(1)
     return
   }
@@ -820,6 +865,7 @@ export async function runHeadless(
 
   // Callback for when a permission prompt is shown
   const onPermissionPrompt = (details: RequiresActionDetails) => {
+    heartbeat?.setPhase('waiting_for_permission')
     if (feature('COMMIT_ATTRIBUTION')) {
       setAppState(prev => ({
         ...prev,
@@ -875,6 +921,7 @@ export async function runHeadless(
       : null
 
   headlessProfilerCheckpoint('before_runHeadlessStreaming')
+  streamJsonDrainStarted = true
   for await (const message of runHeadlessStreaming(
     structuredIO,
     appState.mcp.clients,
@@ -886,47 +933,43 @@ export async function runHeadless(
     getAppState,
     setAppState,
     agents,
-    options,
+    { ...options, heartbeat },
     turnInterruptionState,
   )) {
     if (transformToStreamlined) {
+      if (isHeadlessHeartbeatMessage(message)) {
+        await structuredIO.write(message)
+        continue
+      }
       // Streamlined mode: transform messages and stream immediately
       const transformed = transformToStreamlined(message)
       if (transformed) {
         await structuredIO.write(transformed)
+        if (!isHeadlessHeartbeatMessage(transformed)) {
+          heartbeat?.markActivity()
+        }
       }
     } else if (options.outputFormat === 'stream-json' && options.verbose) {
       await structuredIO.write(message)
+      if (!isHeadlessHeartbeatMessage(message)) {
+        heartbeat?.markActivity()
+      }
     }
     // Should not be getting control messages or stream events in non-stream mode.
     // Also filter out streamlined types since they're only produced by the transformer.
     // SDK-only system events are excluded so lastMessage stays at the result
     // (session_state_changed(idle) and any late task_notification drain after
     // result in the finally block).
-    if (
-      message.type !== 'control_response' &&
-      message.type !== 'control_request' &&
-      message.type !== 'control_cancel_request' &&
-      !(
-        message.type === 'system' &&
-        (message.subtype === 'session_state_changed' ||
-          message.subtype === 'task_notification' ||
-          message.subtype === 'task_started' ||
-          message.subtype === 'task_progress' ||
-          message.subtype === 'post_turn_summary')
-      ) &&
-      message.type !== 'stream_event' &&
-      message.type !== 'keep_alive' &&
-      message.type !== 'streamlined_text' &&
-      message.type !== 'streamlined_tool_use_summary' &&
-      message.type !== 'prompt_suggestion'
-    ) {
+    if (shouldSelectHeadlessFinalMessage(message)) {
       if (needsFullArray) {
         messages.push(message)
       }
       lastMessage = message
     }
   }
+
+  heartbeat?.setPhase('flushing')
+  heartbeat?.stop()
 
   switch (options.outputFormat) {
     case 'json':
@@ -987,6 +1030,37 @@ export async function runHeadless(
   )
 }
 
+type HeadlessHeartbeatStructuredTarget = {
+  write: (message: HeadlessHeartbeatEvent) => void | Promise<void>
+  outbound: {
+    enqueue: (message: HeadlessHeartbeatEvent) => void
+  }
+}
+
+/** @internal */
+export function createHeadlessHeartbeatStructuredEmitter(
+  structuredIO: HeadlessHeartbeatStructuredTarget,
+  hasDrainStarted: () => boolean,
+): (message: HeadlessHeartbeatEvent) => void | Promise<void> {
+  return message => {
+    if (hasDrainStarted()) {
+      structuredIO.outbound.enqueue(message)
+      return
+    }
+    return structuredIO.write(message)
+  }
+}
+
+function getBackgroundTaskCounts(appState: AppState): Record<string, number> {
+  const counts: Record<string, number> = {}
+  for (const task of getRunningTasks(appState)) {
+    if (isBackgroundTask(task)) {
+      counts[task.type] = (counts[task.type] ?? 0) + 1
+    }
+  }
+  return counts
+}
+
 function runHeadlessStreaming(
   structuredIO: StructuredIO,
   mcpClients: MCPServerConnection[],
@@ -1018,6 +1092,7 @@ function runHeadlessStreaming(
     setSDKStatus?: (status: SDKStatus) => void
     promptSuggestions?: boolean | undefined
     workload?: string | undefined
+    heartbeat?: HeadlessHeartbeat | undefined
   },
   turnInterruptionState?: TurnInterruptionState,
 ): AsyncIterable<StdoutMessage> {
@@ -1040,6 +1115,7 @@ function runHeadlessStreaming(
   // failsafe timer that force-exits if cleanup hangs.
   const sigintHandler = () => {
     logForDiagnosticsNoPII('info', 'shutdown_signal', { signal: 'SIGINT' })
+    options.heartbeat?.setPhase('shutting_down')
     if (abortController && !abortController.signal.aborted) {
       abortController.abort('interrupt')
     }
@@ -1882,6 +1958,7 @@ function runHeadlessStreaming(
 
     running = true
     runPhase = undefined
+    options.heartbeat?.setPhase('draining_commands')
     notifySessionStateChanged('running')
     idleTimeout.stop()
 
@@ -2148,6 +2225,7 @@ function runHeadlessStreaming(
             ? Date.now()
             : undefined
 
+          options.heartbeat?.setPhase('in_turn')
           headlessProfilerCheckpoint('before_ask')
           startQueryProfile()
           // Per-iteration ALS context so bg agents spawned inside ask()
@@ -2389,6 +2467,7 @@ function runHeadlessStreaming(
         }
 
         runPhase = 'draining_commands'
+        options.heartbeat?.setPhase('draining_commands')
         await drainCommandQueue()
 
         // Check for running background tasks before exiting.
@@ -2410,6 +2489,7 @@ function runHeadlessStreaming(
             waitingForAgents = true
             if (!hasMainThreadQueued) {
               runPhase = 'waiting_for_agents'
+              options.heartbeat?.setPhase('waiting_for_agents')
               // No commands ready yet, wait for tasks to complete
               await sleep(100)
             }
@@ -2435,6 +2515,7 @@ function runHeadlessStreaming(
         }
       }
     } catch (error) {
+      options.heartbeat?.setPhase('shutting_down')
       // Emit error result message before shutting down
       // Write directly to structuredIO to ensure immediate delivery
       try {
@@ -2457,6 +2538,7 @@ function runHeadlessStreaming(
             ...getInMemoryErrors().map(_ => _.error),
           ],
         })
+        options.heartbeat?.markActivity()
       } catch {
         // If we can't emit the error result, continue with shutdown anyway
       }
@@ -2465,6 +2547,7 @@ function runHeadlessStreaming(
       return
     } finally {
       runPhase = 'finally_flush'
+      options.heartbeat?.setPhase('flushing')
       // Flush pending internal events before going idle
       await structuredIO.flushInternalEvents()
       runPhase = 'finally_post_flush'

--- a/src/cli/print.ts
+++ b/src/cli/print.ts
@@ -724,28 +724,35 @@ export async function runHeadless(
 
   if (options.setupTrigger) {
     heartbeat?.setPhase('startup')
-    await processSetupHooks(options.setupTrigger)
+    await runWithHeartbeatErrorCleanup(heartbeat, () =>
+      processSetupHooks(options.setupTrigger!),
+    )
   }
 
   headlessProfilerCheckpoint('before_loadInitialMessages')
   heartbeat?.setPhase('loading_session')
   const appState = getAppState()
+  const initialMessagesResult = await runWithHeartbeatErrorCleanup(
+    heartbeat,
+    () =>
+      loadInitialMessages(setAppState, {
+        getAppState,
+        continue: options.continue,
+        teleport: options.teleport,
+        resume: options.resume,
+        fromPr: options.fromPr,
+        resumeSessionAt: options.resumeSessionAt,
+        forkSession: options.forkSession,
+        outputFormat: options.outputFormat,
+        sessionStartHooksPromise: options.sessionStartHooksPromise,
+        restoredWorkerState: structuredIO.restoredWorkerState,
+      }),
+  )
   const {
     messages: initialMessages,
     turnInterruptionState,
     agentSetting: resumedAgentSetting,
-  } = await loadInitialMessages(setAppState, {
-    getAppState,
-    continue: options.continue,
-    teleport: options.teleport,
-    resume: options.resume,
-    fromPr: options.fromPr,
-    resumeSessionAt: options.resumeSessionAt,
-    forkSession: options.forkSession,
-    outputFormat: options.outputFormat,
-    sessionStartHooksPromise: options.sessionStartHooksPromise,
-    restoredWorkerState: structuredIO.restoredWorkerState,
-  })
+  } = initialMessagesResult
 
   // SessionStart hooks can emit initialUserMessage — the first user turn for
   // headless orchestrator sessions where stdin is empty and additionalContext
@@ -805,11 +812,13 @@ export async function runHeadless(
     }
 
     const currentAppState = getAppState()
-    const result = await handleRewindFiles(
-      options.rewindFiles as UUID,
-      currentAppState,
-      setAppState,
-      false,
+    const result = await runWithHeartbeatErrorCleanup(heartbeat, () =>
+      handleRewindFiles(
+        options.rewindFiles as UUID,
+        currentAppState,
+        setAppState,
+        false,
+      ),
     )
     if (!result.canRewind) {
       process.stderr.write(`Error: ${result.error || 'Unexpected error'}\n`)
@@ -900,7 +909,7 @@ export async function runHeadless(
 
   // Ensure model strings are initialized before generating model options.
   // For Bedrock users, this waits for the profile fetch to get correct region strings.
-  await ensureModelStringsInitialized()
+  await runWithHeartbeatErrorCleanup(heartbeat, ensureModelStringsInitialized)
   headlessProfilerCheckpoint('after_modelStrings')
 
   // UDS inbox store registration is deferred until after `run` is defined
@@ -928,54 +937,56 @@ export async function runHeadless(
     heartbeat?.start()
     heartbeat?.setPhase('draining_commands')
   }
-  for await (const message of runHeadlessStreaming(
-    structuredIO,
-    appState.mcp.clients,
-    [...commands, ...appState.mcp.commands],
-    filteredTools,
-    initialMessages,
-    canUseTool,
-    sdkMcpConfigs,
-    getAppState,
-    setAppState,
-    agents,
-    { ...options, heartbeat },
-    turnInterruptionState,
-  )) {
-    if (transformToStreamlined) {
-      if (isHeadlessHeartbeatMessage(message)) {
+  try {
+    for await (const message of runHeadlessStreaming(
+      structuredIO,
+      appState.mcp.clients,
+      [...commands, ...appState.mcp.commands],
+      filteredTools,
+      initialMessages,
+      canUseTool,
+      sdkMcpConfigs,
+      getAppState,
+      setAppState,
+      agents,
+      { ...options, heartbeat },
+      turnInterruptionState,
+    )) {
+      if (transformToStreamlined) {
+        if (isHeadlessHeartbeatMessage(message)) {
+          await structuredIO.write(message)
+          continue
+        }
+        // Streamlined mode: transform messages and stream immediately
+        const transformed = transformToStreamlined(message)
+        if (transformed) {
+          await structuredIO.write(transformed)
+          if (!isHeadlessHeartbeatMessage(transformed)) {
+            heartbeat?.markActivity()
+          }
+        }
+      } else if (options.outputFormat === 'stream-json' && options.verbose) {
         await structuredIO.write(message)
-        continue
-      }
-      // Streamlined mode: transform messages and stream immediately
-      const transformed = transformToStreamlined(message)
-      if (transformed) {
-        await structuredIO.write(transformed)
-        if (!isHeadlessHeartbeatMessage(transformed)) {
+        if (!isHeadlessHeartbeatMessage(message)) {
           heartbeat?.markActivity()
         }
       }
-    } else if (options.outputFormat === 'stream-json' && options.verbose) {
-      await structuredIO.write(message)
-      if (!isHeadlessHeartbeatMessage(message)) {
-        heartbeat?.markActivity()
+      // Should not be getting control messages or stream events in non-stream mode.
+      // Also filter out streamlined types since they're only produced by the transformer.
+      // SDK-only system events are excluded so lastMessage stays at the result
+      // (session_state_changed(idle) and any late task_notification drain after
+      // result in the finally block).
+      if (shouldSelectHeadlessFinalMessage(message)) {
+        if (needsFullArray) {
+          messages.push(message)
+        }
+        lastMessage = message
       }
     }
-    // Should not be getting control messages or stream events in non-stream mode.
-    // Also filter out streamlined types since they're only produced by the transformer.
-    // SDK-only system events are excluded so lastMessage stays at the result
-    // (session_state_changed(idle) and any late task_notification drain after
-    // result in the finally block).
-    if (shouldSelectHeadlessFinalMessage(message)) {
-      if (needsFullArray) {
-        messages.push(message)
-      }
-      lastMessage = message
-    }
+  } finally {
+    heartbeat?.setPhase('flushing')
+    heartbeat?.stop()
   }
-
-  heartbeat?.setPhase('flushing')
-  heartbeat?.stop()
 
   switch (options.outputFormat) {
     case 'json':
@@ -1056,6 +1067,19 @@ type RunHeadlessHeartbeatOptions = {
   setInterval?: (callback: () => void, intervalMs: number) => unknown
   clearInterval?: (timer: unknown) => void
   createUuid?: () => string
+}
+
+/** @internal */
+export async function runWithHeartbeatErrorCleanup<T>(
+  heartbeat: Pick<HeadlessHeartbeat, 'stop'> | undefined,
+  operation: () => Promise<T>,
+): Promise<T> {
+  try {
+    return await operation()
+  } catch (error) {
+    heartbeat?.stop()
+    throw error
+  }
 }
 
 /** @internal */

--- a/src/cli/print.ts
+++ b/src/cli/print.ts
@@ -632,7 +632,11 @@ export async function runHeadless(
         emitStructured: emitStructuredHeartbeat,
       })
     : undefined
-  heartbeat?.start()
+  const deferHeartbeatStartUntilStreamDrain =
+    options.outputFormat === 'stream-json'
+  if (!deferHeartbeatStartUntilStreamDrain) {
+    heartbeat?.start()
+  }
   registerCleanup(async () => heartbeat?.stop())
 
   // #34044: if user explicitly set sandbox.enabled=true but deps are missing,
@@ -920,6 +924,10 @@ export async function runHeadless(
 
   headlessProfilerCheckpoint('before_runHeadlessStreaming')
   streamJsonDrainStarted = true
+  if (deferHeartbeatStartUntilStreamDrain) {
+    heartbeat?.start()
+    heartbeat?.setPhase('draining_commands')
+  }
   for await (const message of runHeadlessStreaming(
     structuredIO,
     appState.mcp.clients,
@@ -1056,11 +1064,10 @@ export function createHeadlessHeartbeatStructuredEmitter(
   hasDrainStarted: () => boolean,
 ): (message: HeadlessHeartbeatEvent) => void | Promise<void> {
   return message => {
-    if (hasDrainStarted()) {
-      structuredIO.outbound.enqueue(message)
+    if (!hasDrainStarted()) {
       return
     }
-    return structuredIO.write(message)
+    structuredIO.outbound.enqueue(message)
   }
 }
 

--- a/src/cli/printHeartbeat.test.ts
+++ b/src/cli/printHeartbeat.test.ts
@@ -1,6 +1,53 @@
 import { describe, expect, mock, test } from 'bun:test'
-import { createHeadlessHeartbeatStructuredEmitter } from './print.js'
-import type { HeadlessHeartbeatEvent } from './headlessHeartbeat.js'
+import {
+  createHeadlessHeartbeatStructuredEmitter,
+  createRunHeadlessHeartbeat,
+} from './print.js'
+import {
+  HEADLESS_HEARTBEAT_MIN_INTERVAL_MS,
+  shouldSelectHeadlessFinalMessage,
+  type HeadlessHeartbeatEvent,
+} from './headlessHeartbeat.js'
+
+type FakeTimer = {
+  active: boolean
+  callback: () => void
+  intervalMs: number
+  unref: ReturnType<typeof mock>
+}
+
+function createFakeClock(startMs = 0) {
+  let nowMs = startMs
+  const timers: FakeTimer[] = []
+
+  return {
+    now: () => nowMs,
+    advance: (deltaMs: number) => {
+      nowMs += deltaMs
+    },
+    setInterval: (callback: () => void, intervalMs: number) => {
+      const timer: FakeTimer = {
+        active: true,
+        callback,
+        intervalMs,
+        unref: mock(() => {}),
+      }
+      timers.push(timer)
+      return timer
+    },
+    clearInterval: (timer: unknown) => {
+      const fakeTimer = timer as FakeTimer
+      fakeTimer.active = false
+    },
+    tick: () => {
+      for (const timer of timers) {
+        if (timer.active) {
+          timer.callback()
+        }
+      }
+    },
+  }
+}
 
 const heartbeatEvent: HeadlessHeartbeatEvent = {
   type: 'system',
@@ -44,5 +91,68 @@ describe('createHeadlessHeartbeatStructuredEmitter', () => {
 
     expect(write).not.toHaveBeenCalled()
     expect(enqueue).toHaveBeenCalledWith(heartbeatEvent)
+  })
+})
+
+describe('createRunHeadlessHeartbeat', () => {
+  test('emits stream-json heartbeats through the print flow sink without becoming the final result', async () => {
+    const clock = createFakeClock()
+    const written: HeadlessHeartbeatEvent[] = []
+    const enqueued: HeadlessHeartbeatEvent[] = []
+    let streamJsonDrainStarted = false
+    const emitStructured = createHeadlessHeartbeatStructuredEmitter(
+      {
+        write: async message => {
+          written.push(message)
+        },
+        outbound: {
+          enqueue: message => {
+            enqueued.push(message)
+          },
+        },
+      },
+      () => streamJsonDrainStarted,
+    )
+
+    const heartbeat = createRunHeadlessHeartbeat({
+      intervalMs: HEADLESS_HEARTBEAT_MIN_INTERVAL_MS,
+      outputFormat: 'stream-json',
+      verbose: true,
+      getSessionId: () => 'session-id',
+      getState: () => 'running',
+      getPendingPermissionRequests: () => [],
+      getBackgroundTaskCounts: () => ({}),
+      emitStructured,
+      now: clock.now,
+      setInterval: clock.setInterval,
+      clearInterval: clock.clearInterval,
+      createUuid: () => `heartbeat-${written.length + enqueued.length + 1}`,
+    })
+
+    heartbeat?.start()
+    clock.advance(HEADLESS_HEARTBEAT_MIN_INTERVAL_MS)
+    await clock.tick()
+
+    expect(written).toHaveLength(1)
+    expect(written[0]!.phase).toBe('startup')
+
+    streamJsonDrainStarted = true
+    heartbeat?.setPhase('loading_session')
+    clock.advance(HEADLESS_HEARTBEAT_MIN_INTERVAL_MS)
+    await clock.tick()
+
+    expect(enqueued).toHaveLength(1)
+    expect(enqueued[0]!.phase).toBe('loading_session')
+
+    const resultMessage = {
+      type: 'result',
+      subtype: 'success',
+      result: 'done',
+    }
+    expect(
+      [...written, ...enqueued, resultMessage].filter(
+        shouldSelectHeadlessFinalMessage,
+      ),
+    ).toEqual([resultMessage])
   })
 })

--- a/src/cli/printHeartbeat.test.ts
+++ b/src/cli/printHeartbeat.test.ts
@@ -65,7 +65,7 @@ const heartbeatEvent: HeadlessHeartbeatEvent = {
 }
 
 describe('createHeadlessHeartbeatStructuredEmitter', () => {
-  test('writes heartbeat events immediately before the stream-json drain starts', async () => {
+  test('does not emit heartbeat events before the stream-json drain starts', async () => {
     const write = mock(async (_message: HeadlessHeartbeatEvent) => {})
     const enqueue = mock((_message: HeadlessHeartbeatEvent) => {})
     const emitter = createHeadlessHeartbeatStructuredEmitter(
@@ -75,7 +75,7 @@ describe('createHeadlessHeartbeatStructuredEmitter', () => {
 
     await emitter(heartbeatEvent)
 
-    expect(write).toHaveBeenCalledWith(heartbeatEvent)
+    expect(write).not.toHaveBeenCalled()
     expect(enqueue).not.toHaveBeenCalled()
   })
 
@@ -95,7 +95,7 @@ describe('createHeadlessHeartbeatStructuredEmitter', () => {
 })
 
 describe('createRunHeadlessHeartbeat', () => {
-  test('emits stream-json heartbeats through the print flow sink without becoming the final result', async () => {
+  test('keeps stream-json heartbeats dormant until the print flow starts the drain', async () => {
     const clock = createFakeClock()
     const written: HeadlessHeartbeatEvent[] = []
     const enqueued: HeadlessHeartbeatEvent[] = []
@@ -129,18 +129,19 @@ describe('createRunHeadlessHeartbeat', () => {
       createUuid: () => `heartbeat-${written.length + enqueued.length + 1}`,
     })
 
-    heartbeat?.start()
     clock.advance(HEADLESS_HEARTBEAT_MIN_INTERVAL_MS)
     await clock.tick()
 
-    expect(written).toHaveLength(1)
-    expect(written[0]!.phase).toBe('startup')
+    expect(written).toHaveLength(0)
+    expect(enqueued).toHaveLength(0)
 
     streamJsonDrainStarted = true
+    heartbeat?.start()
     heartbeat?.setPhase('loading_session')
     clock.advance(HEADLESS_HEARTBEAT_MIN_INTERVAL_MS)
     await clock.tick()
 
+    expect(written).toHaveLength(0)
     expect(enqueued).toHaveLength(1)
     expect(enqueued[0]!.phase).toBe('loading_session')
 

--- a/src/cli/printHeartbeat.test.ts
+++ b/src/cli/printHeartbeat.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, mock, test } from 'bun:test'
+import { createHeadlessHeartbeatStructuredEmitter } from './print.js'
+import type { HeadlessHeartbeatEvent } from './headlessHeartbeat.js'
+
+const heartbeatEvent: HeadlessHeartbeatEvent = {
+  type: 'system',
+  subtype: 'heartbeat',
+  timestamp: '2026-06-25T12:00:30.000Z',
+  elapsed_ms: 30_000,
+  since_last_activity_ms: 30_000,
+  state: 'running',
+  phase: 'in_turn',
+  heartbeat_index: 1,
+  pending_permission_requests: 0,
+  background_tasks: {},
+  uuid: 'heartbeat-uuid',
+  session_id: 'session-id',
+}
+
+describe('createHeadlessHeartbeatStructuredEmitter', () => {
+  test('writes heartbeat events immediately before the stream-json drain starts', async () => {
+    const write = mock(async (_message: HeadlessHeartbeatEvent) => {})
+    const enqueue = mock((_message: HeadlessHeartbeatEvent) => {})
+    const emitter = createHeadlessHeartbeatStructuredEmitter(
+      { write, outbound: { enqueue } },
+      () => false,
+    )
+
+    await emitter(heartbeatEvent)
+
+    expect(write).toHaveBeenCalledWith(heartbeatEvent)
+    expect(enqueue).not.toHaveBeenCalled()
+  })
+
+  test('enqueues heartbeat events after the stream-json drain starts', async () => {
+    const write = mock(async (_message: HeadlessHeartbeatEvent) => {})
+    const enqueue = mock((_message: HeadlessHeartbeatEvent) => {})
+    const emitter = createHeadlessHeartbeatStructuredEmitter(
+      { write, outbound: { enqueue } },
+      () => true,
+    )
+
+    await emitter(heartbeatEvent)
+
+    expect(write).not.toHaveBeenCalled()
+    expect(enqueue).toHaveBeenCalledWith(heartbeatEvent)
+  })
+})

--- a/src/cli/printHeartbeat.test.ts
+++ b/src/cli/printHeartbeat.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, mock, test } from 'bun:test'
 import {
   createHeadlessHeartbeatStructuredEmitter,
   createRunHeadlessHeartbeat,
+  runWithHeartbeatErrorCleanup,
 } from './print.js'
 import {
   HEADLESS_HEARTBEAT_MIN_INTERVAL_MS,
@@ -95,6 +96,23 @@ describe('createHeadlessHeartbeatStructuredEmitter', () => {
 })
 
 describe('createRunHeadlessHeartbeat', () => {
+  test('stops active heartbeats when guarded setup work throws', async () => {
+    const stop = mock(() => {})
+    const heartbeat = {
+      start: () => {},
+      stop,
+      markActivity: () => {},
+      setPhase: () => {},
+    }
+
+    await expect(
+      runWithHeartbeatErrorCleanup(heartbeat, async () => {
+        throw new Error('setup failed')
+      }),
+    ).rejects.toThrow('setup failed')
+    expect(stop).toHaveBeenCalledTimes(1)
+  })
+
   test('keeps stream-json heartbeats dormant until the print flow starts the drain', async () => {
     const clock = createFakeClock()
     const written: HeadlessHeartbeatEvent[] = []
@@ -129,6 +147,7 @@ describe('createRunHeadlessHeartbeat', () => {
       createUuid: () => `heartbeat-${written.length + enqueued.length + 1}`,
     })
 
+    heartbeat?.start()
     clock.advance(HEADLESS_HEARTBEAT_MIN_INTERVAL_MS)
     await clock.tick()
 
@@ -136,7 +155,6 @@ describe('createRunHeadlessHeartbeat', () => {
     expect(enqueued).toHaveLength(0)
 
     streamJsonDrainStarted = true
-    heartbeat?.start()
     heartbeat?.setPhase('loading_session')
     clock.advance(HEADLESS_HEARTBEAT_MIN_INTERVAL_MS)
     await clock.tick()

--- a/src/entrypoints/sdk/coreSchemas.ts
+++ b/src/entrypoints/sdk/coreSchemas.ts
@@ -1776,8 +1776,8 @@ export const SDKHeartbeatMessageSchema = lazySchema(() =>
       type: z.literal('system'),
       subtype: z.literal('heartbeat'),
       timestamp: z.string(),
-      elapsed_ms: z.number(),
-      since_last_activity_ms: z.number(),
+      elapsed_ms: z.number().int().nonnegative(),
+      since_last_activity_ms: z.number().int().nonnegative(),
       state: z.enum([
         'starting',
         'running',
@@ -1796,9 +1796,9 @@ export const SDKHeartbeatMessageSchema = lazySchema(() =>
         'flushing',
         'shutting_down',
       ]),
-      heartbeat_index: z.number(),
-      pending_permission_requests: z.number(),
-      background_tasks: z.record(z.string(), z.number()),
+      heartbeat_index: z.number().int().positive(),
+      pending_permission_requests: z.number().int().nonnegative(),
+      background_tasks: z.record(z.string(), z.number().int().positive()),
       uuid: UUIDPlaceholder(),
       session_id: z.string(),
     })

--- a/src/entrypoints/sdk/coreSchemas.ts
+++ b/src/entrypoints/sdk/coreSchemas.ts
@@ -1770,6 +1770,43 @@ export const SDKSessionStateChangedMessageSchema = lazySchema(() =>
     ),
 )
 
+export const SDKHeartbeatMessageSchema = lazySchema(() =>
+  z
+    .object({
+      type: z.literal('system'),
+      subtype: z.literal('heartbeat'),
+      timestamp: z.string(),
+      elapsed_ms: z.number(),
+      since_last_activity_ms: z.number(),
+      state: z.enum([
+        'starting',
+        'running',
+        'requires_action',
+        'idle',
+        'shutting_down',
+      ]),
+      phase: z.enum([
+        'startup',
+        'loading_session',
+        'connecting_mcp',
+        'draining_commands',
+        'in_turn',
+        'waiting_for_permission',
+        'waiting_for_agents',
+        'flushing',
+        'shutting_down',
+      ]),
+      heartbeat_index: z.number(),
+      pending_permission_requests: z.number(),
+      background_tasks: z.record(z.string(), z.number()),
+      uuid: UUIDPlaceholder(),
+      session_id: z.string(),
+    })
+    .describe(
+      'Opt-in headless liveness signal emitted while --print output is quiet.',
+    ),
+)
+
 
 export const SDKTaskProgressMessageSchema = lazySchema(() =>
   z.object({
@@ -1908,6 +1945,7 @@ export const SDKMessageSchema = lazySchema(() =>
     SDKTaskStartedMessageSchema(),
     SDKTaskProgressMessageSchema(),
     SDKSessionStateChangedMessageSchema(),
+    SDKHeartbeatMessageSchema(),
     SDKFilesPersistedEventSchema(),
     SDKToolUseSummaryMessageSchema(),
     SDKRateLimitEventSchema(),

--- a/src/entrypoints/sdk/coreTypes.generated.ts
+++ b/src/entrypoints/sdk/coreTypes.generated.ts
@@ -2001,6 +2001,22 @@ export type SDKSessionStateChangedMessage = {
   session_id: string
 }
 
+/** Opt-in headless liveness signal emitted while --print output is quiet. */
+export type SDKHeartbeatMessage = {
+  type: "system"
+  subtype: "heartbeat"
+  timestamp: string
+  elapsed_ms: number
+  since_last_activity_ms: number
+  state: "starting" | "running" | "requires_action" | "idle" | "shutting_down"
+  phase: "startup" | "loading_session" | "connecting_mcp" | "draining_commands" | "in_turn" | "waiting_for_permission" | "waiting_for_agents" | "flushing" | "shutting_down"
+  heartbeat_index: number
+  pending_permission_requests: number
+  background_tasks: Record<string, number>
+  uuid: string
+  session_id: string
+}
+
 export type SDKToolUseSummaryMessage = {
   type: "tool_use_summary"
   summary: string

--- a/src/entrypoints/sdk/coreTypes.generated.ts
+++ b/src/entrypoints/sdk/coreTypes.generated.ts
@@ -2294,6 +2294,19 @@ export type SDKMessage = ({
   session_id: string
 }) | ({
   type: "system"
+  subtype: "heartbeat"
+  timestamp: string
+  elapsed_ms: number
+  since_last_activity_ms: number
+  state: "starting" | "running" | "requires_action" | "idle" | "shutting_down"
+  phase: "startup" | "loading_session" | "connecting_mcp" | "draining_commands" | "in_turn" | "waiting_for_permission" | "waiting_for_agents" | "flushing" | "shutting_down"
+  heartbeat_index: number
+  pending_permission_requests: number
+  background_tasks: Record<string, number>
+  uuid: string
+  session_id: string
+}) | ({
+  type: "system"
   subtype: "files_persisted"
   files: {
     filename: string

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -160,6 +160,7 @@ import { gracefulShutdown, gracefulShutdownSync } from 'src/utils/gracefulShutdo
 import { setAllHookEventsEnabled } from 'src/utils/hooks/hookEvents.js';
 import { refreshModelCapabilities } from 'src/utils/model/modelCapabilities.js';
 import { peekForStdinData, writeToStderr } from 'src/utils/process.js';
+import { createHeadlessHeartbeat, parseHeadlessHeartbeatDuration, validateHeadlessHeartbeatPrintMode } from 'src/cli/headlessHeartbeat.js';
 import { setCwd } from 'src/utils/Shell.js';
 import { type ProcessedResume, processResumedConversation } from 'src/utils/sessionRestore.js';
 import { plural } from 'src/utils/stringUtils.js';
@@ -935,7 +936,13 @@ async function run(): Promise<CommanderCommand> {
     // If not provided but flag is present, value will be true
     // The actual filtering is handled in debug.ts by parsing process.argv
     return true;
-  }).addOption(new Option('-d2e, --debug-to-stderr', 'Enable debug mode (to stderr)').argParser(Boolean).hideHelp()).option('--debug-file <path>', 'Write debug logs to a specific file path (implicitly enables debug mode)', () => true).option('--verbose', 'Override verbose mode setting from config', () => true).option('-p, --print', 'Print response and exit (useful for pipes). Note: The workspace trust dialog is skipped when Claude is run with the -p mode. Only use this flag in directories you trust.', () => true).option('--bare', 'Minimal mode: skip hooks, LSP, plugin sync, attribution, auto-memory, background prefetches, keychain reads, and CLAUDE.md auto-discovery. Sets CLAUDE_CODE_SIMPLE=1. Anthropic auth is strictly ANTHROPIC_API_KEY or apiKeyHelper via --settings (OAuth and keychain are never read). 3P providers (Bedrock/Vertex/Foundry) use their own credentials. Skills still resolve via /skill-name. Explicitly provide context via: --system-prompt[-file], --append-system-prompt[-file], --add-dir (CLAUDE.md dirs), --mcp-config, --settings, --agents, --plugin-dir.', () => true).addOption(new Option('--init', 'Run Setup hooks with init trigger, then continue').hideHelp()).addOption(new Option('--init-only', 'Run Setup and SessionStart:startup hooks, then exit').hideHelp()).addOption(new Option('--maintenance', 'Run Setup hooks with maintenance trigger, then continue').hideHelp()).addOption(new Option('--output-format <format>', 'Output format (only works with --print): "text" (default), "json" (single result), or "stream-json" (realtime streaming)').choices(['text', 'json', 'stream-json'])).addOption(new Option('--json-schema <schema>', 'JSON Schema for structured output validation. ' + 'Example: {"type":"object","properties":{"name":{"type":"string"}},"required":["name"]}').argParser(String)).option('--include-hook-events', 'Include all hook lifecycle events in the output stream (only works with --output-format=stream-json)', () => true).option('--include-partial-messages', 'Include partial message chunks as they arrive (only works with --print and --output-format=stream-json)', () => true).addOption(new Option('--input-format <format>', 'Input format (only works with --print): "text" (default), or "stream-json" (realtime streaming input)').choices(['text', 'stream-json'])).option('--mcp-debug', '[DEPRECATED. Use --debug instead] Enable MCP debug mode (shows MCP server errors)', () => true).option('--dangerously-skip-permissions', 'Bypass all permission checks. Recommended only for sandboxes with no internet access.', () => true).option('--allow-dangerously-skip-permissions', 'Enable bypassing all permission checks as an option, without it being enabled by default. Recommended only for sandboxes with no internet access.', () => true).addOption(new Option('--thinking <mode>', 'Thinking mode: enabled (equivalent to adaptive), disabled').choices(['enabled', 'adaptive', 'disabled']).hideHelp()).addOption(new Option('--max-thinking-tokens <tokens>', '[DEPRECATED. Use --thinking instead for newer models] Maximum number of thinking tokens (only works with --print)').argParser(Number).hideHelp()).addOption(new Option('--max-turns <turns>', 'Maximum number of agentic turns in non-interactive mode. This will early exit the conversation after the specified number of turns. (only works with --print)').argParser(Number).hideHelp()).addOption(new Option('--max-budget-usd <amount>', 'Maximum dollar amount to spend on API calls (only works with --print)').argParser(value => {
+  }).addOption(new Option('-d2e, --debug-to-stderr', 'Enable debug mode (to stderr)').argParser(Boolean).hideHelp()).option('--debug-file <path>', 'Write debug logs to a specific file path (implicitly enables debug mode)', () => true).option('--verbose', 'Override verbose mode setting from config', () => true).option('-p, --print', 'Print response and exit (useful for pipes). Note: The workspace trust dialog is skipped when Claude is run with the -p mode. Only use this flag in directories you trust.', () => true).addOption(new Option('--heartbeat <duration>', 'Emit a headless liveness heartbeat while output is quiet (only works with --print, e.g. 30s, 2m)').argParser(value => {
+    try {
+      return parseHeadlessHeartbeatDuration(value);
+    } catch (error) {
+      throw new InvalidArgumentError(errorMessage(error));
+    }
+  })).option('--bare', 'Minimal mode: skip hooks, LSP, plugin sync, attribution, auto-memory, background prefetches, keychain reads, and CLAUDE.md auto-discovery. Sets CLAUDE_CODE_SIMPLE=1. Anthropic auth is strictly ANTHROPIC_API_KEY or apiKeyHelper via --settings (OAuth and keychain are never read). 3P providers (Bedrock/Vertex/Foundry) use their own credentials. Skills still resolve via /skill-name. Explicitly provide context via: --system-prompt[-file], --append-system-prompt[-file], --add-dir (CLAUDE.md dirs), --mcp-config, --settings, --agents, --plugin-dir.', () => true).addOption(new Option('--init', 'Run Setup hooks with init trigger, then continue').hideHelp()).addOption(new Option('--init-only', 'Run Setup and SessionStart:startup hooks, then exit').hideHelp()).addOption(new Option('--maintenance', 'Run Setup hooks with maintenance trigger, then continue').hideHelp()).addOption(new Option('--output-format <format>', 'Output format (only works with --print): "text" (default), "json" (single result), or "stream-json" (realtime streaming)').choices(['text', 'json', 'stream-json'])).addOption(new Option('--json-schema <schema>', 'JSON Schema for structured output validation. ' + 'Example: {"type":"object","properties":{"name":{"type":"string"}},"required":["name"]}').argParser(String)).option('--include-hook-events', 'Include all hook lifecycle events in the output stream (only works with --output-format=stream-json)', () => true).option('--include-partial-messages', 'Include partial message chunks as they arrive (only works with --print and --output-format=stream-json)', () => true).addOption(new Option('--input-format <format>', 'Input format (only works with --print): "text" (default), or "stream-json" (realtime streaming input)').choices(['text', 'stream-json'])).option('--mcp-debug', '[DEPRECATED. Use --debug instead] Enable MCP debug mode (shows MCP server errors)', () => true).option('--dangerously-skip-permissions', 'Bypass all permission checks. Recommended only for sandboxes with no internet access.', () => true).option('--allow-dangerously-skip-permissions', 'Enable bypassing all permission checks as an option, without it being enabled by default. Recommended only for sandboxes with no internet access.', () => true).addOption(new Option('--thinking <mode>', 'Thinking mode: enabled (equivalent to adaptive), disabled').choices(['enabled', 'adaptive', 'disabled']).hideHelp()).addOption(new Option('--max-thinking-tokens <tokens>', '[DEPRECATED. Use --thinking instead for newer models] Maximum number of thinking tokens (only works with --print)').argParser(Number).hideHelp()).addOption(new Option('--max-turns <turns>', 'Maximum number of agentic turns in non-interactive mode. This will early exit the conversation after the specified number of turns. (only works with --print)').argParser(Number).hideHelp()).addOption(new Option('--max-budget-usd <amount>', 'Maximum dollar amount to spend on API calls (only works with --print)').argParser(value => {
     const amount = Number(value);
     if (isNaN(amount) || amount <= 0) {
       throw new Error('--max-budget-usd must be a positive number greater than 0');
@@ -1288,6 +1295,10 @@ async function run(): Promise<CommanderCommand> {
 
     // Get isNonInteractiveSession from state (was set before init())
     const isNonInteractiveSession = getIsNonInteractiveSession();
+    const heartbeatIntervalMs = (options as {
+      heartbeat?: number;
+    }).heartbeat;
+    const heartbeatHasPrintFlag = Boolean(options.print);
 
     // Validate that fallback model is different from main model
     if (fallbackModel && options.model && fallbackModel === options.model) {
@@ -1801,6 +1812,13 @@ async function run(): Promise<CommanderCommand> {
         writeToStderr(`Error: --include-partial-messages requires --print and --output-format=stream-json.`);
         process.exit(1);
       }
+    }
+
+    try {
+      validateHeadlessHeartbeatPrintMode(heartbeatIntervalMs, heartbeatHasPrintFlag);
+    } catch (error) {
+      writeToStderr(`Error: ${errorMessage(error)}\n`);
+      process.exit(1);
     }
 
     // Validate --no-session-persistence is only used with print mode
@@ -2655,88 +2673,100 @@ async function run(): Promise<CommanderCommand> {
       // (processBatched with Promise.all). claude.ai is awaited too — its
       // fetch was kicked off early (line ~2558) so only residual time blocks
       // here. --bare skips claude.ai entirely for perf-sensitive scripts.
-      profileCheckpoint('before_connectMcp');
-      await connectMcpBatch(regularMcpConfigs, 'regular');
-      profileCheckpoint('after_connectMcp');
-      // Dedup: suppress plugin MCP servers that duplicate a claude.ai
-      // connector (connector wins), then connect claude.ai servers.
-      // Bounded wait — #23725 made this blocking so single-turn -p sees
-      // connectors, but with 40+ slow connectors tengu_startup_perf p99
-      // climbed to 76s. If fetch+connect doesn't finish in time, proceed;
-      // the promise keeps running and updates headlessStore in the
-      // background so turn 2+ still sees connectors.
-      const CLAUDE_AI_MCP_TIMEOUT_MS = 5_000;
-      const claudeaiConnect = claudeaiConfigPromise.then(claudeaiConfigs => {
-        if (Object.keys(claudeaiConfigs).length > 0) {
-          const claudeaiSigs = new Set<string>();
-          for (const config of Object.values(claudeaiConfigs)) {
-            const sig = getMcpServerSignature(config);
-            if (sig) claudeaiSigs.add(sig);
-          }
-          const suppressed = new Set<string>();
-          for (const [name, config] of Object.entries(regularMcpConfigs)) {
-            if (!name.startsWith('plugin:')) continue;
-            const sig = getMcpServerSignature(config);
-            if (sig && claudeaiSigs.has(sig)) suppressed.add(name);
-          }
-          if (suppressed.size > 0) {
-            logForDebugging(`[MCP] Lazy dedup: suppressing ${suppressed.size} plugin server(s) that duplicate claude.ai connectors: ${[...suppressed].join(', ')}`);
-            // Disconnect before filtering from state. Only connected
-            // servers need cleanup — clearServerCache on a never-connected
-            // server triggers a real connect just to kill it (memoize
-            // cache-miss path, see useManageMCPConnections.ts:870).
-            for (const c of headlessStore.getState().mcp.clients) {
-              if (!suppressed.has(c.name) || c.type !== 'connected') continue;
-              c.client.onclose = undefined;
-              void clearServerCache(c.name, c.config).catch(() => {});
+      const startupHeartbeat = heartbeatIntervalMs ? createHeadlessHeartbeat({
+        intervalMs: heartbeatIntervalMs,
+        outputFormat: 'text',
+        getState: () => 'starting',
+        initialPhase: 'connecting_mcp',
+        getSessionId
+      }) : undefined;
+      startupHeartbeat?.start();
+      try {
+        profileCheckpoint('before_connectMcp');
+        await connectMcpBatch(regularMcpConfigs, 'regular');
+        profileCheckpoint('after_connectMcp');
+        // Dedup: suppress plugin MCP servers that duplicate a claude.ai
+        // connector (connector wins), then connect claude.ai servers.
+        // Bounded wait — #23725 made this blocking so single-turn -p sees
+        // connectors, but with 40+ slow connectors tengu_startup_perf p99
+        // climbed to 76s. If fetch+connect doesn't finish in time, proceed;
+        // the promise keeps running and updates headlessStore in the
+        // background so turn 2+ still sees connectors.
+        const CLAUDE_AI_MCP_TIMEOUT_MS = 5_000;
+        const claudeaiConnect = claudeaiConfigPromise.then(claudeaiConfigs => {
+          if (Object.keys(claudeaiConfigs).length > 0) {
+            const claudeaiSigs = new Set<string>();
+            for (const config of Object.values(claudeaiConfigs)) {
+              const sig = getMcpServerSignature(config);
+              if (sig) claudeaiSigs.add(sig);
             }
-            headlessStore.setState(prev => {
-              let {
-                clients,
-                tools,
-                commands,
-                resources
-              } = prev.mcp;
-              clients = clients.filter(c => !suppressed.has(c.name));
-              tools = tools.filter(t => !t.mcpInfo || !suppressed.has(t.mcpInfo.serverName));
-              for (const name of suppressed) {
-                commands = excludeCommandsByServer(commands, name);
-                resources = excludeResourcesByServer(resources, name);
+            const suppressed = new Set<string>();
+            for (const [name, config] of Object.entries(regularMcpConfigs)) {
+              if (!name.startsWith('plugin:')) continue;
+              const sig = getMcpServerSignature(config);
+              if (sig && claudeaiSigs.has(sig)) suppressed.add(name);
+            }
+            if (suppressed.size > 0) {
+              logForDebugging(`[MCP] Lazy dedup: suppressing ${suppressed.size} plugin server(s) that duplicate claude.ai connectors: ${[...suppressed].join(', ')}`);
+              // Disconnect before filtering from state. Only connected
+              // servers need cleanup — clearServerCache on a never-connected
+              // server triggers a real connect just to kill it (memoize
+              // cache-miss path, see useManageMCPConnections.ts:870).
+              for (const c of headlessStore.getState().mcp.clients) {
+                if (!suppressed.has(c.name) || c.type !== 'connected') continue;
+                c.client.onclose = undefined;
+                void clearServerCache(c.name, c.config).catch(() => {});
               }
-              return {
-                ...prev,
-                mcp: {
-                  ...prev.mcp,
+              headlessStore.setState(prev => {
+                let {
                   clients,
                   tools,
                   commands,
                   resources
+                } = prev.mcp;
+                clients = clients.filter(c => !suppressed.has(c.name));
+                tools = tools.filter(t => !t.mcpInfo || !suppressed.has(t.mcpInfo.serverName));
+                for (const name of suppressed) {
+                  commands = excludeCommandsByServer(commands, name);
+                  resources = excludeResourcesByServer(resources, name);
                 }
-              };
-            });
+                return {
+                  ...prev,
+                  mcp: {
+                    ...prev.mcp,
+                    clients,
+                    tools,
+                    commands,
+                    resources
+                  }
+                };
+              });
+            }
           }
+          // Suppress claude.ai connectors that duplicate an enabled
+          // manual server (URL-signature match). Plugin dedup above only
+          // handles `plugin:*` keys; this catches manual `.mcp.json` entries.
+          // plugin:* must be excluded here — step 1 already suppressed
+          // those (claude.ai wins); leaving them in suppresses the
+          // connector too, and neither survives (gh-39974).
+          const nonPluginConfigs = pickBy(regularMcpConfigs, (_, n) => !n.startsWith('plugin:'));
+          const {
+            servers: dedupedClaudeAi
+          } = dedupClaudeAiMcpServers(claudeaiConfigs, nonPluginConfigs);
+          return connectMcpBatch(dedupedClaudeAi, 'claudeai');
+        });
+        let claudeaiTimer: ReturnType<typeof setTimeout> | undefined;
+        const claudeaiTimedOut = await Promise.race([claudeaiConnect.then(() => false), new Promise<boolean>(resolve => {
+          claudeaiTimer = setTimeout(r => r(true), CLAUDE_AI_MCP_TIMEOUT_MS, resolve);
+        })]);
+        if (claudeaiTimer) clearTimeout(claudeaiTimer);
+        if (claudeaiTimedOut) {
+          logForDebugging(`[MCP] claude.ai connectors not ready after ${CLAUDE_AI_MCP_TIMEOUT_MS}ms — proceeding; background connection continues`);
         }
-        // Suppress claude.ai connectors that duplicate an enabled
-        // manual server (URL-signature match). Plugin dedup above only
-        // handles `plugin:*` keys; this catches manual `.mcp.json` entries.
-        // plugin:* must be excluded here — step 1 already suppressed
-        // those (claude.ai wins); leaving them in suppresses the
-        // connector too, and neither survives (gh-39974).
-        const nonPluginConfigs = pickBy(regularMcpConfigs, (_, n) => !n.startsWith('plugin:'));
-        const {
-          servers: dedupedClaudeAi
-        } = dedupClaudeAiMcpServers(claudeaiConfigs, nonPluginConfigs);
-        return connectMcpBatch(dedupedClaudeAi, 'claudeai');
-      });
-      let claudeaiTimer: ReturnType<typeof setTimeout> | undefined;
-      const claudeaiTimedOut = await Promise.race([claudeaiConnect.then(() => false), new Promise<boolean>(resolve => {
-        claudeaiTimer = setTimeout(r => r(true), CLAUDE_AI_MCP_TIMEOUT_MS, resolve);
-      })]);
-      if (claudeaiTimer) clearTimeout(claudeaiTimer);
-      if (claudeaiTimedOut) {
-        logForDebugging(`[MCP] claude.ai connectors not ready after ${CLAUDE_AI_MCP_TIMEOUT_MS}ms — proceeding; background connection continues`);
+        profileCheckpoint('after_connectMcp_claudeai');
+      } finally {
+        startupHeartbeat?.stop();
       }
-      profileCheckpoint('after_connectMcp_claudeai');
 
       // In headless mode, start deferred prefetches immediately (no user typing delay)
       // --bare / SIMPLE: startDeferredPrefetches early-returns internally.
@@ -2783,6 +2813,7 @@ async function run(): Promise<CommanderCommand> {
         enableAuthStatus: options.enableAuthStatus,
         agent: agentCli,
         workload: options.workload,
+        heartbeatIntervalMs,
         setupTrigger: setupTrigger ?? undefined,
         sessionStartHooksPromise
       });

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1298,7 +1298,7 @@ async function run(): Promise<CommanderCommand> {
     const heartbeatIntervalMs = (options as {
       heartbeat?: number;
     }).heartbeat;
-    const heartbeatHasPrintFlag = Boolean(options.print);
+    const heartbeatHasPrintFlag = Boolean(print);
 
     // Validate that fallback model is different from main model
     if (fallbackModel && options.model && fallbackModel === options.model) {

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -936,7 +936,7 @@ async function run(): Promise<CommanderCommand> {
     // If not provided but flag is present, value will be true
     // The actual filtering is handled in debug.ts by parsing process.argv
     return true;
-  }).addOption(new Option('-d2e, --debug-to-stderr', 'Enable debug mode (to stderr)').argParser(Boolean).hideHelp()).option('--debug-file <path>', 'Write debug logs to a specific file path (implicitly enables debug mode)', () => true).option('--verbose', 'Override verbose mode setting from config', () => true).option('-p, --print', 'Print response and exit (useful for pipes). Note: The workspace trust dialog is skipped when Claude is run with the -p mode. Only use this flag in directories you trust.', () => true).addOption(new Option('--heartbeat <duration>', 'Emit a headless liveness heartbeat while output is quiet (only works with --print, e.g. 30s, 2m)').argParser(value => {
+  }).addOption(new Option('-d2e, --debug-to-stderr', 'Enable debug mode (to stderr)').argParser(Boolean).hideHelp()).option('--debug-file <path>', 'Write debug logs to a specific file path (implicitly enables debug mode)', () => true).option('--verbose', 'Override verbose mode setting from config', () => true).option('-p, --print', 'Print response and exit (useful for pipes). Note: The workspace trust dialog is skipped when Claude is run with the -p mode. Only use this flag in directories you trust.', () => true).addOption(new Option('--heartbeat <duration>', 'Emit a headless liveness heartbeat while output is quiet (only works with --print, e.g. 30s, 2m; pre-stream startup heartbeats use stderr)').argParser(value => {
     try {
       return parseHeadlessHeartbeatDuration(value);
     } catch (error) {
@@ -2673,6 +2673,9 @@ async function run(): Promise<CommanderCommand> {
       // (processBatched with Promise.all). claude.ai is awaited too — its
       // fetch was kicked off early (line ~2558) so only residual time blocks
       // here. --bare skips claude.ai entirely for perf-sensitive scripts.
+      // The structured stream is initialized inside runHeadless after MCP
+      // connection. Keep this pre-stream startup heartbeat on stderr even when
+      // the final output format is stream-json.
       const startupHeartbeat = heartbeatIntervalMs ? createHeadlessHeartbeat({
         intervalMs: heartbeatIntervalMs,
         outputFormat: 'text',

--- a/tests/sdk/generated-types.test.ts
+++ b/tests/sdk/generated-types.test.ts
@@ -3,6 +3,7 @@ import {
   AccountInfoSchema,
   SDKAssistantMessageSchema,
   SDKSystemMessageSchema,
+  SDKHeartbeatMessageSchema,
   SDKCompactBoundaryMessageSchema,
   SDKMessageSchema,
   SDKUserMessageSchema,
@@ -212,6 +213,41 @@ describe('SDK Zod schemas (type generation source)', () => {
     for (const msg of messages) {
       const result = schema.safeParse(msg)
       expect(result.success).toBe(true)
+    }
+  })
+
+  test('SDKHeartbeatMessageSchema rejects values outside the producer contract', () => {
+    const schema = SDKHeartbeatMessageSchema()
+    const validHeartbeat = {
+      type: 'system',
+      subtype: 'heartbeat',
+      timestamp: '2026-06-25T12:00:30.000Z',
+      elapsed_ms: 30_000,
+      since_last_activity_ms: 30_000,
+      state: 'running',
+      phase: 'in_turn',
+      heartbeat_index: 1,
+      pending_permission_requests: 0,
+      background_tasks: { local_agent: 1 },
+      uuid: '12345678-1234-1234-1234-123456789012',
+      session_id: '12345678-1234-1234-1234-123456789012',
+    }
+
+    expect(schema.safeParse(validHeartbeat).success).toBe(true)
+
+    for (const invalidHeartbeat of [
+      { ...validHeartbeat, elapsed_ms: -1 },
+      { ...validHeartbeat, elapsed_ms: 1.5 },
+      { ...validHeartbeat, since_last_activity_ms: -1 },
+      { ...validHeartbeat, since_last_activity_ms: 1.5 },
+      { ...validHeartbeat, heartbeat_index: 0 },
+      { ...validHeartbeat, heartbeat_index: 1.5 },
+      { ...validHeartbeat, pending_permission_requests: -1 },
+      { ...validHeartbeat, pending_permission_requests: 1.5 },
+      { ...validHeartbeat, background_tasks: { local_agent: 0 } },
+      { ...validHeartbeat, background_tasks: { local_agent: 1.5 } },
+    ]) {
+      expect(schema.safeParse(invalidHeartbeat).success).toBe(false)
     }
   })
 

--- a/tests/sdk/generated-types.test.ts
+++ b/tests/sdk/generated-types.test.ts
@@ -1,4 +1,5 @@
 import { describe, test, expect } from 'bun:test'
+import { readFileSync } from 'node:fs'
 import {
   AccountInfoSchema,
   SDKAssistantMessageSchema,
@@ -23,6 +24,12 @@ import {
 } from '../../src/entrypoints/sdk/coreSchemas.js'
 import { z } from 'zod/v4'
 
+const generatedTypesSource = () =>
+  readFileSync(
+    new URL('../../src/entrypoints/sdk/coreTypes.generated.ts', import.meta.url),
+    'utf8',
+  )
+
 /**
  * Tests for generated SDK types from Zod schemas.
  *
@@ -33,6 +40,14 @@ import { z } from 'zod/v4'
  * 4. The full SDKMessage union accepts all message variants
  */
 describe('SDK Zod schemas (type generation source)', () => {
+  test('generated SDK types export heartbeat messages directly', () => {
+    const source = generatedTypesSource()
+
+    expect(source).toMatch(/^export type SDKHeartbeatMessage\b/m)
+    expect(source).not.toContain('// ⚠ Failed: SDKHeartbeatMessageSchema')
+    expect(source).not.toMatch(/^export type SDKHeartbeatMessage = any$/m)
+  })
+
   test('SDKAssistantMessageSchema accepts valid data', () => {
     const schema = SDKAssistantMessageSchema()
     const result = schema.safeParse({

--- a/tests/sdk/generated-types.test.ts
+++ b/tests/sdk/generated-types.test.ts
@@ -1,5 +1,6 @@
 import { describe, test, expect } from 'bun:test'
 import { readFileSync } from 'node:fs'
+import { generateSdkTypes } from '../../scripts/generate-sdk-types.js'
 import {
   AccountInfoSchema,
   SDKAssistantMessageSchema,
@@ -40,12 +41,17 @@ const generatedTypesSource = () =>
  * 4. The full SDKMessage union accepts all message variants
  */
 describe('SDK Zod schemas (type generation source)', () => {
-  test('generated SDK types export heartbeat messages directly', () => {
-    const source = generatedTypesSource()
+  test('SDK type generation exports heartbeat messages directly', () => {
+    const generatedSource = generateSdkTypes()
 
-    expect(source).toMatch(/^export type SDKHeartbeatMessage\b/m)
-    expect(source).not.toContain('// ⚠ Failed: SDKHeartbeatMessageSchema')
-    expect(source).not.toMatch(/^export type SDKHeartbeatMessage = any$/m)
+    expect(generatedSource).toBe(generatedTypesSource())
+    expect(generatedSource).toMatch(/^export type SDKHeartbeatMessage\b/m)
+    expect(generatedSource).not.toContain(
+      '// ⚠ Failed: SDKHeartbeatMessageSchema',
+    )
+    expect(generatedSource).not.toMatch(
+      /^export type SDKHeartbeatMessage = any$/m,
+    )
   })
 
   test('SDKAssistantMessageSchema accepts valid data', () => {

--- a/tests/sdk/generated-types.test.ts
+++ b/tests/sdk/generated-types.test.ts
@@ -234,6 +234,13 @@ describe('SDK Zod schemas (type generation source)', () => {
     }
 
     expect(schema.safeParse(validHeartbeat).success).toBe(true)
+    expect(
+      schema.safeParse({
+        ...validHeartbeat,
+        uuid: '00000000-0000-4000-8000-000000000000',
+        session_id: '',
+      }).success,
+    ).toBe(true)
 
     for (const invalidHeartbeat of [
       { ...validHeartbeat, elapsed_ms: -1 },

--- a/tests/sdk/generated-types.test.ts
+++ b/tests/sdk/generated-types.test.ts
@@ -193,6 +193,20 @@ describe('SDK Zod schemas (type generation source)', () => {
         uuid: '12345678-1234-1234-1234-123456789012',
         session_id: '12345678-1234-1234-1234-123456789012',
       },
+      {
+        type: 'system',
+        subtype: 'heartbeat',
+        timestamp: '2026-06-25T12:00:30.000Z',
+        elapsed_ms: 30_000,
+        since_last_activity_ms: 30_000,
+        state: 'running',
+        phase: 'in_turn',
+        heartbeat_index: 1,
+        pending_permission_requests: 0,
+        background_tasks: {},
+        uuid: '12345678-1234-1234-1234-123456789012',
+        session_id: '12345678-1234-1234-1234-123456789012',
+      },
     ]
 
     for (const msg of messages) {

--- a/tests/sdk/generated-types.test.ts
+++ b/tests/sdk/generated-types.test.ts
@@ -1,5 +1,7 @@
 import { describe, test, expect } from 'bun:test'
+import { spawnSync } from 'node:child_process'
 import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
 import { generateSdkTypes } from '../../scripts/generate-sdk-types.js'
 import {
   AccountInfoSchema,
@@ -25,6 +27,8 @@ import {
 } from '../../src/entrypoints/sdk/coreSchemas.js'
 import { z } from 'zod/v4'
 
+const repoRoot = fileURLToPath(new URL('../..', import.meta.url))
+const normalizeLineEndings = (source: string) => source.replace(/\r\n/g, '\n')
 const generatedTypesSource = () =>
   readFileSync(
     new URL('../../src/entrypoints/sdk/coreTypes.generated.ts', import.meta.url),
@@ -43,8 +47,9 @@ const generatedTypesSource = () =>
 describe('SDK Zod schemas (type generation source)', () => {
   test('SDK type generation exports heartbeat messages directly', () => {
     const generatedSource = generateSdkTypes()
+    const committedSource = normalizeLineEndings(generatedTypesSource())
 
-    expect(generatedSource).toBe(generatedTypesSource())
+    expect(generatedSource).toBe(committedSource)
     expect(generatedSource).toMatch(/^export type SDKHeartbeatMessage\b/m)
     expect(generatedSource).not.toContain(
       '// ⚠ Failed: SDKHeartbeatMessageSchema',
@@ -52,6 +57,23 @@ describe('SDK Zod schemas (type generation source)', () => {
     expect(generatedSource).not.toMatch(
       /^export type SDKHeartbeatMessage = any$/m,
     )
+  })
+
+  test('SDK type generator can be imported from non-file entrypoints', () => {
+    // The generator is a Bun TypeScript script, matching package.json scripts.
+    const bunExecutable = process.execPath
+    const result = spawnSync(
+      bunExecutable,
+      [
+        '--eval',
+        "process.argv[1] = '-'; import('./scripts/generate-sdk-types.ts').then(() => console.log('import-ok'))",
+      ],
+      { cwd: repoRoot, encoding: 'utf8' },
+    )
+
+    expect(result.stderr).toBe('')
+    expect(result.status).toBe(0)
+    expect(normalizeLineEndings(result.stdout).trim()).toBe('import-ok')
   })
 
   test('SDKAssistantMessageSchema accepts valid data', () => {

--- a/tests/sdk/generated-types.test.ts
+++ b/tests/sdk/generated-types.test.ts
@@ -241,6 +241,13 @@ describe('SDK Zod schemas (type generation source)', () => {
         session_id: '',
       }).success,
     ).toBe(true)
+    expect(
+      schema.safeParse({
+        ...validHeartbeat,
+        uuid: 'heartbeat-fallback',
+        session_id: 'session-fallback',
+      }).success,
+    ).toBe(true)
 
     for (const invalidHeartbeat of [
       { ...validHeartbeat, elapsed_ms: -1 },

--- a/tests/sdk/generated-types.test.ts
+++ b/tests/sdk/generated-types.test.ts
@@ -1,6 +1,6 @@
 import { describe, test, expect } from 'bun:test'
 import { spawnSync } from 'node:child_process'
-import { readFileSync } from 'node:fs'
+import { readFileSync, statSync } from 'node:fs'
 import { fileURLToPath } from 'node:url'
 import { generateSdkTypes } from '../../scripts/generate-sdk-types.js'
 import {
@@ -28,12 +28,11 @@ import {
 import { z } from 'zod/v4'
 
 const repoRoot = fileURLToPath(new URL('../..', import.meta.url))
+const generatedTypesPath = fileURLToPath(
+  new URL('../../src/entrypoints/sdk/coreTypes.generated.ts', import.meta.url),
+)
 const normalizeLineEndings = (source: string) => source.replace(/\r\n/g, '\n')
-const generatedTypesSource = () =>
-  readFileSync(
-    new URL('../../src/entrypoints/sdk/coreTypes.generated.ts', import.meta.url),
-    'utf8',
-  )
+const generatedTypesSource = () => readFileSync(generatedTypesPath, 'utf8')
 
 /**
  * Tests for generated SDK types from Zod schemas.
@@ -60,6 +59,9 @@ describe('SDK Zod schemas (type generation source)', () => {
   })
 
   test('SDK type generator can be imported from non-file entrypoints', () => {
+    const beforeSource = generatedTypesSource()
+    const beforeMtimeMs = statSync(generatedTypesPath).mtimeMs
+
     // The generator is a Bun TypeScript script, matching package.json scripts.
     const bunExecutable = process.execPath
     const result = spawnSync(
@@ -74,6 +76,8 @@ describe('SDK Zod schemas (type generation source)', () => {
     expect(result.stderr).toBe('')
     expect(result.status).toBe(0)
     expect(normalizeLineEndings(result.stdout).trim()).toBe('import-ok')
+    expect(generatedTypesSource()).toBe(beforeSource)
+    expect(statSync(generatedTypesPath).mtimeMs).toBe(beforeMtimeMs)
   })
 
   test('SDKAssistantMessageSchema accepts valid data', () => {


### PR DESCRIPTION
## Summary
- adds an opt-in `--heartbeat <duration>` flag for `--print` mode
- emits quiet-based headless liveness heartbeats while output is silent
- preserves stdout contracts for text/json and emits structured `system/heartbeat` events for stream-json after the structured stream is initialized
- documents pre-stream MCP startup heartbeats as stderr-only so SDK stream consumers do not receive structured events before stream initialization
- keeps heartbeat payloads schema-valid when UUID generation fails and tightens SDK heartbeat numeric validation to match producer output
- filters heartbeat events out of final-result selection and verbose JSON result arrays
- adds focused runtime, parser, routing, print-flow heartbeat, and SDK schema coverage

## Impact
- Users running `--print --heartbeat` get opt-in liveness output during quiet periods without changing default CLI behavior.
- Stream-json SDK consumers receive structured heartbeat events only after the structured stream is available; pre-stream MCP startup liveness remains on stderr.
- SDK consumers get stricter heartbeat validation for integer counters/durations and positive background task counts.

## Notes
- Risk surface: this touches print-mode startup, MCP connection waiting, background task visibility, stream-json output routing, and SDK message schemas. The heartbeat remains opt-in and does not change trust, permission, sandbox, provider, or network policy.
- Provider/model path: not provider-specific; validation covered the headless print/stream-json heartbeat path and SDK schema parsing.
- Screenshots: not applicable for this terminal/SDK behavior change.

## Testing
- `bun test src/cli/headlessHeartbeat.test.ts src/cli/printHeartbeat.test.ts tests/sdk/generated-types.test.ts`
- `bun run typecheck`
- `bun run typecheck:type-tests`
- `bun run build`
- `bun run smoke`
- `bun run security:pr-scan -- --base upstream/main`