### PR TITLE
fix(hicap): improve model catalog and effort routing

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -194,7 +194,7 @@ ANTHROPIC_API_KEY=sk-ant-your-key-here
 # For Hicap, use the OpenAI-compatible route flag above and set:
 # HICAP_API_KEY=your-hicap-key-here
 # OPENAI_BASE_URL=https://api.hicap.ai/v1
-# OPENAI_MODEL=claude-opus-4.7
+# OPENAI_MODEL=claude-opus-4.8
 
 # Use a custom OpenAI-compatible endpoint (optional — defaults to api.openai.com)
 # OPENAI_BASE_URL=https://api.openai.com/v1

--- a/src/components/ModelPicker.test.tsx
+++ b/src/components/ModelPicker.test.tsx
@@ -148,3 +148,62 @@ test('does not append a blocked current model to filtered override options', asy
     stdout.end()
   }
 })
+
+test('matches current model to override options case-insensitively', async () => {
+  const { ModelPicker } = await import(
+    `./ModelPicker.js?case-current-${Date.now()}`
+  )
+  let output = ''
+  const stdout = new PassThrough()
+  const stdin = new PassThrough() as PassThrough & {
+    isTTY: boolean
+    setRawMode: (mode: boolean) => void
+    ref: () => void
+    unref: () => void
+  }
+  stdin.isTTY = true
+  stdin.setRawMode = () => {}
+  stdin.ref = () => {}
+  stdin.unref = () => {}
+  ;(stdout as unknown as { columns: number }).columns = 120
+  stdout.on('data', chunk => {
+    output += chunk.toString()
+  })
+
+  const instance = await render(
+    <AppStateProvider
+      initialState={{
+        ...getDefaultAppState(),
+        mainLoopModel: 'GLM-5.2',
+      }}
+    >
+      <ModelPicker
+        initial="GLM-5.2"
+        onSelect={() => {}}
+        optionsOverride={[
+          {
+            value: 'glm-5.2',
+            label: 'GLM 5.2',
+            description: 'Provider: Hicap',
+          },
+        ]}
+      />
+    </AppStateProvider>,
+    {
+      stdin: stdin as unknown as NodeJS.ReadStream,
+      stdout: stdout as unknown as NodeJS.WriteStream,
+      exitOnCtrlC: false,
+    },
+  )
+
+  try {
+    await waitForCondition(() => stripAnsi(output).includes('GLM 5.2'))
+    const rendered = stripAnsi(output)
+    expect(rendered).toContain('GLM 5.2')
+    expect(rendered).not.toContain('Current model')
+  } finally {
+    instance.unmount()
+    stdin.end()
+    stdout.end()
+  }
+})

--- a/src/components/ModelPicker.tsx
+++ b/src/components/ModelPicker.tsx
@@ -44,6 +44,17 @@ export type Props = {
   onRefresh?: () => void;
 };
 const NO_PREFERENCE = '__NO_PREFERENCE__';
+function normalizeModelPickerValue(value: unknown): string | null {
+  return typeof value === 'string' && value.trim()
+    ? value.trim().toLowerCase()
+    : null;
+}
+
+function optionMatchesPickerValue(option: ModelOption, value: string): boolean {
+  const optionKey = normalizeModelPickerValue(option.value);
+  const valueKey = normalizeModelPickerValue(value);
+  return optionKey !== null && valueKey !== null && optionKey === valueKey;
+}
 function mapDiscoveryToneToColor(tone: ModelPickerDiscoveryState['tone']): 'error' | 'warning' | 'success' | 'subtle' {
   switch (tone) {
     case 'error':
@@ -100,7 +111,7 @@ export function ModelPicker(t0) {
   const modelOptions = optionsOverride ?? t3;
   let t4;
   bb0: {
-    if (initial !== null && isModelAllowed(initial) && !modelOptions.some(opt => opt.value === initial)) {
+    if (initial !== null && isModelAllowed(initial) && !modelOptions.some(opt => optionMatchesPickerValue(opt, initial))) {
       let t5;
       if ($[4] !== initial) {
         t5 = modelDisplayString(initial);
@@ -148,7 +159,7 @@ export function ModelPicker(t0) {
   const selectOptions = t5;
   let t6;
   if ($[14] !== initialValue || $[15] !== selectOptions) {
-    t6 = selectOptions.some(_ => _.value === initialValue) ? initialValue : selectOptions[0]?.value ?? undefined;
+    t6 = selectOptions.find(_ => optionMatchesPickerValue(_, initialValue))?.value ?? selectOptions[0]?.value ?? undefined;
     $[14] = initialValue;
     $[15] = selectOptions;
     $[16] = t6;
@@ -322,15 +333,14 @@ export function ModelPicker(t0) {
   const t19 = <Box marginBottom={1} flexDirection="column">{t15}{t17}{t18}{discoveryLine}</Box>;
   const t20 = onCancel ?? _temp4;
   let t21;
-  if ($[49] !== handleFocus || $[50] !== handleSelect || $[51] !== initialFocusValue || $[52] !== initialValue || $[53] !== selectOptions || $[54] !== t20 || $[55] !== visibleCount) {
-    t21 = <Box flexDirection="column"><Select defaultValue={initialValue} defaultFocusValue={initialFocusValue} options={selectOptions} onChange={handleSelect} onFocus={handleFocus} onCancel={t20} visibleOptionCount={visibleCount} /></Box>;
+  if ($[49] !== handleFocus || $[50] !== handleSelect || $[51] !== initialFocusValue || $[52] !== selectOptions || $[53] !== t20 || $[54] !== visibleCount) {
+    t21 = <Box flexDirection="column"><Select defaultValue={initialFocusValue} defaultFocusValue={initialFocusValue} options={selectOptions} onChange={handleSelect} onFocus={handleFocus} onCancel={t20} visibleOptionCount={visibleCount} /></Box>;
     $[49] = handleFocus;
     $[50] = handleSelect;
     $[51] = initialFocusValue;
-    $[52] = initialValue;
-    $[53] = selectOptions;
-    $[54] = t20;
-    $[55] = visibleCount;
+    $[52] = selectOptions;
+    $[53] = t20;
+    $[54] = visibleCount;
     $[56] = t21;
   } else {
     t21 = $[56];

--- a/src/components/ModelPicker.tsx
+++ b/src/components/ModelPicker.tsx
@@ -55,6 +55,11 @@ function optionMatchesPickerValue(option: ModelOption, value: string): boolean {
   const valueKey = normalizeModelPickerValue(value);
   return optionKey !== null && valueKey !== null && optionKey === valueKey;
 }
+
+function resolvePickerOptionValue(options: ModelOption[], value: string): string | undefined {
+  const optionValue = options.find(option => optionMatchesPickerValue(option, value))?.value;
+  return typeof optionValue === 'string' ? optionValue : undefined;
+}
 function mapDiscoveryToneToColor(tone: ModelPickerDiscoveryState['tone']): 'error' | 'warning' | 'success' | 'subtle' {
   switch (tone) {
     case 'error':
@@ -69,7 +74,7 @@ function mapDiscoveryToneToColor(tone: ModelPickerDiscoveryState['tone']): 'erro
   }
 }
 export function ModelPicker(t0) {
-  const $ = _c(83);
+  const $ = _c(84);
   const {
     initial,
     sessionModel,
@@ -86,7 +91,6 @@ export function ModelPicker(t0) {
   const setAppState = useSetAppState();
   const exitState = useExitOnCtrlCDWithKeybindings();
   const initialValue = initial === null ? NO_PREFERENCE : initial;
-  const [focusedValue, setFocusedValue] = useState(initialValue);
   const isFastMode = useAppState(_temp);
   const [hasToggledEffort, setHasToggledEffort] = useState(false);
   const effortValue = useAppState(_temp2);
@@ -167,6 +171,7 @@ export function ModelPicker(t0) {
     t6 = $[16];
   }
   const initialFocusValue = t6;
+  const [focusedValue, setFocusedValue] = useState(initialFocusValue ?? initialValue);
   const visibleCount = Math.min(10, selectOptions.length);
   const hiddenCount = Math.max(0, selectOptions.length - visibleCount);
   let t7;
@@ -208,15 +213,17 @@ export function ModelPicker(t0) {
   const focusedDefaultEffort = t9;
   const displayEffort = focusedAvailableLevels.includes(effort) ? effort : "high";
   let t10;
-  if ($[25] !== effortValue || $[26] !== hasToggledEffort) {
+  if ($[25] !== effortValue || $[26] !== hasToggledEffort || $[83] !== selectOptions) {
     t10 = value => {
-      setFocusedValue(value);
+      const selectedValue = resolvePickerOptionValue(selectOptions, value) ?? value;
+      setFocusedValue(selectedValue);
       if (!hasToggledEffort && effortValue === undefined) {
-        setEffort(getDefaultEffortLevelForOption(value));
+        setEffort(getDefaultEffortLevelForOption(selectedValue));
       }
     };
     $[25] = effortValue;
     $[26] = hasToggledEffort;
+    $[83] = selectOptions;
     $[27] = t10;
   } else {
     t10 = $[27];
@@ -258,11 +265,12 @@ export function ModelPicker(t0) {
   }
   useKeybindings(t12, t13);
   let t14;
-  if ($[35] !== effort || $[36] !== hasToggledEffort || $[37] !== onSelect || $[38] !== setAppState || $[39] !== skipSettingsWrite || $[46] !== focusedAvailableLevels || $[47] !== focusedDefaultEffort) {
+  if ($[35] !== effort || $[36] !== hasToggledEffort || $[37] !== onSelect || $[38] !== setAppState || $[39] !== skipSettingsWrite || $[46] !== focusedAvailableLevels || $[47] !== focusedDefaultEffort || $[48] !== selectOptions) {
     t14 = function handleSelect(value_0) {
-      const selectedModel = resolveOptionModel(value_0);
-      if (value_0 !== NO_PREFERENCE && selectedModel && !isModelAllowed(selectedModel)) {
-        onSelect(value_0 === NO_PREFERENCE ? null : value_0, undefined);
+      const selectedValue = resolvePickerOptionValue(selectOptions, value_0) ?? value_0;
+      const selectedModel = resolveOptionModel(selectedValue);
+      if (selectedValue !== NO_PREFERENCE && selectedModel && !isModelAllowed(selectedModel)) {
+        onSelect(selectedValue === NO_PREFERENCE ? null : selectedValue, undefined);
         return;
       }
       // Clamp effort to a value in the focused model's available levels so
@@ -273,7 +281,7 @@ export function ModelPicker(t0) {
         effort: clampedEffort as AnalyticsMetadata_I_VERIFIED_THIS_IS_NOT_CODE_OR_FILEPATHS
       });
       if (!skipSettingsWrite) {
-        const effortLevel = resolvePickerEffortPersistence(clampedEffort, getDefaultEffortLevelForOption(value_0), getSettingsForSource("userSettings")?.effortLevel, hasToggledEffort);
+        const effortLevel = resolvePickerEffortPersistence(clampedEffort, getDefaultEffortLevelForOption(selectedValue), getSettingsForSource("userSettings")?.effortLevel, hasToggledEffort);
         const persistable = toPersistableEffort(effortLevel);
         if (persistable !== undefined) {
           updateSettingsForSource("userSettings", {
@@ -286,11 +294,11 @@ export function ModelPicker(t0) {
         }));
       }
       const selectedEffort = hasToggledEffort && selectedModel && modelSupportsEffort(selectedModel) ? clampedEffort : undefined;
-      if (value_0 === NO_PREFERENCE) {
+      if (selectedValue === NO_PREFERENCE) {
         onSelect(null, selectedEffort);
         return;
       }
-      onSelect(value_0, selectedEffort);
+      onSelect(selectedValue, selectedEffort);
     };
     $[35] = effort;
     $[36] = hasToggledEffort;
@@ -299,6 +307,7 @@ export function ModelPicker(t0) {
     $[39] = skipSettingsWrite;
     $[46] = focusedAvailableLevels;
     $[47] = focusedDefaultEffort;
+    $[48] = selectOptions;
     $[40] = t14;
   } else {
     t14 = $[40];

--- a/src/components/ProviderManager.test.tsx
+++ b/src/components/ProviderManager.test.tsx
@@ -252,7 +252,7 @@ function mockProviderProfilesModule(options?: {
           provider: 'hicap',
           name: 'Hicap',
           baseUrl: 'https://api.hicap.ai/v1',
-          model: 'claude-opus-4.7',
+          model: 'claude-opus-4.8',
           apiKey: '',
           requiresApiKey: true,
         }
@@ -1001,7 +1001,7 @@ test('ProviderManager saves Hicap preset non-GPT model with Chat Completions', a
     )
 
     expect(modelOutput).toContain('Hicap')
-    expect(modelOutput).toContain('claude-opus-4.7')
+    expect(modelOutput).toContain('claude-opus-4.8')
 
     mounted.stdin.write('\r')
     await waitForFrameOutput(mounted.getOutput, frame =>
@@ -1015,7 +1015,7 @@ test('ProviderManager saves Hicap preset non-GPT model with Chat Completions', a
     expect(addProviderProfile).toHaveBeenCalledWith(
       expect.objectContaining({
         provider: 'hicap',
-        model: 'claude-opus-4.7',
+        model: 'claude-opus-4.8',
         apiFormat: 'chat_completions',
       }),
       expect.objectContaining({ makeActive: true }),

--- a/src/integrations/descriptors.ts
+++ b/src/integrations/descriptors.ts
@@ -30,6 +30,8 @@ export interface OpenAIShimUiConfig {
 export interface OpenAIShimTransportConfig {
   headers?: Record<string, string>
   supportsApiFormatSelection?: boolean
+  defaultApiFormat?: 'chat_completions' | 'responses' | 'responses_compat'
+  requiredApiFormat?: 'chat_completions' | 'responses' | 'responses_compat'
   supportsAuthHeaders?: boolean
   ui?: OpenAIShimUiConfig
   defaultAuthHeader?: OpenAIShimAuthHeaderConfig

--- a/src/integrations/gateways/hicap.ts
+++ b/src/integrations/gateways/hicap.ts
@@ -5,7 +5,7 @@ export default defineGateway({
   label: 'Hicap',
   category: 'aggregating',
   defaultBaseUrl: 'https://api.hicap.ai/v1',
-  defaultModel: 'claude-opus-4.7',
+  defaultModel: 'claude-opus-4.8',
   supportsModelRouting: true,
   setup: {
     requiresAuth: true,
@@ -29,7 +29,7 @@ export default defineGateway({
         name: 'api-key',
         scheme: 'raw',
       },
-      responsesApiModelPrefixes: ['gpt-'],
+      responsesApiModelPrefixes: ['gpt-5.4', 'gpt-5.5'],
     },
   },
   preset: {
@@ -55,13 +55,16 @@ export default defineGateway({
     discoveryCacheTtl: '1d',
     discoveryRefreshMode: 'background-if-stale',
     allowManualRefresh: true,
+    // Hicap /v1/models currently returns ids only; keep verified route metadata here.
     models: [
-      {
-        id: 'hicap-claude-opus-4.7',
-        apiName: 'claude-opus-4.7',
-        label: 'Claude Opus 4.7',
-        modelDescriptorId: 'claude-opus-4-7',
-      },
+      { id: 'hicap-claude-opus-4.8', apiName: 'claude-opus-4.8', label: 'Claude Opus 4.8', modelDescriptorId: 'claude-opus-4-8', contextWindow: 1_000_000, maxOutputTokens: 128_000, reasoning: { mode: 'levels', levels: ['low', 'medium', 'high', 'xhigh', 'max'], defaultLevel: 'high', wireFormat: 'reasoning_effort' } },
+      { id: 'hicap-deepseek-v4-pro', apiName: 'deepseek-v4-pro', label: 'DeepSeek V4 Pro', modelDescriptorId: 'deepseek-v4-pro', contextWindow: 1_048_576, maxOutputTokens: 65_536, reasoning: { mode: 'levels', levels: ['low', 'medium', 'high', 'xhigh', 'max'], defaultLevel: 'high', wireFormat: 'reasoning_effort' } },
+      { id: 'hicap-glm-5.2', apiName: 'glm-5.2', aliases: ['zai-org/glm-5.2'], label: 'GLM 5.2', modelDescriptorId: 'glm-5.2', contextWindow: 1_000_000, maxOutputTokens: 131_072, capabilities: { supportsFunctionCalling: true, supportsJsonMode: true, supportsReasoning: true }, reasoning: { mode: 'levels', levels: ['low', 'medium', 'high', 'xhigh'], defaultLevel: 'high', wireFormat: 'zai_compatible' }, transportOverrides: { openaiShim: { preserveReasoningContent: true, requireReasoningContentOnAssistantMessages: true, reasoningContentFallback: '', thinkingRequestFormat: 'zai-compatible', maxTokensField: 'max_tokens', removeBodyFields: ['store'], enableToolStreaming: true } } },
+      { id: 'hicap-gpt-5.4', apiName: 'gpt-5.4', label: 'GPT-5.4', modelDescriptorId: 'gpt-5.4', contextWindow: 1_050_000, maxOutputTokens: 128_000, capabilities: { supportsReasoning: true }, reasoning: { mode: 'levels', levels: ['low', 'medium', 'high', 'xhigh'], defaultLevel: 'high', wireFormat: 'reasoning_effort' }, transportOverrides: { openaiShim: { requiredApiFormat: 'responses', maxTokensField: 'max_completion_tokens' } } },
+      { id: 'hicap-gpt-5.5', apiName: 'gpt-5.5', label: 'GPT-5.5', modelDescriptorId: 'gpt-5.5', contextWindow: 1_050_000, maxOutputTokens: 128_000, capabilities: { supportsReasoning: true }, reasoning: { mode: 'levels', levels: ['low', 'medium', 'high', 'xhigh'], defaultLevel: 'high', wireFormat: 'reasoning_effort' }, transportOverrides: { openaiShim: { requiredApiFormat: 'responses', maxTokensField: 'max_completion_tokens' } } },
+      { id: 'hicap-grok-4.3', apiName: 'grok-4.3', label: 'Grok 4.3', modelDescriptorId: 'grok-4.3', contextWindow: 1_000_000, maxOutputTokens: 32_768, reasoning: { mode: 'levels', levels: ['low', 'medium', 'high'], defaultLevel: 'high', wireFormat: 'reasoning_effort' } },
+      { id: 'hicap-kimi-k2.7-code', apiName: 'kimi-k2.7-code', label: 'Kimi K2.7 Code', modelDescriptorId: 'kimi-k2.7-code', contextWindow: 262_144, maxOutputTokens: 262_144, reasoning: { mode: 'levels', levels: ['low', 'medium', 'high', 'xhigh', 'max'], defaultLevel: 'high', wireFormat: 'reasoning_effort' } },
+      { id: 'hicap-minimax-m3', apiName: 'minimax-m3', label: 'MiniMax M3', modelDescriptorId: 'minimax-m3', contextWindow: 1_048_576, maxOutputTokens: 131_072, reasoning: { mode: 'levels', levels: ['low', 'medium', 'high', 'xhigh', 'max'], defaultLevel: 'high', wireFormat: 'reasoning_effort' } },
     ],
   },
   usage: { supported: false },

--- a/src/integrations/routeMetadata.test.ts
+++ b/src/integrations/routeMetadata.test.ts
@@ -265,7 +265,7 @@ test.each([
   ['NVIDIA NIM', 'https://integrate.api.nvidia.com/v1', 'nvidia/llama-3.1-nemotron-70b-instruct', 'nvidia-nim'],
   ['OpenRouter', 'https://openrouter.ai/api/v1', 'openai/gpt-5-mini', 'openrouter'],
   ['DeepSeek', 'https://api.deepseek.com/v1', 'deepseek-v4-pro', 'deepseek'],
-  ['Hicap', 'https://api.hicap.ai/v1', 'claude-opus-4.7', 'hicap'],
+  ['Hicap', 'https://api.hicap.ai/v1', 'claude-opus-4.8', 'hicap'],
   ['Xiaomi MiMo', 'https://api.xiaomimimo.com/v1', 'mimo-v2.5-pro', 'xiaomi-mimo'],
   ['Venice', 'https://api.venice.ai/api/v1', 'venice-uncensored', 'venice'],
 ])(

--- a/src/integrations/runtimeMetadata.test.ts
+++ b/src/integrations/runtimeMetadata.test.ts
@@ -184,6 +184,91 @@ describe('resolveOpenAIShimRuntimeContext - Z.AI GLM-5.2', () => {
   })
 })
 
+describe('resolveOpenAIShimRuntimeContext - Hicap catalog metadata', () => {
+  it('uses Hicap static model limits and per-model shim overrides', () => {
+    expect(
+      resolveModelRuntimeLimits({
+        model: 'claude-opus-4.8',
+        baseUrl: 'https://api.hicap.ai/v1',
+        processEnv: { CLAUDE_CODE_USE_OPENAI: '1' },
+      }),
+    ).toEqual({ contextWindow: 1_000_000, maxOutputTokens: 128_000 })
+
+    expect(
+      resolveModelRuntimeLimits({
+        model: 'kimi-k2.7-code',
+        baseUrl: 'https://api.hicap.ai/v1',
+        processEnv: { CLAUDE_CODE_USE_OPENAI: '1' },
+      }),
+    ).toEqual({ contextWindow: 262_144, maxOutputTokens: 262_144 })
+
+    expect(
+      resolveModelRuntimeLimits({
+        model: 'gpt-5.4',
+        baseUrl: 'https://api.hicap.ai/v1',
+        processEnv: { CLAUDE_CODE_USE_OPENAI: '1' },
+      }),
+    ).toEqual({ contextWindow: 1_050_000, maxOutputTokens: 128_000 })
+
+    const glm = resolveOpenAIShimRuntimeContext({
+      model: 'glm-5.2',
+      baseUrl: 'https://api.hicap.ai/v1',
+      processEnv: { CLAUDE_CODE_USE_OPENAI: '1' },
+    })
+    expect(glm.catalogEntry?.id).toBe('hicap-glm-5.2')
+    expect(glm.catalogEntry?.reasoning?.levels).toEqual(['low', 'medium', 'high', 'xhigh'])
+    expect(glm.openaiShimConfig.thinkingRequestFormat).toBe('zai-compatible')
+    expect(glm.openaiShimConfig.maxTokensField).toBe('max_tokens')
+    expect(glm.openaiShimConfig.removeBodyFields).toContain('store')
+    expect(glm.openaiShimConfig.enableToolStreaming).toBe(true)
+
+    const discoveredGlm = resolveOpenAIShimRuntimeContext({
+      model: 'zai-org/GLM-5.2',
+      baseUrl: 'https://api.hicap.ai/v1',
+      processEnv: { CLAUDE_CODE_USE_OPENAI: '1' },
+    })
+    expect(discoveredGlm.catalogEntry?.id).toBe('hicap-glm-5.2')
+    expect(discoveredGlm.openaiShimConfig.thinkingRequestFormat).toBe('zai-compatible')
+    expect(discoveredGlm.openaiShimConfig.maxTokensField).toBe('max_tokens')
+
+    const gpt54 = resolveOpenAIShimRuntimeContext({
+      model: 'gpt-5.4',
+      baseUrl: 'https://api.hicap.ai/v1',
+      processEnv: { CLAUDE_CODE_USE_OPENAI: '1' },
+    })
+    expect(gpt54.routeId).toBe('hicap')
+    expect(gpt54.catalogEntry?.id).toBe('hicap-gpt-5.4')
+    expect(gpt54.catalogEntry?.reasoning?.levels).toEqual([
+      'low',
+      'medium',
+      'high',
+      'xhigh',
+    ])
+    expect(gpt54.openaiShimConfig.requiredApiFormat).toBe('responses')
+    expect(gpt54.openaiShimConfig.maxTokensField).toBe('max_completion_tokens')
+
+    const gpt55 = resolveOpenAIShimRuntimeContext({
+      model: 'gpt-5.5',
+      baseUrl: 'https://api.hicap.ai/v1',
+      processEnv: { CLAUDE_CODE_USE_OPENAI: '1' },
+    })
+    expect(gpt55.catalogEntry?.id).toBe('hicap-gpt-5.5')
+    expect(gpt55.openaiShimConfig.requiredApiFormat).toBe('responses')
+    expect(gpt55.openaiShimConfig.maxTokensField).toBe('max_completion_tokens')
+
+    const grok = resolveOpenAIShimRuntimeContext({
+      model: 'grok-4.3',
+      baseUrl: 'https://api.hicap.ai/v1',
+      processEnv: { CLAUDE_CODE_USE_OPENAI: '1' },
+    })
+    expect(grok.catalogEntry?.reasoning?.levels).toEqual([
+      'low',
+      'medium',
+      'high',
+    ])
+  })
+})
+
 describe('resolveOpenAIShimRuntimeContext - provider override route preference', () => {
   it('does not inherit ambient route config when the preferred base URL is unrecognized', () => {
     const result = resolveOpenAIShimRuntimeContext({

--- a/src/integrations/runtimeMetadata.ts
+++ b/src/integrations/runtimeMetadata.ts
@@ -55,6 +55,14 @@ function matchesCatalogEntryModel(
     return true
   }
 
+  if (
+    (entry.aliases ?? []).some(
+      alias => normalizeModelApiName(alias) === modelApiName,
+    )
+  ) {
+    return true
+  }
+
   if (!entry.modelDescriptorId) {
     return false
   }

--- a/src/services/api/bootstrap.test.ts
+++ b/src/services/api/bootstrap.test.ts
@@ -1,7 +1,7 @@
 import { expect, test } from 'bun:test'
 
 import type { RouteDiscoveryResult } from '../../integrations/discoveryService.js'
-import { _getDiscoveredModelApiNamesForTesting } from './bootstrap.js'
+import { getDiscoveredModelApiNames } from './bootstrap.js'
 
 test('uses static route models from errored discovery results', () => {
   const discovered: RouteDiscoveryResult = {
@@ -15,7 +15,7 @@ test('uses static route models from errored discovery results', () => {
     source: 'error',
   }
 
-  expect(_getDiscoveredModelApiNamesForTesting(discovered)).toEqual(['glm-5.2'])
+  expect(getDiscoveredModelApiNames(discovered)).toEqual(['glm-5.2'])
 })
 
 test('falls back to raw discovery when route discovery has no usable models', () => {
@@ -27,5 +27,5 @@ test('falls back to raw discovery when route discovery has no usable models', ()
     source: 'error',
   }
 
-  expect(_getDiscoveredModelApiNamesForTesting(discovered)).toBeNull()
+  expect(getDiscoveredModelApiNames(discovered)).toBeNull()
 })

--- a/src/services/api/bootstrap.test.ts
+++ b/src/services/api/bootstrap.test.ts
@@ -1,7 +1,7 @@
 import { expect, test } from 'bun:test'
 
 import type { RouteDiscoveryResult } from '../../integrations/discoveryService.js'
-import { getDiscoveredModelApiNames } from './bootstrap.js'
+import { fetchLocalOpenAIModelOptions, getDiscoveredModelApiNames } from './bootstrap.js'
 
 test('uses static route models from errored discovery results', () => {
   const discovered: RouteDiscoveryResult = {
@@ -28,4 +28,92 @@ test('falls back to raw discovery when route discovery has no usable models', ()
   }
 
   expect(getDiscoveredModelApiNames(discovered)).toBeNull()
+})
+
+test('local OpenAI bootstrap canonicalizes errored discovery model options', async () => {
+  const envKeys = [
+    'ANTHROPIC_CUSTOM_HEADERS',
+    'CLAUDE_CODE_USE_OPENAI',
+    'HICAP_API_KEY',
+    'OPENAI_API_KEY',
+    'OPENAI_API_KEYS',
+    'OPENAI_BASE_URL',
+    'OPENAI_MODEL',
+  ] as const
+  const savedEnv = new Map<string, string | undefined>(
+    envKeys.map(key => [key, process.env[key]]),
+  )
+
+  try {
+    process.env.CLAUDE_CODE_USE_OPENAI = '1'
+    process.env.OPENAI_BASE_URL = 'https://api.hicap.ai/v1'
+    process.env.OPENAI_MODEL = 'claude-opus-4.8'
+    process.env.HICAP_API_KEY = 'sk-hicap-test'
+    delete process.env.OPENAI_API_KEY
+    delete process.env.OPENAI_API_KEYS
+    delete process.env.ANTHROPIC_CUSTOM_HEADERS
+
+    const discovered: RouteDiscoveryResult = {
+      routeId: 'hicap',
+      models: [
+        {
+          id: 'live-glm-alias',
+          apiName: 'zai-org/GLM-5.2',
+          label: 'GLM alias',
+        },
+        {
+          id: 'live-glm-canonical',
+          apiName: 'glm-5.2',
+          label: 'GLM duplicate',
+        },
+        {
+          id: 'live-gpt-catalog-id',
+          apiName: 'hicap-gpt-5.5',
+          label: 'GPT catalog id',
+        },
+      ],
+      stale: false,
+      error: { message: 'Discovery failed for route hicap', recordedAt: 1 },
+      source: 'error',
+    }
+
+    const payload = await fetchLocalOpenAIModelOptions({
+      discoverModelsForRoute: async () => discovered,
+      getAdditionalModelOptionsCacheScope: () =>
+        'openai:https://api.hicap.ai/v1:test',
+      resolveProviderRequest: () => ({
+        transport: 'chat_completions',
+        requestedModel: 'claude-opus-4.8',
+        resolvedModel: 'claude-opus-4.8',
+        baseUrl: 'https://api.hicap.ai/v1',
+      }),
+      listOpenAICompatibleModels: async () => {
+        throw new Error(
+          'raw model listing should not run when errored route discovery has models',
+        )
+      },
+    })
+
+    expect(payload?.additionalModelOptions).toEqual([
+      {
+        value: 'glm-5.2',
+        label: 'GLM 5.2',
+        description: 'Detected from Hicap',
+      },
+      {
+        value: 'gpt-5.5',
+        label: 'GPT-5.5',
+        description: 'Detected from Hicap',
+      },
+    ])
+  } finally {
+    for (const key of envKeys) {
+      const value = savedEnv.get(key)
+      if (value === undefined) {
+        delete process.env[key]
+      } else {
+        process.env[key] = value
+      }
+    }
+  }
 })

--- a/src/services/api/bootstrap.test.ts
+++ b/src/services/api/bootstrap.test.ts
@@ -1,0 +1,31 @@
+import { expect, test } from 'bun:test'
+
+import type { RouteDiscoveryResult } from '../../integrations/discoveryService.js'
+import { _getDiscoveredModelApiNamesForTesting } from './bootstrap.js'
+
+test('uses static route models from errored discovery results', () => {
+  const discovered: RouteDiscoveryResult = {
+    routeId: 'hicap',
+    models: [
+      { id: 'hicap-glm-5.2', apiName: 'glm-5.2', label: 'GLM 5.2' },
+      { id: 'blank', apiName: '   ', label: 'Blank' },
+    ],
+    stale: false,
+    error: { message: 'Discovery failed for route hicap', recordedAt: 1 },
+    source: 'error',
+  }
+
+  expect(_getDiscoveredModelApiNamesForTesting(discovered)).toEqual(['glm-5.2'])
+})
+
+test('falls back to raw discovery when route discovery has no usable models', () => {
+  const discovered: RouteDiscoveryResult = {
+    routeId: 'hicap',
+    models: [],
+    stale: false,
+    error: { message: 'Discovery failed for route hicap', recordedAt: 1 },
+    source: 'error',
+  }
+
+  expect(_getDiscoveredModelApiNamesForTesting(discovered)).toBeNull()
+})

--- a/src/services/api/bootstrap.ts
+++ b/src/services/api/bootstrap.ts
@@ -1,10 +1,15 @@
 import axios from 'axios'
 import isEqual from 'lodash-es/isEqual.js'
+import type { RouteDiscoveryResult } from '../../integrations/discoveryService.js'
 import {
   discoverModelsForRoute,
   resolveDiscoveryRouteIdFromBaseUrl,
 } from '../../integrations/discoveryService.js'
-import { getGateway, getVendor } from '../../integrations/index.js'
+import {
+  getCatalogEntriesForRoute,
+  getGateway,
+  getVendor,
+} from '../../integrations/index.js'
 import { resolveRouteCredentialValue } from '../../integrations/routeMetadata.js'
 import { firstUsableCredential, hasInvalidCredentialPlaceholder } from './credentialPool.js'
 import {
@@ -60,6 +65,54 @@ type BootstrapCachePayload = {
   clientData: Record<string, unknown> | null
   additionalModelOptions: ModelOption[]
   additionalModelOptionsScope: string
+}
+
+function normalizeDiscoveredModelLookupKey(model: string): string {
+  return model.trim().split('?', 1)[0]?.trim().toLowerCase() ?? ''
+}
+
+export function _getDiscoveredModelApiNamesForTesting(
+  discovered: RouteDiscoveryResult | null,
+): string[] | null {
+  const discoveredModels = discovered?.models
+    .map(model => model.apiName)
+    .filter(model => model.trim())
+  return discoveredModels?.length ? discoveredModels : null
+}
+
+function buildLocalOpenAIModelOptions(options: {
+  models: string[]
+  routeId: string | null
+  routeLabel: string
+}): ModelOption[] {
+  const seen = new Set<string>()
+  const catalogEntries = options.routeId
+    ? getCatalogEntriesForRoute(options.routeId)
+    : []
+
+  return options.models.flatMap(model => {
+    const normalizedModel = normalizeDiscoveredModelLookupKey(model)
+    const catalogEntry = catalogEntries.find(
+      entry =>
+        normalizeDiscoveredModelLookupKey(entry.apiName) === normalizedModel ||
+        normalizeDiscoveredModelLookupKey(entry.id) === normalizedModel ||
+        (entry.aliases ?? []).some(
+          alias => normalizeDiscoveredModelLookupKey(alias) === normalizedModel,
+        ),
+    )
+    const value = catalogEntry?.apiName ?? model
+    const key = normalizeDiscoveredModelLookupKey(value)
+    if (!key || seen.has(key)) {
+      return []
+    }
+
+    seen.add(key)
+    return [{
+      value,
+      label: catalogEntry?.label ?? model,
+      description: `Detected from ${options.routeLabel}`,
+    }]
+  })
 }
 
 async function fetchBootstrapAPI(): Promise<BootstrapResponse | null> {
@@ -177,9 +230,7 @@ async function fetchLocalOpenAIModelOptions(): Promise<BootstrapCachePayload | n
       })
     : null
   const models =
-    (discovered && discovered.source !== 'error'
-      ? discovered.models.map(model => model.apiName)
-      : null) ??
+    _getDiscoveredModelApiNamesForTesting(discovered) ??
     (await listOpenAICompatibleModels({
       baseUrl,
       apiKey,
@@ -194,11 +245,11 @@ async function fetchLocalOpenAIModelOptions(): Promise<BootstrapCachePayload | n
   return {
     clientData: getGlobalConfig().clientDataCache ?? null,
     additionalModelOptionsScope: scope,
-    additionalModelOptions: models.map(model => ({
-      value: model,
-      label: model,
-      description: `Detected from ${routeLabel}`,
-    })),
+    additionalModelOptions: buildLocalOpenAIModelOptions({
+      models,
+      routeId,
+      routeLabel,
+    }),
   }
 }
 

--- a/src/services/api/bootstrap.ts
+++ b/src/services/api/bootstrap.ts
@@ -71,7 +71,7 @@ function normalizeDiscoveredModelLookupKey(model: string): string {
   return model.trim().split('?', 1)[0]?.trim().toLowerCase() ?? ''
 }
 
-export function _getDiscoveredModelApiNamesForTesting(
+export function getDiscoveredModelApiNames(
   discovered: RouteDiscoveryResult | null,
 ): string[] | null {
   const discoveredModels = discovered?.models
@@ -230,7 +230,7 @@ async function fetchLocalOpenAIModelOptions(): Promise<BootstrapCachePayload | n
       })
     : null
   const models =
-    _getDiscoveredModelApiNamesForTesting(discovered) ??
+    getDiscoveredModelApiNames(discovered) ??
     (await listOpenAICompatibleModels({
       baseUrl,
       apiKey,

--- a/src/services/api/bootstrap.ts
+++ b/src/services/api/bootstrap.ts
@@ -196,18 +196,29 @@ async function fetchBootstrapAPI(): Promise<BootstrapResponse | null> {
   }
 }
 
-async function fetchLocalOpenAIModelOptions(): Promise<BootstrapCachePayload | null> {
+type FetchLocalOpenAIModelOptionsDeps = {
+  discoverModelsForRoute?: typeof discoverModelsForRoute
+  getAdditionalModelOptionsCacheScope?: typeof getAdditionalModelOptionsCacheScope
+  listOpenAICompatibleModels?: typeof listOpenAICompatibleModels
+  resolveProviderRequest?: typeof resolveProviderRequest
+}
+
+export async function fetchLocalOpenAIModelOptions(
+  deps: FetchLocalOpenAIModelOptionsDeps = {},
+): Promise<BootstrapCachePayload | null> {
   if (isEssentialTrafficOnly()) {
     logForDebugging('[Bootstrap] Skipped local model discovery: Nonessential traffic disabled')
     return null
   }
 
-  const scope = getAdditionalModelOptionsCacheScope()
+  const getScope = deps.getAdditionalModelOptionsCacheScope ?? getAdditionalModelOptionsCacheScope
+  const resolveRequest = deps.resolveProviderRequest ?? resolveProviderRequest
+  const scope = getScope()
   if (!scope?.startsWith('openai:')) {
     return null
   }
 
-  const { baseUrl } = resolveProviderRequest()
+  const { baseUrl } = resolveRequest()
   const routeId = resolveDiscoveryRouteIdFromBaseUrl(baseUrl)
   const routeLabel =
     (routeId
@@ -222,8 +233,10 @@ async function fetchLocalOpenAIModelOptions(): Promise<BootstrapCachePayload | n
     ? undefined
     : firstUsableCredential(routeCredential)
 
+  const discoverModels = deps.discoverModelsForRoute ?? discoverModelsForRoute
+  const listModels = deps.listOpenAICompatibleModels ?? listOpenAICompatibleModels
   const discovered = routeId
-    ? await discoverModelsForRoute(routeId, {
+    ? await discoverModels(routeId, {
         baseUrl,
         apiKey,
         headers: parseCustomHeadersEnv(process.env.ANTHROPIC_CUSTOM_HEADERS),
@@ -231,7 +244,7 @@ async function fetchLocalOpenAIModelOptions(): Promise<BootstrapCachePayload | n
     : null
   const models =
     getDiscoveredModelApiNames(discovered) ??
-    (await listOpenAICompatibleModels({
+    (await listModels({
       baseUrl,
       apiKey,
       headers: parseCustomHeadersEnv(process.env.ANTHROPIC_CUSTOM_HEADERS),

--- a/src/services/api/openaiShim.test.ts
+++ b/src/services/api/openaiShim.test.ts
@@ -686,7 +686,7 @@ test('uses Hicap api-key auth header for the Hicap route', async () => {
   const client = createOpenAIShimClient({ defaultHeaders: {} }) as OpenAIShimClient
 
   await client.beta.messages.create({
-    model: 'claude-opus-4.7',
+    model: 'claude-opus-4.8',
     messages: [{ role: 'user', content: 'hello' }],
     max_tokens: 64,
     stream: false,
@@ -7277,6 +7277,56 @@ test('Z.AI GLM-5.2: streaming requests with tools send tool_stream', async () =>
   expect(requestBody?.tool_stream).toBe(true)
 })
 
+test('Hicap GLM-5.2: uses Z.AI-compatible request shaping', async () => {
+  process.env.OPENAI_BASE_URL = 'https://api.hicap.ai/v1'
+  process.env.HICAP_API_KEY = 'sk-hicap-test'
+
+  let requestBody: Record<string, unknown> | undefined
+  globalThis.fetch = (async (_input, init) => {
+    requestBody = JSON.parse(String(init?.body))
+    return makeSseResponse(makeStreamChunks([
+      {
+        id: 'chatcmpl-1',
+        object: 'chat.completion.chunk',
+        model: 'glm-5.2',
+        choices: [{ index: 0, delta: { content: 'ok' }, finish_reason: null }],
+      },
+      {
+        id: 'chatcmpl-1',
+        object: 'chat.completion.chunk',
+        model: 'glm-5.2',
+        choices: [{ index: 0, delta: {}, finish_reason: 'stop' }],
+      },
+    ]))
+  }) as unknown as FetchType
+
+  const client = createOpenAIShimClient({ reasoningEffort: 'xhigh' }) as OpenAIShimClient
+  await client.beta.messages.create({
+    model: 'GLM-5.2',
+    messages: [{ role: 'user', content: 'run pwd' }],
+    tools: [
+      {
+        name: 'Bash',
+        description: 'Run a shell command',
+        input_schema: {
+          type: 'object',
+          properties: { command: { type: 'string' } },
+          required: ['command'],
+        },
+      },
+    ],
+    max_tokens: 64,
+    stream: true,
+  })
+
+  expect(requestBody?.model).toBe('glm-5.2')
+  expect(requestBody?.store).toBeUndefined()
+  expect(requestBody?.max_tokens).toBe(64)
+  expect(requestBody?.max_completion_tokens).toBeUndefined()
+  expect(requestBody?.thinking).toEqual({ type: 'enabled' })
+  expect(requestBody?.reasoning_effort).toBe('max')
+  expect(requestBody?.tool_stream).toBe(true)
+})
 test('Z.AI GLM-5.2: remote tool incompatibility does not use local toolless retry', async () => {
   process.env.OPENAI_BASE_URL = 'https://api.z.ai/api/coding/paas/v4'
   process.env.OPENAI_API_KEY = 'sk-zai-test'

--- a/src/services/api/providerConfig.local.test.ts
+++ b/src/services/api/providerConfig.local.test.ts
@@ -167,7 +167,62 @@ test('uses responses transport when OpenAI-compatible API format requests respon
   })
 })
 
-test('uses responses transport for Hicap gpt models when requested', () => {
+test('uses responses transport for Hicap gpt-5.5 models when requested', () => {
+  process.env.CLAUDE_CODE_USE_OPENAI = '1'
+  process.env.OPENAI_BASE_URL = 'https://api.hicap.ai/v1'
+  process.env.OPENAI_MODEL = 'gpt-5.5'
+  process.env.OPENAI_API_FORMAT = 'responses'
+
+  expect(resolveProviderRequest()).toMatchObject({
+    transport: 'responses',
+    requestedModel: 'gpt-5.5',
+    resolvedModel: 'gpt-5.5',
+    baseUrl: 'https://api.hicap.ai/v1',
+  })
+})
+
+test('defaults Hicap gpt-5.5 to responses transport', () => {
+  process.env.CLAUDE_CODE_USE_OPENAI = '1'
+  process.env.OPENAI_BASE_URL = 'https://api.hicap.ai/v1'
+  process.env.OPENAI_MODEL = 'gpt-5.5'
+
+  expect(resolveProviderRequest()).toMatchObject({
+    transport: 'responses',
+    requestedModel: 'gpt-5.5',
+    resolvedModel: 'gpt-5.5',
+    baseUrl: 'https://api.hicap.ai/v1',
+  })
+})
+
+test('forces Hicap gpt-5.5 to responses even when chat completions is configured', () => {
+  process.env.CLAUDE_CODE_USE_OPENAI = '1'
+  process.env.OPENAI_BASE_URL = 'https://api.hicap.ai/v1'
+  process.env.OPENAI_MODEL = 'gpt-5.5'
+  process.env.OPENAI_API_FORMAT = 'chat_completions'
+
+  expect(resolveProviderRequest()).toMatchObject({
+    transport: 'responses',
+    requestedModel: 'gpt-5.5',
+    resolvedModel: 'gpt-5.5',
+    baseUrl: 'https://api.hicap.ai/v1',
+  })
+})
+
+test('preserves explicit responses_compat for Hicap gpt-5.5', () => {
+  process.env.CLAUDE_CODE_USE_OPENAI = '1'
+  process.env.OPENAI_BASE_URL = 'https://api.hicap.ai/v1'
+  process.env.OPENAI_MODEL = 'gpt-5.5'
+  process.env.OPENAI_API_FORMAT = 'responses_compat'
+
+  expect(resolveProviderRequest()).toMatchObject({
+    transport: 'responses_compat',
+    requestedModel: 'gpt-5.5',
+    resolvedModel: 'gpt-5.5',
+    baseUrl: 'https://api.hicap.ai/v1',
+  })
+})
+
+test('uses responses transport for Hicap gpt-5.4 when requested', () => {
   process.env.CLAUDE_CODE_USE_OPENAI = '1'
   process.env.OPENAI_BASE_URL = 'https://api.hicap.ai/v1'
   process.env.OPENAI_MODEL = 'gpt-5.4'
@@ -181,16 +236,57 @@ test('uses responses transport for Hicap gpt models when requested', () => {
   })
 })
 
+test('defaults Hicap gpt-5.4 to responses transport', () => {
+  process.env.CLAUDE_CODE_USE_OPENAI = '1'
+  process.env.OPENAI_BASE_URL = 'https://api.hicap.ai/v1'
+  process.env.OPENAI_MODEL = 'gpt-5.4'
+
+  expect(resolveProviderRequest()).toMatchObject({
+    transport: 'responses',
+    requestedModel: 'gpt-5.4',
+    resolvedModel: 'gpt-5.4',
+    baseUrl: 'https://api.hicap.ai/v1',
+  })
+})
+
+test('forces Hicap gpt-5.4 to responses even when chat completions is configured', () => {
+  process.env.CLAUDE_CODE_USE_OPENAI = '1'
+  process.env.OPENAI_BASE_URL = 'https://api.hicap.ai/v1'
+  process.env.OPENAI_MODEL = 'gpt-5.4'
+  process.env.OPENAI_API_FORMAT = 'chat_completions'
+
+  expect(resolveProviderRequest()).toMatchObject({
+    transport: 'responses',
+    requestedModel: 'gpt-5.4',
+    resolvedModel: 'gpt-5.4',
+    baseUrl: 'https://api.hicap.ai/v1',
+  })
+})
+
+test('preserves explicit responses_compat for Hicap gpt-5.4', () => {
+  process.env.CLAUDE_CODE_USE_OPENAI = '1'
+  process.env.OPENAI_BASE_URL = 'https://api.hicap.ai/v1'
+  process.env.OPENAI_MODEL = 'gpt-5.4'
+  process.env.OPENAI_API_FORMAT = 'responses_compat'
+
+  expect(resolveProviderRequest()).toMatchObject({
+    transport: 'responses_compat',
+    requestedModel: 'gpt-5.4',
+    resolvedModel: 'gpt-5.4',
+    baseUrl: 'https://api.hicap.ai/v1',
+  })
+})
+
 test('falls back to chat completions for non-gpt Hicap models when responses is requested', () => {
   process.env.CLAUDE_CODE_USE_OPENAI = '1'
   process.env.OPENAI_BASE_URL = 'https://api.hicap.ai/v1'
-  process.env.OPENAI_MODEL = 'claude-opus-4.7'
+  process.env.OPENAI_MODEL = 'claude-opus-4.8'
   process.env.OPENAI_API_FORMAT = 'responses'
 
   expect(resolveProviderRequest()).toMatchObject({
     transport: 'chat_completions',
-    requestedModel: 'claude-opus-4.7',
-    resolvedModel: 'claude-opus-4.7',
+    requestedModel: 'claude-opus-4.8',
+    resolvedModel: 'claude-opus-4.8',
     baseUrl: 'https://api.hicap.ai/v1',
   })
 })

--- a/src/services/api/providerConfig.local.test.ts
+++ b/src/services/api/providerConfig.local.test.ts
@@ -194,6 +194,19 @@ test('defaults Hicap gpt-5.5 to responses transport', () => {
   })
 })
 
+test('defaults Hicap gpt-5.5 catalog id to responses transport', () => {
+  process.env.CLAUDE_CODE_USE_OPENAI = '1'
+  process.env.OPENAI_BASE_URL = 'https://api.hicap.ai/v1'
+  process.env.OPENAI_MODEL = 'hicap-gpt-5.5'
+
+  expect(resolveProviderRequest()).toMatchObject({
+    transport: 'responses',
+    requestedModel: 'hicap-gpt-5.5',
+    resolvedModel: 'gpt-5.5',
+    baseUrl: 'https://api.hicap.ai/v1',
+  })
+})
+
 test('forces Hicap gpt-5.5 to responses even when chat completions is configured', () => {
   process.env.CLAUDE_CODE_USE_OPENAI = '1'
   process.env.OPENAI_BASE_URL = 'https://api.hicap.ai/v1'

--- a/src/services/api/providerConfig.test.ts
+++ b/src/services/api/providerConfig.test.ts
@@ -68,6 +68,30 @@ test('resolveProviderRequest leaves OpenRouter routing untouched without explici
   expect(request.baseUrl).toBe('https://openrouter.ai/api/v1')
 })
 
+test('resolveProviderRequest maps Hicap discovered GLM aliases to static model ids', () => {
+  const request = resolveProviderRequest({
+    model: 'zai-org/GLM-5.2',
+    baseUrl: 'https://api.hicap.ai/v1',
+    processEnv: {},
+  })
+
+  expect(request.requestedModel).toBe('zai-org/GLM-5.2')
+  expect(request.resolvedModel).toBe('glm-5.2')
+  expect(request.baseUrl).toBe('https://api.hicap.ai/v1')
+})
+
+test('resolveProviderRequest canonicalizes Hicap catalog model casing', () => {
+  const request = resolveProviderRequest({
+    model: 'GLM-5.2',
+    baseUrl: 'https://api.hicap.ai/v1',
+    processEnv: {},
+  })
+
+  expect(request.requestedModel).toBe('GLM-5.2')
+  expect(request.resolvedModel).toBe('glm-5.2')
+  expect(request.baseUrl).toBe('https://api.hicap.ai/v1')
+})
+
 test('resolveProviderRequest leaves Hicap routing untouched without explicit aliases', () => {
   const request = resolveProviderRequest({
     model: 'claude-opus-4-7',

--- a/src/services/api/providerConfig.ts
+++ b/src/services/api/providerConfig.ts
@@ -274,7 +274,11 @@ function resolveRouteCatalogAliasApiName(options: {
   }
 
   const entry = getCatalogEntriesForRoute(routeId).find(catalogEntry =>
-    (catalogEntry.aliases ?? []).some(alias => normalizeModelLookupKey(alias) === normalizedModel),
+    normalizeModelLookupKey(catalogEntry.apiName) === normalizedModel ||
+    normalizeModelLookupKey(catalogEntry.id) === normalizedModel ||
+    (catalogEntry.aliases ?? []).some(
+      alias => normalizeModelLookupKey(alias) === normalizedModel,
+    ),
   )
   return entry?.apiName ?? options.model
 }
@@ -872,23 +876,35 @@ export function resolveProviderRequest(options?: {
     ? buildGithubEnterpriseCopilotBaseUrl(gheBaseUrl)
     : undefined
 
-  const requestedApiFormat =
+  const runtimeShimContext =
+    isGithubMode
+      ? null
+      : resolveOpenAIShimRuntimeContext({
+          processEnv,
+          baseUrl: finalBaseUrl,
+          model: descriptor.baseModel,
+          treatAsLocal: finalBaseUrl ? isLocalProviderUrl(finalBaseUrl) : false,
+        })
+  const explicitApiFormat =
     isGithubMode
       ? undefined
       : parseOpenAICompatibleApiFormat(options?.apiFormat) ??
         parseOpenAICompatibleApiFormat(processEnv.OPENAI_API_FORMAT)
+  const requiredApiFormat =
+    isGithubMode
+      ? undefined
+      : parseOpenAICompatibleApiFormat(runtimeShimContext?.openaiShimConfig.requiredApiFormat)
+  const requestedApiFormat =
+    requiredApiFormat &&
+    (explicitApiFormat === undefined || explicitApiFormat === 'chat_completions')
+      ? requiredApiFormat
+      : explicitApiFormat ??
+        parseOpenAICompatibleApiFormat(runtimeShimContext?.openaiShimConfig.defaultApiFormat)
   const supportsRequestedApiFormat =
     (requestedApiFormat !== 'responses' && requestedApiFormat !== 'responses_compat') ||
     (() => {
-      const runtimeShimContext = resolveOpenAIShimRuntimeContext({
-        processEnv,
-        baseUrl: finalBaseUrl,
-        model: descriptor.baseModel,
-        treatAsLocal: finalBaseUrl ? isLocalProviderUrl(finalBaseUrl) : false,
-      })
-
       return openAIShimSupportsApiFormatForModel(
-        runtimeShimContext.openaiShimConfig,
+        runtimeShimContext?.openaiShimConfig,
         'responses',
         descriptor.baseModel,
       )

--- a/src/services/api/providerConfig.ts
+++ b/src/services/api/providerConfig.ts
@@ -869,6 +869,20 @@ export function resolveProviderRequest(options?: {
     ? normalizeGithubModelsApiModel(requestedModel)
     : requestedModel
 
+  // For GitHub Copilot API, normalize to real model ID (e.g., "github:copilot" -> "gpt-4o")
+  // For GitHub Models/custom endpoints:
+  //   - Normalize default alias (github:copilot -> gpt-4o)
+  //   - Preserve provider-qualified models (openai/gpt-4.1 stays as-is)
+  const resolvedModel = isGithubCopilotLike
+    ? normalizeGithubCopilotModel(descriptor.baseModel)
+    : (isGithubModels || isGithubCustom || isGithubGhe
+      ? normalizeGithubModelsApiModel(descriptor.baseModel)
+      : resolveRouteCatalogAliasApiName({
+          model: descriptor.baseModel,
+          baseUrl: finalBaseUrl,
+          processEnv,
+        }))
+
   // For GHE instances, build the Copilot API base URL from either
   // GITHUB_ENTERPRISE_URL or an already-classified GHE OPENAI_BASE_URL.
   const gheBaseUrl = isGithubGhe ? (gheUrl ?? rawBaseUrl) : undefined
@@ -882,7 +896,7 @@ export function resolveProviderRequest(options?: {
       : resolveOpenAIShimRuntimeContext({
           processEnv,
           baseUrl: finalBaseUrl,
-          model: descriptor.baseModel,
+          model: resolvedModel,
           treatAsLocal: finalBaseUrl ? isLocalProviderUrl(finalBaseUrl) : false,
         })
   const explicitApiFormat =
@@ -905,7 +919,7 @@ export function resolveProviderRequest(options?: {
     openAIShimSupportsApiFormatForModel(
       runtimeShimContext?.openaiShimConfig,
       'responses',
-      descriptor.baseModel,
+      resolvedModel,
     )
   const transport: ProviderTransport =
     shouldUseCodexTransport(requestedModel, finalBaseUrl) ||
@@ -914,20 +928,6 @@ export function resolveProviderRequest(options?: {
       : (requestedApiFormat === 'responses' || requestedApiFormat === 'responses_compat') && supportsRequestedApiFormat
         ? requestedApiFormat
         : 'chat_completions'
-
-  // For GitHub Copilot API, normalize to real model ID (e.g., "github:copilot" -> "gpt-4o")
-  // For GitHub Models/custom endpoints:
-  //   - Normalize default alias (github:copilot -> gpt-4o)
-  //   - Preserve provider-qualified models (openai/gpt-4.1 stays as-is)
-  const resolvedModel = isGithubCopilotLike
-    ? normalizeGithubCopilotModel(descriptor.baseModel)
-    : (isGithubModels || isGithubCustom || isGithubGhe
-      ? normalizeGithubModelsApiModel(descriptor.baseModel)
-      : resolveRouteCatalogAliasApiName({
-          model: descriptor.baseModel,
-          baseUrl: finalBaseUrl,
-          processEnv,
-        }))
 
   const reasoning = options?.reasoningEffortOverride
     ? { effort: options.reasoningEffortOverride }

--- a/src/services/api/providerConfig.ts
+++ b/src/services/api/providerConfig.ts
@@ -902,13 +902,11 @@ export function resolveProviderRequest(options?: {
         parseOpenAICompatibleApiFormat(runtimeShimContext?.openaiShimConfig.defaultApiFormat)
   const supportsRequestedApiFormat =
     (requestedApiFormat !== 'responses' && requestedApiFormat !== 'responses_compat') ||
-    (() => {
-      return openAIShimSupportsApiFormatForModel(
-        runtimeShimContext?.openaiShimConfig,
-        'responses',
-        descriptor.baseModel,
-      )
-    })()
+    openAIShimSupportsApiFormatForModel(
+      runtimeShimContext?.openaiShimConfig,
+      'responses',
+      descriptor.baseModel,
+    )
   const transport: ProviderTransport =
     shouldUseCodexTransport(requestedModel, finalBaseUrl) ||
       (isGithubCopilotLike && shouldUseGithubResponsesApi(githubResolvedModel))

--- a/src/utils/effort.codex.test.ts
+++ b/src/utils/effort.codex.test.ts
@@ -914,16 +914,26 @@ test('explicit compat metadata wire formats are controllable and feed the reques
     source: 'metadata',
   })
 
-  expect(resolveModelReasoningControl('custom-zai-low-only')).toMatchObject({
+  const zaiLowOnlyControl = resolveModelReasoningControl('custom-zai-low-only')
+  expect(zaiLowOnlyControl).toMatchObject({
     supportsReasoning: true,
-    controllable: false,
+    controllable: true,
     source: 'metadata',
     wireFormat: 'zai_compatible',
-    levels: [],
+    levels: ['low'],
   })
-  expect(modelSupportsEffort('custom-zai-low-only')).toBe(false)
-  expect(modelSupportsWireEffort('custom-zai-low-only')).toBe(false)
-
+  expect(modelSupportsEffort('custom-zai-low-only')).toBe(true)
+  expect(modelSupportsWireEffort('custom-zai-low-only')).toBe(true)
+  expect(resolveOpenAIShimReasoningRequestPlan({
+    model: 'custom-zai-low-only',
+    requestedEffort: 'low',
+    reasoningControl: zaiLowOnlyControl,
+  })).toEqual({
+    thinkingType: 'enabled',
+    reasoningEffort: 'high',
+    wireFormat: 'zai_compatible',
+    source: 'metadata',
+  })
   expect(resolveModelReasoningControl('custom-deepseek-low-only')).toMatchObject({
     supportsReasoning: true,
     controllable: false,

--- a/src/utils/effort.ts
+++ b/src/utils/effort.ts
@@ -80,7 +80,8 @@ export type ReasoningControlContext = OpenAIShimReasoningSupportContext & {
 
 const DEFAULT_REASONING_LEVELS: EffortLevel[] = ['low', 'medium', 'high']
 const OPENAI_SHIM_COMPAT_LEVELS: EffortLevel[] = ['low', 'medium', 'high', 'xhigh']
-const OPENAI_SHIM_METADATA_COMPAT_LEVELS: EffortLevel[] = ['high', 'xhigh']
+const DEEPSEEK_METADATA_COMPAT_LEVELS: EffortLevel[] = ['high', 'xhigh']
+const ZAI_METADATA_COMPAT_LEVELS: EffortLevel[] = ['low', 'medium', 'high', 'xhigh']
 
 function getReasoningApiProvider(
   context?: ReasoningControlContext,
@@ -117,8 +118,11 @@ function normalizeMetadataReasoningLevels(
   levels: ReasoningControlMetadata['levels'] | undefined,
 ): EffortLevel[] {
   const normalized = normalizeReasoningLevels(levels)
-  if (wireFormat === 'deepseek_compatible' || wireFormat === 'zai_compatible') {
-    return normalized.filter(level => OPENAI_SHIM_METADATA_COMPAT_LEVELS.includes(level))
+  if (wireFormat === 'deepseek_compatible') {
+    return normalized.filter(level => DEEPSEEK_METADATA_COMPAT_LEVELS.includes(level))
+  }
+  if (wireFormat === 'zai_compatible') {
+    return normalized.filter(level => ZAI_METADATA_COMPAT_LEVELS.includes(level))
   }
   return normalized
 }
@@ -614,8 +618,7 @@ export function resolveOpenAIShimReasoningRequestPlan(options: {
     const shouldEnableThinking = thinkingType === 'enabled' || options.requestedEffort !== undefined
     const metadataZaiSupportsReasoningEffort =
       metadataWireFormat === 'zai_compatible' &&
-      (options.reasoningControl?.levels.includes('high') ||
-        options.reasoningControl?.levels.includes('xhigh'))
+      (options.reasoningControl?.levels.length ?? 0) > 0
     const reasoningEffort = options.requestedEffort &&
       (metadataZaiSupportsReasoningEffort || (
         metadataWireFormat !== 'zai_compatible' &&

--- a/src/utils/model/modelOptions.gateways.test.ts
+++ b/src/utils/model/modelOptions.gateways.test.ts
@@ -1,0 +1,142 @@
+import { afterEach, beforeEach, expect, mock, test } from 'bun:test'
+
+import { resetModelStringsForTestingOnly } from '../../bootstrap/state.js'
+import { acquireEnvMutex, releaseEnvMutex } from '../../entrypoints/sdk/shared.js'
+import { saveGlobalConfig } from '../config.js'
+import {
+  resetSettingsCache,
+  setSessionSettingsCache,
+} from '../settings/settingsCache.js'
+
+async function importFreshModelOptionsModule() {
+  mock.restore()
+  mock.module('./providers.js', () => ({
+    getAPIProvider: () => 'openai',
+    getAPIProviderForStatsig: () => 'openai',
+    isFirstPartyAnthropicBaseUrl: () => false,
+    isGithubNativeAnthropicMode: () => false,
+    usesAnthropicAccountFlow: () => false,
+  }))
+  const nonce = `${Date.now()}-${Math.random()}`
+  return import(`./modelOptions.js?ts=${nonce}`)
+}
+
+async function getOpenAIModelOptions() {
+  const { getModelOptions } = await importFreshModelOptionsModule()
+  return getModelOptions()
+}
+const originalEnv = {
+  CLAUDE_CODE_USE_OPENAI: process.env.CLAUDE_CODE_USE_OPENAI,
+  OPENAI_API_BASE: process.env.OPENAI_API_BASE,
+  OPENAI_API_FORMAT: process.env.OPENAI_API_FORMAT,
+  OPENAI_BASE_URL: process.env.OPENAI_BASE_URL,
+  OPENAI_MODEL: process.env.OPENAI_MODEL,
+  OPENAI_API_KEY: process.env.OPENAI_API_KEY,
+  OPENROUTER_API_KEY: process.env.OPENROUTER_API_KEY,
+  ATLAS_CLOUD_API_KEY: process.env.ATLAS_CLOUD_API_KEY,
+  CODEX_API_KEY: process.env.CODEX_API_KEY,
+  CODEX_CREDENTIAL_SOURCE: process.env.CODEX_CREDENTIAL_SOURCE,
+  CHATGPT_ACCOUNT_ID: process.env.CHATGPT_ACCOUNT_ID,
+  CODEX_ACCOUNT_ID: process.env.CODEX_ACCOUNT_ID,
+}
+
+function restoreEnvValue(key: keyof typeof originalEnv): void {
+  const value = originalEnv[key]
+  if (value === undefined) {
+    delete process.env[key]
+  } else {
+    process.env[key] = value
+  }
+}
+
+beforeEach(async () => {
+  await acquireEnvMutex()
+  mock.restore()
+  setSessionSettingsCache({ settings: {}, errors: [] })
+  for (const key of Object.keys(originalEnv) as (keyof typeof originalEnv)[]) {
+    delete process.env[key]
+  }
+  resetModelStringsForTestingOnly()
+})
+
+afterEach(() => {
+  try {
+    mock.restore()
+    resetSettingsCache()
+    for (const key of Object.keys(originalEnv) as (keyof typeof originalEnv)[]) {
+      restoreEnvValue(key)
+    }
+    saveGlobalConfig(current => ({
+      ...current,
+      additionalModelOptionsCache: [],
+      additionalModelOptionsCacheScope: undefined,
+      openaiAdditionalModelOptionsCache: [],
+      openaiAdditionalModelOptionsCacheByProfile: {},
+      providerProfiles: [],
+      activeProviderProfileId: undefined,
+    }))
+    resetModelStringsForTestingOnly()
+  } finally {
+    releaseEnvMutex()
+  }
+})
+
+test('OpenRouter keeps static catalog entries and the active custom model', async () => {
+  process.env.CLAUDE_CODE_USE_OPENAI = '1'
+  process.env.OPENAI_BASE_URL = 'https://openrouter.ai/api/v1'
+  process.env.OPENAI_MODEL = 'deepseek/deepseek-chat'
+  process.env.OPENROUTER_API_KEY = 'sk-openrouter-test'
+
+  const values = (await getOpenAIModelOptions()).map(option => option.value)
+
+  expect(values).toContain('openai/gpt-5-mini')
+  expect(values).toContain('deepseek/deepseek-chat')
+})
+
+test('OpenRouter active profile cache merges with the static route catalog', async () => {
+  process.env.CLAUDE_CODE_USE_OPENAI = '1'
+  process.env.OPENAI_BASE_URL = 'https://openrouter.ai/api/v1'
+  process.env.OPENAI_MODEL = 'qwen/qwen3-32b'
+  process.env.OPENROUTER_API_KEY = 'sk-openrouter-test'
+
+  saveGlobalConfig(current => ({
+    ...current,
+    providerProfiles: [
+      {
+        id: 'openrouter-profile',
+        name: 'OpenRouter',
+        provider: 'openrouter',
+        baseUrl: 'https://openrouter.ai/api/v1',
+        model: 'qwen/qwen3-32b',
+      },
+    ],
+    activeProviderProfileId: 'openrouter-profile',
+    openaiAdditionalModelOptionsCacheByProfile: {
+      'openrouter-profile': [
+        {
+          value: 'qwen/qwen3-32b',
+          label: 'Qwen3 32B',
+          description: 'Provider: OpenRouter',
+        },
+      ],
+    },
+  }))
+
+  const values = (await getOpenAIModelOptions()).map(option => option.value)
+
+  expect(values).toContain('qwen/qwen3-32b')
+  expect(values).toContain('openai/gpt-5-mini')
+})
+
+test('Atlas Cloud canonicalizes static catalog aliases without hiding the catalog', async () => {
+  process.env.CLAUDE_CODE_USE_OPENAI = '1'
+  process.env.OPENAI_BASE_URL = 'https://api.atlascloud.ai/v1'
+  process.env.OPENAI_MODEL = 'claude-opus-4-8'
+  process.env.ATLAS_CLOUD_API_KEY = 'sk-atlas-test'
+
+  const values = (await getOpenAIModelOptions()).map(option => option.value)
+
+  expect(values).toContain('anthropic/claude-opus-4.8')
+  expect(values).toContain('deepseek-ai/deepseek-v4-pro')
+  expect(values).not.toContain('claude-opus-4-8')
+})

--- a/src/utils/model/modelOptions.hicap.test.ts
+++ b/src/utils/model/modelOptions.hicap.test.ts
@@ -1,0 +1,168 @@
+import { afterEach, beforeEach, expect, mock, test } from 'bun:test'
+
+import { resetModelStringsForTestingOnly } from '../../bootstrap/state.js'
+import { acquireEnvMutex, releaseEnvMutex } from '../../entrypoints/sdk/shared.js'
+import { saveGlobalConfig } from '../config.js'
+import {
+  resetSettingsCache,
+  setSessionSettingsCache,
+} from '../settings/settingsCache.js'
+
+async function importFreshModelOptionsModule() {
+  mock.restore()
+  mock.module('./providers.js', () => ({
+    getAPIProvider: () => 'openai',
+    getAPIProviderForStatsig: () => 'openai',
+    isFirstPartyAnthropicBaseUrl: () => false,
+    isGithubNativeAnthropicMode: () => false,
+    usesAnthropicAccountFlow: () => false,
+  }))
+  const nonce = `${Date.now()}-${Math.random()}`
+  return import(`./modelOptions.js?ts=${nonce}`)
+}
+
+async function getOpenAIModelOptions() {
+  const { getModelOptions } = await importFreshModelOptionsModule()
+  return getModelOptions()
+}
+const originalEnv = {
+  CLAUDE_CODE_USE_OPENAI: process.env.CLAUDE_CODE_USE_OPENAI,
+  OPENAI_API_BASE: process.env.OPENAI_API_BASE,
+  OPENAI_API_FORMAT: process.env.OPENAI_API_FORMAT,
+  OPENAI_BASE_URL: process.env.OPENAI_BASE_URL,
+  OPENAI_MODEL: process.env.OPENAI_MODEL,
+  CODEX_API_KEY: process.env.CODEX_API_KEY,
+  CODEX_CREDENTIAL_SOURCE: process.env.CODEX_CREDENTIAL_SOURCE,
+  CHATGPT_ACCOUNT_ID: process.env.CHATGPT_ACCOUNT_ID,
+  CODEX_ACCOUNT_ID: process.env.CODEX_ACCOUNT_ID,
+  HICAP_API_KEY: process.env.HICAP_API_KEY,
+}
+
+function restoreEnvValue(key: keyof typeof originalEnv): void {
+  const value = originalEnv[key]
+  if (value === undefined) {
+    delete process.env[key]
+  } else {
+    process.env[key] = value
+  }
+}
+
+beforeEach(async () => {
+  await acquireEnvMutex()
+  mock.restore()
+  setSessionSettingsCache({ settings: {}, errors: [] })
+  for (const key of Object.keys(originalEnv) as (keyof typeof originalEnv)[]) {
+    delete process.env[key]
+  }
+  resetModelStringsForTestingOnly()
+})
+
+afterEach(() => {
+  try {
+    mock.restore()
+    resetSettingsCache()
+    for (const key of Object.keys(originalEnv) as (keyof typeof originalEnv)[]) {
+      restoreEnvValue(key)
+    }
+    saveGlobalConfig(current => ({
+      ...current,
+      additionalModelOptionsCache: [],
+      additionalModelOptionsCacheScope: undefined,
+      openaiAdditionalModelOptionsCache: [],
+      openaiAdditionalModelOptionsCacheByProfile: {},
+      providerProfiles: [],
+      activeProviderProfileId: undefined,
+    }))
+    resetModelStringsForTestingOnly()
+  } finally {
+    releaseEnvMutex()
+  }
+})
+
+test('Hicap GLM discovered aliases reuse the static model option', async () => {
+  process.env.CLAUDE_CODE_USE_OPENAI = '1'
+  process.env.OPENAI_BASE_URL = 'https://api.hicap.ai/v1'
+  process.env.OPENAI_MODEL = 'zai-org/GLM-5.2'
+  process.env.HICAP_API_KEY = 'hicap-test-key'
+
+  const values = (await getOpenAIModelOptions()).map(option => option.value)
+
+  expect(values).toContain('glm-5.2')
+  expect(values).not.toContain('zai-org/GLM-5.2')
+  expect(values.filter(value => value === 'glm-5.2')).toHaveLength(1)
+})
+test('Hicap Responses models expose the static route catalog in /model options', async () => {
+  process.env.CLAUDE_CODE_USE_OPENAI = '1'
+  process.env.OPENAI_BASE_URL = 'https://api.hicap.ai/v1'
+  process.env.OPENAI_MODEL = 'gpt-5.4'
+  process.env.HICAP_API_KEY = 'hicap-test-key'
+
+  const values = (await getOpenAIModelOptions()).map(option => option.value)
+
+  expect(values).toContain('gpt-5.4')
+  expect(values).toContain('gpt-5.5')
+  expect(values).toContain('glm-5.2')
+  expect(values).toContain('claude-opus-4.8')
+})
+
+test('Hicap active profile model options merge with the static route catalog', async () => {
+  process.env.CLAUDE_CODE_USE_OPENAI = '1'
+  process.env.OPENAI_BASE_URL = 'https://api.hicap.ai/v1'
+  process.env.OPENAI_MODEL = 'gpt-5.4'
+  process.env.HICAP_API_KEY = 'hicap-test-key'
+
+  saveGlobalConfig(current => ({
+    ...current,
+    providerProfiles: [
+      {
+        id: 'hicap-profile',
+        name: 'Hicap',
+        provider: 'hicap',
+        baseUrl: 'https://api.hicap.ai/v1',
+        model: 'gpt-5.4',
+      },
+    ],
+    activeProviderProfileId: 'hicap-profile',
+    openaiAdditionalModelOptionsCacheByProfile: {
+      'hicap-profile': [
+        {
+          value: 'gpt-5.4',
+          label: 'GPT-5.4',
+          description: 'Provider: Hicap',
+        },
+      ],
+    },
+  }))
+
+  const values = (await getOpenAIModelOptions()).map(option => option.value)
+
+  expect(values.filter(value => value === 'gpt-5.4')).toHaveLength(1)
+  expect(values).toContain('gpt-5.5')
+  expect(values).toContain('glm-5.2')
+  expect(values).toContain('claude-opus-4.8')
+})
+
+test('Hicap Responses catalog ignores stale legacy OpenAI model cache', async () => {
+  process.env.CLAUDE_CODE_USE_OPENAI = '1'
+  process.env.OPENAI_BASE_URL = 'https://api.hicap.ai/v1'
+  process.env.OPENAI_MODEL = 'gpt-5.4'
+  process.env.HICAP_API_KEY = 'hicap-test-key'
+
+  saveGlobalConfig(current => ({
+    ...current,
+    openaiAdditionalModelOptionsCache: [
+      {
+        value: 'stale-other-route-model',
+        label: 'Stale model',
+        description: 'Provider: Previous route',
+      },
+    ],
+  }))
+
+  const values = (await getOpenAIModelOptions()).map(option => option.value)
+
+  expect(values).not.toContain('stale-other-route-model')
+  expect(values).toContain('gpt-5.4')
+  expect(values).toContain('gpt-5.5')
+  expect(values).toContain('glm-5.2')
+})

--- a/src/utils/model/modelOptions.ts
+++ b/src/utils/model/modelOptions.ts
@@ -1,6 +1,11 @@
 // biome-ignore-all assist/source/organizeImports: internal-only import markers must not be reordered
 import { getInitialMainLoopModel } from '../../bootstrap/state.js'
-import { getAdditionalModelOptionsCacheScope } from '../../services/api/providerConfig.js'
+import { getCatalogEntriesForRoute } from '../../integrations/index.js'
+import { resolveRouteIdFromBaseUrl } from '../../integrations/routeMetadata.js'
+import {
+  getAdditionalModelOptionsCacheScope,
+  resolveProviderRequest,
+} from '../../services/api/providerConfig.js'
 import {
   isClaudeAISubscriber,
   isMaxSubscriber,
@@ -510,13 +515,28 @@ function getModelOptionsBase(fastMode = false): ModelOption[] {
     return standardOptions
   }
 
-  if (getAdditionalModelOptionsCacheScope()?.startsWith('openai:')) {
-    const activeOpenAIOptions = getActiveOpenAIModelOptionsCache()
+  const activeRouteCatalogOptions = getActiveOpenAIRouteCatalogOptions()
+  const openAIModelOptionsScope = getAdditionalModelOptionsCacheScope()
+  const activeProfile = getActiveProviderProfile()
+  if (
+    activeRouteCatalogOptions.length > 0 ||
+    openAIModelOptionsScope?.startsWith('openai:')
+  ) {
+    const activeOpenAIOptions = activeProfile
+      ? getActiveOpenAIModelOptionsCache()
+      : []
+    const scopedOptions = openAIModelOptionsScope?.startsWith('openai:')
+      ? getScopedAdditionalModelOptions()
+      : []
+    const sourceOptions = activeOpenAIOptions.length > 0
+      ? activeOpenAIOptions
+      : scopedOptions
     return [
       getDefaultOptionForUser(fastMode),
-      ...(activeOpenAIOptions.length > 0
-        ? activeOpenAIOptions
-        : getScopedAdditionalModelOptions()),
+      ...mergeModelOptionsByNormalizedValue(
+        sourceOptions,
+        activeRouteCatalogOptions,
+      ),
     ]
   }
 
@@ -678,6 +698,118 @@ function getKnownModelOption(model: string): ModelOption | null {
   }
 }
 
+function normalizeRouteModelOptionKey(model: string): string {
+  return model.trim().split('?', 1)[0]?.trim().toLowerCase() ?? ''
+}
+
+function getActiveOpenAIRouteId(): string | null {
+  const openAIFlag = process.env.CLAUDE_CODE_USE_OPENAI?.trim().toLowerCase()
+  if (!openAIFlag || ['0', 'false', 'no', 'off'].includes(openAIFlag)) {
+    return null
+  }
+
+  const scope = getAdditionalModelOptionsCacheScope()
+  if (scope?.startsWith('openai:')) {
+    const partitionIndex = scope.lastIndexOf(':')
+    if (partitionIndex > 'openai:'.length) {
+      const baseUrl = scope.slice('openai:'.length, partitionIndex)
+      return resolveRouteIdFromBaseUrl(baseUrl)
+    }
+  }
+
+  return resolveRouteIdFromBaseUrl(resolveProviderRequest().baseUrl)
+}
+
+function mergeModelOptionsByNormalizedValue(
+  primaryOptions: ModelOption[],
+  additionalOptions: ModelOption[],
+): ModelOption[] {
+  const merged: ModelOption[] = []
+  const seen = new Set<string>()
+
+  for (const option of [...primaryOptions, ...additionalOptions]) {
+    if (typeof option.value !== 'string') {
+      continue
+    }
+
+    const value = option.value.trim()
+    const key = normalizeRouteModelOptionKey(value)
+    if (!key || seen.has(key)) {
+      continue
+    }
+
+    seen.add(key)
+    merged.push({
+      ...option,
+      value,
+    })
+  }
+
+  return merged
+}
+
+function getActiveOpenAIRouteCatalogOptions(): ModelOption[] {
+  const routeId = getActiveOpenAIRouteId()
+  if (!routeId) {
+    return []
+  }
+
+  return getCatalogEntriesForRoute(routeId).flatMap(entry => {
+    const value = entry.apiName.trim()
+    if (!value) {
+      return []
+    }
+
+    return [{
+      value,
+      label: entry.label ?? value,
+      description: entry.apiName,
+    }]
+  })
+}
+
+function getRouteCatalogModelOption(value: ModelSetting): ModelOption | null {
+  if (typeof value !== 'string') {
+    return null
+  }
+
+  const routeId = getActiveOpenAIRouteId()
+  if (!routeId) {
+    return null
+  }
+
+  const normalizedValue = normalizeRouteModelOptionKey(value)
+  if (!normalizedValue) {
+    return null
+  }
+
+  const catalogEntry = getCatalogEntriesForRoute(routeId).find(entry =>
+    normalizeRouteModelOptionKey(entry.apiName) === normalizedValue ||
+    normalizeRouteModelOptionKey(entry.id) === normalizedValue ||
+    (entry.aliases ?? []).some(
+      alias => normalizeRouteModelOptionKey(alias) === normalizedValue,
+    ),
+  )
+  if (!catalogEntry) {
+    return null
+  }
+
+  return {
+    value: catalogEntry.apiName,
+    label: catalogEntry.label ?? catalogEntry.apiName,
+    description: catalogEntry.apiName,
+  }
+}
+
+function optionMatchesModel(option: ModelOption, model: ModelSetting): boolean {
+  if (option.value === model) {
+    return true
+  }
+
+  const catalogOption = getRouteCatalogModelOption(model)
+  return catalogOption !== null && option.value === catalogOption.value
+}
+
 export function getModelOptions(fastMode = false): ModelOption[] {
   if (getAPIProvider() === 'github') {
     return filterModelOptionsByAllowlist(getModelOptionsBase(fastMode))
@@ -689,7 +821,7 @@ export function getModelOptions(fastMode = false): ModelOption[] {
   const envCustomModel = process.env.ANTHROPIC_CUSTOM_MODEL_OPTION
   if (
     envCustomModel &&
-    !options.some(existing => existing.value === envCustomModel)
+    !options.some(existing => optionMatchesModel(existing, envCustomModel))
   ) {
     options.push({
       value: envCustomModel,
@@ -702,8 +834,12 @@ export function getModelOptions(fastMode = false): ModelOption[] {
 
   // Append additional model options fetched during bootstrap
   for (const opt of getScopedAdditionalModelOptions()) {
-    if (!options.some(existing => existing.value === opt.value)) {
-      options.push(opt)
+    const catalogOption = getRouteCatalogModelOption(opt.value)
+    const nextOption = catalogOption ? { ...opt, ...catalogOption } : opt
+    if (
+      !options.some(existing => optionMatchesModel(existing, nextOption.value))
+    ) {
+      options.push(nextOption)
     }
   }
 
@@ -717,7 +853,10 @@ export function getModelOptions(fastMode = false): ModelOption[] {
   } else if (initialMainLoopModel !== null) {
     customModel = initialMainLoopModel
   }
-  if (customModel === null || options.some(opt => opt.value === customModel)) {
+  if (
+    customModel === null ||
+    options.some(opt => optionMatchesModel(opt, customModel))
+  ) {
     return filterModelOptionsByAllowlist(options)
   } else if (customModel === 'opusplan') {
     return filterModelOptionsByAllowlist([...options, getOpusPlanOption()])
@@ -736,6 +875,12 @@ export function getModelOptions(fastMode = false): ModelOption[] {
       getMergedOpus1MOption(fastMode),
     ])
   } else {
+    const catalogOption = getRouteCatalogModelOption(customModel)
+    if (catalogOption) {
+      options.push(catalogOption)
+      return filterModelOptionsByAllowlist(options)
+    }
+
     // Try to show a human-readable label for known Anthropic models, with an
     // upgrade hint if the alias now resolves to a newer version.
     const knownOption = getKnownModelOption(customModel)

--- a/src/utils/providerProfiles.test.ts
+++ b/src/utils/providerProfiles.test.ts
@@ -650,7 +650,7 @@ describe('applyProviderProfileToProcessEnv', () => {
       buildProfile({
         provider: 'openai',
         baseUrl: 'https://api.hicap.ai/v1',
-        model: 'claude-opus-4.7',
+        model: 'claude-opus-4.8',
         authHeader: 'api-key',
         authScheme: 'raw',
         authHeaderValue: 'hicap-header-value',
@@ -1499,6 +1499,35 @@ describe('applyActiveProviderProfileFromConfig', () => {
     expect(process.env.OPENAI_BASE_URL).toBe('https://api.openai.com/v1')
     expect(process.env.OPENAI_MODEL).toBe('gpt-4o')
   })
+
+  test('uses saved valid Hicap /model choice when rehydrating active profile', async () => {
+    const {
+      _setSavedModelOverrideForTesting,
+      applyActiveProviderProfileFromConfig,
+      getProviderProfiles,
+    } = await importFreshProviderProfileModules()
+    _setSavedModelOverrideForTesting('gpt-5.4')
+    const activeProfile = buildProfile({
+      id: 'saved_hicap',
+      provider: 'hicap',
+      baseUrl: 'https://api.hicap.ai/v1',
+      model: 'glm-5.2',
+    })
+
+    const applied = applyActiveProviderProfileFromConfig({
+      providerProfiles: [activeProfile],
+      activeProviderProfileId: activeProfile.id,
+    } as any)
+
+    expect(applied?.id).toBe(activeProfile.id)
+    expect(process.env.OPENAI_BASE_URL).toBe('https://api.hicap.ai/v1')
+    expect(process.env.OPENAI_MODEL).toBe('gpt-5.4')
+    const saved = getProviderProfiles({
+      providerProfiles: [activeProfile],
+      activeProviderProfileId: activeProfile.id,
+    } as any).find((profile: ProviderProfile) => profile.id === activeProfile.id)
+    expect(saved?.model).toBe('glm-5.2')
+  })
 })
 
 describe('persistActiveProviderProfileModel', () => {
@@ -1702,7 +1731,7 @@ describe('getProviderPresetDefaults', () => {
     expect(defaults.provider).toBe('hicap')
     expect(defaults.name).toBe('Hicap')
     expect(defaults.baseUrl).toBe('https://api.hicap.ai/v1')
-    expect(defaults.model).toBe('claude-opus-4.7')
+    expect(defaults.model).toBe('claude-opus-4.8')
     expect(defaults.apiKey).toBe('hicap-live-key')
     expect(defaults.requiresApiKey).toBe(true)
   })

--- a/src/utils/providerProfiles.ts
+++ b/src/utils/providerProfiles.ts
@@ -34,6 +34,7 @@ import {
 } from './providerProfile.js'
 import { refreshStartupDiscoveryForRoute } from '../integrations/discoveryService.js'
 import {
+  getCatalogEntriesForRoute,
   getProviderPresetUiMetadata,
   normalizeXiaomiMimoBaseUrl,
   routeSupportsApiFormatSelection,
@@ -56,6 +57,7 @@ import {
   sanitizeProfileCustomHeaders,
   serializeProfileCustomHeaders,
 } from './providerCustomHeaders.js'
+import { getSettings_DEPRECATED } from './settings/settings.js'
 
 export type { ProviderPreset } from '../integrations/index.js'
 
@@ -206,6 +208,54 @@ function resolveProfileCapabilityRouteId(
     resolveRouteIdFromBaseUrl(baseUrl) ??
     resolveProfileRoute(provider).routeId
   )
+}
+
+function normalizeProfileModelLookupKey(model: string | undefined): string {
+  return model?.trim().split('?', 1)[0]?.trim().toLowerCase() ?? ''
+}
+
+function profileSupportsModel(profile: ProviderProfile, model: string): boolean {
+  const normalizedModel = normalizeProfileModelLookupKey(model)
+  if (!normalizedModel) {
+    return false
+  }
+
+  if (
+    parseModelList(profile.model).some(
+      configured => normalizeProfileModelLookupKey(configured) === normalizedModel,
+    )
+  ) {
+    return true
+  }
+
+  const routeId = resolveProfileCapabilityRouteId(profile.provider, profile.baseUrl)
+  return getCatalogEntriesForRoute(routeId).some(
+    entry =>
+      normalizeProfileModelLookupKey(entry.apiName) === normalizedModel ||
+      normalizeProfileModelLookupKey(entry.id) === normalizedModel ||
+      (entry.aliases ?? []).some(
+        alias => normalizeProfileModelLookupKey(alias) === normalizedModel,
+      ),
+  )
+}
+
+let savedModelOverrideForTesting: string | undefined
+
+export function _setSavedModelOverrideForTesting(model: string | undefined): void {
+  savedModelOverrideForTesting = model
+}
+
+function getSavedModelOverrideForProfile(
+  profile: ProviderProfile,
+): string | undefined {
+  const savedModel = trimOrUndefined(
+    savedModelOverrideForTesting ?? getSettings_DEPRECATED()?.model,
+  )
+  if (!savedModel || !profileSupportsModel(profile, savedModel)) {
+    return undefined
+  }
+
+  return savedModel
 }
 
 function sanitizeProfile(profile: ProviderProfile): ProviderProfile | null {
@@ -492,9 +542,11 @@ function isProcessEnvAlignedWithProfile(
   profile: ProviderProfile,
   options?: {
     includeApiKey?: boolean
+    primaryModel?: string
   },
 ): boolean {
   const includeApiKey = options?.includeApiKey ?? true
+  const primaryModel = options?.primaryModel ?? getPrimaryModel(profile.model)
   const { compatibilityMode } = resolveProfileCompatibility(profile.provider)
 
   if (processEnv[PROFILE_ENV_APPLIED_FLAG] !== '1') {
@@ -509,7 +561,7 @@ function isProcessEnvAlignedWithProfile(
     return (
       !hasProviderSelectionFlags(processEnv) &&
       sameOptionalEnvValue(processEnv.ANTHROPIC_BASE_URL, profile.baseUrl) &&
-      sameOptionalEnvValue(processEnv.ANTHROPIC_MODEL, getPrimaryModel(profile.model)) &&
+      sameOptionalEnvValue(processEnv.ANTHROPIC_MODEL, primaryModel) &&
       (!includeApiKey ||
         sameOptionalEnvValue(processEnv.ANTHROPIC_API_KEY, profile.apiKey))
     )
@@ -525,7 +577,7 @@ function isProcessEnvAlignedWithProfile(
       processEnv.CLAUDE_CODE_USE_VERTEX === undefined &&
       processEnv.CLAUDE_CODE_USE_FOUNDRY === undefined &&
       sameOptionalEnvValue(processEnv.MISTRAL_BASE_URL, profile.baseUrl) &&
-      sameOptionalEnvValue(processEnv.MISTRAL_MODEL, getPrimaryModel(profile.model)) &&
+      sameOptionalEnvValue(processEnv.MISTRAL_MODEL, primaryModel) &&
       (!includeApiKey ||
         sameOptionalEnvValue(processEnv.MISTRAL_API_KEY, profile.apiKey))
     )
@@ -541,7 +593,7 @@ function isProcessEnvAlignedWithProfile(
       processEnv.CLAUDE_CODE_USE_VERTEX === undefined &&
       processEnv.CLAUDE_CODE_USE_FOUNDRY === undefined &&
       sameOptionalEnvValue(processEnv.GEMINI_BASE_URL, profile.baseUrl) &&
-      sameOptionalEnvValue(processEnv.GEMINI_MODEL, getPrimaryModel(profile.model)) &&
+      sameOptionalEnvValue(processEnv.GEMINI_MODEL, primaryModel) &&
       (!includeApiKey ||
         sameOptionalEnvValue(processEnv.GEMINI_API_KEY, profile.apiKey))
     )
@@ -561,7 +613,7 @@ function isProcessEnvAlignedWithProfile(
       processEnv.CLAUDE_CODE_USE_VERTEX === undefined &&
       processEnv.CLAUDE_CODE_USE_FOUNDRY === undefined &&
       sameOptionalEnvValue(processEnv.OPENAI_BASE_URL, profile.baseUrl) &&
-      sameOptionalEnvValue(processEnv.OPENAI_MODEL, getPrimaryModel(profile.model)) &&
+      sameOptionalEnvValue(processEnv.OPENAI_MODEL, primaryModel) &&
       sameOptionalEnvValue(processEnv.GITHUB_ENTERPRISE_URL, expectedGheUrl) &&
       (profile.provider !== 'github-enterprise' ||
         !includeApiKey ||
@@ -578,7 +630,7 @@ function isProcessEnvAlignedWithProfile(
       processEnv.CLAUDE_CODE_USE_GITHUB === undefined &&
       processEnv.CLAUDE_CODE_USE_VERTEX === undefined &&
       processEnv.CLAUDE_CODE_USE_FOUNDRY === undefined &&
-      sameOptionalEnvValue(processEnv.ANTHROPIC_MODEL, getPrimaryModel(profile.model)) &&
+      sameOptionalEnvValue(processEnv.ANTHROPIC_MODEL, primaryModel) &&
       sameOptionalEnvValue(processEnv.ANTHROPIC_BEDROCK_BASE_URL, profile.baseUrl)
     )
   }
@@ -592,14 +644,14 @@ function isProcessEnvAlignedWithProfile(
       processEnv.CLAUDE_CODE_USE_GITHUB === undefined &&
       processEnv.CLAUDE_CODE_USE_BEDROCK === undefined &&
       processEnv.CLAUDE_CODE_USE_FOUNDRY === undefined &&
-      sameOptionalEnvValue(processEnv.ANTHROPIC_MODEL, getPrimaryModel(profile.model)) &&
+      sameOptionalEnvValue(processEnv.ANTHROPIC_MODEL, primaryModel) &&
       sameOptionalEnvValue(processEnv.ANTHROPIC_VERTEX_BASE_URL, profile.baseUrl)
     )
   }
 
   const expectedContextWindows = profile.maxContextLength
     ? JSON.stringify({
-        [getPrimaryModel(profile.model)]: profile.maxContextLength,
+        [primaryModel]: profile.maxContextLength,
       })
     : undefined
 
@@ -612,7 +664,7 @@ function isProcessEnvAlignedWithProfile(
     processEnv.CLAUDE_CODE_USE_VERTEX === undefined &&
     processEnv.CLAUDE_CODE_USE_FOUNDRY === undefined &&
     sameOptionalEnvValue(processEnv.OPENAI_BASE_URL, profile.baseUrl) &&
-    sameOptionalEnvValue(processEnv.OPENAI_MODEL, getPrimaryModel(profile.model)) &&
+    sameOptionalEnvValue(processEnv.OPENAI_MODEL, primaryModel) &&
     sameOptionalEnvValue(processEnv.OPENAI_API_FORMAT, profile.apiFormat) &&
     sameOptionalEnvValue(processEnv.OPENAI_AUTH_HEADER, profile.authHeader) &&
     sameOptionalEnvValue(processEnv.OPENAI_AUTH_SCHEME, profile.authScheme) &&
@@ -675,9 +727,12 @@ export function clearProviderProfileEnvFromProcessEnv(
   delete processEnv[PROFILE_ENV_APPLIED_ID]
 }
 
-export function applyProviderProfileToProcessEnv(profile: ProviderProfile): void {
+export function applyProviderProfileToProcessEnv(
+  profile: ProviderProfile,
+  options?: { primaryModel?: string },
+): void {
   const { route, compatibilityMode } = resolveProfileCompatibility(profile.provider)
-  const primaryModel = getPrimaryModel(profile.model)
+  const primaryModel = options?.primaryModel ?? getPrimaryModel(profile.model)
   let profileEnv: ProfileEnv
 
   if (route.routeId === 'unknown-fallback') {
@@ -865,12 +920,20 @@ export function applyActiveProviderProfileFromConfig(
       return undefined
     }
 
-    if (isProcessEnvAlignedWithProfile(processEnv, activeProfile)) {
+    const savedPrimaryModel = getSavedModelOverrideForProfile(activeProfile)
+    if (
+      isProcessEnvAlignedWithProfile(processEnv, activeProfile, {
+        primaryModel: savedPrimaryModel,
+      })
+    ) {
       return activeProfile
     }
   }
 
-  applyProviderProfileToProcessEnv(activeProfile)
+  const savedPrimaryModel = getSavedModelOverrideForProfile(activeProfile)
+  applyProviderProfileToProcessEnv(activeProfile, {
+    primaryModel: savedPrimaryModel,
+  })
   return activeProfile
 }
 

--- a/src/utils/providerValidation.test.ts
+++ b/src/utils/providerValidation.test.ts
@@ -445,7 +445,7 @@ test('opengateway validation accepts OPENAI_API_KEY as fallback', async () => {
 
 test.each([
   ['opengateway', 'https://opengateway.gitlawb.com/v1', 'mimo-v2.5-pro'],
-  ['hicap', 'https://api.hicap.ai/v1', 'claude-opus-4.7'],
+  ['hicap', 'https://api.hicap.ai/v1', 'claude-opus-4.8'],
   ['venice', 'https://api.venice.ai/api/v1', 'venice-uncensored'],
   ['xiaomi mimo', 'https://api.xiaomimimo.com/v1', 'mimo-v2.5-pro'],
   ['opencode', 'https://opencode.ai/zen/v1', 'gpt-5.4'],


### PR DESCRIPTION
## Summary

- update the Hicap gateway catalog default to `claude-opus-4.8`
- add static Hicap entries for `deepseek-v4-pro`, `glm-5.2`, `gpt-5.4`, `gpt-5.5`, `grok-4.3`, `kimi-k2.7-code`, and `minimax-m3`
- make Hicap catalog formatting/metadata match the existing gateway catalog style more closely
- canonicalize Hicap discovered model rows back to curated catalog entries so duplicated IDs/casing/query variants do not produce separate broken picker options
- merge static gateway catalog entries with discovery fallback data even when route discovery returns an error
- preserve runtime `/model` selection as session-level state instead of mutating saved provider profile model lists

## Plumbing Fixes

- keep provider profile startup/restart rehydration from forcing stale Hicap model choices back into `OPENAI_MODEL`
- make model picker option identity stable when the same model appears from both static catalog and live discovery
- add route-catalog alias handling so Hicap discovered aliases such as `GLM-5.2` resolve to the intended API model id instead of drifting into a second out-of-list profile entry
- add runtime metadata for Hicap GPT-5.4/GPT-5.5 Responses API routing so tool calls plus `reasoning_effort` no longer go through chat completions
- keep Z.AI-compatible GLM effort mapping scoped to Hicap/GLM and covered by runtime metadata tests
- add gateway regression coverage so Atlas Cloud/OpenRouter model options and alias behavior are not remapped by the Hicap-specific handling

## Impact

- user-facing impact: Hicap users get the intended default model, static fallback models appear even when discovery is incomplete, GLM-5.2 restart/re-select behavior no longer creates a duplicate broken entry, and GPT-5.4/GPT-5.5 avoid chat-completions `reasoning_effort` failures.
- developer/maintainer impact: the provider/profile/model-picker plumbing now has focused regression tests around static gateway catalog merging, restart rehydration, model identity, effort support, and gateway isolation.

## Testing

- [x] `bun run build`
- [x] `bun run smoke`
- [x] `bun run check`
- [x] focused tests:
  - `bun run typecheck`
  - `bun run test:provider`
  - `bun run test:provider-recommendation`
  - `bun run typecheck:type-tests`
  - `python -m pytest -q python/tests`
  - `bun run integrations:check`
  - `bun run scripts/pr-intent-scan.ts --base upstream/main`
  - `bun run doctor:runtime`

## Risk Surface

- provider-routing/auth impact: this PR intentionally changes Hicap model canonicalization, startup model rehydration, and required Responses API routing for Hicap GPT-5.4/GPT-5.5 only.
- blocking status: not blocking after the review-fix pass; focused tests cover Hicap aliases/restart behavior and Atlas Cloud/OpenRouter regression cases so third-party gateway routing is not silently remapped.

## Notes

- provider/model path tested: Hicap OpenAI-compatible gateway with `claude-opus-4.8`, `glm-5.2`, `gpt-5.4`, `gpt-5.5`, static catalog merge, discovered alias normalization, and restart rehydration paths.
- cross-provider regression coverage: Atlas Cloud/OpenRouter gateway model option tests ensure their aliases and static catalogs are not affected by the Hicap-specific canonicalization.
- screenshots attached (if UI changed): not attached; terminal model picker behavior is covered by focused component tests.
- follow-up work or known limitations: none known.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved model selection in the picker with case/whitespace-insensitive matching and better alias-aware resolution, including consistent initial focus behavior.
  * Enhanced OpenAI-compatible API format selection for compatible providers by honoring required/default format preferences.
* **Bug Fixes**
  * Fixed/avoided duplicate or missing model options by improving deduplication and discovered-model normalization against route catalog entries.
  * Preserved saved “primary model” when applying provider profiles to keep environment and selections aligned.
  * Updated Hicap defaults and mappings to the latest model version (claude-opus-4.8) and refreshed verified model support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->