### PR TITLE
fix(openai-shim): recover GLM/Qwen XML tool calls emitted as text

### DIFF
--- a/src/services/api/openaiShim.ts
+++ b/src/services/api/openaiShim.ts
@@ -1336,11 +1336,11 @@ export function parseXmlToolCalls(text: string): {
     }
 
     if (!name) continue
+    ranges.push(range)
     const dedupKey = `${name}:${JSON.stringify(args)}`
     if (seen.has(dedupKey)) continue
     seen.add(dedupKey)
     results.push({ id: `xml_tc_${++_textToolCallCounter}`, name, arguments: args })
-    ranges.push(range)
   }
 
   return { calls: results, toolCallRanges: ranges }

--- a/src/services/api/openaiShim.ts
+++ b/src/services/api/openaiShim.ts
@@ -1224,6 +1224,128 @@ export function parseTextToolCalls(text: string): {
   return { calls: results, toolCallRanges: acceptedRanges }
 }
 
+// ---------------------------------------------------------------------------
+// XML tool call parser (GLM / Qwen / DeepSeek family)
+//
+// Several open models routed through OpenAI-compatible gateways emit tool
+// calls as XML text inside the assistant message rather than as structured
+// `tool_calls`. Without recovery these leak into visible prose and never
+// execute — the turn then ends with no tool_use block, so the agent appears
+// to "forget" and stop mid-task. We support the three dialects seen in the
+// wild:
+//   A. <tool_call><function=NAME><parameter=KEY>VALUE</parameter>…</function></tool_call>
+//   B. <tool_call>NAME<arg_key>KEY</arg_key><arg_value>VALUE</arg_value>…</tool_call>  (GLM native)
+//   C. <tool_call>{"name":"NAME","arguments":{…}}</tool_call>                          (Hermes JSON)
+// ---------------------------------------------------------------------------
+
+// The streaming finalize path buffers from this opener onward so the raw XML
+// is never surfaced as text before extraction.
+const XML_TOOL_CALL_OPEN = '<tool_call>'
+// Non-greedy block matcher; the `$` alternative tolerates a truncated final
+// block (stream cut off before the closing tag).
+const XML_TOOL_CALL_BLOCK_RE = /<tool_call>([\s\S]*?)(?:<\/tool_call>|$)/g
+const XML_FUNCTION_NAME_RE = /<function=([^>\s]+)\s*>/
+const XML_PARAMETER_RE = /<parameter=([^>\s]+)\s*>([\s\S]*?)<\/parameter>/g
+const XML_ARG_PAIR_RE = /<arg_key>([\s\S]*?)<\/arg_key>\s*<arg_value>([\s\S]*?)<\/arg_value>/g
+
+// Parameter/arg values arrive as untyped text. Try JSON first so numbers,
+// booleans, and nested objects round-trip; fall back to the raw string.
+function coerceXmlToolValue(raw: string): unknown {
+  const trimmed = raw.trim()
+  if (trimmed === '') return ''
+  try {
+    return JSON.parse(trimmed)
+  } catch {
+    return raw
+  }
+}
+
+/**
+ * Returns the length of the longest suffix of `s` that is a (proper) prefix of
+ * the `<tool_call>` opener. Used by the stream to hold back a trailing partial
+ * opener split across SSE deltas so it is never emitted as visible text.
+ */
+function trailingXmlOpenerPrefixLen(s: string): number {
+  const max = Math.min(s.length, XML_TOOL_CALL_OPEN.length - 1)
+  for (let len = max; len > 0; len--) {
+    if (XML_TOOL_CALL_OPEN.startsWith(s.slice(s.length - len))) return len
+  }
+  return 0
+}
+
+/** Exported for unit testing only. */
+export function parseXmlToolCalls(text: string): {
+  calls: ParsedTextToolCall[]
+  toolCallRanges: Array<[number, number]>
+} {
+  const results: ParsedTextToolCall[] = []
+  const seen = new Set<string>()
+  const ranges: Array<[number, number]> = []
+
+  for (const block of text.matchAll(XML_TOOL_CALL_BLOCK_RE)) {
+    const inner = block[1] ?? ''
+    const range: [number, number] = [
+      block.index!,
+      block.index! + block[0].length,
+    ]
+    let name: string | undefined
+    const args: Record<string, unknown> = {}
+
+    const fnMatch = inner.match(XML_FUNCTION_NAME_RE)
+    if (fnMatch) {
+      // Dialect A: <function=NAME><parameter=KEY>VALUE</parameter>…
+      name = fnMatch[1]
+      for (const p of inner.matchAll(XML_PARAMETER_RE)) {
+        const key = p[1]
+        if (key) args[key] = coerceXmlToolValue(p[2] ?? '')
+      }
+    } else {
+      const trimmedInner = inner.trim()
+      const argPairs = [...inner.matchAll(XML_ARG_PAIR_RE)]
+      if (argPairs.length > 0 && !trimmedInner.startsWith('{')) {
+        // Dialect B: leading token is the function name, then arg_key/arg_value.
+        const nameTok = trimmedInner.split(/[\n<]/, 1)[0]?.trim()
+        if (nameTok) name = nameTok
+        for (const p of argPairs) {
+          const key = (p[1] ?? '').trim()
+          if (key) args[key] = coerceXmlToolValue(p[2] ?? '')
+        }
+      } else {
+        // Dialect C: a JSON tool-call object inside the tags.
+        const jsonStart = trimmedInner.indexOf('{')
+        if (jsonStart !== -1) {
+          const jsonRaw = extractBalancedJson(trimmedInner, jsonStart)
+          if (jsonRaw) {
+            try {
+              const obj = JSON.parse(jsonRaw) as Record<string, unknown>
+              if (typeof obj['name'] === 'string') {
+                name = obj['name'] as string
+                const rawArgs = obj['arguments']
+                if (typeof rawArgs === 'string') {
+                  try {
+                    Object.assign(args, JSON.parse(rawArgs))
+                  } catch {}
+                } else if (rawArgs && typeof rawArgs === 'object') {
+                  Object.assign(args, rawArgs as Record<string, unknown>)
+                }
+              }
+            } catch {}
+          }
+        }
+      }
+    }
+
+    if (!name) continue
+    const dedupKey = `${name}:${JSON.stringify(args)}`
+    if (seen.has(dedupKey)) continue
+    seen.add(dedupKey)
+    results.push({ id: `xml_tc_${++_textToolCallCounter}`, name, arguments: args })
+    ranges.push(range)
+  }
+
+  return { calls: results, toolCallRanges: ranges }
+}
+
 /**
  * Async generator that transforms an OpenAI SSE stream into
  * Anthropic-format BetaRawMessageStreamEvent objects.
@@ -1505,6 +1627,12 @@ async function* openaiStreamToAnthropic(
   let ollamaTextBuffer = ''
   const streamState = createStreamState()
   let bufferedRawToolCallsText: string | null = null
+  // XML tool-call fallback (GLM/Qwen-style `<tool_call><function=…>` emitted as
+  // text). Once the opener is seen we stop emitting text and buffer the
+  // remainder in xmlToolCallText, converting it to tool_use blocks at finalize.
+  // xmlHoldback retains a trailing partial opener split across deltas.
+  let xmlToolCallText: string | null = null
+  let xmlHoldback = ''
 
   // Emit message_start
   yield {
@@ -1746,6 +1874,9 @@ async function* openaiStreamToAnthropic(
             if (visible) {
               ollamaTextBuffer += visible
             }
+          } else if (xmlToolCallText !== null) {
+            // Inside an XML tool-call region — buffer, emit nothing visible.
+            xmlToolCallText += delta.content
           } else if (
             !hasEmittedContentStart &&
             bufferedRawToolCallsText === null &&
@@ -1761,12 +1892,40 @@ async function* openaiStreamToAnthropic(
               bufferedRawToolCallsText = null
             }
           } else {
-            yield* emitTextDelta(delta.content)
+            // Watch for an XML tool-call opener that may be split across deltas.
+            // Everything from `<tool_call>` onward is held back (never shown) and
+            // converted to tool_use blocks at finalize; prose before it streams
+            // normally, minus a trailing partial-opener prefix.
+            const combined = xmlHoldback + delta.content
+            const openIdx = combined.indexOf(XML_TOOL_CALL_OPEN)
+            if (openIdx !== -1) {
+              const before = combined.slice(0, openIdx)
+              if (before) yield* emitTextDelta(before)
+              xmlHoldback = ''
+              xmlToolCallText = combined.slice(openIdx)
+            } else {
+              const keep = trailingXmlOpenerPrefixLen(combined)
+              const emit =
+                keep > 0 ? combined.slice(0, combined.length - keep) : combined
+              xmlHoldback = keep > 0 ? combined.slice(combined.length - keep) : ''
+              if (emit) yield* emitTextDelta(emit)
+            }
           }
         }
 
         // Tool calls
         if (delta.tool_calls) {
+          // Structured tool calls arrived — any held-back XML was a false
+          // positive (the model uses one mechanism or the other). Flush it
+          // as text so nothing is lost.
+          if (xmlToolCallText !== null) {
+            yield* emitTextDelta(xmlToolCallText)
+            xmlToolCallText = null
+          }
+          if (xmlHoldback) {
+            yield* emitTextDelta(xmlHoldback)
+            xmlHoldback = ''
+          }
           if (bufferedRawToolCallsText !== null) {
             const parsedBufferedToolCalls = parseRawToolCallsRequestedText(
               bufferedRawToolCallsText,
@@ -1979,6 +2138,57 @@ async function* openaiStreamToAnthropic(
             }
           }
 
+          // XML tool-call fallback for non-Ollama OpenAI-compatible providers
+          // (GLM/Qwen emit `<tool_call><function=…>` as text). Mirror the Ollama
+          // path: convert buffered XML to tool_use blocks and strip the raw XML.
+          let xmlClosedContentBlock = false
+          if (!isOllamaStream && xmlToolCallText !== null) {
+            const buffered = xmlToolCallText
+            xmlToolCallText = null
+            const { calls, toolCallRanges } = parseXmlToolCalls(buffered)
+            if (calls.length > 0) {
+              const stripped = stripRanges(buffered, toolCallRanges).trim()
+              const strippedVisible = stripThinkTags(stripped).trim()
+              if (strippedVisible) {
+                // emitTextDelta opens a text block if one is not already open;
+                // when prose preceded the opener the block is still open and we
+                // simply append the trailing prose to it.
+                yield* emitTextDelta(strippedVisible)
+              }
+              if (hasEmittedContentStart) {
+                yield* closeActiveContentBlock()
+                xmlClosedContentBlock = true
+              }
+              for (const tc of calls) {
+                const toolBlockIndex = contentBlockIndex
+                yield {
+                  type: 'content_block_start',
+                  index: toolBlockIndex,
+                  content_block: { type: 'tool_use', id: tc.id, name: tc.name, input: {} },
+                }
+                contentBlockIndex++
+                yield {
+                  type: 'content_block_delta',
+                  index: toolBlockIndex,
+                  delta: { type: 'input_json_delta', partial_json: JSON.stringify(tc.arguments) },
+                }
+                yield { type: 'content_block_stop', index: toolBlockIndex }
+              }
+              if (originalFinishReason === 'stop') {
+                choice.finish_reason = 'tool_calls'
+              }
+            } else {
+              // No valid tool calls parsed — the buffered text was a false
+              // positive (e.g. the model wrote about `<tool_call>` literally).
+              // Emit it verbatim so nothing is lost.
+              yield* emitTextDelta(buffered)
+            }
+          } else if (!isOllamaStream && xmlHoldback) {
+            // A trailing partial opener that never completed is just text.
+            yield* emitTextDelta(xmlHoldback)
+            xmlHoldback = ''
+          }
+
           // Flush bufferedRawToolCallsText for non-Ollama providers
           const parsedBufferedToolCalls = bufferedRawToolCallsText
             ? parseRawToolCallsRequestedText(bufferedRawToolCallsText)
@@ -1991,8 +2201,9 @@ async function* openaiStreamToAnthropic(
             bufferedRawToolCallsText = null
           }
 
-          // Close any open content blocks (skipped when Ollama already closed it above)
-          if (hasEmittedContentStart && !ollamaClosedContentBlock) {
+          // Close any open content blocks (skipped when the Ollama or XML
+          // fallback already closed it above)
+          if (hasEmittedContentStart && !ollamaClosedContentBlock && !xmlClosedContentBlock) {
             yield* closeActiveContentBlock()
           }
           // Close active tool calls
@@ -3532,6 +3743,43 @@ class OpenAIShimMessages {
     const choice = data.choices?.[0]
     const content: Array<Record<string, unknown>> = []
 
+    // Recover tool calls that the model emitted as text (no structured
+    // tool_calls field): first the "Tool calls requested:" prefix format, then
+    // XML dialects (GLM/Qwen `<tool_call>…`). Falls back to plain text.
+    const pushParsedTextContent = (strippedContent: string) => {
+      if (choice?.message?.tool_calls) {
+        content.push({ type: 'text', text: strippedContent })
+        return
+      }
+      const rawToolCalls = parseRawToolCallsRequestedText(strippedContent)
+      if (rawToolCalls) {
+        for (const toolCall of rawToolCalls) {
+          content.push({
+            type: 'tool_use',
+            id: toolCall.id,
+            name: toolCall.name,
+            input: JSON.parse(toolCall.argumentsJson),
+          })
+        }
+        return
+      }
+      const { calls, toolCallRanges } = parseXmlToolCalls(strippedContent)
+      if (calls.length > 0) {
+        const remaining = stripRanges(strippedContent, toolCallRanges).trim()
+        if (remaining) content.push({ type: 'text', text: remaining })
+        for (const tc of calls) {
+          content.push({
+            type: 'tool_use',
+            id: tc.id,
+            name: tc.name,
+            input: tc.arguments,
+          })
+        }
+        return
+      }
+      content.push({ type: 'text', text: strippedContent })
+    }
+
     // Some reasoning models (e.g. GLM-5) put their chain-of-thought in
     // reasoning_content while content stays null. Preserve it as a thinking
     // block, but do not surface it as visible assistant text.
@@ -3544,25 +3792,7 @@ class OpenAIShimMessages {
         ? choice?.message?.content
         : null
     if (typeof rawContent === 'string' && rawContent) {
-      const strippedContent = stripThinkTags(rawContent)
-      const rawToolCalls = choice?.message?.tool_calls
-        ? null
-        : parseRawToolCallsRequestedText(strippedContent)
-      if (rawToolCalls) {
-        for (const toolCall of rawToolCalls) {
-          content.push({
-            type: 'tool_use',
-            id: toolCall.id,
-            name: toolCall.name,
-            input: JSON.parse(toolCall.argumentsJson),
-          })
-        }
-      } else {
-        content.push({
-          type: 'text',
-          text: strippedContent,
-        })
-      }
+      pushParsedTextContent(stripThinkTags(rawContent))
     } else if (Array.isArray(rawContent) && rawContent.length > 0) {
       const parts: string[] = []
       for (const part of rawContent) {
@@ -3577,25 +3807,7 @@ class OpenAIShimMessages {
       }
       const joined = parts.join('\n')
       if (joined) {
-        const strippedContent = stripThinkTags(joined)
-        const rawToolCalls = choice?.message?.tool_calls
-          ? null
-          : parseRawToolCallsRequestedText(strippedContent)
-        if (rawToolCalls) {
-          for (const toolCall of rawToolCalls) {
-            content.push({
-              type: 'tool_use',
-              id: toolCall.id,
-              name: toolCall.name,
-              input: JSON.parse(toolCall.argumentsJson),
-            })
-          }
-        } else {
-          content.push({
-            type: 'text',
-            text: strippedContent,
-          })
-        }
+        pushParsedTextContent(stripThinkTags(joined))
       }
     }
 

--- a/src/services/api/openaiShim.xmlToolCalls.test.ts
+++ b/src/services/api/openaiShim.xmlToolCalls.test.ts
@@ -1,0 +1,315 @@
+/**
+ * Unit + integration tests for the XML tool-call fallback.
+ *
+ * Models in the GLM / Qwen / DeepSeek family routed through OpenAI-compatible
+ * gateways frequently emit tool calls as XML text inside the assistant message
+ * instead of as structured `tool_calls`. Without recovery these leak into
+ * visible prose and never execute, so the turn ends with no tool_use block and
+ * the agent appears to "forget" and stop mid-task (the reported bug).
+ *
+ * Covers the three dialects seen in the wild plus the streaming/non-streaming
+ * pipeline integration:
+ *   A. <tool_call><function=NAME><parameter=KEY>VALUE</parameter>…</function></tool_call>
+ *   B. <tool_call>NAME<arg_key>KEY</arg_key><arg_value>VALUE</arg_value>…</tool_call>
+ *   C. <tool_call>{"name":"NAME","arguments":{…}}</tool_call>
+ */
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import { createOpenAIShimClient, parseXmlToolCalls } from './openaiShim.js'
+
+type FetchType = typeof globalThis.fetch
+
+type OpenAIShimClient = {
+  beta: {
+    messages: {
+      create: (
+        params: Record<string, unknown>,
+      ) => Promise<unknown> & {
+        withResponse: () => Promise<{ data: AsyncIterable<Record<string, unknown>> }>
+      }
+    }
+  }
+}
+
+function makeSseResponse(lines: string[]): Response {
+  const encoder = new TextEncoder()
+  return new Response(
+    new ReadableStream({
+      start(controller) {
+        for (const line of lines) controller.enqueue(encoder.encode(line))
+        controller.close()
+      },
+    }),
+    { headers: { 'Content-Type': 'text/event-stream' } },
+  )
+}
+
+function makeChunks(chunks: unknown[]): string[] {
+  return [...chunks.map(c => `data: ${JSON.stringify(c)}\n\n`), 'data: [DONE]\n\n']
+}
+
+const glmChunk = (content: string, finishReason?: string) => ({
+  id: 'chatcmpl-glm',
+  object: 'chat.completion.chunk',
+  model: 'glm-5.2',
+  choices: [{ index: 0, delta: { content }, finish_reason: finishReason ?? null }],
+})
+
+const glmToolChunk = (toolCalls: unknown[], finishReason?: string) => ({
+  id: 'chatcmpl-glm',
+  object: 'chat.completion.chunk',
+  model: 'glm-5.2',
+  choices: [{ index: 0, delta: { tool_calls: toolCalls }, finish_reason: finishReason ?? null }],
+})
+
+// ---------------------------------------------------------------------------
+// Parser unit tests
+// ---------------------------------------------------------------------------
+
+describe('parseXmlToolCalls', () => {
+  test('dialect A: <function=NAME><parameter=KEY>VALUE</parameter>', () => {
+    const text =
+      '<tool_call><function=Read>\n<parameter=file_path>/tmp/foo.ts</parameter>\n</function></tool_call>'
+    const { calls } = parseXmlToolCalls(text)
+    expect(calls).toHaveLength(1)
+    expect(calls[0].name).toBe('Read')
+    expect(calls[0].arguments).toEqual({ file_path: '/tmp/foo.ts' })
+    expect(calls[0].id).toMatch(/^xml_tc_\d+$/)
+  })
+
+  test('dialect A: coerces numeric/boolean parameter values, keeps strings', () => {
+    const text =
+      '<tool_call><function=Grep>' +
+      '<parameter=pattern>TODO</parameter>' +
+      '<parameter=limit>10</parameter>' +
+      '<parameter=multiline>true</parameter>' +
+      '</function></tool_call>'
+    const { calls } = parseXmlToolCalls(text)
+    expect(calls[0].arguments).toEqual({ pattern: 'TODO', limit: 10, multiline: true })
+  })
+
+  test('dialect A: nested JSON object parameter round-trips', () => {
+    const text =
+      '<tool_call><function=Edit>' +
+      '<parameter=edits>[{"old":"a","new":"b"}]</parameter>' +
+      '</function></tool_call>'
+    const { calls } = parseXmlToolCalls(text)
+    expect(calls[0].arguments).toEqual({ edits: [{ old: 'a', new: 'b' }] })
+  })
+
+  test('dialect B: GLM-native <arg_key>/<arg_value>', () => {
+    const text =
+      '<tool_call>Bash\n<arg_key>command</arg_key>\n<arg_value>ls -la</arg_value>\n</tool_call>'
+    const { calls } = parseXmlToolCalls(text)
+    expect(calls).toHaveLength(1)
+    expect(calls[0].name).toBe('Bash')
+    expect(calls[0].arguments).toEqual({ command: 'ls -la' })
+  })
+
+  test('dialect C: Hermes JSON inside <tool_call>', () => {
+    const text =
+      '<tool_call>{"name":"Glob","arguments":{"pattern":"src/**/*.ts"}}</tool_call>'
+    const { calls } = parseXmlToolCalls(text)
+    expect(calls).toHaveLength(1)
+    expect(calls[0].name).toBe('Glob')
+    expect(calls[0].arguments).toEqual({ pattern: 'src/**/*.ts' })
+  })
+
+  test('dialect C: arguments as a JSON string is parsed', () => {
+    const text =
+      '<tool_call>{"name":"Bash","arguments":"{\\"command\\":\\"pwd\\"}"}</tool_call>'
+    const { calls } = parseXmlToolCalls(text)
+    expect(calls[0].name).toBe('Bash')
+    expect(calls[0].arguments).toEqual({ command: 'pwd' })
+  })
+
+  test('multiple tool calls in one message', () => {
+    const text =
+      '<tool_call><function=Read><parameter=file_path>a.ts</parameter></function></tool_call>' +
+      'some prose between\n' +
+      '<tool_call><function=Read><parameter=file_path>b.ts</parameter></function></tool_call>'
+    const { calls } = parseXmlToolCalls(text)
+    expect(calls.map(c => c.arguments)).toEqual([{ file_path: 'a.ts' }, { file_path: 'b.ts' }])
+  })
+
+  test('prose before/after tool call is reported via ranges (not consumed)', () => {
+    const text =
+      "I'll read it.\n<tool_call><function=Read><parameter=file_path>x.ts</parameter></function></tool_call>\nDone."
+    const { calls, toolCallRanges } = parseXmlToolCalls(text)
+    expect(calls).toHaveLength(1)
+    const stripped =
+      text.slice(0, toolCallRanges[0][0]) + text.slice(toolCallRanges[0][1])
+    expect(stripped).toBe("I'll read it.\n\nDone.")
+  })
+
+  test('deduplicates identical calls', () => {
+    const block = '<tool_call><function=Read><parameter=file_path>a.ts</parameter></function></tool_call>'
+    const { calls } = parseXmlToolCalls(block + '\n' + block)
+    expect(calls).toHaveLength(1)
+  })
+
+  test('truncated block (no closing tag) still parses', () => {
+    const text = '<tool_call><function=Bash><parameter=command>ls</parameter></function>'
+    const { calls } = parseXmlToolCalls(text)
+    expect(calls).toHaveLength(1)
+    expect(calls[0].name).toBe('Bash')
+  })
+
+  test('no <tool_call> markers → no calls (plain prose is safe)', () => {
+    const { calls, toolCallRanges } = parseXmlToolCalls(
+      'Here is how a <function=Foo> tag would look in documentation.',
+    )
+    expect(calls).toHaveLength(0)
+    expect(toolCallRanges).toHaveLength(0)
+  })
+
+  test('<tool_call> with no recognizable call → no calls emitted', () => {
+    const { calls } = parseXmlToolCalls('<tool_call>garbage with no function</tool_call>')
+    expect(calls).toHaveLength(0)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Streaming integration (non-Ollama OpenAI-compatible gateway, e.g. GLM-5.2)
+// ---------------------------------------------------------------------------
+
+describe('GLM streaming — XML tool calls', () => {
+  let originalFetch: FetchType
+  beforeEach(() => {
+    originalFetch = globalThis.fetch
+    process.env.OPENAI_API_KEY = 'test-key'
+    // Deliberately NOT an Ollama endpoint, so isOllama=false.
+    process.env.OPENAI_BASE_URL = 'https://gateway.example.com/v1'
+  })
+  afterEach(() => {
+    globalThis.fetch = originalFetch
+    delete process.env.OPENAI_API_KEY
+    delete process.env.OPENAI_BASE_URL
+  })
+
+  async function run(chunks: unknown[]): Promise<Record<string, unknown>[]> {
+    globalThis.fetch = (async () =>
+      makeSseResponse(makeChunks(chunks))) as unknown as FetchType
+    const client = createOpenAIShimClient({}) as OpenAIShimClient
+    const result = await client.beta.messages
+      .create({
+        model: 'glm-5.2',
+        messages: [{ role: 'user', content: 'do it' }],
+        max_tokens: 64,
+        stream: true,
+      })
+      .withResponse()
+    const events: Record<string, unknown>[] = []
+    for await (const event of result.data) events.push(event)
+    return events
+  }
+
+  const textOf = (events: Record<string, unknown>[]) =>
+    events
+      .filter(e => e.type === 'content_block_delta' && (e.delta as Record<string, string>)?.type === 'text_delta')
+      .map(e => (e.delta as Record<string, string>).text)
+      .join('')
+
+  const toolStarts = (events: Record<string, unknown>[]) =>
+    events.filter(
+      e => e.type === 'content_block_start' && (e.content_block as Record<string, string>)?.type === 'tool_use',
+    )
+
+  test('emits tool_use and hides raw XML (single chunk)', async () => {
+    const events = await run([
+      glmChunk('<tool_call><function=Bash><parameter=command>ls -la</parameter></function></tool_call>'),
+      glmChunk('', 'stop'),
+    ])
+    const starts = toolStarts(events)
+    expect(starts).toHaveLength(1)
+    expect((starts[0].content_block as Record<string, string>).name).toBe('Bash')
+    expect(textOf(events)).not.toContain('<tool_call>')
+    expect(textOf(events)).not.toContain('<function=')
+    const stop = events.find(e => e.type === 'message_delta')
+    expect((stop?.delta as Record<string, string>)?.stop_reason).toBe('tool_use')
+  })
+
+  test('opener split across SSE deltas is still recovered', async () => {
+    const events = await run([
+      glmChunk('<tool_'),
+      glmChunk('call><function=Bash><parameter=command>pwd</parameter></function></tool_call>'),
+      glmChunk('', 'stop'),
+    ])
+    const starts = toolStarts(events)
+    expect(starts).toHaveLength(1)
+    expect((starts[0].content_block as Record<string, string>).name).toBe('Bash')
+    expect(textOf(events)).not.toContain('<tool_')
+  })
+
+  test('prose before the tool call is preserved, XML stripped', async () => {
+    const events = await run([
+      glmChunk("I'll list the directory.\n"),
+      glmChunk('<tool_call><function=Bash><parameter=command>ls</parameter></function></tool_call>'),
+      glmChunk('', 'stop'),
+    ])
+    expect(toolStarts(events)).toHaveLength(1)
+    // Prose streams verbatim (trailing newline preserved); only the XML is stripped.
+    expect(textOf(events).trim()).toBe("I'll list the directory.")
+    expect(textOf(events)).not.toContain('<tool_call>')
+  })
+
+  test('input_json_delta carries the parsed arguments', async () => {
+    const events = await run([
+      glmChunk('<tool_call><function=Read><parameter=file_path>/tmp/x.ts</parameter></function></tool_call>'),
+      glmChunk('', 'stop'),
+    ])
+    const jsonDelta = events.find(
+      e => e.type === 'content_block_delta' && (e.delta as Record<string, string>)?.type === 'input_json_delta',
+    )
+    expect(JSON.parse((jsonDelta!.delta as Record<string, string>).partial_json)).toEqual({
+      file_path: '/tmp/x.ts',
+    })
+  })
+
+  test('false positive: prose mentioning <tool_call> with no valid call is emitted as text', async () => {
+    const events = await run([
+      glmChunk('The <tool_call> tag is how models request tools.'),
+      glmChunk('', 'stop'),
+    ])
+    expect(toolStarts(events)).toHaveLength(0)
+    expect(textOf(events)).toBe('The <tool_call> tag is how models request tools.')
+  })
+
+  // Locks in current behavior: when a single streamed message contains prose
+  // *between* two XML tool calls, all surviving prose is emitted in one text
+  // block BEFORE the tool_use blocks (the interleave is flattened to
+  // prose-then-all-calls). This mirrors the Ollama text fallback and is fine
+  // for agent loops, which act on the tool calls regardless of prose order.
+  test('multiple tool calls with interleaved prose: prose flattened before calls', async () => {
+    const events = await run([
+      glmChunk("I'll do two things.\n"),
+      glmChunk(
+        '<tool_call><function=Read><parameter=file_path>a.ts</parameter></function></tool_call>' +
+          'middle prose' +
+          '<tool_call><function=Read><parameter=file_path>b.ts</parameter></function></tool_call>',
+      ),
+      glmChunk('', 'stop'),
+    ])
+    const starts = toolStarts(events)
+    expect(starts.map(s => (s.content_block as Record<string, string>).name)).toEqual(['Read', 'Read'])
+    // Both prose fragments survive (leading prose + between-call prose), with the
+    // raw XML stripped; calls follow the prose.
+    expect(textOf(events)).toBe("I'll do two things.\nmiddle prose")
+    expect(textOf(events)).not.toContain('<tool_call>')
+    // All text deltas precede the first tool_use start (prose-then-calls order).
+    const firstToolIdx = events.findIndex(
+      e => e.type === 'content_block_start' && (e.content_block as Record<string, string>)?.type === 'tool_use',
+    )
+    const lastTextIdx = events.map(e => e.type === 'content_block_delta' && (e.delta as Record<string, string>)?.type === 'text_delta').lastIndexOf(true)
+    expect(lastTextIdx).toBeLessThan(firstToolIdx)
+  })
+
+  test('structured tool_calls still work and do not trip the XML path', async () => {
+    const events = await run([
+      glmToolChunk([{ index: 0, id: 'call_1', type: 'function', function: { name: 'Bash', arguments: '{"command":"ls"}' } }]),
+      glmToolChunk([{ index: 0, function: { arguments: '' } }], 'tool_calls'),
+    ])
+    const starts = toolStarts(events)
+    expect(starts).toHaveLength(1)
+    expect((starts[0].content_block as Record<string, string>).name).toBe('Bash')
+  })
+})


### PR DESCRIPTION
## Summary
GLM/Qwen-family models routed through OpenAI-compatible gateways emit tool calls
as XML text (`<tool_call><function=…>`) instead of structured `tool_calls`. The
shim had no parser for this, so the XML leaked into visible prose and never
executed — the turn ended with no `tool_use` block, so the agent appeared to
"forget" and stop mid-task (the reported GLM-5.2 bug).

This adds `parseXmlToolCalls()` covering the three dialects seen in the wild and
wires it into both the streaming and non-streaming paths, mirroring the existing
Ollama text-tool-call fallback:
- **A.** `<tool_call><function=NAME><parameter=KEY>VALUE</parameter>…</function></tool_call>`
- **B.** `<tool_call>NAME<arg_key>KEY</arg_key><arg_value>VALUE</arg_value>…</tool_call>` (GLM-native)
- **C.** `<tool_call>{"name":"NAME","arguments":{…}}</tool_call>` (Hermes JSON)

The streaming path holds back text from the `<tool_call>` opener onward (including
an opener split across SSE deltas), converts the buffer to `tool_use` blocks at
finalize, strips the raw XML, and flips the finish reason to `tool_calls`.
Structured `tool_calls` and false-positive prose (a model literally writing
`<tool_call>`) are both handled losslessly.

## Impact
- GLM/Qwen (and DeepSeek-family) tools now actually execute instead of leaking as
  text, fixing the "agent forgets / stops mid-task" symptom.
- No behavior change for Anthropic, Ollama (still uses its JSON fallback), or any
  provider that emits structured `tool_calls`.
- The XML path is on for all OpenAI-compatible providers — the `<tool_call>`
  marker is distinctive enough to be safe (JSON text recovery remains Ollama-gated).

## Testing
- [x] `bun test src/services/api/openaiShim.xmlToolCalls.test.ts` — 19/19 pass
  (3 dialects, split-opener, false-positive, structured-call coexistence,
  interleaved-prose flatten case)
- [x] `bun test src/services/api/` — 873/873 pass, no regressions
- [x] `tsc --noEmit` — 0 errors
- [x] `bun run deadcode` (knip) — clean

## Notes
- Known minor trade-off: when a single *streamed* message has prose *between* two
  XML tool calls, surviving prose is flattened to prose-then-all-calls. This
  matches the existing Ollama path and doesn't affect agent loops (which act on
  the tool calls regardless of prose order). A test locks in this behavior.
- Longer-term cleaner fix is getting the gateway to request structured tool calls
  from GLM/Qwen, but this client-side fallback is the right defensive layer
  regardless.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved fallback for OpenAI-compatible providers that emit tool calls as XML-formatted text, converting them into structured tool-use blocks while preserving surrounding prose.
  * Added recovery logic for both streamed and non-streamed responses, including richer parsing of XML tool-call parameters.
* **Bug Fixes**
  * Better handling when the XML tool-call start tag is split across streamed updates.
  * Reduced false positives and improved behavior for incomplete or malformed XML tool-call markup.
* **Tests**
  * Added unit and streaming coverage for XML tool-call recovery, parsing edge cases, and truncation scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->