### PR TITLE
fix(remote-session): match ingress host by hostname, not raw substring

### DIFF
--- a/src/constants/product.test.ts
+++ b/src/constants/product.test.ts
@@ -41,9 +41,24 @@ test('isRemoteSessionLocal: false for missing or malformed ingress URL', () => {
 
 // --- isRemoteSessionStaging ---
 
-test('isRemoteSessionStaging: matches the staging ingress hostname label', () => {
+test('isRemoteSessionStaging: matches the real staging ingress/API hosts', () => {
+  // The default staging `sessionIngressUrl` is getBridgeBaseUrl() ===
+  // https://api-staging.anthropic.com, which carries no bare `staging` label —
+  // a generic label match misses it, so assert it explicitly.
+  expect(
+    isRemoteSessionStaging(undefined, 'https://api-staging.anthropic.com'),
+  ).toBe(true)
+  expect(
+    isRemoteSessionStaging(
+      undefined,
+      'https://api-staging.anthropic.com/v1/session_ingress/x',
+    ),
+  ).toBe(true)
   expect(
     isRemoteSessionStaging(undefined, 'https://claude-ai.staging.ant.dev'),
+  ).toBe(true)
+  expect(
+    isRemoteSessionStaging(undefined, 'https://platform.staging.ant.dev'),
   ).toBe(true)
 })
 
@@ -51,14 +66,25 @@ test('isRemoteSessionStaging: matches a `_staging_` session id', () => {
   expect(isRemoteSessionStaging('session_staging_abc', undefined)).toBe(true)
 })
 
-test('isRemoteSessionStaging: does not match `staging` in a production URL path or query', () => {
-  // Regression: the old `ingressUrl.includes('staging')` check would route
-  // these production URLs to the staging endpoint.
+test('isRemoteSessionStaging: does not match unrelated hosts carrying a `staging` label or substring', () => {
+  // Regression: the old `ingressUrl.includes('staging')` check routed these
+  // production URLs to the staging endpoint; a generic dot-label match would
+  // still over-match `foo.staging.example.com`.
   expect(
     isRemoteSessionStaging(undefined, 'https://claude.ai/code/x?ref=staging'),
   ).toBe(false)
   expect(
     isRemoteSessionStaging(undefined, 'https://staging-cdn-claude.example.com'),
+  ).toBe(false)
+  expect(
+    isRemoteSessionStaging(
+      undefined,
+      'https://foo.staging.example.com/v1/session_ingress/x',
+    ),
+  ).toBe(false)
+  // A look-alike of the staging zone outside ant.dev must not match.
+  expect(
+    isRemoteSessionStaging(undefined, 'https://evil-staging.ant.dev.attacker.com'),
   ).toBe(false)
 })
 

--- a/src/constants/product.test.ts
+++ b/src/constants/product.test.ts
@@ -1,0 +1,92 @@
+import { expect, test } from 'bun:test'
+
+import {
+  CLAUDE_AI_BASE_URL,
+  CLAUDE_AI_LOCAL_BASE_URL,
+  CLAUDE_AI_STAGING_BASE_URL,
+  getClaudeAiBaseUrl,
+  isRemoteSessionLocal,
+  isRemoteSessionStaging,
+} from './product.js'
+
+// --- isRemoteSessionLocal ---
+
+test('isRemoteSessionLocal: matches a localhost ingress hostname', () => {
+  expect(isRemoteSessionLocal(undefined, 'http://localhost:4000')).toBe(true)
+  expect(isRemoteSessionLocal(undefined, 'http://127.0.0.1:4000')).toBe(true)
+})
+
+test('isRemoteSessionLocal: matches a `_local_` session id', () => {
+  expect(isRemoteSessionLocal('session_local_abc', undefined)).toBe(true)
+})
+
+test('isRemoteSessionLocal: does not match `localhost` in a production URL path or query', () => {
+  // Regression: the old `ingressUrl.includes('localhost')` check would route
+  // these production URLs to http://localhost:4000.
+  expect(
+    isRemoteSessionLocal(undefined, 'https://claude.ai/code/x?ref=localhost'),
+  ).toBe(false)
+  expect(
+    isRemoteSessionLocal(undefined, 'https://localhost.attacker.example.com'),
+  ).toBe(false)
+  expect(
+    isRemoteSessionLocal(undefined, 'https://my-localhost-proxy.example.com'),
+  ).toBe(false)
+})
+
+test('isRemoteSessionLocal: false for missing or malformed ingress URL', () => {
+  expect(isRemoteSessionLocal(undefined, undefined)).toBe(false)
+  expect(isRemoteSessionLocal(undefined, 'not a url')).toBe(false)
+})
+
+// --- isRemoteSessionStaging ---
+
+test('isRemoteSessionStaging: matches the staging ingress hostname label', () => {
+  expect(
+    isRemoteSessionStaging(undefined, 'https://claude-ai.staging.ant.dev'),
+  ).toBe(true)
+})
+
+test('isRemoteSessionStaging: matches a `_staging_` session id', () => {
+  expect(isRemoteSessionStaging('session_staging_abc', undefined)).toBe(true)
+})
+
+test('isRemoteSessionStaging: does not match `staging` in a production URL path or query', () => {
+  // Regression: the old `ingressUrl.includes('staging')` check would route
+  // these production URLs to the staging endpoint.
+  expect(
+    isRemoteSessionStaging(undefined, 'https://claude.ai/code/x?ref=staging'),
+  ).toBe(false)
+  expect(
+    isRemoteSessionStaging(undefined, 'https://staging-cdn-claude.example.com'),
+  ).toBe(false)
+})
+
+test('isRemoteSessionStaging: false for missing or malformed ingress URL', () => {
+  expect(isRemoteSessionStaging(undefined, undefined)).toBe(false)
+  expect(isRemoteSessionStaging(undefined, 'not a url')).toBe(false)
+})
+
+// --- getClaudeAiBaseUrl routing ---
+
+test('getClaudeAiBaseUrl: production URL with `localhost`/`staging` substrings routes to prod', () => {
+  expect(
+    getClaudeAiBaseUrl(undefined, 'https://claude.ai/code/x?ref=localhost'),
+  ).toBe(CLAUDE_AI_BASE_URL)
+  expect(
+    getClaudeAiBaseUrl(undefined, 'https://claude.ai/code/x?ref=staging'),
+  ).toBe(CLAUDE_AI_BASE_URL)
+})
+
+test('getClaudeAiBaseUrl: routes real local/staging ingress hosts correctly', () => {
+  expect(getClaudeAiBaseUrl(undefined, 'http://localhost:4000')).toBe(
+    CLAUDE_AI_LOCAL_BASE_URL,
+  )
+  expect(
+    getClaudeAiBaseUrl(undefined, 'https://claude-ai.staging.ant.dev'),
+  ).toBe(CLAUDE_AI_STAGING_BASE_URL)
+})
+
+test('getClaudeAiBaseUrl: defaults to production with no hints', () => {
+  expect(getClaudeAiBaseUrl(undefined, undefined)).toBe(CLAUDE_AI_BASE_URL)
+})

--- a/src/constants/product.ts
+++ b/src/constants/product.ts
@@ -26,14 +26,33 @@ function getIngressHostname(ingressUrl?: string): string | undefined {
 }
 
 /**
+ * Hostname of the staging remote-session ingress/API. This is the default
+ * `sessionIngressUrl` host in staging builds: both bridge entry points fall
+ * back to `getBridgeBaseUrl()` (`https://api-staging.anthropic.com`) when
+ * `CLAUDE_BRIDGE_SESSION_INGRESS_URL` is unset — see src/constants/oauth.ts
+ * and src/bridge/bridgeMain.ts. It carries no bare `staging` dot-label, so a
+ * generic label match would miss it.
+ */
+const STAGING_INGRESS_HOSTNAME = 'api-staging.anthropic.com'
+
+/**
+ * Dot-anchored suffix of the staging zone (`claude-ai.staging.ant.dev`,
+ * `platform.staging.ant.dev`, …). Anchored on a leading `.` so it matches a
+ * subdomain of the zone but never an unrelated host that merely embeds the
+ * label, e.g. `foo.staging.example.com`.
+ */
+const STAGING_INGRESS_HOST_SUFFIX = '.staging.ant.dev'
+
+/**
  * Determine if we're in a staging environment for remote sessions.
  * Checks session ID format and ingress URL.
  *
- * The ingress URL is matched on a hostname *label* (`...staging...` as a
- * dot-delimited segment, e.g. `claude-ai.staging.ant.dev`) rather than a raw
- * substring, so a production URL that merely carries `staging` in its path or
- * query (e.g. `https://claude.ai/code/x?ref=staging`) is not misrouted to the
- * staging endpoint.
+ * The ingress URL is matched against an explicit allowlist of the real staging
+ * ingress/API hosts (exact `api-staging.anthropic.com`, or a subdomain of the
+ * `.staging.ant.dev` zone) rather than a raw substring or a generic `staging`
+ * label. A bare label match both *missed* the real `api-staging.anthropic.com`
+ * ingress (no `staging` label) and *over-matched* unrelated hosts such as
+ * `foo.staging.example.com`; the allowlist is correct in both directions.
  */
 export function isRemoteSessionStaging(
   sessionId?: string,
@@ -43,7 +62,13 @@ export function isRemoteSessionStaging(
     return true
   }
   const hostname = getIngressHostname(ingressUrl)
-  return hostname !== undefined && hostname.split('.').includes('staging')
+  if (hostname === undefined) {
+    return false
+  }
+  return (
+    hostname === STAGING_INGRESS_HOSTNAME ||
+    hostname.endsWith(STAGING_INGRESS_HOST_SUFFIX)
+  )
 }
 
 /**

--- a/src/constants/product.ts
+++ b/src/constants/product.ts
@@ -7,31 +7,63 @@ export const CLAUDE_AI_STAGING_BASE_URL = 'https://claude-ai.staging.ant.dev'
 export const CLAUDE_AI_LOCAL_BASE_URL = 'http://localhost:4000'
 
 /**
+ * Parse the hostname from an ingress URL, lowercased. Returns undefined for a
+ * missing or malformed URL so callers can treat it as "no match" rather than
+ * matching on arbitrary substrings of the raw string.
+ *
+ * Inlined (rather than reusing src/bridge helpers) to keep constants/ a leaf of
+ * the module-load DAG.
+ */
+function getIngressHostname(ingressUrl?: string): string | undefined {
+  if (!ingressUrl) {
+    return undefined
+  }
+  try {
+    return new URL(ingressUrl).hostname.toLowerCase()
+  } catch {
+    return undefined
+  }
+}
+
+/**
  * Determine if we're in a staging environment for remote sessions.
  * Checks session ID format and ingress URL.
+ *
+ * The ingress URL is matched on a hostname *label* (`...staging...` as a
+ * dot-delimited segment, e.g. `claude-ai.staging.ant.dev`) rather than a raw
+ * substring, so a production URL that merely carries `staging` in its path or
+ * query (e.g. `https://claude.ai/code/x?ref=staging`) is not misrouted to the
+ * staging endpoint.
  */
 export function isRemoteSessionStaging(
   sessionId?: string,
   ingressUrl?: string,
 ): boolean {
-  return (
-    sessionId?.includes('_staging_') === true ||
-    ingressUrl?.includes('staging') === true
-  )
+  if (sessionId?.includes('_staging_') === true) {
+    return true
+  }
+  const hostname = getIngressHostname(ingressUrl)
+  return hostname !== undefined && hostname.split('.').includes('staging')
 }
 
 /**
  * Determine if we're in a local-dev environment for remote sessions.
  * Checks session ID format (e.g. `session_local_...`) and ingress URL.
+ *
+ * The ingress URL is matched on an exact localhost hostname (mirroring
+ * `isLocalhostBaseUrl` in src/bridge/workSecret.ts) rather than a raw
+ * substring, so a production URL that merely carries `localhost` in its path or
+ * query is not misrouted to the local-dev endpoint.
  */
 export function isRemoteSessionLocal(
   sessionId?: string,
   ingressUrl?: string,
 ): boolean {
-  return (
-    sessionId?.includes('_local_') === true ||
-    ingressUrl?.includes('localhost') === true
-  )
+  if (sessionId?.includes('_local_') === true) {
+    return true
+  }
+  const hostname = getIngressHostname(ingressUrl)
+  return hostname === 'localhost' || hostname === '127.0.0.1'
 }
 
 /**


### PR DESCRIPTION
## What

`isRemoteSessionLocal` and `isRemoteSessionStaging` (in `src/constants/product.ts`) pick which Claude AI base URL serves remote-session traffic — production (`https://claude.ai`), staging (`https://claude-ai.staging.ant.dev`), or local-dev (`http://localhost:4000`) — via `getClaudeAiBaseUrl` / `getRemoteSessionUrl`. The ingress-URL signal was a raw substring test:

```ts
ingressUrl?.includes('localhost') === true
ingressUrl?.includes('staging') === true
```

`includes` matches anywhere in the string, so a production ingress URL that happens to carry those words in its **path or query** is misrouted. For example `https://claude.ai/code/x?ref=staging` resolves to the staging base URL, and any URL containing `localhost` (e.g. `https://my-localhost-proxy.example.com`) resolves to `http://localhost:4000`.

## Fix

Parse the ingress **hostname** and match it precisely, the same way `isLocalhostBaseUrl` (`src/bridge/workSecret.ts`) already does for base URLs elsewhere in the codebase:

- local → hostname is exactly `localhost` or `127.0.0.1`
- staging → hostname has a `staging` dot-label (e.g. `claude-ai.staging.ant.dev`)
- a malformed URL yields no match (safe default → production)

The `_local_` / `_staging_` session-id signals are untouched, and the real local/staging ingress hosts still resolve correctly. The hostname parse is inlined to keep `constants/` a leaf of the module-load DAG.

## Tests

Adds `src/constants/product.test.ts` (the file had no tests). Covers the real local/staging hosts, the session-id signals, malformed/missing URLs, and the regression cases — production URLs with `localhost`/`staging` in path/query now route to production. Verified the regression tests fail against the old substring logic and pass with the fix.

This is the same hostname-vs-substring class as #1669 and #1760.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved remote-session and Claude base URL routing by detecting local/staging via the ingress hostname (and session hints) instead of permissive substring checks.
  * Avoided misclassification of production links when “localhost” or “staging” appear only in paths, query strings, or as unrelated look-alike hostnames.
  * Kept correct routing when the ingress hostname is truly local or staging.

* **Tests**
  * Added a Bun test suite covering local, staging, and production routing/regression scenarios, including base URL selection behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->