### PR TITLE
fix(core): join multi-block message text with a real newline

### DIFF
--- a/src/utils/conversationArc.test.ts
+++ b/src/utils/conversationArc.test.ts
@@ -161,6 +161,33 @@ describe('conversationArc', () => {
       expect(getArc()?.currentPhase).toBe('implementing')
     })
 
+    it('joins multi-block text with a real newline so fact extraction stops at block boundaries', async () => {
+      initializeArc()
+      const blockMessage = {
+        message: {
+          role: 'assistant',
+          content: [
+            { type: 'text', text: 'Set export API_KEY=secret123' },
+            { type: 'text', text: 'and then continue' },
+          ],
+          id: 'test',
+          type: 'message',
+          created_at: Date.now(),
+        },
+        sender: 'assistant',
+      }
+      await updateArcPhase([blockMessage as any])
+
+      const graph = getGlobalGraph()
+      const envVar = Object.values(graph.entities).find(
+        (e: any) => e.type === 'environment_variable' && e.name === 'API_KEY',
+      )
+      expect(envVar).toBeDefined()
+      // With a literal "\n" separator the value absorbed the next block
+      // (`secret123\nand`); a real newline stops the value at the block boundary.
+      expect((envVar as any).attributes.value).toBe('secret123')
+    })
+
     it('progresses phases forward only', async () => {
       initializeArc()
       await updateArcPhase([createMessage('user', 'Write code')])

--- a/src/utils/conversationArc.ts
+++ b/src/utils/conversationArc.ts
@@ -122,7 +122,7 @@ function extractTextFromContent(content: unknown): string {
     return content
       .filter((block: any) => block.type === 'text' && typeof block.text === 'string')
       .map((block: any) => block.text)
-      .join('\\n')
+      .join('\n')
   }
   return ''
 }


### PR DESCRIPTION
## Summary

- `extractTextFromContent` joined multi-block message text with a literal `\n` (backslash-n) rather than a newline.
- Assistant messages commonly arrive as multi-block content arrays; the joined text feeds conversation-arc fact extraction, so the literal separator corrupted extracted values at block seams.

## Impact

- user-facing impact: knowledge-graph fact extraction recorded wrong values when a pattern sat at the end of a text block. The fact-extraction regexes treat newlines as boundaries (env-var / URL / IP values use `[^\s\n"']+`), so with the literal separator a value absorbed the following block — e.g. `export API_KEY=secret123` split across two blocks stored the env-var value as `secret123\nand…` instead of `secret123`.
- developer/maintainer impact: none; a one-character separator change with no API or behavior change elsewhere.

## Testing

- [x] `bun run build`
- [x] `bun run smoke`
- [ ] `bun run check` — build and smoke are green; the full-suite run reports 3 pre-existing order-dependent failures in `src/services/api/claude.lifecycle.test.ts` (it passes 4/4 in isolation), unrelated to this text-join change.
- [x] focused tests: `bun test src/utils/conversationArc.test.ts` — 17 pass; the new case fails on the old literal separator and passes with the fix.

## Notes

- provider/model path tested: n/a — pure text-join fix in conversation-arc fact extraction, no provider path involved.
- screenshots attached (if UI changed): not a UI change.
- follow-up work or known limitations: none.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Text from multi-part assistant messages is now combined with real line breaks, improving how message content is processed.
  * Entity extraction now stops correctly at block boundaries, preventing extra text from being included in extracted values.

* **Tests**
  * Added coverage for multi-block assistant messages to verify newline handling and accurate fact extraction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->