### PR TITLE
fix(compaction): skip microcompact when compaction is off

### DIFF
--- a/src/query.ts
+++ b/src/query.ts
@@ -14,6 +14,7 @@ import {
 } from './services/compact/autoCompact.js'
 import { consumeCompactionRequest } from './utils/memoryPressure.js'
 import { buildPostCompactMessages } from './services/compact/compact.js'
+import type { MicrocompactResult } from './services/compact/microCompact.js'
 /* eslint-disable @typescript-eslint/no-require-imports */
 const reactiveCompact = feature('REACTIVE_COMPACT')
   ? (require('./services/compact/reactiveCompact.js') as typeof import('./services/compact/reactiveCompact.js'))
@@ -450,6 +451,12 @@ async function* queryLoop(
     }
 
     let tracking = autoCompactTracking
+    const configuredMaxMessagesCompactionThreshold =
+      getGlobalConfig().maxMessagesCompactionThreshold
+    const maxMessagesCompactionThreshold =
+      normalizeMaxMessagesCompactionThreshold(
+        configuredMaxMessagesCompactionThreshold,
+      )
 
     // Enforce per-message budget on aggregate tool result size. Runs BEFORE
     // microcompact — cached MC operates purely by tool_use_id (never inspects
@@ -502,17 +509,23 @@ async function* queryLoop(
 
     // Apply microcompact before autocompact
     queryCheckpoint('query_microcompact_start')
-    const microcompactResult = await deps.microcompact(
-      messagesForQuery,
-      toolUseContext,
-      querySource,
-    )
-    messagesForQuery = microcompactResult.messages
+    let microcompactResult: MicrocompactResult | undefined
+    if (
+      querySource === 'compact' ||
+      configuredMaxMessagesCompactionThreshold !== 'off'
+    ) {
+      microcompactResult = await deps.microcompact(
+        messagesForQuery,
+        toolUseContext,
+        querySource,
+      )
+      messagesForQuery = microcompactResult.messages
+    }
     // For cached microcompact (cache editing), defer boundary message until after
     // the API response so we can use actual cache_deleted_input_tokens.
     // Gated behind feature() so the string is eliminated from external builds.
     const pendingCacheEdits = feature('CACHED_MICROCOMPACT')
-      ? microcompactResult.compactionInfo?.pendingCacheEdits
+      ? microcompactResult?.compactionInfo?.pendingCacheEdits
       : undefined
     queryCheckpoint('query_microcompact_end')
 
@@ -568,9 +581,7 @@ async function* queryLoop(
     const canForceCompact =
       querySource !== 'compact' && querySource !== 'session_memory'
     if (canForceCompact) {
-      const configSetting = normalizeMaxMessagesCompactionThreshold(
-        getGlobalConfig().maxMessagesCompactionThreshold,
-      )
+      const configSetting = maxMessagesCompactionThreshold
       const envSetting = process.env.OPENCLAUDE_MAX_ACTIVE_MESSAGES
       const maxActiveMessages = configSetting !== 'off'
         ? Number.parseInt(configSetting, 10)

--- a/src/query/autoCompactCooldown.test.ts
+++ b/src/query/autoCompactCooldown.test.ts
@@ -10,6 +10,9 @@ import {
 import type { Message } from '../types/message.js'
 import { asSystemPrompt } from '../utils/systemPromptType.js'
 import type { MaxMessagesCompactionThreshold } from '../utils/config.js'
+import type { QueryDeps } from './deps.js'
+
+type AutocompactArgs = Parameters<QueryDeps['autocompact']>
 
 // Some smoke-suite files mock config globally; bun:test does not unregister
 // mock.module() registrations on mock.restore(). Pin this suite to the real
@@ -200,13 +203,14 @@ function successfulQueryDeps(
   const autocompact = mock(async () => ({
     wasCompacted: false,
   }))
+  const deps: QueryDeps = {
+    callModel: callModel as QueryDeps['callModel'],
+    microcompact: microcompact as QueryDeps['microcompact'],
+    autocompact: autocompact as QueryDeps['autocompact'],
+    uuid: () => 'test-uuid',
+  }
   return {
-    deps: {
-      callModel,
-      microcompact,
-      autocompact,
-      uuid: () => 'test-uuid',
-    } as never,
+    deps,
     callModel,
     microcompact,
     autocompact,
@@ -214,7 +218,7 @@ function successfulQueryDeps(
 }
 
 async function runSuccessfulQuery(
-  deps: never,
+  deps: QueryDeps,
   querySource: 'repl_main_thread' | 'compact' = 'repl_main_thread',
 ) {
   const { query } = await loadQuery()
@@ -304,11 +308,11 @@ test('active auto-compact cooldown blocks before model call with cooldown guidan
   const callModel = mock(() => {
     throw new Error('model should not be called while autocompact cools down')
   })
-  const deps = {
-    callModel,
+  const deps: QueryDeps = {
+    callModel: callModel as QueryDeps['callModel'],
     microcompact: mock(async (input: Message[]) => ({
       messages: input,
-    })),
+    })) as QueryDeps['microcompact'],
     autocompact: mock(
       async (): Promise<{
         wasCompacted: boolean
@@ -323,9 +327,9 @@ test('active auto-compact cooldown blocks before model call with cooldown guidan
         circuitBreakerActive: true,
         circuitBreakerTripped: false,
       }),
-    ),
+    ) as QueryDeps['autocompact'],
     uuid: () => 'test-uuid',
-  } as never
+  }
 
   const { query } = await loadQuery()
   const { yielded, terminal } = await drain(
@@ -361,18 +365,18 @@ test('auto-compact cooldown tracking is carried into the next query call', async
   const callModel = mock(() => {
     throw new Error('model should not be called while autocompact cools down')
   })
-  const deps = {
-    callModel,
+  const deps: QueryDeps = {
+    callModel: callModel as QueryDeps['callModel'],
     microcompact: mock(async (input: Message[]) => ({
       messages: input,
-    })),
+    })) as QueryDeps['microcompact'],
     autocompact: mock(
       async (
-        _messages: never,
-        _toolUseContext: never,
-        _params: never,
-        _querySource: never,
-        tracking: AutoCompactTrackingState | undefined,
+        _messages: AutocompactArgs[0],
+        _toolUseContext: AutocompactArgs[1],
+        _params: AutocompactArgs[2],
+        _querySource: AutocompactArgs[3],
+        tracking: AutocompactArgs[4],
       ) => {
         seenTracking.push(tracking)
         return {
@@ -383,9 +387,9 @@ test('auto-compact cooldown tracking is carried into the next query call', async
           circuitBreakerTripped: false,
         }
       },
-    ),
+    ) as QueryDeps['autocompact'],
     uuid: () => 'test-uuid',
-  } as never
+  }
 
   let persistedTracking: AutoCompactTrackingState | undefined
   const queryParams = () => ({
@@ -429,18 +433,18 @@ test('post-compact turn tracking callback publishes a fresh object', async () =>
     consecutiveFailures: 0,
   }
   const trackingUpdates: AutoCompactTrackingState[] = []
-  const deps = {
+  const deps: QueryDeps = {
     callModel: mock(async function* () {
       yield assistantToolUseMessage()
-    }),
+    }) as QueryDeps['callModel'],
     microcompact: mock(async (input: Message[]) => ({
       messages: input,
-    })),
+    })) as QueryDeps['microcompact'],
     autocompact: mock(async () => ({
       wasCompacted: false,
-    })),
+    })) as QueryDeps['autocompact'],
     uuid: () => 'test-uuid',
-  } as never
+  }
 
   const { query } = await loadQuery()
   const { terminal } = await drain(
@@ -482,16 +486,16 @@ test('persisted breaker state does not block when auto-compact is disabled', asy
   const callModel = mock(async function* () {
     yield assistantToolUseMessage()
   })
-  const deps = {
-    callModel,
+  const deps: QueryDeps = {
+    callModel: callModel as QueryDeps['callModel'],
     microcompact: mock(async (input: Message[]) => ({
       messages: input,
-    })),
+    })) as QueryDeps['microcompact'],
     autocompact: mock(async () => ({
       wasCompacted: false,
-    })),
+    })) as QueryDeps['autocompact'],
     uuid: () => 'test-uuid',
-  } as never
+  }
 
   const { query } = await loadQuery()
   const { yielded, terminal } = await drain(
@@ -529,13 +533,13 @@ test('breaker metadata tracking callback publishes a fresh object', async () => 
     lastFailureAtMs: 5_000,
   }
   const trackingUpdates: AutoCompactTrackingState[] = []
-  const deps = {
+  const deps: QueryDeps = {
     callModel: mock(() => {
       throw new Error('model should not be called while autocompact cools down')
-    }),
+    }) as QueryDeps['callModel'],
     microcompact: mock(async (input: Message[]) => ({
       messages: input,
-    })),
+    })) as QueryDeps['microcompact'],
     autocompact: mock(async () => ({
       wasCompacted: false,
       consecutiveFailures: MAX_CONSECUTIVE_AUTOCOMPACT_FAILURES,
@@ -543,9 +547,9 @@ test('breaker metadata tracking callback publishes a fresh object', async () => 
       lastFailureAtMs: 15_000,
       circuitBreakerActive: true,
       circuitBreakerTripped: true,
-    })),
+    })) as QueryDeps['autocompact'],
     uuid: () => 'test-uuid',
-  } as never
+  }
 
   const { query } = await loadQuery()
   const { terminal } = await drain(

--- a/src/query/autoCompactCooldown.test.ts
+++ b/src/query/autoCompactCooldown.test.ts
@@ -14,7 +14,11 @@ import {
 import type { Message } from '../types/message.js'
 import { query } from '../query.js'
 import { asSystemPrompt } from '../utils/systemPromptType.js'
-import { getGlobalConfig, saveGlobalConfig } from '../utils/config.js'
+import {
+  getGlobalConfig,
+  type MaxMessagesCompactionThreshold,
+  saveGlobalConfig,
+} from '../utils/config.js'
 
 const SAVED_ENV = {
   CLAUDE_CONFIG_DIR: process.env.CLAUDE_CONFIG_DIR,
@@ -24,32 +28,52 @@ const SAVED_ENV = {
     process.env.CLAUDE_AUTOCOMPACT_PCT_OVERRIDE,
   DISABLE_AUTO_COMPACT: process.env.DISABLE_AUTO_COMPACT,
   DISABLE_COMPACT: process.env.DISABLE_COMPACT,
+  OPENCLAUDE_MAX_ACTIVE_MESSAGES: process.env.OPENCLAUDE_MAX_ACTIVE_MESSAGES,
 }
 
-let savedAutoCompactEnabled: boolean | undefined
+let savedGlobalConfig:
+  | {
+      autoCompactEnabled: boolean
+      maxMessagesCompactionThreshold:
+        | MaxMessagesCompactionThreshold
+        | undefined
+    }
+  | undefined
 let tempDir: string | undefined
 
 beforeEach(async () => {
   await acquireSharedMutationLock('query/autoCompactCooldown.test.ts')
   tempDir = mkdtempSync(join(tmpdir(), 'openclaude-autocompact-test-'))
   process.env.CLAUDE_CONFIG_DIR = tempDir
-  savedAutoCompactEnabled = getGlobalConfig().autoCompactEnabled
-  saveGlobalConfig(current => ({ ...current, autoCompactEnabled: true }))
+  const globalConfig = getGlobalConfig()
+  savedGlobalConfig = {
+    autoCompactEnabled: globalConfig.autoCompactEnabled,
+    maxMessagesCompactionThreshold:
+      globalConfig.maxMessagesCompactionThreshold,
+  }
+  saveGlobalConfig(current => ({
+    ...current,
+    autoCompactEnabled: true,
+    maxMessagesCompactionThreshold: undefined,
+  }))
   process.env.CLAUDE_CODE_AUTO_COMPACT_WINDOW = '200000'
   process.env.CLAUDE_AUTOCOMPACT_PCT_OVERRIDE = '1'
   delete process.env.DISABLE_AUTO_COMPACT
   delete process.env.DISABLE_COMPACT
+  delete process.env.OPENCLAUDE_MAX_ACTIVE_MESSAGES
 })
 
 afterEach(() => {
   try {
-    if (savedAutoCompactEnabled !== undefined) {
-      const autoCompactEnabled = savedAutoCompactEnabled
+    if (savedGlobalConfig) {
+      const { autoCompactEnabled, maxMessagesCompactionThreshold } =
+        savedGlobalConfig
       saveGlobalConfig(current => ({
         ...current,
         autoCompactEnabled,
+        maxMessagesCompactionThreshold,
       }))
-      savedAutoCompactEnabled = undefined
+      savedGlobalConfig = undefined
     }
 
     for (const [key, value] of Object.entries(SAVED_ENV)) {
@@ -150,6 +174,115 @@ async function drain<T, TReturn>(
     yielded.push(next.value)
   }
 }
+
+function successfulQueryDeps(
+  microcompactImpl?: (input: Message[]) => Promise<{ messages: Message[] }>,
+) {
+  const callModel = mock(async function* (_params: { messages: Message[] }) {
+    yield assistantToolUseMessage()
+  })
+  const microcompact = mock(
+    microcompactImpl ?? (async (input: Message[]) => ({ messages: input })),
+  )
+  const autocompact = mock(async () => ({
+    wasCompacted: false,
+  }))
+  return {
+    deps: {
+      callModel,
+      microcompact,
+      autocompact,
+      uuid: () => 'test-uuid',
+    } as never,
+    callModel,
+    microcompact,
+    autocompact,
+  }
+}
+
+async function runSuccessfulQuery(
+  deps: never,
+  querySource: 'repl_main_thread' | 'compact' = 'repl_main_thread',
+) {
+  return await drain(
+    query({
+      messages: [userMessage('hello')],
+      systemPrompt: asSystemPrompt([]),
+      userContext: {},
+      systemContext: {},
+      canUseTool,
+      toolUseContext: toolUseContext(),
+      querySource,
+      maxTurns: 1,
+      deps,
+    }),
+  )
+}
+
+test('explicit off skips automatic microcompact during query flow', async () => {
+  saveGlobalConfig(current => ({
+    ...current,
+    maxMessagesCompactionThreshold: 'off',
+  }))
+  const { deps, callModel, microcompact, autocompact } = successfulQueryDeps(
+    async input => ({ messages: input }),
+  )
+
+  const { terminal } = await runSuccessfulQuery(deps)
+
+  expect(terminal.reason).toBe('max_turns')
+  expect(callModel).toHaveBeenCalledTimes(1)
+  expect(autocompact).toHaveBeenCalledTimes(1)
+  expect(microcompact).not.toHaveBeenCalled()
+})
+
+test('unset message-count threshold keeps automatic microcompact behavior', async () => {
+  const { deps, microcompact } = successfulQueryDeps()
+
+  const { terminal } = await runSuccessfulQuery(deps)
+
+  expect(terminal.reason).toBe('max_turns')
+  expect(microcompact).toHaveBeenCalledTimes(1)
+})
+
+test('automatic microcompact passes compacted messages to the model call', async () => {
+  const compactedMessages = [userMessage('compacted hello')]
+  const { deps, callModel, microcompact } = successfulQueryDeps(async () => ({
+    messages: compactedMessages,
+  }))
+
+  const { terminal } = await runSuccessfulQuery(deps)
+
+  expect(terminal.reason).toBe('max_turns')
+  expect(microcompact).toHaveBeenCalledTimes(1)
+  expect(callModel.mock.calls[0]?.[0].messages).toEqual(compactedMessages)
+})
+
+test('numeric message-count threshold keeps automatic microcompact behavior', async () => {
+  saveGlobalConfig(current => ({
+    ...current,
+    maxMessagesCompactionThreshold: '100',
+  }))
+  const { deps, microcompact } = successfulQueryDeps()
+
+  const { terminal } = await runSuccessfulQuery(deps)
+
+  expect(terminal.reason).toBe('max_turns')
+  expect(microcompact).toHaveBeenCalledTimes(1)
+})
+
+test('explicit compact query source still runs microcompact when threshold is off', async () => {
+  saveGlobalConfig(current => ({
+    ...current,
+    maxMessagesCompactionThreshold: 'off',
+  }))
+  const { deps, microcompact } = successfulQueryDeps()
+
+  const { terminal } = await runSuccessfulQuery(deps, 'compact')
+
+  expect(terminal.reason).toBe('max_turns')
+  expect(microcompact).toHaveBeenCalledTimes(1)
+})
 
 test('active auto-compact cooldown blocks before model call with cooldown guidance', async () => {
   const messages = [overAutoCompactThresholdMessage()]

--- a/src/query/autoCompactCooldown.test.ts
+++ b/src/query/autoCompactCooldown.test.ts
@@ -2,23 +2,30 @@ import { afterEach, beforeEach, expect, mock, test } from 'bun:test'
 import { mkdtempSync, rmSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import {
-  getAutoCompactThreshold,
-  MAX_CONSECUTIVE_AUTOCOMPACT_FAILURES,
-  type AutoCompactTrackingState,
-} from '../services/compact/autoCompact.js'
+import type { AutoCompactTrackingState } from '../services/compact/autoCompact.js'
 import {
   acquireSharedMutationLock,
   releaseSharedMutationLock,
 } from '../test/sharedMutationLock.js'
 import type { Message } from '../types/message.js'
-import { query } from '../query.js'
 import { asSystemPrompt } from '../utils/systemPromptType.js'
-import {
-  getGlobalConfig,
-  type MaxMessagesCompactionThreshold,
-  saveGlobalConfig,
-} from '../utils/config.js'
+import type { MaxMessagesCompactionThreshold } from '../utils/config.js'
+
+// Some smoke-suite files mock config globally; bun:test does not unregister
+// mock.module() registrations on mock.restore(). Pin this suite to the real
+// config before importing query so saved settings are visible to the query loop.
+const realConfigModule = (await import(
+  `../utils/config.js?autoCompactCooldownReal=${Date.now()}-${Math.random()}`
+)) as typeof import('../utils/config.js')
+mock.module('../utils/config.js', () => ({ ...realConfigModule }))
+
+const { getGlobalConfig, saveGlobalConfig } = realConfigModule
+const {
+  getAutoCompactThreshold,
+  MAX_CONSECUTIVE_AUTOCOMPACT_FAILURES,
+} = (await import(
+  `../services/compact/autoCompact.js?autoCompactCooldownReal=${Date.now()}-${Math.random()}`
+)) as typeof import('../services/compact/autoCompact.js')
 
 const SAVED_ENV = {
   CLAUDE_CONFIG_DIR: process.env.CLAUDE_CONFIG_DIR,
@@ -175,6 +182,12 @@ async function drain<T, TReturn>(
   }
 }
 
+async function loadQuery() {
+  return (await import(
+    `../query.js?autoCompactCooldown=${Date.now()}-${Math.random()}`
+  )) as typeof import('../query.js')
+}
+
 function successfulQueryDeps(
   microcompactImpl?: (input: Message[]) => Promise<{ messages: Message[] }>,
 ) {
@@ -204,6 +217,7 @@ async function runSuccessfulQuery(
   deps: never,
   querySource: 'repl_main_thread' | 'compact' = 'repl_main_thread',
 ) {
+  const { query } = await loadQuery()
   return await drain(
     query({
       messages: [userMessage('hello')],
@@ -313,6 +327,7 @@ test('active auto-compact cooldown blocks before model call with cooldown guidan
     uuid: () => 'test-uuid',
   } as never
 
+  const { query } = await loadQuery()
   const { yielded, terminal } = await drain(
     query({
       messages,
@@ -390,6 +405,7 @@ test('auto-compact cooldown tracking is carried into the next query call', async
     },
   })
 
+  const { query } = await loadQuery()
   const first = await drain(query(queryParams()))
   expect(first.terminal.reason).toBe('blocking_limit')
   expect(persistedTracking?.nextRetryAtMs).toBe(nextRetryAtMs)
@@ -426,6 +442,7 @@ test('post-compact turn tracking callback publishes a fresh object', async () =>
     uuid: () => 'test-uuid',
   } as never
 
+  const { query } = await loadQuery()
   const { terminal } = await drain(
     query({
       messages: [userMessage('hello')],
@@ -476,6 +493,7 @@ test('persisted breaker state does not block when auto-compact is disabled', asy
     uuid: () => 'test-uuid',
   } as never
 
+  const { query } = await loadQuery()
   const { yielded, terminal } = await drain(
     query({
       messages: [overAutoCompactThresholdMessage()],
@@ -529,6 +547,7 @@ test('breaker metadata tracking callback publishes a fresh object', async () => 
     uuid: () => 'test-uuid',
   } as never
 
+  const { query } = await loadQuery()
   const { terminal } = await drain(
     query({
       messages: [overAutoCompactThresholdMessage()],

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -740,7 +740,9 @@ function createDefaultGlobalConfig(): GlobalConfig {
     providerProfiles: [],
     openaiAdditionalModelOptionsCacheByProfile: {},
     knowledgeGraphEnabled: true,
-    maxMessagesCompactionThreshold: 'off',
+    // Omitted by default so callers can distinguish "unset" from an explicit
+    // persisted "off"; normalizeMaxMessagesCompactionThreshold keeps the
+    // effective default disabled.
   }
   return config
 }
@@ -1150,11 +1152,17 @@ registerCleanup(async () => {
  * @internal
  */
 function migrateConfigFields(config: GlobalConfig): GlobalConfig {
+  const { maxMessagesCompactionThreshold, ...restConfig } = config
   const normalizedConfig = {
-    ...config,
-    maxMessagesCompactionThreshold: normalizeMaxMessagesCompactionThreshold(
-      config.maxMessagesCompactionThreshold,
-    ),
+    ...restConfig,
+    ...(maxMessagesCompactionThreshold === undefined
+      ? {}
+      : {
+          maxMessagesCompactionThreshold:
+            normalizeMaxMessagesCompactionThreshold(
+              maxMessagesCompactionThreshold,
+            ),
+        }),
   }
 
   // Already migrated


### PR DESCRIPTION
## Summary
- Skip automatic query-loop microcompact when `maxMessagesCompactionThreshold` is explicitly `"off"`.
- Preserve automatic microcompact for unset/default and numeric thresholds, and keep explicit compact-source behavior intact.
- Preserve unset-vs-explicit config state so `"off"` can be detected without raw config file reads.

## Implementation
- Read the raw configured threshold once in `queryLoop`, normalize it once for later message-count logic, and gate only the automatic microcompact call.
- Keep default global config omitting `maxMessagesCompactionThreshold`; migration normalizes only present values.
- Add regression coverage for explicit off, unset/default, numeric threshold, explicit compact source, compacted message handoff, and typed query deps fixtures.

## Tests
- `bun test src/query/autoCompactCooldown.test.ts`
- `bun test src/query*.test.ts`
- `bun test src/query/*.test.ts`
- `bun test src/services/compact/autoCompact.test.ts src/services/compact/microCompact.test.ts`
- `bun test src/services/contextCollapse/*.test.ts`
- `bun run typecheck`
- `bun run typecheck:type-tests`
- `bun run build`
- `bun run smoke`
- `bun run security:pr-scan -- --base upstream/main`
- `git diff --check`

## Risk
- The intentionally preserved behavior is that an unset setting still allows automatic microcompact; only an explicitly persisted `"off"` disables that automatic path.
- Known baseline: `bun test src/services/compact/*.test.ts` fails when `compact.test.ts` runs before `autoCompact.test.ts` because of an existing order-dependent test fixture leak; the targeted compact tests above pass.

Fixes #1715