### PR TITLE
feat(report): generate deterministic session task reports

### DIFF
--- a/docs/advanced-setup.md
+++ b/docs/advanced-setup.md
@@ -377,6 +377,9 @@ openclaude doctor report --markdown
 # write a redacted JSON issue report for attachment
 openclaude doctor report --json --out openclaude-report.json
 
+# write a deterministic JSON task report from a session transcript
+openclaude report --json --transcript ~/.openclaude/projects/-path-to-project/session-id.jsonl --out task-report.json
+
 # full local hardening check (smoke + runtime doctor)
 bun run hardening:check
 
@@ -391,6 +394,7 @@ Notes:
 - Local providers such as `http://localhost:11434/v1`, `http://10.0.0.1:11434/v1`, and `http://127.0.0.1:1337/v1` can run without `OPENAI_API_KEY`.
 - Codex profiles validate `CODEX_API_KEY` or the Codex CLI auth file and probe `POST /responses` instead of `GET /models`.
 - `openclaude doctor report` is redacted by default and is intended for GitHub issues. It summarizes provider/runtime/build/settings state without prompts, transcripts, raw settings files, API keys, MCP command details, or full home-directory paths.
+- `openclaude report --json` summarizes observed session facts such as tool uses, Bash commands, validation commands, changed files, branch metadata, warnings, and linked issue/PR references. Use `--transcript <file>` for an explicit transcript, `--session <id>` for a stored session, or omit both to report the latest session for the current project. Large previews are truncated and credential-shaped strings are redacted. When no validation command is observed, the report keeps `validations` empty and includes a warning instead of claiming checks passed.
 
 ## Provider Launch Profiles
 

--- a/src/cli/handlers/taskReport.ts
+++ b/src/cli/handlers/taskReport.ts
@@ -1,0 +1,109 @@
+import { resolve } from 'node:path'
+
+import {
+  buildTaskReport,
+  formatTaskReportAsJson,
+  writeTaskReport,
+  type TaskReportArgs,
+} from '../../utils/taskReport.js'
+import {
+  getProjectDir,
+  getSessionFilesWithMtime,
+} from '../../utils/sessionStorage.js'
+
+function formatError(error: unknown): string {
+  return error instanceof Error ? error.message : String(error)
+}
+
+function writeLine(
+  stream: NodeJS.WritableStream,
+  message: string,
+): Promise<void> {
+  return new Promise((resolve, reject) => {
+    stream.write(`${message}\n`, error => {
+      if (error) {
+        reject(error)
+      } else {
+        resolve()
+      }
+    })
+  })
+}
+
+export async function taskReportHandler(
+  options: TaskReportArgs,
+): Promise<void> {
+  if (options.format !== 'json') {
+    throw new Error('Task reports currently support JSON output only')
+  }
+
+  const cwd = resolve(options.cwd ?? process.cwd())
+  const transcriptPath = await resolveTranscriptPath({
+    cwd,
+    sessionId: options.sessionId ?? null,
+    transcriptPath: options.transcriptPath ?? null,
+  })
+  const report = await buildTaskReport({
+    transcriptPath,
+    cwd,
+  })
+  const content = formatTaskReportAsJson(report)
+
+  if (options.outFile) {
+    const outputPath = await writeTaskReport(options.outFile, content)
+    await writeLine(process.stderr, `Task report written to ${outputPath}`)
+    return
+  }
+
+  await writeLine(process.stdout, content)
+}
+
+export async function printTaskReportError(error: unknown): Promise<void> {
+  await writeLine(
+    process.stderr,
+    `Failed to generate task report: ${formatError(error)}`,
+  )
+}
+
+async function resolveTranscriptPath({
+  cwd,
+  sessionId,
+  transcriptPath,
+}: {
+  cwd: string
+  sessionId: string | null
+  transcriptPath: string | null
+}): Promise<string> {
+  if (transcriptPath) {
+    return resolve(cwd, transcriptPath)
+  }
+
+  const sessionFiles = await getSessionFilesWithMtime(getProjectDir(cwd))
+  if (sessionId) {
+    const sessionFile = sessionFiles.get(sessionId)
+    if (!sessionFile) {
+      throw new Error(`Session transcript not found: ${sessionId}`)
+    }
+    return sessionFile.path
+  }
+
+  let latest: { path: string; mtime: number; ctime: number } | null = null
+  for (const sessionFile of sessionFiles.values()) {
+    if (
+      !latest ||
+      sessionFile.mtime > latest.mtime ||
+      (sessionFile.mtime === latest.mtime &&
+        (sessionFile.ctime > latest.ctime ||
+          (sessionFile.ctime === latest.ctime &&
+            sessionFile.path.localeCompare(latest.path) < 0)))
+    ) {
+      latest = sessionFile
+    }
+  }
+  if (!latest) {
+    throw new Error(
+      'No session transcripts found for the current project. Pass --transcript <file> or --session <id>.',
+    )
+  }
+  return latest.path
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -4211,6 +4211,48 @@ async function run(): Promise<CommanderCommand> {
     });
   }
 
+  program
+    .command('report')
+    .description(
+      'Generate a deterministic JSON task report for an OpenClaude session',
+    )
+    .option('--json', 'Print JSON output')
+    .option('--transcript <file>', 'Path to a session JSONL transcript')
+    .option(
+      '--session <id>',
+      'Session ID to report (defaults to latest session in the current project)',
+    )
+    .option('--out <file>', 'Write the report to a file')
+    .action(async (options: {
+      json?: boolean;
+      transcript?: string;
+      session?: string;
+      out?: string;
+    }) => {
+      const {
+        taskReportHandler,
+        printTaskReportError,
+      } = await import('./cli/handlers/taskReport.js');
+      try {
+        if (options.json !== true) {
+          throw new Error(
+            'Task reports currently support JSON output only. Pass --json.',
+          );
+        }
+        await taskReportHandler({
+          format: 'json',
+          transcriptPath: options.transcript ?? null,
+          sessionId: options.session ?? null,
+          outFile: options.out ?? null,
+          cwd: process.cwd(),
+        });
+        process.exit(0);
+      } catch (error) {
+        await printTaskReportError(error);
+        process.exit(1);
+      }
+    });
+
   // Doctor command - check installation health
   const doctorCommand = program
     .command('doctor')

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -4239,6 +4239,11 @@ async function run(): Promise<CommanderCommand> {
             'Task reports currently support JSON output only. Pass --json.',
           );
         }
+        if (options.transcript && options.session) {
+          throw new Error(
+            'Pass either --transcript <file> or --session <id>, not both.',
+          );
+        }
         await taskReportHandler({
           format: 'json',
           transcriptPath: options.transcript ?? null,

--- a/src/utils/reportTask.test.ts
+++ b/src/utils/reportTask.test.ts
@@ -213,6 +213,62 @@ describe('task report generation', () => {
     )
   })
 
+  test('captures passing validation commands from observed PowerShell results', async () => {
+    await withTempTranscript(
+      [
+        userMessage(
+          '00000000-0000-4000-8000-000000000045',
+          'Run the Windows checks.',
+          '2026-06-27T08:00:00.000Z',
+        ),
+        assistantToolMessage(
+          '00000000-0000-4000-8000-000000000046',
+          {
+            id: 'tool-powershell-validation-pass',
+            name: 'PowerShell',
+            input: {
+              command: 'bun run typecheck',
+              description: 'Run TypeScript checks',
+            },
+          },
+          '2026-06-27T08:01:00.000Z',
+        ),
+        toolResultMessage(
+          '00000000-0000-4000-8000-000000000047',
+          'tool-powershell-validation-pass',
+          'Typecheck passed',
+          '2026-06-27T08:01:03.000Z',
+          { stdout: 'Typecheck passed\n', stderr: '', interrupted: false },
+        ),
+      ],
+      async transcriptPath => {
+        const report = await buildTaskReport({
+          transcriptPath,
+          git: async () => gitMetadata({ dirty: false, changedFiles: [] }),
+        })
+
+        expect(report.commands).toEqual([
+          expect.objectContaining({
+            toolUseId: 'tool-powershell-validation-pass',
+            command: 'bun run typecheck',
+            description: 'Run TypeScript checks',
+            status: 'success',
+          }),
+        ])
+        expect(report.validations).toEqual([
+          expect.objectContaining({
+            toolUseId: 'tool-powershell-validation-pass',
+            command: 'bun run typecheck',
+            status: 'success',
+          }),
+        ])
+        expect(report.warnings).not.toContain(
+          'No validation commands were observed in this transcript.',
+        )
+      },
+    )
+  })
+
   test('captures failing validation commands with exit code when it is persisted', async () => {
     await withTempTranscript(
       [
@@ -368,6 +424,66 @@ describe('task report generation', () => {
     )
   })
 
+  test('reports backgrounded validation commands with unknown status', async () => {
+    await withTempTranscript(
+      [
+        userMessage(
+          '00000000-0000-4000-8000-000000000048',
+          'Run tests in the background.',
+          '2026-06-27T08:00:00.000Z',
+        ),
+        assistantToolMessage(
+          '00000000-0000-4000-8000-000000000049',
+          {
+            id: 'tool-background-validation',
+            name: 'Bash',
+            input: {
+              command: 'bun test src/utils/reportTask.test.ts',
+              run_in_background: true,
+            },
+          },
+          '2026-06-27T08:01:00.000Z',
+        ),
+        toolResultMessage(
+          '00000000-0000-4000-8000-000000000050',
+          'tool-background-validation',
+          'Command running in background with ID: bg-report-tests.',
+          '2026-06-27T08:01:03.000Z',
+          {
+            stdout: '',
+            stderr: '',
+            interrupted: false,
+            backgroundTaskId: 'bg-report-tests',
+          },
+        ),
+      ],
+      async transcriptPath => {
+        const report = await buildTaskReport({
+          transcriptPath,
+          git: async () => gitMetadata({ dirty: false, changedFiles: [] }),
+        })
+
+        expect(report.commands).toEqual([
+          expect.objectContaining({
+            toolUseId: 'tool-background-validation',
+            command: 'bun test src/utils/reportTask.test.ts',
+            status: 'unknown',
+          }),
+        ])
+        expect(report.validations).toEqual([
+          expect.objectContaining({
+            toolUseId: 'tool-background-validation',
+            command: 'bun test src/utils/reportTask.test.ts',
+            status: 'unknown',
+          }),
+        ])
+        expect(report.warnings).not.toContain(
+          'No validation commands were observed in this transcript.',
+        )
+      },
+    )
+  })
+
   test('classifies validation commands from the raw Bash command before truncation', async () => {
     const longPrefix = 'echo setup && '.repeat(20)
     const rawCommand = `${longPrefix}bun test src/utils/reportTask.test.ts`
@@ -419,17 +535,29 @@ describe('task report generation', () => {
     )
   })
 
-  test('classifies documented web checks as validations', async () => {
-    for (const command of ['bun run web:typecheck', 'bun run web:build']) {
+  test('classifies documented package checks as validations', async () => {
+    const commands = [
+      'bun run web:typecheck',
+      'bun run web:build',
+      'bun run integrations:check',
+      'bun run verify:privacy',
+      'bun run doctor:runtime',
+      'bun run doctor:runtime:json',
+      'bun run build:verified',
+      'bun run hardening:check',
+      'bun run hardening:strict',
+    ]
+
+    for (const [index, command] of commands.entries()) {
       await withTempTranscript(
         [
           userMessage(
-            `00000000-0000-4000-8000-${command.endsWith('build') ? '000000000032' : '000000000031'}`,
+            `00000000-0000-4000-8000-${String(51 + index * 3).padStart(12, '0')}`,
             `Run ${command}.`,
             '2026-06-27T08:00:00.000Z',
           ),
           assistantToolMessage(
-            `00000000-0000-4000-8000-${command.endsWith('build') ? '000000000034' : '000000000033'}`,
+            `00000000-0000-4000-8000-${String(52 + index * 3).padStart(12, '0')}`,
             {
               id: `tool-${command.replaceAll(/[^A-Za-z0-9]/g, '-')}`,
               name: 'Bash',
@@ -440,7 +568,7 @@ describe('task report generation', () => {
             '2026-06-27T08:01:00.000Z',
           ),
           toolResultMessage(
-            `00000000-0000-4000-8000-${command.endsWith('build') ? '000000000036' : '000000000035'}`,
+            `00000000-0000-4000-8000-${String(53 + index * 3).padStart(12, '0')}`,
             `tool-${command.replaceAll(/[^A-Za-z0-9]/g, '-')}`,
             'passed',
             '2026-06-27T08:01:03.000Z',

--- a/src/utils/reportTask.test.ts
+++ b/src/utils/reportTask.test.ts
@@ -623,6 +623,73 @@ describe('task report generation', () => {
     )
   })
 
+  test('does not let task notifications override resolved foreground shell results', async () => {
+    await withTempTranscript(
+      [
+        userMessage(
+          '00000000-0000-4000-8000-000000000092',
+          'Run a foreground validation command.',
+          '2026-06-27T08:00:00.000Z',
+        ),
+        assistantToolMessage(
+          '00000000-0000-4000-8000-000000000093',
+          {
+            id: 'tool-foreground-validation-conflict',
+            name: 'Bash',
+            input: {
+              command: 'bun test src/utils/reportTask.test.ts',
+            },
+          },
+          '2026-06-27T08:01:00.000Z',
+        ),
+        toolResultMessage(
+          '00000000-0000-4000-8000-000000000094',
+          'tool-foreground-validation-conflict',
+          'Command failed with exit code 2.',
+          '2026-06-27T08:01:03.000Z',
+          {
+            stdout: '',
+            stderr: 'failure',
+            interrupted: false,
+            exitCode: 2,
+          },
+        ),
+        userMessage(
+          '00000000-0000-4000-8000-000000000095',
+          `<task-notification>
+<task-id>unrelated-stale-task</task-id>
+<tool-use-id>tool-foreground-validation-conflict</tool-use-id>
+<output-file>/tmp/unrelated-stale-task.txt</output-file>
+<status>completed</status>
+<summary>Background command "bun test src/utils/reportTask.test.ts" completed (exit code 0)</summary>
+</task-notification>`,
+          '2026-06-27T08:02:03.000Z',
+        ),
+      ],
+      async transcriptPath => {
+        const report = await buildTaskReport({
+          transcriptPath,
+          git: async () => gitMetadata({ dirty: false, changedFiles: [] }),
+        })
+
+        expect(report.toolUses).toEqual([
+          expect.objectContaining({
+            id: 'tool-foreground-validation-conflict',
+            status: 'error',
+          }),
+        ])
+        expect(report.validations).toEqual([
+          expect.objectContaining({
+            toolUseId: 'tool-foreground-validation-conflict',
+            command: 'bun test src/utils/reportTask.test.ts',
+            status: 'error',
+            exitCode: 2,
+          }),
+        ])
+      },
+    )
+  })
+
   test('classifies validation commands from the raw Bash command before truncation', async () => {
     const longPrefix = 'echo setup && '.repeat(20)
     const rawCommand = `${longPrefix}bun test src/utils/reportTask.test.ts`

--- a/src/utils/reportTask.test.ts
+++ b/src/utils/reportTask.test.ts
@@ -1,0 +1,769 @@
+import { describe, expect, test } from 'bun:test'
+import { chmodSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { delimiter, join } from 'node:path'
+
+import {
+  buildTaskReport,
+  collectTaskReportGitMetadata,
+  formatTaskReportAsJson,
+  type TaskReportGitMetadata,
+} from './taskReport.js'
+
+const sessionId = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa'
+const cwd = '/workspace/openclaude'
+
+function withTempTranscript(
+  entries: Array<Record<string, unknown> | string>,
+  fn: (path: string) => Promise<void>,
+) {
+  const dir = mkdtempSync(join(tmpdir(), 'openclaude-task-report-'))
+  const file = join(dir, `${sessionId}.jsonl`)
+  writeFileSync(
+    file,
+    entries
+      .map(entry => (typeof entry === 'string' ? entry : JSON.stringify(entry)))
+      .join('\n'),
+  )
+
+  return fn(file).finally(() => {
+    rmSync(dir, { recursive: true, force: true })
+  })
+}
+
+function userMessage(uuid: string, content: unknown, timestamp: string) {
+  return {
+    type: 'user',
+    uuid,
+    parentUuid: null,
+    isSidechain: false,
+    cwd,
+    sessionId,
+    timestamp,
+    version: 'test',
+    gitBranch: 'feat/source-branch',
+    userType: 'external',
+    message: {
+      role: 'user',
+      content,
+    },
+  }
+}
+
+function assistantToolMessage(
+  uuid: string,
+  toolUse: Record<string, unknown>,
+  timestamp: string,
+) {
+  return {
+    type: 'assistant',
+    uuid,
+    parentUuid: null,
+    isSidechain: false,
+    cwd,
+    sessionId,
+    timestamp,
+    version: 'test',
+    gitBranch: 'feat/source-branch',
+    message: {
+      role: 'assistant',
+      id: `msg-${uuid}`,
+      model: 'gpt-5-test',
+      content: [
+        {
+          type: 'tool_use',
+          ...toolUse,
+        },
+      ],
+    },
+  }
+}
+
+function toolResultMessage(
+  uuid: string,
+  toolUseId: string,
+  content: unknown,
+  timestamp: string,
+  toolUseResult?: unknown,
+  isError = false,
+) {
+  return {
+    type: 'user',
+    uuid,
+    parentUuid: null,
+    isSidechain: false,
+    cwd,
+    sessionId,
+    timestamp,
+    version: 'test',
+    userType: 'external',
+    sourceToolAssistantUUID: 'assistant-source',
+    toolUseResult,
+    message: {
+      role: 'user',
+      content: [
+        {
+          type: 'tool_result',
+          tool_use_id: toolUseId,
+          content,
+          is_error: isError,
+        },
+      ],
+    },
+  }
+}
+
+function gitMetadata(
+  overrides: Partial<TaskReportGitMetadata> = {},
+): TaskReportGitMetadata {
+  return {
+    status: 'available',
+    cwd,
+    branch: 'feat/session-task-report-json',
+    head: '13cf30af',
+    dirty: true,
+    changedFiles: ['src/report.ts'],
+    ...overrides,
+  }
+}
+
+describe('task report generation', () => {
+  test('uses an empty validation list and explicit warning when no validation was observed', async () => {
+    await withTempTranscript(
+      [
+        userMessage(
+          '00000000-0000-4000-8000-000000000001',
+          'Generate a task report for issue #123.',
+          '2026-06-27T08:00:00.000Z',
+        ),
+      ],
+      async transcriptPath => {
+        const report = await buildTaskReport({
+          transcriptPath,
+          git: async () => gitMetadata({ dirty: false, changedFiles: [] }),
+        })
+
+        expect(report.schemaVersion).toBe(1)
+        expect(report.session.id).toBe(sessionId)
+        expect(report.session.cwd).toBe(cwd)
+        expect(report.session.initialRequest).toBe(
+          'Generate a task report for issue #123.',
+        )
+        expect(report.validations).toEqual([])
+        expect(report.warnings).toContain(
+          'No validation commands were observed in this transcript.',
+        )
+      },
+    )
+  })
+
+  test('captures passing validation commands from observed Bash results', async () => {
+    await withTempTranscript(
+      [
+        userMessage(
+          '00000000-0000-4000-8000-000000000002',
+          'Run the checks.',
+          '2026-06-27T08:00:00.000Z',
+        ),
+        assistantToolMessage(
+          '00000000-0000-4000-8000-000000000003',
+          {
+            id: 'tool-validation-pass',
+            name: 'Bash',
+            input: {
+              command: 'bun run typecheck',
+              description: 'Run TypeScript checks',
+            },
+          },
+          '2026-06-27T08:01:00.000Z',
+        ),
+        toolResultMessage(
+          '00000000-0000-4000-8000-000000000004',
+          'tool-validation-pass',
+          'Typecheck passed',
+          '2026-06-27T08:01:03.000Z',
+          { stdout: 'Typecheck passed\n', stderr: '', interrupted: false },
+        ),
+      ],
+      async transcriptPath => {
+        const report = await buildTaskReport({
+          transcriptPath,
+          git: async () => gitMetadata({ dirty: false, changedFiles: [] }),
+        })
+
+        expect(report.commands).toEqual([
+          expect.objectContaining({
+            toolUseId: 'tool-validation-pass',
+            command: 'bun run typecheck',
+            description: 'Run TypeScript checks',
+            status: 'success',
+          }),
+        ])
+        expect(report.validations).toEqual([
+          expect.objectContaining({
+            toolUseId: 'tool-validation-pass',
+            command: 'bun run typecheck',
+            status: 'success',
+          }),
+        ])
+        expect(report.warnings).not.toContain(
+          'No validation commands were observed in this transcript.',
+        )
+      },
+    )
+  })
+
+  test('captures failing validation commands with exit code when it is persisted', async () => {
+    await withTempTranscript(
+      [
+        userMessage(
+          '00000000-0000-4000-8000-000000000005',
+          'Run the failing test.',
+          '2026-06-27T08:00:00.000Z',
+        ),
+        assistantToolMessage(
+          '00000000-0000-4000-8000-000000000006',
+          {
+            id: 'tool-validation-fail',
+            name: 'Bash',
+            input: {
+              command: 'bun test src/utils/reportTask.test.ts',
+            },
+          },
+          '2026-06-27T08:01:00.000Z',
+        ),
+        toolResultMessage(
+          '00000000-0000-4000-8000-000000000007',
+          'tool-validation-fail',
+          'Error calling tool (Bash): tests failed\nExit code 1',
+          '2026-06-27T08:01:03.000Z',
+          'Error calling tool (Bash): tests failed\nExit code 1',
+          true,
+        ),
+      ],
+      async transcriptPath => {
+        const report = await buildTaskReport({
+          transcriptPath,
+          git: async () => gitMetadata({ dirty: false, changedFiles: [] }),
+        })
+
+        expect(report.commands).toEqual([
+          expect.objectContaining({
+            toolUseId: 'tool-validation-fail',
+            command: 'bun test src/utils/reportTask.test.ts',
+            status: 'error',
+            exitCode: 1,
+          }),
+        ])
+        expect(report.validations).toEqual([
+          expect.objectContaining({
+            toolUseId: 'tool-validation-fail',
+            command: 'bun test src/utils/reportTask.test.ts',
+            status: 'error',
+            exitCode: 1,
+          }),
+        ])
+        expect(report.errors).toEqual([
+          expect.objectContaining({
+            source: 'tool',
+            toolUseId: 'tool-validation-fail',
+            toolName: 'Bash',
+          }),
+        ])
+      },
+    )
+  })
+
+  test('treats nonzero observed exit code as an error status', async () => {
+    await withTempTranscript(
+      [
+        userMessage(
+          '00000000-0000-4000-8000-000000000025',
+          'Run a command.',
+          '2026-06-27T08:00:00.000Z',
+        ),
+        assistantToolMessage(
+          '00000000-0000-4000-8000-000000000026',
+          {
+            id: 'tool-command-nonzero',
+            name: 'Bash',
+            input: {
+              command: 'node missing.js',
+            },
+          },
+          '2026-06-27T08:01:00.000Z',
+        ),
+        toolResultMessage(
+          '00000000-0000-4000-8000-000000000027',
+          'tool-command-nonzero',
+          'Exit code 1',
+          '2026-06-27T08:01:03.000Z',
+          'Exit code 1',
+        ),
+      ],
+      async transcriptPath => {
+        const report = await buildTaskReport({
+          transcriptPath,
+          git: async () => gitMetadata({ dirty: false, changedFiles: [] }),
+        })
+
+        expect(report.toolUses).toEqual([
+          expect.objectContaining({
+            id: 'tool-command-nonzero',
+            status: 'error',
+          }),
+        ])
+        expect(report.commands).toEqual([
+          expect.objectContaining({
+            toolUseId: 'tool-command-nonzero',
+            status: 'error',
+            exitCode: 1,
+          }),
+        ])
+      },
+    )
+  })
+
+  test('classifies validation commands from the raw Bash command before truncation', async () => {
+    const longPrefix = 'echo setup && '.repeat(20)
+    const rawCommand = `${longPrefix}bun test src/utils/reportTask.test.ts`
+
+    await withTempTranscript(
+      [
+        userMessage(
+          '00000000-0000-4000-8000-000000000019',
+          'Run the long validation command.',
+          '2026-06-27T08:00:00.000Z',
+        ),
+        assistantToolMessage(
+          '00000000-0000-4000-8000-000000000020',
+          {
+            id: 'tool-validation-long',
+            name: 'Bash',
+            input: {
+              command: rawCommand,
+            },
+          },
+          '2026-06-27T08:01:00.000Z',
+        ),
+        toolResultMessage(
+          '00000000-0000-4000-8000-000000000021',
+          'tool-validation-long',
+          'tests passed',
+          '2026-06-27T08:01:03.000Z',
+          { stdout: 'tests passed\n', stderr: '', interrupted: false },
+        ),
+      ],
+      async transcriptPath => {
+        const report = await buildTaskReport({
+          transcriptPath,
+          git: async () => gitMetadata({ dirty: false, changedFiles: [] }),
+          maxPreviewChars: 32,
+        })
+
+        expect(report.commands[0]?.command).not.toContain('bun test')
+        expect(report.validations).toEqual([
+          expect.objectContaining({
+            toolUseId: 'tool-validation-long',
+            status: 'success',
+          }),
+        ])
+        expect(report.warnings).not.toContain(
+          'No validation commands were observed in this transcript.',
+        )
+      },
+    )
+  })
+
+  test('captures file changes and branch metadata when available', async () => {
+    await withTempTranscript(
+      [
+        {
+          type: 'custom-title',
+          sessionId,
+          customTitle: 'Generate deterministic task reports',
+        },
+        {
+          type: 'worktree-state',
+          sessionId,
+          worktreeSession: {
+            originalCwd: cwd,
+            worktreePath: '/workspace/openclaude-report',
+            worktreeName: 'openclaude-report',
+            worktreeBranch: 'feat/session-task-report-json',
+            originalBranch: 'main',
+            originalHeadCommit: '13cf30af',
+            sessionId,
+          },
+        },
+        {
+          type: 'pr-link',
+          sessionId,
+          prNumber: 456,
+          prUrl: 'https://github.com/Gitlawb/openclaude/pull/456',
+          prRepository: 'Gitlawb/openclaude',
+          timestamp: '2026-06-27T08:01:00.000Z',
+        },
+        userMessage(
+          '00000000-0000-4000-8000-000000000008',
+          'Update src/report.ts for https://github.com/Gitlawb/openclaude/issues/123.',
+          '2026-06-27T08:00:00.000Z',
+        ),
+        assistantToolMessage(
+          '00000000-0000-4000-8000-000000000009',
+          {
+            id: 'tool-edit',
+            name: 'Edit',
+            input: {
+              file_path: `${cwd}/src/report.ts`,
+              old_string: 'old',
+              new_string: 'new',
+            },
+          },
+          '2026-06-27T08:02:00.000Z',
+        ),
+        toolResultMessage(
+          '00000000-0000-4000-8000-000000000010',
+          'tool-edit',
+          'Updated src/report.ts',
+          '2026-06-27T08:02:02.000Z',
+          { filePath: `${cwd}/src/report.ts` },
+        ),
+      ],
+      async transcriptPath => {
+        const report = await buildTaskReport({
+          transcriptPath,
+          git: async () =>
+            gitMetadata({
+              changedFiles: ['src/report.ts', 'src/report.test.ts'],
+            }),
+        })
+
+        expect(report.session.name).toBe('Generate deterministic task reports')
+        expect(report.branch.transcriptBranch).toBe('feat/source-branch')
+        expect(report.branch.worktree).toEqual(
+          expect.objectContaining({
+            branch: 'feat/session-task-report-json',
+            originalBranch: 'main',
+            originalHead: '13cf30af',
+          }),
+        )
+        expect(report.branch.pullRequest).toEqual({
+          number: 456,
+          repository: 'Gitlawb/openclaude',
+          url: 'https://github.com/Gitlawb/openclaude/pull/456',
+        })
+        expect(report.git).toEqual(
+          expect.objectContaining({
+            status: 'available',
+            branch: 'feat/session-task-report-json',
+            head: '13cf30af',
+            dirty: true,
+            changedFiles: ['src/report.test.ts', 'src/report.ts'],
+          }),
+        )
+        expect(report.changedFiles).toEqual([
+          { path: 'src/report.test.ts', sources: ['git'] },
+          { path: 'src/report.ts', sources: ['git', 'tool'] },
+        ])
+        expect(report.linkedReferences).toEqual([
+          {
+            kind: 'issue',
+            number: 123,
+            repository: 'Gitlawb/openclaude',
+            url: 'https://github.com/Gitlawb/openclaude/issues/123',
+          },
+          {
+            kind: 'pull_request',
+            number: 456,
+            repository: 'Gitlawb/openclaude',
+            url: 'https://github.com/Gitlawb/openclaude/pull/456',
+          },
+        ])
+      },
+    )
+  })
+
+  test('prefers transcript cwd over caller cwd for git metadata', async () => {
+    const callerCwd = '/workspace/different-project'
+    const observedGitCwds: string[] = []
+
+    await withTempTranscript(
+      [
+        userMessage(
+          '00000000-0000-4000-8000-000000000015',
+          'Report the session.',
+          '2026-06-27T08:00:00.000Z',
+        ),
+      ],
+      async transcriptPath => {
+        const report = await buildTaskReport({
+          transcriptPath,
+          cwd: callerCwd,
+          git: async gitCwd => {
+            observedGitCwds.push(gitCwd)
+            return gitMetadata({
+              cwd: gitCwd,
+              branch: 'feat/session-cwd',
+              dirty: false,
+              changedFiles: [],
+            })
+          },
+        })
+
+        expect(observedGitCwds).toEqual([cwd])
+        expect(report.git).toEqual(
+          expect.objectContaining({
+            cwd,
+            branch: 'feat/session-cwd',
+            dirty: false,
+          }),
+        )
+      },
+    )
+  })
+
+  test('does not serialize file read result content in tool summaries', async () => {
+    const fileBody = 'PRIVATE_FILE_BODY_SHOULD_NOT_APPEAR'
+
+    await withTempTranscript(
+      [
+        userMessage(
+          '00000000-0000-4000-8000-000000000016',
+          'Inspect a file.',
+          '2026-06-27T08:00:00.000Z',
+        ),
+        assistantToolMessage(
+          '00000000-0000-4000-8000-000000000017',
+          {
+            id: 'tool-read',
+            name: 'Read',
+            input: {
+              file_path: 'src/secret.ts',
+            },
+          },
+          '2026-06-27T08:01:00.000Z',
+        ),
+        toolResultMessage(
+          '00000000-0000-4000-8000-000000000018',
+          'tool-read',
+          fileBody,
+          '2026-06-27T08:01:01.000Z',
+          { filePath: 'src/secret.ts', content: fileBody },
+        ),
+      ],
+      async transcriptPath => {
+        const report = await buildTaskReport({
+          transcriptPath,
+          git: async () => gitMetadata({ dirty: false, changedFiles: [] }),
+        })
+        const serialized = formatTaskReportAsJson(report)
+
+        expect(serialized).not.toContain(fileBody)
+        expect(report.toolUses).toEqual([
+          expect.objectContaining({
+            id: 'tool-read',
+            name: 'Read',
+            files: ['src/secret.ts'],
+          }),
+        ])
+        expect(report.toolUses[0]).not.toHaveProperty('resultSummary')
+      },
+    )
+  })
+
+  test('does not collect linked references from tool result content', async () => {
+    await withTempTranscript(
+      [
+        userMessage(
+          '00000000-0000-4000-8000-000000000022',
+          'Summarize the session.',
+          '2026-06-27T08:00:00.000Z',
+        ),
+        toolResultMessage(
+          '00000000-0000-4000-8000-000000000023',
+          'tool-read',
+          'File body mentions https://github.com/Gitlawb/openclaude/issues/999.',
+          '2026-06-27T08:01:01.000Z',
+        ),
+      ],
+      async transcriptPath => {
+        const report = await buildTaskReport({
+          transcriptPath,
+          git: async () => gitMetadata({ dirty: false, changedFiles: [] }),
+        })
+
+        expect(report.linkedReferences).toEqual([])
+      },
+    )
+  })
+
+  test('redacts credential-shaped strings and truncates large outputs deterministically', async () => {
+    const secret = 'sk-ant-secret-token'
+    const longOutput = `${'x'.repeat(200)} ${secret}`
+
+    await withTempTranscript(
+      [
+        userMessage(
+          '00000000-0000-4000-8000-000000000011',
+          `Please use token ghp_1234567890abcdef to test redaction.`,
+          '2026-06-27T08:00:00.000Z',
+        ),
+        assistantToolMessage(
+          '00000000-0000-4000-8000-000000000012',
+          {
+            id: 'tool-secret',
+            name: 'Bash',
+            input: {
+              command: `curl -H "Authorization: Bearer ${secret}" https://example.test`,
+            },
+          },
+          '2026-06-27T08:01:00.000Z',
+        ),
+        toolResultMessage(
+          '00000000-0000-4000-8000-000000000013',
+          'tool-secret',
+          longOutput,
+          '2026-06-27T08:01:01.000Z',
+          { stdout: longOutput, stderr: '', interrupted: false },
+        ),
+      ],
+      async transcriptPath => {
+        const report = await buildTaskReport({
+          transcriptPath,
+          git: async () => gitMetadata({ dirty: false, changedFiles: [] }),
+          maxPreviewChars: 64,
+        })
+        const serialized = formatTaskReportAsJson(report)
+
+        expect(report.redaction).toEqual({
+          mode: 'best_effort',
+          maxPreviewChars: 64,
+        })
+        expect(serialized).toBe(formatTaskReportAsJson(report))
+        expect(serialized.endsWith('\n')).toBe(false)
+        expect(serialized).not.toContain(secret)
+        expect(serialized).not.toContain('ghp_1234567890abcdef')
+        expect(serialized).toContain('[redacted]')
+        expect(report.commands[0]?.stdout?.preview.length).toBeLessThanOrEqual(
+          64,
+        )
+        expect(report.commands[0]?.stdout?.truncated).toBe(true)
+      },
+    )
+  })
+
+  test('normalizes max preview chars in report metadata', async () => {
+    await withTempTranscript(
+      [
+        userMessage(
+          '00000000-0000-4000-8000-000000000024',
+          'abcdef',
+          '2026-06-27T08:00:00.000Z',
+        ),
+      ],
+      async transcriptPath => {
+        const report = await buildTaskReport({
+          transcriptPath,
+          git: false,
+          maxPreviewChars: 0,
+        })
+
+        expect(report.redaction.maxPreviewChars).toBe(1)
+        expect(report.session.initialRequest).toBe('a')
+      },
+    )
+  })
+
+  test('omits dirty status when git status cannot be collected', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'openclaude-task-report-git-'))
+    const binDir = join(dir, 'bin')
+    const repoDir = join(dir, 'repo')
+    const gitPath = join(binDir, 'git')
+    const previousPath = process.env.PATH
+
+    try {
+      mkdirSync(binDir)
+      mkdirSync(repoDir)
+      writeFileSync(
+        gitPath,
+        `#!/bin/sh
+case "$*" in
+  "--no-optional-locks rev-parse --is-inside-work-tree")
+    echo true
+    exit 0
+    ;;
+  "--no-optional-locks branch --show-current")
+    echo feat/report
+    exit 0
+    ;;
+  "--no-optional-locks rev-parse --short=12 HEAD")
+    echo 13cf30afa469
+    exit 0
+    ;;
+  "--no-optional-locks status --porcelain=v1")
+    echo "status failed" >&2
+    exit 1
+    ;;
+esac
+exit 2
+`,
+      )
+      chmodSync(gitPath, 0o755)
+      process.env.PATH = `${binDir}${delimiter}${previousPath ?? ''}`
+
+      const metadata = await collectTaskReportGitMetadata(repoDir)
+
+      expect(metadata).toEqual({
+        status: 'available',
+        cwd: repoDir,
+        branch: 'feat/report',
+        head: '13cf30afa469',
+        changedFiles: [],
+        error: 'status failed',
+      })
+      expect(metadata).not.toHaveProperty('dirty')
+    } finally {
+      if (previousPath === undefined) {
+        delete process.env.PATH
+      } else {
+        process.env.PATH = previousPath
+      }
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  test('degrades gracefully for malformed and old transcripts', async () => {
+    await withTempTranscript(
+      [
+        '{not valid json',
+        {
+          type: 'summary',
+          leafUuid: '00000000-0000-4000-8000-000000000014',
+          summary: 'old transcript metadata',
+        },
+      ],
+      async transcriptPath => {
+        const report = await buildTaskReport({
+          transcriptPath,
+          git: async () => ({
+            status: 'unavailable',
+            cwd,
+            changedFiles: [],
+            error: 'not a git repository',
+          }),
+        })
+
+        expect(report.session.id).toBe(sessionId)
+        expect(report.toolUses).toEqual([])
+        expect(report.commands).toEqual([])
+        expect(report.warnings).toContain(
+          'Skipped 1 malformed transcript line.',
+        )
+        expect(report.warnings).toContain(
+          'No validation commands were observed in this transcript.',
+        )
+      },
+    )
+  })
+})

--- a/src/utils/reportTask.test.ts
+++ b/src/utils/reportTask.test.ts
@@ -678,6 +678,14 @@ describe('task report generation', () => {
             status: 'error',
           }),
         ])
+        expect(report.commands).toEqual([
+          expect.objectContaining({
+            toolUseId: 'tool-foreground-validation-conflict',
+            command: 'bun test src/utils/reportTask.test.ts',
+            status: 'error',
+            exitCode: 2,
+          }),
+        ])
         expect(report.validations).toEqual([
           expect.objectContaining({
             toolUseId: 'tool-foreground-validation-conflict',

--- a/src/utils/reportTask.test.ts
+++ b/src/utils/reportTask.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'bun:test'
 import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
-import { tmpdir } from 'node:os'
+import { homedir, tmpdir } from 'node:os'
 import { join } from 'node:path'
 
 import {
@@ -9,7 +9,6 @@ import {
   formatTaskReportAsJson,
   type TaskReportGitMetadata,
 } from './taskReport.js'
-import { redactHomePath } from './diagnostics/redaction.js'
 
 const sessionId = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa'
 const cwd = '/workspace/openclaude'
@@ -880,7 +879,7 @@ describe('task report generation', () => {
   })
 
   test('omits dirty status when git status cannot be collected', async () => {
-    const repoDir = join(tmpdir(), 'openclaude-task-report-git-repo')
+    const repoDir = join(homedir(), 'openclaude-task-report-git-repo')
     const calls: string[] = []
 
     const metadata = await collectTaskReportGitMetadata(
@@ -919,7 +918,7 @@ describe('task report generation', () => {
     )
     expect(metadata).toEqual({
       status: 'available',
-      cwd: redactHomePath(repoDir),
+      cwd: join('~', 'openclaude-task-report-git-repo'),
       branch: 'feat/report',
       head: '13cf30afa469',
       changedFiles: [],

--- a/src/utils/reportTask.test.ts
+++ b/src/utils/reportTask.test.ts
@@ -484,6 +484,145 @@ describe('task report generation', () => {
     )
   })
 
+  test('reconciles completed backgrounded validation notifications', async () => {
+    await withTempTranscript(
+      [
+        userMessage(
+          '00000000-0000-4000-8000-000000000084',
+          'Run tests in the background.',
+          '2026-06-27T08:00:00.000Z',
+        ),
+        assistantToolMessage(
+          '00000000-0000-4000-8000-000000000085',
+          {
+            id: 'tool-background-validation-complete',
+            name: 'Bash',
+            input: {
+              command: 'bun test src/utils/reportTask.test.ts',
+              run_in_background: true,
+            },
+          },
+          '2026-06-27T08:01:00.000Z',
+        ),
+        toolResultMessage(
+          '00000000-0000-4000-8000-000000000086',
+          'tool-background-validation-complete',
+          'Command running in background with ID: bg-report-tests.',
+          '2026-06-27T08:01:03.000Z',
+          {
+            stdout: '',
+            stderr: '',
+            interrupted: false,
+            backgroundTaskId: 'bg-report-tests',
+          },
+        ),
+        userMessage(
+          '00000000-0000-4000-8000-000000000087',
+          [
+            {
+              type: 'text',
+              text: `<task-notification>
+<task-id>bg-report-tests</task-id>
+<tool-use-id>tool-background-validation-complete</tool-use-id>
+<output-file>/tmp/bg-report-tests.txt</output-file>
+<status>completed</status>
+<summary>Background command "bun test src/utils/reportTask.test.ts" completed (exit code 0)</summary>
+</task-notification>`,
+            },
+          ],
+          '2026-06-27T08:02:03.000Z',
+        ),
+      ],
+      async transcriptPath => {
+        const report = await buildTaskReport({
+          transcriptPath,
+          git: async () => gitMetadata({ dirty: false, changedFiles: [] }),
+        })
+
+        expect(report.toolUses).toEqual([
+          expect.objectContaining({
+            id: 'tool-background-validation-complete',
+            status: 'success',
+          }),
+        ])
+        expect(report.validations).toEqual([
+          expect.objectContaining({
+            toolUseId: 'tool-background-validation-complete',
+            command: 'bun test src/utils/reportTask.test.ts',
+            status: 'success',
+          }),
+        ])
+      },
+    )
+  })
+
+  test('reconciles failed backgrounded validation notifications', async () => {
+    await withTempTranscript(
+      [
+        userMessage(
+          '00000000-0000-4000-8000-000000000088',
+          'Run checks in the background.',
+          '2026-06-27T08:00:00.000Z',
+        ),
+        assistantToolMessage(
+          '00000000-0000-4000-8000-000000000089',
+          {
+            id: 'tool-background-validation-fail',
+            name: 'PowerShell',
+            input: {
+              command: 'bun run typecheck',
+              run_in_background: true,
+            },
+          },
+          '2026-06-27T08:01:00.000Z',
+        ),
+        toolResultMessage(
+          '00000000-0000-4000-8000-000000000090',
+          'tool-background-validation-fail',
+          'Command running in background with ID: bg-typecheck.',
+          '2026-06-27T08:01:03.000Z',
+          {
+            stdout: '',
+            stderr: '',
+            interrupted: false,
+            backgroundTaskId: 'bg-typecheck',
+          },
+        ),
+        userMessage(
+          '00000000-0000-4000-8000-000000000091',
+          `<task-notification>
+<task-id>bg-typecheck</task-id>
+<tool-use-id>tool-background-validation-fail</tool-use-id>
+<output-file>/tmp/bg-typecheck.txt</output-file>
+<status>failed</status>
+<summary>Background command "bun run typecheck" failed with exit code 2</summary>
+</task-notification>`,
+          '2026-06-27T08:02:03.000Z',
+        ),
+      ],
+      async transcriptPath => {
+        const report = await buildTaskReport({
+          transcriptPath,
+          git: async () => gitMetadata({ dirty: false, changedFiles: [] }),
+        })
+
+        expect(report.toolUses).toEqual([
+          expect.objectContaining({
+            id: 'tool-background-validation-fail',
+            status: 'error',
+          }),
+        ])
+        expect(report.validations).toEqual([
+          expect.objectContaining({
+            toolUseId: 'tool-background-validation-fail',
+            command: 'bun run typecheck',
+            status: 'error',
+          }),
+        ])
+      },
+    )
+  })
+
   test('classifies validation commands from the raw Bash command before truncation', async () => {
     const longPrefix = 'echo setup && '.repeat(20)
     const rawCommand = `${longPrefix}bun test src/utils/reportTask.test.ts`

--- a/src/utils/reportTask.test.ts
+++ b/src/utils/reportTask.test.ts
@@ -324,6 +324,50 @@ describe('task report generation', () => {
     )
   })
 
+  test('captures numeric structured exit codes from observed Bash results', async () => {
+    await withTempTranscript(
+      [
+        userMessage(
+          '00000000-0000-4000-8000-000000000028',
+          'Run a structured command.',
+          '2026-06-27T08:00:00.000Z',
+        ),
+        assistantToolMessage(
+          '00000000-0000-4000-8000-000000000029',
+          {
+            id: 'tool-command-structured-exit',
+            name: 'Bash',
+            input: {
+              command: 'node missing.js',
+            },
+          },
+          '2026-06-27T08:01:00.000Z',
+        ),
+        toolResultMessage(
+          '00000000-0000-4000-8000-000000000030',
+          'tool-command-structured-exit',
+          'No textual exit code here',
+          '2026-06-27T08:01:03.000Z',
+          { stdout: '', stderr: 'missing\n', exitCode: 2 },
+        ),
+      ],
+      async transcriptPath => {
+        const report = await buildTaskReport({
+          transcriptPath,
+          git: async () => gitMetadata({ dirty: false, changedFiles: [] }),
+        })
+
+        expect(report.commands).toEqual([
+          expect.objectContaining({
+            toolUseId: 'tool-command-structured-exit',
+            status: 'error',
+            exitCode: 2,
+          }),
+        ])
+      },
+    )
+  })
+
   test('classifies validation commands from the raw Bash command before truncation', async () => {
     const longPrefix = 'echo setup && '.repeat(20)
     const rawCommand = `${longPrefix}bun test src/utils/reportTask.test.ts`
@@ -373,6 +417,54 @@ describe('task report generation', () => {
         )
       },
     )
+  })
+
+  test('classifies documented web checks as validations', async () => {
+    for (const command of ['bun run web:typecheck', 'bun run web:build']) {
+      await withTempTranscript(
+        [
+          userMessage(
+            `00000000-0000-4000-8000-${command.endsWith('build') ? '000000000032' : '000000000031'}`,
+            `Run ${command}.`,
+            '2026-06-27T08:00:00.000Z',
+          ),
+          assistantToolMessage(
+            `00000000-0000-4000-8000-${command.endsWith('build') ? '000000000034' : '000000000033'}`,
+            {
+              id: `tool-${command.replaceAll(/[^A-Za-z0-9]/g, '-')}`,
+              name: 'Bash',
+              input: {
+                command,
+              },
+            },
+            '2026-06-27T08:01:00.000Z',
+          ),
+          toolResultMessage(
+            `00000000-0000-4000-8000-${command.endsWith('build') ? '000000000036' : '000000000035'}`,
+            `tool-${command.replaceAll(/[^A-Za-z0-9]/g, '-')}`,
+            'passed',
+            '2026-06-27T08:01:03.000Z',
+            { stdout: 'passed\n', stderr: '', exitCode: 0 },
+          ),
+        ],
+        async transcriptPath => {
+          const report = await buildTaskReport({
+            transcriptPath,
+            git: async () => gitMetadata({ dirty: false, changedFiles: [] }),
+          })
+
+          expect(report.validations).toEqual([
+            expect.objectContaining({
+              command,
+              status: 'success',
+            }),
+          ])
+          expect(report.warnings).not.toContain(
+            'No validation commands were observed in this transcript.',
+          )
+        },
+      )
+    }
   })
 
   test('captures file changes and branch metadata when available', async () => {
@@ -479,6 +571,47 @@ describe('task report generation', () => {
             repository: 'Gitlawb/openclaude',
             url: 'https://github.com/Gitlawb/openclaude/pull/456',
           },
+        ])
+      },
+    )
+  })
+
+  test('normalizes in-repo paths whose relative path starts with dots', async () => {
+    await withTempTranscript(
+      [
+        userMessage(
+          '00000000-0000-4000-8000-000000000037',
+          'Update a dot-prefixed fixture path.',
+          '2026-06-27T08:00:00.000Z',
+        ),
+        assistantToolMessage(
+          '00000000-0000-4000-8000-000000000038',
+          {
+            id: 'tool-dot-fixture',
+            name: 'Edit',
+            input: {
+              file_path: `${cwd}/..fixtures/report.ts`,
+              old_string: 'old',
+              new_string: 'new',
+            },
+          },
+          '2026-06-27T08:01:00.000Z',
+        ),
+        toolResultMessage(
+          '00000000-0000-4000-8000-000000000039',
+          'tool-dot-fixture',
+          'Updated fixture',
+          '2026-06-27T08:01:02.000Z',
+        ),
+      ],
+      async transcriptPath => {
+        const report = await buildTaskReport({
+          transcriptPath,
+          git: async () => gitMetadata({ dirty: false, changedFiles: [] }),
+        })
+
+        expect(report.changedFiles).toEqual([
+          { path: '..fixtures/report.ts', sources: ['tool'] },
         ])
       },
     )
@@ -680,6 +813,7 @@ describe('task report generation', () => {
     const binDir = join(dir, 'bin')
     const repoDir = join(dir, 'repo')
     const gitPath = join(binDir, 'git')
+    const gitCmdPath = join(binDir, 'git.cmd')
     const previousPath = process.env.PATH
 
     try {
@@ -709,7 +843,32 @@ esac
 exit 2
 `,
       )
-      chmodSync(gitPath, 0o755)
+      writeFileSync(
+        gitCmdPath,
+        `@echo off
+set args=%*
+if "%args%"=="--no-optional-locks rev-parse --is-inside-work-tree" (
+  echo true
+  exit /b 0
+)
+if "%args%"=="--no-optional-locks branch --show-current" (
+  echo feat/report
+  exit /b 0
+)
+if "%args%"=="--no-optional-locks rev-parse --short=12 HEAD" (
+  echo 13cf30afa469
+  exit /b 0
+)
+if "%args%"=="--no-optional-locks status --porcelain=v1" (
+  echo status failed 1>&2
+  exit /b 1
+)
+exit /b 2
+`,
+      )
+      if (process.platform !== 'win32') {
+        chmodSync(gitPath, 0o755)
+      }
       process.env.PATH = `${binDir}${delimiter}${previousPath ?? ''}`
 
       const metadata = await collectTaskReportGitMetadata(repoDir)

--- a/src/utils/reportTask.test.ts
+++ b/src/utils/reportTask.test.ts
@@ -9,6 +9,7 @@ import {
   formatTaskReportAsJson,
   type TaskReportGitMetadata,
 } from './taskReport.js'
+import { redactHomePath } from './diagnostics/redaction.js'
 
 const sessionId = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa'
 const cwd = '/workspace/openclaude'
@@ -918,7 +919,7 @@ describe('task report generation', () => {
     )
     expect(metadata).toEqual({
       status: 'available',
-      cwd: repoDir,
+      cwd: redactHomePath(repoDir),
       branch: 'feat/report',
       head: '13cf30afa469',
       changedFiles: [],

--- a/src/utils/reportTask.test.ts
+++ b/src/utils/reportTask.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from 'bun:test'
-import { chmodSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
-import { delimiter, join } from 'node:path'
+import { join } from 'node:path'
 
 import {
   buildTaskReport,
@@ -617,6 +617,76 @@ describe('task report generation', () => {
     )
   })
 
+  test('normalizes Windows-style tool paths before merging with git paths', async () => {
+    const windowsCwd = 'C:\\workspace\\openclaude'
+
+    await withTempTranscript(
+      [
+        {
+          ...userMessage(
+            '00000000-0000-4000-8000-000000000040',
+            'Update Windows paths.',
+            '2026-06-27T08:00:00.000Z',
+          ),
+          cwd: windowsCwd,
+        },
+        assistantToolMessage(
+          '00000000-0000-4000-8000-000000000041',
+          {
+            id: 'tool-windows-path',
+            name: 'Edit',
+            input: {
+              file_path: 'C:\\workspace\\openclaude\\src\\report.ts',
+              old_string: 'old',
+              new_string: 'new',
+            },
+          },
+          '2026-06-27T08:01:00.000Z',
+        ),
+        toolResultMessage(
+          '00000000-0000-4000-8000-000000000042',
+          'tool-windows-path',
+          'Updated report',
+          '2026-06-27T08:01:02.000Z',
+        ),
+        assistantToolMessage(
+          '00000000-0000-4000-8000-000000000043',
+          {
+            id: 'tool-windows-dot-path',
+            name: 'Edit',
+            input: {
+              file_path: 'C:\\workspace\\openclaude\\..fixtures\\report.ts',
+              old_string: 'old',
+              new_string: 'new',
+            },
+          },
+          '2026-06-27T08:02:00.000Z',
+        ),
+        toolResultMessage(
+          '00000000-0000-4000-8000-000000000044',
+          'tool-windows-dot-path',
+          'Updated fixture',
+          '2026-06-27T08:02:02.000Z',
+        ),
+      ],
+      async transcriptPath => {
+        const report = await buildTaskReport({
+          transcriptPath,
+          git: async () =>
+            gitMetadata({
+              cwd: windowsCwd,
+              changedFiles: ['src/report.ts'],
+            }),
+        })
+
+        expect(report.changedFiles).toEqual([
+          { path: '..fixtures/report.ts', sources: ['tool'] },
+          { path: 'src/report.ts', sources: ['git', 'tool'] },
+        ])
+      },
+    )
+  })
+
   test('prefers transcript cwd over caller cwd for git metadata', async () => {
     const callerCwd = '/workspace/different-project'
     const observedGitCwds: string[] = []
@@ -809,87 +879,52 @@ describe('task report generation', () => {
   })
 
   test('omits dirty status when git status cannot be collected', async () => {
-    const dir = mkdtempSync(join(tmpdir(), 'openclaude-task-report-git-'))
-    const binDir = join(dir, 'bin')
-    const repoDir = join(dir, 'repo')
-    const gitPath = join(binDir, 'git')
-    const gitCmdPath = join(binDir, 'git.cmd')
-    const previousPath = process.env.PATH
+    const repoDir = join(tmpdir(), 'openclaude-task-report-git-repo')
+    const calls: string[] = []
 
-    try {
-      mkdirSync(binDir)
-      mkdirSync(repoDir)
-      writeFileSync(
-        gitPath,
-        `#!/bin/sh
-case "$*" in
-  "--no-optional-locks rev-parse --is-inside-work-tree")
-    echo true
-    exit 0
-    ;;
-  "--no-optional-locks branch --show-current")
-    echo feat/report
-    exit 0
-    ;;
-  "--no-optional-locks rev-parse --short=12 HEAD")
-    echo 13cf30afa469
-    exit 0
-    ;;
-  "--no-optional-locks status --porcelain=v1")
-    echo "status failed" >&2
-    exit 1
-    ;;
-esac
-exit 2
-`,
-      )
-      writeFileSync(
-        gitCmdPath,
-        `@echo off
-set args=%*
-if "%args%"=="--no-optional-locks rev-parse --is-inside-work-tree" (
-  echo true
-  exit /b 0
-)
-if "%args%"=="--no-optional-locks branch --show-current" (
-  echo feat/report
-  exit /b 0
-)
-if "%args%"=="--no-optional-locks rev-parse --short=12 HEAD" (
-  echo 13cf30afa469
-  exit /b 0
-)
-if "%args%"=="--no-optional-locks status --porcelain=v1" (
-  echo status failed 1>&2
-  exit /b 1
-)
-exit /b 2
-`,
-      )
-      if (process.platform !== 'win32') {
-        chmodSync(gitPath, 0o755)
+    const metadata = await collectTaskReportGitMetadata(
+      repoDir,
+      async (gitCwd, args) => {
+        expect(gitCwd).toBe(repoDir)
+        const command = args.join(' ')
+        calls.push(command)
+
+        switch (command) {
+          case '--no-optional-locks rev-parse --is-inside-work-tree':
+            return { stdout: 'true', stderr: '', code: 0 }
+          case '--no-optional-locks branch --show-current':
+            return { stdout: 'feat/report', stderr: '', code: 0 }
+          case '--no-optional-locks rev-parse --short=12 HEAD':
+            return { stdout: '13cf30afa469', stderr: '', code: 0 }
+          case '--no-optional-locks status --porcelain=v1':
+            return { stdout: '', stderr: 'status failed', code: 1 }
+          default:
+            return {
+              stdout: '',
+              stderr: `unexpected command: ${command}`,
+              code: 2,
+            }
+        }
       }
-      process.env.PATH = `${binDir}${delimiter}${previousPath ?? ''}`
+    )
 
-      const metadata = await collectTaskReportGitMetadata(repoDir)
-
-      expect(metadata).toEqual({
-        status: 'available',
-        cwd: repoDir,
-        branch: 'feat/report',
-        head: '13cf30afa469',
-        changedFiles: [],
-        error: 'status failed',
-      })
-      expect(metadata).not.toHaveProperty('dirty')
-    } finally {
-      if (previousPath === undefined) {
-        delete process.env.PATH
-      } else {
-        process.env.PATH = previousPath
-      }
-      rmSync(dir, { recursive: true, force: true })
-    }
+    expect(calls).toEqual(
+      expect.arrayContaining([
+        '--no-optional-locks rev-parse --is-inside-work-tree',
+        '--no-optional-locks branch --show-current',
+        '--no-optional-locks rev-parse --short=12 HEAD',
+        '--no-optional-locks status --porcelain=v1',
+      ]),
+    )
+    expect(metadata).toEqual({
+      status: 'available',
+      cwd: repoDir,
+      branch: 'feat/report',
+      head: '13cf30afa469',
+      changedFiles: [],
+      error: 'status failed',
+    })
+    expect(metadata).not.toHaveProperty('dirty')
   })
 
   test('degrades gracefully for malformed and old transcripts', async () => {

--- a/src/utils/reportTask.test.ts
+++ b/src/utils/reportTask.test.ts
@@ -535,6 +535,59 @@ describe('task report generation', () => {
     )
   })
 
+  test('classifies validation commands inside quoted shell wrappers', async () => {
+    const commands = [
+      "bash -lc 'bun run check'",
+      'powershell -NoProfile -Command "bun run typecheck"',
+    ]
+
+    for (const [index, command] of commands.entries()) {
+      await withTempTranscript(
+        [
+          userMessage(
+            `00000000-0000-4000-8000-${String(78 + index * 3).padStart(12, '0')}`,
+            `Run ${command}.`,
+            '2026-06-27T08:00:00.000Z',
+          ),
+          assistantToolMessage(
+            `00000000-0000-4000-8000-${String(79 + index * 3).padStart(12, '0')}`,
+            {
+              id: `tool-wrapper-validation-${index}`,
+              name: 'Bash',
+              input: {
+                command,
+              },
+            },
+            '2026-06-27T08:01:00.000Z',
+          ),
+          toolResultMessage(
+            `00000000-0000-4000-8000-${String(80 + index * 3).padStart(12, '0')}`,
+            `tool-wrapper-validation-${index}`,
+            'passed',
+            '2026-06-27T08:01:03.000Z',
+            { stdout: 'passed\n', stderr: '', exitCode: 0 },
+          ),
+        ],
+        async transcriptPath => {
+          const report = await buildTaskReport({
+            transcriptPath,
+            git: async () => gitMetadata({ dirty: false, changedFiles: [] }),
+          })
+
+          expect(report.validations).toEqual([
+            expect.objectContaining({
+              command,
+              status: 'success',
+            }),
+          ])
+          expect(report.warnings).not.toContain(
+            'No validation commands were observed in this transcript.',
+          )
+        },
+      )
+    }
+  })
+
   test('classifies documented package checks as validations', async () => {
     const commands = [
       'bun run web:typecheck',

--- a/src/utils/taskReport.ts
+++ b/src/utils/taskReport.ts
@@ -188,7 +188,7 @@ const FILE_CONTENT_TOOLS = new Set(['Read', 'Edit', 'Write', 'NotebookEdit'])
 const SHELL_COMMAND_TOOLS = new Set(['Bash', 'PowerShell'])
 
 const VALIDATION_COMMAND_PATTERNS = [
-  /\b(?:bun|npm|pnpm|yarn)\s+(?:run\s+)?(?:build:verified|doctor:runtime(?::json)?|hardening:(?:check|strict)|integrations:check|security:pr-scan|verify:privacy|web:(?:build|typecheck)|test(?::[A-Za-z0-9_-]+)?|typecheck(?::[A-Za-z0-9_-]+)?|build|check|lint|smoke)(?=$|[\s;&|)])/,
+  /\b(?:bun|npm|pnpm|yarn)\s+(?:run\s+)?(?:build:verified|doctor:runtime(?::json)?|hardening:(?:check|strict)|integrations:check|security:pr-scan|verify:privacy|web:(?:build|typecheck)|test(?::[A-Za-z0-9_-]+)?|typecheck(?::[A-Za-z0-9_-]+)?|build|check|lint|smoke)(?=$|[\s;&|)"'])/,
   /\bbun\s+test\b/,
   /\bgit\s+diff\s+--check\b/,
   /\bpython\s+-m\s+pytest\b/,

--- a/src/utils/taskReport.ts
+++ b/src/utils/taskReport.ts
@@ -1,4 +1,3 @@
-import { spawn } from 'node:child_process'
 import { mkdir, readFile, writeFile } from 'node:fs/promises'
 import {
   basename,
@@ -9,6 +8,8 @@ import {
   resolve,
   win32,
 } from 'node:path'
+
+import { execa } from 'execa'
 
 import {
   redactDiagnosticObject,
@@ -174,7 +175,7 @@ const MUTATING_FILE_TOOLS = new Set(['Edit', 'Write', 'NotebookEdit'])
 const FILE_CONTENT_TOOLS = new Set(['Read', 'Edit', 'Write', 'NotebookEdit'])
 
 const VALIDATION_COMMAND_PATTERNS = [
-  /\b(?:bun|npm|pnpm|yarn)\s+(?:run\s+)?(?:test(?::[A-Za-z0-9_-]+)?|typecheck(?::[A-Za-z0-9_-]+)?|build|smoke|check|lint|security:pr-scan)\b/,
+  /\b(?:bun|npm|pnpm|yarn)\s+(?:run\s+)?(?:test(?::[A-Za-z0-9_-]+)?|typecheck(?::[A-Za-z0-9_-]+)?|web:typecheck|web:build|build|smoke|check|lint|security:pr-scan)\b/,
   /\bbun\s+test\b/,
   /\bgit\s+diff\s+--check\b/,
   /\bpython\s+-m\s+pytest\b/,
@@ -750,6 +751,12 @@ function summarizeToolInput(
 
 function extractExitCode(result: ObservedToolResult | undefined): number | undefined {
   if (!result) return undefined
+  const structuredResult = recordValue(result.toolUseResult)
+  const structuredExitCode = numberValue(structuredResult?.exitCode)
+  if (structuredExitCode !== undefined) {
+    return structuredExitCode
+  }
+
   const parts = [
     unknownToString(result.content),
     unknownToString(result.toolUseResult),
@@ -935,9 +942,13 @@ function relativeWithinCwd(
 ): string | undefined {
   if (!isAbsolutePath(path) || !isAbsolutePath(cwd)) return undefined
   const relativePathValue = relativePath(cwd, path)
+  const isOutsideCwd =
+    relativePathValue === '..' ||
+    relativePathValue.startsWith('../') ||
+    relativePathValue.startsWith('..\\')
   if (
     !relativePathValue ||
-    relativePathValue.startsWith('..') ||
+    isOutsideCwd ||
     isAbsolutePath(relativePathValue)
   ) {
     return undefined
@@ -967,51 +978,38 @@ async function runGit(
   cwd: string,
   args: string[],
 ): Promise<{ stdout: string; stderr: string; code: number; error?: string }> {
-  const maxBuffer = 1_000_000
-  return new Promise(resolve => {
-    let stdout = ''
-    let stderr = ''
-    let resolved = false
-    const child = spawn('git', args, {
+  try {
+    const result = await execa('git', args, {
       cwd,
-      shell: false,
-      stdio: ['ignore', 'pipe', 'pipe'],
+      reject: false,
+      timeout: 3_000,
+      maxBuffer: 1_000_000,
     })
-    const finish = (
-      code: number,
-      extra?: { error?: string; stderr?: string },
-    ) => {
-      if (resolved) return
-      resolved = true
-      clearTimeout(timer)
-      resolve({
-        stdout,
-        stderr: extra?.stderr ?? stderr,
-        code,
-        ...(extra?.error ? { error: extra.error } : {}),
-      })
+    return {
+      stdout: result.stdout,
+      stderr: result.stderr,
+      code: result.exitCode ?? 0,
     }
-    const append = (current: string, chunk: Buffer) => {
-      if (current.length >= maxBuffer) return current
-      return `${current}${chunk.toString('utf8')}`.slice(0, maxBuffer)
+  } catch (error) {
+    const execaError = error as {
+      stdout?: unknown
+      stderr?: unknown
+      exitCode?: unknown
+      timedOut?: unknown
     }
-    const timer = setTimeout(() => {
-      child.kill('SIGTERM')
-      finish(124, { error: 'git command timed out' })
-    }, 3_000)
-    child.stdout?.on('data', chunk => {
-      stdout = append(stdout, chunk)
-    })
-    child.stderr?.on('data', chunk => {
-      stderr = append(stderr, chunk)
-    })
-    child.on('error', error => {
-      finish(1, { error: error.message })
-    })
-    child.on('close', code => {
-      finish(code ?? 1)
-    })
-  })
+    const message = error instanceof Error ? error.message : String(error)
+    return {
+      stdout: typeof execaError.stdout === 'string' ? execaError.stdout : '',
+      stderr: typeof execaError.stderr === 'string' ? execaError.stderr : '',
+      code:
+        typeof execaError.exitCode === 'number'
+          ? execaError.exitCode
+          : execaError.timedOut === true
+            ? 124
+            : 1,
+      error: execaError.timedOut === true ? 'git command timed out' : message,
+    }
+  }
 }
 
 function findSessionId(entries: JsonRecord[]): string | undefined {

--- a/src/utils/taskReport.ts
+++ b/src/utils/taskReport.ts
@@ -185,9 +185,10 @@ type ObservedToolResult = {
 
 const MUTATING_FILE_TOOLS = new Set(['Edit', 'Write', 'NotebookEdit'])
 const FILE_CONTENT_TOOLS = new Set(['Read', 'Edit', 'Write', 'NotebookEdit'])
+const SHELL_COMMAND_TOOLS = new Set(['Bash', 'PowerShell'])
 
 const VALIDATION_COMMAND_PATTERNS = [
-  /\b(?:bun|npm|pnpm|yarn)\s+(?:run\s+)?(?:test(?::[A-Za-z0-9_-]+)?|typecheck(?::[A-Za-z0-9_-]+)?|web:typecheck|web:build|build|smoke|check|lint|security:pr-scan)\b/,
+  /\b(?:bun|npm|pnpm|yarn)\s+(?:run\s+)?(?:build:verified|doctor:runtime(?::json)?|hardening:(?:check|strict)|integrations:check|security:pr-scan|verify:privacy|web:(?:build|typecheck)|test(?::[A-Za-z0-9_-]+)?|typecheck(?::[A-Za-z0-9_-]+)?|build|check|lint|smoke)(?=$|[\s;&|)])/,
   /\bbun\s+test\b/,
   /\bgit\s+diff\s+--check\b/,
   /\bpython\s+-m\s+pytest\b/,
@@ -248,8 +249,8 @@ export async function buildTaskReport(
     if (resultSummary) toolUse.resultSummary = resultSummary
     toolUses.push(toolUse)
 
-    if (observed.name === 'Bash') {
-      const rawCommand = extractBashCommand(observed.input)
+    if (isShellCommandTool(observed.name)) {
+      const rawCommand = extractShellCommand(observed.input)
       const command = buildCommandReport(
         observed,
         result,
@@ -634,7 +635,7 @@ function buildCommandReport(
   maxPreviewChars: number,
 ): TaskReportCommand | null {
   const input = recordValue(observed.input)
-  const rawCommand = extractBashCommand(observed.input)
+  const rawCommand = extractShellCommand(observed.input)
   if (!rawCommand) return null
 
   const structuredResult = recordValue(result?.toolUseResult)
@@ -665,7 +666,7 @@ function buildCommandReport(
   return command
 }
 
-function extractBashCommand(input: unknown): string | undefined {
+function extractShellCommand(input: unknown): string | undefined {
   const inputRecord = recordValue(input)
   return stringValue(inputRecord?.command)
 }
@@ -676,6 +677,7 @@ function getObservedStatus(
   if (!result) return 'unknown'
   const structuredResult = recordValue(result.toolUseResult)
   if (structuredResult?.interrupted === true) return 'cancelled'
+  if (stringValue(structuredResult?.backgroundTaskId)) return 'unknown'
   const exitCode = extractExitCode(result)
   if (exitCode !== undefined && exitCode !== 0) return 'error'
   if (result.isError) return 'error'
@@ -746,7 +748,7 @@ function summarizeToolInput(
 ): string | undefined {
   const record = recordValue(input)
   if (!record) return undefined
-  if (toolName === 'Bash') {
+  if (isShellCommandTool(toolName)) {
     const command = stringValue(record.command)
     return command ? truncateText(redact(command), maxPreviewChars).preview : undefined
   }
@@ -971,6 +973,10 @@ function relativeWithinCwd(
 
 function isValidationCommand(command: string): boolean {
   return VALIDATION_COMMAND_PATTERNS.some(pattern => pattern.test(command))
+}
+
+function isShellCommandTool(toolName: string): boolean {
+  return SHELL_COMMAND_TOOLS.has(toolName)
 }
 
 function parseGitStatusChangedFiles(stdout: string): string[] {

--- a/src/utils/taskReport.ts
+++ b/src/utils/taskReport.ts
@@ -1,0 +1,1104 @@
+import { spawn } from 'node:child_process'
+import { mkdir, readFile, writeFile } from 'node:fs/promises'
+import {
+  basename,
+  dirname,
+  extname,
+  isAbsolute,
+  relative,
+  resolve,
+  win32,
+} from 'node:path'
+
+import {
+  redactDiagnosticObject,
+  redactHomePath,
+  redactLikelySecrets,
+} from './diagnostics/redaction.js'
+import { stableStringifyJson } from './stableStringify.js'
+
+export const TASK_REPORT_SCHEMA_VERSION = 1
+export const DEFAULT_TASK_REPORT_PREVIEW_CHARS = 1_000
+
+type JsonRecord = Record<string, unknown>
+
+export type TaskReportStatus = 'success' | 'error' | 'cancelled' | 'unknown'
+
+export type TaskReportSource = {
+  transcriptPath: string
+  malformedLineCount: number
+}
+
+export type TaskReportSession = {
+  id: string | null
+  name?: string
+  tag?: string
+  cwd?: string
+  startedAt?: string
+  endedAt?: string
+  initialRequest?: string
+  models: string[]
+}
+
+export type TaskReportBranch = {
+  transcriptBranch?: string
+  worktree?: {
+    name?: string
+    path?: string
+    branch?: string
+    originalBranch?: string
+    originalHead?: string
+    originalCwd?: string
+  }
+  pullRequest?: {
+    number: number
+    url?: string
+    repository?: string
+  }
+}
+
+export type TaskReportGitMetadata = {
+  status: 'available' | 'unavailable'
+  cwd: string
+  branch?: string
+  head?: string
+  dirty?: boolean
+  changedFiles: string[]
+  error?: string
+}
+
+export type TaskReportChangedFile = {
+  path: string
+  sources: Array<'tool' | 'git'>
+}
+
+export type TaskReportPreview = {
+  preview: string
+  truncated: boolean
+  chars: number
+}
+
+export type TaskReportToolUse = {
+  id: string
+  name: string
+  timestamp?: string
+  status: TaskReportStatus
+  inputSummary?: string
+  resultSummary?: TaskReportPreview
+  files: string[]
+}
+
+export type TaskReportCommand = {
+  toolUseId: string
+  timestamp?: string
+  command: string
+  description?: string
+  status: TaskReportStatus
+  exitCode?: number
+  stdout?: TaskReportPreview
+  stderr?: TaskReportPreview
+}
+
+export type TaskReportValidation = TaskReportCommand
+
+export type TaskReportError = {
+  source: 'tool' | 'transcript'
+  message: string
+  timestamp?: string
+  toolUseId?: string
+  toolName?: string
+}
+
+export type TaskReportReference = {
+  kind: 'issue' | 'pull_request' | 'unknown'
+  number: number
+  url?: string
+  repository?: string
+}
+
+export type TaskReport = {
+  schemaVersion: typeof TASK_REPORT_SCHEMA_VERSION
+  source: TaskReportSource
+  session: TaskReportSession
+  branch: TaskReportBranch
+  git?: TaskReportGitMetadata
+  changedFiles: TaskReportChangedFile[]
+  toolUses: TaskReportToolUse[]
+  commands: TaskReportCommand[]
+  validations: TaskReportValidation[]
+  errors: TaskReportError[]
+  warnings: string[]
+  linkedReferences: TaskReportReference[]
+  redaction: {
+    mode: 'best_effort'
+    maxPreviewChars: number
+  }
+}
+
+export type BuildTaskReportOptions = {
+  transcriptPath: string
+  cwd?: string
+  git?: false | ((cwd: string) => Promise<TaskReportGitMetadata>)
+  maxPreviewChars?: number
+}
+
+export type TaskReportArgs = {
+  format: 'json'
+  transcriptPath?: string | null
+  sessionId?: string | null
+  outFile?: string | null
+  cwd?: string
+}
+
+type ParsedTranscript = {
+  entries: JsonRecord[]
+  malformedLineCount: number
+}
+
+type ObservedToolUse = {
+  id: string
+  name: string
+  timestamp?: string
+  input: unknown
+}
+
+type ObservedToolResult = {
+  toolUseId: string
+  timestamp?: string
+  content: unknown
+  toolUseResult: unknown
+  isError: boolean
+}
+
+const MUTATING_FILE_TOOLS = new Set(['Edit', 'Write', 'NotebookEdit'])
+const FILE_CONTENT_TOOLS = new Set(['Read', 'Edit', 'Write', 'NotebookEdit'])
+
+const VALIDATION_COMMAND_PATTERNS = [
+  /\b(?:bun|npm|pnpm|yarn)\s+(?:run\s+)?(?:test(?::[A-Za-z0-9_-]+)?|typecheck(?::[A-Za-z0-9_-]+)?|build|smoke|check|lint|security:pr-scan)\b/,
+  /\bbun\s+test\b/,
+  /\bgit\s+diff\s+--check\b/,
+  /\bpython\s+-m\s+pytest\b/,
+  /\bpytest\b/,
+  /\btsc\b/,
+]
+
+export async function buildTaskReport(
+  options: BuildTaskReportOptions,
+): Promise<TaskReport> {
+  const maxPreviewChars = normalizeMaxPreviewChars(options.maxPreviewChars)
+  const transcriptPath = resolve(options.transcriptPath)
+  const { entries, malformedLineCount } =
+    await readTranscriptEntries(transcriptPath)
+
+  const sessionId =
+    findSessionId(entries) ?? basenameWithoutExtension(transcriptPath)
+  const metadata = collectSessionMetadata(entries, maxPreviewChars)
+  const toolResults = collectToolResults(entries)
+  const observedToolUses = collectToolUses(entries)
+  const changedFileSources = new Map<string, Set<'tool' | 'git'>>()
+  const errors: TaskReportError[] = []
+  const commands: TaskReportCommand[] = []
+  const validations: TaskReportValidation[] = []
+  const toolUses: TaskReportToolUse[] = []
+  const referenceTextParts: string[] = []
+  const cwdForGit = metadata.cwd ?? options.cwd ?? process.cwd()
+
+  if (metadata.initialRequest) {
+    referenceTextParts.push(metadata.initialRequest)
+  }
+
+  for (const observed of observedToolUses) {
+    const result = toolResults.get(observed.id)
+    const status = getObservedStatus(result)
+    const files = extractToolFiles(observed.name, observed.input, result)
+    const changedFiles = extractChangedFiles(observed.name, observed.input, result)
+    for (const file of changedFiles) {
+      addChangedFileSource(changedFileSources, file, 'tool', cwdForGit)
+    }
+
+    const resultSummary = shouldIncludeToolResultSummary(observed.name)
+      ? previewUnknown(result?.content ?? result?.toolUseResult, maxPreviewChars)
+      : undefined
+    const toolUse: TaskReportToolUse = {
+      id: observed.id,
+      name: observed.name,
+      status,
+      files: sortUnique(files.map(path => redact(path))),
+    }
+    if (observed.timestamp) toolUse.timestamp = observed.timestamp
+    const summary = summarizeToolInput(
+      observed.name,
+      observed.input,
+      maxPreviewChars,
+    )
+    if (summary) toolUse.inputSummary = summary
+    if (resultSummary) toolUse.resultSummary = resultSummary
+    toolUses.push(toolUse)
+
+    if (observed.name === 'Bash') {
+      const rawCommand = extractBashCommand(observed.input)
+      const command = buildCommandReport(
+        observed,
+        result,
+        status,
+        maxPreviewChars,
+      )
+      if (command) {
+        commands.push(command)
+        if (rawCommand) referenceTextParts.push(redact(rawCommand))
+        if (rawCommand && isValidationCommand(rawCommand)) {
+          validations.push(command)
+        }
+      }
+    }
+
+    if (result?.isError === true) {
+      const message = previewUnknown(
+        result.content ?? result.toolUseResult,
+        maxPreviewChars,
+      )
+      errors.push({
+        source: 'tool',
+        toolUseId: observed.id,
+        toolName: observed.name,
+        message: message?.preview ?? 'Tool result was marked as an error.',
+        ...(result.timestamp ? { timestamp: result.timestamp } : {}),
+      })
+    }
+  }
+
+  const rawGit =
+    options.git === false
+      ? undefined
+      : await (options.git ?? collectTaskReportGitMetadata)(cwdForGit)
+  const git = rawGit ? normalizeGitMetadata(rawGit) : undefined
+  if (git) {
+    for (const file of git.changedFiles) {
+      addChangedFileSource(changedFileSources, file, 'git', cwdForGit)
+    }
+  }
+
+  const branch = collectBranchMetadata(entries)
+  if (branch.pullRequest?.url) {
+    referenceTextParts.push(branch.pullRequest.url)
+  }
+  for (const text of metadata.referenceTextParts) {
+    referenceTextParts.push(text)
+  }
+
+  const warnings: string[] = []
+  if (malformedLineCount > 0) {
+    warnings.push(
+      `Skipped ${malformedLineCount} malformed transcript line${
+        malformedLineCount === 1 ? '' : 's'
+      }.`,
+    )
+  }
+  if (entries.length === 0) {
+    warnings.push('No transcript entries were available for this report.')
+  }
+  if (validations.length === 0) {
+    warnings.push('No validation commands were observed in this transcript.')
+  }
+
+  return {
+    schemaVersion: TASK_REPORT_SCHEMA_VERSION,
+    source: {
+      transcriptPath: redact(transcriptPath),
+      malformedLineCount,
+    },
+    session: {
+      id: sessionId || null,
+      ...(metadata.name ? { name: metadata.name } : {}),
+      ...(metadata.tag ? { tag: metadata.tag } : {}),
+      ...(metadata.cwd ? { cwd: redact(metadata.cwd) } : {}),
+      ...(metadata.startedAt ? { startedAt: metadata.startedAt } : {}),
+      ...(metadata.endedAt ? { endedAt: metadata.endedAt } : {}),
+      ...(metadata.initialRequest
+        ? { initialRequest: metadata.initialRequest }
+        : {}),
+      models: sortUnique(metadata.models),
+    },
+    branch,
+    ...(git ? { git } : {}),
+    changedFiles: formatChangedFiles(changedFileSources),
+    toolUses,
+    commands,
+    validations,
+    errors,
+    warnings,
+    linkedReferences: collectLinkedReferences(referenceTextParts, branch),
+    redaction: {
+      mode: 'best_effort',
+      maxPreviewChars,
+    },
+  }
+}
+
+export async function collectTaskReportGitMetadata(
+  cwd: string,
+): Promise<TaskReportGitMetadata> {
+  const base = ['--no-optional-locks']
+  const inside = await runGit(cwd, [
+    ...base,
+    'rev-parse',
+    '--is-inside-work-tree',
+  ])
+  if (inside.code !== 0 || inside.stdout.trim() !== 'true') {
+    return {
+      status: 'unavailable',
+      cwd: redact(cwd),
+      changedFiles: [],
+      error: redact(
+        inside.error ?? inside.stderr.trim() ?? 'not a git repository',
+      ),
+    }
+  }
+
+  const [branch, head, status] = await Promise.all([
+    runGit(cwd, [...base, 'branch', '--show-current']),
+    runGit(cwd, [...base, 'rev-parse', '--short=12', 'HEAD']),
+    runGit(cwd, [...base, 'status', '--porcelain=v1']),
+  ])
+  const gitStatusAvailable = status.code === 0
+  const changedFiles = gitStatusAvailable
+    ? parseGitStatusChangedFiles(status.stdout)
+    : []
+
+  return {
+    status: 'available',
+    cwd: redact(cwd),
+    ...(branch.code === 0 && branch.stdout.trim()
+      ? { branch: redact(branch.stdout.trim()) }
+      : {}),
+    ...(head.code === 0 && head.stdout.trim()
+      ? { head: redact(head.stdout.trim()) }
+      : {}),
+    ...(gitStatusAvailable ? { dirty: changedFiles.length > 0 } : {}),
+    changedFiles: sortUnique(changedFiles.map(path => redact(path))),
+    ...(status.code !== 0
+      ? { error: redact(status.error ?? status.stderr.trim()) }
+      : {}),
+  }
+}
+
+export function formatTaskReportAsJson(report: TaskReport): string {
+  return stableStringifyJson(report, 2)
+}
+
+export async function writeTaskReport(
+  outFile: string,
+  content: string,
+): Promise<string> {
+  const outputPath = resolve(process.cwd(), outFile)
+  await mkdir(dirname(outputPath), { recursive: true })
+  await writeFile(outputPath, content, 'utf8')
+  return outputPath
+}
+
+async function readTranscriptEntries(
+  transcriptPath: string,
+): Promise<ParsedTranscript> {
+  const raw = await readFile(transcriptPath, 'utf8')
+  if (transcriptPath.endsWith('.json')) {
+    try {
+      const parsed = JSON.parse(raw) as unknown
+      return {
+        entries: coerceJsonTranscriptEntries(parsed),
+        malformedLineCount: 0,
+      }
+    } catch {
+      return { entries: [], malformedLineCount: 1 }
+    }
+  }
+
+  const entries: JsonRecord[] = []
+  let malformedLineCount = 0
+  for (const line of raw.split(/\r?\n/)) {
+    const trimmed = line.trim()
+    if (!trimmed) continue
+    try {
+      const parsed = JSON.parse(trimmed) as unknown
+      if (isRecord(parsed)) {
+        entries.push(parsed)
+      }
+    } catch {
+      malformedLineCount++
+    }
+  }
+  return { entries, malformedLineCount }
+}
+
+function coerceJsonTranscriptEntries(value: unknown): JsonRecord[] {
+  if (Array.isArray(value)) {
+    return value.filter(isRecord)
+  }
+  if (!isRecord(value)) {
+    return []
+  }
+  const messages = value.messages
+  if (Array.isArray(messages)) {
+    return messages.filter(isRecord)
+  }
+  return [value]
+}
+
+function collectSessionMetadata(
+  entries: JsonRecord[],
+  maxPreviewChars: number,
+): {
+  name?: string
+  tag?: string
+  cwd?: string
+  startedAt?: string
+  endedAt?: string
+  initialRequest?: string
+  models: string[]
+  referenceTextParts: string[]
+} {
+  const timestamps = entries
+    .map(entry => stringValue(entry.timestamp))
+    .filter((value): value is string => Boolean(value))
+  const models: string[] = []
+  const referenceTextParts: string[] = []
+  let name: string | undefined
+  let tag: string | undefined
+  let cwd: string | undefined
+  let initialRequest: string | undefined
+
+  for (const entry of entries) {
+    if (entry.type === 'custom-title') {
+      const title = stringValue(entry.customTitle)
+      if (title) name = truncateText(redact(title), maxPreviewChars).preview
+    } else if (entry.type === 'tag') {
+      const observedTag = stringValue(entry.tag)
+      if (observedTag) tag = truncateText(redact(observedTag), maxPreviewChars).preview
+    }
+
+    const observedCwd = stringValue(entry.cwd)
+    if (!cwd && observedCwd) cwd = observedCwd
+
+    const message = recordValue(entry.message)
+    const model = stringValue(message?.model)
+    if (model) models.push(redact(model))
+
+    const isToolResult = isToolResultEntry(entry)
+    const text = isToolResult ? undefined : extractMessageText(message)
+    if (text) referenceTextParts.push(text)
+    if (!initialRequest && entry.type === 'user' && !isToolResult) {
+      const request = text?.trim()
+      if (request) {
+        initialRequest = truncateText(redact(request), maxPreviewChars).preview
+      }
+    }
+  }
+
+  return {
+    ...(name ? { name } : {}),
+    ...(tag ? { tag } : {}),
+    ...(cwd ? { cwd } : {}),
+    ...(timestamps[0] ? { startedAt: timestamps[0] } : {}),
+    ...(timestamps.at(-1) ? { endedAt: timestamps.at(-1) } : {}),
+    ...(initialRequest ? { initialRequest } : {}),
+    models,
+    referenceTextParts,
+  }
+}
+
+function collectBranchMetadata(entries: JsonRecord[]): TaskReportBranch {
+  const branch: TaskReportBranch = {}
+  for (const entry of entries) {
+    const transcriptBranch = stringValue(entry.gitBranch)
+    if (transcriptBranch) {
+      branch.transcriptBranch = redact(transcriptBranch)
+    }
+
+    if (entry.type === 'worktree-state') {
+      const worktree = recordValue(entry.worktreeSession)
+      if (worktree) {
+        branch.worktree = {
+          ...(stringValue(worktree.worktreeName)
+            ? { name: redact(stringValue(worktree.worktreeName) as string) }
+            : {}),
+          ...(stringValue(worktree.worktreePath)
+            ? { path: redact(stringValue(worktree.worktreePath) as string) }
+            : {}),
+          ...(stringValue(worktree.worktreeBranch)
+            ? { branch: redact(stringValue(worktree.worktreeBranch) as string) }
+            : {}),
+          ...(stringValue(worktree.originalBranch)
+            ? {
+                originalBranch: redact(
+                  stringValue(worktree.originalBranch) as string,
+                ),
+              }
+            : {}),
+          ...(stringValue(worktree.originalHeadCommit)
+            ? {
+                originalHead: redact(
+                  stringValue(worktree.originalHeadCommit) as string,
+                ),
+              }
+            : {}),
+          ...(stringValue(worktree.originalCwd)
+            ? { originalCwd: redact(stringValue(worktree.originalCwd) as string) }
+            : {}),
+        }
+      }
+    }
+
+    if (entry.type === 'pr-link') {
+      const number = numberValue(entry.prNumber)
+      if (number !== undefined) {
+        branch.pullRequest = {
+          number,
+          ...(stringValue(entry.prUrl) ? { url: redact(stringValue(entry.prUrl) as string) } : {}),
+          ...(stringValue(entry.prRepository)
+            ? { repository: redact(stringValue(entry.prRepository) as string) }
+            : {}),
+        }
+      }
+    }
+  }
+  return branch
+}
+
+function collectToolUses(entries: JsonRecord[]): ObservedToolUse[] {
+  const toolUses: ObservedToolUse[] = []
+  for (const entry of entries) {
+    if (entry.type !== 'assistant') continue
+    const message = recordValue(entry.message)
+    const content = message?.content
+    if (!Array.isArray(content)) continue
+    for (const block of content) {
+      if (!isRecord(block) || block.type !== 'tool_use') continue
+      const id = stringValue(block.id)
+      const name = stringValue(block.name)
+      if (!id || !name) continue
+      toolUses.push({
+        id,
+        name,
+        input: block.input,
+        ...(stringValue(entry.timestamp)
+          ? { timestamp: stringValue(entry.timestamp) as string }
+          : {}),
+      })
+    }
+  }
+  return toolUses
+}
+
+function collectToolResults(entries: JsonRecord[]): Map<string, ObservedToolResult> {
+  const results = new Map<string, ObservedToolResult>()
+  for (const entry of entries) {
+    if (entry.type !== 'user') continue
+    const message = recordValue(entry.message)
+    const content = message?.content
+    if (!Array.isArray(content)) continue
+    for (const block of content) {
+      if (!isRecord(block) || block.type !== 'tool_result') continue
+      const toolUseId = stringValue(block.tool_use_id)
+      if (!toolUseId) continue
+      results.set(toolUseId, {
+        toolUseId,
+        content: block.content,
+        toolUseResult: entry.toolUseResult,
+        isError: block.is_error === true,
+        ...(stringValue(entry.timestamp)
+          ? { timestamp: stringValue(entry.timestamp) as string }
+          : {}),
+      })
+    }
+  }
+  return results
+}
+
+function buildCommandReport(
+  observed: ObservedToolUse,
+  result: ObservedToolResult | undefined,
+  status: TaskReportStatus,
+  maxPreviewChars: number,
+): TaskReportCommand | null {
+  const input = recordValue(observed.input)
+  const rawCommand = extractBashCommand(observed.input)
+  if (!rawCommand) return null
+
+  const structuredResult = recordValue(result?.toolUseResult)
+  const stdout = stringValue(structuredResult?.stdout)
+  const stderr = stringValue(structuredResult?.stderr)
+  const exitCode = extractExitCode(result)
+  const command: TaskReportCommand = {
+    toolUseId: observed.id,
+    command: truncateText(redact(rawCommand), maxPreviewChars).preview,
+    status,
+  }
+  const description = stringValue(input?.description)
+  if (description) {
+    command.description = truncateText(redact(description), maxPreviewChars).preview
+  }
+  if (observed.timestamp) {
+    command.timestamp = observed.timestamp
+  }
+  if (exitCode !== undefined) {
+    command.exitCode = exitCode
+  }
+  if (stdout !== undefined) {
+    command.stdout = truncateText(redact(stdout), maxPreviewChars)
+  }
+  if (stderr !== undefined) {
+    command.stderr = truncateText(redact(stderr), maxPreviewChars)
+  }
+  return command
+}
+
+function extractBashCommand(input: unknown): string | undefined {
+  const inputRecord = recordValue(input)
+  return stringValue(inputRecord?.command)
+}
+
+function getObservedStatus(
+  result: ObservedToolResult | undefined,
+): TaskReportStatus {
+  if (!result) return 'unknown'
+  const structuredResult = recordValue(result.toolUseResult)
+  if (structuredResult?.interrupted === true) return 'cancelled'
+  const exitCode = extractExitCode(result)
+  if (exitCode !== undefined && exitCode !== 0) return 'error'
+  if (result.isError) return 'error'
+  return 'success'
+}
+
+function shouldIncludeToolResultSummary(toolName: string): boolean {
+  return !FILE_CONTENT_TOOLS.has(toolName)
+}
+
+function extractToolFiles(
+  toolName: string,
+  input: unknown,
+  result: ObservedToolResult | undefined,
+): string[] {
+  const files = new Set<string>()
+  const inputRecord = recordValue(input)
+  for (const file of extractFilePathsFromRecord(inputRecord)) {
+    files.add(file)
+  }
+  if (toolName === 'Bash') {
+    const simulatedSedEdit = recordValue(inputRecord?._simulatedSedEdit)
+    const sedFile = stringValue(simulatedSedEdit?.filePath)
+    if (sedFile) files.add(sedFile)
+  }
+  const resultRecord = recordValue(result?.toolUseResult)
+  for (const file of extractFilePathsFromRecord(resultRecord)) {
+    files.add(file)
+  }
+  return [...files]
+}
+
+function extractChangedFiles(
+  toolName: string,
+  input: unknown,
+  result: ObservedToolResult | undefined,
+): string[] {
+  if (!MUTATING_FILE_TOOLS.has(toolName) && toolName !== 'Bash') {
+    return []
+  }
+  if (toolName === 'Bash') {
+    const inputRecord = recordValue(input)
+    const simulatedSedEdit = recordValue(inputRecord?._simulatedSedEdit)
+    const sedFile = stringValue(simulatedSedEdit?.filePath)
+    return sedFile ? [sedFile] : []
+  }
+  return extractToolFiles(toolName, input, result)
+}
+
+function extractFilePathsFromRecord(record: JsonRecord | null | undefined): string[] {
+  if (!record) return []
+  const candidates = [
+    stringValue(record.file_path),
+    stringValue(record.filePath),
+    stringValue(record.notebook_path),
+    stringValue(record.path),
+  ].filter((value): value is string => Boolean(value))
+  const gitDiff = recordValue(record.gitDiff)
+  const diffFile = stringValue(gitDiff?.filename)
+  if (diffFile) candidates.push(diffFile)
+  return candidates
+}
+
+function summarizeToolInput(
+  toolName: string,
+  input: unknown,
+  maxPreviewChars: number,
+): string | undefined {
+  const record = recordValue(input)
+  if (!record) return undefined
+  if (toolName === 'Bash') {
+    const command = stringValue(record.command)
+    return command ? truncateText(redact(command), maxPreviewChars).preview : undefined
+  }
+  const filePath =
+    stringValue(record.file_path) ??
+    stringValue(record.filePath) ??
+    stringValue(record.notebook_path)
+  if (filePath) {
+    return truncateText(redact(`${toolName} ${filePath}`), maxPreviewChars).preview
+  }
+  const keys = Object.keys(record).sort()
+  if (keys.length === 0) return undefined
+  return truncateText(redact(`${toolName} input keys: ${keys.join(', ')}`), maxPreviewChars).preview
+}
+
+function extractExitCode(result: ObservedToolResult | undefined): number | undefined {
+  if (!result) return undefined
+  const parts = [
+    unknownToString(result.content),
+    unknownToString(result.toolUseResult),
+  ].filter((value): value is string => Boolean(value))
+  for (const part of parts) {
+    const match = /\bexit code[:\s]+(\d+)\b/i.exec(part)
+    if (match?.[1]) {
+      return Number(match[1])
+    }
+  }
+  return undefined
+}
+
+function previewUnknown(
+  value: unknown,
+  maxPreviewChars: number,
+): TaskReportPreview | undefined {
+  const text = unknownToString(value)
+  if (!text) return undefined
+  return truncateText(redact(text), maxPreviewChars)
+}
+
+function unknownToString(value: unknown): string | undefined {
+  if (typeof value === 'string') return value
+  if (value === null || value === undefined) return undefined
+  if (typeof value === 'number' || typeof value === 'boolean') return String(value)
+  if (Array.isArray(value)) {
+    return value
+      .map(item => unknownToString(item))
+      .filter((item): item is string => Boolean(item))
+      .join('\n')
+  }
+  if (isRecord(value)) {
+    const content = value.content
+    if (typeof content === 'string') return content
+    try {
+      return stableStringifyJson(redactObject(value))
+    } catch {
+      return undefined
+    }
+  }
+  return undefined
+}
+
+function extractMessageText(message: JsonRecord | null | undefined): string | undefined {
+  if (!message) return undefined
+  const content = message.content
+  if (typeof content === 'string') return redact(content)
+  if (!Array.isArray(content)) return undefined
+  const parts = content
+    .map(block => {
+      if (typeof block === 'string') return block
+      if (!isRecord(block)) return undefined
+      if (block.type === 'text' && typeof block.text === 'string') {
+        return block.text
+      }
+      if (block.type === 'tool_result') {
+        return unknownToString(block.content)
+      }
+      return undefined
+    })
+    .filter((part): part is string => Boolean(part?.trim()))
+  return parts.length > 0 ? redact(parts.join('\n')) : undefined
+}
+
+function collectLinkedReferences(
+  textParts: string[],
+  branch: TaskReportBranch,
+): TaskReportReference[] {
+  const references = new Map<string, TaskReportReference>()
+
+  if (branch.pullRequest) {
+    const pr = branch.pullRequest
+    const key = `pull_request:${pr.repository ?? ''}:${pr.number}:${pr.url ?? ''}`
+    references.set(key, {
+      kind: 'pull_request',
+      number: pr.number,
+      ...(pr.url ? { url: pr.url } : {}),
+      ...(pr.repository ? { repository: pr.repository } : {}),
+    })
+  }
+
+  for (const text of textParts) {
+    for (const reference of extractGithubUrlReferences(text)) {
+      const key = `${reference.kind}:${reference.repository ?? ''}:${
+        reference.number
+      }:${reference.url ?? ''}`
+      references.set(key, reference)
+    }
+    for (const reference of extractShorthandReferences(text)) {
+      const key = `${reference.kind}:${reference.number}`
+      if (!references.has(key)) {
+        references.set(key, reference)
+      }
+    }
+  }
+
+  return [...references.values()].sort((a, b) => {
+    const kindCompare = a.kind.localeCompare(b.kind)
+    if (kindCompare !== 0) return kindCompare
+    const repoCompare = (a.repository ?? '').localeCompare(b.repository ?? '')
+    if (repoCompare !== 0) return repoCompare
+    return a.number - b.number
+  })
+}
+
+function extractGithubUrlReferences(text: string): TaskReportReference[] {
+  const references: TaskReportReference[] = []
+  const urlPattern =
+    /https:\/\/github\.com\/([A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+)\/(pull|issues)\/(\d+)/g
+  for (const match of text.matchAll(urlPattern)) {
+    const repository = match[1]
+    const kind = match[2] === 'pull' ? 'pull_request' : 'issue'
+    const number = Number(match[3])
+    const url = match[0]
+    if (repository && Number.isSafeInteger(number)) {
+      references.push({
+        kind,
+        number,
+        repository,
+        url,
+      })
+    }
+  }
+  return references
+}
+
+function extractShorthandReferences(text: string): TaskReportReference[] {
+  const references: TaskReportReference[] = []
+  for (const match of text.matchAll(/(?<![A-Za-z0-9_])#(\d+)\b/g)) {
+    const number = Number(match[1])
+    if (Number.isSafeInteger(number)) {
+      references.push({ kind: 'unknown', number })
+    }
+  }
+  return references
+}
+
+function formatChangedFiles(
+  changedFileSources: Map<string, Set<'tool' | 'git'>>,
+): TaskReportChangedFile[] {
+  return [...changedFileSources.entries()]
+    .map(([path, sources]) => ({
+      path,
+      sources: [...sources].sort() as Array<'tool' | 'git'>,
+    }))
+    .sort((a, b) => a.path.localeCompare(b.path))
+}
+
+function addChangedFileSource(
+  changedFileSources: Map<string, Set<'tool' | 'git'>>,
+  path: string,
+  source: 'tool' | 'git',
+  cwd: string,
+) {
+  const redactedPath = redact(normalizeChangedFilePath(path, cwd))
+  const sources = changedFileSources.get(redactedPath) ?? new Set<'tool' | 'git'>()
+  sources.add(source)
+  changedFileSources.set(redactedPath, sources)
+}
+
+function normalizeChangedFilePath(path: string, cwd: string): string {
+  const value = path.trim()
+  const posixRelative = relativeWithinCwd(value, cwd, isAbsolute, relative)
+  if (posixRelative) return posixRelative
+
+  const windowsRelative = relativeWithinCwd(
+    value,
+    cwd,
+    win32.isAbsolute,
+    win32.relative,
+  )
+  if (windowsRelative) return windowsRelative.replaceAll('\\', '/')
+
+  return value
+}
+
+function relativeWithinCwd(
+  path: string,
+  cwd: string,
+  isAbsolutePath: (value: string) => boolean,
+  relativePath: (from: string, to: string) => string,
+): string | undefined {
+  if (!isAbsolutePath(path) || !isAbsolutePath(cwd)) return undefined
+  const relativePathValue = relativePath(cwd, path)
+  if (
+    !relativePathValue ||
+    relativePathValue.startsWith('..') ||
+    isAbsolutePath(relativePathValue)
+  ) {
+    return undefined
+  }
+  return relativePathValue
+}
+
+function isValidationCommand(command: string): boolean {
+  return VALIDATION_COMMAND_PATTERNS.some(pattern => pattern.test(command))
+}
+
+function parseGitStatusChangedFiles(stdout: string): string[] {
+  const changedFiles: string[] = []
+  for (const rawLine of stdout.split(/\r?\n/)) {
+    if (!rawLine.trim()) continue
+    const pathPart = rawLine.length > 3 ? rawLine.slice(3).trim() : rawLine.trim()
+    const renamedPath = pathPart.includes(' -> ')
+      ? pathPart.slice(pathPart.lastIndexOf(' -> ') + ' -> '.length)
+      : pathPart
+    const unquoted = renamedPath.replace(/^"|"$/g, '')
+    if (unquoted) changedFiles.push(unquoted)
+  }
+  return changedFiles
+}
+
+async function runGit(
+  cwd: string,
+  args: string[],
+): Promise<{ stdout: string; stderr: string; code: number; error?: string }> {
+  const maxBuffer = 1_000_000
+  return new Promise(resolve => {
+    let stdout = ''
+    let stderr = ''
+    let resolved = false
+    const child = spawn('git', args, {
+      cwd,
+      shell: false,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    })
+    const finish = (
+      code: number,
+      extra?: { error?: string; stderr?: string },
+    ) => {
+      if (resolved) return
+      resolved = true
+      clearTimeout(timer)
+      resolve({
+        stdout,
+        stderr: extra?.stderr ?? stderr,
+        code,
+        ...(extra?.error ? { error: extra.error } : {}),
+      })
+    }
+    const append = (current: string, chunk: Buffer) => {
+      if (current.length >= maxBuffer) return current
+      return `${current}${chunk.toString('utf8')}`.slice(0, maxBuffer)
+    }
+    const timer = setTimeout(() => {
+      child.kill('SIGTERM')
+      finish(124, { error: 'git command timed out' })
+    }, 3_000)
+    child.stdout?.on('data', chunk => {
+      stdout = append(stdout, chunk)
+    })
+    child.stderr?.on('data', chunk => {
+      stderr = append(stderr, chunk)
+    })
+    child.on('error', error => {
+      finish(1, { error: error.message })
+    })
+    child.on('close', code => {
+      finish(code ?? 1)
+    })
+  })
+}
+
+function findSessionId(entries: JsonRecord[]): string | undefined {
+  for (const entry of entries) {
+    const sessionId = stringValue(entry.sessionId)
+    if (sessionId) return sessionId
+  }
+  return undefined
+}
+
+function isToolResultEntry(entry: JsonRecord): boolean {
+  if (entry.sourceToolAssistantUUID) return true
+  const message = recordValue(entry.message)
+  const content = message?.content
+  return (
+    Array.isArray(content) &&
+    content.some(block => isRecord(block) && block.type === 'tool_result')
+  )
+}
+
+function basenameWithoutExtension(path: string): string {
+  const extension = extname(path)
+  return extension ? basename(path, extension) : basename(path)
+}
+
+function truncateText(value: string, maxChars: number): TaskReportPreview {
+  const safeMax = Math.max(1, maxChars)
+  if (value.length <= safeMax) {
+    return {
+      preview: value,
+      truncated: false,
+      chars: value.length,
+    }
+  }
+  return {
+    preview: value.slice(0, safeMax),
+    truncated: true,
+    chars: value.length,
+  }
+}
+
+function redact(value: string): string {
+  return redactLikelySecrets(redactHomePath(value))
+}
+
+function redactObject(value: unknown): unknown {
+  return redactDiagnosticObject(value)
+}
+
+function normalizeGitMetadata(
+  metadata: TaskReportGitMetadata,
+): TaskReportGitMetadata {
+  return {
+    status: metadata.status,
+    cwd: redact(metadata.cwd),
+    ...(metadata.branch ? { branch: redact(metadata.branch) } : {}),
+    ...(metadata.head ? { head: redact(metadata.head) } : {}),
+    ...(metadata.dirty !== undefined ? { dirty: metadata.dirty } : {}),
+    changedFiles: sortUnique(metadata.changedFiles.map(path => redact(path))),
+    ...(metadata.error ? { error: redact(metadata.error) } : {}),
+  }
+}
+
+function sortUnique(values: string[]): string[] {
+  return [...new Set(values.filter(Boolean))].sort((a, b) => a.localeCompare(b))
+}
+
+function isRecord(value: unknown): value is JsonRecord {
+  return value !== null && typeof value === 'object' && !Array.isArray(value)
+}
+
+function recordValue(value: unknown): JsonRecord | null {
+  return isRecord(value) ? value : null
+}
+
+function stringValue(value: unknown): string | undefined {
+  return typeof value === 'string' ? value : undefined
+}
+
+function numberValue(value: unknown): number | undefined {
+  return typeof value === 'number' && Number.isSafeInteger(value)
+    ? value
+    : undefined
+}
+
+function normalizeMaxPreviewChars(value: number | undefined): number {
+  const candidate = value ?? DEFAULT_TASK_REPORT_PREVIEW_CHARS
+  if (!Number.isFinite(candidate)) return DEFAULT_TASK_REPORT_PREVIEW_CHARS
+  return Math.max(1, Math.floor(candidate))
+}

--- a/src/utils/taskReport.ts
+++ b/src/utils/taskReport.ts
@@ -68,6 +68,18 @@ export type TaskReportGitMetadata = {
   error?: string
 }
 
+type TaskReportGitCommandResult = {
+  stdout: string
+  stderr: string
+  code: number
+  error?: string
+}
+
+export type TaskReportGitRunner = (
+  cwd: string,
+  args: string[],
+) => Promise<TaskReportGitCommandResult>
+
 export type TaskReportChangedFile = {
   path: string
   sources: Array<'tool' | 'git'>
@@ -338,9 +350,10 @@ export async function buildTaskReport(
 
 export async function collectTaskReportGitMetadata(
   cwd: string,
+  gitRunner: TaskReportGitRunner = runGit,
 ): Promise<TaskReportGitMetadata> {
   const base = ['--no-optional-locks']
-  const inside = await runGit(cwd, [
+  const inside = await gitRunner(cwd, [
     ...base,
     'rev-parse',
     '--is-inside-work-tree',
@@ -357,9 +370,9 @@ export async function collectTaskReportGitMetadata(
   }
 
   const [branch, head, status] = await Promise.all([
-    runGit(cwd, [...base, 'branch', '--show-current']),
-    runGit(cwd, [...base, 'rev-parse', '--short=12', 'HEAD']),
-    runGit(cwd, [...base, 'status', '--porcelain=v1']),
+    gitRunner(cwd, [...base, 'branch', '--show-current']),
+    gitRunner(cwd, [...base, 'rev-parse', '--short=12', 'HEAD']),
+    gitRunner(cwd, [...base, 'status', '--porcelain=v1']),
   ])
   const gitStatusAvailable = status.code === 0
   const changedFiles = gitStatusAvailable
@@ -921,7 +934,7 @@ function addChangedFileSource(
 function normalizeChangedFilePath(path: string, cwd: string): string {
   const value = path.trim()
   const posixRelative = relativeWithinCwd(value, cwd, isAbsolute, relative)
-  if (posixRelative) return posixRelative
+  if (posixRelative) return posixRelative.replaceAll('\\', '/')
 
   const windowsRelative = relativeWithinCwd(
     value,
@@ -977,7 +990,7 @@ function parseGitStatusChangedFiles(stdout: string): string[] {
 async function runGit(
   cwd: string,
   args: string[],
-): Promise<{ stdout: string; stderr: string; code: number; error?: string }> {
+): Promise<TaskReportGitCommandResult> {
   try {
     const result = await execa('git', args, {
       cwd,

--- a/src/utils/taskReport.ts
+++ b/src/utils/taskReport.ts
@@ -12,6 +12,11 @@ import {
 import { execa } from 'execa'
 
 import {
+  STATUS_TAG,
+  TASK_NOTIFICATION_TAG,
+  TOOL_USE_ID_TAG,
+} from '../constants/xml.js'
+import {
   redactDiagnosticObject,
   redactHomePath,
   redactLikelySecrets,
@@ -208,6 +213,7 @@ export async function buildTaskReport(
     findSessionId(entries) ?? basenameWithoutExtension(transcriptPath)
   const metadata = collectSessionMetadata(entries, maxPreviewChars)
   const toolResults = collectToolResults(entries)
+  const taskNotificationStatuses = collectTaskNotificationStatuses(entries)
   const observedToolUses = collectToolUses(entries)
   const changedFileSources = new Map<string, Set<'tool' | 'git'>>()
   const errors: TaskReportError[] = []
@@ -223,7 +229,10 @@ export async function buildTaskReport(
 
   for (const observed of observedToolUses) {
     const result = toolResults.get(observed.id)
-    const status = getObservedStatus(result)
+    const observedStatus = getObservedStatus(result)
+    const status = isShellCommandTool(observed.name)
+      ? (taskNotificationStatuses.get(observed.id) ?? observedStatus)
+      : observedStatus
     const files = extractToolFiles(observed.name, observed.input, result)
     const changedFiles = extractChangedFiles(observed.name, observed.input, result)
     for (const file of changedFiles) {
@@ -628,6 +637,45 @@ function collectToolResults(entries: JsonRecord[]): Map<string, ObservedToolResu
   return results
 }
 
+function collectTaskNotificationStatuses(
+  entries: JsonRecord[],
+): Map<string, TaskReportStatus> {
+  const statuses = new Map<string, TaskReportStatus>()
+  for (const entry of entries) {
+    if (isToolResultEntry(entry)) continue
+
+    const text = extractRawMessageText(recordValue(entry.message))
+    if (!text?.includes(`<${TASK_NOTIFICATION_TAG}`)) continue
+
+    const toolUseId = extractXmlTag(text, TOOL_USE_ID_TAG)
+    if (!toolUseId) continue
+
+    const status = taskNotificationStatusToReportStatus(
+      extractXmlTag(text, STATUS_TAG),
+    )
+    if (status) {
+      statuses.set(toolUseId, status)
+    }
+  }
+  return statuses
+}
+
+function taskNotificationStatusToReportStatus(
+  status: string | undefined,
+): TaskReportStatus | undefined {
+  switch (status) {
+    case 'completed':
+      return 'success'
+    case 'failed':
+      return 'error'
+    case 'killed':
+    case 'stopped':
+      return 'cancelled'
+    default:
+      return undefined
+  }
+}
+
 function buildCommandReport(
   observed: ObservedToolUse,
   result: ObservedToolResult | undefined,
@@ -816,6 +864,26 @@ function unknownToString(value: unknown): string | undefined {
   return undefined
 }
 
+function extractRawMessageText(
+  message: JsonRecord | null | undefined,
+): string | undefined {
+  if (!message) return undefined
+  const content = message.content
+  if (typeof content === 'string') return content
+  if (!Array.isArray(content)) return undefined
+  const parts = content
+    .map(block => {
+      if (typeof block === 'string') return block
+      if (!isRecord(block)) return undefined
+      if (block.type === 'text' && typeof block.text === 'string') {
+        return block.text
+      }
+      return undefined
+    })
+    .filter((part): part is string => Boolean(part?.trim()))
+  return parts.length > 0 ? parts.join('\n') : undefined
+}
+
 function extractMessageText(message: JsonRecord | null | undefined): string | undefined {
   if (!message) return undefined
   const content = message.content
@@ -835,6 +903,15 @@ function extractMessageText(message: JsonRecord | null | undefined): string | un
     })
     .filter((part): part is string => Boolean(part?.trim()))
   return parts.length > 0 ? redact(parts.join('\n')) : undefined
+}
+
+function extractXmlTag(text: string, tagName: string): string | undefined {
+  const escapedTagName = tagName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+  const match = new RegExp(
+    `<${escapedTagName}>([\\s\\S]*?)</${escapedTagName}>`,
+  ).exec(text)
+  const value = match?.[1]?.trim()
+  return value || undefined
 }
 
 function collectLinkedReferences(

--- a/src/utils/taskReport.ts
+++ b/src/utils/taskReport.ts
@@ -231,7 +231,10 @@ export async function buildTaskReport(
     const result = toolResults.get(observed.id)
     const observedStatus = getObservedStatus(result)
     const status = isShellCommandTool(observed.name)
-      ? (taskNotificationStatuses.get(observed.id) ?? observedStatus)
+      ? reconcileShellStatus(
+          observedStatus,
+          taskNotificationStatuses.get(observed.id),
+        )
       : observedStatus
     const files = extractToolFiles(observed.name, observed.input, result)
     const changedFiles = extractChangedFiles(observed.name, observed.input, result)
@@ -676,6 +679,15 @@ function taskNotificationStatusToReportStatus(
   }
 }
 
+function reconcileShellStatus(
+  observedStatus: TaskReportStatus,
+  notificationStatus: TaskReportStatus | undefined,
+): TaskReportStatus {
+  return observedStatus === 'unknown'
+    ? (notificationStatus ?? observedStatus)
+    : observedStatus
+}
+
 function buildCommandReport(
   observed: ObservedToolUse,
   result: ObservedToolResult | undefined,
@@ -906,11 +918,16 @@ function extractMessageText(message: JsonRecord | null | undefined): string | un
 }
 
 function extractXmlTag(text: string, tagName: string): string | undefined {
-  const escapedTagName = tagName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
-  const match = new RegExp(
-    `<${escapedTagName}>([\\s\\S]*?)</${escapedTagName}>`,
-  ).exec(text)
-  const value = match?.[1]?.trim()
+  const openingTag = `<${tagName}>`
+  const closingTag = `</${tagName}>`
+  const valueStart = text.indexOf(openingTag)
+  if (valueStart === -1) return undefined
+
+  const contentStart = valueStart + openingTag.length
+  const valueEnd = text.indexOf(closingTag, contentStart)
+  if (valueEnd === -1) return undefined
+
+  const value = text.slice(contentStart, valueEnd).trim()
   return value || undefined
 }
 


### PR DESCRIPTION
## Summary
- Add `openclaude report --json` to generate deterministic JSON task reports from observed session transcripts and repository state.
- This is the first PR in a planned report-generation set. Follow-up PRs are expected to render task reports as Markdown and add a PR-description report template.

## Implementation
- Adds a schema-versioned JSON report generator for session metadata, branch/worktree/PR metadata, git status, changed files, tool uses, Bash commands, validation commands, errors, warnings, and linked issue/PR references.
- Reuses existing redaction and stable JSON utilities, applies deterministic truncation to large previews, and avoids inventing validation results when no validation command is observed.
- Adds a JSON-only `report` CLI command with `--transcript`, `--session`, and `--out` support; `--out` writes status to stderr so stdout remains usable for JSON.
- Documents the new command alongside the existing runtime report tooling.

## Tests
- `bun test src/**/report*.test.ts` covers missing validation warnings, passing and failing validations, command status and exit code capture, file changes, branch metadata, redaction, truncation, and malformed/old transcript handling.
- `bun run typecheck`
- `bun run build`
- `bun run smoke`
- `bun run security:pr-scan -- --base upstream/main`
- `git diff --check`
- `node dist/cli.mjs report --json --transcript <fixture>`
- `node dist/cli.mjs report --json --transcript <fixture> --out <file>`

## Risk
- No dependencies are added and transcript writing format is unchanged.
- This introduces a new reporting surface without a linked issue. The scope is intentionally limited to deterministic JSON facts; prose rendering and PR-description templating are planned as separate follow-up PRs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `report` CLI command to generate deterministic, JSON-only task reports from the latest session, a transcript file, or a session ID (stdout or output file).
  * Reports include session info, tool usage, detected validations/commands, changed files, optional git metadata, linked issue/PR references, and consistent redaction/truncation.
* **Bug Fixes**
  * Improved resilience for malformed transcript lines, exit-code/status mapping, background validation reconciliation, and warnings when no validations are observed.
  * Report generation remains robust when git metadata collection fails.
* **Documentation**
  * Updated the advanced setup guide with a deterministic “task report” example and expanded `--json` details.
* **Tests**
  * Added extensive coverage for report building, serialization/redaction, metadata merging, and warning/error cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->