### PR TITLE
fix(status-line): estimate usage for unsupported providers

### DIFF
--- a/src/components/BuiltinStatusLine.test.tsx
+++ b/src/components/BuiltinStatusLine.test.tsx
@@ -58,6 +58,25 @@ describe('buildBuiltinStatusSegments', () => {
     expect(at(90)).toBe('error')
   })
 
+  it('colors context by the displayed rounded percentage', () => {
+    const at = (pct: number) =>
+      buildBuiltinStatusSegments({ ...fullData, contextUsedPercent: pct }).find(
+        s => s.key === 'context',
+      )
+
+    expect(at(69.6)).toMatchObject({ text: 'ctx 70%', color: 'warning' })
+    expect(at(89.6)).toMatchObject({ text: 'ctx 90%', color: 'error' })
+  })
+
+  it('shows sub-one-percent context usage as nonzero', () => {
+    const context = buildBuiltinStatusSegments({
+      ...fullData,
+      contextUsedPercent: 0.01,
+    }).find(s => s.key === 'context')
+
+    expect(context?.text).toBe('ctx <1%')
+  })
+
   it('colors rate limit by usage thresholds', () => {
     const at = (pct: number) =>
       buildBuiltinStatusSegments({

--- a/src/components/BuiltinStatusLine.tsx
+++ b/src/components/BuiltinStatusLine.tsx
@@ -59,13 +59,15 @@ export function buildBuiltinStatusSegments(data: BuiltinStatusData): StatusSegme
     text: data.modelName
   }];
   if (data.contextUsedPercent !== null) {
-    const pct = Math.round(data.contextUsedPercent);
+    const pct = data.contextUsedPercent;
+    const roundedPct = Math.round(pct);
+    const pctText = pct > 0 && pct < 1 ? '<1' : String(roundedPct);
     segments.push({
       key: 'context',
       priority: 1,
-      text: `ctx ${pct}%`,
+      text: `ctx ${pctText}%`,
       // Thresholds align with the auto-compact warnings
-      color: pct >= 90 ? 'error' : pct >= 70 ? 'warning' : undefined
+      color: roundedPct >= 90 ? 'error' : roundedPct >= 70 ? 'warning' : undefined
     });
   }
   if (data.costUSD > 0) {

--- a/src/components/StatusLine.test.ts
+++ b/src/components/StatusLine.test.ts
@@ -1,0 +1,104 @@
+import { beforeEach, describe, expect, it } from 'bun:test'
+import { resetStateForTests } from '../cost-tracker.js'
+import { getUnreportedSessionUsage } from '../utils/tokens.js'
+import {
+  buildStatusLineCommandInput,
+  resolveStatusLineTokenTotals,
+} from './StatusLine.js'
+import type { AssistantMessage, Message } from '../types/message.js'
+
+;(globalThis as unknown as { MACRO: { VERSION: string } }).MACRO = {
+  VERSION: 'test-version',
+}
+
+const assistantMessage = (
+  content: string,
+  id = 'msg_unsupported',
+): AssistantMessage =>
+  ({
+    type: 'assistant',
+    uuid: '00000000-0000-0000-0000-000000000001',
+    timestamp: '2026-06-28T00:00:00.000Z',
+    message: {
+      id,
+      type: 'message',
+      role: 'assistant',
+      model: 'mimo-v2.5-pro',
+      content: [{ type: 'text', text: content }],
+      stop_reason: 'end_turn',
+      stop_sequence: null,
+      usage: {
+        input_tokens: 0,
+        output_tokens: 0,
+        cache_creation_input_tokens: 0,
+        cache_read_input_tokens: 0,
+      },
+    },
+  }) as unknown as AssistantMessage
+
+const userMessage = (content: string): Message =>
+  ({
+    type: 'user',
+    uuid: '00000000-0000-0000-0000-000000000002',
+    timestamp: '2026-06-28T00:00:00.000Z',
+    message: {
+      role: 'user',
+      content,
+    },
+  }) as Message
+
+describe('resolveStatusLineTokenTotals', () => {
+  it('keeps reported usage totals unchanged', () => {
+    expect(resolveStatusLineTokenTotals(1200, 300, null)).toEqual({
+      totalInputTokens: 1200,
+      totalOutputTokens: 300,
+      totalTokensAreEstimated: undefined,
+    })
+  })
+
+  it('adds unreported session usage to cumulative session totals', () => {
+    expect(
+      resolveStatusLineTokenTotals(1200, 300, {
+        input_tokens: 90,
+        output_tokens: 20,
+      }),
+    ).toEqual({
+      totalInputTokens: 1290,
+      totalOutputTokens: 320,
+      totalTokensAreEstimated: true,
+    })
+  })
+})
+
+describe('buildStatusLineCommandInput', () => {
+  beforeEach(() => {
+    resetStateForTests()
+  })
+
+  it('emits estimated cumulative totals for unreported provider usage', () => {
+    const messages = [
+      userMessage('Please summarize this repository.'),
+      assistantMessage('This repository contains source files and tests.'),
+    ]
+    const unreportedUsage = getUnreportedSessionUsage(messages)
+    expect(unreportedUsage).not.toBeNull()
+
+    const input = buildStatusLineCommandInput(
+      'default',
+      false,
+      {},
+      messages,
+      [],
+      'mimo-v2.5-pro',
+    )
+
+    expect(input.context_window).toMatchObject({
+      total_input_tokens: unreportedUsage!.input_tokens,
+      total_output_tokens: unreportedUsage!.output_tokens,
+      total_tokens_are_estimated: true,
+      current_usage: {
+        is_estimated: true,
+      },
+    })
+  })
+})

--- a/src/components/StatusLine.tsx
+++ b/src/components/StatusLine.tsx
@@ -24,7 +24,7 @@ import { createBaseHookInput, executeStatusLineCommand } from '../utils/hooks.js
 import { getLastAssistantMessage } from '../utils/messages.js';
 import { getRuntimeMainLoopModel, type ModelName, renderModelName } from '../utils/model/model.js';
 import { getCurrentSessionTitle } from '../utils/sessionStorage.js';
-import { doesMostRecentAssistantMessageExceed200k, getCurrentUsage } from '../utils/tokens.js';
+import { doesMostRecentAssistantMessageExceed200k, getCurrentUsage, getUnreportedSessionUsage, type SessionUsage } from '../utils/tokens.js';
 import { getCurrentWorktreeSession } from '../utils/worktree.js';
 import { isVimModeEnabled } from './PromptInput/utils.js';
 export function statusLineShouldDisplay(settings: ReadonlySettings): boolean {
@@ -33,7 +33,32 @@ export function statusLineShouldDisplay(settings: ReadonlySettings): boolean {
   if (feature('KAIROS') && getKairosActive()) return false;
   return settings?.statusLine !== undefined;
 }
-function buildStatusLineCommandInput(permissionMode: PermissionMode, exceeds200kTokens: boolean, settings: ReadonlySettings, messages: Message[], addedDirs: string[], mainLoopModel: ModelName, vimMode?: VimMode): StatusLineCommandInput {
+
+export function resolveStatusLineTokenTotals(
+  totalInputTokens: number,
+  totalOutputTokens: number,
+  unreportedSessionUsage: SessionUsage | null,
+): {
+  totalInputTokens: number;
+  totalOutputTokens: number;
+  totalTokensAreEstimated: boolean | undefined;
+} {
+  if (!unreportedSessionUsage) {
+    return {
+      totalInputTokens,
+      totalOutputTokens,
+      totalTokensAreEstimated: undefined,
+    };
+  }
+
+  return {
+    totalInputTokens: totalInputTokens + unreportedSessionUsage.input_tokens,
+    totalOutputTokens: totalOutputTokens + unreportedSessionUsage.output_tokens,
+    totalTokensAreEstimated: true,
+  };
+}
+
+export function buildStatusLineCommandInput(permissionMode: PermissionMode, exceeds200kTokens: boolean, settings: ReadonlySettings, messages: Message[], addedDirs: string[], mainLoopModel: ModelName, vimMode?: VimMode): StatusLineCommandInput {
   const agentType = getMainThreadAgentType();
   const worktreeSession = getCurrentWorktreeSession();
   const runtimeModel = getRuntimeMainLoopModel({
@@ -45,6 +70,9 @@ function buildStatusLineCommandInput(permissionMode: PermissionMode, exceeds200k
   const currentUsage = getCurrentUsage(messages);
   const contextWindowSize = getContextWindowForModel(runtimeModel, getSdkBetas());
   const contextPercentages = calculateContextPercentages(currentUsage, contextWindowSize);
+  const totalInputTokens = getTotalInputTokens();
+  const totalOutputTokens = getTotalOutputTokens();
+  const resolvedTokenTotals = resolveStatusLineTokenTotals(totalInputTokens, totalOutputTokens, getUnreportedSessionUsage(messages));
   const sessionId = getSessionId();
   const sessionName = getCurrentSessionTitle(sessionId);
   const rawUtil = getRawUtilization();
@@ -88,8 +116,9 @@ function buildStatusLineCommandInput(permissionMode: PermissionMode, exceeds200k
       total_lines_removed: getTotalLinesRemoved()
     },
     context_window: {
-      total_input_tokens: getTotalInputTokens(),
-      total_output_tokens: getTotalOutputTokens(),
+      total_input_tokens: resolvedTokenTotals.totalInputTokens,
+      total_output_tokens: resolvedTokenTotals.totalOutputTokens,
+      total_tokens_are_estimated: resolvedTokenTotals.totalTokensAreEstimated,
       context_window_size: contextWindowSize,
       current_usage: currentUsage,
       used_percentage: contextPercentages.used,

--- a/src/tools/AgentTool/built-in/statuslineSetup.ts
+++ b/src/tools/AgentTool/built-in/statuslineSetup.ts
@@ -52,14 +52,16 @@ How to use the statusLine command:
        "name": "string",         // Output style name (e.g., "default", "Explanatory", "Learning")
      },
      "context_window": {
-       "total_input_tokens": number,       // Total input tokens used in session (cumulative)
-       "total_output_tokens": number,      // Total output tokens used in session (cumulative)
+       "total_input_tokens": number,       // Total input tokens used in session (cumulative, estimated when provider does not report usage)
+       "total_output_tokens": number,      // Total output tokens used in session (cumulative, estimated when provider does not report usage)
+       "total_tokens_are_estimated": boolean | undefined, // true when session totals include transcript-based estimates for one or more turns whose provider did not report usage
        "context_window_size": number,      // Context window size for current model (e.g., 200000)
-       "current_usage": {                   // Token usage from last API call (null if no messages yet)
+       "current_usage": {                   // Token usage from last API call, or transcript estimate when provider reports all-zero usage (null if no messages yet)
          "input_tokens": number,           // Input tokens for current context
          "output_tokens": number,          // Output tokens generated
          "cache_creation_input_tokens": number,  // Tokens written to cache
-         "cache_read_input_tokens": number       // Tokens read from cache
+         "cache_read_input_tokens": number,      // Tokens read from cache
+         "is_estimated": boolean | undefined     // true when usage was estimated because provider did not report token counts
        } | null,
        "used_percentage": number | null,      // Pre-calculated: % of context used (0-100), null if no messages yet
        "remaining_percentage": number | null  // Pre-calculated: % of context remaining (0-100), null if no messages yet

--- a/src/types/statusLine.ts
+++ b/src/types/statusLine.ts
@@ -50,12 +50,22 @@ export type StatusLineCommandInput = {
   context_window: {
     total_input_tokens: number
     total_output_tokens: number
+    /**
+     * Present when session totals include transcript-based estimates for one
+     * or more turns whose provider did not report token usage.
+     */
+    total_tokens_are_estimated?: boolean
     context_window_size: number
     current_usage: {
       input_tokens: number
       output_tokens: number
       cache_creation_input_tokens: number
       cache_read_input_tokens: number
+      /**
+       * Present when the active provider did not report token usage and
+       * OpenClaude estimated the current context from the transcript.
+       */
+      is_estimated?: boolean
     } | null
     used_percentage: number | null
     remaining_percentage: number | null

--- a/src/utils/context.test.ts
+++ b/src/utils/context.test.ts
@@ -4,6 +4,7 @@ import { acquireSharedMutationLock, releaseSharedMutationLock } from '../test/sh
 import { getMaxOutputTokensForModel } from '../services/api/claude.ts'
 import { resolveOpenAIShimRuntimeContext } from '../integrations/runtimeMetadata.ts'
 import {
+  calculateContextPercentages,
   getContextWindowForModel,
   getModelMaxOutputTokens,
   modelSupports1M,
@@ -114,6 +115,22 @@ afterEach(() => {
   } finally {
     releaseSharedMutationLock()
   }
+})
+
+test('calculateContextPercentages preserves tiny nonzero usage', () => {
+  expect(
+    calculateContextPercentages(
+      {
+        input_tokens: 1,
+        cache_creation_input_tokens: 0,
+        cache_read_input_tokens: 0,
+      },
+      1_000_000,
+    ),
+  ).toEqual({
+    used: 0.01,
+    remaining: 99.99,
+  })
 })
 
 test('deepseek-v4-flash uses the gateway-safe output cap by default', () => {

--- a/src/utils/context.ts
+++ b/src/utils/context.ts
@@ -235,14 +235,16 @@ export function calculateContextPercentages(
     currentUsage.cache_creation_input_tokens +
     currentUsage.cache_read_input_tokens
 
-  const usedPercentage = Math.round(
-    (totalInputTokens / contextWindowSize) * 100,
-  )
+  const rawUsedPercentage = (totalInputTokens / contextWindowSize) * 100
+  const usedPercentage =
+    rawUsedPercentage > 0 && rawUsedPercentage < 0.01
+      ? 0.01
+      : Math.round(rawUsedPercentage * 100) / 100
   const clampedUsed = Math.min(100, Math.max(0, usedPercentage))
 
   return {
     used: clampedUsed,
-    remaining: 100 - clampedUsed,
+    remaining: Math.max(0, Math.round((100 - clampedUsed) * 100) / 100),
   }
 }
 

--- a/src/utils/tokens.test.ts
+++ b/src/utils/tokens.test.ts
@@ -1,8 +1,11 @@
-import { describe, expect, it, beforeEach } from 'bun:test'
+import { describe, expect, it } from 'bun:test'
 import {
-  getTokenCountFromUsage,
-} from './tokens.js'
+  roughTokenCountEstimationForMessage,
+  roughTokenCountEstimationForMessages,
+} from '../services/tokenEstimation.js'
+import { getCurrentUsage, getUnreportedSessionUsage } from './tokens.js'
 import { IncrementalTokenCounter } from './incrementalTokenCounter.js'
+import type { AssistantMessage, Message } from '../types/message.js'
 
 interface FakeUsage {
   input_tokens: number
@@ -12,6 +15,199 @@ interface FakeUsage {
 }
 
 describe('tokens', () => {
+  const assistantMessage = (
+    usage: FakeUsage,
+    content = 'assistant response',
+    id = 'msg_1',
+  ): AssistantMessage =>
+    ({
+      type: 'assistant',
+      uuid: '00000000-0000-0000-0000-000000000001',
+      timestamp: '2026-06-28T00:00:00.000Z',
+      message: {
+        id,
+        type: 'message',
+        role: 'assistant',
+        model: 'mimo-v2.5-pro',
+        content: [{ type: 'text', text: content }],
+        stop_reason: 'end_turn',
+        stop_sequence: null,
+        usage,
+      },
+    }) as unknown as AssistantMessage
+
+  const userMessage = (content: string): Message =>
+    ({
+      type: 'user',
+      uuid: '00000000-0000-0000-0000-000000000002',
+      timestamp: '2026-06-28T00:00:00.000Z',
+      message: {
+        role: 'user',
+        content,
+      },
+    }) as Message
+
+  it('returns reported API usage for non-zero assistant usage', () => {
+    expect(
+      getCurrentUsage([
+        userMessage('hello'),
+        assistantMessage({
+          input_tokens: 120,
+          output_tokens: 30,
+          cache_creation_input_tokens: 10,
+          cache_read_input_tokens: 5,
+        }),
+      ]),
+    ).toEqual({
+      input_tokens: 120,
+      output_tokens: 30,
+      cache_creation_input_tokens: 10,
+      cache_read_input_tokens: 5,
+    })
+  })
+
+  it('estimates current context when the latest provider usage is all zero', () => {
+    const prompt = userMessage('Please summarize this repository structure.')
+    const reply = assistantMessage(
+      {
+        input_tokens: 0,
+        output_tokens: 0,
+        cache_creation_input_tokens: 0,
+        cache_read_input_tokens: 0,
+      },
+      'The repository contains source files and tests.',
+    )
+    const usage = getCurrentUsage([prompt, reply])
+
+    expect(usage).toEqual({
+      input_tokens: Math.max(1, roughTokenCountEstimationForMessages([prompt])),
+      output_tokens: Math.max(1, roughTokenCountEstimationForMessage(reply)),
+      cache_creation_input_tokens: 0,
+      cache_read_input_tokens: 0,
+      is_estimated: true,
+    })
+  })
+
+  it('does not fall back to stale older API usage after all-zero provider usage', () => {
+    const older = assistantMessage(
+      {
+        input_tokens: 5000,
+        output_tokens: 250,
+      },
+      'Older Anthropic response.',
+      'msg_reported',
+    )
+    const prompt = userMessage('Now use a provider that does not report usage.')
+    const latest = assistantMessage(
+      {
+        input_tokens: 0,
+        output_tokens: 0,
+        cache_creation_input_tokens: 0,
+        cache_read_input_tokens: 0,
+      },
+      'Latest response from unsupported usage provider.',
+      'msg_unsupported',
+    )
+    const usage = getCurrentUsage([older, prompt, latest])
+
+    expect(usage).toEqual({
+      input_tokens: Math.max(
+        1,
+        roughTokenCountEstimationForMessages([older, prompt]),
+      ),
+      output_tokens: Math.max(1, roughTokenCountEstimationForMessage(latest)),
+      cache_creation_input_tokens: 0,
+      cache_read_input_tokens: 0,
+      is_estimated: true,
+    })
+  })
+
+  it('estimates split assistant response siblings as output tokens', () => {
+    const prompt = userMessage('Please run a tool and summarize the result.')
+    const firstChunk = assistantMessage(
+      {
+        input_tokens: 0,
+        output_tokens: 0,
+        cache_creation_input_tokens: 0,
+        cache_read_input_tokens: 0,
+      },
+      'First split response chunk with substantial text explaining the result.',
+      'msg_split',
+    )
+    const lastChunk = assistantMessage(
+      {
+        input_tokens: 0,
+        output_tokens: 0,
+        cache_creation_input_tokens: 0,
+        cache_read_input_tokens: 0,
+      },
+      'Final chunk.',
+      'msg_split',
+    )
+
+    const messages = [prompt, firstChunk, userMessage('tool result payload'), lastChunk]
+    const usage = getCurrentUsage(messages)
+    const expectedInputTokens = Math.max(
+      1,
+      roughTokenCountEstimationForMessages([prompt]),
+    )
+    const expectedOutputTokens = Math.max(
+      1,
+      roughTokenCountEstimationForMessage(firstChunk) +
+        roughTokenCountEstimationForMessage(lastChunk),
+    )
+
+    expect(usage?.is_estimated).toBe(true)
+    expect(usage?.input_tokens).toBe(expectedInputTokens)
+    expect(usage?.output_tokens).toBe(expectedOutputTokens)
+    expect(getUnreportedSessionUsage(messages)).toMatchObject({
+      input_tokens: expectedInputTokens,
+      output_tokens: expectedOutputTokens,
+    })
+  })
+
+  it('estimates cumulative unreported session usage from all-zero responses', () => {
+    const firstUser = userMessage('First user request.')
+    const firstAssistant = assistantMessage(
+      {
+        input_tokens: 0,
+        output_tokens: 0,
+        cache_creation_input_tokens: 0,
+        cache_read_input_tokens: 0,
+      },
+      'First unsupported provider response.',
+      'msg_first',
+    )
+    const secondUser = userMessage('Second user request.')
+    const secondAssistant = assistantMessage(
+      {
+        input_tokens: 0,
+        output_tokens: 0,
+        cache_creation_input_tokens: 0,
+        cache_read_input_tokens: 0,
+      },
+      'Second unsupported provider response.',
+      'msg_second',
+    )
+
+    const messages = [firstUser, firstAssistant, secondUser, secondAssistant]
+
+    expect(getUnreportedSessionUsage(messages)).toEqual({
+      input_tokens:
+        Math.max(1, roughTokenCountEstimationForMessages([firstUser])) +
+        Math.max(
+          1,
+          roughTokenCountEstimationForMessages([
+            firstUser,
+            firstAssistant,
+            secondUser,
+          ]),
+        ),
+      output_tokens:
+        Math.max(1, roughTokenCountEstimationForMessage(firstAssistant)) +
+        Math.max(1, roughTokenCountEstimationForMessage(secondAssistant)),
+    })
+  })
 })
 
 describe('IncrementalTokenCounter', () => {

--- a/src/utils/tokens.ts
+++ b/src/utils/tokens.ts
@@ -1,11 +1,28 @@
 import type { BetaUsage as Usage } from '@anthropic-ai/sdk/resources/beta/messages/messages.mjs'
-import { roughTokenCountEstimation, roughTokenCountEstimationForMessages } from '../services/tokenEstimation.js'
+import {
+  roughTokenCountEstimation,
+  roughTokenCountEstimationForMessage,
+  roughTokenCountEstimationForMessages,
+} from '../services/tokenEstimation.js'
 import type { AssistantMessage, Message } from '../types/message.js'
 import { SYNTHETIC_MESSAGES, SYNTHETIC_MODEL } from './messages.js'
 import { jsonStringify } from './slowOperations.js'
 import { IncrementalTokenCounter } from './incrementalTokenCounter.js'
 
 let _tokenCounter: IncrementalTokenCounter | undefined
+
+export type CurrentUsage = {
+  input_tokens: number
+  output_tokens: number
+  cache_creation_input_tokens: number
+  cache_read_input_tokens: number
+  is_estimated?: boolean
+}
+
+export type SessionUsage = {
+  input_tokens: number
+  output_tokens: number
+}
 
 export function getIncrementalTokenCounter(): IncrementalTokenCounter {
   if (!_tokenCounter) {
@@ -64,6 +81,115 @@ export function getTokenCountFromUsage(usage: Usage): number {
     (usage.cache_read_input_tokens ?? 0) +
     usage.output_tokens
   )
+}
+
+function isAllZeroUsage(usage: Usage): boolean {
+  return getTokenCountFromUsage(usage) === 0
+}
+
+function getAssistantResponseStartIndex(
+  messages: readonly Message[],
+  index: number,
+): number {
+  const message = messages[index]
+  const responseId = message ? getAssistantMessageId(message) : undefined
+  if (!responseId) return index
+
+  let startIndex = index
+  let j = index - 1
+  while (j >= 0) {
+    const prior = messages[j]
+    const priorId = prior ? getAssistantMessageId(prior) : undefined
+    if (priorId === responseId) {
+      startIndex = j
+    } else if (priorId !== undefined) {
+      break
+    }
+    j--
+  }
+  return startIndex
+}
+
+function getAssistantResponseEndIndex(
+  messages: readonly Message[],
+  index: number,
+): number {
+  const message = messages[index]
+  const responseId = message ? getAssistantMessageId(message) : undefined
+  if (!responseId) return index
+
+  let endIndex = index
+  for (let i = index + 1; i < messages.length; i++) {
+    const current = messages[i]
+    if (current && getAssistantMessageId(current) === responseId) {
+      endIndex = i
+    }
+  }
+  return endIndex
+}
+
+function estimateAssistantResponseOutputTokens(
+  messages: readonly Message[],
+  index: number,
+): number {
+  const message = messages[index]
+  const responseId = message ? getAssistantMessageId(message) : undefined
+  if (!responseId) {
+    return message ? roughTokenCountEstimationForMessage(message) : 0
+  }
+
+  const startIndex = getAssistantResponseStartIndex(messages, index)
+  let estimatedOutputTokens = 0
+  for (let i = startIndex; i <= index; i++) {
+    const current = messages[i]
+    if (current && getAssistantMessageId(current) === responseId) {
+      estimatedOutputTokens += roughTokenCountEstimationForMessage(current)
+    }
+  }
+  return estimatedOutputTokens
+}
+
+export function getUnreportedSessionUsage(
+  messages: readonly Message[],
+): SessionUsage | null {
+  let inputTokens = 0
+  let outputTokens = 0
+  const prefixTokenCounts: number[] = [0]
+  const seenResponseIds = new Set<string>()
+
+  for (const message of messages) {
+    prefixTokenCounts.push(
+      prefixTokenCounts[prefixTokenCounts.length - 1]! +
+        roughTokenCountEstimationForMessage(message),
+    )
+  }
+
+  for (let i = 0; i < messages.length; i++) {
+    const message = messages[i]
+    const usage = message ? getTokenUsage(message) : undefined
+    if (!message || !usage || !isAllZeroUsage(usage)) continue
+
+    const responseId = getAssistantMessageId(message)
+    if (responseId) {
+      if (seenResponseIds.has(responseId)) continue
+      seenResponseIds.add(responseId)
+    }
+
+    const startIndex = getAssistantResponseStartIndex(messages, i)
+    const endIndex = getAssistantResponseEndIndex(messages, i)
+    inputTokens += Math.max(1, prefixTokenCounts[startIndex] ?? 0)
+    outputTokens += Math.max(
+      1,
+      estimateAssistantResponseOutputTokens(messages, endIndex),
+    )
+  }
+
+  if (inputTokens === 0 && outputTokens === 0) return null
+
+  return {
+    input_tokens: inputTokens,
+    output_tokens: outputTokens,
+  }
 }
 
 export function tokenCountFromLastAPIResponse(messages: Message[]): number {
@@ -149,16 +275,30 @@ export function messageTokenCountFromLastAPIResponse(
   return 0
 }
 
-export function getCurrentUsage(messages: Message[]): {
-  input_tokens: number
-  output_tokens: number
-  cache_creation_input_tokens: number
-  cache_read_input_tokens: number
-} | null {
+export function getCurrentUsage(messages: Message[]): CurrentUsage | null {
   for (let i = messages.length - 1; i >= 0; i--) {
     const message = messages[i]
     const usage = message ? getTokenUsage(message) : undefined
     if (usage) {
+      if (isAllZeroUsage(usage)) {
+        const startIndex = getAssistantResponseStartIndex(messages, i)
+        const estimatedInputTokens = Math.max(
+          1,
+          roughTokenCountEstimationForMessages(messages.slice(0, startIndex)),
+        )
+        const estimatedOutputTokens = Math.max(
+          1,
+          estimateAssistantResponseOutputTokens(messages, i),
+        )
+        return {
+          input_tokens: estimatedInputTokens,
+          output_tokens: estimatedOutputTokens,
+          cache_creation_input_tokens: 0,
+          cache_read_input_tokens: 0,
+          is_estimated: true,
+        }
+      }
+
       return {
         input_tokens: usage.input_tokens,
         output_tokens: usage.output_tokens,
@@ -438,24 +578,7 @@ export function tokenCountWithEstimation(messages: readonly Message[]): number {
       // Walk back past any earlier sibling records split from the same API
       // response (same message.id) so interleaved tool_results between them
       // are included in the estimation slice.
-      const responseId = getAssistantMessageId(message)
-      if (responseId) {
-        let j = i - 1
-        while (j >= 0) {
-          const prior = messages[j]
-          const priorId = prior ? getAssistantMessageId(prior) : undefined
-          if (priorId === responseId) {
-            // Earlier split of the same API response — anchor here instead.
-            i = j
-          } else if (priorId !== undefined) {
-            // Hit a different API response — stop walking.
-            break
-          }
-          // priorId === undefined: a user/tool_result/attachment message,
-          // possibly interleaved between splits — keep walking.
-          j--
-        }
-      }
+      i = getAssistantResponseStartIndex(messages, i)
       return (
         getTokenCountFromUsage(usage) +
         getIncrementalTokenCounter().getCount(messages.slice(i + 1))
@@ -465,5 +588,3 @@ export function tokenCountWithEstimation(messages: readonly Message[]): number {
   }
   return getIncrementalTokenCounter().getCount(messages)
 }
-
-


### PR DESCRIPTION
## Summary

Fixes #448.

- Treat all-zero assistant usage from providers that do not report token counts as unsupported usage instead of real 0% usage.
- Estimate current input/output tokens from the local transcript for the status-line/analyze path and mark those values with `is_estimated`.
- Use estimated status-line totals whenever current provider usage is estimated, including mixed-provider sessions, and expose `total_tokens_are_estimated`.
- Preserve tiny nonzero context percentages in status JSON and show `ctx <1%` in the built-in status line instead of rounding back to `ctx 0%`.
- Update the `/statusline setup` schema docs and add focused regression tests.

## User Impact

For providers such as MiMo/OpenGateway that strip or omit streaming usage, the status line no longer stays stuck at misleading all-zero context usage after completed turns. Users get a clearly marked estimate instead of stale or zero-looking usage.

## Provider Path Tested

- MiMo/OpenGateway unsupported-usage path was validated by unit-level regression coverage around shimmed all-zero assistant usage.
- Existing provider suites were also run to check broader OpenAI-compatible/provider behavior.

## Limitations

This does not make unsupported providers return real billable token accounting, cache-token counts, or exact cost/session totals. When provider usage is unavailable, OpenClaude reports transcript-based estimates and marks them as estimated.

## Validation

- `bun install`
- `bun run build`
- `bun run smoke`
- `bun run typecheck`
- `bun run typecheck:type-tests`
- `bun test src/utils/tokens.test.ts src/utils/context.test.ts src/components/BuiltinStatusLine.test.tsx`
- `bun run check` → 5265 pass, 0 fail
- `bun run test:provider` → 954 pass, 0 fail
- `bun run test:provider-recommendation` → 103 pass, 0 fail
- `python -m pytest -q python/tests` → 44 passed
- `bun run security:pr-scan -- --base upstream/main` → no suspicious additions found

## Notes

The first sandboxed full-check attempt failed because some tests need temporary git repos, `/home/pi/.openclaude`, or loopback networking. Rerunning the affected suites and the full check outside those sandbox restrictions passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Status line now supports provider-unreported session token estimates, including `total_tokens_are_estimated` and an `is_estimated` indicator for current usage.

* **Bug Fixes**
  * Tiny non-zero context usage now renders as `ctx <1%`, while warning/error coloring still follows the rounded percentage.
  * Context percentage calculations now preserve very small fractional usage instead of rounding it to zero.

* **Documentation**
  * Updated status line schema/comments to clarify which token totals may be estimates.

* **Tests**
  * Added/expanded tests covering `ctx <1%` behavior and estimated-vs-exact token total resolution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->