### PR TITLE
feat: add /set-context-window and /clear-context-window commands

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -8,6 +8,7 @@ import goal from './commands/goal/index.js'
 import issue from './commands/issue/index.js'
 import feedback from './commands/feedback/index.js'
 import clear from './commands/clear/index.js'
+import clearContextWindow from './commands/clear-context-window/index.js'
 import color from './commands/color/index.js'
 import commit from './commands/commit.js'
 import commitMessage from './commands/commit-message/index.js'
@@ -52,6 +53,7 @@ import {
 import resume, { continueCommand } from './commands/resume/index.js'
 import review, { ultrareview } from './commands/review.js'
 import session from './commands/session/index.js'
+import setContextWindow from './commands/set-context-window/index.js'
 import share from './commands/share/index.js'
 import skills from './commands/skills/index.js'
 import status from './commands/status/index.js'
@@ -286,6 +288,7 @@ const COMMANDS = memoize((): Command[] => [
   cacheStats,
   chrome,
   clear,
+  clearContextWindow,
   color,
   compact,
   commitMessage,
@@ -331,6 +334,7 @@ const COMMANDS = memoize((): Command[] => [
   requestSizeNonInteractive,
   resume,
   session,
+  setContextWindow,
   skills,
   stats,
   status,

--- a/src/commands/clear-context-window/clear-context-window.ts
+++ b/src/commands/clear-context-window/clear-context-window.ts
@@ -1,0 +1,21 @@
+import type { LocalCommandCall } from '../../types/command.js'
+import {
+  clearSessionContextWindowOverride,
+  getSessionContextWindowOverrides,
+} from '../../utils/context.js'
+
+export const call: LocalCommandCall = async (args) => {
+  const trimmed = args.trim()
+
+  if (!trimmed) {
+    clearSessionContextWindowOverride()
+    return { type: 'text', value: 'All context window overrides cleared for this session.' }
+  }
+
+  clearSessionContextWindowOverride(trimmed)
+  const remaining = getSessionContextWindowOverrides()
+  if (remaining.size === 0) {
+    return { type: 'text', value: `Context window override for "${trimmed}" cleared. No overrides remaining.` }
+  }
+  return { type: 'text', value: `Context window override for "${trimmed}" cleared. ${remaining.size} override(s) remaining.` }
+}

--- a/src/commands/clear-context-window/index.ts
+++ b/src/commands/clear-context-window/index.ts
@@ -1,0 +1,10 @@
+import type { Command } from '../../commands.js'
+
+export default {
+  type: 'local',
+  name: 'clear-context-window',
+  description: 'Clear session-scoped context window overrides',
+  argumentHint: '[model]',
+  supportsNonInteractive: true,
+  load: () => import('./clear-context-window.js'),
+} satisfies Command

--- a/src/commands/clear/caches.ts
+++ b/src/commands/clear/caches.ts
@@ -31,6 +31,7 @@ import { clearRepositoryCaches } from '../../utils/detectRepository.js'
 import { clearResolveGitDirCache } from '../../utils/git/gitFilesystem.js'
 import { clearStoredImagePaths } from '../../utils/imageStore.js'
 import { clearSessionEnvVars } from '../../utils/sessionEnvVars.js'
+import { clearSessionContextWindowOverride } from '../../utils/context.js'
 
 /**
  * Clear all session-related caches.
@@ -131,6 +132,8 @@ export function clearSessionCaches(
   clearTrackedMagicDocs()
   // Clear session environment variables
   clearSessionEnvVars()
+  // Clear session-scoped context window overrides
+  clearSessionContextWindowOverride()
   // Clear WebFetch URL cache (up to 50MB of cached page content)
   void import('../../tools/WebFetchTool/utils.js').then(
     ({ clearWebFetchCache }) => clearWebFetchCache(),

--- a/src/commands/set-context-window/index.ts
+++ b/src/commands/set-context-window/index.ts
@@ -1,0 +1,10 @@
+import type { Command } from '../../commands.js'
+
+export default {
+  type: 'local',
+  name: 'set-context-window',
+  description: 'Set a session-scoped context window override for a model',
+  argumentHint: '[model] <tokens>',
+  supportsNonInteractive: true,
+  load: () => import('./set-context-window.js'),
+} satisfies Command

--- a/src/commands/set-context-window/set-context-window.ts
+++ b/src/commands/set-context-window/set-context-window.ts
@@ -4,6 +4,7 @@ import {
   getSessionContextWindowOverride,
   getSessionContextWindowOverrides,
 } from '../../utils/context.js'
+import { getMainLoopModel } from '../../utils/model/model.js'
 
 const HELP = `Usage: /set-context-window [model] <tokens>
 
@@ -41,7 +42,7 @@ export const call: LocalCommandCall = async (args, context) => {
   let tokensStr: string
 
   if (parts.length === 1) {
-    model = context.options.mainLoopModel
+    model = getMainLoopModel()
     tokensStr = parts[0]
   } else if (parts.length === 2) {
     model = parts[0]

--- a/src/commands/set-context-window/set-context-window.ts
+++ b/src/commands/set-context-window/set-context-window.ts
@@ -4,7 +4,6 @@ import {
   getSessionContextWindowOverride,
   getSessionContextWindowOverrides,
 } from '../../utils/context.js'
-import { getMainLoopModel } from '../../utils/model/model.js'
 
 const HELP = `Usage: /set-context-window [model] <tokens>
 
@@ -42,7 +41,7 @@ export const call: LocalCommandCall = async (args, context) => {
   let tokensStr: string
 
   if (parts.length === 1) {
-    model = getMainLoopModel()
+    model = context.options.mainLoopModel
     tokensStr = parts[0]
   } else if (parts.length === 2) {
     model = parts[0]

--- a/src/commands/set-context-window/set-context-window.ts
+++ b/src/commands/set-context-window/set-context-window.ts
@@ -1,0 +1,70 @@
+import type { LocalCommandCall } from '../../types/command.js'
+import {
+  setSessionContextWindowOverride,
+  getSessionContextWindowOverride,
+  getSessionContextWindowOverrides,
+} from '../../utils/context.js'
+
+const HELP = `Usage: /set-context-window [model] <tokens>
+
+Set a session-scoped context window override. Defaults to the active model.
+
+Examples:
+  /set-context-window 256000
+  /set-context-window gpt-4o 200000
+  /set-context-window status
+
+The override takes precedence over integration catalog and provider
+profile defaults. Use /clear-context-window to remove it.`
+
+export const call: LocalCommandCall = async (args, context) => {
+  const trimmed = args.trim()
+
+  if (!trimmed || trimmed === 'help' || trimmed === '-h' || trimmed === '--help') {
+    return { type: 'text', value: HELP }
+  }
+
+  if (trimmed === 'status' || trimmed === 'current') {
+    const overrides = getSessionContextWindowOverrides()
+    if (overrides.size === 0) {
+      return { type: 'text', value: 'No context window overrides set for this session.' }
+    }
+    const lines = Array.from(overrides.entries())
+      .map(([model, tokens]) => `  ${model}: ${tokens.toLocaleString()} tokens`)
+      .join('\n')
+    return { type: 'text', value: `Active context window overrides:\n${lines}` }
+  }
+
+  const parts = trimmed.split(/\s+/)
+
+  let model: string
+  let tokensStr: string
+
+  if (parts.length === 1) {
+    model = context.options.mainLoopModel
+    tokensStr = parts[0]
+  } else {
+    model = parts[0]
+    tokensStr = parts[1]
+  }
+
+  const tokens = parseInt(tokensStr, 10)
+  if (isNaN(tokens)) {
+    return { type: 'text', value: `Error: "${tokensStr}" is not a valid number.` }
+  }
+
+  const previous = getSessionContextWindowOverride(model)
+
+  const result = setSessionContextWindowOverride(model, tokens)
+  if (!result.ok) {
+    return { type: 'text', value: `Error: ${result.error}` }
+  }
+
+  const prevDisplay = previous !== undefined
+    ? `${previous.toLocaleString()} tokens`
+    : 'none (using default)'
+  return {
+    type: 'text',
+    value: `Context window for "${result.normalizedModel}" set to ${tokens.toLocaleString()} tokens (session only).\nPrevious: ${prevDisplay}`,
+  }
+}

--- a/src/commands/set-context-window/set-context-window.ts
+++ b/src/commands/set-context-window/set-context-window.ts
@@ -43,15 +43,17 @@ export const call: LocalCommandCall = async (args, context) => {
   if (parts.length === 1) {
     model = context.options.mainLoopModel
     tokensStr = parts[0]
-  } else {
+  } else if (parts.length === 2) {
     model = parts[0]
     tokensStr = parts[1]
+  } else {
+    return { type: 'text', value: `Error: expected 1 or 2 arguments, got ${parts.length}.\n\n${HELP}` }
   }
 
-  const tokens = parseInt(tokensStr, 10)
-  if (isNaN(tokens)) {
-    return { type: 'text', value: `Error: "${tokensStr}" is not a valid number.` }
+  if (!/^\d+$/.test(tokensStr)) {
+    return { type: 'text', value: `Error: "${tokensStr}" is not a valid integer.` }
   }
+  const tokens = Number(tokensStr)
 
   const previous = getSessionContextWindowOverride(model)
 

--- a/src/utils/context.test.ts
+++ b/src/utils/context.test.ts
@@ -946,18 +946,49 @@ test('setSessionContextWindowOverride sets and gets override', () => {
   expect(getSessionContextWindowOverride('gpt-4o')).toBe(256_000)
 })
 
-test('setSessionContextWindowOverride normalizes case only, preserves provider prefix', () => {
+test('setSessionContextWindowOverride normalizes case and provider prefix', () => {
   setSessionContextWindowOverride('OpenAI/GPT-4o', 200_000)
   expect(getSessionContextWindowOverride('openai/gpt-4o')).toBe(200_000)
   expect(getSessionContextWindowOverride('OpenAI/GPT-4o')).toBe(200_000)
+  expect(getSessionContextWindowOverride('gpt-4o')).toBe(200_000)
 })
 
-test('provider-qualified and unqualified model names are distinct', () => {
+test('provider-qualified and unqualified model names map to the same canonical key', () => {
   setSessionContextWindowOverride('zai-org/glm-5.2', 256_000)
-  setSessionContextWindowOverride('glm-5.2', 128_000)
   expect(getSessionContextWindowOverride('zai-org/glm-5.2')).toBe(256_000)
+  expect(getSessionContextWindowOverride('glm-5.2')).toBe(256_000)
+
+  setSessionContextWindowOverride('glm-5.2', 128_000)
+  expect(getSessionContextWindowOverride('zai-org/glm-5.2')).toBe(128_000)
   expect(getSessionContextWindowOverride('glm-5.2')).toBe(128_000)
-  expect(getSessionContextWindowOverrides().size).toBe(2)
+})
+
+test('mixed-order setting and clearing qualified/unqualified aliases', () => {
+  // Path 1: Set qualified, then set unqualified, then clear unqualified
+  setSessionContextWindowOverride('openai/gpt-4o', 256_000)
+  expect(getSessionContextWindowOverride('openai/gpt-4o')).toBe(256_000)
+  expect(getSessionContextWindowOverride('gpt-4o')).toBe(256_000)
+
+  setSessionContextWindowOverride('gpt-4o', 128_000)
+  expect(getSessionContextWindowOverride('openai/gpt-4o')).toBe(128_000)
+  expect(getSessionContextWindowOverride('gpt-4o')).toBe(128_000)
+
+  clearSessionContextWindowOverride('gpt-4o')
+  expect(getSessionContextWindowOverride('openai/gpt-4o')).toBeUndefined()
+  expect(getSessionContextWindowOverride('gpt-4o')).toBeUndefined()
+
+  // Path 2: Set unqualified, then set qualified, then clear qualified
+  setSessionContextWindowOverride('gpt-4o', 200_000)
+  expect(getSessionContextWindowOverride('gpt-4o')).toBe(200_000)
+  expect(getSessionContextWindowOverride('openai/gpt-4o')).toBe(200_000)
+
+  setSessionContextWindowOverride('openai/gpt-4o', 300_000)
+  expect(getSessionContextWindowOverride('gpt-4o')).toBe(300_000)
+  expect(getSessionContextWindowOverride('openai/gpt-4o')).toBe(300_000)
+
+  clearSessionContextWindowOverride('openai/gpt-4o')
+  expect(getSessionContextWindowOverride('gpt-4o')).toBeUndefined()
+  expect(getSessionContextWindowOverride('openai/gpt-4o')).toBeUndefined()
 })
 
 test('writing openai/gpt-4o is readable via gpt-4o', () => {
@@ -1036,11 +1067,10 @@ test('session override takes precedence over known model catalog metadata', () =
   expect(getContextWindowForModel('gpt-4o')).toBe(defaultWindow)
 })
 
-test('provider-qualified override stores both qualified and stripped keys', () => {
+test('provider-qualified override maps to canonical key', () => {
   setSessionContextWindowOverride('zai-org/glm-5.2', 256_000)
   expect(getSessionContextWindowOverride('zai-org/glm-5.2')).toBe(256_000)
   expect(getSessionContextWindowOverride('glm-5.2')).toBe(256_000)
-  expect(getSessionContextWindowOverrides().size).toBe(2)
 })
 
 test('clearSessionContextWindowOverride resets state for session isolation', () => {

--- a/src/utils/context.test.ts
+++ b/src/utils/context.test.ts
@@ -982,6 +982,14 @@ test('clearSessionContextWindowOverride clears specific model', () => {
   expect(getSessionContextWindowOverride('claude-sonnet-4')).toBe(200_000)
 })
 
+test('clearSessionContextWindowOverride clears stripped fallback when clearing qualified name', () => {
+  setSessionContextWindowOverride('gpt-4o', 256_000)
+  expect(getSessionContextWindowOverride('openai/gpt-4o')).toBe(256_000)
+  clearSessionContextWindowOverride('openai/gpt-4o')
+  expect(getSessionContextWindowOverride('gpt-4o')).toBeUndefined()
+  expect(getSessionContextWindowOverride('openai/gpt-4o')).toBeUndefined()
+})
+
 test('clearSessionContextWindowOverride clears all when no model specified', () => {
   setSessionContextWindowOverride('gpt-4o', 256_000)
   setSessionContextWindowOverride('claude-sonnet-4', 200_000)

--- a/src/utils/context.test.ts
+++ b/src/utils/context.test.ts
@@ -960,6 +960,12 @@ test('provider-qualified and unqualified model names are distinct', () => {
   expect(getSessionContextWindowOverrides().size).toBe(2)
 })
 
+test('writing openai/gpt-4o is readable via gpt-4o', () => {
+  setSessionContextWindowOverride('openai/gpt-4o', 256_000)
+  expect(getSessionContextWindowOverride('gpt-4o')).toBe(256_000)
+  expect(getSessionContextWindowOverride('openai/gpt-4o')).toBe(256_000)
+})
+
 test('setSessionContextWindowOverride rejects below minimum', () => {
   const result = setSessionContextWindowOverride('gpt-4o', 10_000)
   expect(result.ok).toBe(false)
@@ -1030,10 +1036,11 @@ test('session override takes precedence over known model catalog metadata', () =
   expect(getContextWindowForModel('gpt-4o')).toBe(defaultWindow)
 })
 
-test('provider-qualified override does not bleed into unqualified lookup', () => {
+test('provider-qualified override stores both qualified and stripped keys', () => {
   setSessionContextWindowOverride('zai-org/glm-5.2', 256_000)
-  expect(getContextWindowForModel('zai-org/glm-5.2')).toBe(256_000)
-  expect(getSessionContextWindowOverride('glm-5.2')).toBeUndefined()
+  expect(getSessionContextWindowOverride('zai-org/glm-5.2')).toBe(256_000)
+  expect(getSessionContextWindowOverride('glm-5.2')).toBe(256_000)
+  expect(getSessionContextWindowOverrides().size).toBe(2)
 })
 
 test('clearSessionContextWindowOverride resets state for session isolation', () => {

--- a/src/utils/context.test.ts
+++ b/src/utils/context.test.ts
@@ -7,6 +7,7 @@ import {
   getContextWindowForModel,
   getModelMaxOutputTokens,
   modelSupports1M,
+  clearSessionContextWindowOverride,
 } from './context.ts'
 
 const originalEnv = {
@@ -26,6 +27,8 @@ const originalEnv = {
     process.env.CLAUDE_CODE_PROVIDER_PROFILE_ENV_APPLIED_ID,
   MINIMAX_API_KEY: process.env.MINIMAX_API_KEY,
   XAI_API_KEY: process.env.XAI_API_KEY,
+  CLAUDE_CODE_MAX_CONTEXT_TOKENS: process.env.CLAUDE_CODE_MAX_CONTEXT_TOKENS,
+  USER_TYPE: process.env.USER_TYPE,
 }
 
 beforeEach(async () => {
@@ -43,6 +46,8 @@ beforeEach(async () => {
   delete process.env.CLAUDE_CODE_PROVIDER_PROFILE_ENV_APPLIED_ID
   delete process.env.MINIMAX_API_KEY
   delete process.env.XAI_API_KEY
+  delete process.env.CLAUDE_CODE_MAX_CONTEXT_TOKENS
+  delete process.env.USER_TYPE
 })
 
 afterEach(() => {
@@ -111,6 +116,16 @@ afterEach(() => {
       delete process.env.XAI_API_KEY
     } else {
       process.env.XAI_API_KEY = originalEnv.XAI_API_KEY
+    }
+    if (originalEnv.CLAUDE_CODE_MAX_CONTEXT_TOKENS === undefined) {
+      delete process.env.CLAUDE_CODE_MAX_CONTEXT_TOKENS
+    } else {
+      process.env.CLAUDE_CODE_MAX_CONTEXT_TOKENS = originalEnv.CLAUDE_CODE_MAX_CONTEXT_TOKENS
+    }
+    if (originalEnv.USER_TYPE === undefined) {
+      delete process.env.USER_TYPE
+    } else {
+      process.env.USER_TYPE = originalEnv.USER_TYPE
     }
   } finally {
     clearSessionContextWindowOverride()
@@ -934,7 +949,6 @@ test('modelSupports1M honors the 1M disable switch even for Opus 4.7', () => {
 
 import {
   setSessionContextWindowOverride,
-  clearSessionContextWindowOverride,
   getSessionContextWindowOverride,
   getSessionContextWindowOverrides,
 } from './context.ts'
@@ -1065,6 +1079,13 @@ test('session override takes precedence over known model catalog metadata', () =
   expect(getContextWindowForModel('gpt-4o')).toBe(500_000)
   clearSessionContextWindowOverride()
   expect(getContextWindowForModel('gpt-4o')).toBe(defaultWindow)
+})
+
+test('CLAUDE_CODE_MAX_CONTEXT_TOKENS takes precedence over session override', () => {
+  process.env.USER_TYPE = 'ant'
+  process.env.CLAUDE_CODE_MAX_CONTEXT_TOKENS = '50000'
+  setSessionContextWindowOverride('gpt-4o', 200_000)
+  expect(getContextWindowForModel('gpt-4o')).toBe(50_000)
 })
 
 test('provider-qualified override maps to canonical key', () => {

--- a/src/utils/context.test.ts
+++ b/src/utils/context.test.ts
@@ -946,10 +946,18 @@ test('setSessionContextWindowOverride sets and gets override', () => {
   expect(getSessionContextWindowOverride('gpt-4o')).toBe(256_000)
 })
 
-test('setSessionContextWindowOverride normalizes provider prefix', () => {
-  setSessionContextWindowOverride('openai/gpt-4o', 200_000)
-  expect(getSessionContextWindowOverride('gpt-4o')).toBe(200_000)
+test('setSessionContextWindowOverride normalizes case only, preserves provider prefix', () => {
+  setSessionContextWindowOverride('OpenAI/GPT-4o', 200_000)
   expect(getSessionContextWindowOverride('openai/gpt-4o')).toBe(200_000)
+  expect(getSessionContextWindowOverride('OpenAI/GPT-4o')).toBe(200_000)
+})
+
+test('provider-qualified and unqualified model names are distinct', () => {
+  setSessionContextWindowOverride('zai-org/glm-5.2', 256_000)
+  setSessionContextWindowOverride('glm-5.2', 128_000)
+  expect(getSessionContextWindowOverride('zai-org/glm-5.2')).toBe(256_000)
+  expect(getSessionContextWindowOverride('glm-5.2')).toBe(128_000)
+  expect(getSessionContextWindowOverrides().size).toBe(2)
 })
 
 test('setSessionContextWindowOverride rejects below minimum', () => {
@@ -1004,4 +1012,26 @@ test('session override takes precedence over unknown model fallback', () => {
   expect(getContextWindowForModel('unknown-model')).toBe(200_000)
   clearSessionContextWindowOverride()
   expect(getContextWindowForModel('unknown-model')).toBe(128_000)
+})
+
+test('session override takes precedence over known model catalog metadata', () => {
+  const defaultWindow = getContextWindowForModel('gpt-4o')
+  setSessionContextWindowOverride('gpt-4o', 500_000)
+  expect(getContextWindowForModel('gpt-4o')).toBe(500_000)
+  clearSessionContextWindowOverride()
+  expect(getContextWindowForModel('gpt-4o')).toBe(defaultWindow)
+})
+
+test('provider-qualified override does not bleed into unqualified lookup', () => {
+  setSessionContextWindowOverride('zai-org/glm-5.2', 256_000)
+  expect(getContextWindowForModel('zai-org/glm-5.2')).toBe(256_000)
+  expect(getSessionContextWindowOverride('glm-5.2')).toBeUndefined()
+})
+
+test('clearSessionContextWindowOverride resets state for session isolation', () => {
+  setSessionContextWindowOverride('gpt-4o', 256_000)
+  expect(getSessionContextWindowOverride('gpt-4o')).toBe(256_000)
+  clearSessionContextWindowOverride()
+  expect(getSessionContextWindowOverride('gpt-4o')).toBeUndefined()
+  expect(getContextWindowForModel('gpt-4o')).not.toBe(256_000)
 })

--- a/src/utils/context.test.ts
+++ b/src/utils/context.test.ts
@@ -927,3 +927,72 @@ test('modelSupports1M honors the 1M disable switch even for Opus 4.7', () => {
     }
   }
 })
+
+// --- Session-scoped context window overrides ---
+
+import {
+  setSessionContextWindowOverride,
+  clearSessionContextWindowOverride,
+  getSessionContextWindowOverride,
+  getSessionContextWindowOverrides,
+} from './context.ts'
+
+test('setSessionContextWindowOverride sets and gets override', () => {
+  const result = setSessionContextWindowOverride('gpt-4o', 256_000)
+  expect(result.ok).toBe(true)
+  if (result.ok) expect(result.normalizedModel).toBe('gpt-4o')
+  expect(getSessionContextWindowOverride('gpt-4o')).toBe(256_000)
+  clearSessionContextWindowOverride()
+})
+
+test('setSessionContextWindowOverride normalizes provider prefix', () => {
+  setSessionContextWindowOverride('openai/gpt-4o', 200_000)
+  expect(getSessionContextWindowOverride('gpt-4o')).toBe(200_000)
+  expect(getSessionContextWindowOverride('openai/gpt-4o')).toBe(200_000)
+  clearSessionContextWindowOverride()
+})
+
+test('setSessionContextWindowOverride rejects below minimum', () => {
+  const result = setSessionContextWindowOverride('gpt-4o', 10_000)
+  expect(result.ok).toBe(false)
+  if (!result.ok) expect(result.error).toContain('at least')
+  expect(getSessionContextWindowOverride('gpt-4o')).toBeUndefined()
+})
+
+test('setSessionContextWindowOverride rejects non-finite values', () => {
+  expect(setSessionContextWindowOverride('gpt-4o', NaN).ok).toBe(false)
+  expect(setSessionContextWindowOverride('gpt-4o', Infinity).ok).toBe(false)
+  expect(setSessionContextWindowOverride('gpt-4o', -1).ok).toBe(false)
+})
+
+test('clearSessionContextWindowOverride clears specific model', () => {
+  setSessionContextWindowOverride('gpt-4o', 256_000)
+  setSessionContextWindowOverride('claude-sonnet-4', 200_000)
+  clearSessionContextWindowOverride('gpt-4o')
+  expect(getSessionContextWindowOverride('gpt-4o')).toBeUndefined()
+  expect(getSessionContextWindowOverride('claude-sonnet-4')).toBe(200_000)
+  clearSessionContextWindowOverride()
+})
+
+test('clearSessionContextWindowOverride clears all when no model specified', () => {
+  setSessionContextWindowOverride('gpt-4o', 256_000)
+  setSessionContextWindowOverride('claude-sonnet-4', 200_000)
+  clearSessionContextWindowOverride()
+  expect(getSessionContextWindowOverrides().size).toBe(0)
+})
+
+test('getSessionContextWindowOverrides returns a copy', () => {
+  setSessionContextWindowOverride('gpt-4o', 256_000)
+  const copy = getSessionContextWindowOverrides()
+  copy.delete('gpt-4o')
+  expect(getSessionContextWindowOverride('gpt-4o')).toBe(256_000)
+  clearSessionContextWindowOverride()
+})
+
+test('session override takes precedence over fallback in getContextWindowForModel', () => {
+  process.env.CLAUDE_CODE_USE_OPENAI = '1'
+  setSessionContextWindowOverride('unknown-model', 200_000)
+  expect(getContextWindowForModel('unknown-model')).toBe(200_000)
+  clearSessionContextWindowOverride()
+  expect(getContextWindowForModel('unknown-model')).toBe(128_000)
+})

--- a/src/utils/context.test.ts
+++ b/src/utils/context.test.ts
@@ -30,6 +30,7 @@ const originalEnv = {
 
 beforeEach(async () => {
   await acquireSharedMutationLock('context.test.ts')
+  clearSessionContextWindowOverride()
   delete process.env.CLAUDE_CODE_USE_OPENAI
   delete process.env.CLAUDE_CODE_MAX_OUTPUT_TOKENS
   delete process.env.CLAUDE_CODE_OPENAI_CONTEXT_WINDOWS
@@ -112,6 +113,7 @@ afterEach(() => {
       process.env.XAI_API_KEY = originalEnv.XAI_API_KEY
     }
   } finally {
+    clearSessionContextWindowOverride()
     releaseSharedMutationLock()
   }
 })
@@ -942,14 +944,12 @@ test('setSessionContextWindowOverride sets and gets override', () => {
   expect(result.ok).toBe(true)
   if (result.ok) expect(result.normalizedModel).toBe('gpt-4o')
   expect(getSessionContextWindowOverride('gpt-4o')).toBe(256_000)
-  clearSessionContextWindowOverride()
 })
 
 test('setSessionContextWindowOverride normalizes provider prefix', () => {
   setSessionContextWindowOverride('openai/gpt-4o', 200_000)
   expect(getSessionContextWindowOverride('gpt-4o')).toBe(200_000)
   expect(getSessionContextWindowOverride('openai/gpt-4o')).toBe(200_000)
-  clearSessionContextWindowOverride()
 })
 
 test('setSessionContextWindowOverride rejects below minimum', () => {
@@ -959,10 +959,11 @@ test('setSessionContextWindowOverride rejects below minimum', () => {
   expect(getSessionContextWindowOverride('gpt-4o')).toBeUndefined()
 })
 
-test('setSessionContextWindowOverride rejects non-finite values', () => {
+test('setSessionContextWindowOverride rejects non-integer values', () => {
   expect(setSessionContextWindowOverride('gpt-4o', NaN).ok).toBe(false)
   expect(setSessionContextWindowOverride('gpt-4o', Infinity).ok).toBe(false)
   expect(setSessionContextWindowOverride('gpt-4o', -1).ok).toBe(false)
+  expect(setSessionContextWindowOverride('gpt-4o', 64_000.5).ok).toBe(false)
 })
 
 test('clearSessionContextWindowOverride clears specific model', () => {
@@ -971,7 +972,6 @@ test('clearSessionContextWindowOverride clears specific model', () => {
   clearSessionContextWindowOverride('gpt-4o')
   expect(getSessionContextWindowOverride('gpt-4o')).toBeUndefined()
   expect(getSessionContextWindowOverride('claude-sonnet-4')).toBe(200_000)
-  clearSessionContextWindowOverride()
 })
 
 test('clearSessionContextWindowOverride clears all when no model specified', () => {
@@ -986,10 +986,19 @@ test('getSessionContextWindowOverrides returns a copy', () => {
   const copy = getSessionContextWindowOverrides()
   copy.delete('gpt-4o')
   expect(getSessionContextWindowOverride('gpt-4o')).toBe(256_000)
-  clearSessionContextWindowOverride()
 })
 
-test('session override takes precedence over fallback in getContextWindowForModel', () => {
+test('session override takes precedence over env override for OpenAI-compatible model', () => {
+  process.env.CLAUDE_CODE_USE_OPENAI = '1'
+  process.env.CLAUDE_CODE_OPENAI_CONTEXT_WINDOWS = JSON.stringify({ 'custom-model': 64_000 })
+  expect(getContextWindowForModel('custom-model')).toBe(64_000)
+  setSessionContextWindowOverride('custom-model', 256_000)
+  expect(getContextWindowForModel('custom-model')).toBe(256_000)
+  clearSessionContextWindowOverride()
+  expect(getContextWindowForModel('custom-model')).toBe(64_000)
+})
+
+test('session override takes precedence over unknown model fallback', () => {
   process.env.CLAUDE_CODE_USE_OPENAI = '1'
   setSessionContextWindowOverride('unknown-model', 200_000)
   expect(getContextWindowForModel('unknown-model')).toBe(200_000)

--- a/src/utils/context.ts
+++ b/src/utils/context.ts
@@ -56,12 +56,13 @@ const sessionContextWindowOverrides = new Map<string, number>()
 const MIN_CONTEXT_WINDOW_OVERRIDE = 33_000
 
 /**
- * Normalize a model name for override lookup.
- * Lowercases only — preserves provider-qualified names like zai-org/glm-5.2
- * so they don't collide with unqualified glm-5.2.
+ * Normalize a model name for override lookup to get a single canonical key
+ * for the model family (lowercase, prefix stripped).
  */
 function normalizeModelName(model: string): string {
-  return model.toLowerCase()
+  const lowered = model.toLowerCase()
+  const stripped = stripProviderPrefix(lowered)
+  return stripped !== undefined ? stripped : lowered
 }
 
 /**
@@ -94,27 +95,18 @@ export function setSessionContextWindowOverride(
   }
   const normalized = normalizeModelName(model)
   sessionContextWindowOverrides.set(normalized, tokens)
-  const stripped = stripProviderPrefix(normalized)
-  if (stripped !== undefined) {
-    sessionContextWindowOverrides.set(stripped, tokens)
-  }
   return { ok: true, normalizedModel: normalized }
 }
 
 /**
  * Clear session-scoped context window overrides.
- * If model is provided, clears both the exact key and any stripped-prefix
- * fallback key to stay consistent with getSessionContextWindowOverride lookup.
+ * If model is provided, clears the canonical key for the model family.
  * If model is omitted, clears all overrides.
  */
 export function clearSessionContextWindowOverride(model?: string): void {
   if (model) {
     const normalized = normalizeModelName(model)
     sessionContextWindowOverrides.delete(normalized)
-    const stripped = stripProviderPrefix(normalized)
-    if (stripped !== undefined) {
-      sessionContextWindowOverrides.delete(stripped)
-    }
   } else {
     sessionContextWindowOverrides.clear()
   }
@@ -122,17 +114,13 @@ export function clearSessionContextWindowOverride(model?: string): void {
 
 /**
  * Get the current session-scoped context window override for a model, if any.
- * Tries the full normalized name first, then falls back to the stripped prefix
- * variant (e.g. openai/gpt-4o → gpt-4o) for convenience.
+ * Resolves to the canonical key for the model family.
  */
 export function getSessionContextWindowOverride(
   model: string,
 ): number | undefined {
   const normalized = normalizeModelName(model)
-  const exact = sessionContextWindowOverrides.get(normalized)
-  if (exact !== undefined) return exact
-  const stripped = stripProviderPrefix(normalized)
-  return stripped !== undefined ? sessionContextWindowOverrides.get(stripped) : undefined
+  return sessionContextWindowOverrides.get(normalized)
 }
 
 /**

--- a/src/utils/context.ts
+++ b/src/utils/context.ts
@@ -99,13 +99,18 @@ export function setSessionContextWindowOverride(
 
 /**
  * Clear session-scoped context window overrides.
- * If model is provided, clears only that model's override.
+ * If model is provided, clears both the exact key and any stripped-prefix
+ * fallback key to stay consistent with getSessionContextWindowOverride lookup.
  * If model is omitted, clears all overrides.
  */
 export function clearSessionContextWindowOverride(model?: string): void {
   if (model) {
     const normalized = normalizeModelName(model)
     sessionContextWindowOverrides.delete(normalized)
+    const stripped = stripProviderPrefix(normalized)
+    if (stripped !== undefined) {
+      sessionContextWindowOverrides.delete(stripped)
+    }
   } else {
     sessionContextWindowOverrides.clear()
   }

--- a/src/utils/context.ts
+++ b/src/utils/context.ts
@@ -53,7 +53,7 @@ const sessionContextWindowOverrides = new Map<string, number>()
 
 // Minimum context window to avoid auto-compact floor paradox
 // (reservedTokensForSummary + autocompactBuffer = 20k + 13k = 33k)
-const MIN_CONTEXT_WINDOW_OVERRIDE = 32_000
+const MIN_CONTEXT_WINDOW_OVERRIDE = 33_000
 
 /**
  * Normalize a model name for override lookup.

--- a/src/utils/context.ts
+++ b/src/utils/context.ts
@@ -46,6 +46,82 @@ const warnedUnknownIntegrationRuntimeLimitKeys = new Set<string>()
 const PROFILE_ENV_APPLIED_FLAG = 'CLAUDE_CODE_PROVIDER_PROFILE_ENV_APPLIED'
 const PROFILE_ENV_APPLIED_ID = 'CLAUDE_CODE_PROVIDER_PROFILE_ENV_APPLIED_ID'
 
+// Session-scoped context window overrides (abordagem C: module-level state)
+// Key: normalized model name (lowercase, prefix stripped)
+// Value: context window in tokens
+const sessionContextWindowOverrides = new Map<string, number>()
+
+// Minimum context window to avoid auto-compact floor paradox
+// (reservedTokensForSummary + autocompactBuffer = 20k + 13k = 33k)
+const MIN_CONTEXT_WINDOW_OVERRIDE = 32_000
+
+/**
+ * Normalize a model name for override lookup.
+ * Strips provider prefixes (openai/, anthropic/, copilot/, etc.) and lowercases.
+ */
+function normalizeModelName(model: string): string {
+  return model
+    .toLowerCase()
+    .replace(/^[a-z][\w-]*\//, '')
+}
+
+/**
+ * Set a session-scoped context window override for a specific model.
+ * Used by the /set_context_window slash command.
+ * The override is in-memory only and dies with the session.
+ *
+ * Returns the normalized model key used for storage.
+ */
+export function setSessionContextWindowOverride(
+  model: string,
+  tokens: number,
+): { ok: true; normalizedModel: string } | { ok: false; error: string } {
+  if (!Number.isFinite(tokens) || tokens <= 0) {
+    return { ok: false, error: 'Context window must be a positive number' }
+  }
+  if (tokens < MIN_CONTEXT_WINDOW_OVERRIDE) {
+    return {
+      ok: false,
+      error: `Context window must be at least ${MIN_CONTEXT_WINDOW_OVERRIDE} tokens (current: ${tokens})`,
+    }
+  }
+  const normalized = normalizeModelName(model)
+  sessionContextWindowOverrides.set(normalized, tokens)
+  return { ok: true, normalizedModel: normalized }
+}
+
+/**
+ * Clear session-scoped context window overrides.
+ * If model is provided, clears only that model's override.
+ * If model is omitted, clears all overrides.
+ */
+export function clearSessionContextWindowOverride(model?: string): void {
+  if (model) {
+    const normalized = normalizeModelName(model)
+    sessionContextWindowOverrides.delete(normalized)
+  } else {
+    sessionContextWindowOverrides.clear()
+  }
+}
+
+/**
+ * Get the current session-scoped context window override for a model, if any.
+ */
+export function getSessionContextWindowOverride(
+  model: string,
+): number | undefined {
+  const normalized = normalizeModelName(model)
+  return sessionContextWindowOverrides.get(normalized)
+}
+
+/**
+ * Get all current session-scoped context window overrides.
+ * Returns a copy of the internal map.
+ */
+export function getSessionContextWindowOverrides(): Map<string, number> {
+  return new Map(sessionContextWindowOverrides)
+}
+
 /**
  * Check if 1M context is disabled via environment variable.
  * Used by C4E admins to disable 1M context for HIPAA compliance.
@@ -150,6 +226,13 @@ export function getContextWindowForModel(
     if (!isNaN(override) && override > 0) {
       return override
     }
+  }
+
+  // Session-scoped override — set via /set_context_window command.
+  // Takes precedence over all resolution except the internal env var above.
+  const sessionOverride = getSessionContextWindowOverride(model)
+  if (sessionOverride !== undefined) {
+    return sessionOverride
   }
 
   // [1m] suffix — explicit client-side opt-in, respected over all detection

--- a/src/utils/context.ts
+++ b/src/utils/context.ts
@@ -94,6 +94,10 @@ export function setSessionContextWindowOverride(
   }
   const normalized = normalizeModelName(model)
   sessionContextWindowOverrides.set(normalized, tokens)
+  const stripped = stripProviderPrefix(normalized)
+  if (stripped !== undefined) {
+    sessionContextWindowOverrides.set(stripped, tokens)
+  }
   return { ok: true, normalizedModel: normalized }
 }
 

--- a/src/utils/context.ts
+++ b/src/utils/context.ts
@@ -57,12 +57,19 @@ const MIN_CONTEXT_WINDOW_OVERRIDE = 33_000
 
 /**
  * Normalize a model name for override lookup.
- * Strips provider prefixes (openai/, anthropic/, copilot/, etc.) and lowercases.
+ * Lowercases only — preserves provider-qualified names like zai-org/glm-5.2
+ * so they don't collide with unqualified glm-5.2.
  */
 function normalizeModelName(model: string): string {
-  return model
-    .toLowerCase()
-    .replace(/^[a-z][\w-]*\//, '')
+  return model.toLowerCase()
+}
+
+/**
+ * Strip a leading provider prefix (e.g. openai/, anthropic/) for fallback lookup.
+ */
+function stripProviderPrefix(model: string): string | undefined {
+  const stripped = model.replace(/^[a-z][\w-]*\//, '')
+  return stripped !== model ? stripped : undefined
 }
 
 /**
@@ -106,12 +113,17 @@ export function clearSessionContextWindowOverride(model?: string): void {
 
 /**
  * Get the current session-scoped context window override for a model, if any.
+ * Tries the full normalized name first, then falls back to the stripped prefix
+ * variant (e.g. openai/gpt-4o → gpt-4o) for convenience.
  */
 export function getSessionContextWindowOverride(
   model: string,
 ): number | undefined {
   const normalized = normalizeModelName(model)
-  return sessionContextWindowOverrides.get(normalized)
+  const exact = sessionContextWindowOverrides.get(normalized)
+  if (exact !== undefined) return exact
+  const stripped = stripProviderPrefix(normalized)
+  return stripped !== undefined ? sessionContextWindowOverrides.get(stripped) : undefined
 }
 
 /**

--- a/src/utils/context.ts
+++ b/src/utils/context.ts
@@ -76,8 +76,8 @@ export function setSessionContextWindowOverride(
   model: string,
   tokens: number,
 ): { ok: true; normalizedModel: string } | { ok: false; error: string } {
-  if (!Number.isFinite(tokens) || tokens <= 0) {
-    return { ok: false, error: 'Context window must be a positive number' }
+  if (!Number.isFinite(tokens) || !Number.isInteger(tokens) || tokens <= 0) {
+    return { ok: false, error: 'Context window must be a positive integer' }
   }
   if (tokens < MIN_CONTEXT_WINDOW_OVERRIDE) {
     return {


### PR DESCRIPTION
Closes #1779

## Problem

OpenClaude uses a hardcoded 128k fallback context window for OpenAI-compatible models that are not listed in the integration catalog. There is no way for a user to adjust this value at runtime without restarting the application and configuring environment variables.

This limits flexibility, especially when working with custom endpoints or newer models that have larger context windows.

## Proposed Direction

Introduce an in-memory override system managed by two new slash commands. This allows users to dynamically set their context window during a session without changing global environment variables or breaking existing provider structures.

### Commands

- **`/set-context-window [model] <tokens>`**: Sets a session-specific token limit. If `[model]` is omitted, uses the active model. Includes a `status` subcommand to view active overrides.
- **`/clear-context-window [model]`**: Resets overrides back to default fallback values. If `[model]` is omitted, clears all overrides.

### How it works

The system hooks directly into `getContextWindowForModel()` in `src/utils/context.ts`, inserting the override check right after the internal env var guard but before all other resolution (1M detection, integration catalog, model capability, etc.). This means:

- **Auto-compact** respects the new window (fires at the correct threshold)
- **`/context`**, **status line**, and **cost tracker** all reflect the override automatically
- **16 existing call sites** across the codebase work without any modifications

Model names are normalized (lowercased, provider prefix stripped) so `openai/gpt-4o` and `gpt-4o` resolve to the same override.

### Validation

A minimum of 32k tokens is enforced to prevent the auto-compact floor paradox: when the effective context window (`contextWindow - reservedTokensForSummary`) goes negative, the floor logic (`reservedTokensForSummary + autocompactBuffer = 33k`) produces an effective window larger than the actual context window, causing auto-compact to never fire while the model is starved for context.

## Implementation

The architecture uses module-level state (`Map<string, number>`) in `context.ts` — the same pattern as `warnedUnknownIntegrationRuntimeLimitKeys`. This is process-scoped and dies with the session, which is correct for CLI usage.

### Files changed

1. **`src/utils/context.ts`**: Added `sessionContextWindowOverrides` Map, `normalizeModelName()`, setter/getter/clear functions, and the override check in `getContextWindowForModel()`.
2. **`src/commands/set-context-window/`**: New slash command with input validation and status subcommand.
3. **`src/commands/clear-context-window/`**: New slash command to remove overrides.
4. **`src/commands.ts`**: Registered both commands.

### Testing

- All 4950 existing tests pass
- Build succeeds
- Tested manually: set, clear, status, `/context` display, auto-compact behavior

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added new local commands to manage session-scoped context-window token limits per model: `/set-context-window` (with help and `status/current`) and `/clear-context-window`.
* **Bug Fixes**
  * Session-scoped overrides are validated (finite positive integers, above the minimum), normalized across model name formats, and applied with correct precedence; clearing session caches now also clears these overrides.
* **Tests**
  * Expanded coverage for normalization, set/clear behavior (including qualified aliases), defensive-copy results, input validation, precedence, and session isolation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->