### PR TITLE
fix(ollama): cap qwen3-coder-next:cloud output at 32768

### DIFF
--- a/src/integrations/discoveryService.test.ts
+++ b/src/integrations/discoveryService.test.ts
@@ -214,6 +214,11 @@ describe('discoverModelsForRoute', () => {
       stale: true,
       models: [
         {
+          id: 'ollama-qwen3-coder-next-cloud',
+          apiName: 'qwen3-coder-next:cloud',
+          maxOutputTokens: 32_768,
+        },
+        {
           id: 'deepseek-v4-pro-cloud',
           apiName: 'deepseek-v4-pro:cloud',
           contextWindow: 1_048_576,

--- a/src/integrations/gateways/ollama.ts
+++ b/src/integrations/gateways/ollama.ts
@@ -36,6 +36,15 @@ export default defineGateway({
     allowManualRefresh: true,
     models: [
       {
+        id: 'ollama-qwen3-coder-next-cloud',
+        apiName: 'qwen3-coder-next:cloud',
+        label: 'Qwen 3 Coder Next (Ollama Cloud)',
+        modelDescriptorId: 'qwen3-coder-next',
+        maxOutputTokens: 32_768,
+        notes:
+          'Ollama Cloud rejects requests above 32768 output tokens for this model.',
+      },
+      {
         id: 'deepseek-v4-pro-cloud',
         apiName: 'deepseek-v4-pro:cloud',
         label: 'DeepSeek V4 Pro (Cloud)',

--- a/src/utils/context.test.ts
+++ b/src/utils/context.test.ts
@@ -717,6 +717,22 @@ test('DashScope qwen3-coder-next uses provider-specific context and output caps'
   })
 })
 
+test('Ollama qwen3-coder-next cloud variant uses gateway-specific output cap', () => {
+  // The shared qwen3-coder-next descriptor stays at 65536; the Ollama Cloud
+  // `:cloud` variant is capped to 32768 via the gateway catalog override
+  // because Ollama Cloud rejects requests above that. Context window is
+  // inherited from the descriptor (262144).
+  process.env.CLAUDE_CODE_USE_OPENAI = '1'
+  process.env.OPENAI_BASE_URL = 'http://localhost:11434/v1'
+  delete process.env.CLAUDE_CODE_MAX_OUTPUT_TOKENS
+
+  expect(getContextWindowForModel('qwen3-coder-next:cloud')).toBe(262_144)
+  expect(getModelMaxOutputTokens('qwen3-coder-next:cloud')).toEqual({
+    default: 32_768,
+    upperLimit: 32_768,
+  })
+})
+
 test('DashScope qwen3-max uses provider-specific context and output caps', () => {
   process.env.CLAUDE_CODE_USE_OPENAI = '1'
   delete process.env.CLAUDE_CODE_MAX_OUTPUT_TOKENS


### PR DESCRIPTION
## Summary

Re-submission of #1133 (closed as abandoned — @jatmn invited a re-submit). Ollama Cloud rejects `qwen3-coder-next:cloud` requests whose `max_tokens` exceeds 32768 with a 400, because that gateway/model combination supports a maximum of 32768 output tokens.

- Keeps the shared `qwen3-coder-next` descriptor unchanged at its 65536 output default.
- Adds an Ollama gateway catalog override for `qwen3-coder-next:cloud` with `maxOutputTokens: 32768`. Context window (262144) is inherited from the descriptor, so a local `qwen3-coder-next` run keeps the descriptor default — only the `:cloud` variant is capped.

## Why gateway-scoped

The cap is specific to Ollama Cloud, so it belongs in the gateway catalog rather than on the shared model descriptor (which other providers reuse). This matches the existing `deepseek-v4-pro:cloud` override in the same gateway.

## Notes

- Picks up the review nit from the original PR: the existing `deepseek-v4-pro:cloud` trailing comma is preserved, and the new entry's `notes` is trailing-comma'd too, so there's no unrelated formatter churn.

## Testing

- [x] `Ollama qwen3-coder-next cloud variant uses gateway-specific output cap` — asserts `qwen3-coder-next:cloud` resolves to `{ default: 32768, upperLimit: 32768 }` and context window 262144, while the existing test proves the shared descriptor stays 65536. Verified red without the override.
- [x] `bun test src/utils/context.test.ts` — pass.
- [x] `bun run typecheck` — clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for a new Ollama Cloud model configuration: `ollama-qwen3-coder-next-cloud`.
  * Ensures the model uses a 262,144 context window while applying a 32,768 output-token limit consistent with Ollama Cloud constraints.
* **Tests**
  * Added coverage to confirm Ollama-style setups preserve the full context window while enforcing the lower output cap.
  * Updated discovery-service stale-cache expectations to include the new model details (output-token limit and API name).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->