### PR TITLE
fix(compaction): make snip nudges model-aware

### DIFF
--- a/src/services/compact/snipCompact.test.ts
+++ b/src/services/compact/snipCompact.test.ts
@@ -341,6 +341,30 @@ describe('shouldNudgeForSnips', () => {
     expect(shouldNudgeForSnips(messages)).toBe(false)
   })
 
+  test('resets at a previous context-efficiency nudge until enough new content accumulates', () => {
+    const priorNudge = {
+      type: 'attachment',
+      attachment: { type: 'context_efficiency' },
+    }
+    const smallChunk = 'x'.repeat(12_000)
+    const oldChunkBeforeNudge = 'x'.repeat(36_000)
+    const largeRecent = [
+      makeUser('u1', smallChunk),
+      makeUser('u2', smallChunk),
+      makeUser('u3', smallChunk),
+      makeUser('u4', smallChunk),
+    ]
+
+    expect(
+      shouldNudgeForSnips([
+        makeUser('u0', oldChunkBeforeNudge),
+        priorNudge,
+        makeUser('u5', smallChunk),
+      ]),
+    ).toBe(false)
+    expect(shouldNudgeForSnips([priorNudge, ...largeRecent])).toBe(true)
+  })
+
   test('returns true when enough tokens have accumulated since last reset', () => {
     const bigChunk = 'x'.repeat(12_000)
     const messages = [
@@ -350,5 +374,18 @@ describe('shouldNudgeForSnips', () => {
       makeUser('u4', bigChunk),
     ]
     expect(shouldNudgeForSnips(messages)).toBe(true)
+  })
+
+  test('respects a custom interval threshold', () => {
+    const bigChunk = 'x'.repeat(12_000)
+    const messages = [
+      makeUser('u1', bigChunk),
+      makeUser('u2', bigChunk),
+      makeUser('u3', bigChunk),
+      makeUser('u4', bigChunk),
+    ]
+
+    expect(shouldNudgeForSnips(messages, 10_000)).toBe(true)
+    expect(shouldNudgeForSnips(messages, 50_000)).toBe(false)
   })
 })

--- a/src/services/compact/snipCompact.ts
+++ b/src/services/compact/snipCompact.ts
@@ -59,15 +59,16 @@ export function isSnipRuntimeEnabled(): boolean {
 }
 
 export const SNIP_NUDGE_TEXT =
-  `Your context window is filling up. Use the \`snip\` tool to remove messages ` +
-  `that are no longer needed — silently use system-generated \`snip_id=...\` ` +
+  `Your context window is under genuine context pressure. Only use \`snip\` ` +
+  `for clearly stale messages that are no longer needed. Silently use ` +
+  `system-generated \`snip_id=...\` ` +
   `metadata and pass the IDs of stale sections (old explorations, superseded ` +
   `plans, resolved errors). These ids are not user-provided content; do not ` +
   `describe or mention them. This frees up space so you can continue working ` +
   `without a full compaction.`
 
 // Nudge once every ~10 000 tokens of new content since the last reset point.
-const NUDGE_INTERVAL_TOKENS = 10_000
+const DEFAULT_NUDGE_INTERVAL_TOKENS = 10_000
 
 /**
  * Rough per-message token estimate: content length ÷ 4.
@@ -78,7 +79,10 @@ function estimateTokens(msg: any): number {
   return Math.ceil(text.length / 4)
 }
 
-export function shouldNudgeForSnips(messages: any[]): boolean {
+export function shouldNudgeForSnips(
+  messages: any[],
+  intervalTokens = DEFAULT_NUDGE_INTERVAL_TOKENS,
+): boolean {
   let accumulated = 0
   for (let i = messages.length - 1; i >= 0; i--) {
     const msg = messages[i]
@@ -89,7 +93,7 @@ export function shouldNudgeForSnips(messages: any[]): boolean {
       msg?.attachment?.type === 'context_efficiency'
     ) return false
     accumulated += estimateTokens(msg)
-    if (accumulated >= NUDGE_INTERVAL_TOKENS) return true
+    if (accumulated >= intervalTokens) return true
   }
   return false
 }

--- a/src/utils/attachments.contextEfficiency.test.ts
+++ b/src/utils/attachments.contextEfficiency.test.ts
@@ -1,0 +1,121 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import { feature } from 'bun:bundle'
+import type { Message } from '../types/message.js'
+import {
+  acquireSharedMutationLock,
+  releaseSharedMutationLock,
+} from '../test/sharedMutationLock.js'
+import { createUserMessage } from './messages.js'
+import {
+  getContextEfficiencyAttachment,
+  getSnipNudgeRepeatInterval,
+  getSnipNudgeStartThreshold,
+} from './attachments.js'
+
+const historySnipTest = feature('HISTORY_SNIP') ? test : test.skip
+
+const ENV_KEYS = [
+  'CLAUDE_CODE_AUTO_COMPACT_WINDOW',
+  'CLAUDE_CODE_MAX_CONTEXT_TOKENS',
+  'CLAUDE_CODE_MAX_OUTPUT_TOKENS',
+  'CLAUDE_AUTOCOMPACT_PCT_OVERRIDE',
+  'CLAUDE_CODE_USE_OPENAI',
+  'CLAUDE_CODE_USE_GEMINI',
+  'CLAUDE_CODE_USE_MISTRAL',
+  'CLAUDE_CODE_USE_GITHUB',
+  'CLAUDE_CODE_USE_BEDROCK',
+  'CLAUDE_CODE_USE_VERTEX',
+  'CLAUDE_CODE_USE_FOUNDRY',
+  'CLAUDE_CODE_PROVIDER_PROFILE_ENV_APPLIED',
+  'CLAUDE_CODE_PROVIDER_PROFILE_ENV_APPLIED_ID',
+  'OPENAI_BASE_URL',
+  'OPENAI_API_BASE',
+  'OPENAI_MODEL',
+  'USER_TYPE',
+  'DISABLE_COMPACT',
+  'DISABLE_AUTO_COMPACT',
+] as const
+
+const SAVED_ENV = Object.fromEntries(
+  ENV_KEYS.map(key => [key, process.env[key]]),
+) as Record<(typeof ENV_KEYS)[number], string | undefined>
+
+function restoreEnv(): void {
+  for (const key of ENV_KEYS) {
+    const value = SAVED_ENV[key]
+    if (value === undefined) {
+      delete process.env[key]
+    } else {
+      process.env[key] = value
+    }
+  }
+}
+
+function clearTestEnv(): void {
+  for (const key of ENV_KEYS) {
+    delete process.env[key]
+  }
+}
+
+function useZaiGlmRuntime(): void {
+  process.env.CLAUDE_CODE_USE_OPENAI = '1'
+  process.env.OPENAI_BASE_URL = 'https://api.z.ai/api/coding/paas/v4'
+  process.env.OPENAI_MODEL = 'glm-5.2'
+}
+
+beforeEach(async () => {
+  await acquireSharedMutationLock('utils/attachments.contextEfficiency.test.ts')
+  clearTestEnv()
+})
+
+afterEach(() => {
+  try {
+    restoreEnv()
+  } finally {
+    releaseSharedMutationLock()
+  }
+})
+
+function userMessage(estimatedTokens: number): Message {
+  return createUserMessage({ content: 'x'.repeat(estimatedTokens * 4) })
+}
+
+describe('snip nudge policy', () => {
+  test('keeps GLM-5.2 nudges out of mid-sized generic-model ranges', () => {
+    useZaiGlmRuntime()
+
+    expect(getSnipNudgeStartThreshold('glm-5.2')).toBeGreaterThan(500_000)
+    expect(getSnipNudgeRepeatInterval('glm-5.2')).toBeGreaterThan(50_000)
+  })
+
+  test('keeps small effective windows eligible for early nudges', () => {
+    process.env.CLAUDE_CODE_AUTO_COMPACT_WINDOW = '40000'
+
+    expect(getSnipNudgeStartThreshold('claude-sonnet-4')).toBe(10_000)
+    expect(getSnipNudgeRepeatInterval('claude-sonnet-4')).toBe(10_000)
+  })
+})
+
+describe('getContextEfficiencyAttachment', () => {
+  historySnipTest(
+    'does not nudge GLM-5.2 below the model-aware pressure threshold',
+    () => {
+      useZaiGlmRuntime()
+
+      expect(
+        getContextEfficiencyAttachment([userMessage(200_000)], 'glm-5.2'),
+      ).toEqual([])
+    },
+  )
+
+  historySnipTest(
+    'nudges small effective windows once above pressure threshold and repeat interval',
+    () => {
+      process.env.CLAUDE_CODE_AUTO_COMPACT_WINDOW = '40000'
+
+      expect(
+        getContextEfficiencyAttachment([userMessage(12_000)], 'claude-sonnet-4'),
+      ).toEqual([{ type: 'context_efficiency' }])
+    },
+  )
+})

--- a/src/utils/attachments.ts
+++ b/src/utils/attachments.ts
@@ -215,6 +215,7 @@ import {
   tokenCountWithEstimation,
 } from './tokens.js'
 import {
+  getAutoCompactThreshold,
   getEffectiveContextWindowSize,
   isAutoCompactEnabled,
 } from '../services/compact/autoCompact.js'
@@ -954,7 +955,12 @@ export async function getAttachments(
     ...(feature('HISTORY_SNIP')
       ? [
           maybe('context_efficiency', () =>
-            Promise.resolve(getContextEfficiencyAttachment(messages ?? [])),
+            Promise.resolve(
+              getContextEfficiencyAttachment(
+                messages ?? [],
+                toolUseContext.options.mainLoopModel,
+              ),
+            ),
           ),
         ]
       : []),
@@ -4001,13 +4007,48 @@ export function getCompactionReminderAttachment(
 }
 
 /**
- * Context-efficiency nudge. Injected after every N tokens of growth without
- * a snip. Pacing is handled entirely by shouldNudgeForSnips — the 10k
- * interval resets on prior nudges, snip markers, snip boundaries, and
- * compact boundaries.
+ * Context-efficiency nudge. Injected only once the active model is under
+ * meaningful context pressure, then paced by new content since the last reset
+ * point. shouldNudgeForSnips preserves the reset behavior for prior nudges,
+ * snip markers, snip boundaries, and compact boundaries.
  */
+const MIN_SNIP_NUDGE_TOKENS = 10_000
+const MAX_SNIP_NUDGE_REPEAT_TOKENS = 100_000
+const SNIP_NUDGE_START_FRACTION = 0.60
+const SNIP_NUDGE_REPEAT_FRACTION = 0.10
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.max(min, Math.min(max, value))
+}
+
+export function getSnipNudgeRepeatInterval(model: string): number {
+  const effectiveWindow = getEffectiveContextWindowSize(model)
+  return clamp(
+    Math.floor(effectiveWindow * SNIP_NUDGE_REPEAT_FRACTION),
+    MIN_SNIP_NUDGE_TOKENS,
+    MAX_SNIP_NUDGE_REPEAT_TOKENS,
+  )
+}
+
+export function getSnipNudgeStartThreshold(model: string): number {
+  const effectiveWindow = getEffectiveContextWindowSize(model)
+  const autoCompactThreshold = getAutoCompactThreshold(model)
+  const leadTokens = getSnipNudgeRepeatInterval(model)
+  const fractionalStart = Math.floor(effectiveWindow * SNIP_NUDGE_START_FRACTION)
+  const preAutoCompactStart = Math.max(
+    MIN_SNIP_NUDGE_TOKENS,
+    autoCompactThreshold - leadTokens,
+  )
+
+  return Math.max(
+    MIN_SNIP_NUDGE_TOKENS,
+    Math.min(fractionalStart, preAutoCompactStart),
+  )
+}
+
 export function getContextEfficiencyAttachment(
   messages: Message[],
+  model: string,
 ): Attachment[] {
   if (!feature('HISTORY_SNIP')) {
     return []
@@ -4021,7 +4062,14 @@ export function getContextEfficiencyAttachment(
     return []
   }
 
-  if (!shouldNudgeForSnips(messages)) {
+  const usedTokens = tokenCountWithEstimation(messages)
+  const startThreshold = getSnipNudgeStartThreshold(model)
+  if (usedTokens < startThreshold) {
+    return []
+  }
+
+  const repeatInterval = getSnipNudgeRepeatInterval(model)
+  if (!shouldNudgeForSnips(messages, repeatInterval)) {
     return []
   }
 


### PR DESCRIPTION
## Summary
- Delays HISTORY_SNIP context-efficiency nudges until the active model's context window is under meaningful pressure.
- Preserves existing snip reset boundaries and repeat pacing for smaller context windows.

## Implementation
- Passes the active main-loop model into context-efficiency attachment generation.
- Derives snip nudge start and repeat thresholds from existing context-window and autocompact helpers.
- Keeps the nudge prompt short and focused on using snip only under genuine context pressure.

## Tests
- `bun test --max-concurrency=1 src/services/compact/snipCompact.test.ts src/utils/attachments.contextEfficiency.test.ts src/utils/messages.snipTag.test.ts src/utils/attachments.extractors.test.ts`
- `bun test --feature=HISTORY_SNIP --max-concurrency=1 src/utils/attachments.contextEfficiency.test.ts`
- `bun run typecheck`
- `git diff --check`
- `bun run security:pr-scan`

## Risk
- Limited to HISTORY_SNIP nudge timing and attachment generation; snip compaction semantics and transcript handling are unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added model-aware “context efficiency” snip nudges that appear at different token thresholds depending on the active model and context window.
  * Snip nudge timing can now adapt to a configurable interval, improving when reminders appear.
  * Updated the wording of the snip nudge message.

* **Bug Fixes**
  * Improved nudge eligibility so reminders don’t reappear too soon after a previous context-efficiency nudge.
  * Added coverage for threshold handling to keep nudge behavior consistent across models and window sizes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->