### PR TITLE
fix(config): recover from a healthy backup when the global config is corrupt

### DIFF
--- a/src/utils/config.backupRecovery.test.ts
+++ b/src/utils/config.backupRecovery.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, mock, test } from 'bun:test'
+import { afterEach, beforeAll, describe, expect, mock, test } from 'bun:test'
 import type * as ConfigModule from './config.js'
 import {
   NodeFsOperations,
@@ -333,8 +333,19 @@ describe('getConfig recovery (production path)', () => {
 })
 
 describe('enableConfigs startup validation (#1807)', () => {
+  // Capture the real env module once before any test overrides it. Bun's
+  // mock.module() is process-global and is NOT undone by mock.restore(), so the
+  // getGlobalClaudeFile override below would otherwise leak the virtual global
+  // config path into later same-process tests. Teardown re-registers the real
+  // module alongside the fs reset to contain that state.
+  let realEnv: Record<string, unknown>
+  beforeAll(async () => {
+    realEnv = (await import('./env.js')) as Record<string, unknown>
+  })
+
   afterEach(() => {
     setOriginalFsImplementation()
+    mock.module('./env.js', () => realEnv)
   })
 
   test('does not crash on a corrupt global config when no usable backup exists', async () => {
@@ -344,7 +355,6 @@ describe('enableConfigs startup validation (#1807)', () => {
     // terminated the process on every launch. Startup must instead fall through
     // to the corrupt-file/default handling (preserve the corrupt file, start
     // from defaults) and return normally.
-    const realEnv = (await import('./env.js')) as Record<string, unknown>
     mock.module('./env.js', () => ({
       ...realEnv,
       getGlobalClaudeFile: () => FILE,

--- a/src/utils/config.backupRecovery.test.ts
+++ b/src/utils/config.backupRecovery.test.ts
@@ -7,11 +7,13 @@ import {
   type FsOperations,
 } from './fsOperations.js'
 
-// recoverConfigFromBackup reads through the injected filesystem, so these
-// cases drive the #1807 recovery path deterministically without touching the
-// real ~/.openclaude.json. getConfig (its only production caller) is
-// module-private and short-circuits to the in-memory config under
-// NODE_ENV=test, so the helper is exercised directly here.
+// These cases drive the #1807 recovery path through the injected filesystem
+// without touching the real ~/.openclaude.json. They cover three layers:
+//   - recoverConfigFromBackup (the backup-selection helper) directly,
+//   - the production getConfig recovery branch via _getConfigForTesting (getConfig
+//     is module-private but runs its real body under NODE_ENV=test), and
+//   - selectBackupsToPrune, the pure decision that must not prune while the live
+//     config is corrupt.
 //
 // Load config through a query-suffixed specifier so a leaked
 // mock.module('./config.js') from another file in the same process can never
@@ -141,5 +143,111 @@ describe('recoverConfigFromBackup', () => {
       customField: 3,
       keptDefault: true,
     })
+  })
+})
+
+describe('getConfig recovery (production path)', () => {
+  afterEach(() => {
+    setOriginalFsImplementation()
+  })
+
+  test('getConfig recovers a healthy backup when the live config is corrupt', async () => {
+    const { _getConfigForTesting } = await freshConfig()
+    installFs({
+      readdirStringSync: (dir: string) =>
+        dir.endsWith('backups') ? [BACKUP_NAME] : [],
+      readFileSync: (path: string) => {
+        const p = String(path)
+        if (p.endsWith(BACKUP_NAME)) {
+          return '{"theme":"dark","customField":7}'
+        }
+        if (p === FILE) {
+          return '{ corrupt live config ,,,'
+        }
+        throw enoent()
+      },
+      statSync: () => {
+        throw enoent()
+      },
+    })
+
+    // Drives the real getConfig ConfigParseError -> recoverConfigFromBackup
+    // branch, not just the helper in isolation.
+    const recovered = _getConfigForTesting(FILE, () => ({
+      theme: 'light',
+      customField: 0,
+      keptDefault: true,
+    }))
+
+    expect(recovered).toEqual({
+      theme: 'dark',
+      customField: 7,
+      keptDefault: true,
+    })
+  })
+
+  test('getConfig recovers an older healthy backup when the newest is corrupt', async () => {
+    const { _getConfigForTesting } = await freshConfig()
+    const NEWER = `${BASE}.backup.20260630130000`
+    const OLDER = `${BASE}.backup.20260630120000`
+    installFs({
+      readdirStringSync: (dir: string) =>
+        dir.endsWith('backups') ? [OLDER, NEWER] : [],
+      readFileSync: (path: string) => {
+        const p = String(path)
+        if (p.endsWith(NEWER)) {
+          return '{ not valid json ,,,'
+        }
+        if (p.endsWith(OLDER)) {
+          return '{"theme":"solarized"}'
+        }
+        if (p === FILE) {
+          return '{ corrupt live config ,,,'
+        }
+        throw enoent()
+      },
+      statSync: () => {
+        throw enoent()
+      },
+    })
+
+    const recovered = _getConfigForTesting(FILE, () => ({
+      theme: 'light',
+      keptDefault: true,
+    }))
+
+    expect(recovered).toEqual({
+      theme: 'solarized',
+      keptDefault: true,
+    })
+  })
+})
+
+describe('selectBackupsToPrune', () => {
+  test('prunes nothing while the live config is corrupt', async () => {
+    const { selectBackupsToPrune } = await freshConfig()
+    const backups = Array.from(
+      { length: 7 },
+      (_, i) => `${BASE}.backup.2026063012000${i}`,
+    )
+    // A corrupt live config means an older healthy backup may be the only
+    // recovery source, so nothing may be unlinked.
+    expect(selectBackupsToPrune(backups, 5, false)).toEqual([])
+  })
+
+  test('keeps the newest maxBackups and prunes the rest when healthy', async () => {
+    const { selectBackupsToPrune } = await freshConfig()
+    const oldest = `${BASE}.backup.20260630120000`
+    // Deliberately unsorted input: the helper sorts newest-first itself.
+    const backups = [
+      `${BASE}.backup.20260630120003`,
+      oldest,
+      `${BASE}.backup.20260630120005`,
+      `${BASE}.backup.20260630120002`,
+      `${BASE}.backup.20260630120004`,
+      `${BASE}.backup.20260630120001`,
+    ]
+    // 6 backups, keep newest 5 -> only the oldest is pruned.
+    expect(selectBackupsToPrune(backups, 5, true)).toEqual([oldest])
   })
 })

--- a/src/utils/config.backupRecovery.test.ts
+++ b/src/utils/config.backupRecovery.test.ts
@@ -106,4 +106,40 @@ describe('recoverConfigFromBackup', () => {
       recoverConfigFromBackup(FILE, () => ({ theme: 'light' })),
     ).toBeUndefined()
   })
+
+  test('recovers an older healthy backup when the newest one is corrupt', async () => {
+    const { recoverConfigFromBackup } = await freshConfig()
+    const NEWER = `${BASE}.backup.20260630130000`
+    const OLDER = `${BASE}.backup.20260630120000`
+    installFs({
+      readdirStringSync: (dir: string) =>
+        dir.endsWith('backups') ? [OLDER, NEWER] : [],
+      readFileSync: (path: string) => {
+        const p = String(path)
+        if (p.endsWith(NEWER)) {
+          return '{ not valid json ,,,'
+        }
+        if (p.endsWith(OLDER)) {
+          return '{"theme":"solarized","customField":3}'
+        }
+        throw enoent()
+      },
+      statSync: () => {
+        throw enoent()
+      },
+    })
+
+    const recovered = recoverConfigFromBackup(FILE, () => ({
+      theme: 'light',
+      customField: 0,
+      keptDefault: true,
+    }))
+
+    // The corrupt newest backup is skipped; the older healthy one is used.
+    expect(recovered).toEqual({
+      theme: 'solarized',
+      customField: 3,
+      keptDefault: true,
+    })
+  })
 })

--- a/src/utils/config.backupRecovery.test.ts
+++ b/src/utils/config.backupRecovery.test.ts
@@ -1,0 +1,109 @@
+import { afterEach, describe, expect, test } from 'bun:test'
+import type * as ConfigModule from './config.js'
+import {
+  NodeFsOperations,
+  setFsImplementation,
+  setOriginalFsImplementation,
+  type FsOperations,
+} from './fsOperations.js'
+
+// recoverConfigFromBackup reads through the injected filesystem, so these
+// cases drive the #1807 recovery path deterministically without touching the
+// real ~/.openclaude.json. getConfig (its only production caller) is
+// module-private and short-circuits to the in-memory config under
+// NODE_ENV=test, so the helper is exercised directly here.
+//
+// Load config through a query-suffixed specifier so a leaked
+// mock.module('./config.js') from another file in the same process can never
+// turn these assertions into no-ops (the deferredWrite.test.ts trap).
+
+const FILE = '/virtual/.openclaude.json'
+const BASE = '.openclaude.json'
+const BACKUP_NAME = `${BASE}.backup.20260630120000`
+
+function enoent(): NodeJS.ErrnoException {
+  const err = new Error('ENOENT') as NodeJS.ErrnoException
+  err.code = 'ENOENT'
+  return err
+}
+
+function installFs(over: Partial<FsOperations>): void {
+  setFsImplementation({ ...NodeFsOperations, ...over } as FsOperations)
+}
+
+async function freshConfig(): Promise<typeof ConfigModule> {
+  return (await import(
+    `./config.js?backupRecoveryTest=${Date.now()}-${Math.random()}`
+  )) as typeof ConfigModule
+}
+
+describe('recoverConfigFromBackup', () => {
+  afterEach(() => {
+    setOriginalFsImplementation()
+  })
+
+  test('recovers the most recent healthy backup, merged over defaults', async () => {
+    const { recoverConfigFromBackup } = await freshConfig()
+    installFs({
+      readdirStringSync: (dir: string) =>
+        dir.endsWith('backups') ? [BACKUP_NAME] : [],
+      readFileSync: (path: string) => {
+        if (String(path).endsWith(BACKUP_NAME)) {
+          return '{"theme":"dark","customField":7}'
+        }
+        throw enoent()
+      },
+      statSync: () => {
+        throw enoent()
+      },
+    })
+
+    const recovered = recoverConfigFromBackup(FILE, () => ({
+      theme: 'light',
+      customField: 0,
+      keptDefault: true,
+    }))
+
+    // Backup values win; fields absent from the backup keep their defaults.
+    expect(recovered).toEqual({
+      theme: 'dark',
+      customField: 7,
+      keptDefault: true,
+    })
+  })
+
+  test('returns undefined when no backup exists', async () => {
+    const { recoverConfigFromBackup } = await freshConfig()
+    installFs({
+      readdirStringSync: () => [],
+      statSync: () => {
+        throw enoent()
+      },
+    })
+
+    expect(
+      recoverConfigFromBackup(FILE, () => ({ theme: 'light' })),
+    ).toBeUndefined()
+  })
+
+  test('returns undefined when the backup itself is corrupt', async () => {
+    const { recoverConfigFromBackup } = await freshConfig()
+    installFs({
+      readdirStringSync: (dir: string) =>
+        dir.endsWith('backups') ? [BACKUP_NAME] : [],
+      readFileSync: (path: string) => {
+        if (String(path).endsWith(BACKUP_NAME)) {
+          return '{ not valid json ,,,'
+        }
+        throw enoent()
+      },
+      statSync: () => {
+        throw enoent()
+      },
+    })
+
+    expect(
+      recoverConfigFromBackup(FILE, () => ({ theme: 'light' })),
+    ).toBeUndefined()
+  })
+})

--- a/src/utils/config.backupRecovery.test.ts
+++ b/src/utils/config.backupRecovery.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, test } from 'bun:test'
+import { afterEach, describe, expect, mock, test } from 'bun:test'
 import type * as ConfigModule from './config.js'
 import {
   NodeFsOperations,
@@ -183,6 +183,76 @@ describe('recoverConfigFromBackup', () => {
       keptDefault: true,
     })
   })
+
+  test('recovers the global config from a legacy .claude.json backup when every .openclaude backup is corrupt (#1807)', async () => {
+    // The exact #1807 scenario: repeated corrupt writes poisoned every
+    // `.openclaude.json.backup.*` snapshot, and the only clean source left is a
+    // pre-rename `.claude.json.backup.*` file in the same backup dir. Recovery
+    // for the global config must fall back to the legacy basename, newest-valid
+    // first, instead of stopping at the poisoned current-basename snapshots.
+    const { recoverConfigFromBackup } = await freshConfig()
+    // Newest overall is a corrupt .openclaude backup; the healthy snapshot is an
+    // older legacy .claude backup. Timestamp ordering must interleave the two
+    // basenames so the corrupt-newer one is tried (and skipped) before the
+    // healthy-older legacy one is used.
+    const CORRUPT_CURRENT = '.openclaude.json.backup.20260630130000'
+    const HEALTHY_LEGACY = '.claude.json.backup.20260630120000'
+    installFs({
+      readdirStringSync: (dir: string) =>
+        dir.endsWith('backups') ? [HEALTHY_LEGACY, CORRUPT_CURRENT] : [],
+      readFileSync: (path: string) => {
+        const p = String(path)
+        if (p.endsWith(CORRUPT_CURRENT)) {
+          return '{ not valid json ,,,'
+        }
+        if (p.endsWith(HEALTHY_LEGACY)) {
+          return '{"theme":"solarized","customField":9}'
+        }
+        throw enoent()
+      },
+      statSync: () => {
+        throw enoent()
+      },
+    })
+
+    const recovered = recoverConfigFromBackup(FILE, () => ({
+      theme: 'light',
+      customField: 0,
+      keptDefault: true,
+    }))
+
+    expect(recovered).toEqual({
+      theme: 'solarized',
+      customField: 9,
+      keptDefault: true,
+    })
+  })
+
+  test('does not borrow legacy .claude.json backups for a non-global config file', async () => {
+    // The legacy-basename fallback is scoped to the global config. A different
+    // config file (e.g. a project config) must not accidentally recover from an
+    // unrelated `.claude.json` backup.
+    const { recoverConfigFromBackup } = await freshConfig()
+    const OTHER_FILE = '/virtual/project/.some-other-config.json'
+    const HEALTHY_LEGACY = '.claude.json.backup.20260630120000'
+    installFs({
+      readdirStringSync: (dir: string) =>
+        dir.endsWith('backups') ? [HEALTHY_LEGACY] : [],
+      readFileSync: (path: string) => {
+        if (String(path).endsWith(HEALTHY_LEGACY)) {
+          return '{"theme":"solarized"}'
+        }
+        throw enoent()
+      },
+      statSync: () => {
+        throw enoent()
+      },
+    })
+
+    expect(
+      recoverConfigFromBackup(OTHER_FILE, () => ({ theme: 'light' })),
+    ).toBeUndefined()
+  })
 })
 
 describe('getConfig recovery (production path)', () => {
@@ -259,6 +329,47 @@ describe('getConfig recovery (production path)', () => {
       theme: 'solarized',
       keptDefault: true,
     })
+  })
+})
+
+describe('enableConfigs startup validation (#1807)', () => {
+  afterEach(() => {
+    setOriginalFsImplementation()
+  })
+
+  test('does not crash on a corrupt global config when no usable backup exists', async () => {
+    // The #1807 startup lock-out: enableConfigs validated the global config with
+    // the throwing mode, so a present-but-corrupt config with no recoverable
+    // backup rethrew ConfigParseError straight through enableConfigs -> main and
+    // terminated the process on every launch. Startup must instead fall through
+    // to the corrupt-file/default handling (preserve the corrupt file, start
+    // from defaults) and return normally.
+    const realEnv = (await import('./env.js')) as Record<string, unknown>
+    mock.module('./env.js', () => ({
+      ...realEnv,
+      getGlobalClaudeFile: () => FILE,
+    }))
+    installFs({
+      // No backups anywhere, and no already-saved corrupted copies.
+      readdirStringSync: () => [],
+      readFileSync: (path: string) => {
+        if (String(path) === FILE) {
+          return '{ corrupt live config ,,,'
+        }
+        throw enoent()
+      },
+      statSync: () => {
+        throw enoent()
+      },
+      // The preserve-corrupt path may create the backup dir / copy the corrupt
+      // file aside; keep those as no-ops so the virtual fs is never touched.
+      mkdirSync: () => undefined,
+      copyFileSync: () => undefined,
+    })
+
+    const { enableConfigs } = await freshConfig()
+
+    expect(() => enableConfigs()).not.toThrow()
   })
 })
 

--- a/src/utils/config.backupRecovery.test.ts
+++ b/src/utils/config.backupRecovery.test.ts
@@ -144,6 +144,45 @@ describe('recoverConfigFromBackup', () => {
       keptDefault: true,
     })
   })
+
+  test('skips a valid-but-non-object newest backup for an older healthy one', async () => {
+    const { recoverConfigFromBackup } = await freshConfig()
+    const NEWER = `${BASE}.backup.20260630130000`
+    const OLDER = `${BASE}.backup.20260630120000`
+    installFs({
+      readdirStringSync: (dir: string) =>
+        dir.endsWith('backups') ? [OLDER, NEWER] : [],
+      readFileSync: (path: string) => {
+        const p = String(path)
+        if (p.endsWith(NEWER)) {
+          // Parses as valid JSON, but `null` is not a config object. Spreading
+          // it would return bare defaults and stop, discarding the older
+          // healthy snapshot below.
+          return 'null'
+        }
+        if (p.endsWith(OLDER)) {
+          return '{"theme":"solarized","customField":3}'
+        }
+        throw enoent()
+      },
+      statSync: () => {
+        throw enoent()
+      },
+    })
+
+    const recovered = recoverConfigFromBackup(FILE, () => ({
+      theme: 'light',
+      customField: 0,
+      keptDefault: true,
+    }))
+
+    // The valid-but-unusable newest backup is skipped; the older healthy one wins.
+    expect(recovered).toEqual({
+      theme: 'solarized',
+      customField: 3,
+      keptDefault: true,
+    })
+  })
 })
 
 describe('getConfig recovery (production path)', () => {

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -1530,26 +1530,29 @@ function saveConfigWithLock<A extends object>(
         Number.isNaN(mostRecentTimestamp) ||
         Date.now() - mostRecentTimestamp >= MIN_BACKUP_INTERVAL_MS
 
-      if (shouldCreateBackup) {
-        // Only rotate a parseable config into the backup set. If the current
-        // file is corrupt — e.g. after getConfig recovered from a backup in
-        // memory but the healthy config has not been written back yet —
-        // copying it would poison the rotation with the same bad content
-        // recovery just worked around (#1807).
-        let currentConfigParses = false
-        try {
-          jsonParse(stripBOM(fs.readFileSync(file, { encoding: 'utf-8' })))
-          currentConfigParses = true
-        } catch {
-          currentConfigParses = false
-        }
-        if (currentConfigParses) {
-          const backupPath = join(backupDir, `${fileBase}.backup.${Date.now()}`)
-          fs.copyFileSync(file, backupPath)
-        }
+      // Whether the live config currently parses. If it is corrupt — e.g. after
+      // getConfig recovered from a backup in memory but the healthy config has
+      // not been written back yet (#1807) — we must neither rotate the bad
+      // content into the backup set nor prune the existing backups: an older
+      // healthy snapshot may be the only recovery source, and runMigrations()
+      // calls saveGlobalConfig() during startup before the repaired config is
+      // durably on disk.
+      let currentConfigParses = false
+      try {
+        jsonParse(stripBOM(fs.readFileSync(file, { encoding: 'utf-8' })))
+        currentConfigParses = true
+      } catch {
+        currentConfigParses = false
       }
 
-      // Clean up old backups, keeping only the 5 most recent
+      if (shouldCreateBackup && currentConfigParses) {
+        const backupPath = join(backupDir, `${fileBase}.backup.${Date.now()}`)
+        fs.copyFileSync(file, backupPath)
+      }
+
+      // Clean up old backups, keeping only the 5 most recent — but never while
+      // the live config is corrupt (selectBackupsToPrune returns [] then, so a
+      // healthy older backup is not unlinked before recovery is durable).
       const MAX_BACKUPS = 5
       // Re-read if we just created one; otherwise reuse the list
       const backupsForCleanup = shouldCreateBackup
@@ -1560,7 +1563,11 @@ function saveConfigWithLock<A extends object>(
             .reverse()
         : existingBackups
 
-      for (const oldBackup of backupsForCleanup.slice(MAX_BACKUPS)) {
+      for (const oldBackup of selectBackupsToPrune(
+        backupsForCleanup,
+        MAX_BACKUPS,
+        currentConfigParses,
+      )) {
         try {
           fs.unlinkSync(join(backupDir, oldBackup))
         } catch {
@@ -1697,6 +1704,29 @@ function findMostRecentBackup(file: string): string | null {
  * to the in-memory config under NODE_ENV=test, so the recovery path is covered
  * directly against an injected filesystem.
  */
+/**
+ * Given the current backup filenames and whether the live config parses,
+ * returns the backups to unlink so only the newest `maxBackups` remain.
+ *
+ * Returns `[]` when the live config is corrupt: pruning then could delete the
+ * last healthy backup before the recovered config has been durably rewritten,
+ * which is exactly the #1807 data-loss window (runMigrations() saves during
+ * startup before recovery lands on disk). Exported for unit testing.
+ */
+export function selectBackupsToPrune(
+  backupNames: string[],
+  maxBackups: number,
+  liveConfigParses: boolean,
+): string[] {
+  if (!liveConfigParses) {
+    return []
+  }
+  return [...backupNames]
+    .sort()
+    .reverse()
+    .slice(maxBackups)
+}
+
 export function recoverConfigFromBackup<A>(
   file: string,
   createDefault: () => A,

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -1740,6 +1740,18 @@ export function recoverConfigFromBackup<A>(
     try {
       const backupContent = fs.readFileSync(backupPath, { encoding: 'utf-8' })
       const parsedBackup = jsonParse(stripBOM(backupContent))
+      // A backup can parse as valid JSON yet not be a config object (`null`,
+      // an array, a bare string/number). Spreading such a value would either
+      // return bare defaults or splice index/char keys into the result and
+      // then stop, discarding the older healthy snapshots we still have. Skip
+      // it and keep looking so recovery falls through to a usable backup.
+      if (
+        typeof parsedBackup !== 'object' ||
+        parsedBackup === null ||
+        Array.isArray(parsedBackup)
+      ) {
+        continue
+      }
       return {
         ...createDefault(),
         ...parsedBackup,

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -1673,6 +1673,41 @@ function findMostRecentBackup(file: string): string | null {
   return null
 }
 
+/**
+ * Attempt to recover a config whose live file is present but corrupt by
+ * reading the most recent healthy backup and parsing it. Backups in
+ * ~/.claude/backups are written from previously-valid configs, so this lets a
+ * one-off bad write be undone instead of silently discarding the user's
+ * settings. Returns the merged config when a backup exists and parses, or
+ * undefined when there is no usable backup (#1807).
+ *
+ * Exported for unit testing: `getConfig` is module-private and short-circuits
+ * to the in-memory config under NODE_ENV=test, so the recovery path is covered
+ * directly against an injected filesystem.
+ */
+export function recoverConfigFromBackup<A>(
+  file: string,
+  createDefault: () => A,
+): A | undefined {
+  const backupPath = findMostRecentBackup(file)
+  if (!backupPath) {
+    return undefined
+  }
+
+  try {
+    const fs = getFsImplementation()
+    const backupContent = fs.readFileSync(backupPath, { encoding: 'utf-8' })
+    const parsedBackup = jsonParse(stripBOM(backupContent))
+    return {
+      ...createDefault(),
+      ...parsedBackup,
+    }
+  } catch {
+    // Backup missing or itself corrupt — caller falls back to defaults.
+    return undefined
+  }
+}
+
 function getConfig<A>(
   file: string,
   createDefault: () => A,
@@ -1715,6 +1750,22 @@ function getConfig<A>(
         )
       }
       return createDefault()
+    }
+
+    // A present-but-corrupt config previously reset to defaults (or threw when
+    // throwOnInvalid), discarding the user's settings even though healthy
+    // backups exist in ~/.claude/backups. Recover the most recent backup that
+    // still parses before doing anything destructive, so a one-off bad write
+    // no longer wipes config or crashes startup (#1807).
+    if (error instanceof ConfigParseError) {
+      const recovered = recoverConfigFromBackup<A>(file, createDefault)
+      if (recovered) {
+        process.stderr.write(
+          `\nClaude configuration file at ${file} was corrupted and has been ` +
+            `recovered from the most recent healthy backup.\n\n`,
+        )
+        return recovered
+      }
     }
 
     // Re-throw ConfigParseError if throwOnInvalid is true

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -1619,17 +1619,22 @@ export function enableConfigs(): void {
   // Any reads to configuration before this flag is set show an console warning
   // to prevent us from adding config reading during module initialization
   configReadingAllowed = true
-  // We only check the global config because currently all the configs share a file
-  getConfig(
-    getGlobalClaudeFile(),
-    createDefaultGlobalConfig,
-    true /* throw on invalid */,
-  )
+  // We only check the global config because currently all the configs share a
+  // file. This warms the recovery path (recover from a healthy backup, or
+  // preserve the corrupt file and start from defaults) without throwing, so a
+  // corrupt global config self-heals instead of crashing startup (#1807).
+  getConfig(getGlobalClaudeFile(), createDefaultGlobalConfig)
 
   logForDiagnosticsNoPII('info', 'enable_configs_completed', {
     duration_ms: Date.now() - startTime,
   })
 }
+
+// Basename of the current global config, plus the pre-rename legacy basename
+// its backups may still be filed under (#1807). Compared by basename so backup
+// recovery works against an injected virtual path in tests.
+const GLOBAL_CONFIG_BASENAME = '.openclaude.json'
+const LEGACY_GLOBAL_CONFIG_BASENAME = '.claude.json'
 
 /**
  * Returns the directory where config backup files are stored.
@@ -1654,16 +1659,36 @@ function getConfigBackupDir(): string {
  */
 function listBackupsNewestFirst(file: string): string[] {
   const fs = getFsImplementation()
-  const fileBase = basename(file)
+  // The global config was renamed `.claude.json` -> `.openclaude.json`. #1807's
+  // reported scenario is that repeated corrupt writes poisoned every
+  // `.openclaude.json.backup.*` snapshot and the only clean sources left were
+  // the pre-rename `.claude.json.backup.*` files sitting in the same backup
+  // dir. Recover the global config from that legacy basename too, otherwise the
+  // recovery still fails for exactly the case the issue calls out.
+  const fileBases = [basename(file)]
+  if (basename(file) === GLOBAL_CONFIG_BASENAME) {
+    fileBases.push(LEGACY_GLOBAL_CONFIG_BASENAME)
+  }
+  const isTimestampedBackupOf = (name: string): boolean =>
+    fileBases.some(base => name.startsWith(`${base}.backup.`))
+  // Order by the numeric timestamp after `.backup.` so the current and legacy
+  // basenames interleave by recency instead of grouping by filename (a plain
+  // lexicographic sort would put every `.claude.json.*` before every
+  // `.openclaude.json.*` regardless of when each was written).
+  const backupTimestamp = (name: string): number => {
+    const suffix = name.split('.backup.').pop()
+    const parsed = suffix ? Number(suffix) : NaN
+    return Number.isFinite(parsed) ? parsed : -1
+  }
   const paths: string[] = []
 
   const collect = (dir: string): void => {
     try {
       const backups = fs
         .readdirStringSync(dir)
-        .filter(f => f.startsWith(`${fileBase}.backup.`))
-        .sort() // Timestamps sort lexicographically
-      for (const name of backups.reverse()) {
+        .filter(isTimestampedBackupOf)
+        .sort((a, b) => backupTimestamp(b) - backupTimestamp(a))
+      for (const name of backups) {
         paths.push(join(dir, name))
       }
     } catch {
@@ -1676,13 +1701,15 @@ function listBackupsNewestFirst(file: string): string[] {
   collect(getConfigBackupDir())
   collect(dirname(file))
 
-  // Legacy backup file (no timestamp), tried last.
-  const legacyBackup = `${file}.backup`
-  try {
-    fs.statSync(legacyBackup)
-    paths.push(legacyBackup)
-  } catch {
-    // Legacy backup doesn't exist.
+  // Legacy timestampless backups (`<basename>.backup`), tried last.
+  for (const base of fileBases) {
+    const legacyBackup = join(dirname(file), `${base}.backup`)
+    try {
+      fs.statSync(legacyBackup)
+      paths.push(legacyBackup)
+    } catch {
+      // Legacy backup doesn't exist.
+    }
   }
 
   return paths
@@ -1767,7 +1794,6 @@ export function recoverConfigFromBackup<A>(
 function getConfig<A>(
   file: string,
   createDefault: () => A,
-  throwOnInvalid?: boolean,
 ): A {
   // Log a warning if config is accessed before it's allowed
   if (!configReadingAllowed && process.env.NODE_ENV !== 'test') {
@@ -1808,11 +1834,11 @@ function getConfig<A>(
       return createDefault()
     }
 
-    // A present-but-corrupt config previously reset to defaults (or threw when
-    // throwOnInvalid), discarding the user's settings even though healthy
-    // backups exist in ~/.claude/backups. Recover the most recent backup that
-    // still parses before doing anything destructive, so a one-off bad write
-    // no longer wipes config or crashes startup (#1807).
+    // A present-but-corrupt config previously reset to defaults (or crashed the
+    // startup validation path), discarding the user's settings even though
+    // healthy backups exist in ~/.claude/backups. Recover the most recent
+    // backup that still parses before doing anything destructive, so a one-off
+    // bad write no longer wipes config or crashes startup (#1807).
     if (error instanceof ConfigParseError) {
       const recovered = recoverConfigFromBackup<A>(file, createDefault)
       if (recovered) {
@@ -1824,10 +1850,11 @@ function getConfig<A>(
       }
     }
 
-    // Re-throw ConfigParseError if throwOnInvalid is true
-    if (error instanceof ConfigParseError && throwOnInvalid) {
-      throw error
-    }
+    // A present-but-corrupt config used to re-throw here for the startup
+    // validation path (enableConfigs), locking users out on every launch when
+    // recovery found no usable backup. #1807 requires self-healing instead:
+    // once recovery is exhausted, fall through to preserve the corrupt file
+    // aside and start from defaults rather than crashing.
 
     // Log config parse errors so users know what happened
     if (error instanceof ConfigParseError) {

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -1531,8 +1531,22 @@ function saveConfigWithLock<A extends object>(
         Date.now() - mostRecentTimestamp >= MIN_BACKUP_INTERVAL_MS
 
       if (shouldCreateBackup) {
-        const backupPath = join(backupDir, `${fileBase}.backup.${Date.now()}`)
-        fs.copyFileSync(file, backupPath)
+        // Only rotate a parseable config into the backup set. If the current
+        // file is corrupt — e.g. after getConfig recovered from a backup in
+        // memory but the healthy config has not been written back yet —
+        // copying it would poison the rotation with the same bad content
+        // recovery just worked around (#1807).
+        let currentConfigParses = false
+        try {
+          jsonParse(stripBOM(fs.readFileSync(file, { encoding: 'utf-8' })))
+          currentConfigParses = true
+        } catch {
+          currentConfigParses = false
+        }
+        if (currentConfigParses) {
+          const backupPath = join(backupDir, `${fileBase}.backup.${Date.now()}`)
+          fs.copyFileSync(file, backupPath)
+        }
       }
 
       // Clean up old backups, keeping only the 5 most recent
@@ -1624,53 +1638,51 @@ function getConfigBackupDir(): string {
  * (next to the config file) for backwards compatibility.
  * Returns the full path to the most recent backup, or null if none exist.
  */
-function findMostRecentBackup(file: string): string | null {
+/**
+ * All backup paths for `file`, newest first. The dedicated backup directory
+ * takes precedence over the legacy location next to the config file; within
+ * each location, entries are ordered by descending timestamp (the numeric
+ * suffix after `.backup.` sorts lexicographically). The timestampless legacy
+ * `<file>.backup` is tried last.
+ */
+function listBackupsNewestFirst(file: string): string[] {
   const fs = getFsImplementation()
   const fileBase = basename(file)
-  const backupDir = getConfigBackupDir()
+  const paths: string[] = []
 
-  // Check the new backup directory first
-  try {
-    const backups = fs
-      .readdirStringSync(backupDir)
-      .filter(f => f.startsWith(`${fileBase}.backup.`))
-      .sort()
-
-    const mostRecent = backups.at(-1) // Timestamps sort lexicographically
-    if (mostRecent) {
-      return join(backupDir, mostRecent)
-    }
-  } catch {
-    // Backup dir doesn't exist yet
-  }
-
-  // Fall back to legacy location (next to the config file)
-  const fileDir = dirname(file)
-
-  try {
-    const backups = fs
-      .readdirStringSync(fileDir)
-      .filter(f => f.startsWith(`${fileBase}.backup.`))
-      .sort()
-
-    const mostRecent = backups.at(-1) // Timestamps sort lexicographically
-    if (mostRecent) {
-      return join(fileDir, mostRecent)
-    }
-
-    // Check for legacy backup file (no timestamp)
-    const legacyBackup = `${file}.backup`
+  const collect = (dir: string): void => {
     try {
-      fs.statSync(legacyBackup)
-      return legacyBackup
+      const backups = fs
+        .readdirStringSync(dir)
+        .filter(f => f.startsWith(`${fileBase}.backup.`))
+        .sort() // Timestamps sort lexicographically
+      for (const name of backups.reverse()) {
+        paths.push(join(dir, name))
+      }
     } catch {
-      // Legacy backup doesn't exist
+      // Directory doesn't exist yet.
     }
-  } catch {
-    // Ignore errors reading directory
   }
 
-  return null
+  // Check the new backup directory first, then the legacy location next to
+  // the config file.
+  collect(getConfigBackupDir())
+  collect(dirname(file))
+
+  // Legacy backup file (no timestamp), tried last.
+  const legacyBackup = `${file}.backup`
+  try {
+    fs.statSync(legacyBackup)
+    paths.push(legacyBackup)
+  } catch {
+    // Legacy backup doesn't exist.
+  }
+
+  return paths
+}
+
+function findMostRecentBackup(file: string): string | null {
+  return listBackupsNewestFirst(file)[0] ?? null
 }
 
 /**
@@ -1689,23 +1701,25 @@ export function recoverConfigFromBackup<A>(
   file: string,
   createDefault: () => A,
 ): A | undefined {
-  const backupPath = findMostRecentBackup(file)
-  if (!backupPath) {
-    return undefined
+  const fs = getFsImplementation()
+
+  // The newest backup can itself be corrupt (the #1807 scenario tends to
+  // write several bad snapshots in a row), so try each backup from newest to
+  // oldest and recover from the first one that still parses.
+  for (const backupPath of listBackupsNewestFirst(file)) {
+    try {
+      const backupContent = fs.readFileSync(backupPath, { encoding: 'utf-8' })
+      const parsedBackup = jsonParse(stripBOM(backupContent))
+      return {
+        ...createDefault(),
+        ...parsedBackup,
+      }
+    } catch {
+      // This backup is missing or itself corrupt — try the next oldest.
+    }
   }
 
-  try {
-    const fs = getFsImplementation()
-    const backupContent = fs.readFileSync(backupPath, { encoding: 'utf-8' })
-    const parsedBackup = jsonParse(stripBOM(backupContent))
-    return {
-      ...createDefault(),
-      ...parsedBackup,
-    }
-  } catch {
-    // Backup missing or itself corrupt — caller falls back to defaults.
-    return undefined
-  }
+  return undefined
 }
 
 function getConfig<A>(


### PR DESCRIPTION
## Summary

A present-but-corrupt `~/.openclaude.json` takes `getConfig` down the `ConfigParseError` path, which either resets to defaults (silently discarding the user's settings) or re-throws — even though healthy timestamped backups exist in `~/.claude/backups`. Previously `getConfig` only consulted a backup on `ENOENT`, and even then only to print a manual `cp` hint.

## Change

On a corrupt parse, `getConfig` now first tries to recover the most recent backup that still parses (merged over defaults) before doing anything destructive, so a one-off bad write no longer wipes config or crashes startup. If no backup is usable it falls back to the existing defaults path unchanged.

The new `recoverConfigFromBackup` helper is exported and unit-tested directly: `getConfig` is module-private and short-circuits to the in-memory config under `NODE_ENV=test`, so the recovery path is covered against an injected filesystem (healthy backup, no backup, and corrupt-backup cases).

## Notes

This addresses the read/recovery defect in #1807. The other half of that report — the original corrupt write — is harder to action: the config write path (`writeFileSyncAndFlush_DEPRECATED`) is already atomic (temp file + flush + rename, non-atomic only as a last-resort fallback), and the reporter notes the corruption trigger is non-deterministic. Recovery makes the CLI self-heal from such an event regardless of its source. Happy to keep this scoped to recovery if you'd rather track the write-side separately.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatically recovers from the most recent healthy configuration backup when the live/global config is corrupt, merging recovered values over defaults.

* **Bug Fixes**
  * Improved locked-write backup behavior: backups are created only after the live config parses successfully.
  * Prevents pruning of healthy backups when the current live config is unreadable.
  * More resilient recovery across legacy and global backup scenarios, including startup self-healing instead of crashes.

* **Tests**
  * Expanded Bun test coverage for recovery edge cases (invalid JSON, non-object backups, legacy/global interleaving) and pruning behavior (corrupt live configs, unsorted inputs).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->