### PR TITLE
fix(format): show sub-second durations with one decimal instead of "0s"

### DIFF
--- a/src/utils/format.test.ts
+++ b/src/utils/format.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from 'bun:test'
-import { formatDuration, formatFileSize } from './format.js'
+import { formatDuration, formatFileSize, formatSecondsShort } from './format.js'
 
 test('formats sub-second durations with one decimal place', () => {
   // Regression: the < 1s branch was guarded by `ms < 1` (1 millisecond), so
@@ -10,6 +10,17 @@ test('formats sub-second durations with one decimal place', () => {
   expect(formatDuration(900)).toBe('0.9s')
   // 0.999s rounds to one decimal place.
   expect(formatDuration(999)).toBe('1.0s')
+  // Halfway cases must round in integer milliseconds, not on the raw fraction:
+  // `(950 / 1000).toFixed(1)` yields "0.9" because 0.95 isn't representable in
+  // binary floating point, so the decimal is computed from rounded ms instead.
+  expect(formatDuration(950)).toBe('1.0s')
+  expect(formatDuration(850)).toBe('0.9s')
+})
+
+test('formatSecondsShort keeps a stable one-decimal second', () => {
+  expect(formatSecondsShort(1234)).toBe('1.2s')
+  expect(formatSecondsShort(950)).toBe('1.0s')
+  expect(formatSecondsShort(1250)).toBe('1.3s')
 })
 
 test('formats whole-second and zero durations without a decimal', () => {

--- a/src/utils/format.test.ts
+++ b/src/utils/format.test.ts
@@ -1,5 +1,27 @@
 import { expect, test } from 'bun:test'
-import { formatFileSize } from './format.js'
+import { formatDuration, formatFileSize } from './format.js'
+
+test('formats sub-second durations with one decimal place', () => {
+  // Regression: the < 1s branch was guarded by `ms < 1` (1 millisecond), so
+  // real sub-second durations rendered as "0s" instead of the documented
+  // single-decimal form.
+  expect(formatDuration(500)).toBe('0.5s')
+  expect(formatDuration(100)).toBe('0.1s')
+  expect(formatDuration(900)).toBe('0.9s')
+  // 0.999s rounds to one decimal place.
+  expect(formatDuration(999)).toBe('1.0s')
+})
+
+test('formats whole-second and zero durations without a decimal', () => {
+  expect(formatDuration(0)).toBe('0s')
+  expect(formatDuration(1000)).toBe('1s')
+  expect(formatDuration(1500)).toBe('1s')
+})
+
+test('formats multi-unit durations', () => {
+  expect(formatDuration(65000)).toBe('1m 5s')
+  expect(formatDuration(3661000)).toBe('1h 1m 1s')
+})
 
 test('formats sub-KB sizes as raw bytes', () => {
   expect(formatFileSize(0)).toBe('0 bytes')

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -29,8 +29,18 @@ export function formatFileSize(sizeInBytes: number): string {
  * Unlike formatDuration, always keeps the decimal — use for sub-minute timings
  * where the fractional second is meaningful (TTFT, hook durations, etc.).
  */
+/**
+ * Renders milliseconds as a one-decimal second value, rounding in integer
+ * milliseconds so half-steps are stable. Rounding the raw fraction with
+ * `(ms / 1000).toFixed(1)` is unstable because values like `0.95` aren't
+ * exactly representable in binary floating point (`950` would render `0.9`).
+ */
+function oneDecimalSeconds(ms: number): string {
+  return (Math.round(ms / 100) / 10).toFixed(1)
+}
+
 export function formatSecondsShort(ms: number): string {
-  return `${(ms / 1000).toFixed(1)}s`
+  return `${oneDecimalSeconds(ms)}s`
 }
 
 export function formatDuration(
@@ -47,8 +57,7 @@ export function formatDuration(
     // sub-millisecond values and always returned "0.0s", so real sub-second
     // durations fell through and rendered as "0s".
     if (ms < 1000) {
-      const s = (ms / 1000).toFixed(1)
-      return `${s}s`
+      return `${oneDecimalSeconds(ms)}s`
     }
     const s = Math.floor(ms / 1000).toString()
     return `${s}s`

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -42,8 +42,11 @@ export function formatDuration(
     if (ms === 0) {
       return '0s'
     }
-    // For durations < 1s, show 1 decimal place (e.g., 0.5s)
-    if (ms < 1) {
+    // For durations < 1s, show 1 decimal place (e.g., 0.5s). The threshold is
+    // 1000ms (1s), not 1ms — at `ms < 1` this branch could only ever fire for
+    // sub-millisecond values and always returned "0.0s", so real sub-second
+    // durations fell through and rendered as "0s".
+    if (ms < 1000) {
       const s = (ms / 1000).toFixed(1)
       return `${s}s`
     }


### PR DESCRIPTION
## Summary

`formatDuration`'s sub-second branch is guarded by `ms < 1` while the comment right above it documents the intent as "For durations < 1s, show 1 decimal place (e.g., 0.5s)". Since 1s = 1000ms, at `ms < 1` that branch can only ever fire for sub-millisecond values — where `(ms / 1000).toFixed(1)` is always `"0.0"` — so it never produces the `"0.5s"` its own example gives. Real sub-second durations instead fall through to `Math.floor(ms / 1000)` (= 0) and render as `"0s"`.

User-visible: a sub-agent that finishes in under a second shows `Done (… · 0s)` (`AgentTool/UI.tsx`), and sub-second session/ETA durations elsewhere lose their precision the same way.

## Change

Corrected the threshold to `ms < 1000`, matching the documented behavior. `formatDuration(500)` now returns `"0.5s"`; `0`, whole-second, and multi-unit cases are unchanged (`1000` -> `"1s"`, `65000` -> `"1m 5s"`). `replayFormat` is unaffected — it already renders `0 < ms < 1000` as `"<n>ms"` before delegating, so sub-second values never reach this branch through that path.

## Notes

Found while reading the formatting utilities; `formatDuration` had no existing tests, so this adds coverage for the sub-second, whole-second, and multi-unit cases.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sub-second duration rendering to show seconds with one decimal place (instead of displaying as `0s`), including correct rounding near 1.0s and halfway values.
  * Kept formatting consistent for whole-second and multi-unit durations (minutes/hours).
* **Tests**
  * Expanded unit tests for duration formatting across sub-second, whole-second, and longer ranges.
  * Added tests to verify stable one-decimal output for short second values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->