### PR TITLE
fix(plugins): keep marketplace reconciliation prototype-safe

### DIFF
--- a/src/utils/plugins/reconciler.test.ts
+++ b/src/utils/plugins/reconciler.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, test } from 'bun:test'
+
+import { diffMarketplaces } from './reconciler.js'
+import type { DeclaredMarketplace } from './marketplaceManager.js'
+import type { KnownMarketplacesFile, MarketplaceSource } from './schemas.js'
+
+const githubSource = (repo: string): MarketplaceSource => ({
+  source: 'github',
+  repo,
+})
+
+const declared = (
+  source: MarketplaceSource,
+  sourceIsFallback = false,
+): DeclaredMarketplace => ({ source, sourceIsFallback })
+
+// Marketplace names are user-controlled (settings.json `extraKnownMarketplaces`).
+// `diffMarketplaces` looks each declared name up in the materialized map with
+// `materialized[name]`. If that map is a plain object — which the reconciler's
+// error fallback used to produce — a name that collides with an
+// `Object.prototype` member (constructor / toString / valueOf / hasOwnProperty)
+// resolves to the inherited function instead of `undefined`, so the entry is
+// misclassified as already-materialized (sourceChanged) instead of missing.
+// Same prototype-pollution class as the marketplace cache fix in #1787.
+describe('diffMarketplaces — prototype-named marketplaces', () => {
+  for (const protoName of [
+    'constructor',
+    'toString',
+    'valueOf',
+    'hasOwnProperty',
+  ]) {
+    test(`treats a marketplace named "${protoName}" as missing when not materialized`, () => {
+      const declaredMap: Record<string, DeclaredMarketplace> = {
+        [protoName]: declared(githubSource('acme/plugins')),
+      }
+      // A plain object — exactly what an unsafe error fallback yields. The fix
+      // must make the lookup own-property-exact so the inherited member can't
+      // masquerade as a materialized entry.
+      const materialized = {} as KnownMarketplacesFile
+
+      const diff = diffMarketplaces(declaredMap, materialized)
+
+      expect(diff.missing).toEqual([protoName])
+      expect(diff.sourceChanged).toEqual([])
+      expect(diff.upToDate).toEqual([])
+    })
+  }
+
+  test('still classifies a real materialized entry as up to date', () => {
+    const source = githubSource('acme/plugins')
+    const declaredMap: Record<string, DeclaredMarketplace> = {
+      'acme-plugins': declared(source),
+    }
+    const materialized = {
+      'acme-plugins': {
+        source,
+        installLocation: '/home/u/.claude/plugins/marketplaces/acme-plugins',
+      },
+    } as unknown as KnownMarketplacesFile
+
+    const diff = diffMarketplaces(declaredMap, materialized)
+
+    expect(diff.upToDate).toEqual(['acme-plugins'])
+    expect(diff.missing).toEqual([])
+    expect(diff.sourceChanged).toEqual([])
+  })
+
+  test('reports a genuinely absent marketplace as missing', () => {
+    const declaredMap: Record<string, DeclaredMarketplace> = {
+      'never-seen': declared(githubSource('acme/other')),
+    }
+    const diff = diffMarketplaces(
+      declaredMap,
+      {} as KnownMarketplacesFile,
+    )
+
+    expect(diff.missing).toEqual(['never-seen'])
+  })
+})

--- a/src/utils/plugins/reconciler.ts
+++ b/src/utils/plugins/reconciler.ts
@@ -19,7 +19,7 @@ import {
   addMarketplaceSource,
   type DeclaredMarketplace,
   getDeclaredMarketplaces,
-  loadKnownMarketplacesConfig,
+  loadKnownMarketplacesConfigSafe,
 } from './marketplaceManager.js'
 import {
   isLocalMarketplaceSource,
@@ -57,7 +57,13 @@ export function diffMarketplaces(
   const upToDate: string[] = []
 
   for (const [name, intent] of Object.entries(declared)) {
-    const state = materialized[name]
+    // Own-property-exact lookup: marketplace names are user-controlled, so a
+    // name colliding with an `Object.prototype` member (constructor / toString
+    // / __proto__ / …) must not resolve to an inherited value and masquerade as
+    // a materialized entry. Same prototype-pollution class as #1787.
+    const state = Object.hasOwn(materialized, name)
+      ? materialized[name]
+      : undefined
     const normalizedIntent = normalizeSource(intent.source, opts?.projectRoot)
 
     if (!state) {
@@ -119,13 +125,13 @@ export async function reconcileMarketplaces(
     return { installed: [], updated: [], failed: [], upToDate: [], skipped: [] }
   }
 
-  let materialized: KnownMarketplacesFile
-  try {
-    materialized = await loadKnownMarketplacesConfig()
-  } catch (e) {
-    logError(e)
-    materialized = {}
-  }
+  // Read-only snapshot, used only to diff declared intent below — the install
+  // step re-reads and mutates the real config via addMarketplaceSource, so an
+  // empty fallback here can't clobber the user's file. loadKnownMarketplacesConfigSafe
+  // degrades a corrupted/unreadable config to a null-prototype empty map (and
+  // logs via logForDebugging rather than the error file), which keeps the
+  // `materialized[name]` lookups in diffMarketplaces own-property-exact.
+  const materialized = await loadKnownMarketplacesConfigSafe()
 
   const diff = diffMarketplaces(declared, materialized, {
     projectRoot: getOriginalCwd(),


### PR DESCRIPTION
## Problem

Marketplace names are user-controlled — they come from `extraKnownMarketplaces` in settings. `diffMarketplaces` looks each declared name up in the materialized state with `materialized[name]`:

```ts
for (const [name, intent] of Object.entries(declared)) {
  const state = materialized[name]
  if (!state) { missing.push(name) }
  ...
}
```

When `materialized` is a plain object, a marketplace named after an `Object.prototype` member — `constructor`, `toString`, `valueOf`, `hasOwnProperty` — resolves `materialized[name]` to the **inherited** value (a truthy function) instead of `undefined`. The entry then skips the `missing` branch and is misclassified as already-materialized (`sourceChanged`, with `materializedSource: undefined`).

`reconcileMarketplaces` produced exactly such a plain object in its error fallback:

```ts
try {
  materialized = await loadKnownMarketplacesConfig()
} catch (e) {
  logError(e)
  materialized = {}        // plain object → full Object.prototype chain
}
```

So with a corrupted/unreadable `known_marketplaces.json` and a marketplace named e.g. `constructor`, reconciliation mislabels it.

## Fix

Two layers, same concern:

- **`diffMarketplaces`** now does an own-property-exact lookup via `Object.hasOwn`, so the comparison is correct regardless of the map's prototype.
- **`reconcileMarketplaces`** uses the existing `loadKnownMarketplacesConfigSafe`, which already degrades a corrupted/unreadable config to a **null-prototype** empty map (and logs via `logForDebugging` instead of the error file — corrupted user config isn't a Claude Code bug). The snapshot is only used to diff; the install step re-reads and mutates the real config via `addMarketplaceSource`, so the graceful empty fallback can't clobber the user's file (which is why `…Safe` is appropriate here).

## Tests

Adds the first tests for `diffMarketplaces` (the module was previously untested): a prototype-named marketplace with an empty materialized map is now reported as `missing`, plus positive controls for a real materialized entry (`upToDate`) and a genuinely absent one (`missing`). Each proto-name case fails before the fix.

Same prototype-pollution class as the marketplace cache fix in #1787.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved marketplace reconciliation so names that match built-in object properties are handled correctly.
  * Prevented valid marketplace entries from being incorrectly marked as changed or inherited when comparing marketplace lists.
  * Ensured corrupted or unreadable marketplace snapshots are handled more safely during reconciliation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->