### PR TITLE
fix(claude): make stream watchdog deterministic

### DIFF
--- a/src/services/api/claude.streamWatchdog.test.ts
+++ b/src/services/api/claude.streamWatchdog.test.ts
@@ -1,0 +1,483 @@
+import {
+  afterAll,
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  test,
+} from 'bun:test'
+import type {
+  BetaMessage,
+  BetaRawMessageStreamEvent,
+} from '@anthropic-ai/sdk/resources/beta/messages/messages.mjs'
+import type { Stream } from '@anthropic-ai/sdk/streaming.mjs'
+import { mkdtempSync, rmSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import {
+  acquireSharedMutationLock,
+  releaseSharedMutationLock,
+} from '../../test/sharedMutationLock.js'
+import { getEmptyToolPermissionContext } from '../../Tool.js'
+import type { Message } from '../../types/message.js'
+import { asSystemPrompt } from '../../utils/systemPromptType.js'
+import { QueryLifecycleOperationTracker } from '../../utils/queryLifecycle.js'
+import { EMPTY_USAGE } from './emptyUsage.js'
+import type { Options } from './claude.js'
+
+const actualClientModule = await import('./client.js')
+const originalEnv = { ...process.env }
+const hadSavedMacro = Object.hasOwn(globalThis, 'MACRO')
+const savedMacro = (globalThis as Record<string, unknown>).MACRO
+let fixturesRoot: string | undefined
+const envKeys = [
+  'ANTHROPIC_API_KEY',
+  'ANTHROPIC_AUTH_TOKEN',
+  'CLAUDE_CODE_DISABLE_NONSTREAMING_FALLBACK',
+  'CLAUDE_CODE_TEST_FIXTURES_ROOT',
+  'CLAUDE_DISABLE_STREAM_WATCHDOG',
+  'CLAUDE_ENABLE_STREAM_WATCHDOG',
+  'CLAUDE_STREAM_IDLE_TIMEOUT_MS',
+  'OPENCLAUDE_MAX_RETRIES',
+  'VCR_RECORD',
+] as const
+
+type CreateArgs = [
+  Record<string, unknown>,
+  Record<string, unknown> | undefined,
+]
+type CreateHandler = (...args: CreateArgs) => unknown
+
+let createHandler: CreateHandler | undefined
+let importCounter = 0
+
+mock.module('./client.js', () => ({
+  CLIENT_REQUEST_ID_HEADER: actualClientModule.CLIENT_REQUEST_ID_HEADER,
+  getAnthropicClient: async () => ({
+    beta: {
+      messages: {
+        create: (...args: CreateArgs) => {
+          if (!createHandler) {
+            throw new Error('test client create handler not configured')
+          }
+          return createHandler(...args)
+        },
+      },
+    },
+  }),
+}))
+
+function makeBetaMessage(
+  id: string,
+  content: BetaMessage['content'] = [],
+): BetaMessage {
+  return {
+    id,
+    type: 'message',
+    role: 'assistant',
+    model: 'claude-watchdog-test',
+    content,
+    container: null,
+    context_management: null,
+    stop_details: null,
+    stop_reason: 'end_turn',
+    stop_sequence: null,
+    usage: {
+      ...EMPTY_USAGE,
+      input_tokens: 1,
+      output_tokens: 1,
+    },
+  }
+}
+
+function makeMessageStartEvent(): BetaRawMessageStreamEvent {
+  return {
+    type: 'message_start',
+    message: makeBetaMessage('msg-stream-start'),
+  }
+}
+
+function makeCompleteStreamEvents(): BetaRawMessageStreamEvent[] {
+  return [
+    makeMessageStartEvent(),
+    {
+      type: 'content_block_start',
+      index: 0,
+      content_block: { type: 'text', text: '', citations: null },
+    },
+    {
+      type: 'content_block_delta',
+      index: 0,
+      delta: { type: 'text_delta', text: 'stream ok' },
+    },
+    { type: 'content_block_stop', index: 0 },
+    {
+      type: 'message_delta',
+      context_management: null,
+      delta: {
+        container: null,
+        stop_details: null,
+        stop_reason: 'end_turn',
+        stop_sequence: null,
+      },
+      usage: {
+        cache_creation_input_tokens: null,
+        cache_read_input_tokens: null,
+        input_tokens: null,
+        iterations: null,
+        output_tokens: 1,
+        server_tool_use: null,
+      },
+    },
+    { type: 'message_stop' },
+  ]
+}
+
+function deferred<T>(): {
+  promise: Promise<T>
+  reject: (reason?: unknown) => void
+  resolve: (value: T | PromiseLike<T>) => void
+} {
+  let resolve!: (value: T | PromiseLike<T>) => void
+  let reject!: (reason?: unknown) => void
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res
+    reject = rej
+  })
+  return { promise, reject, resolve }
+}
+
+function makeWedgedStream(): {
+  abortSignal: AbortSignal
+  nextStarted: Promise<void>
+  rejectPendingNext: (error: Error) => void
+  returnCalled: () => boolean
+  stream: Stream<BetaRawMessageStreamEvent>
+} {
+  const controller = new AbortController()
+  const pendingNext = deferred<IteratorResult<BetaRawMessageStreamEvent>>()
+  const nextStarted = deferred<void>()
+  let nextCount = 0
+  let returned = false
+  const iterator: AsyncIterator<BetaRawMessageStreamEvent> = {
+    next() {
+      nextCount++
+      if (nextCount === 1) {
+        return Promise.resolve({
+          done: false,
+          value: makeMessageStartEvent(),
+        })
+      }
+      nextStarted.resolve()
+      return pendingNext.promise
+    },
+    return() {
+      returned = true
+      return Promise.resolve({ done: true, value: undefined })
+    },
+  }
+
+  return {
+    abortSignal: controller.signal,
+    nextStarted: nextStarted.promise,
+    rejectPendingNext: error => pendingNext.reject(error),
+    returnCalled: () => returned,
+    stream: {
+      controller,
+      [Symbol.asyncIterator]: () => iterator,
+    } as Stream<BetaRawMessageStreamEvent>,
+  }
+}
+
+function makeCompleteStream(): Stream<BetaRawMessageStreamEvent> {
+  const controller = new AbortController()
+  const events = makeCompleteStreamEvents()
+  const iterator: AsyncIterator<BetaRawMessageStreamEvent> = {
+    next() {
+      const value = events.shift()
+      return Promise.resolve(
+        value === undefined
+          ? { done: true, value: undefined }
+          : { done: false, value },
+      )
+    },
+  }
+
+  return {
+    controller,
+    [Symbol.asyncIterator]: () => iterator,
+  } as Stream<BetaRawMessageStreamEvent>
+}
+
+function makeWithResponse(stream: Stream<BetaRawMessageStreamEvent>) {
+  return {
+    withResponse: async () => ({
+      data: stream,
+      request_id: 'req-stream-watchdog',
+      response: new Response('', {
+        headers: { 'request-id': 'req-stream-watchdog' },
+      }),
+    }),
+  }
+}
+
+function makeOptions(onStreamingFallback?: () => void): Options {
+  return {
+    getToolPermissionContext: async () => getEmptyToolPermissionContext(),
+    model: 'claude-watchdog-test',
+    isNonInteractiveSession: false,
+    querySource: 'sdk',
+    agents: [],
+    hasAppendSystemPrompt: false,
+    mcpTools: [],
+    onStreamingFallback,
+    queryLifecycle: new QueryLifecycleOperationTracker(),
+  }
+}
+
+function makeMessages(): Message[] {
+  return [
+    {
+      type: 'user',
+      uuid: '00000000-0000-0000-0000-000000000101',
+      timestamp: '2026-06-30T00:00:00.000Z',
+      message: { role: 'user', content: 'hello' },
+    } as Message,
+  ]
+}
+
+async function collectStreamingMessages(
+  signal: AbortSignal,
+  options: Options,
+): Promise<unknown[]> {
+  const { queryModelWithStreaming } = await import(
+    `./claude.js?stream-watchdog-test-${importCounter++}`
+  )
+  const messages: unknown[] = []
+  for await (const message of queryModelWithStreaming({
+    messages: makeMessages(),
+    systemPrompt: asSystemPrompt([]),
+    thinkingConfig: { type: 'disabled' },
+    tools: [],
+    signal,
+    options,
+  })) {
+    messages.push(message)
+  }
+  return messages
+}
+
+function delay(ms: number): Promise<'timeout'> {
+  return new Promise(resolve => {
+    setTimeout(() => resolve('timeout'), ms)
+  })
+}
+
+async function settleForCleanup(promise: Promise<unknown>): Promise<void> {
+  await Promise.race([promise.catch(() => undefined), delay(50)])
+}
+
+function setTestMacro(): void {
+  ;(globalThis as Record<string, unknown>).MACRO = {
+    VERSION: '0.0.0-test',
+    DISPLAY_VERSION: '0.0.0-test',
+    BUILD_TIME: 'test',
+    ISSUES_EXPLAINER: 'test',
+    PACKAGE_URL: 'test',
+    NATIVE_PACKAGE_URL: undefined,
+  }
+}
+
+beforeEach(async () => {
+  await acquireSharedMutationLock('claude.streamWatchdog.test.ts')
+  setTestMacro()
+  for (const key of envKeys) {
+    delete process.env[key]
+  }
+  fixturesRoot = mkdtempSync(join(tmpdir(), 'claude-watchdog-vcr-'))
+  process.env.ANTHROPIC_API_KEY = 'sk-test-watchdog'
+  process.env.CLAUDE_CODE_TEST_FIXTURES_ROOT = fixturesRoot
+  process.env.CLAUDE_STREAM_IDLE_TIMEOUT_MS = '25'
+  process.env.OPENCLAUDE_MAX_RETRIES = '0'
+  process.env.VCR_RECORD = '1'
+})
+
+afterEach(() => {
+  try {
+    createHandler = undefined
+    for (const key of envKeys) {
+      if (originalEnv[key] === undefined) {
+        delete process.env[key]
+      } else {
+        process.env[key] = originalEnv[key]
+      }
+    }
+    if (hadSavedMacro) {
+      ;(globalThis as Record<string, unknown>).MACRO = savedMacro
+    } else {
+      delete (globalThis as Record<string, unknown>).MACRO
+    }
+    if (fixturesRoot) {
+      rmSync(fixturesRoot, { force: true, recursive: true })
+      fixturesRoot = undefined
+    }
+  } finally {
+    releaseSharedMutationLock()
+  }
+})
+
+afterAll(() => {
+  mock.module('./client.js', () => actualClientModule)
+})
+
+describe('Claude stream watchdog', () => {
+  test('falls back when the top-level stream iterator never settles', async () => {
+    const wedged = makeWedgedStream()
+    const streamModes: unknown[] = []
+    createHandler = params => {
+      streamModes.push(params.stream)
+      if (params.stream === true) {
+        return makeWithResponse(wedged.stream)
+      }
+      return Promise.resolve(
+        makeBetaMessage('msg-fallback', [
+          { type: 'text', text: 'fallback ok', citations: null },
+        ]),
+      )
+    }
+
+    const request = collectStreamingMessages(
+      new AbortController().signal,
+      makeOptions(),
+    )
+    await wedged.nextStarted
+
+    try {
+      const result = await Promise.race([request, delay(250)])
+      expect(result).not.toBe('timeout')
+      expect(streamModes).toEqual([true, undefined])
+      expect(wedged.abortSignal.aborted).toBe(true)
+      expect(wedged.returnCalled()).toBe(true)
+      expect(
+        (result as unknown[]).some(
+          message =>
+            typeof message === 'object' &&
+            message !== null &&
+            (message as { type?: unknown }).type === 'assistant',
+        ),
+      ).toBe(true)
+    } finally {
+      wedged.rejectPendingNext(new Error('test cleanup'))
+      await settleForCleanup(request)
+    }
+  })
+
+  test('does not attempt fallback when the parent signal aborts first', async () => {
+    process.env.CLAUDE_STREAM_IDLE_TIMEOUT_MS = '250'
+    const wedged = makeWedgedStream()
+    const controller = new AbortController()
+    const streamModes: unknown[] = []
+    createHandler = params => {
+      streamModes.push(params.stream)
+      if (params.stream === true) {
+        return makeWithResponse(wedged.stream)
+      }
+      return Promise.resolve(
+        makeBetaMessage('msg-unexpected-fallback', [
+          { type: 'text', text: 'unexpected fallback', citations: null },
+        ]),
+      )
+    }
+
+    const request = collectStreamingMessages(controller.signal, makeOptions())
+      .then(() => 'resolved')
+      .catch(error =>
+        error instanceof Error ? error.name : String(error),
+      )
+    await wedged.nextStarted
+    controller.abort()
+
+    try {
+      const result = await Promise.race([request, delay(150)])
+      expect(result).toBe('resolved')
+      expect(streamModes).toEqual([true])
+      expect(wedged.abortSignal.aborted).toBe(true)
+      expect(wedged.returnCalled()).toBe(true)
+    } finally {
+      wedged.rejectPendingNext(new Error('test cleanup'))
+      await settleForCleanup(request)
+    }
+  })
+
+  test('complete streams still produce the streamed assistant message', async () => {
+    const streamModes: unknown[] = []
+    let fallbackCount = 0
+    createHandler = params => {
+      streamModes.push(params.stream)
+      if (params.stream === true) {
+        return makeWithResponse(makeCompleteStream())
+      }
+      fallbackCount++
+      return Promise.resolve(
+        makeBetaMessage('msg-unexpected-fallback', [
+          { type: 'text', text: 'unexpected fallback', citations: null },
+        ]),
+      )
+    }
+
+    const messages = await collectStreamingMessages(
+      new AbortController().signal,
+      makeOptions(),
+    )
+
+    expect(streamModes).toEqual([true])
+    expect(fallbackCount).toBe(0)
+    expect(
+      messages.some(
+        message =>
+          typeof message === 'object' &&
+          message !== null &&
+          (message as { type?: unknown }).type === 'assistant' &&
+          JSON.stringify(message).includes('stream ok'),
+      ),
+    ).toBe(true)
+  })
+
+  test('late rejection from an abandoned iterator read is observed', async () => {
+    const wedged = makeWedgedStream()
+    const unhandledRejections: unknown[] = []
+    const onUnhandledRejection = (reason: unknown) => {
+      unhandledRejections.push(reason)
+    }
+    process.on('unhandledRejection', onUnhandledRejection)
+    createHandler = params => {
+      if (params.stream === true) {
+        return makeWithResponse(wedged.stream)
+      }
+      return Promise.resolve(
+        makeBetaMessage('msg-fallback', [
+          { type: 'text', text: 'fallback ok', citations: null },
+        ]),
+      )
+    }
+
+    const request = collectStreamingMessages(
+      new AbortController().signal,
+      makeOptions(),
+    )
+    await wedged.nextStarted
+
+    try {
+      const result = await Promise.race([request, delay(250)])
+      expect(result).not.toBe('timeout')
+      wedged.rejectPendingNext(new Error('late iterator failure'))
+      await new Promise(resolve => setTimeout(resolve, 0))
+      expect(unhandledRejections).toEqual([])
+    } finally {
+      process.off('unhandledRejection', onUnhandledRejection)
+      wedged.rejectPendingNext(new Error('test cleanup'))
+      await settleForCleanup(request)
+    }
+  })
+})

--- a/src/services/api/claude.streamWatchdog.test.ts
+++ b/src/services/api/claude.streamWatchdog.test.ts
@@ -307,10 +307,19 @@ afterEach(() => {
   try {
     createHandler = undefined
     for (const key of envKeys) {
-      if (originalEnv[key] === undefined) {
-        delete process.env[key]
+      const envKey: string = key
+      if (
+        envKey === '__proto__' ||
+        envKey === 'constructor' ||
+        envKey === 'prototype'
+      ) {
+        continue
+      }
+
+      if (originalEnv[envKey] === undefined) {
+        delete process.env[envKey]
       } else {
-        process.env[key] = originalEnv[key]
+        process.env[envKey] = originalEnv[envKey]
       }
     }
     if (hadSavedMacro) {

--- a/src/services/api/claude.ts
+++ b/src/services/api/claude.ts
@@ -260,6 +260,13 @@ type JsonValue = string | number | boolean | null | JsonObject | JsonArray
 type JsonObject = { [key: string]: JsonValue }
 type JsonArray = JsonValue[]
 
+class StreamIdleTimeoutError extends Error {
+  constructor(timeoutMs: number) {
+    super(`Stream idle timeout - no chunks received for ${timeoutMs / 1000}s`)
+    this.name = 'StreamIdleTimeoutError'
+  }
+}
+
 /**
  * Assemble the extra body parameters for the API request, based on the
  * CLAUDE_CODE_EXTRA_BODY environment variable if present and on any beta
@@ -1971,6 +1978,7 @@ async function* queryModel(
     let streamWatchdogFiredAt: number | null = null
     let streamIdleWarningTimer: ReturnType<typeof setTimeout> | null = null
     let streamIdleTimer: ReturnType<typeof setTimeout> | null = null
+
     function clearStreamIdleTimers(): void {
       if (streamIdleWarningTimer !== null) {
         clearTimeout(streamIdleWarningTimer)
@@ -1981,41 +1989,128 @@ async function* queryModel(
         streamIdleTimer = null
       }
     }
-    function resetStreamIdleTimer(): void {
-      clearStreamIdleTimers()
-      if (!streamWatchdogEnabled) {
-        return
-      }
-      streamIdleWarningTimer = setTimeout(
-        warnMs => {
-          logForDebugging(
-            `Streaming idle warning: no chunks received for ${warnMs / 1000}s`,
-            { level: 'warn' },
-          )
-          logForDiagnosticsNoPII('warn', 'cli_streaming_idle_warning')
-        },
-        STREAM_IDLE_WARNING_MS,
-        STREAM_IDLE_WARNING_MS,
+
+    function logStreamIdleWarning(warnMs: number): void {
+      logForDebugging(
+        `Streaming idle warning: no chunks received for ${warnMs / 1000}s`,
+        { level: 'warn' },
       )
-      streamIdleTimer = setTimeout(() => {
-        streamIdleAborted = true
-        streamWatchdogFiredAt = performance.now()
-        logForDebugging(
-          `Streaming idle timeout: no chunks received for ${STREAM_IDLE_TIMEOUT_MS / 1000}s, aborting stream`,
-          { level: 'error' },
-        )
-        logForDiagnosticsNoPII('error', 'cli_streaming_idle_timeout')
-        logEvent('tengu_streaming_idle_timeout', {
-          model:
-            options.model as AnalyticsMetadata_I_VERIFIED_THIS_IS_NOT_CODE_OR_FILEPATHS,
-          request_id: (streamRequestId ??
-            'unknown') as AnalyticsMetadata_I_VERIFIED_THIS_IS_NOT_CODE_OR_FILEPATHS,
-          timeout_ms: STREAM_IDLE_TIMEOUT_MS,
-        })
-        releaseStreamResources()
-      }, STREAM_IDLE_TIMEOUT_MS)
+      logForDiagnosticsNoPII('warn', 'cli_streaming_idle_warning')
     }
-    resetStreamIdleTimer()
+
+    function closeStreamIterator(
+      iterator: AsyncIterator<BetaRawMessageStreamEvent>,
+      reason: Error,
+    ): void {
+      const activeStream = stream
+      releaseStreamResources()
+      try {
+        activeStream?.controller?.abort(reason)
+      } catch {
+        // Ignore - the stream may already be closed by the SDK.
+      }
+
+      try {
+        const returned = iterator.return?.()
+        if (returned) {
+          void Promise.resolve(returned).catch(() => {})
+        }
+      } catch {
+        // Ignore - iterator.return() is best-effort cleanup.
+      }
+    }
+
+    function abortTimedOutStream(
+      iterator: AsyncIterator<BetaRawMessageStreamEvent>,
+      timeoutError: StreamIdleTimeoutError,
+    ): void {
+      streamIdleAborted = true
+      streamWatchdogFiredAt = performance.now()
+      logForDebugging(
+        `Streaming idle timeout: no chunks received for ${STREAM_IDLE_TIMEOUT_MS / 1000}s, aborting stream`,
+        { level: 'error' },
+      )
+      logForDiagnosticsNoPII('error', 'cli_streaming_idle_timeout')
+      logEvent('tengu_streaming_idle_timeout', {
+        model:
+          options.model as AnalyticsMetadata_I_VERIFIED_THIS_IS_NOT_CODE_OR_FILEPATHS,
+        request_id: (streamRequestId ??
+          'unknown') as AnalyticsMetadata_I_VERIFIED_THIS_IS_NOT_CODE_OR_FILEPATHS,
+        timeout_ms: STREAM_IDLE_TIMEOUT_MS,
+      })
+
+      closeStreamIterator(iterator, timeoutError)
+    }
+
+    function readNextStreamPart(
+      iterator: AsyncIterator<BetaRawMessageStreamEvent>,
+    ): Promise<IteratorResult<BetaRawMessageStreamEvent>> {
+      if (signal.aborted) {
+        const abortError = new APIUserAbortError()
+        closeStreamIterator(iterator, abortError)
+        return Promise.reject(abortError)
+      }
+
+      return new Promise((resolve, reject) => {
+        let settled = false
+        const cleanup = () => {
+          clearStreamIdleTimers()
+          signal.removeEventListener('abort', onAbort)
+        }
+        const settleResolve = (
+          result: IteratorResult<BetaRawMessageStreamEvent>,
+        ) => {
+          if (settled) return
+          settled = true
+          cleanup()
+          resolve(result)
+        }
+        const settleReject = (error: unknown) => {
+          if (settled) return
+          settled = true
+          cleanup()
+          reject(error)
+        }
+        const onAbort = () => {
+          const abortError = new APIUserAbortError()
+          closeStreamIterator(iterator, abortError)
+          settleReject(abortError)
+        }
+
+        signal.addEventListener('abort', onAbort, { once: true })
+
+        clearStreamIdleTimers()
+        if (streamWatchdogEnabled) {
+          streamIdleWarningTimer = setTimeout(
+            warnMs => {
+              logStreamIdleWarning(warnMs)
+            },
+            STREAM_IDLE_WARNING_MS,
+            STREAM_IDLE_WARNING_MS,
+          )
+          streamIdleTimer = setTimeout(() => {
+            const timeoutError = new StreamIdleTimeoutError(
+              STREAM_IDLE_TIMEOUT_MS,
+            )
+            abortTimedOutStream(iterator, timeoutError)
+            settleReject(timeoutError)
+          }, STREAM_IDLE_TIMEOUT_MS)
+        }
+
+        let nextPromise: Promise<IteratorResult<BetaRawMessageStreamEvent>>
+        try {
+          nextPromise = Promise.resolve(iterator.next())
+        } catch (error) {
+          settleReject(signal.aborted ? new APIUserAbortError() : error)
+          return
+        }
+
+        nextPromise.then(
+          result => settleResolve(result),
+          error => settleReject(signal.aborted ? new APIUserAbortError() : error),
+        )
+      })
+    }
 
     startSessionActivity('api_call')
     try {
@@ -2026,8 +2121,13 @@ async function* queryModel(
       let totalStallTime = 0
       let stallCount = 0
 
-      for await (const part of stream) {
-        resetStreamIdleTimer()
+      const streamIterator = stream[Symbol.asyncIterator]()
+      while (true) {
+        const streamResult = await readNextStreamPart(streamIterator)
+        if (streamResult.done) {
+          break
+        }
+        const part = streamResult.value
         const now = Date.now()
 
         // Detect and log streaming stalls (only after first event to avoid counting TTFB)
@@ -2552,6 +2652,13 @@ async function* queryModel(
         }
       }
 
+      if (signal.aborted) {
+        logForDebugging(
+          `Streaming aborted by parent signal: ${errorMessage(streamingError)}`,
+        )
+        throw new APIUserAbortError()
+      }
+
       // When the flag is enabled, skip the non-streaming fallback and let the
       // error propagate to withRetry. The mid-stream fallback causes double tool
       // execution when streaming tool execution is active: the partial stream
@@ -2695,6 +2802,11 @@ async function* queryModel(
     // an error message with no actual retry on the fallback model.
     if (errorFromRetry instanceof FallbackTriggeredError) {
       throw errorFromRetry
+    }
+
+    if (signal.aborted) {
+      releaseStreamResources()
+      return
     }
 
     // Check if this is a 404 error during stream creation that should trigger


### PR DESCRIPTION
## Summary

This PR makes the top-level Claude streaming idle watchdog deterministic.

Previously, the watchdog timer logged and released stream resources after `CLAUDE_STREAM_IDLE_TIMEOUT_MS`, but the surrounding `for await (const part of stream)` could remain blocked on a wedged `iterator.next()`. That meant the existing non-streaming fallback branch was not reached until the parent query was later aborted by QueryGuard, at which point fallback could fail with `Request was aborted`.

## What Changed

- Replaced the independent watchdog timer plus `for await` stream loop in `src/services/api/claude.ts` with explicit `AsyncIterator.next()` reads.
- Added a local `StreamIdleTimeoutError` used only to classify deterministic stream idle timeouts.
- Added timeout-aware stream reads that:
  - preserve the existing idle warning and timeout diagnostics,
  - abort the active stream controller on timeout,
  - best-effort call `iterator.return()` without awaiting it,
  - observe late iterator resolution or rejection so abandoned reads do not become unhandled rejections,
  - reject immediately on stream idle timeout so the existing non-streaming fallback path can run while the parent query signal is still live.
- Preserved parent abort behavior: user/query aborts clean up the active stream and iterator, do not start non-streaming fallback, and still let the higher query layer surface the normal interruption behavior.

## Behavior Notes

- The existing fallback gate remains unchanged, including `CLAUDE_CODE_DISABLE_NONSTREAMING_FALLBACK` and the GrowthBook fallback-disable flag.
- Provider payload construction is unchanged.
- Streaming remains enabled by default.
- The change is provider-agnostic and limited to the top-level Claude stream loop.
- Existing telemetry event names are preserved where applicable, including idle warning, idle timeout, and stream-loop-exited-after-watchdog events.

## Testing

- [x] `bun test tests/sdk/query-lifecycle.test.ts src/services/api/claude.streamWatchdog.test.ts`
- [x] `bun test src/services/api/claude.lifecycle.test.ts src/__tests__/bugfixes.test.ts`
- [x] `bun run test:provider`
- [x] `bun run typecheck`
- [x] `git diff --check`
- [x] GitHub Actions: `smoke-and-tests`, `typecheck`, and `web`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved streaming reliability when AI responses stall, helping ensure a fallback response is used instead of hanging.
  * Better handles user-initiated cancellations so aborted requests stop cleanly without being treated as failures.
  * Reduced the risk of stray stream errors showing up after a request has already been abandoned.
* **Tests**
  * Added coverage for stalled, aborted, completed, and late-error streaming scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->