### PR TITLE
feat(resume): group branched sessions in picker

### DIFF
--- a/src/commands/branch/branch.test.ts
+++ b/src/commands/branch/branch.test.ts
@@ -465,6 +465,10 @@ test('/branch creates a new session, copies messages, keeps the source transcrip
   expect(forkPath).toBeString()
   expect((await stat(forkPath!)).mode & 0o777).toBe(0o600)
   const entries = await readEntries(forkPath!)
+  expect(entries[0]).toMatchObject({
+    type: 'session-branch',
+    sessionId: newSessionId,
+  })
   const persistedMessages = entries.filter(
     entry => entry.type === 'user' || entry.type === 'assistant',
   )

--- a/src/commands/branch/branch.ts
+++ b/src/commands/branch/branch.ts
@@ -354,6 +354,7 @@ async function createFork(
       ? { branchedAtMessageId: branchedAtMessage.uuid }
       : {}),
   }
+  lines.unshift(jsonStringify(branchMetadata))
 
   // Append content-replacement entry (if any) with the fork's sessionId.
   // Written as a SINGLE entry (same shape as insertContentReplacement) so
@@ -366,8 +367,6 @@ async function createFork(
     }
     lines.push(jsonStringify(forkedReplacementEntry))
   }
-
-  lines.push(jsonStringify(branchMetadata))
 
   // Write the fork session file
   await writeFile(forkSessionPath, lines.join('\n') + '\n', {

--- a/src/components/LogSelector.resumeBranches.test.ts
+++ b/src/components/LogSelector.resumeBranches.test.ts
@@ -18,6 +18,7 @@ import {
 import type { LogOption, SessionBranchEntry } from '../types/logs.js'
 import {
   LogSelector,
+  countVisibleResumeTreeRows,
   getResumeLogDisplayTitle,
   groupLogsByResumeBranch,
   logMatchesResumePickerSearch,
@@ -251,6 +252,65 @@ test('requests more logs when grouped branch rows underfill the visible picker',
       visibleNodeCount: 10,
     }),
   ).toBe(true)
+})
+
+test('counts expanded branch rows before requesting more logs', () => {
+  const rootId = id(50)
+  const visibleCount = 5
+  const treeNodes = [
+    {
+      id: `group:${rootId}`,
+      value: null,
+      label: 'Root implementation session',
+      children: [1, 2, 3, 4].map(index => ({
+        id: `log:${rootId}:${index}`,
+        value: null,
+        label: `Branch ${index}`,
+        children:
+          index === 4
+            ? [
+                {
+                  id: `log:${rootId}:${index}:1`,
+                  value: null,
+                  label: `Nested branch ${index}`,
+                },
+              ]
+            : undefined,
+      })),
+    },
+  ]
+  const collapsedCount = countVisibleResumeTreeRows(treeNodes, {
+    expandedGroupSessionIds: new Set(),
+    forceExpanded: false,
+  })
+  const manuallyExpandedCount = countVisibleResumeTreeRows(treeNodes, {
+    expandedGroupSessionIds: new Set([rootId]),
+    forceExpanded: false,
+  })
+  const forcedExpandedCount = countVisibleResumeTreeRows(treeNodes, {
+    expandedGroupSessionIds: new Set(),
+    forceExpanded: true,
+  })
+
+  expect(collapsedCount).toBe(1)
+  expect(manuallyExpandedCount).toBe(visibleCount)
+  expect(forcedExpandedCount).toBe(visibleCount + 1)
+  expect(
+    shouldLoadMoreResumeLogs({
+      displayedLogCount: 50,
+      focusedIndex: 0,
+      visibleCount,
+      visibleNodeCount: collapsedCount,
+    }),
+  ).toBe(true)
+  expect(
+    shouldLoadMoreResumeLogs({
+      displayedLogCount: 50,
+      focusedIndex: 0,
+      visibleCount,
+      visibleNodeCount: forcedExpandedCount,
+    }),
+  ).toBe(false)
 })
 
 test('rendered picker expands branch groups and selects child branch logs', async () => {

--- a/src/components/LogSelector.resumeBranches.test.ts
+++ b/src/components/LogSelector.resumeBranches.test.ts
@@ -257,6 +257,7 @@ test('rendered picker expands branch groups and selects child branch logs', asyn
   await acquireSharedMutationLock(
     'components/LogSelector.resumeBranches.test.tsx',
   )
+  let rootRenderer: Awaited<ReturnType<typeof createRoot>> | null = null
   const rootId = id(40)
   const branchId = id(41)
   const projectPath = getOriginalCwd()
@@ -275,13 +276,14 @@ test('rendered picker expands branch groups and selects child branch logs', asyn
   })
   const selected: LogOption[] = []
   const { stdout, stdin, getOutput } = createTestStreams()
-  const rootRenderer = await createRoot({
-    stdout: stdout as unknown as NodeJS.WriteStream,
-    stdin: stdin as unknown as NodeJS.ReadStream,
-    patchConsole: false,
-  })
 
   try {
+    rootRenderer = await createRoot({
+      stdout: stdout as unknown as NodeJS.WriteStream,
+      stdin: stdin as unknown as NodeJS.ReadStream,
+      patchConsole: false,
+    })
+
     rootRenderer.render(
       React.createElement(
         AppStateProvider,
@@ -356,7 +358,7 @@ test('rendered picker expands branch groups and selects child branch logs', asyn
       branchId,
     ])
   } finally {
-    rootRenderer.unmount()
+    rootRenderer?.unmount()
     stdin.end()
     releaseSharedMutationLock()
   }

--- a/src/components/LogSelector.resumeBranches.test.ts
+++ b/src/components/LogSelector.resumeBranches.test.ts
@@ -1,0 +1,154 @@
+import { expect, test } from 'bun:test'
+import type { UUID } from 'node:crypto'
+
+import type { LogOption, SessionBranchEntry } from '../types/logs.js'
+import {
+  getResumeLogDisplayTitle,
+  groupLogsByResumeBranch,
+  logMatchesResumePickerSearch,
+  shouldLoadMoreResumeLogs,
+} from './LogSelector.js'
+
+const ts = '2026-06-30T00:00:00.000Z'
+
+function id(n: number): UUID {
+  return `00000000-0000-4000-8000-${String(n).padStart(12, '0')}` as UUID
+}
+
+function branchMeta(
+  sessionId: UUID,
+  parentSessionId: UUID,
+  rootSessionId: UUID,
+  branchName: string,
+): SessionBranchEntry {
+  return {
+    type: 'session-branch',
+    sessionId,
+    parentSessionId,
+    rootSessionId,
+    branchedFromSessionId: parentSessionId,
+    branchName,
+    branchedAt: ts,
+  }
+}
+
+function log(
+  sessionId: UUID,
+  title: string,
+  modifiedOffset: number,
+  options: Partial<LogOption> = {},
+): LogOption {
+  const modified = new Date(Date.parse(ts) + modifiedOffset)
+  return {
+    date: modified.toISOString(),
+    messages: [],
+    fullPath: `/tmp/${sessionId}.jsonl`,
+    value: modifiedOffset,
+    created: new Date(ts),
+    modified,
+    firstPrompt: title,
+    messageCount: 1,
+    isSidechain: false,
+    sessionId,
+    ...options,
+  }
+}
+
+test('groups root sessions with their branches without moving the group behind newer branches', () => {
+  const rootId = id(1)
+  const branchAId = id(2)
+  const branchBId = id(3)
+  const soloId = id(4)
+  const root = log(rootId, 'Root planning session', 10, {
+    customTitle: 'Root planning session',
+  })
+  const branchA = log(branchAId, 'Copied root prompt', 40, {
+    sessionBranch: branchMeta(branchAId, rootId, rootId, 'Branch A'),
+  })
+  const branchB = log(branchBId, 'Copied root prompt', 100, {
+    sessionBranch: branchMeta(branchBId, rootId, rootId, 'Branch B'),
+  })
+  const solo = log(soloId, 'Unrelated session', 80, {
+    customTitle: 'Unrelated session',
+  })
+
+  const groups = groupLogsByResumeBranch([branchB, solo, root, branchA])
+
+  expect(groups.map(group => group.headerLog.sessionId)).toEqual([
+    rootId,
+    soloId,
+  ])
+  expect(groups[0]?.childLogs.map(child => child.sessionId)).toEqual([
+    branchBId,
+    branchAId,
+  ])
+  expect(groups[0]?.firstIndex).toBe(0)
+  expect(groups[1]?.childLogs).toEqual([])
+})
+
+test('shows branches with missing parents as standalone sessions', () => {
+  const missingRootId = id(20)
+  const missingParentId = id(21)
+  const branchId = id(22)
+  const branch = log(branchId, 'Copied missing parent prompt', 10, {
+    sessionBranch: branchMeta(
+      branchId,
+      missingParentId,
+      missingRootId,
+      'Detached branch',
+    ),
+  })
+
+  const groups = groupLogsByResumeBranch([branch])
+
+  expect(groups).toHaveLength(1)
+  expect(groups[0]?.headerLog.sessionId).toBe(branchId)
+  expect(groups[0]?.childLogs).toEqual([])
+})
+
+test('search and display include branch names and session titles', () => {
+  const rootId = id(30)
+  const branchId = id(31)
+  const root = log(rootId, 'Investigate OAuth callback', 10, {
+    customTitle: 'OAuth callback fix',
+  })
+  const branch = log(branchId, 'Copied root prompt', 20, {
+    sessionBranch: branchMeta(
+      branchId,
+      rootId,
+      rootId,
+      'Retry token exchange',
+    ),
+  })
+
+  expect(getResumeLogDisplayTitle(branch)).toBe('Retry token exchange')
+  expect(logMatchesResumePickerSearch(branch, 'token exchange')).toBe(true)
+  expect(logMatchesResumePickerSearch(root, 'callback fix')).toBe(true)
+})
+
+test('requests more logs when grouped branch rows underfill the visible picker', () => {
+  expect(
+    shouldLoadMoreResumeLogs({
+      displayedLogCount: 50,
+      focusedIndex: 1,
+      visibleCount: 10,
+      visibleNodeCount: 1,
+    }),
+  ).toBe(true)
+  expect(
+    shouldLoadMoreResumeLogs({
+      displayedLogCount: 50,
+      focusedIndex: 1,
+      visibleCount: 10,
+      visibleNodeCount: 10,
+    }),
+  ).toBe(false)
+  expect(
+    shouldLoadMoreResumeLogs({
+      displayedLogCount: 50,
+      focusedIndex: 35,
+      visibleCount: 10,
+      visibleNodeCount: 10,
+    }),
+  ).toBe(true)
+})

--- a/src/components/LogSelector.resumeBranches.test.ts
+++ b/src/components/LogSelector.resumeBranches.test.ts
@@ -1,8 +1,23 @@
+import { PassThrough } from 'node:stream'
+
 import { expect, test } from 'bun:test'
 import type { UUID } from 'node:crypto'
+import React from 'react'
+import { stripVTControlCharacters as stripAnsi } from 'node:util'
 
+import { getOriginalCwd } from '../bootstrap/state.js'
+import { createRoot } from '../ink.js'
+import instances from '../ink/instances.js'
+import type { ParsedKey } from '../ink/parse-keypress.js'
+import { KeybindingSetup } from '../keybindings/KeybindingProviderSetup.js'
+import { AppStateProvider } from '../state/AppState.js'
+import {
+  acquireSharedMutationLock,
+  releaseSharedMutationLock,
+} from '../test/sharedMutationLock.js'
 import type { LogOption, SessionBranchEntry } from '../types/logs.js'
 import {
+  LogSelector,
   getResumeLogDisplayTitle,
   groupLogsByResumeBranch,
   logMatchesResumePickerSearch,
@@ -10,6 +25,8 @@ import {
 } from './LogSelector.js'
 
 const ts = '2026-06-30T00:00:00.000Z'
+const SYNC_START = '\x1B[?2026h'
+const SYNC_END = '\x1B[?2026l'
 
 function id(n: number): UUID {
   return `00000000-0000-4000-8000-${String(n).padStart(12, '0')}` as UUID
@@ -52,6 +69,88 @@ function log(
     sessionId,
     ...options,
   }
+}
+
+function extractLastFrame(output: string): string {
+  let lastFrame: string | null = null
+  let cursor = 0
+  while (cursor < output.length) {
+    const start = output.indexOf(SYNC_START, cursor)
+    if (start === -1) break
+    const contentStart = start + SYNC_START.length
+    const end = output.indexOf(SYNC_END, contentStart)
+    if (end === -1) break
+    const frame = output.slice(contentStart, end)
+    if (frame.trim().length > 0) lastFrame = frame
+    cursor = end + SYNC_END.length
+  }
+  return lastFrame ?? output
+}
+
+function createTestStreams(): {
+  stdout: PassThrough
+  stdin: PassThrough & {
+    isTTY: boolean
+    setRawMode: (mode: boolean) => void
+    ref: () => void
+    unref: () => void
+  }
+  getOutput: () => string
+} {
+  let output = ''
+  const stdout = new PassThrough()
+  const stdin = new PassThrough() as PassThrough & {
+    isTTY: boolean
+    setRawMode: (mode: boolean) => void
+    ref: () => void
+    unref: () => void
+  }
+  stdin.isTTY = true
+  stdin.setRawMode = () => {}
+  stdin.ref = () => {}
+  stdin.unref = () => {}
+  ;(stdout as unknown as { columns: number }).columns = 120
+  stdout.on('data', chunk => {
+    output += chunk.toString()
+  })
+  return { stdout, stdin, getOutput: () => output }
+}
+
+function dispatchKeyboard(
+  stdout: PassThrough,
+  key: Pick<ParsedKey, 'name' | 'sequence' | 'raw'>,
+): void {
+  const instance = instances.get(stdout as unknown as NodeJS.WriteStream) as
+    | { dispatchKeyboardEvent: (parsedKey: ParsedKey) => void }
+    | undefined
+  if (!instance) {
+    throw new Error('Ink instance not found')
+  }
+  instance.dispatchKeyboardEvent({
+    kind: 'key',
+    fn: false,
+    ctrl: false,
+    meta: false,
+    shift: false,
+    option: false,
+    super: false,
+    isPasted: false,
+    ...key,
+  })
+}
+
+async function waitForFrame(
+  getOutput: () => string,
+  predicate: (frame: string) => boolean,
+): Promise<string> {
+  const startedAt = Date.now()
+  let frame = ''
+  while (Date.now() - startedAt < 2500) {
+    frame = stripAnsi(extractLastFrame(getOutput()))
+    if (predicate(frame)) return frame
+    await Bun.sleep(10)
+  }
+  throw new Error(`Timed out waiting for LogSelector output:\n${frame}`)
 }
 
 test('groups root sessions with their branches without moving the group behind newer branches', () => {
@@ -123,6 +222,7 @@ test('search and display include branch names and session titles', () => {
 
   expect(getResumeLogDisplayTitle(branch)).toBe('Retry token exchange')
   expect(logMatchesResumePickerSearch(branch, 'token exchange')).toBe(true)
+  expect(logMatchesResumePickerSearch(branch, 'copied root prompt')).toBe(true)
   expect(logMatchesResumePickerSearch(root, 'callback fix')).toBe(true)
 })
 
@@ -151,4 +251,113 @@ test('requests more logs when grouped branch rows underfill the visible picker',
       visibleNodeCount: 10,
     }),
   ).toBe(true)
+})
+
+test('rendered picker expands branch groups and selects child branch logs', async () => {
+  await acquireSharedMutationLock(
+    'components/LogSelector.resumeBranches.test.tsx',
+  )
+  const rootId = id(40)
+  const branchId = id(41)
+  const projectPath = getOriginalCwd()
+  const root = log(rootId, 'Root implementation session', 10, {
+    customTitle: 'Root implementation session',
+    projectPath,
+  })
+  const branch = log(branchId, 'Branch copied prompt', 20, {
+    projectPath,
+    sessionBranch: branchMeta(
+      branchId,
+      rootId,
+      rootId,
+      'Branch implementation session',
+    ),
+  })
+  const selected: LogOption[] = []
+  const { stdout, stdin, getOutput } = createTestStreams()
+  const rootRenderer = await createRoot({
+    stdout: stdout as unknown as NodeJS.WriteStream,
+    stdin: stdin as unknown as NodeJS.ReadStream,
+    patchConsole: false,
+  })
+
+  try {
+    rootRenderer.render(
+      React.createElement(
+        AppStateProvider,
+        null,
+        React.createElement(
+          KeybindingSetup,
+          null,
+          React.createElement(LogSelector, {
+            logs: [branch, root],
+            maxHeight: 30,
+            forceWidth: 100,
+            onSelect: selectedLog => {
+              selected.push(selectedLog)
+            },
+          }),
+        ),
+      ),
+    )
+
+    await waitForFrame(
+      getOutput,
+      frame =>
+        frame.includes('Root implementation session') &&
+        frame.includes('(+1 other session)') &&
+        !frame.includes('Branch implementation session'),
+    )
+    await Bun.sleep(50)
+
+    dispatchKeyboard(stdout, {
+      name: 'right',
+      sequence: '\x1B[C',
+      raw: '\x1B[C',
+    })
+    await waitForFrame(
+      getOutput,
+      frame =>
+        frame.includes('Root implementation session') &&
+        frame.includes('Branch implementation session'),
+    )
+
+    dispatchKeyboard(stdout, {
+      name: 'left',
+      sequence: '\x1B[D',
+      raw: '\x1B[D',
+    })
+    await waitForFrame(
+      getOutput,
+      frame =>
+        frame.includes('Root implementation session') &&
+        !frame.includes('Branch implementation session'),
+    )
+
+    dispatchKeyboard(stdout, {
+      name: 'right',
+      sequence: '\x1B[C',
+      raw: '\x1B[C',
+    })
+    await waitForFrame(
+      getOutput,
+      frame =>
+        frame.includes('Root implementation session') &&
+        frame.includes('Branch implementation session'),
+    )
+
+    stdin.write('2')
+
+    const startedAt = Date.now()
+    while (Date.now() - startedAt < 2500 && selected.length === 0) {
+      await Bun.sleep(10)
+    }
+    expect(selected.map(selectedLog => selectedLog.sessionId)).toEqual([
+      branchId,
+    ])
+  } finally {
+    rootRenderer.unmount()
+    stdin.end()
+    releaseSharedMutationLock()
+  }
 })

--- a/src/components/LogSelector.tsx
+++ b/src/components/LogSelector.tsx
@@ -178,11 +178,12 @@ export function logMatchesResumePickerSearch(log: LogOption, rawQuery: string): 
   const query = rawQuery.trim().toLowerCase()
   if (!query) return true
   const displayedTitle = getResumeLogDisplayTitle(log).toLowerCase()
+  const baseDisplayTitle = getLogDisplayTitle(log).toLowerCase()
   const branchName = (log.sessionBranch?.branchName || "").toLowerCase()
   const branch = (log.gitBranch || "").toLowerCase()
   const tag = (log.tag || "").toLowerCase()
   const prInfo = log.prNumber ? `pr #${log.prNumber} ${log.prRepository || ""}`.toLowerCase() : ""
-  return displayedTitle.includes(query) || branchName.includes(query) || branch.includes(query) || tag.includes(query) || prInfo.includes(query)
+  return displayedTitle.includes(query) || baseDisplayTitle.includes(query) || branchName.includes(query) || branch.includes(query) || tag.includes(query) || prInfo.includes(query)
 }
 export function shouldLoadMoreResumeLogs(options: {
   displayedLogCount: number;

--- a/src/components/LogSelector.tsx
+++ b/src/components/LogSelector.tsx
@@ -59,6 +59,13 @@ type LogTreeNode = TreeNode<{
   log: LogOption;
   indexInFiltered: number;
 }>;
+export type ResumeLogGroup = {
+  id: string;
+  headerLog: LogOption;
+  childLogs: LogOption[];
+  logs: LogOption[];
+  firstIndex: number;
+};
 type ViewMode = 'list' | 'preview' | 'rename' | 'search';
 type DeepSearchResult = {
   log: LogOption;
@@ -141,7 +148,7 @@ function buildLogLabel(log: LogOption, maxLabelWidth: number, options?: {
   const sessionCountSuffix = isGroupHeader && forkCount > 0 ? ` (+${forkCount} other ${forkCount === 1 ? 'session' : 'sessions'})` : '';
   const sidechainSuffix = log.isSidechain ? ' (sidechain)' : '';
   const maxSummaryWidth = maxLabelWidth - prefixWidth - sidechainSuffix.length - sessionCountSuffix.length;
-  const truncatedSummary = normalizeAndTruncateToWidth(getLogDisplayTitle(log), maxSummaryWidth);
+  const truncatedSummary = normalizeAndTruncateToWidth(getResumeLogDisplayTitle(log), maxSummaryWidth);
   return `${truncatedSummary}${sidechainSuffix}${sessionCountSuffix}`;
 }
 function buildLogMetadata(log: LogOption, options?: {
@@ -157,6 +164,50 @@ function buildLogMetadata(log: LogOption, options?: {
   const baseMetadata = formatLogMetadata(log);
   const projectSuffix = showProjectPath && log.projectPath ? ` · ${log.projectPath}` : '';
   return childPadding + baseMetadata + projectSuffix;
+}
+export function getResumeLogDisplayTitle(log: LogOption): string {
+  const branchName = log.sessionBranch?.branchName?.trim()
+  if (branchName) {
+    const sessionTitle = log.agentName || log.customTitle
+    if (sessionTitle) return getLogDisplayTitle(log)
+    return branchName
+  }
+  return getLogDisplayTitle(log)
+}
+export function logMatchesResumePickerSearch(log: LogOption, rawQuery: string): boolean {
+  const query = rawQuery.trim().toLowerCase()
+  if (!query) return true
+  const displayedTitle = getResumeLogDisplayTitle(log).toLowerCase()
+  const branchName = (log.sessionBranch?.branchName || "").toLowerCase()
+  const branch = (log.gitBranch || "").toLowerCase()
+  const tag = (log.tag || "").toLowerCase()
+  const prInfo = log.prNumber ? `pr #${log.prNumber} ${log.prRepository || ""}`.toLowerCase() : ""
+  return displayedTitle.includes(query) || branchName.includes(query) || branch.includes(query) || tag.includes(query) || prInfo.includes(query)
+}
+export function shouldLoadMoreResumeLogs(options: {
+  displayedLogCount: number;
+  focusedIndex: number;
+  visibleCount: number;
+  visibleNodeCount: number;
+}): boolean {
+  const {
+    displayedLogCount,
+    focusedIndex,
+    visibleCount,
+    visibleNodeCount
+  } = options
+  const buffer = visibleCount * 2
+  return visibleNodeCount < visibleCount || focusedIndex + buffer >= displayedLogCount
+}
+function findContainingGroupNode(nodes: LogTreeNode[], nodeId?: string | number): LogTreeNode | null {
+  if (!nodeId) return null
+  for (const node of nodes) {
+    if (node.id === nodeId) return node
+    if (node.children?.some(child => child.id === nodeId)) {
+      return node
+    }
+  }
+  return null
 }
 export function LogSelector(t0: LogSelectorProps) {
   const $ = _c(247);
@@ -444,14 +495,7 @@ export function LogSelector(t0: LogSelectorProps) {
     }
     let t23;
     if ($[39] !== baseFilteredLogs || $[40] !== searchQuery) {
-      const query = searchQuery.toLowerCase();
-      t23 = baseFilteredLogs.filter(log_5 => {
-        const displayedTitle = getLogDisplayTitle(log_5).toLowerCase();
-        const branch_0 = (log_5.gitBranch || "").toLowerCase();
-        const tag = (log_5.tag || "").toLowerCase();
-        const prInfo = log_5.prNumber ? `pr #${log_5.prNumber} ${log_5.prRepository || ""}`.toLowerCase() : "";
-        return displayedTitle.includes(query) || branch_0.includes(query) || tag.includes(query) || prInfo.includes(query);
-      });
+      t23 = baseFilteredLogs.filter(log_5 => logMatchesResumePickerSearch(log_5, searchQuery));
       $[39] = baseFilteredLogs;
       $[40] = searchQuery;
       $[41] = t23;
@@ -596,19 +640,18 @@ export function LogSelector(t0: LogSelectorProps) {
     }
     let t30;
     if ($[66] !== displayedLogs || $[67] !== highlightColor || $[68] !== maxLabelWidth || $[69] !== showAllProjects || $[70] !== snippets) {
-      const sessionGroups = groupLogsBySessionId(displayedLogs);
-      t30 = Array.from(sessionGroups.entries()).map(t31 => {
-        const [sessionId, groupLogs] = t31;
-        const latestLog = groupLogs[0];
-        const indexInFiltered = displayedLogs.indexOf(latestLog);
+      const sessionGroups = groupLogsByResumeBranch(displayedLogs);
+      t30 = sessionGroups.map(group => {
+        const latestLog = group.headerLog;
+        const indexInFiltered = group.firstIndex;
         const snippet_0 = snippets.get(latestLog);
         const snippetStr = snippet_0 ? formatSnippet(snippet_0, highlightColor) : null;
-        if (groupLogs.length === 1) {
+        if (group.childLogs.length === 0) {
           const metadata = buildLogMetadata(latestLog, {
             showProjectPath: showAllProjects
           });
           return {
-            id: `log:${sessionId}:0`,
+            id: `log:${group.id}:0`,
             value: {
               log: latestLog,
               indexInFiltered
@@ -618,8 +661,8 @@ export function LogSelector(t0: LogSelectorProps) {
             dimDescription: true
           };
         }
-        const forkCount = groupLogs.length - 1;
-        const children = groupLogs.slice(1).map((log_8, index) => {
+        const forkCount = group.childLogs.length;
+        const children = group.childLogs.map((log_8, index) => {
           const childIndexInFiltered = displayedLogs.indexOf(log_8);
           const childSnippet = snippets.get(log_8);
           const childSnippetStr = childSnippet ? formatSnippet(childSnippet, highlightColor) : null;
@@ -628,7 +671,7 @@ export function LogSelector(t0: LogSelectorProps) {
             showProjectPath: showAllProjects
           });
           return {
-            id: `log:${sessionId}:${index + 1}`,
+            id: `log:${group.id}:${index + 1}`,
             value: {
               log: log_8,
               indexInFiltered: childIndexInFiltered
@@ -644,7 +687,7 @@ export function LogSelector(t0: LogSelectorProps) {
           showProjectPath: showAllProjects
         });
         return {
-          id: `group:${sessionId}`,
+          id: `group:${group.id}`,
           value: {
             log: latestLog,
             indexInFiltered
@@ -688,7 +731,7 @@ export function LogSelector(t0: LogSelectorProps) {
       let t32;
       if ($[79] !== highlightColor || $[80] !== maxLabelWidth || $[81] !== showAllProjects || $[82] !== snippets) {
         t32 = (log_9, index_0) => {
-          const rawSummary = getLogDisplayTitle(log_9);
+          const rawSummary = getResumeLogDisplayTitle(log_9);
           const summaryWithSidechain = rawSummary + (log_9.isSidechain ? " (sidechain)" : "");
           const summary = normalizeAndTruncateToWidth(summaryWithSidechain, maxLabelWidth);
           const baseDescription = formatLogMetadata(log_9);
@@ -725,30 +768,26 @@ export function LogSelector(t0: LogSelectorProps) {
   const flatOptions = t30;
   const focusedLog = focusedNode?.value.log ?? null;
   let t31;
-  if ($[84] !== displayedLogs || $[85] !== expandedGroupSessionIds || $[86] !== focusedLog) {
+  if ($[84] !== treeNodes || $[85] !== expandedGroupSessionIds || $[86] !== focusedNode?.id) {
     t31 = () => {
-      if (!isResumeWithRenameEnabled || !focusedLog) {
+      if (!isResumeWithRenameEnabled || !focusedNode) {
         return "";
       }
-      const sessionId_0 = getSessionIdFromLog(focusedLog);
-      if (!sessionId_0) {
+      const groupNode = findContainingGroupNode(treeNodes, focusedNode.id);
+      if (!groupNode?.children?.length || !String(groupNode.id).startsWith("group:")) {
         return "";
       }
-      const sessionLogs = displayedLogs.filter(log_10 => getSessionIdFromLog(log_10) === sessionId_0);
-      const hasMultipleLogs = sessionLogs.length > 1;
-      if (!hasMultipleLogs) {
-        return "";
-      }
-      const isExpanded = expandedGroupSessionIds.has(sessionId_0);
-      const isChildNode = sessionLogs.indexOf(focusedLog) > 0;
+      const groupId = String(groupNode.id).substring(6);
+      const isExpanded = expandedGroupSessionIds.has(groupId);
+      const isChildNode = focusedNode.id !== groupNode.id;
       if (isChildNode) {
         return "\u2190 to collapse";
       }
       return isExpanded ? "\u2190 to collapse" : "\u2192 to expand";
     };
-    $[84] = displayedLogs;
+    $[84] = treeNodes;
     $[85] = expandedGroupSessionIds;
-    $[86] = focusedLog;
+    $[86] = focusedNode?.id;
     $[87] = t31;
   } else {
     t31 = $[87];
@@ -973,10 +1012,7 @@ export function LogSelector(t0: LogSelectorProps) {
   if ($[118] !== displayedLogs) {
     t43 = (node: LogTreeNode) => {
       setFocusedNode(node);
-      const index_2 = displayedLogs.findIndex(log_12 => getSessionIdFromLog(log_12) === getSessionIdFromLog(node.value.log));
-      if (index_2 >= 0) {
-        setFocusedIndex(index_2 + 1);
-      }
+      setFocusedIndex(node.value.indexInFiltered + 1);
     };
     $[118] = displayedLogs;
     $[119] = t43;
@@ -1218,30 +1254,20 @@ export function LogSelector(t0: LogSelectorProps) {
   const showAdditionalFilterLine = filterIndicators.length > 0 && viewMode !== "search";
   const headerLines = 8 + (showAdditionalFilterLine ? 1 : 0) + tagTabsLines;
   const visibleCount = Math.max(1, Math.floor((maxHeight - headerLines - 2) / 3));
-  let t55;
-  let t56;
-  if ($[154] !== displayedLogs.length || $[155] !== focusedIndex || $[156] !== onLoadMore || $[157] !== visibleCount) {
-    t55 = () => {
-      if (!onLoadMore) {
-        return;
-      }
-      const buffer = visibleCount * 2;
-      if (focusedIndex + buffer >= displayedLogs.length) {
-        onLoadMore(visibleCount * 3);
-      }
-    };
-    t56 = [focusedIndex, visibleCount, displayedLogs.length, onLoadMore];
-    $[154] = displayedLogs.length;
-    $[155] = focusedIndex;
-    $[156] = onLoadMore;
-    $[157] = visibleCount;
-    $[158] = t55;
-    $[159] = t56;
-  } else {
-    t55 = $[158];
-    t56 = $[159];
-  }
-  React.useEffect(t55, t56);
+  const loadMoreVisibleCount = isResumeWithRenameEnabled ? treeNodes.length : displayedLogs.length;
+  React.useEffect(() => {
+    if (!onLoadMore) {
+      return;
+    }
+    if (shouldLoadMoreResumeLogs({
+      displayedLogCount: displayedLogs.length,
+      focusedIndex,
+      visibleCount,
+      visibleNodeCount: loadMoreVisibleCount
+    })) {
+      onLoadMore(visibleCount * 3);
+    }
+  }, [displayedLogs.length, focusedIndex, loadMoreVisibleCount, onLoadMore, visibleCount]);
   if (logs.length === 0) {
     return null;
   }
@@ -1375,7 +1401,7 @@ export function LogSelector(t0: LogSelectorProps) {
   }
   let t70;
   if ($[202] !== agenticSearchState.status || $[203] !== branchFilterEnabled || $[204] !== columns || $[205] !== displayedLogs || $[206] !== expandedGroupSessionIds || $[207] !== flatOptions || $[208] !== focusedLog || $[209] !== focusedNode?.id || $[210] !== handleFlatOptionsSelectFocus || $[211] !== handleRenameSubmit || $[212] !== handleTreeSelectFocus || $[213] !== isAgenticSearchOptionFocused || $[214] !== onCancel || $[215] !== onSelect || $[216] !== renameCursorOffset || $[217] !== renameValue || $[218] !== treeNodes || $[219] !== viewMode || $[220] !== visibleCount) {
-    t70 = agenticSearchState.status === "searching" ? null : viewMode === "rename" && focusedLog ? <Box paddingLeft={2} flexDirection="column"><Text bold={true}>Rename session:</Text><Box paddingTop={1}><TextInput value={renameValue} onChange={setRenameValue} onSubmit={handleRenameSubmit} placeholder={getLogDisplayTitle(focusedLog, "Enter new session name")} columns={columns} cursorOffset={renameCursorOffset} onChangeCursorOffset={setRenameCursorOffset} showCursor={true} /></Box></Box> : isResumeWithRenameEnabled ? <TreeSelect nodes={treeNodes} onSelect={node_0 => {
+    t70 = agenticSearchState.status === "searching" ? null : viewMode === "rename" && focusedLog ? <Box paddingLeft={2} flexDirection="column"><Text bold={true}>Rename session:</Text><Box paddingTop={1}><TextInput value={renameValue} onChange={setRenameValue} onSubmit={handleRenameSubmit} placeholder={getResumeLogDisplayTitle(focusedLog) || "Enter new session name"} columns={columns} cursorOffset={renameCursorOffset} onChangeCursorOffset={setRenameCursorOffset} showCursor={true} /></Box></Box> : isResumeWithRenameEnabled ? <TreeSelect nodes={treeNodes} onSelect={node_0 => {
       onSelect(node_0.value.log);
     }} onFocus={handleTreeSelectFocus} onCancel={onCancel} focusNodeId={focusedNode?.id} visibleOptionCount={visibleCount} layout="expanded" isDisabled={viewMode === "search" || isAgenticSearchOptionFocused} hideIndexes={false} isNodeExpanded={nodeId => {
       if (viewMode === "search" || branchFilterEnabled) {
@@ -1513,6 +1539,9 @@ function _temp2(log_1: LogOption): boolean {
   if (log_1.customTitle) {
     return true;
   }
+  if (log_1.sessionBranch?.branchName?.trim()) {
+    return true;
+  }
   const fromMessages = getFirstMeaningfulUserMessageTextContent(log_1.messages);
   if (fromMessages) {
     return true;
@@ -1558,27 +1587,65 @@ function extractSearchableText(message: SerializedMessage): string {
 function buildSearchableText(log: LogOption): string {
   const searchableMessages = log.messages.length <= DEEP_SEARCH_MAX_MESSAGES ? log.messages : [...log.messages.slice(0, DEEP_SEARCH_CROP_SIZE), ...log.messages.slice(-DEEP_SEARCH_CROP_SIZE)];
   const messageText = searchableMessages.map(extractSearchableText).filter(Boolean).join(' ');
-  const metadata = [log.customTitle, log.summary, log.firstPrompt, log.gitBranch, log.tag, log.prNumber ? `PR #${log.prNumber}` : undefined, log.prRepository].filter(Boolean).join(' ');
+  const metadata = [getResumeLogDisplayTitle(log), log.customTitle, log.sessionBranch?.branchName, log.summary, log.firstPrompt, log.gitBranch, log.tag, log.prNumber ? `PR #${log.prNumber}` : undefined, log.prRepository].filter(Boolean).join(' ');
   const fullText = `${metadata} ${messageText}`.trim();
   return fullText.length > DEEP_SEARCH_MAX_TEXT_LENGTH ? fullText.slice(0, DEEP_SEARCH_MAX_TEXT_LENGTH) : fullText;
 }
-function groupLogsBySessionId(filteredLogs: LogOption[]): Map<string, LogOption[]> {
-  const groups = new Map<string, LogOption[]>();
+export function groupLogsByResumeBranch(filteredLogs: LogOption[]): ResumeLogGroup[] {
+  type MutableGroup = {
+    id: string;
+    headerSessionId: string;
+    logs: LogOption[];
+    firstIndex: number;
+  };
+
+  const visibleSessionIds = new Set<string>();
   for (const log of filteredLogs) {
     const sessionId = getSessionIdFromLog(log);
-    if (sessionId) {
-      const existing = groups.get(sessionId);
-      if (existing) {
-        existing.push(log);
-      } else {
-        groups.set(sessionId, [log]);
-      }
-    }
+    if (sessionId) visibleSessionIds.add(sessionId);
   }
 
-  // Sort logs within each group by modified date (newest first)
-  groups.forEach(logs => logs.sort((a, b) => new Date(b.modified).getTime() - new Date(a.modified).getTime()));
-  return groups;
+  const groups = new Map<string, MutableGroup>();
+  for (const [index, log] of filteredLogs.entries()) {
+    const sessionId = getSessionIdFromLog(log);
+    if (!sessionId) continue;
+
+    const branch = log.sessionBranch;
+    let headerSessionId = sessionId;
+    if (branch?.rootSessionId && visibleSessionIds.has(branch.rootSessionId)) {
+      headerSessionId = branch.rootSessionId;
+    } else if (branch?.parentSessionId && visibleSessionIds.has(branch.parentSessionId)) {
+      headerSessionId = branch.parentSessionId;
+    }
+
+    let group = groups.get(headerSessionId);
+    if (!group) {
+      group = {
+        id: headerSessionId,
+        headerSessionId,
+        logs: [],
+        firstIndex: index,
+      };
+      groups.set(headerSessionId, group);
+    } else {
+      group.firstIndex = Math.min(group.firstIndex, index);
+    }
+    group.logs.push(log);
+  }
+
+  return Array.from(groups.values()).map(group => {
+    const headerLog =
+      group.logs.find(log => getSessionIdFromLog(log) === group.headerSessionId) ??
+      group.logs[0]!;
+    const childLogs = group.logs.filter(log => log !== headerLog);
+    return {
+      id: group.id,
+      headerLog,
+      childLogs,
+      logs: [headerLog, ...childLogs],
+      firstIndex: group.firstIndex,
+    };
+  }).sort((a, b) => a.firstIndex - b.firstIndex);
 }
 
 /**

--- a/src/components/LogSelector.tsx
+++ b/src/components/LogSelector.tsx
@@ -200,6 +200,27 @@ export function shouldLoadMoreResumeLogs(options: {
   const buffer = visibleCount * 2
   return visibleNodeCount < visibleCount || focusedIndex + buffer >= displayedLogCount
 }
+export function countVisibleResumeTreeRows(
+  nodes: readonly TreeNode<unknown>[],
+  options: {
+    expandedGroupSessionIds: ReadonlySet<string>;
+    forceExpanded: boolean;
+  },
+): number {
+  const { expandedGroupSessionIds, forceExpanded } = options
+  const isExpanded = (nodeId: string | number): boolean => {
+    if (forceExpanded) return true
+    const groupSessionId = typeof nodeId === "string" && nodeId.startsWith("group:") ? nodeId.slice(6) : null
+    return groupSessionId ? expandedGroupSessionIds.has(groupSessionId) : false
+  }
+  const countNode = (node: TreeNode<unknown>): number => {
+    const children = node.children ?? []
+    if (children.length === 0 || !isExpanded(node.id)) return 1
+    return 1 + children.reduce((count, child) => count + countNode(child), 0)
+  }
+
+  return nodes.reduce((count, node) => count + countNode(node), 0)
+}
 function findContainingGroupNode(nodes: LogTreeNode[], nodeId?: string | number): LogTreeNode | null {
   if (!nodeId) return null
   for (const node of nodes) {
@@ -1255,7 +1276,10 @@ export function LogSelector(t0: LogSelectorProps) {
   const showAdditionalFilterLine = filterIndicators.length > 0 && viewMode !== "search";
   const headerLines = 8 + (showAdditionalFilterLine ? 1 : 0) + tagTabsLines;
   const visibleCount = Math.max(1, Math.floor((maxHeight - headerLines - 2) / 3));
-  const loadMoreVisibleCount = isResumeWithRenameEnabled ? treeNodes.length : displayedLogs.length;
+  const loadMoreVisibleCount = isResumeWithRenameEnabled ? countVisibleResumeTreeRows(treeNodes, {
+    expandedGroupSessionIds,
+    forceExpanded: viewMode === "search" || branchFilterEnabled
+  }) : displayedLogs.length;
   React.useEffect(() => {
     if (!onLoadMore) {
       return;

--- a/src/screens/ResumeConversation.test.ts
+++ b/src/screens/ResumeConversation.test.ts
@@ -1,0 +1,54 @@
+import { expect, test } from 'bun:test'
+import type { UUID } from 'node:crypto'
+
+import type { LogOption } from '../types/logs.js'
+import { filterResumeLogs } from './resumeFilters.js'
+
+const ts = '2026-06-30T00:00:00.000Z'
+
+function id(n: number): UUID {
+  return `00000000-0000-4000-8000-${String(n).padStart(12, '0')}` as UUID
+}
+
+function log(
+  sessionId: UUID,
+  options: Partial<LogOption> = {},
+): LogOption {
+  return {
+    date: ts,
+    messages: [],
+    fullPath: `/tmp/${sessionId}.jsonl`,
+    value: 0,
+    created: new Date(ts),
+    modified: new Date(ts),
+    firstPrompt: 'session',
+    messageCount: 1,
+    isSidechain: false,
+    sessionId,
+    ...options,
+  }
+}
+
+test('filterResumeLogs preserves PR filters before picker grouping', () => {
+  const prLog = log(id(1), {
+    prNumber: 42,
+    prUrl: 'https://github.com/Gitlawb/openclaude/pull/42',
+    prRepository: 'Gitlawb/openclaude',
+  })
+  const otherPrLog = log(id(2), { prNumber: 77 })
+  const nonPrLog = log(id(3))
+  const sidechainLog = log(id(4), { isSidechain: true, prNumber: 42 })
+
+  expect(filterResumeLogs([prLog, otherPrLog, nonPrLog], true)).toEqual([
+    prLog,
+    otherPrLog,
+  ])
+  expect(filterResumeLogs([prLog, otherPrLog, nonPrLog], 42)).toEqual([prLog])
+  expect(
+    filterResumeLogs(
+      [prLog, otherPrLog, nonPrLog],
+      'https://github.com/Gitlawb/openclaude/pull/42',
+    ),
+  ).toEqual([prLog])
+  expect(filterResumeLogs([prLog, sidechainLog], 42)).toEqual([prLog])
+})

--- a/src/screens/ResumeConversation.test.ts
+++ b/src/screens/ResumeConversation.test.ts
@@ -39,6 +39,17 @@ test('filterResumeLogs preserves PR filters before picker grouping', () => {
   const nonPrLog = log(id(3))
   const sidechainLog = log(id(4), { isSidechain: true, prNumber: 42 })
 
+  expect(filterResumeLogs([prLog, nonPrLog, sidechainLog], undefined)).toEqual([
+    prLog,
+    nonPrLog,
+  ])
+  expect(filterResumeLogs([prLog, nonPrLog, sidechainLog], false)).toEqual([
+    prLog,
+    nonPrLog,
+  ])
+  expect(
+    filterResumeLogs([prLog, nonPrLog, sidechainLog], 'not-a-pr'),
+  ).toEqual([prLog, nonPrLog])
   expect(filterResumeLogs([prLog, otherPrLog, nonPrLog], true)).toEqual([
     prLog,
     otherPrLog,

--- a/src/screens/ResumeConversation.tsx
+++ b/src/screens/ResumeConversation.tsx
@@ -35,17 +35,7 @@ import type { ModelSetting } from '../utils/model/model.js';
 import type { ThinkingConfig } from '../utils/thinking.js';
 import { filterContentReplacementsForMessages, type ContentReplacementRecord } from '../utils/toolResultStorage.js';
 import { REPL } from './REPL.js';
-function parsePrIdentifier(value: string): number | null {
-  const directNumber = parseInt(value, 10);
-  if (!isNaN(directNumber) && directNumber > 0) {
-    return directNumber;
-  }
-  const urlMatch = value.match(/github\.com\/[^/]+\/[^/]+\/pull\/(\d+)/);
-  if (urlMatch?.[1]) {
-    return parseInt(urlMatch[1], 10);
-  }
-  return null;
-}
+import { filterResumeLogs } from './resumeFilters.js';
 type Props = {
   commands: Command[];
   worktreePaths: string[];
@@ -114,20 +104,7 @@ export function ResumeConversation({
   // the setLogs updater (keeping it pure per React's contract).
   const logCountRef = React.useRef(0);
   const filteredLogs = React.useMemo(() => {
-    let result = logs.filter(l => !l.isSidechain);
-    if (filterByPr !== undefined) {
-      if (filterByPr === true) {
-        result = result.filter(l_0 => l_0.prNumber !== undefined);
-      } else if (typeof filterByPr === 'number') {
-        result = result.filter(l_1 => l_1.prNumber === filterByPr);
-      } else if (typeof filterByPr === 'string') {
-        const prNumber = parsePrIdentifier(filterByPr);
-        if (prNumber !== null) {
-          result = result.filter(l_2 => l_2.prNumber === prNumber);
-        }
-      }
-    }
-    return result;
+    return filterResumeLogs(logs, filterByPr);
   }, [logs, filterByPr]);
   const isResumeWithRenameEnabled = isCustomTitleEnabled();
   React.useEffect(() => {

--- a/src/screens/resumeFilters.ts
+++ b/src/screens/resumeFilters.ts
@@ -1,0 +1,36 @@
+import type { LogOption } from '../types/logs.js'
+
+export type ResumePrFilter = boolean | number | string | undefined
+
+export function parsePrIdentifier(value: string): number | null {
+  const directNumber = parseInt(value, 10)
+  if (!isNaN(directNumber) && directNumber > 0) {
+    return directNumber
+  }
+  const urlMatch = value.match(/github\.com\/[^/]+\/[^/]+\/pull\/(\d+)/)
+  if (urlMatch?.[1]) {
+    return parseInt(urlMatch[1], 10)
+  }
+  return null
+}
+
+export function filterResumeLogs(
+  logs: LogOption[],
+  filterByPr: ResumePrFilter,
+): LogOption[] {
+  let result = logs.filter(l => !l.isSidechain)
+  if (filterByPr === undefined || filterByPr === false) {
+    return result
+  }
+  if (filterByPr === true) {
+    return result.filter(l => l.prNumber !== undefined)
+  }
+  if (typeof filterByPr === 'number') {
+    return result.filter(l => l.prNumber === filterByPr)
+  }
+  const prNumber = parsePrIdentifier(filterByPr)
+  if (prNumber !== null) {
+    result = result.filter(l => l.prNumber === prNumber)
+  }
+  return result
+}

--- a/src/utils/sessionStorage.test.ts
+++ b/src/utils/sessionStorage.test.ts
@@ -870,6 +870,7 @@ test('loadSameRepoMessageLogsProgressive ignores branch metadata outside lite re
     )
 
     const branchLog = result.logs.find(log => log.sessionId === branchId)
+    expect(branchLog).toBeDefined()
     expect(branchLog?.sessionBranch).toBeUndefined()
   } finally {
     setClaudeConfigHomeDirForTesting(undefined)

--- a/src/utils/sessionStorage.test.ts
+++ b/src/utils/sessionStorage.test.ts
@@ -738,7 +738,7 @@ test('loadSameRepoMessageLogsProgressive preserves branch metadata across worktr
   }
 })
 
-test('loadSameRepoMessageLogsProgressive preserves branch metadata outside lite read windows', async () => {
+test('loadSameRepoMessageLogsProgressive preserves branch metadata from the lite head window', async () => {
   const configDir = await mkdtemp(
     join(tmpdir(), 'openclaude-session-storage-config-'),
   )
@@ -779,7 +779,7 @@ test('loadSameRepoMessageLogsProgressive preserves branch metadata outside lite 
     const largeText = 'x'.repeat(70 * 1024)
     await writeFile(
       join(branchProjectDir, `${branchId}.jsonl`),
-      `${JSON.stringify({
+      `${JSON.stringify(branchMetadata)}\n${JSON.stringify({
         ...user(id(74), null, 'branch prompt'),
         sessionId: branchId,
         cwd: branchProject,
@@ -787,7 +787,7 @@ test('loadSameRepoMessageLogsProgressive preserves branch metadata outside lite 
         ...user(id(75), id(74), largeText),
         sessionId: branchId,
         cwd: branchProject,
-      })}\n${JSON.stringify(branchMetadata)}\n${JSON.stringify({
+      })}\n${JSON.stringify({
         ...assistant(id(76), id(75), largeText),
         sessionId: branchId,
         cwd: branchProject,
@@ -802,6 +802,75 @@ test('loadSameRepoMessageLogsProgressive preserves branch metadata outside lite 
     const branchLog = result.logs.find(log => log.sessionId === branchId)
     expect(branchLog?.sessionBranch?.branchName).toBe('Long-lived branch')
     expect(branchLog?.sessionBranch?.rootSessionId).toBe(rootId)
+  } finally {
+    setClaudeConfigHomeDirForTesting(undefined)
+    getClaudeConfigHomeDir.cache?.clear?.()
+  }
+})
+
+test('loadSameRepoMessageLogsProgressive ignores branch metadata outside lite read windows', async () => {
+  const configDir = await mkdtemp(
+    join(tmpdir(), 'openclaude-session-storage-config-'),
+  )
+  tempDirs.push(configDir)
+  const worktreesRoot = await mkdtemp(
+    join(tmpdir(), 'openclaude-session-storage-worktrees-'),
+  )
+  tempDirs.push(worktreesRoot)
+  const rootProject = join(worktreesRoot, 'main')
+  const branchProject = join(worktreesRoot, 'worktree-feature')
+  const rootId = id(81)
+  const branchId = id(82)
+  const branchMetadata: SessionBranchEntry = {
+    type: 'session-branch',
+    sessionId: branchId,
+    parentSessionId: rootId,
+    rootSessionId: rootId,
+    branchedFromSessionId: rootId,
+    branchName: 'Hidden branch metadata',
+    branchedAt: ts,
+  }
+
+  try {
+    setClaudeConfigHomeDirForTesting(configDir)
+    getClaudeConfigHomeDir.cache?.clear?.()
+    const rootProjectDir = getProjectDir(rootProject)
+    const branchProjectDir = getProjectDir(branchProject)
+    await mkdir(rootProjectDir, { recursive: true })
+    await mkdir(branchProjectDir, { recursive: true })
+    await writeFile(
+      join(rootProjectDir, `${rootId}.jsonl`),
+      `${JSON.stringify({
+        ...user(id(83), null, 'root prompt'),
+        sessionId: rootId,
+        cwd: rootProject,
+      })}\n`,
+    )
+    const largeText = 'x'.repeat(70 * 1024)
+    await writeFile(
+      join(branchProjectDir, `${branchId}.jsonl`),
+      `${JSON.stringify({
+        ...user(id(84), null, 'branch prompt'),
+        sessionId: branchId,
+        cwd: branchProject,
+      })}\n${JSON.stringify({
+        ...user(id(85), id(84), largeText),
+        sessionId: branchId,
+        cwd: branchProject,
+      })}\n${JSON.stringify(branchMetadata)}\n${JSON.stringify({
+        ...assistant(id(86), id(85), largeText),
+        sessionId: branchId,
+        cwd: branchProject,
+      })}\n`,
+    )
+    const result = await loadSameRepoMessageLogsProgressive(
+      [rootProject, branchProject],
+      undefined,
+      10,
+    )
+
+    const branchLog = result.logs.find(log => log.sessionId === branchId)
+    expect(branchLog?.sessionBranch).toBeUndefined()
   } finally {
     setClaudeConfigHomeDirForTesting(undefined)
     getClaudeConfigHomeDir.cache?.clear?.()

--- a/src/utils/sessionStorage.test.ts
+++ b/src/utils/sessionStorage.test.ts
@@ -13,6 +13,7 @@ import {
 import {
   adoptResumedSessionFile,
   buildConversationChain,
+  getProjectDir,
   loadSameRepoMessageLogsProgressive,
   loadTranscriptFile,
   recordGoalState,
@@ -34,8 +35,10 @@ import {
 } from '../bootstrap/state.js'
 import type { GoalState } from '../services/goal/types.js'
 import type { SessionBranchEntry } from '../types/logs.js'
-import { setClaudeConfigHomeDirForTesting } from './envUtils.js'
-import { sanitizePath } from './path.js'
+import {
+  getClaudeConfigHomeDir,
+  setClaudeConfigHomeDirForTesting,
+} from './envUtils.js'
 import { resetSettingsCache } from './settings/settingsCache.js'
 
 const tempDirs: string[] = []
@@ -677,45 +680,46 @@ test('loadSameRepoMessageLogsProgressive preserves branch metadata across worktr
     join(tmpdir(), 'openclaude-session-storage-config-'),
   )
   tempDirs.push(configDir)
-  const rootProject = '/repo/main'
-  const branchProject = '/repo/worktree-feature'
+  const worktreesRoot = await mkdtemp(
+    join(tmpdir(), 'openclaude-session-storage-worktrees-'),
+  )
+  tempDirs.push(worktreesRoot)
+  const rootProject = join(worktreesRoot, 'main')
+  const branchProject = join(worktreesRoot, 'worktree-feature')
   const rootId = id(61)
   const branchId = id(62)
-  const rootProjectDir = join(configDir, 'projects', sanitizePath(rootProject))
-  const branchProjectDir = join(
-    configDir,
-    'projects',
-    sanitizePath(branchProject),
-  )
-  await mkdir(rootProjectDir, { recursive: true })
-  await mkdir(branchProjectDir, { recursive: true })
-  await writeFile(
-    join(rootProjectDir, `${rootId}.jsonl`),
-    `${JSON.stringify({
-      ...user(id(63), null, 'root prompt'),
-      sessionId: rootId,
-      cwd: rootProject,
-    })}\n`,
-  )
-  await writeFile(
-    join(branchProjectDir, `${branchId}.jsonl`),
-    `${JSON.stringify({
-      ...user(id(64), null, 'branch prompt'),
-      sessionId: branchId,
-      cwd: branchProject,
-    })}\n${JSON.stringify({
-      type: 'session-branch',
-      sessionId: branchId,
-      parentSessionId: rootId,
-      rootSessionId: rootId,
-      branchedFromSessionId: rootId,
-      branchName: 'Worktree branch',
-      branchedAt: ts,
-    })}\n`,
-  )
 
   try {
     setClaudeConfigHomeDirForTesting(configDir)
+    getClaudeConfigHomeDir.cache?.clear?.()
+    const rootProjectDir = getProjectDir(rootProject)
+    const branchProjectDir = getProjectDir(branchProject)
+    await mkdir(rootProjectDir, { recursive: true })
+    await mkdir(branchProjectDir, { recursive: true })
+    await writeFile(
+      join(rootProjectDir, `${rootId}.jsonl`),
+      `${JSON.stringify({
+        ...user(id(63), null, 'root prompt'),
+        sessionId: rootId,
+        cwd: rootProject,
+      })}\n`,
+    )
+    await writeFile(
+      join(branchProjectDir, `${branchId}.jsonl`),
+      `${JSON.stringify({
+        ...user(id(64), null, 'branch prompt'),
+        sessionId: branchId,
+        cwd: branchProject,
+      })}\n${JSON.stringify({
+        type: 'session-branch',
+        sessionId: branchId,
+        parentSessionId: rootId,
+        rootSessionId: rootId,
+        branchedFromSessionId: rootId,
+        branchName: 'Worktree branch',
+        branchedAt: ts,
+      })}\n`,
+    )
     const result = await loadSameRepoMessageLogsProgressive(
       [rootProject, branchProject],
       undefined,
@@ -730,6 +734,7 @@ test('loadSameRepoMessageLogsProgressive preserves branch metadata across worktr
     expect(branchLog?.sessionBranch?.rootSessionId).toBe(rootId)
   } finally {
     setClaudeConfigHomeDirForTesting(undefined)
+    getClaudeConfigHomeDir.cache?.clear?.()
   }
 })
 
@@ -738,26 +743,14 @@ test('loadSameRepoMessageLogsProgressive preserves branch metadata outside lite 
     join(tmpdir(), 'openclaude-session-storage-config-'),
   )
   tempDirs.push(configDir)
-  const rootProject = '/repo/main'
-  const branchProject = '/repo/worktree-feature'
+  const worktreesRoot = await mkdtemp(
+    join(tmpdir(), 'openclaude-session-storage-worktrees-'),
+  )
+  tempDirs.push(worktreesRoot)
+  const rootProject = join(worktreesRoot, 'main')
+  const branchProject = join(worktreesRoot, 'worktree-feature')
   const rootId = id(71)
   const branchId = id(72)
-  const rootProjectDir = join(configDir, 'projects', sanitizePath(rootProject))
-  const branchProjectDir = join(
-    configDir,
-    'projects',
-    sanitizePath(branchProject),
-  )
-  await mkdir(rootProjectDir, { recursive: true })
-  await mkdir(branchProjectDir, { recursive: true })
-  await writeFile(
-    join(rootProjectDir, `${rootId}.jsonl`),
-    `${JSON.stringify({
-      ...user(id(73), null, 'root prompt'),
-      sessionId: rootId,
-      cwd: rootProject,
-    })}\n`,
-  )
   const branchMetadata: SessionBranchEntry = {
     type: 'session-branch',
     sessionId: branchId,
@@ -767,26 +760,39 @@ test('loadSameRepoMessageLogsProgressive preserves branch metadata outside lite 
     branchName: 'Long-lived branch',
     branchedAt: ts,
   }
-  const largeText = 'x'.repeat(70 * 1024)
-  await writeFile(
-    join(branchProjectDir, `${branchId}.jsonl`),
-    `${JSON.stringify({
-      ...user(id(74), null, 'branch prompt'),
-      sessionId: branchId,
-      cwd: branchProject,
-    })}\n${JSON.stringify({
-      ...user(id(75), id(74), largeText),
-      sessionId: branchId,
-      cwd: branchProject,
-    })}\n${JSON.stringify(branchMetadata)}\n${JSON.stringify({
-      ...assistant(id(76), id(75), largeText),
-      sessionId: branchId,
-      cwd: branchProject,
-    })}\n`,
-  )
 
   try {
     setClaudeConfigHomeDirForTesting(configDir)
+    getClaudeConfigHomeDir.cache?.clear?.()
+    const rootProjectDir = getProjectDir(rootProject)
+    const branchProjectDir = getProjectDir(branchProject)
+    await mkdir(rootProjectDir, { recursive: true })
+    await mkdir(branchProjectDir, { recursive: true })
+    await writeFile(
+      join(rootProjectDir, `${rootId}.jsonl`),
+      `${JSON.stringify({
+        ...user(id(73), null, 'root prompt'),
+        sessionId: rootId,
+        cwd: rootProject,
+      })}\n`,
+    )
+    const largeText = 'x'.repeat(70 * 1024)
+    await writeFile(
+      join(branchProjectDir, `${branchId}.jsonl`),
+      `${JSON.stringify({
+        ...user(id(74), null, 'branch prompt'),
+        sessionId: branchId,
+        cwd: branchProject,
+      })}\n${JSON.stringify({
+        ...user(id(75), id(74), largeText),
+        sessionId: branchId,
+        cwd: branchProject,
+      })}\n${JSON.stringify(branchMetadata)}\n${JSON.stringify({
+        ...assistant(id(76), id(75), largeText),
+        sessionId: branchId,
+        cwd: branchProject,
+      })}\n`,
+    )
     const result = await loadSameRepoMessageLogsProgressive(
       [rootProject, branchProject],
       undefined,
@@ -798,5 +804,6 @@ test('loadSameRepoMessageLogsProgressive preserves branch metadata outside lite 
     expect(branchLog?.sessionBranch?.rootSessionId).toBe(rootId)
   } finally {
     setClaudeConfigHomeDirForTesting(undefined)
+    getClaudeConfigHomeDir.cache?.clear?.()
   }
 })

--- a/src/utils/sessionStorage.test.ts
+++ b/src/utils/sessionStorage.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, expect, test } from 'bun:test'
 import type { ToolResultBlockParam } from '@anthropic-ai/sdk/resources/index.mjs'
 import { type UUID } from 'node:crypto'
-import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
@@ -13,6 +13,7 @@ import {
 import {
   adoptResumedSessionFile,
   buildConversationChain,
+  loadSameRepoMessageLogsProgressive,
   loadTranscriptFile,
   recordGoalState,
   recordTranscript,
@@ -32,7 +33,9 @@ import {
   switchSession,
 } from '../bootstrap/state.js'
 import type { GoalState } from '../services/goal/types.js'
+import type { SessionBranchEntry } from '../types/logs.js'
 import { setClaudeConfigHomeDirForTesting } from './envUtils.js'
+import { sanitizePath } from './path.js'
 import { resetSettingsCache } from './settings/settingsCache.js'
 
 const tempDirs: string[] = []
@@ -170,6 +173,14 @@ function readGoalStateEntries(text: string): Array<{ goal: GoalState | null }> {
       (entry): entry is { goal: GoalState | null } =>
         entry.type === 'goal-state',
     )
+}
+
+function readSessionBranchEntries(text: string): SessionBranchEntry[] {
+  return text
+    .split('\n')
+    .filter(Boolean)
+    .map(line => JSON.parse(line) as SessionBranchEntry)
+    .filter(entry => entry.type === 'session-branch')
 }
 
 async function withSessionPersistence<T>(fn: () => Promise<T>): Promise<T> {
@@ -600,6 +611,37 @@ test('restoreSessionMetadata re-appends the resumed active goal instead of stale
   })
 })
 
+test('restoreSessionMetadata clears cached branch when resumed transcript has no branch metadata', async () => {
+  await withSessionPersistence(async () => {
+    const staleBranch: SessionBranchEntry = {
+      type: 'session-branch',
+      sessionId: sessionId as UUID,
+      parentSessionId: id(54),
+      rootSessionId: id(54),
+      branchedFromSessionId: id(54),
+      branchName: 'stale branch',
+      branchedAt: ts,
+    }
+    restoreSessionMetadata({ sessionBranch: staleBranch })
+
+    const dir = await mkdtemp(join(tmpdir(), 'openclaude-session-storage-'))
+    tempDirs.push(dir)
+    const filePath = join(dir, `${sessionId}.jsonl`)
+    await writeFile(
+      filePath,
+      `${JSON.stringify(user(id(55), null, 'resume non-branch'))}\n`,
+    )
+
+    switchSession(sessionId as never, dir)
+    await resetSessionFilePointer()
+    restoreSessionMetadata({})
+    adoptResumedSessionFile()
+
+    const text = await readFile(filePath, 'utf8')
+    expect(readSessionBranchEntries(text)).toEqual([])
+  })
+})
+
 test('recordGoalState writes goal metadata durably before resolving', async () => {
   await withSessionPersistence(async () => {
     const dir = await mkdtemp(join(tmpdir(), 'openclaude-session-storage-'))
@@ -628,4 +670,133 @@ test('recordGoalState writes goal metadata durably before resolving', async () =
     expect(text).toContain('"type":"goal-state"')
     expect(text).toContain('durable goal')
   })
+})
+
+test('loadSameRepoMessageLogsProgressive preserves branch metadata across worktrees', async () => {
+  const configDir = await mkdtemp(
+    join(tmpdir(), 'openclaude-session-storage-config-'),
+  )
+  tempDirs.push(configDir)
+  const rootProject = '/repo/main'
+  const branchProject = '/repo/worktree-feature'
+  const rootId = id(61)
+  const branchId = id(62)
+  const rootProjectDir = join(configDir, 'projects', sanitizePath(rootProject))
+  const branchProjectDir = join(
+    configDir,
+    'projects',
+    sanitizePath(branchProject),
+  )
+  await mkdir(rootProjectDir, { recursive: true })
+  await mkdir(branchProjectDir, { recursive: true })
+  await writeFile(
+    join(rootProjectDir, `${rootId}.jsonl`),
+    `${JSON.stringify({
+      ...user(id(63), null, 'root prompt'),
+      sessionId: rootId,
+      cwd: rootProject,
+    })}\n`,
+  )
+  await writeFile(
+    join(branchProjectDir, `${branchId}.jsonl`),
+    `${JSON.stringify({
+      ...user(id(64), null, 'branch prompt'),
+      sessionId: branchId,
+      cwd: branchProject,
+    })}\n${JSON.stringify({
+      type: 'session-branch',
+      sessionId: branchId,
+      parentSessionId: rootId,
+      rootSessionId: rootId,
+      branchedFromSessionId: rootId,
+      branchName: 'Worktree branch',
+      branchedAt: ts,
+    })}\n`,
+  )
+
+  try {
+    setClaudeConfigHomeDirForTesting(configDir)
+    const result = await loadSameRepoMessageLogsProgressive(
+      [rootProject, branchProject],
+      undefined,
+      10,
+    )
+
+    const branchLog = result.logs.find(log => log.sessionId === branchId)
+    expect(new Set(result.logs.map(log => log.projectPath))).toEqual(
+      new Set([branchProject, rootProject]),
+    )
+    expect(branchLog?.sessionBranch?.branchName).toBe('Worktree branch')
+    expect(branchLog?.sessionBranch?.rootSessionId).toBe(rootId)
+  } finally {
+    setClaudeConfigHomeDirForTesting(undefined)
+  }
+})
+
+test('loadSameRepoMessageLogsProgressive preserves branch metadata outside lite read windows', async () => {
+  const configDir = await mkdtemp(
+    join(tmpdir(), 'openclaude-session-storage-config-'),
+  )
+  tempDirs.push(configDir)
+  const rootProject = '/repo/main'
+  const branchProject = '/repo/worktree-feature'
+  const rootId = id(71)
+  const branchId = id(72)
+  const rootProjectDir = join(configDir, 'projects', sanitizePath(rootProject))
+  const branchProjectDir = join(
+    configDir,
+    'projects',
+    sanitizePath(branchProject),
+  )
+  await mkdir(rootProjectDir, { recursive: true })
+  await mkdir(branchProjectDir, { recursive: true })
+  await writeFile(
+    join(rootProjectDir, `${rootId}.jsonl`),
+    `${JSON.stringify({
+      ...user(id(73), null, 'root prompt'),
+      sessionId: rootId,
+      cwd: rootProject,
+    })}\n`,
+  )
+  const branchMetadata: SessionBranchEntry = {
+    type: 'session-branch',
+    sessionId: branchId,
+    parentSessionId: rootId,
+    rootSessionId: rootId,
+    branchedFromSessionId: rootId,
+    branchName: 'Long-lived branch',
+    branchedAt: ts,
+  }
+  const largeText = 'x'.repeat(70 * 1024)
+  await writeFile(
+    join(branchProjectDir, `${branchId}.jsonl`),
+    `${JSON.stringify({
+      ...user(id(74), null, 'branch prompt'),
+      sessionId: branchId,
+      cwd: branchProject,
+    })}\n${JSON.stringify({
+      ...user(id(75), id(74), largeText),
+      sessionId: branchId,
+      cwd: branchProject,
+    })}\n${JSON.stringify(branchMetadata)}\n${JSON.stringify({
+      ...assistant(id(76), id(75), largeText),
+      sessionId: branchId,
+      cwd: branchProject,
+    })}\n`,
+  )
+
+  try {
+    setClaudeConfigHomeDirForTesting(configDir)
+    const result = await loadSameRepoMessageLogsProgressive(
+      [rootProject, branchProject],
+      undefined,
+      10,
+    )
+
+    const branchLog = result.logs.find(log => log.sessionId === branchId)
+    expect(branchLog?.sessionBranch?.branchName).toBe('Long-lived branch')
+    expect(branchLog?.sessionBranch?.rootSessionId).toBe(rootId)
+  } finally {
+    setClaudeConfigHomeDirForTesting(undefined)
+  }
 })

--- a/src/utils/sessionStorage.ts
+++ b/src/utils/sessionStorage.ts
@@ -4,7 +4,7 @@ import type { Dirent } from 'fs'
 // Sync fs primitives for readFileTailSync — separate from fs/promises
 // imports above. Named (not wildcard) per CLAUDE.md style; no collisions
 // with the async-suffixed names.
-import { closeSync, createReadStream, fstatSync, openSync, readSync } from 'fs'
+import { closeSync, fstatSync, openSync, readSync } from 'fs'
 import {
   appendFile as fsAppendFile,
   open as fsOpen,
@@ -5004,7 +5004,6 @@ type LiteMetadata = {
 
 const SESSION_BRANCH_ENTRY_PREFIX = '{"type":"session-branch"'
 const SESSION_BRANCH_ENTRY_PREFIX_SPACED = '{"type": "session-branch"'
-const SESSION_BRANCH_SCAN_CACHE = new Map<string, SessionBranchEntry | null>()
 
 function startsWithSessionBranchEntryPrefix(lineStart: string): boolean {
   return (
@@ -5073,70 +5072,6 @@ function extractSessionBranchMetadata(
       ? undefined
       : extractSessionBranchMetadataFromChunk(head, sessionId))
   )
-}
-
-function couldBeSessionBranchLinePrefix(lineStart: string): boolean {
-  return (
-    SESSION_BRANCH_ENTRY_PREFIX.startsWith(lineStart) ||
-    SESSION_BRANCH_ENTRY_PREFIX_SPACED.startsWith(lineStart) ||
-    startsWithSessionBranchEntryPrefix(lineStart)
-  )
-}
-
-async function scanSessionBranchMetadata(
-  filePath: string,
-  fileSize: number,
-  sessionId?: string,
-): Promise<SessionBranchEntry | undefined> {
-  if (!sessionId) return undefined
-
-  const cacheKey = `${filePath}:${fileSize}:${sessionId}`
-  if (SESSION_BRANCH_SCAN_CACHE.has(cacheKey)) {
-    return SESSION_BRANCH_SCAN_CACHE.get(cacheKey) ?? undefined
-  }
-
-  let carry = ''
-  let skippingLine = false
-  try {
-    for await (const chunk of createReadStream(filePath, {
-      encoding: 'utf8',
-    })) {
-      let text = typeof chunk === 'string' ? chunk : chunk.toString('utf8')
-      if (skippingLine) {
-        const newlineIdx = text.indexOf('\n')
-        if (newlineIdx === -1) continue
-        text = text.slice(newlineIdx + 1)
-        skippingLine = false
-      }
-
-      const lines = (carry + text).split('\n')
-      carry = lines.pop() ?? ''
-      for (const line of lines) {
-        const entry = parseSessionBranchMetadataLine(line, sessionId)
-        if (entry) {
-          SESSION_BRANCH_SCAN_CACHE.set(cacheKey, entry)
-          return entry
-        }
-      }
-
-      if (
-        carry.length >= METADATA_PREFIX_BOUND &&
-        !couldBeSessionBranchLinePrefix(carry)
-      ) {
-        carry = ''
-        skippingLine = true
-      }
-    }
-
-    const entry = skippingLine
-      ? undefined
-      : parseSessionBranchMetadataLine(carry, sessionId)
-    SESSION_BRANCH_SCAN_CACHE.set(cacheKey, entry ?? null)
-    return entry
-  } catch {
-    SESSION_BRANCH_SCAN_CACHE.set(cacheKey, null)
-    return undefined
-  }
 }
 
 /**
@@ -5348,9 +5283,7 @@ async function readLiteMetadata(
       if (num > 0) prNumber = num
     }
   }
-  const sessionBranch =
-    extractSessionBranchMetadata(head, tail, sessionId) ??
-    (await scanSessionBranchMetadata(filePath, fileSize, sessionId))
+  const sessionBranch = extractSessionBranchMetadata(head, tail, sessionId)
 
   return {
     firstPrompt,

--- a/src/utils/sessionStorage.ts
+++ b/src/utils/sessionStorage.ts
@@ -4,7 +4,7 @@ import type { Dirent } from 'fs'
 // Sync fs primitives for readFileTailSync — separate from fs/promises
 // imports above. Named (not wildcard) per CLAUDE.md style; no collisions
 // with the async-suffixed names.
-import { closeSync, fstatSync, openSync, readSync } from 'fs'
+import { closeSync, createReadStream, fstatSync, openSync, readSync } from 'fs'
 import {
   appendFile as fsAppendFile,
   open as fsOpen,
@@ -571,6 +571,7 @@ class Project {
   currentSessionPrUrl: string | undefined
   currentSessionPrRepository: string | undefined
   currentSessionGoal: GoalStateEntry['goal'] | undefined
+  currentSessionBranch: SessionBranchEntry | undefined
 
   sessionFile: string | null = null
   // Entries buffered while sessionFile is null. Flushed by materializeSessionFile
@@ -871,6 +872,12 @@ class Project {
         type: 'goal-state',
         sessionId,
         goal: this.currentSessionGoal,
+      })
+    }
+    if (this.currentSessionBranch) {
+      appendEntryToFile(this.sessionFile, {
+        ...this.currentSessionBranch,
+        sessionId,
       })
     }
   }
@@ -3126,6 +3133,7 @@ export function restoreSessionMetadata(meta: {
   prUrl?: string
   prRepository?: string
   goal?: GoalStateEntry['goal']
+  sessionBranch?: SessionBranchEntry
 }): void {
   const project = getProject()
   // ??= so --name (cacheSessionTitle) wins over the resumed
@@ -3146,6 +3154,9 @@ export function restoreSessionMetadata(meta: {
   // resumed session has no goal. Clear any cached goal so adopt/re-append
   // cannot persist a previous session's active goal into this transcript.
   project.currentSessionGoal = meta.goal ?? undefined
+  // Branch lineage is structural metadata. Absence means this session is not
+  // a branch, so clear stale branch cache before it can be re-appended.
+  project.currentSessionBranch = meta.sessionBranch ?? undefined
 }
 
 /**
@@ -3167,6 +3178,7 @@ export function clearSessionMetadata(): void {
   project.currentSessionPrUrl = undefined
   project.currentSessionPrRepository = undefined
   project.currentSessionGoal = undefined
+  project.currentSessionBranch = undefined
 }
 
 /**
@@ -4987,6 +4999,144 @@ type LiteMetadata = {
   prNumber?: number
   prUrl?: string
   prRepository?: string
+  sessionBranch?: SessionBranchEntry
+}
+
+const SESSION_BRANCH_ENTRY_PREFIX = '{"type":"session-branch"'
+const SESSION_BRANCH_ENTRY_PREFIX_SPACED = '{"type": "session-branch"'
+const SESSION_BRANCH_SCAN_CACHE = new Map<string, SessionBranchEntry | null>()
+
+function startsWithSessionBranchEntryPrefix(lineStart: string): boolean {
+  return (
+    lineStart.startsWith(SESSION_BRANCH_ENTRY_PREFIX) ||
+    lineStart.startsWith(SESSION_BRANCH_ENTRY_PREFIX_SPACED)
+  )
+}
+
+function isSessionBranchEntry(
+  entry: unknown,
+  sessionId?: string,
+): entry is SessionBranchEntry {
+  if (typeof entry !== 'object' || entry === null) return false
+  const candidate = entry as Partial<SessionBranchEntry>
+  return (
+    candidate.type === 'session-branch' &&
+    typeof candidate.sessionId === 'string' &&
+    (sessionId === undefined || candidate.sessionId === sessionId) &&
+    typeof candidate.parentSessionId === 'string' &&
+    typeof candidate.rootSessionId === 'string' &&
+    typeof candidate.branchedFromSessionId === 'string' &&
+    typeof candidate.branchedAt === 'string' &&
+    (candidate.branchName === undefined ||
+      typeof candidate.branchName === 'string') &&
+    (candidate.branchedAtMessageId === undefined ||
+      typeof candidate.branchedAtMessageId === 'string')
+  )
+}
+
+function parseSessionBranchMetadataLine(
+  line: string,
+  sessionId?: string,
+): SessionBranchEntry | undefined {
+  const trimmed = line.trim()
+  if (!startsWithSessionBranchEntryPrefix(trimmed)) {
+    return undefined
+  }
+  try {
+    const entry = jsonParse(trimmed)
+    return isSessionBranchEntry(entry, sessionId) ? entry : undefined
+  } catch {
+    return undefined
+  }
+}
+
+function extractSessionBranchMetadataFromChunk(
+  chunk: string,
+  sessionId?: string,
+): SessionBranchEntry | undefined {
+  const lines = chunk.split('\n')
+  for (let i = lines.length - 1; i >= 0; i--) {
+    const entry = parseSessionBranchMetadataLine(lines[i] ?? '', sessionId)
+    if (entry) return entry
+  }
+  return undefined
+}
+
+function extractSessionBranchMetadata(
+  head: string,
+  tail: string,
+  sessionId?: string,
+): SessionBranchEntry | undefined {
+  return (
+    extractSessionBranchMetadataFromChunk(tail, sessionId) ??
+    (head === tail
+      ? undefined
+      : extractSessionBranchMetadataFromChunk(head, sessionId))
+  )
+}
+
+function couldBeSessionBranchLinePrefix(lineStart: string): boolean {
+  return (
+    SESSION_BRANCH_ENTRY_PREFIX.startsWith(lineStart) ||
+    SESSION_BRANCH_ENTRY_PREFIX_SPACED.startsWith(lineStart) ||
+    startsWithSessionBranchEntryPrefix(lineStart)
+  )
+}
+
+async function scanSessionBranchMetadata(
+  filePath: string,
+  fileSize: number,
+  sessionId?: string,
+): Promise<SessionBranchEntry | undefined> {
+  if (!sessionId) return undefined
+
+  const cacheKey = `${filePath}:${fileSize}:${sessionId}`
+  if (SESSION_BRANCH_SCAN_CACHE.has(cacheKey)) {
+    return SESSION_BRANCH_SCAN_CACHE.get(cacheKey) ?? undefined
+  }
+
+  let carry = ''
+  let skippingLine = false
+  try {
+    for await (const chunk of createReadStream(filePath, {
+      encoding: 'utf8',
+    })) {
+      let text = typeof chunk === 'string' ? chunk : chunk.toString('utf8')
+      if (skippingLine) {
+        const newlineIdx = text.indexOf('\n')
+        if (newlineIdx === -1) continue
+        text = text.slice(newlineIdx + 1)
+        skippingLine = false
+      }
+
+      const lines = (carry + text).split('\n')
+      carry = lines.pop() ?? ''
+      for (const line of lines) {
+        const entry = parseSessionBranchMetadataLine(line, sessionId)
+        if (entry) {
+          SESSION_BRANCH_SCAN_CACHE.set(cacheKey, entry)
+          return entry
+        }
+      }
+
+      if (
+        carry.length >= METADATA_PREFIX_BOUND &&
+        !couldBeSessionBranchLinePrefix(carry)
+      ) {
+        carry = ''
+        skippingLine = true
+      }
+    }
+
+    const entry = skippingLine
+      ? undefined
+      : parseSessionBranchMetadataLine(carry, sessionId)
+    SESSION_BRANCH_SCAN_CACHE.set(cacheKey, entry ?? null)
+    return entry
+  } catch {
+    SESSION_BRANCH_SCAN_CACHE.set(cacheKey, null)
+    return undefined
+  }
 }
 
 /**
@@ -5142,6 +5292,7 @@ async function readLiteMetadata(
   filePath: string,
   fileSize: number,
   buf: Buffer,
+  sessionId?: string,
 ): Promise<LiteMetadata> {
   const { head, tail } = await readHeadAndTail(filePath, fileSize, buf)
   if (!head) return { firstPrompt: '', isSidechain: false }
@@ -5197,6 +5348,9 @@ async function readLiteMetadata(
       if (num > 0) prNumber = num
     }
   }
+  const sessionBranch =
+    extractSessionBranchMetadata(head, tail, sessionId) ??
+    (await scanSessionBranchMetadata(filePath, fileSize, sessionId))
 
   return {
     firstPrompt,
@@ -5211,6 +5365,7 @@ async function readLiteMetadata(
     prNumber,
     prUrl,
     prRepository,
+    sessionBranch,
   }
 }
 
@@ -5428,7 +5583,12 @@ async function enrichLog(
 ): Promise<LogOption | null> {
   if (!log.isLite || !log.fullPath) return log
 
-  const meta = await readLiteMetadata(log.fullPath, log.fileSize ?? 0, readBuf)
+  const meta = await readLiteMetadata(
+    log.fullPath,
+    log.fileSize ?? 0,
+    readBuf,
+    log.sessionId,
+  )
 
   const enriched: LogOption = {
     ...log,
@@ -5444,6 +5604,7 @@ async function enrichLog(
     prNumber: meta.prNumber,
     prUrl: meta.prUrl,
     prRepository: meta.prRepository,
+    sessionBranch: meta.sessionBranch,
     projectPath: meta.projectPath ?? log.projectPath,
   }
 


### PR DESCRIPTION
## Summary

- group branch sessions under a visible root or direct parent in the resume picker
- surface branch names in resume display/search while leaving old sessions and detached branches discoverable
- preserve branch metadata in lite session scans, resumed transcripts, and cross-worktree progressive loading

## Impact

- user-facing impact: branches can be found and resumed from the picker without guessing session ids
- developer/maintainer impact: branch grouping stays metadata-driven and keeps PR/sidechain filtering in a shared helper

## Testing

- [x] `bun run build`
- [x] `bun run smoke`
- [x] `bun run typecheck`
- [x] `bun test --feature=UNATTENDED_RETRY --max-concurrency=1 src/components/LogSelector.resumeBranches.test.ts src/screens/ResumeConversation.test.ts src/utils/sessionStorage.test.ts`
- [x] `git diff --check`
- [x] hosted PR checks: `smoke-and-tests`, `typecheck`, `web`

## Notes

- provider/model path tested: not applicable
- screenshots attached (if UI changed): no
- follow-up work or known limitations: branches whose root or parent transcript is missing remain standalone instead of hidden


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Resume mode now groups and searches conversations by resume branch, with branch-aware titles and picker search.
  * Added resume PR filters supporting PR number and PR URL matching.
  * Persist and restore `session-branch` metadata in cached transcripts to improve resume accuracy.
* **Bug Fixes**
  * Fixed resume picker pagination and expand/collapse/select behavior for branch groups.
  * Improved resume recovery to retain branch metadata only when valid for the current transcript window.
  * Forked sessions now write `session-branch` metadata before copied transcript entries.
* **Tests**
  * Added/expanded coverage for resume filtering, resume-tree grouping, pagination logic, and Ink-based selection flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->