### PR TITLE
feat(report): render task reports as markdown

### DIFF
--- a/docs/advanced-setup.md
+++ b/docs/advanced-setup.md
@@ -425,8 +425,11 @@ openclaude doctor report --markdown
 # write a redacted JSON issue report for attachment
 openclaude doctor report --json --out openclaude-report.json
 
-# write a deterministic JSON task report from a session transcript
+# write a deterministic task report from a session transcript
 openclaude report --json --transcript ~/.openclaude/projects/-path-to-project/session-id.jsonl --out task-report.json
+
+# print a human-readable task report from the latest session in the current project
+openclaude report --markdown
 
 # full local hardening check (smoke + runtime doctor)
 bun run hardening:check
@@ -442,7 +445,7 @@ Notes:
 - Local providers such as `http://localhost:11434/v1`, `http://10.0.0.1:11434/v1`, and `http://127.0.0.1:1337/v1` can run without `OPENAI_API_KEY`.
 - Codex profiles validate `CODEX_API_KEY` or the Codex CLI auth file and probe `POST /responses` instead of `GET /models`.
 - `openclaude doctor report` is redacted by default and is intended for GitHub issues. It summarizes provider/runtime/build/settings state without prompts, transcripts, raw settings files, API keys, MCP command details, or full home-directory paths.
-- `openclaude report --json` summarizes observed session facts such as tool uses, Bash commands, validation commands, changed files, branch metadata, warnings, and linked issue/PR references. Use `--transcript <file>` for an explicit transcript, `--session <id>` for a stored session, or omit both to report the latest session for the current project. Large previews are truncated and credential-shaped strings are redacted. When no validation command is observed, the report keeps `validations` empty and includes a warning instead of claiming checks passed.
+- `openclaude report --json` and `openclaude report --markdown` summarize observed session facts such as tool uses, Bash commands, validation commands, changed files, branch metadata, warnings, and linked issue/PR references. Use `--transcript <file>` for an explicit transcript, `--session <id>` for a stored session, or omit both to report the latest session for the current project. Large previews are truncated and credential-shaped strings are redacted. When no validation command is observed, the report keeps `validations` empty and includes a warning instead of claiming checks passed.
 
 ## Provider Launch Profiles
 

--- a/src/cli/commands/taskReport.ts
+++ b/src/cli/commands/taskReport.ts
@@ -1,0 +1,75 @@
+import {
+  Command as CommanderCommand,
+  Option,
+} from '@commander-js/extra-typings'
+
+import type { TaskReportArgs, TaskReportFormat } from '../../utils/taskReport.js'
+
+export type TaskReportCommandOptions = {
+  json?: boolean
+  markdown?: boolean
+  transcript?: string
+  session?: string
+  out?: string
+}
+
+export type TaskReportCommandDeps = {
+  cwd?: () => string
+  exit?: (code: number) => void
+  taskReportHandler?: (options: TaskReportArgs) => Promise<void>
+  printTaskReportError?: (error: unknown) => Promise<void>
+}
+
+export function registerTaskReportCommand(
+  program: CommanderCommand,
+  deps: TaskReportCommandDeps = {},
+): void {
+  program
+    .command('report')
+    .description('Generate a deterministic task report for an OpenClaude session')
+    .addOption(new Option('--json', 'Print JSON output').conflicts('markdown'))
+    .addOption(new Option('--markdown', 'Print Markdown output').conflicts('json'))
+    .option('--transcript <file>', 'Path to a session JSONL transcript')
+    .option(
+      '--session <id>',
+      'Session ID to report (defaults to latest session in the current project)',
+    )
+    .option('--out <file>', 'Write the report to a file')
+    .action(async (options: TaskReportCommandOptions) => {
+      const exit = deps.exit ?? process.exit
+      try {
+        const format = resolveTaskReportFormat(options)
+        if (options.transcript && options.session) {
+          throw new Error(
+            'Pass either --transcript <file> or --session <id>, not both.',
+          )
+        }
+        const taskReportHandler =
+          deps.taskReportHandler ??
+          (await import('../handlers/taskReport.js')).taskReportHandler
+        await taskReportHandler({
+          format,
+          transcriptPath: options.transcript ?? null,
+          sessionId: options.session ?? null,
+          outFile: options.out ?? null,
+          cwd: (deps.cwd ?? process.cwd)(),
+        })
+        exit(0)
+      } catch (error) {
+        const printTaskReportError =
+          deps.printTaskReportError ??
+          (await import('../handlers/taskReport.js')).printTaskReportError
+        await printTaskReportError(error)
+        exit(1)
+      }
+    })
+}
+
+export function resolveTaskReportFormat(
+  options: Pick<TaskReportCommandOptions, 'json' | 'markdown'>,
+): TaskReportFormat {
+  if (options.json !== true && options.markdown !== true) {
+    throw new Error('Pass either --json or --markdown for task report output.')
+  }
+  return options.json ? 'json' : 'markdown'
+}

--- a/src/cli/handlers/taskReport.ts
+++ b/src/cli/handlers/taskReport.ts
@@ -2,7 +2,7 @@ import { resolve } from 'node:path'
 
 import {
   buildTaskReport,
-  formatTaskReportAsJson,
+  formatTaskReport,
   writeTaskReport,
   type TaskReportArgs,
 } from '../../utils/taskReport.js'
@@ -33,10 +33,6 @@ function writeLine(
 export async function taskReportHandler(
   options: TaskReportArgs,
 ): Promise<void> {
-  if (options.format !== 'json') {
-    throw new Error('Task reports currently support JSON output only')
-  }
-
   const cwd = resolve(options.cwd ?? process.cwd())
   const transcriptPath = await resolveTranscriptPath({
     cwd,
@@ -47,7 +43,7 @@ export async function taskReportHandler(
     transcriptPath,
     cwd,
   })
-  const content = formatTaskReportAsJson(report)
+  const content = formatTaskReport(report, options.format)
 
   if (options.outFile) {
     const outputPath = await writeTaskReport(options.outFile, content)

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -45,6 +45,7 @@ import { isPolicyAllowed, loadPolicyLimits, refreshPolicyLimits, waitForPolicyLi
 import { loadRemoteManagedSettings, refreshRemoteManagedSettings } from './services/remoteManagedSettings/index.js';
 import type { ToolInputJSONSchema } from './Tool.js';
 import { createSyntheticOutputTool, isSyntheticOutputToolEnabled } from './tools/SyntheticOutputTool/SyntheticOutputTool.js';
+import { registerTaskReportCommand } from './cli/commands/taskReport.js';
 import { getTools } from './tools.js';
 import { canUserConfigureAdvisor, getInitialAdvisorSetting, isAdvisorEnabled, isValidAdvisorModel, modelSupportsAdvisor } from './utils/advisor.js';
 import { isAgentSwarmsEnabled } from './utils/agentSwarmsEnabled.js';
@@ -4215,52 +4216,7 @@ async function run(): Promise<CommanderCommand> {
     });
   }
 
-  program
-    .command('report')
-    .description(
-      'Generate a deterministic JSON task report for an OpenClaude session',
-    )
-    .option('--json', 'Print JSON output')
-    .option('--transcript <file>', 'Path to a session JSONL transcript')
-    .option(
-      '--session <id>',
-      'Session ID to report (defaults to latest session in the current project)',
-    )
-    .option('--out <file>', 'Write the report to a file')
-    .action(async (options: {
-      json?: boolean;
-      transcript?: string;
-      session?: string;
-      out?: string;
-    }) => {
-      const {
-        taskReportHandler,
-        printTaskReportError,
-      } = await import('./cli/handlers/taskReport.js');
-      try {
-        if (options.json !== true) {
-          throw new Error(
-            'Task reports currently support JSON output only. Pass --json.',
-          );
-        }
-        if (options.transcript && options.session) {
-          throw new Error(
-            'Pass either --transcript <file> or --session <id>, not both.',
-          );
-        }
-        await taskReportHandler({
-          format: 'json',
-          transcriptPath: options.transcript ?? null,
-          sessionId: options.session ?? null,
-          outFile: options.out ?? null,
-          cwd: process.cwd(),
-        });
-        process.exit(0);
-      } catch (error) {
-        await printTaskReportError(error);
-        process.exit(1);
-      }
-    });
+  registerTaskReportCommand(program);
 
   // Doctor command - check installation health
   const doctorCommand = program

--- a/src/utils/reportTask.test.ts
+++ b/src/utils/reportTask.test.ts
@@ -1,11 +1,17 @@
 import { describe, expect, test } from 'bun:test'
-import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import { homedir, tmpdir } from 'node:os'
-import { join } from 'node:path'
+import { dirname, join, posix } from 'node:path'
 
+import { Command as CommanderCommand } from '@commander-js/extra-typings'
+
+import { registerTaskReportCommand } from '../cli/commands/taskReport.js'
+import { taskReportHandler } from '../cli/handlers/taskReport.js'
 import {
   buildTaskReport,
   collectTaskReportGitMetadata,
+  formatTaskReport,
+  formatTaskReportAsMarkdown,
   formatTaskReportAsJson,
   type TaskReportGitMetadata,
 } from './taskReport.js'
@@ -31,13 +37,45 @@ function withTempTranscript(
   })
 }
 
-function userMessage(uuid: string, content: unknown, timestamp: string) {
+async function captureStreamWrites(
+  stream: NodeJS.WritableStream,
+  fn: () => Promise<void>,
+): Promise<string> {
+  const originalWrite = stream.write
+  let output = ''
+  ;(stream as { write: (...args: unknown[]) => boolean }).write = (
+    chunk: unknown,
+    ...args: unknown[]
+  ) => {
+    output += String(chunk)
+    const callback = args.find((arg): arg is (error?: Error) => void =>
+      typeof arg === 'function',
+    )
+    callback?.()
+    return true
+  }
+
+  try {
+    await fn()
+  } finally {
+    stream.write = originalWrite
+  }
+
+  return output
+}
+
+function userMessage(
+  uuid: string,
+  content: unknown,
+  timestamp: string,
+  messageCwd: string | null = cwd,
+) {
   return {
     type: 'user',
     uuid,
     parentUuid: null,
     isSidechain: false,
-    cwd,
+    ...(messageCwd ? { cwd: messageCwd } : {}),
     sessionId,
     timestamp,
     version: 'test',
@@ -1249,6 +1287,801 @@ describe('task report generation', () => {
         expect(report.commands[0]?.stdout?.truncated).toBe(true)
       },
     )
+  })
+
+  test('formats markdown with required sections and no-validation warning', async () => {
+    await withTempTranscript(
+      [
+        userMessage(
+          '00000000-0000-4000-8000-000000000096',
+          'Generate a task report for issue #123.',
+          '2026-06-27T08:00:00.000Z',
+        ),
+      ],
+      async transcriptPath => {
+        const report = await buildTaskReport({
+          transcriptPath,
+          git: async () => gitMetadata({ dirty: false, changedFiles: [] }),
+        })
+        const markdown = formatTaskReportAsMarkdown(report)
+
+        for (const heading of [
+          '# Task Report',
+          '## Summary',
+          '## Session',
+          '## Branching / Worktree',
+          '## Changes',
+          '## Files changed',
+          '## Commands run',
+          '## Validation',
+          '## Errors / Warnings',
+          '## Risks / Follow-ups',
+        ]) {
+          expect(markdown).toContain(heading)
+        }
+        expect(markdown).toContain('- Validation: none observed')
+        expect(markdown).toContain(
+          '- Initial request:\n  ```text\n  Generate a task report for issue #123.\n  ```',
+        )
+        expect(markdown).toContain(
+          '- No validation commands were observed in this transcript.',
+        )
+        expect(markdown).toContain(
+          '- Not represented in task report JSON v1.',
+        )
+        expect(markdown).not.toContain('Run validation before claiming checks passed')
+      },
+    )
+  })
+
+  test('formats markdown for passing validation commands', async () => {
+    await withTempTranscript(
+      [
+        userMessage(
+          '00000000-0000-4000-8000-000000000097',
+          'Run the checks.',
+          '2026-06-27T08:00:00.000Z',
+        ),
+        assistantToolMessage(
+          '00000000-0000-4000-8000-000000000098',
+          {
+            id: 'tool-validation-markdown-pass',
+            name: 'Bash',
+            input: {
+              command: 'bun run typecheck',
+              description: 'Run TypeScript checks',
+            },
+          },
+          '2026-06-27T08:01:00.000Z',
+        ),
+        toolResultMessage(
+          '00000000-0000-4000-8000-000000000099',
+          'tool-validation-markdown-pass',
+          'Typecheck passed',
+          '2026-06-27T08:01:03.000Z',
+          { stdout: 'Typecheck passed\n', stderr: '', exitCode: 0 },
+        ),
+      ],
+      async transcriptPath => {
+        const report = await buildTaskReport({
+          transcriptPath,
+          git: async () => gitMetadata({ dirty: false, changedFiles: [] }),
+        })
+        const markdown = formatTaskReportAsMarkdown(report)
+
+        expect(markdown).toContain('- Validation: 1 passed, 0 failed, 0 unknown')
+        expect(markdown).toContain(
+          '- `success` `bun run typecheck` - Run TypeScript checks (exit 0)',
+        )
+        expect(markdown).toContain(
+          '  - stdout:\n    ```text\n    Typecheck passed\n    \n    ```',
+        )
+        expect(markdown).toContain('- Not represented in task report JSON v1.')
+      },
+    )
+  })
+
+  test('formats markdown for failing validation and tool errors', async () => {
+    await withTempTranscript(
+      [
+        userMessage(
+          '00000000-0000-4000-8000-000000000100',
+          'Run the failing test.',
+          '2026-06-27T08:00:00.000Z',
+        ),
+        assistantToolMessage(
+          '00000000-0000-4000-8000-000000000101',
+          {
+            id: 'tool-validation-markdown-fail',
+            name: 'Bash',
+            input: {
+              command: 'bun test src/utils/reportTask.test.ts',
+            },
+          },
+          '2026-06-27T08:01:00.000Z',
+        ),
+        toolResultMessage(
+          '00000000-0000-4000-8000-000000000102',
+          'tool-validation-markdown-fail',
+          'Error calling tool (Bash): tests failed\nExit code 1',
+          '2026-06-27T08:01:03.000Z',
+          {
+            stdout: '',
+            stderr: 'tests failed\n',
+            exitCode: 1,
+          },
+          true,
+        ),
+      ],
+      async transcriptPath => {
+        const report = await buildTaskReport({
+          transcriptPath,
+          git: async () => gitMetadata({ dirty: false, changedFiles: [] }),
+        })
+        const markdown = formatTaskReportAsMarkdown(report)
+
+        expect(markdown).toContain('- Validation: 0 passed, 1 failed, 0 unknown')
+        expect(markdown).toContain(
+          '- `error` `bun test src/utils/reportTask.test.ts` (exit 1)',
+        )
+        expect(markdown).toContain(
+          '- Tool error (`Bash`, `tool-validation-markdown-fail`):',
+        )
+        expect(markdown).not.toContain('Resolve failed validation')
+        expect(markdown).toContain('- Not represented in task report JSON v1.')
+      },
+    )
+  })
+
+  test('rejects unsupported task report formats', async () => {
+    await withTempTranscript(
+      [
+        userMessage(
+          '00000000-0000-4000-8000-000000000109',
+          'Generate a task report.',
+          '2026-06-27T08:00:00.000Z',
+        ),
+      ],
+      async transcriptPath => {
+        const report = await buildTaskReport({
+          transcriptPath,
+          git: false,
+        })
+
+        expect(() => formatTaskReport(report, 'html' as never)).toThrow(
+          'Unsupported task report format: html',
+        )
+      },
+    )
+  })
+
+  test('preserves trailing whitespace in markdown command output previews', async () => {
+    await withTempTranscript(
+      [
+        userMessage(
+          '00000000-0000-4000-8000-000000000110',
+          'Run a command with whitespace-sensitive output.',
+          '2026-06-27T08:00:00.000Z',
+        ),
+        assistantToolMessage(
+          '00000000-0000-4000-8000-000000000111',
+          {
+            id: 'tool-whitespace-preview',
+            name: 'Bash',
+            input: {
+              command: 'bun test src/utils/reportTask.test.ts',
+            },
+          },
+          '2026-06-27T08:01:00.000Z',
+        ),
+        toolResultMessage(
+          '00000000-0000-4000-8000-000000000112',
+          'tool-whitespace-preview',
+          'kept trailing whitespace  \n',
+          '2026-06-27T08:01:03.000Z',
+          {
+            stdout: 'kept trailing whitespace  \n',
+            stderr: '',
+            exitCode: 0,
+          },
+        ),
+      ],
+      async transcriptPath => {
+        const report = await buildTaskReport({
+          transcriptPath,
+          git: false,
+        })
+        const markdown = formatTaskReportAsMarkdown(report)
+
+        expect(markdown).toContain(
+          '  - stdout:\n    ```text\n    kept trailing whitespace  \n    \n    ```',
+        )
+      },
+    )
+  })
+
+  test('preserves repeated spaces in markdown command lines', async () => {
+    await withTempTranscript(
+      [
+        userMessage(
+          '00000000-0000-4000-8000-000000000115',
+          'Run a whitespace-sensitive command.',
+          '2026-06-27T08:00:00.000Z',
+        ),
+        assistantToolMessage(
+          '00000000-0000-4000-8000-000000000116',
+          {
+            id: 'tool-command-repeated-spaces',
+            name: 'Bash',
+            input: {
+              command: "printf 'a  b'",
+            },
+          },
+          '2026-06-27T08:01:00.000Z',
+        ),
+        toolResultMessage(
+          '00000000-0000-4000-8000-000000000117',
+          'tool-command-repeated-spaces',
+          'a  b',
+          '2026-06-27T08:01:03.000Z',
+          { stdout: 'a  b', stderr: '', exitCode: 0 },
+        ),
+      ],
+      async transcriptPath => {
+        const report = await buildTaskReport({
+          transcriptPath,
+          git: false,
+        })
+        const markdown = formatTaskReportAsMarkdown(report)
+
+        expect(markdown).toContain("- `success` `printf 'a  b'` (exit 0)")
+        expect(markdown).not.toContain("- `success` `printf 'a b'`")
+      },
+    )
+  })
+
+  test('renders backtick-delimited markdown command spans safely', async () => {
+    await withTempTranscript(
+      [
+        userMessage(
+          '00000000-0000-4000-8000-000000000127',
+          'Run a command that uses command substitution.',
+          '2026-06-27T08:00:00.000Z',
+        ),
+        assistantToolMessage(
+          '00000000-0000-4000-8000-000000000128',
+          {
+            id: 'tool-command-backticks',
+            name: 'Bash',
+            input: {
+              command: 'echo `date`',
+            },
+          },
+          '2026-06-27T08:01:00.000Z',
+        ),
+        toolResultMessage(
+          '00000000-0000-4000-8000-000000000129',
+          'tool-command-backticks',
+          'Tue Jun 30',
+          '2026-06-27T08:01:03.000Z',
+          { stdout: 'Tue Jun 30', stderr: '', exitCode: 0 },
+        ),
+      ],
+      async transcriptPath => {
+        const report = await buildTaskReport({
+          transcriptPath,
+          git: false,
+        })
+        const markdown = formatTaskReportAsMarkdown(report)
+
+        expect(markdown).toContain('- `success` `` echo `date` `` (exit 0)')
+        expect(markdown).not.toContain('- `success` ``echo `date``` (exit 0)')
+      },
+    )
+  })
+
+  test('renders multiline markdown commands as fenced shell blocks', async () => {
+    await withTempTranscript(
+      [
+        userMessage(
+          '00000000-0000-4000-8000-000000000118',
+          'Run a multiline command.',
+          '2026-06-27T08:00:00.000Z',
+        ),
+        assistantToolMessage(
+          '00000000-0000-4000-8000-000000000119',
+          {
+            id: 'tool-command-multiline',
+            name: 'Bash',
+            input: {
+              command:
+                "printf 'a  b'\nbun test src/utils/reportTask.test.ts",
+            },
+          },
+          '2026-06-27T08:01:00.000Z',
+        ),
+        toolResultMessage(
+          '00000000-0000-4000-8000-000000000120',
+          'tool-command-multiline',
+          'tests passed',
+          '2026-06-27T08:01:03.000Z',
+          { stdout: 'tests passed', stderr: '', exitCode: 0 },
+        ),
+      ],
+      async transcriptPath => {
+        const report = await buildTaskReport({
+          transcriptPath,
+          git: false,
+        })
+        const markdown = formatTaskReportAsMarkdown(report)
+
+        expect(markdown).toContain(
+          "- `success` command (exit 0)\n  - Command:\n    ```shell\n    printf 'a  b'\n    bun test src/utils/reportTask.test.ts\n    ```",
+        )
+      },
+    )
+  })
+
+  test('escapes markdown syntax in markdown prose fields', async () => {
+    await withTempTranscript(
+      [
+        {
+          type: 'custom-title',
+          sessionId,
+          customTitle: 'Review *bold* [link](https://example.test)',
+        },
+        userMessage(
+          '00000000-0000-4000-8000-000000000121',
+          'Run a markdown-sensitive command.',
+          '2026-06-27T08:00:00.000Z',
+        ),
+        assistantToolMessage(
+          '00000000-0000-4000-8000-000000000122',
+          {
+            id: 'tool-markdown-prose',
+            name: 'Bash',
+            input: {
+              command: 'node missing.js',
+              description: 'Do *not* make [claims](x)',
+            },
+          },
+          '2026-06-27T08:01:00.000Z',
+        ),
+        toolResultMessage(
+          '00000000-0000-4000-8000-000000000123',
+          'tool-markdown-prose',
+          'Tool **failed** [details](x)',
+          '2026-06-27T08:01:03.000Z',
+          {
+            stdout: '',
+            stderr: 'Tool **failed** [details](x)',
+            exitCode: 1,
+          },
+          true,
+        ),
+      ],
+      async transcriptPath => {
+        const report = await buildTaskReport({
+          transcriptPath,
+          git: false,
+        })
+        report.warnings.push('Warning with *bold* and [link](x)')
+        const markdown = formatTaskReportAsMarkdown(report)
+
+        expect(markdown).toContain(
+          '- Session: Review \\*bold\\* \\[link\\](https://example.test)',
+        )
+        expect(markdown).toContain(
+          '- Title: Review \\*bold\\* \\[link\\](https://example.test)',
+        )
+        expect(markdown).toContain(
+          '- `error` `node missing.js` - Do \\*not\\* make \\[claims\\](x) (exit 1)',
+        )
+        expect(markdown).toContain(
+          '- Tool error (`Bash`, `tool-markdown-prose`): Tool \\*\\*failed\\*\\* \\[details\\](x)',
+        )
+        expect(markdown).toContain(
+          '- Warning with \\*bold\\* and \\[link\\](x)',
+        )
+      },
+    )
+  })
+
+  test('preserves multiline errors and warnings in markdown', async () => {
+    await withTempTranscript(
+      [
+        userMessage(
+          '00000000-0000-4000-8000-000000000124',
+          'Run a command that reports multiline diagnostics.',
+          '2026-06-27T08:00:00.000Z',
+        ),
+        assistantToolMessage(
+          '00000000-0000-4000-8000-000000000125',
+          {
+            id: 'tool-multiline-diagnostic',
+            name: 'Bash',
+            input: {
+              command: 'node missing.js',
+            },
+          },
+          '2026-06-27T08:01:00.000Z',
+        ),
+        toolResultMessage(
+          '00000000-0000-4000-8000-000000000126',
+          'tool-multiline-diagnostic',
+          'first error line\nsecond error line',
+          '2026-06-27T08:01:03.000Z',
+          {
+            stdout: '',
+            stderr: 'first error line\nsecond error line',
+            exitCode: 1,
+          },
+          true,
+        ),
+      ],
+      async transcriptPath => {
+        const report = await buildTaskReport({
+          transcriptPath,
+          git: false,
+        })
+        report.warnings.push('first warning line\nsecond warning line')
+        const markdown = formatTaskReportAsMarkdown(report)
+
+        expect(markdown).toContain(
+          '- Tool error (`Bash`, `tool-multiline-diagnostic`):\n  ```text\n  first error line\n  second error line\n  ```',
+        )
+        expect(markdown).toContain(
+          '- Warning:\n  ```text\n  first warning line\n  second warning line\n  ```',
+        )
+        expect(markdown).not.toContain('first error line second error line')
+        expect(markdown).not.toContain('first warning line second warning line')
+      },
+    )
+  })
+
+  test('formats markdown for changed files and branch metadata', async () => {
+    const reportCwd = join(tmpdir(), 'openclaude')
+    const worktreePath = join(tmpdir(), 'openclaude-report')
+    const reportFilePath = join(reportCwd, 'src', 'report.ts')
+    const reportSourcePath = posix.join('src', 'report.ts')
+    const reportTestPath = posix.join('src', 'report.test.ts')
+
+    await withTempTranscript(
+      [
+        {
+          type: 'custom-title',
+          sessionId,
+          customTitle: 'Generate deterministic task reports',
+        },
+        {
+          type: 'worktree-state',
+          sessionId,
+          worktreeSession: {
+            originalCwd: reportCwd,
+            worktreePath,
+            worktreeName: 'openclaude-report',
+            worktreeBranch: 'feat/session-task-report-json',
+            originalBranch: 'main',
+            originalHeadCommit: '13cf30af',
+            sessionId,
+          },
+        },
+        {
+          type: 'pr-link',
+          sessionId,
+          prNumber: 456,
+          prUrl: 'https://github.com/Gitlawb/openclaude/pull/456',
+          prRepository: 'Gitlawb/openclaude',
+          timestamp: '2026-06-27T08:01:00.000Z',
+        },
+        userMessage(
+          '00000000-0000-4000-8000-000000000103',
+          'Update src/report.ts for https://github.com/Gitlawb/openclaude/issues/123.',
+          '2026-06-27T08:00:00.000Z',
+          reportCwd,
+        ),
+        assistantToolMessage(
+          '00000000-0000-4000-8000-000000000104',
+          {
+            id: 'tool-edit-markdown',
+            name: 'Edit',
+            input: {
+              file_path: reportFilePath,
+              old_string: 'old',
+              new_string: 'new',
+            },
+          },
+          '2026-06-27T08:02:00.000Z',
+        ),
+        toolResultMessage(
+          '00000000-0000-4000-8000-000000000105',
+          'tool-edit-markdown',
+          'Updated src/report.ts',
+          '2026-06-27T08:02:02.000Z',
+          { filePath: reportFilePath },
+        ),
+      ],
+      async transcriptPath => {
+        const report = await buildTaskReport({
+          transcriptPath,
+          git: async () =>
+            gitMetadata({
+              cwd: reportCwd,
+              changedFiles: [reportSourcePath, reportTestPath],
+            }),
+        })
+        const markdown = formatTaskReportAsMarkdown(report)
+
+        expect(markdown).toContain(
+          '- Title: Generate deterministic task reports',
+        )
+        expect(markdown).toContain('- Transcript branch: `feat/source-branch`')
+        expect(markdown).toContain(
+          '- Worktree branch: `feat/session-task-report-json`',
+        )
+        expect(markdown).toContain(
+          '- Pull request: [#456](<https://github.com/Gitlawb/openclaude/pull/456>) (`Gitlawb/openclaude`)',
+        )
+        expect(markdown).toContain(`- \`${reportSourcePath}\` (git, tool)`)
+        expect(markdown).toContain(`- \`${reportTestPath}\` (git)`)
+        expect(markdown).toContain(
+          '- pull_request: [#456](<https://github.com/Gitlawb/openclaude/pull/456>) (`Gitlawb/openclaude`)',
+        )
+      },
+    )
+  })
+
+  test('sanitizes linked reference markdown URLs', async () => {
+    await withTempTranscript(
+      [
+        userMessage(
+          '00000000-0000-4000-8000-000000000130',
+          'Review linked references.',
+          '2026-06-27T08:00:00.000Z',
+        ),
+      ],
+      async transcriptPath => {
+        const report = await buildTaskReport({
+          transcriptPath,
+          git: false,
+        })
+        report.linkedReferences = [
+          {
+            kind: 'issue',
+            number: 321,
+            repository: 'Gitlawb/openclaude',
+            url: 'https://github.com/Gitlawb/openclaude/issues/321?label=a(b)',
+          },
+          {
+            kind: 'pull_request',
+            number: 9,
+            url: 'javascript:alert(1)',
+          },
+        ]
+
+        const markdown = formatTaskReportAsMarkdown(report)
+
+        expect(markdown).toContain(
+          '- issue: [#321](<https://github.com/Gitlawb/openclaude/issues/321?label=a(b)>) (`Gitlawb/openclaude`)',
+        )
+        expect(markdown).toContain('- pull_request: `#9`')
+        expect(markdown).not.toContain('javascript:alert')
+      },
+    )
+  })
+
+  test('formats markdown with redacted secrets and truncated command output', async () => {
+    const secret = 'sk-openclaude-test-secret'
+    const longOutput = `${secret}\n${'passed '.repeat(40)}`
+
+    await withTempTranscript(
+      [
+        userMessage(
+          '00000000-0000-4000-8000-000000000106',
+          `Check the output for ${secret}.`,
+          '2026-06-27T08:00:00.000Z',
+        ),
+        assistantToolMessage(
+          '00000000-0000-4000-8000-000000000107',
+          {
+            id: 'tool-validation-markdown-redacted',
+            name: 'Bash',
+            input: {
+              command: `TOKEN=${secret} bun test src/utils/reportTask.test.ts`,
+            },
+          },
+          '2026-06-27T08:01:00.000Z',
+        ),
+        toolResultMessage(
+          '00000000-0000-4000-8000-000000000108',
+          'tool-validation-markdown-redacted',
+          longOutput,
+          '2026-06-27T08:01:03.000Z',
+          { stdout: longOutput, stderr: '', exitCode: 0 },
+        ),
+      ],
+      async transcriptPath => {
+        const report = await buildTaskReport({
+          transcriptPath,
+          git: async () => gitMetadata({ dirty: false, changedFiles: [] }),
+          maxPreviewChars: 64,
+        })
+        const markdown = formatTaskReportAsMarkdown(report)
+
+        expect(markdown).not.toContain(secret)
+        expect(markdown).toContain('[redacted]')
+        expect(markdown).toContain('stdout (truncated, ')
+        expect(markdown).toContain('```text\n')
+      },
+    )
+  })
+
+  test('prints markdown task reports through the CLI handler', async () => {
+    await withTempTranscript(
+      [
+        userMessage(
+          '00000000-0000-4000-8000-000000000113',
+          'Generate a markdown task report.',
+          '2026-06-27T08:00:00.000Z',
+          null,
+        ),
+      ],
+      async transcriptPath => {
+        const handlerCwd = dirname(transcriptPath)
+        const stdout = await captureStreamWrites(process.stdout, async () => {
+          await taskReportHandler({
+            format: 'markdown',
+            transcriptPath,
+            sessionId: null,
+            outFile: null,
+            cwd: handlerCwd,
+          })
+        })
+
+        expect(stdout).toContain('# Task Report')
+        expect(stdout).toContain('## Validation')
+        expect(stdout).toContain('- Git status: `unavailable`')
+        expect(stdout).toContain('- No validation commands were observed.')
+      },
+    )
+  })
+
+  test('writes markdown task reports through the CLI handler', async () => {
+    await withTempTranscript(
+      [
+        userMessage(
+          '00000000-0000-4000-8000-000000000114',
+          'Write a markdown task report.',
+          '2026-06-27T08:00:00.000Z',
+          null,
+        ),
+      ],
+      async transcriptPath => {
+        const handlerCwd = dirname(transcriptPath)
+        const outFile = `${transcriptPath}.md`
+        const stderr = await captureStreamWrites(process.stderr, async () => {
+          await taskReportHandler({
+            format: 'markdown',
+            transcriptPath,
+            sessionId: null,
+            outFile,
+            cwd: handlerCwd,
+          })
+        })
+
+        expect(stderr).toBe(`Task report written to ${outFile}\n`)
+        expect(readFileSync(outFile, 'utf8')).toContain('# Task Report')
+      },
+    )
+  })
+
+  test('parses markdown report options through the CLI command', async () => {
+    const calls: Array<Parameters<typeof taskReportHandler>[0]> = []
+    const exits: number[] = []
+    const program = new CommanderCommand()
+    program.exitOverride()
+    registerTaskReportCommand(program, {
+      cwd: () => '/repo',
+      exit: code => {
+        exits.push(code)
+      },
+      taskReportHandler: async options => {
+        calls.push(options)
+      },
+      printTaskReportError: async error => {
+        throw error
+      },
+    })
+
+    await program.parseAsync(
+      ['node', 'openclaude', 'report', '--markdown', '--transcript', 'session.jsonl'],
+      { from: 'node' },
+    )
+
+    expect(calls).toEqual([
+      {
+        format: 'markdown',
+        transcriptPath: 'session.jsonl',
+        sessionId: null,
+        outFile: null,
+        cwd: '/repo',
+      },
+    ])
+    expect(exits).toEqual([0])
+  })
+
+  test('parses json report options through the CLI command', async () => {
+    const calls: Array<Parameters<typeof taskReportHandler>[0]> = []
+    const exits: number[] = []
+    const program = new CommanderCommand()
+    program.exitOverride()
+    registerTaskReportCommand(program, {
+      cwd: () => '/repo',
+      exit: code => {
+        exits.push(code)
+      },
+      taskReportHandler: async options => {
+        calls.push(options)
+      },
+      printTaskReportError: async error => {
+        throw error
+      },
+    })
+
+    await program.parseAsync(
+      ['node', 'openclaude', 'report', '--json', '--session', sessionId, '--out', 'task-report.json'],
+      { from: 'node' },
+    )
+
+    expect(calls).toEqual([
+      {
+        format: 'json',
+        transcriptPath: null,
+        sessionId,
+        outFile: 'task-report.json',
+        cwd: '/repo',
+      },
+    ])
+    expect(exits).toEqual([0])
+  })
+
+  test('rejects missing and conflicting report output flags through the CLI command', async () => {
+    const missingErrors: string[] = []
+    const missingExits: number[] = []
+    const missingProgram = new CommanderCommand()
+    missingProgram.exitOverride()
+    registerTaskReportCommand(missingProgram, {
+      exit: code => {
+        missingExits.push(code)
+      },
+      taskReportHandler: async () => {
+        throw new Error('handler should not run')
+      },
+      printTaskReportError: async error => {
+        missingErrors.push(error instanceof Error ? error.message : String(error))
+      },
+    })
+
+    await missingProgram.parseAsync(['node', 'openclaude', 'report'], {
+      from: 'node',
+    })
+
+    expect(missingErrors).toEqual([
+      'Pass either --json or --markdown for task report output.',
+    ])
+    expect(missingExits).toEqual([1])
+
+    const conflictingProgram = new CommanderCommand()
+    conflictingProgram.exitOverride()
+    conflictingProgram.configureOutput({ writeErr: () => {} })
+    registerTaskReportCommand(conflictingProgram)
+
+    await expect(
+      conflictingProgram.parseAsync(
+        ['node', 'openclaude', 'report', '--json', '--markdown'],
+        { from: 'node' },
+      ),
+    ).rejects.toThrow("option '--json' cannot be used with option '--markdown'")
   })
 
   test('normalizes max preview chars in report metadata', async () => {

--- a/src/utils/taskReport.ts
+++ b/src/utils/taskReport.ts
@@ -160,8 +160,10 @@ export type BuildTaskReportOptions = {
   maxPreviewChars?: number
 }
 
+export type TaskReportFormat = 'json' | 'markdown'
+
 export type TaskReportArgs = {
-  format: 'json'
+  format: TaskReportFormat
   transcriptPath?: string | null
   sessionId?: string | null
   outFile?: string | null
@@ -413,6 +415,120 @@ export function formatTaskReportAsJson(report: TaskReport): string {
   return stableStringifyJson(report, 2)
 }
 
+export function formatTaskReportAsMarkdown(report: TaskReport): string {
+  const lines: string[] = ['# Task Report', '']
+
+  lines.push('## Summary')
+  lines.push(`- Session: ${formatSessionSummary(report.session)}`)
+  lines.push(`- Validation: ${formatValidationSummary(report.validations)}`)
+  lines.push(`- Commands run: ${report.commands.length}`)
+  lines.push(`- Files changed: ${report.changedFiles.length}`)
+  lines.push(`- Tool uses: ${report.toolUses.length}`)
+  lines.push(`- Errors: ${report.errors.length}`)
+  lines.push(`- Warnings: ${report.warnings.length}`)
+  lines.push('')
+
+  lines.push('## Session')
+  lines.push(`- ID: ${formatMaybeCode(report.session.id)}`)
+  if (report.session.name) {
+    lines.push(`- Title: ${markdownText(report.session.name)}`)
+  }
+  if (report.session.tag) lines.push(`- Tag: ${codeSpan(report.session.tag)}`)
+  if (report.session.cwd) lines.push(`- CWD: ${codeSpan(report.session.cwd)}`)
+  lines.push(`- Transcript: ${codeSpan(report.source.transcriptPath)}`)
+  if (report.session.startedAt) {
+    lines.push(`- Started: ${codeSpan(report.session.startedAt)}`)
+  }
+  if (report.session.endedAt) {
+    lines.push(`- Ended: ${codeSpan(report.session.endedAt)}`)
+  }
+  if (report.session.initialRequest) {
+    lines.push('- Initial request:')
+    lines.push(
+      indentBlock(formatFencedCode(report.session.initialRequest), '  '),
+    )
+  }
+  lines.push(
+    `- Models: ${
+      report.session.models.length > 0
+        ? report.session.models.map(codeSpan).join(', ')
+        : 'none observed'
+    }`,
+  )
+  lines.push('')
+
+  lines.push('## Branching / Worktree')
+  appendBranchMarkdown(lines, report)
+  lines.push('')
+
+  lines.push('## Changes')
+  if (report.toolUses.length === 0) {
+    lines.push('- No tool uses observed.')
+  } else {
+    for (const toolUse of report.toolUses) {
+      lines.push(
+        `- ${codeSpan(toolUse.status)} ${codeSpan(toolUse.name)}${
+          toolUse.inputSummary ? ` - ${markdownText(toolUse.inputSummary)}` : ''
+        }`,
+      )
+      if (toolUse.timestamp) {
+        lines.push(`  - Time: ${codeSpan(toolUse.timestamp)}`)
+      }
+      if (toolUse.files.length > 0) {
+        lines.push(`  - Files: ${toolUse.files.map(codeSpan).join(', ')}`)
+      }
+      appendPreviewMarkdown(lines, 'result', toolUse.resultSummary)
+    }
+  }
+  lines.push('')
+
+  lines.push('## Files changed')
+  if (report.changedFiles.length === 0) {
+    lines.push('- No changed files observed.')
+  } else {
+    for (const file of report.changedFiles) {
+      lines.push(`- ${codeSpan(file.path)} (${file.sources.join(', ')})`)
+    }
+  }
+  lines.push('')
+
+  lines.push('## Commands run')
+  appendCommandsMarkdown(lines, report.commands)
+  lines.push('')
+
+  lines.push('## Validation')
+  if (report.validations.length === 0) {
+    lines.push('- No validation commands were observed.')
+  } else {
+    appendCommandsMarkdown(lines, report.validations)
+  }
+  lines.push('')
+
+  lines.push('## Errors / Warnings')
+  appendErrorsAndWarningsMarkdown(lines, report)
+  lines.push('')
+
+  lines.push('## Risks / Follow-ups')
+  lines.push('- Not represented in task report JSON v1.')
+  lines.push('')
+
+  return lines.join('\n')
+}
+
+export function formatTaskReport(
+  report: TaskReport,
+  format: TaskReportFormat,
+): string {
+  switch (format) {
+    case 'json':
+      return formatTaskReportAsJson(report)
+    case 'markdown':
+      return formatTaskReportAsMarkdown(report)
+    default:
+      throw new Error(`Unsupported task report format: ${String(format)}`)
+  }
+}
+
 export async function writeTaskReport(
   outFile: string,
   content: string,
@@ -421,6 +537,268 @@ export async function writeTaskReport(
   await mkdir(dirname(outputPath), { recursive: true })
   await writeFile(outputPath, content, 'utf8')
   return outputPath
+}
+
+function formatSessionSummary(session: TaskReportSession): string {
+  if (session.name) return markdownText(session.name)
+  if (session.id) return codeSpan(session.id)
+  return 'unknown'
+}
+
+function formatValidationSummary(validations: TaskReportValidation[]): string {
+  if (validations.length === 0) return 'none observed'
+  const passed = validations.filter(command => command.status === 'success').length
+  const failed = validations.filter(command => command.status === 'error').length
+  const unknown = validations.filter(command => command.status === 'unknown').length
+  const cancelled = validations.filter(
+    command => command.status === 'cancelled',
+  ).length
+  return `${passed} passed, ${failed} failed, ${unknown} unknown${
+    cancelled > 0 ? `, ${cancelled} cancelled` : ''
+  }`
+}
+
+function appendBranchMarkdown(lines: string[], report: TaskReport): void {
+  let hasMetadata = false
+  const branch = report.branch
+
+  if (branch.transcriptBranch) {
+    lines.push(`- Transcript branch: ${codeSpan(branch.transcriptBranch)}`)
+    hasMetadata = true
+  }
+
+  if (branch.worktree) {
+    const worktree = branch.worktree
+    if (worktree.name) lines.push(`- Worktree: ${codeSpan(worktree.name)}`)
+    if (worktree.path) lines.push(`- Worktree path: ${codeSpan(worktree.path)}`)
+    if (worktree.branch) {
+      lines.push(`- Worktree branch: ${codeSpan(worktree.branch)}`)
+    }
+    if (worktree.originalBranch) {
+      lines.push(`- Original branch: ${codeSpan(worktree.originalBranch)}`)
+    }
+    if (worktree.originalHead) {
+      lines.push(`- Original head: ${codeSpan(worktree.originalHead)}`)
+    }
+    if (worktree.originalCwd) {
+      lines.push(`- Original CWD: ${codeSpan(worktree.originalCwd)}`)
+    }
+    hasMetadata = true
+  }
+
+  if (branch.pullRequest) {
+    lines.push(`- Pull request: ${formatReference(branch.pullRequest)}`)
+    hasMetadata = true
+  }
+
+  if (report.git) {
+    lines.push(`- Git status: ${codeSpan(report.git.status)}`)
+    lines.push(`- Git CWD: ${codeSpan(report.git.cwd)}`)
+    if (report.git.branch) {
+      lines.push(`- Git branch: ${codeSpan(report.git.branch)}`)
+    }
+    if (report.git.head) lines.push(`- Git head: ${codeSpan(report.git.head)}`)
+    if (report.git.dirty !== undefined) {
+      lines.push(`- Git dirty: ${report.git.dirty ? 'yes' : 'no'}`)
+    }
+    if (report.git.error) {
+      lines.push(`- Git error: ${markdownText(report.git.error)}`)
+    }
+    hasMetadata = true
+  }
+
+  if (report.linkedReferences.length > 0) {
+    lines.push('- Linked references:')
+    for (const reference of report.linkedReferences) {
+      lines.push(`  - ${reference.kind}: ${formatReference(reference)}`)
+    }
+    hasMetadata = true
+  }
+
+  if (!hasMetadata) {
+    lines.push('- No branch, worktree, or git metadata available.')
+  }
+}
+
+function appendCommandsMarkdown(
+  lines: string[],
+  commands: TaskReportCommand[],
+): void {
+  if (commands.length === 0) {
+    lines.push('- No commands observed.')
+    return
+  }
+
+  for (const command of commands) {
+    const description = command.description
+      ? ` - ${markdownText(command.description)}`
+      : ''
+    const exitCode =
+      command.exitCode !== undefined ? ` (exit ${command.exitCode})` : ''
+    const multilineCommand = hasLineBreak(command.command)
+    const commandLabel = multilineCommand ? 'command' : codeSpan(command.command)
+    lines.push(
+      `- ${codeSpan(command.status)} ${commandLabel}${description}${exitCode}`,
+    )
+    if (multilineCommand) {
+      lines.push('  - Command:')
+      lines.push(
+        indentBlock(formatFencedCode(command.command, 'shell'), '    '),
+      )
+    }
+    if (command.timestamp) {
+      lines.push(`  - Time: ${codeSpan(command.timestamp)}`)
+    }
+    appendPreviewMarkdown(lines, 'stdout', command.stdout)
+    appendPreviewMarkdown(lines, 'stderr', command.stderr)
+  }
+}
+
+function appendPreviewMarkdown(
+  lines: string[],
+  label: string,
+  preview: TaskReportPreview | undefined,
+): void {
+  if (!preview || preview.preview.length === 0) return
+  const suffix = preview.truncated ? ` (truncated, ${preview.chars} chars)` : ''
+  lines.push(`  - ${label}${suffix}:`)
+  lines.push(indentBlock(formatFencedCode(preview.preview), '    '))
+}
+
+function appendErrorsAndWarningsMarkdown(
+  lines: string[],
+  report: TaskReport,
+): void {
+  if (report.errors.length === 0 && report.warnings.length === 0) {
+    lines.push('- none')
+    return
+  }
+
+  if (report.errors.length > 0) {
+    lines.push('### Errors')
+    for (const error of report.errors) {
+      const context =
+        error.toolName || error.toolUseId
+          ? ` (${[
+              error.toolName ? codeSpan(error.toolName) : undefined,
+              error.toolUseId ? codeSpan(error.toolUseId) : undefined,
+            ]
+              .filter(Boolean)
+              .join(', ')})`
+          : ''
+      const label = `${capitalize(error.source)} error${context}`
+      appendProseMarkdown(lines, label, error.message)
+    }
+  }
+
+  if (report.warnings.length > 0) {
+    lines.push('### Warnings')
+    for (const warning of report.warnings) {
+      if (hasLineBreak(warning)) {
+        appendProseMarkdown(lines, 'Warning', warning)
+      } else {
+        lines.push(`- ${markdownText(warning)}`)
+      }
+    }
+  }
+}
+
+function appendProseMarkdown(
+  lines: string[],
+  label: string,
+  value: string,
+): void {
+  if (hasLineBreak(value)) {
+    lines.push(`- ${label}:`)
+    lines.push(indentBlock(formatFencedCode(value), '  '))
+    return
+  }
+
+  lines.push(`- ${label}: ${markdownText(value)}`)
+}
+
+function formatReference(reference: {
+  number: number
+  url?: string
+  repository?: string
+}): string {
+  const label = `#${reference.number}`
+  const safeUrl = reference.url ? formatMarkdownUrl(reference.url) : null
+  const linked = safeUrl ? `[${label}](<${safeUrl}>)` : codeSpan(label)
+  return reference.repository
+    ? `${linked} (${codeSpan(reference.repository)})`
+    : linked
+}
+
+function formatMarkdownUrl(url: string): string | null {
+  try {
+    const parsed = new URL(url)
+    if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+      return null
+    }
+    return parsed.toString()
+  } catch {
+    return null
+  }
+}
+
+function formatMaybeCode(value: string | null | undefined): string {
+  return value ? codeSpan(value) : 'unknown'
+}
+
+function formatFencedCode(value: string, language = 'text'): string {
+  const content = value.replaceAll('\r\n', '\n')
+  const backtickRuns = content.match(/`+/g) ?? []
+  const fenceLength = Math.max(
+    3,
+    ...backtickRuns.map(run => run.length + 1),
+  )
+  const fence = '`'.repeat(fenceLength)
+  return `${fence}${language}\n${content}\n${fence}`
+}
+
+function codeSpan(value: string): string {
+  const content = value
+    .replaceAll('\r\n', '\n')
+    .replaceAll('\r', '\n')
+    .replaceAll('\n', ' ')
+  const backtickRuns = content.match(/`+/g) ?? []
+  const fenceLength = Math.max(
+    1,
+    ...backtickRuns.map(run => run.length + 1),
+  )
+  const fence = '`'.repeat(fenceLength)
+  const needsPadding = content.startsWith('`') || content.endsWith('`')
+  return needsPadding
+    ? `${fence} ${content} ${fence}`
+    : `${fence}${content}${fence}`
+}
+
+function indentBlock(value: string, indent: string): string {
+  return value
+    .split('\n')
+    .map(line => `${indent}${line}`)
+    .join('\n')
+}
+
+function markdownText(value: string): string {
+  return escapeMarkdownText(singleLine(value))
+}
+
+function escapeMarkdownText(value: string): string {
+  return value.replace(/([\\`*_\[\]<>])/g, '\\$1')
+}
+
+function hasLineBreak(value: string): boolean {
+  return /[\r\n]/.test(value)
+}
+
+function singleLine(value: string): string {
+  return value.replace(/\s+/g, ' ').trim()
+}
+
+function capitalize(value: string): string {
+  return value ? `${value[0]?.toUpperCase()}${value.slice(1)}` : value
 }
 
 async function readTranscriptEntries(


### PR DESCRIPTION
## Summary
- Add Markdown output for deterministic task reports via `openclaude report --markdown`.
- Keep JSON output available through `--json` and require one explicit report output format.

## Implementation
- Adds a task report Markdown renderer that formats the existing report model without re-extracting data.
- Covers session, branch/worktree/git metadata, changes, changed files, commands, validation, errors/warnings, and risks/follow-ups.
- Preserves redaction/truncation and protects markdown output for command whitespace, multiline values, backticks, and unsafe reference URLs.
- Extracts report command registration so CLI option parsing is covered directly.

## Impact
- user-facing impact: users can print or write a human-readable Markdown task report for session review and PR preparation.
- developer/maintainer impact: renderer behavior is covered by focused regression tests while JSON report generation remains the data source.

## Testing
- [x] `bun test src/**/report*.test.ts`
- [x] `bun run typecheck`
- [x] `bun run build`
- [x] `bun run smoke`
- [x] `git diff --check`

## Notes
- provider/model path tested: not applicable
- screenshots attached: not applicable
- follow-up work or known limitations: no PR-template mode is included in this change


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new report command with both JSON and Markdown output.
  * Reports can now be generated from the latest session or a specific transcript, and optionally saved to a file.

* **Bug Fixes**
  * Improved report output so non-validation sessions now show a warning instead of implying checks passed.
  * Fixed formatting and escaping issues in Markdown reports for cleaner, safer rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->