### PR TITLE
fix(codex): make Codex alias lookup prototype-safe

### DIFF
--- a/src/services/api/providerConfig.protoAlias.test.ts
+++ b/src/services/api/providerConfig.protoAlias.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, test } from 'bun:test'
+import { isCodexAlias, shouldUseCodexTransport } from './providerConfig.js'
+
+// Regression: CODEX_ALIAS_MODELS is a plain object literal, and the alias
+// lookups keyed it with a config/CLI-controlled model string. Names inherited
+// from Object.prototype resolved through the prototype chain, so `key in map`
+// and `map[key]` reported a match for strings that are NOT Codex aliases. That
+// made `isCodexAlias('constructor')` return true and, with no explicit base
+// URL, `shouldUseCodexTransport` misroute the request through the Codex
+// transport. The lookups must only see own enumerable aliases.
+//
+// The lookups lower-case the model string first, so the reachable inherited
+// keys are the ones that are already all-lowercase: `constructor` and
+// `__proto__`. (`toString`/`valueOf`/etc. lower-case to non-keys and never
+// matched, so they are not the regression surface.)
+describe('providerConfig — Codex alias lookup is prototype-safe', () => {
+  const protoNames = ['constructor', '__proto__']
+
+  for (const name of protoNames) {
+    test(`isCodexAlias('${name}') is false (inherited, not a real alias)`, () => {
+      expect(isCodexAlias(name)).toBe(false)
+    })
+
+    test(`shouldUseCodexTransport('${name}', undefined) does not misroute`, () => {
+      expect(shouldUseCodexTransport(name, undefined)).toBe(false)
+    })
+  }
+
+  // Controls: real aliases still resolve.
+  test('genuine aliases are still recognized', () => {
+    expect(isCodexAlias('codexplan')).toBe(true)
+    expect(isCodexAlias('gpt-5.5')).toBe(true)
+    expect(shouldUseCodexTransport('codexplan', undefined)).toBe(true)
+  })
+
+  // Non-aliases (real model ids that aren't Codex) stay false.
+  test('non-Codex model ids are not treated as aliases', () => {
+    expect(isCodexAlias('claude-opus-4-8')).toBe(false)
+    expect(shouldUseCodexTransport('claude-opus-4-8', undefined)).toBe(false)
+  })
+})

--- a/src/services/api/providerConfig.protoAlias.test.ts
+++ b/src/services/api/providerConfig.protoAlias.test.ts
@@ -85,6 +85,39 @@ describe('providerConfig — Codex alias lookup is prototype-safe', () => {
     })
   }
 
+  // The descriptor path reads CODEX_ALIAS_MODELS twice: the no-query branch
+  // above, and the `baseModel?reasoning=...` query branch, which is a separate
+  // guarded read. Removing the own-property guard from the query branch must
+  // also red-green here. `constructor`/`__proto__` carry no `.model`, so to
+  // exercise the query branch we plant an inherited alias whose `.model`
+  // differs from the key, then confirm a `<key>?reasoning=...` request keeps
+  // the literal base model instead of the inherited alias's `.model`.
+  test('resolveProviderRequest query branch ignores an inherited (polluted) alias', () => {
+    const key = 'polluted-descriptor-alias'
+    // eslint-disable-next-line no-extend-native
+    ;(Object.prototype as Record<string, unknown>)[key] = {
+      model: 'gpt-5.5',
+      reasoningEffort: 'high',
+    }
+    try {
+      const { resolvedModel } = resolveProviderRequest({
+        model: `${key}?reasoning=medium`,
+        processEnv: {},
+      })
+      expect(resolvedModel).toBe(key)
+    } finally {
+      delete (Object.prototype as Record<string, unknown>)[key]
+    }
+  })
+
+  test('resolveProviderRequest query branch still resolves a genuine Codex alias', () => {
+    const { resolvedModel } = resolveProviderRequest({
+      model: 'codexplan?reasoning=medium',
+      processEnv: {},
+    })
+    expect(resolvedModel).toBe('gpt-5.5')
+  })
+
   test('resolveProviderRequest still resolves a genuine Codex alias', () => {
     const { resolvedModel } = resolveProviderRequest({
       model: 'codexplan',

--- a/src/services/api/providerConfig.protoAlias.test.ts
+++ b/src/services/api/providerConfig.protoAlias.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, test } from 'bun:test'
-import { isCodexAlias, shouldUseCodexTransport } from './providerConfig.js'
+import {
+  getReasoningEffortForModel,
+  isCodexAlias,
+  resolveProviderRequest,
+  shouldUseCodexTransport,
+  supportsCodexReasoningEffort,
+} from './providerConfig.js'
 
 // Regression: CODEX_ALIAS_MODELS is a plain object literal, and the alias
 // lookups keyed it with a config/CLI-controlled model string. Names inherited
@@ -37,5 +43,53 @@ describe('providerConfig — Codex alias lookup is prototype-safe', () => {
   test('non-Codex model ids are not treated as aliases', () => {
     expect(isCodexAlias('claude-opus-4-8')).toBe(false)
     expect(shouldUseCodexTransport('claude-opus-4-8', undefined)).toBe(false)
+  })
+
+  // getReasoningEffortForModel indexes the same map (feeds supportsCodexReasoningEffort,
+  // /effort, EffortPicker). It must be prototype-safe too. `constructor` /
+  // `__proto__` carry no `.reasoningEffort`, so to prove the own-property guard
+  // actually fires we plant a polluting alias on Object.prototype (cleaned up in
+  // finally) and confirm it is NOT read as a Codex reasoning default.
+  test('getReasoningEffortForModel ignores an inherited (polluted) alias', () => {
+    const key = 'polluted-effort-alias'
+    // eslint-disable-next-line no-extend-native
+    ;(Object.prototype as Record<string, unknown>)[key] = {
+      model: key,
+      reasoningEffort: 'high',
+    }
+    try {
+      expect(getReasoningEffortForModel(key)).toBeUndefined()
+      expect(supportsCodexReasoningEffort(key)).toBe(false)
+    } finally {
+      delete (Object.prototype as Record<string, unknown>)[key]
+    }
+  })
+
+  test('getReasoningEffortForModel still resolves genuine aliases', () => {
+    expect(getReasoningEffortForModel('codexplan')).toBe('high')
+    expect(getReasoningEffortForModel('gpt-5.5-mini')).toBe('medium')
+    expect(getReasoningEffortForModel('gpt-5.3-codex-spark')).toBeUndefined()
+  })
+
+  // The descriptor parsing path (parseModelDescriptor, via resolveProviderRequest)
+  // is guarded too — a proto-name model must resolve to itself, not to the
+  // inherited Object constructor's (nonexistent) `.model`, which produced an
+  // undefined resolvedModel before the guard.
+  for (const name of protoNames) {
+    test(`resolveProviderRequest keeps '${name}' as the resolved model`, () => {
+      const { resolvedModel } = resolveProviderRequest({
+        model: name,
+        processEnv: {},
+      })
+      expect(resolvedModel).toBe(name)
+    })
+  }
+
+  test('resolveProviderRequest still resolves a genuine Codex alias', () => {
+    const { resolvedModel } = resolveProviderRequest({
+      model: 'codexplan',
+      processEnv: {},
+    })
+    expect(resolvedModel).toBe('gpt-5.5')
   })
 })

--- a/src/services/api/providerConfig.ts
+++ b/src/services/api/providerConfig.ts
@@ -340,7 +340,9 @@ function parseModelDescriptor(model: string): ModelDescriptor {
   const queryIndex = trimmed.indexOf('?')
   if (queryIndex === -1) {
     const alias = trimmed.toLowerCase() as CodexAlias
-    const aliasConfig = CODEX_ALIAS_MODELS[alias]
+    const aliasConfig = Object.hasOwn(CODEX_ALIAS_MODELS, alias)
+      ? CODEX_ALIAS_MODELS[alias]
+      : undefined
     if (aliasConfig) {
       return {
         raw: trimmed,
@@ -359,7 +361,9 @@ function parseModelDescriptor(model: string): ModelDescriptor {
   const baseModel = trimmed.slice(0, queryIndex).trim()
   const params = new URLSearchParams(trimmed.slice(queryIndex + 1))
   const alias = baseModel.toLowerCase() as CodexAlias
-  const aliasConfig = CODEX_ALIAS_MODELS[alias]
+  const aliasConfig = Object.hasOwn(CODEX_ALIAS_MODELS, alias)
+    ? CODEX_ALIAS_MODELS[alias]
+    : undefined
   const resolvedBaseModel = aliasConfig?.model ?? baseModel
   const reasoning =
     parseReasoningEffort(params.get('reasoning') ?? undefined) ??
@@ -379,7 +383,7 @@ function parseModelDescriptor(model: string): ModelDescriptor {
 export function isCodexAlias(model: string): boolean {
   const normalized = model.trim().toLowerCase()
   const base = normalized.split('?', 1)[0] ?? normalized
-  return base in CODEX_ALIAS_MODELS
+  return Object.hasOwn(CODEX_ALIAS_MODELS, base)
 }
 
 function isOpenAICodexShortcutAlias(model: string): boolean {

--- a/src/services/api/providerConfig.ts
+++ b/src/services/api/providerConfig.ts
@@ -1306,7 +1306,9 @@ export function getReasoningEffortForModel(model: string): ReasoningEffort | und
   const normalized = model.trim().toLowerCase()
   const base = normalized.split('?', 1)[0] ?? normalized
   const alias = base as CodexAlias
-  const aliasConfig = CODEX_ALIAS_MODELS[alias]
+  const aliasConfig = Object.hasOwn(CODEX_ALIAS_MODELS, alias)
+    ? CODEX_ALIAS_MODELS[alias]
+    : undefined
   return aliasConfig?.reasoningEffort
 }
 


### PR DESCRIPTION
### Problem

`CODEX_ALIAS_MODELS` is a plain object literal, and the three alias lookups key it directly with a config/CLI-controlled model string:

- `isCodexAlias` — `base in CODEX_ALIAS_MODELS`
- `parseModelDescriptor` (both the no-query and query paths) — `CODEX_ALIAS_MODELS[alias]`

The model string is lower-cased first, so the already-lowercase names inherited from `Object.prototype` — `constructor` and `__proto__` — resolve through the prototype chain. `key in map` returns `true` and `map[key]` returns a truthy inherited value for strings that are **not** Codex aliases.

### Impact

- `isCodexAlias('constructor')` returns `true`. With no explicit base URL, `shouldUseCodexTransport('constructor', undefined)` then returns `true`, so the request is **misrouted through the Codex transport**.
- `parseModelDescriptor('constructor')` passes its `if (aliasConfig)` guard and returns `baseModel: undefined` (reading `.model` off the inherited `Object` constructor), which then flows into API-name resolution.

The `model` argument comes from the user-selected model string (`--model`, model env vars, `settings.json`, provider profiles) — the same config-controlled surface as prior prototype-pollution fixes here (#1710 `CLI_COMMAND_MAPPING`, #1430 `FILENAME_LANGS`, #1787 marketplace manager).

### Fix

Guard each of the three reads with `Object.hasOwn` so only own alias entries match. This keeps the `as const` map — and the `CodexAlias = keyof typeof CODEX_ALIAS_MODELS` type — intact, unlike an `Object.create(null)` rewrite which would collapse `keyof` to `string`. `Object.hasOwn` is already used this way elsewhere in the codebase.

### Test

`providerConfig.protoAlias.test.ts` asserts `isCodexAlias` / `shouldUseCodexTransport` return `false` for the two reachable inherited keys (`constructor`, `__proto__`), plus positive controls that genuine aliases (`codexplan`, `gpt-5.5`) and unrelated model ids still resolve correctly. Red-green verified: 4 assertions fail before the fix, all pass after. Full `providerConfig` suite (94 tests) green; `tsc --noEmit` clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Hardened Codex alias detection and configuration lookups to consider only explicitly-defined aliases, preventing prototype-chain pollution from affecting model parsing.
  * Ensured inherited keys (e.g., `constructor`, `__proto__`) are not treated as valid aliases.
  * Kept query-string model parsing and reasoning-effort mapping consistent for real Codex aliases while leaving non-Codex models unchanged.
* **Tests**
  * Added a regression test suite to verify safe alias handling and correct resolution behavior under prototype pollution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->