### PR TITLE
fix(format): show sub-second durations with a decimal instead of "0s"

### DIFF
--- a/src/utils/format.test.ts
+++ b/src/utils/format.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from 'bun:test'
-import { formatFileSize } from './format.js'
+import { formatDuration, formatFileSize } from './format.js'
 
 test('formats sub-KB sizes as raw bytes', () => {
   expect(formatFileSize(0)).toBe('0 bytes')
@@ -29,4 +29,21 @@ test('rolls MB over to GB when the rounded value reaches 1024', () => {
 test('formats normal MB and GB sizes', () => {
   expect(formatFileSize(1024 * 1024 * 2.5)).toBe('2.5MB')
   expect(formatFileSize(1024 * 1024 * 1024 * 3)).toBe('3GB')
+})
+
+// Regression: the sub-second branch gated on `ms < 1` instead of `ms < 1000`,
+// so every 1–999ms duration fell through to Math.floor(ms/1000) === 0 and
+// rendered "0s" — despite the comment/example promising "0.5s". This showed up
+// as `/cost` printing "Total duration (API): 0s" for a fast/cached turn.
+test('formats sub-second durations with one decimal place', () => {
+  expect(formatDuration(500)).toBe('0.5s')
+  expect(formatDuration(100)).toBe('0.1s')
+  expect(formatDuration(900)).toBe('0.9s')
+})
+
+test('keeps the 0 and whole-second cases intact', () => {
+  expect(formatDuration(0)).toBe('0s')
+  expect(formatDuration(1000)).toBe('1s')
+  expect(formatDuration(1500)).toBe('1s')
+  expect(formatDuration(59000)).toBe('59s')
 })

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -43,7 +43,7 @@ export function formatDuration(
       return '0s'
     }
     // For durations < 1s, show 1 decimal place (e.g., 0.5s)
-    if (ms < 1) {
+    if (ms < 1000) {
       const s = (ms / 1000).toFixed(1)
       return `${s}s`
     }


### PR DESCRIPTION
### Problem

`formatDuration`'s sub-second branch is gated on `ms < 1`:

```ts
// For durations < 1s, show 1 decimal place (e.g., 0.5s)
if (ms < 1) {
  const s = (ms / 1000).toFixed(1)
  return `${s}s`
}
const s = Math.floor(ms / 1000).toString()
return `${s}s`
```

The comment and example (`0.5s` = 500ms) say this branch is meant for durations **below one second**, but `ms < 1` only matches sub-**millisecond** values. So every 1–999ms duration skips the decimal branch and falls through to `Math.floor(ms / 1000)` = `0`, rendering **`"0s"`**. The decimal branch is effectively dead code — it can only fire for `0 < ms < 1`, which never occurs for a real timing.

- `formatDuration(500)` → `"0s"` (should be `"0.5s"`)
- `formatDuration(900)` → `"0s"` (should be `"0.9s"`)

### Impact (user-visible)

- `/cost` — `Total duration (API): ${formatDuration(...)}` / `(wall): ...` prints `0s` for a fast or cached sub-second turn.
- Shell timeout message (`ShellCommand.ts`) renders `0s` for a sub-second configured timeout.
- Elapsed/replay duration displays (`useElapsedTime.ts`, `replayFormat.ts`).

All inputs are runtime-derived and user-facing.

### Fix

Gate on `ms < 1000` (one second), as the comment intends. Durations ≥ 1s are unaffected (they already take the `Math.floor` path). Adds `formatDuration` tests: sub-second decimals plus the unchanged `0` and whole-second cases. Red-green verified; `tsc --noEmit` clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved duration display for sub-second values so times between 1ms and 999ms now show with one decimal place, making short durations easier to read.
  * Kept existing formatting unchanged for zero and whole-second values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->