### PR TITLE
fix(memoryscan): abort remaining workers when one throws on iterator …

### DIFF
--- a/src/memdir/memoryScan.ts
+++ b/src/memdir/memoryScan.ts
@@ -77,21 +77,26 @@ async function scanMemoryFilesWithDependencies(
 ): Promise<MemoryHeader[]> {
   try {
     signal.throwIfAborted()
+    const controller = new AbortController()
+    const internalSignal = controller.signal
+    signal.addEventListener('abort', () => controller.abort(), { once: true })
+
     const topHeaders: RankedMemoryHeader[] = []
     const fileIterator = walkMarkdownFiles(
       memoryDir,
-      signal,
+      internalSignal,
       deps,
     )[Symbol.asyncIterator]()
     let nextOrder = 0
 
     const workers = Array.from({ length: HEADER_READ_CONCURRENCY }, async () => {
-      while (!signal.aborted) {
+      while (!internalSignal.aborted) {
         let next: IteratorResult<string>
         try {
           next = await fileIterator.next()
         } catch (error) {
-          if (signal.aborted) return
+          controller.abort()
+          if (internalSignal.aborted) return
           throw error
         }
         if (next.done) return
@@ -101,19 +106,19 @@ async function scanMemoryFilesWithDependencies(
           const header = await readMemoryHeader(
             memoryDir,
             next.value,
-            signal,
+            internalSignal,
             deps,
           )
-          if (signal.aborted) return
+          if (internalSignal.aborted) return
           insertNewestHeader(topHeaders, { header, order })
         } catch {
-          if (signal.aborted) return
+          if (internalSignal.aborted) return
         }
       }
     })
 
     await Promise.all(workers)
-    return signal.aborted ? [] : topHeaders.map(entry => entry.header)
+    return internalSignal.aborted ? [] : topHeaders.map(entry => entry.header)
   } catch {
     return []
   }

--- a/src/memdir/memoryScan.ts
+++ b/src/memdir/memoryScan.ts
@@ -95,8 +95,8 @@ async function scanMemoryFilesWithDependencies(
         try {
           next = await fileIterator.next()
         } catch (error) {
-          controller.abort()
           if (internalSignal.aborted) return
+          controller.abort()
           throw error
         }
         if (next.done) return


### PR DESCRIPTION
`src/memdir/memoryScan.ts` - `scanMemoryFilesWithDependencies` (line 88-118)

The worker pool spawns `HEADER_READ_CONCURRENCY` workers that iterate a shared async generator via `fileIterator.next()`. When one worker's next() call throws a non-abort error:

```ts
try {
  next = await fileIterator.next()
} catch (error) {
  if (signal.aborted) return
  throw error
}
```

The worker re-throws, `Promise.all(workers)` rejects immediately, and the outer catch returns `[]`. But the caller's `AbortSignal` is never triggered, so remaining workers keep running their `while (!signal.aborted)` loops indefinitely - leaking unresolved promises that hold open file handles from the async generator.

Fix: create an internal `AbortController` inside the function, wire it to the caller's `AbortSignal`, and call `controller.abort()` before re-throwing so all peer workers terminate on any error. The external caller's signal is forwarded to the internal controller, so external cancellation still works as before.

**Changes:**

- Create `AbortController` and pass `controller.signal` (as `internalSignal`) to workers, `walkMarkdownFiles`, and `readMemoryHeader`
- Forward external abort to internal controller via `signal.addEventListener('abort', () => controller.abort(), { once: true })`
- Call `controller.abort()` in the `fileIterator.next()` error handler before re-throwing

**Tests:** `bun test src/memdir/memoryScan.test.ts` - 15/15 pass including existing abort-related tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved memory file scanning reliability by handling cancellation more consistently across scan workers.
  * Scan workers now stop cleanly when a scan is aborted or when an error occurs while advancing items or reading headers.
  * Aborted scans now reliably return no results, avoiding partial or inconsistent output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->