### PR TITLE
fix(installer): gate native-binary install behind NATIVE_PACKAGE_URL

### DIFF
--- a/src/cli/update.test.ts
+++ b/src/cli/update.test.ts
@@ -1,0 +1,31 @@
+import { afterEach, describe, expect, test } from 'bun:test'
+import { getGlobalUpdateFailureHint } from './update.js'
+
+const originalMacro = (globalThis as Record<string, unknown>).MACRO
+
+afterEach(() => {
+  if (originalMacro === undefined) {
+    delete (globalThis as Record<string, unknown>).MACRO
+  } else {
+    ;(globalThis as Record<string, unknown>).MACRO = originalMacro
+  }
+})
+
+describe('getGlobalUpdateFailureHint', () => {
+  test('points npm-only builds at npm instead of the native installer', () => {
+    ;(globalThis as Record<string, unknown>).MACRO = {
+      PACKAGE_URL: '@gitlawb/openclaude',
+    }
+
+    expect(getGlobalUpdateFailureHint(false)).toContain(
+      'npm install -g @gitlawb/openclaude@latest',
+    )
+    expect(getGlobalUpdateFailureHint(false)).not.toContain('openclaude install')
+  })
+
+  test('preserves native installer guidance for native-capable builds', () => {
+    expect(getGlobalUpdateFailureHint(true)).toBe(
+      'Or consider using native installation with: openclaude install\n',
+    )
+  })
+})

--- a/src/cli/update.test.ts
+++ b/src/cli/update.test.ts
@@ -1,26 +1,17 @@
-import { afterEach, describe, expect, test } from 'bun:test'
+import { describe, expect, test } from 'bun:test'
+import { withMockMacro } from 'src/test/mockMacro.js'
 import { getGlobalUpdateFailureHint } from './update.js'
-
-const originalMacro = (globalThis as Record<string, unknown>).MACRO
-
-afterEach(() => {
-  if (originalMacro === undefined) {
-    delete (globalThis as Record<string, unknown>).MACRO
-  } else {
-    ;(globalThis as Record<string, unknown>).MACRO = originalMacro
-  }
-})
 
 describe('getGlobalUpdateFailureHint', () => {
   test('points npm-only builds at npm instead of the native installer', () => {
-    ;(globalThis as Record<string, unknown>).MACRO = {
-      PACKAGE_URL: '@gitlawb/openclaude',
-    }
-
-    expect(getGlobalUpdateFailureHint(false)).toContain(
-      'npm install -g @gitlawb/openclaude@latest',
-    )
-    expect(getGlobalUpdateFailureHint(false)).not.toContain('openclaude install')
+    withMockMacro({ PACKAGE_URL: '@gitlawb/openclaude' }, () => {
+      expect(getGlobalUpdateFailureHint(false)).toContain(
+        'npm install -g @gitlawb/openclaude@latest',
+      )
+      expect(getGlobalUpdateFailureHint(false)).not.toContain(
+        'openclaude install',
+      )
+    })
   })
 
   test('preserves native installer guidance for native-capable builds', () => {

--- a/src/cli/update.ts
+++ b/src/cli/update.ts
@@ -18,6 +18,7 @@ import {
   installOrUpdateClaudePackage,
   localInstallationExists,
 } from 'src/utils/localInstaller.js'
+import { hasNativeDistribution } from 'src/utils/nativeDistribution.js'
 import {
   installLatest as installLatestNative,
   removeInstalledSymlink,
@@ -26,7 +27,7 @@ import { getPackageManager } from 'src/utils/nativeInstaller/packageManagers.js'
 import { writeToStdout } from 'src/utils/process.js'
 import { gte } from 'src/utils/semver.js'
 import { getInitialSettings } from 'src/utils/settings/settings.js'
-import { isThirdPartyBuildBlocked } from 'src/utils/updateStrategy.js'
+import { isThirdPartyBuildBlocked, planUpdate } from 'src/utils/updateStrategy.js'
 
 export async function update() {
   // Block updates for third-party providers using upstream Anthropic builds.
@@ -235,8 +236,10 @@ export async function update() {
     }
   }
 
-  // Handle native installation updates first
-  if (diagnostic.installationType === 'native') {
+  // Handle native installation updates first. npm-only builds fall through to
+  // the npm update path even when the running binary looks native — they have
+  // no native distribution to update from.
+  if (diagnostic.installationType === 'native' && hasNativeDistribution()) {
     logForDebugging(
       'update: Detected native installation, using native updater',
     )
@@ -347,33 +350,33 @@ export async function update() {
   let useLocalUpdate = false
   let updateMethodName = ''
 
-  switch (diagnostic.installationType) {
-    case 'npm-local':
-      useLocalUpdate = true
-      updateMethodName = 'local'
-      break
-    case 'npm-global':
-      useLocalUpdate = false
-      updateMethodName = 'global'
-      break
-    case 'unknown': {
-      // Fallback to detection if we can't determine installation type
-      const isLocal = await localInstallationExists()
-      useLocalUpdate = isLocal
-      updateMethodName = isLocal ? 'local' : 'global'
+  const strategy = planUpdate({
+    thirdPartyBlocked: false,
+    installationType: diagnostic.installationType,
+    nativeDistributionAvailable: hasNativeDistribution(),
+    packageManager: 'unknown',
+    localInstallExists:
+      diagnostic.installationType === 'unknown'
+        ? await localInstallationExists()
+        : false,
+  })
+
+  if (strategy.action === 'npm') {
+    useLocalUpdate = strategy.method === 'local'
+    updateMethodName = strategy.method
+    if (diagnostic.installationType === 'unknown') {
       writeToStdout(
         chalk.yellow('Warning: Could not determine installation type') + '\n',
       )
       writeToStdout(
         `Attempting ${updateMethodName} update based on file detection...\n`,
       )
-      break
     }
-    default:
-      process.stderr.write(
-        `Error: Cannot update ${diagnostic.installationType} installation\n`,
-      )
-      await gracefulShutdown(1)
+  } else {
+    process.stderr.write(
+      `Error: Cannot update ${diagnostic.installationType} installation\n`,
+    )
+    await gracefulShutdown(1)
   }
 
   writeToStdout(`Using ${updateMethodName} installation update method...\n`)

--- a/src/cli/update.ts
+++ b/src/cli/update.ts
@@ -26,8 +26,12 @@ import {
 import { getPackageManager } from 'src/utils/nativeInstaller/packageManagers.js'
 import { writeToStdout } from 'src/utils/process.js'
 import { gte } from 'src/utils/semver.js'
+import { shouldRemoveInstalledSymlinkForNpmUpdate } from 'src/utils/autoUpdaterRouting.js'
 import { getInitialSettings } from 'src/utils/settings/settings.js'
-import { isThirdPartyBuildBlocked, planUpdate } from 'src/utils/updateStrategy.js'
+import {
+  isThirdPartyBuildBlocked,
+  planUpdate,
+} from 'src/utils/updateStrategy.js'
 
 export function getGlobalUpdateFailureHint(
   nativeDistributionAvailable: boolean = hasNativeDistribution(),
@@ -296,7 +300,12 @@ export async function update() {
   // Fallback to existing JS/npm-based update logic
   // Remove native installer symlink since we're not using native installation
   // But only if user hasn't migrated to native installation
-  if (config.installMethod !== 'native') {
+  if (
+    shouldRemoveInstalledSymlinkForNpmUpdate(
+      config.installMethod,
+      hasNativeDistribution(),
+    )
+  ) {
     await removeInstalledSymlink()
   }
 

--- a/src/cli/update.ts
+++ b/src/cli/update.ts
@@ -29,6 +29,14 @@ import { gte } from 'src/utils/semver.js'
 import { getInitialSettings } from 'src/utils/settings/settings.js'
 import { isThirdPartyBuildBlocked, planUpdate } from 'src/utils/updateStrategy.js'
 
+export function getGlobalUpdateFailureHint(
+  nativeDistributionAvailable: boolean = hasNativeDistribution(),
+): string {
+  return nativeDistributionAvailable
+    ? 'Or consider using native installation with: openclaude install\n'
+    : `Or update manually with:\n  npm install -g ${MACRO.PACKAGE_URL}@latest\n`
+}
+
 export async function update() {
   // Block updates for third-party providers using upstream Anthropic builds.
   // The update mechanism downloads from the first-party distribution bucket,
@@ -418,9 +426,7 @@ export async function update() {
         )
       } else {
         process.stderr.write('Try running with sudo or fix npm permissions\n')
-        process.stderr.write(
-          'Or consider using native installation with: openclaude install\n',
-        )
+        process.stderr.write(getGlobalUpdateFailureHint())
       }
       await gracefulShutdown(1)
       break
@@ -432,9 +438,7 @@ export async function update() {
           `  cd ~/.openclaude/local && npm update ${MACRO.PACKAGE_URL}\n`,
         )
       } else {
-        process.stderr.write(
-          'Or consider using native installation with: openclaude install\n',
-        )
+        process.stderr.write(getGlobalUpdateFailureHint())
       }
       await gracefulShutdown(1)
       break

--- a/src/commands/install.tsx
+++ b/src/commands/install.tsx
@@ -9,6 +9,7 @@ import { Box, render, Text } from '../ink.js';
 import { logForDebugging } from '../utils/debug.js';
 import { env } from '../utils/env.js';
 import { errorMessage } from '../utils/errors.js';
+import { hasNativeDistribution } from '../utils/nativeDistribution.js';
 import { checkInstall, cleanupNpmInstallations, cleanupShellAliases, installLatest, repairNativeLauncher } from '../utils/nativeInstaller/index.js';
 import { getInitialSettings, updateSettingsForSource } from '../utils/settings/settings.js';
 interface InstallProps {
@@ -34,6 +35,7 @@ type InstallState = {
   type: 'success';
   version: string;
   setupMessages?: string[];
+  location?: string;
 } | {
   type: 'error';
   message: string;
@@ -98,6 +100,24 @@ export function Install({
     async function run() {
       try {
         logForDebugging(`Install: Starting installation process (force=${force}, target=${target})`);
+
+        // npm-only builds have no native binary to install. Downloading here
+        // would fetch the first-party Claude Code binary and replace the npm
+        // install the user is running, so just confirm the current install.
+        if (!hasNativeDistribution()) {
+          logForDebugging('Install: build has no native distribution; reporting npm installation instead');
+          logEvent('tengu_claude_install_command', {
+            has_version: 1,
+            forced: force ? 1 : 0
+          });
+          setState({
+            type: 'success',
+            version: MACRO.DISPLAY_VERSION,
+            location: process.argv[1] || 'npm global installation',
+            setupMessages: [`This build is distributed via npm (${MACRO.PACKAGE_URL}) and has no native binary, so nothing was downloaded.`, `To update, run: npm install -g ${MACRO.PACKAGE_URL}@latest`]
+          });
+          return;
+        }
 
         // Install native build first
         const channelOrVersion = target || getInitialSettings()?.autoUpdatesChannel || 'latest';
@@ -255,7 +275,7 @@ export function Install({
               </Box>}
             <Box>
               <Text dimColor>Location: </Text>
-              <Text color="text">{getInstallationPath()}</Text>
+              <Text color="text">{state.location ?? getInstallationPath()}</Text>
             </Box>
           </Box>
           <Box marginLeft={2} flexDirection="column" gap={1}>

--- a/src/commands/update/update.test.ts
+++ b/src/commands/update/update.test.ts
@@ -1,32 +1,15 @@
 import { describe, expect, test } from 'bun:test'
+import { withMockMacro } from 'src/test/mockMacro.js'
 
 async function importFreshUpdateCommand() {
   return import(`./update.js?ts=${Date.now()}-${Math.random()}`)
-}
-
-async function withAsyncMockMacro<T>(
-  macro: Record<string, unknown>,
-  run: () => Promise<T>,
-): Promise<T> {
-  const originalMacro = (globalThis as Record<string, unknown>).MACRO
-  ;(globalThis as Record<string, unknown>).MACRO = macro
-
-  try {
-    return await run()
-  } finally {
-    if (originalMacro === undefined) {
-      delete (globalThis as Record<string, unknown>).MACRO
-    } else {
-      ;(globalThis as Record<string, unknown>).MACRO = originalMacro
-    }
-  }
 }
 
 describe('removeStaleNativeLauncherForNpmUpdate', () => {
   test('removes stale native launchers for npm-only builds before npm update', async () => {
     let removed = 0
 
-    await withAsyncMockMacro({ PACKAGE_URL: '@gitlawb/openclaude' }, async () => {
+    await withMockMacro({ PACKAGE_URL: '@gitlawb/openclaude' }, async () => {
       const { removeStaleNativeLauncherForNpmUpdate } =
         await importFreshUpdateCommand()
       await expect(
@@ -46,7 +29,7 @@ describe('removeStaleNativeLauncherForNpmUpdate', () => {
   test('preserves native launchers for native-capable builds', async () => {
     let removed = 0
 
-    await withAsyncMockMacro({ PACKAGE_URL: '@gitlawb/openclaude' }, async () => {
+    await withMockMacro({ PACKAGE_URL: '@gitlawb/openclaude' }, async () => {
       const { removeStaleNativeLauncherForNpmUpdate } =
         await importFreshUpdateCommand()
       await expect(
@@ -66,7 +49,7 @@ describe('removeStaleNativeLauncherForNpmUpdate', () => {
   test('keeps existing cleanup for non-native config states', async () => {
     let removed = 0
 
-    await withAsyncMockMacro({ PACKAGE_URL: '@gitlawb/openclaude' }, async () => {
+    await withMockMacro({ PACKAGE_URL: '@gitlawb/openclaude' }, async () => {
       const { removeStaleNativeLauncherForNpmUpdate } =
         await importFreshUpdateCommand()
       await expect(

--- a/src/commands/update/update.test.ts
+++ b/src/commands/update/update.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, test } from 'bun:test'
+
+async function importFreshUpdateCommand() {
+  return import(`./update.js?ts=${Date.now()}-${Math.random()}`)
+}
+
+async function withAsyncMockMacro<T>(
+  macro: Record<string, unknown>,
+  run: () => Promise<T>,
+): Promise<T> {
+  const originalMacro = (globalThis as Record<string, unknown>).MACRO
+  ;(globalThis as Record<string, unknown>).MACRO = macro
+
+  try {
+    return await run()
+  } finally {
+    if (originalMacro === undefined) {
+      delete (globalThis as Record<string, unknown>).MACRO
+    } else {
+      ;(globalThis as Record<string, unknown>).MACRO = originalMacro
+    }
+  }
+}
+
+describe('removeStaleNativeLauncherForNpmUpdate', () => {
+  test('removes stale native launchers for npm-only builds before npm update', async () => {
+    let removed = 0
+
+    await withAsyncMockMacro({ PACKAGE_URL: '@gitlawb/openclaude' }, async () => {
+      const { removeStaleNativeLauncherForNpmUpdate } =
+        await importFreshUpdateCommand()
+      await expect(
+        removeStaleNativeLauncherForNpmUpdate({
+          getConfig: () => ({ installMethod: 'native' }),
+          hasNativeDistribution: () => false,
+          removeInstalledSymlink: async () => {
+            removed++
+          },
+        }),
+      ).resolves.toBe(true)
+    })
+
+    expect(removed).toBe(1)
+  })
+
+  test('preserves native launchers for native-capable builds', async () => {
+    let removed = 0
+
+    await withAsyncMockMacro({ PACKAGE_URL: '@gitlawb/openclaude' }, async () => {
+      const { removeStaleNativeLauncherForNpmUpdate } =
+        await importFreshUpdateCommand()
+      await expect(
+        removeStaleNativeLauncherForNpmUpdate({
+          getConfig: () => ({ installMethod: 'native' }),
+          hasNativeDistribution: () => true,
+          removeInstalledSymlink: async () => {
+            removed++
+          },
+        }),
+      ).resolves.toBe(false)
+    })
+
+    expect(removed).toBe(0)
+  })
+
+  test('keeps existing cleanup for non-native config states', async () => {
+    let removed = 0
+
+    await withAsyncMockMacro({ PACKAGE_URL: '@gitlawb/openclaude' }, async () => {
+      const { removeStaleNativeLauncherForNpmUpdate } =
+        await importFreshUpdateCommand()
+      await expect(
+        removeStaleNativeLauncherForNpmUpdate({
+          getConfig: () => ({ installMethod: 'global' }),
+          hasNativeDistribution: () => true,
+          removeInstalledSymlink: async () => {
+            removed++
+          },
+        }),
+      ).resolves.toBe(true)
+    })
+
+    expect(removed).toBe(1)
+  })
+})

--- a/src/commands/update/update.tsx
+++ b/src/commands/update/update.tsx
@@ -6,13 +6,22 @@ import {
   getLatestVersion,
   installGlobalPackage,
 } from '../../utils/autoUpdater.js'
-import type { ReleaseChannel } from '../../utils/config.js'
+import {
+  getGlobalConfig,
+  type InstallMethod,
+  type ReleaseChannel,
+} from '../../utils/config.js'
 import { logForDebugging } from '../../utils/debug.js'
 import { errorMessage } from '../../utils/errors.js'
 import { detectGlobalPackageManager } from '../../utils/globalPackageManager.js'
 import { installOrUpdateClaudePackage } from '../../utils/localInstaller.js'
-import { installLatest as installLatestNative } from '../../utils/nativeInstaller/index.js'
+import { hasNativeDistribution } from '../../utils/nativeDistribution.js'
+import {
+  installLatest as installLatestNative,
+  removeInstalledSymlink,
+} from '../../utils/nativeInstaller/index.js'
 import type { PackageManager } from '../../utils/nativeInstaller/packageManagers.js'
+import { shouldRemoveInstalledSymlinkForNpmUpdate } from '../../utils/autoUpdaterRouting.js'
 import { resolveUpdateStrategy } from '../../utils/updateStrategy.js'
 
 const PACKAGE_URL = MACRO.PACKAGE_URL
@@ -49,6 +58,24 @@ function packageManagerHint(manager: PackageManager): string | null {
     default:
       return null
   }
+}
+
+export async function removeStaleNativeLauncherForNpmUpdate(deps: {
+  getConfig?: () => { installMethod?: InstallMethod }
+  hasNativeDistribution?: () => boolean
+  removeInstalledSymlink?: () => Promise<void>
+} = {}): Promise<boolean> {
+  const config = (deps.getConfig ?? getGlobalConfig)()
+  if (
+    shouldRemoveInstalledSymlinkForNpmUpdate(
+      config.installMethod,
+      (deps.hasNativeDistribution ?? hasNativeDistribution)(),
+    )
+  ) {
+    await (deps.removeInstalledSymlink ?? removeInstalledSymlink)()
+    return true
+  }
+  return false
 }
 
 function Update({ onDone, force, target }: UpdateProps): React.ReactNode {
@@ -115,6 +142,10 @@ function Update({ onDone, force, target }: UpdateProps): React.ReactNode {
         }
 
         // strategy.action === 'npm' — update the local or global npm install.
+        // Clear stale native launchers before any early success path so the
+        // next `openclaude` resolves to the npm install we are updating.
+        await removeStaleNativeLauncherForNpmUpdate()
+
         const via =
           strategy.method === 'global'
             ? await detectGlobalPackageManager()

--- a/src/components/AutoUpdater.test.ts
+++ b/src/components/AutoUpdater.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from 'bun:test'
 import {
   getAutoUpdaterNpmMethod,
+  shouldRemoveInstalledSymlinkForNpmUpdate,
   shouldUseNativeAutoUpdater,
 } from '../utils/autoUpdaterRouting.js'
 
@@ -27,5 +28,21 @@ describe('shouldUseNativeAutoUpdater', () => {
     expect(shouldUseNativeAutoUpdater('native', false)).toBe(false)
     expect(shouldUseNativeAutoUpdater('npm-global', true)).toBe(false)
     expect(shouldUseNativeAutoUpdater('development', true)).toBe(false)
+  })
+})
+
+describe('shouldRemoveInstalledSymlinkForNpmUpdate', () => {
+  test('removes stale native launchers for npm-only builds even with native config', () => {
+    expect(shouldRemoveInstalledSymlinkForNpmUpdate('native', false)).toBe(true)
+  })
+
+  test('preserves native launchers for native-capable builds', () => {
+    expect(shouldRemoveInstalledSymlinkForNpmUpdate('native', true)).toBe(false)
+  })
+
+  test('keeps existing npm-update cleanup for non-native config states', () => {
+    expect(shouldRemoveInstalledSymlinkForNpmUpdate('global', false)).toBe(true)
+    expect(shouldRemoveInstalledSymlinkForNpmUpdate('local', true)).toBe(true)
+    expect(shouldRemoveInstalledSymlinkForNpmUpdate(undefined, true)).toBe(true)
   })
 })

--- a/src/components/AutoUpdater.test.ts
+++ b/src/components/AutoUpdater.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, test } from 'bun:test'
+import {
+  getAutoUpdaterNpmMethod,
+  shouldUseNativeAutoUpdater,
+} from '../utils/autoUpdaterRouting.js'
+
+describe('getAutoUpdaterNpmMethod', () => {
+  test('routes native npm-only builds to the global npm updater', () => {
+    expect(getAutoUpdaterNpmMethod('native', 'native', false)).toBe('global')
+  })
+
+  test('leaves native-distribution builds to NativeAutoUpdater', () => {
+    expect(getAutoUpdaterNpmMethod('native', 'native', true)).toBeNull()
+  })
+
+  test('preserves npm and unknown fallback routing', () => {
+    expect(getAutoUpdaterNpmMethod('npm-local', undefined, false)).toBe('local')
+    expect(getAutoUpdaterNpmMethod('npm-global', undefined, false)).toBe('global')
+    expect(getAutoUpdaterNpmMethod('unknown', 'local', false)).toBe('local')
+    expect(getAutoUpdaterNpmMethod('unknown', undefined, false)).toBe('global')
+  })
+})
+
+describe('shouldUseNativeAutoUpdater', () => {
+  test('only mounts NativeAutoUpdater for native builds with a native distribution', () => {
+    expect(shouldUseNativeAutoUpdater('native', true)).toBe(true)
+    expect(shouldUseNativeAutoUpdater('native', false)).toBe(false)
+    expect(shouldUseNativeAutoUpdater('npm-global', true)).toBe(false)
+    expect(shouldUseNativeAutoUpdater('development', true)).toBe(false)
+  })
+})

--- a/src/components/AutoUpdater.tsx
+++ b/src/components/AutoUpdater.tsx
@@ -5,7 +5,7 @@ import { useInterval } from 'usehooks-ts';
 import { useUpdateNotification } from '../hooks/useUpdateNotification.js';
 import { Box, Text } from '../ink.js';
 import { type AutoUpdaterResult, getLatestVersion, getMaxVersion, type InstallStatus, installGlobalPackage, shouldSkipVersion } from '../utils/autoUpdater.js';
-import { getAutoUpdaterNpmMethod } from '../utils/autoUpdaterRouting.js';
+import { getAutoUpdaterNpmMethod, shouldRemoveInstalledSymlinkForNpmUpdate } from '../utils/autoUpdaterRouting.js';
 import { getGlobalConfig, isAutoUpdaterDisabled } from '../utils/config.js';
 import { logForDebugging } from '../utils/debug.js';
 import { getCurrentInstallationType } from '../utils/doctorDiagnostic.js';
@@ -87,7 +87,12 @@ export function AutoUpdater({
       // Remove native installer symlink since we're using JS-based updates
       // But only if user hasn't migrated to native installation
       const config = getGlobalConfig();
-      if (config.installMethod !== 'native') {
+      if (
+        shouldRemoveInstalledSymlinkForNpmUpdate(
+          config.installMethod,
+          hasNativeDistribution(),
+        )
+      ) {
         await removeInstalledSymlink();
       }
 

--- a/src/components/AutoUpdater.tsx
+++ b/src/components/AutoUpdater.tsx
@@ -5,10 +5,12 @@ import { useInterval } from 'usehooks-ts';
 import { useUpdateNotification } from '../hooks/useUpdateNotification.js';
 import { Box, Text } from '../ink.js';
 import { type AutoUpdaterResult, getLatestVersion, getMaxVersion, type InstallStatus, installGlobalPackage, shouldSkipVersion } from '../utils/autoUpdater.js';
+import { getAutoUpdaterNpmMethod } from '../utils/autoUpdaterRouting.js';
 import { getGlobalConfig, isAutoUpdaterDisabled } from '../utils/config.js';
 import { logForDebugging } from '../utils/debug.js';
 import { getCurrentInstallationType } from '../utils/doctorDiagnostic.js';
 import { installOrUpdateClaudePackage, localInstallationExists } from '../utils/localInstaller.js';
+import { hasNativeDistribution } from '../utils/nativeDistribution.js';
 import { removeInstalledSymlink } from '../utils/nativeInstaller/index.js';
 import { gt, gte } from '../utils/semver.js';
 import { getInitialSettings } from '../utils/settings/settings.js';
@@ -100,18 +102,19 @@ export function AutoUpdater({
         return;
       }
 
-      // Choose the appropriate update method based on what's actually running
       let installStatus: InstallStatus;
-      let updateMethod: 'local' | 'global';
-      if (installationType === 'npm-local') {
+      const updateMethod = getAutoUpdaterNpmMethod(
+        installationType,
+        config.installMethod,
+        hasNativeDistribution(),
+      );
+      if (updateMethod === 'local') {
         // Use local update for local installations
         logForDebugging('AutoUpdater: Using local update method');
-        updateMethod = 'local';
         installStatus = await installOrUpdateClaudePackage(channel);
-      } else if (installationType === 'npm-global') {
+      } else if (updateMethod === 'global') {
         // Use global update for global installations
         logForDebugging('AutoUpdater: Using global update method');
-        updateMethod = 'global';
         installStatus = await installGlobalPackage();
       } else if (installationType === 'native') {
         // This shouldn't happen - native should use NativeAutoUpdater
@@ -119,15 +122,9 @@ export function AutoUpdater({
         onChangeIsUpdating(false);
         return;
       } else {
-        // Fallback to config-based detection for unknown types
-        logForDebugging(`AutoUpdater: Unknown installation type, falling back to config`);
-        const isMigrated = config.installMethod === 'local';
-        updateMethod = isMigrated ? 'local' : 'global';
-        if (isMigrated) {
-          installStatus = await installOrUpdateClaudePackage(channel);
-        } else {
-          installStatus = await installGlobalPackage();
-        }
+        logForDebugging(`AutoUpdater: Cannot auto-update ${installationType} build`);
+        onChangeIsUpdating(false);
+        return;
       }
       onChangeIsUpdating(false);
       if (installStatus === 'success') {

--- a/src/components/AutoUpdaterWrapper.tsx
+++ b/src/components/AutoUpdaterWrapper.tsx
@@ -2,9 +2,11 @@ import { c as _c } from "react-compiler-runtime";
 import { feature } from 'bun:bundle';
 import * as React from 'react';
 import type { AutoUpdaterResult } from '../utils/autoUpdater.js';
+import { shouldUseNativeAutoUpdater } from '../utils/autoUpdaterRouting.js';
 import { isAutoUpdaterDisabled } from '../utils/config.js';
 import { logForDebugging } from '../utils/debug.js';
 import { getCurrentInstallationType } from '../utils/doctorDiagnostic.js';
+import { hasNativeDistribution } from '../utils/nativeDistribution.js';
 import { AutoUpdater } from './AutoUpdater.js';
 import { NativeAutoUpdater } from './NativeAutoUpdater.js';
 import { PackageManagerAutoUpdater } from './PackageManagerAutoUpdater.js';
@@ -39,7 +41,9 @@ export function AutoUpdaterWrapper(t0) {
         }
         const installationType = await getCurrentInstallationType();
         logForDebugging(`AutoUpdaterWrapper: Installation type: ${installationType}`);
-        setUseNativeInstaller(installationType === "native");
+        setUseNativeInstaller(
+          shouldUseNativeAutoUpdater(installationType, hasNativeDistribution()),
+        );
         setIsPackageManager(installationType === "package-manager");
       };
       checkInstallation();

--- a/src/hooks/notifs/npmDeprecationNotification.ts
+++ b/src/hooks/notifs/npmDeprecationNotification.ts
@@ -1,0 +1,41 @@
+import { isInBundledMode } from 'src/utils/bundledMode.js'
+import type { InstallationType } from 'src/utils/doctorDiagnostic.js'
+import { getCurrentInstallationType } from 'src/utils/doctorDiagnostic.js'
+import { isEnvTruthy } from 'src/utils/envUtils.js'
+import { hasNativeDistribution } from 'src/utils/nativeDistribution.js'
+
+const NPM_DEPRECATION_MESSAGE =
+  'OpenClaude has switched from npm to the native installer. Run `openclaude install` or see https://github.com/Gitlawb/openclaude#quick-start for more options.'
+
+export async function getNpmDeprecationNotification(deps: {
+  isBundledMode?: () => boolean
+  installationChecksDisabled?: () => boolean
+  getInstallationType?: () => Promise<InstallationType>
+  hasNativeDistribution?: () => boolean
+} = {}) {
+  const isBundled = deps.isBundledMode ?? isInBundledMode
+  const checksDisabled =
+    deps.installationChecksDisabled ??
+    (() => isEnvTruthy(process.env.DISABLE_INSTALLATION_CHECKS))
+  const getInstallationType =
+    deps.getInstallationType ?? getCurrentInstallationType
+  const nativeDistributionAvailable =
+    deps.hasNativeDistribution ?? hasNativeDistribution
+
+  if (isBundled() || checksDisabled() || !nativeDistributionAvailable()) {
+    return null
+  }
+
+  const installationType = await getInstallationType()
+  if (installationType === 'development') {
+    return null
+  }
+
+  return {
+    timeoutMs: 15000,
+    key: 'npm-deprecation-warning',
+    text: NPM_DEPRECATION_MESSAGE,
+    color: 'warning' as const,
+    priority: 'high' as const,
+  }
+}

--- a/src/hooks/notifs/useNpmDeprecationNotification.test.ts
+++ b/src/hooks/notifs/useNpmDeprecationNotification.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, test } from 'bun:test'
+import { getNpmDeprecationNotification } from './npmDeprecationNotification.js'
+
+describe('getNpmDeprecationNotification', () => {
+  test('does not advertise native install when the build has no native distribution', async () => {
+    await expect(
+      getNpmDeprecationNotification({
+        hasNativeDistribution: () => false,
+        getInstallationType: async () => 'npm-global',
+      }),
+    ).resolves.toBeNull()
+  })
+
+  test('keeps the warning for native-capable npm builds', async () => {
+    const notification = await getNpmDeprecationNotification({
+      hasNativeDistribution: () => true,
+      getInstallationType: async () => 'npm-global',
+      isBundledMode: () => false,
+      installationChecksDisabled: () => false,
+    })
+
+    expect(notification).toMatchObject({
+      key: 'npm-deprecation-warning',
+      priority: 'high',
+    })
+  })
+
+  test('suppresses the warning in bundled mode', async () => {
+    await expect(
+      getNpmDeprecationNotification({
+        hasNativeDistribution: () => true,
+        isBundledMode: () => true,
+        installationChecksDisabled: () => false,
+        getInstallationType: async () => 'npm-global',
+      }),
+    ).resolves.toBeNull()
+  })
+
+  test('suppresses the warning when installation checks are disabled', async () => {
+    await expect(
+      getNpmDeprecationNotification({
+        hasNativeDistribution: () => true,
+        isBundledMode: () => false,
+        installationChecksDisabled: () => true,
+        getInstallationType: async () => 'npm-global',
+      }),
+    ).resolves.toBeNull()
+  })
+
+  test('suppresses the warning for development installations', async () => {
+    await expect(
+      getNpmDeprecationNotification({
+        hasNativeDistribution: () => true,
+        isBundledMode: () => false,
+        installationChecksDisabled: () => false,
+        getInstallationType: async () => 'development',
+      }),
+    ).resolves.toBeNull()
+  })
+})

--- a/src/hooks/notifs/useNpmDeprecationNotification.tsx
+++ b/src/hooks/notifs/useNpmDeprecationNotification.tsx
@@ -1,24 +1,6 @@
-import { isInBundledMode } from 'src/utils/bundledMode.js';
-import { getCurrentInstallationType } from 'src/utils/doctorDiagnostic.js';
-import { isEnvTruthy } from 'src/utils/envUtils.js';
 import { useStartupNotification } from './useStartupNotification.js';
-const NPM_DEPRECATION_MESSAGE = 'OpenClaude has switched from npm to the native installer. Run `openclaude install` or see https://github.com/Gitlawb/openclaude#quick-start for more options.';
+import { getNpmDeprecationNotification } from './npmDeprecationNotification.js';
+
 export function useNpmDeprecationNotification() {
-  useStartupNotification(_temp);
-}
-async function _temp() {
-  if (isInBundledMode() || isEnvTruthy(process.env.DISABLE_INSTALLATION_CHECKS)) {
-    return null;
-  }
-  const installationType = await getCurrentInstallationType();
-  if (installationType === "development") {
-    return null;
-  }
-  return {
-    timeoutMs: 15000,
-    key: "npm-deprecation-warning",
-    text: NPM_DEPRECATION_MESSAGE,
-    color: "warning" as const,
-    priority: "high" as const
-  };
+  useStartupNotification(getNpmDeprecationNotification);
 }

--- a/src/test/mockMacro.ts
+++ b/src/test/mockMacro.ts
@@ -5,13 +5,28 @@ export function withMockMacro<T>(
   const originalMacro = (globalThis as Record<string, unknown>).MACRO
   ;(globalThis as Record<string, unknown>).MACRO = macro
 
-  try {
-    return run()
-  } finally {
+  const restore = () => {
     if (originalMacro === undefined) {
       delete (globalThis as Record<string, unknown>).MACRO
     } else {
       ;(globalThis as Record<string, unknown>).MACRO = originalMacro
     }
+  }
+
+  try {
+    const result = run()
+    if (
+      result !== null &&
+      typeof result === 'object' &&
+      'finally' in result &&
+      typeof result.finally === 'function'
+    ) {
+      return result.finally(restore) as T
+    }
+    restore()
+    return result
+  } catch (error) {
+    restore()
+    throw error
   }
 }

--- a/src/test/mockMacro.ts
+++ b/src/test/mockMacro.ts
@@ -15,4 +15,3 @@ export function withMockMacro<T>(
     }
   }
 }
-

--- a/src/test/mockMacro.ts
+++ b/src/test/mockMacro.ts
@@ -1,0 +1,18 @@
+export function withMockMacro<T>(
+  macro: Record<string, unknown>,
+  run: () => T,
+): T {
+  const originalMacro = (globalThis as Record<string, unknown>).MACRO
+  ;(globalThis as Record<string, unknown>).MACRO = macro
+
+  try {
+    return run()
+  } finally {
+    if (originalMacro === undefined) {
+      delete (globalThis as Record<string, unknown>).MACRO
+    } else {
+      ;(globalThis as Record<string, unknown>).MACRO = originalMacro
+    }
+  }
+}
+

--- a/src/utils/autoUpdaterRouting.ts
+++ b/src/utils/autoUpdaterRouting.ts
@@ -1,0 +1,29 @@
+import type { InstallMethod } from './config.js'
+import type { InstallationType } from './doctorDiagnostic.js'
+
+export function getAutoUpdaterNpmMethod(
+  installationType: InstallationType,
+  configInstallMethod: InstallMethod | undefined,
+  nativeDistributionAvailable: boolean,
+): 'local' | 'global' | null {
+  if (installationType === 'npm-local') {
+    return 'local'
+  }
+  if (installationType === 'npm-global') {
+    return 'global'
+  }
+  if (installationType === 'native') {
+    return nativeDistributionAvailable ? null : 'global'
+  }
+  if (installationType === 'unknown') {
+    return configInstallMethod === 'local' ? 'local' : 'global'
+  }
+  return null
+}
+
+export function shouldUseNativeAutoUpdater(
+  installationType: InstallationType,
+  nativeDistributionAvailable: boolean,
+): boolean {
+  return installationType === 'native' && nativeDistributionAvailable
+}

--- a/src/utils/autoUpdaterRouting.ts
+++ b/src/utils/autoUpdaterRouting.ts
@@ -27,3 +27,10 @@ export function shouldUseNativeAutoUpdater(
 ): boolean {
   return installationType === 'native' && nativeDistributionAvailable
 }
+
+export function shouldRemoveInstalledSymlinkForNpmUpdate(
+  configInstallMethod: InstallMethod | undefined,
+  nativeDistributionAvailable: boolean,
+): boolean {
+  return configInstallMethod !== 'native' || !nativeDistributionAvailable
+}

--- a/src/utils/doctorDiagnostic.test.ts
+++ b/src/utils/doctorDiagnostic.test.ts
@@ -1,0 +1,45 @@
+import { afterEach, describe, expect, test } from 'bun:test'
+import { getNativeInstallUnavailableFix } from './doctorDiagnostic.js'
+
+const originalMacro = (globalThis as Record<string, unknown>).MACRO
+
+afterEach(() => {
+  if (originalMacro === undefined) {
+    delete (globalThis as Record<string, unknown>).MACRO
+  } else {
+    ;(globalThis as Record<string, unknown>).MACRO = originalMacro
+  }
+})
+
+describe('getNativeInstallUnavailableFix', () => {
+  test('uses npm guidance when this build has no native distribution', () => {
+    ;(globalThis as Record<string, unknown>).MACRO = {
+      PACKAGE_URL: '@gitlawb/openclaude',
+    }
+
+    for (const reason of [
+      'local-config',
+      'local-overlap',
+      'global-permissions',
+      'native-config',
+    ] as const) {
+      const fix = getNativeInstallUnavailableFix(reason, false)
+      expect(fix).toContain('npm install -g @gitlawb/openclaude@latest')
+      expect(fix).not.toContain('openclaude install')
+      expect(fix).not.toContain('native installation')
+    }
+  })
+
+  test('preserves native install guidance for native-capable builds', () => {
+    ;(globalThis as Record<string, unknown>).MACRO = {
+      PACKAGE_URL: '@gitlawb/openclaude',
+    }
+
+    expect(getNativeInstallUnavailableFix('local-config', true)).toContain(
+      'openclaude install',
+    )
+    expect(getNativeInstallUnavailableFix('global-permissions', true)).toContain(
+      'native installation',
+    )
+  })
+})

--- a/src/utils/doctorDiagnostic.test.ts
+++ b/src/utils/doctorDiagnostic.test.ts
@@ -1,45 +1,32 @@
-import { afterEach, describe, expect, test } from 'bun:test'
+import { describe, expect, test } from 'bun:test'
+import { withMockMacro } from 'src/test/mockMacro.js'
 import { getNativeInstallUnavailableFix } from './doctorDiagnostic.js'
-
-const originalMacro = (globalThis as Record<string, unknown>).MACRO
-
-afterEach(() => {
-  if (originalMacro === undefined) {
-    delete (globalThis as Record<string, unknown>).MACRO
-  } else {
-    ;(globalThis as Record<string, unknown>).MACRO = originalMacro
-  }
-})
 
 describe('getNativeInstallUnavailableFix', () => {
   test('uses npm guidance when this build has no native distribution', () => {
-    ;(globalThis as Record<string, unknown>).MACRO = {
-      PACKAGE_URL: '@gitlawb/openclaude',
-    }
-
-    for (const reason of [
-      'local-config',
-      'local-overlap',
-      'global-permissions',
-      'native-config',
-    ] as const) {
-      const fix = getNativeInstallUnavailableFix(reason, false)
-      expect(fix).toContain('npm install -g @gitlawb/openclaude@latest')
-      expect(fix).not.toContain('openclaude install')
-      expect(fix).not.toContain('native installation')
-    }
+    withMockMacro({ PACKAGE_URL: '@gitlawb/openclaude' }, () => {
+      for (const reason of [
+        'local-config',
+        'local-overlap',
+        'global-permissions',
+        'native-config',
+      ] as const) {
+        const fix = getNativeInstallUnavailableFix(reason, false)
+        expect(fix).toContain('npm install -g @gitlawb/openclaude@latest')
+        expect(fix).not.toContain('openclaude install')
+        expect(fix).not.toContain('native installation')
+      }
+    })
   })
 
   test('preserves native install guidance for native-capable builds', () => {
-    ;(globalThis as Record<string, unknown>).MACRO = {
-      PACKAGE_URL: '@gitlawb/openclaude',
-    }
-
-    expect(getNativeInstallUnavailableFix('local-config', true)).toContain(
-      'openclaude install',
-    )
-    expect(getNativeInstallUnavailableFix('global-permissions', true)).toContain(
-      'native installation',
-    )
+    withMockMacro({ PACKAGE_URL: '@gitlawb/openclaude' }, () => {
+      expect(getNativeInstallUnavailableFix('local-config', true)).toContain(
+        'openclaude install',
+      )
+      expect(
+        getNativeInstallUnavailableFix('global-permissions', true),
+      ).toContain('native installation')
+    })
   })
 })

--- a/src/utils/doctorDiagnostic.ts
+++ b/src/utils/doctorDiagnostic.ts
@@ -31,6 +31,7 @@ import {
   detectWinget,
   getPackageManager,
 } from './nativeInstaller/packageManagers.js'
+import { hasNativeDistribution } from './nativeDistribution.js'
 import { getPlatform } from './platform.js'
 import { getRipgrepStatus } from './ripgrep.js'
 import { SandboxManager } from './sandbox/sandbox-adapter.js'
@@ -52,6 +53,41 @@ function getCliBinaryName(): string {
 
 function getNativeDataDirName(): string {
   return getCliBinaryName()
+}
+
+function getNpmUpdateCommand(): string {
+  return `npm install -g ${MACRO.PACKAGE_URL}@latest`
+}
+
+export function getNativeInstallUnavailableFix(
+  fallback:
+    | 'local-config'
+    | 'local-overlap'
+    | 'global-permissions'
+    | 'native-config',
+  nativeDistributionAvailable: boolean = hasNativeDistribution(),
+): string {
+  if (nativeDistributionAvailable) {
+    switch (fallback) {
+      case 'native-config':
+        return `Run ${getCliBinaryName()} install to update configuration`
+      case 'global-permissions':
+        return `Do one of: (1) Re-install node without sudo, or (2) Use \`${getCliBinaryName()} install\` for native installation`
+      default:
+        return `Consider using native installation: ${getCliBinaryName()} install`
+    }
+  }
+
+  switch (fallback) {
+    case 'local-config':
+      return `Run ${getCliBinaryName()} update to refresh the install method, or update manually with: ${getNpmUpdateCommand()}`
+    case 'local-overlap':
+      return `Use the local install at ~/.openclaude/local/${getCliBinaryName()}, remove it, or update the global npm package with: ${getNpmUpdateCommand()}`
+    case 'global-permissions':
+      return `Do one of: (1) Re-install node without sudo, or (2) Update manually with: ${getNpmUpdateCommand()}`
+    case 'native-config':
+      return `This build has no native binary; set installMethod to 'global' or reinstall with: ${getNpmUpdateCommand()}`
+  }
 }
 
 export type InstallationType =
@@ -480,14 +516,14 @@ async function detectConfigurationIssues(
     if (type === 'npm-local' && config.installMethod !== 'local') {
       warnings.push({
         issue: `Running from local installation but config install method is '${config.installMethod}'`,
-        fix: `Consider using native installation: ${getCliBinaryName()} install`,
+        fix: getNativeInstallUnavailableFix('local-config'),
       })
     }
 
     if (type === 'native' && config.installMethod !== 'native') {
       warnings.push({
         issue: `Running native installation but config install method is '${config.installMethod}'`,
-        fix: `Run ${getCliBinaryName()} install to update configuration`,
+        fix: getNativeInstallUnavailableFix('native-config'),
       })
     }
   }
@@ -495,7 +531,7 @@ async function detectConfigurationIssues(
   if (type === 'npm-global' && (await localInstallationExists())) {
     warnings.push({
       issue: 'Local installation exists but not being used',
-      fix: `Consider using native installation: ${getCliBinaryName()} install`,
+      fix: getNativeInstallUnavailableFix('local-overlap'),
     })
   }
 
@@ -620,7 +656,7 @@ export async function getDoctorDiagnostic(): Promise<DiagnosticInfo> {
     if (!hasUpdatePermissions && !getAutoUpdaterDisabledReason()) {
       warnings.push({
         issue: 'Insufficient permissions for auto-updates',
-        fix: `Do one of: (1) Re-install node without sudo, or (2) Use \`${getCliBinaryName()} install\` for native installation`,
+        fix: getNativeInstallUnavailableFix('global-permissions'),
       })
     }
   }

--- a/src/utils/nativeDistribution.ts
+++ b/src/utils/nativeDistribution.ts
@@ -1,0 +1,21 @@
+/**
+ * True when this build ships its own native binary distribution, i.e. the
+ * build-time `MACRO.NATIVE_PACKAGE_URL` define is set.
+ *
+ * OpenClaude (`@gitlawb/openclaude`) is distributed only as an npm package and
+ * sets `NATIVE_PACKAGE_URL` to `undefined` in both define blocks of
+ * `scripts/build.ts`. Without this gate, the native installer inherited from
+ * upstream downloads the first-party Claude Code binary from Anthropic's GCS
+ * bucket, symlinks the launcher to it, and uninstalls the npm package the user
+ * is actually running. Every native-installer surface (binary download,
+ * launcher symlink, npm cleanup, native auto-update) must stay inert unless
+ * this returns true.
+ *
+ * Bun's `define` inlines the member expression, so in npm-only builds the
+ * guarded branches are statically dead and get stripped by DCE. Re-enabling
+ * native installs later only requires setting `NATIVE_PACKAGE_URL` at build
+ * time — no code changes.
+ */
+export function hasNativeDistribution(): boolean {
+  return MACRO.NATIVE_PACKAGE_URL !== undefined
+}

--- a/src/utils/nativeInstaller/installer.ts
+++ b/src/utils/nativeInstaller/installer.ts
@@ -47,6 +47,7 @@ import { execFileNoThrowWithCwd } from '../execFileNoThrow.js'
 import { getShellType } from '../localInstaller.js'
 import * as lockfile from '../lockfile.js'
 import { logError } from '../log.js'
+import { hasNativeDistribution } from '../nativeDistribution.js'
 import { gt, gte } from '../semver.js'
 import {
   filterClaudeAliases,
@@ -499,6 +500,13 @@ async function versionIsAvailable(version: string): Promise<boolean> {
 }
 
 export async function repairNativeLauncher(version: string): Promise<void> {
+  if (!hasNativeDistribution()) {
+    logForDebugging(
+      'Native installer: no native distribution; skipping launcher repair',
+    )
+    return
+  }
+
   const dirs = getBaseDirectories()
   const installPath = join(dirs.versions, version)
 
@@ -830,6 +838,13 @@ export async function checkInstall(
     return []
   }
 
+  // npm-only builds have no native launcher to validate — a leftover
+  // installMethod:'native' config from a previous build would otherwise
+  // produce "command not found at ~/.local/bin/…" warnings every session.
+  if (!hasNativeDistribution()) {
+    return []
+  }
+
   // Get the actual installation type and config
   const installationType = await getCurrentInstallationType()
 
@@ -1002,6 +1017,13 @@ async function installLatestImpl(
   channelOrVersion: string,
   forceReinstall: boolean = false,
 ): Promise<InstallLatestResult> {
+  if (!hasNativeDistribution()) {
+    logForDebugging(
+      'Native installer: this build has no native distribution (NATIVE_PACKAGE_URL unset); skipping native install',
+    )
+    return { latestVersion: null, wasUpdated: false, lockFailed: false }
+  }
+
   const updateResult = await updateLatest(channelOrVersion, forceReinstall)
 
   if (!updateResult.success) {
@@ -1209,6 +1231,19 @@ async function forceRemoveLock(versionFilePath: string): Promise<void> {
 export async function cleanupOldVersions(): Promise<void> {
   // Yield to ensure we don't block startup
   await Promise.resolve()
+
+  // The versions/staging/locks directories live under the shared
+  // ~/.local/share/claude (etc.) paths, so on a machine that also has the
+  // first-party native Claude Code installed they hold THAT product's version
+  // binaries. An npm-only build must not garbage-collect them: the protection
+  // logic only recognizes its own launcher symlink, so it would delete
+  // binaries a coexisting `claude` launcher still points to.
+  if (!hasNativeDistribution()) {
+    logForDebugging(
+      'Native installer: no native distribution; skipping version cleanup',
+    )
+    return
+  }
 
   const dirs = getBaseDirectories()
   const oneHourAgo = Date.now() - 3600000
@@ -1693,6 +1728,15 @@ export async function cleanupNpmInstallations(): Promise<{
   errors: string[]
   warnings: string[]
 }> {
+  if (!hasNativeDistribution()) {
+    // npm IS the distribution for this build — uninstalling it would remove
+    // the copy the user is running.
+    logForDebugging(
+      'Native installer: no native distribution; keeping npm installation in place',
+    )
+    return { removed: 0, errors: [], warnings: [] }
+  }
+
   const errors: string[] = []
   const warnings: string[] = []
   let removed = 0

--- a/src/utils/openclaudeInstallSurfaces.test.ts
+++ b/src/utils/openclaudeInstallSurfaces.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, expect, mock, test } from 'bun:test'
 import { PassThrough } from 'node:stream'
 import * as fsPromises from 'fs/promises'
-import { homedir } from 'os'
+import { homedir, tmpdir } from 'os'
 import { join } from 'path'
 import { createElement } from 'react'
 import {
@@ -11,9 +11,18 @@ import {
 import * as realEnv from './env.js'
 import * as realEnvUtils from './envUtils.js'
 import * as realExecFileNoThrow from './execFileNoThrow.js'
+import * as realDownload from './nativeInstaller/download.js'
 
 const originalEnv = { ...process.env }
 const originalMacro = (globalThis as Record<string, unknown>).MACRO
+
+function restoreEnvVar(name: string, value: string | undefined): void {
+  if (value === undefined) {
+    delete process.env[name]
+  } else {
+    process.env[name] = value
+  }
+}
 
 // Snapshot the real execFileNoThrow module BEFORE installing the mock below.
 // bun live-updates the `realExecFileNoThrow` namespace to point at the mock once
@@ -34,6 +43,35 @@ let simulateNpmUninstallFailure = false
 let simulateNpmUninstallEnotempty = false
 let fakeNpmPrefix: string | undefined
 const npmUninstallPackages: string[] = []
+
+// Same persisted-mock pattern for the GCS download module: the native-gate
+// tests must never hit the real binary distribution, so while
+// `recordedDownloadCalls` is set the stubs record and short-circuit; otherwise
+// they fall through to the real implementations.
+const realDownloadModule = { ...realDownload }
+let recordedDownloadCalls: string[] | null = null
+
+mock.module('./nativeInstaller/download.js', () => ({
+  ...realDownloadModule,
+  getLatestVersion: (
+    ...args: Parameters<typeof realDownload.getLatestVersion>
+  ) => {
+    if (recordedDownloadCalls) {
+      recordedDownloadCalls.push('getLatestVersion')
+      return Promise.resolve('9.9.9')
+    }
+    return realDownloadModule.getLatestVersion(...args)
+  },
+  downloadVersion: (
+    ...args: Parameters<typeof realDownload.downloadVersion>
+  ) => {
+    if (recordedDownloadCalls) {
+      recordedDownloadCalls.push('downloadVersion')
+      return Promise.resolve()
+    }
+    return realDownloadModule.downloadVersion(...args)
+  },
+}))
 
 mock.module('./execFileNoThrow.js', () => ({
   ...realExecFileNoThrowModule,
@@ -90,6 +128,7 @@ afterEach(() => {
     simulateNpmUninstallEnotempty = false
     fakeNpmPrefix = undefined
     npmUninstallPackages.length = 0
+    recordedDownloadCalls = null
     mock.restore()
     mock.module('../utils/env.js', () => realEnv)
     mock.module('./envUtils.js', () => realEnvUtils)
@@ -173,6 +212,14 @@ test('deep-link protocol resolver uses openclaude launcher for OpenClaude packag
 })
 
 test('install command repairs launcher after npm cleanup before final check', async () => {
+  // A native distribution must be configured for the native install flow to
+  // run at all; without it the command short-circuits to the npm-only path.
+  ;(globalThis as Record<string, unknown>).MACRO = {
+    PACKAGE_URL: '@gitlawb/openclaude',
+    NATIVE_PACKAGE_URL: '@gitlawb/openclaude-native',
+    DISPLAY_VERSION: '0.0.0-test',
+  }
+
   const calls: string[] = []
   let repairCompleted = false
 
@@ -253,34 +300,33 @@ test('install command repairs launcher after npm cleanup before final check', as
 })
 
 test('cleanupNpmInstallations removes only openclaude local install dir', async () => {
-  const removedPaths: string[] = []
+  const testHome = await fsPromises.mkdtemp(join(tmpdir(), 'openclaude-cleanup-'))
+  const openClaudeLocalDir = join(testHome, '.openclaude', 'local')
+  const claudeLocalDir = join(testHome, '.claude', 'local')
   ;(globalThis as Record<string, unknown>).MACRO = {
     PACKAGE_URL: '@gitlawb/openclaude',
+    NATIVE_PACKAGE_URL: '@gitlawb/openclaude-native',
   }
-  process.env.OPENCLAUDE_CONFIG_DIR = join(homedir(), '.openclaude')
+  process.env.HOME = testHome
+  process.env.USERPROFILE = testHome
+  process.env.OPENCLAUDE_CONFIG_DIR = join(testHome, '.openclaude')
   delete process.env.CLAUDE_CONFIG_DIR
-
-  mock.module('fs/promises', () => ({
-    ...fsPromises,
-    rm: async (path: string) => {
-      removedPaths.push(path)
-    },
-  }))
+  await fsPromises.mkdir(openClaudeLocalDir, { recursive: true })
+  await fsPromises.mkdir(claudeLocalDir, { recursive: true })
 
   simulateNpmUninstallFailure = true
 
-  mock.module('./envUtils.js', () => ({
-    ...realEnvUtils,
-    getClaudeConfigHomeDir: () => join(homedir(), '.openclaude'),
-  }))
+  try {
+    const { cleanupNpmInstallations } = await importFreshInstaller()
+    await cleanupNpmInstallations()
 
-  const { cleanupNpmInstallations } = await importFreshInstaller()
-  await cleanupNpmInstallations()
-
-  expect(removedPaths).toContain(join(homedir(), '.openclaude', 'local'))
-  expect(removedPaths).not.toContain(join(homedir(), '.claude', 'local'))
-  expect(npmUninstallPackages).toContain('@gitlawb/openclaude')
-  expect(npmUninstallPackages).not.toContain('@anthropic-ai/claude-code')
+    await expect(fsPromises.stat(openClaudeLocalDir)).rejects.toThrow()
+    await expect(fsPromises.stat(claudeLocalDir)).resolves.toBeTruthy()
+    expect(npmUninstallPackages).toContain('@gitlawb/openclaude')
+    expect(npmUninstallPackages).not.toContain('@anthropic-ai/claude-code')
+  } finally {
+    await fsPromises.rm(testHome, { recursive: true, force: true })
+  }
 })
 
 test('cleanupNpmInstallations manual fallback removes openclaude npm shim', async () => {
@@ -291,6 +337,7 @@ test('cleanupNpmInstallations manual fallback removes openclaude npm shim', asyn
   const shimPath = join(npmPrefix, 'bin', 'openclaude')
   ;(globalThis as Record<string, unknown>).MACRO = {
     PACKAGE_URL: '@gitlawb/openclaude',
+    NATIVE_PACKAGE_URL: '@gitlawb/openclaude-native',
   }
   process.env.HOME = testHome
   process.env.USERPROFILE = testHome
@@ -310,4 +357,197 @@ test('cleanupNpmInstallations manual fallback removes openclaude npm shim', asyn
   } finally {
     await fsPromises.rm(testHome, { recursive: true, force: true })
   }
+})
+
+// ---------------------------------------------------------------------------
+// npm-only builds (NATIVE_PACKAGE_URL unset): every native-installer surface
+// must stay inert. Without these gates, `openclaude install` downloads the
+// first-party Claude Code binary from the GCS bucket, symlinks
+// ~/.local/bin/openclaude to it, and uninstalls the npm package the user is
+// actually running.
+// ---------------------------------------------------------------------------
+
+test('installLatest is inert without a native distribution', async () => {
+  ;(globalThis as Record<string, unknown>).MACRO = {
+    PACKAGE_URL: '@gitlawb/openclaude',
+    NATIVE_PACKAGE_URL: undefined,
+  }
+  recordedDownloadCalls = []
+
+  const { installLatest } = await importFreshInstaller()
+  const result = await installLatest('latest', true)
+
+  expect(result).toEqual({
+    latestVersion: null,
+    wasUpdated: false,
+    lockFailed: false,
+  })
+  expect(recordedDownloadCalls).toEqual([])
+})
+
+test('repairNativeLauncher is inert without a native distribution', async () => {
+  ;(globalThis as Record<string, unknown>).MACRO = {
+    PACKAGE_URL: '@gitlawb/openclaude',
+    NATIVE_PACKAGE_URL: undefined,
+  }
+
+  const { repairNativeLauncher } = await importFreshInstaller()
+
+  // Would otherwise throw: the version is not installed, and repairing would
+  // recreate the ~/.local/bin symlink.
+  await expect(repairNativeLauncher('0.0.0-gate-test')).resolves.toBeUndefined()
+})
+
+test('cleanupNpmInstallations keeps the npm install without a native distribution', async () => {
+  const testHome = await fsPromises.mkdtemp(join(tmpdir(), 'openclaude-npm-only-'))
+  const openClaudeLocalDir = join(testHome, '.openclaude', 'local')
+  ;(globalThis as Record<string, unknown>).MACRO = {
+    PACKAGE_URL: '@gitlawb/openclaude',
+    NATIVE_PACKAGE_URL: undefined,
+  }
+  process.env.HOME = testHome
+  process.env.USERPROFILE = testHome
+  process.env.OPENCLAUDE_CONFIG_DIR = join(testHome, '.openclaude')
+  await fsPromises.mkdir(openClaudeLocalDir, { recursive: true })
+  // If the gate regressed, uninstalls would run and surface as errors here
+  // instead of hitting the machine's real npm prefix.
+  simulateNpmUninstallFailure = true
+
+  try {
+    const { cleanupNpmInstallations } = await importFreshInstaller()
+    const result = await cleanupNpmInstallations()
+
+    expect(result).toEqual({ removed: 0, errors: [], warnings: [] })
+    await expect(fsPromises.stat(openClaudeLocalDir)).resolves.toBeTruthy()
+  } finally {
+    await fsPromises.rm(testHome, { recursive: true, force: true })
+  }
+})
+
+test('checkInstall reports nothing without a native distribution', async () => {
+  ;(globalThis as Record<string, unknown>).MACRO = {
+    PACKAGE_URL: '@gitlawb/openclaude',
+    NATIVE_PACKAGE_URL: undefined,
+  }
+  delete process.env.DISABLE_INSTALLATION_CHECKS
+
+  const { checkInstall } = await importFreshInstaller()
+
+  expect(await checkInstall(true)).toEqual([])
+})
+
+test('cleanupOldVersions leaves the shared versions directory alone without a native distribution', async () => {
+  ;(globalThis as Record<string, unknown>).MACRO = {
+    PACKAGE_URL: '@gitlawb/openclaude',
+    NATIVE_PACKAGE_URL: undefined,
+  }
+
+  // The versions store under XDG data home is shared with the first-party
+  // native Claude Code install. Redirect all XDG roots to a temp dir and
+  // plant more unprotected version binaries than VERSION_RETENTION_COUNT:
+  // an ungated cleanup would delete all but the newest two.
+  const xdgRoot = await fsPromises.mkdtemp(join(tmpdir(), 'openclaude-xdg-'))
+  const versionsDir = join(xdgRoot, 'data', 'claude', 'versions')
+  await fsPromises.mkdir(versionsDir, { recursive: true })
+  const versions = ['1.0.0', '1.0.1', '1.0.2', '1.0.3']
+  for (const version of versions) {
+    await fsPromises.writeFile(join(versionsDir, version), '#!/bin/sh\n', {
+      mode: 0o755,
+    })
+  }
+  const previousXdgDataHome = process.env.XDG_DATA_HOME
+  const previousXdgCacheHome = process.env.XDG_CACHE_HOME
+  const previousXdgStateHome = process.env.XDG_STATE_HOME
+  process.env.XDG_DATA_HOME = join(xdgRoot, 'data')
+  process.env.XDG_CACHE_HOME = join(xdgRoot, 'cache')
+  process.env.XDG_STATE_HOME = join(xdgRoot, 'state')
+
+  try {
+    const { cleanupOldVersions } = await importFreshInstaller()
+    await cleanupOldVersions()
+
+    expect((await fsPromises.readdir(versionsDir)).sort()).toEqual(versions)
+  } finally {
+    await fsPromises.rm(xdgRoot, { recursive: true, force: true })
+    restoreEnvVar('XDG_DATA_HOME', previousXdgDataHome)
+    restoreEnvVar('XDG_CACHE_HOME', previousXdgCacheHome)
+    restoreEnvVar('XDG_STATE_HOME', previousXdgStateHome)
+  }
+})
+
+test('install command skips the native installer without a native distribution', async () => {
+  ;(globalThis as Record<string, unknown>).MACRO = {
+    PACKAGE_URL: '@gitlawb/openclaude',
+    NATIVE_PACKAGE_URL: undefined,
+    DISPLAY_VERSION: '0.0.0-test',
+  }
+
+  const calls: string[] = []
+
+  const stdout = new PassThrough()
+  const stdin = new PassThrough() as PassThrough & {
+    isTTY: boolean
+    setRawMode: (mode: boolean) => void
+    ref: () => void
+    unref: () => void
+  }
+  stdin.isTTY = true
+  stdin.setRawMode = () => {}
+  stdin.ref = () => {}
+  stdin.unref = () => {}
+
+  mock.module('../utils/nativeInstaller/index.js', () => ({
+    installLatest: async () => {
+      calls.push('installLatest')
+      return { latestVersion: '1.2.3', wasUpdated: true, lockFailed: false }
+    },
+    cleanupNpmInstallations: async () => {
+      calls.push('cleanupNpmInstallations')
+      return { removed: 1, errors: [], warnings: [] }
+    },
+    repairNativeLauncher: async (version: string) => {
+      calls.push('repairNativeLauncher:' + version)
+    },
+    checkInstall: async (setup: boolean) => {
+      calls.push('checkInstall:' + setup)
+      return []
+    },
+    cleanupShellAliases: async () => {
+      calls.push('cleanupShellAliases')
+      return []
+    },
+  }))
+
+  const [{ Install }, { render }] = await Promise.all([
+    importFreshInstallCommand(),
+    import(`../ink.js?ts=${Date.now()}-${Math.random()}`),
+  ])
+  const done = new Promise<void>((resolve, reject) => {
+    void render(
+      createElement(Install, {
+        onDone: (result: string) => {
+          try {
+            expect(result).toBe('OpenClaude installation completed successfully')
+            resolve()
+          } catch (error) {
+            reject(error)
+          }
+        },
+      }),
+      {
+        stdout: stdout as unknown as NodeJS.WriteStream,
+        stdin: stdin as unknown as NodeJS.ReadStream,
+        patchConsole: false,
+      },
+    ).catch(reject)
+  })
+
+  try {
+    await done
+  } finally {
+    stdin.end()
+    stdout.end()
+  }
+
+  expect(calls).toEqual([])
 })

--- a/src/utils/updateStrategy.test.ts
+++ b/src/utils/updateStrategy.test.ts
@@ -39,6 +39,7 @@ describe('planUpdate', () => {
     thirdPartyBlocked: false,
     packageManager: 'unknown' as PackageManager,
     localInstallExists: false,
+    nativeDistributionAvailable: true,
   }
 
   test('third-party build is blocked regardless of installation type', () => {
@@ -73,6 +74,16 @@ describe('planUpdate', () => {
     expect(planUpdate({ ...base, installationType: 'native' })).toEqual({
       action: 'native',
     })
+  })
+
+  test('native install routes to npm when the build has no native distribution', () => {
+    expect(
+      planUpdate({
+        ...base,
+        installationType: 'native',
+        nativeDistributionAvailable: false,
+      }),
+    ).toEqual({ action: 'npm', method: 'global' })
   })
 
   test('npm-local and npm-global route to their npm method', () => {
@@ -136,6 +147,7 @@ describe('resolveUpdateStrategy', () => {
           calls.localInstall++
           return true
         }),
+      hasNativeDistribution: overrides.hasNativeDistribution ?? (() => true),
     }
     return { deps, calls }
   }
@@ -167,6 +179,17 @@ describe('resolveUpdateStrategy', () => {
     })
     expect(calls.localInstall).toBe(1)
     expect(calls.packageManager).toBe(0)
+  })
+
+  test('routes a native install to npm when the build has no native distribution', async () => {
+    const { deps } = makeDeps({
+      installationType: 'native',
+      hasNativeDistribution: () => false,
+    })
+    expect(await resolveUpdateStrategy(deps)).toEqual({
+      action: 'npm',
+      method: 'global',
+    })
   })
 
   test('routes a global npm install without extra probes', async () => {

--- a/src/utils/updateStrategy.ts
+++ b/src/utils/updateStrategy.ts
@@ -2,6 +2,7 @@ import type { DiagnosticInfo, InstallationType } from './doctorDiagnostic.js'
 import { getDoctorDiagnostic } from './doctorDiagnostic.js'
 import { localInstallationExists } from './localInstaller.js'
 import { type LegacyAPIProvider, getAPIProvider } from './model/providers.js'
+import { hasNativeDistribution } from './nativeDistribution.js'
 import type { PackageManager } from './nativeInstaller/packageManagers.js'
 import { getPackageManager } from './nativeInstaller/packageManagers.js'
 
@@ -56,6 +57,7 @@ export type UpdateStrategyDeps = {
   getDiagnostic: () => Promise<DiagnosticInfo>
   getPackageManager: () => Promise<PackageManager>
   localInstallationExists: () => Promise<boolean>
+  hasNativeDistribution: () => boolean
 }
 
 const defaultDeps: UpdateStrategyDeps = {
@@ -63,6 +65,7 @@ const defaultDeps: UpdateStrategyDeps = {
   getDiagnostic: getDoctorDiagnostic,
   getPackageManager,
   localInstallationExists,
+  hasNativeDistribution,
 }
 
 /**
@@ -76,6 +79,7 @@ export function planUpdate(input: {
   installationType: InstallationType
   packageManager: PackageManager
   localInstallExists: boolean
+  nativeDistributionAvailable: boolean
 }): UpdateStrategy {
   if (input.thirdPartyBlocked) {
     return { action: 'blocked', reason: 'third-party-build' }
@@ -86,7 +90,11 @@ export function planUpdate(input: {
     case 'package-manager':
       return { action: 'package-manager', manager: input.packageManager }
     case 'native':
-      return { action: 'native' }
+      // npm-only builds must never route to the native installer — it would
+      // download the first-party binary this build does not ship.
+      return input.nativeDistributionAvailable
+        ? { action: 'native' }
+        : { action: 'npm', method: 'global' }
     case 'npm-local':
       return { action: 'npm', method: 'local' }
     case 'npm-global':
@@ -117,6 +125,7 @@ export async function resolveUpdateStrategy(
   return planUpdate({
     thirdPartyBlocked: false,
     installationType,
+    nativeDistributionAvailable: deps.hasNativeDistribution(),
     packageManager:
       installationType === 'package-manager'
         ? await deps.getPackageManager()


### PR DESCRIPTION
## Summary

- what changed: Gated every native-installer surface behind a new `hasNativeDistribution()` predicate (`src/utils/nativeDistribution.ts`, keyed off the build-time `MACRO.NATIVE_PACKAGE_URL` define). Guards added in `installer.ts` (`installLatestImpl`, `repairNativeLauncher`, `cleanupNpmInstallations`, `checkInstall`), `openclaude install` now short-circuits to an npm-mode report, `AutoUpdaterWrapper` never mounts `NativeAutoUpdater` in npm-only builds, and `openclaude update` / `updateStrategy.planUpdate` route native-looking installs to the npm updater.
- why it changed: OpenClaude ships only as an npm package, but the native installer inherited from upstream still pointed at the first-party distribution. Running `openclaude install` downloaded the real Claude Code binary from Anthropic's GCS bucket, symlinked `~/.local/bin/openclaude` to it (so `openclaude` launched Claude Code), and uninstalled the `@gitlawb/openclaude` package the user was running. The `NativeAutoUpdater` retried the same download every 30 minutes.

## Impact

- user-facing impact: `openclaude install` no longer hijacks the command to Claude Code or deletes the working npm install — it reports the current npm installation and how to update. Stale `installMethod: "native"` configs no longer produce "command not found at ~/.local/bin/…" warnings each session. `openclaude update` updates via npm.
- developer/maintainer impact: One predicate (`hasNativeDistribution()`) controls the entire native path. If OpenClaude ever ships its own native binaries, setting `NATIVE_PACKAGE_URL` in both define blocks of `scripts/build.ts` re-enables the original flow unchanged. Bun's `define` inlines the check, so the guarded branches are DCE-stripped from npm-only builds.

## Testing

- [x] `bun run build`
- [x] `bun run smoke`
- [x] `bun run check` — smoke + deadcode pass; `test:full` shows 30 failures that are byte-identical on `main` (pre-existing provider/API-shim mock leaks, unrelated to this change). This branch adds 7 tests, all passing; zero new failures.
- [x] focused tests: `bun test src/utils/openclaudeInstallSurfaces.test.ts src/utils/updateStrategy.test.ts src/components/NativeAutoUpdater.test.ts src/screens/doctorDistTags.test.ts` → 36 pass, 0 fail. Includes 5 new gate tests asserting: no GCS download calls, no launcher symlink writes, npm install never uninstalled, `checkInstall` silent, and the install command skips the native installer entirely. `tsc --noEmit` clean.

## Notes

- provider/model path tested: n/a — no provider/model code touched. End-to-end verified the CLI install surface instead: `HOME=$(mktemp -d) node dist/cli.mjs install` prints the npm-mode message and leaves no `~/.local/share/claude/versions/` dir, no `~/.local/bin/openclaude` symlink, and makes no GCS fetch.
- screenshots attached (if UI changed): n/a — terminal output only; the new `install` output shows version, real location, and `npm install -g @gitlawb/openclaude@latest` update hint.
- follow-up work or known limitations: `getCurrentInstallationType()` can still classify a session as `native` (it describes the running binary and is used by diagnostics — intentionally untouched); all consumers that act on it are now gated. If a native OpenClaude distribution ships later, flip `NATIVE_PACKAGE_URL` in both `scripts/build.ts` define blocks — no code changes needed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Native distribution detection now drives update, install, and auto-updater routing, with clear npm-only fallback behavior.
  * Install success can display an optional “Location” and provides npm upgrade instructions when native isn’t available.
  * Npm deprecation notifications and diagnostic “install unavailable” fixes are tailored to native availability.

* **Bug Fixes**
  * Prevented native maintenance, cleanup, and symlink repair from running on npm-only builds; centralized global update failure guidance.

* **Tests**
  * Added/expanded coverage and mocks for native vs npm-only routing and messaging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->