### PR TITLE
fix(plugins): match reserved-marketplace git URL owner by host, not substring

### DIFF
--- a/src/utils/plugins/schemas.ts
+++ b/src/utils/plugins/schemas.ts
@@ -116,6 +116,48 @@ export const OFFICIAL_GITHUB_ORG = 'anthropics'
  * @param source - The marketplace source configuration
  * @returns An error message if validation fails, or null if valid
  */
+/**
+ * True only when a git URL genuinely targets the official org on github.com.
+ *
+ * Uses exact host + first-path-segment matching, not a substring check: a
+ * substring like `url.includes('github.com/anthropics/')` also matches hostile
+ * URLs such as `https://notgithub.com/anthropics/x` or
+ * `https://evil.com/github.com/anthropics/x`, which would let an attacker claim
+ * a reserved official-marketplace name from a repo they control.
+ */
+function isOfficialAnthropicsGitUrl(rawUrl: string): boolean {
+  const trimmed = rawUrl.trim()
+  if (!trimmed) {
+    return false
+  }
+
+  // scp-like SSH form: git@github.com:anthropics/<repo> (has no scheme).
+  if (!trimmed.includes('://')) {
+    const scp = /^[^@\s]+@([^:\s]+):(.+)$/.exec(trimmed)
+    if (scp) {
+      const host = scp[1]!.toLowerCase()
+      const firstSegment = scp[2]!.replace(/^\/+/, '').split('/')[0]?.toLowerCase()
+      return host === 'github.com' && firstSegment === OFFICIAL_GITHUB_ORG
+    }
+    return false
+  }
+
+  // Scheme forms: https://, http://, ssh://git@github.com/anthropics/<repo>.
+  try {
+    const parsed = new URL(trimmed)
+    if (parsed.hostname.toLowerCase() !== 'github.com') {
+      return false
+    }
+    const firstSegment = parsed.pathname
+      .replace(/^\/+/, '')
+      .split('/')[0]
+      ?.toLowerCase()
+    return firstSegment === OFFICIAL_GITHUB_ORG
+  } catch {
+    return false
+  }
+}
+
 export function validateOfficialNameSource(
   name: string,
   source: { source: string; repo?: string; url?: string },
@@ -139,13 +181,7 @@ export function validateOfficialNameSource(
 
   // Check for git URL source type
   if (source.source === 'git' && source.url) {
-    const url = source.url.toLowerCase()
-    // Check for HTTPS URL format: https://github.com/anthropics/...
-    // or SSH format: git@github.com:anthropics/...
-    const isHttpsAnthropics = url.includes('github.com/anthropics/')
-    const isSshAnthropics = url.includes('git@github.com:anthropics/')
-
-    if (isHttpsAnthropics || isSshAnthropics) {
+    if (isOfficialAnthropicsGitUrl(source.url)) {
       return null // Valid: reserved name from official git URL
     }
 

--- a/src/utils/plugins/validateOfficialNameSource.test.ts
+++ b/src/utils/plugins/validateOfficialNameSource.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, test } from 'bun:test'
+import {
+  OFFICIAL_GITHUB_ORG,
+  validateOfficialNameSource,
+} from './schemas.js'
+
+const RESERVED = 'claude-code-marketplace'
+
+// Regression: the git-URL branch validated official ownership with a substring
+// check (`url.includes('github.com/anthropics/')`), which also matches hostile
+// URLs whose host is not github.com or where that text appears in the path. An
+// attacker could then register a repo they control under a reserved official
+// marketplace name. Ownership must be decided by the exact host + first path
+// segment. Same class as the xai/bridge substring-host fixes.
+describe('validateOfficialNameSource — git URL host is matched exactly', () => {
+  function gitUrl(url: string) {
+    return validateOfficialNameSource(RESERVED, { source: 'git', url })
+  }
+
+  // Genuine official URLs are accepted (null = no error).
+  test('accepts official github.com/anthropics URLs (https, .git, ssh, scp)', () => {
+    expect(gitUrl('https://github.com/anthropics/marketplace')).toBeNull()
+    expect(gitUrl('https://github.com/anthropics/marketplace.git')).toBeNull()
+    expect(gitUrl('https://user@github.com/anthropics/marketplace')).toBeNull()
+    expect(gitUrl('ssh://git@github.com/anthropics/marketplace.git')).toBeNull()
+    expect(gitUrl('git@github.com:anthropics/marketplace.git')).toBeNull()
+    // Host + org are case-insensitive.
+    expect(gitUrl('https://GitHub.com/Anthropics/marketplace')).toBeNull()
+  })
+
+  // Hostile URLs that the old substring check let through must now be rejected.
+  const bypasses = [
+    'https://notgithub.com/anthropics/evil',
+    'https://evil.com/github.com/anthropics/evil',
+    'https://github.com.attacker.com/anthropics/evil',
+    'https://evilgithub.com/anthropics/evil',
+    'git@notgithub.com:anthropics/evil.git',
+    'git@evil.com/github.com:anthropics/evil.git',
+  ]
+  for (const url of bypasses) {
+    test(`rejects reserved-name impersonation via ${url}`, () => {
+      const result = gitUrl(url)
+      expect(result).not.toBeNull()
+      expect(result).toContain('reserved')
+    })
+  }
+
+  // A different org on the real host is still rejected.
+  test('rejects a non-official org on github.com', () => {
+    expect(gitUrl('https://github.com/anthropics-evil/x')).not.toBeNull()
+    expect(gitUrl('https://github.com/notanthropics/x')).not.toBeNull()
+    expect(gitUrl('git@github.com:someoneelse/x.git')).not.toBeNull()
+  })
+
+  // Non-reserved names skip validation entirely (any source is fine).
+  test('non-reserved names are not validated', () => {
+    expect(
+      validateOfficialNameSource('my-personal-marketplace', {
+        source: 'git',
+        url: 'https://notgithub.com/anthropics/evil',
+      }),
+    ).toBeNull()
+  })
+
+  test('OFFICIAL_GITHUB_ORG is anthropics', () => {
+    expect(OFFICIAL_GITHUB_ORG).toBe('anthropics')
+  })
+})


### PR DESCRIPTION
### Problem

`validateOfficialNameSource` protects reserved marketplace names (the `ALLOWED_OFFICIAL_MARKETPLACE_NAMES` set — `claude-code-marketplace`, `anthropic-plugins`, etc.) so only repos from the official `anthropics` org can use them. The `git` source branch decided official ownership with a **substring** check:

```ts
const isHttpsAnthropics = url.includes('github.com/anthropics/')
const isSshAnthropics = url.includes('git@github.com:anthropics/')
if (isHttpsAnthropics || isSshAnthropics) return null // treated as official
```

A substring match accepts URLs whose host is **not** `github.com`, or where that text appears in the **path**:

- `https://notgithub.com/anthropics/evil`
- `https://evilgithub.com/anthropics/evil`
- `https://evil.com/github.com/anthropics/evil`

All contain `github.com/anthropics/` as a substring, so a repo the attacker controls is validated as official — letting them register a reserved official-marketplace name.

### Fix

Parse the URL and require the **exact host** `github.com` with the official org as the **first path segment**. Handles `https`/`http`, `ssh://`, and scp-like SSH (`git@github.com:anthropics/...`) forms, case-insensitively. The GitHub `repo` branch already anchored with `startsWith('anthropics/')` and is unchanged.

Same hostname-vs-substring class as the earlier `isXaiBaseUrl` (#1669) and bridge-localhost (#1760) fixes.

### Test

New `validateOfficialNameSource.test.ts`: rejects the impersonation URLs above (red-green — the three real bypasses fail before the fix), accepts genuine official URLs (https/.git/ssh/scp/mixed-case), rejects a wrong org on the real host, and confirms non-reserved names skip validation. Full `src/utils/plugins` suite (75 tests) green, `tsc --noEmit` clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Tightened validation for reserved marketplace names so only genuine official GitHub URLs are accepted.
  * Improved handling of multiple Git URL formats, including SSH and HTTPS, while rejecting misleading lookalike URLs.

* **Tests**
  * Added broader coverage for official-name validation, including accepted and rejected Git URL cases.
  * Added regression checks to prevent future bypasses of reserved-name protections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->