### PR TITLE
fix(openai-shim): sanitize tool call ids for chat wires

### DIFF
--- a/src/services/api/openaiShim.test.ts
+++ b/src/services/api/openaiShim.test.ts
@@ -6106,6 +6106,50 @@ test('coalesces consecutive assistant messages preserving tool_calls (issue #202
   expect(assistantMsgs?.[0]?.tool_calls?.length).toBeGreaterThan(0)
 })
 
+test('sanitizes overlong or signed tool_use ids for OpenAI-compatible chat wires', async () => {
+  const { __test } = await import('./openaiShim.ts')
+  const signedToolUseId = `toolu_vertex_k9x_3~~sig~~${'S'.repeat(1700)}`
+
+  const messages = __test.convertMessages(
+    [
+      {
+        role: 'assistant',
+        content: [
+          {
+            type: 'tool_use',
+            id: signedToolUseId,
+            name: 'Read',
+            input: { file_path: '/tmp/x' },
+          },
+        ],
+      },
+      {
+        role: 'user',
+        content: [
+          {
+            type: 'tool_result',
+            tool_use_id: signedToolUseId,
+            content: 'done',
+          },
+        ],
+      },
+    ],
+    undefined,
+  )
+
+  const assistantMessage = messages.find(
+    m => m.role === 'assistant' && Array.isArray(m.tool_calls),
+  )
+  const toolMessage = messages.find(m => m.role === 'tool')
+  const wireToolCallId = assistantMessage?.tool_calls?.[0]?.id
+
+  expect(wireToolCallId).toBeDefined()
+  expect(wireToolCallId).not.toBe(signedToolUseId)
+  expect(wireToolCallId!.length).toBeLessThanOrEqual(40)
+  expect(wireToolCallId).toMatch(/^[A-Za-z0-9_-]+$/)
+  expect(toolMessage?.tool_call_id).toBe(wireToolCallId)
+})
+
 test('non-streaming: reasoning_content emitted as thinking block only when content is null', async () => {
   globalThis.fetch = (async (_input, _init) => {
     return new Response(

--- a/src/services/api/openaiShim.ts
+++ b/src/services/api/openaiShim.ts
@@ -92,6 +92,7 @@ import {
 } from './openaiErrorClassification.js'
 import { sanitizeSchemaForOpenAICompat } from '../../utils/schemaSanitizer.js'
 import { redactSecretValueForDisplay, type SecretValueSource } from '../../utils/providerProfile.js'
+import { sanitizeToolUseIdForWire } from '../../utils/toolUseIds.js'
 import { shouldRedactUrlQueryParam } from '../../utils/urlRedaction.js'
 import { createCombinedAbortSignal } from '../../utils/combinedAbortSignal.js'
 import {
@@ -117,6 +118,7 @@ const GITHUB_429_MAX_RETRIES = 3
 const GITHUB_429_BASE_DELAY_SEC = 1
 const GITHUB_429_MAX_DELAY_SEC = 32
 const CREDENTIAL_POOL_COOLDOWN_MS = 30_000
+const CHAT_TOOL_CALL_ID_MAX_LENGTH = 40
 const DEFAULT_STREAM_IDLE_TIMEOUT_MS = 90_000
 const MAX_STREAM_IDLE_TIMEOUT_MS = 2_147_483_647
 const GEMINI_API_HOST = 'generativelanguage.googleapis.com'
@@ -1093,7 +1095,12 @@ function convertMessages(
           (block as { type?: string }).type === 'tool_result' &&
           (block as { tool_use_id?: string }).tool_use_id
         ) {
-          toolResultIds.add((block as { tool_use_id: string }).tool_use_id)
+          toolResultIds.add(
+            sanitizeToolUseIdForWire(
+              (block as { tool_use_id: string }).tool_use_id,
+              CHAT_TOOL_CALL_ID_MAX_LENGTH,
+            ),
+          )
         }
       }
     }
@@ -1129,7 +1136,10 @@ function convertMessages(
         // If the user interrupted (ESC) and a synthetic tool_result was generated without a recorded tool_use,
         // emitting it here would cause a "role must alternate" or "unexpected role" error.
         for (const tr of toolResults) {
-          const id = tr.tool_use_id ?? 'unknown'
+          const id = sanitizeToolUseIdForWire(
+            tr.tool_use_id ?? 'unknown',
+            CHAT_TOOL_CALL_ID_MAX_LENGTH,
+          )
           if (knownToolCallIds.has(id)) {
             result.push({
               role: 'tool',
@@ -1226,7 +1236,9 @@ function convertMessages(
                 extra_content?: Record<string, unknown>
                 signature?: string
               }) => {
-                const id = tu.id ?? `call_${crypto.randomUUID().replace(/-/g, '')}`
+                const id = tu.id
+                  ? sanitizeToolUseIdForWire(tu.id, CHAT_TOOL_CALL_ID_MAX_LENGTH)
+                  : `call_${crypto.randomUUID().replace(/-/g, '')}`
 
                 // Only keep tool calls that have a corresponding result in the history,
                 // or if it's the last message (prefill scenario).

--- a/src/utils/toolUseIds.ts
+++ b/src/utils/toolUseIds.ts
@@ -1,0 +1,37 @@
+/**
+ * Maximum tool-call id length accepted by the OpenAI Responses API. The
+ * chat/completions path may use a smaller endpoint-specific limit.
+ */
+export const MAX_WIRE_TOOL_ID_LENGTH = 64
+
+/**
+ * Sanitize a persisted tool_use id for an outgoing provider wire.
+ *
+ * Some providers can round-trip metadata in ids that other OpenAI-compatible
+ * wires reject because of length or charset constraints. Keep the stable
+ * alphanumeric prefix, then cap deterministically with a hash tail so distinct
+ * overlong ids stay distinct.
+ */
+export function sanitizeToolUseIdForWire(
+  value: unknown,
+  maxLength = MAX_WIRE_TOOL_ID_LENGTH,
+): string {
+  const str = typeof value === 'string' ? value : value == null ? '' : String(value)
+  const clean = str.replace(/[^A-Za-z0-9_-][\s\S]*$/, '')
+  if (clean.length > 0 && clean.length <= maxLength) {
+    return clean
+  }
+
+  let hash = 0x811c9dc5
+  for (let i = 0; i < str.length; i++) {
+    hash ^= str.charCodeAt(i)
+    hash = Math.imul(hash, 0x01000193) >>> 0
+  }
+
+  const tail = `_${hash.toString(36)}`
+  if (clean.length === 0) {
+    return `tool${tail}`
+  }
+  const prefixLength = Math.max(1, maxLength - tail.length)
+  return clean.slice(0, prefixLength) + tail
+}


### PR DESCRIPTION
﻿## Summary
- sanitize persisted Anthropic tool_use ids before sending OpenAI-compatible chat/completions tool calls
- keep tool_result.tool_use_id aligned with the sanitized tool_call id
- add a regression test for overlong/signed ids on the chat wire

## Why
Some provider histories can contain metadata-bearing or overlong tool_use ids. OpenAI-compatible chat wires reject ids with unsupported characters or excessive length, so the shim should normalize ids at the wire boundary without changing provider routing.

## Validation
- `bun test src/services/api/openaiShim.test.ts -t "sanitizes overlong or signed tool_use ids"`
- `bun test src/services/api/openaiShim.test.ts`
- `bun run typecheck`
- `bunx knip --include files,dependencies`
