### PR TITLE
fix(gitdiff): count in-hunk lines starting with ++/-- in raw diff stats

### DIFF
--- a/src/utils/gitDiff.test.ts
+++ b/src/utils/gitDiff.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'bun:test'
-import { parseGitDiff } from './gitDiff.js'
+import { parseGitDiff, parseRawDiffToToolUseDiff } from './gitDiff.js'
 
 describe('parseGitDiff', () => {
   it('keeps hunk content lines whose text starts with -- or ++', () => {
@@ -71,5 +71,47 @@ describe('parseGitDiff', () => {
     expect(lines).toContain('-const b = 2')
     expect(lines).toContain('+const b = 3')
     expect(lines).toContain(' const a = 1')
+  })
+})
+
+describe('parseRawDiffToToolUseDiff', () => {
+  it('counts hunk content lines whose text starts with -- or ++', () => {
+    // Same class as the parseGitDiff regression above: a removed line whose
+    // content is "--legacy-peer-deps" shows as "---legacy-peer-deps", and an
+    // added line "++quiet-flag" shows as "+++quiet-flag". The `+++`/`---`
+    // file-header lines only appear before the first @@, so guarding on them
+    // inside a hunk dropped these real additions/deletions from the counts.
+    const raw = [
+      '--- a/run.sh',
+      '+++ b/run.sh',
+      '@@ -1,2 +1,2 @@',
+      '-npm install',
+      '---legacy-peer-deps',
+      '+npm ci',
+      '+++quiet-flag',
+    ].join('\n')
+
+    const diff = parseRawDiffToToolUseDiff('run.sh', raw, 'modified')
+    expect(diff.additions).toBe(2)
+    expect(diff.deletions).toBe(2)
+    expect(diff.changes).toBe(4)
+    // The header lines before the first @@ are not part of the counted hunk.
+    expect(diff.patch).toContain('---legacy-peer-deps')
+    expect(diff.patch).toContain('+++quiet-flag')
+    expect(diff.patch.startsWith('@@')).toBe(true)
+  })
+
+  it('counts a plain modification without over/under-counting', () => {
+    const raw = [
+      '--- a/a.ts',
+      '+++ b/a.ts',
+      '@@ -1,1 +1,1 @@',
+      '-const b = 2',
+      '+const b = 3',
+    ].join('\n')
+    const diff = parseRawDiffToToolUseDiff('a.ts', raw, 'modified')
+    expect(diff.additions).toBe(1)
+    expect(diff.deletions).toBe(1)
+    expect(diff.changes).toBe(2)
   })
 })

--- a/src/utils/gitDiff.ts
+++ b/src/utils/gitDiff.ts
@@ -451,7 +451,7 @@ export async function fetchSingleFileGitDiff(
  * Extracts only the hunk content (starting from @@) as the patch,
  * and counts additions/deletions.
  */
-function parseRawDiffToToolUseDiff(
+export function parseRawDiffToToolUseDiff(
   filename: string,
   rawDiff: string,
   status: 'modified' | 'added',
@@ -468,9 +468,16 @@ function parseRawDiffToToolUseDiff(
     }
     if (inHunks) {
       patchLines.push(line)
-      if (line.startsWith('+') && !line.startsWith('+++')) {
+      // Count every added/removed line inside a hunk. The `+++ b/file` and
+      // `--- a/file` headers only appear in the preamble before the first `@@`,
+      // so they never reach here — guarding on `!startsWith('+++')` /
+      // `!startsWith('---')` would instead drop genuine hunk content whose text
+      // begins with `++`/`--` (e.g. `+++quiet-flag`, `---legacy-peer-deps`, a
+      // YAML `---` separator), undercounting additions/deletions. Mirrors the
+      // in-hunk handling already documented in parseGitDiff above.
+      if (line.startsWith('+')) {
         additions++
-      } else if (line.startsWith('-') && !line.startsWith('---')) {
+      } else if (line.startsWith('-')) {
         deletions++
       }
     }


### PR DESCRIPTION
### Problem

`parseRawDiffToToolUseDiff` (used by `fetchSingleFileGitDiff` → FileEdit/FileWrite tool results) counts additions/deletions with these guards:

```ts
if (line.startsWith('+') && !line.startsWith('+++')) additions++
else if (line.startsWith('-') && !line.startsWith('---')) deletions++
```

The `!startsWith('+++')` / `!startsWith('---')` guards are meant to skip the `+++ b/file` / `--- a/file` **file headers** — but those headers only appear in the preamble *before* the first `@@`, and this block is already gated behind `inHunks`. So the headers never reach the counter. Inside a hunk the guards only ever match **real content** whose text begins with `++`/`--`, silently dropping it.

### Concrete failure

```
--- a/run.sh
+++ b/run.sh
@@ -1,2 +1,2 @@
-npm install
---legacy-peer-deps
+npm ci
+++quiet-flag
```

- `---legacy-peer-deps` (a removed `--legacy-peer-deps`) → `startsWith('---')` → **not counted**
- `+++quiet-flag` (an added `++quiet-flag`) → `startsWith('+++')` → **not counted**

Current output: `additions=1, deletions=1, changes=2`. Correct: `2 / 2 / 4`. Natural triggers: removing/adding a YAML doc separator or front-matter fence (`---`), a Markdown horizontal rule, a changelog `---`, a `++i`/`--i` C line, or editing diff/patch files.

### Fix

Drop the redundant guards — every in-hunk `+`/`-` line is counted; headers can't reach here. This is the **same defect the sibling `parseGitDiff` already documents and guards against** with its `!currentHunk` check (see the comment at its `---`/`+++` skip); `parseRawDiffToToolUseDiff` was left with the latent instance.

### Test

Exported `parseRawDiffToToolUseDiff` and added a regression covering the `--`/`++` content lines (red-green: additions/deletions/changes are `1/1/2` before the fix, `2/2/4` after) plus a plain-modification control. `gitDiff` suite green, `tsc --noEmit` clean.
