### PR TITLE
fix(query): clean up lifecycle tool tracking

### DIFF
--- a/src/services/tools/StreamingToolExecutor.test.ts
+++ b/src/services/tools/StreamingToolExecutor.test.ts
@@ -10,7 +10,10 @@ import {
   type ToolUseContext,
 } from '../../Tool.js'
 import type { AssistantMessage } from '../../types/message.js'
-import { QueryLifecycleOperationTracker } from '../../utils/queryLifecycle.js'
+import {
+  type QueryActiveOperationSnapshot,
+  QueryLifecycleOperationTracker,
+} from '../../utils/queryLifecycle.js'
 import { StreamingToolExecutor } from './StreamingToolExecutor.js'
 
 const assistantMessage = {
@@ -21,6 +24,15 @@ const assistantMessage = {
     content: [],
   },
 } as unknown as AssistantMessage
+
+class CountingQueryLifecycleTracker extends QueryLifecycleOperationTracker {
+  endCount = 0
+
+  override endToolUse(toolUseId: string): void {
+    this.endCount++
+    super.endToolUse(toolUseId)
+  }
+}
 
 function makeToolUseContext(
   tools: readonly Tool[],
@@ -60,42 +72,16 @@ function makeToolUseContext(
 }
 
 describe('StreamingToolExecutor lifecycle tracking', () => {
-  test('discard aborts in-flight tools and clears lifecycle tracking immediately', async () => {
+  test('normal streaming execution clears lifecycle tracking after results are consumed', async () => {
     const queryLifecycle = new QueryLifecycleOperationTracker()
     const inProgressToolUseIds = { current: new Set<string>() }
     const hasInterruptibleToolInProgress = { current: false }
-    let resolveStarted!: () => void
-    const started = new Promise<void>(resolve => {
-      resolveStarted = resolve
-    })
-    let observedAbortReason: unknown
-    let resolveAborted!: () => void
-    const aborted = new Promise<void>(resolve => {
-      resolveAborted = resolve
-    })
+    let lifecycleSnapshotDuringCall: QueryActiveOperationSnapshot | undefined
     const tool = createToolFixture(z.object({}), {
-      name: 'SlowLifecycleTool',
-      interruptBehavior: () => 'cancel',
-      async call(_input, context) {
-        resolveStarted()
-        await new Promise<void>(resolve => {
-          if (context.abortController.signal.aborted) {
-            observedAbortReason = context.abortController.signal.reason
-            resolveAborted()
-            resolve()
-            return
-          }
-          context.abortController.signal.addEventListener(
-            'abort',
-            () => {
-              observedAbortReason = context.abortController.signal.reason
-              resolveAborted()
-              resolve()
-            },
-            { once: true },
-          )
-        })
-        return { data: 'aborted' }
+      name: 'FastLifecycleTool',
+      async call() {
+        lifecycleSnapshotDuringCall = queryLifecycle.snapshot()
+        return { data: 'ok' }
       },
     })
     const toolUseContext = makeToolUseContext(
@@ -119,23 +105,123 @@ describe('StreamingToolExecutor lifecycle tracking', () => {
       } as ToolUseBlock,
       assistantMessage,
     )
+
+    const results: unknown[] = []
+    for await (const result of executor.getRemainingResults()) {
+      results.push(result)
+    }
+
+    expect(results.length).toBeGreaterThan(0)
+    expect(lifecycleSnapshotDuringCall?.toolUses).toMatchObject([
+      {
+        toolUseId: 'tool-use-1',
+        toolName: 'FastLifecycleTool',
+      },
+    ])
+    expect(queryLifecycle.snapshot()).toEqual({ apiCalls: [], toolUses: [] })
+    expect(inProgressToolUseIds.current.has('tool-use-1')).toBe(false)
+  })
+
+  test('discard aborts in-flight tools and clears lifecycle tracking immediately', async () => {
+    const queryLifecycle = new CountingQueryLifecycleTracker()
+    const inProgressToolUseIds = { current: new Set<string>() }
+    const hasInterruptibleToolInProgress = { current: false }
+    let resolveStarted!: () => void
+    const started = new Promise<void>(resolve => {
+      resolveStarted = resolve
+    })
+    let observedAbortReason: unknown
+    let resolveAborted!: () => void
+    const aborted = new Promise<void>(resolve => {
+      resolveAborted = resolve
+    })
+    let resolveCallFinished!: () => void
+    const callFinished = new Promise<void>(resolve => {
+      resolveCallFinished = resolve
+    })
+    const tool = createToolFixture(z.object({}), {
+      name: 'SlowLifecycleTool',
+      interruptBehavior: () => 'cancel',
+      async call(_input, context) {
+        resolveStarted()
+        await new Promise<void>(resolve => {
+          if (context.abortController.signal.aborted) {
+            observedAbortReason = context.abortController.signal.reason
+            resolveAborted()
+            resolve()
+            return
+          }
+          context.abortController.signal.addEventListener(
+            'abort',
+            () => {
+              observedAbortReason = context.abortController.signal.reason
+              resolveAborted()
+              resolve()
+            },
+            { once: true },
+          )
+        })
+        resolveCallFinished()
+        return { data: 'aborted' }
+      },
+    })
+    const queuedTool = createToolFixture(z.object({}), {
+      name: 'QueuedLifecycleTool',
+    })
+    const toolUseContext = makeToolUseContext(
+      [tool, queuedTool],
+      queryLifecycle,
+      inProgressToolUseIds,
+      hasInterruptibleToolInProgress,
+    )
+    const executor = new StreamingToolExecutor(
+      [tool, queuedTool],
+      (async () => ({ behavior: 'allow' })) as CanUseToolFn,
+      toolUseContext,
+    )
+
+    executor.addTool(
+      {
+        type: 'tool_use',
+        id: 'tool-use-1',
+        name: tool.name,
+        input: {},
+      } as ToolUseBlock,
+      assistantMessage,
+    )
+    executor.addTool(
+      {
+        type: 'tool_use',
+        id: 'tool-use-2',
+        name: queuedTool.name,
+        input: {},
+      } as ToolUseBlock,
+      assistantMessage,
+    )
     await started
 
-    expect(queryLifecycle.snapshot().toolUses).toMatchObject([
+    expect(queryLifecycle.snapshot().toolUses).toEqual([
       {
         toolUseId: 'tool-use-1',
         toolName: tool.name,
+        startedAt: expect.any(Number),
       },
     ])
     expect(inProgressToolUseIds.current.has('tool-use-1')).toBe(true)
+    expect(inProgressToolUseIds.current.has('tool-use-2')).toBe(false)
     expect(hasInterruptibleToolInProgress.current).toBe(true)
 
     executor.discard()
 
     expect(queryLifecycle.snapshot()).toEqual({ apiCalls: [], toolUses: [] })
+    expect(queryLifecycle.endCount).toBe(1)
     expect(inProgressToolUseIds.current.has('tool-use-1')).toBe(false)
+    expect(inProgressToolUseIds.current.has('tool-use-2')).toBe(false)
     expect(hasInterruptibleToolInProgress.current).toBe(false)
     await aborted
+    await callFinished
+    await new Promise(resolve => setTimeout(resolve, 0))
+    expect(queryLifecycle.endCount).toBe(1)
     expect(observedAbortReason).toBe('streaming_fallback')
     expect([...executor.getCompletedResults()]).toEqual([])
   })

--- a/src/services/tools/StreamingToolExecutor.ts
+++ b/src/services/tools/StreamingToolExecutor.ts
@@ -70,9 +70,16 @@ export class StreamingToolExecutor {
     if (this.discarded) return
     this.discarded = true
     this.siblingAbortController.abort('streaming_fallback')
+    const activeLifecycleToolUseIds = new Set(
+      this.toolUseContext.queryLifecycle
+        ?.snapshot()
+        .toolUses.map(toolUse => toolUse.toolUseId) ?? [],
+    )
     for (const tool of this.tools) {
       if (tool.status === 'yielded') continue
-      this.toolUseContext.queryLifecycle?.endToolUse(tool.id)
+      if (activeLifecycleToolUseIds.has(tool.id)) {
+        this.toolUseContext.queryLifecycle?.endToolUse(tool.id)
+      }
       markToolUseAsComplete(this.toolUseContext, tool.id)
       tool.pendingProgress.length = 0
       tool.status = 'yielded'

--- a/src/services/tools/toolExecution.test.ts
+++ b/src/services/tools/toolExecution.test.ts
@@ -1,12 +1,15 @@
 import { afterEach, describe, expect, mock, test } from 'bun:test'
+import type { ToolUseBlock } from '@anthropic-ai/sdk/resources/index.mjs'
 import { z } from 'zod/v4'
 
+import type { CanUseToolFn } from '../../hooks/useCanUseTool.js'
 import { getEmptyToolPermissionContext, type Tool, type ToolUseContext } from '../../Tool.js'
 import {
   getReplayIndexBuilder,
   resetAllReplayIndexBuilders,
 } from '../../bootstrap/state.js'
 import { getDefaultAppState } from '../../state/AppStateStore.js'
+import { createToolFixture } from '../../test/toolFixtures.js'
 import { SkillTool } from '../../tools/SkillTool/SkillTool.js'
 import { AskUserQuestionTool } from '../../tools/AskUserQuestionTool/AskUserQuestionTool.js'
 import { BASH_TOOL_NAME } from '../../tools/BashTool/toolName.js'
@@ -14,6 +17,11 @@ import { FILE_EDIT_TOOL_NAME } from '../../tools/FileEditTool/constants.js'
 import { FILE_WRITE_TOOL_NAME } from '../../tools/FileWriteTool/constants.js'
 import { NOTEBOOK_EDIT_TOOL_NAME } from '../../tools/NotebookEditTool/constants.js'
 import { AbortError } from '../../utils/errors.js'
+import { createAssistantMessage } from '../../utils/messages.js'
+import {
+  type QueryActiveOperationSnapshot,
+  QueryLifecycleOperationTracker,
+} from '../../utils/queryLifecycle.js'
 import { ReplayIndexBuilder } from '../../utils/replayIndexBuilder.js'
 import {
   getReplayResultStatusForError,
@@ -21,14 +29,103 @@ import {
   getSchemaValidationErrorOverride,
   getSchemaValidationToolUseResult,
   checkPermissionsAndCallTool,
+  type MessageUpdateLazy,
   normalizeReplayToolInput,
   normalizeToolInputForValidation,
+  runToolUse,
 } from './toolExecution.js'
 
 afterEach(() => {
   delete process.env.TEST_ENABLE_SESSION_PERSISTENCE
   resetAllReplayIndexBuilders()
 })
+
+class CountingQueryLifecycleTracker extends QueryLifecycleOperationTracker {
+  startCount = 0
+  updateCount = 0
+  endCount = 0
+
+  override startToolUse(
+    toolUse: Parameters<QueryLifecycleOperationTracker['startToolUse']>[0],
+  ): void {
+    this.startCount++
+    super.startToolUse(toolUse)
+  }
+
+  override updateToolUse(
+    toolUse: Parameters<QueryLifecycleOperationTracker['updateToolUse']>[0],
+  ): void {
+    this.updateCount++
+    super.updateToolUse(toolUse)
+  }
+
+  override endToolUse(toolUseId: string): void {
+    this.endCount++
+    super.endToolUse(toolUseId)
+  }
+}
+
+function createLifecycleToolUseContext(
+  tools: readonly Tool[],
+  queryLifecycle: QueryLifecycleOperationTracker,
+  abortController = new AbortController(),
+): ToolUseContext {
+  const appState = getDefaultAppState()
+  return {
+    options: {
+      commands: [],
+      debug: false,
+      mainLoopModel: 'test-model',
+      tools,
+      verbose: false,
+      thinkingConfig: {},
+      mcpClients: [],
+      mcpResources: {},
+      isNonInteractiveSession: true,
+      agentDefinitions: { agents: [], errors: [] },
+    },
+    abortController,
+    queryLifecycle,
+    readFileState: {},
+    getAppState: () => ({
+      ...appState,
+      sessionHooks: new Map(),
+      toolPermissionContext: getEmptyToolPermissionContext(),
+    }),
+    setAppState: () => {},
+    setInProgressToolUseIDs: () => {},
+    setResponseLength: () => {},
+    updateFileHistoryState: () => {},
+    updateAttributionState: () => {},
+    messages: [],
+  } as unknown as ToolUseContext
+}
+
+async function collectRunToolUse(
+  tool: Tool,
+  input: Record<string, unknown>,
+  context: ToolUseContext,
+  canUseTool: CanUseToolFn = async (_tool, toolInput) => ({
+    behavior: 'allow',
+    updatedInput: toolInput,
+  }),
+) {
+  const updates: MessageUpdateLazy[] = []
+  for await (const update of runToolUse(
+    {
+      type: 'tool_use',
+      id: 'toolu_lifecycle',
+      name: tool.name,
+      input,
+    } as ToolUseBlock,
+    createAssistantMessage({ content: 'run tool' }),
+    canUseTool,
+    context,
+  )) {
+    updates.push(update)
+  }
+  return updates
+}
 
 describe('getSchemaValidationErrorOverride', () => {
   test('returns actionable missing-skill error for SkillTool', () => {
@@ -295,6 +392,235 @@ describe('replay tool lifecycle records', () => {
     expect(step.resultStatus).toBe('error')
     expect(step.resultPreview).toBe('mapping failed')
     expect(step.input).toEqual({ value: 'final' })
+  })
+})
+
+describe('query lifecycle tool-use cleanup', () => {
+  const lifecycleInputSchema = z.object({ value: z.string() })
+
+  test('successful tool execution leaves no active lifecycle tool use', async () => {
+    const queryLifecycle = new CountingQueryLifecycleTracker()
+    let lifecycleSnapshotDuringCall: QueryActiveOperationSnapshot | undefined
+    const tool = createToolFixture(lifecycleInputSchema, {
+      name: 'LifecycleSuccessTool',
+      async call() {
+        lifecycleSnapshotDuringCall = queryLifecycle.snapshot()
+        return { data: 'ok' }
+      },
+    })
+    const context = createLifecycleToolUseContext([tool], queryLifecycle)
+
+    const updates = await collectRunToolUse(tool, { value: 'ok' }, context)
+
+    expect(updates.length).toBeGreaterThan(0)
+    expect(lifecycleSnapshotDuringCall?.toolUses).toMatchObject([
+      {
+        toolUseId: 'toolu_lifecycle',
+        toolName: 'LifecycleSuccessTool',
+      },
+    ])
+    expect(queryLifecycle.startCount).toBe(1)
+    expect(queryLifecycle.endCount).toBe(1)
+    expect(queryLifecycle.snapshot()).toEqual({ apiCalls: [], toolUses: [] })
+  })
+
+  test('custom validation failure leaves no active lifecycle tool use', async () => {
+    const queryLifecycle = new CountingQueryLifecycleTracker()
+    const tool = createToolFixture(lifecycleInputSchema, {
+      name: 'LifecycleValidationTool',
+      async validateInput() {
+        return {
+          result: false,
+          message: 'invalid value',
+          errorCode: 1,
+        }
+      },
+    })
+    const context = createLifecycleToolUseContext([tool], queryLifecycle)
+
+    const updates = await collectRunToolUse(tool, { value: 'bad' }, context)
+
+    expect(updates.length).toBeGreaterThan(0)
+    expect(queryLifecycle.startCount).toBe(1)
+    expect(queryLifecycle.endCount).toBe(1)
+    expect(queryLifecycle.snapshot()).toEqual({ apiCalls: [], toolUses: [] })
+  })
+
+  test('schema validation failure does not end a lifecycle entry that never started', async () => {
+    const queryLifecycle = new CountingQueryLifecycleTracker()
+    const tool = createToolFixture(lifecycleInputSchema, {
+      name: 'LifecycleSchemaTool',
+    })
+    const context = createLifecycleToolUseContext([tool], queryLifecycle)
+
+    const updates = await collectRunToolUse(tool, {}, context)
+
+    expect(updates.length).toBeGreaterThan(0)
+    expect(queryLifecycle.startCount).toBe(0)
+    expect(queryLifecycle.updateCount).toBe(0)
+    expect(queryLifecycle.endCount).toBe(0)
+    expect(queryLifecycle.snapshot()).toEqual({ apiCalls: [], toolUses: [] })
+  })
+
+  test('unknown tool does not end a lifecycle entry that never started', async () => {
+    const queryLifecycle = new CountingQueryLifecycleTracker()
+    const tool = createToolFixture(lifecycleInputSchema, {
+      name: 'LifecycleUnknownTool',
+    })
+    const context = createLifecycleToolUseContext([], queryLifecycle)
+
+    const updates = await collectRunToolUse(tool, { value: 'ok' }, context)
+
+    expect(updates.length).toBeGreaterThan(0)
+    expect(queryLifecycle.startCount).toBe(0)
+    expect(queryLifecycle.updateCount).toBe(0)
+    expect(queryLifecycle.endCount).toBe(0)
+    expect(queryLifecycle.snapshot()).toEqual({ apiCalls: [], toolUses: [] })
+  })
+
+  test('permission denial leaves no active lifecycle tool use', async () => {
+    const queryLifecycle = new CountingQueryLifecycleTracker()
+    const tool = createToolFixture(lifecycleInputSchema, {
+      name: 'LifecycleDeniedTool',
+    })
+    const context = createLifecycleToolUseContext([tool], queryLifecycle)
+    const denyToolUse: CanUseToolFn = async () => ({
+      behavior: 'deny',
+      message: 'Denied by test',
+      decisionReason: {
+        type: 'other',
+        reason: 'Denied by test',
+      },
+    })
+
+    const updates = await collectRunToolUse(
+      tool,
+      { value: 'blocked' },
+      context,
+      denyToolUse,
+    )
+
+    expect(updates.length).toBeGreaterThan(0)
+    expect(queryLifecycle.startCount).toBe(1)
+    expect(queryLifecycle.updateCount).toBeGreaterThan(0)
+    expect(queryLifecycle.endCount).toBe(1)
+    expect(queryLifecycle.snapshot()).toEqual({ apiCalls: [], toolUses: [] })
+  })
+
+  test('thrown tool error leaves no active lifecycle tool use', async () => {
+    const queryLifecycle = new CountingQueryLifecycleTracker()
+    const tool = createToolFixture(lifecycleInputSchema, {
+      name: 'LifecycleThrowTool',
+      async call() {
+        throw new Error('tool exploded')
+      },
+    })
+    const context = createLifecycleToolUseContext([tool], queryLifecycle)
+
+    const updates = await collectRunToolUse(tool, { value: 'boom' }, context)
+
+    expect(updates.length).toBeGreaterThan(0)
+    expect(queryLifecycle.startCount).toBe(1)
+    expect(queryLifecycle.endCount).toBe(1)
+    expect(queryLifecycle.snapshot()).toEqual({ apiCalls: [], toolUses: [] })
+  })
+
+  test('aborted tool execution leaves no active lifecycle tool use', async () => {
+    const queryLifecycle = new CountingQueryLifecycleTracker()
+    const tool = createToolFixture(lifecycleInputSchema, {
+      name: 'LifecycleAbortTool',
+      async call() {
+        throw new AbortError('interrupted')
+      },
+    })
+    const context = createLifecycleToolUseContext([tool], queryLifecycle)
+
+    const updates = await collectRunToolUse(tool, { value: 'abort' }, context)
+
+    expect(updates.length).toBeGreaterThan(0)
+    expect(queryLifecycle.startCount).toBe(1)
+    expect(queryLifecycle.endCount).toBe(1)
+    expect(queryLifecycle.snapshot()).toEqual({ apiCalls: [], toolUses: [] })
+  })
+
+  test('permission-updated input can retrack lifecycle metadata and still ends once', async () => {
+    const queryLifecycle = new CountingQueryLifecycleTracker()
+    let lifecycleSnapshotDuringCall: QueryActiveOperationSnapshot | undefined
+    const tool = createToolFixture(
+      z.object({ value: z.string(), timeout: z.number().optional() }),
+      {
+        name: BASH_TOOL_NAME,
+        async call() {
+          lifecycleSnapshotDuringCall = queryLifecycle.snapshot()
+          return { data: 'ok' }
+        },
+      },
+    )
+    const context = createLifecycleToolUseContext([tool], queryLifecycle)
+    const updateInput: CanUseToolFn = async () => ({
+      behavior: 'allow',
+      updatedInput: { value: 'updated', timeout: 20 },
+    })
+
+    const updates = await collectRunToolUse(
+      tool,
+      { value: 'initial', timeout: 10 },
+      context,
+      updateInput,
+    )
+
+    expect(updates.length).toBeGreaterThan(0)
+    expect(lifecycleSnapshotDuringCall?.toolUses).toEqual([
+      {
+        toolUseId: 'toolu_lifecycle',
+        toolName: BASH_TOOL_NAME,
+        startedAt: expect.any(Number),
+        isBash: true,
+        timeoutMs: 20,
+      },
+    ])
+    expect(queryLifecycle.startCount).toBe(1)
+    expect(queryLifecycle.updateCount).toBeGreaterThan(0)
+    expect(queryLifecycle.endCount).toBe(1)
+    expect(queryLifecycle.snapshot()).toEqual({ apiCalls: [], toolUses: [] })
+  })
+
+  test('permission-updated input does not resurrect externally ended lifecycle tracking', async () => {
+    const queryLifecycle = new CountingQueryLifecycleTracker()
+    const tool = createToolFixture(lifecycleInputSchema, {
+      name: 'LifecycleExternallyEndedTool',
+    })
+    const context = createLifecycleToolUseContext([tool], queryLifecycle)
+    let lifecycleSnapshotBeforeExternalEnd:
+      | QueryActiveOperationSnapshot
+      | undefined
+    const endBeforeUpdatingInput: CanUseToolFn = async () => {
+      lifecycleSnapshotBeforeExternalEnd = queryLifecycle.snapshot()
+      queryLifecycle.endToolUse('toolu_lifecycle')
+      return {
+        behavior: 'allow',
+        updatedInput: { value: 'updated' },
+      }
+    }
+
+    const updates = await collectRunToolUse(
+      tool,
+      { value: 'initial' },
+      context,
+      endBeforeUpdatingInput,
+    )
+
+    expect(updates.length).toBeGreaterThan(0)
+    expect(lifecycleSnapshotBeforeExternalEnd?.toolUses).toMatchObject([
+      {
+        toolUseId: 'toolu_lifecycle',
+        toolName: 'LifecycleExternallyEndedTool',
+      },
+    ])
+    expect(queryLifecycle.startCount).toBe(1)
+    expect(queryLifecycle.updateCount).toBe(0)
+    expect(queryLifecycle.endCount).toBe(1)
+    expect(queryLifecycle.snapshot()).toEqual({ apiCalls: [], toolUses: [] })
   })
 })
 

--- a/src/services/tools/toolExecution.ts
+++ b/src/services/tools/toolExecution.ts
@@ -89,6 +89,7 @@ import {
   startSessionActivity,
   stopSessionActivity,
 } from '../../utils/sessionActivity.js'
+import type { QueryActiveToolUse } from '../../utils/queryLifecycle.js'
 import { shouldSkipSessionPersistence } from '../../utils/sessionPersistencePolicy.js'
 import { jsonStringify } from '../../utils/slowOperations.js'
 import { Stream } from '../../utils/stream.js'
@@ -835,9 +836,12 @@ export async function checkPermissionsAndCallTool(
     return (input as BashToolInput).timeout
   }
 
-  function trackLifecycleToolUse(input: unknown): void {
+  let lifecycleStarted = false
+  let lifecycleEnded = false
+
+  function createLifecycleToolUse(input: unknown): QueryActiveToolUse {
     const lifecycleBashTimeoutMs = getLifecycleBashTimeoutMs(input)
-    toolUseContext.queryLifecycle?.startToolUse({
+    return {
       toolUseId: toolUseID,
       toolName: tool.name,
       startedAt: lifecycleStartTime,
@@ -845,11 +849,53 @@ export async function checkPermissionsAndCallTool(
       ...(lifecycleBashTimeoutMs !== undefined && {
         timeoutMs: lifecycleBashTimeoutMs,
       }),
-    })
+    }
+  }
+
+  function isLifecycleToolUseActive(): boolean {
+    return (
+      toolUseContext.queryLifecycle
+        ?.snapshot()
+        .toolUses.some(activeToolUse => activeToolUse.toolUseId === toolUseID) ??
+      false
+    )
+  }
+
+  function trackLifecycleToolUse(input: unknown): void {
+    const queryLifecycle = toolUseContext.queryLifecycle
+    if (!queryLifecycle) return
+    if (lifecycleEnded) return
+
+    const lifecycleToolUse = createLifecycleToolUse(input)
+    if (!lifecycleStarted) {
+      queryLifecycle.startToolUse(lifecycleToolUse)
+      lifecycleStarted = true
+      return
+    }
+
+    if (!isLifecycleToolUseActive()) {
+      lifecycleEnded = true
+      return
+    }
+
+    queryLifecycle.updateToolUse(lifecycleToolUse)
+  }
+
+  function endLifecycleToolUse(): void {
+    if (!lifecycleStarted || lifecycleEnded) return
+
+    const queryLifecycle = toolUseContext.queryLifecycle
+    if (!queryLifecycle) return
+
+    lifecycleEnded = true
+    if (isLifecycleToolUseActive()) {
+      queryLifecycle.endToolUse(toolUseID)
+    }
   }
 
   trackLifecycleToolUse(parsedInput.data)
 
+  try {
   // Validate input values. Each tool has its own validation logic
   const isValidCall = await tool.validateInput?.(
     parsedInput.data,
@@ -1879,5 +1925,8 @@ export async function checkPermissionsAndCallTool(
         toolUseContext.toolDecisions?.delete(toolUseID)
       }
     }
+  }
+  } finally {
+    endLifecycleToolUse()
   }
 }

--- a/src/utils/queryLifecycle.ts
+++ b/src/utils/queryLifecycle.ts
@@ -139,6 +139,11 @@ export class QueryLifecycleOperationTracker {
     this.toolUses.set(toolUse.toolUseId, toSafeToolUseSnapshot(toolUse))
   }
 
+  updateToolUse(toolUse: QueryActiveToolUse): void {
+    if (!this.toolUses.has(toolUse.toolUseId)) return
+    this.toolUses.set(toolUse.toolUseId, toSafeToolUseSnapshot(toolUse))
+  }
+
   endToolUse(toolUseId: string): void {
     this.toolUses.delete(toolUseId)
   }


### PR DESCRIPTION
## Summary

- End query lifecycle tool-use entries in the same execution boundary that starts them so completed foreground turns do not retain stale active tool-use diagnostics.
- Separate lifecycle metadata refreshes from logical starts, preserving Bash timeout metadata when hook or permission paths update tool input.
- Keep streaming discard cleanup safe for queued tools that never reached lifecycle tracking while preserving the separate UI in-progress tool state.

## Impact

- user-facing impact: query timeout and completion diagnostics report active tool uses only for operations that are still genuinely active.
- developer/maintainer impact: lifecycle tracking now has focused regression coverage for success, validation, permission, error, abort, streaming, discard, and unknown-tool paths.

## Testing

- [x] `bun run build`
- [ ] `bun run smoke`
- [ ] `bun run check`
- [x] `bun run typecheck`
- [x] `bun test src/services/tools/toolExecution.test.ts src/services/tools/StreamingToolExecutor.test.ts src/utils/QueryGuard.test.ts src/services/tools/queryActivityLease.test.ts src/screens/REPL.queryLifecycle.test.ts src/services/api/claude.lifecycle.test.ts src/tools/AgentTool/runAgent.routing.test.ts`
- [x] `git diff --check`

## Notes

- provider/model path tested: not applicable; this is tool lifecycle tracking.
- screenshots attached: not applicable; no UI rendering changes.
- follow-up work or known limitations: none known.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved streaming tool execution so interrupted or discarded actions are cleaned up more reliably.
  * Fixed cases where tool activity could be finalized more than once or remain tracked after completion.
  * Added stronger lifecycle handling for successful runs, failures, permission prompts, and aborted executions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->