### PR TITLE
fix(permissions): make legacy tool-name alias lookup prototype-safe

### DIFF
--- a/src/utils/permissions/permissionRuleParser.protoName.test.ts
+++ b/src/utils/permissions/permissionRuleParser.protoName.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, test } from 'bun:test'
+import { AGENT_TOOL_NAME } from '../../tools/AgentTool/constants.js'
+import {
+  normalizeLegacyToolName,
+  permissionRuleValueFromString,
+} from './permissionRuleParser.js'
+
+// Regression: LEGACY_TOOL_NAME_ALIASES is a plain object literal indexed by a
+// caller-supplied tool name. A bare bracket lookup resolves inherited
+// Object.prototype members, so a name that collides with one of them
+// (`constructor`, `toString`, `valueOf`, `hasOwnProperty`, `__proto__`)
+// returned the inherited function/object instead of the string. `?? name`
+// never caught it because the inherited value is non-null. That broke the
+// declared `string` return type and every downstream comparison
+// (availableToolNames.has(...), hook matcher `===`, permission-rule toolName).
+describe('normalizeLegacyToolName — prototype-safe alias lookup', () => {
+  const protoNames = [
+    'constructor',
+    'toString',
+    'valueOf',
+    'hasOwnProperty',
+    '__proto__',
+  ]
+
+  for (const name of protoNames) {
+    test(`'${name}' resolves to itself (own aliases only)`, () => {
+      const result = normalizeLegacyToolName(name)
+      expect(typeof result).toBe('string')
+      expect(result).toBe(name)
+    })
+  }
+
+  // Controls: real legacy aliases and plain passthrough names are unaffected.
+  test('genuine legacy aliases still map to their canonical name', () => {
+    expect(normalizeLegacyToolName('Task')).toBe(AGENT_TOOL_NAME)
+  })
+
+  test('unknown tool names pass through unchanged', () => {
+    expect(normalizeLegacyToolName('Bash')).toBe('Bash')
+    expect(normalizeLegacyToolName('Read')).toBe('Read')
+  })
+})
+
+describe('permissionRuleValueFromString — proto-name tool names', () => {
+  // A permission rule whose tool name collides with a prototype member must
+  // still yield that literal name as a string, not the inherited function.
+  test('bare proto-name rule keeps the literal tool name', () => {
+    const rule = permissionRuleValueFromString('constructor')
+    expect(typeof rule.toolName).toBe('string')
+    expect(rule.toolName).toBe('constructor')
+    expect(rule.ruleContent).toBeUndefined()
+  })
+
+  test('proto-name rule with content keeps the literal tool name and content', () => {
+    const rule = permissionRuleValueFromString('hasOwnProperty(rm -rf /)')
+    expect(typeof rule.toolName).toBe('string')
+    expect(rule.toolName).toBe('hasOwnProperty')
+    expect(rule.ruleContent).toBe('rm -rf /')
+  })
+
+  test('ordinary rules are unchanged', () => {
+    expect(permissionRuleValueFromString('Bash')).toEqual({ toolName: 'Bash' })
+    expect(permissionRuleValueFromString('Bash(npm install)')).toEqual({
+      toolName: 'Bash',
+      ruleContent: 'npm install',
+    })
+  })
+})

--- a/src/utils/permissions/permissionRuleParser.ts
+++ b/src/utils/permissions/permissionRuleParser.ts
@@ -29,7 +29,16 @@ const LEGACY_TOOL_NAME_ALIASES: Record<string, string> = {
 }
 
 export function normalizeLegacyToolName(name: string): string {
-  return LEGACY_TOOL_NAME_ALIASES[name] ?? name
+  // LEGACY_TOOL_NAME_ALIASES is a plain object, so a bracket lookup keyed by a
+  // caller-supplied name resolves inherited Object.prototype members. A tool or
+  // permission-rule name like `constructor`, `toString`, `valueOf`,
+  // `hasOwnProperty` or `__proto__` would otherwise return the inherited
+  // function/object (non-null, so `?? name` never fires), breaking this
+  // function's `string` contract and every downstream `Set.has` / `===`
+  // comparison. Only treat own aliases as matches.
+  return Object.hasOwn(LEGACY_TOOL_NAME_ALIASES, name)
+    ? LEGACY_TOOL_NAME_ALIASES[name]!
+    : name
 }
 
 export function getLegacyToolNames(canonicalName: string): string[] {


### PR DESCRIPTION
## Summary

`normalizeLegacyToolName` resolves legacy/renamed tool names to their canonical form by looking the name up in a plain object, `LEGACY_TOOL_NAME_ALIASES`, with a bare bracket access:

```ts
const LEGACY_TOOL_NAME_ALIASES: Record<string, string> = {
  Task: AGENT_TOOL_NAME,
  KillShell: TASK_STOP_TOOL_NAME,
  // ...
}

export function normalizeLegacyToolName(name: string): string {
  return LEGACY_TOOL_NAME_ALIASES[name] ?? name
}
```

Because the map is a normal object, a `name` that collides with an `Object.prototype` member resolves through the prototype chain. The `?? name` fallback does **not** catch it, since the inherited value is non-null:

| input | returns | expected |
|-------|---------|----------|
| `constructor` | `Object` **function** | `"constructor"` |
| `toString` | `Object.prototype.toString` function | `"toString"` |
| `valueOf` | function | `"valueOf"` |
| `hasOwnProperty` | function | `"hasOwnProperty"` |
| `__proto__` | `{}` (object) | `"__proto__"` |
| `Task` | `"AgentTool"` | ✓ |
| `Bash` | `"Bash"` | ✓ |

So the function, declared `(name: string): string`, returns a **function/object** for those inputs, which breaks every caller:

- `src/utils/messages.ts` — `availableToolNames.has(normalizeLegacyToolName(toolName))`. A tool legitimately named `constructor`/`toString`/etc. is in the Set as a *string*, but `.has(theFunction)` is `false`, so its `tool_reference` blocks are silently stripped as "unavailable".
- `src/utils/hooks.ts` — hook matcher/tool-name normalization compares a function against a string (`===`), so matching misbehaves.
- `src/utils/permissions/permissionRuleParser.ts` — every parsed permission rule's `toolName` flows through this helper, so a rule like `hasOwnProperty(rm -rf /)` parses to `{ toolName: <function>, ruleContent: 'rm -rf /' }` instead of a string tool name.

## Fix

Guard the lookup with `Object.hasOwn` so only own aliases match; everything else passes through unchanged. This mirrors the existing prototype-safe pattern already used elsewhere in the tree.

```ts
export function normalizeLegacyToolName(name: string): string {
  return Object.hasOwn(LEGACY_TOOL_NAME_ALIASES, name)
    ? LEGACY_TOOL_NAME_ALIASES[name]!
    : name
}
```

## Testing

New `permissionRuleParser.protoName.test.ts`:
- `normalizeLegacyToolName` returns the literal string for `constructor` / `toString` / `valueOf` / `hasOwnProperty` / `__proto__`.
- `permissionRuleValueFromString('constructor')` → `{ toolName: 'constructor' }`; `permissionRuleValueFromString('hasOwnProperty(rm -rf /)')` → `{ toolName: 'hasOwnProperty', ruleContent: 'rm -rf /' }`.
- Controls: `Task` → canonical name, `Bash`/`Read` pass through, ordinary rules unchanged.

Reverting only the guard back to `LEGACY_TOOL_NAME_ALIASES[name] ?? name` makes the new proto-name cases fail; the fix makes them pass.

```
bun test src/utils/permissions/    # all pass
bun run typecheck                  # clean
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved permission rule parsing to safely handle tool names that match built-in object property names.
  * Preserved literal tool names like `constructor`, `toString`, `valueOf`, `hasOwnProperty`, and `__proto__` instead of treating them as aliases.
  * Ensured normal tool rules still behave as expected, including rules with additional content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->