### PR TITLE
fix(query): configure hard max and abort reasons

### DIFF
--- a/docs/advanced-setup.md
+++ b/docs/advanced-setup.md
@@ -394,6 +394,7 @@ The **OpenClaude VS Code extension** can store the key in Secret Storage and set
 | `CODEX_HOME` | Codex only | Alternative Codex home directory |
 | `OPENCLAUDE_MAX_RETRIES` | No | Maximum retry attempts for retryable API failures, capped at 100 (default: 10). Set to `0` to disable retries after the initial request. If unset, deprecated `CLAUDE_CODE_MAX_RETRIES` is still honored for compatibility. |
 | `OPENCLAUDE_RETRY_DELAY_MS` | No | Base retry delay in milliseconds for APIs that do not send `Retry-After`; exponential backoff starts from this value, capped at 60000 (default: 500) |
+| `OPENCLAUDE_QUERY_HARD_MAX_MS` | No | Foreground query hard maximum in milliseconds. Defaults to 1800000 (30 minutes). Use a larger positive integer for long autonomous sessions; invalid, zero, negative, fractional, or timer-overflow values are ignored with a warning. |
 | `OPENCLAUDE_DISABLE_CO_AUTHORED_BY` | No | Suppress the default `Co-Authored-By` trailer in generated git commits |
 | `OPENCLAUDE_LOG_TOKEN_USAGE` | No | When truthy (e.g. `verbose`), emits one JSON line on stderr per API request with input/output/cache tokens and the resolved provider. **User-facing debug output** — complements the REPL display controlled by `/config showCacheStats`. Distinct from `CLAUDE_CODE_ENABLE_TOKEN_USAGE_ATTACHMENT`, which is **model-facing** (injects context usage info into the prompt itself). Both can run together. |
 

--- a/src/query.abortClassification.test.ts
+++ b/src/query.abortClassification.test.ts
@@ -62,9 +62,10 @@ function abort(controller: AbortController, reason: AbortInput): void {
   controller.abort(reason)
 }
 
-function makeParams(reason: AbortInput, tools: Tools = []): QueryParams {
-  const toolUseContext = makeToolUseContext(tools)
-
+function makeBaseParams(
+  toolUseContext: QueryParams['toolUseContext'],
+  callModel: QueryDeps['callModel'],
+): QueryParams {
   return {
     messages: [createUserMessage({ content: 'run tool' })],
     systemPrompt: asSystemPrompt([]),
@@ -75,19 +76,7 @@ function makeParams(reason: AbortInput, tools: Tools = []): QueryParams {
     querySource: 'agent:builtin:general-purpose',
     agentStepLimit: { maxSteps: 999, agentType: 'general-purpose' },
     deps: {
-      callModel: async function* () {
-        yield createAssistantMessage({
-          content: [
-            {
-              type: 'tool_use',
-              id: 'toolu_timeout_1',
-              name: 'SlowTool',
-              input: {},
-            },
-          ],
-        })
-        abort(toolUseContext.abortController, reason)
-      },
+      callModel,
       microcompact: async messages => ({ messages }),
       autocompact: async () => ({
         compactionResult: null,
@@ -96,6 +85,24 @@ function makeParams(reason: AbortInput, tools: Tools = []): QueryParams {
       uuid: () => '00000000-0000-4000-8000-000000000000',
     } as unknown as QueryDeps,
   }
+}
+
+function makeParams(reason: AbortInput, tools: Tools = []): QueryParams {
+  const toolUseContext = makeToolUseContext(tools)
+
+  return makeBaseParams(toolUseContext, async function* () {
+    yield createAssistantMessage({
+      content: [
+        {
+          type: 'tool_use',
+          id: 'toolu_timeout_1',
+          name: 'SlowTool',
+          input: {},
+        },
+      ],
+    })
+    abort(toolUseContext.abortController, reason)
+  })
 }
 
 function makeToolAbortParams(reason: AbortInput): QueryParams {
@@ -109,36 +116,18 @@ function makeToolAbortParams(reason: AbortInput): QueryParams {
   })
   toolUseContext = makeToolUseContext([tool])
 
-  return {
-    messages: [createUserMessage({ content: 'run tool' })],
-    systemPrompt: asSystemPrompt([]),
-    userContext: {},
-    systemContext: {},
-    canUseTool: async () => ({ behavior: 'allow' }),
-    toolUseContext,
-    querySource: 'agent:builtin:general-purpose',
-    agentStepLimit: { maxSteps: 999, agentType: 'general-purpose' },
-    deps: {
-      callModel: async function* () {
-        yield createAssistantMessage({
-          content: [
-            {
-              type: 'tool_use',
-              id: 'toolu_abort_during_tool_1',
-              name: 'AbortDuringTool',
-              input: {},
-            },
-          ],
-        })
-      },
-      microcompact: async messages => ({ messages }),
-      autocompact: async () => ({
-        compactionResult: null,
-        consecutiveFailures: undefined,
-      }),
-      uuid: () => '00000000-0000-4000-8000-000000000000',
-    } as unknown as QueryDeps,
-  }
+  return makeBaseParams(toolUseContext, async function* () {
+    yield createAssistantMessage({
+      content: [
+        {
+          type: 'tool_use',
+          id: 'toolu_abort_during_tool_1',
+          name: 'AbortDuringTool',
+          input: {},
+        },
+      ],
+    })
+  })
 }
 
 async function drainWithReturn(params: QueryParams): Promise<{

--- a/src/query.abortClassification.test.ts
+++ b/src/query.abortClassification.test.ts
@@ -1,65 +1,260 @@
 import { describe, expect, test } from 'bun:test'
-import { readFileSync } from 'node:fs'
-import { join } from 'node:path'
+import { z } from 'zod/v4'
 
-const source = readFileSync(join(import.meta.dirname, 'query.ts'), 'utf8')
+import { query, type QueryParams } from './query.js'
+import type { QueryDeps } from './query/deps.js'
+import { createToolFixture } from './test/toolFixtures.js'
+import type { Tools } from './Tool.js'
+import {
+  createAssistantMessage,
+  createUserMessage,
+  INTERRUPT_MESSAGE,
+} from './utils/messages.js'
+import { asSystemPrompt } from './utils/systemPromptType.js'
 
-function getAbortBlocks(): string[] {
-  const blocks: string[] = []
-  let searchFrom = 0
-  const needle = 'if (toolUseContext.abortController.signal.aborted) {'
+const DEFAULT_ABORT = Symbol('default abort')
 
-  while (true) {
-    const start = source.indexOf(needle, searchFrom)
-    if (start === -1) break
+type AbortInput = string | typeof DEFAULT_ABORT
 
-    let depth = 0
-    let end = -1
-    for (
-      let i = start + source.slice(start).indexOf('{');
-      i < source.length;
-      i++
-    ) {
-      const ch = source[i]
-      if (ch === '{') depth++
-      else if (ch === '}') {
-        depth--
-        if (depth === 0) {
-          end = i + 1
-          break
-        }
-      }
-    }
-    expect(end).toBeGreaterThan(start)
-    blocks.push(source.slice(start, end))
-    searchFrom = end
-  }
+function makeToolUseContext(tools: Tools = []): QueryParams['toolUseContext'] {
+  const abortController = new AbortController()
 
-  return blocks
+  return {
+    abortController,
+    agentId: 'agent-test',
+    getAppState: () => ({
+      fastMode: false,
+      mcp: { tools: [], clients: [] },
+      toolPermissionContext: { mode: 'default' },
+      sessionHooks: new Map(),
+      mainLoopModel: 'gpt-4o',
+      effortValue: undefined,
+      advisorModel: undefined,
+    }),
+    options: {
+      commands: [],
+      debug: false,
+      thinkingConfig: { type: 'disabled' },
+      tools,
+      verbose: false,
+      mcpClients: [],
+      mcpResources: {},
+      isNonInteractiveSession: false,
+      agentDefinitions: { activeAgents: [], allowedAgentTypes: undefined },
+      appendSystemPrompt: undefined,
+      providerOverride: undefined,
+      mainLoopModel: 'gpt-4o',
+    },
+    addNotification: () => {},
+    messages: [],
+    setInProgressToolUseIDs: () => {},
+    setResponseLength: () => {},
+    updateFileHistoryState: () => {},
+    updateAttributionState: () => {},
+  } as unknown as QueryParams['toolUseContext']
 }
 
-describe('query abort classification wiring', () => {
-  test('uses abort reason helpers instead of treating every abort as user interruption', () => {
-    expect(source).toContain("from './utils/abortReasons.js'")
-    expect(source).toContain('getMissingToolResultAbortMessage')
-    expect(source).toContain('getQueryAbortSystemMessage')
-    expect(source).toContain('shouldCreateUserInterruptionMessage')
+function abort(controller: AbortController, reason: AbortInput): void {
+  if (reason === DEFAULT_ABORT) {
+    controller.abort()
+    return
+  }
+  controller.abort(reason)
+}
 
-    const abortBlocks = getAbortBlocks().filter(block =>
-      block.includes('createUserInterruptionMessage'),
-    )
-    expect(abortBlocks).toHaveLength(2)
+function makeParams(reason: AbortInput, tools: Tools = []): QueryParams {
+  const toolUseContext = makeToolUseContext(tools)
 
-    for (const block of abortBlocks) {
-      expect(block).toContain('shouldCreateUserInterruptionMessage(')
-      expect(block).toContain('getQueryAbortSystemMessage(')
-      if (block.includes('yieldMissingToolResultBlocks')) {
-        expect(block).toContain('getMissingToolResultAbortMessage(')
-      }
-      expect(block).not.toContain(
-        "toolUseContext.abortController.signal.reason !== 'interrupt'",
-      )
-      expect(block).not.toContain("'Interrupted by user'")
+  return {
+    messages: [createUserMessage({ content: 'run tool' })],
+    systemPrompt: asSystemPrompt([]),
+    userContext: {},
+    systemContext: {},
+    canUseTool: async () => ({ behavior: 'allow' }),
+    toolUseContext,
+    querySource: 'agent:builtin:general-purpose',
+    agentStepLimit: { maxSteps: 999, agentType: 'general-purpose' },
+    deps: {
+      callModel: async function* () {
+        yield createAssistantMessage({
+          content: [
+            {
+              type: 'tool_use',
+              id: 'toolu_timeout_1',
+              name: 'SlowTool',
+              input: {},
+            },
+          ],
+        })
+        abort(toolUseContext.abortController, reason)
+      },
+      microcompact: async messages => ({ messages }),
+      autocompact: async () => ({
+        compactionResult: null,
+        consecutiveFailures: undefined,
+      }),
+      uuid: () => '00000000-0000-4000-8000-000000000000',
+    } as unknown as QueryDeps,
+  }
+}
+
+function makeToolAbortParams(reason: AbortInput): QueryParams {
+  let toolUseContext!: QueryParams['toolUseContext']
+  const tool = createToolFixture(z.object({}), {
+    name: 'AbortDuringTool',
+    async call() {
+      abort(toolUseContext.abortController, reason)
+      return { data: 'aborted during tool execution' }
+    },
+  })
+  toolUseContext = makeToolUseContext([tool])
+
+  return {
+    messages: [createUserMessage({ content: 'run tool' })],
+    systemPrompt: asSystemPrompt([]),
+    userContext: {},
+    systemContext: {},
+    canUseTool: async () => ({ behavior: 'allow' }),
+    toolUseContext,
+    querySource: 'agent:builtin:general-purpose',
+    agentStepLimit: { maxSteps: 999, agentType: 'general-purpose' },
+    deps: {
+      callModel: async function* () {
+        yield createAssistantMessage({
+          content: [
+            {
+              type: 'tool_use',
+              id: 'toolu_abort_during_tool_1',
+              name: 'AbortDuringTool',
+              input: {},
+            },
+          ],
+        })
+      },
+      microcompact: async messages => ({ messages }),
+      autocompact: async () => ({
+        compactionResult: null,
+        consecutiveFailures: undefined,
+      }),
+      uuid: () => '00000000-0000-4000-8000-000000000000',
+    } as unknown as QueryDeps,
+  }
+}
+
+async function drainWithReturn(params: QueryParams): Promise<{
+  yielded: any[]
+  returned: any
+}> {
+  const yielded: any[] = []
+  const generator = query(params)
+  while (true) {
+    const next = await generator.next()
+    if (next.done) return { yielded, returned: next.value }
+    yielded.push(next.value)
+  }
+}
+
+function toolResultContents(yielded: any[]): string[] {
+  return yielded.flatMap(message => {
+    if (message.type !== 'user' || !Array.isArray(message.message.content)) {
+      return []
     }
+    return message.message.content
+      .filter((part: any) => part.type === 'tool_result')
+      .map((part: any) => part.content)
+  })
+}
+
+function systemMessages(yielded: any[]) {
+  return yielded.filter(message => message.type === 'system')
+}
+
+function interruptionMessages(yielded: any[]) {
+  return yielded.filter(
+    message =>
+      message.type === 'user' &&
+      Array.isArray(message.message.content) &&
+      message.message.content.some(
+        (part: any) => part.type === 'text' && part.text === INTERRUPT_MESSAGE,
+      ),
+  )
+}
+
+describe('query abort classification', () => {
+  test('query timeout aborts produce timeout transcript text without user interruption', async () => {
+    const { yielded, returned } = await drainWithReturn(
+      makeParams('query-timeout'),
+    )
+
+    expect(returned.reason).toBe('aborted_streaming')
+    expect(toolResultContents(yielded)).toEqual([
+      'Tool use was interrupted because the query timed out.',
+    ])
+    expect(systemMessages(yielded)).toMatchObject([
+      {
+        content: 'Query timed out before completion.',
+        level: 'warning',
+      },
+    ])
+    expect(interruptionMessages(yielded)).toHaveLength(0)
+  })
+
+  test('hard max aborts produce hard-timeout transcript text without user interruption', async () => {
+    const { yielded, returned } = await drainWithReturn(makeParams('hard_max'))
+
+    expect(returned.reason).toBe('aborted_streaming')
+    expect(toolResultContents(yielded)).toEqual([
+      'Tool use was interrupted because the query reached its hard maximum runtime.',
+    ])
+    expect(systemMessages(yielded)).toMatchObject([
+      {
+        content:
+          'Query reached the hard maximum runtime and was stopped before completion.',
+        level: 'warning',
+      },
+    ])
+    expect(interruptionMessages(yielded)).toHaveLength(0)
+  })
+
+  test('background aborts produce background transcript text without user interruption', async () => {
+    const { yielded, returned } = await drainWithReturn(makeParams('background'))
+
+    expect(returned.reason).toBe('aborted_streaming')
+    expect(toolResultContents(yielded)).toEqual([
+      'Tool use was interrupted because the query was backgrounded.',
+    ])
+    expect(systemMessages(yielded)).toMatchObject([
+      {
+        content: 'Query was backgrounded before completion.',
+        level: 'warning',
+      },
+    ])
+    expect(interruptionMessages(yielded)).toHaveLength(0)
+  })
+
+  test('legacy bare abort remains classified as a user interruption', async () => {
+    const { yielded, returned } = await drainWithReturn(
+      makeParams(DEFAULT_ABORT),
+    )
+
+    expect(returned.reason).toBe('aborted_streaming')
+    expect(toolResultContents(yielded)).toEqual(['Interrupted by user'])
+    expect(systemMessages(yielded)).toHaveLength(0)
+    expect(interruptionMessages(yielded)).toHaveLength(1)
+  })
+
+  test('mid-tool query timeout aborts without creating user interruption text', async () => {
+    const { yielded, returned } = await drainWithReturn(
+      makeToolAbortParams('query-timeout'),
+    )
+
+    expect(returned.reason).toBe('aborted_tools')
+    expect(systemMessages(yielded)).toMatchObject([
+      {
+        content: 'Query timed out before completion.',
+        level: 'warning',
+      },
+    ])
+    expect(interruptionMessages(yielded)).toHaveLength(0)
   })
 })

--- a/src/query.abortClassification.test.ts
+++ b/src/query.abortClassification.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, test } from 'bun:test'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+const source = readFileSync(join(import.meta.dirname, 'query.ts'), 'utf8')
+
+function getAbortBlocks(): string[] {
+  const blocks: string[] = []
+  let searchFrom = 0
+  const needle = 'if (toolUseContext.abortController.signal.aborted) {'
+
+  while (true) {
+    const start = source.indexOf(needle, searchFrom)
+    if (start === -1) break
+
+    let depth = 0
+    let end = -1
+    for (
+      let i = start + source.slice(start).indexOf('{');
+      i < source.length;
+      i++
+    ) {
+      const ch = source[i]
+      if (ch === '{') depth++
+      else if (ch === '}') {
+        depth--
+        if (depth === 0) {
+          end = i + 1
+          break
+        }
+      }
+    }
+    expect(end).toBeGreaterThan(start)
+    blocks.push(source.slice(start, end))
+    searchFrom = end
+  }
+
+  return blocks
+}
+
+describe('query abort classification wiring', () => {
+  test('uses abort reason helpers instead of treating every abort as user interruption', () => {
+    expect(source).toContain("from './utils/abortReasons.js'")
+    expect(source).toContain('getMissingToolResultAbortMessage')
+    expect(source).toContain('getQueryAbortSystemMessage')
+    expect(source).toContain('shouldCreateUserInterruptionMessage')
+
+    const abortBlocks = getAbortBlocks().filter(block =>
+      block.includes('createUserInterruptionMessage'),
+    )
+    expect(abortBlocks).toHaveLength(2)
+
+    for (const block of abortBlocks) {
+      expect(block).toContain('shouldCreateUserInterruptionMessage(')
+      expect(block).toContain('getQueryAbortSystemMessage(')
+      if (block.includes('yieldMissingToolResultBlocks')) {
+        expect(block).toContain('getMissingToolResultAbortMessage(')
+      }
+      expect(block).not.toContain(
+        "toolUseContext.abortController.signal.reason !== 'interrupt'",
+      )
+      expect(block).not.toContain("'Interrupted by user'")
+    }
+  })
+})

--- a/src/query.ts
+++ b/src/query.ts
@@ -49,6 +49,11 @@ import {
 } from './services/api/errors.js'
 import { logAntError, logForDebugging } from './utils/debug.js'
 import {
+  getMissingToolResultAbortMessage,
+  getQueryAbortSystemMessage,
+  shouldCreateUserInterruptionMessage,
+} from './utils/abortReasons.js'
+import {
   createAssistantMessage,
   createUserMessage,
   createUserInterruptionMessage,
@@ -1393,6 +1398,7 @@ async function* queryLoop(
     // executor can generate synthetic tool_result blocks for queued/in-progress tools.
     // Without this, tool_use blocks would lack matching tool_result blocks.
     if (toolUseContext.abortController.signal.aborted) {
+      const abortReason = toolUseContext.abortController.signal.reason
       if (streamingToolExecutor) {
         // Consume remaining results - executor generates synthetic tool_results for
         // aborted tools since it checks the abort signal in executeTool()
@@ -1404,7 +1410,7 @@ async function* queryLoop(
       } else {
         yield* yieldMissingToolResultBlocks(
           assistantMessages,
-          'Interrupted by user',
+          getMissingToolResultAbortMessage(abortReason),
         )
       }
       // chicago MCP: auto-unhide + lock release on interrupt. Same cleanup
@@ -1421,9 +1427,12 @@ async function* queryLoop(
         }
       }
 
-      // Skip the interruption message for submit-interrupts — the queued
-      // user message that follows provides sufficient context.
-      if (toolUseContext.abortController.signal.reason !== 'interrupt') {
+      const abortSystemMessage = getQueryAbortSystemMessage(abortReason)
+      if (abortSystemMessage) {
+        yield createSystemMessage(abortSystemMessage, 'warning')
+      }
+
+      if (shouldCreateUserInterruptionMessage(abortReason)) {
         yield createUserInterruptionMessage({
           toolUse: false,
         })
@@ -2117,6 +2126,7 @@ async function* queryLoop(
 
     // We were aborted during tool calls
     if (toolUseContext.abortController.signal.aborted) {
+      const abortReason = toolUseContext.abortController.signal.reason
       // chicago MCP: auto-unhide + lock release when aborted mid-tool-call.
       // This is the most likely Ctrl+C path for CU (e.g. slow screenshot).
       // Main thread only — see stopHooks.ts for the subagent rationale.
@@ -2130,9 +2140,12 @@ async function* queryLoop(
           // Failures are silent — this is dogfooding cleanup, not critical path
         }
       }
-      // Skip the interruption message for submit-interrupts — the queued
-      // user message that follows provides sufficient context.
-      if (toolUseContext.abortController.signal.reason !== 'interrupt') {
+      const abortSystemMessage = getQueryAbortSystemMessage(abortReason)
+      if (abortSystemMessage) {
+        yield createSystemMessage(abortSystemMessage, 'warning')
+      }
+
+      if (shouldCreateUserInterruptionMessage(abortReason)) {
         yield createUserInterruptionMessage({
           toolUse: true,
         })

--- a/src/query/stopHooks.goal.test.ts
+++ b/src/query/stopHooks.goal.test.ts
@@ -244,6 +244,10 @@ function interruptionMessages(yielded: any[]) {
   )
 }
 
+function systemMessages(yielded: any[]) {
+  return yielded.filter(message => message.type === 'system')
+}
+
 describe('handleStopHooks abort-reason handling', () => {
   test('abort reason "interrupt" suppresses the synthetic interruption message', async () => {
     const appStateRef = { current: getDefaultAppState() }
@@ -273,6 +277,76 @@ describe('handleStopHooks abort-reason handling', () => {
     )
 
     expect(interruptionMessages(yielded)).toHaveLength(0)
+    expect(returned.preventContinuation).toBe(true)
+  })
+
+  test('query timeout abort yields timeout wording without user interruption', async () => {
+    const appStateRef = { current: getDefaultAppState() }
+    const toolUseContext = makeToolUseContext(appStateRef)
+
+    const { yielded, returned } = await drain(
+      handleStopHooks(
+        [],
+        [assistant('assistant-1', 'Done.') as any],
+        asSystemPrompt([]),
+        {},
+        {},
+        toolUseContext,
+        'sdk',
+        false,
+        undefined,
+        {
+          executeStopHooks: async function* () {
+            toolUseContext.abortController.abort('query-timeout')
+            yield {} as any
+          },
+          isTeammate: () => false,
+        },
+      ),
+    )
+
+    expect(interruptionMessages(yielded)).toHaveLength(0)
+    expect(systemMessages(yielded)).toMatchObject([
+      {
+        content: 'Query timed out before completion.',
+        level: 'warning',
+      },
+    ])
+    expect(returned.preventContinuation).toBe(true)
+  })
+
+  test('background abort yields background wording without user interruption', async () => {
+    const appStateRef = { current: getDefaultAppState() }
+    const toolUseContext = makeToolUseContext(appStateRef)
+
+    const { yielded, returned } = await drain(
+      handleStopHooks(
+        [],
+        [assistant('assistant-1', 'Done.') as any],
+        asSystemPrompt([]),
+        {},
+        {},
+        toolUseContext,
+        'sdk',
+        false,
+        undefined,
+        {
+          executeStopHooks: async function* () {
+            toolUseContext.abortController.abort('background')
+            yield {} as any
+          },
+          isTeammate: () => false,
+        },
+      ),
+    )
+
+    expect(interruptionMessages(yielded)).toHaveLength(0)
+    expect(systemMessages(yielded)).toMatchObject([
+      {
+        content: 'Query was backgrounded before completion.',
+        level: 'warning',
+      },
+    ])
     expect(returned.preventContinuation).toBe(true)
   })
 

--- a/src/query/stopHooks.ts
+++ b/src/query/stopHooks.ts
@@ -17,6 +17,10 @@ import type {
   ToolUseSummaryMessage,
 } from '../types/message.js'
 import { createAttachmentMessage } from '../utils/attachments.js'
+import {
+  getQueryAbortSystemMessage,
+  shouldCreateUserInterruptionMessage,
+} from '../utils/abortReasons.js'
 import { logForDebugging } from '../utils/debug.js'
 import { errorMessage } from '../utils/errors.js'
 import type { REPLHookContext } from '../utils/hooks/postSamplingHooks.js'
@@ -316,13 +320,18 @@ export async function* handleStopHooks(
 
       // Check if we were aborted during hook execution
       if (toolUseContext.abortController.signal.aborted) {
+        const abortReason = toolUseContext.abortController.signal.reason
         logEvent('tengu_pre_stop_hooks_cancelled', {
           queryChainId: toolUseContext.queryTracking
             ?.chainId as AnalyticsMetadata_I_VERIFIED_THIS_IS_NOT_CODE_OR_FILEPATHS,
 
           queryDepth: toolUseContext.queryTracking?.depth,
         })
-        if (toolUseContext.abortController.signal.reason !== 'interrupt') {
+        const abortSystemMessage = getQueryAbortSystemMessage(abortReason)
+        if (abortSystemMessage) {
+          yield createSystemMessage(abortSystemMessage, 'warning')
+        }
+        if (shouldCreateUserInterruptionMessage(abortReason)) {
           yield createUserInterruptionMessage({
             toolUse: false,
           })

--- a/src/query/toolFailureLoopGuard.test.ts
+++ b/src/query/toolFailureLoopGuard.test.ts
@@ -1,6 +1,7 @@
 import { expect, test } from 'bun:test'
 
 import type { ToolUseBlock } from '@anthropic-ai/sdk/resources/index.mjs'
+import { getMissingToolResultAbortMessage } from '../utils/abortReasons.js'
 import {
   createToolFailureLoopGuardState,
   getToolFailureLoopThreshold,
@@ -173,6 +174,13 @@ test('user aborts, user rejections, and streaming fallback discards are ignored'
     'User rejected tool use',
     "The user doesn't want to proceed with this tool use",
     "The user doesn't want to take this action right now",
+    getMissingToolResultAbortMessage('interrupt'),
+    getMissingToolResultAbortMessage('query-timeout'),
+    getMissingToolResultAbortMessage('hard-max-query-timeout'),
+    getMissingToolResultAbortMessage('background'),
+    getMissingToolResultAbortMessage('side-task-cancelled'),
+    getMissingToolResultAbortMessage('parent-ended'),
+    getMissingToolResultAbortMessage('unknown-abort'),
     'Streaming fallback - tool execution discarded',
     'Cancelled: parallel tool call abc was skipped',
   ]
@@ -189,6 +197,49 @@ test('user aborts, user rejections, and streaming fallback discards are ignored'
     toolResult('real', 'Error writing file: failed to replace text'),
   ])
   expect(decision.tripped).toBe(false)
+})
+
+test('reason-aware synthetic aborts are ignored through wrappers and memory hints', () => {
+  const state = createToolFailureLoopGuardState()
+
+  const ignoredMessages = [
+    `<tool_use_error>${getMissingToolResultAbortMessage('query-timeout')}</tool_use_error>`,
+    `Error: ${getMissingToolResultAbortMessage('hard-max-query-timeout')}`,
+    `[${getMissingToolResultAbortMessage('background')}]`,
+    `${getMissingToolResultAbortMessage('unknown-abort')}\n\nNote: memory hint`,
+  ]
+
+  for (const [index, message] of ignoredMessages.entries()) {
+    const id = `reason-aware-${index}`
+    const decision = update(state, [toolUse(id, 'Bash')], [
+      toolResult(id, message),
+    ])
+    expect(decision.tripped).toBe(false)
+  }
+
+  const decision = update(
+    state,
+    [toolUse('real', 'Bash')],
+    [toolResult('real', 'Error: command exited 1')],
+    2,
+  )
+
+  expect(decision.tripped).toBe(false)
+})
+
+test('tool timeout messages still count as real tool failures', () => {
+  const state = createToolFailureLoopGuardState()
+  const timeoutMessage = getMissingToolResultAbortMessage('tool-timeout')
+
+  update(state, [toolUse('a', 'Bash')], [toolResult('a', timeoutMessage)], 2)
+  const decision = update(
+    state,
+    [toolUse('b', 'Bash')],
+    [toolResult('b', timeoutMessage)],
+    2,
+  )
+
+  expect(decision.tripped).toBe(true)
 })
 
 test('synthetic tool errors are recognized through wrappers', () => {

--- a/src/query/toolFailureLoopGuard.ts
+++ b/src/query/toolFailureLoopGuard.ts
@@ -1,9 +1,21 @@
 import type { ToolUseBlock } from '@anthropic-ai/sdk/resources/index.mjs'
 
 import type { AttachmentMessage, UserMessage } from '../types/message.js'
+import { getMissingToolResultAbortMessage } from '../utils/abortReasons.js'
 
 const DEFAULT_TOOL_FAILURE_LOOP_THRESHOLD = 3
 const MAX_FALLBACK_CATEGORY_LENGTH = 120
+// Parent-query aborts are synthetic cleanup results, not tool failures.
+// Deliberately exclude tool-timeout: that is the tool's own failure mode.
+const SYNTHETIC_ABORT_TOOL_RESULT_PREFIXES = [
+  getMissingToolResultAbortMessage('interrupt'),
+  getMissingToolResultAbortMessage('query-timeout'),
+  getMissingToolResultAbortMessage('hard-max-query-timeout'),
+  getMissingToolResultAbortMessage('background'),
+  getMissingToolResultAbortMessage('side-task-cancelled'),
+  getMissingToolResultAbortMessage('parent-ended'),
+  getMissingToolResultAbortMessage('unknown-abort'),
+].map(message => message.toLowerCase())
 
 export type ToolFailureLoopGuardState = {
   persistentSignatureCounts: Map<string, number>
@@ -327,6 +339,9 @@ function isIgnoredSyntheticToolResult(content: string): boolean {
     ) ||
     withoutErrorPrefix.startsWith(
       "the user doesn't want to take this action right now",
+    ) ||
+    SYNTHETIC_ABORT_TOOL_RESULT_PREFIXES.some(prefix =>
+      withoutErrorPrefix.startsWith(prefix),
     ) ||
     withoutErrorPrefix === 'streaming fallback - tool execution discarded' ||
     withoutErrorPrefix.startsWith('cancelled: parallel tool call')

--- a/src/screens/REPL.queryLifecycle.test.ts
+++ b/src/screens/REPL.queryLifecycle.test.ts
@@ -23,6 +23,13 @@ function getQueryFinallyBody(): string {
 }
 
 describe('REPL query lifecycle timeout logging', () => {
+  test('constructs QueryGuard with resolved hard max config', () => {
+    expect(source).toContain(
+      "import { getQueryGuardOptionsFromEnv } from '../utils/queryGuardConfig.js'",
+    )
+    expect(source).toContain('new QueryGuard(getQueryGuardOptionsFromEnv())')
+  })
+
   test('does not emit terminal timeout end from timeout handler', () => {
     const body = getAbortTimedOutQueryBody()
     const queueMicrotaskIndex = body.indexOf('queueMicrotask(() => {')

--- a/src/screens/REPL.tsx
+++ b/src/screens/REPL.tsx
@@ -35,10 +35,9 @@ import { registerPrunableCache } from '../utils/memoryPressure.js';
 import { updateLastInteractionTime, getLastInteractionTime, getOriginalCwd, getProjectRoot, getSessionId, switchSession, setCostStateForRestore, resetTurnHookDuration, resetTurnToolDuration, resetTurnClassifierDuration, setMainLoopModelOverride, setMainThreadAgentType } from '../bootstrap/state.js';
 import { asSessionId, asAgentId } from '../types/ids.js';
 import { logForDebugging } from '../utils/debug.js';
-import { normalizeAbortReason } from '../utils/abortReasons.js';
 import { QueryGuard } from '../utils/QueryGuard.js';
 import { getQueryGuardOptionsFromEnv } from '../utils/queryGuardConfig.js';
-import { QueryLifecycleOperationTracker, formatQueryLifecycleAbortSignalReason, formatQueryLifecycleLogMessage, type QueryActiveOperationSnapshot, type QueryGuardTimeoutInfo, type QueryLifecycleContext, type QueryTerminalReason } from '../utils/queryLifecycle.js';
+import { QueryLifecycleOperationTracker, formatQueryLifecycleAbortSignalReason, formatQueryLifecycleLogMessage, getQueryTerminalReason, type QueryActiveOperationSnapshot, type QueryGuardTimeoutInfo, type QueryLifecycleContext, type QueryTerminalReason } from '../utils/queryLifecycle.js';
 import { createCombinedAbortSignal } from '../utils/combinedAbortSignal.js';
 import { isEnvTruthy } from '../utils/envUtils.js';
 import { formatTokens, truncateToWidth } from '../utils/format.js';
@@ -560,24 +559,6 @@ function getAbortReasonLabel(reason: unknown): string | undefined {
   if (typeof reason === 'string') return reason;
   if (reason instanceof Error) return reason.name;
   return String(reason);
-}
-function getQueryTerminalReason(signal: AbortSignal, didThrow: boolean): QueryTerminalReason {
-  if (!signal.aborted) return didThrow ? 'unknown' : 'ok';
-  switch (normalizeAbortReason(signal.reason)) {
-    case 'query-timeout':
-      return 'query-timeout';
-    case 'hard-max-query-timeout':
-      return 'hard-max-query-timeout';
-    case 'user-abort':
-    case 'interrupt':
-      return 'user-abort';
-    case 'background':
-    case 'parent-ended':
-    case 'side-task-cancelled':
-      return 'parent-ended';
-    default:
-      return 'unknown';
-  }
 }
 function summarizeActiveOperations(snapshot: QueryActiveOperationSnapshot): string {
   const apiIds = snapshot.apiCalls.map(call => call.requestId ?? call.clientRequestId ?? 'unknown').join(',');

--- a/src/screens/REPL.tsx
+++ b/src/screens/REPL.tsx
@@ -35,7 +35,9 @@ import { registerPrunableCache } from '../utils/memoryPressure.js';
 import { updateLastInteractionTime, getLastInteractionTime, getOriginalCwd, getProjectRoot, getSessionId, switchSession, setCostStateForRestore, resetTurnHookDuration, resetTurnToolDuration, resetTurnClassifierDuration, setMainLoopModelOverride, setMainThreadAgentType } from '../bootstrap/state.js';
 import { asSessionId, asAgentId } from '../types/ids.js';
 import { logForDebugging } from '../utils/debug.js';
+import { normalizeAbortReason } from '../utils/abortReasons.js';
 import { QueryGuard } from '../utils/QueryGuard.js';
+import { getQueryGuardOptionsFromEnv } from '../utils/queryGuardConfig.js';
 import { QueryLifecycleOperationTracker, formatQueryLifecycleAbortSignalReason, formatQueryLifecycleLogMessage, type QueryActiveOperationSnapshot, type QueryGuardTimeoutInfo, type QueryLifecycleContext, type QueryTerminalReason } from '../utils/queryLifecycle.js';
 import { createCombinedAbortSignal } from '../utils/combinedAbortSignal.js';
 import { isEnvTruthy } from '../utils/envUtils.js';
@@ -561,13 +563,17 @@ function getAbortReasonLabel(reason: unknown): string | undefined {
 }
 function getQueryTerminalReason(signal: AbortSignal, didThrow: boolean): QueryTerminalReason {
   if (!signal.aborted) return didThrow ? 'unknown' : 'ok';
-  switch (getAbortReasonLabel(signal.reason)) {
+  switch (normalizeAbortReason(signal.reason)) {
     case 'query-timeout':
       return 'query-timeout';
-    case 'user-cancel':
+    case 'hard-max-query-timeout':
+      return 'hard-max-query-timeout';
+    case 'user-abort':
     case 'interrupt':
       return 'user-abort';
     case 'background':
+    case 'parent-ended':
+    case 'side-task-cancelled':
       return 'parent-ended';
     default:
       return 'unknown';
@@ -1002,7 +1008,11 @@ export function REPL({
   // Synchronous state machine for the query lifecycle. Replaces the
   // error-prone dual-state pattern where isLoading (React state, async
   // batched) and isQueryRunning (ref, sync) could desync. See QueryGuard.ts.
-  const queryGuard = React.useRef(new QueryGuard()).current;
+  const queryGuardRef = React.useRef<QueryGuard | null>(null);
+  if (queryGuardRef.current === null) {
+    queryGuardRef.current = new QueryGuard(getQueryGuardOptionsFromEnv());
+  }
+  const queryGuard = queryGuardRef.current;
 
   // Subscribe to the guard — true during dispatching or running.
   // This is the single source of truth for "is a local query in flight".
@@ -1804,11 +1814,12 @@ export function REPL({
   const mrRender = useCallback(() => null, []);
   const abortTimedOutQuery = useCallback((timeout: QueryGuardTimeoutInfo) => {
     const timeoutOperations = summarizeActiveOperations(timeout.activeOperations);
+    const timeoutAbortReason = timeout.context.terminalReason ?? 'query-timeout';
     logQueryLifecycle('timeout', timeout.context, timeoutOperations);
     const activeAbortController = abortControllerRef.current;
     if (activeAbortController && !activeAbortController.signal.aborted) {
-      logQueryLifecycle('abort_requested', timeout.context, formatQueryLifecycleAbortSignalReason('query-timeout'));
-      activeAbortController.abort('query-timeout');
+      logQueryLifecycle('abort_requested', timeout.context, formatQueryLifecycleAbortSignalReason(timeoutAbortReason));
+      activeAbortController.abort(timeoutAbortReason);
     }
     if (timeout.activeOperations.apiCalls.length > 0) {
       logForDebugging(`api.call.active_on_abort queryId=${timeout.context.queryId} generation=${timeout.generation} ${timeoutOperations}`);
@@ -1820,7 +1831,7 @@ export function REPL({
     // QueryGuard calls this before forceEnd(); defer UI cleanup until after
     // the guard has released so the normal stale-generation finally path skips.
     queueMicrotask(() => {
-      logQueryLifecycle('abort_acknowledged', timeout.context, formatQueryLifecycleAbortSignalReason('query-timeout'));
+      logQueryLifecycle('abort_acknowledged', timeout.context, formatQueryLifecycleAbortSignalReason(timeoutAbortReason));
       resetLoadingState();
       setAbortController(null);
       void mrOnTurnComplete(messagesRef.current, true);

--- a/src/services/api/claude.abortClassification.test.ts
+++ b/src/services/api/claude.abortClassification.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, test } from 'bun:test'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+const source = readFileSync(join(import.meta.dirname, 'claude.ts'), 'utf8')
+
+describe('Claude stream abort classification wiring', () => {
+  test('logs aborted streams through reason-aware abort formatting', () => {
+    expect(source).toContain('getStreamingAbortMessage(')
+    expect(source).toContain('signal.reason')
+    expect(source).not.toContain('Streaming aborted by user:')
+  })
+})

--- a/src/services/api/claude.abortClassification.test.ts
+++ b/src/services/api/claude.abortClassification.test.ts
@@ -1,13 +1,58 @@
 import { describe, expect, test } from 'bun:test'
-import { readFileSync } from 'node:fs'
-import { join } from 'node:path'
-
-const source = readFileSync(join(import.meta.dirname, 'claude.ts'), 'utf8')
+import { shouldCreateUserInterruptionMessage } from '../../utils/abortReasons.js'
+import { getClaudeStreamingAbortLogMessage } from './claude.js'
 
 describe('Claude stream abort classification wiring', () => {
-  test('logs aborted streams through reason-aware abort formatting', () => {
-    expect(source).toContain('getStreamingAbortMessage(')
-    expect(source).toContain('signal.reason')
-    expect(source).not.toContain('Streaming aborted by user:')
+  test('formats timeout abort logs as timeout aborts, not user aborts', () => {
+    expect(
+      getClaudeStreamingAbortLogMessage(
+        { reason: 'query-timeout' },
+        new Error('Request was aborted.'),
+      ),
+    ).toBe('Streaming aborted by query timeout: Request was aborted.')
+    expect(
+      getClaudeStreamingAbortLogMessage(
+        { reason: 'hard_max' },
+        new Error('Request was aborted.'),
+      ),
+    ).toBe('Streaming aborted by query hard timeout: Request was aborted.')
+    expect(shouldCreateUserInterruptionMessage('query-timeout')).toBe(false)
+    expect(shouldCreateUserInterruptionMessage('hard_max')).toBe(false)
+  })
+
+  test('formats non-timeout abort logs by their normalized stream reason', () => {
+    expect(
+      getClaudeStreamingAbortLogMessage(
+        { reason: 'background' },
+        new Error('Request was aborted.'),
+      ),
+    ).toBe('Streaming aborted for backgrounding: Request was aborted.')
+    expect(
+      getClaudeStreamingAbortLogMessage(
+        { reason: 'streaming_fallback' },
+        new Error('Request was aborted.'),
+      ),
+    ).toBe(
+      'Streaming aborted because side task was cancelled: Request was aborted.',
+    )
+    expect(shouldCreateUserInterruptionMessage('background')).toBe(false)
+    expect(shouldCreateUserInterruptionMessage('streaming_fallback')).toBe(
+      false,
+    )
+  })
+
+  test('keeps actual user aborts user-facing for stream logs and advisor gating', () => {
+    const defaultAbort = new AbortController()
+    defaultAbort.abort()
+
+    expect(
+      getClaudeStreamingAbortLogMessage(
+        defaultAbort.signal,
+        new Error('Request was aborted.'),
+      ),
+    ).toBe('Streaming aborted by user: Request was aborted.')
+    expect(shouldCreateUserInterruptionMessage(defaultAbort.signal.reason)).toBe(
+      true,
+    )
   })
 })

--- a/src/services/api/claude.ts
+++ b/src/services/api/claude.ts
@@ -58,6 +58,10 @@ import {
 } from '../../utils/api.js'
 import { getOauthAccountInfo } from '../../utils/auth.js'
 import {
+  getStreamingAbortMessage,
+  shouldCreateUserInterruptionMessage,
+} from '../../utils/abortReasons.js'
+import {
   getBedrockExtraBodyParamsBetas,
   getMergedBetas,
   getModelBetas,
@@ -2622,15 +2626,19 @@ async function* queryModel(
       }
 
       if (streamingError instanceof APIUserAbortError) {
-        // Check if the abort signal was triggered by the user (ESC key)
-        // If the signal is aborted, it's a user-initiated abort
+        // If the signal is aborted, classify by the AbortSignal reason.
         // If not, it's likely a timeout from the SDK
         if (signal.aborted) {
-          // This is a real user abort (ESC key was pressed)
           logForDebugging(
-            `Streaming aborted by user: ${errorMessage(streamingError)}`,
+            getStreamingAbortMessage(
+              signal.reason,
+              errorMessage(streamingError),
+            ),
           )
-          if (isAdvisorInProgress) {
+          if (
+            isAdvisorInProgress &&
+            shouldCreateUserInterruptionMessage(signal.reason)
+          ) {
             logEvent('tengu_advisor_tool_interrupted', {
               model:
                 options.model as AnalyticsMetadata_I_VERIFIED_THIS_IS_NOT_CODE_OR_FILEPATHS,
@@ -2653,7 +2661,7 @@ async function* queryModel(
 
       if (signal.aborted) {
         logForDebugging(
-          `Streaming aborted by parent signal: ${errorMessage(streamingError)}`,
+          getStreamingAbortMessage(signal.reason, errorMessage(streamingError)),
         )
         throw new APIUserAbortError()
       }

--- a/src/services/api/claude.ts
+++ b/src/services/api/claude.ts
@@ -805,6 +805,13 @@ export async function* queryModelWithStreaming({
   })
 }
 
+export function getClaudeStreamingAbortLogMessage(
+  signal: Pick<AbortSignal, 'reason'>,
+  streamingError: unknown,
+): string {
+  return getStreamingAbortMessage(signal.reason, errorMessage(streamingError))
+}
+
 /**
  * Determines if an LSP tool should be deferred (tool appears with defer_loading: true)
  * because LSP initialization is not yet complete.
@@ -2630,10 +2637,7 @@ async function* queryModel(
         // If not, it's likely a timeout from the SDK
         if (signal.aborted) {
           logForDebugging(
-            getStreamingAbortMessage(
-              signal.reason,
-              errorMessage(streamingError),
-            ),
+            getClaudeStreamingAbortLogMessage(signal, streamingError),
           )
           if (
             isAdvisorInProgress &&
@@ -2661,7 +2665,7 @@ async function* queryModel(
 
       if (signal.aborted) {
         logForDebugging(
-          getStreamingAbortMessage(signal.reason, errorMessage(streamingError)),
+          getClaudeStreamingAbortLogMessage(signal, streamingError),
         )
         throw new APIUserAbortError()
       }

--- a/src/services/tools/StreamingToolExecutor.test.ts
+++ b/src/services/tools/StreamingToolExecutor.test.ts
@@ -25,6 +25,23 @@ const assistantMessage = {
   },
 } as unknown as AssistantMessage
 
+function firstToolResultText(message: unknown): string {
+  const content = (message as { message?: { content?: unknown } }).message
+    ?.content
+  if (!Array.isArray(content)) return ''
+  const toolResult = content.find(
+    block =>
+      typeof block === 'object' &&
+      block !== null &&
+      (block as { type?: unknown }).type === 'tool_result',
+  ) as { content?: unknown } | undefined
+  return String(toolResult?.content ?? '')
+}
+
+function toolUseResultText(message: unknown): string {
+  return String((message as { toolUseResult?: unknown }).toolUseResult ?? '')
+}
+
 class CountingQueryLifecycleTracker extends QueryLifecycleOperationTracker {
   endCount = 0
 
@@ -225,4 +242,67 @@ describe('StreamingToolExecutor lifecycle tracking', () => {
     expect(observedAbortReason).toBe('streaming_fallback')
     expect([...executor.getCompletedResults()]).toEqual([])
   })
+
+  test.each([
+    [
+      'query-timeout',
+      'Tool use was interrupted because the query timed out.',
+    ],
+    [
+      'hard_max',
+      'Tool use was interrupted because the query reached its hard maximum runtime.',
+    ],
+    [
+      'background',
+      'Tool use was interrupted because the query was backgrounded.',
+    ],
+  ])(
+    'already-aborted streaming tool uses reason-aware result for %s',
+    async (abortReason, expectedMessage) => {
+      const queryLifecycle = new QueryLifecycleOperationTracker()
+      const inProgressToolUseIds = { current: new Set<string>() }
+      const hasInterruptibleToolInProgress = { current: false }
+      const tool = createToolFixture(z.object({}), {
+        name: `AbortedStreamingTool_${abortReason}`,
+        async call() {
+          throw new Error('tool should not run after parent abort')
+        },
+      })
+      const toolUseContext = makeToolUseContext(
+        [tool],
+        queryLifecycle,
+        inProgressToolUseIds,
+        hasInterruptibleToolInProgress,
+      )
+      toolUseContext.abortController.abort(abortReason)
+      const executor = new StreamingToolExecutor(
+        [tool],
+        (async () => ({ behavior: 'allow' })) as CanUseToolFn,
+        toolUseContext,
+      )
+
+      executor.addTool(
+        {
+          type: 'tool_use',
+          id: `tool-use-${abortReason}`,
+          name: tool.name,
+          input: {},
+        } as ToolUseBlock,
+        assistantMessage,
+      )
+
+      const updates: unknown[] = []
+      for await (const update of executor.getRemainingResults()) {
+        if (update.message) updates.push(update.message)
+      }
+
+      expect(updates).toHaveLength(1)
+      expect(firstToolResultText(updates[0])).toContain(expectedMessage)
+      expect(toolUseResultText(updates[0])).toBe(expectedMessage)
+      expect(firstToolResultText(updates[0])).not.toContain('User rejected')
+      expect(firstToolResultText(updates[0])).not.toContain(
+        "The user doesn't want",
+      )
+    },
+  )
 })

--- a/src/services/tools/StreamingToolExecutor.ts
+++ b/src/services/tools/StreamingToolExecutor.ts
@@ -9,6 +9,10 @@ import { findToolByName, type Tools, type ToolUseContext } from '../../Tool.js'
 import { BASH_TOOL_NAME } from '../../tools/BashTool/toolName.js'
 import type { AssistantMessage, Message } from '../../types/message.js'
 import { createChildAbortController } from '../../utils/abortController.js'
+import {
+  getMissingToolResultAbortMessage,
+  shouldCreateUserInterruptionMessage,
+} from '../../utils/abortReasons.js'
 import { runToolUse } from './toolExecution.js'
 
 type MessageUpdate = {
@@ -30,6 +34,10 @@ type TrackedTool = {
   pendingProgress: Message[]
   contextModifiers?: Array<(context: ToolUseContext) => ToolUseContext>
 }
+
+type SyntheticErrorReason =
+  | { reason: 'sibling_error' | 'streaming_fallback' | 'user_interrupted' }
+  | { reason: 'parent_abort'; abortReason: unknown }
 
 /**
  * Executes tools as they stream in with concurrency control.
@@ -173,9 +181,10 @@ export class StreamingToolExecutor {
 
   private createSyntheticErrorMessage(
     toolUseId: string,
-    reason: 'sibling_error' | 'user_interrupted' | 'streaming_fallback',
+    syntheticReason: SyntheticErrorReason,
     assistantMessage: AssistantMessage,
   ): Message {
+    const { reason } = syntheticReason
     // For user interruptions (ESC to reject), use REJECT_MESSAGE so the UI shows
     // "User rejected edit" instead of "Error editing file"
     if (reason === 'user_interrupted') {
@@ -189,6 +198,23 @@ export class StreamingToolExecutor {
           },
         ],
         toolUseResult: 'User rejected tool use',
+        sourceToolAssistantUUID: assistantMessage.uuid,
+      })
+    }
+    if (reason === 'parent_abort') {
+      const abortMessage = getMissingToolResultAbortMessage(
+        syntheticReason.abortReason,
+      )
+      return createUserMessage({
+        content: [
+          {
+            type: 'tool_result',
+            content: withMemoryCorrectionHint(abortMessage),
+            is_error: true,
+            tool_use_id: toolUseId,
+          },
+        ],
+        toolUseResult: abortMessage,
         sourceToolAssistantUUID: assistantMessage.uuid,
       })
     }
@@ -228,14 +254,12 @@ export class StreamingToolExecutor {
   /**
    * Determine why a tool should be cancelled.
    */
-  private getAbortReason(
-    tool: TrackedTool,
-  ): 'sibling_error' | 'user_interrupted' | 'streaming_fallback' | null {
+  private getAbortReason(tool: TrackedTool): SyntheticErrorReason | null {
     if (this.discarded) {
-      return 'streaming_fallback'
+      return { reason: 'streaming_fallback' }
     }
     if (this.hasErrored) {
-      return 'sibling_error'
+      return { reason: 'sibling_error' }
     }
     if (this.toolUseContext.abortController.signal.aborted) {
       // 'interrupt' means the user typed a new message while tools were
@@ -243,10 +267,20 @@ export class StreamingToolExecutor {
       // 'block' tools shouldn't reach here (abort isn't fired).
       if (this.toolUseContext.abortController.signal.reason === 'interrupt') {
         return this.getToolInterruptBehavior(tool) === 'cancel'
-          ? 'user_interrupted'
+          ? { reason: 'user_interrupted' }
           : null
       }
-      return 'user_interrupted'
+      if (
+        shouldCreateUserInterruptionMessage(
+          this.toolUseContext.abortController.signal.reason,
+        )
+      ) {
+        return { reason: 'user_interrupted' }
+      }
+      return {
+        reason: 'parent_abort',
+        abortReason: this.toolUseContext.abortController.signal.reason,
+      }
     }
     return null
   }

--- a/src/services/tools/toolExecution.test.ts
+++ b/src/services/tools/toolExecution.test.ts
@@ -17,7 +17,7 @@ import { FILE_EDIT_TOOL_NAME } from '../../tools/FileEditTool/constants.js'
 import { FILE_WRITE_TOOL_NAME } from '../../tools/FileWriteTool/constants.js'
 import { NOTEBOOK_EDIT_TOOL_NAME } from '../../tools/NotebookEditTool/constants.js'
 import { AbortError } from '../../utils/errors.js'
-import { createAssistantMessage } from '../../utils/messages.js'
+import { CANCEL_MESSAGE, createAssistantMessage } from '../../utils/messages.js'
 import {
   type QueryActiveOperationSnapshot,
   QueryLifecycleOperationTracker,
@@ -34,6 +34,23 @@ import {
   normalizeToolInputForValidation,
   runToolUse,
 } from './toolExecution.js'
+
+function firstToolResultText(message: unknown): string {
+  const content = (message as { message?: { content?: unknown } }).message
+    ?.content
+  if (!Array.isArray(content)) return ''
+  const toolResult = content.find(
+    block =>
+      typeof block === 'object' &&
+      block !== null &&
+      (block as { type?: unknown }).type === 'tool_result',
+  ) as { content?: unknown } | undefined
+  return String(toolResult?.content ?? '')
+}
+
+function toolUseResultText(message: unknown): string {
+  return String((message as { toolUseResult?: unknown }).toolUseResult ?? '')
+}
 
 afterEach(() => {
   delete process.env.TEST_ENABLE_SESSION_PERSISTENCE
@@ -506,6 +523,57 @@ describe('query lifecycle tool-use cleanup', () => {
     expect(queryLifecycle.endCount).toBe(1)
     expect(queryLifecycle.snapshot()).toEqual({ apiCalls: [], toolUses: [] })
   })
+
+  test.each([
+    [
+      'query-timeout',
+      'Tool use was interrupted because the query timed out.',
+      false,
+    ],
+    [
+      'hard_max',
+      'Tool use was interrupted because the query reached its hard maximum runtime.',
+      false,
+    ],
+    [
+      'background',
+      'Tool use was interrupted because the query was backgrounded.',
+      false,
+    ],
+    ['interrupt', CANCEL_MESSAGE, true],
+    ['user-abort', CANCEL_MESSAGE, true],
+  ])(
+    'already-aborted tool execution uses reason-aware result for %s',
+    async (abortReason, expectedMessage, isUserCancel) => {
+      const queryLifecycle = new CountingQueryLifecycleTracker()
+      const tool = createToolFixture(lifecycleInputSchema, {
+        name: `LifecycleAlreadyAbortedTool_${abortReason}`,
+        async call() {
+          throw new Error('tool should not run after parent abort')
+        },
+      })
+      const abortController = new AbortController()
+      abortController.abort(abortReason)
+      const context = createLifecycleToolUseContext(
+        [tool],
+        queryLifecycle,
+        abortController,
+      )
+
+      const updates = await collectRunToolUse(tool, { value: 'abort' }, context)
+      const message = updates.find(update => update.message)?.message
+
+      expect(message).toBeDefined()
+      expect(firstToolResultText(message)).toContain(expectedMessage)
+      expect(toolUseResultText(message)).toBe(expectedMessage)
+      expect(firstToolResultText(message)).not.toContain('User rejected')
+      if (!isUserCancel) {
+        expect(firstToolResultText(message)).not.toContain(
+          "The user doesn't want",
+        )
+      }
+    },
+  )
 
   test('thrown tool error leaves no active lifecycle tool use', async () => {
     const queryLifecycle = new CountingQueryLifecycleTracker()

--- a/src/services/tools/toolExecution.ts
+++ b/src/services/tools/toolExecution.ts
@@ -62,6 +62,10 @@ import type {
 } from '../../types/message.js'
 import { count } from '../../utils/array.js'
 import { createAttachmentMessage } from '../../utils/attachments.js'
+import {
+  getMissingToolResultAbortMessage,
+  shouldCreateUserInterruptionMessage,
+} from '../../utils/abortReasons.js'
 import { logForDebugging } from '../../utils/debug.js'
 import {
   AbortError,
@@ -131,6 +135,13 @@ export const HOOK_TIMING_DISPLAY_THRESHOLD_MS = 500
 /** Log a debug warning when hooks/permission-decision block for this long. Matches
  * BashTool's PROGRESS_THRESHOLD_MS — the collapsed view feels stuck past this. */
 const SLOW_PHASE_LOG_THRESHOLD_MS = 2000
+
+function getAlreadyAbortedToolResultMessage(reason: unknown): string {
+  if (reason === 'interrupt' || shouldCreateUserInterruptionMessage(reason)) {
+    return CANCEL_MESSAGE
+  }
+  return getMissingToolResultAbortMessage(reason)
+}
 
 export function getReplayModifiedFiles(
   toolName: string,
@@ -472,6 +483,9 @@ export async function* runToolUse(
   const toolInput = toolUse.input as { [key: string]: string }
   try {
     if (toolUseContext.abortController.signal.aborted) {
+      const abortMessage = getAlreadyAbortedToolResultMessage(
+        toolUseContext.abortController.signal.reason,
+      )
       logEvent('tengu_tool_use_cancelled', {
         toolName: sanitizeToolNameForAnalytics(tool.name),
         toolUseID:
@@ -500,11 +514,11 @@ export async function* runToolUse(
         ),
       })
       const content = createToolResultStopMessage(toolUse.id)
-      content.content = withMemoryCorrectionHint(CANCEL_MESSAGE)
+      content.content = withMemoryCorrectionHint(abortMessage)
       yield {
         message: createUserMessage({
           content: [content],
-          toolUseResult: CANCEL_MESSAGE,
+          toolUseResult: abortMessage,
           sourceToolAssistantUUID: assistantMessage.uuid,
         }),
       }

--- a/src/utils/QueryGuard.test.ts
+++ b/src/utils/QueryGuard.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, test, expect, vi } from 'vitest'
-import { QueryGuard } from './QueryGuard.js'
+import { DEFAULT_QUERY_HARD_MAX_MS, QueryGuard } from './QueryGuard.js'
 import { QueryLifecycleOperationTracker } from './queryLifecycle.js'
 
 describe('QueryGuard', () => {
@@ -339,6 +339,48 @@ describe('QueryGuard', () => {
         generation: gen,
         reason: 'hard_max',
         timeoutMs: 1_000,
+        context: expect.objectContaining({
+          terminalReason: 'hard-max-query-timeout',
+          abortReason: 'hard_max',
+        }),
+      }),
+    )
+  })
+
+  test('larger hard maximum does not abort at the default hard max boundary', () => {
+    vi.useFakeTimers()
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+    const configuredHardMaxMs = DEFAULT_QUERY_HARD_MAX_MS + 1_000
+    const guard = new QueryGuard({
+      idleTimeoutMs: 100,
+      hardMaxQueryMs: configuredHardMaxMs,
+      toolLeaseGraceMs: 0,
+    })
+    const onTimeout = vi.fn()
+    guard.setTimeoutHandler(onTimeout)
+    const gen = guard.tryStart()!
+    guard.acquireLease(
+      {
+        owner: 'api',
+        id: 'stream',
+        timeoutMs: configuredHardMaxMs,
+      },
+      gen,
+    )
+
+    vi.advanceTimersByTime(DEFAULT_QUERY_HARD_MAX_MS)
+
+    expect(guard.isActive).toBe(true)
+    expect(onTimeout).not.toHaveBeenCalled()
+
+    vi.advanceTimersByTime(1_000)
+
+    expect(guard.isActive).toBe(false)
+    expect(onTimeout).toHaveBeenCalledWith(
+      expect.objectContaining({
+        generation: gen,
+        reason: 'hard_max',
+        timeoutMs: configuredHardMaxMs,
         context: expect.objectContaining({
           terminalReason: 'hard-max-query-timeout',
           abortReason: 'hard_max',

--- a/src/utils/abortReasons.test.ts
+++ b/src/utils/abortReasons.test.ts
@@ -1,9 +1,13 @@
 import { describe, expect, test } from 'bun:test'
 import {
   type AbortReason,
+  getMissingToolResultAbortMessage,
+  getQueryAbortSystemMessage,
   getShellAbortMessage,
+  getStreamingAbortMessage,
   isQueryLevelAbort,
   normalizeAbortReason,
+  shouldCreateUserInterruptionMessage,
 } from './abortReasons.js'
 
 describe('abort reason normalization', () => {
@@ -16,6 +20,11 @@ describe('abort reason normalization', () => {
     expect(normalizeAbortReason('interrupt')).toBe('interrupt')
     expect(normalizeAbortReason('background')).toBe('background')
     expect(normalizeAbortReason('parent-ended')).toBe('parent-ended')
+    expect(normalizeAbortReason('hard_max')).toBe('hard-max-query-timeout')
+    expect(normalizeAbortReason('streaming_fallback')).toBe(
+      'side-task-cancelled',
+    )
+    expect(normalizeAbortReason('sibling_error')).toBe('side-task-cancelled')
   })
 
   test('keeps tool timeout distinct from abort cancellations', () => {
@@ -50,6 +59,69 @@ describe('abort reason normalization', () => {
     )
   })
 
+  test('formats streaming abort logs from normalized abort reasons', () => {
+    expect(getStreamingAbortMessage('user-cancel', 'Request was aborted.')).toBe(
+      'Streaming aborted by user: Request was aborted.',
+    )
+    expect(
+      getStreamingAbortMessage('query-timeout', 'Request was aborted.'),
+    ).toBe('Streaming aborted by query timeout: Request was aborted.')
+    expect(getStreamingAbortMessage('hard_max', 'Request was aborted.')).toBe(
+      'Streaming aborted by query hard timeout: Request was aborted.',
+    )
+    expect(getStreamingAbortMessage('background', 'Request was aborted.')).toBe(
+      'Streaming aborted for backgrounding: Request was aborted.',
+    )
+    expect(
+      getStreamingAbortMessage('streaming_fallback', 'Request was aborted.'),
+    ).toBe(
+      'Streaming aborted because side task was cancelled: Request was aborted.',
+    )
+  })
+
+  test('only actual user cancellation creates user interruption transcript text', () => {
+    const defaultAbort = new AbortController()
+    defaultAbort.abort()
+
+    expect(shouldCreateUserInterruptionMessage('user-cancel')).toBe(true)
+    expect(shouldCreateUserInterruptionMessage('user-abort')).toBe(true)
+    expect(
+      shouldCreateUserInterruptionMessage(defaultAbort.signal.reason),
+    ).toBe(true)
+    expect(shouldCreateUserInterruptionMessage('interrupt')).toBe(false)
+    expect(shouldCreateUserInterruptionMessage('query-timeout')).toBe(false)
+    expect(shouldCreateUserInterruptionMessage('hard_max')).toBe(false)
+    expect(shouldCreateUserInterruptionMessage('background')).toBe(false)
+    expect(shouldCreateUserInterruptionMessage('streaming_fallback')).toBe(
+      false,
+    )
+    expect(getQueryAbortSystemMessage('query-timeout')).toBe(
+      'Query timed out before completion.',
+    )
+    expect(getQueryAbortSystemMessage('hard_max')).toBe(
+      'Query reached the hard maximum runtime and was stopped before completion.',
+    )
+    expect(getQueryAbortSystemMessage('background')).toBe(
+      'Query was backgrounded before completion.',
+    )
+    expect(getQueryAbortSystemMessage('streaming_fallback')).toBe(
+      'Query stopped because a side task was cancelled.',
+    )
+    expect(getQueryAbortSystemMessage('parent-ended')).toBe(
+      'Query stopped because the parent query ended.',
+    )
+    expect(getQueryAbortSystemMessage('user-cancel')).toBeNull()
+    expect(getMissingToolResultAbortMessage('query-timeout')).toBe(
+      'Tool use was interrupted because the query timed out.',
+    )
+    expect(getMissingToolResultAbortMessage('hard_max')).toBe(
+      'Tool use was interrupted because the query reached its hard maximum runtime.',
+    )
+    expect(getMissingToolResultAbortMessage('user-cancel')).toBe(
+      'Interrupted by user',
+    )
+  })
+
   test('returns a message for every abort reason', () => {
     const abortReasons: Record<AbortReason, true> = {
       'query-timeout': true,
@@ -57,6 +129,7 @@ describe('abort reason normalization', () => {
       'user-abort': true,
       interrupt: true,
       background: true,
+      'side-task-cancelled': true,
       'tool-timeout': true,
       'parent-ended': true,
       'unknown-abort': true,

--- a/src/utils/abortReasons.test.ts
+++ b/src/utils/abortReasons.test.ts
@@ -28,9 +28,22 @@ describe('abort reason normalization', () => {
   })
 
   test('keeps tool timeout distinct from abort cancellations', () => {
+    expect(normalizeAbortReason(new DOMException('', 'AbortError'))).toBe(
+      'user-abort',
+    )
+    expect(
+      normalizeAbortReason({
+        name: 'AbortError',
+      }),
+    ).toBe('user-abort')
     expect(normalizeAbortReason(new DOMException('', 'TimeoutError'))).toBe(
       'tool-timeout',
     )
+    expect(
+      normalizeAbortReason({
+        name: 'TimeoutError',
+      }),
+    ).toBe('tool-timeout')
     expect(isQueryLevelAbort('tool-timeout')).toBe(false)
     expect(isQueryLevelAbort('query-timeout')).toBe(true)
   })
@@ -85,6 +98,7 @@ describe('abort reason normalization', () => {
 
     expect(shouldCreateUserInterruptionMessage('user-cancel')).toBe(true)
     expect(shouldCreateUserInterruptionMessage('user-abort')).toBe(true)
+    expect(normalizeAbortReason(defaultAbort.signal.reason)).toBe('user-abort')
     expect(
       shouldCreateUserInterruptionMessage(defaultAbort.signal.reason),
     ).toBe(true)
@@ -120,6 +134,15 @@ describe('abort reason normalization', () => {
     expect(getMissingToolResultAbortMessage('user-cancel')).toBe(
       'Interrupted by user',
     )
+    expect(
+      getMissingToolResultAbortMessage(defaultAbort.signal.reason),
+    ).toBe('Interrupted by user')
+    expect(
+      getStreamingAbortMessage(
+        defaultAbort.signal.reason,
+        'Request was aborted.',
+      ),
+    ).toBe('Streaming aborted by user: Request was aborted.')
   })
 
   test('returns a message for every abort reason', () => {

--- a/src/utils/abortReasons.ts
+++ b/src/utils/abortReasons.ts
@@ -39,7 +39,16 @@ export function normalizeAbortReason(reason: unknown): AbortReason {
       : 'unknown-abort'
   }
 
-  if (reason instanceof Error && reason.name === 'TimeoutError') {
+  const name =
+    typeof reason === 'object' && reason !== null
+      ? (reason as { name?: unknown }).name
+      : undefined
+
+  if (name === 'AbortError') {
+    return 'user-abort'
+  }
+
+  if (name === 'TimeoutError') {
     return 'tool-timeout'
   }
 
@@ -100,18 +109,7 @@ export function getStreamingAbortMessage(
 }
 
 export function shouldCreateUserInterruptionMessage(reason: unknown): boolean {
-  if (normalizeAbortReason(reason) === 'user-abort') {
-    return true
-  }
-
-  // AbortController.abort() without an explicit reason was historically used
-  // for user cancellation in some entrypoints. Preserve that legacy signal,
-  // while explicit timeout/background reasons remain non-user aborts.
-  return (
-    typeof reason === 'object' &&
-    reason !== null &&
-    (reason as { name?: unknown }).name === 'AbortError'
-  )
+  return normalizeAbortReason(reason) === 'user-abort'
 }
 
 export function getQueryAbortSystemMessage(reason: unknown): string | null {

--- a/src/utils/abortReasons.ts
+++ b/src/utils/abortReasons.ts
@@ -4,6 +4,7 @@ export type AbortReason =
   | 'user-abort'
   | 'interrupt'
   | 'background'
+  | 'side-task-cancelled'
   | 'tool-timeout'
   | 'parent-ended'
   | 'unknown-abort'
@@ -14,6 +15,7 @@ const KNOWN_ABORT_REASONS = new Set<string>([
   'user-abort',
   'interrupt',
   'background',
+  'side-task-cancelled',
   'tool-timeout',
   'parent-ended',
   'unknown-abort',
@@ -21,6 +23,9 @@ const KNOWN_ABORT_REASONS = new Set<string>([
 
 const ABORT_REASON_ALIASES: Record<string, AbortReason> = {
   'user-cancel': 'user-abort',
+  hard_max: 'hard-max-query-timeout',
+  streaming_fallback: 'side-task-cancelled',
+  sibling_error: 'side-task-cancelled',
 }
 
 export function normalizeAbortReason(reason: unknown): AbortReason {
@@ -53,6 +58,8 @@ export function getShellAbortMessage(reason: AbortReason): string {
       return 'Command was interrupted because the query hit its hard timeout.'
     case 'background':
       return 'Command was interrupted because the enclosing query was backgrounded.'
+    case 'side-task-cancelled':
+      return 'Command was interrupted because a side task was cancelled.'
     case 'tool-timeout':
       return 'Command timed out before completion.'
     case 'user-abort':
@@ -63,5 +70,86 @@ export function getShellAbortMessage(reason: AbortReason): string {
       return 'Command was interrupted because the enclosing query was aborted.'
     case 'unknown-abort':
       return 'Command was interrupted because the enclosing query was aborted.'
+  }
+}
+
+export function getStreamingAbortMessage(
+  reason: unknown,
+  errorText: string,
+): string {
+  switch (normalizeAbortReason(reason)) {
+    case 'user-abort':
+      return `Streaming aborted by user: ${errorText}`
+    case 'interrupt':
+      return `Streaming aborted by submit interrupt: ${errorText}`
+    case 'query-timeout':
+      return `Streaming aborted by query timeout: ${errorText}`
+    case 'hard-max-query-timeout':
+      return `Streaming aborted by query hard timeout: ${errorText}`
+    case 'background':
+      return `Streaming aborted for backgrounding: ${errorText}`
+    case 'side-task-cancelled':
+      return `Streaming aborted because side task was cancelled: ${errorText}`
+    case 'tool-timeout':
+      return `Streaming aborted because tool timed out: ${errorText}`
+    case 'parent-ended':
+      return `Streaming aborted because parent query ended: ${errorText}`
+    case 'unknown-abort':
+      return `Streaming aborted by parent signal: ${errorText}`
+  }
+}
+
+export function shouldCreateUserInterruptionMessage(reason: unknown): boolean {
+  if (normalizeAbortReason(reason) === 'user-abort') {
+    return true
+  }
+
+  // AbortController.abort() without an explicit reason was historically used
+  // for user cancellation in some entrypoints. Preserve that legacy signal,
+  // while explicit timeout/background reasons remain non-user aborts.
+  return (
+    typeof reason === 'object' &&
+    reason !== null &&
+    (reason as { name?: unknown }).name === 'AbortError'
+  )
+}
+
+export function getQueryAbortSystemMessage(reason: unknown): string | null {
+  switch (normalizeAbortReason(reason)) {
+    case 'query-timeout':
+      return 'Query timed out before completion.'
+    case 'hard-max-query-timeout':
+      return 'Query reached the hard maximum runtime and was stopped before completion.'
+    case 'background':
+      return 'Query was backgrounded before completion.'
+    case 'side-task-cancelled':
+      return 'Query stopped because a side task was cancelled.'
+    case 'parent-ended':
+      return 'Query stopped because the parent query ended.'
+    default:
+      return null
+  }
+}
+
+export function getMissingToolResultAbortMessage(reason: unknown): string {
+  switch (normalizeAbortReason(reason)) {
+    case 'user-abort':
+      return 'Interrupted by user'
+    case 'interrupt':
+      return 'Interrupted by submit interrupt'
+    case 'query-timeout':
+      return 'Tool use was interrupted because the query timed out.'
+    case 'hard-max-query-timeout':
+      return 'Tool use was interrupted because the query reached its hard maximum runtime.'
+    case 'background':
+      return 'Tool use was interrupted because the query was backgrounded.'
+    case 'side-task-cancelled':
+      return 'Tool use was interrupted because a side task was cancelled.'
+    case 'tool-timeout':
+      return 'Tool use timed out before completion.'
+    case 'parent-ended':
+      return 'Tool use was interrupted because the parent query ended.'
+    case 'unknown-abort':
+      return 'Tool use was interrupted because the query was aborted.'
   }
 }

--- a/src/utils/queryGuardConfig.test.ts
+++ b/src/utils/queryGuardConfig.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, test, vi } from 'vitest'
+import { DEFAULT_QUERY_HARD_MAX_MS } from './QueryGuard.js'
+import {
+  getQueryGuardOptionsFromEnv,
+  MAX_CONFIGURABLE_QUERY_HARD_MAX_MS,
+} from './queryGuardConfig.js'
+
+describe('query guard config', () => {
+  test('uses defaults when query hard max env is absent or empty', () => {
+    const warn = vi.fn()
+
+    expect(getQueryGuardOptionsFromEnv({}, warn)).toEqual({})
+    expect(
+      getQueryGuardOptionsFromEnv(
+        { OPENCLAUDE_QUERY_HARD_MAX_MS: '   ' },
+        warn,
+      ),
+    ).toEqual({})
+    expect(warn).not.toHaveBeenCalled()
+  })
+
+  test('accepts positive finite integer query hard max values', () => {
+    const warn = vi.fn()
+
+    expect(
+      getQueryGuardOptionsFromEnv(
+        { OPENCLAUDE_QUERY_HARD_MAX_MS: '3600000' },
+        warn,
+      ),
+    ).toEqual({ hardMaxQueryMs: 3_600_000 })
+    expect(
+      getQueryGuardOptionsFromEnv(
+        { OPENCLAUDE_QUERY_HARD_MAX_MS: String(DEFAULT_QUERY_HARD_MAX_MS) },
+        warn,
+      ),
+    ).toEqual({ hardMaxQueryMs: DEFAULT_QUERY_HARD_MAX_MS })
+    expect(
+      getQueryGuardOptionsFromEnv(
+        {
+          OPENCLAUDE_QUERY_HARD_MAX_MS: String(
+            MAX_CONFIGURABLE_QUERY_HARD_MAX_MS,
+          ),
+        },
+        warn,
+      ),
+    ).toEqual({ hardMaxQueryMs: MAX_CONFIGURABLE_QUERY_HARD_MAX_MS })
+    expect(warn).not.toHaveBeenCalled()
+  })
+
+  test('ignores invalid query hard max values with a clear warning', () => {
+    const invalidValues = [
+      '0',
+      '-1',
+      'NaN',
+      '1.5',
+      'Infinity',
+      '123abc',
+      String(MAX_CONFIGURABLE_QUERY_HARD_MAX_MS + 1),
+    ]
+
+    for (const value of invalidValues) {
+      const warn = vi.fn()
+
+      expect(
+        getQueryGuardOptionsFromEnv(
+          { OPENCLAUDE_QUERY_HARD_MAX_MS: value },
+          warn,
+        ),
+      ).toEqual({})
+
+      expect(warn).toHaveBeenCalledTimes(1)
+      expect(warn.mock.calls[0]?.[0]).toContain(
+        'OPENCLAUDE_QUERY_HARD_MAX_MS',
+      )
+      expect(warn.mock.calls[0]?.[0]).toContain(value)
+      expect(warn.mock.calls[0]?.[1]).toEqual({ level: 'warn' })
+    }
+  })
+})

--- a/src/utils/queryGuardConfig.ts
+++ b/src/utils/queryGuardConfig.ts
@@ -1,0 +1,67 @@
+export const OPENCLAUDE_QUERY_HARD_MAX_MS_ENV =
+  'OPENCLAUDE_QUERY_HARD_MAX_MS'
+
+// setTimeout-compatible upper bound; larger values can overflow timer APIs.
+export const MAX_CONFIGURABLE_QUERY_HARD_MAX_MS = 0x7fffffff
+
+type EnvLike = Record<string, string | undefined>
+type DebugLogger = (
+  message: string,
+  options?: { level: 'warn' },
+) => void
+
+export type QueryGuardResolvedOptions = {
+  hardMaxQueryMs?: number
+}
+
+function warnInvalidQueryHardMax(
+  value: string,
+  reason: string,
+  log: DebugLogger,
+): void {
+  log(
+    `${OPENCLAUDE_QUERY_HARD_MAX_MS_ENV} invalid value "${value}" (${reason}); using default query hard max`,
+    { level: 'warn' },
+  )
+}
+
+function defaultWarnLogger(message: string): void {
+  console.warn(`[OpenClaude] ${message}`)
+}
+
+export function getQueryGuardOptionsFromEnv(
+  env: EnvLike = process.env,
+  log: DebugLogger = defaultWarnLogger,
+): QueryGuardResolvedOptions {
+  const raw = env[OPENCLAUDE_QUERY_HARD_MAX_MS_ENV]
+  const value = raw?.trim()
+  if (!value) {
+    return {}
+  }
+
+  if (!/^\d+$/.test(value)) {
+    warnInvalidQueryHardMax(
+      value,
+      'expected a positive integer in milliseconds',
+      log,
+    )
+    return {}
+  }
+
+  const parsed = Number(value)
+  if (!Number.isSafeInteger(parsed) || parsed <= 0) {
+    warnInvalidQueryHardMax(value, 'expected a positive finite integer', log)
+    return {}
+  }
+
+  if (parsed > MAX_CONFIGURABLE_QUERY_HARD_MAX_MS) {
+    warnInvalidQueryHardMax(
+      value,
+      `maximum is ${MAX_CONFIGURABLE_QUERY_HARD_MAX_MS}`,
+      log,
+    )
+    return {}
+  }
+
+  return { hardMaxQueryMs: parsed }
+}

--- a/src/utils/queryLifecycle.test.ts
+++ b/src/utils/queryLifecycle.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from 'vitest'
 import {
   formatQueryLifecycleAbortSignalReason,
   formatQueryLifecycleLogMessage,
+  getQueryTerminalReason,
   type QueryLifecycleContext,
 } from './queryLifecycle.js'
 
@@ -26,5 +27,70 @@ describe('query lifecycle log formatting', () => {
     expect(line).toContain('abortSignalReason=query-timeout')
     expect(line).not.toContain('abortReason=query-timeout')
     expect(line.match(/\babortReason=/g)).toHaveLength(1)
+  })
+})
+
+describe('query terminal reason classification', () => {
+  test('classifies non-aborted completion from throw state', () => {
+    expect(
+      getQueryTerminalReason({ aborted: false, reason: undefined }, false),
+    ).toBe('ok')
+    expect(
+      getQueryTerminalReason({ aborted: false, reason: undefined }, true),
+    ).toBe('unknown')
+  })
+
+  test('passes timeout aborts through as terminal reasons', () => {
+    expect(
+      getQueryTerminalReason({ aborted: true, reason: 'query-timeout' }, false),
+    ).toBe('query-timeout')
+    expect(
+      getQueryTerminalReason(
+        { aborted: true, reason: 'hard-max-query-timeout' },
+        false,
+      ),
+    ).toBe('hard-max-query-timeout')
+    expect(
+      getQueryTerminalReason({ aborted: true, reason: 'hard_max' }, false),
+    ).toBe('hard-max-query-timeout')
+  })
+
+  test('groups user-style aborts as user aborts', () => {
+    const defaultAbort = new AbortController()
+    defaultAbort.abort()
+
+    expect(
+      getQueryTerminalReason({ aborted: true, reason: 'user-cancel' }, false),
+    ).toBe('user-abort')
+    expect(
+      getQueryTerminalReason({ aborted: true, reason: 'interrupt' }, false),
+    ).toBe('user-abort')
+    expect(
+      getQueryTerminalReason(
+        { aborted: true, reason: defaultAbort.signal.reason },
+        false,
+      ),
+    ).toBe('user-abort')
+  })
+
+  test('groups background and side-task aborts under parent-ended', () => {
+    expect(
+      getQueryTerminalReason({ aborted: true, reason: 'background' }, false),
+    ).toBe('parent-ended')
+    expect(
+      getQueryTerminalReason({ aborted: true, reason: 'parent-ended' }, false),
+    ).toBe('parent-ended')
+    expect(
+      getQueryTerminalReason(
+        { aborted: true, reason: 'side-task-cancelled' },
+        false,
+      ),
+    ).toBe('parent-ended')
+    expect(
+      getQueryTerminalReason(
+        { aborted: true, reason: 'streaming_fallback' },
+        false,
+      ),
+    ).toBe('parent-ended')
   })
 })

--- a/src/utils/queryLifecycle.ts
+++ b/src/utils/queryLifecycle.ts
@@ -1,3 +1,5 @@
+import { normalizeAbortReason } from './abortReasons.js'
+
 export type QueryTerminalReason =
   | 'ok'
   | 'query-timeout'
@@ -64,6 +66,28 @@ export type QueryGuardTimeoutInfo = {
   elapsedMs: number
   context: QueryLifecycleContext
   activeOperations: QueryActiveOperationSnapshot
+}
+
+export function getQueryTerminalReason(
+  signal: Pick<AbortSignal, 'aborted' | 'reason'>,
+  didThrow: boolean,
+): QueryTerminalReason {
+  if (!signal.aborted) return didThrow ? 'unknown' : 'ok'
+  switch (normalizeAbortReason(signal.reason)) {
+    case 'query-timeout':
+      return 'query-timeout'
+    case 'hard-max-query-timeout':
+      return 'hard-max-query-timeout'
+    case 'user-abort':
+    case 'interrupt':
+      return 'user-abort'
+    case 'background':
+    case 'parent-ended':
+    case 'side-task-cancelled':
+      return 'parent-ended'
+    default:
+      return 'unknown'
+  }
 }
 
 export function formatQueryLifecycleAbortSignalReason(reason: string): string {


### PR DESCRIPTION
## Summary

- Add `OPENCLAUDE_QUERY_HARD_MAX_MS` so long foreground query sessions can raise the QueryGuard hard maximum without editing source.
- Classify aborts by explicit reason so query timeouts, hard maximums, backgrounding, and parent-task aborts are not surfaced as user interruptions.
- Keep synthetic parent-abort tool results from tripping repeated-tool-failure detection while preserving real tool timeout failures.

## Impact

- user-facing impact: long-running sessions can opt into a larger foreground query hard maximum, and timeout/background abort messages identify the real cause.
- developer/maintainer impact: abort reason formatting is centralized and covered across main query, stop hooks, API stream logging, and tool-result cleanup paths.

## Testing

- [x] `bun run build`
- [x] `bun run smoke`
- [ ] `bun run check` (not run; focused tests, typecheck, smoke/build, and PR intent scan were run instead)
- [x] focused tests:
  - `bun test src/utils/queryGuardConfig.test.ts src/screens/REPL.queryLifecycle.test.ts src/utils/QueryGuard.test.ts src/utils/abortReasons.test.ts src/query.abortClassification.test.ts src/query/stopHooks.goal.test.ts src/query/toolFailureLoopGuard.test.ts src/services/api/claude.abortClassification.test.ts src/services/api/claude.lifecycle.test.ts src/services/api/claude.streamWatchdog.test.ts src/services/tools/StreamingToolExecutor.test.ts src/services/tools/toolExecution.test.ts`
  - `env ZDOTDIR=/tmp/openclaude-empty-zdotdir bun test src/services/tools/queryActivityLease.test.ts src/tools/BashTool/BashTool.errorOutput.test.ts src/utils/ShellCommand.test.ts src/utils/queryLifecycle.test.ts`
  - `bun run typecheck`
  - `bun run security:pr-scan`
  - `git diff --check`

## Notes

- provider/model path tested: not provider-specific
- screenshots attached: not applicable
- follow-up work or known limitations: backgrounding now emits an explicit system warning instead of being silent.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable query hard-time limit via `OPENCLAUDE_QUERY_HARD_MAX_MS`.
  * Made query-guard configuration environment-driven in the REPL lifecycle.
* **Bug Fixes**
  * Improved abort/timeout classification and messaging across streaming, tool execution, stop hooks, and REPL lifecycle logs.
  * Ensured “user interruption” transcript content and advisor/tool interruption events are emitted only for true user cancels.
  * Added support for additional abort normalization, including side-task cancellation.
* **Documentation**
  * Documented `OPENCLAUDE_QUERY_HARD_MAX_MS`, including defaults and invalid-value handling.
* **Tests**
  * Expanded coverage for abort classification, message gating, and reason-specific behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->