### PR TITLE
fix(clipboard): use .NET Clipboard.GetImage() for Windows raw bitmap paste

### DIFF
--- a/src/utils/imagePaste.test.ts
+++ b/src/utils/imagePaste.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, test } from 'bun:test'
+import {
+  buildLinuxClipboardCheckCommand,
+  buildLinuxClipboardSaveCommand,
+  IMAGE_EXTENSION_REGEX,
+  isImageFilePath,
+  asImageFilePath,
+  LINUX_CLIPBOARD_IMAGE_MIME_TYPES,
+  PASTE_THRESHOLD,
+} from './imagePaste.js'
+
+describe('LINUX_CLIPBOARD_IMAGE_MIME_TYPES', () => {
+  test('includes standard image MIME types', () => {
+    expect(LINUX_CLIPBOARD_IMAGE_MIME_TYPES).toContain('image/png')
+    expect(LINUX_CLIPBOARD_IMAGE_MIME_TYPES).toContain('image/jpeg')
+    expect(LINUX_CLIPBOARD_IMAGE_MIME_TYPES).toContain('image/gif')
+    expect(LINUX_CLIPBOARD_IMAGE_MIME_TYPES).toContain('image/webp')
+    expect(LINUX_CLIPBOARD_IMAGE_MIME_TYPES).toContain('image/bmp')
+  })
+})
+
+describe('buildLinuxClipboardCheckCommand', () => {
+  test('includes xclip and wl-paste', () => {
+    const cmd = buildLinuxClipboardCheckCommand()
+    expect(cmd).toContain('xclip')
+    expect(cmd).toContain('wl-paste')
+  })
+
+  test('includes all MIME types from LINUX_CLIPBOARD_IMAGE_MIME_TYPES', () => {
+    const cmd = buildLinuxClipboardCheckCommand()
+    for (const mimeType of LINUX_CLIPBOARD_IMAGE_MIME_TYPES) {
+      // MIME types are escaped with \/ for grep
+      expect(cmd).toContain(mimeType.replace('/', '\\/'))
+    }
+  })
+})
+
+describe('buildLinuxClipboardSaveCommand', () => {
+  test('includes xclip and wl-paste with screenshot path', () => {
+    const cmd = buildLinuxClipboardSaveCommand('/tmp/test.png')
+    expect(cmd).toContain('xclip')
+    expect(cmd).toContain('wl-paste')
+    expect(cmd).toContain('/tmp/test.png')
+  })
+})
+
+describe('IMAGE_EXTENSION_REGEX', () => {
+  test('matches image extensions case-insensitively', () => {
+    expect(IMAGE_EXTENSION_REGEX.test('photo.png')).toBe(true)
+    expect(IMAGE_EXTENSION_REGEX.test('photo.PNG')).toBe(true)
+    expect(IMAGE_EXTENSION_REGEX.test('photo.jpg')).toBe(true)
+    expect(IMAGE_EXTENSION_REGEX.test('photo.jpeg')).toBe(true)
+    expect(IMAGE_EXTENSION_REGEX.test('photo.JPEG')).toBe(true)
+    expect(IMAGE_EXTENSION_REGEX.test('photo.gif')).toBe(true)
+    expect(IMAGE_EXTENSION_REGEX.test('photo.webp')).toBe(true)
+  })
+
+  test('does not match non-image extensions', () => {
+    expect(IMAGE_EXTENSION_REGEX.test('file.txt')).toBe(false)
+    expect(IMAGE_EXTENSION_REGEX.test('file.bmp')).toBe(false)
+    expect(IMAGE_EXTENSION_REGEX.test('file.tiff')).toBe(false)
+  })
+})
+
+describe('PASTE_THRESHOLD', () => {
+  test('is a positive number', () => {
+    expect(PASTE_THRESHOLD).toBeGreaterThan(0)
+  })
+})
+
+describe('isImageFilePath', () => {
+  test('returns true for image file paths', () => {
+    expect(isImageFilePath('/Users/foo/photo.png')).toBe(true)
+    expect(isImageFilePath('C:\\Users\\foo\\photo.jpg')).toBe(true)
+    expect(isImageFilePath('photo.jpeg')).toBe(true)
+    expect(isImageFilePath('image.GIF')).toBe(true)
+  })
+
+  test('returns false for non-image file paths', () => {
+    expect(isImageFilePath('/Users/foo/document.txt')).toBe(false)
+    expect(isImageFilePath('C:\\Users\\foo\\readme.md')).toBe(false)
+    expect(isImageFilePath('plain text')).toBe(false)
+  })
+
+  test('handles quoted paths', () => {
+    expect(isImageFilePath('"/Users/foo/photo.png"')).toBe(true)
+    expect(isImageFilePath("'/Users/foo/photo.png'")).toBe(true)
+  })
+
+  test('handles paths with spaces', () => {
+    expect(isImageFilePath('/Users/foo/my photo.png')).toBe(true)
+  })
+})
+
+describe('asImageFilePath', () => {
+  test('returns cleaned path for valid image paths', () => {
+    expect(asImageFilePath('/Users/foo/photo.png')).toBe('/Users/foo/photo.png')
+    expect(asImageFilePath('"C:\\Users\\foo\\photo.jpg"')).toBe(
+      'C:\\Users\\foo\\photo.jpg',
+    )
+  })
+
+  test('returns null for non-image paths', () => {
+    expect(asImageFilePath('/Users/foo/document.txt')).toBeNull()
+    expect(asImageFilePath('plain text')).toBeNull()
+  })
+
+  test('trims whitespace', () => {
+    expect(asImageFilePath('  /Users/foo/photo.png  ')).toBe(
+      '/Users/foo/photo.png',
+    )
+  })
+})

--- a/src/utils/imagePaste.test.ts
+++ b/src/utils/imagePaste.test.ts
@@ -96,7 +96,9 @@ describe('asImageFilePath', () => {
   test('returns cleaned path for valid image paths', () => {
     expect(asImageFilePath('/Users/foo/photo.png')).toBe('/Users/foo/photo.png')
     expect(asImageFilePath('"C:\\Users\\foo\\photo.jpg"')).toBe(
-      'C:\\Users\\foo\\photo.jpg',
+      process.platform === 'win32'
+        ? 'C:\\Users\\foo\\photo.jpg'
+        : 'C:Usersfoophoto.jpg',
     )
   })
 

--- a/src/utils/imagePaste.ts
+++ b/src/utils/imagePaste.ts
@@ -38,6 +38,14 @@ export const LINUX_CLIPBOARD_IMAGE_MIME_TYPES = [
   'image/bmp',
 ]
 
+// Shared PowerShell command to check if the Windows clipboard contains an image.
+// Uses System.Windows.Forms.Clipboard.ContainsImage() which properly detects
+// raw bitmap data (CF_DIB/CF_BITMAP) from screenshot tools like PrintScreen
+// and Win+Shift+S, unlike Get-Clipboard -Format Image which only works with
+// file references copied from Explorer.
+const WIN32_CLIPBOARD_HAS_IMAGE_CMD =
+  'Add-Type -AssemblyName System.Windows.Forms; [System.Windows.Forms.Clipboard]::ContainsImage()'
+
 export function buildLinuxClipboardCheckCommand(): string {
   const mimePattern = LINUX_CLIPBOARD_IMAGE_MIME_TYPES.map(mimeType =>
     mimeType.replace('/', '\\/'),
@@ -94,9 +102,8 @@ function getClipboardCommands() {
       deleteFile: `rm -f "${screenshotPath}"`,
     },
     win32: {
-      checkImage:
-        'powershell -NoProfile -Command "(Get-Clipboard -Format Image) -ne $null"',
-      saveImage: `powershell -NoProfile -Command "$img = Get-Clipboard -Format Image; if ($img) { $img.Save('${screenshotPath.replace(/\\/g, '\\\\')}', [System.Drawing.Imaging.ImageFormat]::Png) }"`,
+      checkImage: `powershell -NoProfile -Command "${WIN32_CLIPBOARD_HAS_IMAGE_CMD}"`,
+      saveImage: `powershell -NoProfile -Command "Add-Type -AssemblyName System.Windows.Forms; $img = [System.Windows.Forms.Clipboard]::GetImage(); if ($img) { $img.Save('${screenshotPath.replace(/\\/g, '\\\\')}', [System.Drawing.Imaging.ImageFormat]::Png) }"`,
       getPath: 'powershell -NoProfile -Command "Get-Clipboard"',
       deleteFile: `del /f "${screenshotPath}"`,
     },
@@ -118,6 +125,18 @@ export type ImageWithDimensions = {
  * Check if clipboard contains an image without retrieving it.
  */
 export async function hasImageInClipboard(): Promise<boolean> {
+  // Windows: use .NET Clipboard.ContainsImage() which properly detects
+  // raw bitmap data (CF_DIB/CF_BITMAP) from screenshot tools like
+  // PrintScreen and Win+Shift+S.
+  if (process.platform === 'win32') {
+    const result = await execFileNoThrowWithCwd('powershell', [
+      '-NoProfile',
+      '-Command',
+      WIN32_CLIPBOARD_HAS_IMAGE_CMD,
+    ])
+    return result.code === 0 && result.stdout.trim() === 'True'
+  }
+
   if (process.platform !== 'darwin') {
     return false
   }
@@ -209,7 +228,10 @@ export async function getImageFromClipboard(): Promise<ImageWithDimensions | nul
 
   const { commands, screenshotPath } = getClipboardCommands()
   try {
-    // Check if clipboard has image
+    // Check if clipboard has image.
+    // Note: on Windows, ContainsImage() always exits 0 (stdout is "True"/"False")
+    // so this check is effectively a no-op — the real "no image" detection happens
+    // downstream when readFileBytesSync throws because saveImage didn't create the file.
     const checkResult = await execa(commands.checkImage, {
       shell: true,
       reject: false,

--- a/src/utils/imagePaste.ts
+++ b/src/utils/imagePaste.ts
@@ -46,6 +46,10 @@ export const LINUX_CLIPBOARD_IMAGE_MIME_TYPES = [
 const WIN32_CLIPBOARD_HAS_IMAGE_CMD =
   'Add-Type -AssemblyName System.Windows.Forms; [System.Windows.Forms.Clipboard]::ContainsImage()'
 
+function escapePowerShellSingleQuotedString(value: string): string {
+  return value.replace(/'/g, "''")
+}
+
 export function buildLinuxClipboardCheckCommand(): string {
   const mimePattern = LINUX_CLIPBOARD_IMAGE_MIME_TYPES.map(mimeType =>
     mimeType.replace('/', '\\/'),
@@ -103,7 +107,7 @@ function getClipboardCommands() {
     },
     win32: {
       checkImage: `powershell -NoProfile -Command "${WIN32_CLIPBOARD_HAS_IMAGE_CMD}"`,
-      saveImage: `powershell -NoProfile -Command "Add-Type -AssemblyName System.Windows.Forms; $img = [System.Windows.Forms.Clipboard]::GetImage(); if ($img) { $img.Save('${screenshotPath.replace(/\\/g, '\\\\')}', [System.Drawing.Imaging.ImageFormat]::Png) }"`,
+      saveImage: `powershell -NoProfile -Command "Add-Type -AssemblyName System.Windows.Forms; $img = [System.Windows.Forms.Clipboard]::GetImage(); if ($img) { $img.Save('${escapePowerShellSingleQuotedString(screenshotPath)}', [System.Drawing.Imaging.ImageFormat]::Png) }"`,
       getPath: 'powershell -NoProfile -Command "Get-Clipboard"',
       deleteFile: `del /f "${screenshotPath}"`,
     },
@@ -229,14 +233,17 @@ export async function getImageFromClipboard(): Promise<ImageWithDimensions | nul
   const { commands, screenshotPath } = getClipboardCommands()
   try {
     // Check if clipboard has image.
-    // Note: on Windows, ContainsImage() always exits 0 (stdout is "True"/"False")
-    // so this check is effectively a no-op — the real "no image" detection happens
-    // downstream when readFileBytesSync throws because saveImage didn't create the file.
     const checkResult = await execa(commands.checkImage, {
       shell: true,
       reject: false,
     })
     if (checkResult.exitCode !== 0) {
+      return null
+    }
+    if (
+      process.platform === 'win32' &&
+      checkResult.stdout.trim() !== 'True'
+    ) {
       return null
     }
 

--- a/src/utils/imagePaste.win32.test.ts
+++ b/src/utils/imagePaste.win32.test.ts
@@ -1,0 +1,123 @@
+import { afterEach, describe, expect, mock, test } from 'bun:test'
+
+type ImagePasteModule = typeof import('./imagePaste.js')
+type ExecFileModule = typeof import('./execFileNoThrow.js')
+type ExecaModule = typeof import('execa')
+type ExecaCall = [string, ...unknown[]]
+
+const originalPlatform = process.platform
+const originalTemp = process.env.TEMP
+
+let actualExecFileModule: ExecFileModule | undefined
+let actualExecaModule: ExecaModule | undefined
+
+function setPlatform(platform: NodeJS.Platform): void {
+  Object.defineProperty(process, 'platform', {
+    value: platform,
+  })
+}
+
+async function restoreMocks(): Promise<void> {
+  actualExecFileModule ??= await import(
+    `./execFileNoThrow.js?actual=${Date.now()}-${Math.random()}`
+  )
+  actualExecaModule ??= await import(
+    `execa?actual=${Date.now()}-${Math.random()}`
+  )
+  mock.module('./execFileNoThrow.js', () => actualExecFileModule!)
+  mock.module('execa', () => actualExecaModule!)
+}
+
+async function importImagePaste(): Promise<ImagePasteModule> {
+  return import(`./imagePaste.js?win32=${Date.now()}-${Math.random()}`)
+}
+
+afterEach(async () => {
+  setPlatform(originalPlatform)
+  if (originalTemp === undefined) {
+    delete process.env.TEMP
+  } else {
+    process.env.TEMP = originalTemp
+  }
+  await restoreMocks()
+  mock.restore()
+})
+
+describe('Windows clipboard image handling', () => {
+  test('hasImageInClipboard maps PowerShell True and False stdout', async () => {
+    setPlatform('win32')
+    const execFileNoThrowWithCwd = mock(async () => ({
+      code: 0,
+      stdout: 'True\r\n',
+      stderr: '',
+    }))
+    mock.module('./execFileNoThrow.js', () => ({
+      execFileNoThrowWithCwd,
+    }))
+
+    let imagePaste = await importImagePaste()
+    expect(await imagePaste.hasImageInClipboard()).toBe(true)
+    expect(execFileNoThrowWithCwd).toHaveBeenCalledWith('powershell', [
+      '-NoProfile',
+      '-Command',
+      'Add-Type -AssemblyName System.Windows.Forms; [System.Windows.Forms.Clipboard]::ContainsImage()',
+    ])
+
+    execFileNoThrowWithCwd.mockResolvedValueOnce({
+      code: 0,
+      stdout: 'False\r\n',
+      stderr: '',
+    })
+    imagePaste = await importImagePaste()
+    expect(await imagePaste.hasImageInClipboard()).toBe(false)
+  })
+
+  test('getImageFromClipboard returns null before saving when Windows reports no image', async () => {
+    setPlatform('win32')
+    const execa = mock(async () => ({
+      exitCode: 0,
+      stdout: 'False\r\n',
+      stderr: '',
+    }))
+    mock.module('execa', () => ({ execa }))
+
+    const { getImageFromClipboard } = await importImagePaste()
+
+    expect(await getImageFromClipboard()).toBeNull()
+    expect(execa).toHaveBeenCalledTimes(1)
+    const checkCall = execa.mock.calls[0] as unknown as ExecaCall | undefined
+    expect(checkCall?.[0]).toContain('Clipboard]::ContainsImage()')
+  })
+
+  test('getImageFromClipboard keeps Windows backslashes and escapes apostrophes in the save path', async () => {
+    setPlatform('win32')
+    process.env.TEMP = "C:\\Temp\\O'Brien"
+    const execa = mock(async () => ({
+      exitCode: 0,
+      stdout: 'True\r\n',
+      stderr: '',
+    }))
+    execa.mockResolvedValueOnce({
+      exitCode: 0,
+      stdout: 'True\r\n',
+      stderr: '',
+    })
+    execa.mockResolvedValueOnce({
+      exitCode: 1,
+      stdout: '',
+      stderr: '',
+    })
+    mock.module('execa', () => ({ execa }))
+
+    const { getImageFromClipboard } = await importImagePaste()
+
+    expect(await getImageFromClipboard()).toBeNull()
+    const saveCall = execa.mock.calls[1] as unknown as ExecaCall | undefined
+    const saveCommand = String(saveCall?.[0] ?? '')
+    expect(saveCommand).toContain("C:\\Temp\\O''Brien")
+    expect(saveCommand).not.toContain('C:\\\\Temp')
+    expect(saveCommand).toContain(
+      '[System.Windows.Forms.Clipboard]::GetImage()',
+    )
+  })
+})

--- a/src/utils/imagePaste.win32.test.ts
+++ b/src/utils/imagePaste.win32.test.ts
@@ -1,4 +1,7 @@
 import { afterEach, describe, expect, mock, test } from 'bun:test'
+import { mkdtempSync, rmSync, writeFileSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
 
 type ImagePasteModule = typeof import('./imagePaste.js')
 type ExecFileModule = typeof import('./execFileNoThrow.js')
@@ -7,9 +10,11 @@ type ExecaCall = [string, ...unknown[]]
 
 const originalPlatform = process.platform
 const originalTemp = process.env.TEMP
+const originalClaudeCodeTmpdir = process.env.CLAUDE_CODE_TMPDIR
 
 let actualExecFileModule: ExecFileModule | undefined
 let actualExecaModule: ExecaModule | undefined
+let tempDirs: string[] = []
 
 function setPlatform(platform: NodeJS.Platform): void {
   Object.defineProperty(process, 'platform', {
@@ -39,6 +44,15 @@ afterEach(async () => {
   } else {
     process.env.TEMP = originalTemp
   }
+  if (originalClaudeCodeTmpdir === undefined) {
+    delete process.env.CLAUDE_CODE_TMPDIR
+  } else {
+    process.env.CLAUDE_CODE_TMPDIR = originalClaudeCodeTmpdir
+  }
+  for (const tempDir of tempDirs) {
+    rmSync(tempDir, { recursive: true, force: true })
+  }
+  tempDirs = []
   await restoreMocks()
   mock.restore()
 })
@@ -119,5 +133,44 @@ describe('Windows clipboard image handling', () => {
     expect(saveCommand).toContain(
       '[System.Windows.Forms.Clipboard]::GetImage()',
     )
+  })
+
+  test('getImageFromClipboard returns image data when Windows check and save succeed', async () => {
+    setPlatform('win32')
+    const tempDir = mkdtempSync(join(tmpdir(), 'openclaude-image-paste-'))
+    tempDirs.push(tempDir)
+    process.env.CLAUDE_CODE_TMPDIR = tempDir
+    const screenshotPath = join(tempDir, 'claude_cli_latest_screenshot.png')
+    const imageBuffer = Buffer.from(
+      'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==',
+      'base64',
+    )
+    const execa = mock(async (command: string) => {
+      if (command.includes('Clipboard]::GetImage()')) {
+        writeFileSync(screenshotPath, imageBuffer)
+      }
+      return {
+      exitCode: 0,
+      stdout: 'True\r\n',
+      stderr: '',
+      }
+    })
+
+    mock.module('execa', () => ({ execa }))
+
+    const { getImageFromClipboard } = await importImagePaste()
+
+    const image = await getImageFromClipboard()
+    expect(image).toEqual({
+      base64: expect.any(String),
+      mediaType: 'image/png',
+      dimensions: undefined,
+    })
+    expect(image?.base64.length).toBeGreaterThan(0)
+    expect(execa).toHaveBeenCalledTimes(3)
+    const saveCall = execa.mock.calls[1] as unknown as ExecaCall | undefined
+    expect(String(saveCall?.[0] ?? '')).toContain(screenshotPath)
+    const deleteCall = execa.mock.calls[2] as unknown as ExecaCall | undefined
+    expect(deleteCall?.[0]).toContain('del /f')
   })
 })

--- a/src/utils/imagePaste.win32.test.ts
+++ b/src/utils/imagePaste.win32.test.ts
@@ -161,16 +161,16 @@ describe('Windows clipboard image handling', () => {
     const { getImageFromClipboard } = await importImagePaste()
 
     const image = await getImageFromClipboard()
-    expect(image).toEqual({
-      base64: expect.any(String),
-      mediaType: 'image/png',
-      dimensions: {
+    expect(image?.base64).toEqual(expect.any(String))
+    expect(image?.mediaType).toBe('image/png')
+    if (image?.dimensions !== undefined) {
+      expect(image.dimensions).toEqual({
         originalWidth: 1,
         originalHeight: 1,
         displayWidth: 1,
         displayHeight: 1,
-      },
-    })
+      })
+    }
     expect(image?.base64.length).toBeGreaterThan(0)
     expect(execa).toHaveBeenCalledTimes(3)
     const saveCall = execa.mock.calls[1] as unknown as ExecaCall | undefined

--- a/src/utils/imagePaste.win32.test.ts
+++ b/src/utils/imagePaste.win32.test.ts
@@ -6,6 +6,7 @@ import { join } from 'path'
 type ImagePasteModule = typeof import('./imagePaste.js')
 type ExecFileModule = typeof import('./execFileNoThrow.js')
 type ExecaModule = typeof import('execa')
+type ImageResizerModule = typeof import('./imageResizer.js')
 type ExecaCall = [string, ...unknown[]]
 
 const originalPlatform = process.platform
@@ -14,6 +15,7 @@ const originalClaudeCodeTmpdir = process.env.CLAUDE_CODE_TMPDIR
 
 let actualExecFileModule: ExecFileModule | undefined
 let actualExecaModule: ExecaModule | undefined
+let actualImageResizerModule: ImageResizerModule | undefined
 let tempDirs: string[] = []
 
 function setPlatform(platform: NodeJS.Platform): void {
@@ -29,8 +31,12 @@ async function restoreMocks(): Promise<void> {
   actualExecaModule ??= await import(
     `execa?actual=${Date.now()}-${Math.random()}`
   )
+  actualImageResizerModule ??= await import(
+    `./imageResizer.js?actual=${Date.now()}-${Math.random()}`
+  )
   mock.module('./execFileNoThrow.js', () => actualExecFileModule!)
   mock.module('execa', () => actualExecaModule!)
+  mock.module('./imageResizer.js', () => actualImageResizerModule!)
 }
 
 async function importImagePaste(): Promise<ImagePasteModule> {
@@ -156,21 +162,41 @@ describe('Windows clipboard image handling', () => {
       }
     })
 
+    actualImageResizerModule ??= await import(
+      `./imageResizer.js?actual=${Date.now()}-${Math.random()}`
+    )
+    const maybeResizeAndDownsampleImageBuffer = mock(async () => ({
+      buffer: imageBuffer,
+      mediaType: 'png',
+      dimensions: {
+        originalWidth: 1,
+        originalHeight: 1,
+        displayWidth: 1,
+        displayHeight: 1,
+      },
+    }))
     mock.module('execa', () => ({ execa }))
+    mock.module('./imageResizer.js', () => ({
+      ...actualImageResizerModule!,
+      maybeResizeAndDownsampleImageBuffer,
+    }))
 
     const { getImageFromClipboard } = await importImagePaste()
 
     const image = await getImageFromClipboard()
     expect(image?.base64).toEqual(expect.any(String))
     expect(image?.mediaType).toBe('image/png')
-    if (image?.dimensions !== undefined) {
-      expect(image.dimensions).toEqual({
-        originalWidth: 1,
-        originalHeight: 1,
-        displayWidth: 1,
-        displayHeight: 1,
-      })
-    }
+    expect(image?.dimensions).toEqual({
+      originalWidth: 1,
+      originalHeight: 1,
+      displayWidth: 1,
+      displayHeight: 1,
+    })
+    expect(maybeResizeAndDownsampleImageBuffer).toHaveBeenCalledWith(
+      imageBuffer,
+      imageBuffer.length,
+      'png',
+    )
     expect(image?.base64.length).toBeGreaterThan(0)
     expect(execa).toHaveBeenCalledTimes(3)
     const saveCall = execa.mock.calls[1] as unknown as ExecaCall | undefined

--- a/src/utils/imagePaste.win32.test.ts
+++ b/src/utils/imagePaste.win32.test.ts
@@ -150,9 +150,9 @@ describe('Windows clipboard image handling', () => {
         writeFileSync(screenshotPath, imageBuffer)
       }
       return {
-      exitCode: 0,
-      stdout: 'True\r\n',
-      stderr: '',
+        exitCode: 0,
+        stdout: 'True\r\n',
+        stderr: '',
       }
     })
 
@@ -164,7 +164,12 @@ describe('Windows clipboard image handling', () => {
     expect(image).toEqual({
       base64: expect.any(String),
       mediaType: 'image/png',
-      dimensions: undefined,
+      dimensions: {
+        originalWidth: 1,
+        originalHeight: 1,
+        displayWidth: 1,
+        displayHeight: 1,
+      },
     })
     expect(image?.base64.length).toBeGreaterThan(0)
     expect(execa).toHaveBeenCalledTimes(3)


### PR DESCRIPTION
## Summary

Fixes #1844

On Windows, pressing Alt+V to paste an image from the clipboard fails with "No image found in clipboard" when the image comes from PrintScreen or Win+Shift+S (Snipping Tool). These tools store raw bitmap data (CF_DIB/CF_BITMAP) on the clipboard, which PowerShell's `Get-Clipboard -Format Image` does not properly handle.

This PR replaces the Windows clipboard commands with `System.Windows.Forms.Clipboard.GetImage()` / `ContainsImage()`, which natively converts all clipboard image formats including raw DIB bitmaps.

## Changes

- **`src/utils/imagePaste.ts`**: Replace `Get-Clipboard -Format Image` with `Clipboard.GetImage()` for the save command and `Clipboard.ContainsImage()` for the check command. Extract shared `WIN32_CLIPBOARD_HAS_IMAGE_CMD` constant. Add Windows support to `hasImageInClipboard()` to enable the clipboard hint notification. Add clarifying comment on `checkImage` exit code behavior.
- **`src/utils/imagePaste.test.ts`** (new): Unit tests for exported functions/constants from `imagePaste.ts` — MIME types, Linux clipboard commands, image extension regex, file path detection, and paste threshold.

## Impact

- Windows users can now paste screenshots directly from PrintScreen / Win+Shift+S without saving to disk first
- The "Image in clipboard · Alt+V to paste" hint notification now fires on Windows when the terminal regains focus
- No changes to macOS or Linux behavior

## Checks run

- `bun run typecheck` — pass
- `bun test ./src/utils/imagePaste.test.ts` — 14/14 pass
- `bunx biome check` — pass


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Windows clipboard image detection using a PowerShell `ContainsImage()` check for more reliable results.
  - Updated Windows clipboard image retrieval to use the clipboard bitmap (`GetImage()`) and save it to the temp PNG with safer escaping.
  - Added stricter Windows gating to proceed only when the clipboard check confirms an image.

- **Tests**
  - Added Bun test coverage for Linux clipboard MIME/extension parsing and command generation (including proper escaping).
  - Added Windows-only clipboard tests covering PowerShell stdout handling, save-path escaping, and cleanup behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->