### PR TITLE
fix(memory): prevent reported idle retention paths

### DIFF
--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -8,7 +8,7 @@
  * - src/ path aliases
  */
 
-import { readFileSync } from 'fs'
+import { existsSync, readFileSync } from 'fs'
 import { createRequire } from 'module'
 import { dirname, join } from 'path'
 import { noTelemetryPlugin } from './no-telemetry-plugin'
@@ -46,6 +46,15 @@ const productionReactModules = new Map<string, string>([
   ],
   ['scheduler', join(schedulerPackageDir, 'cjs/scheduler.production.js')],
 ])
+
+for (const [specifier, resolvedPath] of productionReactModules) {
+  if (!existsSync(resolvedPath)) {
+    throw new Error(
+      `productionReactPlugin: expected production file for "${specifier}" not found at ${resolvedPath}. ` +
+        'The installed React package layout may have changed.',
+    )
+  }
+}
 
 const productionReactPlugin = {
   name: 'production-react-bundle',

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -9,12 +9,59 @@
  */
 
 import { readFileSync } from 'fs'
+import { createRequire } from 'module'
+import { dirname, join } from 'path'
 import { noTelemetryPlugin } from './no-telemetry-plugin'
 import { CLI_EXTERNALS, SDK_EXTERNALS } from './externals.js'
 import { canonicalStub, collectBundleStubs } from './stubMarkerGuard.js'
 
+const nodeRequire = createRequire(import.meta.url)
 const pkg = JSON.parse(readFileSync('./package.json', 'utf-8'))
 const version = pkg.version
+const reactPackageDir = dirname(nodeRequire.resolve('react/package.json'))
+const reactReconcilerPackageDir = dirname(
+  nodeRequire.resolve('react-reconciler/package.json'),
+)
+const schedulerPackageDir = dirname(nodeRequire.resolve('scheduler/package.json'))
+const productionReactModules = new Map<string, string>([
+  ['react', join(reactPackageDir, 'cjs/react.production.js')],
+  [
+    'react/jsx-runtime',
+    join(reactPackageDir, 'cjs/react-jsx-runtime.production.js'),
+  ],
+  [
+    'react/jsx-dev-runtime',
+    join(reactPackageDir, 'cjs/react-jsx-dev-runtime.production.js'),
+  ],
+  [
+    'react-reconciler',
+    join(reactReconcilerPackageDir, 'cjs/react-reconciler.production.js'),
+  ],
+  [
+    'react-reconciler/constants.js',
+    join(
+      reactReconcilerPackageDir,
+      'cjs/react-reconciler-constants.production.js',
+    ),
+  ],
+  ['scheduler', join(schedulerPackageDir, 'cjs/scheduler.production.js')],
+])
+
+const productionReactPlugin = {
+  name: 'production-react-bundle',
+  setup(build) {
+    build.onResolve(
+      {
+        filter:
+          /^(react|react\/jsx-runtime|react\/jsx-dev-runtime|react-reconciler|react-reconciler\/constants\.js|scheduler)$/,
+      },
+      args => {
+        const path = productionReactModules.get(args.path)
+        return path ? { path } : null
+      },
+    )
+  },
+}
 
 // Feature flags for the open build.
 // Most Anthropic-internal features stay off; open-build features can be
@@ -146,6 +193,7 @@ result = await Bun.build({
   plugins: [
     noTelemetryPlugin,
     featureFlagPreprocessPlugin,
+    productionReactPlugin,
     {
       name: 'bun-bundle-shim',
       setup(build) {

--- a/src/services/mcp/client.test.ts
+++ b/src/services/mcp/client.test.ts
@@ -2,6 +2,7 @@ import assert from 'node:assert/strict'
 import test from 'node:test'
 
 import {
+  appendBoundedMcpStderr,
   cleanupFailedConnection,
   buildMcpStdioCommand,
   logMcpServerStderr,
@@ -105,6 +106,20 @@ test('failed MCP startup stderr remains error-level', () => {
       ['error', 'context7', 'Server stderr: startup failed'],
     ])
   })
+})
+
+test('appendBoundedMcpStderr caps retained stderr and marks truncation', () => {
+  const output = appendBoundedMcpStderr('', Buffer.alloc(300 * 1024, 'x'))
+
+  assert.equal(output.length, 256 * 1024)
+  assert.match(output, /\.\.\.\[stderr truncated\]$/)
+})
+
+test('appendBoundedMcpStderr ignores chunks after truncation', () => {
+  const output = appendBoundedMcpStderr('', Buffer.alloc(300 * 1024, 'x'))
+  const after = appendBoundedMcpStderr(output, 'more stderr')
+
+  assert.equal(after, output)
 })
 
 test('buildMcpStdioCommand — no prefix passes command and args through unchanged', () => {

--- a/src/services/mcp/client.ts
+++ b/src/services/mcp/client.ts
@@ -1031,11 +1031,7 @@ export const connectToServer = memoize(
         const stdioTransport = transport as StdioClientTransport
         if (stdioTransport.stderr) {
           stderrHandler = (data: Buffer) => {
-            try {
-              stderrOutput = appendBoundedMcpStderr(stderrOutput, data)
-            } catch {
-              // Ignore errors from exceeding max string length
-            }
+            stderrOutput = appendBoundedMcpStderr(stderrOutput, data)
           }
           stdioTransport.stderr.on('data', stderrHandler)
         }

--- a/src/services/mcp/client.ts
+++ b/src/services/mcp/client.ts
@@ -569,6 +569,29 @@ type InProcessMcpServer = {
   close(): Promise<void>
 }
 
+const MAX_MCP_STDERR_CHARS = 256 * 1024
+const MCP_STDERR_TRUNCATED_MARKER = '\n...[stderr truncated]'
+
+export function appendBoundedMcpStderr(
+  current: string,
+  chunk: Buffer | string,
+): string {
+  if (current.includes(MCP_STDERR_TRUNCATED_MARKER)) {
+    return current
+  }
+
+  const text = typeof chunk === 'string' ? chunk : chunk.toString()
+  const next = current + text
+  if (next.length <= MAX_MCP_STDERR_CHARS) {
+    return next
+  }
+
+  return (
+    next.slice(0, MAX_MCP_STDERR_CHARS - MCP_STDERR_TRUNCATED_MARKER.length) +
+    MCP_STDERR_TRUNCATED_MARKER
+  )
+}
+
 export async function cleanupFailedConnection(
   transport: Pick<Transport, 'close'>,
   inProcessServer?: Pick<InProcessMcpServer, 'close'>,
@@ -1008,13 +1031,10 @@ export const connectToServer = memoize(
         const stdioTransport = transport as StdioClientTransport
         if (stdioTransport.stderr) {
           stderrHandler = (data: Buffer) => {
-            // Cap stderr accumulation to prevent unbounded memory growth
-            if (stderrOutput.length < 64 * 1024 * 1024) {
-              try {
-                stderrOutput += data.toString()
-              } catch {
-                // Ignore errors from exceeding max string length
-              }
+            try {
+              stderrOutput = appendBoundedMcpStderr(stderrOutput, data)
+            } catch {
+              // Ignore errors from exceeding max string length
             }
           }
           stdioTransport.stderr.on('data', stderrHandler)

--- a/src/utils/fpsTracker.test.ts
+++ b/src/utils/fpsTracker.test.ts
@@ -21,3 +21,31 @@ test('FpsTracker keeps a bounded frame-duration sample window', () => {
   assert.equal(state.frameDurations[state.writeIndex], 1000)
   assert.equal(state.frameDurations[state.writeIndex - 1], 5999)
 })
+
+test('FpsTracker keeps average FPS stable after the sample cap is reached', () => {
+  const originalPerformance = globalThis.performance
+  let now = 0
+
+  Object.defineProperty(globalThis, 'performance', {
+    configurable: true,
+    value: {
+      now: () => now,
+    },
+  })
+
+  try {
+    const tracker = new FpsTracker()
+
+    for (let i = 0; i < 6000; i++) {
+      now = i * (1000 / 60)
+      tracker.record(1000 / 60)
+    }
+
+    assert.equal(tracker.getMetrics()?.averageFps, 60.01)
+  } finally {
+    Object.defineProperty(globalThis, 'performance', {
+      configurable: true,
+      value: originalPerformance,
+    })
+  }
+})

--- a/src/utils/fpsTracker.test.ts
+++ b/src/utils/fpsTracker.test.ts
@@ -1,0 +1,17 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { FpsTracker } from './fpsTracker.js'
+
+test('FpsTracker keeps a bounded frame-duration sample window', () => {
+  const tracker = new FpsTracker()
+
+  for (let i = 0; i < 6000; i++) {
+    tracker.record(i)
+  }
+
+  const state = tracker as unknown as { frameDurations: number[] }
+  assert.equal(state.frameDurations.length, 5000)
+  assert.equal(state.frameDurations[0], 1000)
+  assert.equal(state.frameDurations.at(-1), 5999)
+})

--- a/src/utils/fpsTracker.test.ts
+++ b/src/utils/fpsTracker.test.ts
@@ -10,8 +10,14 @@ test('FpsTracker keeps a bounded frame-duration sample window', () => {
     tracker.record(i)
   }
 
-  const state = tracker as unknown as { frameDurations: number[] }
+  const state = tracker as unknown as {
+    frameDurations: number[]
+    sampleCount: number
+    writeIndex: number
+  }
   assert.equal(state.frameDurations.length, 5000)
-  assert.equal(state.frameDurations[0], 1000)
-  assert.equal(state.frameDurations.at(-1), 5999)
+  assert.equal(state.sampleCount, 5000)
+  assert.equal(state.writeIndex, 1000)
+  assert.equal(state.frameDurations[state.writeIndex], 1000)
+  assert.equal(state.frameDurations[state.writeIndex - 1], 5999)
 })

--- a/src/utils/fpsTracker.ts
+++ b/src/utils/fpsTracker.ts
@@ -6,7 +6,9 @@ export type FpsMetrics = {
 const MAX_FRAME_DURATION_SAMPLES = 5000
 
 export class FpsTracker {
-  private frameDurations: number[] = []
+  private frameDurations: number[] = new Array(MAX_FRAME_DURATION_SAMPLES)
+  private sampleCount = 0
+  private writeIndex = 0
   private firstRenderTime: number | undefined
   private lastRenderTime: number | undefined
 
@@ -16,15 +18,14 @@ export class FpsTracker {
       this.firstRenderTime = now
     }
     this.lastRenderTime = now
-    if (this.frameDurations.length >= MAX_FRAME_DURATION_SAMPLES) {
-      this.frameDurations.shift()
-    }
-    this.frameDurations.push(durationMs)
+    this.frameDurations[this.writeIndex] = durationMs
+    this.writeIndex = (this.writeIndex + 1) % MAX_FRAME_DURATION_SAMPLES
+    this.sampleCount = Math.min(this.sampleCount + 1, MAX_FRAME_DURATION_SAMPLES)
   }
 
   getMetrics(): FpsMetrics | undefined {
     if (
-      this.frameDurations.length === 0 ||
+      this.sampleCount === 0 ||
       this.firstRenderTime === undefined ||
       this.lastRenderTime === undefined
     ) {
@@ -36,10 +37,10 @@ export class FpsTracker {
       return undefined
     }
 
-    const totalFrames = this.frameDurations.length
+    const totalFrames = this.sampleCount
     const averageFps = totalFrames / (totalTimeMs / 1000)
 
-    const sorted = this.frameDurations.slice().sort((a, b) => b - a)
+    const sorted = this.getSamples().sort((a, b) => b - a)
     const p99Index = Math.max(0, Math.ceil(sorted.length * 0.01) - 1)
     const p99FrameTimeMs = sorted[p99Index]!
     const low1PctFps = p99FrameTimeMs > 0 ? 1000 / p99FrameTimeMs : 0
@@ -48,5 +49,16 @@ export class FpsTracker {
       averageFps: Math.round(averageFps * 100) / 100,
       low1PctFps: Math.round(low1PctFps * 100) / 100,
     }
+  }
+
+  private getSamples(): number[] {
+    if (this.sampleCount < MAX_FRAME_DURATION_SAMPLES) {
+      return this.frameDurations.slice(0, this.sampleCount)
+    }
+
+    return [
+      ...this.frameDurations.slice(this.writeIndex),
+      ...this.frameDurations.slice(0, this.writeIndex),
+    ]
   }
 }

--- a/src/utils/fpsTracker.ts
+++ b/src/utils/fpsTracker.ts
@@ -8,6 +8,7 @@ const MAX_FRAME_DURATION_SAMPLES = 5000
 export class FpsTracker {
   private frameDurations: number[] = new Array(MAX_FRAME_DURATION_SAMPLES)
   private sampleCount = 0
+  private totalFrameCount = 0
   private writeIndex = 0
   private firstRenderTime: number | undefined
   private lastRenderTime: number | undefined
@@ -18,6 +19,7 @@ export class FpsTracker {
       this.firstRenderTime = now
     }
     this.lastRenderTime = now
+    this.totalFrameCount += 1
     this.frameDurations[this.writeIndex] = durationMs
     this.writeIndex = (this.writeIndex + 1) % MAX_FRAME_DURATION_SAMPLES
     this.sampleCount = Math.min(this.sampleCount + 1, MAX_FRAME_DURATION_SAMPLES)
@@ -37,7 +39,7 @@ export class FpsTracker {
       return undefined
     }
 
-    const totalFrames = this.sampleCount
+    const totalFrames = this.totalFrameCount
     const averageFps = totalFrames / (totalTimeMs / 1000)
 
     const sorted = this.getSamples().sort((a, b) => b - a)

--- a/src/utils/fpsTracker.ts
+++ b/src/utils/fpsTracker.ts
@@ -3,6 +3,8 @@ export type FpsMetrics = {
   low1PctFps: number
 }
 
+const MAX_FRAME_DURATION_SAMPLES = 5000
+
 export class FpsTracker {
   private frameDurations: number[] = []
   private firstRenderTime: number | undefined
@@ -14,6 +16,9 @@ export class FpsTracker {
       this.firstRenderTime = now
     }
     this.lastRenderTime = now
+    if (this.frameDurations.length >= MAX_FRAME_DURATION_SAMPLES) {
+      this.frameDurations.shift()
+    }
     this.frameDurations.push(durationMs)
   }
 

--- a/src/utils/heapDumpService.test.ts
+++ b/src/utils/heapDumpService.test.ts
@@ -1,0 +1,39 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import {
+  __resetManualHeapDumpCountForTesting,
+  getHeapDumpAnalyticsMetadata,
+  getEffectiveHeapDumpNumber,
+} from './heapDumpService.js'
+
+test('manual heap dumps receive sequential effective dump numbers', () => {
+  __resetManualHeapDumpCountForTesting()
+
+  assert.equal(getEffectiveHeapDumpNumber('manual'), 1)
+  assert.equal(getEffectiveHeapDumpNumber('manual'), 2)
+})
+
+test('explicit and auto heap dump numbers pass through unchanged', () => {
+  __resetManualHeapDumpCountForTesting()
+
+  assert.equal(getEffectiveHeapDumpNumber('manual', 7), 7)
+  assert.equal(getEffectiveHeapDumpNumber('auto-1.5GB', 3), 3)
+  assert.equal(getEffectiveHeapDumpNumber('auto-1.5GB'), 0)
+})
+
+test('failure analytics uses the effective heap dump number', () => {
+  __resetManualHeapDumpCountForTesting()
+
+  const effectiveDumpNumber = getEffectiveHeapDumpNumber('manual')
+
+  assert.deepEqual(
+    getHeapDumpAnalyticsMetadata('manual', effectiveDumpNumber, false),
+    {
+      triggerManual: true,
+      triggerAuto15GB: false,
+      dumpNumber: 1,
+      success: false,
+    },
+  )
+})

--- a/src/utils/heapDumpService.test.ts
+++ b/src/utils/heapDumpService.test.ts
@@ -5,6 +5,7 @@ import {
   __resetManualHeapDumpCountForTesting,
   getHeapDumpAnalyticsMetadata,
   getEffectiveHeapDumpNumber,
+  getHeapDumpFilePaths,
 } from './heapDumpService.js'
 
 test('manual heap dumps receive sequential effective dump numbers', () => {
@@ -36,4 +37,30 @@ test('failure analytics uses the effective heap dump number', () => {
       success: false,
     },
   )
+})
+
+test('effective dump numbers are used in generated heap dump filenames', () => {
+  __resetManualHeapDumpCountForTesting()
+
+  const firstManual = getEffectiveHeapDumpNumber('manual')
+  const secondManual = getEffectiveHeapDumpNumber('manual')
+
+  assert.deepEqual(
+    getHeapDumpFilePaths('session-123', '/tmp/dumps', firstManual),
+    {
+      heapPath: '/tmp/dumps/session-123-dump1.heapsnapshot',
+      diagPath: '/tmp/dumps/session-123-dump1-diagnostics.json',
+    },
+  )
+  assert.deepEqual(
+    getHeapDumpFilePaths('session-123', '/tmp/dumps', secondManual),
+    {
+      heapPath: '/tmp/dumps/session-123-dump2.heapsnapshot',
+      diagPath: '/tmp/dumps/session-123-dump2-diagnostics.json',
+    },
+  )
+  assert.deepEqual(getHeapDumpFilePaths('session-123', '/tmp/dumps', 7), {
+    heapPath: '/tmp/dumps/session-123-dump7.heapsnapshot',
+    diagPath: '/tmp/dumps/session-123-dump7-diagnostics.json',
+  })
 })

--- a/src/utils/heapDumpService.ts
+++ b/src/utils/heapDumpService.ts
@@ -31,6 +31,43 @@ export type HeapDumpResult = {
 
 let manualHeapDumpCount = 0
 
+export function __resetManualHeapDumpCountForTesting(): void {
+  manualHeapDumpCount = 0
+}
+
+export function getEffectiveHeapDumpNumber(
+  trigger: 'manual' | 'auto-1.5GB',
+  dumpNumber = 0,
+): number {
+  if (dumpNumber > 0) {
+    return dumpNumber
+  }
+
+  if (trigger === 'manual') {
+    return ++manualHeapDumpCount
+  }
+
+  return dumpNumber
+}
+
+export function getHeapDumpAnalyticsMetadata(
+  trigger: 'manual' | 'auto-1.5GB',
+  effectiveDumpNumber: number,
+  success: boolean,
+): {
+  triggerManual: boolean
+  triggerAuto15GB: boolean
+  dumpNumber: number
+  success: boolean
+} {
+  return {
+    triggerManual: trigger === 'manual',
+    triggerAuto15GB: trigger === 'auto-1.5GB',
+    dumpNumber: effectiveDumpNumber,
+    success,
+  }
+}
+
 /**
  * Memory diagnostics captured alongside heap dump.
  * Helps identify if leak is in V8 heap (captured in snapshot) or native memory (not captured).
@@ -224,14 +261,10 @@ export async function performHeapDump(
   trigger: 'manual' | 'auto-1.5GB' = 'manual',
   dumpNumber = 0,
 ): Promise<HeapDumpResult> {
+  let effectiveDumpNumber = dumpNumber
   try {
     const sessionId = getSessionId()
-    const effectiveDumpNumber =
-      dumpNumber > 0
-        ? dumpNumber
-        : trigger === 'manual'
-          ? ++manualHeapDumpCount
-          : dumpNumber
+    effectiveDumpNumber = getEffectiveHeapDumpNumber(trigger, dumpNumber)
 
     // Capture diagnostics before any other async I/O —
     // the heap dump itself allocates memory and would skew the numbers.
@@ -268,23 +301,19 @@ export async function performHeapDump(
     await writeHeapSnapshot(heapPath)
     logForDebugging(`[HeapDump] Heap dump written to ${heapPath}`)
 
-    logEvent('tengu_heap_dump', {
-      triggerManual: trigger === 'manual',
-      triggerAuto15GB: trigger === 'auto-1.5GB',
-      dumpNumber: effectiveDumpNumber,
-      success: true,
-    })
+    logEvent(
+      'tengu_heap_dump',
+      getHeapDumpAnalyticsMetadata(trigger, effectiveDumpNumber, true),
+    )
 
     return { success: true, heapPath, diagPath }
   } catch (err) {
     const error = toError(err)
     logError(error)
-    logEvent('tengu_heap_dump', {
-      triggerManual: trigger === 'manual',
-      triggerAuto15GB: trigger === 'auto-1.5GB',
-      dumpNumber,
-      success: false,
-    })
+    logEvent(
+      'tengu_heap_dump',
+      getHeapDumpAnalyticsMetadata(trigger, effectiveDumpNumber, false),
+    )
     return { success: false, error: error.message }
   }
 }

--- a/src/utils/heapDumpService.ts
+++ b/src/utils/heapDumpService.ts
@@ -29,6 +29,8 @@ export type HeapDumpResult = {
   error?: string
 }
 
+let manualHeapDumpCount = 0
+
 /**
  * Memory diagnostics captured alongside heap dump.
  * Helps identify if leak is in V8 heap (captured in snapshot) or native memory (not captured).
@@ -37,7 +39,7 @@ export type MemoryDiagnostics = {
   timestamp: string
   sessionId: string
   trigger: 'manual' | 'auto-1.5GB'
-  dumpNumber: number // 1st, 2nd, etc. auto dump in this session (0 for manual)
+  dumpNumber: number // 1st, 2nd, etc. dump in this session
   uptimeSeconds: number
   memoryUsage: {
     heapUsed: number
@@ -224,10 +226,19 @@ export async function performHeapDump(
 ): Promise<HeapDumpResult> {
   try {
     const sessionId = getSessionId()
+    const effectiveDumpNumber =
+      dumpNumber > 0
+        ? dumpNumber
+        : trigger === 'manual'
+          ? ++manualHeapDumpCount
+          : dumpNumber
 
     // Capture diagnostics before any other async I/O —
     // the heap dump itself allocates memory and would skew the numbers.
-    const diagnostics = await captureMemoryDiagnostics(trigger, dumpNumber)
+    const diagnostics = await captureMemoryDiagnostics(
+      trigger,
+      effectiveDumpNumber,
+    )
 
     const toGB = (bytes: number): string =>
       (bytes / 1024 / 1024 / 1024).toFixed(3)
@@ -240,7 +251,8 @@ export async function performHeapDump(
     const dumpDir = getDesktopPath()
     await getFsImplementation().mkdir(dumpDir)
 
-    const suffix = dumpNumber > 0 ? `-dump${dumpNumber}` : ''
+    const suffix =
+      effectiveDumpNumber > 0 ? `-dump${effectiveDumpNumber}` : ''
     const heapFilename = `${sessionId}${suffix}.heapsnapshot`
     const diagFilename = `${sessionId}${suffix}-diagnostics.json`
     const heapPath = join(dumpDir, heapFilename)
@@ -259,7 +271,7 @@ export async function performHeapDump(
     logEvent('tengu_heap_dump', {
       triggerManual: trigger === 'manual',
       triggerAuto15GB: trigger === 'auto-1.5GB',
-      dumpNumber,
+      dumpNumber: effectiveDumpNumber,
       success: true,
     })
 

--- a/src/utils/heapDumpService.ts
+++ b/src/utils/heapDumpService.ts
@@ -68,6 +68,19 @@ export function getHeapDumpAnalyticsMetadata(
   }
 }
 
+export function getHeapDumpFilePaths(
+  sessionId: string,
+  dumpDir: string,
+  effectiveDumpNumber: number,
+): { heapPath: string; diagPath: string } {
+  const suffix =
+    effectiveDumpNumber > 0 ? `-dump${effectiveDumpNumber}` : ''
+  return {
+    heapPath: join(dumpDir, `${sessionId}${suffix}.heapsnapshot`),
+    diagPath: join(dumpDir, `${sessionId}${suffix}-diagnostics.json`),
+  }
+}
+
 /**
  * Memory diagnostics captured alongside heap dump.
  * Helps identify if leak is in V8 heap (captured in snapshot) or native memory (not captured).
@@ -283,13 +296,11 @@ export async function performHeapDump(
 
     const dumpDir = getDesktopPath()
     await getFsImplementation().mkdir(dumpDir)
-
-    const suffix =
-      effectiveDumpNumber > 0 ? `-dump${effectiveDumpNumber}` : ''
-    const heapFilename = `${sessionId}${suffix}.heapsnapshot`
-    const diagFilename = `${sessionId}${suffix}-diagnostics.json`
-    const heapPath = join(dumpDir, heapFilename)
-    const diagPath = join(dumpDir, diagFilename)
+    const { heapPath, diagPath } = getHeapDumpFilePaths(
+      sessionId,
+      dumpDir,
+      effectiveDumpNumber,
+    )
 
     // Write diagnostics first (cheap, unlikely to fail)
     await writeFile(diagPath, jsonStringify(diagnostics, null, 2), {


### PR DESCRIPTION
## Summary

- force the CLI bundle to resolve React, `react-reconciler`, reconciler constants, and `scheduler` to their production CJS builds, with an explicit existence guard for the production CJS files
- bound the concrete secondary retention paths called out in #1839:
  - cap FPS frame-duration samples with a fixed-size ring buffer while keeping average FPS based on total observed frames
  - cap stdio MCP startup stderr at 256 KiB with an explicit truncation marker
- make repeated manual `/heapdump` captures unique within a session so leak snapshots can be compared without overwriting earlier dumps
- add focused regression coverage for MCP stderr truncation, FPS retention/average behavior, heap dump numbering, heap dump analytics, and generated heap dump filenames

Fixes #1839

## Impact

- user-facing impact: long-running packaged CLI sessions avoid the development reconciler user-timing path that accumulates Node `PerformanceMeasure` entries on render commits; noisy MCP stdio servers and FPS metrics no longer retain unbounded or very large buffers
- developer/maintainer impact: build behavior is explicit and guarded for the bundled React stack without changing app-level dev/test guards or adding dependencies; `/heapdump` is more useful for future memory triage because manual dumps get stable numbered heap/diagnostics filenames

## Testing

- [x] `bun run build`
- [x] `bun run smoke`
- [x] `bun run typecheck`
- [x] `git diff --check origin/main...HEAD`
- [x] focused tests: `bun test --feature=UNATTENDED_RETRY src/utils/fpsTracker.test.ts src/services/mcp/client.test.ts src/utils/heapDumpService.test.ts`
- [x] focused tests: bundle marker check confirmed no React/reconciler/scheduler development bundle markers and no `supportsUserTiming`/`performance.measure` in `dist/cli.mjs`
- [x] GitHub PR checks on the current head: `smoke-and-tests`, `typecheck`, `web`, and CodeRabbit all passed
- [x] focused tests from earlier packaging verification: `npm --cache /tmp/openclaude-npm-cache pack --pack-destination /tmp/openclaude-pack`
- [x] focused tests from earlier packaging verification: packed `package/dist/cli.mjs` marker check confirmed no React/reconciler/scheduler development bundle markers and no `supportsUserTiming`/`performance.measure`

## Notes

- provider/model path tested: not applicable; build/runtime packaging and memory-retention fix only
- screenshots attached (if UI changed): not applicable
- reported issue coverage:
  - primary `PerformanceMeasure` accumulation: fixed for the packaged/global npm CLI by bundling production React/reconciler/scheduler
  - `fpsTracker` frame array growth: fixed by bounding retained samples
  - MCP stderr retention: fixed by reducing retained startup stderr to 256 KiB and truncating further chunks
  - diagnostic tracking Maps: current code already clears these Maps on `shutdown()` and `reset()`
  - child abort controller listeners: current code already uses weak references and removes the parent listener when the child aborts
  - repeated manual `/heapdump` overwrite: fixed by numbering manual dumps within the session and using the effective number in heap snapshot, diagnostics, and analytics paths
- follow-up work or known limitations: the current PR-specific GitHub checks pass; older local full-suite failures seen during earlier investigation were in source suites unrelated to this change


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved MCP server stderr buffering by capping stored output and consistently appending a truncation notice.
  * Updated FPS tracking to use a bounded rolling buffer, preventing unbounded growth and stabilizing average FPS calculations.
  * Standardized manual heap dump numbering so generated filenames and related analytics/diagnostics use the same effective numbering.
* **Build/Packaging**
  * Refined production CLI bundling to resolve React-related imports to production-ready artifacts for more consistent output.
* **Tests**
  * Added unit tests for bounded stderr truncation, FPS ring-buffer behavior, and heap dump numbering/analytics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
