### PR TITLE
fix(lsp): suppress empty diagnostic deliveries

### DIFF
--- a/src/services/lsp/LSPDiagnosticRegistry.test.ts
+++ b/src/services/lsp/LSPDiagnosticRegistry.test.ts
@@ -47,6 +47,12 @@ function diagnosticCount(files: DiagnosticFile[]): number {
   return files.reduce((sum, file) => sum + file.diagnostics.length, 0)
 }
 
+function deliveryLogs(): string[] {
+  return debugMessages.filter(message =>
+    message.startsWith('LSP Diagnostics: Delivering '),
+  )
+}
+
 describe('LSPDiagnosticRegistry storm control', () => {
   beforeEach(() => {
     registry.resetAllLSPDiagnosticState()
@@ -85,6 +91,20 @@ describe('LSPDiagnosticRegistry storm control', () => {
     })
 
     expect(registry.checkForLSPDiagnostics()).toEqual([])
+    expect(deliveryLogs()).not.toContain(
+      'LSP Diagnostics: Delivering 1 file(s) with 0 diagnostic(s) from 1 server(s)',
+    )
+  })
+
+  test('returns no diagnostic set for raw empty diagnostic files', () => {
+    registry.registerPendingLSPDiagnostic({
+      serverName: 'typescript',
+      files: [{ uri: '/repo/cleared.ts', diagnostics: [] }],
+    })
+
+    expect(registry.checkForLSPDiagnostics()).toEqual([])
+    expect(registry.getPendingLSPDiagnosticCount()).toBe(0)
+    expect(deliveryLogs()).toEqual([])
   })
 
   test('snapshots pending diagnostics without consuming delivery', () => {
@@ -194,6 +214,8 @@ describe('LSPDiagnosticRegistry storm control', () => {
     // Intentionally clear by file:// URI while diagnostics use a plain path;
     // both forms must normalize to the same delivered-diagnostic key.
     registry.clearDeliveredDiagnosticsForFile('file:///repo/a.ts')
+    expect(registry.checkForLSPDiagnostics()).toEqual([])
+
     registry.registerPendingLSPDiagnostic({
       serverName: 'typescript',
       files: [file],
@@ -308,11 +330,34 @@ describe('LSPDiagnosticRegistry storm control', () => {
       serverName: 'typescript',
       files: [stormFile],
     })
-    const secondFiles = registry.checkForLSPDiagnostics()[0]?.files ?? []
+    const secondDiagnosticSets = registry.checkForLSPDiagnostics()
 
-    expect(secondFiles.map(file => file.uri)).toEqual([
-      'lsp://diagnostic-storm/typescript',
-    ])
+    expect(secondDiagnosticSets).toEqual([])
+    expect(deliveryLogs()).not.toContain(
+      'LSP Diagnostics: Delivering 1 file(s) with 0 diagnostic(s) from 1 server(s)',
+    )
+  })
+
+  test('returns no diagnostic set when volume limiting leaves only reserved summaries', () => {
+    for (let index = 0; index < 30; index++) {
+      registry.registerPendingLSPDiagnostic({
+        serverName: `server-${index}`,
+        files: [
+          diagnosticFile(
+            `/repo/storm-${index}.ts`,
+            Array.from(
+              { length: 201 },
+              (_, diagnosticIndex) =>
+                `storm ${index} diagnostic ${diagnosticIndex}`,
+            ),
+          ),
+        ],
+      })
+    }
+
+    expect(registry.checkForLSPDiagnostics()).toEqual([])
+    expect(registry.getPendingLSPDiagnosticCount()).toBe(0)
+    expect(deliveryLogs()).toEqual([])
   })
 
   test('reserves compact summaries for multiple storming servers before full diagnostics', () => {

--- a/src/services/lsp/LSPDiagnosticRegistry.test.ts
+++ b/src/services/lsp/LSPDiagnosticRegistry.test.ts
@@ -330,15 +330,18 @@ describe('LSPDiagnosticRegistry storm control', () => {
       serverName: 'typescript',
       files: [stormFile],
     })
-    const secondDiagnosticSets = registry.checkForLSPDiagnostics()
+    const secondFiles = registry.checkForLSPDiagnostics()[0]?.files ?? []
 
-    expect(secondDiagnosticSets).toEqual([])
+    expect(secondFiles.map(file => file.uri)).toEqual([
+      'lsp://diagnostic-storm/typescript',
+    ])
+    expect(diagnosticCount(secondFiles)).toBe(1)
     expect(deliveryLogs()).not.toContain(
       'LSP Diagnostics: Delivering 1 file(s) with 0 diagnostic(s) from 1 server(s)',
     )
   })
 
-  test('returns no diagnostic set when volume limiting leaves only reserved summaries', () => {
+  test('returns compact storm summaries when volume limiting leaves only reserved summaries', () => {
     for (let index = 0; index < 30; index++) {
       registry.registerPendingLSPDiagnostic({
         serverName: `server-${index}`,
@@ -355,9 +358,16 @@ describe('LSPDiagnosticRegistry storm control', () => {
       })
     }
 
-    expect(registry.checkForLSPDiagnostics()).toEqual([])
+    const files = registry.checkForLSPDiagnostics()[0]?.files ?? []
+
+    expect(files).toHaveLength(30)
+    expect(files.every(file => file.uri.startsWith('lsp://diagnostic-storm/')))
+      .toBe(true)
+    expect(diagnosticCount(files)).toBe(30)
     expect(registry.getPendingLSPDiagnosticCount()).toBe(0)
-    expect(deliveryLogs()).toEqual([])
+    expect(deliveryLogs()).not.toContain(
+      'LSP Diagnostics: Delivering 30 file(s) with 0 diagnostic(s) from 30 server(s)',
+    )
   })
 
   test('reserves compact summaries for multiple storming servers before full diagnostics', () => {

--- a/src/services/lsp/LSPDiagnosticRegistry.ts
+++ b/src/services/lsp/LSPDiagnosticRegistry.ts
@@ -790,10 +790,10 @@ export function checkForLSPDiagnostics(): LSPDiagnosticSet[] {
     }
   }
 
-  // Return empty if no diagnostics to deliver (all filtered by deduplication)
-  if (deliveredFiles.length === 0) {
+  // Return empty if no real diagnostics remain after deduplication/filtering.
+  if (deliveredFiles.length === 0 || deliveredCount === 0) {
     logForDebugging(
-      `LSP Diagnostics: No new diagnostics to deliver (all filtered by deduplication)`,
+      `LSP Diagnostics: No new diagnostics to deliver after filtering, deduplication, and volume limiting`,
     )
     return []
   }

--- a/src/services/lsp/LSPDiagnosticRegistry.ts
+++ b/src/services/lsp/LSPDiagnosticRegistry.ts
@@ -554,6 +554,10 @@ function limitDiagnosticFiles(
   return { files: limitedFiles, droppedCount, deliveredCount }
 }
 
+function countDiagnostics(files: DiagnosticFile[]): number {
+  return files.reduce((total, file) => total + file.diagnostics.length, 0)
+}
+
 function trackDeliveredDiagnostics(files: DiagnosticFile[]): void {
   for (const file of files) {
     const normalizedUri = normalizeDiagnosticUri(file.uri)
@@ -790,8 +794,10 @@ export function checkForLSPDiagnostics(): LSPDiagnosticSet[] {
     }
   }
 
-  // Return empty if no real diagnostics remain after deduplication/filtering.
-  if (deliveredFiles.length === 0 || deliveredCount === 0) {
+  const finalDiagnosticCount = countDiagnostics(deliveredFiles)
+
+  // Return empty if no diagnostics remain after deduplication/filtering.
+  if (deliveredFiles.length === 0 || finalDiagnosticCount === 0) {
     logForDebugging(
       `LSP Diagnostics: No new diagnostics to deliver after filtering, deduplication, and volume limiting`,
     )
@@ -811,7 +817,7 @@ export function checkForLSPDiagnostics(): LSPDiagnosticSet[] {
   }
 
   logForDebugging(
-    `LSP Diagnostics: Delivering ${deliveredFiles.length} file(s) with ${deliveredCount} diagnostic(s) from ${serverNames.length} server(s)`,
+    `LSP Diagnostics: Delivering ${deliveredFiles.length} file(s) with ${finalDiagnosticCount} diagnostic(s) from ${serverNames.length} server(s)`,
   )
 
   // Return single result with all deduplicated diagnostics

--- a/src/utils/attachments.lspDiagnostics.test.ts
+++ b/src/utils/attachments.lspDiagnostics.test.ts
@@ -1,0 +1,177 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test'
+import type { ToolUseContext, Tools } from '../Tool.js'
+import { BASH_TOOL_NAME } from '../tools/BashTool/toolName.js'
+import type { DiagnosticFile } from '../services/diagnosticTracking.js'
+import type { Attachment } from './attachments.js'
+
+const debugMessages: string[] = []
+const realDebugModule = await import(
+  `./debug.js?real=${Date.now()}-${Math.random()}`,
+)
+const realLSPRegistry = await import(
+  `../services/lsp/LSPDiagnosticRegistry.ts?real=${Date.now()}-${Math.random()}`,
+)
+
+let diagnosticSets: Array<{ serverName: string; files: DiagnosticFile[] }> = []
+
+const checkForLSPDiagnosticsMock = mock(() => diagnosticSets)
+const clearAllLSPDiagnosticsMock = mock(() => {
+  diagnosticSets = []
+})
+
+mock.module('./debug.js', () => ({
+  ...realDebugModule,
+  logForDebugging: mock((message: string) => {
+    debugMessages.push(message)
+  }),
+}))
+
+mock.module('../services/lsp/LSPDiagnosticRegistry.js', () => ({
+  ...realLSPRegistry,
+  checkForLSPDiagnostics: checkForLSPDiagnosticsMock,
+  clearAllLSPDiagnostics: clearAllLSPDiagnosticsMock,
+}))
+
+const { getAttachmentMessages } = await import(
+  `./attachments.ts?test=${Date.now()}-${Math.random()}`
+)
+
+const SAVED_SIMPLE = process.env.CLAUDE_CODE_SIMPLE
+const SAVED_DISABLE_ATTACHMENTS = process.env.CLAUDE_CODE_DISABLE_ATTACHMENTS
+
+type DiagnosticsAttachment = Extract<Attachment, { type: 'diagnostics' }>
+
+function makeToolUseContext(): ToolUseContext {
+  let inProgressToolUseIDs = new Set<string>()
+
+  return {
+    abortController: new AbortController(),
+    readFileState: {} as ToolUseContext['readFileState'],
+    getAppState: () => ({
+      fastMode: false,
+      mcp: { tools: {}, clients: [] },
+      toolPermissionContext: { mode: 'default' },
+      sessionHooks: new Map(),
+      mainLoopModel: 'gpt-4o',
+      effortValue: undefined,
+      advisorModel: undefined,
+    }),
+    setAppState: () => {},
+    options: {
+      commands: [],
+      debug: false,
+      thinkingConfig: { type: 'disabled' },
+      tools: [{ name: BASH_TOOL_NAME } as Tools[number]],
+      verbose: false,
+      mcpClients: [],
+      mcpResources: {},
+      isNonInteractiveSession: false,
+      agentDefinitions: { activeAgents: [], allowedAgentTypes: undefined },
+      mainLoopModel: 'gpt-4o',
+    },
+    nestedMemoryAttachmentTriggers: new Set(),
+    loadedNestedMemoryPaths: new Set(),
+    dynamicSkillDirTriggers: new Set(),
+    discoveredSkillNames: new Set(),
+    setInProgressToolUseIDs: updater => {
+      inProgressToolUseIDs = updater(inProgressToolUseIDs)
+    },
+    setResponseLength: () => {},
+    updateFileHistoryState: () => {},
+    updateAttributionState: () => {},
+    messages: [],
+  } as unknown as ToolUseContext
+}
+
+async function collectLSPDiagnosticAttachments(): Promise<
+  DiagnosticsAttachment[]
+> {
+  const diagnosticsAttachments: DiagnosticsAttachment[] = []
+
+  for await (const message of getAttachmentMessages(
+    null,
+    makeToolUseContext(),
+    null,
+    [],
+    [],
+    'compact',
+    { skipSkillDiscovery: true },
+  )) {
+    if (message.attachment.type === 'diagnostics') {
+      diagnosticsAttachments.push(message.attachment)
+    }
+  }
+
+  return diagnosticsAttachments
+}
+
+describe('LSP diagnostic attachment filtering', () => {
+  beforeEach(() => {
+    delete process.env.CLAUDE_CODE_SIMPLE
+    delete process.env.CLAUDE_CODE_DISABLE_ATTACHMENTS
+    diagnosticSets = []
+    debugMessages.length = 0
+    checkForLSPDiagnosticsMock.mockClear()
+    clearAllLSPDiagnosticsMock.mockClear()
+  })
+
+  afterEach(() => {
+    if (SAVED_SIMPLE === undefined) {
+      delete process.env.CLAUDE_CODE_SIMPLE
+    } else {
+      process.env.CLAUDE_CODE_SIMPLE = SAVED_SIMPLE
+    }
+    if (SAVED_DISABLE_ATTACHMENTS === undefined) {
+      delete process.env.CLAUDE_CODE_DISABLE_ATTACHMENTS
+    } else {
+      process.env.CLAUDE_CODE_DISABLE_ATTACHMENTS = SAVED_DISABLE_ATTACHMENTS
+    }
+  })
+
+  test('does not return a diagnostics attachment for an empty final LSP payload', async () => {
+    diagnosticSets = [
+      {
+        serverName: 'typescript',
+        files: [{ uri: '/repo/src/clean.ts', diagnostics: [] }],
+      },
+    ]
+
+    const attachments = await collectLSPDiagnosticAttachments()
+
+    expect(attachments).toEqual([])
+    expect(clearAllLSPDiagnosticsMock).not.toHaveBeenCalled()
+    expect(debugMessages).toContain(
+      'LSP Diagnostics: No diagnostic attachments to return after filtering empty diagnostic payloads',
+    )
+  })
+
+  test('returns a diagnostics attachment for a compact storm summary-only payload', async () => {
+    const summaryFile: DiagnosticFile = {
+      uri: 'lsp://diagnostic-storm/typescript',
+      diagnostics: [
+        {
+          message:
+            'LSP diagnostic storm: server=typescript raw=210 duplicates=210 dropped=0 delivered=0 topFiles=[noisy.ts:210]',
+          severity: 'Info',
+          range: {
+            start: { line: 0, character: 0 },
+            end: { line: 0, character: 0 },
+          },
+          source: 'openclaude-lsp',
+          code: 'diagnostic-storm',
+        },
+      ],
+    }
+    diagnosticSets = [{ serverName: 'typescript', files: [summaryFile] }]
+
+    const attachments = await collectLSPDiagnosticAttachments()
+
+    expect(attachments).toEqual([
+      { type: 'diagnostics', files: [summaryFile], isNew: true },
+    ])
+    expect(clearAllLSPDiagnosticsMock).toHaveBeenCalledTimes(1)
+    expect(debugMessages).toContain(
+      'LSP Diagnostics: Returning 1 diagnostic attachment(s)',
+    )
+  })
+})

--- a/src/utils/attachments.lspDiagnostics.test.ts
+++ b/src/utils/attachments.lspDiagnostics.test.ts
@@ -9,7 +9,7 @@ const realDebugModule = await import(
   `./debug.js?real=${Date.now()}-${Math.random()}`,
 )
 const realLSPRegistry = await import(
-  `../services/lsp/LSPDiagnosticRegistry.ts?real=${Date.now()}-${Math.random()}`,
+  `../services/lsp/LSPDiagnosticRegistry.js?real=${Date.now()}-${Math.random()}`,
 )
 
 let diagnosticSets: Array<{ serverName: string; files: DiagnosticFile[] }> = []

--- a/src/utils/attachments.ts
+++ b/src/utils/attachments.ts
@@ -2951,6 +2951,9 @@ async function getLSPDiagnosticAttachments(
       return []
     }
 
+    // checkForLSPDiagnostics normally enforces this invariant. Keep a final
+    // attachment-boundary guard so future registry changes cannot send empty
+    // diagnostics attachments to the model.
     const finalDiagnosticCount = diagnosticSets.reduce(
       (count, set) =>
         count +

--- a/src/utils/attachments.ts
+++ b/src/utils/attachments.ts
@@ -2951,6 +2951,22 @@ async function getLSPDiagnosticAttachments(
       return []
     }
 
+    const finalDiagnosticCount = diagnosticSets.reduce(
+      (count, set) =>
+        count +
+        set.files.reduce(
+          (fileCount, file) => fileCount + file.diagnostics.length,
+          0,
+        ),
+      0,
+    )
+    if (finalDiagnosticCount === 0) {
+      logForDebugging(
+        `LSP Diagnostics: No diagnostic attachments to return after filtering empty diagnostic payloads`,
+      )
+      return []
+    }
+
     logForDebugging(
       `LSP Diagnostics: Found ${diagnosticSets.length} pending diagnostic set(s)`,
     )


### PR DESCRIPTION
## Summary

- Suppress passive LSP diagnostic delivery when the final real diagnostic count is zero after filtering, deduplication, delivered-cache suppression, and volume limiting.
- Preserve delivered-diagnostic tracking so capped or duplicate diagnostic bursts do not trickle unchanged diagnostics into later turns, while file clears still allow real diagnostics to be sent again.

## Impact

- user-facing impact: avoids empty diagnostic attachments being sent into model context.
- developer/maintainer impact: adds regression coverage for raw empty diagnostics, dedupe/filter-to-zero behavior, reserved-summary volume limiting, unchanged suppression, and clear-then-redeliver behavior.

## Testing

- [x] `bun test --feature=UNATTENDED_RETRY --max-concurrency=1 src/services/lsp/LSPDiagnosticRegistry.test.ts`
- [x] `bun test --feature=UNATTENDED_RETRY --max-concurrency=1 src/commands/diagnostics/diagnostics.test.ts`
- [x] `bun run typecheck`
- [x] `bun run smoke`
- [x] `bun run security:pr-scan -- --base upstream/main`
- [x] `git diff --check`

## Notes

- provider/model path tested: not applicable; this is an LSP diagnostics registry change.
- screenshots attached: not applicable; no UI changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented spurious LSP diagnostic deliveries and attachments when filtering/deduplication/volume limiting leaves zero diagnostics.
  * Updated delivery/debug logging to report the final post-filter diagnostic count and avoid “delivering” output when nothing remains (including storm/summary-only scenarios).

* **Tests**
  * Added/extended coverage for empty diagnostic sets and fully empty diagnostic payloads, including checks after clearing delivered diagnostics.
  * Added a new attachment test suite to verify diagnostics attachment filtering and ensure clearing/logging behavior matches expected outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->