### PR TITLE
feat(ux): honest feedback pass — visible retries, statusline truncation marker, hint grace period

### DIFF
--- a/src/components/BuiltinStatusLine.test.tsx
+++ b/src/components/BuiltinStatusLine.test.tsx
@@ -97,14 +97,36 @@ describe('fitSegments', () => {
     expect(fitSegments(segments, 120)).toHaveLength(4)
   })
 
-  it('drops highest-priority-number segments first when narrow', () => {
+  it('degrades segments to short forms before dropping any', () => {
+    // 'Opus 4.8 · 37% · $1 · 5h 42%' = 28 cols — all four survive at 30
     const fitted = fitSegments(segments, 30)
-    expect(fitted.map(s => s.key)).toEqual(['model', 'context', 'cost'])
+    expect(fitted.map(s => s.key)).toEqual([
+      'model',
+      'context',
+      'cost',
+      'rateLimit',
+    ])
+    expect(fitted.find(s => s.key === 'context')?.text).toBe('37%')
+    expect(fitted.find(s => s.key === 'cost')?.text).toBe('$1')
   })
 
-  it('keeps only the model at very narrow widths', () => {
+  it('marks dropped segments with a trailing ellipsis', () => {
+    // Too narrow for all four even degraded; hidden data must be visible as hidden
+    const fitted = fitSegments(segments, 22)
+    expect(fitted.at(-1)?.key).toBe('truncated')
+    expect(fitted.at(-1)?.text).toBe('…')
+    expect(fitted.map(s => s.key)).toContain('context')
+  })
+
+  it('keeps only the model at very narrow widths, skipping the marker if it will not fit', () => {
     const fitted = fitSegments(segments, 10)
     expect(fitted.map(s => s.key)).toEqual(['model'])
+  })
+
+  it('does not mutate the caller-visible segment text', () => {
+    const before = segments.map(s => s.text)
+    fitSegments(segments, 22)
+    expect(segments.map(s => s.text)).toEqual(before)
   })
 
   it('returns empty when even the model does not fit', () => {

--- a/src/components/BuiltinStatusLine.tsx
+++ b/src/components/BuiltinStatusLine.tsx
@@ -38,6 +38,8 @@ export type StatusSegment = {
   /** Lower survives longer when the terminal narrows. */
   priority: number;
   text: string;
+  /** Compact form swapped in before the segment is dropped entirely. */
+  shortText?: string;
   color?: keyof Theme;
 };
 const SEPARATOR = ' · ';
@@ -66,6 +68,7 @@ export function buildBuiltinStatusSegments(data: BuiltinStatusData): StatusSegme
       key: 'context',
       priority: 1,
       text: `ctx ${pctText}%`,
+      shortText: `${pctText}%`,
       // Thresholds align with the auto-compact warnings
       color: roundedPct >= 90 ? 'error' : roundedPct >= 70 ? 'warning' : undefined
     });
@@ -75,7 +78,8 @@ export function buildBuiltinStatusSegments(data: BuiltinStatusData): StatusSegme
     segments.push({
       key: 'cost',
       priority: 2,
-      text: cost >= 100 ? `$${cost.toFixed(0)}` : `$${cost.toFixed(2)}`
+      text: cost >= 100 ? `$${cost.toFixed(0)}` : `$${cost.toFixed(2)}`,
+      shortText: `$${cost.toFixed(0)}`
     });
   }
   if (data.rateLimit) {
@@ -90,21 +94,51 @@ export function buildBuiltinStatusSegments(data: BuiltinStatusData): StatusSegme
   return segments;
 }
 
-/** Drops the highest-priority-number segments until the joined line fits. */
+/** Trailing marker signalling that segments were hidden for width. */
+const TRUNCATION_MARKER: StatusSegment = {
+  key: 'truncated',
+  priority: Number.MAX_SAFE_INTEGER,
+  text: '…'
+};
+
+/**
+ * Fits segments into maxWidth without lying about it: first swaps in each
+ * segment's shortText (highest priority number first), then drops segments,
+ * appending a dim `…` so hidden data is visible as hidden. The marker is
+ * best-effort — at extreme widths showing the model beats showing nothing.
+ */
 export function fitSegments(segments: StatusSegment[], maxWidth: number): StatusSegment[] {
   const fits = (segs: StatusSegment[]): boolean => {
     if (segs.length === 0) return true;
     const width = segs.reduce((sum, s) => sum + s.text.length, 0) + (segs.length - 1) * SEPARATOR.length;
     return width <= maxWidth;
   };
-  const result = [...segments];
-  while (result.length > 1 && !fits(result)) {
+  const result = segments.map(s => ({
+    ...s
+  }));
+  let droppedAny = false;
+  const withMarker = () => droppedAny ? [...result, TRUNCATION_MARKER] : result;
+
+  // Degrade before dropping.
+  if (!fits(withMarker())) {
+    const byPriorityDesc = [...result].sort((a, b) => b.priority - a.priority);
+    for (const seg of byPriorityDesc) {
+      if (seg.shortText !== undefined && seg.shortText.length < seg.text.length) {
+        seg.text = seg.shortText;
+        if (fits(withMarker())) break;
+      }
+    }
+  }
+  while (result.length > 1 && !fits(withMarker())) {
     let dropIndex = 0;
     for (let i = 1; i < result.length; i++) {
       if (result[i]!.priority > result[dropIndex]!.priority) dropIndex = i;
     }
     result.splice(dropIndex, 1);
+    droppedAny = true;
   }
+  const final = withMarker();
+  if (fits(final)) return final;
   return fits(result) ? result : [];
 }
 

--- a/src/components/PromptInput/PromptInputFooter.test.tsx
+++ b/src/components/PromptInput/PromptInputFooter.test.tsx
@@ -1,6 +1,10 @@
 import { describe, expect, it } from 'bun:test'
 import { DEFAULT_GLOBAL_CONFIG } from '../../utils/config.js'
-import { resolveFooterStatusLine } from './PromptInputFooter.js'
+import {
+  resolveFooterStatusLine,
+  SHORTCUTS_HINT_STARTUP_GRACE,
+  shouldSuppressShortcutsHint,
+} from './PromptInputFooter.js'
 
 const guardsPass = {
   isPromptMode: true,
@@ -54,4 +58,48 @@ describe('resolveFooterStatusLine', () => {
       expect(resolveFooterStatusLine(customSettings, guards)).toBeNull()
     })
   }
+})
+
+describe('shouldSuppressShortcutsHint', () => {
+  const base = {
+    suppressedByCaller: false,
+    footerStatusLine: null,
+    isSearching: false,
+    numStartups: 100,
+  } as const
+
+  it('shows the hint when no status line renders, regardless of tenure', () => {
+    expect(shouldSuppressShortcutsHint({ ...base })).toBe(false)
+  })
+
+  // Regression: the builtin statusline ships enabled, so suppressing on
+  // "a status line renders" alone hid the hint for every user forever.
+  it('keeps the hint alongside a status line for new users', () => {
+    expect(
+      shouldSuppressShortcutsHint({
+        ...base,
+        footerStatusLine: 'builtin',
+        numStartups: SHORTCUTS_HINT_STARTUP_GRACE,
+      }),
+    ).toBe(false)
+  })
+
+  it('yields to the status line for established users', () => {
+    expect(
+      shouldSuppressShortcutsHint({
+        ...base,
+        footerStatusLine: 'builtin',
+        numStartups: SHORTCUTS_HINT_STARTUP_GRACE + 1,
+      }),
+    ).toBe(true)
+  })
+
+  it('always suppresses during ctrl-r search and caller overrides', () => {
+    expect(shouldSuppressShortcutsHint({ ...base, isSearching: true })).toBe(
+      true,
+    )
+    expect(
+      shouldSuppressShortcutsHint({ ...base, suppressedByCaller: true }),
+    ).toBe(true)
+  })
 })

--- a/src/components/PromptInput/PromptInputFooter.test.tsx
+++ b/src/components/PromptInput/PromptInputFooter.test.tsx
@@ -94,6 +94,16 @@ describe('shouldSuppressShortcutsHint', () => {
     ).toBe(true)
   })
 
+  it('always yields to a custom status line — explicit config wins over the grace period', () => {
+    expect(
+      shouldSuppressShortcutsHint({
+        ...base,
+        footerStatusLine: 'custom',
+        numStartups: 1,
+      }),
+    ).toBe(true)
+  })
+
   it('always suppresses during ctrl-r search and caller overrides', () => {
     expect(shouldSuppressShortcutsHint({ ...base, isSearching: true })).toBe(
       true,

--- a/src/components/PromptInput/PromptInputFooter.tsx
+++ b/src/components/PromptInput/PromptInputFooter.tsx
@@ -48,7 +48,9 @@ export function resolveFooterStatusLine(settings: ReadonlySettings, guards: {
  * The builtin status line ships enabled, so a status line renders for nearly
  * everyone — treating that as a reason to hide `? for shortcuts` would kill
  * the hint's discoverability entirely. New users (by startup count) keep the
- * hint alongside the status line; established users get the quieter footer.
+ * hint alongside the builtin status line; established users get the quieter
+ * footer. A custom status line is an explicit user configuration, so it
+ * always wins over the hint regardless of tenure.
  */
 export const SHORTCUTS_HINT_STARTUP_GRACE = 10;
 export function shouldSuppressShortcutsHint(args: {
@@ -58,7 +60,8 @@ export function shouldSuppressShortcutsHint(args: {
   numStartups: number;
 }): boolean {
   if (args.suppressedByCaller || args.isSearching) return true;
-  return args.footerStatusLine !== null && args.numStartups > SHORTCUTS_HINT_STARTUP_GRACE;
+  if (args.footerStatusLine === 'custom') return true;
+  return args.footerStatusLine === 'builtin' && args.numStartups > SHORTCUTS_HINT_STARTUP_GRACE;
 }
 
 type Props = {

--- a/src/components/PromptInput/PromptInputFooter.tsx
+++ b/src/components/PromptInput/PromptInputFooter.tsx
@@ -15,6 +15,7 @@ import type { ToolPermissionContext } from '../../Tool.js';
 import type { Message } from '../../types/message.js';
 import type { PromptInputMode, VimMode } from '../../types/textInputTypes.js';
 import type { AutoUpdaterResult } from '../../utils/autoUpdater.js';
+import { getGlobalConfig } from '../../utils/config.js';
 import { isFullscreenEnvEnabled } from '../../utils/fullscreen.js';
 import { BuiltinStatusLine, builtinStatusLineShouldDisplay } from '../BuiltinStatusLine.js';
 import { useCoordinatorTaskCount } from '../CoordinatorAgentStatus.js';
@@ -41,6 +42,23 @@ export function resolveFooterStatusLine(settings: ReadonlySettings, guards: {
   if (statusLineShouldDisplay(settings)) return 'custom';
   if (builtinStatusLineShouldDisplay(settings, config)) return 'builtin';
   return null;
+}
+
+/**
+ * The builtin status line ships enabled, so a status line renders for nearly
+ * everyone — treating that as a reason to hide `? for shortcuts` would kill
+ * the hint's discoverability entirely. New users (by startup count) keep the
+ * hint alongside the status line; established users get the quieter footer.
+ */
+export const SHORTCUTS_HINT_STARTUP_GRACE = 10;
+export function shouldSuppressShortcutsHint(args: {
+  suppressedByCaller: boolean;
+  footerStatusLine: 'custom' | 'builtin' | null;
+  isSearching: boolean;
+  numStartups: number;
+}): boolean {
+  if (args.suppressedByCaller || args.isSearching) return true;
+  return args.footerStatusLine !== null && args.numStartups > SHORTCUTS_HINT_STARTUP_GRACE;
 }
 
 type Props = {
@@ -144,9 +162,15 @@ function PromptInputFooter({
     exitMessageShown: exitMessage.show,
     isPasting
   });
-  // Hide `? for shortcuts` only when a status line actually renders below
-  // (display setting AND render guards), or during ctrl-r search.
-  const suppressHint = suppressHintFromProps || footerStatusLine !== null || isSearching;
+  // Hide `? for shortcuts` during ctrl-r search, or — for established users
+  // only — when a status line actually renders below (display setting AND
+  // render guards). See shouldSuppressShortcutsHint.
+  const suppressHint = shouldSuppressShortcutsHint({
+    suppressedByCaller: suppressHintFromProps,
+    footerStatusLine,
+    isSearching,
+    numStartups: getGlobalConfig().numStartups
+  });
   // Fullscreen: portal data to FullscreenLayout — see promptOverlayContext.tsx
   const overlayData = useMemo(() => isFullscreen && suggestions.length ? {
     suggestions,

--- a/src/components/messages/SystemAPIErrorMessage.test.tsx
+++ b/src/components/messages/SystemAPIErrorMessage.test.tsx
@@ -95,4 +95,13 @@ test('briefAPIErrorReason classifies common failures', () => {
   expect(
     briefAPIErrorReason({ message: 'x', status: 400 } as APIError),
   ).toBe('API error')
+  // extractConnectionErrorDetails only walks Error instances, so the
+  // timeout-shaped error must be a real Error carrying the code
+  expect(
+    briefAPIErrorReason(
+      Object.assign(new Error('request timed out'), {
+        code: 'ETIMEDOUT',
+      }) as unknown as APIError,
+    ),
+  ).toBe('Request timed out')
 })

--- a/src/components/messages/SystemAPIErrorMessage.test.tsx
+++ b/src/components/messages/SystemAPIErrorMessage.test.tsx
@@ -1,0 +1,98 @@
+import { PassThrough } from 'node:stream'
+
+import { expect, test } from 'bun:test'
+import React from 'react'
+import stripAnsi from 'strip-ansi'
+import type { APIError } from '@anthropic-ai/sdk'
+
+import { render } from '../../ink.js'
+import { briefAPIErrorReason } from '../../services/api/errorUtils.js'
+import type { SystemAPIErrorMessage as SystemAPIErrorMessageType } from '../../types/message.js'
+import { SystemAPIErrorMessage } from './SystemAPIErrorMessage.js'
+
+function makeMessage(
+  overrides: Partial<SystemAPIErrorMessageType>,
+): SystemAPIErrorMessageType {
+  return {
+    type: 'system',
+    subtype: 'api_error',
+    error: { message: 'Overloaded', status: 529 } as APIError,
+    retryInMs: 5000,
+    retryAttempt: 1,
+    maxRetries: 10,
+    ...overrides,
+  } as SystemAPIErrorMessageType
+}
+
+async function renderToText(message: SystemAPIErrorMessageType) {
+  const stdout = new PassThrough()
+  let output = ''
+  stdout.on('data', chunk => {
+    output += chunk.toString()
+  })
+  ;(stdout as unknown as { columns: number }).columns = 120
+
+  const instance = await render(
+    <SystemAPIErrorMessage message={message} verbose={false} />,
+    stdout as unknown as NodeJS.WriteStream,
+  )
+  await new Promise(resolve => setTimeout(resolve, 20))
+  instance.unmount()
+  return stripAnsi(output)
+}
+
+// Regression: retries used to be fully hidden until attempt 4, so transient
+// rate limits / overloads looked like a frozen app for the first three
+// attempts. Early attempts must render a visible (compact) line.
+test('attempt 1 renders a compact retry line instead of nothing', async () => {
+  const frame = await renderToText(makeMessage({ retryAttempt: 1 }))
+  expect(frame).toContain('API overloaded')
+  expect(frame.toLowerCase()).toContain('retrying')
+  expect(frame).toContain('attempt 1/10')
+})
+
+test('compact line omits the full error body', async () => {
+  const frame = await renderToText(
+    makeMessage({
+      retryAttempt: 2,
+      error: {
+        message: 'Some very detailed upstream error body',
+        status: 500,
+      } as APIError,
+    }),
+  )
+  expect(frame).toContain('API server error')
+  expect(frame).not.toContain('Some very detailed upstream error body')
+})
+
+test('attempt 4 renders the full error with retry countdown', async () => {
+  const frame = await renderToText(makeMessage({ retryAttempt: 4 }))
+  expect(frame).toContain('Overloaded')
+  expect(frame.toLowerCase()).toContain('retrying in')
+  expect(frame).toContain('attempt 4/10')
+})
+
+test('briefAPIErrorReason classifies common failures', () => {
+  expect(
+    briefAPIErrorReason({ message: 'x', status: 429 } as APIError),
+  ).toBe('Rate limited')
+  expect(
+    briefAPIErrorReason({ message: 'x', status: 529 } as APIError),
+  ).toBe('API overloaded')
+  expect(
+    briefAPIErrorReason({ message: 'x', status: 503 } as APIError),
+  ).toBe('API server error')
+  expect(
+    briefAPIErrorReason({ message: 'Connection error.' } as APIError),
+  ).toBe('Connection issue')
+  // OpenAI-compat shim network failures carry no cause chain, only text
+  expect(
+    briefAPIErrorReason({
+      message:
+        'OpenAI API transport error: fetch failed [openai_category=localhost_resolution_failed]',
+    } as APIError),
+  ).toBe('Connection issue')
+  expect(
+    briefAPIErrorReason({ message: 'x', status: 400 } as APIError),
+  ).toBe('API error')
+})

--- a/src/components/messages/SystemAPIErrorMessage.tsx
+++ b/src/components/messages/SystemAPIErrorMessage.tsx
@@ -1,140 +1,66 @@
-import { c as _c } from "react-compiler-runtime";
-import * as React from 'react';
-import { useState } from 'react';
-import { Box, Text } from 'src/ink.js';
-import { formatAPIError } from 'src/services/api/errorUtils.js';
-import type { SystemAPIErrorMessage } from 'src/types/message.js';
-import { useInterval } from 'usehooks-ts';
-import { CtrlOToExpand } from '../CtrlOToExpand.js';
-import { MessageResponse } from '../MessageResponse.js';
-const MAX_API_ERROR_CHARS = 1000;
+import * as React from 'react'
+import { useState } from 'react'
+import { Box, Text } from 'src/ink.js'
+import { briefAPIErrorReason, formatAPIError } from 'src/services/api/errorUtils.js'
+import type { SystemAPIErrorMessage } from 'src/types/message.js'
+import { useInterval } from 'usehooks-ts'
+import { CtrlOToExpand } from '../CtrlOToExpand.js'
+import { MessageResponse } from '../MessageResponse.js'
+
+const MAX_API_ERROR_CHARS = 1000
+
+// Below this attempt count, show a single unobtrusive line instead of the
+// full error block. Never render nothing: a silent retry is
+// indistinguishable from a hang.
+const FULL_ERROR_ATTEMPT_THRESHOLD = 4
+
 type Props = {
-  message: SystemAPIErrorMessage;
-  verbose: boolean;
-};
-export function SystemAPIErrorMessage(t0) {
-  const $ = _c(33);
-  const {
-    message: t1,
-    verbose
-  } = t0;
-  const {
-    retryAttempt,
-    error,
-    retryInMs,
-    maxRetries
-  } = t1;
-  const hidden = true && retryAttempt < 4;
-  const [countdownMs, setCountdownMs] = useState(0);
-  const done = countdownMs >= retryInMs;
-  let t2;
-  if ($[0] === Symbol.for("react.memo_cache_sentinel")) {
-    t2 = () => setCountdownMs(_temp);
-    $[0] = t2;
-  } else {
-    t2 = $[0];
-  }
-  useInterval(t2, hidden || done ? null : 1000);
-  if (hidden) {
-    return null;
-  }
-  let t3;
-  if ($[1] !== countdownMs || $[2] !== retryInMs) {
-    t3 = Math.round((retryInMs - countdownMs) / 1000);
-    $[1] = countdownMs;
-    $[2] = retryInMs;
-    $[3] = t3;
-  } else {
-    t3 = $[3];
-  }
-  const retryInSecondsLive = Math.max(0, t3);
-  let T0;
-  let T1;
-  let T2;
-  let t4;
-  let t5;
-  let t6;
-  let truncated;
-  if ($[4] !== error || $[5] !== verbose) {
-    const formatted = formatAPIError(error);
-    truncated = !verbose && formatted.length > MAX_API_ERROR_CHARS;
-    T2 = MessageResponse;
-    T1 = Box;
-    t6 = "column";
-    T0 = Text;
-    t4 = "error";
-    t5 = truncated ? formatted.slice(0, MAX_API_ERROR_CHARS) + "\u2026" : formatted;
-    $[4] = error;
-    $[5] = verbose;
-    $[6] = T0;
-    $[7] = T1;
-    $[8] = T2;
-    $[9] = t4;
-    $[10] = t5;
-    $[11] = t6;
-    $[12] = truncated;
-  } else {
-    T0 = $[6];
-    T1 = $[7];
-    T2 = $[8];
-    t4 = $[9];
-    t5 = $[10];
-    t6 = $[11];
-    truncated = $[12];
-  }
-  let t7;
-  if ($[13] !== T0 || $[14] !== t4 || $[15] !== t5) {
-    t7 = <T0 color={t4}>{t5}</T0>;
-    $[13] = T0;
-    $[14] = t4;
-    $[15] = t5;
-    $[16] = t7;
-  } else {
-    t7 = $[16];
-  }
-  let t8;
-  if ($[17] !== truncated) {
-    t8 = truncated && <CtrlOToExpand />;
-    $[17] = truncated;
-    $[18] = t8;
-  } else {
-    t8 = $[18];
-  }
-  const t9 = retryInSecondsLive === 1 ? "second" : "seconds";
-  let t10;
-  if ($[19] !== maxRetries || $[20] !== retryAttempt || $[21] !== retryInSecondsLive || $[22] !== t9) {
-    t10 = <Text dimColor={true}>Retrying in {retryInSecondsLive}{" "}{t9}… (attempt{" "}{retryAttempt}/{maxRetries}){process.env.API_TIMEOUT_MS ? ` · API_TIMEOUT_MS=${process.env.API_TIMEOUT_MS}ms, try increasing it` : ""}</Text>;
-    $[19] = maxRetries;
-    $[20] = retryAttempt;
-    $[21] = retryInSecondsLive;
-    $[22] = t9;
-    $[23] = t10;
-  } else {
-    t10 = $[23];
-  }
-  let t11;
-  if ($[24] !== T1 || $[25] !== t10 || $[26] !== t6 || $[27] !== t7 || $[28] !== t8) {
-    t11 = <T1 flexDirection={t6}>{t7}{t8}{t10}</T1>;
-    $[24] = T1;
-    $[25] = t10;
-    $[26] = t6;
-    $[27] = t7;
-    $[28] = t8;
-    $[29] = t11;
-  } else {
-    t11 = $[29];
-  }
-  let t12;
-  if ($[30] !== T2 || $[31] !== t11) {
-    t12 = <T2>{t11}</T2>;
-    $[30] = T2;
-    $[31] = t11;
-    $[32] = t12;
-  } else {
-    t12 = $[32];
-  }
-  return t12;
+  message: SystemAPIErrorMessage
+  verbose: boolean
 }
-function _temp(ms) {
-  return ms + 1000;
+
+export function SystemAPIErrorMessage({ message, verbose }: Props) {
+  const { retryAttempt, error, retryInMs, maxRetries } = message
+  const compact = retryAttempt < FULL_ERROR_ATTEMPT_THRESHOLD
+  const [countdownMs, setCountdownMs] = useState(0)
+  const done = countdownMs >= retryInMs
+  useInterval(() => setCountdownMs(ms => ms + 1000), done ? null : 1000)
+  const retryInSecondsLive = Math.max(
+    0,
+    Math.round((retryInMs - countdownMs) / 1000),
+  )
+
+  if (compact) {
+    return (
+      <MessageResponse>
+        <Text dimColor>
+          {briefAPIErrorReason(error)} — retrying in {retryInSecondsLive}s
+          {'…'} (attempt {retryAttempt}/{maxRetries})
+        </Text>
+      </MessageResponse>
+    )
+  }
+
+  const formatted = formatAPIError(error)
+  const truncated = !verbose && formatted.length > MAX_API_ERROR_CHARS
+  return (
+    <MessageResponse>
+      <Box flexDirection="column">
+        <Text color="error">
+          {truncated
+            ? formatted.slice(0, MAX_API_ERROR_CHARS) + '…'
+            : formatted}
+        </Text>
+        {truncated && <CtrlOToExpand />}
+        <Text dimColor>
+          Retrying in {retryInSecondsLive}{' '}
+          {retryInSecondsLive === 1 ? 'second' : 'seconds'}
+          {'…'} (attempt {retryAttempt}/{maxRetries})
+          {process.env.API_TIMEOUT_MS
+            ? ` · API_TIMEOUT_MS=${process.env.API_TIMEOUT_MS}ms, try increasing it`
+            : ''}
+        </Text>
+      </Box>
+    </MessageResponse>
+  )
 }

--- a/src/services/api/errorUtils.ts
+++ b/src/services/api/errorUtils.ts
@@ -258,3 +258,33 @@ export function formatAPIError(error: APIError): string {
     ? sanitizedMessage
     : error.message
 }
+
+/**
+ * Short, human classification of an API error for the compact retry line
+ * shown during early retry attempts. Full detail comes from formatAPIError
+ * once retries escalate.
+ */
+export function briefAPIErrorReason(error: APIError): string {
+  const connectionDetails = extractConnectionErrorDetails(error)
+  if (connectionDetails?.code === 'ETIMEDOUT') {
+    return 'Request timed out'
+  }
+  if (connectionDetails || error.message === 'Connection error.') {
+    return 'Connection issue'
+  }
+  // The OpenAI-compat shim wraps network failures in plain-text messages with
+  // no cause chain for extractConnectionErrorDetails to walk.
+  if (/transport error|fetch failed|ECONNREFUSED|ENOTFOUND|EAI_AGAIN/i.test(error.message ?? '')) {
+    return 'Connection issue'
+  }
+  switch (error.status) {
+    case 429:
+      return 'Rate limited'
+    case 529:
+      return 'API overloaded'
+  }
+  if (typeof error.status === 'number' && error.status >= 500) {
+    return 'API server error'
+  }
+  return 'API error'
+}

--- a/web/src/data/configuration.ts
+++ b/web/src/data/configuration.ts
@@ -70,7 +70,7 @@ export const envVars: EnvVar[] = [
   { name: 'GITHUB_TOKEN', description: 'GitHub token for GitHub Models and PR workflows.' },
   { name: 'OPENCLAUDE_CONFIG_DIR', description: 'Preferred config directory override. Defaults to ~/.openclaude when unset.' },
   { name: 'CLAUDE_CONFIG_DIR', description: 'Legacy config directory override. Used only when OPENCLAUDE_CONFIG_DIR is unset.' },
-  { name: 'BASH_MAX_OUTPUT_LENGTH', description: 'Max characters of shell output shown inline before truncation (default 30000, cap 150000). Truncated runs save the full output to a file the agent can read back.' },
+  { name: 'BASH_MAX_OUTPUT_LENGTH', description: 'Max characters of shell output shown inline before truncation (default 30000, cap 150000). Truncated runs save the captured output to a file the agent can read back (very large outputs may be capped).' },
   { name: 'HTTP_PROXY / HTTPS_PROXY', description: 'Route API traffic through a proxy.' },
   { name: 'NODE_EXTRA_CA_CERTS', description: 'Extra CA certificates for corporate TLS interception.' },
   { name: 'CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC', description: 'Disable non-essential network traffic.' },

--- a/web/src/data/configuration.ts
+++ b/web/src/data/configuration.ts
@@ -70,6 +70,7 @@ export const envVars: EnvVar[] = [
   { name: 'GITHUB_TOKEN', description: 'GitHub token for GitHub Models and PR workflows.' },
   { name: 'OPENCLAUDE_CONFIG_DIR', description: 'Preferred config directory override. Defaults to ~/.openclaude when unset.' },
   { name: 'CLAUDE_CONFIG_DIR', description: 'Legacy config directory override. Used only when OPENCLAUDE_CONFIG_DIR is unset.' },
+  { name: 'BASH_MAX_OUTPUT_LENGTH', description: 'Max characters of shell output shown inline before truncation (default 30000, cap 150000). Truncated runs save the full output to a file the agent can read back.' },
   { name: 'HTTP_PROXY / HTTPS_PROXY', description: 'Route API traffic through a proxy.' },
   { name: 'NODE_EXTRA_CA_CERTS', description: 'Extra CA certificates for corporate TLS interception.' },
   { name: 'CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC', description: 'Disable non-essential network traffic.' },


### PR DESCRIPTION
## Summary
Honest-feedback UX pass — the UI should never look frozen and never silently hide state:

- **Visible retries from attempt 1** — `SystemAPIErrorMessage` previously rendered
  nothing until retry attempt 4, so transient rate limits / overloads were
  indistinguishable from a hang. Attempts 1–3 now show a compact dim line
  (`Rate limited — retrying in 4s… (attempt 2/10)`) with a live countdown; the
  full error block is unchanged at attempt ≥ 4. No transcript stacking: only the
  last api_error message renders and it hides on the next non-error message.
  New `briefAPIErrorReason()` classifies 429/529/5xx/connection failures,
  including OpenAI-compat shim transport errors that carry no cause chain.
- **Statusline truncation honesty** — `fitSegments` silently dropped
  rate-limit → cost → context on narrow terminals. Segments now degrade to short
  forms first (`ctx 37%` → `37%`, `$1.23` → `$1`) and anything still dropped is
  marked with a trailing dim `…`. Marker is best-effort: at extreme widths the
  bare model name beats showing nothing.
- **Shortcuts-hint discoverability** — `? for shortcuts` was suppressed whenever
  a status line rendered, which became the default state once the builtin
  statusline shipped (#1605). New users (≤ 10 startups) keep the hint alongside
  the status line; established users get the quieter footer.
- **Docs** — `BASH_MAX_OUTPUT_LENGTH` added to the website env-var reference.

## Impact
- Transient API failures are visible immediately instead of masquerading as a hang.
- Narrow terminals show degraded-but-present data plus an explicit truncation marker.
- New users regain the only in-app discovery path for `/help` and keybindings.

## Testing
- [x] `bun test` on the three touched suites — 33 pass
- [x] `tsc --noEmit` — 0 errors
- [x] `bun run smoke` — build + `--version` OK
- [x] Live TUI verification (tmux + mock OpenAI endpoint): compact retry line from
  attempt 1 against a dead endpoint, full block at attempt ≥ 4, Esc interrupts
  cleanly; statusline at 100/32/24 cols renders full / degraded /
  `test-model · 2% · …`; hint present at numStartups=2, suppressed at 50
- [ ] `bun run check` (full suite) — not run locally

## Notes
- `SystemAPIErrorMessage` was rewritten from react-compiler `_c` output to plain
  React as part of the change.
- Pre-existing (also on main): 25 failures when running the whole
  `src/services/api/` directory in one process — the known cross-file mock-leak
  issue, unrelated to this diff.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced the prompt footer/built-in status line to keep the shortcuts hint visible longer for new users, while still suppressing it during search, when requested, or for custom status lines.
  * Improved API error retry messaging with clearer classifications, live countdown, and attempt indicators.
* **Bug Fixes**
  * Status line fitting in narrow terminals now degrades content to compact forms and shows a visible truncation marker instead of dropping segments.
  * Early API retry attempts now render an informative message instead of showing nothing.
* **Documentation**
  * Documented the `BASH_MAX_OUTPUT_LENGTH` environment variable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->