### PR TITLE
fix(build): shim jsxDEV when bundling production React — TUI rendered nothing

### DIFF
--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -29,9 +29,15 @@ const productionReactModules = new Map<string, string>([
     'react/jsx-runtime',
     join(reactPackageDir, 'cjs/react-jsx-runtime.production.js'),
   ],
+  // NOT react-jsx-dev-runtime.production.js: that file exports
+  // `jsxDEV: undefined` on purpose (production code is expected to use the
+  // non-dev transform), but Bun transpiles our JSX to jsxDEV() calls, so the
+  // real production file would leave every component invoking undefined()
+  // and the UI would never render. The shim dispatches to production
+  // jsx/jsxs; its own `react/jsx-runtime` import is remapped by this plugin.
   [
     'react/jsx-dev-runtime',
-    join(reactPackageDir, 'cjs/react-jsx-dev-runtime.production.js'),
+    join(import.meta.dir, 'reactJsxDevRuntimeProductionShim.js'),
   ],
   [
     'react-reconciler',

--- a/scripts/reactJsxDevRuntimeProductionShim.js
+++ b/scripts/reactJsxDevRuntimeProductionShim.js
@@ -1,0 +1,18 @@
+// React's cjs/react-jsx-dev-runtime.production.js deliberately exports
+// `jsxDEV: undefined` — production bundles are expected to compile JSX with
+// the non-dev transform. Our CLI build runs Bun's transpiler without
+// NODE_ENV=production, so every JSX callsite compiles to a jsxDEV() call.
+// Mapping the specifier straight to React's production file therefore left
+// the whole UI invoking undefined() and nothing past the startup banner ever
+// rendered. Implement jsxDEV in terms of the production jsx/jsxs instead —
+// the same dispatch React's own dev runtime performs, minus dev-only
+// validation. The extra dev-transform args (source, self) are ignorable.
+import { Fragment, jsx, jsxs } from 'react/jsx-runtime'
+
+export { Fragment }
+
+export function jsxDEV(type, config, maybeKey, isStaticChildren) {
+  return isStaticChildren
+    ? jsxs(type, config, maybeKey)
+    : jsx(type, config, maybeKey)
+}

--- a/scripts/reactJsxDevRuntimeProductionShim.test.ts
+++ b/scripts/reactJsxDevRuntimeProductionShim.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, test } from 'bun:test'
+// eslint-disable-next-line no-restricted-imports -- comparing shim output against the real runtime is the point
+import { Fragment, jsx, jsxs } from 'react/jsx-runtime'
+import {
+  Fragment as ShimFragment,
+  jsxDEV,
+} from './reactJsxDevRuntimeProductionShim.js'
+
+// The CLI bundle compiles every JSX callsite to jsxDEV() (Bun's dev
+// transform) but bundles production React, whose jsx-dev-runtime exports
+// `jsxDEV: undefined` — that combination rendered the entire TUI blank with
+// no error (see the shim's header comment). These tests pin the shim's
+// dispatch so a future edit can't silently reintroduce that failure.
+describe('reactJsxDevRuntimeProductionShim', () => {
+  test('jsxDEV is a function (the whole reason the shim exists)', () => {
+    expect(typeof jsxDEV).toBe('function')
+  })
+
+  test('re-exports the real Fragment', () => {
+    expect(ShimFragment).toBe(Fragment)
+  })
+
+  test('routes to jsx() when isStaticChildren is false', () => {
+    const props = { className: 'a', children: 'hi' }
+    expect(jsxDEV('div', props, 'k', false)).toEqual(jsx('div', props, 'k'))
+  })
+
+  test('routes to jsxs() when isStaticChildren is true', () => {
+    const children = ['one', 'two']
+    const props = { children }
+    expect(jsxDEV('div', props, undefined, true)).toEqual(
+      jsxs('div', props, undefined),
+    )
+  })
+
+  test('returns the expected element shape for a trivial element', () => {
+    const el = jsxDEV('span', { children: 'x' }, 'key1', false)
+    expect(el.$$typeof).toBe(Symbol.for('react.transitional.element'))
+    expect(el.type).toBe('span')
+    expect(el.key).toBe('key1')
+    expect(el.props).toEqual({ children: 'x' })
+  })
+})


### PR DESCRIPTION
Summary

- Since #1856 mapped react/jsx-dev-runtime to React's production file, the CLI launched to the startup banner and then rendered no UI at all — no prompt box, no typing, no visible error anywhere. Root cause: Bun transpiles our JSX with the dev transform (no NODE_ENV=production at build time), so every JSX callsite compiles to jsxDEV(), and react-jsx-dev-runtime.production.js deliberately exports jsxDEV: undefined — every element creation invoked undefined() and React never committed a single frame. The failure happens while building the element tree, before the renderer's onUncaughtError/onCaughtError callbacks exist, so nothing was ever logged.
- Fix: map react/jsx-dev-runtime to a small local shim (scripts/reactJsxDevRuntimeProductionShim.js) that dispatches jsxDEV onto the production jsx/jsxs — the same dispatch React's own dev runtime performs, minus dev-only validation. The shim's own react/jsx-runtime import is remapped by the existing plugin, so the bundle stays all-production: the sourcemap shows only .production.js copies of react, jsx-runtime, react-reconciler, constants, and scheduler (memory goal of #1856 intact).

Impact

- user-facing impact: restores the entire interactive TUI on main — since #1856 merged, a fresh build shows the banner but no prompt input and ignores all keystrokes.
- developer/maintainer impact: productionReactModules in scripts/build.ts now points react/jsx-dev-runtime at the shim, with a comment explaining why the real production file must not be used. SDK build is untouched (it intentionally stubs jsxDEV to a no-op for headless mode).

Testing

- [x] bun run build
- [x] bun run smoke
- [ ] bun run check
- [x] focused tests: tsc --noEmit clean; git-bisect harness (tmux + send-keys) reproduces the break at 354feb48 and passes with this fix; verified live in the TUI — prompt box renders, typing echoes, slash menu opens/filters, Esc dismisses; dist/cli.mjs.map grep confirms only production React modules + shim are bundled.

Notes

- provider/model path tested: Gitlawb Opengateway (mimo-v2.5-pro) — interactive startup through slash-menu interaction.
- screenshots attached (if UI changed): n/a — fix restores pre-#1856 rendering; no visual change.
- follow-up work or known limitations: if the build ever switches to the non-dev JSX transform (e.g. defining process.env.NODE_ENV as "production" at bundle time), the shim becomes dead weight and can be dropped; left as-is to avoid changing runtime NODE_ENV semantics elsewhere in the bundle.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved production JSX runtime handling so bundled apps resolve to the correct production behavior.
  * Added a production compatibility shim for the dev JSX runtime to prevent incorrect runtime logic in production bundles.
* **Tests**
  * Added a Bun test suite validating the shim’s `jsxDEV` dispatch for static vs. non-static children and confirming `Fragment` is re-exported correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->