### PR TITLE
feat(onboarding): first-run experience for third-party providers

### DIFF
--- a/src/__tests__/bugfixes.test.ts
+++ b/src/__tests__/bugfixes.test.ts
@@ -699,27 +699,33 @@ describe('Dev-channels dialog coverage', () => {
 // ---------------------------------------------------------------------------
 // Fix: onboarding + trust dialog skipped entirely for third-party providers
 // ---------------------------------------------------------------------------
+// Behavioral coverage lives in src/utils/setupScreenGates.test.ts — the
+// gating decisions were extracted into that provider-free seam because this
+// module's import chain cannot be loaded under bun test (compile-time
+// feature() macro checker, same constraint as the dev-channels tests above).
+// These wiring checks assert showSetupScreens actually consults the seam and
+// that no provider gate was re-introduced around the dialogs.
 describe('Onboarding and trust dialog — third-party providers', () => {
-  test('the onboarding dialog is NOT gated behind usesAnthropicSetup', async () => {
+  test('showSetupScreens routes both dialogs through the provider-free seam', async () => {
     const content = await file('interactiveHelpers.tsx').text()
 
-    // Theme choice and the security notes are universal; Onboarding.tsx drops
-    // the OAuth/preflight steps itself when Anthropic auth is not enabled.
-    // Gating the whole dialog on the Anthropic account flow left third-party
-    // users with no safety notes at all.
-    expect(content).not.toMatch(
-      /usesAnthropicSetup\s*&&\s*\(\s*!config\.theme/,
-    )
+    expect(content).toContain('getRequiredSetupScreens({')
+    expect(content).toContain('if (setupScreens.onboarding)')
+    expect(content).toContain('if (setupScreens.trustDialog)')
   })
 
-  test('the trust dialog is NOT gated behind usesAnthropicSetup', async () => {
+  test('no dialog is gated behind usesAnthropicSetup', async () => {
     const content = await file('interactiveHelpers.tsx').text()
 
-    // Workspace trust is orthogonal to the API provider: an untrusted repo is
-    // exactly as dangerous over a local model as over Anthropic.
+    // Theme choice + security notes are universal, and workspace trust is
+    // orthogonal to the API provider: an untrusted repo is exactly as
+    // dangerous over a local model as over Anthropic. The seam takes no
+    // provider input, so the only way to regress is to add a gate at the
+    // call sites — which this guards against.
+    expect(content).not.toMatch(/usesAnthropicSetup\s*&&\s*\(?\s*setupScreens/)
+    expect(content).not.toMatch(/usesAnthropicSetup\s*&&\s*\(\s*!config\.theme/)
     expect(content).not.toMatch(
       /usesAnthropicSetup\s*&&\s*!checkHasTrustDialogAccepted/,
     )
-    expect(content).toContain('if (!checkHasTrustDialogAccepted())')
   })
 })

--- a/src/__tests__/bugfixes.test.ts
+++ b/src/__tests__/bugfixes.test.ts
@@ -695,3 +695,31 @@ describe('Dev-channels dialog coverage', () => {
     )
   })
 })
+
+// ---------------------------------------------------------------------------
+// Fix: onboarding + trust dialog skipped entirely for third-party providers
+// ---------------------------------------------------------------------------
+describe('Onboarding and trust dialog — third-party providers', () => {
+  test('the onboarding dialog is NOT gated behind usesAnthropicSetup', async () => {
+    const content = await file('interactiveHelpers.tsx').text()
+
+    // Theme choice and the security notes are universal; Onboarding.tsx drops
+    // the OAuth/preflight steps itself when Anthropic auth is not enabled.
+    // Gating the whole dialog on the Anthropic account flow left third-party
+    // users with no safety notes at all.
+    expect(content).not.toMatch(
+      /usesAnthropicSetup\s*&&\s*\(\s*!config\.theme/,
+    )
+  })
+
+  test('the trust dialog is NOT gated behind usesAnthropicSetup', async () => {
+    const content = await file('interactiveHelpers.tsx').text()
+
+    // Workspace trust is orthogonal to the API provider: an untrusted repo is
+    // exactly as dangerous over a local model as over Anthropic.
+    expect(content).not.toMatch(
+      /usesAnthropicSetup\s*&&\s*!checkHasTrustDialogAccepted/,
+    )
+    expect(content).toContain('if (!checkHasTrustDialogAccepted())')
+  })
+})

--- a/src/__tests__/bugfixes.test.ts
+++ b/src/__tests__/bugfixes.test.ts
@@ -714,6 +714,24 @@ describe('Onboarding and trust dialog — third-party providers', () => {
     expect(content).toContain('if (setupScreens.trustDialog)')
   })
 
+  test('the env-config option never renders the raw endpoint', async () => {
+    // OPENAI_BASE_URL/OPENAI_API_BASE can carry credentials (userinfo or
+    // token query params) and everything rendered lands in terminal
+    // scrollback. Redaction behavior is tested in envProviderOption.test.ts;
+    // this guards the wiring — the raw `envBaseUrl` may only reach profile
+    // persistence (addProviderProfile/getProviderProfiles/label), never a
+    // rendered label or status message.
+    const content = await file('components/ConsoleOAuthFlow.tsx').text()
+
+    expect(content).toContain('getEnvProviderOption()')
+    // Rendered sites use the redacted value.
+    expect(content).toMatch(/\{envBaseUrlVarName\}=\{envBaseUrlForDisplay\}/)
+    expect(content).toMatch(/\$\{envBaseUrlForDisplay\}\) as your active provider/)
+    // No rendered site interpolates the raw endpoint.
+    expect(content).not.toMatch(/\{envBaseUrl\}/)
+    expect(content).not.toMatch(/\$\{envBaseUrl\}/)
+  })
+
   test('no dialog is gated behind usesAnthropicSetup', async () => {
     const content = await file('interactiveHelpers.tsx').text()
 

--- a/src/components/ConsoleOAuthFlow.tsx
+++ b/src/components/ConsoleOAuthFlow.tsx
@@ -12,10 +12,12 @@ import { OAuthService } from '../services/oauth/index.js';
 import { getOauthAccountInfo, validateForceLoginOrg } from '../utils/auth.js';
 import { logError } from '../utils/log.js';
 import { getLocalOpenAICompatibleProviderLabel } from '../utils/providerDiscovery.js';
+import { type ProviderProfile } from '../utils/config.js';
 import {
   addProviderProfile,
   getProviderProfiles,
   setActiveProviderProfile,
+  updateProviderProfile,
 } from '../utils/providerProfiles.js';
 import { getSettings_DEPRECATED } from '../utils/settings/settings.js';
 import { ProviderManager } from './ProviderManager.js';
@@ -399,6 +401,12 @@ function OAuthStatusMessage({
       // the route (resolveActiveRouteIdFromEnv requires CLAUDE_CODE_USE_OPENAI
       // or a saved profile), so selecting this saves + activates a profile.
       // Both fields gate the option because a profile requires baseUrl+model.
+      // Name the variable the value actually came from, so someone
+      // troubleshooting an OPENAI_API_BASE setup isn't told to look at
+      // OPENAI_BASE_URL (which is unset in their shell).
+      const envBaseUrlVarName = process.env.OPENAI_BASE_URL
+        ? 'OPENAI_BASE_URL'
+        : 'OPENAI_API_BASE'
       const envBaseUrl =
         process.env.OPENAI_BASE_URL ?? process.env.OPENAI_API_BASE
       const envModel = process.env.OPENAI_MODEL
@@ -411,7 +419,9 @@ function OAuthStatusMessage({
                 label: (
                   <Text>
                     Use current environment configuration ·{' '}
-                    <Text dimColor>OPENAI_BASE_URL={envBaseUrl}</Text>
+                    <Text dimColor>
+                      {envBaseUrlVarName}={envBaseUrl}
+                    </Text>
                     {'\n'}
                   </Text>
                 ),
@@ -470,17 +480,32 @@ function OAuthStatusMessage({
                       profile.baseUrl?.trim() === envBaseUrl?.trim() &&
                       profile.model?.trim() === envModel?.trim(),
                   )
-                  const saved = existing
-                    ? setActiveProviderProfile(existing.id)
-                    : addProviderProfile(
-                        {
-                          name: getLocalOpenAICompatibleProviderLabel(envBaseUrl),
-                          baseUrl: envBaseUrl as string,
-                          model: envModel as string,
-                          apiKey: process.env.OPENAI_API_KEY,
-                        },
-                        { makeActive: true },
-                      )
+                  let saved: ProviderProfile | null
+                  if (existing) {
+                    // Refresh the stored credential from the environment
+                    // before activating: the env is the source of truth the
+                    // user just chose, so a rotated OPENAI_API_KEY must not
+                    // leave the profile running on a stale key. Keep the
+                    // existing key when the env no longer carries one rather
+                    // than blanking a working credential.
+                    updateProviderProfile(existing.id, {
+                      name: existing.name,
+                      baseUrl: envBaseUrl as string,
+                      model: envModel as string,
+                      apiKey: process.env.OPENAI_API_KEY ?? existing.apiKey,
+                    })
+                    saved = setActiveProviderProfile(existing.id)
+                  } else {
+                    saved = addProviderProfile(
+                      {
+                        name: getLocalOpenAICompatibleProviderLabel(envBaseUrl),
+                        baseUrl: envBaseUrl as string,
+                        model: envModel as string,
+                        apiKey: process.env.OPENAI_API_KEY,
+                      },
+                      { makeActive: true },
+                    )
+                  }
                   if (!saved) {
                     // Env values failed profile validation — fall back to the
                     // guided provider setup with fields prefilled from env.
@@ -490,7 +515,7 @@ function OAuthStatusMessage({
                   logEvent('tengu_oauth_env_config_selected', {})
                   setOAuthStatus({
                     state: 'platform_setup_complete',
-                    message: `Saved ${saved.name} (${envBaseUrl}) as your active provider.`,
+                    message: `${existing ? 'Activated' : 'Saved'} ${saved.name} (${envBaseUrl}) as your active provider.`,
                   })
                   return
                 }

--- a/src/components/ConsoleOAuthFlow.tsx
+++ b/src/components/ConsoleOAuthFlow.tsx
@@ -12,7 +12,11 @@ import { OAuthService } from '../services/oauth/index.js';
 import { getOauthAccountInfo, validateForceLoginOrg } from '../utils/auth.js';
 import { logError } from '../utils/log.js';
 import { getLocalOpenAICompatibleProviderLabel } from '../utils/providerDiscovery.js';
-import { addProviderProfile } from '../utils/providerProfiles.js';
+import {
+  addProviderProfile,
+  getProviderProfiles,
+  setActiveProviderProfile,
+} from '../utils/providerProfiles.js';
 import { getSettings_DEPRECATED } from '../utils/settings/settings.js';
 import { ProviderManager } from './ProviderManager.js';
 import { Select } from './CustomSelect/select.js';
@@ -456,15 +460,27 @@ function OAuthStatusMessage({
               options={loginOptions}
               onChange={value => {
                 if (value === 'environment') {
-                  const saved = addProviderProfile(
-                    {
-                      name: getLocalOpenAICompatibleProviderLabel(envBaseUrl),
-                      baseUrl: envBaseUrl as string,
-                      model: envModel as string,
-                      apiKey: process.env.OPENAI_API_KEY,
-                    },
-                    { makeActive: true },
+                  // Re-entering this flow with the same env must not stack
+                  // near-identical profiles: reuse (and activate) an existing
+                  // profile matching the env base URL + model before creating
+                  // a new one. setActiveProviderProfile also re-applies the
+                  // profile env and syncs the startup profile file.
+                  const existing = getProviderProfiles().find(
+                    profile =>
+                      profile.baseUrl?.trim() === envBaseUrl?.trim() &&
+                      profile.model?.trim() === envModel?.trim(),
                   )
+                  const saved = existing
+                    ? setActiveProviderProfile(existing.id)
+                    : addProviderProfile(
+                        {
+                          name: getLocalOpenAICompatibleProviderLabel(envBaseUrl),
+                          baseUrl: envBaseUrl as string,
+                          model: envModel as string,
+                          apiKey: process.env.OPENAI_API_KEY,
+                        },
+                        { makeActive: true },
+                      )
                   if (!saved) {
                     // Env values failed profile validation — fall back to the
                     // guided provider setup with fields prefilled from env.

--- a/src/components/ConsoleOAuthFlow.tsx
+++ b/src/components/ConsoleOAuthFlow.tsx
@@ -488,12 +488,24 @@ function OAuthStatusMessage({
                     // leave the profile running on a stale key. Keep the
                     // existing key when the env no longer carries one rather
                     // than blanking a working credential.
-                    updateProviderProfile(existing.id, {
-                      name: existing.name,
-                      baseUrl: envBaseUrl as string,
-                      model: envModel as string,
+                    //
+                    // updateProviderProfile REPLACES the profile (toProfile
+                    // builds a fresh object, it does not merge), so spread
+                    // the existing profile first — otherwise a configured
+                    // apiFormat / auth header / customHeaders / context
+                    // length would be silently dropped on refresh.
+                    const refreshed = updateProviderProfile(existing.id, {
+                      ...existing,
                       apiKey: process.env.OPENAI_API_KEY ?? existing.apiKey,
                     })
+                    if (!refreshed) {
+                      // The env values failed profile validation. Activating
+                      // now would claim a refresh that did not happen, so send
+                      // the user to guided setup instead of silently running
+                      // on the stale credential.
+                      setOAuthStatus({ state: 'platform_setup' })
+                      return
+                    }
                     saved = setActiveProviderProfile(existing.id)
                   } else {
                     saved = addProviderProfile(

--- a/src/components/ConsoleOAuthFlow.tsx
+++ b/src/components/ConsoleOAuthFlow.tsx
@@ -11,6 +11,7 @@ import { sendNotification } from '../services/notifier.js';
 import { OAuthService } from '../services/oauth/index.js';
 import { getOauthAccountInfo, validateForceLoginOrg } from '../utils/auth.js';
 import { logError } from '../utils/log.js';
+import { getEnvProviderOption } from '../utils/envProviderOption.js';
 import { getLocalOpenAICompatibleProviderLabel } from '../utils/providerDiscovery.js';
 import { type ProviderProfile } from '../utils/config.js';
 import {
@@ -401,16 +402,17 @@ function OAuthStatusMessage({
       // the route (resolveActiveRouteIdFromEnv requires CLAUDE_CODE_USE_OPENAI
       // or a saved profile), so selecting this saves + activates a profile.
       // Both fields gate the option because a profile requires baseUrl+model.
-      // Name the variable the value actually came from, so someone
-      // troubleshooting an OPENAI_API_BASE setup isn't told to look at
-      // OPENAI_BASE_URL (which is unset in their shell).
-      const envBaseUrlVarName = process.env.OPENAI_BASE_URL
-        ? 'OPENAI_BASE_URL'
-        : 'OPENAI_API_BASE'
-      const envBaseUrl =
-        process.env.OPENAI_BASE_URL ?? process.env.OPENAI_API_BASE
-      const envModel = process.env.OPENAI_MODEL
-      const envConfigAvailable = Boolean(envBaseUrl && envModel)
+      // getEnvProviderOption owns the secret-disclosure boundary: only
+      // `displayBaseUrl` (redacted) may be rendered — the raw `baseUrl`
+      // exists solely for profile creation/activation. See its tests for
+      // the credential cases.
+      const {
+        available: envConfigAvailable,
+        varName: envBaseUrlVarName,
+        baseUrl: envBaseUrl,
+        displayBaseUrl: envBaseUrlForDisplay,
+        model: envModel,
+      } = getEnvProviderOption()
 
       const loginOptions = [
         ...(envConfigAvailable
@@ -420,7 +422,7 @@ function OAuthStatusMessage({
                   <Text>
                     Use current environment configuration ·{' '}
                     <Text dimColor>
-                      {envBaseUrlVarName}={envBaseUrl}
+                      {envBaseUrlVarName}={envBaseUrlForDisplay}
                     </Text>
                     {'\n'}
                   </Text>
@@ -527,7 +529,7 @@ function OAuthStatusMessage({
                   logEvent('tengu_oauth_env_config_selected', {})
                   setOAuthStatus({
                     state: 'platform_setup_complete',
-                    message: `${existing ? 'Activated' : 'Saved'} ${saved.name} (${envBaseUrl}) as your active provider.`,
+                    message: `${existing ? 'Activated' : 'Saved'} ${saved.name} (${envBaseUrlForDisplay}) as your active provider.`,
                   })
                   return
                 }

--- a/src/components/ConsoleOAuthFlow.tsx
+++ b/src/components/ConsoleOAuthFlow.tsx
@@ -11,6 +11,8 @@ import { sendNotification } from '../services/notifier.js';
 import { OAuthService } from '../services/oauth/index.js';
 import { getOauthAccountInfo, validateForceLoginOrg } from '../utils/auth.js';
 import { logError } from '../utils/log.js';
+import { getLocalOpenAICompatibleProviderLabel } from '../utils/providerDiscovery.js';
+import { addProviderProfile } from '../utils/providerProfiles.js';
 import { getSettings_DEPRECATED } from '../utils/settings/settings.js';
 import { ProviderManager } from './ProviderManager.js';
 import { Select } from './CustomSelect/select.js';
@@ -386,7 +388,33 @@ function OAuthStatusMessage({
         startingMessage ||
         'OpenClaude can be used with your Claude subscription or billed based on API usage through your Console account.'
 
+      // OPENAI_BASE_URL/OPENAI_MODEL in the environment signal an
+      // OpenAI-compatible setup the user already has — offer to adopt it as
+      // the active provider profile instead of walking them through login for
+      // an account they may never have wanted. Env vars alone do NOT activate
+      // the route (resolveActiveRouteIdFromEnv requires CLAUDE_CODE_USE_OPENAI
+      // or a saved profile), so selecting this saves + activates a profile.
+      // Both fields gate the option because a profile requires baseUrl+model.
+      const envBaseUrl =
+        process.env.OPENAI_BASE_URL ?? process.env.OPENAI_API_BASE
+      const envModel = process.env.OPENAI_MODEL
+      const envConfigAvailable = Boolean(envBaseUrl && envModel)
+
       const loginOptions = [
+        ...(envConfigAvailable
+          ? [
+              {
+                label: (
+                  <Text>
+                    Use current environment configuration ·{' '}
+                    <Text dimColor>OPENAI_BASE_URL={envBaseUrl}</Text>
+                    {'\n'}
+                  </Text>
+                ),
+                value: 'environment' as const,
+              },
+            ]
+          : []),
         {
           label: (
             <Text>
@@ -427,6 +455,29 @@ function OAuthStatusMessage({
             <Select
               options={loginOptions}
               onChange={value => {
+                if (value === 'environment') {
+                  const saved = addProviderProfile(
+                    {
+                      name: getLocalOpenAICompatibleProviderLabel(envBaseUrl),
+                      baseUrl: envBaseUrl as string,
+                      model: envModel as string,
+                      apiKey: process.env.OPENAI_API_KEY,
+                    },
+                    { makeActive: true },
+                  )
+                  if (!saved) {
+                    // Env values failed profile validation — fall back to the
+                    // guided provider setup with fields prefilled from env.
+                    setOAuthStatus({ state: 'platform_setup' })
+                    return
+                  }
+                  logEvent('tengu_oauth_env_config_selected', {})
+                  setOAuthStatus({
+                    state: 'platform_setup_complete',
+                    message: `Saved ${saved.name} (${envBaseUrl}) as your active provider.`,
+                  })
+                  return
+                }
                 if (value === 'platform') {
                   logEvent('tengu_oauth_platform_selected', {})
                   setOAuthStatus({ state: 'platform_setup' })

--- a/src/interactiveHelpers.tsx
+++ b/src/interactiveHelpers.tsx
@@ -114,8 +114,12 @@ export async function showSetupScreens(root: Root, permissionMode: PermissionMod
   const config = getGlobalConfig();
   let onboardingShown = false;
 
-  // Skip onboarding dialog for third-party providers (no Anthropic account needed)
-  if (usesAnthropicSetup && (!config.theme || !config.hasCompletedOnboarding) // always show onboarding at least once
+  // Onboarding runs for ALL providers: theme + security notes are universal,
+  // and the component itself drops the preflight/OAuth steps when Anthropic
+  // auth is not enabled (see oauthEnabled in Onboarding.tsx). Gating this on
+  // the Anthropic account flow left third-party users with no theme choice
+  // and, worse, no prompt-injection/safety notes.
+  if ((!config.theme || !config.hasCompletedOnboarding) // always show onboarding at least once
   ) {
     onboardingShown = true;
     const {
@@ -136,9 +140,11 @@ export async function showSetupScreens(root: Root, permissionMode: PermissionMod
   // Note: non-interactive sessions (CI/CD with -p) never reach showSetupScreens at all.
   // Skip permission checks in claubbit
   if (!isEnvTruthy(process.env.CLAUBBIT)) {
-    // Skip trust dialog UI for third-party providers (no Anthropic auth), but still
-    // run trust state initialization below so the REPL mounts correctly.
-    if (usesAnthropicSetup && !checkHasTrustDialogAccepted()) {
+    // The trust dialog is the workspace trust boundary — it has nothing to do
+    // with which API provider is configured, so it runs for third-party
+    // providers too (an untrusted repo is exactly as dangerous over Ollama as
+    // over Anthropic).
+    if (!checkHasTrustDialogAccepted()) {
       const {
         TrustDialog
       } = await import('./components/TrustDialog/TrustDialog.js');

--- a/src/interactiveHelpers.tsx
+++ b/src/interactiveHelpers.tsx
@@ -20,6 +20,7 @@ import { onChangeAppState } from './state/onChangeAppState.js';
 import { normalizeApiKeyForConfig } from './utils/authPortable.js';
 import { getExternalClaudeMdIncludes, getMemoryFiles, shouldShowClaudeMdExternalIncludesWarning } from './utils/claudemd.js';
 import { checkHasTrustDialogAccepted, getCustomApiKeyStatus, getGlobalConfig, saveGlobalConfig } from './utils/config.js';
+import { getRequiredSetupScreens } from './utils/setupScreenGates.js';
 import { updateDeepLinkTerminalPreference } from './utils/deepLink/terminalPreference.js';
 import { isEnvTruthy, isRunningOnHomespace } from './utils/envUtils.js';
 import { type FpsMetrics, FpsTracker } from './utils/fpsTracker.js';
@@ -118,9 +119,16 @@ export async function showSetupScreens(root: Root, permissionMode: PermissionMod
   // and the component itself drops the preflight/OAuth steps when Anthropic
   // auth is not enabled (see oauthEnabled in Onboarding.tsx). Gating this on
   // the Anthropic account flow left third-party users with no theme choice
-  // and, worse, no prompt-injection/safety notes.
-  if ((!config.theme || !config.hasCompletedOnboarding) // always show onboarding at least once
-  ) {
+  // and, worse, no prompt-injection/safety notes. The decisions live in the
+  // provider-free setupScreenGates seam (behaviorally tested there — this
+  // module's import chain cannot be loaded under bun test).
+  const setupScreens = getRequiredSetupScreens({
+    theme: config.theme,
+    hasCompletedOnboarding: config.hasCompletedOnboarding,
+    trustDialogAccepted: checkHasTrustDialogAccepted(),
+    isClaubbit: isEnvTruthy(process.env.CLAUBBIT),
+  });
+  if (setupScreens.onboarding) {
     onboardingShown = true;
     const {
       Onboarding
@@ -144,7 +152,7 @@ export async function showSetupScreens(root: Root, permissionMode: PermissionMod
     // with which API provider is configured, so it runs for third-party
     // providers too (an untrusted repo is exactly as dangerous over Ollama as
     // over Anthropic).
-    if (!checkHasTrustDialogAccepted()) {
+    if (setupScreens.trustDialog) {
       const {
         TrustDialog
       } = await import('./components/TrustDialog/TrustDialog.js');

--- a/src/utils/envProviderOption.test.ts
+++ b/src/utils/envProviderOption.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, test } from 'bun:test'
+
+import { getEnvProviderOption } from './envProviderOption.js'
+
+// Secret-disclosure regression coverage: OPENAI_BASE_URL / OPENAI_API_BASE
+// are credential-bearing in the wild, and everything the onboarding option
+// renders lands in terminal scrollback. displayBaseUrl must never carry the
+// secret; baseUrl must stay intact so the saved profile still works.
+
+describe('getEnvProviderOption — credential redaction', () => {
+  test('URL userinfo is redacted for display but preserved for the profile', () => {
+    const raw = 'https://svc-user:sup3r-s3cret@api.example.com/v1'
+    const option = getEnvProviderOption({
+      OPENAI_BASE_URL: raw,
+      OPENAI_MODEL: 'gpt-4o',
+    })
+
+    expect(option.displayBaseUrl).not.toContain('sup3r-s3cret')
+    expect(option.displayBaseUrl).not.toContain('svc-user')
+    expect(option.displayBaseUrl).toContain('api.example.com')
+    // The working URL is untouched — the profile must still authenticate.
+    expect(option.baseUrl).toBe(raw)
+    expect(option.available).toBe(true)
+  })
+
+  test('sensitive query parameters are redacted for display', () => {
+    const raw = 'https://api.example.com/v1?token=abcd1234secret&api_key=zzz9999'
+    const option = getEnvProviderOption({
+      OPENAI_BASE_URL: raw,
+      OPENAI_MODEL: 'gpt-4o',
+    })
+
+    expect(option.displayBaseUrl).not.toContain('abcd1234secret')
+    expect(option.displayBaseUrl).not.toContain('zzz9999')
+    expect(option.displayBaseUrl).toContain('api.example.com')
+    expect(option.baseUrl).toBe(raw)
+  })
+
+  test('a credential-bearing OPENAI_API_BASE is redacted and named correctly', () => {
+    const raw = 'https://user:pass@gateway.internal:8443/v1'
+    const option = getEnvProviderOption({
+      OPENAI_API_BASE: raw,
+      OPENAI_MODEL: 'llama3',
+    })
+
+    expect(option.varName).toBe('OPENAI_API_BASE')
+    expect(option.displayBaseUrl).not.toContain('pass')
+    expect(option.baseUrl).toBe(raw)
+  })
+
+  test('a plain endpoint passes through unchanged', () => {
+    const option = getEnvProviderOption({
+      OPENAI_BASE_URL: 'http://localhost:11434/v1',
+      OPENAI_MODEL: 'llama3',
+    })
+    expect(option.displayBaseUrl).toContain('localhost:11434')
+    expect(option.varName).toBe('OPENAI_BASE_URL')
+  })
+
+  test('a malformed endpoint still does not leak userinfo', () => {
+    // redactUrlForDisplay has a non-URL fallback path; the option must not
+    // regress to echoing the raw string when parsing fails.
+    const option = getEnvProviderOption({
+      OPENAI_BASE_URL: 'not a url://user:secret-pw@host/v1',
+      OPENAI_MODEL: 'gpt-4o',
+    })
+    expect(option.displayBaseUrl).not.toContain('secret-pw')
+  })
+})
+
+describe('getEnvProviderOption — availability and var naming', () => {
+  test('OPENAI_BASE_URL wins over OPENAI_API_BASE and is named as such', () => {
+    const option = getEnvProviderOption({
+      OPENAI_BASE_URL: 'https://primary.example.com/v1',
+      OPENAI_API_BASE: 'https://fallback.example.com/v1',
+      OPENAI_MODEL: 'gpt-4o',
+    })
+    expect(option.baseUrl).toBe('https://primary.example.com/v1')
+    expect(option.varName).toBe('OPENAI_BASE_URL')
+  })
+
+  test('a profile needs both a base URL and a model', () => {
+    expect(
+      getEnvProviderOption({ OPENAI_BASE_URL: 'https://x.example/v1' }).available,
+    ).toBe(false)
+    expect(getEnvProviderOption({ OPENAI_MODEL: 'gpt-4o' }).available).toBe(false)
+    expect(getEnvProviderOption({}).available).toBe(false)
+  })
+})

--- a/src/utils/envProviderOption.ts
+++ b/src/utils/envProviderOption.ts
@@ -1,0 +1,40 @@
+import { redactUrlForDisplay } from './redaction.js'
+
+/**
+ * Derivation for the "use current environment configuration" onboarding
+ * option (ConsoleOAuthFlow), extracted as a pure seam so the
+ * secret-disclosure boundary is regression-tested directly rather than
+ * asserted against component source text.
+ *
+ * The split between `baseUrl` and `displayBaseUrl` is load-bearing:
+ * OPENAI_BASE_URL / OPENAI_API_BASE are credential-bearing in the wild
+ * (userinfo like https://user:pass@host/v1, or ?token=/?api_key= query
+ * params). Anything rendered lands in terminal scrollback, so ONLY
+ * `displayBaseUrl` may reach the UI; `baseUrl` keeps the working URL for
+ * profile creation/activation.
+ */
+export type EnvProviderOption = {
+  /** True when both a base URL and a model are present (a profile needs both). */
+  available: boolean
+  /** The env var the base URL actually came from, for accurate troubleshooting. */
+  varName: 'OPENAI_BASE_URL' | 'OPENAI_API_BASE'
+  /** Raw endpoint — for profile persistence/activation only, never rendered. */
+  baseUrl: string | undefined
+  /** Redacted endpoint — the only form safe to render. */
+  displayBaseUrl: string | undefined
+  model: string | undefined
+}
+
+export function getEnvProviderOption(
+  processEnv: NodeJS.ProcessEnv = process.env,
+): EnvProviderOption {
+  const baseUrl = processEnv.OPENAI_BASE_URL ?? processEnv.OPENAI_API_BASE
+  const model = processEnv.OPENAI_MODEL
+  return {
+    available: Boolean(baseUrl && model),
+    varName: processEnv.OPENAI_BASE_URL ? 'OPENAI_BASE_URL' : 'OPENAI_API_BASE',
+    baseUrl,
+    displayBaseUrl: baseUrl ? redactUrlForDisplay(baseUrl) : baseUrl,
+    model,
+  }
+}

--- a/src/utils/setupScreenGates.test.ts
+++ b/src/utils/setupScreenGates.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, test } from 'bun:test'
+
+import { getRequiredSetupScreens } from './setupScreenGates.js'
+
+// Behavioral coverage for the first-run screen gating (#1864). The seam is
+// deliberately provider-free — there is no input to vary by provider, which
+// IS the fix: a third-party (or any) provider gets the same onboarding and
+// workspace-trust decisions as the Anthropic account flow.
+// showSetupScreens itself cannot be imported under bun test (its import
+// chain trips the compile-time feature() macro checker), so the wiring is
+// asserted structurally in src/__tests__/bugfixes.test.ts.
+
+describe('getRequiredSetupScreens', () => {
+  const completed = {
+    theme: 'dark',
+    hasCompletedOnboarding: true,
+    trustDialogAccepted: true,
+    isClaubbit: false,
+  }
+
+  test('fresh install shows both screens', () => {
+    expect(
+      getRequiredSetupScreens({
+        theme: undefined,
+        hasCompletedOnboarding: undefined,
+        trustDialogAccepted: false,
+        isClaubbit: false,
+      }),
+    ).toEqual({ onboarding: true, trustDialog: true })
+  })
+
+  test('fully set-up install shows neither', () => {
+    expect(getRequiredSetupScreens(completed)).toEqual({
+      onboarding: false,
+      trustDialog: false,
+    })
+  })
+
+  test('onboarding re-shows when the theme is missing even if completed once', () => {
+    expect(
+      getRequiredSetupScreens({ ...completed, theme: undefined }).onboarding,
+    ).toBe(true)
+  })
+
+  test('onboarding re-shows when never completed even with a theme set', () => {
+    expect(
+      getRequiredSetupScreens({ ...completed, hasCompletedOnboarding: false })
+        .onboarding,
+    ).toBe(true)
+  })
+
+  test('trust dialog shows whenever unaccepted, independent of onboarding state', () => {
+    expect(
+      getRequiredSetupScreens({ ...completed, trustDialogAccepted: false })
+        .trustDialog,
+    ).toBe(true)
+  })
+
+  test('claubbit skips the trust dialog but never onboarding', () => {
+    const result = getRequiredSetupScreens({
+      theme: undefined,
+      hasCompletedOnboarding: false,
+      trustDialogAccepted: false,
+      isClaubbit: true,
+    })
+    expect(result.trustDialog).toBe(false)
+    expect(result.onboarding).toBe(true)
+  })
+})

--- a/src/utils/setupScreenGates.ts
+++ b/src/utils/setupScreenGates.ts
@@ -1,0 +1,29 @@
+/**
+ * Pure gating decisions for the first-run setup screens, extracted from
+ * showSetupScreens (interactiveHelpers.tsx) as an importable seam:
+ * interactiveHelpers cannot be imported in tests — its import chain trips
+ * Bun's compile-time feature() macro checker before mocks can intercept —
+ * so behavioral coverage lives against this module instead (the same pattern
+ * as the dev-channels registration seam).
+ *
+ * Deliberately provider-free: NO input carries which API provider is active.
+ * That absence is the fix (#1864) — onboarding (theme + safety notes) is
+ * universal, with Onboarding.tsx itself dropping the OAuth/preflight steps
+ * when Anthropic auth is off, and workspace trust is exactly as load-bearing
+ * over a local model as over Anthropic. Re-introducing a provider parameter
+ * here should be treated as a regression signal in review.
+ */
+export function getRequiredSetupScreens(options: {
+  theme: string | undefined
+  hasCompletedOnboarding: boolean | undefined
+  trustDialogAccepted: boolean
+  isClaubbit: boolean
+}): { onboarding: boolean; trustDialog: boolean } {
+  return {
+    // Always show onboarding at least once (theme unset or never completed).
+    onboarding: !options.theme || !options.hasCompletedOnboarding,
+    // The trust dialog is the workspace trust boundary; only the claubbit
+    // harness (which owns its own trust story) skips it.
+    trustDialog: !options.isClaubbit && !options.trustDialogAccepted,
+  }
+}


### PR DESCRIPTION
## Summary
Third-party users — the fork's core audience — previously skipped first-run
onboarding entirely. Two gates in `showSetupScreens` were keyed on
`usesAnthropicAccountFlow()`:

- **Onboarding (theme + security notes) now runs for all providers.** The
  Onboarding component already drops its preflight/OAuth steps when Anthropic
  auth is not enabled, so a third-party first run is: theme → security notes →
  terminal setup — no login screens. Previously these users got no theme
  choice and, worse, never saw the prompt-injection/safety notes.
- **The trust dialog now runs for all providers.** Workspace trust is
  orthogonal to the API provider — an untrusted repo is exactly as dangerous
  over a local model as over Anthropic. The block comment above the gate even
  said "Always show the trust dialog"; the inner check contradicted it. The
  trust-state initialization below the dialog is unchanged, so the REPL
  mounts as before.
- **New login-method option: "Use current environment configuration".** When
  `OPENAI_BASE_URL` + `OPENAI_MODEL` are set, the login screen offers
  adopting them as the first (default) option. Selecting it saves and
  activates a provider profile via `addProviderProfile(..., {makeActive:
  true})`, then continues onboarding.

## Impact
- Every new user now sees the safety notes and gets a theme, regardless of
  provider.
- Env-configured users (Ollama, LM Studio, gateways) go from launch to a
  working session in three keystrokes instead of navigating an
  Anthropic-centric login flow.
- Fixes a real footgun found during verification: `OPENAI_*` env vars alone
  never activate the OpenAI route (`resolveActiveRouteIdFromEnv` requires
  `CLAUDE_CODE_USE_OPENAI` or a saved profile). Users who set only env vars
  silently ran against Anthropic ("Not logged in"). The new option is the
  paved path out. This gap was previously masked in manual testing by a stray
  legacy `.openclaude-profile.json` in the cwd.
- Existing third-party users who never completed onboarding will see it once
  on next launch (theme + security notes, no OAuth), and the trust dialog
  once per project — symmetric with first-party semantics, and they get the
  safety notes they never saw. Flagging for reviewer judgment.

## Testing
- [x] `bun test src/__tests__/bugfixes.test.ts src/components/ProviderManager.test.tsx` — 65 pass
  (includes 2 new guard tests locking the degated conditions)
- [x] `tsc --noEmit` — 0 errors
- [x] Live TUI verification (tmux, scratch `OPENCLAUDE_CONFIG_DIR`, mock OpenAI
  server): fresh 3P first run (`CLAUDE_CODE_USE_OPENAI=1`) walks theme →
  security → trust → REPL with no login screens; env-detected option saves
  "Local OpenAI-compatible", the session completes a real turn against the
  env endpoint, and the profile persists across relaunch; second launch shows
  no onboarding
- [ ] `bun run check` (full suite) — not run locally

## Notes
- The env option only appears when both `OPENAI_BASE_URL` and `OPENAI_MODEL`
  are present, because a provider profile requires baseUrl + model. If
  profile validation fails it falls back to the guided provider setup.
- Profile naming reuses `getLocalOpenAICompatibleProviderLabel`, so known
  gateways get their proper labels.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a **“Use current environment configuration”** option in the OAuth flow that reuses or creates a provider profile from environment base URL/model, then continues setup.
* **Bug Fixes**
  * Updated onboarding and workspace trust dialogs to be driven by setup completion and trust acceptance state, not the API provider type.
  * Prevented raw environment base URL values from being shown in the UI.
* **Tests**
  * Added coverage for onboarding/trust dialog wiring and for credential-safe redaction of displayed environment configuration values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->