### PR TITLE
fix: bound profiler performance entries

### DIFF
--- a/src/cli/print.ts
+++ b/src/cli/print.ts
@@ -323,6 +323,7 @@ import {
 import {
   startQueryProfile,
   logQueryProfileReport,
+  clearQueryProfile,
 } from 'src/utils/queryProfiler.js'
 import { asSessionId } from 'src/types/ids.js'
 import { jsonStringify } from '../utils/slowOperations.js'
@@ -2622,6 +2623,7 @@ function runHeadlessStreaming(
     } finally {
       runPhase = 'finally_flush'
       options.heartbeat?.setPhase('flushing')
+      clearQueryProfile()
       // Flush pending internal events before going idle
       await structuredIO.flushInternalEvents()
       runPhase = 'finally_post_flush'

--- a/src/screens/REPL.tsx
+++ b/src/screens/REPL.tsx
@@ -138,7 +138,7 @@ import { gracefulShutdownSync, isShuttingDown } from '../utils/gracefulShutdown.
 import { handlePromptSubmit, type PromptInputHelpers } from '../utils/handlePromptSubmit.js';
 import { useQueueProcessor } from '../hooks/useQueueProcessor.js';
 import { useMailboxBridge } from '../hooks/useMailboxBridge.js';
-import { queryCheckpoint, logQueryProfileReport } from '../utils/queryProfiler.js';
+import { queryCheckpoint, logQueryProfileReport, clearQueryProfile } from '../utils/queryProfiler.js';
 import type { Message as MessageType, UserMessage, ProgressMessage, HookResultMessage, PartialCompactDirection } from '../types/message.js';
 import { query } from '../query.js';
 import type { AutoCompactTrackingState } from '../services/compact/autoCompact.js';
@@ -3065,7 +3065,7 @@ export function REPL({
     // Signal that a query turn has completed successfully
     await onTurnComplete?.(messagesRef.current);
   }, [initialMcpClients, resetLoadingState, getToolUseContext, toolPermissionContext, setAppState, customSystemPrompt, onTurnComplete, appendSystemPrompt, canUseTool, mainThreadAgentDefinition, onQueryEvent, sessionTitle, titleDisabled, getAutoCompactTrackingForSession, setAutoCompactTrackingForSession, setAutoCompactTrackingForSessionIfUnchanged, queryGuard]);
-  const onQuery = useCallback(async (newMessages: MessageType[], abortController: AbortController, shouldQuery: boolean, additionalAllowedTools: string[], mainLoopModelParam: string, onBeforeQueryCallback?: (input: string, newMessages: MessageType[]) => Promise<boolean>, input?: string, effort?: EffortValue): Promise<void> => {
+  const onQuery = useCallback(async (newMessages: MessageType[], abortController: AbortController, shouldQuery: boolean, additionalAllowedTools: string[], mainLoopModelParam: string, onBeforeQueryCallback?: (input: string, newMessages: MessageType[]) => Promise<boolean>, input?: string, effort?: EffortValue): Promise<void | false> => {
     // If this is a teammate, mark them as active when starting a turn
     if (isAgentSwarmsEnabled()) {
       const teamName = getTeamName();
@@ -3102,7 +3102,7 @@ export function REPL({
           logEvent('tengu_concurrent_onquery_enqueued', {});
         }
       });
-      return;
+      return false;
     }
     lifecycleTracker.clear();
     const thisGeneration = startResult.generation;
@@ -3177,6 +3177,7 @@ export function REPL({
       // running→idle. Returns false if a newer query owns the guard
       // (cancel+resubmit race where the stale finally fires as a microtask).
       if (queryGuard.end(thisGeneration, terminalReason, abortReason)) {
+        clearQueryProfile();
         logCompletedLifecycle(completedContext);
         lifecycleTracker.clear();
         setLastQueryCompletionTime(Date.now());
@@ -3270,8 +3271,10 @@ export function REPL({
           logCompletedLifecycle(guardCompletedContext);
           setLastQueryCompletionTime(Date.now());
           lifecycleTracker.clear();
+          clearQueryProfile();
         } else if (!queryGuard.isActive) {
           lifecycleTracker.clear();
+          clearQueryProfile();
         }
       }
 

--- a/src/utils/handlePromptSubmit.ts
+++ b/src/utils/handlePromptSubmit.ts
@@ -29,7 +29,11 @@ import { resolveSkillModelOverride } from './model/model.js'
 import type { ProcessUserInputContext } from './processUserInput/processUserInput.js'
 import { processUserInput } from './processUserInput/processUserInput.js'
 import type { QueryGuard } from './QueryGuard.js'
-import { queryCheckpoint, startQueryProfile } from './queryProfiler.js'
+import {
+  clearQueryProfile,
+  queryCheckpoint,
+  startQueryProfile,
+} from './queryProfiler.js'
 import { runWithWorkload } from './workloadContext.js'
 
 function exit(): void {
@@ -69,7 +73,8 @@ type BaseExecutionParams = {
     onBeforeQuery?: (input: string, newMessages: Message[]) => Promise<boolean>,
     input?: string,
     effort?: EffortValue,
-  ) => Promise<void>
+    // Return false when the query guard declines ownership before a turn starts.
+  ) => Promise<void | false>
   setAppState: (updater: (prev: AppState) => AppState) => void
   onBeforeQuery?: (input: string, newMessages: Message[]) => Promise<boolean>
   canUseTool?: CanUseToolFn
@@ -432,6 +437,7 @@ async function executeUserInput(params: ExecuteUserInputParams): Promise<void> {
   // throws or onQuery is skipped. onQuery's finally calls queryGuard.end(),
   // which transitions running→idle; cancelReservation() below is a no-op in
   // that case (only acts on dispatching state).
+  let queryProfileOwnedByOnQuery = false
   try {
     // Reserve the guard BEFORE processUserInput — processBashCommand awaits
     // BashTool.call() and processSlashCommand awaits getMessagesForSlashCommand,
@@ -563,7 +569,8 @@ async function executeUserInput(params: ExecuteUserInputParams): Promise<void> {
             ? primaryCmd.value
             : undefined
         const shouldCallBeforeQuery = primaryMode === 'prompt'
-        await onQuery(
+        queryProfileOwnedByOnQuery = true
+        const queryOwnershipResult = await onQuery(
           newMessages,
           abortController,
           shouldQuery,
@@ -575,6 +582,9 @@ async function executeUserInput(params: ExecuteUserInputParams): Promise<void> {
           primaryInput,
           effort,
         )
+        if (queryOwnershipResult === false) {
+          queryProfileOwnedByOnQuery = false
+        }
       } else {
         // Local slash commands that skip messages (e.g., /model, /theme).
         // Release the guard BEFORE clearing toolJSX to prevent spinner flash —
@@ -607,6 +617,9 @@ async function executeUserInput(params: ExecuteUserInputParams): Promise<void> {
     // This is the single source of truth for releasing the reservation;
     // useQueueProcessor no longer needs its own .finally().
     queryGuard.cancelReservation()
+    if (!queryProfileOwnedByOnQuery) {
+      clearQueryProfile()
+    }
     // Safety net: clear the placeholder if processUserInput produced no
     // messages or threw — otherwise it would stay visible until the next
     // turn's resetLoadingState. Harmless when onQuery ran: setMessages grew

--- a/src/utils/headlessProfiler.ts
+++ b/src/utils/headlessProfiler.ts
@@ -19,7 +19,13 @@ import {
 } from '../services/analytics/index.js'
 import { logForDebugging } from './debug.js'
 import { isEnvTruthy } from './envUtils.js'
-import { getPerformance } from './profilerBase.js'
+import {
+  clearProfilerEntries,
+  getPerformance,
+  getProfilerDisplayName,
+  getProfilerEntries,
+  getProfilerMarkName,
+} from './profilerBase.js'
 import { jsonStringify } from './slowOperations.js'
 
 // Detailed profiling mode - same env var as startupProfiler
@@ -36,8 +42,7 @@ const STATSIG_LOGGING_SAMPLED =
 // Enable profiling if either detailed mode OR sampled for Statsig
 const SHOULD_PROFILE = DETAILED_PROFILING || STATSIG_LOGGING_SAMPLED
 
-// Use a unique prefix to avoid conflicts with other profiler marks
-const MARK_PREFIX = 'headless_'
+const PROFILER_SCOPE = 'headless'
 
 // Track current turn number (auto-incremented by headlessProfilerStartTurn)
 let currentTurnNumber = -1
@@ -46,13 +51,7 @@ let currentTurnNumber = -1
  * Clear all headless profiler marks from performance timeline
  */
 function clearHeadlessMarks(): void {
-  const perf = getPerformance()
-  const allMarks = perf.getEntriesByType('mark')
-  for (const mark of allMarks) {
-    if (mark.name.startsWith(MARK_PREFIX)) {
-      perf.clearMarks(mark.name)
-    }
-  }
+  clearProfilerEntries(PROFILER_SCOPE)
 }
 
 /**
@@ -69,7 +68,7 @@ export function headlessProfilerStartTurn(): void {
   clearHeadlessMarks()
 
   const perf = getPerformance()
-  perf.mark(`${MARK_PREFIX}turn_start`)
+  perf.mark(getProfilerMarkName(PROFILER_SCOPE, 'turn_start'))
 
   if (DETAILED_PROFILING) {
     logForDebugging(`[headlessProfiler] Started turn ${currentTurnNumber}`)
@@ -87,7 +86,7 @@ export function headlessProfilerCheckpoint(name: string): void {
   if (!SHOULD_PROFILE) return
 
   const perf = getPerformance()
-  perf.mark(`${MARK_PREFIX}${name}`)
+  perf.mark(getProfilerMarkName(PROFILER_SCOPE, name))
 
   if (DETAILED_PROFILING) {
     logForDebugging(
@@ -106,73 +105,75 @@ export function logHeadlessProfilerTurn(): void {
   // Only log if enabled
   if (!SHOULD_PROFILE) return
 
-  const perf = getPerformance()
-  const allMarks = perf.getEntriesByType('mark')
-
-  // Filter to only our headless marks
-  const marks = allMarks.filter(mark => mark.name.startsWith(MARK_PREFIX))
+  const marks = getProfilerEntries(PROFILER_SCOPE, 'mark')
   if (marks.length === 0) return
 
-  // Build checkpoint lookup (strip prefix for easier access)
-  const checkpointTimes = new Map<string, number>()
-  for (const mark of marks) {
-    const name = mark.name.slice(MARK_PREFIX.length)
-    checkpointTimes.set(name, mark.startTime)
-  }
+  try {
+    // Build checkpoint lookup (strip internal namespace for easier access)
+    const checkpointTimes = new Map<string, number>()
+    for (const mark of marks) {
+      checkpointTimes.set(
+        getProfilerDisplayName(PROFILER_SCOPE, mark.name),
+        mark.startTime,
+      )
+    }
 
-  const turnStart = checkpointTimes.get('turn_start')
-  if (turnStart === undefined) return
+    const turnStart = checkpointTimes.get('turn_start')
+    if (turnStart === undefined) return
 
-  // Compute phase durations relative to turn_start
-  const metadata: Record<string, number | string | undefined> = {
-    turn_number: currentTurnNumber,
-  }
+    // Compute phase durations relative to turn_start
+    const metadata: Record<string, number | string | undefined> = {
+      turn_number: currentTurnNumber,
+    }
 
-  // Time to system message from process start (only meaningful for turn 0)
-  // Use absolute time since perf_hooks startTime is relative to process start
-  const systemMessageTime = checkpointTimes.get('system_message_yielded')
-  if (systemMessageTime !== undefined && currentTurnNumber === 0) {
-    metadata.time_to_system_message_ms = Math.round(systemMessageTime)
-  }
+    // Time to system message from process start (only meaningful for turn 0)
+    // Use absolute time since perf_hooks startTime is relative to process start
+    const systemMessageTime = checkpointTimes.get('system_message_yielded')
+    if (systemMessageTime !== undefined && currentTurnNumber === 0) {
+      metadata.time_to_system_message_ms = Math.round(systemMessageTime)
+    }
 
-  // Time to query start
-  const queryStartTime = checkpointTimes.get('query_started')
-  if (queryStartTime !== undefined) {
-    metadata.time_to_query_start_ms = Math.round(queryStartTime - turnStart)
-  }
+    // Time to query start
+    const queryStartTime = checkpointTimes.get('query_started')
+    if (queryStartTime !== undefined) {
+      metadata.time_to_query_start_ms = Math.round(queryStartTime - turnStart)
+    }
 
-  // Time to first response (first chunk from API)
-  const firstChunkTime = checkpointTimes.get('first_chunk')
-  if (firstChunkTime !== undefined) {
-    metadata.time_to_first_response_ms = Math.round(firstChunkTime - turnStart)
-  }
+    // Time to first response (first chunk from API)
+    const firstChunkTime = checkpointTimes.get('first_chunk')
+    if (firstChunkTime !== undefined) {
+      metadata.time_to_first_response_ms = Math.round(firstChunkTime - turnStart)
+    }
 
-  // Query overhead (time between query start and API request sent)
-  const apiRequestTime = checkpointTimes.get('api_request_sent')
-  if (queryStartTime !== undefined && apiRequestTime !== undefined) {
-    metadata.query_overhead_ms = Math.round(apiRequestTime - queryStartTime)
-  }
+    // Query overhead (time between query start and API request sent)
+    const apiRequestTime = checkpointTimes.get('api_request_sent')
+    if (queryStartTime !== undefined && apiRequestTime !== undefined) {
+      metadata.query_overhead_ms = Math.round(apiRequestTime - queryStartTime)
+    }
 
-  // Add checkpoint count for debugging
-  metadata.checkpoint_count = marks.length
+    // Add checkpoint count for debugging
+    metadata.checkpoint_count = marks.length
 
-  // Add entrypoint for segmentation (sdk-ts, sdk-py, sdk-cli, or undefined)
-  if (process.env.CLAUDE_CODE_ENTRYPOINT) {
-    metadata.entrypoint = process.env.CLAUDE_CODE_ENTRYPOINT
-  }
+    // Add entrypoint for segmentation (sdk-ts, sdk-py, sdk-cli, or undefined)
+    if (process.env.CLAUDE_CODE_ENTRYPOINT) {
+      metadata.entrypoint = process.env.CLAUDE_CODE_ENTRYPOINT
+    }
 
-  // Log to Statsig if sampled
-  if (STATSIG_LOGGING_SAMPLED) {
-    logEvent(
-      'tengu_headless_latency',
-      metadata as AnalyticsMetadata_I_VERIFIED_THIS_IS_NOT_CODE_OR_FILEPATHS,
-    )
-  }
+    // Log to Statsig if sampled
+    if (STATSIG_LOGGING_SAMPLED) {
+      logEvent(
+        'tengu_headless_latency',
+        metadata as AnalyticsMetadata_I_VERIFIED_THIS_IS_NOT_CODE_OR_FILEPATHS,
+      )
+    }
 
-  // Log detailed output if CLAUDE_CODE_PROFILE_STARTUP=1
-  if (DETAILED_PROFILING) {
-    logForDebugging(
-      `[headlessProfiler] Turn ${currentTurnNumber} metrics: ${jsonStringify(metadata)}`,
-    )
+    // Log detailed output if CLAUDE_CODE_PROFILE_STARTUP=1
+    if (DETAILED_PROFILING) {
+      logForDebugging(
+        `[headlessProfiler] Turn ${currentTurnNumber} metrics: ${jsonStringify(metadata)}`,
+      )
+    }
+  } finally {
+    clearHeadlessMarks()
   }
 }

--- a/src/utils/profilerBase.ts
+++ b/src/utils/profilerBase.ts
@@ -7,6 +7,8 @@
 import type { performance as PerformanceType } from 'perf_hooks'
 import { formatFileSize } from './format.js'
 
+const OPENCLAUDE_PERFORMANCE_PREFIX = 'openclaude:'
+
 // Lazy-load performance API only when profiling is enabled.
 // Shared across all profilers — perf_hooks.performance is a process-wide singleton.
 let performance: typeof PerformanceType | null = null
@@ -21,6 +23,45 @@ export function getPerformance(): typeof PerformanceType {
 
 export function formatMs(ms: number): string {
   return ms.toFixed(3)
+}
+
+function getProfilerPrefix(scope: string): string {
+  return `${OPENCLAUDE_PERFORMANCE_PREFIX}${scope}:`
+}
+
+export function getProfilerMarkName(scope: string, name: string): string {
+  return `${getProfilerPrefix(scope)}${name}`
+}
+
+export function getProfilerDisplayName(scope: string, name: string): string {
+  const prefix = getProfilerPrefix(scope)
+  return name.startsWith(prefix) ? name.slice(prefix.length) : name
+}
+
+export function getProfilerEntries(
+  scope: string,
+  type: 'mark' | 'measure',
+) {
+  const prefix = getProfilerPrefix(scope)
+  return getPerformance()
+    .getEntriesByType(type)
+    .filter(entry => entry.name.startsWith(prefix))
+}
+
+export function clearProfilerEntries(scope: string): void {
+  const perf = getPerformance()
+
+  for (const name of new Set(
+    getProfilerEntries(scope, 'mark').map(entry => entry.name),
+  )) {
+    perf.clearMarks(name)
+  }
+
+  for (const name of new Set(
+    getProfilerEntries(scope, 'measure').map(entry => entry.name),
+  )) {
+    perf.clearMeasures(name)
+  }
 }
 
 /**

--- a/src/utils/profilerRetention.test.ts
+++ b/src/utils/profilerRetention.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, expect, spyOn, test } from 'bun:test'
+import { afterEach, beforeEach, expect, mock, spyOn, test } from 'bun:test'
 import { mkdtempSync, rmSync } from 'fs'
 import { tmpdir } from 'os'
 import { join } from 'path'
@@ -204,9 +204,7 @@ afterEach(() => {
       rmSync(tempConfigDir, { recursive: true, force: true })
       tempConfigDir = undefined
     }
-    spyOn(debug, 'logForDebugging').mockRestore()
-    spyOn(analytics, 'logEvent').mockRestore()
-    spyOn(bootstrapState, 'getIsNonInteractiveSession').mockRestore()
+    mock.restore()
   } finally {
     releaseSharedMutationLock()
   }

--- a/src/utils/profilerRetention.test.ts
+++ b/src/utils/profilerRetention.test.ts
@@ -1,0 +1,390 @@
+import { afterEach, beforeEach, expect, spyOn, test } from 'bun:test'
+import { mkdtempSync, rmSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { performance } from 'perf_hooks'
+import {
+  acquireSharedMutationLock,
+  releaseSharedMutationLock,
+} from '../test/sharedMutationLock.js'
+import * as analytics from '../services/analytics/index.js'
+import * as bootstrapState from '../bootstrap/state.js'
+import * as debug from './debug.js'
+
+const originalEnv = {
+  CLAUDE_CODE_PROFILE_QUERY: process.env.CLAUDE_CODE_PROFILE_QUERY,
+  CLAUDE_CODE_PROFILE_STARTUP: process.env.CLAUDE_CODE_PROFILE_STARTUP,
+  CLAUDE_CONFIG_DIR: process.env.CLAUDE_CONFIG_DIR,
+  USER_TYPE: process.env.USER_TYPE,
+}
+
+let tempConfigDir: string | undefined
+
+function restoreEnv(key: keyof typeof originalEnv): void {
+  const value = originalEnv[key]
+  if (value === undefined) {
+    delete process.env[key]
+  } else {
+    process.env[key] = value
+  }
+}
+
+function freshImport(path: string): Promise<Record<string, unknown>> {
+  return import(`${path}?profilerRetention=${Date.now()}-${Math.random()}`)
+}
+
+function markNames(type: 'mark' | 'measure'): string[] {
+  return performance.getEntriesByType(type).map(entry => entry.name)
+}
+
+function clearEntriesByName(names: string[]): void {
+  for (const name of names) {
+    performance.clearMarks(name)
+    performance.clearMeasures(name)
+  }
+}
+
+function openClaudeEntryNames(type: 'mark' | 'measure', scope: string): string[] {
+  const names = markNames(type)
+  const namespacedPrefix = `openclaude:${scope}:`
+  if (scope === 'query') {
+    return names.filter(
+      name => name.startsWith(namespacedPrefix) || name.startsWith('query_'),
+    )
+  }
+  if (scope === 'headless') {
+    return names.filter(
+      name => name.startsWith(namespacedPrefix) || name.startsWith('headless_'),
+    )
+  }
+  if (scope === 'startup') {
+    return names.filter(
+      name =>
+        name.startsWith(namespacedPrefix) ||
+        [
+          'profiler_initialized',
+          'cli_entry',
+          'main_after_run',
+          'startup_retention_checkpoint',
+        ].includes(name),
+    )
+  }
+  return names.filter(name => name.startsWith(namespacedPrefix))
+}
+
+function runIsolatedProfilerScript(script: string): Record<string, unknown> {
+  const result = Bun.spawnSync({
+    cmd: ['bun', '--eval', script],
+    cwd: process.cwd(),
+    env: {
+      ...process.env,
+      CLAUDE_CODE_PROFILE_QUERY: '1',
+    },
+    stdout: 'pipe',
+    stderr: 'pipe',
+  })
+
+  if (result.exitCode !== 0) {
+    throw new Error(
+      `isolated profiler script failed with ${result.exitCode}\n${result.stderr.toString()}`,
+    )
+  }
+
+  const lines = result.stdout.toString().trim().split('\n')
+  const lastLine = lines.at(-1)
+  if (!lastLine) {
+    throw new Error('isolated profiler script produced no output')
+  }
+  return JSON.parse(lastLine) as Record<string, unknown>
+}
+
+function handlePromptSubmitProfilerScript(
+  processUserInputBody: string,
+  onQueryBody = 'onQueryCalls++',
+): string {
+  return `
+    import { mock } from 'bun:test'
+    import { performance } from 'perf_hooks'
+
+    process.env.CLAUDE_CODE_PROFILE_QUERY = '1'
+
+    mock.module('./src/utils/processUserInput/processUserInput.js', () => ({
+      processUserInput: async () => {
+        ${processUserInputBody}
+      },
+    }))
+    mock.module('src/services/analytics/index.js', () => ({
+      logEvent: () => {},
+    }))
+
+    const { handlePromptSubmit } = await import('./src/utils/handlePromptSubmit.js')
+    const queryGuard = {
+      isActive: false,
+      reserve() {},
+      cancelReservation() {},
+    }
+    let onQueryCalls = 0
+
+    performance.mark('external_profiler_retention_start')
+
+    try {
+      await handlePromptSubmit({
+        input: 'hello',
+        mode: 'prompt',
+        pastedContents: {},
+        helpers: {
+          setCursorOffset() {},
+          clearBuffer() {},
+          resetHistory() {},
+        },
+        onInputChange() {},
+        setPastedContents() {},
+        queryGuard,
+        commands: [],
+        messages: [],
+        mainLoopModel: 'sonnet',
+        ideSelection: undefined,
+        querySource: 'repl',
+        setToolJSX() {},
+        getToolUseContext() { return {} },
+        setUserInputOnProcessing() {},
+        setAbortController() {},
+        onQuery: async () => { ${onQueryBody} },
+        setAppState() {},
+      })
+    } catch {}
+
+    const marks = performance.getEntriesByType('mark').map(entry => entry.name)
+    const measures = performance.getEntriesByType('measure').map(entry => entry.name)
+    console.log(JSON.stringify({
+      onQueryCalls,
+      queryMarks: marks.filter(name => name.startsWith('openclaude:query:')),
+      queryMeasures: measures.filter(name => name.startsWith('openclaude:query:')),
+      externalMarkRetained: marks.includes('external_profiler_retention_start'),
+    }))
+  `
+}
+
+beforeEach(async () => {
+  await acquireSharedMutationLock('utils/profilerRetention.test.ts')
+  process.env.CLAUDE_CODE_PROFILE_QUERY = '1'
+  process.env.CLAUDE_CODE_PROFILE_STARTUP = '1'
+  process.env.USER_TYPE = 'external'
+  tempConfigDir = mkdtempSync(join(tmpdir(), 'openclaude-profiler-retention-'))
+  process.env.CLAUDE_CONFIG_DIR = tempConfigDir
+  clearEntriesByName([
+    'external_profiler_retention_start',
+    'external_profiler_retention_end',
+    'external_profiler_retention_measure',
+  ])
+  for (const scope of ['query', 'headless', 'startup']) {
+    for (const type of ['mark', 'measure'] as const) {
+      clearEntriesByName(openClaudeEntryNames(type, scope))
+    }
+  }
+})
+
+afterEach(() => {
+  try {
+    clearEntriesByName([
+      'external_profiler_retention_start',
+      'external_profiler_retention_end',
+      'external_profiler_retention_measure',
+    ])
+    for (const scope of ['query', 'headless', 'startup']) {
+      for (const type of ['mark', 'measure'] as const) {
+        clearEntriesByName(openClaudeEntryNames(type, scope))
+      }
+    }
+    restoreEnv('CLAUDE_CODE_PROFILE_QUERY')
+    restoreEnv('CLAUDE_CODE_PROFILE_STARTUP')
+    restoreEnv('CLAUDE_CONFIG_DIR')
+    restoreEnv('USER_TYPE')
+    if (tempConfigDir) {
+      rmSync(tempConfigDir, { recursive: true, force: true })
+      tempConfigDir = undefined
+    }
+    spyOn(debug, 'logForDebugging').mockRestore()
+    spyOn(analytics, 'logEvent').mockRestore()
+    spyOn(bootstrapState, 'getIsNonInteractiveSession').mockRestore()
+  } finally {
+    releaseSharedMutationLock()
+  }
+})
+
+test('query profile report is logged before scoped cleanup and unrelated entries survive', async () => {
+  const debugSpy = spyOn(debug, 'logForDebugging').mockImplementation(() => {})
+  const {
+    startQueryProfile,
+    queryCheckpoint,
+    endQueryProfile,
+    logQueryProfileReport,
+  } = (await freshImport('./queryProfiler.js')) as {
+    startQueryProfile: () => void
+    queryCheckpoint: (name: string) => void
+    endQueryProfile: () => void
+    logQueryProfileReport: () => void
+  }
+
+  performance.mark('external_profiler_retention_start')
+  performance.mark('external_profiler_retention_end')
+  performance.measure(
+    'external_profiler_retention_measure',
+    'external_profiler_retention_start',
+    'external_profiler_retention_end',
+  )
+
+  for (let i = 0; i < 20; i++) {
+    startQueryProfile()
+    queryCheckpoint('query_api_request_sent')
+    queryCheckpoint('query_first_chunk_received')
+    endQueryProfile()
+    logQueryProfileReport()
+  }
+
+  const reports = debugSpy.mock.calls.map(call => String(call[0]))
+  expect(reports.some(report => report.includes('QUERY PROFILING REPORT'))).toBe(
+    true,
+  )
+  expect(
+    reports.some(report => report.includes('query_first_chunk_received')),
+  ).toBe(true)
+  expect(openClaudeEntryNames('mark', 'query')).toEqual([])
+  expect(openClaudeEntryNames('measure', 'query')).toEqual([])
+  expect(markNames('mark')).toContain('external_profiler_retention_start')
+  expect(markNames('mark')).toContain('external_profiler_retention_end')
+  expect(markNames('measure')).toContain('external_profiler_retention_measure')
+})
+
+test('partial query profile cleanup is available for abort and error paths', async () => {
+  const { startQueryProfile, queryCheckpoint, clearQueryProfile } =
+    (await freshImport('./queryProfiler.js')) as {
+      startQueryProfile: () => void
+      queryCheckpoint: (name: string) => void
+      clearQueryProfile: () => void
+    }
+
+  startQueryProfile()
+  queryCheckpoint('query_context_loading_start')
+  clearQueryProfile()
+
+  expect(openClaudeEntryNames('mark', 'query')).toEqual([])
+  expect(openClaudeEntryNames('measure', 'query')).toEqual([])
+})
+
+test('handle prompt submit clears query profile when processing produces no query', () => {
+  const result = runIsolatedProfilerScript(
+    handlePromptSubmitProfilerScript(
+      "return { messages: [], shouldQuery: false }",
+    ),
+  )
+
+  expect(result.onQueryCalls).toBe(0)
+  expect(result.queryMarks).toEqual([])
+  expect(result.queryMeasures).toEqual([])
+  expect(result.externalMarkRetained).toBe(true)
+})
+
+test('handle prompt submit clears query profile when processing throws before query', () => {
+  const result = runIsolatedProfilerScript(
+    handlePromptSubmitProfilerScript("throw new Error('before query')"),
+  )
+
+  expect(result.onQueryCalls).toBe(0)
+  expect(result.queryMarks).toEqual([])
+  expect(result.queryMeasures).toEqual([])
+  expect(result.externalMarkRetained).toBe(true)
+})
+
+test('handle prompt submit clears query profile when onQuery declines ownership', () => {
+  const result = runIsolatedProfilerScript(
+    handlePromptSubmitProfilerScript(
+      "return { messages: [{ type: 'user', message: { role: 'user', content: 'hello' }, uuid: 'message-1' }], shouldQuery: true }",
+      'onQueryCalls++; return false',
+    ),
+  )
+
+  expect(result.onQueryCalls).toBe(1)
+  expect(result.queryMarks).toEqual([])
+  expect(result.queryMeasures).toEqual([])
+  expect(result.externalMarkRetained).toBe(true)
+})
+
+test('handle prompt submit preserves query profile when onQuery owns cleanup', () => {
+  const result = runIsolatedProfilerScript(
+    handlePromptSubmitProfilerScript(
+      "return { messages: [{ type: 'user', message: { role: 'user', content: 'hello' }, uuid: 'message-1' }], shouldQuery: true }",
+    ),
+  )
+
+  expect(result.onQueryCalls).toBe(1)
+  expect(result.queryMarks).toEqual(
+    expect.arrayContaining([
+      'openclaude:query:query_user_input_received',
+      'openclaude:query:query_process_user_input_start',
+      'openclaude:query:query_process_user_input_end',
+    ]),
+  )
+  expect(result.queryMeasures).toEqual([])
+  expect(result.externalMarkRetained).toBe(true)
+})
+
+test('headless turn logging extracts metrics and clears retained marks', async () => {
+  process.env.USER_TYPE = 'ant'
+  spyOn(bootstrapState, 'getIsNonInteractiveSession').mockImplementation(
+    () => true,
+  )
+  const analyticsSpy = spyOn(analytics, 'logEvent').mockImplementation(() => {})
+  spyOn(debug, 'logForDebugging').mockImplementation(() => {})
+  const {
+    headlessProfilerStartTurn,
+    headlessProfilerCheckpoint,
+    logHeadlessProfilerTurn,
+  } = (await freshImport('./headlessProfiler.js')) as {
+    headlessProfilerStartTurn: () => void
+    headlessProfilerCheckpoint: (name: string) => void
+    logHeadlessProfilerTurn: () => void
+  }
+
+  performance.mark('external_profiler_retention_start')
+
+  for (let i = 0; i < 20; i++) {
+    headlessProfilerStartTurn()
+    headlessProfilerCheckpoint('query_started')
+    headlessProfilerCheckpoint('first_chunk')
+    logHeadlessProfilerTurn()
+  }
+
+  expect(analyticsSpy).toHaveBeenCalled()
+  expect(openClaudeEntryNames('mark', 'headless')).toEqual([])
+  expect(openClaudeEntryNames('measure', 'headless')).toEqual([])
+  expect(markNames('mark')).toContain('external_profiler_retention_start')
+})
+
+test('startup profile report keeps report names but clears one-shot entries', async () => {
+  const debugSpy = spyOn(debug, 'logForDebugging').mockImplementation(() => {})
+  spyOn(analytics, 'logEvent').mockImplementation(() => {})
+  const { profileCheckpoint, profileReport } = (await freshImport(
+    './startupProfiler.js',
+  )) as {
+    profileCheckpoint: (name: string) => void
+    profileReport: () => void
+  }
+
+  performance.mark('external_profiler_retention_start')
+  profileCheckpoint('cli_entry')
+  profileCheckpoint('startup_retention_checkpoint')
+  profileCheckpoint('main_after_run')
+  profileReport()
+
+  const reports = debugSpy.mock.calls.map(call => String(call[0]))
+  expect(reports.some(report => report.includes('STARTUP PROFILING REPORT'))).toBe(
+    true,
+  )
+  expect(
+    reports.some(report => report.includes('startup_retention_checkpoint')),
+  ).toBe(true)
+  expect(openClaudeEntryNames('mark', 'startup')).toEqual([])
+  expect(openClaudeEntryNames('measure', 'startup')).toEqual([])
+  expect(markNames('mark')).toContain('external_profiler_retention_start')
+})

--- a/src/utils/queryProfiler.ts
+++ b/src/utils/queryProfiler.ts
@@ -29,7 +29,17 @@
 
 import { logForDebugging } from './debug.js'
 import { isEnvTruthy } from './envUtils.js'
-import { formatMs, formatTimelineLine, getPerformance } from './profilerBase.js'
+import {
+  clearProfilerEntries,
+  formatMs,
+  formatTimelineLine,
+  getPerformance,
+  getProfilerDisplayName,
+  getProfilerEntries,
+  getProfilerMarkName,
+} from './profilerBase.js'
+
+const PROFILER_SCOPE = 'query'
 
 // Module-level state - initialized once when the module loads
 // eslint-disable-next-line custom-rules/no-process-env-top-level
@@ -50,12 +60,8 @@ let firstTokenTime: number | null = null
 export function startQueryProfile(): void {
   if (!ENABLED) return
 
-  const perf = getPerformance()
-
-  // Clear previous marks and memory snapshots
-  perf.clearMarks()
-  memorySnapshots.clear()
-  firstTokenTime = null
+  // Clear previous query-owned entries without disturbing other instrumentation.
+  clearQueryProfile()
 
   queryCount++
 
@@ -70,12 +76,12 @@ export function queryCheckpoint(name: string): void {
   if (!ENABLED) return
 
   const perf = getPerformance()
-  perf.mark(name)
+  perf.mark(getProfilerMarkName(PROFILER_SCOPE, name))
   memorySnapshots.set(name, process.memoryUsage())
 
   // Track first token specially
   if (name === 'query_first_chunk_received' && firstTokenTime === null) {
-    const marks = perf.getEntriesByType('mark')
+    const marks = getProfilerEntries(PROFILER_SCOPE, 'mark')
     if (marks.length > 0) {
       const lastMark = marks[marks.length - 1]
       firstTokenTime = lastMark?.startTime ?? 0
@@ -131,8 +137,7 @@ function getQueryProfileReport(): string {
     return 'Query profiling not enabled (set CLAUDE_CODE_PROFILE_QUERY=1)'
   }
 
-  const perf = getPerformance()
-  const marks = perf.getEntriesByType('mark')
+  const marks = getProfilerEntries(PROFILER_SCOPE, 'mark')
   if (marks.length === 0) {
     return 'No query profiling checkpoints recorded'
   }
@@ -150,25 +155,26 @@ function getQueryProfileReport(): string {
   let firstChunkTime = 0
 
   for (const mark of marks) {
+    const name = getProfilerDisplayName(PROFILER_SCOPE, mark.name)
     const relativeTime = mark.startTime - baselineTime
     const deltaMs = mark.startTime - prevTime
     lines.push(
       formatTimelineLine(
         relativeTime,
         deltaMs,
-        mark.name,
-        memorySnapshots.get(mark.name),
+        name,
+        memorySnapshots.get(name),
         10,
         9,
-        getSlowWarning(deltaMs, mark.name),
+        getSlowWarning(deltaMs, name),
       ),
     )
 
     // Track key milestones for summary (use relative times)
-    if (mark.name === 'query_api_request_sent') {
+    if (name === 'query_api_request_sent') {
       apiRequestSentTime = relativeTime
     }
-    if (mark.name === 'query_first_chunk_received') {
+    if (name === 'query_first_chunk_received') {
       firstChunkTime = relativeTime
     }
 
@@ -203,7 +209,15 @@ function getQueryProfileReport(): string {
   }
 
   // Add phase summary
-  lines.push(getPhaseSummary(marks, baselineTime))
+  lines.push(
+    getPhaseSummary(
+      marks.map(mark => ({
+        name: getProfilerDisplayName(PROFILER_SCOPE, mark.name),
+        startTime: mark.startTime,
+      })),
+      baselineTime,
+    ),
+  )
 
   lines.push('='.repeat(80))
 
@@ -297,5 +311,19 @@ function getPhaseSummary(
  */
 export function logQueryProfileReport(): void {
   if (!ENABLED) return
-  logForDebugging(getQueryProfileReport())
+  if (getProfilerEntries(PROFILER_SCOPE, 'mark').length === 0) return
+
+  try {
+    logForDebugging(getQueryProfileReport())
+  } finally {
+    clearQueryProfile()
+  }
+}
+
+export function clearQueryProfile(): void {
+  if (!ENABLED) return
+
+  clearProfilerEntries(PROFILER_SCOPE)
+  memorySnapshots.clear()
+  firstTokenTime = null
 }

--- a/src/utils/queryProfiler.ts
+++ b/src/utils/queryProfiler.ts
@@ -76,16 +76,12 @@ export function queryCheckpoint(name: string): void {
   if (!ENABLED) return
 
   const perf = getPerformance()
-  perf.mark(getProfilerMarkName(PROFILER_SCOPE, name))
+  const mark = perf.mark(getProfilerMarkName(PROFILER_SCOPE, name))
   memorySnapshots.set(name, process.memoryUsage())
 
   // Track first token specially
   if (name === 'query_first_chunk_received' && firstTokenTime === null) {
-    const marks = getProfilerEntries(PROFILER_SCOPE, 'mark')
-    if (marks.length > 0) {
-      const lastMark = marks[marks.length - 1]
-      firstTokenTime = lastMark?.startTime ?? 0
-    }
+    firstTokenTime = mark.startTime
   }
 }
 

--- a/src/utils/startupProfiler.ts
+++ b/src/utils/startupProfiler.ts
@@ -18,8 +18,18 @@ import {
 import { logForDebugging } from './debug.js'
 import { getClaudeConfigHomeDir, isEnvTruthy } from './envUtils.js'
 import { getFsImplementation } from './fsOperations.js'
-import { formatMs, formatTimelineLine, getPerformance } from './profilerBase.js'
+import {
+  clearProfilerEntries,
+  formatMs,
+  formatTimelineLine,
+  getPerformance,
+  getProfilerDisplayName,
+  getProfilerEntries,
+  getProfilerMarkName,
+} from './profilerBase.js'
 import { writeFileSync_DEPRECATED } from './slowOperations.js'
+
+const PROFILER_SCOPE = 'startup'
 
 // Module-level state - decided once at module load
 // eslint-disable-next-line custom-rules/no-process-env-top-level
@@ -66,7 +76,7 @@ export function profileCheckpoint(name: string): void {
   if (!SHOULD_PROFILE) return
 
   const perf = getPerformance()
-  perf.mark(name)
+  perf.mark(getProfilerMarkName(PROFILER_SCOPE, name))
 
   // Only capture memory when detailed profiling enabled (env var)
   if (DETAILED_PROFILING) {
@@ -83,8 +93,7 @@ function getReport(): string {
     return 'Startup profiling not enabled'
   }
 
-  const perf = getPerformance()
-  const marks = perf.getEntriesByType('mark')
+  const marks = getProfilerEntries(PROFILER_SCOPE, 'mark')
   if (marks.length === 0) {
     return 'No profiling checkpoints recorded'
   }
@@ -97,11 +106,12 @@ function getReport(): string {
 
   let prevTime = 0
   for (const [i, mark] of marks.entries()) {
+    const name = getProfilerDisplayName(PROFILER_SCOPE, mark.name)
     lines.push(
       formatTimelineLine(
         mark.startTime,
         mark.startTime - prevTime,
-        mark.name,
+        name,
         memorySnapshots[i],
         8,
         7,
@@ -124,23 +134,28 @@ export function profileReport(): void {
   if (reported) return
   reported = true
 
-  // Log to Statsig (sampled: 100% ant, 0.1% external)
-  logStartupPerf()
+  try {
+    // Log to Statsig (sampled: 100% ant, 0.1% external)
+    logStartupPerf()
 
-  // Output detailed report if CLAUDE_CODE_PROFILE_STARTUP=1
-  if (DETAILED_PROFILING) {
-    // Write to file
-    const path = getStartupPerfLogPath()
-    const dir = dirname(path)
-    const fs = getFsImplementation()
-    fs.mkdirSync(dir)
-    writeFileSync_DEPRECATED(path, getReport(), {
-      encoding: 'utf8',
-      flush: true,
-    })
+    // Output detailed report if CLAUDE_CODE_PROFILE_STARTUP=1
+    if (DETAILED_PROFILING) {
+      const report = getReport()
+      // Write to file
+      const path = getStartupPerfLogPath()
+      const dir = dirname(path)
+      const fs = getFsImplementation()
+      fs.mkdirSync(dir)
+      writeFileSync_DEPRECATED(path, report, {
+        encoding: 'utf8',
+        flush: true,
+      })
 
-    logForDebugging('Startup profiling report:')
-    logForDebugging(getReport())
+      logForDebugging('Startup profiling report:')
+      logForDebugging(report)
+    }
+  } finally {
+    clearStartupProfile()
   }
 }
 
@@ -160,14 +175,16 @@ export function logStartupPerf(): void {
   // Only log if we were sampled (decision made at module load)
   if (!STATSIG_LOGGING_SAMPLED) return
 
-  const perf = getPerformance()
-  const marks = perf.getEntriesByType('mark')
+  const marks = getProfilerEntries(PROFILER_SCOPE, 'mark')
   if (marks.length === 0) return
 
   // Build checkpoint lookup
   const checkpointTimes = new Map<string, number>()
   for (const mark of marks) {
-    checkpointTimes.set(mark.name, mark.startTime)
+    checkpointTimes.set(
+      getProfilerDisplayName(PROFILER_SCOPE, mark.name),
+      mark.startTime,
+    )
   }
 
   // Compute phase durations
@@ -191,4 +208,11 @@ export function logStartupPerf(): void {
     'tengu_startup_perf',
     metadata as AnalyticsMetadata_I_VERIFIED_THIS_IS_NOT_CODE_OR_FILEPATHS,
   )
+}
+
+function clearStartupProfile(): void {
+  if (!SHOULD_PROFILE) return
+
+  clearProfilerEntries(PROFILER_SCOPE)
+  memorySnapshots.length = 0
 }


### PR DESCRIPTION
## Summary

- Bound profiler-owned Node `perf_hooks` entries so query, startup, and headless profiling cannot retain marks indefinitely across long sessions.
- Preserve profiling reports/metrics by clearing entries only after the relevant report or metrics extraction window.

## Impact

- user-facing impact: long profiling/debug sessions should no longer accumulate unbounded performance entries that can trigger `MaxPerformanceEntryBufferExceededWarning`.
- developer/maintainer impact: profiler cleanup is scoped to project-owned entry names and avoids clearing unrelated external instrumentation.

## Testing

- [x] `bun run smoke`
- [x] `bun run typecheck`
- [x] focused tests: `bun test src/utils/profilerRetention.test.ts src/utils/handlePromptSubmit.test.ts src/screens/REPL.queryLifecycle.test.ts src/cli/headlessHeartbeat.test.ts src/cli/printHeartbeat.test.ts src/ink/reconciler.test.ts src/ink/renderer.test.ts src/ink/log-update.test.ts`

## Risk

- The touched runtime paths are limited to profiling cleanup in query, startup, and headless execution. Entry cleanup is scoped by profiler namespace and runs after report/metric extraction, so unrelated external performance entries are left intact.
- Startup profiling still writes to the existing startup-perf log path under the configured home directory; this change only clears retained performance entries after the report window.

## Notes

- provider/model path tested: not applicable; profiler lifecycle only.
- screenshots attached (if UI changed): not applicable.
- follow-up work or known limitations: none known.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced profiling reporting for query, startup, and headless runs with more consistent phase labels and timing breakdowns.
  * Added improved controls for detailed startup profiling, including a per-session log path.
* **Bug Fixes**
  * Fixed profiling data lingering or persisting after commands, queries, and startup flows exit.
  * Prevented stale profiling state when queries overlap or when runtime shutdown paths are hit.
  * Improved cleanup so profiling reports are cleared reliably even if logging/report generation fails.
* **Tests**
  * Added coverage for profiler retention and scoped cleanup across query, headless, and startup flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->