### PR TITLE
feat(perf): tier1 token optimization — universal tool compression, doom loop detection, configurable compaction

### DIFF
--- a/src/components/Settings/Config.tsx
+++ b/src/components/Settings/Config.tsx
@@ -312,6 +312,27 @@ export function Config({
       });
     }
   }, {
+    id: 'compactTailTurns',
+    label: 'Compaction: recent messages kept',
+    value: String(globalConfig.compactTailTurns ?? 3),
+    // Include a hand-edited config value so it round-trips through the picker.
+    options: [...new Set(['2', '3', '5', '8', String(globalConfig.compactTailTurns ?? 3)])],
+    type: 'enum' as const,
+    onChange(compactTailTurnsValue: string) {
+      const compactTailTurns = Number(compactTailTurnsValue);
+      saveGlobalConfig(current => ({
+        ...current,
+        compactTailTurns
+      }));
+      setGlobalConfig({
+        ...getGlobalConfig(),
+        compactTailTurns
+      });
+      logEvent('tengu_compact_tail_turns_changed', {
+        value: compactTailTurnsValue as AnalyticsMetadata_I_VERIFIED_THIS_IS_NOT_CODE_OR_FILEPATHS
+      });
+    }
+  }, {
     id: 'toolHistoryCompressionEnabled',
     label: 'Tool history compression',
     value: globalConfig.toolHistoryCompressionEnabled,
@@ -1244,6 +1265,9 @@ export function Config({
     if (globalConfig.maxMessagesCompactionThreshold !== initialConfig.current.maxMessagesCompactionThreshold) {
       const threshold = normalizeMaxMessagesCompactionThreshold(globalConfig.maxMessagesCompactionThreshold);
       formattedChanges.push(threshold === 'off' ? 'Disabled message-count compaction' : `Set message-count compaction to ${threshold}`);
+    }
+    if (globalConfig.compactTailTurns !== initialConfig.current.compactTailTurns) {
+      formattedChanges.push(`Set compaction recent messages kept to ${globalConfig.compactTailTurns ?? 3}`);
     }
     if (globalConfig.toolHistoryCompressionEnabled !== initialConfig.current.toolHistoryCompressionEnabled) {
       formattedChanges.push(`${globalConfig.toolHistoryCompressionEnabled ? 'Enabled' : 'Disabled'} tool history compression`);

--- a/src/components/Settings/Config.tsx
+++ b/src/components/Settings/Config.tsx
@@ -10,7 +10,7 @@ import figures from 'figures';
 import { type GlobalConfig, saveGlobalConfig, getCurrentProjectConfig, type OutputStyle, MAX_MESSAGES_COMPACTION_THRESHOLDS, normalizeMaxMessagesCompactionThreshold } from '../../utils/config.js';
 import { normalizeApiKeyForConfig } from '../../utils/authPortable.js';
 import { getGlobalConfig, getAutoUpdaterDisabledReason, formatAutoUpdaterDisabledReason, getRemoteControlAtStartup } from '../../utils/config.js';
-import { DEFAULT_COMPACT_TAIL_TURNS } from '../../utils/relevancePruning.js';
+import { normalizeCompactTailTurns } from '../../utils/relevancePruning.js';
 import chalk from 'chalk';
 import { getModeColor, permissionModeTitle, permissionModeFromString, toExternalPermissionMode, isExternalPermissionMode, PERMISSION_MODES, type ExternalPermissionMode, type PermissionMode } from '../../utils/permissions/PermissionMode.js';
 import { getAutoModeEnabledState, hasAutoModeOptInAnySource, transitionPlanAutoMode } from '../../utils/permissions/permissionSetup.js';
@@ -315,12 +315,14 @@ export function Config({
   }, {
     id: 'compactTailTurns',
     label: 'Compaction: recent messages kept',
-    value: String(globalConfig.compactTailTurns ?? DEFAULT_COMPACT_TAIL_TURNS),
+    // Display and persist through the SAME normalization autoCompact applies,
+    // so a hand-edited 2.5 or 0 shows (and saves) as what actually runs.
+    value: String(normalizeCompactTailTurns(globalConfig.compactTailTurns)),
     // Include a hand-edited config value so it round-trips through the picker.
-    options: [...new Set(['2', '3', '5', '8', String(globalConfig.compactTailTurns ?? DEFAULT_COMPACT_TAIL_TURNS)])],
+    options: [...new Set(['2', '3', '5', '8', String(normalizeCompactTailTurns(globalConfig.compactTailTurns))])],
     type: 'enum' as const,
     onChange(compactTailTurnsValue: string) {
-      const compactTailTurns = Number(compactTailTurnsValue);
+      const compactTailTurns = normalizeCompactTailTurns(compactTailTurnsValue);
       saveGlobalConfig(current => ({
         ...current,
         compactTailTurns
@@ -1268,7 +1270,7 @@ export function Config({
       formattedChanges.push(threshold === 'off' ? 'Disabled message-count compaction' : `Set message-count compaction to ${threshold}`);
     }
     if (globalConfig.compactTailTurns !== initialConfig.current.compactTailTurns) {
-      formattedChanges.push(`Set compaction recent messages kept to ${globalConfig.compactTailTurns ?? DEFAULT_COMPACT_TAIL_TURNS}`);
+      formattedChanges.push(`Set compaction recent messages kept to ${normalizeCompactTailTurns(globalConfig.compactTailTurns)}`);
     }
     if (globalConfig.toolHistoryCompressionEnabled !== initialConfig.current.toolHistoryCompressionEnabled) {
       formattedChanges.push(`${globalConfig.toolHistoryCompressionEnabled ? 'Enabled' : 'Disabled'} tool history compression`);

--- a/src/components/Settings/Config.tsx
+++ b/src/components/Settings/Config.tsx
@@ -10,6 +10,7 @@ import figures from 'figures';
 import { type GlobalConfig, saveGlobalConfig, getCurrentProjectConfig, type OutputStyle, MAX_MESSAGES_COMPACTION_THRESHOLDS, normalizeMaxMessagesCompactionThreshold } from '../../utils/config.js';
 import { normalizeApiKeyForConfig } from '../../utils/authPortable.js';
 import { getGlobalConfig, getAutoUpdaterDisabledReason, formatAutoUpdaterDisabledReason, getRemoteControlAtStartup } from '../../utils/config.js';
+import { DEFAULT_COMPACT_TAIL_TURNS } from '../../utils/relevancePruning.js';
 import chalk from 'chalk';
 import { getModeColor, permissionModeTitle, permissionModeFromString, toExternalPermissionMode, isExternalPermissionMode, PERMISSION_MODES, type ExternalPermissionMode, type PermissionMode } from '../../utils/permissions/PermissionMode.js';
 import { getAutoModeEnabledState, hasAutoModeOptInAnySource, transitionPlanAutoMode } from '../../utils/permissions/permissionSetup.js';
@@ -314,9 +315,9 @@ export function Config({
   }, {
     id: 'compactTailTurns',
     label: 'Compaction: recent messages kept',
-    value: String(globalConfig.compactTailTurns ?? 3),
+    value: String(globalConfig.compactTailTurns ?? DEFAULT_COMPACT_TAIL_TURNS),
     // Include a hand-edited config value so it round-trips through the picker.
-    options: [...new Set(['2', '3', '5', '8', String(globalConfig.compactTailTurns ?? 3)])],
+    options: [...new Set(['2', '3', '5', '8', String(globalConfig.compactTailTurns ?? DEFAULT_COMPACT_TAIL_TURNS)])],
     type: 'enum' as const,
     onChange(compactTailTurnsValue: string) {
       const compactTailTurns = Number(compactTailTurnsValue);
@@ -1267,7 +1268,7 @@ export function Config({
       formattedChanges.push(threshold === 'off' ? 'Disabled message-count compaction' : `Set message-count compaction to ${threshold}`);
     }
     if (globalConfig.compactTailTurns !== initialConfig.current.compactTailTurns) {
-      formattedChanges.push(`Set compaction recent messages kept to ${globalConfig.compactTailTurns ?? 3}`);
+      formattedChanges.push(`Set compaction recent messages kept to ${globalConfig.compactTailTurns ?? DEFAULT_COMPACT_TAIL_TURNS}`);
     }
     if (globalConfig.toolHistoryCompressionEnabled !== initialConfig.current.toolHistoryCompressionEnabled) {
       formattedChanges.push(`${globalConfig.toolHistoryCompressionEnabled ? 'Enabled' : 'Disabled'} tool history compression`);

--- a/src/query.ts
+++ b/src/query.ts
@@ -537,6 +537,12 @@ async function* queryLoop(
   | ToolUseSummaryMessage,
   Terminal
 > {
+  // Reset this agent's doom loop detection at the start of each query turn.
+  // Keyed by agentId so a subagent starting mid-turn doesn't wipe the main
+  // thread's counter (or a sibling agent's).
+  const { resetDoomLoop } = await import('./utils/doomLoop.js')
+  resetDoomLoop(params.toolUseContext.agentId)
+
   // Start a new turn for multi-turn context tracking
   if (
     feature('MULTI_TURN_CONTEXT') &&

--- a/src/services/api/claude.toolHistoryRouting.test.ts
+++ b/src/services/api/claude.toolHistoryRouting.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, test } from 'bun:test'
+
+import { shouldCompressNativeToolHistory } from './claude.js'
+
+// The routing decision queryModel applies before mutating request messages:
+// every Anthropic-native transport compresses tool history ONLY while prompt
+// caching is inactive, and never for shim-routed providerOverride requests.
+// Parameterized here because the predicate guards a request-mutating branch
+// across four transports and two exclusions.
+
+const NATIVE_CASES = [
+  { apiProvider: 'firstParty', isGithubNativeAnthropic: false },
+  { apiProvider: 'bedrock', isGithubNativeAnthropic: false },
+  { apiProvider: 'vertex', isGithubNativeAnthropic: false },
+  // GitHub-native-Anthropic reports its own provider id; the mode flag is
+  // what marks it native.
+  { apiProvider: 'github', isGithubNativeAnthropic: true },
+] as const
+
+describe('shouldCompressNativeToolHistory', () => {
+  for (const transport of NATIVE_CASES) {
+    const name = transport.isGithubNativeAnthropic
+      ? `${transport.apiProvider} (native-Anthropic mode)`
+      : transport.apiProvider
+
+    test(`${name}: compresses with caching off`, () => {
+      expect(
+        shouldCompressNativeToolHistory({
+          ...transport,
+          hasProviderOverride: false,
+          promptCachingEnabled: false,
+        }),
+      ).toBe(true)
+    })
+
+    test(`${name}: cached sessions stay unmodified`, () => {
+      expect(
+        shouldCompressNativeToolHistory({
+          ...transport,
+          hasProviderOverride: false,
+          promptCachingEnabled: true,
+        }),
+      ).toBe(false)
+    })
+
+    test(`${name}: providerOverride requests are shim-routed, never compressed here`, () => {
+      expect(
+        shouldCompressNativeToolHistory({
+          ...transport,
+          hasProviderOverride: true,
+          promptCachingEnabled: false,
+        }),
+      ).toBe(false)
+    })
+  }
+
+  test('non-native providers never compress at this layer, cached or not', () => {
+    for (const apiProvider of ['openai', 'codex', 'gemini', 'minimax', 'xai']) {
+      for (const promptCachingEnabled of [false, true]) {
+        expect(
+          shouldCompressNativeToolHistory({
+            apiProvider,
+            isGithubNativeAnthropic: false,
+            hasProviderOverride: false,
+            promptCachingEnabled,
+          }),
+        ).toBe(false)
+      }
+    }
+  })
+})

--- a/src/services/api/claude.toolHistoryRouting.test.ts
+++ b/src/services/api/claude.toolHistoryRouting.test.ts
@@ -9,12 +9,12 @@ import { shouldCompressNativeToolHistory } from './claude.js'
 // across four transports and two exclusions.
 
 const NATIVE_CASES = [
-  { apiProvider: 'firstParty', isGithubNativeAnthropic: false },
-  { apiProvider: 'bedrock', isGithubNativeAnthropic: false },
-  { apiProvider: 'vertex', isGithubNativeAnthropic: false },
+  { apiProvider: 'firstParty', isFirstPartyBaseUrl: true, isGithubNativeAnthropic: false },
+  { apiProvider: 'bedrock', isFirstPartyBaseUrl: false, isGithubNativeAnthropic: false },
+  { apiProvider: 'vertex', isFirstPartyBaseUrl: false, isGithubNativeAnthropic: false },
   // GitHub-native-Anthropic reports its own provider id; the mode flag is
   // what marks it native.
-  { apiProvider: 'github', isGithubNativeAnthropic: true },
+  { apiProvider: 'github', isFirstPartyBaseUrl: false, isGithubNativeAnthropic: true },
 ] as const
 
 describe('shouldCompressNativeToolHistory', () => {
@@ -60,6 +60,7 @@ describe('shouldCompressNativeToolHistory', () => {
         expect(
           shouldCompressNativeToolHistory({
             apiProvider,
+            isFirstPartyBaseUrl: false,
             isGithubNativeAnthropic: false,
             hasProviderOverride: false,
             promptCachingEnabled,
@@ -67,5 +68,20 @@ describe('shouldCompressNativeToolHistory', () => {
         ).toBe(false)
       }
     }
+  })
+
+  test('firstParty on a custom ANTHROPIC_BASE_URL is NOT native — no compression', () => {
+    // A custom first-party base URL (proxy / Anthropic-compatible endpoint)
+    // reports firstParty AND caching-disabled; without the base-URL guard it
+    // would be compressed against an endpoint we make no assumptions about.
+    expect(
+      shouldCompressNativeToolHistory({
+        apiProvider: 'firstParty',
+        isFirstPartyBaseUrl: false,
+        isGithubNativeAnthropic: false,
+        hasProviderOverride: false,
+        promptCachingEnabled: false,
+      }),
+    ).toBe(false)
   })
 })

--- a/src/services/api/claude.ts
+++ b/src/services/api/claude.ts
@@ -1346,6 +1346,32 @@ async function* queryModel(
 
   queryCheckpoint('query_tool_schema_build_end')
 
+  // Compress old tool outputs for Anthropic-native transports, but only when
+  // prompt caching is inactive. Rewriting old messages as they cross tier
+  // boundaries diverges the request prefix on every call, which breaks the
+  // prompt cache and costs more than the compression saves — cached native
+  // sessions rely on microCompact (cache-aware) instead. Shim-routed traffic
+  // (OpenAI-compatible env providers, per-agent providerOverride, Codex)
+  // compresses at its own layer, where the local fast-path opt-out applies.
+  // compressToolHistory is generic over AnyMessage — cast to satisfy the type
+  // checker since OpenClaude's Message union is a superset of what the
+  // function actually inspects.
+  const apiProvider = getAPIProvider()
+  const isAnthropicNativeTransport =
+    (apiProvider === 'firstParty' ||
+      apiProvider === 'bedrock' ||
+      apiProvider === 'vertex' ||
+      isGithubNativeAnthropicMode(options.model)) &&
+    !options.providerOverride
+  if (isAnthropicNativeTransport && !getPromptCachingEnabled(options.model)) {
+    const { compressToolHistory } = await import('./compressToolHistory.js')
+    messages = compressToolHistory(
+      messages as unknown as Parameters<typeof compressToolHistory>[0],
+      options.model,
+      { effectiveContextWindowSize: getContextWindowForModel(options.model, getSdkBetas()) },
+    ) as typeof messages
+  }
+
   // Normalize messages before building system prompt (needed for fingerprinting)
   // Instrumentation: Track message count before normalization
   logEvent('tengu_api_before_normalize', {

--- a/src/services/api/claude.ts
+++ b/src/services/api/claude.ts
@@ -1103,6 +1103,33 @@ export function stripExcessMediaItems(
   }) as (UserMessage | AssistantMessage)[]
 }
 
+/**
+ * Tool-history compression routing for Anthropic-native transports (exported
+ * for focused tests — queryModel itself needs a live client to exercise).
+ * Native transports (first-party, Bedrock, Vertex, GitHub-native-Anthropic)
+ * compress only while prompt caching is inactive: retroactive tier rewrites
+ * diverge the cached request prefix and cost more than they save. Requests
+ * carrying a per-agent providerOverride are shim-routed and compress at the
+ * shim layer instead.
+ */
+export function shouldCompressNativeToolHistory(options: {
+  apiProvider: string
+  isGithubNativeAnthropic: boolean
+  hasProviderOverride: boolean
+  promptCachingEnabled: boolean
+}): boolean {
+  const isNativeTransport =
+    options.apiProvider === 'firstParty' ||
+    options.apiProvider === 'bedrock' ||
+    options.apiProvider === 'vertex' ||
+    options.isGithubNativeAnthropic
+  return (
+    isNativeTransport &&
+    !options.hasProviderOverride &&
+    !options.promptCachingEnabled
+  )
+}
+
 async function* queryModel(
   messages: Message[],
   systemPrompt: SystemPrompt,
@@ -1356,14 +1383,13 @@ async function* queryModel(
   // compressToolHistory is generic over AnyMessage — cast to satisfy the type
   // checker since OpenClaude's Message union is a superset of what the
   // function actually inspects.
-  const apiProvider = getAPIProvider()
-  const isAnthropicNativeTransport =
-    (apiProvider === 'firstParty' ||
-      apiProvider === 'bedrock' ||
-      apiProvider === 'vertex' ||
-      isGithubNativeAnthropicMode(options.model)) &&
-    !options.providerOverride
-  if (isAnthropicNativeTransport && !getPromptCachingEnabled(options.model)) {
+  const compressNativeToolHistory = shouldCompressNativeToolHistory({
+    apiProvider: getAPIProvider(),
+    isGithubNativeAnthropic: isGithubNativeAnthropicMode(options.model),
+    hasProviderOverride: Boolean(options.providerOverride),
+    promptCachingEnabled: getPromptCachingEnabled(options.model),
+  })
+  if (compressNativeToolHistory) {
     const { compressToolHistory } = await import('./compressToolHistory.js')
     messages = compressToolHistory(
       messages as unknown as Parameters<typeof compressToolHistory>[0],

--- a/src/services/api/claude.ts
+++ b/src/services/api/claude.ts
@@ -1114,12 +1114,18 @@ export function stripExcessMediaItems(
  */
 export function shouldCompressNativeToolHistory(options: {
   apiProvider: string
+  // firstParty alone is not enough: a custom ANTHROPIC_BASE_URL (proxy /
+  // compatible endpoint) also reports firstParty, but getPromptCachingEnabled
+  // already returns false there — treating it as native would compress every
+  // request against an endpoint we make no assumptions about. Mirror the
+  // same base-URL guard prompt caching itself uses.
+  isFirstPartyBaseUrl: boolean
   isGithubNativeAnthropic: boolean
   hasProviderOverride: boolean
   promptCachingEnabled: boolean
 }): boolean {
   const isNativeTransport =
-    options.apiProvider === 'firstParty' ||
+    (options.apiProvider === 'firstParty' && options.isFirstPartyBaseUrl) ||
     options.apiProvider === 'bedrock' ||
     options.apiProvider === 'vertex' ||
     options.isGithubNativeAnthropic
@@ -1385,6 +1391,7 @@ async function* queryModel(
   // function actually inspects.
   const compressNativeToolHistory = shouldCompressNativeToolHistory({
     apiProvider: getAPIProvider(),
+    isFirstPartyBaseUrl: isFirstPartyAnthropicBaseUrl(),
     isGithubNativeAnthropic: isGithubNativeAnthropicMode(options.model),
     hasProviderOverride: Boolean(options.providerOverride),
     promptCachingEnabled: getPromptCachingEnabled(options.model),

--- a/src/services/api/compressToolHistory.test.ts
+++ b/src/services/api/compressToolHistory.test.ts
@@ -862,3 +862,64 @@ test('idempotent: a second pass over compressed output is a no-op', () => {
     JSON.parse(JSON.stringify(once)),
   )
 })
+
+test('a block aged from mid to old tier upgrades from truncation to a stub', () => {
+  // First pass: exchange sits in the mid tier and gets truncated.
+  const initial = buildConversation(10)
+  const compressedOnce = compressToolHistoryForTest(initial)
+  const truncatedMsg = getResultMessages(compressedOnce)[0]!
+  expect(getResultText(truncatedMsg)).toContain('truncated')
+
+  // The conversation grows; the same block now falls in the old tier. The
+  // tier-aware guard must still upgrade it (blanket idempotency would leave
+  // it truncated — larger — forever).
+  const grown = [
+    ...compressedOnce,
+    ...buildToolExchange(10, 5_000),
+    ...buildToolExchange(11, 5_000),
+    ...buildToolExchange(12, 5_000),
+    ...buildToolExchange(13, 5_000),
+    ...buildToolExchange(14, 5_000),
+    ...buildToolExchange(15, 5_000),
+  ]
+  const compressedTwice = compressToolHistoryForTest(grown)
+  const text = getResultText(getResultMessages(compressedTwice)[0]!)
+  expect(text).toContain('chars omitted')
+  expect(text).not.toContain('truncated')
+})
+
+test('the upgraded stub reports the recovered pre-truncation length', () => {
+  // 5,000-char result truncated in the mid tier, then aged into the old
+  // tier: the stub must say 5000 chars were omitted (the tool's real output
+  // size), not the size of the truncated remnant it was derived from.
+  const initial = buildConversation(10, 5_000)
+  const compressedOnce = compressToolHistoryForTest(initial)
+  const grown = [
+    ...compressedOnce,
+    ...buildToolExchange(10, 5_000),
+    ...buildToolExchange(11, 5_000),
+    ...buildToolExchange(12, 5_000),
+    ...buildToolExchange(13, 5_000),
+    ...buildToolExchange(14, 5_000),
+    ...buildToolExchange(15, 5_000),
+  ]
+  const compressedTwice = compressToolHistoryForTest(grown)
+  const text = getResultText(getResultMessages(compressedTwice)[0]!)
+  const omitted = text.match(/→ (\d+) chars omitted/)
+  expect(omitted).not.toBeNull()
+  expect(Number(omitted![1])).toBe(5_000)
+
+  // And it must match what a fresh single-pass stub of the same conversation
+  // would have reported — upgrade path and direct path agree.
+  const fresh = compressToolHistoryForTest([
+    ...initial,
+    ...buildToolExchange(10, 5_000),
+    ...buildToolExchange(11, 5_000),
+    ...buildToolExchange(12, 5_000),
+    ...buildToolExchange(13, 5_000),
+    ...buildToolExchange(14, 5_000),
+    ...buildToolExchange(15, 5_000),
+  ])
+  const freshText = getResultText(getResultMessages(fresh)[0]!)
+  expect(freshText).toBe(text)
+})

--- a/src/services/api/compressToolHistory.test.ts
+++ b/src/services/api/compressToolHistory.test.ts
@@ -848,3 +848,17 @@ test('extra block attributes (e.g. cache_control) preserved across rewrites', ()
   // The custom attribute survived the stub rewrite via ...block spread
   expect(block.cache_control).toEqual(cacheControl)
 })
+
+test('idempotent: a second pass over compressed output is a no-op', () => {
+  // 16 exchanges at 100k window → old + mid + recent tiers all populated.
+  const messages = buildConversation(16)
+  const once = compressToolHistoryForTest(messages)
+  const twice = compressToolHistoryForTest(once)
+
+  // Stubs must not be re-stubbed (would corrupt the omitted-chars count) and
+  // truncations must not lose their marker — layered call sites (claude.ts +
+  // shim) rely on this.
+  expect(JSON.parse(JSON.stringify(twice))).toEqual(
+    JSON.parse(JSON.stringify(once)),
+  )
+})

--- a/src/services/api/compressToolHistory.ts
+++ b/src/services/api/compressToolHistory.ts
@@ -16,11 +16,15 @@
  *
  * Reuses isCompactableTool from microCompact to avoid touching tools the
  * project already classifies as unsafe to compress (e.g. Task, Agent).
- * Skips blocks already cleared by microCompact (TOOL_RESULT_CLEARED_MESSAGE)
- * and blocks this module already compressed (stub / truncation markers), so
- * a second pass over the same messages is a no-op. That idempotence matters
- * because claude.ts also calls this for Anthropic-native transports when
- * prompt caching is inactive — layered call sites must not re-mangle output.
+ * Skips blocks already cleared by microCompact (TOOL_RESULT_CLEARED_MESSAGE).
+ * Blocks this module already compressed are handled tier-aware: over the SAME
+ * input a second pass is a no-op (stubs and mid-tier truncations are at their
+ * target form), but as new exchanges age a truncated block into the old tier
+ * it still upgrades to a stub — carrying the pre-truncation length recovered
+ * from the marker. That idempotence-without-staleness matters because
+ * claude.ts also calls this for Anthropic-native transports when prompt
+ * caching is inactive — layered call sites must not re-mangle output, yet
+ * aging blocks must keep shrinking.
  */
 import { getEffectiveContextWindowSize } from '../compact/autoCompact.js'
 import { isCompactableTool } from '../compact/microCompact.js'
@@ -245,6 +249,10 @@ function buildStub(
   block: ToolResultBlock,
   toolUsesById: Map<string, ToolUseBlock>,
   separator: string,
+  // For blocks already truncated on an earlier pass: the true pre-truncation
+  // length recovered from the marker, so the stub reports what the tool
+  // actually returned instead of the truncated remnant's size.
+  originalLengthOverride?: number,
 ): ToolResultBlock {
   const original = extractText(block.content, separator)
   const toolUse = toolUsesById.get(block.tool_use_id ?? '')
@@ -254,7 +262,7 @@ function buildStub(
     : '{}'
   return replaceTextContent(
     block,
-    `[${name} args=${args} → ${original.length} chars omitted]`,
+    `[${name} args=${args} → ${originalLengthOverride ?? original.length} chars omitted]`,
   )
 }
 
@@ -328,16 +336,38 @@ function isAlreadyCleared(block: ToolResultBlock): boolean {
   return text === TOOL_RESULT_CLEARED_MESSAGE
 }
 
-// Output of buildStub / truncateBlock from a previous pass. Re-stubbing a stub
-// replaces `→ 45000 chars omitted` with a misleading `→ 58 chars omitted`, and
-// re-truncating chops off the load-bearing truncation marker — so both are
-// skipped to keep compression idempotent across layered call sites.
+// Output of buildStub / truncateBlock from a previous pass. Idempotency across
+// layered call sites (claude.ts + the shim can both run this) is TIER-AWARE,
+// not a blanket skip: a stub is the terminal form and is never re-stubbed
+// (that would replace `→ 45000 chars omitted` with a misleading `→ 58 chars
+// omitted`), and a truncated block is left alone only while it is still in
+// the mid tier — when later exchanges age it into the old tier it upgrades to
+// a stub, with the omitted-chars count recovered from the truncation marker
+// so it reflects the ORIGINAL output length, not the truncated remnant.
 const STUB_MARKER_RE = /^\[[^\n]* args=[^\n]* → \d+ chars omitted\]$/
-const TRUNCATION_MARKER_RE = /\n\[…truncated \d+ chars from tool history\]$/
+const TRUNCATION_MARKER_RE = /\n\[…truncated (\d+) chars from tool history\]$/
 
-function isAlreadyCompressed(block: ToolResultBlock): boolean {
-  const text = extractText(block.content)
-  return STUB_MARKER_RE.test(text) || TRUNCATION_MARKER_RE.test(text)
+type CompressedState =
+  | { kind: 'fresh' }
+  | { kind: 'stub' }
+  | { kind: 'truncated'; originalLength: number }
+
+function getCompressedState(
+  block: ToolResultBlock,
+  separator: string,
+): CompressedState {
+  const text = extractText(block.content, separator)
+  if (STUB_MARKER_RE.test(text)) return { kind: 'stub' }
+  const truncation = text.match(TRUNCATION_MARKER_RE)
+  if (truncation) {
+    // truncateTextContent kept `original - omitted` visible chars and encodes
+    // the omitted remainder in the marker; stripping the marker text itself
+    // recovers the pre-truncation length exactly.
+    const omitted = Number(truncation[1])
+    const visible = text.replace(TRUNCATION_MARKER_RE, '').length
+    return { kind: 'truncated', originalLength: visible + omitted }
+  }
+  return { kind: 'fresh' }
 }
 
 function shouldCompressBlock(
@@ -345,7 +375,6 @@ function shouldCompressBlock(
   toolUsesById: Map<string, ToolUseBlock>,
 ): boolean {
   if (isAlreadyCleared(block)) return false
-  if (isAlreadyCompressed(block)) return false
   const toolUse = toolUsesById.get(block.tool_use_id ?? '')
   // Unknown tool name (orphan tool_result with no matching tool_use) falls
   // through to compression with a generic "tool" stub. Safer default: the
@@ -432,7 +461,18 @@ export function compressToolHistory<T extends AnyMessage>(
         return sanitizeClearedBlock(tr)
       }
       if (!shouldCompressBlock(tr, toolUsesById)) return block
-      return fromEnd < tiers.recent + tiers.mid
+      const inMidTier = fromEnd < tiers.recent + tiers.mid
+      const state = getCompressedState(tr, textBlockSeparator)
+      // Stubs are terminal. Truncated blocks are at target while mid-tier;
+      // once aged into the old tier they upgrade to a stub carrying the
+      // recovered pre-truncation length.
+      if (state.kind === 'stub') return block
+      if (state.kind === 'truncated') {
+        return inMidTier
+          ? block
+          : buildStub(tr, toolUsesById, textBlockSeparator, state.originalLength)
+      }
+      return inMidTier
         ? truncateBlock(tr, MID_MAX_CHARS, textBlockSeparator)
         : buildStub(tr, toolUsesById, textBlockSeparator)
     })

--- a/src/services/api/compressToolHistory.ts
+++ b/src/services/api/compressToolHistory.ts
@@ -16,9 +16,11 @@
  *
  * Reuses isCompactableTool from microCompact to avoid touching tools the
  * project already classifies as unsafe to compress (e.g. Task, Agent).
- * Skips blocks already cleared by microCompact (TOOL_RESULT_CLEARED_MESSAGE).
- *
- * Anthropic native bypasses both shims, so it is unaffected by this module.
+ * Skips blocks already cleared by microCompact (TOOL_RESULT_CLEARED_MESSAGE)
+ * and blocks this module already compressed (stub / truncation markers), so
+ * a second pass over the same messages is a no-op. That idempotence matters
+ * because claude.ts also calls this for Anthropic-native transports when
+ * prompt caching is inactive — layered call sites must not re-mangle output.
  */
 import { getEffectiveContextWindowSize } from '../compact/autoCompact.js'
 import { isCompactableTool } from '../compact/microCompact.js'
@@ -326,11 +328,24 @@ function isAlreadyCleared(block: ToolResultBlock): boolean {
   return text === TOOL_RESULT_CLEARED_MESSAGE
 }
 
+// Output of buildStub / truncateBlock from a previous pass. Re-stubbing a stub
+// replaces `→ 45000 chars omitted` with a misleading `→ 58 chars omitted`, and
+// re-truncating chops off the load-bearing truncation marker — so both are
+// skipped to keep compression idempotent across layered call sites.
+const STUB_MARKER_RE = /^\[[^\n]* args=[^\n]* → \d+ chars omitted\]$/
+const TRUNCATION_MARKER_RE = /\n\[…truncated \d+ chars from tool history\]$/
+
+function isAlreadyCompressed(block: ToolResultBlock): boolean {
+  const text = extractText(block.content)
+  return STUB_MARKER_RE.test(text) || TRUNCATION_MARKER_RE.test(text)
+}
+
 function shouldCompressBlock(
   block: ToolResultBlock,
   toolUsesById: Map<string, ToolUseBlock>,
 ): boolean {
   if (isAlreadyCleared(block)) return false
+  if (isAlreadyCompressed(block)) return false
   const toolUse = toolUsesById.get(block.tool_use_id ?? '')
   // Unknown tool name (orphan tool_result with no matching tool_use) falls
   // through to compression with a generic "tool" stub. Safer default: the

--- a/src/services/compact/autoCompact.ts
+++ b/src/services/compact/autoCompact.ts
@@ -14,7 +14,7 @@ import { logError } from '../../utils/log.js'
 import { tokenCountWithEstimation } from '../../utils/tokens.js'
 import { partitionContext } from '../../utils/contextPartitioning.js'
 import {
-  DEFAULT_COMPACT_TAIL_TURNS,
+  normalizeCompactTailTurns,
   pruneByRelevance,
 } from '../../utils/relevancePruning.js'
 import { getFeatureValue_CACHED_MAY_BE_STALE } from '../analytics/growthbook.js'
@@ -491,15 +491,12 @@ export async function autoCompactIfNeeded(
     const systemMessages = messages.filter(m => m.message?.role === 'system')
     const nonSystemMessages = messages.filter(m => m.message?.role !== 'system')
     
-    // Config may be hand-edited; anything that isn't a positive number
-    // falls back to the default rather than pruning the entire tail.
-    const configuredTailTurns = getGlobalConfig().compactTailTurns
+    // Config may be hand-edited; normalizeCompactTailTurns is the single
+    // rule (shared with the /config UI) — a stray `0.5` must not floor to a
+    // zero-message tail, and invalid values fall back to the default.
     const pruned = pruneByRelevance(nonSystemMessages, {
       targetTokens: availableSpace,
-      preserveRecent:
-        configuredTailTurns && configuredTailTurns > 0
-          ? Math.floor(configuredTailTurns)
-          : DEFAULT_COMPACT_TAIL_TURNS,
+      preserveRecent: normalizeCompactTailTurns(getGlobalConfig().compactTailTurns),
       preserveTools: true,
       preserveErrors: true,
     })

--- a/src/services/compact/autoCompact.ts
+++ b/src/services/compact/autoCompact.ts
@@ -13,7 +13,10 @@ import type { CacheSafeParams } from '../../utils/forkedAgent.js'
 import { logError } from '../../utils/log.js'
 import { tokenCountWithEstimation } from '../../utils/tokens.js'
 import { partitionContext } from '../../utils/contextPartitioning.js'
-import { pruneByRelevance } from '../../utils/relevancePruning.js'
+import {
+  DEFAULT_COMPACT_TAIL_TURNS,
+  pruneByRelevance,
+} from '../../utils/relevancePruning.js'
 import { getFeatureValue_CACHED_MAY_BE_STALE } from '../analytics/growthbook.js'
 import { getMaxOutputTokensForModel } from '../api/claude.js'
 import { notifyCompaction } from '../api/promptCacheBreakDetection.js'
@@ -496,7 +499,7 @@ export async function autoCompactIfNeeded(
       preserveRecent:
         configuredTailTurns && configuredTailTurns > 0
           ? Math.floor(configuredTailTurns)
-          : 3,
+          : DEFAULT_COMPACT_TAIL_TURNS,
       preserveTools: true,
       preserveErrors: true,
     })

--- a/src/services/compact/autoCompact.ts
+++ b/src/services/compact/autoCompact.ts
@@ -488,9 +488,15 @@ export async function autoCompactIfNeeded(
     const systemMessages = messages.filter(m => m.message?.role === 'system')
     const nonSystemMessages = messages.filter(m => m.message?.role !== 'system')
     
+    // Config may be hand-edited; anything that isn't a positive number
+    // falls back to the default rather than pruning the entire tail.
+    const configuredTailTurns = getGlobalConfig().compactTailTurns
     const pruned = pruneByRelevance(nonSystemMessages, {
       targetTokens: availableSpace,
-      preserveRecent: 3,
+      preserveRecent:
+        configuredTailTurns && configuredTailTurns > 0
+          ? Math.floor(configuredTailTurns)
+          : 3,
       preserveTools: true,
       preserveErrors: true,
     })

--- a/src/services/tools/toolExecution.ts
+++ b/src/services/tools/toolExecution.ts
@@ -67,6 +67,7 @@ import {
   shouldCreateUserInterruptionMessage,
 } from '../../utils/abortReasons.js'
 import { logForDebugging } from '../../utils/debug.js'
+import { checkDoomLoop } from '../../utils/doomLoop.js'
 import {
   AbortError,
   errorMessage,
@@ -474,6 +475,30 @@ export async function* runToolUse(
           },
         ],
         toolUseResult: `Error: No such tool available: ${toolName}`,
+        sourceToolAssistantUUID: assistantMessage.uuid,
+      }),
+    }
+    return
+  }
+
+  // Doom loop detection: block after N consecutive identical tool calls.
+  // Keyed by agent so concurrent subagents don't pollute each other's counters.
+  const doomLoop = checkDoomLoop(toolName, toolUse.input, {
+    agentKey: toolUseContext.agentId,
+  })
+  if (doomLoop.blocked) {
+    logForDebugging(`Doom loop detected for ${toolName} (${doomLoop.count} consecutive identical calls)`)
+    yield {
+      message: createUserMessage({
+        content: [
+          {
+            type: 'tool_result',
+            content: `<tool_use_error>Blocked: This tool has been called ${doomLoop.count} times in a row with identical input. You are likely in a loop. Please try a different approach or ask the user for help.</tool_use_error>`,
+            is_error: true,
+            tool_use_id: toolUse.id,
+          },
+        ],
+        toolUseResult: `Blocked: doom loop detected for ${toolName} after ${doomLoop.count} identical calls`,
         sourceToolAssistantUUID: assistantMessage.uuid,
       }),
     }

--- a/src/services/tools/toolExecution.ts
+++ b/src/services/tools/toolExecution.ts
@@ -488,12 +488,20 @@ export async function* runToolUse(
   })
   if (doomLoop.blocked) {
     logForDebugging(`Doom loop detected for ${toolName} (${doomLoop.count} consecutive identical calls)`)
+    // Observability for tuning: a burst of these against varied tools would
+    // indicate false positives (e.g. legitimate polling), not stuck agents.
+    logEvent('tengu_doom_loop_blocked', {
+      toolName: sanitizeToolNameForAnalytics(
+        toolName,
+      ) as AnalyticsMetadata_I_VERIFIED_THIS_IS_NOT_CODE_OR_FILEPATHS,
+      count: doomLoop.count,
+    })
     yield {
       message: createUserMessage({
         content: [
           {
             type: 'tool_result',
-            content: `<tool_use_error>Blocked: This tool has been called ${doomLoop.count} times in a row with identical input. You are likely in a loop. Please try a different approach or ask the user for help.</tool_use_error>`,
+            content: `<tool_use_error>Blocked: ${doomLoop.count} consecutive calls to this tool with identical input — you are likely in a loop. Change the input, try a different tool, or ask the user for help. A deliberate repeat is fine once something observable has changed (new output to check, a modified file, an updated instruction).</tool_use_error>`,
             is_error: true,
             tool_use_id: toolUse.id,
           },

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -292,7 +292,8 @@ export type GlobalConfig = {
   hasUsedBackslashReturn?: boolean
   autoCompactEnabled: boolean // Controls whether auto-compact is enabled
   contextCollapseEnabled: boolean // Opt-in: collapse old transcript spans into summaries (lossy; off by default)
-  toolHistoryCompressionEnabled: boolean // Compress old tool_result content for small-context providers
+  toolHistoryCompressionEnabled: boolean // Compress old tool_result content (shim providers; Anthropic-native only while prompt caching is inactive)
+  compactTailTurns?: number // Recent messages preserved verbatim by auto-compact's relevance pruning (default: 3)
   showTurnDuration: boolean // Controls whether to show turn duration message (e.g., "Cooked for 1m 6s")
   // Controls whether to show per-query cache hit/miss stats at the end of each turn.
   // 'off'     — no display
@@ -769,6 +770,7 @@ export const GLOBAL_CONFIG_KEYS = [
   'editorMode',
   'hasUsedBackslashReturn',
   'autoCompactEnabled',
+  'compactTailTurns',
   'contextCollapseEnabled',
   'toolHistoryCompressionEnabled',
   'showTurnDuration',

--- a/src/utils/doomLoop.test.ts
+++ b/src/utils/doomLoop.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect, beforeEach } from 'bun:test'
+import {
+  checkDoomLoop,
+  resetDoomLoop,
+  resetAllDoomLoops,
+  getDoomLoopState,
+} from './doomLoop.js'
+
+describe('doomLoop', () => {
+  beforeEach(() => {
+    resetAllDoomLoops()
+  })
+
+  it('allows first call', () => {
+    const result = checkDoomLoop('Bash', { command: 'ls' })
+    expect(result.blocked).toBe(false)
+    expect(result.count).toBe(1)
+  })
+
+  it('allows second identical call', () => {
+    checkDoomLoop('Bash', { command: 'ls' })
+    const result = checkDoomLoop('Bash', { command: 'ls' })
+    expect(result.blocked).toBe(false)
+    expect(result.count).toBe(2)
+  })
+
+  it('blocks third identical call by default', () => {
+    checkDoomLoop('Bash', { command: 'ls' })
+    checkDoomLoop('Bash', { command: 'ls' })
+    const result = checkDoomLoop('Bash', { command: 'ls' })
+    expect(result.blocked).toBe(true)
+    expect(result.count).toBe(3)
+  })
+
+  it('resets when a different tool/input is called', () => {
+    checkDoomLoop('Bash', { command: 'ls' })
+    checkDoomLoop('Bash', { command: 'ls' })
+    // Different tool
+    const result = checkDoomLoop('Grep', { pattern: 'foo' })
+    expect(result.blocked).toBe(false)
+    expect(result.count).toBe(1)
+  })
+
+  it('resets when same tool has different input', () => {
+    checkDoomLoop('Bash', { command: 'ls' })
+    checkDoomLoop('Bash', { command: 'ls' })
+    const result = checkDoomLoop('Bash', { command: 'pwd' })
+    expect(result.blocked).toBe(false)
+    expect(result.count).toBe(1)
+  })
+
+  it('respects custom threshold', () => {
+    checkDoomLoop('Bash', { command: 'ls' }, { threshold: 5 })
+    checkDoomLoop('Bash', { command: 'ls' }, { threshold: 5 })
+    checkDoomLoop('Bash', { command: 'ls' }, { threshold: 5 })
+    const result = checkDoomLoop('Bash', { command: 'ls' }, { threshold: 5 })
+    expect(result.blocked).toBe(false)
+    expect(result.count).toBe(4)
+    const blocked = checkDoomLoop('Bash', { command: 'ls' }, { threshold: 5 })
+    expect(blocked.blocked).toBe(true)
+    expect(blocked.count).toBe(5)
+  })
+
+  it('reset clears state for the main agent', () => {
+    checkDoomLoop('Bash', { command: 'ls' })
+    checkDoomLoop('Bash', { command: 'ls' })
+    resetDoomLoop()
+    const result = checkDoomLoop('Bash', { command: 'ls' })
+    expect(result.blocked).toBe(false)
+    expect(result.count).toBe(1)
+  })
+
+  it('tracks agents independently', () => {
+    // Three "agents" each make the same call once — interleaved they must
+    // not trip the shared-counter block.
+    expect(checkDoomLoop('Read', { file: 'a' }, { agentKey: 'agent-1' }).count).toBe(1)
+    expect(checkDoomLoop('Read', { file: 'a' }, { agentKey: 'agent-2' }).count).toBe(1)
+    const third = checkDoomLoop('Read', { file: 'a' }, { agentKey: 'agent-3' })
+    expect(third.blocked).toBe(false)
+    expect(third.count).toBe(1)
+  })
+
+  it('interleaved calls from another agent do not reset the counter', () => {
+    checkDoomLoop('Bash', { command: 'ls' })
+    checkDoomLoop('Grep', { pattern: 'x' }, { agentKey: 'agent-1' })
+    checkDoomLoop('Bash', { command: 'ls' })
+    const result = checkDoomLoop('Bash', { command: 'ls' })
+    expect(result.blocked).toBe(true)
+    expect(result.count).toBe(3)
+  })
+
+  it('resetting one agent leaves others intact', () => {
+    checkDoomLoop('Bash', { command: 'ls' })
+    checkDoomLoop('Bash', { command: 'ls' })
+    checkDoomLoop('Bash', { command: 'ls' }, { agentKey: 'agent-1' })
+    checkDoomLoop('Bash', { command: 'ls' }, { agentKey: 'agent-1' })
+    resetDoomLoop('agent-1')
+    // agent-1 restarts from scratch
+    expect(checkDoomLoop('Bash', { command: 'ls' }, { agentKey: 'agent-1' }).count).toBe(1)
+    // main still one call away from the block
+    const main = checkDoomLoop('Bash', { command: 'ls' })
+    expect(main.blocked).toBe(true)
+    expect(main.count).toBe(3)
+  })
+
+  it('getDoomLoopState returns current state', () => {
+    checkDoomLoop('Bash', { command: 'ls' })
+    const state = getDoomLoopState()
+    expect(state.consecutiveCount).toBe(1)
+    expect(state.blocked).toBe(false)
+    expect(state.lastSignature).toContain('Bash')
+  })
+
+  it('getDoomLoopState is per-agent', () => {
+    checkDoomLoop('Bash', { command: 'ls' }, { agentKey: 'agent-1' })
+    expect(getDoomLoopState('agent-1').consecutiveCount).toBe(1)
+    expect(getDoomLoopState().consecutiveCount).toBe(0)
+  })
+})

--- a/src/utils/doomLoop.test.ts
+++ b/src/utils/doomLoop.test.ts
@@ -116,4 +116,16 @@ describe('doomLoop', () => {
     expect(getDoomLoopState('agent-1').consecutiveCount).toBe(1)
     expect(getDoomLoopState().consecutiveCount).toBe(0)
   })
+
+  it('distinguishes large inputs that share a long identical prefix', () => {
+    // Regression: prefix-truncated signatures collided for inputs identical
+    // in the first 2KB — e.g. two Write calls to the same file differing only
+    // in trailing content — falsely tripping the block on distinct work.
+    const prefix = 'x'.repeat(4096)
+    checkDoomLoop('Write', { file_path: '/a.ts', content: prefix + 'ONE' })
+    checkDoomLoop('Write', { file_path: '/a.ts', content: prefix + 'TWO' })
+    const third = checkDoomLoop('Write', { file_path: '/a.ts', content: prefix + 'THREE' })
+    expect(third.blocked).toBe(false)
+    expect(third.count).toBe(1)
+  })
 })

--- a/src/utils/doomLoop.ts
+++ b/src/utils/doomLoop.ts
@@ -1,0 +1,97 @@
+/**
+ * Doom loop detection: prevents wasting tokens on repeated identical tool calls.
+ *
+ * Tracks consecutive tool calls with the same (name, input) signature.
+ * After a configurable threshold (default 3), blocks execution and tells the
+ * model to change approach or ask the user.
+ *
+ * State is keyed per agent (main thread and each subagent track separately).
+ * Subagents run runToolUse in the same process as the main loop, so a shared
+ * counter would let three parallel agents each legitimately making the same
+ * call once trip the block, and any interleaved call would reset it.
+ */
+
+const DEFAULT_THRESHOLD = 3
+
+const MAIN_AGENT_KEY = 'main'
+
+type ToolSignature = string
+
+interface DoomLoopState {
+  lastSignature: ToolSignature | null
+  consecutiveCount: number
+  blocked: boolean
+}
+
+const stateByAgent = new Map<string, DoomLoopState>()
+
+function getState(agentKey: string): DoomLoopState {
+  let state = stateByAgent.get(agentKey)
+  if (!state) {
+    state = { lastSignature: null, consecutiveCount: 0, blocked: false }
+    stateByAgent.set(agentKey, state)
+  }
+  return state
+}
+
+function computeSignature(toolName: string, input: unknown): ToolSignature {
+  // Use a stable JSON serialization for the input.
+  // Truncate to avoid hashing huge inputs — first 2K chars is enough
+  // to detect identical calls.
+  const inputStr = typeof input === 'string'
+    ? input
+    : JSON.stringify(input) ?? ''
+  return `${toolName}::${inputStr.slice(0, 2048)}`
+}
+
+/**
+ * Record a tool call and check if it's a doom loop.
+ * Returns `{ blocked: true }` if the tool should be blocked,
+ * or `{ blocked: false }` to proceed normally.
+ */
+export function checkDoomLoop(
+  toolName: string,
+  input: unknown,
+  options: { threshold?: number; agentKey?: string } = {},
+): { blocked: boolean; count: number } {
+  const threshold = options.threshold ?? DEFAULT_THRESHOLD
+  const state = getState(options.agentKey ?? MAIN_AGENT_KEY)
+  const sig = computeSignature(toolName, input)
+
+  if (sig === state.lastSignature) {
+    state.consecutiveCount++
+  } else {
+    state.lastSignature = sig
+    state.consecutiveCount = 1
+    state.blocked = false
+  }
+
+  if (state.consecutiveCount >= threshold && !state.blocked) {
+    state.blocked = true
+    return { blocked: true, count: state.consecutiveCount }
+  }
+
+  return { blocked: state.blocked, count: state.consecutiveCount }
+}
+
+/**
+ * Reset doom loop state for one agent (e.g., at the start of its query turn).
+ * Defaults to the main thread, matching checkDoomLoop's default key.
+ */
+export function resetDoomLoop(agentKey: string = MAIN_AGENT_KEY): void {
+  stateByAgent.delete(agentKey)
+}
+
+/** Clear every agent's state. Test isolation only. */
+export function resetAllDoomLoops(): void {
+  stateByAgent.clear()
+}
+
+/**
+ * Get current doom loop state for diagnostics.
+ */
+export function getDoomLoopState(
+  agentKey: string = MAIN_AGENT_KEY,
+): Readonly<DoomLoopState> {
+  return { ...getState(agentKey) }
+}

--- a/src/utils/doomLoop.ts
+++ b/src/utils/doomLoop.ts
@@ -11,6 +11,8 @@
  * call once trip the block, and any interleaved call would reset it.
  */
 
+import { createHash } from 'crypto'
+
 const DEFAULT_THRESHOLD = 3
 
 const MAIN_AGENT_KEY = 'main'
@@ -35,13 +37,18 @@ function getState(agentKey: string): DoomLoopState {
 }
 
 function computeSignature(toolName: string, input: unknown): ToolSignature {
-  // Use a stable JSON serialization for the input.
-  // Truncate to avoid hashing huge inputs — first 2K chars is enough
-  // to detect identical calls.
+  // Hash the FULL serialized input: prefix-truncated comparison treated two
+  // genuinely different calls sharing a 2KB prefix (e.g. Write calls to the
+  // same file with different trailing content) as identical — a false
+  //-positive block on legitimate, distinct work. Serialization of the
+  // in-memory input is the unavoidable cost either way; the digest keeps the
+  // stored signature fixed-size. The tool name stays readable for
+  // getDoomLoopState diagnostics.
   const inputStr = typeof input === 'string'
     ? input
     : JSON.stringify(input) ?? ''
-  return `${toolName}::${inputStr.slice(0, 2048)}`
+  const digest = createHash('sha256').update(inputStr).digest('hex')
+  return `${toolName}::${digest}`
 }
 
 /**

--- a/src/utils/relevancePruning.test.ts
+++ b/src/utils/relevancePruning.test.ts
@@ -184,5 +184,10 @@ describe('normalizeCompactTailTurns', () => {
     expect(normalizeCompactTailTurns('abc')).toBe(DEFAULT_COMPACT_TAIL_TURNS)
     expect(normalizeCompactTailTurns(undefined)).toBe(DEFAULT_COMPACT_TAIL_TURNS)
     expect(normalizeCompactTailTurns(null)).toBe(DEFAULT_COMPACT_TAIL_TURNS)
+    // Non-string non-number shapes must not coerce (Number(true) === 1,
+    // Number([2]) === 2) into a tiny tail.
+    expect(normalizeCompactTailTurns(true)).toBe(DEFAULT_COMPACT_TAIL_TURNS)
+    expect(normalizeCompactTailTurns([2])).toBe(DEFAULT_COMPACT_TAIL_TURNS)
+    expect(normalizeCompactTailTurns({})).toBe(DEFAULT_COMPACT_TAIL_TURNS)
   })
 })

--- a/src/utils/relevancePruning.test.ts
+++ b/src/utils/relevancePruning.test.ts
@@ -1,5 +1,7 @@
-import { describe, expect, it } from 'bun:test'
+import { describe, expect, it, test } from 'bun:test'
 import {
+  DEFAULT_COMPACT_TAIL_TURNS,
+  normalizeCompactTailTurns,
   pruneByRelevance,
   getTopRelevantMessages,
   getRelevanceStats,
@@ -162,5 +164,25 @@ describe('relevancePruning', () => {
       const result = pruneByRelevance(messages, { targetTokens: 1_000_000 })
       expect(result.map(m => m.message.id)).toEqual(messages.map(m => m.message.id))
     })
+  })
+})
+describe('normalizeCompactTailTurns', () => {
+  test('valid values floor to integers', () => {
+    expect(normalizeCompactTailTurns(5)).toBe(5)
+    expect(normalizeCompactTailTurns(2.5)).toBe(2)
+    expect(normalizeCompactTailTurns('8')).toBe(8)
+    expect(normalizeCompactTailTurns(1)).toBe(1)
+  })
+
+  test('invalid or dangerous values fall back to the default', () => {
+    // 0.5 previously passed a `> 0` check and floored to a ZERO-message tail.
+    expect(normalizeCompactTailTurns(0.5)).toBe(DEFAULT_COMPACT_TAIL_TURNS)
+    expect(normalizeCompactTailTurns(0)).toBe(DEFAULT_COMPACT_TAIL_TURNS)
+    expect(normalizeCompactTailTurns(-3)).toBe(DEFAULT_COMPACT_TAIL_TURNS)
+    expect(normalizeCompactTailTurns(NaN)).toBe(DEFAULT_COMPACT_TAIL_TURNS)
+    expect(normalizeCompactTailTurns(Infinity)).toBe(DEFAULT_COMPACT_TAIL_TURNS)
+    expect(normalizeCompactTailTurns('abc')).toBe(DEFAULT_COMPACT_TAIL_TURNS)
+    expect(normalizeCompactTailTurns(undefined)).toBe(DEFAULT_COMPACT_TAIL_TURNS)
+    expect(normalizeCompactTailTurns(null)).toBe(DEFAULT_COMPACT_TAIL_TURNS)
   })
 })

--- a/src/utils/relevancePruning.ts
+++ b/src/utils/relevancePruning.ts
@@ -23,7 +23,15 @@ export const DEFAULT_COMPACT_TAIL_TURNS = 3
  * tail of zero, and a displayed `2.5` must not silently behave as 2.
  */
 export function normalizeCompactTailTurns(value: unknown): number {
-  const num = typeof value === 'number' ? value : Number(value)
+  // Only numbers (persisted config) and strings (the /config picker's value
+  // channel) are coercible; other hand-edited shapes (true → 1, [2] → 2 via
+  // Number()) must not smuggle in a tiny tail — they fall back instead.
+  const num =
+    typeof value === 'number'
+      ? value
+      : typeof value === 'string'
+        ? Number(value)
+        : NaN
   return Number.isFinite(num) && num >= 1
     ? Math.floor(num)
     : DEFAULT_COMPACT_TAIL_TURNS

--- a/src/utils/relevancePruning.ts
+++ b/src/utils/relevancePruning.ts
@@ -14,6 +14,21 @@ import type { Message } from '../types/message.js'
  */
 export const DEFAULT_COMPACT_TAIL_TURNS = 3
 
+/**
+ * Single normalization rule for the hand-editable `compactTailTurns` config:
+ * any finite value ≥ 1 floors to an integer; everything else (0, negatives,
+ * fractions below 1, NaN, non-numbers) falls back to the default. The /config
+ * UI displays and persists through this SAME rule, so what the picker shows
+ * is exactly what autoCompact preserves — a raw `0.5` must not floor to a
+ * tail of zero, and a displayed `2.5` must not silently behave as 2.
+ */
+export function normalizeCompactTailTurns(value: unknown): number {
+  const num = typeof value === 'number' ? value : Number(value)
+  return Number.isFinite(num) && num >= 1
+    ? Math.floor(num)
+    : DEFAULT_COMPACT_TAIL_TURNS
+}
+
 export interface PruningOptions {
   targetTokens: number
   taskContext?: string

--- a/src/utils/relevancePruning.ts
+++ b/src/utils/relevancePruning.ts
@@ -7,6 +7,13 @@
 import { roughTokenCountEstimation } from '../services/tokenEstimation.js'
 import type { Message } from '../types/message.js'
 
+/**
+ * Default number of recent messages preserved verbatim by relevance pruning.
+ * Shared by autoCompact's `compactTailTurns` config plumbing and the /config
+ * UI display so a future default change stays in sync everywhere.
+ */
+export const DEFAULT_COMPACT_TAIL_TURNS = 3
+
 export interface PruningOptions {
   targetTokens: number
   taskContext?: string
@@ -161,7 +168,7 @@ export function pruneByRelevance(
   options: PruningOptions,
 ): Message[] {
   const targetTokens = options.targetTokens ?? 5000
-  const preserveRecent = options.preserveRecent ?? 3
+  const preserveRecent = options.preserveRecent ?? DEFAULT_COMPACT_TAIL_TURNS
 
   if (messages.length <= preserveRecent) {
     return messages


### PR DESCRIPTION
## Summary

- **Tool-history compression on the Anthropic-native transport.** `compressToolHistory` (tiered recent/mid/old pruning of `tool_result` bulk) previously ran only at the OpenAI-compatible shim layer. `queryModel` now also applies it for native transports (firstParty / Bedrock / Vertex / native-GitHub), gated to runs where prompt caching is inactive: retroactively rewriting old messages as they cross tier boundaries diverges the request prefix on every call, so cached native sessions keep relying on the cache-aware `microCompact` instead. Shim-routed traffic (env providers, per-agent `providerOverride`, Codex) still compresses at its own layer, where the local fast-path opt-out applies. `compressToolHistory` is now idempotent — it recognizes its own stub/truncation markers and skips them — so layered call sites can never re-mangle output (e.g. a stub degrading to a misleading `→ 58 chars omitted`).
- **Doom loop detection.** After 3 consecutive identical tool calls (same name + input signature), the call is blocked with a `tool_use_error` telling the model to change approach, instead of burning tokens on a retry loop. State is keyed per agent (`toolUseContext.agentId`, main thread separate), so concurrent subagents neither trip nor reset each other's counters; each agent's counter resets at the start of its own query turn.
- **Configurable compaction tail.** New optional `compactTailTurns` in `GlobalConfig`, wired into `autoCompact`'s relevance pruning (default 3, clamped to positive against hand-edited configs) and exposed in the `/config` UI next to the other compaction settings.

## Impact

- user-facing impact: long sessions on non-cached providers accumulate less dead tool-output context (later/fewer compactions); models stuck repeating an identical call are cut off after 3 attempts with actionable feedback; compaction tail length is now user-tunable via `/config`. Anthropic sessions with prompt caching active are deliberately unaffected.
- developer/maintainer impact: `compressToolHistory` is safe to call from multiple layers (idempotent, marker-guarded); doom-loop state is per-agent by construction; no new required config fields.

## Testing

- [x] `bun run build`
- [x] `bun run smoke`
- [ ] `bun run check`
- [x] focused tests: `doomLoop` (13, incl. per-agent isolation), `compressToolHistory` (31, incl. double-pass idempotency), `services/compact` (80), `toolExecution` (32), `query` (85), `claude.*` (14) — all green; full `tsc --noEmit` clean

## Notes

- provider/model path tested: unit level for the gating predicate (native vs shim vs providerOverride); shim behavior unchanged by construction (its call site is untouched)
- screenshots attached (if UI changed): none — `/config` gains one enum row ("Compaction: recent messages kept"), same pattern as the message-count compaction setting
- follow-up work or known limitations: doom-loop threshold is fixed at 3 (not config-exposed); native-with-caching sessions intentionally skip compression — revisiting that would require an append-time (cache-stable) compression design

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a configurable setting (“Compaction: recent messages kept”) with validated value normalization and persisted config.
* **Bug Fixes**
  * Improved tool-history compression to be idempotent across multiple passes, including upgrading older truncated blocks to stubs.
  * Added “doom loop” detection before tool execution to block repeated identical tool calls.
  * Doom-loop state is reset at the start of each query turn, scoped per agent.
  * Relevance pruning now preserves the configured recent-message count with safe fallback.
* **Tests**
  * Expanded coverage for doom-loop behavior, multi-pass compression/idempotency, and compact-tail normalization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->