### PR TITLE
fix(websearch): match allowed/blocked domains case-insensitively

### DIFF
--- a/src/tools/WebSearchTool/providers/types.test.ts
+++ b/src/tools/WebSearchTool/providers/types.test.ts
@@ -57,6 +57,16 @@ describe('hostMatchesDomain', () => {
     expect(hostMatchesDomain('notexample.com', 'example.com')).toBe(false)
     expect(hostMatchesDomain('xample.com', 'example.com')).toBe(false)
   })
+
+  test('matching is case-insensitive on the domain (host is already lowercased)', () => {
+    // `domain` comes from caller input and may be capitalized; hosts are
+    // case-insensitive, so a mixed-case entry must still match.
+    expect(hostMatchesDomain('example.com', 'Example.com')).toBe(true)
+    expect(hostMatchesDomain('sub.example.com', 'Example.COM')).toBe(true)
+    expect(hostMatchesDomain('reddit.com', 'Reddit.com')).toBe(true)
+    // A mixed-case lookalike still must not match.
+    expect(hostMatchesDomain('notexample.com', 'Example.com')).toBe(false)
+  })
 })
 
 // ---------------------------------------------------------------------------
@@ -125,6 +135,29 @@ describe('applyDomainFilters', () => {
     })
     expect(result).toHaveLength(1)
     expect(result[0].url).toBe('https://example.com/page')
+  })
+
+  test('blocks a capitalized blocked_domains entry (case-insensitive)', () => {
+    const hits = [
+      { title: 'good', url: 'https://example.com/page' },
+      { title: 'blocked', url: 'https://reddit.com/r/x' },
+    ]
+    const result = applyDomainFilters(hits, {
+      query: 'test',
+      blocked_domains: ['Reddit.com'],
+    })
+    expect(result).toHaveLength(1)
+    expect(result[0].url).toBe('https://example.com/page')
+  })
+
+  test('keeps a hit for a capitalized allowed_domains entry (case-insensitive)', () => {
+    const hits = [{ title: 'good', url: 'https://github.com/openai' }]
+    const result = applyDomainFilters(hits, {
+      query: 'test',
+      allowed_domains: ['GitHub.com'],
+    })
+    expect(result).toHaveLength(1)
+    expect(result[0].url).toBe('https://github.com/openai')
   })
 
   test('keeps malformed URLs when filtering blocked (security)', () => {

--- a/src/tools/WebSearchTool/providers/types.ts
+++ b/src/tools/WebSearchTool/providers/types.ts
@@ -90,9 +90,18 @@ export function safeHostname(url: string | undefined): string | undefined {
  *          hostMatchesDomain('badexample.com', 'example.com') → false
  */
 export function hostMatchesDomain(host: string, domain: string): boolean {
-  if (host === domain) return true
+  // `host` arrives already lowercased (WHATWG `new URL().hostname` via
+  // safeHostname), but `domain` comes straight from the caller's
+  // allowed_domains / blocked_domains and is never normalized. Lowercase both
+  // so a capitalized entry like `Reddit.com` still matches `reddit.com` — hosts
+  // are case-insensitive, and without this `blocked_domains: ['Reddit.com']`
+  // silently fails to block and `allowed_domains: ['GitHub.com']` drops every
+  // legitimate hit.
+  const normalizedHost = host.toLowerCase()
+  const normalizedDomain = domain.toLowerCase()
+  if (normalizedHost === normalizedDomain) return true
   // Subdomain: must end with `.domain` (not just `domain`)
-  return host.endsWith('.' + domain)
+  return normalizedHost.endsWith('.' + normalizedDomain)
 }
 
 export function applyDomainFilters(


### PR DESCRIPTION
## Summary

`hostMatchesDomain` gates the client-side WebSearch domain filter (`applyDomainFilters`, used by the brave / duckduckgo / custom / firecrawl providers). It compared the request host against the caller's `allowed_domains` / `blocked_domains` entries with a raw `===` / `endsWith`:

```ts
export function hostMatchesDomain(host: string, domain: string): boolean {
  if (host === domain) return true
  return host.endsWith('.' + domain)
}
```

The `host` is always lowercased — it comes from `safeHostname()` → `new URL(url).hostname`, and the WHATWG URL parser lowercases the hostname. But `domain` comes straight from the tool input (`WebSearchTool.ts` types them as bare `z.string()`) and is never normalized. So any domain entry containing an uppercase letter fails to match a host it should:

- `blocked_domains: ['Reddit.com']` → the block silently fails and `reddit.com` results are still returned (content-restriction bypass).
- `allowed_domains: ['GitHub.com']` → `applyDomainFilters` drops every hit (it returns `false` when nothing in the allowlist matches), so legitimate `github.com` results vanish and the tool returns nothing.

Models and users routinely capitalize brand domains (`GitHub.com`, `Reddit.com`), so this fires in practice.

## Fix

Hostnames are case-insensitive — lowercase both operands before comparing. Lookalike hosts (`notexample.com`) are still rejected.

## Testing

- `hostMatchesDomain('example.com', 'Example.com')` → `true`; `('notexample.com', 'Example.com')` → `false`.
- `applyDomainFilters` blocks a `['Reddit.com']` entry and keeps a hit for a `['GitHub.com']` entry.

Reverting the `.toLowerCase()` normalization re-fails the three new assertions.

```
bun test src/tools/WebSearchTool/providers/types.test.ts   # pass
bun run typecheck                                          # clean
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Domain-based search filtering now works consistently regardless of letter casing.
  * Allowed and blocked domain entries are matched case-insensitively, improving results for mixed-case inputs.
  * Exact domain and subdomain checks continue to reject partial or lookalike matches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->