### PR TITLE
fix(diff): don't overcount new-file additions by the trailing newline

### DIFF
--- a/src/utils/diff.test.ts
+++ b/src/utils/diff.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, mock, test } from 'bun:test'
+
+// Analytics is a leaf side effect of countLinesChanged; stub it so the test
+// only exercises the counting.
+mock.module('src/services/analytics/index.js', () => ({
+  logEvent: () => {},
+}))
+
+import { getTotalLinesAdded } from '../bootstrap/state.js'
+import { countLinesChanged } from './diff.js'
+
+// countLinesChanged is void; it feeds the running total via addToTotalLinesChanged.
+// Measure the delta it contributes for a given call.
+function addedLinesFor(newFileContent: string): number {
+  const before = getTotalLinesAdded()
+  countLinesChanged([], newFileContent)
+  return getTotalLinesAdded() - before
+}
+
+describe('countLinesChanged — new file additions', () => {
+  test('a newline-terminated file counts one addition per content line, like git', () => {
+    // "a\nb\n" is a 2-line file; git reports 2 additions, not 3. The trailing
+    // newline must not be counted as an extra empty line.
+    expect(addedLinesFor('a\nb\n')).toBe(2)
+    expect(addedLinesFor('line1\nline2\nline3\n')).toBe(3)
+    expect(addedLinesFor('only\n')).toBe(1)
+  })
+
+  test('a file without a trailing newline counts each line', () => {
+    expect(addedLinesFor('a\nb')).toBe(2)
+    expect(addedLinesFor('single')).toBe(1)
+  })
+
+  test('CRLF line endings are counted the same as LF', () => {
+    expect(addedLinesFor('a\r\nb\r\n')).toBe(2)
+    expect(addedLinesFor('a\r\nb')).toBe(2)
+  })
+})

--- a/src/utils/diff.ts
+++ b/src/utils/diff.ts
@@ -53,8 +53,13 @@ export function countLinesChanged(
   let numRemovals = 0
 
   if (patch.length === 0 && newFileContent) {
-    // For new files, count all lines as additions
-    numAdditions = newFileContent.split(/\r?\n/).length
+    // For new files, count all lines as additions — the way git does. Splitting
+    // on newlines yields a trailing empty element for content that ends in a
+    // newline (the normal case), so a 2-line file "a\nb\n" would otherwise count
+    // as 3. Drop that phantom line when the content is newline-terminated so the
+    // count matches the diff-based update path (and git's own `+` line count).
+    const lines = newFileContent.split(/\r?\n/)
+    numAdditions = /\r?\n$/.test(newFileContent) ? lines.length - 1 : lines.length
   } else {
     numAdditions = patch.reduce(
       (acc, hunk) => acc + count(hunk.lines, _ => _.startsWith('+')),


### PR DESCRIPTION
## Summary

`countLinesChanged` has a dedicated branch for new files (used by `FileWriteTool` when writing a file that did not exist), which counts every content line as an addition:

```ts
if (patch.length === 0 && newFileContent) {
  // For new files, count all lines as additions
  numAdditions = newFileContent.split(/\r?\n/).length
}
```

Splitting on newlines produces a trailing empty element when the content ends in a newline — which is the normal case for a text file. So a 2-line file `"a\nb\n"` is counted as **3** additions instead of 2, `"line1\nline2\nline3\n"` as 4 instead of 3, and so on. Git reports 2 `+` lines for a 2-line new file, and the diff-based update path in the same function counts `+`-prefixed hunk lines git-accurately — so the create path is off by one against both.

The inflated count feeds the `tengu_file_changed` analytics event (`lines_added`) and the process-wide total-lines-changed counter (`addToTotalLinesChanged` → session stats), so nearly every new file overstates added lines by one.

## Fix

Drop the phantom trailing element when the content is newline-terminated, matching git and the update path. Content without a trailing newline (and CRLF endings) are unaffected.

## Testing

New `src/utils/diff.test.ts` measures the delta `countLinesChanged` contributes to the running total:
- `"a\nb\n"` → 2, `"line1\nline2\nline3\n"` → 3, `"only\n"` → 1 (newline-terminated).
- `"a\nb"` → 2, `"single"` → 1 (no trailing newline, already correct).
- CRLF (`"a\r\nb\r\n"`) counts the same as LF.

Reverting to the plain `.split(...).length` re-fails the newline-terminated and CRLF assertions.

```
bun test src/utils/diff.test.ts   # pass
bun run typecheck                 # clean
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected line-change counting for newly added files so trailing newlines no longer add an extra phantom line.
  * Ensured files with LF and CRLF line endings are counted consistently.
  * Added test coverage for newline-terminated content, files without a trailing newline, and Windows-style line endings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->