### PR TITLE
fix: isolate OpenClaude config from Claude Code

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,9 +146,10 @@ or network service, and permission/provider/model/settings flags are passed to
 the child process the same way they are for a foreground `--print` run. Session
 metadata and logs are stored under the resolved OpenClaude config directory,
 usually `~/.openclaude/bg-sessions/`; `OPENCLAUDE_CONFIG_DIR` can point
-OpenClaude somewhere else, with `CLAUDE_CONFIG_DIR` still supported as the
-legacy fallback. Session names can be reused after older sessions reach a
-terminal state; use the session ID to inspect older logs with the same name.
+OpenClaude somewhere else. `CLAUDE_CONFIG_DIR` is ignored for OpenClaude
+background-session storage. Session names can be reused after older sessions
+reach a terminal state; use the session ID to inspect older logs with the same
+name.
 
 `openclaude attach <id-or-name>` currently reports the matching session and
 points to `openclaude logs <id> -f`; full terminal reattach is not implemented

--- a/README.md
+++ b/README.md
@@ -155,6 +155,20 @@ name.
 points to `openclaude logs <id> -f`; full terminal reattach is not implemented
 for local background sessions yet.
 
+### OpenClaude config cutover
+
+OpenClaude stores its own config under `~/.openclaude` and `~/.openclaude.json`
+by default. It does not read `~/.claude`, project `.claude/` directories, or
+`CLAUDE_CONFIG_DIR`; new users can start with an empty OpenClaude config and do
+not need Claude Code installed.
+
+If you previously used OpenClaude with `.claude` paths, migrate intentionally:
+copy only the settings, commands, agents, skills, scheduled tasks, or other files
+you personally created for OpenClaude into the matching `.openclaude` location.
+Do not blanket-copy `.claude`, and do not copy Claude Code credentials or auth
+files. For provider authentication, prefer running OpenClaude's provider setup
+again or exporting provider-specific environment variables.
+
 ### Fastest OpenAI setup
 
 macOS / Linux:

--- a/src/cli/handlers/skills.test.ts
+++ b/src/cli/handlers/skills.test.ts
@@ -762,7 +762,7 @@ test.serial('removes only the targeted project skill directory', async () => {
   }
 })
 
-test.serial('removes legacy project skills from .claude directories', async () => {
+test.serial('does not remove legacy project skills from .claude directories', async () => {
   await acquireSharedMutationLock('skillsRemoveHandler')
   const originalFs = getFsImplementation()
   try {
@@ -792,13 +792,13 @@ test.serial('removes legacy project skills from .claude directories', async () =
       try {
         process.exitCode = 0
         await skillsRemoveHandler(targetName, { projectDir: cwd })
-        assert.equal(process.exitCode, 0)
+        assert.equal(process.exitCode, 1)
       } finally {
         restoreSettingState(originalSettingsState)
         clearCommandsCache()
       }
 
-      assert.equal(existsSync(target), false)
+      assert.equal(existsSync(target), true)
     })
   } finally {
     setFsImplementation(originalFs)

--- a/src/commands/init-verifiers.ts
+++ b/src/commands/init-verifiers.ts
@@ -162,9 +162,9 @@ Based on the areas detected in Phase 1, you may need to create multiple verifier
 
 ## Phase 4: Generate Verifier Skill
 
-**All verifier skills are created in the project root's \`.claude/skills/\` directory.** This ensures they are automatically loaded when Claude runs in the project.
+**All verifier skills are created in the project root's \`.openclaude/skills/\` directory.** This ensures they are automatically loaded when Claude runs in the project.
 
-Write the skill file to \`.claude/skills/<verifier-name>/SKILL.md\`.
+Write the skill file to \`.openclaude/skills/<verifier-name>/SKILL.md\`.
 
 ### Skill Template Structure
 
@@ -248,7 +248,7 @@ allowed-tools:
 ## Phase 5: Confirm Creation
 
 After writing the skill file(s), inform the user:
-1. Where each skill was created (always in \`.claude/skills/\`)
+1. Where each skill was created (always in \`.openclaude/skills/\`)
 2. How the Verify agent will discover them — the folder name must contain "verifier" (case-insensitive) for automatic discovery
 3. That they can edit the skills to customize them
 4. That they can run /init-verifiers again to add more verifiers for other areas

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -42,7 +42,7 @@ Use AskUserQuestion to find out what the user wants:
 
 ## Phase 2: Explore the codebase
 
-Launch a subagent to survey the codebase, and ask it to read key files to understand the project: manifest files (package.json, Cargo.toml, pyproject.toml, go.mod, pom.xml, etc.), README, Makefile/build configs, CI config, existing CLAUDE.md, .claude/rules/, AGENTS.md, .cursor/rules or .cursorrules, .github/copilot-instructions.md, .windsurfrules, .clinerules, .mcp.json.
+Launch a subagent to survey the codebase, and ask it to read key files to understand the project: manifest files (package.json, Cargo.toml, pyproject.toml, go.mod, pom.xml, etc.), README, Makefile/build configs, CI config, existing CLAUDE.md, .openclaude/rules/, AGENTS.md, .cursor/rules or .cursorrules, .github/copilot-instructions.md, .windsurfrules, .clinerules, .mcp.json.
 
 Detect:
 - Build, test, and lint commands (especially non-standard ones)
@@ -50,7 +50,7 @@ Detect:
 - Project structure (monorepo with workspaces, multi-module, or single project)
 - Code style rules that differ from language defaults
 - Non-obvious gotchas, required env vars, or workflow quirks
-- Existing .claude/skills/ and .claude/rules/ directories
+- Existing .openclaude/skills/ and .openclaude/rules/ directories
 - Formatter configuration (prettier, biome, ruff, black, gofmt, rustfmt, or a unified format script like \`npm run format\` / \`make fmt\`)
 - Git worktree usage: run \`git worktree list\` to check if this repo has multiple worktrees (only relevant if the user wants a personal CLAUDE.local.md)
 
@@ -66,7 +66,7 @@ If the user chose personal CLAUDE.local.md or both: ask about them, not the code
   - What's their role on the team? (e.g., "backend engineer", "data scientist", "new hire onboarding")
   - How familiar are they with this codebase and its languages/frameworks? (so Claude can calibrate explanation depth)
   - Do they have personal sandbox URLs, test accounts, API key paths, or local setup details Claude should know?
-  - Only if Phase 2 found multiple git worktrees: ask whether their worktrees are nested inside the main repo (e.g., \`.claude/worktrees/<name>/\`) or siblings/external (e.g., \`../myrepo-feature/\`). If nested, the upward file walk finds the main repo's CLAUDE.local.md automatically — no special handling needed. If sibling/external, the personal content should live in a home-directory file (e.g., \`~/.claude/<project-name>-instructions.md\`) and each worktree gets a one-line CLAUDE.local.md stub that imports it: \`@~/.claude/<project-name>-instructions.md\`. Never put this import in the project AGENTS.md — that would check a personal reference into the team-shared file.
+  - Only if Phase 2 found multiple git worktrees: ask whether their worktrees are nested inside the main repo (e.g., \`.openclaude/worktrees/<name>/\`) or siblings/external (e.g., \`../myrepo-feature/\`). If nested, the upward file walk finds the main repo's CLAUDE.local.md automatically — no special handling needed. If sibling/external, the personal content should live in a home-directory file (e.g., \`~/.openclaude/<project-name>-instructions.md\`) and each worktree gets a one-line CLAUDE.local.md stub that imports it: \`@~/.openclaude/<project-name>-instructions.md\`. Never put this import in the project AGENTS.md — that would check a personal reference into the team-shared file.
   - Any communication preferences? (e.g., "be terse", "always explain tradeoffs", "don't summarize at the end")
 
 **Synthesize a proposal from Phase 2 findings** — e.g., format-on-edit if a formatter exists, a project verification workflow if tests exist, an AGENTS.md note for anything from the gap-fill answers that's a guideline rather than a workflow. For each, pick the artifact type that fits, **constrained by the Phase 1 skills+hooks choice**:
@@ -131,7 +131,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 If AGENTS.md already exists: read it, propose specific changes as diffs, and explain why each change improves it. Do not silently overwrite.
 
-For projects with multiple concerns, suggest organizing instructions into \`.claude/rules/\` as separate focused files (e.g., \`code-style.md\`, \`testing.md\`, \`security.md\`). These are loaded automatically alongside AGENTS.md and can be scoped to specific file paths using \`paths\` frontmatter.
+For projects with multiple concerns, suggest organizing instructions into \`.openclaude/rules/\` as separate focused files (e.g., \`code-style.md\`, \`testing.md\`, \`security.md\`). These are loaded automatically alongside AGENTS.md and can be scoped to specific file paths using \`paths\` frontmatter.
 
 For projects with distinct subdirectories (monorepos, multi-module projects, etc.): mention that subdirectory AGENTS.md files can be added for module-specific instructions (they're loaded automatically when Claude works in those directories). Offer to create them if the user wants.
 
@@ -148,7 +148,7 @@ Include:
 
 Keep it short — only include what would make Claude's responses noticeably better for this user.
 
-If Phase 2 found multiple git worktrees and the user confirmed they use sibling/external worktrees (not nested inside the main repo): the upward file walk won't find a single CLAUDE.local.md from all worktrees. Write the actual personal content to \`~/.claude/<project-name>-instructions.md\` and make CLAUDE.local.md a one-line stub that imports it: \`@~/.claude/<project-name>-instructions.md\`. The user can copy this one-line stub to each sibling worktree. Never put this import in the project AGENTS.md. If worktrees are nested inside the main repo (e.g., \`.claude/worktrees/\`), no special handling is needed — the main repo's CLAUDE.local.md is found automatically.
+If Phase 2 found multiple git worktrees and the user confirmed they use sibling/external worktrees (not nested inside the main repo): the upward file walk won't find a single CLAUDE.local.md from all worktrees. Write the actual personal content to \`~/.openclaude/<project-name>-instructions.md\` and make CLAUDE.local.md a one-line stub that imports it: \`@~/.openclaude/<project-name>-instructions.md\`. The user can copy this one-line stub to each sibling worktree. Never put this import in the project AGENTS.md. If worktrees are nested inside the main repo (e.g., \`.openclaude/worktrees/\`), no special handling is needed — the main repo's CLAUDE.local.md is found automatically.
 
 If CLAUDE.local.md already exists: read it, propose specific additions, and do not silently overwrite.
 
@@ -167,9 +167,9 @@ Skills add capabilities Claude can use on demand without bloating every session.
 
 For each suggested skill, provide: name, one-line purpose, and why it fits this repo.
 
-If \`.claude/skills/\` already exists with skills, review them first. Do not overwrite existing skills — only propose new ones that complement what is already there.
+If \`.openclaude/skills/\` already exists with skills, review them first. Do not overwrite existing skills — only propose new ones that complement what is already there.
 
-Create each skill at \`.claude/skills/<skill-name>/SKILL.md\`:
+Create each skill at \`.openclaude/skills/<skill-name>/SKILL.md\`:
 
 \`\`\`yaml
 ---

--- a/src/commands/onboard-github/onboard-github.tsx
+++ b/src/commands/onboard-github/onboard-github.tsx
@@ -407,7 +407,7 @@ function OnboardGithub(props: {
         : 'GitHub Copilot onboard complete. '
       onDone(
         successMsg +
-          'Copilot token and OAuth token stored in secure storage (Windows/Linux: ~/.claude/.credentials.json, macOS: Keychain fallback to ~/.claude/.credentials.json); user settings updated. Restart if the model does not switch.',
+          'Copilot token and OAuth token stored in secure storage (Windows/Linux: ~/.openclaude/.credentials.json, macOS: Keychain fallback to ~/.openclaude/.credentials.json); user settings updated. Restart if the model does not switch.',
         { display: 'user' },
       )
     },
@@ -466,7 +466,7 @@ function OnboardGithub(props: {
       if (!activated.ok) {
         setErrorMsg(
           `Key saved, but settings were not updated: ${activated.detail ?? 'unknown error'}. ` +
-            `Add env CLAUDE_CODE_USE_GITHUB=1 and OPENAI_MODEL to ~/.claude/settings.json manually.`,
+            `Add env CLAUDE_CODE_USE_GITHUB=1 and OPENAI_MODEL to ~/.openclaude/settings.json manually.`,
         )
         setStep('error')
         return

--- a/src/components/agents/agentFileUtils.ts
+++ b/src/components/agents/agentFileUtils.ts
@@ -72,7 +72,7 @@ function getAgentDirectoryPath(location: SettingSource): string {
     case 'projectSettings':
       return join(getCwd(), AGENT_PATHS.FOLDER_NAME, AGENT_PATHS.AGENTS_DIR)
     case 'policySettings':
-      return join(getManagedFilePath(), '.claude', AGENT_PATHS.AGENTS_DIR)
+      return join(getManagedFilePath(), AGENT_PATHS.FOLDER_NAME, AGENT_PATHS.AGENTS_DIR)
     case 'localSettings':
       return join(getCwd(), AGENT_PATHS.FOLDER_NAME, AGENT_PATHS.AGENTS_DIR)
   }

--- a/src/components/agents/new-agent-creation/wizard-steps/MemoryStep.tsx
+++ b/src/components/agents/new-agent-creation/wizard-steps/MemoryStep.tsx
@@ -37,28 +37,28 @@ export function MemoryStep() {
   let t1;
   if ($[1] !== isUserScope) {
     t1 = isUserScope ? [{
-      label: "User scope (~/.claude/agent-memory/) (Recommended)",
+      label: "User scope (~/.openclaude/agent-memory/) (Recommended)",
       value: "user"
     }, {
       label: "None (no persistent memory)",
       value: "none"
     }, {
-      label: "Project scope (.claude/agent-memory/)",
+      label: "Project scope (.openclaude/agent-memory/)",
       value: "project"
     }, {
-      label: "Local scope (.claude/agent-memory-local/)",
+      label: "Local scope (.openclaude/agent-memory-local/)",
       value: "local"
     }] : [{
-      label: "Project scope (.claude/agent-memory/) (Recommended)",
+      label: "Project scope (.openclaude/agent-memory/) (Recommended)",
       value: "project"
     }, {
       label: "None (no persistent memory)",
       value: "none"
     }, {
-      label: "User scope (~/.claude/agent-memory/)",
+      label: "User scope (~/.openclaude/agent-memory/)",
       value: "user"
     }, {
-      label: "Local scope (.claude/agent-memory-local/)",
+      label: "Local scope (.openclaude/agent-memory-local/)",
       value: "local"
     }];
     $[1] = isUserScope;

--- a/src/components/permissions/FilePermissionDialog/permissionOptions.tsx
+++ b/src/components/permissions/FilePermissionDialog/permissionOptions.tsx
@@ -1,5 +1,4 @@
-import { homedir } from 'os';
-import { basename, join, sep } from 'path';
+import { basename, sep } from 'path';
 import React, { type ReactNode } from 'react';
 import { getOriginalCwd } from '../../../bootstrap/state.js';
 import { PRODUCT_DISPLAY_NAME } from '../../../constants/product.js';
@@ -10,33 +9,32 @@ import { expandPath, getDirectoryForPath } from '../../../utils/path.js';
 import { normalizeCaseForComparison, pathInAllowedWorkingPath } from '../../../utils/permissions/filesystem.js';
 import type { OptionWithDescription } from '../../CustomSelect/select.js';
 /**
- * Check if a path is within the project's .claude/ folder.
- * This is used to determine whether to show the special ".claude folder" permission option.
+ * Check if a path is within the project's .openclaude/ folder.
+ * This is used to determine whether to show the special OpenClaude folder permission option.
  */
 export function isInClaudeFolder(filePath: string): boolean {
   const absolutePath = expandPath(filePath);
-  const claudeFolderPath = expandPath(`${getOriginalCwd()}/.claude`);
+  const claudeFolderPath = expandPath(`${getOriginalCwd()}/.openclaude`);
 
-  // Check if the path is within the project's .claude folder
+  // Check if the path is within the project's .openclaude folder
   const normalizedAbsolutePath = normalizeCaseForComparison(absolutePath);
   const normalizedClaudeFolderPath = normalizeCaseForComparison(claudeFolderPath);
 
-  // Path must start with the .claude folder path (and be inside it, not just the folder itself)
+  // Path must start with the .openclaude folder path (and be inside it, not just the folder itself)
   return normalizedAbsolutePath.startsWith(normalizedClaudeFolderPath + sep.toLowerCase()) ||
   // Also match case where sep is / on posix systems
   normalizedAbsolutePath.startsWith(normalizedClaudeFolderPath + '/');
 }
 
 /**
- * Check if a path is within the global ~/.openclaude/ folder, or the legacy
- * ~/.claude/ folder during migration.
- * This is used to determine whether to show the special ".claude folder" permission option
+ * Check if a path is within the global ~/.openclaude/ folder.
+ * This is used to determine whether to show the special OpenClaude folder permission option
  * for files in the user's home directory.
  */
 export function isInGlobalClaudeFolder(filePath: string): boolean {
   const absolutePath = expandPath(filePath);
   const normalizedAbsolutePath = normalizeCaseForComparison(absolutePath);
-  const globalClaudeFolderPaths = [join(homedir(), '.openclaude'), join(homedir(), '.claude')];
+  const globalClaudeFolderPaths = [expandPath('~/.openclaude')];
 
   return globalClaudeFolderPaths.some(globalClaudeFolderPath => {
     const normalizedGlobalClaudeFolderPath = normalizeCaseForComparison(globalClaudeFolderPath);
@@ -103,11 +101,11 @@ export function getFilePermissionOptions({
   const inAllowedPath = pathInAllowedWorkingPath(filePath, toolPermissionContext);
   const showFullAccessOption = toolPermissionContext.isBypassPermissionsModeAvailable;
 
-  // Check if this is a .claude/ folder path (project or global)
+  // Check if this is a .openclaude/ folder path (project or global)
   const inClaudeFolder = isInClaudeFolder(filePath);
   const inGlobalClaudeFolder = isInGlobalClaudeFolder(filePath);
 
-  // Option 2: For .claude/ folder, show special option instead of generic session option
+  // Option 2: For .openclaude/ folder, show special option instead of generic session option
   // Note: Session-level options are always shown since they only affect in-memory state,
   // not persisted settings. The allowManagedPermissionRulesOnly setting only restricts
   // persisted permission rules.

--- a/src/components/skills/SkillsMenu.tsx
+++ b/src/components/skills/SkillsMenu.tsx
@@ -51,7 +51,7 @@ function getSkillListLabel(skill: SkillCommand): string {
   return leafName === skill.name ? skill.name : `${skill.name} - ${leafName}`;
 }
 export function getEmptySkillsMenuMessage(): string {
-  return `Create skills in .claude/skills/<name>/SKILL.md or ${getUserSkillExampleDisplayPath()}`;
+  return `Create skills in .openclaude/skills/<name>/SKILL.md or ${getUserSkillExampleDisplayPath()}`;
 }
 export function SkillsMenu(t0) {
   const $ = _c(35);

--- a/src/entrypoints/agentSdkTypes.ts
+++ b/src/entrypoints/agentSdkTypes.ts
@@ -77,7 +77,7 @@ export type {
 // ============================================================================
 
 /**
- * A scheduled task from `<dir>/.claude/scheduled_tasks.json`.
+ * A scheduled task from `<dir>/.openclaude/scheduled_tasks.json`.
  * @internal
  */
 export type CronTask = {
@@ -128,7 +128,7 @@ export type ScheduledTasksHandle = {
 }
 
 /**
- * Watch `<dir>/.claude/scheduled_tasks.json` and yield events as tasks fire.
+ * Watch `<dir>/.openclaude/scheduled_tasks.json` and yield events as tasks fire.
  *
  * Acquires the per-directory scheduler lock (PID-based liveness) so a REPL
  * session in the same dir won't double-fire. Releases the lock and closes

--- a/src/entrypoints/sdk/coreSchemas.ts
+++ b/src/entrypoints/sdk/coreSchemas.ts
@@ -1197,7 +1197,7 @@ export const AgentDefinitionSchema = lazySchema(() =>
         .enum(['user', 'project', 'local'])
         .optional()
         .describe(
-          "Scope for auto-loading agent memory files. 'user' - ~/.claude/agent-memory/<agentType>/, 'project' - .claude/agent-memory/<agentType>/, 'local' - .claude/agent-memory-local/<agentType>/",
+          "Scope for auto-loading agent memory files. 'user' - ~/.openclaude/agent-memory/<agentType>/, 'project' - .openclaude/agent-memory/<agentType>/, 'local' - .openclaude/agent-memory-local/<agentType>/",
         ),
       effort: z
         .union([z.enum(['low', 'medium', 'high', 'xhigh', 'max']), z.number().int()])

--- a/src/outputStyles/loadOutputStylesDir.ts
+++ b/src/outputStyles/loadOutputStylesDir.ts
@@ -11,15 +11,15 @@ import {
 import { clearPluginOutputStyleCache } from '../utils/plugins/loadPluginOutputStyles.js'
 
 /**
- * Loads markdown files from .claude/output-styles directories throughout the project
- * and from ~/.claude/output-styles directory and converts them to output styles.
+ * Loads markdown files from .openclaude/output-styles directories throughout the project
+ * and from ~/.openclaude/output-styles directory and converts them to output styles.
  *
  * Each filename becomes a style name, and the file content becomes the style prompt.
  * The frontmatter provides name and description.
  *
  * Structure:
- * - Project .claude/output-styles/*.md -> project styles
- * - User ~/.claude/output-styles/*.md -> user styles (overridden by project styles)
+ * - Project .openclaude/output-styles/*.md -> project styles
+ * - User ~/.openclaude/output-styles/*.md -> user styles (overridden by project styles)
  *
  * @param cwd Current working directory for project directory traversal
  */

--- a/src/screens/Doctor.tsx
+++ b/src/screens/Doctor.tsx
@@ -166,7 +166,7 @@ export function Doctor(t0: Props) {
     );
     (async () => {
       const userAgentsDir = join(getClaudeConfigHomeDir(), "agents");
-      const projectAgentsDir = join(getOriginalCwd(), ".claude", "agents");
+      const projectAgentsDir = join(getOriginalCwd(), ".openclaude", "agents");
       const {
         activeAgents,
         allAgents,

--- a/src/services/analytics/growthbook.ts
+++ b/src/services/analytics/growthbook.ts
@@ -4,9 +4,9 @@
  *
  * OpenClaude does not phone home. This module replaces the original
  * analytics-driven GrowthBook client with a local-only implementation that
- * reads feature flags from ~/.claude/feature-flags.json for developer overrides.
+ * reads feature flags from ~/.openclaude/feature-flags.json for developer overrides.
  *
- * Priority: CLAUDE_FEATURE_FLAGS_FILE env > ~/.claude/feature-flags.json > defaultValue
+ * Priority: CLAUDE_FEATURE_FLAGS_FILE env > ~/.openclaude/feature-flags.json > defaultValue
  */
 
 import { existsSync, readFileSync } from 'node:fs'
@@ -30,7 +30,7 @@ function _loadFlags(): void {
 	try {
 		const flagsPath =
 			process.env.CLAUDE_FEATURE_FLAGS_FILE ||
-			join(homedir(), '.claude', 'feature-flags.json')
+			join(homedir(), '.openclaude', 'feature-flags.json')
 		const parsed = JSON.parse(readFileSync(flagsPath, 'utf-8'))
 		_flags =
 			parsed && typeof parsed === 'object' && !Array.isArray(parsed) ? parsed : null

--- a/src/services/analytics/growthbook.ts
+++ b/src/services/analytics/growthbook.ts
@@ -6,7 +6,7 @@
  * analytics-driven GrowthBook client with a local-only implementation that
  * reads feature flags from ~/.openclaude/feature-flags.json for developer overrides.
  *
- * Priority: CLAUDE_FEATURE_FLAGS_FILE env > ~/.openclaude/feature-flags.json > defaultValue
+ * Priority: OPENCLAUDE_FEATURE_FLAGS_FILE env > CLAUDE_FEATURE_FLAGS_FILE env > ~/.openclaude/feature-flags.json > defaultValue
  */
 
 import { existsSync, readFileSync } from 'node:fs'
@@ -29,6 +29,7 @@ function _loadFlags(): void {
 	if (_flags !== undefined) return
 	try {
 		const flagsPath =
+			process.env.OPENCLAUDE_FEATURE_FLAGS_FILE ||
 			process.env.CLAUDE_FEATURE_FLAGS_FILE ||
 			join(homedir(), '.openclaude', 'feature-flags.json')
 		const parsed = JSON.parse(readFileSync(flagsPath, 'utf-8'))

--- a/src/services/settingsSync/types.ts
+++ b/src/services/settingsSync/types.ts
@@ -59,9 +59,9 @@ export type SettingsSyncUploadResult = {
  * Keys used for sync entries
  */
 export const SYNC_KEYS = {
-  USER_SETTINGS: '~/.claude/settings.json',
-  USER_MEMORY: '~/.claude/CLAUDE.md',
+  USER_SETTINGS: '~/.openclaude/settings.json',
+  USER_MEMORY: '~/.openclaude/CLAUDE.md',
   projectSettings: (projectId: string) =>
-    `projects/${projectId}/.claude/settings.local.json`,
+    `projects/${projectId}/.openclaude/settings.local.json`,
   projectMemory: (projectId: string) => `projects/${projectId}/CLAUDE.local.md`,
 } as const

--- a/src/services/tips/tipRegistry.ts
+++ b/src/services/tips/tipRegistry.ts
@@ -59,7 +59,7 @@ import { getSessionsSinceLastShown } from './tipHistory.js'
 import type { Tip, TipContext } from './types.js'
 
 export function getCustomCommandsTipContent(): string {
-  return `Create skills at .claude/skills/<name>/SKILL.md in your project or ${getUserSkillExampleDisplayPath()} for skills that work in any project`
+  return `Create skills at .openclaude/skills/<name>/SKILL.md in your project or ${getUserSkillExampleDisplayPath()} for skills that work in any project`
 }
 
 let _isOfficialMarketplaceInstalledCache: boolean | undefined

--- a/src/skills/bundled/loop.test.ts
+++ b/src/skills/bundled/loop.test.ts
@@ -29,7 +29,7 @@ test('bare /loop returns dynamic maintenance instructions', async () => {
   const text = (blocks[0] as { text: string }).text
 
   expect(text).toContain('# /loop — dynamic rescheduling')
-  expect(text).toContain('If .claude/loop.md exists, read it and use it.')
+  expect(text).toContain('If .openclaude/loop.md exists, read it and use it.')
   expect(text).toContain('continue any unfinished work from the conversation')
   expect(text).toContain('Set the scheduled prompt to this exact text so the next iteration stays in dynamic mode:')
   expect(text).toContain('/loop')

--- a/src/skills/bundled/loop.ts
+++ b/src/skills/bundled/loop.ts
@@ -23,8 +23,8 @@ const DYNAMIC_MAX_DELAY = '1 hour'
 
 const MAINTENANCE_PROMPT = `Scheduled maintenance loop iteration.
 
-If .claude/loop.md exists, read it and follow it.
-Otherwise, if ~/.claude/loop.md exists, read it and follow it.
+If .openclaude/loop.md exists, read it and follow it.
+Otherwise, if ~/.openclaude/loop.md exists, read it and follow it.
 Otherwise:
 - continue any unfinished work from the conversation
 - tend to the current branch's pull request: review comments, failed CI runs, merge conflicts
@@ -161,8 +161,8 @@ ${parsed.prompt}
     : `This is a maintenance loop with no explicit prompt.
 
 Determine the effective prompt in this order:
-1. If .claude/loop.md exists, read it and use it.
-2. Otherwise, if ~/.claude/loop.md exists, read it and use it.
+1. If .openclaude/loop.md exists, read it and use it.
+2. Otherwise, if ~/.openclaude/loop.md exists, read it and use it.
 3. Otherwise, use this built-in maintenance prompt:
 
 --- BEGIN MAINTENANCE PROMPT ---

--- a/src/skills/loadSkillsDir.test.ts
+++ b/src/skills/loadSkillsDir.test.ts
@@ -46,7 +46,7 @@ function writeSkill(
 ): void {
   const skillDir = join(
     rootDir,
-    options?.configDirName ?? '.claude',
+    options?.configDirName ?? '.openclaude',
     'skills',
     ...skillPath.split('/'),
   )
@@ -102,7 +102,7 @@ function setRealFilesystemForTest(): ReturnType<typeof getFsImplementation> {
 function setConfigDirEnv(configDir: string): void {
   setClaudeConfigHomeDirForTesting(undefined)
   process.env.OPENCLAUDE_CONFIG_DIR = configDir
-  process.env.CLAUDE_CONFIG_DIR = configDir
+  delete process.env.CLAUDE_CONFIG_DIR
 }
 
 function restoreConfigDirEnv(original: {
@@ -147,7 +147,7 @@ test.serial('loads flat and nested skills with colon namespaces', async () => {
     clearSkillAndConfigCaches()
 
     const skills = await getSkillDirCommands(cwd)
-    const fixtureSkillsRoot = join(configDir, '.claude', 'skills')
+    const fixtureSkillsRoot = join(configDir, '.openclaude', 'skills')
     const promptSkills = skills.filter(
       (
         skill,
@@ -167,7 +167,7 @@ test.serial('loads flat and nested skills with colon namespaces', async () => {
 
     const nestedSkill = promptSkills.find(skill => skill.name === 'git:commit')
     assert.ok(nestedSkill)
-    assert.equal(nestedSkill.skillRoot, join(configDir, '.claude', 'skills', 'git', 'commit'))
+    assert.equal(nestedSkill.skillRoot, join(configDir, '.openclaude', 'skills', 'git', 'commit'))
 
     const deepSkill = promptSkills.find(
       skill => skill.name === 'frontend:react:form',
@@ -175,7 +175,7 @@ test.serial('loads flat and nested skills with colon namespaces', async () => {
     assert.ok(deepSkill)
     assert.equal(
       deepSkill.skillRoot,
-      join(configDir, '.claude', 'skills', 'frontend', 'react', 'form'),
+      join(configDir, '.openclaude', 'skills', 'frontend', 'react', 'form'),
     )
   } finally {
     try {
@@ -190,7 +190,7 @@ test.serial('loads flat and nested skills with colon namespaces', async () => {
   }
 })
 
-test.serial('prefers .openclaude project skills over legacy .claude skills with the same name', async () => {
+test.serial('ignores legacy .claude project skills when .openclaude skills exist', async () => {
   await acquireSharedMutationLock('loadSkillsDir.test.ts')
   const configDir = mkdtempSync(join(tmpdir(), 'openclaude-skills-'))
   const cwd = join(configDir, 'workspace')
@@ -221,7 +221,7 @@ test.serial('prefers .openclaude project skills over legacy .claude skills with 
       skill => skill.type === 'prompt' && skill.name === 'shared',
     )
 
-    assert.equal(sharedSkills.length, 2)
+    assert.equal(sharedSkills.length, 1)
     assert.equal(sharedSkills[0]?.type, 'prompt')
     assert.equal(sharedSkills[0]?.description, 'native project skill')
     assert.match(sharedSkills[0]?.skillRoot ?? '', /\.openclaude/)
@@ -362,7 +362,6 @@ test.serial('dynamic discovery checks .openclaude skill directories', async () =
     })
 
     assert.deepEqual(getProjectSkillsPaths(featureDir), [
-      join(featureDir, '.claude', 'skills'),
       join(featureDir, '.openclaude', 'skills'),
     ])
   } finally {

--- a/src/skills/loadSkillsDir.ts
+++ b/src/skills/loadSkillsDir.ts
@@ -82,7 +82,7 @@ export function getSkillsPath(
 ): string {
   switch (source) {
     case 'policySettings':
-      return join(getManagedFilePath(), '.claude', dir)
+      return join(getManagedFilePath(), '.openclaude', dir)
     case 'userSettings':
       return join(getClaudeConfigHomeDir(), dir)
     case 'projectSettings':
@@ -774,7 +774,7 @@ async function loadSkillsFromCommandsDir(
 export const getSkillDirCommands = memoize(
   async (cwd: string): Promise<Command[]> => {
     const userSkillsDir = join(getClaudeConfigHomeDir(), 'skills')
-    const managedSkillsDir = join(getManagedFilePath(), '.claude', 'skills')
+    const managedSkillsDir = join(getManagedFilePath(), '.openclaude', 'skills')
     const projectSkillsDirs = getProjectDirsUpToHome(
       'skills',
       cwd,

--- a/src/tools/AgentTool/agentMemory.ts
+++ b/src/tools/AgentTool/agentMemory.ts
@@ -9,7 +9,7 @@ import { getCwd } from '../../utils/cwd.js'
 import { findCanonicalGitRoot } from '../../utils/git.js'
 import { sanitizePath } from '../../utils/path.js'
 
-// Persistent agent memory scope: 'user' (~/.claude/agent-memory/), 'project' (.claude/agent-memory/), or 'local' (.claude/agent-memory-local/)
+// Persistent agent memory scope: 'user' (~/.openclaude/agent-memory/), 'project' (.openclaude/agent-memory/), or 'local' (.openclaude/agent-memory-local/)
 export type AgentMemoryScope = 'user' | 'project' | 'local'
 
 /**
@@ -24,7 +24,7 @@ function sanitizeAgentTypeForPath(agentType: string): string {
 /**
  * Returns the local agent memory directory, which is project-specific and not checked into VCS.
  * When CLAUDE_CODE_REMOTE_MEMORY_DIR is set, persists to the mount with project namespacing.
- * Otherwise, uses <cwd>/.claude/agent-memory-local/<agentType>/.
+ * Otherwise, uses <cwd>/.openclaude/agent-memory-local/<agentType>/.
  */
 function getLocalAgentMemoryDir(dirName: string): string {
   if (process.env.CLAUDE_CODE_REMOTE_MEMORY_DIR) {
@@ -40,13 +40,13 @@ function getLocalAgentMemoryDir(dirName: string): string {
       ) + sep
     )
   }
-  return join(getCwd(), '.claude', 'agent-memory-local', dirName) + sep
+  return join(getCwd(), '.openclaude', 'agent-memory-local', dirName) + sep
 }
 
 /**
  * Returns the agent memory directory for a given agent type and scope.
  * - 'user' scope: <memoryBase>/agent-memory/<agentType>/
- * - 'project' scope: <cwd>/.claude/agent-memory/<agentType>/
+ * - 'project' scope: <cwd>/.openclaude/agent-memory/<agentType>/
  * - 'local' scope: see getLocalAgentMemoryDir()
  */
 export function getAgentMemoryDir(
@@ -56,7 +56,7 @@ export function getAgentMemoryDir(
   const dirName = sanitizeAgentTypeForPath(agentType)
   switch (scope) {
     case 'project':
-      return join(getCwd(), '.claude', 'agent-memory', dirName) + sep
+      return join(getCwd(), '.openclaude', 'agent-memory', dirName) + sep
     case 'local':
       return getLocalAgentMemoryDir(dirName)
     case 'user':
@@ -77,7 +77,7 @@ export function isAgentMemoryPath(absolutePath: string): boolean {
 
   // Project scope: always cwd-based (not redirected)
   if (
-    normalizedPath.startsWith(join(getCwd(), '.claude', 'agent-memory') + sep)
+    normalizedPath.startsWith(join(getCwd(), '.openclaude', 'agent-memory') + sep)
   ) {
     return true
   }
@@ -94,7 +94,7 @@ export function isAgentMemoryPath(absolutePath: string): boolean {
     }
   } else if (
     normalizedPath.startsWith(
-      join(getCwd(), '.claude', 'agent-memory-local') + sep,
+      join(getCwd(), '.openclaude', 'agent-memory-local') + sep,
     )
   ) {
     return true
@@ -120,7 +120,7 @@ export function getMemoryScopeDisplay(
     case 'user':
       return `User (${join(getMemoryBaseDir(), 'agent-memory')}/)`
     case 'project':
-      return 'Project (.claude/agent-memory/)'
+      return 'Project (.openclaude/agent-memory/)'
     case 'local':
       return `Local (${getLocalAgentMemoryDir('...')})`
     default:
@@ -133,7 +133,7 @@ export function getMemoryScopeDisplay(
  * Creates the memory directory if needed and returns a prompt with memory contents.
  *
  * @param agentType The agent's type name (used as directory name)
- * @param scope 'user' for ~/.claude/agent-memory/ or 'project' for .claude/agent-memory/
+ * @param scope 'user' for ~/.openclaude/agent-memory/ or 'project' for .openclaude/agent-memory/
  */
 export function loadAgentMemoryPrompt(
   agentType: string,

--- a/src/tools/AgentTool/agentMemorySnapshot.ts
+++ b/src/tools/AgentTool/agentMemorySnapshot.ts
@@ -26,10 +26,10 @@ type SyncedMeta = z.infer<ReturnType<typeof syncedMetaSchema>>
 
 /**
  * Returns the path to the snapshot directory for an agent in the current project.
- * e.g., <cwd>/.claude/agent-memory-snapshots/<agentType>/
+ * e.g., <cwd>/.openclaude/agent-memory-snapshots/<agentType>/
  */
 export function getSnapshotDirForAgent(agentType: string): string {
-  return join(getCwd(), '.claude', SNAPSHOT_BASE, agentType)
+  return join(getCwd(), '.openclaude', SNAPSHOT_BASE, agentType)
 }
 
 function getSnapshotJsonPath(agentType: string): string {

--- a/src/tools/EnterWorktreeTool/prompt.ts
+++ b/src/tools/EnterWorktreeTool/prompt.ts
@@ -18,7 +18,7 @@ export function getEnterWorktreeToolPrompt(): string {
 
 ## Behavior
 
-- In a git repository: creates a new git worktree inside \`.claude/worktrees/\` with a new branch based on HEAD
+- In a git repository: creates a new git worktree inside \`.openclaude/worktrees/\` with a new branch based on HEAD
 - Outside a git repository: delegates to WorktreeCreate/WorktreeRemove hooks for VCS-agnostic isolation
 - Switches the session's working directory to the new worktree
 - Use ExitWorktree to leave the worktree mid-session (keep or remove). On session exit, if still in the worktree, the user will be prompted to keep or remove it

--- a/src/tools/FileEditTool/constants.ts
+++ b/src/tools/FileEditTool/constants.ts
@@ -1,14 +1,11 @@
 // In its own file to avoid circular dependencies
 export const FILE_EDIT_TOOL_NAME = 'Edit'
 
-// Permission pattern for granting session-level access to the project's .claude/ folder
-export const CLAUDE_FOLDER_PERMISSION_PATTERN = '/.claude/**'
+// Permission pattern for granting session-level access to the project's .openclaude/ folder
+export const CLAUDE_FOLDER_PERMISSION_PATTERN = '/.openclaude/**'
 
 // Permission pattern for granting session-level access to the global ~/.openclaude/ folder
 export const GLOBAL_CLAUDE_FOLDER_PERMISSION_PATTERN = '~/.openclaude/**'
-
-// Legacy alias kept so existing session-level rules still work during migration.
-export const LEGACY_GLOBAL_CLAUDE_FOLDER_PERMISSION_PATTERN = '~/.claude/**'
 
 export const FILE_UNEXPECTEDLY_MODIFIED_ERROR =
   'File has been unexpectedly modified. Read it again before attempting to write it.'

--- a/src/tools/ScheduleCronTool/CronCreateTool.ts
+++ b/src/tools/ScheduleCronTool/CronCreateTool.ts
@@ -37,7 +37,7 @@ const inputSchema = lazySchema(() =>
       `true (default) = fire on every cron match until deleted or auto-expired after ${DEFAULT_MAX_AGE_DAYS} days. false = fire once at the next match, then auto-delete. Use false for "remind me at X" one-shot requests with pinned minute/hour/dom/month.`,
     ),
     durable: semanticBoolean(z.boolean().optional()).describe(
-      'true = persist to .claude/scheduled_tasks.json and survive restarts. false (default) = in-memory only, dies when this Claude session ends. Use true only when the user asks the task to survive across sessions.',
+      'true = persist to .openclaude/scheduled_tasks.json and survive restarts. false (default) = in-memory only, dies when this Claude session ends. Use true only when the user asks the task to survive across sessions.',
     ),
   }),
 )
@@ -159,7 +159,7 @@ export const CronCreateTool = buildTool({
   },
   mapToolResultToToolResultBlockParam(output, toolUseID) {
     const where = output.durable
-      ? 'Persisted to .claude/scheduled_tasks.json'
+      ? 'Persisted to .openclaude/scheduled_tasks.json'
       : 'Session-only (not written to disk, dies when Claude exits)'
     return {
       tool_use_id: toolUseID,

--- a/src/tools/ScheduleCronTool/prompt.ts
+++ b/src/tools/ScheduleCronTool/prompt.ts
@@ -63,7 +63,7 @@ export const CRON_LIST_TOOL_NAME = 'CronList'
 
 export function buildCronCreateDescription(durableEnabled: boolean): string {
   return durableEnabled
-    ? 'Schedule a prompt to run at a future time — either recurring on a cron schedule, or once at a specific time. Pass durable: true to persist to .claude/scheduled_tasks.json; otherwise session-only.'
+    ? 'Schedule a prompt to run at a future time — either recurring on a cron schedule, or once at a specific time. Pass durable: true to persist to .openclaude/scheduled_tasks.json; otherwise session-only.'
     : 'Schedule a prompt to run at a future time within this Claude session — either recurring on a cron schedule, or once at a specific time.'
 }
 
@@ -71,13 +71,13 @@ export function buildCronCreatePrompt(durableEnabled: boolean): string {
   const durabilitySection = durableEnabled
     ? `## Durability
 
-By default (durable: false) the job lives only in this Claude session — nothing is written to disk, and the job is gone when Claude exits. Pass durable: true to write to .claude/scheduled_tasks.json so the job survives restarts. Only use durable: true when the user explicitly asks for the task to persist ("keep doing this every day", "set this up permanently"). Most "remind me in 5 minutes" / "check back in an hour" requests should stay session-only.`
+By default (durable: false) the job lives only in this Claude session — nothing is written to disk, and the job is gone when Claude exits. Pass durable: true to write to .openclaude/scheduled_tasks.json so the job survives restarts. Only use durable: true when the user explicitly asks for the task to persist ("keep doing this every day", "set this up permanently"). Most "remind me in 5 minutes" / "check back in an hour" requests should stay session-only.`
     : `## Session-only
 
 Jobs live only in this Claude session — nothing is written to disk, and the job is gone when Claude exits.`
 
   const durableRuntimeNote = durableEnabled
-    ? 'Durable jobs persist to .claude/scheduled_tasks.json and survive session restarts — on next launch they resume automatically. One-shot durable tasks that were missed while the REPL was closed are surfaced for catch-up. Session-only jobs die with the process. '
+    ? 'Durable jobs persist to .openclaude/scheduled_tasks.json and survive session restarts — on next launch they resume automatically. One-shot durable tasks that were missed while the REPL was closed are surfaced for catch-up. Session-only jobs die with the process. '
     : ''
 
   return `Schedule a prompt to be enqueued at a future time. Use for both recurring schedules and one-shot reminders.
@@ -119,13 +119,13 @@ Returns a job ID you can pass to ${CRON_DELETE_TOOL_NAME}.`
 export const CRON_DELETE_DESCRIPTION = 'Cancel a scheduled cron job by ID'
 export function buildCronDeletePrompt(durableEnabled: boolean): string {
   return durableEnabled
-    ? `Cancel a cron job previously scheduled with ${CRON_CREATE_TOOL_NAME}. Removes it from .claude/scheduled_tasks.json (durable jobs) or the in-memory session store (session-only jobs).`
+    ? `Cancel a cron job previously scheduled with ${CRON_CREATE_TOOL_NAME}. Removes it from .openclaude/scheduled_tasks.json (durable jobs) or the in-memory session store (session-only jobs).`
     : `Cancel a cron job previously scheduled with ${CRON_CREATE_TOOL_NAME}. Removes it from the in-memory session store.`
 }
 
 export const CRON_LIST_DESCRIPTION = 'List scheduled cron jobs'
 export function buildCronListPrompt(durableEnabled: boolean): string {
   return durableEnabled
-    ? `List all cron jobs scheduled via ${CRON_CREATE_TOOL_NAME}, both durable (.claude/scheduled_tasks.json) and session-only.`
+    ? `List all cron jobs scheduled via ${CRON_CREATE_TOOL_NAME}, both durable (.openclaude/scheduled_tasks.json) and session-only.`
     : `List all cron jobs scheduled via ${CRON_CREATE_TOOL_NAME} in this session.`
 }

--- a/src/tools/TeamCreateTool/prompt.ts
+++ b/src/tools/TeamCreateTool/prompt.ts
@@ -17,7 +17,7 @@ When spawning teammates via the Agent tool, choose the \`subagent_type\` based o
 
 - **Read-only agents** (e.g., Explore, Plan) cannot edit or write files. Only assign them research, search, or planning tasks. Never assign them implementation work.
 - **Full-capability agents** (e.g., general-purpose) have access to all tools including file editing, writing, and bash. Use these for tasks that require making changes.
-- **Custom agents** defined in \`.claude/agents/\` may have their own tool restrictions. Check their descriptions to understand what they can and cannot do.
+- **Custom agents** defined in \`.openclaude/agents/\` may have their own tool restrictions. Check their descriptions to understand what they can and cannot do.
 
 Always review the agent type descriptions and their available tools listed in the Agent tool prompt before selecting a \`subagent_type\` for a teammate.
 
@@ -31,8 +31,8 @@ Create a new team to coordinate multiple agents working on a project. Teams have
 \`\`\`
 
 This creates:
-- A team file at \`~/.claude/teams/{team-name}/config.json\`
-- A corresponding task list directory at \`~/.claude/tasks/{team-name}/\`
+- A team file at \`~/.openclaude/teams/{team-name}/config.json\`
+- A corresponding task list directory at \`~/.openclaude/tasks/{team-name}/\`
 
 ## Team Workflow
 
@@ -74,7 +74,7 @@ Teammates go idle after every turn—this is completely normal and expected. A t
 ## Discovering Team Members
 
 Teammates can read the team config file to discover other team members:
-- **Team config location**: \`~/.claude/teams/{team-name}/config.json\`
+- **Team config location**: \`~/.openclaude/teams/{team-name}/config.json\`
 
 The config file contains a \`members\` array with each teammate's:
 - \`name\`: Human-readable name (**always use this** for messaging and task assignment)
@@ -87,12 +87,12 @@ The config file contains a \`members\` array with each teammate's:
 
 Example of reading team config:
 \`\`\`
-Use the Read tool to read ~/.claude/teams/{team-name}/config.json
+Use the Read tool to read ~/.openclaude/teams/{team-name}/config.json
 \`\`\`
 
 ## Task List Coordination
 
-Teams share a task list that all teammates can access at \`~/.claude/tasks/{team-name}/\`.
+Teams share a task list that all teammates can access at \`~/.openclaude/tasks/{team-name}/\`.
 
 Teammates should:
 1. Check TaskList periodically, **especially after completing each task**, to find available work or see newly unblocked tasks

--- a/src/tools/TeamDeleteTool/prompt.ts
+++ b/src/tools/TeamDeleteTool/prompt.ts
@@ -5,8 +5,8 @@ export function getPrompt(): string {
 Remove team and task directories when the swarm work is complete.
 
 This operation:
-- Removes the team directory (\`~/.claude/teams/{team-name}/\`)
-- Removes the task directory (\`~/.claude/tasks/{team-name}/\`)
+- Removes the team directory (\`~/.openclaude/teams/{team-name}/\`)
+- Removes the task directory (\`~/.openclaude/tasks/{team-name}/\`)
 - Clears team context from the current session
 
 **IMPORTANT**: TeamDelete will fail if the team still has active members. Gracefully terminate teammates first, then call TeamDelete after all teammates have shut down.

--- a/src/utils/claudeInChrome/chromeNativeHost.ts
+++ b/src/utils/claudeInChrome/chromeNativeHost.ts
@@ -28,7 +28,7 @@ const MAX_MESSAGE_SIZE = 1024 * 1024 // 1MB - Max message size that can be sent 
 
 const LOG_FILE =
   process.env.USER_TYPE === 'ant'
-    ? join(homedir(), '.claude', 'debug', 'chrome-native-host.txt')
+    ? join(homedir(), '.openclaude', 'debug', 'chrome-native-host.txt')
     : undefined
 
 function log(message: string, ...args: unknown[]): void {

--- a/src/utils/claudemd.ts
+++ b/src/utils/claudemd.ts
@@ -2,8 +2,8 @@
  * Files are loaded in the following order:
  *
  * 1. Managed memory (eg. /etc/claude-code/CLAUDE.md) - Global instructions for all users
- * 2. User memory (~/.claude/CLAUDE.md) - Private global instructions for all projects
- * 3. Project memory (AGENTS.md or fallback CLAUDE.md, plus .claude/CLAUDE.md and .claude/rules/*.md in project roots) - Instructions checked into the codebase
+ * 2. User memory (~/.openclaude/CLAUDE.md) - Private global instructions for all projects
+ * 3. Project memory (AGENTS.md or fallback CLAUDE.md, plus .openclaude/CLAUDE.md and .openclaude/rules/*.md in project roots) - Instructions checked into the codebase
  * 4. Local memory (CLAUDE.local.md in project roots) - Private project-specific instructions
  *
  * Files are loaded in reverse order of priority, i.e. the latest files are highest priority
@@ -14,7 +14,7 @@
  * - Project and Local files are discovered by traversing from the current directory up to root
  * - Files closer to the current directory have higher priority (loaded later)
  * - AGENTS.md is preferred for root project instructions; CLAUDE.md is only used when AGENTS.md is absent
- * - .claude/CLAUDE.md and all .md files in .claude/rules/ are checked in each directory for Project memory
+ * - .openclaude/CLAUDE.md and all .md files in .openclaude/rules/ are checked in each directory for Project memory
  *
  * Memory @include directive:
  * - Memory files can include other files using @ notation
@@ -699,7 +699,7 @@ export async function processMemoryFile(
 }
 
 /**
- * Processes all .md files in the .claude/rules/ directory and its subdirectories
+ * Processes all .md files in the .openclaude/rules/ directory and its subdirectories
  * @param rulesDir The path to the rules directory
  * @param type Type of memory file (User, Project, Local)
  * @param processedPaths Set of already processed file paths
@@ -828,7 +828,7 @@ export const getMemoryFiles = memoize(
         includeExternal,
       )),
     )
-    // Process Managed .claude/rules/*.md files
+    // Process Managed .openclaude/rules/*.md files
     const managedClaudeRulesDir = getManagedClaudeRulesDir()
     result.push(
       ...(await processMdRules({
@@ -851,7 +851,7 @@ export const getMemoryFiles = memoize(
           includeExternalForUser, // User-scope external-includes gate
         )),
       )
-      // Process User ~/.claude/rules/*.md files
+      // Process User ~/.openclaude/rules/*.md files
       const userClaudeRulesDir = getUserClaudeRulesDir()
       result.push(
         ...(await processMdRules({
@@ -875,9 +875,9 @@ export const getMemoryFiles = memoize(
     }
 
     // When running from a git worktree nested inside its main repo (e.g.,
-    // .claude/worktrees/<name>/ from `claude -w`), the upward walk passes
+    // .openclaude/worktrees/<name>/ from `claude -w`), the upward walk passes
     // through both the worktree root and the main repo root. Both contain
-    // checked-in files like AGENTS.md/CLAUDE.md and .claude/rules/*.md, so the same
+    // checked-in files like AGENTS.md/CLAUDE.md and .openclaude/rules/*.md, so the same
     // content gets loaded twice. Skip Project-type (checked-in) files from
     // directories above the worktree but within the main repo — the worktree
     // already has its own checkout. CLAUDE.local.md is gitignored so it only
@@ -916,8 +916,8 @@ export const getMemoryFiles = memoize(
           )),
         )
 
-        // Try reading .claude/CLAUDE.md (Project)
-        const dotClaudePath = join(dir, '.claude', 'CLAUDE.md')
+        // Try reading .openclaude/CLAUDE.md (Project)
+        const dotClaudePath = join(dir, '.openclaude', 'CLAUDE.md')
         result.push(
           ...(await processMemoryFile(
             dotClaudePath,
@@ -927,8 +927,8 @@ export const getMemoryFiles = memoize(
           )),
         )
 
-        // Try reading .claude/rules/*.md files (Project)
-        const rulesDir = join(dir, '.claude', 'rules')
+        // Try reading .openclaude/rules/*.md files (Project)
+        const rulesDir = join(dir, '.openclaude', 'rules')
         result.push(
           ...(await processMdRules({
             rulesDir,
@@ -975,8 +975,8 @@ export const getMemoryFiles = memoize(
           )),
         )
 
-        // Try reading .claude/CLAUDE.md from the additional directory
-        const dotClaudePath = join(dir, '.claude', 'CLAUDE.md')
+        // Try reading .openclaude/CLAUDE.md from the additional directory
+        const dotClaudePath = join(dir, '.openclaude', 'CLAUDE.md')
         result.push(
           ...(await processMemoryFile(
             dotClaudePath,
@@ -986,8 +986,8 @@ export const getMemoryFiles = memoize(
           )),
         )
 
-        // Try reading .claude/rules/*.md files from the additional directory
-        const rulesDir = join(dir, '.claude', 'rules')
+        // Try reading .openclaude/rules/*.md files from the additional directory
+        const rulesDir = join(dir, '.openclaude', 'rules')
         result.push(
           ...(await processMdRules({
             rulesDir,
@@ -1233,7 +1233,7 @@ export async function getManagedAndUserConditionalRules(
   const result: MemoryFileInfo[] = []
   const config = getCurrentProjectConfig()
 
-  // Process Managed conditional .claude/rules/*.md files
+  // Process Managed conditional .openclaude/rules/*.md files
   const managedClaudeRulesDir = getManagedClaudeRulesDir()
   result.push(
     ...(await processConditionedMdRules(
@@ -1246,7 +1246,7 @@ export async function getManagedAndUserConditionalRules(
   )
 
   if (isSettingSourceEnabled('userSettings')) {
-    // Process User conditional .claude/rules/*.md files
+    // Process User conditional .openclaude/rules/*.md files
     // Gate external includes through the same User-scope approval flag
     // as unconditional User rules, so declining approval blocks the
     // conditional path too.
@@ -1282,7 +1282,7 @@ export async function getMemoryFilesForNestedDirectory(
 ): Promise<MemoryFileInfo[]> {
   const result: MemoryFileInfo[] = []
 
-  // Process project memory files (AGENTS.md first, otherwise CLAUDE.md, plus .claude/CLAUDE.md)
+  // Process project memory files (AGENTS.md first, otherwise CLAUDE.md, plus .openclaude/CLAUDE.md)
   if (isSettingSourceEnabled('projectSettings')) {
     const projectPath = getProjectInstructionFilePath(
       dir,
@@ -1296,7 +1296,7 @@ export async function getMemoryFilesForNestedDirectory(
         false,
       )),
     )
-    const dotClaudePath = join(dir, '.claude', 'CLAUDE.md')
+    const dotClaudePath = join(dir, '.openclaude', 'CLAUDE.md')
     result.push(
       ...(await processMemoryFile(
         dotClaudePath,
@@ -1315,9 +1315,9 @@ export async function getMemoryFilesForNestedDirectory(
     )
   }
 
-  const rulesDir = join(dir, '.claude', 'rules')
+  const rulesDir = join(dir, '.openclaude', 'rules')
 
-  // Process project unconditional .claude/rules/*.md files, which were not eagerly loaded
+  // Process project unconditional .openclaude/rules/*.md files, which were not eagerly loaded
   // Use a separate processedPaths set to avoid marking conditional rule files as processed
   const unconditionalProcessedPaths = new Set(processedPaths)
   result.push(
@@ -1330,7 +1330,7 @@ export async function getMemoryFilesForNestedDirectory(
     })),
   )
 
-  // Process project conditional .claude/rules/*.md files
+  // Process project conditional .openclaude/rules/*.md files
   result.push(
     ...(await processConditionedMdRules(
       targetPath,
@@ -1363,7 +1363,7 @@ export async function getConditionalRulesForCwdLevelDirectory(
   targetPath: string,
   processedPaths: Set<string>,
 ): Promise<MemoryFileInfo[]> {
-  const rulesDir = join(dir, '.claude', 'rules')
+  const rulesDir = join(dir, '.openclaude', 'rules')
   return processConditionedMdRules(
     targetPath,
     rulesDir,
@@ -1374,7 +1374,7 @@ export async function getConditionalRulesForCwdLevelDirectory(
 }
 
 /**
- * Processes all .md files in the .claude/rules/ directory and its subdirectories,
+ * Processes all .md files in the .openclaude/rules/ directory and its subdirectories,
  * filtering to only include files with frontmatter paths that match the target path
  * @param targetPath The file path to match against frontmatter glob patterns
  * @param rulesDir The path to the rules directory
@@ -1404,11 +1404,11 @@ export async function processConditionedMdRules(
       return false
     }
 
-    // For Project rules: glob patterns are relative to the directory containing .claude
+    // For Project rules: glob patterns are relative to the directory containing .openclaude
     // For Managed/User rules: glob patterns are relative to the original CWD
     const baseDir =
       type === 'Project'
-        ? dirname(dirname(rulesDir)) // Parent of .claude
+        ? dirname(dirname(rulesDir)) // Parent of .openclaude
         : getOriginalCwd() // Project root for managed/user rules
 
     const relativePath = isAbsolute(targetPath)
@@ -1473,7 +1473,7 @@ export async function shouldShowClaudeMdExternalIncludesWarning(): Promise<Exter
 }
 
 /**
- * Check if a file path is a memory file (AGENTS.md, CLAUDE.md, CLAUDE.local.md, or .claude/rules/*.md)
+ * Check if a file path is a memory file (AGENTS.md, CLAUDE.md, CLAUDE.local.md, or .openclaude/rules/*.md)
  */
 export function isMemoryFilePath(filePath: string): boolean {
   const name = basename(filePath)
@@ -1483,10 +1483,10 @@ export function isMemoryFilePath(filePath: string): boolean {
     return true
   }
 
-  // .md files in .claude/rules/ directories
+  // .md files in .openclaude/rules/ directories
   if (
     name.endsWith('.md') &&
-    filePath.includes(`${sep}.claude${sep}rules${sep}`)
+    filePath.includes(`${sep}.openclaude${sep}rules${sep}`)
   ) {
     return true
   }

--- a/src/utils/completionCache.ts
+++ b/src/utils/completionCache.ts
@@ -24,7 +24,7 @@ type ShellInfo = {
 function detectShell(): ShellInfo | null {
   const shell = process.env.SHELL || ''
   const home = homedir()
-  const claudeDir = join(home, '.claude')
+  const claudeDir = join(home, '.openclaude')
 
   if (shell.endsWith('/zsh') || shell.endsWith('/zsh.exe')) {
     const cacheFile = join(claudeDir, 'completion.zsh')

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -2055,7 +2055,7 @@ export function getMemoryPath(memoryType: MemoryType): string {
 }
 
 export function getManagedClaudeRulesDir(): string {
-  return join(getManagedFilePath(), '.claude', 'rules')
+  return join(getManagedFilePath(), '.openclaude', 'rules')
 }
 
 export function getUserClaudeRulesDir(): string {

--- a/src/utils/cronTasks.ts
+++ b/src/utils/cronTasks.ts
@@ -1,4 +1,4 @@
-// Scheduled prompts, stored in <project>/.claude/scheduled_tasks.json.
+// Scheduled prompts, stored in <project>/.openclaude/scheduled_tasks.json.
 //
 // Tasks come in two flavors:
 //   - One-shot (recurring: false/undefined) — fire once, then auto-delete.
@@ -71,7 +71,7 @@ export type CronTask = {
 
 type CronFile = { tasks: CronTask[] }
 
-const CRON_FILE_REL = join('.claude', 'scheduled_tasks.json')
+const CRON_FILE_REL = join('.openclaude', 'scheduled_tasks.json')
 
 /**
  * Path to the cron file. `dir` defaults to getProjectRoot() — pass it
@@ -83,7 +83,7 @@ export function getCronFilePath(dir?: string): string {
 }
 
 /**
- * Read and parse .claude/scheduled_tasks.json. Returns an empty task list if the file
+ * Read and parse .openclaude/scheduled_tasks.json. Returns an empty task list if the file
  * is missing, empty, or malformed. Tasks with invalid cron strings are
  * silently dropped (logged at debug level) so a single bad entry never
  * blocks the whole file.
@@ -158,7 +158,7 @@ export function hasCronTasksSync(dir?: string): boolean {
 }
 
 /**
- * Overwrite .claude/scheduled_tasks.json with the given tasks. Creates .claude/ if
+ * Overwrite .openclaude/scheduled_tasks.json with the given tasks. Creates .openclaude/ if
  * missing. Empty task list writes an empty file (rather than deleting) so
  * the file watcher sees a change event on last-task-removed.
  */
@@ -167,7 +167,7 @@ export async function writeCronTasks(
   dir?: string,
 ): Promise<void> {
   const root = dir ?? getProjectRoot()
-  await mkdir(join(root, '.claude'), { recursive: true })
+  await mkdir(join(root, '.openclaude'), { recursive: true })
   // Strip the runtime-only `durable` flag — everything on disk is durable
   // by definition, and keeping the flag out means readCronTasks() naturally
   // yields durable: undefined without having to set it explicitly.
@@ -187,7 +187,7 @@ export async function writeCronTasks(
  *
  * When `durable` is false the task is held in process memory only
  * (bootstrap/state.ts) — it fires on schedule this session but is never
- * written to .claude/scheduled_tasks.json and dies with the process. The
+ * written to .openclaude/scheduled_tasks.json and dies with the process. The
  * scheduler merges session tasks into its tick loop directly, so no file
  * change event is needed.
  */

--- a/src/utils/cronTasksLock.ts
+++ b/src/utils/cronTasksLock.ts
@@ -1,4 +1,4 @@
-// Scheduler lease lock for .claude/scheduled_tasks.json.
+// Scheduler lease lock for .openclaude/scheduled_tasks.json.
 //
 // When multiple Claude sessions run in the same project directory, only one
 // should drive the cron scheduler. The first session to acquire this lock
@@ -20,7 +20,7 @@ import { safeParseJSON } from './json.js'
 import { lazySchema } from './lazySchema.js'
 import { jsonStringify } from './slowOperations.js'
 
-const LOCK_FILE_REL = join('.claude', 'scheduled_tasks.lock')
+const LOCK_FILE_REL = join('.openclaude', 'scheduled_tasks.lock')
 
 const schedulerLockSchema = lazySchema(() =>
   z.object({
@@ -74,7 +74,7 @@ async function tryCreateExclusive(
     const code = getErrnoCode(e)
     if (code === 'EEXIST') return false
     if (code === 'ENOENT') {
-      // .claude/ doesn't exist yet — create it and retry once. In steady
+      // .openclaude/ doesn't exist yet — create it and retry once. In steady
       // state the dir already exists (scheduled_tasks.json lives there),
       // so this path is hit at most once.
       await mkdir(dirname(path), { recursive: true })

--- a/src/utils/doctorDiagnostic.settingsPath.test.ts
+++ b/src/utils/doctorDiagnostic.settingsPath.test.ts
@@ -43,18 +43,11 @@ afterEach(() => {
 })
 
 describe('detectStaleProjectSettingsPaths', () => {
-  test('warns when legacy project settings exist without canonical settings', async () => {
+  test('does not warn when legacy project settings exist without canonical settings', async () => {
     const project = createProject()
     writeJson(join(project, '.claude', 'settings.json'))
 
-    const warning = await detectStaleProjectSettingsPaths(project)
-
-    expect(warning).toEqual({
-      issue:
-        'Legacy project settings file .claude/settings.json found, but OpenClaude reads .openclaude/settings.json',
-      fix:
-        'Move or copy .claude/settings.json to .openclaude/settings.json if you intended OpenClaude to use those project settings.',
-    })
+    await expect(detectStaleProjectSettingsPaths(project)).resolves.toBeNull()
   })
 
   test('does not warn when the matching canonical project settings file exists', async () => {
@@ -79,27 +72,19 @@ describe('detectStaleProjectSettingsPaths', () => {
     await expect(detectStaleProjectSettingsPaths(project)).resolves.toBeNull()
   })
 
-  test('warns independently for legacy local settings', async () => {
+  test('does not warn independently for legacy local settings', async () => {
     const project = createProject()
     writeJson(join(project, '.claude', 'settings.local.json'))
 
-    const warning = await detectStaleProjectSettingsPaths(project)
-
-    expect(warning?.issue).toContain('.claude/settings.local.json')
-    expect(warning?.issue).toContain('.openclaude/settings.local.json')
+    await expect(detectStaleProjectSettingsPaths(project)).resolves.toBeNull()
   })
 
-  test('warns about both legacy settings files when both canonical files are absent', async () => {
+  test('does not warn about legacy settings files when canonical files are absent', async () => {
     const project = createProject()
     writeJson(join(project, '.claude', 'settings.json'))
     writeJson(join(project, '.claude', 'settings.local.json'))
 
-    const warning = await detectStaleProjectSettingsPaths(project)
-
-    expect(warning?.issue).toContain('.claude/settings.json')
-    expect(warning?.issue).toContain('.claude/settings.local.json')
-    expect(warning?.issue).toContain('.openclaude/settings.json')
-    expect(warning?.issue).toContain('.openclaude/settings.local.json')
+    await expect(detectStaleProjectSettingsPaths(project)).resolves.toBeNull()
   })
 
   test('uses the settings resolver project root by default', async () => {
@@ -107,9 +92,6 @@ describe('detectStaleProjectSettingsPaths', () => {
     writeJson(join(project, '.claude', 'settings.json'))
     setOriginalCwd(project)
 
-    const warning = await detectStaleProjectSettingsPaths()
-
-    expect(warning?.issue).toContain('.claude/settings.json')
-    expect(warning?.issue).toContain('.openclaude/settings.json')
+    await expect(detectStaleProjectSettingsPaths()).resolves.toBeNull()
   })
 })

--- a/src/utils/doctorDiagnostic.ts
+++ b/src/utils/doctorDiagnostic.ts
@@ -35,10 +35,6 @@ import { getPlatform } from './platform.js'
 import { getRipgrepStatus } from './ripgrep.js'
 import { SandboxManager } from './sandbox/sandbox-adapter.js'
 import { getManagedFilePath } from './settings/managedPath.js'
-import {
-  getRelativeSettingsFilePathForSource,
-  getSettingsRootPathForSource,
-} from './settings/settings.js'
 import { CUSTOMIZATION_SURFACES } from './settings/types.js'
 import {
   findClaudeAlias,
@@ -352,7 +348,7 @@ async function pathExists(path: string): Promise<boolean> {
 }
 
 export async function detectStaleProjectSettingsPaths(
-  cwd: string = getSettingsRootPathForSource('projectSettings'),
+  cwd?: string,
 ): Promise<{ issue: string; fix: string } | null> {
   void cwd
   return null

--- a/src/utils/doctorDiagnostic.ts
+++ b/src/utils/doctorDiagnostic.ts
@@ -581,9 +581,8 @@ export async function getDoctorDiagnostic(): Promise<DiagnosticInfo> {
 
     for (const install of npmInstalls) {
       if (install.type === 'npm-global') {
-        const uninstallCmd = MACRO.PACKAGE_URL
-          ? `npm -g uninstall ${MACRO.PACKAGE_URL}`
-          : 'npm -g uninstall openclaude'
+        const uninstallPackageName = MACRO.PACKAGE_URL || '@gitlawb/openclaude'
+        const uninstallCmd = `npm -g uninstall ${uninstallPackageName}`
         warnings.push({
           issue: `Leftover npm global installation at ${install.path}`,
           fix: `Run: ${uninstallCmd}`,

--- a/src/utils/doctorDiagnostic.ts
+++ b/src/utils/doctorDiagnostic.ts
@@ -237,7 +237,7 @@ async function detectMultipleInstallations(): Promise<
   }
 
   // Check for global npm installation
-  const packagesToCheck = MACRO.PACKAGE_URL ? [MACRO.PACKAGE_URL] : []
+  const packagesToCheck = [MACRO.PACKAGE_URL || '@gitlawb/openclaude']
   const npmResult = await execFileNoThrow('npm', [
     '-g',
     'config',

--- a/src/utils/doctorDiagnostic.ts
+++ b/src/utils/doctorDiagnostic.ts
@@ -241,10 +241,7 @@ async function detectMultipleInstallations(): Promise<
   }
 
   // Check for global npm installation
-  const packagesToCheck = ['@anthropic-ai/claude-code']
-  if (MACRO.PACKAGE_URL && MACRO.PACKAGE_URL !== '@anthropic-ai/claude-code') {
-    packagesToCheck.push(MACRO.PACKAGE_URL)
-  }
+  const packagesToCheck = MACRO.PACKAGE_URL ? [MACRO.PACKAGE_URL] : []
   const npmResult = await execFileNoThrow('npm', [
     '-g',
     'config',
@@ -357,36 +354,8 @@ async function pathExists(path: string): Promise<boolean> {
 export async function detectStaleProjectSettingsPaths(
   cwd: string = getSettingsRootPathForSource('projectSettings'),
 ): Promise<{ issue: string; fix: string } | null> {
-  const pairs = [
-    {
-      legacy: '.claude/settings.json',
-      canonical: getRelativeSettingsFilePathForSource('projectSettings'),
-    },
-    {
-      legacy: '.claude/settings.local.json',
-      canonical: getRelativeSettingsFilePathForSource('localSettings'),
-    },
-  ]
-
-  const stale: Array<{ legacy: string; canonical: string }> = []
-  for (const pair of pairs) {
-    const legacyExists = await pathExists(join(cwd, pair.legacy))
-    if (!legacyExists) continue
-    const canonicalExists = await pathExists(join(cwd, pair.canonical))
-    if (!canonicalExists) {
-      stale.push(pair)
-    }
-  }
-
-  if (stale.length === 0) return null
-
-  const legacyPaths = stale.map(pair => pair.legacy).join(', ')
-  const canonicalPaths = stale.map(pair => pair.canonical).join(', ')
-
-  return {
-    issue: `Legacy project settings file${stale.length === 1 ? '' : 's'} ${legacyPaths} found, but OpenClaude reads ${canonicalPaths}`,
-    fix: `Move or copy ${legacyPaths} to ${canonicalPaths} if you intended OpenClaude to use those project settings.`,
-  }
+  void cwd
+  return null
 }
 
 async function detectConfigurationIssues(
@@ -616,13 +585,9 @@ export async function getDoctorDiagnostic(): Promise<DiagnosticInfo> {
 
     for (const install of npmInstalls) {
       if (install.type === 'npm-global') {
-        let uninstallCmd = 'npm -g uninstall @anthropic-ai/claude-code'
-        if (
-          MACRO.PACKAGE_URL &&
-          MACRO.PACKAGE_URL !== '@anthropic-ai/claude-code'
-        ) {
-          uninstallCmd += ` && npm -g uninstall ${MACRO.PACKAGE_URL}`
-        }
+        const uninstallCmd = MACRO.PACKAGE_URL
+          ? `npm -g uninstall ${MACRO.PACKAGE_URL}`
+          : 'npm -g uninstall openclaude'
         warnings.push({
           issue: `Leftover npm global installation at ${install.path}`,
           fix: `Run: ${uninstallCmd}`,

--- a/src/utils/env.test.ts
+++ b/src/utils/env.test.ts
@@ -19,8 +19,8 @@ let tempDir: string
 beforeEach(async () => {
   await acquireSharedMutationLock('env.test.ts')
   tempDir = mkdtempSync(join(tmpdir(), 'openclaude-env-test-'))
-  delete process.env.OPENCLAUDE_CONFIG_DIR
-  process.env.CLAUDE_CONFIG_DIR = tempDir
+  process.env.OPENCLAUDE_CONFIG_DIR = tempDir
+  delete process.env.CLAUDE_CONFIG_DIR
   delete process.env.CLAUDE_CODE_CUSTOM_OAUTH_URL
   delete process.env.USER_TYPE
 })
@@ -64,10 +64,10 @@ test('getGlobalClaudeFile: new install returns .openclaude.json when neither fil
   expect(getGlobalClaudeFile()).toBe(join(tempDir, '.openclaude.json'))
 })
 
-test('getGlobalClaudeFile: explicit config dir keeps .claude.json fallback when only legacy file exists', async () => {
+test('getGlobalClaudeFile: ignores .claude.json when only legacy file exists', async () => {
   writeFileSync(join(tempDir, '.claude.json'), '{}')
   const { getGlobalClaudeFile } = await importFreshEnvModule()
-  expect(getGlobalClaudeFile()).toBe(join(tempDir, '.claude.json'))
+  expect(getGlobalClaudeFile()).toBe(join(tempDir, '.openclaude.json'))
 })
 
 test('getGlobalClaudeFile: migrated user uses .openclaude.json when both files exist', async () => {
@@ -91,7 +91,7 @@ test('getGlobalClaudeFile: OPENCLAUDE_CONFIG_DIR uses preferred config dir', asy
   }
 })
 
-test('getGlobalClaudeFile: OPENCLAUDE_CONFIG_DIR keeps .claude.json fallback when only legacy file exists', async () => {
+test('getGlobalClaudeFile: OPENCLAUDE_CONFIG_DIR ignores .claude.json fallback when only legacy file exists', async () => {
   const preferredDir = mkdtempSync(join(tmpdir(), 'openclaude-preferred-env-test-'))
   try {
     process.env.OPENCLAUDE_CONFIG_DIR = preferredDir
@@ -100,13 +100,13 @@ test('getGlobalClaudeFile: OPENCLAUDE_CONFIG_DIR keeps .claude.json fallback whe
 
     const { getGlobalClaudeFile } = await importFreshEnvModule()
 
-    expect(getGlobalClaudeFile()).toBe(join(preferredDir, '.claude.json'))
+    expect(getGlobalClaudeFile()).toBe(join(preferredDir, '.openclaude.json'))
   } finally {
     rmSync(preferredDir, { recursive: true, force: true })
   }
 })
 
-test('resolveGlobalClaudeFile: failed default migration keeps legacy file when new file is missing', async () => {
+test('resolveGlobalClaudeFile: ignores legacy file even when new file is missing', async () => {
   writeFileSync(join(tempDir, '.claude.json'), '{}')
   const { resolveGlobalClaudeFile } = await importFreshEnvModule()
 
@@ -116,5 +116,5 @@ test('resolveGlobalClaudeFile: failed default migration keeps legacy file when n
       migrationSucceeded: false,
       existsSync: path => path === join(tempDir, '.claude.json'),
     }),
-  ).toBe(join(tempDir, '.claude.json'))
+  ).toBe(join(tempDir, '.openclaude.json'))
 })

--- a/src/utils/env.test.ts
+++ b/src/utils/env.test.ts
@@ -113,7 +113,6 @@ test('resolveGlobalClaudeFile: ignores legacy file even when new file is missing
   expect(
     resolveGlobalClaudeFile({
       homeDir: tempDir,
-      migrationSucceeded: false,
     }),
   ).toBe(join(tempDir, '.openclaude.json'))
 })

--- a/src/utils/env.test.ts
+++ b/src/utils/env.test.ts
@@ -114,7 +114,6 @@ test('resolveGlobalClaudeFile: ignores legacy file even when new file is missing
     resolveGlobalClaudeFile({
       homeDir: tempDir,
       migrationSucceeded: false,
-      existsSync: path => path === join(tempDir, '.claude.json'),
     }),
   ).toBe(join(tempDir, '.openclaude.json'))
 })

--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -7,7 +7,6 @@ import { createCombinedAbortSignal } from './combinedAbortSignal.js'
 import {
   getClaudeConfigHomeDir,
   isEnvTruthy,
-  migrateLegacyClaudeConfigHome,
   resolveConfigDirEnv,
 } from './envUtils.js'
 import { findExecutable } from './findExecutable.js'
@@ -25,17 +24,10 @@ export function resolveGlobalClaudeFile(options: {
 }): string {
   const oauthSuffix = options.oauthSuffix ?? ''
   const configDir = options.configDirEnv || options.homeDir || homedir()
-  const hasExplicitConfigDir = Boolean(options.configDirEnv)
   const newFilename = `.openclaude${oauthSuffix}.json`
-  const legacyFilename = `.claude${oauthSuffix}.json`
 
-  if (
-    (hasExplicitConfigDir || options.migrationSucceeded === false) &&
-    !options.existsSync(join(configDir, newFilename)) &&
-    options.existsSync(join(configDir, legacyFilename))
-  ) {
-    return join(configDir, legacyFilename)
-  }
+  void options.migrationSucceeded
+  void options.existsSync
   return join(configDir, newFilename)
 }
 
@@ -53,24 +45,13 @@ export const getGlobalClaudeFile = memoize((): string => {
   const oauthSuffix = fileSuffixForOauthConfig()
   const configDirEnv = resolveConfigDirEnv({
     openClaudeConfigDir: process.env.OPENCLAUDE_CONFIG_DIR,
-    legacyConfigDir: process.env.CLAUDE_CONFIG_DIR,
   })
   const configDir = configDirEnv || homedir()
-  const hasExplicitConfigDir = Boolean(configDirEnv)
-  let migrationSucceeded = true
 
-  if (!hasExplicitConfigDir) {
-    migrationSucceeded = migrateLegacyClaudeConfigHome({ homeDir: configDir })
-  }
-
-  // Default installs hard-cut to .openclaude.json after the migration above.
-  // Explicit config-dir users keep the legacy filename fallback because
-  // either env var is an opt-out for automatic migration.
   return resolveGlobalClaudeFile({
     configDirEnv,
     homeDir: configDir,
     oauthSuffix,
-    migrationSucceeded,
     existsSync: path => getFsImplementation().existsSync(path),
   })
 })

--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -19,13 +19,11 @@ export function resolveGlobalClaudeFile(options: {
   configDirEnv?: string
   homeDir?: string
   oauthSuffix?: string
-  migrationSucceeded?: boolean
 }): string {
   const oauthSuffix = options.oauthSuffix ?? ''
   const configDir = options.configDirEnv || options.homeDir || homedir()
   const newFilename = `.openclaude${oauthSuffix}.json`
 
-  void options.migrationSucceeded
   return join(configDir, newFilename)
 }
 

--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -20,14 +20,12 @@ export function resolveGlobalClaudeFile(options: {
   homeDir?: string
   oauthSuffix?: string
   migrationSucceeded?: boolean
-  existsSync: (path: string) => boolean
 }): string {
   const oauthSuffix = options.oauthSuffix ?? ''
   const configDir = options.configDirEnv || options.homeDir || homedir()
   const newFilename = `.openclaude${oauthSuffix}.json`
 
   void options.migrationSucceeded
-  void options.existsSync
   return join(configDir, newFilename)
 }
 
@@ -52,7 +50,6 @@ export const getGlobalClaudeFile = memoize((): string => {
     configDirEnv,
     homeDir: configDir,
     oauthSuffix,
-    existsSync: path => getFsImplementation().existsSync(path),
   })
 })
 

--- a/src/utils/envUtils.ts
+++ b/src/utils/envUtils.ts
@@ -1,171 +1,22 @@
 import memoize from 'lodash-es/memoize.js'
-import {
-  copyFileSync,
-  lstatSync,
-  mkdirSync,
-  readlinkSync,
-  readdirSync,
-  statSync,
-  symlinkSync,
-} from 'fs'
 import { homedir } from 'os'
-import { dirname, join } from 'path'
-
-const LEGACY_GLOBAL_CONFIG_FILE_RE =
-  /^\.claude(?:-(?:custom|local|staging)-oauth)?\.json$/
-
-function getErrnoCode(error: unknown): string | undefined {
-  if (
-    error &&
-    typeof error === 'object' &&
-    'code' in error &&
-    typeof error.code === 'string'
-  ) {
-    return error.code
-  }
-  return undefined
-}
-
-function pathExists(path: string): boolean {
-  try {
-    lstatSync(path)
-    return true
-  } catch (error) {
-    if (getErrnoCode(error) === 'ENOENT') {
-      return false
-    }
-    return true
-  }
-}
-
-function pathIsDirectory(path: string): boolean {
-  try {
-    return lstatSync(path).isDirectory()
-  } catch {
-    return false
-  }
-}
-
-function getSymlinkType(source: string): 'dir' | 'file' | 'junction' {
-  if (process.platform !== 'win32') {
-    return 'file'
-  }
-
-  try {
-    return statSync(source).isDirectory() ? 'junction' : 'file'
-  } catch {
-    return 'file'
-  }
-}
-
-function copyMissingPathSync(source: string, destination: string): void {
-  const sourceStats = lstatSync(source)
-
-  if (sourceStats.isDirectory()) {
-    if (!pathExists(destination)) {
-      // Match fsOperations' recursive mkdir behavior while keeping this module
-      // independent from the config-home resolver it backs.
-      mkdirSync(destination, { recursive: true })
-    } else if (!lstatSync(destination).isDirectory()) {
-      throw new Error(`Cannot migrate ${source}: ${destination} is not a directory`)
-    }
-
-    for (const entry of readdirSync(source)) {
-      copyMissingPathSync(join(source, entry), join(destination, entry))
-    }
-    return
-  }
-
-  if (pathExists(destination)) {
-    return
-  }
-
-  mkdirSync(dirname(destination), { recursive: true })
-
-  if (sourceStats.isSymbolicLink()) {
-    symlinkSync(readlinkSync(source), destination, getSymlinkType(source))
-    return
-  }
-
-  if (sourceStats.isFile()) {
-    copyFileSync(source, destination)
-  }
-}
-
-function getLegacyGlobalConfigFiles(homeDir: string): string[] {
-  try {
-    return readdirSync(homeDir).filter(file =>
-      LEGACY_GLOBAL_CONFIG_FILE_RE.test(file),
-    )
-  } catch (error) {
-    if (getErrnoCode(error) === 'ENOENT') {
-      return []
-    }
-    throw error
-  }
-}
-
-export function migrateLegacyClaudeConfigHome(options?: {
-  configDirEnv?: string
-  homeDir?: string
-}): boolean {
-  if (options?.configDirEnv) {
-    return true
-  }
-
-  const homeDir = options?.homeDir ?? homedir()
-  const openClaudeDir = join(homeDir, '.openclaude')
-  const legacyClaudeDir = join(homeDir, '.claude')
-
-  try {
-    const legacyDirExists = pathIsDirectory(legacyClaudeDir)
-    const legacyGlobalConfigFiles = getLegacyGlobalConfigFiles(homeDir)
-
-    if (!legacyDirExists && legacyGlobalConfigFiles.length === 0) {
-      return true
-    }
-
-    if (legacyDirExists) {
-      copyMissingPathSync(legacyClaudeDir, openClaudeDir)
-    }
-
-    for (const legacyFile of legacyGlobalConfigFiles) {
-      const openClaudeFile = legacyFile.replace(/^\.claude/, '.openclaude')
-      copyMissingPathSync(
-        join(homeDir, legacyFile),
-        join(homeDir, openClaudeFile),
-      )
-    }
-    return true
-  } catch {
-    return false
-  }
-}
+import { join } from 'path'
 
 /**
  * Resolves the override env value for the config home directory.
- * `OPENCLAUDE_CONFIG_DIR` is preferred — `CLAUDE_CONFIG_DIR` is the legacy
- * Anthropic name kept working for backward compatibility. When both are set
- * and disagree, `OPENCLAUDE_CONFIG_DIR` wins and we warn once so the user
- * can clean up. Exported for tests.
+ * Resolves the OpenClaude config home override.
+ *
+ * Intentionally does not read `CLAUDE_CONFIG_DIR`: OpenClaude config must stay
+ * independent from Claude Code config and credentials.
  */
-let warnedAboutConflictingConfigDirEnvs = false
-
 export function resolveConfigDirEnv(options?: {
   openClaudeConfigDir?: string
   legacyConfigDir?: string
   warn?: (message: string) => void
 }): string | undefined {
-  const open = options?.openClaudeConfigDir
-  const legacy = options?.legacyConfigDir
-  if (open && legacy && open !== legacy && !warnedAboutConflictingConfigDirEnvs) {
-    const message = `Both OPENCLAUDE_CONFIG_DIR and CLAUDE_CONFIG_DIR are set to different values. Using OPENCLAUDE_CONFIG_DIR=${open}; ignoring CLAUDE_CONFIG_DIR=${legacy}.`
-    if (options?.warn) {
-      warnedAboutConflictingConfigDirEnvs = true
-      options.warn(message)
-    }
-  }
-  return open || legacy || undefined
+  void options?.legacyConfigDir
+  void options?.warn
+  return options?.openClaudeConfigDir || undefined
 }
 
 /**
@@ -173,7 +24,7 @@ export function resolveConfigDirEnv(options?: {
  * unit tests can re-trigger it.
  */
 export function __resetConfigDirEnvWarningForTesting(): void {
-  warnedAboutConflictingConfigDirEnvs = false
+  // Kept as a no-op for older tests importing this helper.
 }
 
 export function resolveClaudeConfigHomeDir(options?: {
@@ -208,20 +59,6 @@ export function getClaudeConfigHomeDirOverrideForTesting(): string | undefined {
 const getDefaultClaudeConfigHomeDir = memoize(
   (): string => {
     const homeDir = homedir()
-    const migrationSucceeded = migrateLegacyClaudeConfigHome({
-      homeDir,
-    })
-    const openClaudeDir = join(homeDir, '.openclaude')
-    const legacyClaudeDir = join(homeDir, '.claude')
-
-    if (
-      !migrationSucceeded &&
-      !pathIsDirectory(openClaudeDir) &&
-      pathExists(legacyClaudeDir)
-    ) {
-      return legacyClaudeDir.normalize('NFC')
-    }
-
     return resolveClaudeConfigHomeDir({
       homeDir,
     })
@@ -237,11 +74,6 @@ export const getClaudeConfigHomeDir = Object.assign(
 
     const configDirEnv = resolveConfigDirEnv({
       openClaudeConfigDir: process.env.OPENCLAUDE_CONFIG_DIR,
-      legacyConfigDir: process.env.CLAUDE_CONFIG_DIR,
-      warn: message => {
-        // eslint-disable-next-line no-console
-        console.warn(`[openclaude] ${message}`)
-      },
     })
     if (configDirEnv) {
       return resolveClaudeConfigHomeDir({ configDirEnv })

--- a/src/utils/hooks/skillImprovement.ts
+++ b/src/utils/hooks/skillImprovement.ts
@@ -194,8 +194,8 @@ export async function applySkillImprovement(
   const { join } = await import('path')
   const fs = await import('fs/promises')
 
-  // Skills live at .claude/skills/<name>/SKILL.md relative to CWD
-  const filePath = join(getCwd(), '.claude', 'skills', skillName, 'SKILL.md')
+  // Skills live at .openclaude/skills/<name>/SKILL.md relative to CWD
+  const filePath = join(getCwd(), '.openclaude', 'skills', skillName, 'SKILL.md')
 
   let currentContent: string
   try {

--- a/src/utils/ide.ts
+++ b/src/utils/ide.ts
@@ -474,7 +474,7 @@ export async function getIdeLockfilesPaths(): Promise<string[]> {
   if (windowsHome) {
     const converter = new WindowsToWSLConverter(process.env.WSL_DISTRO_NAME)
     const wslPath = converter.toLocalPath(windowsHome)
-    paths.push(resolve(wslPath, '.claude', 'ide'))
+    paths.push(resolve(wslPath, '.openclaude', 'ide'))
   }
 
   // Construct the path based on the standard Windows WSL locations
@@ -499,7 +499,7 @@ export async function getIdeLockfilesPaths(): Promise<string[]> {
       ) {
         continue // Skip system directories
       }
-      paths.push(join(usersDir, user.name, '.claude', 'ide'))
+      paths.push(join(usersDir, user.name, '.openclaude', 'ide'))
     }
   } catch (error: unknown) {
     if (isFsInaccessible(error)) {

--- a/src/utils/localInstaller.ts
+++ b/src/utils/localInstaller.ts
@@ -22,9 +22,7 @@ function getLocalInstallDir(): string {
 
 export function getCandidateLocalInstallDirs(options?: {
   configHomeDir?: string
-  homeDir?: string
 }): string[] {
-  void options?.homeDir
   const configHomeDir = options?.configHomeDir ?? getClaudeConfigHomeDir()
   return [join(configHomeDir, 'local')]
 }

--- a/src/utils/localInstaller.ts
+++ b/src/utils/localInstaller.ts
@@ -3,7 +3,6 @@
  */
 
 import { access, chmod, writeFile } from 'fs/promises'
-import { homedir } from 'os'
 import { join } from 'path'
 import { type ReleaseChannel, saveGlobalConfig } from './config.js'
 import { getClaudeConfigHomeDir } from './envUtils.js'
@@ -21,19 +20,13 @@ function getLocalInstallDir(): string {
   return join(getClaudeConfigHomeDir(), 'local')
 }
 
-function getLegacyLocalInstallDir(homeDir = homedir()): string {
-  return join(homeDir, '.claude', 'local')
-}
-
 export function getCandidateLocalInstallDirs(options?: {
   configHomeDir?: string
   homeDir?: string
 }): string[] {
-  const homeDir = options?.homeDir ?? homedir()
+  void options?.homeDir
   const configHomeDir = options?.configHomeDir ?? getClaudeConfigHomeDir()
-  return Array.from(
-    new Set([join(configHomeDir, 'local'), getLegacyLocalInstallDir(homeDir)]),
-  )
+  return [join(configHomeDir, 'local')]
 }
 
 function getCandidateLocalBinaryPaths(localInstallDir: string): string[] {
@@ -45,10 +38,7 @@ function getCandidateLocalBinaryPaths(localInstallDir: string): string[] {
 
 export function isManagedLocalInstallationPath(execPath: string): boolean {
   const normalizedExecPath = execPath.replace(/\\+/g, '/')
-  return (
-    normalizedExecPath.includes('/.openclaude/local/node_modules/') ||
-    normalizedExecPath.includes('/.claude/local/node_modules/')
-  )
+  return normalizedExecPath.includes('/.openclaude/local/node_modules/')
 }
 
 export function getLocalClaudePath(): string {

--- a/src/utils/markdownConfigLoader.ts
+++ b/src/utils/markdownConfigLoader.ts
@@ -26,7 +26,7 @@ import {
 import { getManagedFilePath } from './settings/managedPath.js'
 import { isRestrictedToPluginOnly } from './settings/pluginOnlyPolicy.js'
 
-// Claude configuration directory names
+// OpenClaude configuration directory names
 export const CLAUDE_CONFIG_DIRECTORIES = [
   'commands',
   'agents',
@@ -38,7 +38,7 @@ export const CLAUDE_CONFIG_DIRECTORIES = [
 
 export type ClaudeConfigDirectory = (typeof CLAUDE_CONFIG_DIRECTORIES)[number]
 
-export const PROJECT_CONFIG_DIR_NAMES = ['.claude', '.openclaude'] as const
+export const PROJECT_CONFIG_DIR_NAMES = ['.openclaude'] as const
 
 // Concurrency cap for parallel readFile + parseFrontmatter when loading
 // commands/agents/skills/etc. With unbounded Promise.all, a directory holding
@@ -239,14 +239,14 @@ async function getFileIdentity(filePath: string): Promise<string | null> {
  * Normally the walk stops at the nearest `.git` above `cwd`. But if the Bash
  * tool has cd'd into a nested git repo inside the session's project (submodule,
  * vendored dep with its own `.git`), that nested root isn't the right boundary —
- * stopping there makes the parent project's `.claude/` unreachable (#31905).
+ * stopping there makes the parent project's `.openclaude/` unreachable (#31905).
  *
  * The boundary is widened to the session's git root only when BOTH:
  *   - the nearest `.git` from cwd belongs to a *different* canonical repo
  *     (submodule/vendored clone — not a worktree, which resolves back to main)
  *   - that nearest `.git` sits *inside* the session's project tree
  *
- * Worktrees (under `.claude/worktrees/`) stay on the old behavior: their `.git`
+ * Worktrees (under `.openclaude/worktrees/`) stay on the old behavior: their `.git`
  * file is the stop, and loadMarkdownFilesForSubdir's fallback adds the main-repo
  * copy only when the worktree lacks one.
  */
@@ -283,15 +283,15 @@ function resolveStopBoundary(cwd: string): string | null {
 
 /**
  * Traverses from the current directory up to the git root (or home directory if not in a git repo),
- * collecting all .claude directories along the way.
+ * collecting all .openclaude directories along the way.
  *
  * Stopping at git root prevents commands/skills from parent directories outside the repository
- * from leaking into projects. For example, if ~/projects/.claude/commands/ exists, it won't
+ * from leaking into projects. For example, if ~/projects/.openclaude/commands/ exists, it won't
  * appear in ~/projects/my-repo/ if my-repo is a git repository.
  *
  * @param subdir Subdirectory (eg. "commands", "agents")
  * @param cwd Current working directory to start from
- * @returns Array of directory paths containing .claude/subdir, from most specific (cwd) to least specific
+ * @returns Array of directory paths containing .openclaude/subdir, from most specific (cwd) to least specific
  */
 export function getProjectDirsUpToHome(
   subdir: ClaudeConfigDirectory,
@@ -365,17 +365,17 @@ export const loadMarkdownFilesForSubdir = memoize(
   ): Promise<MarkdownFile[]> {
     const searchStartTime = Date.now()
     const userDir = join(getClaudeConfigHomeDir(), subdir)
-    const managedDir = join(getManagedFilePath(), '.claude', subdir)
+    const managedDir = join(getManagedFilePath(), '.openclaude', subdir)
     const projectDirs = getProjectDirsUpToHome(subdir, cwd)
 
-    // For git worktrees where the worktree does NOT have .claude/<subdir> checked
+    // For git worktrees where the worktree does NOT have .openclaude/<subdir> checked
     // out (e.g. sparse-checkout), fall back to the main repository's copy.
     // getProjectDirsUpToHome stops at the worktree root (where the .git file is),
     // so it never sees the main repo on its own.
     //
-    // Only add the main repo's copy when the worktree root's .claude/<subdir>
+    // Only add the main repo's copy when the worktree root's .openclaude/<subdir>
     // is absent. A standard `git worktree add` checks out the full tree, so the
-    // worktree already has identical .claude/<subdir> content — loading the main
+    // worktree already has identical .openclaude/<subdir> content — loading the main
     // repo's copy too would duplicate every command/agent/skill
     // (anthropics/claude-code#29599, #28182, #26992).
     //
@@ -444,7 +444,7 @@ export const loadMarkdownFilesForSubdir = memoize(
     const allFiles = [...managedFiles, ...userFiles, ...projectFiles]
 
     // Deduplicate files that resolve to the same physical file (same inode).
-    // This prevents the same file from appearing multiple times when ~/.claude is
+    // This prevents the same file from appearing multiple times when ~/.openclaude is
     // symlinked to a directory within the project hierarchy, causing the same
     // physical file to be discovered through different paths.
     const fileIdentities = await Promise.all(
@@ -606,7 +606,7 @@ async function findMarkdownFilesNative(
 
 /**
  * Generic function to load markdown files from specified directories
- * @param dir Directory (eg. "~/.claude/commands")
+ * @param dir Directory (eg. "~/.openclaude/commands")
  * @returns Array of parsed markdown files with metadata
  */
 async function loadMarkdownFiles(dir: string): Promise<

--- a/src/utils/nativeInstaller/installer.ts
+++ b/src/utils/nativeInstaller/installer.ts
@@ -1697,21 +1697,7 @@ export async function cleanupNpmInstallations(): Promise<{
   const warnings: string[] = []
   let removed = 0
 
-  // Always attempt to remove @anthropic-ai/claude-code
-  const codePackageResult = await attemptNpmUninstall(
-    '@anthropic-ai/claude-code',
-  )
-  if (codePackageResult.success) {
-    removed++
-    if (codePackageResult.warning) {
-      warnings.push(codePackageResult.warning)
-    }
-  } else if (codePackageResult.error) {
-    errors.push(codePackageResult.error)
-  }
-
-  // Also attempt to remove MACRO.PACKAGE_URL if it's defined and different
-  if (MACRO.PACKAGE_URL && MACRO.PACKAGE_URL !== '@anthropic-ai/claude-code') {
+  if (MACRO.PACKAGE_URL) {
     const macroPackageResult = await attemptNpmUninstall(MACRO.PACKAGE_URL)
     if (macroPackageResult.success) {
       removed++
@@ -1723,10 +1709,7 @@ export async function cleanupNpmInstallations(): Promise<{
     }
   }
 
-  // Preserve compatibility with pre-migration installs under ~/.claude/local.
-  const localInstallDirs = Array.from(
-    new Set([join(getClaudeConfigHomeDir(), 'local'), join(homedir(), '.claude', 'local')]),
-  )
+  const localInstallDirs = [join(getClaudeConfigHomeDir(), 'local')]
 
   for (const localInstallDir of localInstallDirs) {
     try {

--- a/src/utils/openclaudeDisplayPaths.ts
+++ b/src/utils/openclaudeDisplayPaths.ts
@@ -10,7 +10,6 @@ import { getDisplayPath } from './file.js'
 function getUserConfigHomeForDisplay(): string {
   const configDirEnv = resolveConfigDirEnv({
     openClaudeConfigDir: process.env.OPENCLAUDE_CONFIG_DIR,
-    legacyConfigDir: process.env.CLAUDE_CONFIG_DIR,
   })
 
   if (configDirEnv) {

--- a/src/utils/openclaudeInstallSurfaces.test.ts
+++ b/src/utils/openclaudeInstallSurfaces.test.ts
@@ -33,6 +33,7 @@ const realExecFileNoThrowModule = { ...realExecFileNoThrow }
 let simulateNpmUninstallFailure = false
 let simulateNpmUninstallEnotempty = false
 let fakeNpmPrefix: string | undefined
+const npmUninstallPackages: string[] = []
 
 mock.module('./execFileNoThrow.js', () => ({
   ...realExecFileNoThrowModule,
@@ -51,6 +52,7 @@ mock.module('./execFileNoThrow.js', () => ({
       }
 
       if (simulateNpmUninstallEnotempty && commandArgs[0] === 'uninstall') {
+        npmUninstallPackages.push(String(commandArgs.at(-1)))
         return Promise.resolve({
           stdout: '',
           stderr: 'npm error code ENOTEMPTY',
@@ -59,6 +61,7 @@ mock.module('./execFileNoThrow.js', () => ({
       }
 
       if (simulateNpmUninstallFailure && commandArgs[0] === 'uninstall') {
+        npmUninstallPackages.push(String(commandArgs.at(-1)))
         return Promise.resolve({
           stdout: '',
           stderr: 'npm ERR! code E404',
@@ -86,6 +89,7 @@ afterEach(() => {
     simulateNpmUninstallFailure = false
     simulateNpmUninstallEnotempty = false
     fakeNpmPrefix = undefined
+    npmUninstallPackages.length = 0
     mock.restore()
     mock.module('../utils/env.js', () => realEnv)
     mock.module('./envUtils.js', () => realEnvUtils)
@@ -248,12 +252,13 @@ test('install command repairs launcher after npm cleanup before final check', as
   ])
 })
 
-test('cleanupNpmInstallations removes both openclaude and legacy claude local install dirs', async () => {
+test('cleanupNpmInstallations removes only openclaude local install dir', async () => {
   const removedPaths: string[] = []
   ;(globalThis as Record<string, unknown>).MACRO = {
     PACKAGE_URL: '@gitlawb/openclaude',
   }
-  process.env.CLAUDE_CONFIG_DIR = join(homedir(), '.openclaude')
+  process.env.OPENCLAUDE_CONFIG_DIR = join(homedir(), '.openclaude')
+  delete process.env.CLAUDE_CONFIG_DIR
 
   mock.module('fs/promises', () => ({
     ...fsPromises,
@@ -273,7 +278,9 @@ test('cleanupNpmInstallations removes both openclaude and legacy claude local in
   await cleanupNpmInstallations()
 
   expect(removedPaths).toContain(join(homedir(), '.openclaude', 'local'))
-  expect(removedPaths).toContain(join(homedir(), '.claude', 'local'))
+  expect(removedPaths).not.toContain(join(homedir(), '.claude', 'local'))
+  expect(npmUninstallPackages).toContain('@gitlawb/openclaude')
+  expect(npmUninstallPackages).not.toContain('@anthropic-ai/claude-code')
 })
 
 test('cleanupNpmInstallations manual fallback removes openclaude npm shim', async () => {
@@ -287,7 +294,8 @@ test('cleanupNpmInstallations manual fallback removes openclaude npm shim', asyn
   }
   process.env.HOME = testHome
   process.env.USERPROFILE = testHome
-  process.env.CLAUDE_CONFIG_DIR = join(testHome, '.openclaude')
+  process.env.OPENCLAUDE_CONFIG_DIR = join(testHome, '.openclaude')
+  delete process.env.CLAUDE_CONFIG_DIR
   fakeNpmPrefix = npmPrefix
   simulateNpmUninstallEnotempty = true
 

--- a/src/utils/openclaudePaths.test.ts
+++ b/src/utils/openclaudePaths.test.ts
@@ -351,7 +351,6 @@ describe('OpenClaude paths', () => {
     expect(
       getCandidateLocalInstallDirs({
         configHomeDir: join(homedir(), '.openclaude'),
-        homeDir: homedir(),
       }),
     ).toEqual([
       join(homedir(), '.openclaude', 'local'),

--- a/src/utils/openclaudePaths.test.ts
+++ b/src/utils/openclaudePaths.test.ts
@@ -3,7 +3,6 @@ import {
   existsSync,
   mkdirSync,
   mkdtempSync,
-  readFileSync,
   rmSync,
   writeFileSync,
 } from 'fs'
@@ -68,7 +67,7 @@ describe('OpenClaude paths', () => {
     ).toBe(join(homedir(), '.openclaude'))
   })
 
-  test('migrates legacy config home and global config files to .openclaude', async () => {
+  test('does not migrate legacy .claude config into .openclaude', async () => {
     await acquireEnvMutex()
     const tempHome = mkdtempSync(join(tmpdir(), 'openclaude-paths-test-'))
     try {
@@ -85,115 +84,13 @@ describe('OpenClaude paths', () => {
         join(tempHome, '.claude-custom-oauth.json'),
         '{"custom":true}',
       )
-
-      const { migrateLegacyClaudeConfigHome } = await importFreshEnvUtils()
-
-      expect(migrateLegacyClaudeConfigHome({ homeDir: tempHome })).toBe(true)
-      expect(
-        readFileSync(
-          join(tempHome, '.openclaude', 'skills', 'legacy-skill', 'SKILL.md'),
-          'utf8',
-        ),
-      ).toBe('legacy skill')
-      expect(existsSync(join(tempHome, '.openclaude', 'settings.json'))).toBe(
-        true,
-      )
-      expect(readFileSync(join(tempHome, '.openclaude.json'), 'utf8')).toBe(
-        '{"legacy":true}',
-      )
-      expect(
-        readFileSync(join(tempHome, '.openclaude-custom-oauth.json'), 'utf8'),
-      ).toBe('{"custom":true}')
-    } finally {
-      rmSync(tempHome, { recursive: true, force: true })
-    }
-  })
-
-  test('migration preserves existing .openclaude data while copying missing legacy data', async () => {
-    await acquireEnvMutex()
-    const tempHome = mkdtempSync(join(tmpdir(), 'openclaude-paths-test-'))
-    try {
-      mkdirSync(join(tempHome, '.claude', 'skills', 'legacy-skill'), {
-        recursive: true,
-      })
-      mkdirSync(join(tempHome, '.openclaude', 'skills'), { recursive: true })
-      writeFileSync(join(tempHome, '.claude', 'settings.json'), 'legacy')
-      writeFileSync(join(tempHome, '.openclaude', 'settings.json'), 'current')
-      writeFileSync(
-        join(tempHome, '.claude', 'skills', 'legacy-skill', 'SKILL.md'),
-        'legacy skill',
-      )
-
-      const { migrateLegacyClaudeConfigHome } = await importFreshEnvUtils()
-
-      expect(migrateLegacyClaudeConfigHome({ homeDir: tempHome })).toBe(true)
-      expect(
-        readFileSync(join(tempHome, '.openclaude', 'settings.json'), 'utf8'),
-      ).toBe('current')
-      expect(
-        readFileSync(
-          join(tempHome, '.openclaude', 'skills', 'legacy-skill', 'SKILL.md'),
-          'utf8',
-        ),
-      ).toBe('legacy skill')
-    } finally {
-      rmSync(tempHome, { recursive: true, force: true })
-    }
-  })
-
-  test('migration skips explicit CLAUDE_CONFIG_DIR overrides', async () => {
-    await acquireEnvMutex()
-    const tempHome = mkdtempSync(join(tmpdir(), 'openclaude-paths-test-'))
-    try {
-      mkdirSync(join(tempHome, '.claude'), { recursive: true })
-      writeFileSync(join(tempHome, '.claude', 'settings.json'), 'legacy')
-
-      const { migrateLegacyClaudeConfigHome } = await importFreshEnvUtils()
-
-      expect(
-        migrateLegacyClaudeConfigHome({
-          configDirEnv: join(tempHome, 'custom-config'),
-          homeDir: tempHome,
-        }),
-      ).toBe(true)
       expect(existsSync(join(tempHome, '.openclaude'))).toBe(false)
     } finally {
       rmSync(tempHome, { recursive: true, force: true })
     }
   })
 
-  test('migration fails closed when .openclaude collides with a non-directory', async () => {
-    await acquireEnvMutex()
-    const tempHome = mkdtempSync(join(tmpdir(), 'openclaude-paths-test-'))
-    try {
-      writeFileSync(join(tempHome, '.openclaude'), 'not a directory')
-      mkdirSync(join(tempHome, '.claude'), { recursive: true })
-      writeFileSync(join(tempHome, '.claude', 'settings.json'), 'legacy')
-
-      const { migrateLegacyClaudeConfigHome } = await importFreshEnvUtils()
-
-      expect(migrateLegacyClaudeConfigHome({ homeDir: tempHome })).toBe(false)
-    } finally {
-      rmSync(tempHome, { recursive: true, force: true })
-    }
-  })
-
-  test('migration ignores non-directory legacy config homes', async () => {
-    await acquireEnvMutex()
-    const tempHome = mkdtempSync(join(tmpdir(), 'openclaude-paths-test-'))
-    try {
-      writeFileSync(join(tempHome, '.claude'), 'not a directory')
-
-      const { migrateLegacyClaudeConfigHome } = await importFreshEnvUtils()
-
-      expect(migrateLegacyClaudeConfigHome({ homeDir: tempHome })).toBe(true)
-      expect(existsSync(join(tempHome, '.openclaude'))).toBe(false)
-    } finally {
-      rmSync(tempHome, { recursive: true, force: true })
-    }
-  })
-
-  test('config home falls back to legacy when migration fails on a non-directory .openclaude collision', async () => {
+  test('config home does not fall back to legacy .claude', async () => {
     await acquireEnvMutex()
     const tempHome = mkdtempSync(join(tmpdir(), 'openclaude-paths-test-'))
     try {
@@ -208,7 +105,7 @@ describe('OpenClaude paths', () => {
 
       const { getClaudeConfigHomeDir } = await importFreshEnvUtils()
 
-      expect(getClaudeConfigHomeDir()).toBe(join(tempHome, '.claude'))
+      expect(getClaudeConfigHomeDir()).toBe(join(tempHome, '.openclaude'))
     } finally {
       rmSync(tempHome, { recursive: true, force: true })
     }
@@ -225,7 +122,7 @@ describe('OpenClaude paths', () => {
     )
   })
 
-  test('default plans directory respects explicit CLAUDE_CONFIG_DIR', async () => {
+  test('default plans directory respects explicit configDirEnv argument', async () => {
     await acquireEnvMutex()
     const { getDefaultPlansDirectory } = await importFreshPlans()
 
@@ -265,7 +162,7 @@ describe('OpenClaude paths', () => {
     ).toBe(join('/tmp/caf\u00e9', '.openclaude', 'plans'))
   })
 
-  test('default plans directory normalizes explicit CLAUDE_CONFIG_DIR to NFC', async () => {
+  test('default plans directory normalizes explicit configDirEnv argument to NFC', async () => {
     await acquireEnvMutex()
     const { getDefaultPlansDirectory } = await importFreshPlans()
 
@@ -274,19 +171,17 @@ describe('OpenClaude paths', () => {
     ).toBe(join('/tmp/caf\u00e9-openclaude', 'plans'))
   })
 
-  test('uses CLAUDE_CONFIG_DIR override when provided (legacy)', async () => {
+  test('ignores CLAUDE_CONFIG_DIR override when provided', async () => {
     await acquireEnvMutex()
     delete process.env.OPENCLAUDE_CONFIG_DIR
     process.env.CLAUDE_CONFIG_DIR = '/tmp/custom-openclaude'
-    const { getClaudeConfigHomeDir, resolveClaudeConfigHomeDir } =
-      await importFreshEnvUtils()
+    mock.module('os', () => ({
+      homedir: () => '/tmp/home',
+      tmpdir,
+    }))
+    const { getClaudeConfigHomeDir } = await importFreshEnvUtils()
 
-    expect(getClaudeConfigHomeDir()).toBe('/tmp/custom-openclaude')
-    expect(
-      resolveClaudeConfigHomeDir({
-        configDirEnv: '/tmp/custom-openclaude',
-      }),
-    ).toBe('/tmp/custom-openclaude')
+    expect(getClaudeConfigHomeDir()).toBe('/tmp/home/.openclaude')
   })
 
   test('OPENCLAUDE_CONFIG_DIR overrides the default (issue #454)', async () => {
@@ -307,25 +202,25 @@ describe('OpenClaude paths', () => {
     expect(getClaudeConfigHomeDir()).toBe('/tmp/oc-wins')
   })
 
-  test('CLAUDE_CONFIG_DIR is still honored when OPENCLAUDE_CONFIG_DIR is unset', async () => {
+  test('CLAUDE_CONFIG_DIR is ignored when OPENCLAUDE_CONFIG_DIR is unset', async () => {
     await acquireEnvMutex()
     delete process.env.OPENCLAUDE_CONFIG_DIR
     process.env.CLAUDE_CONFIG_DIR = '/tmp/legacy-only'
     const { getClaudeConfigHomeDir } = await importFreshEnvUtils()
 
-    expect(getClaudeConfigHomeDir()).toBe('/tmp/legacy-only')
+    expect(getClaudeConfigHomeDir()).not.toBe('/tmp/legacy-only')
   })
 
-  test('empty OPENCLAUDE_CONFIG_DIR falls through to CLAUDE_CONFIG_DIR', async () => {
+  test('empty OPENCLAUDE_CONFIG_DIR does not fall through to CLAUDE_CONFIG_DIR', async () => {
     await acquireEnvMutex()
     process.env.OPENCLAUDE_CONFIG_DIR = ''
     process.env.CLAUDE_CONFIG_DIR = '/tmp/legacy-fallback'
     const { getClaudeConfigHomeDir } = await importFreshEnvUtils()
 
-    expect(getClaudeConfigHomeDir()).toBe('/tmp/legacy-fallback')
+    expect(getClaudeConfigHomeDir()).not.toBe('/tmp/legacy-fallback')
   })
 
-  test('resolveConfigDirEnv prefers OPENCLAUDE over CLAUDE and warns on conflict', async () => {
+  test('resolveConfigDirEnv ignores CLAUDE_CONFIG_DIR without warning', async () => {
     await acquireEnvMutex()
     const { resolveConfigDirEnv, __resetConfigDirEnvWarningForTesting } =
       await importFreshEnvUtils()
@@ -339,19 +234,17 @@ describe('OpenClaude paths', () => {
     })
 
     expect(result).toBe('/a')
-    expect(warnings.length).toBe(1)
-    expect(warnings[0]).toContain('OPENCLAUDE_CONFIG_DIR=/a')
-    expect(warnings[0]).toContain('CLAUDE_CONFIG_DIR=/b')
+    expect(warnings.length).toBe(0)
 
     resolveConfigDirEnv({
       openClaudeConfigDir: '/x',
       legacyConfigDir: '/y',
       warn: m => warnings.push(m),
     })
-    expect(warnings.length).toBe(1)
+    expect(warnings.length).toBe(0)
   })
 
-  test('resolveConfigDirEnv silent callers do not consume the conflict warning', async () => {
+  test('resolveConfigDirEnv ignores legacy env for silent and warning callers', async () => {
     await acquireEnvMutex()
     const { resolveConfigDirEnv, __resetConfigDirEnvWarningForTesting } =
       await importFreshEnvUtils()
@@ -372,9 +265,7 @@ describe('OpenClaude paths', () => {
         warn: m => warnings.push(m),
       }),
     ).toBe('/warn-open')
-    expect(warnings.length).toBe(1)
-    expect(warnings[0]).toContain('OPENCLAUDE_CONFIG_DIR=/warn-open')
-    expect(warnings[0]).toContain('CLAUDE_CONFIG_DIR=/warn-legacy')
+    expect(warnings.length).toBe(0)
   })
 
   test('resolveConfigDirEnv does not warn when both env vars agree', async () => {
@@ -420,9 +311,8 @@ describe('OpenClaude paths', () => {
 
   test('local installer uses openclaude wrapper path', async () => {
     await acquireEnvMutex()
-    // Force .openclaude config home so the test doesn't fall back to
-    // ~/.claude when ~/.openclaude doesn't exist on this machine.
-    process.env.CLAUDE_CONFIG_DIR = join(homedir(), '.openclaude')
+    process.env.OPENCLAUDE_CONFIG_DIR = join(homedir(), '.openclaude')
+    delete process.env.CLAUDE_CONFIG_DIR
     const { getLocalClaudePath } = await importFreshLocalInstaller()
 
     expect(getLocalClaudePath()).toBe(
@@ -442,7 +332,7 @@ describe('OpenClaude paths', () => {
     ).toBe(true)
   })
 
-  test('local installation detection still matches legacy .claude path', async () => {
+  test('local installation detection ignores legacy .claude path', async () => {
     await acquireEnvMutex()
     const { isManagedLocalInstallationPath } =
       await importFreshLocalInstaller()
@@ -451,10 +341,10 @@ describe('OpenClaude paths', () => {
       isManagedLocalInstallationPath(
         `${join(homedir(), '.claude', 'local')}/node_modules/.bin/openclaude`,
       ),
-    ).toBe(true)
+    ).toBe(false)
   })
 
-  test('candidate local install dirs include both openclaude and legacy claude paths', async () => {
+  test('candidate local install dirs include only openclaude path', async () => {
     await acquireEnvMutex()
     const { getCandidateLocalInstallDirs } = await importFreshLocalInstaller()
 
@@ -465,11 +355,10 @@ describe('OpenClaude paths', () => {
       }),
     ).toEqual([
       join(homedir(), '.openclaude', 'local'),
-      join(homedir(), '.claude', 'local'),
     ])
   })
 
-  test('legacy local installs are detected when they still expose the claude binary', async () => {
+  test('legacy local installs are ignored even when they expose the claude binary', async () => {
     await acquireEnvMutex()
     mock.module('fs/promises', () => ({
       ...fsPromises,
@@ -486,9 +375,7 @@ describe('OpenClaude paths', () => {
     const { getDetectedLocalInstallDir, localInstallationExists } =
       await importFreshLocalInstaller()
 
-    expect(await localInstallationExists()).toBe(true)
-    expect(await getDetectedLocalInstallDir()).toBe(
-      join(homedir(), '.claude', 'local'),
-    )
+    expect(await localInstallationExists()).toBe(false)
+    expect(await getDetectedLocalInstallDir()).toBeNull()
   })
 })

--- a/src/utils/openclaudePaths.test.ts
+++ b/src/utils/openclaudePaths.test.ts
@@ -208,7 +208,7 @@ describe('OpenClaude paths', () => {
     process.env.CLAUDE_CONFIG_DIR = '/tmp/legacy-only'
     const { getClaudeConfigHomeDir } = await importFreshEnvUtils()
 
-    expect(getClaudeConfigHomeDir()).not.toBe('/tmp/legacy-only')
+    expect(getClaudeConfigHomeDir()).toBe(join(homedir(), '.openclaude'))
   })
 
   test('empty OPENCLAUDE_CONFIG_DIR does not fall through to CLAUDE_CONFIG_DIR', async () => {
@@ -217,7 +217,7 @@ describe('OpenClaude paths', () => {
     process.env.CLAUDE_CONFIG_DIR = '/tmp/legacy-fallback'
     const { getClaudeConfigHomeDir } = await importFreshEnvUtils()
 
-    expect(getClaudeConfigHomeDir()).not.toBe('/tmp/legacy-fallback')
+    expect(getClaudeConfigHomeDir()).toBe(join(homedir(), '.openclaude'))
   })
 
   test('resolveConfigDirEnv ignores CLAUDE_CONFIG_DIR without warning', async () => {

--- a/src/utils/openclaudeUiSurfaces.test.ts
+++ b/src/utils/openclaudeUiSurfaces.test.ts
@@ -10,6 +10,7 @@ import { isInGlobalClaudeFolder } from '../components/permissions/FilePermission
 import { getDisplayPath } from './file.ts'
 import { getDefaultPermissionModeOptions } from './permissions/defaultPermissionModeOptions.ts'
 import {
+  checkPathSafetyForAutoEdit,
   getClaudeSkillScope,
   isClaudeSettingsPath,
 } from './permissions/filesystem.ts'
@@ -55,6 +56,28 @@ describe('OpenClaude settings path surfaces', () => {
         join(process.cwd(), '.openclaude', 'settings.local.json'),
       ),
     ).toBe(true)
+  })
+
+  test('legacy .claude paths remain protected from auto-editing', () => {
+    expect(
+      isClaudeSettingsPath(join(process.cwd(), '.claude', 'settings.json')),
+    ).toBe(true)
+    expect(
+      isClaudeSettingsPath(
+        join(process.cwd(), '.claude', 'settings.local.json'),
+      ),
+    ).toBe(true)
+
+    expect(
+      checkPathSafetyForAutoEdit(
+        join(process.cwd(), '.claude', 'settings.json'),
+      ),
+    ).toMatchObject({ safe: false })
+    expect(
+      checkPathSafetyForAutoEdit(
+        join(process.cwd(), '.claude', 'commands', 'foo.md'),
+      ),
+    ).toMatchObject({ safe: false })
   })
 
   test('permission save destinations point user settings to configured OPENCLAUDE_CONFIG_DIR', async () => {

--- a/src/utils/openclaudeUiSurfaces.test.ts
+++ b/src/utils/openclaudeUiSurfaces.test.ts
@@ -109,7 +109,8 @@ describe('OpenClaude settings path surfaces', () => {
   })
 
   test('permission dialog treats ~/.openclaude as the global Claude folder', () => {
-    process.env.CLAUDE_CONFIG_DIR = join(homedir(), '.openclaude')
+    process.env.OPENCLAUDE_CONFIG_DIR = join(homedir(), '.openclaude')
+    delete process.env.CLAUDE_CONFIG_DIR
 
     expect(
       isInGlobalClaudeFolder(
@@ -118,7 +119,7 @@ describe('OpenClaude settings path surfaces', () => {
     ).toBe(true)
     expect(
       isInGlobalClaudeFolder(join(homedir(), '.claude', 'settings.json')),
-    ).toBe(true)
+    ).toBe(false)
   })
 
   test('permission dialog does not treat arbitrary CLAUDE_CONFIG_DIR as the global Claude folder', () => {
@@ -131,8 +132,9 @@ describe('OpenClaude settings path surfaces', () => {
     ).toBe(false)
   })
 
-  test('global skill scope recognizes ~/.openclaude and legacy ~/.claude skills', () => {
-    process.env.CLAUDE_CONFIG_DIR = join(homedir(), '.openclaude')
+  test('global skill scope recognizes ~/.openclaude skills only', () => {
+    process.env.OPENCLAUDE_CONFIG_DIR = join(homedir(), '.openclaude')
+    delete process.env.CLAUDE_CONFIG_DIR
 
     expect(
       getClaudeSkillScope(
@@ -147,10 +149,7 @@ describe('OpenClaude settings path surfaces', () => {
       getClaudeSkillScope(
         join(homedir(), '.claude', 'skills', 'legacy', 'SKILL.md'),
       ),
-    ).toEqual({
-      skillName: 'legacy',
-      pattern: '~/.claude/skills/legacy/**',
-    })
+    ).toBeNull()
   })
 
   test('global skill scope does not emit fixed rules for arbitrary CLAUDE_CONFIG_DIR skills', () => {

--- a/src/utils/permissions/filesystem.ts
+++ b/src/utils/permissions/filesystem.ts
@@ -81,6 +81,7 @@ export const DANGEROUS_DIRECTORIES = [
   '.vscode',
   '.idea',
   '.openclaude',
+  '.claude',
 ] as const
 
 /**
@@ -215,9 +216,13 @@ export function isClaudeSettingsPath(filePath: string): boolean {
   // Use platform separator so endsWith checks work on both Unix (/) and Windows (\)
   if (
     normalizedPath.endsWith(`${sep}.openclaude${sep}settings.json`) ||
-    normalizedPath.endsWith(`${sep}.openclaude${sep}settings.local.json`)
+    normalizedPath.endsWith(`${sep}.openclaude${sep}settings.local.json`) ||
+    normalizedPath.endsWith(`${sep}.claude${sep}settings.json`) ||
+    normalizedPath.endsWith(`${sep}.claude${sep}settings.local.json`)
   ) {
-    // Include .openclaude/settings.json even for other projects
+    // Include .openclaude and legacy .claude settings even for other projects.
+    // This is write-safety classification only; config loading does not read
+    // or migrate from .claude.
     return true
   }
   // Check for current project's settings files (including managed settings and CLI args)

--- a/src/utils/permissions/filesystem.ts
+++ b/src/utils/permissions/filesystem.ts
@@ -10,7 +10,6 @@ import {
   CLAUDE_FOLDER_PERMISSION_PATTERN,
   FILE_EDIT_TOOL_NAME,
   GLOBAL_CLAUDE_FOLDER_PERMISSION_PATTERN,
-  LEGACY_GLOBAL_CLAUDE_FOLDER_PERMISSION_PATTERN,
 } from 'src/tools/FileEditTool/constants.js'
 import type { z } from 'zod/v4'
 import { getOriginalCwd, getSessionId } from '../../bootstrap/state.js'
@@ -70,7 +69,6 @@ export const DANGEROUS_FILES = [
   '.ripgreprc',
   '.mcp.json',
   '.openclaude.json',
-  '.claude.json',
 ] as const
 
 /**
@@ -81,7 +79,6 @@ export const DANGEROUS_DIRECTORIES = [
   '.git',
   '.vscode',
   '.idea',
-  '.claude',
   '.openclaude',
 ] as const
 
@@ -99,13 +96,12 @@ export function normalizeCaseForComparison(path: string): string {
 }
 
 /**
- * If filePath is inside a .claude/skills/{name}/ directory (project) or
- * .openclaude/skills/{name}/ directory (global), plus the legacy global
- * .claude/skills path, return the skill name and a session-allow pattern
+ * If filePath is inside a .openclaude/skills/{name}/ directory (project) or
+ * .openclaude/skills/{name}/ directory (global), return the skill name and a session-allow pattern
  * scoped to just that skill.
  * Used to offer a narrower "allow edits to this skill only" option in the
  * permission dialog and SDK suggestions, so iterating on one skill doesn't
- * require granting session access to all of .claude/ (settings.json, hooks/, etc.).
+ * require granting session access to all of .openclaude/ (settings.json, hooks/, etc.).
  */
 export function getClaudeSkillScope(
   filePath: string,
@@ -115,16 +111,12 @@ export function getClaudeSkillScope(
 
   const bases = [
     {
-      dir: expandPath(join(getOriginalCwd(), '.claude', 'skills')),
-      prefix: '/.claude/skills/',
+      dir: expandPath(join(getOriginalCwd(), '.openclaude', 'skills')),
+      prefix: '/.openclaude/skills/',
     },
     {
       dir: expandPath(join(homedir(), '.openclaude', 'skills')),
       prefix: '~/.openclaude/skills/',
-    },
-    {
-      dir: expandPath(join(homedir(), '.claude', 'skills')),
-      prefix: '~/.claude/skills/',
     },
   ]
 
@@ -222,11 +214,9 @@ export function isClaudeSettingsPath(filePath: string): boolean {
   // Use platform separator so endsWith checks work on both Unix (/) and Windows (\)
   if (
     normalizedPath.endsWith(`${sep}.openclaude${sep}settings.json`) ||
-    normalizedPath.endsWith(`${sep}.openclaude${sep}settings.local.json`) ||
-    normalizedPath.endsWith(`${sep}.claude${sep}settings.json`) ||
-    normalizedPath.endsWith(`${sep}.claude${sep}settings.local.json`)
+    normalizedPath.endsWith(`${sep}.openclaude${sep}settings.local.json`)
   ) {
-    // Include .claude/settings.json even for other projects
+    // Include .openclaude/settings.json even for other projects
     return true
   }
   // Check for current project's settings files (including managed settings and CLI args)
@@ -242,23 +232,17 @@ function isClaudeConfigFilePath(filePath: string): boolean {
     return true
   }
 
-  // Check if file is within .claude/commands or .claude/agents directories
+  // Check if file is within .openclaude/commands or .openclaude/agents directories
   // using proper path segment validation (not string matching with includes())
   // pathInWorkingPath now handles case-insensitive comparison to prevent bypasses
-  const commandsDir = join(getOriginalCwd(), '.claude', 'commands')
-  const agentsDir = join(getOriginalCwd(), '.claude', 'agents')
-  const skillsDir = join(getOriginalCwd(), '.claude', 'skills')
-  const openCommandsDir = join(getOriginalCwd(), '.openclaude', 'commands')
-  const openAgentsDir = join(getOriginalCwd(), '.openclaude', 'agents')
-  const openSkillsDir = join(getOriginalCwd(), '.openclaude', 'skills')
+  const commandsDir = join(getOriginalCwd(), '.openclaude', 'commands')
+  const agentsDir = join(getOriginalCwd(), '.openclaude', 'agents')
+  const skillsDir = join(getOriginalCwd(), '.openclaude', 'skills')
 
   return (
     pathInWorkingPath(filePath, commandsDir) ||
     pathInWorkingPath(filePath, agentsDir) ||
-    pathInWorkingPath(filePath, skillsDir) ||
-    pathInWorkingPath(filePath, openCommandsDir) ||
-    pathInWorkingPath(filePath, openAgentsDir) ||
-    pathInWorkingPath(filePath, openSkillsDir)
+    pathInWorkingPath(filePath, skillsDir)
   )
 }
 
@@ -536,17 +520,17 @@ function isDangerousFilePathToAutoEdit(path: string): boolean {
         continue
       }
 
-      // Special case: .claude/worktrees/ is a structural path (where Claude stores
-      // git worktrees), not a user-created dangerous directory. Skip the .claude
-      // segment when it's followed by 'worktrees'. Any nested .claude directories
+      // Special case: .openclaude/worktrees/ is a structural path (where OpenClaude stores
+      // git worktrees), not a user-created dangerous directory. Skip the .openclaude
+      // segment when it's followed by 'worktrees'. Any nested .openclaude directories
       // within the worktree (not followed by 'worktrees') are still blocked.
-      if (dir === '.claude') {
+      if (dir === '.openclaude') {
         const nextSegment = pathSegments[i + 1]
         if (
           nextSegment &&
           normalizeCaseForComparison(nextSegment) === 'worktrees'
         ) {
-          break // Skip this .claude, continue checking other segments
+          break // Skip this .openclaude, continue checking other segments
         }
       }
 
@@ -1356,22 +1340,19 @@ export function checkWritePermissionForTool<Input extends AnyObject>(
   )
   if (claudeFolderAllowRule) {
     // Check if this rule is scoped under a Claude config folder.
-    // Accepts broad project/global patterns ('/.claude/**',
-    // '~/.openclaude/**', and legacy '~/.claude/**') plus narrowed skill
+    // Accepts broad project/global patterns ('/.openclaude/**',
+    // '~/.openclaude/**') plus narrowed skill
     // patterns like '~/.openclaude/skills/my-skill/**' so users can grant
     // session access to a single skill without also exposing settings.json
     // or hooks/. The rule already matched the path via matchingRuleForInput;
     // this is an additional scope check. Reject '..' to prevent a rule like
-    // '/.claude/../**' from leaking this bypass outside the config folder.
+    // '/.openclaude/../**' from leaking this bypass outside the config folder.
     const ruleContent = claudeFolderAllowRule.ruleValue.ruleContent
     if (
       ruleContent &&
       (ruleContent.startsWith(CLAUDE_FOLDER_PERMISSION_PATTERN.slice(0, -2)) ||
         ruleContent.startsWith(
           GLOBAL_CLAUDE_FOLDER_PERMISSION_PATTERN.slice(0, -2),
-        ) ||
-        ruleContent.startsWith(
-          LEGACY_GLOBAL_CLAUDE_FOLDER_PERMISSION_PATTERN.slice(0, -2),
         )) &&
       !ruleContent.includes('..') &&
       ruleContent.endsWith('/**')
@@ -1679,16 +1660,16 @@ export function checkEditableInternalPath(
     }
   }
 
-  // .claude/launch.json — desktop preview config (dev server command + port).
+  // .openclaude/launch.json — desktop preview config (dev server command + port).
   // The desktop's preview_start MCP tool instructs Claude to create/update
   // this file as part of the preview workflow. Without this carve-out the
-  // .claude/ DANGEROUS_DIRECTORIES check prompts for it, which in SDK mode
+  // .openclaude/ DANGEROUS_DIRECTORIES check prompts for it, which in SDK mode
   // cascades: user clicks "Always allow" → setMode:acceptEdits suggestion
   // applied → silent downgrade from auto mode. Matches the project-level
-  // .claude/ only (not ~/.claude/) since launch.json is per-project.
+  // .openclaude/ only (not ~/.openclaude/) since launch.json is per-project.
   if (
     normalizeCaseForComparison(normalizedPath) ===
-    normalizeCaseForComparison(join(getOriginalCwd(), '.claude', 'launch.json'))
+    normalizeCaseForComparison(join(getOriginalCwd(), '.openclaude', 'launch.json'))
   ) {
     return {
       behavior: 'allow',

--- a/src/utils/permissions/filesystem.ts
+++ b/src/utils/permissions/filesystem.ts
@@ -69,6 +69,7 @@ export const DANGEROUS_FILES = [
   '.ripgreprc',
   '.mcp.json',
   '.openclaude.json',
+  '.claude.json',
 ] as const
 
 /**

--- a/src/utils/plugins/addDirPluginSettings.ts
+++ b/src/utils/plugins/addDirPluginSettings.ts
@@ -37,7 +37,7 @@ export function getAddDirEnabledPlugins(): NonNullable<
   const result: NonNullable<SettingsJson['enabledPlugins']> = {}
   for (const dir of getAdditionalDirectoriesForClaudeMd()) {
     for (const file of SETTINGS_FILES) {
-      const { settings } = parseSettingsFile(join(dir, '.claude', file))
+      const { settings } = parseSettingsFile(join(dir, '.openclaude', file))
       if (!settings?.enabledPlugins) {
         continue
       }
@@ -60,7 +60,7 @@ export function getAddDirExtraMarketplaces(): Record<
   const result: Record<string, ExtraKnownMarketplace> = {}
   for (const dir of getAdditionalDirectoriesForClaudeMd()) {
     for (const file of SETTINGS_FILES) {
-      const { settings } = parseSettingsFile(join(dir, '.claude', file))
+      const { settings } = parseSettingsFile(join(dir, '.openclaude', file))
       if (!settings?.extraKnownMarketplaces) {
         continue
       }

--- a/src/utils/sandbox/sandbox-adapter.test.ts
+++ b/src/utils/sandbox/sandbox-adapter.test.ts
@@ -66,4 +66,26 @@ describe('convertToSandboxRuntimeConfig', () => {
       resolve(activeCwd, '.openclaude', 'settings.local.json'),
     )
   })
+
+  test('denies legacy Claude config surfaces in original and changed cwd', () => {
+    const config = convertToSandboxRuntimeConfig({} as SettingsJson)
+
+    for (const cwd of [getOriginalCwd(), activeCwd]) {
+      expect(config.filesystem.denyWrite).toContain(
+        resolve(cwd, '.claude', 'settings.json'),
+      )
+      expect(config.filesystem.denyWrite).toContain(
+        resolve(cwd, '.claude', 'settings.local.json'),
+      )
+      expect(config.filesystem.denyWrite).toContain(
+        resolve(cwd, '.claude', 'commands'),
+      )
+      expect(config.filesystem.denyWrite).toContain(
+        resolve(cwd, '.claude', 'agents'),
+      )
+      expect(config.filesystem.denyWrite).toContain(
+        resolve(cwd, '.claude', 'skills'),
+      )
+    }
+  })
 })

--- a/src/utils/sandbox/sandbox-adapter.test.ts
+++ b/src/utils/sandbox/sandbox-adapter.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
 import { mkdtemp, rm } from 'fs/promises'
 import { tmpdir } from 'os'
-import { join, resolve } from 'path'
+import { join, resolve, sep } from 'path'
 import {
   getCwdState,
   getOriginalCwd,
@@ -72,19 +72,7 @@ describe('convertToSandboxRuntimeConfig', () => {
 
     for (const cwd of [getOriginalCwd(), activeCwd]) {
       expect(config.filesystem.denyWrite).toContain(
-        resolve(cwd, '.claude', 'settings.json'),
-      )
-      expect(config.filesystem.denyWrite).toContain(
-        resolve(cwd, '.claude', 'settings.local.json'),
-      )
-      expect(config.filesystem.denyWrite).toContain(
-        resolve(cwd, '.claude', 'commands'),
-      )
-      expect(config.filesystem.denyWrite).toContain(
-        resolve(cwd, '.claude', 'agents'),
-      )
-      expect(config.filesystem.denyWrite).toContain(
-        resolve(cwd, '.claude', 'skills'),
+        resolve(cwd, '.claude'),
       )
     }
   })
@@ -93,14 +81,27 @@ describe('convertToSandboxRuntimeConfig', () => {
     const config = convertToSandboxRuntimeConfig({} as SettingsJson)
     const configDir = process.env.CLAUDE_CONFIG_DIR!
 
-    expect(config.filesystem.denyWrite).toContain(
-      resolve(configDir, 'settings.json'),
-    )
-    expect(config.filesystem.denyWrite).toContain(
-      resolve(configDir, 'settings.local.json'),
-    )
-    expect(config.filesystem.denyWrite).toContain(resolve(configDir, 'commands'))
-    expect(config.filesystem.denyWrite).toContain(resolve(configDir, 'agents'))
-    expect(config.filesystem.denyWrite).toContain(resolve(configDir, 'skills'))
+    expect(config.filesystem.denyWrite).toContain(resolve(configDir))
+  })
+
+  test('root deny covers non-settings legacy Claude state', () => {
+    const config = convertToSandboxRuntimeConfig({} as SettingsJson)
+
+    const representativeLegacyPaths = [
+      resolve(getOriginalCwd(), '.claude', 'CLAUDE.md'),
+      resolve(activeCwd, '.claude', 'credentials.json'),
+      resolve(process.env.CLAUDE_CONFIG_DIR!, 'plugins', 'plugin.json'),
+      resolve(process.env.CLAUDE_CONFIG_DIR!, 'scheduled-tasks', 'task.json'),
+    ]
+
+    for (const legacyPath of representativeLegacyPaths) {
+      expect(
+        config.filesystem.denyWrite.some(
+          deniedRoot =>
+            legacyPath === deniedRoot ||
+            legacyPath.startsWith(`${deniedRoot}${sep}`),
+        ),
+      ).toBe(true)
+    }
   })
 })

--- a/src/utils/sandbox/sandbox-adapter.test.ts
+++ b/src/utils/sandbox/sandbox-adapter.test.ts
@@ -65,11 +65,5 @@ describe('convertToSandboxRuntimeConfig', () => {
     expect(config.filesystem.denyWrite).toContain(
       resolve(activeCwd, '.openclaude', 'settings.local.json'),
     )
-    expect(config.filesystem.denyWrite).toContain(
-      resolve(activeCwd, '.claude', 'settings.json'),
-    )
-    expect(config.filesystem.denyWrite).toContain(
-      resolve(activeCwd, '.claude', 'settings.local.json'),
-    )
   })
 })

--- a/src/utils/sandbox/sandbox-adapter.test.ts
+++ b/src/utils/sandbox/sandbox-adapter.test.ts
@@ -88,4 +88,19 @@ describe('convertToSandboxRuntimeConfig', () => {
       )
     }
   })
+
+  test('denies legacy Claude config surfaces from CLAUDE_CONFIG_DIR', () => {
+    const config = convertToSandboxRuntimeConfig({} as SettingsJson)
+    const configDir = process.env.CLAUDE_CONFIG_DIR!
+
+    expect(config.filesystem.denyWrite).toContain(
+      resolve(configDir, 'settings.json'),
+    )
+    expect(config.filesystem.denyWrite).toContain(
+      resolve(configDir, 'settings.local.json'),
+    )
+    expect(config.filesystem.denyWrite).toContain(resolve(configDir, 'commands'))
+    expect(config.filesystem.denyWrite).toContain(resolve(configDir, 'agents'))
+    expect(config.filesystem.denyWrite).toContain(resolve(configDir, 'skills'))
+  })
 })

--- a/src/utils/sandbox/sandbox-adapter.ts
+++ b/src/utils/sandbox/sandbox-adapter.ts
@@ -23,6 +23,7 @@ import {
 import { rmSync, statSync } from 'fs'
 import { readFile } from 'fs/promises'
 import { memoize } from 'lodash-es'
+import { homedir } from 'os'
 import { join, resolve, sep } from 'path'
 import {
   getAdditionalDirectoriesForClaudeMd,
@@ -155,6 +156,16 @@ function getCurrentCwdSettingsDenyWritePaths(cwd: string): string[] {
   ]
 }
 
+function getLegacyClaudeConfigDenyWritePaths(cwd: string): string[] {
+  return [
+    resolve(cwd, '.claude', 'settings.json'),
+    resolve(cwd, '.claude', 'settings.local.json'),
+    resolve(cwd, '.claude', 'commands'),
+    resolve(cwd, '.claude', 'agents'),
+    resolve(cwd, '.claude', 'skills'),
+  ]
+}
+
 /**
  * Check if only managed sandbox domains should be used.
  * This is true when policySettings has sandbox.network.allowManagedDomainsOnly: true
@@ -249,8 +260,11 @@ export function convertToSandboxRuntimeConfig(
   // This handles the case where the user has cd'd to a different directory
   const cwd = getCwdState()
   const originalCwd = getOriginalCwd()
+  denyWrite.push(...getLegacyClaudeConfigDenyWritePaths(originalCwd))
+  denyWrite.push(...getLegacyClaudeConfigDenyWritePaths(homedir()))
   if (cwd !== originalCwd) {
     denyWrite.push(...getCurrentCwdSettingsDenyWritePaths(cwd))
+    denyWrite.push(...getLegacyClaudeConfigDenyWritePaths(cwd))
   }
 
   // Block writes to .openclaude/skills in both original and current working directories.

--- a/src/utils/sandbox/sandbox-adapter.ts
+++ b/src/utils/sandbox/sandbox-adapter.ts
@@ -157,23 +157,7 @@ function getCurrentCwdSettingsDenyWritePaths(cwd: string): string[] {
 }
 
 function getLegacyClaudeConfigDenyWritePaths(cwd: string): string[] {
-  return [
-    resolve(cwd, '.claude', 'settings.json'),
-    resolve(cwd, '.claude', 'settings.local.json'),
-    resolve(cwd, '.claude', 'commands'),
-    resolve(cwd, '.claude', 'agents'),
-    resolve(cwd, '.claude', 'skills'),
-  ]
-}
-
-function getClaudeConfigRootDenyWritePaths(configDir: string): string[] {
-  return [
-    resolve(configDir, 'settings.json'),
-    resolve(configDir, 'settings.local.json'),
-    resolve(configDir, 'commands'),
-    resolve(configDir, 'agents'),
-    resolve(configDir, 'skills'),
-  ]
+  return [resolve(cwd, '.claude')]
 }
 
 /**
@@ -273,9 +257,7 @@ export function convertToSandboxRuntimeConfig(
   denyWrite.push(...getLegacyClaudeConfigDenyWritePaths(originalCwd))
   denyWrite.push(...getLegacyClaudeConfigDenyWritePaths(homedir()))
   if (process.env.CLAUDE_CONFIG_DIR) {
-    denyWrite.push(
-      ...getClaudeConfigRootDenyWritePaths(process.env.CLAUDE_CONFIG_DIR),
-    )
+    denyWrite.push(resolve(process.env.CLAUDE_CONFIG_DIR))
   }
   if (cwd !== originalCwd) {
     denyWrite.push(...getCurrentCwdSettingsDenyWritePaths(cwd))

--- a/src/utils/sandbox/sandbox-adapter.ts
+++ b/src/utils/sandbox/sandbox-adapter.ts
@@ -148,8 +148,8 @@ export function resolveSandboxFilesystemPath(
 
 function getCurrentCwdSettingsDenyWritePaths(cwd: string): string[] {
   return [
-    resolve(cwd, '.claude', 'settings.json'),
-    resolve(cwd, '.claude', 'settings.local.json'),
+    resolve(cwd, '.openclaude', 'settings.json'),
+    resolve(cwd, '.openclaude', 'settings.local.json'),
     resolve(cwd, getRelativeSettingsFilePathForSource('projectSettings')),
     resolve(cwd, getRelativeSettingsFilePathForSource('localSettings')),
   ]
@@ -253,14 +253,14 @@ export function convertToSandboxRuntimeConfig(
     denyWrite.push(...getCurrentCwdSettingsDenyWritePaths(cwd))
   }
 
-  // Block writes to .claude/skills in both original and current working directories.
-  // The sandbox-runtime's getDangerousDirectories() protects .claude/commands and
-  // .claude/agents but not .claude/skills. Skills have the same privilege level
+  // Block writes to .openclaude/skills in both original and current working directories.
+  // The sandbox-runtime's getDangerousDirectories() protects .openclaude/commands and
+  // .openclaude/agents but not .openclaude/skills. Skills have the same privilege level
   // (auto-discovered, auto-loaded, full Claude capabilities) so they need the
   // same OS-level sandbox protection.
-  denyWrite.push(resolve(originalCwd, '.claude', 'skills'))
+  denyWrite.push(resolve(originalCwd, '.openclaude', 'skills'))
   if (cwd !== originalCwd) {
-    denyWrite.push(resolve(cwd, '.claude', 'skills'))
+    denyWrite.push(resolve(cwd, '.openclaude', 'skills'))
   }
 
   // SECURITY: Git's is_git_directory() treats cwd as a bare repo if it has

--- a/src/utils/sandbox/sandbox-adapter.ts
+++ b/src/utils/sandbox/sandbox-adapter.ts
@@ -166,6 +166,16 @@ function getLegacyClaudeConfigDenyWritePaths(cwd: string): string[] {
   ]
 }
 
+function getClaudeConfigRootDenyWritePaths(configDir: string): string[] {
+  return [
+    resolve(configDir, 'settings.json'),
+    resolve(configDir, 'settings.local.json'),
+    resolve(configDir, 'commands'),
+    resolve(configDir, 'agents'),
+    resolve(configDir, 'skills'),
+  ]
+}
+
 /**
  * Check if only managed sandbox domains should be used.
  * This is true when policySettings has sandbox.network.allowManagedDomainsOnly: true
@@ -262,6 +272,11 @@ export function convertToSandboxRuntimeConfig(
   const originalCwd = getOriginalCwd()
   denyWrite.push(...getLegacyClaudeConfigDenyWritePaths(originalCwd))
   denyWrite.push(...getLegacyClaudeConfigDenyWritePaths(homedir()))
+  if (process.env.CLAUDE_CONFIG_DIR) {
+    denyWrite.push(
+      ...getClaudeConfigRootDenyWritePaths(process.env.CLAUDE_CONFIG_DIR),
+    )
+  }
   if (cwd !== originalCwd) {
     denyWrite.push(...getCurrentCwdSettingsDenyWritePaths(cwd))
     denyWrite.push(...getLegacyClaudeConfigDenyWritePaths(cwd))

--- a/src/utils/secureStorage/keychainPrefetch.ts
+++ b/src/utils/secureStorage/keychainPrefetch.ts
@@ -4,8 +4,8 @@
  *
  * isRemoteManagedSettingsEligible() reads two separate keychain entries
  * SEQUENTIALLY via sync execSync during applySafeConfigEnvironmentVariables():
- *   1. "Claude Code-credentials" (OAuth tokens)  — ~32ms
- *   2. "Claude Code" (legacy API key)            — ~33ms
+ *   1. "OpenClaude-credentials" (OAuth tokens)  — ~32ms
+ *   2. "OpenClaude" (legacy API key)            — ~33ms
  * Sequential cost: ~65ms on every macOS startup.
  *
  * Firing both here lets the subprocesses run in parallel with the ~65ms of

--- a/src/utils/secureStorage/macOsKeychainHelpers.ts
+++ b/src/utils/secureStorage/macOsKeychainHelpers.ts
@@ -16,6 +16,7 @@
 
 import { createHash } from 'crypto'
 import { homedir, userInfo } from 'os'
+import { resolve } from 'path'
 import { getOauthConfig } from 'src/constants/oauth.js'
 import {
   getClaudeConfigHomeDir,
@@ -38,13 +39,15 @@ export function getSecureStorageServiceName(
 ): string {
   const configDir = getClaudeConfigHomeDir()
   const defaultConfigDir = resolveClaudeConfigHomeDir({ homeDir: homedir() })
-  const isDefaultDir = configDir === defaultConfigDir
+  const normalizedConfigDir = resolve(configDir).normalize('NFC')
+  const normalizedDefaultConfigDir = resolve(defaultConfigDir).normalize('NFC')
+  const isDefaultDir = normalizedConfigDir === normalizedDefaultConfigDir
 
   // Use a hash of the config dir path to create a unique but stable suffix
   // Only add suffix for non-default directories to maintain backwards compatibility
   const dirHash = isDefaultDir
     ? ''
-    : `-${createHash('sha256').update(configDir).digest('hex').substring(0, 8)}`
+    : `-${createHash('sha256').update(normalizedConfigDir).digest('hex').substring(0, 8)}`
   return `Claude Code${getOauthConfig().OAUTH_FILE_SUFFIX}${serviceSuffix}${dirHash}`
 }
 

--- a/src/utils/secureStorage/macOsKeychainHelpers.ts
+++ b/src/utils/secureStorage/macOsKeychainHelpers.ts
@@ -27,15 +27,14 @@ import type { SecureStorageData } from './index.js'
 export const CREDENTIALS_SERVICE_SUFFIX = '-credentials'
 
 /**
- * Get the service/resource name for secure storage, scoped by CLAUDE_CONFIG_DIR
+ * Get the service/resource name for secure storage, scoped by OPENCLAUDE_CONFIG_DIR
  * if it's set to a non-default location.
  */
 export function getSecureStorageServiceName(
   serviceSuffix: string = '',
 ): string {
   const configDir = getClaudeConfigHomeDir()
-  const isDefaultDir =
-    !process.env.OPENCLAUDE_CONFIG_DIR && !process.env.CLAUDE_CONFIG_DIR
+  const isDefaultDir = !process.env.OPENCLAUDE_CONFIG_DIR
 
   // Use a hash of the config dir path to create a unique but stable suffix
   // Only add suffix for non-default directories to maintain backwards compatibility

--- a/src/utils/secureStorage/macOsKeychainHelpers.ts
+++ b/src/utils/secureStorage/macOsKeychainHelpers.ts
@@ -51,7 +51,7 @@ export function getSecureStorageServiceName(
   const dirHash = isDefaultDir
     ? ''
     : `-${createHash('sha256').update(normalizedConfigDir).digest('hex').substring(0, 8)}`
-  return `Claude Code${getOauthConfig().OAUTH_FILE_SUFFIX}${serviceSuffix}${dirHash}`
+  return `OpenClaude${getOauthConfig().OAUTH_FILE_SUFFIX}${serviceSuffix}${dirHash}`
 }
 
 export function getMacOsKeychainStorageServiceName(

--- a/src/utils/secureStorage/macOsKeychainHelpers.ts
+++ b/src/utils/secureStorage/macOsKeychainHelpers.ts
@@ -15,9 +15,12 @@
  */
 
 import { createHash } from 'crypto'
-import { userInfo } from 'os'
+import { homedir, userInfo } from 'os'
 import { getOauthConfig } from 'src/constants/oauth.js'
-import { getClaudeConfigHomeDir } from '../envUtils.js'
+import {
+  getClaudeConfigHomeDir,
+  resolveClaudeConfigHomeDir,
+} from '../envUtils.js'
 import type { SecureStorageData } from './index.js'
 
 // Suffix distinguishing the OAuth credentials keychain entry from the legacy
@@ -34,7 +37,8 @@ export function getSecureStorageServiceName(
   serviceSuffix: string = '',
 ): string {
   const configDir = getClaudeConfigHomeDir()
-  const isDefaultDir = !process.env.OPENCLAUDE_CONFIG_DIR
+  const defaultConfigDir = resolveClaudeConfigHomeDir({ homeDir: homedir() })
+  const isDefaultDir = configDir === defaultConfigDir
 
   // Use a hash of the config dir path to create a unique but stable suffix
   // Only add suffix for non-default directories to maintain backwards compatibility

--- a/src/utils/secureStorage/macOsKeychainHelpers.ts
+++ b/src/utils/secureStorage/macOsKeychainHelpers.ts
@@ -37,7 +37,10 @@ export const CREDENTIALS_SERVICE_SUFFIX = '-credentials'
 export function getSecureStorageServiceName(
   serviceSuffix: string = '',
 ): string {
-  const configDir = getClaudeConfigHomeDir()
+  const configDirEnv = process.env.OPENCLAUDE_CONFIG_DIR || undefined
+  const configDir = configDirEnv
+    ? resolveClaudeConfigHomeDir({ configDirEnv })
+    : getClaudeConfigHomeDir()
   const defaultConfigDir = resolveClaudeConfigHomeDir({ homeDir: homedir() })
   const normalizedConfigDir = resolve(configDir).normalize('NFC')
   const normalizedDefaultConfigDir = resolve(defaultConfigDir).normalize('NFC')

--- a/src/utils/secureStorage/platformStorage.test.ts
+++ b/src/utils/secureStorage/platformStorage.test.ts
@@ -2,6 +2,7 @@ import { expect, test, mock, describe, beforeEach, afterEach, afterAll, beforeAl
 import * as realExeca from "execa";
 import { homedir } from "os";
 import { join } from "path";
+import { setClaudeConfigHomeDirForTesting } from "../envUtils.js";
 import { getSecureStorageServiceName, CREDENTIALS_SERVICE_SUFFIX } from "./macOsKeychainHelpers.js";
 import {
   acquireSharedMutationLock,
@@ -94,12 +95,14 @@ describe("Secure Storage Platform Implementations", () => {
 
   beforeEach(() => {
     process.env = { ...originalEnv };
+    setClaudeConfigHomeDirForTesting(undefined);
     mockExecaSync.mockClear();
     // Default mock behavior
     mockExecaSync.mockImplementation(() => execaResult());
   });
 
   afterEach(() => {
+    setClaudeConfigHomeDirForTesting(undefined);
     process.env = originalEnv;
   });
 

--- a/src/utils/secureStorage/platformStorage.test.ts
+++ b/src/utils/secureStorage/platformStorage.test.ts
@@ -161,6 +161,17 @@ describe("Secure Storage Platform Implementations", () => {
       expect(explicitDefaultName).toBe(defaultName);
     });
 
+    test("service name stays default when OPENCLAUDE_CONFIG_DIR has a trailing separator", () => {
+      delete process.env.OPENCLAUDE_CONFIG_DIR;
+      delete process.env.CLAUDE_CONFIG_DIR;
+      const defaultName = getSecureStorageServiceName(CREDENTIALS_SERVICE_SUFFIX);
+
+      process.env.OPENCLAUDE_CONFIG_DIR = `${join(homedir(), ".openclaude")}/`;
+      const explicitDefaultName = getSecureStorageServiceName(CREDENTIALS_SERVICE_SUFFIX);
+
+      expect(explicitDefaultName).toBe(defaultName);
+    });
+
     test("Linux storage ignores CLAUDE_CONFIG_DIR scoped service name", () => {
       delete process.env.OPENCLAUDE_CONFIG_DIR;
       delete process.env.CLAUDE_CONFIG_DIR;

--- a/src/utils/secureStorage/platformStorage.test.ts
+++ b/src/utils/secureStorage/platformStorage.test.ts
@@ -2,12 +2,12 @@ import { expect, test, mock, describe, beforeEach, afterEach, afterAll, beforeAl
 import * as realExeca from "execa";
 import { homedir } from "os";
 import { join } from "path";
-import { setClaudeConfigHomeDirForTesting } from "../envUtils.js";
-import { getSecureStorageServiceName, CREDENTIALS_SERVICE_SUFFIX } from "./macOsKeychainHelpers.js";
 import {
   acquireSharedMutationLock,
   releaseSharedMutationLock,
 } from "../../test/sharedMutationLock.js";
+import type * as EnvUtils from "../envUtils.js";
+import type * as MacOsKeychainHelpers from "./macOsKeychainHelpers.js";
 import type { linuxSecretStorage as LinuxSecretStorage } from "./linuxSecretStorage.js";
 import type { windowsCredentialStorage as WindowsCredentialStorage } from "./windowsCredentialStorage.js";
 
@@ -78,6 +78,10 @@ function getSecretToolArgs(index = 0): readonly string[] {
 
 describe("Secure Storage Platform Implementations", () => {
   const originalEnv = process.env;
+  let realEnvUtils: typeof EnvUtils;
+  let getSecureStorageServiceName: typeof MacOsKeychainHelpers.getSecureStorageServiceName;
+  let CREDENTIALS_SERVICE_SUFFIX: typeof MacOsKeychainHelpers.CREDENTIALS_SERVICE_SUFFIX;
+  let setClaudeConfigHomeDirForTesting: typeof EnvUtils.setClaudeConfigHomeDirForTesting;
   let linuxSecretStorage: typeof LinuxSecretStorage;
   let windowsCredentialStorage: typeof WindowsCredentialStorage;
 
@@ -89,6 +93,12 @@ describe("Secure Storage Platform Implementations", () => {
       execaSync: mockExecaSync,
     }));
     const moduleSuffix = `?platformStorageTest=${Date.now()}-${Math.random()}`;
+    realEnvUtils = await import(`../envUtils.js${moduleSuffix}`);
+    mock.module("../envUtils.js", () => realEnvUtils);
+    ({ setClaudeConfigHomeDirForTesting } = realEnvUtils);
+    ({ getSecureStorageServiceName, CREDENTIALS_SERVICE_SUFFIX } = await import(
+      `./macOsKeychainHelpers.js${moduleSuffix}`
+    ));
     ({ linuxSecretStorage } = await import(`./linuxSecretStorage.js${moduleSuffix}`));
     ({ windowsCredentialStorage } = await import(`./windowsCredentialStorage.js${moduleSuffix}`));
   });
@@ -109,6 +119,9 @@ describe("Secure Storage Platform Implementations", () => {
   afterAll(() => {
     try {
       mock.module("execa", () => realExeca);
+      if (realEnvUtils) {
+        mock.module("../envUtils.js", () => realEnvUtils);
+      }
     } finally {
       releaseSharedMutationLock();
     }

--- a/src/utils/secureStorage/platformStorage.test.ts
+++ b/src/utils/secureStorage/platformStorage.test.ts
@@ -1,5 +1,7 @@
 import { expect, test, mock, describe, beforeEach, afterEach, afterAll, beforeAll } from "bun:test";
 import * as realExeca from "execa";
+import { homedir } from "os";
+import { join } from "path";
 import { getSecureStorageServiceName, CREDENTIALS_SERVICE_SUFFIX } from "./macOsKeychainHelpers.js";
 import {
   acquireSharedMutationLock,
@@ -146,6 +148,17 @@ describe("Secure Storage Platform Implementations", () => {
       expect(preferredName).not.toBe(defaultName);
       expect(preferredName).toContain("Claude Code");
       expect(preferredName).toContain(CREDENTIALS_SERVICE_SUFFIX);
+    });
+
+    test("service name stays default when OPENCLAUDE_CONFIG_DIR points at default config dir", () => {
+      delete process.env.OPENCLAUDE_CONFIG_DIR;
+      delete process.env.CLAUDE_CONFIG_DIR;
+      const defaultName = getSecureStorageServiceName(CREDENTIALS_SERVICE_SUFFIX);
+
+      process.env.OPENCLAUDE_CONFIG_DIR = join(homedir(), ".openclaude");
+      const explicitDefaultName = getSecureStorageServiceName(CREDENTIALS_SERVICE_SUFFIX);
+
+      expect(explicitDefaultName).toBe(defaultName);
     });
 
     test("Linux storage ignores CLAUDE_CONFIG_DIR scoped service name", () => {

--- a/src/utils/secureStorage/platformStorage.test.ts
+++ b/src/utils/secureStorage/platformStorage.test.ts
@@ -121,7 +121,7 @@ describe("Secure Storage Platform Implementations", () => {
   };
 
   describe("Config-Dir Isolation", () => {
-    test("service name changes with CLAUDE_CONFIG_DIR", () => {
+    test("service name ignores CLAUDE_CONFIG_DIR", () => {
       delete process.env.OPENCLAUDE_CONFIG_DIR;
       delete process.env.CLAUDE_CONFIG_DIR;
       const defaultName = getSecureStorageServiceName(CREDENTIALS_SERVICE_SUFFIX);
@@ -129,7 +129,7 @@ describe("Secure Storage Platform Implementations", () => {
       process.env.CLAUDE_CONFIG_DIR = "/tmp/other-config";
       const otherName = getSecureStorageServiceName(CREDENTIALS_SERVICE_SUFFIX);
 
-      expect(otherName).not.toBe(defaultName);
+      expect(otherName).toBe(defaultName);
       expect(otherName).toContain("Claude Code");
       expect(otherName).toContain(CREDENTIALS_SERVICE_SUFFIX);
     });
@@ -148,7 +148,7 @@ describe("Secure Storage Platform Implementations", () => {
       expect(preferredName).toContain(CREDENTIALS_SERVICE_SUFFIX);
     });
 
-    test("Linux storage uses scoped service name", () => {
+    test("Linux storage ignores CLAUDE_CONFIG_DIR scoped service name", () => {
       delete process.env.OPENCLAUDE_CONFIG_DIR;
       delete process.env.CLAUDE_CONFIG_DIR;
       process.env.CLAUDE_CONFIG_DIR = "/tmp/linux-scoped";
@@ -171,7 +171,7 @@ describe("Secure Storage Platform Implementations", () => {
       expect(args).toContain(expectedName);
     });
 
-    test("Windows storage uses scoped resource name", () => {
+    test("Windows storage ignores CLAUDE_CONFIG_DIR scoped resource name", () => {
       delete process.env.OPENCLAUDE_CONFIG_DIR;
       delete process.env.CLAUDE_CONFIG_DIR;
       process.env.CLAUDE_CONFIG_DIR = "/tmp/win-scoped";

--- a/src/utils/secureStorage/platformStorage.test.ts
+++ b/src/utils/secureStorage/platformStorage.test.ts
@@ -148,7 +148,7 @@ describe("Secure Storage Platform Implementations", () => {
       const otherName = getSecureStorageServiceName(CREDENTIALS_SERVICE_SUFFIX);
 
       expect(otherName).toBe(defaultName);
-      expect(otherName).toContain("Claude Code");
+      expect(otherName).toContain("OpenClaude");
       expect(otherName).toContain(CREDENTIALS_SERVICE_SUFFIX);
     });
 
@@ -162,7 +162,7 @@ describe("Secure Storage Platform Implementations", () => {
       const preferredName = getSecureStorageServiceName(CREDENTIALS_SERVICE_SUFFIX);
 
       expect(preferredName).not.toBe(defaultName);
-      expect(preferredName).toContain("Claude Code");
+      expect(preferredName).toContain("OpenClaude");
       expect(preferredName).toContain(CREDENTIALS_SERVICE_SUFFIX);
     });
 

--- a/src/utils/skills/skillChangeDetector.test.ts
+++ b/src/utils/skills/skillChangeDetector.test.ts
@@ -139,7 +139,7 @@ describe('skillChangeDetector reload batching', () => {
     expect(chokidarWatch).not.toHaveBeenCalled()
   })
 
-  test('watches native and legacy project/add-dir skill paths that the loader reads', async () => {
+  test('watches OpenClaude project/add-dir skill paths that the loader reads', async () => {
     const detector = await importFreshModule()
     const addDir = platformPath.join('/tmp', 'openclaude-add-dir')
     const userSkillsPath = platformPath.join('/tmp', 'user', 'skills')
@@ -163,16 +163,11 @@ describe('skillChangeDetector reload batching', () => {
     expect(watchedPaths).toContain(userSkillsPath)
     expect(watchedPaths).toContain(userCommandsPath)
     expect(watchedPaths).toContain(
-      platformPath.join(addDir, '.claude', 'skills'),
-    )
-    expect(watchedPaths).toContain(
       platformPath.join(addDir, '.openclaude', 'skills'),
     )
-    expect(
-      watchedPaths.some(path =>
-        path.endsWith(platformPath.join('.claude', 'skills')),
-      ),
-    ).toBe(true)
+    expect(watchedPaths).not.toContain(
+      platformPath.join(addDir, '.claude', 'skills'),
+    )
     expect(
       watchedPaths.some(path =>
         path.endsWith(platformPath.join('.openclaude', 'skills')),
@@ -182,7 +177,7 @@ describe('skillChangeDetector reload batching', () => {
       watchedPaths.some(path =>
         path.endsWith(platformPath.join('.claude', 'commands')),
       ),
-    ).toBe(true)
+    ).toBe(false)
     expect(
       watchedPaths.some(path =>
         path.endsWith(platformPath.join('.openclaude', 'commands')),

--- a/src/utils/skills/skillChangeDetector.ts
+++ b/src/utils/skills/skillChangeDetector.ts
@@ -229,8 +229,8 @@ async function getWatchablePaths(): Promise<string[]> {
     await pushIfExists(userCommandsPath)
   }
 
-  // Project skills/commands directories. The loader accepts both native
-  // .openclaude and legacy .claude project paths, so live reload watches both.
+  // Project skills/commands directories. Keep this in sync with the loader's
+  // OpenClaude project config directories.
   for (const configDirName of PROJECT_CONFIG_DIR_NAMES) {
     await pushIfExists(platformPath.resolve(configDirName, 'skills'))
     await pushIfExists(platformPath.resolve(configDirName, 'commands'))

--- a/src/utils/worktree.ts
+++ b/src/utils/worktree.ts
@@ -51,7 +51,7 @@ const MAX_WORKTREE_SLUG_LENGTH = 64
 /**
  * Validates a worktree slug to prevent path traversal and directory escape.
  *
- * The slug is joined into `.claude/worktrees/<slug>` via path.join, which
+ * The slug is joined into `.openclaude/worktrees/<slug>` via path.join, which
  * normalizes `..` segments — so `../../../target` would escape the worktrees
  * directory. Similarly, an absolute path (leading `/` or `C:\`) would discard
  * the prefix entirely.
@@ -232,14 +232,14 @@ const GIT_NO_PROMPT_ENV = {
 }
 
 function worktreesDir(repoRoot: string): string {
-  return join(repoRoot, '.claude', 'worktrees')
+  return join(repoRoot, '.openclaude', 'worktrees')
 }
 
 // Flatten nested slugs (`user/feature` → `user+feature`) for both the branch
 // name and the directory path. Nesting in either location is unsafe:
 //   - git refs: `worktree-user` (file) vs `worktree-user/feature` (needs dir)
 //     is a D/F conflict that git rejects.
-//   - directory: `.claude/worktrees/user/feature/` lives inside the `user`
+//   - directory: `.openclaude/worktrees/user/feature/` lives inside the `user`
 //     worktree; `git worktree remove` on the parent deletes children with
 //     uncommitted work.
 // `+` is valid in git branch names and filesystem paths but NOT in the
@@ -579,7 +579,7 @@ async function performPostCreationSetup(
   repoRoot: string,
   worktreePath: string,
 ): Promise<void> {
-  // Copy settings.local.json to the worktree's .claude directory
+  // Copy settings.local.json to the worktree's .openclaude directory
   // This propagates local settings (which may contain secrets) to the worktree
   const localSettingsRelativePath =
     getRelativeSettingsFilePathForSource('localSettings')
@@ -996,8 +996,8 @@ export async function createAgentWorktree(
 
   // Fall back to git worktree
   // findCanonicalGitRoot (not findGitRoot) so agent worktrees always land in
-  // the main repo's .claude/worktrees/ even when spawned from inside a session
-  // worktree — otherwise they nest at <worktree>/.claude/worktrees/ and the
+  // the main repo's .openclaude/worktrees/ even when spawned from inside a session
+  // worktree — otherwise they nest at <worktree>/.openclaude/worktrees/ and the
   // periodic cleanup (which scans the canonical root) never finds them.
   const gitRoot = findCanonicalGitRoot(sessionCwd)
   if (!gitRoot) {


### PR DESCRIPTION
## Summary

- stop migrating or falling back from `.claude` to `.openclaude` config, auth, settings, agents, skills, memory, scheduled tasks, and related surfaces
- ignore `CLAUDE_CONFIG_DIR` for OpenClaude config resolution and credential scoping; use `OPENCLAUDE_CONFIG_DIR` or `~/.openclaude`
- keep native/system cleanup scoped to OpenClaude so updates do not uninstall `@anthropic-ai/claude-code` or remove `~/.claude/local`

## Why

Fixes #1825. OpenClaude should not read, copy, mutate, or clean up Claude Code config or credentials.

## Validation

- `bun run typecheck`
- `bun test src/utils/openclaudePaths.test.ts src/utils/env.test.ts src/utils/openclaudeInstallSurfaces.test.ts src/utils/openclaudeUiSurfaces.test.ts src/utils/doctorDiagnostic.settingsPath.test.ts src/utils/secureStorage/platformStorage.test.ts src/utils/sandbox/sandbox-adapter.test.ts`
- `bun test src/skills/loadSkillsDir.test.ts src/cli/handlers/skills.test.ts src/skills/bundled/loop.test.ts src/utils/markdownConfigLoader.scaling.test.ts`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated skills, settings, permissions, sandbox write protections, worktree storage, secure storage, and scheduled-task persistence to consistently use `.openclaude` paths, with legacy `.claude` locations no longer honored.
  * Improved diagnostics/cleanup and stale-settings behavior to better match the new config layout and reduced/adjusted warnings.

* **Documentation & Tests**
  * Refreshed prompts, tool guidance, and JSDoc to reference `.openclaude` locations across skills, cron, teams, verifiers, loop, IDE, and output styles.
  * Updated and strengthened tests to enforce `.openclaude` precedence and legacy ignore behavior (including revised removal expectations).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->