### PR TITLE
fix(openai-shim): guard tool-arg field lookup against prototype keys

### DIFF
--- a/src/services/api/toolArgumentNormalization.test.ts
+++ b/src/services/api/toolArgumentNormalization.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, test } from 'bun:test'
-import { normalizeToolArguments } from './toolArgumentNormalization'
+import {
+  hasToolFieldMapping,
+  normalizeToolArguments,
+} from './toolArgumentNormalization'
 
 describe('normalizeToolArguments', () => {
   describe('Bash tool', () => {
@@ -175,6 +178,44 @@ describe('normalizeToolArguments', () => {
       expect(normalizeToolArguments('UnknownTool', '"hello"')).toEqual(
         'hello',
       )
+    })
+  })
+
+  // A provider-supplied tool-call name that collides with an Object.prototype
+  // member must NOT resolve to an inherited value through the plain-object
+  // lookup table. Before the Object.hasOwn guard, `'constructor' in fields`
+  // was true and `fields['constructor']` was the Object constructor function,
+  // so a JSON-encoded string argument was wrapped into a garbage-keyed object
+  // ({ 'function Object() { [native code] }': 'hello' }) instead of passing
+  // through unchanged.
+  describe('prototype-polluting tool names', () => {
+    test.each([
+      'constructor',
+      '__proto__',
+      'toString',
+      'valueOf',
+      'hasOwnProperty',
+      'isPrototypeOf',
+    ])('%s is not treated as a known field mapping', (toolName) => {
+      expect(hasToolFieldMapping(toolName)).toBe(false)
+    })
+
+    test('does not wrap a plain string for a proto-chain tool name', () => {
+      expect(normalizeToolArguments('constructor', 'hello')).toEqual({})
+      expect(normalizeToolArguments('toString', 'hello')).toEqual({})
+    })
+
+    test('preserves a JSON-encoded string for a proto-chain tool name', () => {
+      expect(normalizeToolArguments('constructor', '"hello"')).toEqual('hello')
+      expect(normalizeToolArguments('valueOf', '"x"')).toEqual('x')
+    })
+  })
+
+  describe('hasToolFieldMapping', () => {
+    test('true for own known tools, false otherwise', () => {
+      expect(hasToolFieldMapping('Bash')).toBe(true)
+      expect(hasToolFieldMapping('Read')).toBe(true)
+      expect(hasToolFieldMapping('UnknownTool')).toBe(false)
     })
   })
 })

--- a/src/services/api/toolArgumentNormalization.ts
+++ b/src/services/api/toolArgumentNormalization.ts
@@ -23,11 +23,19 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 }
 
 function getPlainStringToolArgumentField(toolName: string): string | null {
-  return STRING_ARGUMENT_TOOL_FIELDS[toolName] ?? null
+  // Guard with Object.hasOwn: `toolName` is a provider-supplied tool-call name,
+  // so a plain `STRING_ARGUMENT_TOOL_FIELDS[toolName]` lookup resolves inherited
+  // Object.prototype members (`constructor`, `toString`, `valueOf`, …) to their
+  // functions — truthy, so the `?? null` fallback never fires and the value is
+  // wrapped into a garbage-keyed object downstream.
+  return Object.hasOwn(STRING_ARGUMENT_TOOL_FIELDS, toolName)
+    ? STRING_ARGUMENT_TOOL_FIELDS[toolName]!
+    : null
 }
 
 export function hasToolFieldMapping(toolName: string): boolean {
-  return toolName in STRING_ARGUMENT_TOOL_FIELDS
+  // `toolName in obj` would leak proto-chain keys (see above); own-key only.
+  return Object.hasOwn(STRING_ARGUMENT_TOOL_FIELDS, toolName)
 }
 
 function wrapPlainStringToolArguments(


### PR DESCRIPTION
### Problem

`STRING_ARGUMENT_TOOL_FIELDS` in `src/services/api/toolArgumentNormalization.ts` is a plain-object lookup table keyed by a **provider-supplied** tool-call name (`tool_calls[i].function.name` from an OpenAI-compatible response). Two helpers accessed it without an own-property check:

```ts
function getPlainStringToolArgumentField(toolName: string): string | null {
  return STRING_ARGUMENT_TOOL_FIELDS[toolName] ?? null
}
export function hasToolFieldMapping(toolName: string): boolean {
  return toolName in STRING_ARGUMENT_TOOL_FIELDS
}
```

For a tool call whose `function.name` is an `Object.prototype` key — `constructor`, `toString`, `valueOf`, `__proto__`, `hasOwnProperty`, `isPrototypeOf` — the `in` check returns `true` and the bracket lookup returns the **inherited** member (e.g. the `Object` constructor function). Because that value is truthy, the `?? null` fallback never fires and `wrapPlainStringToolArguments` builds a computed-property object:

```
normalizeToolArguments('constructor', '"hello"')
// => { 'function Object() { [native code] }': 'hello' }   (corrupted tool_use input)
```

In the streaming decoder, `hasToolFieldMapping(tc.function.name)` also wrongly returns `true` for those names, flipping the `normalizeAtStop` branch.

**Consumers:** `src/services/api/openaiShim.ts` (`normalizeToolArguments` at 1592/2313/3128, `hasToolFieldMapping` at 2863).

### Fix

Gate both lookups on `Object.hasOwn`, matching the existing convention for provider-keyed maps in this codebase.

### Tests

Added coverage asserting the six proto-chain names are not treated as field mappings, that a plain string is not wrapped for them, and that a JSON-encoded string passes through unchanged — plus own-key control cases. Verified red→green (8 failures without the guard).

Same prototype-pollution class as the earlier `detectCodeIndexingFromCommand` (Map) and `FILENAME_LANGS` fixes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of tool-call arguments so unexpected built-in object names are no longer treated as valid tool mappings.
  * Plain-text arguments now stay unwrapped when they should, while JSON-encoded string arguments are preserved correctly.

* **Tests**
  * Expanded coverage for edge cases involving special tool names and verified mapping checks for known and unknown tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->