### PR TITLE
fix(read): report zero lines for an empty file

### DIFF
--- a/src/utils/readFileInRange.test.ts
+++ b/src/utils/readFileInRange.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, test } from 'bun:test'
+import { mkdtempSync, writeFileSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { readFileInRange } from './readFileInRange.js'
+
+function writeTemp(name: string, contents: string): string {
+  const dir = mkdtempSync(join(tmpdir(), 'openclaude-readrange-'))
+  const path = join(dir, name)
+  writeFileSync(path, contents)
+  return path
+}
+
+describe('readFileInRange', () => {
+  test('reports zero lines for an empty file', async () => {
+    const path = writeTemp('empty.txt', '')
+    const result = await readFileInRange(path, 0)
+    expect(result.content).toBe('')
+    expect(result.lineCount).toBe(0)
+    // Regression: an empty file must report totalLines === 0 so the
+    // FileReadTool empty-file branch (keyed on totalLines === 0) is reachable.
+    // Before the fix the final-fragment block pushed a phantom line -> 1.
+    expect(result.totalLines).toBe(0)
+    expect(result.totalBytes).toBe(0)
+    expect(result.readBytes).toBe(0)
+  })
+
+  test('single line without trailing newline is one line', async () => {
+    const path = writeTemp('one.txt', 'hello')
+    const result = await readFileInRange(path, 0)
+    expect(result.content).toBe('hello')
+    expect(result.lineCount).toBe(1)
+    expect(result.totalLines).toBe(1)
+  })
+
+  test('two lines without trailing newline are two lines', async () => {
+    const path = writeTemp('two.txt', 'a\nb')
+    const result = await readFileInRange(path, 0)
+    expect(result.totalLines).toBe(2)
+    expect(result.content).toBe('a\nb')
+  })
+})

--- a/src/utils/readFileInRange.test.ts
+++ b/src/utils/readFileInRange.test.ts
@@ -1,15 +1,24 @@
-import { describe, expect, test } from 'bun:test'
-import { mkdtempSync, writeFileSync } from 'fs'
+import { afterEach, describe, expect, test } from 'bun:test'
+import { mkdtempSync, rmSync, writeFileSync } from 'fs'
 import { tmpdir } from 'os'
 import { join } from 'path'
 import { readFileInRange } from './readFileInRange.js'
 
+const createdDirs: string[] = []
+
 function writeTemp(name: string, contents: string): string {
   const dir = mkdtempSync(join(tmpdir(), 'openclaude-readrange-'))
+  createdDirs.push(dir)
   const path = join(dir, name)
   writeFileSync(path, contents)
   return path
 }
+
+afterEach(() => {
+  while (createdDirs.length > 0) {
+    rmSync(createdDirs.pop()!, { recursive: true, force: true })
+  }
+})
 
 describe('readFileInRange', () => {
   test('reports zero lines for an empty file', async () => {

--- a/src/utils/readFileInRange.ts
+++ b/src/utils/readFileInRange.ts
@@ -137,6 +137,21 @@ function readFileInRangeFast(
   // Strip BOM.
   const text = raw.charCodeAt(0) === 0xfeff ? raw.slice(1) : raw
 
+  // Empty file: no lines at all. Without this short-circuit the final-fragment
+  // block below pushes one phantom empty line and reports totalLines: 1, which
+  // makes the FileReadTool empty-file branch (keyed on totalLines === 0) show
+  // the wrong "shorter than the provided offset" warning for a 0-byte file.
+  if (text.length === 0) {
+    return {
+      content: '',
+      lineCount: 0,
+      totalLines: 0,
+      totalBytes: 0,
+      readBytes: 0,
+      mtimeMs,
+    }
+  }
+
   // Split lines, strip \r, select range.
   const selectedLines: string[] = []
   let lineIndex = 0


### PR DESCRIPTION
### Problem

`readFileInRangeFast` (`src/utils/readFileInRange.ts`) runs its "final fragment (no trailing newline)" block unconditionally after the newline-scan loop. For an empty (0-byte) file the loop never runs, then the final block computes `text.slice(0) === ''`, pushes it, and does `lineIndex++`, so it returns:

```
{ content: '', lineCount: 1, totalLines: 1, ... }   // should be 0 / 0
```

A 0-byte file always takes the fast path (`size 0 < FAST_PATH_MAX_SIZE`), so this is the only path that matters here.

**Consumer** — `src/tools/FileReadTool/FileReadTool.ts`:

```ts
content =
  data.file.totalLines === 0
    ? '…the file exists but the contents are empty.'
    : `…the file exists but is shorter than the provided offset (${data.file.startLine}). The file has ${data.file.totalLines} lines.`
```

Because `totalLines` is `1` (never `0`) for an empty file, reading any empty text file emits the **wrong** message — *"the file exists but is shorter than the provided offset (1). The file has 1 lines."* — and the dedicated *"the contents are empty"* message is unreachable dead code.

### Fix

Short-circuit empty input right after the BOM strip and return `totalLines: 0`. Trailing-newline counting for non-empty files (`"a\n".split("\n")` → 2-element split semantics) is intentionally left unchanged — only the empty-file off-by-one is corrected, and the consumer's `totalLines === 0` branch defines the intended contract.

### Tests

New `readFileInRange.test.ts`: an empty file resolves `{ content:'', lineCount:0, totalLines:0 }` (red before the fix: `totalLines === 1`), plus one-line and two-line no-trailing-newline controls. Verified red→green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Correctly report `0` lines and `0` bytes for empty files, avoiding a phantom blank line.
  * Ensures empty reads return `content: ''` with consistent line/byte counters.
* **Tests**
  * Added Bun test coverage for empty, single-line, and two-line inputs.
  * Added regression assertions for files without trailing newlines.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->