### PR TITLE
fix(query-guard): exclude human-interaction wait from session timeout

### DIFF
--- a/src/Tool.ts
+++ b/src/Tool.ts
@@ -100,6 +100,13 @@ export type QueryChainTracking = {
 export type QueryActivity = {
   registerActivity(reason: string): void
   acquireLease(input: QueryGuardLeaseInput): QueryGuardLease
+  /**
+   * Suspend the query watchdog while blocked on a human decision (permission
+   * prompt, AskUserQuestion, plan-mode selection). Returns a resume function
+   * to call exactly once when the interaction ends. Optional so existing
+   * queryActivity implementations and test mocks stay valid.
+   */
+  beginUserInteraction?(): () => void
 }
 
 export type ValidationResult =

--- a/src/hooks/toolPermission/handlers/interactiveHandler.test.ts
+++ b/src/hooks/toolPermission/handlers/interactiveHandler.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, test, vi } from 'vitest'
+import {
+  handleInteractivePermission,
+  type InteractivePermissionParams,
+} from './interactiveHandler.js'
+
+/**
+ * These tests pin the watchdog pause/resume wiring in the interactive
+ * permission path: `beginUserInteraction()` must run once when the dialog is
+ * shown, and its resume fn must fire exactly once per terminal resolution
+ * (allow/reject/abort) — and never twice, even if two branches race. This is
+ * the choke-point the session-timeout fix depends on; a future resolution path
+ * that bypasses `resolveOnce` would fail these tests instead of silently
+ * reintroducing the original bug.
+ */
+
+type QueueItem = {
+  onAbort: () => void
+  onAllow: (
+    updatedInput: Record<string, unknown>,
+    permissionUpdates: unknown[],
+    feedback?: string,
+  ) => Promise<void>
+  onReject: (feedback?: string) => void
+}
+
+function setup() {
+  const resume = vi.fn()
+  const beginUserInteraction = vi.fn(() => resume)
+  let queueItem: QueueItem | undefined
+
+  const ctx = {
+    tool: { name: 'Bash', requiresUserInteraction: () => false },
+    input: {},
+    assistantMessage: { message: { id: 'msg-1' } },
+    toolUseID: 'tu-1',
+    toolUseContext: {
+      queryActivity: {
+        registerActivity: vi.fn(),
+        acquireLease: vi.fn(() => ({ id: '', release() {} })),
+        beginUserInteraction,
+      },
+      abortController: new AbortController(),
+      getAppState: () => ({
+        toolPermissionContext: { mode: 'default' },
+        mcp: { clients: [] },
+      }),
+    },
+    pushToQueue: vi.fn((item: QueueItem) => {
+      queueItem = item
+    }),
+    removeFromQueue: vi.fn(),
+    updateQueueItem: vi.fn(),
+    logDecision: vi.fn(),
+    logCancelled: vi.fn(),
+    handleUserAllow: vi.fn(async () => ({ behavior: 'allow' })),
+    cancelAndAbort: vi.fn(() => ({ behavior: 'deny' })),
+    buildAllow: vi.fn((input: Record<string, unknown>) => ({
+      behavior: 'allow',
+      updatedInput: input,
+    })),
+    persistPermissions: vi.fn(),
+    runHooks: vi.fn(async () => null),
+  }
+
+  const resolve = vi.fn()
+  const params = {
+    ctx,
+    description: 'desc',
+    result: { behavior: 'ask' },
+    // Skip the async hook/classifier races so only the dialog callbacks resolve.
+    awaitAutomatedChecksBeforeDialog: true,
+    bridgeCallbacks: undefined,
+    channelCallbacks: undefined,
+  } as unknown as InteractivePermissionParams
+
+  handleInteractivePermission(params, resolve)
+
+  return {
+    resume,
+    beginUserInteraction,
+    resolve,
+    getQueueItem: () => queueItem as QueueItem,
+  }
+}
+
+describe('handleInteractivePermission watchdog suspension', () => {
+  test('suspends once when the dialog is shown, before any resolution', () => {
+    const { beginUserInteraction, resume } = setup()
+    expect(beginUserInteraction).toHaveBeenCalledTimes(1)
+    expect(resume).not.toHaveBeenCalled()
+  })
+
+  test('resumes exactly once on allow', async () => {
+    const { getQueueItem, resume, resolve } = setup()
+    await getQueueItem().onAllow({}, [])
+    expect(resume).toHaveBeenCalledTimes(1)
+    expect(resolve).toHaveBeenCalledTimes(1)
+  })
+
+  test('resumes exactly once on reject', () => {
+    const { getQueueItem, resume, resolve } = setup()
+    getQueueItem().onReject('no thanks')
+    expect(resume).toHaveBeenCalledTimes(1)
+    expect(resolve).toHaveBeenCalledTimes(1)
+  })
+
+  test('resumes exactly once on abort', () => {
+    const { getQueueItem, resume, resolve } = setup()
+    getQueueItem().onAbort()
+    expect(resume).toHaveBeenCalledTimes(1)
+    expect(resolve).toHaveBeenCalledTimes(1)
+  })
+
+  test('resumes only once when two resolution paths race', async () => {
+    const { getQueueItem, resume, resolve } = setup()
+    getQueueItem().onReject('first')
+    await getQueueItem().onAllow({}, []) // loses the claim
+    expect(resume).toHaveBeenCalledTimes(1)
+    expect(resolve).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/hooks/toolPermission/handlers/interactiveHandler.ts
+++ b/src/hooks/toolPermission/handlers/interactiveHandler.ts
@@ -67,7 +67,21 @@ function handleInteractivePermission(
     channelCallbacks,
   } = params
 
-  const { resolve: resolveOnce, isResolved, claim } = createResolveOnce(resolve)
+  // Reaching this handler means we are about to show a dialog and block on the
+  // user's decision. Suspend the query watchdog for exactly that window so
+  // human think-time is not counted toward the idle/hard-max timeout. Scoped
+  // here (not around the whole permission resolution) so non-human async work
+  // — e.g. the classifier in hasPermissionsToUseTool — stays watched and a
+  // genuinely stuck check can still fire the watchdog. Resume fires on the
+  // single terminal resolution (allow/reject/abort/hook/classifier/bridge/
+  // channel), so it runs exactly once.
+  const resumeWatchdog = ctx.toolUseContext.queryActivity?.beginUserInteraction?.()
+  const { resolve: resolveOnce, isResolved, claim } = createResolveOnce(
+    (decision: PermissionDecision) => {
+      resumeWatchdog?.()
+      resolve(decision)
+    },
+  )
   let userInteracted = false
   let checkmarkTransitionTimer: ReturnType<typeof setTimeout> | undefined
   // Hoisted so onDismissCheckmark (Esc during checkmark window) can also

--- a/src/screens/REPL.tsx
+++ b/src/screens/REPL.tsx
@@ -2625,7 +2625,8 @@ export function REPL({
       registerActivity: (reason: string) => {
         queryGuard.registerActivity(reason, queryGeneration);
       },
-      acquireLease: (input) => queryGuard.acquireLease(input, queryGeneration)
+      acquireLease: (input) => queryGuard.acquireLease(input, queryGeneration),
+      beginUserInteraction: () => queryGuard.beginUserInteraction(queryGeneration)
     } satisfies ProcessUserInputContext['queryActivity'];
     return {
       abortController,

--- a/src/services/tools/toolExecution.ts
+++ b/src/services/tools/toolExecution.ts
@@ -1143,15 +1143,27 @@ export async function checkPermissionsAndCallTool(
   const permissionMode = toolUseContext.getAppState().toolPermissionContext.mode
   const permissionStart = Date.now()
 
-  const resolved = await resolveHookPermissionDecision(
-    hookPermissionResult,
-    tool,
-    processedInput,
-    toolUseContext,
-    canUseTool,
-    assistantMessage,
-    toolUseID,
-  )
+  // Suspend the query watchdog for the whole permission resolution. An
+  // interactive 'ask' dialog blocks here on the user's decision (permission
+  // prompt, AskUserQuestion, plan-mode selection); that human think-time must
+  // not count toward the idle or hard-max timeout, or a slow choice aborts the
+  // query. Non-interactive resolutions return near-instantly, so the pause is
+  // a no-op for them.
+  const resumeWatchdog = toolUseContext.queryActivity?.beginUserInteraction?.()
+  let resolved: Awaited<ReturnType<typeof resolveHookPermissionDecision>>
+  try {
+    resolved = await resolveHookPermissionDecision(
+      hookPermissionResult,
+      tool,
+      processedInput,
+      toolUseContext,
+      canUseTool,
+      assistantMessage,
+      toolUseID,
+    )
+  } finally {
+    resumeWatchdog?.()
+  }
   const permissionDecision = resolved.decision
   processedInput = resolved.input
   trackLifecycleToolUse(processedInput)

--- a/src/services/tools/toolExecution.ts
+++ b/src/services/tools/toolExecution.ts
@@ -1143,27 +1143,15 @@ export async function checkPermissionsAndCallTool(
   const permissionMode = toolUseContext.getAppState().toolPermissionContext.mode
   const permissionStart = Date.now()
 
-  // Suspend the query watchdog for the whole permission resolution. An
-  // interactive 'ask' dialog blocks here on the user's decision (permission
-  // prompt, AskUserQuestion, plan-mode selection); that human think-time must
-  // not count toward the idle or hard-max timeout, or a slow choice aborts the
-  // query. Non-interactive resolutions return near-instantly, so the pause is
-  // a no-op for them.
-  const resumeWatchdog = toolUseContext.queryActivity?.beginUserInteraction?.()
-  let resolved: Awaited<ReturnType<typeof resolveHookPermissionDecision>>
-  try {
-    resolved = await resolveHookPermissionDecision(
-      hookPermissionResult,
-      tool,
-      processedInput,
-      toolUseContext,
-      canUseTool,
-      assistantMessage,
-      toolUseID,
-    )
-  } finally {
-    resumeWatchdog?.()
-  }
+  const resolved = await resolveHookPermissionDecision(
+    hookPermissionResult,
+    tool,
+    processedInput,
+    toolUseContext,
+    canUseTool,
+    assistantMessage,
+    toolUseID,
+  )
   const permissionDecision = resolved.decision
   processedInput = resolved.input
   trackLifecycleToolUse(processedInput)

--- a/src/utils/QueryGuard.test.ts
+++ b/src/utils/QueryGuard.test.ts
@@ -623,4 +623,99 @@ describe('QueryLifecycleOperationTracker', () => {
     expect(JSON.stringify(snapshot)).not.toContain('ANTHROPIC_API_KEY')
     expect(JSON.stringify(snapshot)).not.toContain('tool output')
   })
+
+  describe('beginUserInteraction (human-wait suspension)', () => {
+    test('idle timeout does not fire while suspended', () => {
+      vi.useFakeTimers()
+      vi.spyOn(console, 'error').mockImplementation(() => {})
+      const guard = new QueryGuard({ idleTimeoutMs: 100, hardMaxQueryMs: 1_000 })
+      guard.tryStart()
+
+      const resume = guard.beginUserInteraction()
+      // Well past the idle timeout, but the user is still deciding.
+      vi.advanceTimersByTime(100_000)
+      expect(guard.isActive).toBe(true)
+
+      resume()
+      // Idle window restarts fresh from resume.
+      vi.advanceTimersByTime(99)
+      expect(guard.isActive).toBe(true)
+      vi.advanceTimersByTime(1)
+      expect(guard.isActive).toBe(false)
+    })
+
+    test('hard-max deadline is shifted forward by the paused duration', () => {
+      vi.useFakeTimers()
+      vi.spyOn(console, 'error').mockImplementation(() => {})
+      const guard = new QueryGuard({
+        idleTimeoutMs: 10_000,
+        hardMaxQueryMs: 1_000,
+      })
+      guard.tryStart()
+
+      vi.advanceTimersByTime(500)
+      const resume = guard.beginUserInteraction()
+      vi.advanceTimersByTime(5_000) // human think-time, excluded from budget
+      resume()
+
+      // 500ms of the 1000ms hard-max was spent before the pause; 500ms remain.
+      vi.advanceTimersByTime(499)
+      expect(guard.isActive).toBe(true)
+      vi.advanceTimersByTime(1)
+      expect(guard.isActive).toBe(false)
+    })
+
+    test('reference counts nested interactions', () => {
+      vi.useFakeTimers()
+      vi.spyOn(console, 'error').mockImplementation(() => {})
+      const guard = new QueryGuard({ idleTimeoutMs: 100, hardMaxQueryMs: 10_000 })
+      guard.tryStart()
+
+      const resumeA = guard.beginUserInteraction()
+      const resumeB = guard.beginUserInteraction()
+      vi.advanceTimersByTime(1_000)
+      resumeA()
+      // Still suspended by B — watchdog stays frozen.
+      vi.advanceTimersByTime(1_000)
+      expect(guard.isActive).toBe(true)
+
+      resumeB()
+      vi.advanceTimersByTime(100)
+      expect(guard.isActive).toBe(false)
+    })
+
+    test('repeated resume calls are ignored', () => {
+      vi.useFakeTimers()
+      vi.spyOn(console, 'error').mockImplementation(() => {})
+      const guard = new QueryGuard({ idleTimeoutMs: 100, hardMaxQueryMs: 10_000 })
+      guard.tryStart()
+
+      const resume = guard.beginUserInteraction()
+      resume()
+      resume() // no-op, must not underflow the suspend counter
+
+      const resume2 = guard.beginUserInteraction()
+      vi.advanceTimersByTime(1_000)
+      expect(guard.isActive).toBe(true)
+      resume2()
+      vi.advanceTimersByTime(100)
+      expect(guard.isActive).toBe(false)
+    })
+
+    test('suspending a stale generation is a no-op', () => {
+      vi.useFakeTimers()
+      vi.spyOn(console, 'error').mockImplementation(() => {})
+      const guard = new QueryGuard({ idleTimeoutMs: 100, hardMaxQueryMs: 10_000 })
+      const gen1 = guard.tryStart()!
+      guard.forceEnd()
+      guard.tryStart()
+
+      // Resume tied to the old generation must not affect the current query.
+      const staleResume = guard.beginUserInteraction(gen1)
+      staleResume()
+
+      vi.advanceTimersByTime(100)
+      expect(guard.isActive).toBe(false)
+    })
+  })
 })

--- a/src/utils/QueryGuard.ts
+++ b/src/utils/QueryGuard.ts
@@ -121,6 +121,8 @@ export class QueryGuard {
   private _timeoutHandler: QueryTimeoutHandler | null = null
   private _queryStartedAt = 0
   private _lastActivityAt = 0
+  private _suspendCount = 0
+  private _suspendedAt = 0
   private _leaseCounter = 0
   private _activeLeases = new Map<string, LeaseRecord>()
   private _context: QueryLifecycleContext | null = null
@@ -180,6 +182,8 @@ export class QueryGuard {
     this._status = 'running'
     ++this._generation
     this._activeLeases.clear()
+    this._suspendCount = 0
+    this._suspendedAt = 0
     this._lastContext = null
     this._queryStartedAt = Date.now()
     this._lastActivityAt = this._queryStartedAt
@@ -210,6 +214,7 @@ export class QueryGuard {
     if (this._status !== 'running') return false
     this._clearTimeout()
     this._activeLeases.clear()
+    this._suspendCount = 0
     this._completeContext(terminalReason, abortReason)
     this._status = 'idle'
     this._getActiveOperations = null
@@ -230,6 +235,7 @@ export class QueryGuard {
     if (this._status === 'idle') return
     this._clearTimeout()
     this._activeLeases.clear()
+    this._suspendCount = 0
     this._completeContext(terminalReason, abortReason)
     this._status = 'idle'
     this._getActiveOperations = null
@@ -317,6 +323,66 @@ export class QueryGuard {
     const lease = this._activeLeases.get(leaseId)
     if (!lease || lease.generation !== generation) return
     this._activeLeases.delete(leaseId)
+    this._scheduleTimeout()
+  }
+
+  /**
+   * Suspend the watchdog while the query is legitimately blocked on a human
+   * decision (permission prompt, AskUserQuestion, plan-mode selection). Human
+   * think-time is not "stuck work" and must not count toward the idle timeout
+   * or the hard-maximum budget, otherwise a slow user choice aborts the whole
+   * query. Reference-counted so concurrent or nested interactions are safe.
+   *
+   * Pass the generation when suspending from an async callback so a stale
+   * interaction cannot pause a newer query. Returns a resume function; call it
+   * exactly once (a good fit for a `finally` block). Repeated or stale-
+   * generation resume calls are ignored.
+   */
+  beginUserInteraction(generation = this._generation): () => void {
+    if (this._status !== 'running' || generation !== this._generation) {
+      return () => {}
+    }
+    if (this._suspendCount === 0) {
+      this._suspendedAt = Date.now()
+      // Freeze the watchdog: no timer may fire while awaiting the human.
+      this._clearTimeout()
+    }
+    this._suspendCount++
+
+    let resumed = false
+    return () => {
+      if (resumed) return
+      resumed = true
+      // A superseded query already reset the counter; ignore stale resumes.
+      if (generation !== this._generation) return
+      if (this._suspendCount === 0) return
+      this._suspendCount--
+      if (this._suspendCount === 0) {
+        this._resumeAfterInteraction()
+      }
+    }
+  }
+
+  /**
+   * Restart the watchdog after the last concurrent human interaction ends.
+   * The paused duration is added back to the hard-max deadline and every lease
+   * that predates the pause, so human think-time is fully excluded from each
+   * budget; the idle window restarts fresh because the wait was intentional.
+   */
+  private _resumeAfterInteraction(): void {
+    if (this._status !== 'running') return
+    const now = Date.now()
+    const suspendedMs = Math.max(0, now - this._suspendedAt)
+    this._suspendedAt = 0
+    this._queryStartedAt += suspendedMs
+    for (const lease of this._activeLeases.values()) {
+      // Leases acquired during the pause already start after _suspendedAt, so
+      // only shift ones that were live when the interaction began.
+      if (lease.startedAt <= now - suspendedMs) {
+        lease.deadlineAt += suspendedMs
+      }
+    }
+    this._lastActivityAt = now
     this._scheduleTimeout()
   }
 
@@ -430,6 +496,8 @@ export class QueryGuard {
   private _scheduleTimeout(): void {
     this._clearTimeout()
     if (this._status !== 'running') return
+    // Watchdog is frozen while blocked on a human decision.
+    if (this._suspendCount > 0) return
 
     const now = Date.now()
     const reason = this._getTimeoutReason(now)

--- a/src/utils/QueryGuard.ts
+++ b/src/utils/QueryGuard.ts
@@ -215,6 +215,7 @@ export class QueryGuard {
     this._clearTimeout()
     this._activeLeases.clear()
     this._suspendCount = 0
+    this._suspendedAt = 0
     this._completeContext(terminalReason, abortReason)
     this._status = 'idle'
     this._getActiveOperations = null
@@ -236,6 +237,7 @@ export class QueryGuard {
     this._clearTimeout()
     this._activeLeases.clear()
     this._suspendCount = 0
+    this._suspendedAt = 0
     this._completeContext(terminalReason, abortReason)
     this._status = 'idle'
     this._getActiveOperations = null


### PR DESCRIPTION
Fixes #1878

## What changed and why

The session query watchdog (`QueryGuard`) counts the time a query spends blocked on a user decision toward its idle timeout (5 min). While a query is legitimately waiting on a permission prompt, `AskUserQuestion`, or plan-mode selection, no lease is held, so after 5 minutes the idle watchdog force-ends the whole query and aborts the turn — even though the app is only waiting on the user.

This adds a reference-counted suspend/resume to `QueryGuard` for human-interaction waits:

- `beginUserInteraction()` freezes the watchdog and returns a resume fn.
- On resume, the paused duration is added back to the deadlines (hard-max and any lease that predates the pause) and the idle window restarts fresh, so human wait-time is fully excluded from the watchdog.
- The suspend counter (and `_suspendedAt`) is reset on `tryStart`/`end`/`forceEnd` to prevent cross-generation leaks, and resume is generation-guarded so a stale interaction cannot pause a newer query.

It is exposed as an optional `queryActivity.beginUserInteraction` capability and applied in `interactiveHandler` — the point where the permission dialog is shown and the turn blocks on the user's decision. It is scoped to that window (not the whole permission resolution), so non-human async work such as the classifier in `hasPermissionsToUseTool` stays watched and a genuinely stuck check can still fire the watchdog. Resume runs on the single terminal resolution (allow/reject/abort/hook/classifier/bridge/channel), so it fires exactly once.

## User / developer impact

- Users are no longer interrupted mid-turn for taking time on a permission prompt / question / plan approval.
- The watchdog still fires for genuinely stuck work (no stream chunk, no tool progress, no active lease) — the anti-infinite-spinner behavior from #1255 is preserved. Only human wait-time is excluded.
- No config or public API surface changed; `beginUserInteraction` is optional on `QueryActivity`, so existing implementations and test mocks are unaffected.

## Root cause

The idle watchdog was introduced in #1255 (later extended with leases in #1686) without excluding time spent blocked on the user. This PR fills that gap.

## Scope

Focused on the single bug: human-interaction waits being counted toward the watchdog. Does not change behavior for stuck model/tool work.

## Testing

- [x] `bun test src/utils/QueryGuard.test.ts src/utils/queryGuardConfig.test.ts src/services/tools/queryActivityLease.test.ts src/services/tools/toolExecution.test.ts src/hooks/toolPermission/handlers/interactiveHandler.test.ts` — 79 pass (incl. 5 new `QueryGuard` suspension tests + 5 new `interactiveHandler` pause/resume-wiring tests)
- [x] `bun run typecheck`
- [x] `bun run typecheck:type-tests` — 10 files
- [x] `bun run build`
- [x] `bun run smoke` — prints `0.23.0 (OpenClaude)`
- [x] `bun run deadcode`
- [x] `bun run security:pr-scan`
- [x] `git diff --check`
- [ ] `bun run check` — its `test:full` stage runs the whole suite single-concurrency and does not complete locally; it stalls partway (after `src/utils/conversationCache.test.ts`). This is a full-suite issue (cross-test state/handle leakage), **not** a hang in any file this PR touches — see the per-file run below.

### Whole-suite verified per file

To rule out the stall/failures being caused by this change, I ran **all 510 test files individually**:

- **506 pass · 4 fail · 0 hang.** No file hangs in isolation, so the `bun run check` stall is purely full-suite test-interaction, not a single-file deadlock.
- The 4 failing files — `src/utils/hookChains.test.ts`, `src/utils/model/model.openai-shim-providers.test.ts`, `src/utils/model/parseUserSpecifiedModel.bestTag.test.ts`, `src/utils/model/parseUserSpecifiedModel.disable1m.test.ts` — do **not** import any module this PR changes, and fail identically on `main` (0 pass / 15 fail there too). They are pre-existing, environment-related (provider config/network) failures unrelated to this change.
- Files that only fail inside the full suite pass in isolation (e.g. `src/commands.test.ts` bughunter suite 28 pass, `scripts/reactJsxDevRuntimeProductionShim.test.ts` 5 pass), confirming those are full-suite artifacts, not real failures.

## Notes

- provider/model path tested: not applicable — `QueryGuard` and the permission path are provider-agnostic; no provider behavior changed.
- screenshots: not applicable — no UI/terminal-presentation change; this alters timeout behavior only.
- follow-up work or known limitations: the `bun run check` full-suite stall and the pre-existing `hookChains`/`model` failures are out of scope here and exist on `main`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for pausing query timeouts during human decision-making, such as permission prompts or other interactive steps.
  * Interactive flows now resume timing automatically once the user finishes responding.

* **Bug Fixes**
  * Improved timeout handling so brief user wait periods don’t trigger idle or max-duration expirations.
  * Made repeated or overlapping interactions safer, preventing duplicate resume behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->