### PR TITLE
fix(nvidia-nim): enable reasoning template kwargs

### DIFF
--- a/src/services/api/openaiShim.test.ts
+++ b/src/services/api/openaiShim.test.ts
@@ -7993,6 +7993,46 @@ test('DeepSeek sends thinking toggle and normalized reasoning effort', async () 
   expect(requestBody?.store).toBeUndefined()
 })
 
+test('NVIDIA NIM DeepSeek sends chat template thinking kwargs', async () => {
+  process.env.OPENAI_BASE_URL = 'https://integrate.api.nvidia.com/v1'
+  process.env.NVIDIA_API_KEY = 'nvapi-test'
+
+  let requestBody: Record<string, unknown> | undefined
+  globalThis.fetch = (async (_input, init) => {
+    requestBody = JSON.parse(String(init?.body))
+    return new Response(
+      JSON.stringify({
+        id: 'chatcmpl-1',
+        model: 'deepseek-ai/deepseek-v4-pro',
+        choices: [
+          { message: { role: 'assistant', content: 'ok' }, finish_reason: 'stop' },
+        ],
+        usage: { prompt_tokens: 3, completion_tokens: 1, total_tokens: 4 },
+      }),
+      { headers: { 'Content-Type': 'application/json' } },
+    )
+  }) as unknown as FetchType
+
+  const client = createOpenAIShimClient({
+    reasoningEffort: 'xhigh',
+  }) as OpenAIShimClient
+  await client.beta.messages.create({
+    model: 'deepseek-ai/deepseek-v4-pro',
+    system: 'test',
+    messages: [{ role: 'user', content: 'hi' }],
+    max_tokens: 64,
+    stream: false,
+    thinking: { type: 'enabled' },
+  })
+
+  expect(requestBody?.thinking).toEqual({ type: 'enabled' })
+  expect(requestBody?.reasoning_effort).toBe('max')
+  expect(requestBody?.chat_template_kwargs).toEqual({
+    thinking: true,
+    enable_thinking: true,
+  })
+})
+
 test('DeepSeek omits thinking controls when the Anthropic-side request does not set them', async () => {
   process.env.OPENAI_BASE_URL = 'https://api.deepseek.com/v1'
   process.env.OPENAI_API_KEY = 'sk-deepseek'
@@ -8563,6 +8603,43 @@ test('Z.AI GLM-5.2: per-turn thinking overrides model-query default', async () =
 
   expect(requestBody?.thinking).toEqual({ type: 'enabled' })
   expect(requestBody?.reasoning_effort).toBe('high')
+})
+
+test('NVIDIA NIM Z.AI GLM sends chat template thinking kwargs', async () => {
+  process.env.OPENAI_BASE_URL = 'https://integrate.api.nvidia.com/v1'
+  process.env.NVIDIA_API_KEY = 'nvapi-test'
+
+  let requestBody: Record<string, unknown> | undefined
+  globalThis.fetch = (async (_input, init) => {
+    requestBody = JSON.parse(String(init?.body))
+    return new Response(
+      JSON.stringify({
+        id: 'chatcmpl-1',
+        model: 'z-ai/glm-5.2',
+        choices: [
+          { message: { role: 'assistant', content: 'ok' }, finish_reason: 'stop' },
+        ],
+      }),
+      { headers: { 'Content-Type': 'application/json' } },
+    )
+  }) as unknown as FetchType
+
+  const client = createOpenAIShimClient({
+    reasoningEffort: 'xhigh',
+  }) as OpenAIShimClient
+  await client.beta.messages.create({
+    model: 'z-ai/glm-5.2',
+    messages: [{ role: 'user', content: 'hi' }],
+    max_tokens: 64,
+    stream: false,
+  })
+
+  expect(requestBody?.thinking).toEqual({ type: 'enabled' })
+  expect(requestBody?.reasoning_effort).toBe('max')
+  expect(requestBody?.chat_template_kwargs).toEqual({
+    thinking: true,
+    enable_thinking: true,
+  })
 })
 
 test('Z.AI GLM-5.2: streaming requests with tools send tool_stream', async () => {

--- a/src/services/api/openaiShim.test.ts
+++ b/src/services/api/openaiShim.test.ts
@@ -8033,6 +8033,41 @@ test('NVIDIA NIM DeepSeek sends chat template thinking kwargs', async () => {
   })
 })
 
+test('NVIDIA NIM DeepSeek omits chat template thinking kwargs when thinking is disabled', async () => {
+  process.env.OPENAI_BASE_URL = 'https://integrate.api.nvidia.com/v1'
+  process.env.NVIDIA_API_KEY = 'nvapi-test'
+
+  let requestBody: Record<string, unknown> | undefined
+  globalThis.fetch = (async (_input, init) => {
+    requestBody = JSON.parse(String(init?.body))
+    return new Response(
+      JSON.stringify({
+        id: 'chatcmpl-1',
+        model: 'deepseek-ai/deepseek-v4-pro',
+        choices: [
+          { message: { role: 'assistant', content: 'ok' }, finish_reason: 'stop' },
+        ],
+      }),
+      { headers: { 'Content-Type': 'application/json' } },
+    )
+  }) as unknown as FetchType
+
+  const client = createOpenAIShimClient({
+    reasoningEffort: 'xhigh',
+  }) as OpenAIShimClient
+  await client.beta.messages.create({
+    model: 'deepseek-ai/deepseek-v4-pro?thinking=disabled',
+    system: 'test',
+    messages: [{ role: 'user', content: 'hi' }],
+    max_tokens: 64,
+    stream: false,
+  })
+
+  expect(requestBody?.thinking).toBeUndefined()
+  expect(requestBody?.reasoning_effort).toBeUndefined()
+  expect(requestBody?.chat_template_kwargs).toBeUndefined()
+})
+
 test('DeepSeek omits thinking controls when the Anthropic-side request does not set them', async () => {
   process.env.OPENAI_BASE_URL = 'https://api.deepseek.com/v1'
   process.env.OPENAI_API_KEY = 'sk-deepseek'
@@ -8640,6 +8675,72 @@ test('NVIDIA NIM Z.AI GLM sends chat template thinking kwargs', async () => {
     thinking: true,
     enable_thinking: true,
   })
+})
+
+test('NVIDIA NIM Z.AI GLM omits chat template thinking kwargs without a reasoning request', async () => {
+  process.env.OPENAI_BASE_URL = 'https://integrate.api.nvidia.com/v1'
+  process.env.NVIDIA_API_KEY = 'nvapi-test'
+
+  let requestBody: Record<string, unknown> | undefined
+  globalThis.fetch = (async (_input, init) => {
+    requestBody = JSON.parse(String(init?.body))
+    return new Response(
+      JSON.stringify({
+        id: 'chatcmpl-1',
+        model: 'z-ai/glm-5.2',
+        choices: [
+          { message: { role: 'assistant', content: 'ok' }, finish_reason: 'stop' },
+        ],
+      }),
+      { headers: { 'Content-Type': 'application/json' } },
+    )
+  }) as unknown as FetchType
+
+  const client = createOpenAIShimClient({}) as OpenAIShimClient
+  await client.beta.messages.create({
+    model: 'z-ai/glm-5.2',
+    messages: [{ role: 'user', content: 'hi' }],
+    max_tokens: 64,
+    stream: false,
+  })
+
+  expect(requestBody?.thinking).toBeUndefined()
+  expect(requestBody?.reasoning_effort).toBeUndefined()
+  expect(requestBody?.chat_template_kwargs).toBeUndefined()
+})
+
+test('NVIDIA NIM Z.AI GLM omits chat template thinking kwargs when thinking is disabled', async () => {
+  process.env.OPENAI_BASE_URL = 'https://integrate.api.nvidia.com/v1'
+  process.env.NVIDIA_API_KEY = 'nvapi-test'
+
+  let requestBody: Record<string, unknown> | undefined
+  globalThis.fetch = (async (_input, init) => {
+    requestBody = JSON.parse(String(init?.body))
+    return new Response(
+      JSON.stringify({
+        id: 'chatcmpl-1',
+        model: 'z-ai/glm-5.2',
+        choices: [
+          { message: { role: 'assistant', content: 'ok' }, finish_reason: 'stop' },
+        ],
+      }),
+      { headers: { 'Content-Type': 'application/json' } },
+    )
+  }) as unknown as FetchType
+
+  const client = createOpenAIShimClient({
+    reasoningEffort: 'xhigh',
+  }) as OpenAIShimClient
+  await client.beta.messages.create({
+    model: 'z-ai/glm-5.2?thinking=disabled',
+    messages: [{ role: 'user', content: 'hi' }],
+    max_tokens: 64,
+    stream: false,
+  })
+
+  expect(requestBody?.thinking).toEqual({ type: 'disabled' })
+  expect(requestBody?.reasoning_effort).toBeUndefined()
+  expect(requestBody?.chat_template_kwargs).toBeUndefined()
 })
 
 test('Z.AI GLM-5.2: streaming requests with tools send tool_stream', async () => {

--- a/src/services/api/openaiShim.ts
+++ b/src/services/api/openaiShim.ts
@@ -386,6 +386,25 @@ function setNvidiaNimChatTemplateThinking(body: Record<string, unknown>): void {
   body.chat_template_kwargs = kwargs
 }
 
+function maybeSetNvidiaNimChatTemplateThinking(
+  body: Record<string, unknown>,
+  baseUrl: string | undefined,
+  reasoningRequestPlan: {
+    thinkingType?: string
+    reasoningEffort?: string
+  },
+): void {
+  if (!hasNvidiaNimApiHost(baseUrl)) return
+  if (
+    reasoningRequestPlan.thinkingType !== 'enabled' &&
+    !reasoningRequestPlan.reasoningEffort
+  ) {
+    return
+  }
+
+  setNvidiaNimChatTemplateThinking(body)
+}
+
 function formatRetryAfterHint(response: Response): string {
   const ra = response.headers.get('retry-after')
   return ra ? ` (Retry-After: ${ra})` : ''
@@ -3778,13 +3797,7 @@ class OpenAIShimMessages {
       if (reasoningRequestPlan.reasoningEffort) {
         body.reasoning_effort = reasoningRequestPlan.reasoningEffort
       }
-      if (
-        hasNvidiaNimApiHost(request.baseUrl) &&
-        (reasoningRequestPlan.thinkingType === 'enabled' ||
-          reasoningRequestPlan.reasoningEffort)
-      ) {
-        setNvidiaNimChatTemplateThinking(body)
-      }
+      maybeSetNvidiaNimChatTemplateThinking(body, request.baseUrl, reasoningRequestPlan)
     }
 
     if (reasoningRequestPlan.wireFormat === 'zai_compatible') {
@@ -3798,13 +3811,7 @@ class OpenAIShimMessages {
       } else {
         delete body.reasoning_effort
       }
-      if (
-        hasNvidiaNimApiHost(request.baseUrl) &&
-        (reasoningRequestPlan.thinkingType === 'enabled' ||
-          reasoningRequestPlan.reasoningEffort)
-      ) {
-        setNvidiaNimChatTemplateThinking(body)
-      }
+      maybeSetNvidiaNimChatTemplateThinking(body, request.baseUrl, reasoningRequestPlan)
     }
 
     // Route/model strip rules are authoritative even when compatibility

--- a/src/services/api/openaiShim.ts
+++ b/src/services/api/openaiShim.ts
@@ -364,6 +364,28 @@ export function hasMistralApiHost(baseUrl: string | undefined): boolean {
   }
 }
 
+function hasNvidiaNimApiHost(baseUrl: string | undefined): boolean {
+  if (!baseUrl) return false
+
+  try {
+    return new URL(baseUrl).hostname.toLowerCase() === 'integrate.api.nvidia.com'
+  } catch {
+    return false
+  }
+}
+
+function setNvidiaNimChatTemplateThinking(body: Record<string, unknown>): void {
+  const existing = body.chat_template_kwargs
+  const kwargs =
+    existing && typeof existing === 'object' && !Array.isArray(existing)
+      ? { ...(existing as Record<string, unknown>) }
+      : {}
+
+  kwargs.thinking = true
+  kwargs.enable_thinking = true
+  body.chat_template_kwargs = kwargs
+}
+
 function formatRetryAfterHint(response: Response): string {
   const ra = response.headers.get('retry-after')
   return ra ? ` (Retry-After: ${ra})` : ''
@@ -3756,6 +3778,13 @@ class OpenAIShimMessages {
       if (reasoningRequestPlan.reasoningEffort) {
         body.reasoning_effort = reasoningRequestPlan.reasoningEffort
       }
+      if (
+        hasNvidiaNimApiHost(request.baseUrl) &&
+        (reasoningRequestPlan.thinkingType === 'enabled' ||
+          reasoningRequestPlan.reasoningEffort)
+      ) {
+        setNvidiaNimChatTemplateThinking(body)
+      }
     }
 
     if (reasoningRequestPlan.wireFormat === 'zai_compatible') {
@@ -3768,6 +3797,13 @@ class OpenAIShimMessages {
         body.reasoning_effort = reasoningRequestPlan.reasoningEffort
       } else {
         delete body.reasoning_effort
+      }
+      if (
+        hasNvidiaNimApiHost(request.baseUrl) &&
+        (reasoningRequestPlan.thinkingType === 'enabled' ||
+          reasoningRequestPlan.reasoningEffort)
+      ) {
+        setNvidiaNimChatTemplateThinking(body)
       }
     }
 

--- a/src/utils/providerProfile.test.ts
+++ b/src/utils/providerProfile.test.ts
@@ -507,6 +507,34 @@ test('buildStartupEnvFromProfile preserves explicit OpenAI-compatible env withou
   assert.equal(isDefaultStartupProviderEnv(env), false)
 })
 
+test('buildStartupEnvFromProfile preserves concrete env-only NIM setup over stale profile', async () => {
+  const processEnv = {
+    OPENAI_BASE_URL: 'https://integrate.api.nvidia.com/v1',
+    OPENAI_MODEL: 'qwen/qwen3.5-397b-a17b',
+    NVIDIA_API_KEY: 'nvapi-live',
+    NVIDIA_NIM: '1',
+  }
+
+  const env = await buildStartupEnvFromProfile({
+    persisted: profile('openai', {
+      OPENAI_BASE_URL: 'https://integrate.api.nvidia.com/v1',
+      OPENAI_MODEL: 'z-ai/glm-5.2',
+      NVIDIA_API_KEY: 'nvapi-stale',
+      NVIDIA_NIM: '1',
+    }),
+    processEnv,
+  })
+
+  assert.notEqual(env, processEnv)
+  assert.equal(env.CLAUDE_CODE_USE_OPENAI, '1')
+  assert.equal(env.CLAUDE_CODE_PROVIDER_ROUTE_ID, 'nvidia-nim')
+  assert.equal(env.OPENAI_MODEL, 'qwen/qwen3.5-397b-a17b')
+  assert.equal(env.OPENAI_BASE_URL, 'https://integrate.api.nvidia.com/v1')
+  assert.equal(env.NVIDIA_API_KEY, 'nvapi-live')
+  assert.equal(env.NVIDIA_NIM, '1')
+  assert.equal(resolveActiveRouteIdFromEnv(env), 'nvidia-nim')
+})
+
 test('buildStartupEnvFromProfile respects an explicit CLAUDE_CODE_USE_OPENAI=0 opt-out (issue #1245)', async () => {
   const env = await buildStartupEnvFromProfile({
     persisted: null,

--- a/src/utils/providerProfile.test.ts
+++ b/src/utils/providerProfile.test.ts
@@ -535,6 +535,50 @@ test('buildStartupEnvFromProfile preserves concrete env-only NIM setup over stal
   assert.equal(resolveActiveRouteIdFromEnv(env), 'nvidia-nim')
 })
 
+test('buildStartupEnvFromProfile preserves explicit OpenAI opt-out over concrete env-only NIM setup', async () => {
+  const processEnv: NodeJS.ProcessEnv = {
+    CLAUDE_CODE_USE_OPENAI: '0',
+    OPENAI_BASE_URL: 'https://integrate.api.nvidia.com/v1',
+    OPENAI_MODEL: 'qwen/qwen3.5-397b-a17b',
+    NVIDIA_API_KEY: 'nvapi-live',
+    NVIDIA_NIM: '1',
+  }
+
+  const env = await buildStartupEnvFromProfile({
+    persisted: null,
+    processEnv,
+  })
+
+  assert.equal(env, processEnv)
+  assert.equal(env.CLAUDE_CODE_USE_OPENAI, '0')
+  assert.equal(env.CLAUDE_CODE_PROVIDER_ROUTE_ID, undefined)
+  assert.equal(isDefaultStartupProviderEnv(env), false)
+})
+
+test('buildStartupEnvFromProfile preserves explicit Gemini selection over concrete env-only NIM setup', async () => {
+  const processEnv: NodeJS.ProcessEnv = {
+    CLAUDE_CODE_USE_GEMINI: '1',
+    GEMINI_API_KEY: 'gemini-live',
+    GEMINI_MODEL: 'gemini-2.5-flash',
+    OPENAI_BASE_URL: 'https://integrate.api.nvidia.com/v1',
+    OPENAI_MODEL: 'qwen/qwen3.5-397b-a17b',
+    NVIDIA_API_KEY: 'nvapi-live',
+    NVIDIA_NIM: '1',
+  }
+
+  const env = await buildStartupEnvFromProfile({
+    persisted: null,
+    processEnv,
+  })
+
+  assert.equal(env, processEnv)
+  assert.equal(env.CLAUDE_CODE_USE_GEMINI, '1')
+  assert.equal(env.CLAUDE_CODE_USE_OPENAI, undefined)
+  assert.equal(env.CLAUDE_CODE_PROVIDER_ROUTE_ID, undefined)
+  assert.equal(resolveActiveRouteIdFromEnv(env), 'gemini')
+  assert.equal(isDefaultStartupProviderEnv(env), false)
+})
+
 test('buildStartupEnvFromProfile respects an explicit CLAUDE_CODE_USE_OPENAI=0 opt-out (issue #1245)', async () => {
   const env = await buildStartupEnvFromProfile({
     persisted: null,

--- a/src/utils/providerProfile.test.ts
+++ b/src/utils/providerProfile.test.ts
@@ -535,6 +535,49 @@ test('buildStartupEnvFromProfile preserves concrete env-only NIM setup over stal
   assert.equal(resolveActiveRouteIdFromEnv(env), 'nvidia-nim')
 })
 
+test('buildStartupEnvFromProfile does not activate non-NIM env-only OpenAI-compatible setup', async () => {
+  const env = await buildStartupEnvFromProfile({
+    persisted: null,
+    processEnv: {
+      OPENAI_BASE_URL: 'https://openrouter.ai/api/v1',
+      OPENAI_MODEL: 'openrouter/zhipu/glm-5.2',
+      OPENAI_API_KEY: 'sk-live',
+    },
+  })
+
+  assert.equal(env.CLAUDE_CODE_USE_OPENAI, '1')
+  assert.equal(env.CLAUDE_CODE_PROVIDER_ROUTE_ID, undefined)
+  assert.equal(env.OPENAI_BASE_URL, 'https://opengateway.gitlawb.com/v1')
+  assert.equal(env.OPENAI_MODEL, 'mimo-v2.5-pro')
+  assert.equal(env.OPENAI_API_KEY, undefined)
+  assert.equal(resolveActiveRouteIdFromEnv(env), 'gitlawb-opengateway')
+  assert.equal(isDefaultStartupProviderEnv(env), true)
+})
+
+test('buildStartupEnvFromProfile documents no-flag Gemini env does not beat concrete NIM setup', async () => {
+  const processEnv = {
+    GEMINI_API_KEY: 'gemini-live',
+    GEMINI_MODEL: 'gemini-2.5-flash',
+    OPENAI_BASE_URL: 'https://integrate.api.nvidia.com/v1',
+    OPENAI_MODEL: 'qwen/qwen3.5-397b-a17b',
+    NVIDIA_API_KEY: 'nvapi-live',
+    NVIDIA_NIM: '1',
+  }
+
+  const env = await buildStartupEnvFromProfile({
+    persisted: null,
+    processEnv,
+  })
+
+  assert.notEqual(env, processEnv)
+  assert.equal(env.CLAUDE_CODE_USE_OPENAI, '1')
+  assert.equal(env.CLAUDE_CODE_USE_GEMINI, undefined)
+  assert.equal(env.CLAUDE_CODE_PROVIDER_ROUTE_ID, 'nvidia-nim')
+  assert.equal(env.GEMINI_API_KEY, undefined)
+  assert.equal(env.OPENAI_MODEL, 'qwen/qwen3.5-397b-a17b')
+  assert.equal(resolveActiveRouteIdFromEnv(env), 'nvidia-nim')
+})
+
 test('buildStartupEnvFromProfile preserves explicit OpenAI opt-out over concrete env-only NIM setup', async () => {
   const processEnv: NodeJS.ProcessEnv = {
     CLAUDE_CODE_USE_OPENAI: '0',

--- a/src/utils/providerProfile.ts
+++ b/src/utils/providerProfile.ts
@@ -25,6 +25,7 @@ import {
   getRouteDefaultBaseUrl,
   getRouteDefaultModel,
   normalizeXiaomiMimoBaseUrl,
+  resolveRouteCredentialValue,
   resolveRouteIdFromBaseUrl,
 } from '../integrations/routeMetadata.js'
 import {
@@ -1244,6 +1245,10 @@ function hasConcreteProviderSelection(
     return true
   }
 
+  if (getConcreteOpenAICompatibleEnvRouteId(processEnv)) {
+    return true
+  }
+
   if (isEnvTruthy(processEnv.CLAUDE_CODE_USE_OPENAI)) {
     return (
       sanitizeProviderConfigValue(processEnv.OPENAI_BASE_URL) !== undefined ||
@@ -1298,6 +1303,38 @@ function hasConcreteProviderSelection(
     sanitizeApiKey(processEnv.FIREWORKS_API_KEY) !== undefined ||
     sanitizeApiKey(processEnv.NEARAI_API_KEY) !== undefined
   )
+}
+
+function getConcreteOpenAICompatibleEnvRouteId(
+  processEnv: NodeJS.ProcessEnv = process.env,
+): string | null {
+  const openAIBaseUrl =
+    sanitizeProviderConfigValue(processEnv.OPENAI_BASE_URL) ??
+    sanitizeProviderConfigValue(processEnv.OPENAI_API_BASE)
+  const openAIModel = normalizeProfileModel(
+    sanitizeProviderConfigValue(processEnv.OPENAI_MODEL),
+  )
+  const openAICredential = resolveOpenAICredentialEnvSelection(processEnv)
+  const openAIRouteId = resolveRouteIdFromBaseUrl(openAIBaseUrl)
+  const routeCredential = sanitizeApiKey(
+    resolveRouteCredentialValue({
+      routeId: openAIRouteId ?? 'custom',
+      baseUrl: openAIBaseUrl,
+      processEnv,
+    }),
+  )
+  const authHeaderValue = sanitizeApiKey(processEnv.OPENAI_AUTH_HEADER_VALUE)
+  if (
+    openAIBaseUrl !== undefined &&
+    openAIModel !== undefined &&
+    (openAICredential?.kind === 'usable' ||
+      routeCredential !== undefined ||
+      authHeaderValue !== undefined)
+  ) {
+    return openAIRouteId ?? 'custom'
+  }
+
+  return null
 }
 
 export function selectAutoProfile(
@@ -1857,6 +1894,7 @@ export async function buildLaunchEnv(options: {
     'FIREWORKS_API_KEY',
     'AIMLAPI_API_KEY',
     'MIMO_API_KEY',
+    'NVIDIA_API_KEY',
     'VENICE_API_KEY',
   ] as const) {
     // AI/ML API accepts the generic OPENAI_API_KEY, so it does not need an
@@ -1864,6 +1902,9 @@ export async function buildLaunchEnv(options: {
     // actually targets the aimlapi route — otherwise an ambient or persisted
     // AI/ML key would leak into an unrelated OpenAI-compatible session.
     if (dedicatedKey === 'AIMLAPI_API_KEY' && effectiveOpenAIRouteId !== 'aimlapi') {
+      continue
+    }
+    if (dedicatedKey === 'NVIDIA_API_KEY' && effectiveOpenAIRouteId !== 'nvidia-nim') {
       continue
     }
     const dedicatedValue =
@@ -1874,6 +1915,12 @@ export async function buildLaunchEnv(options: {
       sanitizeApiKey(persistedEnv[dedicatedKey])
     if (dedicatedValue) {
       env[dedicatedKey] = dedicatedValue
+    }
+  }
+  if (effectiveOpenAIRouteId === 'nvidia-nim') {
+    const nvidiaNimFlag = processEnv.NVIDIA_NIM || persistedEnv.NVIDIA_NIM
+    if (nvidiaNimFlag) {
+      env.NVIDIA_NIM = nvidiaNimFlag
     }
   }
   const customHeaders = shellCustomHeaders || persistedCustomHeaders
@@ -1924,6 +1971,21 @@ export async function buildStartupEnvFromProfile(options?: {
   // Moonshot" bug.
   if (profileManagedEnv) {
     return processEnv
+  }
+
+  const concreteOpenAIRouteId = getConcreteOpenAICompatibleEnvRouteId(processEnv)
+  if (
+    concreteOpenAIRouteId &&
+    !isEnvTruthy(processEnv.CLAUDE_CODE_USE_OPENAI)
+  ) {
+    return buildLaunchEnv({
+      profile: 'openai',
+      persisted: null,
+      goal:
+        options?.goal ??
+        normalizeRecommendationGoal(processEnv.OPENCLAUDE_PROFILE_GOAL),
+      processEnv,
+    })
   }
 
   // If startup already has a concrete provider selection, keep trusting it.

--- a/src/utils/providerProfile.ts
+++ b/src/utils/providerProfile.ts
@@ -1238,14 +1238,32 @@ export function hasExplicitProviderSelection(
   )
 }
 
+function hasExplicitNonOpenAIProviderSelection(
+  processEnv: NodeJS.ProcessEnv = process.env,
+): boolean {
+  return (
+    isEnvTruthy(processEnv.CLAUDE_CODE_USE_GITHUB) ||
+    isEnvTruthy(processEnv.CLAUDE_CODE_USE_GEMINI) ||
+    isEnvTruthy(processEnv.CLAUDE_CODE_USE_MISTRAL) ||
+    isEnvTruthy(processEnv.CLAUDE_CODE_USE_BEDROCK) ||
+    isEnvTruthy(processEnv.CLAUDE_CODE_USE_VERTEX) ||
+    isEnvTruthy(processEnv.CLAUDE_CODE_USE_FOUNDRY)
+  )
+}
+
+function hasExplicitOpenAICompatibleOptOut(
+  processEnv: NodeJS.ProcessEnv = process.env,
+): boolean {
+  return (
+    processEnv.CLAUDE_CODE_USE_OPENAI !== undefined &&
+    !isEnvTruthy(processEnv.CLAUDE_CODE_USE_OPENAI)
+  )
+}
+
 function hasConcreteProviderSelection(
   processEnv: NodeJS.ProcessEnv = process.env,
 ): boolean {
   if (processEnv.CLAUDE_CODE_PROVIDER_PROFILE_ENV_APPLIED === '1') {
-    return true
-  }
-
-  if (getConcreteOpenAICompatibleEnvRouteId(processEnv)) {
     return true
   }
 
@@ -1294,6 +1312,14 @@ function hasConcreteProviderSelection(
     isEnvTruthy(processEnv.CLAUDE_CODE_USE_BEDROCK) ||
     isEnvTruthy(processEnv.CLAUDE_CODE_USE_VERTEX) ||
     isEnvTruthy(processEnv.CLAUDE_CODE_USE_FOUNDRY)
+  ) {
+    return true
+  }
+
+  if (
+    !hasExplicitOpenAICompatibleOptOut(processEnv) &&
+    !hasExplicitNonOpenAIProviderSelection(processEnv) &&
+    getConcreteOpenAICompatibleEnvRouteId(processEnv)
   ) {
     return true
   }
@@ -1976,7 +2002,9 @@ export async function buildStartupEnvFromProfile(options?: {
   const concreteOpenAIRouteId = getConcreteOpenAICompatibleEnvRouteId(processEnv)
   if (
     concreteOpenAIRouteId &&
-    !isEnvTruthy(processEnv.CLAUDE_CODE_USE_OPENAI)
+    !isEnvTruthy(processEnv.CLAUDE_CODE_USE_OPENAI) &&
+    !hasExplicitOpenAICompatibleOptOut(processEnv) &&
+    !hasExplicitNonOpenAIProviderSelection(processEnv)
   ) {
     return buildLaunchEnv({
       profile: 'openai',
@@ -2005,10 +2033,7 @@ export async function buildStartupEnvFromProfile(options?: {
     // injecting the default Opengateway profile — otherwise the fallback
     // re-enables OpenAI and the startup validator reports a spurious missing
     // OPENAI_API_KEY warning (#1245).
-    if (
-      processEnv.CLAUDE_CODE_USE_OPENAI !== undefined &&
-      !isEnvTruthy(processEnv.CLAUDE_CODE_USE_OPENAI)
-    ) {
+    if (hasExplicitOpenAICompatibleOptOut(processEnv)) {
       return processEnv
     }
 

--- a/src/utils/providerProfile.ts
+++ b/src/utils/providerProfile.ts
@@ -1316,14 +1316,6 @@ function hasConcreteProviderSelection(
     return true
   }
 
-  if (
-    !hasExplicitOpenAICompatibleOptOut(processEnv) &&
-    !hasExplicitNonOpenAIProviderSelection(processEnv) &&
-    getConcreteOpenAICompatibleEnvRouteId(processEnv)
-  ) {
-    return true
-  }
-
   // Env-only provider setups — no CLAUDE_CODE_USE_* flag needed
   return (
     sanitizeApiKey(processEnv.FIREWORKS_API_KEY) !== undefined ||
@@ -2001,7 +1993,7 @@ export async function buildStartupEnvFromProfile(options?: {
 
   const concreteOpenAIRouteId = getConcreteOpenAICompatibleEnvRouteId(processEnv)
   if (
-    concreteOpenAIRouteId &&
+    concreteOpenAIRouteId === 'nvidia-nim' &&
     !isEnvTruthy(processEnv.CLAUDE_CODE_USE_OPENAI) &&
     !hasExplicitOpenAICompatibleOptOut(processEnv) &&
     !hasExplicitNonOpenAIProviderSelection(processEnv)


### PR DESCRIPTION
## Summary
- add NVIDIA NIM host-gated chat_template_kwargs for DeepSeek-compatible and Z.AI-compatible reasoning requests
- preserve and activate concrete env-only NVIDIA NIM startup config before stale legacy profiles can override OPENAI_MODEL
- carry NVIDIA_API_KEY/NVIDIA_NIM through OpenAI-compatible launch env when the resolved route is nvidia-nim

Fixes #1892.

## Risk surface
- Touches NIM auth/env carry-over, OpenAI-compatible provider routing, and startup profile precedence.
- This is an issue-scoped, blocking bug fix for NVIDIA NIM users whose reasoning requests or env-only startup config were broken; explicit provider selections and explicit OpenAI opt-outs remain preserved.

## Pending PR overlap checked
- #1842 touches openaiShim tool-call id serialization only; no conflict with reasoning request body fields.
- #1630 touches effort semantics, but this patch uses the existing resolved reasoning plan and only adds NIM-specific serialization.
- #1864 and #1886 touch onboarding/provider setup flows, not this startup precedence or NIM shim path.
- upstream branch fix/provider-precedence-startup-freeze is profile-precedence adjacent but has no open PR and does not fix env-only NIM model reversion.

## Tests
- bun test src/services/api/openaiShim.test.ts -t NVIDIA NIM
- bun test src/services/api/openaiShim.test.ts
- HOME=/tmp/openclaude-pr-1893-final-home-full XDG_CONFIG_HOME=/tmp/openclaude-pr-1893-final-config-full bun test src/utils/providerProfile.test.ts
- bun run typecheck
- bun run smoke
- bun run security:pr-scan
- bun run verify:privacy
- bun run integrations:check
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved NVIDIA NIM handling in OpenAI-compatible setups, ensuring the correct NVIDIA credentials are carried over and the right active route is selected.
  * Fixed “thinking”/reasoning request formatting for NVIDIA NIM models so required parameters are included when enabled and fully omitted when disabled.
* **Tests**
  * Added/extended regression tests covering NVIDIA NIM request shaping for multiple model families and validating startup environment/profile selection precedence and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
