### PR TITLE
fix(model): enable model discovery for custom OpenAI-compatible providers

### DIFF
--- a/src/commands/model/model.test.tsx
+++ b/src/commands/model/model.test.tsx
@@ -2423,7 +2423,7 @@ test('/model refresh passes first pooled OpenAI credential to descriptor discove
   expect(discoverModelsForRoute).toHaveBeenCalledWith('openrouter', {
     apiKey: 'key-a',
     baseUrl: 'https://openrouter.ai/api/v1',
-    headers: undefined,
+    headers: {},
     forceRefresh: true,
   })
 })
@@ -3297,10 +3297,10 @@ test('cross-profile /model does NOT switch a literal prefixed model id lacking t
 	  }
 	})
 
-	test('/model remote custom route falls through to legacy OpenAI path', async () => {
+	test('/model remote custom route uses descriptor discovery', async () => {
 	  // Remote custom endpoint — not a local URL so no openai: cache scope.
-	  // The route resolves to 'custom' and the code must fall through to the
-	  // legacy OpenAI path instead of getting stuck in descriptor discovery.
+	  // The route resolves to 'custom' and must use descriptor discovery
+	  // since there is a real custom gateway with an OpenAI-compatible catalog.
 	  process.env.CLAUDE_CODE_USE_OPENAI = '1'
 	  process.env.OPENAI_BASE_URL = 'https://api.custom-remote.example.com/v1'
 	  process.env.OPENAI_MODEL = 'remote-model'
@@ -3312,21 +3312,42 @@ test('cross-profile /model does NOT switch a literal prefixed model id lacking t
 	  delete process.env.CLAUDE_CODE_USE_BEDROCK
 	  delete process.env.CLAUDE_CODE_USE_VERTEX
 	  delete process.env.CLAUDE_CODE_USE_FOUNDRY
-		  delete process.env.OPENAI_API_BASE
+		delete process.env.OPENAI_API_BASE
 
-		  // Remote URL → no openai: cache scope (null or undefined)
-		  // The legacy fallback should still work regardless.
-
-		  const rendered = await renderModelCommandWithCapturedPicker(
-		    'remote-custom-legacy-fallback',
-		  )
-		  try {
-		    const props = rendered.getCapturedProps()
-		    // Remote custom route: falls through to legacy OpenAI path (no crash).
-		    // The ModelPicker renders with at least a "Default" option available.
-		    expect(props).toBeDefined()
-		  } finally {
-		    rendered.instance.unmount()
-		    rendered.stdout.end()
-		  }
+		// Mock descriptor discovery for the custom route
+		mockDescriptorDiscovery({
+			cachedModels: [
+				{ id: 'remote-model', apiName: 'remote-model', label: 'Remote Model' },
+				{ id: 'model-b', apiName: 'model-b', label: 'Model B' },
+			],
+			discoveredModels: [
+				{ id: 'remote-model', apiName: 'remote-model', label: 'Remote Model' },
+			],
+			routeId: 'custom',
 		})
+
+		mockProviderProfiles({
+			getActiveOpenAIModelOptionsCache: () => [],
+			getActiveProviderProfile: () => undefined,
+			getProfileModelOptions: () => [],
+			setActiveOpenAIModelOptionsCache: () => {},
+		})
+
+		const rendered = await renderModelCommandWithCapturedPicker(
+			'remote-custom-descriptor',
+		)
+		try {
+			const props = rendered.getCapturedProps()
+			// Remote custom route: uses descriptor discovery path
+			expect(props).toBeDefined()
+			// Should show discovered models
+			expect(props.optionsOverride).toContainEqual(
+				expect.objectContaining({
+					value: 'remote-model',
+				}),
+			)
+		} finally {
+			rendered.instance.unmount()
+			rendered.stdout.end()
+		}
+	})

--- a/src/commands/model/model.test.tsx
+++ b/src/commands/model/model.test.tsx
@@ -3292,7 +3292,41 @@ test('cross-profile /model does NOT switch a literal prefixed model id lacking t
     expect(doneMessage).toContain(
       encodeSwitchProfileValue('profile_openai', 'gpt-5-mini'),
     )
-  } finally {
-    instance.unmount()
-  }
-})
+	  } finally {
+	    instance.unmount()
+	  }
+	})
+
+	test('/model remote custom route falls through to legacy OpenAI path', async () => {
+	  // Remote custom endpoint — not a local URL so no openai: cache scope.
+	  // The route resolves to 'custom' and the code must fall through to the
+	  // legacy OpenAI path instead of getting stuck in descriptor discovery.
+	  process.env.CLAUDE_CODE_USE_OPENAI = '1'
+	  process.env.OPENAI_BASE_URL = 'https://api.custom-remote.example.com/v1'
+	  process.env.OPENAI_MODEL = 'remote-model'
+	  delete process.env.OPENAI_API_KEY
+	  delete process.env.OPENROUTER_API_KEY
+	  delete process.env.CLAUDE_CODE_USE_GEMINI
+	  delete process.env.CLAUDE_CODE_USE_GITHUB
+	  delete process.env.CLAUDE_CODE_USE_MISTRAL
+	  delete process.env.CLAUDE_CODE_USE_BEDROCK
+	  delete process.env.CLAUDE_CODE_USE_VERTEX
+	  delete process.env.CLAUDE_CODE_USE_FOUNDRY
+		  delete process.env.OPENAI_API_BASE
+
+		  // Remote URL → no openai: cache scope (null or undefined)
+		  // The legacy fallback should still work regardless.
+
+		  const rendered = await renderModelCommandWithCapturedPicker(
+		    'remote-custom-legacy-fallback',
+		  )
+		  try {
+		    const props = rendered.getCapturedProps()
+		    // Remote custom route: falls through to legacy OpenAI path (no crash).
+		    // The ModelPicker renders with at least a "Default" option available.
+		    expect(props).toBeDefined()
+		  } finally {
+		    rendered.instance.unmount()
+		    rendered.stdout.end()
+		  }
+		})

--- a/src/commands/model/model.tsx
+++ b/src/commands/model/model.tsx
@@ -444,7 +444,12 @@ async function loadDescriptorDiscoveryContext(
     return null
   }
 
-  if (routeId === 'custom') {
+
+  // Local custom providers (Ollama, LM Studio) should use the legacy local
+  // OpenAI path which handles scoped caches, default options, and allowlist
+  // filtering correctly. Remote custom providers proceed with descriptor
+  // discovery so their dynamically-discovered models appear in the picker.
+  if (routeId === 'custom' && getAdditionalModelOptionsCacheScope()?.startsWith('openai:')) {
     return null
   }
 

--- a/src/commands/model/model.tsx
+++ b/src/commands/model/model.tsx
@@ -444,7 +444,6 @@ async function loadDescriptorDiscoveryContext(
     return null
   }
 
-
   // Local custom providers (Ollama, LM Studio) should use the legacy local
   // OpenAI path which handles scoped caches, default options, and allowlist
   // filtering correctly. Remote custom providers proceed with descriptor
@@ -553,7 +552,10 @@ async function loadModelDiscoveryContext(): Promise<ModelDiscoveryContext | null
     }
   }
 
-  if (getAdditionalModelOptionsCacheScope()?.startsWith('openai:')) {
+	  if (
+	    getAdditionalModelOptionsCacheScope()?.startsWith('openai:') ||
+	    routeId === 'custom'
+	  ) {
     const { baseUrl } = getOpenAIDiscoveryRequestOptions()
     const activeProfile = getActiveProviderProfile()
     const legacyRouteId = routeId ?? 'custom'

--- a/src/commands/model/model.tsx
+++ b/src/commands/model/model.tsx
@@ -375,6 +375,18 @@ function getOpenAIDiscoveryRequestOptions(routeId?: string | null): {
     baseUrl: process.env.OPENAI_BASE_URL,
   })
 
+  const headers: Record<string, string> = {
+    ...parseCustomHeadersEnv(process.env.ANTHROPIC_CUSTOM_HEADERS),
+  }
+
+  // Forward custom auth headers that the OpenAI shim uses for inference.
+  // These support gateways that authenticate with non-Bearer schemes.
+  const authHeader = process.env.OPENAI_AUTH_HEADER?.trim()
+  const authHeaderValue = process.env.OPENAI_AUTH_HEADER_VALUE?.trim()
+  if (authHeader && /^[A-Za-z0-9!#$%&'*+.^_`|~-]+$/.test(authHeader)) {
+    headers[authHeader] = authHeaderValue ?? ''
+  }
+
   return {
     apiKey: firstUsableCredential(
       resolveRouteCredentialValue({
@@ -384,7 +396,7 @@ function getOpenAIDiscoveryRequestOptions(routeId?: string | null): {
       }),
     ),
     baseUrl: request.baseUrl,
-    headers: parseCustomHeadersEnv(process.env.ANTHROPIC_CUSTOM_HEADERS),
+    headers,
   }
 }
 

--- a/src/commands/model/model.tsx
+++ b/src/commands/model/model.tsx
@@ -379,25 +379,51 @@ function getOpenAIDiscoveryRequestOptions(routeId?: string | null): {
     ...parseCustomHeadersEnv(process.env.ANTHROPIC_CUSTOM_HEADERS),
   }
 
-  // Forward custom auth headers that the OpenAI shim uses for inference.
-  // These support gateways that authenticate with non-Bearer schemes.
+  const apiKey = firstUsableCredential(
+    resolveRouteCredentialValue({
+      routeId,
+      baseUrl: request.baseUrl,
+      processEnv: process.env,
+    }),
+  )
+
+  // Forward custom auth headers matching the OpenAI shim's inference logic.
+  // This ensures discovery requests authenticate the same way as chat requests.
   const authHeader = process.env.OPENAI_AUTH_HEADER?.trim()
-  const authHeaderValue = process.env.OPENAI_AUTH_HEADER_VALUE?.trim()
+  let explicitCustomAuthHeaderValue: string | undefined
   if (authHeader && /^[A-Za-z0-9!#$%&'*+.^_`|~-]+$/.test(authHeader)) {
-    headers[authHeader] = authHeaderValue ?? ''
+    explicitCustomAuthHeaderValue = process.env.OPENAI_AUTH_HEADER_VALUE?.trim()
   }
 
-  return {
-    apiKey: firstUsableCredential(
-      resolveRouteCredentialValue({
-        routeId,
-        baseUrl: request.baseUrl,
-        processEnv: process.env,
-      }),
-    ),
-    baseUrl: request.baseUrl,
-    headers,
+  if (explicitCustomAuthHeaderValue) {
+    // Custom auth header with explicit value — same as shim's hasCustomAuthHeader + configuredAuthHeaderValue.
+    // Apply OPENAI_AUTH_SCHEME: default 'bearer' for Authorization header, 'raw' for others.
+    const isAuth = authHeader!.toLowerCase() === 'authorization'
+    const scheme = process.env.OPENAI_AUTH_SCHEME?.trim().toLowerCase()
+    const effectiveScheme =
+      scheme === 'raw' || scheme === 'bearer' ? scheme : isAuth ? 'bearer' : 'raw'
+    headers[authHeader!] =
+      effectiveScheme === 'bearer'
+        ? `Bearer ${explicitCustomAuthHeaderValue}`
+        : explicitCustomAuthHeaderValue
+    // Auth is handled by the custom header — omit the default Bearer apiKey.
+    return { baseUrl: request.baseUrl, headers }
   }
+
+  if (authHeader) {
+    // Custom auth header name is set but no explicit value — use the resolved apiKey
+    // formatted with OPENAI_AUTH_SCHEME (same as shim lines 4221-4231).
+    const scheme = process.env.OPENAI_AUTH_SCHEME?.trim().toLowerCase()
+    const isAuth = authHeader.toLowerCase() === 'authorization'
+    const effectiveScheme =
+      scheme === 'raw' || scheme === 'bearer' ? scheme : isAuth ? 'bearer' : 'raw'
+    headers[authHeader] =
+      effectiveScheme === 'bearer' ? `Bearer ${apiKey ?? ''}` : (apiKey ?? '')
+    // Auth is handled by the custom header — omit the default Bearer apiKey.
+    return { baseUrl: request.baseUrl, headers }
+  }
+
+  return { apiKey, baseUrl: request.baseUrl, headers }
 }
 
 // Reconciles fast-mode state when /model picks a new target — both the regular
@@ -519,6 +545,13 @@ async function loadDescriptorDiscoveryContext(
     staticEntries,
     cached?.models ?? [],
   )
+
+  // If this dynamic catalog has no usable entries (no static models and no
+  // cached discovery), fall through to the legacy OpenAI path which provides
+  // the Default option and a working fallback surface.
+  if (mergedEntries.length === 0) {
+    return null
+  }
 
   let discoveryState: ModelPickerDiscoveryState | undefined
 

--- a/src/integrations/runtimeMetadata.ts
+++ b/src/integrations/runtimeMetadata.ts
@@ -420,6 +420,14 @@ function findCachedCatalogEntryForApiName(
   }
 
   const baseUrl = runtimeEnv.OPENAI_BASE_URL ?? runtimeEnv.OPENAI_API_BASE
+  const discoveryHeaders: Record<string, string> = {
+    ...parseCustomHeadersEnv(runtimeEnv.ANTHROPIC_CUSTOM_HEADERS),
+  }
+  const authHeader = runtimeEnv.OPENAI_AUTH_HEADER?.trim()
+  const authHeaderValue = runtimeEnv.OPENAI_AUTH_HEADER_VALUE?.trim()
+  if (authHeader && /^[A-Za-z0-9!#$%&'*+.^_`|~-]+$/.test(authHeader) && authHeaderValue) {
+    discoveryHeaders[authHeader] = authHeaderValue
+  }
   const cacheKey = getDiscoveryCacheKey(routeId, {
     baseUrl,
     apiKey: firstUsableCredential(
@@ -429,7 +437,7 @@ function findCachedCatalogEntryForApiName(
         processEnv: runtimeEnv,
       }),
     ),
-    headers: parseCustomHeadersEnv(runtimeEnv.ANTHROPIC_CUSTOM_HEADERS),
+    headers: discoveryHeaders,
   })
   const cached = getCachedModelsSync(cacheKey, getDiscoveryCacheTtlMs(routeId))
 

--- a/src/utils/model/nvidiaNimModels.ts
+++ b/src/utils/model/nvidiaNimModels.ts
@@ -213,10 +213,18 @@ export function getNvidiaNimDiscoveryCacheKeyForEnv(
   // Include custom headers in the cache key so this read lands in the
   // same partition the picker (`getOpenAIDiscoveryRequestOptions` in
   // src/commands/model/model.tsx) writes to.
+  const customHeaders: Record<string, string> = {
+    ...parseCustomHeadersEnv(processEnv.ANTHROPIC_CUSTOM_HEADERS),
+  }
+  const authHeader = processEnv.OPENAI_AUTH_HEADER?.trim()
+  const authHeaderValue = processEnv.OPENAI_AUTH_HEADER_VALUE?.trim()
+  if (authHeader && /^[A-Za-z0-9!#$%&'*+.^_`|~-]+$/.test(authHeader) && authHeaderValue) {
+    customHeaders[authHeader] = authHeaderValue
+  }
   return getDiscoveryCacheKey('nvidia-nim', {
     baseUrl: request.baseUrl,
     apiKey,
-    headers: parseCustomHeadersEnv(processEnv.ANTHROPIC_CUSTOM_HEADERS),
+    headers: customHeaders,
   })
 }
 


### PR DESCRIPTION
Remove the early return in `loadDescriptorDiscoveryContext` that skipped model discovery for `routeId === 'custom'`.

This prevented the `/model` picker from showing dynamically discovered models and blocked `/model refresh` for users of custom OpenAI-compatible endpoints (e.g., custom gateways, self-hosted APIs).

Previously, models from the API's `/v1/models` endpoint were fetched during startup discovery and cached, but the descriptor context refused to load them for custom routes, forcing the picker to fall back to hardcoded default options instead.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved descriptor-based model discovery for custom routes to avoid skipping when a descriptor catalog is available.
  * Strengthened the legacy OpenAI-compatible discovery fallback for custom routes and OpenAI-scoped configurations when descriptor context is missing.
  * Updated discovery caching to account for forwarded auth/header combinations, improving compatibility across providers (including NVIDIA NIM).
* **Tests**
  * Adjusted discovery cache expectations and added coverage for remote custom OpenAI routes to verify the model picker renders without errors and includes discovered options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->