### PR TITLE
refactor(messages): extract content helpers (4 of 8)

### DIFF
--- a/src/services/compact/compact.test.ts
+++ b/src/services/compact/compact.test.ts
@@ -357,15 +357,7 @@ function registerCommonCompactStubs(options: CompactMockOptions = {}) {
       uuid: `sys-${Math.random()}`,
       timestamp: new Date().toISOString(),
     })),
-    getAssistantMessageText: mock(
-      (msg: Message) =>
-        typeof msg.message.content === 'string'
-          ? msg.message.content
-          : (Array.isArray(msg.message.content) &&
-              msg.message.content[0]?.type === 'text')
-            ? msg.message.content[0].text
-            : '',
-    ),
+    getAssistantMessageText: _realMessagesModule.getAssistantMessageText,
     getLastAssistantMessage: mock(
       (msgs: Message[]) => msgs.findLast(m => m.type === 'assistant') ?? null,
     ),

--- a/src/utils/messages.ts
+++ b/src/utils/messages.ts
@@ -317,61 +317,16 @@ export {
   prepareUserContent,
 } from './messages/factories.js'
 
-export function extractTag(html: string, tagName: string): string | null {
-  if (!html.trim() || !tagName.trim()) {
-    return null
-  }
-
-  const escapedTag = escapeRegExp(tagName)
-
-  // Create regex pattern that handles:
-  // 1. Self-closing tags
-  // 2. Tags with attributes
-  // 3. Nested tags of the same type
-  // 4. Multiline content
-  const pattern = new RegExp(
-    `<${escapedTag}(?:\\s+[^>]*)?>` + // Opening tag with optional attributes
-      '([\\s\\S]*?)' + // Content (non-greedy match)
-      `<\\/${escapedTag}>`, // Closing tag
-    'gi',
-  )
-
-  let match
-  let depth = 0
-  let lastIndex = 0
-  const openingTag = new RegExp(`<${escapedTag}(?:\\s+[^>]*?)?>`, 'gi')
-  const closingTag = new RegExp(`<\\/${escapedTag}>`, 'gi')
-
-  while ((match = pattern.exec(html)) !== null) {
-    // Check for nested tags
-    const content = match[1]
-    const beforeMatch = html.slice(lastIndex, match.index)
-
-    // Reset depth counter
-    depth = 0
-
-    // Count opening tags before this match
-    openingTag.lastIndex = 0
-    while (openingTag.exec(beforeMatch) !== null) {
-      depth++
-    }
-
-    // Count closing tags before this match
-    closingTag.lastIndex = 0
-    while (closingTag.exec(beforeMatch) !== null) {
-      depth--
-    }
-
-    // Only include content if we're at the correct nesting level
-    if (depth === 0 && content) {
-      return content
-    }
-
-    lastIndex = match.index + match[0].length
-  }
-
-  return null
-}
+export {
+  extractTag,
+  extractTextContent,
+  getAssistantMessageText,
+  getContentText,
+  getUserMessageText,
+  isEmptyMessageText,
+  stripPromptXMLTags,
+  textForResubmit,
+} from "./messages/content.js"
 
 export function isNotEmptyMessage(message: Message): boolean {
   if (
@@ -2249,18 +2204,6 @@ export function normalizeContentFromAPI(
   })
 }
 
-export function isEmptyMessageText(text: string): boolean {
-  return (
-    stripPromptXMLTags(text).trim() === '' || text.trim() === NO_CONTENT_MESSAGE
-  )
-}
-const STRIPPED_TAGS_RE =
-  /<(commit_analysis|context|function_analysis|pr_analysis)>.*?<\/\1>\n?/gs
-
-export function stripPromptXMLTags(content: string): string {
-  return content.replace(STRIPPED_TAGS_RE, '').trim()
-}
-
 export function getToolUseID(message: NormalizedMessage): string | null {
   switch (message.type) {
     case 'attachment':
@@ -2341,77 +2284,6 @@ export function filterUnresolvedToolUses(messages: Message[]): Message[] {
   })
 }
 
-export function getAssistantMessageText(message: Message): string | null {
-  if (message.type !== 'assistant') {
-    return null
-  }
-
-  // For content blocks array, extract and concatenate text blocks
-  if (Array.isArray(message.message.content)) {
-    return (
-      message.message.content
-        .filter(block => block.type === 'text')
-        .map(block => (block.type === 'text' ? block.text : ''))
-        .join('\n')
-        .trim() || null
-    )
-  }
-  return null
-}
-
-export function getUserMessageText(
-  message: Message | NormalizedMessage,
-): string | null {
-  if (message.type !== 'user') {
-    return null
-  }
-
-  const content = message.message.content
-
-  return getContentText(content)
-}
-
-export function textForResubmit(
-  msg: UserMessage,
-): { text: string; mode: 'bash' | 'prompt' } | null {
-  const content = getUserMessageText(msg)
-  if (content === null) return null
-  const bash = extractTag(content, 'bash-input')
-  if (bash) return { text: bash, mode: 'bash' }
-  const cmd = extractTag(content, COMMAND_NAME_TAG)
-  if (cmd) {
-    const args = extractTag(content, COMMAND_ARGS_TAG) ?? ''
-    return { text: `${cmd} ${args}`, mode: 'prompt' }
-  }
-  return { text: stripIdeContextTags(content), mode: 'prompt' }
-}
-
-/**
- * Extract text from an array of content blocks, joining text blocks with the
- * given separator. Works with ContentBlock, ContentBlockParam, BetaContentBlock,
- * and their readonly/DeepImmutable variants via structural typing.
- */
-export function extractTextContent(
-  blocks: readonly { readonly type: string }[],
-  separator = '',
-): string {
-  return blocks
-    .filter((b): b is { type: 'text'; text: string } => b.type === 'text')
-    .map(b => b.text)
-    .join(separator)
-}
-
-export function getContentText(
-  content: string | DeepImmutable<Array<ContentBlockParam>>,
-): string | null {
-  if (typeof content === 'string') {
-    return content
-  }
-  if (Array.isArray(content)) {
-    return extractTextContent(content, '\n').trim() || null
-  }
-  return null
-}
 
 export { handleMessageFromStream } from './messages/streaming.js'
 export type { StreamingThinking, StreamingToolUse } from './messages/streaming.js'

--- a/src/utils/messages.ts
+++ b/src/utils/messages.ts
@@ -136,14 +136,18 @@ import { TASK_UPDATE_TOOL_NAME } from '../tools/TaskUpdateTool/constants.js'
 import type { PermissionMode } from '../types/permissions.js'
 import { normalizeToolInput, normalizeToolInputForAPI } from './api.js'
 import { logAntError, logForDebugging } from './debug.js'
-import { stripIdeContextTags } from './displayTags.js'
+import { hasEmbeddedSearchTools } from './embeddedTools.js'
 import { formatFileSize } from './format.js'
 import { validateImagesForAPI } from './imageValidation.js'
 import { safeParseJSON } from './json.js'
 import { logError, logMCPDebug } from './log.js'
 import { normalizeLegacyToolName } from './permissions/permissionRuleParser.js'
 import { isDangerousPermissionMode } from './permissions/PermissionMode.js'
-import { escapeRegExp } from './stringUtils.js'
+import {
+  getPlanModeV2AgentCount,
+  getPlanModeV2ExploreAgentCount,
+  isPlanModeInterviewPhaseEnabled,
+} from './planModeV2.js'
 import { isTodoV2Enabled } from './tasks.js'
 import {
   CANCEL_MESSAGE,
@@ -326,7 +330,7 @@ export {
   isEmptyMessageText,
   stripPromptXMLTags,
   textForResubmit,
-} from "./messages/content.js"
+} from './messages/content.js'
 
 export function isNotEmptyMessage(message: Message): boolean {
   if (

--- a/src/utils/messages/content.test.ts
+++ b/src/utils/messages/content.test.ts
@@ -1,12 +1,19 @@
 import { expect, test } from 'bun:test'
-import { createUserMessage } from '../messages.js'
 import {
   extractTag,
   extractTextContent,
   getContentText,
+  isEmptyMessageText,
   stripPromptXMLTags,
   textForResubmit,
 } from './content.js'
+
+function userMessage(content: string) {
+  return {
+    type: 'user',
+    message: { content },
+  } as never
+}
 
 test('extractTextContent joins only text blocks', () => {
   expect(
@@ -26,14 +33,54 @@ test('getContentText returns null for array content without text', () => {
 })
 
 test('textForResubmit extracts bash-input commands', () => {
-  const message = createUserMessage({
-    content: '<bash-input>git status</bash-input>',
-  })
+  const message = userMessage('<bash-input>git status</bash-input>')
 
   expect(textForResubmit(message)).toEqual({
     text: 'git status',
     mode: 'bash',
   })
+})
+
+test('textForResubmit extracts slash commands and strips IDE context from plain text', () => {
+  const commandMessage = userMessage(
+    '<command-name>review</command-name><command-args>pr 1901</command-args>',
+  )
+  expect(textForResubmit(commandMessage)).toEqual({
+    text: 'review pr 1901',
+    mode: 'prompt',
+  })
+
+  const plainMessage = userMessage(
+    '<ide_opened_file>/tmp/noise.ts</ide_opened_file>\nplease review this',
+  )
+  expect(textForResubmit(plainMessage)).toEqual({
+    text: 'please review this',
+    mode: 'prompt',
+  })
+})
+
+test('isEmptyMessageText treats stripped tag-only and sentinel text as empty', () => {
+  expect(isEmptyMessageText('<context>hidden</context>')).toBe(true)
+  expect(isEmptyMessageText('(no content)')).toBe(true)
+  expect(isEmptyMessageText('hello')).toBe(false)
+})
+
+test('getAssistantMessageText joins text blocks for assistant messages', async () => {
+  const { getAssistantMessageText } = await import(
+    `./content.js?getAssistantMessageText=${Date.now()}-${Math.random()}`,
+  )
+  const message = {
+    type: 'assistant',
+    message: {
+      content: [
+        { type: 'text', text: 'alpha' },
+        { type: 'tool_use', id: 'toolu_1' },
+        { type: 'text', text: 'beta' },
+      ],
+    },
+  } as never
+
+  expect(getAssistantMessageText(message)).toBe('alpha\nbeta')
 })
 
 test('extractTag handles attributes and stripPromptXMLTags removes hidden blocks', () => {

--- a/src/utils/messages/content.test.ts
+++ b/src/utils/messages/content.test.ts
@@ -2,6 +2,7 @@ import { expect, test } from 'bun:test'
 import {
   extractTag,
   extractTextContent,
+  getAssistantMessageText,
   getContentText,
   isEmptyMessageText,
   stripPromptXMLTags,
@@ -65,10 +66,7 @@ test('isEmptyMessageText treats stripped tag-only and sentinel text as empty', (
   expect(isEmptyMessageText('hello')).toBe(false)
 })
 
-test('getAssistantMessageText joins text blocks for assistant messages', async () => {
-  const { getAssistantMessageText } = await import(
-    `./content.js?getAssistantMessageText=${Date.now()}-${Math.random()}`,
-  )
+test('getAssistantMessageText joins text blocks for assistant messages', () => {
   const message = {
     type: 'assistant',
     message: {

--- a/src/utils/messages/content.test.ts
+++ b/src/utils/messages/content.test.ts
@@ -1,0 +1,44 @@
+import { expect, test } from 'bun:test'
+import { createUserMessage } from '../messages.js'
+import {
+  extractTag,
+  extractTextContent,
+  getContentText,
+  stripPromptXMLTags,
+  textForResubmit,
+} from './content.js'
+
+test('extractTextContent joins only text blocks', () => {
+  expect(
+    extractTextContent(
+      [
+        { type: 'text', text: 'alpha' } as { type: string; text: string },
+        { type: 'image' },
+        { type: 'text', text: 'beta' } as { type: string; text: string },
+      ],
+      '\n',
+    ),
+  ).toBe('alpha\nbeta')
+})
+
+test('getContentText returns null for array content without text', () => {
+  expect(getContentText([{ type: 'image' } as never])).toBeNull()
+})
+
+test('textForResubmit extracts bash-input commands', () => {
+  const message = createUserMessage({
+    content: '<bash-input>git status</bash-input>',
+  })
+
+  expect(textForResubmit(message)).toEqual({
+    text: 'git status',
+    mode: 'bash',
+  })
+})
+
+test('extractTag handles attributes and stripPromptXMLTags removes hidden blocks', () => {
+  expect(extractTag('<command-name data-x="1">review</command-name>', 'command-name')).toBe(
+    'review',
+  )
+  expect(stripPromptXMLTags('<context>hidden</context>\nvisible')).toBe('visible')
+})

--- a/src/utils/messages/content.ts
+++ b/src/utils/messages/content.ts
@@ -62,7 +62,6 @@ export function extractTag(html: string, tagName: string): string | null {
   return null
 }
 
-
 export function isEmptyMessageText(text: string): boolean {
   return (
     stripPromptXMLTags(text).trim() === '' || text.trim() === NO_CONTENT_MESSAGE

--- a/src/utils/messages/content.ts
+++ b/src/utils/messages/content.ts
@@ -1,0 +1,148 @@
+import type { ContentBlockParam } from '@anthropic-ai/sdk/resources/index.mjs'
+import type { DeepImmutable } from '../../types/utils.js'
+import type { Message, NormalizedMessage, UserMessage } from '../../types/message.js'
+import { COMMAND_ARGS_TAG, COMMAND_NAME_TAG } from '../../constants/xml.js'
+import { NO_CONTENT_MESSAGE } from '../../constants/messages.js'
+import { stripIdeContextTags } from '../displayTags.js'
+import { escapeRegExp } from '../stringUtils.js'
+
+export function extractTag(html: string, tagName: string): string | null {
+  if (!html.trim() || !tagName.trim()) {
+    return null
+  }
+
+  const escapedTag = escapeRegExp(tagName)
+
+  // Create regex pattern that handles:
+  // 1. Self-closing tags
+  // 2. Tags with attributes
+  // 3. Nested tags of the same type
+  // 4. Multiline content
+  const pattern = new RegExp(
+    `<${escapedTag}(?:\\s+[^>]*)?>` + // Opening tag with optional attributes
+      '([\\s\\S]*?)' + // Content (non-greedy match)
+      `<\\/${escapedTag}>`, // Closing tag
+    'gi',
+  )
+
+  let match
+  let depth = 0
+  let lastIndex = 0
+  const openingTag = new RegExp(`<${escapedTag}(?:\\s+[^>]*?)?>`, 'gi')
+  const closingTag = new RegExp(`<\\/${escapedTag}>`, 'gi')
+
+  while ((match = pattern.exec(html)) !== null) {
+    // Check for nested tags
+    const content = match[1]
+    const beforeMatch = html.slice(lastIndex, match.index)
+
+    // Reset depth counter
+    depth = 0
+
+    // Count opening tags before this match
+    openingTag.lastIndex = 0
+    while (openingTag.exec(beforeMatch) !== null) {
+      depth++
+    }
+
+    // Count closing tags before this match
+    closingTag.lastIndex = 0
+    while (closingTag.exec(beforeMatch) !== null) {
+      depth--
+    }
+
+    // Only include content if we're at the correct nesting level
+    if (depth === 0 && content) {
+      return content
+    }
+
+    lastIndex = match.index + match[0].length
+  }
+
+  return null
+}
+
+
+export function isEmptyMessageText(text: string): boolean {
+  return (
+    stripPromptXMLTags(text).trim() === '' || text.trim() === NO_CONTENT_MESSAGE
+  )
+}
+const STRIPPED_TAGS_RE =
+  /<(commit_analysis|context|function_analysis|pr_analysis)>.*?<\/\1>\n?/gs
+
+export function stripPromptXMLTags(content: string): string {
+  return content.replace(STRIPPED_TAGS_RE, '').trim()
+}
+
+export function getAssistantMessageText(message: Message): string | null {
+  if (message.type !== 'assistant') {
+    return null
+  }
+
+  // For content blocks array, extract and concatenate text blocks
+  if (Array.isArray(message.message.content)) {
+    return (
+      message.message.content
+        .filter(block => block.type === 'text')
+        .map(block => (block.type === 'text' ? block.text : ''))
+        .join('\n')
+        .trim() || null
+    )
+  }
+  return null
+}
+
+export function getUserMessageText(
+  message: Message | NormalizedMessage,
+): string | null {
+  if (message.type !== 'user') {
+    return null
+  }
+
+  const content = message.message.content
+
+  return getContentText(content)
+}
+
+export function textForResubmit(
+  msg: UserMessage,
+): { text: string; mode: 'bash' | 'prompt' } | null {
+  const content = getUserMessageText(msg)
+  if (content === null) return null
+  const bash = extractTag(content, 'bash-input')
+  if (bash) return { text: bash, mode: 'bash' }
+  const cmd = extractTag(content, COMMAND_NAME_TAG)
+  if (cmd) {
+    const args = extractTag(content, COMMAND_ARGS_TAG) ?? ''
+    return { text: `${cmd} ${args}`, mode: 'prompt' }
+  }
+  return { text: stripIdeContextTags(content), mode: 'prompt' }
+}
+
+/**
+ * Extract text from an array of content blocks, joining text blocks with the
+ * given separator. Works with ContentBlock, ContentBlockParam, BetaContentBlock,
+ * and their readonly/DeepImmutable variants via structural typing.
+ */
+export function extractTextContent(
+  blocks: readonly { readonly type: string }[],
+  separator = '',
+): string {
+  return blocks
+    .filter((b): b is { type: 'text'; text: string } => b.type === 'text')
+    .map(b => b.text)
+    .join(separator)
+}
+
+export function getContentText(
+  content: string | DeepImmutable<Array<ContentBlockParam>>,
+): string | null {
+  if (typeof content === 'string') {
+    return content
+  }
+  if (Array.isArray(content)) {
+    return extractTextContent(content, '\n').trim() || null
+  }
+  return null
+}


### PR DESCRIPTION
## Summary

Part 4 of 8 in the messages.ts de-monolith migration.

This standalone PR extracts text/content helpers from src/utils/messages.ts into src/utils/messages/content.ts. The public messages.ts surface continues to re-export the moved APIs so existing imports remain valid while this migration lands one PR at a time.

Associated test coverage included:
- Added src/utils/messages/content.test.ts for the moved content helpers.

## Related active PR impact

No direct active PR overlap found for this text-helper slice. #1614 still directly touches src/utils/messages.ts, but this PR avoids the normalization/tool-id areas that #1614 edits.

## Validation

- bun test src/utils/messages/content.test.ts
- bun run typecheck
- bun run typecheck:type-tests
- bun run security:pr-scan
- bun run check was run on part 1 and failed in existing unrelated full-suite areas; not rerun here to avoid repeating the same baseline failures.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized message text extraction and XML-style tag handling into a shared utility for consistent parsing across the app.
* **New Features**
  * Improved resubmission flow that detects bash input vs command/prompt content and extracts the correct text and mode.
  * Enhanced helpers for extracting/normalizing text from structured message blocks and for stripping hidden context from prompt content.
* **Tests**
  * Added a Bun-based test suite covering tag parsing/stripping, empty-message detection, text extraction, and resubmission behavior.
  * Updated compact service tests to use the real assistant text helper.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->