### PR TITLE
refactor(messages): extract basic factories (5 of 8)

### DIFF
--- a/src/services/compact/compact.test.ts
+++ b/src/services/compact/compact.test.ts
@@ -350,15 +350,7 @@ function registerCommonCompactStubs(options: CompactMockOptions = {}) {
 
   // --- Message helpers (DEFENSIVE — stub just enough) ---
   mock.module('../../utils/messages.js', () => ({
-    createUserMessage: mock(
-      (opts: { content: string; isCompactSummary?: boolean }) => ({
-        type: 'user' as const,
-        message: { role: 'user' as const, content: opts.content },
-        uuid: `msg-${Math.random()}`,
-        timestamp: new Date().toISOString(),
-        isCompactSummary: opts.isCompactSummary ?? false,
-      }),
-    ),
+    createUserMessage: _realMessagesModule.createUserMessage,
     createCompactBoundaryMessage: mock(() => ({
       type: 'system' as const,
       message: { role: 'system' as const, content: '' },
@@ -634,6 +626,13 @@ afterEach(() => {
   try {
     mock.restore()
     clearProviderEnv()
+    // mock.module() persists process-wide in bun:test. Restore the message
+    // helpers after each compact test so downstream test files do not import
+    // the compact-only createUserMessage stub.
+    mock.module('../../utils/messages.js', () => ({ ..._realMessagesModule }))
+    mock.module('../../utils/messages/systemFactories.js', () => ({
+      ..._realSystemFactoriesModule,
+    }))
   } finally {
     releaseSharedMutationLock()
   }

--- a/src/utils/messages.ts
+++ b/src/utils/messages.ts
@@ -323,7 +323,7 @@ export {
   hasToolCallsInLastAssistantTurn,
   isSyntheticMessage,
   prepareUserContent,
-} from "./messages/factories.js"
+} from './messages/factories.js'
 
 export function extractTag(html: string, tagName: string): string | null {
   if (!html.trim() || !tagName.trim()) {

--- a/src/utils/messages.ts
+++ b/src/utils/messages.ts
@@ -162,6 +162,14 @@ import {
 import { escapeRegExp } from './stringUtils.js'
 import { isTodoV2Enabled } from './tasks.js'
 import {
+  CANCEL_MESSAGE,
+  createUserMessage,
+  INTERRUPT_MESSAGE,
+  INTERRUPT_MESSAGE_FOR_TOOL_USE,
+  isSyntheticApiErrorMessage,
+  REJECT_MESSAGE,
+} from './messages/factories.js'
+import {
   formatToolResultPairingIssue,
   validateToolResultPairing,
   type ToolResultPairingValidationContext,
@@ -210,13 +218,6 @@ export function deriveShortMessageId(uuid: string): string {
   return parseInt(hex, 16).toString(36).slice(0, 6)
 }
 
-export const INTERRUPT_MESSAGE = '[Request interrupted by user]'
-export const INTERRUPT_MESSAGE_FOR_TOOL_USE =
-  '[Request interrupted by user for tool use]'
-export const CANCEL_MESSAGE =
-  "The user doesn't want to take this action right now. STOP what you are doing and wait for the user to tell you how to proceed."
-export const REJECT_MESSAGE =
-  "The user doesn't want to proceed with this tool use. The tool use was rejected (eg. if it was a file edit, the new_string was NOT written to the file). STOP what you are doing and wait for the user to tell you how to proceed."
 export const REJECT_MESSAGE_WITH_REASON_PREFIX =
   "The user doesn't want to proceed with this tool use. The tool use was rejected (eg. if it was a file edit, the new_string was NOT written to the file). To tell you how to proceed, the user said:\n"
 export const SUBAGENT_REJECT_MESSAGE =
@@ -243,8 +244,6 @@ export function AUTO_REJECT_MESSAGE(toolName: string): string {
 export function DONT_ASK_REJECT_MESSAGE(toolName: string): string {
   return `Permission to use ${toolName} has been denied because Claude Code is running in don't ask mode. ${DENIAL_WORKAROUND_GUIDANCE}`
 }
-export const NO_RESPONSE_REQUESTED = 'No response requested.'
-
 // Synthetic tool_result content inserted by ensureToolResultPairing when a
 // tool_use block has no matching tool_result. Exported so HFI submission can
 // reject any payload containing it — placeholder satisfies pairing structurally
@@ -303,349 +302,28 @@ export function buildClassifierUnavailableMessage(
   )
 }
 
-export const SYNTHETIC_MODEL = '<synthetic>'
-
-export const SYNTHETIC_MESSAGES = new Set([
+export {
+  CANCEL_MESSAGE,
   INTERRUPT_MESSAGE,
   INTERRUPT_MESSAGE_FOR_TOOL_USE,
-  CANCEL_MESSAGE,
-  REJECT_MESSAGE,
   NO_RESPONSE_REQUESTED,
-])
-
-export function isSyntheticMessage(message: Message): boolean {
-  return (
-    message.type !== 'progress' &&
-    message.type !== 'attachment' &&
-    message.type !== 'system' &&
-    Array.isArray(message.message.content) &&
-    message.message.content[0]?.type === 'text' &&
-    SYNTHETIC_MESSAGES.has(message.message.content[0].text)
-  )
-}
-
-function isSyntheticApiErrorMessage(
-  message: Message,
-): message is AssistantMessage & { isApiErrorMessage: true } {
-  return (
-    message.type === 'assistant' &&
-    message.isApiErrorMessage === true &&
-    message.message.model === SYNTHETIC_MODEL
-  )
-}
-
-export function getLastAssistantMessage(
-  messages: Message[],
-): AssistantMessage | undefined {
-  // findLast exits early from the end — much faster than filter + last for
-  // large message arrays (called on every REPL render via useFeedbackSurvey).
-  return messages.findLast(
-    (msg): msg is AssistantMessage => msg.type === 'assistant',
-  )
-}
-
-export function hasToolCallsInLastAssistantTurn(messages: Message[]): boolean {
-  for (let i = messages.length - 1; i >= 0; i--) {
-    const message = messages[i]
-    if (message && message.type === 'assistant') {
-      const assistantMessage = message as AssistantMessage
-      const content = assistantMessage.message.content
-      if (Array.isArray(content)) {
-        return content.some(block => block.type === 'tool_use')
-      }
-    }
-  }
-  return false
-}
-
-function baseCreateAssistantMessage({
-  content,
-  isApiErrorMessage = false,
-  apiError,
-  error,
-  errorDetails,
-  isVirtual,
-  usage = {
-    input_tokens: 0,
-    output_tokens: 0,
-    cache_creation_input_tokens: 0,
-    cache_read_input_tokens: 0,
-    server_tool_use: { web_search_requests: 0, web_fetch_requests: 0 },
-    service_tier: null,
-    cache_creation: {
-      ephemeral_1h_input_tokens: 0,
-      ephemeral_5m_input_tokens: 0,
-    },
-    inference_geo: null,
-    iterations: null,
-    speed: null,
-  },
-}: {
-  content: BetaContentBlock[]
-  isApiErrorMessage?: boolean
-  apiError?: AssistantMessage['apiError']
-  error?: SDKAssistantMessageError
-  errorDetails?: string
-  isVirtual?: true
-  usage?: Usage
-}): AssistantMessage {
-  return {
-    type: 'assistant',
-    uuid: randomUUID(),
-    timestamp: new Date().toISOString(),
-    message: {
-      id: randomUUID(),
-      container: null,
-      model: SYNTHETIC_MODEL,
-      role: 'assistant',
-      stop_reason: 'stop_sequence',
-      stop_sequence: '',
-      type: 'message',
-      usage,
-      content,
-      context_management: null,
-    },
-    requestId: undefined,
-    apiError,
-    error,
-    errorDetails,
-    isApiErrorMessage,
-    isVirtual,
-  }
-}
-
-export function createAssistantMessage({
-  content,
-  usage,
-  isVirtual,
-}: {
-  content: string | BetaContentBlock[]
-  usage?: Usage
-  isVirtual?: true
-}): AssistantMessage {
-  return baseCreateAssistantMessage({
-    content:
-      typeof content === 'string'
-        ? [
-            {
-              type: 'text' as const,
-              text: content === '' ? NO_CONTENT_MESSAGE : content,
-            } as BetaContentBlock, // NOTE: citations field is not supported in Bedrock API
-          ]
-        : content,
-    usage,
-    isVirtual,
-  })
-}
-
-export function createAssistantAPIErrorMessage({
-  content,
-  apiError,
-  error,
-  errorDetails,
-}: {
-  content: string
-  apiError?: AssistantMessage['apiError']
-  error?: SDKAssistantMessageError
-  errorDetails?: string
-}): AssistantMessage {
-  return baseCreateAssistantMessage({
-    content: [
-      {
-        type: 'text' as const,
-        text: content === '' ? NO_CONTENT_MESSAGE : content,
-      } as BetaContentBlock, // NOTE: citations field is not supported in Bedrock API
-    ],
-    isApiErrorMessage: true,
-    apiError,
-    error,
-    errorDetails,
-  })
-}
-
-export function createUserMessage({
-  content,
-  isMeta,
-  isVisibleInTranscriptOnly,
-  isVirtual,
-  isCompactSummary,
-  isCollapseSummary,
-  summarizeMetadata,
-  toolUseResult,
-  isAgentStepLimitToolResult,
-  mcpMeta,
-  uuid,
-  timestamp,
-  imagePasteIds,
-  sourceToolAssistantUUID,
-  permissionMode,
-  origin,
-}: {
-  content: string | ContentBlockParam[]
-  isMeta?: boolean
-  isVisibleInTranscriptOnly?: boolean
-  isVirtual?: boolean
-  isCompactSummary?: boolean
-  isCollapseSummary?: boolean
-  toolUseResult?: unknown // Matches tool's `Output` type
-  isAgentStepLimitToolResult?: boolean
-  /** MCP protocol metadata to pass through to SDK consumers (never sent to model) */
-  mcpMeta?: {
-    _meta?: Record<string, unknown>
-    structuredContent?: Record<string, unknown>
-  }
-  uuid?: UUID | string
-  timestamp?: string
-  imagePasteIds?: number[]
-  // For tool_result messages: the UUID of the assistant message containing the matching tool_use
-  sourceToolAssistantUUID?: UUID
-  // Permission mode when message was sent (for rewind restoration)
-  permissionMode?: PermissionMode
-  summarizeMetadata?: {
-    messagesSummarized: number
-    userContext?: string
-    direction?: PartialCompactDirection
-  }
-  // Provenance of this message. undefined = human (keyboard).
-  origin?: MessageOrigin
-}): UserMessage {
-  const rewindRestorablePermissionMode = isDangerousPermissionMode(
-    permissionMode,
-  )
-    ? undefined
-    : permissionMode
-  const m: UserMessage = {
-    type: 'user',
-    message: {
-      role: 'user',
-      content: content || NO_CONTENT_MESSAGE, // Make sure we don't send empty messages
-    },
-    isMeta,
-    isVisibleInTranscriptOnly,
-    isVirtual,
-    isCompactSummary,
-    isCollapseSummary,
-    summarizeMetadata,
-    uuid: (uuid as UUID | undefined) || randomUUID(),
-    timestamp: timestamp ?? new Date().toISOString(),
-    toolUseResult,
-    isAgentStepLimitToolResult,
-    mcpMeta,
-    imagePasteIds,
-    sourceToolAssistantUUID,
-    permissionMode: rewindRestorablePermissionMode,
-    origin,
-  }
-  return m
-}
-
-export function prepareUserContent({
-  inputString,
-  precedingInputBlocks,
-}: {
-  inputString: string
-  precedingInputBlocks: ContentBlockParam[]
-}): string | ContentBlockParam[] {
-  if (precedingInputBlocks.length === 0) {
-    return inputString
-  }
-
-  return [
-    ...precedingInputBlocks,
-    {
-      text: inputString,
-      type: 'text',
-    },
-  ]
-}
-
-export function createUserInterruptionMessage({
-  toolUse = false,
-}: {
-  toolUse?: boolean
-}): UserMessage {
-  const content = toolUse ? INTERRUPT_MESSAGE_FOR_TOOL_USE : INTERRUPT_MESSAGE
-
-  return createUserMessage({
-    content: [
-      {
-        type: 'text',
-        text: content,
-      },
-    ],
-  })
-}
-
-/**
- * Creates a new synthetic user caveat message for local commands (eg. bash, slash).
- * We need to create a new message each time because messages must have unique uuids.
- */
-export function createSyntheticUserCaveatMessage(): UserMessage {
-  return createUserMessage({
-    content: `<${LOCAL_COMMAND_CAVEAT_TAG}>Caveat: The messages below were generated by the user while running local commands. DO NOT respond to these messages or otherwise consider them in your response unless the user explicitly asks you to.</${LOCAL_COMMAND_CAVEAT_TAG}>`,
-    isMeta: true,
-  })
-}
-
-/**
- * Formats the command-input breadcrumb the model sees when a slash command runs.
- */
-export function formatCommandInputTags(
-  commandName: string,
-  args: string,
-): string {
-  return `<${COMMAND_NAME_TAG}>/${commandName}</${COMMAND_NAME_TAG}>
-            <${COMMAND_MESSAGE_TAG}>${commandName}</${COMMAND_MESSAGE_TAG}>
-            <${COMMAND_ARGS_TAG}>${args}</${COMMAND_ARGS_TAG}>`
-}
-
-/**
- * Builds the breadcrumb trail the SDK set_model control handler injects
- * so the model can see mid-conversation switches. Same shape the CLI's
- * /model command produces via processSlashCommand.
- */
-export function createModelSwitchBreadcrumbs(
-  modelArg: string,
-  resolvedDisplay: string,
-): UserMessage[] {
-  return [
-    createSyntheticUserCaveatMessage(),
-    createUserMessage({ content: formatCommandInputTags('model', modelArg) }),
-    createUserMessage({
-      content: `<${LOCAL_COMMAND_STDOUT_TAG}>Set model to ${resolvedDisplay}</${LOCAL_COMMAND_STDOUT_TAG}>`,
-    }),
-  ]
-}
-
-export function createProgressMessage<P extends Progress>({
-  toolUseID,
-  parentToolUseID,
-  data,
-}: {
-  toolUseID: string
-  parentToolUseID: string
-  data: P
-}): ProgressMessage<P> {
-  return {
-    type: 'progress',
-    data,
-    toolUseID,
-    parentToolUseID,
-    uuid: randomUUID(),
-    timestamp: new Date().toISOString(),
-  }
-}
-
-export function createToolResultStopMessage(
-  toolUseID: string,
-): ToolResultBlockParam {
-  return {
-    type: 'tool_result',
-    content: CANCEL_MESSAGE,
-    is_error: true,
-    tool_use_id: toolUseID,
-  }
-}
+  REJECT_MESSAGE,
+  SYNTHETIC_MESSAGES,
+  SYNTHETIC_MODEL,
+  createAssistantAPIErrorMessage,
+  createAssistantMessage,
+  createModelSwitchBreadcrumbs,
+  createProgressMessage,
+  createSyntheticUserCaveatMessage,
+  createToolResultStopMessage,
+  createUserInterruptionMessage,
+  createUserMessage,
+  formatCommandInputTags,
+  getLastAssistantMessage,
+  hasToolCallsInLastAssistantTurn,
+  isSyntheticMessage,
+  prepareUserContent,
+} from "./messages/factories.js"
 
 export function extractTag(html: string, tagName: string): string | null {
   if (!html.trim() || !tagName.trim()) {

--- a/src/utils/messages/factories.test.ts
+++ b/src/utils/messages/factories.test.ts
@@ -114,6 +114,31 @@ test('hasToolCallsInLastAssistantTurn inspects only the last assistant', () => {
   )
 })
 
+test('hasToolCallsInLastAssistantTurn preserves non-array assistant content behavior', () => {
+  const toolAssistant = createAssistantMessage({
+    content: [
+      {
+        type: 'tool_use',
+        id: 'toolu_1',
+        name: 'Read',
+        input: {},
+      } as never,
+    ],
+  })
+  const baseAssistant = createAssistantMessage({ content: 'legacy text content' })
+  const nonArrayAssistant = {
+    ...baseAssistant,
+    message: {
+      ...baseAssistant.message,
+      content: 'legacy text content',
+    },
+  } as unknown as Message
+
+  expect(
+    hasToolCallsInLastAssistantTurn([toolAssistant, nonArrayAssistant]),
+  ).toBe(true)
+})
+
 test('prepareUserContent keeps plain input unless preceding blocks exist', () => {
   expect(
     prepareUserContent({ inputString: 'hello', precedingInputBlocks: [] }),

--- a/src/utils/messages/factories.test.ts
+++ b/src/utils/messages/factories.test.ts
@@ -1,10 +1,26 @@
 import { expect, test } from 'bun:test'
-import {
+import type { Message } from '../../types/message.js'
+
+const factories = (await import(
+  `./factories.js?factory-test=${Date.now()}-${Math.random()}`
+)) as typeof import('./factories.js')
+
+const {
+  createAssistantAPIErrorMessage,
   createAssistantMessage,
+  createModelSwitchBreadcrumbs,
+  createProgressMessage,
+  createSyntheticUserCaveatMessage,
   createToolResultStopMessage,
+  createUserInterruptionMessage,
   createUserMessage,
   formatCommandInputTags,
-} from './factories.js'
+  getLastAssistantMessage,
+  hasToolCallsInLastAssistantTurn,
+  isSyntheticApiErrorMessage,
+  isSyntheticMessage,
+  prepareUserContent,
+} = factories
 
 test('createAssistantMessage builds a synthetic assistant message', () => {
   const message = createAssistantMessage({ content: 'hello' })
@@ -16,12 +32,109 @@ test('createAssistantMessage builds a synthetic assistant message', () => {
   })
 })
 
-test('createUserMessage preserves metadata and normalizes empty content', () => {
-  const message = createUserMessage({ content: '', isMeta: true })
+test('createAssistantAPIErrorMessage builds a synthetic API error message', () => {
+  const message = createAssistantAPIErrorMessage({
+    content: '',
+    errorDetails: 'rate limited',
+  })
+
+  expect(message.isApiErrorMessage).toBe(true)
+  expect(message.errorDetails).toBe('rate limited')
+  expect(message.message.content[0]).toMatchObject({
+    type: 'text',
+    text: '(no content)',
+  })
+  expect(isSyntheticApiErrorMessage(message)).toBe(true)
+})
+
+test('createUserMessage preserves metadata and normalizes permission mode', () => {
+  const message = createUserMessage({
+    content: '',
+    isMeta: true,
+    permissionMode: 'default',
+  })
+  const dangerousMessage = createUserMessage({
+    content: 'dangerous',
+    permissionMode: 'fullAccess',
+  })
 
   expect(message.type).toBe('user')
   expect(message.isMeta).toBe(true)
   expect(message.message.content).toBe('(no content)')
+  expect(message.permissionMode).toBe('default')
+  expect(dangerousMessage.permissionMode).toBeUndefined()
+})
+
+test('synthetic helpers identify interruption messages and ignore normal messages', () => {
+  const interruption = createUserInterruptionMessage({})
+  const toolInterruption = createUserInterruptionMessage({ toolUse: true })
+  const normalMessage = createUserMessage({ content: 'hello' })
+
+  expect(isSyntheticMessage(interruption)).toBe(true)
+  expect(isSyntheticMessage(toolInterruption)).toBe(true)
+  expect(isSyntheticMessage(normalMessage)).toBe(false)
+})
+
+test('getLastAssistantMessage returns the nearest assistant from the tail', () => {
+  const first = createAssistantMessage({ content: 'first' })
+  const second = createAssistantMessage({ content: 'second' })
+  const messages: Message[] = [
+    createUserMessage({ content: 'start' }),
+    first,
+    createUserMessage({ content: 'middle' }),
+    second,
+    createUserMessage({ content: 'tail' }),
+  ]
+
+  expect(getLastAssistantMessage(messages)).toBe(second)
+})
+
+test('hasToolCallsInLastAssistantTurn inspects only the last assistant', () => {
+  const toolAssistant = createAssistantMessage({
+    content: [
+      {
+        type: 'tool_use',
+        id: 'toolu_1',
+        name: 'Read',
+        input: {},
+      } as never,
+    ],
+  })
+  const textAssistant = createAssistantMessage({ content: 'done' })
+
+  expect(
+    hasToolCallsInLastAssistantTurn([
+      createUserMessage({ content: 'run tool' }),
+      toolAssistant,
+      createUserMessage({ content: 'next' }),
+    ]),
+  ).toBe(true)
+  expect(hasToolCallsInLastAssistantTurn([toolAssistant, textAssistant])).toBe(
+    false,
+  )
+})
+
+test('prepareUserContent keeps plain input unless preceding blocks exist', () => {
+  expect(
+    prepareUserContent({ inputString: 'hello', precedingInputBlocks: [] }),
+  ).toBe('hello')
+
+  expect(
+    prepareUserContent({
+      inputString: 'tail',
+      precedingInputBlocks: [{ type: 'text', text: 'head' }],
+    }),
+  ).toEqual([
+    { type: 'text', text: 'head' },
+    { type: 'text', text: 'tail' },
+  ])
+})
+
+test('createSyntheticUserCaveatMessage marks local command caveats as meta', () => {
+  const message = createSyntheticUserCaveatMessage()
+
+  expect(message.isMeta).toBe(true)
+  expect(message.message.content).toContain('<local-command-caveat>')
 })
 
 test('formatCommandInputTags and createToolResultStopMessage retain public shape', () => {
@@ -30,5 +143,31 @@ test('formatCommandInputTags and createToolResultStopMessage retain public shape
     type: 'tool_result',
     tool_use_id: 'toolu_1',
     is_error: true,
+  })
+})
+
+test('createModelSwitchBreadcrumbs builds the command breadcrumb sequence', () => {
+  const breadcrumbs = createModelSwitchBreadcrumbs('sonnet', 'Claude Sonnet')
+
+  expect(breadcrumbs).toHaveLength(3)
+  expect(breadcrumbs[0]?.isMeta).toBe(true)
+  expect(breadcrumbs[1]?.message.content).toContain('<command-name>/model')
+  expect(breadcrumbs[2]?.message.content).toContain(
+    '<local-command-stdout>Set model to Claude Sonnet</local-command-stdout>',
+  )
+})
+
+test('createProgressMessage preserves tool IDs and payload', () => {
+  const message = createProgressMessage({
+    toolUseID: 'toolu_child',
+    parentToolUseID: 'toolu_parent',
+    data: { message: 'working' },
+  })
+
+  expect(message).toMatchObject({
+    type: 'progress',
+    toolUseID: 'toolu_child',
+    parentToolUseID: 'toolu_parent',
+    data: { message: 'working' },
   })
 })

--- a/src/utils/messages/factories.test.ts
+++ b/src/utils/messages/factories.test.ts
@@ -1,0 +1,34 @@
+import { expect, test } from 'bun:test'
+import {
+  createAssistantMessage,
+  createToolResultStopMessage,
+  createUserMessage,
+  formatCommandInputTags,
+} from './factories.js'
+
+test('createAssistantMessage builds a synthetic assistant message', () => {
+  const message = createAssistantMessage({ content: 'hello' })
+
+  expect(message.type).toBe('assistant')
+  expect(message.message.content[0]).toMatchObject({
+    type: 'text',
+    text: 'hello',
+  })
+})
+
+test('createUserMessage preserves metadata and normalizes empty content', () => {
+  const message = createUserMessage({ content: '', isMeta: true })
+
+  expect(message.type).toBe('user')
+  expect(message.isMeta).toBe(true)
+  expect(message.message.content).toBe('(no content)')
+})
+
+test('formatCommandInputTags and createToolResultStopMessage retain public shape', () => {
+  expect(formatCommandInputTags('model', 'sonnet')).toContain('<command-name>')
+  expect(createToolResultStopMessage('toolu_1')).toMatchObject({
+    type: 'tool_result',
+    tool_use_id: 'toolu_1',
+    is_error: true,
+  })
+})

--- a/src/utils/messages/factories.ts
+++ b/src/utils/messages/factories.ts
@@ -79,10 +79,13 @@ export function getLastAssistantMessage(
 }
 
 export function hasToolCallsInLastAssistantTurn(messages: Message[]): boolean {
-  const content = getLastAssistantMessage(messages)?.message.content
-  return (
-    Array.isArray(content) && content.some(block => block.type === 'tool_use')
-  )
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const message = messages[i]
+    if (message?.type !== 'assistant') continue
+    if (!Array.isArray(message.message.content)) continue
+    return message.message.content.some(block => block.type === 'tool_use')
+  }
+  return false
 }
 
 function baseCreateAssistantMessage({

--- a/src/utils/messages/factories.ts
+++ b/src/utils/messages/factories.ts
@@ -1,0 +1,364 @@
+import type { BetaUsage as Usage } from "@anthropic-ai/sdk/resources/beta/messages/messages.mjs"
+import type { BetaContentBlock } from "@anthropic-ai/sdk/resources/beta/messages/messages.mjs"
+import type { ContentBlockParam, ToolResultBlockParam } from "@anthropic-ai/sdk/resources/index.mjs"
+import { randomUUID, type UUID } from "crypto"
+import type { Progress } from "../../Tool.js"
+import type { SDKAssistantMessageError } from "../../entrypoints/agentSdkTypes.js"
+import type { Message, AssistantMessage, UserMessage, ProgressMessage, MessageOrigin, PartialCompactDirection } from "../../types/message.js"
+import type { PermissionMode } from "../../types/permissions.js"
+import { NO_CONTENT_MESSAGE } from "../../constants/messages.js"
+import { COMMAND_ARGS_TAG, COMMAND_MESSAGE_TAG, COMMAND_NAME_TAG, LOCAL_COMMAND_CAVEAT_TAG, LOCAL_COMMAND_STDOUT_TAG } from "../../constants/xml.js"
+import { isDangerousPermissionMode } from "../permissions/PermissionMode.js"
+
+export const INTERRUPT_MESSAGE = '[Request interrupted by user]'
+export const INTERRUPT_MESSAGE_FOR_TOOL_USE =
+  '[Request interrupted by user for tool use]'
+export const CANCEL_MESSAGE =
+  "The user doesn't want to take this action right now. STOP what you are doing and wait for the user to tell you how to proceed."
+export const REJECT_MESSAGE =
+  "The user doesn't want to proceed with this tool use. The tool use was rejected (eg. if it was a file edit, the new_string was NOT written to the file). STOP what you are doing and wait for the user to tell you how to proceed."
+export const NO_RESPONSE_REQUESTED = 'No response requested.'
+
+export const SYNTHETIC_MODEL = '<synthetic>'
+
+export const SYNTHETIC_MESSAGES = new Set([
+  INTERRUPT_MESSAGE,
+  INTERRUPT_MESSAGE_FOR_TOOL_USE,
+  CANCEL_MESSAGE,
+  REJECT_MESSAGE,
+  NO_RESPONSE_REQUESTED,
+])
+
+export function isSyntheticMessage(message: Message): boolean {
+  return (
+    message.type !== 'progress' &&
+    message.type !== 'attachment' &&
+    message.type !== 'system' &&
+    Array.isArray(message.message.content) &&
+    message.message.content[0]?.type === 'text' &&
+    SYNTHETIC_MESSAGES.has(message.message.content[0].text)
+  )
+}
+
+export function isSyntheticApiErrorMessage(
+  message: Message,
+): message is AssistantMessage & { isApiErrorMessage: true } {
+  return (
+    message.type === 'assistant' &&
+    message.isApiErrorMessage === true &&
+    message.message.model === SYNTHETIC_MODEL
+  )
+}
+
+export function getLastAssistantMessage(
+  messages: Message[],
+): AssistantMessage | undefined {
+  // findLast exits early from the end — much faster than filter + last for
+  // large message arrays (called on every REPL render via useFeedbackSurvey).
+  return messages.findLast(
+    (msg): msg is AssistantMessage => msg.type === 'assistant',
+  )
+}
+
+export function hasToolCallsInLastAssistantTurn(messages: Message[]): boolean {
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const message = messages[i]
+    if (message && message.type === 'assistant') {
+      const assistantMessage = message as AssistantMessage
+      const content = assistantMessage.message.content
+      if (Array.isArray(content)) {
+        return content.some(block => block.type === 'tool_use')
+      }
+    }
+  }
+  return false
+}
+
+function baseCreateAssistantMessage({
+  content,
+  isApiErrorMessage = false,
+  apiError,
+  error,
+  errorDetails,
+  isVirtual,
+  usage = {
+    input_tokens: 0,
+    output_tokens: 0,
+    cache_creation_input_tokens: 0,
+    cache_read_input_tokens: 0,
+    server_tool_use: { web_search_requests: 0, web_fetch_requests: 0 },
+    service_tier: null,
+    cache_creation: {
+      ephemeral_1h_input_tokens: 0,
+      ephemeral_5m_input_tokens: 0,
+    },
+    inference_geo: null,
+    iterations: null,
+    speed: null,
+  },
+}: {
+  content: BetaContentBlock[]
+  isApiErrorMessage?: boolean
+  apiError?: AssistantMessage['apiError']
+  error?: SDKAssistantMessageError
+  errorDetails?: string
+  isVirtual?: true
+  usage?: Usage
+}): AssistantMessage {
+  return {
+    type: 'assistant',
+    uuid: randomUUID(),
+    timestamp: new Date().toISOString(),
+    message: {
+      id: randomUUID(),
+      container: null,
+      model: SYNTHETIC_MODEL,
+      role: 'assistant',
+      stop_reason: 'stop_sequence',
+      stop_sequence: '',
+      type: 'message',
+      usage,
+      content,
+      context_management: null,
+    },
+    requestId: undefined,
+    apiError,
+    error,
+    errorDetails,
+    isApiErrorMessage,
+    isVirtual,
+  }
+}
+
+export function createAssistantMessage({
+  content,
+  usage,
+  isVirtual,
+}: {
+  content: string | BetaContentBlock[]
+  usage?: Usage
+  isVirtual?: true
+}): AssistantMessage {
+  return baseCreateAssistantMessage({
+    content:
+      typeof content === 'string'
+        ? [
+            {
+              type: 'text' as const,
+              text: content === '' ? NO_CONTENT_MESSAGE : content,
+            } as BetaContentBlock, // NOTE: citations field is not supported in Bedrock API
+          ]
+        : content,
+    usage,
+    isVirtual,
+  })
+}
+
+export function createAssistantAPIErrorMessage({
+  content,
+  apiError,
+  error,
+  errorDetails,
+}: {
+  content: string
+  apiError?: AssistantMessage['apiError']
+  error?: SDKAssistantMessageError
+  errorDetails?: string
+}): AssistantMessage {
+  return baseCreateAssistantMessage({
+    content: [
+      {
+        type: 'text' as const,
+        text: content === '' ? NO_CONTENT_MESSAGE : content,
+      } as BetaContentBlock, // NOTE: citations field is not supported in Bedrock API
+    ],
+    isApiErrorMessage: true,
+    apiError,
+    error,
+    errorDetails,
+  })
+}
+
+export function createUserMessage({
+  content,
+  isMeta,
+  isVisibleInTranscriptOnly,
+  isVirtual,
+  isCompactSummary,
+  isCollapseSummary,
+  summarizeMetadata,
+  toolUseResult,
+  isAgentStepLimitToolResult,
+  mcpMeta,
+  uuid,
+  timestamp,
+  imagePasteIds,
+  sourceToolAssistantUUID,
+  permissionMode,
+  origin,
+}: {
+  content: string | ContentBlockParam[]
+  isMeta?: boolean
+  isVisibleInTranscriptOnly?: boolean
+  isVirtual?: boolean
+  isCompactSummary?: boolean
+  isCollapseSummary?: boolean
+  toolUseResult?: unknown // Matches tool's `Output` type
+  isAgentStepLimitToolResult?: boolean
+  /** MCP protocol metadata to pass through to SDK consumers (never sent to model) */
+  mcpMeta?: {
+    _meta?: Record<string, unknown>
+    structuredContent?: Record<string, unknown>
+  }
+  uuid?: UUID | string
+  timestamp?: string
+  imagePasteIds?: number[]
+  // For tool_result messages: the UUID of the assistant message containing the matching tool_use
+  sourceToolAssistantUUID?: UUID
+  // Permission mode when message was sent (for rewind restoration)
+  permissionMode?: PermissionMode
+  summarizeMetadata?: {
+    messagesSummarized: number
+    userContext?: string
+    direction?: PartialCompactDirection
+  }
+  // Provenance of this message. undefined = human (keyboard).
+  origin?: MessageOrigin
+}): UserMessage {
+  const rewindRestorablePermissionMode = isDangerousPermissionMode(
+    permissionMode,
+  )
+    ? undefined
+    : permissionMode
+  const m: UserMessage = {
+    type: 'user',
+    message: {
+      role: 'user',
+      content: content || NO_CONTENT_MESSAGE, // Make sure we don't send empty messages
+    },
+    isMeta,
+    isVisibleInTranscriptOnly,
+    isVirtual,
+    isCompactSummary,
+    isCollapseSummary,
+    summarizeMetadata,
+    uuid: (uuid as UUID | undefined) || randomUUID(),
+    timestamp: timestamp ?? new Date().toISOString(),
+    toolUseResult,
+    isAgentStepLimitToolResult,
+    mcpMeta,
+    imagePasteIds,
+    sourceToolAssistantUUID,
+    permissionMode: rewindRestorablePermissionMode,
+    origin,
+  }
+  return m
+}
+
+export function prepareUserContent({
+  inputString,
+  precedingInputBlocks,
+}: {
+  inputString: string
+  precedingInputBlocks: ContentBlockParam[]
+}): string | ContentBlockParam[] {
+  if (precedingInputBlocks.length === 0) {
+    return inputString
+  }
+
+  return [
+    ...precedingInputBlocks,
+    {
+      text: inputString,
+      type: 'text',
+    },
+  ]
+}
+
+export function createUserInterruptionMessage({
+  toolUse = false,
+}: {
+  toolUse?: boolean
+}): UserMessage {
+  const content = toolUse ? INTERRUPT_MESSAGE_FOR_TOOL_USE : INTERRUPT_MESSAGE
+
+  return createUserMessage({
+    content: [
+      {
+        type: 'text',
+        text: content,
+      },
+    ],
+  })
+}
+
+/**
+ * Creates a new synthetic user caveat message for local commands (eg. bash, slash).
+ * We need to create a new message each time because messages must have unique uuids.
+ */
+export function createSyntheticUserCaveatMessage(): UserMessage {
+  return createUserMessage({
+    content: `<${LOCAL_COMMAND_CAVEAT_TAG}>Caveat: The messages below were generated by the user while running local commands. DO NOT respond to these messages or otherwise consider them in your response unless the user explicitly asks you to.</${LOCAL_COMMAND_CAVEAT_TAG}>`,
+    isMeta: true,
+  })
+}
+
+/**
+ * Formats the command-input breadcrumb the model sees when a slash command runs.
+ */
+export function formatCommandInputTags(
+  commandName: string,
+  args: string,
+): string {
+  return `<${COMMAND_NAME_TAG}>/${commandName}</${COMMAND_NAME_TAG}>
+            <${COMMAND_MESSAGE_TAG}>${commandName}</${COMMAND_MESSAGE_TAG}>
+            <${COMMAND_ARGS_TAG}>${args}</${COMMAND_ARGS_TAG}>`
+}
+
+/**
+ * Builds the breadcrumb trail the SDK set_model control handler injects
+ * so the model can see mid-conversation switches. Same shape the CLI's
+ * /model command produces via processSlashCommand.
+ */
+export function createModelSwitchBreadcrumbs(
+  modelArg: string,
+  resolvedDisplay: string,
+): UserMessage[] {
+  return [
+    createSyntheticUserCaveatMessage(),
+    createUserMessage({ content: formatCommandInputTags('model', modelArg) }),
+    createUserMessage({
+      content: `<${LOCAL_COMMAND_STDOUT_TAG}>Set model to ${resolvedDisplay}</${LOCAL_COMMAND_STDOUT_TAG}>`,
+    }),
+  ]
+}
+
+export function createProgressMessage<P extends Progress>({
+  toolUseID,
+  parentToolUseID,
+  data,
+}: {
+  toolUseID: string
+  parentToolUseID: string
+  data: P
+}): ProgressMessage<P> {
+  return {
+    type: 'progress',
+    data,
+    toolUseID,
+    parentToolUseID,
+    uuid: randomUUID(),
+    timestamp: new Date().toISOString(),
+  }
+}
+
+export function createToolResultStopMessage(
+  toolUseID: string,
+): ToolResultBlockParam {
+  return {
+    type: 'tool_result',
+    content: CANCEL_MESSAGE,
+    is_error: true,
+    tool_use_id: toolUseID,
+  }
+}

--- a/src/utils/messages/factories.ts
+++ b/src/utils/messages/factories.ts
@@ -1,14 +1,32 @@
-import type { BetaUsage as Usage } from "@anthropic-ai/sdk/resources/beta/messages/messages.mjs"
-import type { BetaContentBlock } from "@anthropic-ai/sdk/resources/beta/messages/messages.mjs"
-import type { ContentBlockParam, ToolResultBlockParam } from "@anthropic-ai/sdk/resources/index.mjs"
-import { randomUUID, type UUID } from "crypto"
-import type { Progress } from "../../Tool.js"
-import type { SDKAssistantMessageError } from "../../entrypoints/agentSdkTypes.js"
-import type { Message, AssistantMessage, UserMessage, ProgressMessage, MessageOrigin, PartialCompactDirection } from "../../types/message.js"
-import type { PermissionMode } from "../../types/permissions.js"
-import { NO_CONTENT_MESSAGE } from "../../constants/messages.js"
-import { COMMAND_ARGS_TAG, COMMAND_MESSAGE_TAG, COMMAND_NAME_TAG, LOCAL_COMMAND_CAVEAT_TAG, LOCAL_COMMAND_STDOUT_TAG } from "../../constants/xml.js"
-import { isDangerousPermissionMode } from "../permissions/PermissionMode.js"
+import type {
+  BetaContentBlock,
+  BetaUsage as Usage,
+} from '@anthropic-ai/sdk/resources/beta/messages/messages.mjs'
+import type {
+  ContentBlockParam,
+  ToolResultBlockParam,
+} from '@anthropic-ai/sdk/resources/index.mjs'
+import { randomUUID, type UUID } from 'crypto'
+import type { Progress } from '../../Tool.js'
+import { NO_CONTENT_MESSAGE } from '../../constants/messages.js'
+import {
+  COMMAND_ARGS_TAG,
+  COMMAND_MESSAGE_TAG,
+  COMMAND_NAME_TAG,
+  LOCAL_COMMAND_CAVEAT_TAG,
+  LOCAL_COMMAND_STDOUT_TAG,
+} from '../../constants/xml.js'
+import type { SDKAssistantMessageError } from '../../entrypoints/agentSdkTypes.js'
+import type {
+  AssistantMessage,
+  Message,
+  MessageOrigin,
+  PartialCompactDirection,
+  ProgressMessage,
+  UserMessage,
+} from '../../types/message.js'
+import type { PermissionMode } from '../../types/permissions.js'
+import { isDangerousPermissionMode } from '../permissions/PermissionMode.js'
 
 export const INTERRUPT_MESSAGE = '[Request interrupted by user]'
 export const INTERRUPT_MESSAGE_FOR_TOOL_USE =

--- a/src/utils/messages/factories.ts
+++ b/src/utils/messages/factories.ts
@@ -61,17 +61,10 @@ export function getLastAssistantMessage(
 }
 
 export function hasToolCallsInLastAssistantTurn(messages: Message[]): boolean {
-  for (let i = messages.length - 1; i >= 0; i--) {
-    const message = messages[i]
-    if (message && message.type === 'assistant') {
-      const assistantMessage = message as AssistantMessage
-      const content = assistantMessage.message.content
-      if (Array.isArray(content)) {
-        return content.some(block => block.type === 'tool_use')
-      }
-    }
-  }
-  return false
+  const content = getLastAssistantMessage(messages)?.message.content
+  return (
+    Array.isArray(content) && content.some(block => block.type === 'tool_use')
+  )
 }
 
 function baseCreateAssistantMessage({


### PR DESCRIPTION
## Summary

Part 5 of 8 in the messages.ts de-monolith migration.

This standalone PR extracts basic message factories and adjacent synthetic-message helpers from src/utils/messages.ts into src/utils/messages/factories.ts. The public messages.ts surface continues to re-export the moved APIs so existing imports remain valid while this migration lands one PR at a time.

Associated test coverage included:
- Added src/utils/messages/factories.test.ts for the moved factory helpers.
- Added coverage for the reviewer-raised legacy non-array assistant-content edge case in hasToolCallsInLastAssistantTurn.

## Related active PR impact

No direct active PR overlap found for this factory slice. #1614 still directly touches src/utils/messages.ts, but this PR avoids the normalization/tool-id areas that #1614 edits.

## Validation

- bun install --frozen-lockfile
- bun test src/utils/messages/factories.test.ts
- bun test --feature=UNATTENDED_RETRY --max-concurrency=1 src/services/compact/compact.test.ts src/services/tools/toolExecution.test.ts src/services/tools/StreamingToolExecutor.test.ts src/services/goal/controller.test.ts
- bun test src/utils/messages/factories.test.ts src/services/compact/compact.test.ts src/services/tools/toolExecution.test.ts src/services/tools/StreamingToolExecutor.test.ts src/services/goal/controller.test.ts
- bun test src/query.abortClassification.test.ts src/query/stopHooks.goal.test.ts
- bun test src/services/tools/toolExecution.test.ts
- bun test src/commands/branch/branch.test.ts src/services/awaySummary.test.ts
- bun test src/services/goal/controller.test.ts
- bun run typecheck
- bun run typecheck:type-tests
- bun run security:pr-scan --base upstream/main --head HEAD
- bun run build
- bun run smoke

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added centralized message factories for constructing assistant, user, progress, interruption, tool-result stop, and model-switch breadcrumb messages.
  * Improved command-style formatting, synthetic local-command caveats, and model-switch sequences.
* **Bug Fixes**
  * Standardized handling of empty message content and improved recognition of synthetic/API-error assistant messages.
  * Refined tool-call detection limited to the last assistant turn.
* **Tests**
  * Added Bun tests validating message shapes, normalization, metadata, and breadcrumb/progress behavior for consistent outputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
