### PR TITLE
fix(shim): don't infer Z.AI tool_stream for non-catalog GLM gateways

### DIFF
--- a/src/integrations/runtimeMetadata.test.ts
+++ b/src/integrations/runtimeMetadata.test.ts
@@ -183,6 +183,26 @@ describe('resolveOpenAIShimRuntimeContext - Z.A.I GLM-5.2', () => {
   })
 })
 
+describe('resolveOpenAIShimRuntimeContext - GLM on a non-Z.AI gateway (#1896)', () => {
+  it('infers the GLM reasoning shim but not tool streaming for a third-party gateway', () => {
+    const result = resolveOpenAIShimRuntimeContext({
+      model: 'z-ai/glm-5.2',
+      baseUrl: 'https://integrate.api.nvidia.com/v1',
+      processEnv: {},
+    })
+
+    // No catalog entry for a custom OpenAI-compatible gateway, so the shim is
+    // inferred from the model name.
+    expect(result.catalogEntry).toBeNull()
+    // Reasoning-shaping fields still apply — GLM needs them on any gateway.
+    expect(result.openaiShimConfig.thinkingRequestFormat).toBe('zai-compatible')
+    expect(result.openaiShimConfig.preserveReasoningContent).toBe(true)
+    // tool_stream is Z.AI-proprietary and must NOT be inferred; NVIDIA NIM (and
+    // other third-party gateways) reject it with 400 Unsupported parameter(s).
+    expect(result.openaiShimConfig.enableToolStreaming).not.toBe(true)
+  })
+})
+
 describe('resolveOpenAIShimRuntimeContext - Moonshot and Kimi Code catalog metadata', () => {
   it('uses Moonshot direct catalog order, limits, and reasoning controls', () => {
     expect(

--- a/src/integrations/runtimeMetadata.ts
+++ b/src/integrations/runtimeMetadata.ts
@@ -218,7 +218,15 @@ function inferRemoteModelOpenAIShimConfig(
   const hasGlm = segments.some(s => /^glm-\d/.test(s))
   const isFireworks = segments.some(s => s === 'fireworks')
   if (hasGlm && !isFireworks && !catalogEntry) {
-    return { ...ZAI_GLM_OPENAI_SHIM }
+    // `tool_stream` is a Z.AI-proprietary streaming extension. Only a catalog
+    // entry may opt into it (Z.AI-contract gateways set it via
+    // `transportOverrides.openaiShim`); it must not be inferred from the model
+    // name alone. An arbitrary OpenAI-compatible gateway serving GLM — e.g.
+    // NVIDIA NIM (`integrate.api.nvidia.com`) — rejects the request with
+    // `400 Unsupported parameter(s): tool_stream` (#1896). Keep the
+    // reasoning-shaping fields (which any GLM endpoint benefits from) but drop
+    // tool streaming; without it tool calls simply aren't streamed.
+    return { ...ZAI_GLM_OPENAI_SHIM, enableToolStreaming: false }
   }
 
   return undefined


### PR DESCRIPTION
Closes #1896.

## Problem

Serving a GLM model (`z-ai/glm-5.2`) through a third-party OpenAI-compatible gateway such as NVIDIA NIM (`https://integrate.api.nvidia.com/v1`) fails on the first turn:

```
API Error: 400 Validation: Unsupported parameter(s): `tool_stream`
```

`inferRemoteModelOpenAIShimConfig` (in `runtimeMetadata.ts`) infers the full `ZAI_GLM_OPENAI_SHIM` — including `enableToolStreaming: true` — for any `glm-<n>` model that has no catalog entry. `tool_stream` is a Z.AI-proprietary streaming extension, but the matcher applied it from the model name alone, independent of which gateway is actually serving the model. Any non-Z.AI gateway then rejects the request.

## Fix

Keep inferring the GLM reasoning-shaping fields (preserved/echoed reasoning content, `zai-compatible` thinking format, `max_tokens`, stripping `store`) — those help GLM on any endpoint — but stop inferring `enableToolStreaming`. Only a catalog entry may opt into it: the Z.AI-contract gateways (zai, opencode-go, atlas-cloud, hicap) already set it explicitly via `transportOverrides.openaiShim`, so they are unaffected (their requests still send `tool_stream`).

This is host-agnostic on purpose — it fixes hosted NIM, self-hosted NIM, and any other custom OpenAI-compatible GLM endpoint, matching the report’s "breaks any non-Z.AI-official gateway". `tool_stream` is only a streaming optimization; without it tool calls still work, just not streamed (the shim already has a `delete body.tool_stream` fallback for tool-incompatible retries).

## Test

Added a `resolveOpenAIShimRuntimeContext` case for `z-ai/glm-5.2` on the NIM base URL: asserts no catalog entry (inference path), the reasoning fields still apply, and `enableToolStreaming` is not `true`. Verified fail-on-main (the case fails without the change, `enableToolStreaming === true`). Full `runtimeMetadata` suite (36) and the `openaiShim` `tool_stream` cases (Z.AI path still sends it) pass; `tsc --noEmit` clean for the touched files.

Distinct from #1892 (that covers `chat_template_kwargs` / reasoning on NIM); this is only the `tool_stream` rejection.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility for GLM models when routed through an OpenAI-compatible third-party endpoint.
  * Ensures GLM reasoning-shaping settings are still applied, while tool streaming is explicitly disabled when no matching catalog entry is found.
  * Added automated coverage to prevent regressions for this scenario.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->