### PR TITLE
fix(powershell): make CMDLET_PATH_CONFIG prototype-safe

### DIFF
--- a/src/tools/PowerShellTool/pathValidation.protoName.test.ts
+++ b/src/tools/PowerShellTool/pathValidation.protoName.test.ts
@@ -49,12 +49,14 @@ function parsedCommandNamed(name: string): ParsedPowerShellCommand {
 }
 
 // CMDLET_PATH_CONFIG is keyed by the (lowercased) cmdlet name. A command whose
-// name collides with an Object.prototype member — `constructor`, `__proto__` —
-// must resolve to no config (unknown-cmdlet passthrough), not an inherited
-// prototype value. Before the null-proto fix the lookup returned a truthy
-// inherited member, so `[...config.knownSwitches]` threw (spread of undefined)
-// and crashed path-constraint validation. (`toString`/`valueOf` lowercase to
-// `tostring`/`valueof` and never collide, so only these two are reachable.)
+// name collides with an inherited Object.prototype member must resolve to no
+// config (unknown-cmdlet passthrough), not the inherited prototype value. Before
+// the null-proto fix the lookup returned a truthy inherited member, so
+// `[...config.knownSwitches]` threw (spread of undefined) and crashed
+// path-constraint validation. `constructor` and `__proto__` below are
+// representative all-lowercase collisions reachable through the lowercased key;
+// the null-prototype container neutralizes every inherited-key lookup, not just
+// these two.
 describe('checkPathConstraints with prototype-polluting cmdlet names', () => {
   test.each(['constructor', '__proto__'])(
     'treats %s as an unknown cmdlet instead of crashing',
@@ -80,13 +82,15 @@ describe('checkPathConstraints with prototype-polluting cmdlet names', () => {
     const parsed = parsedCommandNamed('set-content')
     // set-content is a known write cmdlet, so its config is found and the
     // lookup does not fall through to the unknown-cmdlet branch — proves the
-    // null-proto container still holds its own entries.
-    expect(() =>
-      checkPathConstraints(
-        { command: parsed.originalCommand },
-        parsed,
-        defaultContext(),
-      ),
-    ).not.toThrow()
+    // null-proto container still holds and resolves its own entries. Its
+    // parameterized `-Path` cannot be statically validated, so the classified
+    // decision is `ask` rather than the `passthrough` returned for the
+    // prototype-key names above.
+    const result = checkPathConstraints(
+      { command: parsed.originalCommand },
+      parsed,
+      defaultContext(),
+    )
+    expect(result.behavior).toBe('ask')
   })
 })

--- a/src/tools/PowerShellTool/pathValidation.protoName.test.ts
+++ b/src/tools/PowerShellTool/pathValidation.protoName.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, test } from 'bun:test'
+import type { ToolPermissionContext } from '../../types/permissions.js'
+import type { ParsedPowerShellCommand } from '../../utils/powershell/parser.js'
+import { checkPathConstraints } from './pathValidation.js'
+
+function defaultContext(): ToolPermissionContext {
+  return {
+    mode: 'default',
+    additionalWorkingDirectories: new Map(),
+    alwaysAllowRules: {},
+    alwaysDenyRules: {},
+    alwaysAskRules: {},
+    isBypassPermissionsModeAvailable: false,
+  }
+}
+
+// Build a parsed command with a single cmdlet whose name we control. The real
+// PowerShell AST parser requires a pwsh binary, so the parsed structure is
+// constructed directly — the defect under test is in the CMDLET_PATH_CONFIG
+// lookup keyed by the cmdlet name, downstream of parsing. A PowerShell command
+// like `constructor -Path C:\x` parses to a command named `constructor` on a
+// machine with pwsh installed.
+function parsedCommandNamed(name: string): ParsedPowerShellCommand {
+  const command = `${name} -Path C:\\temp\\file.txt`
+  return {
+    valid: true,
+    errors: [],
+    variables: [],
+    hasStopParsing: false,
+    originalCommand: command,
+    statements: [
+      {
+        statementType: 'PipelineAst',
+        text: command,
+        redirections: [],
+        commands: [
+          {
+            name,
+            nameType: 'cmdlet',
+            elementType: 'CommandAst',
+            args: ['-Path', 'C:\\temp\\file.txt'],
+            text: command,
+            elementTypes: ['StringConstantExpressionAst', 'CommandParameterAst'],
+          },
+        ],
+      },
+    ],
+  } as unknown as ParsedPowerShellCommand
+}
+
+// CMDLET_PATH_CONFIG is keyed by the (lowercased) cmdlet name. A command whose
+// name collides with an Object.prototype member — `constructor`, `__proto__` —
+// must resolve to no config (unknown-cmdlet passthrough), not an inherited
+// prototype value. Before the null-proto fix the lookup returned a truthy
+// inherited member, so `[...config.knownSwitches]` threw (spread of undefined)
+// and crashed path-constraint validation. (`toString`/`valueOf` lowercase to
+// `tostring`/`valueof` and never collide, so only these two are reachable.)
+describe('checkPathConstraints with prototype-polluting cmdlet names', () => {
+  test.each(['constructor', '__proto__'])(
+    'treats %s as an unknown cmdlet instead of crashing',
+    (name) => {
+      const parsed = parsedCommandNamed(name)
+      expect(() =>
+        checkPathConstraints(
+          { command: parsed.originalCommand },
+          parsed,
+          defaultContext(),
+        ),
+      ).not.toThrow()
+      const result = checkPathConstraints(
+        { command: parsed.originalCommand },
+        parsed,
+        defaultContext(),
+      )
+      expect(result.behavior).toBe('passthrough')
+    },
+  )
+
+  test('a real path cmdlet is still classified (control)', () => {
+    const parsed = parsedCommandNamed('set-content')
+    // set-content is a known write cmdlet, so its config is found and the
+    // lookup does not fall through to the unknown-cmdlet branch — proves the
+    // null-proto container still holds its own entries.
+    expect(() =>
+      checkPathConstraints(
+        { command: parsed.originalCommand },
+        parsed,
+        defaultContext(),
+      ),
+    ).not.toThrow()
+  })
+})

--- a/src/tools/PowerShellTool/pathValidation.ts
+++ b/src/tools/PowerShellTool/pathValidation.ts
@@ -121,7 +121,16 @@ type CmdletPathConfig = {
   optionalWrite?: boolean
 }
 
-const CMDLET_PATH_CONFIG: Record<string, CmdletPathConfig> = {
+// Uses Object.create(null) to prevent prototype-chain pollution — an
+// attacker-controlled cmdlet name like 'constructor' or '__proto__' must return
+// undefined here (hitting the `if (!config)` unknown-cmdlet passthrough), not an
+// inherited Object.prototype member. Without it, the lookup returns a truthy
+// inherited value and `[...config.knownSwitches]` throws (spread of undefined),
+// crashing path-constraint validation. Same defense as CMDLET_ALLOWLIST
+// (readOnlyValidation.ts) and COMMON_ALIASES (parser.ts).
+const CMDLET_PATH_CONFIG: Record<string, CmdletPathConfig> = Object.assign(
+  Object.create(null) as Record<string, CmdletPathConfig>,
+  {
   // ─── Write/create operations ──────────────────────────────────────────────
   'set-content': {
     operationType: 'write',
@@ -762,7 +771,8 @@ const CMDLET_PATH_CONFIG: Record<string, CmdletPathConfig> = {
     ],
     knownValueParams: ['-name', '-description', '-scope', '-as'],
   },
-}
+  },
+)
 
 /**
  * Checks if a lowercase parameter name (with leading dash) matches any entry


### PR DESCRIPTION
### Problem

`CMDLET_PATH_CONFIG` in `src/tools/PowerShellTool/pathValidation.ts` is a plain object literal keyed by the lowercased cmdlet name. Its sibling lookup maps are deliberately null-proto for exactly this reason:

- `CMDLET_ALLOWLIST` — `Object.create(null)` (`readOnlyValidation.ts`), comment: *"attacker-controlled command names like 'constructor' or '__proto__' must return undefined"*
- `COMMON_ALIASES` — same defense (`parser.ts`)

`extractPathsFromCommand` looks the cmdlet up and guards only on falsiness:

```ts
const config = CMDLET_PATH_CONFIG[resolveToCanonical(cmd.name)]
if (!config) { return { paths: [], operationType: 'read', ... } }   // unknown-cmdlet passthrough
const switchParams = [...config.knownSwitches, ...COMMON_SWITCHES]   // crashes if config is inherited
```

`resolveToCanonical` lowercases the name, so a command named **`constructor`** or **`__proto__`** (both all-lowercase) makes the lookup return an inherited `Object.prototype` member — truthy — so the `!config` guard is bypassed. Execution then hits `[...config.knownSwitches]`, and `config.knownSwitches` is `undefined`, so the spread throws a `TypeError` and **crashes path-constraint validation** instead of treating the name as an unknown non-path cmdlet.

**Consumer:** `extractPathsFromCommand` → `checkPathConstraintsForStatement` → `checkPathConstraints` (`powershellPermissions.ts`), reached per-command for every PowerShell command.

### Fix

Give `CMDLET_PATH_CONFIG` a null prototype via `Object.assign(Object.create(null), { … })`, exactly like its siblings, so inherited-key lookups return `undefined` and hit the existing unknown-cmdlet passthrough.

### Tests

New `pathValidation.protoName.test.ts` builds a parsed command named `constructor` / `__proto__` and asserts `checkPathConstraints` does not throw and returns `passthrough`, plus a `set-content` control proving own entries still resolve. Verified red→green (both proto names throw a `TypeError` before the fix). The parsed structure is constructed directly because the real AST parser needs a `pwsh` binary; the defect is in the name-keyed lookup downstream of parsing.

Same prototype-pollution class as the `detectCodeIndexingFromCommand` (Map) and `FILENAME_LANGS` fixes; completes the null-proto treatment already applied to the two sibling PowerShell maps.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved command path validation to safely handle unusual cmdlet names (including prototype-like strings), preventing crashes and treating them as unknown commands.
  * Ensured known cmdlets continue to be recognized correctly.

* **Tests**
  * Added a Bun test suite covering command-path validation for special-name cases and confirming expected classification for a known cmdlet.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->