### PR TITLE
fix(commands): escape named-argument names before building the regex

### DIFF
--- a/src/utils/argumentSubstitution.test.ts
+++ b/src/utils/argumentSubstitution.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, test } from 'bun:test'
+import { substituteArguments } from './argumentSubstitution.js'
+
+describe('substituteArguments named-argument regex safety', () => {
+  test('substitutes a normal named argument', () => {
+    expect(substituteArguments('hello $name', 'world', false, ['name'])).toBe(
+      'hello world',
+    )
+  })
+
+  // A frontmatter argument name is author-defined and unrestricted beyond
+  // rejecting empty/numeric-only names, so a name with regex metacharacters must
+  // be treated literally rather than compiled into a live pattern.
+  test('does not over-match when the name contains a regex wildcard', () => {
+    // Name `a.` must not let `.` match the `b` in `$ab`.
+    expect(substituteArguments('$ab', 'X', false, ['a.'])).toBe('$ab')
+    // The literal `$a.` placeholder still substitutes.
+    expect(substituteArguments('$a.', 'X', false, ['a.'])).toBe('X')
+  })
+
+  test('does not throw when the name contains unbalanced regex characters', () => {
+    for (const name of ['a)', 'a(', 'a[', 'a+', 'a*', 'a{2']) {
+      expect(() =>
+        substituteArguments('body has no placeholder', 'x', true, [name]),
+      ).not.toThrow()
+    }
+  })
+
+  test('substitutes a literal placeholder whose name has metacharacters', () => {
+    expect(substituteArguments('run $a+b now', 'VAL', false, ['a+b'])).toBe(
+      'run VAL now',
+    )
+  })
+})

--- a/src/utils/argumentSubstitution.ts
+++ b/src/utils/argumentSubstitution.ts
@@ -11,6 +11,7 @@
  */
 
 import { tryParseShellCommand } from './bash/shellQuote.js'
+import { escapeRegExp } from './stringUtils.js'
 
 /**
  * Parse an arguments string into an array of individual arguments.
@@ -113,9 +114,13 @@ export function substituteArguments(
     if (!name) continue
 
     // Match $name but not $name[...] or $nameXxx (word chars)
-    // Also ensure we match word boundaries to avoid partial matches
+    // Also ensure we match word boundaries to avoid partial matches.
+    // escapeRegExp: the name comes from author-defined frontmatter, so a name
+    // containing regex metacharacters would otherwise throw (unbalanced `(`/`[`)
+    // or over-match (`a.` matching `$ab`) — parseArgumentNames does not restrict
+    // the character set beyond rejecting empty/numeric-only names.
     content = content.replace(
-      new RegExp(`\\$${name}(?![\\[\\w])`, 'g'),
+      new RegExp(`\\$${escapeRegExp(name)}(?![\\[\\w])`, 'g'),
       parsedArgs[i] ?? '',
     )
   }


### PR DESCRIPTION
### Problem

`substituteArguments` (`src/utils/argumentSubstitution.ts`) builds a dynamic regex from each frontmatter-defined argument name **without escaping regex metacharacters**:

```ts
content = content.replace(
  new RegExp(`\$${name}(?![\[\w])`, 'g'),
  parsedArgs[i] ?? '',
)
```

`parseArgumentNames` only filters out empty and numeric-only names, so any author-defined argument name that contains a regex special character reaches the `RegExp` constructor. Two failure modes:

1. **Crash** — a skill/command whose `arguments` frontmatter contains an unbalanced `(` / `[` (e.g. `pattern)`) makes `new RegExp('\$pattern)(?![\[\w])')` throw `SyntaxError` on **every** invocation of that skill/command, regardless of whether the name appears in the body, so `substituteArguments` throws uncaught.
2. **Silent wrong substitution** — a name like `a.` over-matches: `.` is a wildcard, so `$ab` gets replaced with the argument value.

**Consumers:** `src/skills/loadSkillsDir.ts` and `src/utils/plugins/loadPluginCommands.ts` both feed `parseArgumentNames(...)` output straight into `substituteArguments`.

### Fix

Escape the name with the existing `escapeRegExp` helper (`src/utils/stringUtils.ts`) before building the pattern, so the name is matched literally.

### Tests

New `argumentSubstitution.test.ts`: a normal name still substitutes; a wildcard name (`a.`) no longer over-matches `$ab` but still fills the literal `$a.` placeholder; unbalanced-metacharacter names (`a)`, `a(`, `a[`, `a+`, `a*`, `a{2`) no longer throw; and a metacharacter name (`a+b`) substitutes its literal placeholder. Verified red→green (3 of 4 fail before the fix).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved named-argument substitution to treat placeholder names with special characters literally, preventing invalid-regex errors and unintended over-matching.
  * Enhanced robustness so substitution handles tricky argument-name inputs safely without throwing.

* **Tests**
  * Added a Bun test suite covering special-character argument names, ensuring correct matching/substitution and error-free behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->