### PR TITLE
fix(editor): guard editor-override lookup against prototype keys

### DIFF
--- a/src/utils/promptEditor.test.ts
+++ b/src/utils/promptEditor.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, test } from 'bun:test'
+import { resolveEditorCommand } from './promptEditor.js'
+
+describe('resolveEditorCommand', () => {
+  test('applies known overrides', () => {
+    expect(resolveEditorCommand('code')).toBe('code -w')
+    expect(resolveEditorCommand('subl')).toBe('subl --wait')
+  })
+
+  test('returns the editor name as-is when there is no override', () => {
+    expect(resolveEditorCommand('vim')).toBe('vim')
+    expect(resolveEditorCommand('nano')).toBe('nano')
+  })
+
+  // $VISUAL / $EDITOR are arbitrary strings. A name that collides with an
+  // Object.prototype member must fall through to the literal name, not resolve
+  // to an inherited member — otherwise the exec command becomes a stringified
+  // function ("function Object() { [native code] }") / "[object Object]".
+  test.each(['constructor', '__proto__', 'hasOwnProperty', 'toString'])(
+    'does not leak a prototype member for editor name %s',
+    (editor) => {
+      const command = resolveEditorCommand(editor)
+      expect(command).toBe(editor)
+      expect(typeof command).toBe('string')
+    },
+  )
+})

--- a/src/utils/promptEditor.ts
+++ b/src/utils/promptEditor.ts
@@ -18,6 +18,22 @@ const EDITOR_OVERRIDES: Record<string, string> = {
   subl: 'subl --wait', // Sublime Text: wait for file to be closed
 }
 
+/**
+ * Resolve the shell command for an editor name, applying any override.
+ *
+ * `editor` comes from $VISUAL / $EDITOR, so it can be an arbitrary string.
+ * Guard the lookup with Object.hasOwn: a bare `EDITOR_OVERRIDES[editor]` would
+ * resolve inherited Object.prototype members for names like `constructor` or
+ * `__proto__` (the Object constructor function / Object.prototype), which are
+ * non-nullish and so defeat the `?? editor` fallback — the command would become
+ * a stringified function instead of the literal editor name.
+ */
+export function resolveEditorCommand(editor: string): string {
+  return Object.hasOwn(EDITOR_OVERRIDES, editor)
+    ? EDITOR_OVERRIDES[editor]!
+    : editor
+}
+
 function isGuiEditor(editor: string): boolean {
   return classifyGuiEditor(editor) !== undefined
 }
@@ -65,7 +81,7 @@ export function editFileInEditor(filePath: string): EditorResult {
 
   try {
     // Use override command if available, otherwise use the editor as-is
-    const editorCommand = EDITOR_OVERRIDES[editor] ?? editor
+    const editorCommand = resolveEditorCommand(editor)
     execSync_DEPRECATED(`${editorCommand} "${filePath}"`, {
       stdio: 'inherit',
     })


### PR DESCRIPTION
### Problem

`editFileInEditor` in `src/utils/promptEditor.ts` resolves the editor command with a bare plain-object lookup:

```ts
const editorCommand = EDITOR_OVERRIDES[editor] ?? editor
execSync_DEPRECATED(`${editorCommand} "${filePath}"`, { stdio: 'inherit' })
```

`editor` comes from `getExternalEditor()`, which is the trimmed value of `$VISUAL` / `$EDITOR` (`src/utils/editor.ts`) — an arbitrary user string. `EDITOR_OVERRIDES` is a plain object literal, so for a name that collides with an `Object.prototype` member — `constructor`, `__proto__`, `hasOwnProperty`, `toString` — the lookup returns the **inherited** member (the `Object` constructor function, `Object.prototype`, etc.). Those are non-nullish, so the `?? editor` fallback that is meant to yield the literal editor name is defeated:

```
EDITOR=constructor  →  editorCommand = function Object() { [native code] }
```

`execSync` then runs that stringified garbage as a shell command instead of the editor the user named (`constructor`).

### Fix

Extract `resolveEditorCommand(editor)` and gate the override lookup on `Object.hasOwn`, so unknown / prototype-colliding names fall through to the literal editor name. Same prototype-pollution class as the earlier `detectCodeIndexingFromCommand` (Map) and `FILENAME_LANGS` fixes.

### Tests

New `promptEditor.test.ts` covers the known overrides (`code` → `code -w`, `subl` → `subl --wait`), a plain name passthrough (`vim`, `nano`), and asserts the four prototype-member names resolve to the literal name rather than a leaked function. Verified red→green (all four proto names return a `Function` before the fix).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved how external editor commands are resolved, so invalid or built-in property names no longer map to unexpected commands.
  * Unknown editor names now consistently stay as entered instead of being resolved through inherited object properties.

* **Tests**
  * Added coverage for editor command resolution, including common aliases and safety cases for reserved property names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->