### PR TITLE
fix(diff): count dropped lines correctly in truncated diff snippet

### DIFF
--- a/src/tools/FileEditTool/utils.test.ts
+++ b/src/tools/FileEditTool/utils.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, test } from 'bun:test'
-import { findWhitespaceAgnosticMatch, adjustNewStringIndentation } from './utils.js'
+import {
+  findWhitespaceAgnosticMatch,
+  adjustNewStringIndentation,
+  getSnippetForTwoFileDiff,
+} from './utils.js'
 
 describe('findWhitespaceAgnosticMatch', () => {
   test('returns exact match for simple string', () => {
@@ -178,5 +182,31 @@ describe('adjustNewStringIndentation', () => {
     // oldIndent "  " maps to "    " for foo(), but maps to "" for bar()
     // It should detect the conflict and return null
     expect(adjustNewStringIndentation(oldString, fileMatch, newString)).toBeNull()
+  })
+})
+
+describe('getSnippetForTwoFileDiff truncation notice', () => {
+  test('reports the exact number of dropped lines when cutting at a line boundary', () => {
+    // A full-replacement diff of an empty file with a large file yields a single
+    // hunk whose line-numbered snippet far exceeds DIFF_SNIPPET_MAX_BYTES (8192),
+    // forcing truncation at a line boundary.
+    const bigFile =
+      Array.from({ length: 800 }, (_, i) => `line ${i + 1} content here`).join(
+        '\n',
+      ) + '\n'
+    const snippet = getSnippetForTwoFileDiff('', bigFile)
+
+    const match = snippet.match(/\.\.\. \[(\d+) lines truncated\] \.\.\./)
+    expect(match).not.toBeNull()
+    const reportedTruncated = Number(match![1])
+
+    // The snippet body before the marker holds the kept lines. Together with the
+    // reported truncated count they must sum to the total lines the untruncated
+    // snippet would have shown — here, the 800 added lines. Before the fix the
+    // boundary newline was double-counted and this reported 801.
+    const keptBody = snippet.slice(0, snippet.indexOf('\n\n... ['))
+    const keptLines = keptBody.split('\n').length
+
+    expect(keptLines + reportedTruncated).toBe(800)
   })
 })

--- a/src/tools/FileEditTool/utils.ts
+++ b/src/tools/FileEditTool/utils.ts
@@ -399,9 +399,22 @@ export function getSnippetForTwoFileDiff(
   // Truncate at the last line boundary that fits within the cap.
   // Marker format matches BashTool/utils.ts.
   const cutoff = full.lastIndexOf('\n', DIFF_SNIPPET_MAX_BYTES)
-  const kept =
-    cutoff > 0 ? full.slice(0, cutoff) : full.slice(0, DIFF_SNIPPET_MAX_BYTES)
-  const remaining = countCharInString(full, '\n', kept.length) + 1
+  let kept: string
+  let remaining: number
+  if (cutoff > 0) {
+    kept = full.slice(0, cutoff)
+    // `full[cutoff]` is the newline that terminates the last kept line, so
+    // counting newlines from `cutoff` onward counts that boundary newline plus
+    // every later one — exactly the number of dropped lines. No `+1`: the
+    // boundary newline is not itself a dropped line, it stands in for the
+    // missing trailing newline of the final dropped line.
+    remaining = countCharInString(full, '\n', cutoff)
+  } else {
+    kept = full.slice(0, DIFF_SNIPPET_MAX_BYTES)
+    // Mid-line cut (no newline within the cap): the partial tail line and every
+    // following line are dropped, so add 1 for that partial line.
+    remaining = countCharInString(full, '\n', kept.length) + 1
+  }
   return `${kept}\n\n... [${remaining} lines truncated] ...`
 }
 


### PR DESCRIPTION
### Problem
`getSnippetForTwoFileDiff` (`src/tools/FileEditTool/utils.ts`) caps the two-file diff snippet at `DIFF_SNIPPET_MAX_BYTES` and appends a `... [N lines truncated] ...` notice. In the normal case the cut snaps back to the last line boundary:

```ts
const cutoff = full.lastIndexOf('\n', DIFF_SNIPPET_MAX_BYTES)
const kept = cutoff > 0 ? full.slice(0, cutoff) : full.slice(0, DIFF_SNIPPET_MAX_BYTES)
const remaining = countCharInString(full, '\n', kept.length) + 1
```

When `cutoff > 0`, `kept` ends right before the boundary newline, so `full[cutoff]` is that `'\n'`. `countCharInString(full, '\n', kept.length)` counts from `cutoff`, which **includes** the boundary newline plus every later one — that count is already exactly the number of dropped lines. The unconditional `+ 1` then double-counts the boundary, so the notice reports **one line too many** (two if the snippet ends in a trailing newline). The `+ 1` is only correct in the mid-line branch, where a partial tail line genuinely needs counting.

The sibling `formatOutput` in `src/tools/BashTool/utils.ts` (which the comment says this "matches") guards this exact case; this function didn't.

### Fix
Split the boundary and mid-line branches — no `+ 1` at a line boundary, `+ 1` only for a mid-line cut.

### Impact
`getSnippetForTwoFileDiff` feeds `src/utils/attachments.ts` whenever an externally-edited text file is re-read into context and its diff snippet exceeds the 8 KB cap — routine for large edits. The model was shown an inflated truncated-line count.

### Test
Adds a regression: a full-replacement diff of an 800-line file truncates at a boundary; asserts `keptLines + reportedTruncated === 800` (reported 801 before the fix).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved how truncated diff snippets count omitted lines, preventing off-by-one errors in large file comparisons.
  * Truncation notices now report the number of dropped lines more accurately, especially at newline boundaries.

* **Tests**
  * Added coverage to verify truncated diff snippets keep the retained and omitted line counts in sync for large inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->