### PR TITLE
fix(diff): number diff-snippet hunks by their new-file position

### DIFF
--- a/src/tools/FileEditTool/utils.test.ts
+++ b/src/tools/FileEditTool/utils.test.ts
@@ -210,3 +210,26 @@ describe('getSnippetForTwoFileDiff truncation notice', () => {
     expect(keptLines + reportedTruncated).toBe(800)
   })
 })
+
+describe('getSnippetForTwoFileDiff line numbering', () => {
+  test('numbers later hunks by their new-file position', () => {
+    const a = Array.from({ length: 60 }, (_, i) => `line ${i + 1}`).join('\n')
+    // First hunk inserts 3 lines near the top; second hunk changes a line near
+    // the bottom, so the second hunk's new-file start is 3 greater than its
+    // old-file start.
+    const bLines = Array.from({ length: 60 }, (_, i) => `line ${i + 1}`)
+    bLines.splice(3, 0, 'INSERTED A', 'INSERTED B', 'INSERTED C')
+    bLines[57] = 'CHANGED near bottom' // original line 55, now at new-file line 58
+    const b = bLines.join('\n')
+
+    const snippet = getSnippetForTwoFileDiff(a, b)
+
+    // The changed line sits at line 58 in the new file. Before the fix it was
+    // labeled 55 (its old-file number), off by the net +3 of the first hunk.
+    const changedLine = snippet
+      .split('\n')
+      .find(l => l.includes('CHANGED near bottom'))
+    expect(changedLine).toBeDefined()
+    expect(changedLine!.trim()).toStartWith('58→')
+  })
+})

--- a/src/tools/FileEditTool/utils.ts
+++ b/src/tools/FileEditTool/utils.ts
@@ -382,7 +382,11 @@ export function getSnippetForTwoFileDiff(
 
   const full = patch.hunks
     .map(_ => ({
-      startLine: _.oldStart,
+      // `content` below keeps the new-file lines (deletions are filtered out),
+      // so number them from the hunk's new-file start. Using `oldStart` mislabels
+      // every hunk after one that changed the line count, by the net line delta
+      // of the earlier hunks.
+      startLine: _.newStart,
       content: _.lines
         // Filter out deleted lines AND diff metadata lines
         .filter(_ => !_.startsWith('-') && !_.startsWith('\\'))


### PR DESCRIPTION
### Problem
`getSnippetForTwoFileDiff` (`src/tools/FileEditTool/utils.ts`) builds each hunk's snippet from the **new-file** lines (deletions are filtered out) but seeds `addLineNumbers` with the hunk's `oldStart`:

```ts
const full = patch.hunks
  .map(_ => ({
    startLine: _.oldStart,          // <- old-file number on new-file content
    content: _.lines.filter(l => !l.startsWith('-') && !l.startsWith('\\')).map(l => l.slice(1)).join('\n'),
  }))
  .map(addLineNumbers)
  .join('\n...\n')
```

For the first hunk `oldStart === newStart`, so labels are correct. But any hunk that follows one which inserted or removed lines is mislabeled by the **net line delta** of the earlier hunks — the displayed numbers no longer match the file the model is looking at.

### Fix
Seed `addLineNumbers` from `newStart`, since the numbered content is new-file content.

### Impact
Same `attachments.ts` path — any multi-hunk external edit where an earlier hunk changed the line count produced wrong line numbers on every later hunk.

### Test
Adds a regression: a two-hunk diff whose first hunk inserts 3 lines; asserts the changed line near the bottom is labeled `58→` (its new-file position), not `55→` (its old-file position).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected snippet line-numbering to reflect the new-file positions for changed lines.
  * Resolved mislabeling when multiple edits occur within the same file, preventing numbering/off-by-one display errors.
* **Tests**
  * Added a new test to verify changed-line labels use the correct line numbers across multiple hunks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->