### PR TITLE
fix(memdir): enforce entrypoint cap in bytes, not UTF-16 char length

### DIFF
--- a/src/memdir/memdir.entrypointBytes.test.ts
+++ b/src/memdir/memdir.entrypointBytes.test.ts
@@ -34,4 +34,19 @@ describe('truncateEntrypointContent byte cap', () => {
     expect(result.content).toBe(raw)
     expect(result.byteCount).toBe(Buffer.byteLength(raw))
   })
+
+  test('hard byte cut does not split a multibyte character or exceed the cap', () => {
+    // A single 30KB line of CJK with no newline before the cap forces the hard
+    // byte-cut fallback. Cutting at byte 25000 lands mid-`一` (3 bytes each);
+    // decoding a split character yields U+FFFD and pushes the body back over
+    // the cap. The body before the warning must stay within the cap and hold no
+    // replacement chars.
+    const raw = '一'.repeat(10000) // 30,000 bytes, no newline
+    const result = truncateEntrypointContent(raw)
+
+    expect(result.wasByteTruncated).toBe(true)
+    const body = result.content.split('\n\n> WARNING:')[0]!
+    expect(Buffer.byteLength(body)).toBeLessThanOrEqual(MAX_ENTRYPOINT_BYTES)
+    expect(body).not.toContain('�')
+  })
 })

--- a/src/memdir/memdir.entrypointBytes.test.ts
+++ b/src/memdir/memdir.entrypointBytes.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, test } from 'bun:test'
+import { MAX_ENTRYPOINT_BYTES, truncateEntrypointContent } from './memdir.js'
+
+describe('truncateEntrypointContent byte cap', () => {
+  test('enforces the byte cap on multibyte content that is under the char cap', () => {
+    // 50 short lines of CJK text: well under MAX_ENTRYPOINT_LINES (200) and
+    // under MAX_ENTRYPOINT_BYTES *characters*, but ~3x over it in real bytes
+    // (each `一` is 3 UTF-8 bytes).
+    const line = '一'.repeat(498) // 498 chars, 1494 bytes
+    const raw = Array.from({ length: 50 }, () => line).join('\n')
+
+    expect(raw.length).toBeLessThanOrEqual(MAX_ENTRYPOINT_BYTES)
+    expect(Buffer.byteLength(raw)).toBeGreaterThan(MAX_ENTRYPOINT_BYTES)
+
+    const result = truncateEntrypointContent(raw)
+
+    // The byte cap must fire, byteCount must report real bytes, and the emitted
+    // content must actually be bounded by the cap (plus the appended warning).
+    // Before the fix `.length` undercounted, so wasByteTruncated was false and
+    // the full ~75KB passed through uncapped.
+    expect(result.wasByteTruncated).toBe(true)
+    expect(result.byteCount).toBe(Buffer.byteLength(raw))
+    const warningBytes = 400
+    expect(Buffer.byteLength(result.content)).toBeLessThanOrEqual(
+      MAX_ENTRYPOINT_BYTES + warningBytes,
+    )
+  })
+
+  test('leaves small multibyte content untouched', () => {
+    const raw = '# 見出し\n\n- 項目一つ\n- 項目二つ'
+    const result = truncateEntrypointContent(raw)
+    expect(result.wasByteTruncated).toBe(false)
+    expect(result.wasLineTruncated).toBe(false)
+    expect(result.content).toBe(raw)
+    expect(result.byteCount).toBe(Buffer.byteLength(raw))
+  })
+})

--- a/src/memdir/memdir.entrypointBytes.test.ts
+++ b/src/memdir/memdir.entrypointBytes.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, test } from 'bun:test'
-import { MAX_ENTRYPOINT_BYTES, truncateEntrypointContent } from './memdir.js'
+import {
+  MAX_ENTRYPOINT_BYTES,
+  MAX_ENTRYPOINT_LINES,
+  truncateEntrypointContent,
+} from './memdir.js'
 
 describe('truncateEntrypointContent byte cap', () => {
   test('enforces the byte cap on multibyte content that is under the char cap', () => {
@@ -33,6 +37,30 @@ describe('truncateEntrypointContent byte cap', () => {
     expect(result.wasLineTruncated).toBe(false)
     expect(result.content).toBe(raw)
     expect(result.byteCount).toBe(Buffer.byteLength(raw))
+  })
+
+  test('applies line truncation then byte truncation when content exceeds both caps', () => {
+    // 250 lines (over MAX_ENTRYPOINT_LINES) where even the first 200 lines are
+    // well over MAX_ENTRYPOINT_BYTES: each line is 100 CJK chars = 300 bytes, so
+    // 200 lines ≈ 60KB. Line truncation fires first, then the byte cut runs on
+    // the already line-clipped result — exercising the combined path.
+    const line = '一'.repeat(100) // 300 bytes
+    const raw = Array.from({ length: 250 }, () => line).join('\n')
+
+    expect(raw.split('\n').length).toBeGreaterThan(MAX_ENTRYPOINT_LINES)
+    expect(Buffer.byteLength(raw)).toBeGreaterThan(MAX_ENTRYPOINT_BYTES)
+
+    const result = truncateEntrypointContent(raw)
+
+    expect(result.wasLineTruncated).toBe(true)
+    expect(result.wasByteTruncated).toBe(true)
+    // Combined reason string names both caps.
+    expect(result.content).toContain('lines and')
+    // The body (before the warning) stays within the byte cap and holds no
+    // split-character replacement chars.
+    const body = result.content.split('\n\n> WARNING:')[0]!
+    expect(Buffer.byteLength(body)).toBeLessThanOrEqual(MAX_ENTRYPOINT_BYTES)
+    expect(body).not.toContain('�')
   })
 
   test('hard byte cut does not split a multibyte character or exceed the cap', () => {

--- a/src/memdir/memdir.ts
+++ b/src/memdir/memdir.ts
@@ -59,7 +59,10 @@ export function truncateEntrypointContent(raw: string): EntrypointTruncation {
   const trimmed = raw.trim()
   const contentLines = trimmed.split('\n')
   const lineCount = contentLines.length
-  const byteCount = trimmed.length
+  // Actual UTF-8 byte size — `.length` counts UTF-16 code units, which
+  // undercounts multibyte content (CJK/emoji are 3-4 bytes each) by up to ~4x
+  // and would let a large multibyte file slip past this byte budget entirely.
+  const byteCount = Buffer.byteLength(trimmed)
 
   const wasLineTruncated = lineCount > MAX_ENTRYPOINT_LINES
   // Check original byte count — long lines are the failure mode the byte cap
@@ -80,9 +83,13 @@ export function truncateEntrypointContent(raw: string): EntrypointTruncation {
     ? contentLines.slice(0, MAX_ENTRYPOINT_LINES).join('\n')
     : trimmed
 
-  if (truncated.length > MAX_ENTRYPOINT_BYTES) {
-    const cutAt = truncated.lastIndexOf('\n', MAX_ENTRYPOINT_BYTES)
-    truncated = truncated.slice(0, cutAt > 0 ? cutAt : MAX_ENTRYPOINT_BYTES)
+  if (Buffer.byteLength(truncated) > MAX_ENTRYPOINT_BYTES) {
+    // Cut in byte space so the cap actually bounds bytes. Snap back to the last
+    // newline before the cap to avoid slicing mid-line (and mid-multibyte-char).
+    const buf = Buffer.from(truncated, 'utf8')
+    const newlineByte = buf.lastIndexOf(0x0a, MAX_ENTRYPOINT_BYTES)
+    const cutAt = newlineByte > 0 ? newlineByte : MAX_ENTRYPOINT_BYTES
+    truncated = buf.subarray(0, cutAt).toString('utf8')
   }
 
   const reason =

--- a/src/memdir/memdir.ts
+++ b/src/memdir/memdir.ts
@@ -84,11 +84,19 @@ export function truncateEntrypointContent(raw: string): EntrypointTruncation {
     : trimmed
 
   if (Buffer.byteLength(truncated) > MAX_ENTRYPOINT_BYTES) {
-    // Cut in byte space so the cap actually bounds bytes. Snap back to the last
-    // newline before the cap to avoid slicing mid-line (and mid-multibyte-char).
+    // Cut in byte space so the cap actually bounds bytes. Prefer the last
+    // newline before the cap to avoid slicing mid-line; otherwise hard-cut at
+    // the cap.
     const buf = Buffer.from(truncated, 'utf8')
     const newlineByte = buf.lastIndexOf(0x0a, MAX_ENTRYPOINT_BYTES)
-    const cutAt = newlineByte > 0 ? newlineByte : MAX_ENTRYPOINT_BYTES
+    let cutAt = newlineByte > 0 ? newlineByte : MAX_ENTRYPOINT_BYTES
+    // Never slice through a multibyte UTF-8 character. If the hard-cut lands on
+    // a continuation byte (0b10xxxxxx), back up to the character's first byte so
+    // the decoded body stays within the cap instead of decoding to a U+FFFD
+    // replacement char (which would push the output back over the byte limit).
+    while (cutAt > 0 && (buf[cutAt]! & 0xc0) === 0x80) {
+      cutAt--
+    }
     truncated = buf.subarray(0, cutAt).toString('utf8')
   }
 
@@ -238,7 +246,7 @@ export function buildMemoryLines(
         '',
         `**Step 2** — add a pointer to that file in \`${ENTRYPOINT_NAME}\`. \`${ENTRYPOINT_NAME}\` is an index, not a memory — each entry should be one line, under ~150 characters: \`- [Title](file.md) — one-line hook\`. It has no frontmatter. Never write memory content directly into \`${ENTRYPOINT_NAME}\`.`,
         '',
-        `- \`${ENTRYPOINT_NAME}\` is always loaded into your conversation context — lines after ${MAX_ENTRYPOINT_LINES} will be truncated, so keep the index concise`,
+        `- \`${ENTRYPOINT_NAME}\` is always loaded into your conversation context — it is truncated after ${MAX_ENTRYPOINT_LINES} lines or ${formatFileSize(MAX_ENTRYPOINT_BYTES)}, whichever comes first, so keep the index concise (one short line per entry; long or many entries lose the tail)`,
         '- Keep the name, description, and type fields in memory files up-to-date with the content',
         '- Organize memory semantically by topic, not chronologically',
         '- Update or remove memories that turn out to be wrong or outdated',

--- a/src/memdir/teamMemPrompts.ts
+++ b/src/memdir/teamMemPrompts.ts
@@ -2,8 +2,10 @@ import {
   buildSearchingPastContextSection,
   DIRS_EXIST_GUIDANCE,
   ENTRYPOINT_NAME,
+  MAX_ENTRYPOINT_BYTES,
   MAX_ENTRYPOINT_LINES,
 } from './memdir.js'
+import { formatFileSize } from '../utils/format.js'
 import {
   MEMORY_DRIFT_CAVEAT,
   MEMORY_FRONTMATTER_EXAMPLE,
@@ -55,7 +57,7 @@ export function buildCombinedMemoryPrompt(
         '',
         `**Step 2** — add a pointer to that file in the same directory's \`${ENTRYPOINT_NAME}\`. Each directory (private and team) has its own \`${ENTRYPOINT_NAME}\` index — each entry should be one line, under ~150 characters: \`- [Title](file.md) — one-line hook\`. They have no frontmatter. Never write memory content directly into a \`${ENTRYPOINT_NAME}\`.`,
         '',
-        `- Both \`${ENTRYPOINT_NAME}\` indexes are loaded into your conversation context — lines after ${MAX_ENTRYPOINT_LINES} will be truncated, so keep them concise`,
+        `- Both \`${ENTRYPOINT_NAME}\` indexes are loaded into your conversation context — each is truncated after ${MAX_ENTRYPOINT_LINES} lines or ${formatFileSize(MAX_ENTRYPOINT_BYTES)}, whichever comes first, so keep them concise (one short line per entry; long or many entries lose the tail)`,
         '- Keep the name, description, and type fields in memory files up-to-date with the content',
         '- Organize memory semantically by topic, not chronologically',
         '- Update or remove memories that turn out to be wrong or outdated',

--- a/src/services/extractMemories/prompts.ts
+++ b/src/services/extractMemories/prompts.ts
@@ -11,11 +11,17 @@
 
 import { feature } from 'bun:bundle'
 import {
+  ENTRYPOINT_NAME,
+  MAX_ENTRYPOINT_BYTES,
+  MAX_ENTRYPOINT_LINES,
+} from '../../memdir/memdir.js'
+import {
   MEMORY_FRONTMATTER_EXAMPLE,
   TYPES_SECTION_COMBINED,
   TYPES_SECTION_INDIVIDUAL,
   WHAT_NOT_TO_SAVE_SECTION,
 } from '../../memdir/memoryTypes.js'
+import { formatFileSize } from '../../utils/format.js'
 import { BASH_TOOL_NAME } from '../../tools/BashTool/toolName.js'
 import { FILE_EDIT_TOOL_NAME } from '../../tools/FileEditTool/constants.js'
 import { FILE_READ_TOOL_NAME } from '../../tools/FileReadTool/prompt.js'
@@ -75,7 +81,7 @@ export function buildExtractAutoOnlyPrompt(
         '',
         '**Step 2** — add a pointer to that file in `MEMORY.md`. `MEMORY.md` is an index, not a memory — each entry should be one line, under ~150 characters: `- [Title](file.md) — one-line hook`. It has no frontmatter. Never write memory content directly into `MEMORY.md`.',
         '',
-        '- `MEMORY.md` is always loaded into your system prompt — lines after 200 will be truncated, so keep the index concise',
+        `- \`${ENTRYPOINT_NAME}\` is always loaded into your system prompt — it is truncated after ${MAX_ENTRYPOINT_LINES} lines or ${formatFileSize(MAX_ENTRYPOINT_BYTES)}, whichever comes first, so keep the index concise (one short line per entry)`,
         '- Organize memory semantically by topic, not chronologically',
         '- Update or remove memories that turn out to be wrong or outdated',
         '- Do not write duplicate memories. First check if there is an existing memory you can update before writing a new one.',
@@ -134,7 +140,7 @@ export function buildExtractCombinedPrompt(
         '',
         "**Step 2** — add a pointer to that file in the same directory's `MEMORY.md`. Each directory (private and team) has its own `MEMORY.md` index — each entry should be one line, under ~150 characters: `- [Title](file.md) — one-line hook`. They have no frontmatter. Never write memory content directly into a `MEMORY.md`.",
         '',
-        '- Both `MEMORY.md` indexes are loaded into your system prompt — lines after 200 will be truncated, so keep them concise',
+        `- Both \`${ENTRYPOINT_NAME}\` indexes are loaded into your system prompt — each is truncated after ${MAX_ENTRYPOINT_LINES} lines or ${formatFileSize(MAX_ENTRYPOINT_BYTES)}, whichever comes first, so keep them concise`,
         '- Organize memory semantically by topic, not chronologically',
         '- Update or remove memories that turn out to be wrong or outdated',
         '- Do not write duplicate memories. First check if there is an existing memory you can update before writing a new one.',


### PR DESCRIPTION
### Problem
`truncateEntrypointContent` (`src/memdir/memdir.ts`) caps `MEMORY.md`/`CLAUDE.md` entrypoint content with `MAX_ENTRYPOINT_BYTES = 25_000`. Everything about it is byte-oriented — the field is `byteCount`, the flag is `wasByteTruncated`, and the warning renders the size with `formatFileSize(byteCount)` — but it measures and cuts with `String.length`:

```ts
const byteCount = trimmed.length                       // UTF-16 code units, not bytes
const wasByteTruncated = byteCount > MAX_ENTRYPOINT_BYTES
...
if (truncated.length > MAX_ENTRYPOINT_BYTES) {         // same char/byte confusion
  const cutAt = truncated.lastIndexOf('\n', MAX_ENTRYPOINT_BYTES)
  truncated = truncated.slice(0, cutAt > 0 ? cutAt : MAX_ENTRYPOINT_BYTES)
}
```

`.length` counts UTF-16 code units, so multibyte content (CJK/emoji are 3-4 UTF-8 bytes each) is undercounted by up to ~4x. A `MEMORY.md` that is, say, ~75 KB of real bytes but under 25,000 characters is **not** flagged, `byteCount` is reported as a fraction of the true size, and the full content is passed through **uncapped** — defeating the byte budget whose whole purpose is to bound context bloat from long-line indexes.

### Reachability
`src/utils/claudemd.ts` runs `truncateEntrypointContent(strippedContent)` on entrypoint content when memory files are built for the prompt, and `src/memdir/memdir.ts` uses it in `buildMemoryPrompt`. Any user whose `MEMORY.md`/`CLAUDE.md` is mostly non-ASCII hits this every session.

### Fix
Measure with `Buffer.byteLength` and perform the newline-boundary cut in byte space (`Buffer.lastIndexOf(0x0a, cap)` + `subarray`), so the cap actually bounds bytes and `byteCount` reports real bytes. Mirrors how the codebase already does byte-truncation elsewhere.

### Test
Adds regressions: a 50-line CJK file that is under the char cap but ~3x over the byte cap must now fire `wasByteTruncated`, report `byteCount === Buffer.byteLength(raw)`, and emit content bounded by the cap; and small multibyte content is left untouched with an accurate `byteCount`. Both fail before the fix (`wasByteTruncated` false; `byteCount` 20 vs 42).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enforced entrypoint size limits using true UTF-8 byte counts so multibyte/CJK content can’t bypass the byte cap.
  * Improved truncation to keep output UTF-8 safe (no mid-character cuts) and applied byte truncation consistently when line and byte limits are both exceeded.
* **Tests**
  * Added Bun tests for UTF-8 byte truncation, correct byte counting, newline-aware slicing, and the “hard byte cut” path.
* **Documentation**
  * Updated MEMORY.md and memory prompt guidance to state truncation happens by max lines **or** max bytes (whichever comes first).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->