### PR TITLE
fix(effort): keep effort indicator visible in prompt footer

### DIFF
--- a/src/components/IdeStatusIndicator.tsx
+++ b/src/components/IdeStatusIndicator.tsx
@@ -9,6 +9,11 @@ type IdeStatusIndicatorProps = {
   ideSelection: IDESelection | undefined;
   mcpClients?: MCPServerConnection[];
 };
+
+export function hasIdeSelection(ideSelection: IDESelection | undefined): boolean {
+  return Boolean(ideSelection?.filePath || (ideSelection?.text && ideSelection.lineCount > 0));
+}
+
 export function IdeStatusIndicator(t0) {
   const $ = _c(7);
   const {
@@ -18,7 +23,7 @@ export function IdeStatusIndicator(t0) {
   const {
     status: ideStatus
   } = useIdeConnectionStatus(mcpClients);
-  const shouldShowIdeSelection = ideStatus === "connected" && (ideSelection?.filePath || ideSelection?.text && ideSelection.lineCount > 0);
+  const shouldShowIdeSelection = ideStatus === "connected" && hasIdeSelection(ideSelection);
   if (ideStatus === null || !shouldShowIdeSelection || !ideSelection) {
     return null;
   }

--- a/src/components/PromptInput/Notifications.effort.test.tsx
+++ b/src/components/PromptInput/Notifications.effort.test.tsx
@@ -158,8 +158,7 @@ async function renderNotifications({
 test('renders effort as the stable footer fallback when no notification is active', async () => {
   const output = await renderNotifications({ effortValue: 'medium' })
 
-  expect(output).toContain('medium')
-  expect(output).toContain('/effort')
+  expect(output).toContain('medium · /effort')
 })
 
 test('updates the mounted effort footer when app state changes', async () => {
@@ -247,6 +246,19 @@ test('ignores empty text notifications when rendering the effort footer fallback
     currentNotification: {
       key: 'empty',
       text: '',
+      priority: 'low',
+    },
+  })
+
+  expect(output).toContain('medium · /effort')
+})
+
+test('ignores empty JSX notifications when rendering the effort footer fallback', async () => {
+  const output = await renderNotifications({
+    effortValue: 'medium',
+    currentNotification: {
+      key: 'empty-jsx',
+      jsx: null,
       priority: 'low',
     },
   })

--- a/src/components/PromptInput/Notifications.effort.test.tsx
+++ b/src/components/PromptInput/Notifications.effort.test.tsx
@@ -13,11 +13,18 @@ import type { Message } from '../../types/message.js'
 import type { EffortValue } from '../../utils/effort.js'
 import { renderToString } from '../../utils/staticRender.js'
 
+const actualAutoUpdaterWrapper = await import(
+  `../AutoUpdaterWrapper.js?actual=${Date.now()}-${Math.random()}`
+)
+const EFFORT_ENV_KEY = 'CLAUDE_CODE_EFFORT_LEVEL'
+let savedEffortEnv: string | undefined
+
 beforeEach(async () => {
   await acquireSharedMutationLock(
     'components/PromptInput/Notifications.effort.test.tsx',
   )
-  mock.restore()
+  savedEffortEnv = process.env[EFFORT_ENV_KEY]
+  delete process.env[EFFORT_ENV_KEY]
   mock.module('../AutoUpdaterWrapper.js', () => ({
     AutoUpdaterWrapper: () => null,
   }))
@@ -25,7 +32,12 @@ beforeEach(async () => {
 
 afterEach(() => {
   try {
-    mock.restore()
+    if (savedEffortEnv === undefined) {
+      delete process.env[EFFORT_ENV_KEY]
+    } else {
+      process.env[EFFORT_ENV_KEY] = savedEffortEnv
+    }
+    mock.module('../AutoUpdaterWrapper.js', () => actualAutoUpdaterWrapper)
   } finally {
     releaseSharedMutationLock()
   }

--- a/src/components/PromptInput/Notifications.effort.test.tsx
+++ b/src/components/PromptInput/Notifications.effort.test.tsx
@@ -1,0 +1,101 @@
+import { afterEach, beforeEach, expect, mock, test } from 'bun:test'
+import React from 'react'
+
+import type { Notification } from '../../context/notifications.js'
+import { AppStateProvider, getDefaultAppState } from '../../state/AppState.js'
+import {
+  acquireSharedMutationLock,
+  releaseSharedMutationLock,
+} from '../../test/sharedMutationLock.js'
+import type { Message } from '../../types/message.js'
+import type { EffortValue } from '../../utils/effort.js'
+import { renderToString } from '../../utils/staticRender.js'
+
+beforeEach(async () => {
+  await acquireSharedMutationLock(
+    'components/PromptInput/Notifications.effort.test.tsx',
+  )
+  mock.restore()
+  mock.module('../AutoUpdaterWrapper.js', () => ({
+    AutoUpdaterWrapper: () => null,
+  }))
+})
+
+afterEach(() => {
+  try {
+    mock.restore()
+  } finally {
+    releaseSharedMutationLock()
+  }
+})
+
+async function renderNotifications({
+  effortValue,
+  currentNotification = null,
+}: {
+  effortValue: EffortValue | undefined
+  currentNotification?: Notification | null
+}): Promise<string> {
+  const { Notifications } = await import(
+    `./Notifications.js?ts=${Date.now()}-${Math.random()}`
+  )
+
+  return renderToString(
+    <AppStateProvider
+      initialState={{
+        ...getDefaultAppState(),
+        mainLoopModelForSession: 'claude-opus-4-8',
+        effortValue,
+        notifications: {
+          current: currentNotification,
+          queue: [],
+        },
+      }}
+    >
+      <Notifications
+        apiKeyStatus="valid"
+        autoUpdaterResult={{ version: null, status: 'success' }}
+        debug={false}
+        isAutoUpdating={false}
+        verbose={false}
+        messages={[] as Message[]}
+        onAutoUpdaterResult={() => {}}
+        onChangeIsUpdating={() => {}}
+        ideSelection={undefined}
+      />
+    </AppStateProvider>,
+    120,
+  )
+}
+
+test('renders effort as the stable footer fallback when no notification is active', async () => {
+  const output = await renderNotifications({ effortValue: 'medium' })
+
+  expect(output).toContain('medium')
+  expect(output).toContain('/effort')
+})
+
+test('uses current app state when rendering the effort footer fallback', async () => {
+  const highOutput = await renderNotifications({ effortValue: 'high' })
+  const lowOutput = await renderNotifications({ effortValue: 'low' })
+
+  expect(highOutput).toContain('high')
+  expect(highOutput).toContain('/effort')
+  expect(lowOutput).toContain('low')
+  expect(lowOutput).toContain('/effort')
+  expect(lowOutput).not.toContain('high · /effort')
+})
+
+test('lets transient notifications temporarily occupy the footer slot', async () => {
+  const output = await renderNotifications({
+    effortValue: 'medium',
+    currentNotification: {
+      key: 'other',
+      text: 'Other notice',
+      priority: 'high',
+    },
+  })
+
+  expect(output).toContain('Other notice')
+  expect(output).not.toContain('medium · /effort')
+})

--- a/src/components/PromptInput/Notifications.effort.test.tsx
+++ b/src/components/PromptInput/Notifications.effort.test.tsx
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, expect, mock, test } from 'bun:test'
+import { feature } from 'bun:bundle'
 import React from 'react'
 
 import type { Notification } from '../../context/notifications.js'
@@ -17,6 +18,7 @@ const actualAutoUpdaterWrapper = await import(
   `../AutoUpdaterWrapper.js?actual=${Date.now()}-${Math.random()}`
 )
 const EFFORT_ENV_KEY = 'CLAUDE_CODE_EFFORT_LEVEL'
+const briefFeatureTest = feature('KAIROS') || feature('KAIROS_BRIEF') ? test : test.skip
 let savedEffortEnv: string | undefined
 
 beforeEach(async () => {
@@ -48,11 +50,15 @@ async function renderNotifications({
   currentNotification = null,
   ideSelection = undefined,
   mcpClients = undefined,
+  isBriefOnly = false,
+  viewingAgentTaskId = undefined,
 }: {
   effortValue: EffortValue | undefined
   currentNotification?: Notification | null
   ideSelection?: IDESelection
   mcpClients?: MCPServerConnection[]
+  isBriefOnly?: boolean
+  viewingAgentTaskId?: string
 }): Promise<string> {
   const { Notifications } = await import(
     `./Notifications.js?ts=${Date.now()}-${Math.random()}`
@@ -64,6 +70,8 @@ async function renderNotifications({
         ...getDefaultAppState(),
         mainLoopModelForSession: 'claude-opus-4-8',
         effortValue,
+        isBriefOnly,
+        viewingAgentTaskId,
         notifications: {
           current: currentNotification,
           queue: [],
@@ -144,5 +152,14 @@ test('preserves IDE selection status before the effort fallback', async () => {
   })
 
   expect(output).toContain('In example.ts')
+  expect(output).not.toContain('medium · /effort')
+})
+
+briefFeatureTest('suppresses effort when brief owns the footer gap', async () => {
+  const output = await renderNotifications({
+    effortValue: 'medium',
+    isBriefOnly: true,
+  })
+
   expect(output).not.toContain('medium · /effort')
 })

--- a/src/components/PromptInput/Notifications.effort.test.tsx
+++ b/src/components/PromptInput/Notifications.effort.test.tsx
@@ -127,6 +127,19 @@ test('lets transient notifications temporarily occupy the footer slot', async ()
   expect(output).not.toContain('medium · /effort')
 })
 
+test('ignores empty text notifications when rendering the effort footer fallback', async () => {
+  const output = await renderNotifications({
+    effortValue: 'medium',
+    currentNotification: {
+      key: 'empty',
+      text: '',
+      priority: 'low',
+    },
+  })
+
+  expect(output).toContain('medium · /effort')
+})
+
 test('preserves IDE selection status before the effort fallback', async () => {
   const output = await renderNotifications({
     effortValue: 'medium',

--- a/src/components/PromptInput/Notifications.effort.test.tsx
+++ b/src/components/PromptInput/Notifications.effort.test.tsx
@@ -2,6 +2,8 @@ import { afterEach, beforeEach, expect, mock, test } from 'bun:test'
 import React from 'react'
 
 import type { Notification } from '../../context/notifications.js'
+import type { IDESelection } from '../../hooks/useIdeSelection.js'
+import type { MCPServerConnection } from '../../services/mcp/types.js'
 import { AppStateProvider, getDefaultAppState } from '../../state/AppState.js'
 import {
   acquireSharedMutationLock,
@@ -32,9 +34,13 @@ afterEach(() => {
 async function renderNotifications({
   effortValue,
   currentNotification = null,
+  ideSelection = undefined,
+  mcpClients = undefined,
 }: {
   effortValue: EffortValue | undefined
   currentNotification?: Notification | null
+  ideSelection?: IDESelection
+  mcpClients?: MCPServerConnection[]
 }): Promise<string> {
   const { Notifications } = await import(
     `./Notifications.js?ts=${Date.now()}-${Math.random()}`
@@ -61,7 +67,8 @@ async function renderNotifications({
         messages={[] as Message[]}
         onAutoUpdaterResult={() => {}}
         onChangeIsUpdating={() => {}}
-        ideSelection={undefined}
+        ideSelection={ideSelection}
+        mcpClients={mcpClients}
       />
     </AppStateProvider>,
     120,
@@ -97,5 +104,33 @@ test('lets transient notifications temporarily occupy the footer slot', async ()
   })
 
   expect(output).toContain('Other notice')
+  expect(output).not.toContain('medium · /effort')
+})
+
+test('preserves IDE selection status before the effort fallback', async () => {
+  const output = await renderNotifications({
+    effortValue: 'medium',
+    ideSelection: {
+      lineCount: 0,
+      filePath: '/tmp/example.ts',
+    },
+    mcpClients: [
+      {
+        name: 'ide',
+        type: 'connected',
+        capabilities: {},
+        config: {
+          type: 'sse-ide',
+          url: 'http://localhost:1234',
+          ideName: 'VS Code',
+          scope: 'local',
+        },
+        client: {},
+        cleanup: async () => {},
+      } as unknown as MCPServerConnection,
+    ],
+  })
+
+  expect(output).toContain('In example.ts')
   expect(output).not.toContain('medium · /effort')
 })

--- a/src/components/PromptInput/Notifications.effort.test.tsx
+++ b/src/components/PromptInput/Notifications.effort.test.tsx
@@ -1,11 +1,19 @@
+import { PassThrough } from 'node:stream'
+
 import { afterEach, beforeEach, expect, mock, test } from 'bun:test'
 import { feature } from 'bun:bundle'
-import React from 'react'
+import React, { useEffect } from 'react'
+import { stripVTControlCharacters as stripAnsi } from 'node:util'
 
 import type { Notification } from '../../context/notifications.js'
 import type { IDESelection } from '../../hooks/useIdeSelection.js'
+import { createRoot } from '../../ink.js'
 import type { MCPServerConnection } from '../../services/mcp/types.js'
-import { AppStateProvider, getDefaultAppState } from '../../state/AppState.js'
+import {
+  AppStateProvider,
+  getDefaultAppState,
+  useSetAppState,
+} from '../../state/AppState.js'
 import {
   acquireSharedMutationLock,
   releaseSharedMutationLock,
@@ -18,8 +26,60 @@ const actualAutoUpdaterWrapper = await import(
   `../AutoUpdaterWrapper.js?actual=${Date.now()}-${Math.random()}`
 )
 const EFFORT_ENV_KEY = 'CLAUDE_CODE_EFFORT_LEVEL'
-const briefFeatureTest = feature('KAIROS') || feature('KAIROS_BRIEF') ? test : test.skip
 let savedEffortEnv: string | undefined
+
+const SYNC_START = '\x1B[?2026h'
+const SYNC_END = '\x1B[?2026l'
+
+function extractLastFrame(output: string): string {
+  let lastFrame: string | null = null
+  let cursor = 0
+  while (cursor < output.length) {
+    const start = output.indexOf(SYNC_START, cursor)
+    if (start === -1) break
+    const contentStart = start + SYNC_START.length
+    const end = output.indexOf(SYNC_END, contentStart)
+    if (end === -1) break
+    const frame = output.slice(contentStart, end)
+    if (frame.trim().length > 0) lastFrame = frame
+    cursor = end + SYNC_END.length
+  }
+  return lastFrame ?? output
+}
+
+function createTestStreams() {
+  let output = ''
+  const stdout = new PassThrough()
+  const stdin = new PassThrough() as PassThrough & {
+    isTTY: boolean
+    setRawMode: () => void
+    ref: () => void
+    unref: () => void
+  }
+  stdin.isTTY = true
+  stdin.setRawMode = () => {}
+  stdin.ref = () => {}
+  stdin.unref = () => {}
+  ;(stdout as unknown as { columns: number }).columns = 120
+  stdout.on('data', chunk => {
+    output += chunk.toString()
+  })
+  return { stdout, stdin, getOutput: () => output }
+}
+
+async function waitForFrame(
+  getOutput: () => string,
+  predicate: (frame: string) => boolean,
+  timeoutMs = 3000,
+): Promise<string> {
+  const startedAt = Date.now()
+  while (Date.now() - startedAt < timeoutMs) {
+    const frame = stripAnsi(extractLastFrame(getOutput()))
+    if (predicate(frame)) return frame
+    await Bun.sleep(10)
+  }
+  throw new Error('Timed out waiting for rendered frame')
+}
 
 beforeEach(async () => {
   await acquireSharedMutationLock(
@@ -102,15 +162,69 @@ test('renders effort as the stable footer fallback when no notification is activ
   expect(output).toContain('/effort')
 })
 
-test('uses current app state when rendering the effort footer fallback', async () => {
-  const highOutput = await renderNotifications({ effortValue: 'high' })
-  const lowOutput = await renderNotifications({ effortValue: 'low' })
+test('updates the mounted effort footer when app state changes', async () => {
+  const { Notifications } = await import(
+    `./Notifications.js?mounted=${Date.now()}-${Math.random()}`
+  )
+  const { stdout, stdin, getOutput } = createTestStreams()
+  const root = await createRoot({
+    stdout: stdout as unknown as NodeJS.WriteStream,
+    stdin: stdin as unknown as NodeJS.ReadStream,
+    patchConsole: false,
+  })
+  let setAppState: ReturnType<typeof useSetAppState> | undefined
 
-  expect(highOutput).toContain('high')
-  expect(highOutput).toContain('/effort')
-  expect(lowOutput).toContain('low')
-  expect(lowOutput).toContain('/effort')
-  expect(lowOutput).not.toContain('high · /effort')
+  function AppStateController() {
+    const setState = useSetAppState()
+    useEffect(() => {
+      setAppState = setState
+    }, [setState])
+    return null
+  }
+
+  root.render(
+    <AppStateProvider
+      initialState={{
+        ...getDefaultAppState(),
+        mainLoopModelForSession: 'claude-opus-4-8',
+        effortValue: 'high',
+      }}
+    >
+      <Notifications
+        apiKeyStatus="valid"
+        autoUpdaterResult={{ version: null, status: 'success' }}
+        debug={false}
+        isAutoUpdating={false}
+        verbose={false}
+        messages={[] as Message[]}
+        onAutoUpdaterResult={() => {}}
+        onChangeIsUpdating={() => {}}
+        ideSelection={undefined}
+        mcpClients={undefined}
+      />
+      <AppStateController />
+    </AppStateProvider>,
+  )
+
+  try {
+    const initialFrame = await waitForFrame(getOutput, frame =>
+      frame.includes('high · /effort'),
+    )
+    expect(initialFrame).toContain('high · /effort')
+
+    setAppState!(state => ({ ...state, effortValue: 'low' }))
+
+    const updatedFrame = await waitForFrame(getOutput, frame =>
+      frame.includes('low · /effort'),
+    )
+    expect(updatedFrame).toContain('low · /effort')
+    expect(updatedFrame).not.toContain('high · /effort')
+  } finally {
+    root.unmount()
+    stdin.end()
+    stdout.end()
+    await Bun.sleep(0)
+  }
 })
 
 test('lets transient notifications temporarily occupy the footer slot', async () => {
@@ -168,11 +282,19 @@ test('preserves IDE selection status before the effort fallback', async () => {
   expect(output).not.toContain('medium · /effort')
 })
 
-briefFeatureTest('suppresses effort when brief owns the footer gap', async () => {
-  const output = await renderNotifications({
-    effortValue: 'medium',
-    isBriefOnly: true,
-  })
+if (feature('KAIROS') || feature('KAIROS_BRIEF')) {
+  test('respects brief footer ownership and teammate view', async () => {
+    const briefOutput = await renderNotifications({
+      effortValue: 'medium',
+      isBriefOnly: true,
+    })
+    const teammateOutput = await renderNotifications({
+      effortValue: 'medium',
+      isBriefOnly: true,
+      viewingAgentTaskId: 'task-123',
+    })
 
-  expect(output).not.toContain('medium · /effort')
-})
+    expect(briefOutput).not.toContain('medium · /effort')
+    expect(teammateOutput).toContain('medium · /effort')
+  })
+}

--- a/src/components/PromptInput/Notifications.tsx
+++ b/src/components/PromptInput/Notifications.tsx
@@ -39,9 +39,11 @@ const VoiceIndicator: typeof import('./VoiceIndicator.js').VoiceIndicator = feat
 /* eslint-enable @typescript-eslint/no-require-imports */
 
 export const FOOTER_TEMPORARY_STATUS_TIMEOUT = 5000;
+
 function hasIdeSelection(ideSelection: IDESelection | undefined): boolean {
-  return Boolean(ideSelection?.filePath || ideSelection?.text && ideSelection.lineCount > 0);
+  return Boolean(ideSelection?.filePath || (ideSelection?.text && ideSelection.lineCount > 0));
 }
+
 type Props = {
   apiKeyStatus: VerificationStatus;
   autoUpdaterResult: AutoUpdaterResult | null;
@@ -57,7 +59,7 @@ type Props = {
   isNarrow?: boolean;
 };
 export function Notifications(t0) {
-  const $ = _c(34);
+  const $ = _c(35);
   const {
     apiKeyStatus,
     autoUpdaterResult,
@@ -179,8 +181,8 @@ export function Notifications(t0) {
   const t11 = isNarrow ? "flex-start" : "flex-end";
   const t12 = isInOverageMode ?? false;
   let t13;
-  if ($[15] !== apiKeyStatus || $[16] !== autoUpdaterResult || $[17] !== debug || $[18] !== ideSelection || $[19] !== isAutoUpdating || $[20] !== isShowingCompactMessage || $[21] !== mainLoopModel || $[22] !== mcpClients || $[23] !== notifications || $[24] !== onAutoUpdaterResult || $[25] !== onChangeIsUpdating || $[26] !== shouldShowAutoUpdater || $[27] !== t12 || $[28] !== tokenUsage || $[29] !== verbose) {
-    t13 = <NotificationContent ideSelection={ideSelection} mcpClients={mcpClients} notifications={notifications} isInOverageMode={t12} isTeamOrEnterprise={isTeamOrEnterprise} apiKeyStatus={apiKeyStatus} debug={debug} verbose={verbose} tokenUsage={tokenUsage} mainLoopModel={mainLoopModel} shouldShowAutoUpdater={shouldShowAutoUpdater} autoUpdaterResult={autoUpdaterResult} isAutoUpdating={isAutoUpdating} isShowingCompactMessage={isShowingCompactMessage} onAutoUpdaterResult={onAutoUpdaterResult} onChangeIsUpdating={onChangeIsUpdating} />;
+  if ($[15] !== apiKeyStatus || $[16] !== autoUpdaterResult || $[17] !== debug || $[18] !== ideSelection || $[19] !== isAutoUpdating || $[20] !== isShowingCompactMessage || $[21] !== mainLoopModel || $[22] !== mcpClients || $[23] !== notifications || $[24] !== onAutoUpdaterResult || $[25] !== onChangeIsUpdating || $[26] !== shouldShowAutoUpdater || $[27] !== t12 || $[28] !== tokenUsage || $[29] !== shouldShowIdeSelection || $[30] !== verbose) {
+    t13 = <NotificationContent ideSelection={ideSelection} mcpClients={mcpClients} notifications={notifications} isInOverageMode={t12} isTeamOrEnterprise={isTeamOrEnterprise} apiKeyStatus={apiKeyStatus} debug={debug} verbose={verbose} tokenUsage={tokenUsage} mainLoopModel={mainLoopModel} shouldShowAutoUpdater={shouldShowAutoUpdater} shouldShowIdeSelection={shouldShowIdeSelection} autoUpdaterResult={autoUpdaterResult} isAutoUpdating={isAutoUpdating} isShowingCompactMessage={isShowingCompactMessage} onAutoUpdaterResult={onAutoUpdaterResult} onChangeIsUpdating={onChangeIsUpdating} />;
     $[15] = apiKeyStatus;
     $[16] = autoUpdaterResult;
     $[17] = debug;
@@ -195,19 +197,20 @@ export function Notifications(t0) {
     $[26] = shouldShowAutoUpdater;
     $[27] = t12;
     $[28] = tokenUsage;
-    $[29] = verbose;
-    $[30] = t13;
+    $[29] = shouldShowIdeSelection;
+    $[30] = verbose;
+    $[31] = t13;
   } else {
-    t13 = $[30];
+    t13 = $[31];
   }
   let t14;
-  if ($[31] !== t11 || $[32] !== t13) {
+  if ($[32] !== t11 || $[33] !== t13) {
     t14 = <SentryErrorBoundary><Box flexDirection="column" alignItems={t11} flexShrink={0} overflowX="hidden">{t13}</Box></SentryErrorBoundary>;
-    $[31] = t11;
-    $[32] = t13;
-    $[33] = t14;
+    $[32] = t11;
+    $[33] = t13;
+    $[34] = t14;
   } else {
-    t14 = $[33];
+    t14 = $[34];
   }
   return t14;
 }
@@ -229,6 +232,7 @@ function NotificationContent({
   tokenUsage,
   mainLoopModel,
   shouldShowAutoUpdater,
+  shouldShowIdeSelection,
   autoUpdaterResult,
   isAutoUpdating,
   isShowingCompactMessage,
@@ -249,6 +253,7 @@ function NotificationContent({
   tokenUsage: number;
   mainLoopModel: string;
   shouldShowAutoUpdater: boolean;
+  shouldShowIdeSelection: boolean;
   autoUpdaterResult: AutoUpdaterResult | null;
   isAutoUpdating: boolean;
   isShowingCompactMessage: boolean;
@@ -285,10 +290,6 @@ function NotificationContent({
   // biome-ignore lint/correctness/useHookAtTopLevel: feature() is a compile-time constant
   useAppState(s_2 => s_2.viewingAgentTaskId) : undefined;
   const briefOwnsGap = isBriefOnly && !viewingAgentTaskId;
-  const {
-    status: ideStatus
-  } = useIdeConnectionStatus(mcpClients);
-  const shouldShowIdeSelection = ideStatus === "connected" && hasIdeSelection(ideSelection);
   const shouldShowEffortFallback = !briefOwnsGap && !shouldShowIdeSelection;
   const effortValue = useAppState(s => s.effortValue);
   const effortNotificationText = shouldShowEffortFallback ? getEffortNotificationText(effortValue, mainLoopModel) : undefined;
@@ -300,7 +301,7 @@ function NotificationContent({
         {notifications.current.text}
       </Text>;
   }
-  const effortFallbackNode = effortNotificationText ? <Text dimColor wrap="truncate">
+  const effortFallbackNode = effortNotificationText ? <Text dimColor wrap="truncate" key="effort-fallback">
         {effortNotificationText}
       </Text> : null;
 

--- a/src/components/PromptInput/Notifications.tsx
+++ b/src/components/PromptInput/Notifications.tsx
@@ -39,6 +39,9 @@ const VoiceIndicator: typeof import('./VoiceIndicator.js').VoiceIndicator = feat
 /* eslint-enable @typescript-eslint/no-require-imports */
 
 export const FOOTER_TEMPORARY_STATUS_TIMEOUT = 5000;
+function hasIdeSelection(ideSelection: IDESelection | undefined): boolean {
+  return Boolean(ideSelection?.filePath || ideSelection?.text && ideSelection.lineCount > 0);
+}
 type Props = {
   apiKeyStatus: VerificationStatus;
   autoUpdaterResult: AutoUpdaterResult | null;
@@ -125,7 +128,7 @@ export function Notifications(t0) {
     t6 = $[7];
   }
   useEffect(t5, t6);
-  const shouldShowIdeSelection = ideStatus === "connected" && (ideSelection?.filePath || ideSelection?.text && ideSelection.lineCount > 0);
+  const shouldShowIdeSelection = ideStatus === "connected" && hasIdeSelection(ideSelection);
   const shouldShowAutoUpdater = !shouldShowIdeSelection || isAutoUpdating || autoUpdaterResult?.status !== "success";
   const isInOverageMode = claudeAiLimits.isUsingOverage;
   let t7;
@@ -281,15 +284,14 @@ function NotificationContent({
   const viewingAgentTaskId = feature('KAIROS') || feature('KAIROS_BRIEF') ?
   // biome-ignore lint/correctness/useHookAtTopLevel: feature() is a compile-time constant
   useAppState(s_2 => s_2.viewingAgentTaskId) : undefined;
-  const showExtras = !isBriefOnly;
   const briefOwnsGap = isBriefOnly && !viewingAgentTaskId;
   const {
     status: ideStatus
   } = useIdeConnectionStatus(mcpClients);
-  const shouldShowIdeSelection = ideStatus === "connected" && Boolean(ideSelection?.filePath || ideSelection?.text && ideSelection.lineCount > 0);
+  const shouldShowIdeSelection = ideStatus === "connected" && hasIdeSelection(ideSelection);
   const shouldShowEffortFallback = !briefOwnsGap && !shouldShowIdeSelection;
-  const effortValue = useAppState(s => shouldShowEffortFallback ? s.effortValue : null);
-  const effortNotificationText = shouldShowEffortFallback ? getEffortNotificationText(effortValue ?? undefined, mainLoopModel) : undefined;
+  const effortValue = useAppState(s => s.effortValue);
+  const effortNotificationText = shouldShowEffortFallback ? getEffortNotificationText(effortValue, mainLoopModel) : undefined;
   let notificationNode: ReactNode = null;
   if (notifications.current) {
     notificationNode = 'jsx' in notifications.current ? <Text wrap="truncate" key={notifications.current.key}>
@@ -338,7 +340,7 @@ function NotificationContent({
             {tokenUsage} tokens
           </Text>
         </Box>}
-      {showExtras && <TokenWarning tokenUsage={tokenUsage} model={mainLoopModel} />}
+      {!isBriefOnly && <TokenWarning tokenUsage={tokenUsage} model={mainLoopModel} />}
       {shouldShowAutoUpdater && <AutoUpdaterWrapper verbose={verbose} onAutoUpdaterResult={onAutoUpdaterResult} autoUpdaterResult={autoUpdaterResult} isUpdating={isAutoUpdating} onChangeIsUpdating={onChangeIsUpdating} showSuccessMessage={!isShowingCompactMessage} />}
       {feature('VOICE_MODE') ? voiceEnabled && voiceError && <Box>
               <Text color="error" wrap="truncate">

--- a/src/components/PromptInput/Notifications.tsx
+++ b/src/components/PromptInput/Notifications.tsx
@@ -31,6 +31,7 @@ import { IdeStatusIndicator } from '../IdeStatusIndicator.js';
 import { MemoryUsageIndicator } from '../MemoryUsageIndicator.js';
 import { SentryErrorBoundary } from '../SentryErrorBoundary.js';
 import { TokenWarning } from '../TokenWarning.js';
+import { getEffortNotificationText } from '../EffortIndicator.js';
 import { SandboxPromptFooterHint } from './SandboxPromptFooterHint.js';
 
 /* eslint-disable @typescript-eslint/no-require-imports */
@@ -277,6 +278,8 @@ function NotificationContent({
   const isBriefOnly = feature('KAIROS') || feature('KAIROS_BRIEF') ?
   // biome-ignore lint/correctness/useHookAtTopLevel: feature() is a compile-time constant
   useAppState(s_1 => s_1.isBriefOnly) : false;
+  const effortValue = useAppState(s => s.effortValue);
+  const effortNotificationText = isBriefOnly ? undefined : getEffortNotificationText(effortValue, mainLoopModel);
 
   // When voice is actively recording or processing, replace all
   // notifications with just the voice indicator.
@@ -285,11 +288,13 @@ function NotificationContent({
   }
   return <>
       <IdeStatusIndicator ideSelection={ideSelection} mcpClients={mcpClients} />
-      {notifications.current && ('jsx' in notifications.current ? <Text wrap="truncate" key={notifications.current.key}>
+      {notifications.current ? ('jsx' in notifications.current ? <Text wrap="truncate" key={notifications.current.key}>
             {notifications.current.jsx}
           </Text> : <Text color={notifications.current.color} dimColor={!notifications.current.color} wrap="truncate">
             {notifications.current.text}
-          </Text>)}
+          </Text>) : effortNotificationText ? <Text dimColor wrap="truncate">
+            {effortNotificationText}
+          </Text> : null}
       {isInOverageMode && !isTeamOrEnterprise && <Box>
           <Text dimColor wrap="truncate">
             Now using extra usage

--- a/src/components/PromptInput/Notifications.tsx
+++ b/src/components/PromptInput/Notifications.tsx
@@ -27,11 +27,11 @@ import { getMessagesAfterCompactBoundary } from '../../utils/messages.js';
 import { tokenCountFromLastAPIResponse } from '../../utils/tokens.js';
 import { AutoUpdaterWrapper } from '../AutoUpdaterWrapper.js';
 import { ConfigurableShortcutHint } from '../ConfigurableShortcutHint.js';
+import { getEffortNotificationText } from '../EffortIndicator.js';
 import { hasIdeSelection, IdeStatusIndicator } from '../IdeStatusIndicator.js';
 import { MemoryUsageIndicator } from '../MemoryUsageIndicator.js';
 import { SentryErrorBoundary } from '../SentryErrorBoundary.js';
 import { TokenWarning } from '../TokenWarning.js';
-import { getEffortNotificationText } from '../EffortIndicator.js';
 import { SandboxPromptFooterHint } from './SandboxPromptFooterHint.js';
 
 /* eslint-disable @typescript-eslint/no-require-imports */
@@ -286,15 +286,19 @@ function NotificationContent({
   useAppState(s_2 => s_2.viewingAgentTaskId) : undefined;
   const briefOwnsGap = isBriefOnly && !viewingAgentTaskId;
   const shouldShowEffortFallback = !briefOwnsGap && !shouldShowIdeSelection;
-  const effortValue = useAppState(s => s.effortValue);
+  const effortValue = useAppState(s_3 => s_3.effortValue);
   const effortNotificationText = shouldShowEffortFallback ? getEffortNotificationText(effortValue, mainLoopModel) : undefined;
   let notificationNode: ReactNode = null;
   if (notifications.current) {
-    notificationNode = 'jsx' in notifications.current ? <Text wrap="truncate" key={notifications.current.key}>
+    if ('jsx' in notifications.current) {
+      notificationNode = <Text wrap="truncate" key={notifications.current.key}>
         {notifications.current.jsx}
-      </Text> : <Text color={notifications.current.color} dimColor={!notifications.current.color} wrap="truncate">
+      </Text>;
+    } else if (notifications.current.text) {
+      notificationNode = <Text color={notifications.current.color} dimColor={!notifications.current.color} wrap="truncate">
         {notifications.current.text}
       </Text>;
+    }
   }
   const effortFallbackNode = effortNotificationText ? <Text dimColor wrap="truncate" key="effort-fallback">
         {effortNotificationText}

--- a/src/components/PromptInput/Notifications.tsx
+++ b/src/components/PromptInput/Notifications.tsx
@@ -291,9 +291,12 @@ function NotificationContent({
   let notificationNode: ReactNode = null;
   if (notifications.current) {
     if ('jsx' in notifications.current) {
-      notificationNode = <Text wrap="truncate" key={notifications.current.key}>
-        {notifications.current.jsx}
-      </Text>;
+      const notificationJsx = notifications.current.jsx;
+      if (notificationJsx !== null && notificationJsx !== undefined && notificationJsx !== '' && typeof notificationJsx !== 'boolean') {
+        notificationNode = <Text wrap="truncate" key={notifications.current.key}>
+          {notificationJsx}
+        </Text>;
+      }
     } else if (notifications.current.text) {
       notificationNode = <Text color={notifications.current.color} dimColor={!notifications.current.color} wrap="truncate">
         {notifications.current.text}

--- a/src/components/PromptInput/Notifications.tsx
+++ b/src/components/PromptInput/Notifications.tsx
@@ -278,8 +278,29 @@ function NotificationContent({
   const isBriefOnly = feature('KAIROS') || feature('KAIROS_BRIEF') ?
   // biome-ignore lint/correctness/useHookAtTopLevel: feature() is a compile-time constant
   useAppState(s_1 => s_1.isBriefOnly) : false;
-  const effortValue = useAppState(s => s.effortValue);
-  const effortNotificationText = isBriefOnly ? undefined : getEffortNotificationText(effortValue, mainLoopModel);
+  const viewingAgentTaskId = feature('KAIROS') || feature('KAIROS_BRIEF') ?
+  // biome-ignore lint/correctness/useHookAtTopLevel: feature() is a compile-time constant
+  useAppState(s_2 => s_2.viewingAgentTaskId) : undefined;
+  const showExtras = !isBriefOnly;
+  const briefOwnsGap = isBriefOnly && !viewingAgentTaskId;
+  const {
+    status: ideStatus
+  } = useIdeConnectionStatus(mcpClients);
+  const shouldShowIdeSelection = ideStatus === "connected" && Boolean(ideSelection?.filePath || ideSelection?.text && ideSelection.lineCount > 0);
+  const shouldShowEffortFallback = !briefOwnsGap && !shouldShowIdeSelection;
+  const effortValue = useAppState(s => shouldShowEffortFallback ? s.effortValue : null);
+  const effortNotificationText = shouldShowEffortFallback ? getEffortNotificationText(effortValue ?? undefined, mainLoopModel) : undefined;
+  let notificationNode: ReactNode = null;
+  if (notifications.current) {
+    notificationNode = 'jsx' in notifications.current ? <Text wrap="truncate" key={notifications.current.key}>
+        {notifications.current.jsx}
+      </Text> : <Text color={notifications.current.color} dimColor={!notifications.current.color} wrap="truncate">
+        {notifications.current.text}
+      </Text>;
+  }
+  const effortFallbackNode = effortNotificationText ? <Text dimColor wrap="truncate">
+        {effortNotificationText}
+      </Text> : null;
 
   // When voice is actively recording or processing, replace all
   // notifications with just the voice indicator.
@@ -288,13 +309,7 @@ function NotificationContent({
   }
   return <>
       <IdeStatusIndicator ideSelection={ideSelection} mcpClients={mcpClients} />
-      {notifications.current ? ('jsx' in notifications.current ? <Text wrap="truncate" key={notifications.current.key}>
-            {notifications.current.jsx}
-          </Text> : <Text color={notifications.current.color} dimColor={!notifications.current.color} wrap="truncate">
-            {notifications.current.text}
-          </Text>) : effortNotificationText ? <Text dimColor wrap="truncate">
-            {effortNotificationText}
-          </Text> : null}
+      {notificationNode ?? effortFallbackNode}
       {isInOverageMode && !isTeamOrEnterprise && <Box>
           <Text dimColor wrap="truncate">
             Now using extra usage
@@ -323,7 +338,7 @@ function NotificationContent({
             {tokenUsage} tokens
           </Text>
         </Box>}
-      {!isBriefOnly && <TokenWarning tokenUsage={tokenUsage} model={mainLoopModel} />}
+      {showExtras && <TokenWarning tokenUsage={tokenUsage} model={mainLoopModel} />}
       {shouldShowAutoUpdater && <AutoUpdaterWrapper verbose={verbose} onAutoUpdaterResult={onAutoUpdaterResult} autoUpdaterResult={autoUpdaterResult} isUpdating={isAutoUpdating} onChangeIsUpdating={onChangeIsUpdating} showSuccessMessage={!isShowingCompactMessage} />}
       {feature('VOICE_MODE') ? voiceEnabled && voiceError && <Box>
               <Text color="error" wrap="truncate">

--- a/src/components/PromptInput/Notifications.tsx
+++ b/src/components/PromptInput/Notifications.tsx
@@ -27,7 +27,7 @@ import { getMessagesAfterCompactBoundary } from '../../utils/messages.js';
 import { tokenCountFromLastAPIResponse } from '../../utils/tokens.js';
 import { AutoUpdaterWrapper } from '../AutoUpdaterWrapper.js';
 import { ConfigurableShortcutHint } from '../ConfigurableShortcutHint.js';
-import { IdeStatusIndicator } from '../IdeStatusIndicator.js';
+import { hasIdeSelection, IdeStatusIndicator } from '../IdeStatusIndicator.js';
 import { MemoryUsageIndicator } from '../MemoryUsageIndicator.js';
 import { SentryErrorBoundary } from '../SentryErrorBoundary.js';
 import { TokenWarning } from '../TokenWarning.js';
@@ -39,11 +39,6 @@ const VoiceIndicator: typeof import('./VoiceIndicator.js').VoiceIndicator = feat
 /* eslint-enable @typescript-eslint/no-require-imports */
 
 export const FOOTER_TEMPORARY_STATUS_TIMEOUT = 5000;
-
-function hasIdeSelection(ideSelection: IDESelection | undefined): boolean {
-  return Boolean(ideSelection?.filePath || (ideSelection?.text && ideSelection.lineCount > 0));
-}
-
 type Props = {
   apiKeyStatus: VerificationStatus;
   autoUpdaterResult: AutoUpdaterResult | null;

--- a/src/components/PromptInput/PromptInput.tsx
+++ b/src/components/PromptInput/PromptInput.tsx
@@ -99,7 +99,6 @@ import { AutoModeOptInDialog } from '../AutoModeOptInDialog.js';
 import { BridgeDialog } from '../BridgeDialog.js';
 import { ConfigurableShortcutHint } from '../ConfigurableShortcutHint.js';
 import { getVisibleAgentTasks, useCoordinatorTaskCount } from '../CoordinatorAgentStatus.js';
-import { getEffortNotificationText } from '../EffortIndicator.js';
 import { getFastIconString } from '../FastIcon.js';
 import { GlobalSearchDialog } from '../GlobalSearchDialog.js';
 import { HistorySearchDialog } from '../HistorySearchDialog.js';
@@ -336,7 +335,6 @@ function PromptInput({
   const mainLoopModelForSession = useAppState(s => s.mainLoopModelForSession);
   const thinkingEnabled = useAppState(s => s.thinkingEnabled);
   const isFastMode = useAppState(s => isFastModeEnabled() ? s.fastMode : false);
-  const effortValue = useAppState(s => s.effortValue);
   const viewedTeammate = getViewedTeammateTask(store.getState());
   const viewingAgentName = viewedTeammate?.identity.agentName;
   // identity.color is typed as `string | undefined` (not AgentColorName) because
@@ -2013,22 +2011,6 @@ function PromptInput({
   const showFastIcon = isFastModeEnabled() ? isFastMode && (isFastModeAvailable() || fastModeCooldown) : false;
   const showFastIconHint = useShowFastIconHint(showFastIcon ?? false);
 
-  // Show effort notification on startup and when effort changes.
-  // Suppressed in brief/assistant mode — the value reflects the local
-  // client's effort, not the connected agent's.
-  const effortNotificationText = briefOwnsGap ? undefined : getEffortNotificationText(effortValue, mainLoopModel);
-  useEffect(() => {
-    if (!effortNotificationText) {
-      removeNotification('effort-level');
-      return;
-    }
-    addNotification({
-      key: 'effort-level',
-      text: effortNotificationText,
-      priority: 'high',
-      timeoutMs: 12_000
-    });
-  }, [effortNotificationText, addNotification, removeNotification]);
   useBuddyNotification();
   const companionSpeaking = isBuddyEnabled() ?
   useAppState(s => s.companionReaction !== undefined) : false;


### PR DESCRIPTION
## Summary

- move the effort indicator out of the transient notification queue and render it as a stable prompt-footer fallback
- keep transient notifications and active IDE selections ahead of the effort fallback
- preserve brief-mode footer ownership and add focused coverage for effort fallback, IDE selection precedence, empty notifications, and brief suppression

Fixes #1831

## Impact

- user-facing impact: changing effort via the TUI picker now leaves the active effort visible in the footer instead of disappearing after the old notification timeout
- developer/maintainer impact: removes the PromptInput effort notification effect, shares the IDE selection predicate, and pins the footer behavior with static-render tests

## Testing

- [x] `bun run build` via `bun run check` / `bun run smoke`
- [x] `bun run smoke` via `bun run check`
- [x] `bun run check` (exits 1 locally; compared with `origin/main`, both have the same 75 unique failing tests and no branch-only failures)
- [x] focused tests:
  - `bun test src/components/PromptInput/Notifications.effort.test.tsx`
  - `bun test --feature=KAIROS_BRIEF src/components/PromptInput/Notifications.effort.test.tsx`
  - `CLAUDE_CODE_EFFORT_LEVEL=high bun test --feature=KAIROS_BRIEF src/components/PromptInput/Notifications.effort.test.tsx`

## Notes

- provider/model path tested: N/A; this is prompt footer UI behavior only
- screenshots attached (if UI changed): not attached; this is a one-line terminal footer state covered by static-render tests for the rendered output
- follow-up work or known limitations: local `bun run check` currently has existing failures on `origin/main`; this branch does not add any new failing test cases

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Footer messaging now cleanly switches between IDE selection details and effort fallback, preventing both from appearing together.
  * Transient/current notifications with empty content no longer displace the effort footer.
  * Brief-mode now shows effort fallback only for the appropriate view based on the active task context.
  * Effort notifications are no longer auto-injected on startup or when effort changes.

* **Refactor**
  * Streamlined notification rendering conditions to make footer selection more reliable.

* **Tests**
  * Added test coverage for effort/footer fallback and IDE selection behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->