### PR TITLE
docs: clarify pre-PR contributor checklist

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,6 +56,7 @@ Before opening a PR:
 
 Every PR needs a reason. Your PR description must include:
 
+- confirmation that you reviewed both this `CONTRIBUTING.md` file and [`AGENTS.md`](AGENTS.md)
 - what changed and why
 - the user or developer impact
 - the exact checks you ran

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,6 +46,14 @@ This step prevents wasted effort on PRs that might otherwise be closed without r
 
 ## Pull Requests
 
+Before opening a PR:
+
+- Read this `CONTRIBUTING.md` file.
+- Read [`AGENTS.md`](AGENTS.md) for repo-specific coding-agent conventions, validation commands, provider guidance, and architecture rules.
+- Re-check open and recently closed PRs for duplicates.
+- Keep the branch focused on one issue or one clearly scoped improvement.
+- Run the narrowest meaningful validation command for the touched area.
+
 Every PR needs a reason. Your PR description must include:
 
 - what changed and why


### PR DESCRIPTION
## Summary
- Add an explicit pre-PR checklist to `CONTRIBUTING.md`
- Require PR descriptions to confirm the contributor reviewed both `CONTRIBUTING.md` and `AGENTS.md`
- Reinforce duplicate checks, focused scope, and validation expectations

Closes #1716

## Checks
- `git diff --check`