### PR TITLE
fix(clipboard): fall back to image retrieval after Windows probe failure

### DIFF
--- a/src/utils/imagePaste.ts
+++ b/src/utils/imagePaste.ts
@@ -106,10 +106,8 @@ function getClipboardCommands() {
       deleteFile: `rm -f "${screenshotPath}"`,
     },
     win32: {
-      // System.Windows.Forms.Clipboard requires an STA thread. PowerShell's
-      // default apartment state is not guaranteed for non-interactive calls.
-      checkImage: `powershell -NoProfile -STA -Command "${WIN32_CLIPBOARD_HAS_IMAGE_CMD}"`,
-      saveImage: `powershell -NoProfile -STA -Command "Add-Type -AssemblyName System.Windows.Forms; $img = [System.Windows.Forms.Clipboard]::GetImage(); if ($img) { $img.Save('${escapePowerShellSingleQuotedString(screenshotPath)}', [System.Drawing.Imaging.ImageFormat]::Png) }"`,
+      checkImage: `powershell -NoProfile -Command "${WIN32_CLIPBOARD_HAS_IMAGE_CMD}"`,
+      saveImage: `powershell -NoProfile -Command "$ErrorActionPreference = 'Stop'; Add-Type -AssemblyName System.Windows.Forms; $img = [System.Windows.Forms.Clipboard]::GetImage(); if (-not $img) { exit 1 }; $img.Save('${escapePowerShellSingleQuotedString(screenshotPath)}', [System.Drawing.Imaging.ImageFormat]::Png)"`,
       getPath: 'powershell -NoProfile -Command "Get-Clipboard"',
       deleteFile: `del /f "${screenshotPath}"`,
     },
@@ -137,7 +135,6 @@ export async function hasImageInClipboard(): Promise<boolean> {
   if (process.platform === 'win32') {
     const result = await execFileNoThrowWithCwd('powershell', [
       '-NoProfile',
-      '-STA',
       '-Command',
       WIN32_CLIPBOARD_HAS_IMAGE_CMD,
     ])
@@ -240,15 +237,11 @@ export async function getImageFromClipboard(): Promise<ImageWithDimensions | nul
       shell: true,
       reject: false,
     })
-    if (checkResult.exitCode !== 0) {
+    if (process.platform !== 'win32' && checkResult.exitCode !== 0) {
       return null
     }
-    if (
-      process.platform === 'win32' &&
-      checkResult.stdout.trim() !== 'True'
-    ) {
-      return null
-    }
+    // GetImage() and the saved PNG are authoritative. In particular, do not
+    // reject a raw Windows bitmap solely because the probe fails or says False.
 
     // Save the image
     const saveResult = await execa(commands.saveImage, {

--- a/src/utils/imagePaste.ts
+++ b/src/utils/imagePaste.ts
@@ -106,8 +106,10 @@ function getClipboardCommands() {
       deleteFile: `rm -f "${screenshotPath}"`,
     },
     win32: {
-      checkImage: `powershell -NoProfile -Command "${WIN32_CLIPBOARD_HAS_IMAGE_CMD}"`,
-      saveImage: `powershell -NoProfile -Command "Add-Type -AssemblyName System.Windows.Forms; $img = [System.Windows.Forms.Clipboard]::GetImage(); if ($img) { $img.Save('${escapePowerShellSingleQuotedString(screenshotPath)}', [System.Drawing.Imaging.ImageFormat]::Png) }"`,
+      // System.Windows.Forms.Clipboard requires an STA thread. PowerShell's
+      // default apartment state is not guaranteed for non-interactive calls.
+      checkImage: `powershell -NoProfile -STA -Command "${WIN32_CLIPBOARD_HAS_IMAGE_CMD}"`,
+      saveImage: `powershell -NoProfile -STA -Command "Add-Type -AssemblyName System.Windows.Forms; $img = [System.Windows.Forms.Clipboard]::GetImage(); if ($img) { $img.Save('${escapePowerShellSingleQuotedString(screenshotPath)}', [System.Drawing.Imaging.ImageFormat]::Png) }"`,
       getPath: 'powershell -NoProfile -Command "Get-Clipboard"',
       deleteFile: `del /f "${screenshotPath}"`,
     },
@@ -135,6 +137,7 @@ export async function hasImageInClipboard(): Promise<boolean> {
   if (process.platform === 'win32') {
     const result = await execFileNoThrowWithCwd('powershell', [
       '-NoProfile',
+      '-STA',
       '-Command',
       WIN32_CLIPBOARD_HAS_IMAGE_CMD,
     ])

--- a/src/utils/imagePaste.win32.test.ts
+++ b/src/utils/imagePaste.win32.test.ts
@@ -79,6 +79,7 @@ describe('Windows clipboard image handling', () => {
     expect(await imagePaste.hasImageInClipboard()).toBe(true)
     expect(execFileNoThrowWithCwd).toHaveBeenCalledWith('powershell', [
       '-NoProfile',
+      '-STA',
       '-Command',
       'Add-Type -AssemblyName System.Windows.Forms; [System.Windows.Forms.Clipboard]::ContainsImage()',
     ])
@@ -106,6 +107,7 @@ describe('Windows clipboard image handling', () => {
     expect(await getImageFromClipboard()).toBeNull()
     expect(execa).toHaveBeenCalledTimes(1)
     const checkCall = execa.mock.calls[0] as unknown as ExecaCall | undefined
+    expect(checkCall?.[0]).toContain('powershell -NoProfile -STA -Command')
     expect(checkCall?.[0]).toContain('Clipboard]::ContainsImage()')
   })
 
@@ -136,6 +138,7 @@ describe('Windows clipboard image handling', () => {
     const saveCommand = String(saveCall?.[0] ?? '')
     expect(saveCommand).toContain("C:\\Temp\\O''Brien")
     expect(saveCommand).not.toContain('C:\\\\Temp')
+    expect(saveCommand).toContain('powershell -NoProfile -STA -Command')
     expect(saveCommand).toContain(
       '[System.Windows.Forms.Clipboard]::GetImage()',
     )

--- a/src/utils/imagePaste.win32.test.ts
+++ b/src/utils/imagePaste.win32.test.ts
@@ -79,7 +79,6 @@ describe('Windows clipboard image handling', () => {
     expect(await imagePaste.hasImageInClipboard()).toBe(true)
     expect(execFileNoThrowWithCwd).toHaveBeenCalledWith('powershell', [
       '-NoProfile',
-      '-STA',
       '-Command',
       'Add-Type -AssemblyName System.Windows.Forms; [System.Windows.Forms.Clipboard]::ContainsImage()',
     ])
@@ -93,7 +92,7 @@ describe('Windows clipboard image handling', () => {
     expect(await imagePaste.hasImageInClipboard()).toBe(false)
   })
 
-  test('getImageFromClipboard returns null before saving when Windows reports no image', async () => {
+  test('getImageFromClipboard tries GetImage when Windows reports no image', async () => {
     setPlatform('win32')
     const execa = mock(async () => ({
       exitCode: 0,
@@ -105,9 +104,9 @@ describe('Windows clipboard image handling', () => {
     const { getImageFromClipboard } = await importImagePaste()
 
     expect(await getImageFromClipboard()).toBeNull()
-    expect(execa).toHaveBeenCalledTimes(1)
+    expect(execa).toHaveBeenCalledTimes(2)
     const checkCall = execa.mock.calls[0] as unknown as ExecaCall | undefined
-    expect(checkCall?.[0]).toContain('powershell -NoProfile -STA -Command')
+    expect(checkCall?.[0]).toContain('powershell -NoProfile -Command')
     expect(checkCall?.[0]).toContain('Clipboard]::ContainsImage()')
   })
 
@@ -138,13 +137,14 @@ describe('Windows clipboard image handling', () => {
     const saveCommand = String(saveCall?.[0] ?? '')
     expect(saveCommand).toContain("C:\\Temp\\O''Brien")
     expect(saveCommand).not.toContain('C:\\\\Temp')
-    expect(saveCommand).toContain('powershell -NoProfile -STA -Command')
+    expect(saveCommand).toContain('powershell -NoProfile -Command')
     expect(saveCommand).toContain(
       '[System.Windows.Forms.Clipboard]::GetImage()',
     )
+    expect(saveCommand).toContain('if (-not $img) { exit 1 }')
   })
 
-  test('getImageFromClipboard returns image data when Windows check and save succeed', async () => {
+  test('getImageFromClipboard saves a raw Windows bitmap when ContainsImage reports False', async () => {
     setPlatform('win32')
     const tempDir = mkdtempSync(join(tmpdir(), 'openclaude-image-paste-'))
     tempDirs.push(tempDir)
@@ -160,7 +160,7 @@ describe('Windows clipboard image handling', () => {
       }
       return {
         exitCode: 0,
-        stdout: 'True\r\n',
+        stdout: 'False\r\n',
         stderr: '',
       }
     })
@@ -202,6 +202,10 @@ describe('Windows clipboard image handling', () => {
     )
     expect(image?.base64.length).toBeGreaterThan(0)
     expect(execa).toHaveBeenCalledTimes(3)
+    const checkCall = execa.mock.calls[0] as unknown as ExecaCall | undefined
+    expect(String(checkCall?.[0] ?? '')).toContain(
+      'Clipboard]::ContainsImage()',
+    )
     const saveCall = execa.mock.calls[1] as unknown as ExecaCall | undefined
     expect(String(saveCall?.[0] ?? '')).toContain(screenshotPath)
     const deleteCall = execa.mock.calls[2] as unknown as ExecaCall | undefined

--- a/src/utils/screenshotClipboard.ts
+++ b/src/utils/screenshotClipboard.ts
@@ -101,7 +101,7 @@ async function copyPngToClipboard(
     const psScript = `Add-Type -AssemblyName System.Windows.Forms; [System.Windows.Forms.Clipboard]::SetImage([System.Drawing.Image]::FromFile('${pngPath.replace(/'/g, "''")}'))`
     const result = await execFileNoThrowWithCwd(
       'powershell',
-      ['-NoProfile', '-STA', '-Command', psScript],
+      ['-NoProfile', '-Command', psScript],
       { timeout: 5000 },
     )
 

--- a/src/utils/screenshotClipboard.ts
+++ b/src/utils/screenshotClipboard.ts
@@ -101,7 +101,7 @@ async function copyPngToClipboard(
     const psScript = `Add-Type -AssemblyName System.Windows.Forms; [System.Windows.Forms.Clipboard]::SetImage([System.Drawing.Image]::FromFile('${pngPath.replace(/'/g, "''")}'))`
     const result = await execFileNoThrowWithCwd(
       'powershell',
-      ['-NoProfile', '-Command', psScript],
+      ['-NoProfile', '-STA', '-Command', psScript],
       { timeout: 5000 },
     )
 


### PR DESCRIPTION
## Summary

Fixes #1844.

`getImageFromClipboard()` previously returned before attempting `Clipboard.GetImage()` whenever the preliminary `Clipboard.ContainsImage()` probe either failed or printed `False`. The Windows 11 report reaches the Alt+V handler but ends at that null result, and adding `-STA` could not explain it because Windows PowerShell 5.1 already uses STA by default.

This change makes the `GetImage()` save result authoritative on Windows: it still runs the lightweight probe, but attempts retrieval even when the probe disagrees. The save command exits nonzero for a null image or save error, so a stale temporary PNG cannot be submitted.

## Validation

- `bun test ./src/utils/imagePaste.win32.test.ts ./src/utils/imagePaste.test.ts`
- `bun run typecheck`
- `bun run smoke`
- `bun run security:pr-scan -- --base upstream/main --head HEAD`
- `git diff --check upstream/main...HEAD`
- Windows 11 integration: wrote a real `System.Drawing.Bitmap` to the desktop clipboard (`Bitmap` and `System.Drawing.Bitmap` formats), then invoked the production `getImageFromClipboard()` function that Alt+V calls; it returned `image/png` payload data.
- Manual acceptance: the reporter's PrintScreen/Win+Shift+S → Alt+V flow was confirmed working on this build.

Final reviewed SHA: `6f05883fc093dae941ba74d9346896655ea8d544`