### PR TITLE
fix(tools): keep HY3 tool schemas inline

### DIFF
--- a/src/integrations/brands/tencent.ts
+++ b/src/integrations/brands/tencent.ts
@@ -5,7 +5,7 @@ export default defineBrand({
   label: 'Tencent',
   canonicalVendorId: 'openai',
   defaultCapabilities: {
-    supportsVision: true,
+    supportsVision: false,
     supportsStreaming: true,
     supportsFunctionCalling: true,
     supportsJsonMode: true,

--- a/src/integrations/models/tencent.ts
+++ b/src/integrations/models/tencent.ts
@@ -6,10 +6,10 @@ export default [
     label: 'Tencent HY3',
     brandId: 'tencent',
     vendorId: 'openai',
-    classification: ['chat', 'reasoning', 'vision', 'coding'],
+    classification: ['chat', 'reasoning', 'coding'],
     defaultModel: 'tencent/hy3',
     capabilities: {
-      supportsVision: true,
+      supportsVision: false,
       supportsStreaming: true,
       supportsFunctionCalling: true,
       supportsJsonMode: true,
@@ -17,6 +17,6 @@ export default [
       supportsPreciseTokenCount: false,
     },
     contextWindow: 262_144,
-    maxOutputTokens: 65_536,
+    maxOutputTokens: 131_072,
   }),
 ]

--- a/src/integrations/tencent.test.ts
+++ b/src/integrations/tencent.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, test } from 'bun:test'
+
+import {
+  getCatalogEntriesForRoute,
+  getModel,
+} from './index.js'
+import { resolveModelRuntimeLimits } from './runtimeMetadata.js'
+
+describe('Tencent HY3 descriptor', () => {
+  test('exposes the verified HY3 capabilities and limits to gateway catalogs', () => {
+    const model = getModel('tencent/hy3')
+
+    expect(model).toBeDefined()
+    expect(model).toMatchObject({
+      id: 'tencent/hy3',
+      classification: ['chat', 'reasoning', 'coding'],
+      contextWindow: 262_144,
+      maxOutputTokens: 131_072,
+      capabilities: {
+        supportsVision: false,
+        supportsStreaming: true,
+        supportsFunctionCalling: true,
+        supportsJsonMode: true,
+        supportsReasoning: true,
+      },
+    })
+
+    const catalogEntry = getCatalogEntriesForRoute('gitlawb-opengateway').find(
+      entry => entry.apiName === 'tencent/hy3',
+    )
+    expect(catalogEntry?.modelDescriptorId).toBe(model?.id)
+
+    expect(
+      resolveModelRuntimeLimits({
+        model: 'tencent/hy3',
+        baseUrl: 'https://opengateway.gitlawb.com/v1',
+        processEnv: {},
+      }),
+    ).toEqual({ contextWindow: 262_144, maxOutputTokens: 131_072 })
+  })
+})

--- a/src/services/api/openaiShim.test.ts
+++ b/src/services/api/openaiShim.test.ts
@@ -9920,6 +9920,7 @@ function makeJsonChatCompletion(body: Record<string, unknown>): Response {
 
 async function collectFallbackEvents(
   body: Record<string, unknown>,
+  model = 'fake-model',
 ): Promise<Array<Record<string, unknown>>> {
   const previousFetch = globalThis.fetch
   globalThis.fetch = (async () => makeJsonChatCompletion(body)) as unknown as FetchType
@@ -9927,7 +9928,7 @@ async function collectFallbackEvents(
     const client = createOpenAIShimClient({}) as OpenAIShimClient
     const result = await client.beta.messages
       .create({
-        model: 'fake-model',
+        model,
         messages: [{ role: 'user', content: 'hi' }],
         max_tokens: 64,
         stream: true,
@@ -10159,7 +10160,7 @@ test('JSON fallback: recovers Tencent HY3 text tool calls into tool_use blocks',
         finish_reason: 'stop',
       },
     ],
-  })
+  }, 'tencent/hy3')
   const toolStart = events.find(
     event =>
       event.type === 'content_block_start' &&
@@ -10186,6 +10187,38 @@ test('JSON fallback: recovers Tencent HY3 text tool calls into tool_use blocks',
     | { delta?: { stop_reason?: string } }
     | undefined
   expect(stopEvent?.delta?.stop_reason).toBe('tool_use')
+})
+
+test('JSON fallback: preserves HY3-looking text for non-Tencent model names', async () => {
+  const text =
+    '<tool_call:example>TaskCreate\nsubject: merely a documentation example\n</tool_call:example>'
+  const events = await collectFallbackEvents({
+    id: 'chatcmpl-json-non-tencent-hy3',
+    model: 'other/hy3-documentation',
+    choices: [
+      {
+        message: { role: 'assistant', content: text },
+        finish_reason: 'stop',
+      },
+    ],
+  }, 'other/hy3-documentation')
+  const toolStart = events.find(
+    event =>
+      event.type === 'content_block_start' &&
+      typeof event.content_block === 'object' &&
+      event.content_block !== null &&
+      (event.content_block as Record<string, unknown>).type === 'tool_use',
+  )
+  const textDelta = events.find(
+    event =>
+      event.type === 'content_block_delta' &&
+      typeof event.delta === 'object' &&
+      event.delta !== null &&
+      (event.delta as Record<string, unknown>).type === 'text_delta',
+  ) as { delta?: { text?: string } } | undefined
+
+  expect(toolStart).toBeUndefined()
+  expect(textDelta?.delta?.text).toBe(text)
 })
 
 test('JSON fallback: empty tool_calls array does not block raw-text recovery', async () => {

--- a/src/services/api/openaiShim.test.ts
+++ b/src/services/api/openaiShim.test.ts
@@ -10145,6 +10145,49 @@ test('JSON fallback: recovers raw-text tool call into tool_use block', async () 
 
 })
 
+test('JSON fallback: recovers Tencent HY3 text tool calls into tool_use blocks', async () => {
+  const events = await collectFallbackEvents({
+    id: 'chatcmpl-json-hy3',
+    model: 'tencent/hy3',
+    choices: [
+      {
+        message: {
+          role: 'assistant',
+          content:
+            '<tool_call:call_hy3>TaskCreate\n subject: Verify HY3\n description: Run the live test\n</tool_call:call_hy3>',
+        },
+        finish_reason: 'stop',
+      },
+    ],
+  })
+  const toolStart = events.find(
+    event =>
+      event.type === 'content_block_start' &&
+      typeof event.content_block === 'object' &&
+      event.content_block !== null &&
+      (event.content_block as Record<string, unknown>).type === 'tool_use',
+  ) as { content_block?: Record<string, unknown> } | undefined
+  expect(toolStart?.content_block).toMatchObject({
+    type: 'tool_use',
+    name: 'TaskCreate',
+  })
+  const jsonDelta = events.find(
+    event =>
+      event.type === 'content_block_delta' &&
+      typeof event.delta === 'object' &&
+      event.delta !== null &&
+      (event.delta as Record<string, unknown>).type === 'input_json_delta',
+  ) as { delta?: { partial_json?: string } } | undefined
+  expect(JSON.parse(jsonDelta?.delta?.partial_json ?? '')).toEqual({
+    subject: 'Verify HY3',
+    description: 'Run the live test',
+  })
+  const stopEvent = events.find(e => e.type === 'message_delta') as
+    | { delta?: { stop_reason?: string } }
+    | undefined
+  expect(stopEvent?.delta?.stop_reason).toBe('tool_use')
+})
+
 test('JSON fallback: empty tool_calls array does not block raw-text recovery', async () => {
   // tool_calls: [] is truthy; it must be treated as "no structured tool calls"
   // so the raw "Tool calls requested" recovery still runs.

--- a/src/services/api/openaiShim.ts
+++ b/src/services/api/openaiShim.ts
@@ -1919,13 +1919,17 @@ function parseHy3ToolCallInner(inner: string): {
  * opener split across SSE deltas so it is never emitted as visible text.
  */
 function trailingXmlOpenerPrefixLen(s: string): number {
+  let longest = 0
   for (const opener of XML_TOOL_CALL_OPENERS) {
     const max = Math.min(s.length, opener.length - 1)
     for (let len = max; len > 0; len--) {
-      if (opener.startsWith(s.slice(s.length - len))) return len
+      if (opener.startsWith(s.slice(s.length - len))) {
+        longest = Math.max(longest, len)
+        break
+      }
     }
   }
-  return 0
+  return longest
 }
 
 function findXmlToolCallOpener(text: string): number {

--- a/src/services/api/openaiShim.ts
+++ b/src/services/api/openaiShim.ts
@@ -1817,26 +1817,42 @@ export function parseTextToolCalls(text: string): {
 // ---------------------------------------------------------------------------
 // XML tool call parser (GLM / Qwen / DeepSeek family)
 //
-// Several open models routed through OpenAI-compatible gateways emit tool
-// calls as XML text inside the assistant message rather than as structured
-// `tool_calls`. Without recovery these leak into visible prose and never
-// execute — the turn then ends with no tool_use block, so the agent appears
-// to "forget" and stop mid-task. We support the three dialects seen in the
-// wild:
+// Several models routed through OpenAI-compatible gateways emit tool calls as
+// XML text inside the assistant message rather than as structured `tool_calls`.
+// Without recovery these leak into visible prose and never execute — the turn
+// then ends with no tool_use block, so the agent appears to "forget" and stop
+// mid-task. We support the four dialects seen in the wild:
 //   A. <tool_call><function=NAME><parameter=KEY>VALUE</parameter>…</function></tool_call>
 //   B. <tool_call>NAME<arg_key>KEY</arg_key><arg_value>VALUE</arg_value>…</tool_call>  (GLM native)
 //   C. <tool_call>{"name":"NAME","arguments":{…}}</tool_call>                          (Hermes JSON)
+//   D. <tool_calls:ID><tool_call:ID>NAME<parameter name="KEY">VALUE</parameter>…           (Tencent HY3)
 // ---------------------------------------------------------------------------
 
 // The streaming finalize path buffers from this opener onward so the raw XML
 // is never surfaced as text before extraction.
 const XML_TOOL_CALL_OPEN = '<tool_call>'
+const HY3_TOOL_CALLS_OPEN = '<tool_calls:'
+const HY3_TOOL_CALL_OPEN = '<tool_call:'
+const XML_TOOL_CALL_OPENERS = [
+  XML_TOOL_CALL_OPEN,
+  HY3_TOOL_CALLS_OPEN,
+  HY3_TOOL_CALL_OPEN,
+]
 // Non-greedy block matcher; the `$` alternative tolerates a truncated final
 // block (stream cut off before the closing tag).
 const XML_TOOL_CALL_BLOCK_RE = /<tool_call>([\s\S]*?)(?:<\/tool_call>|$)/g
+const HY3_TOOL_CALLS_BLOCK_RE = /<tool_calls:[^>\s]+>([\s\S]*?)(?:<\/tool_calls(?::[^>\s]+)?>|$)/g
+const HY3_TOOL_CALL_BLOCK_RE = /<tool_call:[^>\s]+>([\s\S]*?)(?:<\/tool_call(?::[^>\s]+)?>|$)/g
 const XML_FUNCTION_NAME_RE = /<function=([^>\s]+)\s*>/
 const XML_PARAMETER_RE = /<parameter=([^>\s]+)\s*>([\s\S]*?)<\/parameter>/g
 const XML_ARG_PAIR_RE = /<arg_key>([\s\S]*?)<\/arg_key>\s*<arg_value>([\s\S]*?)<\/arg_value>/g
+const HY3_PARAMETER_RE = /<parameter\s+name=["']([^"'>\s]+)["']\s*>([\s\S]*?)<\/parameter>/g
+const HY3_NAMED_ARGUMENT_LINE_RE = /^\s*([A-Za-z_][\w-]*)\s*:\s*(.+?)\s*$/gm
+const HY3_ZERO_ARGUMENT_TOOL_NAMES = new Set([
+  'EnterPlanMode',
+  'ExitPlanMode',
+  'TaskList',
+])
 
 // Parameter/arg values arrive as untyped text. Try JSON first so numbers,
 // booleans, and nested objects round-trip; fall back to the raw string.
@@ -1850,17 +1866,65 @@ function coerceXmlToolValue(raw: string): unknown {
   }
 }
 
+function parseHy3ToolCallInner(inner: string): {
+  name?: string
+  args: Record<string, unknown>
+} {
+  const args: Record<string, unknown> = {}
+  const trimmed = inner.trim()
+  const name = trimmed
+    .split(/[\n<]/, 1)[0]
+    ?.trim()
+    .replace(/[\s`*_]+$/, '')
+  let hasStructuredArguments = false
+
+  for (const parameter of inner.matchAll(HY3_PARAMETER_RE)) {
+    const key = parameter[1]
+    if (key) {
+      hasStructuredArguments = true
+      args[key] = coerceXmlToolValue(parameter[2] ?? '')
+    }
+  }
+  for (const line of inner.matchAll(HY3_NAMED_ARGUMENT_LINE_RE)) {
+    const key = line[1]
+    if (key) {
+      hasStructuredArguments = true
+      args[key] = coerceXmlToolValue(line[2] ?? '')
+    }
+  }
+
+  // The provider's textual wrapper is not self-authenticating. Requiring a
+  // normal tool identifier and at least one named argument avoids executing or
+  // hiding documentation snippets that merely demonstrate `<tool_call:...>`.
+  return {
+    name: name && /^[A-Za-z_][\w.-]*$/.test(name) &&
+      (hasStructuredArguments || HY3_ZERO_ARGUMENT_TOOL_NAMES.has(name))
+      ? name
+      : undefined,
+    args,
+  }
+}
+
 /**
  * Returns the length of the longest suffix of `s` that is a (proper) prefix of
  * the `<tool_call>` opener. Used by the stream to hold back a trailing partial
  * opener split across SSE deltas so it is never emitted as visible text.
  */
 function trailingXmlOpenerPrefixLen(s: string): number {
-  const max = Math.min(s.length, XML_TOOL_CALL_OPEN.length - 1)
-  for (let len = max; len > 0; len--) {
-    if (XML_TOOL_CALL_OPEN.startsWith(s.slice(s.length - len))) return len
+  for (const opener of XML_TOOL_CALL_OPENERS) {
+    const max = Math.min(s.length, opener.length - 1)
+    for (let len = max; len > 0; len--) {
+      if (opener.startsWith(s.slice(s.length - len))) return len
+    }
   }
   return 0
+}
+
+function findXmlToolCallOpener(text: string): number {
+  return XML_TOOL_CALL_OPENERS.reduce((first, opener) => {
+    const index = text.indexOf(opener)
+    return index === -1 ? first : first === -1 ? index : Math.min(first, index)
+  }, -1)
 }
 
 /** Exported for unit testing only. */
@@ -1871,6 +1935,37 @@ export function parseXmlToolCalls(text: string): {
   const results: ParsedTextToolCall[] = []
   const seen = new Set<string>()
   const ranges: Array<[number, number]> = []
+
+  const addCall = (name: string, args: Record<string, unknown>) => {
+    const dedupKey = `${name}:${JSON.stringify(args)}`
+    if (seen.has(dedupKey)) return
+    seen.add(dedupKey)
+    results.push({ id: `xml_tc_${++_textToolCallCounter}`, name, arguments: args })
+  }
+
+  const hy3WrapperRanges = [...text.matchAll(HY3_TOOL_CALLS_BLOCK_RE)]
+    .filter(wrapper =>
+      [...(wrapper[1] ?? '').matchAll(HY3_TOOL_CALL_BLOCK_RE)].length > 0,
+    )
+    .map(wrapper => [
+      wrapper.index!,
+      wrapper.index! + wrapper[0].length,
+    ] as [number, number])
+
+  for (const block of text.matchAll(HY3_TOOL_CALL_BLOCK_RE)) {
+    const { name, args } = parseHy3ToolCallInner(block[1] ?? '')
+    if (!name) continue
+    const range: [number, number] = [
+      block.index!,
+      block.index! + block[0].length,
+    ]
+    if (!hy3WrapperRanges.some(wrapper => wrapper[0] <= range[0] && range[1] <= wrapper[1])) {
+      ranges.push(range)
+    }
+    addCall(name, args)
+  }
+
+  ranges.push(...hy3WrapperRanges)
 
   for (const block of text.matchAll(XML_TOOL_CALL_BLOCK_RE)) {
     const inner = block[1] ?? ''
@@ -1927,10 +2022,7 @@ export function parseXmlToolCalls(text: string): {
 
     if (!name) continue
     ranges.push(range)
-    const dedupKey = `${name}:${JSON.stringify(args)}`
-    if (seen.has(dedupKey)) continue
-    seen.add(dedupKey)
-    results.push({ id: `xml_tc_${++_textToolCallCounter}`, name, arguments: args })
+    addCall(name, args)
   }
 
   return { calls: results, toolCallRanges: ranges }
@@ -2281,8 +2373,25 @@ function convertNonStreamingResponseToAnthropicMessage(
     choice?.message?.content !== '' && choice?.message?.content != null
       ? choice?.message?.content
       : null
-  if (typeof rawContent === 'string' && rawContent) {
-    const strippedContent = stripThinkTags(rawContent)
+  const appendTextOrRecoveredToolCalls = (rawText: string) => {
+    const strippedContent = stripThinkTags(rawText)
+    if (!hasStructuredToolCalls) {
+      const { calls: xmlToolCalls, toolCallRanges } = parseXmlToolCalls(strippedContent)
+      if (xmlToolCalls.length > 0) {
+        const visibleText = stripRanges(strippedContent, toolCallRanges).trim()
+        if (visibleText) content.push({ type: 'text', text: visibleText })
+        for (const toolCall of xmlToolCalls) {
+          content.push({
+            type: 'tool_use',
+            id: toolCall.id,
+            name: toolCall.name,
+            input: toolCall.arguments,
+          })
+        }
+        return
+      }
+    }
+
     const rawToolCalls = hasStructuredToolCalls
       ? null
       : parseRawToolCallsRequestedText(strippedContent)
@@ -2296,11 +2405,11 @@ function convertNonStreamingResponseToAnthropicMessage(
         })
       }
     } else {
-      content.push({
-        type: 'text',
-        text: strippedContent,
-      })
+      content.push({ type: 'text', text: strippedContent })
     }
+  }
+  if (typeof rawContent === 'string' && rawContent) {
+    appendTextOrRecoveredToolCalls(rawContent)
   } else if (Array.isArray(rawContent) && rawContent.length > 0) {
     const parts: string[] = []
     for (const part of rawContent) {
@@ -2315,25 +2424,7 @@ function convertNonStreamingResponseToAnthropicMessage(
     }
     const joined = parts.join('\n')
     if (joined) {
-      const strippedContent = stripThinkTags(joined)
-      const rawToolCalls = hasStructuredToolCalls
-        ? null
-        : parseRawToolCallsRequestedText(strippedContent)
-      if (rawToolCalls) {
-        for (const toolCall of rawToolCalls) {
-          content.push({
-            type: 'tool_use',
-            id: toolCall.id,
-            name: toolCall.name,
-            input: JSON.parse(toolCall.argumentsJson),
-          })
-        }
-      } else {
-        content.push({
-          type: 'text',
-          text: strippedContent,
-        })
-      }
+      appendTextOrRecoveredToolCalls(joined)
     }
   }
 
@@ -2811,7 +2902,7 @@ async function* openaiStreamToAnthropic(
             // converted to tool_use blocks at finalize; prose before it streams
             // normally, minus a trailing partial-opener prefix.
             const combined = xmlHoldback + delta.content
-            const openIdx = combined.indexOf(XML_TOOL_CALL_OPEN)
+            const openIdx = findXmlToolCallOpener(combined)
             if (openIdx !== -1) {
               const before = combined.slice(0, openIdx)
               if (before) yield* emitTextDelta(before)

--- a/src/services/api/openaiShim.ts
+++ b/src/services/api/openaiShim.ts
@@ -1848,6 +1848,7 @@ const XML_PARAMETER_RE = /<parameter=([^>\s]+)\s*>([\s\S]*?)<\/parameter>/g
 const XML_ARG_PAIR_RE = /<arg_key>([\s\S]*?)<\/arg_key>\s*<arg_value>([\s\S]*?)<\/arg_value>/g
 const HY3_PARAMETER_RE = /<parameter\s+name=["']([^"'>\s]+)["']\s*>([\s\S]*?)<\/parameter>/g
 const HY3_NAMED_ARGUMENT_LINE_RE = /^\s*([A-Za-z_][\w-]*)\s*:\s*(.+?)\s*$/gm
+const HY3_ARG_PAIR_RE = /<arg_key(?::[^>\s]+)?>([\s\S]*?)<\/arg_key(?::[^>\s]+)?>\s*<arg_value(?::[^>\s]+)?>([\s\S]*?)<\/arg_value(?::[^>\s]+)?>/g
 const HY3_ZERO_ARGUMENT_TOOL_NAMES = new Set([
   'EnterPlanMode',
   'ExitPlanMode',
@@ -1890,6 +1891,13 @@ function parseHy3ToolCallInner(inner: string): {
     if (key) {
       hasStructuredArguments = true
       args[key] = coerceXmlToolValue(line[2] ?? '')
+    }
+  }
+  for (const pair of inner.matchAll(HY3_ARG_PAIR_RE)) {
+    const key = pair[1]?.trim()
+    if (key) {
+      hasStructuredArguments = true
+      args[key] = coerceXmlToolValue(pair[2] ?? '')
     }
   }
 
@@ -1943,22 +1951,29 @@ export function parseXmlToolCalls(text: string): {
     results.push({ id: `xml_tc_${++_textToolCallCounter}`, name, arguments: args })
   }
 
+  const hy3Blocks = [...text.matchAll(HY3_TOOL_CALL_BLOCK_RE)].map(block => ({
+    range: [block.index!, block.index! + block[0].length] as [number, number],
+    parsed: parseHy3ToolCallInner(block[1] ?? ''),
+  }))
   const hy3WrapperRanges = [...text.matchAll(HY3_TOOL_CALLS_BLOCK_RE)]
-    .filter(wrapper =>
-      [...(wrapper[1] ?? '').matchAll(HY3_TOOL_CALL_BLOCK_RE)].length > 0,
-    )
+    .filter(wrapper => {
+      const range: [number, number] = [
+        wrapper.index!,
+        wrapper.index! + wrapper[0].length,
+      ]
+      return hy3Blocks.some(
+        block => block.parsed.name && range[0] <= block.range[0] && block.range[1] <= range[1],
+      )
+    })
     .map(wrapper => [
       wrapper.index!,
       wrapper.index! + wrapper[0].length,
     ] as [number, number])
 
-  for (const block of text.matchAll(HY3_TOOL_CALL_BLOCK_RE)) {
-    const { name, args } = parseHy3ToolCallInner(block[1] ?? '')
+  for (const block of hy3Blocks) {
+    const { name, args } = block.parsed
     if (!name) continue
-    const range: [number, number] = [
-      block.index!,
-      block.index! + block[0].length,
-    ]
+    const range = block.range
     if (!hy3WrapperRanges.some(wrapper => wrapper[0] <= range[0] && range[1] <= wrapper[1])) {
       ranges.push(range)
     }

--- a/src/services/api/openaiShim.ts
+++ b/src/services/api/openaiShim.ts
@@ -1909,14 +1909,19 @@ function parseHy3ToolCallInner(inner: string): {
   }
 }
 
+function isHy3Model(model: string): boolean {
+  return model.split('?', 1)[0]?.toLowerCase() === 'tencent/hy3'
+}
+
 /**
  * Returns the length of the longest suffix of `s` that is a (proper) prefix of
  * the `<tool_call>` opener. Used by the stream to hold back a trailing partial
  * opener split across SSE deltas so it is never emitted as visible text.
  */
-function trailingXmlOpenerPrefixLen(s: string): number {
+function trailingXmlOpenerPrefixLen(s: string, allowHy3: boolean): number {
   let longest = 0
-  for (const opener of XML_TOOL_CALL_OPENERS) {
+  const openers = allowHy3 ? XML_TOOL_CALL_OPENERS : [XML_TOOL_CALL_OPEN]
+  for (const opener of openers) {
     const max = Math.min(s.length, opener.length - 1)
     for (let len = max; len > 0; len--) {
       if (opener.startsWith(s.slice(s.length - len))) {
@@ -1928,15 +1933,16 @@ function trailingXmlOpenerPrefixLen(s: string): number {
   return longest
 }
 
-function findXmlToolCallOpener(text: string): number {
-  return XML_TOOL_CALL_OPENERS.reduce((first, opener) => {
+function findXmlToolCallOpener(text: string, allowHy3: boolean): number {
+  const openers = allowHy3 ? XML_TOOL_CALL_OPENERS : [XML_TOOL_CALL_OPEN]
+  return openers.reduce((first, opener) => {
     const index = text.indexOf(opener)
     return index === -1 ? first : first === -1 ? index : Math.min(first, index)
   }, -1)
 }
 
 /** Exported for unit testing only. */
-export function parseXmlToolCalls(text: string): {
+export function parseXmlToolCalls(text: string, allowHy3 = false): {
   calls: ParsedTextToolCall[]
   toolCallRanges: Array<[number, number]>
 } {
@@ -1951,24 +1957,28 @@ export function parseXmlToolCalls(text: string): {
     results.push({ id: `xml_tc_${++_textToolCallCounter}`, name, arguments: args })
   }
 
-  const hy3Blocks = [...text.matchAll(HY3_TOOL_CALL_BLOCK_RE)].map(block => ({
-    range: [block.index!, block.index! + block[0].length] as [number, number],
-    parsed: parseHy3ToolCallInner(block[1] ?? ''),
-  }))
-  const hy3WrapperRanges = [...text.matchAll(HY3_TOOL_CALLS_BLOCK_RE)]
-    .filter(wrapper => {
-      const range: [number, number] = [
+  const hy3Blocks = allowHy3
+    ? [...text.matchAll(HY3_TOOL_CALL_BLOCK_RE)].map(block => ({
+      range: [block.index!, block.index! + block[0].length] as [number, number],
+      parsed: parseHy3ToolCallInner(block[1] ?? ''),
+    }))
+    : []
+  const hy3WrapperRanges = allowHy3
+    ? [...text.matchAll(HY3_TOOL_CALLS_BLOCK_RE)]
+      .filter(wrapper => {
+        const range: [number, number] = [
+          wrapper.index!,
+          wrapper.index! + wrapper[0].length,
+        ]
+        return hy3Blocks.some(
+          block => block.parsed.name && range[0] <= block.range[0] && block.range[1] <= range[1],
+        )
+      })
+      .map(wrapper => [
         wrapper.index!,
         wrapper.index! + wrapper[0].length,
-      ]
-      return hy3Blocks.some(
-        block => block.parsed.name && range[0] <= block.range[0] && block.range[1] <= range[1],
-      )
-    })
-    .map(wrapper => [
-      wrapper.index!,
-      wrapper.index! + wrapper[0].length,
-    ] as [number, number])
+      ] as [number, number])
+    : []
 
   for (const block of hy3Blocks) {
     const { name, args } = block.parsed
@@ -2391,7 +2401,10 @@ function convertNonStreamingResponseToAnthropicMessage(
   const appendTextOrRecoveredToolCalls = (rawText: string) => {
     const strippedContent = stripThinkTags(rawText)
     if (!hasStructuredToolCalls) {
-      const { calls: xmlToolCalls, toolCallRanges } = parseXmlToolCalls(strippedContent)
+      const { calls: xmlToolCalls, toolCallRanges } = parseXmlToolCalls(
+        strippedContent,
+        isHy3Model(model),
+      )
       if (xmlToolCalls.length > 0) {
         const visibleText = stripRanges(strippedContent, toolCallRanges).trim()
         if (visibleText) content.push({ type: 'text', text: visibleText })
@@ -2513,6 +2526,7 @@ async function* openaiStreamToAnthropic(
   requestUrl?: string,
 ): AsyncGenerator<AnthropicStreamEvent> {
   const messageId = makeMessageId()
+  const allowHy3ToolCalls = isHy3Model(model)
   let contentBlockIndex = 0
   const activeToolCalls = new Map<
     number,
@@ -2917,14 +2931,20 @@ async function* openaiStreamToAnthropic(
             // converted to tool_use blocks at finalize; prose before it streams
             // normally, minus a trailing partial-opener prefix.
             const combined = xmlHoldback + delta.content
-            const openIdx = findXmlToolCallOpener(combined)
+            const openIdx = findXmlToolCallOpener(
+              combined,
+              allowHy3ToolCalls,
+            )
             if (openIdx !== -1) {
               const before = combined.slice(0, openIdx)
               if (before) yield* emitTextDelta(before)
               xmlHoldback = ''
               xmlToolCallText = combined.slice(openIdx)
             } else {
-              const keep = trailingXmlOpenerPrefixLen(combined)
+              const keep = trailingXmlOpenerPrefixLen(
+                combined,
+                allowHy3ToolCalls,
+              )
               const emit =
                 keep > 0 ? combined.slice(0, combined.length - keep) : combined
               xmlHoldback = keep > 0 ? combined.slice(combined.length - keep) : ''
@@ -3180,7 +3200,10 @@ async function* openaiStreamToAnthropic(
           if (!isOllamaStream && xmlToolCallText !== null) {
             const buffered = xmlToolCallText
             xmlToolCallText = null
-            const { calls, toolCallRanges } = parseXmlToolCalls(buffered)
+            const { calls, toolCallRanges } = parseXmlToolCalls(
+              buffered,
+              allowHy3ToolCalls,
+            )
             if (calls.length > 0) {
               const stripped = stripRanges(buffered, toolCallRanges).trim()
               const strippedVisible = stripThinkTags(stripped).trim()

--- a/src/services/api/openaiShim.ts
+++ b/src/services/api/openaiShim.ts
@@ -1849,11 +1849,6 @@ const XML_ARG_PAIR_RE = /<arg_key>([\s\S]*?)<\/arg_key>\s*<arg_value>([\s\S]*?)<
 const HY3_PARAMETER_RE = /<parameter\s+name=["']([^"'>\s]+)["']\s*>([\s\S]*?)<\/parameter>/g
 const HY3_NAMED_ARGUMENT_LINE_RE = /^\s*([A-Za-z_][\w-]*)\s*:\s*(.+?)\s*$/gm
 const HY3_ARG_PAIR_RE = /<arg_key(?::[^>\s]+)?>([\s\S]*?)<\/arg_key(?::[^>\s]+)?>\s*<arg_value(?::[^>\s]+)?>([\s\S]*?)<\/arg_value(?::[^>\s]+)?>/g
-const HY3_ZERO_ARGUMENT_TOOL_NAMES = new Set([
-  'EnterPlanMode',
-  'ExitPlanMode',
-  'TaskList',
-])
 
 // Parameter/arg values arrive as untyped text. Try JSON first so numbers,
 // booleans, and nested objects round-trip; fall back to the raw string.
@@ -1902,11 +1897,12 @@ function parseHy3ToolCallInner(inner: string): {
   }
 
   // The provider's textual wrapper is not self-authenticating. Requiring a
-  // normal tool identifier and at least one named argument avoids executing or
-  // hiding documentation snippets that merely demonstrate `<tool_call:...>`.
+  // normal tool identifier avoids executing or hiding documentation snippets
+  // that merely demonstrate `<tool_call:...>`, while still allowing every
+  // valid zero-input tool instead of maintaining a stale name allowlist.
   return {
     name: name && /^[A-Za-z_][\w.-]*$/.test(name) &&
-      (hasStructuredArguments || HY3_ZERO_ARGUMENT_TOOL_NAMES.has(name))
+      (hasStructuredArguments || trimmed === name)
       ? name
       : undefined,
     args,

--- a/src/services/api/openaiShim.xmlToolCalls.test.ts
+++ b/src/services/api/openaiShim.xmlToolCalls.test.ts
@@ -174,13 +174,13 @@ describe('parseXmlToolCalls', () => {
     expect(toolCallRanges).toEqual([])
   })
 
-  test('allows known zero-argument plan tools', () => {
+  test('allows zero-argument tools without a name allowlist', () => {
     const { calls } = parseXmlToolCalls(
-      '<tool_call:call_1>EnterPlanMode</tool_call:call_1>',
+      '<tool_call:call_1>CronList</tool_call:call_1>',
     )
 
     expect(calls).toHaveLength(1)
-    expect(calls[0]).toMatchObject({ name: 'EnterPlanMode', arguments: {} })
+    expect(calls[0]).toMatchObject({ name: 'CronList', arguments: {} })
   })
 
   test('dialect D: Tencent HY3 official tagged arguments', () => {
@@ -407,6 +407,21 @@ describe('GLM streaming — XML tool calls', () => {
       subject: 'Verify HY3',
       description: 'Run the live test',
     })
+  })
+
+  test('recovers zero-argument Tencent HY3 calls from streaming output', async () => {
+    const events = await run([
+      hy3Chunk('<tool_call:call_1>CronList</tool_call:call_1>'),
+      hy3Chunk('', 'stop'),
+    ])
+
+    expect(toolStarts(events)).toHaveLength(1)
+    expect((toolStarts(events)[0].content_block as Record<string, string>).name).toBe('CronList')
+    expect(textOf(events)).not.toContain('<tool_call')
+    const jsonDelta = events.find(
+      event => event.type === 'content_block_delta' && (event.delta as Record<string, string>)?.type === 'input_json_delta',
+    )
+    expect(JSON.parse((jsonDelta!.delta as Record<string, string>).partial_json)).toEqual({})
   })
 
   test('strips a complete Tencent HY3 wrapper from streaming output', async () => {

--- a/src/services/api/openaiShim.xmlToolCalls.test.ts
+++ b/src/services/api/openaiShim.xmlToolCalls.test.ts
@@ -7,11 +7,12 @@
  * visible prose and never execute, so the turn ends with no tool_use block and
  * the agent appears to "forget" and stop mid-task (the reported bug).
  *
- * Covers the three dialects seen in the wild plus the streaming/non-streaming
+ * Covers the four dialects seen in the wild plus the streaming/non-streaming
  * pipeline integration:
  *   A. <tool_call><function=NAME><parameter=KEY>VALUE</parameter>…</function></tool_call>
  *   B. <tool_call>NAME<arg_key>KEY</arg_key><arg_value>VALUE</arg_value>…</tool_call>
  *   C. <tool_call>{"name":"NAME","arguments":{…}}</tool_call>
+ *   D. <tool_calls:ID><tool_call:ID>NAME<parameter name="KEY">VALUE</parameter>…</tool_calls:ID>
  */
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
 import { createOpenAIShimClient, parseXmlToolCalls } from './openaiShim.js'
@@ -59,6 +60,13 @@ const glmToolChunk = (toolCalls: unknown[], finishReason?: string) => ({
   object: 'chat.completion.chunk',
   model: 'glm-5.2',
   choices: [{ index: 0, delta: { tool_calls: toolCalls }, finish_reason: finishReason ?? null }],
+})
+
+const hy3Chunk = (content: string, finishReason?: string) => ({
+  id: 'chatcmpl-hy3',
+  object: 'chat.completion.chunk',
+  model: 'tencent/hy3',
+  choices: [{ index: 0, delta: { content }, finish_reason: finishReason ?? null }],
 })
 
 // ---------------------------------------------------------------------------
@@ -120,6 +128,59 @@ describe('parseXmlToolCalls', () => {
     const { calls } = parseXmlToolCalls(text)
     expect(calls[0].name).toBe('Bash')
     expect(calls[0].arguments).toEqual({ command: 'pwd' })
+  })
+
+  test('dialect D: Tencent HY3 wrapper with named parameters', () => {
+    const text =
+      '<tool_calls:call_1><tool_call:call_1>TaskCreate\n' +
+      '<parameter name="subject">Verify HY3</parameter>' +
+      '<parameter name="description">Run the live test</parameter>' +
+      '</invoke></tool_call:call_1></tool_calls:call_1>'
+    const { calls, toolCallRanges } = parseXmlToolCalls(text)
+
+    expect(calls).toHaveLength(1)
+    expect(calls[0].name).toBe('TaskCreate')
+    expect(calls[0].arguments).toEqual({
+      subject: 'Verify HY3',
+      description: 'Run the live test',
+    })
+    expect(toolCallRanges).toEqual([[0, text.length]])
+  })
+
+  test('dialect D: Tencent HY3 inline named arguments', () => {
+    const text =
+      '<tool_call:call_1>TaskCreate\n' +
+      ' subject: Verify HY3\n' +
+      ' description: Run the live test\n' +
+      ' activeForm: Validating HY3\n' +
+      '</tool_call:call_1>'
+    const { calls } = parseXmlToolCalls(text)
+
+    expect(calls).toHaveLength(1)
+    expect(calls[0].name).toBe('TaskCreate')
+    expect(calls[0].arguments).toEqual({
+      subject: 'Verify HY3',
+      description: 'Run the live test',
+      activeForm: 'Validating HY3',
+    })
+  })
+
+  test('does not treat a literal HY3 wrapper example as a tool call', () => {
+    const text =
+      'Documentation: <tool_call:example>Run this example</tool_call:example>'
+    const { calls, toolCallRanges } = parseXmlToolCalls(text)
+
+    expect(calls).toEqual([])
+    expect(toolCallRanges).toEqual([])
+  })
+
+  test('allows known zero-argument plan tools', () => {
+    const { calls } = parseXmlToolCalls(
+      '<tool_call:call_1>EnterPlanMode</tool_call:call_1>',
+    )
+
+    expect(calls).toHaveLength(1)
+    expect(calls[0]).toMatchObject({ name: 'EnterPlanMode', arguments: {} })
   })
 
   test('multiple tool calls in one message', () => {
@@ -311,5 +372,36 @@ describe('GLM streaming — XML tool calls', () => {
     const starts = toolStarts(events)
     expect(starts).toHaveLength(1)
     expect((starts[0].content_block as Record<string, string>).name).toBe('Bash')
+  })
+
+  test('recovers Tencent HY3 XML calls without exposing wrapper text', async () => {
+    const events = await run([
+      hy3Chunk('<tool_call:call_1>TaskCreate\n subject: Verify HY3\n'),
+      hy3Chunk(' description: Run the live test\n</tool_call:call_1>'),
+      hy3Chunk('', 'stop'),
+    ])
+    const starts = toolStarts(events)
+    expect(starts).toHaveLength(1)
+    expect((starts[0].content_block as Record<string, string>).name).toBe('TaskCreate')
+    expect(textOf(events)).not.toContain('<tool_call')
+    const jsonDelta = events.find(
+      event => event.type === 'content_block_delta' && (event.delta as Record<string, string>)?.type === 'input_json_delta',
+    )
+    expect(JSON.parse((jsonDelta!.delta as Record<string, string>).partial_json)).toEqual({
+      subject: 'Verify HY3',
+      description: 'Run the live test',
+    })
+  })
+
+  test('strips a complete Tencent HY3 wrapper from streaming output', async () => {
+    const events = await run([
+      hy3Chunk('<tool_calls:call_1><tool_call:call_1>TaskCreate\n subject: Verify HY3\n'),
+      hy3Chunk(' description: Run the live test\n</tool_call:call_1></tool_calls:call_1>'),
+      hy3Chunk('', 'stop'),
+    ])
+
+    expect(toolStarts(events)).toHaveLength(1)
+    expect(textOf(events)).not.toContain('<tool_call')
+    expect(textOf(events)).not.toContain('</tool_calls')
   })
 })

--- a/src/services/api/openaiShim.xmlToolCalls.test.ts
+++ b/src/services/api/openaiShim.xmlToolCalls.test.ts
@@ -183,6 +183,22 @@ describe('parseXmlToolCalls', () => {
     expect(calls[0]).toMatchObject({ name: 'EnterPlanMode', arguments: {} })
   })
 
+  test('dialect D: Tencent HY3 official tagged arguments', () => {
+    const text =
+      '<tool_calls:opensource><tool_call:opensource>TaskCreate<tool_sep:opensource>' +
+      '<arg_key:opensource>subject</arg_key:opensource><arg_value:opensource>Verify HY3</arg_value:opensource>' +
+      '<arg_key:opensource>description</arg_key:opensource><arg_value:opensource>Run the live test</arg_value:opensource>' +
+      '</tool_call:opensource></tool_calls:opensource>'
+    const { calls, toolCallRanges } = parseXmlToolCalls(text)
+
+    expect(calls).toHaveLength(1)
+    expect(calls[0]).toMatchObject({
+      name: 'TaskCreate',
+      arguments: { subject: 'Verify HY3', description: 'Run the live test' },
+    })
+    expect(toolCallRanges).toEqual([[0, text.length]])
+  })
+
   test('multiple tool calls in one message', () => {
     const text =
       '<tool_call><function=Read><parameter=file_path>a.ts</parameter></function></tool_call>' +
@@ -403,5 +419,24 @@ describe('GLM streaming — XML tool calls', () => {
     expect(toolStarts(events)).toHaveLength(1)
     expect(textOf(events)).not.toContain('<tool_call')
     expect(textOf(events)).not.toContain('</tool_calls')
+  })
+
+  test('recovers Tencent HY3 official tagged arguments from streaming output', async () => {
+    const events = await run([
+      hy3Chunk('<tool_calls:opensource><tool_call:opensource>TaskCreate<tool_sep:opensource><arg_key:opensource>subject</arg_key:opensource>'),
+      hy3Chunk('<arg_value:opensource>Verify HY3</arg_value:opensource><arg_key:opensource>description</arg_key:opensource><arg_value:opensource>Run the live test</arg_value:opensource></tool_call:opensource></tool_calls:opensource>'),
+      hy3Chunk('', 'stop'),
+    ])
+
+    expect(toolStarts(events)).toHaveLength(1)
+    expect((toolStarts(events)[0].content_block as Record<string, string>).name).toBe('TaskCreate')
+    expect(textOf(events)).not.toContain('<tool_call')
+    const jsonDelta = events.find(
+      event => event.type === 'content_block_delta' && (event.delta as Record<string, string>)?.type === 'input_json_delta',
+    )
+    expect(JSON.parse((jsonDelta!.delta as Record<string, string>).partial_json)).toEqual({
+      subject: 'Verify HY3',
+      description: 'Run the live test',
+    })
   })
 })

--- a/src/services/api/openaiShim.xmlToolCalls.test.ts
+++ b/src/services/api/openaiShim.xmlToolCalls.test.ts
@@ -421,6 +421,18 @@ describe('GLM streaming — XML tool calls', () => {
     expect(textOf(events)).not.toContain('</tool_calls')
   })
 
+  test('recovers an HY3 wrapper when its colon suffix is split across SSE deltas', async () => {
+    const events = await run([
+      hy3Chunk('<tool_calls'),
+      hy3Chunk(':call_1><tool_call:call_1>TaskCreate\n subject: Verify HY3\n description: Run the live test\n</tool_call:call_1></tool_calls:call_1>'),
+      hy3Chunk('', 'stop'),
+    ])
+
+    expect(toolStarts(events)).toHaveLength(1)
+    expect((toolStarts(events)[0].content_block as Record<string, string>).name).toBe('TaskCreate')
+    expect(textOf(events)).not.toContain('<tool_calls')
+  })
+
   test('recovers Tencent HY3 official tagged arguments from streaming output', async () => {
     const events = await run([
       hy3Chunk('<tool_calls:opensource><tool_call:opensource>TaskCreate<tool_sep:opensource><arg_key:opensource>subject</arg_key:opensource>'),

--- a/src/services/api/openaiShim.xmlToolCalls.test.ts
+++ b/src/services/api/openaiShim.xmlToolCalls.test.ts
@@ -136,7 +136,7 @@ describe('parseXmlToolCalls', () => {
       '<parameter name="subject">Verify HY3</parameter>' +
       '<parameter name="description">Run the live test</parameter>' +
       '</invoke></tool_call:call_1></tool_calls:call_1>'
-    const { calls, toolCallRanges } = parseXmlToolCalls(text)
+    const { calls, toolCallRanges } = parseXmlToolCalls(text, true)
 
     expect(calls).toHaveLength(1)
     expect(calls[0].name).toBe('TaskCreate')
@@ -154,7 +154,7 @@ describe('parseXmlToolCalls', () => {
       ' description: Run the live test\n' +
       ' activeForm: Validating HY3\n' +
       '</tool_call:call_1>'
-    const { calls } = parseXmlToolCalls(text)
+    const { calls } = parseXmlToolCalls(text, true)
 
     expect(calls).toHaveLength(1)
     expect(calls[0].name).toBe('TaskCreate')
@@ -168,6 +168,15 @@ describe('parseXmlToolCalls', () => {
   test('does not treat a literal HY3 wrapper example as a tool call', () => {
     const text =
       'Documentation: <tool_call:example>Run this example</tool_call:example>'
+    const { calls, toolCallRanges } = parseXmlToolCalls(text, true)
+
+    expect(calls).toEqual([])
+    expect(toolCallRanges).toEqual([])
+  })
+
+  test('does not recover structured HY3 examples for non-HY3 routes', () => {
+    const text =
+      '<tool_call:example>TaskCreate\nsubject: merely a documentation example\n</tool_call:example>'
     const { calls, toolCallRanges } = parseXmlToolCalls(text)
 
     expect(calls).toEqual([])
@@ -177,6 +186,7 @@ describe('parseXmlToolCalls', () => {
   test('allows zero-argument tools without a name allowlist', () => {
     const { calls } = parseXmlToolCalls(
       '<tool_call:call_1>CronList</tool_call:call_1>',
+      true,
     )
 
     expect(calls).toHaveLength(1)
@@ -189,7 +199,7 @@ describe('parseXmlToolCalls', () => {
       '<arg_key:opensource>subject</arg_key:opensource><arg_value:opensource>Verify HY3</arg_value:opensource>' +
       '<arg_key:opensource>description</arg_key:opensource><arg_value:opensource>Run the live test</arg_value:opensource>' +
       '</tool_call:opensource></tool_calls:opensource>'
-    const { calls, toolCallRanges } = parseXmlToolCalls(text)
+    const { calls, toolCallRanges } = parseXmlToolCalls(text, true)
 
     expect(calls).toHaveLength(1)
     expect(calls[0]).toMatchObject({
@@ -263,7 +273,10 @@ describe('GLM streaming — XML tool calls', () => {
     delete process.env.OPENAI_BASE_URL
   })
 
-  async function run(chunks: unknown[]): Promise<Record<string, unknown>[]> {
+  async function run(
+    chunks: unknown[],
+    model = 'glm-5.2',
+  ): Promise<Record<string, unknown>[]> {
     const previousFetch = globalThis.fetch
     globalThis.fetch = (async () =>
       makeSseResponse(makeChunks(chunks))) as unknown as FetchType
@@ -271,7 +284,7 @@ describe('GLM streaming — XML tool calls', () => {
       const client = createOpenAIShimClient({}) as OpenAIShimClient
       const result = await client.beta.messages
         .create({
-          model: 'glm-5.2',
+          model,
           messages: [{ role: 'user', content: 'do it' }],
           max_tokens: 64,
           stream: true,
@@ -356,6 +369,27 @@ describe('GLM streaming — XML tool calls', () => {
     expect(textOf(events)).toBe('The <tool_call> tag is how models request tools.')
   })
 
+  test('does not recover a structured HY3 example for a non-HY3 model', async () => {
+    const text =
+      '<tool_call:example>TaskCreate\nsubject: merely a documentation example\n</tool_call:example>'
+    const events = await run([glmChunk(text), glmChunk('', 'stop')])
+
+    expect(toolStarts(events)).toHaveLength(0)
+    expect(textOf(events)).toBe(text)
+  })
+
+  test('does not recover a structured HY3 example for a non-Tencent model name', async () => {
+    const text =
+      '<tool_call:example>TaskCreate\nsubject: merely a documentation example\n</tool_call:example>'
+    const events = await run(
+      [glmChunk(text), glmChunk('', 'stop')],
+      'other/hy3-documentation',
+    )
+
+    expect(toolStarts(events)).toHaveLength(0)
+    expect(textOf(events)).toBe(text)
+  })
+
   // Locks in current behavior: when a single streamed message contains prose
   // *between* two XML tool calls, all surviving prose is emitted in one text
   // block BEFORE the tool_use blocks (the interleave is flattened to
@@ -400,7 +434,7 @@ describe('GLM streaming — XML tool calls', () => {
       hy3Chunk('<tool_call:call_1>TaskCreate\n subject: Verify HY3\n'),
       hy3Chunk(' description: Run the live test\n</tool_call:call_1>'),
       hy3Chunk('', 'stop'),
-    ])
+    ], 'tencent/hy3')
     const starts = toolStarts(events)
     expect(starts).toHaveLength(1)
     expect((starts[0].content_block as Record<string, string>).name).toBe('TaskCreate')
@@ -418,7 +452,7 @@ describe('GLM streaming — XML tool calls', () => {
     const events = await run([
       hy3Chunk('<tool_call:call_1>CronList</tool_call:call_1>'),
       hy3Chunk('', 'stop'),
-    ])
+    ], 'tencent/hy3')
 
     expect(toolStarts(events)).toHaveLength(1)
     expect((toolStarts(events)[0].content_block as Record<string, string>).name).toBe('CronList')
@@ -434,7 +468,7 @@ describe('GLM streaming — XML tool calls', () => {
       hy3Chunk('<tool_calls:call_1><tool_call:call_1>TaskCreate\n subject: Verify HY3\n'),
       hy3Chunk(' description: Run the live test\n</tool_call:call_1></tool_calls:call_1>'),
       hy3Chunk('', 'stop'),
-    ])
+    ], 'tencent/hy3')
 
     expect(toolStarts(events)).toHaveLength(1)
     expect(textOf(events)).not.toContain('<tool_call')
@@ -446,7 +480,7 @@ describe('GLM streaming — XML tool calls', () => {
       hy3Chunk('<tool_calls'),
       hy3Chunk(':call_1><tool_call:call_1>TaskCreate\n subject: Verify HY3\n description: Run the live test\n</tool_call:call_1></tool_calls:call_1>'),
       hy3Chunk('', 'stop'),
-    ])
+    ], 'tencent/hy3')
 
     expect(toolStarts(events)).toHaveLength(1)
     expect((toolStarts(events)[0].content_block as Record<string, string>).name).toBe('TaskCreate')
@@ -458,7 +492,7 @@ describe('GLM streaming — XML tool calls', () => {
       hy3Chunk('<tool_calls:opensource><tool_call:opensource>TaskCreate<tool_sep:opensource><arg_key:opensource>subject</arg_key:opensource>'),
       hy3Chunk('<arg_value:opensource>Verify HY3</arg_value:opensource><arg_key:opensource>description</arg_key:opensource><arg_value:opensource>Run the live test</arg_value:opensource></tool_call:opensource></tool_calls:opensource>'),
       hy3Chunk('', 'stop'),
-    ])
+    ], 'tencent/hy3')
 
     expect(toolStarts(events)).toHaveLength(1)
     expect((toolStarts(events)[0].content_block as Record<string, string>).name).toBe('TaskCreate')

--- a/src/services/api/openaiShim.xmlToolCalls.test.ts
+++ b/src/services/api/openaiShim.xmlToolCalls.test.ts
@@ -264,20 +264,25 @@ describe('GLM streaming — XML tool calls', () => {
   })
 
   async function run(chunks: unknown[]): Promise<Record<string, unknown>[]> {
+    const previousFetch = globalThis.fetch
     globalThis.fetch = (async () =>
       makeSseResponse(makeChunks(chunks))) as unknown as FetchType
-    const client = createOpenAIShimClient({}) as OpenAIShimClient
-    const result = await client.beta.messages
-      .create({
-        model: 'glm-5.2',
-        messages: [{ role: 'user', content: 'do it' }],
-        max_tokens: 64,
-        stream: true,
-      })
-      .withResponse()
-    const events: Record<string, unknown>[] = []
-    for await (const event of result.data) events.push(event)
-    return events
+    try {
+      const client = createOpenAIShimClient({}) as OpenAIShimClient
+      const result = await client.beta.messages
+        .create({
+          model: 'glm-5.2',
+          messages: [{ role: 'user', content: 'do it' }],
+          max_tokens: 64,
+          stream: true,
+        })
+        .withResponse()
+      const events: Record<string, unknown>[] = []
+      for await (const event of result.data) events.push(event)
+      return events
+    } finally {
+      globalThis.fetch = previousFetch
+    }
   }
 
   const textOf = (events: Record<string, unknown>[]) =>

--- a/src/utils/toolSearch.test.ts
+++ b/src/utils/toolSearch.test.ts
@@ -57,7 +57,8 @@ describe('resolveToolSearchMode', () => {
 describe('modelSupportsToolReference', () => {
   test('keeps Tencent HY3 on the inline tool-schema path', () => {
     expect(modelSupportsToolReference('tencent/hy3')).toBe(false)
-    expect(modelSupportsToolReference('hy3')).toBe(false)
+    expect(modelSupportsToolReference('tencent/hy3?reasoning=high')).toBe(false)
+    expect(modelSupportsToolReference('other/hy3-documentation')).toBe(true)
   })
 
   test('does not defer TaskCreate for Tencent HY3', async () => {

--- a/src/utils/toolSearch.test.ts
+++ b/src/utils/toolSearch.test.ts
@@ -1,5 +1,15 @@
-import { describe, expect, test } from 'bun:test'
-import { resolveToolSearchMode } from './toolSearch.js'
+import { afterEach, describe, expect, mock, test } from 'bun:test'
+import {
+  isToolSearchEnabled,
+  modelSupportsToolReference,
+  resolveToolSearchMode,
+} from './toolSearch.js'
+import { TaskCreateTool } from '../tools/TaskCreateTool/TaskCreateTool.js'
+import { ToolSearchTool } from '../tools/ToolSearchTool/ToolSearchTool.js'
+
+afterEach(() => {
+  mock.restore()
+})
 
 describe('resolveToolSearchMode', () => {
   test('defaults to tst when nothing is configured', () => {
@@ -41,5 +51,34 @@ describe('resolveToolSearchMode', () => {
     }
     expect(resolveToolSearchMode(env, 'codex')).toBe('tst-auto')
     expect(resolveToolSearchMode(env, 'firstParty')).toBe('standard')
+  })
+})
+
+describe('modelSupportsToolReference', () => {
+  test('keeps Tencent HY3 on the inline tool-schema path', () => {
+    expect(modelSupportsToolReference('tencent/hy3')).toBe(false)
+    expect(modelSupportsToolReference('hy3')).toBe(false)
+  })
+
+  test('does not defer TaskCreate for Tencent HY3', async () => {
+    expect(
+      await isToolSearchEnabled(
+        'tencent/hy3',
+        [ToolSearchTool, TaskCreateTool],
+        async () => undefined as never,
+        [],
+      ),
+    ).toBe(false)
+  })
+
+  test('keeps built-in HY3 compatibility when feature flags add exceptions', async () => {
+    mock.module('../services/analytics/growthbook.js', () => ({
+      getFeatureValue_CACHED_MAY_BE_STALE: () => ['haiku'],
+    }))
+    const freshToolSearch = await import(
+      `./toolSearch.ts?feature-flags-${Date.now()}`
+    )
+
+    expect(freshToolSearch.modelSupportsToolReference('tencent/hy3')).toBe(false)
   })
 })

--- a/src/utils/toolSearch.ts
+++ b/src/utils/toolSearch.ts
@@ -239,11 +239,15 @@ export function getToolSearchMode(): ToolSearchMode {
  * Default patterns for models that do NOT support tool_reference.
  * New models are assumed to support tool_reference unless explicitly listed here.
  */
-const DEFAULT_UNSUPPORTED_MODEL_PATTERNS = ['haiku']
+// HY3 supports standard OpenAI function calls, but it does not reliably follow
+// the extra ToolSearch round trip before calling a deferred tool. Keep its
+// schemas inline so it can call tools such as TaskCreate on the first attempt.
+const DEFAULT_UNSUPPORTED_MODEL_PATTERNS = ['haiku', 'hy3']
 
 /**
  * Get the list of model patterns that do NOT support tool_reference.
- * Can be configured via GrowthBook for live updates without code changes.
+ * A configured list adds temporary exceptions; it cannot remove built-in
+ * compatibility exceptions that protect known-unsupported models.
  */
 function getUnsupportedToolReferencePatterns(): string[] {
   try {
@@ -253,7 +257,7 @@ function getUnsupportedToolReferencePatterns(): string[] {
       null,
     )
     if (patterns && Array.isArray(patterns) && patterns.length > 0) {
-      return patterns
+      return [...new Set([...DEFAULT_UNSUPPORTED_MODEL_PATTERNS, ...patterns])]
     }
   } catch {
     // GrowthBook not ready, use defaults

--- a/src/utils/toolSearch.ts
+++ b/src/utils/toolSearch.ts
@@ -242,7 +242,8 @@ export function getToolSearchMode(): ToolSearchMode {
 // HY3 supports standard OpenAI function calls, but it does not reliably follow
 // the extra ToolSearch round trip before calling a deferred tool. Keep its
 // schemas inline so it can call tools such as TaskCreate on the first attempt.
-const DEFAULT_UNSUPPORTED_MODEL_PATTERNS = ['haiku', 'hy3']
+const BUILT_IN_UNSUPPORTED_MODEL_IDS = new Set(['tencent/hy3'])
+const DEFAULT_UNSUPPORTED_MODEL_PATTERNS = ['haiku']
 
 /**
  * Get the list of model patterns that do NOT support tool_reference.
@@ -280,6 +281,10 @@ function getUnsupportedToolReferencePatterns(): string[] {
  */
 export function modelSupportsToolReference(model: string): boolean {
   const normalizedModel = model.toLowerCase()
+  const canonicalModelId = normalizedModel.split('?', 1)[0] ?? normalizedModel
+  if (BUILT_IN_UNSUPPORTED_MODEL_IDS.has(canonicalModelId)) {
+    return false
+  }
   const unsupportedPatterns = getUnsupportedToolReferencePatterns()
 
   // Check if model matches any unsupported pattern


### PR DESCRIPTION
## Summary

- keep Tencent HY3 on the inline tool-schema path, avoiding the deferred `TaskCreate` schema loop reported in #1912
- preserve that compatibility behavior when local tool-search feature flags add other unsupported models
- correct HY3’s shared descriptor to its documented non-vision, 256K-context, 128K-output capabilities
- recover HY3's OpenGateway text-form tool-call wrapper into executable OpenClaude tool uses

## Root cause

HY3 does not reliably perform the extra `ToolSearch` discovery turn before invoking a deferred tool, so `TaskCreate` could be omitted from the request schema. Live OpenGateway validation also showed that, under OpenClaude's streamed request shape, HY3 emits `<tool_call:...>` text with named arguments instead of structured OpenAI `tool_calls`; the shim previously surfaced that text instead of executing the tool. The shim now supports both that gateway form and Tencent HY3's documented tagged `<tool_call:opensource>` / `<arg_key:opensource>` grammar.

## Validation

- `bun test src/utils/toolSearch.test.ts src/integrations/tencent.test.ts src/integrations/index.test.ts`
- `bun test src/services/api/openaiShim.xmlToolCalls.test.ts src/services/api/openaiShim.test.ts`
- `bun run test:provider`
- `bun run typecheck`
- `bun run integrations:check`
- `bun run security:pr-scan -- --base upstream/main --head HEAD`
- `bun run build`
- `node dist/cli.mjs --version`

Live validation used a minimal, isolated TaskCreate prompt against OpenGateway HY3. The shim converted the returned textual wrapper into `TaskCreate` with the expected `subject` and `description` fields.

Final reviewed commit: `d3170c5065a717b19a8ae995163e2b9b9e567b4a`.

Fixes #1912


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced compatibility with Tencent HY3 tool calls, including additional XML wrapper dialects and argument styles for both streamed and non-streamed responses.
* **Bug Fixes**
  * Corrected Tencent HY3 capability reporting by disabling default vision support and marking tool reference support as unreliable.
  * Raised Tencent HY3 maximum output limit to 131,072 tokens.
  * Improved recovery of XML-formatted tool calls into structured tool-use content.
* **Tests**
  * Added/expanded coverage for Tencent HY3 capabilities, catalog visibility, runtime limits, and tool-call recovery (including streaming edge cases).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->