### PR TITLE
fix(model): default NVIDIA NIM main loop model

### DIFF
--- a/src/utils/model/model.openai-shim-providers.test.ts
+++ b/src/utils/model/model.openai-shim-providers.test.ts
@@ -14,6 +14,7 @@ import {
   clearPluginSettingsBase,
   resetSettingsCache,
 } from '../settings/settingsCache.js'
+import { getRouteDefaultModel } from '../../integrations/routeMetadata.js'
 async function importFreshModelModule() {
   mock.restore()
   mock.module('./providers.js', () => ({
@@ -325,7 +326,7 @@ test('getDefaultMainLoopModelSetting falls back to the NVIDIA NIM descriptor def
 
   const { getDefaultMainLoopModelSetting } = await importFreshModelModule()
   expect(getDefaultMainLoopModelSetting()).toBe(
-    'nvidia/llama-3.1-nemotron-70b-instruct',
+    getRouteDefaultModel('nvidia-nim'),
   )
 })
 

--- a/src/utils/model/model.openai-shim-providers.test.ts
+++ b/src/utils/model/model.openai-shim-providers.test.ts
@@ -306,6 +306,29 @@ test('getDefaultMainLoopModelSetting defaults MiniMax to M3', async () => {
   expect(getDefaultMainLoopModel()).toBe('MiniMax-M3')
 })
 
+test('getDefaultMainLoopModelSetting uses the NVIDIA NIM route model', async () => {
+  process.env.NVIDIA_NIM = '1'
+  process.env.CLAUDE_CODE_USE_OPENAI = '1'
+  process.env.OPENAI_MODEL = 'meta/llama-3.3-70b-instruct'
+
+  const {
+    getDefaultMainLoopModel,
+    getDefaultMainLoopModelSetting,
+  } = await importFreshModelModule()
+  expect(getDefaultMainLoopModelSetting()).toBe('meta/llama-3.3-70b-instruct')
+  expect(getDefaultMainLoopModel()).toBe('meta/llama-3.3-70b-instruct')
+})
+
+test('getDefaultMainLoopModelSetting falls back to the NVIDIA NIM descriptor default', async () => {
+  process.env.NVIDIA_NIM = '1'
+  process.env.CLAUDE_CODE_USE_OPENAI = '1'
+
+  const { getDefaultMainLoopModelSetting } = await importFreshModelModule()
+  expect(getDefaultMainLoopModelSetting()).toBe(
+    'nvidia/llama-3.1-nemotron-70b-instruct',
+  )
+})
+
 test('getDefaultMainLoopModelSetting defaults Xiaomi MiMo to mimo-v2.5-pro', async () => {
   process.env.MIMO_API_KEY = 'mimo-test'
   process.env.CLAUDE_CODE_USE_OPENAI = '1'

--- a/src/utils/model/model.openai-shim-providers.test.ts
+++ b/src/utils/model/model.openai-shim-providers.test.ts
@@ -14,7 +14,6 @@ import {
   clearPluginSettingsBase,
   resetSettingsCache,
 } from '../settings/settingsCache.js'
-import { getRouteDefaultModel } from '../../integrations/routeMetadata.js'
 async function importFreshModelModule() {
   mock.restore()
   mock.module('./providers.js', () => ({
@@ -326,7 +325,7 @@ test('getDefaultMainLoopModelSetting falls back to the NVIDIA NIM descriptor def
 
   const { getDefaultMainLoopModelSetting } = await importFreshModelModule()
   expect(getDefaultMainLoopModelSetting()).toBe(
-    getRouteDefaultModel('nvidia-nim'),
+    'nvidia/llama-3.1-nemotron-70b-instruct',
   )
 })
 

--- a/src/utils/model/model.ts
+++ b/src/utils/model/model.ts
@@ -30,6 +30,7 @@ import { type ModelAlias, isModelAlias } from './aliases.js'
 import { capitalize } from '../stringUtils.js'
 import { DEFAULT_GEMINI_MODEL } from '../providerProfile.js'
 import { getAntModelOverrideConfig, resolveAntModel } from './antModels.js'
+import { getRouteDefaultModel } from '../../integrations/routeMetadata.js'
 
 export type ModelShortName = string
 export type ModelName = string
@@ -392,7 +393,9 @@ export function getDefaultMainLoopModelSetting(): ModelName | ModelAlias {
   // with the route descriptor so headless sessions never send a Claude model.
   if (getAPIProvider() === 'nvidia-nim') {
     return (
-      process.env.OPENAI_MODEL || 'nvidia/llama-3.1-nemotron-70b-instruct'
+      process.env.OPENAI_MODEL ||
+      getRouteDefaultModel('nvidia-nim') ||
+      'nvidia/llama-3.1-nemotron-70b-instruct'
     )
   }
   // xAI provider: always use the configured Grok model (default grok-4.3)

--- a/src/utils/model/model.ts
+++ b/src/utils/model/model.ts
@@ -388,6 +388,13 @@ export function getDefaultMainLoopModelSetting(): ModelName | ModelAlias {
   if (getAPIProvider() === 'codex') {
     return process.env.OPENAI_MODEL || 'gpt-5.5'
   }
+  // NVIDIA NIM uses OpenAI-compatible model ids. Keep this fallback aligned
+  // with the route descriptor so headless sessions never send a Claude model.
+  if (getAPIProvider() === 'nvidia-nim') {
+    return (
+      process.env.OPENAI_MODEL || 'nvidia/llama-3.1-nemotron-70b-instruct'
+    )
+  }
   // xAI provider: always use the configured Grok model (default grok-4.3)
   if (getAPIProvider() === 'xai') {
     return process.env.OPENAI_MODEL || 'grok-4.3'

--- a/src/utils/modelCost.modelGate.test.ts
+++ b/src/utils/modelCost.modelGate.test.ts
@@ -22,6 +22,29 @@ afterEach(() => {
   }
 })
 
+test('unknown models do not inherit the configured default model price', async () => {
+  mock.module('./model.js', () => ({
+    firstPartyNameToCanonical: (model: string) => {
+      if (model.includes('claude-haiku-4-5')) return 'claude-haiku-4-5'
+      return model
+    },
+    getCanonicalName: (model: string) => {
+      if (model.includes('claude-haiku-4-5')) return 'claude-haiku-4-5'
+      return model
+    },
+    getDefaultMainLoopModelSetting: () => 'claude-haiku-4-5',
+  }))
+  const { getModelCosts, COST_HAIKU_45, COST_TIER_5_25 } =
+    await importFreshModelCost()
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const usage = {} as any
+  const costs = getModelCosts('meta/llama-3.3-70b-instruct', usage)
+
+  expect(costs).toEqual(COST_TIER_5_25)
+  expect(costs).not.toEqual(COST_HAIKU_45)
+})
+
 // Regression for #1769: fast mode is now enabled for Opus 4.8, but getModelCosts
 // only applied the elevated fast-mode tier to opus-4-6, so fast-mode 4.8 was
 // billed at the normal rate while the picker advertised the fast-mode price.

--- a/src/utils/modelCost.modelGate.test.ts
+++ b/src/utils/modelCost.modelGate.test.ts
@@ -23,7 +23,7 @@ afterEach(() => {
 })
 
 test('unknown models do not inherit the configured default model price', async () => {
-  mock.module('./model.js', () => ({
+  mock.module('./model/model.js', () => ({
     firstPartyNameToCanonical: (model: string) => {
       if (model.includes('claude-haiku-4-5')) return 'claude-haiku-4-5'
       return model

--- a/src/utils/modelCost.ts
+++ b/src/utils/modelCost.ts
@@ -21,7 +21,6 @@ import {
 import {
   firstPartyNameToCanonical,
   getCanonicalName,
-  getDefaultMainLoopModelSetting,
   type ModelShortName,
 } from './model/model.js'
 
@@ -166,10 +165,7 @@ export function getModelCosts(model: string, usage: Usage): ModelCosts {
   const costs = MODEL_COSTS[shortName]
   if (!costs) {
     trackUnknownModelCost(model, shortName)
-    return (
-      MODEL_COSTS[getCanonicalName(getDefaultMainLoopModelSetting())] ??
-      DEFAULT_UNKNOWN_MODEL_COST
-    )
+    return DEFAULT_UNKNOWN_MODEL_COST
   }
   return costs
 }
@@ -184,7 +180,8 @@ function trackUnknownModelCost(model: string, shortName: ModelShortName): void {
 }
 
 // Calculate the cost of a query in US dollars.
-// If the model's costs are not found, use the default model's costs.
+// Unknown models use the explicit unknown-model estimate and are marked in
+// session state; they must never inherit an unrelated configured default.
 export function calculateUSDCost(resolvedModel: string, usage: Usage): number {
   const modelCosts = getModelCosts(resolvedModel, usage)
   return tokensToUSDCost(modelCosts, usage)


### PR DESCRIPTION
## Summary

Fixes #1925 and addresses the incorrect unknown-model pricing fallback in #1924.

- Return `OPENAI_MODEL` for NVIDIA NIM main-loop defaults.
- Use the NVIDIA NIM descriptor default when `OPENAI_MODEL` is unset, avoiding an invalid Claude model on the NIM endpoint.
- Add regression coverage for configured and env-only NIM sessions.
- Keep unknown-model token accounting and its visible inaccuracy warning, while preventing those models from inheriting an unrelated configured default model's price.

## Pricing behavior for unpriced NIM models

This PR does not claim an exact NVIDIA NIM price where the application has no
authoritative per-model rate. An unpriced NIM model continues to use the
application's generic unknown-model estimate: **$5 per million input tokens**
and **$25 per million output tokens**. The session output explicitly warns:

```text
costs may be inaccurate due to usage of unknown models
```

Why it is unknown: NVIDIA's model endpoint returns model IDs, but not
input/output token prices. NVIDIA's public pricing documentation describes
free developer access and GPU-based production licensing, not a per-model
token-price API. LiteLLM's current catalog also has no NIM chat-model price
entries. OpenClaude therefore has no source for a verified NIM token price.

The fix is that this estimate is no longer silently replaced by the price of
whichever model the user configured as their default.

## Validation

- `bun test src/utils/model/model.openai-shim-providers.test.ts`
- `bun test src/utils/modelCost.modelGate.test.ts`
- `bun run typecheck`
- `bun run check` (build, smoke, and dead-code stages passed; the serial full-test stage has pre-existing unrelated failures, reproduced on unchanged `main`)

## Limitation

The complete serial test suite currently has baseline failures outside this change (discovery cache, shell-governance, and xAI OAuth suites). The focused provider suite and TypeScript check pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved NVIDIA NIM model selection to honor the configured OpenAI model and use the route’s default when none is specified.
  * Corrected cost estimates for unrecognized models so they use the appropriate unknown-model estimate instead of inheriting pricing from an unrelated default model.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->