### PR TITLE
fix(gitdiff): apply the 1MB diff cap in bytes, not UTF-16 char length

### DIFF
--- a/src/utils/gitDiff.test.ts
+++ b/src/utils/gitDiff.test.ts
@@ -72,6 +72,22 @@ describe('parseGitDiff', () => {
     expect(lines).toContain('+const b = 3')
     expect(lines).toContain(' const a = 1')
   })
+
+  it('skips a file whose diff exceeds the 1MB cap in bytes, not UTF-16 units', () => {
+    // A per-file diff that is under the cap in UTF-16 code units but well over
+    // it in real UTF-8 bytes (each `一` is 1 code unit but 3 bytes). Before the
+    // fix the char-length check let this multi-MB diff through.
+    const cjkLine = '+' + '一'.repeat(100)
+    const body = ['a/big.txt b/big.txt', '@@ -1,1 +1,5000 @@']
+    for (let i = 0; i < 5000; i++) body.push(cjkLine)
+    const fileChunk = body.join('\n')
+    const stdout = 'diff --git ' + fileChunk
+
+    expect(fileChunk.length).toBeLessThan(1_000_000)
+    expect(Buffer.byteLength(fileChunk, 'utf8')).toBeGreaterThan(1_000_000)
+
+    expect(parseGitDiff(stdout).has('big.txt')).toBe(false)
+  })
 })
 
 describe('parseRawDiffToToolUseDiff', () => {

--- a/src/utils/gitDiff.ts
+++ b/src/utils/gitDiff.ts
@@ -210,8 +210,11 @@ export function parseGitDiff(
     // Stop after MAX_FILES
     if (result.size >= MAX_FILES) break
 
-    // Skip files larger than 1MB
-    if (fileDiff.length > MAX_DIFF_SIZE_BYTES) {
+    // Skip files larger than 1MB. Measure UTF-8 bytes, not String.length:
+    // `.length` counts UTF-16 code units, which undercounts multibyte content
+    // (CJK/emoji are 3-4 bytes each) by up to ~4x and would let a multi-MB
+    // single-file diff slip past this cap.
+    if (Buffer.byteLength(fileDiff, 'utf8') > MAX_DIFF_SIZE_BYTES) {
       continue
     }
 


### PR DESCRIPTION
### Problem
`parseGitDiff` skips per-file diffs larger than `MAX_DIFF_SIZE_BYTES` (1 MB). The constant is named `_BYTES`, its comment says `1 MB`, and the function doc promises *"Files >1MB: skipped entirely (not in result map)"*. But the guard measured `String.length`:

```ts
if (fileDiff.length > MAX_DIFF_SIZE_BYTES) { continue }
```

`.length` counts UTF-16 code units, not bytes. Multibyte content (CJK/emoji are 3-4 UTF-8 bytes each) undercounts real size by up to ~4x, so a single-file diff of several MB in bytes but under 1M code units slips past the cap and is parsed and inserted into the result map — defeating the bound that keeps huge single-file diffs from bloating memory/context.

### Reachability
`fetchGitDiffHunks()` runs `git diff HEAD` and feeds the raw stdout to `parseGitDiff` for the diff viewer. A repo with CJK/emoji source or translation files produces exactly this multibyte diff.

### Fix
Measure with `Buffer.byteLength(fileDiff, 'utf8')`.

### Test
Adds a regression: a per-file diff under the cap in UTF-16 units but over it in bytes is now skipped (`.has('big.txt') === false`); passes before the fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of large file differences by accurately measuring multi-byte text.
  * Oversized differences are now consistently skipped when they exceed the 1 MB limit.

* **Tests**
  * Added regression coverage for large UTF-8 content to help prevent future parsing issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->