### PR TITLE
fix(context): order pruned messages by envelope timestamp, not phantom field

### DIFF
--- a/src/utils/relevancePruning.test.ts
+++ b/src/utils/relevancePruning.test.ts
@@ -141,4 +141,26 @@ describe('relevancePruning', () => {
       expect(stats.toolCallCount).toBeGreaterThanOrEqual(0)
     })
   })
+
+  describe('chronological ordering', () => {
+    // Production Message objects carry the chronological key on the envelope
+    // `timestamp` (an ISO string), not on `message.created_at`. Build that real
+    // shape here so the final "restore chronological order" sort is exercised.
+    function envMessage(idx: number): any {
+      return {
+        type: 'user',
+        uuid: `u${idx}`,
+        timestamp: new Date(1_700_000_000_000 + idx * 1000).toISOString(),
+        message: { role: 'user', content: `message number ${idx} content here`, id: `m${idx}` },
+      }
+    }
+
+    it('returns retained messages in chronological order', () => {
+      const messages = Array.from({ length: 8 }, (_, i) => envMessage(i))
+      // Large target keeps every group; with preserveRecent=3 the last three
+      // are sliced off first, so a broken final sort leaves them out front.
+      const result = pruneByRelevance(messages, { targetTokens: 1_000_000 })
+      expect(result.map(m => m.message.id)).toEqual(messages.map(m => m.message.id))
+    })
+  })
 })

--- a/src/utils/relevancePruning.ts
+++ b/src/utils/relevancePruning.ts
@@ -80,6 +80,19 @@ export function hasErrors(message: Message): boolean {
   return textContent.includes('error') || textContent.includes('fail') || textContent.includes('exception')
 }
 
+/**
+ * Chronological key for a message, in epoch milliseconds. Reads the envelope
+ * `timestamp` (an ISO-8601 string present on every Message variant), NOT
+ * `message.message.created_at` — that nested API-body field is never populated
+ * on our Message objects, so the old code always saw `undefined` and its
+ * recency scoring, tie-break and final chronological sort were all no-ops.
+ * Returns 0 for a missing/unparseable timestamp (sorts as oldest).
+ */
+function messageTimeMs(message: Message | undefined): number {
+  const parsed = message?.timestamp ? Date.parse(message.timestamp) : NaN
+  return Number.isNaN(parsed) ? 0 : parsed
+}
+
 export function calculateRelevance(
   message: Message,
   options: PruningOptions,
@@ -104,7 +117,7 @@ export function calculateRelevance(
     score += 0.3
   }
 
-  const ageHours = (Date.now() - (message.message?.created_at ?? 0)) / (1000 * 60 * 60)
+  const ageHours = (Date.now() - messageTimeMs(message)) / (1000 * 60 * 60)
   if (ageHours < 1) {
     score += 0.15
   }
@@ -169,8 +182,8 @@ export function pruneByRelevance(
 
   scored.sort((a, b) => {
     if (b.score !== a.score) return b.score - a.score
-    const aTime = a.group[0]?.message?.created_at ?? 0
-    const bTime = b.group[0]?.message?.created_at ?? 0
+    const aTime = messageTimeMs(a.group[0])
+    const bTime = messageTimeMs(b.group[0])
     return bTime - aTime
   })
 
@@ -191,7 +204,7 @@ export function pruneByRelevance(
     totalTokens += tokens
   }
 
-  return result.sort((a, b) => (a.message?.created_at ?? 0) - (b.message?.created_at ?? 0))
+  return result.sort((a, b) => messageTimeMs(a) - messageTimeMs(b))
 }
 
 export function getTopRelevantMessages(


### PR DESCRIPTION
### Problem
`pruneByRelevance` keyed recency scoring, the group tie-break, and the final "restore chronological order" sort off `message.message?.created_at`:

```ts
const ageHours = (Date.now() - (message.message?.created_at ?? 0)) / 3_600_000
...
const aTime = a.group[0]?.message?.created_at ?? 0   // tie-break
...
return result.sort((a, b) => (a.message?.created_at ?? 0) - (b.message?.created_at ?? 0))  // final
```

That nested API-body field is **never populated** on our `Message` objects (nothing in the tree assigns `created_at` to a message body; `message` has a `[key: string]: any` index signature so it type-checks but resolves to `undefined`). With `?? 0` every read is `0`, making all three no-ops:
- the `ageHours < 1` recency bonus never fires,
- the tie-break never breaks ties,
- the final sort is a no-op, so the result stays `[...recentMessages, ...olderSelectedGroups]` — the newest `preserveRecent` messages jump ahead of older retained ones.

The chronological key actually lives on the **envelope** as `timestamp` (an ISO-8601 string present on every `Message` variant, per `src/types/message.ts`).

### Reachability
`autoCompact` calls `pruneByRelevance` (with `preserveRecent: 3`) when the conversation can't fit the window; the reordered list becomes `finalMessages` and replaces the conversation, so out-of-order messages get sent to the model.

### Fix
Add a `messageTimeMs()` helper that parses the envelope `timestamp` and route all three sites through it.

### Test
Adds a regression built from the real envelope shape asserting retained messages stay in chronological order; fails before the fix (newest three appear first). Existing suite stays green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved message relevance pruning by correctly applying recency scoring based on message timestamps.
  * Preserved chronological order for retained messages, including when older messages are grouped and sorted.
  * Added handling for missing or invalid timestamps to ensure stable pruning behavior.

* **Tests**
  * Added coverage verifying that retained messages remain in their original chronological order.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->