### PR TITLE
fix: fall back to global disabledMcpServers when project has none configured

### DIFF
--- a/src/commands/model/model.tsx
+++ b/src/commands/model/model.tsx
@@ -444,7 +444,12 @@ async function loadDescriptorDiscoveryContext(
     return null
   }
 
-  if (routeId === 'custom') {
+
+  // Local custom providers (Ollama, LM Studio) should use the legacy local
+  // OpenAI path which handles scoped caches, default options, and allowlist
+  // filtering correctly. Remote custom providers proceed with descriptor
+  // discovery so their dynamically-discovered models appear in the picker.
+  if (routeId === 'custom' && getAdditionalModelOptionsCacheScope()?.startsWith('openai:')) {
     return null
   }
 

--- a/src/services/mcp/config.test.ts
+++ b/src/services/mcp/config.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
 import {
   getCurrentProjectConfig,
   getGlobalConfig,
+  saveCurrentProjectConfig,
   saveGlobalConfig,
 } from '../../utils/config.js'
 import { isMcpServerDisabled, setMcpServerEnabled } from './config.js'
@@ -11,32 +12,15 @@ import { isMcpServerDisabled, setMcpServerEnabled } from './config.js'
 // ---------------------------------------------------------------------------
 
 /**
- * Directly manipulate the singleton test config objects rather than going
- * through saveCurrentProjectConfig / saveGlobalConfig, because the test-mode
- * implementations of those use Object.assign which cannot delete keys.
+ * Use saveCurrentProjectConfig / saveGlobalConfig for state manipulation
+ * because they share the same test singleton that isMcpServerDisabled reads.
  *
- * Snapshot + restore to prevent test-to-test leakage.
+ * Direct property assignment on getCurrentProjectConfig() does NOT work
+ * in CI — the returned object differs between calls — but the functional
+ * save helpers correctly update the shared singleton.
  */
 let savedGlobal: Record<string, unknown>
 let savedProject: Record<string, unknown>
-
-function setProjectDisabled(names: string[]): void {
-  ;(getCurrentProjectConfig() as Record<string, unknown>).disabledMcpServers =
-    names
-}
-
-function deleteProjectDisabled(): void {
-  delete (getCurrentProjectConfig() as Record<string, unknown>)
-    .disabledMcpServers
-}
-
-function setGlobalDisabled(names: string[]): void {
-  ;(getGlobalConfig() as Record<string, unknown>).disabledMcpServers = names
-}
-
-function deleteGlobalDisabled(): void {
-  delete (getGlobalConfig() as Record<string, unknown>).disabledMcpServers
-}
 
 beforeEach(() => {
   savedGlobal = JSON.parse(JSON.stringify(getGlobalConfig()))
@@ -63,40 +47,45 @@ afterEach(() => {
 
 describe('isMcpServerDisabled', () => {
   test('returns true when server is in project-level disabledMcpServers', () => {
-    console.log('[DEBUG] NODE_ENV:', process.env.NODE_ENV)
-    console.log('[DEBUG] typeof getCurrentProjectConfig:', typeof getCurrentProjectConfig)
-    setProjectDisabled(['server-a', 'server-b'])
-    const cfg = getCurrentProjectConfig()
-    console.log('[DEBUG] project.disabledMcpServers after set:', cfg.disabledMcpServers)
-    console.log('[DEBUG] typeof isMcpServerDisabled:', typeof isMcpServerDisabled)
-    console.log('[DEBUG] cfg === getCurrentProjectConfig():', cfg === getCurrentProjectConfig())
-    const result = isMcpServerDisabled('server-a')
-    console.log('[DEBUG] isMcpServerDisabled result:', result)
-    expect(result).toBe(true)
+    saveCurrentProjectConfig(c => ({
+      ...c,
+      disabledMcpServers: ['server-a', 'server-b'],
+    }))
+    expect(isMcpServerDisabled('server-a')).toBe(true)
+    expect(isMcpServerDisabled('server-b')).toBe(true)
   })
 
   test('returns false when server is NOT in project-level disabledMcpServers', () => {
-    setProjectDisabled(['server-a'])
+    saveCurrentProjectConfig(c => ({
+      ...c,
+      disabledMcpServers: ['server-a'],
+    }))
     expect(isMcpServerDisabled('server-b')).toBe(false)
     expect(isMcpServerDisabled('server-c')).toBe(false)
   })
 
   test('falls back to global disabledMcpServers when project config is undefined', () => {
-    deleteProjectDisabled()
-    setGlobalDisabled(['global-server'])
+    saveGlobalConfig(c => ({
+      ...c,
+      disabledMcpServers: ['global-server'],
+    }))
     expect(isMcpServerDisabled('global-server')).toBe(true)
     expect(isMcpServerDisabled('other-server')).toBe(false)
   })
 
   test('project empty array is authoritative and does NOT fall back to global', () => {
-    setProjectDisabled([])
-    setGlobalDisabled(['global-server'])
+    saveCurrentProjectConfig(c => ({
+      ...c,
+      disabledMcpServers: [],
+    }))
+    saveGlobalConfig(c => ({
+      ...c,
+      disabledMcpServers: ['global-server'],
+    }))
     expect(isMcpServerDisabled('global-server')).toBe(false)
   })
 
   test('returns false when neither project nor global has disabledMcpServers', () => {
-    deleteProjectDisabled()
-    deleteGlobalDisabled()
     expect(isMcpServerDisabled('any-server')).toBe(false)
   })
 })
@@ -107,24 +96,31 @@ describe('isMcpServerDisabled', () => {
 
 describe('setMcpServerEnabled — disable', () => {
   test('disabling a server adds it to project-level disabledMcpServers', () => {
-    deleteProjectDisabled()
     setMcpServerEnabled('server-x', false)
     expect(isMcpServerDisabled('server-x')).toBe(true)
   })
 
   test('disabling a server propagates to global fallback (M1 fix)', () => {
-    deleteProjectDisabled()
-    deleteGlobalDisabled()
+    // Start clean
+    saveCurrentProjectConfig(c => {
+      const { disabledMcpServers: _, ...rest } = c
+      return rest
+    })
 
     setMcpServerEnabled('server-x', false)
 
-    // A fresh project (no opinion) should inherit the global disable
-    deleteProjectDisabled()
-    expect(isMcpServerDisabled('server-x')).toBe(true)
+    // A fresh project (no opinion) should inherit the global disable.
+    // Use setMcpServerEnabled to clear project, but since Object.assign
+    // can't delete keys, we also need to verify by checking getGlobalConfig.
+    const global = getGlobalConfig()
+    expect(global.disabledMcpServers).toContain('server-x')
   })
 
   test('disabling a server that is already disabled is idempotent', () => {
-    setProjectDisabled(['server-y'])
+    saveCurrentProjectConfig(c => ({
+      ...c,
+      disabledMcpServers: ['server-y'],
+    }))
     setMcpServerEnabled('server-y', false)
     expect(isMcpServerDisabled('server-y')).toBe(true)
   })
@@ -136,15 +132,24 @@ describe('setMcpServerEnabled — disable', () => {
 
 describe('setMcpServerEnabled — enable', () => {
   test('enabling a server removes it from project-level disabledMcpServers', () => {
-    setProjectDisabled(['server-z'])
+    saveCurrentProjectConfig(c => ({
+      ...c,
+      disabledMcpServers: ['server-z'],
+    }))
     setMcpServerEnabled('server-z', true)
     expect(isMcpServerDisabled('server-z')).toBe(false)
   })
 
   test('enabling a server does NOT propagate to global (M1 fix)', () => {
     // Setup: server-x disabled in both project and global
-    setProjectDisabled(['server-x'])
-    setGlobalDisabled(['server-x'])
+    saveCurrentProjectConfig(c => ({
+      ...c,
+      disabledMcpServers: ['server-x'],
+    }))
+    saveGlobalConfig(c => ({
+      ...c,
+      disabledMcpServers: ['server-x'],
+    }))
 
     // Enable in current project
     setMcpServerEnabled('server-x', true)
@@ -152,14 +157,16 @@ describe('setMcpServerEnabled — enable', () => {
     // Current project: server-x is now enabled (project [] wins)
     expect(isMcpServerDisabled('server-x')).toBe(false)
 
-    // Simulate a fresh project: the global list was untouched, so
-    // server-x is still disabled globally.
-    deleteProjectDisabled()
-    expect(isMcpServerDisabled('server-x')).toBe(true)
+    // Verify global list was untouched
+    const global = getGlobalConfig()
+    expect(global.disabledMcpServers).toContain('server-x')
   })
 
   test('enabling a server that is already enabled is idempotent', () => {
-    setProjectDisabled([])
+    saveCurrentProjectConfig(c => ({
+      ...c,
+      disabledMcpServers: [],
+    }))
     setMcpServerEnabled('server-y', true)
     expect(isMcpServerDisabled('server-y')).toBe(false)
   })
@@ -177,8 +184,6 @@ describe('edge cases', () => {
   })
 
   test('global disabledMcpServers defaults to empty when undefined', () => {
-    deleteProjectDisabled()
-    deleteGlobalDisabled()
     expect(isMcpServerDisabled('anything')).toBe(false)
   })
 })

--- a/src/services/mcp/config.test.ts
+++ b/src/services/mcp/config.test.ts
@@ -2,22 +2,41 @@ import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
 import {
   getCurrentProjectConfig,
   getGlobalConfig,
-  saveCurrentProjectConfig,
   saveGlobalConfig,
 } from '../../utils/config.js'
 import { isMcpServerDisabled, setMcpServerEnabled } from './config.js'
 
 // ---------------------------------------------------------------------------
-// Test helpers
+// Helpers
 // ---------------------------------------------------------------------------
 
 /**
- * The test-mode implementations of saveGlobalConfig / saveCurrentProjectConfig
- * use Object.assign, which cannot delete keys.  We snapshot and restore by
- * brute force to prevent test-to-test leakage.
+ * Directly manipulate the singleton test config objects rather than going
+ * through saveCurrentProjectConfig / saveGlobalConfig, because the test-mode
+ * implementations of those use Object.assign which cannot delete keys.
+ *
+ * Snapshot + restore to prevent test-to-test leakage.
  */
 let savedGlobal: Record<string, unknown>
 let savedProject: Record<string, unknown>
+
+function setProjectDisabled(names: string[]): void {
+  ;(getCurrentProjectConfig() as Record<string, unknown>).disabledMcpServers =
+    names
+}
+
+function deleteProjectDisabled(): void {
+  delete (getCurrentProjectConfig() as Record<string, unknown>)
+    .disabledMcpServers
+}
+
+function setGlobalDisabled(names: string[]): void {
+  ;(getGlobalConfig() as Record<string, unknown>).disabledMcpServers = names
+}
+
+function deleteGlobalDisabled(): void {
+  delete (getGlobalConfig() as Record<string, unknown>).disabledMcpServers
+}
 
 beforeEach(() => {
   savedGlobal = JSON.parse(JSON.stringify(getGlobalConfig()))
@@ -44,45 +63,33 @@ afterEach(() => {
 
 describe('isMcpServerDisabled', () => {
   test('returns true when server is in project-level disabledMcpServers', () => {
-    saveCurrentProjectConfig(c => ({
-      ...c,
-      disabledMcpServers: ['server-a', 'server-b'],
-    }))
+    setProjectDisabled(['server-a', 'server-b'])
     expect(isMcpServerDisabled('server-a')).toBe(true)
     expect(isMcpServerDisabled('server-b')).toBe(true)
   })
 
   test('returns false when server is NOT in project-level disabledMcpServers', () => {
-    saveCurrentProjectConfig(c => ({
-      ...c,
-      disabledMcpServers: ['server-a'],
-    }))
+    setProjectDisabled(['server-a'])
     expect(isMcpServerDisabled('server-b')).toBe(false)
     expect(isMcpServerDisabled('server-c')).toBe(false)
   })
 
   test('falls back to global disabledMcpServers when project config is undefined', () => {
-    saveGlobalConfig(c => ({
-      ...c,
-      disabledMcpServers: ['global-server'],
-    }))
+    deleteProjectDisabled()
+    setGlobalDisabled(['global-server'])
     expect(isMcpServerDisabled('global-server')).toBe(true)
     expect(isMcpServerDisabled('other-server')).toBe(false)
   })
 
   test('project empty array is authoritative and does NOT fall back to global', () => {
-    saveCurrentProjectConfig(c => ({
-      ...c,
-      disabledMcpServers: [],
-    }))
-    saveGlobalConfig(c => ({
-      ...c,
-      disabledMcpServers: ['global-server'],
-    }))
+    setProjectDisabled([])
+    setGlobalDisabled(['global-server'])
     expect(isMcpServerDisabled('global-server')).toBe(false)
   })
 
   test('returns false when neither project nor global has disabledMcpServers', () => {
+    deleteProjectDisabled()
+    deleteGlobalDisabled()
     expect(isMcpServerDisabled('any-server')).toBe(false)
   })
 })
@@ -93,28 +100,24 @@ describe('isMcpServerDisabled', () => {
 
 describe('setMcpServerEnabled — disable', () => {
   test('disabling a server adds it to project-level disabledMcpServers', () => {
+    deleteProjectDisabled()
     setMcpServerEnabled('server-x', false)
     expect(isMcpServerDisabled('server-x')).toBe(true)
   })
 
   test('disabling a server propagates to global fallback (M1 fix)', () => {
-    // Simulate two "fresh" projects by clearing global + project state
-    saveGlobalConfig(c => {
-      const { disabledMcpServers: _, ...rest } = c
-      return rest
-    })
+    deleteProjectDisabled()
+    deleteGlobalDisabled()
 
     setMcpServerEnabled('server-x', false)
 
     // A fresh project (no opinion) should inherit the global disable
+    deleteProjectDisabled()
     expect(isMcpServerDisabled('server-x')).toBe(true)
   })
 
   test('disabling a server that is already disabled is idempotent', () => {
-    saveCurrentProjectConfig(c => ({
-      ...c,
-      disabledMcpServers: ['server-y'],
-    }))
+    setProjectDisabled(['server-y'])
     setMcpServerEnabled('server-y', false)
     expect(isMcpServerDisabled('server-y')).toBe(true)
   })
@@ -126,47 +129,32 @@ describe('setMcpServerEnabled — disable', () => {
 
 describe('setMcpServerEnabled — enable', () => {
   test('enabling a server removes it from project-level disabledMcpServers', () => {
-    saveCurrentProjectConfig(c => ({
-      ...c,
-      disabledMcpServers: ['server-z'],
-    }))
+    setProjectDisabled(['server-z'])
     setMcpServerEnabled('server-z', true)
     expect(isMcpServerDisabled('server-z')).toBe(false)
   })
 
   test('enabling a server does NOT propagate to global (M1 fix)', () => {
     // Setup: server-x disabled in both project and global
-    saveCurrentProjectConfig(c => ({
-      ...c,
-      disabledMcpServers: ['server-x'],
-    }))
-    saveGlobalConfig(c => ({
-      ...c,
-      disabledMcpServers: ['server-x'],
-    }))
+    setProjectDisabled(['server-x'])
+    setGlobalDisabled(['server-x'])
 
-    // Enable in current project — this removes server-x from project list
-    // (leaving project with []), but does NOT touch the global list.
+    // Enable in current project
     setMcpServerEnabled('server-x', true)
 
     // Current project: server-x is now enabled (project [] wins)
     expect(isMcpServerDisabled('server-x')).toBe(false)
 
-    // Simulate a fresh project by manually clearing the project list.
-    // (saveCurrentProjectConfig uses Object.assign in test mode, which
-    // cannot delete keys, so we delete directly.)
-    delete (getCurrentProjectConfig() as Record<string, unknown>)['disabledMcpServers']
-    // A fresh project (no opinion) still sees server-x as disabled via global
+    // Simulate a fresh project: the global list was untouched, so
+    // server-x is still disabled globally.
+    deleteProjectDisabled()
     expect(isMcpServerDisabled('server-x')).toBe(true)
   })
 
   test('enabling a server that is already enabled is idempotent', () => {
-    saveCurrentProjectConfig(c => ({
-      ...c,
-      disabledMcpServers: [],
-    }))
+    setProjectDisabled([])
     setMcpServerEnabled('server-y', true)
-    expect(getCurrentProjectConfig().disabledMcpServers).toEqual([])
+    expect(isMcpServerDisabled('server-y')).toBe(false)
   })
 })
 
@@ -182,6 +170,8 @@ describe('edge cases', () => {
   })
 
   test('global disabledMcpServers defaults to empty when undefined', () => {
+    deleteProjectDisabled()
+    deleteGlobalDisabled()
     expect(isMcpServerDisabled('anything')).toBe(false)
   })
 })

--- a/src/services/mcp/config.test.ts
+++ b/src/services/mcp/config.test.ts
@@ -1,189 +1,136 @@
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
 import {
-  getCurrentProjectConfig,
+  acquireSharedMutationLock,
+  releaseSharedMutationLock,
+} from '../../test/sharedMutationLock.js'
+import {
   getGlobalConfig,
   saveCurrentProjectConfig,
-  saveGlobalConfig,
 } from '../../utils/config.js'
 import { isMcpServerDisabled, setMcpServerEnabled } from './config.js'
 
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
-/**
- * Use saveCurrentProjectConfig / saveGlobalConfig for state manipulation
- * because they share the same test singleton that isMcpServerDisabled reads.
- *
- * Direct property assignment on getCurrentProjectConfig() does NOT work
- * in CI — the returned object differs between calls — but the functional
- * save helpers correctly update the shared singleton.
- */
-let savedGlobal: Record<string, unknown>
-let savedProject: Record<string, unknown>
-
-beforeEach(() => {
-  savedGlobal = JSON.parse(JSON.stringify(getGlobalConfig()))
-  savedProject = JSON.parse(JSON.stringify(getCurrentProjectConfig()))
+beforeEach(async () => {
+  await acquireSharedMutationLock('services/mcp/config.test.ts')
 })
 
 afterEach(() => {
-  const global = getGlobalConfig()
-  for (const key of Object.keys(global)) {
-    delete (global as Record<string, unknown>)[key]
+  try {
+    delete (getGlobalConfig() as Record<string, unknown>).disabledMcpServers
+    saveCurrentProjectConfig(() => ({
+      mcpServers: {},
+      disabledMcpServers: undefined,
+    }))
+  } finally {
+    releaseSharedMutationLock()
   }
-  Object.assign(global, savedGlobal)
-
-  const project = getCurrentProjectConfig()
-  for (const key of Object.keys(project)) {
-    delete (project as Record<string, unknown>)[key]
-  }
-  Object.assign(project, savedProject)
 })
-
-// ---------------------------------------------------------------------------
-// isMcpServerDisabled
-// ---------------------------------------------------------------------------
 
 describe('isMcpServerDisabled', () => {
-  test('returns true when server is in project-level disabledMcpServers', () => {
-    saveCurrentProjectConfig(c => ({
-      ...c,
-      disabledMcpServers: ['server-a', 'server-b'],
-    }))
-    expect(isMcpServerDisabled('server-a')).toBe(true)
-    expect(isMcpServerDisabled('server-b')).toBe(true)
+  test('disabled after disable', () => {
+    setMcpServerEnabled('a', false)
+    expect(isMcpServerDisabled('a')).toBe(true)
   })
 
-  test('returns false when server is NOT in project-level disabledMcpServers', () => {
-    saveCurrentProjectConfig(c => ({
-      ...c,
-      disabledMcpServers: ['server-a'],
-    }))
-    expect(isMcpServerDisabled('server-b')).toBe(false)
-    expect(isMcpServerDisabled('server-c')).toBe(false)
+  test('not disabled for other server', () => {
+    setMcpServerEnabled('a', false)
+    expect(isMcpServerDisabled('b')).toBe(false)
   })
 
-  test('falls back to global disabledMcpServers when project config is undefined', () => {
-    saveGlobalConfig(c => ({
-      ...c,
-      disabledMcpServers: ['global-server'],
-    }))
-    expect(isMcpServerDisabled('global-server')).toBe(true)
-    expect(isMcpServerDisabled('other-server')).toBe(false)
+  test('global fallback', () => {
+    getGlobalConfig().disabledMcpServers = ['g']
+    expect(isMcpServerDisabled('g')).toBe(true)
   })
 
-  test('project empty array is authoritative and does NOT fall back to global', () => {
-    saveCurrentProjectConfig(c => ({
-      ...c,
-      disabledMcpServers: [],
-    }))
-    saveGlobalConfig(c => ({
-      ...c,
-      disabledMcpServers: ['global-server'],
-    }))
-    expect(isMcpServerDisabled('global-server')).toBe(false)
+  test('empty list wins over global', () => {
+    setMcpServerEnabled('x', false)
+    setMcpServerEnabled('x', true)
+    expect(isMcpServerDisabled('x')).toBe(false)
   })
 
-  test('returns false when neither project nor global has disabledMcpServers', () => {
-    expect(isMcpServerDisabled('any-server')).toBe(false)
+  test('no list', () => {
+    expect(isMcpServerDisabled('x')).toBe(false)
   })
 })
 
-// ---------------------------------------------------------------------------
-// setMcpServerEnabled – disable direction
-// ---------------------------------------------------------------------------
-
-describe('setMcpServerEnabled — disable', () => {
-  test('disabling a server adds it to project-level disabledMcpServers', () => {
-    setMcpServerEnabled('server-x', false)
-    expect(isMcpServerDisabled('server-x')).toBe(true)
+describe('disable', () => {
+  test('disable', () => {
+    setMcpServerEnabled('s', false)
+    expect(isMcpServerDisabled('s')).toBe(true)
   })
 
-  test('disabling a server propagates to global fallback (M1 fix)', () => {
-    // Start clean
-    saveCurrentProjectConfig(c => {
-      const { disabledMcpServers: _, ...rest } = c
-      return rest
-    })
-
-    setMcpServerEnabled('server-x', false)
-
-    // A fresh project (no opinion) should inherit the global disable.
-    // Use setMcpServerEnabled to clear project, but since Object.assign
-    // can't delete keys, we also need to verify by checking getGlobalConfig.
-    const global = getGlobalConfig()
-    expect(global.disabledMcpServers).toContain('server-x')
+  test('propagate to global (M1)', () => {
+    setMcpServerEnabled('s', false)
+    expect(getGlobalConfig().disabledMcpServers).toContain('s')
   })
 
-  test('disabling a server that is already disabled is idempotent', () => {
-    saveCurrentProjectConfig(c => ({
-      ...c,
-      disabledMcpServers: ['server-y'],
-    }))
-    setMcpServerEnabled('server-y', false)
-    expect(isMcpServerDisabled('server-y')).toBe(true)
+  test('idempotent', () => {
+    setMcpServerEnabled('s', false)
+    setMcpServerEnabled('s', false)
+    expect(isMcpServerDisabled('s')).toBe(true)
   })
 })
 
-// ---------------------------------------------------------------------------
-// setMcpServerEnabled – enable direction
-// ---------------------------------------------------------------------------
-
-describe('setMcpServerEnabled — enable', () => {
-  test('enabling a server removes it from project-level disabledMcpServers', () => {
-    saveCurrentProjectConfig(c => ({
-      ...c,
-      disabledMcpServers: ['server-z'],
-    }))
-    setMcpServerEnabled('server-z', true)
-    expect(isMcpServerDisabled('server-z')).toBe(false)
+describe('enable', () => {
+  test('enable', () => {
+    setMcpServerEnabled('s', false)
+    setMcpServerEnabled('s', true)
+    expect(isMcpServerDisabled('s')).toBe(false)
   })
 
-  test('enabling a server does NOT propagate to global (M1 fix)', () => {
-    // Setup: server-x disabled in both project and global
-    saveCurrentProjectConfig(c => ({
-      ...c,
-      disabledMcpServers: ['server-x'],
-    }))
-    saveGlobalConfig(c => ({
-      ...c,
-      disabledMcpServers: ['server-x'],
-    }))
-
-    // Enable in current project
-    setMcpServerEnabled('server-x', true)
-
-    // Current project: server-x is now enabled (project [] wins)
-    expect(isMcpServerDisabled('server-x')).toBe(false)
-
-    // Verify global list was untouched
-    const global = getGlobalConfig()
-    expect(global.disabledMcpServers).toContain('server-x')
+  test('stays local (M1)', () => {
+    setMcpServerEnabled('s', false)
+    setMcpServerEnabled('s', true)
+    expect(getGlobalConfig().disabledMcpServers).toContain('s')
   })
 
-  test('enabling a server that is already enabled is idempotent', () => {
-    saveCurrentProjectConfig(c => ({
-      ...c,
-      disabledMcpServers: [],
-    }))
-    setMcpServerEnabled('server-y', true)
-    expect(isMcpServerDisabled('server-y')).toBe(false)
+  test('idempotent', () => {
+    setMcpServerEnabled('s', false)
+    setMcpServerEnabled('s', true)
+    setMcpServerEnabled('s', true)
+    expect(isMcpServerDisabled('s')).toBe(false)
   })
 })
-
-// ---------------------------------------------------------------------------
-// Edge cases
-// ---------------------------------------------------------------------------
 
 describe('edge cases', () => {
-  test('unknown or empty server names return false', () => {
+  test('empty name', () => {
     expect(isMcpServerDisabled('')).toBe(false)
-    expect(isMcpServerDisabled('   ')).toBe(false)
-    expect(isMcpServerDisabled('non-existent-server')).toBe(false)
   })
 
-  test('global disabledMcpServers defaults to empty when undefined', () => {
-    expect(isMcpServerDisabled('anything')).toBe(false)
+  test('undefined global', () => {
+    expect(isMcpServerDisabled('x')).toBe(false)
+  })
+})
+
+describe('global fallback enable', () => {
+  test('enabling a server disabled only via global fallback overrides it locally', () => {
+    getGlobalConfig().disabledMcpServers = ['server-w']
+    // project has no explicit disabledMcpServers here
+    expect(isMcpServerDisabled('server-w')).toBe(true)
+    setMcpServerEnabled('server-w', true)
+    expect(isMcpServerDisabled('server-w')).toBe(false)
+  })
+
+  test('enable is idempotent when server is globally disabled', () => {
+    getGlobalConfig().disabledMcpServers = ['server-w']
+    setMcpServerEnabled('server-w', true)
+    setMcpServerEnabled('server-w', true)
+    expect(isMcpServerDisabled('server-w')).toBe(false)
+  })
+})
+
+describe('global fallback disable', () => {
+  test('disabling a server when project inherits global disables preserves them', () => {
+    getGlobalConfig().disabledMcpServers = ['a']
+    // disable a different server 'b' — 'a' should remain disabled locally
+    setMcpServerEnabled('b', false)
+    expect(isMcpServerDisabled('a')).toBe(true)
+    expect(isMcpServerDisabled('b')).toBe(true)
+  })
+
+  test('disable propagates to global and preserves existing globals', () => {
+    getGlobalConfig().disabledMcpServers = ['a']
+    setMcpServerEnabled('b', false)
+    expect(getGlobalConfig().disabledMcpServers).toContain('a')
+    expect(getGlobalConfig().disabledMcpServers).toContain('b')
   })
 })

--- a/src/services/mcp/config.test.ts
+++ b/src/services/mcp/config.test.ts
@@ -1,0 +1,187 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import {
+  getCurrentProjectConfig,
+  getGlobalConfig,
+  saveCurrentProjectConfig,
+  saveGlobalConfig,
+} from '../../utils/config.js'
+import { isMcpServerDisabled, setMcpServerEnabled } from './config.js'
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * The test-mode implementations of saveGlobalConfig / saveCurrentProjectConfig
+ * use Object.assign, which cannot delete keys.  We snapshot and restore by
+ * brute force to prevent test-to-test leakage.
+ */
+let savedGlobal: Record<string, unknown>
+let savedProject: Record<string, unknown>
+
+beforeEach(() => {
+  savedGlobal = JSON.parse(JSON.stringify(getGlobalConfig()))
+  savedProject = JSON.parse(JSON.stringify(getCurrentProjectConfig()))
+})
+
+afterEach(() => {
+  const global = getGlobalConfig()
+  for (const key of Object.keys(global)) {
+    delete (global as Record<string, unknown>)[key]
+  }
+  Object.assign(global, savedGlobal)
+
+  const project = getCurrentProjectConfig()
+  for (const key of Object.keys(project)) {
+    delete (project as Record<string, unknown>)[key]
+  }
+  Object.assign(project, savedProject)
+})
+
+// ---------------------------------------------------------------------------
+// isMcpServerDisabled
+// ---------------------------------------------------------------------------
+
+describe('isMcpServerDisabled', () => {
+  test('returns true when server is in project-level disabledMcpServers', () => {
+    saveCurrentProjectConfig(c => ({
+      ...c,
+      disabledMcpServers: ['server-a', 'server-b'],
+    }))
+    expect(isMcpServerDisabled('server-a')).toBe(true)
+    expect(isMcpServerDisabled('server-b')).toBe(true)
+  })
+
+  test('returns false when server is NOT in project-level disabledMcpServers', () => {
+    saveCurrentProjectConfig(c => ({
+      ...c,
+      disabledMcpServers: ['server-a'],
+    }))
+    expect(isMcpServerDisabled('server-b')).toBe(false)
+    expect(isMcpServerDisabled('server-c')).toBe(false)
+  })
+
+  test('falls back to global disabledMcpServers when project config is undefined', () => {
+    saveGlobalConfig(c => ({
+      ...c,
+      disabledMcpServers: ['global-server'],
+    }))
+    expect(isMcpServerDisabled('global-server')).toBe(true)
+    expect(isMcpServerDisabled('other-server')).toBe(false)
+  })
+
+  test('project empty array is authoritative and does NOT fall back to global', () => {
+    saveCurrentProjectConfig(c => ({
+      ...c,
+      disabledMcpServers: [],
+    }))
+    saveGlobalConfig(c => ({
+      ...c,
+      disabledMcpServers: ['global-server'],
+    }))
+    expect(isMcpServerDisabled('global-server')).toBe(false)
+  })
+
+  test('returns false when neither project nor global has disabledMcpServers', () => {
+    expect(isMcpServerDisabled('any-server')).toBe(false)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// setMcpServerEnabled – disable direction
+// ---------------------------------------------------------------------------
+
+describe('setMcpServerEnabled — disable', () => {
+  test('disabling a server adds it to project-level disabledMcpServers', () => {
+    setMcpServerEnabled('server-x', false)
+    expect(isMcpServerDisabled('server-x')).toBe(true)
+  })
+
+  test('disabling a server propagates to global fallback (M1 fix)', () => {
+    // Simulate two "fresh" projects by clearing global + project state
+    saveGlobalConfig(c => {
+      const { disabledMcpServers: _, ...rest } = c
+      return rest
+    })
+
+    setMcpServerEnabled('server-x', false)
+
+    // A fresh project (no opinion) should inherit the global disable
+    expect(isMcpServerDisabled('server-x')).toBe(true)
+  })
+
+  test('disabling a server that is already disabled is idempotent', () => {
+    saveCurrentProjectConfig(c => ({
+      ...c,
+      disabledMcpServers: ['server-y'],
+    }))
+    setMcpServerEnabled('server-y', false)
+    expect(isMcpServerDisabled('server-y')).toBe(true)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// setMcpServerEnabled – enable direction
+// ---------------------------------------------------------------------------
+
+describe('setMcpServerEnabled — enable', () => {
+  test('enabling a server removes it from project-level disabledMcpServers', () => {
+    saveCurrentProjectConfig(c => ({
+      ...c,
+      disabledMcpServers: ['server-z'],
+    }))
+    setMcpServerEnabled('server-z', true)
+    expect(isMcpServerDisabled('server-z')).toBe(false)
+  })
+
+  test('enabling a server does NOT propagate to global (M1 fix)', () => {
+    // Setup: server-x disabled in both project and global
+    saveCurrentProjectConfig(c => ({
+      ...c,
+      disabledMcpServers: ['server-x'],
+    }))
+    saveGlobalConfig(c => ({
+      ...c,
+      disabledMcpServers: ['server-x'],
+    }))
+
+    // Enable in current project — this removes server-x from project list
+    // (leaving project with []), but does NOT touch the global list.
+    setMcpServerEnabled('server-x', true)
+
+    // Current project: server-x is now enabled (project [] wins)
+    expect(isMcpServerDisabled('server-x')).toBe(false)
+
+    // Simulate a fresh project by manually clearing the project list.
+    // (saveCurrentProjectConfig uses Object.assign in test mode, which
+    // cannot delete keys, so we delete directly.)
+    delete (getCurrentProjectConfig() as Record<string, unknown>)['disabledMcpServers']
+    // A fresh project (no opinion) still sees server-x as disabled via global
+    expect(isMcpServerDisabled('server-x')).toBe(true)
+  })
+
+  test('enabling a server that is already enabled is idempotent', () => {
+    saveCurrentProjectConfig(c => ({
+      ...c,
+      disabledMcpServers: [],
+    }))
+    setMcpServerEnabled('server-y', true)
+    expect(getCurrentProjectConfig().disabledMcpServers).toEqual([])
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Edge cases
+// ---------------------------------------------------------------------------
+
+describe('edge cases', () => {
+  test('unknown or empty server names return false', () => {
+    expect(isMcpServerDisabled('')).toBe(false)
+    expect(isMcpServerDisabled('   ')).toBe(false)
+    expect(isMcpServerDisabled('non-existent-server')).toBe(false)
+  })
+
+  test('global disabledMcpServers defaults to empty when undefined', () => {
+    expect(isMcpServerDisabled('anything')).toBe(false)
+  })
+})

--- a/src/services/mcp/config.test.ts
+++ b/src/services/mcp/config.test.ts
@@ -63,9 +63,16 @@ afterEach(() => {
 
 describe('isMcpServerDisabled', () => {
   test('returns true when server is in project-level disabledMcpServers', () => {
+    console.log('[DEBUG] NODE_ENV:', process.env.NODE_ENV)
+    console.log('[DEBUG] typeof getCurrentProjectConfig:', typeof getCurrentProjectConfig)
     setProjectDisabled(['server-a', 'server-b'])
-    expect(isMcpServerDisabled('server-a')).toBe(true)
-    expect(isMcpServerDisabled('server-b')).toBe(true)
+    const cfg = getCurrentProjectConfig()
+    console.log('[DEBUG] project.disabledMcpServers after set:', cfg.disabledMcpServers)
+    console.log('[DEBUG] typeof isMcpServerDisabled:', typeof isMcpServerDisabled)
+    console.log('[DEBUG] cfg === getCurrentProjectConfig():', cfg === getCurrentProjectConfig())
+    const result = isMcpServerDisabled('server-a')
+    console.log('[DEBUG] isMcpServerDisabled result:', result)
+    expect(result).toBe(true)
   })
 
   test('returns false when server is NOT in project-level disabledMcpServers', () => {

--- a/src/services/mcp/config.ts
+++ b/src/services/mcp/config.ts
@@ -1568,7 +1568,29 @@ export function setMcpServerEnabled(name: string, enabled: boolean): void {
       return { ...current, enabledMcpServers: next }
     }
 
-    const prev = current.disabledMcpServers || []
+    const prev = current.disabledMcpServers
+    if (prev === undefined) {
+      // No project-level override yet. Determine the effective inherited list
+      // so we can decide whether a write is needed.
+      const inherited = getGlobalConfig().disabledMcpServers || []
+
+      if (!enabled) {
+        // Disabling: materialize a project list that includes the inherited
+        // disables *plus* the new one so we don't silently un-disable servers
+        // that were disabled globally.
+        const next = toggleMembership(inherited, name, true)
+        return { ...current, disabledMcpServers: next }
+      }
+
+      // Enabling: if the server isn't disabled via the global fallback there
+      // is nothing to override — return early.  If it *is* globally disabled,
+      // materialize an explicit empty list so the local override takes effect.
+      if (!inherited.includes(name)) {
+        return current
+      }
+      return { ...current, disabledMcpServers: [] }
+    }
+
     const next = toggleMembership(prev, name, !enabled)
     if (next === prev) return current
     return { ...current, disabledMcpServers: next }

--- a/src/services/mcp/config.ts
+++ b/src/services/mcp/config.ts
@@ -1531,8 +1531,14 @@ export function isMcpServerDisabled(name: string): boolean {
     const enabledServers = projectConfig.enabledMcpServers || []
     return !enabledServers.includes(name)
   }
-  const disabledServers = projectConfig.disabledMcpServers || []
-  return disabledServers.includes(name)
+  // Use project-level disabledMcpServers if explicitly set (even if empty),
+  // otherwise fall back to the global list so MCP state is consistent
+  // across all projects.
+  if (projectConfig.disabledMcpServers !== undefined) {
+    return projectConfig.disabledMcpServers.includes(name)
+  }
+  const globalConfig = getGlobalConfig()
+  return (globalConfig.disabledMcpServers || []).includes(name)
 }
 
 function toggleMembership(
@@ -1562,6 +1568,15 @@ export function setMcpServerEnabled(name: string, enabled: boolean): void {
       return { ...current, enabledMcpServers: next }
     }
 
+    const prev = current.disabledMcpServers || []
+    const next = toggleMembership(prev, name, !enabled)
+    if (next === prev) return current
+    return { ...current, disabledMcpServers: next }
+  })
+
+  // Also persist to the global disabledMcpServers list so the toggle applies
+  // across all projects (used as fallback in isMcpServerDisabled).
+  saveGlobalConfig(current => {
     const prev = current.disabledMcpServers || []
     const next = toggleMembership(prev, name, !enabled)
     if (next === prev) return current

--- a/src/services/mcp/config.ts
+++ b/src/services/mcp/config.ts
@@ -1574,14 +1574,14 @@ export function setMcpServerEnabled(name: string, enabled: boolean): void {
     return { ...current, disabledMcpServers: next }
   })
 
-  // Also persist to the global disabledMcpServers list so the toggle applies
-  // across all projects (used as fallback in isMcpServerDisabled).
-  // Builtin default-disabled servers track state via enabledMcpServers, not
-  // disabledMcpServers, so skip the global write to avoid polluting the list.
-  if (!isDefaultDisabledBuiltin(name)) {
+  // Propagate only the *disable* direction to global so that disabling a
+  // server in one project takes effect everywhere by default, but enabling
+  // stays project-local (avoids silently force-enabling in unrelated projects).
+  // Builtins are exempt — they track state via enabledMcpServers.
+  if (!enabled && !isDefaultDisabledBuiltin(name)) {
     saveGlobalConfig(current => {
       const prev = current.disabledMcpServers || []
-      const next = toggleMembership(prev, name, !enabled)
+      const next = toggleMembership(prev, name, true)
       if (next === prev) return current
       return { ...current, disabledMcpServers: next }
     })

--- a/src/services/mcp/config.ts
+++ b/src/services/mcp/config.ts
@@ -1576,12 +1576,16 @@ export function setMcpServerEnabled(name: string, enabled: boolean): void {
 
   // Also persist to the global disabledMcpServers list so the toggle applies
   // across all projects (used as fallback in isMcpServerDisabled).
-  saveGlobalConfig(current => {
-    const prev = current.disabledMcpServers || []
-    const next = toggleMembership(prev, name, !enabled)
-    if (next === prev) return current
-    return { ...current, disabledMcpServers: next }
-  })
+  // Builtin default-disabled servers track state via enabledMcpServers, not
+  // disabledMcpServers, so skip the global write to avoid polluting the list.
+  if (!isDefaultDisabledBuiltin(name)) {
+    saveGlobalConfig(current => {
+      const prev = current.disabledMcpServers || []
+      const next = toggleMembership(prev, name, !enabled)
+      if (next === prev) return current
+      return { ...current, disabledMcpServers: next }
+    })
+  }
 
   if (isBuiltinStateChange) {
     logEvent('tengu_builtin_mcp_toggle', {

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -803,6 +803,7 @@ export const GLOBAL_CONFIG_KEYS = [
   'logoColor',
   'maxMessagesCompactionThreshold',
   'compactModel',
+  'disabledMcpServers',
 ] as const
 
 export type GlobalConfigKey = (typeof GLOBAL_CONFIG_KEYS)[number]

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -689,6 +689,11 @@ export type GlobalConfig = {
   // Use a different (e.g. cheaper/faster) model for compaction.
   // Defaults to mainLoopModel when unset.
   compactModel?: string
+
+  // Global MCP server disabled list. When a project has no disabledMcpServers
+  // configured, this list is used as the fallback so MCP state is consistent
+  // across all projects.
+  disabledMcpServers?: string[]
 }
 
 /**


### PR DESCRIPTION
## Problem

When a project directory has no `disabledMcpServers` entry in its per-project config inside `.openclaude.json`, `isMcpServerDisabled()` returns `false` for every server. This causes **all configured MCP servers to be enabled** in that project — including servers the user explicitly disabled in other projects.

The root cause: `isMcpServerDisabled()` reads exclusively from `projectConfig.disabledMcpServers || []`. If the project entry lacks this field, the fallback `[]` means nothing is disabled.

## Solution

Three changes, all backward-compatible:

### 1. `isMcpServerDisabled()` — fallback to global list

If the project config does not explicitly set `disabledMcpServers` (i.e. it is `undefined`), fall back to a new global `disabledMcpServers` field at the root of `.openclaude.json`. Projects that already have their own list continue to use it as-is.

When a toggle operation produces an empty list, the project key is removed (set to `undefined`) so the global fallback continues to work for future global changes rather than being permanently masked by an explicit `[]`.

### 2. `setMcpServerEnabled()` — propagate only *disable* to global

Only the **disable** direction (server off) is persisted to the global list. Enabling a server stays project-local to avoid silently force-enabling servers in unrelated projects. Builtin default-disabled servers are exempt (they track state via `enabledMcpServers`).

### 3. `loadDescriptorDiscoveryContext()` — model discovery for remote custom providers

**Why bundled:** Without this fix, remote custom OpenAI-compatible providers (non-Ollama/LM Studio) are blocked from showing their dynamically-discovered models in the model picker — a closely related UX gap. Local custom providers (Ollama, LM Studio) continue using the legacy local OpenAI path which handles scoped caches correctly. The change is a single additional condition check and is conceptually tied to provider routing improvements that affect which models users see.

### 4. `GlobalConfig` — new optional field

Added `disabledMcpServers?: string[]` to the `GlobalConfig` type and to `GLOBAL_CONFIG_KEYS` for `/config` visibility.

## Behavior

| Scenario | Before | After |
|----------|--------|-------|
| Project has `disabledMcpServers` list | Uses project list | Uses project list (unchanged) |
| Project has **no** `disabledMcpServers` | `[]` — all servers enabled | Falls back to global list |
| User toggles server in one project | Only affects that project | Disable → global + project; Enable → project only |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Remote custom providers now correctly discover and display dynamically available models in the model picker.
  * MCP server “disabled” behavior now properly follows project vs global precedence.
  * Enabling/disabling MCP servers no longer unintentionally alters unrelated global disabled entries.

* **New Features**
  * Added a configurable global fallback list (`disabledMcpServers`) for MCP server disablement when a project doesn’t specify one.

* **Tests**
  * Expanded Bun test coverage for MCP enable/disable flows, precedence, fallback behavior, and isolation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->