### PR TITLE
fix(repl): add correction context after interruption

### DIFF
--- a/src/query.ts
+++ b/src/query.ts
@@ -432,6 +432,9 @@ export type QueryParams = {
    * exposed to tools, or written to transcript state.
    */
   requestOnlyMessages?: Message[]
+  /** Called around each outbound model request, including retries. */
+  onModelRequestStart?: () => void
+  onModelRequestEnd?: () => void
   systemPrompt: SystemPrompt
   userContext: { [k: string]: string }
   systemContext: { [k: string]: string }
@@ -1322,7 +1325,9 @@ async function* queryLoop(
         try {
           let streamingFallbackOccured = false
           queryCheckpoint('query_api_streaming_start')
-          for await (const message of deps.callModel({
+          params.onModelRequestStart?.()
+          try {
+            for await (const message of deps.callModel({
             messages: prependUserContext(
               injectRequestOnlyMessages(
                 messagesForQuery,
@@ -1382,7 +1387,7 @@ async function* queryLoop(
                 },
               }),
             },
-          })) {
+            })) {
             // We won't use the tool_calls from the first attempt
             // We could.. but then we'd have to merge assistant messages
             // with different ids and double up on full the tool_results
@@ -1568,6 +1573,9 @@ async function* queryLoop(
                 }
               }
             }
+            }
+          } finally {
+            params.onModelRequestEnd?.()
           }
           queryCheckpoint('query_api_streaming_end')
 

--- a/src/query.ts
+++ b/src/query.ts
@@ -594,6 +594,9 @@ async function* queryLoop(
   // trigger point. Loop-local (not on State) to avoid touching the 7 continue
   // sites.
   let taskBudgetRemaining: number | undefined = undefined
+  // Request-only context can be invalidated by a full conversation rewrite.
+  // Keep it outside the loop so that invalidation survives every retry state.
+  let requestOnlyMessages = params.requestOnlyMessages
   let pendingToolFailureAdvisories: {
     message: ReturnType<typeof createUserMessage>
     threshold: number
@@ -693,7 +696,6 @@ async function* queryLoop(
     }
 
     let messagesForQuery = [...getMessagesAfterCompactBoundary(messages)]
-    let requestOnlyMessages = params.requestOnlyMessages
     if (pendingToolFailureAdvisories.length > 0) {
       messagesForQuery.push(
         ...pendingToolFailureAdvisories.map(advisory => advisory.message),

--- a/src/query.ts
+++ b/src/query.ts
@@ -1320,7 +1320,10 @@ async function* queryLoop(
             messages: prependUserContext(
               injectRequestOnlyMessages(
                 messagesForQuery,
-                params.requestOnlyMessages,
+                // A full compaction replaces the interrupted turn that gave
+                // the correction reminder its meaning. Do not carry that
+                // request-only context into the rewritten conversation.
+                compactionResult ? undefined : params.requestOnlyMessages,
               ),
               userContext,
             ),

--- a/src/query.ts
+++ b/src/query.ts
@@ -1863,6 +1863,9 @@ async function* queryLoop(
             querySource,
           )
           if (drained.committed > 0) {
+            // Draining replaces archived history with a summary, so a reminder
+            // about the pre-collapse interrupted turn is no longer valid.
+            requestOnlyMessages = undefined
             const next: State = {
               messages: drained.messages,
               toolUseContext,

--- a/src/query.ts
+++ b/src/query.ts
@@ -693,6 +693,7 @@ async function* queryLoop(
     }
 
     let messagesForQuery = [...getMessagesAfterCompactBoundary(messages)]
+    let requestOnlyMessages = params.requestOnlyMessages
     if (pendingToolFailureAdvisories.length > 0) {
       messagesForQuery.push(
         ...pendingToolFailureAdvisories.map(advisory => advisory.message),
@@ -911,6 +912,9 @@ async function* queryLoop(
     queryCheckpoint('query_autocompact_end')
 
     if (compactionResult) {
+      // A full rewrite removes the interrupted turn this correction context
+      // refers to, so it cannot be valid for the compacted request.
+      requestOnlyMessages = undefined
       const {
         preCompactTokenCount,
         postCompactTokenCount,
@@ -1320,10 +1324,7 @@ async function* queryLoop(
             messages: prependUserContext(
               injectRequestOnlyMessages(
                 messagesForQuery,
-                // A full compaction replaces the interrupted turn that gave
-                // the correction reminder its meaning. Do not carry that
-                // request-only context into the rewritten conversation.
-                compactionResult ? undefined : params.requestOnlyMessages,
+                requestOnlyMessages,
               ),
               userContext,
             ),
@@ -1901,6 +1902,9 @@ async function* queryLoop(
         })
 
         if (compacted) {
+          // The reactive path also replaces the complete conversation; do not
+          // re-inject request-only context whose referent was compacted away.
+          requestOnlyMessages = undefined
           // task_budget: same carryover as the proactive path above.
           // messagesForQuery still holds the pre-compact array here (the
           // 413-failed attempt's input).

--- a/src/query.ts
+++ b/src/query.ts
@@ -41,6 +41,7 @@ import type {
   UserMessage,
   TombstoneMessage,
 } from './types/message.js'
+import { isHumanTurn } from './utils/messagePredicates.js'
 import { logError } from './utils/log.js'
 import {
   getProviderMaxTokensCapFromMessage,
@@ -426,6 +427,11 @@ function isWithheldProviderMaxTokensCap(
 
 export type QueryParams = {
   messages: Message[]
+  /**
+   * Model-visible context for this query call only. Never compacted, yielded,
+   * exposed to tools, or written to transcript state.
+   */
+  requestOnlyMessages?: Message[]
   systemPrompt: SystemPrompt
   userContext: { [k: string]: string }
   systemContext: { [k: string]: string }
@@ -447,6 +453,22 @@ export type QueryParams = {
   taskBudget?: { total: number }
   agentStepLimit?: AgentStepLimitConfig
   deps?: QueryDeps
+}
+
+function injectRequestOnlyMessages(
+  messages: readonly Message[],
+  requestOnlyMessages: readonly Message[] | undefined,
+): Message[] {
+  if (!requestOnlyMessages?.length) return [...messages]
+  const latestUserIndex = messages.findLastIndex(isHumanTurn)
+  const insertionIndex = latestUserIndex === -1
+    ? messages.length
+    : latestUserIndex
+  return [
+    ...messages.slice(0, insertionIndex),
+    ...requestOnlyMessages,
+    ...messages.slice(insertionIndex),
+  ]
 }
 
 // -- query loop state
@@ -1295,7 +1317,13 @@ async function* queryLoop(
           let streamingFallbackOccured = false
           queryCheckpoint('query_api_streaming_start')
           for await (const message of deps.callModel({
-            messages: prependUserContext(messagesForQuery, userContext),
+            messages: prependUserContext(
+              injectRequestOnlyMessages(
+                messagesForQuery,
+                params.requestOnlyMessages,
+              ),
+              userContext,
+            ),
             systemPrompt: fullSystemPrompt,
             thinkingConfig: toolUseContext.options.thinkingConfig,
             tools: toolsForModel,

--- a/src/query/requestOnlyMessages.test.ts
+++ b/src/query/requestOnlyMessages.test.ts
@@ -167,6 +167,26 @@ test('keeps request-only context in every model call but out of tool context', a
   )
 })
 
+test('leaves model messages unchanged when request-only context is absent', async () => {
+  const originalMessages = [createUserMessage({ content: 'ordinary prompt' })]
+  const modelCalls: Message[][] = []
+  const callModel: QueryDeps['callModel'] = async function* ({ messages }) {
+    modelCalls.push(messages)
+    yield createAssistantMessage({ content: 'done' })
+  }
+  const params = baseParams(
+    callModel,
+    async () => ({ wasCompacted: false }),
+  )
+  params.messages = originalMessages
+  params.requestOnlyMessages = undefined
+
+  await collect(params)
+
+  expect(modelCalls).toHaveLength(1)
+  expect(modelCalls[0]).toEqual(originalMessages)
+})
+
 for (const preserveCorrection of [false, true]) {
   test(`reapplies request-only context after ${
     preserveCorrection ? 'suffix-preserving' : 'full'

--- a/src/query/requestOnlyMessages.test.ts
+++ b/src/query/requestOnlyMessages.test.ts
@@ -187,6 +187,22 @@ test('leaves model messages unchanged when request-only context is absent', asyn
   expect(modelCalls[0]).toEqual(originalMessages)
 })
 
+test('scopes model-request lifecycle callbacks to callModel', async () => {
+  const events: string[] = []
+  const params = baseParams(
+    async function* () {
+      yield createAssistantMessage({ content: 'done' })
+    },
+    async () => ({ wasCompacted: false }),
+  )
+  params.onModelRequestStart = () => events.push('start')
+  params.onModelRequestEnd = () => events.push('end')
+
+  await collect(params)
+
+  expect(events).toEqual(['start', 'end'])
+})
+
 for (const preserveCorrection of [false, true]) {
   test(`reapplies request-only context after ${
     preserveCorrection ? 'suffix-preserving' : 'full'

--- a/src/query/requestOnlyMessages.test.ts
+++ b/src/query/requestOnlyMessages.test.ts
@@ -1,0 +1,230 @@
+import { expect, test } from 'bun:test'
+import { z } from 'zod/v4'
+import { query, type QueryParams } from '../query.js'
+import type { QueryDeps } from './deps.js'
+import { buildTool, type Tools } from '../Tool.js'
+import type { Message } from '../types/message.js'
+import {
+  createAssistantMessage,
+  createCompactBoundaryMessage,
+  createUserMessage,
+} from '../utils/messages.js'
+import { INTERRUPTION_CORRECTION_REMINDER } from '../utils/interruptionCorrection.js'
+import { asSystemPrompt } from '../utils/systemPromptType.js'
+
+function makeToolUseContext(tools: Tools = []): QueryParams['toolUseContext'] {
+  return {
+    abortController: new AbortController(),
+    getAppState: () => ({
+      fastMode: false,
+      mcp: { tools: {}, clients: [] },
+      toolPermissionContext: { mode: 'default' },
+      sessionHooks: new Map(),
+      mainLoopModel: 'test-model',
+      effortValue: undefined,
+      advisorModel: undefined,
+    }),
+    options: {
+      commands: [],
+      debug: false,
+      thinkingConfig: { type: 'disabled' },
+      tools,
+      verbose: false,
+      mcpClients: [],
+      mcpResources: {},
+      isNonInteractiveSession: false,
+      agentDefinitions: { activeAgents: [], allowedAgentTypes: undefined },
+      appendSystemPrompt: undefined,
+      providerOverride: undefined,
+      mainLoopModel: 'test-model',
+    },
+    addNotification: () => {},
+    messages: [],
+    readFileState: {},
+    setAppState: () => {},
+    setInProgressToolUseIDs: () => {},
+    setResponseLength: () => {},
+    updateFileHistoryState: () => {},
+    updateAttributionState: () => {},
+  } as unknown as QueryParams['toolUseContext']
+}
+
+async function collect(params: QueryParams): Promise<unknown[]> {
+  const yielded: unknown[] = []
+  for await (const event of query(params)) yielded.push(event)
+  return yielded
+}
+
+function userTexts(messages: readonly Message[]): string[] {
+  return messages.flatMap(message =>
+    message.type === 'user' && typeof message.message.content === 'string'
+      ? [message.message.content]
+      : [],
+  )
+}
+
+function baseParams(
+  callModel: QueryDeps['callModel'],
+  autocompact: QueryDeps['autocompact'],
+  tools: Tools = [],
+): QueryParams {
+  return {
+    messages: [createUserMessage({ content: 'do Y instead' })],
+    requestOnlyMessages: [
+      createUserMessage({
+        content: INTERRUPTION_CORRECTION_REMINDER,
+        isMeta: true,
+      }),
+    ],
+    systemPrompt: asSystemPrompt([]),
+    userContext: {},
+    systemContext: {},
+    canUseTool: async () => ({ behavior: 'allow' }),
+    toolUseContext: makeToolUseContext(tools),
+    querySource: 'repl_main_thread',
+    maxTurns: 2,
+    deps: {
+      callModel,
+      microcompact: async messages => ({ messages }),
+      autocompact,
+      uuid: () => '00000000-0000-4000-8000-000000000000',
+    } as QueryDeps,
+  }
+}
+
+test('keeps request-only context in every model call but out of tool context', async () => {
+  const modelCalls: Message[][] = []
+  const toolContexts: Message[][] = []
+  const inspectTool = buildTool({
+    name: 'InspectContext',
+    inputSchema: z.object({}),
+    maxResultSizeChars: Infinity,
+    async description() {
+      return 'Inspect current context'
+    },
+    async prompt() {
+      return ''
+    },
+    async call(_input, context) {
+      toolContexts.push(context.messages)
+      return { data: 'ok' }
+    },
+    mapToolResultToToolResultBlockParam(content, toolUseID) {
+      return {
+        type: 'tool_result',
+        tool_use_id: toolUseID,
+        content: String(content),
+      }
+    },
+    renderToolUseMessage() {
+      return null
+    },
+    renderToolResultMessage() {
+      return null
+    },
+  })
+  const callModel: QueryDeps['callModel'] = async function* ({ messages }) {
+    modelCalls.push(messages)
+    if (modelCalls.length === 1) {
+      yield createAssistantMessage({
+        content: [
+          {
+            type: 'tool_use',
+            id: 'inspect-context-1',
+            name: 'InspectContext',
+            input: {},
+          },
+        ],
+      })
+      return
+    }
+    yield createAssistantMessage({ content: 'done' })
+  }
+
+  await collect(
+    baseParams(
+      callModel,
+      async () => ({ wasCompacted: false }),
+      [inspectTool],
+    ),
+  )
+
+  expect(modelCalls).toHaveLength(2)
+  for (const messages of modelCalls) {
+    expect(userTexts(messages)).toContain(INTERRUPTION_CORRECTION_REMINDER)
+  }
+  expect(userTexts(modelCalls[0]!)).toEqual([
+    INTERRUPTION_CORRECTION_REMINDER,
+    'do Y instead',
+  ])
+  expect(userTexts(modelCalls[1]!)).toEqual([
+    INTERRUPTION_CORRECTION_REMINDER,
+    'do Y instead',
+  ])
+  expect(toolContexts).toHaveLength(1)
+  expect(userTexts(toolContexts[0]!)).not.toContain(
+    INTERRUPTION_CORRECTION_REMINDER,
+  )
+})
+
+for (const preserveCorrection of [false, true]) {
+  test(`reapplies request-only context after ${
+    preserveCorrection ? 'suffix-preserving' : 'full'
+  } compaction without yielding it`, async () => {
+    const correction = createUserMessage({ content: 'do Y instead' })
+    const modelCalls: Message[][] = []
+    const compactionInputs: Message[][] = []
+    const callModel: QueryDeps['callModel'] = async function* ({ messages }) {
+      modelCalls.push(messages)
+      yield createAssistantMessage({ content: 'done' })
+    }
+    const autocompact: QueryDeps['autocompact'] = async messages => {
+      compactionInputs.push(messages)
+      return {
+        wasCompacted: true,
+        consecutiveFailures: 0,
+        compactionResult: {
+          boundaryMarker: createCompactBoundaryMessage('auto', 10_000),
+          summaryMessages: [createUserMessage({ content: 'compact summary' })],
+          messagesToKeep: preserveCorrection ? [correction] : [],
+          attachments: [],
+          hookResults: [],
+          preCompactTokenCount: 10_000,
+          postCompactTokenCount: 500,
+          truePostCompactTokenCount: 500,
+        },
+      }
+    }
+    const params = baseParams(callModel, autocompact)
+    params.messages = [correction]
+
+    const yielded = await collect(params)
+
+    expect(userTexts(compactionInputs[0]!)).not.toContain(
+      INTERRUPTION_CORRECTION_REMINDER,
+    )
+    expect(userTexts(modelCalls[0]!)).toEqual(
+      preserveCorrection
+        ? [
+            'compact summary',
+            INTERRUPTION_CORRECTION_REMINDER,
+            'do Y instead',
+          ]
+        : [INTERRUPTION_CORRECTION_REMINDER, 'compact summary'],
+    )
+    expect(
+      yielded.some(
+        event =>
+          typeof event === 'object' &&
+          event !== null &&
+          'type' in event &&
+          event.type === 'user' &&
+          'message' in event &&
+          typeof event.message === 'object' &&
+          event.message !== null &&
+          'content' in event.message &&
+          event.message.content === INTERRUPTION_CORRECTION_REMINDER,
+      ),
+    ).toBe(false)
+  })
+}

--- a/src/query/requestOnlyMessages.test.ts
+++ b/src/query/requestOnlyMessages.test.ts
@@ -225,12 +225,8 @@ for (const preserveCorrection of [false, true]) {
     )
     expect(userTexts(modelCalls[0]!)).toEqual(
       preserveCorrection
-        ? [
-            'compact summary',
-            INTERRUPTION_CORRECTION_REMINDER,
-            'do Y instead',
-          ]
-        : [INTERRUPTION_CORRECTION_REMINDER, 'compact summary'],
+        ? ['compact summary', 'do Y instead']
+        : ['compact summary'],
     )
     expect(
       yielded.some(

--- a/src/query/requestOnlyMessages.test.ts
+++ b/src/query/requestOnlyMessages.test.ts
@@ -244,3 +244,80 @@ for (const preserveCorrection of [false, true]) {
     ).toBe(false)
   })
 }
+
+test('does not restore request-only context after compaction retries the turn', async () => {
+  const modelCalls: Message[][] = []
+  const inspectTool = buildTool({
+    name: 'InspectContextAfterCompact',
+    inputSchema: z.object({}),
+    maxResultSizeChars: Infinity,
+    async description() {
+      return 'Inspect current context'
+    },
+    async prompt() {
+      return ''
+    },
+    async call() {
+      return { data: 'ok' }
+    },
+    mapToolResultToToolResultBlockParam(content, toolUseID) {
+      return {
+        type: 'tool_result',
+        tool_use_id: toolUseID,
+        content: String(content),
+      }
+    },
+    renderToolUseMessage() {
+      return null
+    },
+    renderToolResultMessage() {
+      return null
+    },
+  })
+  const callModel: QueryDeps['callModel'] = async function* ({ messages }) {
+    modelCalls.push(messages)
+    if (modelCalls.length === 1) {
+      yield createAssistantMessage({
+        content: [
+          {
+            type: 'tool_use',
+            id: 'inspect-after-compact',
+            name: 'InspectContextAfterCompact',
+            input: {},
+          },
+        ],
+      })
+      return
+    }
+    yield createAssistantMessage({ content: 'done' })
+  }
+  let compacted = false
+  const autocompact: QueryDeps['autocompact'] = async () => {
+    if (compacted) return { wasCompacted: false }
+    compacted = true
+    return {
+      wasCompacted: true,
+      consecutiveFailures: 0,
+      compactionResult: {
+        boundaryMarker: createCompactBoundaryMessage('auto', 10_000),
+        summaryMessages: [createUserMessage({ content: 'compact summary' })],
+        messagesToKeep: [createUserMessage({ content: 'do Y instead' })],
+        attachments: [],
+        hookResults: [],
+        preCompactTokenCount: 10_000,
+        postCompactTokenCount: 500,
+        truePostCompactTokenCount: 500,
+      },
+    }
+  }
+
+  await collect(baseParams(callModel, autocompact, [inspectTool]))
+
+  expect(modelCalls).toHaveLength(2)
+  expect(userTexts(modelCalls[0]!)).not.toContain(
+    INTERRUPTION_CORRECTION_REMINDER,
+  )
+  expect(userTexts(modelCalls[1]!)).not.toContain(
+    INTERRUPTION_CORRECTION_REMINDER,
+  )
+})

--- a/src/screens/REPL.queryLifecycle.test.ts
+++ b/src/screens/REPL.queryLifecycle.test.ts
@@ -22,6 +22,17 @@ function getQueryFinallyBody(): string {
   return source.slice(finallyStart, finallyEnd)
 }
 
+function getOnCancelBody(): string {
+  const start = source.indexOf('function onCancel(')
+  expect(start).toBeGreaterThan(-1)
+  const end = source.indexOf(
+    'const handleQueuedCommandOnCancel = useCallback',
+    start,
+  )
+  expect(end).toBeGreaterThan(start)
+  return source.slice(start, end)
+}
+
 describe('REPL query lifecycle timeout logging', () => {
   test('constructs QueryGuard with resolved hard max config', () => {
     expect(source).toContain(
@@ -52,5 +63,47 @@ describe('REPL query lifecycle timeout logging', () => {
     expect(body).toContain("guardCompletedContext?.terminalReason === 'hard-max-query-timeout'")
     expect(body).toContain('guardCompletedContext.queryGeneration === thisGeneration')
     expect(body).toContain('logCompletedLifecycle(guardCompletedContext)')
+  })
+
+  test('wires one-shot correction state to exact local model-turn cancellation', () => {
+    expect(source).toContain(
+      'const pendingInterruptionCorrectionSessionRef = useRef<string | null>(null)',
+    )
+    expect(source).toContain(
+      'const modelBoundQueryIdRef = useRef<string | null>(null)',
+    )
+    expect(source).toContain(
+      'modelBoundQueryIdRef.current = queryContext.queryId',
+    )
+
+    const onCancelBody = getOnCancelBody()
+    expect(onCancelBody).toContain('shouldMarkInterruptionCorrection({')
+    expect(onCancelBody).toContain('isUserInitiated')
+    expect(onCancelBody).toContain('activeRemote.isRemoteMode')
+    expect(source).toContain('onCancel: () => onCancel(true)')
+
+    const reminderHookOccurrences =
+      source.match(/takeInterruptionCorrectionReminder/g)?.length ?? 0
+    expect(reminderHookOccurrences).toBeGreaterThanOrEqual(3)
+  })
+
+  test('marks model ownership only after pre-query callbacks approve', () => {
+    const onQueryStart = source.indexOf('const onQuery = useCallback')
+    const approvalIndex = source.indexOf(
+      'const shouldProceed = await onBeforeQueryCallback',
+      onQueryStart,
+    )
+    const ownershipIndex = source.indexOf(
+      'modelBoundQueryIdRef.current = queryContext.queryId',
+      onQueryStart,
+    )
+    const modelExecutionIndex = source.indexOf(
+      'await onQueryImpl(',
+      onQueryStart,
+    )
+
+    expect(approvalIndex).toBeGreaterThan(onQueryStart)
+    expect(ownershipIndex).toBeGreaterThan(approvalIndex)
+    expect(modelExecutionIndex).toBeGreaterThan(ownershipIndex)
   })
 })

--- a/src/screens/REPL.queryLifecycle.test.ts
+++ b/src/screens/REPL.queryLifecycle.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, test } from 'bun:test'
 import { readFileSync } from 'node:fs'
 import { join } from 'node:path'
+import { InterruptionCorrectionTracker } from '../utils/interruptionCorrection.js'
+import { QueryGuard } from '../utils/QueryGuard.js'
 
 const source = readFileSync(join(import.meta.dirname, 'REPL.tsx'), 'utf8')
 
@@ -67,7 +69,10 @@ describe('REPL query lifecycle timeout logging', () => {
 
   test('wires the correction tracker to local model-turn cancellation', () => {
     expect(source).toContain(
-      'const interruptionCorrectionTrackerRef = useRef(new InterruptionCorrectionTracker())',
+      'const interruptionCorrectionTrackerRef = useRef<InterruptionCorrectionTracker | null>(null)',
+    )
+    expect(source).toContain(
+      'new InterruptionCorrectionTracker(queryGuard, getSessionId)',
     )
 
     const onCancelBody = getOnCancelBody()
@@ -102,5 +107,56 @@ describe('REPL query lifecycle timeout logging', () => {
     expect(source).toContain(
       'interruptionCorrectionTrackerRef.current.finishModelTurn(queryContext.queryId)',
     )
+  })
+
+  test('executes correction arming and consumption through QueryGuard', () => {
+    const queryGuard = new QueryGuard()
+    let sessionId = 'session-a'
+    const tracker = new InterruptionCorrectionTracker(
+      queryGuard,
+      () => sessionId,
+    )
+
+    const localCommand = queryGuard.tryStart({
+      queryId: 'local-command',
+      querySource: 'repl_main_thread',
+      startedAt: 1,
+    })!
+    tracker.bindModelTurn({
+      shouldQuery: false,
+      isAborted: false,
+      queryId: localCommand.context.queryId,
+    })
+    tracker.handleCancellation({
+      isUserInitiated: true,
+      isRemoteMode: false,
+    })
+    queryGuard.forceEnd('user-abort', 'user-cancel')
+    expect(tracker.takeReminder()).toBeNull()
+
+    const modelTurn = queryGuard.tryStart({
+      queryId: 'model-turn',
+      querySource: 'repl_main_thread',
+      startedAt: 2,
+    })!
+    tracker.bindModelTurn({
+      shouldQuery: true,
+      isAborted: false,
+      queryId: modelTurn.context.queryId,
+    })
+    tracker.handleCancellation({
+      isUserInitiated: true,
+      isRemoteMode: false,
+    })
+    queryGuard.forceEnd('user-abort', 'user-cancel')
+
+    expect(tracker.takeReminder()).toMatchObject({
+      type: 'user',
+      isMeta: true,
+    })
+    expect(tracker.takeReminder()).toBeNull()
+
+    sessionId = 'session-b'
+    expect(tracker.takeReminder()).toBeNull()
   })
 })

--- a/src/screens/REPL.queryLifecycle.test.ts
+++ b/src/screens/REPL.queryLifecycle.test.ts
@@ -194,4 +194,12 @@ describe('REPL query lifecycle timeout logging', () => {
 
     expect(tracker.takeReminder()).toBeNull()
   })
+
+  test('keeps maxTurns in the query callback dependencies', () => {
+    const start = source.indexOf('const onQueryImpl = useCallback')
+    expect(start).toBeGreaterThan(-1)
+    const end = source.indexOf('const onQuery = useCallback', start)
+    expect(end).toBeGreaterThan(start)
+    expect(source.slice(start, end)).toContain('titleDisabled, maxTurns,')
+  })
 })

--- a/src/screens/REPL.queryLifecycle.test.ts
+++ b/src/screens/REPL.queryLifecycle.test.ts
@@ -24,17 +24,6 @@ function getQueryFinallyBody(): string {
   return source.slice(finallyStart, finallyEnd)
 }
 
-function getOnCancelBody(): string {
-  const start = source.indexOf('function onCancel(')
-  expect(start).toBeGreaterThan(-1)
-  const end = source.indexOf(
-    'const handleQueuedCommandOnCancel = useCallback',
-    start,
-  )
-  expect(end).toBeGreaterThan(start)
-  return source.slice(start, end)
-}
-
 describe('REPL query lifecycle timeout logging', () => {
   test('constructs QueryGuard with resolved hard max config', () => {
     expect(source).toContain(
@@ -67,48 +56,6 @@ describe('REPL query lifecycle timeout logging', () => {
     expect(body).toContain('logCompletedLifecycle(guardCompletedContext)')
   })
 
-  test('wires the correction tracker to local model-turn cancellation', () => {
-    expect(source).toContain(
-      'const interruptionCorrectionTrackerRef = useRef<InterruptionCorrectionTracker | null>(null)',
-    )
-    expect(source).toContain(
-      'new InterruptionCorrectionTracker(queryGuard, getSessionId)',
-    )
-
-    const onCancelBody = getOnCancelBody()
-    expect(onCancelBody).toContain('.handleCancellation({')
-    expect(onCancelBody).toContain('isUserInitiated')
-    expect(onCancelBody).toContain('activeRemote.isRemoteMode')
-    expect(source).toContain('onCancel: () => onCancel(true)')
-
-    const reminderHookOccurrences =
-      source.match(/takeInterruptionCorrectionReminder/g)?.length ?? 0
-    expect(reminderHookOccurrences).toBeGreaterThanOrEqual(3)
-  })
-
-  test('marks model ownership only after pre-query callbacks approve', () => {
-    const onQueryStart = source.indexOf('const onQuery = useCallback')
-    const approvalIndex = source.indexOf(
-      'const shouldProceed = await onBeforeQueryCallback',
-      onQueryStart,
-    )
-    const ownershipIndex = source.indexOf(
-      'interruptionCorrectionTracker.bindModelTurn({',
-      onQueryStart,
-    )
-    const modelExecutionIndex = source.indexOf(
-      'await onQueryImpl(',
-      onQueryStart,
-    )
-
-    expect(approvalIndex).toBeGreaterThan(onQueryStart)
-    expect(ownershipIndex).toBeGreaterThan(approvalIndex)
-    expect(modelExecutionIndex).toBeGreaterThan(ownershipIndex)
-    expect(source).toContain(
-      'interruptionCorrectionTracker.finishModelTurn(queryContext.queryId)',
-    )
-  })
-
   test('executes correction arming and consumption through QueryGuard', () => {
     const queryGuard = new QueryGuard()
     let sessionId = 'session-a'
@@ -124,7 +71,6 @@ describe('REPL query lifecycle timeout logging', () => {
     })!
     tracker.bindModelTurn({
       shouldQuery: false,
-      isAborted: false,
       queryId: localCommand.context.queryId,
     })
     tracker.handleCancellation({
@@ -141,7 +87,6 @@ describe('REPL query lifecycle timeout logging', () => {
     })!
     tracker.bindModelTurn({
       shouldQuery: true,
-      isAborted: false,
       queryId: modelTurn.context.queryId,
     })
     tracker.handleCancellation({
@@ -156,7 +101,65 @@ describe('REPL query lifecycle timeout logging', () => {
     })
     expect(tracker.takeReminder()).toBeNull()
 
+    const sessionScopedTurn = queryGuard.tryStart({
+      queryId: 'session-scoped-turn',
+      querySource: 'repl_main_thread',
+      startedAt: 3,
+    })!
+    tracker.bindModelTurn({
+      shouldQuery: true,
+      queryId: sessionScopedTurn.context.queryId,
+    })
+    tracker.handleCancellation({
+      isUserInitiated: true,
+      isRemoteMode: false,
+    })
+    queryGuard.forceEnd('user-abort', 'user-cancel')
+
     sessionId = 'session-b'
     expect(tracker.takeReminder()).toBeNull()
+  })
+
+  test('arms when the user cancels during pre-query work', async () => {
+    const queryGuard = new QueryGuard()
+    const tracker = new InterruptionCorrectionTracker(
+      queryGuard,
+      () => 'session-a',
+    )
+    const modelTurn = queryGuard.tryStart({
+      queryId: 'pre-query-turn',
+      querySource: 'repl_main_thread',
+      startedAt: 1,
+    })!
+    let releasePreQuery!: () => void
+    const preQueryPending = new Promise<void>(resolve => {
+      releasePreQuery = resolve
+    })
+    let signalPreQueryStarted!: () => void
+    const preQueryStarted = new Promise<void>(resolve => {
+      signalPreQueryStarted = resolve
+    })
+    const turn = tracker.runModelTurn({
+      shouldQuery: true,
+      queryId: modelTurn.context.queryId,
+      run: async () => {
+        signalPreQueryStarted()
+        await preQueryPending
+      },
+    })
+
+    await preQueryStarted
+    tracker.handleCancellation({
+      isUserInitiated: true,
+      isRemoteMode: false,
+    })
+    queryGuard.forceEnd('user-abort', 'user-cancel')
+    releasePreQuery()
+    await turn
+
+    expect(tracker.takeReminder()).toMatchObject({
+      type: 'user',
+      isMeta: true,
+    })
   })
 })

--- a/src/screens/REPL.queryLifecycle.test.ts
+++ b/src/screens/REPL.queryLifecycle.test.ts
@@ -32,6 +32,16 @@ describe('REPL query lifecycle timeout logging', () => {
     expect(source).toContain('new QueryGuard(getQueryGuardOptionsFromEnv())')
   })
 
+  test('clears interruption-correction state before resuming another session', () => {
+    const switchSessionIndex = source.indexOf('switchSession(asSessionId(sessionId)')
+    const sessionChangeIndex = source.indexOf(
+      'interruptionCorrectionTracker.handleSessionChange()',
+    )
+    expect(switchSessionIndex).toBeGreaterThan(-1)
+    expect(sessionChangeIndex).toBeGreaterThan(-1)
+    expect(sessionChangeIndex).toBeLessThan(switchSessionIndex)
+  })
+
   test('does not emit terminal timeout end from timeout handler', () => {
     const body = getAbortTimedOutQueryBody()
     const queueMicrotaskIndex = body.indexOf('queueMicrotask(() => {')

--- a/src/screens/REPL.queryLifecycle.test.ts
+++ b/src/screens/REPL.queryLifecycle.test.ts
@@ -24,6 +24,14 @@ function getQueryFinallyBody(): string {
   return source.slice(finallyStart, finallyEnd)
 }
 
+function getOnQueryImplBody(): string {
+  const start = source.indexOf('const onQueryImpl = useCallback')
+  expect(start).toBeGreaterThan(-1)
+  const end = source.indexOf('const onQuery = useCallback', start)
+  expect(end).toBeGreaterThan(start)
+  return source.slice(start, end)
+}
+
 describe('REPL query lifecycle timeout logging', () => {
   test('constructs QueryGuard with resolved hard max config', () => {
     expect(source).toContain(
@@ -64,6 +72,16 @@ describe('REPL query lifecycle timeout logging', () => {
     expect(body).toContain("guardCompletedContext?.terminalReason === 'hard-max-query-timeout'")
     expect(body).toContain('guardCompletedContext.queryGeneration === thisGeneration')
     expect(body).toContain('logCompletedLifecycle(guardCompletedContext)')
+  })
+
+  test('keeps correction ownership through post-response tool work', () => {
+    const impl = getOnQueryImplBody()
+    const finallyBody = getQueryFinallyBody()
+
+    expect(impl).not.toContain('onModelRequestEnd: interruptionCorrectionQueryId')
+    expect(finallyBody).toContain(
+      'interruptionCorrectionTracker.finishModelTurn(queryContext.queryId)',
+    )
   })
 
   test('executes correction arming and consumption through QueryGuard', () => {

--- a/src/screens/REPL.queryLifecycle.test.ts
+++ b/src/screens/REPL.queryLifecycle.test.ts
@@ -71,6 +71,7 @@ describe('REPL query lifecycle timeout logging', () => {
     })!
     tracker.bindModelTurn({
       shouldQuery: false,
+      isInterruptionCorrectionEligible: true,
       queryId: localCommand.context.queryId,
     })
     tracker.handleCancellation({
@@ -87,6 +88,7 @@ describe('REPL query lifecycle timeout logging', () => {
     })!
     tracker.bindModelTurn({
       shouldQuery: true,
+      isInterruptionCorrectionEligible: true,
       queryId: modelTurn.context.queryId,
     })
     tracker.handleCancellation({
@@ -108,6 +110,7 @@ describe('REPL query lifecycle timeout logging', () => {
     })!
     tracker.bindModelTurn({
       shouldQuery: true,
+      isInterruptionCorrectionEligible: true,
       queryId: sessionScopedTurn.context.queryId,
     })
     tracker.handleCancellation({
@@ -141,6 +144,7 @@ describe('REPL query lifecycle timeout logging', () => {
     })
     const turn = tracker.runModelTurn({
       shouldQuery: true,
+      isInterruptionCorrectionEligible: true,
       queryId: modelTurn.context.queryId,
       run: async () => {
         signalPreQueryStarted()
@@ -161,5 +165,33 @@ describe('REPL query lifecycle timeout logging', () => {
       type: 'user',
       isMeta: true,
     })
+  })
+
+  test('does not arm when the model turn is marked ineligible', async () => {
+    const queryGuard = new QueryGuard()
+    const tracker = new InterruptionCorrectionTracker(
+      queryGuard,
+      () => 'session-a',
+    )
+    const modelTurn = queryGuard.tryStart({
+      queryId: 'remote-origin-turn',
+      querySource: 'repl_main_thread',
+      startedAt: 1,
+    })!
+
+    await tracker.runModelTurn({
+      shouldQuery: true,
+      isInterruptionCorrectionEligible: false,
+      queryId: modelTurn.context.queryId,
+      run: async () => {
+        tracker.handleCancellation({
+          isUserInitiated: true,
+          isRemoteMode: false,
+        })
+        queryGuard.forceEnd('user-abort', 'user-cancel')
+      },
+    })
+
+    expect(tracker.takeReminder()).toBeNull()
   })
 })

--- a/src/screens/REPL.queryLifecycle.test.ts
+++ b/src/screens/REPL.queryLifecycle.test.ts
@@ -93,7 +93,7 @@ describe('REPL query lifecycle timeout logging', () => {
       onQueryStart,
     )
     const ownershipIndex = source.indexOf(
-      'interruptionCorrectionTrackerRef.current.bindModelTurn({',
+      'interruptionCorrectionTracker.bindModelTurn({',
       onQueryStart,
     )
     const modelExecutionIndex = source.indexOf(
@@ -105,7 +105,7 @@ describe('REPL query lifecycle timeout logging', () => {
     expect(ownershipIndex).toBeGreaterThan(approvalIndex)
     expect(modelExecutionIndex).toBeGreaterThan(ownershipIndex)
     expect(source).toContain(
-      'interruptionCorrectionTrackerRef.current.finishModelTurn(queryContext.queryId)',
+      'interruptionCorrectionTracker.finishModelTurn(queryContext.queryId)',
     )
   })
 

--- a/src/screens/REPL.queryLifecycle.test.ts
+++ b/src/screens/REPL.queryLifecycle.test.ts
@@ -65,19 +65,13 @@ describe('REPL query lifecycle timeout logging', () => {
     expect(body).toContain('logCompletedLifecycle(guardCompletedContext)')
   })
 
-  test('wires one-shot correction state to exact local model-turn cancellation', () => {
+  test('wires the correction tracker to local model-turn cancellation', () => {
     expect(source).toContain(
-      'const pendingInterruptionCorrectionSessionRef = useRef<string | null>(null)',
-    )
-    expect(source).toContain(
-      'const modelBoundQueryIdRef = useRef<string | null>(null)',
-    )
-    expect(source).toContain(
-      'modelBoundQueryIdRef.current = queryContext.queryId',
+      'const interruptionCorrectionTrackerRef = useRef(new InterruptionCorrectionTracker())',
     )
 
     const onCancelBody = getOnCancelBody()
-    expect(onCancelBody).toContain('shouldMarkInterruptionCorrection({')
+    expect(onCancelBody).toContain('.handleCancellation({')
     expect(onCancelBody).toContain('isUserInitiated')
     expect(onCancelBody).toContain('activeRemote.isRemoteMode')
     expect(source).toContain('onCancel: () => onCancel(true)')
@@ -94,7 +88,7 @@ describe('REPL query lifecycle timeout logging', () => {
       onQueryStart,
     )
     const ownershipIndex = source.indexOf(
-      'modelBoundQueryIdRef.current = queryContext.queryId',
+      'interruptionCorrectionTrackerRef.current.bindModelTurn({',
       onQueryStart,
     )
     const modelExecutionIndex = source.indexOf(
@@ -105,5 +99,8 @@ describe('REPL query lifecycle timeout logging', () => {
     expect(approvalIndex).toBeGreaterThan(onQueryStart)
     expect(ownershipIndex).toBeGreaterThan(approvalIndex)
     expect(modelExecutionIndex).toBeGreaterThan(ownershipIndex)
+    expect(source).toContain(
+      'interruptionCorrectionTrackerRef.current.finishModelTurn(queryContext.queryId)',
+    )
   })
 })

--- a/src/screens/REPL.queryLifecycle.test.ts
+++ b/src/screens/REPL.queryLifecycle.test.ts
@@ -123,13 +123,6 @@ describe('REPL query lifecycle timeout logging', () => {
     expect(tracker.takeReminder()).toBeNull()
   })
 
-  test('binds correction tracking only after pre-query work', () => {
-    const preQuery = source.indexOf('await mrOnBeforeQuery')
-    const bind = source.indexOf('await interruptionCorrectionTracker.runModelTurn')
-    expect(preQuery).toBeGreaterThan(-1)
-    expect(bind).toBeGreaterThan(preQuery)
-  })
-
   test('does not arm when the model turn is marked ineligible', async () => {
     const queryGuard = new QueryGuard()
     const tracker = new InterruptionCorrectionTracker(
@@ -158,11 +151,4 @@ describe('REPL query lifecycle timeout logging', () => {
     expect(tracker.takeReminder()).toBeNull()
   })
 
-  test('keeps maxTurns in the query callback dependencies', () => {
-    const start = source.indexOf('const onQueryImpl = useCallback')
-    expect(start).toBeGreaterThan(-1)
-    const end = source.indexOf('const onQuery = useCallback', start)
-    expect(end).toBeGreaterThan(start)
-    expect(source.slice(start, end)).toContain('titleDisabled, maxTurns,')
-  })
 })

--- a/src/screens/REPL.queryLifecycle.test.ts
+++ b/src/screens/REPL.queryLifecycle.test.ts
@@ -123,48 +123,11 @@ describe('REPL query lifecycle timeout logging', () => {
     expect(tracker.takeReminder()).toBeNull()
   })
 
-  test('arms when the user cancels during pre-query work', async () => {
-    const queryGuard = new QueryGuard()
-    const tracker = new InterruptionCorrectionTracker(
-      queryGuard,
-      () => 'session-a',
-    )
-    const modelTurn = queryGuard.tryStart({
-      queryId: 'pre-query-turn',
-      querySource: 'repl_main_thread',
-      startedAt: 1,
-    })!
-    let releasePreQuery!: () => void
-    const preQueryPending = new Promise<void>(resolve => {
-      releasePreQuery = resolve
-    })
-    let signalPreQueryStarted!: () => void
-    const preQueryStarted = new Promise<void>(resolve => {
-      signalPreQueryStarted = resolve
-    })
-    const turn = tracker.runModelTurn({
-      shouldQuery: true,
-      isInterruptionCorrectionEligible: true,
-      queryId: modelTurn.context.queryId,
-      run: async () => {
-        signalPreQueryStarted()
-        await preQueryPending
-      },
-    })
-
-    await preQueryStarted
-    tracker.handleCancellation({
-      isUserInitiated: true,
-      isRemoteMode: false,
-    })
-    queryGuard.forceEnd('user-abort', 'user-cancel')
-    releasePreQuery()
-    await turn
-
-    expect(tracker.takeReminder()).toMatchObject({
-      type: 'user',
-      isMeta: true,
-    })
+  test('binds correction tracking only after pre-query work', () => {
+    const preQuery = source.indexOf('await mrOnBeforeQuery')
+    const bind = source.indexOf('await interruptionCorrectionTracker.runModelTurn')
+    expect(preQuery).toBeGreaterThan(-1)
+    expect(bind).toBeGreaterThan(preQuery)
   })
 
   test('does not arm when the model turn is marked ineligible', async () => {

--- a/src/screens/REPL.tsx
+++ b/src/screens/REPL.tsx
@@ -136,7 +136,7 @@ import { BASH_INPUT_TAG, COMMAND_MESSAGE_TAG, COMMAND_NAME_TAG, LOCAL_COMMAND_ST
 import { escapeXml } from '../utils/xml.js';
 import type { ThinkingConfig } from '../utils/thinking.js';
 import { gracefulShutdownSync, isShuttingDown } from '../utils/gracefulShutdown.js';
-import { buildConcurrentRequeuedPrompt, handlePromptSubmit, isNormalLocalUserPrompt, type PromptInputHelpers } from '../utils/handlePromptSubmit.js';
+import { buildConcurrentRequeuedPrompt, handlePromptSubmit, type PromptInputHelpers } from '../utils/handlePromptSubmit.js';
 import { applyInterruptionCorrectionAutoRestore, applyInterruptionCorrectionAwareMessageUpdate, buildInterruptionCorrectionMessageViews, InterruptionCorrectionTracker } from '../utils/interruptionCorrection.js';
 import { useQueueProcessor } from '../hooks/useQueueProcessor.js';
 import { useMailboxBridge } from '../hooks/useMailboxBridge.js';
@@ -2337,7 +2337,6 @@ export function REPL({
     interruptionCorrectionTracker.handleCancellation({
       isUserInitiated,
       isRemoteMode: activeRemote.isRemoteMode,
-      hasQueuedNormalPrompt: getCommandQueue().some(isNormalLocalUserPrompt)
     });
     const cancelOperations = queryLifecycleTrackerRef.current.snapshot();
     const completedCancelContext = cancelContext ? {

--- a/src/screens/REPL.tsx
+++ b/src/screens/REPL.tsx
@@ -137,6 +137,7 @@ import { escapeXml } from '../utils/xml.js';
 import type { ThinkingConfig } from '../utils/thinking.js';
 import { gracefulShutdownSync, isShuttingDown } from '../utils/gracefulShutdown.js';
 import { handlePromptSubmit, type PromptInputHelpers } from '../utils/handlePromptSubmit.js';
+import { consumeInterruptionCorrectionReminder, shouldMarkInterruptionCorrection } from '../utils/interruptionCorrection.js';
 import { useQueueProcessor } from '../hooks/useQueueProcessor.js';
 import { useMailboxBridge } from '../hooks/useMailboxBridge.js';
 import { queryCheckpoint, logQueryProfileReport, clearQueryProfile } from '../utils/queryProfiler.js';
@@ -975,6 +976,17 @@ export function REPL({
   // Ref for the synchronous restore callback — set after restoreMessageSync is
   // defined, read in the onQuery finally block for auto-restore on interrupt.
   const restoreMessageSyncRef = useRef<(m: UserMessage) => void>(() => { });
+
+  // A user-cancelled model turn arms one hidden reminder for the next normal
+  // local prompt. The query id prevents local command dispatch from being
+  // mistaken for an active assistant turn.
+  const pendingInterruptionCorrectionSessionRef = useRef<string | null>(null);
+  const modelBoundQueryIdRef = useRef<string | null>(null);
+  const takeInterruptionCorrectionReminder = useCallback(() => {
+    const result = consumeInterruptionCorrectionReminder(pendingInterruptionCorrectionSessionRef.current, getSessionId());
+    pendingInterruptionCorrectionSessionRef.current = result.pendingSessionId;
+    return result.reminder;
+  }, []);
 
   // Ref to the fullscreen layout's scroll box for keyboard scrolling.
   // Null when fullscreen mode is disabled (ref never attached).
@@ -2300,7 +2312,7 @@ export function REPL({
     if (was !== now) repinScroll();
     prevDialogRef.current = focusedInputDialog;
   }, [focusedInputDialog, repinScroll]);
-  function onCancel() {
+  function onCancel(isUserInitiated = false) {
     if (focusedInputDialog === 'elicitation') {
       // Elicitation dialog handles its own Escape, and closing it shouldn't affect any loading state.
       return;
@@ -2313,6 +2325,17 @@ export function REPL({
       proactiveModule?.pauseProactive();
     }
     const cancelContext = queryGuard.activeContext;
+    if (shouldMarkInterruptionCorrection({
+      isUserInitiated,
+      activeQueryId: cancelContext?.queryId ?? null,
+      modelBoundQueryId: modelBoundQueryIdRef.current,
+      isRemoteMode: activeRemote.isRemoteMode
+    })) {
+      pendingInterruptionCorrectionSessionRef.current = getSessionId();
+    }
+    if (cancelContext?.queryId === modelBoundQueryIdRef.current) {
+      modelBoundQueryIdRef.current = null;
+    }
     const cancelOperations = queryLifecycleTrackerRef.current.snapshot();
     const completedCancelContext = cancelContext ? {
       ...cancelContext,
@@ -2407,7 +2430,7 @@ export function REPL({
   // CancelRequestHandler props - rendered inside KeybindingSetup
   const cancelRequestProps = {
     setToolUseConfirmQueue,
-    onCancel,
+    onCancel: () => onCancel(true),
     onAgentsKilled: () => setMessages(prev => [...prev, createAgentsKilledMessage()]),
     isMessageSelectorVisible: isMessageSelectorVisible || !!showBashesDialog,
     screen,
@@ -3160,11 +3183,17 @@ export function REPL({
           return;
         }
       }
+      if (shouldQuery && !abortController.signal.aborted && queryGuard.activeContext?.queryId === queryContext.queryId) {
+        modelBoundQueryIdRef.current = queryContext.queryId;
+      }
       await onQueryImpl(latestMessages, newMessages, abortController, shouldQuery, additionalAllowedTools, mainLoopModelParam, thisGeneration, effort, lifecycleTracker);
     } catch (error) {
       didThrow = true;
       throw error;
     } finally {
+      if (modelBoundQueryIdRef.current === queryContext.queryId) {
+        modelBoundQueryIdRef.current = null;
+      }
       const terminalReason = getQueryTerminalReason(abortController.signal, didThrow);
       const abortReason = getAbortReasonLabel(abortController.signal.reason);
       const activeOperations = lifecycleTracker.snapshot();
@@ -3810,6 +3839,7 @@ export function REPL({
       addNotification,
       setMessages,
       slashCommandOverride: options?.slashCommandOverride,
+      takeInterruptionCorrectionReminder,
       // Read via ref so streamMode can be dropped from onSubmit deps —
       // handlePromptSubmit only uses it for debug log + telemetry event.
       streamMode: streamModeRef.current,
@@ -3840,7 +3870,7 @@ export function REPL({
     // messages array in downstream closures (PromptInput, handleAutoRunIssue).
     // Heap analysis showed ~9 REPL scopes and ~15 messages array versions
     // accumulating after #20174/#20175, all traced to this dep.
-    mainLoopModel, pastedContents, ideSelection, setUserInputOnProcessing, setAbortController, addNotification, onQuery, stashedPrompt, setStashedPrompt, setAppState, onBeforeQuery, canUseTool, remoteSession, setMessages, awaitPendingHooks, repinScroll]);
+    mainLoopModel, pastedContents, ideSelection, setUserInputOnProcessing, setAbortController, addNotification, onQuery, stashedPrompt, setStashedPrompt, setAppState, onBeforeQuery, canUseTool, remoteSession, setMessages, awaitPendingHooks, repinScroll, takeInterruptionCorrectionReminder]);
 
   // Callback for when user submits input while viewing a teammate's transcript
   const onAgentSubmit = useCallback(async (input: string, task: InProcessTeammateTaskState | LocalAgentTaskState, helpers: PromptInputHelpers) => {
@@ -4175,9 +4205,10 @@ export function REPL({
       canUseTool,
       addNotification,
       setMessages,
+      takeInterruptionCorrectionReminder,
       queuedCommands
     });
-  }, [queryGuard, commands, setToolJSX, getToolUseContext, messages, mainLoopModel, ideSelection, setUserInputOnProcessing, canUseTool, setAbortController, onQuery, addNotification, setAppState, onBeforeQuery]);
+  }, [queryGuard, commands, setToolJSX, getToolUseContext, messages, mainLoopModel, ideSelection, setUserInputOnProcessing, canUseTool, setAbortController, onQuery, addNotification, setAppState, onBeforeQuery, takeInterruptionCorrectionReminder]);
   useQueueProcessor({
     executeQueuedInput,
     hasActiveLocalJsxUI: isShowingLocalJSXCommand,

--- a/src/screens/REPL.tsx
+++ b/src/screens/REPL.tsx
@@ -976,7 +976,7 @@ export function REPL({
   // Ref for the synchronous restore callback — set after restoreMessageSync is
   // defined, read in the onQuery finally block for auto-restore on interrupt.
   const restoreMessageSyncRef = useRef<(m: UserMessage, options?: {
-    interruptionCorrectionRequestOnlyMessages?: readonly MessageType[];
+    preserveInterruptionCorrectionReminder?: boolean;
   }) => void>(() => { });
 
   // Ref to the fullscreen layout's scroll box for keyboard scrolling.
@@ -2929,7 +2929,7 @@ export function REPL({
       void removeTranscriptMessage(tombstonedMessage.uuid);
     }, setStreamingThinking, undefined, onStreamingText);
   }, [setMessages, setResponseLength, setStreamMode, setStreamingToolUses, setStreamingThinking, onStreamingText]);
-  const onQueryImpl = useCallback(async (messagesIncludingNewMessages: MessageType[], newMessages: MessageType[], abortController: AbortController, shouldQuery: boolean, additionalAllowedTools: string[], mainLoopModelParam: string, queryGeneration: number, effort?: EffortValue, queryLifecycle?: QueryLifecycleOperationTracker, requestOnlyMessages: MessageType[] = []) => {
+  const onQueryImpl = useCallback(async (messagesIncludingNewMessages: MessageType[], newMessages: MessageType[], abortController: AbortController, shouldQuery: boolean, additionalAllowedTools: string[], mainLoopModelParam: string, queryGeneration: number, effort?: EffortValue, queryLifecycle?: QueryLifecycleOperationTracker, requestOnlyMessages: MessageType[] = [], interruptionCorrectionQueryId?: string) => {
     // Prepare IDE integration for new prompt. Read mcpClients fresh from
     // store — useManageMCPConnections may have populated it since the
     // render that captured this closure (same pattern as computeTools).
@@ -3087,6 +3087,11 @@ export function REPL({
       queryGuard.registerActivity(`query_event:${event.type}`, queryGeneration);
       onQueryEvent(event);
     }
+    // The provider stream is complete. Post-turn callbacks may await external
+    // work, but Esc during that work must not be treated as interrupting it.
+    if (interruptionCorrectionQueryId) {
+      interruptionCorrectionTracker.finishModelTurn(interruptionCorrectionQueryId);
+    }
     if (isBuddyEnabled()) {
       void fireCompanionObserver(messagesRef.current, reaction => setAppState(prev => prev.companionReaction === reaction ? prev : {
         ...prev,
@@ -3102,7 +3107,7 @@ export function REPL({
 
     // Signal that a query turn has completed successfully
     await onTurnComplete?.(messagesRef.current);
-  }, [initialMcpClients, resetLoadingState, getToolUseContext, toolPermissionContext, setAppState, customSystemPrompt, onTurnComplete, appendSystemPrompt, canUseTool, mainThreadAgentDefinition, onQueryEvent, sessionTitle, titleDisabled, maxTurns, getAutoCompactTrackingForSession, setAutoCompactTrackingForSession, setAutoCompactTrackingForSessionIfUnchanged, queryGuard]);
+  }, [initialMcpClients, resetLoadingState, getToolUseContext, toolPermissionContext, setAppState, customSystemPrompt, onTurnComplete, appendSystemPrompt, canUseTool, mainThreadAgentDefinition, onQueryEvent, sessionTitle, titleDisabled, maxTurns, getAutoCompactTrackingForSession, setAutoCompactTrackingForSession, setAutoCompactTrackingForSessionIfUnchanged, queryGuard, interruptionCorrectionTracker]);
   const onQuery = useCallback(async (newMessages: MessageType[], abortController: AbortController, shouldQuery: boolean, additionalAllowedTools: string[], mainLoopModelParam: string, onBeforeQueryCallback?: (input: string, newMessages: MessageType[]) => Promise<boolean>, input?: string, effort?: EffortValue, isInterruptionCorrectionEligible = false): Promise<void | false> => {
     // If this is a teammate, mark them as active when starting a turn
     if (isAgentSwarmsEnabled()) {
@@ -3145,8 +3150,9 @@ export function REPL({
     logQueryLifecycle('start', queryContext);
     logQueryLifecycle('guard_start', queryContext);
     let didThrow = false;
-    let interruptionCorrectionRequestOnlyMessages: readonly MessageType[] = [];
     let preflightVetoed = false;
+    let modelTurnStarted = false;
+    let hasInterruptionCorrectionRequestOnlyMessage = false;
     try {
       // isLoading is derived from queryGuard — tryStart() above already
       // transitioned dispatching→running, so no setter call needed here.
@@ -3163,7 +3169,7 @@ export function REPL({
         persistentNewMessages,
         requestOnlyMessages
       } = buildInterruptionCorrectionMessageViews(messagesRef.current, newMessages);
-      interruptionCorrectionRequestOnlyMessages = requestOnlyMessages;
+      hasInterruptionCorrectionRequestOnlyMessage = requestOnlyMessages.length > 0;
       setMessages(persistentMessages);
       responseLengthRef.current = 0;
       if (feature('TOKEN_BUDGET')) {
@@ -3193,12 +3199,13 @@ export function REPL({
         }
       }
       if (!preflightVetoed) {
+        modelTurnStarted = true;
         await interruptionCorrectionTracker.runModelTurn({
           shouldQuery,
           isInterruptionCorrectionEligible,
           queryId: queryContext.queryId,
           run: async () => {
-            await onQueryImpl(latestMessages, persistentNewMessages, abortController, shouldQuery, additionalAllowedTools, mainLoopModelParam, thisGeneration, effort, lifecycleTracker, requestOnlyMessages);
+            await onQueryImpl(latestMessages, persistentNewMessages, abortController, shouldQuery, additionalAllowedTools, mainLoopModelParam, thisGeneration, effort, lifecycleTracker, requestOnlyMessages, queryContext.queryId);
           },
         });
       }
@@ -3207,6 +3214,11 @@ export function REPL({
       }
     } catch (error) {
       didThrow = true;
+      // A preflight failure happens before any provider request owns this
+      // request-only reminder, so keep it for the next eligible correction.
+      if (!modelTurnStarted && hasInterruptionCorrectionRequestOnlyMessage) {
+        interruptionCorrectionTracker.restoreReminder();
+      }
       throw error;
     } finally {
       const terminalReason = getQueryTerminalReason(abortController.signal, didThrow);
@@ -3357,7 +3369,7 @@ export function REPL({
             // otherwise Up-arrow shows the restored text twice.
             removeLastFromHistory();
             restoreMessageSyncRef.current(lastUserMsg, {
-              interruptionCorrectionRequestOnlyMessages
+              preserveInterruptionCorrectionReminder: true
             });
           }
         }
@@ -3997,12 +4009,12 @@ export function REPL({
   // fresh via the setMessages wrapper) so callers don't need to worry about
   // stale closures.
   const rewindConversationTo = useCallback((message: UserMessage, {
-    interruptionCorrectionRequestOnlyMessages = []
+    preserveInterruptionCorrectionReminder = false
   }: {
-    interruptionCorrectionRequestOnlyMessages?: readonly MessageType[];
+    preserveInterruptionCorrectionReminder?: boolean;
   } = {}) => {
     const prev = messagesRef.current;
-    const messageIndex = applyInterruptionCorrectionAutoRestore(prev, message, setMessages, interruptionCorrectionTracker, interruptionCorrectionRequestOnlyMessages);
+    const messageIndex = applyInterruptionCorrectionAutoRestore(prev, message, setMessages, interruptionCorrectionTracker, preserveInterruptionCorrectionReminder);
     if (messageIndex === null) return;
     logEvent('tengu_conversation_rewind', {
       preRewindMessageCount: prev.length,
@@ -4054,7 +4066,7 @@ export function REPL({
   // interrupt (so React batches with the abort's setMessages → single render,
   // no flicker). MessageSelector wraps this in setImmediate via handleRestoreMessage.
   const restoreMessageSync = useCallback((message: UserMessage, options?: {
-    interruptionCorrectionRequestOnlyMessages?: readonly MessageType[];
+    preserveInterruptionCorrectionReminder?: boolean;
   }) => {
     rewindConversationTo(message, options);
     const r = textForResubmit(message);

--- a/src/screens/REPL.tsx
+++ b/src/screens/REPL.tsx
@@ -137,7 +137,7 @@ import { escapeXml } from '../utils/xml.js';
 import type { ThinkingConfig } from '../utils/thinking.js';
 import { gracefulShutdownSync, isShuttingDown } from '../utils/gracefulShutdown.js';
 import { handlePromptSubmit, type PromptInputHelpers } from '../utils/handlePromptSubmit.js';
-import { consumeInterruptionCorrectionReminder, shouldMarkInterruptionCorrection } from '../utils/interruptionCorrection.js';
+import { InterruptionCorrectionTracker } from '../utils/interruptionCorrection.js';
 import { useQueueProcessor } from '../hooks/useQueueProcessor.js';
 import { useMailboxBridge } from '../hooks/useMailboxBridge.js';
 import { queryCheckpoint, logQueryProfileReport, clearQueryProfile } from '../utils/queryProfiler.js';
@@ -980,12 +980,9 @@ export function REPL({
   // A user-cancelled model turn arms one hidden reminder for the next normal
   // local prompt. The query id prevents local command dispatch from being
   // mistaken for an active assistant turn.
-  const pendingInterruptionCorrectionSessionRef = useRef<string | null>(null);
-  const modelBoundQueryIdRef = useRef<string | null>(null);
+  const interruptionCorrectionTrackerRef = useRef(new InterruptionCorrectionTracker());
   const takeInterruptionCorrectionReminder = useCallback(() => {
-    const result = consumeInterruptionCorrectionReminder(pendingInterruptionCorrectionSessionRef.current, getSessionId());
-    pendingInterruptionCorrectionSessionRef.current = result.pendingSessionId;
-    return result.reminder;
+    return interruptionCorrectionTrackerRef.current.takeReminder(getSessionId());
   }, []);
 
   // Ref to the fullscreen layout's scroll box for keyboard scrolling.
@@ -2325,17 +2322,12 @@ export function REPL({
       proactiveModule?.pauseProactive();
     }
     const cancelContext = queryGuard.activeContext;
-    if (shouldMarkInterruptionCorrection({
+    interruptionCorrectionTrackerRef.current.handleCancellation({
       isUserInitiated,
       activeQueryId: cancelContext?.queryId ?? null,
-      modelBoundQueryId: modelBoundQueryIdRef.current,
-      isRemoteMode: activeRemote.isRemoteMode
-    })) {
-      pendingInterruptionCorrectionSessionRef.current = getSessionId();
-    }
-    if (cancelContext?.queryId === modelBoundQueryIdRef.current) {
-      modelBoundQueryIdRef.current = null;
-    }
+      isRemoteMode: activeRemote.isRemoteMode,
+      sessionId: getSessionId()
+    });
     const cancelOperations = queryLifecycleTrackerRef.current.snapshot();
     const completedCancelContext = cancelContext ? {
       ...cancelContext,
@@ -3183,17 +3175,18 @@ export function REPL({
           return;
         }
       }
-      if (shouldQuery && !abortController.signal.aborted && queryGuard.activeContext?.queryId === queryContext.queryId) {
-        modelBoundQueryIdRef.current = queryContext.queryId;
-      }
+      interruptionCorrectionTrackerRef.current.bindModelTurn({
+        shouldQuery,
+        isAborted: abortController.signal.aborted,
+        activeQueryId: queryGuard.activeContext?.queryId ?? null,
+        queryId: queryContext.queryId
+      });
       await onQueryImpl(latestMessages, newMessages, abortController, shouldQuery, additionalAllowedTools, mainLoopModelParam, thisGeneration, effort, lifecycleTracker);
     } catch (error) {
       didThrow = true;
       throw error;
     } finally {
-      if (modelBoundQueryIdRef.current === queryContext.queryId) {
-        modelBoundQueryIdRef.current = null;
-      }
+      interruptionCorrectionTrackerRef.current.finishModelTurn(queryContext.queryId);
       const terminalReason = getQueryTerminalReason(abortController.signal, didThrow);
       const abortReason = getAbortReasonLabel(abortController.signal.reason);
       const activeOperations = lifecycleTracker.snapshot();

--- a/src/screens/REPL.tsx
+++ b/src/screens/REPL.tsx
@@ -3175,32 +3175,33 @@ export function REPL({
       lastFlushedStreamingVisibleRef.current = null;
       setStreamingText(null);
 
-      await interruptionCorrectionTracker.runModelTurn({
-        shouldQuery,
-        isInterruptionCorrectionEligible,
-        queryId: queryContext.queryId,
-        run: async () => {
-          // Request-only context is passed separately to query(), so compaction,
-          // tools, transcript logging, later turns, and resume never persist it.
-          const latestMessages = persistentMessages;
-          if (input) {
-            await mrOnBeforeQuery(input, latestMessages, persistentNewMessages.length);
-          }
+      // Request-only context is passed separately to query(), so compaction,
+      // tools, transcript logging, later turns, and resume never persist it.
+      const latestMessages = persistentMessages;
+      if (input) {
+        await mrOnBeforeQuery(input, latestMessages, persistentNewMessages.length);
+      }
 
-          // Pass full conversation history to callback
-          if (onBeforeQueryCallback && input) {
-            const shouldProceed = await onBeforeQueryCallback(input, latestMessages);
-            if (!shouldProceed) {
-              // No provider request owns this reminder when preflight vetoes
-              // the turn. Return false so handlePromptSubmit restores it for
-              // the next eligible correction prompt.
-              preflightVetoed = true;
-              return;
-            }
-          }
-          await onQueryImpl(latestMessages, persistentNewMessages, abortController, shouldQuery, additionalAllowedTools, mainLoopModelParam, thisGeneration, effort, lifecycleTracker, requestOnlyMessages);
+      // Pass full conversation history to callback
+      if (onBeforeQueryCallback && input) {
+        const shouldProceed = await onBeforeQueryCallback(input, latestMessages);
+        if (!shouldProceed) {
+          // No provider request owns this reminder when preflight vetoes
+          // the turn. Return false so handlePromptSubmit restores it for
+          // the next eligible correction prompt.
+          preflightVetoed = true;
         }
-      });
+      }
+      if (!preflightVetoed) {
+        await interruptionCorrectionTracker.runModelTurn({
+          shouldQuery,
+          isInterruptionCorrectionEligible,
+          queryId: queryContext.queryId,
+          run: async () => {
+          await onQueryImpl(latestMessages, persistentNewMessages, abortController, shouldQuery, additionalAllowedTools, mainLoopModelParam, thisGeneration, effort, lifecycleTracker, requestOnlyMessages);
+          },
+        });
+      }
       if (preflightVetoed) {
         return false;
       }

--- a/src/screens/REPL.tsx
+++ b/src/screens/REPL.tsx
@@ -3102,7 +3102,7 @@ export function REPL({
 
     // Signal that a query turn has completed successfully
     await onTurnComplete?.(messagesRef.current);
-  }, [initialMcpClients, resetLoadingState, getToolUseContext, toolPermissionContext, setAppState, customSystemPrompt, onTurnComplete, appendSystemPrompt, canUseTool, mainThreadAgentDefinition, onQueryEvent, sessionTitle, titleDisabled, getAutoCompactTrackingForSession, setAutoCompactTrackingForSession, setAutoCompactTrackingForSessionIfUnchanged, queryGuard]);
+  }, [initialMcpClients, resetLoadingState, getToolUseContext, toolPermissionContext, setAppState, customSystemPrompt, onTurnComplete, appendSystemPrompt, canUseTool, mainThreadAgentDefinition, onQueryEvent, sessionTitle, titleDisabled, maxTurns, getAutoCompactTrackingForSession, setAutoCompactTrackingForSession, setAutoCompactTrackingForSessionIfUnchanged, queryGuard]);
   const onQuery = useCallback(async (newMessages: MessageType[], abortController: AbortController, shouldQuery: boolean, additionalAllowedTools: string[], mainLoopModelParam: string, onBeforeQueryCallback?: (input: string, newMessages: MessageType[]) => Promise<boolean>, input?: string, effort?: EffortValue, isInterruptionCorrectionEligible = false): Promise<void | false> => {
     // If this is a teammate, mark them as active when starting a turn
     if (isAgentSwarmsEnabled()) {

--- a/src/screens/REPL.tsx
+++ b/src/screens/REPL.tsx
@@ -3198,7 +3198,7 @@ export function REPL({
           isInterruptionCorrectionEligible,
           queryId: queryContext.queryId,
           run: async () => {
-          await onQueryImpl(latestMessages, persistentNewMessages, abortController, shouldQuery, additionalAllowedTools, mainLoopModelParam, thisGeneration, effort, lifecycleTracker, requestOnlyMessages);
+            await onQueryImpl(latestMessages, persistentNewMessages, abortController, shouldQuery, additionalAllowedTools, mainLoopModelParam, thisGeneration, effort, lifecycleTracker, requestOnlyMessages);
           },
         });
       }

--- a/src/screens/REPL.tsx
+++ b/src/screens/REPL.tsx
@@ -3162,34 +3162,34 @@ export function REPL({
       lastFlushedStreamingVisibleRef.current = null;
       setStreamingText(null);
 
-      // messagesRef is updated synchronously by the setMessages wrapper
-      // above, so it already includes newMessages from the append at the
-      // top of this try block.  No reconstruction needed, no waiting for
-      // React's scheduler (previously cost 20-56ms per prompt; the 56ms
-      // case was a GC pause caught during the await).
-      const latestMessages = messagesRef.current;
-      if (input) {
-        await mrOnBeforeQuery(input, latestMessages, newMessages.length);
-      }
-
-      // Pass full conversation history to callback
-      if (onBeforeQueryCallback && input) {
-        const shouldProceed = await onBeforeQueryCallback(input, latestMessages);
-        if (!shouldProceed) {
-          return;
-        }
-      }
-      interruptionCorrectionTracker.bindModelTurn({
+      await interruptionCorrectionTracker.runModelTurn({
         shouldQuery,
-        isAborted: abortController.signal.aborted,
-        queryId: queryContext.queryId
+        queryId: queryContext.queryId,
+        run: async () => {
+          // messagesRef is updated synchronously by the setMessages wrapper
+          // above, so it already includes newMessages from the append at the
+          // top of this try block.  No reconstruction needed, no waiting for
+          // React's scheduler (previously cost 20-56ms per prompt; the 56ms
+          // case was a GC pause caught during the await).
+          const latestMessages = messagesRef.current;
+          if (input) {
+            await mrOnBeforeQuery(input, latestMessages, newMessages.length);
+          }
+
+          // Pass full conversation history to callback
+          if (onBeforeQueryCallback && input) {
+            const shouldProceed = await onBeforeQueryCallback(input, latestMessages);
+            if (!shouldProceed) {
+              return;
+            }
+          }
+          await onQueryImpl(latestMessages, newMessages, abortController, shouldQuery, additionalAllowedTools, mainLoopModelParam, thisGeneration, effort, lifecycleTracker);
+        }
       });
-      await onQueryImpl(latestMessages, newMessages, abortController, shouldQuery, additionalAllowedTools, mainLoopModelParam, thisGeneration, effort, lifecycleTracker);
     } catch (error) {
       didThrow = true;
       throw error;
     } finally {
-      interruptionCorrectionTracker.finishModelTurn(queryContext.queryId);
       const terminalReason = getQueryTerminalReason(abortController.signal, didThrow);
       const abortReason = getAbortReasonLabel(abortController.signal.reason);
       const activeOperations = lifecycleTracker.snapshot();

--- a/src/screens/REPL.tsx
+++ b/src/screens/REPL.tsx
@@ -137,7 +137,7 @@ import { escapeXml } from '../utils/xml.js';
 import type { ThinkingConfig } from '../utils/thinking.js';
 import { gracefulShutdownSync, isShuttingDown } from '../utils/gracefulShutdown.js';
 import { buildConcurrentRequeuedPrompt, handlePromptSubmit, isNormalLocalUserPrompt, type PromptInputHelpers } from '../utils/handlePromptSubmit.js';
-import { applyInterruptionCorrectionAwareMessageUpdate, buildInterruptionCorrectionMessageViews, InterruptionCorrectionTracker } from '../utils/interruptionCorrection.js';
+import { applyInterruptionCorrectionAutoRestore, applyInterruptionCorrectionAwareMessageUpdate, buildInterruptionCorrectionMessageViews, InterruptionCorrectionTracker } from '../utils/interruptionCorrection.js';
 import { useQueueProcessor } from '../hooks/useQueueProcessor.js';
 import { useMailboxBridge } from '../hooks/useMailboxBridge.js';
 import { queryCheckpoint, logQueryProfileReport, clearQueryProfile } from '../utils/queryProfiler.js';
@@ -975,7 +975,9 @@ export function REPL({
 
   // Ref for the synchronous restore callback — set after restoreMessageSync is
   // defined, read in the onQuery finally block for auto-restore on interrupt.
-  const restoreMessageSyncRef = useRef<(m: UserMessage) => void>(() => { });
+  const restoreMessageSyncRef = useRef<(m: UserMessage, options?: {
+    interruptionCorrectionRequestOnlyMessages?: readonly MessageType[];
+  }) => void>(() => { });
 
   // Ref to the fullscreen layout's scroll box for keyboard scrolling.
   // Null when fullscreen mode is disabled (ref never attached).
@@ -3143,6 +3145,7 @@ export function REPL({
     logQueryLifecycle('start', queryContext);
     logQueryLifecycle('guard_start', queryContext);
     let didThrow = false;
+    let interruptionCorrectionRequestOnlyMessages: readonly MessageType[] = [];
     try {
       // isLoading is derived from queryGuard — tryStart() above already
       // transitioned dispatching→running, so no setter call needed here.
@@ -3159,6 +3162,7 @@ export function REPL({
         persistentNewMessages,
         requestOnlyMessages
       } = buildInterruptionCorrectionMessageViews(messagesRef.current, newMessages);
+      interruptionCorrectionRequestOnlyMessages = requestOnlyMessages;
       setMessages(persistentMessages);
       responseLengthRef.current = 0;
       if (feature('TOKEN_BUDGET')) {
@@ -3343,7 +3347,9 @@ export function REPL({
             // The submit is being undone — undo its history entry too,
             // otherwise Up-arrow shows the restored text twice.
             removeLastFromHistory();
-            restoreMessageSyncRef.current(lastUserMsg);
+            restoreMessageSyncRef.current(lastUserMsg, {
+              interruptionCorrectionRequestOnlyMessages
+            });
           }
         }
       }
@@ -3981,18 +3987,20 @@ export function REPL({
   // Does NOT touch the prompt input. Index is computed from messagesRef (always
   // fresh via the setMessages wrapper) so callers don't need to worry about
   // stale closures.
-  const rewindConversationTo = useCallback((message: UserMessage) => {
+  const rewindConversationTo = useCallback((message: UserMessage, {
+    interruptionCorrectionRequestOnlyMessages = []
+  }: {
+    interruptionCorrectionRequestOnlyMessages?: readonly MessageType[];
+  } = {}) => {
     const prev = messagesRef.current;
-    const messageIndex = prev.lastIndexOf(message);
-    if (messageIndex === -1) return;
+    const messageIndex = applyInterruptionCorrectionAutoRestore(prev, message, setMessages, interruptionCorrectionTracker, interruptionCorrectionRequestOnlyMessages);
+    if (messageIndex === null) return;
     logEvent('tengu_conversation_rewind', {
       preRewindMessageCount: prev.length,
       postRewindMessageCount: messageIndex,
       messagesRemoved: prev.length - messageIndex,
       rewindToMessageIndex: messageIndex
     });
-    setMessages(prev.slice(0, messageIndex));
-    interruptionCorrectionTracker.handleConversationRewrite();
     resetAutoCompactTracking();
     // Careful, this has to happen after setMessages
     setConversationId(randomUUID());
@@ -4036,8 +4044,10 @@ export function REPL({
   // Synchronous rewind + input population. Used directly by auto-restore on
   // interrupt (so React batches with the abort's setMessages → single render,
   // no flicker). MessageSelector wraps this in setImmediate via handleRestoreMessage.
-  const restoreMessageSync = useCallback((message: UserMessage) => {
-    rewindConversationTo(message);
+  const restoreMessageSync = useCallback((message: UserMessage, options?: {
+    interruptionCorrectionRequestOnlyMessages?: readonly MessageType[];
+  }) => {
+    rewindConversationTo(message, options);
     const r = textForResubmit(message);
     if (r) {
       setInputValue(r.text);

--- a/src/screens/REPL.tsx
+++ b/src/screens/REPL.tsx
@@ -3065,17 +3065,21 @@ export function REPL({
     resetTurnToolDuration();
     resetTurnClassifierDuration();
     let expectedAutoCompactTracking = queryAutoCompactTracking;
-    if (interruptionCorrectionQueryId) {
-      interruptionCorrectionTracker.bindModelTurn({
-        shouldQuery,
-        isInterruptionCorrectionEligible: true,
-        queryId: interruptionCorrectionQueryId,
-      });
-    }
-    try {
-      for await (const event of query({
+    for await (const event of query({
       messages: messagesIncludingNewMessages,
       requestOnlyMessages,
+      onModelRequestStart: interruptionCorrectionQueryId
+        ? () => interruptionCorrectionTracker.bindModelTurn({
+            shouldQuery,
+            isInterruptionCorrectionEligible: true,
+            queryId: interruptionCorrectionQueryId,
+          })
+        : undefined,
+      onModelRequestEnd: interruptionCorrectionQueryId
+        ? () => interruptionCorrectionTracker.finishModelTurn(
+            interruptionCorrectionQueryId,
+          )
+        : undefined,
       systemPrompt,
       userContext,
       systemContext,
@@ -3091,14 +3095,8 @@ export function REPL({
         }
       }
       })) {
-        queryGuard.registerActivity(`query_event:${event.type}`, queryGeneration);
-        onQueryEvent(event);
-      }
-    } finally {
-      // Only the provider request itself is interruption-eligible.
-      if (interruptionCorrectionQueryId) {
-        interruptionCorrectionTracker.finishModelTurn(interruptionCorrectionQueryId);
-      }
+      queryGuard.registerActivity(`query_event:${event.type}`, queryGeneration);
+      onQueryEvent(event);
     }
     if (isBuddyEnabled()) {
       void fireCompanionObserver(messagesRef.current, reaction => setAppState(prev => prev.companionReaction === reaction ? prev : {

--- a/src/screens/REPL.tsx
+++ b/src/screens/REPL.tsx
@@ -4047,7 +4047,7 @@ export function REPL({
         generationRequestId: null
       }
     }));
-  }, [setMessages, resetAutoCompactTracking, setAppState, interruptionCorrectionTracker]);
+  }, [setMessages, resetAutoCompactTracking, setAppState, interruptionCorrectionTracker, setConversationId]);
 
   // Synchronous rewind + input population. Used directly by auto-restore on
   // interrupt (so React batches with the abort's setMessages → single render,
@@ -4081,7 +4081,7 @@ export function REPL({
         setPastedContents(newPastedContents);
       }
     }
-  }, [rewindConversationTo, setInputValue]);
+  }, [rewindConversationTo, setInputValue, setInputMode]);
   restoreMessageSyncRef.current = restoreMessageSync;
 
   // MessageSelector path: defer via setImmediate so the "Interrupted" message

--- a/src/screens/REPL.tsx
+++ b/src/screens/REPL.tsx
@@ -3065,7 +3065,15 @@ export function REPL({
     resetTurnToolDuration();
     resetTurnClassifierDuration();
     let expectedAutoCompactTracking = queryAutoCompactTracking;
-    for await (const event of query({
+    if (interruptionCorrectionQueryId) {
+      interruptionCorrectionTracker.bindModelTurn({
+        shouldQuery,
+        isInterruptionCorrectionEligible: true,
+        queryId: interruptionCorrectionQueryId,
+      });
+    }
+    try {
+      for await (const event of query({
       messages: messagesIncludingNewMessages,
       requestOnlyMessages,
       systemPrompt,
@@ -3082,14 +3090,15 @@ export function REPL({
           expectedAutoCompactTracking = tracking;
         }
       }
-    })) {
-      queryGuard.registerActivity(`query_event:${event.type}`, queryGeneration);
-      onQueryEvent(event);
-    }
-    // The provider stream is complete. Post-turn callbacks may await external
-    // work, but Esc during that work must not be treated as interrupting it.
-    if (interruptionCorrectionQueryId) {
-      interruptionCorrectionTracker.finishModelTurn(interruptionCorrectionQueryId);
+      })) {
+        queryGuard.registerActivity(`query_event:${event.type}`, queryGeneration);
+        onQueryEvent(event);
+      }
+    } finally {
+      // Only the provider request itself is interruption-eligible.
+      if (interruptionCorrectionQueryId) {
+        interruptionCorrectionTracker.finishModelTurn(interruptionCorrectionQueryId);
+      }
     }
     if (isBuddyEnabled()) {
       void fireCompanionObserver(messagesRef.current, reaction => setAppState(prev => prev.companionReaction === reaction ? prev : {
@@ -3199,14 +3208,7 @@ export function REPL({
       }
       if (!preflightVetoed) {
         modelTurnStarted = true;
-        await interruptionCorrectionTracker.runModelTurn({
-          shouldQuery,
-          isInterruptionCorrectionEligible,
-          queryId: queryContext.queryId,
-          run: async () => {
-            await onQueryImpl(latestMessages, persistentNewMessages, abortController, shouldQuery, additionalAllowedTools, mainLoopModelParam, thisGeneration, effort, lifecycleTracker, requestOnlyMessages, queryContext.queryId);
-          },
-        });
+        await onQueryImpl(latestMessages, persistentNewMessages, abortController, shouldQuery, additionalAllowedTools, mainLoopModelParam, thisGeneration, effort, lifecycleTracker, requestOnlyMessages, isInterruptionCorrectionEligible ? queryContext.queryId : undefined);
       }
       if (preflightVetoed) {
         return false;

--- a/src/screens/REPL.tsx
+++ b/src/screens/REPL.tsx
@@ -977,14 +977,6 @@ export function REPL({
   // defined, read in the onQuery finally block for auto-restore on interrupt.
   const restoreMessageSyncRef = useRef<(m: UserMessage) => void>(() => { });
 
-  // A user-cancelled model turn arms one hidden reminder for the next normal
-  // local prompt. The query id prevents local command dispatch from being
-  // mistaken for an active assistant turn.
-  const interruptionCorrectionTrackerRef = useRef(new InterruptionCorrectionTracker());
-  const takeInterruptionCorrectionReminder = useCallback(() => {
-    return interruptionCorrectionTrackerRef.current.takeReminder(getSessionId());
-  }, []);
-
   // Ref to the fullscreen layout's scroll box for keyboard scrolling.
   // Null when fullscreen mode is disabled (ref never attached).
   const scrollRef = useRef<ScrollBoxHandle>(null);
@@ -1011,6 +1003,17 @@ export function REPL({
     queryGuardRef.current = new QueryGuard(getQueryGuardOptionsFromEnv());
   }
   const queryGuard = queryGuardRef.current;
+
+  // A user-cancelled model turn arms one hidden reminder for the next normal
+  // local prompt. The tracker reads QueryGuard directly so its tested lifecycle
+  // rules cannot drift from the REPL's active-query identity.
+  const interruptionCorrectionTrackerRef = useRef<InterruptionCorrectionTracker | null>(null);
+  if (interruptionCorrectionTrackerRef.current === null) {
+    interruptionCorrectionTrackerRef.current = new InterruptionCorrectionTracker(queryGuard, getSessionId);
+  }
+  const takeInterruptionCorrectionReminder = useCallback(() => {
+    return interruptionCorrectionTrackerRef.current!.takeReminder();
+  }, []);
 
   // Subscribe to the guard — true during dispatching or running.
   // This is the single source of truth for "is a local query in flight".
@@ -2309,6 +2312,8 @@ export function REPL({
     if (was !== now) repinScroll();
     prevDialogRef.current = focusedInputDialog;
   }, [focusedInputDialog, repinScroll]);
+  // Omitted means a programmatic edit/restore cancellation, which must not arm
+  // correction context because those flows rewind the conversation themselves.
   function onCancel(isUserInitiated = false) {
     if (focusedInputDialog === 'elicitation') {
       // Elicitation dialog handles its own Escape, and closing it shouldn't affect any loading state.
@@ -2324,9 +2329,7 @@ export function REPL({
     const cancelContext = queryGuard.activeContext;
     interruptionCorrectionTrackerRef.current.handleCancellation({
       isUserInitiated,
-      activeQueryId: cancelContext?.queryId ?? null,
-      isRemoteMode: activeRemote.isRemoteMode,
-      sessionId: getSessionId()
+      isRemoteMode: activeRemote.isRemoteMode
     });
     const cancelOperations = queryLifecycleTrackerRef.current.snapshot();
     const completedCancelContext = cancelContext ? {
@@ -3178,7 +3181,6 @@ export function REPL({
       interruptionCorrectionTrackerRef.current.bindModelTurn({
         shouldQuery,
         isAborted: abortController.signal.aborted,
-        activeQueryId: queryGuard.activeContext?.queryId ?? null,
         queryId: queryContext.queryId
       });
       await onQueryImpl(latestMessages, newMessages, abortController, shouldQuery, additionalAllowedTools, mainLoopModelParam, thisGeneration, effort, lifecycleTracker);

--- a/src/screens/REPL.tsx
+++ b/src/screens/REPL.tsx
@@ -3082,11 +3082,6 @@ export function REPL({
             onModelRequestStart?.()
           }
         : undefined,
-      onModelRequestEnd: interruptionCorrectionQueryId
-        ? () => interruptionCorrectionTracker.finishModelTurn(
-            interruptionCorrectionQueryId,
-          )
-        : undefined,
       systemPrompt,
       userContext,
       systemContext,
@@ -3227,6 +3222,10 @@ export function REPL({
       }
       throw error;
     } finally {
+      // A provider response can hand off to tools before the assistant turn
+      // finishes. Keep correction ownership through that work (and retries),
+      // then clear it only when this query reaches its terminal cleanup.
+      interruptionCorrectionTracker.finishModelTurn(queryContext.queryId);
       const terminalReason = getQueryTerminalReason(abortController.signal, didThrow);
       const abortReason = getAbortReasonLabel(abortController.signal.reason);
       const activeOperations = lifecycleTracker.snapshot();

--- a/src/screens/REPL.tsx
+++ b/src/screens/REPL.tsx
@@ -2018,6 +2018,7 @@ export function REPL({
       // Clear any active loading state (no queryId since we're not in a query)
       resetLoadingState();
       setAbortController(null);
+      interruptionCorrectionTracker.handleSessionChange();
       setConversationId(sessionId);
 
       // Get target session's costs BEFORE saving current session

--- a/src/screens/REPL.tsx
+++ b/src/screens/REPL.tsx
@@ -3094,8 +3094,8 @@ export function REPL({
 
     // Signal that a query turn has completed successfully
     await onTurnComplete?.(messagesRef.current);
-  }, [initialMcpClients, resetLoadingState, getToolUseContext, toolPermissionContext, setAppState, customSystemPrompt, onTurnComplete, appendSystemPrompt, canUseTool, mainThreadAgentDefinition, onQueryEvent, sessionTitle, titleDisabled, maxTurns, getAutoCompactTrackingForSession, setAutoCompactTrackingForSession, setAutoCompactTrackingForSessionIfUnchanged, queryGuard]);
-  const onQuery = useCallback(async (newMessages: MessageType[], abortController: AbortController, shouldQuery: boolean, additionalAllowedTools: string[], mainLoopModelParam: string, onBeforeQueryCallback?: (input: string, newMessages: MessageType[]) => Promise<boolean>, input?: string, effort?: EffortValue): Promise<void | false> => {
+  }, [initialMcpClients, resetLoadingState, getToolUseContext, toolPermissionContext, setAppState, customSystemPrompt, onTurnComplete, appendSystemPrompt, canUseTool, mainThreadAgentDefinition, onQueryEvent, sessionTitle, titleDisabled, getAutoCompactTrackingForSession, setAutoCompactTrackingForSession, setAutoCompactTrackingForSessionIfUnchanged, queryGuard]);
+  const onQuery = useCallback(async (newMessages: MessageType[], abortController: AbortController, shouldQuery: boolean, additionalAllowedTools: string[], mainLoopModelParam: string, onBeforeQueryCallback?: (input: string, newMessages: MessageType[]) => Promise<boolean>, input?: string, effort?: EffortValue, isInterruptionCorrectionEligible = false): Promise<void | false> => {
     // If this is a teammate, mark them as active when starting a turn
     if (isAgentSwarmsEnabled()) {
       const teamName = getTeamName();
@@ -3164,6 +3164,7 @@ export function REPL({
 
       await interruptionCorrectionTracker.runModelTurn({
         shouldQuery,
+        isInterruptionCorrectionEligible,
         queryId: queryContext.queryId,
         run: async () => {
           // messagesRef is updated synchronously by the setMessages wrapper
@@ -3432,6 +3433,8 @@ export function REPL({
           setCursorOffset: () => { },
           clearBuffer: () => { },
           resetHistory: () => { }
+        }, undefined, {
+          allowInterruptionCorrection: false
         });
       } else {
         // Plan messages or complex content (images, etc.) - send directly to model
@@ -3460,6 +3463,7 @@ export function REPL({
   }, options?: {
     fromKeybinding?: boolean;
     slashCommandOverride?: Command;
+    allowInterruptionCorrection?: boolean;
   }) => {
     // Re-pin scroll to bottom on submit so the user always sees the new
     // exchange (matches OpenCode's auto-scroll behavior).
@@ -3835,6 +3839,7 @@ export function REPL({
       addNotification,
       setMessages,
       slashCommandOverride: options?.slashCommandOverride,
+      allowInterruptionCorrection: options?.allowInterruptionCorrection,
       takeInterruptionCorrectionReminder,
       // Read via ref so streamMode can be dropped from onSubmit deps —
       // handlePromptSubmit only uses it for debug log + telemetry event.

--- a/src/screens/REPL.tsx
+++ b/src/screens/REPL.tsx
@@ -137,7 +137,7 @@ import { escapeXml } from '../utils/xml.js';
 import type { ThinkingConfig } from '../utils/thinking.js';
 import { gracefulShutdownSync, isShuttingDown } from '../utils/gracefulShutdown.js';
 import { buildConcurrentRequeuedPrompt, handlePromptSubmit, isNormalLocalUserPrompt, type PromptInputHelpers } from '../utils/handlePromptSubmit.js';
-import { InterruptionCorrectionTracker } from '../utils/interruptionCorrection.js';
+import { buildInterruptionCorrectionMessageViews, InterruptionCorrectionTracker } from '../utils/interruptionCorrection.js';
 import { useQueueProcessor } from '../hooks/useQueueProcessor.js';
 import { useMailboxBridge } from '../hooks/useMailboxBridge.js';
 import { queryCheckpoint, logQueryProfileReport, clearQueryProfile } from '../utils/queryProfiler.js';
@@ -2926,7 +2926,7 @@ export function REPL({
       void removeTranscriptMessage(tombstonedMessage.uuid);
     }, setStreamingThinking, undefined, onStreamingText);
   }, [setMessages, setResponseLength, setStreamMode, setStreamingToolUses, setStreamingThinking, onStreamingText]);
-  const onQueryImpl = useCallback(async (messagesIncludingNewMessages: MessageType[], newMessages: MessageType[], abortController: AbortController, shouldQuery: boolean, additionalAllowedTools: string[], mainLoopModelParam: string, queryGeneration: number, effort?: EffortValue, queryLifecycle?: QueryLifecycleOperationTracker) => {
+  const onQueryImpl = useCallback(async (messagesIncludingNewMessages: MessageType[], newMessages: MessageType[], abortController: AbortController, shouldQuery: boolean, additionalAllowedTools: string[], mainLoopModelParam: string, queryGeneration: number, effort?: EffortValue, queryLifecycle?: QueryLifecycleOperationTracker, requestOnlyMessages: MessageType[] = []) => {
     // Prepare IDE integration for new prompt. Read mcpClients fresh from
     // store — useManageMCPConnections may have populated it since the
     // render that captured this closure (same pattern as computeTools).
@@ -3065,6 +3065,7 @@ export function REPL({
     let expectedAutoCompactTracking = queryAutoCompactTracking;
     for await (const event of query({
       messages: messagesIncludingNewMessages,
+      requestOnlyMessages,
       systemPrompt,
       userContext,
       systemContext,
@@ -3152,7 +3153,12 @@ export function REPL({
       // Idempotent with respect to the end-of-turn reset — double-reset
       // is a no-op.
       resetCurrentTurn();
-      setMessages(oldMessages => [...oldMessages, ...newMessages]);
+      const {
+        persistentMessages,
+        persistentNewMessages,
+        requestOnlyMessages
+      } = buildInterruptionCorrectionMessageViews(messagesRef.current, newMessages);
+      setMessages(persistentMessages);
       responseLengthRef.current = 0;
       if (feature('TOKEN_BUDGET')) {
         const parsedBudget = input ? parseTokenBudget(input) : null;
@@ -3168,14 +3174,11 @@ export function REPL({
         isInterruptionCorrectionEligible,
         queryId: queryContext.queryId,
         run: async () => {
-          // messagesRef is updated synchronously by the setMessages wrapper
-          // above, so it already includes newMessages from the append at the
-          // top of this try block.  No reconstruction needed, no waiting for
-          // React's scheduler (previously cost 20-56ms per prompt; the 56ms
-          // case was a GC pause caught during the await).
-          const latestMessages = messagesRef.current;
+          // Request-only context is passed separately to query(), so compaction,
+          // tools, transcript logging, later turns, and resume never persist it.
+          const latestMessages = persistentMessages;
           if (input) {
-            await mrOnBeforeQuery(input, latestMessages, newMessages.length);
+            await mrOnBeforeQuery(input, latestMessages, persistentNewMessages.length);
           }
 
           // Pass full conversation history to callback
@@ -3185,7 +3188,7 @@ export function REPL({
               return;
             }
           }
-          await onQueryImpl(latestMessages, newMessages, abortController, shouldQuery, additionalAllowedTools, mainLoopModelParam, thisGeneration, effort, lifecycleTracker);
+          await onQueryImpl(latestMessages, persistentNewMessages, abortController, shouldQuery, additionalAllowedTools, mainLoopModelParam, thisGeneration, effort, lifecycleTracker, requestOnlyMessages);
         }
       });
     } catch (error) {

--- a/src/screens/REPL.tsx
+++ b/src/screens/REPL.tsx
@@ -1011,8 +1011,9 @@ export function REPL({
   if (interruptionCorrectionTrackerRef.current === null) {
     interruptionCorrectionTrackerRef.current = new InterruptionCorrectionTracker(queryGuard, getSessionId);
   }
+  const interruptionCorrectionTracker = interruptionCorrectionTrackerRef.current;
   const takeInterruptionCorrectionReminder = useCallback(() => {
-    return interruptionCorrectionTrackerRef.current!.takeReminder();
+    return interruptionCorrectionTracker.takeReminder();
   }, []);
 
   // Subscribe to the guard — true during dispatching or running.
@@ -2327,7 +2328,7 @@ export function REPL({
       proactiveModule?.pauseProactive();
     }
     const cancelContext = queryGuard.activeContext;
-    interruptionCorrectionTrackerRef.current.handleCancellation({
+    interruptionCorrectionTracker.handleCancellation({
       isUserInitiated,
       isRemoteMode: activeRemote.isRemoteMode
     });
@@ -3178,7 +3179,7 @@ export function REPL({
           return;
         }
       }
-      interruptionCorrectionTrackerRef.current.bindModelTurn({
+      interruptionCorrectionTracker.bindModelTurn({
         shouldQuery,
         isAborted: abortController.signal.aborted,
         queryId: queryContext.queryId
@@ -3188,7 +3189,7 @@ export function REPL({
       didThrow = true;
       throw error;
     } finally {
-      interruptionCorrectionTrackerRef.current.finishModelTurn(queryContext.queryId);
+      interruptionCorrectionTracker.finishModelTurn(queryContext.queryId);
       const terminalReason = getQueryTerminalReason(abortController.signal, didThrow);
       const abortReason = getAbortReasonLabel(abortController.signal.reason);
       const activeOperations = lifecycleTracker.snapshot();

--- a/src/screens/REPL.tsx
+++ b/src/screens/REPL.tsx
@@ -2337,6 +2337,11 @@ export function REPL({
     interruptionCorrectionTracker.handleCancellation({
       isUserInitiated,
       isRemoteMode: activeRemote.isRemoteMode,
+      hasQueuedNormalPrompt: getCommandQueue().some(command =>
+        command.mode === 'prompt' &&
+        command.preExpansionValue !== undefined &&
+        command.allowInterruptionCorrection !== false,
+      ),
     });
     const cancelOperations = queryLifecycleTrackerRef.current.snapshot();
     const completedCancelContext = cancelContext ? {
@@ -2928,7 +2933,7 @@ export function REPL({
       void removeTranscriptMessage(tombstonedMessage.uuid);
     }, setStreamingThinking, undefined, onStreamingText);
   }, [setMessages, setResponseLength, setStreamMode, setStreamingToolUses, setStreamingThinking, onStreamingText]);
-  const onQueryImpl = useCallback(async (messagesIncludingNewMessages: MessageType[], newMessages: MessageType[], abortController: AbortController, shouldQuery: boolean, additionalAllowedTools: string[], mainLoopModelParam: string, queryGeneration: number, effort?: EffortValue, queryLifecycle?: QueryLifecycleOperationTracker, requestOnlyMessages: MessageType[] = [], interruptionCorrectionQueryId?: string) => {
+  const onQueryImpl = useCallback(async (messagesIncludingNewMessages: MessageType[], newMessages: MessageType[], abortController: AbortController, shouldQuery: boolean, additionalAllowedTools: string[], mainLoopModelParam: string, queryGeneration: number, effort?: EffortValue, queryLifecycle?: QueryLifecycleOperationTracker, requestOnlyMessages: MessageType[] = [], interruptionCorrectionQueryId?: string, onModelRequestStart?: () => void) => {
     // Prepare IDE integration for new prompt. Read mcpClients fresh from
     // store — useManageMCPConnections may have populated it since the
     // render that captured this closure (same pattern as computeTools).
@@ -3069,11 +3074,14 @@ export function REPL({
       messages: messagesIncludingNewMessages,
       requestOnlyMessages,
       onModelRequestStart: interruptionCorrectionQueryId
-        ? () => interruptionCorrectionTracker.bindModelTurn({
-            shouldQuery,
-            isInterruptionCorrectionEligible: true,
-            queryId: interruptionCorrectionQueryId,
-          })
+        ? () => {
+            interruptionCorrectionTracker.bindModelTurn({
+              shouldQuery,
+              isInterruptionCorrectionEligible: true,
+              queryId: interruptionCorrectionQueryId,
+            })
+            onModelRequestStart?.()
+          }
         : undefined,
       onModelRequestEnd: interruptionCorrectionQueryId
         ? () => interruptionCorrectionTracker.finishModelTurn(
@@ -3114,7 +3122,7 @@ export function REPL({
     // Signal that a query turn has completed successfully
     await onTurnComplete?.(messagesRef.current);
   }, [initialMcpClients, resetLoadingState, getToolUseContext, toolPermissionContext, setAppState, customSystemPrompt, onTurnComplete, appendSystemPrompt, canUseTool, mainThreadAgentDefinition, onQueryEvent, sessionTitle, titleDisabled, maxTurns, getAutoCompactTrackingForSession, setAutoCompactTrackingForSession, setAutoCompactTrackingForSessionIfUnchanged, queryGuard, interruptionCorrectionTracker]);
-  const onQuery = useCallback(async (newMessages: MessageType[], abortController: AbortController, shouldQuery: boolean, additionalAllowedTools: string[], mainLoopModelParam: string, onBeforeQueryCallback?: (input: string, newMessages: MessageType[]) => Promise<boolean>, input?: string, effort?: EffortValue, isInterruptionCorrectionEligible = false): Promise<void | false> => {
+  const onQuery = useCallback(async (newMessages: MessageType[], abortController: AbortController, shouldQuery: boolean, additionalAllowedTools: string[], mainLoopModelParam: string, onBeforeQueryCallback?: (input: string, newMessages: MessageType[]) => Promise<boolean>, input?: string, effort?: EffortValue, isInterruptionCorrectionEligible = false, onModelRequestStart?: () => void): Promise<void | false> => {
     // If this is a teammate, mark them as active when starting a turn
     if (isAgentSwarmsEnabled()) {
       const teamName = getTeamName();
@@ -3206,7 +3214,7 @@ export function REPL({
       }
       if (!preflightVetoed) {
         modelTurnStarted = true;
-        await onQueryImpl(latestMessages, persistentNewMessages, abortController, shouldQuery, additionalAllowedTools, mainLoopModelParam, thisGeneration, effort, lifecycleTracker, requestOnlyMessages, isInterruptionCorrectionEligible ? queryContext.queryId : undefined);
+        await onQueryImpl(latestMessages, persistentNewMessages, abortController, shouldQuery, additionalAllowedTools, mainLoopModelParam, thisGeneration, effort, lifecycleTracker, requestOnlyMessages, isInterruptionCorrectionEligible ? queryContext.queryId : undefined, onModelRequestStart);
       }
       if (preflightVetoed) {
         return false;

--- a/src/screens/REPL.tsx
+++ b/src/screens/REPL.tsx
@@ -3146,6 +3146,7 @@ export function REPL({
     logQueryLifecycle('guard_start', queryContext);
     let didThrow = false;
     let interruptionCorrectionRequestOnlyMessages: readonly MessageType[] = [];
+    let preflightVetoed = false;
     try {
       // isLoading is derived from queryGuard — tryStart() above already
       // transitioned dispatching→running, so no setter call needed here.
@@ -3190,12 +3191,19 @@ export function REPL({
           if (onBeforeQueryCallback && input) {
             const shouldProceed = await onBeforeQueryCallback(input, latestMessages);
             if (!shouldProceed) {
+              // No provider request owns this reminder when preflight vetoes
+              // the turn. Return false so handlePromptSubmit restores it for
+              // the next eligible correction prompt.
+              preflightVetoed = true;
               return;
             }
           }
           await onQueryImpl(latestMessages, persistentNewMessages, abortController, shouldQuery, additionalAllowedTools, mainLoopModelParam, thisGeneration, effort, lifecycleTracker, requestOnlyMessages);
         }
       });
+      if (preflightVetoed) {
+        return false;
+      }
     } catch (error) {
       didThrow = true;
       throw error;

--- a/src/screens/REPL.tsx
+++ b/src/screens/REPL.tsx
@@ -136,7 +136,7 @@ import { BASH_INPUT_TAG, COMMAND_MESSAGE_TAG, COMMAND_NAME_TAG, LOCAL_COMMAND_ST
 import { escapeXml } from '../utils/xml.js';
 import type { ThinkingConfig } from '../utils/thinking.js';
 import { gracefulShutdownSync, isShuttingDown } from '../utils/gracefulShutdown.js';
-import { handlePromptSubmit, type PromptInputHelpers } from '../utils/handlePromptSubmit.js';
+import { buildConcurrentRequeuedPrompt, handlePromptSubmit, isNormalLocalUserPrompt, type PromptInputHelpers } from '../utils/handlePromptSubmit.js';
 import { InterruptionCorrectionTracker } from '../utils/interruptionCorrection.js';
 import { useQueueProcessor } from '../hooks/useQueueProcessor.js';
 import { useMailboxBridge } from '../hooks/useMailboxBridge.js';
@@ -1014,6 +1014,9 @@ export function REPL({
   const interruptionCorrectionTracker = interruptionCorrectionTrackerRef.current;
   const takeInterruptionCorrectionReminder = useCallback(() => {
     return interruptionCorrectionTracker.takeReminder();
+  }, []);
+  const restoreInterruptionCorrectionReminder = useCallback(() => {
+    interruptionCorrectionTracker.restoreReminder();
   }, []);
 
   // Subscribe to the guard — true during dispatching or running.
@@ -2330,7 +2333,8 @@ export function REPL({
     const cancelContext = queryGuard.activeContext;
     interruptionCorrectionTracker.handleCancellation({
       isUserInitiated,
-      isRemoteMode: activeRemote.isRemoteMode
+      isRemoteMode: activeRemote.isRemoteMode,
+      hasQueuedNormalPrompt: getCommandQueue().some(isNormalLocalUserPrompt)
     });
     const cancelOperations = queryLifecycleTrackerRef.current.snapshot();
     const completedCancelContext = cancelContext ? {
@@ -3124,10 +3128,7 @@ export function REPL({
       // (e.g. expanded skill content, tick prompts) that should not be
       // replayed as user-visible text.
       newMessages.filter((m): m is UserMessage => m.type === 'user' && !m.isMeta).map(_ => getContentText(_.message.content)).filter(_ => _ !== null).forEach((msg, i) => {
-        enqueue({
-          value: msg,
-          mode: 'prompt'
-        });
+        enqueue(buildConcurrentRequeuedPrompt(msg, isInterruptionCorrectionEligible));
         if (i === 0) {
           logEvent('tengu_concurrent_onquery_enqueued', {});
         }
@@ -3841,6 +3842,7 @@ export function REPL({
       slashCommandOverride: options?.slashCommandOverride,
       allowInterruptionCorrection: options?.allowInterruptionCorrection,
       takeInterruptionCorrectionReminder,
+      restoreInterruptionCorrectionReminder,
       // Read via ref so streamMode can be dropped from onSubmit deps —
       // handlePromptSubmit only uses it for debug log + telemetry event.
       streamMode: streamModeRef.current,
@@ -3871,7 +3873,7 @@ export function REPL({
     // messages array in downstream closures (PromptInput, handleAutoRunIssue).
     // Heap analysis showed ~9 REPL scopes and ~15 messages array versions
     // accumulating after #20174/#20175, all traced to this dep.
-    mainLoopModel, pastedContents, ideSelection, setUserInputOnProcessing, setAbortController, addNotification, onQuery, stashedPrompt, setStashedPrompt, setAppState, onBeforeQuery, canUseTool, remoteSession, setMessages, awaitPendingHooks, repinScroll, takeInterruptionCorrectionReminder]);
+    mainLoopModel, pastedContents, ideSelection, setUserInputOnProcessing, setAbortController, addNotification, onQuery, stashedPrompt, setStashedPrompt, setAppState, onBeforeQuery, canUseTool, remoteSession, setMessages, awaitPendingHooks, repinScroll, takeInterruptionCorrectionReminder, restoreInterruptionCorrectionReminder]);
 
   // Callback for when user submits input while viewing a teammate's transcript
   const onAgentSubmit = useCallback(async (input: string, task: InProcessTeammateTaskState | LocalAgentTaskState, helpers: PromptInputHelpers) => {
@@ -3986,6 +3988,7 @@ export function REPL({
       rewindToMessageIndex: messageIndex
     });
     setMessages(prev.slice(0, messageIndex));
+    interruptionCorrectionTracker.handleConversationRewrite();
     resetAutoCompactTracking();
     // Careful, this has to happen after setMessages
     setConversationId(randomUUID());
@@ -4024,7 +4027,7 @@ export function REPL({
         generationRequestId: null
       }
     }));
-  }, [setMessages, resetAutoCompactTracking, setAppState]);
+  }, [setMessages, resetAutoCompactTracking, setAppState, interruptionCorrectionTracker]);
 
   // Synchronous rewind + input population. Used directly by auto-restore on
   // interrupt (so React batches with the abort's setMessages → single render,
@@ -4207,9 +4210,10 @@ export function REPL({
       addNotification,
       setMessages,
       takeInterruptionCorrectionReminder,
+      restoreInterruptionCorrectionReminder,
       queuedCommands
     });
-  }, [queryGuard, commands, setToolJSX, getToolUseContext, messages, mainLoopModel, ideSelection, setUserInputOnProcessing, canUseTool, setAbortController, onQuery, addNotification, setAppState, onBeforeQuery, takeInterruptionCorrectionReminder]);
+  }, [queryGuard, commands, setToolJSX, getToolUseContext, messages, mainLoopModel, ideSelection, setUserInputOnProcessing, canUseTool, setAbortController, onQuery, addNotification, setAppState, onBeforeQuery, takeInterruptionCorrectionReminder, restoreInterruptionCorrectionReminder]);
   useQueueProcessor({
     executeQueuedInput,
     hasActiveLocalJsxUI: isShowingLocalJSXCommand,
@@ -5250,6 +5254,7 @@ export function REPL({
             } else {
               setMessages(postCompact);
             }
+            interruptionCorrectionTracker.handleConversationRewrite();
             // Partial compact bypasses handleMessageFromStream — clear
             // the auto-compact breaker and context-blocked flag.
             setAutoCompactTrackingForSession(getSessionId(), undefined);

--- a/src/screens/REPL.tsx
+++ b/src/screens/REPL.tsx
@@ -136,7 +136,7 @@ import { BASH_INPUT_TAG, COMMAND_MESSAGE_TAG, COMMAND_NAME_TAG, LOCAL_COMMAND_ST
 import { escapeXml } from '../utils/xml.js';
 import type { ThinkingConfig } from '../utils/thinking.js';
 import { gracefulShutdownSync, isShuttingDown } from '../utils/gracefulShutdown.js';
-import { buildConcurrentRequeuedPrompt, handlePromptSubmit, type PromptInputHelpers } from '../utils/handlePromptSubmit.js';
+import { buildConcurrentRequeuedPrompt, handlePromptSubmit, isNormalLocalUserPrompt, type PromptInputHelpers } from '../utils/handlePromptSubmit.js';
 import { applyInterruptionCorrectionAutoRestore, applyInterruptionCorrectionAwareMessageUpdate, buildInterruptionCorrectionMessageViews, InterruptionCorrectionTracker } from '../utils/interruptionCorrection.js';
 import { useQueueProcessor } from '../hooks/useQueueProcessor.js';
 import { useMailboxBridge } from '../hooks/useMailboxBridge.js';
@@ -2337,10 +2337,8 @@ export function REPL({
     interruptionCorrectionTracker.handleCancellation({
       isUserInitiated,
       isRemoteMode: activeRemote.isRemoteMode,
-      hasQueuedNormalPrompt: getCommandQueue().some(command =>
-        command.mode === 'prompt' &&
-        command.preExpansionValue !== undefined &&
-        command.allowInterruptionCorrection !== false,
+      hasQueuedNormalPrompt: getCommandQueue().some(
+        isNormalLocalUserPrompt,
       ),
     });
     const cancelOperations = queryLifecycleTrackerRef.current.snapshot();

--- a/src/screens/REPL.tsx
+++ b/src/screens/REPL.tsx
@@ -137,7 +137,7 @@ import { escapeXml } from '../utils/xml.js';
 import type { ThinkingConfig } from '../utils/thinking.js';
 import { gracefulShutdownSync, isShuttingDown } from '../utils/gracefulShutdown.js';
 import { buildConcurrentRequeuedPrompt, handlePromptSubmit, isNormalLocalUserPrompt, type PromptInputHelpers } from '../utils/handlePromptSubmit.js';
-import { buildInterruptionCorrectionMessageViews, InterruptionCorrectionTracker } from '../utils/interruptionCorrection.js';
+import { applyInterruptionCorrectionAwareMessageUpdate, buildInterruptionCorrectionMessageViews, InterruptionCorrectionTracker } from '../utils/interruptionCorrection.js';
 import { useQueueProcessor } from '../hooks/useQueueProcessor.js';
 import { useMailboxBridge } from '../hooks/useMailboxBridge.js';
 import { queryCheckpoint, logQueryProfileReport, clearQueryProfile } from '../utils/queryProfiler.js';
@@ -1301,9 +1301,10 @@ export function REPL({
   // that queue functional updaters then synchronously read the ref
   // (e.g. handleSpeculationAccept → onQuery) see stale data.
   const setMessages = useCallback((action: React.SetStateAction<MessageType[]>) => {
-    const prev = messagesRef.current;
-    const next = typeof action === 'function' ? action(messagesRef.current) : action;
-    messagesRef.current = next;
+    const {
+      previousMessages: prev,
+      nextMessages: next
+    } = applyInterruptionCorrectionAwareMessageUpdate(messagesRef, action, interruptionCorrectionTracker);
     if (next.length < userInputBaselineRef.current) {
       // Shrank (compact/rewind/clear) — clamp so placeholderText's length
       // check can't go stale.
@@ -1324,7 +1325,7 @@ export function REPL({
       }
     }
     rawSetMessages(next);
-  }, []);
+  }, [interruptionCorrectionTracker]);
   // Capture the baseline message count alongside the placeholder text so
   // the render can hide it once displayedMessages grows past the baseline.
   const setUserInputOnProcessing = useCallback((input: string | undefined) => {
@@ -5257,7 +5258,6 @@ export function REPL({
             } else {
               setMessages(postCompact);
             }
-            interruptionCorrectionTracker.handleConversationRewrite();
             // Partial compact bypasses handleMessageFromStream — clear
             // the auto-compact breaker and context-blocked flag.
             setAutoCompactTrackingForSession(getSessionId(), undefined);

--- a/src/services/contextCollapse/operations.test.ts
+++ b/src/services/contextCollapse/operations.test.ts
@@ -93,12 +93,11 @@ describe('projectView', () => {
     expect(serialized).toContain('<collapsed')
   })
 
-  test('collapsed summary stays meta so the snip sweep cannot remove it', async () => {
-    // Regression: the system->user conversion in normalizeMessagesForAPI must
-    // preserve isMeta on the collapse placeholder. The snip-tag sweep
-    // (appendMessageTagToUserMessage) skips isMeta messages; if the conversion
-    // drops the flag, HISTORY_SNIP tags the summary with a snip_id and SnipTool
-    // can remove the only replacement for the archived span.
+  test('collapsed summary merged with real input stays non-snippable', async () => {
+    // The system->user conversion preserves isMeta on the collapse placeholder,
+    // but merging it with adjacent real user input must clear isMeta. The
+    // isCollapseSummary marker independently keeps the only replacement for the
+    // archived span out of the snip sweep.
     const mod = await import('./operations.js')
     const { normalizeMessagesForAPI, appendMessageTagToUserMessage } =
       await import('../../utils/messages.js')
@@ -110,9 +109,12 @@ describe('projectView', () => {
     )
     expect(summaryMsg).toBeDefined()
     expect(summaryMsg!.type).toBe('user')
-    expect((summaryMsg as { isMeta?: boolean }).isMeta).toBe(true)
+    expect((summaryMsg as { isMeta?: boolean }).isMeta).toBeUndefined()
+    expect(
+      (summaryMsg as { isCollapseSummary?: boolean }).isCollapseSummary,
+    ).toBe(true)
 
-    // With snip injection enabled the sweep leaves the meta summary untagged...
+    // With snip injection enabled the sweep leaves the collapse summary untagged...
     const swept = appendMessageTagToUserMessage(summaryMsg as never)
     expect(JSON.stringify(swept.message.content)).not.toContain('snip_id=')
     // ...while a normal (non-meta) user message still gets a snip id, so the

--- a/src/services/contextCollapse/operations.test.ts
+++ b/src/services/contextCollapse/operations.test.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from 'crypto'
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import { feature } from 'bun:bundle'
 import type { UUID } from 'crypto'
 import type { Message } from '../../types/message.js'
 
@@ -94,10 +95,10 @@ describe('projectView', () => {
   })
 
   test('collapsed summary merged with real input stays non-snippable', async () => {
-    // The system->user conversion preserves isMeta on the collapse placeholder,
-    // but merging it with adjacent real user input must clear isMeta. The
-    // isCollapseSummary marker independently keeps the only replacement for the
-    // archived span out of the snip sweep.
+    // The system->user conversion preserves isMeta on the collapse placeholder.
+    // An active HISTORY_SNIP runtime clears it when adjacent real input merges;
+    // otherwise the legacy meta contract remains. The isCollapseSummary marker
+    // independently keeps the archived-span replacement out of the snip sweep.
     const mod = await import('./operations.js')
     const { normalizeMessagesForAPI, appendMessageTagToUserMessage } =
       await import('../../utils/messages.js')
@@ -109,7 +110,9 @@ describe('projectView', () => {
     )
     expect(summaryMsg).toBeDefined()
     expect(summaryMsg!.type).toBe('user')
-    expect((summaryMsg as { isMeta?: boolean }).isMeta).toBeUndefined()
+    expect((summaryMsg as { isMeta?: boolean }).isMeta).toBe(
+      feature('HISTORY_SNIP') ? undefined : true,
+    )
     expect(
       (summaryMsg as { isCollapseSummary?: boolean }).isCollapseSummary,
     ).toBe(true)

--- a/src/types/textInputTypes.ts
+++ b/src/types/textInputTypes.ts
@@ -323,6 +323,11 @@ export type QueuedCommand = {
   skipSlashCommands?: boolean
   slashCommandOverride?: Command
   /**
+   * False for programmatic submissions that should not arm or consume local
+   * interruption-correction context. Undefined preserves keyboard behavior.
+   */
+  allowInterruptionCorrection?: boolean
+  /**
    * When true, slash commands are dispatched but filtered through
    * isBridgeSafeCommand() — 'local-jsx' and terminal-only commands return
    * a helpful error instead of executing. Set by the Remote Control bridge

--- a/src/utils/handlePromptSubmit.test.ts
+++ b/src/utils/handlePromptSubmit.test.ts
@@ -204,6 +204,61 @@ describe('handlePromptSubmit', () => {
     expect(restoreCount).toBe(1)
   })
 
+  it('does not re-arm a reminder when an owned query rejects', async () => {
+    const correctionMessage = createUserMessage({ content: 'do Y instead' })
+    const reminderMessage = createUserMessage({
+      content: '<system-reminder>interrupted</system-reminder>',
+      isMeta: true,
+    })
+    mock.module('./processUserInput/processUserInput.js', () => ({
+      processUserInput: async () => ({
+        messages: [correctionMessage],
+        shouldQuery: true,
+      }),
+    }))
+    const { handlePromptSubmit } = await import('./handlePromptSubmit.js')
+
+    let restoreCount = 0
+    const submission = handlePromptSubmit({
+      input: 'do Y instead',
+      mode: 'prompt',
+      pastedContents: {},
+      helpers: {
+        setCursorOffset: () => {},
+        clearBuffer: () => {},
+        resetHistory: () => {},
+      },
+      onInputChange: () => {},
+      setPastedContents: () => {},
+      takeInterruptionCorrectionReminder: () => reminderMessage,
+      restoreInterruptionCorrectionReminder: () => {
+        restoreCount++
+      },
+      queryGuard: {
+        isActive: false,
+        reserve: () => true,
+        cancelReservation: () => {},
+      } as never,
+      isExternalLoading: false,
+      commands: [],
+      messages: [],
+      mainLoopModel: 'sonnet',
+      ideSelection: undefined,
+      querySource: 'repl' as never,
+      setToolJSX: () => {},
+      getToolUseContext: () => ({}) as never,
+      setUserInputOnProcessing: () => {},
+      setAbortController: () => {},
+      onQuery: async () => {
+        throw new Error('completion failed')
+      },
+      setAppState: () => ({}) as never,
+    } as never)
+
+    await expect(submission).rejects.toThrow('completion failed')
+    expect(restoreCount).toBe(0)
+  })
+
   it('restores a reminder when a later queued normal prompt throws before dispatch', async () => {
     const reminderMessage = createUserMessage({
       content: '<system-reminder>interrupted</system-reminder>',

--- a/src/utils/handlePromptSubmit.test.ts
+++ b/src/utils/handlePromptSubmit.test.ts
@@ -213,6 +213,8 @@ describe('handlePromptSubmit', () => {
       { ...normalPrompt, isMeta: true },
       { ...normalPrompt, origin: { kind: 'task-notification' } },
       { ...normalPrompt, slashCommandOverride: {} },
+      { ...normalPrompt, workload: 'cron' },
+      { ...normalPrompt, agentId: 'agent-1' },
       { ...normalPrompt, value: [{ type: 'text', text: 'do Y instead' }] },
     ]
 

--- a/src/utils/handlePromptSubmit.test.ts
+++ b/src/utils/handlePromptSubmit.test.ts
@@ -4,6 +4,7 @@ import {
   releaseSharedMutationLock,
 } from '../test/sharedMutationLock.js'
 import { getCommandQueue, resetCommandQueue } from './messageQueueManager.js'
+import { createUserMessage } from './messages.js'
 
 describe('handlePromptSubmit', () => {
   beforeEach(async () => {
@@ -20,6 +21,193 @@ describe('handlePromptSubmit', () => {
       mock.restore()
     } finally {
       releaseSharedMutationLock()
+    }
+  })
+
+  it('prepends a pending interruption reminder to the next normal prompt', async () => {
+    const correctionMessage = createUserMessage({ content: 'do Y instead' })
+    const reminderMessage = createUserMessage({
+      content: '<system-reminder>interrupted</system-reminder>',
+      isMeta: true,
+    })
+    mock.module('./processUserInput/processUserInput.js', () => ({
+      processUserInput: async () => ({
+        messages: [correctionMessage],
+        shouldQuery: true,
+      }),
+    }))
+    const { handlePromptSubmit } = await import('./handlePromptSubmit.js')
+
+    const queriedMessages: unknown[][] = []
+    let reminderTakeCount = 0
+
+    await handlePromptSubmit({
+      input: 'do Y instead',
+      mode: 'prompt',
+      pastedContents: {},
+      helpers: {
+        setCursorOffset: () => {},
+        clearBuffer: () => {},
+        resetHistory: () => {},
+      },
+      onInputChange: () => {},
+      setPastedContents: () => {},
+      takeInterruptionCorrectionReminder: () => {
+        reminderTakeCount++
+        return reminderMessage
+      },
+      queryGuard: {
+        isActive: false,
+        reserve: () => true,
+        cancelReservation: () => {},
+      } as never,
+      isExternalLoading: false,
+      commands: [],
+      messages: [],
+      mainLoopModel: 'sonnet',
+      ideSelection: undefined,
+      querySource: 'repl' as never,
+      setToolJSX: () => {},
+      getToolUseContext: () => ({}) as never,
+      setUserInputOnProcessing: () => {},
+      setAbortController: () => {},
+      onQuery: async newMessages => {
+        queriedMessages.push(newMessages)
+      },
+      setAppState: () => ({}) as never,
+    })
+
+    expect(reminderTakeCount).toBe(1)
+    expect(queriedMessages).toEqual([[reminderMessage, correctionMessage]])
+  })
+
+  it('preserves a reminder across a queued slash command and injects it once', async () => {
+    const reminderMessage = createUserMessage({
+      content: '<system-reminder>interrupted</system-reminder>',
+      isMeta: true,
+    })
+    mock.module('./processUserInput/processUserInput.js', () => ({
+      processUserInput: async ({ input }: { input: string }) => ({
+        messages: input.startsWith('/')
+          ? []
+          : [createUserMessage({ content: input })],
+        shouldQuery: !input.startsWith('/'),
+      }),
+    }))
+    const { handlePromptSubmit } = await import('./handlePromptSubmit.js')
+
+    let pending = true
+    let injectedCount = 0
+    const queriedMessages: unknown[][] = []
+    const takeReminder = () => {
+      if (!pending) return null
+      pending = false
+      injectedCount++
+      return reminderMessage
+    }
+    const baseParams = {
+      helpers: {
+        setCursorOffset: () => {},
+        clearBuffer: () => {},
+        resetHistory: () => {},
+      },
+      onInputChange: () => {},
+      setPastedContents: () => {},
+      takeInterruptionCorrectionReminder: takeReminder,
+      queryGuard: {
+        isActive: false,
+        reserve: () => true,
+        cancelReservation: () => {},
+      } as never,
+      isExternalLoading: false,
+      commands: [],
+      messages: [],
+      mainLoopModel: 'sonnet',
+      ideSelection: undefined,
+      querySource: 'repl' as never,
+      setToolJSX: () => {},
+      getToolUseContext: () => ({}) as never,
+      setUserInputOnProcessing: () => {},
+      setAbortController: () => {},
+      onQuery: async (newMessages: unknown[]) => {
+        queriedMessages.push(newMessages)
+      },
+      setAppState: () => ({}) as never,
+    }
+
+    await handlePromptSubmit({
+      ...baseParams,
+      queuedCommands: [
+        {
+          value: '/help',
+          preExpansionValue: '[Pasted text #1]',
+          mode: 'prompt',
+        },
+      ],
+    } as never)
+    expect(pending).toBe(true)
+    expect(injectedCount).toBe(0)
+
+    for (const value of ['do Y instead', 'future prompt']) {
+      await handlePromptSubmit({
+        ...baseParams,
+        queuedCommands: [{ value, preExpansionValue: value, mode: 'prompt' }],
+      } as never)
+    }
+
+    expect(injectedCount).toBe(1)
+    expect(queriedMessages).toHaveLength(2)
+    expect(queriedMessages[0]).toEqual([
+      reminderMessage,
+      expect.objectContaining({
+        type: 'user',
+        message: expect.objectContaining({ content: 'do Y instead' }),
+      }),
+    ])
+    expect(queriedMessages[1]).toEqual([
+      expect.objectContaining({
+        type: 'user',
+        message: expect.objectContaining({ content: 'future prompt' }),
+      }),
+    ])
+  })
+
+  it('only consumes correction reminders for normal local keyboard prompts', async () => {
+    const promptSubmitModule = await import('./handlePromptSubmit.js')
+    const isNormalLocalUserPrompt = (
+      promptSubmitModule as typeof promptSubmitModule & {
+        isNormalLocalUserPrompt?: (command: Record<string, unknown>) => boolean
+      }
+    ).isNormalLocalUserPrompt
+
+    expect(typeof isNormalLocalUserPrompt).toBe('function')
+
+    const normalPrompt = {
+      value: 'do Y instead',
+      preExpansionValue: 'do Y instead',
+      mode: 'prompt',
+    }
+    expect(isNormalLocalUserPrompt?.(normalPrompt)).toBe(true)
+
+    const ineligiblePrompts = [
+      { ...normalPrompt, value: '/help', preExpansionValue: '/help' },
+      {
+        ...normalPrompt,
+        value: '/help',
+        preExpansionValue: '[Pasted text #1]',
+      },
+      { ...normalPrompt, mode: 'bash' },
+      { ...normalPrompt, preExpansionValue: undefined },
+      { ...normalPrompt, skipSlashCommands: true },
+      { ...normalPrompt, bridgeOrigin: true },
+      { ...normalPrompt, isMeta: true },
+      { ...normalPrompt, origin: { kind: 'task-notification' } },
+      { ...normalPrompt, slashCommandOverride: {} },
+      { ...normalPrompt, value: [{ type: 'text', text: 'do Y instead' }] },
+    ]
+
+    for (const prompt of ineligiblePrompts) {
+      expect(isNormalLocalUserPrompt?.(prompt)).toBe(false)
     }
   })
 

--- a/src/utils/handlePromptSubmit.test.ts
+++ b/src/utils/handlePromptSubmit.test.ts
@@ -249,7 +249,19 @@ describe('handlePromptSubmit', () => {
       getToolUseContext: () => ({}) as never,
       setUserInputOnProcessing: () => {},
       setAbortController: () => {},
-      onQuery: async () => {
+      onQuery: async (
+        _messages,
+        _abortController,
+        _shouldQuery,
+        _tools,
+        _model,
+        _beforeQuery,
+        _input,
+        _effort,
+        _eligible,
+        onModelRequestStart,
+      ) => {
+        onModelRequestStart?.()
         throw new Error('completion failed')
       },
       setAppState: () => ({}) as never,

--- a/src/utils/handlePromptSubmit.test.ts
+++ b/src/utils/handlePromptSubmit.test.ts
@@ -204,14 +204,20 @@ describe('handlePromptSubmit', () => {
     expect(restoreCount).toBe(1)
   })
 
-  it('restores a reminder when processing the normal prompt throws', async () => {
+  it('restores a reminder when a later queued normal prompt throws before dispatch', async () => {
     const reminderMessage = createUserMessage({
       content: '<system-reminder>interrupted</system-reminder>',
       isMeta: true,
     })
+    let calls = 0
     mock.module('./processUserInput/processUserInput.js', () => ({
       processUserInput: async () => {
-        throw new Error('hook failed')
+        calls++
+        if (calls === 2) throw new Error('hook failed')
+        return {
+          messages: [createUserMessage({ content: 'first correction' })],
+          shouldQuery: true,
+        }
       },
     }))
     const { handlePromptSubmit } = await import('./handlePromptSubmit.js')
@@ -221,6 +227,18 @@ describe('handlePromptSubmit', () => {
     const submission = handlePromptSubmit({
       input: 'do Y instead',
       mode: 'prompt',
+      queuedCommands: [
+        {
+          value: 'first correction',
+          preExpansionValue: 'first correction',
+          mode: 'prompt',
+        },
+        {
+          value: 'second correction',
+          preExpansionValue: 'second correction',
+          mode: 'prompt',
+        },
+      ],
       pastedContents: {},
       helpers: {
         setCursorOffset: () => {},

--- a/src/utils/handlePromptSubmit.test.ts
+++ b/src/utils/handlePromptSubmit.test.ts
@@ -3,7 +3,7 @@ import {
   acquireSharedMutationLock,
   releaseSharedMutationLock,
 } from '../test/sharedMutationLock.js'
-import * as realAnalyticsModule from '../services/analytics/index.js'
+import * as realAnalyticsModule from 'src/services/analytics/index.js'
 import { getCommandQueue, resetCommandQueue } from './messageQueueManager.js'
 import { createUserMessage } from './messages.js'
 import * as realProcessUserInputModule from './processUserInput/processUserInput.js'

--- a/src/utils/handlePromptSubmit.test.ts
+++ b/src/utils/handlePromptSubmit.test.ts
@@ -91,7 +91,7 @@ describe('handlePromptSubmit', () => {
     expect(queriedMessages).toEqual([[reminderMessage, correctionMessage]])
   })
 
-  it('consumes but does not append a reminder when a normal prompt is blocked', async () => {
+  it('restores a reminder when a normal prompt is blocked before query dispatch', async () => {
     const correctionMessage = createUserMessage({ content: 'do Y instead' })
     const reminderMessage = createUserMessage({
       content: '<system-reminder>interrupted</system-reminder>',
@@ -106,6 +106,7 @@ describe('handlePromptSubmit', () => {
     const { handlePromptSubmit } = await import('./handlePromptSubmit.js')
 
     let reminderTakeCount = 0
+    let restoreCount = 0
     const queriedMessages: unknown[][] = []
     await handlePromptSubmit({
       input: 'do Y instead',
@@ -121,6 +122,9 @@ describe('handlePromptSubmit', () => {
       takeInterruptionCorrectionReminder: () => {
         reminderTakeCount++
         return reminderMessage
+      },
+      restoreInterruptionCorrectionReminder: () => {
+        restoreCount++
       },
       queryGuard: {
         isActive: false,
@@ -144,6 +148,7 @@ describe('handlePromptSubmit', () => {
     })
 
     expect(reminderTakeCount).toBe(1)
+    expect(restoreCount).toBe(1)
     expect(queriedMessages).toEqual([[correctionMessage]])
   })
 
@@ -199,7 +204,7 @@ describe('handlePromptSubmit', () => {
     expect(restoreCount).toBe(1)
   })
 
-  it('consumes a reminder when processing the normal prompt throws', async () => {
+  it('restores a reminder when processing the normal prompt throws', async () => {
     const reminderMessage = createUserMessage({
       content: '<system-reminder>interrupted</system-reminder>',
       isMeta: true,
@@ -252,7 +257,7 @@ describe('handlePromptSubmit', () => {
 
     await expect(submission).rejects.toThrow('hook failed')
     expect(reminderTakeCount).toBe(1)
-    expect(restoreCount).toBe(0)
+    expect(restoreCount).toBe(1)
   })
 
   it('preserves a reminder across a queued slash command and injects it once', async () => {

--- a/src/utils/handlePromptSubmit.test.ts
+++ b/src/utils/handlePromptSubmit.test.ts
@@ -91,6 +91,170 @@ describe('handlePromptSubmit', () => {
     expect(queriedMessages).toEqual([[reminderMessage, correctionMessage]])
   })
 
+  it('consumes but does not append a reminder when a normal prompt is blocked', async () => {
+    const correctionMessage = createUserMessage({ content: 'do Y instead' })
+    const reminderMessage = createUserMessage({
+      content: '<system-reminder>interrupted</system-reminder>',
+      isMeta: true,
+    })
+    mock.module('./processUserInput/processUserInput.js', () => ({
+      processUserInput: async () => ({
+        messages: [correctionMessage],
+        shouldQuery: false,
+      }),
+    }))
+    const { handlePromptSubmit } = await import('./handlePromptSubmit.js')
+
+    let reminderTakeCount = 0
+    const queriedMessages: unknown[][] = []
+    await handlePromptSubmit({
+      input: 'do Y instead',
+      mode: 'prompt',
+      pastedContents: {},
+      helpers: {
+        setCursorOffset: () => {},
+        clearBuffer: () => {},
+        resetHistory: () => {},
+      },
+      onInputChange: () => {},
+      setPastedContents: () => {},
+      takeInterruptionCorrectionReminder: () => {
+        reminderTakeCount++
+        return reminderMessage
+      },
+      queryGuard: {
+        isActive: false,
+        reserve: () => true,
+        cancelReservation: () => {},
+      } as never,
+      isExternalLoading: false,
+      commands: [],
+      messages: [],
+      mainLoopModel: 'sonnet',
+      ideSelection: undefined,
+      querySource: 'repl' as never,
+      setToolJSX: () => {},
+      getToolUseContext: () => ({}) as never,
+      setUserInputOnProcessing: () => {},
+      setAbortController: () => {},
+      onQuery: async newMessages => {
+        queriedMessages.push(newMessages)
+      },
+      setAppState: () => ({}) as never,
+    })
+
+    expect(reminderTakeCount).toBe(1)
+    expect(queriedMessages).toEqual([[correctionMessage]])
+  })
+
+  it('re-arms an injected reminder when the query guard declines ownership', async () => {
+    const correctionMessage = createUserMessage({ content: 'do Y instead' })
+    const reminderMessage = createUserMessage({
+      content: '<system-reminder>interrupted</system-reminder>',
+      isMeta: true,
+    })
+    mock.module('./processUserInput/processUserInput.js', () => ({
+      processUserInput: async () => ({
+        messages: [correctionMessage],
+        shouldQuery: true,
+      }),
+    }))
+    const { handlePromptSubmit } = await import('./handlePromptSubmit.js')
+
+    let restoreCount = 0
+    await handlePromptSubmit({
+      input: 'do Y instead',
+      mode: 'prompt',
+      pastedContents: {},
+      helpers: {
+        setCursorOffset: () => {},
+        clearBuffer: () => {},
+        resetHistory: () => {},
+      },
+      onInputChange: () => {},
+      setPastedContents: () => {},
+      takeInterruptionCorrectionReminder: () => reminderMessage,
+      restoreInterruptionCorrectionReminder: () => {
+        restoreCount++
+      },
+      queryGuard: {
+        isActive: false,
+        reserve: () => true,
+        cancelReservation: () => {},
+      } as never,
+      isExternalLoading: false,
+      commands: [],
+      messages: [],
+      mainLoopModel: 'sonnet',
+      ideSelection: undefined,
+      querySource: 'repl' as never,
+      setToolJSX: () => {},
+      getToolUseContext: () => ({}) as never,
+      setUserInputOnProcessing: () => {},
+      setAbortController: () => {},
+      onQuery: async () => false,
+      setAppState: () => ({}) as never,
+    } as never)
+
+    expect(restoreCount).toBe(1)
+  })
+
+  it('consumes a reminder when processing the normal prompt throws', async () => {
+    const reminderMessage = createUserMessage({
+      content: '<system-reminder>interrupted</system-reminder>',
+      isMeta: true,
+    })
+    mock.module('./processUserInput/processUserInput.js', () => ({
+      processUserInput: async () => {
+        throw new Error('hook failed')
+      },
+    }))
+    const { handlePromptSubmit } = await import('./handlePromptSubmit.js')
+
+    let reminderTakeCount = 0
+    let restoreCount = 0
+    const submission = handlePromptSubmit({
+      input: 'do Y instead',
+      mode: 'prompt',
+      pastedContents: {},
+      helpers: {
+        setCursorOffset: () => {},
+        clearBuffer: () => {},
+        resetHistory: () => {},
+      },
+      onInputChange: () => {},
+      setPastedContents: () => {},
+      takeInterruptionCorrectionReminder: () => {
+        reminderTakeCount++
+        return reminderMessage
+      },
+      restoreInterruptionCorrectionReminder: () => {
+        restoreCount++
+      },
+      queryGuard: {
+        isActive: false,
+        reserve: () => true,
+        cancelReservation: () => {},
+      } as never,
+      isExternalLoading: false,
+      commands: [],
+      messages: [],
+      mainLoopModel: 'sonnet',
+      ideSelection: undefined,
+      querySource: 'repl' as never,
+      setToolJSX: () => {},
+      getToolUseContext: () => ({}) as never,
+      setUserInputOnProcessing: () => {},
+      setAbortController: () => {},
+      onQuery: async () => {},
+      setAppState: () => ({}) as never,
+    } as never)
+
+    await expect(submission).rejects.toThrow('hook failed')
+    expect(reminderTakeCount).toBe(1)
+    expect(restoreCount).toBe(0)
+  })
+
   it('preserves a reminder across a queued slash command and injects it once', async () => {
     const reminderMessage = createUserMessage({
       content: '<system-reminder>interrupted</system-reminder>',
@@ -221,6 +385,24 @@ describe('handlePromptSubmit', () => {
     for (const prompt of ineligiblePrompts) {
       expect(isNormalLocalUserPrompt?.(prompt)).toBe(false)
     }
+  })
+
+  it('preserves local prompt provenance when a concurrent turn is requeued', async () => {
+    const { buildConcurrentRequeuedPrompt } =
+      await import('./handlePromptSubmit.js')
+
+    expect(buildConcurrentRequeuedPrompt('do Y instead', true)).toEqual({
+      value: 'do Y instead',
+      preExpansionValue: 'do Y instead',
+      allowInterruptionCorrection: true,
+      mode: 'prompt',
+    })
+    expect(buildConcurrentRequeuedPrompt('remote prompt', false)).toEqual({
+      value: 'remote prompt',
+      preExpansionValue: undefined,
+      allowInterruptionCorrection: false,
+      mode: 'prompt',
+    })
   })
 
   it('marks only normal local prompts as correction-eligible model turns', async () => {

--- a/src/utils/handlePromptSubmit.test.ts
+++ b/src/utils/handlePromptSubmit.test.ts
@@ -223,6 +223,105 @@ describe('handlePromptSubmit', () => {
     }
   })
 
+  it('marks only normal local prompts as correction-eligible model turns', async () => {
+    mock.module('./processUserInput/processUserInput.js', () => ({
+      processUserInput: async ({ input }: { input: string }) => ({
+        messages: [createUserMessage({ content: input })],
+        shouldQuery: true,
+      }),
+    }))
+    const { handlePromptSubmit } = await import('./handlePromptSubmit.js')
+
+    const correctionEligibility: unknown[] = []
+    const baseParams = {
+      helpers: {
+        setCursorOffset: () => {},
+        clearBuffer: () => {},
+        resetHistory: () => {},
+      },
+      onInputChange: () => {},
+      setPastedContents: () => {},
+      queryGuard: {
+        isActive: false,
+        reserve: () => true,
+        cancelReservation: () => {},
+      } as never,
+      isExternalLoading: false,
+      commands: [],
+      messages: [],
+      mainLoopModel: 'sonnet',
+      ideSelection: undefined,
+      querySource: 'repl' as never,
+      setToolJSX: () => {},
+      getToolUseContext: () => ({}) as never,
+      setUserInputOnProcessing: () => {},
+      setAbortController: () => {},
+      onQuery: async (
+        _newMessages: unknown,
+        _abortController: unknown,
+        _shouldQuery: unknown,
+        _allowedTools: unknown,
+        _mainLoopModel: unknown,
+        _onBeforeQuery: unknown,
+        _input: unknown,
+        _effort: unknown,
+        isInterruptionCorrectionEligible: unknown,
+      ) => {
+        correctionEligibility.push(isInterruptionCorrectionEligible)
+      },
+      setAppState: () => ({}) as never,
+    }
+
+    await handlePromptSubmit({
+      ...baseParams,
+      queuedCommands: [
+        {
+          value: 'local prompt',
+          preExpansionValue: 'local prompt',
+          mode: 'prompt',
+        },
+      ],
+    } as never)
+    await handlePromptSubmit({
+      ...baseParams,
+      queuedCommands: [
+        {
+          value: 'remote prompt',
+          preExpansionValue: 'remote prompt',
+          mode: 'prompt',
+          bridgeOrigin: true,
+          skipSlashCommands: true,
+        },
+      ],
+    } as never)
+    await handlePromptSubmit({
+      ...baseParams,
+      queuedCommands: [
+        {
+          value: 'local prompt',
+          preExpansionValue: 'local prompt',
+          mode: 'prompt',
+        },
+        {
+          value: 'remote prompt',
+          preExpansionValue: 'remote prompt',
+          mode: 'prompt',
+          bridgeOrigin: true,
+          skipSlashCommands: true,
+        },
+      ],
+    } as never)
+    await handlePromptSubmit({
+      ...baseParams,
+      input: 'programmatic initial prompt',
+      mode: 'prompt',
+      pastedContents: {},
+      allowInterruptionCorrection: false,
+    } as never)
+
+    expect(correctionEligibility).toEqual([true, false, false, false])
+  })
+
   it('queues prompt submissions during generation without interrupting the current turn', async () => {
     const { handlePromptSubmit } = await import('./handlePromptSubmit.js')
 

--- a/src/utils/handlePromptSubmit.test.ts
+++ b/src/utils/handlePromptSubmit.test.ts
@@ -3,8 +3,13 @@ import {
   acquireSharedMutationLock,
   releaseSharedMutationLock,
 } from '../test/sharedMutationLock.js'
+import * as realAnalyticsModule from '../services/analytics/index.js'
 import { getCommandQueue, resetCommandQueue } from './messageQueueManager.js'
 import { createUserMessage } from './messages.js'
+import * as realProcessUserInputModule from './processUserInput/processUserInput.js'
+
+const realAnalytics = { ...realAnalyticsModule }
+const realProcessUserInput = { ...realProcessUserInputModule }
 
 describe('handlePromptSubmit', () => {
   beforeEach(async () => {
@@ -19,6 +24,11 @@ describe('handlePromptSubmit', () => {
     try {
       resetCommandQueue()
       mock.restore()
+      mock.module('src/services/analytics/index.js', () => realAnalytics)
+      mock.module(
+        './processUserInput/processUserInput.js',
+        () => realProcessUserInput,
+      )
     } finally {
       releaseSharedMutationLock()
     }

--- a/src/utils/handlePromptSubmit.ts
+++ b/src/utils/handlePromptSubmit.ts
@@ -484,7 +484,7 @@ async function executeUserInput(params: ExecuteUserInputParams): Promise<void> {
   // that case (only acts on dispatching state).
   let queryProfileOwnedByOnQuery = false
   let interruptionCorrectionReminder: Message | null | undefined
-  let interruptionCorrectionReminderOwnedByModel = false
+  let interruptionCorrectionModelRequested = false
   try {
     // Reserve the guard BEFORE processUserInput — processBashCommand awaits
     // BashTool.call() and processSlashCommand awaits getMessagesForSlashCommand,
@@ -628,6 +628,7 @@ async function executeUserInput(params: ExecuteUserInputParams): Promise<void> {
             ? primaryCmd.value
             : undefined
         const shouldCallBeforeQuery = primaryMode === 'prompt'
+        interruptionCorrectionModelRequested = shouldQuery
         queryProfileOwnedByOnQuery = true
         const queryOwnershipResult = await onQuery(
           newMessages,
@@ -644,8 +645,6 @@ async function executeUserInput(params: ExecuteUserInputParams): Promise<void> {
           // human turn may arm interruption-correction context.
           isInterruptionCorrectionEligible,
         )
-        interruptionCorrectionReminderOwnedByModel =
-          shouldQuery && queryOwnershipResult !== false
         if (queryOwnershipResult === false) {
           queryProfileOwnedByOnQuery = false
         }
@@ -675,11 +674,12 @@ async function executeUserInput(params: ExecuteUserInputParams): Promise<void> {
       }
     }) // end runWithWorkload — ALS context naturally scoped, no finally needed
   } finally {
-    // Keep the reminder until an eligible model turn takes ownership. Local
-    // commands and preflight vetoes do not consume correction context.
+    // `onQuery` owns the reminder lifecycle once dispatch starts. It restores
+    // the reminder itself for preflight failures and returns false when the
+    // guard declined ownership; do not re-arm after a post-dispatch failure.
     if (
       interruptionCorrectionReminder &&
-      !interruptionCorrectionReminderOwnedByModel
+      (!queryProfileOwnedByOnQuery || !interruptionCorrectionModelRequested)
     ) {
       restoreInterruptionCorrectionReminder?.()
     }

--- a/src/utils/handlePromptSubmit.ts
+++ b/src/utils/handlePromptSubmit.ts
@@ -483,6 +483,8 @@ async function executeUserInput(params: ExecuteUserInputParams): Promise<void> {
   // which transitions running→idle; cancelReservation() below is a no-op in
   // that case (only acts on dispatching state).
   let queryProfileOwnedByOnQuery = false
+  let interruptionCorrectionReminder: Message | null | undefined
+  let interruptionCorrectionReminderInjected = false
   try {
     // Reserve the guard BEFORE processUserInput — processBashCommand awaits
     // BashTool.call() and processSlashCommand awaits getMessagesForSlashCommand,
@@ -507,10 +509,9 @@ async function executeUserInput(params: ExecuteUserInputParams): Promise<void> {
     const commands = queuedCommands ?? []
     const isInterruptionCorrectionEligible =
       commands.length > 0 && commands.every(isNormalLocalUserPrompt)
-    const interruptionCorrectionReminder = isInterruptionCorrectionEligible
+    interruptionCorrectionReminder = isInterruptionCorrectionEligible
       ? takeInterruptionCorrectionReminder?.()
       : undefined
-    let interruptionCorrectionReminderInjected = false
 
     // Compute the workload tag for this turn. queueProcessor can batch a
     // cron prompt with a same-tick human prompt; only tag when EVERY
@@ -676,6 +677,15 @@ async function executeUserInput(params: ExecuteUserInputParams): Promise<void> {
       }
     }) // end runWithWorkload — ALS context naturally scoped, no finally needed
   } finally {
+    // Processing can be vetoed by a UserPromptSubmit hook or throw before a
+    // model-bound query owns the reminder. Keep it for the next eligible
+    // correction instead of silently losing the interruption context.
+    if (
+      interruptionCorrectionReminder &&
+      !interruptionCorrectionReminderInjected
+    ) {
+      restoreInterruptionCorrectionReminder?.()
+    }
     // Safety net: release the guard reservation if processUserInput threw
     // or onQuery was skipped. No-op if onQuery already ran (guard is idle
     // via end(), or running — cancelReservation only acts on dispatching).

--- a/src/utils/handlePromptSubmit.ts
+++ b/src/utils/handlePromptSubmit.ts
@@ -51,7 +51,9 @@ export function isNormalLocalUserPrompt(command: QueuedCommand): boolean {
     command.bridgeOrigin !== true &&
     command.isMeta !== true &&
     command.origin === undefined &&
-    command.slashCommandOverride === undefined
+    command.slashCommandOverride === undefined &&
+    command.workload === undefined &&
+    command.agentId === undefined
   )
 }
 

--- a/src/utils/handlePromptSubmit.ts
+++ b/src/utils/handlePromptSubmit.ts
@@ -485,6 +485,7 @@ async function executeUserInput(params: ExecuteUserInputParams): Promise<void> {
   let queryProfileOwnedByOnQuery = false
   let interruptionCorrectionReminder: Message | null | undefined
   let interruptionCorrectionReminderInjected = false
+  let queryDispatchStarted = false
   try {
     // Reserve the guard BEFORE processUserInput — processBashCommand awaits
     // BashTool.call() and processSlashCommand awaits getMessagesForSlashCommand,
@@ -630,6 +631,7 @@ async function executeUserInput(params: ExecuteUserInputParams): Promise<void> {
             : undefined
         const shouldCallBeforeQuery = primaryMode === 'prompt'
         queryProfileOwnedByOnQuery = true
+        queryDispatchStarted = shouldQuery
         const queryOwnershipResult = await onQuery(
           newMessages,
           abortController,
@@ -682,7 +684,7 @@ async function executeUserInput(params: ExecuteUserInputParams): Promise<void> {
     // correction instead of silently losing the interruption context.
     if (
       interruptionCorrectionReminder &&
-      !interruptionCorrectionReminderInjected
+      !queryDispatchStarted
     ) {
       restoreInterruptionCorrectionReminder?.()
     }

--- a/src/utils/handlePromptSubmit.ts
+++ b/src/utils/handlePromptSubmit.ts
@@ -40,6 +40,21 @@ function exit(): void {
   gracefulShutdownSync(0)
 }
 
+export function isNormalLocalUserPrompt(command: QueuedCommand): boolean {
+  return (
+    command.mode === 'prompt' &&
+    typeof command.value === 'string' &&
+    !command.value.trimStart().startsWith('/') &&
+    typeof command.preExpansionValue === 'string' &&
+    !command.preExpansionValue.trimStart().startsWith('/') &&
+    command.skipSlashCommands !== true &&
+    command.bridgeOrigin !== true &&
+    command.isMeta !== true &&
+    command.origin === undefined &&
+    command.slashCommandOverride === undefined
+  )
+}
+
 type BaseExecutionParams = {
   queuedCommands?: QueuedCommand[]
   messages: Message[]
@@ -78,6 +93,7 @@ type BaseExecutionParams = {
   setAppState: (updater: (prev: AppState) => AppState) => void
   onBeforeQuery?: (input: string, newMessages: Message[]) => Promise<boolean>
   canUseTool?: CanUseToolFn
+  takeInterruptionCorrectionReminder?: () => Message | null
 }
 
 /**
@@ -145,6 +161,7 @@ export async function handlePromptSubmit(
     onBeforeQuery,
     canUseTool,
     queuedCommands,
+    takeInterruptionCorrectionReminder,
     uuid,
     skipSlashCommands,
     slashCommandOverride,
@@ -174,6 +191,7 @@ export async function handlePromptSubmit(
       resetHistory,
       canUseTool,
       onInputChange,
+      takeInterruptionCorrectionReminder,
     })
     return
   }
@@ -393,6 +411,7 @@ export async function handlePromptSubmit(
     resetHistory,
     canUseTool,
     onInputChange,
+    takeInterruptionCorrectionReminder,
   })
 }
 
@@ -420,6 +439,7 @@ async function executeUserInput(params: ExecuteUserInputParams): Promise<void> {
     resetHistory,
     canUseTool,
     queuedCommands,
+    takeInterruptionCorrectionReminder,
   } = params
 
   // Note: paste references are already processed before calling this function
@@ -484,6 +504,10 @@ async function executeUserInput(params: ExecuteUserInputParams): Promise<void> {
       for (let i = 0; i < commands.length; i++) {
         const cmd = commands[i]!
         const isFirst = i === 0
+        const interruptionCorrectionReminder =
+          isNormalLocalUserPrompt(cmd)
+            ? takeInterruptionCorrectionReminder?.()
+            : undefined
         const result = await processUserInput({
           input: cmd.value,
           preExpansionInput: cmd.preExpansionValue,
@@ -506,6 +530,9 @@ async function executeUserInput(params: ExecuteUserInputParams): Promise<void> {
           isMeta: cmd.isMeta,
           skipAttachments: !isFirst,
         })
+        if (interruptionCorrectionReminder) {
+          newMessages.push(interruptionCorrectionReminder)
+        }
         // Stamp origin here rather than threading another arg through
         // processUserInput → processUserInputBase → processTextPrompt → createUserMessage.
         // Derive origin from mode for task-notifications — mirrors the origin

--- a/src/utils/handlePromptSubmit.ts
+++ b/src/utils/handlePromptSubmit.ts
@@ -484,8 +484,7 @@ async function executeUserInput(params: ExecuteUserInputParams): Promise<void> {
   // that case (only acts on dispatching state).
   let queryProfileOwnedByOnQuery = false
   let interruptionCorrectionReminder: Message | null | undefined
-  let interruptionCorrectionReminderInjected = false
-  let queryDispatchStarted = false
+  let interruptionCorrectionReminderOwnedByModel = false
   try {
     // Reserve the guard BEFORE processUserInput — processBashCommand awaits
     // BashTool.call() and processSlashCommand awaits getMessagesForSlashCommand,
@@ -565,7 +564,6 @@ async function executeUserInput(params: ExecuteUserInputParams): Promise<void> {
           interruptionCorrectionReminder
         ) {
           newMessages.push(interruptionCorrectionReminder)
-          interruptionCorrectionReminderInjected = true
         }
         // Stamp origin here rather than threading another arg through
         // processUserInput → processUserInputBase → processTextPrompt → createUserMessage.
@@ -631,7 +629,6 @@ async function executeUserInput(params: ExecuteUserInputParams): Promise<void> {
             : undefined
         const shouldCallBeforeQuery = primaryMode === 'prompt'
         queryProfileOwnedByOnQuery = true
-        queryDispatchStarted = shouldQuery
         const queryOwnershipResult = await onQuery(
           newMessages,
           abortController,
@@ -647,11 +644,10 @@ async function executeUserInput(params: ExecuteUserInputParams): Promise<void> {
           // human turn may arm interruption-correction context.
           isInterruptionCorrectionEligible,
         )
+        interruptionCorrectionReminderOwnedByModel =
+          shouldQuery && queryOwnershipResult !== false
         if (queryOwnershipResult === false) {
           queryProfileOwnedByOnQuery = false
-          if (interruptionCorrectionReminderInjected) {
-            restoreInterruptionCorrectionReminder?.()
-          }
         }
       } else {
         // Local slash commands that skip messages (e.g., /model, /theme).
@@ -679,12 +675,11 @@ async function executeUserInput(params: ExecuteUserInputParams): Promise<void> {
       }
     }) // end runWithWorkload — ALS context naturally scoped, no finally needed
   } finally {
-    // Processing can be vetoed by a UserPromptSubmit hook or throw before a
-    // model-bound query owns the reminder. Keep it for the next eligible
-    // correction instead of silently losing the interruption context.
+    // Keep the reminder until an eligible model turn takes ownership. Local
+    // commands and preflight vetoes do not consume correction context.
     if (
       interruptionCorrectionReminder &&
-      !queryDispatchStarted
+      !interruptionCorrectionReminderOwnedByModel
     ) {
       restoreInterruptionCorrectionReminder?.()
     }

--- a/src/utils/handlePromptSubmit.ts
+++ b/src/utils/handlePromptSubmit.ts
@@ -53,7 +53,8 @@ export function isNormalLocalUserPrompt(command: QueuedCommand): boolean {
     command.origin === undefined &&
     command.slashCommandOverride === undefined &&
     command.workload === undefined &&
-    command.agentId === undefined
+    command.agentId === undefined &&
+    command.allowInterruptionCorrection !== false
   )
 }
 
@@ -90,6 +91,7 @@ type BaseExecutionParams = {
     onBeforeQuery?: (input: string, newMessages: Message[]) => Promise<boolean>,
     input?: string,
     effort?: EffortValue,
+    isInterruptionCorrectionEligible?: boolean,
     // Return false when the query guard declines ownership before a turn starts.
   ) => Promise<void | false>
   setAppState: (updater: (prev: AppState) => AppState) => void
@@ -139,6 +141,7 @@ export type HandlePromptSubmitParams = BaseExecutionParams & {
    */
   skipSlashCommands?: boolean
   slashCommandOverride?: Command
+  allowInterruptionCorrection?: boolean
 }
 
 export async function handlePromptSubmit(
@@ -167,6 +170,7 @@ export async function handlePromptSubmit(
     uuid,
     skipSlashCommands,
     slashCommandOverride,
+    allowInterruptionCorrection,
   } = params
 
   const { setCursorOffset, clearBuffer, resetHistory } = helpers
@@ -368,6 +372,7 @@ export async function handlePromptSubmit(
       pastedContents: hasImages ? pastedContents : undefined,
       skipSlashCommands,
       slashCommandOverride,
+      allowInterruptionCorrection,
       uuid,
     })
 
@@ -392,6 +397,7 @@ export async function handlePromptSubmit(
     pastedContents: hasImages ? pastedContents : undefined,
     skipSlashCommands,
     slashCommandOverride,
+    allowInterruptionCorrection,
     uuid,
   }
 
@@ -610,6 +616,9 @@ async function executeUserInput(params: ExecuteUserInputParams): Promise<void> {
           shouldCallBeforeQuery ? onBeforeQuery : undefined,
           primaryInput,
           effort,
+          // Fail closed for mixed-provenance batches: only an entirely local
+          // human turn may arm interruption-correction context.
+          commands.length > 0 && commands.every(isNormalLocalUserPrompt),
         )
         if (queryOwnershipResult === false) {
           queryProfileOwnedByOnQuery = false

--- a/src/utils/handlePromptSubmit.ts
+++ b/src/utils/handlePromptSubmit.ts
@@ -104,6 +104,7 @@ type BaseExecutionParams = {
     input?: string,
     effort?: EffortValue,
     isInterruptionCorrectionEligible?: boolean,
+    onModelRequestStart?: () => void,
     // Return false when the query guard declines ownership before a turn starts.
   ) => Promise<void | false>
   setAppState: (updater: (prev: AppState) => AppState) => void
@@ -484,7 +485,7 @@ async function executeUserInput(params: ExecuteUserInputParams): Promise<void> {
   // that case (only acts on dispatching state).
   let queryProfileOwnedByOnQuery = false
   let interruptionCorrectionReminder: Message | null | undefined
-  let interruptionCorrectionModelRequested = false
+  let interruptionCorrectionReminderOwnedByModel = false
   try {
     // Reserve the guard BEFORE processUserInput — processBashCommand awaits
     // BashTool.call() and processSlashCommand awaits getMessagesForSlashCommand,
@@ -628,7 +629,6 @@ async function executeUserInput(params: ExecuteUserInputParams): Promise<void> {
             ? primaryCmd.value
             : undefined
         const shouldCallBeforeQuery = primaryMode === 'prompt'
-        interruptionCorrectionModelRequested = shouldQuery
         queryProfileOwnedByOnQuery = true
         const queryOwnershipResult = await onQuery(
           newMessages,
@@ -644,6 +644,9 @@ async function executeUserInput(params: ExecuteUserInputParams): Promise<void> {
           // Fail closed for mixed-provenance batches: only an entirely local
           // human turn may arm interruption-correction context.
           isInterruptionCorrectionEligible,
+          () => {
+            interruptionCorrectionReminderOwnedByModel = true
+          },
         )
         if (queryOwnershipResult === false) {
           queryProfileOwnedByOnQuery = false
@@ -674,12 +677,10 @@ async function executeUserInput(params: ExecuteUserInputParams): Promise<void> {
       }
     }) // end runWithWorkload — ALS context naturally scoped, no finally needed
   } finally {
-    // `onQuery` owns the reminder lifecycle once dispatch starts. It restores
-    // the reminder itself for preflight failures and returns false when the
-    // guard declined ownership; do not re-arm after a post-dispatch failure.
+    // Keep the reminder until an actual model request takes ownership.
     if (
       interruptionCorrectionReminder &&
-      (!queryProfileOwnedByOnQuery || !interruptionCorrectionModelRequested)
+      !interruptionCorrectionReminderOwnedByModel
     ) {
       restoreInterruptionCorrectionReminder?.()
     }

--- a/src/utils/handlePromptSubmit.ts
+++ b/src/utils/handlePromptSubmit.ts
@@ -58,6 +58,18 @@ export function isNormalLocalUserPrompt(command: QueuedCommand): boolean {
   )
 }
 
+export function buildConcurrentRequeuedPrompt(
+  value: string,
+  isInterruptionCorrectionEligible: boolean,
+): QueuedCommand {
+  return {
+    value,
+    preExpansionValue: isInterruptionCorrectionEligible ? value : undefined,
+    allowInterruptionCorrection: isInterruptionCorrectionEligible,
+    mode: 'prompt',
+  }
+}
+
 type BaseExecutionParams = {
   queuedCommands?: QueuedCommand[]
   messages: Message[]
@@ -98,6 +110,7 @@ type BaseExecutionParams = {
   onBeforeQuery?: (input: string, newMessages: Message[]) => Promise<boolean>
   canUseTool?: CanUseToolFn
   takeInterruptionCorrectionReminder?: () => Message | null
+  restoreInterruptionCorrectionReminder?: () => void
 }
 
 /**
@@ -167,6 +180,7 @@ export async function handlePromptSubmit(
     canUseTool,
     queuedCommands,
     takeInterruptionCorrectionReminder,
+    restoreInterruptionCorrectionReminder,
     uuid,
     skipSlashCommands,
     slashCommandOverride,
@@ -198,6 +212,7 @@ export async function handlePromptSubmit(
       canUseTool,
       onInputChange,
       takeInterruptionCorrectionReminder,
+      restoreInterruptionCorrectionReminder,
     })
     return
   }
@@ -420,6 +435,7 @@ export async function handlePromptSubmit(
     canUseTool,
     onInputChange,
     takeInterruptionCorrectionReminder,
+    restoreInterruptionCorrectionReminder,
   })
 }
 
@@ -448,6 +464,7 @@ async function executeUserInput(params: ExecuteUserInputParams): Promise<void> {
     canUseTool,
     queuedCommands,
     takeInterruptionCorrectionReminder,
+    restoreInterruptionCorrectionReminder,
   } = params
 
   // Note: paste references are already processed before calling this function
@@ -488,6 +505,12 @@ async function executeUserInput(params: ExecuteUserInputParams): Promise<void> {
     // ideSelection + pastedContents, rest skip attachments to avoid
     // duplicating turn-level context (IDE selection, todos, diffs).
     const commands = queuedCommands ?? []
+    const isInterruptionCorrectionEligible =
+      commands.length > 0 && commands.every(isNormalLocalUserPrompt)
+    const interruptionCorrectionReminder = isInterruptionCorrectionEligible
+      ? takeInterruptionCorrectionReminder?.()
+      : undefined
+    let interruptionCorrectionReminderInjected = false
 
     // Compute the workload tag for this turn. queueProcessor can batch a
     // cron prompt with a same-tick human prompt; only tag when EVERY
@@ -512,10 +535,6 @@ async function executeUserInput(params: ExecuteUserInputParams): Promise<void> {
       for (let i = 0; i < commands.length; i++) {
         const cmd = commands[i]!
         const isFirst = i === 0
-        const interruptionCorrectionReminder =
-          isNormalLocalUserPrompt(cmd)
-            ? takeInterruptionCorrectionReminder?.()
-            : undefined
         const result = await processUserInput({
           input: cmd.value,
           preExpansionInput: cmd.preExpansionValue,
@@ -538,8 +557,13 @@ async function executeUserInput(params: ExecuteUserInputParams): Promise<void> {
           isMeta: cmd.isMeta,
           skipAttachments: !isFirst,
         })
-        if (interruptionCorrectionReminder) {
+        if (
+          isFirst &&
+          result.shouldQuery &&
+          interruptionCorrectionReminder
+        ) {
           newMessages.push(interruptionCorrectionReminder)
+          interruptionCorrectionReminderInjected = true
         }
         // Stamp origin here rather than threading another arg through
         // processUserInput → processUserInputBase → processTextPrompt → createUserMessage.
@@ -618,10 +642,13 @@ async function executeUserInput(params: ExecuteUserInputParams): Promise<void> {
           effort,
           // Fail closed for mixed-provenance batches: only an entirely local
           // human turn may arm interruption-correction context.
-          commands.length > 0 && commands.every(isNormalLocalUserPrompt),
+          isInterruptionCorrectionEligible,
         )
         if (queryOwnershipResult === false) {
           queryProfileOwnedByOnQuery = false
+          if (interruptionCorrectionReminderInjected) {
+            restoreInterruptionCorrectionReminder?.()
+          }
         }
       } else {
         // Local slash commands that skip messages (e.g., /model, /theme).

--- a/src/utils/interruptionCorrection.test.ts
+++ b/src/utils/interruptionCorrection.test.ts
@@ -1,12 +1,15 @@
 import { expect, test } from 'bun:test'
 import {
+  applyInterruptionCorrectionAwareMessageUpdate,
   buildInterruptionCorrectionMessageViews,
   consumeInterruptionCorrectionReminder,
   InterruptionCorrectionTracker,
   shouldMarkInterruptionCorrection,
 } from './interruptionCorrection.js'
 import { createUserMessage } from './messages/factories.js'
+import { createCompactBoundaryMessage } from './messages/systemFactories.js'
 import { QueryGuard } from './QueryGuard.js'
+import type { Message } from '../types/message.js'
 
 test('only marks a local user cancellation of the active model query', () => {
   const localUserCancellation = {
@@ -72,6 +75,115 @@ test('clears a pending reminder when the interrupted context is rewritten', () =
 
   tracker.handleConversationRewrite()
 
+  expect(tracker.takeReminder()).toBeNull()
+})
+
+test('clears a pending reminder when a full compact boundary is applied', () => {
+  const queryGuard = new QueryGuard()
+  const tracker = new InterruptionCorrectionTracker(
+    queryGuard,
+    () => 'session-a',
+  )
+  const turn = queryGuard.tryStart({
+    queryId: 'interrupted-turn',
+    querySource: 'repl_main_thread',
+    startedAt: 1,
+  })!
+  tracker.bindModelTurn({
+    shouldQuery: true,
+    isInterruptionCorrectionEligible: true,
+    queryId: turn.context.queryId,
+  })
+  tracker.handleCancellation({
+    isUserInitiated: true,
+    isRemoteMode: false,
+  })
+  queryGuard.forceEnd('user-abort', 'user-cancel')
+
+  const messagesRef = { current: [] }
+  applyInterruptionCorrectionAwareMessageUpdate(
+    messagesRef,
+    [createCompactBoundaryMessage('manual', 100)],
+    tracker,
+  )
+
+  expect(tracker.takeReminder()).toBeNull()
+})
+
+test('keeps a pending reminder when messages retain the existing compact boundary', () => {
+  const queryGuard = new QueryGuard()
+  const tracker = new InterruptionCorrectionTracker(
+    queryGuard,
+    () => 'session-a',
+  )
+  const boundary = createCompactBoundaryMessage('manual', 100)
+  const turn = queryGuard.tryStart({
+    queryId: 'post-compact-turn',
+    querySource: 'repl_main_thread',
+    startedAt: 1,
+  })!
+  tracker.bindModelTurn({
+    shouldQuery: true,
+    isInterruptionCorrectionEligible: true,
+    queryId: turn.context.queryId,
+  })
+  tracker.handleCancellation({
+    isUserInitiated: true,
+    isRemoteMode: false,
+  })
+  queryGuard.forceEnd('user-abort', 'user-cancel')
+
+  const messagesRef = { current: [boundary] }
+  applyInterruptionCorrectionAwareMessageUpdate(
+    messagesRef,
+    [boundary, createUserMessage({ content: 'new correction' })],
+    tracker,
+  )
+
+  expect(tracker.takeReminder()).toMatchObject({ type: 'user', isMeta: true })
+})
+
+test('clears a pending reminder when a later compaction replaces an existing boundary', () => {
+  const queryGuard = new QueryGuard()
+  const tracker = new InterruptionCorrectionTracker(
+    queryGuard,
+    () => 'session-a',
+  )
+  const previousBoundary = createCompactBoundaryMessage('manual', 100)
+  const turn = queryGuard.tryStart({
+    queryId: 'repeat-compact-turn',
+    querySource: 'repl_main_thread',
+    startedAt: 1,
+  })!
+  tracker.bindModelTurn({
+    shouldQuery: true,
+    isInterruptionCorrectionEligible: true,
+    queryId: turn.context.queryId,
+  })
+  tracker.handleCancellation({
+    isUserInitiated: true,
+    isRemoteMode: false,
+  })
+  queryGuard.forceEnd('user-abort', 'user-cancel')
+
+  const messagesRef: { current: Message[] } = { current: [previousBoundary] }
+  const nextBoundary = createCompactBoundaryMessage('manual', 200)
+  const transition = applyInterruptionCorrectionAwareMessageUpdate(
+    messagesRef,
+    previousMessages => [
+      ...previousMessages.slice(0, -1),
+      nextBoundary,
+      createUserMessage({ content: 'compact summary' }),
+    ],
+    tracker,
+  )
+
+  expect(transition.previousMessages).toEqual([previousBoundary])
+  expect(transition.nextMessages).toEqual([
+    nextBoundary,
+    expect.objectContaining({ type: 'user' }),
+  ])
+  expect(messagesRef.current).toBe(transition.nextMessages)
   expect(tracker.takeReminder()).toBeNull()
 })
 

--- a/src/utils/interruptionCorrection.test.ts
+++ b/src/utils/interruptionCorrection.test.ts
@@ -54,6 +54,28 @@ test('does not arm after the model turn has completed', async () => {
   expect(tracker.takeReminder()).toBeNull()
 })
 
+test('keeps correction ownership through post-response tool work', () => {
+  const queryGuard = new QueryGuard()
+  const tracker = new InterruptionCorrectionTracker(queryGuard, () => 'session-a')
+  const turn = queryGuard.tryStart({
+    queryId: 'tool-turn',
+    querySource: 'repl_main_thread',
+    startedAt: 1,
+  })!
+
+  // The provider response completed and handed the turn off to a tool. The
+  // active query is not terminal yet, so cancellation must still arm context.
+  tracker.bindModelTurn({
+    shouldQuery: true,
+    isInterruptionCorrectionEligible: true,
+    queryId: turn.context.queryId,
+  })
+  tracker.handleCancellation({ isUserInitiated: true, isRemoteMode: false })
+  queryGuard.forceEnd('user-abort', 'user-cancel')
+
+  expect(tracker.takeReminder()).toMatchObject({ type: 'user', isMeta: true })
+})
+
 test('clears a pending reminder when the interrupted context is rewritten', () => {
   const queryGuard = new QueryGuard()
   const tracker = new InterruptionCorrectionTracker(

--- a/src/utils/interruptionCorrection.test.ts
+++ b/src/utils/interruptionCorrection.test.ts
@@ -527,6 +527,30 @@ The previous assistant turn was interrupted by the user. Treat the user's latest
   ).toEqual({ pendingSessionId: null, reminder: null })
 })
 
+test('clears a pending reminder when switching sessions', () => {
+  const queryGuard = new QueryGuard()
+  let sessionId = 'session-a'
+  const tracker = new InterruptionCorrectionTracker(queryGuard, () => sessionId)
+  const turn = queryGuard.tryStart({
+    queryId: 'interrupted-turn',
+    querySource: 'repl_main_thread',
+    startedAt: 1,
+  })!
+  tracker.bindModelTurn({
+    shouldQuery: true,
+    isInterruptionCorrectionEligible: true,
+    queryId: turn.context.queryId,
+  })
+  tracker.handleCancellation({ isUserInitiated: true, isRemoteMode: false })
+  queryGuard.forceEnd('user-abort', 'user-cancel')
+
+  sessionId = 'session-b'
+  tracker.handleSessionChange()
+  sessionId = 'session-a'
+
+  expect(tracker.takeReminder()).toBeNull()
+})
+
 test('keeps the correction reminder in one request without persisting it', () => {
   const priorMessage = createUserMessage({ content: 'start with X' })
   const reminder = consumeInterruptionCorrectionReminder(

--- a/src/utils/interruptionCorrection.test.ts
+++ b/src/utils/interruptionCorrection.test.ts
@@ -27,7 +27,6 @@ test('only marks a local user cancellation of the active model query', () => {
     { ...localUserCancellation, modelBoundQueryId: null },
     { ...localUserCancellation, modelBoundQueryId: 'query-2' },
     { ...localUserCancellation, isRemoteMode: true },
-    { ...localUserCancellation, hasQueuedNormalPrompt: true },
   ]
 
   for (const cancellation of excludedCancellations) {

--- a/src/utils/interruptionCorrection.test.ts
+++ b/src/utils/interruptionCorrection.test.ts
@@ -332,6 +332,22 @@ test('clears a pending reminder when an existing compact boundary is removed', (
   expect(tracker.takeReminder()).toBeNull()
 })
 
+test('clears a pending reminder when the conversation is cleared', () => {
+  const tracker = new InterruptionCorrectionTracker(
+    new QueryGuard(),
+    () => 'session-a',
+  )
+  tracker.restoreReminder()
+
+  applyInterruptionCorrectionAwareMessageUpdate(
+    { current: [createUserMessage({ content: 'discard this turn' })] },
+    [],
+    tracker,
+  )
+
+  expect(tracker.takeReminder()).toBeNull()
+})
+
 test('does not restore a consumed reminder after programmatic auto-restore cancellation', () => {
   const queryGuard = new QueryGuard()
   const tracker = new InterruptionCorrectionTracker(

--- a/src/utils/interruptionCorrection.test.ts
+++ b/src/utils/interruptionCorrection.test.ts
@@ -300,6 +300,93 @@ test('clears a pending reminder when a later compaction replaces an existing bou
   expect(tracker.takeReminder()).toBeNull()
 })
 
+test('clears a pending reminder when an existing compact boundary is removed', () => {
+  const queryGuard = new QueryGuard()
+  const tracker = new InterruptionCorrectionTracker(
+    queryGuard,
+    () => 'session-a',
+  )
+  const boundary = createCompactBoundaryMessage('manual', 100)
+  const turn = queryGuard.tryStart({
+    queryId: 'post-compact-turn',
+    querySource: 'repl_main_thread',
+    startedAt: 1,
+  })!
+  tracker.bindModelTurn({
+    shouldQuery: true,
+    isInterruptionCorrectionEligible: true,
+    queryId: turn.context.queryId,
+  })
+  tracker.handleCancellation({
+    isUserInitiated: true,
+    isRemoteMode: false,
+  })
+  queryGuard.forceEnd('user-abort', 'user-cancel')
+
+  applyInterruptionCorrectionAwareMessageUpdate(
+    { current: [boundary] },
+    [],
+    tracker,
+  )
+
+  expect(tracker.takeReminder()).toBeNull()
+})
+
+test('does not restore a consumed reminder after programmatic auto-restore cancellation', () => {
+  const queryGuard = new QueryGuard()
+  const tracker = new InterruptionCorrectionTracker(
+    queryGuard,
+    () => 'session-a',
+  )
+  const interruptedAttempt = queryGuard.tryStart({
+    queryId: 'attempt-a',
+    querySource: 'repl_main_thread',
+    startedAt: 1,
+  })!
+  tracker.bindModelTurn({
+    shouldQuery: true,
+    isInterruptionCorrectionEligible: true,
+    queryId: interruptedAttempt.context.queryId,
+  })
+  tracker.handleCancellation({
+    isUserInitiated: true,
+    isRemoteMode: false,
+  })
+  queryGuard.forceEnd('user-abort', 'user-cancel')
+
+  const reminder = tracker.takeReminder()!
+  const correction = createUserMessage({ content: 'do B instead' })
+  const correctionTurn = buildInterruptionCorrectionMessageViews(
+    [],
+    [reminder, correction],
+  )
+  const programmaticRestore = queryGuard.tryStart({
+    queryId: 'programmatic-restore',
+    querySource: 'repl_main_thread',
+    startedAt: 2,
+  })!
+  tracker.bindModelTurn({
+    shouldQuery: true,
+    isInterruptionCorrectionEligible: true,
+    queryId: programmaticRestore.context.queryId,
+  })
+  tracker.handleCancellation({
+    isUserInitiated: false,
+    isRemoteMode: false,
+  })
+  queryGuard.forceEnd('user-abort', 'user-cancel')
+
+  applyInterruptionCorrectionAutoRestore(
+    [correction],
+    correction,
+    () => {},
+    tracker,
+    correctionTurn.requestOnlyMessages,
+  )
+
+  expect(tracker.takeReminder()).toBeNull()
+})
+
 test('builds one same-session reminder and clears pending state', () => {
   const withoutPending = consumeInterruptionCorrectionReminder(null, 'session-a')
   expect(withoutPending).toEqual({ pendingSessionId: null, reminder: null })

--- a/src/utils/interruptionCorrection.test.ts
+++ b/src/utils/interruptionCorrection.test.ts
@@ -1,9 +1,11 @@
 import { expect, test } from 'bun:test'
 import {
+  buildInterruptionCorrectionMessageViews,
   consumeInterruptionCorrectionReminder,
   InterruptionCorrectionTracker,
   shouldMarkInterruptionCorrection,
 } from './interruptionCorrection.js'
+import { createUserMessage } from './messages/factories.js'
 import { QueryGuard } from './QueryGuard.js'
 
 test('only marks a local user cancellation of the active model query', () => {
@@ -35,15 +37,32 @@ test('clears a pending reminder when the interrupted context is rewritten', () =
     queryGuard,
     () => 'session-a',
   )
-  const turn = queryGuard.tryStart({
-    queryId: 'auto-restored-turn',
+  const proofTurn = queryGuard.tryStart({
+    queryId: 'proof-turn',
     querySource: 'repl_main_thread',
     startedAt: 1,
   })!
   tracker.bindModelTurn({
     shouldQuery: true,
     isInterruptionCorrectionEligible: true,
-    queryId: turn.context.queryId,
+    queryId: proofTurn.context.queryId,
+  })
+  tracker.handleCancellation({
+    isUserInitiated: true,
+    isRemoteMode: false,
+  })
+  queryGuard.forceEnd('user-abort', 'user-cancel')
+  expect(tracker.takeReminder()).toMatchObject({ type: 'user', isMeta: true })
+
+  const rewrittenTurn = queryGuard.tryStart({
+    queryId: 'auto-restored-turn',
+    querySource: 'repl_main_thread',
+    startedAt: 2,
+  })!
+  tracker.bindModelTurn({
+    shouldQuery: true,
+    isInterruptionCorrectionEligible: true,
+    queryId: rewrittenTurn.context.queryId,
   })
   tracker.handleCancellation({
     isUserInitiated: true,
@@ -85,4 +104,45 @@ The previous assistant turn was interrupted by the user. Treat the user's latest
   expect(
     consumeInterruptionCorrectionReminder('session-a', 'session-b'),
   ).toEqual({ pendingSessionId: null, reminder: null })
+})
+
+test('keeps the correction reminder in one request without persisting it', () => {
+  const priorMessage = createUserMessage({ content: 'start with X' })
+  const reminder = consumeInterruptionCorrectionReminder(
+    'session-a',
+    'session-a',
+  ).reminder!
+  const otherMetaMessage = createUserMessage({
+    content: '<system-reminder>keep this context</system-reminder>',
+    isMeta: true,
+  })
+  const correction = createUserMessage({ content: 'do Y instead' })
+
+  const correctionTurn = buildInterruptionCorrectionMessageViews(
+    [priorMessage],
+    [otherMetaMessage, reminder, correction],
+  )
+  expect(correctionTurn.persistentMessages).toEqual([
+    priorMessage,
+    otherMetaMessage,
+    correction,
+  ])
+  expect(correctionTurn.persistentNewMessages).toEqual([
+    otherMetaMessage,
+    correction,
+  ])
+  expect(correctionTurn.requestOnlyMessages).toEqual([reminder])
+
+  const laterPrompt = createUserMessage({ content: 'unrelated follow-up' })
+  const laterTurn = buildInterruptionCorrectionMessageViews(
+    correctionTurn.persistentMessages,
+    [laterPrompt],
+  )
+  expect(laterTurn.persistentMessages).toEqual([
+    priorMessage,
+    otherMetaMessage,
+    correction,
+    laterPrompt,
+  ])
+  expect(laterTurn.requestOnlyMessages).toEqual([])
 })

--- a/src/utils/interruptionCorrection.test.ts
+++ b/src/utils/interruptionCorrection.test.ts
@@ -1,8 +1,10 @@
 import { expect, test } from 'bun:test'
 import {
   consumeInterruptionCorrectionReminder,
+  InterruptionCorrectionTracker,
   shouldMarkInterruptionCorrection,
 } from './interruptionCorrection.js'
+import { QueryGuard } from './QueryGuard.js'
 
 test('only marks a local user cancellation of the active model query', () => {
   const localUserCancellation = {
@@ -19,11 +21,39 @@ test('only marks a local user cancellation of the active model query', () => {
     { ...localUserCancellation, modelBoundQueryId: null },
     { ...localUserCancellation, modelBoundQueryId: 'query-2' },
     { ...localUserCancellation, isRemoteMode: true },
+    { ...localUserCancellation, hasQueuedNormalPrompt: true },
   ]
 
   for (const cancellation of excludedCancellations) {
     expect(shouldMarkInterruptionCorrection(cancellation)).toBe(false)
   }
+})
+
+test('clears a pending reminder when the interrupted context is rewritten', () => {
+  const queryGuard = new QueryGuard()
+  const tracker = new InterruptionCorrectionTracker(
+    queryGuard,
+    () => 'session-a',
+  )
+  const turn = queryGuard.tryStart({
+    queryId: 'auto-restored-turn',
+    querySource: 'repl_main_thread',
+    startedAt: 1,
+  })!
+  tracker.bindModelTurn({
+    shouldQuery: true,
+    isInterruptionCorrectionEligible: true,
+    queryId: turn.context.queryId,
+  })
+  tracker.handleCancellation({
+    isUserInitiated: true,
+    isRemoteMode: false,
+  })
+  queryGuard.forceEnd('user-abort', 'user-cancel')
+
+  tracker.handleConversationRewrite()
+
+  expect(tracker.takeReminder()).toBeNull()
 })
 
 test('builds one same-session reminder and clears pending state', () => {

--- a/src/utils/interruptionCorrection.test.ts
+++ b/src/utils/interruptionCorrection.test.ts
@@ -1,5 +1,6 @@
 import { expect, test } from 'bun:test'
 import {
+  applyInterruptionCorrectionAutoRestore,
   applyInterruptionCorrectionAwareMessageUpdate,
   buildInterruptionCorrectionMessageViews,
   consumeInterruptionCorrectionReminder,
@@ -76,6 +77,118 @@ test('clears a pending reminder when the interrupted context is rewritten', () =
   tracker.handleConversationRewrite()
 
   expect(tracker.takeReminder()).toBeNull()
+})
+
+test('preserves the earlier reminder when an interrupted correction is auto-restored', () => {
+  const queryGuard = new QueryGuard()
+  const tracker = new InterruptionCorrectionTracker(
+    queryGuard,
+    () => 'session-a',
+  )
+  const attemptMessage = createUserMessage({ content: 'do A' })
+  const interruptedAttempt = queryGuard.tryStart({
+    queryId: 'attempt-a',
+    querySource: 'repl_main_thread',
+    startedAt: 1,
+  })!
+  tracker.bindModelTurn({
+    shouldQuery: true,
+    isInterruptionCorrectionEligible: true,
+    queryId: interruptedAttempt.context.queryId,
+  })
+  tracker.handleCancellation({
+    isUserInitiated: true,
+    isRemoteMode: false,
+  })
+  queryGuard.forceEnd('user-abort', 'user-cancel')
+
+  // Correction B consumes A's reminder before its pre-query work begins.
+  const reminderForCorrection = tracker.takeReminder()!
+  const correction = createUserMessage({ content: 'do B instead' })
+  const correctionTurn = buildInterruptionCorrectionMessageViews(
+    [],
+    [reminderForCorrection, correction],
+  )
+  expect(correctionTurn.requestOnlyMessages).toEqual([reminderForCorrection])
+
+  const interruptedCorrection = queryGuard.tryStart({
+    queryId: 'correction-b',
+    querySource: 'repl_main_thread',
+    startedAt: 2,
+  })!
+  tracker.bindModelTurn({
+    shouldQuery: true,
+    isInterruptionCorrectionEligible: true,
+    queryId: interruptedCorrection.context.queryId,
+  })
+  tracker.handleCancellation({
+    isUserInitiated: true,
+    isRemoteMode: false,
+  })
+  queryGuard.forceEnd('user-abort', 'user-cancel')
+
+  // REPL auto-restore rewinds B while leaving interrupted attempt A in history.
+  let restoredMessages: Message[] = []
+  const rewindIndex = applyInterruptionCorrectionAutoRestore(
+    [attemptMessage, correction, createUserMessage({ content: 'interrupted' })],
+    correction,
+    messages => {
+      restoredMessages = messages
+    },
+    tracker,
+    correctionTurn.requestOnlyMessages,
+  )
+  expect(rewindIndex).toBe(1)
+  expect(restoredMessages).toEqual([attemptMessage])
+
+  const reminderForResubmission = tracker.takeReminder()!
+  const resubmittedTurn = buildInterruptionCorrectionMessageViews(
+    [],
+    [reminderForResubmission, correction],
+  )
+  expect(resubmittedTurn.requestOnlyMessages).toEqual([
+    reminderForResubmission,
+  ])
+  expect(tracker.takeReminder()).toBeNull()
+})
+
+test('leaves history and correction state unchanged when an auto-restore target is absent', () => {
+  const queryGuard = new QueryGuard()
+  const tracker = new InterruptionCorrectionTracker(
+    queryGuard,
+    () => 'session-a',
+  )
+  const turn = queryGuard.tryStart({
+    queryId: 'interrupted-turn',
+    querySource: 'repl_main_thread',
+    startedAt: 1,
+  })!
+  tracker.bindModelTurn({
+    shouldQuery: true,
+    isInterruptionCorrectionEligible: true,
+    queryId: turn.context.queryId,
+  })
+  tracker.handleCancellation({
+    isUserInitiated: true,
+    isRemoteMode: false,
+  })
+  queryGuard.forceEnd('user-abort', 'user-cancel')
+
+  const history = [createUserMessage({ content: 'do A' })]
+  let setMessagesCalled = false
+  const rewindIndex = applyInterruptionCorrectionAutoRestore(
+    history,
+    createUserMessage({ content: 'not in history' }),
+    () => {
+      setMessagesCalled = true
+    },
+    tracker,
+    [],
+  )
+
+  expect(rewindIndex).toBeNull()
+  expect(setMessagesCalled).toBe(false)
+  expect(tracker.takeReminder()).toMatchObject({ type: 'user', isMeta: true })
 })
 
 test('clears a pending reminder when a full compact boundary is applied', () => {

--- a/src/utils/interruptionCorrection.test.ts
+++ b/src/utils/interruptionCorrection.test.ts
@@ -1,7 +1,5 @@
 import { expect, test } from 'bun:test'
-import { QueryGuard } from './QueryGuard.js'
 import {
-  InterruptionCorrectionTracker,
   consumeInterruptionCorrectionReminder,
   shouldMarkInterruptionCorrection,
 } from './interruptionCorrection.js'
@@ -57,54 +55,4 @@ The previous assistant turn was interrupted by the user. Treat the user's latest
   expect(
     consumeInterruptionCorrectionReminder('session-a', 'session-b'),
   ).toEqual({ pendingSessionId: null, reminder: null })
-})
-
-test('tracks the REPL query, cancellation, and one-shot reminder flow', () => {
-  const tracker = new InterruptionCorrectionTracker()
-  const queryGuard = new QueryGuard()
-
-  const localCommand = queryGuard.tryStart({
-    queryId: 'local-command',
-    querySource: 'repl_main_thread',
-    startedAt: 1,
-  })!
-  tracker.bindModelTurn({
-    shouldQuery: false,
-    isAborted: false,
-    activeQueryId: queryGuard.activeContext?.queryId ?? null,
-    queryId: localCommand.context.queryId,
-  })
-  tracker.handleCancellation({
-    isUserInitiated: true,
-    activeQueryId: queryGuard.activeContext?.queryId ?? null,
-    isRemoteMode: false,
-    sessionId: 'session-a',
-  })
-  queryGuard.forceEnd('user-abort', 'user-cancel')
-  expect(tracker.takeReminder('session-a')).toBeNull()
-
-  const modelTurn = queryGuard.tryStart({
-    queryId: 'model-turn',
-    querySource: 'repl_main_thread',
-    startedAt: 2,
-  })!
-  tracker.bindModelTurn({
-    shouldQuery: true,
-    isAborted: false,
-    activeQueryId: queryGuard.activeContext?.queryId ?? null,
-    queryId: modelTurn.context.queryId,
-  })
-  tracker.handleCancellation({
-    isUserInitiated: true,
-    activeQueryId: queryGuard.activeContext?.queryId ?? null,
-    isRemoteMode: false,
-    sessionId: 'session-a',
-  })
-  queryGuard.forceEnd('user-abort', 'user-cancel')
-
-  expect(tracker.takeReminder('session-a')).toMatchObject({
-    type: 'user',
-    isMeta: true,
-  })
-  expect(tracker.takeReminder('session-a')).toBeNull()
 })

--- a/src/utils/interruptionCorrection.test.ts
+++ b/src/utils/interruptionCorrection.test.ts
@@ -35,6 +35,26 @@ test('only marks a local user cancellation of the active model query', () => {
   }
 })
 
+test('does not arm after the model turn has completed', async () => {
+  const queryGuard = new QueryGuard()
+  const tracker = new InterruptionCorrectionTracker(queryGuard, () => 'session-a')
+  const turn = queryGuard.tryStart({
+    queryId: 'completed-turn',
+    querySource: 'repl_main_thread',
+    startedAt: 1,
+  })!
+
+  await tracker.runModelTurn({
+    shouldQuery: true,
+    isInterruptionCorrectionEligible: true,
+    queryId: turn.context.queryId,
+    run: async () => {},
+  })
+  tracker.handleCancellation({ isUserInitiated: true, isRemoteMode: false })
+
+  expect(tracker.takeReminder()).toBeNull()
+})
+
 test('clears a pending reminder when the interrupted context is rewritten', () => {
   const queryGuard = new QueryGuard()
   const tracker = new InterruptionCorrectionTracker(
@@ -136,7 +156,7 @@ test('preserves the earlier reminder when an interrupted correction is auto-rest
       restoredMessages = messages
     },
     tracker,
-    correctionTurn.requestOnlyMessages,
+    true,
   )
   expect(rewindIndex).toBe(1)
   expect(restoredMessages).toEqual([attemptMessage])
@@ -150,6 +170,48 @@ test('preserves the earlier reminder when an interrupted correction is auto-rest
     reminderForResubmission,
   ])
   expect(tracker.takeReminder()).toBeNull()
+})
+
+test('preserves the reminder when auto-restore rewinds the first prompt to empty history', () => {
+  const queryGuard = new QueryGuard()
+  const tracker = new InterruptionCorrectionTracker(
+    queryGuard,
+    () => 'session-a',
+  )
+  const firstPrompt = createUserMessage({ content: 'do A' })
+  const turn = queryGuard.tryStart({
+    queryId: 'first-turn',
+    querySource: 'repl_main_thread',
+    startedAt: 1,
+  })!
+  tracker.bindModelTurn({
+    shouldQuery: true,
+    isInterruptionCorrectionEligible: true,
+    queryId: turn.context.queryId,
+  })
+  tracker.handleCancellation({
+    isUserInitiated: true,
+    isRemoteMode: false,
+  })
+  queryGuard.forceEnd('user-abort', 'user-cancel')
+
+  const messagesRef: { current: Message[] } = { current: [firstPrompt] }
+  applyInterruptionCorrectionAutoRestore(
+    messagesRef.current,
+    firstPrompt,
+    messages => {
+      applyInterruptionCorrectionAwareMessageUpdate(
+        messagesRef,
+        messages,
+        tracker,
+      )
+    },
+    tracker,
+    true,
+  )
+
+  expect(messagesRef.current).toEqual([])
+  expect(tracker.takeReminder()).toMatchObject({ type: 'user', isMeta: true })
 })
 
 test('leaves history and correction state unchanged when an auto-restore target is absent', () => {
@@ -183,12 +245,45 @@ test('leaves history and correction state unchanged when an auto-restore target 
       setMessagesCalled = true
     },
     tracker,
-    [],
   )
 
   expect(rewindIndex).toBeNull()
   expect(setMessagesCalled).toBe(false)
   expect(tracker.takeReminder()).toMatchObject({ type: 'user', isMeta: true })
+})
+
+test('clears a pending reminder when a manual rewind changes conversation history', () => {
+  const queryGuard = new QueryGuard()
+  const tracker = new InterruptionCorrectionTracker(
+    queryGuard,
+    () => 'session-a',
+  )
+  const earlierPrompt = createUserMessage({ content: 'do A' })
+  const interruptedPrompt = createUserMessage({ content: 'do B' })
+  const turn = queryGuard.tryStart({
+    queryId: 'interrupted-turn',
+    querySource: 'repl_main_thread',
+    startedAt: 1,
+  })!
+  tracker.bindModelTurn({
+    shouldQuery: true,
+    isInterruptionCorrectionEligible: true,
+    queryId: turn.context.queryId,
+  })
+  tracker.handleCancellation({
+    isUserInitiated: true,
+    isRemoteMode: false,
+  })
+  queryGuard.forceEnd('user-abort', 'user-cancel')
+
+  applyInterruptionCorrectionAutoRestore(
+    [earlierPrompt, interruptedPrompt],
+    interruptedPrompt,
+    () => {},
+    tracker,
+  )
+
+  expect(tracker.takeReminder()).toBeNull()
 })
 
 test('clears a pending reminder when a full compact boundary is applied', () => {
@@ -397,7 +492,6 @@ test('does not restore a consumed reminder after programmatic auto-restore cance
     correction,
     () => {},
     tracker,
-    correctionTurn.requestOnlyMessages,
   )
 
   expect(tracker.takeReminder()).toBeNull()

--- a/src/utils/interruptionCorrection.test.ts
+++ b/src/utils/interruptionCorrection.test.ts
@@ -1,5 +1,7 @@
 import { expect, test } from 'bun:test'
+import { QueryGuard } from './QueryGuard.js'
 import {
+  InterruptionCorrectionTracker,
   consumeInterruptionCorrectionReminder,
   shouldMarkInterruptionCorrection,
 } from './interruptionCorrection.js'
@@ -55,4 +57,54 @@ The previous assistant turn was interrupted by the user. Treat the user's latest
   expect(
     consumeInterruptionCorrectionReminder('session-a', 'session-b'),
   ).toEqual({ pendingSessionId: null, reminder: null })
+})
+
+test('tracks the REPL query, cancellation, and one-shot reminder flow', () => {
+  const tracker = new InterruptionCorrectionTracker()
+  const queryGuard = new QueryGuard()
+
+  const localCommand = queryGuard.tryStart({
+    queryId: 'local-command',
+    querySource: 'repl_main_thread',
+    startedAt: 1,
+  })!
+  tracker.bindModelTurn({
+    shouldQuery: false,
+    isAborted: false,
+    activeQueryId: queryGuard.activeContext?.queryId ?? null,
+    queryId: localCommand.context.queryId,
+  })
+  tracker.handleCancellation({
+    isUserInitiated: true,
+    activeQueryId: queryGuard.activeContext?.queryId ?? null,
+    isRemoteMode: false,
+    sessionId: 'session-a',
+  })
+  queryGuard.forceEnd('user-abort', 'user-cancel')
+  expect(tracker.takeReminder('session-a')).toBeNull()
+
+  const modelTurn = queryGuard.tryStart({
+    queryId: 'model-turn',
+    querySource: 'repl_main_thread',
+    startedAt: 2,
+  })!
+  tracker.bindModelTurn({
+    shouldQuery: true,
+    isAborted: false,
+    activeQueryId: queryGuard.activeContext?.queryId ?? null,
+    queryId: modelTurn.context.queryId,
+  })
+  tracker.handleCancellation({
+    isUserInitiated: true,
+    activeQueryId: queryGuard.activeContext?.queryId ?? null,
+    isRemoteMode: false,
+    sessionId: 'session-a',
+  })
+  queryGuard.forceEnd('user-abort', 'user-cancel')
+
+  expect(tracker.takeReminder('session-a')).toMatchObject({
+    type: 'user',
+    isMeta: true,
+  })
+  expect(tracker.takeReminder('session-a')).toBeNull()
 })

--- a/src/utils/interruptionCorrection.test.ts
+++ b/src/utils/interruptionCorrection.test.ts
@@ -1,0 +1,58 @@
+import { expect, test } from 'bun:test'
+import {
+  consumeInterruptionCorrectionReminder,
+  shouldMarkInterruptionCorrection,
+} from './interruptionCorrection.js'
+
+test('only marks a local user cancellation of the active model query', () => {
+  const localUserCancellation = {
+    isUserInitiated: true,
+    activeQueryId: 'query-1',
+    modelBoundQueryId: 'query-1',
+    isRemoteMode: false,
+  }
+  expect(shouldMarkInterruptionCorrection(localUserCancellation)).toBe(true)
+
+  const excludedCancellations = [
+    { ...localUserCancellation, isUserInitiated: false },
+    { ...localUserCancellation, activeQueryId: null },
+    { ...localUserCancellation, modelBoundQueryId: null },
+    { ...localUserCancellation, modelBoundQueryId: 'query-2' },
+    { ...localUserCancellation, isRemoteMode: true },
+  ]
+
+  for (const cancellation of excludedCancellations) {
+    expect(shouldMarkInterruptionCorrection(cancellation)).toBe(false)
+  }
+})
+
+test('builds one same-session reminder and clears pending state', () => {
+  const withoutPending = consumeInterruptionCorrectionReminder(null, 'session-a')
+  expect(withoutPending).toEqual({ pendingSessionId: null, reminder: null })
+
+  const first = consumeInterruptionCorrectionReminder('session-a', 'session-a')
+  expect(first.pendingSessionId).toBeNull()
+  expect(first.reminder).toMatchObject({
+    type: 'user',
+    isMeta: true,
+    message: {
+      content: `<system-reminder>
+The previous assistant turn was interrupted by the user. Treat the user's latest message as a correction and do not continue the interrupted plan unless explicitly asked.
+</system-reminder>`,
+    },
+  })
+
+  expect(
+    consumeInterruptionCorrectionReminder(
+      first.pendingSessionId,
+      'session-a',
+    ),
+  ).toEqual({
+    pendingSessionId: null,
+    reminder: null,
+  })
+
+  expect(
+    consumeInterruptionCorrectionReminder('session-a', 'session-b'),
+  ).toEqual({ pendingSessionId: null, reminder: null })
+})

--- a/src/utils/interruptionCorrection.ts
+++ b/src/utils/interruptionCorrection.ts
@@ -1,5 +1,6 @@
 import type { Message, UserMessage } from '../types/message.js'
 import { createUserMessage } from './messages/factories.js'
+import { isCompactBoundaryMessage } from './messages/systemFactories.js'
 
 export const INTERRUPTION_CORRECTION_REMINDER = `<system-reminder>
 The previous assistant turn was interrupted by the user. Treat the user's latest message as a correction and do not continue the interrupted plan unless explicitly asked.
@@ -69,6 +70,36 @@ export function buildInterruptionCorrectionMessageViews(
     persistentNewMessages,
     requestOnlyMessages,
   }
+}
+
+function handleInterruptionCorrectionMessageUpdate(
+  previousMessages: readonly Message[],
+  nextMessages: readonly Message[],
+  tracker: { handleConversationRewrite(): void },
+): void {
+  const previousBoundary = previousMessages.findLast(isCompactBoundaryMessage)
+  const nextBoundary = nextMessages.findLast(isCompactBoundaryMessage)
+  if (nextBoundary && nextBoundary.uuid !== previousBoundary?.uuid) {
+    tracker.handleConversationRewrite()
+  }
+}
+
+export function applyInterruptionCorrectionAwareMessageUpdate(
+  messagesRef: { current: Message[] },
+  action: Message[] | ((messages: Message[]) => Message[]),
+  tracker: { handleConversationRewrite(): void },
+): { previousMessages: Message[]; nextMessages: Message[] } {
+  const previousMessages = messagesRef.current
+  const nextMessages = typeof action === 'function'
+    ? action(previousMessages)
+    : action
+  handleInterruptionCorrectionMessageUpdate(
+    previousMessages,
+    nextMessages,
+    tracker,
+  )
+  messagesRef.current = nextMessages
+  return { previousMessages, nextMessages }
 }
 
 export class InterruptionCorrectionTracker {

--- a/src/utils/interruptionCorrection.ts
+++ b/src/utils/interruptionCorrection.ts
@@ -11,18 +11,15 @@ export function shouldMarkInterruptionCorrection({
   activeQueryId,
   modelBoundQueryId,
   isRemoteMode,
-  hasQueuedNormalPrompt = false,
 }: {
   isUserInitiated: boolean
   activeQueryId: string | null
   modelBoundQueryId: string | null
   isRemoteMode: boolean
-  hasQueuedNormalPrompt?: boolean
 }): boolean {
   return (
     isUserInitiated &&
     !isRemoteMode &&
-    !hasQueuedNormalPrompt &&
     activeQueryId !== null &&
     activeQueryId === modelBoundQueryId
   )
@@ -187,11 +184,9 @@ export class InterruptionCorrectionTracker {
   handleCancellation({
     isUserInitiated,
     isRemoteMode,
-    hasQueuedNormalPrompt = false,
   }: {
     isUserInitiated: boolean
     isRemoteMode: boolean
-    hasQueuedNormalPrompt?: boolean
   }): void {
     const activeQueryId = this.queryGuard.activeContext?.queryId ?? null
     if (
@@ -200,7 +195,6 @@ export class InterruptionCorrectionTracker {
         activeQueryId,
         modelBoundQueryId: this.modelBoundQueryId,
         isRemoteMode,
-        hasQueuedNormalPrompt,
       })
     ) {
       this.pendingSessionId = this.getSessionId()

--- a/src/utils/interruptionCorrection.ts
+++ b/src/utils/interruptionCorrection.ts
@@ -10,15 +10,18 @@ export function shouldMarkInterruptionCorrection({
   activeQueryId,
   modelBoundQueryId,
   isRemoteMode,
+  hasQueuedNormalPrompt = false,
 }: {
   isUserInitiated: boolean
   activeQueryId: string | null
   modelBoundQueryId: string | null
   isRemoteMode: boolean
+  hasQueuedNormalPrompt?: boolean
 }): boolean {
   return (
     isUserInitiated &&
     !isRemoteMode &&
+    !hasQueuedNormalPrompt &&
     activeQueryId !== null &&
     activeQueryId === modelBoundQueryId
   )
@@ -95,9 +98,11 @@ export class InterruptionCorrectionTracker {
   handleCancellation({
     isUserInitiated,
     isRemoteMode,
+    hasQueuedNormalPrompt = false,
   }: {
     isUserInitiated: boolean
     isRemoteMode: boolean
+    hasQueuedNormalPrompt?: boolean
   }): void {
     const activeQueryId = this.queryGuard.activeContext?.queryId ?? null
     if (
@@ -106,6 +111,7 @@ export class InterruptionCorrectionTracker {
         activeQueryId,
         modelBoundQueryId: this.modelBoundQueryId,
         isRemoteMode,
+        hasQueuedNormalPrompt,
       })
     ) {
       this.pendingSessionId = this.getSessionId()
@@ -122,6 +128,14 @@ export class InterruptionCorrectionTracker {
     if (this.modelBoundQueryId === queryId) {
       this.modelBoundQueryId = null
     }
+  }
+
+  handleConversationRewrite(): void {
+    this.pendingSessionId = null
+  }
+
+  restoreReminder(): void {
+    this.pendingSessionId = this.getSessionId()
   }
 
   takeReminder(): UserMessage | null {

--- a/src/utils/interruptionCorrection.ts
+++ b/src/utils/interruptionCorrection.ts
@@ -100,7 +100,10 @@ function handleInterruptionCorrectionMessageUpdate(
 ): void {
   const previousBoundary = previousMessages.findLast(isCompactBoundaryMessage)
   const nextBoundary = nextMessages.findLast(isCompactBoundaryMessage)
-  if (nextBoundary?.uuid !== previousBoundary?.uuid) {
+  if (
+    nextBoundary?.uuid !== previousBoundary?.uuid ||
+    (previousMessages.length > 0 && nextMessages.length === 0)
+  ) {
     tracker.handleConversationRewrite()
   }
 }

--- a/src/utils/interruptionCorrection.ts
+++ b/src/utils/interruptionCorrection.ts
@@ -1,0 +1,40 @@
+import type { UserMessage } from '../types/message.js'
+import { createUserMessage } from './messages/factories.js'
+
+export const INTERRUPTION_CORRECTION_REMINDER = `<system-reminder>
+The previous assistant turn was interrupted by the user. Treat the user's latest message as a correction and do not continue the interrupted plan unless explicitly asked.
+</system-reminder>`
+
+export function shouldMarkInterruptionCorrection({
+  isUserInitiated,
+  activeQueryId,
+  modelBoundQueryId,
+  isRemoteMode,
+}: {
+  isUserInitiated: boolean
+  activeQueryId: string | null
+  modelBoundQueryId: string | null
+  isRemoteMode: boolean
+}): boolean {
+  return (
+    isUserInitiated &&
+    !isRemoteMode &&
+    activeQueryId !== null &&
+    activeQueryId === modelBoundQueryId
+  )
+}
+
+export function consumeInterruptionCorrectionReminder(
+  pendingSessionId: string | null,
+  currentSessionId: string,
+): { pendingSessionId: null; reminder: UserMessage | null } {
+  return {
+    pendingSessionId: null,
+    reminder: pendingSessionId === currentSessionId
+      ? createUserMessage({
+          content: INTERRUPTION_CORRECTION_REMINDER,
+          isMeta: true,
+        })
+      : null,
+  }
+}

--- a/src/utils/interruptionCorrection.ts
+++ b/src/utils/interruptionCorrection.ts
@@ -52,27 +52,39 @@ export class InterruptionCorrectionTracker {
 
   bindModelTurn({
     shouldQuery,
+    isInterruptionCorrectionEligible,
     queryId,
   }: {
     shouldQuery: boolean
+    isInterruptionCorrectionEligible: boolean
     queryId: string
   }): void {
     const activeQueryId = this.queryGuard.activeContext?.queryId ?? null
-    if (shouldQuery && activeQueryId === queryId) {
+    if (
+      shouldQuery &&
+      isInterruptionCorrectionEligible &&
+      activeQueryId === queryId
+    ) {
       this.modelBoundQueryId = queryId
     }
   }
 
   async runModelTurn({
     shouldQuery,
+    isInterruptionCorrectionEligible,
     queryId,
     run,
   }: {
     shouldQuery: boolean
+    isInterruptionCorrectionEligible: boolean
     queryId: string
     run: () => Promise<void>
   }): Promise<void> {
-    this.bindModelTurn({ shouldQuery, queryId })
+    this.bindModelTurn({
+      shouldQuery,
+      isInterruptionCorrectionEligible,
+      queryId,
+    })
     try {
       await run()
     } finally {

--- a/src/utils/interruptionCorrection.ts
+++ b/src/utils/interruptionCorrection.ts
@@ -38,3 +38,68 @@ export function consumeInterruptionCorrectionReminder(
       : null,
   }
 }
+
+export class InterruptionCorrectionTracker {
+  private pendingSessionId: string | null = null
+  private modelBoundQueryId: string | null = null
+
+  bindModelTurn({
+    shouldQuery,
+    isAborted,
+    activeQueryId,
+    queryId,
+  }: {
+    shouldQuery: boolean
+    isAborted: boolean
+    activeQueryId: string | null
+    queryId: string
+  }): void {
+    if (shouldQuery && !isAborted && activeQueryId === queryId) {
+      this.modelBoundQueryId = queryId
+    }
+  }
+
+  handleCancellation({
+    isUserInitiated,
+    activeQueryId,
+    isRemoteMode,
+    sessionId,
+  }: {
+    isUserInitiated: boolean
+    activeQueryId: string | null
+    isRemoteMode: boolean
+    sessionId: string
+  }): void {
+    if (
+      shouldMarkInterruptionCorrection({
+        isUserInitiated,
+        activeQueryId,
+        modelBoundQueryId: this.modelBoundQueryId,
+        isRemoteMode,
+      })
+    ) {
+      this.pendingSessionId = sessionId
+    }
+    if (
+      activeQueryId !== null &&
+      activeQueryId === this.modelBoundQueryId
+    ) {
+      this.modelBoundQueryId = null
+    }
+  }
+
+  finishModelTurn(queryId: string): void {
+    if (this.modelBoundQueryId === queryId) {
+      this.modelBoundQueryId = null
+    }
+  }
+
+  takeReminder(sessionId: string): UserMessage | null {
+    const result = consumeInterruptionCorrectionReminder(
+      this.pendingSessionId,
+      sessionId,
+    )
+    this.pendingSessionId = result.pendingSessionId
+    return result.reminder
+  }
+}

--- a/src/utils/interruptionCorrection.ts
+++ b/src/utils/interruptionCorrection.ts
@@ -78,17 +78,21 @@ export function applyInterruptionCorrectionAutoRestore(
   setMessages: (messages: Message[]) => void,
   tracker: {
     handleConversationRewrite(options?: { preserveReminder?: boolean }): void
+    prepareForAutoRestore(): void
   },
-  requestOnlyMessages: readonly Message[],
+  preserveReminder = false,
 ): number | null {
   const messageIndex = previousMessages.lastIndexOf(rewindMessage)
   if (messageIndex === -1) return null
 
+  if (preserveReminder) {
+    tracker.prepareForAutoRestore()
+  }
   setMessages(previousMessages.slice(0, messageIndex))
   tracker.handleConversationRewrite({
-    preserveReminder: requestOnlyMessages.some(
-      isInterruptionCorrectionReminder,
-    ),
+    // This finalizes the one-rewrite preservation window. It does not create
+    // a reminder when none was pending.
+    preserveReminder,
   })
   return messageIndex
 }
@@ -129,6 +133,7 @@ export function applyInterruptionCorrectionAwareMessageUpdate(
 export class InterruptionCorrectionTracker {
   private pendingSessionId: string | null = null
   private modelBoundQueryId: string | null = null
+  private preservePendingReminderForRewrite = false
 
   constructor(
     private readonly queryGuard: {
@@ -219,9 +224,15 @@ export class InterruptionCorrectionTracker {
   }: {
     preserveReminder?: boolean
   } = {}): void {
-    if (!preserveReminder) {
+    if (!preserveReminder && !this.preservePendingReminderForRewrite) {
       this.pendingSessionId = null
     }
+    this.preservePendingReminderForRewrite = false
+  }
+
+  prepareForAutoRestore(): void {
+    this.preservePendingReminderForRewrite =
+      this.pendingSessionId === this.getSessionId()
   }
 
   restoreReminder(): void {

--- a/src/utils/interruptionCorrection.ts
+++ b/src/utils/interruptionCorrection.ts
@@ -43,17 +43,23 @@ export class InterruptionCorrectionTracker {
   private pendingSessionId: string | null = null
   private modelBoundQueryId: string | null = null
 
+  constructor(
+    private readonly queryGuard: {
+      readonly activeContext: { queryId: string } | null
+    },
+    private readonly getSessionId: () => string,
+  ) {}
+
   bindModelTurn({
     shouldQuery,
     isAborted,
-    activeQueryId,
     queryId,
   }: {
     shouldQuery: boolean
     isAborted: boolean
-    activeQueryId: string | null
     queryId: string
   }): void {
+    const activeQueryId = this.queryGuard.activeContext?.queryId ?? null
     if (shouldQuery && !isAborted && activeQueryId === queryId) {
       this.modelBoundQueryId = queryId
     }
@@ -61,15 +67,12 @@ export class InterruptionCorrectionTracker {
 
   handleCancellation({
     isUserInitiated,
-    activeQueryId,
     isRemoteMode,
-    sessionId,
   }: {
     isUserInitiated: boolean
-    activeQueryId: string | null
     isRemoteMode: boolean
-    sessionId: string
   }): void {
+    const activeQueryId = this.queryGuard.activeContext?.queryId ?? null
     if (
       shouldMarkInterruptionCorrection({
         isUserInitiated,
@@ -78,7 +81,7 @@ export class InterruptionCorrectionTracker {
         isRemoteMode,
       })
     ) {
-      this.pendingSessionId = sessionId
+      this.pendingSessionId = this.getSessionId()
     }
     if (
       activeQueryId !== null &&
@@ -94,10 +97,10 @@ export class InterruptionCorrectionTracker {
     }
   }
 
-  takeReminder(sessionId: string): UserMessage | null {
+  takeReminder(): UserMessage | null {
     const result = consumeInterruptionCorrectionReminder(
       this.pendingSessionId,
-      sessionId,
+      this.getSessionId(),
     )
     this.pendingSessionId = result.pendingSessionId
     return result.reminder

--- a/src/utils/interruptionCorrection.ts
+++ b/src/utils/interruptionCorrection.ts
@@ -72,6 +72,27 @@ export function buildInterruptionCorrectionMessageViews(
   }
 }
 
+export function applyInterruptionCorrectionAutoRestore(
+  previousMessages: readonly Message[],
+  rewindMessage: UserMessage,
+  setMessages: (messages: Message[]) => void,
+  tracker: {
+    handleConversationRewrite(options?: { preserveReminder?: boolean }): void
+  },
+  requestOnlyMessages: readonly Message[],
+): number | null {
+  const messageIndex = previousMessages.lastIndexOf(rewindMessage)
+  if (messageIndex === -1) return null
+
+  setMessages(previousMessages.slice(0, messageIndex))
+  tracker.handleConversationRewrite({
+    preserveReminder: requestOnlyMessages.some(
+      isInterruptionCorrectionReminder,
+    ),
+  })
+  return messageIndex
+}
+
 function handleInterruptionCorrectionMessageUpdate(
   previousMessages: readonly Message[],
   nextMessages: readonly Message[],
@@ -190,8 +211,14 @@ export class InterruptionCorrectionTracker {
     }
   }
 
-  handleConversationRewrite(): void {
-    this.pendingSessionId = null
+  handleConversationRewrite({
+    preserveReminder = false,
+  }: {
+    preserveReminder?: boolean
+  } = {}): void {
+    if (!preserveReminder) {
+      this.pendingSessionId = null
+    }
   }
 
   restoreReminder(): void {

--- a/src/utils/interruptionCorrection.ts
+++ b/src/utils/interruptionCorrection.ts
@@ -11,15 +11,18 @@ export function shouldMarkInterruptionCorrection({
   activeQueryId,
   modelBoundQueryId,
   isRemoteMode,
+  hasQueuedNormalPrompt = false,
 }: {
   isUserInitiated: boolean
   activeQueryId: string | null
   modelBoundQueryId: string | null
   isRemoteMode: boolean
+  hasQueuedNormalPrompt?: boolean
 }): boolean {
   return (
     isUserInitiated &&
     !isRemoteMode &&
+    !hasQueuedNormalPrompt &&
     activeQueryId !== null &&
     activeQueryId === modelBoundQueryId
   )
@@ -184,9 +187,11 @@ export class InterruptionCorrectionTracker {
   handleCancellation({
     isUserInitiated,
     isRemoteMode,
+    hasQueuedNormalPrompt = false,
   }: {
     isUserInitiated: boolean
     isRemoteMode: boolean
+    hasQueuedNormalPrompt?: boolean
   }): void {
     const activeQueryId = this.queryGuard.activeContext?.queryId ?? null
     if (
@@ -195,6 +200,7 @@ export class InterruptionCorrectionTracker {
         activeQueryId,
         modelBoundQueryId: this.modelBoundQueryId,
         isRemoteMode,
+        hasQueuedNormalPrompt,
       })
     ) {
       this.pendingSessionId = this.getSessionId()

--- a/src/utils/interruptionCorrection.ts
+++ b/src/utils/interruptionCorrection.ts
@@ -1,4 +1,4 @@
-import type { UserMessage } from '../types/message.js'
+import type { Message, UserMessage } from '../types/message.js'
 import { createUserMessage } from './messages/factories.js'
 
 export const INTERRUPTION_CORRECTION_REMINDER = `<system-reminder>
@@ -39,6 +39,35 @@ export function consumeInterruptionCorrectionReminder(
           isMeta: true,
         })
       : null,
+  }
+}
+
+function isInterruptionCorrectionReminder(message: Message): boolean {
+  return (
+    message.type === 'user' &&
+    message.isMeta === true &&
+    message.message.content === INTERRUPTION_CORRECTION_REMINDER
+  )
+}
+
+export function buildInterruptionCorrectionMessageViews(
+  history: readonly Message[],
+  newMessages: readonly Message[],
+): {
+  persistentMessages: Message[]
+  persistentNewMessages: Message[]
+  requestOnlyMessages: Message[]
+} {
+  const persistentNewMessages = newMessages.filter(
+    message => !isInterruptionCorrectionReminder(message),
+  )
+  const requestOnlyMessages = newMessages.filter(
+    isInterruptionCorrectionReminder,
+  )
+  return {
+    persistentMessages: [...history, ...persistentNewMessages],
+    persistentNewMessages,
+    requestOnlyMessages,
   }
 }
 

--- a/src/utils/interruptionCorrection.ts
+++ b/src/utils/interruptionCorrection.ts
@@ -52,16 +52,31 @@ export class InterruptionCorrectionTracker {
 
   bindModelTurn({
     shouldQuery,
-    isAborted,
     queryId,
   }: {
     shouldQuery: boolean
-    isAborted: boolean
     queryId: string
   }): void {
     const activeQueryId = this.queryGuard.activeContext?.queryId ?? null
-    if (shouldQuery && !isAborted && activeQueryId === queryId) {
+    if (shouldQuery && activeQueryId === queryId) {
       this.modelBoundQueryId = queryId
+    }
+  }
+
+  async runModelTurn({
+    shouldQuery,
+    queryId,
+    run,
+  }: {
+    shouldQuery: boolean
+    queryId: string
+    run: () => Promise<void>
+  }): Promise<void> {
+    this.bindModelTurn({ shouldQuery, queryId })
+    try {
+      await run()
+    } finally {
+      this.finishModelTurn(queryId)
     }
   }
 

--- a/src/utils/interruptionCorrection.ts
+++ b/src/utils/interruptionCorrection.ts
@@ -100,7 +100,7 @@ function handleInterruptionCorrectionMessageUpdate(
 ): void {
   const previousBoundary = previousMessages.findLast(isCompactBoundaryMessage)
   const nextBoundary = nextMessages.findLast(isCompactBoundaryMessage)
-  if (nextBoundary && nextBoundary.uuid !== previousBoundary?.uuid) {
+  if (nextBoundary?.uuid !== previousBoundary?.uuid) {
     tracker.handleConversationRewrite()
   }
 }

--- a/src/utils/interruptionCorrection.ts
+++ b/src/utils/interruptionCorrection.ts
@@ -239,6 +239,12 @@ export class InterruptionCorrectionTracker {
     this.pendingSessionId = this.getSessionId()
   }
 
+  handleSessionChange(): void {
+    this.pendingSessionId = null
+    this.modelBoundQueryId = null
+    this.preservePendingReminderForRewrite = false
+  }
+
   takeReminder(): UserMessage | null {
     const result = consumeInterruptionCorrectionReminder(
       this.pendingSessionId,

--- a/src/utils/messages.ts
+++ b/src/utils/messages.ts
@@ -1395,17 +1395,25 @@ export function normalizeMessagesForAPI(
     types: Set<string>,
   ): ContentBlockParam[] => content
     .filter(block => !types.has(block.type))
-    .map(block =>
-      block.type === 'tool_result' && Array.isArray(block.content)
-        ? {
-            ...block,
-            content: stripTargetsFromContent(
-              block.content as ContentBlockParam[],
-              types,
-            ) as typeof block.content,
-          }
-        : block,
-    )
+    .map(block => {
+      if (block.type !== 'tool_result' || !Array.isArray(block.content)) {
+        return block
+      }
+      const strippedContent = stripTargetsFromContent(
+        block.content as ContentBlockParam[],
+        types,
+      )
+      return {
+        ...block,
+        // A tool result must retain content to preserve the paired tool-use
+        // contract and avoid OpenAI-compatible providers rejecting an empty
+        // role: tool message after media is removed.
+        content: (strippedContent.length > 0
+          ? strippedContent
+          : [{ type: 'text', text: '[Media removed after provider rejection.]' }]
+        ) as typeof block.content,
+      }
+    })
   // Build set of available tool names for filtering unavailable tool references
   const availableToolNames = new Set(tools.map(t => t.name))
 

--- a/src/utils/messages.ts
+++ b/src/utils/messages.ts
@@ -1865,11 +1865,33 @@ export function mergeUserMessages(a: UserMessage, b: UserMessage): UserMessage {
     content: string | ContentBlockParam[],
   ): string | ContentBlockParam[] =>
     isCollapseSummary ? stripSnipTagsFromContent(content) : content
+  if (feature('HISTORY_SNIP')) {
+    // A merged message is only meta if ALL merged messages are meta. If any
+    // operand is real user content, the result must not be flagged isMeta
+    // (so internal snip ids get injected and it's treated as user-visible content).
+    // Gated behind the full runtime check because changing isMeta semantics
+    // affects downstream callers (including attachment error recovery), so it
+    // must only fire when snip is actually enabled.
+    const { isSnipRuntimeEnabled } =
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      require('../services/compact/snipCompact.js') as typeof import('../services/compact/snipCompact.js')
+    if (isSnipRuntimeEnabled()) {
+      return {
+        ...a,
+        isMeta: a.isMeta && b.isMeta ? (true as const) : undefined,
+        isCollapseSummary,
+        uuid: a.isMeta ? b.uuid : a.uuid,
+        message: {
+          ...a.message,
+          content: finalize(
+            hoistToolResults(joinTextAtSeam(lastContent, currentContent)),
+          ),
+        },
+      }
+    }
+  }
   return {
     ...a,
-    // A merged message is only meta if every operand is meta. Any real user
-    // content makes the combined turn a real user message for all consumers.
-    isMeta: a.isMeta && b.isMeta ? (true as const) : undefined,
     isCollapseSummary,
     // Preserve the non-meta message's uuid so snip ids (derived from uuid)
     // stay stable across API calls (meta messages like system context get fresh uuids each call)

--- a/src/utils/messages.ts
+++ b/src/utils/messages.ts
@@ -1381,6 +1381,31 @@ export function normalizeMessagesForAPI(
   messages: Message[],
   tools: Tools = [],
 ): (UserMessage | AssistantMessage)[] {
+  const containsStripTarget = (
+    content: ContentBlockParam[],
+    types: Set<string>,
+  ): boolean => content.some(block =>
+    types.has(block.type) ||
+    (block.type === 'tool_result' &&
+      Array.isArray(block.content) &&
+      containsStripTarget(block.content as ContentBlockParam[], types)),
+  )
+  const stripTargetsFromContent = (
+    content: ContentBlockParam[],
+    types: Set<string>,
+  ): ContentBlockParam[] => content
+    .filter(block => !types.has(block.type))
+    .map(block =>
+      block.type === 'tool_result' && Array.isArray(block.content)
+        ? {
+            ...block,
+            content: stripTargetsFromContent(
+              block.content as ContentBlockParam[],
+              types,
+            ) as typeof block.content,
+          }
+        : block,
+    )
   // Build set of available tool names for filtering unavailable tool references
   const availableToolNames = new Set(tools.map(t => t.name))
 
@@ -1454,7 +1479,7 @@ export function normalizeMessagesForAPI(
         const content = candidate.message.content
         if (
           !Array.isArray(content) ||
-          !content.some(block => blockTypesToStrip.has(block.type))
+          !containsStripTarget(content, blockTypesToStrip)
         ) {
           continue
         }
@@ -1558,9 +1583,7 @@ export function normalizeMessagesForAPI(
           if (typesToStrip) {
             const content = normalizedMessage.message.content
             if (Array.isArray(content)) {
-              const filtered = content.filter(
-                block => !typesToStrip.has(block.type),
-              )
+              const filtered = stripTargetsFromContent(content, typesToStrip)
               if (filtered.length === 0) {
                 // All content blocks were stripped; skip this message entirely
                 return

--- a/src/utils/messages.ts
+++ b/src/utils/messages.ts
@@ -1414,6 +1414,26 @@ export function normalizeMessagesForAPI(
         ) as typeof block.content,
       }
     })
+  const stripMediaFromUserMessage = (
+    message: UserMessage,
+    types: Set<string>,
+  ): UserMessage => {
+    const content = message.message.content
+    if (!Array.isArray(content)) return message
+    const filtered = stripTargetsFromContent(content, types)
+    return {
+      ...message,
+      message: {
+        ...message.message,
+        content: filtered.length > 0
+          ? filtered
+          : [{
+              type: 'text',
+              text: '[Media removed after provider rejection.]',
+            }],
+      },
+    }
+  }
   // Build set of available tool names for filtering unavailable tool references
   const availableToolNames = new Set(tools.map(t => t.name))
 
@@ -1459,6 +1479,16 @@ export function normalizeMessagesForAPI(
   // Walk the reordered messages to build a targeted strip map:
   // userMessageUUID → set of block types to strip from that message.
   const stripTargets = new Map<string, Set<string>>()
+  const addStripTarget = (uuid: string, types: Set<string>): void => {
+    const existing = stripTargets.get(uuid)
+    if (existing) {
+      for (const type of types) {
+        existing.add(type)
+      }
+      return
+    }
+    stripTargets.set(uuid, new Set(types))
+  }
   for (let i = 0; i < reorderedMessages.length; i++) {
     const msg = reorderedMessages[i]!
     if (!isSyntheticApiErrorMessage(msg)) {
@@ -1491,13 +1521,16 @@ export function normalizeMessagesForAPI(
         ) {
           continue
         }
-        const existing = stripTargets.get(candidate.uuid)
-        if (existing) {
-          for (const t of blockTypesToStrip) {
-            existing.add(t)
-          }
-        } else {
-          stripTargets.set(candidate.uuid, new Set(blockTypesToStrip))
+        addStripTarget(candidate.uuid, blockTypesToStrip)
+        continue
+      }
+      if (candidate.type === 'attachment') {
+        const normalized = normalizeAttachmentForAPI(candidate.attachment)
+        if (normalized.some(message =>
+          Array.isArray(message.message.content) &&
+          containsStripTarget(message.message.content, blockTypesToStrip)
+        )) {
+          addStripTarget(candidate.uuid, blockTypesToStrip)
         }
         continue
       }
@@ -1505,8 +1538,12 @@ export function normalizeMessagesForAPI(
       if (isSyntheticApiErrorMessage(candidate)) {
         continue
       }
-      // Stop if we hit an assistant message or other non-user message.
-      break
+      // Only an assistant message starts an earlier API turn. Progress and
+      // filtered system records are not sent to the provider and must not
+      // prevent cleanup of media in the failed request.
+      if (candidate.type === 'assistant') {
+        break
+      }
     }
   }
 
@@ -1589,21 +1626,10 @@ export function normalizeMessagesForAPI(
           // the problematic content on every subsequent API call.
           const typesToStrip = stripTargets.get(normalizedMessage.uuid)
           if (typesToStrip) {
-            const content = normalizedMessage.message.content
-            if (Array.isArray(content)) {
-              const filtered = stripTargetsFromContent(content, typesToStrip)
-              if (filtered.length === 0) {
-                // All content blocks were stripped; skip this message entirely
-                return
-              }
-              normalizedMessage = {
-                ...normalizedMessage,
-                message: {
-                  ...normalizedMessage.message,
-                  content: filtered,
-                },
-              }
-            }
+            normalizedMessage = stripMediaFromUserMessage(
+              normalizedMessage,
+              typesToStrip,
+            )
           }
 
           // Server renders tool_reference expansion as <functions>...</functions>
@@ -1759,11 +1785,20 @@ export function normalizeMessagesForAPI(
           const rawAttachmentMessage = normalizeAttachmentForAPI(
             message.attachment,
           )
+          const typesToStrip = stripTargets.get(message.uuid)
+          const strippedAttachmentMessage = typesToStrip
+            ? rawAttachmentMessage.map(attachmentMessage => {
+                return stripMediaFromUserMessage(
+                  attachmentMessage,
+                  typesToStrip,
+                )
+              })
+            : rawAttachmentMessage
           const attachmentMessage = checkStatsigFeatureGate_CACHED_MAY_BE_STALE(
             'tengu_chair_sermon',
           )
-            ? rawAttachmentMessage.map(ensureSystemReminderWrap)
-            : rawAttachmentMessage
+            ? strippedAttachmentMessage.map(ensureSystemReminderWrap)
+            : strippedAttachmentMessage
 
           // If the last message is also a user message, merge them
           const lastMessage = last(result)

--- a/src/utils/messages.ts
+++ b/src/utils/messages.ts
@@ -1865,34 +1865,11 @@ export function mergeUserMessages(a: UserMessage, b: UserMessage): UserMessage {
     content: string | ContentBlockParam[],
   ): string | ContentBlockParam[] =>
     isCollapseSummary ? stripSnipTagsFromContent(content) : content
-  if (feature('HISTORY_SNIP')) {
-    // A merged message is only meta if ALL merged messages are meta. If any
-    // operand is real user content, the result must not be flagged isMeta
-    // (so internal snip ids get injected and it's treated as user-visible content).
-    // Gated behind the full runtime check because changing isMeta semantics
-    // affects downstream callers (e.g., VCR fixture hashing in SDK harness
-    // tests), so this must only fire when snip is actually enabled — not
-    // for all ants.
-    const { isSnipRuntimeEnabled } =
-      // eslint-disable-next-line @typescript-eslint/no-require-imports
-      require('../services/compact/snipCompact.js') as typeof import('../services/compact/snipCompact.js')
-    if (isSnipRuntimeEnabled()) {
-      return {
-        ...a,
-        isMeta: a.isMeta && b.isMeta ? (true as const) : undefined,
-        isCollapseSummary,
-        uuid: a.isMeta ? b.uuid : a.uuid,
-        message: {
-          ...a.message,
-          content: finalize(
-            hoistToolResults(joinTextAtSeam(lastContent, currentContent)),
-          ),
-        },
-      }
-    }
-  }
   return {
     ...a,
+    // A merged message is only meta if every operand is meta. Any real user
+    // content makes the combined turn a real user message for all consumers.
+    isMeta: a.isMeta && b.isMeta ? (true as const) : undefined,
     isCollapseSummary,
     // Preserve the non-meta message's uuid so snip ids (derived from uuid)
     // stay stable across API calls (meta messages like system context get fresh uuids each call)

--- a/src/utils/messages.ts
+++ b/src/utils/messages.ts
@@ -1588,14 +1588,12 @@ export function normalizeMessagesForAPI(
                 // All content blocks were stripped; skip this message entirely
                 return
               }
-              if (filtered.length < content.length) {
-                normalizedMessage = {
-                  ...normalizedMessage,
-                  message: {
-                    ...normalizedMessage.message,
-                    content: filtered,
-                  },
-                }
+              normalizedMessage = {
+                ...normalizedMessage,
+                message: {
+                  ...normalizedMessage.message,
+                  content: filtered,
+                },
               }
             }
           }

--- a/src/utils/messages.ts
+++ b/src/utils/messages.ts
@@ -1444,29 +1444,29 @@ export function normalizeMessagesForAPI(
     if (!blockTypesToStrip) {
       continue
     }
-    // Prefer the raw meta attachment immediately before its real prompt: API
-    // normalization merges that pair later. Otherwise an ordinary pasted
-    // attachment is carried by the immediate user message itself.
+    // Provider errors do not identify the rejected attachment. Strip the
+    // matching block type from every contiguous user message in this failed
+    // turn: choosing only one adjacent message can retain the bad payload and
+    // make every retry fail again.
     for (let j = i - 1; j >= 0; j--) {
       const candidate = reorderedMessages[j]!
       if (candidate.type === 'user') {
-        const preceding = reorderedMessages[j - 1]
-        const target =
-          preceding?.type === 'user' &&
-          preceding.isMeta &&
-          Array.isArray(preceding.message.content) &&
-          preceding.message.content.some(block => blockTypesToStrip.has(block.type))
-            ? preceding
-            : candidate
-        const existing = stripTargets.get(target.uuid)
+        const content = candidate.message.content
+        if (
+          !Array.isArray(content) ||
+          !content.some(block => blockTypesToStrip.has(block.type))
+        ) {
+          continue
+        }
+        const existing = stripTargets.get(candidate.uuid)
         if (existing) {
           for (const t of blockTypesToStrip) {
             existing.add(t)
           }
         } else {
-          stripTargets.set(target.uuid, new Set(blockTypesToStrip))
+          stripTargets.set(candidate.uuid, new Set(blockTypesToStrip))
         }
-        break
+        continue
       }
       // Skip over other synthetic error messages.
       if (isSyntheticApiErrorMessage(candidate)) {

--- a/src/utils/messages.ts
+++ b/src/utils/messages.ts
@@ -1444,17 +1444,27 @@ export function normalizeMessagesForAPI(
     if (!blockTypesToStrip) {
       continue
     }
-    // Walk backward to find the immediately preceding user message.
+    // Prefer the raw meta attachment immediately before its real prompt: API
+    // normalization merges that pair later. Otherwise an ordinary pasted
+    // attachment is carried by the immediate user message itself.
     for (let j = i - 1; j >= 0; j--) {
       const candidate = reorderedMessages[j]!
       if (candidate.type === 'user') {
-        const existing = stripTargets.get(candidate.uuid)
+        const preceding = reorderedMessages[j - 1]
+        const target =
+          preceding?.type === 'user' &&
+          preceding.isMeta &&
+          Array.isArray(preceding.message.content) &&
+          preceding.message.content.some(block => blockTypesToStrip.has(block.type))
+            ? preceding
+            : candidate
+        const existing = stripTargets.get(target.uuid)
         if (existing) {
           for (const t of blockTypesToStrip) {
             existing.add(t)
           }
         } else {
-          stripTargets.set(candidate.uuid, new Set(blockTypesToStrip))
+          stripTargets.set(target.uuid, new Set(blockTypesToStrip))
         }
         break
       }

--- a/src/utils/messages.ts
+++ b/src/utils/messages.ts
@@ -1444,10 +1444,10 @@ export function normalizeMessagesForAPI(
     if (!blockTypesToStrip) {
       continue
     }
-    // Walk backward to find the nearest preceding isMeta user message
+    // Walk backward to find the immediately preceding user message.
     for (let j = i - 1; j >= 0; j--) {
       const candidate = reorderedMessages[j]!
-      if (candidate.type === 'user' && candidate.isMeta) {
+      if (candidate.type === 'user') {
         const existing = stripTargets.get(candidate.uuid)
         if (existing) {
           for (const t of blockTypesToStrip) {
@@ -1458,11 +1458,11 @@ export function normalizeMessagesForAPI(
         }
         break
       }
-      // Skip over other synthetic error messages or non-meta messages
+      // Skip over other synthetic error messages.
       if (isSyntheticApiErrorMessage(candidate)) {
         continue
       }
-      // Stop if we hit an assistant message or non-meta user message
+      // Stop if we hit an assistant message or other non-user message.
       break
     }
   }
@@ -1541,11 +1541,11 @@ export function normalizeMessagesForAPI(
             )
           }
 
-          // Strip document/image blocks from the specific meta user message that
+          // Strip document/image blocks from the specific user message that
           // preceded a PDF/image/request-too-large error, to prevent re-sending
           // the problematic content on every subsequent API call.
           const typesToStrip = stripTargets.get(normalizedMessage.uuid)
-          if (typesToStrip && normalizedMessage.isMeta) {
+          if (typesToStrip) {
             const content = normalizedMessage.message.content
             if (Array.isArray(content)) {
               const filtered = content.filter(

--- a/src/utils/messages/apiTransform.test.ts
+++ b/src/utils/messages/apiTransform.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from 'bun:test'
 import {
   createUserMessage,
   mergeUserMessages,
+  normalizeMessagesForAPI,
 } from '../messages.js'
 import {
   appendMessageTagToUserMessage,
@@ -25,6 +26,17 @@ function countTags(out: UserMessage): number {
 }
 
 describe('appendMessageTagToUserMessage', () => {
+  test('normalizing meta context with real user input produces a non-meta message', () => {
+    const reminder = createUserMessage({ content: 'context', isMeta: true })
+    const correction = createUserMessage({ content: 'do Y instead' })
+
+    const [merged] = normalizeMessagesForAPI([reminder, correction])
+
+    expect(merged?.isMeta).toBeUndefined()
+    expect(JSON.stringify(merged?.message.content)).toContain('context')
+    expect(JSON.stringify(merged?.message.content)).toContain('do Y instead')
+  })
+
   test('appends internal snip metadata to string content', () => {
     const msg = { ...createUserMessage({ content: 'hello' }), uuid: UUID }
     const out = appendMessageTagToUserMessage(msg as UserMessage)

--- a/src/utils/messages/apiTransform.test.ts
+++ b/src/utils/messages/apiTransform.test.ts
@@ -113,6 +113,32 @@ describe('appendMessageTagToUserMessage', () => {
     expect(retryContent).not.toContain('"type":"image"')
   })
 
+  test('keeps a placeholder when nested media is the only tool result', () => {
+    const toolResult = createUserMessage({
+      content: [{
+        type: 'tool_result',
+        tool_use_id: 'toolu_image_only',
+        content: [{
+          type: 'image',
+          source: {
+            type: 'base64',
+            media_type: 'image/png',
+            data: 'only-nested-image',
+          },
+        }],
+      }],
+    })
+    const retry = normalizeMessagesForAPI([
+      toolResult,
+      createAssistantAPIErrorMessage({ content: getImageTooLargeErrorMessage() }),
+    ])
+    const retryContent = JSON.stringify(retry[0]?.message.content)
+
+    expect(retryContent).toContain('Media removed after provider rejection.')
+    expect(retryContent).not.toContain('only-nested-image')
+    expect(retryContent).not.toContain('"type":"image"')
+  })
+
   test('strips every ambiguous image attachment in the failed turn', () => {
     const oldAttachment = createUserMessage({
       content: [{ type: 'image', source: { type: 'base64', media_type: 'image/png', data: 'old-invalid-image' } }],

--- a/src/utils/messages/apiTransform.test.ts
+++ b/src/utils/messages/apiTransform.test.ts
@@ -84,6 +84,35 @@ describe('appendMessageTagToUserMessage', () => {
     expect(retryContent).not.toContain('oversized-pasted-image')
   })
 
+  test('retries strip rejected media nested in a tool result', () => {
+    const toolResult = createUserMessage({
+      content: [{
+        type: 'tool_result',
+        tool_use_id: 'toolu_oversized_image',
+        content: [
+          {
+            type: 'image',
+            source: {
+              type: 'base64',
+              media_type: 'image/png',
+              data: 'nested-oversized-image',
+            },
+          },
+          { type: 'text', text: 'remaining tool output' },
+        ],
+      }],
+    })
+    const retry = normalizeMessagesForAPI([
+      toolResult,
+      createAssistantAPIErrorMessage({ content: getImageTooLargeErrorMessage() }),
+    ])
+    const retryContent = JSON.stringify(retry[0]?.message.content)
+
+    expect(retryContent).toContain('remaining tool output')
+    expect(retryContent).not.toContain('nested-oversized-image')
+    expect(retryContent).not.toContain('"type":"image"')
+  })
+
   test('strips every ambiguous image attachment in the failed turn', () => {
     const oldAttachment = createUserMessage({
       content: [{ type: 'image', source: { type: 'base64', media_type: 'image/png', data: 'old-invalid-image' } }],

--- a/src/utils/messages/apiTransform.test.ts
+++ b/src/utils/messages/apiTransform.test.ts
@@ -1,9 +1,12 @@
 import { describe, expect, test } from 'bun:test'
+import { feature } from 'bun:bundle'
 import {
+  createAssistantAPIErrorMessage,
   createUserMessage,
   mergeUserMessages,
   normalizeMessagesForAPI,
 } from '../messages.js'
+import { getImageTooLargeErrorMessage } from '../../services/api/errors.js'
 import {
   appendMessageTagToUserMessage,
   deriveShortMessageId,
@@ -14,6 +17,7 @@ import type { UserMessage } from '../../types/message.js'
 
 const UUID = 'a1b2c3d4-0000-0000-0000-000000000099'
 const UUID_B = 'b2c3d4e5-0000-0000-0000-000000000088'
+const testWithoutHistorySnip = feature('HISTORY_SNIP') ? test.skip : test
 
 function tagFor(uuid: string): string {
   return `snip_id=${deriveShortMessageId(uuid)}`
@@ -26,16 +30,47 @@ function countTags(out: UserMessage): number {
 }
 
 describe('appendMessageTagToUserMessage', () => {
-  test('normalizing meta context with real user input produces a non-meta message', () => {
+  test('normalizing meta context honors snip merge semantics', () => {
     const reminder = createUserMessage({ content: 'context', isMeta: true })
     const correction = createUserMessage({ content: 'do Y instead' })
 
     const [merged] = normalizeMessagesForAPI([reminder, correction])
 
-    expect(merged?.isMeta).toBeUndefined()
+    expect(merged?.isMeta).toBe(feature('HISTORY_SNIP') ? undefined : true)
     expect(JSON.stringify(merged?.message.content)).toContain('context')
     expect(JSON.stringify(merged?.message.content)).toContain('do Y instead')
   })
+
+  testWithoutHistorySnip(
+    'non-snip retries strip a rejected meta image after it merged with a prompt',
+    () => {
+      const attachment = createUserMessage({
+        content: [
+          {
+            type: 'image',
+            source: {
+              type: 'base64',
+              media_type: 'image/png',
+              data: 'oversized-image',
+            },
+          },
+        ],
+        isMeta: true,
+      })
+      const prompt = createUserMessage({ content: 'describe this image' })
+      const [failedRequest] = normalizeMessagesForAPI([attachment, prompt])
+      const imageError = createAssistantAPIErrorMessage({
+        content: getImageTooLargeErrorMessage(),
+      })
+
+      const retry = normalizeMessagesForAPI([failedRequest!, imageError])
+      const retryContent = JSON.stringify(retry[0]?.message.content)
+
+      expect(retryContent).toContain('describe this image')
+      expect(retryContent).not.toContain('oversized-image')
+      expect(retryContent).not.toContain('"type":"image"')
+    },
+  )
 
   test('appends internal snip metadata to string content', () => {
     const msg = { ...createUserMessage({ content: 'hello' }), uuid: UUID }

--- a/src/utils/messages/apiTransform.test.ts
+++ b/src/utils/messages/apiTransform.test.ts
@@ -14,6 +14,7 @@ import {
   stripToolReferenceBlocksFromUserMessage,
 } from './apiTransform.js'
 import type { UserMessage } from '../../types/message.js'
+import { createAttachmentMessage } from '../attachments.js'
 
 const UUID = 'a1b2c3d4-0000-0000-0000-000000000099'
 const UUID_B = 'b2c3d4e5-0000-0000-0000-000000000088'
@@ -82,6 +83,52 @@ describe('appendMessageTagToUserMessage', () => {
 
     expect(retryContent).toContain('describe this image')
     expect(retryContent).not.toContain('oversized-pasted-image')
+  })
+
+  test('keeps a placeholder for an image-only pasted prompt on retry', () => {
+    const prompt = createUserMessage({
+      content: [{
+        type: 'image',
+        source: {
+          type: 'base64',
+          media_type: 'image/png',
+          data: 'image-only-prompt',
+        },
+      }],
+    })
+    const retry = normalizeMessagesForAPI([
+      prompt,
+      createAssistantAPIErrorMessage({ content: getImageTooLargeErrorMessage() }),
+    ])
+    const retryContent = JSON.stringify(retry[0]?.message.content)
+
+    expect(retryContent).toContain('Media removed after provider rejection.')
+    expect(retryContent).not.toContain('image-only-prompt')
+  })
+
+  test('retries strip rejected media from a file attachment', () => {
+    const attachment = createAttachmentMessage({
+      type: 'file',
+      filename: '/tmp/oversized.png',
+      displayPath: 'oversized.png',
+      content: {
+        type: 'image',
+        file: {
+          base64: 'attachment-image',
+          type: 'image/png',
+          originalSize: 1,
+        },
+      },
+    })
+    const retry = normalizeMessagesForAPI([
+      createUserMessage({ content: 'describe this file' }),
+      attachment,
+      createAssistantAPIErrorMessage({ content: getImageTooLargeErrorMessage() }),
+    ])
+    const retryContent = JSON.stringify(retry.map(message => message.message.content))
+
+    expect(retryContent).toContain('Media removed after provider rejection.')
+    expect(retryContent).not.toContain('attachment-image')
   })
 
   test('retries strip rejected media nested in a tool result', () => {

--- a/src/utils/messages/apiTransform.test.ts
+++ b/src/utils/messages/apiTransform.test.ts
@@ -57,12 +57,11 @@ describe('appendMessageTagToUserMessage', () => {
         isMeta: true,
       })
       const prompt = createUserMessage({ content: 'describe this image' })
-      const [failedRequest] = normalizeMessagesForAPI([attachment, prompt])
       const imageError = createAssistantAPIErrorMessage({
         content: getImageTooLargeErrorMessage(),
       })
 
-      const retry = normalizeMessagesForAPI([failedRequest!, imageError])
+      const retry = normalizeMessagesForAPI([attachment, prompt, imageError])
       const retryContent = JSON.stringify(retry[0]?.message.content)
 
       expect(retryContent).toContain('describe this image')
@@ -70,6 +69,39 @@ describe('appendMessageTagToUserMessage', () => {
       expect(retryContent).not.toContain('"type":"image"')
     },
   )
+
+  test('retries strip an oversized pasted image on an ordinary user prompt', () => {
+    const prompt = createUserMessage({
+      content: [{ type: 'image', source: { type: 'base64', media_type: 'image/png', data: 'oversized-pasted-image' } }, { type: 'text', text: 'describe this image' }],
+    })
+    const retry = normalizeMessagesForAPI([
+      prompt,
+      createAssistantAPIErrorMessage({ content: getImageTooLargeErrorMessage() }),
+    ])
+    const retryContent = JSON.stringify(retry[0]?.message.content)
+
+    expect(retryContent).toContain('describe this image')
+    expect(retryContent).not.toContain('oversized-pasted-image')
+  })
+
+  test('keeps a later real attachment when the preceding meta attachment failed', () => {
+    const oldAttachment = createUserMessage({
+      content: [{ type: 'image', source: { type: 'base64', media_type: 'image/png', data: 'old-invalid-image' } }],
+      isMeta: true,
+    })
+    const laterAttachment = createUserMessage({
+      content: [{ type: 'image', source: { type: 'base64', media_type: 'image/png', data: 'latest-valid-image' } }, { type: 'text', text: 'describe this screenshot' }],
+    })
+    const retry = normalizeMessagesForAPI([
+      oldAttachment,
+      laterAttachment,
+      createAssistantAPIErrorMessage({ content: getImageTooLargeErrorMessage() }),
+    ])
+    const retryContent = JSON.stringify(retry[0]?.message.content)
+
+    expect(retryContent).toContain('latest-valid-image')
+    expect(retryContent).not.toContain('old-invalid-image')
+  })
 
   test('appends internal snip metadata to string content', () => {
     const msg = { ...createUserMessage({ content: 'hello' }), uuid: UUID }

--- a/src/utils/messages/apiTransform.test.ts
+++ b/src/utils/messages/apiTransform.test.ts
@@ -17,7 +17,6 @@ import type { UserMessage } from '../../types/message.js'
 
 const UUID = 'a1b2c3d4-0000-0000-0000-000000000099'
 const UUID_B = 'b2c3d4e5-0000-0000-0000-000000000088'
-const testWithoutHistorySnip = feature('HISTORY_SNIP') ? test.skip : test
 
 function tagFor(uuid: string): string {
   return `snip_id=${deriveShortMessageId(uuid)}`
@@ -41,8 +40,8 @@ describe('appendMessageTagToUserMessage', () => {
     expect(JSON.stringify(merged?.message.content)).toContain('do Y instead')
   })
 
-  testWithoutHistorySnip(
-    'non-snip retries strip a rejected meta image after it merged with a prompt',
+  test(
+    'retries strip a rejected image after it merged with a prompt',
     () => {
       const attachment = createUserMessage({
         content: [

--- a/src/utils/messages/apiTransform.test.ts
+++ b/src/utils/messages/apiTransform.test.ts
@@ -84,7 +84,7 @@ describe('appendMessageTagToUserMessage', () => {
     expect(retryContent).not.toContain('oversized-pasted-image')
   })
 
-  test('keeps a later real attachment when the preceding meta attachment failed', () => {
+  test('strips every ambiguous image attachment in the failed turn', () => {
     const oldAttachment = createUserMessage({
       content: [{ type: 'image', source: { type: 'base64', media_type: 'image/png', data: 'old-invalid-image' } }],
       isMeta: true,
@@ -99,8 +99,32 @@ describe('appendMessageTagToUserMessage', () => {
     ])
     const retryContent = JSON.stringify(retry[0]?.message.content)
 
-    expect(retryContent).toContain('latest-valid-image')
+    expect(retryContent).toContain('describe this screenshot')
     expect(retryContent).not.toContain('old-invalid-image')
+    expect(retryContent).not.toContain('latest-valid-image')
+  })
+
+  test('strips an earlier image past a different meta attachment', () => {
+    const image = createUserMessage({
+      content: [{ type: 'image', source: { type: 'base64', media_type: 'image/png', data: 'oversized-image' } }],
+      isMeta: true,
+    })
+    const pdf = createUserMessage({
+      content: [{ type: 'document', source: { type: 'base64', media_type: 'application/pdf', data: 'valid-pdf' } }],
+      isMeta: true,
+    })
+    const prompt = createUserMessage({ content: 'describe both attachments' })
+    const retry = normalizeMessagesForAPI([
+      image,
+      pdf,
+      prompt,
+      createAssistantAPIErrorMessage({ content: getImageTooLargeErrorMessage() }),
+    ])
+    const retryContent = JSON.stringify(retry[0]?.message.content)
+
+    expect(retryContent).toContain('valid-pdf')
+    expect(retryContent).toContain('describe both attachments')
+    expect(retryContent).not.toContain('oversized-image')
   })
 
   test('appends internal snip metadata to string content', () => {


### PR DESCRIPTION
## Summary

- add a one-shot model-visible reminder after a user interrupts an active assistant turn
- keep slash commands, local UI commands, remote events, timeouts, and programmatic aborts from consuming or arming the reminder

## Impact

- user-facing impact: the next normal correction prompt is explicitly framed as corrective instead of letting the model continue the interrupted plan
- developer/maintainer impact: interruption state is session-scoped and tied to the exact model-bound query

## Testing

- [x] `bun run build`
- [x] `bun run smoke`
- [ ] `bun run check` — the feature branch and an untouched `upstream/main` baseline produced the same 43 existing failures; the branch added five passing tests in that comparison
- [x] `bun run typecheck`
- [x] focused tests: interruption state, prompt submission, REPL lifecycle wiring, and meta-message API behavior

## Notes

- provider/model path tested: provider-independent message construction; no live provider-backed REPL session
- screenshots attached: not applicable for this terminal interaction change
- follow-up work or known limitations: no rendered Ink/Escape integration test; the QueryGuard-backed lifecycle boundary and queued-input behavior are covered directly

Fixes #1422


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added one-time, session-scoped interruption-correction reminders for eligible *normal local* prompts, with full REPL turn lifecycle integration.
  - Introduced **request-only messages** to provide model context without compacting, persisting, exposing to tools, or being added to transcript state.
  - Added prompt submission control (`allowInterruptionCorrection`) and model-call lifecycle hooks (`onModelRequestStart`/`onModelRequestEnd`).

- **Bug Fixes**
  - Fixed interruption-correction arming/restoration behavior across cancellation, queued/concurrent turns, rewind/auto-restore, and session switching.
  - Improved provider-error normalization and feature-flag-dependent meta tagging.

- **Tests**
  - Expanded REPL, prompt submission/queue, interruption-correction, request-only propagation, and message normalization coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->