### PR TITLE
refactor(cli): commander-authoritative argv handling for SSH / cc:// and remote bypass

### DIFF
--- a/src/bootstrap/state.ts
+++ b/src/bootstrap/state.ts
@@ -111,6 +111,13 @@ type State = {
   useCoworkPlugins: boolean
   // Session-only bypass permissions mode flag (not persisted)
   sessionBypassPermissionsMode: boolean
+  /**
+   * True when THIS session hands bypass to a remote tool executor (`cc://` or
+   * ssh). The local permission mode is deliberately downgraded for those
+   * sessions, so the mode alone cannot tell the UI that tools run without
+   * consent — see the bypass status notice.
+   */
+  remoteBypassPermissions: boolean
   // Session startup dangerous permission mode for integrations that need to
   // preserve the distinction between bypassPermissions and fullAccess before
   // the app is fully mounted.
@@ -325,6 +332,7 @@ function getInitialState(): State {
     useCoworkPlugins: false,
     // Session-only bypass permissions mode flag (not persisted)
     sessionBypassPermissionsMode: false,
+    remoteBypassPermissions: false,
     sessionDangerousPermissionMode: null,
     // Scheduled tasks disabled until flag or dialog enables them
     scheduledTasksEnabled: false,
@@ -1205,6 +1213,14 @@ export function setSessionBypassPermissionsMode(enabled: boolean): void {
 
 export function getSessionBypassPermissionsMode(): boolean {
   return STATE.sessionBypassPermissionsMode
+}
+
+export function setRemoteBypassPermissions(enabled: boolean): void {
+  STATE.remoteBypassPermissions = enabled
+}
+
+export function getRemoteBypassPermissions(): boolean {
+  return STATE.remoteBypassPermissions
 }
 
 export function setSessionDangerousPermissionMode(

--- a/src/cli/handlers/skillsCli.ts
+++ b/src/cli/handlers/skillsCli.ts
@@ -1,3 +1,4 @@
+import { SKILLS_GLOBAL_BOOLEAN_FLAGS } from '../skillsBooleanFlags.js'
 import { setAdditionalDirectoriesForClaudeMd } from '../../bootstrap/state.js'
 
 type SkillsCliOptions = {
@@ -10,28 +11,6 @@ type SkillsCliOptions = {
   sha256?: string
 }
 
-const TRAILING_GLOBAL_BOOLEAN_FLAGS = new Set([
-  '--bare',
-  '--debug',
-  '--debug-to-stderr',
-  '--dangerously-skip-permissions',
-  '--allow-dangerously-skip-permissions',
-  '--disable-slash-commands',
-  '--enable-auth-status',
-  '--fork-session',
-  '--ide',
-  '--include-hook-events',
-  '--include-partial-messages',
-  '--init',
-  '--init-only',
-  '--maintenance',
-  '--mcp-debug',
-  '--no-chrome',
-  '--no-session-persistence',
-  '--replay-user-messages',
-  '--strict-mcp-config',
-  '--verbose',
-])
 
 const TRAILING_GLOBAL_VALUE_FLAGS = new Set([
   '--agent',
@@ -130,7 +109,7 @@ function parseSkillsCliArgs(args: string[]): {
         return { options, positionals, error: '--sha256 requires a value.' }
       }
       options.sha256 = value
-    } else if (TRAILING_GLOBAL_BOOLEAN_FLAGS.has(arg)) {
+    } else if (SKILLS_GLOBAL_BOOLEAN_FLAGS.has(arg)) {
       continue
     } else if (TRAILING_GLOBAL_VALUE_FLAGS.has(arg)) {
       const value = args[index + 1]

--- a/src/cli/skillsBooleanFlags.test.ts
+++ b/src/cli/skillsBooleanFlags.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'bun:test'
+import { Command } from '@commander-js/extra-typings'
+import { applyMainOptions } from '../mainCliOptions.js'
+import {
+  SKILLS_GLOBAL_BOOLEAN_FLAGS,
+  SKILLS_PROMPT_MODE_FLAGS,
+} from './skillsBooleanFlags.js'
+
+// Absent from this build's registrations because scripts/build.ts compiles their
+// features out. Listed so the arity check's escape hatch cannot quietly widen.
+const FEATURE_GATED_FLAGS = [
+  '--assistant',
+  '--brief',
+  '--enable-auto-mode',
+  '--hard-fail',
+  '--proactive',
+]
+
+describe('skills flag sets', () => {
+  it('keeps the boolean and prompt-mode sets disjoint', () => {
+    // getSkillsCliArgs tests the boolean set FIRST, so a flag in both is
+    // silently skipped and never reaches its prompt-mode handling. That is not
+    // hypothetical: `--continue` was added to the boolean set because it is
+    // value-less — the obvious half of that set's contract — and it broke
+    // `openclaude --continue skills list`, which must resume the prior
+    // conversation with `skills list` as its prompt rather than dispatch to the
+    // skills manager.
+    const overlap = [...SKILLS_PROMPT_MODE_FLAGS].filter(flag =>
+      SKILLS_GLOBAL_BOOLEAN_FLAGS.has(flag),
+    )
+    expect(overlap).toEqual([])
+  })
+
+  it('lists no value-taking flag in the boolean set', () => {
+    // Arity is asked of commander, not hand-listed, so this tracks
+    // applyMainOptions automatically as options are added or change shape.
+    //
+    // The earlier version of this test filtered on membership in
+    // SKILLS_PROMPT_MODE_FLAGS, which the test above already proves empty — so
+    // it was a vacuous duplicate and `--model` in the boolean set passed both.
+    // This half of the contract has no other guard: entries are skipped WITHOUT
+    // consuming a following token, so a value-taking flag leaves its value
+    // behind as a stray operand.
+    // Keyed by BOTH spellings: commander stores a dual-long registration's first
+    // flag as `.short`, so `--yolo` (the alias this PR adds) was absent from a
+    // long-only map and fell through the feature-gated escape hatch below —
+    // unchecked by the very test meant to cover it.
+    const registered = new Map(
+      applyMainOptions(new Command()).options.flatMap(option =>
+        [option.long, option.short]
+          .filter((name): name is string => Boolean(name))
+          .map(name => [name, option] as const),
+      ),
+    )
+
+    const valueTaking = [...SKILLS_GLOBAL_BOOLEAN_FLAGS].filter(flag => {
+      // `--debug` is the documented exception: its value is optional, and
+      // consuming it would swallow the subcommand instead (see the module doc).
+      if (flag === '--debug') return false
+      const option = registered.get(flag)
+      // Feature-gated flags are absent from this build's registrations; they
+      // cannot be checked here and are value-less by inspection. Kept narrow on
+      // purpose — this escape hatch previously swallowed `--yolo` too.
+      if (option === undefined) {
+        expect(FEATURE_GATED_FLAGS).toContain(flag)
+        return false
+      }
+      return option.required || option.optional
+    })
+
+    expect(valueTaking).toEqual([])
+  })
+})

--- a/src/cli/skillsBooleanFlags.ts
+++ b/src/cli/skillsBooleanFlags.ts
@@ -1,0 +1,90 @@
+/**
+ * Flags that mark the invocation as prompt-mode: a following `skills` is the
+ * user's PROMPT TEXT, not the management subcommand. The leading scan stops
+ * routing when it sees one.
+ *
+ * Kept beside the boolean set on purpose — the two must stay disjoint, the
+ * boolean set is tested first, and an entry appearing in both silently wins
+ * there. `skillsBooleanFlags.test.ts` asserts the disjointness.
+ */
+export const SKILLS_PROMPT_MODE_FLAGS: ReadonlySet<string> = new Set([
+  '--continue',
+  '--from-pr',
+  '--print',
+  '-c',
+  '-p',
+  '-r',
+  '--resume',
+])
+
+/**
+ * Global boolean (value-less) flags that may sit around a `skills` subcommand.
+ *
+ * Two pre-parsers need this set: the leading-flag scan in
+ * `src/entrypoints/cli.tsx` (which decides whether argv routes to the skills
+ * handler) and the trailing-flag scan in `src/cli/handlers/skillsCli.ts`. They
+ * held verbatim copies, so adding one flag meant editing both — and a miss
+ * surfaces at runtime as `Unknown skills option: --x`, never as a type error.
+ *
+ * The contract is value-less AND ROUTING-NEUTRAL — both halves matter, and only
+ * the first is obvious. Entries are skipped without consuming a following token,
+ * so a value-taking option leaves its value behind as a stray operand; but a
+ * value-less option that CHANGES WHAT THE INVOCATION MEANS must not be here
+ * either. Those belong in SKILLS_PROMPT_MODE_FLAGS below.
+ *
+ * That distinction is not theoretical: `--continue` is value-less, so an
+ * enumeration of commander's value-less options says it belongs here — and
+ * adding it broke `openclaude --continue skills list`, which must resume the
+ * prior conversation with `skills list` as its PROMPT. The leading scan tests
+ * this set first, so an entry here silently overrides prompt-mode handling.
+ *
+ * `--debug` is a deliberate exception, inherited from both original copies: its
+ * value is optional (`-d, --debug [filter]`), and the alternative is worse. If
+ * this pre-parse consumed the next token, `openclaude skills --debug list`
+ * would swallow the SUBCOMMAND as the filter and stop routing to `list` — the
+ * pre-parse cannot tell a filter from a subcommand, because it does not know
+ * the subcommand set. The cost is that an explicitly supplied filter leaks:
+ * `skills show --debug api` binds `api` as the skill name. Pre-existing on both
+ * copies; noted here rather than silently traded away.
+ *
+ * Kept in its own module rather than exported from either consumer: `cli.tsx` is
+ * the entrypoint (top-level side effects, latency-sensitive) and importing it
+ * from a handler would be a cycle, while importing the handler from `cli.tsx`
+ * would pull it into startup.
+ */
+export const SKILLS_GLOBAL_BOOLEAN_FLAGS: ReadonlySet<string> = new Set([
+  '--bare',
+  '--debug',
+  '--debug-to-stderr',
+  '--yolo', // alias for --dangerously-skip-permissions
+  '--dangerously-skip-permissions',
+  '--allow-dangerously-skip-permissions',
+  '--deep-link-origin',
+  '--plan-mode-required',
+  '--tmux',
+  // Feature-gated in scripts/build.ts, so absent from the default build's argv —
+  // listed anyway because a flag that is not registered simply never appears,
+  // whereas a missing entry is a runtime `Unknown skills option` the day the
+  // flag ships enabled.
+  '--assistant',
+  '--brief',
+  '--enable-auto-mode',
+  '--hard-fail',
+  '--proactive',
+  '--disable-slash-commands',
+  '--enable-auth-status',
+  '--fork-session',
+  '--ide',
+  '--include-hook-events',
+  '--include-partial-messages',
+  '--init',
+  '--init-only',
+  '--maintenance',
+  '--mcp-debug',
+  '--chrome',
+  '--no-chrome',
+  '--no-session-persistence',
+  '--replay-user-messages',
+  '--strict-mcp-config',
+  '--verbose',
+])

--- a/src/components/StatusNotices.tsx
+++ b/src/components/StatusNotices.tsx
@@ -1,6 +1,7 @@
 import { c as _c } from "react-compiler-runtime";
 import * as React from 'react';
 import { Box } from '../ink.js';
+import { getRemoteBypassPermissions } from '../bootstrap/state.js';
 import { useAppState } from '../state/AppState.js';
 import type { AgentDefinitionsResult } from '../tools/AgentTool/loadAgentsDir.js';
 import type { MemoryFileInfo } from '../utils/claudemd.js';
@@ -97,6 +98,10 @@ export function StatusNotices(t0) {
     isLocalModel,
     localModelContextLoad,
     permissionMode,
+    // Remote sessions downgrade the local mode on purpose; without this the
+    // bypass warning would be silent for a session whose remote tools run
+    // without consent.
+    remoteBypassPermissions: getRemoteBypassPermissions(),
     mainLoopModel: mainLoopModel ?? undefined,
   };
   const activeNotices = getActiveNotices(context);

--- a/src/entrypoints/cli.test.ts
+++ b/src/entrypoints/cli.test.ts
@@ -16,6 +16,8 @@ import {
 import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
+import { Command } from '@commander-js/extra-typings'
+import { applyMainOptions } from '../mainCliOptions.js'
 import {
   applyLoadedEnvFileValues,
   loadEnvFile,
@@ -99,6 +101,63 @@ function clearRuntimeMocks() {
     fn.mockClear()
   }
 }
+
+// Several tests in this file spawn the built CLI (the Node-24 premature-exit
+// regression and the live --yolo registration check). `bun test` on a clean
+// checkout hasn't produced dist/cli.mjs, so build it once up front — file-level
+// so it runs before every describe, not just the one that needs it last.
+//
+// Rebuild when the artifact is missing OR older than ANY source under src/: a
+// stale dist (CI cache, older local build) would otherwise let the --help test
+// pass against a build predating the change it exists to catch. Scanning the
+// whole tree rather than a hand-listed subset means the check can't drift as
+// the CLI's registration moves between files.
+beforeAll(async () => {
+  const fs = await import('node:fs')
+  const path = await import('node:path')
+  const repoRoot = path.resolve(import.meta.dir, '../..')
+  const srcDir = path.join(repoRoot, 'src')
+  const distPath = path.join(repoRoot, 'dist/cli.mjs')
+  const distMtime = fs.existsSync(distPath) ? fs.statSync(distPath).mtimeMs : 0
+  let newestSource = 0
+  // A missing artifact is rebuilt unconditionally, so skip the scan entirely —
+  // its answer cannot change the decision.
+  if (distMtime === 0) newestSource = Number.POSITIVE_INFINITY
+  // src/ also holds plain .js/.mjs sources (e.g. src/commands/*/index.js).
+  // Test files are skipped (*.test.*, *.spec.*, __tests__/): they never reach
+  // dist/cli.mjs, so editing a test shouldn't force a rebuild before this runs.
+  for await (const rel of distMtime === 0
+    ? []
+    : new Bun.Glob('**/*.{ts,tsx,js,jsx,mjs,cjs}').scan(srcDir)) {
+    if (/\.(test|spec)\.[cm]?[jt]sx?$/.test(rel) || rel.includes('__tests__')) continue
+    const m = fs.statSync(path.join(srcDir, rel)).mtimeMs
+    if (m > newestSource) newestSource = m
+  }
+  // Build inputs outside src/ also determine the bundle. scripts/build.ts holds
+  // the featureFlags map these tests reason about (SSH_REMOTE/DIRECT_CONNECT
+  // compile out), so editing it must invalidate dist too — otherwise the --help
+  // assertion below passes against a binary that predates the change.
+  for (const rel of ['scripts/build.ts', 'package.json']) {
+    const abs = path.join(repoRoot, rel)
+    if (!fs.existsSync(abs)) continue
+    const m = fs.statSync(abs).mtimeMs
+    if (m > newestSource) newestSource = m
+  }
+  if (distMtime < newestSource) {
+    // Cap the spawn itself: the hook's 300s budget is a runner-level timeout and
+    // cannot preempt a wedged synchronous spawn.
+    const built = Bun.spawnSync(['bun', 'run', 'build'], {
+      cwd: repoRoot,
+      timeout: 240_000,
+    })
+    if (built.exitCode !== 0) {
+      throw new Error(
+        `on-demand \`bun run build\` failed (exit ${built.exitCode}):\n` +
+          `${built.stdout.toString()}${built.stderr.toString()}`,
+      )
+    }
+  }
+}, 300_000)
 
 describe('cli.tsx — NODE_OPTIONS --max-old-space-size (issue #402)', () => {
   const originalNodeOptions = process.env.NODE_OPTIONS
@@ -320,70 +379,73 @@ describe('cli.tsx — --provider startup ordering', () => {
 
 })
 
+const mockImporters = {
+  startupProfiler: async () => ({
+    profileCheckpoint: mockProfileCheckpoint,
+  }),
+  bg: async () => ({
+    psHandler: mockPsHandler,
+    logsHandler: mockLogsHandler,
+    attachHandler: mockAttachHandler,
+    killHandler: mockKillHandler,
+    handleBgFlag: mockHandleBgFlag,
+  }),
+  envFile: async () => ({
+    loadEnvFile: mockLoadEnvFile,
+    parseProviderEnvFileArgs: mockParseProviderEnvFileArgs,
+    reapplyRememberedEnvFileValues: mockReapplyRememberedEnvFileValues,
+    rememberLoadedEnvFileValues: mockRememberLoadedEnvFileValues,
+  }),
+  config: async () => ({
+    enableConfigs: mockEnableConfigs,
+  }),
+  managedEnv: async () => ({
+    applySafeConfigEnvironmentVariables:
+      mockApplySafeConfigEnvironmentVariables,
+  }),
+  providerProfile: async () => ({
+    applyStartupEnvFromProfile: mockApplyStartupEnvFromProfile,
+  }),
+  providerValidation: async () => ({
+    getProviderValidationError: mockGetProviderValidationError,
+    validateProviderEnvForStartupOrExit:
+      mockValidateProviderEnvForStartupOrExit,
+  }),
+  flagSettings: async () => ({
+    eagerLoadSettingsFromArgs: mockEagerLoadSettingsFromArgs,
+  }),
+  agentRouting: async () => ({
+    applyAgentProviderOverrideToEnv: mockApplyAgentProviderOverrideToEnv,
+    resolveOutOfProcessTeammateProviderFromCliArgs:
+      mockResolveOutOfProcessTeammateProviderFromCliArgs,
+  }),
+  settings: async () => ({
+    getInitialSettings: mockGetInitialSettings,
+  }),
+  githubModelsCredentials: async () => ({
+    hydrateGithubModelsTokenFromSecureStorage:
+      mockHydrateGithubModelsTokenFromSecureStorage,
+    refreshGithubModelsTokenIfNeeded: mockRefreshGithubModelsTokenIfNeeded,
+  }),
+  startupScreen: async () => ({
+    printStartupScreen: mockPrintStartupScreen,
+  }),
+  earlyInput: async () => ({
+    startCapturingEarlyInput: mockStartCapturingEarlyInput,
+  }),
+  main: async () => ({
+    main: mockCliMain,
+  }),
+}
+
 describe('cli.tsx — background routing behavior', () => {
   const bgOptions = {
     bgSessionsEnabled: true,
-    importers: {
-      startupProfiler: async () => ({
-        profileCheckpoint: mockProfileCheckpoint,
-      }),
-      bg: async () => ({
-        psHandler: mockPsHandler,
-        logsHandler: mockLogsHandler,
-        attachHandler: mockAttachHandler,
-        killHandler: mockKillHandler,
-        handleBgFlag: mockHandleBgFlag,
-      }),
-      envFile: async () => ({
-        loadEnvFile: mockLoadEnvFile,
-        parseProviderEnvFileArgs: mockParseProviderEnvFileArgs,
-        reapplyRememberedEnvFileValues: mockReapplyRememberedEnvFileValues,
-        rememberLoadedEnvFileValues: mockRememberLoadedEnvFileValues,
-      }),
-      config: async () => ({
-        enableConfigs: mockEnableConfigs,
-      }),
-      managedEnv: async () => ({
-        applySafeConfigEnvironmentVariables:
-          mockApplySafeConfigEnvironmentVariables,
-      }),
-      providerProfile: async () => ({
-        applyStartupEnvFromProfile: mockApplyStartupEnvFromProfile,
-      }),
-      providerValidation: async () => ({
-        getProviderValidationError: mockGetProviderValidationError,
-        validateProviderEnvForStartupOrExit:
-          mockValidateProviderEnvForStartupOrExit,
-      }),
-      flagSettings: async () => ({
-        eagerLoadSettingsFromArgs: mockEagerLoadSettingsFromArgs,
-      }),
-      agentRouting: async () => ({
-        applyAgentProviderOverrideToEnv: mockApplyAgentProviderOverrideToEnv,
-        resolveOutOfProcessTeammateProviderFromCliArgs:
-          mockResolveOutOfProcessTeammateProviderFromCliArgs,
-      }),
-      settings: async () => ({
-        getInitialSettings: mockGetInitialSettings,
-      }),
-      githubModelsCredentials: async () => ({
-        hydrateGithubModelsTokenFromSecureStorage:
-          mockHydrateGithubModelsTokenFromSecureStorage,
-        refreshGithubModelsTokenIfNeeded: mockRefreshGithubModelsTokenIfNeeded,
-      }),
-      startupScreen: async () => ({
-        printStartupScreen: mockPrintStartupScreen,
-      }),
-      earlyInput: async () => ({
-        startCapturingEarlyInput: mockStartCapturingEarlyInput,
-      }),
-      main: async () => ({
-        main: mockCliMain,
-      }),
-    },
+    importers: mockImporters,
   } as unknown as Parameters<CliMain>[1]
   const originalAutoRunGuard =
     process.env.OPENCLAUDE_DISABLE_CLI_ENTRYPOINT_AUTO_RUN
+  const savedArgv = [...process.argv]
 
   beforeAll(async () => {
     process.env.OPENCLAUDE_DISABLE_CLI_ENTRYPOINT_AUTO_RUN = '1'
@@ -403,6 +465,10 @@ describe('cli.tsx — background routing behavior', () => {
 
   beforeEach(() => {
     clearRuntimeMocks()
+  })
+
+  afterEach(() => {
+    process.argv = [...savedArgv]
   })
 
   it('dispatches background management commands before startup work', async () => {
@@ -564,5 +630,413 @@ describe('Node 24 premature exit regression (issue #1678)', () => {
     const src = await Bun.file(`${import.meta.dir}/cli.tsx`).text()
     expect(src).toMatch(/await main\(\)/)
     expect(src).not.toMatch(/^\s*void main\(\)/m)
+  })
+})
+
+describe('cli.tsx — --yolo alias (PR #1939)', () => {
+  const options = {
+    importers: mockImporters,
+  } as unknown as Parameters<CliMain>[1]
+  const originalAutoRunGuard =
+    process.env.OPENCLAUDE_DISABLE_CLI_ENTRYPOINT_AUTO_RUN
+  const savedArgv = [...process.argv]
+
+  beforeAll(async () => {
+    process.env.OPENCLAUDE_DISABLE_CLI_ENTRYPOINT_AUTO_RUN = '1'
+    const entrypoint = await import('./cli.js')
+    runCliEntrypoint = entrypoint.main
+  })
+
+  afterAll(() => {
+    if (originalAutoRunGuard === undefined) {
+      delete process.env.OPENCLAUDE_DISABLE_CLI_ENTRYPOINT_AUTO_RUN
+    } else {
+      process.env.OPENCLAUDE_DISABLE_CLI_ENTRYPOINT_AUTO_RUN =
+        originalAutoRunGuard
+    }
+  })
+
+  beforeEach(() => {
+    clearRuntimeMocks()
+  })
+
+  afterEach(() => {
+    process.argv = [...savedArgv]
+  })
+
+  // Built from the REAL registration (applyMainOptions), not a local re-declare,
+  // so this fails if the alias is dropped/reordered or the canonical attribute
+  // name changes. commander derives the attribute from the LAST long flag, so
+  // both spellings set dangerouslySkipPermissions — why a native alias works.
+  const buildProgram = () =>
+    applyMainOptions(new Command()).allowExcessArguments().exitOverride()
+
+  it('the real registration resolves --yolo to dangerouslySkipPermissions', () => {
+    expect(
+      buildProgram().parse(['node', 'x', '--yolo']).opts()
+        .dangerouslySkipPermissions,
+    ).toBe(true)
+    expect(
+      buildProgram().parse(['node', 'x', '--dangerously-skip-permissions']).opts()
+        .dangerouslySkipPermissions,
+    ).toBe(true)
+    expect(
+      buildProgram().parse(['node', 'x']).opts().dangerouslySkipPermissions,
+    ).toBeUndefined()
+  })
+
+  // Regression guard for the six correctness bugs the old pre-parse argv rewrite
+  // caused: --yolo must reach commander untouched, whatever position it sits in
+  // (after a value flag, after `--`, or on a subcommand), so commander — not a
+  // hand-rolled scanner — resolves it.
+  it.each([
+    [['--yolo', '-p', 'hi']],
+    [['--system-prompt', '--yolo']],
+    [['-p', '--', '--yolo']],
+    [['mcp', 'add', '--yolo', 'srv', 'cmd']],
+  ])('passes %j through to cliMain verbatim', async argv => {
+    process.argv = ['node', 'openclaude', ...argv]
+    let argvSeenByCliMain: string[] | undefined
+    mockCliMain.mockImplementationOnce(async () => {
+      argvSeenByCliMain = [...process.argv]
+    })
+
+    await runCliEntrypoint(argv, options)
+
+    expect(argvSeenByCliMain).toEqual(['node', 'openclaude', ...argv])
+  })
+
+  it('does not mutate the host process.argv (no leak of a caller args array)', async () => {
+    // main() must not push an explicit args array into the process-global argv:
+    // cliMain reads the real process.argv, and leaking a caller's args (e.g. a
+    // bypass flag) into it would corrupt an overlapping call or the host.
+    const hostArgv = ['node', 'openclaude', 'host-arg']
+    process.argv = [...hostArgv]
+    await runCliEntrypoint(['--yolo', '-p', 'hi'], options)
+    // Assert cliMain actually ran: an early return before it would leave argv
+    // untouched for the wrong reason and pass this vacuously. The it.each above
+    // is self-protecting (it asserts a value the mock writes); this is not.
+    expect(mockCliMain).toHaveBeenCalledTimes(1)
+    expect(process.argv).toEqual(hostArgv)
+  })
+
+  it('the built CLI lists --yolo on the main command help (live registration)', async () => {
+    // Behavioral proof the alias is registered on the real main command — not
+    // dead code or the wrong command: commander only prints an option in --help
+    // if it is actually registered. --help short-circuits before any startup.
+    const fs = await import('node:fs')
+    const path = await import('node:path')
+    const cliPath = path.resolve(import.meta.dir, '../../dist/cli.mjs')
+    // Fail loudly (don't silently skip) if the build artifact is missing.
+    expect(fs.existsSync(cliPath)).toBe(true)
+    // The describe's beforeAll sets OPENCLAUDE_DISABLE_CLI_ENTRYPOINT_AUTO_RUN=1
+    // to keep main() from auto-running in-process; the child must NOT inherit it
+    // or the entrypoint never runs and prints nothing.
+    const childEnv: Record<string, string | undefined> = {
+      ...process.env,
+      OPENCLAUDE_DISABLE_TELEMETRY: '1',
+    }
+    delete childEnv.OPENCLAUDE_DISABLE_CLI_ENTRYPOINT_AUTO_RUN
+    const help = (args: string[]) => {
+      const out = Bun.spawnSync(['node', cliPath, ...args], {
+        // COLUMNS is pinned because the assertions below match the flags column
+        // verbatim: the child inherits the runner's terminal width, and a narrow
+        // CI terminal would wrap the 41-character flag string and fail this for
+        // reasons unrelated to whether the option is registered.
+        env: { ...childEnv, COLUMNS: '200' },
+        timeout: 30_000,
+      })
+      return {
+        exitCode: out.exitCode,
+        text: `${out.stdout.toString()}${out.stderr.toString()}`,
+      }
+    }
+    // The alias is live on the MAIN command (commander only prints a registered
+    // option in --help). Deliberately not asserting `open --help` / `ssh --help`
+    // here: DIRECT_CONNECT and SSH_REMOTE are compiled out of the default build,
+    // so those render the ROOT help and the assertion would pass even for a
+    // nonsense subcommand — i.e. it would prove nothing. Their registrations are
+    // covered structurally below and behaviourally in sshPreParse.test.ts.
+    const { exitCode, text } = help(['--yolo', '--help'])
+    expect(exitCode).toBe(0)
+    expect(text).not.toContain('unknown option')
+    expect(text).toContain('--yolo, --dangerously-skip-permissions')
+    // Guard the reasoning above: if these commands ever ship enabled, revisit.
+    // The negative match is only meaningful while commander still renders a
+    // Commands: section with two-space subcommand indentation, so that shape is
+    // asserted first — otherwise a formatting change would silently retire this
+    // canary, and the TEMPORARY source-text guard below depends on it firing.
+    const rootHelp = help(['--help']).text
+    expect(rootHelp).toContain('Commands:')
+    expect(rootHelp).toMatch(/^ {2}agents /m) // a command known to ship enabled
+    expect(rootHelp).not.toMatch(/^ {2}(open|ssh)(\s|\|)/m)
+  }, 120_000)
+
+  it('routes skills subcommands with --yolo exactly like the canonical flag', () => {
+    // The alias is in SKILLS_GLOBAL_BOOLEAN_FLAGS so the skills pre-parsers skip
+    // it; dropping it there fails at RUNTIME with `Unknown skills option:
+    // --yolo`, which no type check catches. Spawned rather than unit-tested
+    // because getSkillsCliArgs is not exported — this exercises the real
+    // routing, both pre-parsers included.
+    const cli = join(import.meta.dir, '..', '..', 'dist', 'cli.mjs')
+    // Isolated home/config: without this the child resolves the runner's real
+    // settings and installed skills, so both the `Skills:` header and the parity
+    // comparison of two full outputs depend on host state unrelated to --yolo.
+    const home = mkdtempSync(join(tmpdir(), 'oc-skills-'))
+    const env: Record<string, string | undefined> = {
+      ...process.env,
+      HOME: home,
+      USERPROFILE: home,
+      XDG_CONFIG_HOME: join(home, '.config'),
+      CLAUDE_CONFIG_DIR: join(home, '.claude'),
+      OPENCLAUDE_DISABLE_TELEMETRY: '1',
+      COLUMNS: '200',
+    }
+    delete env.OPENCLAUDE_DISABLE_CLI_ENTRYPOINT_AUTO_RUN
+    // Memoised: the parity loop below asks for the same argv repeatedly, and each
+    // spawn is ~1.5s.
+    const cache = new Map<string, string>()
+    const run = (args: string[]) => {
+      const key = args.join(' ')
+      const hit = cache.get(key)
+      if (hit !== undefined) return hit
+      const out = Bun.spawnSync(['node', cli, ...args], { env, timeout: 30_000 })
+      const text = `${out.stdout.toString()}${out.stderr.toString()}`
+      cache.set(key, text)
+      return text
+    }
+    const output = run
+
+    try {
+      // leading and trailing positions both route to the skills handler
+      expect(output(['--yolo', 'skills', 'list'])).toContain('Skills:')
+      expect(output(['skills', 'list', '--yolo'])).toContain('Skills:')
+      expect(output(['--yolo', 'skills', 'list'])).not.toContain('Unknown skills')
+      expect(output(['skills', 'list', '--yolo'])).not.toContain('Unknown skills')
+
+      // The alias must behave EXACTLY like the flag it aliases, in every position
+      // — including the one neither supports. A global boolean between `skills`
+      // and its subcommand is rejected for the whole set (--verbose, --bare, --ide
+      // …), so this pins parity rather than a fix for that pre-existing gap.
+      for (const position of [
+        (f: string) => [f, 'skills', 'list'],
+        (f: string) => ['skills', 'list', f],
+        (f: string) => ['skills', f, 'list'],
+      ]) {
+        expect(output(position('--yolo'))).toBe(
+          // replaceAll, not replace: an output naming the canonical flag twice
+          // (an error line plus a usage line, say) would otherwise keep the
+          // second occurrence and fail for a reason unrelated to alias parity.
+          output(position('--dangerously-skip-permissions')).replaceAll(
+            '--dangerously-skip-permissions',
+            '--yolo',
+          ),
+        )
+      }
+    } finally {
+      // Always: an assertion throwing above would otherwise leave the
+      // mkdtemp directory behind for the life of the machine.
+      rmSync(home, { recursive: true, force: true })
+    }
+  }, 120_000)
+
+  it('has no raw --print token scans left in main.tsx (PR #1939 review P1)', async () => {
+    // `openclaude ssh host -- --print` is deliberately NOT headless, and the
+    // ssh flow rewrites argv to a literal `-- --print` positional. Any gate
+    // that decides print mode by scanning tokens sees that positional and takes
+    // the local print path instead of opening the interactive remote session.
+    // Every such gate must ask commander (resolvesPrintMode), which honours the
+    // end-of-options boundary — and bundled shorts like `-pv`.
+    //
+    // This is a source guard because SSH_REMOTE and DIRECT_CONNECT are absent
+    // from scripts/build.ts's featureFlags map, so they compile to `false` with
+    // no opt-in: the rewritten-argv path cannot be reached through dist/cli.mjs
+    // at all. Behavioural coverage lives at the parseSshFlags boundary in
+    // utils/sshPreParse.test.ts.
+    // Covers every startup path that decides print mode, not just main.tsx:
+    // interactivity/earlyInput/providerValidation/gracefulShutdown all see the
+    // rewritten argv too, and a scan in any of them reintroduces the misroute.
+    const files = [
+      '../main.tsx',
+      '../utils/interactivity.ts',
+      '../utils/earlyInput.ts',
+      '../utils/providerValidation.ts',
+      '../utils/gracefulShutdown.ts',
+    ]
+    // Scanned per file, never concatenated: a joined blob made the reported
+    // line number an offset into it, so a failure pointed at a line that exists
+    // in no file, and a set-wide `toContain` passed as long as any one file kept
+    // its gate.
+    const sources = new Map<string, string>()
+    for (const rel of files) {
+      sources.set(rel, await Bun.file(`${import.meta.dir}/${rel}`).text())
+    }
+    const rawScans = [...sources.entries()]
+      .flatMap(([rel, text]) =>
+        text
+          .split(/\r?\n/)
+          .map((line, i) => [`${rel}:${i + 1}`, line] as const),
+      )
+      .filter(([, line]) =>
+        // Any shape of token comparison, not just the two that existed:
+        // .includes(), .indexOf() !== -1, .some()/.find() with ===, a bare
+        // === / !== against the literal, or a `case '-p':`.
+        [
+          /\.(includes|indexOf|lastIndexOf)\(\s*'(-p|--print|--init-only|--sdk-url)'\s*\)/,
+          /\.(some|find|findIndex|filter)\([^)]*(===|!==|startsWith)\s*\(?\s*'(-p|--print|--init-only|--sdk-url)'/,
+          /(===|!==)\s*'(-p|--print|--init-only|--sdk-url)'/,
+          /case\s+'(-p|--print|--init-only|--sdk-url)'\s*:/,
+        ].some(re => re.test(line)),
+      )
+    expect(rawScans.map(([where, line]) => `${where}  ${line.trim()}`)).toEqual([])
+    // …and EVERY file still consults commander. Asserted per file: against the
+    // concatenated text these passed as long as any one file kept its gate, so
+    // deleting the gate in (say) earlyInput.ts tripped neither this nor the
+    // raw-scan filter above — the very misroute this test exists to prevent.
+    // Collected rather than asserted per iteration, so a failure names the files
+    // that lost their gate instead of only reporting the missing substring.
+    // Either entry point counts — both resolve through commander. Callers that
+    // need more than print mode use resolvesHeadlessFlags (which also covers
+    // --init-only and --sdk-url); resolvesPrintMode is the thin wrapper.
+    const withoutGate = [...sources.entries()]
+      .filter(([, text]) => !/resolves(PrintMode|HeadlessFlags)\(/.test(text))
+      .map(([rel]) => rel)
+    expect(withoutGate).toEqual([])
+
+    // Same reasoning for the remote-session bypass guards: DIRECT_CONNECT and
+    // SSH_REMOTE compile out, so the wiring cannot be exercised at runtime. The
+    // helpers themselves are unit-tested in mainCliOptions.test.ts; these pin
+    // that main.tsx actually calls all three (flag, --permission-mode, and the
+    // resolved-mode backstop that covers settings `permissions.defaultMode`).
+    const mainOnly = sources.get('../main.tsx')!
+    expect(mainOnly).toContain('localDangerouslySkipPermissions(')
+    expect(mainOnly).toContain('localPermissionModeCli(')
+    expect(mainOnly).toContain('localResolvedPermissionMode(')
+
+    // The ssh headless rejection must sit OUTSIDE the host check: print shorts
+    // are not ssh-side options, so `ssh -p host` leaves the host unbound and an
+    // inside-the-check guard is skipped entirely, falling through to the local
+    // print path with the trust dialog skipped.
+    // Both indices asserted: -1 from either would slice from the end of the
+    // file and leave the ordering assertion comparing literals found anywhere
+    // later — reporting a pass while the guard sits back inside the host check.
+    const sshStart = mainOnly.indexOf('const parsed = parseSshFlags(rawCliArgs)')
+    const sshEnd = mainOnly.indexOf('_pendingSSH.host = parsed.host')
+    expect(sshStart).toBeGreaterThan(-1)
+    expect(sshEnd).toBeGreaterThan(sshStart)
+    const sshBlock = mainOnly.slice(sshStart, sshEnd)
+    expect(sshBlock).toContain('if (parsed.headless)')
+    expect(sshBlock.indexOf('if (parsed.headless)')).toBeLessThan(
+      sshBlock.indexOf('if (parsed.host !== undefined)'),
+    )
+
+    // The remote-bypass warning must be fed per PATH, from every source that
+    // reaches THAT remote. `cc://` forwards the request itself (all three
+    // doors, settings included); ssh forwards only what its own argv resolved,
+    // which is invisible locally — `ssh --yolo host` claims the flag for the
+    // remote and forwards nothing, so the local option is unset.
+    const ccStart = mainOnly.indexOf('const ccRemoteBypass =')
+    const ccEnd = mainOnly.indexOf('const sshRemoteBypass =')
+    expect(ccStart).toBeGreaterThan(-1)
+    expect(ccEnd).toBeGreaterThan(ccStart)
+    expect(mainOnly.slice(ccStart, ccEnd)).toContain('remoteBypassRequested')
+
+    // and remoteBypassRequested itself covers all three doors
+    const reqStart = mainOnly.indexOf('const remoteBypassRequested =')
+    const reqEnd = mainOnly.indexOf(';', reqStart)
+    expect(reqStart).toBeGreaterThan(-1)
+    expect(reqEnd).toBeGreaterThan(reqStart)
+    const request = mainOnly.slice(reqStart, reqEnd)
+    expect(request).toContain('dangerouslySkipPermissions')
+    expect(request).toContain('permissionModeCli')
+    expect(request).toContain('permissionModeFromCLI')
+
+    // ssh must NOT inherit the cc:// term: a settings-derived dangerous mode is
+    // forwarded by createDirectConnectSession but never by the ssh launch
+    // contract, so counting it for ssh claims a bypass the remote never got.
+    // Anchored on the CALL, not the bare name: `setRemoteBypassPermissions`
+    // also appears in the import list at the top of the file, so indexOf found
+    // that first and produced an empty slice that asserted nothing.
+    const sshTermStart = mainOnly.indexOf('const sshRemoteBypass =')
+    const sshTermEnd = mainOnly.indexOf(
+      'setRemoteBypassPermissions(ccRemoteBypass',
+    )
+    expect(sshTermStart).toBeGreaterThan(-1)
+    expect(sshTermEnd).toBeGreaterThan(sshTermStart)
+    const sshTerm = mainOnly.slice(sshTermStart, sshTermEnd)
+    expect(sshTerm).not.toContain('remoteBypassRequested')
+    expect(sshTerm).toContain('_pendingSSH?.dangerouslySkipPermissions')
+    expect(sshTerm).toContain('_pendingSSH?.permissionMode')
+  })
+
+  it('lists both spellings in the published web flag reference', async () => {
+    // web/ has no test runner (only `astro check` / `astro build`), so this is
+    // asserted from here rather than introducing a framework to that package.
+    // Read as text, not imported: web/ is outside this tsconfig's rootDir, and
+    // importing it fails typecheck with TS6059.
+    const webFlags = await Bun.file(
+      `${import.meta.dir}/../../web/src/data/cliFlags.ts`,
+    ).text()
+
+    // the documented entry names both spellings, in the order commander uses
+    // (alias first, canonical last — see BYPASS_PERMISSIONS_FLAGS)
+    expect(webFlags).toContain(
+      "flag: '--yolo, --dangerously-skip-permissions'",
+    )
+    // …and the separate --allow- flag is still documented on its own
+    expect(webFlags).toContain("flag: '--allow-dangerously-skip-permissions'")
+    // no stray entry documents the bare canonical flag on its own
+    expect(webFlags).not.toContain("flag: '--dangerously-skip-permissions'")
+  })
+
+  it('registers --yolo via .option() on the main command, ssh, and open subcommands', async () => {
+    // Supplementary structural guard (the executable --help test above is the
+    // primary proof): each occurrence must be a real .option() registration.
+    //
+    // TEMPORARY: source-text matching is a stand-in for coverage that cannot
+    // exist yet. SSH_REMOTE and DIRECT_CONNECT are absent from the featureFlags
+    // map in scripts/build.ts, so feature() compiles them to false and neither
+    // subcommand is reachable in dist/cli.mjs. The moment either flag ships
+    // enabled, replace this with behavioural `ssh --help` / `open --help`
+    // assertions — the `expect(help(['--help']).text).not.toMatch(/^ {2}(open|ssh) /m)`
+    // guard in the test above fails when that happens, so it cannot go unnoticed.
+    // The main-command option lives in mainCliOptions.ts (applyMainOptions,
+    // reused by the ssh pre-parser); ssh + open subcommands are in main.tsx.
+    const mainSrc = await Bun.file(`${import.meta.dir}/../main.tsx`).text()
+    const optsSrc = await Bun.file(`${import.meta.dir}/../mainCliOptions.ts`).text()
+    // All four sites now register via the shared BYPASS_PERMISSIONS_FLAGS
+    // constant, so match either that identifier or an inline literal — the
+    // exact string it holds is pinned in mainCliOptions.test.ts.
+    const registration =
+      /\.option\(\s*(BYPASS_PERMISSIONS_FLAGS|'--yolo, --dangerously-skip-permissions')/
+    // Per-command assertions rather than a total count, so adding a fourth
+    // registration elsewhere doesn't break this guard.
+    expect(optsSrc).toMatch(registration) // main command (applyMainOptions)
+    // …and the constant really is the flags string (not, say, re-pointed at a
+    // different option), so matching the identifier above still proves the
+    // right flag is registered.
+    expect(optsSrc).toMatch(
+      /export const BYPASS_PERMISSIONS_FLAGS\s*=\s*'--yolo, --dangerously-skip-permissions' as const/,
+    )
+    // For the subcommands, check the registration sits inside that command's
+    // own `.command('…')` statement. NB: `ssh --help` renders the ROOT help
+    // (the ssh registration exists only so the command is listed), so a --help
+    // assertion would silently re-test the main command — hence source checks.
+    const commandStatement = (name: string) => {
+      const start = mainSrc.indexOf(`program.command('${name}`)
+      expect(start).toBeGreaterThan(-1)
+      // Without this, a missing `.action(` yields -1 and slice(start, -1)
+      // spans the rest of the file — the regex would then match a DIFFERENT
+      // command's registration and the guard would pass vacuously.
+      const end = mainSrc.indexOf('.action(', start)
+      expect(end).toBeGreaterThan(start)
+      return mainSrc.slice(start, end)
+    }
+    expect(commandStatement('ssh <host> [dir]')).toMatch(registration)
+    expect(commandStatement('open <cc-url>')).toMatch(registration)
+    // `ssh --yolo` is parsed by the ssh pre-parser (parseSshFlags), which reuses
+    // the main option arities; its handling has runtime tests in
+    // utils/sshPreParse.test.ts.
+    expect(mainSrc).toContain('parseSshFlags(rawCliArgs)')
   })
 })

--- a/src/entrypoints/cli.tsx
+++ b/src/entrypoints/cli.tsx
@@ -1,3 +1,7 @@
+import {
+  SKILLS_GLOBAL_BOOLEAN_FLAGS,
+  SKILLS_PROMPT_MODE_FLAGS,
+} from '../cli/skillsBooleanFlags.js';
 import { feature } from 'bun:bundle';
 
 // Defensive compatibility guard for environments where globalThis.File is
@@ -38,28 +42,6 @@ process.env.CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS ??= 'true'
 // eslint-disable-next-line custom-rules/no-top-level-side-effects
 process.env.COREPACK_ENABLE_AUTO_PIN = '0';
 
-const SKILLS_LEADING_BOOLEAN_FLAGS = new Set([
-  '--bare',
-  '--debug',
-  '--debug-to-stderr',
-  '--dangerously-skip-permissions',
-  '--allow-dangerously-skip-permissions',
-  '--disable-slash-commands',
-  '--enable-auth-status',
-  '--fork-session',
-  '--ide',
-  '--include-hook-events',
-  '--include-partial-messages',
-  '--init',
-  '--init-only',
-  '--maintenance',
-  '--mcp-debug',
-  '--no-chrome',
-  '--no-session-persistence',
-  '--replay-user-messages',
-  '--strict-mcp-config',
-  '--verbose',
-])
 
 const SKILLS_LEADING_VALUE_FLAGS = new Set([
   '--agent',
@@ -91,15 +73,7 @@ const SKILLS_LEADING_VALUE_FLAGS = new Set([
   '--name',
 ])
 
-const SKILLS_LEADING_OPTIONAL_VALUE_FLAGS = new Set([
-  '--continue',
-  '--from-pr',
-  '--print',
-  '-c',
-  '-p',
-  '-r',
-  '--resume',
-])
+
 
 const SKILLS_LEADING_MULTI_VALUE_FLAGS = new Set([
   '--add-dir',
@@ -132,7 +106,7 @@ function getSkillsCliArgs(args: string[]): SkillsCliParseResult | undefined {
       }
       return { additionalDirectories, args: args.slice(index) }
     }
-    if (SKILLS_LEADING_BOOLEAN_FLAGS.has(arg)) {
+    if (SKILLS_GLOBAL_BOOLEAN_FLAGS.has(arg)) {
       continue
     }
     if (SKILLS_LEADING_MULTI_VALUE_FLAGS.has(arg)) {
@@ -186,7 +160,7 @@ function getSkillsCliArgs(args: string[]): SkillsCliParseResult | undefined {
     ) {
       continue
     }
-    if (SKILLS_LEADING_OPTIONAL_VALUE_FLAGS.has(arg)) {
+    if (SKILLS_PROMPT_MODE_FLAGS.has(arg)) {
       sawPromptModeFlag = true
       if (
         args[index + 1] &&
@@ -198,7 +172,7 @@ function getSkillsCliArgs(args: string[]): SkillsCliParseResult | undefined {
       continue
     }
     if (
-      Array.from(SKILLS_LEADING_OPTIONAL_VALUE_FLAGS).some(flag =>
+      Array.from(SKILLS_PROMPT_MODE_FLAGS).some(flag =>
         arg?.startsWith(`${flag}=`),
       )
     ) {
@@ -311,6 +285,28 @@ export async function main(
   args: string[] = process.argv.slice(2),
   options: CliEntrypointOptions = {},
 ): Promise<void> {
+  // --yolo is registered as a native commander alias of
+  // --dangerously-skip-permissions: on the main command in applyMainOptions
+  // (mainCliOptions.ts), and on the `ssh`/`open` stubs in main.tsx. commander
+  // resolves it and all opts().dangerouslySkipPermissions
+  // reads work unchanged — cc://, the ssh line, and the bypass safety notice are
+  // all commander-authoritative, so there are no raw-argv bypass scanners.
+  //
+  // Both spellings are listed in exactly one place: the shared
+  // SKILLS_GLOBAL_BOOLEAN_FLAGS set in src/cli/skillsBooleanFlags.ts, which the
+  // skills fast-path pre-parse below and its counterpart in skillsCli.ts both
+  // consume — and that set is purely for `skills` routing (skipping flags around
+  // the subcommand), not bypass detection.
+  //
+  // main() does NOT mirror the caller's `args` array onto process.argv for the
+  // general cliMain flow: cliMain() parses the global process.argv, and the sole
+  // production entry (the auto-run at the tail of this file) calls main() with no
+  // args, so `args` already equals process.argv.slice(2). Keeping a caller's args
+  // out of the process-global argv avoids leaking a programmatic invocation's
+  // arguments (including a permission-bypass flag) into an overlapping call or
+  // the host process. (The `skills` and `--update` fast-paths below do rewrite
+  // process.argv, but only to re-route to their own subcommand, not to inject the
+  // caller's args.)
   const bgSessionsEnabled = isBgSessionsEnabled(options)
   const importers = getCliEntrypointImporters(options.importers)
   let reapplyProviderEnvFileValues = () => {}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -19,7 +19,8 @@ import { ensureKeychainPrefetchCompleted, startKeychainPrefetch } from './utils/
 // eslint-disable-next-line custom-rules/no-top-level-side-effects
 startKeychainPrefetch();
 import { feature } from 'bun:bundle';
-import { Command as CommanderCommand, InvalidArgumentError, Option } from '@commander-js/extra-typings';
+import { Command as CommanderCommand, Option } from '@commander-js/extra-typings';
+import { applyMainOptions, BYPASS_PERMISSIONS_FLAGS, localDangerouslySkipPermissions, localPermissionModeCli, localResolvedPermissionMode, resolvesPrintMode } from './mainCliOptions.js';
 import chalk from 'chalk';
 import { readFileSync } from 'fs';
 import mapValues from 'lodash-es/mapValues.js';
@@ -27,6 +28,7 @@ import pickBy from 'lodash-es/pickBy.js';
 import uniqBy from 'lodash-es/uniqBy.js';
 import React from 'react';
 import { getOauthConfig } from './constants/oauth.js';
+import { parseSshFlags } from './utils/sshPreParse.js';
 import { getRemoteSessionUrl } from './constants/product.js';
 import { getSystemContext, getUserContext } from './context.js';
 import { init, initializeTelemetryAfterTrust } from './entrypoints/init.js';
@@ -122,7 +124,7 @@ import { logError } from './utils/log.js';
 import { getModelDeprecationWarning } from './utils/model/deprecation.js';
 import { getDefaultMainLoopModel, getUserSpecifiedModelSetting, normalizeModelStringForAPI, parseUserSpecifiedModel } from './utils/model/model.js';
 import { ensureModelStringsInitialized } from './utils/model/modelStrings.js';
-import { PERMISSION_MODES } from './utils/permissions/PermissionMode.js';
+import { isDangerousPermissionMode, PERMISSION_MODES, type PermissionMode } from './utils/permissions/PermissionMode.js';
 import { checkAndDisableBypassPermissions, getAutoModeEnabledStateIfCached, initializeToolPermissionContext, initialPermissionModeFromCLI, isDefaultPermissionModeAuto, parseToolListFromCLI, stripDangerousPermissionsForAutoMode, verifyAutoModeGateAccess } from './utils/permissions/permissionSetup.js';
 import { cleanupOrphanedPluginVersionsInBackground } from './utils/plugins/cacheUtils.js';
 import { initializeVersionedPlugins } from './utils/plugins/installedPluginsManager.js';
@@ -163,11 +165,11 @@ import { gracefulShutdown, gracefulShutdownSync } from 'src/utils/gracefulShutdo
 import { setAllHookEventsEnabled } from 'src/utils/hooks/hookEvents.js';
 import { refreshModelCapabilities } from 'src/utils/model/modelCapabilities.js';
 import { peekForStdinData, writeToStderr } from 'src/utils/process.js';
-import { createHeadlessHeartbeat, parseHeadlessHeartbeatDuration, validateHeadlessHeartbeatPrintMode } from 'src/cli/headlessHeartbeat.js';
+import { createHeadlessHeartbeat, validateHeadlessHeartbeatPrintMode } from 'src/cli/headlessHeartbeat.js';
 import { setCwd } from 'src/utils/Shell.js';
 import { type ProcessedResume, processResumedConversation } from 'src/utils/sessionRestore.js';
 import { plural } from 'src/utils/stringUtils.js';
-import { type ChannelEntry, getInitialMainLoopModel, getIsNonInteractiveSession, getSdkBetas, getSessionId, getUserMsgOptIn, setAllowedChannels, setChromeFlagOverride, setClientType, setCwdState, setDirectConnectServerUrl, setInitialMainLoopModel, setInlinePlugins, setIsInteractive, setKairosActive, setOriginalCwd, setQuestionPreviewFormat, setSdkBetas, setSessionBypassPermissionsMode, setSessionDangerousPermissionMode, setSessionPersistenceDisabled, setSessionSource, setUserMsgOptIn, switchSession } from './bootstrap/state.js';
+import { type ChannelEntry, getInitialMainLoopModel, getIsNonInteractiveSession, getSdkBetas, getSessionId, getUserMsgOptIn, setAllowedChannels, setChromeFlagOverride, setClientType, setCwdState, setDirectConnectServerUrl, setInitialMainLoopModel, setInlinePlugins, setIsInteractive, setKairosActive, setOriginalCwd, setQuestionPreviewFormat, setSdkBetas, getRemoteBypassPermissions, setRemoteBypassPermissions, setSessionBypassPermissionsMode, setSessionDangerousPermissionMode, setSessionPersistenceDisabled, setSessionSource, setUserMsgOptIn, switchSession } from './bootstrap/state.js';
 
 /* eslint-disable @typescript-eslint/no-require-imports */
 const autoModeStateModule = feature('TRANSCRIPT_CLASSIFIER') ? require('./utils/permissions/autoModeState.js') as typeof import('./utils/permissions/autoModeState.js') : null;
@@ -512,12 +514,10 @@ function initializeEntrypoint(isNonInteractive: boolean): void {
 type PendingConnect = {
   url: string | undefined;
   authToken: string | undefined;
-  dangerouslySkipPermissions: boolean;
 };
 const _pendingConnect: PendingConnect | undefined = feature('DIRECT_CONNECT') ? {
   url: undefined,
-  authToken: undefined,
-  dangerouslySkipPermissions: false
+  authToken: undefined
 } : undefined;
 
 // Set by early argv processing when `claude assistant [sessionId]` is detected
@@ -569,7 +569,24 @@ export async function main() {
     // In print mode, print.ts registers its own SIGINT handler that aborts
     // the in-flight query and calls gracefulShutdown; skip here to avoid
     // preempting it with a synchronous process.exit().
-    if (process.argv.includes('-p') || process.argv.includes('--print')) {
+    // Commander-authoritative: after the ssh rewrite argv can hold a literal
+    // `-- --print` positional, which a token scan would misread as print mode.
+    //
+    // Guarded like the handler in gracefulShutdown.ts, and for a sharper reason:
+    // this listener is registered FIRST, and Node's EventEmitter is synchronous,
+    // so a throw here would stop the later (guarded) listener from ever running
+    // and turn Ctrl-C into a silent no-op.
+    //
+    // resolvesHeadlessFlags guards its own config read and option-set
+    // construction, so this is a second layer that should never fire — kept
+    // because of that asymmetry, not because the callee is unguarded.
+    let isPrintMode = false;
+    try {
+      isPrintMode = resolvesPrintMode(process.argv.slice(2));
+    } catch {
+      // fall through to process.exit(0)
+    }
+    if (isPrintMode) {
       return;
     }
     process.exit(0);
@@ -588,25 +605,33 @@ export async function main() {
         parseConnectUrl
       } = await import('./server/parseConnectUrl.js');
       const parsed = parseConnectUrl(ccUrl);
-      _pendingConnect.dangerouslySkipPermissions = rawCliArgs.includes('--dangerously-skip-permissions');
-      if (rawCliArgs.includes('-p') || rawCliArgs.includes('--print')) {
+      // Only the cc:// URL is stripped here; the argv is otherwise untouched.
+      // The --dangerously-skip-permissions / --yolo flag is left in place so
+      // commander — never a token scan — decides whether it is set: the `open`
+      // subcommand registers it on the headless path, and the main command does
+      // on the interactive one. Because that flag targets the REMOTE session,
+      // the interactive path forwards it to createDirectConnectSession but
+      // deliberately does NOT apply it to this local client's permission mode
+      // (see isPendingRemoteSession where the mode is computed).
+      const withoutCcUrl = rawCliArgs.filter((_, i) => i !== ccIdx);
+      // The headless-routing check runs before commander (it decides WHICH
+      // command parses), so it asks commander itself: that judges bundled
+      // shorts (`-pv`), `-- --print` positionals and value positions exactly as
+      // the real parse will, unlike a token scan.
+      // Judge the same token list the branches actually parse (both use
+      // withoutCcUrl), so the routing decision can't diverge from the real parse.
+      if (resolvesPrintMode(withoutCcUrl)) {
         // Headless: rewrite to internal `open` subcommand
-        const stripped = rawCliArgs.filter((_, i) => i !== ccIdx);
-        const dspIdx = stripped.indexOf('--dangerously-skip-permissions');
-        if (dspIdx !== -1) {
-          stripped.splice(dspIdx, 1);
-        }
-        process.argv = [process.argv[0]!, process.argv[1]!, 'open', ccUrl, ...stripped];
+        process.argv = [process.argv[0]!, process.argv[1]!, 'open', ccUrl, ...withoutCcUrl];
       } else {
-        // Interactive: strip cc:// URL and flags, run main command
+        // Interactive: only the cc:// URL is dropped — nothing claims or
+        // rewrites the bypass flag. It stays in argv so the main command's
+        // parse resolves it, is forwarded to the remote via
+        // createDirectConnectSession, and is excluded from THIS session's
+        // permission mode by localDangerouslySkipPermissions below.
         _pendingConnect.url = parsed.serverUrl;
         _pendingConnect.authToken = parsed.authToken;
-        const stripped = rawCliArgs.filter((_, i) => i !== ccIdx);
-        const dspIdx = stripped.indexOf('--dangerously-skip-permissions');
-        if (dspIdx !== -1) {
-          stripped.splice(dspIdx, 1);
-        }
-        process.argv = [process.argv[0]!, process.argv[1]!, ...stripped];
+        process.argv = [process.argv[0]!, process.argv[1]!, ...withoutCcUrl];
       }
     }
   }
@@ -675,95 +700,45 @@ export async function main() {
   // sessions need the local REPL to drive them (interrupt, permissions).
   if (feature('SSH_REMOTE') && _pendingSSH) {
     const rawCliArgs = process.argv.slice(2);
-    // SSH-specific flags can appear before the host positional (e.g.
-    // `ssh --permission-mode auto host /tmp` — standard POSIX flags-before-
-    // positionals). Pull them all out BEFORE checking whether a host was
-    // given, so `claude ssh --permission-mode auto host` and `claude ssh host
-    // --permission-mode auto` are equivalent. The host check below only needs
-    // to guard against `-h`/`--help` (which commander should handle).
     if (rawCliArgs[0] === 'ssh') {
-      const localIdx = rawCliArgs.indexOf('--local');
-      if (localIdx !== -1) {
-        _pendingSSH.local = true;
-        rawCliArgs.splice(localIdx, 1);
-      }
-      const dspIdx = rawCliArgs.indexOf('--dangerously-skip-permissions');
-      if (dspIdx !== -1) {
-        _pendingSSH.dangerouslySkipPermissions = true;
-        rawCliArgs.splice(dspIdx, 1);
-      }
-      const pmIdx = rawCliArgs.indexOf('--permission-mode');
-      if (pmIdx !== -1 && rawCliArgs[pmIdx + 1] && !rawCliArgs[pmIdx + 1]!.startsWith('-')) {
-        _pendingSSH.permissionMode = rawCliArgs[pmIdx + 1];
-        rawCliArgs.splice(pmIdx, 2);
-      }
-      const pmEqIdx = rawCliArgs.findIndex(a => a.startsWith('--permission-mode='));
-      if (pmEqIdx !== -1) {
-        _pendingSSH.permissionMode = rawCliArgs[pmEqIdx]!.split('=')[1];
-        rawCliArgs.splice(pmEqIdx, 1);
-      }
-      // Forward session-resume + model flags to the remote CLI's initial spawn.
-      // --continue/-c and --resume <uuid> operate on the REMOTE session history
-      // (which persists under the remote's ~/.claude/projects/<cwd>/).
-      // --model controls which model the remote uses.
-      const extractFlag = (flag: string, opts: {
-        hasValue?: boolean;
-        as?: string;
-      } = {}) => {
-        const i = rawCliArgs.indexOf(flag);
-        if (i !== -1) {
-          _pendingSSH.extraCliArgs.push(opts.as ?? flag);
-          const val = rawCliArgs[i + 1];
-          if (opts.hasValue && val && !val.startsWith('-')) {
-            _pendingSSH.extraCliArgs.push(val);
-            rawCliArgs.splice(i, 2);
-          } else {
-            rawCliArgs.splice(i, 1);
-          }
-        }
-        const eqI = rawCliArgs.findIndex(a => a.startsWith(`${flag}=`));
-        if (eqI !== -1) {
-          _pendingSSH.extraCliArgs.push(opts.as ?? flag, rawCliArgs[eqI]!.slice(flag.length + 1));
-          rawCliArgs.splice(eqI, 1);
-        }
-      };
-      extractFlag('-c', {
-        as: '--continue'
-      });
-      extractFlag('--continue');
-      extractFlag('--resume', {
-        hasValue: true
-      });
-      extractFlag('--model', {
-        hasValue: true
-      });
-      extractFlag('--fallback-model', {
-        hasValue: true
-      });
-    }
-    // After pre-extraction, any remaining dash-arg at [1] is either -h/--help
-    // (commander handles) or an unknown-to-ssh flag (fall through to commander
-    // so it surfaces a proper error). Only a non-dash arg is the host.
-    if (rawCliArgs[0] === 'ssh' && rawCliArgs[1] && !rawCliArgs[1].startsWith('-')) {
-      _pendingSSH.host = rawCliArgs[1];
-      // Optional positional cwd.
-      let consumed = 2;
-      if (rawCliArgs[2] && !rawCliArgs[2].startsWith('-')) {
-        _pendingSSH.cwd = rawCliArgs[2];
-        consumed = 3;
-      }
-      const rest = rawCliArgs.slice(consumed);
-
-      // Headless (-p) mode is not supported with SSH in v1 — reject early
-      // so the flag doesn't silently cause local execution.
-      if (rest.includes('-p') || rest.includes('--print')) {
+      // Parse the ssh line with commander (see parseSshFlags): option arity,
+      // last-value, and the `--` marker are all handled by the parser, so
+      // flags-before-host (`ssh --permission-mode auto host`) and `ssh host
+      // --permission-mode auto` are equivalent.
+      const parsed = parseSshFlags(rawCliArgs);
+      // Headless (-p) mode is not supported with SSH in v1. Rejected OUTSIDE the
+      // host check on purpose: print shorts are not ssh-side options, so
+      // commander stops collecting operands at them and `ssh -p host` leaves the
+      // host unbound — inside the check, that line skipped the guard entirely and
+      // fell through to the LOCAL print path with the workspace trust dialog
+      // skipped. parsed.headless is commander-resolved, so a bundled `-pv` is
+      // caught (a raw scan missed it) and a `ssh host -- --print` positional
+      // correctly is not.
+      //
+      // Also before any _pendingSSH write, so module state stays untouched on the
+      // rejected path (gracefulShutdownSync only sets process.exitCode, so a
+      // future edit that keeps executing must not find a populated session).
+      if (parsed.headless) {
         process.stderr.write('Error: headless (-p/--print) mode is not supported with openclaude ssh\n');
         gracefulShutdownSync(1);
         return;
       }
+      // Only a real host triggers the ssh flow; otherwise (no host, `-h`,
+      // `--help`) fall through to commander's `ssh` usage action.
+      if (parsed.host !== undefined) {
 
-      // Rewrite argv so the main command sees remaining flags but not `ssh`.
-      process.argv = [process.argv[0]!, process.argv[1]!, ...rest];
+        _pendingSSH.host = parsed.host;
+        _pendingSSH.cwd = parsed.cwd;
+        _pendingSSH.local = parsed.local;
+        if (parsed.permissionMode !== undefined) {
+          _pendingSSH.permissionMode = parsed.permissionMode;
+        }
+        _pendingSSH.dangerouslySkipPermissions = parsed.dangerouslySkipPermissions;
+        _pendingSSH.extraCliArgs.push(...parsed.extraCliArgs);
+
+        // Rewrite argv so the main command sees the leftover flags but not `ssh`.
+        process.argv = [process.argv[0]!, process.argv[1]!, ...parsed.forwardToMain];
+      }
     }
   }
 
@@ -931,58 +906,10 @@ async function run(): Promise<CommanderCommand> {
     }
     profileCheckpoint('preAction_after_settings_sync');
   });
-  program.name('openclaude').description(`OpenClaude - starts an interactive session by default, use -p/--print for non-interactive output`).argument('[prompt]', 'Your prompt', String)
+  applyMainOptions(program.name('openclaude').description(`OpenClaude - starts an interactive session by default, use -p/--print for non-interactive output`).argument('[prompt]', 'Your prompt', String)
   // Subcommands inherit helpOption via commander's copyInheritedSettings —
   // setting it once here covers mcp, plugin, auth, and all other subcommands.
-  .helpOption('-h, --help', 'Display help for command').option('-d, --debug [filter]', 'Enable debug mode with optional category filtering (e.g., "api,hooks" or "!1p,!file")', (_value: string | true) => {
-    // If value is provided, it will be the filter string
-    // If not provided but flag is present, value will be true
-    // The actual filtering is handled in debug.ts by parsing process.argv
-    return true;
-  }).addOption(new Option('-d2e, --debug-to-stderr', 'Enable debug mode (to stderr)').argParser(Boolean).hideHelp()).option('--debug-file <path>', 'Write debug logs to a specific file path (implicitly enables debug mode)', () => true).option('--verbose', 'Override verbose mode setting from config', () => true).option('-p, --print', 'Print response and exit (useful for pipes). Note: The workspace trust dialog is skipped when Claude is run with the -p mode. Only use this flag in directories you trust.', () => true).addOption(new Option('--heartbeat <duration>', 'Emit a headless liveness heartbeat while output is quiet (only works with --print, e.g. 30s, 2m; pre-stream startup heartbeats use stderr)').argParser(value => {
-    try {
-      return parseHeadlessHeartbeatDuration(value);
-    } catch (error) {
-      throw new InvalidArgumentError(errorMessage(error));
-    }
-  })).option('--bare', 'Minimal mode: skip hooks, LSP, plugin sync, attribution, auto-memory, background prefetches, keychain reads, and CLAUDE.md auto-discovery. Sets CLAUDE_CODE_SIMPLE=1. Anthropic auth is strictly ANTHROPIC_API_KEY or apiKeyHelper via --settings (OAuth and keychain are never read). 3P providers (Bedrock/Vertex/Foundry) use their own credentials. Skills still resolve via /skill-name. Explicitly provide context via: --system-prompt[-file], --append-system-prompt[-file], --add-dir (CLAUDE.md dirs), --mcp-config, --settings, --agents, --plugin-dir.', () => true).addOption(new Option('--init', 'Run Setup hooks with init trigger, then continue').hideHelp()).addOption(new Option('--init-only', 'Run Setup and SessionStart:startup hooks, then exit').hideHelp()).addOption(new Option('--maintenance', 'Run Setup hooks with maintenance trigger, then continue').hideHelp()).addOption(new Option('--output-format <format>', 'Output format (only works with --print): "text" (default), "json" (single result), or "stream-json" (realtime streaming)').choices(['text', 'json', 'stream-json'])).addOption(new Option('--json-schema <schema>', 'JSON Schema for structured output validation. ' + 'Example: {"type":"object","properties":{"name":{"type":"string"}},"required":["name"]}').argParser(String)).option('--include-hook-events', 'Include all hook lifecycle events in the output stream (only works with --output-format=stream-json)', () => true).option('--include-partial-messages', 'Include partial message chunks as they arrive (only works with --print and --output-format=stream-json)', () => true).addOption(new Option('--input-format <format>', 'Input format (only works with --print): "text" (default), or "stream-json" (realtime streaming input)').choices(['text', 'stream-json'])).option('--mcp-debug', '[DEPRECATED. Use --debug instead] Enable MCP debug mode (shows MCP server errors)', () => true).option('--dangerously-skip-permissions', 'Bypass all permission checks. Recommended only for sandboxes with no internet access.', () => true).option('--allow-dangerously-skip-permissions', 'Enable bypassing all permission checks as an option, without it being enabled by default. Recommended only for sandboxes with no internet access.', () => true).addOption(new Option('--thinking <mode>', 'Thinking mode: enabled (equivalent to adaptive), disabled').choices(['enabled', 'adaptive', 'disabled']).hideHelp()).addOption(new Option('--max-thinking-tokens <tokens>', '[DEPRECATED. Use --thinking instead for newer models] Maximum number of thinking tokens (only works with --print)').argParser(Number).hideHelp()).addOption(new Option('--max-turns <turns>', 'Maximum number of agentic turns in non-interactive mode. This will early exit the conversation after the specified number of turns. (only works with --print)').argParser(Number).hideHelp()).addOption(new Option('--max-budget-usd <amount>', 'Maximum dollar amount to spend on API calls (only works with --print)').argParser(value => {
-    const amount = Number(value);
-    if (isNaN(amount) || amount <= 0) {
-      throw new Error('--max-budget-usd must be a positive number greater than 0');
-    }
-    return amount;
-  })).addOption(new Option('--task-budget <tokens>', 'API-side task budget in tokens (output_config.task_budget)').argParser(value => {
-    const tokens = Number(value);
-    if (isNaN(tokens) || tokens <= 0 || !Number.isInteger(tokens)) {
-      throw new Error('--task-budget must be a positive integer');
-    }
-    return tokens;
-  }).hideHelp()).option('--replay-user-messages', 'Re-emit user messages from stdin back on stdout for acknowledgment (only works with --input-format=stream-json and --output-format=stream-json)', () => true).addOption(new Option('--enable-auth-status', 'Enable auth status messages in SDK mode').default(false).hideHelp()).option('--allowedTools, --allowed-tools <tools...>', 'Comma or space-separated list of tool names to allow (e.g. "Bash(git:*) Edit")').option('--tools <tools...>', 'Specify the list of available tools from the built-in set. Use "" to disable all tools, "default" to use all tools, or specify tool names (e.g. "Bash,Edit,Read").').option('--disallowedTools, --disallowed-tools <tools...>', 'Comma or space-separated list of tool names to deny (e.g. "Bash(git:*) Edit")').option('--mcp-config <configs...>', 'Load MCP servers from JSON files or strings (space-separated)').addOption(new Option('--permission-prompt-tool <tool>', 'MCP tool to use for permission prompts (only works with --print)').argParser(String).hideHelp()).addOption(new Option('--system-prompt <prompt>', 'System prompt to use for the session').argParser(String)).addOption(new Option('--system-prompt-file <file>', 'Read system prompt from a file').argParser(String).hideHelp()).addOption(new Option('--append-system-prompt <prompt>', 'Append a system prompt to the default system prompt').argParser(String)).addOption(new Option('--append-system-prompt-file <file>', 'Read system prompt from a file and append to the default system prompt').argParser(String).hideHelp()).addOption(new Option('--permission-mode <mode>', 'Permission mode to use for the session').argParser(String).choices(PERMISSION_MODES))
-  .option('-c, --continue', 'Continue the most recent conversation in the current directory', () => true)
-  .option('-r, --resume [value]', 'Resume a conversation by session ID, or open interactive picker with optional search term', value => value || true)
-  .option('--fork-session', 'When resuming, branch the conversation into a new session ID; does not create filesystem or worktree isolation (use with --resume or --continue)', () => true)
-  .addOption(new Option('--prefill <text>', 'Pre-fill the prompt input with text without submitting it').hideHelp()).addOption(new Option('--deep-link-origin', 'Signal that this session was launched from a deep link').hideHelp()).addOption(new Option('--deep-link-repo <slug>', 'Repo slug the deep link ?repo= parameter resolved to the current cwd').hideHelp()).addOption(new Option('--deep-link-last-fetch <ms>', 'FETCH_HEAD mtime in epoch ms, precomputed by the deep link trampoline').argParser(v => {
-    const n = Number(v);
-    return Number.isFinite(n) ? n : undefined;
-  }).hideHelp()).option('--from-pr [value]', 'Resume a session linked to a PR by PR number/URL, or open interactive picker with optional search term', value => value || true).option('--no-session-persistence', 'Disable session persistence - sessions will not be saved to disk and cannot be resumed (only works with --print)').addOption(new Option('--resume-session-at <message id>', 'When resuming, only messages up to and including the assistant message with <message.id> (use with --resume in print mode)').argParser(String).hideHelp()).addOption(new Option('--rewind-files <user-message-id>', 'Restore files to state at the specified user message and exit (requires --resume)').hideHelp())
-  // @[MODEL LAUNCH]: Update the example model ID in the --model help text.
-  .option('--model <model>', `Model for the current session. Provide an alias for the latest model (e.g. 'sonnet' or 'opus') or a model's full name (e.g. 'claude-sonnet-4-6').`).option('--provider <provider>', `AI provider to use (anthropic, openai, gemini, github, bedrock, vertex, ollama). Reads API keys from environment variables.`).addOption(new Option('--effort <level>', `Effort level for the current session (low, medium, high, xhigh, max, ultracode)`).argParser((rawValue: string) => {
-    const value = rawValue.toLowerCase();
-    const allowed = ['low', 'medium', 'high', 'xhigh', 'max', 'ultracode'];
-    if (!allowed.includes(value)) {
-      throw new InvalidArgumentError(`It must be one of: ${allowed.join(', ')}`);
-    }
-    return value;
-  })).option('--agent <agent>', `Agent for the current session. Overrides the 'agent' setting.`).option('--betas <betas...>', 'Beta headers to include in API requests (API key users only)').option('--fallback-model <model>', 'Enable automatic fallback to specified model when default model is overloaded').addOption(new Option('--workload <tag>', 'Workload tag for billing-header attribution (cc_workload). Process-scoped; set by SDK daemon callers that spawn subprocesses for cron work. (only works with --print)').hideHelp()).option('--settings <file-or-json>', 'Path to a settings JSON file or a JSON string to load additional settings from').option('--add-dir <directories...>', 'Additional directories to allow tool access to').option('--ide', 'Automatically connect to IDE on startup if exactly one valid IDE is available', () => true).option('--strict-mcp-config', 'Only use MCP servers from --mcp-config, ignoring all other MCP configurations', () => true).option('--session-id <uuid>', 'Use a specific session ID for the conversation (must be a valid UUID)').option('-n, --name <name>', 'Set a display name for this session (shown in /resume and terminal title)').option('--agents <json>', 'JSON object defining custom agents (e.g. \'{"reviewer": {"description": "Reviews code", "prompt": "You are a code reviewer"}}\')').option('--setting-sources <sources>', 'Comma-separated list of setting sources to load (user, project, local).')
-  // gh-33508: <paths...> (variadic) consumed everything until the next
-  // --flag. `claude --plugin-dir /path mcp add --transport http` swallowed
-  // `mcp` and `add` as paths, then choked on --transport as an unknown
-  // top-level option. Single-value + collect accumulator means each
-  // --plugin-dir takes exactly one arg; repeat the flag for multiple dirs.
-  .option('--plugin-dir <path>', 'Load plugins from a directory for this session only (repeatable: --plugin-dir A --plugin-dir B)', (val: string, prev: string[]) => [...prev, val], [] as string[]).option('--disable-slash-commands', 'Disable all skills', () => true).option('--chrome', 'Enable Claude in Chrome integration').option('--no-chrome', 'Disable Claude in Chrome integration').option('--file <specs...>', 'File resources to download at startup. Format: file_id:relative_path (e.g., --file file_abc:doc.txt file_def:img.png)')
-  // cli.tsx consumes --provider-env-file before provider resolution; this registration
-  // keeps Commander help and unknown-option handling aligned with that bootstrap path.
-  .option('--provider-env-file <path>', 'Load provider environment variables from a file before validation (repeatable; existing values win)', (val: string, prev: string[]) => [...prev, val], [] as string[]).action(async (prompt, options) => {
+  .helpOption('-h, --help', 'Display help for command')).action(async (prompt, options) => {
     profileCheckpoint('action_handler_start');
 
     // --bare = one-switch minimal mode. Sets SIMPLE so all the existing
@@ -1362,13 +1289,82 @@ async function run(): Promise<CommanderCommand> {
       const addendum = getTeammatePromptAddendum().TEAMMATE_SYSTEM_PROMPT_ADDENDUM;
       appendSystemPrompt = appendSystemPrompt ? `${appendSystemPrompt}\n\n${addendum}` : addendum;
     }
+    // Both remote paths run the tools elsewhere, so the bypass flag belongs to
+    // THAT session, not this local client: `cc://` forwards it via
+    // createDirectConnectSession, ssh via _pendingSSH.dangerouslySkipPermissions.
+    const isPendingRemoteSession =
+      (feature('DIRECT_CONNECT') && Boolean(_pendingConnect?.url)) ||
+      (feature('SSH_REMOTE') && Boolean(_pendingSSH?.host));
     const {
-      mode: permissionMode,
+      mode: permissionModeFromCLI,
       notification: permissionModeNotification
     } = initialPermissionModeFromCLI({
-      permissionModeCli,
-      dangerouslySkipPermissions
+      // Every door to bypass is shut for a remote session, not just the flag.
+      // Two are CLI-side and gated here so the resolver's notification stays
+      // coherent; the third (settings `permissions.defaultMode`) is computed
+      // inside the resolver and is neutralized by the backstop below.
+      // (Pre-existing gaps — only the flag was handled before this PR.)
+      permissionModeCli: localPermissionModeCli(
+        permissionModeCli,
+        isPendingRemoteSession
+      ),
+      dangerouslySkipPermissions: localDangerouslySkipPermissions(
+        dangerouslySkipPermissions,
+        isPendingRemoteSession
+      )
     });
+    // A dangerous --permission-mode is a bypass REQUEST, and for `cc://` the
+    // remote protocol can express it: dangerously_skip_permissions is the only
+    // permission field createDirectConnectSession takes. Dropping the mode
+    // locally (above) without translating it here meant the user asked for
+    // bypass and silently got a default-permission remote session.
+    // bypassPermissions and fullAccess are treated as equivalent throughout this
+    // codebase (isDangerousPermissionMode, setSessionBypassPermissionsMode, the
+    // root/sudo gate), so both map onto the single boolean.
+    // All three sources, not just the two CLI ones: permissionModeFromCLI is the
+    // mode the resolver produced BEFORE the backstop, and since both CLI inputs
+    // were already suppressed above, a dangerous value there can only have come
+    // from settings `permissions.defaultMode`. Without it, `cc://` with that
+    // setting downgraded the local mode, sent dangerouslySkipPermissions:false
+    // to the remote, and recorded no remote-bypass state — the user asked for
+    // bypass and got a default-permission session with no signal at all.
+    const remoteBypassRequested =
+      Boolean(dangerouslySkipPermissions) ||
+      isDangerousPermissionMode(permissionModeCli as PermissionMode | undefined) ||
+      isDangerousPermissionMode(permissionModeFromCLI);
+    // Backstop, whatever the source: this local client never runs bypassing.
+    const permissionMode = localResolvedPermissionMode(
+      permissionModeFromCLI,
+      isPendingRemoteSession
+    );
+    // …but the REMOTE executor may still run without consent, and the local mode
+    // no longer shows it. Record that separately so the UI can still warn — the
+    // notice reads the resolved local mode, which is now `default` here.
+    // Per PATH, not one shared predicate: what actually reaches each remote
+    // differs, and claiming bypass the remote never received is its own bug.
+    //
+    // `cc://` gets remoteBypassRequested itself — the same value passed to
+    // createDirectConnectSession below — so a settings-derived dangerous mode
+    // counts there precisely because it IS forwarded.
+    //
+    // ssh gets ONLY what the ssh pre-parse resolved from its own argv. The
+    // launch contract carries `_pendingSSH.permissionMode` and
+    // `.dangerouslySkipPermissions` and nothing else, so a local settings
+    // defaultMode never reaches the remote and must not be reported as if it
+    // had. Reading _pendingSSH also catches what is invisible locally:
+    // `ssh --yolo host` claims the flag for the remote and forwards nothing.
+    const ccRemoteBypass =
+      feature('DIRECT_CONNECT') &&
+      Boolean(_pendingConnect?.url) &&
+      remoteBypassRequested;
+    const sshRemoteBypass =
+      feature('SSH_REMOTE') &&
+      Boolean(_pendingSSH?.host) &&
+      (Boolean(_pendingSSH?.dangerouslySkipPermissions) ||
+        isDangerousPermissionMode(
+          _pendingSSH?.permissionMode as PermissionMode | undefined
+        ));
+    setRemoteBypassPermissions(ccRemoteBypass || sshRemoteBypass);
 
     // Store session bypass permissions mode for trust dialog check
     setSessionBypassPermissionsMode(permissionMode === 'bypassPermissions' || permissionMode === 'fullAccess');
@@ -2462,9 +2458,20 @@ async function run(): Promise<CommanderCommand> {
       worktreeEnabled,
       skipWebFetchPreflight: getInitialSettings().skipWebFetchPreflight,
       githubActionInputs: process.env.GITHUB_ACTION_INPUTS,
+      // Local-only on purpose: this records whether the flag reached THIS
+      // command's argv. On `ssh --yolo host` it is false while modeIsBypass is
+      // true — the remote runs bypassing but the flag never reaches the
+      // rewritten local argv. Read the two together, not as a contradiction.
       dangerouslySkipPermissionsPassed: dangerouslySkipPermissions ?? false,
       permissionMode,
-      modeIsBypass: permissionMode === 'bypassPermissions' || permissionMode === 'fullAccess',
+      // Remote sessions downgrade the LOCAL mode on purpose, so reading it alone
+      // recorded modeIsBypass:false for `ssh --yolo host` — a session whose tools
+      // do run bypassing, just elsewhere. The flag itself is not visible either:
+      // that argv never reaches the rewritten main command.
+      modeIsBypass:
+        permissionMode === 'bypassPermissions' ||
+        permissionMode === 'fullAccess' ||
+        getRemoteBypassPermissions(),
       allowDangerouslySkipPermissionsPassed: allowDangerouslySkipPermissions,
       systemPromptFlag: systemPrompt ? options.systemPromptFile ? 'file' : 'flag' : undefined,
       appendSystemPromptFlag: appendSystemPrompt ? options.appendSystemPromptFile ? 'file' : 'flag' : undefined,
@@ -3123,7 +3130,11 @@ async function run(): Promise<CommanderCommand> {
           serverUrl: _pendingConnect.url,
           authToken: _pendingConnect.authToken,
           cwd: getOriginalCwd(),
-          dangerouslySkipPermissions: _pendingConnect.dangerouslySkipPermissions
+          // Applied to the REMOTE session only (the local permission mode
+          // deliberately ignores it for cc:// connects). Includes a dangerous
+          // --permission-mode, which this protocol can only express as the
+          // bypass boolean — otherwise that request was accepted and dropped.
+          dangerouslySkipPermissions: remoteBypassRequested
         });
         if (session.workDir) {
           setOriginalCwd(session.workDir);
@@ -3679,56 +3690,6 @@ async function run(): Promise<CommanderCommand> {
     }
   }).version(`${MACRO.DISPLAY_VERSION ?? MACRO.VERSION} (OpenClaude)`, '-v, --version', 'Output the version number');
 
-  // Worktree flags
-  program.option('-w, --worktree [name]', 'Create a new git worktree for this session (optionally specify a name)');
-  program.option('--tmux', 'Create a tmux session for the worktree (requires --worktree). Uses iTerm2 native panes when available; use --tmux=classic for traditional tmux.');
-  if (canUserConfigureAdvisor()) {
-    program.addOption(new Option('--advisor <model>', 'Enable the server-side advisor tool with the specified model (alias or full ID).').hideHelp());
-  }
-  if (feature('TRANSCRIPT_CLASSIFIER')) {
-    program.addOption(new Option('--enable-auto-mode', 'Opt in to auto mode').hideHelp());
-  }
-  if (feature('PROACTIVE') || feature('KAIROS')) {
-    program.addOption(new Option('--proactive', 'Start in proactive autonomous mode'));
-  }
-  if (feature('UDS_INBOX')) {
-    program.addOption(new Option('--messaging-socket-path <path>', 'Unix domain socket path for the UDS messaging server (defaults to a tmp path)'));
-  }
-  if (feature('KAIROS') || feature('KAIROS_BRIEF')) {
-    program.addOption(new Option('--brief', 'Enable SendUserMessage tool for agent-to-user communication'));
-  }
-  if (feature('KAIROS')) {
-    program.addOption(new Option('--assistant', 'Force assistant mode (Agent SDK daemon use)').hideHelp());
-  }
-  if (feature('KAIROS') || feature('KAIROS_CHANNELS')) {
-    program.addOption(new Option('--channels <servers...>', 'MCP servers whose channel notifications (inbound push) should register this session. Space-separated server names.').hideHelp());
-    program.addOption(new Option('--dangerously-load-development-channels <servers...>', 'Load channel servers not on the approved allowlist. For local channel development only. Shows a confirmation dialog at startup.').hideHelp());
-  }
-
-  // Teammate identity options (set by leader when spawning tmux teammates)
-  // These replace the CLAUDE_CODE_* environment variables
-  program.addOption(new Option('--agent-id <id>', 'Teammate agent ID').hideHelp());
-  program.addOption(new Option('--agent-name <name>', 'Teammate display name').hideHelp());
-  program.addOption(new Option('--team-name <name>', 'Team name for swarm coordination').hideHelp());
-  program.addOption(new Option('--agent-color <color>', 'Teammate UI color').hideHelp());
-  program.addOption(new Option('--plan-mode-required', 'Require plan mode before implementation').hideHelp());
-  program.addOption(new Option('--parent-session-id <id>', 'Parent session ID for analytics correlation').hideHelp());
-  program.addOption(new Option('--teammate-mode <mode>', 'How to spawn teammates: "tmux", "in-process", or "auto"').choices(['auto', 'tmux', 'in-process']).hideHelp());
-  program.addOption(new Option('--agent-type <type>', 'Custom agent type for this teammate').hideHelp());
-
-  // Enable SDK URL for all builds but hide from help
-  program.addOption(new Option('--sdk-url <url>', 'Use remote WebSocket endpoint for SDK I/O streaming (only with -p and stream-json format)').hideHelp());
-
-  // Enable teleport/remote flags for all builds but keep them undocumented until GA
-  program.addOption(new Option('--teleport [session]', 'Resume a teleport session, optionally specify session ID').hideHelp());
-  program.addOption(new Option('--remote [description]', 'Create a remote session with the given description').hideHelp());
-  if (feature('BRIDGE_MODE')) {
-    program.addOption(new Option('--remote-control [name]', 'Start an interactive session with Remote Control enabled (optionally named)').argParser(value => value || true).hideHelp());
-    program.addOption(new Option('--rc [name]', 'Alias for --remote-control').argParser(value => value || true).hideHelp());
-  }
-  if (feature('HARD_FAIL')) {
-    program.addOption(new Option('--hard-fail', 'Crash on logError calls instead of silently logging').hideHelp());
-  }
   profileCheckpoint('run_main_options_built');
 
   // -p/--print mode: skip subcommand registration. The 52 subcommands
@@ -3739,7 +3700,10 @@ async function run(): Promise<CommanderCommand> {
   // + 40ms sync keychain subprocess), both hidden by the try/catch that
   // always returns false before enableConfigs(). cc:// URLs are rewritten to
   // `open` at main() line ~851 BEFORE this runs, so argv check is safe here.
-  const isPrintMode = process.argv.includes('-p') || process.argv.includes('--print');
+  // Commander-authoritative (~0.6ms): `ssh host -- --print` rewrites argv to a
+  // literal `-- --print` positional, and a token scan would take the print path
+  // instead of opening the interactive remote session. Also judges `-pv`.
+  const isPrintMode = resolvesPrintMode(process.argv.slice(2));
   const isCcUrl = process.argv.some(a => a.startsWith('cc://') || a.startsWith('cc+unix://'));
   if (isPrintMode && !isCcUrl) {
     profileCheckpoint('run_before_parse');
@@ -3903,7 +3867,7 @@ async function run(): Promise<CommanderCommand> {
   // this action it means the argv rewrite didn't fire (e.g. user ran
   // `claude ssh` with no host) — just print usage.
   if (feature('SSH_REMOTE')) {
-    program.command('ssh <host> [dir]').description('Run OpenClaude on a remote host over SSH. Deploys the binary and ' + 'tunnels API auth back through your local machine — no remote setup needed.').option('--permission-mode <mode>', 'Permission mode for the remote session').option('--dangerously-skip-permissions', 'Skip all permission prompts on the remote (dangerous)').option('--local', 'e2e test mode — spawn the child CLI locally (skip ssh/deploy). ' + 'Exercises the auth proxy and unix-socket plumbing without a remote host.').action(async () => {
+    program.command('ssh <host> [dir]').description('Run OpenClaude on a remote host over SSH. Deploys the binary and ' + 'tunnels API auth back through your local machine — no remote setup needed.').addOption(new Option('--permission-mode <mode>', 'Permission mode for the remote session').choices(PERMISSION_MODES)).option(BYPASS_PERMISSIONS_FLAGS, 'Skip all permission prompts on the remote (alias: --yolo; dangerous)', () => true).option('--local', 'e2e test mode — spawn the child CLI locally (skip ssh/deploy). ' + 'Exercises the auth proxy and unix-socket plumbing without a remote host.').action(async () => {
       // Argv rewriting in main() should have consumed `ssh <host>` before
       // commander runs. Reaching here means host was missing or the
       // rewrite predicate didn't match.
@@ -3916,9 +3880,19 @@ async function run(): Promise<CommanderCommand> {
   // Interactive mode (without -p) is handled by early argv rewriting in main()
   // which redirects to the main command with full TUI support.
   if (feature('DIRECT_CONNECT')) {
-    program.command('open <cc-url>').description('Connect to an OpenClaude server (internal — use cc:// URLs)').option('-p, --print [prompt]', 'Print mode (headless)').option('--output-format <format>', 'Output format: text, json, stream-json', 'text').action(async (ccUrl: string, opts: {
+    program.command('open <cc-url>')
+      // NOT allowUnknownOption(): this stub is a rewrite target for the cc://
+      // headless path, which forwards whatever the user typed alongside the URL.
+      // Tolerating unknown options made it fail OPEN — security-scoping flags
+      // like --disallowed-tools, --tools, --strict-mcp-config and --add-dir were
+      // silently ignored while --dangerously-skip-permissions/--yolo still
+      // applied, so a session could open with fewer constraints than the user
+      // asked for. Erroring on a flag this stub cannot honour is the safe
+      // direction, and matches the behaviour before the alias existed.
+      .description('Connect to an OpenClaude server (internal — use cc:// URLs)').option('-p, --print [prompt]', 'Print mode (headless)').option('--output-format <format>', 'Output format: text, json, stream-json', 'text').option(BYPASS_PERMISSIONS_FLAGS, 'Bypass all permission checks (alias: --yolo)', () => true).action(async (ccUrl: string, opts: {
       print?: string | boolean;
       outputFormat: string;
+      dangerouslySkipPermissions?: boolean;
     }) => {
       const {
         parseConnectUrl
@@ -3933,7 +3907,7 @@ async function run(): Promise<CommanderCommand> {
           serverUrl,
           authToken,
           cwd: getOriginalCwd(),
-          dangerouslySkipPermissions: _pendingConnect?.dangerouslySkipPermissions
+          dangerouslySkipPermissions: opts.dangerouslySkipPermissions ?? false
         });
         if (session.workDir) {
           setOriginalCwd(session.workDir);

--- a/src/mainCliOptions.test.ts
+++ b/src/mainCliOptions.test.ts
@@ -1,0 +1,293 @@
+import { describe, expect, it } from 'bun:test'
+import {
+  applyMainOptions,
+  BYPASS_PERMISSIONS_FLAGS,
+  localDangerouslySkipPermissions,
+  localPermissionModeCli,
+  localResolvedPermissionMode,
+  resolvesHeadlessFlags,
+  resolvesPrintMode,
+} from './mainCliOptions.js'
+import { Command } from '@commander-js/extra-typings'
+import { isDangerousPermissionMode } from './utils/permissions/PermissionMode.js'
+import {
+  initialPermissionModeFromCLI,
+  isBypassPermissionsModeDisabled,
+} from './utils/permissions/permissionSetup.js'
+
+describe('resolvesPrintMode', () => {
+  it('detects -p/--print, including inside a bundled short cluster', () => {
+    expect(resolvesPrintMode(['-p'])).toBe(true)
+    expect(resolvesPrintMode(['--print'])).toBe(true)
+    // commander expands `-pv`; a token scan would miss it and misroute.
+    expect(resolvesPrintMode(['-pv'])).toBe(true)
+    expect(resolvesPrintMode(['cc://server', '-p', 'do a thing'])).toBe(true)
+  })
+
+  it(`does not fire when -p sits in another option value slot`, () => {
+    // commander consumes `-p` as --settings' required value, so it is data.
+    expect(resolvesPrintMode(['cc://server', '--settings', '-p'])).toBe(false)
+  })
+
+  it('does not fire for a positional after `--` or when absent', () => {
+    expect(resolvesPrintMode(['cc://server', '--', '--print'])).toBe(false)
+    expect(resolvesPrintMode(['cc://server'])).toBe(false)
+    expect(resolvesPrintMode([])).toBe(false)
+  })
+
+  it('does not throw on invalid usage', () => {
+    expect(() => resolvesPrintMode(['--model'])).not.toThrow()
+    expect(resolvesPrintMode(['--model'])).toBe(false)
+  })
+})
+
+describe('resolvesPrintMode — parse errors elsewhere on the line', () => {
+  it('still reports print mode when a later option is invalid', () => {
+    // `-p --model` (missing value) throws in commander, but print was already
+    // parsed; returning false here would misroute a headless invocation.
+    expect(resolvesPrintMode(['cc://server', '-p', '--model'])).toBe(true)
+    // …and an invalid line with no print flag still resolves to false.
+    expect(resolvesPrintMode(['cc://server', '--model'])).toBe(false)
+  })
+})
+
+describe('localDangerouslySkipPermissions (cc:// direct connect)', () => {
+  it('suppresses bypass for the LOCAL session while leaving the flag forwardable', () => {
+    // The remote executes the tools, so the flag must reach
+    // createDirectConnectSession unchanged...
+    const rawFlagForRemote = true
+    // ...while this local client resolves to a non-bypass mode.
+    expect(localDangerouslySkipPermissions(rawFlagForRemote, true)).toBe(false)
+
+    const { mode } = initialPermissionModeFromCLI({
+      permissionModeCli: undefined,
+      dangerouslySkipPermissions: localDangerouslySkipPermissions(
+        rawFlagForRemote,
+        true,
+      ),
+    })
+    // Asserted through the backstop, not on the resolver's output directly:
+    // initialPermissionModeFromCLI also folds in settings
+    // `permissions.defaultMode`, so on a machine or runner configured with
+    // bypassPermissions the resolved mode is dangerous even though the FLAG was
+    // suppressed — which is precisely why localResolvedPermissionMode exists.
+    // The guarantee this suite pins is the end state, and that one really does
+    // hold in every environment.
+    expect(isDangerousPermissionMode(localResolvedPermissionMode(mode, true))).toBe(
+      false,
+    )
+  })
+
+  it('leaves the flag untouched when there is no pending cc:// connect', () => {
+    expect(localDangerouslySkipPermissions(true, false)).toBe(true)
+    expect(localDangerouslySkipPermissions(undefined, false)).toBeUndefined()
+    expect(localDangerouslySkipPermissions(false, false)).toBe(false)
+
+    // …and that path really does reach a bypassing mode, so the assertion
+    // above is not vacuously true.
+    // Non-vacuity: the SAME call without suppression reaches a bypassing mode
+    // wherever the environment permits bypass at all. Asserted as an equality
+    // against that condition rather than a bare `true`, so a machine or CI
+    // runner with permissions.disableBypassPermissionsMode (or the Statsig
+    // gate) set cannot flake this — initialPermissionModeFromCLI reads both.
+    // CLAUDE_CODE_REMOTE also feeds initialPermissionModeFromCLI (it filters
+    // settings-based default modes), so a dev shell or runner that exports it
+    // could move the resolved mode for reasons unrelated to the bypass gate.
+    // Cleared for the assertion and restored even if it fails.
+    const remote = process.env.CLAUDE_CODE_REMOTE
+    delete process.env.CLAUDE_CODE_REMOTE
+    try {
+      const { mode } = initialPermissionModeFromCLI({
+        permissionModeCli: undefined,
+        dangerouslySkipPermissions: localDangerouslySkipPermissions(true, false),
+      })
+      expect(isDangerousPermissionMode(mode)).toBe(
+        !isBypassPermissionsModeDisabled(),
+      )
+    } finally {
+      if (remote !== undefined) process.env.CLAUDE_CODE_REMOTE = remote
+    }
+  })
+})
+
+describe('BYPASS_PERMISSIONS_FLAGS', () => {
+  it('keeps the spelling order that makes commander name the attribute', () => {
+    // commander derives the attribute from the LAST long flag. If a future edit
+    // swaps the spellings, every `opts().dangerouslySkipPermissions` reader in
+    // the codebase silently reads `undefined` instead — so pin the order here
+    // rather than relying on each of the four registration sites agreeing.
+    expect(BYPASS_PERMISSIONS_FLAGS).toBe('--yolo, --dangerously-skip-permissions')
+
+    const parsed = applyMainOptions(new Command())
+      .exitOverride()
+      .parse(['--yolo'], { from: 'user' })
+      .opts() as Record<string, unknown>
+    expect(parsed.dangerouslySkipPermissions).toBe(true)
+    expect(parsed.yolo).toBeUndefined()
+
+    // The two positions that must NOT grant bypass are decided entirely by
+    // commander, so a change in registration order or arity would move them
+    // without failing anything else in this suite.
+    const inValueSlot = applyMainOptions(new Command())
+      .exitOverride()
+      .parse(['--settings', '--yolo'], { from: 'user' })
+      .opts() as Record<string, unknown>
+    expect(inValueSlot.dangerouslySkipPermissions).toBeUndefined()
+    expect(inValueSlot.settings).toBe('--yolo')
+
+    const afterMarker = applyMainOptions(new Command())
+      // Stated explicitly: commander 12 tolerates the excess operand this line
+      // produces, commander 13 errors by default. The precondition belongs in
+      // the test rather than in the library version it happens to run against.
+      .allowExcessArguments()
+      .exitOverride()
+      .parse(['--', '--yolo'], { from: 'user' })
+      .opts() as Record<string, unknown>
+    expect(afterMarker.dangerouslySkipPermissions).toBeUndefined()
+
+    // the canonical spelling resolves to the same attribute
+    const canonical = applyMainOptions(new Command())
+      .exitOverride()
+      .parse(['--dangerously-skip-permissions'], { from: 'user' })
+      .opts() as Record<string, unknown>
+    expect(canonical.dangerouslySkipPermissions).toBe(true)
+  })
+})
+
+describe('localPermissionModeCli (the second door to bypass)', () => {
+  it('drops a bypassing mode for a pending remote session', () => {
+    for (const mode of ['bypassPermissions', 'fullAccess']) {
+      expect(localPermissionModeCli(mode, true)).toBeUndefined()
+      // …and the resolved local mode is then not dangerous
+      const { mode: resolved } = initialPermissionModeFromCLI({
+        permissionModeCli: localPermissionModeCli(mode, true),
+        dangerouslySkipPermissions: localDangerouslySkipPermissions(true, true),
+      })
+      // …through the backstop, for the same settings-defaultMode reason as above
+      expect(
+        isDangerousPermissionMode(localResolvedPermissionMode(resolved, true)),
+      ).toBe(false)
+    }
+  })
+
+  it('leaves non-bypassing modes and local sessions alone', () => {
+    expect(localPermissionModeCli('plan', true)).toBe('plan')
+    expect(localPermissionModeCli('acceptEdits', true)).toBe('acceptEdits')
+    expect(localPermissionModeCli(undefined, true)).toBeUndefined()
+    // no pending remote session: nothing is dropped
+    expect(localPermissionModeCli('bypassPermissions', false)).toBe(
+      'bypassPermissions',
+    )
+    expect(localPermissionModeCli('fullAccess', false)).toBe('fullAccess')
+  })
+})
+
+describe('resolvesPrintMode memoization', () => {
+  it('never leaks a previous answer across different token lists', () => {
+    // The reason the RESULT is cached and not the Command: a reused command
+    // keeps its parsed values, so `-p` once would answer true forever. These
+    // interleavings would all fail under that mistake.
+    expect(resolvesPrintMode(['-p'])).toBe(true)
+    expect(resolvesPrintMode(['--verbose'])).toBe(false)
+    expect(resolvesPrintMode(['-p'])).toBe(true)
+    expect(resolvesPrintMode(['--', '--print'])).toBe(false)
+    expect(resolvesPrintMode(['-pv'])).toBe(true)
+    expect(resolvesPrintMode([])).toBe(false)
+    expect(resolvesPrintMode(['--print'])).toBe(true)
+    expect(resolvesPrintMode(['--settings', '-p'])).toBe(false)
+  })
+
+  it('returns the same answer when asked repeatedly (cache hit path)', () => {
+    for (const tokens of [['-p'], ['--', '--print'], ['--settings', '-p']]) {
+      const first = resolvesPrintMode(tokens)
+      expect(resolvesPrintMode(tokens)).toBe(first)
+      expect(resolvesPrintMode([...tokens])).toBe(first)
+    }
+  })
+})
+
+describe('localResolvedPermissionMode (the third door: settings defaultMode)', () => {
+  it('downgrades a dangerous RESOLVED mode for a pending remote session', () => {
+    // permissions.defaultMode in settings is folded in by
+    // initialPermissionModeFromCLI itself — ungated by either CLI input — so it
+    // can only be neutralized on the way out.
+    for (const mode of ['bypassPermissions', 'fullAccess'] as const) {
+      expect(localResolvedPermissionMode(mode, true)).toBe('default')
+      expect(isDangerousPermissionMode(localResolvedPermissionMode(mode, true))).toBe(
+        false,
+      )
+    }
+  })
+
+  it('leaves non-bypassing modes and local sessions untouched', () => {
+    for (const mode of ['default', 'plan', 'acceptEdits', 'auto'] as const) {
+      expect(localResolvedPermissionMode(mode, true)).toBe(mode)
+      expect(localResolvedPermissionMode(mode, false)).toBe(mode)
+    }
+    // a local session keeps its dangerous mode — this guard is remote-only
+    expect(localResolvedPermissionMode('bypassPermissions', false)).toBe(
+      'bypassPermissions',
+    )
+    expect(localResolvedPermissionMode('fullAccess', false)).toBe('fullAccess')
+  })
+
+  it('closes every door together', () => {
+    // all three sources asking for bypass at once, on a remote session
+    const { mode } = initialPermissionModeFromCLI({
+      permissionModeCli: localPermissionModeCli('bypassPermissions', true),
+      dangerouslySkipPermissions: localDangerouslySkipPermissions(true, true),
+    })
+    expect(isDangerousPermissionMode(localResolvedPermissionMode(mode, true))).toBe(
+      false,
+    )
+  })
+})
+
+describe('resolvesHeadlessFlags — the other two routing flags', () => {
+  it('honours the end-of-options marker and value slots for all three', () => {
+    // initOnly and sdkUrl gate interactivity exactly like print, so the two
+    // shapes that matter for them are the same: a post-`--` positional and a
+    // token sitting in another option's value slot.
+    expect(resolvesHeadlessFlags(['--', '--init-only']).initOnly).toBe(false)
+    expect(resolvesHeadlessFlags(['--settings', '--init-only']).initOnly).toBe(false)
+    expect(resolvesHeadlessFlags(['--', '--sdk-url', 'x']).sdkUrl).toBe(false)
+    expect(resolvesHeadlessFlags(['--settings', '--sdk-url']).sdkUrl).toBe(false)
+
+    // …and the genuine forms, including `=` which the old startsWith() scan
+    // matched and commander also resolves
+    expect(resolvesHeadlessFlags(['--init-only']).initOnly).toBe(true)
+    expect(resolvesHeadlessFlags(['--sdk-url', 'x']).sdkUrl).toBe(true)
+    expect(resolvesHeadlessFlags(['--sdk-url=x']).sdkUrl).toBe(true)
+
+    // the three are independent — one being set must not imply the others
+    const onlyPrint = resolvesHeadlessFlags(['-p'])
+    expect(onlyPrint).toEqual({ print: true, initOnly: false, sdkUrl: false })
+    const none = resolvesHeadlessFlags(['--verbose'])
+    expect(none).toEqual({ print: false, initOnly: false, sdkUrl: false })
+  })
+})
+
+describe('resolvesHeadlessFlags — a rejected VALUE earlier on the line', () => {
+  it('does not swallow the routing flag that follows it', () => {
+    // commander aborts the whole parse at a .choices()/argParser rejection, so
+    // reading opts() afterwards missed anything later on the line. These all
+    // resolved false before, silently reversing six startup gates: early-input
+    // capture would enable raw mode on a headless run, and a provider-config
+    // error would degrade from exit(1) to a warning.
+    expect(resolvesHeadlessFlags(['--output-format', 'bogus', '-p']).print).toBe(true)
+    expect(resolvesHeadlessFlags(['--thinking', 'bogus', '-p']).print).toBe(true)
+    expect(resolvesHeadlessFlags(['--effort', 'bogus', '-p']).print).toBe(true)
+    expect(resolvesHeadlessFlags(['--permission-mode', 'nope', '-p']).print).toBe(true)
+    expect(
+      resolvesHeadlessFlags(['--thinking', 'bogus', '--init-only']).initOnly,
+    ).toBe(true)
+    expect(
+      resolvesHeadlessFlags(['--thinking', 'bogus', '--sdk-url', 'x']).sdkUrl,
+    ).toBe(true)
+
+    // …and a valid value still behaves, including the end-of-options case that
+    // must stay false
+    expect(resolvesHeadlessFlags(['--output-format', 'json', '-p']).print).toBe(true)
+    expect(resolvesHeadlessFlags(['--', '--print']).print).toBe(false)
+  })
+})

--- a/src/mainCliOptions.ts
+++ b/src/mainCliOptions.ts
@@ -1,0 +1,309 @@
+import { Command, InvalidArgumentError, Option } from '@commander-js/extra-typings';
+import { feature } from 'bun:bundle';
+import { parseHeadlessHeartbeatDuration } from 'src/cli/headlessHeartbeat.js';
+import { errorMessage } from 'src/utils/errors.js';
+import { isDangerousPermissionMode, PERMISSION_MODES, type PermissionMode } from './utils/permissions/PermissionMode.js';
+import { canUserConfigureAdvisor } from './utils/advisor.js';
+
+/**
+ * The single source of truth for the bypass option's flag string.
+ *
+ * ORDER IS LOAD-BEARING: commander keys the parsed attribute off the LAST long
+ * flag, so `--yolo, --dangerously-skip-permissions` yields
+ * `opts().dangerouslySkipPermissions` (the name the whole codebase reads) with
+ * `--yolo` kept as the alias. Swapping the two spellings silently renames the
+ * attribute to `opts().yolo`. `as const` keeps the literal type so
+ * @commander-js/extra-typings can still infer that attribute name.
+ */
+export const BYPASS_PERMISSIONS_FLAGS =
+  '--yolo, --dangerously-skip-permissions' as const
+
+/**
+ * The main command's global CLI options, registered on `cmd`. Extracted from
+ * main.tsx so the ssh pre-parser (src/utils/sshPreParse.ts) can reuse the exact
+ * option arities and stop misparsing the host. The unconditional options are the
+ * typed fluent chain (so the main command's action keeps its typed `options`);
+ * the feature-gated options are runtime mutations (same as before this extract).
+ */
+export function applyMainOptions<A extends unknown[]>(cmd: Command<A, {}>) {
+  const withMainOptions = cmd.option('-d, --debug [filter]', 'Enable debug mode with optional category filtering (e.g., "api,hooks" or "!1p,!file")', (_value: string | true) => {
+    // If value is provided, it will be the filter string
+    // If not provided but flag is present, value will be true
+    // The actual filtering is handled in debug.ts by parsing process.argv
+    return true;
+  }).addOption(new Option('-d2e, --debug-to-stderr', 'Enable debug mode (to stderr)').argParser(Boolean).hideHelp()).option('--debug-file <path>', 'Write debug logs to a specific file path (implicitly enables debug mode)', () => true).option('--verbose', 'Override verbose mode setting from config', () => true).option('-p, --print', 'Print response and exit (useful for pipes). Note: The workspace trust dialog is skipped when Claude is run with the -p mode. Only use this flag in directories you trust.', () => true).addOption(new Option('--heartbeat <duration>', 'Emit a headless liveness heartbeat while output is quiet (only works with --print, e.g. 30s, 2m; pre-stream startup heartbeats use stderr)').argParser(value => {
+    try {
+      return parseHeadlessHeartbeatDuration(value);
+    } catch (error) {
+      throw new InvalidArgumentError(errorMessage(error));
+    }
+  })).option('--bare', 'Minimal mode: skip hooks, LSP, plugin sync, attribution, auto-memory, background prefetches, keychain reads, and CLAUDE.md auto-discovery. Sets CLAUDE_CODE_SIMPLE=1. Anthropic auth is strictly ANTHROPIC_API_KEY or apiKeyHelper via --settings (OAuth and keychain are never read). 3P providers (Bedrock/Vertex/Foundry) use their own credentials. Skills still resolve via /skill-name. Explicitly provide context via: --system-prompt[-file], --append-system-prompt[-file], --add-dir (CLAUDE.md dirs), --mcp-config, --settings, --agents, --plugin-dir.', () => true).addOption(new Option('--init', 'Run Setup hooks with init trigger, then continue').hideHelp()).addOption(new Option('--init-only', 'Run Setup and SessionStart:startup hooks, then exit').hideHelp()).addOption(new Option('--maintenance', 'Run Setup hooks with maintenance trigger, then continue').hideHelp()).addOption(new Option('--output-format <format>', 'Output format (only works with --print): "text" (default), "json" (single result), or "stream-json" (realtime streaming)').choices(['text', 'json', 'stream-json'])).addOption(new Option('--json-schema <schema>', 'JSON Schema for structured output validation. ' + 'Example: {"type":"object","properties":{"name":{"type":"string"}},"required":["name"]}').argParser(String)).option('--include-hook-events', 'Include all hook lifecycle events in the output stream (only works with --output-format=stream-json)', () => true).option('--include-partial-messages', 'Include partial message chunks as they arrive (only works with --print and --output-format=stream-json)', () => true).addOption(new Option('--input-format <format>', 'Input format (only works with --print): "text" (default), or "stream-json" (realtime streaming input)').choices(['text', 'stream-json'])).option('--mcp-debug', '[DEPRECATED. Use --debug instead] Enable MCP debug mode (shows MCP server errors)', () => true).option(BYPASS_PERMISSIONS_FLAGS, 'Bypass all permission checks (alias: --yolo). Recommended only for sandboxes with no internet access.', () => true).option('--allow-dangerously-skip-permissions', 'Enable bypassing all permission checks as an option, without it being enabled by default. Recommended only for sandboxes with no internet access.', () => true).addOption(new Option('--thinking <mode>', 'Thinking mode: enabled (equivalent to adaptive), disabled').choices(['enabled', 'adaptive', 'disabled']).hideHelp()).addOption(new Option('--max-thinking-tokens <tokens>', '[DEPRECATED. Use --thinking instead for newer models] Maximum number of thinking tokens (only works with --print)').argParser(Number).hideHelp()).addOption(new Option('--max-turns <turns>', 'Maximum number of agentic turns in non-interactive mode. This will early exit the conversation after the specified number of turns. (only works with --print)').argParser(Number).hideHelp()).addOption(new Option('--max-budget-usd <amount>', 'Maximum dollar amount to spend on API calls (only works with --print)').argParser(value => {
+    const amount = Number(value);
+    if (isNaN(amount) || amount <= 0) {
+      throw new Error('--max-budget-usd must be a positive number greater than 0');
+    }
+    return amount;
+  })).addOption(new Option('--task-budget <tokens>', 'API-side task budget in tokens (output_config.task_budget)').argParser(value => {
+    const tokens = Number(value);
+    if (isNaN(tokens) || tokens <= 0 || !Number.isInteger(tokens)) {
+      throw new Error('--task-budget must be a positive integer');
+    }
+    return tokens;
+  }).hideHelp()).option('--replay-user-messages', 'Re-emit user messages from stdin back on stdout for acknowledgment (only works with --input-format=stream-json and --output-format=stream-json)', () => true).addOption(new Option('--enable-auth-status', 'Enable auth status messages in SDK mode').default(false).hideHelp()).option('--allowedTools, --allowed-tools <tools...>', 'Comma or space-separated list of tool names to allow (e.g. "Bash(git:*) Edit")').option('--tools <tools...>', 'Specify the list of available tools from the built-in set. Use "" to disable all tools, "default" to use all tools, or specify tool names (e.g. "Bash,Edit,Read").').option('--disallowedTools, --disallowed-tools <tools...>', 'Comma or space-separated list of tool names to deny (e.g. "Bash(git:*) Edit")').option('--mcp-config <configs...>', 'Load MCP servers from JSON files or strings (space-separated)').addOption(new Option('--permission-prompt-tool <tool>', 'MCP tool to use for permission prompts (only works with --print)').argParser(String).hideHelp()).addOption(new Option('--system-prompt <prompt>', 'System prompt to use for the session').argParser(String)).addOption(new Option('--system-prompt-file <file>', 'Read system prompt from a file').argParser(String).hideHelp()).addOption(new Option('--append-system-prompt <prompt>', 'Append a system prompt to the default system prompt').argParser(String)).addOption(new Option('--append-system-prompt-file <file>', 'Read system prompt from a file and append to the default system prompt').argParser(String).hideHelp()).addOption(new Option('--permission-mode <mode>', 'Permission mode to use for the session').argParser(String).choices(PERMISSION_MODES))
+  .option('-c, --continue', 'Continue the most recent conversation in the current directory', () => true)
+  .option('-r, --resume [value]', 'Resume a conversation by session ID, or open interactive picker with optional search term', value => value || true)
+  .option('--fork-session', 'When resuming, branch the conversation into a new session ID; does not create filesystem or worktree isolation (use with --resume or --continue)', () => true)
+  .addOption(new Option('--prefill <text>', 'Pre-fill the prompt input with text without submitting it').hideHelp()).addOption(new Option('--deep-link-origin', 'Signal that this session was launched from a deep link').hideHelp()).addOption(new Option('--deep-link-repo <slug>', 'Repo slug the deep link ?repo= parameter resolved to the current cwd').hideHelp()).addOption(new Option('--deep-link-last-fetch <ms>', 'FETCH_HEAD mtime in epoch ms, precomputed by the deep link trampoline').argParser(v => {
+    const n = Number(v);
+    return Number.isFinite(n) ? n : undefined;
+  }).hideHelp()).option('--from-pr [value]', 'Resume a session linked to a PR by PR number/URL, or open interactive picker with optional search term', value => value || true).option('--no-session-persistence', 'Disable session persistence - sessions will not be saved to disk and cannot be resumed (only works with --print)').addOption(new Option('--resume-session-at <message id>', 'When resuming, only messages up to and including the assistant message with <message.id> (use with --resume in print mode)').argParser(String).hideHelp()).addOption(new Option('--rewind-files <user-message-id>', 'Restore files to state at the specified user message and exit (requires --resume)').hideHelp())
+  // @[MODEL LAUNCH]: Update the example model ID in the --model help text.
+  .option('--model <model>', `Model for the current session. Provide an alias for the latest model (e.g. 'sonnet' or 'opus') or a model's full name (e.g. 'claude-sonnet-4-6').`).option('--provider <provider>', `AI provider to use (anthropic, openai, gemini, github, bedrock, vertex, ollama). Reads API keys from environment variables.`).addOption(new Option('--effort <level>', `Effort level for the current session (low, medium, high, xhigh, max, ultracode)`).argParser((rawValue: string) => {
+    const value = rawValue.toLowerCase();
+    const allowed = ['low', 'medium', 'high', 'xhigh', 'max', 'ultracode'];
+    if (!allowed.includes(value)) {
+      throw new InvalidArgumentError(`It must be one of: ${allowed.join(', ')}`);
+    }
+    return value;
+  })).option('--agent <agent>', `Agent for the current session. Overrides the 'agent' setting.`).option('--betas <betas...>', 'Beta headers to include in API requests (API key users only)').option('--fallback-model <model>', 'Enable automatic fallback to specified model when default model is overloaded').addOption(new Option('--workload <tag>', 'Workload tag for billing-header attribution (cc_workload). Process-scoped; set by SDK daemon callers that spawn subprocesses for cron work. (only works with --print)').hideHelp()).option('--settings <file-or-json>', 'Path to a settings JSON file or a JSON string to load additional settings from').option('--add-dir <directories...>', 'Additional directories to allow tool access to').option('--ide', 'Automatically connect to IDE on startup if exactly one valid IDE is available', () => true).option('--strict-mcp-config', 'Only use MCP servers from --mcp-config, ignoring all other MCP configurations', () => true).option('--session-id <uuid>', 'Use a specific session ID for the conversation (must be a valid UUID)').option('-n, --name <name>', 'Set a display name for this session (shown in /resume and terminal title)').option('--agents <json>', 'JSON object defining custom agents (e.g. \'{"reviewer": {"description": "Reviews code", "prompt": "You are a code reviewer"}}\')').option('--setting-sources <sources>', 'Comma-separated list of setting sources to load (user, project, local).')
+  // gh-33508: <paths...> (variadic) consumed everything until the next
+  // --flag. `claude --plugin-dir /path mcp add --transport http` swallowed
+  // `mcp` and `add` as paths, then choked on --transport as an unknown
+  // top-level option. Single-value + collect accumulator means each
+  // --plugin-dir takes exactly one arg; repeat the flag for multiple dirs.
+  .option('--plugin-dir <path>', 'Load plugins from a directory for this session only (repeatable: --plugin-dir A --plugin-dir B)', (val: string, prev: string[]) => [...prev, val], [] as string[]).option('--disable-slash-commands', 'Disable all skills', () => true).option('--chrome', 'Enable Claude in Chrome integration').option('--no-chrome', 'Disable Claude in Chrome integration').option('--file <specs...>', 'File resources to download at startup. Format: file_id:relative_path (e.g., --file file_abc:doc.txt file_def:img.png)')
+  // cli.tsx consumes --provider-env-file before provider resolution; this registration
+  // keeps Commander help and unknown-option handling aligned with that bootstrap path.
+  .option('--provider-env-file <path>', 'Load provider environment variables from a file before validation (repeatable; existing values win)', (val: string, prev: string[]) => [...prev, val], [] as string[]);
+  // Worktree flags
+  withMainOptions.option('-w, --worktree [name]', 'Create a new git worktree for this session (optionally specify a name)');
+  withMainOptions.option('--tmux', 'Create a tmux session for the worktree (requires --worktree). Uses iTerm2 native panes when available; use --tmux=classic for traditional tmux.');
+  if (canUserConfigureAdvisor()) {
+    withMainOptions.addOption(new Option('--advisor <model>', 'Enable the server-side advisor tool with the specified model (alias or full ID).').hideHelp());
+  }
+  if (feature('TRANSCRIPT_CLASSIFIER')) {
+    withMainOptions.addOption(new Option('--enable-auto-mode', 'Opt in to auto mode').hideHelp());
+  }
+  if (feature('PROACTIVE') || feature('KAIROS')) {
+    withMainOptions.addOption(new Option('--proactive', 'Start in proactive autonomous mode'));
+  }
+  if (feature('UDS_INBOX')) {
+    withMainOptions.addOption(new Option('--messaging-socket-path <path>', 'Unix domain socket path for the UDS messaging server (defaults to a tmp path)'));
+  }
+  if (feature('KAIROS') || feature('KAIROS_BRIEF')) {
+    withMainOptions.addOption(new Option('--brief', 'Enable SendUserMessage tool for agent-to-user communication'));
+  }
+  if (feature('KAIROS')) {
+    withMainOptions.addOption(new Option('--assistant', 'Force assistant mode (Agent SDK daemon use)').hideHelp());
+  }
+  if (feature('KAIROS') || feature('KAIROS_CHANNELS')) {
+    withMainOptions.addOption(new Option('--channels <servers...>', 'MCP servers whose channel notifications (inbound push) should register this session. Space-separated server names.').hideHelp());
+    withMainOptions.addOption(new Option('--dangerously-load-development-channels <servers...>', 'Load channel servers not on the approved allowlist. For local channel development only. Shows a confirmation dialog at startup.').hideHelp());
+  }
+
+  // Teammate identity options (set by leader when spawning tmux teammates)
+  // These replace the CLAUDE_CODE_* environment variables
+  withMainOptions.addOption(new Option('--agent-id <id>', 'Teammate agent ID').hideHelp());
+  withMainOptions.addOption(new Option('--agent-name <name>', 'Teammate display name').hideHelp());
+  withMainOptions.addOption(new Option('--team-name <name>', 'Team name for swarm coordination').hideHelp());
+  withMainOptions.addOption(new Option('--agent-color <color>', 'Teammate UI color').hideHelp());
+  withMainOptions.addOption(new Option('--plan-mode-required', 'Require plan mode before implementation').hideHelp());
+  withMainOptions.addOption(new Option('--parent-session-id <id>', 'Parent session ID for analytics correlation').hideHelp());
+  withMainOptions.addOption(new Option('--teammate-mode <mode>', 'How to spawn teammates: "tmux", "in-process", or "auto"').choices(['auto', 'tmux', 'in-process']).hideHelp());
+  withMainOptions.addOption(new Option('--agent-type <type>', 'Custom agent type for this teammate').hideHelp());
+
+  // Enable SDK URL for all builds but hide from help
+  withMainOptions.addOption(new Option('--sdk-url <url>', 'Use remote WebSocket endpoint for SDK I/O streaming (only with -p and stream-json format)').hideHelp());
+
+  // Enable teleport/remote flags for all builds but keep them undocumented until GA
+  withMainOptions.addOption(new Option('--teleport [session]', 'Resume a teleport session, optionally specify session ID').hideHelp());
+  withMainOptions.addOption(new Option('--remote [description]', 'Create a remote session with the given description').hideHelp());
+  if (feature('BRIDGE_MODE')) {
+    withMainOptions.addOption(new Option('--remote-control [name]', 'Start an interactive session with Remote Control enabled (optionally named)').argParser(value => value || true).hideHelp());
+    withMainOptions.addOption(new Option('--rc [name]', 'Alias for --remote-control').argParser(value => value || true).hideHelp());
+  }
+  if (feature('HARD_FAIL')) {
+    withMainOptions.addOption(new Option('--hard-fail', 'Crash on logError calls instead of silently logging').hideHelp());
+  }
+  return withMainOptions;
+}
+
+/**
+ * Single-entry memo for {@link resolvesPrintMode}: six startup call sites ask
+ * the same question about the same argv, and each answer costs a full option
+ * registration (~0.6ms measured).
+ *
+ * The RESULT is cached, never the `Command` — reusing a parsed command is
+ * unsafe, because commander writes parsed values onto it and offers no reset,
+ * so one `-p` would make every later call answer `true`.
+ *
+ * The key includes `canUserConfigureAdvisor()` as well as the tokens: it reads
+ * provider env (via `shouldIncludeFirstPartyOnlyBetas`) that cli.tsx mutates
+ * DURING startup, and it gates `--advisor <model>`, a value-taking option — so
+ * `--advisor -p` can legitimately resolve differently before and after that
+ * mutation. Keying on it means the cache can never freeze the earlier answer.
+ */
+let headlessFlagsMemo:
+  | { key: string; result: HeadlessRoutingFlags }
+  | undefined;
+
+/**
+ * The three flags every startup gate consults before deciding whether this is
+ * an interactive session. All are resolved by one commander parse so they agree
+ * with each other and with the real parse.
+ */
+export type HeadlessRoutingFlags = {
+  print: boolean;
+  initOnly: boolean;
+  sdkUrl: boolean;
+};
+
+/**
+ * What commander resolves for the routing flags from these argv tokens.
+ *
+ * Consulted by every startup gate that has to decide interactivity BEFORE the
+ * real parse runs: the cc:// direct-connect rewrite and the ssh flow in
+ * main.tsx, `utils/interactivity.ts`, `utils/earlyInput.ts`,
+ * `utils/providerValidation.ts` and `utils/gracefulShutdown.ts`. That breadth is
+ * why the memo above exists, and why it has to stay correct across startup
+ * rather than for a call or two.
+ *
+ * Delegating to commander means bundled shorts (`-pv`), `--`-positionals
+ * (`-- --print`, `-- --init-only`), `=` forms (`--sdk-url=x`) and value
+ * positions are all judged exactly as the real parse will judge them, instead
+ * of by token matching.
+ */
+export function resolvesHeadlessFlags(
+  tokens: readonly string[],
+): HeadlessRoutingFlags {
+  // Guarded HERE rather than at each call site, because this is the only part
+  // of the function outside the parse try/catch below: `canUserConfigureAdvisor`
+  // reads the feature-flag file. It cannot throw today (that read is itself a
+  // try/catch that yields `null` on any failure), but every consumer of this
+  // function is a startup or signal-handler path — early-input capture,
+  // interactivity, provider validation, two SIGINT handlers — and none of them
+  // should die because a hidden option's gate could not be read. One guard
+  // covers them all, and it degrades precisely: the gate defaults to `false`,
+  // which only affects whether the hidden `--advisor` option is registered.
+  let advisorConfigurable = false;
+  try {
+    advisorConfigurable = canUserConfigureAdvisor();
+  } catch {
+    // fall through with the default
+  }
+  // JSON, not a delimiter: it escapes any token content unambiguously and
+  // keeps this file plain text (a literal NUL made ripgrep treat it as binary).
+  const key = JSON.stringify([advisorConfigurable, tokens]);
+  if (headlessFlagsMemo?.key === key) {
+    return headlessFlagsMemo.result;
+  }
+  // Registration is inside the guard too: applyMainOptions calls the advisor
+  // gate again while building the option list, so guarding only the memo key
+  // above would leave that path exposed (confirmed by forcing the gate to
+  // throw). If the option set cannot be built at all, every flag reads false —
+  // the same answer as an empty command line, and the real parse still runs
+  // afterwards and reports whatever is wrong.
+  let opts: Record<string, unknown> = {};
+  try {
+    const cmd = applyMainOptions(new Command())
+      .allowUnknownOption()
+      .exitOverride()
+      .configureOutput({ writeErr: () => {} });
+    // Validation is stripped, arity is kept. Whether a VALUE is acceptable has
+    // no bearing on whether `-p` was passed, but commander aborts the whole
+    // parse at a rejected value — so `--output-format bogus -p` resolved as NOT
+    // print, silently reversing these gates for every line with an invalid
+    // value earlier on it. Only the option's arity matters here, and that is
+    // untouched.
+    for (const option of cmd.options) {
+      const mutable = option as {
+        argChoices?: string[];
+        parseArg?: unknown;
+      };
+      mutable.argChoices = undefined;
+      mutable.parseArg = undefined;
+    }
+    try {
+      cmd.parseOptions([...tokens]);
+    } catch {
+      // A genuinely malformed line (e.g. `-p --model` with no value) can still
+      // throw on arity. commander populates opts() as it goes, so a flag it
+      // already parsed remains authoritative; the real parse reports the error.
+    }
+    opts = cmd.opts() as Record<string, unknown>;
+  } catch {
+    // fall through with no resolved flags
+  }
+  const result: HeadlessRoutingFlags = {
+    print: Boolean(opts.print),
+    initOnly: Boolean(opts.initOnly),
+    sdkUrl: Boolean(opts.sdkUrl),
+  };
+  headlessFlagsMemo = { key, result };
+  return result;
+}
+
+/** True when commander resolves `-p`/`--print`. See resolvesHeadlessFlags. */
+export function resolvesPrintMode(tokens: readonly string[]): boolean {
+  return resolvesHeadlessFlags(tokens).print;
+}
+
+/**
+ * The bypass flag applies to the session that EXECUTES tools. On a `cc://`
+ * connect or an `ssh` session that is the REMOTE session, so this local client
+ * must not enter bypassPermissions — mirroring the behaviour before the alias
+ * existed, where the flag was stripped from the argv the main command parsed.
+ * The raw flag still reaches the remote (`createDirectConnectSession` for
+ * `cc://`, `_pendingSSH.dangerouslySkipPermissions` for ssh), so callers must
+ * keep using the unmodified value there.
+ */
+export function localDangerouslySkipPermissions(
+  dangerouslySkipPermissions: boolean | undefined,
+  isPendingRemoteSession: boolean,
+): boolean | undefined {
+  return isPendingRemoteSession ? false : dangerouslySkipPermissions
+}
+
+/**
+ * Companion to {@link localDangerouslySkipPermissions} for `--permission-mode`.
+ *
+ * The bypass FLAG is not the only way to ask for bypass: `--permission-mode
+ * bypassPermissions|fullAccess` reaches the same resolver. For a pending remote
+ * session the tools run elsewhere, so honouring it locally would put this
+ * client into bypass through a second door while the first one is shut.
+ *
+ * Non-bypassing modes (plan, acceptEdits, …) pass through untouched — only the
+ * dangerous ones are dropped.
+ */
+export function localPermissionModeCli(
+  permissionModeCli: string | undefined,
+  isPendingRemoteSession: boolean,
+): string | undefined {
+  return isPendingRemoteSession &&
+    isDangerousPermissionMode(permissionModeCli as PermissionMode | undefined)
+    ? undefined
+    : permissionModeCli
+}
+
+/**
+ * Final backstop on the RESOLVED mode: a pending remote session must never leave
+ * this local client in a bypassing mode, whatever asked for it.
+ *
+ * The two input-side helpers cover the CLI sources and keep the resolver's
+ * notification coherent. Settings `permissions.defaultMode` is a third source,
+ * computed INSIDE `initialPermissionModeFromCLI` from the settings files and
+ * gated by neither CLI input — so it can only be neutralized here, on the way
+ * out. Acting on the resolved mode also means a future fourth source is covered
+ * by construction rather than needing another guard.
+ *
+ * Downgrades to `default`; non-bypassing modes (plan, acceptEdits, auto, …) are
+ * returned untouched.
+ */
+export function localResolvedPermissionMode(
+  mode: PermissionMode,
+  isPendingRemoteSession: boolean,
+): PermissionMode {
+  return isPendingRemoteSession && isDangerousPermissionMode(mode)
+    ? 'default'
+    : mode
+}

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -43,7 +43,7 @@ import { logError } from './utils/log.js'
 import { getRecentActivity } from './utils/logoV2Utils.js'
 import { lockCurrentVersion } from './utils/nativeInstaller/index.js'
 import { checkSupportedNodeVersion } from './utils/nodeRuntime.js'
-import type { PermissionMode } from './utils/permissions/PermissionMode.js'
+import { isDangerousPermissionMode, type PermissionMode } from './utils/permissions/PermissionMode.js'
 import { getPlanSlug } from './utils/plans.js'
 import { saveWorktreeState } from './utils/sessionStorage.js'
 import { profileCheckpoint } from './utils/startupProfiler.js'
@@ -380,11 +380,7 @@ export async function setup(
   }
 
   // If permission mode is set to bypass, verify we're in a safe environment
-  if (
-    permissionMode === 'bypassPermissions' ||
-    permissionMode === 'fullAccess' ||
-    allowDangerouslySkipPermissions
-  ) {
+  if (isDangerousPermissionMode(permissionMode) || allowDangerouslySkipPermissions) {
     // Check if running as root/sudo on Unix-like systems
     // Allow root if in a sandbox (e.g., TPU devspaces that require root)
     if (
@@ -394,9 +390,19 @@ export async function setup(
       process.env.IS_SANDBOX !== '1' &&
       !isEnvTruthy(process.env.CLAUDE_CODE_BUBBLEWRAP)
     ) {
+      // Name what actually triggered the gate: it fires for a bypassing
+      // permission mode (however it was set — --dangerously-skip-permissions,
+      // its --yolo alias, --permission-mode, or settings defaultMode) as well as
+      // for --allow-dangerously-skip-permissions.
+      // Distinguish the two triggers: a bypassing permission mode is active
+      // bypass, whereas --allow-dangerously-skip-permissions only makes it
+      // available — saying "bypass is active" for the latter would mislead.
+      const reason = isDangerousPermissionMode(permissionMode)
+        ? `Permission bypass (permission mode ${permissionMode})`
+        : '--allow-dangerously-skip-permissions'
       // biome-ignore lint/suspicious/noConsole:: intentional console output
       console.error(
-        `--dangerously-skip-permissions cannot be used with root/sudo privileges for security reasons`,
+        `${reason} cannot be used with root/sudo privileges for security reasons`,
       )
       process.exit(1)
     }

--- a/src/utils/earlyInput.test.ts
+++ b/src/utils/earlyInput.test.ts
@@ -1,0 +1,111 @@
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
+import {
+  isCapturingEarlyInput,
+  startCapturingEarlyInput,
+  stopCapturingEarlyInput,
+} from './earlyInput.js'
+
+// startCapturingEarlyInput reads process.argv and drives the REAL process.stdin
+// (setRawMode, ref, 'readable' listener). Under `bun test` stdin is usually not
+// a TTY, so the gate would never be reached; these stub the TTY surface and
+// restore every mutated descriptor afterwards so no raw-mode or listener state
+// leaks into other files.
+const STDIN_KEYS = ['isTTY', 'setEncoding', 'setRawMode', 'ref'] as const
+
+describe('startCapturingEarlyInput print-mode gate', () => {
+  let saved: Map<string, PropertyDescriptor | undefined>
+  let originalArgv: string[]
+  let rawModeCalls: boolean[]
+
+  beforeEach(() => {
+    originalArgv = process.argv
+    rawModeCalls = []
+    saved = new Map(
+      STDIN_KEYS.map(key => [
+        key,
+        Object.getOwnPropertyDescriptor(process.stdin, key),
+      ]),
+    )
+    const stub = {
+      isTTY: true,
+      setEncoding: () => process.stdin,
+      setRawMode: (mode: boolean) => {
+        rawModeCalls.push(mode)
+        return process.stdin
+      },
+      ref: () => process.stdin,
+    }
+    for (const key of STDIN_KEYS) {
+      Object.defineProperty(process.stdin, key, {
+        value: stub[key],
+        configurable: true,
+        writable: true,
+      })
+    }
+  })
+
+  afterEach(() => {
+    // Ordering matters: stop first (it removes the 'readable' listener via the
+    // stubbed stdin) and only then restore the descriptors.
+    stopCapturingEarlyInput()
+    for (const key of STDIN_KEYS) {
+      const descriptor = saved.get(key)
+      if (descriptor) {
+        Object.defineProperty(process.stdin, key, descriptor)
+      } else {
+        delete (process.stdin as unknown as Record<string, unknown>)[key]
+      }
+    }
+    process.argv = originalArgv
+  })
+
+  const startWith = (args: string[]): boolean => {
+    process.argv = ['node', 'openclaude', ...args]
+    startCapturingEarlyInput()
+    return isCapturingEarlyInput()
+  }
+
+  it('captures when no print flag is present', () => {
+    expect(startWith([])).toBe(true)
+    expect(rawModeCalls).toEqual([true])
+  })
+
+  it.each([[['--print']], [['-p']], [['-p', 'hi']], [['--print', 'hi']]])(
+    'blocks capture for %j (print mode)',
+    args => {
+      // Raw mode disables ISIG, so terminal Ctrl+C no longer raises SIGINT.
+      // Capturing under -p would make a headless run uninterruptible.
+      expect(startWith(args)).toBe(false)
+      expect(rawModeCalls).toEqual([])
+    },
+  )
+
+  it.each([[['--', '--print']], [['--', '-p']]])(
+    'still captures for %j — a post-`--` token is a positional, not print mode',
+    args => {
+      // This is the case the gate exists for: the ssh argv rewrite can emit a
+      // `--print` AFTER `--`, where commander treats it as a plain operand. A
+      // naive `argv.includes('--print')` scan would read that as print mode and
+      // silently drop the user's early keystrokes in an interactive session.
+      expect(startWith(args)).toBe(true)
+      expect(rawModeCalls).toEqual([true])
+    },
+  )
+
+  it('is idempotent — a second call does not re-enter raw mode', () => {
+    expect(startWith([])).toBe(true)
+    startCapturingEarlyInput()
+    expect(isCapturingEarlyInput()).toBe(true)
+    expect(rawModeCalls).toEqual([true])
+  })
+
+  it('does not capture when stdin is not a TTY', () => {
+    Object.defineProperty(process.stdin, 'isTTY', {
+      value: false,
+      configurable: true,
+      writable: true,
+    })
+    expect(startWith([])).toBe(false)
+    expect(rawModeCalls).toEqual([])
+  })
+})

--- a/src/utils/earlyInput.ts
+++ b/src/utils/earlyInput.ts
@@ -12,6 +12,7 @@
  */
 
 import { lastGrapheme } from './intl.js'
+import { resolvesPrintMode } from '../mainCliOptions.js'
 
 // Buffer for early input characters
 let earlyInputBuffer = ''
@@ -33,8 +34,9 @@ export function startCapturingEarlyInput(): void {
   if (
     !process.stdin.isTTY ||
     isCapturing ||
-    process.argv.includes('-p') ||
-    process.argv.includes('--print')
+    // Commander-authoritative: a post-`--` `--print` positional (produced by
+    // the ssh argv rewrite) is not print mode, so capture must still happen.
+    resolvesPrintMode(process.argv.slice(2))
   ) {
     return
   }

--- a/src/utils/gracefulShutdown.ts
+++ b/src/utils/gracefulShutdown.ts
@@ -43,6 +43,7 @@ import { isEnvTruthy } from './envUtils.js'
 import { getCurrentSessionTitle, sessionIdExists } from './sessionStorage.js'
 import { sleep } from './sleep.js'
 import { profileReport } from './startupProfiler.js'
+import { resolvesPrintMode } from '../mainCliOptions.js'
 
 /**
  * Clean up terminal modes synchronously before process exit.
@@ -264,7 +265,22 @@ export const setupGracefulShutdown = memoize(() => {
     // avoid racing with it. Only check print mode — other non-interactive
     // sessions (--sdk-url, --init-only, non-TTY) don't register their own
     // SIGINT handler and need gracefulShutdown to run.
-    if (process.argv.includes('-p') || process.argv.includes('--print')) {
+    // Commander-authoritative, matching the handler in main.tsx: a `-- --print`
+    // positional from the ssh rewrite is not print mode.
+    //
+    // Second layer, deliberately kept: resolvesHeadlessFlags guards its own
+    // config read and its option-set construction, so this should never fire.
+    // It stays because the consequence here is asymmetric — a throw in a SIGNAL
+    // handler leaves gracefulShutdown unreached and makes Ctrl-C a no-op, which
+    // is far worse than misclassifying print mode. Do not remove it on the
+    // grounds that the callee is already guarded.
+    let isPrintMode = false
+    try {
+      isPrintMode = resolvesPrintMode(process.argv.slice(2))
+    } catch {
+      // fall through to the shutdown path
+    }
+    if (isPrintMode) {
       return
     }
     logForDiagnosticsNoPII('info', 'shutdown_signal', { signal: 'SIGINT' })

--- a/src/utils/interactivity.test.ts
+++ b/src/utils/interactivity.test.ts
@@ -77,3 +77,34 @@ describe('isInteractiveSession', () => {
     ).toBe(false)
   })
 })
+
+describe('isInteractiveSession — post-`--` print positional (PR #1939 review P1)', () => {
+  test('stays interactive for the argv the ssh rewrite produces', () => {
+    // `openclaude ssh host -- --print` is deliberately NOT headless; the ssh
+    // flow rewrites argv to ['--','--print']. A token scan saw `--print` and
+    // classified the session non-interactive, so the main action took the
+    // headless branch instead of the SSH REPL branch.
+    const base = { stdoutIsTTY: true, env: {} as NodeJS.ProcessEnv }
+    expect(isInteractiveSession({ ...base, args: ['--', '--print'] })).toBe(true)
+    expect(isInteractiveSession({ ...base, args: ['--', '-p'] })).toBe(true)
+
+    // …while genuine print requests stay non-interactive, bundled shorts too.
+    expect(isInteractiveSession({ ...base, args: ['--print'] })).toBe(false)
+    expect(isInteractiveSession({ ...base, args: ['-p'] })).toBe(false)
+    expect(isInteractiveSession({ ...base, args: ['-pv'] })).toBe(false)
+  })
+
+  test('the same holds for --init-only and --sdk-url', () => {
+    // These were still raw token scans after the --print migration, so the same
+    // rewritten argv misclassified the session. One commander parse now resolves
+    // all three together.
+    const base = { stdoutIsTTY: true, env: {} as NodeJS.ProcessEnv }
+    expect(isInteractiveSession({ ...base, args: ['--', '--init-only'] })).toBe(true)
+    expect(isInteractiveSession({ ...base, args: ['--', '--sdk-url', 'x'] })).toBe(true)
+
+    expect(isInteractiveSession({ ...base, args: ['--init-only'] })).toBe(false)
+    expect(isInteractiveSession({ ...base, args: ['--sdk-url', 'x'] })).toBe(false)
+    // `=` form, which the old startsWith() scan caught and commander also does
+    expect(isInteractiveSession({ ...base, args: ['--sdk-url=x'] })).toBe(false)
+  })
+})

--- a/src/utils/interactivity.ts
+++ b/src/utils/interactivity.ts
@@ -1,3 +1,5 @@
+import { resolvesHeadlessFlags } from '../mainCliOptions.js';
+
 /**
  * Determines if the current session should be treated as interactive.
  * Robustly handles SSH sessions which might not report TTY status accurately.
@@ -10,11 +12,15 @@ export function isInteractiveSession(options: {
   const { stdoutIsTTY, args, env } = options;
 
   // Explicit non-interactive flags
-  const hasPrintFlag = args.includes('-p') || args.includes('--print');
-  const hasInitOnlyFlag = args.includes('--init-only');
-  const hasSdkUrl = args.some(arg => arg.startsWith('--sdk-url'));
+  // Commander-authoritative, not token scans: `openclaude ssh host -- --print`
+  // rewrites argv to a literal `-- --print` POSITIONAL, which is deliberately
+  // not headless. Scans classified it non-interactive, so the main action took
+  // the headless branch instead of the SSH REPL branch. One parse resolves all
+  // three flags, so they agree with each other and with the real parse — and it
+  // judges `-pv`, `--sdk-url=x` and `-- --init-only` the same way it will.
+  const { print, initOnly, sdkUrl } = resolvesHeadlessFlags(args);
 
-  if (hasPrintFlag || hasInitOnlyFlag || hasSdkUrl) {
+  if (print || initOnly || sdkUrl) {
     return false;
   }
 

--- a/src/utils/permissions/permissionSetup.test.ts
+++ b/src/utils/permissions/permissionSetup.test.ts
@@ -79,12 +79,89 @@ describe('getDangerousPermissionModeTransitionError', () => {
           shouldShow: true,
         }),
         shouldDisableBypassPermissions: async () => false,
+        isBypassPermissionsModeDisabled: () => false,
       },
     })
 
     expect(error).toBe(
       'Cannot set permission mode to fullAccess until the user explicitly confirms Full Access in a local interactive session',
     )
+  })
+
+  test('reports the settings-disabled reason instead of enablement guidance', async () => {
+    // Every other call site injects `() => false` to reach the guidance branch,
+    // which left the deny branch this dep controls untested: dropping the
+    // `deps.isBypassPermissionsModeDisabled()` call would keep the suite green
+    // while making a configuration-disabled bypass reachable.
+    const error = await getDangerousPermissionModeTransitionError({
+      mode: 'bypassPermissions',
+      toolPermissionContext: {
+        isBypassPermissionsModeAvailable: false,
+      },
+      requireLocalConfirmation: false,
+      deps: {
+        getStartupDangerousPermissionPromptState: () => ({
+          mode: 'bypassPermissions',
+          shouldShow: false,
+        }),
+        shouldDisableBypassPermissions: async () => false,
+        isBypassPermissionsModeDisabled: () => true,
+      },
+    })
+
+    expect(error).toContain('disabled by settings or configuration')
+    // and it must NOT hand out the enablement route while disabled
+    expect(error).not.toContain('--yolo')
+  })
+
+  test('names both spellings when bypass is not yet enabled (PR #1939)', async () => {
+    // The enablement message is the one place a blocked transition tells the
+    // user how to unblock it, so it has to mention the alias as well as the
+    // canonical flag — otherwise `--yolo` is undiscoverable from the error.
+    const error = await getDangerousPermissionModeTransitionError({
+      mode: 'bypassPermissions',
+      toolPermissionContext: {
+        isBypassPermissionsModeAvailable: false,
+      },
+      requireLocalConfirmation: false,
+      deps: {
+        getStartupDangerousPermissionPromptState: () => ({
+          mode: 'bypassPermissions',
+          shouldShow: false,
+        }),
+        shouldDisableBypassPermissions: async () => false,
+        isBypassPermissionsModeDisabled: () => false,
+      },
+    })
+
+    // Deterministic: the resolver consults isBypassPermissionsModeDisabled()
+    // BEFORE this branch and it reads settings plus the Statsig gate, so on a
+    // machine configured that way the guidance was never reached and the
+    // assertions silently skipped. It is injected above instead of branching on
+    // ambient state — and module mocking was not an option here, since bun's
+    // mock.module is process-wide and broke 84 tests elsewhere in this suite.
+    expect(error).toContain('--dangerously-skip-permissions (alias --yolo)')
+    expect(error).toContain('--allow-dangerously-skip-permissions')
+    expect(error).toContain('permissions.allowBypassPermissionsMode')
+
+    // …and the same guidance is given for fullAccess, which the flag also
+    // unblocks (it sets the shared isBypassPermissionsModeAvailable bit).
+    const fullAccessError = await getDangerousPermissionModeTransitionError({
+      mode: 'fullAccess',
+      toolPermissionContext: {
+        isBypassPermissionsModeAvailable: false,
+      },
+      requireLocalConfirmation: false,
+      deps: {
+        getStartupDangerousPermissionPromptState: () => ({
+          mode: 'fullAccess',
+          shouldShow: false,
+        }),
+        shouldDisableBypassPermissions: async () => false,
+        isBypassPermissionsModeDisabled: () => false,
+      },
+    })
+    expect(fullAccessError).toContain('--yolo')
   })
 
   test('uses the authoritative org gate for later dangerous-mode entry', async () => {
@@ -99,6 +176,7 @@ describe('getDangerousPermissionModeTransitionError', () => {
           shouldShow: false,
         }),
         shouldDisableBypassPermissions: async () => true,
+        isBypassPermissionsModeDisabled: () => false,
       },
     })
 
@@ -120,6 +198,7 @@ describe('getDangerousPermissionModeTransitionError', () => {
           mode: 'fullAccess',
         }),
         shouldDisableBypassPermissions: async () => false,
+        isBypassPermissionsModeDisabled: () => false,
       },
     })
 
@@ -140,6 +219,7 @@ describe('getDangerousPermissionModeTransitionError', () => {
           mode: 'fullAccess',
         }),
         shouldDisableBypassPermissions: async () => false,
+        isBypassPermissionsModeDisabled: () => false,
       },
     })
 

--- a/src/utils/permissions/permissionSetup.ts
+++ b/src/utils/permissions/permissionSetup.ts
@@ -1539,6 +1539,13 @@ export function isBypassPermissionsModeDisabled(): boolean {
 type DangerousPermissionModeTransitionValidationDeps = {
   getStartupDangerousPermissionPromptState: typeof getStartupDangerousPermissionPromptState
   shouldDisableBypassPermissions: typeof shouldDisableBypassPermissions
+  /**
+   * Injectable so a test can reach the branches BEHIND it: this reads settings
+   * and the Statsig gate, and when it returns true the function short-circuits,
+   * which silently skipped the enablement-guidance assertions on any machine
+   * configured that way.
+   */
+  isBypassPermissionsModeDisabled: typeof isBypassPermissionsModeDisabled
 }
 
 export type PermissionModeChangeRequestDecision =
@@ -1553,6 +1560,7 @@ const DEFAULT_DANGEROUS_PERMISSION_MODE_TRANSITION_VALIDATION_DEPS: DangerousPer
   {
     getStartupDangerousPermissionPromptState,
     shouldDisableBypassPermissions,
+    isBypassPermissionsModeDisabled,
   }
 
 export async function getPermissionModeChangeRequestDecision({
@@ -1656,7 +1664,7 @@ export async function getDangerousPermissionModeTransitionError({
     return undefined
   }
 
-  if (isBypassPermissionsModeDisabled()) {
+  if (deps.isBypassPermissionsModeDisabled()) {
     return `Cannot set permission mode to ${mode} because it is disabled by settings or configuration`
   }
 
@@ -1664,7 +1672,7 @@ export async function getDangerousPermissionModeTransitionError({
     !toolPermissionContext.isBypassPermissionsModeAvailable &&
     !allowSessionBypassPermissionsModeEnable
   ) {
-    return `Cannot set permission mode to ${mode}. Enable it with --allow-dangerously-skip-permissions or set permissions.allowBypassPermissionsMode in settings.json`
+    return `Cannot set permission mode to ${mode}. Enable it with --allow-dangerously-skip-permissions, start the session with --dangerously-skip-permissions (alias --yolo), or set permissions.allowBypassPermissionsMode in settings.json`
   }
 
   if (requireLocalConfirmation) {

--- a/src/utils/providerValidation.test.ts
+++ b/src/utils/providerValidation.test.ts
@@ -665,3 +665,26 @@ test('startup provider validation stays strict for non-interactive launches', ()
     }),
   ).toBe(true)
 })
+
+test('print resolution is commander-authoritative on a TTY (PR #1939 review)', () => {
+  const onTTY = (args: string[]) =>
+    shouldExitForStartupProviderValidationError({ args, stdoutIsTTY: true })
+
+  // `openclaude ssh host -- --print` rewrites argv to a literal `-- --print`
+  // POSITIONAL, which is not print mode — startup validation must not hard-exit.
+  expect(onTTY(['--', '--print'])).toBe(false)
+  expect(onTTY(['--', '-p'])).toBe(false)
+
+  // …while genuine print requests still gate, including a bundled short that a
+  // token scan missed before.
+  expect(onTTY(['--print'])).toBe(true)
+  expect(onTTY(['-p'])).toBe(true)
+  expect(onTTY(['-pv'])).toBe(true)
+
+  // …and the other two routing flags, migrated in the same commit
+  expect(onTTY(['--', '--init-only'])).toBe(false)
+  expect(onTTY(['--', '--sdk-url', 'x'])).toBe(false)
+  expect(onTTY(['--init-only'])).toBe(true)
+  expect(onTTY(['--sdk-url', 'x'])).toBe(true)
+  expect(onTTY(['--sdk-url=x'])).toBe(true)
+})

--- a/src/utils/providerValidation.ts
+++ b/src/utils/providerValidation.ts
@@ -50,6 +50,7 @@ import {
   redactSecretValueForDisplay,
   type SecretValueSource,
 } from './providerSecrets.js'
+import { resolvesHeadlessFlags } from '../mainCliOptions.js'
 
 function isEnvTruthy(value: string | undefined): boolean {
   if (!value) return false
@@ -658,12 +659,15 @@ export function shouldExitForStartupProviderValidationError(options: {
     return true
   }
 
-  return (
-    args.includes('-p') ||
-    args.includes('--print') ||
-    args.includes('--init-only') ||
-    args.some(arg => arg.startsWith('--sdk-url'))
-  )
+  // Commander-authoritative: see interactivity.ts. A post-`--` positional
+  // (produced by the ssh argv rewrite) must not make startup validation
+  // hard-exit on a TTY, for any of these three flags.
+  //
+  // Enumerated, not Object.values(): otherwise a fourth field added to
+  // HeadlessRoutingFlags would silently become a hard-exit trigger here while
+  // interactivity.ts (which destructures) stayed unaffected.
+  const { print, initOnly, sdkUrl } = resolvesHeadlessFlags(args)
+  return print || initOnly || sdkUrl
 }
 
 export async function validateProviderEnvForStartupOrExit(

--- a/src/utils/sshPreParse.test.ts
+++ b/src/utils/sshPreParse.test.ts
@@ -1,0 +1,926 @@
+import { describe, expect, it } from 'bun:test'
+import { Command } from '@commander-js/extra-typings'
+import { parseSshFlags } from './sshPreParse.js'
+import { applyMainOptions, resolvesPrintMode } from '../mainCliOptions.js'
+
+/** What the local main command makes of a token list (bypass + settings). */
+function mainReads(tokens: readonly string[]): {
+  settings: unknown
+  bypass: boolean
+} {
+  const cmd = applyMainOptions(new Command())
+    .allowUnknownOption()
+    .exitOverride()
+    .configureOutput({ writeErr: () => {} })
+  try {
+    cmd.parseOptions([...tokens])
+  } catch {
+    // an invalid value still leaves the flags parsed so far readable
+  }
+  const opts = cmd.opts() as Record<string, unknown>
+  return { settings: opts.settings, bypass: Boolean(opts.dangerouslySkipPermissions) }
+}
+
+describe('parseSshFlags (commander-authoritative, reuses main option arities)', () => {
+  it('extracts host, cwd, and permission-mode without enabling bypass', () => {
+    const r = parseSshFlags(['ssh', 'host', '/tmp', '--permission-mode', 'plan'])
+    expect(r.host).toBe('host')
+    expect(r.cwd).toBe('/tmp')
+    expect(r.permissionMode).toBe('plan')
+    expect(r.dangerouslySkipPermissions).toBe(false)
+  })
+
+  it('accepts ssh flags before the host positional', () => {
+    const r = parseSshFlags(['ssh', '--permission-mode', 'plan', 'host'])
+    expect(r.host).toBe('host')
+    expect(r.permissionMode).toBe('plan')
+  })
+
+  it('does not guess a host after an unrecognized flag (no wrong-host connect)', () => {
+    // commander treats the rest of the line as unknown once it meets a flag the
+    // ssh side doesn't own, so no host is found and the real `ssh` command
+    // reports the error — never a connection to the flag's value.
+    const r = parseSshFlags(['ssh', '--settings', 'foo.json', 'target-host'])
+    expect(r.host).toBeUndefined()
+    expect(r.dangerouslySkipPermissions).toBe(false)
+  })
+
+  it('forwards a value-bearing MAIN flag placed after the host', () => {
+    const r = parseSshFlags(['ssh', 'host', '--settings', 'foo.json'])
+    expect(r.host).toBe('host')
+    expect(r.cwd).toBeUndefined()
+    expect(r.forwardToMain).toEqual(['--settings', 'foo.json'])
+  })
+
+  it('a variadic MAIN flag before the host greedily consumes it (commander behavior)', () => {
+    // `--add-dir <dirs...>` is variadic, so `ssh --add-dir a b host` has no host
+    // (all three are dirs). parseSshFlags returns no host → main falls through to
+    // the real ssh command, which errors instead of connecting to a wrong host.
+    const r = parseSshFlags(['ssh', '--add-dir', 'a', 'b', 'target-host'])
+    expect(r.host).toBeUndefined()
+  })
+
+  it('forwards a variadic MAIN flag placed after the host', () => {
+    const r = parseSshFlags(['ssh', 'host', '--add-dir', 'a', 'b'])
+    expect(r.host).toBe('host')
+    expect(r.forwardToMain).toEqual(['--add-dir', 'a', 'b'])
+  })
+
+  it('enables bypass for a genuine standalone --yolo / canonical flag', () => {
+    const yolo = parseSshFlags(['ssh', 'host', '--yolo'])
+    expect(yolo.dangerouslySkipPermissions).toBe(true)
+    const canonical = parseSshFlags(['ssh', 'host', '--dangerously-skip-permissions'])
+    expect(canonical.dangerouslySkipPermissions).toBe(true)
+    // The token is FORWARDED verbatim. The ssh parse no longer registers the
+    // bypass option (it would misclaim a main option's value — see the
+    // value-slot suite below), so nothing removes it from argv. The local
+    // session is kept out of bypass at the permission-mode computation
+    // instead: localDangerouslySkipPermissions(flag, isPendingRemoteSession)
+    // in main.tsx, the same mechanism the cc:// path uses.
+    expect(yolo.forwardToMain).toEqual(['--yolo'])
+    expect(canonical.forwardToMain).toEqual(['--dangerously-skip-permissions'])
+  })
+
+  it('rejects an invalid --permission-mode instead of routing with it', () => {
+    // commander consumes the next token as the required value, then its
+    // .choices() rejects it — so we fall through and the real ssh command
+    // reports the allowed modes. A --yolo swallowed there is never a bypass.
+    for (const bad of ['--yolo', 'notamode']) {
+      const r = parseSshFlags(['ssh', 'host', '--permission-mode', bad])
+      expect(r.host).toBeUndefined()
+      expect(r.permissionMode).toBeUndefined()
+      expect(r.dangerouslySkipPermissions).toBe(false)
+    }
+    // A valid mode still routes.
+    const ok = parseSshFlags(['ssh', 'host', '--permission-mode', 'plan'])
+    expect(ok.host).toBe('host')
+    expect(ok.permissionMode).toBe('plan')
+  })
+
+  it('does NOT enable bypass for a --yolo positional after --', () => {
+    const r = parseSshFlags(['ssh', 'host', '/tmp', '--', '--yolo'])
+    expect(r.dangerouslySkipPermissions).toBe(false)
+    expect(r.host).toBe('host')
+    expect(r.cwd).toBe('/tmp')
+    expect(r.forwardToMain).toEqual(['--', '--yolo'])
+  })
+
+  it('forwards a repeated option verbatim (the main parse applies last-value)', () => {
+    const r = parseSshFlags(['ssh', 'host', '--settings', 'a', '--settings', 'b'])
+    expect(r.forwardToMain).toEqual(['--settings', 'a', '--settings', 'b'])
+  })
+
+  it('forwards ssh model/resume/continue to the remote, not the local main', () => {
+    const r = parseSshFlags(['ssh', 'host', '--model', 'gpt', '--continue'])
+    expect(r.host).toBe('host')
+    expect(r.extraCliArgs).toEqual(['--continue', '--model', 'gpt'])
+    expect(r.forwardToMain).toEqual([])
+  })
+
+  it('parses --local (ssh-side flag, not forwarded to the main command)', () => {
+    const r = parseSshFlags(['ssh', '--local', 'host'])
+    expect(r.local).toBe(true)
+    expect(r.host).toBe('host')
+    expect(r.forwardToMain).toEqual([])
+    expect(parseSshFlags(['ssh', 'host']).local).toBe(false)
+  })
+
+  it('forwards local main flags (e.g. --debug) to the main command', () => {
+    const r = parseSshFlags(['ssh', 'host', '--debug'])
+    expect(r.host).toBe('host')
+    expect(r.forwardToMain).toEqual(['--debug'])
+  })
+
+  it('treats --help/-h in option position as a no-route signal', () => {
+    expect(parseSshFlags(['ssh', 'host', '--help']).host).toBeUndefined()
+    expect(parseSshFlags(['ssh', 'host', '-h']).host).toBeUndefined()
+    // but --help after -- is positional, so the ssh flow still routes
+    expect(parseSshFlags(['ssh', 'host', '--', '--help']).host).toBe('host')
+  })
+
+  it('returns no host when none is given', () => {
+    expect(parseSshFlags(['ssh', '--help']).host).toBeUndefined()
+    expect(parseSshFlags(['ssh']).host).toBeUndefined()
+  })
+
+  it('does not throw on invalid usage; falls through with no host', () => {
+    expect(() => parseSshFlags(['ssh', 'host', '--model'])).not.toThrow()
+    expect(parseSshFlags(['ssh', 'host', '--model']).host).toBeUndefined()
+  })
+
+  it('emits nothing to stderr on invalid usage (no duplicate diagnostics)', () => {
+    const originalWrite = process.stderr.write
+    let captured = ''
+    process.stderr.write = ((chunk: unknown) => {
+      captured += String(chunk)
+      return true
+    }) as typeof process.stderr.write
+    try {
+      parseSshFlags(['ssh', 'host', '--model'])
+    } finally {
+      process.stderr.write = originalWrite
+    }
+    expect(captured).toBe('')
+  })
+})
+
+describe('parseSshFlags — forwarded token fidelity', () => {
+  it('forwards --chrome without also emitting --no-chrome', () => {
+    // --chrome/--no-chrome share one commander attribute, so both Option
+    // instances report source 'cli'; only the matching polarity may forward.
+    const on = parseSshFlags(['ssh', 'host', '--chrome'])
+    expect(on.forwardToMain).toEqual(['--chrome'])
+    const off = parseSshFlags(['ssh', 'host', '--no-chrome'])
+    expect(off.forwardToMain).toEqual(['--no-chrome'])
+  })
+
+  it('preserves values of options whose parser coerces to true', () => {
+    // --debug/--debug-file coerce to `true`, but utils/debug.ts reads the raw
+    // argv, so the value and its exact form must survive forwarding.
+    expect(parseSshFlags(['ssh', 'host', '--debug=api,hooks']).forwardToMain).toEqual([
+      '--debug=api,hooks',
+    ])
+    expect(
+      parseSshFlags(['ssh', 'host', '--debug-file', '/tmp/x.log']).forwardToMain,
+    ).toEqual(['--debug-file', '/tmp/x.log'])
+  })
+})
+
+describe('parseSshFlags — optional-arg options mirror commander', () => {
+  it('an optional-arg flag consumes the next token exactly as commander does', () => {
+    // commander's `--debug [filter]` consumes a following non-dash token, so
+    // `ssh --debug host` has NO host (it became the filter) and falls through
+    // to the real ssh command — the forwarded pairing matches that consumption.
+    const before = parseSshFlags(['ssh', '--debug', 'host'])
+    expect(before.host).toBeUndefined()
+
+    // After the host, the same rule applies to the following token.
+    const after = parseSshFlags(['ssh', 'host', '--debug', '/tmp'])
+    expect(after.host).toBe('host')
+    expect(after.cwd).toBeUndefined()
+    expect(after.forwardToMain).toEqual(['--debug', '/tmp'])
+
+    // With nothing to consume, the bare flag forwards alone.
+    expect(parseSshFlags(['ssh', 'host', '--debug']).forwardToMain).toEqual([
+      '--debug',
+    ])
+  })
+})
+
+describe('parseSshFlags — dash-prefixed required values', () => {
+  it('never mistakes a dash-prefixed VALUE for an ssh-side short', () => {
+    // `-c.json` is --mcp-config's value, not --continue.
+    const r = parseSshFlags(['ssh', 'host', '--mcp-config', '-c.json'])
+    expect(r.extraCliArgs).toEqual([])
+    expect(r.forwardToMain).toEqual(['--mcp-config', '-c.json'])
+  })
+
+  it('forwards a dash-prefixed required value (jatmn P2)', () => {
+    // commander consumes a required value unconditionally, so `-foo` is the
+    // path here; dropping it would make the main parse fail "argument missing".
+    const r = parseSshFlags(['ssh', 'host', '--debug-file', '-foo'])
+    expect(r.host).toBe('host')
+    expect(r.forwardToMain).toEqual(['--debug-file', '-foo'])
+  })
+
+  it('does not steal a following option as an OPTIONAL arg value', () => {
+    // `--debug [filter]` must not swallow `--verbose`; both forward separately.
+    const r = parseSshFlags(['ssh', 'host', '--debug', '--verbose'])
+    expect(r.forwardToMain).toContain('--debug')
+    expect(r.forwardToMain).toContain('--verbose')
+  })
+})
+
+describe('parseSshFlags — repeated coerced options', () => {
+  it('forwards every occurrence verbatim, letting the main parse pick last', () => {
+    // Pass-through (not reconstruction) keeps the exact `=` form and both
+    // occurrences; the local main command re-parses and applies last-value.
+    const r = parseSshFlags(['ssh', 'host', '--debug=api', '--debug=hooks'])
+    expect(r.forwardToMain).toEqual(['--debug=api', '--debug=hooks'])
+  })
+})
+
+describe('parseSshFlags — bundled short flags', () => {
+  it('forwards a bundled short cluster instead of dropping it', () => {
+    // commander expands `-pv` itself (nothing lands in `unknown`), so an
+    // exact-match-only walk would silently drop it.
+    const r = parseSshFlags(['ssh', 'host', '-pv'])
+    expect(r.host).toBe('host')
+    // Forwarded verbatim — the local parse expands the cluster itself.
+    expect(r.forwardToMain).toEqual(['-pv'])
+  })
+
+  it('claims a bare -c but leaves clusters verbatim', () => {
+    // `-c` alone is ssh-side (goes to the remote). A cluster is passed through
+    // untouched, exactly as before this alias existed — expanding it here would
+    // mean re-implementing commander's tokenizer.
+    expect(parseSshFlags(['ssh', 'host', '-c']).extraCliArgs).toEqual(['--continue'])
+    expect(parseSshFlags(['ssh', 'host', '-c']).forwardToMain).toEqual([])
+    // Both halves of the cluster's routing are pinned: it is forwarded whole,
+    // so its `-c` applies --continue LOCALLY and nothing is sent to the remote.
+    // Asserting only forwardToMain would let a future change that starts
+    // expanding clusters flip the routing without failing this test.
+    expect(parseSshFlags(['ssh', 'host', '-cr']).forwardToMain).toEqual(['-cr'])
+    expect(parseSshFlags(['ssh', 'host', '-cr']).extraCliArgs).toEqual([])
+  })
+
+})
+
+describe('parseSshFlags — dual-long options', () => {
+  it('forwards either spelling of a dual-long option with its value', () => {
+    // `--allowedTools, --allowed-tools <tools...>`: commander keeps the second
+    // spelling in Option.long and the first in Option.short, so both are matched
+    // and neither the flag nor its value can be dropped or shift the host.
+    for (const flag of ['--allowedTools', '--allowed-tools']) {
+      const r = parseSshFlags(['ssh', 'host', flag, 'Edit'])
+      expect(r.host).toBe('host')
+      expect(r.cwd).toBeUndefined()
+      expect(r.forwardToMain).toEqual([flag, 'Edit'])
+    }
+    const d = parseSshFlags(['ssh', 'host', '--disallowedTools', 'Bash'])
+    expect(d.forwardToMain).toEqual(['--disallowedTools', 'Bash'])
+  })
+})
+
+describe('parseSshFlags — post-`--` operands are never the remote cwd (jatmn P1)', () => {
+  it('forwards post-`--` data instead of mapping it onto cwd', () => {
+    for (const token of ['--yolo', '--print', '-p', 'prompt']) {
+      const r = parseSshFlags(['ssh', 'host', '--', token])
+      expect(r.host).toBe('host')
+      expect(r.cwd).toBeUndefined()
+      expect(r.forwardToMain).toEqual(['--', token])
+      expect(r.dangerouslySkipPermissions).toBe(false)
+      expect(r.headless).toBe(false)
+    }
+  })
+
+  it('still takes a genuine pre-`--` positional as cwd', () => {
+    const r = parseSshFlags(['ssh', 'host', '/tmp', '--', '--yolo'])
+    expect(r.cwd).toBe('/tmp')
+    expect(r.forwardToMain).toEqual(['--', '--yolo'])
+  })
+})
+
+describe('parseSshFlags — variadic dash-prefixed values (jatmn P2)', () => {
+  it('forwards a dash-prefixed first value like commander consumes it', () => {
+    // commander: `--add-dir -foo` → addDir: ['-foo']; dropping it would leave
+    // the local parse missing a required value.
+    expect(parseSshFlags(['ssh', 'host', '--add-dir', '-foo']).forwardToMain).toEqual([
+      '--add-dir',
+      '-foo',
+    ])
+    expect(parseSshFlags(['ssh', 'host', '--tools', '-x']).forwardToMain).toEqual([
+      '--tools',
+      '-x',
+    ])
+  })
+
+  it('still collects multiple non-dash variadic values', () => {
+    expect(parseSshFlags(['ssh', 'host', '--add-dir', 'a', 'b']).forwardToMain).toEqual([
+      '--add-dir',
+      'a',
+      'b',
+    ])
+  })
+})
+
+describe('parseSshFlags — a `--` consumed as an ssh option value', () => {
+  it('is not treated as the end-of-options marker', () => {
+    // commander gives `--model` the `--` as its value, so what follows is a
+    // normal token — not positional data behind a marker.
+    const m = parseSshFlags(['ssh', 'host', '--model', '--'])
+    expect(m.extraCliArgs).toEqual(['--model', '--'])
+    expect(m.cwd).toBeUndefined()
+
+    // …so the next token is still an ordinary positional (the remote cwd).
+    const withCwd = parseSshFlags(['ssh', 'host', '--model', '--', 'x'])
+    expect(withCwd.cwd).toBe('x')
+
+    // For an option with .choices(), swallowing `--` makes the value invalid,
+    // so the route is abandoned and the real ssh command reports the choices —
+    // and critically the trailing --yolo never becomes a silent bypass.
+    const bad = parseSshFlags(['ssh', 'host', '--permission-mode', '--', '--yolo'])
+    expect(bad.host).toBeUndefined()
+    expect(bad.dangerouslySkipPermissions).toBe(false)
+  })
+})
+
+describe('parseSshFlags — a `--` consumed by a MAIN-only required-value option', () => {
+  // `--settings`/`--system-prompt`/… take a required value, and commander will
+  // give them a following `--` as that value. The `--` is therefore NOT an
+  // end-of-options marker, so the `--yolo` after it sits in genuine option
+  // position: the remote session must be granted bypass, matching what
+  // commander resolves for the identical tokens with no `ssh` in front.
+  //
+  // The end-of-options boundary is derived from the full option arities for
+  // exactly this reason — an earlier version used a hand-listed set of
+  // value-taking flags, split here, and computed the remote bypass as false
+  // while commander said true (caught in review).
+  // --debug-file is included deliberately: its argParser returns `true` and
+  // discards the raw text, so a check that looked for a stored literal `--`
+  // would miss it. The boundary test compares parse failures instead.
+  for (const flag of [
+    '--settings',
+    '--system-prompt',
+    '--session-id',
+    '--debug-file',
+    '--mcp-config',
+  ]) {
+    it(`grants remote bypass for \`${flag} -- --yolo\`, matching commander`, () => {
+      const userTokens = [flag, '--', '--yolo']
+      const r = parseSshFlags(['ssh', 'host', ...userTokens])
+
+      expect(r.host).toBe('host')
+      expect(r.cwd).toBeUndefined()
+      // commander gives the `--` to the required-value option, so this `--yolo`
+      // is a real flag — the remote session gets bypass
+      expect(r.dangerouslySkipPermissions).toBe(true)
+      expect(mainReads(userTokens).bypass).toBe(true)
+      // the split still round-trips: what main receives is what the user typed
+      expect(r.forwardToMain).toEqual(userTokens)
+      expect(mainReads(r.forwardToMain)).toEqual(mainReads(userTokens))
+    })
+  }
+
+  it('still treats a genuine end-of-options `--` as an escape', () => {
+    // no option is waiting for a value, so this `--` IS the marker: the trailing
+    // token is positional data and must not grant bypass anywhere.
+    const r = parseSshFlags(['ssh', 'host', '--', '--yolo'])
+    expect(r.host).toBe('host')
+    expect(r.cwd).toBeUndefined()
+    expect(r.dangerouslySkipPermissions).toBe(false)
+    expect(r.forwardToMain).toEqual(['--', '--yolo'])
+  })
+
+  it('does not let an earlier swallowed `--` mask a later real marker', () => {
+    // `--settings` eats the first `--`; the second is a genuine marker, so the
+    // trailing --yolo is positional and grants nothing.
+    const r = parseSshFlags(['ssh', 'host', '--settings', '--', '--', '--yolo'])
+    expect(r.host).toBe('host')
+    expect(r.dangerouslySkipPermissions).toBe(false)
+  })
+})
+
+
+
+describe('parseSshFlags — bypass flag BEFORE the host (PR #1939 review P1)', () => {
+  // An unrecognized flag ahead of the host stops commander collecting operands,
+  // so leaving the bypass option unregistered made `ssh --yolo host` find no
+  // host at all and skip the whole ssh flow — it fell through to the stub `ssh`
+  // usage handler. The pre-refactor path stripped the token before host
+  // detection, so this worked; it has to keep working.
+  const cases: Array<[string[], string | undefined, boolean, string[]]> = [
+    // tokens                                   host      remote bypass  forwarded
+    [['--yolo', 'host'], 'host', true, []],
+    [['--dangerously-skip-permissions', 'host'], 'host', true, []],
+    [['--yolo', 'host', '/tmp'], 'host', true, []],
+    [['--yolo', '--local', 'host'], 'host', true, []],
+    // …and the value-slot protection is unaffected by that registration
+    [['host', '--debug-file', '--yolo'], 'host', false, ['--debug-file', '--yolo']],
+    [['host', '--settings', '--yolo', '--yolo'], 'host', true, ['--settings', '--yolo', '--yolo']],
+  ]
+
+  for (const [tokens, host, bypass, forwarded] of cases) {
+    it(`ssh ${tokens.join(' ')}`, () => {
+      const r = parseSshFlags(['ssh', ...tokens])
+      expect(r.host).toBe(host as string)
+      expect(r.dangerouslySkipPermissions).toBe(bypass)
+      expect(r.forwardToMain).toEqual(forwarded)
+    })
+  }
+
+  it('binds the cwd too when the flag precedes both positionals', () => {
+    expect(parseSshFlags(['ssh', '--yolo', 'host', '/tmp']).cwd).toBe('/tmp')
+  })
+
+  it('binds the host when a bare -c precedes it', () => {
+    // Same class as the bypass case: `-c` is deliberately absent from the LEAN
+    // parse (there it would read `--mcp-config -c.json` as a cluster and forge
+    // a --continue), so the positional parse has to know it or commander stops
+    // collecting operands. origin/main stripped `-c` by index before looking
+    // for the host, so this worked before the refactor.
+    const c = parseSshFlags(['ssh', '-c', 'host'])
+    expect(c.host).toBe('host')
+    expect(c.extraCliArgs).toEqual(['--continue'])
+    // and the host is NOT left in argv as a stray local prompt
+    expect(c.forwardToMain).toEqual([])
+
+    expect(parseSshFlags(['ssh', '-c', 'host', '/tmp']).cwd).toBe('/tmp')
+    expect(parseSshFlags(['ssh', '-c', '--local', 'host']).local).toBe(true)
+
+    // combined with the bypass flag, either order
+    for (const tokens of [
+      ['-c', '--yolo', 'host'],
+      ['--yolo', '-c', 'host'],
+    ]) {
+      const r = parseSshFlags(['ssh', ...tokens])
+      expect(r.host).toBe('host')
+      expect(r.dangerouslySkipPermissions).toBe(true)
+      expect(r.extraCliArgs).toEqual(['--continue'])
+      expect(r.forwardToMain).toEqual([])
+    }
+  })
+
+  it('binds the host when a bare -r precedes it, and claims it for the remote', () => {
+    // Same class as `-c`: `--resume` is long-only in the claiming parse (a `-r`
+    // there would read `--mcp-config -r.json` as a cluster), so the positional
+    // parse has to know the short or commander stops collecting operands.
+    // origin/main extracted `-r` by index, so both halves worked before.
+    const r = parseSshFlags(['ssh', '-r', 'id', 'host'])
+    expect(r.host).toBe('host')
+    expect(r.extraCliArgs).toEqual(['--resume', 'id'])
+    expect(r.forwardToMain).toEqual([])
+
+    // …and in the position that already bound the host, where the REMOTE was
+    // silently losing the resume (it was forwarded to the local command).
+    const after = parseSshFlags(['ssh', 'host', '-r', 'id'])
+    expect(after.host).toBe('host')
+    expect(after.extraCliArgs).toEqual(['--resume', 'id'])
+    expect(after.forwardToMain).toEqual([])
+
+    // bare `-r` with no value (the option's value is optional)
+    expect(parseSshFlags(['ssh', 'host', '-r']).extraCliArgs).toEqual(['--resume'])
+    // alongside -c
+    expect(parseSshFlags(['ssh', '-c', '-r', 'id', 'host']).extraCliArgs).toEqual([
+      '--continue',
+      '--resume',
+      'id',
+    ])
+  })
+
+  it('drops every claimed -r span, not just the first', () => {
+    // commander keeps the LAST value, so a single-index removal would forward
+    // the other span to the local command and replay the resume there.
+    for (const tokens of [
+      ['host', '-r', 'a', '-r', 'b'],
+      ['-r', 'a', '-r', 'b', 'host'],
+      ['host', '-r', 'a', '--resume', 'b'],
+      ['host', '--resume', 'b', '-r', 'a'],
+    ]) {
+      const r = parseSshFlags(['ssh', ...tokens])
+      expect(r.host).toBe('host')
+      expect(r.extraCliArgs).toEqual(['--resume', 'b'])
+      expect(r.forwardToMain).toEqual([])
+    }
+
+    // a bare `-r` with no value consumes nothing after it
+    expect(parseSshFlags(['ssh', 'host', '-r']).forwardToMain).toEqual([])
+    // …and a `-r` sitting in a value slot is still left alone
+    expect(
+      parseSshFlags(['ssh', 'host', '--mcp-config', '-r']).forwardToMain,
+    ).toEqual(['--mcp-config', '-r'])
+  })
+
+  it('leaves a short alone when it is the value of a value-DISCARDING option', () => {
+    // `--debug-file <path>` has an argParser returning `true`, so the raw text is
+    // gone from the resolved options — a check that inspected values could not
+    // see that `-c` here is a VALUE, and stripped it out of the forwarded line,
+    // leaving --debug-file without its argument.
+    const c = parseSshFlags(['ssh', 'host', '--continue', '--debug-file', '-c'])
+    expect(c.extraCliArgs).toEqual(['--continue'])
+    expect(c.forwardToMain).toEqual(['--debug-file', '-c'])
+
+    const r = parseSshFlags(['ssh', 'host', '--resume', 'x', '--debug-file', '-r'])
+    expect(r.extraCliArgs).toEqual(['--resume', 'x'])
+    expect(r.forwardToMain).toEqual(['--debug-file', '-r'])
+
+    // a line carrying BOTH a real short and one in a value slot fails safe:
+    // the flag goes to the local command rather than risking the value
+    const both = parseSshFlags(['ssh', 'host', '-c', '--debug-file', '-c'])
+    expect(both.extraCliArgs).toEqual([])
+    expect(both.forwardToMain).toEqual(['-c', '--debug-file', '-c'])
+
+    // …and the ordinary cases still claim the short for the remote
+    expect(parseSshFlags(['ssh', 'host', '-c']).extraCliArgs).toEqual(['--continue'])
+    expect(parseSshFlags(['ssh', 'host', '-r', 'id']).extraCliArgs).toEqual([
+      '--resume',
+      'id',
+    ])
+  })
+
+  it('adding -r to the positional parse does not forge a --resume', () => {
+    const r = parseSshFlags(['ssh', 'host', '--mcp-config', '-r.json'])
+    expect(r.host).toBe('host')
+    expect(r.extraCliArgs).toEqual([])
+    expect(r.forwardToMain).toEqual(['--mcp-config', '-r.json'])
+  })
+
+  it('adding -c to the positional parse does not forge a --continue', () => {
+    // The lean parse still owns claiming, so a dash-prefixed VALUE is untouched.
+    const r = parseSshFlags(['ssh', 'host', '--mcp-config', '-c.json'])
+    expect(r.host).toBe('host')
+    expect(r.extraCliArgs).toEqual([])
+    expect(r.forwardToMain).toEqual(['--mcp-config', '-c.json'])
+  })
+
+  it('still reads the ssh-side flags that follow the bypass token', () => {
+    // Commander stops collecting OPERANDS at a token it doesn't recognize, but
+    // keeps parsing OPTIONS — so the ssh-side fields are intact even though the
+    // positionals had to come from the bypass-registered parse.
+    expect(parseSshFlags(['ssh', '--yolo', '--local', 'host']).local).toBe(true)
+    expect(
+      parseSshFlags(['ssh', '--yolo', '--permission-mode', 'plan', 'host'])
+        .permissionMode,
+    ).toBe('plan')
+    expect(
+      parseSshFlags(['ssh', '--yolo', '--model', 'sonnet', 'host']).extraCliArgs,
+    ).toEqual(['--model', 'sonnet'])
+    expect(
+      parseSshFlags(['ssh', '--yolo', '--continue', 'host']).extraCliArgs,
+    ).toEqual(['--continue'])
+    expect(
+      parseSshFlags(['ssh', '--yolo', '--fallback-model', 'm', 'host'])
+        .extraCliArgs,
+    ).toEqual(['--fallback-model', 'm'])
+
+    // …and all of it together, with a cwd
+    const all = parseSshFlags([
+      'ssh',
+      '--dangerously-skip-permissions',
+      '--local',
+      '--model',
+      'm',
+      'host',
+      '/tmp',
+    ])
+    expect(all.host).toBe('host')
+    expect(all.cwd).toBe('/tmp')
+    expect(all.local).toBe(true)
+    expect(all.dangerouslySkipPermissions).toBe(true)
+    expect(all.extraCliArgs).toEqual(['--model', 'm'])
+  })
+})
+
+describe('parseSshFlags — a bypass token in a MAIN option VALUE slot', () => {
+  // Regression for PR #1939 review P1: the ssh-only parse used to register the
+  // bypass option itself. Not knowing main's arities, it claimed the token in
+  // `ssh host --debug-file --yolo` as a bypass request AND swallowed it, so the
+  // REMOTE session started with permission bypass while the main command lost
+  // the value it needed. Whether the flag is set is now asked of the full main
+  // option set, and the token is forwarded verbatim.
+  const cases: Array<[string[], boolean]> = [
+    [['--debug-file', '--yolo'], false],
+    [['--settings', '--yolo'], false],
+    [['--mcp-config', '--yolo'], false],
+    [['--system-prompt', '--dangerously-skip-permissions'], false],
+    // …while a genuine flag still enables it, including after a value slot has
+    // eaten an earlier occurrence (the case that made occurrence-counting
+    // unworkable in the deleted claimBypassFlag).
+    [['--yolo'], true],
+    [['--settings', '--yolo', '--yolo'], true],
+    [['--yolo', '--settings', 'x'], true],
+  ]
+
+  for (const [userTokens, expectedRemoteBypass] of cases) {
+    it(`${userTokens.join(' ')} -> remote bypass ${expectedRemoteBypass}`, () => {
+      const r = parseSshFlags(['ssh', 'host', ...userTokens])
+      expect(r.host).toBe('host')
+      expect(r.dangerouslySkipPermissions).toBe(expectedRemoteBypass)
+      // nothing is consumed or reordered: main sees exactly what was typed
+      expect(r.forwardToMain).toEqual(userTokens)
+      expect(mainReads(r.forwardToMain)).toEqual(mainReads(userTokens))
+    })
+  }
+})
+
+describe('parseSshFlags — post-`--` print token survives the argv rewrite', () => {
+  it('detects headless via commander, including a bundled -p', () => {
+    expect(parseSshFlags(['ssh', 'host', '-pv']).headless).toBe(true)
+    expect(parseSshFlags(['ssh', 'host', '-p']).headless).toBe(true)
+    expect(parseSshFlags(['ssh', 'host', '--print']).headless).toBe(true)
+    // positional after `--` is data, not headless mode
+    expect(parseSshFlags(['ssh', 'host', '/tmp', '--', '--print']).headless).toBe(false)
+    expect(parseSshFlags(['ssh', 'host']).headless).toBe(false)
+  })
+
+  // Regression for PR #1939 review P1: `ssh host -- --print` is NOT headless,
+  // but main.tsx rewrites argv to `-- --print`, and the print-mode gates there
+  // used a raw token scan that saw `--print` and took the local print path
+  // instead of opening the interactive remote session.
+  it('is invisible to a commander-authoritative print check', () => {
+    const r = parseSshFlags(['ssh', 'host', '--', '--print'])
+    expect(r.host).toBe('host')
+    expect(r.headless).toBe(false)
+    expect(r.forwardToMain).toEqual(['--', '--print'])
+
+    // The rewritten argv is what main.tsx's print gates see. A token scan gets
+    // this wrong; resolvesPrintMode (what those gates now use) does not.
+    expect(r.forwardToMain.includes('--print')).toBe(true) // the trap
+    expect(resolvesPrintMode(r.forwardToMain)).toBe(false) // the fix
+
+    // and a real print request is still detected after the rewrite
+    const headless = parseSshFlags(['ssh', 'host', '-p'])
+    expect(headless.headless).toBe(true)
+  })
+})
+
+describe('parseSshFlags — ssh controls in a MAIN option VALUE slot', () => {
+  // The ssh-only parse does not know main arities, so it would claim a control
+  // that commander gives to a preceding required-value option: `ssh host
+  // --settings --local` would start a LOCAL test session AND drop the user's
+  // --settings value. The arity-aware parse is authoritative; when the two
+  // disagree the line is abandoned so the real `ssh` command reports usage.
+  for (const [control, tokens] of [
+    ['--local', ['--settings', '--local']],
+    ['--model', ['--settings', '--model', 'x']],
+    ['--resume', ['--settings', '--resume']],
+    ['--continue', ['--settings', '--continue']],
+    ['--local after another value flag', ['--system-prompt', '--local']],
+    ['--local after a valueless-parser flag', ['--debug-file', '--local']],
+  ] as Array<[string, string[]]>) {
+    it(`does not claim ${control} from a value slot`, () => {
+      const r = parseSshFlags(['ssh', 'host', ...tokens])
+      expect(r.host).toBeUndefined()
+      expect(r.local).toBe(false)
+      expect(r.extraCliArgs).toEqual([])
+    })
+  }
+
+  it('still honours the same controls when they are genuinely present', () => {
+    expect(parseSshFlags(['ssh', 'host', '--local']).local).toBe(true)
+    expect(parseSshFlags(['ssh', 'host', '--model', 'x']).extraCliArgs).toEqual([
+      '--model',
+      'x',
+    ])
+    expect(parseSshFlags(['ssh', 'host', '--continue']).extraCliArgs).toEqual([
+      '--continue',
+    ])
+    expect(parseSshFlags(['ssh', 'host', '--resume', 'id']).extraCliArgs).toEqual([
+      '--resume',
+      'id',
+    ])
+    expect(
+      parseSshFlags(['ssh', 'host', '--permission-mode', 'plan']).permissionMode,
+    ).toBe('plan')
+
+    // …including after a value flag that IS satisfied, which is the case the
+    // check must not confuse with a value slot
+    const satisfied = parseSshFlags(['ssh', 'host', '--settings', 'f.json', '--local'])
+    expect(satisfied.host).toBe('host')
+    expect(satisfied.local).toBe(true)
+  })
+})
+
+describe('parseSshFlags — help detection when a required value is missing', () => {
+  it('sees --help/-h in commander `unknown` (assumption of the short-circuit)', () => {
+    // The help short-circuit reads mainUnknown. That only works because
+    // commander 12.1.0's parseOptions() reports help flags as unknown rather
+    // than handling them itself — parse() is what acts on help, not
+    // parseOptions(). Pinned here so a commander upgrade that moves help
+    // handling into parseOptions fails loudly instead of silently routing an
+    // `ssh host --help` into a real ssh session.
+    const cmd = applyMainOptions(new Command())
+      .allowUnknownOption()
+      .exitOverride()
+      .configureOutput({ writeErr: () => {}, writeOut: () => {} })
+    const { unknown } = cmd.parseOptions(['host', '--help'])
+    expect(unknown).toEqual(['--help'])
+
+    const short = applyMainOptions(new Command())
+      .allowUnknownOption()
+      .exitOverride()
+      .configureOutput({ writeErr: () => {}, writeOut: () => {} })
+    expect(short.parseOptions(['host', '-h']).unknown).toEqual(['-h'])
+
+    // …and the behaviour that rests on it, both directions
+    expect(parseSshFlags(['ssh', 'host', '--help']).host).toBeUndefined()
+    expect(parseSshFlags(['ssh', 'host', '-h']).host).toBeUndefined()
+    // a --help in a VALUE slot is not a help request
+    expect(parseSshFlags(['ssh', 'host', '--debug-file', '--help']).host).toBe('host')
+  })
+
+  // The short-circuit reads commander's `unknown` list. A required value missing
+  // at the END of the line throws before commander returns that list, which left
+  // it empty and made `ssh host --help --settings` route instead of falling
+  // through to the real `ssh` help.
+  it('still short-circuits on --help/-h before a valueless option', () => {
+    for (const tokens of [
+      ['--help', '--settings'],
+      ['-h', '--settings'],
+      ['--help', '--system-prompt'],
+      ['--settings', 'x', '--help'],
+    ]) {
+      const r = parseSshFlags(['ssh', 'host', ...tokens])
+      expect(r.host).toBeUndefined()
+      expect(r.forwardToMain).toEqual([])
+    }
+  })
+
+  it('short-circuits even when the missing value belongs to a VALIDATING option', () => {
+    // The retry appends a filler token to satisfy arity, but an option with
+    // .choices() or a throwing argParser rejects it, so commander again reports
+    // no `unknown` and the help token was invisible — the route proceeded to a
+    // real connect. These are the shapes the earlier --settings/--system-prompt
+    // coverage missed, because those accept any string.
+    for (const tokens of [
+      ['--help', '--output-format'], // .choices()
+      ['--help', '--effort'], // throwing argParser
+      ['-h', '--thinking'], // .choices(), short form
+      ['--help', '--max-turns'], // numeric argParser
+      ['--help', '--max-budget-usd'], // numeric argParser
+      ['-h', '--teammate-mode'], // .choices()
+      ['--help', '--permission-mode'], // .choices(), also ssh-side
+    ]) {
+      const r = parseSshFlags(['ssh', 'host', ...tokens])
+      expect(r.host).toBeUndefined()
+      expect(r.forwardToMain).toEqual([])
+    }
+  })
+
+  it('does not turn a --help VALUE into a help request', () => {
+    // `--settings --help` gives --help to --settings, so this is a real route.
+    const r = parseSshFlags(['ssh', 'host', '--settings', '--help'])
+    expect(r.host).toBe('host')
+    expect(r.forwardToMain).toEqual(['--settings', '--help'])
+  })
+
+  it('never leaks the retry filler token into the result', () => {
+    // The filler only ever reaches the throwaway retry parse; forwarding comes
+    // from the ssh-side parses, so it cannot appear downstream.
+    const r = parseSshFlags(['ssh', 'host', '--settings'])
+    expect(JSON.stringify(r)).not.toContain('filler')
+  })
+})
+
+describe('parseSshFlags — main-option VALUES are never read as ssh controls', () => {
+  it('does not treat a --help in a value slot as a help request', () => {
+    // `--debug-file --help`: --help is the path value, so the ssh flow routes.
+    const r = parseSshFlags(['ssh', 'host', '--debug-file', '--help'])
+    expect(r.host).toBe('host')
+    expect(r.forwardToMain).toEqual(['--debug-file', '--help'])
+    // A genuine help request still short-circuits…
+    expect(parseSshFlags(['ssh', 'host', '--help']).host).toBeUndefined()
+    // …and a post-`--` one is data, so the ssh flow routes.
+    expect(parseSshFlags(['ssh', 'host', '--', '--help']).host).toBe('host')
+  })
+
+  it('does not claim a -c that is another option value as --continue', () => {
+    const r = parseSshFlags(['ssh', 'host', '--mcp-config', '-c'])
+    expect(r.extraCliArgs).toEqual([])
+    expect(r.forwardToMain).toEqual(['--mcp-config', '-c'])
+    // The genuine short flag is still claimed for the remote.
+    expect(parseSshFlags(['ssh', 'host', '-c']).extraCliArgs).toEqual(['--continue'])
+
+    // …even when a long --continue elsewhere on the line also sets the option,
+    // the `-c` that is another option's value must survive.
+    const both = parseSshFlags(['ssh', 'host', '--continue', '--mcp-config', '-c'])
+    expect(both.extraCliArgs).toEqual(['--continue'])
+    expect(both.forwardToMain).toEqual(['--mcp-config', '-c'])
+  })
+})
+
+describe('parseSshFlags — host validity and headless after a rejected value', () => {
+  it('does not treat an empty operand as a host', () => {
+    // `ssh "$HOST" --yolo` with HOST unset passed main.tsx's `host !== undefined`
+    // route check while failing the Boolean(host) gate that arms the
+    // remote-bypass guards — leaving a LOCAL session running every tool
+    // bypassing, with no remote at all. origin/main printed the usage error.
+    const empty = parseSshFlags(['ssh', '', '--yolo'])
+    expect(empty.host).toBeUndefined()
+    expect(parseSshFlags(['ssh', '']).host).toBeUndefined()
+    expect(parseSshFlags(['ssh', '', '/tmp']).host).toBeUndefined()
+    // a real host is unaffected
+    expect(parseSshFlags(['ssh', 'host', '--yolo']).host).toBe('host')
+  })
+
+  it('still resolves headless when an earlier option rejects its value', () => {
+    // headless came from a mainOpts snapshot taken after commander aborted at
+    // the rejected value, so the guard in main.tsx was silently skipped and the
+    // ssh line fell through to the LOCAL print path.
+    expect(parseSshFlags(['ssh', 'host', '--output-format', 'bogus', '-p']).headless).toBe(true)
+    expect(parseSshFlags(['ssh', 'host', '--thinking', 'bogus', '-p']).headless).toBe(true)
+    expect(parseSshFlags(['ssh', 'host', '-p']).headless).toBe(true)
+    // post-`--` print is still positional data, not a print request
+    expect(parseSshFlags(['ssh', 'host', '--', '--print']).headless).toBe(false)
+  })
+})
+
+describe('parseSshFlags — short clusters BEFORE the host', () => {
+  it('credits the parse that claimed the cluster', () => {
+    // The lean parse does not register the shorts and the exact-token checks
+    // never match a cluster, so a cluster claimed by the positional parse used
+    // to reach NEITHER destination: absent from extraCliArgs, and absent from
+    // positionalUnknown which the swap adopts. It simply disappeared.
+    const rid = parseSshFlags(['ssh', '-rid', 'host'])
+    expect(rid.host).toBe('host')
+    expect(rid.extraCliArgs).toEqual(['--resume', 'id'])
+    expect(rid.forwardToMain).toEqual([])
+
+    // `-cr host /tmp`: commander gives `host` to -r's OPTIONAL value, so /tmp is
+    // the first free operand. Surprising, but identical to what the main grammar
+    // does with the same tokens — and the flags now reach the remote either way.
+    const cr = parseSshFlags(['ssh', '-cr', 'host', '/tmp'])
+    expect(cr.host).toBe('/tmp')
+    expect(cr.extraCliArgs).toEqual(['--continue', '--resume', 'host'])
+    expect(cr.forwardToMain).toEqual([])
+
+    // `-cr host` binds no host at all for the same reason (`host` is -r's
+    // value), so the route is abandoned and the real ssh command reports usage.
+    expect(parseSshFlags(['ssh', '-cr', 'host']).host).toBeUndefined()
+
+    // the non-clustered forms are unchanged
+    expect(parseSshFlags(['ssh', '-c', 'host']).extraCliArgs).toEqual(['--continue'])
+    expect(parseSshFlags(['ssh', '-r', 'id', 'host']).extraCliArgs).toEqual([
+      '--resume',
+      'id',
+    ])
+    // …and a short in a value slot is still left alone
+    expect(
+      parseSshFlags(['ssh', 'host', '--debug-file', '-c']).forwardToMain,
+    ).toEqual(['--debug-file', '-c'])
+  })
+})
+
+describe('parseSshFlags — a claimed --permission-mode never reaches the local command', () => {
+  it('keeps the mode out of forwardToMain entirely', () => {
+    // Unlike the bypass FLAG (forwarded on purpose and neutralized later at the
+    // permission-mode computation), the mode is claimed for the remote and must
+    // not be forwarded at all: `--permission-mode bypassPermissions` reaching
+    // the local command would put THIS session into a dangerous mode, which no
+    // later backstop would undo because it arrives as a legitimate CLI request.
+    for (const mode of [
+      'bypassPermissions',
+      'fullAccess',
+      'plan',
+      'acceptEdits',
+    ] as const) {
+      const r = parseSshFlags(['ssh', 'host', '--permission-mode', mode])
+      expect(r.permissionMode).toBe(mode)
+      expect(r.forwardToMain).toEqual([])
+      expect(r.forwardToMain.join(' ')).not.toContain('--permission-mode')
+    }
+
+    // …including before the host, where the positional parse is the claimant
+    const before = parseSshFlags(['ssh', '--permission-mode', 'plan', 'host'])
+    expect(before.host).toBe('host')
+    expect(before.permissionMode).toBe('plan')
+    expect(before.forwardToMain).toEqual([])
+  })
+})
+
+describe('parseSshFlags — bypass token in a value-DISCARDING option slot', () => {
+  it('does not claim it, and keeps the option its argument', () => {
+    // `--debug-file <path>` has an argParser returning `true`, so the raw text
+    // is gone from the resolved options. The value-shaped guard could not see
+    // that the second `--yolo` here is --debug-file's VALUE: the operand swap
+    // applied, the positional parse claimed it as a bypass request, and the
+    // forwarded line came out as ['--debug-file'] — argument missing.
+    for (const spelling of ['--yolo', '--dangerously-skip-permissions']) {
+      const tokens = [spelling, 'host', '--debug-file', spelling]
+      const r = parseSshFlags(['ssh', ...tokens])
+      // ambiguous from the ssh side, so the route is abandoned and the real
+      // `ssh` command reports usage — never a silently truncated argv
+      expect(r.host).toBeUndefined()
+      expect(r.forwardToMain).toEqual(tokens)
+    }
+
+    // the unambiguous shapes are unchanged
+    expect(parseSshFlags(['ssh', '--yolo', 'host']).host).toBe('host')
+    expect(parseSshFlags(['ssh', '--yolo', 'host']).dangerouslySkipPermissions).toBe(true)
+    expect(parseSshFlags(['ssh', '--yolo', 'host', '/tmp']).cwd).toBe('/tmp')
+    // and a bypass token that is purely a value still grants nothing
+    const valueOnly = parseSshFlags(['ssh', 'host', '--debug-file', '--yolo'])
+    expect(valueOnly.dangerouslySkipPermissions).toBe(false)
+    expect(valueOnly.forwardToMain).toEqual(['--debug-file', '--yolo'])
+  })
+})

--- a/src/utils/sshPreParse.ts
+++ b/src/utils/sshPreParse.ts
@@ -1,0 +1,476 @@
+import { Command, Option } from '@commander-js/extra-typings'
+import {
+  PERMISSION_MODES,
+  type PermissionMode,
+} from './permissions/PermissionMode.js'
+import {
+  applyMainOptions,
+  BYPASS_PERMISSIONS_FLAGS,
+  resolvesHeadlessFlags,
+} from '../mainCliOptions.js'
+
+/**
+ * Result of parsing the flags of a `claude ssh <host> [dir] …` invocation,
+ * before the main command is run. Extracted from main.tsx so the parsing is
+ * unit-testable.
+ */
+export interface SshFlagParse {
+  host: string | undefined
+  cwd: string | undefined
+  local: boolean
+  /**
+   * Narrowed to the known modes: the pre-parse registers this option with
+   * `.choices(PERMISSION_MODES)`, so an invalid value throws and the whole
+   * route is abandoned — nothing outside the union can reach a caller.
+   */
+  permissionMode: PermissionMode | undefined
+  dangerouslySkipPermissions: boolean
+  /** True when commander resolved -p/--print (headless), incl. bundled shorts. */
+  headless: boolean
+  /** Flags forwarded to the remote CLI's initial spawn (e.g. `--model <m>`). */
+  extraCliArgs: string[]
+  /** Leftover (local main-command) flags handed to the local main command / TUI. */
+  forwardToMain: string[]
+}
+
+// Factory (not a shared constant) so each caller gets its own fresh arrays and
+// a mutation can't leak between invocations.
+const noHostResult = (): SshFlagParse => ({
+  host: undefined,
+  cwd: undefined,
+  local: false,
+  permissionMode: undefined,
+  dangerouslySkipPermissions: false,
+  headless: false,
+  extraCliArgs: [],
+  forwardToMain: [],
+})
+
+/**
+ * The FULL option set: every main option plus the ssh-only `--local`.
+ *
+ * Built in one place because the correctness argument in this file rests on the
+ * three users of it — the end-of-options boundary probe, the authoritative
+ * `mainOpts` read, and the help-detection retry — seeing an IDENTICAL set. A
+ * divergent copy would silently break the comparisons those make against the
+ * ssh-side parses.
+ */
+function fullOptionCommand() {
+  return applyMainOptions(new Command())
+    .option('--local')
+    .allowUnknownOption()
+    .exitOverride()
+    .configureOutput({ writeErr: () => {} })
+}
+
+/**
+ * Whether the FULL option set (every main option plus the ssh-only `--local`)
+ * rejects these tokens.
+ *
+ * NOTE: each call pays a complete option registration (~150 options). That is
+ * fine for the handful of probes an ssh line needs — two per `--`, two per short
+ * occurrence — but a future loop over every token would multiply it silently.
+ *
+ * Rejects these tokens — used only to compare two prefixes, never to report an
+ * error, which the real parse does.
+ */
+function fullParseThrows(prefix: readonly string[]): boolean {
+  const cmd = fullOptionCommand()
+  try {
+    cmd.parseOptions([...prefix])
+    return false
+  } catch {
+    return true
+  }
+}
+
+/**
+ * Index of the end-of-options marker, or -1 when the line has none.
+ *
+ * A `--` is the marker unless an option consumed it as its VALUE, which is
+ * asked of commander rather than a hand-maintained list of value-taking flags:
+ * drop the `--` and, if an option is left without its required value (the parse
+ * now fails) while keeping it parses cleanly, that option had swallowed it.
+ *
+ * Comparing the two prefixes — rather than inspecting the stored value for a
+ * literal `--` — matters because an argParser can discard the raw text
+ * (`--debug-file <path>` resolves to `true`), and because a `--` swallowed
+ * EARLIER on the line must not mask a later genuine marker.
+ */
+function endOfOptionsIndex(tokens: readonly string[]): number {
+  for (let i = 0; i < tokens.length; i += 1) {
+    if (tokens[i] !== '--') continue
+    const consumedAsValue =
+      fullParseThrows(tokens.slice(0, i)) && !fullParseThrows(tokens.slice(0, i + 1))
+    if (consumedAsValue) continue
+    return i
+  }
+  return -1
+}
+
+/**
+ * The ssh-side option set, in one of two variants — see parseSshFlags for why
+ * both are needed.
+ *
+ * `forPositionals` registers the flags that exist purely so commander keeps
+ * COLLECTING OPERANDS past them (it stops at the first token it doesn't know):
+ * the bypass flag and the bare `-c` short. The lean variant must NOT know them,
+ * because there they would CLAIM tokens: the bypass flag would swallow one
+ * sitting in a main option's value slot, and `-c` would read a dash-prefixed
+ * value like `--mcp-config -c.json` as a cluster and forge a --continue.
+ */
+function sshOnlyCommand(forPositionals: boolean) {
+  const cmd = new Command()
+    .option('--local')
+    // Same choices as the real ssh command: an invalid mode (including a flag
+    // swallowed as the value, `--permission-mode --yolo`) throws here, so we
+    // fall through and commander reports the allowed choices instead of routing
+    // an ssh session with a bogus mode.
+    .addOption(
+      new Option('--permission-mode <mode>').choices(PERMISSION_MODES),
+    )
+    // The short is added only in the positional variant (see above); the lean
+    // parse matches a bare `-c` exactly, further down, where no arity reasoning
+    // is involved.
+    .option(forPositionals ? '-c, --continue' : '--continue')
+    .option(forPositionals ? '-r, --resume [value]' : '--resume [value]')
+    .option('--model <model>')
+    .option('--fallback-model <model>')
+    .allowUnknownOption()
+    .exitOverride()
+    // Silence this throwaway pre-parse's error output; the real `ssh` command
+    // parse reports invalid usage to the user, so we must not double-print it.
+    .configureOutput({ writeErr: () => {} })
+  return forPositionals ? cmd.option(BYPASS_PERMISSIONS_FLAGS) : cmd
+}
+
+/**
+ * Parse a `claude ssh …` line by SUBTRACTION: a throwaway commander command
+ * registers only the ssh-side options, so commander itself claims those (with
+ * their values) and hands everything it doesn't recognize back in `unknown`,
+ * verbatim. Nothing here re-implements commander's tokenizer — clusters
+ * (`-pn notes`), `=` forms (`--print=x`), bare `-` values and dash-prefixed
+ * values all pass through exactly as typed, because we never inspect them.
+ *
+ * host/cwd are the first two positionals commander reports for the pre-`--`
+ * head, so a token after `--` can never become the remote `[dir]`.
+ *
+ * `rawCliArgs` starts with the `ssh` token (i.e. `process.argv.slice(2)`).
+ *
+ * Note: an unrecognized flag before the host makes commander treat the rest of
+ * the line as unknown, so no host is found and the real `ssh` command reports
+ * the error — the same outcome as before this alias existed. Put ssh flags
+ * after the host (`ssh host --add-dir a b`).
+ */
+export function parseSshFlags(rawCliArgs: readonly string[]): SshFlagParse {
+  // TWO ssh-side parses, differing only in whether the bypass flag is
+  // registered. Neither alone is right, and each is used only for what it is
+  // provably right about:
+  //
+  //   forwarding  — `cmd` (bypass NOT registered). Registering it makes
+  //                 commander claim a token in a main option's VALUE slot
+  //                 (`ssh host --debug-file --yolo`), swallowing the value.
+  //                 Unregistered, the token stays in `unknown` and is
+  //                 forwarded verbatim.
+  //   positionals — `positionalCmd`. An unrecognized flag BEFORE the host makes
+  //                 commander stop collecting operands, so without those
+  //                 registrations `ssh --yolo host` and `ssh -c host` find no
+  //                 host at all and the whole ssh flow is skipped — both
+  //                 regressions caught in review (origin/main stripped those
+  //                 tokens by index before looking for the host).
+  //
+  // Whether bypass is actually SET is never taken from either: that comes from
+  // the full main option set below, which knows every arity.
+  const cmd = sshOnlyCommand(false)
+  const positionalCmd = sshOnlyCommand(true)
+
+  // Split at the end-of-options marker: tokens after it are
+  // positional data for the local main command, never the remote `[dir]`.
+  // Parsing only the head keeps commander from mapping `ssh host -- --yolo`'s
+  // trailing token onto operands[1] (i.e. cwd).
+  const args = [...rawCliArgs.slice(1)]
+  const eooIndex = endOfOptionsIndex(args)
+  const head = eooIndex === -1 ? args : args.slice(0, eooIndex)
+  const tail = eooIndex === -1 ? [] : args.slice(eooIndex + 1)
+
+  let operands: string[]
+  let unknown: string[]
+  let positionalOperands: string[]
+  let positionalUnknown: string[]
+  try {
+    ;({ operands, unknown } = cmd.parseOptions([...head]))
+    // Both halves are captured here rather than re-parsing later: a second pass
+    // over the same instance is idempotent only while no ssh-side option uses a
+    // collect accumulator, and nothing should depend on that staying true.
+    ;({ operands: positionalOperands, unknown: positionalUnknown } =
+      positionalCmd.parseOptions([...head]))
+  } catch {
+    return noHostResult()
+  }
+  // Decisions that depend on MAIN-option arity are asked of the main option set,
+  // never of the ssh-only parse above: to that parse a main option's VALUE looks
+  // like a flag (`--debug-file --help`, `--mcp-config -c`).
+  // Registers `--local` too (see fullOptionCommand), so this arity-aware parse
+  // can answer for every ssh control — see the value-slot check below.
+  const mainParse = fullOptionCommand()
+  let mainUnknown: string[] = []
+  try {
+    ;({ unknown: mainUnknown } = mainParse.parseOptions([...head]))
+  } catch {
+    // A required value missing at the END of the line (`ssh host --help
+    // --settings`) throws before commander returns what it did not recognize,
+    // leaving `mainUnknown` empty — and the help short-circuit below reads it,
+    // so the route would proceed instead of falling through to `ssh --help`.
+    //
+    // Retry once with a filler token so the arity is satisfied and commander can
+    // report `unknown`. The filler is dash-free, so it can only ever be consumed
+    // as that option's value or land as an operand — never mistaken for a flag,
+    // and never able to ADD a token to `unknown`. Only the unknown list is taken
+    // from the retry; `mainOpts` stays with the original parse, which holds what
+    // the user actually typed. The real parse still reports the usage error.
+    const retry = fullOptionCommand()
+    try {
+      ;({ unknown: mainUnknown } = retry.parseOptions([
+        ...head,
+        'openclaude-missing-value-filler',
+      ]))
+    } catch {
+      // The filler satisfies ARITY, not VALIDATION: an option with `.choices()`
+      // or a throwing argParser (`--output-format`, `--effort`, `--thinking`,
+      // `--max-turns`, …) rejects it, and commander again never reports what it
+      // did not recognize. Fall back to the ssh-side parse, which classifies a
+      // help token correctly for its own arities. Only reachable on a line that
+      // is already invalid, where rendering usage beats opening a connection.
+      mainUnknown = unknown
+    }
+  }
+  const mainOpts = mainParse.opts() as Record<string, unknown>
+
+  // A help request in option position is a no-route signal: fall through so
+  // commander's real `ssh` command renders ITS help. A `--help` that is another
+  // option's value is not a help request, which is why this consults the main
+  // parse rather than the ssh-only one.
+  if (mainUnknown.includes('--help') || mainUnknown.includes('-h')) {
+    return noHostResult()
+  }
+  const o = cmd.opts() as Record<string, unknown>
+
+  // The ssh-only parse does not know MAIN option arities, so it can claim a
+  // control that is really some main option's VALUE: in `ssh host --settings
+  // --local`, commander gives `--local` to `--settings`, but the ssh-only parse
+  // sees a flag and would start a LOCAL test session while silently dropping
+  // the user's --settings value.
+  //
+  // The bypass flag avoids this by not being registered in that parse at all;
+  // the rest cannot, because they must be claimed (they go to the remote, and
+  // `--local` is not a main option, so forwarding it would make the local
+  // command reject an unknown option). Instead, compare the two views: the
+  // arity-aware parse is authoritative about whether the control is really
+  // there. If it disagrees, the line is ambiguous from the ssh side — abandon
+  // the route and let the real `ssh` command report usage, exactly as for an
+  // invalid --permission-mode or a --help in option position.
+  // `continue` is included: the LONG form is registered in the ssh-only parse,
+  // so it can be misclaimed from a value slot. A bare `-c` cannot — that short
+  // is deliberately unregistered there — so this can only ever fire on a real
+  // mis-claim, never on the shortContinue path handled below.
+  const misclaimedControls = [
+    'local',
+    'permissionMode',
+    'model',
+    'fallbackModel',
+    'resume',
+    'continue',
+  ].filter(
+    key => Boolean(o[key]) && !mainOpts[key],
+  )
+  if (misclaimedControls.length > 0) {
+    return noHostResult()
+  }
+
+  // ssh/remote-side flags forwarded to the remote spawn.
+  // Value-shaped, not position-aware: this asks whether ANY resolved main
+  // option value is exactly `-c`, so a line carrying both a real `-c` flag and
+  // an unrelated `-c` value (`ssh host -c --mcp-config -c`) suppresses
+  // shortContinue. That fails safe — `--continue` is forwarded to the local
+  // main command rather than silently claimed for the remote — and precise
+  // positions would require re-walking commander's token consumption, which
+  // this file exists to avoid.
+  // `-c` is ssh-side, but only when commander agrees it is a flag here: in
+  // `--mcp-config -c` it is that option's value and must stay in forwardToMain.
+  // `mainOpts.continue` alone isn't enough — a long `--continue` elsewhere on
+  // the line sets it too, so also require that no main option swallowed a `-c`.
+  // Was the token at this index consumed as some option's VALUE? Asked by
+  // dropping it and seeing whether the parse then fails for a missing required
+  // value — the same probe the end-of-options boundary uses, and for the same
+  // reason: inspecting the resolved values misses options whose argParser
+  // DISCARDS the raw text (`--debug-file <path>` resolves to `true`), so
+  // `ssh host --continue --debug-file -c` looked like a genuine `-c` and its
+  // value was stripped out of the forwarded line.
+  const isValueSlot = (index: number): boolean =>
+    fullParseThrows(head.slice(0, index)) &&
+    !fullParseThrows(head.slice(0, index + 1))
+
+  /**
+   * Whether this short appears in FLAG position, and nowhere in a value slot.
+   * Shared by the `-c` and `-r` checks so a third short cannot drift. Requiring
+   * no value-slot occurrence is deliberately conservative: a line carrying both
+   * (`ssh host -c --debug-file -c`) forwards the flag to the local command
+   * rather than risk stripping the other occurrence, which is a value.
+   */
+  const hasOnlyFlagPositionOccurrences = (token: string): boolean => {
+    const indices = head.flatMap((t, i) => (t === token ? [i] : []))
+    return indices.length > 0 && !indices.some(isValueSlot)
+  }
+  const consumedAsValue = !hasOnlyFlagPositionOccurrences('-c')
+  const shortContinue =
+    Boolean(mainOpts.continue) && head.includes('-c') && !consumedAsValue
+  // Same treatment for `-r`: long-only in the claiming parse (a `-r` there would
+  // read `--mcp-config -r.json` as a cluster), so a bare short is recognised via
+  // the arity-aware parse instead. Without this the REMOTE lost the resume —
+  // origin/main extracted it with indexOf before this refactor.
+  const resumeConsumedAsValue = !hasOnlyFlagPositionOccurrences('-r')
+  const shortResume =
+    mainOpts.resume !== undefined &&
+    o.resume === undefined &&
+    head.includes('-r') &&
+    !resumeConsumedAsValue
+  // Whatever commander didn't claim is forwarded verbatim — that IS the
+  // subtraction — so the real parse reports typos rather than this throwaway
+  // swallowing them. exitOverride() means invalid usage throws above, in which
+  // case we fall through and let the real parse report it.
+  // Did registering the bypass flag change which positionals commander found?
+  // If so, a bypass token stood in FLAG position ahead of the host: the
+  // bypass-registered parse is then the accurate view of the whole line, and
+  // its `unknown` (which excludes the token it legitimately claimed, and the
+  // positionals it collected) is what should be forwarded. Otherwise the two
+  // parses agree on positionals and the unregistered parse is authoritative,
+  // keeping a value-slot token from being swallowed.
+  //
+  // Guard: if the main parse attributes a bypass spelling to some option's
+  // VALUE, the bypass-registered view cannot be trusted to have claimed only
+  // real flags, so stay with the conservative parse — at worst no host is
+  // found and the real `ssh` command reports usage, which is the documented
+  // outcome for any main-only flag placed before the host.
+  // Derived from the constant, never re-listed: an alias added there must not
+  // silently slip past this guard.
+  const bypassSpellings = new Set(
+    BYPASS_PERMISSIONS_FLAGS.split(',')
+      .map(flag => flag.trim())
+      .filter(flag => flag.startsWith('--')),
+  )
+  // Detected with the arity probe, not by inspecting resolved VALUES: an
+  // argParser can discard the raw text (`--debug-file <path>` resolves to
+  // `true`), so a value-shaped check could not see the second `--yolo` in
+  // `ssh --yolo host --debug-file --yolo`. The swap then applied, the positional
+  // parse claimed that token as a bypass request, and the forwarded line lost
+  // --debug-file's argument. Same fix already used for the `-c`/`-r` shorts.
+  const bypassInValueSlot = head.some(
+    (token, index) => bypassSpellings.has(token) && isValueSlot(index),
+  )
+  const fullerParseBoundTheHost =
+    !bypassInValueSlot && positionalOperands.length > operands.length
+  if (fullerParseBoundTheHost) {
+    operands = positionalOperands
+    unknown = positionalUnknown
+  }
+
+  // When the positional parse is the one that bound the host, IT is also the
+  // parse that claimed any short cluster (`ssh -cr host`): the lean parse does
+  // not register the shorts, and the exact-token checks below never match a
+  // cluster. Without crediting it here the cluster reaches neither the remote
+  // (extraCliArgs) nor the local command (it is absent from positionalUnknown,
+  // which the swap adopts) — it simply disappeared.
+  const positionalOpts = positionalCmd.opts() as Record<string, unknown>
+  const claimed = fullerParseBoundTheHost ? positionalOpts : o
+
+  const extraCliArgs: string[] = []
+  if (claimed.continue || shortContinue) extraCliArgs.push('--continue')
+  const resumeValue =
+    claimed.resume !== undefined
+      ? claimed.resume
+      : shortResume
+        ? mainOpts.resume
+        : undefined
+  if (resumeValue !== undefined) {
+    extraCliArgs.push('--resume')
+    if (typeof resumeValue === 'string') extraCliArgs.push(resumeValue)
+  }
+  // ALL SIX ssh controls come from `claimed` — continue, resume, model,
+  // fallbackModel, local and permissionMode — rather than from `o`.
+  //
+  // Reading any of them from `o` is correct only while that spelling is
+  // long-only in both variants, so the two parses cannot disagree. That is a
+  // property of the current registrations, not a rule: registering a short for
+  // one in the positional variant would silently lose its value in the cluster
+  // case, which is the bug crediting `claimed` was added to fix.
+  if (typeof claimed.model === 'string') extraCliArgs.push('--model', claimed.model)
+  if (typeof claimed.fallbackModel === 'string') {
+    extraCliArgs.push('--fallback-model', claimed.fallbackModel)
+  }
+
+
+  let forwardToMain = shortContinue
+    ? unknown.filter(t => t !== '-c')
+    : [...unknown]
+  // Strip whenever resume was claimed for the remote AT ALL, not only when the
+  // short was the source: `-r a --resume b` resolves to `b` from the long form,
+  // and leaving the short's span behind would replay it on the local command.
+  if (
+    resumeValue !== undefined &&
+    head.includes('-r') &&
+    !resumeConsumedAsValue
+  ) {
+    // Claimed for the remote above, so it must not also reach the local command.
+    // EVERY occurrence is dropped, not just the first: commander keeps the last
+    // value (`-r a -r b` resolves to `b`), so removing one span would forward
+    // the other. The following token is consumed only when it is not
+    // dash-prefixed, which is commander's rule for an OPTIONAL value.
+    const kept: string[] = []
+    for (let i = 0; i < forwardToMain.length; i += 1) {
+      const token = forwardToMain[i]!
+      if (token !== '-r') {
+        kept.push(token)
+        continue
+      }
+      const next = forwardToMain[i + 1]
+      if (next !== undefined && !next.startsWith('-')) i += 1
+    }
+    forwardToMain = kept
+  }
+  // Positional data — extra pre-`--` operands plus everything after `--` — is
+  // handed to the main command behind a `--` so its parse cannot re-read a
+  // token like `--yolo` as a bypass flag (e.g. `ssh host -- --yolo`).
+  const positionalTail = [...operands.slice(2), ...tail]
+  if (positionalTail.length > 0) forwardToMain.push('--', ...positionalTail)
+
+  return {
+    // An empty operand is not a host: `ssh "$HOST" --yolo` with HOST unset used
+    // to pass main.tsx's `host !== undefined` route check while failing the
+    // Boolean(host) gate that arms the remote-bypass guards, leaving a LOCAL
+    // session running every tool bypassing with no remote at all.
+    host: operands[0] ? operands[0] : undefined,
+    cwd: operands[1],
+    local: Boolean(claimed.local),
+    // Safe by construction: `.choices(PERMISSION_MODES)` rejected anything
+    // else before this point (an invalid mode returns noHostResult above).
+    permissionMode:
+      typeof claimed.permissionMode === 'string'
+        ? (claimed.permissionMode as PermissionMode)
+        : undefined,
+    // Arity-aware: true only when commander, knowing every main option's
+    // arity, resolves the flag as SET — not when it sits in a value slot.
+    dangerouslySkipPermissions: Boolean(mainOpts.dangerouslySkipPermissions),
+    // -p/--print isn't an ssh-side option, so ask the main option set (still
+    // commander, never a token scan): that judges bundled shorts and value
+    // positions, and only the pre-`--` head is considered.
+    // Resolved through the shared helper, NOT from the mainOpts snapshot:
+    // parseOptions stops at a rejected value, so `ssh host --output-format bogus
+    // -p` left print unset and silently skipped the headless rejection in
+    // main.tsx. resolvesHeadlessFlags strips validation (arity is all that
+    // matters for whether -p was passed) and is what every other startup gate
+    // uses, so this decision cannot drift from theirs.
+    headless: resolvesHeadlessFlags(head).print,
+    extraCliArgs,
+    forwardToMain,
+  }
+}

--- a/src/utils/statusNoticeDefinitions.safety.test.tsx
+++ b/src/utils/statusNoticeDefinitions.safety.test.tsx
@@ -39,9 +39,14 @@ const SAVED_ARGV = process.argv
 const SAVED_API_KEY = process.env.ANTHROPIC_API_KEY
 
 beforeEach(() => {
-  // Reset argv each test so the dangerously-skip-permissions detector starts
-  // from a known baseline.
-  process.argv = [...SAVED_ARGV.filter(a => a !== '--dangerously-skip-permissions')]
+  // Test isolation: normalize argv to a clean baseline so a stray bypass flag
+  // in the test runner's argv can't leak into any test. (The notice itself is
+  // keyed off permissionMode, not argv.)
+  process.argv = [
+    ...SAVED_ARGV.filter(
+      a => a !== '--dangerously-skip-permissions' && a !== '--yolo',
+    ),
+  ]
   // Other status notices read auth state via getAnthropicApiKeyWithSource,
   // which throws when no key/token is present. Seed a dummy so getActiveNotices
   // can iterate every notice without unrelated failures crashing the test.
@@ -136,15 +141,106 @@ describe('third-party permissive mode notice (#244 finding 1)', () => {
 })
 
 describe('dangerously-skip-permissions sandbox notice (#244 finding 2)', () => {
-  test('fires when --dangerously-skip-permissions is in argv', () => {
-    process.argv = [...process.argv, '--dangerously-skip-permissions']
-    expect(activeIds(buildContext())).toContain('dangerously-skip-permissions-no-sandbox')
-  })
-
-  test('fires when permission mode is bypassPermissions (e.g. settings defaultMode)', () => {
+  // The notice is Commander-authoritative: both --dangerously-skip-permissions
+  // and its --yolo alias are resolved into permissionMode === 'bypassPermissions'
+  // during startup, so the notice keys off the resolved mode, not raw argv.
+  test('fires when permission mode is bypassPermissions', () => {
     expect(activeIds(buildContext({ permissionMode: 'bypassPermissions' }))).toContain(
       'dangerously-skip-permissions-no-sandbox',
     )
+  })
+
+  test('fires for fullAccess too (bypass-equivalent mode)', () => {
+    expect(activeIds(buildContext({ permissionMode: 'fullAccess' }))).toContain(
+      'dangerously-skip-permissions-no-sandbox',
+    )
+  })
+
+  test('fires for a REMOTE session whose local mode was downgraded', () => {
+    // `cc://` and ssh sessions forward the bypass flag to the remote executor
+    // and deliberately resolve the LOCAL mode to `default`. Reading the mode
+    // alone would silence the warning for exactly the case the user cannot
+    // see — tools running on another host with every consent check bypassed.
+    const ctx = buildContext({
+      permissionMode: 'default',
+      remoteBypassPermissions: true,
+    })
+    expect(activeIds(ctx)).toContain('dangerously-skip-permissions-no-sandbox')
+  })
+
+  test('stays silent for an ordinary local session', () => {
+    expect(
+      activeIds(buildContext({ permissionMode: 'default' })),
+    ).not.toContain('dangerously-skip-permissions-no-sandbox')
+    expect(
+      activeIds(
+        buildContext({ permissionMode: 'default', remoteBypassPermissions: false }),
+      ),
+    ).not.toContain('dangerously-skip-permissions-no-sandbox')
+  })
+
+  test('the remote wording says where the bypass applies', async () => {
+    const notice = await renderNoticePlainText(
+      'dangerously-skip-permissions-no-sandbox',
+      buildContext({ permissionMode: 'default', remoteBypassPermissions: true }),
+    )
+    expect(notice).toContain('remote')
+    // must not claim THIS session is bypassing — its mode is default
+    expect(notice).not.toContain('(default)')
+    expect(notice).toContain('--yolo')
+    // Both halves of the remediation: reconnecting without the flag alone can
+    // leave the remote bypassed when a bypassing --permission-mode or a settings
+    // defaultMode is what granted it.
+    expect(notice).toContain('--permission-mode')
+    expect(notice).toContain('defaultMode')
+  })
+
+  test('remote wording survives a later LOCAL mode change (jatmn P2)', async () => {
+    // remoteBypassPermissions is decided once at startup; the local mode stays
+    // live (Shift+Tab, /permission-mode). Preferring the local branch swapped in
+    // wording claiming THIS session bypasses, hiding that tools still run
+    // remotely without consent.
+    const notice = await renderNoticePlainText(
+      'dangerously-skip-permissions-no-sandbox',
+      buildContext({
+        permissionMode: 'bypassPermissions', // user switched locally, mid-session
+        remoteBypassPermissions: true,
+      }),
+    )
+    expect(notice).toContain('remote')
+    // both are true here, so it must say both rather than pick one
+    expect(notice).toContain('bypassPermissions')
+    expect(notice).not.toContain('this local session is unaffected')
+    // …and it must say how to restore LOCAL prompts. Reconnecting fixes only the
+    // remote half, so a notice naming just that leaves the user believing they
+    // cleared a bypass that is still active here.
+    expect(notice).toContain('/permission-mode')
+    expect(notice).toContain('Shift+Tab')
+  })
+
+  test('rendered notice names the --yolo alias so the message is not misleading', async () => {
+    const notice = await renderNoticePlainText(
+      'dangerously-skip-permissions-no-sandbox',
+      buildContext({ permissionMode: 'bypassPermissions' }),
+    )
+    // Fires for either spelling, so its text must name both.
+    expect(notice).toContain('--yolo')
+    expect(notice).toContain('--dangerously-skip-permissions')
+  })
+
+  test('rendered notice names the resolved mode, not just the flag', async () => {
+    // The notice also fires for a mode set via settings/--permission-mode, so
+    // the headline must reflect the actual mode rather than claiming a flag.
+    const full = await renderNoticePlainText(
+      'dangerously-skip-permissions-no-sandbox',
+      buildContext({ permissionMode: 'fullAccess' }),
+    )
+    expect(full).toContain('fullAccess')
+    const bypass = await renderNoticePlainText(
+      'dangerously-skip-permissions-no-sandbox',
+      buildContext({ permissionMode: 'bypassPermissions' }),
+    )
+    expect(bypass).toContain('bypassPermissions')
   })
 
   test('does not fire in default mode without the flag', () => {
@@ -175,10 +271,10 @@ describe('safety notice rendering', () => {
       `${figures.warning}bypassPermissions`,
     )
     expect(dangerouslySkipNotice).toContain(
-      `${figures.warning} --dangerously-skip-permissions`,
+      `${figures.warning} Permission bypass`,
     )
     expect(dangerouslySkipNotice).not.toContain(
-      `${figures.warning}--dangerously-skip-permissions`,
+      `${figures.warning}Permission bypass`,
     )
     expect(
       thirdPartyNotice

--- a/src/utils/statusNoticeDefinitions.tsx
+++ b/src/utils/statusNoticeDefinitions.tsx
@@ -4,6 +4,7 @@ import * as React from 'react';
 import { getLargeMemoryFiles, MAX_MEMORY_CHARACTER_COUNT, type MemoryFileInfo } from './claudemd.js';
 import figures from 'figures';
 import { getCwd } from './cwd.js';
+import { isDangerousPermissionMode } from './permissions/PermissionMode.js';
 import { relative } from 'path';
 import { formatNumber } from './format.js';
 import type { getGlobalConfig } from './config.js';
@@ -28,6 +29,12 @@ export type StatusNoticeContext = {
   localModelContextLoad?: LocalModelContextWarning | null;
   /** Active session permission mode. Used by the 3P-safety notices. */
   permissionMode?: PermissionMode;
+  /**
+   * True when this session forwards bypass to a REMOTE tool executor (`cc://`
+   * or ssh). Those sessions downgrade the LOCAL mode to `default` on purpose,
+   * so `permissionMode` alone cannot reveal that tools run without consent.
+   */
+  remoteBypassPermissions?: boolean;
   /** Current main-loop model id. Used by the 3P-safety notices to decide
    * whether the AI classifier would actually run. */
   mainLoopModel?: string;
@@ -288,25 +295,52 @@ const thirdPartyPermissiveModeNotice: StatusNoticeDefinition = {
 // every tool call. On first-party builds an employee-only sandbox check
 // (Docker/Bubblewrap + no internet) gates this flag; external users skip the
 // check entirely (setup.ts), so the flag is effectively "run any command with
-// no review". Warn loudly. Detection reads from process.argv so the notice
-// fires from the first frame, before any AppState mode change propagates.
-// See issue #244 finding 2.
-function hasDangerouslySkipPermissionsArg(): boolean {
-  return process.argv.includes('--dangerously-skip-permissions');
-}
+// no review". Warn loudly.
+// See issue #244 finding 2. Commander-authoritative: bypass (from either
+// --dangerously-skip-permissions or its --yolo alias) is resolved by commander
+// into the permission mode during startup, before this notice renders, so we
+// read the resolved mode instead of re-scanning raw argv (which cannot model
+// commander's option arity / `--` semantics).
 const dangerouslySkipPermissionsNotice: StatusNoticeDefinition = {
   id: 'dangerously-skip-permissions-no-sandbox',
   type: 'warning',
+  // fullAccess is bypass-equivalent (see setSessionBypassPermissionsMode in
+  // main.tsx and the root/sudo gate in setup.ts), so it must warn too.
+  // Two ways to be bypassing: this session's own resolved mode, or a remote
+  // executor this session handed the flag to. The local mode is deliberately
+  // downgraded for remote sessions, so reading it alone would silence the
+  // warning for exactly the case where the user cannot see what the tools do.
   isActive: ctx =>
-    hasDangerouslySkipPermissionsArg() ||
-    ctx.permissionMode === 'bypassPermissions',
-  render: () => <WarningNoticeRow>
+    isDangerousPermissionMode(ctx.permissionMode) ||
+    Boolean(ctx.remoteBypassPermissions),
+  // Name the resolved mode, not the flag: this fires for either bypass mode
+  // however it was reached (--dangerously-skip-permissions/--yolo, settings
+  // defaultMode, or --permission-mode), so flag-only wording would mislead.
+  // Remote takes precedence over the local mode, and is not silently replaced
+  // by it: `remoteBypassPermissions` is decided once at startup, while the local
+  // mode stays live (Shift+Tab, /permission-mode). Preferring the local branch
+  // meant that switching modes mid-session on a remote connection swapped in
+  // wording claiming THIS session bypasses, hiding the fact that tools still run
+  // remotely without consent. When both are true, say both.
+  render: ctx => ctx.remoteBypassPermissions ? <WarningNoticeRow>
       <Text color="warning">
-        <Text bold>--dangerously-skip-permissions</Text> is active.
+        Permission bypass is active on the <Text bold>remote</Text> session
+        {isDangerousPermissionMode(ctx.permissionMode) ? <Text> and locally (<Text bold>{ctx.permissionMode}</Text>)</Text> : null}.
+      </Text>
+      <Text dimColor>
+        Tools run on the remote host with every consent check bypassed
+        {isDangerousPermissionMode(ctx.permissionMode) ? ', and this local session is bypassing too' : '; this local session is unaffected'}.
+        Reconnect without <Text bold>--dangerously-skip-permissions</Text>/<Text bold>--yolo</Text> — and without a
+        bypassing <Text bold>--permission-mode</Text> (or a <Text bold>permissions.defaultMode</Text> setting that sets one) — to re-enable prompts there.
+        {isDangerousPermissionMode(ctx.permissionMode) ? <Text> Reconnecting does not clear the LOCAL bypass: switch this session's mode back with <Text bold>/permission-mode</Text> (or Shift+Tab).</Text> : null}
+      </Text>
+    </WarningNoticeRow> : <WarningNoticeRow>
+      <Text color="warning">
+        Permission bypass (<Text bold>{ctx.permissionMode}</Text>) is active.
       </Text>
       <Text dimColor>
         Every tool consent check is bypassed. Only use inside a sandbox with no internet access.
-        Restart without the flag to re-enable prompts.
+        Restart without <Text bold>--dangerously-skip-permissions</Text>/<Text bold>--yolo</Text> (or change the permission mode) to re-enable prompts.
       </Text>
     </WarningNoticeRow>
 };

--- a/web/src/data/cliFlags.ts
+++ b/web/src/data/cliFlags.ts
@@ -83,7 +83,7 @@ export const flagGroups: FlagGroup[] = [
       { flag: '--allowed-tools', arg: '<tools...>', description: 'Comma or space-separated list of tool rules to allow (e.g. "Bash(git:*) Edit").' },
       { flag: '--disallowed-tools', arg: '<tools...>', description: 'Comma or space-separated list of tool rules to deny.' },
       { flag: '--tools', arg: '<tools...>', description: 'Restrict the built-in tool set: "" disables all tools, "default" enables all, or list names like "Bash,Edit,Read".' },
-      { flag: '--dangerously-skip-permissions', description: 'Bypass all permission checks. Recommended only for sandboxes with no internet access.' },
+      { flag: '--yolo, --dangerously-skip-permissions', description: 'Bypass all permission checks. Recommended only for sandboxes with no internet access.' },
       { flag: '--allow-dangerously-skip-permissions', description: 'Make permission bypass available as an option without enabling it by default.' },
       { flag: '--add-dir', arg: '<dirs...>', description: 'Additional directories to allow tool access to.' },
     ],


### PR DESCRIPTION
This PR is being repurposed as the SSH / `cc://` argv refactor, per review in #1939.

The `--yolo` alias itself has been split out into a focused PR:
- **#2097** — `feat(cli): add --yolo alias for --dangerously-skip-permissions`

### What this refactor contains
- Extraction of main CLI option parsing into `src/mainCliOptions.ts`.
- `src/utils/sshPreParse.ts`: commander-driven SSH argv rewrite with proper handling of value-taking options, `--`, and the bypass flag.
- Commander-authoritative startup gates (early input, print mode, permission-mode validation) instead of hand-rolled token scans.
- Remote-bypass plumbing for SSH and direct-connect sessions.
- Unified skills boolean/prompt-mode flag sets in `src/cli/skillsBooleanFlags.ts`.
- Expanded test coverage for the above.

### Status
- The alias portion has been removed from this branch's scope; it now lives in #2097.
- This branch is currently based on an older `main` and needs a rebase/merge against the latest `origin/main` before review (merge state: DIRTY). That work is in progress.
- All prior review threads on this PR were resolved; the remaining open question is whether the full refactor should land here or be further split.

### Notable fixes already validated on this branch
- ArgParser-discarded values no longer cause the bypass flag to be misclassified as a value (arity probe).
- Skills boolean/prompt-mode sets are kept disjoint.
- `earlyInput.ts` raw-mode gate is covered by regression tests.

cc @jatmn