### PR TITLE
feat(grpc): expose system_prompt on ChatRequest → QueryEngine customSystemPrompt

### DIFF
--- a/src/grpc/server.ts
+++ b/src/grpc/server.ts
@@ -203,6 +203,7 @@ export class GrpcServer {
             readFileCache: fileCache,
             userSpecifiedModel: req.model,
             fallbackModel: req.model,
+            ...(req.system_prompt ? { customSystemPrompt: req.system_prompt } : {}),
           })
 
           // Track accumulated response data for FinalResponse

--- a/src/proto/openclaude.proto
+++ b/src/proto/openclaude.proto
@@ -31,6 +31,11 @@ message ChatRequest {
   reserved 3;                   // Reserved to prevent accidental reuse
   optional string model = 4;
   string session_id = 5;        // Non-empty = cross-stream session persistence
+  reserved 6;                   // Held for a pending bypass_permissions proposal
+  optional string system_prompt = 7; // Replaces the default system prompt entirely
+                                     // (QueryEngine customSystemPrompt). Lets callers
+                                     // repurpose the agent (personas, structured-output
+                                     // responders) instead of the built-in identity.
 }
 
 message UserInput {


### PR DESCRIPTION
## Problem

Headless gRPC callers (OpenAI-compatible bridges, MCP adapters) have no way to set a system prompt. Anything they prepend to the task text is overridden by the agent's built-in identity, so persona or structured-output requests get refused:

> "I'm OpenClaude, a software engineering assistant — I can't roleplay as …"

## Fix

`QueryEngine` already supports `customSystemPrompt` — it just isn't reachable over gRPC. This adds the missing plumbing:

- `ChatRequest.system_prompt` (optional string, field 7) in `openclaude.proto`
- one-line passthrough in `src/grpc/server.ts` → `customSystemPrompt`

When set, it replaces the default system prompt entirely (same semantics as `QueryEngine`'s existing option). Absent/empty keeps today's behavior — fully backward compatible on the wire.

Field 6 is `reserved` — it's taken by a `bypass_permissions` field already deployed on downstream forks; skipping it avoids a wire-format collision if that lands later.

## Testing

Deployed on a fork behind an OpenAI-compatible bridge routed through LiteLLM: a persona system prompt + JSON-only instruction that previously got refused now returns clean in-character JSON.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for an optional custom system prompt when starting a chat.
  * Custom prompts can replace the default instructions to tailor the assistant’s persona and behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->