### PR TITLE
fix(prompt): keep footer mounted across slash suggestions

### DIFF
--- a/src/components/PromptInput/KeepMounted.test.tsx
+++ b/src/components/PromptInput/KeepMounted.test.tsx
@@ -1,0 +1,61 @@
+import { PassThrough } from 'node:stream'
+import { stripVTControlCharacters as stripAnsi } from 'node:util'
+import { expect, test } from 'bun:test'
+import { useEffect } from 'react'
+import { createRoot, Text } from '../../ink.js'
+import { KeepMounted } from './KeepMounted.js'
+
+function createTestStdout(): NodeJS.WriteStream {
+  const stdout = new PassThrough()
+  ;(stdout as unknown as { columns: number }).columns = 80
+  return stdout as unknown as NodeJS.WriteStream
+}
+
+test('keeps children mounted while visibility changes', async () => {
+  let mounts = 0
+  let unmounts = 0
+  const stdout = createTestStdout() as unknown as PassThrough
+  let output = ''
+  stdout.on('data', chunk => {
+    output += chunk.toString()
+  })
+
+  function Probe() {
+    useEffect(() => {
+      mounts++
+      return () => {
+        unmounts++
+      }
+    }, [])
+    return <Text>persistent child</Text>
+  }
+
+  const root = await createRoot({
+    stdout: stdout as unknown as NodeJS.WriteStream,
+    patchConsole: false,
+  })
+  const render = (hidden: boolean) =>
+    root.render(
+      <KeepMounted hidden={hidden}>
+        <Probe />
+      </KeepMounted>,
+    )
+
+  render(false)
+  await Bun.sleep(10)
+  expect(stripAnsi(output)).toContain('persistent child')
+
+  output = ''
+  render(true)
+  await Bun.sleep(10)
+  const hiddenFrame = stripAnsi(output).replaceAll('\r', '').replaceAll('\n', '')
+  expect(hiddenFrame).toBe('')
+
+  render(false)
+
+  expect(mounts).toBe(1)
+  expect(unmounts).toBe(0)
+
+  root.unmount()
+  expect(unmounts).toBe(1)
+})

--- a/src/components/PromptInput/KeepMounted.tsx
+++ b/src/components/PromptInput/KeepMounted.tsx
@@ -1,0 +1,16 @@
+import type { ReactNode } from 'react'
+import { Box } from '../../ink.js'
+
+export function KeepMounted({
+  hidden,
+  children,
+}: {
+  hidden: boolean
+  children: ReactNode
+}): ReactNode {
+  return (
+    <Box height={hidden ? 0 : undefined} overflow="hidden">
+      {children}
+    </Box>
+  )
+}

--- a/src/components/PromptInput/PromptInputFooter.test.tsx
+++ b/src/components/PromptInput/PromptInputFooter.test.tsx
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'bun:test'
 import { DEFAULT_GLOBAL_CONFIG } from '../../utils/config.js'
 import {
+  resolveConfiguredFooterStatusLine,
   resolveFooterStatusLine,
   SHORTCUTS_HINT_STARTUP_GRACE,
   shouldSuppressShortcutsHint,
@@ -58,6 +59,18 @@ describe('resolveFooterStatusLine', () => {
       expect(resolveFooterStatusLine(customSettings, guards)).toBeNull()
     })
   }
+})
+
+describe('resolveConfiguredFooterStatusLine', () => {
+  it('keeps a custom statusline configured while transient UI hides its row', () => {
+    expect(resolveConfiguredFooterStatusLine(customSettings)).toBe('custom')
+    expect(
+      resolveFooterStatusLine(customSettings, {
+        ...guardsPass,
+        exitMessageShown: true,
+      }),
+    ).toBeNull()
+  })
 })
 
 describe('shouldSuppressShortcutsHint', () => {

--- a/src/components/PromptInput/PromptInputFooter.tsx
+++ b/src/components/PromptInput/PromptInputFooter.tsx
@@ -21,6 +21,7 @@ import { BuiltinStatusLine, builtinStatusLineShouldDisplay } from '../BuiltinSta
 import { useCoordinatorTaskCount } from '../CoordinatorAgentStatus.js';
 import { getLastAssistantMessageId, StatusLine, statusLineShouldDisplay } from '../StatusLine.js';
 import { Notifications } from './Notifications.js';
+import { KeepMounted } from './KeepMounted.js';
 import { PromptInputFooterLeftSide } from './PromptInputFooterLeftSide.js';
 import { PromptInputFooterSuggestions, type SuggestionItem } from './PromptInputFooterSuggestions.js';
 import { PromptInputHelpMenu } from './PromptInputHelpMenu.js';
@@ -42,6 +43,15 @@ export function resolveFooterStatusLine(settings: ReadonlySettings, guards: {
   if (statusLineShouldDisplay(settings)) return 'custom';
   if (builtinStatusLineShouldDisplay(settings, config)) return 'builtin';
   return null;
+}
+
+export function resolveConfiguredFooterStatusLine(settings: ReadonlySettings): 'custom' | 'builtin' | null {
+  return resolveFooterStatusLine(settings, {
+    isPromptMode: true,
+    isShort: false,
+    exitMessageShown: false,
+    isPasting: false
+  });
 }
 
 /**
@@ -165,6 +175,7 @@ function PromptInputFooter({
     exitMessageShown: exitMessage.show,
     isPasting
   });
+  const configuredFooterStatusLine = resolveConfiguredFooterStatusLine(settings);
   // Hide `? for shortcuts` during ctrl-r search, or — for established users
   // only — when a status line actually renders below (display setting AND
   // render guards). See shouldSuppressShortcutsHint.
@@ -181,25 +192,26 @@ function PromptInputFooter({
     maxColumnWidth
   } : null, [isFullscreen, suggestions, selectedSuggestion, maxColumnWidth]);
   useSetPromptOverlay(overlayData);
-  if (suggestions.length && !isFullscreen) {
-    return <Box paddingX={2} paddingY={0}>
-        <PromptInputFooterSuggestions suggestions={suggestions} selectedSuggestion={selectedSuggestion} maxColumnWidth={maxColumnWidth} />
-      </Box>;
-  }
-  if (helpOpen) {
-    return <PromptInputHelpMenu dimColor={true} fixedWidth={true} paddingX={2} />;
-  }
+  const showInlineSuggestions = suggestions.length > 0 && !isFullscreen;
+  const hideRegularFooter = showInlineSuggestions || helpOpen;
   return <>
-      <Box flexDirection={isNarrow ? 'column' : 'row'} justifyContent={isNarrow ? 'flex-start' : 'space-between'} paddingX={2} gap={isNarrow ? 0 : 1}>
-        <Box flexDirection="column" flexShrink={isNarrow ? 0 : 1}>
-          {footerStatusLine === 'custom' ? <StatusLine messagesRef={messagesRef} lastAssistantMessageId={lastAssistantMessageId} vimMode={vimMode} /> : footerStatusLine === 'builtin' ? <BuiltinStatusLine messagesRef={messagesRef} lastAssistantMessageId={lastAssistantMessageId} /> : null}
+      <KeepMounted hidden={hideRegularFooter}>
+        <Box flexDirection={isNarrow ? 'column' : 'row'} justifyContent={isNarrow ? 'flex-start' : 'space-between'} paddingX={2} gap={isNarrow ? 0 : 1}>
+          <Box flexDirection="column" flexShrink={isNarrow ? 0 : 1}>
+          <KeepMounted hidden={footerStatusLine === null}>
+            {configuredFooterStatusLine === 'custom' ? <StatusLine messagesRef={messagesRef} lastAssistantMessageId={lastAssistantMessageId} vimMode={vimMode} /> : configuredFooterStatusLine === 'builtin' ? <BuiltinStatusLine messagesRef={messagesRef} lastAssistantMessageId={lastAssistantMessageId} /> : null}
+          </KeepMounted>
           <PromptInputFooterLeftSide exitMessage={exitMessage} vimMode={vimMode} mode={mode} toolPermissionContext={toolPermissionContext} suppressHint={suppressHint} isLoading={isLoading} tasksSelected={pillSelected} teamsSelected={teamsSelected} teammateFooterIndex={teammateFooterIndex} tmuxSelected={tmuxSelected} isPasting={isPasting} isSearching={isSearching} historyQuery={historyQuery} setHistoryQuery={setHistoryQuery} historyFailedMatch={historyFailedMatch} onOpenTasksDialog={onOpenTasksDialog} />
-        </Box>
-        <Box flexShrink={1} gap={1}>
+          </Box>
+          <Box flexShrink={1} gap={1}>
           {isFullscreen ? null : <Notifications apiKeyStatus={apiKeyStatus} autoUpdaterResult={autoUpdaterResult} debug={debug} isAutoUpdating={isAutoUpdating} verbose={verbose} messages={messages} onAutoUpdaterResult={onAutoUpdaterResult} onChangeIsUpdating={onChangeIsUpdating} ideSelection={ideSelection} mcpClients={mcpClients} isInputWrapped={isInputWrapped} isNarrow={isNarrow} />}
           <BridgeStatusIndicator bridgeSelected={bridgeSelected} />
+          </Box>
         </Box>
-      </Box>
+      </KeepMounted>
+      {showInlineSuggestions ? <Box paddingX={2} paddingY={0}>
+          <PromptInputFooterSuggestions suggestions={suggestions} selectedSuggestion={selectedSuggestion} maxColumnWidth={maxColumnWidth} />
+        </Box> : helpOpen ? <PromptInputHelpMenu dimColor={true} fixedWidth={true} paddingX={2} /> : null}
     </>;
 }
 export default memo(PromptInputFooter);


### PR DESCRIPTION
## Summary

- keep the regular prompt footer mounted while inline slash suggestions temporarily replace it
- collapse hidden footer content without adding a terminal row
- preserve the configured statusline component across the suggestion visibility transition so its external command is not restarted

Fixes #1942.

## Impact

- user-facing impact: typing remains responsive when a slash-command dropdown disappears after a non-match or completed command; slash matching, selection, and execution behavior are unchanged
- developer/maintainer impact: adds a small `KeepMounted` layout helper and direct regression coverage for mount identity and footer statusline resolution

## Testing

- [x] `bun run build`
- [x] `bun run smoke`
- [x] `bun run check` — branch and `origin/main@4f971a13` each reported 92 normalized failure names; `fix-only=0`, `main-only=0`
- [x] focused tests: `bun test src/components/PromptInput/KeepMounted.test.tsx src/components/PromptInput/PromptInputFooter.test.tsx` — 15 pass, 0 fail
- [x] `bun run typecheck`
- [x] `bun run typecheck:type-tests` — 10 focused type-test files passed
- [x] `bun run security:pr-scan`

## Notes

- provider/model path tested: not applicable; this changes prompt footer lifecycle only
- screenshots attached (if UI changed): not applicable; terminal presentation is intentionally unchanged and the corrected symptom is a timing/input-stall behavior that a static screenshot cannot show
- follow-up work or known limitations: Ctrl+C feedback and `@` file-suggestion responsiveness are intentionally excluded and will be reviewed separately


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved prompt footer transitions between status messages, inline suggestions, and help content.
  * Footer content now stays mounted while visually hidden when alternate bottom-slot content is shown, reducing flicker.
  * Custom status line choices are consistently respected during transient UI states.

* **Tests**
  * Added coverage verifying footer-related components remain mounted across visibility toggles.
  * Added validation for custom status line resolution when transient UI guards are active.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->