### PR TITLE
fix(update): avoid upstream package commands for custom builds

### DIFF
--- a/src/cli/update.test.ts
+++ b/src/cli/update.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, test } from 'bun:test'
 import { withMockMacro } from 'src/test/mockMacro.js'
-import { getGlobalUpdateFailureHint } from './update.js'
+import { resolvePackageManagerUpdateGuidance } from '../utils/packageManagerUpdateGuidance.js'
+import {
+  getGlobalUpdateFailureHint,
+  writePackageManagerUpdateGuidance,
+} from './update.js'
 
 describe('getGlobalUpdateFailureHint', () => {
   test('points npm-only builds at npm instead of the native installer', () => {
@@ -18,5 +22,30 @@ describe('getGlobalUpdateFailureHint', () => {
     expect(getGlobalUpdateFailureHint(true)).toBe(
       'Or consider using native installation with: openclaude install\n',
     )
+  })
+})
+
+describe('writePackageManagerUpdateGuidance', () => {
+  test('writes safe OpenClaude guidance without upstream commands', async () => {
+    let output = ''
+
+    await writePackageManagerUpdateGuidance('homebrew', 'latest', {
+      displayVersion: '1.0.0',
+      getGuidance: manager =>
+        resolvePackageManagerUpdateGuidance(manager, '@gitlawb/openclaude'),
+      getLatestVersion: async () => '2.0.0',
+      write: value => {
+        output += value
+      },
+      bold: value => value,
+    })
+
+    expect(output).toContain(
+      'OpenClaude is managed by Homebrew. Use Homebrew to update OpenClaude.',
+    )
+    expect(output).toContain('Update available: 1.0.0 → 2.0.0')
+    expect(output).not.toContain('brew upgrade claude-code')
+    expect(output).not.toContain('Anthropic.ClaudeCode')
+    expect(output).not.toContain('apk upgrade claude-code')
   })
 })

--- a/src/cli/update.test.ts
+++ b/src/cli/update.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, test } from 'bun:test'
 import { withMockMacro } from 'src/test/mockMacro.js'
-import { resolvePackageManagerUpdateGuidance } from '../utils/packageManagerUpdateGuidance.js'
 import {
   getGlobalUpdateFailureHint,
   writePackageManagerUpdateGuidance,
@@ -26,26 +25,37 @@ describe('getGlobalUpdateFailureHint', () => {
 })
 
 describe('writePackageManagerUpdateGuidance', () => {
-  test('writes safe OpenClaude guidance without upstream commands', async () => {
-    let output = ''
+  test.each([
+    ['@anthropic-ai/claude-code', true],
+    ['@gitlawb/openclaude', false],
+    ['@example/custom-cli', false],
+  ] as const)(
+    'uses the runtime package identity for %s',
+    async (packageUrl, expectsUpstreamCommand) => {
+      let output = ''
 
-    await writePackageManagerUpdateGuidance('homebrew', 'latest', {
-      displayVersion: '1.0.0',
-      getGuidance: manager =>
-        resolvePackageManagerUpdateGuidance(manager, '@gitlawb/openclaude'),
-      getLatestVersion: async () => '2.0.0',
-      write: value => {
-        output += value
-      },
-      bold: value => value,
-    })
+      await withMockMacro({ PACKAGE_URL: packageUrl }, async () => {
+        await writePackageManagerUpdateGuidance('homebrew', 'latest', {
+          displayVersion: '1.0.0',
+          getLatestVersion: async () => '2.0.0',
+          write: value => {
+            output += value
+          },
+          bold: value => value,
+        })
+      })
 
-    expect(output).toContain(
-      'OpenClaude is managed by Homebrew. Use Homebrew to update OpenClaude.',
-    )
-    expect(output).toContain('Update available: 1.0.0 → 2.0.0')
-    expect(output).not.toContain('brew upgrade claude-code')
-    expect(output).not.toContain('Anthropic.ClaudeCode')
-    expect(output).not.toContain('apk upgrade claude-code')
-  })
+      expect(output).toContain(
+        'OpenClaude is managed by Homebrew. Use Homebrew to update OpenClaude.',
+      )
+      expect(output).toContain('Update available: 1.0.0 → 2.0.0')
+      if (expectsUpstreamCommand) {
+        expect(output).toContain('brew upgrade claude-code')
+      } else {
+        expect(output).not.toContain('brew upgrade claude-code')
+        expect(output).not.toContain('Anthropic.ClaudeCode')
+        expect(output).not.toContain('apk upgrade claude-code')
+      }
+    },
+  )
 })

--- a/src/cli/update.ts
+++ b/src/cli/update.ts
@@ -9,6 +9,7 @@ import { regenerateCompletionCache } from 'src/utils/completionCache.js'
 import {
   getGlobalConfig,
   type InstallMethod,
+  type ReleaseChannel,
   saveGlobalConfig,
 } from 'src/utils/config.js'
 import { logForDebugging } from 'src/utils/debug.js'
@@ -23,7 +24,14 @@ import {
   installLatest as installLatestNative,
   removeInstalledSymlink,
 } from 'src/utils/nativeInstaller/index.js'
-import { getPackageManager } from 'src/utils/nativeInstaller/packageManagers.js'
+import {
+  getPackageManager,
+  type PackageManager,
+} from 'src/utils/nativeInstaller/packageManagers.js'
+import {
+  getPackageManagerUpdateGuidance,
+  type PackageManagerUpdateGuidance,
+} from 'src/utils/packageManagerUpdateGuidance.js'
 import { writeToStdout } from 'src/utils/process.js'
 import { gte } from 'src/utils/semver.js'
 import { shouldRemoveInstalledSymlinkForNpmUpdate } from 'src/utils/autoUpdaterRouting.js'
@@ -39,6 +47,42 @@ export function getGlobalUpdateFailureHint(
   return nativeDistributionAvailable
     ? 'Or consider using native installation with: openclaude install\n'
     : `Or update manually with:\n  npm install -g ${MACRO.PACKAGE_URL}@latest\n`
+}
+
+export async function writePackageManagerUpdateGuidance(
+  manager: PackageManager,
+  channel: ReleaseChannel,
+  deps: {
+    displayVersion?: string
+    getGuidance?: (manager: PackageManager) => PackageManagerUpdateGuidance
+    getLatestVersion?: (channel: ReleaseChannel) => Promise<string | null>
+    write?: (value: string) => void
+    bold?: (value: string) => string
+  } = {},
+): Promise<void> {
+  const guidance = (deps.getGuidance ?? getPackageManagerUpdateGuidance)(manager)
+  const displayVersion = deps.displayVersion ?? MACRO.DISPLAY_VERSION
+  const write = deps.write ?? writeToStdout
+  const bold = deps.bold ?? chalk.bold
+
+  write('\n')
+  write(`${guidance.message}\n`)
+
+  if (!guidance.managerName) {
+    return
+  }
+
+  const latest = await (deps.getLatestVersion ?? getLatestVersion)(channel)
+  if (latest && !gte(displayVersion, latest)) {
+    write(`Update available: ${displayVersion} → ${latest}\n`)
+    if (guidance.command) {
+      write('\n')
+      write('To update, run:\n')
+      write(bold(`  ${guidance.command}`) + '\n')
+    }
+  } else {
+    write('OpenClaude is up to date!\n')
+  }
 }
 
 export async function update() {
@@ -155,51 +199,7 @@ export async function update() {
   // Check if running from a package manager
   if (diagnostic.installationType === 'package-manager') {
     const packageManager = await getPackageManager()
-    writeToStdout('\n')
-
-    if (packageManager === 'homebrew') {
-      writeToStdout('Claude is managed by Homebrew.\n')
-      const latest = await getLatestVersion(channel)
-      if (latest && !gte(MACRO.DISPLAY_VERSION, latest)) {
-        writeToStdout(`Update available: ${MACRO.DISPLAY_VERSION} → ${latest}\n`)
-        writeToStdout('\n')
-        writeToStdout('To update, run:\n')
-        writeToStdout(chalk.bold('  brew upgrade claude-code') + '\n')
-      } else {
-        writeToStdout('Claude is up to date!\n')
-      }
-    } else if (packageManager === 'winget') {
-      writeToStdout('Claude is managed by winget.\n')
-      const latest = await getLatestVersion(channel)
-      if (latest && !gte(MACRO.DISPLAY_VERSION, latest)) {
-        writeToStdout(`Update available: ${MACRO.DISPLAY_VERSION} → ${latest}\n`)
-        writeToStdout('\n')
-        writeToStdout('To update, run:\n')
-        writeToStdout(
-          chalk.bold('  winget upgrade Anthropic.ClaudeCode') + '\n',
-        )
-      } else {
-        writeToStdout('Claude is up to date!\n')
-      }
-    } else if (packageManager === 'apk') {
-      writeToStdout('Claude is managed by apk.\n')
-      const latest = await getLatestVersion(channel)
-      if (latest && !gte(MACRO.DISPLAY_VERSION, latest)) {
-        writeToStdout(`Update available: ${MACRO.DISPLAY_VERSION} → ${latest}\n`)
-        writeToStdout('\n')
-        writeToStdout('To update, run:\n')
-        writeToStdout(chalk.bold('  apk upgrade claude-code') + '\n')
-      } else {
-        writeToStdout('Claude is up to date!\n')
-      }
-    } else {
-      // pacman, deb, and rpm don't get specific commands because they each have
-      // multiple frontends (pacman: yay/paru/makepkg, deb: apt/apt-get/aptitude/nala,
-      // rpm: dnf/yum/zypper)
-      writeToStdout('Claude is managed by a package manager.\n')
-      writeToStdout('Please use your package manager to update.\n')
-    }
-
+    await writePackageManagerUpdateGuidance(packageManager, channel)
     await gracefulShutdown(0)
   }
 

--- a/src/commands/update/update.tsx
+++ b/src/commands/update/update.tsx
@@ -21,6 +21,7 @@ import {
   removeInstalledSymlink,
 } from '../../utils/nativeInstaller/index.js'
 import type { PackageManager } from '../../utils/nativeInstaller/packageManagers.js'
+import { getPackageManagerUpdateGuidance } from '../../utils/packageManagerUpdateGuidance.js'
 import { shouldRemoveInstalledSymlinkForNpmUpdate } from '../../utils/autoUpdaterRouting.js'
 import { resolveUpdateStrategy } from '../../utils/updateStrategy.js'
 
@@ -46,18 +47,25 @@ type UpdateState =
   | { type: 'success'; version: string; via: string }
   | { type: 'error'; message: string }
 
-// Manager-specific upgrade command, mirroring src/cli/update.ts.
-function packageManagerHint(manager: PackageManager): string | null {
-  switch (manager) {
-    case 'homebrew':
-      return 'brew upgrade claude-code'
-    case 'winget':
-      return 'winget upgrade Anthropic.ClaudeCode'
-    case 'apk':
-      return 'apk upgrade claude-code'
-    default:
-      return null
-  }
+export function PackageManagerUpdateGuidance({
+  manager,
+}: {
+  manager: PackageManager
+}): React.ReactNode {
+  const guidance = getPackageManagerUpdateGuidance(manager)
+  return (
+    <Box flexDirection="column" gap={1}>
+      <Box>
+        <StatusIcon status="warning" withSpace />
+        <Text color="warning">{guidance.message}</Text>
+      </Box>
+      {guidance.command && (
+        <Box marginLeft={2}>
+          <Text dimColor>To update, run: {guidance.command}</Text>
+        </Box>
+      )}
+    </Box>
+  )
 }
 
 export async function removeStaleNativeLauncherForNpmUpdate(deps: {
@@ -254,21 +262,7 @@ function Update({ onDone, force, target }: UpdateProps): React.ReactNode {
       )}
 
       {state.type === 'package-manager' && (
-        <Box flexDirection="column" gap={1}>
-          <Box>
-            <StatusIcon status="warning" withSpace />
-            <Text color="warning">
-              OpenClaude is managed by a package manager ({state.manager}).
-            </Text>
-          </Box>
-          <Box marginLeft={2}>
-            <Text dimColor>
-              {packageManagerHint(state.manager)
-                ? `To update, run: ${packageManagerHint(state.manager)}`
-                : 'Please use your package manager to update.'}
-            </Text>
-          </Box>
-        </Box>
+        <PackageManagerUpdateGuidance manager={state.manager} />
       )}
 
       {state.type === 'no-package-manager' && (

--- a/src/components/PackageManagerAutoUpdater.tsx
+++ b/src/components/PackageManagerAutoUpdater.tsx
@@ -7,6 +7,7 @@ import { type AutoUpdaterResult, getLatestVersionFromGcs, getMaxVersion, shouldS
 import { isAutoUpdaterDisabled } from '../utils/config.js';
 import { logForDebugging } from '../utils/debug.js';
 import { getPackageManager, type PackageManager } from '../utils/nativeInstaller/packageManagers.js';
+import { getPackageManagerUpdateGuidance } from '../utils/packageManagerUpdateGuidance.js';
 import { gt, gte } from '../utils/semver.js';
 import { getInitialSettings } from '../utils/settings/settings.js';
 type Props = {
@@ -17,6 +18,10 @@ type Props = {
   showSuccessMessage: boolean;
   verbose: boolean;
 };
+export function PackageManagerUpdateAvailableNotice({ manager }: { manager: PackageManager }) {
+  const guidance = getPackageManagerUpdateGuidance(manager);
+  return <Text color="warning" wrap="truncate">Update available! {guidance.message}{guidance.command && <> Run: <Text bold={true}>{guidance.command}</Text></>}</Text>;
+}
 export function PackageManagerAutoUpdater(t0) {
   const $ = _c(10);
   const {
@@ -73,7 +78,6 @@ export function PackageManagerAutoUpdater(t0) {
   if (!updateAvailable) {
     return null;
   }
-  const updateCommand = packageManager === "homebrew" ? "brew upgrade claude-code" : packageManager === "winget" ? "winget upgrade Anthropic.ClaudeCode" : packageManager === "apk" ? "apk upgrade claude-code" : "your package manager update command";
   let t4;
   if ($[3] !== verbose) {
     t4 = verbose && <Text dimColor={true} wrap="truncate">currentVersion: {MACRO.VERSION}</Text>;
@@ -83,9 +87,9 @@ export function PackageManagerAutoUpdater(t0) {
     t4 = $[4];
   }
   let t5;
-  if ($[5] !== updateCommand) {
-    t5 = <Text color="warning" wrap="truncate">Update available! Run: <Text bold={true}>{updateCommand}</Text></Text>;
-    $[5] = updateCommand;
+  if ($[5] !== packageManager) {
+    t5 = <PackageManagerUpdateAvailableNotice manager={packageManager as PackageManager} />;
+    $[5] = packageManager;
     $[6] = t5;
   } else {
     t5 = $[6];

--- a/src/components/PackageManagerUpdateGuidance.test.tsx
+++ b/src/components/PackageManagerUpdateGuidance.test.tsx
@@ -1,0 +1,75 @@
+import { describe, expect, test } from 'bun:test'
+import React from 'react'
+import { withMockMacro } from '../test/mockMacro.js'
+import { renderToString } from '../utils/staticRender.js'
+
+const forbiddenCommands = [
+  'brew upgrade claude-code',
+  'Anthropic.ClaudeCode',
+  'apk upgrade claude-code',
+]
+
+describe('package-manager update surfaces', () => {
+  async function renderSurfaces(
+    manager: 'homebrew' | 'winget' | 'apk',
+    packageUrl: string,
+  ): Promise<{ slash: string; passive: string }> {
+    return withMockMacro({ PACKAGE_URL: packageUrl }, async () => {
+      const [{ PackageManagerUpdateGuidance }, { PackageManagerUpdateAvailableNotice }] =
+        await Promise.all([
+          import(`../commands/update/update.js?slash=${Math.random()}`),
+          import(`./PackageManagerAutoUpdater.js?passive=${Math.random()}`),
+        ])
+
+      const slash = await renderToString(
+        <PackageManagerUpdateGuidance manager={manager} />,
+        200,
+      )
+      const passive = await renderToString(
+        <PackageManagerUpdateAvailableNotice manager={manager} />,
+        200,
+      )
+
+      return { slash, passive }
+    })
+  }
+
+  test.each([
+    ['homebrew', 'Homebrew'],
+    ['winget', 'winget'],
+    ['apk', 'apk'],
+  ] as const)(
+    'slash and passive %s surfaces render the same safe OpenClaude guidance',
+    async (manager, managerName) => {
+      const { slash, passive } = await renderSurfaces(
+        manager,
+        '@gitlawb/openclaude',
+      )
+      const sharedGuidance = `OpenClaude is managed by ${managerName}. Use ${managerName} to update OpenClaude.`
+
+      expect(slash).toContain(sharedGuidance)
+      expect(passive).toContain(sharedGuidance)
+      for (const command of forbiddenCommands) {
+        expect(slash).not.toContain(command)
+        expect(passive).not.toContain(command)
+      }
+    },
+  )
+
+  test.each([
+    ['homebrew', 'brew upgrade claude-code'],
+    ['winget', 'winget upgrade Anthropic.ClaudeCode'],
+    ['apk', 'apk upgrade claude-code'],
+  ] as const)(
+    'slash and passive %s surfaces preserve the upstream command',
+    async (manager, command) => {
+      const { slash, passive } = await renderSurfaces(
+        manager,
+        '@anthropic-ai/claude-code',
+      )
+
+      expect(slash).toContain(command)
+      expect(passive).toContain(command)
+    },
+  )
+})

--- a/src/utils/packageManagerUpdateGuidance.test.ts
+++ b/src/utils/packageManagerUpdateGuidance.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, test } from 'bun:test'
+import type { PackageManager } from './nativeInstaller/packageManagers.js'
+import { resolvePackageManagerUpdateGuidance } from './packageManagerUpdateGuidance.js'
+
+const UPSTREAM_PACKAGE_URL = '@anthropic-ai/claude-code'
+const OPENCLAUDE_PACKAGE_URL = '@gitlawb/openclaude'
+
+describe('resolvePackageManagerUpdateGuidance', () => {
+  test.each([
+    ['homebrew', 'Homebrew', 'brew upgrade claude-code'],
+    ['winget', 'winget', 'winget upgrade Anthropic.ClaudeCode'],
+    ['apk', 'apk', 'apk upgrade claude-code'],
+  ] as const)(
+    'preserves the upstream %s command only for the upstream package',
+    (manager, managerName, command) => {
+      expect(
+        resolvePackageManagerUpdateGuidance(manager, UPSTREAM_PACKAGE_URL),
+      ).toEqual({
+        message: `OpenClaude is managed by ${managerName}. Use ${managerName} to update OpenClaude.`,
+        managerName,
+        command,
+      })
+    },
+  )
+
+  test.each(['homebrew', 'winget', 'apk'] as const)(
+    'does not guess an upstream command for an OpenClaude %s install',
+    manager => {
+      const guidance = resolvePackageManagerUpdateGuidance(
+        manager,
+        OPENCLAUDE_PACKAGE_URL,
+      )
+
+      expect(guidance.command).toBeUndefined()
+      expect(guidance.message).toContain('OpenClaude')
+      expect(guidance.message.toLowerCase()).toContain(manager === 'homebrew' ? 'homebrew' : manager)
+      expect(JSON.stringify(guidance)).not.toContain('brew upgrade claude-code')
+      expect(JSON.stringify(guidance)).not.toContain('Anthropic.ClaudeCode')
+      expect(JSON.stringify(guidance)).not.toContain('apk upgrade claude-code')
+    },
+  )
+
+  test('does not guess a command for an unknown custom package URL', () => {
+    expect(
+      resolvePackageManagerUpdateGuidance('homebrew', '@example/custom-cli'),
+    ).toEqual({
+      message:
+        'OpenClaude is managed by Homebrew. Use Homebrew to update OpenClaude.',
+      managerName: 'Homebrew',
+    })
+  })
+
+  test.each(['pacman', 'deb', 'rpm', 'mise', 'asdf', 'unknown'] as PackageManager[])(
+    'uses safe generic guidance for %s',
+    manager => {
+      expect(
+        resolvePackageManagerUpdateGuidance(manager, OPENCLAUDE_PACKAGE_URL),
+      ).toEqual({
+        message:
+          'OpenClaude is managed by a package manager. Use your package manager to update OpenClaude.',
+      })
+    },
+  )
+})

--- a/src/utils/packageManagerUpdateGuidance.ts
+++ b/src/utils/packageManagerUpdateGuidance.ts
@@ -1,0 +1,52 @@
+import type { PackageManager } from './nativeInstaller/packageManagers.js'
+import { PRODUCT_DISPLAY_NAME } from '../constants/product.js'
+
+const UPSTREAM_PACKAGE_URL = '@anthropic-ai/claude-code'
+
+const upstreamCommands: Partial<Record<PackageManager, string>> = {
+  homebrew: 'brew upgrade claude-code',
+  winget: 'winget upgrade Anthropic.ClaudeCode',
+  apk: 'apk upgrade claude-code',
+}
+
+const managerNames: Partial<Record<PackageManager, string>> = {
+  homebrew: 'Homebrew',
+  winget: 'winget',
+  apk: 'apk',
+}
+
+export type PackageManagerUpdateGuidance = {
+  message: string
+  managerName?: string
+  command?: string
+}
+
+export function resolvePackageManagerUpdateGuidance(
+  manager: PackageManager,
+  packageUrl: string,
+): PackageManagerUpdateGuidance {
+  const managerName = managerNames[manager]
+  if (!managerName) {
+    return {
+      message:
+        `${PRODUCT_DISPLAY_NAME} is managed by a package manager. Use your package manager to update ${PRODUCT_DISPLAY_NAME}.`,
+    }
+  }
+
+  const command =
+    packageUrl === UPSTREAM_PACKAGE_URL
+      ? upstreamCommands[manager]
+      : undefined
+
+  return {
+    message: `${PRODUCT_DISPLAY_NAME} is managed by ${managerName}. Use ${managerName} to update ${PRODUCT_DISPLAY_NAME}.`,
+    managerName,
+    ...(command ? { command } : {}),
+  }
+}
+
+export function getPackageManagerUpdateGuidance(
+  manager: PackageManager,
+): PackageManagerUpdateGuidance {
+  return resolvePackageManagerUpdateGuidance(manager, MACRO.PACKAGE_URL)
+}


### PR DESCRIPTION
## Summary
- Prevent OpenClaude and other custom builds from recommending Anthropic package identifiers when updates are managed by Homebrew, winget, or apk.
- Keep the existing upstream commands available only for the exact `@anthropic-ai/claude-code` package identity.

## Implementation
- Add a pure package-manager guidance resolver keyed by detected manager and injectable package URL, with the runtime macro confined to a small wrapper.
- Reuse the resolver in the non-interactive update command, `/update`, and the passive update notification.
- Preserve package-manager version checks while falling back to safe manager-specific guidance when no authoritative command exists.

## Tests
- Cover upstream, OpenClaude, custom-package, and unknown-manager resolution.
- Verify CLI output and rendered slash/passive surfaces, including forbidden upstream identifiers for OpenClaude builds.
- Passed `bun run check`, focused update tests, `bun run typecheck`, `bun run build`, and `bun run security:pr-scan`.

## Risk
- Limited to user-facing update guidance for package-manager installations; package-manager detection and npm/native routing are unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added consistent package-manager update guidance across the command-line and in-app update screens.
  * Shows manager-specific “managed by” messaging and an update command when available, with a single shared guidance source for all surfaces.
* **Bug Fixes**
  * Prevented incorrect or unrelated package-manager commands from appearing in update guidance.
  * Preserved the correct upstream update command for official package installations; falls back to safe generic guidance for custom/unsupported sources.
* **Tests**
  * Expanded test coverage for guidance generation and UI rendering across multiple package managers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->